### PR TITLE
Fix `tmerge` for (partially) const types with undef fields

### DIFF
--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -417,7 +417,7 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
                 ai = getfield_tfunc(typea, Const(i))
                 bi = getfield_tfunc(typeb, Const(i))
                 ity = tmerge(ai, bi)
-                if ai === Union{} || bi == Union{}
+                if ai === Union{} || bi === Union{}
                     ity = widenconst(ity)
                 end
                 fields[i] = ity

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -414,8 +414,12 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
             fields = Vector{Any}(undef, type_nfields)
             anyconst = false
             for i = 1:type_nfields
-                ity = tmerge(getfield_tfunc(typea, Const(i)),
-                             getfield_tfunc(typeb, Const(i)))
+                ai = getfield_tfunc(typea, Const(i))
+                bi = getfield_tfunc(typeb, Const(i))
+                ity = tmerge(ai, bi)
+                if ai === Union{} || bi == Union{}
+                    ity = widenconst(ity)
+                end
                 fields[i] = ity
                 anyconst |= has_nontrivial_const_info(ity)
             end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3998,11 +3998,13 @@ end
     @test ⊑(a, c)
     @test ⊑(b, c)
 
-    function f()
-        g = init
-        while true
-            g = Base.ImmutableDict(g, 1=>2)
-        end
+    @test @eval Module() begin
+        const ginit = Base.ImmutableDict{Any,Any}()
+        Base.return_types() do
+            g = ginit
+            while true
+                g = Base.ImmutableDict(g, 1=>2)
+            end
+        end |> only === Union{}
     end
-    @test Base.return_types(f, ()) |> only === Union{}
 end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3988,3 +3988,21 @@ end |> only == Int
         end
     end |> only === Union{UnionNarrowingByIsdefinedA, UnionNarrowingByIsdefinedB}
 end
+
+# issue #43784
+@testset "issue #43784" begin
+    init = Base.ImmutableDict{Any,Any}()
+    a = Const(init)
+    b = Core.PartialStruct(typeof(init), Any[Const(init), Any, Any])
+    c = Core.Compiler.tmerge(a, b)
+    @test ⊑(a, c)
+    @test ⊑(b, c)
+
+    function f()
+        g = init
+        while true
+            g = Base.ImmutableDict(g, 1=>2)
+        end
+    end
+    @test Base.return_types(f, ()) |> only === Union{}
+end


### PR DESCRIPTION
When `tmerge` is applied to `Const`/`PartialStruct` and a field is `Const` in one of the types and `Union{}` (i.e. undef) in the other, the resulting field type must not be `Const` (as the resursively called `tmerge` produces).

Fixes #43784.