### PR TITLE
Don't hash the key if dictionary is empty

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -278,6 +278,7 @@ end
 
 # get the index where a key is stored, or -1 if not present
 function ht_keyindex(h::Dict{K,V}, key) where V where K
+    isempty(h) && return -1
     sz = length(h.keys)
     iter = 0
     maxprobe = h.maxprobe


### PR DESCRIPTION
Avoids hashing the input key for empty dictionaries.

Inspired by https://github.com/rust-lang/hashbrown/pull/305.

