### PR TITLE
Add some comments to `Make.inc` that explicitly define what we mean when we say "assert build of Julia"

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -14,6 +14,11 @@
 # Set to zero to turn off extra precompile (e.g. for the REPL)
 JULIA_PRECOMPILE ?= 1
 
+# Set FORCE_ASSERTIONS to 1 to enable assertions in the C and C++ portions
+# of the Julia code base. You may also want to set LLVM_ASSERTIONS to 1,
+# which will enable assertions in LLVM.
+# An "assert build" of Julia is a build that has both FORCE_ASSERTIONS=1
+# and LLVM_ASSERTIONS=1.
 FORCE_ASSERTIONS ?= 0
 
 # OPENBLAS build options
@@ -330,6 +335,7 @@ INSTALL_M := $(JULIAHOME)/contrib/install.sh 755
 
 # LLVM Options
 LLVMROOT := $(build_prefix)
+# Set LLVM_ASSERTIONS to 1 to enable assertions in LLVM.
 LLVM_ASSERTIONS := 0
 LLVM_DEBUG := 0
 # set to 1 to get clang and compiler-rt

--- a/doc/src/devdocs/build/build.md
+++ b/doc/src/devdocs/build/build.md
@@ -272,13 +272,13 @@ If you need to build Julia from source with Git checkouts of more than one stdli
 
 ## Building an "assert build" of Julia
 
-An "assert build" of Julia has both `FORCE_ASSERTIONS=1` and `LLVM_ASSERTIONS=1`. To build
-an assert build, you can run the following commands:
+An "assert build" of Julia is a build that was built with both `FORCE_ASSERTIONS=1` and
+`LLVM_ASSERTIONS=1`. To build an assert build, define both of the following variables
+in your `Make.user` file:
 
 ```
-git clone https://github.com/JuliaLang/julia.git
-cd julia
-make FORCE_ASSERTIONS=1 LLVM_ASSERTIONS=1
+FORCE_ASSERTIONS=1
+LLVM_ASSERTIONS=1
 ```
 
 Please note that assert builds of Julia will be slower than regular (non-assert) builds.

--- a/doc/src/devdocs/build/build.md
+++ b/doc/src/devdocs/build/build.md
@@ -269,3 +269,16 @@ If you need to build Julia from source with a Git checkout of a stdlib, then use
 For example, if you need to build Julia from source with a Git checkout of Pkg, then use `make DEPS_GIT=Pkg` when building Julia. The `Pkg` repo is in `stdlib/Pkg`, and created initially with a detached `HEAD`. If you're doing this from a pre-existing Julia repository, you may need to `make clean` beforehand.
 
 If you need to build Julia from source with Git checkouts of more than one stdlib, then `DEPS_GIT` should be a space-separated list of the stdlib names. For example, if you need to build Julia from source with a Git checkout of Pkg, Tar, and Downloads, then use `make DEPS_GIT='Pkg Tar Downloads'` when building Julia.
+
+## Building an "assert build" of Julia
+
+An "assert build" of Julia has both `FORCE_ASSERTIONS=1` and `LLVM_ASSERTIONS=1`. To build
+an assert build, you can run the following commands:
+
+```
+git clone https://github.com/JuliaLang/julia.git
+cd julia
+make FORCE_ASSERTIONS=1 LLVM_ASSERTIONS=1
+```
+
+Please note that assert builds of Julia will be slower than regular (non-assert) builds.


### PR DESCRIPTION
I figure we should explicitly write down the definition of "assert build of Julia". In this PR, I've done so in the form of comments in the `Make.inc` file. If desired, I can also add a sentence or two somewhere in the devdocs.