### PR TITLE
Defer code-compression until serialization

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -327,7 +327,7 @@ already_inferred_quick_test(interp::AbstractInterpreter, mi::MethodInstance) =
 function maybe_compress_codeinfo(interp::AbstractInterpreter, linfo::MethodInstance, ci::CodeInfo)
     def = linfo.def
     toplevel = !isa(def, Method)
-    if toplevel
+    if toplevel || JLOptions().incremental != Int8(0)  # defer compression until serialization
         return ci
     end
     if may_discard_trees(interp)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7574,7 +7574,7 @@ jl_compile_result_t jl_emit_codeinst(
                 jl_options.debug_level > 1) {
                 // update the stored code
                 if (codeinst->inferred != (jl_value_t*)src) {
-                    if (jl_is_method(def))
+                    if (jl_is_method(def) && !jl_options.incremental)    // defer compression until serialization
                         src = (jl_code_info_t*)jl_compress_ir(def, src);
                     codeinst->inferred = (jl_value_t*)src;
                     jl_gc_wb(codeinst, src);

--- a/src/method.c
+++ b/src/method.c
@@ -715,8 +715,12 @@ static void jl_method_set_source(jl_method_t *m, jl_code_info_t *src)
     jl_gc_wb(m, m->slot_syms);
     if (gen_only)
         m->source = NULL;
-    else
-        m->source = (jl_value_t*)jl_compress_ir(m, src);
+    else {
+        if (jl_options.incremental)    // defer compression until serialization
+            m->source = (jl_value_t*)src;
+        else
+            m->source = (jl_value_t*)jl_compress_ir(m, src);
+    }
     jl_gc_wb(m, m->source);
     JL_GC_POP();
 }


### PR DESCRIPTION
During incremental compilation (aka, package precompilation),
wait to call `jl_compress_ir` until the moment of method
serialization. This increases the efficiency of potential
root-order transformations (e.g., #42016).  Aside from
possible memory constraints, there appears to be little downside
to waiting.

This is a small piece of #42016, split out to test whether it can be safely done on its own. If folks want, we can disable the defensive decompression portion of this PR, but defensive decompression ~~will~~may be necessary for #42016. So I wanted to start with the full shebang.

Here's where root-reordering is potentially useful:

```julia
module PkgA
f(args...) = ...
end

module PkgB
using PkgA
# code that add more roots to PkgA.f ("B roots")
end

module PkgC
using PkgA
# run some code that adds roots to PkgA.f   ("C roots")
using PkgB   # this adds more roots to PkgA.f  ("B roots")
# run yet more code that adds yet more roots to PkgA.f   (more "C roots")
end
 ```

If we want to encode the package-of-origin for each root, root-reordering improves the efficiency of run-length encoding by enabling one to group the new roots added by `PkgC` into a single block. It may not be strictly necessary: we could have a run of PkgC roots, followed by a run of PkgB roots, followed by more PkgC roots. As long as we tag the roots by both module id and within-module count, then we can disambiguate them. But to me it seems to make sense to do a bit of work during serialization to make the code that runs during deserialization faster and simpler.

Since most roots seem to arise from compression (rather than codegen), just this one change already goes much of the way---we may not need additional reorderings.