### PR TITLE
Improve performance of `svd` and `eigen` of `Diagonal`s

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -673,7 +673,7 @@ function eigen(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{
         λ = λ[p] # make a copy, otherwise this permutes D.diag
         evecs = zeros(Td, size(D))
         @inbounds for i in eachindex(p)
-            evecs[i,p[i]] = one(Td)
+            evecs[p[i],i] = one(Td)
         end
     else
         evecs = Matrix{Td}(I, size(D))
@@ -694,8 +694,8 @@ function svd(D::Diagonal{T}) where {T<:Number}
     Vt = copy(U)
     for i in 1:length(d)
         j = piv[i]
-        U[i,j] = d[j] / S[i]
-        Vt[j,i] = one(Td)
+        U[j,i] = d[j] / S[i]
+        Vt[i,j] = one(Td)
     end
     return SVD(U, S, Vt)
 end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -682,7 +682,7 @@ function svd(D::Diagonal{T}) where {T<:Number}
     Vt = copy(U)
     for i in 1:length(d)
         j = piv[i]
-        U[j,i] = d[j] / abs(d[j])
+        U[j,i] = d[j] / S[j]
         Vt[i,j] = one(Td)
     end
     return SVD(U, S, Vt)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -682,7 +682,7 @@ function svd(D::Diagonal{T}) where {T<:Number}
     Vt = copy(U)
     for i in 1:length(d)
         j = piv[i]
-        U[j,i] = d[j] / S[j]
+        U[j,i] = d[j] / S[i]
         Vt[i,j] = one(Td)
     end
     return SVD(U, S, Vt)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -682,7 +682,7 @@ function svd(D::Diagonal{T}) where {T<:Number}
     Vt = copy(U)
     for i in 1:length(d)
         j = piv[i]
-        U[j,i] = d[j] >= zero(T) ? one(Td) : -one(Td)
+        U[j,i] = d[j] / abs(d[j])
         Vt[i,j] = one(Td)
     end
     return SVD(U, S, Vt)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -670,7 +670,7 @@ function eigen(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{
     λ = eigvals(D)
     if !isnothing(sortby)
         p = sortperm(λ; alg=QuickSort, by=sortby)
-        permute!(λ, p)
+        λ = λ[p] # make a copy, otherwise this permutes D.diag
         evecs = zeros(Td, size(D))
         @inbounds for i in eachindex(p)
             evecs[i,p[i]] = one(Td)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -673,7 +673,7 @@ function eigen(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{
         permute!(λ, p)
         evecs = zeros(Td, size(D))
         @inbounds for i in eachindex(p)
-            evecs[p[i],i] = one(Td)
+            evecs[i,p[i]] = one(Td)
         end
     else
         evecs = Matrix{Td}(I, size(D))
@@ -694,8 +694,8 @@ function svd(D::Diagonal{T}) where {T<:Number}
     Vt = copy(U)
     for i in 1:length(d)
         j = piv[i]
-        U[j,i] = d[j] / S[i]
-        Vt[i,j] = one(Td)
+        U[i,j] = d[j] / S[i]
+        Vt[j,i] = one(Td)
     end
     return SVD(U, S, Vt)
 end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -672,14 +672,20 @@ end
 #Singular system
 svdvals(D::Diagonal{<:Number}) = sort!(abs.(D.diag), rev = true)
 svdvals(D::Diagonal) = [svdvals(v) for v in D.diag]
-function svd(D::Diagonal{T}) where T<:Number
-    S   = abs.(D.diag)
-    piv = sortperm(S, rev = true)
-    U   = Diagonal(D.diag ./ S)
-    Up  = hcat([U[:,i] for i = 1:length(D.diag)][piv]...)
-    V   = Diagonal(fill!(similar(D.diag), one(T)))
-    Vp  = hcat([V[:,i] for i = 1:length(D.diag)][piv]...)
-    return SVD(Up, S[piv], copy(Vp'))
+function svd(D::Diagonal{T}) where {T<:Number}
+    d = D.diag
+    s = abs.(d)
+    piv = sortperm(s, rev = true)
+    S = s[piv]
+    Td  = typeof(oneunit(T)/oneunit(T))
+    U = zeros(Td, size(D))
+    Vt = copy(U)
+    for i in 1:length(d)
+        j = piv[i]
+        U[j,i] = d[j] >= zero(T) ? one(Td) : -one(Td)
+        Vt[i,j] = one(Td)
+    end
+    return SVD(U, S, Vt)
 end
 
 # disambiguation methods: * and / of Diagonal and Adj/Trans AbsVec

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -666,7 +666,19 @@ function eigen(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{
     if any(!isfinite, D.diag)
         throw(ArgumentError("matrix contains Infs or NaNs"))
     end
-    Eigen(sorteig!(eigvals(D), eigvecs(D), sortby)...)
+    Td = Base.promote_op(/, eltype(D), eltype(D))
+    λ = eigvals(D)
+    if !isnothing(sortby)
+        p = sortperm(λ; alg=QuickSort, by=sortby)
+        permute!(λ, p)
+        evecs = zeros(Td, size(D))
+        @inbounds for i in eachindex(p)
+            evecs[p[i],i] = one(Td)
+        end
+    else
+        evecs = Matrix{Td}(I, size(D))
+    end
+    Eigen(λ, evecs)
 end
 
 #Singular system

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -5,6 +5,10 @@ module TestDiagonal
 using Test, LinearAlgebra, Random
 using LinearAlgebra: BlasFloat, BlasComplex
 
+const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
+isdefined(Main, :Furlongs) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "Furlongs.jl"))
+using .Main.Furlongs
+
 n=12 #Size of matrix problem to test
 Random.seed!(1)
 
@@ -411,6 +415,16 @@ Random.seed!(1)
         @test svd(D).V == V
     end
 
+    @testset "svd with Diagonal{Furlong}" begin
+        Du = Furlong.(D)
+        @test Du isa Diagonal{<:Furlong{1}}
+        U, s, V = svd(Du)
+        @test map(x -> x.val, U*Diagonal(s)*V') ≈ D
+        @test svdvals(Du) == s
+        @test U isa AbstractMatrix{<:Furlong{0}}
+        @test V isa AbstractMatrix{<:Furlong{0}}
+        @test s isa AbstractVector{<:Furlong{1}}
+    end
 end
 
 @testset "rdiv! (#40887)" begin

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -424,7 +424,7 @@ Random.seed!(1)
         @test Du isa Diagonal{<:Furlong{1}}
         F = svd(Du)
         U, s, V = F
-        @test Matrix(F) == Du
+        @test map(x -> x.val, Matrix(F)) ≈ map(x -> x.val, Du)
         @test svdvals(Du) == s
         @test U isa AbstractMatrix{<:Furlong{0}}
         @test V isa AbstractMatrix{<:Furlong{0}}

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -428,7 +428,7 @@ Random.seed!(1)
         E = eigen(Du)
         vals, vecs = E
         @test Matrix(E) == Du
-        @test vals isa AbstactVector{<:Furlong{1}}
+        @test vals isa AbstractVector{<:Furlong{1}}
         @test vecs isa AbstractMatrix{<:Furlong{0}}
     end
 end

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -348,8 +348,12 @@ Random.seed!(1)
 
     @testset "Eigensystem" begin
         eigD = eigen(D)
-        @test Diagonal(eigD.values) ≈ D
+        @test Diagonal(eigD.values) == D
         @test eigD.vectors == Matrix(I, size(D))
+        eigsortD = eigen(D, sortby=LinearAlgebra.eigsortby)
+        @test eigsortD.values !== D.diag
+        @test eigsortD.values == sort(D.diag, by=LinearAlgebra.eigsortby)
+        @test Matrix(eigsortD) == D
     end
 
     @testset "ldiv" begin

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -415,15 +415,21 @@ Random.seed!(1)
         @test svd(D).V == V
     end
 
-    @testset "svd with Diagonal{Furlong}" begin
+    @testset "svd/eigen with Diagonal{Furlong}" begin
         Du = Furlong.(D)
         @test Du isa Diagonal{<:Furlong{1}}
-        U, s, V = svd(Du)
-        @test map(x -> x.val, U*Diagonal(s)*V') ≈ D
+        F = svd(Du)
+        U, s, V = F
+        @test Matrix(F) == Du
         @test svdvals(Du) == s
         @test U isa AbstractMatrix{<:Furlong{0}}
         @test V isa AbstractMatrix{<:Furlong{0}}
         @test s isa AbstractVector{<:Furlong{1}}
+        E = eigen(Du)
+        vals, vecs = E
+        @test Matrix(E) == Du
+        @test vals isa AbstactVector{<:Furlong{1}}
+        @test vecs isa AbstractMatrix{<:Furlong{0}}
     end
 end
 


### PR DESCRIPTION
This reduces lots of intermediate array allocations, and now even works with (Furlong) units. I'll add a test for that case later.