### PR TITLE
[macOS] Codesign binary-dist tarballs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -428,7 +428,19 @@ endif
 ifeq ($(OS), WINNT)
 	cd $(BUILDROOT)/julia-$(JULIA_COMMIT)/bin && rm -f llvm* llc.exe lli.exe opt.exe LTO.dll bugpoint.exe macho-dump.exe
 endif
+	# If we're on macOS, and we have a codesigning identity, then codesign the binary-dist tarball!
+ifeq ($(OS),Darwin)
+ifneq ($(MACOS_CODESIGN_IDENTITY),)
+	echo "Codesigning with identity $(MACOS_CODESIGN_IDENTITY)"; \
+	MACHO_FILES=$$(find "$(BUILDROOT)/julia-$(JULIA_COMMIT)" -type f -perm -0111 | cut -d: -f1); \
+	for f in $${MACHO_FILES}; do \
+		echo "Codesigning $${f}..."; \
+		codesign -s "$(MACOS_CODESIGN_IDENTITY)" --option=runtime --entitlements $(JULIAHOME)/contrib/mac/app/Entitlements.plist -vvv --timestamp --deep --force "$${f}"; \
+	done
+endif
+endif
 	cd $(BUILDROOT) && $(TAR) zcvf $(JULIA_BINARYDIST_FILENAME).tar.gz julia-$(JULIA_COMMIT)
+
 
 exe:
 	# run Inno Setup to compile installer

--- a/contrib/mac/app/Makefile
+++ b/contrib/mac/app/Makefile
@@ -50,6 +50,9 @@ dmg/$(APP_NAME): startup.applescript julia.icns
 	make -C $(JULIAHOME) binary-dist
 	tar zxf $(JULIAHOME)/$(JULIA_BINARYDIST_FILENAME).tar.gz -C $@/Contents/Resources/julia --strip-components 1
 	find $@/Contents/Resources/julia -type f -exec chmod -w {} \;
+	# Even though the tarball may already be signed, we re-sign here to make it easier to add
+	# unsigned executables (like the app launcher) and whatnot, without needing to maintain lists
+	# of what is or is not signed.  Codesigning is cheap, so might as well do it early and often.
 	if [ -n "$$MACOS_CODESIGN_IDENTITY" ]; then \
 	    echo "Codesigning with identity $$MACOS_CODESIGN_IDENTITY"; \
 		MACHO_FILES=$$(find "$@" -type f -perm -0111 | cut -d: -f1); \


### PR DESCRIPTION
Because we're starting to distribute macOS tarballs as well, let's
codesign them by default, when possible.

@davidanthoff This should help us avoid inconsistencies between the `.tar.gz` files and `.dmg` files, as the most manual step so far has been the codesigning of the tarball contents.