### PR TITLE
Very WIP: Refactor core inference loops to use less memory

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -759,13 +759,13 @@ function concrete_eval_call(interp::AbstractInterpreter,
         Core._call_in_world_total(world, f, args...)
     catch
         # The evaulation threw. By :consistent-cy, we're guaranteed this would have happened at runtime
-        return ConstCallResults(Union{}, ConcreteResult(result.edge, result.edge_effects), result.edge_effects)
+        return ConstCallResults(Union{}, ConcreteResult(result.edge::MethodInstance, result.edge_effects), result.edge_effects)
     end
     if is_inlineable_constant(value) || call_result_unused(sv)
         # If the constant is not inlineable, still do the const-prop, since the
         # code that led to the creation of the Const may be inlineable in the same
         # circumstance and may be optimizable.
-        return ConstCallResults(Const(value), ConcreteResult(result.edge, EFFECTS_TOTAL, value), EFFECTS_TOTAL)
+        return ConstCallResults(Const(value), ConcreteResult(result.edge::MethodInstance, EFFECTS_TOTAL, value), EFFECTS_TOTAL)
     end
     return nothing
 end
@@ -801,7 +801,7 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter, resul
     end
     val = concrete_eval_call(interp, f, result, arginfo, sv)
     if val !== nothing
-        add_backedge!(result.edge, sv)
+        add_backedge!(val.const_result.mi, sv)
         return val
     end
     mi = maybe_get_const_prop_profitable(interp, result, f, arginfo, match, sv)
@@ -841,8 +841,8 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter, resul
     return ConstCallResults(result, ConstPropResult(inf_result), inf_result.ipo_effects)
 end
 
-# if there's a possibility we could get a better result (hopefully without doing too much work)
-# returns `MethodInstance` with constant arguments, returns nothing otherwise
+# if there's a possibility we could get a better result with these constant arguments
+# (hopefully without doing too much work), returns `MethodInstance`, or nothing otherwise
 function maybe_get_const_prop_profitable(interp::AbstractInterpreter, result::MethodCallResult,
                                          @nospecialize(f), arginfo::ArgInfo, match::MethodMatch,
                                          sv::InferenceState)
@@ -1811,7 +1811,12 @@ function abstract_eval_special_value(interp::AbstractInterpreter, @nospecialize(
     elseif isa(e, SSAValue)
         return abstract_eval_ssavalue(e, sv)
     elseif isa(e, SlotNumber) || isa(e, Argument)
-        return vtypes[slot_id(e)].typ
+        sn = slot_id(e)
+        s = vtypes[sn]
+        if s.undef
+            sv.src.slotflags[sn] |= SLOT_USEDUNDEF | SLOT_STATICUNDEF
+        end
+        return s.typ
     elseif isa(e, GlobalRef)
         return abstract_eval_global(e.mod, e.name, sv)
     end
@@ -1998,11 +2003,15 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
         sym = e.args[1]
         t = Bool
         if isa(sym, SlotNumber)
-            vtyp = vtypes[slot_id(sym)]
+            sn = slot_id(sym)
+            vtyp = vtypes[sn]
             if vtyp.typ === Bottom
+                sv.src.slotflags[sn] |= SLOT_USEDUNDEF | SLOT_STATICUNDEF
                 t = Const(false) # never assigned previously
             elseif !vtyp.undef
                 t = Const(true) # definitely assigned previously
+            else
+                sv.src.slotflags[sn] |= SLOT_USEDUNDEF | SLOT_STATICUNDEF
             end
         elseif isa(sym, Symbol)
             if isdefined(sv.mod, sym)
@@ -2147,7 +2156,6 @@ function widenreturn_noconditional(@nospecialize(rt))
     return widenconst(rt)
 end
 
-
 function handle_control_backedge!(frame::InferenceState, from::Int, to::Int)
     if from > to
         if is_effect_overridden(frame, :terminates_globally)
@@ -2161,198 +2169,347 @@ function handle_control_backedge!(frame::InferenceState, from::Int, to::Int)
     return nothing
 end
 
+struct StmtResult
+    changes::Union{Nothing, StateUpdate}
+    type::Any # ::Union{LatticeElement, Nothing} - `nothing` if stmt may not be used as an SSA Value
+    # effects
+end
+
+@inline function abstract_interpret_basic_statement!(interp::AbstractInterpreter,
+    pc_vartable::VarTable, @nospecialize(stmt), frame::InferenceState)
+    if isa(stmt, NewvarNode)
+        changes = StateUpdate(stmt.slot, VarState(Bottom, true), pc_vartable, false)
+        return StmtResult(changes, nothing)
+    elseif !isa(stmt, Expr)
+        t = abstract_eval_statement(interp, stmt, pc_vartable, frame)
+        return StmtResult(nothing, t)
+    end
+    changes = nothing
+    stmt = stmt::Expr
+    hd = stmt.head
+    if hd === :(=)
+        t = abstract_eval_statement(interp, stmt.args[2], pc_vartable, frame)
+        if t === Bottom
+            return StmtResult(nothing, Bottom)
+        end
+        lhs = stmt.args[1]
+        if isa(lhs, SlotNumber)
+            changes = StateUpdate(lhs, VarState(t, false), pc_vartable, false)
+        elseif isa(lhs, GlobalRef)
+            tristate_merge!(frame, Effects(EFFECTS_TOTAL,
+                effect_free=TRISTATE_UNKNOWN,
+                nothrow=TRISTATE_UNKNOWN))
+        elseif !isa(lhs, SSAValue)
+            tristate_merge!(frame, EFFECTS_UNKNOWN)
+        end
+        return StmtResult(changes, t)
+    elseif hd === :method
+        fname = stmt.args[1]
+        if isa(fname, SlotNumber)
+            changes = StateUpdate(fname, VarState(Any, false), pc_vartable, false)
+        end
+        return StmtResult(changes, nothing)
+    elseif (hd === :code_coverage_effect ||
+            (hd !== :boundscheck && # :boundscheck can be narrowed to Bool
+             hd !== nothing && is_meta_expr_head(hd)))
+        return StmtResult(nothing, Nothing)
+    else
+        t = abstract_eval_statement(interp, stmt, pc_vartable, frame)
+        return StmtResult(nothing, t)
+    end
+end
+
+@inline function propagate_exception_slots!(frame::InferenceState, changes::StateUpdate)
+    let cur_hand = frame.handler_at[frame.currpc], l, enter
+        while cur_hand != 0
+            enter = frame.src.code[cur_hand]::Expr
+            l = enter.args[1]::Int
+            exceptbb = block_for_inst(frame.cfg, l)
+            # propagate new type info to exception handler
+            # the handling for Expr(:enter) propagates all changes from before the try/catch
+            # so this only needs to propagate any changes
+            if (stupdate1!(frame.bb_vartables[exceptbb], changes) ||
+                !was_reached(frame, first(frame.cfg.blocks[exceptbb].stmts)))
+                push!(frame.ip, exceptbb)
+            end
+            cur_hand = frame.handler_at[cur_hand]
+        end
+    end
+end
+
+@inline function abstract_interpret_return(interp::AbstractInterpreter,
+    nargs::Int, node::ReturnNode, frame::InferenceState)
+    (; bestguess, slottypes) = frame
+    rt = abstract_eval_value(interp, node.val, frame.pc_vartable, frame)
+    rt = widenreturn(rt, bestguess, nargs, slottypes, frame.pc_vartable)
+    # narrow representation of bestguess slightly to prepare for tmerge with rt
+    if rt isa InterConditional && bestguess isa Const
+        let slot_id = rt.slot
+            old_id_type = slottypes[slot_id]
+            if bestguess.val === true && rt.elsetype !== Bottom
+                bestguess = InterConditional(slot_id, old_id_type, Bottom)
+            elseif bestguess.val === false && rt.vtype !== Bottom
+                bestguess = InterConditional(slot_id, Bottom, old_id_type)
+            end
+        end
+    end
+    # copy limitations to return value
+    if !isempty(frame.pclimitations)
+        union!(frame.limitations, frame.pclimitations)
+        empty!(frame.pclimitations)
+    end
+    if !isempty(frame.limitations)
+        rt = LimitedAccuracy(rt, copy(frame.limitations))
+    end
+    if tchanged(rt, bestguess)
+        # new (wider) return type for frame
+        bestguess = tmerge(bestguess, rt)
+        # TODO: if bestguess isa InterConditional && !interesting(bestguess); bestguess = widenconditional(bestguess); end
+        frame.bestguess = bestguess
+        for (caller, caller_pc) in frame.cycle_backedges
+            if !((caller.src.ssavaluetypes::Vector{Any})[caller_pc] === Any)
+                # no reason to revisit if that call-site doesn't affect the final result
+                push!(caller.ip, block_for_inst(caller.cfg, caller_pc))
+            end
+        end
+    end
+end
+
+@inline function abstract_interpret_branch_condition(interp::AbstractInterpreter,
+    stmt::GotoIfNot, frame::InferenceState)::Pair{Union{Nothing, Bool}, Any}
+    condx = stmt.cond
+    condt = abstract_eval_value(interp, condx, frame.pc_vartable, frame)
+    if condt === Bottom
+        empty!(frame.pclimitations)
+        return Pair{Union{Nothing, Bool}, Any}(nothing, Bottom)
+    end
+    if !(isa(condt, Const) || isa(condt, Conditional)) && isa(condx, SlotNumber)
+        # if this non-`Conditional` object is a slot, we form and propagate
+        # the conditional constraint on it
+        condt = Conditional(condx, Const(true), Const(false))
+    end
+    condval = maybe_extract_const_bool(condt)
+    l = stmt.dest::Int
+    if !isempty(frame.pclimitations)
+        # we can't model the possible effect of control
+        # dependencies on the return value, so we propagate it
+        # directly to all the return values (unless we error first)
+        condval isa Bool || union!(frame.limitations, frame.pclimitations)
+        empty!(frame.pclimitations)
+    end
+    return Pair{Union{Nothing, Bool}, Any}(condval, condt)
+end
+
 # make as much progress on `frame` as possible (without handling cycles)
 function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
     @assert !frame.inferred
     frame.dont_work_on_me = true # mark that this function is currently on the stack
     W = frame.ip
-    states = frame.stmt_types
     def = frame.linfo.def
     isva = isa(def, Method) && def.isva
     nargs = length(frame.result.argtypes) - isva
     slottypes = frame.slottypes
     ssavaluetypes = frame.src.ssavaluetypes::Vector{Any}
-    while !isempty(W)
-        # make progress on the active ip set
-        local pc::Int = popfirst!(W)
-        local pc´::Int = pc + 1 # next program-counter (after executing instruction)
-        frame.currpc = pc
-        edges = frame.stmt_edges[pc]
-        edges === nothing || empty!(edges)
-        frame.stmt_info[pc] = nothing
-        stmt = frame.src.code[pc]
-        changes = states[pc]::VarTable
-        t = nothing
+    bbs = frame.cfg.blocks
+    nbbs = length(bbs)
 
-        hd = isa(stmt, Expr) ? stmt.head : nothing
+    if frame.currbb != 1
+        frame.currbb = _bits_findnext(W.bits, 1)::Int # next basic block
+    end
 
-        if isa(stmt, NewvarNode)
-            sn = slot_id(stmt.slot)
-            changes[sn] = VarState(Bottom, true)
-        elseif isa(stmt, GotoNode)
-            l = (stmt::GotoNode).label
-            handle_control_backedge!(frame, pc, l)
-            pc´ = l
-        elseif isa(stmt, GotoIfNot)
-            condx = stmt.cond
-            condt = abstract_eval_value(interp, condx, changes, frame)
-            if condt === Bottom
-                empty!(frame.pclimitations)
-                continue
-            end
-            if !(isa(condt, Const) || isa(condt, Conditional)) && isa(condx, SlotNumber)
-                # if this non-`Conditional` object is a slot, we form and propagate
-                # the conditional constraint on it
-                condt = Conditional(condx, Const(true), Const(false))
-            end
-            condval = maybe_extract_const_bool(condt)
-            l = stmt.dest::Int
-            if !isempty(frame.pclimitations)
-                # we can't model the possible effect of control
-                # dependencies on the return value, so we propagate it
-                # directly to all the return values (unless we error first)
-                condval isa Bool || union!(frame.limitations, frame.pclimitations)
-                empty!(frame.pclimitations)
-            end
-            # constant conditions
-            if condval === true
-            elseif condval === false
-                handle_control_backedge!(frame, pc, l)
-                pc´ = l
-            else
-                # general case
-                changes_else = changes
-                if isa(condt, Conditional)
-                    changes_else = conditional_changes(changes_else, condt.elsetype, condt.var)
-                    changes      = conditional_changes(changes,      condt.vtype,    condt.var)
-                end
-                newstate_else = stupdate!(states[l], changes_else)
-                if newstate_else !== nothing
-                    handle_control_backedge!(frame, pc, l)
-                    # add else branch to active IP list
-                    push!(W, l)
-                    states[l] = newstate_else
-                end
-            end
-        elseif isa(stmt, ReturnNode)
-            bestguess = frame.bestguess
-            rt = abstract_eval_value(interp, stmt.val, changes, frame)
-            rt = widenreturn(rt, bestguess, nargs, slottypes, changes)
-            # narrow representation of bestguess slightly to prepare for tmerge with rt
-            if rt isa InterConditional && bestguess isa Const
-                let slot_id = rt.slot
-                    old_id_type = slottypes[slot_id]
-                    if bestguess.val === true && rt.elsetype !== Bottom
-                        bestguess = InterConditional(slot_id, old_id_type, Bottom)
-                    elseif bestguess.val === false && rt.vtype !== Bottom
-                        bestguess = InterConditional(slot_id, Bottom, old_id_type)
+    stoverwrite!(frame.pc_vartable, frame.bb_vartables[frame.currbb])
+    while frame.currbb <= nbbs
+        delete!(W, frame.currbb)
+        frame.currpc = first(bbs[frame.currbb].stmts)
+        bbend = last(bbs[frame.currbb].stmts)
+
+        for frame.currpc in frame.currpc:bbend
+            stmt = frame.src.code[frame.currpc]
+            push!(frame.was_reached, frame.currpc)
+            # If we're at the end of the basic block ...
+            if frame.currpc == bbend
+                # Handle control flow
+                if isa(stmt, GotoNode)
+                    succs = bbs[frame.currbb].succs
+                    @assert length(succs) == 1
+                    nextbb = succs[1]
+                    ssavaluetypes[frame.currpc] = Any
+                    handle_control_backedge!(frame, frame.currpc, stmt.label)
+                    @goto branch
+                elseif isa(stmt, GotoIfNot)
+                    # TODO condval, condt = abstract_interpret_branch_condition(interp, stmt, frame)
+                    condx = stmt.cond
+                    condt = abstract_eval_value(interp, condx, frame.pc_vartable, frame)
+                    if condt === Bottom
+                        empty!(frame.pclimitations)
+                        @goto find_next_bb
                     end
-                end
-            end
-            # copy limitations to return value
-            if !isempty(frame.pclimitations)
-                union!(frame.limitations, frame.pclimitations)
-                empty!(frame.pclimitations)
-            end
-            if !isempty(frame.limitations)
-                rt = LimitedAccuracy(rt, copy(frame.limitations))
-            end
-            if tchanged(rt, bestguess)
-                # new (wider) return type for frame
-                bestguess = tmerge(bestguess, rt)
-                # TODO: if bestguess isa InterConditional && !interesting(bestguess); bestguess = widenconditional(bestguess); end
-                frame.bestguess = bestguess
-                for (caller, caller_pc) in frame.cycle_backedges
-                    # notify backedges of updated type information
-                    typeassert(caller.stmt_types[caller_pc], VarTable) # we must have visited this statement before
-                    if !((caller.src.ssavaluetypes::Vector{Any})[caller_pc] === Any)
-                        # no reason to revisit if that call-site doesn't affect the final result
-                        push!(caller.ip, caller_pc)
+                    if !(isa(condt, Const) || isa(condt, Conditional)) && isa(condx, SlotNumber)
+                        # if this non-`Conditional` object is a slot, we form and propagate
+                        # the conditional constraint on it
+                        condt = Conditional(condx, Const(true), Const(false))
                     end
+                    condval = maybe_extract_const_bool(condt)
+                    if !isempty(frame.pclimitations)
+                        # we can't model the possible effect of control
+                        # dependencies on the return
+                        # directly to all the return values (unless we error first)
+                        condval isa Bool || union!(frame.limitations, frame.pclimitations)
+                        empty!(frame.pclimitations)
+                    end
+                    ssavaluetypes[frame.currpc] = Any
+                    if condval === true
+                        @goto fallthrough
+                    else
+                        succs = bbs[frame.currbb].succs
+                        if length(succs) == 1
+                            @assert condval === false || (stmt.dest === frame.currpc + 1)
+                            nextbb = succs[1]
+                            @goto branch
+                        end
+                        @assert length(succs) == 2
+                        truebb = frame.currbb + 1
+                        falsebb = succs[1] == truebb ? succs[2] : succs[1]
+                        if condval === false
+                            nextbb = falsebb
+                            handle_control_backedge!(frame, frame.currpc, stmt.dest)
+                            @goto branch
+                        else
+                            # We continue with the true branch, but process the false
+                            # branch here.
+                            if isa(condt, Conditional)
+                                newstate = stupdate!(frame.bb_vartables[falsebb], frame.pc_vartable,
+                                    conditional_changes(frame.pc_vartable, condt.elsetype, condt.var))
+                                stoverwrite1!(frame.pc_vartable,
+                                    conditional_changes(frame.pc_vartable, condt.vtype, condt.var))
+                            else
+                                newstate = stupdate!(frame.bb_vartables[falsebb], frame.pc_vartable)
+                            end
+                            if newstate !== nothing || !was_reached(frame, first(bbs[falsebb].stmts))
+                                handle_control_backedge!(frame, frame.currpc, stmt.dest)
+                                push!(W, falsebb)
+                            end
+                            @goto fallthrough
+                        end
+                    end
+                elseif isa(stmt, ReturnNode)
+                    # TODO abstract_interpret_return(interp, nargs, stmt, frame)
+                    bestguess = frame.bestguess
+                    rt = abstract_eval_value(interp, stmt.val, frame.pc_vartable, frame)
+                    rt = widenreturn(rt, bestguess, nargs, slottypes, frame.pc_vartable)
+                    # narrow representation of bestguess slightly to prepare for tmerge with rt
+                    if rt isa InterConditional && bestguess isa Const
+                        let slot_id = rt.slot
+                            old_id_type = slottypes[slot_id]
+                            if bestguess.val === true && rt.elsetype !== Bottom
+                                bestguess = InterConditional(slot_id, old_id_type, Bottom)
+                            elseif bestguess.val === false && rt.vtype !== Bottom
+                                bestguess = InterConditional(slot_id, Bottom, old_id_type)
+                            end
+                        end
+                    end
+                    # copy limitations to return value
+                    if !isempty(frame.pclimitations)
+                        union!(frame.limitations, frame.pclimitations)
+                        empty!(frame.pclimitations)
+                    end
+                    if !isempty(frame.limitations)
+                        rt = LimitedAccuracy(rt, copy(frame.limitations))
+                    end
+                    if tchanged(rt, bestguess)
+                        # new (wider) return type for frame
+                        bestguess = tmerge(bestguess, rt)
+                        # TODO: if bestguess isa InterConditional && !interesting(bestguess); bestguess = widenconditional(bestguess); end
+                        frame.bestguess = bestguess
+                        for (caller, caller_pc) in frame.cycle_backedges
+                            if !((caller.src.ssavaluetypes::Vector{Any})[caller_pc] === Any)
+                                # no reason to revisit if that call-site doesn't affect the final result
+                                push!(caller.ip, block_for_inst(caller.cfg, caller_pc))
+                            end
+                        end
+                    end
+                    ssavaluetypes[frame.currpc] = Any
+                    @goto find_next_bb
+                elseif isexpr(stmt, :enter)
+                    # Propagate entry info to exception handler
+                    l = stmt.args[1]::Int
+                    catchbb = block_for_inst(frame.cfg, l)
+                    if stupdate!(frame.bb_vartables[catchbb], frame.pc_vartable) !== nothing
+                        push!(W, catchbb)
+                    end
+                    ssavaluetypes[frame.currpc] = Any
+                    @goto fallthrough
                 end
+                # Fall through terminator - treat as regular stmt
             end
-            continue
-        elseif hd === :enter
-            stmt = stmt::Expr
-            l = stmt.args[1]::Int
-            # propagate type info to exception handler
-            old = states[l]
-            newstate_catch = stupdate!(old, changes)
-            if newstate_catch !== nothing
-                push!(W, l)
-                states[l] = newstate_catch
+            # Process non control-flow statements
+            (; changes, type) = abstract_interpret_basic_statement!(interp,
+                frame.pc_vartable, stmt, frame)
+            if type === Union{}
+                @goto find_next_bb
             end
-            typeassert(states[l], VarTable)
-        elseif hd === :leave
-        else
-            if hd === :(=)
-                stmt = stmt::Expr
-                t = abstract_eval_statement(interp, stmt.args[2], changes, frame)
-                if t === Bottom
-                    continue
-                end
-                ssavaluetypes[pc] = t
-                lhs = stmt.args[1]
-                if isa(lhs, SlotNumber)
-                    changes = StateUpdate(lhs, VarState(t, false), changes, false)
-                elseif isa(lhs, GlobalRef)
-                    tristate_merge!(frame, Effects(EFFECTS_TOTAL,
-                        effect_free=TRISTATE_UNKNOWN,
-                        nothrow=TRISTATE_UNKNOWN))
-                elseif !isa(lhs, SSAValue)
-                    tristate_merge!(frame, EFFECTS_UNKNOWN)
-                end
-            elseif hd === :method
-                stmt = stmt::Expr
-                fname = stmt.args[1]
-                if isa(fname, SlotNumber)
-                    changes = StateUpdate(fname, VarState(Any, false), changes, false)
-                end
-            elseif hd === :code_coverage_effect ||
-                    (hd !== :boundscheck && # :boundscheck can be narrowed to Bool
-                    hd !== nothing && is_meta_expr_head(hd))
-                # these do not generate code
-            else
-                t = abstract_eval_statement(interp, stmt, changes, frame)
-                if t === Bottom
-                    continue
-                end
-                if !isempty(frame.ssavalue_uses[pc])
-                    record_ssa_assign(pc, t, frame)
-                else
-                    ssavaluetypes[pc] = t
-                end
-            end
-            if isa(changes, StateUpdate)
-                let cur_hand = frame.handler_at[pc], l, enter
+            if changes !== nothing
+                stoverwrite1!(frame.pc_vartable, changes)
+                # TODO propagate_exception_slots!(frame, changes)
+                let cur_hand = frame.handler_at[frame.currpc], l, enter
                     while cur_hand != 0
-                        enter = frame.src.code[cur_hand]
-                        l = (enter::Expr).args[1]::Int
+                        enter = frame.src.code[cur_hand]::Expr
+                        l = enter.args[1]::Int
+                        exceptbb = block_for_inst(frame.cfg, l)
                         # propagate new type info to exception handler
                         # the handling for Expr(:enter) propagates all changes from before the try/catch
                         # so this only needs to propagate any changes
-                        if stupdate1!(states[l]::VarTable, changes::StateUpdate) !== false
-                            push!(W, l)
+                        if stupdate1!(frame.bb_vartables[exceptbb], changes) || !was_reached(frame, first(bbs[exceptbb].stmts))
+                            push!(frame.ip, exceptbb)
                         end
                         cur_hand = frame.handler_at[cur_hand]
                     end
                 end
             end
+            if type === nothing
+                ssavaluetypes[frame.currpc] = Any
+                continue
+            end
+            if !isempty(frame.ssavalue_uses[frame.currpc])
+                record_ssa_assign!(frame.currpc, type, frame)
+            else
+                ssavaluetypes[frame.currpc] = type
+            end
         end
 
-        @assert isempty(frame.pclimitations) "unhandled LimitedAccuracy"
+    # Case 1: Fallthrough termination
+    @label fallthrough
+        nextbb = frame.currbb + 1
 
-        if t === nothing
-            # mark other reached expressions as `Any` to indicate they don't throw
-            ssavaluetypes[pc] = Any
+    # Case 2: Directly branch to a different BB
+    @label branch
+        newstate = stupdate!(frame.bb_vartables[nextbb], frame.pc_vartable)
+        if newstate !== nothing || !was_reached(frame, first(bbs[nextbb].stmts))
+            push!(W, nextbb)
+        end
+        @goto find_next_bb
+
+        # TODO: Restore optimization
+        if nextbb <= nbbs
+            newstate = stupdate!(frame.bb_vartables[nextbb], frame.pc_vartable)
+            if newstate !== nothing
+                frame.currbb = nextbb
+                frame.currpc = first(bbs[nextbb].stmts)
+                stoverwrite!(frame.pc_vartable, newstate)
+                continue
+            end
         end
 
-        newstate = stupdate!(states[pc´], changes)
-        if newstate !== nothing
-            states[pc´] = newstate
-            push!(W, pc´)
-        end
-    end
+    # Case 3: Control flow ended along the current path (converged, return or throw)
+    @label find_next_bb
+        frame.currbb = _bits_findnext(W.bits, 1)::Int # next basic block
+        frame.currbb == -1 && break # the working set is empty
+        frame.currbb > nbbs && break
+
+        frame.currpc = first(bbs[frame.currbb].stmts)
+        stoverwrite!(frame.pc_vartable, frame.bb_vartables[frame.currbb])
+    end # while frame.currbb <= nbbs
+
     frame.dont_work_on_me = false
     nothing
 end
@@ -2366,7 +2523,7 @@ function conditional_changes(changes::VarTable, @nospecialize(typ), var::SlotNum
         oldtyp isa LimitedAccuracy && (typ = tmerge(typ, LimitedAccuracy(Bottom, oldtyp.causes)))
         return StateUpdate(var, VarState(typ, false), changes, true)
     end
-    return changes
+    return nothing
 end
 
 function bool_rt_to_conditional(@nospecialize(rt), slottypes::Vector{Any}, state::VarTable, slot_id::Int)

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -128,6 +128,14 @@ include("compiler/utilities.jl")
 include("compiler/validation.jl")
 include("compiler/methodtable.jl")
 
+function argextype end # imported by EscapeAnalysis
+function stmt_effect_free end # imported by EscapeAnalysis
+function alloc_array_ndims end # imported by EscapeAnalysis
+function try_compute_field end # imported by EscapeAnalysis
+include("compiler/ssair/basicblock.jl")
+include("compiler/ssair/domtree.jl")
+include("compiler/ssair/ir.jl")
+
 include("compiler/inferenceresult.jl")
 include("compiler/inferencestate.jl")
 

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -88,6 +88,7 @@ mutable struct OptimizationState
     linfo::MethodInstance
     src::CodeInfo
     ir::Union{Nothing, IRCode}
+    was_reached::Union{Nothing, BitSet}
     stmt_info::Vector{Any}
     mod::Module
     sptypes::Vector{Any} # static parameters
@@ -100,7 +101,7 @@ mutable struct OptimizationState
             WorldView(code_cache(interp), frame.world),
             interp)
         return new(frame.linfo,
-                   frame.src, nothing, frame.stmt_info, frame.mod,
+                   frame.src, nothing, frame.was_reached, frame.stmt_info, frame.mod,
                    frame.sptypes, frame.slottypes, inlining)
     end
     function OptimizationState(linfo::MethodInstance, src::CodeInfo, params::OptimizationParams, interp::AbstractInterpreter)
@@ -128,10 +129,12 @@ mutable struct OptimizationState
             WorldView(code_cache(interp), get_world_counter()),
             interp)
         return new(linfo,
-                   src, nothing, stmt_info, mod,
+                   src, nothing, nothing, stmt_info, mod,
                    sptypes_from_meth_instance(linfo), slottypes, inlining)
     end
 end
+
+was_reached((; was_reached)::OptimizationState, pc::Int) = was_reached === nothing || pc in was_reached
 
 function OptimizationState(linfo::MethodInstance, params::OptimizationParams, interp::AbstractInterpreter)
     src = retrieve_code_info(linfo)
@@ -551,20 +554,13 @@ function run_passes(ci::CodeInfo, sv::OptimizationState, caller::InferenceResult
 end
 
 function convert_to_ircode(ci::CodeInfo, sv::OptimizationState)
-    code = copy_exprargs(ci.code)
     coverage = coverage_enabled(sv.mod)
-    # Go through and add an unreachable node after every
-    # Union{} call. Then reindex labels.
-    idx = 1
-    oldidx = 1
-    changemap = fill(0, length(code))
-    prevloc = zero(eltype(ci.codelocs))
-    stmtinfo = sv.stmt_info
-    codelocs = ci.codelocs
-    ssavaluetypes = ci.ssavaluetypes::Vector{Any}
-    ssaflags = ci.ssaflags
+    linetable = ci.linetable
+    if !isa(linetable, Vector{LineInfoNode})
+        linetable = collect(LineInfoNode, linetable::Vector{Any})::Vector{LineInfoNode}
+    end
     if !coverage && JLOptions().code_coverage == 3 # path-specific coverage mode
-        for line in ci.linetable
+        for line in linetable
             if is_file_tracked(line.file)
                 # if any line falls in a tracked file enable coverage for all
                 coverage = true
@@ -572,8 +568,39 @@ function convert_to_ircode(ci::CodeInfo, sv::OptimizationState)
             end
         end
     end
+    # Go through and add an unreachable node after every
+    # Union{} call. Then reindex labels
+    code = copy_exprargs(ci.code)
+    stmtinfo = sv.stmt_info
+    codelocs = ci.codelocs
+    ssavaluetypes = ci.ssavaluetypes::Vector{Any}
+    ssaflags = ci.ssaflags
+    meta = Any[]
+    idx = 1
+    oldidx = 1
+    changemap = fill(0, length(code))
     labelmap = coverage ? fill(0, length(code)) : changemap
+    prevloc = zero(eltype(ci.codelocs))
     while idx <= length(code)
+        stmt = code[idx]
+        if process_meta!(meta, stmt) || !was_reached(sv, oldidx)
+            if oldidx < length(labelmap)
+                changemap[oldidx] != 0 && (changemap[oldidx+1] = changemap[oldidx])
+                if coverage && labelmap[oldidx] != 0
+                    labelmap[oldidx + 1] = labelmap[oldidx]
+                end
+                changemap[oldidx] = -1
+                coverage && (labelmap[oldidx] = -1)
+            end
+            # TODO: It would be more efficient to do this in bulk
+            deleteat!(code, idx)
+            deleteat!(codelocs, idx)
+            deleteat!(ssavaluetypes, idx)
+            deleteat!(stmtinfo, idx)
+            deleteat!(ssaflags, idx)
+            oldidx += 1
+            continue
+        end
         codeloc = codelocs[idx]
         if coverage && codeloc != prevloc && codeloc != 0
             # insert a side-effect instruction before the current instruction in the same basic block
@@ -589,7 +616,16 @@ function convert_to_ircode(ci::CodeInfo, sv::OptimizationState)
             idx += 1
             prevloc = codeloc
         end
-        if code[idx] isa Expr && ssavaluetypes[idx] === Union{}
+        if isa(stmt, GotoIfNot)
+            # replace GotoIfNot with:
+            # - GotoNode if the fallthrough target is unreachable
+            # - no-op if the branch target is unreachable
+            if !was_reached(sv, oldidx + 1)
+                code[idx] = GotoNode(stmt.dest)
+            elseif !was_reached(sv, stmt.dest)
+                code[idx] = nothing
+            end
+        elseif stmt isa Expr && ssavaluetypes[idx] === Union{}
             if !(idx < length(code) && isa(code[idx + 1], ReturnNode) && !isdefined((code[idx + 1]::ReturnNode), :val))
                 # insert unreachable in the same basic block after the current instruction (splitting it)
                 insert!(code, idx + 1, ReturnNode())
@@ -607,34 +643,23 @@ function convert_to_ircode(ci::CodeInfo, sv::OptimizationState)
         idx += 1
         oldidx += 1
     end
+
     renumber_ir_elements!(code, changemap, labelmap)
 
-    meta = Any[]
-    for i = 1:length(code)
-        code[i] = remove_meta!(code[i], meta)
-    end
     strip_trailing_junk!(ci, code, stmtinfo)
-    cfg = compute_basic_blocks(code)
     types = Any[]
     stmts = InstructionStream(code, types, stmtinfo, codelocs, ssaflags)
-    linetable = ci.linetable
-    isa(linetable, Vector{LineInfoNode}) || (linetable = collect(LineInfoNode, linetable::Vector{Any}))
-    ir = IRCode(stmts, cfg, linetable, sv.slottypes, meta, sv.sptypes)
-    return ir
+    cfg = compute_basic_blocks(code)
+    return IRCode(stmts, cfg, linetable, sv.slottypes, meta, sv.sptypes)
 end
 
-function remove_meta!(@nospecialize(stmt), meta::Vector{Any})
-    if isa(stmt, Expr)
-        head = stmt.head
-        if head === :meta
-            args = stmt.args
-            if length(args) > 0
-                push!(meta, stmt)
-            end
-            return nothing
-        end
+function process_meta!(meta::Vector{Any}, @nospecialize stmt)
+    isa(stmt, Expr) || return false
+    stmt.head === :meta || return false
+    if length(stmt.args) > 0
+        push!(meta, stmt)
     end
-    return stmt
+    return true
 end
 
 function slot2reg(ir::IRCode, ci::CodeInfo, sv::OptimizationState)
@@ -796,7 +821,9 @@ end
 
 function cumsum_ssamap!(ssamap::Vector{Int})
     rel_change = 0
+    any_change = false
     for i = 1:length(ssamap)
+        any_change = any_change || ssamap[i] != 0
         rel_change += ssamap[i]
         if ssamap[i] == -1
             # Keep a marker that this statement was deleted
@@ -805,16 +832,15 @@ function cumsum_ssamap!(ssamap::Vector{Int})
             ssamap[i] = rel_change
         end
     end
+    return any_change
 end
 
 function renumber_ir_elements!(body::Vector{Any}, ssachangemap::Vector{Int}, labelchangemap::Vector{Int})
-    cumsum_ssamap!(labelchangemap)
+    any_change = cumsum_ssamap!(labelchangemap)
     if ssachangemap !== labelchangemap
-        cumsum_ssamap!(ssachangemap)
+        any_change = cumsum_ssamap!(ssachangemap)
     end
-    if labelchangemap[end] == 0 && ssachangemap[end] == 0
-        return
-    end
+    any_change || return
     for i = 1:length(body)
         el = body[i]
         if isa(el, GotoNode)
@@ -824,7 +850,8 @@ function renumber_ir_elements!(body::Vector{Any}, ssachangemap::Vector{Int}, lab
             if isa(cond, SSAValue)
                 cond = SSAValue(cond.id + ssachangemap[cond.id])
             end
-            body[i] = GotoIfNot(cond, el.dest + labelchangemap[el.dest])
+            was_deleted = labelchangemap[el.dest] == typemin(Int)
+            body[i] = was_deleted ? cond : GotoIfNot(cond, el.dest + labelchangemap[el.dest])
         elseif isa(el, ReturnNode)
             if isdefined(el, :val)
                 val = el.val

--- a/base/compiler/ssair/driver.jl
+++ b/base/compiler/ssair/driver.jl
@@ -8,14 +8,6 @@ else
     end
 end
 
-function argextype end # imported by EscapeAnalysis
-function stmt_effect_free end # imported by EscapeAnalysis
-function alloc_array_ndims end # imported by EscapeAnalysis
-function try_compute_field end # imported by EscapeAnalysis
-
-include("compiler/ssair/basicblock.jl")
-include("compiler/ssair/domtree.jl")
-include("compiler/ssair/ir.jl")
 include("compiler/ssair/slot2ssa.jl")
 include("compiler/ssair/inlining.jl")
 include("compiler/ssair/verify.jl")

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -736,7 +736,7 @@ function dominates_ssa(compact::IncrementalCompact, domtree::DomTree, x::AnySSAV
             elseif xinfo !== nothing
                 return !xinfo.attach_after
             else
-                return yinfo.attach_after
+                return (yinfo::NewNodeInfo).attach_after
             end
         end
         return x′.id < y′.id

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -424,11 +424,38 @@ function stupdate!(state::VarTable, changes::StateUpdate)
     return newstate
 end
 
-function stupdate!(state::VarTable, changes::VarTable)
+function stupdate!(state::VarTable, changes::VarTable, ::Nothing=nothing)
     newstate = nothing
     for i = 1:length(state)
         newtype = changes[i]
         oldtype = state[i]
+        if schanged(newtype, oldtype)
+            newstate = state
+            state[i] = smerge(oldtype, newtype)
+        end
+    end
+    return newstate
+end
+
+function stupdate!(state::VarTable, changes::VarTable, update::StateUpdate)
+    newstate = nothing
+    changeid = slot_id(update.var)
+    for i = 1:length(state)
+        if i == changeid
+            newtype = update.vtype
+        else
+            newtype = changes[i]
+        end
+        oldtype = state[i]
+        # remove any Conditional for this slot from the vtable
+        # (unless this change is came from the conditional)
+        if !update.conditional && isa(newtype, VarState)
+            newtypetyp = ignorelimited(newtype.typ)
+            if isa(newtypetyp, Conditional) && slot_id(newtypetyp.var) == changeid
+                newtypetyp = widenwrappedconditional(newtype.typ)
+                newtype = VarState(newtypetyp, newtype.undef)
+            end
+        end
         if schanged(newtype, oldtype)
             newstate = state
             state[i] = smerge(oldtype, newtype)
@@ -469,3 +496,36 @@ function stupdate1!(state::VarTable, change::StateUpdate)
     end
     return false
 end
+
+function stoverwrite!(state::VarTable, newstate::VarTable)
+    for i = 1:length(state)
+        state[i] = newstate[i]
+    end
+    return nothing
+end
+
+function stoverwrite1!(state::VarTable, change::StateUpdate)
+    changeid = slot_id(change.var)
+    # remove any Conditional for this slot from the catch block vtable
+    # (unless this change is came from the conditional)
+    if !change.conditional
+        for i = 1:length(state)
+            oldtype = state[i]
+            if isa(oldtype, VarState)
+                oldtypetyp = ignorelimited(oldtype.typ)
+                if isa(oldtypetyp, Conditional) && slot_id(oldtypetyp.var) == changeid
+                    oldtypetyp = widenconditional(oldtypetyp)
+                    if oldtype.typ isa LimitedAccuracy
+                        oldtypetyp = LimitedAccuracy(oldtypetyp, (oldtype.typ::LimitedAccuracy).causes)
+                    end
+                    state[i] = VarState(oldtypetyp, oldtype.undef)
+                end
+            end
+        end
+    end
+    # and update the type of it
+    newtype = change.vtype
+    state[changeid] = newtype
+    return nothing
+end
+stoverwrite1!(state::VarTable, ::Nothing) = nothing

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4133,3 +4133,6 @@ end |> !Core.Compiler.is_concrete_eval_eligible
 @test !fully_eliminated() do
     entry_to_be_invalidated('a')
 end
+@test Base.infer_effects((Int,)) do n
+    for i = 1:n; end
+end |> !Core.Compiler.is_terminates


### PR DESCRIPTION
Currently inference uses `O(<number of statements>*<number of slots>)` state
in the core inference loop. This is usually fine, because users don't tend
to write functions that are particularly long. However, MTK does generate
functions that are excessively long and we've observed MTK models that spend
99% of their inference time just allocating and copying this state.
It is possible to get away with significantly smaller state, and this PR is
a first step in that direction, reducing the state to `O(<number of basic blocks>*<number of slots>)`.
Further improvements are possible by making use of slot liveness information
and only storing those slots that are live across a particular basic block.

The core change here is to keep a full set of slottypes only at
basic block boundaries rather than at each statement. For statements
in between, the full variable state can be fully recovered by
linearly scanning throught the basic block, taking note of
slot assignments (together with the SSA type) and NewVarNodes.

The current status of this branch is that the changes appear correct
(no known functional regressions) and significantly improve the MTK
test cases in question (no exact benchmarks here for now, since
the branch still needs a number of fixes before final numbers make
sense), but somewhat regress optimizer quality (which is expected
and just a missing TODO) and bootstrap time (which is not expected
and something I need to dig into).
