### PR TITLE
Add NEWS on precompilation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,12 @@ Compiler/Runtime improvements
   Code heavily dependent on constant propagation should see significant compile-time performance improvements and
   certain cases (e.g. calls to uninlinable functions that are nevertheless effect free) should see runtime performance
   improvements. Effects may be overwritten manually with the `@Base.assume_effects` macro ([#43852]).
+* Precompilation (with explicit `precompile` directives or representative workloads) now saves more type-inferred code,
+  resulting in reduced time-to-first task for packages that use precompilation.  This change also eliminates the
+  runtime performance degradation occasionally triggered by precompilation on older Julia versions. More specifically,
+  any newly-inferred method/type combinations needed by your package--regardless of where those methods were
+  defined--can now be cached in the precompile file, as long as they are inferrably called by a method owned by
+  your package ([#43990]).
 
 Command-line option changes
 ---------------------------
@@ -274,5 +280,6 @@ Tooling Improvements
 [#43852]: https://github.com/JuliaLang/julia/issues/43852
 [#43865]: https://github.com/JuliaLang/julia/issues/43865
 [#43919]: https://github.com/JuliaLang/julia/issues/43919
+[#43990]: https://github.com/JuliaLang/julia/issues/43990
 [#44080]: https://github.com/JuliaLang/julia/issues/44080
 [#44136]: https://github.com/JuliaLang/julia/issues/44136


### PR DESCRIPTION
Note this is against the release-1.8 branch, and that #43990 still needs to be backported. (I'm happy to submit the backport as a PR, but I figured that @KristofferC may prefer to manage this process.)

If this isn't the right way to do this, let me know.