### PR TITLE
Pickup ASAN and LLVM assertion build fixes from #43418

### DIFF
--- a/cli/loader_exe.c
+++ b/cli/loader_exe.c
@@ -63,6 +63,15 @@ int main(int argc, char * argv[])
     return ret;
 }
 
+#if defined(__GLIBC__) && (defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_))
+// fork is generally bad news, but it is better if we prevent applications from
+// making it worse as openblas threadpools cause it to hang
+int __register_atfork232(void (*prepare)(void), void (*parent)(void), void (*child)(void), void *dso_handle) {
+    return 0;
+}
+__asm__ (".symver __register_atfork232, __register_atfork@@GLIBC_2.3.2");
+#endif
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -223,7 +223,7 @@ __attribute__((constructor)) void jl_load_libjulia_internal(void) {
     }
     // jl_options must be initialized very early, in case an embedder sets some
     // values there before calling jl_init
-    ((void (*)())jl_init_options_addr)();
+    ((void (*)(void))jl_init_options_addr)();
 
     for (unsigned int symbol_idx=0; codegen_func_names[symbol_idx] != NULL; ++symbol_idx) {
         void *addr = lookup_symbol(libjulia_codegen, codegen_func_names[symbol_idx]);

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -718,8 +718,7 @@ void jl_register_fptrs_impl(uint64_t sysimage_base, const jl_sysimg_fptrs_t *fpt
 template<typename T>
 static inline void ignoreError(T &err) JL_NOTSAFEPOINT
 {
-#if !defined(NDEBUG)
-    // Needed only with LLVM assertion build
+#if !defined(NDEBUG) // Needed only with LLVM assertion build
     consumeError(err.takeError());
 #endif
 }
@@ -985,7 +984,7 @@ static objfileentry_t &find_object_file(uint64_t fbase, StringRef fname) JL_NOTS
                 if (DebugInfo) {
                     errorobj = std::move(DebugInfo);
                     // Yes, we've checked, and yes LLVM want us to check again.
-                    assert(errorobj);
+                    ignoreError(errorobj);
                     debugobj = errorobj->getBinary();
                 }
                 else {


### PR DESCRIPTION
- fix compiler warning in cli
- fix LLVM_ASSERTIONS build
- sanitizers: fix support loading of libjulia-codegen
- sanitizers: disable calls to pthread_atfork

Cherry-picked from #43418
