### PR TITLE
Remove global basic integer types

### DIFF
--- a/src/abi_ppc64le.cpp
+++ b/src/abi_ppc64le.cpp
@@ -125,10 +125,10 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret, LLVMContext &ctx) const
     int hfa = isHFA(dt, &ty0, &hva);
     if (hfa <= 8) {
         if (ty0 == jl_float32_type) {
-            return ArrayType::get(T_float32, hfa);
+            return ArrayType::get(llvm::Type::getFloatTy(ctx), hfa);
         }
         else if (ty0 == jl_float64_type) {
-            return ArrayType::get(T_float64, hfa);
+            return ArrayType::get(llvm::Type::getDoubleTy(ctx), hfa);
         }
         else {
             jl_datatype_t *vecty = (jl_datatype_t*)jl_field_type(ty0, 0);

--- a/src/abi_ppc64le.cpp
+++ b/src/abi_ppc64le.cpp
@@ -133,7 +133,7 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret, LLVMContext &ctx) const
         else {
             jl_datatype_t *vecty = (jl_datatype_t*)jl_field_type(ty0, 0);
             assert(jl_is_datatype(vecty) && vecty->name == jl_vecelement_typename);
-            Type *ety = bitstype_to_llvm(jl_tparam0(vecty));
+            Type *ety = bitstype_to_llvm(jl_tparam0(vecty), ctx);
             Type *vty = FixedVectorType::get(ety, jl_datatype_nfields(ty0));
             return ArrayType::get(vty, hfa);
         }

--- a/src/abi_x86.cpp
+++ b/src/abi_x86.cpp
@@ -82,7 +82,7 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret, LLVMContext &ctx) const
         return NULL;
     // special case Complex{Float32} as a return type
     if (is_complex64(dt))
-        return T_int64;
+        return llvm::Type::getInt64Ty(ctx);
     return NULL;
 }
 

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1106,7 +1106,7 @@ std::string generate_func_sig(const char *fname)
                 if (pat->isIntegerTy() && pat->getPrimitiveSizeInBits() < sizeof(int) * 8)
                     pat = llvm::Type::getInt32Ty(lrt->getContext());
                 if (pat->isFloatingPointTy() && pat->getPrimitiveSizeInBits() < sizeof(double) * 8)
-                    pat = T_float64;
+                    pat = llvm::Type::getDoubleTy(lrt->getContext());
                 ab.removeAttribute(Attribute::SExt);
                 ab.removeAttribute(Attribute::ZExt);
             }

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -122,7 +122,7 @@ static Value *runtime_sym_lookup(
         }
         else {
             // f_lib is actually one of the special sentinel values
-            libname = ConstantExpr::getIntToPtr(ConstantInt::get(T_size, (uintptr_t)f_lib), T_pint8);
+            libname = ConstantExpr::getIntToPtr(ConstantInt::get(getSizeTy(irbuilder.getContext()), (uintptr_t)f_lib), T_pint8);
         }
         llvmf = irbuilder.CreateCall(prepare_call_in(jl_builderModule(irbuilder), jldlsym_func),
                     { libname, nameval, libptrgv });
@@ -236,7 +236,7 @@ static GlobalVariable *emit_plt_thunk(
         if (!attrs.hasAttrSomewhere(Attribute::ByVal))
             ret->setTailCallKind(CallInst::TCK_MustTail);
 #endif
-        if (functype->getReturnType() == T_void) {
+        if (functype->getReturnType() == getVoidTy(irbuilder.getContext())) {
             irbuilder.CreateRetVoid();
         }
         else {
@@ -355,7 +355,7 @@ static Value *llvm_type_rewrite(
     if (target_type == from_type)
         return v;
 
-    if (from_type == T_void || isa<UndefValue>(v))
+    if (from_type == getVoidTy(ctx.builder.getContext()) || isa<UndefValue>(v))
         return UndefValue::get(target_type); // convert undef (unreachable) -> undef (target_type)
 
     assert(from_type->isPointerTy() == target_type->isPointerTy()); // expect that all ABIs consider all pointers to be equivalent
@@ -418,7 +418,7 @@ static Value *runtime_apply_type_env(jl_codectx_t &ctx, jl_value_t *ty)
         ctx.builder.CreateInBoundsGEP(
                 T_prjlvalue,
                 ctx.spvals_ptr,
-                ConstantInt::get(T_size, sizeof(jl_svec_t) / sizeof(jl_value_t*)))
+                ConstantInt::get(getSizeTy(ctx.builder.getContext()), sizeof(jl_svec_t) / sizeof(jl_value_t*)))
     };
     auto call = ctx.builder.CreateCall(prepare_call(jlapplytype_func), makeArrayRef(args));
     addRetAttr(call, Attribute::getWithAlignment(ctx.builder.getContext(), Align(16)));
@@ -459,7 +459,7 @@ static void typeassert_input(jl_codectx_t &ctx, const jl_cgval_t &jvinfo, jl_val
                 Value *vx = boxed(ctx, jvinfo);
                 Value *istype = ctx.builder.CreateICmpNE(
                         ctx.builder.CreateCall(prepare_call(jlisa_func), { vx, boxed(ctx, jlto_runtime) }),
-                        ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 0));
+                        ConstantInt::get(getInt32Ty(ctx.builder.getContext()), 0));
                 BasicBlock *failBB = BasicBlock::Create(ctx.builder.getContext(), "fail", ctx.f);
                 BasicBlock *passBB = BasicBlock::Create(ctx.builder.getContext(), "pass", ctx.f);
                 ctx.builder.CreateCondBr(istype, passBB, failBB);
@@ -552,7 +552,7 @@ static void interpret_symbol_arg(jl_codectx_t &ctx, native_sym_arg_t &out, jl_va
             emit_cpointercheck(ctx, arg1, errmsg);
         }
         arg1 = update_julia_type(ctx, arg1, (jl_value_t*)jl_voidpointer_type);
-        jl_ptr = emit_unbox(ctx, T_size, arg1, (jl_value_t*)jl_voidpointer_type);
+        jl_ptr = emit_unbox(ctx, getSizeTy(ctx.builder.getContext()), arg1, (jl_value_t*)jl_voidpointer_type);
     }
     else {
         out.gcroot = ptr;
@@ -639,7 +639,7 @@ static jl_cgval_t emit_cglobal(jl_codectx_t &ctx, jl_value_t **args, size_t narg
     else {
         rt = (jl_value_t*)jl_voidpointer_type;
     }
-    Type *lrt = T_size;
+    Type *lrt = getSizeTy(ctx.builder.getContext());
     assert(lrt == julia_type_to_llvm(ctx, rt));
 
     interpret_symbol_arg(ctx, sym, args[1], "cglobal", false);
@@ -989,12 +989,12 @@ public:
         err_msg = generate_func_sig(fname);
     }
 
-    FunctionType *functype() const {
+    FunctionType *functype(LLVMContext &ctxt) const {
         assert(err_msg.empty());
         if (nreqargs > 0)
-            return FunctionType::get(sret ? T_void : prt, makeArrayRef(fargt_sig).slice(0, nreqargs), true);
+            return FunctionType::get(sret ? getVoidTy(ctxt) : prt, makeArrayRef(fargt_sig).slice(0, nreqargs), true);
         else
-            return FunctionType::get(sret ? T_void : prt, fargt_sig, false);
+            return FunctionType::get(sret ? getVoidTy(ctxt) : prt, fargt_sig, false);
     }
 
     jl_cgval_t emit_a_ccall(
@@ -1018,7 +1018,7 @@ std::string generate_func_sig(const char *fname)
     sret = 0;
 
     if (type_is_ghost(lrt)) {
-        prt = lrt = T_void;
+        prt = lrt = getVoidTy(lrt->getContext());
         abi->use_sret(jl_nothing_type, lrt->getContext());
     }
     else {
@@ -1073,7 +1073,7 @@ std::string generate_func_sig(const char *fname)
             }
 
             t = _julia_struct_to_llvm(ctx, lrt->getContext(), tti, &isboxed, llvmcall);
-            if (t == NULL || t == T_void) {
+            if (t == NULL || t == getVoidTy(lrt->getContext())) {
                 return make_errmsg(fname, i + 1, " doesn't correspond to a C type");
             }
         }
@@ -1104,9 +1104,9 @@ std::string generate_func_sig(const char *fname)
             // so attempt to do that coercion here
             if (!llvmcall && cc == CallingConv::C) {
                 if (pat->isIntegerTy() && pat->getPrimitiveSizeInBits() < sizeof(int) * 8)
-                    pat = llvm::Type::getInt32Ty(lrt->getContext());
+                    pat = getInt32Ty(lrt->getContext());
                 if (pat->isFloatingPointTy() && pat->getPrimitiveSizeInBits() < sizeof(double) * 8)
-                    pat = llvm::Type::getDoubleTy(lrt->getContext());
+                    pat = getDoubleTy(lrt->getContext());
                 ab.removeAttribute(Attribute::SExt);
                 ab.removeAttribute(Attribute::ZExt);
             }
@@ -1374,7 +1374,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
     bool isVa = nreqargs > 0;
     (void)isVa; // prevent compiler warning
     if (is_libjulia_func(jl_array_ptr)) {
-        assert(lrt == T_size);
+        assert(lrt == getSizeTy(ctx.builder.getContext()));
         assert(!isVa && !llvmcall && nccallargs == 1);
         const jl_cgval_t &ary = argv[0];
         JL_GC_POP();
@@ -1382,7 +1382,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
                                         retboxed, rt, unionall, static_rt);
     }
     else if (is_libjulia_func(jl_value_ptr)) {
-        assert(retboxed ? lrt == T_prjlvalue : lrt == T_size);
+        assert(retboxed ? lrt == T_prjlvalue : lrt == getSizeTy(ctx.builder.getContext()));
         assert(!isVa && !llvmcall && nccallargs == 1);
         jl_value_t *tti = jl_svecref(at, 0);
         Value *ary;
@@ -1390,7 +1390,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         bool isboxed;
         if (jl_is_abstract_ref_type(tti)) {
             tti = (jl_value_t*)jl_voidpointer_type;
-            largty = T_size;
+            largty = getSizeTy(ctx.builder.getContext());
             isboxed = false;
         }
         else {
@@ -1408,7 +1408,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
                     ctx,
                     ctx.builder.CreatePtrToInt(
                         emit_pointer_from_objref(ctx, emit_bitcast(ctx, ary, T_prjlvalue)),
-                        T_size),
+                        getSizeTy(ctx.builder.getContext())),
                     retboxed, rt, unionall, static_rt);
         }
         else {
@@ -1422,18 +1422,18 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
     }
     else if (is_libjulia_func(jl_cpu_pause)) {
         // Keep in sync with the julia_threads.h version
-        assert(lrt == T_void);
+        assert(lrt == getVoidTy(ctx.builder.getContext()));
         assert(!isVa && !llvmcall && nccallargs == 0);
 #ifdef __MIC__
         // TODO
 #elif defined(_CPU_X86_64_) || defined(_CPU_X86_)  /* !__MIC__ */
-        static auto pauseinst = InlineAsm::get(FunctionType::get(T_void, false), "pause",
+        static auto pauseinst = InlineAsm::get(FunctionType::get(getVoidTy(ctx.builder.getContext()), false), "pause",
                                                "~{memory}", true);
         ctx.builder.CreateCall(pauseinst);
         JL_GC_POP();
         return ghostValue(jl_nothing_type, ctx.tbaa());
 #elif defined(_CPU_AARCH64_) || (defined(_CPU_ARM_) && __ARM_ARCH >= 7)
-        static auto wfeinst = InlineAsm::get(FunctionType::get(T_void, false), "wfe",
+        static auto wfeinst = InlineAsm::get(FunctionType::get(getVoidTy(ctx.builder.getContext()), false), "wfe",
                                              "~{memory}", true);
         ctx.builder.CreateCall(wfeinst);
         JL_GC_POP();
@@ -1445,13 +1445,13 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
     }
     else if (is_libjulia_func(jl_cpu_wake)) {
         // Keep in sync with the julia_threads.h version
-        assert(lrt == T_void);
+        assert(lrt == getVoidTy(ctx.builder.getContext()));
         assert(!isVa && !llvmcall && nccallargs == 0);
 #if JL_CPU_WAKE_NOOP == 1
         JL_GC_POP();
         return ghostValue(jl_nothing_type, ctx.tbaa());
 #elif defined(_CPU_AARCH64_) || (defined(_CPU_ARM_) && __ARM_ARCH >= 7)
-        static auto sevinst = InlineAsm::get(FunctionType::get(T_void, false), "sev",
+        static auto sevinst = InlineAsm::get(FunctionType::get(getVoidTy(ctx.builder.getContext()), false), "sev",
                                              "~{memory}", true);
         ctx.builder.CreateCall(sevinst);
         JL_GC_POP();
@@ -1459,17 +1459,17 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
 #endif
     }
     else if (is_libjulia_func(jl_gc_safepoint)) {
-        assert(lrt == T_void);
+        assert(lrt == getVoidTy(ctx.builder.getContext()));
         assert(!isVa && !llvmcall && nccallargs == 0);
         JL_GC_POP();
         ctx.builder.CreateCall(prepare_call(gcroot_flush_func));
         emit_signal_fence(ctx);
-        ctx.builder.CreateLoad(T_size, get_current_signal_page(ctx), true);
+        ctx.builder.CreateLoad(getSizeTy(ctx.builder.getContext()), get_current_signal_page(ctx), true);
         emit_signal_fence(ctx);
         return ghostValue(jl_nothing_type, ctx.tbaa());
     }
     else if (is_libjulia_func("jl_get_ptls_states")) {
-        assert(lrt == T_size);
+        assert(lrt == getSizeTy(ctx.builder.getContext()));
         assert(!isVa && !llvmcall && nccallargs == 0);
         JL_GC_POP();
         return mark_or_box_ccall_result(ctx,
@@ -1477,13 +1477,13 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
             retboxed, rt, unionall, static_rt);
     }
     else if (is_libjulia_func(jl_threadid)) {
-        assert(lrt == llvm::Type::getInt16Ty(ctx.builder.getContext()));
+        assert(lrt == getInt16Ty(ctx.builder.getContext()));
         assert(!isVa && !llvmcall && nccallargs == 0);
         JL_GC_POP();
         Value *ptask_i16 = emit_bitcast(ctx, get_current_task(ctx), T_pint16);
         const int tid_offset = offsetof(jl_task_t, tid);
-        Value *ptid = ctx.builder.CreateInBoundsGEP(llvm::Type::getInt16Ty(ctx.builder.getContext()), ptask_i16, ConstantInt::get(T_size, tid_offset / sizeof(int16_t)));
-        LoadInst *tid = ctx.builder.CreateAlignedLoad(llvm::Type::getInt16Ty(ctx.builder.getContext()), ptid, Align(sizeof(int16_t)));
+        Value *ptid = ctx.builder.CreateInBoundsGEP(getInt16Ty(ctx.builder.getContext()), ptask_i16, ConstantInt::get(getSizeTy(ctx.builder.getContext()), tid_offset / sizeof(int16_t)));
+        LoadInst *tid = ctx.builder.CreateAlignedLoad(getInt16Ty(ctx.builder.getContext()), ptid, Align(sizeof(int16_t)));
         tbaa_decorate(ctx.tbaa().tbaa_gcframe, tid);
         return mark_or_box_ccall_result(ctx, tid, retboxed, rt, unionall, static_rt);
     }
@@ -1495,16 +1495,16 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         JL_GC_POP();
         Value *ptls_i32 = emit_bitcast(ctx, get_current_ptls(ctx), T_pint32);
         const int finh_offset = offsetof(jl_tls_states_t, finalizers_inhibited);
-        Value *pfinh = ctx.builder.CreateInBoundsGEP(llvm::Type::getInt32Ty(ctx.builder.getContext()), ptls_i32, ConstantInt::get(T_size, finh_offset / 4));
-        LoadInst *finh = ctx.builder.CreateAlignedLoad(llvm::Type::getInt32Ty(ctx.builder.getContext()), pfinh, Align(sizeof(int32_t)));
+        Value *pfinh = ctx.builder.CreateInBoundsGEP(getInt32Ty(ctx.builder.getContext()), ptls_i32, ConstantInt::get(getSizeTy(ctx.builder.getContext()), finh_offset / 4));
+        LoadInst *finh = ctx.builder.CreateAlignedLoad(getInt32Ty(ctx.builder.getContext()), pfinh, Align(sizeof(int32_t)));
         Value *newval;
         if (is_libjulia_func(jl_gc_disable_finalizers_internal)) {
-            newval = ctx.builder.CreateAdd(finh, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 1));
+            newval = ctx.builder.CreateAdd(finh, ConstantInt::get(getInt32Ty(ctx.builder.getContext()), 1));
         }
         else {
-            newval = ctx.builder.CreateSelect(ctx.builder.CreateICmpEQ(finh, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 0)),
-                                              ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 0),
-                                              ctx.builder.CreateSub(finh, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 1)));
+            newval = ctx.builder.CreateSelect(ctx.builder.CreateICmpEQ(finh, ConstantInt::get(getInt32Ty(ctx.builder.getContext()), 0)),
+                                              ConstantInt::get(getInt32Ty(ctx.builder.getContext()), 0),
+                                              ctx.builder.CreateSub(finh, ConstantInt::get(getInt32Ty(ctx.builder.getContext()), 1)));
         }
         ctx.builder.CreateStore(newval, pfinh);
         return ghostValue(jl_nothing_type, ctx.tbaa());
@@ -1517,17 +1517,17 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         return mark_or_box_ccall_result(ctx, ct, retboxed, rt, unionall, static_rt);
     }
     else if (is_libjulia_func(jl_set_next_task)) {
-        assert(lrt == T_void);
+        assert(lrt == getVoidTy(ctx.builder.getContext()));
         assert(!isVa && !llvmcall && nccallargs == 1);
         JL_GC_POP();
         Value *ptls_pv = emit_bitcast(ctx, get_current_ptls(ctx), T_ppjlvalue);
         const int nt_offset = offsetof(jl_tls_states_t, next_task);
-        Value *pnt = ctx.builder.CreateInBoundsGEP(T_pjlvalue, ptls_pv, ConstantInt::get(T_size, nt_offset / sizeof(void*)));
+        Value *pnt = ctx.builder.CreateInBoundsGEP(T_pjlvalue, ptls_pv, ConstantInt::get(getSizeTy(ctx.builder.getContext()), nt_offset / sizeof(void*)));
         ctx.builder.CreateStore(emit_pointer_from_objref(ctx, boxed(ctx, argv[0])), pnt);
         return ghostValue(jl_nothing_type, ctx.tbaa());
     }
     else if (is_libjulia_func(jl_sigatomic_begin)) {
-        assert(lrt == T_void);
+        assert(lrt == getVoidTy(ctx.builder.getContext()));
         assert(!isVa && !llvmcall && nccallargs == 0);
         JL_GC_POP();
         ctx.builder.CreateCall(prepare_call(gcroot_flush_func));
@@ -1539,7 +1539,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         return ghostValue(jl_nothing_type, ctx.tbaa());
     }
     else if (is_libjulia_func(jl_sigatomic_end)) {
-        assert(lrt == T_void);
+        assert(lrt == getVoidTy(ctx.builder.getContext()));
         assert(!isVa && !llvmcall && nccallargs == 0);
         JL_GC_POP();
         ctx.builder.CreateCall(prepare_call(gcroot_flush_func));
@@ -1561,8 +1561,8 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
                 checkBB, contBB);
         ctx.builder.SetInsertPoint(checkBB);
         ctx.builder.CreateLoad(
-                T_size,
-                ctx.builder.CreateConstInBoundsGEP1_32(T_size, get_current_signal_page(ctx), -1),
+                getSizeTy(ctx.builder.getContext()),
+                ctx.builder.CreateConstInBoundsGEP1_32(getSizeTy(ctx.builder.getContext()), get_current_signal_page(ctx), -1),
                 true);
         ctx.builder.CreateBr(contBB);
         ctx.f->getBasicBlockList().push_back(contBB);
@@ -1575,18 +1575,18 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         Value *len;
         if (svecv.constant && svecv.typ == (jl_value_t*)jl_simplevector_type) {
             // Check the type as well before we call
-            len = ConstantInt::get(T_size, jl_svec_len(svecv.constant));
+            len = ConstantInt::get(getSizeTy(ctx.builder.getContext()), jl_svec_len(svecv.constant));
         }
         else {
             auto ptr = emit_bitcast(ctx, boxed(ctx, svecv), T_psize);
-            len = ctx.builder.CreateAlignedLoad(T_size, ptr, Align(sizeof(size_t)));
+            len = ctx.builder.CreateAlignedLoad(getSizeTy(ctx.builder.getContext()), ptr, Align(sizeof(size_t)));
             // Only mark with TBAA if we are sure about the type.
             // This could otherwise be in a dead branch
             if (svecv.typ == (jl_value_t*)jl_simplevector_type)
                 tbaa_decorate(ctx.tbaa().tbaa_const, cast<Instruction>(len));
             MDBuilder MDB(ctx.builder.getContext());
             auto rng = MDB.createRange(
-                Constant::getNullValue(T_size), ConstantInt::get(T_size, INTPTR_MAX / sizeof(void*) - 1));
+                Constant::getNullValue(getSizeTy(ctx.builder.getContext())), ConstantInt::get(getSizeTy(ctx.builder.getContext()), INTPTR_MAX / sizeof(void*) - 1));
             cast<LoadInst>(len)->setMetadata(LLVMContext::MD_range, rng);
         }
         JL_GC_POP();
@@ -1597,8 +1597,8 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         assert(!isVa && !llvmcall && nccallargs == 2);
         const jl_cgval_t &svecv = argv[0];
         const jl_cgval_t &idxv = argv[1];
-        Value *idx = emit_unbox(ctx, T_size, idxv, (jl_value_t*)jl_long_type);
-        idx = ctx.builder.CreateAdd(idx, ConstantInt::get(T_size, 1));
+        Value *idx = emit_unbox(ctx, getSizeTy(ctx.builder.getContext()), idxv, (jl_value_t*)jl_long_type);
+        idx = ctx.builder.CreateAdd(idx, ConstantInt::get(getSizeTy(ctx.builder.getContext()), 1));
         auto ptr = emit_bitcast(ctx, boxed(ctx, svecv), T_pprjlvalue);
         Value *slot_addr = ctx.builder.CreateInBoundsGEP(T_prjlvalue,
                                                          decay_derived(ctx, ptr), idx);
@@ -1609,7 +1609,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         // This could otherwise be in a dead branch
         if (svecv.typ == (jl_value_t*)jl_simplevector_type)
             tbaa_decorate(ctx.tbaa().tbaa_const, load);
-        Value *res = ctx.builder.CreateZExt(ctx.builder.CreateICmpNE(load, Constant::getNullValue(T_prjlvalue)), llvm::Type::getInt8Ty(ctx.builder.getContext()));
+        Value *res = ctx.builder.CreateZExt(ctx.builder.CreateICmpNE(load, Constant::getNullValue(T_prjlvalue)), getInt8Ty(ctx.builder.getContext()));
         JL_GC_POP();
         return mark_or_box_ccall_result(ctx, res, retboxed, rt, unionall, static_rt);
     }
@@ -1618,8 +1618,8 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         assert(!isVa && !llvmcall && nccallargs == 2);
         const jl_cgval_t &svecv = argv[0];
         const jl_cgval_t &idxv = argv[1];
-        Value *idx = emit_unbox(ctx, T_size, idxv, (jl_value_t*)jl_long_type);
-        idx = ctx.builder.CreateAdd(idx, ConstantInt::get(T_size, 1));
+        Value *idx = emit_unbox(ctx, getSizeTy(ctx.builder.getContext()), idxv, (jl_value_t*)jl_long_type);
+        idx = ctx.builder.CreateAdd(idx, ConstantInt::get(getSizeTy(ctx.builder.getContext()), 1));
         auto ptr = emit_bitcast(ctx, boxed(ctx, svecv), T_pprjlvalue);
         Value *slot_addr = ctx.builder.CreateInBoundsGEP(T_prjlvalue,
                                                          decay_derived(ctx, ptr), idx);
@@ -1646,44 +1646,44 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
             bool ptrarray = !jl_stored_inline(ety);
             if (!ptrarray && !jl_type_hasptr(ety)) {
                 JL_GC_POP();
-                return mark_or_box_ccall_result(ctx, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 1),
+                return mark_or_box_ccall_result(ctx, ConstantInt::get(getInt32Ty(ctx.builder.getContext()), 1),
                                                 false, rt, unionall, static_rt);
             }
             else if (!jl_has_free_typevars(ety)) {
-                Value *idx = emit_unbox(ctx, T_size, idxv, (jl_value_t*)jl_ulong_type);
+                Value *idx = emit_unbox(ctx, getSizeTy(ctx.builder.getContext()), idxv, (jl_value_t*)jl_ulong_type);
                 Value *arrayptr = emit_bitcast(ctx, emit_arrayptr(ctx, aryv, aryex), T_pprjlvalue);
                 if (!ptrarray) {
                     size_t elsz = jl_datatype_size(ety);
                     unsigned align = jl_datatype_align(ety);
                     size_t stride = LLT_ALIGN(elsz, align) / sizeof(jl_value_t*);
                     if (stride != 1)
-                        idx = ctx.builder.CreateMul(idx, ConstantInt::get(T_size, stride));
-                    idx = ctx.builder.CreateAdd(idx, ConstantInt::get(T_size, ((jl_datatype_t*)ety)->layout->first_ptr));
+                        idx = ctx.builder.CreateMul(idx, ConstantInt::get(getSizeTy(ctx.builder.getContext()), stride));
+                    idx = ctx.builder.CreateAdd(idx, ConstantInt::get(getSizeTy(ctx.builder.getContext()), ((jl_datatype_t*)ety)->layout->first_ptr));
                 }
                 Value *slot_addr = ctx.builder.CreateInBoundsGEP(T_prjlvalue, arrayptr, idx);
                 LoadInst *load = ctx.builder.CreateAlignedLoad(T_prjlvalue, slot_addr, Align(sizeof(void*)));
                 load->setAtomic(AtomicOrdering::Unordered);
                 tbaa_decorate(ctx.tbaa().tbaa_ptrarraybuf, load);
-                Value *res = ctx.builder.CreateZExt(ctx.builder.CreateICmpNE(load, Constant::getNullValue(T_prjlvalue)), llvm::Type::getInt32Ty(ctx.builder.getContext()));
+                Value *res = ctx.builder.CreateZExt(ctx.builder.CreateICmpNE(load, Constant::getNullValue(T_prjlvalue)), getInt32Ty(ctx.builder.getContext()));
                 JL_GC_POP();
                 return mark_or_box_ccall_result(ctx, res, retboxed, rt, unionall, static_rt);
             }
         }
     }
     else if (is_libjulia_func(jl_string_ptr)) {
-        assert(lrt == T_size);
+        assert(lrt == getSizeTy(ctx.builder.getContext()));
         assert(!isVa && !llvmcall && nccallargs == 1);
         auto obj = emit_bitcast(ctx, emit_pointer_from_objref(ctx, boxed(ctx, argv[0])),
                                 T_pprjlvalue);
         // The inbounds gep makes it more clear to LLVM that the resulting value is not
         // a null pointer.
         auto strp = ctx.builder.CreateConstInBoundsGEP1_32(T_prjlvalue, obj, 1);
-        strp = ctx.builder.CreatePtrToInt(strp, T_size);
+        strp = ctx.builder.CreatePtrToInt(strp, getSizeTy(ctx.builder.getContext()));
         JL_GC_POP();
         return mark_or_box_ccall_result(ctx, strp, retboxed, rt, unionall, static_rt);
     }
     else if (is_libjulia_func(jl_symbol_name)) {
-        assert(lrt == T_size);
+        assert(lrt == getSizeTy(ctx.builder.getContext()));
         assert(!isVa && !llvmcall && nccallargs == 1);
         auto obj = emit_bitcast(ctx, emit_pointer_from_objref(ctx, boxed(ctx, argv[0])),
                                 T_pprjlvalue);
@@ -1691,7 +1691,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         // a null pointer.
         auto strp = ctx.builder.CreateConstInBoundsGEP1_32(
             T_prjlvalue, obj, (sizeof(jl_sym_t) + sizeof(void*) - 1) / sizeof(void*));
-        strp = ctx.builder.CreatePtrToInt(strp, T_size);
+        strp = ctx.builder.CreatePtrToInt(strp, getSizeTy(ctx.builder.getContext()));
         JL_GC_POP();
         return mark_or_box_ccall_result(ctx, strp, retboxed, rt, unionall, static_rt);
     }
@@ -1699,16 +1699,16 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         const jl_cgval_t &dst = argv[0];
         const jl_cgval_t &src = argv[1];
         const jl_cgval_t &n = argv[2];
-        Value *destp = emit_unbox(ctx, T_size, dst, (jl_value_t*)jl_voidpointer_type);
+        Value *destp = emit_unbox(ctx, getSizeTy(ctx.builder.getContext()), dst, (jl_value_t*)jl_voidpointer_type);
 
         ctx.builder.CreateMemCpy(
                 emit_inttoptr(ctx, destp, T_pint8),
                 MaybeAlign(1),
                 emit_inttoptr(ctx,
-                    emit_unbox(ctx, T_size, src, (jl_value_t*)jl_voidpointer_type),
+                    emit_unbox(ctx, getSizeTy(ctx.builder.getContext()), src, (jl_value_t*)jl_voidpointer_type),
                     T_pint8),
                 MaybeAlign(0),
-                emit_unbox(ctx, T_size, n, (jl_value_t*)jl_ulong_type),
+                emit_unbox(ctx, getSizeTy(ctx.builder.getContext()), n, (jl_value_t*)jl_ulong_type),
                 false);
         JL_GC_POP();
         return rt == (jl_value_t*)jl_nothing_type ? ghostValue(jl_nothing_type, ctx.tbaa()) :
@@ -1718,13 +1718,13 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         const jl_cgval_t &dst = argv[0];
         const jl_cgval_t &val = argv[1];
         const jl_cgval_t &n = argv[2];
