### PR TITLE
remove tuple indexing by non-integer

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -268,6 +268,6 @@ end
 
 @deprecate var"@_inline_meta"   var"@inline"   false
 @deprecate var"@_noinline_meta" var"@noinline" false
-@deprecate getindex(@nospecialize(t::Tuple), i::Real) getfield(t, convert(Int, i))
+@eval @deprecate getindex(@nospecialize(t::Tuple), i::Real) = getfield(t, convert(Int, i), $(Expr(:boundscheck)))
 
 # END 1.8 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -268,6 +268,6 @@ end
 
 @deprecate var"@_inline_meta"   var"@inline"   false
 @deprecate var"@_noinline_meta" var"@noinline" false
-@deprecate getindex(@nospecialize(t::Tuple), i::Real) getfield(t, convert(Int, i), $(Expr(:boundscheck)))
+@deprecate getindex(@nospecialize(t::Tuple), i::Real) getfield(t, convert(Int, i))
 
 # END 1.8 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -268,6 +268,6 @@ end
 
 @deprecate var"@_inline_meta"   var"@inline"   false
 @deprecate var"@_noinline_meta" var"@noinline" false
-@deprecate getindex(@nospecialize(t::Tuple), i::Real) = t[convert(Int, i)]
+@deprecate getindex(@nospecialize(t::Tuple), i::Real) t[convert(Int, i)]
 
 # END 1.8 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -268,6 +268,6 @@ end
 
 @deprecate var"@_inline_meta"   var"@inline"   false
 @deprecate var"@_noinline_meta" var"@noinline" false
-@eval @deprecate getindex(@nospecialize(t::Tuple), i::Real) = getfield(t, convert(Int, i), $(Expr(:boundscheck)))
+@eval (@deprecate getindex(@nospecialize(t::Tuple), i::Real) = getfield(t, convert(Int, i), $(Expr(:boundscheck))))
 
 # END 1.8 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -268,6 +268,6 @@ end
 
 @deprecate var"@_inline_meta"   var"@inline"   false
 @deprecate var"@_noinline_meta" var"@noinline" false
-@deprecate getindex(@nospecialize(t::Tuple), i::Real) t[convert(Int, i)]
+@deprecate getindex(@nospecialize(t::Tuple), i::Real) getfield(t, convert(Int, i), $(Expr(:boundscheck)))
 
 # END 1.8 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -268,5 +268,6 @@ end
 
 @deprecate var"@_inline_meta"   var"@inline"   false
 @deprecate var"@_noinline_meta" var"@noinline" false
+@deprecate getindex(@nospecialize(t::Tuple), i::Real) = t[convert(Int, i)]
 
 # END 1.8 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -268,9 +268,6 @@ end
 
 @deprecate var"@_inline_meta"   var"@inline"   false
 @deprecate var"@_noinline_meta" var"@noinline" false
-@eval function getindex(@nospecialize(t::Tuple), i::Real)
-  Base.depwarn("`getindex(t::Tuple, i::Real)` is deprecated, use `t[convert(Int, i)]` instead.", :getindex)
-  getfield(t, convert(Int, i), $(Expr(:boundscheck)))
-end
+@deprecate getindex(t::Tuple, i::Real) t[convert(Int, i)]
 
 # END 1.8 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -268,6 +268,9 @@ end
 
 @deprecate var"@_inline_meta"   var"@inline"   false
 @deprecate var"@_noinline_meta" var"@noinline" false
-@eval (@deprecate getindex(@nospecialize(t::Tuple), i::Real) = getfield(t, convert(Int, i), $(Expr(:boundscheck))))
+@eval function getindex(@nospecialize(t::Tuple), i::Real)
+  Base.depwarn("`getindex(t::Tuple, i::Real)` is deprecated, use `t[convert(Int, i)]` instead.", ((Base.Core).Typeof(getindex)).name.mt.name)
+  getfield(t, convert(Int, i), $(Expr(:boundscheck)))
+end
 
 # END 1.8 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -269,7 +269,7 @@ end
 @deprecate var"@_inline_meta"   var"@inline"   false
 @deprecate var"@_noinline_meta" var"@noinline" false
 @eval function getindex(@nospecialize(t::Tuple), i::Real)
