### PR TITLE
Add a warning to the docstring of `InteractiveUtils.versioninfo()` reminding users to remove sensitive information before sharing the output

### DIFF
--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -85,6 +85,10 @@ controlled with boolean keyword arguments:
 
 - `verbose`: print all additional information
 
+!!! warning "Warning"
+    The output of this function may contain sensitive information. Before sharing the output,
+    please review the output and remove any data that should not be shared publicly.
+
 See also: [`VERSION`](@ref).
 """
 function versioninfo(io::IO=stdout; verbose::Bool=false)


### PR DESCRIPTION
This has always been true. For example, when you pass `verbose = true`, we print a whole bunch of environment variables, and it's always been possible that one or more of those environment variables contained sensitive information.

So this PR isn't actually changing the situation. It's just documenting the situation that has existed all along.