-        Value *destp = emit_unbox(ctx, T_size, dst, (jl_value_t*)jl_voidpointer_type);
-        Value *val32 = emit_unbox(ctx, llvm::Type::getInt32Ty(ctx.builder.getContext()), val, (jl_value_t*)jl_uint32_type);
-        Value *val8 = ctx.builder.CreateTrunc(val32, llvm::Type::getInt8Ty(ctx.builder.getContext()), "memset_val");
+        Value *destp = emit_unbox(ctx, getSizeTy(ctx.builder.getContext()), dst, (jl_value_t*)jl_voidpointer_type);
+        Value *val32 = emit_unbox(ctx, getInt32Ty(ctx.builder.getContext()), val, (jl_value_t*)jl_uint32_type);
+        Value *val8 = ctx.builder.CreateTrunc(val32, getInt8Ty(ctx.builder.getContext()), "memset_val");
         ctx.builder.CreateMemSet(
             emit_inttoptr(ctx, destp, T_pint8),
             val8,
-            emit_unbox(ctx, T_size, n, (jl_value_t*)jl_ulong_type),
+            emit_unbox(ctx, getSizeTy(ctx.builder.getContext()), n, (jl_value_t*)jl_ulong_type),
             MaybeAlign(1)
         );
         JL_GC_POP();
@@ -1735,16 +1735,16 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         const jl_cgval_t &dst = argv[0];
         const jl_cgval_t &src = argv[1];
         const jl_cgval_t &n = argv[2];
-        Value *destp = emit_unbox(ctx, T_size, dst, (jl_value_t*)jl_voidpointer_type);
+        Value *destp = emit_unbox(ctx, getSizeTy(ctx.builder.getContext()), dst, (jl_value_t*)jl_voidpointer_type);
 
         ctx.builder.CreateMemMove(
                 emit_inttoptr(ctx, destp, T_pint8),
                 MaybeAlign(0),
                 emit_inttoptr(ctx,
-                    emit_unbox(ctx, T_size, src, (jl_value_t*)jl_voidpointer_type),
+                    emit_unbox(ctx, getSizeTy(ctx.builder.getContext()), src, (jl_value_t*)jl_voidpointer_type),
                     T_pint8),
                 MaybeAlign(0),
-                emit_unbox(ctx, T_size, n, (jl_value_t*)jl_ulong_type),
+                emit_unbox(ctx, getSizeTy(ctx.builder.getContext()), n, (jl_value_t*)jl_ulong_type),
                 false);
         JL_GC_POP();
         return rt == (jl_value_t*)jl_nothing_type ? ghostValue(jl_nothing_type, ctx.tbaa()) :
@@ -1757,15 +1757,15 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
             JL_GC_POP();
             const int hash_offset = offsetof(jl_sym_t, hash);
             Value *ph1 = emit_bitcast(ctx, decay_derived(ctx, boxed(ctx, val)), T_psize);
-            Value *ph2 = ctx.builder.CreateInBoundsGEP(T_size, ph1, ConstantInt::get(T_size, hash_offset / sizeof(size_t)));
-            LoadInst *hashval = ctx.builder.CreateAlignedLoad(T_size, ph2, Align(sizeof(size_t)));
+            Value *ph2 = ctx.builder.CreateInBoundsGEP(getSizeTy(ctx.builder.getContext()), ph1, ConstantInt::get(getSizeTy(ctx.builder.getContext()), hash_offset / sizeof(size_t)));
+            LoadInst *hashval = ctx.builder.CreateAlignedLoad(getSizeTy(ctx.builder.getContext()), ph2, Align(sizeof(size_t)));
             tbaa_decorate(ctx.tbaa().tbaa_const, hashval);
             return mark_or_box_ccall_result(ctx, hashval, retboxed, rt, unionall, static_rt);
         }
         else if (!val.isboxed) {
             // If the value is not boxed, try to compute the object id without
             // reboxing it.
-            auto T_pint8_derived = PointerType::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), AddressSpace::Derived);
+            auto T_pint8_derived = PointerType::get(getInt8Ty(ctx.builder.getContext()), AddressSpace::Derived);
             if (!val.isghost && !val.ispointer())
                 val = value_to_pointer(ctx, val);
             Value *args[] = {
@@ -1803,7 +1803,7 @@ jl_cgval_t function_sig_t::emit_a_ccall(
         return jl_cgval_t();
     }
 
-    FunctionType *functype = this->functype();
+    FunctionType *functype = this->functype(ctx.builder.getContext());
 
     Value **argvals = (Value**) alloca((nccallargs + sret) * sizeof(Value*));
     for (size_t ai = 0; ai < nccallargs; ai++) {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -83,20 +83,20 @@ static Value *stringConstPtr(
 
 
 // --- MDNode ---
-Metadata *to_md_tree(jl_value_t *val) {
+Metadata *to_md_tree(jl_value_t *val, llvm::LLVMContext &ctxt) {
     if (val == jl_nothing)
         return nullptr;
     Metadata *MD = nullptr;
     if (jl_is_symbol(val)) {
         MD = MDString::get(jl_LLVMContext, jl_symbol_name((jl_sym_t*)val));
     } else if (jl_is_bool(val)) {
-        MD = ConstantAsMetadata::get(ConstantInt::get(T_int1, jl_unbox_bool(val)));
+        MD = ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt1Ty(ctxt), jl_unbox_bool(val)));
     } else if (jl_is_long(val)) {
-        MD = ConstantAsMetadata::get(ConstantInt::get(T_int64, jl_unbox_long(val)));
+        MD = ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt64Ty(ctxt), jl_unbox_long(val)));
     } else if (jl_is_tuple(val)) {
         SmallVector<Metadata *, 8> MDs;
         for (int f = 0, nf = jl_nfields(val); f < nf; ++f) {
-            MD = to_md_tree(jl_fieldref(val, f));
+            MD = to_md_tree(jl_fieldref(val, f), ctxt);
             if (MD)
                 MDs.push_back(MD);
         }
@@ -359,11 +359,11 @@ static inline Instruction *maybe_mark_load_dereferenceable(Instruction *LI, bool
             // The `dereferencable` below does not imply `nonnull` for non addrspace(0) pointers.
             LI->setMetadata(LLVMContext::MD_nonnull, MDNode::get(LI->getContext(), None));
         if (size) {
-            Metadata *OP = ConstantAsMetadata::get(ConstantInt::get(T_int64, size));
+            Metadata *OP = ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt64Ty(LI->getContext()), size));
             LI->setMetadata(can_be_null ? LLVMContext::MD_dereferenceable_or_null : LLVMContext::MD_dereferenceable,
                             MDNode::get(LI->getContext(), { OP }));
             if (align >= 1) {
-                Metadata *OP = ConstantAsMetadata::get(ConstantInt::get(T_int64, align));
+                Metadata *OP = ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt64Ty(LI->getContext()), align));
                 LI->setMetadata(LLVMContext::MD_align, MDNode::get(LI->getContext(), { OP }));
             }
         }
@@ -483,9 +483,9 @@ static Value *emit_struct_gep(jl_codectx_t &ctx, Type *lty, Value *base, unsigne
     return ctx.builder.CreateConstInBoundsGEP2_32(lty, base, 0, idx);
 }
 
-static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, bool *isboxed, bool llvmcall=false);
+static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, llvm::LLVMContext &ctxt, jl_value_t *jt, bool *isboxed, bool llvmcall=false);
 
-static Type *_julia_type_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, bool *isboxed)
+static Type *_julia_type_to_llvm(jl_codegen_params_t *ctx, llvm::LLVMContext &ctxt, jl_value_t *jt, bool *isboxed)
 {
     // this function converts a Julia Type into the equivalent LLVM type
     if (isboxed) *isboxed = false;
@@ -494,7 +494,7 @@ static Type *_julia_type_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, bool 
     if (jl_is_concrete_immutable(jt)) {
         if (jl_datatype_nbits(jt) == 0)
             return T_void;
-        Type *t = _julia_struct_to_llvm(ctx, jt, isboxed);
+        Type *t = _julia_struct_to_llvm(ctx, ctxt, jt, isboxed);
         assert(t != NULL);
         return t;
     }
@@ -504,26 +504,26 @@ static Type *_julia_type_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, bool 
 
 static Type *julia_type_to_llvm(jl_codectx_t &ctx, jl_value_t *jt, bool *isboxed)
 {
-    return _julia_type_to_llvm(&ctx.emission_context, jt, isboxed);
+    return _julia_type_to_llvm(&ctx.emission_context, ctx.builder.getContext(), jt, isboxed);
 }
 
 extern "C" JL_DLLEXPORT
 Type *jl_type_to_llvm_impl(jl_value_t *jt, bool *isboxed)
 {
-    return _julia_type_to_llvm(NULL, jt, isboxed);
+    return _julia_type_to_llvm(NULL, jl_LLVMContext, jt, isboxed);
 }
 
 
 // converts a julia bitstype into the equivalent LLVM bitstype
-static Type *bitstype_to_llvm(jl_value_t *bt, bool llvmcall = false)
+static Type *bitstype_to_llvm(jl_value_t *bt, llvm::LLVMContext &ctxt, bool llvmcall = false)
 {
     assert(jl_is_primitivetype(bt));
     if (bt == (jl_value_t*)jl_bool_type)
-        return T_int8;
+        return llvm::Type::getInt8Ty(ctxt);
     if (bt == (jl_value_t*)jl_int32_type)
-        return T_int32;
+        return llvm::Type::getInt32Ty(ctxt);
     if (bt == (jl_value_t*)jl_int64_type)
-        return T_int64;
+        return llvm::Type::getInt64Ty(ctxt);
     if (bt == (jl_value_t*)jl_float16_type)
         return T_float16;
     if (bt == (jl_value_t*)jl_float32_type)
@@ -539,7 +539,7 @@ static Type *bitstype_to_llvm(jl_value_t *bt, bool llvmcall = false)
             as = jl_unbox_int64(as_param);
         else
             jl_error("invalid pointer address space");
-        return PointerType::get(T_int8, as);
+        return PointerType::get(llvm::Type::getInt8Ty(ctxt), as);
     }
     int nb = jl_datatype_size(bt);
     return Type::getIntNTy(jl_LLVMContext, nb * 8);
@@ -558,7 +558,7 @@ static unsigned jl_field_align(jl_datatype_t *dt, size_t i)
     return std::min({al, (unsigned)jl_datatype_align(dt), (unsigned)JL_HEAP_ALIGNMENT});
 }
 
