### PR TITLE
Docstring of `|>`: add parentheses around `->` func

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -952,7 +952,7 @@ Applies a function to the preceding argument. This allows for easy function chai
 
 # Examples
 ```jldoctest
-julia> [1:5;] |> x->x.^2 |> sum |> inv
+julia> [1:5;] |> (x->x.^2) |> sum |> inv
 0.01818181818181818
 ```
 """


### PR DESCRIPTION
This clarifies the current behaviour where the subsequent pipes get parsed as part of the anonymous function's body if there are no parentheses.

The current line
```
[1:5;] |> x->x.^2 |> sum |> inv
```
is parsed as
```
[1:5;] |> x -> (x.^2 |> sum |> inv)
```
but it feels like the author meant (and readers would expect)
```
[1:5;] |> (x->x.^2) |> sum |> inv
```

This PR makes this explicit.

See also #38761 and #43661.