### PR TITLE
Optimize real matrix * complex vector by reinterpreting as real

### DIFF
--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -10,101 +10,101 @@ using LinearAlgebra: mul!
 
 @testset "matrices with zero dimensions" begin
     for (dimsA, dimsB, dimsC) in (
-            ((0,5), (5,3), (0,3)),
-            ((3,5), (5,0), (3,0)),
-            ((3,0), (0,4), (3,4)),
-            ((0,5), (5,0), (0,0)),
-            ((0,0), (0,4), (0,4)),
-            ((3,0), (0,0), (3,0)),
-            ((0,0), (0,0), (0,0)) )
+        ((0, 5), (5, 3), (0, 3)),
+        ((3, 5), (5, 0), (3, 0)),
+        ((3, 0), (0, 4), (3, 4)),
+        ((0, 5), (5, 0), (0, 0)),
+        ((0, 0), (0, 4), (0, 4)),
+        ((3, 0), (0, 0), (3, 0)),
+        ((0, 0), (0, 0), (0, 0)))
         @test Matrix{Float64}(undef, dimsA) * Matrix{Float64}(undef, dimsB) == zeros(dimsC)
     end
-    @test Matrix{Float64}(undef, 5, 0) |> t -> t't == zeros(0,0)
-    @test Matrix{Float64}(undef, 5, 0) |> t -> t*t' == zeros(5,5)
-    @test Matrix{ComplexF64}(undef, 5, 0) |> t -> t't == zeros(0,0)
-    @test Matrix{ComplexF64}(undef, 5, 0) |> t -> t*t' == zeros(5,5)
+    @test Matrix{Float64}(undef, 5, 0) |> t -> t't == zeros(0, 0)
+    @test Matrix{Float64}(undef, 5, 0) |> t -> t * t' == zeros(5, 5)
+    @test Matrix{ComplexF64}(undef, 5, 0) |> t -> t't == zeros(0, 0)
+    @test Matrix{ComplexF64}(undef, 5, 0) |> t -> t * t' == zeros(5, 5)
 end
 @testset "2x2 matmul" begin
     AA = [1 2; 3 4]
     BB = [5 6; 7 8]
-    AAi = AA+(0.5*im).*BB
-    BBi = BB+(2.5*im).*AA[[2,1],[2,1]]
+    AAi = AA + (0.5 * im) .* BB
+    BBi = BB + (2.5 * im) .* AA[[2, 1], [2, 1]]
     for A in (copy(AA), view(AA, 1:2, 1:2)), B in (copy(BB), view(BB, 1:2, 1:2))
-        @test A*B == [19 22; 43 50]
+        @test A * B == [19 22; 43 50]
         @test *(transpose(A), B) == [26 30; 38 44]
         @test *(A, transpose(B)) == [17 23; 39 53]
         @test *(transpose(A), transpose(B)) == [23 31; 34 46]
     end
     for Ai in (copy(AAi), view(AAi, 1:2, 1:2)), Bi in (copy(BBi), view(BBi, 1:2, 1:2))
-        @test Ai*Bi == [-21+53.5im -4.25+51.5im; -12+95.5im 13.75+85.5im]
+        @test Ai * Bi == [-21+53.5im -4.25+51.5im; -12+95.5im 13.75+85.5im]
         @test *(adjoint(Ai), Bi) == [68.5-12im 57.5-28im; 88-3im 76.5-25im]
         @test *(Ai, adjoint(Bi)) == [64.5+5.5im 43+31.5im; 104-18.5im 80.5+31.5im]
         @test *(adjoint(Ai), adjoint(Bi)) == [-28.25-66im 9.75-58im; -26-89im 21-73im]
         @test_throws DimensionMismatch [1 2; 0 0; 0 0] * [1 2]
     end
-    @test_throws DimensionMismatch mul!(Matrix{Float64}(undef,3,3), AA, BB)
+    @test_throws DimensionMismatch mul!(Matrix{Float64}(undef, 3, 3), AA, BB)
 end
 @testset "3x3 matmul" begin
-    AA = [1 2 3; 4 5 6; 7 8 9].-5
+    AA = [1 2 3; 4 5 6; 7 8 9] .- 5
     BB = [1 0 5; 6 -10 3; 2 -4 -1]
-    AAi = AA+(0.5*im).*BB
-    BBi = BB+(2.5*im).*AA[[2,1,3],[2,3,1]]
+    AAi = AA + (0.5 * im) .* BB
+    BBi = BB + (2.5 * im) .* AA[[2, 1, 3], [2, 3, 1]]
     for A in (copy(AA), view(AA, 1:3, 1:3)), B in (copy(BB), view(BB, 1:3, 1:3))
-        @test A*B == [-26 38 -27; 1 -4 -6; 28 -46 15]
+        @test A * B == [-26 38 -27; 1 -4 -6; 28 -46 15]
         @test *(adjoint(A), B) == [-6 2 -25; 3 -12 -18; 12 -26 -11]
         @test *(A, adjoint(B)) == [-14 0 6; 4 -3 -3; 22 -6 -12]
         @test *(adjoint(A), adjoint(B)) == [6 -8 -6; 12 -9 -9; 18 -10 -12]
     end
     for Ai in (copy(AAi), view(AAi, 1:3, 1:3)), Bi in (copy(BBi), view(BBi, 1:3, 1:3))
-        @test Ai*Bi == [-44.75+13im 11.75-25im -38.25+30im; -47.75-16.5im -51.5+51.5im -56+6im; 16.75-4.5im -53.5+52im -15.5im]
+        @test Ai * Bi == [-44.75+13im 11.75-25im -38.25+30im; -47.75-16.5im -51.5+51.5im -56+6im; 16.75-4.5im -53.5+52im -15.5im]
         @test *(adjoint(Ai), Bi) == [-21+2im -1.75+49im -51.25+19.5im; 25.5+56.5im -7-35.5im 22+35.5im; -3+12im -32.25+43im -34.75-2.5im]
         @test *(Ai, adjoint(Bi)) == [-20.25+15.5im -28.75-54.5im 22.25+68.5im; -12.25+13im -15.5+75im -23+27im; 18.25+im 1.5+94.5im -27-54.5im]
         @test *(adjoint(Ai), adjoint(Bi)) == [1+2im 20.75+9im -44.75+42im; 19.5+17.5im -54-36.5im 51-14.5im; 13+7.5im 11.25+31.5im -43.25-14.5im]
         @test_throws DimensionMismatch [1 2 3; 0 0 0; 0 0 0] * [1 2 3]
     end
-    @test_throws DimensionMismatch mul!(Matrix{Float64}(undef,4,4), AA, BB)
+    @test_throws DimensionMismatch mul!(Matrix{Float64}(undef, 4, 4), AA, BB)
 end
 
 # Generic AbstractArrays
 module MyArray15367
-    using Test, Random
+using Test, Random
 
-    struct MyArray{T,N} <: AbstractArray{T,N}
-        data::Array{T,N}
-    end
+struct MyArray{T,N} <: AbstractArray{T,N}
+    data::Array{T,N}
+end
 
-    Base.size(A::MyArray) = size(A.data)
-    Base.getindex(A::MyArray, indices...) = A.data[indices...]
+Base.size(A::MyArray) = size(A.data)
+Base.getindex(A::MyArray, indices...) = A.data[indices...]
 
-    A = MyArray(rand(4,5))
-    b = rand(5)
-    @test A*b ≈ A.data*b
+A = MyArray(rand(4, 5))
+b = rand(5)
+@test A * b ≈ A.data * b
 end
 
 @testset "Generic integer matrix multiplication" begin
     AA = [1 2 3; 4 5 6] .- 3
     BB = [2 -2; 3 -5; -4 7]
     for A in (copy(AA), view(AA, 1:2, 1:3)), B in (copy(BB), view(BB, 1:3, 1:2))
-        @test A*B == [-7 9; -4 9]
+        @test A * B == [-7 9; -4 9]
         @test *(transpose(A), transpose(B)) == [-6 -11 15; -6 -13 18; -6 -15 21]
     end
     AA = fill(1, 2, 100)
     BB = fill(1, 100, 3)
     for A in (copy(AA), view(AA, 1:2, 1:100)), B in (copy(BB), view(BB, 1:100, 1:3))
