### PR TITLE
completely initialize SystemError

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -20,7 +20,7 @@ struct SystemError <: Exception
     extrainfo
     SystemError(p::AbstractString, e::Integer, extrainfo) = new(p, e, extrainfo)
     SystemError(p::AbstractString, e::Integer) = new(p, e, nothing)
-    SystemError(p::AbstractString) = new(p, Libc.errno())
+    SystemError(p::AbstractString) = new(p, Libc.errno(), nothing)
 end
 
 lock(::IO) = nothing

--- a/test/error.jl
+++ b/test/error.jl
@@ -81,3 +81,8 @@ end
     # non-Functions
     @test retry(Float64)(1) === 1.0
 end
+
+@testset "SystemError initialization" begin
+    e = SystemError("fail")
+    @test e.extrainfo === nothing
+end


### PR DESCRIPTION
before:
```
julia> throw(SystemError("fail"))
ERROR: 
Stacktrace:
 [1] top-level scope
   @ REPL[6]:1
SYSTEM (REPL): showing an error caused an error
ERROR: UndefRefError: access to undefined reference
```

after:
```
julia> throw(SystemError("fail"))
ERROR: SystemError: fail: Success
Stacktrace:
 [1] top-level scope
   @ REPL[1]:1

```
