### PR TITLE
Remove various uses of jl_LLVMContext in codegen

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -88,8 +88,8 @@ static Value *runtime_sym_lookup(
     //   }
     //   return (*llvmgv)
     BasicBlock *enter_bb = irbuilder.GetInsertBlock();
-    BasicBlock *dlsym_lookup = BasicBlock::Create(jl_LLVMContext, "dlsym");
-    BasicBlock *ccall_bb = BasicBlock::Create(jl_LLVMContext, "ccall");
+    BasicBlock *dlsym_lookup = BasicBlock::Create(irbuilder.getContext(), "dlsym");
+    BasicBlock *ccall_bb = BasicBlock::Create(irbuilder.getContext(), "ccall");
     Constant *initnul = ConstantPointerNull::get((PointerType*)T_pvoidfunc);
     LoadInst *llvmf_orig = irbuilder.CreateAlignedLoad(T_pvoidfunc, llvmgv, Align(sizeof(void*)));
     // This in principle needs a consume ordering so that load from
@@ -205,7 +205,7 @@ static GlobalVariable *emit_plt_thunk(
                                              GlobalVariable::ExternalLinkage,
                                              ConstantExpr::getBitCast(plt, T_pvoidfunc),
                                              fname);
-    BasicBlock *b0 = BasicBlock::Create(jl_LLVMContext, "top", plt);
+    BasicBlock *b0 = BasicBlock::Create(M->getContext(), "top", plt);
     IRBuilder<> irbuilder(b0);
     Value *ptr = runtime_sym_lookup(emission_context, irbuilder, NULL, funcptype, f_lib, NULL, f_name, plt, libptrgv,
                                     llvmgv, runtime_lib);
@@ -421,7 +421,7 @@ static Value *runtime_apply_type_env(jl_codectx_t &ctx, jl_value_t *ty)
                 ConstantInt::get(T_size, sizeof(jl_svec_t) / sizeof(jl_value_t*)))
     };
     auto call = ctx.builder.CreateCall(prepare_call(jlapplytype_func), makeArrayRef(args));
-    addRetAttr(call, Attribute::getWithAlignment(jl_LLVMContext, Align(16)));
+    addRetAttr(call, Attribute::getWithAlignment(ctx.builder.getContext(), Align(16)));
     return call;
 }
 
@@ -460,8 +460,8 @@ static void typeassert_input(jl_codectx_t &ctx, const jl_cgval_t &jvinfo, jl_val
                 Value *istype = ctx.builder.CreateICmpNE(
                         ctx.builder.CreateCall(prepare_call(jlisa_func), { vx, boxed(ctx, jlto_runtime) }),
                         ConstantInt::get(T_int32, 0));
-                BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext, "fail", ctx.f);
-                BasicBlock *passBB = BasicBlock::Create(jl_LLVMContext, "pass", ctx.f);
+                BasicBlock *failBB = BasicBlock::Create(ctx.builder.getContext(), "fail", ctx.f);
+                BasicBlock *passBB = BasicBlock::Create(ctx.builder.getContext(), "pass", ctx.f);
                 ctx.builder.CreateCondBr(istype, passBB, failBB);
 
                 ctx.builder.SetInsertPoint(failBB);
@@ -825,7 +825,7 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
         << jl_string_data(ir) << "\n}";
 
         SMDiagnostic Err = SMDiagnostic();
