### PR TITLE
Non-capturing BoundsError API

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -57,6 +57,9 @@ modifyproperty!(x, f::Symbol, op, v, order::Symbol=:notatomic) =
 replaceproperty!(x, f::Symbol, expected, desired, success_order::Symbol=:notatomic, fail_order::Symbol=success_order) =
     (@inline; Core.replacefield!(x, f, expected, convert(fieldtype(typeof(x), f), desired), success_order, fail_order))
 
+throw_boundserror(a, i) = (@noinline; throw(BoundsError(a, i)))
+throw_boundserror() = (@noinline; throw(BoundsError()))
+
 convert(::Type{Any}, Core.@nospecialize x) = x
 convert(::Type{T}, x::T) where {T} = x
 include("coreio.jl")

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -253,7 +253,7 @@ julia> selectdim(A, 2, 3:4)
 @noinline function _selectdim(A, d, i, idxs)
     d >= 1 || throw(ArgumentError("dimension must be ≥ 1, got $d"))
     nd = ndims(A)
-    d > nd && (i == 1 || throw(BoundsError(A, (ntuple(Returns(Colon()),d-1)..., i))))
+    d > nd && (i == 1 || throw_boundserror(A, (ntuple(Returns(Colon()),d-1)..., i)))
     return view(A, idxs...)
 end
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -326,7 +326,7 @@ function _copyto_impl!(dest::Array, doffs::Integer, src::Array, soffs::Integer, 
     n == 0 && return dest
     n > 0 || _throw_argerror()
     if soffs < 1 || doffs < 1 || soffs+n-1 > length(src) || doffs+n-1 > length(dest)
-        throw(BoundsError())
+        throw_boundserror()
     end
     unsafe_copyto!(dest, doffs, src, soffs, n)
     return dest
@@ -1568,7 +1568,7 @@ function _deleteat!(a::Vector, inds, dltd=Nowhere())
             if i < q
                 throw(ArgumentError("indices must be unique and sorted"))
             else
-                throw(BoundsError())
+                throw_boundserror()
             end
         end
         while q < i
@@ -1589,7 +1589,7 @@ end
 # Simpler and more efficient version for logical indexing
 function deleteat!(a::Vector, inds::AbstractVector{Bool})
     n = length(a)
-    length(inds) == n || throw(BoundsError(a, inds))
+    length(inds) == n || throw_boundserror(a, inds)
     p = 1
     for (q, i) in enumerate(inds)
         _copy_item!(a, p, q)
@@ -1864,9 +1864,9 @@ function reverse!(v::AbstractVector, start::Integer, stop::Integer=lastindex(v))
     liv = LinearIndices(v)
     if n <= s  # empty case; ok
     elseif !(first(liv) ≤ s ≤ last(liv))
-        throw(BoundsError(v, s))
+        throw_boundserror(v, s)
     elseif !(first(liv) ≤ n ≤ last(liv))
-        throw(BoundsError(v, n))
+        throw_boundserror(v, n)
     end
     r = n
     @inbounds for i in s:div(s+n-1, 2)

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -434,7 +434,7 @@ function one(x::BitMatrix)
 end
 
 function copyto!(dest::BitArray, src::BitArray)
-    length(src) > length(dest) && throw(BoundsError(dest, length(dest)+1))
+    length(src) > length(dest) && throw_boundserror(dest, length(dest)+1)
     destc = dest.chunks; srcc = src.chunks
     nc = min(length(destc), length(srcc))
     nc == 0 && return dest
@@ -462,15 +462,15 @@ copyto!(dest::BitArray, doffs::Integer, src::Array, soffs::Integer, n::Integer) 
     _copyto_int!(dest, Int(doffs), src, Int(soffs), Int(n))
 function _copyto_int!(dest::BitArray, doffs::Int, src::Array, soffs::Int, n::Int)
     n == 0 && return dest
-    soffs < 1 && throw(BoundsError(src, soffs))
-    doffs < 1 && throw(BoundsError(dest, doffs))
-    soffs+n-1 > length(src) && throw(BoundsError(src, length(src)+1))
-    doffs+n-1 > length(dest) && throw(BoundsError(dest, length(dest)+1))
+    soffs < 1 && throw_boundserror(src, soffs)
+    doffs < 1 && throw_boundserror(dest, doffs)
+    soffs+n-1 > length(src) && throw_boundserror(src, length(src)+1)
+    doffs+n-1 > length(dest) && throw_boundserror(dest, length(dest)+1)
     return unsafe_copyto!(dest, doffs, src, soffs, n)
 end
 
 function copyto!(dest::BitArray, src::Array)
-    length(src) > length(dest) && throw(BoundsError(dest, length(dest)+1))
+    length(src) > length(dest) && throw_boundserror(dest, length(dest)+1)
     length(src) == 0 && return dest
     return unsafe_copyto!(dest, 1, src, 1, length(src))
 end
@@ -811,7 +811,7 @@ resize!(B::BitVector, n::Integer) = _resize_int!(B, Int(n))
 function _resize_int!(B::BitVector, n::Int)
     n0 = length(B)
     n == n0 && return B
-    n >= 0 || throw(BoundsError(B, n))
+    n >= 0 || throw_boundserror(B, n)
     if n < n0
         deleteat!(B, n+1:n0)
         return B
@@ -888,7 +888,7 @@ insert!(B::BitVector, i::Integer, item) = _insert_int!(B, Int(i), item)
 function _insert_int!(B::BitVector, i::Int, item)
     i = Int(i)
     n = length(B)
-    1 <= i <= n+1 || throw(BoundsError(B, i))
+    1 <= i <= n+1 || throw_boundserror(B, i)
     item = convert(Bool, item)
 
     Bc = B.chunks
@@ -950,7 +950,7 @@ function deleteat!(B::BitVector, i::Integer)
     i isa Bool && depwarn("passing Bool as an index is deprecated", :deleteat!)
     i = Int(i)
     n = length(B)
-    1 <= i <= n || throw(BoundsError(B, i))
+    1 <= i <= n || throw_boundserror(B, i)
 
     return _deleteat!(B, i)
 end
@@ -959,8 +959,8 @@ function deleteat!(B::BitVector, r::AbstractUnitRange{Int})
     n = length(B)
     i_f = first(r)
     i_l = last(r)
-    1 <= i_f || throw(BoundsError(B, i_f))
-    i_l <= n || throw(BoundsError(B, n+1))
+    1 <= i_f || throw_boundserror(B, i_f)
+    i_l <= n || throw_boundserror(B, n+1)
 
     Bc = B.chunks
     new_l = length(B) - length(r)
@@ -997,7 +997,7 @@ function deleteat!(B::BitVector, inds)
         if !(q <= i <= n)
             i isa Bool && throw(ArgumentError("invalid index $i of type Bool"))
             i < q && throw(ArgumentError("indices must be unique and sorted"))
-            throw(BoundsError(B, i))
+            throw_boundserror(B, i)
         end
         new_l -= 1
         if i > q
@@ -1023,7 +1023,7 @@ function deleteat!(B::BitVector, inds)
 end
 
 function deleteat!(B::BitVector, inds::AbstractVector{Bool})
-    length(inds) == length(B) || throw(BoundsError(B, inds))
+    length(inds) == length(B) || throw_boundserror(B, inds)
 
     n = new_l = length(B)
     y = findfirst(inds)
@@ -1073,7 +1073,7 @@ function splice!(B::BitVector, i::Integer)
     i isa Bool && depwarn("passing Bool as an index is deprecated", :splice!)
     i = Int(i)
     n = length(B)
-    1 <= i <= n || throw(BoundsError(B, i))
+    1 <= i <= n || throw_boundserror(B, i)
 
     v = B[i]   # TODO: change to a copy if/when subscripting becomes an ArrayView
     _deleteat!(B, i)
@@ -1090,8 +1090,8 @@ end
 function _splice_int!(B::BitVector, r, ins)
     n = length(B)
     i_f, i_l = first(r), last(r)
-    1 <= i_f <= n+1 || throw(BoundsError(B, i_f))
-    i_l <= n || throw(BoundsError(B, n+1))
+    1 <= i_f <= n+1 || throw_boundserror(B, i_f)
+    i_l <= n || throw_boundserror(B, n+1)
 
     Bins = convert(BitArray, ins)
 
@@ -1471,7 +1471,7 @@ end
 # returns the index of the next true element, or nothing if all false
 function findnext(B::BitArray, start::Integer)
     start = Int(start)
-    start > 0 || throw(BoundsError(B, start))
+    start > 0 || throw_boundserror(B, start)
     start > length(B) && return nothing
     unsafe_bitfindnext(B.chunks, start)
 end
@@ -1480,7 +1480,7 @@ end
 
 # aux function: same as findnext(~B, start), but performed without temporaries
 function findnextnot(B::BitArray, start::Int)
-    start > 0 || throw(BoundsError(B, start))
+    start > 0 || throw_boundserror(B, start)
     start > length(B) && return nothing
 
     Bc = B.chunks
@@ -1528,7 +1528,7 @@ function _findnext_int(testf::Function, B::BitArray, start::Int)
     !f0 && f1 && return findnext(B, start)
     f0 && !f1 && return findnextnot(B, start)
 
-    start > 0 || throw(BoundsError(B, start))
+    start > 0 || throw_boundserror(B, start)
     start > length(B) && return nothing
     f0 && f1 && return start
     return nothing # last case: !f0 && !f1
@@ -1557,14 +1557,14 @@ end
 function findprev(B::BitArray, start::Integer)
     start = Int(start)
     start > 0 || return nothing
-    start > length(B) && throw(BoundsError(B, start))
+    start > length(B) && throw_boundserror(B, start)
     unsafe_bitfindprev(B.chunks, start)
 end
 
 function findprevnot(B::BitArray, start::Int)
     start = Int(start)
     start > 0 || return nothing
-    start > length(B) && throw(BoundsError(B, start))
+    start > length(B) && throw_boundserror(B, start)
 
     Bc = B.chunks
 
@@ -1605,7 +1605,7 @@ function _findprev_int(testf::Function, B::BitArray, start::Int)
     f0 && !f1 && return findprevnot(B, start)
 
     start > 0 || return nothing
-    start > length(B) && throw(BoundsError(B, start))
+    start > length(B) && throw_boundserror(B, start)
     f0 && f1 && return start
     return nothing # last case: !f0 && !f1
 end

--- a/base/char.jl
+++ b/base/char.jl
@@ -192,7 +192,7 @@ typemax(::Type{Char}) = bitcast(Char, typemax(UInt32))
 typemin(::Type{Char}) = bitcast(Char, typemin(UInt32))
 
 size(c::AbstractChar) = ()
-size(c::AbstractChar, d::Integer) = d < 1 ? throw(BoundsError()) : 1
+size(c::AbstractChar, d::Integer) = d < 1 ? throw_boundserror() : 1
 ndims(c::AbstractChar) = 0
 ndims(::Type{<:AbstractChar}) = 0
 length(c::AbstractChar) = 1
@@ -200,8 +200,8 @@ IteratorSize(::Type{Char}) = HasShape{0}()
 firstindex(c::AbstractChar) = 1
 lastindex(c::AbstractChar) = 1
 getindex(c::AbstractChar) = c
-getindex(c::AbstractChar, i::Integer) = i == 1 ? c : throw(BoundsError())
-getindex(c::AbstractChar, I::Integer...) = all(x -> x == 1, I) ? c : throw(BoundsError())
+getindex(c::AbstractChar, i::Integer) = i == 1 ? c : throw_boundserror()
+getindex(c::AbstractChar, I::Integer...) = all(x -> x == 1, I) ? c : throw_boundserror()
 first(c::AbstractChar) = c
 last(c::AbstractChar) = c
 eltype(::Type{T}) where {T<:AbstractChar} = T

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -97,8 +97,8 @@ isperm(P::Any32) = _isperm(P)
 function swapcols!(a::AbstractMatrix, i, j)
     i == j && return
     cols = axes(a,2)
-    @boundscheck i in cols || throw(BoundsError(a, (:,i)))
-    @boundscheck j in cols || throw(BoundsError(a, (:,j)))
+    @boundscheck i in cols || throw_boundserror(a, (:,i))
+    @boundscheck j in cols || throw_boundserror(a, (:,j))
     for k in axes(a,1)
         @inbounds a[k,i],a[k,j] = a[k,j],a[k,i]
     end
@@ -108,8 +108,8 @@ end
 function swaprows!(a::AbstractMatrix, i, j)
     i == j && return
     rows = axes(a,1)
-    @boundscheck i in rows || throw(BoundsError(a, (:,i)))
-    @boundscheck j in rows || throw(BoundsError(a, (:,j)))
+    @boundscheck i in rows || throw_boundserror(a, (:,i))
+    @boundscheck j in rows || throw_boundserror(a, (:,j))
     for k in axes(a,2)
         @inbounds a[i,k],a[j,k] = a[j,k],a[i,k]
     end

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -413,38 +413,38 @@ function setindex!(x::UseRef, @nospecialize(v))
         rhs = stmt.args[2]
         if isa(rhs, Expr)
             if is_relevant_expr(rhs)
-                x.op > length(rhs.args) && throw(BoundsError())
+                x.op > length(rhs.args) && throw_boundserror()
                 rhs.args[x.op] = v
                 return v
             end
         end
-        x.op == 1 || throw(BoundsError())
+        x.op == 1 || throw_boundserror()
         stmt.args[2] = v
     elseif isa(stmt, Expr) # @assert is_relevant_expr(stmt)
-        x.op > length(stmt.args) && throw(BoundsError())
+        x.op > length(stmt.args) && throw_boundserror()
         stmt.args[x.op] = v
     elseif isa(stmt, GotoIfNot)
-        x.op == 1 || throw(BoundsError())
+        x.op == 1 || throw_boundserror()
         x.stmt = GotoIfNot(v, stmt.dest)
     elseif isa(stmt, ReturnNode)
-        x.op == 1 || throw(BoundsError())
+        x.op == 1 || throw_boundserror()
         x.stmt = typeof(stmt)(v)
     elseif isa(stmt, UpsilonNode)
-        x.op == 1 || throw(BoundsError())
+        x.op == 1 || throw_boundserror()
         x.stmt = typeof(stmt)(v)
     elseif isa(stmt, PiNode)
-        x.op == 1 || throw(BoundsError())
+        x.op == 1 || throw_boundserror()
         x.stmt = typeof(stmt)(v, stmt.typ)
     elseif isa(stmt, PhiNode)
-        x.op > length(stmt.values) && throw(BoundsError())
-        isassigned(stmt.values, x.op) || throw(BoundsError())
+        x.op > length(stmt.values) && throw_boundserror()
+        isassigned(stmt.values, x.op) || throw_boundserror()
         stmt.values[x.op] = v
     elseif isa(stmt, PhiCNode)
-        x.op > length(stmt.values) && throw(BoundsError())
-        isassigned(stmt.values, x.op) || throw(BoundsError())
+        x.op > length(stmt.values) && throw_boundserror()
+        isassigned(stmt.values, x.op) || throw_boundserror()
         stmt.values[x.op] = v
     else
-        throw(BoundsError())
+        throw_boundserror()
     end
     return x
 end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -40,7 +40,36 @@ function showerror(io::IO, ex::BoundsError)
     print(io, "BoundsError")
     if isdefined(ex, :a)
         print(io, ": attempt to access ")
-        summary(io, ex.a)
+        a = ex.a
+        if isa(a, Core.Summarized)
+            typ = a.type
+            ax = a.axes
+            if typ <: Tuple
+                # We could give more info here, since we have a.axes, but this is the current behavior.
+                print(io, typ)
+            elseif typ <: AbstractString
+                ax = ax[1]
+                print(io, ax, "-codeunit ", typ)
+            elseif isa(ax, Tuple)
+                if length(ax) == 1
+                    ax = ax[1]
+                    isa(ax, OneTo) && (ax = ax.stop)
+                    isa(ax, Int) && print(io, ax, "-element ", typ)
+                else
+                    for i = 1:length(ax)
+                        if i == length(ax)
+                            print(io, ax[i].stop, " ", typ)
+                        else
+                            print(io, ax[i].stop, "x")
+                        end
+                    end
+                end
+            else
+                print(io, typ)
+            end
+        else
+            summary(io, a)
+        end
         if isdefined(ex, :i)
             print(io, " at index [")
             if ex.i isa AbstractRange

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -607,7 +607,7 @@ end
 
 function getindex(v::SimpleVector, i::Int)
     @boundscheck if !(1 <= i <= length(v))
-        throw(BoundsError(v,i))
+        throw_boundserror(v,i)
     end
     return ccall(:jl_svec_ref, Any, (Any, Int), v, i - 1)
 end

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -446,6 +446,7 @@ export
     sum!,
     sum,
     to_indices,
+    throw_boundserror,
     vcat,
     vec,
     view,

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -196,7 +196,7 @@ function read_sub(from::GenericIOBuffer, a::AbstractArray{T}, offs, nel) where T
     require_one_based_indexing(a)
     from.readable || _throw_not_readable()
     if offs+nel-1 > length(a) || offs < 1 || nel < 0
-        throw(BoundsError())
+        throw_boundserror()
     end
     if isbitstype(T) && isa(a,Array)
         nb = UInt(nel * sizeof(T))

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -193,7 +193,7 @@ end
 function _parse_string(text::AbstractString, filename::AbstractString,
                        lineno::Integer, index::Integer, options)
     if index < 1 || index > ncodeunits(text) + 1
-        throw(BoundsError(text, index))
+        throw_boundserror(text, index)
     end
     ex, offset::Int = Core._parse(text, filename, lineno, index-1, options)
     ex, offset+1

--- a/base/number.jl
+++ b/base/number.jl
@@ -78,29 +78,29 @@ false
 isfinite(x::Number) = iszero(x - x)
 
 size(x::Number) = ()
-size(x::Number, d::Integer) = d < 1 ? throw(BoundsError()) : 1
+size(x::Number, d::Integer) = d < 1 ? throw_boundserror() : 1
 axes(x::Number) = ()
-axes(x::Number, d::Integer) = d < 1 ? throw(BoundsError()) : OneTo(1)
+axes(x::Number, d::Integer) = d < 1 ? throw_boundserror() : OneTo(1)
 eltype(::Type{T}) where {T<:Number} = T
 ndims(x::Number) = 0
 ndims(::Type{<:Number}) = 0
 length(x::Number) = 1
 firstindex(x::Number) = 1
-firstindex(x::Number, d::Int) = d < 1 ? throw(BoundsError()) : 1
+firstindex(x::Number, d::Int) = d < 1 ? throw_boundserror() : 1
 lastindex(x::Number) = 1
-lastindex(x::Number, d::Int) = d < 1 ? throw(BoundsError()) : 1
+lastindex(x::Number, d::Int) = d < 1 ? throw_boundserror() : 1
 IteratorSize(::Type{<:Number}) = HasShape{0}()
 keys(::Number) = OneTo(1)
 
 getindex(x::Number) = x
 function getindex(x::Number, i::Integer)
     @inline
-    @boundscheck i == 1 || throw(BoundsError())
+    @boundscheck i == 1 || throw_boundserror()
     x
 end
 function getindex(x::Number, I::Integer...)
     @inline
-    @boundscheck all(isone, I) || throw(BoundsError())
+    @boundscheck all(isone, I) || throw_boundserror()
     x
 end
 get(x::Number, i::Integer, default) = isone(i) ? x : default

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -164,7 +164,7 @@ end
 
 fieldname(t::UnionAll, i::Integer) = fieldname(unwrap_unionall(t), i)
 fieldname(t::Type{<:Tuple}, i::Integer) =
-    i < 1 || i > fieldcount(t) ? throw(BoundsError(t, i)) : Int(i)
+    i < 1 || i > fieldcount(t) ? throw_boundserror(t, i) : Int(i)
 
 """
     fieldnames(x::DataType)
@@ -477,7 +477,7 @@ function getindex(dtfd::DataTypeFieldDesc, i::Int)
     layout = unsafe_load(layout_ptr)
     fielddesc_type = (layout.flags >> 1) & 3
     nfields = layout.nfields
-    @boundscheck ((1 <= i <= nfields) || throw(BoundsError(dtfd, i)))
+    @boundscheck ((1 <= i <= nfields) || throw_boundserror(dtfd, i))
     if fielddesc_type == 0
         return FieldDesc(unsafe_load(Ptr{FieldDescStorage{UInt8}}(fd_ptr), i))
     elseif fielddesc_type == 1

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -409,7 +409,7 @@ findnext(re::Regex, str::Union{String,SubString}, idx::Integer) = _findnext_re(r
 # TODO: return only start index and update deprecation
 function _findnext_re(re::Regex, str::Union{String,SubString}, idx::Integer, match_data::Ptr{Cvoid})
     if idx > nextind(str,lastindex(str))
-        throw(BoundsError())
+        throw_boundserror()
     end
     opts = re.match_options
     compile(re)

--- a/base/show.jl
+++ b/base/show.jl
@@ -2792,6 +2792,7 @@ function summary(x)
     String(take!(io))
 end
 
+
 ## `summary` for AbstractArrays
 # sizes such as 0-dimensional, 4-dimensional, 2x3
 dims2string(d) = isempty(d) ? "0-dimensional" :

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -6,7 +6,7 @@ function findnext(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:AbstractChar}
                   s::String, i::Integer)
     if i < 1 || i > sizeof(s)
         i == sizeof(s) + 1 && return nothing
-        throw(BoundsError(s, i))
+        throw_boundserror(s, i)
     end
     @inbounds isvalid(s, i) || string_index_err(s, i)
     c = pred.x
@@ -30,11 +30,11 @@ findnext(::typeof(iszero), a::ByteArray, i::Integer) = nothing_sentinel(_search(
 
 function _search(a::Union{String,ByteArray}, b::Union{Int8,UInt8}, i::Integer = 1)
     if i < 1
-        throw(BoundsError(a, i))
+        throw_boundserror(a, i)
     end
     n = sizeof(a)
     if i > n
-        return i == n+1 ? 0 : throw(BoundsError(a, i))
+        return i == n+1 ? 0 : throw_boundserror(a, i)
     end
     p = pointer(a)
     q = GC.@preserve a ccall(:memchr, Ptr{UInt8}, (Ptr{UInt8}, Int32, Csize_t), p+i-1, b, n-i+1)
@@ -73,11 +73,11 @@ findprev(::typeof(iszero), a::ByteArray, i::Integer) = nothing_sentinel(_rsearch
 
 function _rsearch(a::Union{String,ByteArray}, b::Union{Int8,UInt8}, i::Integer = sizeof(a))
     if i < 1
-        return i == 0 ? 0 : throw(BoundsError(a, i))
+        return i == 0 ? 0 : throw_boundserror(a, i)
     end
     n = sizeof(a)
     if i > n
-        return i == n+1 ? 0 : throw(BoundsError(a, i))
+        return i == n+1 ? 0 : throw_boundserror(a, i)
     end
     p = pointer(a)
     q = GC.@preserve a ccall(:memrchr, Ptr{UInt8}, (Ptr{UInt8}, Int32, Csize_t), p, b, i)
@@ -152,7 +152,7 @@ findfirst(pattern::AbstractVector{<:Union{Int8,UInt8}},
 function findnext(testf::Function, s::AbstractString, i::Integer)
     i = Int(i)
     z = ncodeunits(s) + 1
-    1 ≤ i ≤ z || throw(BoundsError(s, i))
+    1 ≤ i ≤ z || throw_boundserror(s, i)
     @inbounds i == z || isvalid(s, i) || string_index_err(s, i)
     e = lastindex(s)
     while i <= e
@@ -171,7 +171,7 @@ function _searchindex(s::Union{AbstractString,ByteArray},
     x = Iterators.peel(t)
     if isnothing(x)
         return 1 <= i <= nextind(s,lastindex(s))::Int ? i :
-               throw(BoundsError(s, i))
+               throw_boundserror(s, i)
     end
     t1, trest = x
     while true
@@ -207,7 +207,7 @@ function _searchindex(s::AbstractVector{<:Union{Int8,UInt8}},
     n = length(t)
     m = length(s)
     i = Int(_i) - sentinel
-    (i < 1 || i > m+1) && throw(BoundsError(s, _i))
+    (i < 1 || i > m+1) && throw_boundserror(s, _i)
 
     if n == 0
         return 1 <= i <= m+1 ? max(1, i) : sentinel
@@ -410,7 +410,7 @@ findlast(ch::AbstractChar, string::AbstractString) = findlast(==(ch), string)
 function findprev(testf::Function, s::AbstractString, i::Integer)
     i = Int(i)
     z = ncodeunits(s) + 1
-    0 ≤ i ≤ z || throw(BoundsError(s, i))
+    0 ≤ i ≤ z || throw_boundserror(s, i)
     i == z && return nothing
     @inbounds i == 0 || isvalid(s, i) || string_index_err(s, i)
     while i >= 1
@@ -425,7 +425,7 @@ function _rsearchindex(s::AbstractString,
                        i::Integer)
     if isempty(t)
         return 1 <= i <= nextind(s, lastindex(s))::Int ? i :
-               throw(BoundsError(s, i))
+               throw_boundserror(s, i)
     end
     t1, trest = Iterators.peel(Iterators.reverse(t))::NTuple{2,Any}
     while true
@@ -465,7 +465,7 @@ function _rsearchindex(s::AbstractVector{<:Union{Int8,UInt8}}, t::AbstractVector
     n = length(t)
     m = length(s)
     k = Int(_k) - sentinel
-    k < 0 && throw(BoundsError(s, _k))
+    k < 0 && throw_boundserror(s, _k)
 
     if n == 0
         return 0 <= k <= m ? max(k, 1) : sentinel

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -146,7 +146,7 @@ typemin(::String) = typemin(String)
     i == 0 && return 0
     n = ncodeunits(s)
     i == n + 1 && return i
-    @boundscheck between(i, 1, n) || throw(BoundsError(s, i))
+    @boundscheck between(i, 1, n) || throw_boundserror(s, i)
     @inbounds b = codeunit(s, i)
     (b & 0xc0 == 0x80) & (i-1 > 0) || return i
     @inbounds b = codeunit(s, i-1)
@@ -166,7 +166,7 @@ end
 @inline function _nextind_str(s, i::Int)
     i == 0 && return 1
     n = ncodeunits(s)
-    @boundscheck between(i, 1, n) || throw(BoundsError(s, i))
+    @boundscheck between(i, 1, n) || throw_boundserror(s, i)
     @inbounds l = codeunit(s, i)
     (l < 0x80) | (0xf8 ≤ l) && return i+1
     if l < 0xc0
@@ -286,8 +286,8 @@ length(s::String) = length_continued(s, 1, ncodeunits(s), ncodeunits(s))
 
 @inline function length(s::String, i::Int, j::Int)
     @boundscheck begin
-        0 < i ≤ ncodeunits(s)+1 || throw(BoundsError(s, i))
-        0 ≤ j < ncodeunits(s)+1 || throw(BoundsError(s, j))
+        0 < i ≤ ncodeunits(s)+1 || throw_boundserror(s, i)
+        0 ≤ j < ncodeunits(s)+1 || throw_boundserror(s, j)
     end
     j < i && return 0
     @inbounds i, k = thisind(s, i), i

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -174,7 +174,7 @@ simply needs to define [`getindex`](@ref):
 
 ```jldoctest squaretype
 julia> function Base.getindex(S::Squares, i::Int)
-           1 <= i <= S.count || throw(BoundsError(S, i))
+           1 <= i <= S.count || throw_boundserror(S, i)
            return i*i
        end
 

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -1338,7 +1338,7 @@ The same thing can be done using recursion:
 julia> sub2ind_rec(dims::Tuple{}) = 1;
 
 julia> sub2ind_rec(dims::Tuple{}, i1::Integer, I::Integer...) =
-           i1 == 1 ? sub2ind_rec(dims, I...) : throw(BoundsError());
+           i1 == 1 ? sub2ind_rec(dims, I...) : throw_boundserror();
 
 julia> sub2ind_rec(dims::Tuple{Integer, Vararg{Integer}}, i1::Integer) = i1;
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -617,6 +617,12 @@ static const auto jlboundserror_func = new JuliaFunction{
             {PointerType::get(JuliaType::get_jlvalue_ty(C), AddressSpace::CalleeRooted), getSizeTy(C)}, false); },
     get_attrs_noreturn,
 };
+static const auto jlboundserrorsum_func = new JuliaFunction{
+    XSTR(jl_bounds_error_summarized),
+    [](LLVMContext &C) { return FunctionType::get(getVoidTy(C),
+            {getSizeTy(C), PointerType::get(JuliaType::get_jlvalue_ty(C), AddressSpace::CalleeRooted), getSizeTy(C)}, false); },
+    get_attrs_noreturn,
+};
 static const auto jlvboundserror_func = new JuliaFunction{
     XSTR(jl_bounds_error_tuple_int),
     [](LLVMContext &C) { return FunctionType::get(getVoidTy(C),
@@ -8066,6 +8072,7 @@ static void init_jit_functions(void)
     add_named_global(jlundefvarerror_func, &jl_undefined_var_error);
     add_named_global(jlboundserrorv_func, &jl_bounds_error_ints);
     add_named_global(jlboundserror_func, &jl_bounds_error_int);
+    add_named_global(jlboundserrorsum_func, &jl_bounds_error_summarized);
     add_named_global(jlvboundserror_func, &jl_bounds_error_tuple_int);
     add_named_global(jluboundserror_func, &jl_bounds_error_unboxed_int);
     add_named_global(jlnew_func, &jl_new_structv);

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -1408,7 +1408,7 @@ JL_DLLEXPORT jl_value_t *jl_get_nth_field(jl_value_t *v, size_t i)
 {
     jl_datatype_t *st = (jl_datatype_t*)jl_typeof(v);
     if (i >= jl_datatype_nfields(st))
-        jl_bounds_error_int(v, i + 1);
+        jl_bounds_error_summarized(jl_nfields(v), (jl_value_t *)st, i + 1);
     size_t offs = jl_field_offset(st, i);
     if (jl_field_isptr(st, i)) {
         return jl_atomic_load_relaxed((_Atomic(jl_value_t*)*)((char*)v + offs));

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -61,6 +61,7 @@
     XX(jl_bounds_error) \
     XX(jl_bounds_error_int) \
     XX(jl_bounds_error_ints) \
+    XX(jl_bounds_error_summarized) \
     XX(jl_bounds_error_tuple_int) \
     XX(jl_bounds_error_unboxed_int) \
     XX(jl_bounds_error_v) \

--- a/src/julia.h
+++ b/src/julia.h
@@ -1667,6 +1667,9 @@ JL_DLLEXPORT void JL_NORETURN jl_bounds_error_v(jl_value_t *v JL_MAYBE_UNROOTED,
                                                 jl_value_t **idxs, size_t nidxs);
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error_int(jl_value_t *v JL_MAYBE_UNROOTED,
                                                   size_t i);
+JL_DLLEXPORT void JL_NORETURN jl_bounds_error_summarized(size_t nfields JL_MAYBE_UNROOTED,
+                                                         jl_value_t *ty JL_MAYBE_UNROOTED,
+                                                         size_t i);
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error_tuple_int(jl_value_t **v,
                                                         size_t nv, size_t i);
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error_unboxed_int(void *v, jl_value_t *vt, size_t i);

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -139,11 +139,29 @@ JL_DLLEXPORT void JL_NORETURN jl_atomic_error(char *str) // == jl_exceptionf(jl_
     jl_throw(jl_new_struct(jl_atomicerror_type, msg));
 }
 
+void JL_NORETURN jl_throw_bounds_error(jl_value_t *v, jl_value_t *t)
+{
+    jl_value_t **args;
+    JL_GC_PUSHARGS(args, 2);
+    args[0] = v;
+    args[1] = t;
+    jl_throw(jl_apply_generic((jl_value_t*)jl_boundserror_type, args, 2));
+}
+
+void JL_NORETURN jl_throw_bounds_error_summarized(jl_value_t *axes, jl_value_t *typ, jl_value_t *t)
+{
+    jl_value_t **args;
+    JL_GC_PUSHARGS(args, 3);
+    args[0] = axes;
+    args[1] = typ;
+    args[2] = t;
+    jl_throw(jl_apply_generic((jl_value_t*)jl_boundserror_type, args, 3));
+}
 
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error(jl_value_t *v, jl_value_t *t)
 {
     JL_GC_PUSH2(&v, &t); // root arguments so the caller doesn't need to
-    jl_throw(jl_new_struct((jl_datatype_t*)jl_boundserror_type, v, t));
+    jl_throw_bounds_error(v, t);
 }
 
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error_v(jl_value_t *v, jl_value_t **idxs, size_t nidxs)
@@ -152,7 +170,7 @@ JL_DLLEXPORT void JL_NORETURN jl_bounds_error_v(jl_value_t *v, jl_value_t **idxs
     // items in idxs are assumed to already be rooted
     JL_GC_PUSH2(&v, &t); // root v so the caller doesn't need to
     t = jl_f_tuple(NULL, idxs, nidxs);
-    jl_throw(jl_new_struct((jl_datatype_t*)jl_boundserror_type, v, t));
+    jl_throw_bounds_error(v, t);
 }
 
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error_tuple_int(jl_value_t **v, size_t nv, size_t i)
@@ -169,7 +187,7 @@ JL_DLLEXPORT void JL_NORETURN jl_bounds_error_unboxed_int(void *data, jl_value_t
     JL_GC_PUSH2(&v, &t);
     v = jl_new_bits(vt, data);
     t = jl_box_long(i);
-    jl_throw(jl_new_struct((jl_datatype_t*)jl_boundserror_type, v, t));
+    jl_throw_bounds_error(v, t);
 }
 
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error_int(jl_value_t *v JL_MAYBE_UNROOTED, size_t i)
@@ -177,7 +195,7 @@ JL_DLLEXPORT void JL_NORETURN jl_bounds_error_int(jl_value_t *v JL_MAYBE_UNROOTE
     jl_value_t *t = NULL;
     JL_GC_PUSH2(&v, &t); // root arguments so the caller doesn't need to
     t = jl_box_long(i);
-    jl_throw(jl_new_struct((jl_datatype_t*)jl_boundserror_type, v, t));
+    jl_throw_bounds_error(v, t);
 }
 
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error_ints(jl_value_t *v JL_MAYBE_UNROOTED,
@@ -191,7 +209,18 @@ JL_DLLEXPORT void JL_NORETURN jl_bounds_error_ints(jl_value_t *v JL_MAYBE_UNROOT
         jl_svecset(t, i, jl_box_long(idxs[i]));
     }
     t = jl_f_tuple(NULL, jl_svec_data(t), nidxs);
-    jl_throw(jl_new_struct((jl_datatype_t*)jl_boundserror_type, v, t));
+    jl_throw_bounds_error(v, t);
+}
+
+JL_DLLEXPORT void JL_NORETURN jl_bounds_error_summarized(size_t nfields,
+                                                         jl_value_t *ty JL_MAYBE_UNROOTED, size_t i)
+{
+    jl_value_t *nf = NULL;
+    jl_value_t *t = NULL;
+    JL_GC_PUSH3(&nf, &ty, &t);
+    t = jl_box_long(i);
+    nf = jl_box_long(nfields);
+    jl_throw_bounds_error_summarized(nf, ty, t);
 }
 
 JL_DLLEXPORT void JL_NORETURN jl_eof_error(void)

--- a/stdlib/LibGit2/src/status.jl
+++ b/stdlib/LibGit2/src/status.jl
@@ -25,7 +25,7 @@ function Base.length(status::GitStatus)
 end
 
 function Base.getindex(status::GitStatus, i::Integer)
-    1 <= i <= length(status) || throw(BoundsError())
+    1 <= i <= length(status) || throw_boundserror()
     ensure_initialized()
     GC.@preserve status begin
         entry_ptr = ccall((:git_status_byindex, :libgit2),

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1419,9 +1419,9 @@ function axpy!(α, x::AbstractArray, rx::AbstractArray{<:Integer}, y::AbstractAr
     if length(rx) != length(ry)
         throw(DimensionMismatch("rx has length $(length(rx)), but ry has length $(length(ry))"))
     elseif !checkindex(Bool, eachindex(IndexLinear(), x), rx)
-        throw(BoundsError(x, rx))
+        throw_boundserror(x, rx)
     elseif !checkindex(Bool, eachindex(IndexLinear(), y), ry)
-        throw(BoundsError(y, ry))
+        throw_boundserror(y, ry)
     end
     for (IY, IX) in zip(eachindex(ry), eachindex(rx))
         @inbounds y[ry[IY]] += x[rx[IX]]*α

--- a/stdlib/LinearAlgebra/src/lq.jl
+++ b/stdlib/LinearAlgebra/src/lq.jl
@@ -181,7 +181,7 @@ function size(Q::LQPackedQ)
 end
 function size(Q::LQPackedQ, dim::Integer)
     if dim < 1
-        throw(BoundsError())
+        throw_boundserror()
     elseif dim <= 2 # && 1 <= dim
         return size(Q.factors, 2)
     else # 2 < dim

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -19,10 +19,10 @@ function dot(x::Vector{T}, rx::AbstractRange{TI}, y::Vector{T}, ry::AbstractRang
         throw(DimensionMismatch(lazy"length of rx, $(length(rx)), does not equal length of ry, $(length(ry))"))
     end
     if minimum(rx) < 1 || maximum(rx) > length(x)
-        throw(BoundsError(x, rx))
+        throw_boundserror(x, rx)
     end
     if minimum(ry) < 1 || maximum(ry) > length(y)
-        throw(BoundsError(y, ry))
+        throw_boundserror(y, ry)
     end
     GC.@preserve x y BLAS.dot(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
 end
@@ -32,10 +32,10 @@ function dot(x::Vector{T}, rx::AbstractRange{TI}, y::Vector{T}, ry::AbstractRang
         throw(DimensionMismatch(lazy"length of rx, $(length(rx)), does not equal length of ry, $(length(ry))"))
     end
     if minimum(rx) < 1 || maximum(rx) > length(x)
-        throw(BoundsError(x, rx))
+        throw_boundserror(x, rx)
     end
     if minimum(ry) < 1 || maximum(ry) > length(y)
-        throw(BoundsError(y, ry))
+        throw_boundserror(y, ry)
     end
     GC.@preserve x y BLAS.dotc(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
 end

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -589,7 +589,7 @@ end
 copyto!(S::SharedArray, A::Array) = (copyto!(S.s, A); S)
 
 function copyto!(S::SharedArray, R::SharedArray)
-    length(S) == length(R) || throw(BoundsError())
+    length(S) == length(R) || throw_boundserror()
     ps = intersect(procs(S), procs(R))
     isempty(ps) && throw(ArgumentError("source and destination arrays don't share any process"))
     l = length(S)

--- a/stdlib/Sockets/src/IPAddr.jl
+++ b/stdlib/Sockets/src/IPAddr.jl
@@ -112,7 +112,7 @@ print_ipv6_field(io,field::UInt16) = print(io,string(field, base = 16))
 print_ipv6_field(io,ip,i) = print_ipv6_field(io,ipv6_field(ip,i))
 function ipv6_field(ip::IPv6,i)
     if i < 0 || i > 7
-        throw(BoundsError())
+        throw_boundserror()
     end
     UInt16((ip.host&(UInt128(0xFFFF)<<(i*16))) >> (i*16))
 end

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -126,7 +126,7 @@ else
 end
 
 # elide a throw
-cb(x) = x > 0 || throw(BoundsError())
+cb(x) = x > 0 || throw_boundserror()
 
 @inline function B1()
     y = [1, 2, 3]

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -281,7 +281,7 @@ struct TypeWithIntParam{T<:Integer, Vector{T}<:A<:AbstractArray{T}} end
 struct Bounded  # not an AbstractArray
     bound::Int
 end
-Base.getindex(b::Bounded, i) = checkindex(Bool, 1:b.bound, i) || throw(BoundsError(b, i))
+Base.getindex(b::Bounded, i) = checkindex(Bool, 1:b.bound, i) || throw_boundserror(b, i)
 Base.summary(io::IO, b::Bounded) = print(io, "$(b.bound)-size Bounded")
 let undefvar
     err_str = @except_strbt sqrt(-1) DomainError

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -250,7 +250,7 @@ struct ConstantRange{T} <: AbstractRange{T}
 end
 
 Base.length(r::ConstantRange) = r.len
-Base.getindex(r::ConstantRange, i::Int) = (1 <= i <= r.len || throw(BoundsError(r,i)); r.val)
+Base.getindex(r::ConstantRange, i::Int) = (1 <= i <= r.len || throw_boundserror(r,i); r.val)
 Base.step(r::ConstantRange) = 0
 
 @testset "searchsorted method with ranges which check for zero step range" begin


### PR DESCRIPTION
This PR rebases #43738 and changes the API for `BoundsError` a bit.

We export `throw_boundserror` from Base, which by default routes to the same `BoundsError` constructor that we know and love. However, we also implement a new `BoundsError` constructor that accepts axes (or whatever equivalent notion of size) and a type rather than an object. 

Therefore, by defining `throw_boundserror(t::Tuple,...)`, `throw_boundserror(s::AbstractString,...)` to give just the size and type info to the new `BoundsError` constructor, we avoid capture of these objects, opening us up to be a bit less conservative about `ThrownEscape` in #43800. Package developers can also add their own implementation of `throw_boundserror` to prevent their objects from being captured by `BoundsError` and give more accurate size/type in error messages for their custom types.

We also define a new function, `jl_bounds_error_summarized`, which replaces `jl_bounds_error` in `jl_get_nth_field` and similarly avoids the capture of structs via `getfield`/`getproperty`.

Note: for `Array`, we call `Base.axes` from inside of the normal `BoundsError` constructor, instead of defining a `throw_boundserror(a::AbstractArray,...)`, per https://github.com/JuliaLang/julia/pull/43738#discussion_r782597082.

Co-authored by Shuhei Kadowaki (@aviatesk)