### PR TITLE
Fix M1 tail call issue when building

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -234,9 +234,10 @@ static GlobalVariable *emit_plt_thunk(
         // musttail support is very bad on ARM, PPC, PPC64 (as of LLVM 3.9)
         // Known failures includes vararg (not needed here) and sret.
 
-#if (defined(_CPU_X86_) || defined(_CPU_X86_64_) || (defined(_CPU_AARCH64_) && !defined(__APPLE__)))
+#if (defined(_CPU_X86_) || defined(_CPU_X86_64_) || (defined(_CPU_AARCH64_) && !defined(_OS_DARWIN_)))
         // Ref https://bugs.llvm.org/show_bug.cgi?id=47058
         // LLVM, as of 10.0.1 emits wrong/worse code when musttail is set
+        // Apple silicon macs give an LLVM ERROR if musttail is set here #44107. Purity PR
         if (!attrs.hasAttrSomewhere(Attribute::ByVal))
             ret->setTailCallKind(CallInst::TCK_MustTail);
 #endif

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -233,8 +233,8 @@ static GlobalVariable *emit_plt_thunk(
     else {
         // musttail support is very bad on ARM, PPC, PPC64 (as of LLVM 3.9)
         // Known failures includes vararg (not needed here) and sret.
-#if (defined(_CPU_X86_) || defined(_CPU_X86_64_) || \
-                        defined(_CPU_AARCH64_))
+
+#if (defined(_CPU_X86_) || defined(_CPU_X86_64_) || (defined(_CPU_AARCH64_) && !defined(__APPLE__)))
         // Ref https://bugs.llvm.org/show_bug.cgi?id=47058
         // LLVM, as of 10.0.1 emits wrong/worse code when musttail is set
         if (!attrs.hasAttrSomewhere(Attribute::ByVal))

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -237,7 +237,7 @@ static GlobalVariable *emit_plt_thunk(
 #if (defined(_CPU_X86_) || defined(_CPU_X86_64_) || (defined(_CPU_AARCH64_) && !defined(_OS_DARWIN_)))
         // Ref https://bugs.llvm.org/show_bug.cgi?id=47058
         // LLVM, as of 10.0.1 emits wrong/worse code when musttail is set
-        // Apple silicon macs give an LLVM ERROR if musttail is set here #44107. Purity PR
+        // Apple silicon macs give an LLVM ERROR if musttail is set here #44107.
         if (!attrs.hasAttrSomewhere(Attribute::ByVal))
             ret->setTailCallKind(CallInst::TCK_MustTail);
 #endif


### PR DESCRIPTION
This implements @staticfloat solution for the LLVM error that appears on m1 builds #44107.
Current master is very brittle when building the m1 but this bug happens every time without the PR.
I tried debugging it quite a lot and LLVM DEBUG with arm lower call debug on doesn't show why it doesn't tail call so I have no idea why it fails, the bug was added by the purity PR as mentioned in the issue. I don't know if it has to do with the anonymous union but apple gives a warning for that