### PR TITLE
Add a generic scal!

### DIFF
--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -5,7 +5,7 @@ Interface to BLAS subroutines.
 """
 module BLAS
 
-import ..axpy!, ..axpby!
+import ..scal!, ..axpy!, ..axpby!
 import Base: copyto!
 using Base: require_one_based_indexing, USE_BLAS64
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1437,6 +1437,13 @@ function axpby!(α, x::AbstractArray, β, y::AbstractArray)
     y
 end
 
+function scal!(α, x::AbstractArray)
+    for IX in eachindex(x)
+        @inbounds x[IX] *= α
+    end
+    x
+end
+
 """
     rotate!(x, y, c, s)
 

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -295,6 +295,15 @@ end
     @test LinearAlgebra.axpy!(α, x, rx, y, ry) == [1 1 1 1; 11 1 1 26]
 end
 
+@testset "Generic scal!" begin
+    α = rand(BigFloat)
+    x = rand(BigFloat, 5)
+    y = scal(α, x)
+    @test y ≈ α * x
+    scal!(α, x)
+    @test y ≈ x
+end
+
 @testset "norm and normalize!" begin
     vr = [3.0, 4.0]
     for Tr in (Float32, Float64)


### PR DESCRIPTION
`scal!` was only defined for `Float32`, `Float64`, `ComplexF32` and `ComplexF64` vectors.