### PR TITLE
Add a `donotdelete` builtin

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -527,6 +527,7 @@ add_tfunc(atomic_pointerset, 3, 3, (a, v, order) -> (@nospecialize; a), 5)
 add_tfunc(atomic_pointerswap, 3, 3, (a, v, order) -> (@nospecialize; pointer_eltype(a)), 5)
 add_tfunc(atomic_pointermodify, 4, 4, atomic_pointermodify_tfunc, 5)
 add_tfunc(atomic_pointerreplace, 5, 5, atomic_pointerreplace_tfunc, 5)
+add_tfunc(donotdelete, 0, INT_INF, (@nospecialize args...)->Nothing, 0)
 
 # more accurate typeof_tfunc for vararg tuples abstract only in length
 function typeof_concrete_vararg(t::DataType)
@@ -1697,6 +1698,8 @@ function _builtin_nothrow(@nospecialize(f), argtypes::Array{Any,1}, @nospecializ
         return false
     elseif f === Core.get_binding_type
         return length(argtypes) == 2
+    elseif f === donotdelete
+        return true
     end
     return false
 end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2897,4 +2897,39 @@ See also [`"`](@ref \")
 """
 kw"\"\"\""
 
+"""
+    donotdelete(args...)
+
+This function prevents dead-code elimination (DCE) of itself and any arguments
+passed to it, but is otherwise the lightest barrier possible. In particular,
+it is not a GC safepoint, does model an observable heap effect, does not expand
+to any code itself and may be re-ordered with respect to other side effects
+(though the total number of executions may not change).
+
+A useful model for this function is that it hashes all memory `reachable` from
+args and escapes this information through some observable side-channel that does
+not otherwise impact program behavior. Of course that's just a model. The
+function does nothing and returns `nothing`.
+
+This is intended for use in benchmarks that want to guarantee that `args` are
+actually computed. (Otherwise DCE may see that the result of the benchmark is
+unused and delete the entire benchmark code).
+
+**Note**: `donotdelete` does not affect constant folding. For example, in
+          `donotdelete(1+1)`, no add instruction needs to be executed at runtime and
+          the code is semantically equivalent to `donotdelete(2).`
+
+# Examples
+
+function loop()
+    for i = 1:1000
+        # The complier must guarantee that there are 1000 program points (in the correct
+        # order) at which the value of `i` is in a register, but has otherwise
+        # total control over the program.
+        donotdelete(i)
+    end
+end
+"""
+Base.donotdelete
+
 end

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Core: CodeInfo, SimpleVector
+using Core: CodeInfo, SimpleVector, donotdelete
 
 const Callable = Union{Function,Type}
 

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -53,6 +53,7 @@ DECLARE_BUILTIN(typeassert);
 DECLARE_BUILTIN(_typebody);
 DECLARE_BUILTIN(typeof);
 DECLARE_BUILTIN(_typevar);
+DECLARE_BUILTIN(donotdelete);
 
 JL_CALLABLE(jl_f_invoke_kwsorter);
 #ifdef DEFINE_BUILTIN_GLOBALS
@@ -67,6 +68,7 @@ JL_CALLABLE(jl_f__setsuper);
 JL_CALLABLE(jl_f__equiv_typedef);
 JL_CALLABLE(jl_f_get_binding_type);
 JL_CALLABLE(jl_f_set_binding_type);
+JL_CALLABLE(jl_f_donotdelete);
 
 #ifdef __cplusplus
 }

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1472,6 +1472,11 @@ JL_CALLABLE(jl_f__setsuper)
     return jl_nothing;
 }
 
+JL_CALLABLE(jl_f_donotdelete)
+{
+    return jl_nothing;
+}
+
 static int equiv_field_types(jl_value_t *old, jl_value_t *ft)
 {
     size_t nf = jl_svec_len(ft);
@@ -1874,6 +1879,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin_func("_equiv_typedef", jl_f__equiv_typedef);
     add_builtin_func("get_binding_type", jl_f_get_binding_type);
     add_builtin_func("set_binding_type!", jl_f_set_binding_type);
+    jl_builtin_donotdelete = add_builtin_func("donotdelete", jl_f_donotdelete);
 
     // builtin types
     add_builtin("Any", (jl_value_t*)jl_any_type);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -26,7 +26,7 @@ extern "C" {
 // TODO: put WeakRefs on the weak_refs list during deserialization
 // TODO: handle finalizers
 
-#define NUM_TAGS    152
+#define NUM_TAGS    153
 
 // An array of references that need to be restored from the sysimg
 // This is a manually constructed dual of the gvars array, which would be produced by codegen for Julia code, for C.
@@ -198,6 +198,7 @@ jl_value_t **const*const get_tags(void) {
         INSERT_TAG(jl_builtin__expr);
         INSERT_TAG(jl_builtin_ifelse);
         INSERT_TAG(jl_builtin__typebody);
+        INSERT_TAG(jl_builtin_donotdelete);
 
         // All optional tags must be placed at the end, so that we
         // don't accidentally have a `NULL` in the middle
@@ -252,7 +253,7 @@ static const jl_fptr_args_t id_to_fptrs[] = {
     &jl_f_applicable, &jl_f_invoke, &jl_f_sizeof, &jl_f__expr, &jl_f__typevar,
     &jl_f_ifelse, &jl_f__structtype, &jl_f__abstracttype, &jl_f__primitivetype,
     &jl_f__typebody, &jl_f__setsuper, &jl_f__equiv_typedef, &jl_f_get_binding_type,
-    &jl_f_set_binding_type, &jl_f_opaque_closure_call,
+    &jl_f_set_binding_type, &jl_f_opaque_closure_call, &jl_f_donotdelete,
     NULL };
 
 typedef struct {

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -711,3 +711,9 @@ end
 @test !cmp43123(Ref{Function}(+), Ref{Union{typeof(+), typeof(-)}}(-))
 @test cmp43123(Function[+], Union{typeof(+), typeof(-)}[+])
 @test !cmp43123(Function[+], Union{typeof(+), typeof(-)}[-])
+
+# Test that donotdelete survives through to LLVM time
+f_donotdelete_input(x) = Base.donotdelete(x+1)
+f_donotdelete_const() = Base.donotdelete(1+1)
+@test occursin("call void (...) @jl_f_donotdelete(i64", get_llvm(f_donotdelete_input, Tuple{Int64}, true, false, false))
+@test occursin("call void (...) @jl_f_donotdelete()", get_llvm(f_donotdelete_const, Tuple{}, true, false, false))


### PR DESCRIPTION
In #43852 we noticed that the compiler is getting good enough to
completely DCE a number of our benchmarks. We need to add some sort
of mechanism to prevent the compiler from doing so. This adds just
such an intrinsic. The intrinsic itself doesn't do anything, but
it is considered effectful by our optimizer, preventing it from
being DCE'd. At the LLVM level, it turns into a volatile store to
an alloca (or an llvm.sideeffect if the values passed to the
`dcebarrier` do not have any actual LLVM-level representation).

The docs for the new intrinsic are as follows:
```
    dcebarrier(args...)

This function prevents dead-code elimination (DCE) of itself and any arguments
passed to it, but is otherwise the lightest barrier possible. In particular,
it is not a GC safepoint, does model an observable heap effect, does not expand
to any code itself and may be re-ordered with respect to other side effects
(though the total number of executions may not change).

A useful model for this function is that it hashes all memory `reachable` from
args and escapes this information through some observable side-channel that does
not otherwise impact program behavior. Of course that's just a model. The
function does nothing and returns `nothing`.

This is intended for use in benchmarks that want to guarantee that `args` are
actually computed. (Otherwise DCE may see that the result of the benchmark is
unused and delete the entire benchmark code).

**Note**: `dcebarrier` does not affect constant foloding. For example, in
          `dcebarrier(1+1)`, no add instruction needs to be executed at runtime and
          the code is semantically equivalent to `dcebarrier(2).`

*# Examples

function loop()
    for i = 1:1000
        # The complier must guarantee that there are 1000 program points (in the correct
       	# order) at which the value of `i` is in a register, but has otherwise
        # total control over the program.
        dcebarrier(i)
    end
end
```

I believe the voltatile store at the LLVM level is actually somewhat
stronger than what we want here. Ideally the `dcebarrier` would not
and up generating any machine code at all and would also be compatible
with optimizations like SROA and vectorization. However, I think this
is fine for now.