### PR TITLE
AbstractInterpreter: pass `caller::InferenceResult` to the optimizer

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -250,9 +250,7 @@ function _typeinf(interp::AbstractInterpreter, frame::InferenceState)
     for (caller, _, _) in results
         opt = caller.src
         if opt isa OptimizationState # implies `may_optimize(interp) === true`
-            result_type = caller.result
-            @assert !(result_type isa LimitedAccuracy)
-            analyzed = optimize(interp, opt, OptimizationParams(interp), result_type)
+            analyzed = optimize(interp, opt, OptimizationParams(interp), caller)
             if isa(analyzed, ConstAPI)
                 # XXX: The work in ir_to_codeinf! is essentially wasted. The only reason
                 # we're doing it is so that code_llvm can return the code


### PR DESCRIPTION
`caller::InferenceResult` will be used as a key for caching
interprocedural information analyzed at optimization phase
(as we will do with the escape analysis).