### PR TITLE
abs2(::Number) fallback

### DIFF
--- a/base/number.jl
+++ b/base/number.jl
@@ -174,6 +174,7 @@ julia> abs2(-3)
 9
 ```
 """
+abs2(x::Number) = abs(x)^2
 abs2(x::Real) = x*x
 
 """

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2416,6 +2416,12 @@ zero(::Type{TestNumber{Inner}}) where {Inner} = TestNumber(zero(Inner))
 big(test_number::TestNumber) = TestNumber(big(test_number.inner))
 @test big(TestNumber{Int}) == TestNumber{BigInt}
 
+# abstract abs2
+Base.:*(x::TestNumber, y::TestNumber) = TestNumber(x.inner*y.inner)
+Base.:(==)(x::TestNumber, y::TestNumber) = x.inner == y.inner
+Base.abs(x::TestNumber) = TestNumber(abs(x.inner))
+@test abs2(TestNumber(3+4im)) == TestNumber(25)
+
 @testset "multiplicative inverses" begin
     function testmi(numrange, denrange)
         for d in denrange


### PR DESCRIPTION
I noticed that the `abs2(x)` function was missing an `abs(x)^2` fallback, so it fails for user-defined `Number` types if you don't implement it explicitly.

Seems better to have a fallback implementing the generic definition of this function.