-static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, bool *isboxed, bool llvmcall)
+static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, llvm::LLVMContext &ctxt, jl_value_t *jt, bool *isboxed, bool llvmcall)
 {
     // this function converts a Julia Type into the equivalent LLVM struct
     // use this where C-compatible (unboxed) structs are desired
@@ -567,7 +567,7 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, boo
     if (jt == (jl_value_t*)jl_bottom_type)
         return T_void;
     if (jl_is_primitivetype(jt))
-        return bitstype_to_llvm(jt, llvmcall);
+        return bitstype_to_llvm(jt, ctxt, llvmcall);
     jl_datatype_t *jst = (jl_datatype_t*)jt;
     if (jl_is_structtype(jt) && !(jst->layout && jl_is_layout_opaque(jst->layout))) {
         bool isTuple = jl_is_tuple_type(jt);
@@ -605,7 +605,7 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, boo
                 isvector = false;
             }
             else if (ty == (jl_value_t*)jl_bool_type) {
-                lty = T_int8;
+                lty = llvm::Type::getInt8Ty(ctxt);
             }
             else if (jl_is_uniontype(ty)) {
                 // pick an Integer type size such that alignment will generally be correct,
@@ -617,7 +617,7 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, boo
                 if (fsz > 0) {
                     if (al > MAX_ALIGN) {
                         Type *AlignmentType;
-                        AlignmentType = ArrayType::get(FixedVectorType::get(T_int8, al), 0);
+                        AlignmentType = ArrayType::get(FixedVectorType::get(llvm::Type::getInt8Ty(ctxt), al), 0);
                         latypes.push_back(AlignmentType);
                         al = MAX_ALIGN;
                     }
@@ -628,16 +628,16 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, boo
                     while (NumATy--)
                         latypes.push_back(AlignmentType);
                     while (remainder--)
-                        latypes.push_back(T_int8);
+                        latypes.push_back(llvm::Type::getInt8Ty(ctxt));
                 }
-                latypes.push_back(T_int8);
+                latypes.push_back(llvm::Type::getInt8Ty(ctxt));
                 isarray = false;
                 allghost = false;
                 continue;
             }
             else {
                 bool isptr;
-                lty = _julia_struct_to_llvm(ctx, ty, &isptr, llvmcall);
+                lty = _julia_struct_to_llvm(ctx, jl_LLVMContext, ty, &isptr, llvmcall);
                 assert(lty && !isptr);
             }
             if (lasttype != NULL && lasttype != lty)
@@ -668,7 +668,7 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, boo
 #if 0 // stress-test code that tries to assume julia-index == llvm-index
       // (also requires change to emit_new_struct to not assume 0 == 0)
             if (!isTuple && latypes.size() > 1) {
-                Type *NoopType = ArrayType::get(T_int1, 0);
+                Type *NoopType = ArrayType::get(llvm::Type::getInt1Ty(ctxt), 0);
                 latypes.insert(latypes.begin(), NoopType);
             }
 #endif
@@ -680,13 +680,13 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, boo
     // if (jl_is_uniontype(ty)) {
     //  // pick an Integer type size such that alignment will be correct
     //  // and always end with an Int8 (selector byte)
-    //  lty = ArrayType::get(IntegerType::get(jl_LLVMContext, 8 * al), fsz / al);
+    //  lty = ArrayType::get(IntegerType::get(lty->getContext(), 8 * al), fsz / al);
     //  std::vector<Type*> Elements(2);
     //  Elements[0] = lty;
-    //  Elements[1] = T_int8;
+    //  Elements[1] = llvm::Type::getInt8Ty(ctxt);
     //  unsigned remainder = fsz % al;
     //  while (remainder--)
-    //      Elements.push_back(T_int8);
+    //      Elements.push_back(llvm::Type::getInt8Ty(ctxt));
     //  lty = StructType::get(lty->getContext(), makeArrayRef(Elements));
     // }
     if (isboxed) *isboxed = true;
@@ -695,7 +695,7 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, jl_value_t *jt, boo
 
 static Type *julia_struct_to_llvm(jl_codectx_t &ctx, jl_value_t *jt, bool *isboxed)
 {
-    return _julia_struct_to_llvm(&ctx.emission_context, jt, isboxed);
+    return _julia_struct_to_llvm(&ctx.emission_context, ctx.builder.getContext(), jt, isboxed);
 }
 
 static bool is_datatype_all_pointers(jl_datatype_t *dt)
@@ -835,13 +835,13 @@ static jl_cgval_t emit_typeof(jl_codectx_t &ctx, const jl_cgval_t &p)
         return mark_julia_type(ctx, emit_typeof(ctx, p.V), true, jl_datatype_type);
     }
     if (p.TIndex) {
-        Value *tindex = ctx.builder.CreateAnd(p.TIndex, ConstantInt::get(T_int8, 0x7f));
+        Value *tindex = ctx.builder.CreateAnd(p.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x7f));
         bool allunboxed = is_uniontype_allunboxed(p.typ);
         Value *datatype_or_p = imaging_mode ? Constant::getNullValue(T_ppjlvalue) : Constant::getNullValue(T_prjlvalue);
         unsigned counter = 0;
         for_each_uniontype_small(
             [&](unsigned idx, jl_datatype_t *jt) {
-                Value *cmp = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(T_int8, idx));
+                Value *cmp = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), idx));
                 Value *ptr;
                 if (imaging_mode) {
                     ptr = literal_pointer_val_slot(ctx, (jl_value_t*)jt);
@@ -912,20 +912,20 @@ static Value *emit_datatype_size(jl_codectx_t &ctx, Value *dt)
 {
     Value *Ptr = emit_bitcast(ctx, decay_derived(ctx, dt), T_pint32);
     Value *Idx = ConstantInt::get(T_size, offsetof(jl_datatype_t, size) / sizeof(int));
-    return tbaa_decorate(ctx.tbaa().tbaa_const, ctx.builder.CreateAlignedLoad(T_int32, ctx.builder.CreateInBoundsGEP(T_int32, Ptr, Idx), Align(sizeof(int32_t))));
+    return tbaa_decorate(ctx.tbaa().tbaa_const, ctx.builder.CreateAlignedLoad(llvm::Type::getInt32Ty(ctx.builder.getContext()), ctx.builder.CreateInBoundsGEP(llvm::Type::getInt32Ty(ctx.builder.getContext()), Ptr, Idx), Align(sizeof(int32_t))));
 }
 
 /* this is valid code, it's simply unused
 static Value *emit_sizeof(jl_codectx_t &ctx, const jl_cgval_t &p)
 {
     if (p.TIndex) {
-        Value *tindex = ctx.builder.CreateAnd(p.TIndex, ConstantInt::get(T_int8, 0x7f));
-        Value *size = ConstantInt::get(T_int32, -1);
+        Value *tindex = ctx.builder.CreateAnd(p.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x7f));
+        Value *size = ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), -1);
         unsigned counter = 0;
         bool allunboxed = for_each_uniontype_small(
                 [&](unsigned idx, jl_datatype_t *jt) {
-                    Value *cmp = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(T_int8, idx));
-                    size = ctx.builder.CreateSelect(cmp, ConstantInt::get(T_int32, jl_datatype_size(jt)), size);
+                    Value *cmp = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), idx));
+                    size = ctx.builder.CreateSelect(cmp, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), jl_datatype_size(jt)), size);
                 },
                 p.typ,
                 counter);
@@ -934,8 +934,8 @@ static Value *emit_sizeof(jl_codectx_t &ctx, const jl_cgval_t &p)
             BasicBlock *dynloadBB = BasicBlock::Create(ctx.builder.getContext(), "dyn_sizeof", ctx.f);
             BasicBlock *postBB = BasicBlock::Create(ctx.builder.getContext(), "post_sizeof", ctx.f);
             Value *isboxed = ctx.builder.CreateICmpNE(
-                    ctx.builder.CreateAnd(p.TIndex, ConstantInt::get(T_int8, 0x80)),
-                    ConstantInt::get(T_int8, 0));
+                    ctx.builder.CreateAnd(p.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80)),
+                    ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0));
             ctx.builder.CreateCondBr(isboxed, dynloadBB, postBB);
             ctx.builder.SetInsertPoint(dynloadBB);
             Value *datatype = emit_typeof(p.V);
@@ -943,19 +943,19 @@ static Value *emit_sizeof(jl_codectx_t &ctx, const jl_cgval_t &p)
             ctx.builder.CreateBr(postBB);
             dynloadBB = ctx.builder.GetInsertBlock(); // could have changed
             ctx.builder.SetInsertPoint(postBB);
-            PHINode *sizeof_merge = ctx.builder.CreatePHI(T_int32, 2);
+            PHINode *sizeof_merge = ctx.builder.CreatePHI(llvm::Type::getInt32Ty(ctx.builder.getContext()), 2);
             sizeof_merge->addIncoming(dyn_size, dynloadBB);
             sizeof_merge->addIncoming(size, currBB);
             size = sizeof_merge;
         }
 #ifndef NDEBUG
         // try to catch codegen errors early, before it uses this to memcpy over the entire stack
-        CreateConditionalAbort(ctx.builder, ctx.builder.CreateICmpEQ(size, ConstantInt::get(T_int32, -1)));
+        CreateConditionalAbort(ctx.builder, ctx.builder.CreateICmpEQ(size, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), -1)));
 #endif
         return size;
     }
     else if (jl_is_concrete_type(p.typ)) {
-        return ConstantInt::get(T_int32, jl_datatype_size(p.typ));
+        return ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), jl_datatype_size(p.typ));
     }
     else {
         Value *datatype = emit_typeof_boxed(ctx, p);
@@ -973,16 +973,16 @@ static Value *emit_datatype_mutabl(jl_codectx_t &ctx, Value *dt)
             ctx.builder.CreateAlignedLoad(T_pint8, ctx.builder.CreateInBoundsGEP(T_pint8, Ptr, Idx), Align(sizeof(int8_t*))));
     Value *Idx2 = ConstantInt::get(T_size, offsetof(jl_typename_t, n_uninitialized) + sizeof(((jl_typename_t*)nullptr)->n_uninitialized));
     Value *mutabl = tbaa_decorate(ctx.tbaa().tbaa_const,
-            ctx.builder.CreateAlignedLoad(T_int8, ctx.builder.CreateInBoundsGEP(T_int8, Nam, Idx2), Align(1)));
+            ctx.builder.CreateAlignedLoad(llvm::Type::getInt8Ty(ctx.builder.getContext()), ctx.builder.CreateInBoundsGEP(llvm::Type::getInt8Ty(ctx.builder.getContext()), Nam, Idx2), Align(1)));
     mutabl = ctx.builder.CreateLShr(mutabl, 1);
-    return ctx.builder.CreateTrunc(mutabl, T_int1);
+    return ctx.builder.CreateTrunc(mutabl, llvm::Type::getInt1Ty(ctx.builder.getContext()));
 }
 
 static Value *emit_datatype_isprimitivetype(jl_codectx_t &ctx, Value *dt)
 {
     Value *immut = ctx.builder.CreateNot(emit_datatype_mutabl(ctx, dt));
     Value *nofields = ctx.builder.CreateICmpEQ(emit_datatype_nfields(ctx, dt), Constant::getNullValue(T_size));
-    Value *sized = ctx.builder.CreateICmpSGT(emit_datatype_size(ctx, dt), ConstantInt::get(T_int32, 0));
+    Value *sized = ctx.builder.CreateICmpSGT(emit_datatype_size(ctx, dt), ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 0));
     return ctx.builder.CreateAnd(immut, ctx.builder.CreateAnd(nofields, sized));
 }
 
@@ -1098,7 +1098,7 @@ static Value *emit_guarded_test(jl_codectx_t &ctx, Value *ifnot, Value *defval, 
 template<typename Func>
 static Value *emit_guarded_test(jl_codectx_t &ctx, Value *ifnot, bool defval, Func &&func)
 {
-    return emit_guarded_test(ctx, ifnot, ConstantInt::get(T_int1, defval), func);
+    return emit_guarded_test(ctx, ifnot, ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), defval), func);
 }
 
 template<typename Func>
@@ -1215,7 +1215,7 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
             BasicBlock *failBB = BasicBlock::Create(ctx.builder.getContext(), "fail", ctx.f);
             ctx.builder.SetInsertPoint(failBB);
         }
-        return std::make_pair(ConstantInt::get(T_int1, *known_isa), true);
+        return std::make_pair(ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), *known_isa), true);
     }
 
     if (jl_is_type_type(intersected_type) && jl_pointer_egal(intersected_type)) {
@@ -1230,11 +1230,11 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
         Value *vtyp = track_pjlvalue(ctx, literal_pointer_val(ctx, type));
         if (msg && *msg == "typeassert") {
             ctx.builder.CreateCall(prepare_call(jltypeassert_func), { vx, vtyp });
-            return std::make_pair(ConstantInt::get(T_int1, 1), true);
+            return std::make_pair(ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 1), true);
         }
         return std::make_pair(ctx.builder.CreateICmpNE(
                 ctx.builder.CreateCall(prepare_call(jlisa_func), { vx, vtyp }),
-                ConstantInt::get(T_int32, 0)), false);
+                ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 0)), false);
     }
     // tests for isa concretetype can be handled with pointer comparisons
     if (jl_is_concrete_type(intersected_type)) {
@@ -1242,12 +1242,12 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
             unsigned tindex = get_box_tindex((jl_datatype_t*)intersected_type, x.typ);
             if (tindex > 0) {
                 // optimize more when we know that this is a split union-type where tindex = 0 is invalid
-                Value *xtindex = ctx.builder.CreateAnd(x.TIndex, ConstantInt::get(T_int8, 0x7f));
-                return std::make_pair(ctx.builder.CreateICmpEQ(xtindex, ConstantInt::get(T_int8, tindex)), false);
+                Value *xtindex = ctx.builder.CreateAnd(x.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x7f));
+                return std::make_pair(ctx.builder.CreateICmpEQ(xtindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), tindex)), false);
             }
             else if (x.Vboxed) {
                 // test for (x.TIndex == 0x80 && typeof(x.V) == type)
-                Value *isboxed = ctx.builder.CreateICmpEQ(x.TIndex, ConstantInt::get(T_int8, 0x80));
+                Value *isboxed = ctx.builder.CreateICmpEQ(x.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80));
                 BasicBlock *currBB = ctx.builder.GetInsertBlock();
                 BasicBlock *isaBB = BasicBlock::Create(ctx.builder.getContext(), "isa", ctx.f);
                 BasicBlock *postBB = BasicBlock::Create(ctx.builder.getContext(), "post_isa", ctx.f);
@@ -1258,13 +1258,13 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
                 ctx.builder.CreateBr(postBB);
                 isaBB = ctx.builder.GetInsertBlock(); // could have changed
                 ctx.builder.SetInsertPoint(postBB);
-                PHINode *istype = ctx.builder.CreatePHI(T_int1, 2);
-                istype->addIncoming(ConstantInt::get(T_int1, 0), currBB);
+                PHINode *istype = ctx.builder.CreatePHI(llvm::Type::getInt1Ty(ctx.builder.getContext()), 2);
+                istype->addIncoming(ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 0), currBB);
                 istype->addIncoming(istype_boxed, isaBB);
                 return std::make_pair(istype, false);
             } else {
                 // handle the case where we know that `x` is unboxed (but of unknown type), but that concrete type `type` cannot be unboxed
-                return std::make_pair(ConstantInt::get(T_int1, 0), false);
+                return std::make_pair(ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 0), false);
             }
         }
         return std::make_pair(emit_exactly_isa(ctx, x, intersected_type), false);
@@ -1285,13 +1285,13 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
         emit_isa_union(ctx, x, intersected_type, bbs);
         int nbbs = bbs.size();
         BasicBlock *currBB = ctx.builder.GetInsertBlock();
-        PHINode *res = ctx.builder.CreatePHI(T_int1, nbbs);
+        PHINode *res = ctx.builder.CreatePHI(llvm::Type::getInt1Ty(ctx.builder.getContext()), nbbs);
         for (int i = 0; i < nbbs; i++) {
             auto bb = bbs[i].first.second;
             ctx.builder.SetInsertPoint(bb);
             if (i + 1 < nbbs) {
                 ctx.builder.CreateCondBr(bbs[i].second, currBB, bbs[i + 1].first.first);
-                res->addIncoming(ConstantInt::get(T_int1, 1), bb);
+                res->addIncoming(ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 1), bb);
             }
             else {
                 ctx.builder.CreateBr(currBB);
@@ -1306,7 +1306,7 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
             ctx.builder.CreateCall(prepare_call(jlsubtype_func),
               { emit_typeof_boxed(ctx, x),
                 track_pjlvalue(ctx, literal_pointer_val(ctx, type)) }),
-            ConstantInt::get(T_int32, 0)), false);
+            ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 0)), false);
 }
 
 static void emit_typecheck(jl_codectx_t &ctx, const jl_cgval_t &x, jl_value_t *type, const std::string &msg)
@@ -1331,10 +1331,10 @@ static void emit_typecheck(jl_codectx_t &ctx, const jl_cgval_t &x, jl_value_t *t
 static Value *emit_isconcrete(jl_codectx_t &ctx, Value *typ)
 {
     Value *isconcrete;
-    isconcrete = ctx.builder.CreateConstInBoundsGEP1_32(T_int8, emit_bitcast(ctx, decay_derived(ctx, typ), T_pint8), offsetof(jl_datatype_t, hash) + sizeof(((jl_datatype_t*)nullptr)->hash));
-    isconcrete = tbaa_decorate(ctx.tbaa().tbaa_const, ctx.builder.CreateAlignedLoad(T_int8, isconcrete, Align(1)));
+    isconcrete = ctx.builder.CreateConstInBoundsGEP1_32(llvm::Type::getInt8Ty(ctx.builder.getContext()), emit_bitcast(ctx, decay_derived(ctx, typ), T_pint8), offsetof(jl_datatype_t, hash) + sizeof(((jl_datatype_t*)nullptr)->hash));
+    isconcrete = tbaa_decorate(ctx.tbaa().tbaa_const, ctx.builder.CreateAlignedLoad(llvm::Type::getInt8Ty(ctx.builder.getContext()), isconcrete, Align(1)));
     isconcrete = ctx.builder.CreateLShr(isconcrete, 1);
-    isconcrete = ctx.builder.CreateTrunc(isconcrete, T_int1);
+    isconcrete = ctx.builder.CreateTrunc(isconcrete, llvm::Type::getInt1Ty(ctx.builder.getContext()));
     return isconcrete;
 }
 
@@ -1533,7 +1533,7 @@ static jl_cgval_t typed_load(jl_codectx_t &ctx, Value *ptr, Value *idx_0based, j
         //load->setMetadata(LLVMContext::MD_range, MDNode::get(ctx.builder.getContext(), {
         //    ConstantAsMetadata::get(ConstantInt::get(T_int8, 0)),
         //    ConstantAsMetadata::get(ConstantInt::get(T_int8, 2)) }));
-        instr = ctx.builder.CreateTrunc(instr, T_int1);
+        instr = ctx.builder.CreateTrunc(instr, llvm::Type::getInt1Ty(ctx.builder.getContext()));
     }
     return mark_julia_type(ctx, instr, isboxed, jltype);
 }
@@ -1571,8 +1571,8 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             return rhs;
         }
         else if (isreplacefield) {
-            Value *Success = emit_f_is(ctx, cmp, ghostValue(jltype, ctx.tbaa()));
-            Success = ctx.builder.CreateZExt(Success, T_int8);
+            Value *Success = emit_f_is(ctx, cmp, ghostValue(jltype));
+            Success = ctx.builder.CreateZExt(Success, llvm::Type::getInt8Ty(ctx.builder.getContext()));
             const jl_cgval_t argv[2] = {ghostValue(jltype, ctx.tbaa()), mark_julia_type(ctx, Success, false, jl_bool_type)};
             jl_datatype_t *rettyp = jl_apply_cmpswap_type(jltype);
             return emit_new_struct(ctx, (jl_value_t*)rettyp, 2, argv);
@@ -1686,8 +1686,8 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
                     instr = load;
                     ctx.builder.CreateBr(DoneBB);
                     ctx.builder.SetInsertPoint(DoneBB);
-                    Succ = ctx.builder.CreatePHI(T_int1, 2);
-                    Succ->addIncoming(ConstantInt::get(T_int1, false), SkipBB);
+                    Succ = ctx.builder.CreatePHI(llvm::Type::getInt1Ty(ctx.builder.getContext()), 2);
+                    Succ->addIncoming(ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), false), SkipBB);
                     Current = ctx.builder.CreatePHI(instr->getType(), 2);
                     Current->addIncoming(instr, SkipBB);
                     ctx.builder.SetInsertPoint(BB);
@@ -1886,7 +1886,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
         }
         oldval = mark_julia_type(ctx, instr, isboxed, jltype);
         if (isreplacefield) {
-            Success = ctx.builder.CreateZExt(Success, T_int8);
+            Success = ctx.builder.CreateZExt(Success, llvm::Type::getInt8Ty(ctx.builder.getContext()));
             const jl_cgval_t argv[2] = {oldval, mark_julia_type(ctx, Success, false, jl_bool_type)};
             jl_datatype_t *rettyp = jl_apply_cmpswap_type(jltype);
             oldval = emit_new_struct(ctx, (jl_value_t*)rettyp, 2, argv);
@@ -2048,7 +2048,7 @@ static bool emit_getfield_unknownidx(jl_codectx_t &ctx,
                 assert(stt->layout->npointers == 0); // we could, but don't emit this
                 idx = idx0();
                 if (sizeof(void*) != sizeof(int))
-                    idx = ctx.builder.CreateTrunc(idx, T_int32); // llvm3.3 requires this, harmless elsewhere
+                    idx = ctx.builder.CreateTrunc(idx, llvm::Type::getInt32Ty(ctx.builder.getContext())); // llvm3.3 requires this, harmless elsewhere
                 Value *fld = ctx.builder.CreateExtractElement(strct.V, idx);
                 *ret = mark_julia_type(ctx, fld, isboxed, jft);
                 return true;
@@ -2151,11 +2151,11 @@ static jl_cgval_t emit_unionload(jl_codectx_t &ctx, Value *addr, Value *ptindex,
         jl_value_t *jfty, size_t fsz, size_t al, MDNode *tbaa, bool mutabl,
         unsigned union_max, MDNode *tbaa_ptindex)
 {
-    Instruction *tindex0 = tbaa_decorate(tbaa_ptindex, ctx.builder.CreateAlignedLoad(T_int8, ptindex, Align(1)));
+    Instruction *tindex0 = tbaa_decorate(tbaa_ptindex, ctx.builder.CreateAlignedLoad(llvm::Type::getInt8Ty(ctx.builder.getContext()), ptindex, Align(1)));
     tindex0->setMetadata(LLVMContext::MD_range, MDNode::get(ctx.builder.getContext(), {
-        ConstantAsMetadata::get(ConstantInt::get(T_int8, 0)),
-        ConstantAsMetadata::get(ConstantInt::get(T_int8, union_max)) }));
-    Value *tindex = ctx.builder.CreateNUWAdd(ConstantInt::get(T_int8, 1), tindex0);
+        ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0)),
+        ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), union_max)) }));
+    Value *tindex = ctx.builder.CreateNUWAdd(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 1), tindex0);
     if (fsz > 0 && mutabl) {
         // move value to an immutable stack slot (excluding tindex)
         Type *AT = ArrayType::get(IntegerType::get(ctx.builder.getContext(), 8 * al), (fsz + al - 1) / al);
@@ -2211,7 +2211,7 @@ static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &st
             // can pessimize mem2reg
             if (byte_offset > 0) {
                 addr = ctx.builder.CreateInBoundsGEP(
-                        T_int8,
+                        llvm::Type::getInt8Ty(ctx.builder.getContext()),
                         emit_bitcast(ctx, staddr, T_pint8),
                         ConstantInt::get(T_size, byte_offset));
             }
@@ -2245,7 +2245,7 @@ static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &st
             Value *ptindex;
             if (isboxed) {
                 ptindex = ctx.builder.CreateConstInBoundsGEP1_32(
-                    T_int8, emit_bitcast(ctx, staddr, T_pint8), byte_offset + fsz);
+                    llvm::Type::getInt8Ty(ctx.builder.getContext()), emit_bitcast(ctx, staddr, T_pint8), byte_offset + fsz);
             }
             else {
                 ptindex = emit_struct_gep(ctx, cast<StructType>(lt), staddr, byte_offset + fsz);
@@ -2280,7 +2280,7 @@ static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &st
             fldv = obj;
         }
         else if (isa<VectorType>(T)) {
-            fldv = ctx.builder.CreateExtractElement(obj, ConstantInt::get(T_int32, idx));
+            fldv = ctx.builder.CreateExtractElement(obj, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), idx));
         }
         else if (!jl_field_isptr(jt, idx) && jl_is_uniontype(jfty)) {
             int fsz = jl_field_size(jt, idx) - 1;
@@ -2291,7 +2291,7 @@ static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &st
                 IntegerType *ET = cast<IntegerType>(T->getStructElementType(st_idx));
                 unsigned align = (ET->getBitWidth() + 7) / 8;
                 lv = emit_static_alloca(ctx, ET);
-                lv->setOperand(0, ConstantInt::get(T_int32, (fsz + align - 1) / align));
+                lv->setOperand(0, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), (fsz + align - 1) / align));
                 // emit all of the align-sized words
                 unsigned i = 0;
                 for (; i < fsz / align; i++) {
@@ -2306,14 +2306,14 @@ static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &st
                     staddr = ctx.builder.CreateBitCast(staddr, T_pint8);
                     for (; i < ptindex - st_idx; i++) {
                         Value *fldv = ctx.builder.CreateExtractValue(obj, makeArrayRef(st_idx + i));
-                        Value *fldp = ctx.builder.CreateConstInBoundsGEP1_32(T_int8, staddr, i);
+                        Value *fldp = ctx.builder.CreateConstInBoundsGEP1_32(llvm::Type::getInt8Ty(ctx.builder.getContext()), staddr, i);
                         ctx.builder.CreateAlignedStore(fldv, fldp, Align(1));
                     }
                 }
             }
             Value *tindex0 = ctx.builder.CreateExtractValue(obj, makeArrayRef(ptindex));
-            Value *tindex = ctx.builder.CreateNUWAdd(ConstantInt::get(T_int8, 1), tindex0);
-            return mark_julia_slot(lv, jfty, tindex, ctx.tbaa(), ctx.tbaa().tbaa_stack);
+            Value *tindex = ctx.builder.CreateNUWAdd(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 1), tindex0);
+            return mark_julia_slot(lv, jfty, tindex, ctx.tbaa().tbaa_stack);
         }
         else {
             unsigned st_idx;
@@ -2339,15 +2339,15 @@ static Value *emit_n_varargs(jl_codectx_t &ctx)
 {
     Value *valen = NULL;
     if (ctx.nvargs != -1) {
-        valen = ConstantInt::get(T_int32, ctx.nvargs);
+        valen = ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), ctx.nvargs);
     } else {
         assert(ctx.argCount);
         int nreq = ctx.nReqArgs;
         valen = ctx.builder.CreateSub((Value*)ctx.argCount,
-                                        ConstantInt::get(T_int32, nreq));
+                                        ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), nreq));
     }
 #ifdef _P64
-    return ctx.builder.CreateSExt(valen, T_int64);
+    return ctx.builder.CreateSExt(valen, llvm::Type::getInt64Ty(ctx.builder.getContext()));
 #else
     return valen;
 #endif
@@ -2440,7 +2440,7 @@ static Value *emit_arraysize(jl_codectx_t &ctx, const jl_cgval_t &tinfo, Value *
 
 static Value *emit_arraysize(jl_codectx_t &ctx, const jl_cgval_t &tinfo, int dim)
 {
-    return emit_arraysize(ctx, tinfo, ConstantInt::get(T_int32, dim));
+    return emit_arraysize(ctx, tinfo, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), dim));
 }
 
 static Value *emit_vectormaxsize(jl_codectx_t &ctx, const jl_cgval_t &ary)
@@ -2538,7 +2538,7 @@ static Value *emit_arrayflags(jl_codectx_t &ctx, const jl_cgval_t &tinfo)
             jl_array_llvmt,
             emit_bitcast(ctx, decay_derived(ctx, t), jl_parray_llvmt),
             arrayflag_field);
-    return tbaa_decorate(ctx.tbaa().tbaa_arrayflags, ctx.builder.CreateAlignedLoad(T_int16, addr, Align(sizeof(int16_t))));
+    return tbaa_decorate(ctx.tbaa().tbaa_arrayflags, ctx.builder.CreateAlignedLoad(llvm::Type::getInt16Ty(ctx.builder.getContext()), addr, Align(sizeof(int16_t))));
 }
 
 static Value *emit_arrayndims(jl_codectx_t &ctx, const jl_cgval_t &ary)
@@ -2557,13 +2557,13 @@ static Value *emit_arrayelsize(jl_codectx_t &ctx, const jl_cgval_t &tinfo)
     Value *addr = ctx.builder.CreateStructGEP(jl_array_llvmt,
             emit_bitcast(ctx, decay_derived(ctx, t), jl_parray_llvmt),
             elsize_field);
-    return tbaa_decorate(ctx.tbaa().tbaa_const, ctx.builder.CreateAlignedLoad(T_int16, addr, Align(sizeof(int16_t))));
+    return tbaa_decorate(ctx.tbaa().tbaa_const, ctx.builder.CreateAlignedLoad(llvm::Type::getInt16Ty(ctx.builder.getContext()), addr, Align(sizeof(int16_t))));
 }
 
 static Value *emit_arrayoffset(jl_codectx_t &ctx, const jl_cgval_t &tinfo, int nd)
 {
     if (nd != -1 && nd != 1) // only Vector can have an offset
-        return ConstantInt::get(T_int32, 0);
+        return ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 0);
     Value *t = boxed(ctx, tinfo);
     int offset_field = 4;
 
@@ -2571,7 +2571,7 @@ static Value *emit_arrayoffset(jl_codectx_t &ctx, const jl_cgval_t &tinfo, int n
             jl_array_llvmt,
             emit_bitcast(ctx, decay_derived(ctx, t), jl_parray_llvmt),
             offset_field);
-    return tbaa_decorate(ctx.tbaa().tbaa_arrayoffset, ctx.builder.CreateAlignedLoad(T_int32, addr, Align(sizeof(int32_t))));
+    return tbaa_decorate(ctx.tbaa().tbaa_arrayoffset, ctx.builder.CreateAlignedLoad(llvm::Type::getInt32Ty(ctx.builder.getContext()), addr, Align(sizeof(int32_t))));
 }
 
 // Returns the size of the array represented by `tinfo` for the given dimension `dim` if
@@ -2798,7 +2798,7 @@ static Value *load_i8box(jl_codectx_t &ctx, Value *v, jl_datatype_t *ty)
 {
     auto jvar = ty == jl_int8_type ? jlboxed_int8_cache : jlboxed_uint8_cache;
     GlobalVariable *gv = prepare_global_in(jl_Module, jvar);
-    Value *idx[] = {ConstantInt::get(T_int32, 0), ctx.builder.CreateZExt(v, T_int32)};
+    Value *idx[] = {ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 0), ctx.builder.CreateZExt(v, llvm::Type::getInt32Ty(ctx.builder.getContext()))};
     auto slot = ctx.builder.CreateInBoundsGEP(gv->getType()->getElementType(), gv, idx);
     return tbaa_decorate(ctx.tbaa().tbaa_const, maybe_mark_load_dereferenceable(
             ctx.builder.CreateAlignedLoad(T_pjlvalue, slot, Align(sizeof(void*))), false,
@@ -2811,8 +2811,8 @@ static Value *_boxed_special(jl_codectx_t &ctx, const jl_cgval_t &vinfo, Type *t
 {
     jl_value_t *jt = vinfo.typ;
     if (jt == (jl_value_t*)jl_bool_type)
-        return track_pjlvalue(ctx, julia_bool(ctx, ctx.builder.CreateTrunc(as_value(ctx, t, vinfo), T_int1)));
-    if (t == T_int1)
+        return track_pjlvalue(ctx, julia_bool(ctx, ctx.builder.CreateTrunc(as_value(ctx, t, vinfo), llvm::Type::getInt1Ty(ctx.builder.getContext()))));
+    if (t == llvm::Type::getInt1Ty(ctx.builder.getContext()))
         return track_pjlvalue(ctx, julia_bool(ctx, as_value(ctx, t, vinfo)));
 
     if (ctx.linfo && jl_is_method(ctx.linfo->def.method) && !vinfo.ispointer()) { // don't bother codegen pre-boxing for toplevel
@@ -2868,13 +2868,13 @@ static Value *_boxed_special(jl_codectx_t &ctx, const jl_cgval_t &vinfo, Type *t
 
 static Value *compute_box_tindex(jl_codectx_t &ctx, Value *datatype, jl_value_t *supertype, jl_value_t *ut)
 {
-    Value *tindex = ConstantInt::get(T_int8, 0);
+    Value *tindex = ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0);
     unsigned counter = 0;
     for_each_uniontype_small(
             [&](unsigned idx, jl_datatype_t *jt) {
                 if (jl_subtype((jl_value_t*)jt, supertype)) {
                     Value *cmp = ctx.builder.CreateICmpEQ(track_pjlvalue(ctx, literal_pointer_val(ctx, (jl_value_t*)jt)), datatype);
-                    tindex = ctx.builder.CreateSelect(cmp, ConstantInt::get(T_int8, idx), tindex);
+                    tindex = ctx.builder.CreateSelect(cmp, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), idx), tindex);
                 }
             },
             ut,
@@ -2907,12 +2907,12 @@ static Value *emit_typeof_or_null(jl_codectx_t &ctx, Value *v)
 static Value *compute_tindex_unboxed(jl_codectx_t &ctx, const jl_cgval_t &val, jl_value_t *typ)
 {
     if (val.typ == jl_bottom_type)
-        return UndefValue::get(T_int8);
+        return UndefValue::get(llvm::Type::getInt8Ty(ctx.builder.getContext()));
     if (val.constant)
-        return ConstantInt::get(T_int8, get_box_tindex((jl_datatype_t*)jl_typeof(val.constant), typ));
+        return ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), get_box_tindex((jl_datatype_t*)jl_typeof(val.constant), typ));
 
     if (val.TIndex)
-        return ctx.builder.CreateAnd(val.TIndex, ConstantInt::get(T_int8, 0x7f));
+        return ctx.builder.CreateAnd(val.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x7f));
     Value *typof;
     if (val.isboxed && !jl_is_concrete_type(val.typ) && !jl_is_type_type(val.typ))
         typof = emit_typeof_or_null(ctx, val.V);
@@ -3001,7 +3001,7 @@ static Value *box_union(jl_codectx_t &ctx, const jl_cgval_t &vinfo, const SmallB
                 Type *t = julia_type_to_llvm(ctx, (jl_value_t*)jt);
                 BasicBlock *tempBB = BasicBlock::Create(ctx.builder.getContext(), "box_union", ctx.f);
                 ctx.builder.SetInsertPoint(tempBB);
-                switchInst->addCase(ConstantInt::get(T_int8, idx), tempBB);
+                switchInst->addCase(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), idx), tempBB);
                 Value *box;
                 if (type_is_ghost(t)) {
                     box = track_pjlvalue(ctx, literal_pointer_val(ctx, jt->instance));
@@ -3111,9 +3111,9 @@ static void emit_unionmove(jl_codectx_t &ctx, Value *dest, MDNode *tbaa_dst, con
         }
     }
     else if (src.TIndex) {
-        Value *tindex = ctx.builder.CreateAnd(src.TIndex, ConstantInt::get(T_int8, 0x7f));
+        Value *tindex = ctx.builder.CreateAnd(src.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x7f));
         if (skip)
-            tindex = ctx.builder.CreateSelect(skip, ConstantInt::get(T_int8, 0), tindex);
+            tindex = ctx.builder.CreateSelect(skip, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0), tindex);
         Value *src_ptr = data_pointer(ctx, src);
         src_ptr = src_ptr ? maybe_bitcast(ctx, src_ptr, T_pint8) : src_ptr;
         dest = maybe_bitcast(ctx, dest, T_pint8);
@@ -3127,7 +3127,7 @@ static void emit_unionmove(jl_codectx_t &ctx, Value *dest, MDNode *tbaa_dst, con
                     unsigned alignment = julia_alignment((jl_value_t*)jt);
                     BasicBlock *tempBB = BasicBlock::Create(ctx.builder.getContext(), "union_move", ctx.f);
                     ctx.builder.SetInsertPoint(tempBB);
-                    switchInst->addCase(ConstantInt::get(T_int8, idx), tempBB);
+                    switchInst->addCase(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), idx), tempBB);
                     if (nb > 0) {
                         if (!src_ptr) {
                             Function *trap_func =
@@ -3273,7 +3273,7 @@ static jl_cgval_t emit_setfield(jl_codectx_t &ctx,
     Value *addr = data_pointer(ctx, strct);
     if (byte_offset > 0) {
         addr = ctx.builder.CreateInBoundsGEP(
-                T_int8,
+                llvm::Type::getInt8Ty(ctx.builder.getContext()),
                 emit_bitcast(ctx, maybe_decay_tracked(ctx, addr), T_pint8),
                 ConstantInt::get(T_size, byte_offset)); // TODO: use emit_struct_gep
     }
@@ -3287,7 +3287,7 @@ static jl_cgval_t emit_setfield(jl_codectx_t &ctx,
         jl_cgval_t rhs_union = convert_julia_type(ctx, rhs, jfty);
         if (rhs_union.typ == jl_bottom_type)
             return jl_cgval_t();
-        Value *ptindex = ctx.builder.CreateInBoundsGEP(T_int8, emit_bitcast(ctx, maybe_decay_tracked(ctx, addr), T_pint8), ConstantInt::get(T_size, fsz));
+        Value *ptindex = ctx.builder.CreateInBoundsGEP(llvm::Type::getInt8Ty(ctx.builder.getContext()), emit_bitcast(ctx, maybe_decay_tracked(ctx, addr), T_pint8), ConstantInt::get(T_size, fsz));
         if (needlock)
             emit_lockstate_value(ctx, strct, true);
         BasicBlock *ModifyBB;
@@ -3332,7 +3332,7 @@ static jl_cgval_t emit_setfield(jl_codectx_t &ctx,
             ctx.builder.SetInsertPoint(XchgBB);
         }
         Value *tindex = compute_tindex_unboxed(ctx, rhs_union, jfty);
-        tindex = ctx.builder.CreateNUWSub(tindex, ConstantInt::get(T_int8, 1));
+        tindex = ctx.builder.CreateNUWSub(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 1));
         tbaa_decorate(ctx.tbaa().tbaa_unionselbyte, ctx.builder.CreateAlignedStore(tindex, ptindex, Align(1)));
         // copy data
         if (!rhs.isghost) {
@@ -3345,7 +3345,7 @@ static jl_cgval_t emit_setfield(jl_codectx_t &ctx,
         if (needlock)
             emit_lockstate_value(ctx, strct, false);
         if (isreplacefield) {
-            Success = ctx.builder.CreateZExt(Success, T_int8);
+            Success = ctx.builder.CreateZExt(Success, llvm::Type::getInt8Ty(ctx.builder.getContext()));
             jl_cgval_t argv[2] = {oldval, mark_julia_type(ctx, Success, false, jl_bool_type)};
             jl_datatype_t *rettyp = jl_apply_cmpswap_type(jfty);
             oldval = emit_new_struct(ctx, (jl_value_t*)rettyp, 2, argv);
@@ -3439,7 +3439,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                     if (rhs_union.typ == jl_bottom_type)
                         return jl_cgval_t();
                     Value *tindex = compute_tindex_unboxed(ctx, rhs_union, jtype);
-                    tindex = ctx.builder.CreateNUWSub(tindex, ConstantInt::get(T_int8, 1));
+                    tindex = ctx.builder.CreateNUWSub(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 1));
                     size_t fsz = 0, al = 0;
                     bool isptr = !jl_islayout_inline(jtype, &fsz, &al);
                     assert(!isptr && fsz == jl_field_size(sty, i) - 1); (void)isptr;
@@ -3453,7 +3453,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                             Type *ET = IntegerType::get(ctx.builder.getContext(), 8 * al);
                             assert(lt->getStructElementType(llvm_idx) == ET);
                             AllocaInst *lv = emit_static_alloca(ctx, ET);
-                            lv->setOperand(0, ConstantInt::get(T_int32, (fsz + al - 1) / al));
+                            lv->setOperand(0, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), (fsz + al - 1) / al));
                             emit_unionmove(ctx, lv, ctx.tbaa().tbaa_stack, fval_info, nullptr);
                             // emit all of the align-sized words
                             unsigned i = 0;
@@ -3467,8 +3467,8 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                                 Value *staddr = ctx.builder.CreateConstInBoundsGEP1_32(ET, lv, i);
                                 staddr = ctx.builder.CreateBitCast(staddr, T_pint8);
                                 for (; i < ptindex - llvm_idx; i++) {
-                                    Value *fldp = ctx.builder.CreateConstInBoundsGEP1_32(T_int8, staddr, i);
-                                    Value *fldv = tbaa_decorate(ctx.tbaa().tbaa_stack, ctx.builder.CreateAlignedLoad(T_int8, fldp, Align(1)));
+                                    Value *fldp = ctx.builder.CreateConstInBoundsGEP1_32(llvm::Type::getInt8Ty(ctx.builder.getContext()), staddr, i);
+                                    Value *fldv = tbaa_decorate(ctx.tbaa().tbaa_stack, ctx.builder.CreateAlignedLoad(llvm::Type::getInt8Ty(ctx.builder.getContext()), fldp, Align(1)));
                                     strct = ctx.builder.CreateInsertValue(strct, fldv, makeArrayRef(llvm_idx + i));
                                 }
                             }
@@ -3493,7 +3493,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                     if (jl_is_vecelement_type(ty))
                         strct = fval;  // VecElement type comes unwrapped in LLVM.
                     else if (lt->isVectorTy())
-                        strct = ctx.builder.CreateInsertElement(strct, fval, ConstantInt::get(T_int32, llvm_idx));
+                        strct = ctx.builder.CreateInsertElement(strct, fval, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), llvm_idx));
                     else if (lt->isAggregateType())
                         strct = ctx.builder.CreateInsertValue(strct, fval, makeArrayRef(llvm_idx));
                     else
@@ -3506,10 +3506,10 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                     int fsz = jl_field_size(sty, i) - 1;
                     unsigned llvm_idx = convert_struct_offset(ctx, cast<StructType>(lt), offs + fsz);
                     if (init_as_value)
-                        strct = ctx.builder.CreateInsertValue(strct, ConstantInt::get(T_int8, 0), makeArrayRef(llvm_idx));
+                        strct = ctx.builder.CreateInsertValue(strct, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0), makeArrayRef(llvm_idx));
                     else
                         tbaa_decorate(ctx.tbaa().tbaa_unionselbyte, ctx.builder.CreateAlignedStore(
-                                ConstantInt::get(T_int8, 0),
+                                ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0),
                                 ctx.builder.CreateConstInBoundsGEP2_32(lt, strct, 0, llvm_idx),
                                 Align(1)));
                 }
@@ -3529,8 +3529,8 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
         for (size_t i = nargs; i < nf; i++) {
             if (!jl_field_isptr(sty, i) && jl_is_uniontype(jl_field_type(sty, i))) {
                 tbaa_decorate(ctx.tbaa().tbaa_unionselbyte, ctx.builder.CreateAlignedStore(
-                        ConstantInt::get(T_int8, 0),
-                        ctx.builder.CreateInBoundsGEP(T_int8, emit_bitcast(ctx, strct, T_pint8),
+                        ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0),
+                        ctx.builder.CreateInBoundsGEP(llvm::Type::getInt8Ty(ctx.builder.getContext()), emit_bitcast(ctx, strct, T_pint8),
                                 ConstantInt::get(T_size, jl_field_offset(sty, i) + jl_field_size(sty, i) - 1)),
                         Align(1)));
             }
@@ -3568,7 +3568,7 @@ static Value *emit_defer_signal(jl_codectx_t &ctx)
 {
     Value *ptls = emit_bitcast(ctx, get_current_ptls(ctx),
                                         PointerType::get(T_sigatomic, 0));
-    Constant *offset = ConstantInt::getSigned(T_int32,
+    Constant *offset = ConstantInt::getSigned(llvm::Type::getInt32Ty(ctx.builder.getContext()),
         offsetof(jl_tls_states_t, defer_signal) / sizeof(sig_atomic_t));
     return ctx.builder.CreateInBoundsGEP(T_sigatomic, ptls, ArrayRef<Value*>(offset), "jl_defer_signal");
 }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -525,11 +525,11 @@ static Type *bitstype_to_llvm(jl_value_t *bt, llvm::LLVMContext &ctxt, bool llvm
     if (bt == (jl_value_t*)jl_int64_type)
         return llvm::Type::getInt64Ty(ctxt);
     if (bt == (jl_value_t*)jl_float16_type)
-        return T_float16;
+        return llvm::Type::getHalfTy(ctxt);
     if (bt == (jl_value_t*)jl_float32_type)
-        return T_float32;
+        return llvm::Type::getFloatTy(ctxt);
     if (bt == (jl_value_t*)jl_float64_type)
-        return T_float64;
+        return llvm::Type::getDoubleTy(ctxt);
     if (jl_is_llvmpointer_type(bt)) {
         jl_value_t *as_param = jl_tparam1(bt);
         int as;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -83,16 +83,16 @@ static Value *stringConstPtr(
 
 
 // --- MDNode ---
-Metadata *to_md_tree(jl_value_t *val, llvm::LLVMContext &ctxt) {
+Metadata *to_md_tree(jl_value_t *val, LLVMContext &ctxt) {
     if (val == jl_nothing)
         return nullptr;
     Metadata *MD = nullptr;
     if (jl_is_symbol(val)) {
-        MD = MDString::get(jl_LLVMContext, jl_symbol_name((jl_sym_t*)val));
+        MD = MDString::get(ctxt, jl_symbol_name((jl_sym_t*)val));
     } else if (jl_is_bool(val)) {
-        MD = ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt1Ty(ctxt), jl_unbox_bool(val)));
+        MD = ConstantAsMetadata::get(ConstantInt::get(getInt1Ty(ctxt), jl_unbox_bool(val)));
     } else if (jl_is_long(val)) {
-        MD = ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt64Ty(ctxt), jl_unbox_long(val)));
+        MD = ConstantAsMetadata::get(ConstantInt::get(getInt64Ty(ctxt), jl_unbox_long(val)));
     } else if (jl_is_tuple(val)) {
         SmallVector<Metadata *, 8> MDs;
         for (int f = 0, nf = jl_nfields(val); f < nf; ++f) {
@@ -100,7 +100,7 @@ Metadata *to_md_tree(jl_value_t *val, llvm::LLVMContext &ctxt) {
             if (MD)
                 MDs.push_back(MD);
         }
-        MD = MDNode::get(jl_LLVMContext, MDs);
+        MD = MDNode::get(ctxt, MDs);
     } else {
         jl_error("LLVM metadata needs to Symbol/Bool/Int or Tuple thereof");
     }
@@ -359,11 +359,11 @@ static inline Instruction *maybe_mark_load_dereferenceable(Instruction *LI, bool
             // The `dereferencable` below does not imply `nonnull` for non addrspace(0) pointers.
             LI->setMetadata(LLVMContext::MD_nonnull, MDNode::get(LI->getContext(), None));
         if (size) {
-            Metadata *OP = ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt64Ty(LI->getContext()), size));
+            Metadata *OP = ConstantAsMetadata::get(ConstantInt::get(getInt64Ty(LI->getContext()), size));
             LI->setMetadata(can_be_null ? LLVMContext::MD_dereferenceable_or_null : LLVMContext::MD_dereferenceable,
                             MDNode::get(LI->getContext(), { OP }));
             if (align >= 1) {
-                Metadata *OP = ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt64Ty(LI->getContext()), align));
+                Metadata *OP = ConstantAsMetadata::get(ConstantInt::get(getInt64Ty(LI->getContext()), align));
                 LI->setMetadata(LLVMContext::MD_align, MDNode::get(LI->getContext(), { OP }));
             }
         }
@@ -432,7 +432,7 @@ static Value *maybe_bitcast(jl_codectx_t &ctx, Value *V, Type *to) {
 
 static Value *julia_binding_gv(jl_codectx_t &ctx, Value *bv)
 {
-    Value *offset = ConstantInt::get(T_size, offsetof(jl_binding_t, value) / sizeof(size_t));
+    Value *offset = ConstantInt::get(getSizeTy(ctx.builder.getContext()), offsetof(jl_binding_t, value) / sizeof(size_t));
     return ctx.builder.CreateInBoundsGEP(T_prjlvalue, bv, offset);
 }
 
@@ -483,17 +483,17 @@ static Value *emit_struct_gep(jl_codectx_t &ctx, Type *lty, Value *base, unsigne
     return ctx.builder.CreateConstInBoundsGEP2_32(lty, base, 0, idx);
 }
 
-static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, llvm::LLVMContext &ctxt, jl_value_t *jt, bool *isboxed, bool llvmcall=false);
+static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, LLVMContext &ctxt, jl_value_t *jt, bool *isboxed, bool llvmcall=false);
 
-static Type *_julia_type_to_llvm(jl_codegen_params_t *ctx, llvm::LLVMContext &ctxt, jl_value_t *jt, bool *isboxed)
+static Type *_julia_type_to_llvm(jl_codegen_params_t *ctx, LLVMContext &ctxt, jl_value_t *jt, bool *isboxed)
 {
     // this function converts a Julia Type into the equivalent LLVM type
     if (isboxed) *isboxed = false;
     if (jt == (jl_value_t*)jl_bottom_type)
-        return T_void;
+        return getVoidTy(ctxt);
     if (jl_is_concrete_immutable(jt)) {
         if (jl_datatype_nbits(jt) == 0)
-            return T_void;
+            return getVoidTy(ctxt);
         Type *t = _julia_struct_to_llvm(ctx, ctxt, jt, isboxed);
         assert(t != NULL);
         return t;
@@ -515,21 +515,21 @@ Type *jl_type_to_llvm_impl(jl_value_t *jt, bool *isboxed)
 
 
 // converts a julia bitstype into the equivalent LLVM bitstype
-static Type *bitstype_to_llvm(jl_value_t *bt, llvm::LLVMContext &ctxt, bool llvmcall = false)
+static Type *bitstype_to_llvm(jl_value_t *bt, LLVMContext &ctxt, bool llvmcall = false)
 {
     assert(jl_is_primitivetype(bt));
     if (bt == (jl_value_t*)jl_bool_type)
-        return llvm::Type::getInt8Ty(ctxt);
+        return getInt8Ty(ctxt);
     if (bt == (jl_value_t*)jl_int32_type)
-        return llvm::Type::getInt32Ty(ctxt);
+        return getInt32Ty(ctxt);
     if (bt == (jl_value_t*)jl_int64_type)
-        return llvm::Type::getInt64Ty(ctxt);
+        return getInt64Ty(ctxt);
     if (bt == (jl_value_t*)jl_float16_type)
-        return llvm::Type::getHalfTy(ctxt);
+        return getHalfTy(ctxt);
     if (bt == (jl_value_t*)jl_float32_type)
-        return llvm::Type::getFloatTy(ctxt);
+        return getFloatTy(ctxt);
     if (bt == (jl_value_t*)jl_float64_type)
-        return llvm::Type::getDoubleTy(ctxt);
+        return getDoubleTy(ctxt);
     if (jl_is_llvmpointer_type(bt)) {
         jl_value_t *as_param = jl_tparam1(bt);
         int as;
@@ -539,10 +539,10 @@ static Type *bitstype_to_llvm(jl_value_t *bt, llvm::LLVMContext &ctxt, bool llvm
             as = jl_unbox_int64(as_param);
         else
             jl_error("invalid pointer address space");
-        return PointerType::get(llvm::Type::getInt8Ty(ctxt), as);
+        return PointerType::get(getInt8Ty(ctxt), as);
     }
     int nb = jl_datatype_size(bt);
-    return Type::getIntNTy(jl_LLVMContext, nb * 8);
+    return Type::getIntNTy(ctxt, nb * 8);
 }
 
 static bool jl_type_hasptr(jl_value_t* typ)
@@ -558,14 +558,14 @@ static unsigned jl_field_align(jl_datatype_t *dt, size_t i)
     return std::min({al, (unsigned)jl_datatype_align(dt), (unsigned)JL_HEAP_ALIGNMENT});
 }
 
-static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, llvm::LLVMContext &ctxt, jl_value_t *jt, bool *isboxed, bool llvmcall)
+static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, LLVMContext &ctxt, jl_value_t *jt, bool *isboxed, bool llvmcall)
 {
     // this function converts a Julia Type into the equivalent LLVM struct
     // use this where C-compatible (unboxed) structs are desired
     // use julia_type_to_llvm directly when you want to preserve Julia's type semantics
     if (isboxed) *isboxed = false;
     if (jt == (jl_value_t*)jl_bottom_type)
-        return T_void;
+        return getVoidTy(ctxt);
     if (jl_is_primitivetype(jt))
         return bitstype_to_llvm(jt, ctxt, llvmcall);
     jl_datatype_t *jst = (jl_datatype_t*)jt;
@@ -576,7 +576,7 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, llvm::LLVMContext &
         if (!jl_struct_try_layout(jst))
             return NULL; // caller should have checked jl_type_mappable_to_c already, but we'll be nice
         if (ntypes == 0 || jl_datatype_nbits(jst) == 0)
-            return T_void;
+            return getVoidTy(ctxt);
         Type *_struct_decl = NULL;
         // TODO: we should probably make a temporary root for `jst` somewhere
         // don't use pre-filled struct_decl for llvmcall (f16, etc. may be different)
@@ -605,7 +605,7 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, llvm::LLVMContext &
                 isvector = false;
             }
             else if (ty == (jl_value_t*)jl_bool_type) {
-                lty = llvm::Type::getInt8Ty(ctxt);
+                lty = getInt8Ty(ctxt);
             }
             else if (jl_is_uniontype(ty)) {
                 // pick an Integer type size such that alignment will generally be correct,
@@ -617,27 +617,27 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, llvm::LLVMContext &
                 if (fsz > 0) {
                     if (al > MAX_ALIGN) {
                         Type *AlignmentType;
-                        AlignmentType = ArrayType::get(FixedVectorType::get(llvm::Type::getInt8Ty(ctxt), al), 0);
+                        AlignmentType = ArrayType::get(FixedVectorType::get(getInt8Ty(ctxt), al), 0);
                         latypes.push_back(AlignmentType);
                         al = MAX_ALIGN;
                     }
-                    Type *AlignmentType = IntegerType::get(jl_LLVMContext, 8 * al);
+                    Type *AlignmentType = IntegerType::get(ctxt, 8 * al);
                     unsigned NumATy = fsz / al;
                     unsigned remainder = fsz % al;
                     assert(al == 1 || NumATy > 0);
                     while (NumATy--)
                         latypes.push_back(AlignmentType);
                     while (remainder--)
-                        latypes.push_back(llvm::Type::getInt8Ty(ctxt));
+                        latypes.push_back(getInt8Ty(ctxt));
                 }
-                latypes.push_back(llvm::Type::getInt8Ty(ctxt));
+                latypes.push_back(getInt8Ty(ctxt));
                 isarray = false;
                 allghost = false;
                 continue;
             }
             else {
                 bool isptr;
-                lty = _julia_struct_to_llvm(ctx, jl_LLVMContext, ty, &isptr, llvmcall);
+                lty = _julia_struct_to_llvm(ctx, ctxt, ty, &isptr, llvmcall);
                 assert(lty && !isptr);
             }
             if (lasttype != NULL && lasttype != lty)
@@ -650,7 +650,7 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, llvm::LLVMContext &
         }
         if (allghost) {
             assert(jst->layout == NULL); // otherwise should have been caught above
-            struct_decl = T_void;
+            struct_decl = getVoidTy(ctxt);
         }
         else if (jl_is_vecelement_type(jt) && !jl_is_uniontype(jl_svecref(ftypes, 0))) {
             // VecElement type is unwrapped in LLVM (when possible)
@@ -662,17 +662,17 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, llvm::LLVMContext &
             else if (isTuple || !llvmcall)
                 struct_decl = ArrayType::get(lasttype, ntypes);
             else
-                struct_decl = StructType::get(jl_LLVMContext, latypes);
+                struct_decl = StructType::get(ctxt, latypes);
         }
         else {
 #if 0 // stress-test code that tries to assume julia-index == llvm-index
       // (also requires change to emit_new_struct to not assume 0 == 0)
             if (!isTuple && latypes.size() > 1) {
-                Type *NoopType = ArrayType::get(llvm::Type::getInt1Ty(ctxt), 0);
+                Type *NoopType = ArrayType::get(getInt1Ty(ctxt), 0);
                 latypes.insert(latypes.begin(), NoopType);
             }
 #endif
-            struct_decl = StructType::get(jl_LLVMContext, latypes);
+            struct_decl = StructType::get(ctxt, latypes);
         }
         return struct_decl;
     }
@@ -683,10 +683,10 @@ static Type *_julia_struct_to_llvm(jl_codegen_params_t *ctx, llvm::LLVMContext &
     //  lty = ArrayType::get(IntegerType::get(lty->getContext(), 8 * al), fsz / al);
     //  std::vector<Type*> Elements(2);
     //  Elements[0] = lty;
-    //  Elements[1] = llvm::Type::getInt8Ty(ctxt);
+    //  Elements[1] = getInt8Ty(ctxt);
     //  unsigned remainder = fsz % al;
     //  while (remainder--)
-    //      Elements.push_back(llvm::Type::getInt8Ty(ctxt));
+    //      Elements.push_back(getInt8Ty(ctxt));
     //  lty = StructType::get(lty->getContext(), makeArrayRef(Elements));
     // }
     if (isboxed) *isboxed = true;
@@ -783,7 +783,7 @@ static Value *emit_nthptr_addr(jl_codectx_t &ctx, Value *v, ssize_t n, bool gctr
     return ctx.builder.CreateInBoundsGEP(
             T_prjlvalue,
             emit_bitcast(ctx, maybe_decay_tracked(ctx, v), T_pprjlvalue),
-            ConstantInt::get(T_size, n));
+            ConstantInt::get(getSizeTy(ctx.builder.getContext()), n));
 }
 
 static Value *emit_nthptr_addr(jl_codectx_t &ctx, Value *v, Value *idx)
@@ -835,13 +835,13 @@ static jl_cgval_t emit_typeof(jl_codectx_t &ctx, const jl_cgval_t &p)
         return mark_julia_type(ctx, emit_typeof(ctx, p.V), true, jl_datatype_type);
     }
     if (p.TIndex) {
-        Value *tindex = ctx.builder.CreateAnd(p.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x7f));
+        Value *tindex = ctx.builder.CreateAnd(p.TIndex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0x7f));
         bool allunboxed = is_uniontype_allunboxed(p.typ);
         Value *datatype_or_p = imaging_mode ? Constant::getNullValue(T_ppjlvalue) : Constant::getNullValue(T_prjlvalue);
         unsigned counter = 0;
         for_each_uniontype_small(
             [&](unsigned idx, jl_datatype_t *jt) {
-                Value *cmp = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), idx));
+                Value *cmp = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), idx));
                 Value *ptr;
                 if (imaging_mode) {
                     ptr = literal_pointer_val_slot(ctx, (jl_value_t*)jt);
@@ -897,7 +897,7 @@ static Value *emit_typeof_boxed(jl_codectx_t &ctx, const jl_cgval_t &p)
 static Value *emit_datatype_types(jl_codectx_t &ctx, Value *dt)
 {
     Value *Ptr = emit_bitcast(ctx, decay_derived(ctx, dt), T_ppjlvalue);
-    Value *Idx = ConstantInt::get(T_size, offsetof(jl_datatype_t, types) / sizeof(void*));
+    Value *Idx = ConstantInt::get(getSizeTy(ctx.builder.getContext()), offsetof(jl_datatype_t, types) / sizeof(void*));
     return tbaa_decorate(ctx.tbaa().tbaa_const, ctx.builder.CreateAlignedLoad(
                 T_pjlvalue, ctx.builder.CreateInBoundsGEP(T_pjlvalue, Ptr, Idx), Align(sizeof(void*))));
 }
@@ -905,27 +905,27 @@ static Value *emit_datatype_types(jl_codectx_t &ctx, Value *dt)
 static Value *emit_datatype_nfields(jl_codectx_t &ctx, Value *dt)
 {
     Value *type_svec = emit_bitcast(ctx, emit_datatype_types(ctx, dt), T_psize);
-    return tbaa_decorate(ctx.tbaa().tbaa_const, ctx.builder.CreateAlignedLoad(T_size, type_svec, Align(sizeof(void*))));
+    return tbaa_decorate(ctx.tbaa().tbaa_const, ctx.builder.CreateAlignedLoad(getSizeTy(ctx.builder.getContext()), type_svec, Align(sizeof(void*))));
 }
 
 static Value *emit_datatype_size(jl_codectx_t &ctx, Value *dt)
 {
     Value *Ptr = emit_bitcast(ctx, decay_derived(ctx, dt), T_pint32);
-    Value *Idx = ConstantInt::get(T_size, offsetof(jl_datatype_t, size) / sizeof(int));
-    return tbaa_decorate(ctx.tbaa().tbaa_const, ctx.builder.CreateAlignedLoad(llvm::Type::getInt32Ty(ctx.builder.getContext()), ctx.builder.CreateInBoundsGEP(llvm::Type::getInt32Ty(ctx.builder.getContext()), Ptr, Idx), Align(sizeof(int32_t))));
+    Value *Idx = ConstantInt::get(getSizeTy(ctx.builder.getContext()), offsetof(jl_datatype_t, size) / sizeof(int));
+    return tbaa_decorate(ctx.tbaa().tbaa_const, ctx.builder.CreateAlignedLoad(getInt32Ty(ctx.builder.getContext()), ctx.builder.CreateInBoundsGEP(getInt32Ty(ctx.builder.getContext()), Ptr, Idx), Align(sizeof(int32_t))));
 }
 
 /* this is valid code, it's simply unused
 static Value *emit_sizeof(jl_codectx_t &ctx, const jl_cgval_t &p)
 {
     if (p.TIndex) {
-        Value *tindex = ctx.builder.CreateAnd(p.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x7f));
-        Value *size = ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), -1);
+        Value *tindex = ctx.builder.CreateAnd(p.TIndex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0x7f));
+        Value *size = ConstantInt::get(getInt32Ty(ctx.builder.getContext()), -1);
         unsigned counter = 0;
         bool allunboxed = for_each_uniontype_small(
                 [&](unsigned idx, jl_datatype_t *jt) {
-                    Value *cmp = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), idx));
-                    size = ctx.builder.CreateSelect(cmp, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), jl_datatype_size(jt)), size);
+                    Value *cmp = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), idx));
+                    size = ctx.builder.CreateSelect(cmp, ConstantInt::get(getInt32Ty(ctx.builder.getContext()), jl_datatype_size(jt)), size);
                 },
                 p.typ,
                 counter);
@@ -934,8 +934,8 @@ static Value *emit_sizeof(jl_codectx_t &ctx, const jl_cgval_t &p)
             BasicBlock *dynloadBB = BasicBlock::Create(ctx.builder.getContext(), "dyn_sizeof", ctx.f);
             BasicBlock *postBB = BasicBlock::Create(ctx.builder.getContext(), "post_sizeof", ctx.f);
             Value *isboxed = ctx.builder.CreateICmpNE(
-                    ctx.builder.CreateAnd(p.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80)),
-                    ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0));
+                    ctx.builder.CreateAnd(p.TIndex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0x80)),
+                    ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0));
             ctx.builder.CreateCondBr(isboxed, dynloadBB, postBB);
             ctx.builder.SetInsertPoint(dynloadBB);
             Value *datatype = emit_typeof(p.V);
@@ -943,19 +943,19 @@ static Value *emit_sizeof(jl_codectx_t &ctx, const jl_cgval_t &p)
             ctx.builder.CreateBr(postBB);
             dynloadBB = ctx.builder.GetInsertBlock(); // could have changed
             ctx.builder.SetInsertPoint(postBB);
-            PHINode *sizeof_merge = ctx.builder.CreatePHI(llvm::Type::getInt32Ty(ctx.builder.getContext()), 2);
+            PHINode *sizeof_merge = ctx.builder.CreatePHI(getInt32Ty(ctx.builder.getContext()), 2);
             sizeof_merge->addIncoming(dyn_size, dynloadBB);
             sizeof_merge->addIncoming(size, currBB);
             size = sizeof_merge;
         }
 #ifndef NDEBUG
         // try to catch codegen errors early, before it uses this to memcpy over the entire stack
-        CreateConditionalAbort(ctx.builder, ctx.builder.CreateICmpEQ(size, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), -1)));
+        CreateConditionalAbort(ctx.builder, ctx.builder.CreateICmpEQ(size, ConstantInt::get(getInt32Ty(ctx.builder.getContext()), -1)));
 #endif
         return size;
     }
     else if (jl_is_concrete_type(p.typ)) {
-        return ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), jl_datatype_size(p.typ));
+        return ConstantInt::get(getInt32Ty(ctx.builder.getContext()), jl_datatype_size(p.typ));
     }
     else {
         Value *datatype = emit_typeof_boxed(ctx, p);
@@ -968,21 +968,21 @@ static Value *emit_sizeof(jl_codectx_t &ctx, const jl_cgval_t &p)
 static Value *emit_datatype_mutabl(jl_codectx_t &ctx, Value *dt)
 {
     Value *Ptr = emit_bitcast(ctx, decay_derived(ctx, dt), T_ppint8);
-    Value *Idx = ConstantInt::get(T_size, offsetof(jl_datatype_t, name));
+    Value *Idx = ConstantInt::get(getSizeTy(ctx.builder.getContext()), offsetof(jl_datatype_t, name));
     Value *Nam = tbaa_decorate(ctx.tbaa().tbaa_const,
             ctx.builder.CreateAlignedLoad(T_pint8, ctx.builder.CreateInBoundsGEP(T_pint8, Ptr, Idx), Align(sizeof(int8_t*))));
-    Value *Idx2 = ConstantInt::get(T_size, offsetof(jl_typename_t, n_uninitialized) + sizeof(((jl_typename_t*)nullptr)->n_uninitialized));
+    Value *Idx2 = ConstantInt::get(getSizeTy(ctx.builder.getContext()), offsetof(jl_typename_t, n_uninitialized) + sizeof(((jl_typename_t*)nullptr)->n_uninitialized));
     Value *mutabl = tbaa_decorate(ctx.tbaa().tbaa_const,
-            ctx.builder.CreateAlignedLoad(llvm::Type::getInt8Ty(ctx.builder.getContext()), ctx.builder.CreateInBoundsGEP(llvm::Type::getInt8Ty(ctx.builder.getContext()), Nam, Idx2), Align(1)));
+            ctx.builder.CreateAlignedLoad(getInt8Ty(ctx.builder.getContext()), ctx.builder.CreateInBoundsGEP(getInt8Ty(ctx.builder.getContext()), Nam, Idx2), Align(1)));
     mutabl = ctx.builder.CreateLShr(mutabl, 1);
-    return ctx.builder.CreateTrunc(mutabl, llvm::Type::getInt1Ty(ctx.builder.getContext()));
+    return ctx.builder.CreateTrunc(mutabl, getInt1Ty(ctx.builder.getContext()));
 }
 
 static Value *emit_datatype_isprimitivetype(jl_codectx_t &ctx, Value *dt)
 {
     Value *immut = ctx.builder.CreateNot(emit_datatype_mutabl(ctx, dt));
-    Value *nofields = ctx.builder.CreateICmpEQ(emit_datatype_nfields(ctx, dt), Constant::getNullValue(T_size));
-    Value *sized = ctx.builder.CreateICmpSGT(emit_datatype_size(ctx, dt), ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 0));
+    Value *nofields = ctx.builder.CreateICmpEQ(emit_datatype_nfields(ctx, dt), Constant::getNullValue(getSizeTy(ctx.builder.getContext())));
+    Value *sized = ctx.builder.CreateICmpSGT(emit_datatype_size(ctx, dt), ConstantInt::get(getInt32Ty(ctx.builder.getContext()), 0));
     return ctx.builder.CreateAnd(immut, ctx.builder.CreateAnd(nofields, sized));
 }
 
@@ -1098,7 +1098,7 @@ static Value *emit_guarded_test(jl_codectx_t &ctx, Value *ifnot, Value *defval, 
 template<typename Func>
 static Value *emit_guarded_test(jl_codectx_t &ctx, Value *ifnot, bool defval, Func &&func)
 {
-    return emit_guarded_test(ctx, ifnot, ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), defval), func);
+    return emit_guarded_test(ctx, ifnot, ConstantInt::get(getInt1Ty(ctx.builder.getContext()), defval), func);
 }
 
 template<typename Func>
@@ -1215,7 +1215,7 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
             BasicBlock *failBB = BasicBlock::Create(ctx.builder.getContext(), "fail", ctx.f);
             ctx.builder.SetInsertPoint(failBB);
         }
-        return std::make_pair(ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), *known_isa), true);
+        return std::make_pair(ConstantInt::get(getInt1Ty(ctx.builder.getContext()), *known_isa), true);
     }
 
     if (jl_is_type_type(intersected_type) && jl_pointer_egal(intersected_type)) {
@@ -1230,11 +1230,11 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
         Value *vtyp = track_pjlvalue(ctx, literal_pointer_val(ctx, type));
         if (msg && *msg == "typeassert") {
             ctx.builder.CreateCall(prepare_call(jltypeassert_func), { vx, vtyp });
-            return std::make_pair(ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 1), true);
+            return std::make_pair(ConstantInt::get(getInt1Ty(ctx.builder.getContext()), 1), true);
         }
         return std::make_pair(ctx.builder.CreateICmpNE(
                 ctx.builder.CreateCall(prepare_call(jlisa_func), { vx, vtyp }),
-                ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 0)), false);
+                ConstantInt::get(getInt32Ty(ctx.builder.getContext()), 0)), false);
     }
     // tests for isa concretetype can be handled with pointer comparisons
     if (jl_is_concrete_type(intersected_type)) {
@@ -1242,12 +1242,12 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
             unsigned tindex = get_box_tindex((jl_datatype_t*)intersected_type, x.typ);
             if (tindex > 0) {
                 // optimize more when we know that this is a split union-type where tindex = 0 is invalid
-                Value *xtindex = ctx.builder.CreateAnd(x.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x7f));
-                return std::make_pair(ctx.builder.CreateICmpEQ(xtindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), tindex)), false);
+                Value *xtindex = ctx.builder.CreateAnd(x.TIndex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0x7f));
+                return std::make_pair(ctx.builder.CreateICmpEQ(xtindex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), tindex)), false);
             }
             else if (x.Vboxed) {
                 // test for (x.TIndex == 0x80 && typeof(x.V) == type)
-                Value *isboxed = ctx.builder.CreateICmpEQ(x.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80));
+                Value *isboxed = ctx.builder.CreateICmpEQ(x.TIndex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0x80));
                 BasicBlock *currBB = ctx.builder.GetInsertBlock();
                 BasicBlock *isaBB = BasicBlock::Create(ctx.builder.getContext(), "isa", ctx.f);
                 BasicBlock *postBB = BasicBlock::Create(ctx.builder.getContext(), "post_isa", ctx.f);
@@ -1258,13 +1258,13 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
                 ctx.builder.CreateBr(postBB);
                 isaBB = ctx.builder.GetInsertBlock(); // could have changed
                 ctx.builder.SetInsertPoint(postBB);
-                PHINode *istype = ctx.builder.CreatePHI(llvm::Type::getInt1Ty(ctx.builder.getContext()), 2);
-                istype->addIncoming(ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 0), currBB);
+                PHINode *istype = ctx.builder.CreatePHI(getInt1Ty(ctx.builder.getContext()), 2);
+                istype->addIncoming(ConstantInt::get(getInt1Ty(ctx.builder.getContext()), 0), currBB);
                 istype->addIncoming(istype_boxed, isaBB);
                 return std::make_pair(istype, false);
             } else {
                 // handle the case where we know that `x` is unboxed (but of unknown type), but that concrete type `type` cannot be unboxed
-                return std::make_pair(ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 0), false);
+                return std::make_pair(ConstantInt::get(getInt1Ty(ctx.builder.getContext()), 0), false);
             }
         }
         return std::make_pair(emit_exactly_isa(ctx, x, intersected_type), false);
@@ -1285,13 +1285,13 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
         emit_isa_union(ctx, x, intersected_type, bbs);
         int nbbs = bbs.size();
         BasicBlock *currBB = ctx.builder.GetInsertBlock();
-        PHINode *res = ctx.builder.CreatePHI(llvm::Type::getInt1Ty(ctx.builder.getContext()), nbbs);
+        PHINode *res = ctx.builder.CreatePHI(getInt1Ty(ctx.builder.getContext()), nbbs);
         for (int i = 0; i < nbbs; i++) {
             auto bb = bbs[i].first.second;
             ctx.builder.SetInsertPoint(bb);
             if (i + 1 < nbbs) {
                 ctx.builder.CreateCondBr(bbs[i].second, currBB, bbs[i + 1].first.first);
-                res->addIncoming(ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 1), bb);
+                res->addIncoming(ConstantInt::get(getInt1Ty(ctx.builder.getContext()), 1), bb);
             }
             else {
                 ctx.builder.CreateBr(currBB);
@@ -1306,7 +1306,7 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
             ctx.builder.CreateCall(prepare_call(jlsubtype_func),
               { emit_typeof_boxed(ctx, x),
                 track_pjlvalue(ctx, literal_pointer_val(ctx, type)) }),
-            ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 0)), false);
+            ConstantInt::get(getInt32Ty(ctx.builder.getContext()), 0)), false);
 }
 
 static void emit_typecheck(jl_codectx_t &ctx, const jl_cgval_t &x, jl_value_t *type, const std::string &msg)
@@ -1331,10 +1331,10 @@ static void emit_typecheck(jl_codectx_t &ctx, const jl_cgval_t &x, jl_value_t *t
 static Value *emit_isconcrete(jl_codectx_t &ctx, Value *typ)
 {
     Value *isconcrete;
-    isconcrete = ctx.builder.CreateConstInBoundsGEP1_32(llvm::Type::getInt8Ty(ctx.builder.getContext()), emit_bitcast(ctx, decay_derived(ctx, typ), T_pint8), offsetof(jl_datatype_t, hash) + sizeof(((jl_datatype_t*)nullptr)->hash));
-    isconcrete = tbaa_decorate(ctx.tbaa().tbaa_const, ctx.builder.CreateAlignedLoad(llvm::Type::getInt8Ty(ctx.builder.getContext()), isconcrete, Align(1)));
+    isconcrete = ctx.builder.CreateConstInBoundsGEP1_32(getInt8Ty(ctx.builder.getContext()), emit_bitcast(ctx, decay_derived(ctx, typ), T_pint8), offsetof(jl_datatype_t, hash) + sizeof(((jl_datatype_t*)nullptr)->hash));
+    isconcrete = tbaa_decorate(ctx.tbaa().tbaa_const, ctx.builder.CreateAlignedLoad(getInt8Ty(ctx.builder.getContext()), isconcrete, Align(1)));
     isconcrete = ctx.builder.CreateLShr(isconcrete, 1);
-    isconcrete = ctx.builder.CreateTrunc(isconcrete, llvm::Type::getInt1Ty(ctx.builder.getContext()));
+    isconcrete = ctx.builder.CreateTrunc(isconcrete, getInt1Ty(ctx.builder.getContext()));
     return isconcrete;
 }
 
@@ -1362,7 +1362,7 @@ static bool bounds_check_enabled(jl_codectx_t &ctx, jl_value_t *inbounds) {
 
 static Value *emit_bounds_check(jl_codectx_t &ctx, const jl_cgval_t &ainfo, jl_value_t *ty, Value *i, Value *len, jl_value_t *boundscheck)
 {
-    Value *im1 = ctx.builder.CreateSub(i, ConstantInt::get(T_size, 1));
+    Value *im1 = ctx.builder.CreateSub(i, ConstantInt::get(getSizeTy(ctx.builder.getContext()), 1));
 #if CHECK_BOUNDS==1
     if (bounds_check_enabled(ctx, boundscheck)) {
         Value *ok = ctx.builder.CreateICmpULT(im1, len);
@@ -1533,7 +1533,7 @@ static jl_cgval_t typed_load(jl_codectx_t &ctx, Value *ptr, Value *idx_0based, j
         //load->setMetadata(LLVMContext::MD_range, MDNode::get(ctx.builder.getContext(), {
         //    ConstantAsMetadata::get(ConstantInt::get(T_int8, 0)),
         //    ConstantAsMetadata::get(ConstantInt::get(T_int8, 2)) }));
-        instr = ctx.builder.CreateTrunc(instr, llvm::Type::getInt1Ty(ctx.builder.getContext()));
+        instr = ctx.builder.CreateTrunc(instr, getInt1Ty(ctx.builder.getContext()));
     }
     return mark_julia_type(ctx, instr, isboxed, jltype);
 }
@@ -1571,8 +1571,8 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             return rhs;
         }
         else if (isreplacefield) {
-            Value *Success = emit_f_is(ctx, cmp, ghostValue(jltype));
-            Success = ctx.builder.CreateZExt(Success, llvm::Type::getInt8Ty(ctx.builder.getContext()));
+            Value *Success = emit_f_is(ctx, cmp, ghostValue(jltype, ctx.tbaa()));
+            Success = ctx.builder.CreateZExt(Success, getInt8Ty(ctx.builder.getContext()));
             const jl_cgval_t argv[2] = {ghostValue(jltype, ctx.tbaa()), mark_julia_type(ctx, Success, false, jl_bool_type)};
             jl_datatype_t *rettyp = jl_apply_cmpswap_type(jltype);
             return emit_new_struct(ctx, (jl_value_t*)rettyp, 2, argv);
@@ -1686,8 +1686,8 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
                     instr = load;
                     ctx.builder.CreateBr(DoneBB);
                     ctx.builder.SetInsertPoint(DoneBB);
-                    Succ = ctx.builder.CreatePHI(llvm::Type::getInt1Ty(ctx.builder.getContext()), 2);
-                    Succ->addIncoming(ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), false), SkipBB);
+                    Succ = ctx.builder.CreatePHI(getInt1Ty(ctx.builder.getContext()), 2);
+                    Succ->addIncoming(ConstantInt::get(getInt1Ty(ctx.builder.getContext()), false), SkipBB);
                     Current = ctx.builder.CreatePHI(instr->getType(), 2);
                     Current->addIncoming(instr, SkipBB);
                     ctx.builder.SetInsertPoint(BB);
@@ -1886,7 +1886,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
         }
         oldval = mark_julia_type(ctx, instr, isboxed, jltype);
         if (isreplacefield) {
-            Success = ctx.builder.CreateZExt(Success, llvm::Type::getInt8Ty(ctx.builder.getContext()));
+            Success = ctx.builder.CreateZExt(Success, getInt8Ty(ctx.builder.getContext()));
             const jl_cgval_t argv[2] = {oldval, mark_julia_type(ctx, Success, false, jl_bool_type)};
             jl_datatype_t *rettyp = jl_apply_cmpswap_type(jltype);
             oldval = emit_new_struct(ctx, (jl_value_t*)rettyp, 2, argv);
@@ -2015,7 +2015,7 @@ static bool emit_getfield_unknownidx(jl_codectx_t &ctx,
     size_t nfields = jl_datatype_nfields(stt);
     bool maybe_null = (unsigned)stt->name->n_uninitialized != 0;
     auto idx0 = [&]() {
-        return emit_bounds_check(ctx, strct, (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields), inbounds);
+        return emit_bounds_check(ctx, strct, (jl_value_t*)stt, idx, ConstantInt::get(getSizeTy(ctx.builder.getContext()), nfields), inbounds);
     };
     if (nfields == 0) {
         (void)idx0();
@@ -2048,7 +2048,7 @@ static bool emit_getfield_unknownidx(jl_codectx_t &ctx,
                 assert(stt->layout->npointers == 0); // we could, but don't emit this
                 idx = idx0();
                 if (sizeof(void*) != sizeof(int))
-                    idx = ctx.builder.CreateTrunc(idx, llvm::Type::getInt32Ty(ctx.builder.getContext())); // llvm3.3 requires this, harmless elsewhere
+                    idx = ctx.builder.CreateTrunc(idx, getInt32Ty(ctx.builder.getContext())); // llvm3.3 requires this, harmless elsewhere
                 Value *fld = ctx.builder.CreateExtractElement(strct.V, idx);
                 *ret = mark_julia_type(ctx, fld, isboxed, jft);
                 return true;
@@ -2138,7 +2138,7 @@ static bool emit_getfield_unknownidx(jl_codectx_t &ctx,
             return true;
         }
         else if (strct.isboxed) {
-            idx = ctx.builder.CreateSub(idx, ConstantInt::get(T_size, 1));
+            idx = ctx.builder.CreateSub(idx, ConstantInt::get(getSizeTy(ctx.builder.getContext()), 1));
             Value *fld = ctx.builder.CreateCall(prepare_call(jlgetnthfieldchecked_func), { boxed(ctx, strct), idx });
             *ret = mark_julia_type(ctx, fld, true, jl_any_type);
             return true;
@@ -2151,11 +2151,11 @@ static jl_cgval_t emit_unionload(jl_codectx_t &ctx, Value *addr, Value *ptindex,
         jl_value_t *jfty, size_t fsz, size_t al, MDNode *tbaa, bool mutabl,
         unsigned union_max, MDNode *tbaa_ptindex)
 {
-    Instruction *tindex0 = tbaa_decorate(tbaa_ptindex, ctx.builder.CreateAlignedLoad(llvm::Type::getInt8Ty(ctx.builder.getContext()), ptindex, Align(1)));
+    Instruction *tindex0 = tbaa_decorate(tbaa_ptindex, ctx.builder.CreateAlignedLoad(getInt8Ty(ctx.builder.getContext()), ptindex, Align(1)));
     tindex0->setMetadata(LLVMContext::MD_range, MDNode::get(ctx.builder.getContext(), {
-        ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0)),
-        ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), union_max)) }));
-    Value *tindex = ctx.builder.CreateNUWAdd(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 1), tindex0);
+        ConstantAsMetadata::get(ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0)),
+        ConstantAsMetadata::get(ConstantInt::get(getInt8Ty(ctx.builder.getContext()), union_max)) }));
+    Value *tindex = ctx.builder.CreateNUWAdd(ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 1), tindex0);
     if (fsz > 0 && mutabl) {
         // move value to an immutable stack slot (excluding tindex)
         Type *AT = ArrayType::get(IntegerType::get(ctx.builder.getContext(), 8 * al), (fsz + al - 1) / al);
@@ -2211,9 +2211,9 @@ static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &st
             // can pessimize mem2reg
             if (byte_offset > 0) {
                 addr = ctx.builder.CreateInBoundsGEP(
-                        llvm::Type::getInt8Ty(ctx.builder.getContext()),
+                        getInt8Ty(ctx.builder.getContext()),
                         emit_bitcast(ctx, staddr, T_pint8),
-                        ConstantInt::get(T_size, byte_offset));
+                        ConstantInt::get(getSizeTy(ctx.builder.getContext()), byte_offset));
             }
             else {
                 addr = staddr;
@@ -2245,7 +2245,7 @@ static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &st
             Value *ptindex;
             if (isboxed) {
                 ptindex = ctx.builder.CreateConstInBoundsGEP1_32(
-                    llvm::Type::getInt8Ty(ctx.builder.getContext()), emit_bitcast(ctx, staddr, T_pint8), byte_offset + fsz);
+                    getInt8Ty(ctx.builder.getContext()), emit_bitcast(ctx, staddr, T_pint8), byte_offset + fsz);
             }
             else {
                 ptindex = emit_struct_gep(ctx, cast<StructType>(lt), staddr, byte_offset + fsz);
@@ -2280,7 +2280,7 @@ static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &st
             fldv = obj;
         }
         else if (isa<VectorType>(T)) {
-            fldv = ctx.builder.CreateExtractElement(obj, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), idx));
+            fldv = ctx.builder.CreateExtractElement(obj, ConstantInt::get(getInt32Ty(ctx.builder.getContext()), idx));
         }
         else if (!jl_field_isptr(jt, idx) && jl_is_uniontype(jfty)) {
             int fsz = jl_field_size(jt, idx) - 1;
@@ -2291,7 +2291,7 @@ static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &st
                 IntegerType *ET = cast<IntegerType>(T->getStructElementType(st_idx));
                 unsigned align = (ET->getBitWidth() + 7) / 8;
                 lv = emit_static_alloca(ctx, ET);
-                lv->setOperand(0, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), (fsz + align - 1) / align));
+                lv->setOperand(0, ConstantInt::get(getInt32Ty(ctx.builder.getContext()), (fsz + align - 1) / align));
                 // emit all of the align-sized words
                 unsigned i = 0;
                 for (; i < fsz / align; i++) {
@@ -2306,14 +2306,14 @@ static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &st
                     staddr = ctx.builder.CreateBitCast(staddr, T_pint8);
                     for (; i < ptindex - st_idx; i++) {
                         Value *fldv = ctx.builder.CreateExtractValue(obj, makeArrayRef(st_idx + i));
-                        Value *fldp = ctx.builder.CreateConstInBoundsGEP1_32(llvm::Type::getInt8Ty(ctx.builder.getContext()), staddr, i);
+                        Value *fldp = ctx.builder.CreateConstInBoundsGEP1_32(getInt8Ty(ctx.builder.getContext()), staddr, i);
                         ctx.builder.CreateAlignedStore(fldv, fldp, Align(1));
                     }
                 }
             }
             Value *tindex0 = ctx.builder.CreateExtractValue(obj, makeArrayRef(ptindex));
-            Value *tindex = ctx.builder.CreateNUWAdd(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 1), tindex0);
-            return mark_julia_slot(lv, jfty, tindex, ctx.tbaa().tbaa_stack);
+            Value *tindex = ctx.builder.CreateNUWAdd(ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 1), tindex0);
+            return mark_julia_slot(lv, jfty, tindex, ctx.tbaa(), ctx.tbaa().tbaa_stack);
         }
         else {
             unsigned st_idx;
@@ -2339,15 +2339,15 @@ static Value *emit_n_varargs(jl_codectx_t &ctx)
 {
     Value *valen = NULL;
     if (ctx.nvargs != -1) {
-        valen = ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), ctx.nvargs);
+        valen = ConstantInt::get(getInt32Ty(ctx.builder.getContext()), ctx.nvargs);
     } else {
         assert(ctx.argCount);
         int nreq = ctx.nReqArgs;
         valen = ctx.builder.CreateSub((Value*)ctx.argCount,
-                                        ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), nreq));
+                                        ConstantInt::get(getInt32Ty(ctx.builder.getContext()), nreq));
     }
 #ifdef _P64
-    return ctx.builder.CreateSExt(valen, llvm::Type::getInt64Ty(ctx.builder.getContext()));
+    return ctx.builder.CreateSExt(valen, getInt64Ty(ctx.builder.getContext()));
 #else
     return valen;
 #endif
@@ -2410,7 +2410,7 @@ static Value *emit_arraysize(jl_codectx_t &ctx, const jl_cgval_t &tinfo, Value *
     MDNode *tbaa = ctx.tbaa().tbaa_arraysize;
     if (arraytype_constdim(tinfo.typ, &ndim)) {
         if (ndim == 0)
-            return ConstantInt::get(T_size, 1);
+            return ConstantInt::get(getSizeTy(ctx.builder.getContext()), 1);
         if (ndim == 1) {
             if (auto d = dyn_cast<ConstantInt>(dim)) {
                 if (d->getZExtValue() == 1) {
@@ -2421,7 +2421,7 @@ static Value *emit_arraysize(jl_codectx_t &ctx, const jl_cgval_t &tinfo, Value *
         if (ndim > 1) {
             if (tinfo.constant && isa<ConstantInt>(dim)) {
                 auto n = cast<ConstantInt>(dim)->getZExtValue() - 1;
-                return ConstantInt::get(T_size, jl_array_dim(tinfo.constant, n));
+                return ConstantInt::get(getSizeTy(ctx.builder.getContext()), jl_array_dim(tinfo.constant, n));
             }
             tbaa = ctx.tbaa().tbaa_const;
         }
@@ -2431,16 +2431,16 @@ static Value *emit_arraysize(jl_codectx_t &ctx, const jl_cgval_t &tinfo, Value *
     auto load = emit_nthptr_recast(ctx,
             t,
             ctx.builder.CreateAdd(dim, ConstantInt::get(dim->getType(), o)),
-            tbaa, T_size);
+            tbaa, getSizeTy(ctx.builder.getContext()));
     MDBuilder MDB(ctx.builder.getContext());
-    auto rng = MDB.createRange(Constant::getNullValue(T_size), ConstantInt::get(T_size, arraytype_maxsize(tinfo.typ)));
+    auto rng = MDB.createRange(Constant::getNullValue(getSizeTy(ctx.builder.getContext())), ConstantInt::get(getSizeTy(ctx.builder.getContext()), arraytype_maxsize(tinfo.typ)));
     load->setMetadata(LLVMContext::MD_range, rng);
     return load;
 }
 
 static Value *emit_arraysize(jl_codectx_t &ctx, const jl_cgval_t &tinfo, int dim)
 {
-    return emit_arraysize(ctx, tinfo, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), dim));
+    return emit_arraysize(ctx, tinfo, ConstantInt::get(getInt32Ty(ctx.builder.getContext()), dim));
 }
 
 static Value *emit_vectormaxsize(jl_codectx_t &ctx, const jl_cgval_t &ary)
@@ -2455,10 +2455,10 @@ static Value *emit_arraylen_prim(jl_codectx_t &ctx, const jl_cgval_t &tinfo)
     MDNode *tbaa = ctx.tbaa().tbaa_arraylen;
     if (arraytype_constdim(ty, &ndim)) {
         if (ndim == 0)
-            return ConstantInt::get(T_size, 1);
+            return ConstantInt::get(getSizeTy(ctx.builder.getContext()), 1);
         if (ndim != 1) {
             if (tinfo.constant)
-                return ConstantInt::get(T_size, jl_array_len(tinfo.constant));
+                return ConstantInt::get(getSizeTy(ctx.builder.getContext()), jl_array_len(tinfo.constant));
             tbaa = ctx.tbaa().tbaa_const;
         }
     }
@@ -2466,10 +2466,10 @@ static Value *emit_arraylen_prim(jl_codectx_t &ctx, const jl_cgval_t &tinfo)
     Value *addr = ctx.builder.CreateStructGEP(jl_array_llvmt,
             emit_bitcast(ctx, decay_derived(ctx, t), jl_parray_llvmt),
             1); //index (not offset) of length field in jl_parray_llvmt
-    LoadInst *len = ctx.builder.CreateAlignedLoad(T_size, addr, Align(sizeof(size_t)));
+    LoadInst *len = ctx.builder.CreateAlignedLoad(getSizeTy(ctx.builder.getContext()), addr, Align(sizeof(size_t)));
     len->setOrdering(AtomicOrdering::NotAtomic);
     MDBuilder MDB(ctx.builder.getContext());
-    auto rng = MDB.createRange(Constant::getNullValue(T_size), ConstantInt::get(T_size, arraytype_maxsize(tinfo.typ)));
+    auto rng = MDB.createRange(Constant::getNullValue(getSizeTy(ctx.builder.getContext())), ConstantInt::get(getSizeTy(ctx.builder.getContext()), arraytype_maxsize(tinfo.typ)));
     len->setMetadata(LLVMContext::MD_range, rng);
     return tbaa_decorate(tbaa, len);
 }
@@ -2538,7 +2538,7 @@ static Value *emit_arrayflags(jl_codectx_t &ctx, const jl_cgval_t &tinfo)
             jl_array_llvmt,
             emit_bitcast(ctx, decay_derived(ctx, t), jl_parray_llvmt),
             arrayflag_field);
-    return tbaa_decorate(ctx.tbaa().tbaa_arrayflags, ctx.builder.CreateAlignedLoad(llvm::Type::getInt16Ty(ctx.builder.getContext()), addr, Align(sizeof(int16_t))));
+    return tbaa_decorate(ctx.tbaa().tbaa_arrayflags, ctx.builder.CreateAlignedLoad(getInt16Ty(ctx.builder.getContext()), addr, Align(sizeof(int16_t))));
 }
 
 static Value *emit_arrayndims(jl_codectx_t &ctx, const jl_cgval_t &ary)
@@ -2557,13 +2557,13 @@ static Value *emit_arrayelsize(jl_codectx_t &ctx, const jl_cgval_t &tinfo)
     Value *addr = ctx.builder.CreateStructGEP(jl_array_llvmt,
             emit_bitcast(ctx, decay_derived(ctx, t), jl_parray_llvmt),
             elsize_field);
-    return tbaa_decorate(ctx.tbaa().tbaa_const, ctx.builder.CreateAlignedLoad(llvm::Type::getInt16Ty(ctx.builder.getContext()), addr, Align(sizeof(int16_t))));
+    return tbaa_decorate(ctx.tbaa().tbaa_const, ctx.builder.CreateAlignedLoad(getInt16Ty(ctx.builder.getContext()), addr, Align(sizeof(int16_t))));
 }
 
 static Value *emit_arrayoffset(jl_codectx_t &ctx, const jl_cgval_t &tinfo, int nd)
 {
     if (nd != -1 && nd != 1) // only Vector can have an offset
-        return ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 0);
+        return ConstantInt::get(getInt32Ty(ctx.builder.getContext()), 0);
     Value *t = boxed(ctx, tinfo);
     int offset_field = 4;
 
@@ -2571,7 +2571,7 @@ static Value *emit_arrayoffset(jl_codectx_t &ctx, const jl_cgval_t &tinfo, int n
             jl_array_llvmt,
             emit_bitcast(ctx, decay_derived(ctx, t), jl_parray_llvmt),
             offset_field);
-    return tbaa_decorate(ctx.tbaa().tbaa_arrayoffset, ctx.builder.CreateAlignedLoad(llvm::Type::getInt32Ty(ctx.builder.getContext()), addr, Align(sizeof(int32_t))));
+    return tbaa_decorate(ctx.tbaa().tbaa_arrayoffset, ctx.builder.CreateAlignedLoad(getInt32Ty(ctx.builder.getContext()), addr, Align(sizeof(int32_t))));
 }
 
 // Returns the size of the array represented by `tinfo` for the given dimension `dim` if
@@ -2579,7 +2579,7 @@ static Value *emit_arrayoffset(jl_codectx_t &ctx, const jl_cgval_t &tinfo, int n
 static Value *emit_arraysize_for_unsafe_dim(jl_codectx_t &ctx,
         const jl_cgval_t &tinfo, jl_value_t *ex, size_t dim, size_t nd)
 {
-    return dim > nd ? ConstantInt::get(T_size, 1) : emit_arraysize(ctx, tinfo, ex, dim);
+    return dim > nd ? ConstantInt::get(getSizeTy(ctx.builder.getContext()), 1) : emit_arraysize(ctx, tinfo, ex, dim);
 }
 
 // `nd == -1` means the dimension is unknown.
@@ -2588,8 +2588,8 @@ static Value *emit_array_nd_index(
         const jl_cgval_t *argv, size_t nidxs, jl_value_t *inbounds)
 {
     Value *a = boxed(ctx, ainfo);
-    Value *i = Constant::getNullValue(T_size);
-    Value *stride = ConstantInt::get(T_size, 1);
+    Value *i = Constant::getNullValue(getSizeTy(ctx.builder.getContext()));
+    Value *stride = ConstantInt::get(getSizeTy(ctx.builder.getContext()), 1);
 #if CHECK_BOUNDS==1
     bool bc = bounds_check_enabled(ctx, inbounds);
     BasicBlock *failBB = NULL, *endBB = NULL;
@@ -2600,11 +2600,11 @@ static Value *emit_array_nd_index(
 #endif
     Value **idxs = (Value**)alloca(sizeof(Value*) * nidxs);
     for (size_t k = 0; k < nidxs; k++) {
-        idxs[k] = emit_unbox(ctx, T_size, argv[k], (jl_value_t*)jl_long_type); // type asserted by caller
+        idxs[k] = emit_unbox(ctx, getSizeTy(ctx.builder.getContext()), argv[k], (jl_value_t*)jl_long_type); // type asserted by caller
     }
     Value *ii = NULL;
     for (size_t k = 0; k < nidxs; k++) {
-        ii = ctx.builder.CreateSub(idxs[k], ConstantInt::get(T_size, 1));
+        ii = ctx.builder.CreateSub(idxs[k], ConstantInt::get(getSizeTy(ctx.builder.getContext()), 1));
         i = ctx.builder.CreateAdd(i, ctx.builder.CreateMul(ii, stride));
         if (k < nidxs - 1) {
             assert(nd >= 0);
@@ -2649,23 +2649,23 @@ static Value *emit_array_nd_index(
             for (size_t k = nidxs+1; k < (size_t)nd; k++) {
                 BasicBlock *dimsokBB = BasicBlock::Create(ctx.builder.getContext(), "dimsok");
                 Value *dim = emit_arraysize_for_unsafe_dim(ctx, ainfo, ex, k, nd);
-                ctx.builder.CreateCondBr(ctx.builder.CreateICmpEQ(dim, ConstantInt::get(T_size, 1)), dimsokBB, failBB);
+                ctx.builder.CreateCondBr(ctx.builder.CreateICmpEQ(dim, ConstantInt::get(getSizeTy(ctx.builder.getContext()), 1)), dimsokBB, failBB);
                 ctx.f->getBasicBlockList().push_back(dimsokBB);
                 ctx.builder.SetInsertPoint(dimsokBB);
             }
             Value *dim = emit_arraysize_for_unsafe_dim(ctx, ainfo, ex, nd, nd);
-            ctx.builder.CreateCondBr(ctx.builder.CreateICmpEQ(dim, ConstantInt::get(T_size, 1)), endBB, failBB);
+            ctx.builder.CreateCondBr(ctx.builder.CreateICmpEQ(dim, ConstantInt::get(getSizeTy(ctx.builder.getContext()), 1)), endBB, failBB);
         }
 
         ctx.f->getBasicBlockList().push_back(failBB);
         ctx.builder.SetInsertPoint(failBB);
         // CreateAlloca is OK here since we are on an error branch
-        Value *tmp = ctx.builder.CreateAlloca(T_size, ConstantInt::get(T_size, nidxs));
+        Value *tmp = ctx.builder.CreateAlloca(getSizeTy(ctx.builder.getContext()), ConstantInt::get(getSizeTy(ctx.builder.getContext()), nidxs));
         for (size_t k = 0; k < nidxs; k++) {
-            ctx.builder.CreateAlignedStore(idxs[k], ctx.builder.CreateInBoundsGEP(T_size, tmp, ConstantInt::get(T_size, k)), Align(sizeof(size_t)));
+            ctx.builder.CreateAlignedStore(idxs[k], ctx.builder.CreateInBoundsGEP(getSizeTy(ctx.builder.getContext()), tmp, ConstantInt::get(getSizeTy(ctx.builder.getContext()), k)), Align(sizeof(size_t)));
         }
         ctx.builder.CreateCall(prepare_call(jlboundserrorv_func),
-            { mark_callee_rooted(ctx, a), tmp, ConstantInt::get(T_size, nidxs) });
+            { mark_callee_rooted(ctx, a), tmp, ConstantInt::get(getSizeTy(ctx.builder.getContext()), nidxs) });
         ctx.builder.CreateUnreachable();
 
         ctx.f->getBasicBlockList().push_back(endBB);
@@ -2798,7 +2798,7 @@ static Value *load_i8box(jl_codectx_t &ctx, Value *v, jl_datatype_t *ty)
 {
     auto jvar = ty == jl_int8_type ? jlboxed_int8_cache : jlboxed_uint8_cache;
     GlobalVariable *gv = prepare_global_in(jl_Module, jvar);
-    Value *idx[] = {ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 0), ctx.builder.CreateZExt(v, llvm::Type::getInt32Ty(ctx.builder.getContext()))};
+    Value *idx[] = {ConstantInt::get(getInt32Ty(ctx.builder.getContext()), 0), ctx.builder.CreateZExt(v, getInt32Ty(ctx.builder.getContext()))};
     auto slot = ctx.builder.CreateInBoundsGEP(gv->getType()->getElementType(), gv, idx);
     return tbaa_decorate(ctx.tbaa().tbaa_const, maybe_mark_load_dereferenceable(
             ctx.builder.CreateAlignedLoad(T_pjlvalue, slot, Align(sizeof(void*))), false,
@@ -2811,8 +2811,8 @@ static Value *_boxed_special(jl_codectx_t &ctx, const jl_cgval_t &vinfo, Type *t
 {
     jl_value_t *jt = vinfo.typ;
     if (jt == (jl_value_t*)jl_bool_type)
-        return track_pjlvalue(ctx, julia_bool(ctx, ctx.builder.CreateTrunc(as_value(ctx, t, vinfo), llvm::Type::getInt1Ty(ctx.builder.getContext()))));
-    if (t == llvm::Type::getInt1Ty(ctx.builder.getContext()))
+        return track_pjlvalue(ctx, julia_bool(ctx, ctx.builder.CreateTrunc(as_value(ctx, t, vinfo), getInt1Ty(ctx.builder.getContext()))));
+    if (t == getInt1Ty(ctx.builder.getContext()))
         return track_pjlvalue(ctx, julia_bool(ctx, as_value(ctx, t, vinfo)));
 
     if (ctx.linfo && jl_is_method(ctx.linfo->def.method) && !vinfo.ispointer()) { // don't bother codegen pre-boxing for toplevel
@@ -2868,13 +2868,13 @@ static Value *_boxed_special(jl_codectx_t &ctx, const jl_cgval_t &vinfo, Type *t
 
 static Value *compute_box_tindex(jl_codectx_t &ctx, Value *datatype, jl_value_t *supertype, jl_value_t *ut)
 {
-    Value *tindex = ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0);
+    Value *tindex = ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0);
     unsigned counter = 0;
     for_each_uniontype_small(
             [&](unsigned idx, jl_datatype_t *jt) {
                 if (jl_subtype((jl_value_t*)jt, supertype)) {
                     Value *cmp = ctx.builder.CreateICmpEQ(track_pjlvalue(ctx, literal_pointer_val(ctx, (jl_value_t*)jt)), datatype);
-                    tindex = ctx.builder.CreateSelect(cmp, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), idx), tindex);
+                    tindex = ctx.builder.CreateSelect(cmp, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), idx), tindex);
                 }
             },
             ut,
@@ -2907,12 +2907,12 @@ static Value *emit_typeof_or_null(jl_codectx_t &ctx, Value *v)
 static Value *compute_tindex_unboxed(jl_codectx_t &ctx, const jl_cgval_t &val, jl_value_t *typ)
 {
     if (val.typ == jl_bottom_type)
-        return UndefValue::get(llvm::Type::getInt8Ty(ctx.builder.getContext()));
+        return UndefValue::get(getInt8Ty(ctx.builder.getContext()));
     if (val.constant)
-        return ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), get_box_tindex((jl_datatype_t*)jl_typeof(val.constant), typ));
+        return ConstantInt::get(getInt8Ty(ctx.builder.getContext()), get_box_tindex((jl_datatype_t*)jl_typeof(val.constant), typ));
 
     if (val.TIndex)
-        return ctx.builder.CreateAnd(val.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x7f));
+        return ctx.builder.CreateAnd(val.TIndex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0x7f));
     Value *typof;
     if (val.isboxed && !jl_is_concrete_type(val.typ) && !jl_is_type_type(val.typ))
         typof = emit_typeof_or_null(ctx, val.V);
@@ -3001,7 +3001,7 @@ static Value *box_union(jl_codectx_t &ctx, const jl_cgval_t &vinfo, const SmallB
                 Type *t = julia_type_to_llvm(ctx, (jl_value_t*)jt);
                 BasicBlock *tempBB = BasicBlock::Create(ctx.builder.getContext(), "box_union", ctx.f);
                 ctx.builder.SetInsertPoint(tempBB);
-                switchInst->addCase(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), idx), tempBB);
+                switchInst->addCase(ConstantInt::get(getInt8Ty(ctx.builder.getContext()), idx), tempBB);
                 Value *box;
                 if (type_is_ghost(t)) {
                     box = track_pjlvalue(ctx, literal_pointer_val(ctx, jt->instance));
@@ -3099,21 +3099,21 @@ static void emit_unionmove(jl_codectx_t &ctx, Value *dest, MDNode *tbaa_dst, con
                 Value *src_ptr = data_pointer(ctx, src);
                 unsigned nb = jl_datatype_size(typ);
                 unsigned alignment = julia_alignment(typ);
-                Value *nbytes = ConstantInt::get(T_size, nb);
+                Value *nbytes = ConstantInt::get(getSizeTy(ctx.builder.getContext()), nb);
                 if (skip) {
                     // TODO: this Select is very bad for performance, but is necessary to work around LLVM bugs with the undef option that we want to use:
                     //   select copy dest -> dest to simulate an undef value / conditional copy
                     // src_ptr = ctx.builder.CreateSelect(skip, dest, src_ptr);
-                    nbytes = ctx.builder.CreateSelect(skip, Constant::getNullValue(T_size), nbytes);
+                    nbytes = ctx.builder.CreateSelect(skip, Constant::getNullValue(getSizeTy(ctx.builder.getContext())), nbytes);
                 }
                 emit_memcpy(ctx, dest, tbaa_dst, src_ptr, src.tbaa, nbytes, alignment, isVolatile);
             }
         }
     }
     else if (src.TIndex) {
-        Value *tindex = ctx.builder.CreateAnd(src.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x7f));
+        Value *tindex = ctx.builder.CreateAnd(src.TIndex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0x7f));
         if (skip)
-            tindex = ctx.builder.CreateSelect(skip, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0), tindex);
+            tindex = ctx.builder.CreateSelect(skip, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0), tindex);
         Value *src_ptr = data_pointer(ctx, src);
         src_ptr = src_ptr ? maybe_bitcast(ctx, src_ptr, T_pint8) : src_ptr;
         dest = maybe_bitcast(ctx, dest, T_pint8);
@@ -3127,7 +3127,7 @@ static void emit_unionmove(jl_codectx_t &ctx, Value *dest, MDNode *tbaa_dst, con
                     unsigned alignment = julia_alignment((jl_value_t*)jt);
                     BasicBlock *tempBB = BasicBlock::Create(ctx.builder.getContext(), "union_move", ctx.f);
                     ctx.builder.SetInsertPoint(tempBB);
-                    switchInst->addCase(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), idx), tempBB);
+                    switchInst->addCase(ConstantInt::get(getInt8Ty(ctx.builder.getContext()), idx), tempBB);
                     if (nb > 0) {
                         if (!src_ptr) {
                             Function *trap_func =
@@ -3194,7 +3194,7 @@ static Value *emit_allocobj(jl_codectx_t &ctx, size_t static_size, Value *jt)
 {
     Value *current_task = get_current_task(ctx);
     Function *F = prepare_call(jl_alloc_obj_func);
-    auto call = ctx.builder.CreateCall(F, {current_task, ConstantInt::get(T_size, static_size), maybe_decay_untracked(ctx, jt)});
+    auto call = ctx.builder.CreateCall(F, {current_task, ConstantInt::get(getSizeTy(ctx.builder.getContext()), static_size), maybe_decay_untracked(ctx, jt)});
     call->setAttributes(F->getAttributes());
     return call;
 }
@@ -3273,9 +3273,9 @@ static jl_cgval_t emit_setfield(jl_codectx_t &ctx,
     Value *addr = data_pointer(ctx, strct);
     if (byte_offset > 0) {
         addr = ctx.builder.CreateInBoundsGEP(
-                llvm::Type::getInt8Ty(ctx.builder.getContext()),
+                getInt8Ty(ctx.builder.getContext()),
                 emit_bitcast(ctx, maybe_decay_tracked(ctx, addr), T_pint8),
-                ConstantInt::get(T_size, byte_offset)); // TODO: use emit_struct_gep
+                ConstantInt::get(getSizeTy(ctx.builder.getContext()), byte_offset)); // TODO: use emit_struct_gep
     }
     jl_value_t *jfty = jl_field_type(sty, idx0);
     if (!jl_field_isptr(sty, idx0) && jl_is_uniontype(jfty)) {
@@ -3287,7 +3287,7 @@ static jl_cgval_t emit_setfield(jl_codectx_t &ctx,
         jl_cgval_t rhs_union = convert_julia_type(ctx, rhs, jfty);
         if (rhs_union.typ == jl_bottom_type)
             return jl_cgval_t();
-        Value *ptindex = ctx.builder.CreateInBoundsGEP(llvm::Type::getInt8Ty(ctx.builder.getContext()), emit_bitcast(ctx, maybe_decay_tracked(ctx, addr), T_pint8), ConstantInt::get(T_size, fsz));
+        Value *ptindex = ctx.builder.CreateInBoundsGEP(getInt8Ty(ctx.builder.getContext()), emit_bitcast(ctx, maybe_decay_tracked(ctx, addr), T_pint8), ConstantInt::get(getSizeTy(ctx.builder.getContext()), fsz));
         if (needlock)
             emit_lockstate_value(ctx, strct, true);
         BasicBlock *ModifyBB;
@@ -3332,7 +3332,7 @@ static jl_cgval_t emit_setfield(jl_codectx_t &ctx,
             ctx.builder.SetInsertPoint(XchgBB);
         }
         Value *tindex = compute_tindex_unboxed(ctx, rhs_union, jfty);
-        tindex = ctx.builder.CreateNUWSub(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 1));
+        tindex = ctx.builder.CreateNUWSub(tindex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 1));
         tbaa_decorate(ctx.tbaa().tbaa_unionselbyte, ctx.builder.CreateAlignedStore(tindex, ptindex, Align(1)));
         // copy data
         if (!rhs.isghost) {
@@ -3345,7 +3345,7 @@ static jl_cgval_t emit_setfield(jl_codectx_t &ctx,
         if (needlock)
             emit_lockstate_value(ctx, strct, false);
         if (isreplacefield) {
-            Success = ctx.builder.CreateZExt(Success, llvm::Type::getInt8Ty(ctx.builder.getContext()));
+            Success = ctx.builder.CreateZExt(Success, getInt8Ty(ctx.builder.getContext()));
             jl_cgval_t argv[2] = {oldval, mark_julia_type(ctx, Success, false, jl_bool_type)};
             jl_datatype_t *rettyp = jl_apply_cmpswap_type(jfty);
             oldval = emit_new_struct(ctx, (jl_value_t*)rettyp, 2, argv);
@@ -3439,7 +3439,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                     if (rhs_union.typ == jl_bottom_type)
                         return jl_cgval_t();
                     Value *tindex = compute_tindex_unboxed(ctx, rhs_union, jtype);
-                    tindex = ctx.builder.CreateNUWSub(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 1));
+                    tindex = ctx.builder.CreateNUWSub(tindex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 1));
                     size_t fsz = 0, al = 0;
                     bool isptr = !jl_islayout_inline(jtype, &fsz, &al);
                     assert(!isptr && fsz == jl_field_size(sty, i) - 1); (void)isptr;
@@ -3453,7 +3453,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                             Type *ET = IntegerType::get(ctx.builder.getContext(), 8 * al);
                             assert(lt->getStructElementType(llvm_idx) == ET);
                             AllocaInst *lv = emit_static_alloca(ctx, ET);
-                            lv->setOperand(0, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), (fsz + al - 1) / al));
+                            lv->setOperand(0, ConstantInt::get(getInt32Ty(ctx.builder.getContext()), (fsz + al - 1) / al));
                             emit_unionmove(ctx, lv, ctx.tbaa().tbaa_stack, fval_info, nullptr);
                             // emit all of the align-sized words
                             unsigned i = 0;
@@ -3467,8 +3467,8 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                                 Value *staddr = ctx.builder.CreateConstInBoundsGEP1_32(ET, lv, i);
                                 staddr = ctx.builder.CreateBitCast(staddr, T_pint8);
                                 for (; i < ptindex - llvm_idx; i++) {
-                                    Value *fldp = ctx.builder.CreateConstInBoundsGEP1_32(llvm::Type::getInt8Ty(ctx.builder.getContext()), staddr, i);
-                                    Value *fldv = tbaa_decorate(ctx.tbaa().tbaa_stack, ctx.builder.CreateAlignedLoad(llvm::Type::getInt8Ty(ctx.builder.getContext()), fldp, Align(1)));
+                                    Value *fldp = ctx.builder.CreateConstInBoundsGEP1_32(getInt8Ty(ctx.builder.getContext()), staddr, i);
+                                    Value *fldv = tbaa_decorate(ctx.tbaa().tbaa_stack, ctx.builder.CreateAlignedLoad(getInt8Ty(ctx.builder.getContext()), fldp, Align(1)));
                                     strct = ctx.builder.CreateInsertValue(strct, fldv, makeArrayRef(llvm_idx + i));
                                 }
                             }
@@ -3493,7 +3493,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                     if (jl_is_vecelement_type(ty))
                         strct = fval;  // VecElement type comes unwrapped in LLVM.
                     else if (lt->isVectorTy())
-                        strct = ctx.builder.CreateInsertElement(strct, fval, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), llvm_idx));
+                        strct = ctx.builder.CreateInsertElement(strct, fval, ConstantInt::get(getInt32Ty(ctx.builder.getContext()), llvm_idx));
                     else if (lt->isAggregateType())
                         strct = ctx.builder.CreateInsertValue(strct, fval, makeArrayRef(llvm_idx));
                     else
@@ -3506,10 +3506,10 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                     int fsz = jl_field_size(sty, i) - 1;
                     unsigned llvm_idx = convert_struct_offset(ctx, cast<StructType>(lt), offs + fsz);
                     if (init_as_value)
-                        strct = ctx.builder.CreateInsertValue(strct, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0), makeArrayRef(llvm_idx));
+                        strct = ctx.builder.CreateInsertValue(strct, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0), makeArrayRef(llvm_idx));
                     else
                         tbaa_decorate(ctx.tbaa().tbaa_unionselbyte, ctx.builder.CreateAlignedStore(
-                                ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0),
+                                ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0),
                                 ctx.builder.CreateConstInBoundsGEP2_32(lt, strct, 0, llvm_idx),
                                 Align(1)));
                 }
@@ -3529,9 +3529,9 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
         for (size_t i = nargs; i < nf; i++) {
             if (!jl_field_isptr(sty, i) && jl_is_uniontype(jl_field_type(sty, i))) {
                 tbaa_decorate(ctx.tbaa().tbaa_unionselbyte, ctx.builder.CreateAlignedStore(
-                        ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0),
-                        ctx.builder.CreateInBoundsGEP(llvm::Type::getInt8Ty(ctx.builder.getContext()), emit_bitcast(ctx, strct, T_pint8),
-                                ConstantInt::get(T_size, jl_field_offset(sty, i) + jl_field_size(sty, i) - 1)),
+                        ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0),
+                        ctx.builder.CreateInBoundsGEP(getInt8Ty(ctx.builder.getContext()), emit_bitcast(ctx, strct, T_pint8),
+                                ConstantInt::get(getSizeTy(ctx.builder.getContext()), jl_field_offset(sty, i) + jl_field_size(sty, i) - 1)),
                         Align(1)));
             }
         }
@@ -3568,7 +3568,7 @@ static Value *emit_defer_signal(jl_codectx_t &ctx)
 {
     Value *ptls = emit_bitcast(ctx, get_current_ptls(ctx),
                                         PointerType::get(T_sigatomic, 0));
-    Constant *offset = ConstantInt::getSigned(llvm::Type::getInt32Ty(ctx.builder.getContext()),
+    Constant *offset = ConstantInt::getSigned(getInt32Ty(ctx.builder.getContext()),
         offsetof(jl_tls_states_t, defer_signal) / sizeof(sig_atomic_t));
     return ctx.builder.CreateInBoundsGEP(T_sigatomic, ptls, ArrayRef<Value*>(offset), "jl_defer_signal");
 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -169,11 +169,6 @@ static IntegerType *T_char;
 static IntegerType *T_size;
 static IntegerType *T_sigatomic;
 
-static Type *T_float16;
-static Type *T_float32;
-static Type *T_float64;
-static Type *T_float128;
-
 static Type *T_pint8;
 static Type *T_pint16;
 static Type *T_pint32;
@@ -851,8 +846,8 @@ BOX_FUNC(uint32, T_prjlvalue, llvm::Type::getInt32Ty(C), get_attrs_zext);
 BOX_FUNC(int64, T_prjlvalue, llvm::Type::getInt64Ty(C), get_attrs_sext);
 BOX_FUNC(uint64, T_prjlvalue, llvm::Type::getInt64Ty(C), get_attrs_zext);
 BOX_FUNC(char, T_prjlvalue, T_char, get_attrs_zext);
-BOX_FUNC(float32, T_prjlvalue, T_float32, get_func_attrs);
-BOX_FUNC(float64, T_prjlvalue, T_float64, get_func_attrs);
+BOX_FUNC(float32, T_prjlvalue, llvm::Type::getFloatTy(C), get_func_attrs);
+BOX_FUNC(float64, T_prjlvalue, llvm::Type::getDoubleTy(C), get_func_attrs);
 BOX_FUNC(ssavalue, T_prjlvalue, T_size, get_func_attrs);
 #undef BOX_FUNC
 
@@ -7789,12 +7784,8 @@ static void init_julia_llvm_env(Module *m)
         T_size = llvm::Type::getInt32Ty(m->getContext());
     T_sigatomic = Type::getIntNTy(m->getContext(), sizeof(sig_atomic_t) * 8);
     T_psize = PointerType::get(T_size, 0);
-    T_float16 = Type::getHalfTy(m->getContext());
-    T_float32 = Type::getFloatTy(m->getContext());
-    T_pfloat32 = PointerType::get(T_float32, 0);
-    T_float64 = Type::getDoubleTy(m->getContext());
-    T_pfloat64 = PointerType::get(T_float64, 0);
-    T_float128 = Type::getFP128Ty(m->getContext());
+    T_pfloat32 = PointerType::get(llvm::Type::getFloatTy(m->getContext()), 0);
+    T_pfloat64 = PointerType::get(llvm::Type::getDoubleTy(m->getContext()), 0);
     T_void = Type::getVoidTy(m->getContext());
     T_pvoidfunc = FunctionType::get(T_void, /*isVarArg*/false)->getPointerTo();
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -165,17 +165,6 @@ static FunctionType *jl_func_sig;
 static FunctionType *jl_func_sig_sparams;
 static Type *T_pvoidfunc;
 
