### PR TITLE
inference: always use const-prop'ed result

### DIFF
--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -895,3 +895,15 @@ end
 # sqrt not considered volatile
 f_sqrt() = sqrt(2)
 @test fully_eliminated(f_sqrt, Tuple{})
+
+# use constant prop' result even when the return type doesn't get refined
+const Gx = Ref{Any}()
+Base.@constprop :aggressive function conditional_escape!(cnd, x)
+    if cnd
+        Gx[] = x
+    end
+    return nothing
+end
+@test fully_eliminated((String,)) do x
+    Base.@invoke conditional_escape!(false::Any, x::Any)
+end


### PR DESCRIPTION
Previously, for `invoke`/opaque closure callsite, we use constant-prop'ed
method body only when the inferred return type gets strictly improved
by const-prop. But since the inliner is now able to inline the method
body from `InferenceResult`, I believe it is always better to use method
body shaped up by const-prop' no matter if the return type is improved
(as we already do for ordinal call sites).

> use constant prop' result even when the return type doesn't get refined
```julia
const Gx = Ref{Any}()
Base.@constprop :aggressive function conditional_escape!(cnd, x)
    if cnd
        Gx[] = x
    end
    return nothing
end
@test fully_eliminated((String,)) do x
    Base.@invoke conditional_escape!(false::Any, x::Any)
end
```