### PR TITLE
Elaborate `code_native` funciton and macro docstring

### DIFF
--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -234,9 +234,13 @@ code_llvm(@nospecialize(f), @nospecialize(types=Base.default_tt(f)); raw=false, 
 
 Prints the native assembly instructions generated for running the method matching the given
 generic function and type signature to `io`.
-Switch assembly syntax using `syntax` symbol parameter set to `:att` for AT&T syntax or `:intel` for Intel syntax.
-Keyword argument `debuginfo` may be one of source (default) or none, to specify the verbosity of code comments.
-If `binary` is `true`, it also prints the binary machine code for each instruction precedented by an abbreviated address.
+
+* Set assembly syntax by setting `syntax` to `:att` (default) for AT&T syntax or `:intel` for Intel syntax.
+* Specify verbosity of code comments by setting `debuginfo` to `:source` (default) or `:none`.
+* If `binary` is `true`, also print the binary machine code for each instruction precedented by an abbreviated address.
+* If `dump_module` is `false`, do not print metadata such as rodata or directives.
+
+See also: [`@code_native`](@ref), [`code_llvm`](@ref), [`code_typed`](@ref) and [`code_lowered`](@ref)
 """
 function code_native(io::IO, @nospecialize(f), @nospecialize(types=Base.default_tt(f));
                      dump_module::Bool=true, syntax::Symbol=:att, debuginfo::Symbol=:default, binary::Bool=false)

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -336,11 +336,17 @@ by putting them and their value before the function call, like this:
 Evaluates the arguments to the function or macro call, determines their types, and calls
 [`code_native`](@ref) on the resulting expression.
 
-Set the optional keyword argument `debuginfo` by putting it before the function call, like this:
+Set any of the optional keyword arguments `syntax`, `debuginfo`, `binary` or `dump_module`
+by putting it before the function call, like this:
 
-    @code_native debuginfo=:default f(x)
+    @code_native syntax=:intel debuginfo=:default binary=true dump_module=false f(x)
 
-`debuginfo` may be one of `:source` (default) or `:none`, to specify the verbosity of code comments.
+* Set assembly syntax by setting `syntax` to `:att` (default) for AT&T syntax or `:intel` for Intel syntax.
+* Specify verbosity of code comments by setting `debuginfo` to `:source` (default) or `:none`.
+* If `binary` is `true`, also print the binary machine code for each instruction precedented by an abbreviated address.
+* If `dump_module` is `false`, do not print metadata such as rodata or directives.
+
+See also: [`code_native`](@ref), [`@code_llvm`](@ref), [`@code_typed`](@ref) and [`@code_lowered`](@ref)
 """
 :@code_native
 


### PR DESCRIPTION
Make the docstrings of `code_native` and `@code_native` similar. Make sure
all keywords are mentioned in both docstrings, and add a "see also" section
for closely related functions/macros.

NOTE: I don't really understand what the `dump_module` keyword actually does, so I took a guess based on the PR that implemented it. Someone who understand this, please review that it's correct before merging.