### PR TITLE
Add the `InteractiveUtils.diagnostics()` and `InteractiveUtils.stdlib_diagnostics()` functions

### DIFF
--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -19,6 +19,7 @@ include("editless.jl")
 include("codeview.jl")
 include("macros.jl")
 include("clipboard.jl")
+include("diagnostics.jl")
 
 """
     varinfo(m::Module=Main, pattern::Regex=r""; all::Bool = false, imported::Bool = false, sortby::Symbol = :name, minsize::Int = 0)

--- a/stdlib/InteractiveUtils/src/diagnostics.jl
+++ b/stdlib/InteractiveUtils/src/diagnostics.jl
@@ -72,7 +72,9 @@ const _STDLIB_NAMES = _stdlib_names()
 
 function _loaded_stdlibs()
     modules = copy(Base.loaded_modules_array())
-    stdlib_names = _STDLIB_NAMES
+    stdlib_names = copy(_STDLIB_NAMES)
+    push!(stdlib_names, "Base")
+    push!(stdlib_names, "Core")
     filter!(m -> String(nameof(m)) in stdlib_names, modules)
     return modules
 end

--- a/stdlib/InteractiveUtils/src/diagnostics.jl
+++ b/stdlib/InteractiveUtils/src/diagnostics.jl
@@ -65,7 +65,7 @@ end
 # Copied from https://github.com/JuliaLang/Pkg.jl/blob/68ba0adc9b686db83dd65676cdd2c55313bd2520/src/utils.jl#L27
 _stdlib_dir() = normpath(joinpath(Sys.BINDIR::String, "..", "share", "julia", "stdlib", "v$(VERSION.major).$(VERSION.minor)"))
 
-_stdlib_names() = readdir(stdlib_dir())
+_stdlib_names() = readdir(_stdlib_dir())
 
 # Bake this into the sysimage
 const _STDLIB_NAMES = _stdlib_names()

--- a/stdlib/InteractiveUtils/src/diagnostics.jl
+++ b/stdlib/InteractiveUtils/src/diagnostics.jl
@@ -1,0 +1,122 @@
+"""
+    InteractiveUtils.diagnostics(io::IO=stderr)
+
+Print a variety of useful debugging info.
+
+!!! warning "Warning"
+    The output of this function may contain sensitive information. Before sharing the output,
+    please review the output and remove any data that should not be shared publicly.
+
+See also: [`versioninfo`](@ref), [`stdlib_diagnostics`](@ref).
+"""
+diagnostics()                        = diagnostics(stderr)
+diagnostics(modules::Vector{Module}) = diagnostics(stderr, modules)
+diagnostics(m::Module)               = diagnostics(stderr, m)
+function diagnostics(io::IO)
+    # Get the list of all modules that are currently loaded
+    loaded_modules = copy(Base.loaded_modules_array())
+    sort!(loaded_modules; by = nameof)
+    diagnostics(io, loaded_modules)
+    return nothing
+end
+function diagnostics(io::IO, modules::Vector{Module})
+    for m in modules
+        diagnostics(io, m)
+    end
+    return nothing
+end
+function diagnostics(io::IO, m::Module)
+    module_name = nameof(m)
+    if isdefined(m, :__diagnostics__) && applicable(m.__diagnostics__, io)
+        header = "# $(module_name)"
+        println(io, header)
+        try
+            m.__diagnostics__(io)
+        catch ex
+            bt = catch_backtrace()
+            msg = "Warning: caught an error while running $(module_name).__diagnostics__()"
+            println(io, msg)
+            Base.showerror(io, ex)
+            Base.show_backtrace(io, bt)
+        end
+    end
+    return nothing
+end
+
+"""
+    InteractiveUtils.stdlib_diagnostics(io::IO=stderr)
+
+Print a variety of useful debugging info, but only for the standard libraries (stdlibs).
+
+!!! warning "Warning"
+    The output of this function may contain sensitive information. Before sharing the output,
+    please review the output and remove any data that should not be shared publicly.
+
+See also: [`versioninfo`](@ref), [`diagnostics`](@ref).
+"""
+stdlib_diagnostics() = stdlib_diagnostics(stderr)
+function stdlib_diagnostics(io::IO)
+    stdlib_modules = _loaded_stdlibs()
+    sort!(stdlib_modules; by = nameof)
+    diagnostics(io, stdlib_modules)
+    return nothing
+end
+
+# Copied from https://github.com/JuliaLang/Pkg.jl/blob/68ba0adc9b686db83dd65676cdd2c55313bd2520/src/utils.jl#L27
+_stdlib_dir() = normpath(joinpath(Sys.BINDIR::String, "..", "share", "julia", "stdlib", "v$(VERSION.major).$(VERSION.minor)"))
+
+_stdlib_names() = readdir(stdlib_dir())
+
+# Bake this into the sysimage
+const _STDLIB_NAMES = _stdlib_names()
+
+function _loaded_stdlibs()
+    modules = copy(Base.loaded_modules_array())
+    stdlib_names = _STDLIB_NAMES
+    filter!(m -> String(nameof(m)) in stdlib_names, modules)
+    return modules
+end
+
+# InteractiveUtils.__diagnostics__()
+function __diagnostics__(io::IO)
+    indent = "  "
+    versioninfo(io; verbose = true) # InteractiveUtils.versioninfo()
+    println(io, "Miscellaneous Info:")
+    if !_is_tagged_commit()
+        println(io, indent, "INFO: It looks like you are probably not using the official binaries from julialang.org")
+    end
+    startup_files = [
+        "Global" => _global_julia_startup_file(),
+        "Local"  => _local_julia_startup_file(),
+    ]
+    for (type, filename) in startup_files
+        if filename === nothing
+            description = "does not exist"
+        else
+            str = strip(read(filename, String))
+            expr = Base.Meta.parse(str; raise = false)
+            if expr === nothing
+                description = "is empty"
+            else
+                description = "exists and contains code ($(filename))"
+            end
+        end
+        println(io, indent, type, " startup file: ", description)
+    end
+    println(io, indent, "Base.julia_cmd(): ", Base.julia_cmd())
+    return nothing
+end
+
+# We can't say with 100% certainty whether or not this is the official binary
+# from julialang.org, but we can make an educated guess.
+function _is_tagged_commit()
+    tagged_commit = Base.GIT_VERSION_INFO.tagged_commit
+    if !tagged_commit
+        return false
+    end
+    banner = Base.TAGGED_RELEASE_BANNER
+    if banner == "Official https://julialang.org/ release"
+        return true
+    end
+    return false
+end

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -240,7 +240,7 @@ end
 end
 
 @testset "diagnostics()" begin
-    # check that diagnostics(io) doesn't error, produces some output
+    # check that `InteractiveUtils.diagnostics(io)` doesn't error, produces some output
     buf = PipeBuffer()
     InteractiveUtils.diagnostics(buf)
     output = read(buf, String)
@@ -248,6 +248,17 @@ end
     @test occursin("Environment:", ver)
 
     InteractiveUtils.diagnostics(stdout) # TODO: delete this line before merging the PR
+end
+
+@testset "stdlib_diagnostics()" begin
+    # check that `InteractiveUtils.stdlib_diagnostics(io)` doesn't error, produces some output
+    buf = PipeBuffer()
+    InteractiveUtils.stdlib_diagnostics(buf)
+    output = read(buf, String)
+    @test occursin("Julia Version $VERSION", output)
+    @test occursin("Environment:", ver)
+
+    InteractiveUtils.stdlib_diagnostics(stdout) # TODO: delete this line before merging the PR
 end
 
 const curmod = @__MODULE__

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -222,7 +222,7 @@ module A
 end
 
 # PR #23075
-@testset "versioninfo" begin
+@testset "versioninfo()" begin
     # check that versioninfo(io; verbose=true) doesn't error, produces some output
     mktempdir() do dir
         buf = PipeBuffer()
@@ -237,6 +237,17 @@ end
         @test  occursin("Environment:", read(setenv(`$exename -e 'using InteractiveUtils; versioninfo()'`,
                                                     String["JULIA_CPU_THREADS=1"]), String))
     end
+end
+
+@testset "diagnostics()" begin
+    # check that diagnostics(io) doesn't error, produces some output
+    buf = PipeBuffer()
+    InteractiveUtils.diagnostics(buf)
+    output = read(buf, String)
+    @test occursin("Julia Version $VERSION", output)
+    @test occursin("Environment:", ver)
+
+    InteractiveUtils.diagnostics(stdout) # TODO: delete this line before merging the PR
 end
 
 const curmod = @__MODULE__

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -254,7 +254,7 @@ end
     InteractiveUtils.stdlib_diagnostics(buf)
     output = read(buf, String)
     @test occursin("Julia Version $VERSION", output)
-    @test occursin("Environment:", ver)
+    @test occursin("Environment:", output)
 
     InteractiveUtils.stdlib_diagnostics(stdout) # TODO: delete this line before merging the PR
 end

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -245,9 +245,7 @@ end
     InteractiveUtils.diagnostics(buf)
     output = read(buf, String)
     @test occursin("Julia Version $VERSION", output)
-    @test occursin("Environment:", ver)
-
-    InteractiveUtils.diagnostics(stdout) # TODO: delete this line before merging the PR
+    @test occursin("Environment:", output)
 end
 
 @testset "stdlib_diagnostics()" begin

--- a/stdlib/LinearAlgebra/src/diagnostics.jl
+++ b/stdlib/LinearAlgebra/src/diagnostics.jl
@@ -1,0 +1,5 @@
+# LinearAlgebra.__diagnostics__()
+function __diagnostics__(io::IO)
+    versioninfo(io) # LinearAlgebra.versioninfo()
+    return nothing
+end

--- a/stdlib/LinearAlgebra/src/diagnostics.jl
+++ b/stdlib/LinearAlgebra/src/diagnostics.jl
@@ -1,5 +1,7 @@
 # LinearAlgebra.__diagnostics__()
 function __diagnostics__(io::IO)
     versioninfo(io) # LinearAlgebra.versioninfo()
+    blas_threads = BLAS.get_num_threads()
+    println(io, "LinearAlgebra.BLAS.get_num_threads() = ", blas_threads)
     return nothing
 end

--- a/stdlib/LinearAlgebra/test/diagnostics.jl
+++ b/stdlib/LinearAlgebra/test/diagnostics.jl
@@ -1,0 +1,9 @@
+@testset "__diagnostics__()" begin
+    # check that `LinearAlgebra.__diagnostics__(io)` doesn't error, produces some output
+    buf = PipeBuffer()
+    LinearAlgebra.__diagnostics__(buf)
+    output = read(buf, String)
+    @test !isempty(strip(output))
+
+    LinearAlgebra.__diagnostics__(stdout) # TODO: delete this line before merging the PR
+end

--- a/stdlib/LinearAlgebra/test/diagnostics.jl
+++ b/stdlib/LinearAlgebra/test/diagnostics.jl
@@ -1,3 +1,5 @@
+import LinearAlgebra
+
 @testset "__diagnostics__()" begin
     # check that `LinearAlgebra.__diagnostics__(io)` doesn't error, produces some output
     buf = PipeBuffer()

--- a/stdlib/LinearAlgebra/test/testgroups
+++ b/stdlib/LinearAlgebra/test/testgroups
@@ -26,3 +26,4 @@ structuredbroadcast
 addmul
 ldlt
 factorization
+diagnostics


### PR DESCRIPTION
- [x] Needs [#43807](https://github.com/JuliaLang/julia/pull/43807)

This PR is an attempt to create an "all-in-one" debugging function that dumps as much debugging information as possible. That way, when a user opens a new bug report, instead of needing to run ten or twenty different commands, they can just run a single command (`InteractiveUtils.diagnostics()`) and post the output of that command (after confirming that the output does not contain any information that should not be shared publicly).