### PR TITLE
Add a convenience macro for `precompile`

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1039,4 +1039,5 @@ export
     @goto,
     @view,
     @views,
-    @static
+    @static,
+    @precompile

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -1028,6 +1028,9 @@ macro precompile(ex)
     inner = unwrap_macrocalls(ex)
     is_function_def(inner) || error("@precompile can only be used on function definitions")
 
+    # Unsure how to handle methods with type parameters correctly without writing lots of custom logic.
+    inner.args[1].head == :where && error("@precompile is not implemented for methods with type parameters")
+
     sig = inner.args[1].args
     func_name = sig[1]::Symbol
     # Drop function name and kwargs.

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -1009,14 +1009,13 @@ end
     @precompile
 
 Compile a given function with concrete arguments, but without executing it. This is a
-convenience macro for [`precompile`](@ref). For example, write
+convenience macro for [`precompile`](@ref).
 
+# Example
 ```
 @precompile f(name::String, id::Int) = string(name, id);
 ```
-
 This is the same as
-
 ```
 f(name::String, id::Int) = string(name, id)
 precompile(f, (String, Int))
@@ -1044,7 +1043,7 @@ macro precompile(ex)
     precompile_ex = :(precompile($func_name, $types))
 
     return esc(quote
-        $inner
+        Base.@__doc__($inner)
         $precompile_ex
     end)
 end

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -1013,11 +1013,11 @@ convenience macro for [`precompile`](@ref).
 
 # Example
 ```
-@precompile f(name::String, id::Int) = string(name, id);
+@precompile f(a::String, b::Int) = string(a, b)
 ```
 This is the same as
 ```
-f(name::String, id::Int) = string(name, id)
+f(a::String, b::Int) = string(a, b)
 precompile(f, (String, Int))
 ```
 

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -1030,18 +1030,18 @@ macro precompile(ex)
     is_function_def(inner) || error("@precompile can only be used on function definitions")
 
     sig = inner.args[1].args
+    func_name = sig[1]::Symbol
     # Drop function name and kwargs.
     args = filter(x -> x isa(Expr) && !isexpr(x, :parameters), sig)
     types = Tuple(eval(last(arg.args)) for arg in args)
     if !all(isconcretetype.(types))
         nonconcrete = filter(!isconcretetype, types)
         multiple = 1 < length(nonconcrete)
-        msg = "The type$(multiple ? 's' : "") $nonconcrete in the signature $(sig[1])$(types) $(multiple ? "are" : "is") not concrete."
+        msg = "The type$(multiple ? 's' : "") $nonconcrete in the signature $(func_name)$(types) $(multiple ? "are" : "is") not concrete."
         error(msg)
     end
 
-    f_name = sig[1]
-    precompile_ex = :(precompile($f_name, $types))
+    precompile_ex = :(precompile($func_name, $types))
 
     return esc(quote
         $inner

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1284,6 +1284,7 @@ end
 
     M = Module()
     @eval M begin
+        without_precompile() = 1
         @precompile f(a::Float64, b::Int) = a + b
         @precompile g() = 1
         @precompile h(a::Float64; b=3) = a + b
@@ -1291,6 +1292,7 @@ end
         @precompile withdoc() = 1
     end
     specialized_once(func) = !isempty(only(methods(func)).specializations)
+    @test !specialized_once(M.without_precompile)
     @test specialized_once(M.f)
     @test M.f(1.0, 2) == 3.0
     @test specialized_once(M.g)

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1280,13 +1280,17 @@ end
 end
 
 @testset "@precompile" begin
-    # This isn't caught properly.
-    # @test_throws LoadError @precompile nothing
+    @test_throws LoadError eval(:(@precompile nothing))
 
     M = Module()
     @eval M begin
         @precompile f(a::Float64, b::Int) = a + b
+        @precompile g() = 1
+        @precompile h(a::Float64; b=3) = a + b
     end
-    @test !isempty(only(methods(M.f)).specializations)
+    specialized_once(func) = !isempty(only(methods(func)).specializations)
+    @test specialized_once(M.f)
     @test M.f(1.0, 2) == 3.0
+    @test specialized_once(M.g)
+    @test specialized_once(M.h)
 end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1290,6 +1290,9 @@ end
         @precompile h(a::Float64; b=3) = a + b
         "Some doc"
         @precompile withdoc() = 1
+
+        k(a, b) = a + b
+        @precompile k(1, 2)
     end
     specialized_once(func) = !isempty(only(methods(func)).specializations)
     @test !specialized_once(M.without_precompile)
@@ -1298,4 +1301,8 @@ end
     @test specialized_once(M.g)
     @test specialized_once(M.h)
     @test contains(string(@doc M.withdoc), "Some doc")
+
+    @test specialized_once(M.k)
+    @test_throws UndefVarError eval(:(@precompile z(1, 2)))
+    @test_throws LoadError eval(:(@precompile M.k()))
 end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1278,3 +1278,15 @@ end
     @test any(mi -> mi.specTypes.parameters[2] === Any, mis)
     @test all(mi -> isa(mi.cache, Core.CodeInstance), mis)
 end
+
+@testset "@precompile" begin
+    # This isn't caught properly.
+    # @test_throws LoadError @precompile nothing
+
+    M = Module()
+    @eval M begin
+        @precompile f(a::Float64, b::Int) = a + b
+    end
+    @test !isempty(only(methods(M.f)).specializations)
+    @test M.f(1.0, 2) == 3.0
+end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1287,10 +1287,13 @@ end
         @precompile f(a::Float64, b::Int) = a + b
         @precompile g() = 1
         @precompile h(a::Float64; b=3) = a + b
+        "Some doc"
+        @precompile withdoc() = 1
     end
     specialized_once(func) = !isempty(only(methods(func)).specializations)
     @test specialized_once(M.f)
     @test M.f(1.0, 2) == 3.0
     @test specialized_once(M.g)
     @test specialized_once(M.h)
+    @test contains(string(@doc M.withdoc), "Some doc")
 end


### PR DESCRIPTION
This PR is inspired by a recent addition to Pluto (https://github.com/fonsp/Pluto.jl/pull/1934). There, adding one single `precompile` reduced the time to open a notebook bij **3 seconds** while only increasing the time for `using Pluto` by 0.2 seconds. This PR proposes to add a `@precompile` macro so that

```julia
@precompile f(a::Float64, b::Int) = a + b
```

has the same effect as

```julia
f(a::Float64, b::Int) = a + b
precompile(f, (Float64, Int))
```

So, this macro avoids a bit of code duplication and, therefore, makes it easier to keep the signature of the function definition in sync with the call to `precompile`.

One related discussion to this PR is whether this macro wouldn't get in the way of writing generic Julia code as is mentioned in https://github.com/JuliaLang/julia/issues/12897#issuecomment-136552141. So, maybe we should add a note to this to the docstring? Also, a reasonable pattern would be to write things like

```julia
@precompile function f(name::String, id::Int)
    ...
end
f(name::AbstractString, id::Int) = f(string(name)::String, id)
```
to still allow writing generic code in cases where a conversion to a concrete type is possible.