### PR TITLE
Provide custom manifest name via `JULIA_MANIFEST_NAME` env var

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -244,6 +244,13 @@ end
 
 ## load path expansion: turn LOAD_PATH entries into concrete paths ##
 
+function expand_version_placeholders(str::String)
+    str = replace(str, '#' => VERSION.major, count=1)
+    str = replace(str, '#' => VERSION.minor, count=1)
+    str = replace(str, '#' => VERSION.patch, count=1)
+    return str
+end
+
 function load_path_expand(env::AbstractString)::Union{String, Nothing}
     # named environment?
     if startswith(env, '@')
@@ -252,9 +259,7 @@ function load_path_expand(env::AbstractString)::Union{String, Nothing}
         env == "@" && return active_project(false)
         env == "@." && return current_project()
         env == "@stdlib" && return Sys.STDLIB
-        env = replace(env, '#' => VERSION.major, count=1)
-        env = replace(env, '#' => VERSION.minor, count=1)
-        env = replace(env, '#' => VERSION.patch, count=1)
+        env = expand_version_placeholders(env)
         name = env[2:end]
         # look for named env in each depot
         for depot in DEPOT_PATH

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -415,7 +415,7 @@ function manifest_names()
     env_var_name = "JULIA_MANIFEST_NAME"
     custom_def = strip(get(ENV, env_var_name, ""))
     if !isempty(custom_def)
-        man_name = expand_version_placeholders(custom_def)
+        man_name = expand_version_placeholders(String(custom_def))
         if endswith(custom_def, ":")
             return String[man_name, default_manifest_names...]
         else

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -407,9 +407,24 @@ end
 
 ## generic project & manifest API ##
 
-const project_names = ("JuliaProject.toml", "Project.toml")
-const manifest_names = ("JuliaManifest.toml", "Manifest.toml")
-const preferences_names = ("JuliaLocalPreferences.toml", "LocalPreferences.toml")
+const project_names = ["JuliaProject.toml", "Project.toml"]
+const default_manifest_names = ["JuliaManifest.toml", "Manifest.toml"]
+const preferences_names = ["JuliaLocalPreferences.toml", "LocalPreferences.toml"]
+
+function manifest_names()
+    env_var_name = "JULIA_MANIFEST_NAME"
+    custom_def = strip(get(ENV, env_var_name, ""))
+    if !isempty(custom_def)
+        man_name = expand_version_placeholders(custom_def)
+        if endswith(custom_def, ":")
+            return String[man_name, default_manifest_names...]
+        else
+            return String[man_name]
+        end
+    else
+        return default_manifest_names
+    end
+end
 
 # classify the LOAD_PATH entry to be one of:
 #  - `false`: nonexistant / nothing to see here
@@ -525,7 +540,7 @@ function project_file_manifest_path(project_file::String)::Union{Nothing,String}
         end
     end
     if manifest_path === nothing
-        for mfst in manifest_names
+        for mfst in manifest_names()
             manifest_file = joinpath(dir, mfst)
             if isfile_casesensitive(manifest_file)
                 manifest_path = manifest_file

--- a/doc/src/manual/code-loading.md
+++ b/doc/src/manual/code-loading.md
@@ -65,6 +65,14 @@ Each kind of environment defines these three maps differently, as detailed in th
 
 A project environment is determined by a directory containing a project file called `Project.toml`, and optionally a manifest file called `Manifest.toml`. These files may also be called `JuliaProject.toml` and `JuliaManifest.toml`, in which case `Project.toml` and `Manifest.toml` are ignored. This allows for coexistence with other tools that might consider files called `Project.toml` and `Manifest.toml` significant. For pure Julia projects, however, the names `Project.toml` and `Manifest.toml` are preferred.
 
+A custom manifest filename may also be provided via the environment variable `JULIA_MANIFEST_NAME`. If the provided name ends with a `:` it will be tried first before the default manifest names, otherwise that name alone will be allowed. The provided name may also have placeholder `#` characters which will be auto-populated sequentially with the julia `VERSION` fields. This approach enables providing dedicated manifests for multiple julia versions, such as in a package testing setup where checked-in manifests may be needed.
+
+For instance:
+
+- `$ JULIA_MANIFEST_NAME=ManifestA.toml: julia` will first look for a manifest named `ManifestA.toml` then use the default options.
+- `$ JULIA_MANIFEST_NAME=ManifestA.toml julia` will only look for/create a manifest named `ManifestA.toml`
+- `$ JULIA_MANIFEST_NAME=Manifest.#.#.toml julia` in julia 1.8.0 will only look for/create a manifest named `Manifest.1.8.toml`
+
 The roots, graph and paths maps of a project environment are defined as follows:
 
 **The roots map** of the environment is determined by the contents of the project file, specifically, its top-level `name` and `uuid` entries and its `[deps]` section (all optional). Consider the following example project file for the hypothetical application, `App`, as described earlier:

--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -18,7 +18,7 @@ function parse_toml(path::String)
     Base.parsed_toml(path)
 end
 
-# keep in sync with Base.project_names and Base.manifest_names
+# keep in sync with Base.project_names and Base.default_manifest_names
 const artifact_names = ("JuliaArtifacts.toml", "Artifacts.toml")
 
 const ARTIFACTS_DIR_OVERRIDE = Ref{Union{String,Nothing}}(nothing)

--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -161,6 +161,6 @@ end
 @testset "`Artifacts.artifact_names` and friends" begin
     n = length(Artifacts.artifact_names)
     @test length(Base.project_names) == n
-    @test length(Base.manifest_names) == n
+    @test length(Base.default_manifest_names) == n
     @test length(Base.preferences_names) == n
 end


### PR DESCRIPTION
Allows providing a custom manifest name via the `JULIA_MANIFEST_NAME` env var, which can have placeholder `#` chars that will be replaced by the `VERSION` fields.

```
% JULIA_MANIFEST_NAME=Manifest.#.#.toml julia -e "import Pkg; Pkg.status(mode=Pkg.PKGMODE_MANIFEST)"
Status `~/.julia/environments/v1.9/Manifest.1.9.toml` (empty manifest)
```

Requires https://github.com/JuliaLang/Pkg.jl/pull/3000

Discussed in https://github.com/JuliaLang/julia/pull/43845#issuecomment-1046318841

Closes #43845