### PR TITLE
RFC: Let MultiSelectMenu return nothing on quit

### DIFF
--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -616,7 +616,7 @@ The MultiSelectMenu allows users to select many choices from a list.
 menu = MultiSelectMenu(options)
 
 # `request` returns a `Set` of selected indices
-# if the menu us canceled (ctrl-c or q), return an empty set
+# if the menu us canceled (ctrl-c or q), return `nothing`
 choices = request("Select the fruits you like:", menu)
 
 if length(choices) > 0

--- a/stdlib/REPL/src/TerminalMenus/MultiSelectMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/MultiSelectMenu.jl
@@ -32,6 +32,7 @@ mutable struct MultiSelectMenu{C} <: _ConfiguredMenu{C}
     pagesize::Int
     pageoffset::Int
     selected::Set{Int}
+    quit::Bool
     config::C
 end
 
@@ -42,7 +43,7 @@ end
 
 Create a MultiSelectMenu object. Use `request(menu::MultiSelectMenu)` to get
 user input. It returns a `Set` containing the indices of options that
-were selected by the user.
+were selected by the user, or `nothing` if the menu was canceled.
 
 # Arguments
 
@@ -75,9 +76,8 @@ function MultiSelectMenu(options::Array{String,1}; pagesize::Int=10, selected=In
         MultiSelectMenu(options, pagesize, pageoffset, _selected, MultiSelectConfig(; kwargs...))
     else
         warn && Base.depwarn("Legacy `MultiSelectMenu` interface is deprecated, set a configuration option such as `MultiSelectMenu(options; charset=:ascii)` to trigger the new interface.", :MultiSelectMenu)
-        MultiSelectMenu(options, pagesize, pageoffset, _selected, CONFIG)
+        MultiSelectMenu(options, pagesize, pageoffset, _selected, false, CONFIG)
     end
-
 end
 
 
@@ -86,14 +86,14 @@ end
 # See AbstractMenu.jl
 #######################################
 
-header(m::MultiSelectMenu) = "[press: d=done, a=all, n=none]"
-
+header(m::MultiSelectMenu) = "[press: q=quit, d=done, a=all, n=none]"
 options(m::MultiSelectMenu) = m.options
-
-cancel(m::MultiSelectMenu) = m.selected = Set{Int}()
+cancel(m::MultiSelectMenu) = m.quit = true
+selected(m::MultiSelectMenu) = m.quit ? nothing : m.selected
 
 # Do not exit menu when a user selects one of the options
 function pick(menu::MultiSelectMenu, cursor::Int)
+    menu.quit = false
     if cursor in menu.selected
         delete!(menu.selected, cursor)
     else
@@ -117,6 +117,7 @@ end
 # a: Select all
 # n: Deselect all
 function keypress(menu::MultiSelectMenu, key::UInt32)
+    menu.quit = false
     if key == UInt32('d') || key == UInt32('D')
         return true # break
     elseif key == UInt32('a') || key == UInt32('A')

--- a/stdlib/REPL/src/TerminalMenus/MultiSelectMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/MultiSelectMenu.jl
@@ -73,7 +73,7 @@ function MultiSelectMenu(options::Array{String,1}; pagesize::Int=10, selected=In
     end
 
     if !isempty(kwargs)
-        MultiSelectMenu(options, pagesize, pageoffset, _selected, MultiSelectConfig(; kwargs...))
+        MultiSelectMenu(options, pagesize, pageoffset, _selected, false, MultiSelectConfig(; kwargs...))
     else
         warn && Base.depwarn("Legacy `MultiSelectMenu` interface is deprecated, set a configuration option such as `MultiSelectMenu(options; charset=:ascii)` to trigger the new interface.", :MultiSelectMenu)
         MultiSelectMenu(options, pagesize, pageoffset, _selected, false, CONFIG)


### PR DESCRIPTION
MultiSelectMenu used to return Set{Int}() when quit, but this made it
impossible to distinguish between the choice of no elements and the
lack of a choice.
Now, the menu returns nothing when quit.

Also updates the header to include "q=quit".

__NOTE__ that this is probably a breaking change.
It addresses #44002 - this PR is more to start a discussion.
If this can be done in a reasonably non-breaking way, I can make the PR.