### PR TITLE
alloc profiler: fix analyzegc error

### DIFF
--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -46,7 +46,7 @@ jl_combined_results g_combined_results; // Will live forever.
 
 // === stack stuff ===
 
-jl_raw_backtrace_t get_raw_backtrace() {
+jl_raw_backtrace_t get_raw_backtrace() JL_NOTSAFEPOINT {
     // A single large buffer to record backtraces onto
     static jl_bt_element_t static_bt_data[JL_MAX_BT_SIZE];
 

--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -120,7 +120,8 @@ JL_DLLEXPORT void jl_free_alloc_profile() {
 
 void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size) JL_NOTSAFEPOINT {
     auto& global_profile = g_alloc_profile;
-    auto& profile = global_profile.per_thread_profiles[jl_threadid()];
+    auto thread_id = jl_atomic_load_relaxed(&jl_current_task->tid);
+    auto& profile = global_profile.per_thread_profiles[thread_id];
 
     auto sample_val = double(rand()) / double(RAND_MAX);
     auto should_record = sample_val <= global_profile.sample_rate;


### PR DESCRIPTION
Get the thread id with a different function that's also `JL_NOTSAFEPOINT`.

Fixes the analyzegc build failure introduced by https://github.com/JuliaLang/julia/pull/42768.