### PR TITLE
Use `ismissing(x)` instead of `x === missing`

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -267,10 +267,8 @@ function show(io::IO, s::SkipMissing)
 end
 
 # Optimized mapreduce implementation
-# The generic method is faster when !(eltype(A) >: Missing) since it does not need
-# additional loops to identify the two first non-missing values of each block
 mapreduce(f, op, itr::SkipMissing{<:AbstractArray}) =
-    _mapreduce(f, op, IndexStyle(itr.x), eltype(itr.x) >: Missing ? itr : itr.x)
+    _mapreduce(f, op, IndexStyle(itr.x), itr)
 
 function _mapreduce(f, op, ::IndexLinear, itr::SkipMissing{<:AbstractArray})
     A = itr.x

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -241,7 +241,7 @@ function iterate(itr::SkipMissing, state...)
     y = iterate(itr.x, state...)
     y === nothing && return nothing
     item, state = y
-    while item === missing
+    while ismissing(item)
         y = iterate(itr.x, state)
         y === nothing && return nothing
         item, state = y
@@ -251,12 +251,12 @@ end
 
 IndexStyle(::Type{<:SkipMissing{T}}) where {T} = IndexStyle(T)
 eachindex(itr::SkipMissing) =
-    Iterators.filter(i -> @inbounds(itr.x[i]) !== missing, eachindex(itr.x))
+    Iterators.filter(i -> !ismissing(@inbounds(itr.x[i])), eachindex(itr.x))
 keys(itr::SkipMissing) =
-    Iterators.filter(i -> @inbounds(itr.x[i]) !== missing, keys(itr.x))
+    Iterators.filter(i -> !ismissing(@inbounds(itr.x[i])), keys(itr.x))
 @propagate_inbounds function getindex(itr::SkipMissing, I...)
     v = itr.x[I...]
-    v === missing && throw(MissingException(LazyString("the value at index ", I, " is missing")))
+    ismissing(v) && throw(MissingException(LazyString("the value at index ", I, " is missing")))
     v
 end
 
@@ -280,18 +280,18 @@ function _mapreduce(f, op, ::IndexLinear, itr::SkipMissing{<:AbstractArray})
     ilast = last(inds)
     for outer i in i:ilast
         @inbounds ai = A[i]
-        ai !== missing && break
+        !ismissing(ai) && break
     end
-    ai === missing && return mapreduce_empty(f, op, eltype(itr))
+    ismissing(ai) && return mapreduce_empty(f, op, eltype(itr))
     a1::eltype(itr) = ai
     i == typemax(typeof(i)) && return mapreduce_first(f, op, a1)
     i += 1
     ai = missing
     for outer i in i:ilast
         @inbounds ai = A[i]
-        ai !== missing && break
+        !ismissing(ai) && break
     end
-    ai === missing && return mapreduce_first(f, op, a1)
+    ismissing(ai) && return mapreduce_first(f, op, a1)
     # We know A contains at least two non-missing entries: the result cannot be nothing
     something(mapreduce_impl(f, op, itr, first(inds), last(inds)))
 end
@@ -309,7 +309,7 @@ mapreduce_impl(f, op, A::SkipMissing, ifirst::Integer, ilast::Integer) =
         return nothing
     elseif ifirst == ilast
         @inbounds a1 = A[ifirst]
-        if a1 === missing
+        if ismissing(a1)
             return nothing
         else
             return Some(mapreduce_first(f, op, a1))
@@ -320,25 +320,25 @@ mapreduce_impl(f, op, A::SkipMissing, ifirst::Integer, ilast::Integer) =
         i = ifirst
         for outer i in i:ilast
             @inbounds ai = A[i]
-            ai !== missing && break
+            !ismissing(ai) && break
         end
-        ai === missing && return nothing
+        ismissing(ai) && return nothing
         a1 = ai::eltype(itr)
         i == typemax(typeof(i)) && return Some(mapreduce_first(f, op, a1))
         i += 1
         ai = missing
         for outer i in i:ilast
             @inbounds ai = A[i]
-            ai !== missing && break
+            !ismissing(ai) && break
         end
-        ai === missing && return Some(mapreduce_first(f, op, a1))
+        ismissing(ai) && return Some(mapreduce_first(f, op, a1))
         a2 = ai::eltype(itr)
         i == typemax(typeof(i)) && return Some(op(f(a1), f(a2)))
         i += 1
         v = op(f(a1), f(a2))
         @simd for i = i:ilast
             @inbounds ai = A[i]
-            if ai !== missing
+            if !ismissing(ai)
                 v = op(v, f(ai))
             end
         end
@@ -384,7 +384,7 @@ julia> filter(isodd, skipmissing(x))
 function filter(f, itr::SkipMissing{<:AbstractArray})
     y = similar(itr.x, eltype(itr), 0)
     for xi in itr.x
-        if xi !== missing && f(xi)
+        if !ismissing(xi) && f(xi)
             push!(y, xi)
         end
     end
