### PR TITLE
some improvements to GC stat printing

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1134,6 +1134,7 @@ static void jl_gc_free_array(jl_array_t *a) JL_NOTSAFEPOINT
         else
             free(d);
         gc_num.freed += jl_array_nbytes(a);
+        gc_num.freecall++;
     }
 }
 


### PR DESCRIPTION
- line up `elapsed time`
- print most numbers unconditionally, except malloc/realloc/free (since some workloads don't use those)
- print minor/full collections instead of all/full collections
- count `free` calls for arrays, since we count `malloc`s for them
