### PR TITLE
Add `rdiv!` for `Bidiagonal` + small improvements

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -253,8 +253,7 @@ end
 
 adjoint(B::Bidiagonal) = Adjoint(B)
 transpose(B::Bidiagonal) = Transpose(B)
-adjoint(B::Bidiagonal{<:Real}) = Bidiagonal(B.dv, B.ev, B.uplo == 'U' ? :L : :U)
-adjoint(B::Bidiagonal{<:Number}) = Bidiagonal(conj.(B.dv), conj.(B.ev), B.uplo == 'U' ? :L : :U)
+adjoint(B::Bidiagonal{<:Number}) = Bidiagonal(conj(B.dv), conj(B.ev), B.uplo == 'U' ? :L : :U)
 transpose(B::Bidiagonal{<:Number}) = Bidiagonal(B.dv, B.ev, B.uplo == 'U' ? :L : :U)
 function Base.copy(aB::Adjoint{<:Any,<:Bidiagonal})
     B = aB.parent
@@ -789,8 +788,8 @@ function ldiv!(C::AbstractMatrix, A::Bidiagonal, B::AbstractMatrix)
     end
     C
 end
-ldiv!(A::Transpose{<:Any,<:Bidiagonal}, b::AbstractVecOrMat) = @inline ldiv!(b, copy(A), b)
-ldiv!(A::Adjoint{<:Any,<:Bidiagonal}, b::AbstractVecOrMat) = @inline ldiv!(b, copy(A), b)
+ldiv!(A::Transpose{<:Any,<:Bidiagonal}, b::AbstractVecOrMat) = @inline ldiv!(b, A, b)
+ldiv!(A::Adjoint{<:Any,<:Bidiagonal}, b::AbstractVecOrMat) = @inline ldiv!(b, A, b)
 ldiv!(c::AbstractVecOrMat, A::Transpose{<:Any,<:Bidiagonal}, b::AbstractVecOrMat) = ldiv!(c, copy(A), b)
 ldiv!(c::AbstractVecOrMat, A::Adjoint{<:Any,<:Bidiagonal}, b::AbstractVecOrMat) = ldiv!(c, copy(A), b)
 

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -785,13 +785,20 @@ function \(B::Bidiagonal{<:Number}, U::UpperOrUnitUpperTriangular{<:Number})
     A = ldiv!(zeros(T, size(U)), B, U)
     return B.uplo == 'U' ? UpperTriangular(A) : A
 end
+function \(B::Bidiagonal, U::UpperOrUnitUpperTriangular)
+    A = ldiv!(copy(parent(U)), B, U)
+    return B.uplo == 'U' ? UpperTriangular(A) : A
+end
 function \(B::Bidiagonal{<:Number}, L::LowerOrUnitLowerTriangular{<:Number})
     T = typeof((oneunit(eltype(B)))\oneunit(eltype(L)))
     A = ldiv!(zeros(T, size(L)), B, L)
     return B.uplo == 'L' ? LowerTriangular(A) : A
 end
+function \(B::Bidiagonal, L::LowerOrUnitLowerTriangular)
+    A = ldiv!(copy(parent(L)), B, L)
+    return B.uplo == 'L' ? LowerTriangular(A) : A
+end
 
-# if we don't want the type split, the following two/three methods can be removed
 function \(U::UpperOrUnitUpperTriangular{<:Number}, B::Bidiagonal{<:Number})
     T = typeof((oneunit(eltype(U)))/oneunit(eltype(B)))
     A = ldiv!(U, copy_similar(B, T))
@@ -850,7 +857,7 @@ function _rdiv!(C::AbstractMatrix, A::AbstractMatrix, B::Bidiagonal)
     end
     C
 end
-rdiv!(A::AbstractMatrix, B::Bidiagonal) = @inline _rdiv!(B, A, B)
+rdiv!(A::AbstractMatrix, B::Bidiagonal) = @inline _rdiv!(A, A, B)
 rdiv!(A::AbstractMatrix, B::Adjoint{<:Any,<:Bidiagonal}) = @inline _rdiv!(A, A, B)
 rdiv!(A::AbstractMatrix, B::Transpose{<:Any,<:Bidiagonal}) = @inline _rdiv!(A, A, B)
 rdiv!(C::AbstractMatrix, A::AbstractMatrix, B::Adjoint{<:Any,<:Bidiagonal}) =
