### PR TITLE
Change PATH_MAX to JL_PATH_MAX

### DIFF
--- a/cli/loader.h
+++ b/cli/loader.h
@@ -1,6 +1,6 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
-/* Bring in definitions for `_OS_X_`, `PATH_MAX` and `PATHSEPSTRING`, `jl_ptls_t`, etc... */
+/* Bring in definitions for `_OS_X_`, `JULIA_PATH_MAX` and `PATHSEPSTRING`, `jl_ptls_t`, etc... */
 #include "../src/support/platform.h"
 #include "../src/support/dirpath.h"
 #include "../src/julia_fasttls.h"

--- a/cli/loader.h
+++ b/cli/loader.h
@@ -1,6 +1,6 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
-/* Bring in definitions for `_OS_X_`, `JULIA_PATH_MAX` and `PATHSEPSTRING`, `jl_ptls_t`, etc... */
+/* Bring in definitions for `_OS_X_`, `JL_PATH_MAX` and `PATHSEPSTRING`, `jl_ptls_t`, etc... */
 #include "../src/support/platform.h"
 #include "../src/support/dirpath.h"
 #include "../src/julia_fasttls.h"

--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -49,14 +49,14 @@ static void * load_library(const char * rel_path, const char * src_dir, int err)
         return handle;
 #endif
 
-    char path[2*JULIA_PATH_MAX + 1] = {0};
+    char path[2*JL_PATH_MAX + 1] = {0};
     strncat(path, src_dir, sizeof(path) - 1);
     strncat(path, PATHSEPSTRING, sizeof(path) - 1);
     strncat(path, rel_path, sizeof(path) - 1);
 
 #if defined(_OS_WINDOWS_)
