### PR TITLE
Cleanup `copy_oftype`-like functions in factorizations

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -366,11 +366,11 @@ In general, the type of the output corresponds to that of `similar(A, T)`.
 
 There are three often used methods in LinearAlgebra to create a mutable copy
 of an array with a given eltype. These copies can be passed to in-place
-algorithms (such as ldiv!, rdiv!, lu! and so on). Which one to use in practice
+algorithms (such as `ldiv!`, `rdiv!`, `lu!` and so on). Which one to use in practice
 depends on what is known (or assumed) about the structure of the array in that
 algorithm.
 
-See also: `copy_similar`, `copy_to_array`.
+See also: `copy_similar`.
 """
 copy_oftype(A::AbstractArray, ::Type{T}) where {T} = copyto!(similar(A, T), A)
 
@@ -380,24 +380,11 @@ copy_oftype(A::AbstractArray, ::Type{T}) where {T} = copyto!(similar(A, T), A)
 Copy `A` to a mutable array with eltype `T` based on `similar(A, T, size(A))`.
 
 Compared to `copy_oftype`, the result can be more flexible. In general, the type
-of the output corresponds to that of the three-argument method `similar(A, T, size(s))`.
+of the output corresponds to that of the three-argument method `similar(A, T, size(A))`.
 
-See also: `copy_oftype`, `copy_to_array`.
+See also: `copy_oftype`.
 """
 copy_similar(A::AbstractArray, ::Type{T}) where {T} = copyto!(similar(A, T, size(A)), A)
-
-"""
-    copy_to_array(A, T)
-
-Copy `A` to a regular dense `Array` with element type `T`.
-
-The resulting array is mutable. It can be used, for example, to pass the data of
-`A` to an efficient in-place method for a matrix factorization such as `lu!`, in
-cases where a more specific implementation of `lu!` (or `lu`) is not available.
-
-See also: `copy_oftype`, `copy_similar`.
-"""
-copy_to_array(A::AbstractArray, ::Type{T}) where {T} = copyto!(Array{T}(undef, size(A)...), A)
 
 # The three copy functions above return mutable arrays with eltype T.
 # To only ensure a certain eltype, and if a mutable copy is not needed, it is

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -71,7 +71,7 @@ end
 
 #To allow Bidiagonal's where the "dv" is Vector{T} and "ev" Vector{S},
 #where T and S can be promoted
-function LinearAlgebra.Bidiagonal(dv::Vector{T}, ev::Vector{S}, uplo::Symbol) where {T,S}
+function Bidiagonal(dv::Vector{T}, ev::Vector{S}, uplo::Symbol) where {T,S}
     TS = promote_type(T,S)
     return Bidiagonal{TS,Vector{TS}}(dv, ev, uplo)
 end

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -76,9 +76,6 @@ adjoint(F::LU) = Adjoint(F)
 transpose(F::LU) = Transpose(F)
 
 # StridedMatrix
-lu(A::StridedMatrix, pivot::Union{RowMaximum,NoPivot} = RowMaximum(); check::Bool = true) =
-    lu!(copy_oftype(A, lutype(eltype(A))), pivot; check=check)
-
 lu!(A::StridedMatrix{<:BlasFloat}; check::Bool = true) = lu!(A, RowMaximum(); check=check)
 function lu!(A::StridedMatrix{T}, ::RowMaximum; check::Bool = true) where {T<:BlasFloat}
     lpt = LAPACK.getrf!(A)
@@ -282,8 +279,7 @@ true
 ```
 """
 function lu(A::AbstractMatrix{T}, pivot::Union{RowMaximum,NoPivot} = RowMaximum(); check::Bool = true) where {T}
-    S = lutype(T)
-    lu!(copy_to_array(A, S), pivot; check = check)
+    lu!(copy_similar(A, lutype(T)), pivot; check = check)
 end
 # TODO: remove for Julia v2.0
 @deprecate lu(A::AbstractMatrix, ::Val{true}; check::Bool = true) lu(A, RowMaximum(); check=check)

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -86,9 +86,6 @@ function lu!(A::StridedMatrix{<:BlasFloat}, pivot::NoPivot; check::Bool = true)
     return generic_lufact!(A, pivot; check = check)
 end
 
-lu(A::HermOrSym, pivot::Union{RowMaximum,NoPivot} = RowMaximum(); check::Bool = true) =
-    lu!(copy_oftype(A, lutype(eltype(A))), pivot; check=check)
-
 function lu!(A::HermOrSym, pivot::Union{RowMaximum,NoPivot} = RowMaximum(); check::Bool = true)
     copytri!(A.data, A.uplo, isa(A, Hermitian))
     lu!(A.data, pivot; check = check)
@@ -279,12 +276,15 @@ true
 ```
 """
 function lu(A::AbstractMatrix{T}, pivot::Union{RowMaximum,NoPivot} = RowMaximum(); check::Bool = true) where {T}
-    lu!(copy_similar(A, lutype(T)), pivot; check = check)
+    lu!(_lucopy(A, lutype(T)), pivot; check = check)
 end
 # TODO: remove for Julia v2.0
 @deprecate lu(A::AbstractMatrix, ::Val{true}; check::Bool = true) lu(A, RowMaximum(); check=check)
 @deprecate lu(A::AbstractMatrix, ::Val{false}; check::Bool = true) lu(A, NoPivot(); check=check)
 
+_lucopy(A::AbstractMatrix, T) = copy_similar(A, T)
+_lucopy(A::HermOrSym, T)      = copy_oftype(A, T)
+_lucopy(A::Tridiagonal, T)    = copy_oftype(A, T)
 
 lu(S::LU) = S
 function lu(x::Number; check::Bool=true)
@@ -492,9 +492,6 @@ inv!(A::LU{T,<:StridedMatrix}) where {T} =
 inv(A::LU{<:BlasFloat,<:StridedMatrix}) = inv!(copy(A))
 
 # Tridiagonal
-
-lu(A::Tridiagonal{T}, pivot::Union{RowMaximum,NoPivot} = RowMaximum(); check::Bool = true) where T =
-    lu!(copy_oftype(A, lutype(T)), pivot; check = check)
 
 # See dgttrf.f
 function lu!(A::Tridiagonal{T,V}, pivot::Union{RowMaximum,NoPivot} = RowMaximum(); check::Bool = true) where {T,V}

--- a/stdlib/LinearAlgebra/src/schur.jl
+++ b/stdlib/LinearAlgebra/src/schur.jl
@@ -97,7 +97,7 @@ julia> A
 schur!(A::StridedMatrix{<:BlasFloat}) = Schur(LinearAlgebra.LAPACK.gees!('V', A)...)
 
 """
