### PR TITLE
Simplification of libblastrampoline stuff in LinearAlgebra

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,12 @@ Standard library changes
 
 #### LinearAlgebra
 
+* We are now wholly reliant on libblastrampoline (LBT) for calling
+  BLAS and LAPACK. OpenBLAS is shipped by default, but building the
+  system image with other BLAS/LAPACK libraries is not
+  supported. Instead, it is recommended that the LBT mechanism be used
+  for swapping BLAS/LAPACK with vendor provided ones. ([#44360])
+
 #### Markdown
 
 #### Printf

--- a/base/Makefile
+++ b/base/Makefile
@@ -47,8 +47,6 @@ else
 	@echo "const MACHINE = \"$(XC_HOST)\"" >> $@
 endif
 	@echo "const libm_name = \"$(LIBMNAME)\"" >> $@
-	@echo "const libblas_name = \"libblastrampoline\"" >> $@
-	@echo "const liblapack_name = \"libblastrampoline\"" >> $@
 ifeq ($(USE_BLAS64), 1)
 	@echo "const USE_BLAS64 = true" >> $@
 else

--- a/base/Makefile
+++ b/base/Makefile
@@ -47,8 +47,8 @@ else
 	@echo "const MACHINE = \"$(XC_HOST)\"" >> $@
 endif
 	@echo "const libm_name = \"$(LIBMNAME)\"" >> $@
-	@echo "const libblas_name = \"$(LIBBLASNAME)\"" >> $@
-	@echo "const liblapack_name = \"$(LIBLAPACKNAME)\"" >> $@
+	@echo "const libblas_name = \"libblastrampoline\"" >> $@
+	@echo "const liblapack_name = \"libblastrampoline\"" >> $@
 ifeq ($(USE_BLAS64), 1)
 	@echo "const USE_BLAS64 = true" >> $@
 else

--- a/stdlib/LinearAlgebra/Project.toml
+++ b/stdlib/LinearAlgebra/Project.toml
@@ -4,6 +4,7 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 libblastrampoline_jll = "8e850b90-86db-534c-a0d3-1478176c7d93"
+OpenBLAS_jll = "4536629a-c528-5b80-bd46-f80d51c5b363"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -565,29 +565,6 @@ function versioninfo(io::IO=stdout)
     return nothing
 end
 
-function find_library_path(name)
-    shlib_ext = string(".", Libdl.dlext)
-    if !endswith(name, shlib_ext)
-        name_ext = string(name, shlib_ext)
-    end
-
-    # On windows, we look in `bin` and never in `lib`
-    @static if Sys.iswindows()
-        path = joinpath(Sys.BINDIR, name_ext)
-        isfile(path) && return path
-    else
-        # On other platforms, we check `lib/julia` first, and if that doesn't exist, `lib`.
-        path = joinpath(Sys.BINDIR, Base.LIBDIR, "julia", name_ext)
-        isfile(path) && return path
-
-        path = joinpath(Sys.BINDIR, Base.LIBDIR, name_ext)
-        isfile(path) && return path
-    end
-
-    # If we can't find it by absolute path, we'll try just passing this straight through to `dlopen()`
-    return name
-end
-
 function __init__()
     try
         BLAS.lbt_forward(OpenBLAS_jll.libopenblas_path; clear=true)

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -19,6 +19,8 @@ using Base: IndexLinear, promote_eltype, promote_op, promote_typeof,
     @propagate_inbounds, @pure, reduce, typed_hvcat, typed_vcat, require_one_based_indexing,
     splat
 using Base.Broadcast: Broadcasted, broadcasted
+using OpenBLAS_jll
+using libblastrampoline_jll
 import Libdl
 
 export
@@ -588,17 +590,7 @@ end
 
 function __init__()
     try
-        libblas_path = find_library_path(Base.libblas_name)
-        liblapack_path = find_library_path(Base.liblapack_name)
-        # We manually `dlopen()` these libraries here, so that we search with `libjulia-internal`'s
-        # `RPATH` and not `libblastrampoline's`.  Once it's been opened, when LBT tries to open it,
-        # it will find the library already loaded.
-        libblas_path = Libdl.dlpath(Libdl.dlopen(libblas_path))
-        BLAS.lbt_forward(libblas_path; clear=true)
-        if liblapack_path != libblas_path
-            liblapack_path = Libdl.dlpath(Libdl.dlopen(liblapack_path))
-            BLAS.lbt_forward(liblapack_path)
-        end
+        BLAS.lbt_forward(OpenBLAS_jll.libopenblas_path; clear=true)
         BLAS.check()
     catch ex
         Base.showerror_nostdio(ex, "WARNING: Error during initialization of module LinearAlgebra")

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -63,11 +63,7 @@ export
     trsm!,
     trsm
 
-import LinearAlgebra
-using LinearAlgebra: BlasReal, BlasComplex, BlasFloat, BlasInt, DimensionMismatch, checksquare, stride1, chkstride1
-
-using libblastrampoline_jll
-const lbt = libblastrampoline_jll.libblastrampoline
+using ..LinearAlgebra: libblastrampoline, BlasReal, BlasComplex, BlasFloat, BlasInt, DimensionMismatch, checksquare, stride1, chkstride1
 
 include("lbt.jl")
 
@@ -189,7 +185,7 @@ for (fname, elty) in ((:dcopy_,:Float64),
     @eval begin
         # SUBROUTINE DCOPY(N,DX,INCX,DY,INCY)
         function blascopy!(n::Integer, DX::Union{Ptr{$elty},AbstractArray{$elty}}, incx::Integer, DY::Union{Ptr{$elty},AbstractArray{$elty}}, incy::Integer)
-            ccall((@blasfunc($fname), lbt), Cvoid,
+            ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                 (Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}),
                  n, DX, incx, DY, incy)
             DY
@@ -211,12 +207,12 @@ first `n` elements of array `Y` with stride `incy`. Returns `X` and `Y`.
 """
 function rot! end
 
-for (fname, elty, cty, sty, lib) in ((:drot_, :Float64, :Float64, :Float64, lbt),
-                                     (:srot_, :Float32, :Float32, :Float32, lbt),
-                                     (:zdrot_, :ComplexF64, :Float64, :Float64, lbt),
-                                     (:csrot_, :ComplexF32, :Float32, :Float32, lbt),
-                                     (:zrot_, :ComplexF64, :Float64, :ComplexF64, lbt),
-                                     (:crot_, :ComplexF32, :Float32, :ComplexF32, lbt))
+for (fname, elty, cty, sty, lib) in ((:drot_, :Float64, :Float64, :Float64, libblastrampoline),
+                                     (:srot_, :Float32, :Float32, :Float32, libblastrampoline),
+                                     (:zdrot_, :ComplexF64, :Float64, :Float64, libblastrampoline),
+                                     (:csrot_, :ComplexF32, :Float32, :Float32, libblastrampoline),
+                                     (:zrot_, :ComplexF64, :Float64, :ComplexF64, libblastrampoline),
+                                     (:crot_, :ComplexF32, :Float32, :ComplexF32, libblastrampoline))
     @eval begin
         # SUBROUTINE DROT(N,DX,INCX,DY,INCY,C,S)
         function rot!(n::Integer, DX::Union{Ptr{$elty},AbstractArray{$elty}}, incx::Integer, DY::Union{Ptr{$elty},AbstractArray{$elty}}, incy::Integer, C::$cty, S::$sty)
@@ -257,7 +253,7 @@ for (fname, elty) in ((:dscal_,:Float64),
     @eval begin
         # SUBROUTINE DSCAL(N,DA,DX,INCX)
         function scal!(n::Integer, DA::$elty, DX::Union{Ptr{$elty},AbstractArray{$elty}}, incx::Integer)
-            ccall((@blasfunc($fname), lbt), Cvoid,
+            ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                   (Ref{BlasInt}, Ref{$elty}, Ptr{$elty}, Ref{BlasInt}),
                   n, DA, DX, incx)
             DX
@@ -328,7 +324,7 @@ for (fname, elty) in ((:cblas_ddot,:Float64),
                 # *     .. Array Arguments ..
                 #       DOUBLE PRECISION DX(*),DY(*)
         function dot(n::Integer, DX::Union{Ptr{$elty},AbstractArray{$elty}}, incx::Integer, DY::Union{Ptr{$elty},AbstractArray{$elty}}, incy::Integer)
-            ccall((@blasfunc($fname), lbt), $elty,
+            ccall((@blasfunc($fname), libblastrampoline), $elty,
                 (BlasInt, Ptr{$elty}, BlasInt, Ptr{$elty}, BlasInt),
                  n, DX, incx, DY, incy)
         end
@@ -345,7 +341,7 @@ for (fname, elty) in ((:cblas_zdotc_sub,:ComplexF64),
                 #       DOUBLE PRECISION DX(*),DY(*)
         function dotc(n::Integer, DX::Union{Ptr{$elty},AbstractArray{$elty}}, incx::Integer, DY::Union{Ptr{$elty},AbstractArray{$elty}}, incy::Integer)
             result = Ref{$elty}()
-            ccall((@blasfunc($fname), lbt), Cvoid,
+            ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                 (BlasInt, Ptr{$elty}, BlasInt, Ptr{$elty}, BlasInt, Ptr{$elty}),
                  n, DX, incx, DY, incy, result)
             result[]
@@ -363,7 +359,7 @@ for (fname, elty) in ((:cblas_zdotu_sub,:ComplexF64),
                 #       DOUBLE PRECISION DX(*),DY(*)
         function dotu(n::Integer, DX::Union{Ptr{$elty},AbstractArray{$elty}}, incx::Integer, DY::Union{Ptr{$elty},AbstractArray{$elty}}, incy::Integer)
             result = Ref{$elty}()
-            ccall((@blasfunc($fname), lbt), Cvoid,
+            ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                 (BlasInt, Ptr{$elty}, BlasInt, Ptr{$elty}, BlasInt, Ptr{$elty}),
                  n, DX, incx, DY, incy, result)
             result[]
@@ -408,7 +404,7 @@ for (fname, elty, ret_type) in ((:dnrm2_,:Float64,:Float64),
     @eval begin
         # SUBROUTINE DNRM2(N,X,INCX)
         function nrm2(n::Integer, X::Union{Ptr{$elty},AbstractArray{$elty}}, incx::Integer)
-            ccall((@blasfunc($fname), lbt), $ret_type,
+            ccall((@blasfunc($fname), libblastrampoline), $ret_type,
                 (Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}),
                  n, X, incx)
         end
@@ -449,7 +445,7 @@ for (fname, elty, ret_type) in ((:dasum_,:Float64,:Float64),
     @eval begin
         # SUBROUTINE ASUM(N, X, INCX)
         function asum(n::Integer, X::Union{Ptr{$elty},AbstractArray{$elty}}, incx::Integer)
-            ccall((@blasfunc($fname), lbt), $ret_type,
+            ccall((@blasfunc($fname), libblastrampoline), $ret_type,
                 (Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}),
                  n, X, incx)
         end
@@ -495,7 +491,7 @@ for (fname, elty) in ((:daxpy_,:Float64),
                 #*     .. Array Arguments ..
                 #      DOUBLE PRECISION DX(*),DY(*)
         function axpy!(n::Integer, alpha::($elty), dx::Union{Ptr{$elty}, AbstractArray{$elty}}, incx::Integer, dy::Union{Ptr{$elty}, AbstractArray{$elty}}, incy::Integer)
-            ccall((@blasfunc($fname), lbt), Cvoid,
+            ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                 (Ref{BlasInt}, Ref{$elty}, Ptr{$elty}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}),
                  n, alpha, dx, incx, dy, incy)
             dy
@@ -566,7 +562,7 @@ for (fname, elty) in ((:daxpby_,:Float64), (:saxpby_,:Float32),
         function axpby!(n::Integer, alpha::($elty), dx::Union{Ptr{$elty},
                         AbstractArray{$elty}}, incx::Integer, beta::($elty),
                         dy::Union{Ptr{$elty}, AbstractArray{$elty}}, incy::Integer)
-            ccall((@blasfunc($fname), lbt), Cvoid, (Ref{BlasInt}, Ref{$elty}, Ptr{$elty},
+            ccall((@blasfunc($fname), libblastrampoline), Cvoid, (Ref{BlasInt}, Ref{$elty}, Ptr{$elty},
                 Ref{BlasInt}, Ref{$elty}, Ptr{$elty}, Ref{BlasInt}),
                 n, alpha, dx, incx, beta, dy, incy)
             dy
@@ -591,7 +587,7 @@ for (fname, elty) in ((:idamax_,:Float64),
                       (:icamax_,:ComplexF32))
     @eval begin
         function iamax(n::Integer, dx::Union{Ptr{$elty}, AbstractArray{$elty}}, incx::Integer)
-            ccall((@blasfunc($fname), lbt),BlasInt,
+            ccall((@blasfunc($fname), libblastrampoline),BlasInt,
                 (Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}),
                 n, dx, incx)
         end
@@ -651,7 +647,7 @@ for (fname, elty) in ((:dgemv_,:Float64),
             end
             lda >= size(A,1) || size(A,2) <= 1 || error("when `size(A,2) > 1`, `abs(stride(A,2))` must be at least `size(A,1)`")
             lda = max(1, size(A,1), lda)
-            GC.@preserve A X Y ccall((@blasfunc($fname), lbt), Cvoid,
+            GC.@preserve A X Y ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                 (Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{$elty},
                  Ptr{$elty}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt},
                  Ref{$elty}, Ptr{$elty}, Ref{BlasInt}, Clong),
@@ -733,7 +729,7 @@ for (fname, elty) in ((:dgbmv_,:Float64),
             chkstride1(A)
             px, stx = vec_pointer_stride(x, ArgumentError("input vector with 0 stride is not allowed"))
             py, sty = vec_pointer_stride(y, ArgumentError("dest vector with 0 stride is not allowed"))
-            GC.@preserve x y ccall((@blasfunc($fname), lbt), Cvoid,
+            GC.@preserve x y ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                 (Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{BlasInt},
                  Ref{BlasInt}, Ref{$elty}, Ptr{$elty}, Ref{BlasInt},
                  Ptr{$elty}, Ref{BlasInt}, Ref{$elty}, Ptr{$elty},
@@ -765,10 +761,10 @@ Only the [`ul`](@ref stdlib-blas-uplo) triangle of `A` is used.
 """
 function symv! end
 
-for (fname, elty, lib) in ((:dsymv_,:Float64,lbt),
-                           (:ssymv_,:Float32,lbt),
-                           (:zsymv_,:ComplexF64,lbt),
-                           (:csymv_,:ComplexF32,lbt))
+for (fname, elty, lib) in ((:dsymv_,:Float64,libblastrampoline),
+                           (:ssymv_,:Float32,libblastrampoline),
+                           (:zsymv_,:ComplexF64,libblastrampoline),
+                           (:csymv_,:ComplexF32,libblastrampoline))
     # Note that the complex symv are not BLAS but auiliary functions in LAPACK
     @eval begin
              #      SUBROUTINE DSYMV(UPLO,N,ALPHA,A,LDA,X,INCX,BETA,Y,INCY)
@@ -861,7 +857,7 @@ for (fname, elty) in ((:zhemv_,:ComplexF64),
             lda = max(1, stride(A, 2))
             px, stx = vec_pointer_stride(x, ArgumentError("input vector with 0 stride is not allowed"))
             py, sty = vec_pointer_stride(y, ArgumentError("dest vector with 0 stride is not allowed"))
-            GC.@preserve x y ccall((@blasfunc($fname), lbt), Cvoid,
+            GC.@preserve x y ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                 (Ref{UInt8}, Ref{BlasInt}, Ref{$elty}, Ptr{$elty},
                  Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}, Ref{$elty},
                  Ptr{$elty}, Ref{BlasInt}, Clong),
@@ -918,7 +914,7 @@ for (fname, elty) in ((:zhpmv_, :ComplexF64),
                        y::Union{Ptr{$elty}, AbstractArray{$elty}},
                        incy::Integer)
 
-            ccall((@blasfunc($fname), lbt), Cvoid,
+            ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                   (Ref{UInt8},     # uplo,
                    Ref{BlasInt},   # n,
                    Ref{$elty},     # α,
@@ -1003,7 +999,7 @@ for (fname, elty) in ((:dsbmv_,:Float64),
             chkstride1(A)
             px, stx = vec_pointer_stride(x, ArgumentError("input vector with 0 stride is not allowed"))
             py, sty = vec_pointer_stride(y, ArgumentError("dest vector with 0 stride is not allowed"))
-            GC.@preserve x y ccall((@blasfunc($fname), lbt), Cvoid,
+            GC.@preserve x y ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                 (Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{$elty},
                  Ptr{$elty}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt},
                  Ref{$elty}, Ptr{$elty}, Ref{BlasInt}, Clong),
@@ -1075,7 +1071,7 @@ for (fname, elty) in ((:dspmv_, :Float64),
                        y::Union{Ptr{$elty}, AbstractArray{$elty}},
                        incy::Integer)
 
-            ccall((@blasfunc($fname), lbt), Cvoid,
+            ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                   (Ref{UInt8},     # uplo,
                    Ref{BlasInt},   # n,
                    Ref{$elty},     # α,
@@ -1154,7 +1150,7 @@ for (fname, elty) in ((:dspr_, :Float64),
                       incx::Integer,
                       AP::Union{Ptr{$elty}, AbstractArray{$elty}})
 
-            ccall((@blasfunc($fname), lbt), Cvoid,
+            ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                   (Ref{UInt8},     # uplo,
                    Ref{BlasInt},   # n,
                    Ref{$elty},     # α,
@@ -1228,7 +1224,7 @@ for (fname, elty) in ((:zhbmv_,:ComplexF64),
             chkstride1(A)
             px, stx = vec_pointer_stride(x, ArgumentError("input vector with 0 stride is not allowed"))
             py, sty = vec_pointer_stride(y, ArgumentError("dest vector with 0 stride is not allowed"))
-            GC.@preserve x y ccall((@blasfunc($fname), lbt), Cvoid,
+            GC.@preserve x y ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                 (Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{$elty},
                  Ptr{$elty}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt},
                  Ref{$elty}, Ptr{$elty}, Ref{BlasInt}, Clong),
@@ -1290,7 +1286,7 @@ for (fname, elty) in ((:dtrmv_,:Float64),
             end
             chkstride1(A)
             px, stx = vec_pointer_stride(x, ArgumentError("input vector with 0 stride is not allowed"))
-            GC.@preserve x ccall((@blasfunc($fname), lbt), Cvoid,
+            GC.@preserve x ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                 (Ref{UInt8}, Ref{UInt8}, Ref{UInt8}, Ref{BlasInt},
                  Ptr{$elty}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt},
                  Clong, Clong, Clong),
@@ -1347,7 +1343,7 @@ for (fname, elty) in ((:dtrsv_,:Float64),
             end
             chkstride1(A)
             px, stx = vec_pointer_stride(x, ArgumentError("input vector with 0 stride is not allowed"))
-            GC.@preserve x ccall((@blasfunc($fname), lbt), Cvoid,
+            GC.@preserve x ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                 (Ref{UInt8}, Ref{UInt8}, Ref{UInt8}, Ref{BlasInt},
                  Ptr{$elty}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt},
                  Clong, Clong, Clong),
@@ -1383,7 +1379,7 @@ for (fname, elty) in ((:dger_,:Float64),
             end
             px, stx = vec_pointer_stride(x, ArgumentError("input vector with 0 stride is not allowed"))
             py, sty = vec_pointer_stride(y, ArgumentError("input vector with 0 stride is not allowed"))
-            GC.@preserve x y ccall((@blasfunc($fname), lbt), Cvoid,
+            GC.@preserve x y ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                 (Ref{BlasInt}, Ref{BlasInt}, Ref{$elty}, Ptr{$elty},
                  Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}, Ptr{$elty},
                  Ref{BlasInt}),
@@ -1403,10 +1399,10 @@ Rank-1 update of the symmetric matrix `A` with vector `x` as `alpha*x*transpose(
 """
 function syr! end
 
-for (fname, elty, lib) in ((:dsyr_,:Float64,lbt),
-                           (:ssyr_,:Float32,lbt),
-                           (:zsyr_,:ComplexF64,lbt),
-                           (:csyr_,:ComplexF32,lbt))
+for (fname, elty, lib) in ((:dsyr_,:Float64,libblastrampoline),
+                           (:ssyr_,:Float32,libblastrampoline),
+                           (:zsyr_,:ComplexF64,libblastrampoline),
+                           (:csyr_,:ComplexF32,libblastrampoline))
     @eval begin
         function syr!(uplo::AbstractChar, α::$elty, x::AbstractVector{$elty}, A::AbstractMatrix{$elty})
             chkuplo(uplo)
@@ -1447,7 +1443,7 @@ for (fname, elty, relty) in ((:zher_,:ComplexF64, :Float64),
                 throw(DimensionMismatch(lazy"A has size ($n,$n), x has length $(length(x))"))
             end
             px, stx = vec_pointer_stride(x, ArgumentError("input vector with 0 stride is not allowed"))
-            GC.@preserve x ccall((@blasfunc($fname), lbt), Cvoid,
+            GC.@preserve x ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                 (Ref{UInt8}, Ref{BlasInt}, Ref{$relty}, Ptr{$elty},
                  Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}, Clong),
                  uplo, n, α, px, stx, A, max(1,stride(A,2)), 1)
@@ -1499,7 +1495,7 @@ for (gemm, elty) in
             chkstride1(A)
             chkstride1(B)
             chkstride1(C)
-            ccall((@blasfunc($gemm), lbt), Cvoid,
+            ccall((@blasfunc($gemm), libblastrampoline), Cvoid,
                 (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt},
                  Ref{BlasInt}, Ref{$elty}, Ptr{$elty}, Ref{BlasInt},
                  Ptr{$elty}, Ref{BlasInt}, Ref{$elty}, Ptr{$elty},
@@ -1563,7 +1559,7 @@ for (mfname, elty) in ((:dsymm_,:Float64),
             chkstride1(A)
             chkstride1(B)
             chkstride1(C)
-            ccall((@blasfunc($mfname), lbt), Cvoid,
+            ccall((@blasfunc($mfname), libblastrampoline), Cvoid,
                 (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt},
                  Ref{$elty}, Ptr{$elty}, Ref{BlasInt}, Ptr{$elty},
                  Ref{BlasInt}, Ref{$elty}, Ptr{$elty}, Ref{BlasInt},
@@ -1637,7 +1633,7 @@ for (mfname, elty) in ((:zhemm_,:ComplexF64),
             chkstride1(A)
             chkstride1(B)
             chkstride1(C)
-            ccall((@blasfunc($mfname), lbt), Cvoid,
+            ccall((@blasfunc($mfname), libblastrampoline), Cvoid,
                 (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt},
                  Ref{$elty}, Ptr{$elty}, Ref{BlasInt}, Ptr{$elty},
                  Ref{BlasInt}, Ref{$elty}, Ptr{$elty}, Ref{BlasInt},
@@ -1727,7 +1723,7 @@ for (fname, elty) in ((:dsyrk_,:Float64),
             k  = size(A, trans == 'N' ? 2 : 1)
             chkstride1(A)
             chkstride1(C)
-            ccall((@blasfunc($fname), lbt), Cvoid,
+            ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                   (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt},
                    Ref{$elty}, Ptr{$elty}, Ref{BlasInt}, Ref{$elty},
                    Ptr{$elty}, Ref{BlasInt}, Clong, Clong),
@@ -1786,7 +1782,7 @@ for (fname, elty, relty) in ((:zherk_, :ComplexF64, :Float64),
             chkstride1(A)
             chkstride1(C)
             k  = size(A, trans == 'N' ? 2 : 1)
-            ccall((@blasfunc($fname), lbt), Cvoid,
+            ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                     (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt},
                     Ref{$relty}, Ptr{$elty}, Ref{BlasInt}, Ref{$relty},
                     Ptr{$elty}, Ref{BlasInt}, Clong, Clong),
@@ -1830,7 +1826,7 @@ for (fname, elty) in ((:dsyr2k_,:Float64),
             chkstride1(A)
             chkstride1(B)
             chkstride1(C)
-            ccall((@blasfunc($fname), lbt), Cvoid,
+            ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                 (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt},
                  Ref{$elty}, Ptr{$elty}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}, Ref{$elty},
                  Ptr{$elty}, Ref{BlasInt}, Clong, Clong),
@@ -1898,7 +1894,7 @@ for (fname, elty1, elty2) in ((:zher2k_,:ComplexF64,:Float64), (:cher2k_,:Comple
             chkstride1(B)
             chkstride1(C)
             k  = size(A, trans == 'N' ? 2 : 1)
-            ccall((@blasfunc($fname), lbt), Cvoid,
+            ccall((@blasfunc($fname), libblastrampoline), Cvoid,
                     (Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt},
                     Ref{$elty1}, Ptr{$elty1}, Ref{BlasInt}, Ptr{$elty1}, Ref{BlasInt},
                     Ref{$elty2},  Ptr{$elty1}, Ref{BlasInt}, Clong, Clong),
@@ -2014,7 +2010,7 @@ for (mmname, smname, elty) in
             end
             chkstride1(A)
             chkstride1(B)
-            ccall((@blasfunc($mmname), lbt), Cvoid,
+            ccall((@blasfunc($mmname), libblastrampoline), Cvoid,
                   (Ref{UInt8}, Ref{UInt8}, Ref{UInt8}, Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt},
                    Ref{$elty}, Ptr{$elty}, Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt},
                    Clong, Clong, Clong, Clong),
@@ -2045,7 +2041,7 @@ for (mmname, smname, elty) in
             end
             chkstride1(A)
             chkstride1(B)
-            ccall((@blasfunc($smname), lbt), Cvoid,
+            ccall((@blasfunc($smname), libblastrampoline), Cvoid,
                    (Ref{UInt8}, Ref{UInt8}, Ref{UInt8}, Ref{UInt8},
                     Ref{BlasInt}, Ref{BlasInt}, Ref{$elty}, Ptr{$elty},
                     Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt},

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -668,10 +668,6 @@ end
     @test BLAS.get_num_threads() === default
 end
 
-# https://github.com/JuliaLang/julia/pull/39845
-@test LinearAlgebra.BLAS.libblas == "libblastrampoline"
-@test LinearAlgebra.BLAS.liblapack == "libblastrampoline"
-
 @testset "test for 0-strides" for elty in (Float32, Float64, ComplexF32, ComplexF64)
     A = randn(elty, 10, 10);
     a = view([randn(elty)], 1 .+ 0(1:10))

--- a/stdlib/LinearAlgebra/test/lapack.jl
+++ b/stdlib/LinearAlgebra/test/lapack.jl
@@ -702,9 +702,6 @@ let A = [NaN NaN; NaN NaN]
     @test_throws ArgumentError eigen(A)
 end
 
-# # https://github.com/JuliaLang/julia/pull/39845
-@test LinearAlgebra.LAPACK.liblapack == "libblastrampoline"
-
 # Issue #42762 https://github.com/JuliaLang/julia/issues/42762
 # Tests geqrf! and gerqf! with null column dimensions
 a = zeros(2,0), zeros(0)

--- a/stdlib/libblastrampoline_jll/Project.toml
+++ b/stdlib/libblastrampoline_jll/Project.toml
@@ -5,7 +5,6 @@ version = "5.0.1+0"
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
-OpenBLAS_jll = "4536629a-c528-5b80-bd46-f80d51c5b363"
 
 [compat]
 julia = "1.8"

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -359,10 +359,10 @@ precompile_test_harness(false) do dir
             Dict(let m = Base.root_module(Base, s)
                      Base.PkgId(m) => Base.module_build_id(m)
                  end for s in
-                [:ArgTools, :Artifacts, :Base64, :CRC32c, :Dates, :DelimitedFiles,
-                 :Distributed, :Downloads, :FileWatching, :Future, :InteractiveUtils,
+                [:ArgTools, :Artifacts, :Base64, :CompilerSupportLibraries_jll, :CRC32c, :Dates, :DelimitedFiles,
+                 :Distributed, :Downloads, :FileWatching, :Future, :InteractiveUtils, :libblastrampoline_jll,
                  :LazyArtifacts, :LibCURL, :LibCURL_jll, :LibGit2, :Libdl, :LinearAlgebra,
-                 :Logging, :Markdown, :Mmap, :MozillaCACerts_jll, :NetworkOptions, :Pkg, :Printf,
+                 :Logging, :Markdown, :Mmap, :MozillaCACerts_jll, :NetworkOptions, :OpenBLAS_jll, :Pkg, :Printf,
                  :Profile, :p7zip_jll, :REPL, :Random, :SHA, :Serialization, :SharedArrays, :Sockets,
                  :SparseArrays, :Statistics, :SuiteSparse, :TOML, :Tar, :Test, :UUIDs, :Unicode,
                  :nghttp2_jll]


### PR DESCRIPTION
We traditionally hardcode `libblas_name` and `liblapack_name` into the system image. These do not get updated, even when you use an alternate set of libraries through MKL.jl. `build_h.jl` was reporting different names than what was in the BLAS and LAPACK modules in LinearAlgebra.

Now that we use LBT, it is best to mention `libblastrampoline` as the provider of these libraries. This revealed a lot of old code that could be simplified and cleaned up.

Perhaps we can remove these things altogether from build_h.jl, since these are no longer build time choices, but runtime ones.

Also undo the compatibility symbols added in #39845 - since the new APIs now have been around for a while.

cc @staticfloat 