### PR TITLE
switch OpaqueClosure from `isva` field to separate argument tuple type

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -424,7 +424,7 @@ eval(Core, :(CodeInstance(mi::MethodInstance, @nospecialize(rettype), @nospecial
                     mi, rettype, inferred_const, inferred, const_flags, min_world, max_world, ipo_effects, effects, relocatability)))
 eval(Core, :(Const(@nospecialize(v)) = $(Expr(:new, :Const, :v))))
 eval(Core, :(PartialStruct(@nospecialize(typ), fields::Array{Any, 1}) = $(Expr(:new, :PartialStruct, :typ, :fields))))
-eval(Core, :(PartialOpaque(@nospecialize(typ), @nospecialize(env), isva::Bool, parent::MethodInstance, source::Method) = $(Expr(:new, :PartialOpaque, :typ, :env, :isva, :parent, :source))))
+eval(Core, :(PartialOpaque(@nospecialize(typ), @nospecialize(env), parent::MethodInstance, source::Method) = $(Expr(:new, :PartialOpaque, :typ, :env, :parent, :source))))
 eval(Core, :(InterConditional(slot::Int, @nospecialize(vtype), @nospecialize(elsetype)) = $(Expr(:new, :InterConditional, :slot, :vtype, :elsetype))))
 eval(Core, :(MethodMatch(@nospecialize(spec_types), sparams::SimpleVector, method::Method, fully_covers::Bool) =
     $(Expr(:new, :MethodMatch, :spec_types, :sparams, :method, :fully_covers))))

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -235,16 +235,15 @@ function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src::Union{IRC
         elseif head === :foreigncall
             return foreigncall_effect_free(stmt, src)
         elseif head === :new_opaque_closure
-            length(args) < 5 && return false
+            length(args) < 4 && return false
             typ = argextype(args[1], src)
             typ, isexact = instanceof_tfunc(typ)
             isexact || return false
             typ ⊑ Tuple || return false
-            isva = argextype(args[2], src)
-            rt_lb = argextype(args[3], src)
-            rt_ub = argextype(args[4], src)
-            src = argextype(args[5], src)
-            if !(isva ⊑ Bool && rt_lb ⊑ Type && rt_ub ⊑ Type && src ⊑ Method)
+            rt_lb = argextype(args[2], src)
+            rt_ub = argextype(args[3], src)
+            src = argextype(args[4], src)
+            if !(rt_lb ⊑ Type && rt_ub ⊑ Type && src ⊑ Method)
                 return false
             end
             return true

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1056,10 +1056,10 @@ end
 
 function narrow_opaque_closure!(ir::IRCode, stmt::Expr, @nospecialize(info), state::InliningState)
     if isa(info, OpaqueClosureCreateInfo)
-        lbt = argextype(stmt.args[3], ir)
+        lbt = argextype(stmt.args[2], ir)
         lb, exact = instanceof_tfunc(lbt)
         exact || return
-        ubt = argextype(stmt.args[4], ir)
+        ubt = argextype(stmt.args[3], ir)
         ub, exact = instanceof_tfunc(ubt)
         exact || return
         # Narrow opaque closure type
@@ -1068,7 +1068,7 @@ function narrow_opaque_closure!(ir::IRCode, stmt::Expr, @nospecialize(info), sta
             # N.B.: Narrowing the ub requires a backdge on the mi whose type
             # information we're using, since a change in that function may
             # invalidate ub result.
-            stmt.args[4] = newT
+            stmt.args[3] = newT
         end
     end
 end

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -3,7 +3,7 @@
 function inflate_ir(ci::CodeInfo, linfo::MethodInstance)
     sptypes = sptypes_from_meth_instance(linfo)
     if ci.inferred
-        argtypes, _ = matching_cache_argtypes(linfo, nothing, false)
+        argtypes, _ = matching_cache_argtypes(linfo, nothing)
     else
         argtypes = Any[ Any for i = 1:length(ci.slotflags) ]
     end

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -393,8 +393,8 @@ function lift_leaves(compact::IncrementalCompact,
                     ocleaf = simple_walk(compact, ocleaf)
                 end
                 ocdef, _ = walk_to_def(compact, ocleaf)
-                if isexpr(ocdef, :new_opaque_closure) && isa(field, Int) && 1 ≤ field ≤ length(ocdef.args)-5
-                    lift_arg!(compact, leaf, cache_key, ocdef, 5+field, lifted_leaves)
+                if isexpr(ocdef, :new_opaque_closure) && isa(field, Int) && 1 ≤ field ≤ length(ocdef.args)-4
+                    lift_arg!(compact, leaf, cache_key, ocdef, 4+field, lifted_leaves)
                     continue
                 end
                 return nothing

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1580,9 +1580,8 @@ function array_elmtype(@nospecialize ary)
     return Any
 end
 
-function _opaque_closure_tfunc(@nospecialize(arg), @nospecialize(isva),
-        @nospecialize(lb), @nospecialize(ub), @nospecialize(source), env::Vector{Any},
-        linfo::MethodInstance)
+function _opaque_closure_tfunc(@nospecialize(arg), @nospecialize(lb), @nospecialize(ub),
+        @nospecialize(source), env::Vector{Any}, linfo::MethodInstance)
 
     argt, argt_exact = instanceof_tfunc(arg)
     lbt, lb_exact = instanceof_tfunc(lb)
@@ -1596,9 +1595,8 @@ function _opaque_closure_tfunc(@nospecialize(arg), @nospecialize(isva),
     t = lbt == ubt ? t{ubt} : (t{T} where lbt <: T <: ubt)
 
     (isa(source, Const) && isa(source.val, Method)) || return t
-    (isa(isva, Const) && isa(isva.val, Bool)) || return t
 
-    return PartialOpaque(t, tuple_tfunc(env), isva.val, linfo, source.val)
+    return PartialOpaque(t, tuple_tfunc(env), linfo, source.val)
 end
 
 # whether getindex for the elements can potentially throw UndefRef

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -428,12 +428,11 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
     end
     if isa(typea, PartialOpaque) && isa(typeb, PartialOpaque) && widenconst(typea) == widenconst(typeb)
         if !(typea.source === typeb.source &&
-             typea.isva === typeb.isva &&
              typea.parent === typeb.parent)
             return widenconst(typea)
         end
         return PartialOpaque(typea.typ, tmerge(typea.env, typeb.env),
-            typea.isva, typea.parent, typea.source)
+            typea.parent, typea.source)
     end
     # no special type-inference lattice, join the types
     typea, typeb = widenconst(typea), widenconst(typeb)

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -126,9 +126,8 @@ mutable struct InferenceResult
     ipo_effects::Effects # if inference is finished
     effects::Effects # if optimization is finished
     function InferenceResult(linfo::MethodInstance,
-                             arginfo#=::Union{Nothing,Tuple{ArgInfo,InferenceState}}=# = nothing,
-                             va_override::Bool = false)
-        argtypes, overridden_by_const = matching_cache_argtypes(linfo, arginfo, va_override)
+                             arginfo#=::Union{Nothing,Tuple{ArgInfo,InferenceState}}=# = nothing)
+        argtypes, overridden_by_const = matching_cache_argtypes(linfo, arginfo)
         return new(linfo, argtypes, overridden_by_const, Any, nothing, WorldRange(), Effects(), Effects())
     end
 end

--- a/base/opaque_closure.jl
+++ b/base/opaque_closure.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 """
-    @opaque (args...) -> body
+    @opaque ([type, ]args...) -> body
 
 Marks a given closure as "opaque". Opaque closures capture the
 world age of their creation (as opposed to their invocation).
@@ -10,9 +10,17 @@ list, but trades off against the ability to inline opaque
 closures at the call site, if their creation is not statically
 visible.
 
+An argument tuple type (`type`) may optionally be specified, to
+specify allowed argument types in a more flexible way. In particular,
+the argument type may be fixed length even if the function is variadic.
+
 !!! warning
     This interface is experimental and subject to change or removal without notice.
 """
 macro opaque(ex)
     esc(Expr(:opaque_closure, ex))
+end
+
+macro opaque(ty, ex)
+    esc(Expr(:opaque_closure, ty, ex))
 end

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2782,8 +2782,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
         jl_code_info_t *src,
         jl_value_t *jlrettype,
         jl_codegen_params_t &params,
-        LLVMContext &ctxt,
-        bool vaOverride = false);
+        LLVMContext &ctxt);
 
 static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                               const jl_cgval_t *argv, size_t nargs, jl_value_t *rt,
@@ -4554,7 +4553,7 @@ static void emit_stmtpos(jl_codectx_t &ctx, jl_value_t *expr, int ssaval_result)
     }
 }
 
