### PR TITLE
Add API for `atomicget`, `atomicset!`, `atomicmodify!`  and high-level API for `AtomicRef`

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -57,6 +57,15 @@ modifyproperty!(x, f::Symbol, op, v, order::Symbol=:notatomic) =
 replaceproperty!(x, f::Symbol, expected, desired, success_order::Symbol=:notatomic, fail_order::Symbol=success_order) =
     (@inline; Core.replacefield!(x, f, expected, convert(fieldtype(typeof(x), f), desired), success_order, fail_order))
 
+function asatomicref end
+atomicget(ref) = (@inline; atomicget(ref, :sequentially_consistent))
+atomicset!(ref, value) = (@inline; atomicset!(ref, value, :sequentially_consistent))
+atomicswap!(ref, value) = (@inline; atomicswap!(ref, value, :sequentially_consistent))
+atomicmodify!(ref, op::OP, value) where {OP} =
+    (@inline; atomicmodify!(ref, op, value, :sequentially_consistent))
+atomicreplace!(ref, expected, desired, order::Symbol = :sequentially_consistent) =
+    (@inline; atomicreplace!(ref, expected, desired, order, order))
+
 convert(::Type{Any}, Core.@nospecialize x) = x
 convert(::Type{T}, x::T) where {T} = x
 include("coreio.jl")

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -289,3 +289,13 @@ end
 @deprecate getindex(t::Tuple, i::Real) t[convert(Int, i)]
 
 # END 1.8 deprecations
+
+# BEGIN 1.9 deprecations
+
+# Workaround that `@deprecate` does not handle `Threads.Atomic()`
+module _DeprecateThreads
+import Base.Threads: Atomic
+@deprecate Atomic() Atomic{Int}() false
+end
+
+# END 1.9 deprecations

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -250,9 +250,9 @@ using Base.Threads
 end
 end
 
-# Ensure only LLVM-supported types can be atomic
-@test_throws TypeError Atomic{BigInt}
-@test_throws TypeError Atomic{ComplexF64}
+# Ensure only LLVM-supported types support nullary constructor
+@test_throws MethodError Atomic{BigInt}()
+@test_throws MethodError Atomic{ComplexF64}()
 
 if Sys.ARCH == :i686 || startswith(string(Sys.ARCH), "arm") ||
    Sys.ARCH === :powerpc64le || Sys.ARCH === :ppc64le

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -79,7 +79,7 @@ end
 function test_threaded_loop_and_atomic_add()
     for r in [1:10000, collect(1:10000), Base.IdentityUnitRange(-500:500), (1,2,3,4,5,6,7,8,9,10)]
         n = length(r)
-        x = Atomic()
+        x = Atomic{Int}()
         a = zeros(Int, n)
         threaded_loop(a,r,x)
         found = zeros(Bool,n)
@@ -140,7 +140,7 @@ function threaded_add_locked(::Type{LockT}, x, n) where LockT
     end
     @test !islocked(critical)
     nentered = 0
-    nfailed = Atomic()
+    nfailed = Atomic{Int}()
     @threads for i = 1:n
         if trylock(critical)
             @test islocked(critical)
@@ -562,7 +562,7 @@ end
 test_nested_loops()
 
 function test_thread_too_few_iters()
-    x = Atomic()
+    x = Atomic{Int}()
     a = zeros(Int, nthreads()+2)
     threaded_loop(a, 1:nthreads()-1, x)
     found = zeros(Bool, nthreads()+2)


### PR DESCRIPTION
While writing code like #44387, I often find myself needing a single atomic location. It's very simple to write a `struct` with a single field using `@atomic` but it'd be nice to have a `Ref`-like API that can be used to store single value. We already do have `Threads.Atomic` but it is defined only for builtin types and it does not support `@atomic` API for specifying the ordering.

So, this PR adds a support for the `@atomic` API on `Threads.Atomic` so that we can do

```julia
julia> ref = Threads.Atomic{Any}(nothing)
Base.Threads.Atomic{Any}(nothing)

julia> @atomic ref[] = [1];

julia> @atomic ref[]
1-element Vector{Int64}:
 1
```

The secondary but also important aim in this PR is to support indexing as a way to specify the memory location and make it extensible. This is required for solving issues like https://github.com/JuliaGPU/CUDA.jl/issues/48 and https://github.com/JuliaGPU/CUDA.jl/issues/995 where it is required to add atomic operations on custom arrays. (cc @maleadt @jpsamaroo @vchuravy) Here's how I lower an atomic indexing op:

```julia
julia> @macroexpand @atomic x[mix(i,end)] += 1
:((Base.atomicmodify!((Base.asatomicref(x))[mix(i, end)], +, 1, :sequentially_consistent))[2])
```

For example, if `x isa AbstractArray{T,N}`, the new API `asatomicref(x)` may return a wrapper array `AbstractArray{<:AtomicRef{T},N}` where `AtomicRef{T}` is a `Ref`-like object that may implement `atomicget`, `atomicset!,` `atomicmodify!`, etc. The extra indirection `asatomicref` is for letting the usual array index machinery to handle complex indexing like `x[mix(i,end)]`. See the docstring of these APIs for more info.

I've already tried this approach in https://github.com/JuliaConcurrent/AtomicArrays.jl and I could use it for implementing `@atomic` interface for an `Array` wrapper and CUDA.jl https://github.com/JuliaConcurrent/AtomicArrays.jl/pull/3.

If the general direction of this PR is fine, I need to tweak some existing documentation:

- [ ] Mention that we still keep `Threads.Atomic` API (I think we started discouraging `Threads.Atomic` after 1.7 somewhere)
- [ ] Discourage `Threads.atomic_*` API in the documentation and show how to translate to the new API
- [ ] Include the new API in the documentation