### PR TITLE
Add some additional information to `LinearAlgebra.versioninfo()`

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -531,10 +531,34 @@ end
 
 
 function versioninfo(io::IO=stdout)
+    indent = "  "
     config = BLAS.get_config()
-    println(io, "BLAS: $(BLAS.libblastrampoline) ($(join(string.(config.build_flags), ", ")))")
+    build_flags = join(string.(config.build_flags), ", ")
+    println(io, "BLAS: ", BLAS.libblastrampoline, " (", build_flags, ")")
     for lib in config.loaded_libs
-        println(io, " --> $(lib.libname) ($(uppercase(string(lib.interface))))")
+        interface = uppercase(string(lib.interface))
+        println(io, indent, "--> ", lib.libname, " (", interface, ")")
+    end
+    println(io, "Threading:")
+    println(io, indent, "Threads.nthreads() = ", Base.Threads.nthreads())
+    println(io, indent, "LinearAlgebra.BLAS.get_num_threads() = ", BLAS.get_num_threads())
+    println(io, "Relevant environment variables:")
+    env_var_names = [
+        "JULIA_NUM_THREADS",
+        "MKL_DYNAMIC",
+        "MKL_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+    ]
+    printed_at_least_one_env_var = false
+    for name in env_var_names
+        if haskey(ENV, name)
+            value = ENV[name]
+            println(io, indent, name, " = ", value)
+            printed_at_least_one_env_var = true
+        end
+    end
+    if !printed_at_least_one_env_var
+        println(io, indent, "[none]")
     end
     return nothing
 end


### PR DESCRIPTION
Example output:

```julia
julia> LinearAlgebra.versioninfo()
BLAS: libblastrampoline (f2c_capable)
  --> /Users/dilum/.asdf/installs/julia/1.7.2/lib/julia/libopenblas64_.0.3.13.dylib (ILP64)
Threading:
  Threads.nthreads() = 1
  BLAS.get_num_threads() = 1
Relevant environment variables:
  JULIA_NUM_THREADS = 1
  MKL_NUM_THREADS = 1
  OPENBLAS_NUM_THREADS = 1
```