### PR TITLE
Profile.Allocs: Add task and timestamp

### DIFF
--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -20,6 +20,8 @@ struct jl_raw_alloc_t {
     jl_datatype_t *type_address;
     jl_raw_backtrace_t backtrace;
     size_t size;
+    jl_task_t *task;
+    uint64_t timestamp;
 };
 
 // == These structs define the global singleton profile buffer that will be used by
@@ -133,7 +135,9 @@ void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size) JL_NOTSAFEPOIN
     profile.allocs.emplace_back(jl_raw_alloc_t{
         type,
         get_raw_backtrace(),
-        size
+        size,
+        jl_current_task,
+        cycleclock()
     });
 }
 

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -160,7 +160,7 @@ end
 # Without this, the Alloc's stacktrace prints for lines and lines and lines...
 function Base.show(io::IO, a::Alloc)
     stacktrace_sample = length(a.stacktrace) >= 1 ? "$(a.stacktrace[1]), ..." : ""
-    print(io, "$Alloc($(a.type), $StackFrame[$stacktrace_sample], $(a.size), $(a.task), $(a.timestamp))")
+    print(io, "$Alloc($(a.type), $StackFrame[$stacktrace_sample], $(a.size))")
 end
 
 const BacktraceCache = Dict{BTElement,Vector{StackFrame}}

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -19,7 +19,7 @@ struct RawAlloc
     type::Ptr{Type}
     backtrace::RawBacktrace
     size::Csize_t
-    task::Task
+    task::Ptr{Cvoid}
     timestamp::UInt64
 end
 
@@ -149,7 +149,7 @@ struct Alloc
     type::Any
     stacktrace::StackTrace
     size::Int
-    task::Task
+    task::Ptr{Cvoid}
     timestamp::UInt64
 end
 

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -19,6 +19,8 @@ struct RawAlloc
     type::Ptr{Type}
     backtrace::RawBacktrace
     size::Csize_t
+    task::Task
+    timestamp::UInt64
 end
 
 # matches jl_profile_allocs_raw_results_t on the C side
@@ -147,6 +149,8 @@ struct Alloc
     type::Any
     stacktrace::StackTrace
     size::Int
+    task::Task
+    timestamp::UInt64
 end
 
 struct AllocResults
@@ -156,7 +160,7 @@ end
 # Without this, the Alloc's stacktrace prints for lines and lines and lines...
 function Base.show(io::IO, a::Alloc)
     stacktrace_sample = length(a.stacktrace) >= 1 ? "$(a.stacktrace[1]), ..." : ""
-    print(io, "$Alloc($(a.type), $StackFrame[$stacktrace_sample], $(a.size))")
+    print(io, "$Alloc($(a.type), $StackFrame[$stacktrace_sample], $(a.size), $(a.task), $(a.timestamp))")
 end
 
 const BacktraceCache = Dict{BTElement,Vector{StackFrame}}
@@ -180,7 +184,9 @@ function decode_alloc(cache::BacktraceCache, raw_alloc::RawAlloc)::Alloc
     Alloc(
         load_type(raw_alloc.type),
         stacktrace_memoized(cache, load_backtrace(raw_alloc.backtrace)),
-        UInt(raw_alloc.size)
+        UInt(raw_alloc.size),
+        raw_alloc.task,
+        raw_alloc.timestamp
     )
 end
 


### PR DESCRIPTION
This makes it possible to track when and on what task an allocation occurred, similar to what we have for the time-based profiler.

EDIT: The motivation for this change is to support consumers like Dagger.jl, which will want to pair this data with its own collected events (which record nanosecond-resolution timestamps as well as task pointers) and task runtime data from https://github.com/JuliaLang/julia/pull/43453 to create a cohesive view of allocations within a distributed, multithreaded application.