### PR TITLE
Fix thread-safety violation in Allocations Profiler: Create a new per-thread backtrace buffer in ptls

### DIFF
--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -54,6 +54,9 @@ jl_raw_backtrace_t get_raw_backtrace() JL_NOTSAFEPOINT {
     // per-thread backtrace buffer.
     jl_ptls_t ptls = jl_current_task->ptls;
     jl_bt_element_t *shared_bt_data_buffer = ptls->profiling_bt_buffer;
+    if (shared_bt_data_buffer == NULL)
+        ptls->profiling_bt_buffer = shared_bt_data_buffer = \
+                malloc_s(sizeof(jl_bt_element_t) * (JL_MAX_BT_SIZE + 1));
 
     size_t bt_size = rec_backtrace(shared_bt_data_buffer, JL_MAX_BT_SIZE, 2);
 

--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -49,15 +49,24 @@ jl_combined_results g_combined_results; // Will live forever.
 // === stack stuff ===
 
 jl_raw_backtrace_t get_raw_backtrace() JL_NOTSAFEPOINT {
-    // A single large buffer to record backtraces onto
-    static jl_bt_element_t static_bt_data[JL_MAX_BT_SIZE];
+    // We first record the backtrace onto a MAX-sized buffer, so that we don't have to
+    // allocate the buffer until we know the size. To ensure thread-safety, we *re-use the
+    // per-thread backtrace buffer*, which is shared with Julia's exception throwing
+    // mechanism. This sharing is safe, because this function cannot be interleaved with
+    // exception throwing.
+    jl_ptls_t ptls = jl_current_task->ptls;
+    jl_bt_element_t *shared_bt_data_buffer = ptls->bt_data;
 
-    size_t bt_size = rec_backtrace(static_bt_data, JL_MAX_BT_SIZE, 2);
+    size_t bt_size = rec_backtrace(shared_bt_data_buffer, JL_MAX_BT_SIZE, 2);
 
     // Then we copy only the needed bytes out of the buffer into our profile.
     size_t bt_bytes = bt_size * sizeof(jl_bt_element_t);
     jl_bt_element_t *bt_data = (jl_bt_element_t*) malloc(bt_bytes);
-    memcpy(bt_data, static_bt_data, bt_bytes);
+    memcpy(bt_data, shared_bt_data_buffer, bt_bytes);
+
+    // Now, "clear" the ptls buffer, so that this buffer isn't incorrectly rooting objects
+    // in that buffer.
+    ptls->bt_size = 0;
 
     return jl_raw_backtrace_t{
         bt_data,

--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -64,7 +64,7 @@ jl_raw_backtrace_t get_raw_backtrace() JL_NOTSAFEPOINT {
 
     // Then we copy only the needed bytes out of the buffer into our profile.
     size_t bt_bytes = bt_size * sizeof(jl_bt_element_t);
-    jl_bt_element_t *bt_data = (jl_bt_element_t*) malloc(bt_bytes);
+    jl_bt_element_t *bt_data = (jl_bt_element_t*) malloc_s(bt_bytes);
     memcpy(bt_data, shared_bt_data_buffer, bt_bytes);
 
 

--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -54,9 +54,11 @@ jl_raw_backtrace_t get_raw_backtrace() JL_NOTSAFEPOINT {
     // per-thread backtrace buffer.
     jl_ptls_t ptls = jl_current_task->ptls;
     jl_bt_element_t *shared_bt_data_buffer = ptls->profiling_bt_buffer;
-    if (shared_bt_data_buffer == NULL)
-        ptls->profiling_bt_buffer = shared_bt_data_buffer = \
-                malloc_s(sizeof(jl_bt_element_t) * (JL_MAX_BT_SIZE + 1));
+    if (shared_bt_data_buffer == NULL) {
+        size_t size = sizeof(jl_bt_element_t) * (JL_MAX_BT_SIZE + 1);
+        shared_bt_data_buffer = (jl_bt_element_t*) malloc_s(size);
+        ptls->profiling_bt_buffer = shared_bt_data_buffer;
+    }
 
     size_t bt_size = rec_backtrace(shared_bt_data_buffer, JL_MAX_BT_SIZE, 2);
 

--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -50,12 +50,10 @@ jl_combined_results g_combined_results; // Will live forever.
 
 jl_raw_backtrace_t get_raw_backtrace() JL_NOTSAFEPOINT {
     // We first record the backtrace onto a MAX-sized buffer, so that we don't have to
-    // allocate the buffer until we know the size. To ensure thread-safety, we *re-use the
-    // per-thread backtrace buffer*, which is shared with Julia's exception throwing
-    // mechanism. This sharing is safe, because this function cannot be interleaved with
-    // exception throwing.
+    // allocate the buffer until we know the size. To ensure thread-safety, we use a
+    // per-thread backtrace buffer.
     jl_ptls_t ptls = jl_current_task->ptls;
-    jl_bt_element_t *shared_bt_data_buffer = ptls->bt_data;
+    jl_bt_element_t *shared_bt_data_buffer = ptls->profiling_bt_buffer;
 
     size_t bt_size = rec_backtrace(shared_bt_data_buffer, JL_MAX_BT_SIZE, 2);
 

--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -65,9 +65,6 @@ jl_raw_backtrace_t get_raw_backtrace() JL_NOTSAFEPOINT {
     jl_bt_element_t *bt_data = (jl_bt_element_t*) malloc(bt_bytes);
     memcpy(bt_data, shared_bt_data_buffer, bt_bytes);
 
-    // Now, "clear" the ptls buffer, so that this buffer isn't incorrectly rooting objects
-    // in that buffer.
-    ptls->bt_size = 0;
 
     return jl_raw_backtrace_t{
         bt_data,

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -246,6 +246,8 @@ typedef struct _jl_tls_states_t {
     // Temporary backtrace buffer. Scanned for gc roots when bt_size > 0.
     struct _jl_bt_element_t *bt_data; // JL_MAX_BT_SIZE + 1 elements long
     size_t bt_size;    // Size for backtrace in transit in bt_data
+    // Temporary backtrace buffer used only for allocations profiler.
+    struct _jl_bt_element_t *profiling_bt_buffer;
     // Atomically set by the sender, reset by the handler.
     volatile _Atomic(sig_atomic_t) signal_request; // TODO: no actual reason for this to be _Atomic
     // Allow the sigint to be raised asynchronously


### PR DESCRIPTION
Another approach to fix https://github.com/JuliaLang/julia/issues/44099. 

This is an alternative approach to https://github.com/JuliaLang/julia/pull/44114, but it creates a separate per-thread allocations backtrace buffer, to avoid potential sharing issues.

CC: @vilterp 