### PR TITLE
Profile: Stop allocation profiler even on error

### DIFF
--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -61,9 +61,11 @@ const _g_expected_sampled_allocs = Ref{Float64}(0)
 function _prof_expr(expr, opts)
     quote
         $start(; $(esc(opts)))
-        local res = $(esc(expr))
-        $stop()
-        res
+        try
+            $(esc(expr))
+        finally
+            $stop()
+        end
     end
 end
 


### PR DESCRIPTION
Stops the allocation profiler on error as well as return.

I noticed this because interrupting a run left the system sluggish

cc. @NHDaly @vilterp 