### PR TITLE
Use opaque closure for tasks

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -131,7 +131,9 @@ true
 ```
 """
 macro task(ex)
-    :(Task(()->$(esc(ex))))
+    # Avoid using `@opaque` to make bootstrap easier
+    thunk = esc(Expr(:opaque_closure, :(()->($ex))))
+    :(Task($thunk))
 end
 
 """
@@ -473,7 +475,8 @@ isolating the asynchronous code from changes to the variable's value in the curr
 macro async(expr)
     letargs = Base._lift_one_interp!(expr)
 
-    thunk = esc(:(()->($expr)))
+    # Avoid using `@opaque` to make bootstrap easier
+    thunk = esc(Expr(:opaque_closure, :(()->($expr))))
     var = esc(sync_varname)
     quote
         let $(letargs...)

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -223,7 +223,8 @@ isolating the asynchronous code from changes to the variable's value in the curr
 macro spawn(expr)
     letargs = Base._lift_one_interp!(expr)
 
-    thunk = esc(:(()->($expr)))
+    # Avoid using `@opaque` to make bootstrap easier
+    thunk = esc(Expr(:opaque_closure, :(()->($expr))))
     var = esc(Base.sync_varname)
     quote
         let $(letargs...)

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -221,6 +221,7 @@ static Value *julia_pgv(jl_codectx_t &ctx, const char *cname, void *addr)
         if (gv->getParent() != M)
             gv = cast_or_null<GlobalVariable>(M->getNamedValue(localname));
     }
+    assert(localname != "");
     if (gv == nullptr)
         gv = new GlobalVariable(*M, ctx.types().T_pjlvalue,
                                 false, GlobalVariable::PrivateLinkage,


### PR DESCRIPTION
To make `fetch(::Task)` inferrable and also to optimize tasks better in general, it might be a good idea to use opaque closures with `@spawn` etc. Now we are at a very early phase of 1.9-DEV, it might be a good idea to start using opaque closures now and let possible bugs surface before the next feature freeze. (But this PR does not make `fetch(::Task)` inferrable on its own.)

Actually, it looks like we need to fix at least one bug before even start using opaque closures in `@spawn` since codegen for opaque closures does not work with sysimage yet. I get an error like

> ```
> Sysimage built. Summary:
> Total ───────  81.970892 seconds
> Base: ───────  32.638817 seconds 39.8176%
> Stdlibs: ────  49.330319 seconds 60.1803%
> julia: /cache/build/default-amdci5-0/julialang/julia-master/usr/include/llvm/Support/Casting.h:104: static bool llvm::isa_impl_cl<To, const From*>::doit(const From*) [with To = llvm::GlobalVariable; From = llvm::GlobalValue]: Assertion `Val && "isa<> used on a null pointer"' failed.
>
> signal (6): Aborted
> in expression starting at none:0
> gsignal at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
> abort at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
> unknown function (ip: 0x7f67e9dd540e)
> __assert_fail at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
> doit at /cache/build/default-amdci5-0/julialang/julia-master/usr/include/llvm/Support/Casting.h:104 [inlined]
> doit at /cache/build/default-amdci5-0/julialang/julia-master/usr/include/llvm/Support/Casting.h:131 [inlined]
> doit at /cache/build/default-amdci5-0/julialang/julia-master/usr/include/llvm/Support/Casting.h:122 [inlined]
> isa<llvm::GlobalVariable, llvm::GlobalValue*> at /cache/build/default-amdci5-0/julialang/julia-master/usr/include/llvm/Support/Casting.h:143 [inlined]
> cast<llvm::GlobalVariable, llvm::GlobalValue> at /cache/build/default-amdci5-0/julialang/julia-master/usr/include/llvm/Support/Casting.h:269 [inlined]
> jl_create_native_impl at /cache/build/default-amdci5-0/julialang/julia-master/src/aotcompile.cpp:369
> jl_precompile at /cache/build/default-amdci5-0/julialang/julia-master/src/precompile.c:402 [inlined]
> ```
>
> --- https://buildkite.com/julialang/julia-master/builds/8961#8ba39922-d862-4ac8-95d1-ecd0178c9819/193-847

This is due to the lookup of the global `clone->getNamedValue(global)` in

https://github.com/JuliaLang/julia/blob/7b395153e80672f8cdb18f51dd653a85e28b2070/src/aotcompile.cpp#L366-L373

failed and returned a NULL.

I tried to fix this in d30e90afc7f9ef0a65d29b162d185c013d5f3071 but I'm not sure if this is the right way to do it. I just simply tried to treat the symptom I found with rr.

@Keno Are opaque closures ready for this? Also, is my patch d30e90afc7f9ef0a65d29b162d185c013d5f3071 OK?
