### PR TITLE
Mention NTuple{N}(eachsplit) pattern to split without allocating

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -572,7 +572,7 @@ The optional keyword arguments are:
  - `keepempty`: whether empty fields should be kept in the result. Default is `false` without
    a `dlm` argument, `true` with a `dlm` argument.
 
-To split into a tuple with the first N substrings and avoid allocating an array,
+To split into a tuple with the first `N` substrings and avoid allocating an array,
 use `NTuple{N}(eachsplit(str, dlm))`.
 
 See also [`rsplit`](@ref), [`eachsplit`](@ref).

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -502,10 +502,8 @@ See also [`split`](@ref).
 julia> a = "Ma.rch"
 "Ma.rch"
 
-julia> collect(eachsplit(a, "."))
-2-element Vector{SubString}:
- "Ma"
- "rch"
+julia> NTuple{2}(eachsplit(a, '.'))
+("Ma", "rch")
 ```
 """
 function eachsplit end
@@ -574,7 +572,10 @@ The optional keyword arguments are:
  - `keepempty`: whether empty fields should be kept in the result. Default is `false` without
    a `dlm` argument, `true` with a `dlm` argument.
 
-See also [`rsplit`](@ref).
+To split into a tuple with the first N substrings and avoid allocating an array,
+use `NTuple{N}(eachsplit(str, dlm))`.
+
+See also [`rsplit`](@ref), [`eachsplit`](@ref).
 
 # Examples
 ```jldoctest

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -49,6 +49,7 @@ Base.findprev(::AbstractString, ::AbstractString, ::Integer)
 Base.occursin
 Base.reverse(::Union{String,SubString{String}})
 Base.replace(s::AbstractString, ::Pair...)
+Base.eachsplit
 Base.split
 Base.rsplit
 Base.strip


### PR DESCRIPTION
Because `split` allocates a new vector, it is unsuitable in high performance code.
`eachsplit`, while it currently does not avoid allocations, could potentially be used
for higher performance. However, manually extracting the first N elements from an
`eachsplit` iterator is not straightforward.
The `NTuple{N}(eachsplit(str, dlm))` pattern allows for doing N-1 splits without
allocating a container to hold the results.

Currently `eachsplit` still allocates when given a string delimiter, but perhaps that can be
improved in the future.

See discussion in #43557.