### PR TITLE
fix #43411, wrapped `NamedTuple` can be bitstype more often

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -61,6 +61,8 @@ static int layout_uses_free_typevars(jl_value_t *v, jl_typeenv_t *env)
         jl_datatype_t *dt = (jl_datatype_t*)v;
         if (dt->layout || dt->isconcretetype || !dt->name->mayinlinealloc)
             return 0;
+        if (dt->name == jl_namedtuple_typename)
+            return layout_uses_free_typevars(jl_tparam0(dt), env) || layout_uses_free_typevars(jl_tparam1(dt), env);
         jl_svec_t *types = jl_get_fieldtypes(dt);
         size_t i, l = jl_svec_len(types);
         for (i = 0; i < l; i++) {

--- a/test/core.jl
+++ b/test/core.jl
@@ -7324,6 +7324,12 @@ end
 @test isbitstype(X41654)
 @test ('a'=>X41654(),)[1][2] isa X41654
 
+# issue #43411
+struct A43411{S, T}
+    x::NamedTuple{S, T}
+end
+@test isbitstype(A43411{(:a,), Tuple{Int}})
+
 # Issue #34206/34207
 function mre34206(a, n)
     va = view(a, :)


### PR DESCRIPTION
fix #43411