### PR TITLE
Remove BLAS.vendor() that was deprecated in 1.7

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -161,6 +161,10 @@ end
 include(strcat((length(Core.ARGS)>=2 ? Core.ARGS[2] : ""), "build_h.jl"))     # include($BUILDROOT/base/build_h.jl)
 include(strcat((length(Core.ARGS)>=2 ? Core.ARGS[2] : ""), "version_git.jl")) # include($BUILDROOT/base/version_git.jl)
 
+# These used to be in build_h.jl and are retained for backwards compatibility
+const libblas_name = "libblastrampoline"
+const liblapack_name = "libblastrampoline"
+
 # numeric operations
 include("hashing.jl")
 include("rounding.jl")

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -77,6 +77,8 @@ Return an object representing the current `libblastrampoline` configuration.
 """
 get_config() = lbt_get_config()
 
+vendor() = error("`vendor()` is deprecated, use `BLAS.get_config()` instead")
+
 if USE_BLAS64
     macro blasfunc(x)
         return Expr(:quote, Symbol(x, "64_"))

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -67,6 +67,8 @@ using ..LinearAlgebra: libblastrampoline, BlasReal, BlasComplex, BlasFloat, Blas
 
 include("lbt.jl")
 
+vendor() = :lbt
+
 """
     get_config()
 

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -77,17 +77,6 @@ Return an object representing the current `libblastrampoline` configuration.
 """
 get_config() = lbt_get_config()
 
-# We hard-lock `vendor()` to `openblas(64)` here to satisfy older code, but all new code should use
-# `get_config()` since it is now possible to have multiple vendors loaded at once.
-function vendor()
-    Base.depwarn("`vendor()` is deprecated, use `BLAS.get_config()` and inspect the output instead", :vendor; force=true)
-    if USE_BLAS64
-        return :openblas64
-    else
-        return :openblas
-    end
-end
-
 if USE_BLAS64
     macro blasfunc(x)
         return Expr(:quote, Symbol(x, "64_"))


### PR DESCRIPTION
`BLAS.vendor()` had a deprecation warning in 1.7 and 1.9. I think it should be ok to remove in 1.9.