### PR TITLE
expose `Filesystem.touch` for `Filesytem.File` objects

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -429,6 +429,7 @@ end
 
 """
     touch(path::AbstractString)
+    touch(fd::File)
 
 Update the last-modified timestamp on a file to the current time.
 
@@ -454,18 +455,13 @@ We can see the [`mtime`](@ref) has been modified by `touch`.
 function touch(path::AbstractString)
     f = open(path, JL_O_WRONLY | JL_O_CREAT, 0o0666)
     try
-        if Sys.isunix()
-            ret = ccall(:futimes, Cint, (Cint, Ptr{Cvoid}), fd(f), C_NULL)
-            systemerror(:futimes, ret != 0, extrainfo=path)
-        else
-            t = time()
-            futime(f,t,t)
-        end
+        touch(f)
     finally
         close(f)
     end
     path
 end
+
 
 """
     tempdir()

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -263,4 +263,16 @@ end
 fd(f::File) = f.handle
 stat(f::File) = stat(f.handle)
 
+function touch(f::File)
+    @static if Sys.isunix()
+        ret = ccall(:futimes, Cint, (Cint, Ptr{Cvoid}), fd(f), C_NULL)
+        systemerror(:futimes, ret != 0)
+    else
+        t = time()
+        futime(f, t, t)
+    end
+    f
+end
+
+
 end


### PR DESCRIPTION
Wanted this for Pidfile.jl, so thought it would be useful to expose separately. Currently I polyfill it, in expectation of this PR:
https://github.com/vtjnash/Pidfile.jl/commit/147f07883555fb18d7bdf7e0cea68730c042d987#diff-3b86733f3bbb623c9149814588ef59698913a5e9d9654f999cc726c50a8334cdR98