### PR TITLE
Remove sqrt from the volatile list

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -618,7 +618,6 @@ function is_pure_intrinsic_infer(f::IntrinsicFunction)
              f === Intrinsics.pointerset || # this one is never effect-free
              f === Intrinsics.llvmcall ||   # this one is never effect-free
              f === Intrinsics.arraylen ||   # this one is volatile
-             f === Intrinsics.sqrt_llvm ||  # this one may differ at runtime (by a few ulps)
              f === Intrinsics.sqrt_llvm_fast ||  # this one may differ at runtime (by a few ulps)
              f === Intrinsics.have_fma ||  # this one depends on the runtime environment
              f === Intrinsics.cglobal)  # cglobal lookup answer changes at runtime

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -891,3 +891,7 @@ let
     ftest(a) = (fcond(a, nothing); a)
     @test fully_eliminated(ftest, Tuple{Bool})
 end
+
+# sqrt not considered volatile
+f_sqrt() = sqrt(2)
+@test fully_eliminated(f_sqrt, Tuple{})

--- a/test/math.jl
+++ b/test/math.jl
@@ -1386,8 +1386,10 @@ end
         # Runtime version
         @test sqrt(x) === y
         # Interpreter compile-time version
+        @test Base.invokelatest((@eval ()->sqrt(Base.inferencebarrier($x)))) == y
+        # Inference const-prop version
         @test Base.invokelatest((@eval ()->sqrt($x))) == y
         # LLVM constant folding version
-        @test Base.invokelatest((@eval ()->(@force_compile; sqrt($x)))) == y
+        @test Base.invokelatest((@eval ()->(@force_compile; sqrt(Base.inferencebarrier($x))))) == y
     end
 end


### PR DESCRIPTION
The LLVM IR spec now explicitly says that this intrinsic is required
to be rounded correctly. That means that without fasthmath flag
(which we do not set here), this intrinsic must have the bitwise
correctly rounded answer and should thus not differ between compile
and runtime. If there is still a case where it does differ, that is
likely some other underlying bug that we should fix instead.

Before:
```
julia> f() = sqrt(2)
f (generic function with 1 method)

julia> @code_typed f()
CodeInfo(
1 ─ %1 = Base.Math.sqrt_llvm(2.0)::Float64
└──      return %1
) => Float64
```

After:
```
julia> @code_typed f()
CodeInfo(
1 ─     return 1.4142135623730951
) => Float64
```