### PR TITLE
Fix memory error during precompilation

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -272,6 +272,7 @@ static int has_backedge_to_worklist(jl_method_instance_t *mi, htable_t *visited)
     for (i = 0; i < n; i++) {
         jl_method_instance_t *be = (jl_method_instance_t*)jl_array_ptr_ref(mi->backedges, i);
         if (has_backedge_to_worklist(be, visited)) {
+            bp = ptrhash_bp(visited, mi);           // re-acquire since rehashing might change the location
             *bp = (void*)((char*)HT_NOTFOUND + 2);  // found
             return 1;
         }

--- a/src/dump.c
+++ b/src/dump.c
@@ -286,10 +286,10 @@ static size_t queue_external_mis(jl_array_t *list)
 {
     size_t i, n = 0;
     htable_t visited;
-    htable_new(&visited, 0);
     if (list) {
         assert(jl_is_array(list));
         size_t n0 = jl_array_len(list);
+        htable_new(&visited, n0);
         for (i = 0; i < n0; i++) {
             jl_method_instance_t *mi = (jl_method_instance_t*)jl_array_ptr_ref(list, i);
             assert(jl_is_method_instance(mi));
@@ -2640,7 +2640,7 @@ JL_DLLEXPORT int jl_save_incremental(const char *fname, jl_array_t *worklist)
     arraylist_new(&reinit_list, 0);
     htable_new(&edges_map, 0);
     htable_new(&backref_table, 5000);
-    htable_new(&external_mis, 0);
+    htable_new(&external_mis, newly_inferred ? jl_array_len(newly_inferred) : 0);
     ptrhash_put(&backref_table, jl_main_module, (char*)HT_NOTFOUND + 1);
     backref_table_numel = 1;
     jl_idtable_type = jl_base_module ? jl_get_global(jl_base_module, jl_symbol("IdDict")) : NULL;


### PR DESCRIPTION
Fixes #44338

I tested this with
```
(pkgs) pkg> st
Status `/tmp/tim/pkgs/Project.toml`
  [5c1252a2] GeometryBasics v0.4.1
  [7073ff75] IJulia v1.23.2
  [98e50ef6] JuliaFormatter v0.22.4
  [add582a8] MLJ v0.17.1
  [d491faf4] MLJModels v0.15.4
  [ccf2f8ad] PlotThemes v2.0.1
  [7792a7ef] StrideArraysCore v0.2.12
```
which only intermittently triggers #44338, but the frequency was well above 1 in 10 and probably more like 1 in 3. After a few manual runs, I did this:

```sh
$ for i in {1..50}
> do
>     rm -rf ~/.julia/compiled/v1.9/*
>     ./julia --startup=no -e 'using Pkg; Pkg.activate("/tmp/tim/pkgs"); Pkg.precompile()'
>     echo "$i done"
> done
```

49 of these 50 runs completed successfully. The one exception threw this backtrace:

```
signal (11): Segmentation fault
in expression starting at none:0
jl_collect_backedges at /home/tim/src/julia-master/src/dump.c:1229
ijl_save_incremental at /home/tim/src/julia-master/src/dump.c:2676
jl_write_compiler_output at /home/tim/src/julia-master/src/precompile.c:65
ijl_atexit_hook at /home/tim/src/julia-master/src/init.c:207
jl_repl_entrypoint at /home/tim/src/julia-master/src/jlapi.c:707
jl_load_repl at /home/tim/src/julia-master/cli/loader_lib.c:271
main at /home/tim/src/julia-master/cli/loader_exe.c:59
__libc_start_main at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
_start at /home/tim/src/julia-master/usr/bin/julia-debug (unknown line)
Allocations: 8546957 (Pool: 8542808; Big: 4149); GC: 10
Stacktrace:
 [1] pkgerror(msg::String)
   @ Pkg.Types ~/src/julia-master/usr/share/julia/stdlib/v1.9/Pkg/src/Types.jl:67
 [2] precompile(ctx::Pkg.Types.Context, pkgs::Vector{String}; internal_call::Bool, strict::Bool, warn_loaded::Bool, already_instantiated::Bool, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Pkg.API ~/src/julia-master/usr/share/julia/stdlib/v1.9/Pkg/src/API.jl:1427
 [3] precompile
   @ ~/src/julia-master/usr/share/julia/stdlib/v1.9/Pkg/src/API.jl:1060 [inlined]
 [4] #precompile#225
   @ ~/src/julia-master/usr/share/julia/stdlib/v1.9/Pkg/src/API.jl:1057 [inlined]
 [5] precompile (repeats 2 times)
   @ ~/src/julia-master/usr/share/julia/stdlib/v1.9/Pkg/src/API.jl:1057 [inlined]
 [6] top-level scope
   @ none:1
```

which is also htable-related, but one that we've used this way for a long time. In particular, the crash probably occurred in a part of that line that has been part of Julia for 5 years: https://github.com/JuliaLang/julia/blob/fb85cb3a5deea742260c70a2763aa7c64d26eb02/src/dump.c#L1077

One other interesting case: while almost all of these runs took between 90-92s each to compile, on one run it took 436s. I don't have any data about what caused that, so it's not really actionable.