### PR TITLE
Fix next prompt detector in `generate_precompile_statements`

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -231,6 +231,11 @@ if Profile !== nothing
     """
 end
 
+const JULIA_PROMPT = "julia> "
+const PKG_PROMPT = "pkg> "
+const SHELL_PROMPT = "shell> "
+const HELP_PROMPT = "help?> "
+
 function generate_precompile_statements()
     start_time = time_ns()
     debug_output = devnull # or stdout
@@ -311,7 +316,7 @@ function generate_precompile_statements()
             close(ptm)
         end
         # wait for the definitive prompt before start writing to the TTY
-        readuntil(output_copy, "julia>")
+        readuntil(output_copy, JULIA_PROMPT)
         sleep(0.1)
         readavailable(output_copy)
         # Input our script
@@ -329,9 +334,16 @@ function generate_precompile_statements()
                 write(ptm, l, "\n")
                 readuntil(output_copy, "\n")
                 # wait for the next prompt-like to appear
-                # NOTE: this is rather inaccurate because the Pkg REPL mode is a special flower
                 readuntil(output_copy, "\n")
-                readuntil(output_copy, "> ")
+                strbuf = ""
+                while true
+                    strbuf *= String(readavailable(output_copy))
+                    occursin(JULIA_PROMPT, strbuf) && break
+                    occursin(PKG_PROMPT, strbuf) && break
+                    occursin(SHELL_PROMPT, strbuf) && break
+                    occursin(HELP_PROMPT, strbuf) && break
+                    sleep(0.1)
+                end
             end
             println()
         end


### PR DESCRIPTION
In `generate_precompile_statements` it turns out the repeatedly overprinted `> ` chars from the `Pkg.precompile` progress bar were being interpreted as the next prompts.. making the precompile statement generator process race to the end and crashing the end of the process. I'm not sure whether that means the scripts afterwards failed to get precompile statements generated.

This was confirmed by setting `debug_output = stdout`