-static IntegerType *T_int1;
-static IntegerType *T_int8;
-static IntegerType *T_int16;
-static IntegerType *T_int32;
-static IntegerType *T_int64;
-
-static IntegerType *T_uint8;
-static IntegerType *T_uint16;
-static IntegerType *T_uint32;
-static IntegerType *T_uint64;
-
 static IntegerType *T_char;
 static IntegerType *T_size;
 static IntegerType *T_sigatomic;
@@ -546,7 +535,7 @@ static const auto jlvboundserror_func = new JuliaFunction{
 static const auto jluboundserror_func = new JuliaFunction{
     XSTR(jl_bounds_error_unboxed_int),
     [](LLVMContext &C) { return FunctionType::get(T_void,
-            {PointerType::get(T_int8, AddressSpace::Derived), T_pjlvalue, T_size}, false); },
+            {PointerType::get(llvm::Type::getInt8Ty(C), AddressSpace::Derived), T_pjlvalue, T_size}, false); },
     get_attrs_noreturn,
 };
 static const auto jlcheckassign_func = new JuliaFunction{
@@ -569,7 +558,7 @@ static const auto jlgetbindingorerror_func = new JuliaFunction{
 };
 static const auto jlboundp_func = new JuliaFunction{
     XSTR(jl_boundp),
-    [](LLVMContext &C) { return FunctionType::get(T_int32,
+    [](LLVMContext &C) { return FunctionType::get(llvm::Type::getInt32Ty(C),
                 {T_pjlvalue, T_pjlvalue}, false); },
     nullptr,
 };
@@ -608,7 +597,7 @@ static const auto jlapplygeneric_func = new JuliaFunction{
 static const auto jlinvoke_func = new JuliaFunction{
     XSTR(jl_invoke),
     [](LLVMContext &C) { return FunctionType::get(T_prjlvalue,
-                {T_prjlvalue, T_pprjlvalue, T_uint32, T_prjlvalue}, false); },
+                {T_prjlvalue, T_pprjlvalue, llvm::Type::getInt32Ty(C), T_prjlvalue}, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
             AttributeSet(),
             Attributes(C, {Attribute::NonNull}),
@@ -659,7 +648,7 @@ static const auto jl_current_exception_func = new JuliaFunction{
 static const auto jlleave_func = new JuliaFunction{
     XSTR(jl_pop_handler),
     [](LLVMContext &C) { return FunctionType::get(T_void,
-            {T_int32}, false); },
+            {llvm::Type::getInt32Ty(C)}, false); },
     nullptr,
 };
 static const auto jl_restore_excstack_func = new JuliaFunction{
@@ -677,7 +666,7 @@ static const auto jlegalx_func = new JuliaFunction{
     XSTR(jl_egal__unboxed),
     [](LLVMContext &C) {
         Type *T = PointerType::get(T_jlvalue, AddressSpace::Derived);
-        return FunctionType::get(T_int32, {T, T, T_prjlvalue}, false); },
+        return FunctionType::get(llvm::Type::getInt32Ty(C), {T, T, T_prjlvalue}, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
             Attributes(C, {Attribute::ReadOnly, Attribute::NoUnwind, Attribute::ArgMemOnly}),
             AttributeSet(),
@@ -732,14 +721,14 @@ static const auto jl_write_barrier_func = new JuliaFunction{
 };
 static const auto jlisa_func = new JuliaFunction{
     XSTR(jl_isa),
-    [](LLVMContext &C) { return FunctionType::get(T_int32,
+    [](LLVMContext &C) { return FunctionType::get(llvm::Type::getInt32Ty(C),
             {T_prjlvalue, T_prjlvalue}, false); },
     nullptr,
 };
 
 static const auto jlsubtype_func = new JuliaFunction{
     XSTR(jl_subtype),
-    [](LLVMContext &C) { return FunctionType::get(T_int32,
+    [](LLVMContext &C) { return FunctionType::get(llvm::Type::getInt32Ty(C),
             {T_prjlvalue, T_prjlvalue}, false); },
     nullptr,
 };
@@ -758,15 +747,15 @@ static const auto jlapplytype_func = new JuliaFunction{
 static const auto jl_object_id__func = new JuliaFunction{
     XSTR(jl_object_id_),
     [](LLVMContext &C) { return FunctionType::get(T_size,
-            {T_prjlvalue, PointerType::get(T_int8, AddressSpace::Derived)}, false); },
+            {T_prjlvalue, PointerType::get(llvm::Type::getInt8Ty(C), AddressSpace::Derived)}, false); },
     nullptr,
 };
 static const auto setjmp_func = new JuliaFunction{
     jl_setjmp_name,
-    [](LLVMContext &C) { return FunctionType::get(T_int32,
+    [](LLVMContext &C) { return FunctionType::get(llvm::Type::getInt32Ty(C),
             {T_pint8,
 #ifndef _OS_WINDOWS_
-            T_int32,
+            llvm::Type::getInt32Ty(C),
 #endif
             }, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
@@ -776,7 +765,7 @@ static const auto setjmp_func = new JuliaFunction{
 };
 static const auto memcmp_func = new JuliaFunction{
     XSTR(memcmp),
-    [](LLVMContext &C) { return FunctionType::get(T_int32,
+    [](LLVMContext &C) { return FunctionType::get(llvm::Type::getInt32Ty(C),
             {T_pint8, T_pint8, T_size}, false); },
     [](LLVMContext &C) { return AttributeList::get(C,
             Attributes(C, {Attribute::ReadOnly, Attribute::NoUnwind, Attribute::ArgMemOnly}),
@@ -830,13 +819,13 @@ static const auto jlgetcfunctiontrampoline_func = new JuliaFunction{
 };
 static const auto diff_gc_total_bytes_func = new JuliaFunction{
     XSTR(jl_gc_diff_total_bytes),
-    [](LLVMContext &C) { return FunctionType::get(T_int64, false); },
+    [](LLVMContext &C) { return FunctionType::get(llvm::Type::getInt64Ty(C), false); },
     nullptr,
 };
 static const auto sync_gc_total_bytes_func = new JuliaFunction{
     XSTR(jl_gc_sync_total_bytes),
-    [](LLVMContext &C) { return FunctionType::get(T_int64,
-            {T_int64}, false); },
+    [](LLVMContext &C) { return FunctionType::get(llvm::Type::getInt64Ty(C),
+            {llvm::Type::getInt64Ty(C)}, false); },
     nullptr,
 };
 static const auto jlarray_data_owner_func = new JuliaFunction{
@@ -855,12 +844,12 @@ static const auto box_##ct##_func = new JuliaFunction{                        \
             {at}, false); },                                                  \
     attrs,                                                                    \
 }
-BOX_FUNC(int16, T_prjlvalue, T_int16, get_attrs_sext);
-BOX_FUNC(uint16, T_prjlvalue, T_int16, get_attrs_zext);
-BOX_FUNC(int32, T_prjlvalue, T_int32, get_attrs_sext);
-BOX_FUNC(uint32, T_prjlvalue, T_int32, get_attrs_zext);
-BOX_FUNC(int64, T_prjlvalue, T_int64, get_attrs_sext);
-BOX_FUNC(uint64, T_prjlvalue, T_int64, get_attrs_zext);
+BOX_FUNC(int16, T_prjlvalue, llvm::Type::getInt16Ty(C), get_attrs_sext);
+BOX_FUNC(uint16, T_prjlvalue, llvm::Type::getInt16Ty(C), get_attrs_zext);
+BOX_FUNC(int32, T_prjlvalue, llvm::Type::getInt32Ty(C), get_attrs_sext);
+BOX_FUNC(uint32, T_prjlvalue, llvm::Type::getInt32Ty(C), get_attrs_zext);
+BOX_FUNC(int64, T_prjlvalue, llvm::Type::getInt64Ty(C), get_attrs_sext);
+BOX_FUNC(uint64, T_prjlvalue, llvm::Type::getInt64Ty(C), get_attrs_zext);
 BOX_FUNC(char, T_prjlvalue, T_char, get_attrs_zext);
 BOX_FUNC(float32, T_prjlvalue, T_float32, get_func_attrs);
 BOX_FUNC(float64, T_prjlvalue, T_float64, get_func_attrs);
@@ -886,7 +875,7 @@ static const auto gc_preserve_end_func = new JuliaFunction {
 };
 static const auto except_enter_func = new JuliaFunction{
     "julia.except_enter",
-    [](LLVMContext &C) { return FunctionType::get(T_int32, false); },
+    [](LLVMContext &C) { return FunctionType::get(llvm::Type::getInt32Ty(C), false); },
     [](LLVMContext &C) { return AttributeList::get(C,
             AttributeSet::get(C, makeArrayRef({Attribute::get(C, Attribute::ReturnsTwice)})),
             AttributeSet(),
@@ -1011,7 +1000,7 @@ struct jl_cgval_t {
             assert(Vboxed->getType() == T_prjlvalue);
         assert(gcroot == nullptr);
         assert(!(isboxed && TIndex != NULL));
-        assert(TIndex == NULL || TIndex->getType() == T_int8);
+        assert(TIndex == NULL || TIndex->getType() == llvm::Type::getInt8Ty(TIndex->getContext()));
     }
     explicit jl_cgval_t(jl_value_t *typ) : // ghost value constructor
         // mark explicit to avoid being used implicitly for conversion from NULL (use jl_cgval_t() instead)
@@ -1257,7 +1246,7 @@ static void undef_derived_strct(IRBuilder<> &irbuilder, Value *ptr, jl_datatype_
     assert(ptr->getType()->getPointerAddressSpace() != AddressSpace::Tracked);
     size_t first_offset = sty->layout->nfields ? jl_field_offset(sty, 0) : 0;
     if (first_offset != 0)
-        irbuilder.CreateMemSet(ptr, ConstantInt::get(T_int8, 0), first_offset, MaybeAlign(0));
+        irbuilder.CreateMemSet(ptr, ConstantInt::get(llvm::Type::getInt8Ty(irbuilder.getContext()), 0), first_offset, MaybeAlign(0));
     size_t i, np = sty->layout->npointers;
     if (np == 0)
         return;
@@ -1447,14 +1436,14 @@ static void store_def_flag(jl_codectx_t &ctx, const jl_varinfo_t &vi, bool val)
 {
     assert((!vi.boxroot || vi.pTIndex) && "undef check is null pointer for boxed things");
     assert(vi.usedUndef && vi.defFlag && "undef flag codegen corrupted");
-    ctx.builder.CreateStore(ConstantInt::get(T_int1, val), vi.defFlag, vi.isVolatile);
+    ctx.builder.CreateStore(ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), val), vi.defFlag, vi.isVolatile);
 }
 
 static void alloc_def_flag(jl_codectx_t &ctx, jl_varinfo_t& vi)
 {
     assert((!vi.boxroot || vi.pTIndex) && "undef check is null pointer for boxed things");
     if (vi.usedUndef) {
-        vi.defFlag = emit_static_alloca(ctx, T_int1);
+        vi.defFlag = emit_static_alloca(ctx, llvm::Type::getInt1Ty(ctx.builder.getContext()));
         store_def_flag(ctx, vi, false);
     }
 }
@@ -1515,9 +1504,9 @@ static void CreateConditionalAbort(IRBuilder<> &irbuilder, Value *test)
 static jl_cgval_t convert_julia_type_union(jl_codectx_t &ctx, const jl_cgval_t &v, jl_value_t *typ, Value **skip)
 {
     // previous value was a split union, compute new index, or box
-    Value *new_tindex = ConstantInt::get(T_int8, 0x80);
+    Value *new_tindex = ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80);
     SmallBitVector skip_box(1, true);
-    Value *tindex = ctx.builder.CreateAnd(v.TIndex, ConstantInt::get(T_int8, 0x7f));
+    Value *tindex = ctx.builder.CreateAnd(v.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x7f));
     if (jl_is_uniontype(typ)) {
         // compute the TIndex mapping from v.typ -> typ
         unsigned counter = 0;
@@ -1529,8 +1518,8 @@ static jl_cgval_t convert_julia_type_union(jl_codectx_t &ctx, const jl_cgval_t &
                 if (new_idx) {
                     // found a matching element,
                     // match it against either the unboxed index
-                    Value *cmp = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(T_int8, idx));
-                    new_tindex = ctx.builder.CreateSelect(cmp, ConstantInt::get(T_int8, new_idx), new_tindex);
+                    Value *cmp = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), idx));
+                    new_tindex = ctx.builder.CreateSelect(cmp, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), new_idx), new_tindex);
                     t = true;
                 }
                 else if (!jl_subtype((jl_value_t*)jt, typ)) {
@@ -1538,7 +1527,7 @@ static jl_cgval_t convert_julia_type_union(jl_codectx_t &ctx, const jl_cgval_t &
                     // since it isn't part of the new union
                     t = true;
                     if (skip) {
-                        Value *skip1 = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(T_int8, idx));
+                        Value *skip1 = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), idx));
                         *skip = *skip ? ctx.builder.CreateOr(*skip, skip1) : skip1;
                     }
                 }
@@ -1564,9 +1553,9 @@ static jl_cgval_t convert_julia_type_union(jl_codectx_t &ctx, const jl_cgval_t &
         // value) against all the types that are now explicitly
         // selected and select the appropriate one as our new tindex.
         if (v.Vboxed) {
-            wasboxed = ctx.builder.CreateAnd(v.TIndex, ConstantInt::get(T_int8, 0x80));
+            wasboxed = ctx.builder.CreateAnd(v.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80));
             new_tindex = ctx.builder.CreateOr(wasboxed, new_tindex);
-            wasboxed = ctx.builder.CreateICmpNE(wasboxed, ConstantInt::get(T_int8, 0));
+            wasboxed = ctx.builder.CreateICmpNE(wasboxed, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0));
 
             BasicBlock *currBB = ctx.builder.GetInsertBlock();
 
@@ -1588,7 +1577,7 @@ static jl_cgval_t convert_julia_type_union(jl_codectx_t &ctx, const jl_cgval_t &
             // (0x80). We could use `v.Tindex`, here, since we know
             // it has to be 0x80, but it seems likely the backend
             // will like the explicit constant better.
-            Value *union_box_tindex = ConstantInt::get(T_int8, 0x80);
+            Value *union_box_tindex = ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80);
             unsigned counter = 0;
             for_each_uniontype_small(
                 // for each new union-split value
@@ -1598,7 +1587,7 @@ static jl_cgval_t convert_julia_type_union(jl_codectx_t &ctx, const jl_cgval_t &
                         // didn't handle this item before, select its new union index
                         maybe_setup_union_isa();
                         Value *cmp = ctx.builder.CreateICmpEQ(track_pjlvalue(ctx, literal_pointer_val(ctx, (jl_value_t*)jt)), union_box_dt);
-                        union_box_tindex = ctx.builder.CreateSelect(cmp, ConstantInt::get(T_int8, 0x80 | idx), union_box_tindex);
+                        union_box_tindex = ctx.builder.CreateSelect(cmp, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80 | idx), union_box_tindex);
                     }
                 },
                 typ,
@@ -1607,10 +1596,10 @@ static jl_cgval_t convert_julia_type_union(jl_codectx_t &ctx, const jl_cgval_t &
                 BasicBlock *postBB = BasicBlock::Create(ctx.builder.getContext(), "post_union_isa", ctx.f);
                 ctx.builder.CreateBr(postBB);
                 ctx.builder.SetInsertPoint(currBB);
-                Value *wasunknown = ctx.builder.CreateICmpEQ(v.TIndex, ConstantInt::get(T_int8, 0x80));
+                Value *wasunknown = ctx.builder.CreateICmpEQ(v.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80));
                 ctx.builder.CreateCondBr(wasunknown, union_isaBB, postBB);
                 ctx.builder.SetInsertPoint(postBB);
-                PHINode *tindex_phi = ctx.builder.CreatePHI(T_int8, 2);
+                PHINode *tindex_phi = ctx.builder.CreatePHI(llvm::Type::getInt8Ty(ctx.builder.getContext()), 2);
                 tindex_phi->addIncoming(new_tindex, currBB);
                 tindex_phi->addIncoming(union_box_tindex, post_union_isaBB);
                 new_tindex = tindex_phi;
@@ -1625,8 +1614,8 @@ static jl_cgval_t convert_julia_type_union(jl_codectx_t &ctx, const jl_cgval_t &
                 // to touch it at all. Otherwise we're either transitioning
                 // unboxed->boxed, or leaving an unboxed value in place.
                 Value *isboxed = ctx.builder.CreateICmpNE(
-                    ctx.builder.CreateAnd(new_tindex, ConstantInt::get(T_int8, 0x80)),
-                    ConstantInt::get(T_int8, 0));
+                    ctx.builder.CreateAnd(new_tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80)),
+                    ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0));
                 boxv = ctx.builder.CreateSelect(
                     ctx.builder.CreateAnd(wasboxed, isboxed), v.Vboxed, boxv);
             }
@@ -1707,7 +1696,7 @@ static jl_cgval_t convert_julia_type(jl_codectx_t &ctx, const jl_cgval_t &v, jl_
             assert(jl_is_concrete_type(v.typ));
             unsigned new_idx = get_box_tindex((jl_datatype_t*)v.typ, typ);
             if (new_idx) {
-                new_tindex = ConstantInt::get(T_int8, new_idx);
+                new_tindex = ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), new_idx);
                 if (v.V && !v.ispointer()) {
                     // TODO: remove this branch once all consumers of v.TIndex understand how to handle a non-ispointer value
                     Value *slotv = emit_static_alloca(ctx, v.V->getType());
@@ -1722,7 +1711,7 @@ static jl_cgval_t convert_julia_type(jl_codectx_t &ctx, const jl_cgval_t &v, jl_
             }
             else if (skip) {
                 // undef
-                *skip = ConstantInt::get(T_int1, 1);
+                *skip = ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 1);
                 return jl_cgval_t();
             }
             else {
@@ -1877,7 +1866,7 @@ static void visitLine(jl_codectx_t &ctx, uint64_t *ptr, Value *addend, const cha
     Value *pv = ConstantExpr::getIntToPtr(
         ConstantInt::get(T_size, (uintptr_t)ptr),
         T_pint64);
-    Value *v = ctx.builder.CreateLoad(T_int64, pv, true, name);
+    Value *v = ctx.builder.CreateLoad(llvm::Type::getInt64Ty(ctx.builder.getContext()), pv, true, name);
     v = ctx.builder.CreateAdd(v, addend);
     ctx.builder.CreateStore(v, pv, true); // volatile, not atomic, so this might be an underestimate,
                                           // but it's faster this way
@@ -1890,7 +1879,7 @@ static void coverageVisitLine(jl_codectx_t &ctx, StringRef filename, int line)
     assert(!imaging_mode);
     if (filename == "" || filename == "none" || filename == "no file" || filename == "<missing>" || line < 0)
         return;
-    visitLine(ctx, jl_coverage_data_pointer(filename, line), ConstantInt::get(T_int64, 1), "lcnt");
+    visitLine(ctx, jl_coverage_data_pointer(filename, line), ConstantInt::get(llvm::Type::getInt64Ty(ctx.builder.getContext()), 1), "lcnt");
 }
 
 // Memory allocation log (malloc_log)
@@ -2260,7 +2249,7 @@ static Value *emit_box_compare(jl_codectx_t &ctx, const jl_cgval_t &arg1, const 
             Value *dt_eq = ctx.builder.CreateICmpEQ(dtarg, emit_typeof_boxed(ctx, arg2));
             return emit_guarded_test(ctx, dt_eq, false, [&] {
                 return ctx.builder.CreateTrunc(ctx.builder.CreateCall(prepare_call(jlegalx_func),
-                                                                      {varg1, varg2, dtarg}), T_int1);
+                                                                      {varg1, varg2, dtarg}), llvm::Type::getInt1Ty(ctx.builder.getContext()));
             });
         });
     });
@@ -2272,24 +2261,24 @@ static Value *emit_bitsunion_compare(jl_codectx_t &ctx, const jl_cgval_t &arg1, 
 {
     assert(jl_egal(arg1.typ, arg2.typ) && arg1.TIndex && arg2.TIndex && jl_is_uniontype(arg1.typ) && "unimplemented");
     Value *tindex = arg1.TIndex;
-    tindex = ctx.builder.CreateAnd(tindex, ConstantInt::get(T_int8, 0x7f));
+    tindex = ctx.builder.CreateAnd(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x7f));
     Value *tindex2 = arg2.TIndex;
-    tindex2 = ctx.builder.CreateAnd(tindex2, ConstantInt::get(T_int8, 0x7f));
+    tindex2 = ctx.builder.CreateAnd(tindex2, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x7f));
     Value *typeeq = ctx.builder.CreateICmpEQ(tindex, tindex2);
-    tindex = ctx.builder.CreateSelect(typeeq, tindex, ConstantInt::get(T_int8, 0x00));
+    tindex = ctx.builder.CreateSelect(typeeq, tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x00));
     BasicBlock *defaultBB = BasicBlock::Create(ctx.builder.getContext(), "unionbits_is_boxed", ctx.f);
     SwitchInst *switchInst = ctx.builder.CreateSwitch(tindex, defaultBB);
     BasicBlock *postBB = BasicBlock::Create(ctx.builder.getContext(), "post_unionbits_is", ctx.f);
     ctx.builder.SetInsertPoint(postBB);
-    PHINode *phi = ctx.builder.CreatePHI(T_int1, 2);
-    switchInst->addCase(ConstantInt::get(T_int8, 0), postBB);
-    phi->addIncoming(ConstantInt::get(T_int1, 0), switchInst->getParent());
+    PHINode *phi = ctx.builder.CreatePHI(llvm::Type::getInt1Ty(ctx.builder.getContext()), 2);
+    switchInst->addCase(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0), postBB);
+    phi->addIncoming(ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 0), switchInst->getParent());
     unsigned counter = 0;
     bool allunboxed = for_each_uniontype_small(
         [&](unsigned idx, jl_datatype_t *jt) {
             BasicBlock *tempBB = BasicBlock::Create(ctx.builder.getContext(), "unionbits_is", ctx.f);
             ctx.builder.SetInsertPoint(tempBB);
-            switchInst->addCase(ConstantInt::get(T_int8, idx), tempBB);
+            switchInst->addCase(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), idx), tempBB);
             jl_cgval_t sel_arg1(arg1, (jl_value_t*)jt, NULL);
             jl_cgval_t sel_arg2(arg2, (jl_value_t*)jt, NULL);
             Value *cmp = emit_bits_compare(ctx, sel_arg1, sel_arg2);
@@ -2317,7 +2306,7 @@ static Value *emit_bits_compare(jl_codectx_t &ctx, jl_cgval_t arg1, jl_cgval_t a
     assert(jl_is_datatype(arg1.typ) && arg1.typ == arg2.typ && !isboxed);
 
     if (type_is_ghost(at))
-        return ConstantInt::get(T_int1, 1);
+        return ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 1);
 
     if (at->isIntegerTy() || at->isPointerTy() || at->isFloatingPointTy()) {
         Type *at_int = INTT(at);
@@ -2328,14 +2317,14 @@ static Value *emit_bits_compare(jl_codectx_t &ctx, jl_cgval_t arg1, jl_cgval_t a
 
     if (at->isVectorTy()) {
         jl_svec_t *types = ((jl_datatype_t*)arg1.typ)->types;
-        Value *answer = ConstantInt::get(T_int1, 1);
+        Value *answer = ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 1);
         Value *varg1 = emit_unbox(ctx, at, arg1, arg1.typ);
         Value *varg2 = emit_unbox(ctx, at, arg2, arg2.typ);
         for (size_t i = 0, l = jl_svec_len(types); i < l; i++) {
             jl_value_t *fldty = jl_svecref(types, i);
             Value *subAns, *fld1, *fld2;
-            fld1 = ctx.builder.CreateExtractElement(varg1, ConstantInt::get(T_int32, i)),
-            fld2 = ctx.builder.CreateExtractElement(varg2, ConstantInt::get(T_int32, i)),
+            fld1 = ctx.builder.CreateExtractElement(varg1, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), i)),
+            fld2 = ctx.builder.CreateExtractElement(varg2, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), i)),
             subAns = emit_bits_compare(ctx,
                     mark_julia_type(ctx, fld1, false, fldty),
                     mark_julia_type(ctx, fld2, false, fldty));
