### PR TITLE
Add "project" mode for faster code coverage and allocation tracking

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -193,16 +193,20 @@ function julia_cmd(julia=joinpath(Sys.BINDIR::String, julia_exename()))
         coverage_file = (opts.output_code_coverage != C_NULL) ?  unsafe_string(opts.output_code_coverage) : ""
         if isempty(coverage_file) || occursin("%p", coverage_file)
             if opts.code_coverage == 1
-                push!(addflags, "--code-coverage=user")
+                push!(addflags, "--code-coverage=project")
             elseif opts.code_coverage == 2
+                push!(addflags, "--code-coverage=user")
+            elseif opts.code_coverage == 3
                 push!(addflags, "--code-coverage=all")
             end
             isempty(coverage_file) || push!(addflags, "--code-coverage=$coverage_file")
         end
     end
     if opts.malloc_log == 1
-        push!(addflags, "--track-allocation=user")
+        push!(addflags, "--track-allocation=project")
     elseif opts.malloc_log == 2
+        push!(addflags, "--track-allocation=user")
+    elseif opts.malloc_log == 3
         push!(addflags, "--track-allocation=all")
     end
     if opts.color == 1

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -195,11 +195,11 @@ Generate LLVM bitcode (.bc)
 Generate an incremental output file (rather than complete)
 
 .TP
---code-coverage={none|user|all}, --code-coverage
+--code-coverage={none|project|user|all}, --code-coverage
 Count executions of source lines (omitting setting is equivalent to 'user')
 
 .TP
---track-allocation={none|user|all}, --track-allocation
+--track-allocation={none|project|user|all}, --track-allocation
 Count bytes allocated by each source line
 
 .SH FILES

--- a/doc/src/manual/command-line-options.md
+++ b/doc/src/manual/command-line-options.md
@@ -106,9 +106,9 @@ The following is a complete list of command-line switches available when launchi
 |`--inline={yes\|no}`                   |Control whether inlining is permitted, including overriding `@inline` declarations|
 |`--check-bounds={yes\|no\|auto}`       |Emit bounds checks always, never, or respect `@inbounds` declarations|
 |`--math-mode={ieee,fast}`              |Disallow or enable unsafe floating point optimizations (overrides `@fastmath` declaration)|
-|`--code-coverage={none\|user\|all}`    |Count executions of source lines|
+|`--code-coverage={none\|project\|user\|all}`    |Count executions of source lines|
 |`--code-coverage`                      |equivalent to `--code-coverage=user`|
-|`--track-allocation={none\|user\|all}` |Count bytes allocated by each source line|
+|`--track-allocation={none\|project\|user\|all}` |Count bytes allocated by each source line|
 |`--track-allocation`                   |equivalent to `--track-allocation=user`|
 
 !!! compat "Julia 1.1"

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -85,6 +85,7 @@
     XX(jl_pinode_type) \
     XX(jl_pointer_type) \
     XX(jl_pointer_typename) \
+    XX(jl_project_module) \
     XX(jl_quotenode_type) \
     XX(jl_readonlymemory_exception) \
     XX(jl_ref_type) \

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -145,12 +145,12 @@ static const char opts[]  =
     " --math-mode={ieee,fast}   Disallow or enable unsafe floating point optimizations (overrides @fastmath declaration)\n\n"
 
     // instrumentation options
-    " --code-coverage={none|user|all}, --code-coverage\n"
+    " --code-coverage={none|project|user|all}, --code-coverage\n"
     "                           Count executions of source lines (omitting setting is equivalent to \"user\")\n"
     " --code-coverage=tracefile.info\n"
     "                           Append coverage information to the LCOV tracefile (filename supports format tokens).\n"
 // TODO: These TOKENS are defined in `runtime_ccall.cpp`. A more verbose `--help` should include that list here.
-    " --track-allocation={none|user|all}, --track-allocation\n"
+    " --track-allocation={none|project|user|all}, --track-allocation\n"
     "                           Count bytes allocated by each source line (omitting setting is equivalent to \"user\")\n"
     " --bug-report=KIND         Launch a bug report session. It can be used to start a REPL, run a script, or evaluate\n"
     "                           expressions. It first tries to use BugReporting.jl installed in current environment and\n"
