### PR TITLE
optimize `in(::Char, ::String)`

### DIFF
--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -165,10 +165,11 @@ end
 
 in(c::AbstractChar, s::AbstractString) = (findfirst(isequal(c),s)!==nothing)
 function in(c::Char, s::String)
-    c > '\x7f' && return findfirst(isequal(c),s) !== nothing
-    b = Int8(c)
+    b = first_utf8_byte(c)
     q = GC.@preserve s ccall(:memchr, Ptr{UInt8}, (Ptr{UInt8}, Int32, Csize_t), pointer(s), b, sizeof(s))
-    return q != C_NULL
+    q == C_NULL && return false
+    c > '\x7f' && return findnext(isequal(c), s, q) !== nothing
+    return true
 end
 
 function _searchindex(s::Union{AbstractString,ByteArray},

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -164,6 +164,12 @@ end
 
 
 in(c::AbstractChar, s::AbstractString) = (findfirst(isequal(c),s)!==nothing)
+function in(c::Char, s::String)
+    c > '\x7f' && return findfirst(isequal(c),s) !== nothing
+    b = Int8(c)
+    q = GC.@preserve s ccall(:memchr, Ptr{UInt8}, (Ptr{UInt8}, Int32, Csize_t), pointer(s), b, sizeof(s))
+    return q != C_NULL
+end
 
 function _searchindex(s::Union{AbstractString,ByteArray},
                       t::Union{AbstractString,AbstractChar,Int8,UInt8},


### PR DESCRIPTION
This is approximately 2x faster for finding ascii characters in strings than before.

```julia
julia> s = "chalet"
#old
julia> @btime in('\0', $(Ref(s))[])
  10.470 ns (0 allocations: 0 bytes)
false
#new
julia> @btime in('t', $(Ref(s))[])
  4.470 ns (0 allocations: 0 bytes)
true
julia> s = "h"^1000*'t'
#old
julia> @btime in('\0', $(Ref(s))[])
  17.184 ns (0 allocations: 0 bytes)
false
#new
julia> @btime in('t', $(Ref(s))[])
  9.469 ns (0 allocations: 0 bytes)
true
```
closes https://github.com/JuliaLang/julia/issues/43980