### PR TITLE
Convenience method `cd(::Module)`

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -149,9 +149,9 @@ cd(f::Function) = cd(f, homedir())
 
 """
     cd(m::Module)
-    
+
 Set the current working directory to the root directory of the package that imported module
-`m`. Throws a `DomainError` if `m` was not imported from a package.
+`m`. Throws an error if `m` was not imported from a package.
 
 See also: [`pkgdir`](@ref).
 
@@ -165,14 +165,13 @@ julia> pwd()
 "/home/JuliaUser/julia-$(string(VERSION))/share/julia/stdlib/v$(string(VERSION.major)).$(string(VERSION.minor))/LinearAlgebra"
 
 julia> cd(Base)
-ERROR: DomainError with Base:
-module must be imported from a package.
+ERROR: module must be imported from a package.
 [...]
 ```
 """
 function cd(m::Module)
     dir = pkgdir(m)
-    dir === nothing && throw(DomainError(m, "module must be imported from a package."))
+    dir === nothing && error("module must be imported from a package.")
     cd(dir)
 end
 

--- a/base/file.jl
+++ b/base/file.jl
@@ -157,7 +157,10 @@ See also: [`pkgdir`](@ref).
 
 # Examples
 ```julia-repl
+julia> import LinearAlgebra
+
 julia> cd(LinearAlgebra)
+
 julia> pwd()
 "/home/JuliaUser/julia-$(string(VERSION))/share/julia/stdlib/v$(string(VERSION.major)).$(string(VERSION.minor))/LinearAlgebra"
 

--- a/base/file.jl
+++ b/base/file.jl
@@ -116,6 +116,7 @@ else
         end
     end
 end
+
 """
     cd(f::Function, dir::AbstractString=homedir())
 
@@ -145,6 +146,32 @@ julia> pwd()
 ```
 """
 cd(f::Function) = cd(f, homedir())
+
+"""
+    cd(m::Module)
+    
+Set the current working directory to the root directory of the package that imported module
+`m`. Throws a `DomainError` if `m` was not imported from a package.
+
+See also: [`pkgdir`](@ref).
+
+# Examples
+```julia-repl
+julia> cd(LinearAlgebra)
+julia> pwd()
+"/home/JuliaUser/julia-$(string(VERSION))/share/julia/stdlib/v$(string(VERSION.major)).$(string(VERSION.minor))/LinearAlgebra"
+
+julia> cd(Base)
+ERROR: DomainError with Base:
+module must be imported from a package.
+[...]
+```
+"""
+function cd(m::Module)
+    dir = pkgdir(m)
+    dir === nothing && throw(DomainError(m, "module must be imported from a package."))
+    cd(dir)
+end
 
 function checkmode(mode::Integer)
     if !(0 <= mode <= 511)

--- a/test/file.jl
+++ b/test/file.jl
@@ -1726,5 +1726,5 @@ end
     @test pwd() == pkgdir(LinearAlgebra)
 
     @eval module M; end
-    @test_throws DomainError cd(M)
+    @test_throws ErrorException cd(M)
 end

--- a/test/file.jl
+++ b/test/file.jl
@@ -1719,3 +1719,12 @@ end
     @test dstat.total < 32PB
     @test dstat.used + dstat.available == dstat.total
 end
+
+@testset "cd(::Module)" begin
+    import LinearAlgebra
+    cd(LinearAlgebra)
+    @test pwd() == pkgdir(LinearAlgebra)
+
+    @eval module M; end
+    @test_throws DomainError cd(M)
+end


### PR DESCRIPTION
This adds a new method `cd(m::Module)` that sets the current working directory to `m` package root; if `m` is not a package, an error is thrown.

This is basically just a quality-of-life thing: I usually forget which combination of `pkgdir`, `pathof`, etc., I need in order to find a package's root - and having `cd(::Module)` seems consistent with e.g., the recently added `edit(::Module)`.