### PR TITLE
Extract out a function `Base.time_print_string(...)` to get the `@time` string

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -115,7 +115,7 @@ function format_bytes(bytes) # also used by InteractiveUtils
     end
 end
 
-function time_print(elapsedtime, bytes=0, gctime=0, allocs=0, compile_time=0, newline=false, _lpad=true)
+function time_print_string(elapsedtime, bytes=0, gctime=0, allocs=0, compile_time=0, newline=false, _lpad=true)
     timestr = Ryu.writefixed(Float64(elapsedtime/1e9), 6)
     str = sprint() do io
         _lpad && print(io, length(timestr) < 10 ? (" "^(10 - length(timestr))) : "")
@@ -144,8 +144,14 @@ function time_print(elapsedtime, bytes=0, gctime=0, allocs=0, compile_time=0, ne
             print(io, Ryu.writefixed(Float64(100*compile_time/elapsedtime), 2), "% compilation time")
         end
         parens && print(io, ")")
+        newline && println(io)
     end
-    newline ? println(str) : print(str)
+    return str
+end
+
+function time_print(args...)
+    str = time_print_str(args...)
+    print(str)
     nothing
 end
 


### PR DESCRIPTION
This allows us to log the `@time` message via `@info` instead of
`print`, which is useful for anyone using structured logging.
(For example, for production web servers, we want to always log with our
structured logger, to ensure that the log message gets a timestamp,
transaction ID, etc.)

So with this change, we can now call with `@info` instead:
```
@info Base.time_print_string(args...)
```

@IanButterworth: this is a small change, and 100% non-breaking (keeps the old API entirely, but extracts out this helper function that we can call without the side-effect of printing), so hopefully should be an easy change! 😊 Thanks