### PR TITLE
Print a hint if the user types `exit` in the REPL (implemented by customizing `Base.show` for `typeof(exit)`)

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -29,7 +29,8 @@ exit(n) = ccall(:jl_exit, Cvoid, (Int32,), n)
 exit() = exit(0)
 
 function Base.show(io::IO, m::MIME"text/plain", fn::typeof(exit))
-    invoke(show, Tuple{IO, MIME"text/plain", Function}, io, m, fn)
+    TT = Tuple{IO, MIME"text/plain", Function}
+    invoke(show, TT, io, m, fn)
     println(io)
     print(io, "Hint: To exit Julia, use Ctrl-D or type exit() and press enter.")
     return nothing

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -28,6 +28,13 @@ the keyboard shortcut `^D`.
 exit(n) = ccall(:jl_exit, Cvoid, (Int32,), n)
 exit() = exit(0)
 
+function Base.show(io::IO, m::MIME"text/plain", fn::F) where F <: typeof(exit)
+    invoke(show, Tuple{IO, MIME"text/plain", F}, io, m, fn)
+    println(io)
+    print(io, "Hint: To exit Julia, use Ctrl-D or type exit() and press enter.")
+    return nothing
+end
+
 const roottask = current_task()
 
 is_interactive = false

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -28,8 +28,8 @@ the keyboard shortcut `^D`.
 exit(n) = ccall(:jl_exit, Cvoid, (Int32,), n)
 exit() = exit(0)
 
-function Base.show(io::IO, m::MIME"text/plain", fn::F) where F <: typeof(exit)
-    invoke(show, Tuple{IO, MIME"text/plain", F}, io, m, fn)
+function Base.show(io::IO, m::MIME"text/plain", fn::typeof(exit))
+    invoke(show, Tuple{IO, MIME"text/plain", Function}, io, m, fn)
     println(io)
     print(io, "Hint: To exit Julia, use Ctrl-D or type exit() and press enter.")
     return nothing


### PR DESCRIPTION
This implements the suggestion from triage in https://github.com/JuliaLang/julia/pull/42011#issuecomment-961323748 and https://github.com/JuliaLang/julia/pull/42011#issuecomment-961729741.