### PR TITLE
Fix `Diagonal \ StaticArray`

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -352,7 +352,7 @@ function mul!(C::AbstractMatrix, Da::Diagonal, Db::Diagonal, alpha::Number, beta
 end
 
 _init(op, A::AbstractArray{<:Number}, B::AbstractArray{<:Number}) =
-    (_ -> zero(typeof(op(oneunit(eltype(A)), oneunit(eltype(D)))))
+    (_ -> zero(typeof(op(oneunit(eltype(A)), oneunit(eltype(D))))))
 _init(op, A::AbstractArray, B::AbstractArray) =
     promote_op(op, eltype(A), eltype(B))
 /(A::AbstractVecOrMat, D::Diagonal) = _rdiv!(_init(/, A, D).(A), A, D)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -373,11 +373,15 @@ function _rdiv!(B::AbstractVecOrMat, A::AbstractVecOrMat, D::Diagonal)
     B
 end
 
-function \(D::Diagonal, B::AbstractVecOrMat)
+function \(D::Diagonal, B::AbstractVector)
     j = findfirst(iszero, D.diag)
     isnothing(j) || throw(SingularException(j))
     return D.diag .\ B
 end
+# ugly hack in order to preserve structure like *diagonal, but at the same time allow for
+# eltype conversion of unconvertible types (like units)
+\(D::Diagonal, B::AbstractMatrix) =
+    ldiv!((_ -> zero(promote_op(\, eltype(D), eltype(B)))).(B), D, B)
 
 ldiv!(D::Diagonal, B::AbstractVecOrMat) = @inline ldiv!(B, D, B)
 function ldiv!(B::AbstractVecOrMat, D::Diagonal, A::AbstractVecOrMat)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -352,11 +352,10 @@ function mul!(C::AbstractMatrix, Da::Diagonal, Db::Diagonal, alpha::Number, beta
 end
 
 _init(op, A::AbstractArray{<:Number}, B::AbstractArray{<:Number}) =
-    (_ -> zero(typeof(op(oneunit(eltype(A)), oneunit(eltype(D))))))
-_init(op, A::AbstractArray, B::AbstractArray) =
-    promote_op(op, eltype(A), eltype(B))
-/(A::AbstractVecOrMat, D::Diagonal) = _rdiv!(_init(/, A, D).(A), A, D)
+    (_ -> zero(typeof(op(oneunit(eltype(A)), oneunit(eltype(B))))))
+_init(op, A::AbstractArray, B::AbstractArray) = promote_op(op, eltype(A), eltype(B))
 
+/(A::AbstractVecOrMat, D::Diagonal) = _rdiv!(_init(/, A, D).(A), A, D)
 rdiv!(A::AbstractVecOrMat, D::Diagonal) = @inline _rdiv!(A, A, D)
 # avoid copy when possible via internal 3-arg backend
 function _rdiv!(B::AbstractVecOrMat, A::AbstractVecOrMat, D::Diagonal)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -353,6 +353,8 @@ end
 
 /(A::AbstractVecOrMat, D::Diagonal) =
     _rdiv!((promote_op(/, eltype(A), eltype(D))).(A), A, D)
+/(A::AbstractVecOrMat{<:Number}, D::Diagonal{<:Number}) =
+    _rdiv!((_ -> zero(typeof(oneunit(eltype(A)) / oneunit(eltype(D))))).(A), A, D)
 
 rdiv!(A::AbstractVecOrMat, D::Diagonal) = @inline _rdiv!(A, A, D)
 # avoid copy when possible via internal 3-arg backend
@@ -378,10 +380,12 @@ function \(D::Diagonal, B::AbstractVector)
     isnothing(j) || throw(SingularException(j))
     return D.diag .\ B
 end
+\(D::Diagonal, B::AbstractVecOrMat) =
+    ldiv!(promote_op(\, eltype(D), eltype(B)).(B), D, B)
 # ugly hack in order to preserve structure like *diagonal, but at the same time allow for
 # eltype conversion of unconvertible types (like units)
-\(D::Diagonal, B::AbstractMatrix) =
-    ldiv!((_ -> zero(promote_op(\, eltype(D), eltype(B)))).(B), D, B)
+\(D::Diagonal{<:Number}, B::AbstractMatrix{<:Number}) =
+    ldiv!((_ -> zero(typeof(oneunit(eltype(D)) \ oneunit(eltype(B))))).(B), D, B)
 
 ldiv!(D::Diagonal, B::AbstractVecOrMat) = @inline ldiv!(B, D, B)
 function ldiv!(B::AbstractVecOrMat, D::Diagonal, A::AbstractVecOrMat)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -373,8 +373,11 @@ function _rdiv!(B::AbstractVecOrMat, A::AbstractVecOrMat, D::Diagonal)
     B
 end
 
-\(D::Diagonal, B::AbstractVecOrMat) =
-    ldiv!(promote_op(\, eltype(D), eltype(B)).(B), D, B)
+function \(D::Diagonal, B::AbstractVecOrMat)
+    j = findfirst(iszero, D.diag)
+    isnothing(j) || throw(SingularException(j))
+    return D.diag .\ B
+end
 
 ldiv!(D::Diagonal, B::AbstractVecOrMat) = @inline ldiv!(B, D, B)
 function ldiv!(B::AbstractVecOrMat, D::Diagonal, A::AbstractVecOrMat)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -808,6 +808,10 @@ end
             @test DS isa Tridiagonal
             DM = D \ Mm
             for i in -1:1; @test diag(DS, i) ≈ diag(DM, i) end
+            DS = M / D
+            @test DS isa Tridiagonal
+            DM = Mm / D
+            for i in -1:1; @test diag(DS, i) ≈ diag(DM, i) end
         end
     end
     # eltype promotion case


### PR DESCRIPTION
This restores the old behavior, but keeps the singularity check which was the only reason why this method directed to 3-arg `ldiv!`.