### PR TITLE
release-1.8: Backports for julia 1.8-beta1/2

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -276,9 +276,6 @@ include("weakkeydict.jl")
 
 include("env.jl")
 
-# BinaryPlatforms, used by Artifacts
-include("binaryplatforms.jl")
-
 # functions defined in Random
 function rand end
 function randn end
@@ -335,6 +332,9 @@ using .Order
 # Combinatorics
 include("sort.jl")
 using .Sort
+
+# BinaryPlatforms, used by Artifacts.  Needs `Sort`.
+include("binaryplatforms.jl")
 
 # Fast math
 include("fastmath.jl")

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1712,13 +1712,15 @@ end
 _cs(d, a, b) = (a == b ? a : throw(DimensionMismatch(
     "mismatch in dimension $d (expected $a got $b)")))
 
-function dims2cat(::Val{n}) where {n}
-    n <= 0 && throw(ArgumentError("cat dimension must be a positive integer, but got $n"))
-    ntuple(i -> (i == n), Val(n))
+function dims2cat(::Val{dims}) where dims
+    if any(≤(0), dims)
+        throw(ArgumentError("All cat dimensions must be positive integers, but got $dims"))
+    end
+    ntuple(in(dims), maximum(dims))
 end
 
 function dims2cat(dims)
-    if any(dims .<= 0)
+    if any(≤(0), dims)
         throw(ArgumentError("All cat dimensions must be positive integers, but got $dims"))
     end
     ntuple(in(dims), maximum(dims))

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -189,7 +189,10 @@ empty(a::AbstractDict) = empty(a, keytype(a), valtype(a))
 empty(a::AbstractDict, ::Type{V}) where {V} = empty(a, keytype(a), V) # Note: this is the form which makes sense for `Vector`.
 
 copy(a::AbstractDict) = merge!(empty(a), a)
-copy!(dst::AbstractDict, src::AbstractDict) = merge!(empty!(dst), src)
+function copy!(dst::AbstractDict, src::AbstractDict)
+    dst === src && return dst
+    merge!(empty!(dst), src)
+end
 
 """
     merge!(d::AbstractDict, others::AbstractDict...)

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -3,7 +3,10 @@
 eltype(::Type{<:AbstractSet{T}}) where {T} = @isdefined(T) ? T : Any
 sizehint!(s::AbstractSet, n) = nothing
 
-copy!(dst::AbstractSet, src::AbstractSet) = union!(empty!(dst), src)
+function copy!(dst::AbstractSet, src::AbstractSet)
+    dst === src && return dst
+    union!(empty!(dst), src)
+end
 
 ## set operations (union, intersection, symmetric difference)
 

--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -608,7 +608,8 @@ const arch_march_isa_mapping = let
             "armv8_0" => get_set("aarch64", "armv8.0-a"),
             "armv8_1" => get_set("aarch64", "armv8.1-a"),
             "armv8_2_crypto" => get_set("aarch64", "armv8.2-a+crypto"),
-            "armv8_4_crypto_sve" => get_set("aarch64", "armv8.4-a+crypto+sve"),
+            "a64fx" => get_set("aarch64", "a64fx"),
+            "apple_m1" => get_set("aarch64", "apple_m1"),
         ],
         "powerpc64le" => [
             "power8" => get_set("powerpc64le", "power8"),

--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -262,6 +262,15 @@ setenv(cmd::Cmd, env::Pair{<:AbstractString}...; dir=cmd.dir) =
     setenv(cmd, env; dir=dir)
 setenv(cmd::Cmd; dir=cmd.dir) = Cmd(cmd; dir=dir)
 
+# split environment entry string into before and after first `=` (key and value)
+function splitenv(e::String)
+    i = findnext('=', e, 2)
+    if i === nothing
+        throw(ArgumentError("malformed environment entry"))
+    end
+    e[1:prevind(e, i)], e[nextind(e, i):end]
+end
+
 """
     addenv(command::Cmd, env...; inherit::Bool = true)
 
