### PR TITLE
Allow constructing WorkerPool from AbstractRange{Int}

### DIFF
--- a/stdlib/Distributed/src/workerpool.jl
+++ b/stdlib/Distributed/src/workerpool.jl
@@ -33,9 +33,9 @@ function WorkerPool()
 end
 
 """
-    WorkerPool(workers::Vector{Int})
+    WorkerPool(workers::Union{Vector{Int},AbstractRange{Int}})
 
-Create a `WorkerPool` from a vector of worker ids.
+Create a `WorkerPool` from a vector or range of worker ids.
 
 # Examples
 ```julia-repl
@@ -43,9 +43,11 @@ Create a `WorkerPool` from a vector of worker ids.
 
 julia> WorkerPool([2, 3])
 WorkerPool(Channel{Int64}(sz_max:9223372036854775807,sz_curr:2), Set([2, 3]), RemoteChannel{Channel{Any}}(1, 1, 6))
+julia> WorkerPool(2:4)
+WorkerPool(Channel{Int64}(sz_max:9223372036854775807,sz_curr:2), Set([4, 2, 3]), RemoteChannel{Channel{Any}}(1, 1, 7))
 ```
 """
-function WorkerPool(workers::Vector{Int})
+function WorkerPool(workers::Union{Vector{Int},AbstractRange{Int}})
     pool = WorkerPool()
     foreach(w->push!(pool, w), workers)
     return pool

--- a/stdlib/Distributed/src/workerpool.jl
+++ b/stdlib/Distributed/src/workerpool.jl
@@ -43,6 +43,7 @@ Create a `WorkerPool` from a vector or range of worker ids.
 
 julia> WorkerPool([2, 3])
 WorkerPool(Channel{Int64}(sz_max:9223372036854775807,sz_curr:2), Set([2, 3]), RemoteChannel{Channel{Any}}(1, 1, 6))
+
 julia> WorkerPool(2:4)
 WorkerPool(Channel{Int64}(sz_max:9223372036854775807,sz_curr:2), Set([4, 2, 3]), RemoteChannel{Channel{Any}}(1, 1, 7))
 ```

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -666,7 +666,8 @@ pmap(_->myid(), 1:nworkers())  # priming run
 wp = WorkerPool(workers())
 @test nworkers() == length(unique(pmap(_->myid(), wp, 1:100)))
 @test nworkers() == length(unique(remotecall_fetch(wp->pmap(_->myid(), wp, 1:100), id_other, wp)))
-
+wp = WorkerPool(2:3)
+@test sort(unique(pmap(_->myid(), wp, 1:100))) == [2,3]
 
 # CachingPool tests
 wp = CachingPool(workers())


### PR DESCRIPTION
e.g WorkerPool(2:10)

Super trivial quality of life improvement, avoiding an unnecessary `collect`.