### PR TITLE
Fixed inference on String causing invalidations in binaryplatform

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -71,7 +71,7 @@ struct Platform <: AbstractPlatform
                 if isa(value, VersionNumber)
                     value = string(value)
                 elseif isa(value, AbstractString)
-                    v = tryparse(VersionNumber, String(value))
+                    v = tryparse(VersionNumber, String(value)::String)
                     if isa(v, VersionNumber)
                         value = string(v)
                     end


### PR DESCRIPTION
Identified a source of some invalidations (e.g. when using `JSON3`) due to failed inference on `String(value)`.
Thanks to @timholy and @YingboMa ! 