### PR TITLE
Fix Windows env using _wputenv_s instead of SetEnvironmentVariableW

### DIFF
--- a/base/env.jl
+++ b/base/env.jl
@@ -24,7 +24,7 @@ if Sys.iswindows()
         var = cwstring(svar)
         val = cwstring(sval)
         if overwrite || !_hasenv(var)
-            ret = ccall(:SetEnvironmentVariableW,stdcall,Int32,(Ptr{UInt16},Ptr{UInt16}),var,val)
+            ret = ccall(:_wputenv_s, stdcall, Int32, (Ptr{UInt16}, Ptr{UInt16}), var, val)
             windowserror(:setenv, ret == 0)
         end
     end

--- a/base/env.jl
+++ b/base/env.jl
@@ -25,7 +25,7 @@ if Sys.iswindows()
         val = cwstring(sval)
         if overwrite || !_hasenv(var)
             ret = ccall(:_wputenv_s, stdcall, Int32, (Ptr{UInt16}, Ptr{UInt16}), var, val)
-            windowserror(:setenv, ret == 0)
+            windowserror(:setenv, ret != 0)
         end
     end
 

--- a/test/env.jl
+++ b/test/env.jl
@@ -118,3 +118,12 @@ if Sys.iswindows()
         end
     end
 end
+
+# Test for #44054
+let key = "KARPINSKI", value = "STEFAN"
+    @test !haskey(ENV, key)
+    ENV[key] = value
+    ret_value = ccall(:getenv, Cstring, (Cstring,), key)
+    @test ret_value != C_NULL && unsafe_string(ret_value) == value
+    delete!(ENV, key)
+end


### PR DESCRIPTION
Fixes JuliaLang#44054 by using [`_wputenv_s`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/putenv-s-wputenv-s?view=msvc-170) instead of [`SetEnvironmentVariableW`](https://docs.microsoft.com/en-us/windows/win32/api/processenv/nf-processenv-setenvironmentvariablew).

This will allow C programs using `getenv` to see environment changes made via Julia's `ENV` on Windows.