### PR TITLE
Refine `isunordered` docstring

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -234,7 +234,11 @@ isgreater(x, y) = isunordered(x) || isunordered(y) ? isless(x, y) : isless(y, x)
 """
     isunordered(x)
 
-Return true if `x` is a value that is not normally orderable, such as `NaN` or `missing`.
+Return `true` if `x` is a value that is not orderable according to [`<`](@ref), such as `NaN`
+or `missing`.
+
+The values that evaluate to `true` with this predicate may be orderable with respect to other
+orderings such as [`isless`](@ref).
 
 !!! compat "Julia 1.7"
     This function requires Julia 1.7 or later.


### PR DESCRIPTION
This patch clarifies that `isunordered` is defined with respect to `<`. Hopefully, this mitigate the possible misunderstanding that `<` is the only ordering in Julia.