-    wchar_t wpath[2*JULIA_PATH_MAX + 1] = {0};
-    if (!utf8_to_wchar(path, wpath, 2*JULIA_PATH_MAX)) {
+    wchar_t wpath[2*JL_PATH_MAX + 1] = {0};
+    if (!utf8_to_wchar(path, wpath, 2*JL_PATH_MAX)) {
         jl_loader_print_stderr3("ERROR: Unable to convert path ", path, " to wide string!\n");
         exit(1);
     }
@@ -98,7 +98,7 @@ static void * lookup_symbol(const void * lib_handle, const char * symbol_name) {
 }
 
 // Find the location of libjulia.
-char lib_dir[JULIA_PATH_MAX];
+char lib_dir[JL_PATH_MAX];
 JL_DLLEXPORT const char * jl_get_libdir()
 {
     // Reuse the path if this is not the first call.
@@ -107,11 +107,11 @@ JL_DLLEXPORT const char * jl_get_libdir()
     }
 #if defined(_OS_WINDOWS_)
     // On Windows, we use GetModuleFileNameW
-    wchar_t libjulia_path[JULIA_PATH_MAX];
+    wchar_t libjulia_path[JL_PATH_MAX];
     HMODULE libjulia = NULL;
 
     // Get a handle to libjulia.
-    if (!utf8_to_wchar(LIBJULIA_NAME, libjulia_path, JULIA_PATH_MAX)) {
+    if (!utf8_to_wchar(LIBJULIA_NAME, libjulia_path, JL_PATH_MAX)) {
         jl_loader_print_stderr3("ERROR: Unable to convert path ", LIBJULIA_NAME, " to wide string!\n");
         exit(1);
     }
@@ -120,11 +120,11 @@ JL_DLLEXPORT const char * jl_get_libdir()
         jl_loader_print_stderr3("ERROR: Unable to load ", LIBJULIA_NAME, "!\n");
         exit(1);
     }
-    if (!GetModuleFileNameW(libjulia, libjulia_path, JULIA_PATH_MAX)) {
+    if (!GetModuleFileNameW(libjulia, libjulia_path, JL_PATH_MAX)) {
         jl_loader_print_stderr("ERROR: GetModuleFileName() failed\n");
         exit(1);
     }
-    if (!wchar_to_utf8(libjulia_path, lib_dir, JULIA_PATH_MAX)) {
+    if (!wchar_to_utf8(libjulia_path, lib_dir, JL_PATH_MAX)) {
         jl_loader_print_stderr("ERROR: Unable to convert julia path to UTF-8\n");
         exit(1);
     }

--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -49,14 +49,14 @@ static void * load_library(const char * rel_path, const char * src_dir, int err)
         return handle;
 #endif
 
-    char path[2*PATH_MAX + 1] = {0};
+    char path[2*JULIA_PATH_MAX + 1] = {0};
     strncat(path, src_dir, sizeof(path) - 1);
     strncat(path, PATHSEPSTRING, sizeof(path) - 1);
     strncat(path, rel_path, sizeof(path) - 1);
 
 #if defined(_OS_WINDOWS_)
-    wchar_t wpath[2*PATH_MAX + 1] = {0};
-    if (!utf8_to_wchar(path, wpath, 2*PATH_MAX)) {
+    wchar_t wpath[2*JULIA_PATH_MAX + 1] = {0};
+    if (!utf8_to_wchar(path, wpath, 2*JULIA_PATH_MAX)) {
         jl_loader_print_stderr3("ERROR: Unable to convert path ", path, " to wide string!\n");
         exit(1);
     }
@@ -98,7 +98,7 @@ static void * lookup_symbol(const void * lib_handle, const char * symbol_name) {
 }
 
 // Find the location of libjulia.
-char lib_dir[PATH_MAX];
+char lib_dir[JULIA_PATH_MAX];
 JL_DLLEXPORT const char * jl_get_libdir()
 {
     // Reuse the path if this is not the first call.
@@ -107,11 +107,11 @@ JL_DLLEXPORT const char * jl_get_libdir()
     }
 #if defined(_OS_WINDOWS_)
     // On Windows, we use GetModuleFileNameW
-    wchar_t libjulia_path[PATH_MAX];
+    wchar_t libjulia_path[JULIA_PATH_MAX];
     HMODULE libjulia = NULL;
 
     // Get a handle to libjulia.
-    if (!utf8_to_wchar(LIBJULIA_NAME, libjulia_path, PATH_MAX)) {
+    if (!utf8_to_wchar(LIBJULIA_NAME, libjulia_path, JULIA_PATH_MAX)) {
         jl_loader_print_stderr3("ERROR: Unable to convert path ", LIBJULIA_NAME, " to wide string!\n");
         exit(1);
     }
@@ -120,11 +120,11 @@ JL_DLLEXPORT const char * jl_get_libdir()
         jl_loader_print_stderr3("ERROR: Unable to load ", LIBJULIA_NAME, "!\n");
         exit(1);
     }
-    if (!GetModuleFileNameW(libjulia, libjulia_path, PATH_MAX)) {
+    if (!GetModuleFileNameW(libjulia, libjulia_path, JULIA_PATH_MAX)) {
         jl_loader_print_stderr("ERROR: GetModuleFileName() failed\n");
         exit(1);
     }
-    if (!wchar_to_utf8(libjulia_path, lib_dir, PATH_MAX)) {
+    if (!wchar_to_utf8(libjulia_path, lib_dir, JULIA_PATH_MAX)) {
         jl_loader_print_stderr("ERROR: Unable to convert julia path to UTF-8\n");
         exit(1);
     }

--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -175,7 +175,7 @@ static intptr_t get_anon_hdl(void)
     if (check_fd_or_close(fd))
         return fd;
 #  endif
-    char shm_name[PATH_MAX] = "julia-codegen-0123456789-0123456789/tmp///";
+    char shm_name[JULIA_PATH_MAX] = "julia-codegen-0123456789-0123456789/tmp///";
     pid_t pid = getpid();
     // `shm_open` can't be mapped exec on mac
 #  ifndef _OS_DARWIN_

--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -175,7 +175,7 @@ static intptr_t get_anon_hdl(void)
     if (check_fd_or_close(fd))
         return fd;
 #  endif
-    char shm_name[JULIA_PATH_MAX] = "julia-codegen-0123456789-0123456789/tmp///";
+    char shm_name[JL_PATH_MAX] = "julia-codegen-0123456789-0123456789/tmp///";
     pid_t pid = getpid();
     // `shm_open` can't be mapped exec on mac
 #  ifndef _OS_DARWIN_

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -865,7 +865,7 @@ static objfileentry_t &find_object_file(uint64_t fbase, StringRef fname) JL_NOTS
             CFRelease(objuuid);
             CFRelease(objurl);
 
-            char objpathcstr[PATH_MAX];
+            char objpathcstr[JULIA_PATH_MAX];
             if (dsympathurl != NULL &&
                 CFURLGetFileSystemRepresentation(
                     dsympathurl, true, (UInt8 *)objpathcstr,

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -865,7 +865,7 @@ static objfileentry_t &find_object_file(uint64_t fbase, StringRef fname) JL_NOTS
             CFRelease(objuuid);
             CFRelease(objurl);
 
-            char objpathcstr[JULIA_PATH_MAX];
+            char objpathcstr[JL_PATH_MAX];
             if (dsympathurl != NULL &&
                 CFURLGetFileSystemRepresentation(
                     dsympathurl, true, (UInt8 *)objpathcstr,

--- a/src/init.c
+++ b/src/init.c
@@ -466,8 +466,8 @@ static char *abspath(const char *in, int nprefix)
             memcpy(out, in, sz + nprefix);
         }
         else {
-            size_t path_size = PATH_MAX;
-            char *path = (char*)malloc_s(PATH_MAX);
+            size_t path_size = JULIA_PATH_MAX;
+            char *path = (char*)malloc_s(JULIA_PATH_MAX);
             if (uv_cwd(path, &path_size)) {
                 jl_error("fatal error: unexpected error while retrieving current working directory");
             }
@@ -502,8 +502,8 @@ static const char *absformat(const char *in)
     if (in[0] == '%' || jl_isabspath(in))
         return in;
     // get an escaped copy of cwd
-    size_t path_size = PATH_MAX;
-    char path[PATH_MAX];
+    size_t path_size = JULIA_PATH_MAX;
+    char path[JULIA_PATH_MAX];
     if (uv_cwd(path, &path_size)) {
         jl_error("fatal error: unexpected error while retrieving current working directory");
     }
@@ -527,17 +527,17 @@ static const char *absformat(const char *in)
 static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel)
 {   // this function resolves the paths in jl_options to absolute file locations as needed
     // and it replaces the pointers to `julia_bindir`, `julia_bin`, `image_file`, and output file paths
-    // it may fail, print an error, and exit(1) if any of these paths are longer than PATH_MAX
+    // it may fail, print an error, and exit(1) if any of these paths are longer than JULIA_PATH_MAX
     //
     // note: if you care about lost memory, you should call the appropriate `free()` function
     // on the original pointer for each `char*` you've inserted into `jl_options`, after
     // calling `julia_init()`
-    char *free_path = (char*)malloc_s(PATH_MAX);
-    size_t path_size = PATH_MAX;
+    char *free_path = (char*)malloc_s(JULIA_PATH_MAX);
+    size_t path_size = JULIA_PATH_MAX;
     if (uv_exepath(free_path, &path_size)) {
         jl_error("fatal error: unexpected error while retrieving exepath");
     }
-    if (path_size >= PATH_MAX) {
+    if (path_size >= JULIA_PATH_MAX) {
         jl_error("fatal error: jl_options.julia_bin path too long");
     }
     jl_options.julia_bin = (char*)malloc_s(path_size + 1);
@@ -556,10 +556,10 @@ static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel)
     if (jl_options.image_file) {
         if (rel == JL_IMAGE_JULIA_HOME && !jl_isabspath(jl_options.image_file)) {
             // build time path, relative to JULIA_BINDIR
-            free_path = (char*)malloc_s(PATH_MAX);
-            int n = snprintf(free_path, PATH_MAX, "%s" PATHSEPSTRING "%s",
+            free_path = (char*)malloc_s(JULIA_PATH_MAX);
+            int n = snprintf(free_path, JULIA_PATH_MAX, "%s" PATHSEPSTRING "%s",
                              jl_options.julia_bindir, jl_options.image_file);
-            if (n >= PATH_MAX || n < 0) {
+            if (n >= JULIA_PATH_MAX || n < 0) {
                 jl_error("fatal error: jl_options.image_file path too long");
             }
             jl_options.image_file = free_path;

--- a/src/init.c
+++ b/src/init.c
@@ -466,8 +466,8 @@ static char *abspath(const char *in, int nprefix)
             memcpy(out, in, sz + nprefix);
         }
         else {
-            size_t path_size = JULIA_PATH_MAX;
-            char *path = (char*)malloc_s(JULIA_PATH_MAX);
+            size_t path_size = JL_PATH_MAX;
+            char *path = (char*)malloc_s(JL_PATH_MAX);
             if (uv_cwd(path, &path_size)) {
                 jl_error("fatal error: unexpected error while retrieving current working directory");
             }
@@ -502,8 +502,8 @@ static const char *absformat(const char *in)
     if (in[0] == '%' || jl_isabspath(in))
         return in;
     // get an escaped copy of cwd
-    size_t path_size = JULIA_PATH_MAX;
-    char path[JULIA_PATH_MAX];
+    size_t path_size = JL_PATH_MAX;
+    char path[JL_PATH_MAX];
     if (uv_cwd(path, &path_size)) {
         jl_error("fatal error: unexpected error while retrieving current working directory");
     }
@@ -527,17 +527,17 @@ static const char *absformat(const char *in)
 static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel)
 {   // this function resolves the paths in jl_options to absolute file locations as needed
     // and it replaces the pointers to `julia_bindir`, `julia_bin`, `image_file`, and output file paths
-    // it may fail, print an error, and exit(1) if any of these paths are longer than JULIA_PATH_MAX
+    // it may fail, print an error, and exit(1) if any of these paths are longer than JL_PATH_MAX
     //
     // note: if you care about lost memory, you should call the appropriate `free()` function
     // on the original pointer for each `char*` you've inserted into `jl_options`, after
     // calling `julia_init()`
-    char *free_path = (char*)malloc_s(JULIA_PATH_MAX);
-    size_t path_size = JULIA_PATH_MAX;
+    char *free_path = (char*)malloc_s(JL_PATH_MAX);
+    size_t path_size = JL_PATH_MAX;
     if (uv_exepath(free_path, &path_size)) {
         jl_error("fatal error: unexpected error while retrieving exepath");
     }
-    if (path_size >= JULIA_PATH_MAX) {
+    if (path_size >= JL_PATH_MAX) {
         jl_error("fatal error: jl_options.julia_bin path too long");
     }
     jl_options.julia_bin = (char*)malloc_s(path_size + 1);
@@ -556,10 +556,10 @@ static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel)
     if (jl_options.image_file) {
         if (rel == JL_IMAGE_JULIA_HOME && !jl_isabspath(jl_options.image_file)) {
             // build time path, relative to JULIA_BINDIR
-            free_path = (char*)malloc_s(JULIA_PATH_MAX);
-            int n = snprintf(free_path, JULIA_PATH_MAX, "%s" PATHSEPSTRING "%s",
+            free_path = (char*)malloc_s(JL_PATH_MAX);
+            int n = snprintf(free_path, JL_PATH_MAX, "%s" PATHSEPSTRING "%s",
                              jl_options.julia_bindir, jl_options.image_file);
-            if (n >= JULIA_PATH_MAX || n < 0) {
+            if (n >= JL_PATH_MAX || n < 0) {
                 jl_error("fatal error: jl_options.image_file path too long");
             }
             jl_options.image_file = free_path;

--- a/src/julia_fasttls.h
+++ b/src/julia_fasttls.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-/* Bring in definitions for `_OS_X_`, `JULIA_PATH_MAX` and `PATHSEPSTRING`, `jl_ptls_t`, etc... */
+/* Bring in definitions for `_OS_X_`, `JL_PATH_MAX` and `PATHSEPSTRING`, `jl_ptls_t`, etc... */
 #include "platform.h"
 #include "dirpath.h"
 

--- a/src/julia_fasttls.h
+++ b/src/julia_fasttls.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-/* Bring in definitions for `_OS_X_`, `PATH_MAX` and `PATHSEPSTRING`, `jl_ptls_t`, etc... */
+/* Bring in definitions for `_OS_X_`, `JULIA_PATH_MAX` and `PATHSEPSTRING`, `jl_ptls_t`, etc... */
 #include "platform.h"
 #include "dirpath.h"
 

--- a/src/support/dirpath.h
+++ b/src/support/dirpath.h
@@ -7,13 +7,13 @@
 #define PATHSEPSTRING "\\"
 #define PATHLISTSEPSTRING ";"
 #if defined(_COMPILER_CLANG_)
-#define JULIA_PATH_MAX MAX_PATH
+#define JL_PATH_MAX MAX_PATH
 #endif
 #else
 #define PATHSEPSTRING "/"
 #define PATHLISTSEPSTRING ":"
-#ifndef JULIA_PATH_MAX // many platforms don't have a max path, we define one anyways
-#define JULIA_PATH_MAX 1024
+#ifndef JL_PATH_MAX // many platforms don't have a max path, we define one anyways
+#define JL_PATH_MAX 1024
 #endif
 #endif
 

--- a/src/support/dirpath.h
+++ b/src/support/dirpath.h
@@ -7,13 +7,13 @@
 #define PATHSEPSTRING "\\"
 #define PATHLISTSEPSTRING ";"
 #if defined(_COMPILER_CLANG_)
-#define PATH_MAX MAX_PATH
+#define JULIA_PATH_MAX MAX_PATH
 #endif
 #else
 #define PATHSEPSTRING "/"
 #define PATHLISTSEPSTRING ":"
-#ifndef PATH_MAX // many platforms don't have a max path, we define one anyways
-#define PATH_MAX 1024
+#ifndef JULIA_PATH_MAX // many platforms don't have a max path, we define one anyways
+#define JULIA_PATH_MAX 1024
 #endif
 #endif
 

--- a/src/support/dirpath.h
+++ b/src/support/dirpath.h
@@ -6,6 +6,7 @@
 #ifdef _OS_WINDOWS_
 #define PATHSEPSTRING "\\"
 #define PATHLISTSEPSTRING ";"
+#define JL_PATH_MAX PATH_MAX
 #if defined(_COMPILER_CLANG_)
 #define JL_PATH_MAX MAX_PATH
 #endif


### PR DESCRIPTION
Linked to #10682 and to avoid warning like the below one (see https://discourse.julialang.org/t/ccall-c-sort-vector-of-string/74635/21):
```
D:\Code\test>clang++ --std=c++17 -shared -undefined dynamic_lookup -o libsort.dll 
-I C:\Users\gitboy\.julia\artifacts\ddaec29ab3e1def8127a1757203ee4a75c1bbead\include\
-ID:\julia-1.7.1-win64\julia-1.7.1\include\julia
-LD:\julia-1.7.1-win64\julia-1.7.1\lib\julia sort.cpp

In file included from sort.cpp:1:
In file included from C:\Users\gitboy\.julia\artifacts\ddaec29ab3e1def8127a1757203ee4a75c1bbead\include\jlcxx/jlcxx.hpp:13:
In file included from C:\Users\gitboy\.julia\artifacts\ddaec29ab3e1def8127a1757203ee4a75c1bbead\include\jlcxx/julia_headers.hpp:15:
In file included from D:\julia-1.7.1-win64\julia-1.7.1\include\julia\julia.h:12:
In file included from D:\julia-1.7.1-win64\julia-1.7.1\include\julia\julia_fasttls.h:14:
  D:\julia-1.7.1-win64\julia-1.7.1\include\julia/dirpath.h:10:9: warning: 'PATH_MAX' macro
    redefined [-Wmacro-refedined]
  #define PATH_MAX MAX_PATH
          ^
  D:\llvm-mingw-20211002-msvcrt-x86_64\llvm-mingw-20211002-msvcrt-x86_64\include\limits.h:20:9:
      previous definition is here
  #define PATH_MAX   260
          ^
  1 warning generated
```