@@ -499,7 +499,9 @@ restart_switch:
         case opt_code_coverage:
             if (optarg != NULL) {
                 size_t endof = strlen(optarg);
-                if (!strcmp(optarg, "user"))
+                if (!strcmp(optarg,"project"))
+                    codecov = JL_LOG_PROJECT;
+                else if (!strcmp(optarg, "user"))
                     codecov = JL_LOG_USER;
                 else if (!strcmp(optarg, "all"))
                     codecov = JL_LOG_ALL;
@@ -520,7 +522,9 @@ restart_switch:
             break;
         case opt_track_allocation:
             if (optarg != NULL) {
-                if (!strcmp(optarg,"user"))
+                if (!strcmp(optarg,"project"))
+                    malloclog = JL_LOG_PROJECT;
+                else if (!strcmp(optarg,"user"))
                     malloclog = JL_LOG_USER;
                 else if (!strcmp(optarg,"all"))
                     malloclog = JL_LOG_ALL;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1579,6 +1579,7 @@ extern JL_DLLEXPORT jl_module_t *jl_main_module JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_module_t *jl_core_module JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_module_t *jl_base_module JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_module_t *jl_top_module JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_module_t *jl_project_module JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name);
 JL_DLLEXPORT void jl_set_module_nospecialize(jl_module_t *self, int on);
 JL_DLLEXPORT void jl_set_module_optlevel(jl_module_t *self, int lvl);
@@ -2071,8 +2072,9 @@ JL_DLLEXPORT int jl_generating_output(void) JL_NOTSAFEPOINT;
 // Settings for code_coverage and malloc_log
 // NOTE: if these numbers change, test/cmdlineargs.jl will have to be updated
 #define JL_LOG_NONE 0
-#define JL_LOG_USER 1
-#define JL_LOG_ALL  2
+#define JL_LOG_PROJECT 1
+#define JL_LOG_USER 2
+#define JL_LOG_ALL  3
 
 #define JL_OPTIONS_CHECK_BOUNDS_DEFAULT 0
 #define JL_OPTIONS_CHECK_BOUNDS_ON 1

--- a/src/module.c
+++ b/src/module.c
@@ -154,6 +154,16 @@ JL_DLLEXPORT uint8_t jl_istopmod(jl_module_t *mod)
     return mod->istopmod;
 }
 