-static std::pair<Function*, Function*> get_oc_function(jl_codectx_t &ctx, jl_method_t *closure_method, jl_tupletype_t *env_t, jl_tupletype_t *argt_typ, jl_value_t *rettype, bool vaOverride)
+static std::pair<Function*, Function*> get_oc_function(jl_codectx_t &ctx, jl_method_t *closure_method, jl_tupletype_t *env_t, jl_tupletype_t *argt_typ, jl_value_t *rettype)
 {
     jl_svec_t *sig_args = NULL;
     jl_value_t *sigtype = NULL;
@@ -4583,7 +4582,7 @@ static std::pair<Function*, Function*> get_oc_function(jl_codectx_t &ctx, jl_met
     std::unique_ptr<Module> closure_m;
     jl_llvm_functions_t closure_decls;
     std::tie(closure_m, closure_decls) = emit_function(mi, ir, rettype, ctx.emission_context,
-                                                       ctx.builder.getContext(), vaOverride);
+                                                       ctx.builder.getContext());
 
     assert(closure_decls.functionObject != "jl_fptr_sparam");
     bool isspecsig = closure_decls.functionObject != "jl_fptr_args";
@@ -4868,16 +4867,15 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
         return mark_julia_type(ctx, val, true, (jl_value_t*)jl_any_type);
     }
     else if (head == jl_new_opaque_closure_sym) {
-        assert(nargs >= 5 && "Not enough arguments in new_opaque_closure");
-        SmallVector<jl_cgval_t, 5> argv(nargs, jl_cgval_t(ctx.builder.getContext()));
+        assert(nargs >= 4 && "Not enough arguments in new_opaque_closure");
+        SmallVector<jl_cgval_t, 4> argv(nargs, jl_cgval_t(ctx.builder.getContext()));
         for (size_t i = 0; i < nargs; ++i) {
             argv[i] = emit_expr(ctx, args[i]);
         }
         const jl_cgval_t &argt = argv[0];
-        const jl_cgval_t &isva = argv[1];
-        const jl_cgval_t &lb = argv[2];
-        const jl_cgval_t &ub = argv[3];
-        const jl_cgval_t &source = argv[4];
+        const jl_cgval_t &lb = argv[1];
+        const jl_cgval_t &ub = argv[2];
+        const jl_cgval_t &source = argv[3];
         if (source.constant == NULL) {
             // For now, we require non-constant source to be handled by using
             // eval. This should probably be a verifier error and an abort here.
@@ -4885,30 +4883,27 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
             return jl_cgval_t(ctx.builder.getContext());
         }
         bool can_optimize = argt.constant != NULL && lb.constant != NULL && ub.constant != NULL &&
-            isva.constant != NULL &&
-            jl_is_tuple_type(argt.constant) && jl_is_bool(isva.constant) &&
-            jl_is_type(lb.constant) && jl_is_type(ub.constant) && jl_is_method(source.constant);
-
-        if (can_optimize) {
-            can_optimize &= ((jl_method_t*)source.constant)->nargs > 0 || !jl_unbox_bool(isva.constant);
-        }
+            jl_is_tuple_type(argt.constant) &&
+            jl_is_type(lb.constant) && jl_is_type(ub.constant) && jl_is_method(source.constant) &&
+            ((jl_method_t*)source.constant)->nargs > 0 &&
+            jl_is_valid_oc_argtype((jl_tupletype_t*)argt.constant, (jl_method_t*)source.constant);
 
         if (can_optimize) {
             jl_value_t *closure_t = NULL;
             jl_tupletype_t *env_t = NULL;
             JL_GC_PUSH2(&closure_t, &env_t);
 
-            jl_value_t **env_component_ts = (jl_value_t**)alloca(sizeof(jl_value_t*) * (nargs-5));
-            for (size_t i = 0; i < nargs - 5; ++i) {
-                env_component_ts[i] = argv[5+i].typ;
+            jl_value_t **env_component_ts = (jl_value_t**)alloca(sizeof(jl_value_t*) * (nargs-4));
+            for (size_t i = 0; i < nargs - 4; ++i) {
+                env_component_ts[i] = argv[4+i].typ;
             }
 
-            env_t = jl_apply_tuple_type_v(env_component_ts, nargs-5);
+            env_t = jl_apply_tuple_type_v(env_component_ts, nargs-4);
             // we need to know the full env type to look up the right specialization
             if (jl_is_concrete_type((jl_value_t*)env_t)) {
                 jl_tupletype_t *argt_typ = (jl_tupletype_t*)argt.constant;
                 Function *F, *specF;
-                std::tie(F, specF) = get_oc_function(ctx, (jl_method_t*)source.constant, env_t, argt_typ, ub.constant, jl_unbox_bool(isva.constant));
+                std::tie(F, specF) = get_oc_function(ctx, (jl_method_t*)source.constant, env_t, argt_typ, ub.constant);
                 if (F) {
                     jl_cgval_t jlcall_ptr = mark_julia_type(ctx, F, false, jl_voidpointer_type);
                     jl_cgval_t world_age = mark_julia_type(ctx,
@@ -4923,11 +4918,10 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
                         fptr = mark_julia_type(ctx, (llvm::Value*)Constant::getNullValue(getSizeTy(ctx.builder.getContext())), false, jl_voidpointer_type);
 
                     // TODO: Inline the env at the end of the opaque closure and generate a descriptor for GC
-                    jl_cgval_t env = emit_new_struct(ctx, (jl_value_t*)env_t, nargs-5, &argv.data()[5]);
+                    jl_cgval_t env = emit_new_struct(ctx, (jl_value_t*)env_t, nargs-4, &argv.data()[4]);
 
-                    jl_cgval_t closure_fields[6] = {
+                    jl_cgval_t closure_fields[5] = {
                         env,
-                        isva,
                         world_age,
                         source,
                         jlcall_ptr,
@@ -4935,7 +4929,7 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
                     };
 
                     closure_t = jl_apply_type2((jl_value_t*)jl_opaque_closure_type, (jl_value_t*)argt_typ, ub.constant);
-                    jl_cgval_t ret = emit_new_struct(ctx, closure_t, 6, closure_fields);
+                    jl_cgval_t ret = emit_new_struct(ctx, closure_t, 5, closure_fields);
 
                     JL_GC_POP();
                     return ret;
@@ -6283,8 +6277,7 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
         jl_code_info_t *src,
         jl_value_t *jlrettype,
         jl_codegen_params_t &params,
-        LLVMContext &ctxt,
-        bool vaOverride)
+        LLVMContext &ctxt)
 {
     // step 1. unpack AST and allocate codegen context for this function
     jl_llvm_functions_t declarations;
@@ -6302,9 +6295,8 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
     if (jl_is_method(lam->def.method)) {
         ctx.nargs = nreq = lam->def.method->nargs;
         ctx.is_opaque_closure = lam->def.method->is_for_opaque_closure;
-        if (vaOverride ||
-            (nreq > 0 && jl_is_method(lam->def.value) && lam->def.method->isva)) {
-            assert(nreq > 0 && (ctx.is_opaque_closure || !vaOverride));
+        if ((nreq > 0 && jl_is_method(lam->def.value) && lam->def.method->isva)) {
+            assert(nreq > 0);
             nreq--;
             va = 1;
         }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -287,9 +287,9 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         JL_GC_PUSHARGS(argv, nargs);
         for (size_t i = 0; i < nargs; i++)
             argv[i] = eval_value(args[i], s);
-        JL_NARGSV(new_opaque_closure, 5);
+        JL_NARGSV(new_opaque_closure, 4);
         jl_value_t *ret = (jl_value_t*)jl_new_opaque_closure((jl_tupletype_t*)argv[0], argv[1], argv[2],
-            argv[3], argv[4], argv+5, nargs-5);
+            argv[3], argv+4, nargs-4);
         JL_GC_POP();
         return ret;
     }
@@ -714,7 +714,7 @@ jl_value_t *jl_interpret_opaque_closure(jl_opaque_closure_t *oc, jl_value_t **ar
     s->continue_at = 0;
     s->mi = NULL;
     size_t defargs = source->nargs;
-    int isva = !!oc->isva;
+    int isva = source->isva;
     assert(isva ? nargs + 2 >= defargs : nargs + 1 == defargs);
     for (size_t i = 1; i < defargs - isva; i++)
         s->locals[i] = args[i - 1];

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2634,16 +2634,16 @@ void jl_init_types(void) JL_GC_DISABLED
 
     tv = jl_svec2(tvar("A"), tvar("R"));
     jl_opaque_closure_type = (jl_unionall_t*)jl_new_datatype(jl_symbol("OpaqueClosure"), core, jl_function_type, tv,
-        jl_perm_symsvec(6, "captures", "isva", "world", "source", "invoke", "specptr"),
-        jl_svec(6, jl_any_type, jl_bool_type, jl_long_type, jl_any_type, pointer_void, pointer_void),
-        jl_emptysvec, 0, 0, 6)->name->wrapper;
+        jl_perm_symsvec(5, "captures", "world", "source", "invoke", "specptr"),
+        jl_svec(5, jl_any_type, jl_long_type, jl_any_type, pointer_void, pointer_void),
+        jl_emptysvec, 0, 0, 5)->name->wrapper;
     jl_opaque_closure_typename = ((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_opaque_closure_type))->name;
     jl_compute_field_offsets((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_opaque_closure_type));
 
     jl_partial_opaque_type = jl_new_datatype(jl_symbol("PartialOpaque"), core, jl_any_type, jl_emptysvec,
-        jl_perm_symsvec(5, "typ", "env", "isva", "parent", "source"),
-        jl_svec(5, jl_type_type, jl_any_type, jl_bool_type, jl_method_instance_type, jl_method_type),
-        jl_emptysvec, 0, 0, 5);
+        jl_perm_symsvec(4, "typ", "env", "parent", "source"),
+        jl_svec(4, jl_type_type, jl_any_type, jl_method_instance_type, jl_method_type),
+        jl_emptysvec, 0, 0, 4);
 
     // complete builtin type metadata
     jl_voidpointer_type = (jl_datatype_t*)pointer_void;

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1075,16 +1075,16 @@
                   (loop (if isseq F (cdr F)) (cdr A) stmts
                         (list* ty T) (list* ca C) (list* g GC)))))))))
 
