### PR TITLE
[LateLowerGC] Change undef FCA into zeroinit

### DIFF
--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2258,6 +2258,17 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S) {
                         I->setMetadata(LLVMContext::MD_tbaa, MutableTBAA);
                 }
             }
+            // FCA chains created by SROA start with an undef value
+            // if the type contains an tracked pointer that can lead to a partial
+            // initialisation and LateLower might have inserted an extractvalue
+            // of an undef field. Fix this by changing it to start with an zero-init
+            if (auto *IV = dyn_cast<InsertValueInst>(*&it)) {
+                Value *SourceAggregate = IV->getAggregateOperand();
+                if (isa<UndefValue>(SourceAggregate)) {
+                    IV->setOperand(IV->getAggregateOperandIndex(), ConstantAggregateZero::get(IV->getType()));
+                }
+            }
+
             auto *CI = dyn_cast<CallInst>(&*it);
             if (!CI) {
                 ++it;

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2266,6 +2266,7 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S) {
                 Value *SourceAggregate = IV->getAggregateOperand();
                 if (isa<UndefValue>(SourceAggregate)) {
                     IV->setOperand(IV->getAggregateOperandIndex(), ConstantAggregateZero::get(IV->getType()));
+                    ChangesMade = true;
                 }
             }
 


### PR DESCRIPTION
Fixes #43798

@vtjnash and I discussed this offline. The long-term proper fix maybe to not from FCA entirely in the front-end.
For now we settled on the fact that we can scan the IR and make sure that formed FCA are not undef initialized,
but instead zero initialized, ensuring that LateLowerGC didn't synthesize a use of an undef value. 

An alternative proposal by me was to use `ValueTracking` to see if something is proven undef, but that seemed rather costly
and more invasive.