### PR TITLE
fix #44086, missing field reordering in `NamedTuple{n,T}(::NamedTuple)`

### DIFF
--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -333,3 +333,6 @@ end
 
 # issue #43045
 @test merge(NamedTuple(), Iterators.reverse(pairs((a=1,b=2)))) === (b = 2, a = 1)
+
+# issue #44086
+@test NamedTuple{(:x, :y, :z), Tuple{Int8, Int16, Int32}}((z=1, x=2, y=3)) === (x = Int8(2), y = Int16(3), z = Int32(1))


### PR DESCRIPTION
fix #44086