### PR TITLE
In `Base.runtests`, if the tests fail, before loading `InteractiveUtils`, set the `LOAD_PATH` to only include `@stdlib`

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -590,7 +590,10 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS::Int 
         nothing
     catch
         buf = PipeBuffer()
-        Base.require(Base, :InteractiveUtils).versioninfo(buf)
+        interactiveutils_uuid = Base.UUID("b77e0a4c-d291-57a0-90e8-8db25a27a240")
+        interactiveutils_id = Base.PkgId(interactiveutils_uuid, "InteractiveUtils")
+        interactiveutils_module = Base.require(interactiveutils_id)
+        interactiveutils_module.versioninfo(buf)
         error("A test has failed. Please submit a bug report (https://github.com/JuliaLang/julia/issues)\n" *
               "including error messages above and the output of versioninfo():\n$(read(buf, String))")
     end

--- a/base/util.jl
+++ b/base/util.jl
@@ -590,10 +590,9 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS::Int 
         nothing
     catch
         buf = PipeBuffer()
-        interactiveutils_uuid = Base.UUID("b77e0a4c-d291-57a0-90e8-8db25a27a240")
-        interactiveutils_id = Base.PkgId(interactiveutils_uuid, "InteractiveUtils")
-        interactiveutils_module = Base.require(interactiveutils_id)
-        interactiveutils_module.versioninfo(buf)
+        original_load_path = copy(Base.LOAD_PATH); empty!(Base.LOAD_PATH); pushfirst!(Base.LOAD_PATH, "@stdlib")
+        Base.require(Base, :InteractiveUtils).versioninfo(buf)
+        empty!(Base.LOAD_PATH); append!(Base.LOAD_PATH, original_load_path)
         error("A test has failed. Please submit a bug report (https://github.com/JuliaLang/julia/issues)\n" *
               "including error messages above and the output of versioninfo():\n$(read(buf, String))")
     end


### PR DESCRIPTION
In theory, it's possible that someone has a setup where their load path has a package named `InteractiveUtils`. So, to increase the probability that we are actually loading the correct `InteractiveUtils` stdlib, let's set `Base.LOAD_PATH` to only include `@stdlib`.

After we load `InteractiveUtils`, we restore the original contents of `Base.LOAD_PATH`.