### PR TITLE
Precompile display(["a"])

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -49,7 +49,7 @@ repl_script = """
 2+2
 print("")
 printstyled("a", "b")
-display(["a"])        
+display(["a"])
 display([1])
 display([1 2; 3 4])
 @time 1+1

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -49,6 +49,7 @@ repl_script = """
 2+2
 print("")
 printstyled("a", "b")
+display(["a"])        
 display([1])
 display([1 2; 3 4])
 @time 1+1


### PR DESCRIPTION
In a 1.7 repl, compiling `display(::Vector{String})` takes nearly half a second, which is inconvenient for handling string data. This change precompiles that method to reduce latency.

```jl
julia> @timev display([1])
1-element Vector{Int64}:
 1
  0.021591 seconds (7.04 k allocations: 416.012 KiB, 92.94% compilation time)
elapsed time (ns): 21591439
bytes allocated:   425996
pool allocs:       7032
non-pool GC allocs:3

julia> @timev display(["a"])
1-element Vector{String}:
 "a"
  0.469237 seconds (491.48 k allocations: 25.637 MiB, 99.61% compilation time)
elapsed time (ns): 469237391
bytes allocated:   26882206
pool allocs:       491244
non-pool GC allocs:239

julia> @timev display(["a"])
1-element Vector{String}:
 "a"
  0.001495 seconds (316 allocations: 40.719 KiB)
elapsed time (ns): 1494888
bytes allocated:   41696
pool allocs:       313
non-pool GC allocs:3
```