### PR TITLE
Make more passes NewPM compatible

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -895,6 +895,10 @@ static void registerCallbacks(PassBuilder &PB) {
                 PM.addPass(AllocOptPass());
                 return true;
             }
+            if (Name == "PropagateJuliaAddrspaces") {
+                PM.addPass(PropagateJuliaAddrspacesPass());
+                return true;
+            }
             return false;
         });
 
@@ -915,6 +919,10 @@ static void registerCallbacks(PassBuilder &PB) {
             }
             if (Name == "FinalLowerGC") {
                 PM.addPass(FinalLowerGCPass());
+                return true;
+            }
+            if (Name == "RemoveJuliaAddrspaces") {
+                PM.addPass(RemoveJuliaAddrspacesPass());
                 return true;
             }
             return false;

--- a/src/llvm-remove-addrspaces.cpp
+++ b/src/llvm-remove-addrspaces.cpp
@@ -457,7 +457,7 @@ struct RemoveAddrspacesPassLegacy : public ModulePass {
 
 public:
     bool runOnModule(Module &M) override {
-        removeAddrspaces(M, ASRemapper);
+        return removeAddrspaces(M, ASRemapper);
     }
 };
 

--- a/src/llvm-remove-addrspaces.cpp
+++ b/src/llvm-remove-addrspaces.cpp
@@ -14,6 +14,7 @@
 
 #include "codegen_shared.h"
 #include "julia.h"
+#include "passes.h"
 
 #define DEBUG_TYPE "remove_addrspaces"
 
@@ -231,18 +232,7 @@ unsigned removeAllAddrspaces(unsigned AS)
     return AddressSpace::Generic;
 }
 
-struct RemoveAddrspacesPass : public ModulePass {
-    static char ID;
-    AddrspaceRemapFunction ASRemapper;
-    RemoveAddrspacesPass(
-            AddrspaceRemapFunction ASRemapper = removeAllAddrspaces)
-        : ModulePass(ID), ASRemapper(ASRemapper){};
-
-public:
-    bool runOnModule(Module &M) override;
-};
-
-bool RemoveAddrspacesPass::runOnModule(Module &M)
+bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
 {
     ValueToValueMapTy VMap;
     AddrspaceRemoveTypeRemapper TypeRemapper(ASRemapper);
@@ -457,8 +447,22 @@ bool RemoveAddrspacesPass::runOnModule(Module &M)
     return true;
 }
 
-char RemoveAddrspacesPass::ID = 0;
-static RegisterPass<RemoveAddrspacesPass>
+
+struct RemoveAddrspacesPassLegacy : public ModulePass {
+    static char ID;
+    AddrspaceRemapFunction ASRemapper;
+    RemoveAddrspacesPassLegacy(
+            AddrspaceRemapFunction ASRemapper = removeAllAddrspaces)
+        : ModulePass(ID), ASRemapper(ASRemapper){};
+
+public:
+    bool runOnModule(Module &M) override {
+        removeAddrspaces(M, ASRemapper);
+    }
+};
+
+char RemoveAddrspacesPassLegacy::ID = 0;
+static RegisterPass<RemoveAddrspacesPassLegacy>
         X("RemoveAddrspaces",
           "Remove IR address space information.",
           false,
@@ -467,7 +471,17 @@ static RegisterPass<RemoveAddrspacesPass>
 Pass *createRemoveAddrspacesPass(
         AddrspaceRemapFunction ASRemapper = removeAllAddrspaces)
 {
-    return new RemoveAddrspacesPass(ASRemapper);
+    return new RemoveAddrspacesPassLegacy(ASRemapper);
+}
+
+RemoveAddrspacesPass::RemoveAddrspacesPass() : RemoveAddrspacesPass(removeAllAddrspaces) {}
+
+PreservedAnalyses RemoveAddrspacesPass::run(Module &M, ModuleAnalysisManager &AM) {
+    if (removeAddrspaces(M, ASRemapper)) {
+        return PreservedAnalyses::allInSet<CFGAnalyses>();
+    } else {
+        return PreservedAnalyses::all();
+    }
 }
 
 
@@ -483,16 +497,16 @@ unsigned removeJuliaAddrspaces(unsigned AS)
         return AS;
 }
 
