### PR TITLE
llvm-cpufeatures: get TargetMachine from the MachineModuleInfoWrapperPass pass

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -20,6 +20,7 @@
 #include <llvm/Analysis/BasicAliasAnalysis.h>
 #include <llvm/Analysis/TypeBasedAliasAnalysis.h>
 #include <llvm/Analysis/ScopedNoAliasAA.h>
+#include <llvm/CodeGen/MachineModuleInfo.h>
 #include <llvm/IR/Verifier.h>
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/Scalar.h>
@@ -592,6 +593,7 @@ void jl_dump_native_impl(void *native_code,
 
 void addTargetPasses(legacy::PassManagerBase *PM, TargetMachine *TM)
 {
+    PM->add(new MachineModuleInfoWrapperPass(static_cast<const LLVMTargetMachine*>(TM))); // do as llc does, not as it says
     PM->add(new TargetLibraryInfoWrapperPass(Triple(TM->getTargetTriple())));
     PM->add(createTargetTransformInfoWrapperPass(TM->getTargetIRAnalysis()));
 }

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -34,6 +34,7 @@
     _Z22jl_coverage_alloc_lineN4llvm9StringRefEi;
     _Z22jl_malloc_data_pointerN4llvm9StringRefEi;
     LLVMExtra*;
+    llvmGetPassPluginInfo;
 
     /* freebsd */
     environ;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1378,6 +1378,7 @@ static jl_value_t *jl_read_value(jl_serializer_state *s)
     return (jl_value_t*)get_item_for_reloc(s, base, size, offset);
 }
 
+JL_DLLEXPORT int32_t (*jl_sysimg_cpuflags[3])(void);
 
 static void jl_update_all_fptrs(jl_serializer_state *s)
 {
@@ -1389,7 +1390,6 @@ static void jl_update_all_fptrs(jl_serializer_state *s)
         return;
     int sysimg_fvars_max = s->fptr_record->size / sizeof(void*);
     size_t i;
-    uintptr_t base = (uintptr_t)&s->s->buf[0];
     jl_method_instance_t **linfos = (jl_method_instance_t**)&s->fptr_record->buf[0];
     uint32_t clone_idx = 0;
     for (i = 0; i < sysimg_fvars_max; i++) {
@@ -1403,8 +1403,8 @@ static void jl_update_all_fptrs(jl_serializer_state *s)
                 specfunc = 0;
                 offset = ~offset;
             }
+            uintptr_t base = (uintptr_t)&s->s->buf[0];
             jl_code_instance_t *codeinst = (jl_code_instance_t*)(base + offset);
-            uintptr_t base = (uintptr_t)fvars.base;
             assert(jl_is_method(codeinst->def->def.method) && codeinst->invoke != jl_fptr_const_return);
             assert(specfunc ? codeinst->invoke != NULL : codeinst->invoke == NULL);
             linfos[i] = codeinst->def;
@@ -1417,7 +1417,7 @@ static void jl_update_all_fptrs(jl_serializer_state *s)
                     offset = fvars.clone_offsets[clone_idx];
                 break;
             }
-            void *fptr = (void*)(base + offset);
+            void *fptr = (void*)((uintptr_t)fvars.base + offset);
             if (specfunc) {
                 codeinst->specptr.fptr = fptr;
                 codeinst->isspecsig = 1; // TODO: set only if confirmed to be true
@@ -1428,6 +1428,20 @@ static void jl_update_all_fptrs(jl_serializer_state *s)
         }
     }
     jl_register_fptrs(sysimage_base, &fvars, linfos, sysimg_fvars_max);
+    // now populate the feature flags accessors too
+    for (; i < sysimg_fvars_max + 3; i++) {
+        int32_t offset = fvars.offsets[i];
+        for (; clone_idx < fvars.nclones; clone_idx++) {
+            uint32_t idx = fvars.clone_idxs[clone_idx] & jl_sysimg_val_mask;
+            if (idx < i)
+                continue;
+            if (idx == i)
+                offset = fvars.clone_offsets[clone_idx];
+            break;
+        }
+        void *fptr = (void*)((uintptr_t)fvars.base + offset);
+        ((void**)jl_sysimg_cpuflags)[i - sysimg_fvars_max] = fptr;
+    }
 }
 
 

--- a/test/llvmpasses/Makefile
+++ b/test/llvmpasses/Makefile
@@ -4,7 +4,7 @@ include $(JULIAHOME)/Make.inc
 
 check: .
 
-TESTS = $(patsubst $(SRCDIR)/%,%,$(wildcard $(SRCDIR)/*.jl $(SRCDIR)/*.ll))
+TESTS = $(patsubst $(SRCDIR)/%,%,$(wildcard $(SRCDIR)/*.jl $(SRCDIR)/*.ll  $(SRCDIR)/*.mir))
 
 . $(TESTS):
 	PATH=$(build_bindir):$(build_depsbindir):$$PATH \

--- a/test/llvmpasses/havefma.ll
+++ b/test/llvmpasses/havefma.ll
@@ -1,0 +1,24 @@
+; RUNx: opt --mtriple=`llvm-config --host-target` -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='require<machine-module>,CPUFeatures' -S %s | FileCheck %s --check-prefixes=CHECK,CHECK-any
+; RUNx: opt --mtriple=x86_64-unknown-linux-gnu -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='require<machine-module>,CPUFeatures' -S %s | FileCheck %s --check-prefixes=CHECK,CHECK-generic
+; RUNx: opt --mtriple=aarch64-unknown-linux-gnu -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='require<machine-module>,CPUFeatures' -S %s | FileCheck %s --check-prefixes=CHECK,CHECK-aarch64
+; RUNx: opt --mtriple=x86_64-unknown-linux-gnu --march=avx512 -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='require<machine-module>,CPUFeatures' -S %s | FileCheck %s --check-prefixes=CHECK,CHECK-avx512
+; RUN: true
+
+declare i1 @julia.cpu.have_fma.f32()
+declare i1 @julia.cpu.have_fma.f64()
+
+; CHECK-LABEL: @havefma_test(
+; CHECK-LABEL: top:
+; CHECK-any-NEXT: %0 = and i1
+; CHECK-generic-NEXT: %0 = and i1 false, false
+; CHECK-avx512-NEXT: %0 = and i1 false, false
+; CHECK-aarch64-NEXT: %0 = and i1 true, true
+; CHECK-NEXT: ret i1 %0
+
+define i1 @havefma_test() {
+top:
+  %0 = call i1 @julia.cpu.have_fma.f32()
+  %1 = call i1 @julia.cpu.have_fma.f64()
+  %2 = and i1 %0, %1
+  ret i1 %2
+}

--- a/test/llvmpasses/lit.cfg.py
+++ b/test/llvmpasses/lit.cfg.py
@@ -7,7 +7,7 @@ import lit.util
 import lit.formats
 
 config.name = 'Julia'
-config.suffixes = ['.ll','.jl']
+config.suffixes = ['.ll','.mir','.jl']
 config.test_source_root = os.path.dirname(__file__)
 config.test_format = lit.formats.ShTest(True)
 config.substitutions.append(('%shlibext', '.dylib' if platform.system() == 'Darwin' else '.dll' if


### PR DESCRIPTION
This is usually only supposed to be accessible to a MachineModulePass,
but we can trick llvm to give us access to the TargetMachine here too.

Also hack in a sysimg check also, so that the compile result is ensured
to be compatible with the loaded image too (we disable loading of the
sysimg when emitting a new compile).