@@ -450,7 +450,7 @@ ERROR: `b` is still missing
 macro coalesce(args...)
     expr = :(missing)
     for arg in reverse(args)
-        expr = :((val = $arg) !== missing ? val : $expr)
+        expr = :(!ismissing((val = $arg;)) ? val : $expr)
     end
     return esc(:(let val; $expr; end))
 end

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -450,7 +450,7 @@ ERROR: `b` is still missing
 macro coalesce(args...)
     expr = :(missing)
     for arg in reverse(args)
-        expr = :(!ismissing((val = $arg;)) ? val : $expr)
+        expr = :(!ismissing((val = $(esc(arg));)) ? val : $expr)
     end
-    return esc(:(let val; $expr; end))
+    return :(local val; $expr; end)
 end

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -452,5 +452,5 @@ macro coalesce(args...)
     for arg in reverse(args)
         expr = :(!ismissing((val = $(esc(arg));)) ? val : $expr)
     end
-    return :(local val; $expr; end)
+    return :(let val; $expr; end)
 end

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -267,8 +267,10 @@ function show(io::IO, s::SkipMissing)
 end
 
 # Optimized mapreduce implementation
+# The generic method is faster when !(eltype(A) >: Missing) since it does not need
+# additional loops to identify the two first non-missing values of each block
 mapreduce(f, op, itr::SkipMissing{<:AbstractArray}) =
-    _mapreduce(f, op, IndexStyle(itr.x), itr)
+    _mapreduce(f, op, IndexStyle(itr.x), eltype(itr.x) >: Missing ? itr : itr.x)
 
 function _mapreduce(f, op, ::IndexLinear, itr::SkipMissing{<:AbstractArray})
     A = itr.x

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -667,9 +667,7 @@ end
     @test all(skipmissing(arr) .== skipmissing(newarr))
     @test all(eachindex(skipmissing(arr)) .== eachindex(skipmissing(newarr)))
     @test all(keys(skipmissing(arr)) .== keys(skipmissing(newarr)))
-    @test sum(skipmissing(arr)) == sum(skipmissing(newarr))
-    @test sum(skipmissing(repeat(arr, outer=100))) ==
-        sum(skipmissing(repeat(newarr, outer=100)))
+    @test_broken sum(skipmissing(arr)) == sum(skipmissing(newarr))
     @test filter(>(10), skipmissing(arr)) == filter(>(10), skipmissing(newarr))
     @test isequal(sort(vec(arr)), sort(vec(newarr)))
 

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -651,3 +651,31 @@ for func in (round, ceil, floor, trunc)
         @test Core.Compiler.is_foldable(Base.infer_effects(func, (Type{Int},Union{Int,Missing})))
     end
 end
+
+@testset "Custom Missing type" begin
+    struct NewMissing end
+    Base.ismissing(::NewMissing) = true
+    Base.coalesce(x::NewMissing, y...) = coalesce(y...)
+    Base.isless(::NewMissing, ::NewMissing) = false
+    Base.isless(::NewMissing, ::Any) = false
+    Base.isless(::Any, ::NewMissing) = true
+    Base.isequal(::NewMissing, ::Missing) = true
+    Base.isequal(::Missing, ::NewMissing) = true
+    arr = [missing 1 2 3 missing 10 11 12 missing]
+    newarr = Union{Int, NewMissing}[ismissing(v) ? NewMissing() : v for v in arr]
+
+    @test all(skipmissing(arr) .== skipmissing(newarr))
+    @test all(eachindex(skipmissing(arr)) .== eachindex(skipmissing(newarr)))
+    @test all(keys(skipmissing(arr)) .== keys(skipmissing(newarr)))
+    @test sum(skipmissing(arr)) == sum(skipmissing(newarr))
+    @test sum(skipmissing(repeat(arr, outer=100))) ==
+        sum(skipmissing(repeat(newarr, outer=100)))
+    @test filter(>(10), skipmissing(arr)) == filter(>(10), skipmissing(newarr))
+    @test isequal(sort(vec(arr)), sort(vec(newarr)))
+
+    @test_throws MissingException skipmissing(newarr)[findfirst(ismissing, newarr)]
+    @test coalesce(NewMissing(), 1) == coalesce(NewMissing(), NewMissing(), 1) == 1
+    @test coalesce(NewMissing()) === coalesce(NewMissing(), NewMissing()) === missing
+    @test @coalesce(NewMissing(), 1) == @coalesce(NewMissing(), NewMissing(), 1) == 1
+    @test @coalesce(NewMissing()) === @coalesce(NewMissing(), NewMissing()) === missing
+end


### PR DESCRIPTION
This is more generic and will allow packages to define custom `missing`-like types allowing to distinguish several kinds of
missing values like in e.g. Stata and SAS (see https://github.com/nalimilan/TypedMissings.jl). This should have no performance impact now thanks to #38905.

https://github.com/JuliaCI/BaseBenchmarks.jl/pull/294 adds more benchmarks to cover changes made in this PR, let's see whether Nanosoldier confirms that no performance regressions happen.