### PR TITLE
codegen: Avoid some uses of PointerType::getElementType()

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -271,7 +271,7 @@ static Value *emit_plt(
                 functype, attrs, cc, f_lib, f_name, libptrgv, llvmgv, runtime_lib);
     }
     GlobalVariable *got = prepare_global_in(jl_Module, sharedgot);
-    LoadInst *got_val = ctx.builder.CreateAlignedLoad(got->getType()->getElementType(), got, Align(sizeof(void*)));
+    LoadInst *got_val = ctx.builder.CreateAlignedLoad(got->getValueType(), got, Align(sizeof(void*)));
     // See comment in `runtime_sym_lookup` above. This in principle needs a
     // consume ordering too. This is even less likely to cause issues though
     // since the only thing we do to this loaded pointer is to call it

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -159,7 +159,7 @@ static Type *T_pjlvalue;
 static Type *T_prjlvalue;
 static Type *T_ppjlvalue;
 static Type *T_pprjlvalue;
-static Type *jl_array_llvmt;
+static StructType *jl_array_llvmt;
 static Type *jl_parray_llvmt;
 static FunctionType *jl_func_sig;
 static FunctionType *jl_func_sig_sparams;
@@ -1146,7 +1146,7 @@ static inline GlobalVariable *prepare_global_in(Module *M, GlobalVariable *G)
     GlobalValue *local = M->getNamedValue(G->getName());
     if (!local) {
         // Copy the GlobalVariable, but without the initializer, so it becomes a declaration
-        GlobalVariable *proto = new GlobalVariable(*M, G->getType()->getElementType(),
+        GlobalVariable *proto = new GlobalVariable(*M, G->getValueType(),
                 G->isConstant(), GlobalVariable::ExternalLinkage,
                 nullptr, G->getName(), nullptr, G->getThreadLocalMode());
         proto->copyAttributesFrom(G);
@@ -5245,7 +5245,6 @@ static Function* gen_cfun_wrapper(
                 // undo whatever we might have done to this poor argument
                 assert(jl_is_datatype(jargty));
                 if (sig.byRefList.at(i)) {
-                    assert(cast<PointerType>(val->getType())->getElementType() == sig.fargt[i]);
                     val = ctx.builder.CreateAlignedLoad(sig.fargt[i], val, Align(1)); // unknown alignment from C
                 }
                 else {
@@ -5479,7 +5478,7 @@ static Function* gen_cfun_wrapper(
     ctx.builder.ClearInsertionPoint();
 
     if (aliasname) {
-        GlobalAlias::create(cw->getType()->getElementType(), cw->getType()->getAddressSpace(),
+        GlobalAlias::create(cw->getValueType(), cw->getType()->getAddressSpace(),
                             GlobalValue::ExternalLinkage, aliasname, cw, M);
     }
 

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -273,7 +273,7 @@ bool LowerPTLS::runOnModule(Module &_M)
 #endif
     T_pgcstack_getter = FT_pgcstack_getter->getPointerTo();
     T_pppjlvalue = cast<PointerType>(FT_pgcstack_getter->getReturnType());
-    T_ppjlvalue = cast<PointerType>(T_pppjlvalue->getElementType());
+    T_ppjlvalue = JuliaType::get_ppjlvalue_ty(*ctx);
     if (imaging_mode) {
         pgcstack_func_slot = create_aliased_global(T_pgcstack_getter, "jl_pgcstack_func_slot");
         pgcstack_key_slot = create_aliased_global(T_size, "jl_pgcstack_key_slot"); // >= sizeof(jl_pgcstack_key_t)


### PR DESCRIPTION
`getElementType()` will eventually go away with the LLVM switch to opaque pointers.

The assertion in `gen_cfun_wrapper` is still checked within `CreateAlignedLoad`. 

As suggested by @vtjnash in https://github.com/JuliaLang/julia/pull/43628. More work will need to be done to completely remove `PointerType::getElementType()` from our codebase, e.g. using `getWithSamePointeeType` for the address space passes, etc.