### PR TITLE
Make type of `PartialStruct`'s `typ` field more precise

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2539,7 +2539,7 @@ void jl_init_types(void) JL_GC_DISABLED
 
     jl_partial_struct_type = jl_new_datatype(jl_symbol("PartialStruct"), core, jl_any_type, jl_emptysvec,
                                        jl_perm_symsvec(2, "typ", "fields"),
-                                       jl_svec2(jl_any_type, jl_array_any_type),
+                                       jl_svec2(jl_datatype_type, jl_array_any_type),
                                        jl_emptysvec, 0, 0, 2);
 
     jl_interconditional_type = jl_new_datatype(jl_symbol("InterConditional"), core, jl_any_type, jl_emptysvec,


### PR DESCRIPTION
Just a bit more precision in preparation of some further
work speeding up inference hot paths.