### PR TITLE
Fix aliasing case for copy! in AbstractSet/AbstractDict

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -189,7 +189,10 @@ empty(a::AbstractDict) = empty(a, keytype(a), valtype(a))
 empty(a::AbstractDict, ::Type{V}) where {V} = empty(a, keytype(a), V) # Note: this is the form which makes sense for `Vector`.
 
 copy(a::AbstractDict) = merge!(empty(a), a)
-copy!(dst::AbstractDict, src::AbstractDict) = merge!(empty!(dst), src)
+function copy!(dst::AbstractDict, src::AbstractDict)
+    dst === src && return dst
+    merge!(empty!(dst), src)
+end
 
 """
     merge!(d::AbstractDict, others::AbstractDict...)

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -3,7 +3,10 @@
 eltype(::Type{<:AbstractSet{T}}) where {T} = @isdefined(T) ? T : Any
 sizehint!(s::AbstractSet, n) = nothing
 
-copy!(dst::AbstractSet, src::AbstractSet) = union!(empty!(dst), src)
+function copy!(dst::AbstractSet, src::AbstractSet)
+    dst === src && return dst
+    union!(empty!(dst), src)
+end
 
 ## set operations (union, intersection, symmetric difference)
 

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1179,6 +1179,8 @@ end
             @test s === copy!(s, Base.ImmutableDict(a[])) == Dict(a[])
         end
     end
+    s2 = copy(s)
+    @test copy!(s, s) == s2
 end
 
 @testset "map!(f, values(dict))" begin

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -151,6 +151,9 @@ end
             @test s === copy!(s, BitSet(a)) == S(a)
         end
     end
+    s = Set([1, 2])
+    s2 = copy(s)
+    @test copy!(s, s) == s2
 end
 
 @testset "sizehint, empty" begin


### PR DESCRIPTION
[Ref #41268](https://github.com/JuliaLang/julia/issues/41268)

In `copy!(dst, src)` when `src` is an alias for `dst` do nothing.