@@ -282,7 +291,7 @@ function addenv(cmd::Cmd, env::Dict; inherit::Bool = true)
             merge!(new_env, ENV)
         end
     else
-        for (k, v) in eachsplit.(cmd.env, "=")
+        for (k, v) in splitenv.(cmd.env)
             new_env[string(k)::String] = string(v)::String
         end
     end
@@ -301,7 +310,7 @@ function addenv(cmd::Cmd, pairs::Pair{<:AbstractString}...; inherit::Bool = true
 end
 
 function addenv(cmd::Cmd, env::Vector{<:AbstractString}; inherit::Bool = true)
-    return addenv(cmd, Dict(k => v for (k, v) in eachsplit.(env, "=")); inherit)
+    return addenv(cmd, Dict(k => v for (k, v) in splitenv.(env)); inherit)
 end
 
 """

--- a/base/compiler/methodtable.jl
+++ b/base/compiler/methodtable.jl
@@ -84,9 +84,9 @@ function findall(@nospecialize(sig::Type), table::OverlayMethodTable; limit::Int
         _min_val[] = typemin(UInt)
         _max_val[] = typemax(UInt)
         ms = _methods_by_ftype(sig, nothing, limit, table.world, false, _min_val, _max_val, _ambig)
-    end
-    if ms === false
-        return missing
+        if ms === false
+            return missing
+        end
     end
     return MethodLookupResult(ms::Vector{Any}, WorldRange(_min_val[], _max_val[]), _ambig[] != 0)
 end
@@ -123,3 +123,8 @@ end
 
 # This query is not cached
 findsup(@nospecialize(sig::Type), table::CachedMethodTable) = findsup(sig, table.table)
+
+isoverlayed(::MethodTableView)     = error("unsatisfied MethodTableView interface")
+isoverlayed(::InternalMethodTable) = false
+isoverlayed(::OverlayMethodTable)  = true
+isoverlayed(mt::CachedMethodTable) = isoverlayed(mt.table)

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1000,7 +1000,11 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
     elseif isa(stmt, GotoNode) && compact.cfg_transforms_enabled
         result[result_idx][:inst] = GotoNode(compact.bb_rename_succ[stmt.label])
         result_idx += 1
-    elseif isa(stmt, GlobalRef) || isa(stmt, GotoNode)
+    elseif isa(stmt, GlobalRef)
+        result[result_idx][:inst] = stmt
+        result[result_idx][:type] = argextype(stmt, compact)
+        result_idx += 1
+    elseif isa(stmt, GotoNode)
         result[result_idx][:inst] = stmt
         result_idx += 1
     elseif isa(stmt, GotoIfNot) && compact.cfg_transforms_enabled

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1705,7 +1705,8 @@ function _builtin_nothrow(@nospecialize(f), argtypes::Array{Any,1}, @nospecializ
         end
         return false
     elseif f === Core.get_binding_type
-        return length(argtypes) == 2
+        length(argtypes) == 2 || return false
+        return argtypes[1] ⊑ Module && argtypes[2] ⊑ Symbol
     elseif f === donotdelete
         return true
     end

--- a/base/process.jl
+++ b/base/process.jl
@@ -402,16 +402,25 @@ process failed, or if the process attempts to print anything to stdout.
 """
 function open(f::Function, cmds::AbstractCmd, args...; kwargs...)
     P = open(cmds, args...; kwargs...)
+    function waitkill(P::Process)
+        close(P)
+        # 0.1 seconds after we hope it dies (from closing stdio),
+        # we kill the process with SIGTERM (15)
+        local t = Timer(0.1) do t
+            process_running(P) && kill(P)
+        end
+        wait(P)
+        close(t)
+    end
     ret = try
         f(P)
     catch
-        kill(P)
-        close(P)
+        waitkill(P)
         rethrow()
     end
     close(P.in)
     if !eof(P.out)
-        close(P.out)
+        waitkill(P)
         throw(_UVError("open(do)", UV_EPIPE))
     end
     success(P) || pipeline_error(P)

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -1,5 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+if Threads.nthreads() != 1
+    @warn "Running this file with multiple Julia threads may lead to a build error" Threads.nthreads()
+end
+
 if Base.isempty(Base.ARGS) || Base.ARGS[1] !== "0"
 Sys.__init_build()
 # Prevent this from being put into the Main namespace

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -292,6 +292,7 @@ else
         analytics = "UA-28835595-6",
         collapselevel = 1,
         sidebar_sitename = false,
+        ansicolor = true,
     )
 end
 

