### PR TITLE
add jl_egal and jl_gc_safepoint back to exports list

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -21,6 +21,10 @@
     XX(jl_apply_type2) \
     XX(jl_argument_datatype) \
     XX(jl_argument_method_table) \
+    XX(jl_arraylen) \
+    XX(jl_arrayref) \
+    XX(jl_arrayset) \
+    XX(jl_arrayunset) \
     XX(jl_array_cconvert_cstring) \
     XX(jl_array_copy) \
     XX(jl_array_del_at) \
@@ -31,19 +35,15 @@
     XX(jl_array_grow_beg) \
     XX(jl_array_grow_end) \
     XX(jl_array_isassigned) \
-    XX(jl_arraylen) \
     XX(jl_array_ptr) \
     XX(jl_array_ptr_1d_append) \
     XX(jl_array_ptr_1d_push) \
     XX(jl_array_ptr_copy) \
     XX(jl_array_rank) \
-    XX(jl_arrayref) \
-    XX(jl_arrayset) \
     XX(jl_array_size) \
     XX(jl_array_sizehint) \
     XX(jl_array_to_string) \
     XX(jl_array_typetagdata) \
-    XX(jl_arrayunset) \
     XX(jl_array_validate_dims) \
     XX(jl_atexit_hook) \
     XX(jl_atomic_bool_cmpswap_bits) \
@@ -85,8 +85,8 @@
     XX(jl_call1) \
     XX(jl_call2) \
     XX(jl_call3) \
-    XX(jl_call_in_typeinf_world) \
     XX(jl_calloc) \
+    XX(jl_call_in_typeinf_world) \
     XX(jl_capture_interp_frame) \
     XX(jl_ceil_llvm) \
     XX(jl_ceil_llvm_withtype) \
@@ -115,6 +115,7 @@
     XX(jl_dlopen) \
     XX(jl_dlsym) \
     XX(jl_dump_host_cpu) \
+    XX(jl_egal) \
     XX(jl_egal__bits) \
     XX(jl_egal__special) \
     XX(jl_eh_restore_state) \
@@ -131,15 +132,14 @@
     XX(jl_error) \
     XX(jl_errorf) \
     XX(jl_eval_string) \
-    XX(jl_exception_clear) \
     XX(jl_exceptionf) \
+    XX(jl_exception_clear) \
     XX(jl_exception_occurred) \
     XX(jl_excstack_state) \
     XX(jl_exit) \
     XX(jl_exit_on_sigint) \
     XX(jl_exit_threaded_region) \
     XX(jl_expand) \
-    XX(jl_resolve_globals_in_ir) \
     XX(jl_expand_and_resolve) \
     XX(jl_expand_stmt) \
     XX(jl_expand_stmt_with_loc) \
@@ -150,11 +150,11 @@
     XX(jl_gc_add_finalizer) \
     XX(jl_gc_add_finalizer_th) \
     XX(jl_gc_add_ptr_finalizer) \
+    XX(jl_gc_allocobj) \
     XX(jl_gc_alloc_0w) \
     XX(jl_gc_alloc_1w) \
     XX(jl_gc_alloc_2w) \
     XX(jl_gc_alloc_3w) \
-    XX(jl_gc_allocobj) \
     XX(jl_gc_alloc_typed) \
     XX(jl_gc_big_alloc) \
     XX(jl_gc_collect) \
@@ -184,6 +184,7 @@
     XX(jl_gc_pool_alloc) \
     XX(jl_gc_queue_multiroot) \
     XX(jl_gc_queue_root) \
+    XX(jl_gc_safepoint) \
     XX(jl_gc_schedule_foreign_sweepfunc) \
     XX(jl_gc_set_cb_notify_external_alloc) \
     XX(jl_gc_set_cb_notify_external_free) \
@@ -198,6 +199,9 @@
     XX(jl_generic_function_def) \
     XX(jl_gensym) \
     XX(jl_getallocationgranularity) \
+    XX(jl_getnameinfo) \
+    XX(jl_getpagesize) \
+    XX(jl_getpid) \
     XX(jl_get_ARCH) \
     XX(jl_get_backtrace) \
     XX(jl_get_binding) \