+(define (just-arglist? ex)
+  (and (pair? ex)
+       (or (memq (car ex) '(tuple block ...))
+           (and (eq? (car ex) 'where)
+                (just-arglist? (cadr ex))))))
+
 (define (expand-function-def e)   ;; handle function definitions
-  (define (just-arglist? ex)
-    (and (pair? ex)
-         (or (memq (car ex) '(tuple block ...))
-             (and (eq? (car ex) 'where)
-                  (just-arglist? (cadr ex))))))
-  (let ((name (cadr e)))
-    (if (just-arglist? name)
-        (expand-forms (cons '-> (cdr e)))
-        (expand-function-def- e))))
+  (if (just-arglist? (cadr e))
+      (expand-forms (cons '-> (cdr e)))
+      (expand-function-def- e)))
 
 ;; convert (where (where x S) T) to (where x T S)
 (define (flatten-where-expr e)
@@ -1200,6 +1200,21 @@
                    `(where (call ,name ,@argl) ,@where)
                    `(call ,name ,@argl))
               ,body)))))
+
+(define (function-arglist e)
+  (cond ((eq? (car e) 'function)
+         (if (just-arglist? (cadr e))
+             (function-arglist (cons '-> (cdr e)))
+             (let* ((name  (cadr e))
+                    (dcl   (and (pair? name) (eq? (car name) '|::|)))
+                    (name  (if dcl (cadr name) name)))
+               (cddr name))))
+        ((eq? (car e) '->)
+         (let* ((a (cadr e)))
+           (if (pair? a)
+               (tuple-to-arglist (filter (lambda (x) (not (linenum? x))) a))
+               (list a))))
+        (else '())))
 
 (define (let-binds e)
   (if (and (pair? (cadr e))
@@ -2262,7 +2277,18 @@
 
    'opaque_closure
    (lambda (e)
-     (let* ((meth (caddr (caddr (expand-forms (cadr e))))) ;; `method` expr
+     (let* ((ty   (and (length> e 2) (expand-forms (cadr e))))
+            (F    (if (length> e 2) (caddr e) (cadr e)))
+            (isva (let* ((arglist (function-arglist F))
+                         (lastarg (and (pair? arglist) (last arglist))))
+                    (if (and ty (any (lambda (arg)
+                                       (let ((arg (if (vararg? arg) (cadr arg) arg)))
+                                         (not (equal? (arg-type arg) '(core Any)))))
+                                     arglist))
+                        (error "Opaque closure argument type may not be specified both in the method signature and separately"))
+                    (if (or (varargexpr? lastarg) (vararg? lastarg))
+                        '(true) '(false))))
+            (meth (caddr (caddr (expand-forms F)))) ;; `method` expr
             (lam       (cadddr meth))
             (sig-block (caddr meth))
             (sig-block (if (and (pair? sig-block) (eq? (car sig-block) 'block))
@@ -2274,15 +2300,11 @@
             (tvars     (cddr (cadddr sig-svec)))
             (argtypes  (cdddr typ-svec))
             (functionloc (cadr (caddddr sig-svec))))
-       (if (length= argtypes 0)
-        `(_opaque_closure ,(expand-forms `(curly (core Tuple))) (false) 0 ,functionloc ,lam)
-         (let* ((vssa (make-ssavalue))
-                (vval (expand-forms (last argtypes)))
-                (argtypes (append (butlast argtypes) (list `(block (= ,vssa ,vval)))))
-                (argtype   (foldl (lambda (var ex) `(call (core UnionAll) ,var ,ex))
-                                  (expand-forms `(curly (core Tuple) ,@argtypes))
-                                  (reverse tvars))))
-              `(_opaque_closure ,argtype (call (core isa) ,vssa (core TypeofVararg)) ,(length argtypes) ,functionloc ,lam)))))
+       (let* ((argtype   (foldl (lambda (var ex) `(call (core UnionAll) ,var ,ex))
+                                (expand-forms `(curly (core Tuple) ,@argtypes))
+                                (reverse tvars))))
+         `(_opaque_closure ,(or ty argtype) ,isva ,(length argtypes) ,functionloc ,lam))))
+
    'block
    (lambda (e)
      (cond ((null? (cdr e)) '(null))
@@ -3831,9 +3853,10 @@ f(x) = yt(x)
                                            (capt-var-access v fname opaq)
                                            v)))
                                    cvs)))
-               `(new_opaque_closure ,(cadr e) ,isva (call (core apply_type) Union) (core Any)
-                      (opaque_closure_method (null) ,nargs ,functionloc ,(convert-lambda lam2 (car (lam:args lam2)) #f '() (symbol-to-idx-map cvs)))
-                      ,@var-exprs))))
+               `(new_opaque_closure
+                 ,(cadr e) (call (core apply_type) Union) (core Any)
+                 (opaque_closure_method (null) ,nargs ,isva ,functionloc ,(convert-lambda lam2 (car (lam:args lam2)) #f '() (symbol-to-idx-map cvs)))
+                 ,@var-exprs))))
           ((method)
            (let* ((name  (method-expr-name e))
                   (short (length= e 2))  ;; function f end
@@ -4339,13 +4362,13 @@ f(x) = yt(x)
                               (cons (cadr e) (cons fptr (cdddr e)))))
                            ;; Leave a literal lambda in place for later global expansion
                            ((eq? (car e) 'new_opaque_closure)
-                             (let* ((oc_method (car (list-tail (cdr e) 4))) ;; opaque_closure_method
-                                    (lambda (caddddr oc_method))
-                                    (lambda (linearize lambda)))
-                                (append
-                                  (compile-args (list-head (cdr e) 4) break-labels)
-                                  (list (append (butlast oc_method) (list lambda)))
-                                  (compile-args (list-tail (cdr e) 5) break-labels))))
+                            (let* ((oc_method (car (list-tail (cdr e) 3))) ;; opaque_closure_method
+                                   (lambda (list-ref oc_method 5))
+                                   (lambda (linearize lambda)))
+                              (append
+                               (compile-args (list-head (cdr e) 3) break-labels)
+                               (list (append (butlast oc_method) (list lambda)))
+                               (compile-args (list-tail (cdr e) 4) break-labels))))
                            ;; NOTE: 1st argument to cglobal treated same as for ccall
                            ((and (length> e 2)
                                  (or (eq? (cadr e) 'cglobal)

--- a/src/julia.h
+++ b/src/julia.h
@@ -367,7 +367,6 @@ struct _jl_method_instance_t {
 typedef struct jl_opaque_closure_t {
     JL_DATA_TYPE
     jl_value_t *captures;
-    uint8_t isva;
     size_t world;
     jl_method_t *source;
     jl_fptr_args_t invoke;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -658,8 +658,9 @@ extern htable_t jl_current_modules JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_module_t *jl_precompile_toplevel_module JL_GLOBALLY_ROOTED;
 int jl_compile_extern_c(void *llvmmod, void *params, void *sysimg, jl_value_t *declrt, jl_value_t *sigt);
 
-jl_opaque_closure_t *jl_new_opaque_closure(jl_tupletype_t *argt, jl_value_t *isva, jl_value_t *rt_lb,
-    jl_value_t *rt_ub, jl_value_t *source,  jl_value_t **env, size_t nenv);
+jl_opaque_closure_t *jl_new_opaque_closure(jl_tupletype_t *argt, jl_value_t *rt_lb, jl_value_t *rt_ub,
+    jl_value_t *source,  jl_value_t **env, size_t nenv);
+JL_DLLEXPORT int jl_is_valid_oc_argtype(jl_tupletype_t *argt, jl_method_t *source);
 
 // Each tuple can exist in one of 4 Vararg states:
 //   NONE: no vararg                            Tuple{Int,Float32}

--- a/src/method.c
+++ b/src/method.c
@@ -19,7 +19,7 @@ extern jl_value_t *jl_builtin_getfield;
 extern jl_value_t *jl_builtin_tuple;
 
 jl_method_t *jl_make_opaque_closure_method(jl_module_t *module, jl_value_t *name,
-    jl_value_t *nargs, jl_value_t *functionloc, jl_code_info_t *ci);
+    jl_value_t *nargs, jl_value_t *functionloc, jl_code_info_t *ci, int isva);
 
 static void check_c_types(const char *where, jl_value_t *rt, jl_value_t *at)
 {
@@ -91,17 +91,19 @@ static jl_value_t *resolve_globals(jl_value_t *expr, jl_module_t *module, jl_sve
         else {
             size_t i = 0, nargs = jl_array_len(e->args);
             if (e->head == jl_opaque_closure_method_sym) {
-                if (nargs != 4) {
+                if (nargs != 5) {
                     jl_error("opaque_closure_method: invalid syntax");
                 }
                 jl_value_t *name = jl_exprarg(e, 0);
                 jl_value_t *nargs = jl_exprarg(e, 1);
-                jl_value_t *functionloc = jl_exprarg(e, 2);
-                jl_value_t *ci = jl_exprarg(e, 3);
+                int isva = jl_exprarg(e, 2) == jl_true;
+                jl_value_t *functionloc = jl_exprarg(e, 3);
+                jl_value_t *ci = jl_exprarg(e, 4);
                 if (!jl_is_code_info(ci)) {
                     jl_error("opaque_closure_method: lambda should be a CodeInfo");
                 }
-                return (jl_value_t*)jl_make_opaque_closure_method(module, name, nargs, functionloc, (jl_code_info_t*)ci);
+                jl_method_t *m = jl_make_opaque_closure_method(module, name, nargs, functionloc, (jl_code_info_t*)ci, isva);
+                return (jl_value_t*)m;
             }
             if (e->head == jl_cfunction_sym) {
                 JL_NARGS(cfunction method definition, 5, 5); // (type, func, rt, at, cc)
@@ -779,14 +781,13 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t *module)
 // method definition ----------------------------------------------------------
 
 jl_method_t *jl_make_opaque_closure_method(jl_module_t *module, jl_value_t *name,
-    jl_value_t *nargs, jl_value_t *functionloc, jl_code_info_t *ci)
+    jl_value_t *nargs, jl_value_t *functionloc, jl_code_info_t *ci, int isva)
 {
     jl_method_t *m = jl_new_method_uninit(module);
     JL_GC_PUSH1(&m);
     // TODO: Maybe have a signature of (parent method, stmt#)?
     m->sig = (jl_value_t*)jl_anytuple_type;
-    // Unused for opaque closures. va-ness is determined on construction
-    m->isva = 0;
+    m->isva = isva;
     m->is_for_opaque_closure = 1;
     if (name == jl_nothing) {
         m->name = jl_symbol("opaque closure");

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3720,12 +3720,12 @@ let
     Core.Compiler.replace_code_newstyle!(ci, ir, 4)
     ci.ssavaluetypes = length(ci.code)
     @test any(x->isa(x, Core.PhiNode), ci.code)
-    oc = @eval b->$(Expr(:new_opaque_closure, Tuple{Bool, Float64}, false, Any, Any,
-        Expr(:opaque_closure_method, nothing, 2, LineNumberNode(0, nothing), ci)))(b, 1.0)
+    oc = @eval b->$(Expr(:new_opaque_closure, Tuple{Bool, Float64}, Any, Any,
+        Expr(:opaque_closure_method, nothing, 2, false, LineNumberNode(0, nothing), ci)))(b, 1.0)
     @test Base.return_types(oc, Tuple{Bool}) == Any[Float64]
 
-    oc = @eval ()->$(Expr(:new_opaque_closure, Tuple{Bool, Float64}, false, Any, Any,
-        Expr(:opaque_closure_method, nothing, 2, LineNumberNode(0, nothing), ci)))(true, 1.0)
+    oc = @eval ()->$(Expr(:new_opaque_closure, Tuple{Bool, Float64}, Any, Any,
+        Expr(:opaque_closure_method, nothing, 2, false, LineNumberNode(0, nothing), ci)))(true, 1.0)
     @test Base.return_types(oc, Tuple{}) == Any[Float64]
 end
 

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -7,8 +7,8 @@ const lno = LineNumberNode(1, :none)
 
 let ci = @code_lowered const_int()
     @eval function oc_trivial()
-        $(Expr(:new_opaque_closure, Tuple{}, false, Any, Any,
-            Expr(:opaque_closure_method, nothing, 0, lno, ci)))
+        $(Expr(:new_opaque_closure, Tuple{}, Any, Any,
+            Expr(:opaque_closure_method, nothing, 0, false, lno, ci)))
     end
 end
 @test isa(oc_trivial(), Core.OpaqueClosure{Tuple{}, Any})
@@ -16,8 +16,8 @@ end
 
 let ci = @code_lowered const_int()
     @eval function oc_simple_inf()
-        $(Expr(:new_opaque_closure, Tuple{}, false, Union{}, Any,
-            Expr(:opaque_closure_method, nothing, 0, lno, ci)))
+        $(Expr(:new_opaque_closure, Tuple{}, Union{}, Any,
+            Expr(:opaque_closure_method, nothing, 0, false, lno, ci)))
     end
 end
 @test isa(oc_simple_inf(), Core.OpaqueClosure{Tuple{}, Int})
@@ -30,8 +30,8 @@ end
 (a::OcClos2Int)() = getfield(a, 1) + getfield(a, 2)
 let ci = @code_lowered OcClos2Int(1, 2)();
     @eval function oc_trivial_clos()
-        $(Expr(:new_opaque_closure, Tuple{}, false, Int, Int,
-            Expr(:opaque_closure_method, nothing, 0, lno, ci),
+        $(Expr(:new_opaque_closure, Tuple{}, Int, Int,
+            Expr(:opaque_closure_method, nothing, 0, false, lno, ci),
             1, 2))
     end
 end
@@ -39,8 +39,8 @@ end
 
 let ci = @code_lowered OcClos2Int(1, 2)();
     @eval function oc_self_call_clos()
-        $(Expr(:new_opaque_closure, Tuple{}, false, Int, Int,
-            Expr(:opaque_closure_method, nothing, 0, lno, ci),
+        $(Expr(:new_opaque_closure, Tuple{}, Int, Int,
+            Expr(:opaque_closure_method, nothing, 0, false, lno, ci),
             1, 2))()
     end
 end
@@ -56,8 +56,8 @@ end
 (a::OcClos1Any)() = getfield(a, 1)
 let ci = @code_lowered OcClos1Any(1)()
     @eval function oc_pass_clos(x)
-        $(Expr(:new_opaque_closure, Tuple{}, false, Any, Any,
-            Expr(:opaque_closure_method, nothing, 0, lno, ci),
+        $(Expr(:new_opaque_closure, Tuple{}, Any, Any,
+            Expr(:opaque_closure_method, nothing, 0, false, lno, ci),
             :x))
     end
 end
@@ -66,8 +66,8 @@ end
 
 let ci = @code_lowered OcClos1Any(1)()
     @eval function oc_infer_pass_clos(x)
-        $(Expr(:new_opaque_closure, Tuple{}, false, Union{}, Any,
-            Expr(:opaque_closure_method, nothing, 0, lno, ci),
+        $(Expr(:new_opaque_closure, Tuple{}, Union{}, Any,
+            Expr(:opaque_closure_method, nothing, 0, false, lno, ci),
             :x))
     end
 end
@@ -78,8 +78,8 @@ end
 
 let ci = @code_lowered identity(1)
     @eval function oc_infer_pass_id()
-        $(Expr(:new_opaque_closure, Tuple{Any}, false, Any, Any,
-            Expr(:opaque_closure_method, nothing, 1, lno, ci)))
+        $(Expr(:new_opaque_closure, Tuple{Any}, Any, Any,
+            Expr(:opaque_closure_method, nothing, 1, false, lno, ci)))
     end
 end
 function complicated_identity(x)
@@ -100,8 +100,8 @@ end
 
 let ci = @code_lowered OcOpt([1 2])()
     @eval function oc_opt_ndims(A)
-        $(Expr(:new_opaque_closure, Tuple{}, false, Union{}, Any,
-            Expr(:opaque_closure_method, nothing, 0, lno, ci),
+        $(Expr(:new_opaque_closure, Tuple{}, Union{}, Any,
+            Expr(:opaque_closure_method, nothing, 0, false, lno, ci),
             :A))
     end
 end
@@ -140,13 +140,28 @@ g_world_age = @opaque ()->test_oc_world_age()
 @test g_world_age() == 1
 @test isa(mk_oc_world_age(), Core.OpaqueClosure{Tuple{}, Int})
 
-# Evil, dynamic Vararg stuff (don't do this - made to work for consistency)
-function maybe_opaque(isva::Bool)
-    T = isva ? Vararg{Int, 1} : Int
-    @opaque (x::T)->x
+function maybe_vararg(isva::Bool)
+    T = isva ? Vararg{Int} : Int
+    @opaque Tuple{T} (x...)->x
 end
-@test maybe_opaque(false)(1) == 1
-@test maybe_opaque(true)(1) == (1,)
+@test maybe_vararg(false)(1) == (1,)
+@test_throws MethodError maybe_vararg(false)(1,2,3)
+@test maybe_vararg(true)(1) == (1,)
+@test maybe_vararg(true)(1,2,3) == (1,2,3)
+@test (@opaque Tuple{Int, Int} (a, b, x...)->x)(1,2) === ()
+@test (@opaque Tuple{Int, Int} (a, x...)->x)(1,2) === (2,)
+@test (@opaque Tuple{Int, Vararg{Int}} (a, x...)->x)(1,2,3,4) === (2,3,4)
+@test (@opaque (a::Int, x::Int...)->x)(1,2,3) === (2,3)
+
+@test_throws ErrorException (@opaque Tuple{Vararg{Int}} x->x)
+@test_throws ErrorException (@opaque Tuple{Int, Vararg{Int}} x->x)
+@test_throws ErrorException (@opaque Tuple{Int, Int} x->x)
+@test_throws ErrorException (@opaque Tuple{Any} (x,y)->x)
+@test_throws ErrorException (@opaque Tuple{Vararg{Int}} (x,y...)->x)
+@test_throws ErrorException (@opaque Tuple{Int} (x,y,z...)->x)
+
+# cannot specify types both on arguments and separately
+@test_throws ErrorException @eval @opaque Tuple{Any} (x::Int)->x
 
 # Vargarg in complied mode
 mk_va_opaque() = @opaque (x...)->x
@@ -159,8 +174,8 @@ mk_va_opaque() = @opaque (x...)->x
 # Opaque closure in CodeInfo returned from generated functions
 function mk_ocg(args...)
     ci = @code_lowered const_int()
-    cig = Meta.lower(@__MODULE__, Expr(:new_opaque_closure, Tuple{}, false, Any, Any,
-        Expr(:opaque_closure_method, nothing, 0, lno, ci))).args[1]
+    cig = Meta.lower(@__MODULE__, Expr(:new_opaque_closure, Tuple{}, Any, Any,
+        Expr(:opaque_closure_method, nothing, 0, false, lno, ci))).args[1]
     cig.slotnames = Symbol[Symbol("#self#")]
     cig.slottypes = Any[Any]
     cig.slotflags = UInt8[0x00]


### PR DESCRIPTION
Depends on #43320, but I will put this up now for review.

~~TODO: Add signature type compatibility check in codegen.~~