### PR TITLE
Fix test invalided by #44096

### DIFF
--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -437,7 +437,7 @@ Random.seed!(1)
             Tridiag = Tridiagonal(rand(elty, 9), rand(elty, 10), rand(elty, 9))
             SymTri = SymTridiagonal(rand(elty, 10), rand(elty, 9))
 
-            mats = [Diag, BidiagU, BidiagL, Tridiag, SymTri]
+            mats = Any[Diag, BidiagU, BidiagL, Tridiag, SymTri]
             for a in mats
                 for b in mats
                     @test a*b ≈ Matrix(a)*Matrix(b)

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -477,7 +477,7 @@ end
     X = convert(Matrix{elty}, [1.0 2.0; 3.0 4.0])
     Y = convert(Matrix{elty}, [1.5 2.5; 3.5 4.5])
     @test dot(X, Y) == convert(elty, 35.0)
-    Z = convert(Vector{Matrix{elty}}, [reshape(1:4, 2, 2), fill(1, 2, 2)])
+    Z = Matrix{elty}[reshape(1:4, 2, 2), fill(1, 2, 2)]
     @test dot(Z, Z) == convert(elty, 34.0)
 end
 

--- a/stdlib/LinearAlgebra/test/special.jl
+++ b/stdlib/LinearAlgebra/test/special.jl
@@ -145,7 +145,7 @@ end
     LoBi = Bidiagonal(rand(20,20), :L)
     Sym = SymTridiagonal(rand(20), rand(19))
     Dense = rand(20, 20)
-    mats = [UpTri, LoTri, Diag, Tridiag, UpBi, LoBi, Sym, Dense]
+    mats = Any[UpTri, LoTri, Diag, Tridiag, UpBi, LoBi, Sym, Dense]
 
     for op in (+,-,*)
         for A in mats
@@ -160,7 +160,7 @@ end
     diag = 1:5
     offdiag = 1:4
     uniformscalingmats = [UniformScaling(3), UniformScaling(1.0), UniformScaling(3//5), UniformScaling(ComplexF64(1.3, 3.5))]
-    mats = [Diagonal(diag), Bidiagonal(diag, offdiag, 'U'), Bidiagonal(diag, offdiag, 'L'), Tridiagonal(offdiag, diag, offdiag), SymTridiagonal(diag, offdiag)]
+    mats = Any[Diagonal(diag), Bidiagonal(diag, offdiag, 'U'), Bidiagonal(diag, offdiag, 'L'), Tridiagonal(offdiag, diag, offdiag), SymTridiagonal(diag, offdiag)]
     for T in [ComplexF64, Int64, Rational{Int64}, Float64]
         push!(mats, Diagonal(Vector{T}(diag)))
         push!(mats, Bidiagonal(Vector{T}(diag), Vector{T}(offdiag), 'U'))
@@ -321,7 +321,7 @@ using .Main.Furlongs
         Bl = Bidiagonal(rand(elty, 10), rand(elty, 9), 'L')
         T = Tridiagonal(rand(elty, 9),rand(elty, 10), rand(elty, 9))
         S = SymTridiagonal(rand(elty, 10), rand(elty, 9))
-        mats = [D, Bu, Bl, T, S]
+        mats = Any[D, Bu, Bl, T, S]
         for A in mats
             @test iszero(zero(A))
             @test isone(one(A))

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -64,7 +64,7 @@ end
     iobuf = IOBuffer()
     with_logger(NullLogger()) do
         @testset for format in [:flat, :tree]
-            @testset for threads in [1:Threads.nthreads(), 1, 1:1, 1:2, [1,2]]
+            @testset for threads in Any[1:Threads.nthreads(), 1, 1:1, 1:2, [1,2]]
                 @testset for groupby in [:none, :thread, :task, [:thread, :task], [:task, :thread]]
                     Profile.print(iobuf; groupby, threads, format)
                     @test !isempty(String(take!(iobuf)))

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -630,14 +630,14 @@ test18695(r) = sum( t^2 for t in r )
 @test prod(Char['a','b']) == "ab"
 
 @testset "optimized reduce(vcat/hcat, A) for arrays" begin
-    for args in ([1:2], [[1, 2]], [1:2, 3:4], [[3, 4, 5], 1:2], [1:2, [3.5, 4.5]],
+    for args in ([1:2], [[1, 2]], [1:2, 3:4], AbstractVector{Int}[[3, 4, 5], 1:2], AbstractVector[1:2, [3.5, 4.5]],
                  [[1 2], [3 4; 5 6]], [reshape([1, 2], 2, 1), 3:4])
         X = reduce(vcat, args)
         Y = vcat(args...)
         @test X == Y
         @test typeof(X) === typeof(Y)
     end
-    for args in ([1:2], [[1, 2]], [1:2, 3:4], [[3, 4, 5], 1:3], [1:2, [3.5, 4.5]],
+    for args in ([1:2], [[1, 2]], [1:2, 3:4], AbstractVector{Int}[[3, 4, 5], 1:3], AbstractVector[1:2, [3.5, 4.5]],
                  [[1 2; 3 4], [5 6; 7 8]], [1:2, [5 6; 7 8]], [[5 6; 7 8], [1, 2]])
         X = reduce(hcat, args)
         Y = hcat(args...)


### PR DESCRIPTION
It turns out #44096 changes the default promote behavior of `AbstractArray` with the same `ndims`. Thus some Test in `Base` is "skipped" silently.

This PR tries to re-activate them.