### PR TITLE
Add missing colour `:light_white`

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -18,6 +18,7 @@ const text_colors = Dict{Union{Symbol,Int},String}(
     :light_blue    => "\033[94m",
     :light_magenta => "\033[95m",
     :light_cyan    => "\033[96m",
+    :light_white   => "\033[97m",
     :normal        => "\033[0m",
     :default       => "\033[39m",
     :bold          => "\033[1m",


### PR DESCRIPTION
Julia currently defines 15 of the 16 "basic" ANSI colours, omitting "bright white" (see https://en.wikipedia.org/wiki/ANSI_escape_code). This adds "bright white", which Julia would call "light white".