### PR TITLE
gc: Cast to jl_value_t* to avoid compiler warning

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -3575,7 +3575,7 @@ JL_DLLEXPORT void *jl_gc_managed_malloc(size_t sz)
 #endif
     errno = last_errno;
     // jl_gc_managed_malloc is currently always used for allocating array buffers.
-    maybe_record_alloc_to_profile(b, sz, (jl_datatype_t*)jl_buff_tag);
+    maybe_record_alloc_to_profile((jl_value_t*)b, sz, (jl_datatype_t*)jl_buff_tag);
     return b;
 }
 
@@ -3617,7 +3617,7 @@ static void *gc_managed_realloc_(jl_ptls_t ptls, void *d, size_t sz, size_t olds
     SetLastError(last_error);
 #endif
     errno = last_errno;
-    maybe_record_alloc_to_profile(b, sz, jl_gc_unknown_type_tag);
+    maybe_record_alloc_to_profile((jl_value_t*)b, sz, jl_gc_unknown_type_tag);
     return b;
 }
 


### PR DESCRIPTION
When compiling, I saw 2 warnings with GCC 11:

```
/home/****/dev/julia/core/julia/src/gc.c: In function 'ijl_gc_managed_malloc':
/home/****/dev/julia/core/julia/src/gc.c:3578:35: warning: request for implicit conversion from 'void *' to 'jl_value_t *' {aka 'struct _jl_value_t *'} not permitted in C++ [-Wc++-compat]
 3578 |     maybe_record_alloc_to_profile(b, sz, (jl_datatype_t*)jl_buff_tag);
      |                                   ^
/home/****/dev/julia/core/julia/src/gc.c: In function 'gc_managed_realloc_':
/home/****/dev/julia/core/julia/src/gc.c:3620:35: warning: request for implicit conversion from 'void *' to 'jl_value_t *' {aka 'struct _jl_value_t *'} not permitted in C++ [-Wc++-compat]
 3620 |     maybe_record_alloc_to_profile(b, sz, jl_gc_unknown_type_tag);
      |                                   ^
```

This just fixes them by adding the explicit typecast to `jl_value_t*`.