### PR TITLE
Avoid warning due to unused jl_set_gc_and_wait() on Darwin [nfc]

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -804,7 +804,7 @@ typedef jl_gcframe_t ***(*jl_pgcstack_key_t)(void) JL_NOTSAFEPOINT;
 #endif
 JL_DLLEXPORT void jl_pgcstack_getkey(jl_get_pgcstack_func **f, jl_pgcstack_key_t *k);
 
-#if !defined(__clang_gcanalyzer__)
+#if !defined(__clang_gcanalyzer__) && !defined(_OS_DARWIN_)
 static inline void jl_set_gc_and_wait(void)
 {
     jl_task_t *ct = jl_current_task;


### PR DESCRIPTION
Also makes it clear to the reader that signals-mach.c uses
a different approach entirely (which almost tripped me up
the first time I was reading through this part of the codebase).
