### PR TITLE
Revert "IO: tie lifetime of handle field to container"

### DIFF
--- a/base/libuv.jl
+++ b/base/libuv.jl
@@ -61,11 +61,8 @@ function preserve_handle(x)
 end
 function unpreserve_handle(x)
     lock(preserve_handle_lock)
-    v = get(uvhandles, x, 0)::Int
-    if v == 0
-        unlock(preserve_handle_lock)
-        error("unbalanced call to unpreserve_handle for $(typeof(x))")
-    elseif v == 1
+    v = uvhandles[x]::Int
+    if v == 1
         pop!(uvhandles, x)
     else
         uvhandles[x] = v - 1

--- a/base/process.jl
+++ b/base/process.jl
@@ -52,7 +52,6 @@ function uv_return_spawn(p::Ptr{Cvoid}, exit_status::Int64, termsignal::Int32)
     proc = unsafe_pointer_to_objref(data)::Process
     proc.exitcode = exit_status
     proc.termsignal = termsignal
-    disassociate_julia_struct(proc.handle)
     ccall(:jl_close_uv, Cvoid, (Ptr{Cvoid},), proc.handle)
     proc.handle = C_NULL
     lock(proc.exitnotify)
@@ -66,7 +65,7 @@ end
 
 # called when the libuv handle is destroyed
 function _uv_hook_close(proc::Process)
-    Libc.free(@atomicswap :not_atomic proc.handle = C_NULL)
+    proc.handle = C_NULL
     nothing
 end
 
