### PR TITLE
Instrument jl_gc_big_alloc() when called from generated code for Allocations Profiler

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -507,7 +507,7 @@ JL_DLLEXPORT jl_value_t *jl_alloc_string(size_t len)
     else {
         if (allocsz < sz) // overflow in adding offs, size was "negative"
             jl_throw(jl_memory_exception);
-        s = jl_gc_pool_alloc_noinline(ptls, allocsz);
+        s = jl_gc_big_alloc_noinline(ptls, allocsz);
     }
     jl_set_typeof(s, jl_string_type);
     maybe_record_alloc_to_profile(s, len, jl_string_type);

--- a/src/array.c
+++ b/src/array.c
@@ -507,7 +507,7 @@ JL_DLLEXPORT jl_value_t *jl_alloc_string(size_t len)
     else {
         if (allocsz < sz) // overflow in adding offs, size was "negative"
             jl_throw(jl_memory_exception);
-        s = jl_gc_big_alloc(ptls, allocsz);
+        s = jl_gc_pool_alloc_noinline(ptls, allocsz);
     }
     jl_set_typeof(s, jl_string_type);
     maybe_record_alloc_to_profile(s, len, jl_string_type);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -231,7 +231,7 @@ JL_DLLEXPORT extern const char *jl_filename;
 
 jl_value_t *jl_gc_pool_alloc_noinline(jl_ptls_t ptls, int pool_offset,
                                    int osize);
-JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc_noinline(jl_ptls_t ptls, size_t allocsz);
+JL_DLLEXPORT jl_value_t *jl_gc_big_alloc_noinline(jl_ptls_t ptls, size_t allocsz);
 JL_DLLEXPORT int jl_gc_classify_pools(size_t sz, int *osize);
 extern uv_mutex_t gc_perm_lock;
 void *jl_gc_perm_alloc_nolock(size_t sz, int zero,
@@ -365,7 +365,7 @@ STATIC_INLINE jl_value_t *jl_gc_alloc_(jl_ptls_t ptls, size_t sz, void *ty)
     else {
         if (allocsz < sz) // overflow in adding offs, size was "negative"
             jl_throw(jl_memory_exception);
-        v = jl_gc_pool_alloc_noinline(ptls, allocsz);
+        v = jl_gc_big_alloc_noinline(ptls, allocsz);
     }
     jl_set_typeof(v, ty);
     maybe_record_alloc_to_profile(v, sz, (jl_datatype_t*)ty);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -231,7 +231,7 @@ JL_DLLEXPORT extern const char *jl_filename;
 
 jl_value_t *jl_gc_pool_alloc_noinline(jl_ptls_t ptls, int pool_offset,
                                    int osize);
-JL_DLLEXPORT jl_value_t *jl_gc_big_alloc(jl_ptls_t ptls, size_t allocsz);
+JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc_noinline(jl_ptls_t ptls, size_t allocsz);
 JL_DLLEXPORT int jl_gc_classify_pools(size_t sz, int *osize);
 extern uv_mutex_t gc_perm_lock;
 void *jl_gc_perm_alloc_nolock(size_t sz, int zero,
@@ -365,7 +365,7 @@ STATIC_INLINE jl_value_t *jl_gc_alloc_(jl_ptls_t ptls, size_t sz, void *ty)
     else {
         if (allocsz < sz) // overflow in adding offs, size was "negative"
             jl_throw(jl_memory_exception);
-        v = jl_gc_big_alloc(ptls, allocsz);
+        v = jl_gc_pool_alloc_noinline(ptls, allocsz);
     }
     jl_set_typeof(v, ty);
     maybe_record_alloc_to_profile(v, sz, (jl_datatype_t*)ty);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -231,7 +231,7 @@ JL_DLLEXPORT extern const char *jl_filename;
 
 jl_value_t *jl_gc_pool_alloc_noinline(jl_ptls_t ptls, int pool_offset,
                                    int osize);
-JL_DLLEXPORT jl_value_t *jl_gc_big_alloc_noinline(jl_ptls_t ptls, size_t allocsz);
+jl_value_t *jl_gc_big_alloc_noinline(jl_ptls_t ptls, size_t allocsz);
 JL_DLLEXPORT int jl_gc_classify_pools(size_t sz, int *osize);
 extern uv_mutex_t gc_perm_lock;
 void *jl_gc_perm_alloc_nolock(size_t sz, int zero,


### PR DESCRIPTION
Instrument jl_gc_big_alloc() when called from generated code for Allocations Profiler

Add _maybe_record_alloc_to_profile() call into jl_gc_big_alloc() to
allow us to instrument it in the Allocations Profiler.

Followup to #43868

Finishes last case of #43688 (gets the stacks, though not the types, of big allocs).

--------------------------


## Before

![graphviz (2)](https://user-images.githubusercontent.com/1582097/152557258-4a9669d8-fedc-4b43-bf37-6426982b16b5.svg)

*: instrumented; red: currently missed; green: newly introduced function

<details>
<summary>graphviz</summary>

```graphviz
digraph G {
  node [shape=box];

  generated_code [label="<generated code>"];

  new_array;
  jl_gc_alloc_string [label="jl_gc_alloc_string *"];
  jl_gc_alloc [label="jl_gc_alloc *"];
  jl_gc_managed_malloc [label="jl_managed_malloc *"]; // https://github.com/vilterp/julia/pull/20
  jl_gc_pool_alloc [fillcolor="#90ed8f" style=filled label="jl_gc_pool_alloc *"];
  jl_gc_pool_alloc_noinline [fillcolor="#90ed8f" style=filled label="jl_gc_pool_alloc_noinline"];
  jl_gc_pool_alloc_inner;
  jl_gc_big_alloc;

  {
    rank=same;
    jl_gc_managed_malloc;
    jl_gc_pool_alloc_noinline;
    jl_gc_big_alloc;
  }

  generated_code -> jl_gc_alloc_string;
  generated_code -> new_array;
  generated_code -> jl_gc_alloc;
  generated_code -> jl_gc_big_alloc [color=red];
  generated_code -> jl_gc_pool_alloc;
  jl_gc_pool_alloc -> jl_gc_pool_alloc_inner  [style=dotted label="inlined"];
  jl_gc_pool_alloc_noinline -> jl_gc_pool_alloc_inner  [style=dotted  label="inlined"];


  jl_gc_alloc -> jl_gc_pool_alloc_noinline;
  jl_gc_alloc -> jl_gc_big_alloc;
  new_array -> jl_gc_alloc;
  new_array -> jl_gc_managed_malloc;
  jl_gc_alloc_string -> jl_gc_pool_alloc_noinline;
  jl_gc_alloc_string -> jl_gc_big_alloc;
}
```
</details>

## After

![graphviz (3)](https://user-images.githubusercontent.com/1582097/152869280-27ddc7cd-0707-4cce-939e-30f8885a361b.svg)

*: instrumented; green: newly introduced function

<details>
<summary>graphviz</summary>

```graphviz
digraph G {
  node [shape=box];

  generated_code [label="<generated code>"];

  new_array;
  jl_gc_alloc_string [label="jl_gc_alloc_string *"];
  jl_gc_alloc [label="jl_gc_alloc *"];
  jl_gc_managed_malloc [label="jl_managed_malloc *"]; // https://github.com/vilterp/julia/pull/20
  jl_gc_pool_alloc [fillcolor="#90ed8f" style=filled label="jl_gc_pool_alloc *"];
  jl_gc_pool_alloc_noinline [fillcolor="#90ed8f" style=filled label="jl_gc_pool_alloc_noinline"];
  jl_gc_pool_alloc_inner;
  jl_gc_big_alloc [fillcolor="#90ed8f" style=filled label="jl_gc_big_alloc *"];
  jl_gc_big_alloc_noinline [fillcolor="#90ed8f" style=filled label="jl_gc_pool_alloc_noinline"];
  jl_gc_big_alloc_inner;


  {
    rank=same;
    jl_gc_managed_malloc;
    jl_gc_pool_alloc_noinline;
    jl_gc_big_alloc_noinline;
  }

  generated_code -> jl_gc_alloc_string;
  generated_code -> new_array;
  generated_code -> jl_gc_alloc;
  generated_code -> jl_gc_big_alloc;
  generated_code -> jl_gc_pool_alloc;
  jl_gc_pool_alloc -> jl_gc_pool_alloc_inner  [style=dotted label="inlined"];
  jl_gc_pool_alloc_noinline -> jl_gc_pool_alloc_inner  [style=dotted  label="inlined"];
  jl_gc_big_alloc -> jl_gc_big_alloc_inner  [style=dotted label="inlined"];
  jl_gc_big_alloc_noinline -> jl_gc_big_alloc_inner  [style=dotted  label="inlined"];


  jl_gc_alloc -> jl_gc_pool_alloc_noinline;
  jl_gc_alloc -> jl_gc_big_alloc_noinline;
  new_array -> jl_gc_alloc;
  new_array -> jl_gc_managed_malloc;
  jl_gc_alloc_string -> jl_gc_pool_alloc_noinline;
  jl_gc_alloc_string -> jl_gc_big_alloc_noinline;
}
```
</details>