### PR TITLE
Add per-methtable max methods mechanism

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -896,6 +896,10 @@ end
 
 ## from general iterable to any array
 
+# This is `@Experimental.max_methods 1 function copyto! end`, which is not
+# defined at this point in bootstrap.
+typeof(function copyto! end).name.max_methods = UInt8(1)
+
 function copyto!(dest::AbstractArray, src)
     destiter = eachindex(dest)
     y = iterate(destiter)

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -137,6 +137,20 @@ macro max_methods(n::Int)
 end
 
 """
+    Experimental.@max_methods n::Int function fname end
+
+Set the maximum number of potentially-matching methods considered when running inference
+for the generic function `fname`. Overrides any module-level or global inference settings
+for max_methods. This setting is global for the entire generic function (or more precisely
+the MethodTable).
+"""
+macro max_methods(n::Int, fdef::Expr)
+    0 < n <= 255 || error("We must have that `1 <= max_methods <= 255`, but `max_methods = $n`.")
+    (fdef.head == :function && length(fdef.args) == 1) || error("Second argument must be a function forward declaration")
+    return :(typeof($(esc(fdef))).name.max_methods = $(UInt8(n)))
+end
+
+"""
     Experimental.@compiler_options optimize={0,1,2,3} compile={yes,no,all,min} infer={yes,no} max_methods={default,1,2,3,...}
 
 Set compiler options for code in the enclosing module. Options correspond directly to

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -80,6 +80,7 @@ JL_DLLEXPORT jl_typename_t *jl_new_typename_in(jl_sym_t *name, jl_module_t *modu
     tn->partial = NULL;
     tn->atomicfields = NULL;
     tn->constfields = NULL;
+    tn->max_methods = 0;
     return tn;
 }
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -1001,6 +1001,7 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
                 jl_serialize_value(s, tn->mt);
                 ios_write(s->s, (char*)&tn->hash, sizeof(tn->hash));
                 write_uint8(s->s, tn->abstract | (tn->mutabl << 1) | (tn->mayinlinealloc << 2));
+                write_uint8(s->s, tn->max_methods);
                 if (!tn->abstract)
                     write_uint16(s->s, tn->n_uninitialized);
                 size_t nb = tn->atomicfields ? (jl_svec_len(tn->names) + 31) / 32 * sizeof(uint32_t) : 0;
@@ -2013,6 +2014,7 @@ static jl_value_t *jl_deserialize_value_any(jl_serializer_state *s, uint8_t tag,
             tn->abstract = flags & 1;
             tn->mutabl = (flags>>1) & 1;
             tn->mayinlinealloc = (flags>>2) & 1;
+            tn->max_methods = read_uint8(s->s);
             if (tn->abstract)
                 tn->n_uninitialized = 0;
             else

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2017,18 +2017,20 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_typename_type->name->mt = jl_nonfunction_mt;
     jl_typename_type->super = jl_any_type;
     jl_typename_type->parameters = jl_emptysvec;
-    jl_typename_type->name->n_uninitialized = 13 - 2;
-    jl_typename_type->name->names = jl_perm_symsvec(13, "name", "module",
+    jl_typename_type->name->n_uninitialized = 14 - 2;
+    jl_typename_type->name->names = jl_perm_symsvec(14, "name", "module",
                                                     "names", "atomicfields", "constfields",
                                                     "wrapper", "cache", "linearcache",
                                                     "mt", "partial",
                                                     "hash", "n_uninitialized",
-                                                    "flags"); // "abstract", "mutable", "mayinlinealloc",
-    jl_typename_type->types = jl_svec(13, jl_symbol_type, jl_any_type /*jl_module_type*/,
+                                                    "flags", // "abstract", "mutable", "mayinlinealloc",
+                                                    "max_methods");
+    jl_typename_type->types = jl_svec(14, jl_symbol_type, jl_any_type /*jl_module_type*/,
                                       jl_simplevector_type, jl_any_type/*jl_voidpointer_type*/, jl_any_type/*jl_voidpointer_type*/,
                                       jl_type_type, jl_simplevector_type, jl_simplevector_type,
                                       jl_methtable_type, jl_any_type,
                                       jl_any_type /*jl_long_type*/, jl_any_type /*jl_int32_type*/,
+                                      jl_any_type /*jl_uint8_type*/,
                                       jl_any_type /*jl_uint8_type*/);
     const static uint32_t typename_constfields[1] = { 0x00001d3f }; // (1<<0)|(1<<1)|(1<<2)|(1<<3)|(1<<4)|(1<<5)|(1<<8)|(1<<10)|(1<<11)|(1<<12)
     jl_typename_type->name->constfields = typename_constfields;
@@ -2665,6 +2667,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_typename_type->types, 10, jl_long_type);
     jl_svecset(jl_typename_type->types, 11, jl_int32_type);
     jl_svecset(jl_typename_type->types, 12, jl_uint8_type);
+    jl_svecset(jl_typename_type->types, 13, jl_uint8_type);
     jl_svecset(jl_methtable_type->types, 4, jl_long_type);
     jl_svecset(jl_methtable_type->types, 6, jl_module_type);
     jl_svecset(jl_methtable_type->types, 7, jl_array_any_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -467,6 +467,7 @@ typedef struct {
     uint8_t abstract:1;
     uint8_t mutabl:1;
     uint8_t mayinlinealloc:1;
+    uint8_t max_methods; // override for inference's max_methods setting (0 = no additional limit or relaxation)
 } jl_typename_t;
 
 typedef struct {

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4030,3 +4030,11 @@ end
 @test Tuple{} <: code_typed(f_boundscheck_elim, Tuple{Int})[1][2]
 
 @test !Core.Compiler.builtin_nothrow(Core.get_binding_type, Any[Rational{Int}, Core.Const(:foo)], Any)
+
+# Test that max_methods works as expected
+@Base.Experimental.max_methods 1 function f_max_methods end
+f_max_methods(x::Int) = 1
+f_max_methods(x::Float64) = 2
+g_max_methods(x) = f_max_methods(x)
+@test Core.Compiler.return_type(g_max_methods, Tuple{Int}) === Int
+@test Core.Compiler.return_type(g_max_methods, Tuple{Any}) === Any


### PR DESCRIPTION
Allows overriding the max-methods default for specific generic
functions that are known to benefit from a different value of
max methods. Also replaces the one case in Base where we're
already overriding max methds by this new mechanism.