### PR TITLE
Fix llvmpasses test

### DIFF
--- a/.buildkite/pipelines/main/misc/llvmpasses.yml
+++ b/.buildkite/pipelines/main/misc/llvmpasses.yml
@@ -26,7 +26,6 @@ steps:
     timeout_in_minutes: 60
   - label: "llvmpasses"
     key: "llvmpasses"
-    soft_fail: true # TODO: delete this line
     plugins:
       - JuliaCI/julia#v1:
           # Drop default "registries" directory, so it is not persisted from execution to execution

--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -239,11 +239,8 @@ __attribute__((constructor)) void jl_load_libjulia_internal(void) {
     }
     void *fptr = lookup_symbol(RTLD_DEFAULT, "jl_get_pgcstack_static");
     void *(*key)(void) = lookup_symbol(RTLD_DEFAULT, "jl_pgcstack_addr_static");
-    if (fptr == NULL || key == NULL) {
-        jl_loader_print_stderr("ERROR: Cannot find jl_get_pgcstack_static(), must define this symbol within calling executable!\n");
-        exit(1);
-    }
-    jl_pgcstack_setkey(fptr, key);
+    if (fptr != NULL && key != NULL)
+        jl_pgcstack_setkey(fptr, key);
 #endif
 
     // jl_options must be initialized very early, in case an embedder sets some

--- a/doc/src/devdocs/llvm.md
+++ b/doc/src/devdocs/llvm.md
@@ -79,7 +79,7 @@ environment. In addition, it exposes the `-julia` meta-pass, which runs the
 entire Julia pass-pipeline over the IR. As an example, to generate a system
 image, one could do:
 ```
-opt -enable-new-pm=0 -load libjulia-internal.so -julia -o opt.bc unopt.bc
+opt -enable-new-pm=0 -load libjulia-codegen.so -julia -o opt.bc unopt.bc
 llc -o sys.o opt.bc
 cc -shared -o sys.so sys.o
 ```

--- a/test/llvmpasses/cpu-features.ll
+++ b/test/llvmpasses/cpu-features.ll
@@ -1,4 +1,4 @@
-; RUN: opt -load libjulia-internal%shlibext -CPUFeatures -simplifycfg -S %s | FileCheck %s
+; RUN: opt -enable-new-pm=0 -load libjulia-codegen%shlibext -CPUFeatures -simplifycfg -S %s | FileCheck %s
 
 declare i1 @julia.cpu.have_fma.f64()
 declare double @with_fma(double %0, double %1, double %2)

--- a/test/llvmpasses/loopinfo.jl
+++ b/test/llvmpasses/loopinfo.jl
@@ -104,7 +104,7 @@ end
 end
 
 # FINAL-LABEL: @julia_notunroll
-function notunroll(J, I)
+@eval function notunroll(J, I)
     for i in 1:10
         for j in J
             1 <= j <= I && continue
@@ -113,6 +113,7 @@ function notunroll(J, I)
 # FINAL: call void @j_iteration
 # FINAL-NOT: call void @j_iteration
         end
+        $(Expr(:loopinfo, (Symbol("llvm.loop.unroll.disable"),)))
     end
 end
 


### PR DESCRIPTION
- Do not fail if fastpath for TLS can't be found
- Fix cpu-features.ll opt invocation
- Make notunroll test robust against loop-rotation
- Revert "CI (Buildkite): temporarily allow the `llvmpasses` job to fail (#43663)"