@@ -588,10 +587,10 @@ Get the child process ID, if it still exists.
     This function requires at least Julia 1.1.
 """
 function Libc.getpid(p::Process)
-    # TODO: due to threading, this method is only weakly synchronized with the user application
+    # TODO: due to threading, this method is no longer synchronized with the user application
     iolock_begin()
     ppid = Int32(0)
-    if p.handle != C_NULL # e.g. process_running
+    if p.handle != C_NULL
         ppid = ccall(:jl_uv_process_pid, Int32, (Ptr{Cvoid},), p.handle)
     end
     iolock_end()

--- a/src/init.c
+++ b/src/init.c
@@ -167,7 +167,8 @@ static void jl_close_item_atexit(uv_handle_t *handle)
     switch(handle->type) {
     case UV_PROCESS:
         // cause Julia to forget about the Process object
-        handle->data = NULL;
+        if (handle->data)
+            jl_uv_call_close_callback((jl_value_t*)handle->data);
         // and make libuv think it is already dead
         ((uv_process_t*)handle)->pid = 0;
         // fall-through

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -77,7 +77,7 @@ JL_DLLEXPORT void jl_iolock_end(void)
 }
 
 
-static void jl_uv_call_close_callback(jl_value_t *val)
+void jl_uv_call_close_callback(jl_value_t *val)
 {
     jl_value_t *args[2];
     args[0] = jl_get_global(jl_base_relative_to(((jl_datatype_t*)jl_typeof(val))->name->module),
@@ -105,7 +105,6 @@ static void jl_uv_closeHandle(uv_handle_t *handle)
         ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
         jl_uv_call_close_callback((jl_value_t*)handle->data);
         ct->world_age = last_age;
-        return;
     }
     if (handle == (uv_handle_t*)&signal_async)
         return;
@@ -126,10 +125,6 @@ static void jl_uv_flush_close_callback(uv_write_t *req, int status)
         free(req);
         return;
     }
-    if (uv_is_closing((uv_handle_t*)stream)) { // avoid double-close on the stream
-        free(req);
-        return;
-    }
     if (status == 0 && uv_is_writable(stream) && stream->write_queue_size != 0) {
         // new data was written, wait for it to flush too
         uv_buf_t buf;
@@ -139,9 +134,12 @@ static void jl_uv_flush_close_callback(uv_write_t *req, int status)
         if (uv_write(req, stream, &buf, 1, (uv_write_cb)jl_uv_flush_close_callback) == 0)
             return;
     }
-    if (stream->type == UV_TTY)
-        uv_tty_set_mode((uv_tty_t*)stream, UV_TTY_MODE_NORMAL);
-    uv_close((uv_handle_t*)stream, &jl_uv_closeHandle);
+    if (!uv_is_closing((uv_handle_t*)stream)) { // avoid double-close on the stream
+        if (stream->type == UV_TTY)
+            uv_tty_set_mode((uv_tty_t*)stream, UV_TTY_MODE_NORMAL);
+        uv_close((uv_handle_t*)stream, &jl_uv_closeHandle);
+    }
+    free(req);
 }
 
 static void uv_flush_callback(uv_write_t *req, int status)
@@ -224,14 +222,15 @@ static void jl_proc_exit_cleanup_cb(uv_process_t *process, int64_t exit_status, 
 
 JL_DLLEXPORT void jl_close_uv(uv_handle_t *handle)
 {
-    JL_UV_LOCK();
     if (handle->type == UV_PROCESS && ((uv_process_t*)handle)->pid != 0) {
         // take ownership of this handle,
         // so we can waitpid for the resource to exit and avoid leaving zombies
         assert(handle->data == NULL); // make sure Julia has forgotten about it already
         ((uv_process_t*)handle)->exit_cb = jl_proc_exit_cleanup_cb;
+        return;
     }
-    else if (handle->type == UV_FILE) {
+    JL_UV_LOCK();
+    if (handle->type == UV_FILE) {
         uv_fs_t req;
         jl_uv_file_t *fd = (jl_uv_file_t*)handle;
         if ((ssize_t)fd->file != -1) {
@@ -239,26 +238,31 @@ JL_DLLEXPORT void jl_close_uv(uv_handle_t *handle)
             fd->file = (uv_os_fd_t)(ssize_t)-1;
         }
         jl_uv_closeHandle(handle); // synchronous (ok since the callback is known to not interact with any global state)
+        JL_UV_UNLOCK();
+        return;
     }
-    else if (!uv_is_closing(handle)) { // avoid double-closing the stream
-        if (handle->type == UV_NAMED_PIPE || handle->type == UV_TCP || handle->type == UV_TTY) {
-            // flush the stream write-queue first
-            uv_write_t *req = (uv_write_t*)malloc_s(sizeof(uv_write_t));
-            req->handle = (uv_stream_t*)handle;
-            jl_uv_flush_close_callback(req, 0);
-        }
-        else {
-            uv_close(handle, &jl_uv_closeHandle);
-        }
+
+    if (handle->type == UV_NAMED_PIPE || handle->type == UV_TCP || handle->type == UV_TTY) {
+        uv_write_t *req = (uv_write_t*)malloc_s(sizeof(uv_write_t));
+        req->handle = (uv_stream_t*)handle;
+        jl_uv_flush_close_callback(req, 0);
+        JL_UV_UNLOCK();
+        return;
+    }
+
+    // avoid double-closing the stream
+    if (!uv_is_closing(handle)) {
+        uv_close(handle, &jl_uv_closeHandle);
     }
     JL_UV_UNLOCK();
 }
 
 JL_DLLEXPORT void jl_forceclose_uv(uv_handle_t *handle)
 {
-    if (!uv_is_closing(handle)) { // avoid double-closing the stream
+    // avoid double-closing the stream
+    if (!uv_is_closing(handle)) {
         JL_UV_LOCK();
-        if (!uv_is_closing(handle)) { // double-check
+        if (!uv_is_closing(handle)) {
             uv_close(handle, &jl_uv_closeHandle);
         }
         JL_UV_UNLOCK();

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -553,6 +553,7 @@ JL_DLLEXPORT jl_fptr_args_t jl_get_builtin_fptr(jl_value_t *b);
 
 extern uv_loop_t *jl_io_loop;
 void jl_uv_flush(uv_stream_t *stream);
+void jl_uv_call_close_callback(jl_value_t *val);
 
 typedef struct jl_typeenv_t {
     jl_tvar_t *var;

--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -76,7 +76,7 @@ iswritable(f::FDEvent) = f.writable
 |(a::FDEvent, b::FDEvent) = FDEvent(getfield(a, :events) | getfield(b, :events))
 
 mutable struct FileMonitor
-    @atomic handle::Ptr{Cvoid}
+    handle::Ptr{Cvoid}
     file::String
     notify::Base.ThreadSynchronizer
     events::Int32
@@ -99,14 +99,12 @@ mutable struct FileMonitor
 end
 
 mutable struct FolderMonitor
-    @atomic handle::Ptr{Cvoid}
-    # notify::Channel{Any} # eltype = Union{Pair{String, FileEvent}, IOError}
-    notify::Base.ThreadSynchronizer
-    channel::Vector{Any} # eltype = Pair{String, FileEvent}
+    handle::Ptr{Cvoid}
+    notify::Channel{Any} # eltype = Union{Pair{String, FileEvent}, IOError}
     FolderMonitor(folder::AbstractString) = FolderMonitor(String(folder))
     function FolderMonitor(folder::String)
         handle = Libc.malloc(_sizeof_uv_fs_event)
-        this = new(handle, Base.ThreadSynchronizer(), [])
+        this = new(handle, Channel(Inf))
         associate_julia_struct(handle, this)
         iolock_begin()
         err = ccall(:uv_fs_event_init, Cint, (Ptr{Cvoid}, Ptr{Cvoid}), eventloop(), handle)
@@ -124,7 +122,7 @@ mutable struct FolderMonitor
 end
 
 mutable struct PollingFileWatcher
-    @atomic handle::Ptr{Cvoid}
+    handle::Ptr{Cvoid}
     file::String
     interval::UInt32
     notify::Base.ThreadSynchronizer
@@ -149,14 +147,14 @@ mutable struct PollingFileWatcher
 end
 
 mutable struct _FDWatcher
-    @atomic handle::Ptr{Cvoid}
+    handle::Ptr{Cvoid}
     fdnum::Int # this is NOT the file descriptor
     refcount::Tuple{Int, Int}
     notify::Base.ThreadSynchronizer
     events::Int32
     active::Tuple{Bool, Bool}
 
-    let FDWatchers = Vector{Any}() # n.b.: this structure and the refcount are protected by the iolock
+    let FDWatchers = Vector{Any}() # XXX: this structure and refcount need thread-safety locks
         global _FDWatcher, uvfinalize
         @static if Sys.isunix()
             _FDWatcher(fd::RawFD, mask::FDEvent) = _FDWatcher(fd, mask.readable, mask.writable)
@@ -208,7 +206,7 @@ mutable struct _FDWatcher
                 if t.handle != C_NULL
                     disassociate_julia_struct(t)
                     ccall(:jl_close_uv, Cvoid, (Ptr{Cvoid},), t.handle)
-                    @atomic :monotonic t.handle = C_NULL
+                    t.handle = C_NULL
                 end
                 t.refcount = (0, 0)
                 t.active = (false, false)
@@ -315,35 +313,27 @@ function close(t::FDWatcher)
 end
 
 function uvfinalize(uv::Union{FileMonitor, FolderMonitor, PollingFileWatcher})
-    iolock_begin()
-    if uv.handle != C_NULL
-        disassociate_julia_struct(uv)
-        ccall(:jl_close_uv, Cvoid, (Ptr{Cvoid},), uv.handle)
-    end
-    iolock_end()
+    disassociate_julia_struct(uv)
+    close(uv)
 end
 
 function close(t::Union{FileMonitor, FolderMonitor, PollingFileWatcher})
-    iolock_begin()
     if t.handle != C_NULL
-        preserve_handle(t)
         ccall(:jl_close_uv, Cvoid, (Ptr{Cvoid},), t.handle)
     end
-    iolock_end()
 end
 
 function _uv_hook_close(uv::_FDWatcher)
     # fyi: jl_atexit_hook can cause this to get called too
-    Libc.free(@atomicswap :monotonic uv.handle = C_NULL)
+    uv.handle = C_NULL
     uvfinalize(uv)
     nothing
 end
 
 function _uv_hook_close(uv::PollingFileWatcher)
-    unpreserve_handle(uv)
     lock(uv.notify)
     try
-        Libc.free(@atomicswap :monotonic uv.handle = C_NULL)
+        uv.handle = C_NULL
         uv.active = false
         notify(uv.notify, StatStruct())
     finally
@@ -353,10 +343,9 @@ function _uv_hook_close(uv::PollingFileWatcher)
 end
 
 function _uv_hook_close(uv::FileMonitor)
-    unpreserve_handle(uv)
     lock(uv.notify)
     try
-        Libc.free(@atomicswap :monotonic uv.handle = C_NULL)
+        uv.handle = C_NULL
         uv.active = false
         notify(uv.notify, FileEvent())
     finally
@@ -366,14 +355,8 @@ function _uv_hook_close(uv::FileMonitor)
 end
 
 function _uv_hook_close(uv::FolderMonitor)
-    unpreserve_handle(uv)
-    lock(uv.notify)
-    try
-        Libc.free(@atomicswap :monotonic uv.handle = C_NULL)
-        notify_error(uv.notify, EOFError())
-    finally
-        unlock(uv.notify)
-    end
+    uv.handle = C_NULL
+    close(uv.notify)
     nothing
 end
 
@@ -401,17 +384,11 @@ end
 
 function uv_fseventscb_folder(handle::Ptr{Cvoid}, filename::Ptr, events::Int32, status::Int32)
     t = @handle_as handle FolderMonitor
-    lock(t.notify)
-    try
-        if status != 0
-            notify_error(t.notify, _UVError("FolderMonitor", status))
-        else
-            fname = (filename == C_NULL) ? "" : unsafe_string(convert(Cstring, filename))
-            push!(t.channel, fname => FileEvent(events))
-            notify(t.notify)
-        end
-    finally
-        unlock(t.notify)
+    if status != 0
+        put!(t.notify, _UVError("FolderMonitor", status))
+    else
+        fname = (filename == C_NULL) ? "" : unsafe_string(convert(Cstring, filename))
+        put!(t.notify, fname => FileEvent(events))
     end
     nothing
 end
@@ -469,7 +446,7 @@ end
 
 function start_watching(t::_FDWatcher)
     iolock_begin()
-    t.handle == C_NULL && throw(ArgumentError("FDWatcher is closed"))
+    t.handle == C_NULL && return throw(ArgumentError("FDWatcher is closed"))
     readable = t.refcount[1] > 0
     writable = t.refcount[2] > 0
     if t.active[1] != readable || t.active[2] != writable
@@ -487,7 +464,7 @@ end
 
 function start_watching(t::PollingFileWatcher)
     iolock_begin()
-    t.handle == C_NULL && throw(ArgumentError("PollingFileWatcher is closed"))
+    t.handle == C_NULL && return throw(ArgumentError("PollingFileWatcher is closed"))
     if !t.active
         uv_error("PollingFileWatcher (start)",
                  ccall(:uv_fs_poll_start, Int32, (Ptr{Cvoid}, Ptr{Cvoid}, Cstring, UInt32),
@@ -516,7 +493,7 @@ end
 
 function start_watching(t::FileMonitor)
     iolock_begin()
-    t.handle == C_NULL && throw(ArgumentError("FileMonitor is closed"))
+    t.handle == C_NULL && return throw(ArgumentError("FileMonitor is closed"))
     if !t.active
         uv_error("FileMonitor (start)",
                  ccall(:uv_fs_event_start, Int32, (Ptr{Cvoid}, Ptr{Cvoid}, Cstring, Int32),
@@ -670,20 +647,26 @@ function wait(m::FileMonitor)
 end
 
 function wait(m::FolderMonitor)
-    m.handle == C_NULL && throw(EOFError())
-    preserve_handle(m)
-    lock(m.notify)
-    evt = try
-            m.handle == C_NULL && throw(EOFError())
-            while isempty(m.channel)
-                wait(m.notify)
+    m.handle == C_NULL && return throw(ArgumentError("FolderMonitor is closed"))
+    if isready(m.notify)
+        evt = take!(m.notify) # non-blocking fast-path
+    else
+        preserve_handle(m)
+        evt = try
+                take!(m.notify)
+            catch ex
+                unpreserve_handle(m)
+                if ex isa InvalidStateException && ex.state === :closed
+                    rethrow(EOFError()) # `wait(::Channel)` throws the wrong exception
+                end
+                rethrow()
             end
-            popfirst!(m.channel)
-        finally
-            unlock(m.notify)
-            unpreserve_handle(m)
-        end
-    return evt::Pair{String, FileEvent}
+    end
+    if evt isa Pair{String, FileEvent}
+        return evt
+    else
+        throw(evt)
+    end
 end
 
 
@@ -704,7 +687,6 @@ function poll_fd(s::Union{RawFD, Sys.iswindows() ? WindowsRawSocket : Union{}}, 
     mask.timedout && return mask
     fdw = _FDWatcher(s, mask)
     local timer
-    # we need this flag to explicitly track whether we call `close` already, to update the internal refcount correctly
     timedout = false # TODO: make this atomic
     try
         if timeout_s >= 0
@@ -792,39 +774,37 @@ function watch_folder(s::String, timeout_s::Real=-1)
     fm = get!(watched_folders, s) do
         return FolderMonitor(s)
     end
-    local timer
-    if timeout_s >= 0
-        @lock fm.notify isempty(fm.channel) || return popfirst!(fm.channel)
+    if timeout_s >= 0 && !isready(fm.notify)
         if timeout_s <= 0.010
             # for very small timeouts, we can just sleep for the whole timeout-interval
             (timeout_s == 0) ? yield() : sleep(timeout_s)
-            @lock fm.notify isempty(fm.channel) || return popfirst!(fm.channel)
-            return "" => FileEvent() # timeout
-        else
-            timer = Timer(timeout_s) do t
-                @lock fm.notify notify(fm.notify)
+            if !isready(fm.notify)
+                return "" => FileEvent() # timeout
             end
+            # fall-through to a guaranteed non-blocking fast-path call to wait
+        else
+            # If we may need to be able to cancel via a timeout,
+            # create a second monitor object just for that purpose.
+            # We still take the events from the primary stream.
+            fm2 = FileMonitor(s)
+            timer = Timer(timeout_s) do t
+                close(fm2)
+            end
+            try
+                while isopen(fm.notify) && !isready(fm.notify)
+                    fm2.handle == C_NULL && return "" => FileEvent() # timeout
+                    wait(fm2)
+                end
+            finally
+                close(fm2)
+                close(timer)
+            end
+            # guaranteed that next call to `wait(fm)` is non-blocking
+            # since we haven't entered the libuv event loop yet
+            # or the Base scheduler workqueue since last testing `isready`
         end
     end
-    # inline a copy of `wait` with added support for checking timer
-    fm.handle == C_NULL && throw(EOFError())
-    preserve_handle(fm)
-    lock(fm.notify)
-    evt = try
-            fm.handle == C_NULL && throw(EOFError())
-            while isempty(fm.channel)
-                if @isdefined(timer)
-                    isopen(timer) || return "" => FileEvent() # timeout
-                end
-                wait(fm.notify)
-            end
-            popfirst!(fm.channel)
-        finally
-            unlock(fm.notify)
-            unpreserve_handle(fm)
-            @isdefined(timer) && close(timer)
-        end
-    return evt::Pair{String, FileEvent}
+    return wait(fm)
 end
 
 """

--- a/stdlib/Sockets/src/Sockets.jl
+++ b/stdlib/Sockets/src/Sockets.jl
@@ -200,6 +200,7 @@ end
 show(io::IO, stream::UDPSocket) = print(io, typeof(stream), "(", uv_status_string(stream), ")")
 
 function _uv_hook_close(sock::UDPSocket)
+    sock.handle = C_NULL
     lock(sock.cond)
     try
         sock.status = StatusClosed
@@ -480,7 +481,6 @@ function uv_connectcb(conn::Ptr{Cvoid}, status::Cint)
         else
             sock.readerror = _UVError("connect", status) # TODO: perhaps we should not reuse readerror for this
             if !(sock.status == StatusClosed || sock.status == StatusClosing)
-                preserve_handle(sock)
                 ccall(:jl_forceclose_uv, Cvoid, (Ptr{Cvoid},), hand)
                 sock.status = StatusClosing
             end


### PR DESCRIPTION
Reverts JuliaLang/julia#43218

That PR last ran without full CI, and it appears current CI was broken by it. Revert for now and we can investigate in the morning and fix it.