### PR TITLE
Guard GCC-specific macros with `_COMPILER_GCC_`

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -422,7 +422,7 @@ jl_svec_t *jl_perm_symsvec(size_t n, ...);
 
 // this sizeof(__VA_ARGS__) trick can't be computed until C11, but that only matters to Clang in some situations
 #if !defined(__clang_analyzer__) && !(defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_))
-#ifdef __GNUC__
+#ifdef _COMPILER_GCC_
 #define jl_perm_symsvec(n, ...) \
     (jl_perm_symsvec)(__extension__({                                         \
             static_assert(                                                    \


### PR DESCRIPTION
By default Clang on Linux defines the macro `__GNUC__`, so to guard GCC-specific
code paths it isn't sufficient to check `#ifdef __GNUC__`.

If @Keno confirms this was the intended check, this would fix #44352.  In the meantime I can confirm I can successfully build this branch with Clang (`CC=clang CXX=clang++`) on Linux.