### PR TITLE
Clarify the warning on redefining const globals

### DIFF
--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -733,7 +733,7 @@ julia> const y = 1.0
 1.0
 
 julia> y = 2.0
-WARNING: redefinition of constant y. This may fail, cause incorrect answers, or produce other errors.
+WARNING: redefinition of constant y. This may cause previously defined functions using it to fail or produce incorrect answers.
 2.0
 ```
 * if an assignment would not result in the change of variable value no message is given:
@@ -772,7 +772,7 @@ julia> const a = [1]
  1
 
 julia> a = [1]
-WARNING: redefinition of constant a. This may fail, cause incorrect answers, or produce other errors.
+WARNING: redefinition of constant a. This may cause previously defined functions using it to fail or produce incorrect answers.
 1-element Vector{Int64}:
  1
 ```
@@ -793,7 +793,7 @@ julia> f()
 1
 
 julia> x = 2
-WARNING: redefinition of constant x. This may fail, cause incorrect answers, or produce other errors.
+WARNING: redefinition of constant x. This may cause previously defined functions using it to fail or produce incorrect answers.
 2
 
 julia> f()

--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -733,7 +733,7 @@ julia> const y = 1.0
 1.0
 
 julia> y = 2.0
-WARNING: redefinition of constant y. This may cause previously defined functions using it to fail or produce incorrect answers.
+WARNING: redefinition of constant y. This may cause previously defined methods using it to fail or produce incorrect answers.
 2.0
 ```
 * if an assignment would not result in the change of variable value no message is given:
@@ -772,7 +772,7 @@ julia> const a = [1]
  1
 
 julia> a = [1]
-WARNING: redefinition of constant a. This may cause previously defined functions using it to fail or produce incorrect answers.
+WARNING: redefinition of constant a. This may cause previously defined methods using it to fail or produce incorrect answers.
 1-element Vector{Int64}:
  1
 ```
@@ -793,7 +793,7 @@ julia> f()
 1
 
 julia> x = 2
-WARNING: redefinition of constant x. This may cause previously defined functions using it to fail or produce incorrect answers.
+WARNING: redefinition of constant x. This may cause previously defined methods using it to fail or produce incorrect answers.
 2
 
 julia> f()

--- a/src/module.c
+++ b/src/module.c
@@ -803,7 +803,7 @@ JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs) JL_NOT
                       jl_symbol_name(b->name));
 #endif
         }
-        jl_safe_printf("WARNING: redefinition of constant %s. This may cause previously defined functions using it to fail or produce incorrect answers.\n",
+        jl_safe_printf("WARNING: redefinition of constant %s. This may cause previously defined modules using it to fail or produce incorrect answers.\n",
                        jl_symbol_name(b->name));
     }
     jl_atomic_store_relaxed(&b->value, rhs);

--- a/src/module.c
+++ b/src/module.c
@@ -803,7 +803,7 @@ JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs) JL_NOT
                       jl_symbol_name(b->name));
 #endif
         }
-        jl_safe_printf("WARNING: redefinition of constant %s. This may fail, cause incorrect answers, or produce other errors.\n",
+        jl_safe_printf("WARNING: redefinition of constant %s. This may cause previously defined functions using it to fail or produce incorrect answers.\n",
                        jl_symbol_name(b->name));
     }
     jl_atomic_store_relaxed(&b->value, rhs);


### PR DESCRIPTION
See discussion around https://discourse.julialang.org/t/typeconst-proposal/75953/19. The current warning does not make clear exactly what is allowed and not when redefining consts, and so conveys the impression that it is wrong to redefine consts at all (if so, why is it allowed?). As I understand it, it's OK to redefine consts as long as you redefine the functions that use them. Is it the case? If yes, the proposed PR clarifies that. If not, the warning should be made even more alarming.