### PR TITLE
Reduce number of `getindex(::Type, ...)` methods

### DIFF
--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2318,10 +2318,12 @@ let A = zeros(Int, 2, 2), B = zeros(Float64, 2, 2)
     f40() = Float64[A A]
     f41() = [A B]
     f42() = Int[A B]
+    f43() = Int[A...]
+    f44() = Float64[A..., B...]
 
     for f in [f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16,
               f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30,
-              f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42]
+              f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43, f44]
         @test isconcretetype(Base.return_types(f, ())[1])
     end
 end


### PR DESCRIPTION
Previously, there were special cases for `T[]`, `T[a]`, `T[a,b]` and `T[a,b,c]`. Together with the general case for more elements, that meant five methods to consider in cases like `T[x...]` where the length of `x` was not known at compile time. That was beyond the inference limit and such a call would be inferred as `Any`. So this change gets rid of all the special cases.

The loop-based general case worked well if all arguments were of the same type, but otherwise suffered from type-instability inside the loop. Without the special cases for low element count this would be hit more often, so the loop is replaced with a call to `afoldl` that basically unrolls the loop for up to 32 elements.

```julia
julia> f(x) = Int[x...];

julia> @code_typed(f([1]))[2]
Any # master
Vector{Int64} (alias for Array{Int64, 1}) # PR

julia> @btime Float64[1, 2.0, 0x3];
  35.326 ns (1 allocation: 80 bytes) # master
  35.215 ns (1 allocation: 80 bytes) # PR

julia> @btime Float64[1, 2.0, 0x3, 4.0f0];
  255.610 ns (7 allocations: 256 bytes) # master
  36.245 ns (1 allocation: 96 bytes) # PR

julia> @btime Float64[1, 2, 3, 4];
  35.578 ns (1 allocation: 96 bytes) # master
  35.143 ns (1 allocation: 96 bytes) # PR
```
Motivated by https://github.com/JuliaMath/FFTW.jl/pull/231.