-        @test A*B == [100 100 100; 100 100 100]
+        @test A * B == [100 100 100; 100 100 100]
     end
     AA = rand(1:20, 5, 5) .- 10
     BB = rand(1:20, 5, 5) .- 10
     CC = Matrix{Int}(undef, size(AA, 1), size(BB, 2))
     for A in (copy(AA), view(AA, 1:5, 1:5)), B in (copy(BB), view(BB, 1:5, 1:5)), C in (copy(CC), view(CC, 1:5, 1:5))
-        @test *(transpose(A), B) == A'*B
-        @test *(A, transpose(B)) == A*B'
+        @test *(transpose(A), B) == A' * B
+        @test *(A, transpose(B)) == A * B'
         # Preallocated
-        @test mul!(C, A, B) == A*B
-        @test mul!(C, transpose(A), B) == A'*B
-        @test mul!(C, A, transpose(B)) == A*B'
-        @test mul!(C, transpose(A), transpose(B)) == A'*B'
-        @test LinearAlgebra.mul!(C, adjoint(A), transpose(B)) == A'*transpose(B)
+        @test mul!(C, A, B) == A * B
+        @test mul!(C, transpose(A), B) == A' * B
+        @test mul!(C, A, transpose(B)) == A * B'
+        @test mul!(C, transpose(A), transpose(B)) == A' * B'
+        @test LinearAlgebra.mul!(C, adjoint(A), transpose(B)) == A' * transpose(B)
 
         # Inplace multiply-add
         α = rand(-10:10)
@@ -113,17 +113,17 @@ end
         βC = β * C
         _C0 = copy(C)
         C0() = (C .= _C0; C)  # reset C but don't change the container type
-        @test mul!(C0(), A, B, α, β) == α*A*B .+ βC
-        @test mul!(C0(), transpose(A), B, α, β) == α*A'*B .+ βC
-        @test mul!(C0(), A, transpose(B), α, β) == α*A*B' .+ βC
-        @test mul!(C0(), transpose(A), transpose(B), α, β) == α*A'*B' .+ βC
-        @test mul!(C0(), adjoint(A), transpose(B), α, β) == α*A'*transpose(B) .+ βC
+        @test mul!(C0(), A, B, α, β) == α * A * B .+ βC
+        @test mul!(C0(), transpose(A), B, α, β) == α * A' * B .+ βC
+        @test mul!(C0(), A, transpose(B), α, β) == α * A * B' .+ βC
+        @test mul!(C0(), transpose(A), transpose(B), α, β) == α * A' * B' .+ βC
+        @test mul!(C0(), adjoint(A), transpose(B), α, β) == α * A' * transpose(B) .+ βC
 
         #test DimensionMismatch for generic_matmatmul
-        @test_throws DimensionMismatch LinearAlgebra.mul!(C, adjoint(A), transpose(fill(1,4,4)))
-        @test_throws DimensionMismatch LinearAlgebra.mul!(C, adjoint(fill(1,4,4)), transpose(B))
+        @test_throws DimensionMismatch LinearAlgebra.mul!(C, adjoint(A), transpose(fill(1, 4, 4)))
+        @test_throws DimensionMismatch LinearAlgebra.mul!(C, adjoint(fill(1, 4, 4)), transpose(B))
     end
-    vv = [1,2]
+    vv = [1, 2]
     CC = Matrix{Int}(undef, 2, 2)
     for v in (copy(vv), view(vv, 1:2)), C in (copy(CC), view(CC, 1:2, 1:2))
         @test @inferred(mul!(C, v, adjoint(v))) == [1 2; 2 4]
@@ -134,36 +134,36 @@ end
 end
 
 @testset "generic_matvecmul" begin
-    AA = rand(5,5)
+    AA = rand(5, 5)
     BB = rand(5)
     for A in (copy(AA), view(AA, 1:5, 1:5)), B in (copy(BB), view(BB, 1:5))
-        @test_throws DimensionMismatch LinearAlgebra.generic_matvecmul!(zeros(6),'N',A,B)
-        @test_throws DimensionMismatch LinearAlgebra.generic_matvecmul!(B,'N',A,zeros(6))
+        @test_throws DimensionMismatch LinearAlgebra.generic_matvecmul!(zeros(6), 'N', A, B)
+        @test_throws DimensionMismatch LinearAlgebra.generic_matvecmul!(B, 'N', A, zeros(6))
     end
-    vv = [1,2,3]
+    vv = [1, 2, 3]
     CC = Matrix{Int}(undef, 3, 3)
     for v in (copy(vv), view(vv, 1:3)), C in (copy(CC), view(CC, 1:3, 1:3))
-        @test mul!(C, v, transpose(v)) == v*v'
+        @test mul!(C, v, transpose(v)) == v * v'
         C .= C0 = rand(-10:10, size(C))
-        @test mul!(C, v, transpose(v), 2, 3) == 2v*v' .+ 3C0
+        @test mul!(C, v, transpose(v), 2, 3) == 2v * v' .+ 3C0
     end
-    vvf = map(Float64,vv)
+    vvf = map(Float64, vv)
     CC = Matrix{Float64}(undef, 3, 3)
     for vf in (copy(vvf), view(vvf, 1:3)), C in (copy(CC), view(CC, 1:3, 1:3))
-        @test mul!(C, vf, transpose(vf)) == vf*vf'
+        @test mul!(C, vf, transpose(vf)) == vf * vf'
         C .= C0 = rand(eltype(C), size(C))
-        @test mul!(C, vf, transpose(vf), 2, 3) ≈ 2vf*vf' .+ 3C0
+        @test mul!(C, vf, transpose(vf), 2, 3) ≈ 2vf * vf' .+ 3C0
     end
 end
 
 @testset "fallbacks & such for BlasFloats" begin
-    AA = rand(Float64,6,6)
-    BB = rand(Float64,6,6)
-    CC = zeros(Float64,6,6)
+    AA = rand(Float64, 6, 6)
+    BB = rand(Float64, 6, 6)
+    CC = zeros(Float64, 6, 6)
     for A in (copy(AA), view(AA, 1:6, 1:6)), B in (copy(BB), view(BB, 1:6, 1:6)), C in (copy(CC), view(CC, 1:6, 1:6))
-        @test LinearAlgebra.mul!(C, transpose(A), transpose(B)) == transpose(A)*transpose(B)
-        @test LinearAlgebra.mul!(C, A, adjoint(B)) == A*transpose(B)
-        @test LinearAlgebra.mul!(C, adjoint(A), B) == transpose(A)*B
+        @test LinearAlgebra.mul!(C, transpose(A), transpose(B)) == transpose(A) * transpose(B)
+        @test LinearAlgebra.mul!(C, A, adjoint(B)) == A * transpose(B)
+        @test LinearAlgebra.mul!(C, adjoint(A), B) == transpose(A) * B
 
         # Inplace multiply-add
         α = rand(Float64)
@@ -172,119 +172,153 @@ end
         βC = β * C
         _C0 = copy(C)
         C0() = (C .= _C0; C)  # reset C but don't change the container type
-        @test mul!(C0(), transpose(A), transpose(B), α, β) ≈ α*transpose(A)*transpose(B) .+ βC
-        @test mul!(C0(), A, adjoint(B), α, β) ≈ α*A*transpose(B) .+ βC
-        @test mul!(C0(), adjoint(A), B, α, β) ≈ α*transpose(A)*B .+ βC
+        @test mul!(C0(), transpose(A), transpose(B), α, β) ≈ α * transpose(A) * transpose(B) .+ βC
+        @test mul!(C0(), A, adjoint(B), α, β) ≈ α * A * transpose(B) .+ βC
+        @test mul!(C0(), adjoint(A), B, α, β) ≈ α * transpose(A) * B .+ βC
     end
 end
 
 @testset "mixed Blas-non-Blas matmul" begin
-    AA = rand(-10:10,6,6)
-    BB = rand(Float64,6,6)
-    CC = zeros(Float64,6,6)
+    AA = rand(-10:10, 6, 6)
+    BB = rand(Float64, 6, 6)
+    CC = zeros(Float64, 6, 6)
     for A in (copy(AA), view(AA, 1:6, 1:6)), B in (copy(BB), view(BB, 1:6, 1:6)), C in (copy(CC), view(CC, 1:6, 1:6))
