### PR TITLE
Revert "Profile.Allocs: Add task and timestamp"

### DIFF
--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -20,8 +20,6 @@ struct jl_raw_alloc_t {
     jl_datatype_t *type_address;
     jl_raw_backtrace_t backtrace;
     size_t size;
-    jl_task_t *task;
-    uint64_t timestamp;
 };
 
 // == These structs define the global singleton profile buffer that will be used by
@@ -134,9 +132,7 @@ void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size, jl_datatype_t 
     profile.allocs.emplace_back(jl_raw_alloc_t{
         type,
         get_raw_backtrace(),
-        size,
-        jl_current_task,
-        cycleclock()
+        size
     });
 }
 

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -19,8 +19,6 @@ struct RawAlloc
     type::Ptr{Type}
     backtrace::RawBacktrace
     size::Csize_t
-    task::Ptr{Cvoid}
-    timestamp::UInt64
 end
 
 # matches jl_profile_allocs_raw_results_t on the C side
@@ -123,8 +121,6 @@ struct Alloc
     type::Any
     stacktrace::StackTrace
     size::Int
-    task::Ptr{Cvoid}
-    timestamp::UInt64
 end
 
 struct AllocResults
@@ -162,9 +158,7 @@ function decode_alloc(cache::BacktraceCache, raw_alloc::RawAlloc)::Alloc
     Alloc(
         load_type(raw_alloc.type),
         stacktrace_memoized(cache, load_backtrace(raw_alloc.backtrace)),
-        UInt(raw_alloc.size),
-        raw_alloc.task,
-        raw_alloc.timestamp
+        UInt(raw_alloc.size)
     )
 end
 


### PR DESCRIPTION
Reverts JuliaLang/julia#44055

This broke analyzegc.

> /cache/build/default-amdci5-2/julialang/julia-master/src/gc-alloc-profiler.cpp:140:9: error: Calling potential safepoint from function annotated JL_NOTSAFEPOINT [julia.GCChecker]