### PR TITLE
effects: look for `:terminate_globally` override in backedge termination check

### DIFF
--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -89,7 +89,7 @@ struct EffectsOverride
     consistent::Bool
     effect_free::Bool
     nothrow::Bool
-    terminates::Bool
+    terminates_globally::Bool
     terminates_locally::Bool
 end
 
@@ -98,7 +98,7 @@ function encode_effects_override(eo::EffectsOverride)
     eo.consistent && (e |= 0x01)
     eo.effect_free && (e |= 0x02)
     eo.nothrow && (e |= 0x04)
-    eo.terminates && (e |= 0x08)
+    eo.terminates_globally && (e |= 0x08)
     eo.terminates_locally && (e |= 0x10)
     e
 end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1055,3 +1055,17 @@ function f_call_invoke_callback(f::FCallback)
     return nothing
 end
 @test !fully_eliminated(f_call_invoke_callback, Tuple{FCallback})
+
+# https://github.com/JuliaLang/julia/issues/41694
+Base.@assume_effects :terminates_globally function issue41694(x)
+    res = 1
+    1 < x < 20 || throw("bad")
+    while x > 1
+        res *= x
+        x -= 1
+    end
+    return res
+end
+@test fully_eliminated() do
+    issue41694(2)
+end


### PR DESCRIPTION
Now we can "fix" #41694:
```julia
Base.@assume_effects :terminates_globally function issue41694(x)
    res = 1
    1 < x < 20 || throw("bad")
    while x > 1
        res *= x
        x -= 1
    end
    return res
end
@test fully_eliminated() do
    issue41694(2)
end
```