-        @test LinearAlgebra.mul!(C, A, B) == A*B
-        @test LinearAlgebra.mul!(C, transpose(A), transpose(B)) == transpose(A)*transpose(B)
-        @test LinearAlgebra.mul!(C, A, adjoint(B)) == A*transpose(B)
-        @test LinearAlgebra.mul!(C, adjoint(A), B) == transpose(A)*B
+        @test LinearAlgebra.mul!(C, A, B) == A * B
+        @test LinearAlgebra.mul!(C, transpose(A), transpose(B)) == transpose(A) * transpose(B)
+        @test LinearAlgebra.mul!(C, A, adjoint(B)) == A * transpose(B)
+        @test LinearAlgebra.mul!(C, adjoint(A), B) == transpose(A) * B
     end
 end
 
 @testset "matrix algebra with subarrays of floats (stride != 1)" begin
-    A = reshape(map(Float64,1:20),5,4)
-    Aref = A[1:2:end,1:2:end]
+    A = reshape(map(Float64, 1:20), 5, 4)
+    Aref = A[1:2:end, 1:2:end]
     Asub = view(A, 1:2:5, 1:2:4)
-    b = [1.2,-2.5]
-    @test (Aref*b) == (Asub*b)
+    b = [1.2, -2.5]
+    @test (Aref * b) == (Asub * b)
     @test *(transpose(Asub), Asub) == *(transpose(Aref), Aref)
     @test *(Asub, transpose(Asub)) == *(Aref, transpose(Aref))
     Ai = A .+ im
-    Aref = Ai[1:2:end,1:2:end]
+    Aref = Ai[1:2:end, 1:2:end]
     Asub = view(Ai, 1:2:5, 1:2:4)
     @test *(adjoint(Asub), Asub) == *(adjoint(Aref), Aref)
     @test *(Asub, adjoint(Asub)) == *(Aref, adjoint(Aref))
 end
 
 @testset "matrix x matrix with negative stride" begin
-    M = reshape(map(Float64,1:77),7,11)
-    N = reshape(map(Float64,1:63),9,7)
-    U = view(M,7:-1:1,11:-2:1)
-    V = view(N,7:-1:2,7:-1:1)
-    @test U*V ≈ Matrix(U) * Matrix(V)
+    M = reshape(map(Float64, 1:77), 7, 11)
+    N = reshape(map(Float64, 1:63), 9, 7)
+    U = view(M, 7:-1:1, 11:-2:1)
+    V = view(N, 7:-1:2, 7:-1:1)
+    @test U * V ≈ Matrix(U) * Matrix(V)
 end
 
 @testset "dot product of subarrays of vectors (floats, negative stride, issue #37767)" begin
     for T in (Float32, Float64, ComplexF32, ComplexF64)
         a = Vector{T}(3:2:7)
         b = Vector{T}(1:10)
-        v = view(b,7:-2:3)
-        @test dot(a,Vector(v)) ≈ 67.0
-        @test dot(a,v) ≈ 67.0
-        @test dot(v,a) ≈ 67.0
-        @test dot(Vector(v),Vector(v)) ≈ 83.0
-        @test dot(v,v) ≈ 83.0
+        v = view(b, 7:-2:3)
+        @test dot(a, Vector(v)) ≈ 67.0
+        @test dot(a, v) ≈ 67.0
+        @test dot(v, a) ≈ 67.0
+        @test dot(Vector(v), Vector(v)) ≈ 83.0
+        @test dot(v, v) ≈ 83.0
     end
 end
 
-@testset "Complex matrix x real MatOrVec etc (issue #29224)" for T1 in (Float32,Float64)
-    for T2 in (Float32,Float64)
-        for arg1_real in (true,false)
-            @testset "Combination $T1 $T2 $arg1_real $arg2_real" for arg2_real in (true,false)
-                A0 = reshape(Vector{T1}(1:25),5,5) .+
-                   (arg1_real ? 0 : 1im*reshape(Vector{T1}(-3:21),5,5))
-                A = view(A0,1:2,1:2)
-                B = Matrix{T2}([1.0 3.0; -1.0 2.0]).+
-                    (arg2_real ? 0 : 1im*Matrix{T2}([3.0 4; -1 10]))
-                AB_correct = copy(A)*B
-                AB = A*B;  # view times matrix
+@testset "Complex matrix x real MatOrVec etc (issue #29224)" for T1 in (Float32, Float64)
+    for T2 in (Float32, Float64)
+        for arg1_real in (true, false)
+            @testset "Combination $T1 $T2 $arg1_real $arg2_real" for arg2_real in (true, false)
+                A0 = reshape(Vector{T1}(1:25), 5, 5) .+
+                     (arg1_real ? 0 : 1im * reshape(Vector{T1}(-3:21), 5, 5))
+                A = view(A0, 1:2, 1:2)
+                B = Matrix{T2}([1.0 3.0; -1.0 2.0]) .+
+                    (arg2_real ? 0 : 1im * Matrix{T2}([3.0 4; -1 10]))
+                AB_correct = copy(A) * B
+                AB = A * B  # view times matrix
                 @test AB ≈ AB_correct
-                A1 = view(A0,:,1:2)  # rectangular view times matrix
-                @test A1*B ≈ copy(A1)*B
-                B1 = view(B,1:2,1:2);
-                AB1 = A*B1; # view times view
+                A1 = view(A0, :, 1:2)  # rectangular view times matrix
+                @test A1 * B ≈ copy(A1) * B
+                B1 = view(B, 1:2, 1:2)
+                AB1 = A * B1 # view times view
                 @test AB1 ≈ AB_correct
-                x = Vector{T2}([1.0;10.0]) .+ (arg2_real ? 0 : 1im*Vector{T2}([3;-1]))
-                Ax_exact = copy(A)*x
-                Ax = A*x  # view times vector
+                x = Vector{T2}([1.0; 10.0]) .+ (arg2_real ? 0 : 1im * Vector{T2}([3; -1]))
+                Ax_exact = copy(A) * x
+                Ax = A * x  # view times vector
                 @test Ax ≈ Ax_exact
-                x1 = view(x,1:2)
-                Ax1 = A*x1  # view times viewed vector
+                x1 = view(x, 1:2)
+                Ax1 = A * x1  # view times viewed vector
                 @test Ax1 ≈ Ax_exact
-                @test copy(A)*x1 ≈ Ax_exact # matrix times viewed vector
+                @test copy(A) * x1 ≈ Ax_exact # matrix times viewed vector
                 # View times transposed matrix
-                Bt = transpose(B);
-                @test A*Bt ≈ A*copy(Bt)
+                Bt = transpose(B)
+                @test A * Bt ≈ A * copy(Bt)
             end
         end
     end
 end
 
+@testset "real matrix x complex vec" begin
+    _matmulres(M, v) = [mapreduce(*, +, row, v) for row in eachrow(M)]
+    testmatmul(M, v) = @test M * v ≈ _matmulres(M, v)
+
+    @testset for T in (Float32, Float64), n = (4, 5)
+        M1 = reshape(Vector{T}(1:n^2), n, n)
+        M2 = reinterpret(reshape, T, [Tuple(T(i + j) for j in 1:n) for i in 1:n])
+        v = convert(Vector{Complex{T}}, (1:n) .+ im .* (4 .+ (1:n)))
+
+        for M in (M1, M2)
+            M_view_cont = @view M[:, :]
+            v_view_cont = @view v[:]
+            for _M in (M, M_view_cont), _v in (v, v_view_cont)
+                testmatmul(_M, _v)
+            end
+
+            # construct a view with strides(M, 1) == 1 and strides(M, 2) != 1
+            ax_noncont = 1:2:n
+            n1 = length(ax_noncont)
+            M_view_noncont = @view M[1:n1, ax_noncont]
+            v_view_noncont = @view v[ax_noncont]
+            testmatmul(M_view_noncont, v_view_noncont)
+
+            @testset for op in (transpose, adjoint)
+                for _M in (M, M_view_cont), _v in (v, v_view_cont)
+                    _M2 = op(_M)
+                    testmatmul(_M2, _v)
+                end
+                _M2 = op(M_view_noncont)
+                testmatmul(_M2, v_view_noncont)
+            end
+        end
+    end
+end
 
 @testset "issue #15286" begin
     A = reshape(map(Float64, 1:20), 5, 4)
     C = zeros(8, 8)
     sC = view(C, 1:2:8, 1:2:8)
