### PR TITLE
Add precision about stateful iterators to `isempty`

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -778,7 +778,7 @@ Determine whether a collection is empty (has no elements).
 !!! warning
 
     `isempty(itr)` may consume the next element of a stateful iterator `itr`
-    unless an appropriate [`Base.isdone(itr)`](@ref) or `isempty` method is defined.
+    unless an appropriate `Base.isdone(itr)` or `isempty` method is defined.
     Use of `isempty` should therefore be avoided when writing generic
     code which should support any iterator type.
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -775,6 +775,9 @@ inferencebarrier(@nospecialize(x)) = Ref{Any}(x)[]
 
 Determine whether a collection is empty (has no elements).
 
+This operation is guaranteed not to consume elements even for stateful
+iterators (which should define [`Base.isdone`](@ref) to that end).
+
 # Examples
 ```jldoctest
 julia> isempty([])

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -775,8 +775,12 @@ inferencebarrier(@nospecialize(x)) = Ref{Any}(x)[]
 
 Determine whether a collection is empty (has no elements).
 
-This operation is guaranteed not to consume elements even for stateful
-iterators (which should define [`Base.isdone`](@ref) to that end).
+!!! warning
+
+    `isempty(itr)` may consume the next element of a stateful iterator `itr`
+    unless an appropriate [`Base.isdone(itr)`](@ref) or `isempty` method is defined.
+    Use of `isempty` should therefore be avoided when writing generic
+    code which should support any iterator type.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
The [manual](https://docs.julialang.org/en/v1.8-dev/manual/interfaces/#man-interface-iteration) now (https://github.com/JuliaLang/julia/pull/43099) mentions that stateful iterators should implement `isdone`, so it appears `isempty` is not supposed to consume elements.
This matters a lot for callers as if you can't rely on this you can't do `isempty(c) && return; for x in c` but instead have to call `iterate(c)` manually.

Maybe the "should" in the manual and the docstring should be "must" instead?