### PR TITLE
Preserve shape when collecting broadcasted objects

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -262,6 +262,7 @@ Base.@propagate_inbounds function Base.iterate(bc::Broadcasted, s)
 end
 
 Base.IteratorSize(::Type{<:Broadcasted{<:Any,<:NTuple{N,Base.OneTo}}}) where {N} = Base.HasShape{N}()
+Base.IteratorSize(::Type{<:Broadcasted{<:AbstractArrayStyle{N}, Nothing}}) where {N} = Base.HasShape{N}()
 Base.IteratorEltype(::Type{<:Broadcasted}) = Base.EltypeUnknown()
 
 ## Instantiation fills in the "missing" fields in Broadcasted.

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -263,11 +263,15 @@ end
 
 Base.IteratorSize(::Type{T}) where {T<:Broadcasted} = Base.HasShape{ndims(T)}()
 Base.ndims(BC::Type{<:Broadcasted{<:Any,Nothing}}) = _maxndims(fieldtype(BC, 2))
-function Base.ndims(BC::Type{<:Broadcasted{<:AbstractArrayStyle{N},Nothing}}) where {N}
-    N isa Integer && return N
-    _maxndims(fieldtype(BC, 2))
+Base.ndims(::Type{<:Broadcasted{<:AbstractArrayStyle{N},Nothing}}) where {N<:Integer} = N
+
+_maxndims(T::Type{<:Tuple}) = reduce(max, (ntuple(n -> _ndims(fieldtype(T, n)), Base._counttuple(T))))
+_maxndims(::Type{<:Tuple{T}}) where {T} = ndims(T)
+_maxndims(::Type{<:Tuple{T}}) where {T<:Tuple} = _ndims(T)
+function _maxndims(::Type{<:Tuple{T, S}}) where {T, S}
+    return T<:Tuple || S<:Tuple ? max(_ndims(T), _ndims(S)) : max(ndims(T), ndims(S))
 end
-Base.@pure _maxndims(T) = mapfoldl(_ndims, max, fieldtypes(T))
+
 _ndims(x) = ndims(x)
 _ndims(::Type{<:Tuple}) = 1
 

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -263,6 +263,7 @@ end
 
 Base.IteratorSize(::Type{<:Broadcasted{<:Any,<:NTuple{N,Base.OneTo}}}) where {N} = Base.HasShape{N}()
 Base.IteratorSize(::Type{<:Broadcasted{<:AbstractArrayStyle{N}, Nothing}}) where {N} = Base.HasShape{N}()
+Base.IteratorSize(::Type{<:Broadcasted{<:ArrayStyle, Nothing, <:Any, <:Tuple{T, N}}}) where {T, N} = Base.HasShape{ndims(T)}()
 Base.IteratorEltype(::Type{<:Broadcasted}) = Base.EltypeUnknown()
 
 ## Instantiation fills in the "missing" fields in Broadcasted.

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -244,7 +244,7 @@ Base.IndexStyle(::Type{<:Broadcasted{<:Any}}) = IndexCartesian()
 
 Base.LinearIndices(bc::Broadcasted{<:Any,<:Tuple{Any}}) = LinearIndices(axes(bc))::LinearIndices{1}
 
-Base.ndims(::Broadcasted{<:Any,<:NTuple{N,Any}}) where {N} = N
+Base.ndims(bc::Broadcasted) = ndims(typeof(bc))
 Base.ndims(::Type{<:Broadcasted{<:Any,<:NTuple{N,Any}}}) where {N} = N
 
 Base.size(bc::Broadcasted) = map(length, axes(bc))
@@ -267,8 +267,7 @@ function Base.ndims(BC::Type{<:Broadcasted{<:AbstractArrayStyle{N},Nothing}}) wh
     N isa Integer && return N
     _maxndims(fieldtype(BC, 2))
 end
