### PR TITLE
Switch aarch64-darwin codegen to JITLink (ObjectLinkingLayer) and small code model

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -139,9 +139,6 @@ extern void _chkstk(void);
 #endif
 }
 
-// llvm state
-extern JITEventListener *CreateJuliaJITEventListener();
-
 // for image reloading
 bool imaging_mode = false;
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8100,7 +8100,12 @@ extern "C" void jl_init_llvm(void)
     }
     // Allocate a target...
     Optional<CodeModel::Model> codemodel =
-#ifdef _P64
+#if defined(JL_USE_JITLINK)
+        // JITLink can patch up relocations between far objects so we can use the
+        // small code model – which is good, as the large code model is unmaintained
+        // on MachO/AArch64.
+        CodeModel::Small;
+#elif defined(_P64)
         // Make sure we are using the large code model on 64bit
         // Let LLVM pick a default suitable for jitting on 32bit
         CodeModel::Large;
@@ -8142,13 +8147,15 @@ extern "C" void jl_init_llvm(void)
     }
 #endif
     if (jl_using_gdb_jitevents)
-        jl_ExecutionEngine->RegisterJITEventListener(JITEventListener::createGDBRegistrationListener());
+        jl_ExecutionEngine->enableJITDebuggingSupport();
 
 #if defined(JL_USE_INTEL_JITEVENTS) || \
     defined(JL_USE_OPROFILE_JITEVENTS) || \
     defined(JL_USE_PERF_JITEVENTS)
+#ifdef JL_USE_JITLINK
+#error "JIT profiling support (JL_USE_*_JITEVENTS) not yet available on platforms that use JITLink"
+#else
     const char *jit_profiling = getenv("ENABLE_JITPROFILING");
