### PR TITLE
Teach cfg_simplify to drop GotoIfNots that go to the same destination

### DIFF
--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -151,6 +151,14 @@ function verify_ir(ir::IRCode, print::Bool=true)
             @assert length(stmt.edges) == length(stmt.values)
             for i = 1:length(stmt.edges)
                 edge = stmt.edges[i]
+                for j = (i+1):length(stmt.edges)
+                    edge′ = stmt.edges[j]
+                    if edge == edge′
+                        # TODO: Move `unique` to Core.Compiler. For now we assume the predecessor list is
+                        @verify_error "Edge list φ node $idx in bb $bb not unique (double edge?)"
+                        error("")
+                    end
+                end
                 if !(edge == 0 && bb == 1) && !(edge in ir.cfg.blocks[bb].preds)
                     #@Base.show ir.argtypes
                     #@Base.show ir

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -855,3 +855,22 @@ let src = @eval Module() begin
     end
     @test count(iscall((src, Core.tuple)), src.code) == 0
 end
+
+# Test that cfg_simplify can converging control flow through empty blocks
+function foo_cfg_empty(b)
+    if b
+        @goto x
+    end
+    @label x
+    return 1
+end
+let ci = code_typed(foo_cfg_empty, Tuple{Bool}, optimize=true)[1][1]
+    ir = Core.Compiler.inflate_ir(ci)
+    @test length(ir.stmts) == 3
+    @test length(ir.cfg.blocks) == 3
+    Core.Compiler.verify_ir(ir)
+    ir = Core.Compiler.cfg_simplify!(ir)
+    Core.Compiler.verify_ir(ir)
+    @test length(ir.cfg.blocks) <= 2
+    @test isa(ir.stmts[length(ir.stmts)][:inst], ReturnNode)
+end


### PR DESCRIPTION
An example is in the test. The primary reason to do this is not for
the GotoIfNot itself, but rather to drop the use of the GotoIfNot
condition, which may be rooting a number of other statements.

Unfortunately this still shows how diffcult CFG manipulation is using
our current IR datastrcuctures. I'd like to improve that, but unfortunately
it's not the highest priority at present.