### PR TITLE
Avoid dynamic allocation in `hypot`

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -671,7 +671,8 @@ true
 ```
 """
 hypot(x::Number) = abs(float(x))
-hypot(x::Number, y::Number, xs::Number...) = _hypot(float.(promote(x, y, xs...))...)
+hypot(x::Number, y::Number) = _hypot(promote(float(x), y)...)
+hypot(x::Number, y::Number, xs::Number...) = _hypot(promote(float(x), y, xs...))
 function _hypot(x, y)
     # preserves unit
     axu = abs(x)
@@ -743,7 +744,7 @@ end
 end
 _hypot(x::ComplexF16, y::ComplexF16) = Float16(_hypot(ComplexF32(x), ComplexF32(y)))
 
-function _hypot(x...)
+function _hypot(x::NTuple{N,<:Number}) where {N}
     maxabs = maximum(abs, x)
     if isnan(maxabs) && any(isinf, x)
         return typeof(maxabs)(Inf)

--- a/test/math.jl
+++ b/test/math.jl
@@ -1399,3 +1399,12 @@ end
 # the compiler ever gets good enough to figure
 # that out by itself, move this to inference).
 @test code_typed(x->Val{x^0.0}(), Tuple{Float64})[1][2] == Val{1.0}
+
+function f44336()
+    as = ntuple(_ -> rand(), Val(32))
+    @inline hypot(as...)
+end
+@testset "Issue #44336" begin
+    f44336()
+    @test (@allocated f44336()) == 0
+end


### PR DESCRIPTION
Close #44336
Test added.
A simple bench:
```julia
julia> @btime hypot($1.0,$2.0,$3.0,$4.0,$5.0,$6.0,$6.0,$7.0,$1,$1);
  38.710 ns (0 allocations: 0 bytes) # master: 580.556 ns (18 allocations: 528 bytes)
```