### PR TITLE
add doc string for `uppercase(::AbstractChar)` and friends

### DIFF
--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -270,10 +270,64 @@ julia> textwidth("March")
 """
 textwidth(s::AbstractString) = mapreduce(textwidth, +, s; init=0)
 
+"""
+    lowercase(c::AbstractChar)
+
+Convert `c` to lowercase.
+
+See also [`uppercase`](@ref), [`titlecase`](@ref).
+
+# Examples
+```jldoctest
+julia> lowercase('A')
+'a': ASCII/Unicode U+0061 (category Ll: Letter, lowercase)
+
+julia> lowercase('Ö')
+'ö': Unicode U+00F6 (category Ll: Letter, lowercase)
+```
+"""
 lowercase(c::T) where {T<:AbstractChar} = isascii(c) ? ('A' <= c <= 'Z' ? c + 0x20 : c) :
     T(ccall(:utf8proc_tolower, UInt32, (UInt32,), c))
+
+"""
+    uppercase(c::AbstractChar)
+
+Convert `c` to uppercase.
+
+See also [`lowercase`](@ref), [`titlecase`](@ref).
+
+# Examples
+```jldoctest
+julia> uppercase('a')
+'A': ASCII/Unicode U+0041 (category Lu: Letter, uppercase)
+
+julia> uppercase('ê')
+'Ê': Unicode U+00CA (category Lu: Letter, uppercase)
+```
+"""
 uppercase(c::T) where {T<:AbstractChar} = isascii(c) ? ('a' <= c <= 'z' ? c - 0x20 : c) :
     T(ccall(:utf8proc_toupper, UInt32, (UInt32,), c))
+
+"""
+    titlecase(c::AbstractChar)
+
+Convert `c` to titlecase. This may differ from uppercase for digraphs,
+compare the example below.
+
+See also [`uppercase`](@ref), [`lowercase`](@ref).
+
+# Examples
+```jldoctest
+julia> titlecase('a')
+'A': ASCII/Unicode U+0041 (category Lu: Letter, uppercase)
+
+julia> titlecase('ǆ')
+'ǅ': Unicode U+01C5 (category Lt: Letter, titlecase)
+
+julia> uppercase('ǆ')
+'Ǆ': Unicode U+01C4 (category Lu: Letter, uppercase)
+```
+"""
 titlecase(c::T) where {T<:AbstractChar} = isascii(c) ? ('a' <= c <= 'z' ? c - 0x20 : c) :
     T(ccall(:utf8proc_totitle, UInt32, (UInt32,), c))
 


### PR DESCRIPTION
Currently, `uppercase`, `lowercase` and `titlecase` are only documented for `AbstractString` arguments. This pull request adds doc strings for `AbstractChar` methods, which  also exist.