### PR TITLE
Fix #43004 by commenting out broken throw tests

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -3602,9 +3602,10 @@ end
 @test_throws TypeError Union{Int, 1}
 
 @test_throws ErrorException Vararg{Any,-2}
-@test_throws ErrorException Vararg{Int, N} where N<:T where T
-@test_throws ErrorException Vararg{Int, N} where N<:Integer
-@test_throws ErrorException Vararg{Int, N} where N>:Integer
+# Disabled due to #39698, see src/jltypes.c
+#@test_throws ErrorException Vararg{Int, N} where N<:T where T
+#@test_throws ErrorException Vararg{Int, N} where N<:Integer
+#@test_throws ErrorException Vararg{Int, N} where N>:Integer
 
 mutable struct FooNTuple{N}
     z::Tuple{Integer, Vararg{Int, N}}


### PR DESCRIPTION
 #39875 disabled bounds errors on `Vararg`. d06bab00016d5d372af876e2b56bddc2adbec97c removed the corresponding tests from the 1.6 branch. However, the tests remain on master and the 1.7 branch.

This pull request just comments out the tests since the corresponding code in `src/jltypes.c` is only commented out via #39875. If the decision is reached to delete, then both the commented out code and tests should be deleted at the same time.

Fixes #43004 and recommend backport to 1.7.