-    schur(A::AbstractMatrix) -> F::Schur
+    schur(A) -> F::Schur
 
 Computes the Schur factorization of the matrix `A`. The (quasi) triangular Schur factor can
 be obtained from the `Schur` object `F` with either `F.Schur` or `F.T` and the
@@ -333,7 +333,7 @@ schur!(A::StridedMatrix{T}, B::StridedMatrix{T}) where {T<:BlasFloat} =
     GeneralizedSchur(LinearAlgebra.LAPACK.gges!('V', 'V', A, B)...)
 
 """
-    schur(A::StridedMatrix, B::StridedMatrix) -> F::GeneralizedSchur
+    schur(A, B) -> F::GeneralizedSchur
 
 Computes the Generalized Schur (or QZ) factorization of the matrices `A` and `B`. The
 (quasi) triangular Schur factors can be obtained from the `Schur` object `F` with `F.S`
@@ -345,14 +345,9 @@ generalized eigenvalues of `A` and `B` can be obtained with `F.α./F.β`.
 Iterating the decomposition produces the components `F.S`, `F.T`, `F.Q`, `F.Z`,
 `F.α`, and `F.β`.
 """
-schur(A::StridedMatrix{T},B::StridedMatrix{T}) where {T<:BlasFloat} = schur!(copy(A),copy(B))
-function schur(A::StridedMatrix{TA}, B::StridedMatrix{TB}) where {TA,TB}
-    S = promote_type(eigtype(TA), TB)
-    return schur!(copy_oftype(A, S), copy_oftype(B, S))
-end
 function schur(A::AbstractMatrix{TA}, B::AbstractMatrix{TB}) where {TA,TB}
     S = promote_type(eigtype(TA), TB)
-    return schur!(copy_oftype(A, S), copy_oftype(B, S))
+    return schur!(copy_similar(A, S), copy_similar(B, S))
 end
 
 """

--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -50,6 +50,15 @@ Bidiagonal(A::AbstractTriangular) =
     isbanded(A, -1, 0) ? Bidiagonal(diag(A, 0), diag(A, -1), :L) : # is lower bidiagonal
         throw(ArgumentError("matrix cannot be represented as Bidiagonal"))
 
+_lucopy(A::Bidiagonal, T)     = copy_oftype(Tridiagonal(A), T)
+_lucopy(A::Diagonal, T)       = copy_oftype(Tridiagonal(A), T)
+function _lucopy(A::SymTridiagonal, T)
+    du = copy_similar(_evview(A), T)
+    dl = copy.(transpose.(du))
+    d  = copy_similar(A.dv, T)    
+    return Tridiagonal(dl, d, du)
+end
+        
 const ConvertibleSpecialMatrix = Union{Diagonal,Bidiagonal,SymTridiagonal,Tridiagonal,AbstractTriangular}
 const PossibleTriangularMatrix = Union{Diagonal, Bidiagonal, AbstractTriangular}
 

--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -55,10 +55,10 @@ _lucopy(A::Diagonal, T)       = copy_oftype(Tridiagonal(A), T)
 function _lucopy(A::SymTridiagonal, T)
     du = copy_similar(_evview(A), T)
     dl = copy.(transpose.(du))
-    d  = copy_similar(A.dv, T)    
+    d  = copy_similar(A.dv, T)
     return Tridiagonal(dl, d, du)
 end
-        
+
 const ConvertibleSpecialMatrix = Union{Diagonal,Bidiagonal,SymTridiagonal,Tridiagonal,AbstractTriangular}
 const PossibleTriangularMatrix = Union{Diagonal, Bidiagonal, AbstractTriangular}
 


### PR DESCRIPTION
Minor cleanup after JuliaLang/julia#40831. 

I don't think we need non-mutating `lu`- and `schur`-methods with `StridedMatrix` type in their signature. `copy(::StridedMatrix)` does the same as `copy_similar(::StridedMatrix)`, so that reduces the number of needed methods.

Closes https://github.com/JuliaDiff/TaylorSeries.jl/issues/295

This now also closes JuliaLang/LinearAlgebra.jl#375 in a much less verbose way than JuliaLang/julia#41288.