### PR TITLE
many types should define broadcastable(o) = Ref(o)

### DIFF
--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -464,8 +464,8 @@ it to return something different that supports `axes` and indexing. By
 default, this is the identity function for all `AbstractArray`s and `Number`s — they already
 support `axes` and indexing.
 
-If a type does *not* act like an indexable container, then it should typically be defined to act as a
-0-dimensional "scalar" for the purposes of broadcasting.  This is accomplished by defining a method:
+If a type is intended to act like a "0-dimensional scalar" (a single object) rather than as a
+container for broadcasting, then the following method should be defined:
 ```julia
 Base.broadcastable(o::MyType) = Ref(o)
 ```

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -466,7 +466,7 @@ support `axes` and indexing.
 
 If a type does *not* act like an indexable container, then it should typically be defined to act as a
 0-dimensional "scalar" for the purposes of broadcasting.  This is accomplished by defining a method:
-```
+```julia
 Base.broadcastable(o::MyType) = Ref(o)
 ```
 that returns the argument wrapped in a 0-dimensional [`Ref`](@ref) container.   For example, such a wrapper

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -462,10 +462,17 @@ Not all types support `axes` and indexing, but many are convenient to allow in b
 The [`Base.broadcastable`](@ref) function is called on each argument to broadcast, allowing
 it to return something different that supports `axes` and indexing. By
 default, this is the identity function for all `AbstractArray`s and `Number`s — they already
-support `axes` and indexing. For a handful of other types (including but not limited to
-types themselves, functions, special singletons like [`missing`](@ref) and [`nothing`](@ref), and dates),
-`Base.broadcastable` returns the argument wrapped in a `Ref` to act as a 0-dimensional
-"scalar" for the purposes of broadcasting. Custom types can similarly specialize
+support `axes` and indexing.
+
+If a type does *not* act like an indexable container, then it should typically be defined to act as a
+0-dimensional "scalar" for the purposes of broadcasting.  This is accomplished by defining a method:
+```
+Base.broadcastable(o::MyType) = Ref(o)
+```
+that returns the argument wrapped in a 0-dimensional [`Ref`](@ref) container.   For example, such a wrapper
+method is defined for types themselves, functions, special singletons like [`missing`](@ref) and [`nothing`](@ref), and dates.
+
+Custom array-like types can specialize
 `Base.broadcastable` to define their shape, but they should follow the convention that
 `collect(Base.broadcastable(x)) == collect(x)`. A notable exception is `AbstractString`;
 strings are special-cased to behave as scalars for the purposes of broadcast even though

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -426,6 +426,9 @@ There is much more to say about how instances of composite types are created, bu
 depends on both [Parametric Types](@ref) and on [Methods](@ref), and is sufficiently important
 to be addressed in its own section: [Constructors](@ref man-constructors).
 
+For most user-defined types `X`, you will want to define a method [`Base.broadcastable(x::X) = Ref(x)`](@ref man-interfaces-broadcasting)
+so that instances of that type act as 0-dimensional "scalars" for [broadcasting](@ref Broadcasting).
+
 ## Mutable Composite Types
 
 If a composite type is declared with `mutable struct` instead of `struct`, then instances of

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -426,7 +426,7 @@ There is much more to say about how instances of composite types are created, bu
 depends on both [Parametric Types](@ref) and on [Methods](@ref), and is sufficiently important
 to be addressed in its own section: [Constructors](@ref man-constructors).
 
-For most user-defined types `X`, you will want to define a method [`Base.broadcastable(x::X) = Ref(x)`](@ref man-interfaces-broadcasting)
+For many user-defined types `X`, you may want to define a method [`Base.broadcastable(x::X) = Ref(x)`](@ref man-interfaces-broadcasting)
 so that instances of that type act as 0-dimensional "scalars" for [broadcasting](@ref Broadcasting).
 
 ## Mutable Composite Types


### PR DESCRIPTION
This is an important point because it is the *most common case* for user-defined types, but I noticed that it was a bit buried.