### PR TITLE
make `cat(As..., dims=Val((1,2,...))` work

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1694,13 +1694,15 @@ end
 _cs(d, a, b) = (a == b ? a : throw(DimensionMismatch(
     "mismatch in dimension $d (expected $a got $b)")))
 
-function dims2cat(::Val{n}) where {n}
-    n <= 0 && throw(ArgumentError("cat dimension must be a positive integer, but got $n"))
-    ntuple(i -> (i == n), Val(n))
+function dims2cat(::Val{dims}) where dims
+    if any(≤(0), dims)
+        throw(ArgumentError("All cat dimensions must be positive integers, but got $dims"))
+    end
+    ntuple(in(dims), maximum(dims))
 end
 
 function dims2cat(dims)
-    if any(dims .<= 0)
+    if any(≤(0), dims)
         throw(ArgumentError("All cat dimensions must be positive integers, but got $dims"))
     end
     ntuple(in(dims), maximum(dims))

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -732,6 +732,7 @@ function test_cat(::Type{TestAbstractArray})
     @test @inferred(cat(As...; dims=Val(3))) == zeros(2, 2, 2)
     cat3v(As) = cat(As...; dims=Val(3))
     @test @inferred(cat3v(As)) == zeros(2, 2, 2)
+    @test @inferred(cat(As...; dims=Val((1,2)))) == zeros(4, 4)
 end
 
 function test_ind2sub(::Type{TestAbstractArray})


### PR DESCRIPTION
While `cat(A, B; dims=2)` does not infer (cf. https://github.com/JuliaLang/julia/issues/5339), `cat(A, B, dims=Val(2))` does. The latter version is preferable when the concatenation dimension is known statically.

The generalization of this for concatenation along multiple dimensions, e.g. `cat(A, B, dims=(1,2))` to `cat(A, B, dims=Val((1,2))`, doesn't work currently due to a missing method of `Base.dims2cat` for `Val{(i,j,...)}`. This PR adds that and makes `cat(A, B, dims=Val((1,2,...)))` work.

On this PR:
```jl
julia> @code_warntype cat(rand(2,2), rand(2,2), dims=Val((1,2)))
MethodInstance for (::Base.var"#cat##kw")(::NamedTuple{(:dims,), Tuple{Val{(1, 2)}}}, ::typeof(cat), ::Matrix{Float64}, ::Matrix{Float64})
  from (::Base.var"#cat##kw")(::Any, ::typeof(cat), A...) in Base at abstractarray.jl:1861
Arguments
  _::Core.Const(Base.var"#cat##kw"())
  @_2::Core.Const((dims = Val{(1, 2)}(),))
  @_3::Core.Const(cat)
  A::Tuple{Matrix{Float64}, Matrix{Float64}}
Locals
  dims::Val{(1, 2)}
  @_6::Val{(1, 2)}
Body::Matrix{Float64}
[... omitted]
```
Cc. @mcabbott who suggested the `dims=Val((1,2))` form on Slack.