### PR TITLE
tests: fix type-error in computing duration

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,7 +207,7 @@ cd(@__DIR__) do
 
     local stdin_monitor
     all_tasks = Task[]
-    o_ts_duration = nothing
+    o_ts_duration = 0.0
     try
         # Monitor stdin and kill this task on ^C
         # but don't do this on Windows, because it may deadlock in the kernel


### PR DESCRIPTION
Regression introduced by ca11c2fc24a (when tests fail or are interrupted)