### PR TITLE
Fix bad precompile statements via an output lock

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1970,6 +1970,8 @@ jl_code_instance_t *jl_method_compiled(jl_method_instance_t *mi, size_t world)
     return NULL;
 }
 
+jl_mutex_t precomp_statement_out_lock;
+
 static void record_precompile_statement(jl_method_instance_t *mi)
 {
     static ios_t f_precompile;
@@ -1980,6 +1982,7 @@ static void record_precompile_statement(jl_method_instance_t *mi)
     if (!jl_is_method(def))
         return;
 
+    JL_LOCK(&precomp_statement_out_lock);
     if (s_precompile == NULL) {
         const char *t = jl_options.trace_compile;
         if (!strncmp(t, "stderr", 6)) {
@@ -1998,6 +2001,7 @@ static void record_precompile_statement(jl_method_instance_t *mi)
         if (s_precompile != JL_STDERR)
             ios_flush(&f_precompile);
     }
+    JL_UNLOCK(&precomp_statement_out_lock);
 }
 
 jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t world)

--- a/src/gf.c
+++ b/src/gf.c
@@ -1982,7 +1982,8 @@ static void record_precompile_statement(jl_method_instance_t *mi)
     if (!jl_is_method(def))
         return;
 
-    JL_LOCK(&precomp_statement_out_lock);
+    if (jl_n_threads > 1)
+        JL_LOCK(&precomp_statement_out_lock);
     if (s_precompile == NULL) {
         const char *t = jl_options.trace_compile;
         if (!strncmp(t, "stderr", 6)) {
@@ -2001,7 +2002,8 @@ static void record_precompile_statement(jl_method_instance_t *mi)
         if (s_precompile != JL_STDERR)
             ios_flush(&f_precompile);
     }
-    JL_UNLOCK(&precomp_statement_out_lock);
+    if (jl_n_threads > 1)
+        JL_UNLOCK(&precomp_statement_out_lock);
 }
 
 jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t world)


### PR DESCRIPTION
It seems like multithreading might cause statements to be outputted at the same time, so a file lock is needed?

Fixes the latest reports in https://github.com/JuliaLang/julia/issues/28808 but shouldn't close that issue as the core issue there appears to be a different bug.