### PR TITLE
faster inv and div for Complex{Union{Float16, Float32}}

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -366,12 +366,6 @@ function /(a::Complex{T}, b::Complex{T}) where T<:Real
     end
 end
 
-function inv(z::Complex{<:Union{Float16,Float32}})
-    c, d = reim(widen(z))
-    mag = inv(muladd(c, c, d^2))
-    return oftype(z, Complex(c*mag, d*mag))
-end
-
 function /(z::Complex{T}, w::Complex{T}) where {T<:Union{Float16,Float32}}
     a, b = reim(widen(z))
     c, d = reim(widen(w))
@@ -458,6 +452,12 @@ function robust_cdiv2(a::Float64, b::Float64, c::Float64, d::Float64, r::Float64
     end
 end
 
+function inv(z::Complex{<:Union{Float16,Float32}})
+    c, d = reim(widen(z))
+    (isinf(c) | isinf(d)) && return complex(copysign(0f0, c), flipsign(-0f0, d))
+    mag = inv(muladd(c, c, d^2))
+    return oftype(z, Complex(c*mag, -d*mag))
+end
 function inv(w::ComplexF64)
     c, d = reim(w)
     (isinf(c) | isinf(d)) && return complex(copysign(0.0, c), flipsign(-0.0, d))

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -347,20 +347,13 @@ muladd(z::Complex, w::Complex, x::Real) =
 
 function /(a::Complex{T}, b::Complex{T}) where T<:Real
     are = real(a); aim = imag(a); bre = real(b); bim = imag(b)
+    (isinf(bre) | isinf(bim)) && return complex(copysign(zero(T), bre), flipsign(-zero(T), bim)) * a
     if abs(bre) <= abs(bim)
-        if isinf(bre) && isinf(bim)
-            r = sign(bre)/sign(bim)
-        else
-            r = bre / bim
-        end
+        r = bre / bim
         den = bim + r*bre
         Complex((are*r + aim)/den, (aim*r - are)/den)
     else
-        if isinf(bre) && isinf(bim)
-            r = sign(bim)/sign(bre)
-        else
-            r = bim / bre
-        end
+        r = bim / bre
         den = bre + r*bim
         Complex((are + aim*r)/den, (aim - are*r)/den)
     end
@@ -369,7 +362,7 @@ end
 function /(z::Complex{T}, w::Complex{T}) where {T<:Union{Float16,Float32}}
     c, d = reim(widen(w))
     a, b = reim(widen(z))
-    (isinf(c) | isinf(d)) && return complex(copysign(zero(T), c), flipsign(zero(T), d)) * z
+    (isinf(c) | isinf(d)) && return complex(copysign(zero(T), c), flipsign(-zero(T), d)) * z
     mag = inv(muladd(c, c, d^2))
     re_part = muladd(a, c, b*d)
     im_part = muladd(b, c, -a*d)
@@ -386,7 +379,7 @@ function /(z::ComplexF64, w::ComplexF64)
     a, b = reim(z); c, d = reim(w)
     absa = abs(a); absb = abs(b);  ab = absa >= absb ? absa : absb # equiv. to max(abs(a),abs(b)) but without NaN-handling (faster)
     absc = abs(c); absd = abs(d);  cd = absc >= absd ? absc : absd
-    ((absc==Inf) | (absd==Inf)) && return complex(copysign(0.0, c), flipsign(0.0, d)) * z
+    ((absc==Inf) | (absd==Inf)) && return complex(copysign(0.0, c), flipsign(-0.0, d))*z
     halfov = 0.5*floatmax(Float64)              # overflow threshold
     twounϵ = floatmin(Float64)*2.0/eps(Float64) # underflow threshold
 

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -366,7 +366,7 @@ function /(a::Complex{T}, b::Complex{T}) where T<:Real
     end
 end
 
-function (z::Complex{<:Union{Float16,Float32}}) =
+function inv(z::Complex{<:Union{Float16,Float32}})
     c, d = reim(widen(z))
     mag = inv(muladd(c, c, d^2))
     return oftype(z, Complex(c*mag, d*mag))

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -386,7 +386,7 @@ function /(z::ComplexF64, w::ComplexF64)
     a, b = reim(z); c, d = reim(w)
     absa = abs(a); absb = abs(b);  ab = absa >= absb ? absa : absb # equiv. to max(abs(a),abs(b)) but without NaN-handling (faster)
     absc = abs(c); absd = abs(d);  cd = absc >= absd ? absc : absd
-
+    ((absc==Inf) | (absd==Inf)) && return complex(copysign(0.0, c), flipsign(0.0, d)) * z
     halfov = 0.5*floatmax(Float64)              # overflow threshold
     twounϵ = floatmin(Float64)*2.0/eps(Float64) # underflow threshold
 

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -453,7 +453,7 @@ function robust_cdiv2(a::Float64, b::Float64, c::Float64, d::Float64, r::Float64
     end
 end
 
-function inv(z::T) where T<:Complex{<:Union{Float16,Float32}}
+function inv(z::Complex{T}) where T<:Union{Float16,Float32}
     c, d = reim(widen(z))
     (isinf(c) | isinf(d)) && return complex(copysign(zero(T), c), flipsign(-zero(T), d))
     mag = inv(muladd(c, c, d^2))

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -351,7 +351,7 @@ function /(a::Complex{T}, b::Complex{T}) where T<:Real
         if isfinite(a)
             return complex(zero(T)*sign(are)*sign(bre), -zero(T)*sign(aim)*sign(bim))
         end
-        return T(Nan+NaN*im)
+        return T(NaN)+T(NaN)*im
     end
     if abs(bre) <= abs(bim)
         r = bre / bim
@@ -371,7 +371,7 @@ function /(z::Complex{T}, w::Complex{T}) where {T<:Union{Float16,Float32}}
         if isfinite(z)
             return complex(zero(T)*sign(a)*sign(c), -zero(T)*sign(b)*sign(d))
         end
-        return T(Nan+NaN*im)
+        return T(NaN)+T(NaN)*im
     end
     mag = inv(muladd(c, c, d^2))
     re_part = muladd(a, c, b*d)
@@ -393,7 +393,7 @@ function /(z::ComplexF64, w::ComplexF64)
         if isfinite(z)
             return complex(0.0*sign(a)*sign(c), -0.0*sign(b)*sign(d))
         end
-        return Nan+NaN*im
+        return NaN+NaN*im
     end
     halfov = 0.5*floatmax(Float64)              # overflow threshold
     twounϵ = floatmin(Float64)*2.0/eps(Float64) # underflow threshold

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -369,7 +369,7 @@ function /(z::Complex{T}, w::Complex{T}) where {T<:Union{Float16,Float32}}
     a, b = reim(widen(z))
     if (isinf(c) | isinf(d))
         if isfinite(z)
-            return complex(zero(T)*sign(a)*sign(c), -zero(T)*sign(b)*sign(d))
+            return complex(zero(T)*sign(real(z))*sign(real(w)), -zero(T)*sign(imag(z))*sign(imag(w)))
         end
         return T(NaN)+T(NaN)*im
     end

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -373,7 +373,8 @@ function inv(z::Complex{<:Union{Float16,Float32}})
 end
 
 function /(z::Complex{T}, w::Complex{T}) where {T<:Union{Float16,Float32}}
-    c, d = reim(widen(z))
+    a, b = reim(widen(z))
+    c, d = reim(widen(w))
     mag = inv(muladd(c, c, d^2))
     re_part = muladd(a, c, b*d)
     im_part = muladd(b, c, -a*d)

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -369,7 +369,7 @@ end
 function /(z::Complex{T}, w::Complex{T}) where {T<:Union{Float16,Float32}}
     c, d = reim(widen(w))
     a, b = reim(widen(z))
-    (isinf(c) | isinf(d)) && return complex(copysign(zero(T), c), flipsign(zero(T), d)) * z
+    (isinf(c) | isinf(d)) && return complex(copysign(zero(z), c), flipsign(zero(z), d)) * z
     mag = inv(muladd(c, c, d^2))
     re_part = muladd(a, c, b*d)
     im_part = muladd(b, c, -a*d)
@@ -455,7 +455,7 @@ end
 
 function inv(z::Complex{<:Union{Float16,Float32}})
     c, d = reim(widen(z))
-    (isinf(c) | isinf(d)) && return complex(copysign(zero(T), c), flipsign(-zero(T), d))
+    (isinf(c) | isinf(d)) && return complex(copysign(zero(z), c), flipsign(-zero(z), d))
     mag = inv(muladd(c, c, d^2))
     return oftype(z, Complex(c*mag, -d*mag))
 end

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -369,7 +369,7 @@ end
 function /(z::Complex{T}, w::Complex{T}) where {T<:Union{Float16,Float32}}
     c, d = reim(widen(w))
     a, b = reim(widen(z))
-    (isinf(c) | isinf(d)) && return complex(copysign(zero(z), c), flipsign(zero(z), d)) * z
+    (isinf(c) | isinf(d)) && return complex(copysign(zero(T), c), flipsign(zero(T), d)) * z
     mag = inv(muladd(c, c, d^2))
     re_part = muladd(a, c, b*d)
     im_part = muladd(b, c, -a*d)
@@ -453,9 +453,9 @@ function robust_cdiv2(a::Float64, b::Float64, c::Float64, d::Float64, r::Float64
     end
 end
 
-function inv(z::Complex{<:Union{Float16,Float32}})
+function inv(z::T) where T<:Complex{<:Union{Float16,Float32}}
     c, d = reim(widen(z))
-    (isinf(c) | isinf(d)) && return complex(copysign(zero(z), c), flipsign(-zero(z), d))
+    (isinf(c) | isinf(d)) && return complex(copysign(zero(T), c), flipsign(-zero(T), d))
     mag = inv(muladd(c, c, d^2))
     return oftype(z, Complex(c*mag, -d*mag))
 end

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -369,7 +369,7 @@ end
 function /(z::Complex{T}, w::Complex{T}) where {T<:Union{Float16,Float32}}
     c, d = reim(widen(w))
     a, b = reim(widen(z))
-    (isinf(c) | isinf(d)) && return complex(copysign(0f0, c), flipsign(0f0, d)) * z
+    (isinf(c) | isinf(d)) && return complex(copysign(zero(T), c), flipsign(zero(T), d)) * z
     mag = inv(muladd(c, c, d^2))
     re_part = muladd(a, c, b*d)
     im_part = muladd(b, c, -a*d)
@@ -455,7 +455,7 @@ end
 
 function inv(z::Complex{<:Union{Float16,Float32}})
     c, d = reim(widen(z))
-    (isinf(c) | isinf(d)) && return complex(copysign(0f0, c), flipsign(-0f0, d))
+    (isinf(c) | isinf(d)) && return complex(copysign(zero(T), c), flipsign(-zero(T), d))
     mag = inv(muladd(c, c, d^2))
     return oftype(z, Complex(c*mag, -d*mag))
 end

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -366,11 +366,19 @@ function /(a::Complex{T}, b::Complex{T}) where T<:Real
     end
 end
 
-inv(z::Complex{<:Union{Float16,Float32}}) =
-    oftype(z, inv(widen(z)))
+function (z::Complex{<:Union{Float16,Float32}}) =
+    c, d = reim(widen(z))
+    mag = inv(muladd(c, c, d^2))
+    return oftype(z, Complex(c*mag, d*mag))
+end
 
-/(z::Complex{T}, w::Complex{T}) where {T<:Union{Float16,Float32}} =
-    oftype(z, widen(z)*inv(widen(w)))
+function /(z::Complex{T}, w::Complex{T}) where {T<:Union{Float16,Float32}}
+    c, d = reim(widen(z))
+    mag = inv(muladd(c, c, d^2))
+    re_part = muladd(a, c, b*d)
+    im_part = muladd(b, c, -a*d)
+    return oftype(z, Complex(re_part*mag, im_part*mag))
+end
 
 # robust complex division for double precision
 # variables are scaled & unscaled to avoid over/underflow, if necessary

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -367,8 +367,9 @@ function /(a::Complex{T}, b::Complex{T}) where T<:Real
 end
 
 function /(z::Complex{T}, w::Complex{T}) where {T<:Union{Float16,Float32}}
-    a, b = reim(widen(z))
     c, d = reim(widen(w))
+    a, b = reim(widen(z))
+    (isinf(c) | isinf(d)) && return complex(copysign(0f0, c), flipsign(0f0, d)) * z
     mag = inv(muladd(c, c, d^2))
     re_part = muladd(a, c, b*d)
     im_part = muladd(b, c, -a*d)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1089,7 +1089,7 @@ end
 
         # divide complex by complex Inf
         @test isequal(complex(one(T)) / complex(T(Inf), T(-Inf)), complex(zero(T), zero(T)))
-        @test isequal(complex(one(T)) / complex(T(-Inf), T(Inf)), complex(zero(T), -zero(T)))
+        @test isequal(complex(one(T)) / complex(T(-Inf), T(Inf)), complex(-zero(T), -zero(T)))
     end
 end
 

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -88,7 +88,6 @@ end
             @test isequal(T(-0.0) / im, Complex(T(-0.0), T(+0.0)))
             @test isequal(T(+1.0) / im, Complex(T(+0.0), T(-1.0)))
             @test isequal(T(-1.0) / im, Complex(T(-0.0), T(+1.0)))
-            @test isequal(complex(one(T)) / complex(T(Inf), T(Inf)), complex(zero(T)))
         end
     end
     @test isequal(true + complex(true,false), complex(true,false) + complex(true,false))
@@ -1040,7 +1039,7 @@ end
 @testset "corner cases of division, issue #22983" begin
     # These results abide by ISO/IEC 10967-3:2006(E) and
     # mathematical definition of division of complex numbers.
-    for T in (Float32, Float64, BigFloat)
+    for T in (Float16, Float32, Float64, BigFloat)
         @test isequal(one(T) / zero(Complex{T}), one(Complex{T}) / zero(Complex{T}))
         @test isequal(one(T) / zero(Complex{T}), Complex{T}(NaN, NaN))
         @test isequal(one(Complex{T}) / zero(T), Complex{T}(Inf, NaN))
@@ -1051,7 +1050,7 @@ end
 end
 
 @testset "division by Inf, issue#23134" begin
-    @testset "$T" for T in (Float32, Float64, BigFloat)
+    @testset "$T" for T in (Float16, Float32, Float64, BigFloat)
         @test isequal(one(T) / complex(T(Inf)),         complex(zero(T), -zero(T)))
         @test isequal(one(T) / complex(T(Inf), one(T)), complex(zero(T), -zero(T)))
         @test isequal(one(T) / complex(T(Inf), T(NaN)), complex(zero(T), -zero(T)))
@@ -1089,8 +1088,8 @@ end
         @test isequal(one(T) / complex(T(-NaN),  T(-Inf)), complex(-zero(T), zero(T)))
 
         # divide complex by complex Inf
-        @test isequal(complex(one(T)) / complex(T(Inf), T(-Inf)), complex(zero(T), zero(T))) broken=(T==Float64)
-        @test isequal(complex(one(T)) / complex(T(-Inf), T(Inf)), complex(-zero(T), -zero(T))) broken=(T in (Float32, Float64))
+        @test isequal(complex(one(T)) / complex(T(Inf), T(-Inf)), complex(zero(T), zero(T)))
+        @test isequal(complex(one(T)) / complex(T(-Inf), T(Inf)), complex(zero(T), -zero(T)))
     end
 end
 

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -88,6 +88,7 @@ end
             @test isequal(T(-0.0) / im, Complex(T(-0.0), T(+0.0)))
             @test isequal(T(+1.0) / im, Complex(T(+0.0), T(-1.0)))
             @test isequal(T(-1.0) / im, Complex(T(-0.0), T(+1.0)))
+            @test isequal(complex(one(T)) / complex(T(Inf), T(Inf)), complex(zero(T)))
         end
     end
     @test isequal(true + complex(true,false), complex(true,false) + complex(true,false))

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1090,6 +1090,8 @@ end
         # divide complex by complex Inf
         @test isequal(complex(one(T)) / complex(T(Inf), T(-Inf)), complex(zero(T), zero(T)))
         @test isequal(complex(one(T)) / complex(T(-Inf), T(Inf)), complex(-zero(T), -zero(T)))
+        @test isequal(complex(T(Inf)) / complex(T(Inf), T(-Inf)), complex(T(NaN), T(NaN)))
+        @test isequal(complex(T(NaN)) / complex(T(-Inf), T(Inf)), complex(T(NaN), T(NaN)))
     end
 end
 


### PR DESCRIPTION
As discovered in https://discourse.julialang.org/t/efficient-calculation-of-many-complex-lorentzians-on-a-large-array/76150/21, Complex division for `Float16` and `Float32` are currently doing a lot of extra work. This still does the math in `Float64`, but ignores all the extra checks.