### PR TITLE
Fixed inference on String and Symbol causing invalidations in show.jl

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1542,7 +1542,7 @@ function show_list(io::IO, items, sep, indent::Int, prec::Int=0, quote_level::In
             (first && prec >= prec_power &&
              ((item isa Expr && item.head === :call && (callee = item.args[1]; isa(callee, Symbol) && callee in uni_ops)) ||
               (item isa Real && item < 0))) ||
-            (enclose_operators && item isa Symbol && isoperator(item::Symbol) && is_valid_identifier(item::Symbol))
+            (enclose_operators && item isa Symbol && isoperator(item) && is_valid_identifier(item))
         parens && print(io, '(')
         if kw && is_expr(item, :kw, 2)
             item = item::Expr
@@ -1784,7 +1784,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
             item = args[1]
             # field
             field = unquoted(args[2])
-            parens = !is_quoted(item) && !(item isa Symbol && isidentifier(item::Symbol)) && !is_expr(item, :(.))
+            parens = !is_quoted(item) && !(item isa Symbol && isidentifier(item)) && !is_expr(item, :(.))
             parens && print(io, '(')
             show_unquoted(io, item, indent, 0, quote_level)
             parens && print(io, ')')


### PR DESCRIPTION
The added type annotations mainly fix invalidations due to new definitions of `all` (e.g. in `StaticArrays`). 
@timholy 