-#endif
 
 #if defined(JL_USE_INTEL_JITEVENTS)
     if (jit_profiling && atoi(jit_profiling)) {
@@ -8181,6 +8188,8 @@ extern "C" void jl_init_llvm(void)
 #ifdef JL_USE_PERF_JITEVENTS
     if (jl_using_perf_jitevents)
         jl_ExecutionEngine->RegisterJITEventListener(JITEventListener::createPerfJITEventListener());
+#endif
+#endif
 #endif
 
     cl::PrintOptionValues();

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -113,12 +113,6 @@ void jl_add_code_in_flight(StringRef name, jl_code_instance_t *codeinst, const D
 }
 
 
-#ifdef _OS_WINDOWS_
-#if defined(_CPU_X86_64_)
-void *lookupWriteAddressFor(RTDyldMemoryManager *memmgr, void *rt_addr);
-#endif
-#endif
-
 #if defined(_OS_WINDOWS_)
 static void create_PRUNTIME_FUNCTION(uint8_t *Code, size_t Size, StringRef fnname,
                                      uint8_t *Section, size_t Allocated, uint8_t *UnwindData)
@@ -177,7 +171,14 @@ struct revcomp {
 };
 
 
-class JuliaJITEventListener
+// Central registry for resolving function addresses to `jl_method_instance_t`s and
+// originating `ObjectFile`s (for the DWARF debug info).
+//
+// A global singleton instance is notified by the JIT whenever a new object is emitted,
+// and later queried by the various function info APIs. We also use the chance to handle
+// some platform-specific unwind info registration (which is unrelated to the query
+// functionality).
+class JITObjectRegistry
 {
     std::map<size_t, ObjectInfo, revcomp> objectmap;
     std::map<size_t, std::pair<size_t, jl_method_instance_t *>, revcomp> linfomap;
@@ -194,44 +195,16 @@ public:
         return linfo;
     }
 
-    void NotifyObjectEmitted(const object::ObjectFile &Object,
-                             const RuntimeDyld::LoadedObjectInfo &L,
-                             RTDyldMemoryManager *memmgr)
+    void registerJITObject(const object::ObjectFile &Object,
+                           std::function<uint64_t(const StringRef &)> getLoadAddress,
+                           std::function<void*(void*)> lookupWriteAddress)
     {
         jl_ptls_t ptls = jl_current_task->ptls;
         // This function modify codeinst->fptr in GC safe region.
         // This should be fine since the GC won't scan this field.
         int8_t gc_state = jl_gc_safe_enter(ptls);
 
-        auto SavedObject = L.getObjectForDebug(Object).takeBinary();
-        // If the debug object is unavailable, save (a copy of) the original object
-        // for our backtraces.
-        // This copy seems unfortunate, but there doesn't seem to be a way to take
-        // ownership of the original buffer.
-        if (!SavedObject.first) {
-            auto NewBuffer = MemoryBuffer::getMemBufferCopy(
-                    Object.getData(), Object.getFileName());
-            auto NewObj = cantFail(object::ObjectFile::createObjectFile(NewBuffer->getMemBufferRef()));
-            SavedObject = std::make_pair(std::move(NewObj), std::move(NewBuffer));
-        }
-        const object::ObjectFile &debugObj = *SavedObject.first.release();
-        SavedObject.second.release();
-
-        object::section_iterator EndSection = debugObj.section_end();
-        StringMap<object::SectionRef> loadedSections;
-        for (const object::SectionRef &lSection: Object.sections()) {
-            auto sName = lSection.getName();
-            if (sName) {
-                bool inserted = loadedSections.insert(std::make_pair(*sName, lSection)).second;
-                assert(inserted); (void)inserted;
-            }
-        }
-        auto getLoadAddress = [&] (const StringRef &sName) -> uint64_t {
-            auto search = loadedSections.find(sName);
-            if (search == loadedSections.end())
-                return 0;
-            return L.getSectionLoadAddress(search->second);
-        };
+        object::section_iterator EndSection = Object.section_end();
 
 #ifdef _CPU_ARM_
         // ARM does not have/use .eh_frame
@@ -290,7 +263,7 @@ public:
         uint8_t *UnwindData = NULL;
 #if defined(_CPU_X86_64_)
         uint8_t *catchjmp = NULL;
-        for (const object::SymbolRef &sym_iter : debugObj.symbols()) {
+        for (const object::SymbolRef &sym_iter : Object.symbols()) {
             StringRef sName = cantFail(sym_iter.getName());
             uint8_t **pAddr = NULL;
             if (sName.equals("__UnwindData")) {
@@ -313,9 +286,8 @@ public:
                 SectionAddrCheck = SectionAddr;
                 SectionLoadCheck = SectionLoadAddr;
                 SectionWriteCheck = SectionLoadAddr;
-                if (memmgr)
-                    SectionWriteCheck = (uintptr_t)lookupWriteAddressFor(memmgr,
-                            (void*)SectionLoadAddr);
+                if (lookupWriteAddress)
+                    SectionWriteCheck = (uintptr_t)lookupWriteAddress((void*)SectionLoadAddr);
                 Addr += SectionWriteCheck - SectionLoadAddr;
                 *pAddr = (uint8_t*)Addr;
             }
@@ -343,7 +315,7 @@ public:
 #endif // defined(_OS_X86_64_)
 #endif // defined(_OS_WINDOWS_)
 
-        auto symbols = object::computeSymbolSizes(debugObj);
+        auto symbols = object::computeSymbolSizes(Object);
         bool first = true;
         for (const auto &sym_size : symbols) {
             const object::SymbolRef &sym_iter = sym_size.first;
@@ -380,7 +352,7 @@ public:
                 if (codeinst)
                     linfomap[Addr] = std::make_pair(Size, codeinst->def);
                 if (first) {
-                    ObjectInfo tmp = {&debugObj,
+                    ObjectInfo tmp = {&Object,
                         (size_t)SectionSize,
                         (ptrdiff_t)(SectionAddr - SectionLoadAddr),
                         *Section,
@@ -394,22 +366,18 @@ public:
         jl_gc_safe_leave(ptls, gc_state);
     }
 
-    // must implement if we ever start freeing code
-    // virtual void NotifyFreeingObject(const ObjectImage &Object) {}
-    // virtual void NotifyFreeingObject(const object::ObjectFile &Obj) {}
-
     std::map<size_t, ObjectInfo, revcomp>& getObjectMap() JL_NOTSAFEPOINT
     {
         return objectmap;
     }
 };
 
-static JuliaJITEventListener jl_jit_events;
-JL_DLLEXPORT void ORCNotifyObjectEmitted(const object::ObjectFile &Object,
-                                         const RuntimeDyld::LoadedObjectInfo &L,
-                                         RTDyldMemoryManager *memmgr)
+static JITObjectRegistry jl_jit_object_registry;
+void jl_register_jit_object(const object::ObjectFile &Object,
+                            std::function<uint64_t(const StringRef &)> getLoadAddress,
+                            std::function<void *(void *)> lookupWriteAddress)
 {
-    jl_jit_events.NotifyObjectEmitted(Object, L, memmgr);
+    jl_jit_object_registry.registerJITObject(Object, getLoadAddress, lookupWriteAddress);
 }
 
 // TODO: convert the safe names from aotcomile.cpp:makeSafeName back into symbols
@@ -1178,7 +1146,7 @@ int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, int64_t *slide,
 {
     int found = 0;
     uv_rwlock_wrlock(&threadsafe);
-    std::map<size_t, ObjectInfo, revcomp> &objmap = jl_jit_events.getObjectMap();
+    std::map<size_t, ObjectInfo, revcomp> &objmap = jl_jit_object_registry.getObjectMap();
     std::map<size_t, ObjectInfo, revcomp>::iterator fit = objmap.lower_bound(fptr);
 
     if (symsize)
@@ -1212,7 +1180,7 @@ extern "C" JL_DLLEXPORT int jl_getFunctionInfo_impl(jl_frame_t **frames_out, siz
     int64_t slide;
     uint64_t symsize;
     if (jl_DI_for_fptr(pointer, &symsize, &slide, &Section, &context)) {
-        frames[0].linfo = jl_jit_events.lookupLinfo(pointer);
+        frames[0].linfo = jl_jit_object_registry.lookupLinfo(pointer);
         int nf = lookup_pointer(Section, context, frames_out, pointer, slide, true, noInline);
         return nf;
     }
@@ -1221,7 +1189,7 @@ extern "C" JL_DLLEXPORT int jl_getFunctionInfo_impl(jl_frame_t **frames_out, siz
 
 extern "C" jl_method_instance_t *jl_gdblookuplinfo(void *p) JL_NOTSAFEPOINT
 {
-    return jl_jit_events.lookupLinfo((size_t)p);
+    return jl_jit_object_registry.lookupLinfo((size_t)p);
 }
 
 #if (defined(_OS_LINUX_) || defined(_OS_FREEBSD_) || (defined(_OS_DARWIN_) && defined(LLVM_SHLIB)))
@@ -1643,7 +1611,7 @@ uint64_t jl_getUnwindInfo_impl(uint64_t dwAddr)
 {
     // Might be called from unmanaged thread
     uv_rwlock_rdlock(&threadsafe);
-    std::map<size_t, ObjectInfo, revcomp> &objmap = jl_jit_events.getObjectMap();
+    std::map<size_t, ObjectInfo, revcomp> &objmap = jl_jit_object_registry.getObjectMap();
     std::map<size_t, ObjectInfo, revcomp>::iterator it = objmap.lower_bound(dwAddr);
     uint64_t ipstart = 0; // ip of the start of the section (if found)
     if (it != objmap.end() && dwAddr < it->first + it->second.SectionSize) {

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -3,7 +3,6 @@
 #include "platform.h"
 
 #include "llvm-version.h"
-#include <llvm/ExecutionEngine/ExecutionEngine.h>
 #include <llvm/DebugInfo/DIContext.h>
 #include <llvm/DebugInfo/DWARF/DWARFContext.h>
 #include <llvm/Object/SymbolSize.h>
@@ -14,6 +13,7 @@
 #include <llvm/IR/DebugInfo.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/Mangler.h>
+#include <llvm/ExecutionEngine/RTDyldMemoryManager.h>
 #include <llvm/ExecutionEngine/RuntimeDyld.h>
 #include <llvm/BinaryFormat/Magic.h>
 #include <llvm/Object/MachO.h>

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -64,7 +64,6 @@
 #include <llvm/BinaryFormat/MachO.h>
 #include <llvm/DebugInfo/DIContext.h>
 #include <llvm/DebugInfo/DWARF/DWARFContext.h>
-#include <llvm/ExecutionEngine/JITEventListener.h>
 #include <llvm/IR/AssemblyAnnotationWriter.h>
 #include <llvm/IR/DebugInfo.h>
 #include <llvm/IR/Function.h>

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -477,11 +477,7 @@ public:
 };
 
 
-// Custom object emission notification handler for the JuliaOJIT
-extern JITEventListener *CreateJuliaJITEventListener();
-
-JL_DLLEXPORT void ORCNotifyObjectEmitted(JITEventListener *Listener,
-                                         const object::ObjectFile &obj,
+JL_DLLEXPORT void ORCNotifyObjectEmitted(const object::ObjectFile &obj,
                                          const RuntimeDyld::LoadedObjectInfo &L,
                                          RTDyldMemoryManager *memmgr);
 
@@ -489,7 +485,7 @@ template <typename ObjT, typename LoadResult>
 void JuliaOJIT::registerObject(const ObjT &Obj, const LoadResult &LO)
 {
     const ObjT* Object = &Obj;
-    ORCNotifyObjectEmitted(JuliaListener.get(), *Object, *LO, MemMgr.get());
+    ORCNotifyObjectEmitted(*Object, *LO, MemMgr.get());
 }
 
 CodeGenOpt::Level CodeGenOptLevelFor(int optlevel)
@@ -612,7 +608,6 @@ JuliaOJIT::JuliaOJIT(TargetMachine &TM, LLVMContext *LLVMCtx)
     DL(TM.createDataLayout()),
     ObjStream(ObjBufferSV),
     MemMgr(createRTDyldMemoryManager()),
-    JuliaListener(CreateJuliaJITEventListener()),
     TSCtx(std::unique_ptr<LLVMContext>(LLVMCtx)),
 #if JL_LLVM_VERSION >= 130000
     ES(cantFail(orc::SelfExecutorProcessControl::Create())),

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -3,7 +3,6 @@
 #include "llvm-version.h"
 #include "platform.h"
 
-
 #include "llvm/IR/Mangler.h"
 #include <llvm/ADT/StringMap.h>
 #include <llvm/Analysis/TargetLibraryInfo.h>
@@ -34,7 +33,17 @@ using namespace llvm;
 #include "jitlayers.h"
 #include "julia_assert.h"
 
-RTDyldMemoryManager* createRTDyldMemoryManager(void);
+#ifdef JL_USE_JITLINK
+# if JL_LLVM_VERSION >= 140000
+#  include <llvm/ExecutionEngine/Orc/DebuggerSupportPlugin.h>
+# endif
+# include <llvm/ExecutionEngine/JITLink/EHFrameSupport.h>
+# include <llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h>
+#else
+# include <llvm/ExecutionEngine/SectionMemoryManager.h>
+#endif
+
+#define DEBUG_TYPE "jitlayers"
 
 void jl_init_jit(void) { }
 
@@ -431,63 +440,6 @@ jl_value_t *jl_dump_method_asm_impl(jl_method_instance_t *mi, size_t world,
     return jl_dump_function_asm(F, raw_mc, asm_variant, debuginfo, binary);
 }
 
-// A simple forwarding class, since OrcJIT v2 needs a unique_ptr, while we have a shared_ptr
-class ForwardingMemoryManager : public RuntimeDyld::MemoryManager {
-private:
-    std::shared_ptr<RuntimeDyld::MemoryManager> MemMgr;
-
-public:
-    ForwardingMemoryManager(std::shared_ptr<RuntimeDyld::MemoryManager> MemMgr) : MemMgr(MemMgr) {}
-    virtual ~ForwardingMemoryManager() = default;
-    virtual uint8_t *allocateCodeSection(uintptr_t Size, unsigned Alignment,
-                                     unsigned SectionID,
-                                     StringRef SectionName) override {
-        return MemMgr->allocateCodeSection(Size, Alignment, SectionID, SectionName);
-    }
-    virtual uint8_t *allocateDataSection(uintptr_t Size, unsigned Alignment,
-                                     unsigned SectionID,
-                                     StringRef SectionName,
-                                     bool IsReadOnly) override {
-        return MemMgr->allocateDataSection(Size, Alignment, SectionID, SectionName, IsReadOnly);
-    }
-    virtual void reserveAllocationSpace(uintptr_t CodeSize, uint32_t CodeAlign,
-                                        uintptr_t RODataSize,
-                                        uint32_t RODataAlign,
-                                        uintptr_t RWDataSize,
-                                        uint32_t RWDataAlign) override {
-        return MemMgr->reserveAllocationSpace(CodeSize, CodeAlign, RODataSize, RODataAlign, RWDataSize, RWDataAlign);
-    }
-    virtual bool needsToReserveAllocationSpace() override {
-        return MemMgr->needsToReserveAllocationSpace();
-    }
-    virtual void registerEHFrames(uint8_t *Addr, uint64_t LoadAddr,
-                                  size_t Size) override {
-        return MemMgr->registerEHFrames(Addr, LoadAddr, Size);
-    }
-    virtual void deregisterEHFrames() override {
-        return MemMgr->deregisterEHFrames();
-    }
-    virtual bool finalizeMemory(std::string *ErrMsg = nullptr) override {
-        return MemMgr->finalizeMemory(ErrMsg);
-    }
-    virtual void notifyObjectLoaded(RuntimeDyld &RTDyld,
-                                    const object::ObjectFile &Obj) override {
-        return MemMgr->notifyObjectLoaded(RTDyld, Obj);
-    }
-};
-
-
-JL_DLLEXPORT void ORCNotifyObjectEmitted(const object::ObjectFile &obj,
-                                         const RuntimeDyld::LoadedObjectInfo &L,
-                                         RTDyldMemoryManager *memmgr);
-
-template <typename ObjT, typename LoadResult>
-void JuliaOJIT::registerObject(const ObjT &Obj, const LoadResult &LO)
-{
-    const ObjT* Object = &Obj;
-    ORCNotifyObjectEmitted(*Object, *LO, MemMgr.get());
-}
-
 CodeGenOpt::Level CodeGenOptLevelFor(int optlevel)
 {
 #ifdef DISABLE_OPT
@@ -603,11 +555,257 @@ CompilerResultT JuliaOJIT::CompilerT::operator()(Module &M)
     return CompilerResultT(std::move(ObjBuffer));
 }
 
+void jl_register_jit_object(const object::ObjectFile &debugObj,
+                            std::function<uint64_t(const StringRef &)> getLoadAddress,
+                            std::function<void *(void *)> lookupWriteAddress);
+
+#ifdef JL_USE_JITLINK
+
+namespace {
+
+using namespace llvm::orc;
+
+struct JITObjectInfo {
+    std::unique_ptr<MemoryBuffer> BackingBuffer;
+    std::unique_ptr<object::ObjectFile> Object;
+    StringMap<uint64_t> SectionLoadAddresses;
+};
+
+class JLDebuginfoPlugin : public ObjectLinkingLayer::Plugin {
+    std::map<MaterializationResponsibility *, std::unique_ptr<JITObjectInfo>> PendingObjs;
+    // Resources from distinct MaterializationResponsibilitys can get merged
+    // after emission, so we can have multiple debug objects per resource key.
+    std::map<ResourceKey, std::vector<std::unique_ptr<JITObjectInfo>>> RegisteredObjs;
+
+public:
+    void notifyMaterializing(MaterializationResponsibility &MR, jitlink::LinkGraph &G,
+                             jitlink::JITLinkContext &Ctx,
+                             MemoryBufferRef InputObject) override
+    {
+        // Keeping around a full copy of the input object file (and re-parsing it) is
+        // wasteful, but for now, this lets us reuse the existing debuginfo.cpp code.
+        // Should look into just directly pulling out all the information required in
+        // a JITLink pass and just keeping the required tables/DWARF sections around
+        // (perhaps using the LLVM DebuggerSupportPlugin as a reference).
+        auto NewBuffer =
+            MemoryBuffer::getMemBufferCopy(InputObject.getBuffer(), G.getName());
+        auto NewObj =
+            cantFail(object::ObjectFile::createObjectFile(NewBuffer->getMemBufferRef()));
+
+        assert(PendingObjs.count(&MR) == 0);
+        PendingObjs[&MR] = std::unique_ptr<JITObjectInfo>(
+            new JITObjectInfo{std::move(NewBuffer), std::move(NewObj), {}});
+    }
+
+    Error notifyEmitted(MaterializationResponsibility &MR) override
+    {
+        auto It = PendingObjs.find(&MR);
+        if (It == PendingObjs.end())
+            return Error::success();
+
+        auto NewInfo = PendingObjs[&MR].get();
+        auto getLoadAddress = [NewInfo](const StringRef &Name) -> uint64_t {
+            auto result = NewInfo->SectionLoadAddresses.find(Name);
+            if (result == NewInfo->SectionLoadAddresses.end()) {
+                LLVM_DEBUG({
+                    dbgs() << "JLDebuginfoPlugin: No load address found for section '"
+                           << Name << "'\n";
+                });
+                return 0;
+            }
+            return result->second;
+        };
+
+        jl_register_jit_object(*NewInfo->Object, getLoadAddress, nullptr);
+
+        cantFail(MR.withResourceKeyDo([&](ResourceKey K) {
+            RegisteredObjs[K].push_back(std::move(PendingObjs[&MR]));
+            PendingObjs.erase(&MR);
+        }));
+
+        return Error::success();
+    }
+
+    Error notifyFailed(MaterializationResponsibility &MR) override
+    {
+        PendingObjs.erase(&MR);
+        return Error::success();
+    }
+
+    Error notifyRemovingResources(ResourceKey K) override
+    {
+        RegisteredObjs.erase(K);
+        // TODO: If we ever unload code, need to notify debuginfo registry.
+        return Error::success();
+    }
+
+    void notifyTransferringResources(ResourceKey DstKey, ResourceKey SrcKey) override
+    {
+        auto SrcIt = RegisteredObjs.find(SrcKey);
+        if (SrcIt != RegisteredObjs.end()) {
+            for (std::unique_ptr<JITObjectInfo> &Info : SrcIt->second)
+                RegisteredObjs[DstKey].push_back(std::move(Info));
+            RegisteredObjs.erase(SrcIt);
+        }
+    }
+
+    void modifyPassConfig(MaterializationResponsibility &MR, jitlink::LinkGraph &,
+                          jitlink::PassConfiguration &PassConfig) override
+    {
+        auto It = PendingObjs.find(&MR);
+        if (It == PendingObjs.end())
+            return;
+
+        JITObjectInfo &Info = *It->second;
+        PassConfig.PostAllocationPasses.push_back([&Info](jitlink::LinkGraph &G) -> Error {
+            for (const jitlink::Section &Sec : G.sections()) {
+                // Canonical JITLink section names have the segment name included, e.g.
+                // "__TEXT,__text" or "__DWARF,__debug_str". There are some special internal
+                // sections without a comma separator, which we can just ignore.
+                size_t SepPos = Sec.getName().find(',');
+                if (SepPos >= 16 || (Sec.getName().size() - (SepPos + 1) > 16)) {
+                    LLVM_DEBUG({
+                        dbgs() << "JLDebuginfoPlugin: Ignoring section '" << Sec.getName()
+                               << "'\n";
+                    });
+                    continue;
+                }
+                auto SecName = Sec.getName().substr(SepPos + 1);
+                Info.SectionLoadAddresses[SecName] = jitlink::SectionRange(Sec).getStart();
+            }
+            return Error::success();
+        });
+    }
+};
+}
+
+# ifdef LLVM_SHLIB
+class JLEHFrameRegistrar final : public jitlink::EHFrameRegistrar {
+public:
+    Error registerEHFrames(JITTargetAddress EHFrameSectionAddr,
+                         size_t EHFrameSectionSize) override {
+        register_eh_frames(
+            jitTargetAddressToPointer<uint8_t *>(EHFrameSectionAddr),
+            EHFrameSectionSize);
+        return Error::success();
+    }
+
+    Error deregisterEHFrames(JITTargetAddress EHFrameSectionAddr,
+                           size_t EHFrameSectionSize) override {
+        deregister_eh_frames(
+            jitTargetAddressToPointer<uint8_t *>(EHFrameSectionAddr),
+            EHFrameSectionSize);
+        return Error::success();
+    }
+};
+# endif
+
+#else // !JL_USE_JITLINK
+
+RTDyldMemoryManager* createRTDyldMemoryManager(void);
+
+// A simple forwarding class, since OrcJIT v2 needs a unique_ptr, while we have a shared_ptr
+class ForwardingMemoryManager : public RuntimeDyld::MemoryManager {
+private:
+    std::shared_ptr<RuntimeDyld::MemoryManager> MemMgr;
+
+public:
+    ForwardingMemoryManager(std::shared_ptr<RuntimeDyld::MemoryManager> MemMgr) : MemMgr(MemMgr) {}
+    virtual ~ForwardingMemoryManager() = default;
+    virtual uint8_t *allocateCodeSection(uintptr_t Size, unsigned Alignment,
+                                     unsigned SectionID,
+                                     StringRef SectionName) override {
+        return MemMgr->allocateCodeSection(Size, Alignment, SectionID, SectionName);
+    }
+    virtual uint8_t *allocateDataSection(uintptr_t Size, unsigned Alignment,
+                                     unsigned SectionID,
+                                     StringRef SectionName,
+                                     bool IsReadOnly) override {
+        return MemMgr->allocateDataSection(Size, Alignment, SectionID, SectionName, IsReadOnly);
+    }
+    virtual void reserveAllocationSpace(uintptr_t CodeSize, uint32_t CodeAlign,
+                                        uintptr_t RODataSize,
+                                        uint32_t RODataAlign,
+                                        uintptr_t RWDataSize,
+                                        uint32_t RWDataAlign) override {
+        return MemMgr->reserveAllocationSpace(CodeSize, CodeAlign, RODataSize, RODataAlign, RWDataSize, RWDataAlign);
+    }
+    virtual bool needsToReserveAllocationSpace() override {
+        return MemMgr->needsToReserveAllocationSpace();
+    }
+    virtual void registerEHFrames(uint8_t *Addr, uint64_t LoadAddr,
+                                  size_t Size) override {
+        return MemMgr->registerEHFrames(Addr, LoadAddr, Size);
+    }
+    virtual void deregisterEHFrames() override {
+        return MemMgr->deregisterEHFrames();
+    }
+    virtual bool finalizeMemory(std::string *ErrMsg = nullptr) override {
+        return MemMgr->finalizeMemory(ErrMsg);
+    }
+    virtual void notifyObjectLoaded(RuntimeDyld &RTDyld,
+                                    const object::ObjectFile &Obj) override {
+        return MemMgr->notifyObjectLoaded(RTDyld, Obj);
+    }
+};
+
+
+#if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
+void *lookupWriteAddressFor(RTDyldMemoryManager *MemMgr, void *rt_addr);
+#endif
+
+void registerRTDyldJITObject(const object::ObjectFile &Object,
+                             const RuntimeDyld::LoadedObjectInfo &L,
+                             const std::shared_ptr<RTDyldMemoryManager> &MemMgr)
+{
+    auto SavedObject = L.getObjectForDebug(Object).takeBinary();
+    // If the debug object is unavailable, save (a copy of) the original object
+    // for our backtraces.
+    // This copy seems unfortunate, but there doesn't seem to be a way to take
+    // ownership of the original buffer.
+    if (!SavedObject.first) {
+        auto NewBuffer =
+            MemoryBuffer::getMemBufferCopy(Object.getData(), Object.getFileName());
+        auto NewObj =
+            cantFail(object::ObjectFile::createObjectFile(NewBuffer->getMemBufferRef()));
+        SavedObject = std::make_pair(std::move(NewObj), std::move(NewBuffer));
+    }
+    const object::ObjectFile *DebugObj = SavedObject.first.release();
+    SavedObject.second.release();
+
+    StringMap<object::SectionRef> loadedSections;
+    // Use the original Object, not the DebugObject, as this is used for the
+    // RuntimeDyld::LoadedObjectInfo lookup.
+    for (const object::SectionRef &lSection : Object.sections()) {
+        auto sName = lSection.getName();
+        if (sName) {
+            bool inserted = loadedSections.insert(std::make_pair(*sName, lSection)).second;
+            assert(inserted);
+            (void)inserted;
+        }
+    }
+    auto getLoadAddress = [loadedSections = std::move(loadedSections),
+                           &L](const StringRef &sName) -> uint64_t {
+        auto search = loadedSections.find(sName);
+        if (search == loadedSections.end())
+            return 0;
+        return L.getSectionLoadAddress(search->second);
+    };
+
+    jl_register_jit_object(*DebugObj, getLoadAddress,
+#if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
+        [MemMgr](void *p) { return lookupWriteAddressFor(MemMgr.get(), p); }
+#else
+        nullptr
+#endif
+    );
+}
+#endif
+
 JuliaOJIT::JuliaOJIT(TargetMachine &TM, LLVMContext *LLVMCtx)
   : TM(TM),
     DL(TM.createDataLayout()),
     ObjStream(ObjBufferSV),
-    MemMgr(createRTDyldMemoryManager()),
     TSCtx(std::unique_ptr<LLVMContext>(LLVMCtx)),
 #if JL_LLVM_VERSION >= 130000
     ES(cantFail(orc::SelfExecutorProcessControl::Create())),
@@ -616,6 +814,16 @@ JuliaOJIT::JuliaOJIT(TargetMachine &TM, LLVMContext *LLVMCtx)
 #endif
     GlobalJD(ES.createBareJITDylib("JuliaGlobals")),
     JD(ES.createBareJITDylib("JuliaOJIT")),
+#ifdef JL_USE_JITLINK
+    // TODO: Port our memory management optimisations to JITLink instead of using the
+    // default InProcessMemoryManager.
+# if JL_LLVM_VERSION < 140000
+    ObjectLayer(ES, std::make_unique<jitlink::InProcessMemoryManager>()),
+# else
+    ObjectLayer(ES, cantFail(jitlink::InProcessMemoryManager::Create())),
+# endif
+#else
+    MemMgr(createRTDyldMemoryManager()),
     ObjectLayer(
             ES,
             [this]() {
@@ -623,14 +831,29 @@ JuliaOJIT::JuliaOJIT(TargetMachine &TM, LLVMContext *LLVMCtx)
                 return result;
             }
         ),
+#endif
     CompileLayer(ES, ObjectLayer, std::make_unique<CompilerT>(this))
 {
+#ifdef JL_USE_JITLINK
+# if defined(_OS_DARWIN_) && defined(LLVM_SHLIB)
+    // When dynamically linking against LLVM, use our custom EH frame registration code
+    // also used with RTDyld to inform both our and the libc copy of libunwind.
+    auto ehRegistrar = std::make_unique<JLEHFrameRegistrar>();
+# else
+    auto ehRegistrar = std::make_unique<jitlink::InProcessEHFrameRegistrar>();
+# endif
+    ObjectLayer.addPlugin(std::make_unique<EHFrameRegistrationPlugin>(
+        ES, std::move(ehRegistrar)));
+
+    ObjectLayer.addPlugin(std::make_unique<JLDebuginfoPlugin>());
+#else
     ObjectLayer.setNotifyLoaded(
         [this](orc::MaterializationResponsibility &MR,
                const object::ObjectFile &Object,
-               const RuntimeDyld::LoadedObjectInfo &LOS) {
-            registerObject(Object, &LOS);
+               const RuntimeDyld::LoadedObjectInfo &LO) {
+            registerRTDyldJITObject(Object, LO, MemMgr);
         });
+#endif
     for (int i = 0; i < 4; i++) {
         TMs[i] = TM.getTarget().createTargetMachine(TM.getTargetTriple().getTriple(), TM.getTargetCPU(),
                 TM.getTargetFeatureString(), TM.Options, Reloc::Static, TM.getCodeModel(),
@@ -694,8 +917,8 @@ void JuliaOJIT::addModule(std::unique_ptr<Module> M)
             NewExports.push_back(getMangledName(F.getName()));
         }
     }
-#ifndef JL_NDEBUG
-    // validate the relocations for M
+#if !defined(JL_NDEBUG) && !defined(JL_USE_JITLINK)
+    // validate the relocations for M (not implemented for the JITLink memory manager yet)
     for (Module::global_object_iterator I = M->global_objects().begin(), E = M->global_objects().end(); I != E; ) {
         GlobalObject *F = &*I;
         ++I;
@@ -788,12 +1011,38 @@ StringRef JuliaOJIT::getFunctionAtAddress(uint64_t Addr, jl_code_instance_t *cod
 }
 
 
+#ifdef JL_USE_JITLINK
+# if JL_LLVM_VERSION < 140000
+#  warning "JIT debugging (GDB integration) not available on LLVM < 14.0 (for JITLink)"
+void JuliaOJIT::enableJITDebuggingSupport() {}
+# else
+extern "C" orc::shared::CWrapperFunctionResult
+llvm_orc_registerJITLoaderGDBAllocAction(const char *Data, size_t Size);
+
+void JuliaOJIT::enableJITDebuggingSupport()
+{
+    // We do not use GDBJITDebugInfoRegistrationPlugin::Create, as the runtime name
+    // lookup is unnecessarily involved/fragile for our in-process JIT use case
+    // (with the llvm_orc_registerJITLoaderGDBAllocAction symbol being in either
+    // libjulia-codegen or yet another shared library for LLVM depending on the build
+    // flags, etc.).
+    const auto Addr = ExecutorAddr::fromPtr(&llvm_orc_registerJITLoaderGDBAllocAction);
+    ObjectLayer.addPlugin(std::make_unique<orc::GDBJITDebugInfoRegistrationPlugin>(Addr));
+}
+# endif
+#else
+void JuliaOJIT::enableJITDebuggingSupport()
+{
+    RegisterJITEventListener(JITEventListener::createGDBRegistrationListener());
+}
+
 void JuliaOJIT::RegisterJITEventListener(JITEventListener *L)
 {
     if (!L)
         return;
     this->ObjectLayer.registerJITEventListener(*L);
 }
+#endif
 
 const DataLayout& JuliaOJIT::getDataLayout() const
 {
@@ -817,12 +1066,20 @@ std::string JuliaOJIT::getMangledName(const GlobalValue *GV)
     return getMangledName(GV->getName());
 }
 
+#ifdef JL_USE_JITLINK
+size_t JuliaOJIT::getTotalBytes() const
+{
+    // TODO: Implement in future custom JITLink memory manager.
+    return 0;
+}
+#else
 size_t getRTDyldMemoryManagerTotalBytes(RTDyldMemoryManager *mm);
 
 size_t JuliaOJIT::getTotalBytes() const
 {
     return getRTDyldMemoryManagerTotalBytes(MemMgr.get());
 }
+#endif
 
 JuliaOJIT *jl_ExecutionEngine;
 

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -194,7 +194,6 @@ private:
     TargetMachine *TMs[4];
     MCContext *Ctx;
     std::shared_ptr<RTDyldMemoryManager> MemMgr;
-    std::unique_ptr<JITEventListener> JuliaListener;
 
 
     orc::ThreadSafeContext TSCtx;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -6,10 +6,10 @@
 #include <llvm/IR/Value.h>
 #include "llvm/IR/LegacyPassManager.h"
 
-#include <llvm/ExecutionEngine/SectionMemoryManager.h>
 #include <llvm/ExecutionEngine/Orc/IRCompileLayer.h>
 #include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>
 #include <llvm/ExecutionEngine/JITEventListener.h>
+#include <llvm/ExecutionEngine/RTDyldMemoryManager.h>
 
 #include <llvm/Target/TargetMachine.h>
 #include "julia_assert.h"


### PR DESCRIPTION
This fixes #41440, #43285 and similar runtime crashes, which stem from `CodeModel::Large` not being correctly implemented on MachO/ARM64.

With it, the only testsuite failures remaining on my M1 Max machine are occasional thread.jl hangs, which appear to be the same as https://github.com/JuliaLang/julia/issues/41820.

Now that master is on LLVM 13, this should work against the default BinaryBuilder LLVM. LLVM 14 (Git main) is still preferred, as debugger integration (`ENABLE_GDBLISTENER`) is not supported on 13.x. I tested https://github.com/dnadlinger/llvm-project/commit/57eb8c10025bdbca8f8260bd43a46d0aca369fe8, which is llvm/llvm-project@1dd5e6fed5db with our 13.x patches. Our LLVM patch set (julia-releases/13.x) is absolutely required so that `__eh_frame` unwind information is generated and passed through the stack, without which backtraces silently won't work (see llvm/llvm-project#52921).

Profiler integration (`ENABLE_JITPROFILING`) is not currently supported on either version; this is an upstream LLVM restriction.

---

As pointed out in the comments, this currently doesn't use the custom Julia RTDyld memory manager, as the API has changed quite significantly. We'll probably want to port the dual-map optimisations to JITLinkMemoryManager soon, but I believe the random segfaults are much more disruptive, and thus the JITLink switch shouldn't be held up by that.