### PR TITLE
fix bug in `addenv` for environment entries with embedded `=`

### DIFF
--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -262,6 +262,15 @@ setenv(cmd::Cmd, env::Pair{<:AbstractString}...; dir=cmd.dir) =
     setenv(cmd, env; dir=dir)
 setenv(cmd::Cmd; dir=cmd.dir) = Cmd(cmd; dir=dir)
 
+# split environment entry string into before and after first `=` (key and value)
+function splitenv(e::String)
+    i = findfirst('=', e)
+    if i === nothing
+        throw(ArgumentError("malformed environment entry"))
+    end
+    e[1:prevind(e, i)], e[nextind(e, i):end]
+end
+
 """
     addenv(command::Cmd, env...; inherit::Bool = true)
 
@@ -282,7 +291,7 @@ function addenv(cmd::Cmd, env::Dict; inherit::Bool = true)
             merge!(new_env, ENV)
         end
     else
-        for (k, v) in eachsplit.(cmd.env, "=")
+        for (k, v) in splitenv.(cmd.env)
             new_env[string(k)::String] = string(v)::String
         end
     end
@@ -301,7 +310,7 @@ function addenv(cmd::Cmd, pairs::Pair{<:AbstractString}...; inherit::Bool = true
 end
 
 function addenv(cmd::Cmd, env::Vector{<:AbstractString}; inherit::Bool = true)
-    return addenv(cmd, Dict(k => v for (k, v) in eachsplit.(env, "=")); inherit)
+    return addenv(cmd, Dict(k => v for (k, v) in splitenv.(env)); inherit)
 end
 
 """

--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -264,7 +264,7 @@ setenv(cmd::Cmd; dir=cmd.dir) = Cmd(cmd; dir=dir)
 
 # split environment entry string into before and after first `=` (key and value)
 function splitenv(e::String)
-    i = findfirst('=', e, 2)
+    i = findnext('=', e, 2)
     if i === nothing
         throw(ArgumentError("malformed environment entry"))
     end

--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -264,7 +264,7 @@ setenv(cmd::Cmd; dir=cmd.dir) = Cmd(cmd; dir=dir)
 
 # split environment entry string into before and after first `=` (key and value)
 function splitenv(e::String)
-    i = findfirst('=', e)
+    i = findfirst('=', e, 2)
     if i === nothing
         throw(ArgumentError("malformed environment entry"))
     end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -825,6 +825,12 @@ end
     dir = joinpath(pwd(), "dir")
     cmd = addenv(setenv(`julia`; dir=dir), Dict())
     @test cmd.dir == dir
+
+    @test addenv(``, ["a=b=c"], inherit=false).env == ["a=b=c"]
+    cmd = addenv(``, "a"=>"b=c", inherit=false)
+    @test cmd.env == ["a=b=c"]
+    cmd = addenv(cmd, "b"=>"b")
+    @test issetequal(cmd.env, ["b=b", "a=b=c"])
 end
 
 @testset "setenv with dir (with tests for #42131)" begin


### PR DESCRIPTION
Environment variable values can contain `=`, for example `LS_COLORS` in my case. `addenv` is truncating them at the first embedded `=`.