@@ -871,13 +878,19 @@ function /(U::UpperOrUnitUpperTriangular{<:Number}, B::Bidiagonal{<:Number})
     A = _rdiv!(zeros(T, size(U)), U, B)
     return B.uplo == 'U' ? UpperTriangular(A) : A
 end
+function /(U::UpperOrUnitUpperTriangular, B::Bidiagonal)
+    A = _rdiv!(copy(parent(U)), U, B)
+    return B.uplo == 'U' ? UpperTriangular(A) : A
+end
 function /(L::LowerOrUnitLowerTriangular{<:Number}, B::Bidiagonal{<:Number})
     T = typeof((oneunit(eltype(L)))/oneunit(eltype(B)))
     A = _rdiv!(zeros(T, size(L)), L, B)
     return B.uplo == 'L' ? LowerTriangular(A) : A
 end
-
-# if we don't want the type split, the following two/three methods can be removed
+function /(L::LowerOrUnitLowerTriangular, B::Bidiagonal)
+    A = _rdiv!(copy(parent(L)), L, B)
+    return B.uplo == 'L' ? LowerTriangular(A) : A
+end
 function /(B::Bidiagonal{<:Number}, U::UpperOrUnitUpperTriangular{<:Number})
     T = typeof((oneunit(eltype(B)))/oneunit(eltype(U)))
     A = rdiv!(copy_similar(B, T), U)

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -799,8 +799,8 @@ ldiv!(A::Adjoint{<:Any,<:Bidiagonal}, b::AbstractVecOrMat) = ldiv!(copy(A), b)
 ### Generic promotion methods and fallbacks
 function \(A::Bidiagonal{<:Number}, B::AbstractVecOrMat{<:Number})
     TA, TB = eltype(A), eltype(B)
-    TAB = typeof((zero(TA)*zero(TB) + zero(TA)*zero(TB))/one(TA))
-    ldiv!(convert(AbstractArray{TAB}, A), copy_similar(B, TAB))
+    TAB = typeof((oneunit(TA))\oneunit(TB))
+    ldiv!(A, copy_similar(B, TAB))
 end
 \(A::Bidiagonal, B::AbstractVecOrMat) = ldiv!(A, copy(B))
 \(tA::Transpose{<:Any,<:Bidiagonal}, B::AbstractVecOrMat) = ldiv!(tA, copy(B))
@@ -843,17 +843,21 @@ rdiv!(A::AbstractMatrix, B::Transpose{<:Any,<:Bidiagonal}) = rdiv!(A, copy(B))
 
 function /(A::AbstractMatrix{<:Number}, B::Bidiagonal{<:Number})
     TA, TB = eltype(A), eltype(B)
-    TAB = typeof((zero(TA)*zero(TB) + zero(TA)*zero(TB))/one(TA))
-    rdiv!(copy_similar(A, TAB), convert(AbstractArray{TAB}, B))
+    TAB = typeof((oneunit(TA))/oneunit(TB))
+    rdiv!(copy_similar(A, TAB), B)
 end
-/(A::AbstractMatrix, B::Bidiagonal) = rdiv!(copy_similar(A), B)
+/(A::AbstractMatrix, B::Bidiagonal) = rdiv!(copy(A), B)
 /(A::AbstractMatrix, B::Transpose{<:Any,<:Bidiagonal}) = A / copy(B)
 /(A::AbstractMatrix, B::Adjoint{<:Any,<:Bidiagonal}) = A / copy(B)
 # disambiguation