-  Base.depwarn("`getindex(t::Tuple, i::Real)` is deprecated, use `t[convert(Int, i)]` instead.", ((Base.Core).Typeof(getindex)).name.mt.name)
+  Base.depwarn("`getindex(t::Tuple, i::Real)` is deprecated, use `t[convert(Int, i)]` instead.", :getindex)
   getfield(t, convert(Int, i), $(Expr(:boundscheck)))
 end
 

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -28,6 +28,7 @@ size(@nospecialize(t::Tuple), d::Integer) = (d == 1) ? length(t) : throw(Argumen
 axes(@nospecialize t::Tuple) = (OneTo(length(t)),)
 @eval getindex(@nospecialize(t::Tuple), i::Int) = getfield(t, i, $(Expr(:boundscheck)))
 @eval getindex(@nospecialize(t::Tuple), i::Integer) = getfield(t, convert(Int, i), $(Expr(:boundscheck)))
+@deprecate @eval getindex(@nospecialize(t::Tuple), i::Real) = getfield(t, convert(Int, i), $(Expr(:boundscheck)))
 getindex(t::Tuple, r::AbstractArray{<:Any,1}) = (eltype(t)[t[ri] for ri in r]...,)
 getindex(t::Tuple, b::AbstractArray{Bool,1}) = length(b) == length(t) ? getindex(t, findall(b)) : throw(BoundsError(t, b))
 getindex(t::Tuple, c::Colon) = t

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -27,7 +27,7 @@ lastindex(@nospecialize t::Tuple) = length(t)
 size(@nospecialize(t::Tuple), d::Integer) = (d == 1) ? length(t) : throw(ArgumentError("invalid tuple dimension $d"))
 axes(@nospecialize t::Tuple) = (OneTo(length(t)),)
 @eval getindex(@nospecialize(t::Tuple), i::Int) = getfield(t, i, $(Expr(:boundscheck)))
-@eval getindex(@nospecialize(t::Tuple), i::Real) = getfield(t, convert(Int, i), $(Expr(:boundscheck)))
+@eval getindex(@nospecialize(t::Tuple), i::Integer) = getfield(t, convert(Int, i), $(Expr(:boundscheck)))
 getindex(t::Tuple, r::AbstractArray{<:Any,1}) = (eltype(t)[t[ri] for ri in r]...,)
 getindex(t::Tuple, b::AbstractArray{Bool,1}) = length(b) == length(t) ? getindex(t, findall(b)) : throw(BoundsError(t, b))
 getindex(t::Tuple, c::Colon) = t

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -28,7 +28,6 @@ size(@nospecialize(t::Tuple), d::Integer) = (d == 1) ? length(t) : throw(Argumen
 axes(@nospecialize t::Tuple) = (OneTo(length(t)),)
 @eval getindex(@nospecialize(t::Tuple), i::Int) = getfield(t, i, $(Expr(:boundscheck)))
 @eval getindex(@nospecialize(t::Tuple), i::Integer) = getfield(t, convert(Int, i), $(Expr(:boundscheck)))
-@deprecate @eval getindex(@nospecialize(t::Tuple), i::Real) = getfield(t, convert(Int, i), $(Expr(:boundscheck)))
 getindex(t::Tuple, r::AbstractArray{<:Any,1}) = (eltype(t)[t[ri] for ri in r]...,)
 getindex(t::Tuple, b::AbstractArray{Bool,1}) = length(b) == length(t) ? getindex(t, findall(b)) : throw(BoundsError(t, b))
 getindex(t::Tuple, c::Colon) = t

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -120,3 +120,11 @@ global_logger(prev_logger)
 end
 
 # END 0.7 deprecations
+
+@testset "tuple indexed by float deprecation" begin
+    @test_deprecated getindex((1,), 1.0) === 1
+    @test_deprecated getindex((1,2), 2.0) === 2
+    @test_throws Exception getindex((), 1.0)
+    @test_throws Exception getindex((1,2), 0.0)
+    @test_throws Exception getindex((1,2), -1.0)
+end

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -150,8 +150,8 @@ end
     @test_throws BoundsError getindex((1,2), 0)
     @test_throws BoundsError getindex((1,2), -1)
 
-    @test getindex((1,), 1.0) === 1
-    @test getindex((1,2), 2.0) === 2
+    @test_deprecated getindex((1,), 1.0) === 1
+    @test_deprecated getindex((1,2), 2.0) === 2
     @test_throws BoundsError getindex((), 1.0)
     @test_throws BoundsError getindex((1,2), 0.0)
     @test_throws BoundsError getindex((1,2), -1.0)

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -152,9 +152,9 @@ end
 
     @test_deprecated getindex((1,), 1.0) === 1
     @test_deprecated getindex((1,2), 2.0) === 2
-    @test_throws getindex((), 1.0)
-    @test_throws getindex((1,2), 0.0)
-    @test_throws getindex((1,2), -1.0)
+    @test_throws Exception getindex((), 1.0)
+    @test_throws Exception getindex((1,2), 0.0)
+    @test_throws Exception getindex((1,2), -1.0)
 
     @test getindex((5,6,7,8), [1,2,3]) === (5,6,7)
     @test_throws BoundsError getindex((1,2), [3,4])

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -150,12 +150,6 @@ end
     @test_throws BoundsError getindex((1,2), 0)
     @test_throws BoundsError getindex((1,2), -1)
 
-    @test_deprecated getindex((1,), 1.0) === 1
-    @test_deprecated getindex((1,2), 2.0) === 2
-    @test_throws Exception getindex((), 1.0)
-    @test_throws Exception getindex((1,2), 0.0)
-    @test_throws Exception getindex((1,2), -1.0)
-
     @test getindex((5,6,7,8), [1,2,3]) === (5,6,7)
     @test_throws BoundsError getindex((1,2), [3,4])
 

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -152,9 +152,9 @@ end
 
     @test_deprecated getindex((1,), 1.0) === 1
     @test_deprecated getindex((1,2), 2.0) === 2
-    @test_throws BoundsError getindex((), 1.0)
-    @test_throws BoundsError getindex((1,2), 0.0)
-    @test_throws BoundsError getindex((1,2), -1.0)
+    @test_throws getindex((), 1.0)
+    @test_throws getindex((1,2), 0.0)
+    @test_throws getindex((1,2), -1.0)
 
     @test getindex((5,6,7,8), [1,2,3]) === (5,6,7)
     @test_throws BoundsError getindex((1,2), [3,4])


### PR DESCRIPTION
Currently we don't throw an error for `(1,2)[1.0]` even though we really should. I'd be open to making this a deprectation warning rather than an error, if people think this might break actual people's code.