### PR TITLE
Use `GlobalRef` of `Core.CodeInfo` in `@generated`

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -574,6 +574,7 @@ macro generated(f)
     if isa(f, Expr) && (f.head === :function || is_short_function_def(f))
         body = f.args[2]
         lno = body.args[1]
+        tmp = gensym("tmp")
         return Expr(:escape,
                     Expr(f.head, f.args[1],
                          Expr(:block,
@@ -581,8 +582,8 @@ macro generated(f)
                               Expr(:if, Expr(:generated),
                                    # https://github.com/JuliaLang/julia/issues/25678
                                    Expr(:block,
-                                        :(local tmp = $body),
-                                        :(if tmp isa $(GlobalRef(Core, :CodeInfo)); return tmp; else tmp; end)),
+                                        :(local $tmp = $body),
+                                        :(if $tmp isa $(GlobalRef(Core, :CodeInfo)); return $tmp; else $tmp; end)),
                                    Expr(:block,
                                         Expr(:meta, :generated_only),
                                         Expr(:return, nothing))))))

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -582,7 +582,7 @@ macro generated(f)
                                    # https://github.com/JuliaLang/julia/issues/25678
                                    Expr(:block,
                                         :(local tmp = $body),
-                                        :(if tmp isa Core.CodeInfo; return tmp; else tmp; end)),
+                                        :(if tmp isa $(GlobalRef(Core, :CodeInfo)); return tmp; else tmp; end)),
                                    Expr(:block,
                                         Expr(:meta, :generated_only),
                                         Expr(:return, nothing))))))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2981,6 +2981,21 @@ end
 @generated g25678(x) = return :x
 @test g25678(7) === 7
 
+# issue 25678: module of name `Core`
+# https://github.com/JuliaLang/julia/pull/40778/files#r784416018
+@test @eval Module() begin
+    Core = 1
+    @generated f() = 1
+    f() == 1
+end
+
+# issue 25678: argument of name `tmp`
+# https://github.com/JuliaLang/julia/pull/43823#discussion_r785365312
+@test @eval Module() begin
+    @generated f(tmp) = tmp
+    f(1) === Int
+end
+
 # issue #19012
 @test Meta.parse("\U2200", raise=false) == Symbol("∀")
 @test Meta.parse("\U2203", raise=false) == Symbol("∃")


### PR DESCRIPTION
This PR addresses https://github.com/JuliaLang/julia/pull/40778/files#r784416018 and replaces the reference to `Core.CodeInfo` in `@generated` with a `GlobalRef`.

The current implementation caused errors in Turing (https://github.com/TuringLang/Turing.jl/issues/1756) which collected core AD parts in  a `Core` submodule (not anymore, it's renamed to `Essential` now since it's not the first time this caused problems: https://github.com/simonster/Reexport.jl/pull/33#issuecomment-904564731).

Currently the PR is still missing some tests. It's a bit embarrassing but I did not manage to come up with a MWE that would be fixed by this PR. I tried things like
```julia
module M
module Core
@generated f(x) = :(2 * x)
end
end

M.Core.f(3)
```
but they all seemed to work fine. Maybe someone has a suggestion how I can reproduce the bug and ensure that `Core` in `@generated` refers to the submodule (or something else) without `CodeInfo`?