### PR TITLE
optimizer: bail out of inlining if ir_inline_unionsplit will fail

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -821,7 +821,6 @@ function analyze_method!(match::MethodMatch, argtypes::Vector{Any},
                          flag::UInt8, state::InliningState)
     method = match.method
     spec_types = match.spec_types
-    methsig = method.sig
 
     # Check that we have the correct number of arguments
     na = Int(method.nargs)

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -820,9 +820,10 @@ end
 function analyze_method!(match::MethodMatch, argtypes::Vector{Any},
                          flag::UInt8, state::InliningState)
     method = match.method
+    spec_types = match.spec_types
     methsig = method.sig
 
-    # Check that we habe the correct number of arguments
+    # Check that we have the correct number of arguments
     na = Int(method.nargs)
     npassedargs = length(argtypes)
     if na != npassedargs && !(na > 0 && method.isva)
@@ -831,6 +832,13 @@ function analyze_method!(match::MethodMatch, argtypes::Vector{Any},
         # though we have too many arguments to actually
         # call this function
         return nothing
+    end
+    if !match.fully_covers
+        # type-intersection was not able to give us a simple list of types, so
+        # ir_inline_unionsplit won't be able to deal with inlining this
+        if !(spec_types isa DataType && length(spec_types.parameters) == length(argtypes) && !isvarargtype(spec_types.parameters[end]))
+            return nothing
+        end
     end
 
     # Bail out if any static parameters are left as TypeVar


### PR DESCRIPTION
Intersection cannot deal with this `metharg`, so it does not simplify
the type at all when handling this case. This can cause us to run into
an assertion later, where we assume the intersection of a non-Varags
type will always return a simple DataType without Varargs.

Fixes #44238

    atype = Tuple{typeof(Base.similar),
      Tuple{Union{Polyhedra.Polyhedron{T}, Polyhedra.Representation{T}} where T},
      Array{_A, 1} where _A,
      Array{_C, 1} where _C,
      Array{_B, 1} where _B}

    metharg = Tuple{typeof(Base.similar),
      Tuple{Vararg{Union{Polyhedra.Polyhedron{T}, Polyhedra.Representation{T}} where T}},
      Vararg{Union{Union{AbstractArray{var"#s14", 1}, Polyhedra.AbstractRepIterator{var"#s13", var"#s14"} where var"#s13", Polyhedra.AllRepIterator{var"#s14", var"#s14", LinElemT, LRT, RT} where RT<:Polyhedra.AbstractRepIterator{var"#s14", var"#s14"} where LRT<:Polyhedra.AbstractRepIterator{var"#s14", LinElemT} where LinElemT where var"#s14"} where var"#s14"<:(Polyhedra.HyperPlane{T, AT} where AT<:AbstractArray{T, 1}), Union{AbstractArray{var"#s14", 1}, Polyhedra.AbstractRepIterator{var"#s13", var"#s14"} where var"#s13", Polyhedra.AllRepIterator{var"#s14", var"#s14", LinElemT, LRT, RT} where RT<:Polyhedra.AbstractRepIterator{var"#s14", var"#s14"} where LRT<:Polyhedra.AbstractRepIterator{var"#s14", LinElemT} where LinElemT where var"#s14"} where var"#s14"<:(Polyhedra.HalfSpace{T, AT} where AT<:AbstractArray{T, 1}), Union{AbstractArray{var"#s14", 1}, Polyhedra.AbstractRepIterator{var"#s13", var"#s14"} where var"#s13", Polyhedra.AllRepIterator{var"#s14", var"#s14", LinElemT, LRT, RT} where RT<:Polyhedra.AbstractRepIterator{var"#s14", var"#s14"} where LRT<:Polyhedra.AbstractRepIterator{var"#s14", LinElemT} where LinElemT where var"#s14"} where var"#s14"<:AbstractArray{T, 1}, Union{AbstractArray{var"#s14", 1}, Polyhedra.AbstractRepIterator{var"#s13", var"#s14"} where var"#s13", Polyhedra.AllRepIterator{var"#s14", var"#s14", LinElemT, LRT, RT} where RT<:Polyhedra.AbstractRepIterator{var"#s14", var"#s14"} where LRT<:Polyhedra.AbstractRepIterator{var"#s14", LinElemT} where LinElemT where var"#s14"} where var"#s14"<:(Polyhedra.Line{T, AT} where AT<:AbstractArray{T, 1}), Union{AbstractArray{var"#s14", 1}, Polyhedra.AbstractRepIterator{var"#s13", var"#s14"} where var"#s13", Polyhedra.AllRepIterator{var"#s14", var"#s14", LinElemT, LRT, RT} where RT<:Polyhedra.AbstractRepIterator{var"#s14", var"#s14"} where LRT<:Polyhedra.AbstractRepIterator{var"#s14", LinElemT} where LinElemT where var"#s14"} where var"#s14"<:(Polyhedra.Ray{T, AT} where AT<:AbstractArray{T, 1})} where T}}

Currently `typeintersection(atype, metharg) === metharg`