### PR TITLE
Use `apple-m1` as the base mcpu for `aarch64-apple-darwin`

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -903,7 +903,7 @@ USE_BLAS64:=1
 BINARY:=64
 ifeq ($(OS),Darwin)
 # Apple Chips are all at least A12Z
-MCPU:=apple-a12
+MCPU:=apple-m1
 endif
 endif
 


### PR DESCRIPTION
Since the Apple devkits are all presumably returned to Apple at this
point, it doesn't make sense to continue to build for the earlier a12
model, we should just build for the M1 explicitly.  LLVM supports
`-mcpu=apple-m1` since LLVM 13.0.0-rc1 [0].  Clang 13 (ships with
Xcode 13) understands this, so it's a safe bet that this can be used
with the C compiler that is generating this code as well.

[0]
https://github.com/llvm/llvm-project/commit/a8a3a43792472c9775c60fa79b9357033d47ce40