### PR TITLE
Don't hardcode LLVM version in link flags

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -127,7 +127,7 @@ else
 ifeq ($(OS), Darwin)
 CG_LLVMLINK += $(LLVM_LDFLAGS) -lLLVM
 else
-CG_LLVMLINK += $(LLVM_LDFLAGS) -lLLVM-13jl
+CG_LLVMLINK += $(LLVM_LDFLAGS) -lLLVM-$(LLVM_VER_MAJ)jl
 endif
 endif
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -127,7 +127,7 @@ else
 ifeq ($(OS), Darwin)
 CG_LLVMLINK += $(LLVM_LDFLAGS) -lLLVM
 else
-CG_LLVMLINK += $(LLVM_LDFLAGS) -lLLVM-$(LLVM_VER_MAJ)jl
+CG_LLVMLINK += $(LLVM_LDFLAGS) $(shell $(LLVM_CONFIG_HOST) --libs  --link-shared)
 endif
 endif
 endif


### PR DESCRIPTION
- Don't hardcode LLVM_VER in link flags
- fixup! Don't hardcode LLVM_VER in link flags
