### PR TITLE
Add trailing nl for `display(::TextDisplay, ...)`

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -142,7 +142,6 @@ function eval_user_input(errio, @nospecialize(ast), show_value::Bool)
                         @error "Evaluation succeeded, but an error occurred while displaying the value" typeof(value)
                         rethrow()
                     end
-                    println()
                 end
             end
             break

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -239,14 +239,14 @@ objects are printed in the Julia REPL.)
 struct TextDisplay <: AbstractDisplay
     io::IO
 end
-display(d::TextDisplay, M::MIME"text/plain", @nospecialize x) = show(d.io, M, x)
+display(d::TextDisplay, M::MIME"text/plain", @nospecialize x) = (show(d.io, M, x); println(d.io))
 display(d::TextDisplay, @nospecialize x) = display(d, MIME"text/plain"(), x)
 
 # if you explicitly call display("text/foo", x), it should work on a TextDisplay:
 displayable(d::TextDisplay, M::MIME) = istextmime(M)
 function display(d::TextDisplay, M::MIME, @nospecialize x)
     displayable(d, M) || throw(MethodError(display, (d, M, x)))
-    show(d.io, M, x)
+    show(d.io, M, x); println(d.io)
 end
 
 import Base: close, flush

--- a/stdlib/DelimitedFiles/test/runtests.jl
+++ b/stdlib/DelimitedFiles/test/runtests.jl
@@ -321,10 +321,10 @@ end
 # issue #11484: useful error message for invalid readdlm filepath arguments
 @test_throws ArgumentError readdlm(tempdir())
 
-# displaying as text/csv
-let d = TextDisplay(IOBuffer())
-    display(d, "text/csv", [3 1 4])
-    @test String(take!(d.io)) == "3,1,4\n"
+# showing as text/csv
+let d = TextDisplay(PipeBuffer())
+    show(d.io, "text/csv", [3 1 4])
+    @test read(d.io, String) == "3,1,4\n"
 end
 
 @testset "complex" begin

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -275,10 +275,10 @@ end
     @test sprint(show, [1 missing]) == "$(Union{Int, Missing})[1 missing]"
     b = IOBuffer()
     display(TextDisplay(b), [missing])
-    @test String(take!(b)) == "1-element Vector{$Missing}:\n missing"
+    @test String(take!(b)) == "1-element Vector{$Missing}:\n missing\n"
     b = IOBuffer()
     display(TextDisplay(b), [1 missing])
-    @test String(take!(b)) == "1×2 Matrix{$(Union{Int, Missing})}:\n 1  missing"
+    @test String(take!(b)) == "1×2 Matrix{$(Union{Int, Missing})}:\n 1  missing\n"
 end
 
 @testset "arrays with missing values" begin

--- a/test/show.jl
+++ b/test/show.jl
@@ -1877,11 +1877,10 @@ end
 
 @testset "#14684: `display` should print associative types in full" begin
     d = Dict(1 => 2, 3 => 45)
-    buf = IOBuffer()
-    td = TextDisplay(buf)
+    td = TextDisplay(PipeBuffer())
 
     display(td, d)
-    result = String(take!(td.io))
+    result = read(td.io, String)
     @test occursin(summary(d), result)
 
     # Is every pair in the string?
@@ -1891,8 +1890,7 @@ end
 end
 
 @testset "#43766: `display` trailing newline" begin
-    buf = PipeBuffer()
-    td = TextDisplay(buf)
+    td = TextDisplay(PipeBuffer())
     display(td, 1)
     @test read(td.io, String) == "1\n"
     show(td.io, 1)

--- a/test/show.jl
+++ b/test/show.jl
@@ -1890,6 +1890,15 @@ end
     end
 end
 
+@testset "#43766: `display` trailing newline" begin
+    buf = PipeBuffer()
+    td = TextDisplay(buf)
+    display(td, 1)
+    @test read(td.io, String) == "1\n"
+    show(td.io, 1)
+    @test read(td.io, String) == "1"
+end
+
 function _methodsstr(f)
     buf = IOBuffer()
     show(buf, methods(f))


### PR DESCRIPTION
Fix https://github.com/JuliaLang/julia/issues/43766.

Test pass locally on `1.6.5` and `1.7.1` builds on `linux`, let's check `CI` now ...

It'd be great (if possible) to have this land in `1.6` and `1.7`.