### PR TITLE
some patches on #43852

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -217,7 +217,7 @@ function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src::Union{IRC
             # `Expr(:new)` of unknown type could raise arbitrary TypeError.
             typ, isexact = instanceof_tfunc(typ)
             isexact || return false
-            isconcretedispatch(typ) || return false
+            isconcretetype(typ) || return false
             typ = typ::DataType
             fieldcount(typ) >= length(args) - 1 || return false
             for fld_idx in 1:(length(args) - 1)

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -863,12 +863,13 @@ function handle_single_case!(
     if isa(case, ConstantCase)
         ir[SSAValue(idx)][:inst] = case.val
     elseif isa(case, InvokeCase)
-        if is_total(case.effects)
-            inline_const_if_inlineable!(ir[SSAValue(idx)]) && return nothing
-        end
+        is_total(case.effects) && inline_const_if_inlineable!(ir[SSAValue(idx)]) && return nothing
         isinvoke && rewrite_invoke_exprargs!(stmt)
         stmt.head = :invoke
         pushfirst!(stmt.args, case.invoke)
+        if is_removable_if_unused(case.effects)
+            ir[SSAValue(idx)][:flag] |= IR_FLAG_EFFECT_FREE
+        end
     elseif case === nothing
         # Do, well, nothing
     else

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -388,91 +388,109 @@ true. These assertions are made for all world ages. It is thus advisable to limi
 the use of generic functions that may later be extended to invalidate the
 assumption (which would cause undefined behavior).
 
-The following `settings` are supported.
+The following `setting`s are supported.
+- `:consistent`
+- `:effect_free`
+- `:nothrow`
+- `:terminates_globally`
+- `:terminates_locally`
+- `:total`
+
+---
 # `:consistent`
 
 The `:consistent` setting asserts that for egal inputs:
-    - The manner of termination (return value, exception, non-termination) will always be the same.
-    - If the method returns, the results will always be egal.
+- The manner of termination (return value, exception, non-termination) will always be the same.
+- If the method returns, the results will always be egal.
 
-Note: This in particular implies that the return value of the method must be
-      immutable. Multiple allocations of mutable objects (even with identical
-      contents) are not egal.
+!!! note
+    This in particular implies that the return value of the method must be
+    immutable. Multiple allocations of mutable objects (even with identical
+    contents) are not egal.
 
-Note: The :consistent-cy assertion is made world-age wise. More formally, write
-      fᵢ for the evaluation of `f` in world-age `i`, then we require:
+!!! note
+    The `:consistent`-cy assertion is made world-age wise. More formally, write
+    ``fᵢ`` for the evaluation of ``f`` in world-age ``i``, then we require:
+    ```math
+    ∀ i, x, y: x ≡ y → fᵢ(x) ≡ fᵢ(y)
+    ```
+    However, for two world ages ``i``, ``j`` s.t. ``i ≠ j``, we may have ``fᵢ(x) ≢ fⱼ(y)``.
 
-          ∀ i, x, y: x === y → fᵢ(x) === fᵢ(y)
+    A further implication is that `:consistent` functions may not make their
+    return value dependent on the state of the heap or any other global state
+    that is not constant for a given world age.
 
-      However, for two world ages `i, j` s.t. `i != j`, we may have `fᵢ(x) !== fⱼ(y)`.
+!!! note
+    The `:consistent`-cy includes all legal rewrites performed by the optimizer.
+    For example, floating-point fastmath operations are not considered `:consistent`,
+    because the optimizer may rewrite them causing the output to not be `:consistent`,
+    even for the same world age (e.g. because one ran in the interpreter, while
+    the other was optimized).
 
-Note: A further implication is that :consistent functions may not make their
-      return value dependent on the state of the heap or any other global state
-      that is not constant for a given world age.
+!!! note
+    If `:consistent` functions terminate by throwing an exception, that exception
+    itself is not required to meet the egality requirement specified above.
 
-Note: The :consistent-cy includes all legal rewrites performed by the optimizer.
-      For example, floating-point fastmath operations are not considered :consistent,
-      because the optimizer may rewrite them causing the output to not be :consistent,
-      even for the same world age (e.g. because one ran in the interpreter, while
-      the other was optimized).
-
-Note: If :consistent functions terminate by throwing an exception, that exception
-      itself is not required to meet the egality requirement specified above.
-
+---
 # `:effect_free`
 
 The `:effect_free` setting asserts that the method is free of externally semantically
 visible side effects. The following is an incomplete list of externally semantically
 visible side effects:
-
- - Changing the value of a global variable.
- - Mutating the heap (e.g. an array or mutable value), except as noted below
- - Changing the method table (e.g. through calls to eval)
- - File/Network/etc. I/O
- - Task switching
+- Changing the value of a global variable.
+- Mutating the heap (e.g. an array or mutable value), except as noted below
+- Changing the method table (e.g. through calls to eval)
+- File/Network/etc. I/O
+- Task switching
 
 However, the following are explicitly not semantically visible, even if they
 may be observable:
-
- - Memory allocations (both mutable and immutable)
- - Elapsed time
- - Garbage collection
- - Heap mutations of objects whose lifetime does not exceed the method (i.e.
-   were allocated in the method and do not escape).
- - The returned value (which is externally visible, but not a side effect)
+- Memory allocations (both mutable and immutable)
+- Elapsed time
+- Garbage collection
+- Heap mutations of objects whose lifetime does not exceed the method (i.e.
+  were allocated in the method and do not escape).
+- The returned value (which is externally visible, but not a side effect)
 
 The rule of thumb here is that an externally visible side effect is anything
 that would affect the execution of the remainder of the program if the function
 were not executed.
 
-Note: The effect free assertion is made both for the method itself and any code
-      that is executed by the method. Keep in mind that the assertion must be
-      valid for all world ages and limit use of this assertion accordingly.
+!!! note
+    The `:effect_free` assertion is made both for the method itself and any code
+    that is executed by the method. Keep in mind that the assertion must be
+    valid for all world ages and limit use of this assertion accordingly.
 
+---
 # `:nothrow`
 
 The `:nothrow` settings asserts that this method does not terminate abnormally
 (i.e. will either always return a value or never return).
 
-Note: It is permissible for :nothrow annotated methods to make use of exception
-      handling internally as long as the exception is not rethrown out of the
-      method itself.
+!!! note
+    It is permissible for `:nothrow` annotated methods to make use of exception
+    handling internally as long as the exception is not rethrown out of the
+    method itself.
 
-Note: MethodErrors and similar exceptions count as abnormal termination.
+!!! note
+    `MethodErrors` and similar exceptions count as abnormal termination.
 
+---
 # `:terminates_globally`
 
 The `:terminates_globally` settings asserts that this method will eventually terminate
 (either normally or abnormally), i.e. does not loop indefinitely.
 
-Note: The compiler will consider this a strong indication that the method will
-      terminate relatively *quickly* and may (if otherwise legal), call this
-      method at compile time. I.e. it is a bad idea to annotate this setting
-      on a method that *technically*, but not *practically*, terminates.
+!!! note
+    This `:terminates_globally` assertion covers any other methods called by the annotated method.
 
-Note: The `terminates_globally` assertion covers any other methods called by
-      the annotated method.
+!!! note
+    The compiler will consider this a strong indication that the method will
+    terminate relatively *quickly* and may (if otherwise legal), call this
+    method at compile time. I.e. it is a bad idea to annotate this setting
+    on a method that *technically*, but not *practically*, terminates.
 
+---
 # `:terminates_locally`
 
 The `:terminates_locally` setting is like `:terminates_globally`, except that it only
@@ -480,21 +498,24 @@ applies to syntactic control flow *within* the annotated method. It is thus
 a much weaker (and thus safer) assertion that allows for the possibility of
 non-termination if the method calls some other method that does not terminate.
 
-Note: `terminates_globally` implies `terminates_locally`.
+!!! note
+    `:terminates_globally` implies `:terminates_locally`.
 
+---
 # `:total`
 
-The `setting` combines the following other assertions:
-    - `:consistent`
-    - `:effect_free`
-    - `:nothrow`
-    - `:terminates_globally`
+This `setting` combines the following other assertions:
+- `:consistent`
+- `:effect_free`
+- `:nothrow`
+- `:terminates_globally`
 and is a convenient shortcut.
 
-Note: `@assume_effects :total` is similar to `@Base.pure` with the primary
-      distinction that the :consistent-cy requirement applies world-age wise rather
-      than globally as described above. However, in particular, a method annotated
-      `@Base.pure` is always total.
+!!! note
+    `@assume_effects :total` is similar to `@Base.pure` with the primary
+    distinction that the `:consistent`-cy requirement applies world-age wise rather
+    than globally as described above. However, in particular, a method annotated
+    `@Base.pure` is always `:total`.
 """
 macro assume_effects(args...)
     (consistent, effect_free, nothrow, terminates_globally, terminates_locally) =
@@ -530,7 +551,6 @@ macro assume_effects(args...)
     end
     return esc(pushmeta!(ex, :purity, consistent, effect_free, nothrow, terminates_globally, terminates_locally))
 end
-
 
 """
     @propagate_inbounds


### PR DESCRIPTION
[refine docstrings of @assume_effects](https://github.com/JuliaLang/julia/commit/f9d3f25b4675089c7e9826a969df07d5c3df42ff) 

This commit tries to render the docstring of `@assume_effects` within
Documenter.jl-generated HTML:
- render bullet points
- codify the names of settings
- use math syntax
- use note admonitions

---

[improve `:nothrow` effect analysis on allocation](https://github.com/JuliaLang/julia/commit/24cfeb1bca4a2bc4736a8f37f2ae564fca3b9640) 

Improves `:nothrow` assertion for mutable allocations.
Also adds missing `IR_FLAG_EFFECT_FREE` flagging for non-inlined callees
in `handle_single_case!` so that we can do more dead code elimination.