### PR TITLE
improve VersionNumber docs

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -17,8 +17,9 @@ alpha-numeric annotations.
 operators (`==`, `<`, `<=`, etc.), with the result following semver rules.
 
 See also [`@v_str`](@ref) to efficiently construct `VersionNumber` objects
-from semver-format strings, and [`VERSION`](@ref) for the `VersionNumber`
-of Julia itself.
+from semver-format strings, [`VERSION`](@ref) for the `VersionNumber`
+of Julia itself, and [Version Number Literals](@ref man-version-number-literals)
+in the manual.
 
 # Examples
 ```jldoctest
@@ -234,7 +235,7 @@ nextmajor(v::VersionNumber) = v < thismajor(v) ? thismajor(v) : VersionNumber(v.
 """
     VERSION
 
-A `VersionNumber` object describing which version of Julia is in use. For details see
+A [`VersionNumber`](@ref) object describing which version of Julia is in use. See also
 [Version Number Literals](@ref man-version-number-literals).
 """
 const VERSION = try

--- a/base/version.jl
+++ b/base/version.jl
@@ -22,7 +22,7 @@ of Julia itself.
 
 # Examples
 ```jldoctest
-julia> a = VersionNumber("1.2.3")
+julia> a = VersionNumber(1, 2, 3)
 v"1.2.3"
 
 julia> a >= v"1.2"

--- a/base/version.jl
+++ b/base/version.jl
@@ -17,7 +17,7 @@ alpha-numeric annotations.
 operators (`==`, `<`, `<=`, etc.), with the result following semver rules.
 
 See also [`@v_str`](@ref) to efficiently construct `VersionNumber` objects
-from semver-format strings, [`VERSION`](@ref) for the `VersionNumber`
+from semver-format literal strings, [`VERSION`](@ref) for the `VersionNumber`
 of Julia itself, and [Version Number Literals](@ref man-version-number-literals)
 in the manual.
 

--- a/base/version.jl
+++ b/base/version.jl
@@ -8,18 +8,31 @@ const VInt = UInt32
 """
     VersionNumber
 
-Version number type which follow the specifications of
-[semantic versioning](https://semver.org/), composed of major, minor
+Version number type which follows the specifications of
+[semantic versioning (semver)](https://semver.org/), composed of major, minor
 and patch numeric values, followed by pre-release and build
-alpha-numeric annotations. See also [`@v_str`](@ref).
+alpha-numeric annotations.
+
+`VersionNumber` objects can be compared with all of the standard comparison
+operators (`==`, `<`, `<=`, etc.), with the result following semver rules.
+
+See also [`@v_str`](@ref) to efficiently construct `VersionNumber` objects
+from semver-format strings, and [`VERSION`](@ref) for the `VersionNumber`
+of Julia itself.
 
 # Examples
 ```jldoctest
-julia> VersionNumber("1.2.3")
+julia> a = VersionNumber("1.2.3")
 v"1.2.3"
 
-julia> VersionNumber("2.0.1-rc1")
+julia> a >= v"1.2"
+true
+
+julia> b = VersionNumber("2.0.1-rc1")
 v"2.0.1-rc1"
+
+julia> b >= v"2.0.1"
+false
 ```
 """
 struct VersionNumber


### PR DESCRIPTION
The `VersionNumber` docs were a bit thin, so I expanded them e.g. to mention the use of comparison operators.