@@ -224,14 +228,11 @@
     XX(jl_get_module_infer) \
     XX(jl_get_module_of_binding) \
     XX(jl_get_module_optlevel) \
-    XX(jl_getnameinfo) \
     XX(jl_get_next_task) \
     XX(jl_get_nth_field) \
     XX(jl_get_nth_field_checked) \
     XX(jl_get_nth_field_noalloc) \
-    XX(jl_getpagesize) \
     XX(jl_get_pgcstack) \
-    XX(jl_getpid) \
     XX(jl_get_ptls_states) \
     XX(jl_get_root_symbol) \
     XX(jl_get_safe_restore) \
@@ -255,19 +256,19 @@
     XX(jl_idtable_rehash) \
     XX(jl_infer_thunk) \
     XX(jl_init) \
-    XX(jl_init__threading) \
+    XX(jl_init_options) \
     XX(jl_init_restored_modules) \
     XX(jl_init_with_image) \
     XX(jl_init_with_image__threading) \
-    XX(jl_init_options) \
+    XX(jl_init__threading) \
     XX(jl_install_sigint_handler) \
     XX(jl_instantiate_type_in_env) \
     XX(jl_instantiate_unionall) \
     XX(jl_intersect_types) \
-    XX(jl_in_threaded_region) \
     XX(jl_intrinsic_name) \
     XX(jl_invoke) \
     XX(jl_invoke_api) \
+    XX(jl_in_threaded_region) \
     XX(jl_iolock_begin) \
     XX(jl_iolock_end) \
     XX(jl_ios_buffer_n) \
@@ -280,6 +281,8 @@
     XX(jl_ir_slotflag) \
     XX(jl_isa) \
     XX(jl_isa_compileable_sig) \
+    XX(jl_islayout_inline) \
+    XX(jl_istopmod) \
     XX(jl_is_binding_deprecated) \
     XX(jl_is_char_signed) \
     XX(jl_is_const) \
@@ -288,12 +291,10 @@
     XX(jl_is_imported) \
     XX(jl_is_initialized) \
     XX(jl_is_in_pure_context) \
-    XX(jl_islayout_inline) \
     XX(jl_is_memdebug) \
     XX(jl_is_not_broken_subtype) \
     XX(jl_is_operator) \
     XX(jl_is_task_started) \
-    XX(jl_istopmod) \
     XX(jl_is_unary_and_binary_operator) \
     XX(jl_is_unary_operator) \
     XX(jl_lazy_load_and_lookup) \
@@ -336,8 +337,8 @@
     XX(jl_nb_available) \
     XX(jl_new_array) \
     XX(jl_new_bits) \
-    XX(jl_new_code_info_uninit) \
     XX(jl_new_codeinst) \
+    XX(jl_new_code_info_uninit) \
     XX(jl_new_datatype) \
     XX(jl_new_foreign_type) \
     XX(jl_new_method_instance_uninit) \
@@ -347,14 +348,14 @@
     XX(jl_new_primitivetype) \
     XX(jl_new_struct) \
     XX(jl_new_structt) \
-    XX(jl_new_struct_uninit) \
     XX(jl_new_structv) \
+    XX(jl_new_struct_uninit) \
     XX(jl_new_task) \
     XX(jl_new_typename_in) \
     XX(jl_new_typevar) \
     XX(jl_next_from_addrinfo) \
-    XX(jl_no_exc_handler) \
     XX(jl_normalize_to_compilable_sig) \
+    XX(jl_no_exc_handler) \
     XX(jl_object_id) \
     XX(jl_object_id_) \
     XX(jl_obvious_subtype) \
@@ -372,8 +373,8 @@
     XX(jl_pop_handler) \
     XX(jl_preload_sysimg_so) \
     XX(jl_prepend_cwd) \
-    XX(jl_print_backtrace) \
     XX(jl_printf) \
+    XX(jl_print_backtrace) \
     XX(jl_process_events) \
     XX(jl_profile_clear_data) \
     XX(jl_profile_delay_nsec) \
