### PR TITLE
[WIP] Enable opaque pointers mode in codegen

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -127,7 +127,7 @@ else
 ifeq ($(OS), Darwin)
 CG_LLVMLINK += $(LLVM_LDFLAGS) -lLLVM
 else
-CG_LLVMLINK += $(LLVM_LDFLAGS) -lLLVM-13jl
+CG_LLVMLINK += $(LLVM_LDFLAGS) -lLLVM-14jl
 endif
 endif
 endif

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1978,43 +1978,43 @@ static void emit_memcpy_llvm(jl_codectx_t &ctx, Value *dst, MDNode *tbaa_dst, Va
     // If the types are small and simple, use load and store directly.
     // Going through memcpy can cause LLVM (e.g. SROA) to create bitcasts between float and int
     // that interferes with other optimizations.
-    if (sz <= 64) {
-        // The size limit is arbitrary but since we mainly care about floating points and
-        // machine size vectors this should be enough.
-        const DataLayout &DL = jl_Module->getDataLayout();
-        auto srcty = cast<PointerType>(src->getType());
-        //TODO unsafe nonopaque pointer
-        auto srcel = srcty->getElementType();
-        auto dstty = cast<PointerType>(dst->getType());
-        //TODO unsafe nonopaque pointer
-        auto dstel = dstty->getElementType();
-        if (srcel->isArrayTy() && srcel->getArrayNumElements() == 1) {
-            src = ctx.builder.CreateConstInBoundsGEP2_32(srcel, src, 0, 0);
-            srcel = srcel->getArrayElementType();
-            srcty = srcel->getPointerTo();
-        }
-        if (dstel->isArrayTy() && dstel->getArrayNumElements() == 1) {
-            dst = ctx.builder.CreateConstInBoundsGEP2_32(dstel, dst, 0, 0);
-            dstel = dstel->getArrayElementType();
-            dstty = dstel->getPointerTo();
-        }
+    // if (sz <= 64) {
+    //     // The size limit is arbitrary but since we mainly care about floating points and
+    //     // machine size vectors this should be enough.
+    //     const DataLayout &DL = jl_Module->getDataLayout();
+    //     auto srcty = cast<PointerType>(src->getType());
+    //     //TODO unsafe nonopaque pointer
+    //     auto srcel = srcty->getElementType();
+    //     auto dstty = cast<PointerType>(dst->getType());
+    //     //TODO unsafe nonopaque pointer
+    //     auto dstel = dstty->getElementType();
+    //     if (srcel->isArrayTy() && srcel->getArrayNumElements() == 1) {
+    //         src = ctx.builder.CreateConstInBoundsGEP2_32(srcel, src, 0, 0);
+    //         srcel = srcel->getArrayElementType();
+    //         srcty = srcel->getPointerTo();
+    //     }
+    //     if (dstel->isArrayTy() && dstel->getArrayNumElements() == 1) {
+    //         dst = ctx.builder.CreateConstInBoundsGEP2_32(dstel, dst, 0, 0);
+    //         dstel = dstel->getArrayElementType();
+    //         dstty = dstel->getPointerTo();
+    //     }
 
-        llvm::Type *directel = nullptr;
-        if (srcel->isSized() && srcel->isSingleValueType() && DL.getTypeStoreSize(srcel) == sz) {
-            directel = srcel;
-            dst = emit_bitcast(ctx, dst, srcty);
-        }
-        else if (dstel->isSized() && dstel->isSingleValueType() &&
-                 DL.getTypeStoreSize(dstel) == sz) {
-            directel = dstel;
-            src = emit_bitcast(ctx, src, dstty);
-        }
-        if (directel) {
-            auto val = tbaa_decorate(tbaa_src, ctx.builder.CreateAlignedLoad(directel, src, Align(align), is_volatile));
-            tbaa_decorate(tbaa_dst, ctx.builder.CreateAlignedStore(val, dst, Align(align), is_volatile));
-            return;
-        }
-    }
+    //     llvm::Type *directel = nullptr;
+    //     if (srcel->isSized() && srcel->isSingleValueType() && DL.getTypeStoreSize(srcel) == sz) {
+    //         directel = srcel;
+    //         dst = emit_bitcast(ctx, dst, srcty);
+    //     }
+    //     else if (dstel->isSized() && dstel->isSingleValueType() &&
+    //              DL.getTypeStoreSize(dstel) == sz) {
+    //         directel = dstel;
+    //         src = emit_bitcast(ctx, src, dstty);
+    //     }
+    //     if (directel) {
+    //         auto val = tbaa_decorate(tbaa_src, ctx.builder.CreateAlignedLoad(directel, src, Align(align), is_volatile));
+    //         tbaa_decorate(tbaa_dst, ctx.builder.CreateAlignedStore(val, dst, Align(align), is_volatile));
+    //         return;
+    //     }
+    // }
     // the memcpy intrinsic does not allow to specify different alias tags
     // for the load part (x.tbaa) and the store part (ctx.tbaa().tbaa_stack).
     // since the tbaa lattice has to be a tree we have unfortunately


### PR DESCRIPTION
Opaque pointers are untyped pointers in LLVM IR. By giving up types, they also remove many redundant bitcasts between various pointer types and thus could potentially reduce LLVM optimization time. In addition, some of our optimization passes can benefit from opaque pointers (alloc-opt, remove-addrspaces) as they will only need to insert addrspacecast instructions rather than changing the types of pointers while optimizing. 

This PR builds on top of #43827 as that PR defers construction of the global context until after command line options are parsed, which enables us to specify opaque pointers mode in the command line arguments.

Restrictions:

1. Opaque pointers requires LLVM 14 or above.
    1. There have been many patches between LLVM 13 and LLVM 14 related to opaque pointers, and it is unlikely that most will be backported back two major versions.
2. The sysimg currently fails to build due to an assert in loop access analysis
    1. This was fixed recently but after the 14.0.0-rc branch cut (Backport issue: https://github.com/llvm/llvm-project/issues/54059)
    2. For now, it's easier to build the sysimg with opaque pointers turned off (comment out `ctxt->enableOpaquePointers();
` in codegen.cpp ~ line 8319) and then turn on opaque pointers with `JULIA_LLVM_ARGS="--opaque-pointers"` for experimentation purposes
---

More information on opaque pointers: https://llvm.org/docs/OpaquePointers.html

---

Make.user to force LLVM 14.0.0-rc version
```
#LLVM_DEBUG=2
LLVM_ASSERTIONS=1
USE_BINARYBUILDER_LLVM=0
FORCE_ASSERTIONS=1
LLVM_GIT_URL:=https://github.com/llvm/llvm-project.git
LLVM_VER=14.0.0
override LLVM_SHA1=f5f0bd8e3d972d040827c88adf1a9880ebcb821e
```