### PR TITLE
fix #44153, limit input types of reflection utilities

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1230,7 +1230,7 @@ end
 Similar to [`code_typed`](@ref), except the argument is a tuple type describing
 a full signature to query.
 """
-function code_typed_by_type(@nospecialize(tt#=::Type=#);
+function code_typed_by_type(@nospecialize(tt::Type);
                             optimize=true,
                             debuginfo::Symbol=:default,
                             world = get_world_counter(),
@@ -1301,7 +1301,7 @@ function print_statement_costs(io::IO, @nospecialize(f), @nospecialize(t); kwarg
     print_statement_costs(io, tt; kwargs...)
 end
 
-function print_statement_costs(io::IO, @nospecialize(tt#=::Type=#);
+function print_statement_costs(io::IO, @nospecialize(tt::Type);
                                world = get_world_counter(),
                                interp = Core.Compiler.NativeInterpreter(world))
     matches = _methods_by_ftype(tt, -1, world)::Vector
@@ -1329,9 +1329,9 @@ function print_statement_costs(io::IO, @nospecialize(tt#=::Type=#);
     end
 end
 
-print_statement_costs(args...; kwargs...) = print_statement_costs(stdout, args...; kwargs...)
+print_statement_costs(args...; kwargs...) = print_statement_costs(stdout::IO, args...; kwargs...)
 
-function _which(@nospecialize(tt#=::Type=#), world=get_world_counter())
+function _which(@nospecialize(tt::Type), world=get_world_counter())
     min_valid = RefValue{UInt}(typemin(UInt))
     max_valid = RefValue{UInt}(typemax(UInt))
     match = ccall(:jl_gf_invoke_lookup_worlds, Any,


### PR DESCRIPTION
After #43113 Julia compiler can inline `@nospecialize ::AbstractType`
signature, so we can reintroduce the input type annotations.
Still I want to keep the current `::Any` signature for those utility
functions heavily in `Core.Compiler` (e.g. `isbitstype`) because `isa(t, Type)`
check inserted by the inliner otherwise might involve some cost.
But I agree that the other non-performance sensitive functions like `which`
is better to have input type restrictions.