-_maxndims(T) = mapfoldl(_ndims, max, _fieldtypes(T))
-_fieldtypes(T) = ntuple(Base.Fix1(fieldtype,T), Val(fieldcount(T))) # Base.fieldtypes is not stable.
+Base.@pure _maxndims(T) = mapfoldl(_ndims, max, fieldtypes(T))
 _ndims(x) = ndims(x)
 _ndims(::Type{<:Tuple}) = 1
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -863,6 +863,24 @@ let
     a1 = AD1(rand(2,3))
     bc1 = Broadcast.broadcasted(*, a1, 2)
     @test collect(Iterators.product(bc1, bc1)) == collect(Iterators.product(copy(bc1), copy(bc1)))
+
+    # using ndims of second arg
+    bc2 = Broadcast.broadcasted(*, 2, a1)
+    @test collect(Iterators.product(bc2, bc2)) == collect(Iterators.product(copy(bc2), copy(bc2)))
+
+    # >2 args
+    bc3 = Broadcast.broadcasted(*, a1, 3, a1)
+    @test collect(Iterators.product(bc3, bc3)) == collect(Iterators.product(copy(bc3), copy(bc3)))
+
+    # including a tuple and custom array type
+    bc4 = Broadcast.broadcasted(*, (1,2,3), AD1(rand(3)))
+    @test collect(Iterators.product(bc4, bc4)) == collect(Iterators.product(copy(bc4), copy(bc4)))
+
+    # testing ArrayConflict
+    @test Broadcast.broadcasted(+, AD1(rand(3)), AD2(rand(3))) isa Broadcast.Broadcasted{Broadcast.ArrayConflict}
+    @test Broadcast.broadcasted(+, AD1(rand(3)), AD2(rand(3))) isa Broadcast.Broadcasted{<:Broadcast.AbstractArrayStyle{Any}}
+
+    @test @inferred(Base.IteratorSize(Broadcast.broadcasted((1,2,3),a1,zeros(3,3,3)))) === Base.HasShape{3}()
  end
 
 # issue #31295

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -858,7 +858,11 @@ end
 # issue 43847: collect preserves shape of broadcasted
 let
     bc = Broadcast.broadcasted(*, [1 2; 3 4], 2)
-    @test size(collect(bc)) == size(bc)
+    @test collect(Iterators.product(bc, bc)) == collect(Iterators.product(copy(bc), copy(bc)))
+
+    a1 = AD1(rand(2,3))
+    bc1 = Broadcast.broadcasted(*, a1, 2)
+    @test collect(Iterators.product(bc1, bc1)) == collect(Iterators.product(copy(bc1), copy(bc1)))
  end
 
 # issue #31295

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -881,6 +881,11 @@ let
     @test Broadcast.broadcasted(+, AD1(rand(3)), AD2(rand(3))) isa Broadcast.Broadcasted{<:Broadcast.AbstractArrayStyle{Any}}
 
     @test @inferred(Base.IteratorSize(Broadcast.broadcasted((1,2,3),a1,zeros(3,3,3)))) === Base.HasShape{3}()
+
+    # inference on nested
+    bc = Base.broadcasted(+, AD1(randn(3)), AD1(randn(3)))
+    bc_nest = Base.broadcasted(+, bc , bc)
+    @test @inferred(Base.IteratorSize(bc_nest)) === Base.HasShape{1}()
  end
 
 # issue #31295

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -855,6 +855,12 @@ let
     @test ndims(copy(bc)) == ndims([v for v in bc]) == ndims(collect(bc)) == ndims(bc)
 end
 
+# issue 43847: collect preserves shape of broadcasted
+let
+    bc = Broadcast.broadcasted(*, [1 2; 3 4], 2)
+    @test size(collect(bc)) == size(bc)
+ end
+
 # issue #31295
 let a = rand(5), b = rand(5), c = copy(a)
     view(identity(a), 1:3) .+= view(b, 1:3)


### PR DESCRIPTION
Fix for #43847 

I first implemented the fix proposed on the issue but as expected this was ambiguous. I'm not sure if my proposal is as general as the initial proposal but it is not ambiguous and results in desired behaviour in a test.

(Replacing https://github.com/JuliaLang/julia/pull/44039)