### PR TITLE
alloc profile: optimize decoding

### DIFF
--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -152,7 +152,7 @@ end
 
 struct AllocResults
     stack_frames::BacktraceCache
-    alloc_stack_trace::Vector{Vector{BTElement}} # TODO: keep as Vector{BTElement}
+    alloc_stack_trace::Vector{Vector{BTElement}}
     alloc_type::Vector{Ptr{Type}}
     alloc_size::Vector{Int}
 end

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -191,11 +191,6 @@ function decode(raw_results::RawResults)::AllocResults
     alloc_size = Vector{Int}()
     alloc_stack_trace = Vector{Vector{BTElement}}()
 
-    # TODO: sizehint all of these? idk
-    sizehint!(alloc_type, raw_results.num_allocs)
-    sizehint!(alloc_size, raw_results.num_allocs)
-    sizehint!(alloc_stack_trace, raw_results.num_allocs)
-
     for i in 1:raw_results.num_allocs
         raw_alloc = unsafe_load(raw_results.allocs, i)
         push!(alloc_type, raw_alloc.type) # defer the unsafe_load?
@@ -220,6 +215,13 @@ function Base.getindex(res::AllocResults, i::Int)
         stacktrace_memoized(res.stack_frames, res.alloc_stack_trace[i]),
         res.alloc_size[i]
     )
+end
+
+function Base.iterate(res::AllocResults, state=1)
+    if state > length(res)
+        return nothing
+    end
+    return (res[state], state+1)
 end
 
 function Base.length(res::AllocResults)

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -177,14 +177,6 @@ function load_type(ptr::Ptr{Type})
     return unsafe_pointer_to_objref(ptr)
 end
 
-# function decode_alloc(cache::BacktraceCache, raw_alloc::RawAlloc)::Alloc
-#     Alloc(
-#         load_type(raw_alloc.type),
-#         stacktrace_memoized(cache, raw_alloc.backtrace),
-#         UInt(raw_alloc.size)
-#     )
-# end
-
 function decode(raw_results::RawResults)::AllocResults
     cache = BacktraceCache()
     alloc_type = Vector{Ptr{Type}}()
@@ -209,6 +201,10 @@ function decode(raw_results::RawResults)::AllocResults
     )
 end
 
+# --- make AllocResults look like an array of allocs ---
+
+# decode stack traces lazily for performance
+
 function Base.getindex(res::AllocResults, i::Int)
     return Alloc(
         load_type(res.alloc_type[i]),
@@ -228,6 +224,8 @@ function Base.length(res::AllocResults)
     # length of any of the arrays will do...
     return length(res.alloc_size)
 end
+
+# --- decode stack traces ---
 
 function get_frames(cache::BacktraceCache, element::BTElement)
     return get!(cache, element) do

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -201,11 +201,16 @@ function stacktrace_memoized(
     cache::BacktraceCache,
     raw_trace::RawBacktrace
 )::StackTrace
-    [
-        frame
-        for i in 1:raw_trace.size
+    stacktrace = StackTrace()
+    sizehint!(stacktrace, raw_trace.size * 3 ÷ 2)
+
+    for i in 1:raw_trace.size
         for frame in get_frames(cache, unsafe_load(raw_trace.data, i))
-    ]
+            push!(stacktrace, frame)
+        end
+    end
+
+    return stacktrace
 end
 
 # Precompile once for the package cache.


### PR DESCRIPTION
### Problem

`Profile.Alloc.decode()` spends ~50% of time in GC. This is because it constructs a large graph of objects representing each alloc and its stack trace, which the GC has to traverse during each mark phase.

### Solution

Instead of decoding the profile into an array of `Alloc` structs, each of which contains an array of `StackFrame` structs, decode it into arrays of scalars (which the GC can safely skip) and make it _look_ like an array of `Alloc`s. Hopefully we can pass this through to pprof without materializing as much in memory as well.

### Evaluation

```julia
# On a profile of HeapSnapshotParser with 3M allocs:

# before
julia> @time Profile.Allocs.fetch()
20.752397 seconds (17.38 M allocations: 16.735 GiB, 64.56% gc time)

# after
julia> @time Profile.Allocs.fetch()
  0.838798 seconds (3.27 M allocations: 1.016 GiB, 53.57% gc time)
# note that it'll still take more time to get a pprof protobuf of this
# but at this stage we can already explore with `length(prof)` and `prof[i]`, `prof.alloc_type[i]` etc
```

### TODO

- evaluate end-to-end perf including pprof
- maybe `AllocResults` should still have a member called `allocs` that implements the array interface, so we can add `frees` later

This is a similar approach to https://github.com/JuliaArrays/StructArrays.jl, which I'd use if this wasn't in `Base`…