### PR TITLE
Don't `invokelatest` in `@threads`

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -91,7 +91,7 @@ function _threadsfor(iter, lbody, schedule)
               :(error("`@threads :static` cannot be used concurrently or nested"))
               else
               # only use threads when called from outside @threads
-              :(Base.invokelatest(threadsfor_fun, true))
+              :(threadsfor_fun(true))
               end)
         else
             threading_run(threadsfor_fun)


### PR DESCRIPTION
Now that child tasks inherit world age #41449, we need to call the single-thread fallback of `@threads` in the same world age.