### PR TITLE
Remove explicit references to jl_data_layout

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -390,7 +390,7 @@ static Value *llvm_type_rewrite(
     // sizes.
     Value *from;
     Value *to;
-    const DataLayout &DL = jl_data_layout;
+    const DataLayout &DL = ctx.builder.GetInsertBlock()->getModule()->getDataLayout();
     unsigned align = std::max(DL.getPrefTypeAlignment(target_type), DL.getPrefTypeAlignment(from_type));
     if (DL.getTypeAllocSize(target_type) >= DL.getTypeAllocSize(from_type)) {
         to = emit_static_alloca(ctx, target_type);
@@ -937,7 +937,7 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
 static Value *box_ccall_result(jl_codectx_t &ctx, Value *result, Value *runtime_dt, jl_value_t *rt)
 {
     // XXX: need to handle parameterized zero-byte types (singleton)
-    const DataLayout &DL = jl_data_layout;
+    const DataLayout &DL = ctx.builder.GetInsertBlock()->getModule()->getDataLayout();
     unsigned nb = DL.getTypeStoreSize(result->getType());
     MDNode *tbaa = jl_is_mutable(rt) ? tbaa_mutab : tbaa_immut;
     Value *strct = emit_allocobj(ctx, nb, runtime_dt);
@@ -2004,7 +2004,7 @@ jl_cgval_t function_sig_t::emit_a_ccall(
                 MDNode *tbaa = jl_is_mutable(rt) ? tbaa_mutab : tbaa_immut;
                 int boxalign = julia_alignment(rt);
                 // copy the data from the return value to the new struct
-                const DataLayout &DL = jl_data_layout;
+                const DataLayout &DL = ctx.builder.GetInsertBlock()->getModule()->getDataLayout();
                 auto resultTy = result->getType();
                 if (DL.getTypeStoreSize(resultTy) > rtsz) {
                     // ARM and AArch64 can use a LLVM type larger than the julia type.

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -464,9 +464,8 @@ static bool type_is_permalloc(jl_value_t *typ)
         typ == (jl_value_t*)jl_uint8_type;
 }
 
-static unsigned convert_struct_offset(Type *lty, unsigned byte_offset)
+static unsigned convert_struct_offset(const llvm::DataLayout &DL, Type *lty, unsigned byte_offset)
 {
-    const DataLayout &DL = jl_data_layout;
     const StructLayout *SL = DL.getStructLayout(cast<StructType>(lty));
     unsigned idx = SL->getElementContainingOffset(byte_offset);
     assert(SL->getElementOffset(idx) == byte_offset);
@@ -475,7 +474,7 @@ static unsigned convert_struct_offset(Type *lty, unsigned byte_offset)
 
 static unsigned convert_struct_offset(jl_codectx_t &ctx, Type *lty, unsigned byte_offset)
 {
-    return convert_struct_offset(lty, byte_offset);
+    return convert_struct_offset(ctx.builder.GetInsertBlock()->getModule()->getDataLayout(), lty, byte_offset);
 }
 
 static Value *emit_struct_gep(jl_codectx_t &ctx, Type *lty, Value *base, unsigned byte_offset)
@@ -1478,7 +1477,7 @@ static jl_cgval_t typed_load(jl_codectx_t &ctx, Value *ptr, Value *idx_0based, j
         return ghostValue(jltype);
     AllocaInst *intcast = NULL;
     if (!isboxed && Order != AtomicOrdering::NotAtomic && !elty->isIntOrPtrTy()) {
-        const DataLayout &DL = jl_data_layout;
+        const DataLayout &DL = jl_Module->getDataLayout();
         unsigned nb = DL.getTypeSizeInBits(elty);
         intcast = ctx.builder.CreateAlloca(elty);
         elty = Type::getIntNTy(ctx.builder.getContext(), nb);
@@ -1590,7 +1589,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
     }
     AllocaInst *intcast = nullptr;
     if (!isboxed && Order != AtomicOrdering::NotAtomic && !elty->isIntOrPtrTy()) {
-        const DataLayout &DL = jl_data_layout;
+        const DataLayout &DL = jl_Module->getDataLayout();
         unsigned nb = DL.getTypeSizeInBits(elty);
         if (!issetfield)
             intcast = ctx.builder.CreateAlloca(elty);
@@ -1935,7 +1934,7 @@ static void emit_memcpy_llvm(jl_codectx_t &ctx, Value *dst, MDNode *tbaa_dst, Va
     if (sz <= 64) {
         // The size limit is arbitrary but since we mainly care about floating points and
         // machine size vectors this should be enough.
-        const DataLayout &DL = jl_data_layout;
+        const DataLayout &DL = jl_Module->getDataLayout();
         auto srcty = cast<PointerType>(src->getType());
         auto srcel = srcty->getElementType();
         auto dstty = cast<PointerType>(dst->getType());
@@ -2700,7 +2699,7 @@ static void init_bits_cgval(jl_codectx_t &ctx, Value *newv, const jl_cgval_t& v,
     }
 }
 
-static jl_value_t *static_constant_instance(Constant *constant, jl_value_t *jt)
+static jl_value_t *static_constant_instance(const llvm::DataLayout &DL, Constant *constant, jl_value_t *jt)
 {
     assert(constant != NULL && jl_is_concrete_type(jt));
     jl_datatype_t *jst = (jl_datatype_t*)jt;
@@ -2729,7 +2728,7 @@ static jl_value_t *static_constant_instance(Constant *constant, jl_value_t *jt)
     if (ConstantExpr *ce = dyn_cast<ConstantExpr>(constant)) {
         unsigned OpCode = ce->getOpcode();
         if (OpCode == Instruction::BitCast || OpCode == Instruction::PtrToInt || OpCode == Instruction::IntToPtr) {
-            return static_constant_instance(ce->getOperand(0), jt);
+            return static_constant_instance(DL, ce->getOperand(0), jt);
         }
         return NULL;
     }
@@ -2766,9 +2765,9 @@ static jl_value_t *static_constant_instance(Constant *constant, jl_value_t *jt)
         }
         unsigned llvm_idx = i;
         if (i > 0 && isa<StructType>(constant->getType()))
-            llvm_idx = convert_struct_offset(constant->getType(), jl_field_offset(jst, i));
+            llvm_idx = convert_struct_offset(DL, constant->getType(), jl_field_offset(jst, i));
         Constant *fld = constant->getAggregateElement(llvm_idx);
-        flds[i] = static_constant_instance(fld, ft);
+        flds[i] = static_constant_instance(DL, fld, ft);
         if (flds[i] == NULL) {
             JL_GC_POP();
             return NULL; // must have been unreachable
@@ -2818,7 +2817,7 @@ static Value *_boxed_special(jl_codectx_t &ctx, const jl_cgval_t &vinfo, Type *t
 
     if (ctx.linfo && jl_is_method(ctx.linfo->def.method) && !vinfo.ispointer()) { // don't bother codegen pre-boxing for toplevel
         if (Constant *c = dyn_cast<Constant>(vinfo.V)) {
-            jl_value_t *s = static_constant_instance(c, jt);
+            jl_value_t *s = static_constant_instance(jl_Module->getDataLayout(), c, jt);
             if (s) {
                 jl_add_method_root(ctx, s);
                 return track_pjlvalue(ctx, literal_pointer_val(ctx, s));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3817,7 +3817,7 @@ static jl_cgval_t emit_varinfo(jl_codectx_t &ctx, jl_varinfo_t &vi, jl_sym_t *va
                 ctx.builder.CreateAlignedStore(unbox, ssaslot, ssaslot->getAlign());
             }
             else {
-                const DataLayout &DL = jl_data_layout;
+                const DataLayout &DL = jl_Module->getDataLayout();
                 uint64_t sz = DL.getTypeStoreSize(T);
                 emit_memcpy(ctx, ssaslot, tbaa_stack, vi.value, sz, ssaslot->getAlign().value());
             }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -196,7 +196,7 @@ static Constant *julia_const_to_llvm(jl_codectx_t &ctx, const void *ptr, jl_data
         if (type_is_ghost(lft))
             continue;
         assert(!jl_field_isptr(bt, i));
-        unsigned llvm_idx = isa<StructType>(lt) ? convert_struct_offset(lt, offs) : i;
+        unsigned llvm_idx = isa<StructType>(lt) ? convert_struct_offset(jl_Module->getDataLayout(), lt, offs) : i;
         while (fields.size() < llvm_idx)
             fields.push_back(
                 UndefValue::get(GetElementPtrInst::getTypeAtIndex(lt, fields.size())));
@@ -286,7 +286,7 @@ static Value *emit_unboxed_coercion(jl_codectx_t &ctx, Type *to, Value *unboxed)
         return unboxed;
     bool frompointer = ty->isPointerTy();
     bool topointer = to->isPointerTy();
-    const DataLayout &DL = jl_data_layout;
+    const DataLayout &DL = jl_Module->getDataLayout();
     if (ty == T_int1 && to == T_int8) {
         // bools may be stored internally as int8
         unboxed = ctx.builder.CreateZExt(unboxed, T_int8);
@@ -305,7 +305,7 @@ static Value *emit_unboxed_coercion(jl_codectx_t &ctx, Type *to, Value *unboxed)
     }
     else if (!ty->isIntOrPtrTy() && !ty->isFloatingPointTy()) {
 #ifndef JL_NDEBUG
-        const DataLayout &DL = jl_data_layout;
+        const DataLayout &DL = jl_Module->getDataLayout();
 #endif
         assert(DL.getTypeSizeInBits(ty) == DL.getTypeSizeInBits(to));
         AllocaInst *cast = ctx.builder.CreateAlloca(ty);
@@ -395,7 +395,7 @@ static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x, jl_va
             // appropriate coercion manually.
             AllocaInst *AI = cast<AllocaInst>(p);
             Type *AllocType = AI->getAllocatedType();
-            const DataLayout &DL = jl_data_layout;
+            const DataLayout &DL = jl_Module->getDataLayout();
             if (!AI->isArrayAllocation() &&
                     (AllocType->isFloatingPointTy() || AllocType->isIntegerTy() || AllocType->isPointerTy()) &&
                     (to->isFloatingPointTy() || to->isIntegerTy() || to->isPointerTy()) &&


### PR DESCRIPTION
This is another PR in the collection developing to reduce dependencies on global codegen variables.