### PR TITLE
Add a GitHub Actions workflow for automatic validation of the citation metadata file (`CITATION.CFF`)

### DIFF
--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -1,0 +1,33 @@
+name: cffconvert
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release-*'
+    paths:
+      - CITATION.cff
+  pull_request:
+    branches:
+      - 'master'
+      - 'release-*'
+    paths:
+      - CITATION.cff
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: "validate"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out a copy of the repository
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Check whether the citation metadata from CITATION.cff is valid
+        uses: citation-file-format/cffconvert-github-action@2.0.0
+        with:
+          args: "--validate"

--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-# Cite me
+# Official format description at https://citation-file-format.github.io
 cff-version: 1.2.0
 message: "Cite this paper whenever you use Julia"
 authors:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,3 +1,4 @@
+# Cite me
 cff-version: 1.2.0
 message: "Cite this paper whenever you use Julia"
 authors:


### PR DESCRIPTION
Hello!

We noticed that your `CITATION.cff` had a small issue and fixed it.

In addition to the fix, this Pull Request automates validation of that file using the [cffconvert GitHub Action](https://github.com/marketplace/actions/cffconvert). That way, it's a little bit easier to be robust against future changes to the `CITATION.cff` file.

BTW it's perfectly fine if you don't feel like accepting this Pull Request for whatever reason -- we just thought it might be helpful is all.

We found your repository using a partially automated workflow; if you have any questions about that, feel free to create an issue over at https://github.com/cffbots/filtering/issues/

On behalf of the cffbots team,
@abelsiqueira / @fdiblen / @jspaaks