### PR TITLE
Tighten validation of `hvncat` implementation

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2363,6 +2363,10 @@ function _typed_hvncat_dims(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, as
             end
         elseif currentdims[d1] > outdims[d1] # exceeded dimension
             throw(ArgumentError("argument $i has too many elements along axis $d1"))
+        else
+            for d ∈ (d2, 3:N...)
+                currentdims[d] += cat_size(as[i], d)
+            end
         end
     end
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2329,15 +2329,17 @@ function _typed_hvncat_dims(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, as
 
     # validate shapes for lowest level of concatenation
     d = findfirst(>(1), dims)
-    nblocks = length(as) ÷ dims[d]
-    for b ∈ 1:nblocks
-        offset = ((b - 1) * dims[d])
-        startelementi = offset + 1
-        for i ∈ offset .+ (2:dims[d])
-            for dd ∈ 1:N
-                dd == d && continue
-                if size(as[startelementi], dd) != size(as[i], dd)
-                    throw(ArgumentError("incompatible shape in element $i"))
+    if d !== nothing # all dims are 1
+        nblocks = length(as) ÷ dims[d]
+        for b ∈ 1:nblocks
+            offset = ((b - 1) * dims[d])
+            startelementi = offset + 1
+            for i ∈ offset .+ (2:dims[d])
+                for dd ∈ 1:N
+                    dd == d && continue
+                    if size(as[startelementi], dd) != size(as[i], dd)
+                        throw(ArgumentError("incompatible shape in element $i"))
+                    end
                 end
             end
         end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1534,6 +1534,10 @@ using Base: typed_hvncat
     @test Int[] == typed_hvncat(Int, 1) isa Array{Int, 1}
     @test Array{Int, 2}(undef, 0, 0) == typed_hvncat(Int, 2) isa Array{Int, 2}
     @test Array{Int, 3}(undef, 0, 0, 0) == typed_hvncat(Int, 3) isa Array{Int, 3}
+
+    # Issue 43933 - semicolon precedence mistake should produce an error
+    @test_throws ArgumentError [[1 1]; 2 ;; 3 ; [3 4]]
+    @test_throws ArgumentError [[1 ;;; 1]; 2 ;;; 3 ; [3 ;;; 4]]
 end
 
 @testset "keepat!" begin


### PR DESCRIPTION
As documented in #43933 , a user may run into an unexpected array if they attempt to concatenate arrays using the multidimensional syntax but don't know the semicolon precedence rules:

```
[[1 1]; 2 ;; 3 ; [3 4]]
[[1 ;;; 1]; 2 ;;; 3 ; [3 ;;; 4]]
```

Naively, one might think these expressions would work, assuming `;` had lowest precedence. The `_typed_hvncat_dims` implementation needed to do more to check the dimensions of the arguments.

Fixes #43933 

Should be backported to 1.7, yes?