### PR TITLE
filesystem permission masks common type `UInt16`

### DIFF
--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -17,21 +17,19 @@ const S_ISUID = 0o4000  # set UID bit
 const S_ISGID = 0o2000  # set GID bit
 const S_ENFMT = S_ISGID # file locking enforcement
 const S_ISVTX = 0o1000  # sticky bit
-const S_IRWXU = 0o0700  # mask for owner permissions
-const S_IRUSR = 0o0400  # read by owner
 
-const S_IRUSR = 0o400
-const S_IWUSR = 0o200
-const S_IXUSR = 0o100
-const S_IRWXU = 0o700
-const S_IRGRP = 0o040
-const S_IWGRP = 0o020
-const S_IXGRP = 0o010
-const S_IRWXG = 0o070
-const S_IROTH = 0o004
-const S_IWOTH = 0o002
-const S_IXOTH = 0o001
-const S_IRWXO = 0o007
+const S_IRUSR = 0o0400  # read by owner
+const S_IWUSR = 0o0200  # write by owner
+const S_IXUSR = 0o0100  # execute by owner
+const S_IRWXU = 0o0700  # mask for owner permissions
+const S_IRGRP = 0o0040  # read by group
+const S_IWGRP = 0o0020  # write by group
+const S_IXGRP = 0o0010  # execute by group
+const S_IRWXG = 0o0070  # mask for group permissions
+const S_IROTH = 0o0004  # read by other
+const S_IWOTH = 0o0002  # write by other
+const S_IXOTH = 0o0001  # execute by other
+const S_IRWXO = 0o0007  # mask for other permissions
 
 export File,
        StatStruct,

--- a/test/filesystem.jl
+++ b/test/filesystem.jl
@@ -34,3 +34,9 @@ mktempdir() do dir
   close(file)
 
 end
+
+import Base.Filesystem: S_IRUSR, S_IRGRP, S_IROTH
+@testset "types of permission mask constants" begin
+  @test S_IRUSR & ~S_IRGRP == S_IRUSR
+  @test typeof(S_IRUSR) == typeof(S_IRGRP) == typeof(S_IROTH)
+end


### PR DESCRIPTION
When using the filesystem permission masks like `S_IRUSR` and similar the following surprise,
when applying bitmask operations:
```
julia> import Base.Filesystem: S_IRUSR, S_IRGRP, S_IROTH

julia> S_IRUSR & ~S_IRGRP
0x0000

julia> 0o440 & ~S_IRGRP
0x0000
```
which should be
```
julia> S_IRUSR & ~S_IRGRP
0x0100

julia> 0o440 & ~S_IRGRP
0x0100
```
