### PR TITLE
Fixes complex range broadcasting with another range

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1069,6 +1069,12 @@ _precision_complex(::Type{ComplexF32},base) = precision(Float32, base=base)
 _precision_complex(::Type{ComplexF16},base) = precision(Float16, base=base)
 precision(::Type{T}; base::Integer=2) where {T<:Complex}= _precision_complex(T,base)
 
+# This really shouldn't be here but the boostrapping process doesn't allow it
+function twiceprecision(val::TwicePrecision{T}, nb::Integer) where {T<:Complex}
+        return val
+end
+nbitslen(::Type{T}, len, offset) where {T<:Complex} =
+    min(cld(precision(T), 2), nbitslen(len, offset))
 
 float(z::Complex{<:AbstractFloat}) = z
 float(z::Complex) = Complex(float(real(z)), float(imag(z)))

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1071,7 +1071,7 @@ precision(::Type{T}; base::Integer=2) where {T<:Complex}= _precision_complex(T,b
 
 # This really shouldn't be here but the boostrapping process doesn't allow it
 function twiceprecision(val::TwicePrecision{T}, nb::Integer) where {T<:Complex}
-        return val
+    return val
 end
 nbitslen(::Type{T}, len, offset) where {T<:Complex} =
     min(cld(precision(T), 2), nbitslen(len, offset))

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1064,6 +1064,11 @@ function round(z::Complex, rr::RoundingMode=RoundNearest, ri::RoundingMode=rr; k
             round(imag(z), ri; kwargs...))
 end
 
+_precision_complex(::Type{ComplexF64},base) = precision(Float64, base=base)
+_precision_complex(::Type{ComplexF32},base) = precision(Float32, base=base)
+_precision_complex(::Type{ComplexF16},base) = precision(Float16, base=base)
+precision(::Type{T}; base::Integer=2) where {T<:Complex}= _precision_complex(T,base)
+
 
 float(z::Complex{<:AbstractFloat}) = z
 float(z::Complex) = Complex(float(real(z)), float(imag(z)))

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -249,15 +249,11 @@ function twiceprecision(val::TwicePrecision{T}, nb::Integer) where {T<:IEEEFloat
     TwicePrecision{T}(hi, (val.hi - hi) + val.lo)
 end
 
-function twiceprecision(val::TwicePrecision{T}, nb::Integer) where {T<:Complex}
-    return val
-end
 
 nbitslen(r::StepRangeLen) = nbitslen(eltype(r), length(r), r.offset)
 nbitslen(::Type{T}, len, offset) where {T<:IEEEFloat} =
     min(cld(precision(T), 2), nbitslen(len, offset))
-nbitslen(::Type{T}, len, offset) where {T<:Complex} =
-    min(cld(precision(T), 2), nbitslen(len, offset))
+
 # The +1 here is for safety, because the precision of the significand
 # is 1 bit higher than the number that are explicitly stored.
 nbitslen(len, offset) = len < 2 ? 0 : ceil(Int, log2(max(offset-1, len-offset))) + 1

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -249,8 +249,14 @@ function twiceprecision(val::TwicePrecision{T}, nb::Integer) where {T<:IEEEFloat
     TwicePrecision{T}(hi, (val.hi - hi) + val.lo)
 end
 
+function twiceprecision(val::TwicePrecision{T}, nb::Integer) where {T<:Complex}
+    return val
+end
+
 nbitslen(r::StepRangeLen) = nbitslen(eltype(r), length(r), r.offset)
 nbitslen(::Type{T}, len, offset) where {T<:IEEEFloat} =
+    min(cld(precision(T), 2), nbitslen(len, offset))
+nbitslen(::Type{T}, len, offset) where {T<:Complex} =
     min(cld(precision(T), 2), nbitslen(len, offset))
 # The +1 here is for safety, because the precision of the significand
 # is 1 bit higher than the number that are explicitly stored.

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -249,11 +249,9 @@ function twiceprecision(val::TwicePrecision{T}, nb::Integer) where {T<:IEEEFloat
     TwicePrecision{T}(hi, (val.hi - hi) + val.lo)
 end
 
-
 nbitslen(r::StepRangeLen) = nbitslen(eltype(r), length(r), r.offset)
 nbitslen(::Type{T}, len, offset) where {T<:IEEEFloat} =
     min(cld(precision(T), 2), nbitslen(len, offset))
-
 # The +1 here is for safety, because the precision of the significand
 # is 1 bit higher than the number that are explicitly stored.
 nbitslen(len, offset) = len < 2 ? 0 : ceil(Int, log2(max(offset-1, len-offset))) + 1

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1081,6 +1081,6 @@ end
 end
 
 @testset "Fix method error #32792" begin
-    xx = range(-10,10; length=1000) 
+    xx = range(-10,10; length=1000)
     @test xx .- im .* xx isa AbstractRange
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1079,3 +1079,8 @@ end
     y = randn(2)
     @inferred(test(x, y)) == [0, 0]
 end
+
+@testset "Fix method error #32792" begin
+    xx = range(-10,10; length=1000) 
+    @test xx .- im .* xx isa AbstractRange
+end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1206,3 +1206,9 @@ end
     @test !iseven(7+0im) && isodd(7+0im)
     @test !iseven(6+1im) && !isodd(7+1im)
 end
+
+@testset "precision" begin
+    @test precision(ComplexF64) == 53
+    @test precision(ComplexF32) == 24
+    @test precision(ComplexF16) == 11
+end


### PR DESCRIPTION
Fixes #32792.
To fix it I had to add `precision` to complex types, I can split it into two different PRs if necessary