### PR TITLE
Allow branch folding to look at type information, fix Conditional bug

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1007,7 +1007,13 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
         stmt = renumber_ssa2!(stmt, ssa_rename, used_ssas, late_fixup, result_idx, do_rename_ssa)::GotoIfNot
         result[result_idx][:inst] = stmt
         cond = stmt.cond
-        if isa(cond, Bool) && compact.fold_constant_branches
+        if compact.fold_constant_branches
+            if !isa(cond, Bool)
+                condT = widenconditional(argextype(cond, compact))
+                isa(condT, Const) || @goto bail
+                cond = condT.val
+                isa(cond, Bool) || @goto bail
+            end
             if cond
                 result[result_idx][:inst] = nothing
                 kill_edge!(compact, active_bb, active_bb, stmt.dest)
@@ -1018,6 +1024,7 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
                 result_idx += 1
             end
         else
+            @label bail
             result[result_idx][:inst] = GotoIfNot(cond, compact.bb_rename_succ[stmt.dest])
             result_idx += 1
         end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -884,3 +884,10 @@ end
 # have_fma elimination inside ^
 f_pow() = ^(2.0, -1.0)
 @test fully_eliminated(f_pow, Tuple{})
+
+# bug where Conditional wasn't being properly marked as ConstAPI
+let
+    @noinline fcond(a, b) = a === b
+    ftest(a) = (fcond(a, nothing); a)
+    @test fully_eliminated(ftest, Tuple{Bool})
+end

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -758,3 +758,18 @@ let # effect-freeness computation for array allocation
         nothing
     end
 end
+
+# allow branch folding to look at type information
+let ci = code_typed1(optimize=false) do
+        cond = 1 + 1 == 2
+        if !cond
+            gcd(24, 36)
+        else
+            gcd(64, 128)
+        end
+    end
+    ir = Core.Compiler.inflate_ir(ci)
+    @test count(@nospecialize(stmt)->isa(stmt, Core.GotoIfNot), ir.stmts.inst) == 1
+    ir = Core.Compiler.compact!(ir, true)
+    @test count(@nospecialize(stmt)->isa(stmt, Core.GotoIfNot), ir.stmts.inst) == 0
+end


### PR DESCRIPTION
Branch folding now properly folds things like:

```
%a = complicated()::Const(true)
goto if not %a
```

Also fix a bug where Conditional wasn't properly being marked as ConstAPI in `finish(::AbstractInterpreter, ::OptimizationState)`

CC: @Keno