### PR TITLE
fix ranges PR conflict

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -167,7 +167,14 @@ range_length(len::Integer) = OneTo(len)
 range_stop(stop) = range_start_stop(oftype(stop, 1), stop)
 range_stop(stop::Integer) = range_length(stop)
 
-range_step_stop_length(step, stop, length) = reverse(range_start_step_length(stop, -step, length))
+function range_step_stop_length(step, a, len::Integer)
+    start = a - step * (len - oneunit(len))
+    if start isa Signed
+        # overflow in recomputing length from stop is okay
+        return StepRange{typeof(start),typeof(step)}(start, step, convert(typeof(start), a))
+    end
+    return StepRangeLen{typeof(start),typeof(start),typeof(step)}(start, step, len)
+end
 
 # Stop and length as the only argument
 function range_stop_length(a, len::Integer)
@@ -177,7 +184,7 @@ function range_stop_length(a, len::Integer)
         # overflow in recomputing length from stop is okay
         return UnitRange(start, oftype(start, a))
     end
-    return range_step_stop_length(oftype(a - a, 1), a, len)
+    return StepRangeLen{typeof(start),typeof(start),typeof(step)}(start, step, len)
 end
 
 # Start and length as the only argument
@@ -188,7 +195,7 @@ function range_start_length(a, len::Integer)
         # overflow in recomputing length from stop is okay
         return UnitRange(oftype(stop, a), stop)
     end
-    return range_start_step_length(a, oftype(a - a, 1), len)
+    return StepRangeLen{typeof(stop),typeof(a),typeof(step)}(a, step, len)
 end
 
 range_start_stop(start, stop) = start:stop

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -35,9 +35,14 @@ using Base.Checked: checked_length
         @test r ==  range(; stop=Float64(stop))
     end
 
-    for T = (Int8, Rational{Int16}, UInt32, Float64, Char)
+    for T = (Int8, UInt32, Float64, Char)
         @test typeof(range(start=T(5), length=3)) === typeof(range(stop=T(5), length=3))
+        @test typeof(range(start=T(5), length=Int8(3))) === typeof(range(stop=T(5), length=Int8(3)))
     end
+    let T = Rational{Int16}
+        @test typeof(range(start=T(5), length=Int16(3))) === typeof(range(stop=T(5), length=Int16(3)))
+    end
+
 
     @test first(10:3) === 10
     @test last(10:3) === 9


### PR DESCRIPTION
We cannot safely use reverse, so we do not anymore. That is now causing
conflict between #43059 and #29842. And this is likely clearer anyways.

Closes #43788