### PR TITLE
debuginfo: Fix build on 32-bit ARM

### DIFF
--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -227,7 +227,7 @@ public:
                     continue;
                 }
             }
-            uint64_t loadaddr = L.getSectionLoadAddress(section);
+            uint64_t loadaddr = getLoadAddress(section.getName().get());
             size_t seclen = section.getSize();
             if (istext) {
                 arm_text_addr = loadaddr;


### PR DESCRIPTION
This slipped through in 955d4271, as we aren't building for
32 bit ARM during CI right now.

GitHub: Fixes #44254.