@@ -394,6 +395,7 @@
     XX(jl_realloc) \
     XX(jl_register_newmeth_tracer) \
     XX(jl_reshape_array) \
+    XX(jl_resolve_globals_in_ir) \
     XX(jl_restore_excstack) \
     XX(jl_restore_incremental) \
     XX(jl_restore_incremental_from_buf) \
@@ -472,18 +474,18 @@
     XX(jl_tty_set_mode) \
     XX(jl_tupletype_fill) \
     XX(jl_typeassert) \
+    XX(jl_typeinf_begin) \
+    XX(jl_typeinf_end) \
+    XX(jl_typename_str) \
+    XX(jl_typeof_str) \
+    XX(jl_types_equal) \
     XX(jl_type_equality_is_identity) \
     XX(jl_type_error) \
     XX(jl_type_error_rt) \
-    XX(jl_typeinf_begin) \
-    XX(jl_typeinf_end) \
     XX(jl_type_intersection) \
     XX(jl_type_intersection_with_env) \
     XX(jl_type_morespecific) \
     XX(jl_type_morespecific_no_subtype) \
-    XX(jl_typename_str) \
-    XX(jl_typeof_str) \
-    XX(jl_types_equal) \
     XX(jl_type_union) \
     XX(jl_type_unionall) \
     XX(jl_unbox_bool) \
@@ -499,8 +501,8 @@
     XX(jl_unbox_uint8) \
     XX(jl_unbox_uint8pointer) \
     XX(jl_unbox_voidpointer) \
-    XX(jl_uncompress_argname_n) \
     XX(jl_uncompress_argnames) \
+    XX(jl_uncompress_argname_n) \
     XX(jl_uncompress_ir) \
     XX(jl_undefined_var_error) \
     XX(jl_value_ptr) \

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -411,7 +411,7 @@ JL_DLLEXPORT const char *jl_git_commit(void)
     return commit;
 }
 
-// Create function versions of some useful macros
+// Create function versions of some useful macros for GDB or FFI use
 JL_DLLEXPORT jl_taggedvalue_t *(jl_astaggedvalue)(jl_value_t *v)
 {
     return jl_astaggedvalue(v);
@@ -430,6 +430,11 @@ JL_DLLEXPORT jl_value_t *(jl_typeof)(jl_value_t *v)
 JL_DLLEXPORT jl_value_t *(jl_get_fieldtypes)(jl_value_t *v)
 {
     return (jl_value_t*)jl_get_fieldtypes((jl_datatype_t*)v);
+}
+
+JL_DLLEXPORT int ijl_egal(jl_value_t *a, jl_value_t *b)
+{
+    return jl_egal(a, b);
 }
 
 
@@ -459,7 +464,7 @@ JL_DLLEXPORT void (jl_gc_safe_leave)(int8_t state)
 }
 #endif
 
-JL_DLLEXPORT void (jl_gc_safepoint)(void)
+JL_DLLEXPORT void jl_gc_safepoint(void)
 {
     jl_task_t *ct = jl_current_task;
     jl_gc_safepoint_(ct->ptls);

--- a/src/julia.h
+++ b/src/julia.h
@@ -7,6 +7,7 @@
 #include "jl_internal_funcs.inc"
 #undef jl_setjmp
 #undef jl_longjmp
+#undef jl_egal
 #endif
 
 #include "julia_fasttls.h"
@@ -925,6 +926,7 @@ STATIC_INLINE void jl_gc_multi_wb(const void *parent, const jl_value_t *ptr) JL_
 JL_DLLEXPORT void *jl_gc_managed_malloc(size_t sz);
 JL_DLLEXPORT void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz,
                                          int isaligned, jl_value_t *owner);
+JL_DLLEXPORT void jl_gc_safepoint(void);
 
 // object accessors -----------------------------------------------------------
 


### PR DESCRIPTION
Simple oversight when these were turned into macros. I could not find
any others that seemed applicable, so just these two appeared to need
fixing right now.

Fix #44373

(the src/jl_exported_funcs.inc is also re-sorted, since `sort` didn't seem to like our current list)