### PR TITLE
Manually split `string(a::Union{Char, String, SubString{String}, Symbol}...)`

### DIFF
--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -216,8 +216,12 @@ function string(a::Union{Char, String, SubString{String}, Symbol}...)
     for v in a
         if v isa Char
             n += ncodeunits(v)
-        else
+        elseif v isa String
             n += sizeof(v)
+        elseif v isa SubString{String}
+            n += sizeof(v)
+        else
+            n += sizeof(v::Symbol)
         end
     end
     out = _string_n(n)

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -214,6 +214,8 @@ end
 function string(a::Union{Char, String, SubString{String}, Symbol}...)
     n = 0
     for v in a
+        # 4 types is too many for automatic Union-splitting, so we split manually
+        # and allow one specializable call site per concrete type
         if v isa Char
             n += ncodeunits(v)
         elseif v isa String


### PR DESCRIPTION
4 is one too many for automatic Union-splitting.  Poor inference in
this method accounts for more than 2000 invalidations.

Fix (at least partial) for #43157. I don't remember my numbers before this change, but if my vague memory is correct this knocks ~1s off the `using Plots` time and ~2s off `display(plot(rand(10)))`. It also brings the number of invalidations down from 2622 to 599.

The regression appears to have been introduced in #41992---a very innocuous-seeming change. There still may be more TTFP to fix, though.