### PR TITLE
[contrib] Update `download_cmake.sh` to CMake 3.19.3 and support aarch64

### DIFF
--- a/contrib/download_cmake.sh
+++ b/contrib/download_cmake.sh
@@ -14,30 +14,32 @@ CMAKE_VERSION_MAJMIN=$CMAKE_VERSION_MAJOR.$CMAKE_VERSION_MINOR
 CMAKE_VERSION=$CMAKE_VERSION_MAJMIN.$CMAKE_VERSION_PATCH
 
 # listed at https://cmake.org/files/v$CMAKE_VERSION_MAJMIN/cmake-$CMAKE_VERSION-SHA-256.txt
-# for the files cmake-$CMAKE_VERSION-Darwin-x86_64.tar.gz
+# for the files cmake-$CMAKE_VERSION-macos-universal.tar.gz
 # cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz and cmake-$CMAKE_VERSION-Linux-aarch64.tar.gz
-CMAKE_SHA256_DARWIN_X86_64=a6b79ad05f89241a05797510e650354d74ff72cc988981cdd1eb2b3b2bda66ac
+CMAKE_SHA256_DARWIN=a6b79ad05f89241a05797510e650354d74ff72cc988981cdd1eb2b3b2bda66ac
 CMAKE_SHA256_LINUX_X86_64=c18b65697e9679e5c88dccede08c323cd3d3730648e59048047bba82097e0ffc
 CMAKE_SHA256_LINUX_AARCH64=66e507c97ffb586d7ca6567890808b792c8eb004b645706df6fbf27826a395a2
 
 PLATFORM="$(uname)-$(uname -m)"
-FULLNAME=cmake-$CMAKE_VERSION-$PLATFORM
 case $PLATFORM in
-  Darwin-x86_64)
+  Darwin-*)
+    FULLNAME=cmake-$CMAKE_VERSION-macos-universal
     ../tools/jldownload https://cmake.org/files/v$CMAKE_VERSION_MAJMIN/$FULLNAME.tar.gz
     echo "$CMAKE_SHA256_DARWIN  $FULLNAME.tar.gz" | shasum -a 256 -c -
     CMAKE_EXTRACTED_PATH=$FULLNAME/CMake.app/Contents/bin/cmake;;
   Linux-x86_64)
+    FULLNAME=cmake-$CMAKE_VERSION-$PLATFORM
     ../tools/jldownload https://cmake.org/files/v$CMAKE_VERSION_MAJMIN/$FULLNAME.tar.gz
     echo "$CMAKE_SHA256_LINUX_X86_64  $FULLNAME.tar.gz" | sha256sum -c -
     CMAKE_EXTRACTED_PATH=$FULLNAME/bin/cmake;;
   Linux-aarch64)
+    FULLNAME=cmake-$CMAKE_VERSION-$PLATFORM
     ../tools/jldownload https://cmake.org/files/v$CMAKE_VERSION_MAJMIN/$FULLNAME.tar.gz
     echo "$CMAKE_SHA256_LINUX_AARCH64  $FULLNAME.tar.gz" | sha256sum -c -
     CMAKE_EXTRACTED_PATH=$FULLNAME/bin/cmake;;
   *)
-    echo "This script only supports x86_64 Mac and Linux. For other platforms," >&2
-    echo "get cmake from your package manager or compile it from source." >&2
+    echo "This script only supports Mac and Linux, both for x86_64 and aarch64." >&2
+    echo "For other platforms, get cmake from your package manager or compile it from source." >&2
     exit 1;;
 esac
 

--- a/contrib/download_cmake.sh
+++ b/contrib/download_cmake.sh
@@ -9,15 +9,16 @@ cd "$(dirname "$0")"/../deps/scratch
 
 CMAKE_VERSION_MAJOR=3
 CMAKE_VERSION_MINOR=19
-CMAKE_VERSION_PATCH=2
+CMAKE_VERSION_PATCH=3
 CMAKE_VERSION_MAJMIN=$CMAKE_VERSION_MAJOR.$CMAKE_VERSION_MINOR
 CMAKE_VERSION=$CMAKE_VERSION_MAJMIN.$CMAKE_VERSION_PATCH
 
 # listed at https://cmake.org/files/v$CMAKE_VERSION_MAJMIN/cmake-$CMAKE_VERSION-SHA-256.txt
 # for the files cmake-$CMAKE_VERSION-Darwin-x86_64.tar.gz
-# and cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz
-CMAKE_SHA256_DARWIN=50afa2cb66bea6a0314ef28034f3ff1647325e30cf5940f97906a56fd9640bd8
-CMAKE_SHA256_LINUX=4d8a6d852c530f263b22479aad196416bb4406447e918bd9759c6593b7f5f3f9
+# cmake-$CMAKE_VERSION-Linux-x86_64.tar.gz and cmake-$CMAKE_VERSION-Linux-aarch64.tar.gz
+CMAKE_SHA256_DARWIN_X86_64=a6b79ad05f89241a05797510e650354d74ff72cc988981cdd1eb2b3b2bda66ac
+CMAKE_SHA256_LINUX_X86_64=c18b65697e9679e5c88dccede08c323cd3d3730648e59048047bba82097e0ffc
+CMAKE_SHA256_LINUX_AARCH64=66e507c97ffb586d7ca6567890808b792c8eb004b645706df6fbf27826a395a2
 
 PLATFORM="$(uname)-$(uname -m)"
 FULLNAME=cmake-$CMAKE_VERSION-$PLATFORM
@@ -28,7 +29,11 @@ case $PLATFORM in
     CMAKE_EXTRACTED_PATH=$FULLNAME/CMake.app/Contents/bin/cmake;;
   Linux-x86_64)
     ../tools/jldownload https://cmake.org/files/v$CMAKE_VERSION_MAJMIN/$FULLNAME.tar.gz
-    echo "$CMAKE_SHA256_LINUX  $FULLNAME.tar.gz" | sha256sum -c -
+    echo "$CMAKE_SHA256_LINUX_X86_64  $FULLNAME.tar.gz" | sha256sum -c -
+    CMAKE_EXTRACTED_PATH=$FULLNAME/bin/cmake;;
+  Linux-aarch64)
+    ../tools/jldownload https://cmake.org/files/v$CMAKE_VERSION_MAJMIN/$FULLNAME.tar.gz
+    echo "$CMAKE_SHA256_LINUX_AARCH64  $FULLNAME.tar.gz" | sha256sum -c -
     CMAKE_EXTRACTED_PATH=$FULLNAME/bin/cmake;;
   *)
     echo "This script only supports x86_64 Mac and Linux. For other platforms," >&2


### PR DESCRIPTION
Should this use a more recent version?  At least 3.19.3 is the first one to provide a build for aarch64 linux which is what I need.