### PR TITLE
Improve inference in typejoin

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -766,7 +766,7 @@ function invoke_in_world(world::UInt, @nospecialize(f), @nospecialize args...; k
 end
 
 # TODO: possibly make this an intrinsic
-inferencebarrier(@nospecialize(x)) = Ref{Any}(x)[]
+inferencebarrier(@nospecialize(x)) = RefValue{Any}(x).x
 
 """
     isempty(collection) -> Bool

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -33,7 +33,7 @@ function typejoin(@nospecialize(a), @nospecialize(b))
         if !(b <: Tuple)
             return Any
         end
-        ap, bp = a.parameters::Core.SimpleVector, b.parameters::Core.SimpleVector
+        ap, bp = a.parameters, b.parameters
         lar = length(ap)
         lbr = length(bp)
         if lar == 0
@@ -207,16 +207,17 @@ function typejoin_union_tuple(T::DataType)
 end
 
 # Returns length, isfixed
-function full_va_len(p)
+function full_va_len(p::Core.SimpleVector)
     isempty(p) && return 0, true
     last = p[end]
     if isvarargtype(last)
-        if isdefined(last, :N) && isa(last.N, Int)
-            return length(p)::Int + last.N - 1, true
+        if isdefined(last, :N)
+            N = last.N
+            isa(N, Int) && return length(p) + N - 1, true
         end
-        return length(p)::Int, false
+        return length(p), false
     end
-    return length(p)::Int, true
+    return length(p), true
 end
 
 # reduce typejoin over A[i:end]

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -29,11 +29,15 @@ function typejoin(@nospecialize(a), @nospecialize(b))
         return typejoin(typejoin(a.a, a.b), b)
     elseif isa(b, Union)
         return typejoin(a, typejoin(b.a, b.b))
-    elseif a <: Tuple
+    end
+    # a and b are DataTypes
+    # We have to hide Constant info from inference, see #44390
+    a, b = inferencebarrier(a)::DataType, inferencebarrier(b)::DataType
+    if a <: Tuple
         if !(b <: Tuple)
             return Any
         end
-        ap, bp = a.parameters::Core.SimpleVector, b.parameters::Core.SimpleVector
+        ap, bp = a.parameters, b.parameters
         lar = length(ap)
         lbr = length(bp)
         if lar == 0
@@ -77,8 +81,6 @@ function typejoin(@nospecialize(a), @nospecialize(b))
     elseif b <: Tuple
         return Any
     end
-    # We have to hide Constant info from inference, see #44390
-    a, b = inferencebarrier(a)::DataType, inferencebarrier(b)::DataType
     while b !== Any
         if a <: b.name.wrapper
             while a.name !== b.name

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -33,7 +33,7 @@ function typejoin(@nospecialize(a), @nospecialize(b))
         if !(b <: Tuple)
             return Any
         end
-        ap, bp = a.parameters, b.parameters
+        ap, bp = a.parameters::Core.SimpleVector, b.parameters::Core.SimpleVector
         lar = length(ap)
         lbr = length(bp)
         if lar == 0
@@ -77,7 +77,8 @@ function typejoin(@nospecialize(a), @nospecialize(b))
     elseif b <: Tuple
         return Any
     end
-    a, b = a::DataType, b::DataType
+    # We have to hide Constant info from inference, see #44390
+    a, b = inferencebarrier(a)::DataType, inferencebarrier(b)::DataType
     while b !== Any
         if a <: b.name.wrapper
             while a.name !== b.name


### PR DESCRIPTION
This fixes hundreds of `promote_rule` invalidations from Unitful. Discovered in a conversation with @louisponet 

@aviatesk, inference of `typejoin` in one case shows an interesting phenomenon:

```julia
descend(typejoin, (Type{Int}, Any); optimize=false, iswarn=true)
```
reveals that inference fails to discover that `a.name` returns a `TypeName` and `a.parameters` returns a `SimpleVector`. AFAICT the `Const` annotation interferes with knowing that `a` behaves as a `DataType`. Is this easily fixable or should I add some annotations?