### PR TITLE
Track memops more accurately

### DIFF
--- a/src/llvm-alloc-helpers.cpp
+++ b/src/llvm-alloc-helpers.cpp
@@ -80,8 +80,6 @@ bool AllocUseInfo::addMemOp(Instruction *inst, unsigned opno, uint32_t offset,
     MemOp memop(inst, opno);
     memop.offset = offset;
     uint64_t size = DL.getTypeStoreSize(elty);
-    if (size >= UINT32_MAX - offset)
-        return false;
     memop.size = size;
     memop.isaggr = isa<StructType>(elty) || isa<ArrayType>(elty) || isa<VectorType>(elty);
     memop.isobjref = hasObjref(elty);
@@ -105,6 +103,8 @@ bool AllocUseInfo::addMemOp(Instruction *inst, unsigned opno, uint32_t offset,
         field.second.hasaggr = true;
     }
     field.second.accesses.push_back(memop);
+    if (size >= UINT32_MAX - offset)
+        return false;
     return true;
 }
 

--- a/src/llvm-alloc-helpers.h
+++ b/src/llvm-alloc-helpers.h
@@ -27,8 +27,8 @@ namespace jl_alloc {
 
     struct MemOp {
         llvm::Instruction *inst;
+        uint64_t offset = 0;
         unsigned opno;
-        uint32_t offset = 0;
         uint32_t size = 0;
         bool isobjref:1;
         bool isaggr:1;


### PR DESCRIPTION
Currently AllocUseInfo::addMemOp exits early if the memory operation has an unknown memory address. addMemOp also tracks global refstore and refload variables, but since these are after the early exit, an operation with unknown memory address that performs a refstore/refload will not be tracked in the use information. This PR fixes this bug.