### PR TITLE
Speed up fieldtype_tfunc for Union fields

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1002,7 +1002,7 @@ swapfield!_tfunc(o, f, v) = (@nospecialize; getfield_tfunc(o, f))
 modifyfield!_tfunc(o, f, op, v, order) = (@nospecialize; modifyfield!_tfunc(o, f, op, v))
 function modifyfield!_tfunc(o, f, op, v)
     @nospecialize
-    T = _fieldtype_tfunc(o, isconcretetype(o), f)
+    T = _fieldtype_tfunc(o, isconcretetype(o), isa(o, Const) || hasuniquerep(o), f)
     T === Bottom && return Bottom
     PT = Const(Pair)
     return instanceof_tfunc(apply_type_tfunc(PT, T, T))[1]
@@ -1042,7 +1042,7 @@ replacefield!_tfunc(o, f, x, v, success_order, failure_order) = (@nospecialize; 
 replacefield!_tfunc(o, f, x, v, success_order) = (@nospecialize; replacefield!_tfunc(o, f, x, v))
 function replacefield!_tfunc(o, f, x, v)
     @nospecialize
-    T = _fieldtype_tfunc(o, isconcretetype(o), f)
+    T = _fieldtype_tfunc(o, isconcretetype(o), isa(o, Const) || hasuniquerep(o), f)
     T === Bottom && return Bottom
     PT = Const(ccall(:jl_apply_cmpswap_type, Any, (Any,), T) where T)
     return instanceof_tfunc(apply_type_tfunc(PT, T))[1]
@@ -1140,15 +1140,15 @@ function fieldtype_tfunc(@nospecialize(s0), @nospecialize(name))
 
     s, exact = instanceof_tfunc(s0)
     s === Bottom && return Bottom
-    return _fieldtype_tfunc(s, exact, name)
+    return _fieldtype_tfunc(s, exact, isa(s0, Const) || hasuniquerep(s0), name)
 end
 
-function _fieldtype_tfunc(@nospecialize(s), exact::Bool, @nospecialize(name))
+function _fieldtype_tfunc(@nospecialize(s), exact::Bool, s_uniquerep::Bool, @nospecialize(name))
     exact = exact && !has_free_typevars(s)
     u = unwrap_unionall(s)
     if isa(u, Union)
-        ta0 = _fieldtype_tfunc(rewrap_unionall(u.a, s), exact, name)
-        tb0 = _fieldtype_tfunc(rewrap_unionall(u.b, s), exact, name)
+        ta0 = _fieldtype_tfunc(rewrap_unionall(u.a, s), exact, s_uniquerep, name)
+        tb0 = _fieldtype_tfunc(rewrap_unionall(u.b, s), exact, s_uniquerep, name)
         ta0 ⊑ tb0 && return tb0
         tb0 ⊑ ta0 && return ta0
         ta, exacta, _, istypea = instanceof_tfunc(ta0)
@@ -1230,15 +1230,16 @@ function _fieldtype_tfunc(@nospecialize(s), exact::Bool, @nospecialize(name))
         return Const(ft)
     end
 
-    exactft = exact || (!has_free_typevars(ft) && u.name !== Tuple.name)
+    exactft = !has_free_typevars(ft)
     ft = rewrap_unionall(ft, s)
-    if exactft
+    if exact && s_uniquerep
+        return Const(ft)
+    elseif exact || (exactft && u.name !== Tuple.name)
         if hasuniquerep(ft)
             return Const(ft) # ft unique via type cache
         end
         return Type{ft}
-    end
-    if u.name === Tuple.name && ft === Any
+    elseif u.name === Tuple.name && ft === Any
         # Tuple{:x} is possible
         return Any
     end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -727,6 +727,7 @@ let fieldtype_tfunc = Core.Compiler.fieldtype_tfunc,
     @test fieldtype_tfunc(Type{Union{Base.RefValue{T}, Type{Int32}}} where {T<:Real}, Const(:x)) == Type{<:Real}
     @test fieldtype_tfunc(Type{<:Tuple}, Const(1)) == Any
     @test fieldtype_tfunc(Type{<:Tuple}, Any) == Any
+    @test fieldtype_tfunc(Const(Base.RefValue{Union{Int64, Float64}}), Const(:x)) == Const(Union{Int64, Float64})
     @test fieldtype_nothrow(Type{Base.RefValue{<:Real}}, Const(:x))
     @test !fieldtype_nothrow(Type{Union{}}, Const(:x))
     @test !fieldtype_nothrow(Union{Type{Base.RefValue{T}}, Int32} where {T<:Real}, Const(:x))


### PR DESCRIPTION
Previously, `fieldtype_tfunc` would return Union fields as
`Type{Union{...}}` rather than `Const(Union{...})`. However,
converting the latter to the former actually takes a fair
amount of time, so try to be a bit more precise here and
check whether the lattice element we're calling fieldtype
on is guaranteed to produce a `Const` argument.