@@ -2378,11 +2367,11 @@ static Value *emit_bits_compare(jl_codectx_t &ctx, jl_cgval_t arg1, jl_cgval_t a
             }
             if (tbaa)
                 tbaa_decorate(tbaa, answer);
-            return ctx.builder.CreateICmpEQ(answer, ConstantInt::get(T_int32, 0));
+            return ctx.builder.CreateICmpEQ(answer, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 0));
         }
         else {
             jl_svec_t *types = sty->types;
-            Value *answer = ConstantInt::get(T_int1, 1);
+            Value *answer = ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 1);
             for (size_t i = 0, l = jl_svec_len(types); i < l; i++) {
                 jl_value_t *fldty = jl_svecref(types, i);
                 if (type_is_ghost(julia_type_to_llvm(ctx, fldty)))
@@ -2420,13 +2409,13 @@ static Value *emit_f_is(jl_codectx_t &ctx, const jl_cgval_t &arg1, const jl_cgva
 {
     // handle simple static expressions with no side-effects
     if (arg1.constant && arg2.constant)
-        return ConstantInt::get(T_int1, jl_egal(arg1.constant, arg2.constant));
+        return ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), jl_egal(arg1.constant, arg2.constant));
 
     jl_value_t *rt1 = arg1.typ;
     jl_value_t *rt2 = arg2.typ;
     if (jl_is_concrete_type(rt1) && jl_is_concrete_type(rt2) && !jl_is_kind(rt1) && !jl_is_kind(rt2) && rt1 != rt2) {
         // disjoint concrete leaf types are never equal (quick test)
-        return ConstantInt::get(T_int1, 0);
+        return ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 0);
     }
 
     if (arg1.isghost || arg2.isghost || arg1.constant == jl_bottom_type ||
@@ -2444,7 +2433,7 @@ static Value *emit_f_is(jl_codectx_t &ctx, const jl_cgval_t &arg1, const jl_cgva
         if (!(arg1.isboxed || arg1.constant) || !(arg2.isboxed || arg2.constant))
             // not TIndex && not boxed implies it is an unboxed value of a different type from this singleton
             // (which was probably caught above, but just to be safe, we repeat it here explicitly)
-            return ConstantInt::get(T_int1, 0);
+            return ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 0);
         Value *varg1 = arg1.constant ? literal_pointer_val(ctx, arg1.constant) : maybe_bitcast(ctx, arg1.Vboxed, T_pjlvalue);
         Value *varg2 = arg2.constant ? literal_pointer_val(ctx, arg2.constant) : maybe_bitcast(ctx, arg2.Vboxed, T_pjlvalue);
         // rooting these values isn't needed since we won't load this pointer
@@ -2456,7 +2445,7 @@ static Value *emit_f_is(jl_codectx_t &ctx, const jl_cgval_t &arg1, const jl_cgva
     }
 
     if (jl_type_intersection(rt1, rt2) == (jl_value_t*)jl_bottom_type) // types are disjoint (exhaustive test)
-        return ConstantInt::get(T_int1, 0);
+        return ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 0);
 
     bool justbits1 = jl_is_concrete_immutable(rt1);
     bool justbits2 = jl_is_concrete_immutable(rt2);
