### PR TITLE
Add fallback `parse` method that uses `tryparse`

### DIFF
--- a/base/parse.jl
+++ b/base/parse.jl
@@ -5,7 +5,21 @@ import Base.Checked: add_with_overflow, mul_with_overflow
 ## string to integer functions ##
 
 """
-    parse(type, str; base)
+    parse(::Type{T}, str::AbstractString) -> T
+
+Parse `str` as type `T`, throwing an error on failure.
+By default `parse` falls back on `tryparse`. Users rarely need to extend `parse`
+and should instead implement `tryparse` for parsing custom types.
+
+See also: [`tryparse`](@ref)
+"""
+function parse(::Type{T}, str::AbstractString; kwargs...) where T
+    y = tryparse(T, str; kwargs...)
+    isa(y, T) ? y : throw(ArgumentError("Cannot parse as $T: \"$str\""))
+end
+
+"""
+    parse(::Type{T <: Number}, str; base)
 
 Parse a string as a number. For `Integer` types, a base can be specified
 (the default is 10). For floating-point types, the string is parsed as a decimal
@@ -227,7 +241,16 @@ end
 end
 
 """
-    tryparse(type, str; base)
+    tryparse(::Type{T}, str::AbstractString)::Union{T, Nothing}
+
+Attempt to parse `str` as `T`, or return `nothing` if the parsing failed.
+Users are encouraged to extend `tryparse` for custom types instead of `parse`,
+as this method allows the caller to gracefully handle malformed input.
+"""
+function tryparse end
+
+"""
+    tryparse(::Type{T <: Number}, str; base)
 
 Like [`parse`](@ref), but returns either a value of the requested type,
 or [`nothing`](@ref) if the string does not contain a valid number.

--- a/doc/src/base/numbers.md
+++ b/doc/src/base/numbers.md
@@ -44,8 +44,6 @@ Base.Irrational
 Base.digits
 Base.digits!
 Base.bitstring
-Base.parse
-Base.tryparse
 Base.big
 Base.signed
 Base.unsigned

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -9,6 +9,8 @@ Base.sizeof(::AbstractString)
 Base.:*(::Union{AbstractChar, AbstractString}, ::Union{AbstractChar, AbstractString}...)
 Base.:^(::Union{AbstractString, AbstractChar}, ::Integer)
 Base.string
+Base.parse
+Base.tryparse
 Base.repeat(::AbstractString, ::Integer)
 Base.repeat(::AbstractChar, ::Integer)
 Base.repr(::Any)


### PR DESCRIPTION
Malformed strings must be expected when parsing. In that case, `parse`
throws an error, which means handling it neccesitates catching, which
is slow an un-idiomatic in Julia. For this reason, `tryparse` was added.

Because `parse` can generically be derived from `tryparse`, if we implement
`parse` in terms of `tryparse`, then implementing the latter give both methods
for free, such that the caller has control over how to handle failures.

This PR adds a fallback definition of `parse` which calls `tryparse`, and
adds a generic docstring to both functions that explain that users should
implement `tryparse` for custom types.

Previously, the `parse` documentation in both docstring and manual implied
that only numbers were being parsed, e.g. `Base.parse` was listed under
"Numbers" in the manual, and the generic docstring referred to numbers.
This PR moves the manual entry to "Strings" and clarifies that the old
docstring refers to parsing numbers only.

See also: #43149