### PR TITLE
Add docstring to `String`

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -32,7 +32,7 @@ const ByteArray = Union{CodeUnits{UInt8,String}, Vector{UInt8},Vector{Int8}, Fas
 """
     String <: AbstractString
 
-The generic, default string type in Julia, used by e.g. string literals.
+The default string type in Julia, used by e.g. string literals.
 
 `String`s are immutable sequences of `Char`s. A `String` is stored internally as
 a contiguous byte array, and while they are interpreted as being UTF-8 encoded,

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -29,6 +29,18 @@ const ByteArray = Union{CodeUnits{UInt8,String}, Vector{UInt8},Vector{Int8}, Fas
 
 @inline between(b::T, lo::T, hi::T) where {T<:Integer} = (lo ≤ b) & (b ≤ hi)
 
+@doc """
+    String <: AbstractString
+
+The generic, default string type in Julia, used by e.g. string literals.
+
+`String`s are immutable sequences of `Char`s. A `String` is stored internally as
+a contiguous byte array, and while they are interpreted as being UTF-8 encoded,
+they can be composed of any byte sequence.
+This representation often makes `String` appropriate for passing strings to C.
+"""
+String
+
 ## constructors and conversions ##
 
 # String constructor docstring from boot.jl, workaround for #16730
@@ -36,9 +48,9 @@ const ByteArray = Union{CodeUnits{UInt8,String}, Vector{UInt8},Vector{Int8}, Fas
 """
     String(v::AbstractVector{UInt8})
 
-Create a new `String` object from a byte vector `v` containing UTF-8 encoded
-characters. If `v` is `Vector{UInt8}` it will be truncated to zero length and
-future modification of `v` cannot affect the contents of the resulting string.
+Create a new `String` object using the data buffer from byte vector `v`.
+If `v` is `Vector{UInt8}` it will be truncated to zero length and future
+modification of `v` cannot affect the contents of the resulting string.
 To avoid truncation of `Vector{UInt8}` data, use `String(copy(v))`; for other
 `AbstractVector` types, `String(v)` already makes a copy.
 
@@ -76,8 +88,7 @@ _string_n(n::Integer) = ccall(:jl_alloc_string, Ref{String}, (Csize_t,), n)
 """
     String(s::AbstractString)
 
-Convert a string to a contiguous byte array representation encoded as UTF-8 bytes.
-This representation is often appropriate for passing strings to C.
+Create a new `String` from an existing `AbstractString`.
 """
 String(s::AbstractString) = print_to_string(s)
 @pure String(s::Symbol) = unsafe_string(unsafe_convert(Ptr{UInt8}, s))

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -38,7 +38,6 @@ The default string type in Julia, used by e.g. string literals.
 a contiguous byte array, and while they are interpreted as being UTF-8 encoded,
 they can be composed of any byte sequence. Use [`isvalid`](@ref) to validate
 that the underlying byte sequence is valid as UTF-8.
-This representation often makes `String` appropriate for passing strings to C.
 """
 String
 

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -29,7 +29,7 @@ const ByteArray = Union{CodeUnits{UInt8,String}, Vector{UInt8},Vector{Int8}, Fas
 
 @inline between(b::T, lo::T, hi::T) where {T<:Integer} = (lo ≤ b) & (b ≤ hi)
 
-@doc """
+"""
     String <: AbstractString
 
 The generic, default string type in Julia, used by e.g. string literals.

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -36,7 +36,8 @@ The default string type in Julia, used by e.g. string literals.
 
 `String`s are immutable sequences of `Char`s. A `String` is stored internally as
 a contiguous byte array, and while they are interpreted as being UTF-8 encoded,
-they can be composed of any byte sequence.
+they can be composed of any byte sequence. Use [`isvalid`](@ref) to validate
+that the underlying byte sequence is valid as UTF-8.
 This representation often makes `String` appropriate for passing strings to C.
 """
 String

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -49,7 +49,7 @@ String
     String(v::AbstractVector{UInt8})
 
 Create a new `String` object using the data buffer from byte vector `v`.
-If `v` is `Vector{UInt8}` it will be truncated to zero length and future
+If `v` is a `Vector{UInt8}` it will be truncated to zero length and future
 modification of `v` cannot affect the contents of the resulting string.
 To avoid truncation of `Vector{UInt8}` data, use `String(copy(v))`; for other
 `AbstractVector` types, `String(v)` already makes a copy.


### PR DESCRIPTION
The type `String` itself did not have a docstring, instead the type is documented through two of its constructors.
Add docstring to `String`, and remove redundant information from the constructor docstrings.
In particular, mention that `String`s, while they are interpreted as being UTF8 encoded, do not assume strings are valid UTF8, and may be arbitrary byte sequences.

This PR was spurred [by a discussion on the UTF8-ness of `String`](https://julialang.zulipchat.com/#narrow/stream/225540-gripes/topic/Encoding.20of.20default.20String)
