### PR TITLE
Fix asan for jl_precompile_toplevel_module

### DIFF
--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -85,7 +85,6 @@
     XX(jl_pinode_type) \
     XX(jl_pointer_type) \
     XX(jl_pointer_typename) \
-    XX(jl_precompile_toplevel_module) \
     XX(jl_quotenode_type) \
     XX(jl_readonlymemory_exception) \
     XX(jl_ref_type) \

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -34,7 +34,7 @@ htable_t jl_current_modules;
 jl_mutex_t jl_modules_mutex;
 
 // During incremental compilation, the following gets set
-JL_DLLEXPORT jl_module_t *jl_precompile_toplevel_module;           // the toplevel module currently being defined
+JL_DLLEXPORT jl_module_t *jl_precompile_toplevel_module = NULL;   // the toplevel module currently being defined
 
 JL_DLLEXPORT void jl_add_standard_imports(jl_module_t *m)
 {


### PR DESCRIPTION
PR #43793 passed the buildkite test but the logs for #43881 show an
address sanitzer failure. Removing `jl_precompile_toplevel_module` from
`jl_exported_data.inc` fixes the error. For good measure, set it to `NULL`
at the point of definition, even though it gets nulled during
initialization.