### PR TITLE
Detect the number of performance cores in the M1 macs via the new macos12 API

### DIFF
--- a/src/sys.c
+++ b/src/sys.c
@@ -622,22 +622,20 @@ JL_DLLEXPORT int jl_cpu_threads(void) JL_NOTSAFEPOINT
     char buf[7];
     len = 7;
     sysctlbyname("kern.osrelease", buf, &len, NULL, 0);
-    if (buf[0] > 1 && buf[1] > 0)
-    {
+    if (buf[0] > 1 && buf[1] > 0){
         len = 4;
         sysctlbyname("hw.perflevel0.physicalcpu", &count, &len, NULL, 0);
     }
-    else
-    {
-    int32_t family = 0;
-    len = 4;
-    sysctlbyname("hw.cpufamily", &family, &len, NULL, 0);
-    if (family >= 1 && count > 1) {
-        if (family == CPUFAMILY_ARM_FIRESTORM_ICESTORM) {
-            // We know the Apple M1 has 4 efficiency cores, so subtract them out.
-            count -= 4;
+    else {
+        int32_t family = 0;
+        len = 4;
+        sysctlbyname("hw.cpufamily", &family, &len, NULL, 0);
+        if (family >= 1 && count > 1) {
+            if (family == CPUFAMILY_ARM_FIRESTORM_ICESTORM) {
+                // We know the Apple M1 has 4 efficiency cores, so subtract them out.
+                count -= 4;
+            }
         }
-    }
     }
 #endif
     return count;

--- a/src/sys.c
+++ b/src/sys.c
@@ -618,7 +618,7 @@ JL_DLLEXPORT int jl_cpu_threads(void) JL_NOTSAFEPOINT
     }
 
 #if defined(__APPLE__) && defined(_CPU_AARCH64_)
-    // MacOS 12 added a way to query performance cores, 
+//MacOS 12 added a way to query performance cores
     char buf[7];
     len = 7;
     sysctlbyname("kern.osrelease", buf, &len, NULL, 0);


### PR DESCRIPTION
Should fix #44067. The logic is a bit convoluted right now due to older mac versions not having the API.