### PR TITLE
adce_pass: Drop phinode edges that can be proved unused

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1146,7 +1146,7 @@ function adce_pass!(ir::IRCode)
             if !isassigned(stmt.values, i)
                 # Should be impossible to have something used only by PiNodes that's undef
                 push!(to_drop, i)
-            elseif typeintersect(widenconst(argextype(stmt.values[i], compact)), t) === Union{}
+            elseif !hasintersect(widenconst(argextype(stmt.values[i], compact)), t)
                 push!(to_drop, i)
             end
         end

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1131,7 +1131,10 @@ function adce_pass!(ir::IRCode)
         count_uses(compact.result[phi][:inst]::PhiNode, phi_uses)
     end
     # Narrow any union phi nodes that have unused branches
-    for (phi, t) in zip(unionphis, unionphi_types)
+    @assert length(unionphis) == length(unionphi_types)
+    for i = 1:length(unionphis)
+        phi = unionphis[i]
+        t = unionphi_types[i]
         if phi_uses[phi] != 0
             continue
         end

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1060,6 +1060,11 @@ function mark_phi_cycles!(compact::IncrementalCompact, safe_phis::SPCSet, phi::I
     end
 end
 
+function is_union_phi(compact::IncrementalCompact, idx::Int)
+    inst = compact.result[idx]
+    return isa(inst[:inst], PhiNode) && isa(inst[:type], Union)
+end
+
 """
     adce_pass!(ir::IRCode) -> newir::IRCode
 
@@ -1082,21 +1087,73 @@ within `sroa_pass!` which redirects references of `typeassert`ed value to the co
 function adce_pass!(ir::IRCode)
     phi_uses = fill(0, length(ir.stmts) + length(ir.new_nodes))
     all_phis = Int[]
+    unionphis = Int[] # sorted
+    unionphi_types = Any[]
     compact = IncrementalCompact(ir)
     for ((_, idx), stmt) in compact
         if isa(stmt, PhiNode)
             push!(all_phis, idx)
-        elseif is_known_call(stmt, typeassert, compact) && length(stmt.args) == 3
-            # nullify safe `typeassert` calls
-            ty, isexact = instanceof_tfunc(argextype(stmt.args[3], compact))
-            if isexact && argextype(stmt.args[2], compact) ⊑ ty
-                compact[idx] = nothing
+            if isa(compact.result[idx][:type], Union)
+                push!(unionphis, idx)
+                push!(unionphi_types, Union{})
+            end
+        elseif isa(stmt, PiNode)
+            val = stmt.val
+            if isa(val, SSAValue) && is_union_phi(compact, val.id)
+                r = searchsorted(unionphis, val.id)
+                if !isempty(r)
+                    unionphi_types[first(r)] = Union{unionphi_types[first(r)], widenconst(stmt.typ)}
+                end
+            end
+        else
+            if is_known_call(stmt, typeassert, compact) && length(stmt.args) == 3
+                # nullify safe `typeassert` calls
+                ty, isexact = instanceof_tfunc(argextype(stmt.args[3], compact))
+                if isexact && argextype(stmt.args[2], compact) ⊑ ty
+                    compact[idx] = nothing
+                    continue
+                end
+            end
+            for ur in userefs(stmt)
+                use = ur[]
+                if isa(use, SSAValue) && is_union_phi(compact, use.id)
+                    r = searchsorted(unionphis, use.id)
+                    if !isempty(r)
+                        deleteat!(unionphis, first(r))
+                        deleteat!(unionphi_types, first(r))
+                    end
+                end
             end
         end
     end
     non_dce_finish!(compact)
     for phi in all_phis
         count_uses(compact.result[phi][:inst]::PhiNode, phi_uses)
+    end
+    # Narrow any union phi nodes that have unused branches
+    for (phi, t) in zip(unionphis, unionphi_types)
+        if phi_uses[phi] != 0
+            continue
+        end
+        if t === Union{}
+            compact.result[phi][:inst] = nothing
+            continue
+        end
+        to_drop = Int[]
+        stmt = compact[phi]
+        stmt === nothing && continue
+        for i = 1:length(stmt.values)
+            if !isassigned(stmt.values, i)
+                # Should be impossible to have something used only by PiNodes that's undef
+                push!(to_drop, i)
+            elseif typeintersect(widenconst(argextype(stmt.values[i], compact)), t) === Union{}
+                push!(to_drop, i)
+            end
+        end
+        isempty(to_drop) && continue
+        deleteat!(stmt.values, to_drop)
+        deleteat!(stmt.edges, to_drop)
+        compact.result[phi][:type] = t
     end
     # Perform simple DCE for unused values
     extra_worklist = Int[]

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -852,8 +852,6 @@ let
         dispatch(a)
     end
     let src = code_typed(foo, Tuple{Bool})[1][1]
-        @test !any(src.code) do stmt
-            isa(stmt, Expr) && stmt.head === :call && stmt.args[1] === Core.tuple
-        end
+        @test count(iscall((src, Core.tuple)), src.code) == 0
     end
 end

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -838,3 +838,22 @@ let ci = code_typed1(optimize=false) do
     ir = Core.Compiler.compact!(ir, true)
     @test count(@nospecialize(stmt)->isa(stmt, Core.GotoIfNot), ir.stmts.inst) == 0
 end
+
+# Test that adce_pass! can drop phi node uses that can be concluded unused
+# from PiNode analysis.
+let
+    @noinline mkfloat() = rand(Float64)
+    @noinline use(a::Float64) = ccall(:jl_, Cvoid, (Any,), a)
+    dispatch(a::Float64) = use(a)
+    dispatch(a::Tuple) = nothing
+    function foo(b)
+        a = mkfloat()
+        a = b ? (a, 2.0) : a
+        dispatch(a)
+    end
+    let src = code_typed(foo, Tuple{Bool})[1][1]
+        @test !any(src.code) do stmt
+            isa(stmt, Expr) && stmt.head === :call && stmt.args[1] === Core.tuple
+        end
+    end
+end


### PR DESCRIPTION
Review note: Base branch is #43227, since that's needed for the test to pass. I'd suggest merging that first, which will automatically update the base branch.

Consider a case like:
```
f(x::Float64) = println(x)
f(x::SomeBigStruct) = nothing
```

Union splitting introduces code that looks like:

```
   goto 2 if not ...
1: a = ::Float64
   goto 3
2: b = new(SomeBigStruct, ...)::SomeBigStruct
3: c = phi(a, b)
   if !isa(c, Float64) goto 5
4: d = PiNode(c, Float64)
   println(d)
   goto 6
5: nothing
6: return nothing
```

Now, #43227 will turn this into:

```
   goto 2 if not ...
1: a = ::Float64
   goto 3
2: b = new(SomeBigStruct, ...)::SomeBigStruct
3: c = phi(a, b)
   cond = phi(true, false)
   if !cond goto 5
4: d = PiNode(c, Float64)
   println(d)
   goto 6
5: nothing
6: return nothing
```

But even though dynamically `b` is never used,
it doesn't get deleted, because there's still a
use in the PhiNode `c`.

This PR teaches adce to recognize this situation and,
for PhiNodes that are only ever used by PiNodes, drop
any edges that are known to be unused. E.g. in the above
case, the adce improvements would turn it into:

```
   goto 2 if not ...
1: a = ::Float64
   goto 3
2: b = new(SomeBigStruct, ...)::SomeBigStruct
3: c = phi(a)
   cond = phi(true, false)
   if !cond goto 5
4: d = PiNode(c, Float64)
   println(d)
   goto 6
5: nothing
6: return nothing
```

Which in turn would let regular DCE drop the allocation:

```
   goto 2 if not ...
1: a = ::Float64
   goto 3
2: nothing
3: c = phi(a)
   cond = phi(true, false)
   if !cond goto 5
4: d = PiNode(c, Float64)
   println(d)
   goto 6
5: nothing
6: return nothing
```

Co-authored-by: Ian Atol <ian.atol@juliacomputing.com>