### PR TITLE
TaskFailedException: Move nested task stacktrace first

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -243,9 +243,12 @@ julia> take!(c)
 
 julia> put!(c, 1);
 ERROR: TaskFailedException
-Stacktrace:
+
+    Nested task error: foo
+    Stacktrace:
 [...]
-    nested task error: foo
+
+Stacktrace:
 [...]
 ```
 """

--- a/base/task.jl
+++ b/base/task.jl
@@ -78,13 +78,13 @@ struct TaskFailedException <: Exception
 end
 
 function showerror(io::IO, ex::TaskFailedException, bt = nothing; backtrace=true)
-    print(io, "TaskFailedException")
+    println(io, "TaskFailedException")
+    printstyled(io, "\n    Nested task error: ", color=error_color())
+    show_task_exception(io, ex.task)
+    println(io)
     if bt !== nothing && backtrace
         show_backtrace(io, bt)
     end
-    println(io)
-    printstyled(io, "\n    nested task error: ", color=error_color())
-    show_task_exception(io, ex.task)
 end
 
 function show_task_exception(io::IO, t::Task; indent = true)

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -1728,9 +1728,9 @@ let e = @test_throws RemoteException pmap(1) do _
         end
     # check that the inner TaskFailedException is correctly formed & can be printed
     es = sprint(showerror, e.value)
-    @test contains(es, ":\nTaskFailedException\nStacktrace:\n")
-    @test contains(es, "\n\n    nested task error:")
-    @test contains(es, "\n\n    nested task error: 42\n")
+    @test contains(es, ":\nTaskFailedException\n")
+    @test contains(es, "\n\n    Nested task error:")
+    @test contains(es, "\n\n    Nested task error: 42\n")
 end
 
 # issue #27429, propagate relative `include` path to workers


### PR DESCRIPTION
I think it may make more sense for the deepest thing to come first in the `TaskFailedException` error stack, so this proposes moving the nested error first.

At least, I often find myself getting confused looking for the deepest part up top, then realize I'm just looking at `wait` etc, which can be quite disorientating when both stacktraces are large.

A simple example with
```
wait(@async error())
```
## Master

![Screenshot from 2022-02-04 23-17-06](https://user-images.githubusercontent.com/1694067/152628319-96044641-0140-4df0-8f14-9ea3f99ca86f.png)

## This PR

![Screenshot from 2022-02-04 23-16-42](https://user-images.githubusercontent.com/1694067/152628315-7bb127c4-ec3e-423f-8e17-2e3bf247e19c.png)

