### PR TITLE
alloc profiler: add compat note to docstring

### DIFF
--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -45,13 +45,17 @@ julia> last(sort(results.allocs, by=x->x.size))
 Profile.Allocs.Alloc(Vector{Any}, Base.StackTraces.StackFrame[_new_array_ at array.c:127, ...], 5576)
 ```
 
-Note: The current implementation of the Allocations Profiler _does not
-capture types for all allocations._ Allocations for which the profiler
-could not capture the type are represented as having type
-`Profile.Allocs.UnknownType`.
+!!! note
+    The current implementation of the Allocations Profiler does not
+    capture types for all allocations. Allocations for which the profiler
+    could not capture the type are represented as having type
+    `Profile.Allocs.UnknownType`.
 
-You can read more about the missing types and the plan to improve this, here:
-https://github.com/JuliaLang/julia/issues/43688.
+    You can read more about the missing types and the plan to improve this, here:
+    https://github.com/JuliaLang/julia/issues/43688.
+
+!!! compat "Julia 1.8"
+    The allocation profiler was added in Julia 1.8.
 """
 macro profile(opts, ex)
     _prof_expr(ex, opts)


### PR DESCRIPTION
Note that the alloc profiler was only added in 1.8.

Also, put a box around the note about missing types.

cc @NHDaly 