### PR TITLE
Fix build against LLVM 14 (Git main)

### DIFF
--- a/src/llvm-julia-licm.cpp
+++ b/src/llvm-julia-licm.cpp
@@ -119,7 +119,7 @@ struct JuliaLICMPass : public LoopPass, public JuliaPassContext {
                 }
                 else if (callee == write_barrier_func) {
                     bool valid = true;
-                    for (std::size_t i = 0; i < call->getNumArgOperands(); i++) {
+                    for (std::size_t i = 0; i < call->arg_size(); i++) {
                         if (!L->makeLoopInvariant(call->getArgOperand(i), changed)) {
                             valid = false;
                             break;
@@ -139,7 +139,7 @@ struct JuliaLICMPass : public LoopPass, public JuliaPassContext {
                         continue;
                     }
                     bool valid = true;
-                    for (std::size_t i = 0; i < call->getNumArgOperands(); i++) {
+                    for (std::size_t i = 0; i < call->arg_size(); i++) {
                         if (!L->makeLoopInvariant(call->getArgOperand(i), changed)) {
                             valid = false;
                             break;


### PR DESCRIPTION
4c45f292a0e688f7b32b1116f9feefc95f93f14d had reintroduced a use of getNumArgOperands(), which was already slated for removal in (at least) LLVM 12.
