### PR TITLE
Profile: Faster data dict lookup

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -349,15 +349,18 @@ function getdict(data::Vector{UInt})
 end
 
 function getdict!(dict::LineInfoDict, data::Vector{UInt})
-    for ip in data
-        # Lookup is expensive, so do it only once per ip.
-        haskey(dict, UInt64(ip)) && continue
-        st = lookup(convert(Ptr{Cvoid}, ip))
-        # To correct line numbers for moving code, put it in the form expected by
-        # Base.update_stackframes_callback[]
-        stn = map(x->(x, 1), st)
-        try Base.invokelatest(Base.update_stackframes_callback[], stn) catch end
-        dict[UInt64(ip)] = map(first, stn)
+    # we don't want metadata here as we're just looking up ips
+    unique_data_itr = Iterators.unique(has_meta(data) ? strip_meta(data) : data)
+    foreach(ip -> dict[UInt64(ip)] = StackFrame[], unique_data_itr)
+    @sync for ip in unique_data_itr
+        Threads.@spawn begin
+            st = lookup(convert(Ptr{Cvoid}, ip))
+            # To correct line numbers for moving code, put it in the form expected by
+            # Base.update_stackframes_callback[]
+            stn = map(x->(x, 1), st)
+            try Base.invokelatest(Base.update_stackframes_callback[], stn) catch end
+            dict[UInt64(ip)] = map(first, stn)
+        end
     end
     return dict
 end


### PR DESCRIPTION
The ip -> stackframe lookup that happens when viewing profiling data dominates TTFPP and TTSPP

## Master
```
julia> @time ProfileView.view()
 20.764135 seconds (2.68 M allocations: 304.669 MiB, 0.48% gc time)
```
which is basically all spent in `getdict!` within `retrieve`
```
julia> @time Profile.retrieve();
 20.858307 seconds (1.87 M allocations: 172.837 MiB, 0.36% gc time)

julia> @time Profile.retrieve();
 20.861972 seconds (1.87 M allocations: 172.837 MiB, 0.83% gc time)
```

## This PR
```
julia> @time Profile.retrieve();
  1.891498 seconds (3.50 M allocations: 314.141 MiB)

julia> @time Profile.retrieve();
  2.110156 seconds (3.50 M allocations: 314.143 MiB, 8.65% gc time)
```
so
```
julia> @time ProfileView.view()
  2.392356 seconds (4.41 M allocations: 450.986 MiB, 14.13% gc time, 1.23% compilation time)
```

And when julia only has one thread it takes the same amount of time as master.