-struct RemoveJuliaAddrspacesPass : public ModulePass {
+struct RemoveJuliaAddrspacesPassLegacy : public ModulePass {
     static char ID;
-    RemoveAddrspacesPass Pass;
-    RemoveJuliaAddrspacesPass() : ModulePass(ID), Pass(removeJuliaAddrspaces){};
+    RemoveAddrspacesPassLegacy Pass;
+    RemoveJuliaAddrspacesPassLegacy() : ModulePass(ID), Pass(removeJuliaAddrspaces){};
 
-    bool runOnModule(Module &M) { return Pass.runOnModule(M); }
+    bool runOnModule(Module &M) override { return Pass.runOnModule(M); }
 };
 
-char RemoveJuliaAddrspacesPass::ID = 0;
-static RegisterPass<RemoveJuliaAddrspacesPass>
+char RemoveJuliaAddrspacesPassLegacy::ID = 0;
+static RegisterPass<RemoveJuliaAddrspacesPassLegacy>
         Y("RemoveJuliaAddrspaces",
           "Remove IR address space information.",
           false,
@@ -500,7 +514,11 @@ static RegisterPass<RemoveJuliaAddrspacesPass>
 
 Pass *createRemoveJuliaAddrspacesPass()
 {
-    return new RemoveJuliaAddrspacesPass();
+    return new RemoveJuliaAddrspacesPassLegacy();
+}
+
+PreservedAnalyses RemoveJuliaAddrspacesPass::run(Module &M, ModuleAnalysisManager &AM) {
+    return RemoveAddrspacesPass(removeJuliaAddrspaces).run(M, AM);
 }
 
 extern "C" JL_DLLEXPORT void LLVMExtraAddRemoveJuliaAddrspacesPass_impl(LLVMPassManagerRef PM)

--- a/src/passes.h
+++ b/src/passes.h
@@ -26,6 +26,10 @@ struct LateLowerGC : PassInfoMixin<LateLowerGC> {
 struct AllocOptPass : PassInfoMixin<AllocOptPass> {
     PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
+struct PropagateJuliaAddrspacesPass : PassInfoMixin<PropagateJuliaAddrspacesPass> {
+    PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+    static bool isRequired() { return true; }
+};
 
 // Module Passes
 struct CPUFeatures : PassInfoMixin<CPUFeatures> {
@@ -42,6 +46,21 @@ struct LowerSIMDLoop : PassInfoMixin<LowerSIMDLoop> {
 };
 
 struct FinalLowerGCPass : PassInfoMixin<LateLowerGC> {
+    PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+    static bool isRequired() { return true; }
+};
+
+struct RemoveJuliaAddrspacesPass : PassInfoMixin<RemoveJuliaAddrspacesPass> {
+    PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+    static bool isRequired() { return true; }
+};
+
+struct RemoveAddrspacesPass : PassInfoMixin<RemoveAddrspacesPass> {
+
+    std::function<unsigned(unsigned)> ASRemapper;
+    RemoveAddrspacesPass();
+    RemoveAddrspacesPass(std::function<unsigned(unsigned)> ASRemapper) : ASRemapper(std::move(ASRemapper)) {}
+
     PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
     static bool isRequired() { return true; }
 };

--- a/test/llvmpasses/propagate-addrspace.ll
+++ b/test/llvmpasses/propagate-addrspace.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -enable-new-pm=0 -load libjulia-codegen%shlibext -PropagateJuliaAddrspaces -dce -S %s | FileCheck %s
+; RUN: opt -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='PropagateJuliaAddrspaces,dce' -S %s | FileCheck %s
 
 define i64 @simple() {
 ; CHECK-LABEL: @simple

--- a/test/llvmpasses/remove-addrspaces.ll
+++ b/test/llvmpasses/remove-addrspaces.ll
@@ -1,4 +1,5 @@
 ; RUN: opt -enable-new-pm=0 -load libjulia-codegen%shlibext -RemoveJuliaAddrspaces -S %s | FileCheck %s
+; RUN: opt -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='RemoveJuliaAddrspaces' -S %s | FileCheck %s
 
 
 define i64 @getindex({} addrspace(10)* nonnull align 16 dereferenceable(40)) {


### PR DESCRIPTION
* Makes RemoveAddrspaces, RemoveJuliaAddrspaces, and PropagateJuliaAddrspaces NewPM-compatible
* Ensures that LateGCLower correctly reports clobbered analyses when the CFG is invalidated