### PR TITLE
Define `isempty(g::Generator)` and `Base.isdone(g::Generator)`

### DIFF
--- a/base/generator.jl
+++ b/base/generator.jl
@@ -130,4 +130,5 @@ IteratorEltype(::Type{Generator{I,T}}) where {I,T} = EltypeUnknown()
 
 IteratorEltype(::Type{Any}) = EltypeUnknown()
 
+isempty(g::Generator) = isempty(g.iter)
 isdone(g::Generator, state...) = isdone(g.iter, state...)

--- a/base/generator.jl
+++ b/base/generator.jl
@@ -53,7 +53,8 @@ axes(g::Generator) = axes(g.iter)
 ndims(g::Generator) = ndims(g.iter)
 keys(g::Generator) = keys(g.iter)
 last(g::Generator) = g.f(last(g.iter))
-
+isempty(g::Generator) = isempty(g.iter)
+isdone(g::Generator, state...) = isdone(g.iter, state...)
 
 ## iterator traits
 
@@ -129,6 +130,3 @@ IteratorEltype(::Type) = HasEltype()  # HasEltype is the default
 IteratorEltype(::Type{Generator{I,T}}) where {I,T} = EltypeUnknown()
 
 IteratorEltype(::Type{Any}) = EltypeUnknown()
-
-isempty(g::Generator) = isempty(g.iter)
-isdone(g::Generator, state...) = isdone(g.iter, state...)

--- a/base/generator.jl
+++ b/base/generator.jl
@@ -129,3 +129,5 @@ IteratorEltype(::Type) = HasEltype()  # HasEltype is the default
 IteratorEltype(::Type{Generator{I,T}}) where {I,T} = EltypeUnknown()
 
 IteratorEltype(::Type{Any}) = EltypeUnknown()
+
+isdone(g::Generator, state...) = isdone(g.iter, state...)

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -904,6 +904,6 @@ end
     itr = eachline(IOBuffer("foo\n"))
     gen = (x for x in itr)
     @test !isempty(gen)
-    @test !isdone(gen)
+    @test !Base.isdone(gen)
     @test collect(gen) == ["foo"]
 end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -899,3 +899,11 @@ end
     @test last(Iterators.map(identity, 1:3)) == 3
     @test last(Iterators.filter(iseven, (Iterators.map(identity, 1:3)))) == 2
 end
+
+@testset "isempty and isdone for Generators" begin
+    itr = eachline(IOBuffer("foo\n"))
+    gen = (x for x in itr)
+    @test !isempty(gen)
+    @test !isdone(gen)
+    @test collect(gen) == ["foo"]
+end


### PR DESCRIPTION
This makes it a bit safer to use `isempty` on generators (otherwise isempty might eat values from stateful iterables wrapped by a generator).