-        Mod = parseAssemblyString(ir_stream.str(), Err, jl_LLVMContext);
+        Mod = parseAssemblyString(ir_stream.str(), Err, ctx.builder.getContext());
         if (!Mod) {
             std::string message = "Failed to parse LLVM assembly: \n";
             raw_string_ostream stream(message);
@@ -842,7 +842,7 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
 
         if (jl_is_string(ir)) {
             SMDiagnostic Err = SMDiagnostic();
-            Mod = parseAssemblyString(jl_string_data(ir), Err, jl_LLVMContext);
+            Mod = parseAssemblyString(jl_string_data(ir), Err, ctx.builder.getContext());
             if (!Mod) {
                 std::string message = "Failed to parse LLVM assembly: \n";
                 raw_string_ostream stream(message);
@@ -856,7 +856,7 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
                 StringRef((char *)jl_array_data(ir), jl_array_len(ir)), "llvmcall",
                 /*RequiresNullTerminator*/ false);
             Expected<std::unique_ptr<Module>> ModuleOrErr =
-                parseBitcodeFile(*Buf, jl_LLVMContext);
+                parseBitcodeFile(*Buf, ctx.builder.getContext());
             if (Error Err = ModuleOrErr.takeError()) {
                 std::string Message;
                 handleAllErrors(std::move(Err),
@@ -1019,14 +1019,14 @@ std::string generate_func_sig(const char *fname)
 
     if (type_is_ghost(lrt)) {
         prt = lrt = T_void;
-        abi->use_sret(jl_nothing_type, jl_LLVMContext);
+        abi->use_sret(jl_nothing_type, lrt->getContext());
     }
     else {
         if (!jl_is_datatype(rt) || ((jl_datatype_t*)rt)->layout == NULL || jl_is_layout_opaque(((jl_datatype_t*)rt)->layout) || jl_is_cpointer_type(rt) || retboxed) {
             prt = lrt; // passed as pointer
-            abi->use_sret(jl_voidpointer_type, jl_LLVMContext);
+            abi->use_sret(jl_voidpointer_type, lrt->getContext());
         }
-        else if (abi->use_sret((jl_datatype_t*)rt, jl_LLVMContext)) {
+        else if (abi->use_sret((jl_datatype_t*)rt, lrt->getContext())) {
             AttrBuilder retattrs = AttrBuilder();
 #if !defined(_OS_WINDOWS_) // llvm used to use the old mingw ABI, skipping this marking works around that difference
             retattrs.addStructRetAttr(lrt);
@@ -1038,7 +1038,7 @@ std::string generate_func_sig(const char *fname)
             prt = lrt;
         }
         else {
-            prt = abi->preferred_llvm_type((jl_datatype_t*)rt, true, jl_LLVMContext);
+            prt = abi->preferred_llvm_type((jl_datatype_t*)rt, true, lrt->getContext());
             if (prt == NULL)
                 prt = lrt;
         }
@@ -1084,7 +1084,7 @@ std::string generate_func_sig(const char *fname)
         }
 
         // Whether or not LLVM wants us to emit a pointer to the data
-        bool byRef = abi->needPassByRef((jl_datatype_t*)tti, ab, jl_LLVMContext, t);
+        bool byRef = abi->needPassByRef((jl_datatype_t*)tti, ab, lrt->getContext(), t);
 
         if (jl_is_cpointer_type(tti)) {
             pat = t;
@@ -1093,7 +1093,7 @@ std::string generate_func_sig(const char *fname)
             pat = PointerType::get(t, AddressSpace::Derived);
         }
         else {
-            pat = abi->preferred_llvm_type((jl_datatype_t*)tti, false, jl_LLVMContext);
+            pat = abi->preferred_llvm_type((jl_datatype_t*)tti, false, lrt->getContext());
             if (pat == NULL)
                 pat = t;
         }
@@ -1116,20 +1116,20 @@ std::string generate_func_sig(const char *fname)
         fargt.push_back(t);
         fargt_isboxed.push_back(isboxed);
         fargt_sig.push_back(pat);
-        paramattrs.push_back(AttributeSet::get(jl_LLVMContext, ab));
+        paramattrs.push_back(AttributeSet::get(lrt->getContext(), ab));
     }
 
     for (size_t i = 0; i < nccallargs + sret; ++i) {
         const auto &as = paramattrs.at(i);
         if (!as.hasAttributes())
             continue;
-        attributes = addAttributesAtIndex(attributes, jl_LLVMContext, i + 1, as);
+        attributes = addAttributesAtIndex(attributes, lrt->getContext(), i + 1, as);
     }
     // If return value is boxed it must be non-null.
     if (retboxed)
-        attributes = addRetAttribute(attributes, jl_LLVMContext, Attribute::NonNull);
+        attributes = addRetAttribute(attributes, lrt->getContext(), Attribute::NonNull);
     if (rt == jl_bottom_type) {
-        attributes = addFnAttribute(attributes, jl_LLVMContext, Attribute::NoReturn);
+        attributes = addFnAttribute(attributes, lrt->getContext(), Attribute::NoReturn);
     }
     return "";
 }
@@ -1553,9 +1553,9 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
                 defer_sig,
                 ConstantInt::get(T_sigatomic, 1));
         ctx.builder.CreateStore(defer_sig, pdefer_sig);
-        BasicBlock *checkBB = BasicBlock::Create(jl_LLVMContext, "check",
+        BasicBlock *checkBB = BasicBlock::Create(ctx.builder.getContext(), "check",
                                                  ctx.f);
-        BasicBlock *contBB = BasicBlock::Create(jl_LLVMContext, "cont");
+        BasicBlock *contBB = BasicBlock::Create(ctx.builder.getContext(), "cont");
         ctx.builder.CreateCondBr(
                 ctx.builder.CreateICmpEQ(defer_sig, ConstantInt::get(T_sigatomic, 0)),
                 checkBB, contBB);
@@ -1584,7 +1584,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
             // This could otherwise be in a dead branch
             if (svecv.typ == (jl_value_t*)jl_simplevector_type)
                 tbaa_decorate(tbaa_const, cast<Instruction>(len));
-            MDBuilder MDB(jl_LLVMContext);
+            MDBuilder MDB(ctx.builder.getContext());
             auto rng = MDB.createRange(
                 Constant::getNullValue(T_size), ConstantInt::get(T_size, INTPTR_MAX / sizeof(void*) - 1));
             cast<LoadInst>(len)->setMetadata(LLVMContext::MD_range, rng);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -663,7 +663,7 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, boo
             else if (isTuple || !llvmcall)
                 struct_decl = ArrayType::get(lasttype, ntypes);
             else
-                struct_decl = StructType::get(lasttype->getContext(), latypes);
+                struct_decl = StructType::get(jl_LLVMContext, latypes);
         }
         else {
 #if 0 // stress-test code that tries to assume julia-index == llvm-index
@@ -673,7 +673,7 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, boo
                 latypes.insert(latypes.begin(), NoopType);
             }
 #endif
-            struct_decl = StructType::get(lasttype->getContext(), latypes);
+            struct_decl = StructType::get(jl_LLVMContext, latypes);
         }
         return struct_decl;
     }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1435,8 +1435,8 @@ static void CreateTrap(IRBuilder<> &irbuilder, bool create_new_block)
 static void CreateConditionalAbort(IRBuilder<> &irbuilder, Value *test)
 {
     Function *f = irbuilder.GetInsertBlock()->getParent();
-    BasicBlock *abortBB = BasicBlock::Create(jl_LLVMContext, "debug_abort", f);
-    BasicBlock *postBB = BasicBlock::Create(jl_LLVMContext, "post_abort", f);
+    BasicBlock *abortBB = BasicBlock::Create(irbuilder.getContext(), "debug_abort", f);
+    BasicBlock *postBB = BasicBlock::Create(irbuilder.getContext(), "post_abort", f);
     irbuilder.CreateCondBr(test, abortBB, postBB);
     irbuilder.SetInsertPoint(abortBB);
     Function *trap_func = Intrinsic::getDeclaration(
@@ -1517,7 +1517,7 @@ static jl_cgval_t convert_julia_type_union(jl_codectx_t &ctx, const jl_cgval_t &
             BasicBlock *post_union_isaBB = NULL;
             auto maybe_setup_union_isa = [&]() {
                 if (!union_isaBB) {
-                    union_isaBB = BasicBlock::Create(jl_LLVMContext, "union_isa", ctx.f);
+                    union_isaBB = BasicBlock::Create(ctx.builder.getContext(), "union_isa", ctx.f);
                     ctx.builder.SetInsertPoint(union_isaBB);
                     union_box_dt = emit_typeof_or_null(ctx, v.Vboxed);
                     post_union_isaBB = ctx.builder.GetInsertBlock();
@@ -1544,7 +1544,7 @@ static jl_cgval_t convert_julia_type_union(jl_codectx_t &ctx, const jl_cgval_t &
                 typ,
                 counter);
             if (union_box_dt) {
-                BasicBlock *postBB = BasicBlock::Create(jl_LLVMContext, "post_union_isa", ctx.f);
+                BasicBlock *postBB = BasicBlock::Create(ctx.builder.getContext(), "post_union_isa", ctx.f);
                 ctx.builder.CreateBr(postBB);
                 ctx.builder.SetInsertPoint(currBB);
                 Value *wasunknown = ctx.builder.CreateICmpEQ(v.TIndex, ConstantInt::get(T_int8, 0x80));
@@ -2217,9 +2217,9 @@ static Value *emit_bitsunion_compare(jl_codectx_t &ctx, const jl_cgval_t &arg1, 
     tindex2 = ctx.builder.CreateAnd(tindex2, ConstantInt::get(T_int8, 0x7f));
     Value *typeeq = ctx.builder.CreateICmpEQ(tindex, tindex2);
     tindex = ctx.builder.CreateSelect(typeeq, tindex, ConstantInt::get(T_int8, 0x00));
-    BasicBlock *defaultBB = BasicBlock::Create(jl_LLVMContext, "unionbits_is_boxed", ctx.f);
+    BasicBlock *defaultBB = BasicBlock::Create(ctx.builder.getContext(), "unionbits_is_boxed", ctx.f);
     SwitchInst *switchInst = ctx.builder.CreateSwitch(tindex, defaultBB);
-    BasicBlock *postBB = BasicBlock::Create(jl_LLVMContext, "post_unionbits_is", ctx.f);
+    BasicBlock *postBB = BasicBlock::Create(ctx.builder.getContext(), "post_unionbits_is", ctx.f);
     ctx.builder.SetInsertPoint(postBB);
     PHINode *phi = ctx.builder.CreatePHI(T_int1, 2);
     switchInst->addCase(ConstantInt::get(T_int8, 0), postBB);
@@ -2227,7 +2227,7 @@ static Value *emit_bitsunion_compare(jl_codectx_t &ctx, const jl_cgval_t &arg1, 
     unsigned counter = 0;
     bool allunboxed = for_each_uniontype_small(
         [&](unsigned idx, jl_datatype_t *jt) {
-            BasicBlock *tempBB = BasicBlock::Create(jl_LLVMContext, "unionbits_is", ctx.f);
+            BasicBlock *tempBB = BasicBlock::Create(ctx.builder.getContext(), "unionbits_is", ctx.f);
             ctx.builder.SetInsertPoint(tempBB);
             switchInst->addCase(ConstantInt::get(T_int8, idx), tempBB);
             jl_cgval_t sel_arg1(arg1, (jl_value_t*)jt, NULL);
@@ -2415,8 +2415,8 @@ static Value *emit_f_is(jl_codectx_t &ctx, const jl_cgval_t &arg1, const jl_cgva
                 return emit_bits_compare(ctx, arg1, arg2);
             Value *same_type = emit_exactly_isa(ctx, (typ == rt2 ? arg1 : arg2), typ);
             BasicBlock *currBB = ctx.builder.GetInsertBlock();
-            BasicBlock *isaBB = BasicBlock::Create(jl_LLVMContext, "is", ctx.f);
-            BasicBlock *postBB = BasicBlock::Create(jl_LLVMContext, "post_is", ctx.f);
+            BasicBlock *isaBB = BasicBlock::Create(ctx.builder.getContext(), "is", ctx.f);
+            BasicBlock *postBB = BasicBlock::Create(ctx.builder.getContext(), "post_is", ctx.f);
             ctx.builder.CreateCondBr(same_type, isaBB, postBB);
             ctx.builder.SetInsertPoint(isaBB);
             Value *bitcmp = emit_bits_compare(ctx, jl_cgval_t(arg1, typ, NULL),
@@ -2677,9 +2677,9 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                     Value *idx_dyn = emit_unbox(ctx, T_size, idx, (jl_value_t*)jl_long_type);
                     error_unless(ctx, ctx.builder.CreateICmpSGT(idx_dyn, Constant::getNullValue(T_size)),
                                  "arraysize: dimension out of range");
-                    BasicBlock *outBB = BasicBlock::Create(jl_LLVMContext, "outofrange", ctx.f);
-                    BasicBlock *inBB = BasicBlock::Create(jl_LLVMContext, "inrange");
-                    BasicBlock *ansBB = BasicBlock::Create(jl_LLVMContext, "arraysize");
+                    BasicBlock *outBB = BasicBlock::Create(ctx.builder.getContext(), "outofrange", ctx.f);
+                    BasicBlock *inBB = BasicBlock::Create(ctx.builder.getContext(), "inrange");
+                    BasicBlock *ansBB = BasicBlock::Create(ctx.builder.getContext(), "arraysize");
                     ctx.builder.CreateCondBr(ctx.builder.CreateICmpSLE(idx_dyn,
                                 ConstantInt::get(T_size, ndims)),
                             inBB, outBB);
@@ -2739,7 +2739,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                         ptindex = data;
                     }
                     else {
-                        Type *AT = ArrayType::get(IntegerType::get(jl_LLVMContext, 8 * al), (elsz + al - 1) / al);
+                        Type *AT = ArrayType::get(IntegerType::get(ctx.builder.getContext(), 8 * al), (elsz + al - 1) / al);
                         data = emit_bitcast(ctx, data, AT->getPointerTo());
                         // isbits union selector bytes are stored after a->maxsize
                         Value *ndims = (nd == -1 ? emit_arrayndims(ctx, ary) : ConstantInt::get(T_int16, nd));
@@ -2811,8 +2811,8 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                         flags = ctx.builder.CreateAnd(flags, 3);
                         Value *is_owned = ctx.builder.CreateICmpEQ(flags, ConstantInt::get(T_int16, 3));
                         BasicBlock *curBB = ctx.builder.GetInsertBlock();
-                        BasicBlock *ownedBB = BasicBlock::Create(jl_LLVMContext, "array_owned", ctx.f);
-                        BasicBlock *mergeBB = BasicBlock::Create(jl_LLVMContext, "merge_own", ctx.f);
+                        BasicBlock *ownedBB = BasicBlock::Create(ctx.builder.getContext(), "array_owned", ctx.f);
+                        BasicBlock *mergeBB = BasicBlock::Create(ctx.builder.getContext(), "merge_own", ctx.f);
                         ctx.builder.CreateCondBr(is_owned, ownedBB, mergeBB);
                         ctx.builder.SetInsertPoint(ownedBB);
                         // load owner pointer
@@ -2837,7 +2837,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                         data_owner->addIncoming(own_ptr, ownedBB);
                     }
                     if (!isboxed && jl_is_uniontype(ety)) {
-                        Type *AT = ArrayType::get(IntegerType::get(jl_LLVMContext, 8 * al), (elsz + al - 1) / al);
+                        Type *AT = ArrayType::get(IntegerType::get(ctx.builder.getContext(), 8 * al), (elsz + al - 1) / al);
                         Value *data = emit_bitcast(ctx, emit_arrayptr(ctx, ary, ary_ex), AT->getPointerTo());
                         Value *offset = emit_arrayoffset(ctx, ary, nd);
                         // compute tindex from val
@@ -3105,7 +3105,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             // String and SimpleVector's length fields have the same layout
             auto ptr = emit_bitcast(ctx, boxed(ctx, obj), T_psize);
             Value *len = tbaa_decorate(tbaa_const, ctx.builder.CreateAlignedLoad(T_size, ptr, Align(sizeof(size_t))));
-            MDBuilder MDB(jl_LLVMContext);
+            MDBuilder MDB(ctx.builder.getContext());
             if (sty == jl_simplevector_type) {
                 auto rng = MDB.createRange(
                     Constant::getNullValue(T_size), ConstantInt::get(T_size, INTPTR_MAX / sizeof(void*) - 1));
@@ -3593,8 +3593,8 @@ static jl_cgval_t emit_call(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt)
 
 static void undef_var_error_ifnot(jl_codectx_t &ctx, Value *ok, jl_sym_t *name)
 {
-    BasicBlock *err = BasicBlock::Create(jl_LLVMContext, "err", ctx.f);
-    BasicBlock *ifok = BasicBlock::Create(jl_LLVMContext, "ok");
+    BasicBlock *err = BasicBlock::Create(ctx.builder.getContext(), "err", ctx.f);
+    BasicBlock *ifok = BasicBlock::Create(ctx.builder.getContext(), "ok");
     ctx.builder.CreateCondBr(ok, ifok, err);
     ctx.builder.SetInsertPoint(err);
     ctx.builder.CreateCall(prepare_call(jlundefvarerror_func),
@@ -3631,8 +3631,8 @@ static Value *global_binding_pointer(jl_codectx_t &ctx, jl_module_t *m, jl_sym_t
                     false, GlobalVariable::PrivateLinkage, initnul);
             LoadInst *cachedval = ctx.builder.CreateAlignedLoad(T_pjlvalue, bindinggv, Align(sizeof(void*)));
             cachedval->setOrdering(AtomicOrdering::Unordered);
-            BasicBlock *have_val = BasicBlock::Create(jl_LLVMContext, "found");
-            BasicBlock *not_found = BasicBlock::Create(jl_LLVMContext, "notfound");
+            BasicBlock *have_val = BasicBlock::Create(ctx.builder.getContext(), "found");
+            BasicBlock *not_found = BasicBlock::Create(ctx.builder.getContext(), "notfound");
             BasicBlock *currentbb = ctx.builder.GetInsertBlock();
             ctx.builder.CreateCondBr(ctx.builder.CreateICmpNE(cachedval, initnul), have_val, not_found);
             ctx.f->getBasicBlockList().push_back(not_found);
@@ -4629,10 +4629,10 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
                 F = cast<Function>(V);
             }
             else {
-                F = Function::Create(get_func_sig(jl_LLVMContext),
+                F = Function::Create(get_func_sig(ctx.builder.getContext()),
                                 Function::ExternalLinkage,
                                 fname, jl_Module);
-                F->setAttributes(get_func_attrs(jl_LLVMContext));
+                F->setAttributes(get_func_attrs(ctx.builder.getContext()));
             }
             jl_cgval_t jlcall_ptr = mark_julia_type(ctx,
                 F, false, jl_voidpointer_type);
@@ -4706,7 +4706,7 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
                 MDs.push_back(MD);
         }
 
-        MDNode* MD = MDNode::get(jl_LLVMContext, MDs);
+        MDNode* MD = MDNode::get(ctx.builder.getContext(), MDs);
         CallInst *I = ctx.builder.CreateCall(prepare_call(jl_loopinfo_marker_func));
         I->setMetadata("julia.loopinfo", MD);
         return jl_cgval_t();
@@ -4738,7 +4738,7 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
             }
         }
         Value *token = vals.empty()
-            ? (Value*)ConstantTokenNone::get(jl_LLVMContext)
+            ? (Value*)ConstantTokenNone::get(ctx.builder.getContext())
             : ctx.builder.CreateCall(prepare_call(gc_preserve_begin_func), vals);
         jl_cgval_t tok(token, NULL, false, (jl_value_t*)jl_nothing_type, NULL);
         return tok;
@@ -4824,7 +4824,7 @@ static Value *get_current_signal_page(jl_codectx_t &ctx)
 
 static Function *emit_tojlinvoke(jl_code_instance_t *codeinst, Module *M, jl_codegen_params_t &params)
 {
-    jl_codectx_t ctx(jl_LLVMContext, params);
+    jl_codectx_t ctx(M->getContext(), params);
     std::string name;
     raw_string_ostream(name) << "tojlinvoke" << globalUnique++;
     Function *f = Function::Create(jl_func_sig,
@@ -4834,7 +4834,7 @@ static Function *emit_tojlinvoke(jl_code_instance_t *codeinst, Module *M, jl_cod
     f->addFnAttr(Thunk);
     //f->setAlwaysInline();
     ctx.f = f; // for jl_Module
-    BasicBlock *b0 = BasicBlock::Create(jl_LLVMContext, "top", f);
+    BasicBlock *b0 = BasicBlock::Create(ctx.builder.getContext(), "top", f);
     ctx.builder.SetInsertPoint(b0);
     Function *theFunc;
     Value *theFarg;
@@ -4842,7 +4842,7 @@ static Function *emit_tojlinvoke(jl_code_instance_t *codeinst, Module *M, jl_cod
     if (params.cache && invoke != NULL) {
         StringRef theFptrName = jl_ExecutionEngine->getFunctionAtAddress((uintptr_t)invoke, codeinst);
         theFunc = cast<Function>(
-            M->getOrInsertFunction(theFptrName, jlinvoke_func->_type(jl_LLVMContext)).getCallee());
+            M->getOrInsertFunction(theFptrName, jlinvoke_func->_type(ctx.builder.getContext())).getCallee());
         theFarg = literal_pointer_val(ctx, (jl_value_t*)codeinst);
     }
     else {
@@ -4867,7 +4867,7 @@ static void emit_cfunc_invalidate(
     jl_codectx_t ctx(jl_LLVMContext, params);
     ctx.f = gf_thunk;
 
-    BasicBlock *b0 = BasicBlock::Create(jl_LLVMContext, "top", gf_thunk);
+    BasicBlock *b0 = BasicBlock::Create(ctx.builder.getContext(), "top", gf_thunk);
     ctx.builder.SetInsertPoint(b0);
     DebugLoc noDbg;
     ctx.builder.SetCurrentDebugLocation(noDbg);
@@ -5051,7 +5051,7 @@ static Function* gen_cfun_wrapper(
         // Add the new nest attribute
         AttrBuilder attrBuilder;
         attrBuilder.addAttribute(Attribute::Nest);
-        newAttributes.emplace_back(it, AttributeSet::get(jl_LLVMContext, attrBuilder));
+        newAttributes.emplace_back(it, AttributeSet::get(M->getContext(), attrBuilder));
 
         // Shift forward the rest of the attributes
         if (attributes.getNumAttrSets() > 0) { // without this check the loop range below is invalid
@@ -5069,7 +5069,7 @@ static Function* gen_cfun_wrapper(
         }
 
         // Create the new AttributeList
-        attributes = AttributeList::get(jl_LLVMContext, newAttributes);
+        attributes = AttributeList::get(M->getContext(), newAttributes);
         functype = FunctionType::get(sig.sret ? T_void : sig.prt, fargt_sig, /*isVa*/false);
     }
     else {
@@ -5081,13 +5081,13 @@ static Function* gen_cfun_wrapper(
     cw->setAttributes(attributes);
     jl_init_function(cw);
 
-    jl_codectx_t ctx(jl_LLVMContext, params);
+    jl_codectx_t ctx(M->getContext(), params);
     ctx.f = cw;
     ctx.world = world;
     ctx.name = name;
     ctx.funcName = name;
 
-    BasicBlock *b0 = BasicBlock::Create(jl_LLVMContext, "top", cw);
+    BasicBlock *b0 = BasicBlock::Create(ctx.builder.getContext(), "top", cw);
     ctx.builder.SetInsertPoint(b0);
     DebugLoc noDbg;
     ctx.builder.SetCurrentDebugLocation(noDbg);
@@ -5200,11 +5200,11 @@ static Function* gen_cfun_wrapper(
                 Value *runtime_dt = ctx.builder.CreateAlignedLoad(T_prjlvalue,
                         ctx.builder.CreateConstInBoundsGEP1_32(T_prjlvalue, nestPtr, jl_array_len(*closure_types)),
                         Align(sizeof(void*)));
-                BasicBlock *boxedBB = BasicBlock::Create(jl_LLVMContext, "isboxed", cw);
-                BasicBlock *loadBB = BasicBlock::Create(jl_LLVMContext, "need-load", cw);
-                BasicBlock *unboxedBB = BasicBlock::Create(jl_LLVMContext, "maybe-unboxed", cw);
-                BasicBlock *isanyBB = BasicBlock::Create(jl_LLVMContext, "any", cw);
-                BasicBlock *afterBB = BasicBlock::Create(jl_LLVMContext, "after", cw);
+                BasicBlock *boxedBB = BasicBlock::Create(ctx.builder.getContext(), "isboxed", cw);
+                BasicBlock *loadBB = BasicBlock::Create(ctx.builder.getContext(), "need-load", cw);
+                BasicBlock *unboxedBB = BasicBlock::Create(ctx.builder.getContext(), "maybe-unboxed", cw);
+                BasicBlock *isanyBB = BasicBlock::Create(ctx.builder.getContext(), "any", cw);
+                BasicBlock *afterBB = BasicBlock::Create(ctx.builder.getContext(), "after", cw);
                 Value *isrtboxed = ctx.builder.CreateIsNull(val);
                 ctx.builder.CreateCondBr(isrtboxed, boxedBB, loadBB);
                 ctx.builder.SetInsertPoint(boxedBB);
@@ -5306,9 +5306,9 @@ static Function* gen_cfun_wrapper(
         Value *ret_jlcall;
         if (age_ok) {
             assert(theFptr);
-            b_generic = BasicBlock::Create(jl_LLVMContext, "generic", cw);
-            b_jlcall = BasicBlock::Create(jl_LLVMContext, "apply", cw);
-            b_after = BasicBlock::Create(jl_LLVMContext, "after", cw);
+            b_generic = BasicBlock::Create(ctx.builder.getContext(), "generic", cw);
+            b_jlcall = BasicBlock::Create(ctx.builder.getContext(), "apply", cw);
+            b_after = BasicBlock::Create(ctx.builder.getContext(), "after", cw);
             ctx.builder.CreateCondBr(age_ok, b_jlcall, b_generic);
             ctx.builder.SetInsertPoint(b_jlcall);
             // for jlcall, we need to pass the function object even if it is a ghost.
@@ -5486,7 +5486,7 @@ static Function* gen_cfun_wrapper(
                 GlobalVariable::ExternalLinkage,
                 funcName, M);
         jl_init_function(cw_make);
-        BasicBlock *b0 = BasicBlock::Create(jl_LLVMContext, "top", cw_make);
+        BasicBlock *b0 = BasicBlock::Create(ctx.builder.getContext(), "top", cw_make);
         IRBuilder<> cwbuilder(b0);
         Function::arg_iterator AI = cw_make->arg_begin();
         Argument *Tramp = &*AI; ++AI;
@@ -5732,13 +5732,13 @@ static Function *gen_invoke_wrapper(jl_method_instance_t *lam, jl_value_t *jlret
     //Value *mfunc = &*AI++; (void)mfunc; // unused
     assert(AI == w->arg_end());
 
-    jl_codectx_t ctx(jl_LLVMContext, params);
+    jl_codectx_t ctx(M->getContext(), params);
     ctx.f = w;
     ctx.linfo = lam;
     ctx.rettype = jlretty;
     ctx.world = 0;
 
-    BasicBlock *b0 = BasicBlock::Create(jl_LLVMContext, "top", w);
+    BasicBlock *b0 = BasicBlock::Create(ctx.builder.getContext(), "top", w);
     ctx.builder.SetInsertPoint(b0);
     DebugLoc noDbg;
     ctx.builder.SetCurrentDebugLocation(noDbg);
@@ -5865,7 +5865,7 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, String
             Type *AT = ArrayType::get(T_int8, props.union_bytes);
             fsig.push_back(AT->getPointerTo());
             Type *pair[] = { T_prjlvalue, T_int8 };
-            rt = StructType::get(jl_LLVMContext, makeArrayRef(pair));
+            rt = StructType::get(ctx.builder.getContext(), makeArrayRef(pair));
         }
         else if (allunbox) {
             props.cc = jl_returninfo_t::Ghosts;
@@ -5902,26 +5902,26 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, String
         assert(srt);
         unsigned argno = 1;
 #if JL_LLVM_VERSION < 120000
-        attributes = attributes.addAttribute(jl_LLVMContext, argno, Attribute::StructRet);
+        attributes = attributes.addAttribute(ctx.builder.getContext(), argno, Attribute::StructRet);
         (void)srt; // silence unused variable error
 #else
-        Attribute sret = Attribute::getWithStructRetType(jl_LLVMContext, srt);
-        attributes = addAttributeAtIndex(attributes, jl_LLVMContext, argno, sret);
+        Attribute sret = Attribute::getWithStructRetType(ctx.builder.getContext(), srt);
+        attributes = addAttributeAtIndex(attributes, ctx.builder.getContext(), argno, sret);
 #endif
-        attributes = addAttributeAtIndex(attributes, jl_LLVMContext, argno, Attribute::NoAlias);
-        attributes = addAttributeAtIndex(attributes, jl_LLVMContext, argno, Attribute::NoCapture);
+        attributes = addAttributeAtIndex(attributes, ctx.builder.getContext(), argno, Attribute::NoAlias);
+        attributes = addAttributeAtIndex(attributes, ctx.builder.getContext(), argno, Attribute::NoCapture);
     }
     if (props.cc == jl_returninfo_t::Union) {
         unsigned argno = 1;
-        attributes = addAttributeAtIndex(attributes, jl_LLVMContext, argno, Attribute::NoAlias);
-        attributes = addAttributeAtIndex(attributes, jl_LLVMContext, argno, Attribute::NoCapture);
+        attributes = addAttributeAtIndex(attributes, ctx.builder.getContext(), argno, Attribute::NoAlias);
+        attributes = addAttributeAtIndex(attributes, ctx.builder.getContext(), argno, Attribute::NoCapture);
     }
 
     if (props.return_roots) {
         fsig.push_back(ArrayType::get(T_prjlvalue, props.return_roots)->getPointerTo(0));
         unsigned argno = fsig.size();
-        attributes = addAttributeAtIndex(attributes, jl_LLVMContext, argno, Attribute::NoAlias);
-        attributes = addAttributeAtIndex(attributes, jl_LLVMContext, argno, Attribute::NoCapture);
+        attributes = addAttributeAtIndex(attributes, ctx.builder.getContext(), argno, Attribute::NoAlias);
+        attributes = addAttributeAtIndex(attributes, ctx.builder.getContext(), argno, Attribute::NoCapture);
     }
 
     for (size_t i = 0; i < jl_nparams(sig); i++) {
@@ -5937,17 +5937,17 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, String
             continue;
         unsigned argno = fsig.size();
         if (ty->isAggregateType()) { // aggregate types are passed by pointer
-            attributes = attributes.addParamAttribute(jl_LLVMContext, argno, Attribute::NoCapture);
-            attributes = attributes.addParamAttribute(jl_LLVMContext, argno, Attribute::ReadOnly);
+            attributes = attributes.addParamAttribute(ctx.builder.getContext(), argno, Attribute::NoCapture);
+            attributes = attributes.addParamAttribute(ctx.builder.getContext(), argno, Attribute::ReadOnly);
             ty = PointerType::get(ty, AddressSpace::Derived);
         }
         else if (isboxed && jl_is_immutable_datatype(jt)) {
-            attributes = attributes.addParamAttribute(jl_LLVMContext, argno, Attribute::ReadOnly);
+            attributes = attributes.addParamAttribute(ctx.builder.getContext(), argno, Attribute::ReadOnly);
         }
         else if (jl_is_primitivetype(jt) && ty->isIntegerTy()) {
             bool issigned = jl_signed_type && jl_subtype(jt, (jl_value_t*)jl_signed_type);
             Attribute::AttrKind attr = issigned ? Attribute::SExt : Attribute::ZExt;
-            attributes = attributes.addParamAttribute(jl_LLVMContext, argno, attr);
+            attributes = attributes.addParamAttribute(ctx.builder.getContext(), argno, attr);
         }
         fsig.push_back(ty);
     }
@@ -6166,7 +6166,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
     declarations.specFunctionObject = funcName.str();
 
     // allocate Function declarations and wrapper objects
-    Module *M = new Module(ctx.name, jl_LLVMContext);
+    Module *M = new Module(ctx.name, ctx.builder.getContext());
     jl_setup_module(M, ctx.params);
     jl_returninfo_t returninfo = {};
     Function *f = NULL;
@@ -6234,8 +6234,8 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
     }
 
     if (returninfo.cc == jl_returninfo_t::Union) {
-        addAttributeAtIndex(f, 1, Attribute::getWithDereferenceableBytes(jl_LLVMContext, returninfo.union_bytes));
-        addAttributeAtIndex(f, 1, Attribute::getWithAlignment(jl_LLVMContext, Align(returninfo.union_align)));
+        addAttributeAtIndex(f, 1, Attribute::getWithDereferenceableBytes(ctx.builder.getContext(), returninfo.union_bytes));
+        addAttributeAtIndex(f, 1, Attribute::getWithAlignment(ctx.builder.getContext(), Align(returninfo.union_align)));
     }
 
 #ifdef JL_DEBUG_BUILD
@@ -6311,7 +6311,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                                      ,nullptr          // Template Declaration
                                      ,nullptr          // ThrownTypes
                                      );
-        topdebugloc = DILocation::get(jl_LLVMContext, toplineno, 0, SP, NULL);
+        topdebugloc = DILocation::get(ctx.builder.getContext(), toplineno, 0, SP, NULL);
         f->setSubprogram(SP);
         if (jl_options.debug_level >= 2) {
             const bool AlwaysPreserve = true;
@@ -6363,7 +6363,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
     }
 
     // step 5. create first basic block
-    BasicBlock *b0 = BasicBlock::Create(jl_LLVMContext, "top", f);
+    BasicBlock *b0 = BasicBlock::Create(ctx.builder.getContext(), "top", f);
     ctx.builder.SetInsertPoint(b0);
     ctx.builder.SetCurrentDebugLocation(noDbg);
 
@@ -6745,7 +6745,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                 if (fname.empty())
                     fname = "macro expansion";
                 if (info.inlined_at == 0 && info.file == ctx.file) { // if everything matches, emit a toplevel line number
-                    info.loc = DILocation::get(jl_LLVMContext, info.line, 0, SP, NULL);
+                    info.loc = DILocation::get(ctx.builder.getContext(), info.line, 0, SP, NULL);
                 }
                 else { // otherwise, describe this as an inlining frame
                     DISubprogram *&inl_SP = subprograms[std::make_tuple(fname, info.file)];
@@ -6765,8 +6765,8 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                                                      ,nullptr          // ThrownTypes
                                                      );
                     }
-                    DebugLoc inl_loc = (info.inlined_at == 0) ? DebugLoc(DILocation::get(jl_LLVMContext, 0, 0, SP, NULL)) : linetable.at(info.inlined_at).loc;
-                    info.loc = DILocation::get(jl_LLVMContext, info.line, 0, inl_SP, inl_loc);
+                    DebugLoc inl_loc = (info.inlined_at == 0) ? DebugLoc(DILocation::get(ctx.builder.getContext(), 0, 0, SP, NULL)) : linetable.at(info.inlined_at).loc;
+                    info.loc = DILocation::get(ctx.builder.getContext(), info.line, 0, inl_SP, inl_loc);
                 }
             }
         }
@@ -6779,7 +6779,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
     {
         size_t nstmts = jl_array_len(stmts);
         aliasscopes.resize(nstmts + 1, nullptr);
-        MDBuilder mbuilder(jl_LLVMContext);
+        MDBuilder mbuilder(ctx.builder.getContext());
         MDNode *alias_domain = mbuilder.createAliasScopeDomain(ctx.name);
         for (i = 0; i < nstmts; i++) {
             jl_value_t *stmt = jl_array_ptr_ref(stmts, i);
@@ -6788,7 +6788,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                 if (expr->head == jl_aliasscope_sym) {
                     MDNode *scope = mbuilder.createAliasScope("aliasscope", alias_domain);
                     scope_stack.push_back(scope);
-                    MDNode *scope_list = MDNode::get(jl_LLVMContext, ArrayRef<Metadata*>(scope_stack));
+                    MDNode *scope_list = MDNode::get(ctx.builder.getContext(), ArrayRef<Metadata*>(scope_stack));
                     scope_list_stack.push_back(scope_list);
                     current_aliasscope = scope_list;
                 } else if (expr->head == jl_popaliasscope_sym) {
@@ -6940,7 +6940,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
     }
 
     for (int label : branch_targets) {
-        BasicBlock *bb = BasicBlock::Create(jl_LLVMContext,
+        BasicBlock *bb = BasicBlock::Create(ctx.builder.getContext(),
             "L" + std::to_string(label), f);
         BB[label] = bb;
     }
@@ -7121,7 +7121,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
             // We need to mark this on the call site as well. See issue #6757
             sj->setCanReturnTwice();
             Value *isz = ctx.builder.CreateICmpEQ(sj, ConstantInt::get(T_int32, 0));
-            BasicBlock *tryblk = BasicBlock::Create(jl_LLVMContext, "try", f);
+            BasicBlock *tryblk = BasicBlock::Create(ctx.builder.getContext(), "try", f);
             BasicBlock *handlr = NULL;
             handlr = BB[lname];
             workstack.push_back(lname - 1);
@@ -7764,17 +7764,17 @@ static void init_julia_llvm_env(Module *m)
 {
     // every variable or function mapped in this function must be
     // exported from libjulia, to support static compilation
-    T_int1  = Type::getInt1Ty(jl_LLVMContext);
-    T_int8  = Type::getInt8Ty(jl_LLVMContext);
+    T_int1  = Type::getInt1Ty(m->getContext());
+    T_int8  = Type::getInt8Ty(m->getContext());
     T_pint8 = PointerType::get(T_int8, 0);
     T_ppint8 = PointerType::get(T_pint8, 0);
     T_pppint8 = PointerType::get(T_ppint8, 0);
-    T_int16 = Type::getInt16Ty(jl_LLVMContext);
+    T_int16 = Type::getInt16Ty(m->getContext());
     T_pint16 = PointerType::get(T_int16, 0);
-    T_int32 = Type::getInt32Ty(jl_LLVMContext);
-    T_char = Type::getInt32Ty(jl_LLVMContext);
+    T_int32 = Type::getInt32Ty(m->getContext());
+    T_char = Type::getInt32Ty(m->getContext());
     T_pint32 = PointerType::get(T_int32, 0);
-    T_int64 = Type::getInt64Ty(jl_LLVMContext);
+    T_int64 = Type::getInt64Ty(m->getContext());
     T_pint64 = PointerType::get(T_int64, 0);
     T_uint8 = T_int8;   T_uint16 = T_int16;
     T_uint32 = T_int32; T_uint64 = T_int64;
@@ -7782,15 +7782,15 @@ static void init_julia_llvm_env(Module *m)
         T_size = T_uint64;
     else
         T_size = T_uint32;
-    T_sigatomic = Type::getIntNTy(jl_LLVMContext, sizeof(sig_atomic_t) * 8);
+    T_sigatomic = Type::getIntNTy(m->getContext(), sizeof(sig_atomic_t) * 8);
     T_psize = PointerType::get(T_size, 0);
-    T_float16 = Type::getHalfTy(jl_LLVMContext);
-    T_float32 = Type::getFloatTy(jl_LLVMContext);
+    T_float16 = Type::getHalfTy(m->getContext());
+    T_float32 = Type::getFloatTy(m->getContext());
     T_pfloat32 = PointerType::get(T_float32, 0);
-    T_float64 = Type::getDoubleTy(jl_LLVMContext);
+    T_float64 = Type::getDoubleTy(m->getContext());
     T_pfloat64 = PointerType::get(T_float64, 0);
-    T_float128 = Type::getFP128Ty(jl_LLVMContext);
-    T_void = Type::getVoidTy(jl_LLVMContext);
+    T_float128 = Type::getFP128Ty(m->getContext());
+    T_void = Type::getVoidTy(m->getContext());
     T_pvoidfunc = FunctionType::get(T_void, /*isVarArg*/false)->getPointerTo();
 
     // add needed base debugging definitions to our LLVM environment
@@ -7829,7 +7829,7 @@ static void init_julia_llvm_env(Module *m)
     jl_di_func_null_sig = dbuilder.createSubroutineType(
         dbuilder.getOrCreateTypeArray(None));
 
-    T_jlvalue = StructType::get(jl_LLVMContext);
+    T_jlvalue = StructType::get(m->getContext());
     T_pjlvalue = PointerType::get(T_jlvalue, 0);
     T_prjlvalue = PointerType::get(T_jlvalue, AddressSpace::Tracked);
     T_ppjlvalue = PointerType::get(T_pjlvalue, 0);
@@ -7853,7 +7853,7 @@ static void init_julia_llvm_env(Module *m)
     };
     static_assert(sizeof(jl_array_flags_t) == sizeof(int16_t),
                   "Size of jl_array_flags_t is not the same as int16_t");
-    jl_array_llvmt = StructType::get(jl_LLVMContext, makeArrayRef(vaelts));
+    jl_array_llvmt = StructType::get(m->getContext(), makeArrayRef(vaelts));
     jl_parray_llvmt = PointerType::get(jl_array_llvmt, 0);
 }
 


### PR DESCRIPTION
This PR removes most of the uses of the global jl_LLVMContext whenever an LLVMContext argument is implicitly passed into the function. 