### PR TITLE
Add do-block syntax for Semaphore acquire. Add Semaphore tests

### DIFF
--- a/base/lock.jl
+++ b/base/lock.jl
@@ -315,7 +315,7 @@ function acquire(s::Semaphore)
 end
 
 """
-    acquire(f::Function, s::Semaphore)
+    acquire(f, s::Semaphore)
 
 Execute `f` after acquiring from Semaphore `s`,
 and `release` on completion or error.
@@ -333,8 +333,12 @@ s = Base.Semaphore(2)
     end
 end
 ```
+
+!!! compat "Julia 1.8"
+    This method requires at least Julia 1.8.
+
 """
-function acquire(f::Function, s::Semaphore)
+function acquire(f, s::Semaphore)
     acquire(s)
     try
         f()

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -341,11 +341,10 @@ end
 function acquire(f, s::Semaphore)
     acquire(s)
     try
-        f()
+        return f()
     finally
         release(s)
     end
-    return
 end
 
 """

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -315,6 +315,36 @@ function acquire(s::Semaphore)
 end
 
 """
+    acquire(f::Function, s::Semaphore)
+
+Execute `f` after acquiring from Semaphore `s`,
+and `release` on completion or error.
+
+For example, a do-block form that ensures only 2
+calls of `foo` will be active at the same time:
+
+```julia
+s = Base.Semaphore(2)
+@sync for _ in 1:100
+    Threads.@spawn begin
+        Base.acquire(s) do
+            foo()
+        end
+    end
+end
+```
+"""
+function acquire(f::Function, s::Semaphore)
+    acquire(s)
+    try
+        f()
+    finally
+        release(s)
+    end
+    return
+end
+
+"""
     release(s::Semaphore)
 
 Return one permit to the pool,

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -158,6 +158,32 @@ for l in (Threads.SpinLock(), ReentrantLock())
     @test try unlock(l) finally end === nothing
 end
 
+@testset "Semaphore" begin
+    sleep_secs = 0.01
+    sem_size = 2
+    n = 100
+
+    s = Base.Semaphore(sem_size)
+
+    t = @elapsed @sync for _ in 1:n
+        @async begin
+            Base.acquire(s)
+            sleep(sleep_secs)
+            Base.release(s)
+        end
+    end
+    @test isapprox(t, (n / sem_size) * sleep_secs, rtol = 0.2)
+
+    t = @elapsed @sync for _ in 1:n
+        @async begin
+            Base.acquire(s) do
+                sleep(sleep_secs)
+            end
+        end
+    end
+    @test isapprox(t, (n / sem_size) * sleep_secs, rtol = 0.2)
+end
+
 # task switching
 
 @noinline function f6597(c)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -186,11 +186,12 @@ end
     history = fill!(Vector{Int}(undef, 2n), -1)
     @sync for _ in 1:n
         @async begin
-            Base.acquire(s) do
+            @test Base.acquire(s) do
                 history[Threads.atomic_add!(clock, 1)] = Threads.atomic_add!(occupied, 1) + 1
                 sleep(rand(0:0.01:0.1))
                 history[Threads.atomic_add!(clock, 1)] = Threads.atomic_sub!(occupied, 1) - 1
-            end
+                return :resultvalue
+            end == :resultvalue
         end
     end
     @test all(<=(sem_size), history)


### PR DESCRIPTION
Add do-block syntax for `Semaphore` `acquire`
```julia
s = Base.Semaphore(2)
@sync for _ in 1:100
    Threads.@spawn begin
        Base.acquire(s) do
            foo()
        end
    end
end
```

Also, from what I can tell `Semaphore` wasn't tested in Base before this