### PR TITLE
Silence all warnings when building with GCC on Linux

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -347,7 +347,7 @@ static bool is_native_simd_type(jl_datatype_t *dt) {
 #elif defined _CPU_PPC64_
   typedef ABI_PPC64leLayout DefaultAbiState;
 #else
-#  warning "ccall is defaulting to llvm ABI, since no platform ABI has been defined for this CPU/OS combination"
+#  pragma message("ccall is defaulting to llvm ABI, since no platform ABI has been defined for this CPU/OS combination")
   typedef ABI_LLVMLayout DefaultAbiState;
 #endif
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3340,7 +3340,7 @@ static jl_cgval_t emit_setfield(jl_codectx_t &ctx,
         Value *ptindex = ctx.builder.CreateInBoundsGEP(getInt8Ty(ctx.builder.getContext()), emit_bitcast(ctx, maybe_decay_tracked(ctx, addr), getInt8PtrTy(ctx.builder.getContext())), ConstantInt::get(getSizeTy(ctx.builder.getContext()), fsz));
         if (needlock)
             emit_lockstate_value(ctx, strct, true);
-        BasicBlock *ModifyBB;
+        BasicBlock *ModifyBB = NULL;
         if (ismodifyfield) {
             ModifyBB = BasicBlock::Create(ctx.builder.getContext(), "modify_xchg", ctx.f);
             ctx.builder.CreateBr(ModifyBB);

--- a/src/crc32c.c
+++ b/src/crc32c.c
@@ -346,7 +346,7 @@ static crc32c_func_t crc32c_dispatch(unsigned long hwcap)
 #    define crc32c_dispatch() crc32c_dispatch(getauxval(AT_HWCAP))
 #    define crc32c_dispatch_ifunc "crc32c_dispatch"
 #  else
-#  warning CRC32 feature detection not implemented for this OS. Falling back to software version.
+#  pragma message("CRC32 feature detection not implemented for this OS. Falling back to software version.")
 #  endif
 #else
 // If we don't have any accelerated version to define, just make the _sw version define

--- a/src/dump.c
+++ b/src/dump.c
@@ -1071,6 +1071,7 @@ static void serialize_htable_keys(jl_serializer_state *s, htable_t *ht, int nite
     write_int32(s->s, nitems);
     void **table = ht->table;
     size_t i, n = 0, sz = ht->size;
+    (void)n;
     for (i = 0; i < sz; i += 2) {
         if (table[i+1] != HT_NOTFOUND) {
             jl_serialize_value(s, (jl_value_t*)table[i]);

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -983,13 +983,13 @@ void gc_time_summary(int sweep_full, uint64_t start, uint64_t end,
                      uint64_t pause)
 {
     if (sweep_full > 0)
-        jl_safe_printf("%ld Major collection: estimate freed = %ld
-                       live = %ldm new interval = %ldm time = %ldms\n",
+        jl_safe_printf("%ld Major collection: estimate freed = %ld\n"
+                       "live = %ldm new interval = %ldm time = %ldms\n",
                        end - start, freed, live/1024/1024,
                        interval/1024/1024, pause/1000000 );
     else
-        jl_safe_printf("%ld Minor collection: estimate freed = %ld live = %ldm
-                       new interval = %ldm time = %ldms\n",
+        jl_safe_printf("%ld Minor collection: estimate freed = %ld live = %ldm\n"
+                       "new interval = %ldm time = %ldms\n",
                        end - start, freed, live/1024/1024,
                        interval/1024/1024, pause/1000000 );
 }

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1118,7 +1118,7 @@ StringRef JuliaOJIT::getFunctionAtAddress(uint64_t Addr, jl_code_instance_t *cod
 
 #ifdef JL_USE_JITLINK
 # if JL_LLVM_VERSION < 140000
-#  warning "JIT debugging (GDB integration) not available on LLVM < 14.0 (for JITLink)"
+#  pragma message("JIT debugging (GDB integration) not available on LLVM < 14.0 (for JITLink)")
 void JuliaOJIT::enableJITDebuggingSupport() {}
 # else
 extern "C" orc::shared::CWrapperFunctionResult

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -32,7 +32,7 @@
 // for Mac/aarch64.
 #if defined(_OS_DARWIN_) && defined(_CPU_AARCH64_)
 # if JL_LLVM_VERSION < 130000
-#  warning "On aarch64-darwin, LLVM version >= 13 is required for JITLink; fallback suffers from occasional segfaults"
+#  pragma message("On aarch64-darwin, LLVM version >= 13 is required for JITLink; fallback suffers from occasional segfaults")
 # endif
 # define JL_USE_JITLINK
 #endif


### PR DESCRIPTION
With this PR I can do a clean build from scratch (at least after `git clean -fxd`) with `make CFLAGS=-Werror CXXFLAGS=-Werror` when using GCC 11.1.0 on Linux.  Clang is _way_ more picky.

@staticfloat @vtjnash does it make sense to enable `-Werror` in CI at least for the platforms where we use GCC?  Now that there is a (partially) clean state it'd be good to not introduce new warnings.