### PR TITLE
[REPL] handle failure of edit call gracefully

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1202,7 +1202,12 @@ function setup_interface(
             if n <= 0 || n > length(linfos) || startswith(linfos[n][1], "REPL[")
                 @goto writeback
             end
-            InteractiveUtils.edit(linfos[n][1], linfos[n][2])
+            try
+                InteractiveUtils.edit(linfos[n][1], linfos[n][2])
+            catch ex
+                ex isa ProcessFailedException || ex isa Base.IOError || ex isa SystemError || rethrow()
+                @info "edit failed" _exception=ex
+            end
             LineEdit.refresh_line(s)
             return
             @label writeback


### PR DESCRIPTION
For example:
```julia
julia> ENV["EDITOR"] = "broken"
"broken"

julia> 1^Q┌ Info: edit failed
└   _exception = IOError: could not spawn `broken /data/vtjnash/julia1/usr/share/julia/base/special/trig.jl`: no such file or directory (ENOENT)
julia> 
```

(instead of printing a full stack-trace)