### PR TITLE
Optimized negation of a Tridiagonal matrix

### DIFF
--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -736,6 +736,7 @@ end
 
 +(A::Tridiagonal, B::Tridiagonal) = Tridiagonal(A.dl+B.dl, A.d+B.d, A.du+B.du)
 -(A::Tridiagonal, B::Tridiagonal) = Tridiagonal(A.dl-B.dl, A.d-B.d, A.du-B.du)
+-(A::Tridiagonal) = Tridiagonal(-A.dl, -A.d, -A.du)
 *(A::Tridiagonal, B::Number) = Tridiagonal(A.dl*B, A.d*B, A.du*B)
 *(B::Number, A::Tridiagonal) = Tridiagonal(B*A.dl, B*A.d, B*A.du)
 /(A::Tridiagonal, B::Number) = Tridiagonal(A.dl/B, A.d/B, A.du/B)


### PR DESCRIPTION
There was a missing specialized method `-(::Tridiagonal)`, so the operation used to fall back to that for an `AbstractArray`. This PR adds this method by forwarding the negation to the diagonals.

Master:
```julia
julia> T = Tridiagonal(ones(300), zeros(301), -ones(300));

julia> @btime -$T;
  3.317 μs (4 allocations: 7.55 KiB)
```
This PR:
```julia
julia> @btime -$T;
  1.778 μs (4 allocations: 7.55 KiB)
```