### PR TITLE
Fix missing `jl_effective_threads` declaration

### DIFF
--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -4,6 +4,7 @@
 #include <errno.h>
 
 #include "julia.h"
+#include "julia_internal.h"
 
 #include <unistd.h>
 #include <getopt.h>


### PR DESCRIPTION
Fix the error `error: implicit declaration of function 'jl_effective_threads' is invalid in C99 [-Werror,-Wimplicit-function-declaration]` https://github.com/JuliaLang/julia/pull/42340#issuecomment-1045800717. @IanButterworth said it worked locally.

close #44250
close #44249

PS: Why our CI didn't catch this? Also, why normal build (`make`) in Linux didn't catch this? This may need a bit more investigation (unless someone knows why). But I think a quick fix like this makes sense.