### PR TITLE
Fix skipped range test

### DIFF
--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -860,7 +860,7 @@ function range_fuzztests(::Type{T}, niter, nrange) where {T}
         @test m == length(r)
         @test strt == first(r)
         @test Δ == step(r)
-        @test_skip stop ≈ last(r)
+        @test stop ≈ last(r) rtol = 0.001
         l = range(strt, stop=stop, length=n)
         @test n == length(l)
         @test strt == first(l)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -860,7 +860,7 @@ function range_fuzztests(::Type{T}, niter, nrange) where {T}
         @test m == length(r)
         @test strt == first(r)
         @test Δ == step(r)
-        @test stop ≈ last(r) rtol = 0.001
+        @test stop ≈ last(r)
         l = range(strt, stop=stop, length=n)
         @test n == length(l)
         @test strt == first(l)


### PR DESCRIPTION
92% of the 352656 "Broken" tests in Base are attributed with this `@test_skip`, which seems like it was meant to be un-skipped in https://github.com/JuliaLang/julia/pull/43360 where it was channged to a `≈` and passes locally when un-skipped.


It's not addressed in this PR but the next biggest chunk are the 24795 `@test_broken`'s in `test/abstractarray.jl` https://github.com/JuliaLang/julia/blob/394af3850112c67afe118ebbf05d36594bdc85ed/test/abstractarray.jl#L1160

I point this out because between both, that's 99.95% of tests marked as "Broken", which seems a bit disproportionate