### PR TITLE
Add optional error message to `only` to simplify usage

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1429,11 +1429,11 @@ Stacktrace:
             throw(ArgumentError("Collection is empty, must contain exactly 1 element"))
         else
             throw(ArgumentError("Collection is empty, must contain exactly 1 element; $message"))
-        end            
+        end
     end
     (ret, state) = i::NTuple{2,Any}
     @boundscheck if iterate(x, state) !== nothing
-        if message == "" 
+        if message == ""
             throw(ArgumentError("Collection has multiple elements, must contain exactly 1 element"))
         else
             throw(ArgumentError("Collection has multiple elements, must contain exactly 1 element; $message"))

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1402,12 +1402,12 @@ Stacktrace:
 [...]
 
 julia> only(('a', 'b'))
-ERROR: ArgumentError: Tuple contains multiple elements, must contain exactly 1 element
+ERROR: ArgumentError: Tuple contains 2 elements, must contain exactly 1 element
 Stacktrace:
 [...]
 
 julia> only(('a', 'b'), "my error message")
-ERROR: ArgumentError: Tuple contains multiple elements, must contain exactly 1 element; my error message
+ERROR: ArgumentError: Tuple contains 2 elements, must contain exactly 1 element; my error message
 Stacktrace:
 [...]
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1457,7 +1457,7 @@ only(x::Tuple, message="") = throw(
 
 only(a::AbstractArray{<:Any, 0}, message="") = @inbounds return a[]
 only(x::NamedTuple{<:Any, <:Tuple{Any}}, message="") = first(x)
-only(x::NamedTuple, messsage="") = throw(
+only(x::NamedTuple, message="") = throw(
     if message == ""
         ArgumentError("NamedTuple contains $(length(x)) elements, must contain exactly 1 element")
     else

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1372,10 +1372,11 @@ IteratorEltype(::Type{Stateful{T,VS}}) where {T,VS} = IteratorEltype(T)
 length(s::Stateful) = length(s.itr) - s.taken
 
 """
-    only(x)
+    only(x, [message])
 
 Return the one and only element of collection `x`, or throw an [`ArgumentError`](@ref) if the
-collection has zero or multiple elements.
+collection has zero or multiple elements. An optional error message can be provided to customize
+the message if the collection has zero or multiple elements.
 
 See also [`first`](@ref), [`last`](@ref).
 
@@ -1396,19 +1397,24 @@ Stacktrace:
 [...]
 
 julia> only(('a', 'b'))
-ERROR: ArgumentError: Tuple contains 2 elements, must contain exactly 1 element
+ERROR: ArgumentError: Tuple contains multiple elements, must contain exactly 1 element
+Stacktrace:
+[...]
+
+julia> only(('a', 'b'), "my error message")
+ERROR: ArgumentError: Tuple contains multiple elements, my error message
 Stacktrace:
 [...]
 ```
 """
-@propagate_inbounds function only(x)
+@propagate_inbounds function only(x, message="must contain exactly 1 element")
     i = iterate(x)
     @boundscheck if i === nothing
-        throw(ArgumentError("Collection is empty, must contain exactly 1 element"))
+        throw(ArgumentError("Collection is empty, $message"))
     end
     (ret, state) = i::NTuple{2,Any}
     @boundscheck if iterate(x, state) !== nothing
-        throw(ArgumentError("Collection has multiple elements, must contain exactly 1 element"))
+        throw(ArgumentError("Collection has multiple elements, $message"))
     end
     return ret
 end


### PR DESCRIPTION
Uses of only are often replaced (or just not done in the first place) with explicit logic to get better error messages. Allowing the error message to be passed in would prevent this and make `only` more useful.