### PR TITLE
Fix searchsorted in Core.Compiler

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -10,7 +10,8 @@ using .Base: copymutable, LinearIndices, length, (:),
     AbstractVector, @inbounds, AbstractRange, @eval, @inline, Vector, @noinline,
     AbstractMatrix, AbstractUnitRange, isless, identity, eltype, >, <, <=, >=, |, +, -, *, !,
     extrema, sub_with_overflow, add_with_overflow, oneunit, div, getindex, setindex!,
-    length, resize!, fill, Missing, require_one_based_indexing, keytype
+    length, resize!, fill, Missing, require_one_based_indexing, keytype,
+    UnitRange, max, min
 
 using .Base: >>>, !==
 


### PR DESCRIPTION
Just a few missing imports, since this code is used from both places and when it's insider `Core.Compiler` it does not get Base's default exports.