@@ -2484,8 +2473,8 @@ static Value *emit_f_is(jl_codectx_t &ctx, const jl_cgval_t &arg1, const jl_cgva
             isaBB = ctx.builder.GetInsertBlock(); // might have changed
             ctx.builder.CreateBr(postBB);
             ctx.builder.SetInsertPoint(postBB);
-            PHINode *cmp = ctx.builder.CreatePHI(T_int1, 2);
-            cmp->addIncoming(ConstantInt::get(T_int1, 0), currBB);
+            PHINode *cmp = ctx.builder.CreatePHI(llvm::Type::getInt1Ty(ctx.builder.getContext()), 2);
+            cmp->addIncoming(ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 0), currBB);
             cmp->addIncoming(bitcmp, isaBB);
             return cmp;
         });
@@ -2627,7 +2616,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
     if (f == jl_builtin_is && nargs == 2) {
         // emit comparison test
         Value *ans = emit_f_is(ctx, argv[1], argv[2]);
-        *ret = mark_julia_type(ctx, ctx.builder.CreateZExt(ans, T_int8), false, jl_bool_type);
+        *ret = mark_julia_type(ctx, ctx.builder.CreateZExt(ans, llvm::Type::getInt8Ty(ctx.builder.getContext())), false, jl_bool_type);
         return true;
     }
 
