### PR TITLE
Inferrability: eliminate more Core.Box

### DIFF
--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -629,8 +629,10 @@ function show_ir_stmt(io::IO, code::Union{IRCode, CodeInfo}, idx::Int, line_info
 
         @assert new_node_inst !== UNDEF # we filtered these out earlier
         show_type = should_print_ssa_type(new_node_inst)
-        with_output_color(:green, io) do io′
-            print_stmt(io′, node_idx, new_node_inst, used, maxlength_idx, false, show_type)
+        let maxlength_idx=maxlength_idx, show_type=show_type
+            with_output_color(:green, io) do io′
+                print_stmt(io′, node_idx, new_node_inst, used, maxlength_idx, false, show_type)
+            end
         end
 
         if new_node_type === UNDEF # try to be robust against errors

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -345,13 +345,15 @@ function showerror_ambiguous(io::IO, meth, f, args)
         sigfix = typeintersect(m.sig, sigfix)
     end
     if isa(unwrap_unionall(sigfix), DataType) && sigfix <: Tuple
-        if all(m->morespecific(sigfix, m.sig), meth)
-            print(io, "\nPossible fix, define\n  ")
-            Base.show_tuple_as_call(io, :function,  sigfix)
-        else
-            println(io)
-            print(io, "To resolve the ambiguity, try making one of the methods more specific, or ")
-            print(io, "adding a new method more specific than any of the existing applicable methods.")
+        let sigfix=sigfix
+            if all(m->morespecific(sigfix, m.sig), meth)
+                print(io, "\nPossible fix, define\n  ")
+                Base.show_tuple_as_call(io, :function,  sigfix)
+            else
+                println(io)
+                print(io, "To resolve the ambiguity, try making one of the methods more specific, or ")
+                print(io, "adding a new method more specific than any of the existing applicable methods.")
+            end
         end
     end
     nothing

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -211,8 +211,8 @@ function print_shell_escaped_posixly(io::IO, args::AbstractString...)
         first || print(io, ' ')
         # avoid printing quotes around simple enough strings
         # that any (reasonable) shell will definitely never consider them to be special
-        have_single = false
-        have_double = false
+        have_single::Bool = false
+        have_double::Bool = false
         function isword(c::AbstractChar)
             if '0' <= c <= '9' || 'a' <= c <= 'z' || 'A' <= c <= 'Z'
                 # word characters

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -130,9 +130,9 @@ end
 
 function getkey(wkh::WeakKeyDict{K}, kk, default) where K
     k = lock(wkh) do
-        k = getkey(wkh.ht, kk, nothing)
-        k === nothing && return nothing
-        return k.value
+        k_ = getkey(wkh.ht, kk, nothing)
+        k_ === nothing && return nothing
+        return k_.value
     end
     return k === nothing ? default : k::K
 end

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -130,9 +130,9 @@ end
 
 function getkey(wkh::WeakKeyDict{K}, kk, default) where K
     k = lock(wkh) do
-        k_ = getkey(wkh.ht, kk, nothing)
-        k_ === nothing && return nothing
-        return k_.value
+        local k = getkey(wkh.ht, kk, nothing)
+        k === nothing && return nothing
+        return k.value
     end
     return k === nothing ? default : k::K
 end

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1979,11 +1979,11 @@ function enter_prefix_search(s::MIState, p::PrefixHistoryPrompt, backward::Bool)
         pss.indent = state(s, parent).indent
         pss.mi = s
     end
-    pss = state(s, p)
+    pss_ = state(s, p)
     if backward
-        history_prev_prefix(pss, pss.histprompt.hp, pss.prefix)
+        history_prev_prefix(pss_, pss_.histprompt.hp, pss_.prefix)
     else
-        history_next_prefix(pss, pss.histprompt.hp, pss.prefix)
+        history_next_prefix(pss_, pss_.histprompt.hp, pss_.prefix)
     end
     nothing
 end

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1971,7 +1971,7 @@ function enter_prefix_search(s::MIState, p::PrefixHistoryPrompt, backward::Bool)
     parent = mode(s)
 
     transition(s, p) do
-        pss = state(s, p)
+        local pss = state(s, p)
         pss.parent = parent
         pss.histprompt.parent_prompt = parent
         pss.prefix = String(buf.data[1:position(buf)])
@@ -1979,11 +1979,11 @@ function enter_prefix_search(s::MIState, p::PrefixHistoryPrompt, backward::Bool)
         pss.indent = state(s, parent).indent
         pss.mi = s
     end
-    pss_ = state(s, p)
+    pss = state(s, p)
     if backward
-        history_prev_prefix(pss_, pss_.histprompt.hp, pss_.prefix)
+        history_prev_prefix(pss, pss.histprompt.hp, pss.prefix)
     else
-        history_next_prefix(pss_, pss_.histprompt.hp, pss_.prefix)
+        history_next_prefix(pss, pss.histprompt.hp, pss.prefix)
     end
     nothing
 end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -87,7 +87,7 @@ struct Pass <: Result
     value
     source::Union{Nothing,LineNumberNode}
     message_only::Bool
-    function Pass(test_type::Symbol, orig_expr, data, thrown, source=nothing, message_only=false)
+    function Pass(test_type::Symbol, orig_expr, data, thrown, source::Union{Nothing,LineNumberNode}=nothing, message_only::Bool=false)
         return new(test_type, orig_expr, data, thrown, source, message_only)
     end
 end
@@ -168,7 +168,7 @@ struct Error <: Result
     backtrace::String
     source::LineNumberNode
 
-    function Error(test_type, orig_expr, value, bt, source)
+    function Error(test_type::Symbol, orig_expr, value, bt, source::LineNumberNode)
         if test_type === :test_error
             bt = scrub_exc_stack(bt)
         end


### PR DESCRIPTION
These stem from #15276, i.e., [captured variables](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-captured).
They were identified by scanning all compiled MethodInstances with
`hasbox` in the newly-released MethodAnalysis 0.4.5.

`Core.Box` often causes "follow-on" inference problems,
but for these cases there were relatively few, which may be why
these didn't show up earlier during the Great Invalidation Hunt.
Still, there doesn't seem to be any particular reason not to fix them.

This doesn't eliminate all `Core.Box` cases from Base, but only a
handful remain. The most common remaining case stems from inner
functions calling themselves.