### PR TITLE
docs: fix heading level of "Module initialization and precompilation"

### DIFF
--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -394,7 +394,7 @@ end
 end
 ```
 
-### Module initialization and precompilation
+## Module initialization and precompilation
 
 Large modules can take several seconds to load because executing all of the statements in a module
 often involves compiling a large amount of code.


### PR DESCRIPTION
In the "Modules" section of the manual, ["Module initialization and precompilation"](https://docs.julialang.org/en/v1/manual/modules/#Module-initialization-and-precompilation) is not a subsection of "Submodules and relative paths", but rather stands on the same level as it and "Namespace management". This PR fixes that.
(This also makes sure the init & precomp section is visible in the TOC sidebar).