### PR TITLE
`InteractiveUtils.versioninfo(; verbose = true)`: remove unnecessary blank line before "Memory"

### DIFF
--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -118,7 +118,7 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
     if verbose
         cpuio = IOBuffer() # print cpu_summary with correct alignment
         Sys.cpu_summary(cpuio)
-        for (i, line) in enumerate(split(String(take!(cpuio)), "\n"))
+        for (i, line) in enumerate(split(chomp(String(take!(cpuio))), "\n"))
             prefix = i == 1 ? "  CPU: " : "       "
             println(io, prefix, line)
         end


### PR DESCRIPTION
Currently, when you call `InteractiveUtils.versioninfo(; verbose = true)`, it prints a blank line after the "CPU" section and before the "Memory" line. As far as I can tell, this blank line is not necessary. Therefore, this pull request removes the blank line.