### PR TITLE
fix #44328: method validation for opaque closures

### DIFF
--- a/base/compiler/validation.jl
+++ b/base/compiler/validation.jl
@@ -53,6 +53,7 @@ const NON_TOP_LEVEL_METHOD = "encountered `Expr` head `:method` in non-top-level
 const NON_TOP_LEVEL_GLOBAL = "encountered `Expr` head `:global` in non-top-level code (i.e. `nargs` > 0)"
 const SIGNATURE_NARGS_MISMATCH = "method signature does not match number of method arguments"
 const SLOTNAMES_NARGS_MISMATCH = "CodeInfo for method contains fewer slotnames than the number of method arguments"
+const INVALID_SIGNATURE_OPAQUE_CLOSURE = "invalid signature of method for opaque closure - `sig` field must always be set to `Tuple`"
 
 struct InvalidCodeError <: Exception
     kind::String
@@ -215,7 +216,9 @@ function validate_code!(errors::Vector{>:InvalidCodeError}, mi::Core.MethodInsta
         m = mi.def::Method
         mnargs = m.nargs
         n_sig_params = length((unwrap_unionall(m.sig)::DataType).parameters)
-        if (m.isva ? (n_sig_params < (mnargs - 1)) : (n_sig_params != mnargs))
+        if m.is_for_opaque_closure
+            m.sig === Tuple || push!(errors, InvalidCodeError(INVALID_SIGNATURE_OPAQUE_CLOSURE, (m.sig, m.isva)))
+        elseif (m.isva ? (n_sig_params < (mnargs - 1)) : (n_sig_params != mnargs))
             push!(errors, InvalidCodeError(SIGNATURE_NARGS_MISMATCH, (m.isva, n_sig_params, mnargs)))
         end
     end

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3862,7 +3862,7 @@ f(x) = yt(x)
                                            v)))
                                    cvs)))
                `(new_opaque_closure
-                 ,(cadr e) (top Bottom) (core Any)
+                 ,(cadr e) (call (core apply_type) (core Union)) (core Any)
                  (opaque_closure_method (null) ,nargs ,isva ,functionloc ,(convert-lambda lam2 (car (lam:args lam2)) #f '() (symbol-to-idx-map cvs)))
                  ,@var-exprs))))
           ((method)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3862,7 +3862,7 @@ f(x) = yt(x)
                                            v)))
                                    cvs)))
                `(new_opaque_closure
-                 ,(cadr e) (call (core apply_type) Union) (core Any)
+                 ,(cadr e) (top Bottom) (core Any)
                  (opaque_closure_method (null) ,nargs ,isva ,functionloc ,(convert-lambda lam2 (car (lam:args lam2)) #f '() (symbol-to-idx-map cvs)))
                  ,@var-exprs))))
           ((method)


### PR DESCRIPTION
I believe it's intentional that for these methods, the `sig` field is
just ignored and always set to `Tuple`. Also fixes a lowering bug I
discovered that would cause errors if `Union` was shadowed.

I have verified that this fixes the reported warnings.
