### PR TITLE
[REPLCompletions] set working directory to \

### DIFF
--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1030,12 +1030,12 @@ let current_dir, forbidden
      # Issue #19310
     if Sys.iswindows()
         current_dir = pwd()
-        cd("C:")
+        cd("C:\\")
         test_complete("C"); @test true
         test_complete("C:"); @test true
         test_complete("C:\\"); @test true
-        if isdir("D:")
-            cd("D:")
+        if isdir("D:\\")
+            cd("D:\\")
             test_complete("C"); @test true
             test_complete("C:"); @test true
             test_complete("C:\\"); @test true


### PR DESCRIPTION
Using C: would try to go to ENV["=C:"], which we might have rmdir
earlier. We just need the root here for the test, so specify that
exactly so we go to C:\ and not the last working directory on C.