### PR TITLE
Help LLVM better vectorize reduction over `skipmissing`

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -310,6 +310,15 @@ _mapreduce(f, op, ::IndexCartesian, itr::SkipMissing) = mapfoldl(f, op, itr)
 mapreduce_impl(f, op, A::SkipMissing, ifirst::Integer, ilast::Integer) =
     mapreduce_impl(f, op, A, ifirst, ilast, pairwise_blocksize(f, op))
 
+# Some help function to make LLVM better vectorizing these reduction.
+# It returns a `noop`, which make sure `op(v, noop) === v`
+_fast_noop(::Union{typeof(add_sum),typeof(+)}, ::Type{T}, ::T) where {T<:Union{HWReal,Complex{<:HWReal}}} = zero(T)
+_fast_noop(::Union{typeof(mul_prod),typeof(*)}, ::Type{T}, ::T) where {T<:HWReal} = one(T)
+# TODO: min/max for IEEEFloat need manually unroll to vectorize.
+_fast_noop(::Union{typeof(min),typeof(max)}, ::Type{T}, v::T) where {T<:Integer} = T <: HWReal ? v : nothing
+# General fallback
+_fast_noop(f, T, v) = nothing
+
 # Returns nothing when the input contains only missing values, and Some(x) otherwise
 @noinline function mapreduce_impl(f, op, itr::SkipMissing{<:AbstractArray},
                                   ifirst::Integer, ilast::Integer, blksize::Int)
@@ -345,10 +354,19 @@ mapreduce_impl(f, op, A::SkipMissing, ifirst::Integer, ilast::Integer) =
         i == typemax(typeof(i)) && return Some(op(f(a1), f(a2)))
         i += 1
         v = op(f(a1), f(a2))
-        @simd for i = i:ilast
-            @inbounds ai = A[i]
-            if ai !== missing
-                v = op(v, f(ai))
+        # We need to make sure `fskip` is stable.
+        noop = _fast_noop(op, _return_type(f, Tuple{nonmissingtype(eltype(A))}), v)
+        if isnothing(noop)
+            @simd for i = i:ilast
+                @inbounds ai = A[i]
+                if !ismissing(ai)
+                    v = op(v, f(ai))
+                end
+            end
+        else
+            @inline fskip(x) = ismissing(x) ? noop : f(x)
+            @inbounds @simd for i = i:ilast
+                v = op(v, fskip(A[i]))
             end
         end
         return Some(v)
@@ -463,4 +481,3 @@ macro coalesce(args...)
     end
     return esc(:(let val; $expr; end))
 end
-


### PR DESCRIPTION
Looks like LLVM can't handle "conditonal" reduction well for float cases.
Local Benchmark shows:
```julia
          ("skipmissing", "sum", "Union{Missing, Float64}", 1) => TrialJudgement(-79.78% => improvement)
          ("skipmissing", "sum", "Union{Missing, Float32}", 1) => TrialJudgement(-84.44% => improvement)
          ("skipmissing", "sum", "Union{Missing, Int64}", 1) => TrialJudgement(-5.56% => improvement)
          ("skipmissing", "sum", "Union{Missing, ComplexF64}", 1) => TrialJudgement(-58.43% => improvement)
```