-    B = reshape(map(Float64,-9:10),5,4)
-    @test mul!(sC, transpose(A), A) == A'*A
-    @test mul!(sC, transpose(A), B) == A'*B
+    B = reshape(map(Float64, -9:10), 5, 4)
+    @test mul!(sC, transpose(A), A) == A' * A
+    @test mul!(sC, transpose(A), B) == A' * B
 
     Aim = A .- im
-    C = zeros(ComplexF64,8,8)
+    C = zeros(ComplexF64, 8, 8)
     sC = view(C, 1:2:8, 1:2:8)
-    B = reshape(map(Float64,-9:10),5,4) .+ im
-    @test mul!(sC, adjoint(Aim), Aim) == Aim'*Aim
-    @test mul!(sC, adjoint(Aim), B) == Aim'*B
+    B = reshape(map(Float64, -9:10), 5, 4) .+ im
+    @test mul!(sC, adjoint(Aim), Aim) == Aim' * Aim
+    @test mul!(sC, adjoint(Aim), B) == Aim' * B
 end
 
 @testset "syrk & herk" begin
-    AA = reshape(1:1503, 501, 3).-750.0
+    AA = reshape(1:1503, 501, 3) .- 750.0
     res = Float64[135228751 9979252 -115270247; 9979252 10481254 10983256; -115270247 10983256 137236759]
     for A in (copy(AA), view(AA, 1:501, 1:3))
         @test *(transpose(A), A) == res
         @test *(adjoint(A), transpose(copy(A'))) == res
     end
     cutoff = 501
-    A = reshape(1:6*cutoff,2*cutoff,3).-(6*cutoff)/2
+    A = reshape(1:6*cutoff, 2 * cutoff, 3) .- (6 * cutoff) / 2
     Asub = view(A, 1:2:2*cutoff, 1:3)
     Aref = A[1:2:2*cutoff, 1:3]
     @test *(transpose(Asub), Asub) == *(transpose(Aref), Aref)
@@ -294,31 +328,31 @@ end
     @test *(adjoint(Asub), Asub) == *(adjoint(Aref), Aref)
 
     A5x5, A6x5 = Matrix{Float64}.(undef, ((5, 5), (6, 5)))
-    @test_throws DimensionMismatch LinearAlgebra.syrk_wrapper!(A5x5,'N',A6x5)
-    @test_throws DimensionMismatch LinearAlgebra.herk_wrapper!(A5x5,'N',A6x5)
+    @test_throws DimensionMismatch LinearAlgebra.syrk_wrapper!(A5x5, 'N', A6x5)
+    @test_throws DimensionMismatch LinearAlgebra.herk_wrapper!(A5x5, 'N', A6x5)
 end
 
 @testset "matmul for types w/o sizeof (issue #1282)" begin
-    AA = fill(complex(1,1), 10, 10)
+    AA = fill(complex(1, 1), 10, 10)
     for A in (copy(AA), view(AA, 1:10, 1:10))
         A2 = A^2
-        @test A2[1,1] == 20im
+        @test A2[1, 1] == 20im
     end
 end
 
 @testset "mul! (scaling)" begin
-    A5x5, b5, C5x6 = Array{Float64}.(undef,((5,5), 5, (5,6)))
-    for A in (A5x5, view(A5x5, :, :)), b in (b5,  view(b5, :)), C in (C5x6, view(C5x6, :, :))
+    A5x5, b5, C5x6 = Array{Float64}.(undef, ((5, 5), 5, (5, 6)))
+    for A in (A5x5, view(A5x5, :, :)), b in (b5, view(b5, :)), C in (C5x6, view(C5x6, :, :))
         @test_throws DimensionMismatch mul!(A, Diagonal(b), C)
     end
 end
 
 @testset "muladd" begin
-    A23 = reshape(1:6, 2,3) .+ 0
-    B34 = reshape(1:12, 3,4) .+ im
-    u2 = [10,20]
-    v3 = [3,5,7] .+ im
-    w4 = [11,13,17,19im]
+    A23 = reshape(1:6, 2, 3) .+ 0
+    B34 = reshape(1:12, 3, 4) .+ im
+    u2 = [10, 20]
+    v3 = [3, 5, 7] .+ im
+    w4 = [11, 13, 17, 19im]
 
     @testset "matrix-matrix" begin
         @test muladd(A23, B34, 0) == A23 * B34
@@ -326,13 +360,13 @@ end
         @test muladd(A23, B34, u2) == A23 * B34 .+ u2
         @test muladd(A23, B34, w4') == A23 * B34 .+ w4'
         @test_throws DimensionMismatch muladd(B34, A23, 1)
-        @test muladd(ones(1,3), ones(3,4), ones(1,4)) == fill(4.0,1,4)
-        @test_throws DimensionMismatch muladd(ones(1,3), ones(3,4), ones(9,4))
+        @test muladd(ones(1, 3), ones(3, 4), ones(1, 4)) == fill(4.0, 1, 4)
+        @test_throws DimensionMismatch muladd(ones(1, 3), ones(3, 4), ones(9, 4))
 
         # broadcasting fallback method allows trailing dims
-        @test muladd(A23, B34, ones(2,4,1)) == A23 * B34 + ones(2,4,1)
-        @test_throws DimensionMismatch muladd(ones(1,3), ones(3,4), ones(9,4,1))
-        @test_throws DimensionMismatch muladd(ones(1,3), ones(3,4), ones(1,4,9))
+        @test muladd(A23, B34, ones(2, 4, 1)) == A23 * B34 + ones(2, 4, 1)
+        @test_throws DimensionMismatch muladd(ones(1, 3), ones(3, 4), ones(9, 4, 1))
+        @test_throws DimensionMismatch muladd(ones(1, 3), ones(3, 4), ones(1, 4, 9))
         # and catches z::Array{T,0}
         @test muladd(A23, B34, fill(0)) == A23 * B34
     end
@@ -341,14 +375,14 @@ end
         @test muladd(A23, v3, 100) == A23 * v3 .+ 100
         @test muladd(A23, v3, u2) == A23 * v3 .+ u2
         @test muladd(A23, v3, im) isa Vector{Complex{Int}}
-        @test muladd(ones(1,3), ones(3), ones(1)) == [4]
-        @test_throws DimensionMismatch muladd(ones(1,3), ones(3), ones(7))
+        @test muladd(ones(1, 3), ones(3), ones(1)) == [4]
+        @test_throws DimensionMismatch muladd(ones(1, 3), ones(3), ones(7))
 
         # fallback
-        @test muladd(A23, v3, ones(2,1,1)) == A23 * v3 + ones(2,1,1)
-        @test_throws DimensionMismatch muladd(A23, v3, ones(2,2))
-        @test_throws DimensionMismatch muladd(ones(1,3), ones(3), ones(7,1))
-        @test_throws DimensionMismatch muladd(ones(1,3), ones(3), ones(1,7))
+        @test muladd(A23, v3, ones(2, 1, 1)) == A23 * v3 + ones(2, 1, 1)
+        @test_throws DimensionMismatch muladd(A23, v3, ones(2, 2))
+        @test_throws DimensionMismatch muladd(ones(1, 3), ones(3), ones(7, 1))
+        @test_throws DimensionMismatch muladd(ones(1, 3), ones(3), ones(1, 7))
         @test muladd(A23, v3, fill(0)) == A23 * v3
     end
     @testset "adjoint-matrix" begin
@@ -357,9 +391,9 @@ end
         @test muladd(v3', B34, w4') == v3' * B34 .+ w4'
 
         # via fallback
-        @test muladd(v3', B34, ones(1,4)) == (B34' * v3 + ones(4,1))'
-        @test_throws DimensionMismatch muladd(v3', B34, ones(7,4))
-        @test_throws DimensionMismatch muladd(v3', B34, ones(1,4,7))
+        @test muladd(v3', B34, ones(1, 4)) == (B34' * v3 + ones(4, 1))'
+        @test_throws DimensionMismatch muladd(v3', B34, ones(7, 4))
+        @test_throws DimensionMismatch muladd(v3', B34, ones(1, 4, 7))
         @test muladd(v3', B34, fill(0)) == v3' * B34 # does not make an Adjoint
     end
     @testset "vector-adjoint" begin
@@ -367,21 +401,21 @@ end
         @test muladd(u2, v3', 99) == u2 * v3' .+ 99
         @test muladd(u2, v3', A23) == u2 * v3' .+ A23
 
-        @test muladd(u2, v3', ones(2,3,1)) == u2 * v3' + ones(2,3,1)
-        @test_throws DimensionMismatch muladd(u2, v3', ones(2,3,4))
-        @test_throws DimensionMismatch muladd([1], v3', ones(7,3))
+        @test muladd(u2, v3', ones(2, 3, 1)) == u2 * v3' + ones(2, 3, 1)
+        @test_throws DimensionMismatch muladd(u2, v3', ones(2, 3, 4))
+        @test_throws DimensionMismatch muladd([1], v3', ones(7, 3))
         @test muladd(u2, v3', fill(0)) == u2 * v3'
     end
     @testset "dot" begin # all use muladd(::Any, ::Any, ::Any)
         @test muladd(u2', u2, 0) isa Number
-        @test muladd(v3', v3, im) == dot(v3,v3) + im
-        @test muladd(u2', u2, [1]) == [dot(u2,u2) + 1]
-        @test_throws DimensionMismatch muladd(u2', u2, [1,1]) == [dot(u2,u2) + 1]
-        @test muladd(u2', u2, fill(0)) == dot(u2,u2)
+        @test muladd(v3', v3, im) == dot(v3, v3) + im
+        @test muladd(u2', u2, [1]) == [dot(u2, u2) + 1]
+        @test_throws DimensionMismatch muladd(u2', u2, [1, 1]) == [dot(u2, u2) + 1]
+        @test muladd(u2', u2, fill(0)) == dot(u2, u2)
     end
     @testset "arrays of arrays" begin
-        vofm = [rand(1:9,2,2) for _ in 1:3]
-        Mofm = [rand(1:9,2,2) for _ in 1:3, _ in 1:3]
+        vofm = [rand(1:9, 2, 2) for _ in 1:3]
+        Mofm = [rand(1:9, 2, 2) for _ in 1:3, _ in 1:3]
 
         @test muladd(vofm', vofm, vofm[1]) == vofm' * vofm .+ vofm[1] # inner
         @test muladd(vofm, vofm', Mofm) == vofm * vofm' .+ Mofm       # outer
@@ -392,8 +426,8 @@ end
 end
 
 @testset "muladd & structured matrices" begin
-    A33 = reshape(1:9, 3,3) .+ im
-    v3 = [3,5,7im]
+    A33 = reshape(1:9, 3, 3) .+ im
+    v3 = [3, 5, 7im]
 
     # no special treatment
     @test muladd(Symmetric(A33), Symmetric(A33), 1) == Symmetric(A33) * Symmetric(A33) .+ 1
@@ -405,43 +439,43 @@ end
     @test u1 == UpperTriangular(A33) * UpperTriangular(A33) + Diagonal(v3)
 
     # diagonal
-    @test muladd(Diagonal(v3), Diagonal(A33), Diagonal(v3)).diag == ([1,5,9] .+ im .+ 1) .* v3
+    @test muladd(Diagonal(v3), Diagonal(A33), Diagonal(v3)).diag == ([1, 5, 9] .+ im .+ 1) .* v3
 
     # uniformscaling
     @test muladd(Diagonal(v3), I, I).diag == v3 .+ 1
-    @test muladd(2*I, 3*I, I).λ == 7
+    @test muladd(2 * I, 3 * I, I).λ == 7
     @test muladd(A33, A33', I) == A33 * A33' + I
 
     # https://github.com/JuliaLang/julia/issues/38426
-    @test @evalpoly(A33, 1.0*I, 1.0*I) == I + A33
-    @test @evalpoly(A33, 1.0*I, 1.0*I, 1.0*I) == I + A33 + A33^2
+    @test @evalpoly(A33, 1.0 * I, 1.0 * I) == I + A33
+    @test @evalpoly(A33, 1.0 * I, 1.0 * I, 1.0 * I) == I + A33 + A33^2
 end
 
 # issue #6450
-@test dot(Any[1.0,2.0], Any[3.5,4.5]) === 12.5
+@test dot(Any[1.0, 2.0], Any[3.5, 4.5]) === 12.5
 
 @testset "dot" for elty in (Float32, Float64, ComplexF32, ComplexF64)
-    x = convert(Vector{elty},[1.0, 2.0, 3.0])
-    y = convert(Vector{elty},[3.5, 4.5, 5.5])
+    x = convert(Vector{elty}, [1.0, 2.0, 3.0])
+    y = convert(Vector{elty}, [3.5, 4.5, 5.5])
     @test_throws DimensionMismatch dot(x, 1:2, y, 1:3)
     @test_throws BoundsError dot(x, 1:4, y, 1:4)
     @test_throws BoundsError dot(x, 1:3, y, 2:4)
     @test dot(x, 1:2, y, 1:2) == convert(elty, 12.5)
-    @test transpose(x)*y == convert(elty, 29.0)
-    X = convert(Matrix{elty},[1.0 2.0; 3.0 4.0])
-    Y = convert(Matrix{elty},[1.5 2.5; 3.5 4.5])
+    @test transpose(x) * y == convert(elty, 29.0)
+    X = convert(Matrix{elty}, [1.0 2.0; 3.0 4.0])
+    Y = convert(Matrix{elty}, [1.5 2.5; 3.5 4.5])
     @test dot(X, Y) == convert(elty, 35.0)
-    Z = convert(Vector{Matrix{elty}},[reshape(1:4, 2, 2), fill(1, 2, 2)])
+    Z = convert(Vector{Matrix{elty}}, [reshape(1:4, 2, 2), fill(1, 2, 2)])
     @test dot(Z, Z) == convert(elty, 34.0)
 end
 
-dot1(x,y) = invoke(dot, Tuple{Any,Any}, x,y)
-dot2(x,y) = invoke(dot, Tuple{AbstractArray,AbstractArray}, x,y)
+dot1(x, y) = invoke(dot, Tuple{Any,Any}, x, y)
+dot2(x, y) = invoke(dot, Tuple{AbstractArray,AbstractArray}, x, y)
 @testset "generic dot" begin
     AA = [1+2im 3+4im; 5+6im 7+8im]
     BB = [2+7im 4+1im; 3+8im 6+5im]
     for A in (copy(AA), view(AA, 1:2, 1:2)), B in (copy(BB), view(BB, 1:2, 1:2))
-        @test dot(A,B) == dot(vec(A),vec(B)) == dot1(A,B) == dot2(A,B) == dot(float.(A),float.(B))
+        @test dot(A, B) == dot(vec(A), vec(B)) == dot1(A, B) == dot2(A, B) == dot(float.(A), float.(B))
         @test dot(Int[], Int[]) == 0 == dot1(Int[], Int[]) == dot2(Int[], Int[])
         @test_throws MethodError dot(Any[], Any[])
         @test_throws MethodError dot1(Any[], Any[])
@@ -458,17 +492,17 @@ end
 
 @testset "Issue 11978" begin
     A = Matrix{Matrix{Float64}}(undef, 2, 2)
-    A[1,1] = Matrix(1.0I, 3, 3)
-    A[2,2] = Matrix(1.0I, 2, 2)
-    A[1,2] = Matrix(1.0I, 3, 2)
-    A[2,1] = Matrix(1.0I, 2, 3)
+    A[1, 1] = Matrix(1.0I, 3, 3)
+    A[2, 2] = Matrix(1.0I, 2, 2)
+    A[1, 2] = Matrix(1.0I, 3, 2)
+    A[2, 1] = Matrix(1.0I, 2, 3)
     b = Vector{Vector{Float64}}(undef, 2)
-    b[1] = fill(1., 3)
-    b[2] = fill(1., 2)
-    @test A*b == Vector{Float64}[[2,2,1], [2,2]]
+    b[1] = fill(1.0, 3)
+    b[2] = fill(1.0, 2)
+    @test A * b == Vector{Float64}[[2, 2, 1], [2, 2]]
 end
 
-@test_throws ArgumentError LinearAlgebra.copytri!(Matrix{Float64}(undef,10,10),'Z')
+@test_throws ArgumentError LinearAlgebra.copytri!(Matrix{Float64}(undef, 10, 10), 'Z')
 
 @testset "Issue 30055" begin
     B = [1+im 2+im 3+im; 4+im 5+im 6+im; 7+im 9+im im]
@@ -479,10 +513,10 @@ end
     @test copy(transpose(A)) == transpose(A)
     @test copy(A') == A'
     B = Matrix{Matrix{Complex{Int}}}(undef, 2, 2)
-    B[1,1] = [1+im 2+im; 3+im 4+im]
-    B[2,1] = [1+2im 1+3im;1+3im 1+4im]
-    B[1,2] = [7+im 8+2im; 9+3im 4im]
-    B[2,2] = [9+im 8+im; 7+im 6+im]
+    B[1, 1] = [1+im 2+im; 3+im 4+im]
+    B[2, 1] = [1+2im 1+3im; 1+3im 1+4im]
+    B[1, 2] = [7+im 8+2im; 9+3im 4im]
+    B[2, 2] = [9+im 8+im; 7+im 6+im]
     A = UpperTriangular(B)
     @test copy(transpose(A)) == transpose(A)
     @test copy(A') == A'
@@ -491,27 +525,27 @@ end
     @test copy(A') == A'
 end
 
-@testset "gemv! and gemm_wrapper for $elty" for elty in [Float32,Float64,ComplexF64,ComplexF32]
-    A10x10, x10, x11 = Array{elty}.(undef, ((10,10), 10, 11))
-    @test_throws DimensionMismatch LinearAlgebra.gemv!(x10,'N',A10x10,x11)
-    @test_throws DimensionMismatch LinearAlgebra.gemv!(x11,'N',A10x10,x10)
-    @test LinearAlgebra.gemv!(elty[], 'N', Matrix{elty}(undef,0,0), elty[]) == elty[]
-    @test LinearAlgebra.gemv!(x10, 'N', Matrix{elty}(undef,10,0), elty[]) == zeros(elty,10)
+@testset "gemv! and gemm_wrapper for $elty" for elty in [Float32, Float64, ComplexF64, ComplexF32]
+    A10x10, x10, x11 = Array{elty}.(undef, ((10, 10), 10, 11))
+    @test_throws DimensionMismatch LinearAlgebra.gemv!(x10, 'N', A10x10, x11)
+    @test_throws DimensionMismatch LinearAlgebra.gemv!(x11, 'N', A10x10, x10)
+    @test LinearAlgebra.gemv!(elty[], 'N', Matrix{elty}(undef, 0, 0), elty[]) == elty[]
+    @test LinearAlgebra.gemv!(x10, 'N', Matrix{elty}(undef, 10, 0), elty[]) == zeros(elty, 10)
 
     I0x0 = Matrix{elty}(I, 0, 0)
     I10x10 = Matrix{elty}(I, 10, 10)
     I10x11 = Matrix{elty}(I, 10, 11)
-    @test LinearAlgebra.gemm_wrapper('N','N', I10x10, I10x10) == I10x10
-    @test_throws DimensionMismatch LinearAlgebra.gemm_wrapper!(I10x10,'N','N', I10x11, I10x10)
-    @test_throws DimensionMismatch LinearAlgebra.gemm_wrapper!(I10x10,'N','N', I0x0, I0x0)
+    @test LinearAlgebra.gemm_wrapper('N', 'N', I10x10, I10x10) == I10x10
+    @test_throws DimensionMismatch LinearAlgebra.gemm_wrapper!(I10x10, 'N', 'N', I10x11, I10x10)
+    @test_throws DimensionMismatch LinearAlgebra.gemm_wrapper!(I10x10, 'N', 'N', I0x0, I0x0)
 
-    A = rand(elty,3,3)
-    @test LinearAlgebra.matmul3x3('T','N',A, Matrix{elty}(I, 3, 3)) == transpose(A)
+    A = rand(elty, 3, 3)
+    @test LinearAlgebra.matmul3x3('T', 'N', A, Matrix{elty}(I, 3, 3)) == transpose(A)
 end
 
 @testset "#13593, #13488" begin
-    aa = rand(3,3)
-    bb = rand(3,3)
+    aa = rand(3, 3)
+    bb = rand(3, 3)
     for a in (copy(aa), view(aa, 1:3, 1:3)), b in (copy(bb), view(bb, 1:3, 1:3))
         @test_throws ArgumentError mul!(a, a, b)
         @test_throws ArgumentError mul!(a, b, a)
@@ -532,7 +566,7 @@ struct RootInt
 end
 import Base: *, adjoint, transpose
 import LinearAlgebra: Adjoint, Transpose
-(*)(x::RootInt, y::RootInt) = x.i*y.i
+(*)(x::RootInt, y::RootInt) = x.i * y.i
 adjoint(x::RootInt) = x
 transpose(x::RootInt) = x
 Adjoint(x::RootInt) = x
@@ -550,16 +584,16 @@ Transpose(x::RootInt) = x
     C = [1]
     mul!(C, a, transpose(a), 2, 3)
     @test C[1] == 21
-    a = [RootInt(2),RootInt(10)]
-    @test a*adjoint(a) == [4 20; 20 100]
+    a = [RootInt(2), RootInt(10)]
+    @test a * adjoint(a) == [4 20; 20 100]
     A = [RootInt(3) RootInt(5)]
-    @test A*a == [56]
+    @test A * a == [56]
 end
 
 function test_mul(C, A, B)
     mul!(C, A, B)
     @test Array(A) * Array(B) ≈ C
-    @test A*B ≈ C
+    @test A * B ≈ C
 
     # This is similar to how `isapprox` choose `rtol` (when `atol=0`)
     # but consider all number types involved:
@@ -572,20 +606,20 @@ function test_mul(C, A, B)
     βArrayC = β * Array(C)
     βC = β * C
     mul!(C, A, B, α, β)
-    @test α * Array(A) * Array(B) .+ βArrayC ≈ C  rtol=rtol
-    @test α * A * B .+ βC ≈ C  rtol=rtol
+    @test α * Array(A) * Array(B) .+ βArrayC ≈ C rtol = rtol
+    @test α * A * B .+ βC ≈ C rtol = rtol
 end
 
 @testset "mul! vs * for special types" begin
     eltypes = [Float32, Float64, Int64]
     for k in [3, 4, 10]
         T = rand(eltypes)
-        bi1 = Bidiagonal(rand(T, k), rand(T, k-1), rand([:U, :L]))
-        bi2 = Bidiagonal(rand(T, k), rand(T, k-1), rand([:U, :L]))
-        tri1 = Tridiagonal(rand(T,k-1), rand(T, k), rand(T, k-1))
-        tri2 = Tridiagonal(rand(T,k-1), rand(T, k), rand(T, k-1))
-        stri1 = SymTridiagonal(rand(T, k), rand(T, k-1))
-        stri2 = SymTridiagonal(rand(T, k), rand(T, k-1))
+        bi1 = Bidiagonal(rand(T, k), rand(T, k - 1), rand([:U, :L]))
+        bi2 = Bidiagonal(rand(T, k), rand(T, k - 1), rand([:U, :L]))
+        tri1 = Tridiagonal(rand(T, k - 1), rand(T, k), rand(T, k - 1))
+        tri2 = Tridiagonal(rand(T, k - 1), rand(T, k), rand(T, k - 1))
+        stri1 = SymTridiagonal(rand(T, k), rand(T, k - 1))
+        stri2 = SymTridiagonal(rand(T, k), rand(T, k - 1))
         C = rand(T, k, k)
         specialmatrices = (bi1, bi2, tri1, tri2, stri1, stri2)
         for A in specialmatrices
@@ -605,7 +639,7 @@ end
     for T in eltypes
         A = Bidiagonal(rand(T, 2), rand(T, 1), rand([:U, :L]))
         B = Bidiagonal(rand(T, 2), rand(T, 1), rand([:U, :L]))
-        C = randn(2,2)
+        C = randn(2, 2)
         test_mul(C, A, B)
         B = randn(2, 9)
         C = randn(2, 9)
@@ -628,69 +662,69 @@ end
 
 # #18218
 module TestPR18218
-    using Test
-    import Base.*, Base.+, Base.zero
-    struct TypeA
-        x::Int
-    end
-    Base.convert(::Type{TypeA}, x::Int) = TypeA(x)
-    struct TypeB
-        x::Int
-    end
-    struct TypeC
-        x::Int
-    end
-    Base.convert(::Type{TypeC}, x::Int) = TypeC(x)
-    zero(c::TypeC) = TypeC(0)
-    zero(::Type{TypeC}) = TypeC(0)
-    (*)(x::Int, a::TypeA) = TypeB(x*a.x)
-    (*)(a::TypeA, x::Int) = TypeB(a.x*x)
-    (+)(a::Union{TypeB,TypeC}, b::Union{TypeB,TypeC}) = TypeC(a.x+b.x)
-    A = TypeA[1 2; 3 4]
-    b = [1, 2]
-    d = A * b
-    @test typeof(d) == Vector{TypeC}
-    @test d == TypeC[5, 11]
+using Test
+import Base.*, Base.+, Base.zero
+struct TypeA
+    x::Int
+end
+Base.convert(::Type{TypeA}, x::Int) = TypeA(x)
+struct TypeB
+    x::Int
+end
+struct TypeC
+    x::Int
+end
+Base.convert(::Type{TypeC}, x::Int) = TypeC(x)
+zero(c::TypeC) = TypeC(0)
+zero(::Type{TypeC}) = TypeC(0)
+(*)(x::Int, a::TypeA) = TypeB(x * a.x)
+(*)(a::TypeA, x::Int) = TypeB(a.x * x)
+(+)(a::Union{TypeB,TypeC}, b::Union{TypeB,TypeC}) = TypeC(a.x + b.x)
+A = TypeA[1 2; 3 4]
+b = [1, 2]
+d = A * b
+@test typeof(d) == Vector{TypeC}
+@test d == TypeC[5, 11]
 end
 
 @testset "VecOrMat of Vectors" begin
-    X   = rand(ComplexF64, 3, 3)
-    Xv1 = [X[:,j] for i in 1:1, j in 1:3]
-    Xv2 = [transpose(X[i,:]) for i in 1:3]
-    Xv3 = [transpose(X[i,:]) for i in 1:3, j in 1:1]
+    X = rand(ComplexF64, 3, 3)
+    Xv1 = [X[:, j] for i in 1:1, j in 1:3]
+    Xv2 = [transpose(X[i, :]) for i in 1:3]
+    Xv3 = [transpose(X[i, :]) for i in 1:3, j in 1:1]
 
-    XX   = X*X
-    XtX  = transpose(X)*X
-    XcX  = X'*X
-    XXt  = X*transpose(X)
+    XX = X * X
+    XtX = transpose(X) * X
+    XcX = X' * X
+    XXt = X * transpose(X)
     XtXt = transpose(XX)
-    XcXt = X'*transpose(X)
-    XXc  = X*X'
-    XtXc = transpose(X)*X'
-    XcXc = X'*X'
+    XcXt = X' * transpose(X)
+    XXc = X * X'
+    XtXc = transpose(X) * X'
+    XcXc = X' * X'
 
     @test (Xv1*Xv2)[1] ≈ XX
     @test (Xv1*Xv3)[1] ≈ XX
-    @test  transpose(Xv1)*Xv1     ≈ XtX
-    @test  transpose(Xv2)*Xv2     ≈ XtX
+    @test transpose(Xv1) * Xv1 ≈ XtX
+    @test transpose(Xv2) * Xv2 ≈ XtX
     @test (transpose(Xv3)*Xv3)[1] ≈ XtX
-    @test  Xv1'*Xv1     ≈ XcX
-    @test  Xv2'*Xv2     ≈ XcX
+    @test Xv1' * Xv1 ≈ XcX
+    @test Xv2' * Xv2 ≈ XcX
     @test (Xv3'*Xv3)[1] ≈ XcX
     @test (Xv1*transpose(Xv1))[1] ≈ XXt
-    @test  Xv2*transpose(Xv2)     ≈ XXt
-    @test  Xv3*transpose(Xv3)     ≈ XXt
-    @test transpose(Xv1)*transpose(Xv2) ≈ XtXt
-    @test transpose(Xv1)*transpose(Xv3) ≈ XtXt
-    @test  Xv1'*transpose(Xv2) ≈ XcXt
-    @test  Xv1'*transpose(Xv3) ≈ XcXt
+    @test Xv2 * transpose(Xv2) ≈ XXt
+    @test Xv3 * transpose(Xv3) ≈ XXt
+    @test transpose(Xv1) * transpose(Xv2) ≈ XtXt
+    @test transpose(Xv1) * transpose(Xv3) ≈ XtXt
+    @test Xv1' * transpose(Xv2) ≈ XcXt
+    @test Xv1' * transpose(Xv3) ≈ XcXt
     @test (Xv1*Xv1')[1] ≈ XXc
-    @test  Xv2*Xv2'     ≈ XXc
-    @test  Xv3*Xv3'     ≈ XXc
-    @test transpose(Xv1)*Xv2' ≈ XtXc
-    @test transpose(Xv1)*Xv3' ≈ XtXc
-    @test Xv1'*Xv2' ≈ XcXc
-    @test Xv1'*Xv3' ≈ XcXc
+    @test Xv2 * Xv2' ≈ XXc
+    @test Xv3 * Xv3' ≈ XXc
+    @test transpose(Xv1) * Xv2' ≈ XtXc
+    @test transpose(Xv1) * Xv3' ≈ XtXc
+    @test Xv1' * Xv2' ≈ XcXc
+    @test Xv1' * Xv3' ≈ XcXc
 end
 
 @testset "method ambiguity" begin
@@ -698,7 +732,7 @@ end
     # https://github.com/JuliaLang/julia/issues/28804
     script = joinpath(@__DIR__, "ambiguous_exec.jl")
     cmd = `$(Base.julia_cmd()) --startup-file=no $script`
-    @test success(pipeline(cmd; stdout=stdout, stderr=stderr))
+    @test success(pipeline(cmd; stdout = stdout, stderr = stderr))
 end
 
 struct A32092
@@ -747,7 +781,7 @@ end
     @test (A * v == v) === missing
     M = fill(1.0, 2, 2)
     a = fill(missing, 2, 1)
-    @test (a' * M * a == fill(missing,1,1)) === missing
+    @test (a' * M * a == fill(missing, 1, 1)) === missing
 end
 
 
@@ -768,48 +802,48 @@ end
 
 @testset "3-arg *, order by type" begin
     x = [1, 2im]
-    y = [im, 20, 30+40im]
-    z = [-1, 200+im, -3]
+    y = [im, 20, 30 + 40im]
+    z = [-1, 200 + im, -3]
     A = [1 2 3im; 4 5 6+im]
     B = [-10 -20; -30 -40]
-    a = 3 + im * round(Int, 10^6*(pi-3))
+    a = 3 + im * round(Int, 10^6 * (pi - 3))
     b = 123
 
-    @test x'*A*y == (x'*A)*y == x'*(A*y)
-    @test y'*A'*x == (y'*A')*x == y'*(A'*x)
-    @test y'*transpose(A)*x == (y'*transpose(A))*x == y'*(transpose(A)*x)
+    @test x' * A * y == (x' * A) * y == x' * (A * y)
+    @test y' * A' * x == (y' * A') * x == y' * (A' * x)
+    @test y' * transpose(A) * x == (y' * transpose(A)) * x == y' * (transpose(A) * x)
 
-    @test B*A*y == (B*A)*y == B*(A*y)
+    @test B * A * y == (B * A) * y == B * (A * y)
 
-    @test a*A*y == (a*A)*y == a*(A*y)
-    @test A*y*a == (A*y)*a == A*(y*a)
+    @test a * A * y == (a * A) * y == a * (A * y)
+    @test A * y * a == (A * y) * a == A * (y * a)
 
-    @test a*B*A == (a*B)*A == a*(B*A)
-    @test B*A*a == (B*A)*a == B*(A*a)
+    @test a * B * A == (a * B) * A == a * (B * A)
+    @test B * A * a == (B * A) * a == B * (A * a)
 
-    @test a*y'*z == (a*y')*z == a*(y'*z)
-    @test y'*z*a == (y'*z)*a == y'*(z*a)
+    @test a * y' * z == (a * y') * z == a * (y' * z)
+    @test y' * z * a == (y' * z) * a == y' * (z * a)
 
-    @test a*y*z' == (a*y)*z' == a*(y*z')
-    @test y*z'*a == (y*z')*a == y*(z'*a)
+    @test a * y * z' == (a * y) * z' == a * (y * z')
+    @test y * z' * a == (y * z') * a == y * (z' * a)
 
-    @test a*x'*A == (a*x')*A == a*(x'*A)
-    @test x'*A*a == (x'*A)*a == x'*(A*a)
-    @test a*x'*A isa Adjoint{<:Any, <:Vector}
+    @test a * x' * A == (a * x') * A == a * (x' * A)
+    @test x' * A * a == (x' * A) * a == x' * (A * a)
+    @test a * x' * A isa Adjoint{<:Any,<:Vector}
 
-    @test a*transpose(x)*A == (a*transpose(x))*A == a*(transpose(x)*A)
-    @test transpose(x)*A*a == (transpose(x)*A)*a == transpose(x)*(A*a)
-    @test a*transpose(x)*A isa Transpose{<:Any, <:Vector}
+    @test a * transpose(x) * A == (a * transpose(x)) * A == a * (transpose(x) * A)
+    @test transpose(x) * A * a == (transpose(x) * A) * a == transpose(x) * (A * a)
+    @test a * transpose(x) * A isa Transpose{<:Any,<:Vector}
 
-    @test x'*B*A == (x'*B)*A == x'*(B*A)
-    @test x'*B*A isa Adjoint{<:Any, <:Vector}
+    @test x' * B * A == (x' * B) * A == x' * (B * A)
+    @test x' * B * A isa Adjoint{<:Any,<:Vector}
 
-    @test y*x'*A == (y*x')*A == y*(x'*A)
-    y31 = reshape(y,3,1)
-    @test y31*x'*A == (y31*x')*A == y31*(x'*A)
+    @test y * x' * A == (y * x') * A == y * (x' * A)
+    y31 = reshape(y, 3, 1)
+    @test y31 * x' * A == (y31 * x') * A == y31 * (x' * A)
 
-    vm = [rand(1:9,2,2) for _ in 1:3]
-    Mm = [rand(1:9,2,2) for _ in 1:3, _ in 1:3]
+    vm = [rand(1:9, 2, 2) for _ in 1:3]
+    Mm = [rand(1:9, 2, 2) for _ in 1:3, _ in 1:3]
 
     @test vm' * Mm * vm == (vm' * Mm) * vm == vm' * (Mm * vm)
     @test Mm * Mm' * vm == (Mm * Mm') * vm == Mm * (Mm' * vm)
@@ -818,50 +852,53 @@ end
 end
 
 @testset "3-arg *, order by size" begin
-    M44 = randn(4,4)
-    M24 = randn(2,4)
-    M42 = randn(4,2)
-    @test M44*M44*M44 ≈ (M44*M44)*M44 ≈ M44*(M44*M44)
-    @test M42*M24*M44 ≈ (M42*M24)*M44 ≈ M42*(M24*M44)
-    @test M44*M42*M24 ≈ (M44*M42)*M24 ≈ M44*(M42*M24)
+    M44 = randn(4, 4)
+    M24 = randn(2, 4)
+    M42 = randn(4, 2)
+    @test M44 * M44 * M44 ≈ (M44 * M44) * M44 ≈ M44 * (M44 * M44)
+    @test M42 * M24 * M44 ≈ (M42 * M24) * M44 ≈ M42 * (M24 * M44)
+    @test M44 * M42 * M24 ≈ (M44 * M42) * M24 ≈ M44 * (M42 * M24)
 end
 
 @testset "4-arg *, by type" begin
-    y = [im, 20, 30+40im]
-    z = [-1, 200+im, -3]
-    a = 3 + im * round(Int, 10^6*(pi-3))
+    y = [im, 20, 30 + 40im]
+    z = [-1, 200 + im, -3]
+    a = 3 + im * round(Int, 10^6 * (pi - 3))
     b = 123
-    M = rand(vcat(1:9, im.*[1,2,3]), 3,3)
-    N = rand(vcat(1:9, im.*[1,2,3]), 3,3)
+    M = rand(vcat(1:9, im .* [1, 2, 3]), 3, 3)
+    N = rand(vcat(1:9, im .* [1, 2, 3]), 3, 3)
 
-    @test a * b * M * y == (a*b) * (M*y)
-    @test a * b * M * N == (a*b) * (M*N)
-    @test a * M * N * y == (a*M) * (N*y)
-    @test a * y' * M * z == (a*y') * (M*z)
-    @test a * y' * M * N == (a*y') * (M*N)
+    @test a * b * M * y == (a * b) * (M * y)
+    @test a * b * M * N == (a * b) * (M * N)
+    @test a * M * N * y == (a * M) * (N * y)
+    @test a * y' * M * z == (a * y') * (M * z)
+    @test a * y' * M * N == (a * y') * (M * N)
 
-    @test M * y * a * b == (M*y) * (a*b)
-    @test M * N * a * b == (M*N) * (a*b)
-    @test M * N * y * a == (a*M) * (N*y)
-    @test y' * M * z * a == (a*y') * (M*z)
-    @test y' * M * N * a == (a*y') * (M*N)
+    @test M * y * a * b == (M * y) * (a * b)
+    @test M * N * a * b == (M * N) * (a * b)
+    @test M * N * y * a == (a * M) * (N * y)
+    @test y' * M * z * a == (a * y') * (M * z)
+    @test y' * M * N * a == (a * y') * (M * N)
 
-    @test M * N * conj(M) * y == (M*N) * (conj(M)*y)
-    @test y' * M * N * conj(M) == (y'*M) * (N*conj(M))
-    @test y' * M * N * z == (y'*M) * (N*z)
+    @test M * N * conj(M) * y == (M * N) * (conj(M) * y)
+    @test y' * M * N * conj(M) == (y' * M) * (N * conj(M))
+    @test y' * M * N * z == (y' * M) * (N * z)
 end
 
 @testset "4-arg *, by size" begin
     for shift in 1:5
-        s1,s2,s3,s4,s5 = circshift(3:7, shift)
-        a=randn(s1,s2); b=randn(s2,s3); c=randn(s3,s4); d=randn(s4,s5)
+        s1, s2, s3, s4, s5 = circshift(3:7, shift)
+        a = randn(s1, s2)
+        b = randn(s2, s3)
+        c = randn(s3, s4)
+        d = randn(s4, s5)
 
         # _quad_matmul
-        @test *(a,b,c,d) ≈ (a*b) * (c*d)
+        @test *(a, b, c, d) ≈ (a * b) * (c * d)
 
         # _tri_matmul(A,B,B,δ)
-        @test *(11.1,b,c,d) ≈ (11.1*b) * (c*d)
-        @test *(a,b,c,99.9) ≈ (a*b) * (c*99.9)
+        @test *(11.1, b, c, d) ≈ (11.1 * b) * (c * d)
+        @test *(a, b, c, 99.9) ≈ (a * b) * (c * 99.9)
     end
 end
 


### PR DESCRIPTION
```julia
julia> M = rand(Float32, 1000, 1000); V = rand(ComplexF32, size(M,2))

julia> C32_1 = @btime $M * $V; # current master
  714.915 μs (1 allocation: 7.94 KiB)

julia> Revise.track(LinearAlgebra)

julia> C32_2 = @btime $M * $V; # this PR
  342.096 μs (1 allocation: 7.94 KiB)

julia> C32_1 ≈ C32_2
true
```

and similarly for `Float64`. Currently this hits `generic_matvecmul!`, which is presumably slow.

I had also tried to add a similar method for real matrix * complex matrix, but for some reason that I don't understand this makes `BLAS.gemm!` (consequently M1 * M2) worse. I have removed that method from this PR.

Sorry about the numerous whitespace changes introduced by the VSCode plugin, however hopefully these will improve readability. I haven't figured out how to disable this.