### PR TITLE
Fix splatnew test

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3137,11 +3137,12 @@ _use_unstable_kw_2() = _unstable_kw(x = 2, y = rand())
 @test Base.return_types(_use_unstable_kw_1) == Any[String]
 @test Base.return_types(_use_unstable_kw_2) == Any[String]
 @eval struct StructWithSplatNew
-    x::Int
+    x::String
     StructWithSplatNew(t) = $(Expr(:splatnew, :StructWithSplatNew, :t))
 end
 _construct_structwithsplatnew() = StructWithSplatNew(("",))
 @test Base.return_types(_construct_structwithsplatnew) == Any[StructWithSplatNew]
+@test isa(_construct_structwithsplatnew(), StructWithSplatNew)
 
 # case where a call cycle can be broken by constant propagation
 struct NotQRSparse


### PR DESCRIPTION
The function being tested currently throws:
```
julia> _construct_structwithsplatnew()
ERROR: TypeError: in new, expected Int64, got a value of type String
Stacktrace:
 [1] StructWithSplatNew
   @ ./REPL[15]:3 [inlined]
 [2] _construct_structwithsplatnew()
   @ Main ./REPL[16]:1
 [3] top-level scope
   @ REPL[18]:1
```

As a result, compiler precision improvements can cause the test
to fail, which is not intended. Fix the fieldtype of the struct
to make sure it doesn't throw.