### PR TITLE
[CPUID] Add ISA entries for A64FX and M1

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -276,9 +276,6 @@ include("weakkeydict.jl")
 
 include("env.jl")
 
-# BinaryPlatforms, used by Artifacts
-include("binaryplatforms.jl")
-
 # functions defined in Random
 function rand end
 function randn end
@@ -335,6 +332,9 @@ using .Order
 # Combinatorics
 include("sort.jl")
 using .Sort
+
+# BinaryPlatforms, used by Artifacts.  Needs `Sort`.
+include("binaryplatforms.jl")
 
 # Fast math
 include("fastmath.jl")

--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -609,6 +609,7 @@ const arch_march_isa_mapping = let
             "armv8_1" => get_set("aarch64", "armv8.1-a"),
             "armv8_2_crypto" => get_set("aarch64", "armv8.2-a+crypto"),
             "a64fx" => get_set("aarch64", "a64fx"),
+            "apple_m1" => get_set("aarch64", "apple_m1"),
         ],
         "powerpc64le" => [
             "power8" => get_set("powerpc64le", "power8"),

--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -608,7 +608,7 @@ const arch_march_isa_mapping = let
             "armv8_0" => get_set("aarch64", "armv8.0-a"),
             "armv8_1" => get_set("aarch64", "armv8.1-a"),
             "armv8_2_crypto" => get_set("aarch64", "armv8.2-a+crypto"),
-            "armv8_4_crypto_sve" => get_set("aarch64", "armv8.4-a+crypto+sve"),
+            "a64fx" => get_set("aarch64", "a64fx"),
         ],
         "powerpc64le" => [
             "power8" => get_set("powerpc64le", "power8"),

--- a/base/cpuid.jl
+++ b/base/cpuid.jl
@@ -59,7 +59,7 @@ const ISAs_by_family = Dict(
         "armv8.1-a" => ISA(Set((JL_AArch64_v8_1a, JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm))),
         "armv8.2-a+crypto" => ISA(Set((JL_AArch64_v8_2a, JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm, JL_AArch64_aes, JL_AArch64_sha2))),
         "a64fx" => ISA(Set((JL_AArch64_v8_2a, JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm, JL_AArch64_aes, JL_AArch64_sha2, JL_AArch64_ccpp, JL_AArch64_complxnum, JL_AArch64_fullfp16, JL_AArch64_sve))),
-        "armv8.4-a+crypto+sve" => ISA(Set((JL_AArch64_v8_4a, JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm, JL_AArch64_fp16fml, JL_AArch64_aes, JL_AArch64_sha2, JL_AArch64_dotprod, JL_AArch64_sve))),
+        "apple_m1" => ISA(Set((JL_AArch64_v8_5a, JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm, JL_AArch64_aes, JL_AArch64_sha2, JL_AArch64_sha3, JL_AArch64_ccpp, JL_AArch64_complxnum, JL_AArch64_fp16fml, JL_AArch64_fullfp16, JL_AArch64_dotprod, JL_AArch64_rcpc, JL_AArch64_altnzcv))),
     ],
     "powerpc64le" => [
         # We have no way to test powerpc64le features yet, so we're only going to declare the lowest ISA:

--- a/base/cpuid.jl
+++ b/base/cpuid.jl
@@ -58,6 +58,7 @@ const ISAs_by_family = Dict(
         "armv8.0-a" => ISA(Set{UInt32}()),
         "armv8.1-a" => ISA(Set((JL_AArch64_v8_1a, JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm))),
         "armv8.2-a+crypto" => ISA(Set((JL_AArch64_v8_2a, JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm, JL_AArch64_aes, JL_AArch64_sha2))),
+        "a64fx" => ISA(Set((JL_AArch64_v8_2a, JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm, JL_AArch64_aes, JL_AArch64_sha2, JL_AArch64_ccpp, JL_AArch64_complxnum, JL_AArch64_fullfp16, JL_AArch64_sve))),
         "armv8.4-a+crypto+sve" => ISA(Set((JL_AArch64_v8_4a, JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm, JL_AArch64_fp16fml, JL_AArch64_aes, JL_AArch64_sha2, JL_AArch64_dotprod, JL_AArch64_sve))),
     ],
     "powerpc64le" => [

--- a/base/cpuid.jl
+++ b/base/cpuid.jl
@@ -58,7 +58,7 @@ const ISAs_by_family = Dict(
         "armv8.0-a" => ISA(Set{UInt32}()),
         "armv8.1-a" => ISA(Set((JL_AArch64_v8_1a, JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm))),
         "armv8.2-a+crypto" => ISA(Set((JL_AArch64_v8_2a, JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm, JL_AArch64_aes, JL_AArch64_sha2))),
-        "a64fx" => ISA(Set((JL_AArch64_v8_2a, JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm, JL_AArch64_aes, JL_AArch64_sha2, JL_AArch64_ccpp, JL_AArch64_complxnum, JL_AArch64_fullfp16, JL_AArch64_sve))),
+        "a64fx" => ISA(Set((JL_AArch64_v8_2a, JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm, JL_AArch64_sha2, JL_AArch64_ccpp, JL_AArch64_complxnum, JL_AArch64_fullfp16, JL_AArch64_sve))),
         "apple_m1" => ISA(Set((JL_AArch64_v8_5a, JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm, JL_AArch64_aes, JL_AArch64_sha2, JL_AArch64_sha3, JL_AArch64_ccpp, JL_AArch64_complxnum, JL_AArch64_fp16fml, JL_AArch64_fullfp16, JL_AArch64_dotprod, JL_AArch64_rcpc, JL_AArch64_altnzcv))),
     ],
     "powerpc64le" => [


### PR DESCRIPTION
On A64FX we get
```julia
julia> Base.BinaryPlatforms.CPUID.cpu_isa()
Base.BinaryPlatforms.CPUID.ISA(Set(UInt32[0x00000016, 0x00000004, 0x00000006, 0x00000007, 0x0000000c, 0x00000008]))
```
which corresponds to the following set
```julia
julia> @eval Base.BinaryPlatforms.CPUID JL_AArch64_lse, JL_AArch64_crc, JL_AArch64_rdm, JL_AArch64_aes, JL_AArch64_sha2, JL_AArch64_sve
(0x00000008, 0x00000007, 0x0000000c, 0x00000004, 0x00000006, 0x00000016)
```
which is literally the `armv8.2-a+crypto` set + `JL_AArch64_sve`.

I'd even go as far as removing `armv8.4-a+crypto+sve`, I don't think there is any existing CPU at the moment with all those capabilities, it isn't very useful there.

Also, what about backporting to v1.6 and v1.7?