@@ -2660,8 +2649,8 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         if (jl_is_type_type(ty.typ) && !jl_has_free_typevars(ty.typ)) {
             jl_value_t *tp0 = jl_tparam0(ty.typ);
             Value *isa_result = emit_isa(ctx, arg, tp0, NULL).first;
-            if (isa_result->getType() == T_int1)
-                isa_result = ctx.builder.CreateZExt(isa_result, T_int8);
+            if (isa_result->getType() == llvm::Type::getInt1Ty(ctx.builder.getContext()))
+                isa_result = ctx.builder.CreateZExt(isa_result, llvm::Type::getInt8Ty(ctx.builder.getContext()));
             *ret = mark_julia_type(ctx, isa_result, false, jl_bool_type);
             return true;
         }
@@ -2673,7 +2662,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         if (jl_is_type_type(ta.typ) && !jl_has_free_typevars(ta.typ) &&
             jl_is_type_type(tb.typ) && !jl_has_free_typevars(tb.typ)) {
             int issub = jl_subtype(jl_tparam0(ta.typ), jl_tparam0(tb.typ));
-            *ret = mark_julia_type(ctx, ConstantInt::get(T_int8, issub), false, jl_bool_type);
+            *ret = mark_julia_type(ctx, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), issub), false, jl_bool_type);
             return true;
         }
     }
@@ -2685,7 +2674,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                 Value *theF = boxed(ctx, argv[2]);
                 Value *nva = emit_n_varargs(ctx);
 #ifdef _P64
-                nva = ctx.builder.CreateTrunc(nva, T_int32);
+                nva = ctx.builder.CreateTrunc(nva, llvm::Type::getInt32Ty(ctx.builder.getContext()));
 #endif
                 Value *theArgs = ctx.builder.CreateInBoundsGEP(T_prjlvalue, ctx.argArray, ConstantInt::get(T_size, ctx.nReqArgs));
                 Value *r = ctx.builder.CreateCall(prepare_call(jlapplygeneric_func), { theF, theArgs, nva });
@@ -2802,8 +2791,8 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                         Type *AT = ArrayType::get(IntegerType::get(ctx.builder.getContext(), 8 * al), (elsz + al - 1) / al);
                         data = emit_bitcast(ctx, data, AT->getPointerTo());
                         // isbits union selector bytes are stored after a->maxsize
-                        Value *ndims = (nd == -1 ? emit_arrayndims(ctx, ary) : ConstantInt::get(T_int16, nd));
-                        Value *is_vector = ctx.builder.CreateICmpEQ(ndims, ConstantInt::get(T_int16, 1));
+                        Value *ndims = (nd == -1 ? emit_arrayndims(ctx, ary) : ConstantInt::get(llvm::Type::getInt16Ty(ctx.builder.getContext()), nd));
+                        Value *is_vector = ctx.builder.CreateICmpEQ(ndims, ConstantInt::get(llvm::Type::getInt16Ty(ctx.builder.getContext()), 1));
                         Value *selidx_v = ctx.builder.CreateSub(emit_vectormaxsize(ctx, ary), ctx.builder.CreateZExt(offset, T_size));
                         Value *selidx_m = emit_arraylen(ctx, ary);
                         Value *selidx = ctx.builder.CreateSelect(is_vector, selidx_v, selidx_m);
@@ -2811,8 +2800,8 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                         data = ctx.builder.CreateInBoundsGEP(AT, data, idx);
                     }
                     ptindex = emit_bitcast(ctx, ptindex, T_pint8);
-                    ptindex = ctx.builder.CreateInBoundsGEP(T_int8, ptindex, offset);
-                    ptindex = ctx.builder.CreateInBoundsGEP(T_int8, ptindex, idx);
+                    ptindex = ctx.builder.CreateInBoundsGEP(llvm::Type::getInt8Ty(ctx.builder.getContext()), ptindex, offset);
+                    ptindex = ctx.builder.CreateInBoundsGEP(llvm::Type::getInt8Ty(ctx.builder.getContext()), ptindex, idx);
                     *ret = emit_unionload(ctx, data, ptindex, ety, elsz, al, ctx.tbaa().tbaa_arraybuf, true, union_max, ctx.tbaa().tbaa_arrayselbyte);
                 }
                 else {
@@ -2869,7 +2858,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                         Value *flags = emit_arrayflags(ctx, ary);
                         // the owner of the data is ary itself except if ary->how == 3
                         flags = ctx.builder.CreateAnd(flags, 3);
-                        Value *is_owned = ctx.builder.CreateICmpEQ(flags, ConstantInt::get(T_int16, 3));
+                        Value *is_owned = ctx.builder.CreateICmpEQ(flags, ConstantInt::get(llvm::Type::getInt16Ty(ctx.builder.getContext()), 3));
                         BasicBlock *curBB = ctx.builder.GetInsertBlock();
                         BasicBlock *ownedBB = BasicBlock::Create(ctx.builder.getContext(), "array_owned", ctx.f);
                         BasicBlock *mergeBB = BasicBlock::Create(ctx.builder.getContext(), "merge_own", ctx.f);
@@ -2903,14 +2892,14 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                         // compute tindex from val
                         jl_cgval_t rhs_union = convert_julia_type(ctx, val, ety);
                         Value *tindex = compute_tindex_unboxed(ctx, rhs_union, ety);
-                        tindex = ctx.builder.CreateNUWSub(tindex, ConstantInt::get(T_int8, 1));
+                        tindex = ctx.builder.CreateNUWSub(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 1));
                         Value *ptindex;
                         if (elsz == 0) {
                             ptindex = data;
                         }
                         else {
-                            Value *ndims = (nd == -1 ? emit_arrayndims(ctx, ary) : ConstantInt::get(T_int16, nd));
-                            Value *is_vector = ctx.builder.CreateICmpEQ(ndims, ConstantInt::get(T_int16, 1));
+                            Value *ndims = (nd == -1 ? emit_arrayndims(ctx, ary) : ConstantInt::get(llvm::Type::getInt16Ty(ctx.builder.getContext()), nd));
+                            Value *is_vector = ctx.builder.CreateICmpEQ(ndims, ConstantInt::get(llvm::Type::getInt16Ty(ctx.builder.getContext()), 1));
                             Value *selidx_v = ctx.builder.CreateSub(emit_vectormaxsize(ctx, ary), ctx.builder.CreateZExt(offset, T_size));
                             Value *selidx_m = emit_arraylen(ctx, ary);
                             Value *selidx = ctx.builder.CreateSelect(is_vector, selidx_v, selidx_m);
@@ -2918,8 +2907,8 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                             data = ctx.builder.CreateInBoundsGEP(AT, data, idx);
                         }
                         ptindex = emit_bitcast(ctx, ptindex, T_pint8);
-                        ptindex = ctx.builder.CreateInBoundsGEP(T_int8, ptindex, offset);
-                        ptindex = ctx.builder.CreateInBoundsGEP(T_int8, ptindex, idx);
+                        ptindex = ctx.builder.CreateInBoundsGEP(llvm::Type::getInt8Ty(ctx.builder.getContext()), ptindex, offset);
+                        ptindex = ctx.builder.CreateInBoundsGEP(llvm::Type::getInt8Ty(ctx.builder.getContext()), ptindex, idx);
                         tbaa_decorate(ctx.tbaa().tbaa_arrayselbyte, ctx.builder.CreateStore(tindex, ptindex));
                         if (elsz > 0 && (!jl_is_datatype(val.typ) || jl_datatype_size(val.typ) > 0)) {
                             // copy data (if any)
@@ -3370,7 +3359,7 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, jl_method_instance_
         idx++;
         break;
     case jl_returninfo_t::Union:
-        result = emit_static_alloca(ctx, ArrayType::get(T_int8, returninfo.union_bytes));
+        result = emit_static_alloca(ctx, ArrayType::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), returninfo.union_bytes));
         if (returninfo.union_align > 1)
             result->setAlignment(Align(returninfo.union_align));
         argvals[idx] = result;
@@ -3439,8 +3428,8 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, jl_method_instance_
             Value *tindex = ctx.builder.CreateExtractValue(call, 1);
             Value *derived = ctx.builder.CreateSelect(
                 ctx.builder.CreateICmpEQ(
-                        ctx.builder.CreateAnd(tindex, ConstantInt::get(T_int8, 0x80)),
-                        ConstantInt::get(T_int8, 0)),
+                        ctx.builder.CreateAnd(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80)),
+                        ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0)),
                 decay_derived(ctx, ctx.builder.CreateBitCast(argvals[0], T_pjlvalue)),
                 decay_derived(ctx, box)
             );
@@ -3784,7 +3773,7 @@ static jl_cgval_t emit_isdefined(jl_codectx_t &ctx, jl_value_t *sym)
             return mark_julia_const(jl_true, ctx.tbaa());
         if (vi.boxroot == NULL || vi.pTIndex != NULL) {
             assert(vi.defFlag);
-            isnull = ctx.builder.CreateAlignedLoad(T_int1, vi.defFlag, Align(1), vi.isVolatile);
+            isnull = ctx.builder.CreateAlignedLoad(llvm::Type::getInt1Ty(ctx.builder.getContext()), vi.defFlag, Align(1), vi.isVolatile);
         }
         if (vi.boxroot != NULL) {
             Value *boxed = ctx.builder.CreateAlignedLoad(T_prjlvalue, vi.boxroot, Align(sizeof(void*)), vi.isVolatile);
@@ -3792,10 +3781,10 @@ static jl_cgval_t emit_isdefined(jl_codectx_t &ctx, jl_value_t *sym)
             if (vi.pTIndex) {
                 // value is either boxed in the stack slot, or unboxed in value
                 // as indicated by testing (pTIndex & 0x80)
-                Value *tindex = ctx.builder.CreateAlignedLoad(T_int8, vi.pTIndex, Align(sizeof(void*)), vi.isVolatile);
+                Value *tindex = ctx.builder.CreateAlignedLoad(llvm::Type::getInt8Ty(ctx.builder.getContext()), vi.pTIndex, Align(sizeof(void*)), vi.isVolatile);
                 Value *load_unbox = ctx.builder.CreateICmpEQ(
-                            ctx.builder.CreateAnd(tindex, ConstantInt::get(T_int8, 0x80)),
-                            ConstantInt::get(T_int8, 0));
+                            ctx.builder.CreateAnd(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80)),
+                            ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0));
                 isnull = ctx.builder.CreateSelect(load_unbox, isnull, box_isnull);
             }
             else {
@@ -3848,7 +3837,7 @@ static jl_cgval_t emit_isdefined(jl_codectx_t &ctx, jl_value_t *sym)
                     literal_pointer_val(ctx, (jl_value_t*)modu),
                     literal_pointer_val(ctx, (jl_value_t*)name)
                 });
-            isnull = ctx.builder.CreateICmpNE(v, ConstantInt::get(T_int32, 0));
+            isnull = ctx.builder.CreateICmpNE(v, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 0));
         }
     }
     return mark_julia_type(ctx, isnull, false, jl_bool_type);
@@ -3862,7 +3851,7 @@ static jl_cgval_t emit_varinfo(jl_codectx_t &ctx, jl_varinfo_t &vi, jl_sym_t *va
         if ((!vi.isVolatile && vi.isSA) || vi.isArgument || vi.value.constant || !vi.value.V) {
             v = vi.value;
             if (vi.pTIndex)
-                v.TIndex = ctx.builder.CreateAlignedLoad(T_int8, vi.pTIndex, Align(1));
+                v.TIndex = ctx.builder.CreateAlignedLoad(llvm::Type::getInt8Ty(ctx.builder.getContext()), vi.pTIndex, Align(1));
         }
         else {
             // copy value to a non-mutable (non-volatile SSA) location
@@ -3884,14 +3873,14 @@ static jl_cgval_t emit_varinfo(jl_codectx_t &ctx, jl_varinfo_t &vi, jl_sym_t *va
             }
             Value *tindex = NULL;
             if (vi.pTIndex)
-                tindex = ctx.builder.CreateAlignedLoad(T_int8, vi.pTIndex, Align(1), vi.isVolatile);
-            v = mark_julia_slot(ssaslot, vi.value.typ, tindex, ctx.tbaa(), ctx.tbaa().tbaa_stack);
+                tindex = ctx.builder.CreateAlignedLoad(llvm::Type::getInt8Ty(ctx.builder.getContext()), vi.pTIndex, Align(1), vi.isVolatile);
+            v = mark_julia_slot(ssaslot, vi.value.typ, tindex, ctx.tbaa().tbaa_stack);
         }
         if (vi.boxroot == NULL)
             v = update_julia_type(ctx, v, typ);
         if (vi.usedUndef) {
             assert(vi.defFlag);
-            isnull = ctx.builder.CreateAlignedLoad(T_int1, vi.defFlag, Align(1), vi.isVolatile);
+            isnull = ctx.builder.CreateAlignedLoad(llvm::Type::getInt1Ty(ctx.builder.getContext()), vi.defFlag, Align(1), vi.isVolatile);
         }
     }
     if (vi.boxroot != NULL) {
@@ -3904,8 +3893,8 @@ static jl_cgval_t emit_varinfo(jl_codectx_t &ctx, jl_varinfo_t &vi, jl_sym_t *va
             // value is either boxed in the stack slot, or unboxed in value
             // as indicated by testing (pTIndex & 0x80)
             Value *load_unbox = ctx.builder.CreateICmpEQ(
-                        ctx.builder.CreateAnd(v.TIndex, ConstantInt::get(T_int8, 0x80)),
-                        ConstantInt::get(T_int8, 0));
+                        ctx.builder.CreateAnd(v.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80)),
+                        ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0));
             if (vi.usedUndef)
                 isnull = ctx.builder.CreateSelect(load_unbox, isnull, box_isnull);
             if (v.V) { // v.V will be null if it is a union of all ghost values
@@ -3985,7 +3974,7 @@ static void emit_vi_assignment_unboxed(jl_codectx_t &ctx, jl_varinfo_t &vi, Valu
                 // due to LLVM bugs.
                 // This check should probably mostly catch the relevant situations.
                 if (vi.value.V != rval_info.V) {
-                    Value *copy_bytes = ConstantInt::get(T_int32, jl_datatype_size(vi.value.typ));
+                    Value *copy_bytes = ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), jl_datatype_size(vi.value.typ));
                     emit_memcpy(ctx, vi.value.V, ctx.tbaa().tbaa_stack, rval_info, copy_bytes,
                                 julia_alignment(rval_info.typ), vi.isVolatile);
                 }
@@ -4028,13 +4017,13 @@ static void emit_phinode_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r)
         if (dest) {
             Instruction *phi = dest->clone();
             phi->insertAfter(dest);
-            PHINode *Tindex_phi = PHINode::Create(T_int8, jl_array_len(edges), "tindex_phi");
+            PHINode *Tindex_phi = PHINode::Create(llvm::Type::getInt8Ty(ctx.builder.getContext()), jl_array_len(edges), "tindex_phi");
             BB->getInstList().insert(InsertPt, Tindex_phi);
             PHINode *ptr_phi = PHINode::Create(T_prjlvalue, jl_array_len(edges), "ptr_phi");
             BB->getInstList().insert(InsertPt, ptr_phi);
             Value *isboxed = ctx.builder.CreateICmpNE(
-                    ctx.builder.CreateAnd(Tindex_phi, ConstantInt::get(T_int8, 0x80)),
-                    ConstantInt::get(T_int8, 0));
+                    ctx.builder.CreateAnd(Tindex_phi, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80)),
+                    ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0));
             ctx.builder.CreateMemCpy(phi, MaybeAlign(min_align), dest, MaybeAlign(0), nbytes, false);
             ctx.builder.CreateLifetimeEnd(dest);
             Value *ptr = ctx.builder.CreateSelect(isboxed,
@@ -4048,7 +4037,7 @@ static void emit_phinode_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r)
             return;
         }
         else if (allunbox) {
-            PHINode *Tindex_phi = PHINode::Create(T_int8, jl_array_len(edges), "tindex_phi");
+            PHINode *Tindex_phi = PHINode::Create(llvm::Type::getInt8Ty(ctx.builder.getContext()), jl_array_len(edges), "tindex_phi");
             BB->getInstList().insert(InsertPt, Tindex_phi);
             jl_cgval_t val = mark_julia_slot(NULL, phiType, Tindex_phi, ctx.tbaa(), ctx.tbaa().tbaa_stack);
             ctx.PhiNodes.push_back(std::make_tuple(val, BB, dest, (PHINode*)NULL, r));
@@ -4138,13 +4127,13 @@ static void emit_varinfo_assign(jl_codectx_t &ctx, jl_varinfo_t &vi, jl_cgval_t 
         if (rval_info.TIndex) {
             tindex = rval_info.TIndex;
             if (!vi.boxroot)
-                tindex = ctx.builder.CreateAnd(tindex, ConstantInt::get(T_int8, 0x7f));
+                tindex = ctx.builder.CreateAnd(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x7f));
         }
         else {
             assert(rval_info.isboxed || rval_info.constant);
             tindex = compute_tindex_unboxed(ctx, rval_info, vi.value.typ);
             if (vi.boxroot)
-                tindex = ctx.builder.CreateOr(tindex, ConstantInt::get(T_int8, 0x80));
+                tindex = ctx.builder.CreateOr(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80));
             else
                 rval_info.TIndex = tindex;
         }
@@ -4158,8 +4147,8 @@ static void emit_varinfo_assign(jl_codectx_t &ctx, jl_varinfo_t &vi, jl_cgval_t 
         if (vi.pTIndex && rval_info.TIndex) {
             ctx.builder.CreateStore(rval_info.TIndex, vi.pTIndex, vi.isVolatile);
             isboxed = ctx.builder.CreateICmpNE(
-                    ctx.builder.CreateAnd(rval_info.TIndex, ConstantInt::get(T_int8, 0x80)),
-                    ConstantInt::get(T_int8, 0));
+                    ctx.builder.CreateAnd(rval_info.TIndex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80)),
+                    ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0));
             rval = rval_info.Vboxed ? rval_info.Vboxed : Constant::getNullValue(T_prjlvalue);
             assert(rval->getType() == T_prjlvalue);
             assert(!vi.value.constant);
@@ -4238,8 +4227,8 @@ static void emit_upsilonnode(jl_codectx_t &ctx, ssize_t phic, jl_value_t *val)
             // does need to satisfy the union invariants (i.e. inbounds
             // tindex).
             ctx.builder.CreateAlignedStore(
-                vi.boxroot ? ConstantInt::get(T_int8, 0x80) :
-                             ConstantInt::get(T_int8, 0x01),
+                vi.boxroot ? ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80) :
+                             ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x01),
                 vi.pTIndex, Align(1), true);
         }
         else if (vi.value.V && !vi.value.constant && vi.value.typ != jl_bottom_type) {
@@ -4268,16 +4257,16 @@ static Value *emit_condition(jl_codectx_t &ctx, const jl_cgval_t &condV, const s
         emit_typecheck(ctx, condV, (jl_value_t*)jl_bool_type, msg);
     }
     if (isbool) {
-        Value *cond = emit_unbox(ctx, T_int8, condV, (jl_value_t*)jl_bool_type);
-        assert(cond->getType() == T_int8);
-        return ctx.builder.CreateXor(ctx.builder.CreateTrunc(cond, T_int1), ConstantInt::get(T_int1, 1));
+        Value *cond = emit_unbox(ctx, llvm::Type::getInt8Ty(ctx.builder.getContext()), condV, (jl_value_t*)jl_bool_type);
+        assert(cond->getType() == llvm::Type::getInt8Ty(ctx.builder.getContext()));
+        return ctx.builder.CreateXor(ctx.builder.CreateTrunc(cond, llvm::Type::getInt1Ty(ctx.builder.getContext())), ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 1));
     }
     if (condV.isboxed) {
         return ctx.builder.CreateICmpEQ(boxed(ctx, condV),
             track_pjlvalue(ctx, literal_pointer_val(ctx, jl_false)));
     }
     // not a boolean
-    return ConstantInt::get(T_int1, 0); // TODO: replace with Undef
+    return ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 0); // TODO: replace with Undef
 }
 
 static Value *emit_condition(jl_codectx_t &ctx, jl_value_t *cond, const std::string &msg)
@@ -4330,7 +4319,7 @@ static void emit_stmtpos(jl_codectx_t &ctx, jl_value_t *expr, int ssaval_result)
     else if (head == jl_leave_sym) {
         assert(jl_is_long(args[0]));
         ctx.builder.CreateCall(prepare_call(jlleave_func),
-                           ConstantInt::get(T_int32, jl_unbox_long(args[0])));
+                           ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), jl_unbox_long(args[0])));
     }
     else if (head == jl_pop_exception_sym) {
         jl_cgval_t excstack_state = emit_expr(ctx, jl_exprarg(expr, 0));
@@ -4434,7 +4423,7 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
     else if (head == jl_throw_undef_if_not_sym) {
         assert(nargs == 2);
         jl_sym_t *var = (jl_sym_t*)args[0];
-        Value *cond = ctx.builder.CreateTrunc(emit_unbox(ctx, T_int8, emit_expr(ctx, args[1]), (jl_value_t*)jl_bool_type), T_int1);
+        Value *cond = ctx.builder.CreateTrunc(emit_unbox(ctx, llvm::Type::getInt8Ty(ctx.builder.getContext()), emit_expr(ctx, args[1]), (jl_value_t*)jl_bool_type), llvm::Type::getInt1Ty(ctx.builder.getContext()));
         if (var == jl_getfield_undefref_sym) {
             raise_exception_unless(ctx, cond,
                 literal_pointer_val(ctx, jl_undefref_exception));
@@ -4762,7 +4751,7 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
         // parse Expr(:loopinfo, "julia.simdloop", ("llvm.loop.vectorize.width", 4))
         SmallVector<Metadata *, 8> MDs;
         for (int i = 0, ie = nargs; i < ie; ++i) {
-            Metadata *MD = to_md_tree(args[i]);
+            Metadata *MD = to_md_tree(args[i], ctx.builder.getContext());
             if (MD)
                 MDs.push_back(MD);
         }
@@ -5001,7 +4990,7 @@ static void emit_cfunc_invalidate(
         Type *retty = gf_thunk->getReturnType();
         Value *gf_retval = UndefValue::get(retty);
         Value *tindex = compute_box_tindex(ctx, emit_typeof_boxed(ctx, gf_retbox), (jl_value_t*)jl_any_type, rettype);
-        tindex = ctx.builder.CreateOr(tindex, ConstantInt::get(T_int8, 0x80));
+        tindex = ctx.builder.CreateOr(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80));
         gf_retval = ctx.builder.CreateInsertValue(gf_retval, gf_ret, 0);
         gf_retval = ctx.builder.CreateInsertValue(gf_retval, tindex, 1);
         ctx.builder.CreateRet(gf_retval);
@@ -5480,8 +5469,8 @@ static Function* gen_cfun_wrapper(
                 Value *tindex = ctx.builder.CreateExtractValue(call, 1);
                 Value *derived = ctx.builder.CreateSelect(
                     ctx.builder.CreateICmpEQ(
-                            ctx.builder.CreateAnd(tindex, ConstantInt::get(T_int8, 0x80)),
-                            ConstantInt::get(T_int8, 0)),
+                            ctx.builder.CreateAnd(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80)),
+                            ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0)),
                     decay_derived(ctx, ctx.builder.CreateBitCast(result, T_pjlvalue)),
                     decay_derived(ctx, box));
                 retval = mark_julia_slot(derived,
@@ -5742,7 +5731,7 @@ const char *jl_generate_ccallable(void *llvmmod, void *sysimg_handle, jl_value_t
         crt = (jl_value_t*)jl_any_type;
     }
     bool toboxed;
-    Type *lcrt = _julia_struct_to_llvm(&params, crt, &toboxed);
+    Type *lcrt = _julia_struct_to_llvm(&params, jl_LLVMContext, crt, &toboxed);
     if (toboxed)
         lcrt = T_prjlvalue;
     size_t nargs = jl_nparams(sigt)-1;
@@ -5823,7 +5812,7 @@ static Function *gen_invoke_wrapper(jl_method_instance_t *lam, jl_value_t *jlret
         idx++;
         break;
     case jl_returninfo_t::Union:
-        result = ctx.builder.CreateAlloca(ArrayType::get(T_int8, f.union_bytes));
+        result = ctx.builder.CreateAlloca(ArrayType::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), f.union_bytes));
         if (f.union_align > 1)
             result->setAlignment(Align(f.union_align));
         args[idx] = result;
@@ -5925,14 +5914,14 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, String
         union_alloca_type((jl_uniontype_t*)jlrettype, allunbox, props.union_bytes, props.union_align, props.union_minalign);
         if (props.union_bytes) {
             props.cc = jl_returninfo_t::Union;
-            Type *AT = ArrayType::get(T_int8, props.union_bytes);
+            Type *AT = ArrayType::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), props.union_bytes);
             fsig.push_back(AT->getPointerTo());
