### PR TITLE
inferece: remove `CachedMethodTable`

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -65,7 +65,7 @@ mutable struct InferenceState
     # The place to look up methods while working on this function.
     # In particular, we cache method lookup results for the same function to
     # fast path repeated queries.
-    method_table::CachedMethodTable{InternalMethodTable}
+    method_table::InternalMethodTable
 
     # The interpreter that created this inference state. Not looked at by
     # NativeInterpreter. But other interpreters may use this to detect cycles
@@ -141,7 +141,7 @@ mutable struct InferenceState
             cache === :global, false, false,
             Effects(consistent, ALWAYS_TRUE, ALWAYS_TRUE, ALWAYS_TRUE,
                    inbounds_taints_consistency),
-            CachedMethodTable(method_table(interp)),
+            method_table(interp),
             interp)
         result.result = frame
         cache !== :no && push!(get_inference_cache(interp), result)

--- a/base/compiler/methodtable.jl
+++ b/base/compiler/methodtable.jl
@@ -2,22 +2,6 @@
 
 abstract type MethodTableView; end
 
-struct MethodLookupResult
-    # Really Vector{Core.MethodMatch}, but it's easier to represent this as
-    # and work with Vector{Any} on the C side.
-    matches::Vector{Any}
-    valid_worlds::WorldRange
-    ambig::Bool
-end
-length(result::MethodLookupResult) = length(result.matches)
-function iterate(result::MethodLookupResult, args...)
-    r = iterate(result.matches, args...)
-    r === nothing && return nothing
-    match, state = r
-    return (match::MethodMatch, state)
-end
-getindex(result::MethodLookupResult, idx::Int) = getindex(result.matches, idx)::MethodMatch
-
 """
     struct InternalMethodTable <: MethodTableView
 
@@ -39,19 +23,21 @@ struct OverlayMethodTable <: MethodTableView
     mt::Core.MethodTable
 end
 
-"""
-    struct CachedMethodTable <: MethodTableView
-
-Overlays another method table view with an additional local fast path cache that
-can respond to repeated, identical queries faster than the original method table.
-"""
-struct CachedMethodTable{T} <: MethodTableView
-    cache::IdDict{Any, Union{Missing, MethodLookupResult}}
-    table::T
+struct MethodLookupResult
+    # Really Vector{Core.MethodMatch}, but it's easier to represent this as
+    # and work with Vector{Any} on the C side.
+    matches::Vector{Any}
+    valid_worlds::WorldRange
+    ambig::Bool
 end
-CachedMethodTable(table::T) where T =
-    CachedMethodTable{T}(IdDict{Any, Union{Missing, MethodLookupResult}}(),
-        table)
+length(result::MethodLookupResult) = length(result.matches)
+function iterate(result::MethodLookupResult, args...)
+    r = iterate(result.matches, args...)
+    r === nothing && return nothing
+    match, state = r
+    return (match::MethodMatch, state)
+end
+getindex(result::MethodLookupResult, idx::Int) = getindex(result.matches, idx)::MethodMatch
 
 """
     findall(sig::Type, view::MethodTableView; limit=typemax(Int))
@@ -91,13 +77,6 @@ function findall(@nospecialize(sig::Type), table::OverlayMethodTable; limit::Int
     return MethodLookupResult(ms::Vector{Any}, WorldRange(_min_val[], _max_val[]), _ambig[] != 0)
 end
 
-function findall(@nospecialize(sig::Type), table::CachedMethodTable; limit::Int=typemax(Int))
-    box = Core.Box(sig)
-    return get!(table.cache, sig) do
-        findall(box.contents, table.table; limit=limit)
-    end
-end
-
 """
     findsup(sig::Type, view::MethodTableView)::Union{Tuple{MethodMatch, WorldRange}, Nothing}
 
@@ -121,10 +100,6 @@ function findsup(@nospecialize(sig::Type), table::InternalMethodTable)
     (result.method, WorldRange(min_valid[], max_valid[]))
 end
 
-# This query is not cached
-findsup(@nospecialize(sig::Type), table::CachedMethodTable) = findsup(sig, table.table)
-
 isoverlayed(::MethodTableView)     = error("unsatisfied MethodTableView interface")
 isoverlayed(::InternalMethodTable) = false
 isoverlayed(::OverlayMethodTable)  = true
-isoverlayed(mt::CachedMethodTable) = isoverlayed(mt.table)

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -263,7 +263,6 @@ struct NativeInterpreter <: AbstractInterpreter
         # incorrect, fail out loudly.
         @assert world <= get_world_counter()
 
-
         return new(
             # Initially empty cache
             Vector{InferenceResult}(),


### PR DESCRIPTION
Previously the method lookup result was created per frame and so the
look cache hasn't been use that much. With this change the cache is
created per inference, and so the cached result will be used when we
already saw the same match in the same inference shot, and it may speed
up the lookup time a bit.

This commit also setups new `AbstractInterpreter` interface `get_method_lookup_cache`
which specifies what method lookup cache is used by each `AbstractInterpreter`.
`NativeInterpreter` creates a cache per inference, and so it is valid
since lookup is done in the same world age in the same inference shot.
External `AbstractInterpreter` doesn't opt into this cache by default,
and its behavior won't change in anyway.