--- a/doc/src/devdocs/EscapeAnalysis.md
+++ b/doc/src/devdocs/EscapeAnalysis.md
@@ -1,3 +1,5 @@
+# `EscapeAnalysis`
+
 `Core.Compiler.EscapeAnalysis` is a compiler utility module that aims to analyze
 escape information of [Julia's SSA-form IR](@ref Julia-SSA-form-IR) a.k.a. `IRCode`.
 
@@ -18,8 +20,7 @@ This escape analysis aims to:
 You can give a try to the escape analysis by loading the `EAUtils.jl` utility script that
 define the convenience entries `code_escapes` and `@code_escapes` for testing and debugging purposes:
 ```@repl EAUtils
-include(normpath(Sys.BINDIR::String, "..", "share", "julia", "test", "testhelpers", "EAUtils.jl"))
-using EAUtils
+include(normpath(Sys.BINDIR, "..", "share", "julia", "test", "compiler", "EscapeAnalysis", "EAUtils.jl")); using .EAUtils
 
 mutable struct SafeRef{T}
     x::T

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -233,10 +233,11 @@ static GlobalVariable *emit_plt_thunk(
     else {
         // musttail support is very bad on ARM, PPC, PPC64 (as of LLVM 3.9)
         // Known failures includes vararg (not needed here) and sret.
-#if (defined(_CPU_X86_) || defined(_CPU_X86_64_) || \
-                        defined(_CPU_AARCH64_))
+
+#if (defined(_CPU_X86_) || defined(_CPU_X86_64_) || (defined(_CPU_AARCH64_) && !defined(_OS_DARWIN_)))
         // Ref https://bugs.llvm.org/show_bug.cgi?id=47058
         // LLVM, as of 10.0.1 emits wrong/worse code when musttail is set
+        // Apple silicon macs give an LLVM ERROR if musttail is set here #44107.
         if (!attrs.hasAttrSomewhere(Attribute::ByVal))
             ret->setTailCallKind(CallInst::TCK_MustTail);
 #endif

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -227,7 +227,7 @@ public:
                     continue;
                 }
             }
-            uint64_t loadaddr = L.getSectionLoadAddress(section);
+            uint64_t loadaddr = getLoadAddress(section.getName().get());
             size_t seclen = section.getSize();
             if (istext) {
                 arm_text_addr = loadaddr;

--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -20,7 +20,7 @@ struct jl_raw_alloc_t {
     jl_datatype_t *type_address;
     jl_raw_backtrace_t backtrace;
     size_t size;
-    jl_task_t *task;
+    void *task;
     uint64_t timestamp;
 };
 
@@ -135,7 +135,7 @@ void _maybe_record_alloc_to_profile(jl_value_t *val, size_t size, jl_datatype_t 
         type,
         get_raw_backtrace(),
         size,
-        jl_current_task,
+        (void *)jl_current_task,
         cycleclock()
     });
 }

--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -71,7 +71,7 @@ extern "C" {  // Needed since these functions doesn't take any arguments.
 
 JL_DLLEXPORT void jl_start_alloc_profile(double sample_rate) {
     // We only need to do this once, the first time this is called.
-    while (g_alloc_profile.per_thread_profiles.size() < jl_n_threads) {
+    while (g_alloc_profile.per_thread_profiles.size() < (size_t)jl_n_threads) {
         g_alloc_profile.per_thread_profiles.push_back(jl_per_thread_alloc_profile_t{});
     }
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -1961,6 +1961,8 @@ jl_code_instance_t *jl_method_compiled(jl_method_instance_t *mi, size_t world)
     return NULL;
 }
 
+jl_mutex_t precomp_statement_out_lock;
+
 static void record_precompile_statement(jl_method_instance_t *mi)
 {
     static ios_t f_precompile;
@@ -1971,6 +1973,8 @@ static void record_precompile_statement(jl_method_instance_t *mi)
     if (!jl_is_method(def))
         return;
 
+    if (jl_n_threads > 1)
+        JL_LOCK(&precomp_statement_out_lock);
     if (s_precompile == NULL) {
         const char *t = jl_options.trace_compile;
         if (!strncmp(t, "stderr", 6)) {
@@ -1989,6 +1993,8 @@ static void record_precompile_statement(jl_method_instance_t *mi)
         if (s_precompile != JL_STDERR)
             ios_flush(&f_precompile);
     }
+    if (jl_n_threads > 1)
+        JL_UNLOCK(&precomp_statement_out_lock);
 }
 
 jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t world)

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -4,6 +4,7 @@
 #include <errno.h>
 
 #include "julia.h"
+#include "julia_internal.h"
 
 #include <unistd.h>
 #include <getopt.h>

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -246,6 +246,8 @@ typedef struct _jl_tls_states_t {
     // Temporary backtrace buffer. Scanned for gc roots when bt_size > 0.
     struct _jl_bt_element_t *bt_data; // JL_MAX_BT_SIZE + 1 elements long
     size_t bt_size;    // Size for backtrace in transit in bt_data
+    // Temporary backtrace buffer used only for allocations profiler.
+    struct _jl_bt_element_t *profiling_bt_buffer;
     // Atomically set by the sender, reset by the handler.
     volatile _Atomic(sig_atomic_t) signal_request; // TODO: no actual reason for this to be _Atomic
     // Allow the sigint to be raised asynchronously

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -132,22 +132,23 @@ static size_t jl_safe_read_mem(const volatile char *ptr, char *out, size_t len)
 static double profile_autostop_time = -1.0;
 static double profile_peek_duration = 1.0; // seconds
 
-double jl_get_profile_peek_duration(void) {
+double jl_get_profile_peek_duration(void)
+{
     return profile_peek_duration;
 }
-void jl_set_profile_peek_duration(double t) {
+void jl_set_profile_peek_duration(double t)
+{
     profile_peek_duration = t;
-    return;
 }
 
 uintptr_t profile_show_peek_cond_loc;
 JL_DLLEXPORT void jl_set_peek_cond(uintptr_t cond)
 {
     profile_show_peek_cond_loc = cond;
-    return;
 }
 
-static void jl_check_profile_autostop(void) {
+static void jl_check_profile_autostop(void)
+{
     if ((profile_autostop_time != -1.0) && (jl_hrtime() > profile_autostop_time)) {
         profile_autostop_time = -1.0;
         jl_profile_stop_timer();

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -1216,7 +1216,7 @@ end
 """
     spr!(uplo, α, x, AP)
 
-Update matrix `A` as `α*A*x*x'`, where `A` is a symmetric matrix provided
+Update matrix `A` as `A+α*x*x'`, where `A` is a symmetric matrix provided
 in packed format `AP` and `x` is a vector.
 
 With `uplo = 'U'`, the array AP must contain the upper triangular part of the

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -886,7 +886,9 @@ function dot(x::AbstractArray, y::AbstractArray)
     s
 end
 
-dot(x::Adjoint, y::Adjoint) = conj(dot(parent(x), parent(y)))
+function dot(x::Adjoint{<:Union{Real,Complex}}, y::Adjoint{<:Union{Real,Complex}})
+    return conj(dot(parent(x), parent(y)))
+end
 dot(x::Transpose, y::Transpose) = dot(parent(x), parent(y))
 
 """

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -497,20 +497,21 @@ end
 end
 
 @testset "adjtrans dot" begin
-    for t in (transpose, adjoint)
-        x, y = t(rand(ComplexF64, 10)), t(rand(ComplexF64, 10))
+    for t in (transpose, adjoint), T in (ComplexF64, Quaternion{Float64})
+        x, y = t(rand(T, 10)), t(rand(T, 10))
         X, Y = copy(x), copy(y)
         @test dot(x, y) ≈ dot(X, Y)
-        x, y = t([rand(ComplexF64, 2, 2) for _ in 1:5]), t([rand(ComplexF64, 2, 2) for _ in 1:5])
+        x, y = t([rand(T, 2, 2) for _ in 1:5]), t([rand(T, 2, 2) for _ in 1:5])
         X, Y = copy(x), copy(y)
         @test dot(x, y) ≈ dot(X, Y)
-        x, y = t(rand(ComplexF64, 10, 5)), t(rand(ComplexF64, 10, 5))
+        x, y = t(rand(T, 10, 5)), t(rand(T, 10, 5))
         X, Y = copy(x), copy(y)
         @test dot(x, y) ≈ dot(X, Y)
-        x = t([rand(ComplexF64, 2, 2) for _ in 1:5, _ in 1:5])
-        y = t([rand(ComplexF64, 2, 2) for _ in 1:5, _ in 1:5])
+        x = t([rand(T, 2, 2) for _ in 1:5, _ in 1:5])
+        y = t([rand(T, 2, 2) for _ in 1:5, _ in 1:5])
         X, Y = copy(x), copy(y)
         @test dot(x, y) ≈ dot(X, Y)
+        x, y = t([rand(T, 2, 2) for _ in 1:5]), t([rand(T, 2, 2) for _ in 1:5])
     end
 end
 

--- a/stdlib/Profile/Project.toml
+++ b/stdlib/Profile/Project.toml
@@ -5,9 +5,10 @@ uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [extras]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Logging", "Serialization", "Test"]
+test = ["Base64", "Logging", "Serialization", "Test"]

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -123,7 +123,7 @@ struct Alloc
     type::Any
     stacktrace::StackTrace
     size::Int
-    task::Ptr{Cvoid}
+    task::Ptr{Cvoid} # N.B. unrooted, may not be valid
     timestamp::UInt64
 end
 

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -54,7 +54,7 @@ function _peek_report()
     iob = IOBuffer()
     ioc = IOContext(IOContext(iob, stdout), :displaysize=>displaysize(stdout))
     print(ioc, groupby = [:thread, :task])
-    Base.print(stdout, String(resize!(iob.data, iob.size)))
+    Base.print(stdout, String(take!(iob)))
 end
 # This is a ref so that it can be overridden by other profile info consumers.
 const peek_report = Ref{Function}(_peek_report)
@@ -73,7 +73,8 @@ Set the duration in seconds of the profile "peek" that is triggered via `SIGINFO
 set_peek_duration(t::Float64) = ccall(:jl_set_profile_peek_duration, Cvoid, (Float64,), t)
 
 precompile_script = """
-Profile.@profile sleep(0.5)
+import Profile
+Profile.@profile while Profile.len_data() < 1000; rand(10,10) * rand(10,10); end
 Profile.peek_report[]()
 Profile.clear()
 """

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -226,8 +226,6 @@ if Sys.isbsd() || Sys.islinux()
             end
         end
     end
-else
-    @warn "Skipping \"SIGINFO/SIGUSR1 profile triggering\" test as it is not supported on this platform"
 end
 
 @testset "FlameGraphs" begin

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -200,9 +200,12 @@ if Sys.isbsd() || Sys.islinux()
                 """
             iob = Base.BufferStream()
             p = run(pipeline(`$cmd -e $script`, stderr = devnull, stdout = iob), wait = false)
-            t = Timer(60) do t # should be done in under 10 seconds
+            t = Timer(120) do t
+                # should be under 10 seconds, so give it 2 minutes then report failure
+                println("KILLING BY PROFILE TEST WATCHDOG\n")
+                kill(p, Base.SIGTERM)
+                sleep(10)
                 kill(p, Base.SIGKILL)
-                sleep(5)
                 close(iob)
             end
             try
@@ -210,7 +213,7 @@ if Sys.isbsd() || Sys.islinux()
                 @assert occursin("started", s)
                 @assert process_running(p)
                 for _ in 1:2
-                    sleep(2)
+                    sleep(2.5)
                     if Sys.isbsd()
                         kill(p, 29) # SIGINFO
                     elseif Sys.islinux()

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -16,7 +16,7 @@ function killjob(d)
     end
     if @isdefined(SIGINFO)
         ccall(:uv_kill, Cint, (Cint, Cint), getpid(), SIGINFO)
-        sleep(1)
+        sleep(5) # Allow time for profile to collect and print before killing
     end
     ccall(:uv_kill, Cint, (Cint, Cint), getpid(), Base.SIGTERM)
     nothing

--- a/sysimage.mk
+++ b/sysimage.mk
@@ -77,6 +77,7 @@ define sysimg_builder
 $$(build_private_libdir)/sys$1-o.a $$(build_private_libdir)/sys$1-bc.a : $$(build_private_libdir)/sys$1-%.a : $$(build_private_libdir)/sys.ji
 	@$$(call PRINT_JULIA, cd $$(JULIAHOME)/base && \
 	if ! JULIA_BINDIR=$$(call cygpath_w,$(build_bindir)) WINEPATH="$$(call cygpath_w,$$(build_bindir));$$$$WINEPATH" \
+			JULIA_NUM_THREADS=1 \
 			$$(call spawn, $3) $2 -C "$$(JULIA_CPU_TARGET)" --output-$$* $$(call cygpath_w,$$@).tmp $$(JULIA_SYSIMG_BUILD_FLAGS) \
 			--startup-file=no --warn-overwrite=yes --sysimage $$(call cygpath_w,$$<) $$(call cygpath_w,$$(JULIAHOME)/contrib/generate_precompile.jl) $(JULIA_PRECOMPILE); then \
 		echo '*** This error is usually fixed by running `make clean`. If the error persists$$(COMMA) try `make cleanall`. ***'; \

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -732,6 +732,7 @@ function test_cat(::Type{TestAbstractArray})
     @test @inferred(cat(As...; dims=Val(3))) == zeros(2, 2, 2)
     cat3v(As) = cat(As...; dims=Val(3))
     @test @inferred(cat3v(As)) == zeros(2, 2, 2)
+    @test @inferred(cat(As...; dims=Val((1,2)))) == zeros(4, 4)
 end
 
 function test_ind2sub(::Type{TestAbstractArray})

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2318,10 +2318,12 @@ let A = zeros(Int, 2, 2), B = zeros(Float64, 2, 2)
     f40() = Float64[A A]
     f41() = [A B]
     f42() = Int[A B]
+    f43() = Int[A...]
+    f44() = Float64[A..., B...]
 
     for f in [f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15, f16,
               f17, f18, f19, f20, f21, f22, f23, f24, f25, f26, f27, f28, f29, f30,
-              f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42]
+              f31, f32, f33, f34, f35, f36, f37, f38, f39, f40, f41, f42, f43, f44]
         @test isconcretetype(Base.return_types(f, ())[1])
     end
 end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4028,3 +4028,5 @@ function f_boundscheck_elim(n)
     ntuple(x->(@inbounds getfield(sin, x)), n)
 end
 @test Tuple{} <: code_typed(f_boundscheck_elim, Tuple{Int})[1][2]
+
+@test !Core.Compiler.builtin_nothrow(Core.get_binding_type, Any[Rational{Int}, Core.Const(:foo)], Any)

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1069,3 +1069,15 @@ end
 @test fully_eliminated() do
     issue41694(2)
 end
+
+global x44200::Int = 0
+function f44200()
+    global x = 0
+    while x < 10
+        x += 1
+    end
+    x
+end
+let src = code_typed1(f44200)
+    @test count(x -> isa(x, Core.PiNode), src.code) == 0
+end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1070,6 +1070,24 @@ end
     issue41694(2)
 end
 
+Base.@assume_effects :terminates_globally function recur_termination1(x)
+    x == 1 && return 1
+    1 < x < 20 || throw("bad")
+    return x * recur_termination1(x-1)
+end
+@test fully_eliminated() do
+    recur_termination1(12)
+end
+Base.@assume_effects :terminates_globally function recur_termination21(x)
+    x == 1 && return 1
+    1 < x < 20 || throw("bad")
+    return recur_termination22(x)
+end
+recur_termination22(x) = x * recur_termination21(x-1)
+@test fully_eliminated() do
+    recur_termination21(12) + recur_termination22(12)
+end
+
 global x44200::Int = 0
 function f44200()
     global x = 0

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1179,6 +1179,8 @@ end
             @test s === copy!(s, Base.ImmutableDict(a[])) == Dict(a[])
         end
     end
+    s2 = copy(s)
+    @test copy!(s, s) == s2
 end
 
 @testset "map!(f, values(dict))" begin

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -151,6 +151,9 @@ end
             @test s === copy!(s, BitSet(a)) == S(a)
         end
     end
+    s = Set([1, 2])
+    s2 = copy(s)
+    @test copy!(s, s) == s2
 end
 
 @testset "sizehint, empty" begin

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -826,6 +826,12 @@ end
     dir = joinpath(pwd(), "dir")
     cmd = addenv(setenv(`julia`; dir=dir), Dict())
     @test cmd.dir == dir
+
+    @test addenv(``, ["a=b=c"], inherit=false).env == ["a=b=c"]
+    cmd = addenv(``, "a"=>"b=c", inherit=false)
+    @test cmd.env == ["a=b=c"]
+    cmd = addenv(cmd, "b"=>"b")
+    @test issetequal(cmd.env, ["b=b", "a=b=c"])
 end
 
 @testset "setenv with dir (with tests for #42131)" begin

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1212,6 +1212,17 @@ let a = [], b = [4,3,2,1]
     @test a == [1,2]
 end
 
+# issue #44239
+struct KWGetindex end
+Base.getindex(::KWGetindex, args...; kws...) = (args, NamedTuple(kws))
+let A = KWGetindex(), a = [], b = [4,3,2,1]
+    f() = (push!(a, 1); 2)
+    g() = (push!(a, 2); ())
+    @test A[f(), g()..., k = f()] === ((2,), (k = 2,))
+    @test a == [1, 2, 1]
+    @test A[var"end"=1] === ((), (var"end" = 1,))
+end
+
 @testset "raw_str macro" begin
     @test raw"$" == "\$"
     @test raw"\n" == "\\n"

--- a/test/testhelpers/Quaternions.jl
+++ b/test/testhelpers/Quaternions.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module Quaternions
+using Random
 
 export Quaternion
 
@@ -35,5 +36,18 @@ Base.:(*)(q::Quaternion, r::Real) = Quaternion(q.s*r, q.v1*r, q.v2*r, q.v3*r)
 Base.:(*)(q::Quaternion, b::Bool) = b * q # remove method ambiguity
 Base.:(/)(q::Quaternion, w::Quaternion) = q * conj(w) * (1.0 / abs2(w))
 Base.:(\)(q::Quaternion, w::Quaternion) = conj(q) * w * (1.0 / abs2(q))
+
+# adapted from https://github.com/JuliaGeometry/Quaternions.jl/pull/42
+function Base.rand(rng::AbstractRNG, ::Random.SamplerType{Quaternion{T}}) where {T<:Real}
+    return Quaternion{T}(rand(rng, T), rand(rng, T), rand(rng, T), rand(rng, T))
+end
+function Base.randn(rng::AbstractRNG, ::Type{Quaternion{T}}) where {T<:AbstractFloat}
+    return Quaternion{T}(
+        randn(rng, T) / 2,
+        randn(rng, T) / 2,
+        randn(rng, T) / 2,
+        randn(rng, T) / 2,
+    )
+end
 
 end

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -16,7 +16,7 @@ function killjob(d)
     end
     if @isdefined(SIGINFO)
         ccall(:uv_kill, Cint, (Cint, Cint), getpid(), SIGINFO)
-        sleep(1)
+        sleep(5) # Allow time for profile to collect and print before killing
     end
     ccall(:uv_kill, Cint, (Cint, Cint), getpid(), Base.SIGTERM)
     nothing


### PR DESCRIPTION
Backported PRs:
- [x] #44218 <!-- Allow more time for profile print when Sockets and Threads watchdogs request info -->
- [x] #44199 <!-- Profile: Minor fixes. Signal handling fix. -->
- [x] #44211 <!-- make `cat(As..., dims=Val((1,2,...))` work -->
- [x] #44127 <!-- Reduce number of `getindex(::Type, ...)` methods -->
- [x] #44224 <!-- `AbstractInterpreter`: make it easier to overload pure/concrete-eval -->
- [x] #44200 <!-- set type of statement when processing `GlobalRef`s -->
- [x] #44229 <!-- fix nothrow check for `get_binding_type` -->
- [x] #44180 <!-- Fix build warning in gc-alloc-profiler.cpp: cast to (size_t) -->
- [x] #44212 <!-- fix bug in `addenv` for environment entries with embedded `=` -->
- [x] #44251 <!-- Fix missing `jl_effective_threads` declaration -->
- [x] #44246 <!-- fix #44239, regression in keyword args in getindex -->
- [x] #44219 <!-- Fix dot(::Adjoint, ::Adjoint) for numbers that don't commute under multiplication -->
- [x] #44078 <!-- Ensure that `open(::Function, ::Cmd)` waits for termination -->
- [x] #44269 <!-- Profile.Allocs: jl_raw_alloc_t.task is untyped pointer -->
- [x] #44281 <!-- In the `sysimage.mk` Makefile, set the `JULIA_NUM_THREADS=1` environment variable when running the `generate_precompile.jl` script -->
- [x] #44268 <!-- Profile: Use grace period to avoid trailing signals from timer -->
- [x] #44270 <!-- debuginfo: Fix build on 32-bit ARM -->
- [x] #44194 <!-- [CPUID] Add ISA entries for A64FX and M1 -->
- [x] #44265 <!-- Fix aliasing case for copy! in AbstractSet/AbstractDict -->
- [x] #44252 <!-- Fix bad precompile statements via an output lock -->
- [x] #44116 <!-- Fix thread-safety violation in Allocations Profiler: Create a new per-thread backtrace buffer in ptls -->
- [x] #44303 <!-- fix `BLAS.spr!` docstring -->
- [x] #44279 <!-- Fix M1 tail call issue when building -->
- [x] #44257 <!-- fix documentation build of EscapeAnalysis.jl -->
- [x] #44210 <!-- effects: make `:terminates_globally` functional on recursive functions -->
- [x] #44282 <!-- inference: override return type inference by const-prop more carefully -->

Non-merged PRs with backport label:
- [ ] #44313 <!-- Make sure `range(start; step, length)` uses TwicePrecision when possible -->
- [ ] #44311 <!-- fix #43411, wrapped `NamedTuple` can be bitstype more often -->
- [ ] #44262 <!-- Make sure all the relocations are filled in for partially cloned target -->
- [ ] #44232 <!-- ensure binding type is set consistently for consts -->
- [ ] #44197 <!-- add entry point to construct an OpaqueClosure from pre-optimized IRCode -->
- [ ] #44168 <!-- Clarify the behavior of `@threads for` -->
- [ ] #43990 <!-- Cache external CodeInstances -->