### PR TITLE
`AbstractInterpreter`: remove `method_table(::AbstractInterpreter, ::InferenceState)` interface

### DIFF
--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -314,6 +314,13 @@ may_compress(::AbstractInterpreter) = true
 may_discard_trees(::AbstractInterpreter) = true
 verbose_stmt_info(::AbstractInterpreter) = false
 
+"""
+    method_table(interp::AbstractInterpreter) -> MethodTableView
+
+Returns a method table this `interp` uses for method lookup.
+External `AbstractInterpreter` can optionally return `OverlayMethodTable` here
+to incorporate customized dispatches for the overridden methods.
+"""
 method_table(interp::AbstractInterpreter) = InternalMethodTable(get_world_counter(interp))
 
 """

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -142,7 +142,7 @@ function choosetests(choices = [])
     filtertests!(tests, "subarray")
     filtertests!(tests, "compiler", ["compiler/inference", "compiler/validation",
         "compiler/ssair", "compiler/irpasses", "compiler/codegen",
-        "compiler/inline", "compiler/contextual",
+        "compiler/inline", "compiler/contextual", "compiler/AbstractInterpreter",
         "compiler/EscapeAnalysis/local", "compiler/EscapeAnalysis/interprocedural"])
     filtertests!(tests, "compiler/EscapeAnalysis", [
         "compiler/EscapeAnalysis/local", "compiler/EscapeAnalysis/interprocedural"])

--- a/test/compiler/AbstractInterpreter.jl
+++ b/test/compiler/AbstractInterpreter.jl
@@ -1,0 +1,47 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+const CC = Core.Compiler
+import Core: MethodInstance, CodeInstance
+import .CC: WorldRange, WorldView
+
+# define new `AbstractInterpreter` that satisfies the minimum interface requirements
+# while managing its cache independently
+macro newinterp(name)
+    cachename = gensym(string(name, "Cache"))
+    name = esc(name)
+    quote
+        struct $cachename
+            dict::IdDict{MethodInstance,CodeInstance}
+        end
+        struct $name <: CC.AbstractInterpreter
+            interp::CC.NativeInterpreter
+            cache::$cachename
+            $name(world = Base.get_world_counter();
+                interp = CC.NativeInterpreter(world),
+                cache = $cachename(IdDict{MethodInstance,CodeInstance}())
+                ) = new(interp, cache)
+        end
+        CC.InferenceParams(interp::$name) = CC.InferenceParams(interp.interp)
+        CC.OptimizationParams(interp::$name) = CC.OptimizationParams(interp.interp)
+        CC.get_world_counter(interp::$name) = CC.get_world_counter(interp.interp)
+        CC.get_inference_cache(interp::$name) = CC.get_inference_cache(interp.interp)
+        CC.code_cache(interp::$name) = WorldView(interp.cache, WorldRange(CC.get_world_counter(interp)))
+        CC.get(wvc::WorldView{<:$cachename}, mi::MethodInstance, default) = get(wvc.cache.dict, mi, default)
+        CC.getindex(wvc::WorldView{<:$cachename}, mi::MethodInstance) = getindex(wvc.cache.dict, mi)
+        CC.haskey(wvc::WorldView{<:$cachename}, mi::MethodInstance) = haskey(wvc.cache.dict, mi)
+        CC.setindex!(wvc::WorldView{<:$cachename}, ci::CodeInstance, mi::MethodInstance) = setindex!(wvc.cache.dict, ci, mi)
+    end
+end
+
+# `OverlayMethodTable`
+# --------------------
+import Base.Experimental: @MethodTable, @overlay
+
+@newinterp MTOverlayInterp
+@MethodTable(OverlayedMT)
+CC.method_table(interp::MTOverlayInterp) = CC.OverlayMethodTable(CC.get_world_counter(interp), OverlayedMT)
+
+@overlay OverlayedMT sin(x::Float64) = 1
+@test Base.return_types((Int,), MTOverlayInterp()) do x
+    sin(x)
+end == Any[Int]


### PR DESCRIPTION
In https://github.com/JuliaLang/julia/pull/44240 we removed the `CachedMethodTable` support as it turned out to
be ineffective under the current compiler infrastructure.
Because of this, there is no strong reason to keep a method table per `InferenceState`.
This commit simply removes the `method_table(::AbstractInterpreter, ::InferenceState)`
interface and should make it clearer which interface needs to be overloaded to
implement a contextual dispatch.