### PR TITLE
Fix minor typo of "git_version.jl" to "version_git.jl", 

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -99,7 +99,7 @@ endif
 $(BUILDDIR)/version_git.jl.phony: $(SRCDIR)/version_git.sh
 ifneq ($(NO_GIT), 1)
 	sh $< $(SRCDIR) > $@
-	@# This to avoid touching git_version.jl when it is not modified,
+	@# This to avoid touching version_git.jl when it is not modified,
 	@# so that the system image does not need to be rebuilt.
 	@if ! cmp -s $@ version_git.jl; then \
 	    $(call PRINT_PERL,) \


### PR DESCRIPTION
This just fixes a note in the comments that refers to a "git_version.jl" that does not exist. This obviously meant to refer to "base/version_git.jl".