### PR TITLE
fix nothrow check for `get_binding_type`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1705,7 +1705,8 @@ function _builtin_nothrow(@nospecialize(f), argtypes::Array{Any,1}, @nospecializ
         end
         return false
     elseif f === Core.get_binding_type
-        return length(argtypes) == 2
+        length(argtypes) == 2 || return false
+        return argtypes[1] ⊑ Module && argtypes[2] ⊑ Symbol
     elseif f === donotdelete
         return true
     end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4028,3 +4028,5 @@ function f_boundscheck_elim(n)
     ntuple(x->(@inbounds getfield(sin, x)), n)
 end
 @test Tuple{} <: code_typed(f_boundscheck_elim, Tuple{Int})[1][2]
+
+@test !Core.Compiler.builtin_nothrow(Core.get_binding_type, Any[Rational{Int}, Core.Const(:foo)], Any)


### PR DESCRIPTION
This got missed in #43671.
