### PR TITLE
docs: Improve discoverability of `atreplinit` (mention it in Manual>"Command-line Interface">"Startup file")

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -100,7 +100,7 @@ Manual = [
     "manual/faq.md",
     "manual/noteworthy-differences.md",
     "manual/unicode-input.md",
-    "manual/command-line-options.md",
+    "manual/command-line-interface.md",
 ]
 
 BaseDocs = [

--- a/doc/src/manual/command-line-interface.md
+++ b/doc/src/manual/command-line-interface.md
@@ -1,4 +1,4 @@
-# [Command-line Options](@id command-line-options)
+# Command-line Interface
 
 ## Using arguments inside scripts
 
@@ -79,7 +79,7 @@ end
 ```
 
 
-## Command-line switches for Julia
+## [Command-line switches for Julia](@id command-line-options)
 
 There are various ways to run Julia code and provide options, similar to those available for the
 `perl` and `ruby` programs:

--- a/doc/src/manual/command-line-options.md
+++ b/doc/src/manual/command-line-options.md
@@ -63,6 +63,16 @@ Note that although you should have a `~/.julia` directory once you've run Julia 
 first time, you may need to create the `~/.julia/config` folder and the
 `~/.julia/config/startup.jl` file if you use it.
 
+To have startup code run only in [The Julia REPL] (and not when `julia` is *e.g.* run
+on a script), use [`atreplinit`](@ref) in `startup.jl`:
+
+```julia
+atreplinit() do repl
+    # ...
+end
+```
+
+
 ## Command-line switches for Julia
 
 There are various ways to run Julia code and provide options, similar to those available for the

--- a/doc/src/manual/command-line-options.md
+++ b/doc/src/manual/command-line-options.md
@@ -39,6 +39,9 @@ $ julia --color=yes -O -- script.jl arg1 arg2..
 
 See also [Scripting](@ref man-scripting) for more information on writing Julia scripts.
 
+
+## Parallel mode
+
 Julia can be started in parallel mode with either the `-p` or the `--machine-file` options. `-p n`
 will launch an additional `n` worker processes, while `--machine-file file` will launch a worker
 for each line in file `file`. The machines defined in `file` must be accessible via a password-less
@@ -47,6 +50,9 @@ takes the form `[count*][user@]host[:port] [bind_addr[:port]]`. `user` defaults 
 `port` to the standard ssh port. `count` is the number of workers to spawn on the node, and defaults
 to 1. The optional `bind-to bind_addr[:port]` specifies the IP address and port that other workers
 should use to connect to this worker.
+
+
+## Startup file
 
 If you have code that you want executed whenever Julia is run, you can put it in
 `~/.julia/config/startup.jl`:

--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -34,8 +34,7 @@ command:
 $ julia script.jl
 ```
 
-You can pass additional arguments to Julia, and to your program `script.jl`. A detailed list of all the available switches can be found at [Command-line Options](@ref
-command-line-options).
+You can pass additional arguments to Julia, and to your program `script.jl`. A detailed list of all the available options can be found under [Command-line Interface](@ref).
 
 ## Resources
 


### PR DESCRIPTION
As @StefanKarpinski said [here][1], "startup files should probably only be for REPL convenience".

However, the manual makes no mention of [`atreplinit`][2], which is the sanctioned way to achieve this.

I personally discovered `atreplinit` way too late[^1]. In the linked PR, @clarkevans had a similar experience, and [suggested][3] to mention `atreplinit` in the `startup.jl` section of the manual.

Which is what this PR does (first commit).

---

I made two additional, related improvements to [the page in question][4] (next two commits):

1. Add two missing headers, "Parallel mode" and "Startup file".
    These now sit along "Using arguments inside scripts" and "Command-line switches for Julia", which were recently introduced:
    #42878

2. Rename the page from "Command-line Options" to "Command-line Interface",
    to reflect the fact that it describes not only command line options.

---

- [x] Docs built locally and crossrefs manually checked.

[^1]: Namely only after creating a stop-gap solution for running the contents of `startup.jl` in the REPL only, using command line aliases and a custom env var.

[1]: https://github.com/JuliaLang/julia/issues/35932#issuecomment-655160115
[2]: https://docs.julialang.org/en/v1/stdlib/REPL/#Base.atreplinit
[3]: https://github.com/JuliaLang/julia/issues/35932#issuecomment-655060914
[4]: https://github.com/JuliaLang/julia/blob/991f0b17/doc/src/manual/command-line-options.md