### PR TITLE
Fix `iterate(c::Channel)` when `close(c, e)` used

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -496,7 +496,7 @@ function iterate(c::Channel, state=nothing)
     try
         return (take!(c), nothing)
     catch e
-        if isa(e, InvalidStateException) && e.state === :closed
+        if e === c.excp && c.state === :closed
             return nothing
         else
             rethrow()


### PR DESCRIPTION
Before this PR, the example below would throw an error, now it doesn't. I don't know if that was intended or not:

```jl
julia> c = Channel()
Channel{Any}(0) (empty)

julia> @async begin sleep(10); close(c, ErrorException("oops")) end
Task (runnable) @0x00007fe049d50a20

julia> collect(c)
```