### PR TITLE
fix escaping

### DIFF
--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -174,7 +174,7 @@ function gen_call_with_extracted_types(__module__, fcn, ex0, kws=Expr[])
 end
 
 """
-Same behaviour as gen_call_with_extracted_types except that keyword arguments
+Same behaviour as `gen_call_with_extracted_types` except that keyword arguments
 of the form "foo=bar" are passed on to the called function as well.
 The keyword arguments must be given before the mandatory argument.
 """


### PR DESCRIPTION
Before the help string displayed with `call` and `extracted` underlined