### PR TITLE
optimizer: propagate callsite inlining annotation across kwfunc

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -39,6 +39,7 @@ mutable struct InferenceState
     stmt_types::Vector{Union{Nothing, VarTable}}
     stmt_edges::Vector{Union{Nothing, Vector{Any}}}
     stmt_info::Vector{Any}
+    kwfunc_inlining::Union{Nothing,Bool}
     # return type
     bestguess #::Type
     # current active instruction pointers
@@ -119,7 +120,7 @@ mutable struct InferenceState
             sp, slottypes, mod, 0,
             IdSet{InferenceState}(), IdSet{InferenceState}(),
             src, get_world_counter(interp), valid_worlds,
-            nargs, s_types, s_edges, stmt_info,
+            nargs, s_types, s_edges, stmt_info, nothing,
             Union{}, ip, 1, n, handler_at,
             ssavalue_uses,
             Vector{Tuple{InferenceState,LineNum}}(), # cycle_backedges

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -39,7 +39,6 @@ mutable struct InferenceState
     stmt_types::Vector{Union{Nothing, VarTable}}
     stmt_edges::Vector{Union{Nothing, Vector{Any}}}
     stmt_info::Vector{Any}
-    kwfunc_inlining::Union{Nothing,Bool}
     # return type
     bestguess #::Type
     # current active instruction pointers
@@ -120,7 +119,7 @@ mutable struct InferenceState
             sp, slottypes, mod, 0,
             IdSet{InferenceState}(), IdSet{InferenceState}(),
             src, get_world_counter(interp), valid_worlds,
-            nargs, s_types, s_edges, stmt_info, nothing,
+            nargs, s_types, s_edges, stmt_info,
             Union{}, ip, 1, n, handler_at,
             ssavalue_uses,
             Vector{Tuple{InferenceState,LineNum}}(), # cycle_backedges

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -228,6 +228,8 @@ end
 function singleton_type(@nospecialize(ft))
     if isa(ft, Const)
         return ft.val
+    elseif isa(ft, Kwfunc)
+        return ft.kwsorter
     elseif isconstType(ft)
         return ft.parameters[1]
     elseif ft isa DataType && isdefined(ft, :instance)


### PR DESCRIPTION
The callsite inlining annotations only works per-frame, but it might
appear unintuitive when applied to kwfuncs. This commits adds an extra
effort to propagate callsite inlining annotations across kwfunc abstraction:
```julia
julia> function someeval(@nospecialize(x); mod=Main)
           v = Core.eval(mod, :(x = $(esc(x)))) # by default this prevents inlining
           return v
       end
someeval (generic function with 1 method)

julia> let src = code_typed1((Any,)) do x
               someeval(x; mod=Main)
           end
           @test count(iscall((src, Core._expr)), src.code) == 0

           src = code_typed1((Any,)) do x
               @inline someeval(x; mod=Main)
           end
           @test count(iscall((src, Core._expr)), src.code) == 2
       end
Test Passed
```