-            Type *pair[] = { T_prjlvalue, T_int8 };
+            Type *pair[] = { T_prjlvalue, llvm::Type::getInt8Ty(ctx.builder.getContext()) };
             rt = StructType::get(ctx.builder.getContext(), makeArrayRef(pair));
         }
         else if (allunbox) {
             props.cc = jl_returninfo_t::Ghosts;
-            rt = T_int8;
+            rt = llvm::Type::getInt8Ty(ctx.builder.getContext());
         }
         else {
             rt = T_prjlvalue;
@@ -6477,12 +6466,12 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
             Value *lv = try_emit_union_alloca(ctx, (jl_uniontype_t*)jt, allunbox, align, nbytes);
             if (lv) {
                 lv->setName(jl_symbol_name(s));
-                varinfo.value = mark_julia_slot(lv, jt, NULL, ctx.tbaa(), ctx.tbaa().tbaa_stack);
-                varinfo.pTIndex = emit_static_alloca(ctx, T_int8);
+                varinfo.value = mark_julia_slot(lv, jt, NULL, ctx.tbaa().tbaa_stack);
+                varinfo.pTIndex = emit_static_alloca(ctx, llvm::Type::getInt8Ty(ctx.builder.getContext()));
             }
             else if (allunbox) {
                 // all ghost values just need a selector allocated
-                AllocaInst *lv = emit_static_alloca(ctx, T_int8);
+                AllocaInst *lv = emit_static_alloca(ctx, llvm::Type::getInt8Ty(ctx.builder.getContext()));
                 lv->setName(jl_symbol_name(s));
                 varinfo.pTIndex = lv;
                 varinfo.value.tbaa = NULL;
@@ -6662,7 +6651,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                 // Load closure world
                 Value *argaddr = emit_bitcast(ctx, maybe_decay_tracked(ctx, data_pointer(ctx, theArg)), T_pint8);
                 Value *worldaddr = ctx.builder.CreateInBoundsGEP(
-                        T_int8, argaddr,
+                        llvm::Type::getInt8Ty(ctx.builder.getContext()), argaddr,
                         ConstantInt::get(T_size, offsetof(jl_opaque_closure_t, world)));
 
                 jl_cgval_t closure_world = typed_load(ctx, worldaddr, NULL, (jl_value_t*)jl_long_type,
@@ -6671,7 +6660,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
 
                 // Load closure env
                 Value *envaddr = ctx.builder.CreateInBoundsGEP(
-                        T_int8, argaddr,
+                        llvm::Type::getInt8Ty(ctx.builder.getContext()), argaddr,
                         ConstantInt::get(T_size, offsetof(jl_opaque_closure_t, captures)));
 
                 jl_cgval_t closure_env = typed_load(ctx, envaddr, NULL, (jl_value_t*)jl_any_type,
@@ -6743,7 +6732,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                           ctx.builder.CreateInBoundsGEP(T_prjlvalue, argArray,
                                   ConstantInt::get(T_size, nreq - 1)),
                           ctx.builder.CreateSub(argCount,
-                                  ConstantInt::get(T_int32, nreq - 1)) });
+                                  ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), nreq - 1)) });
             restTuple->setAttributes(F->getAttributes());
             ctx.builder.CreateStore(restTuple, vi.boxroot);
         }
@@ -7079,8 +7068,8 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                         // also need to account for the possibility the return object is boxed
                         // and avoid / skip copying it to the stack
                         isboxed_union = ctx.builder.CreateICmpNE(
-                            ctx.builder.CreateAnd(tindex, ConstantInt::get(T_int8, 0x80)),
-                            ConstantInt::get(T_int8, 0));
+                            ctx.builder.CreateAnd(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80)),
+                            ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0));
                         data = ctx.builder.CreateSelect(isboxed_union, retvalinfo.Vboxed, data);
                     }
                 }
@@ -7088,7 +7077,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                     // treat this as a simple boxed returninfo
                     //assert(retvalinfo.isboxed);
                     tindex = compute_tindex_unboxed(ctx, retvalinfo, jlrettype);
-                    tindex = ctx.builder.CreateOr(tindex, ConstantInt::get(T_int8, 0x80));
+                    tindex = ctx.builder.CreateOr(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80));
                     data = boxed(ctx, retvalinfo);
                     sret = NULL;
                 }
@@ -7183,7 +7172,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
             CallInst *sj = ctx.builder.CreateCall(prepare_call(except_enter_func));
             // We need to mark this on the call site as well. See issue #6757
             sj->setCanReturnTwice();
-            Value *isz = ctx.builder.CreateICmpEQ(sj, ConstantInt::get(T_int32, 0));
+            Value *isz = ctx.builder.CreateICmpEQ(sj, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), 0));
             BasicBlock *tryblk = BasicBlock::Create(ctx.builder.getContext(), "try", f);
             BasicBlock *handlr = NULL;
             handlr = BB[lname];
@@ -7318,14 +7307,14 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                 if (val.typ == (jl_value_t*)jl_bottom_type) {
                     if (VN)
                         V = undef_value_for_type(VN->getType());
-                    RTindex = UndefValue::get(T_int8);
+                    RTindex = UndefValue::get(llvm::Type::getInt8Ty(ctx.builder.getContext()));
                 }
                 else if (jl_is_concrete_type(val.typ) || val.constant) {
                     size_t tindex = get_box_tindex((jl_datatype_t*)val.typ, phiType);
                     if (tindex == 0) {
                         if (VN)
                             V = boxed(ctx, val);
-                        RTindex = ConstantInt::get(T_int8, 0x80);
+                        RTindex = ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80);
                     }
                     else {
                         if (VN)
@@ -7333,7 +7322,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                         Type *lty = julia_type_to_llvm(ctx, val.typ);
                         if (dest && !type_is_ghost(lty)) // basically, if !ghost union
                             emit_unbox(ctx, lty, val, val.typ, dest, ctx.tbaa().tbaa_stack);
-                        RTindex = ConstantInt::get(T_int8, tindex);
+                        RTindex = ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), tindex);
                     }
                 }
                 else {
@@ -7348,7 +7337,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                         if (dest) {
                             // If dest is not set, this is a ghost union, the recipient of which
                             // is often not prepared to handle a boxed representation of the ghost.
-                            RTindex = ctx.builder.CreateOr(RTindex, ConstantInt::get(T_int8, 0x80));
+                            RTindex = ctx.builder.CreateOr(RTindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80));
                         }
                         new_union.TIndex = RTindex;
                     }
@@ -7357,8 +7346,8 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                     if (dest) { // basically, if !ghost union
                         if (new_union.Vboxed != nullptr) {
                             Value *isboxed = ctx.builder.CreateICmpNE( // if 0x80 is set, we won't select this slot anyways
-                                    ctx.builder.CreateAnd(RTindex, ConstantInt::get(T_int8, 0x80)),
-                                    ConstantInt::get(T_int8, 0));
+                                    ctx.builder.CreateAnd(RTindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80)),
+                                    ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0));
                             skip = skip ? ctx.builder.CreateOr(isboxed, skip) : isboxed;
                         }
                         emit_unionmove(ctx, dest, ctx.tbaa().tbaa_arraybuf, new_union, skip);
@@ -7397,12 +7386,12 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
                 continue;
             ctx.builder.SetInsertPoint(FromBB->getTerminator());
             // PHI is undef on this branch. But still may need to put a valid pointer in place.
-            Value *RTindex = TindexN ? UndefValue::get(T_int8) : NULL;
+            Value *RTindex = TindexN ? UndefValue::get(llvm::Type::getInt8Ty(ctx.builder.getContext())) : NULL;
             if (VN) {
                 Value *undef = undef_value_for_type(VN->getType());
                 VN->addIncoming(undef, FromBB);
                 if (TindexN) // let the runtime / optimizer know this is unknown / boxed / null, so that it won't try to union_move / copy it later
-                    RTindex = ConstantInt::get(T_int8, 0x80);
+                    RTindex = ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80);
             }
             if (TindexN)
                 TindexN->addIncoming(RTindex, FromBB);
@@ -7787,24 +7776,17 @@ static void init_julia_llvm_env(Module *m)
 {
     // every variable or function mapped in this function must be
     // exported from libjulia, to support static compilation
-    T_int1  = Type::getInt1Ty(m->getContext());
-    T_int8  = Type::getInt8Ty(m->getContext());
-    T_pint8 = PointerType::get(T_int8, 0);
+    T_pint8 = PointerType::get(llvm::Type::getInt8Ty(m->getContext()), 0);
     T_ppint8 = PointerType::get(T_pint8, 0);
     T_pppint8 = PointerType::get(T_ppint8, 0);
-    T_int16 = Type::getInt16Ty(m->getContext());
-    T_pint16 = PointerType::get(T_int16, 0);
-    T_int32 = Type::getInt32Ty(m->getContext());
+    T_pint16 = PointerType::get(llvm::Type::getInt16Ty(m->getContext()), 0);
     T_char = Type::getInt32Ty(m->getContext());
-    T_pint32 = PointerType::get(T_int32, 0);
-    T_int64 = Type::getInt64Ty(m->getContext());
-    T_pint64 = PointerType::get(T_int64, 0);
-    T_uint8 = T_int8;   T_uint16 = T_int16;
-    T_uint32 = T_int32; T_uint64 = T_int64;
+    T_pint32 = PointerType::get(llvm::Type::getInt32Ty(m->getContext()), 0);
+    T_pint64 = PointerType::get(llvm::Type::getInt64Ty(m->getContext()), 0);
     if (sizeof(size_t) == 8)
-        T_size = T_uint64;
+        T_size = llvm::Type::getInt64Ty(m->getContext());
     else
-        T_size = T_uint32;
+        T_size = llvm::Type::getInt32Ty(m->getContext());
     T_sigatomic = Type::getIntNTy(m->getContext(), sizeof(sig_atomic_t) * 8);
     T_psize = PointerType::get(T_size, 0);
     T_float16 = Type::getHalfTy(m->getContext());
@@ -7861,18 +7843,18 @@ static void init_julia_llvm_env(Module *m)
     std::vector<Type*> ftargs(0);
     ftargs.push_back(T_prjlvalue);  // function
     ftargs.push_back(T_pprjlvalue); // args[]
-    ftargs.push_back(T_int32);      // nargs
+    ftargs.push_back(llvm::Type::getInt32Ty(m->getContext()));      // nargs
     jl_func_sig = FunctionType::get(T_prjlvalue, ftargs, false);
     assert(jl_func_sig != NULL);
     ftargs.push_back(T_pprjlvalue); // linfo->sparam_vals
     jl_func_sig_sparams = FunctionType::get(T_prjlvalue, ftargs, false);
     assert(jl_func_sig_sparams != NULL);
 
-    Type *vaelts[] = {PointerType::get(T_int8, AddressSpace::Loaded)
+    Type *vaelts[] = {PointerType::get(llvm::Type::getInt8Ty(m->getContext()), AddressSpace::Loaded)
                       , T_size
-                      , T_int16
-                      , T_int16
-                      , T_int32
+                      , llvm::Type::getInt16Ty(m->getContext())
+                      , llvm::Type::getInt16Ty(m->getContext())
+                      , llvm::Type::getInt32Ty(m->getContext())
     };
     static_assert(sizeof(jl_array_flags_t) == sizeof(int16_t),
                   "Size of jl_array_flags_t is not the same as int16_t");

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -121,11 +121,11 @@ static Type *INTT(Type *t)
     if (t->isPointerTy())
         return T_size;
     if (t == T_float64)
-        return T_int64;
+        return llvm::Type::getInt64Ty(t->getContext());
     if (t == T_float32)
-        return T_int32;
+        return llvm::Type::getInt32Ty(t->getContext());
     if (t == T_float16)
-        return T_int16;
+        return llvm::Type::getInt16Ty(t->getContext());
     unsigned nb = t->getPrimitiveSizeInBits();
     assert(t != T_void && nb > 0);
     return IntegerType::get(t->getContext(), nb);
@@ -148,7 +148,7 @@ static Constant *julia_const_to_llvm(jl_codectx_t &ctx, const void *ptr, jl_data
     // make sure to return exactly the type specified by
     // julia_type_to_llvm as this will be assumed by the callee.
     if (bt == jl_bool_type)
-        return ConstantInt::get(T_int8, (*(const uint8_t*)ptr) ? 1 : 0);
+        return ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), (*(const uint8_t*)ptr) ? 1 : 0);
 
     Type *lt = julia_struct_to_llvm(ctx, (jl_value_t*)bt, NULL);
 
@@ -239,15 +239,15 @@ static Constant *julia_const_to_llvm(jl_codectx_t &ctx, const void *ptr, jl_data
                     uint8_t byte = *ov;
                     APInt Elem(8, byte);
                     active_sz -= 1;
-                    fld = ConstantInt::get(T_int8, Elem);
+                    fld = ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), Elem);
                 }
                 else {
-                    fld = UndefValue::get(T_int8);
+                    fld = UndefValue::get(llvm::Type::getInt8Ty(ctx.builder.getContext()));
                 }
                 ov += 1;
                 fields.push_back(fld);
             }
-            fields.push_back(ConstantInt::get(T_int8, sel));
+            fields.push_back(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), sel));
         }
         else {
             Constant *val = julia_const_to_llvm(ctx, ov, (jl_datatype_t*)ft);
@@ -268,9 +268,9 @@ static Constant *julia_const_to_llvm(jl_codectx_t &ctx, const void *ptr, jl_data
 static Constant *julia_const_to_llvm(jl_codectx_t &ctx, jl_value_t *e)
 {
     if (e == jl_true)
-        return ConstantInt::get(T_int8, 1);
+        return ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 1);
     if (e == jl_false)
-        return ConstantInt::get(T_int8, 0);
+        return ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0);
     jl_value_t *bt = jl_typeof(e);
     if (!jl_is_pointerfree(bt))
         return NULL;
@@ -285,13 +285,13 @@ static Value *emit_unboxed_coercion(jl_codectx_t &ctx, Type *to, Value *unboxed)
     bool frompointer = ty->isPointerTy();
     bool topointer = to->isPointerTy();
     const DataLayout &DL = jl_Module->getDataLayout();
-    if (ty == T_int1 && to == T_int8) {
+    if (ty == llvm::Type::getInt1Ty(ctx.builder.getContext()) && to == llvm::Type::getInt8Ty(ctx.builder.getContext())) {
         // bools may be stored internally as int8
-        unboxed = ctx.builder.CreateZExt(unboxed, T_int8);
+        unboxed = ctx.builder.CreateZExt(unboxed, llvm::Type::getInt8Ty(ctx.builder.getContext()));
     }
-    else if (ty == T_int8 && to == T_int1) {
+    else if (ty == llvm::Type::getInt8Ty(ctx.builder.getContext()) && to == llvm::Type::getInt1Ty(ctx.builder.getContext())) {
         // bools may be stored internally as int8
-        unboxed = ctx.builder.CreateTrunc(unboxed, T_int1);
+        unboxed = ctx.builder.CreateTrunc(unboxed, llvm::Type::getInt1Ty(ctx.builder.getContext()));
     }
     else if (ty == T_void || DL.getTypeSizeInBits(ty) != DL.getTypeSizeInBits(to)) {
         // this can happen in dead code
@@ -359,17 +359,17 @@ static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x, jl_va
     // bools stored as int8, so an extra Trunc is needed to get an int1
     Value *p = x.constant ? literal_pointer_val(ctx, x.constant) : x.V;
 
-    if (jt == (jl_value_t*)jl_bool_type || to == T_int1) {
-        Instruction *unbox_load = tbaa_decorate(x.tbaa, ctx.builder.CreateLoad(T_int8, maybe_bitcast(ctx, p, T_pint8)));
+    if (jt == (jl_value_t*)jl_bool_type || to == llvm::Type::getInt1Ty(ctx.builder.getContext())) {
+        Instruction *unbox_load = tbaa_decorate(x.tbaa, ctx.builder.CreateLoad(llvm::Type::getInt8Ty(ctx.builder.getContext()), maybe_bitcast(ctx, p, T_pint8)));
         if (jt == (jl_value_t*)jl_bool_type)
             unbox_load->setMetadata(LLVMContext::MD_range, MDNode::get(ctx.builder.getContext(), {
-                ConstantAsMetadata::get(ConstantInt::get(T_int8, 0)),
-                ConstantAsMetadata::get(ConstantInt::get(T_int8, 2)) }));
+                ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0)),
+                ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 2)) }));
         Value *unboxed;
-        if (to == T_int1)
-            unboxed = ctx.builder.CreateTrunc(unbox_load, T_int1);
+        if (to == llvm::Type::getInt1Ty(ctx.builder.getContext()))
+            unboxed = ctx.builder.CreateTrunc(unbox_load, llvm::Type::getInt1Ty(ctx.builder.getContext()));
         else
-            unboxed = unbox_load; // `to` must be T_int8
+            unboxed = unbox_load; // `to` must be llvm::Type::getInt8Ty(ctx.builder.getContext())
         if (!dest)
             return unboxed;
         Type *dest_ty = unboxed->getType()->getPointerTo();
@@ -442,7 +442,7 @@ static jl_cgval_t generic_bitcast(jl_codectx_t &ctx, const jl_cgval_t *argv)
     if (!bt)
         return emit_runtime_call(ctx, bitcast, argv, 2);
 
-    Type *llvmt = bitstype_to_llvm(bt);
+    Type *llvmt = bitstype_to_llvm(bt, ctx.builder.getContext());
     int nb = jl_datatype_size(bt);
 
     // Examine the second argument //
@@ -465,7 +465,7 @@ static jl_cgval_t generic_bitcast(jl_codectx_t &ctx, const jl_cgval_t *argv)
             if (isboxed) {
                 Value *size = emit_datatype_size(ctx, typ);
                 error_unless(ctx,
-                        ctx.builder.CreateICmpEQ(size, ConstantInt::get(T_int32, nb)),
+                        ctx.builder.CreateICmpEQ(size, ConstantInt::get(llvm::Type::getInt32Ty(ctx.builder.getContext()), nb)),
                         "bitcast: argument size does not match size of target type");
             }
             else {
@@ -487,7 +487,7 @@ static jl_cgval_t generic_bitcast(jl_codectx_t &ctx, const jl_cgval_t *argv)
         // but if the v.typ is not well known, use llvmt
         if (isboxed)
             vxt = llvmt;
-        auto storage_type = vxt == T_int1 ? T_int8 : vxt;
+        auto storage_type = vxt == llvm::Type::getInt1Ty(ctx.builder.getContext()) ? llvm::Type::getInt8Ty(ctx.builder.getContext()) : vxt;
         vx = tbaa_decorate(v.tbaa, ctx.builder.CreateLoad(
             storage_type,
             emit_bitcast(ctx, data_pointer(ctx, v),
@@ -496,9 +496,9 @@ static jl_cgval_t generic_bitcast(jl_codectx_t &ctx, const jl_cgval_t *argv)
 
     vxt = vx->getType();
     if (vxt != llvmt) {
-        if (llvmt == T_int1)
+        if (llvmt == llvm::Type::getInt1Ty(ctx.builder.getContext()))
             vx = ctx.builder.CreateTrunc(vx, llvmt);
-        else if (vxt == T_int1 && llvmt == T_int8)
+        else if (vxt == llvm::Type::getInt1Ty(ctx.builder.getContext()) && llvmt == llvm::Type::getInt8Ty(ctx.builder.getContext()))
             vx = ctx.builder.CreateZExt(vx, llvmt);
         else if (vxt->isPointerTy() && !llvmt->isPointerTy())
             vx = ctx.builder.CreatePtrToInt(vx, llvmt);
@@ -528,8 +528,8 @@ static jl_cgval_t generic_cast(
     jl_value_t *jlto = staticeval_bitstype(targ);
     if (!jlto || !jl_is_primitivetype(v.typ))
         return emit_runtime_call(ctx, f, argv, 2);
-    Type *to = bitstype_to_llvm(jlto);
-    Type *vt = bitstype_to_llvm(v.typ);
+    Type *to = bitstype_to_llvm(jlto, ctx.builder.getContext());
+    Type *vt = bitstype_to_llvm(v.typ, ctx.builder.getContext());
     if (toint)
         to = INTT(to);
     else
@@ -607,7 +607,7 @@ static jl_cgval_t emit_pointerref(jl_codectx_t &ctx, jl_cgval_t *argv)
         im1 = ctx.builder.CreateMul(im1, ConstantInt::get(T_size,
                     LLT_ALIGN(size, jl_datatype_align(ety))));
         Value *thePtr = emit_unbox(ctx, T_pint8, e, e.typ);
-        thePtr = ctx.builder.CreateInBoundsGEP(T_int8, emit_bitcast(ctx, thePtr, T_pint8), im1);
+        thePtr = ctx.builder.CreateInBoundsGEP(llvm::Type::getInt8Ty(ctx.builder.getContext()), emit_bitcast(ctx, thePtr, T_pint8), im1);
         MDNode *tbaa = best_tbaa(ctx.tbaa(), ety);
         emit_memcpy(ctx, strct, tbaa, thePtr, nullptr, size, 1);
         return mark_julia_type(ctx, strct, true, ety);
@@ -676,7 +676,7 @@ static jl_cgval_t emit_pointerset(jl_codectx_t &ctx, jl_cgval_t *argv)
         uint64_t size = jl_datatype_size(ety);
         im1 = ctx.builder.CreateMul(im1, ConstantInt::get(T_size,
                     LLT_ALIGN(size, jl_datatype_align(ety))));
-        emit_memcpy(ctx, ctx.builder.CreateInBoundsGEP(T_int8, thePtr, im1), nullptr, x, size, align_nb);
+        emit_memcpy(ctx, ctx.builder.CreateInBoundsGEP(llvm::Type::getInt8Ty(ctx.builder.getContext()), thePtr, im1), nullptr, x, size, align_nb);
     }
     else {
         bool isboxed;
@@ -990,23 +990,23 @@ static jl_cgval_t emit_ifelse(jl_codectx_t &ctx, jl_cgval_t c, jl_cgval_t x, jl_
                 ifelse_tbaa = MDNode::getMostGenericTBAA(x.tbaa, y.tbaa);
                 if (ifelse_tbaa == NULL) {
                     // LLVM won't return a TBAA result for the root, but mark_julia_struct requires it: make it now
-                    auto *OffsetNode = ConstantAsMetadata::get(ConstantInt::get(T_int64, 0));
+                    auto *OffsetNode = ConstantAsMetadata::get(ConstantInt::get(llvm::Type::getInt64Ty(ctx.builder.getContext()), 0));
                     Metadata *Ops[] = {ctx.tbaa().tbaa_root, ctx.tbaa().tbaa_root, OffsetNode};
                     ifelse_tbaa = MDNode::get(ctx.builder.getContext(), Ops);
                 }
             }
             Value *tindex;
             if (!x_tindex && x.constant) {
-                x_tindex = ConstantInt::get(T_int8, 0x80 | get_box_tindex((jl_datatype_t*)jl_typeof(x.constant), rt_hint));
+                x_tindex = ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80 | get_box_tindex((jl_datatype_t*)jl_typeof(x.constant), rt_hint));
             }
             if (!y_tindex && y.constant) {
-                y_tindex = ConstantInt::get(T_int8, 0x80 | get_box_tindex((jl_datatype_t*)jl_typeof(y.constant), rt_hint));
+                y_tindex = ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80 | get_box_tindex((jl_datatype_t*)jl_typeof(y.constant), rt_hint));
             }
             if (x_tindex && y_tindex) {
                 tindex = ctx.builder.CreateSelect(isfalse, y_tindex, x_tindex);
             }
             else {
-                PHINode *ret = PHINode::Create(T_int8, 2);
+                PHINode *ret = PHINode::Create(llvm::Type::getInt8Ty(ctx.builder.getContext()), 2);
                 BasicBlock *post = BasicBlock::Create(ctx.builder.getContext(), "post", ctx.f);
                 BasicBlock *compute = BasicBlock::Create(ctx.builder.getContext(), "compute_tindex", ctx.f);
                 // compute tindex if we select the previously-boxed value
@@ -1024,7 +1024,7 @@ static jl_cgval_t emit_ifelse(jl_codectx_t &ctx, jl_cgval_t c, jl_cgval_t x, jl_
                     ctx.builder.SetInsertPoint(compute);
                     tindex = compute_tindex_unboxed(ctx, x, rt_hint);
                 }
-                tindex = ctx.builder.CreateOr(tindex, ConstantInt::get(T_int8, 0x80));
+                tindex = ctx.builder.CreateOr(tindex, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 0x80));
                 compute = ctx.builder.GetInsertBlock(); // could have changed
                 ctx.builder.CreateBr(post);
                 ret->addIncoming(tindex, compute);
@@ -1136,11 +1136,11 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
         const jl_cgval_t &x = argv[0];
         if (!jl_is_primitivetype(x.typ))
             return emit_runtime_call(ctx, f, argv, nargs);
-        Type *xt = INTT(bitstype_to_llvm(x.typ));
+        Type *xt = INTT(bitstype_to_llvm(x.typ, ctx.builder.getContext()));
         Value *from = emit_unbox(ctx, xt, x, x.typ);
         Value *ans;
         if (x.typ == (jl_value_t*)jl_bool_type)
-            ans = ctx.builder.CreateXor(from, ConstantInt::get(T_int8, 1, true));
+            ans = ctx.builder.CreateXor(from, ConstantInt::get(llvm::Type::getInt8Ty(ctx.builder.getContext()), 1, true));
         else
             ans = ctx.builder.CreateXor(from, ConstantInt::get(xt, -1, true));
         return mark_julia_type(ctx, ans, false, x.typ);
@@ -1162,7 +1162,7 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
         else
             return emit_runtime_call(ctx, f, argv, nargs);
 
-        FunctionCallee intr = jl_Module->getOrInsertFunction(intr_name, T_int1);
+        FunctionCallee intr = jl_Module->getOrInsertFunction(intr_name, llvm::Type::getInt1Ty(ctx.builder.getContext()));
         auto ret = ctx.builder.CreateCall(intr);
         return mark_julia_type(ctx, ret, false, jl_bool_type);
     }
@@ -1174,7 +1174,7 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
         // verify argument types
         if (!jl_is_primitivetype(xinfo.typ))
             return emit_runtime_call(ctx, f, argv, nargs);
-        Type *xtyp = bitstype_to_llvm(xinfo.typ);
+        Type *xtyp = bitstype_to_llvm(xinfo.typ, ctx.builder.getContext());
         if (float_func[f])
             xtyp = FLOATT(xtyp);
         else
@@ -1189,7 +1189,7 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
         ////LLVM seems to emit better code if we do the latter,
         ////(more likely to fold away the cast) so that's what we'll do.
         //if (xtyp == (jl_value_t*)jl_bool_type)
-        //    r = T_int1;
+        //    r = llvm::Type::getInt1Ty(ctx.builder.getContext());
 
         Type **argt = (Type**)alloca(sizeof(Type*) * nargs);
         argt[0] = xtyp;
@@ -1197,7 +1197,7 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
         if (f == shl_int || f == lshr_int || f == ashr_int) {
             if (!jl_is_primitivetype(argv[1].typ))
                 return emit_runtime_call(ctx, f, argv, nargs);
-            argt[1] = INTT(bitstype_to_llvm(argv[1].typ));
+            argt[1] = INTT(bitstype_to_llvm(argv[1].typ, ctx.builder.getContext()));
         }
         else {
             for (size_t i = 1; i < nargs; ++i) {
@@ -1217,8 +1217,8 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
         jl_value_t *newtyp = xinfo.typ;
         Value *r = emit_untyped_intrinsic(ctx, f, argvalues, nargs, (jl_datatype_t**)&newtyp, xinfo.typ);
         // Turn Bool operations into mod 1 now, if needed
-        if (newtyp == (jl_value_t*)jl_bool_type && r->getType() != T_int1)
-            r = ctx.builder.CreateTrunc(r, T_int1);
+        if (newtyp == (jl_value_t*)jl_bool_type && r->getType() != llvm::Type::getInt1Ty(ctx.builder.getContext()))
+            r = ctx.builder.CreateTrunc(r, llvm::Type::getInt1Ty(ctx.builder.getContext()));
         return mark_julia_type(ctx, r, false, newtyp);
     }
     }
@@ -1252,14 +1252,14 @@ static Value *emit_untyped_intrinsic(jl_codectx_t &ctx, intrinsic f, Value **arg
     // for pointer arithmetic which lowers to getelementptr.
     case add_ptr: {
         return ctx.builder.CreatePtrToInt(
-            ctx.builder.CreateGEP(T_int8,
+            ctx.builder.CreateGEP(llvm::Type::getInt8Ty(ctx.builder.getContext()),
                 emit_inttoptr(ctx, x, T_pint8), y), t);
 
     }
 
     case sub_ptr: {
         return ctx.builder.CreatePtrToInt(
-            ctx.builder.CreateGEP(T_int8,
+            ctx.builder.CreateGEP(llvm::Type::getInt8Ty(ctx.builder.getContext()),
                 emit_inttoptr(ctx, x, T_pint8), ctx.builder.CreateNeg(y)), t);
 
     }
@@ -1313,7 +1313,7 @@ static Value *emit_untyped_intrinsic(jl_codectx_t &ctx, intrinsic f, Value **arg
         Value *res = ctx.builder.CreateCall(intr, {x, y});
         Value *val = ctx.builder.CreateExtractValue(res, ArrayRef<unsigned>(0));
         Value *obit = ctx.builder.CreateExtractValue(res, ArrayRef<unsigned>(1));
-        Value *obyte = ctx.builder.CreateZExt(obit, T_int8);
+        Value *obyte = ctx.builder.CreateZExt(obit, llvm::Type::getInt8Ty(ctx.builder.getContext()));
 
         jl_value_t *params[2];
         params[0] = xtyp;
@@ -1435,12 +1435,12 @@ static Value *emit_untyped_intrinsic(jl_codectx_t &ctx, intrinsic f, Value **arg
     }
     case ctlz_int: {
         FunctionCallee ctlz = Intrinsic::getDeclaration(jl_Module, Intrinsic::ctlz, makeArrayRef(t));
-        y = ConstantInt::get(T_int1, 0);
+        y = ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 0);
         return ctx.builder.CreateCall(ctlz, {x, y});
     }
     case cttz_int: {
         FunctionCallee cttz = Intrinsic::getDeclaration(jl_Module, Intrinsic::cttz, makeArrayRef(t));
-        y = ConstantInt::get(T_int1, 0);
+        y = ConstantInt::get(llvm::Type::getInt1Ty(ctx.builder.getContext()), 0);
         return ctx.builder.CreateCall(cttz, {x, y});
     }
 

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -103,13 +103,13 @@ static Type *FLOATT(Type *t)
         return t;
     unsigned nb = (t->isPointerTy() ? sizeof(void*) * 8 : t->getPrimitiveSizeInBits());
     if (nb == 64)
-        return T_float64;
+        return llvm::Type::getDoubleTy(t->getContext());
     if (nb == 32)
-        return T_float32;
+        return llvm::Type::getFloatTy(t->getContext());
     if (nb == 16)
-        return T_float16;
+        return llvm::Type::getHalfTy(t->getContext());
     if (nb == 128)
-        return T_float128;
+        return llvm::Type::getFP128Ty(t->getContext());
     return NULL;
 }
 
@@ -120,11 +120,11 @@ static Type *INTT(Type *t)
         return t;
     if (t->isPointerTy())
         return T_size;
-    if (t == T_float64)
+    if (t == llvm::Type::getDoubleTy(t->getContext()))
         return llvm::Type::getInt64Ty(t->getContext());
-    if (t == T_float32)
+    if (t == llvm::Type::getFloatTy(t->getContext()))
         return llvm::Type::getInt32Ty(t->getContext());
-    if (t == T_float16)
+    if (t == llvm::Type::getHalfTy(t->getContext()))
         return llvm::Type::getInt16Ty(t->getContext());
     unsigned nb = t->getPrimitiveSizeInBits();
     assert(t != T_void && nb > 0);


### PR DESCRIPTION
Global types for basic integer types are unnecessary since they are cached on LLVMContext objects themselves. Localizing them to LLVMContext enables the possibility of running the LLVM backend on multiple threads.