+JL_DLLEXPORT void jl_set_projmod(jl_module_t *mod)
+{
+    jl_project_module = mod;
+}
+
+JL_DLLEXPORT uint8_t jl_unset_projmod(void)
+{
+    jl_project_module = NULL;
+}
+
 static jl_binding_t *new_binding(jl_sym_t *name)
 {
     jl_task_t *ct = jl_current_task;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -26,7 +26,7 @@ extern "C" {
 // TODO: put WeakRefs on the weak_refs list during deserialization
 // TODO: handle finalizers
 
-#define NUM_TAGS    153
+#define NUM_TAGS    154
 
 // An array of references that need to be restored from the sysimg
 // This is a manually constructed dual of the gvars array, which would be produced by codegen for Julia code, for C.
@@ -165,6 +165,7 @@ jl_value_t **const*const get_tags(void) {
         INSERT_TAG(jl_base_module);
         INSERT_TAG(jl_main_module);
         INSERT_TAG(jl_top_module);
+        INSERT_TAG(jl_project_module);
         INSERT_TAG(jl_typeinf_func);
         INSERT_TAG(jl_type_type_mt);
         INSERT_TAG(jl_nonfunction_mt);

--- a/stdlib/Pkg.version
+++ b/stdlib/Pkg.version
@@ -1,4 +1,4 @@
-PKG_BRANCH = master
-PKG_SHA1 = c991ce0a31b784133e061816d21f7d2556a182e7
+PKG_BRANCH = ib/coverage_project
+PKG_SHA1 = 7a8920e20e47173fb55c27da48ef54a66ce3b65d
 PKG_GIT_URL := https://github.com/JuliaLang/Pkg.jl.git
 PKG_TAR_URL = https://api.github.com/repos/JuliaLang/Pkg.jl/tarball/$1

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -306,21 +306,27 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             --code-coverage=$covfile --code-coverage=none`) == "0"
         @test !isfile(covfile)
         @test readchomp(`$exename -E "Base.JLOptions().code_coverage" -L $inputfile
-            --code-coverage=$covfile --code-coverage`) == "1"
+            --code-coverage=$covfile --code-coverage`) == "2"
         @test isfile(covfile)
         got = read(covfile, String)
         rm(covfile)
         @test occursin(expected, got) || (expected, got)
         @test_broken occursin(expected_good, got)
         @test readchomp(`$exename -E "Base.JLOptions().code_coverage" -L $inputfile
-            --code-coverage=$covfile --code-coverage=user`) == "1"
+            --code-coverage=$covfile --code-coverage=project`) == "1"
+        @test isfile(covfile)
+        got = read(covfile, String)
+        rm(covfile)
+        @test isempty(got) || ("", got)
+        @test readchomp(`$exename -E "Base.JLOptions().code_coverage" -L $inputfile
+            --code-coverage=$covfile --code-coverage=user`) == "2"
         @test isfile(covfile)
         got = read(covfile, String)
         rm(covfile)
         @test occursin(expected, got) || (expected, got)
         @test_broken occursin(expected_good, got)
         @test readchomp(`$exename -E "Base.JLOptions().code_coverage" -L $inputfile
-            --code-coverage=$covfile --code-coverage=all`) == "2"
+            --code-coverage=$covfile --code-coverage=all`) == "3"
         @test isfile(covfile)
         got = read(covfile, String)
         rm(covfile)


### PR DESCRIPTION
Adds a `project` option to `--code-coverage` and `--track-allocation` for just tracking the active project module and its submodules.

For instance with code coverage:
```
$ pwd
/usr/Foo.jl

$ julia --code-coverage=project --project -e 'using Foo; Foo.bar()`
```
after which coverage files will be generated within the `Foo` module and its submodules, but no other imported modules.

The idea is to increase the efficiency of code coverage and allocation tracking given that the current most narrow option is `user` which is any non-Core module, including stdlibs.

The `julia-runtest` github action defaults to [having code coverage on](https://github.com/julia-actions/julia-runtest/blob/101f621257f9303898fc48d847e87520e2de41cd/action.yml#L13) which [Pkg sets to `user` mode](https://github.com/JuliaLang/Pkg.jl/blob/7af3e27e3784ccde287b4bcb87891a22830a7dee/src/Operations.jl#L1403), so is currently spending the majority of code-coverage tracking time in modules that won't be evaluated for code coverage by the coverage tooling that just evaluates coverage files the active repo.

## Benchmarks

A favorable case, where the project code is small, but dep code is large
`src/Foo.jl`
```julia
module Foo
import PNGFiles
function bar(n = 10000)
    for _ in 1:3
        @time Threads.@threads for tid in 1:Threads.nthreads()
            f = "$(tid)_img.png"
            for _ in 1:n
                PNGFiles.save(f, rand(UInt8, 100, 100))
                PNGFiles.load(f)
            end
        end
    end
end
end # module Foo
```
### Code Coverage
```
/Foo$ julia --project --code-coverage=all -e "using Foo; Foo.bar(100)"
 16.068388 seconds (1.71 M allocations: 152.005 MiB, 0.67% gc time, 4.32% compilation time)
 15.516894 seconds (33.76 k allocations: 65.759 MiB)
 15.424748 seconds (33.77 k allocations: 65.759 MiB)
... --code-coverage=user
  0.533590 seconds (2.02 M allocations: 170.098 MiB, 90.94% compilation time)
  0.068086 seconds (33.76 k allocations: 65.758 MiB)
  0.206111 seconds (33.76 k allocations: 65.758 MiB, 64.23% gc time)
```
`all` is a lot slower than the others, so compare the others with more iterations
```
/Foo$ julia --project --code-coverage=user -e "using Foo; Foo.bar(10000)"
  7.720869 seconds (5.24 M allocations: 6.517 GiB, 2.93% gc time, 6.13% compilation time)
  6.893507 seconds (3.36 M allocations: 6.421 GiB, 0.33% gc time)
  6.883390 seconds (3.36 M allocations: 6.421 GiB, 0.43% gc time)
... --code-coverage=project
  3.343359 seconds (5.35 M allocations: 6.523 GiB, 8.20% gc time, 15.61% compilation time)
  2.751018 seconds (3.36 M allocations: 6.421 GiB, 3.41% gc time)
  2.848022 seconds (3.36 M allocations: 6.421 GiB, 3.25% gc time)
... --code-coverage=none
  3.423068 seconds (5.03 M allocations: 6.504 GiB, 6.62% gc time, 12.47% compilation time)
  2.760789 seconds (3.36 M allocations: 6.421 GiB, 1.10% gc time)
  2.765776 seconds (3.36 M allocations: 6.421 GiB, 1.05% gc time)
```
So `project` is ~2x faster than `user`, and the `.cov` files for `src/Foo.jl` are near-identical for `user` and `project` (might code-cov iterators not be thread-safe?)

In real-world testing, it might be hard to see this in above CI variability.

[Here](https://github.com/IanButterworth/OrdinaryDiffEq.jl/runs/4751874030?check_suite_focus=true) I ran `OrdinaryDiffEq`'s test suite on 5f6b8a1767f72c6b86ae391ece9c0ca52cd73c6b (before this PR) and 27f01f2771b77ffad4eb4b0668d1ae0893c3fe93 (this PR)

A few testsets as examples:
```
before  -> after
6m54.2s -> 6m43.3s
6m01.6s -> 6m48.2s
55.7s   -> 1m03.9s
8m31.9s -> 7m23.3s
```

### Tracking Allocations
```
/Foo$ julia --project --track-allocation=all -e "using Foo; Foo.bar(100)"
 38.192262 seconds (2.02 M allocations: 169.261 MiB, 2.38% compilation time)
 37.371601 seconds (33.76 k allocations: 65.759 MiB)
 37.923109 seconds (33.76 k allocations: 65.759 MiB, 0.33% gc time)
... --track-allocation=user
  1.041746 seconds (1.61 M allocations: 146.495 MiB, 10.20% gc time, 67.78% compilation time)
  0.240931 seconds (33.76 k allocations: 65.759 MiB)
  0.248995 seconds (33.77 k allocations: 65.759 MiB)

```
again, `all` is a lot slower than the others, so compare the others with more iterations
```
/Foo$ julia --project --track-allocation=user -e "using Foo; Foo.bar(10000)"
 24.162710 seconds (5.14 M allocations: 6.510 GiB, 0.95% gc time, 3.02% compilation time)
 22.962427 seconds (3.36 M allocations: 6.421 GiB, 0.09% gc time)
 23.114932 seconds (3.36 M allocations: 6.421 GiB, 0.13% gc time)
... --track-allocation=project
  3.487994 seconds (4.90 M allocations: 6.498 GiB, 6.20% gc time, 11.88% compilation time)
  2.909793 seconds (3.36 M allocations: 6.421 GiB, 1.08% gc time)
  2.908083 seconds (3.36 M allocations: 6.421 GiB, 0.99% gc time)
... --track-allocation=none
  3.239760 seconds (5.04 M allocations: 6.505 GiB, 6.70% gc time, 12.27% compilation time)
  2.817924 seconds (3.36 M allocations: 6.421 GiB, 1.00% gc time)
  2.806771 seconds (3.36 M allocations: 6.421 GiB, 0.92% gc time)
```
So `project` is ~8x faster than `user`, and the `.mem` files for `src/Foo.jl` are identical for `user` and `project`

## Todo

- [ ] Fix tests
- [ ] Add News
- [ ] Revert the Pkg branch change. (Pkg does an odd thing of testing the project code from a temporary env, so the actual "active project" for this purpose needs a setting that Pkg can override) 

Closes https://github.com/JuliaLang/julia/issues/41626
May close https://github.com/JuliaLang/julia/issues/36142