### PR TITLE
Factor MethodList representation by optional arguments

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -736,7 +736,7 @@ function print_stackframe(io, i, frame::StackFrame, n::Int, ndigits_max, modulec
     printstyled(io, inlined ? " [inlined]" : "", color = :light_black)
 end
 
-function print_module_path_file(io, modul, file, line; modulecolor = :light_black, digit_align_width = 0)
+function print_module_path_file(io, modul, file, line; modulecolor=:light_black, digit_align_width=0, htmlurl="")
     printstyled(io, " " ^ digit_align_width * "@", color = :light_black)
 
     # module
@@ -753,7 +753,9 @@ function print_module_path_file(io, modul, file, line; modulecolor = :light_blac
     !isempty(dir) && printstyled(io, dir, Filesystem.path_separator, color = :light_black)
 
     # filename, separator, line
+    isempty(htmlurl) || print(io, """<a href="$htmlurl" target="_blank">""")
     printstyled(io, basename(file), ":", line; color = :light_black, underline = true)
+    isempty(htmlurl) || print(io, "</a>")
 end
 
 function show_backtrace(io::IO, t::Vector)

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -507,6 +507,13 @@ let s = "CompletionFoo.test4(\"e\",r\" \","
     @test s[r] == "CompletionFoo.test4"
 end
 
+# Test builtins method completion
+let s = "typeof("
+    c, r = test_complete(s)
+    @test length(c) == 1
+    @test c[1] == "typeof(...) @ Core none:0"
+end
+
 # (As discussed in #19829, the Base.REPLCompletions.get_type function isn't
 #  powerful enough to analyze anonymous functions.)
 let s = "CompletionFoo.test5(broadcast((x,y)->x==y, push!(Base.split(\"\",' '),\"\",\"\"), \"\"),"

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1433,6 +1433,14 @@ end
     c, r = test_complete("CompletionFoo.kwtest3(a; namedarg=0, foob")
     @test c == ["foobar="]
 
+    # Check completion of kwargs given before all the args are present
+    c, r = test_complete("CompletionFoo.kwtest3(a")
+    @test "another!kwarg=" ∈ c
+    c, r = test_complete("CompletionFoo.kwtest3(le")
+    @test "length" ∈ c
+    @test "length=" ∈ c
+    @test "len2=" ∈ c
+
     # Check for confusion with CompletionFoo.named
     c, r = test_complete_foo("kwtest3(blabla; unknown=4, namedar")
     @test c == ["namedarg="]
@@ -1450,7 +1458,7 @@ end
     @test "len2=" ∈ c
     c, r = test_complete_foo("kwtest3(1+3im; named")
     @test "named" ∈ c
-    # TODO: @test "namedarg=" ∉ c
+    @test "namedarg=" ∉ c
     @test "len2" ∉ c
     c, r = test_complete_foo("kwtest3(1+3im; named.")
     @test c == ["len2"]
@@ -1516,8 +1524,6 @@ end
     @test hasnokwsuggestions("CompletionFoo.kwtest3(a; kwargs..., ")
 
     #= TODO: Test the absence of kwarg completion the call is incompatible with the method bearing the kwarg.
-    @test hasnokwsuggestions("CompletionFoo.kwtest3(a")
-    @test hasnokwsuggestions("CompletionFoo.kwtest3(le")
     @test hasnokwsuggestions("CompletionFoo.kwtest3(a; unknown=4, another!kw") # only methods 1 and 3 could slurp `unknown`
     @test hasnokwsuggestions("CompletionFoo.kwtest3(1+3im; nameda")
     @test hasnokwsuggestions("CompletionFoo.kwtest3(12//7; foob") # because of specificity

--- a/test/show.jl
+++ b/test/show.jl
@@ -2595,3 +2595,26 @@ end
     ir = Core.Compiler.complete(compact)
     verify_display(ir)
 end
+
+@testset "Method table for functions with optional arguments" begin
+    f44434_1(a::T, b::T=3, c=4, d...) where {T} = pass
+    let repr = sprint(show, "text/plain", methods(f44434_1))
+        @test occursin("(a::T, [b::T, c], d...)", repr)
+    end
+    f44434_2(a, b=5) = 1
+    f44434_2(x, y::Integer) = 2
+    let repr = sprint(show, "text/plain", methods(f44434_2))
+        @test occursin("(a, [b])", repr)
+        @test occursin("(x, y::Integer)", repr)
+    end
+    f44434_3(a, b::Integer=5) = pass
+    let repr = sprint(show, "text/plain", methods(f44434_3))
+        @test occursin("(a, [b::Integer])", repr)
+    end
+    f44434_3(x, y::Integer) = pass
+    let repr = sprint(show, "text/plain", methods(f44434_3))
+        @test !occursin("(a, [b::Integer])", repr)
+        @test occursin("(a)", repr)
+        @test occursin("(x, y::Integer)", repr)
+    end
+end

--- a/test/show.jl
+++ b/test/show.jl
@@ -2607,11 +2607,12 @@ end
         @test occursin("(a, [b])", repr)
         @test occursin("(x, y::Integer)", repr)
     end
-    f44434_3(a, b::Integer=5) = pass
+    # use @eval to avoid a warning about method definition overwritten
+    @eval f44434_3(a, b::Integer=5) = pass
     let repr = sprint(show, "text/plain", methods(f44434_3))
         @test occursin("(a, [b::Integer])", repr)
     end
-    f44434_3(x, y::Integer) = pass
+    @eval f44434_3(x, y::Integer) = pass
     let repr = sprint(show, "text/plain", methods(f44434_3))
         @test !occursin("(a, [b::Integer])", repr)
         @test occursin("(a)", repr)


### PR DESCRIPTION
When defining a function with both optional and keyword arguments, the representation of the resulting methods do not show the keyword arguments, except for the last one. For example, there is no `foo(a; kwarg)` method appearing in the following list, although calling `foo(3; kwarg=6)` is valid:
```julia
julia> foo(a, b=3; kwarg) = nothing
foo (generic function with 2 methods)

julia> methods(foo)
# 2 methods for generic function "foo" from Main:
 [1] foo(a)
     @ REPL[1]:1
 [2] foo(a, b; kwarg)
     @ REPL[1]:1
```

I suppose this comes from the actual implementation of method dispatch with keyword arguments, with the kwsorter and stuff, and there are good reasons why those methods are defined like that. Without changing any of these internals thus, this PR changes the **representation** of the `MethodList` created when calling `methods(foo)`, in order to show a "factored method" closer to the definition:
```julia
julia> methods(foo)
# 2 methods for generic function "foo" from Main:
 [1:2] foo(a, [b]; kwarg)
     @ REPL[1]:1
```

This is done by converting the `MethodList` to the new `FactoredMethodList` type upon calling `show`, so the `MethodList` itself is untouched. You can still access the previous representation by looking at the actual list of methods:
```julia
julia> methods(foo).ms
[1] foo(a) @ Main REPL[1]:1
[2] foo(a, b; kwarg) @ Main REPL[1]:1
```

The detection of "factored method" definitions works by comparing the locations of the method definitions, as well as their argument names and types. It's not perfect since you could define methods at the same position through macros or `@eval`, but I don't think it's too bad since there is no loss of information anyway, all previously represented methods will still be represented (in a more compact way possibly).

This is also ported to REPL completions, which was the initial reason for this PR (see #43536):
```julia
julia> iterate(trues(6), #TAB
iterate(B::BitArray, [i::Int64]) @ Base bitarray.jl:361
iterate(A::AbstractArray, state) @ Base abstractarray.jl:1217
```