-/(A::AdjOrTransAbsVec{<:Number}, B::Bidiagonal{<:Number}) = wrapperop(A)(wrapperop(A)(B) \ parent(A))
-/(A::AdjOrTransAbsVec, B::Bidiagonal) = wrapperop(A)(wrapperop(A)(B) \ parent(A))
-/(A::AdjOrTransAbsVec, B::Transpose{<:Any,<:Bidiagonal}) = wrapperop(A)(parent(B) \ parent(A))
-/(A::AdjOrTransAbsVec, B::Adjoint{<:Any,<:Bidiagonal}) = wrapperop(A)(parent(B) \ parent(A))
+/(A::AdjointAbsVec{<:Number}, B::Bidiagonal{<:Number}) = adjoint(adjoint(B) \ parent(A))
+/(A::TransposeAbsVec{<:Number}, B::Bidiagonal{<:Number}) = transpose(transpose(B) \ parent(A))
+/(A::AdjointAbsVec, B::Bidiagonal) = adjoint(adjoint(B) \ parent(A))
+/(A::TransposeAbsVec, B::Bidiagonal) = transpose(transpose(B) \ parent(A))
+/(A::AdjointAbsVec, B::Transpose{<:Any,<:Bidiagonal}) = adjoint(adjoint(B) \ parent(A))
+/(A::TransposeAbsVec, B::Transpose{<:Any,<:Bidiagonal}) = transpose(transpose(B) \ parent(A))
+/(A::AdjointAbsVec, B::Adjoint{<:Any,<:Bidiagonal}) = adjoint(adjoint(B) \ parent(A))
+/(A::TransposeAbsVec, B::Adjoint{<:Any,<:Bidiagonal}) = transpose(transpose(B) \ parent(A))
 
 factorize(A::Bidiagonal) = A
 

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -351,7 +351,8 @@ function mul!(C::AbstractMatrix, Da::Diagonal, Db::Diagonal, alpha::Number, beta
     return C
 end
 
-/(A::AbstractVecOrMat, D::Diagonal) = _rdiv!(similar(A, promote_op(/, eltype(A), eltype(D)), size(A)), A, D)
+/(A::AbstractVecOrMat, D::Diagonal) =
+    _rdiv!((promote_op(/, eltype(A), eltype(D))).(A), A, D)
 
 rdiv!(A::AbstractVecOrMat, D::Diagonal) = @inline _rdiv!(A, A, D)
 # avoid copy when possible via internal 3-arg backend
@@ -372,7 +373,8 @@ function _rdiv!(B::AbstractVecOrMat, A::AbstractVecOrMat, D::Diagonal)
     B
 end
 
-\(D::Diagonal, B::AbstractVecOrMat) = ldiv!(similar(B, promote_op(\, eltype(D), eltype(B)), size(B)), D, B)
+\(D::Diagonal, B::AbstractVecOrMat) =
+    ldiv!(promote_op(\, eltype(D), eltype(B)).(B), D, B)
 
 ldiv!(D::Diagonal, B::AbstractVecOrMat) = @inline ldiv!(B, D, B)
 function ldiv!(B::AbstractVecOrMat, D::Diagonal, A::AbstractVecOrMat)

--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -161,12 +161,12 @@ end
 
 function *(H::UpperHessenberg, B::Bidiagonal)
     TS = promote_op(matprod, eltype(H), eltype(B))
-    A = A_mul_B_td!(zeros(TS, size(H)...), H, B)
+    A = A_mul_B_td!(zeros(TS, size(H)), H, B)
     return B.uplo == 'U' ? UpperHessenberg(A) : A
 end
 function *(B::Bidiagonal, H::UpperHessenberg)
     TS = promote_op(matprod, eltype(B), eltype(H))
-    A = A_mul_B_td!(zeros(TS, size(B)...), B, H)
+    A = A_mul_B_td!(zeros(TS, size(H)), B, H)
     return B.uplo == 'U' ? UpperHessenberg(A) : A
 end
 
@@ -174,18 +174,16 @@ end
 /(H::UpperHessenberg{<:Number}, B::Bidiagonal{<:Number}) = _rdiv(H, B)
 function _rdiv(H::UpperHessenberg, B::Bidiagonal)
     T = typeof(oneunit(eltype(H))/oneunit(eltype(B)))
-    HH = copy_similar(H, T)
-    A = rdiv!(HH, B)
+    A = _rdiv!(zeros(T, size(H)), H, B)
     return B.uplo == 'U' ? UpperHessenberg(A) : A
 end
 
-\(B::Bidiagonal, H::UpperHessenberg) = _ldiv(B, H)
 \(B::Bidiagonal{<:Number}, H::UpperHessenberg{<:Number}) = _ldiv(B, H)
+\(B::Bidiagonal, H::UpperHessenberg) = _ldiv(B, H)
 function _ldiv(B::Bidiagonal, H::UpperHessenberg)
     T = typeof(oneunit(eltype(B))\oneunit(eltype(H)))
-    HH = copy_similar(H, T)
-    ldiv!(B, HH)
-    return B.uplo == 'U' ? UpperHessenberg(HH) : HH
+    A = ldiv!(zeros(T, size(H)), B, H)
+    return B.uplo == 'U' ? UpperHessenberg(A) : A
 end
 
 # Solving (H+µI)x = b: we can do this in O(m²) time and O(m) memory

--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -122,69 +122,70 @@ end
 
 function *(H::UpperHessenberg, U::UpperOrUnitUpperTriangular)
     T = typeof(oneunit(eltype(H))*oneunit(eltype(U)))
-    HH = similar(H.data, T, size(H))
-    copyto!(HH, H)
+    HH = copy_similar(H, T)
     rmul!(HH, U)
     UpperHessenberg(HH)
 end
 function *(U::UpperOrUnitUpperTriangular, H::UpperHessenberg)
     T = typeof(oneunit(eltype(H))*oneunit(eltype(U)))
-    HH = similar(H.data, T, size(H))
-    copyto!(HH, H)
+    HH = copy_similar(H, T)
     lmul!(U, HH)
     UpperHessenberg(HH)
 end
 
 function /(H::UpperHessenberg, U::UpperTriangular)
     T = typeof(oneunit(eltype(H))/oneunit(eltype(U)))
-    HH = similar(H.data, T, size(H))
-    copyto!(HH, H)
+    HH = copy_similar(H, T)
     rdiv!(HH, U)
     UpperHessenberg(HH)
 end
 function /(H::UpperHessenberg, U::UnitUpperTriangular)
     T = typeof(oneunit(eltype(H))/oneunit(eltype(U)))
-    HH = similar(H.data, T, size(H))
-    copyto!(HH, H)
+    HH = copy_similar(H, T)
     rdiv!(HH, U)
     UpperHessenberg(HH)
 end
 
 function \(U::UpperTriangular, H::UpperHessenberg)
     T = typeof(oneunit(eltype(U))\oneunit(eltype(H)))
-    HH = similar(H.data, T, size(H))
-    copyto!(HH, H)
+    HH = copy_similar(H, T)
     ldiv!(U, HH)
     UpperHessenberg(HH)
 end
 function \(U::UnitUpperTriangular, H::UpperHessenberg)
     T = typeof(oneunit(eltype(U))\oneunit(eltype(H)))
-    HH = similar(H.data, T, size(H))
-    copyto!(HH, H)
+    HH = copy_similar(H, T)
     ldiv!(U, HH)
     UpperHessenberg(HH)
 end
 
 function *(H::UpperHessenberg, B::Bidiagonal)
     TS = promote_op(matprod, eltype(H), eltype(B))
-    if B.uplo == 'U'
-        A_mul_B_td!(UpperHessenberg(zeros(TS, size(H)...)), H, B)
-    else
-        A_mul_B_td!(zeros(TS, size(H)...), H, B)
-    end
+    A = A_mul_B_td!(zeros(TS, size(H)...), H, B)
+    return B.uplo == 'U' ? UpperHessenberg(A) : A
 end
 function *(B::Bidiagonal, H::UpperHessenberg)
     TS = promote_op(matprod, eltype(B), eltype(H))
-    if B.uplo == 'U'
-        A_mul_B_td!(UpperHessenberg(zeros(TS, size(B)...)), B, H)
-    else
-        A_mul_B_td!(zeros(TS, size(B)...), B, H)
-    end
+    A = A_mul_B_td!(zeros(TS, size(B)...), B, H)
+    return B.uplo == 'U' ? UpperHessenberg(A) : A
 end
 
-function /(H::UpperHessenberg, B::Bidiagonal)
-    A = Base.@invoke /(H::AbstractMatrix, B::Bidiagonal)
-    B.uplo == 'U' ? UpperHessenberg(A) : A
+/(H::UpperHessenberg, B::Bidiagonal) = _rdiv(H, B)
+/(H::UpperHessenberg{<:Number}, B::Bidiagonal{<:Number}) = _rdiv(H, B)
+function _rdiv(H::UpperHessenberg, B::Bidiagonal)
+    T = typeof(oneunit(eltype(H))/oneunit(eltype(B)))
+    HH = copy_similar(H, T)
+    A = rdiv!(HH, B)
+    return B.uplo == 'U' ? UpperHessenberg(A) : A
+end
+
+\(B::Bidiagonal, H::UpperHessenberg) = _ldiv(B, H)
+\(B::Bidiagonal{<:Number}, H::UpperHessenberg{<:Number}) = _ldiv(B, H)
+function _ldiv(B::Bidiagonal, H::UpperHessenberg)
+    T = typeof(oneunit(eltype(B))\oneunit(eltype(H)))
+    HH = copy_similar(H, T)
+    ldiv!(B, HH)
+    return B.uplo == 'U' ? UpperHessenberg(HH) : HH
 end
 
 # Solving (H+µI)x = b: we can do this in O(m²) time and O(m) memory

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -547,6 +547,19 @@ end
     bb = Any[b[1:3], b[4:6], b[7:9]]
     @test vcat((Alb\bb)...) ≈ LowerTriangular(A)\b
     @test vcat((Aub\bb)...) ≈ UpperTriangular(A)\b
+    Alb = Bidiagonal([tril(A[1:3,1:3]), tril(A[4:6,4:6]), tril(A[7:9,7:9])],
+                     [triu(A[4:6,1:3]), triu(A[7:9,4:6])], 'L')
+    Aub = Bidiagonal([triu(A[1:3,1:3]), triu(A[4:6,4:6]), triu(A[7:9,7:9])],
+                     [tril(A[1:3,4:6]), tril(A[4:6,7:9])], 'U')
+    d = [randn(3,3) for _ in 1:3]
+    dl = [randn(3,3) for _ in 1:2]
+    B = [randn(3,3) for _ in 1:3, _ in 1:3]
+    for W in (UpperTriangular, LowerTriangular), t in (identity, adjoint, transpose)
+        @test Matrix(t(Alb) \ W(B)) ≈ t(Alb) \ Matrix(W(B))
+        @test Matrix(t(Aub) \ W(B)) ≈ t(Aub) \ Matrix(W(B))
+        @test Matrix(W(B) / t(Alb)) ≈ Matrix(W(B)) / t(Alb)
+        @test Matrix(W(B) / t(Aub)) ≈ Matrix(W(B)) / t(Aub)
+    end
 end
 
 @testset "sum, mapreduce" begin

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -262,6 +262,13 @@ Random.seed!(1)
                 x = transpose(T) \ b
                 tx = transpose(Tfull) \ b
                 @test norm(x-tx,Inf) <= 4*condT*max(eps()*norm(tx,Inf), eps(promty)*norm(x,Inf))
+                x = copy(transpose(b)) / T
+                tx = copy(transpose(b)) / Tfull
+                @test_throws DimensionMismatch rdiv!(Matrix{elty}(undef, 1, n+1), T)
+                @test norm(x-tx,Inf) <= 4*condT*max(eps()*norm(tx,Inf), eps(promty)*norm(x,Inf))
+                x = copy(transpose(b)) / transpose(T)
+                tx = copy(transpose(b)) / transpose(Tfull)
+                @test norm(x-tx,Inf) <= 4*condT*max(eps()*norm(tx,Inf), eps(promty)*norm(x,Inf))
                 @testset "Generic Mat-vec ops" begin
                     @test T*b ≈ Tfull*b
                     @test T'*b ≈ Tfull'*b
@@ -275,6 +282,22 @@ Random.seed!(1)
             zA  = Bidiagonal(zdv, zev, :U)
             zb  = Vector{elty}(undef, 0)
             @test ldiv!(zA, zb) === zb
+            @testset "linear solves with abstract matrices" begin
+                diag = b[:,1]
+                D = Diagonal(diag)
+                x = T \ D
+                tx = Tfull \ D
+                @test norm(x-tx,Inf) <= 4*condT*max(eps()*norm(tx,Inf), eps(promty)*norm(x,Inf))
+                x = D / T
+                tx = D / Tfull
+                @test norm(x-tx,Inf) <= 4*condT*max(eps()*norm(tx,Inf), eps(promty)*norm(x,Inf))
+                x = transpose(T) \ D
+                tx = transpose(Tfull) \ D
+                @test norm(x-tx,Inf) <= 4*condT*max(eps()*norm(tx,Inf), eps(promty)*norm(x,Inf))
+                x = D / transpose(T)
+                tx = D / transpose(Tfull)
+                @test norm(x-tx,Inf) <= 4*condT*max(eps()*norm(tx,Inf), eps(promty)*norm(x,Inf))
+            end
         end
 
         if elty <: BlasReal

--- a/stdlib/LinearAlgebra/test/hessenberg.jl
+++ b/stdlib/LinearAlgebra/test/hessenberg.jl
@@ -90,18 +90,18 @@ let n = 10
                 @testset "Multiplication/division" begin
                     for x = (5, 5I, Diagonal(d), Bidiagonal(d,dl,:U),
                              UpperTriangular(A), UnitUpperTriangular(A))
-                        @test (H*x)::UpperHessenberg == Array(H)*x broken = eltype(H) <: Furlong && x isa Bidiagonal
-                        @test (x*H)::UpperHessenberg == x*Array(H) broken = eltype(H) <: Furlong && x isa Bidiagonal
-                        @test H/x == Array(H)/x broken = eltype(H) <: Furlong && x isa Union{Bidiagonal, UpperTriangular}
-                        @test x\H == x\Array(H) broken = eltype(H) <: Furlong && x isa Union{Bidiagonal, UpperTriangular}
-                        @test H/x isa UpperHessenberg broken = eltype(H) <: Furlong && x isa Bidiagonal
-                        @test x\H isa UpperHessenberg broken = eltype(H) <: Furlong && x isa Bidiagonal
+                        @test (H*x)::UpperHessenberg == Array(H)*x
+                        @test (x*H)::UpperHessenberg == x*Array(H)
+                        @test H/x == Array(H)/x broken = eltype(H) <: Furlong && x isa UpperTriangular
+                        @test x\H == x\Array(H) broken = eltype(H) <: Furlong && x isa UpperTriangular
+                        @test H/x isa UpperHessenberg
+                        @test x\H isa UpperHessenberg
                     end
                     x = Bidiagonal(d, dl, :L)
                     @test H*x == Array(H)*x
                     @test x*H == x*Array(H)
-                    @test H/x == Array(H)/x broken = eltype(H) <: Furlong
-                    @test_broken x\H == x\Array(H) # issue 40037
+                    @test H/x == Array(H)/x
+                    @test x\H == x\Array(H)
                 end
             end
         end

--- a/stdlib/LinearAlgebra/test/hessenberg.jl
+++ b/stdlib/LinearAlgebra/test/hessenberg.jl
@@ -84,12 +84,31 @@ let n = 10
                         @test op(x,H) isa UpperHessenberg
                     end
                 end
-                A = randn(n,n)
-                d = randn(n)
-                dl = randn(n-1)
-                @testset "Multiplication/division" begin
-                    for x = (5, 5I, Diagonal(d), Bidiagonal(d,dl,:U),
-                             UpperTriangular(A), UnitUpperTriangular(A))
+            end
+            H = UpperHessenberg(Areal)
+            A = randn(n,n)
+            d = randn(n)
+            dl = randn(n-1)
+            @testset "Multiplication/division" begin
+                for x = (5, 5I, Diagonal(d), Bidiagonal(d,dl,:U),
+                            UpperTriangular(A), UnitUpperTriangular(A))
+                    @test (H*x)::UpperHessenberg == Array(H)*x
+                    @test (x*H)::UpperHessenberg == x*Array(H)
+                    @test H/x == Array(H)/x broken = eltype(H) <: Furlong && x isa UpperTriangular
+                    @test x\H == x\Array(H) broken = eltype(H) <: Furlong && x isa UpperTriangular
+                    @test H/x isa UpperHessenberg
+                    @test x\H isa UpperHessenberg
+                end
+                x = Bidiagonal(d, dl, :L)
+                @test H*x == Array(H)*x
+                @test x*H == x*Array(H)
+                @test H/x == Array(H)/x
+                @test x\H == x\Array(H)
+            end
+            H = UpperHessenberg(Furlong.(Areal))
+            for A in (A, Furlong.(A))
+                @testset "Multiplication/division Furlong" begin
+                    for x = (5, 5I, Diagonal(d), Bidiagonal(d,dl,:U))
                         @test (H*x)::UpperHessenberg == Array(H)*x
                         @test (x*H)::UpperHessenberg == x*Array(H)
                         @test H/x == Array(H)/x broken = eltype(H) <: Furlong && x isa UpperTriangular


### PR DESCRIPTION
This add `rdiv!` functionality for `Bidiagonal`s and fixes left-divisions with abstract matrices:
```julia
julia> Bidiagonal(rand(4), rand(3), :U) \ Diagonal(rand(4))
ERROR: ArgumentError: cannot set off-diagonal entry (1, 2) to a nonzero value (-0.6716542213315394)
```
since we use a structure-preserving `copy` instead of `copy_similar`. This bug is many years old. This also fixes products and divisions with Hessenberg matrices, including fixes for unit-like eltypes.

Fixes  JuliaLang/LinearAlgebra.jl#821.