### PR TITLE
Generalize `strides` for `ReinterpretArray` and `ReshapedArray`

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -176,6 +176,8 @@ function _checked_strides(stp, N)
     map(first, drs)
 end
 
+_checkcontiguous(::Type{Bool}, A::ReinterpretArray) = _checkcontiguous(Bool, parent(A))
+
 similar(a::ReinterpretArray, T::Type, d::Dims) = similar(a.parent, T, d)
 
 function check_readable(a::ReinterpretArray{T, N, S} where N) where {T,S}

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -242,7 +242,7 @@ end
 
 @inline function _unsafe_getindex(A::ReshapedArray{T,N}, indices::Vararg{Int,N}) where {T,N}
     axp = axes(A.parent)
-    i = offset_if_vec(Base._sub2ind(size(A), indices...), axp)
+    i = offset_if_vec(_sub2ind(size(A), indices...), axp)
     I = ind2sub_rs(axp, A.mi, i)
     _unsafe_getindex_rs(parent(A), I)
 end
@@ -266,7 +266,7 @@ end
 
 @inline function _unsafe_setindex!(A::ReshapedArray{T,N}, val, indices::Vararg{Int,N}) where {T,N}
     axp = axes(A.parent)
-    i = offset_if_vec(Base._sub2ind(size(A), indices...), axp)
+    i = offset_if_vec(_sub2ind(size(A), indices...), axp)
     @inbounds parent(A)[ind2sub_rs(axes(A.parent), A.mi, i)...] = val
     val
 end

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -295,7 +295,7 @@ unsafe_convert(::Type{Ptr{T}}, V::SubArray{T,N,P,<:Tuple{Vararg{Union{RangeIndex
 
 
 _checkcontiguous(::Type{Bool}, A::AbstractArray) = size_to_strides(1, size(A)...) == strides(A)
-_checkcontiguous(::Type{Bool}, A::DenseArray) = true
+_checkcontiguous(::Type{Bool}, A::Array) = true
 _checkcontiguous(::Type{Bool}, A::ReshapedArray) = _checkcontiguous(Bool, parent(A))
 _checkcontiguous(::Type{Bool}, A::FastContiguousSubArray) = _checkcontiguous(Bool, parent(A))
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1561,3 +1561,24 @@ end
     r = Base.IdentityUnitRange(3:4)
     @test reshape(r, :) === reshape(r, (:,)) === r
 end
+
+@testset "strides for ReshapedArray" begin
+    # Type-based contiguous check
+    a = vec(reinterpret(reshape,Int16,reshape(view(reinterpret(Int32,randn(Float64,100)),2:11),5,:)))
+    @test only(only(code_typed(Base._checkcontiguous, Base.typesof(Bool, a))).first.code).val
+    @test strides(a) == (1,)
+    # General contiguous check
+    a = view(rand(10,10), 1:10, 1:10)
+    @test strides(vec(a)) == (1,)
+    b = view(parent(a), 1:9, 1:10)
+    @test_throws "Parent must be contiguous." strides(vec(b))
+    # StridedVector parent
+    for n in 1:3
+        a = view(collect(1:60n), 1:n:60n)
+        @test strides(reshape(a, 3, 4, 5)) == (n, 3n, 12n)
+        @test strides(reshape(a, 5, 6, 2)) == (n, 5n, 30n)
+        b = view(parent(a), 60n:-n:1)
+        @test strides(reshape(b, 3, 4, 5)) == (-n, -3n, -12n)
+        @test strides(reshape(b, 5, 6, 2)) == (-n, -5n, -30n)
+    end
+end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1563,10 +1563,7 @@ end
 end
 
 @testset "strides for ReshapedArray" begin
-    # Type-based contiguous check
-    a = vec(reinterpret(reshape,Int16,reshape(view(reinterpret(Int32,randn(Float64,100)),2:11),5,:)))
-    @test only(only(code_typed(Base._checkcontiguous, Base.typesof(Bool, a))).first.code).val
-    @test strides(a) == (1,)
+    # Type-based contiguous check is tested in test/compiler/inline.jl
     # General contiguous check
     a = view(rand(10,10), 1:10, 1:10)
     @test strides(vec(a)) == (1,)

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -907,3 +907,10 @@ end
 @test fully_eliminated((String,)) do x
     Base.@invoke conditional_escape!(false::Any, x::Any)
 end
+
+@testset "strides for ReshapedArray (PR#44027)" begin
+    # Type-based contiguous check
+    a = vec(reinterpret(reshape,Int16,reshape(view(reinterpret(Int32,randn(10)),2:11),5,:)))
+    f(a) = only(strides(a));
+    @test fully_eliminated(f, Tuple{typeof(a)}) && f(a) == 1
+end

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -169,8 +169,8 @@ function check_strides(A::AbstractArray)
 end
 
 @testset "strides for NonReshapedReinterpretArray" begin
-    A = Array{Int32}(reshape(1:72, 9, 8))
-    for viewax2 in (1:8, 1:2:6, 7:-1:1, 5:-2:1)
+    A = Array{Int32}(reshape(1:88, 11, 8))
+    for viewax2 in (1:8, 1:2:6, 7:-1:1, 5:-2:1, 2:3:8, 7:-6:1, 3:5:11)
         # dim1 is contiguous
         for T in (Int16, Float32)
             @test check_strides(reinterpret(T, view(A, 1:8, viewax2)))
@@ -179,6 +179,17 @@ end
             @test check_strides(reinterpret(Int64, view(A, 1:8, viewax2)))
         else
             @test_throws "Parent's strides" strides(reinterpret(Int64, view(A, 1:8, viewax2)))
+        end
+        # non-integer-multipled classified
+        if mod(step(viewax2), 3) == 0
+            @test check_strides(reinterpret(NTuple{3,Int16}, view(A, 2:7, viewax2)))
+        else
+            @test_throws "Parent's strides" strides(reinterpret(NTuple{3,Int16}, view(A, 2:7, viewax2)))
+        end
+        if mod(step(viewax2), 5) == 0
+            @test check_strides(reinterpret(NTuple{5,Int16}, view(A, 2:11, viewax2)))
+        else
+            @test_throws "Parent's strides" strides(reinterpret(NTuple{5,Int16}, view(A, 2:11, viewax2)))
         end
         # dim1 is not contiguous
         for T in (Int16, Int64)


### PR DESCRIPTION
`strides` for `ReinterpretArray` was genelized in #37414, but it works only for contiguous parent (So the check there is also not correct.)
This PR tries to extend it by using parent's `strides` rather than self's `size` during calculation.

Similar generalization is also applied to `ReshapedArray`.

Test added.