### PR TITLE
Add missing include of llvm-version.h in codegen_shared.h

### DIFF
--- a/src/codegen_shared.h
+++ b/src/codegen_shared.h
@@ -10,6 +10,7 @@
 #define STR(csym)           #csym
 #define XSTR(csym)          STR(csym)
 #include "julia.h"
+#include "llvm-version.h"
 
 enum AddressSpace {
     Generic = 0,


### PR DESCRIPTION
Without this, `JL_LLVM_VERSION` is undefined and defaults to 0, so the branch for older LLVM is always taken.