### PR TITLE
Manual for `JULIA_EDITOR`: note that `code.cmd` needed for vscode on Windows

### DIFF
--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -262,6 +262,8 @@ over `$EDITOR`. If none of these environment variables is set, then the editor
 is taken to be `open` on Windows and OS X, or `/etc/alternatives/editor` if it
 exists, or `emacs` otherwise.
 
+To use Visual Studio Code on Windows, set `$JULIA_EDITOR` to `code.cmd`.
+
 ## Parallelization
 
 ### `JULIA_CPU_THREADS`


### PR DESCRIPTION
As eg discussed [here](https://discourse.julialang.org/t/windows-command-for-vs-code/29902/9).

Using `code` or `Code.exe` does not work, nor do fully qualified paths to those files:
``IOError: could not spawn `code -g 'C:/…:324'`: no such file or directory (ENOENT)``.
(A quick and naive read of InteractiveUtils' `editless.jl` might suggest otherwise, as it [contains](https://github.com/JuliaLang/julia/blob/bf534986/stdlib/InteractiveUtils/src/editless.jl#L136-L145) both the strings `code` and `code.exe`, but not `code.cmd` [unless you [go back in time](https://github.com/JuliaLang/julia/commit/d22c88fab)]).

Quite a time sink figuring this out. Hopefully adding this one line to the manual spares future Julia users the frustration.

<details>for searchability: vs code, Visual Studio Code</details>