### PR TITLE
Migrate codegen to operate on orc::ThreadSafeModule

### DIFF
--- a/doc/src/devdocs/locks.md
+++ b/doc/src/devdocs/locks.md
@@ -47,6 +47,11 @@ The following is a level 4 lock, which can only recurse to acquire level 1, 2, o
 
 No Julia code may be called while holding a lock above this point.
 
+orc::ThreadSafeContext locks occupy a special spot in the locking diagram. They are used to protect
+LLVM's global non-threadsafe state, but there may be an arbitrary number of them. For now, there is
+only one global context, and thus acquiring it is a level 5 lock. However, acquiring such a lock
+should only be done at the same time that the codegen lock is acquired.
+
 The following are a level 6 lock, which can only recurse to acquire locks at lower levels:
 
 >   * codegen

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -970,7 +970,7 @@ llvmGetPassPluginInfo() {
 // this is paired with jl_dump_function_ir, jl_dump_function_asm, jl_dump_method_asm in particular ways:
 // misuse will leak memory or cause read-after-free
 extern "C" JL_DLLEXPORT
-void *jl_get_llvmf_defn_impl(jl_method_instance_t *mi, LLVMOrcThreadSafeContextRef ctxt, size_t world, char getwrapper, char optimize, const jl_cgparams_t params)
+void *jl_get_llvmf_defn_impl(jl_method_instance_t *mi, size_t world, char getwrapper, char optimize, const jl_cgparams_t params)
 {
     if (jl_is_method(mi->def.method) && mi->def.method->source == NULL &&
             mi->def.method->generator == NULL) {
@@ -1013,7 +1013,7 @@ void *jl_get_llvmf_defn_impl(jl_method_instance_t *mi, LLVMOrcThreadSafeContextR
     // emit this function into a new llvm module
     if (src && jl_is_code_info(src)) {
         JL_LOCK(&jl_codegen_lock);
-        jl_codegen_params_t output(*reinterpret_cast<orc::ThreadSafeContext*>(ctxt));
+        jl_codegen_params_t output(jl_ExecutionEngine->getContext());
         output.world = world;
         output.params = &params;
         orc::ThreadSafeModule m = jl_create_llvm_module(name_from_method_instance(mi), output.tsctx);

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -512,7 +512,7 @@ void jl_dump_native_impl(void *native_code,
 
     // Reset the target triple to make sure it matches the new target machine
     data->M.getModuleUnlocked()->setTargetTriple(TM->getTargetTriple().str());
-    data->M.getModuleUnlocked()->setDataLayout(create_jl_data_layout(*TM));
+    data->M.getModuleUnlocked()->setDataLayout(jl_create_datalayout(*TM));
     Type *T_size;
     if (sizeof(size_t) == 8)
         T_size = Type::getInt64Ty(Context);

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -11,10 +11,10 @@ GlobalVariable *jl_emit_RTLD_DEFAULT_var(Module *M)
 // Find or create the GVs for the library and symbol lookup.
 // Return `runtime_lib` (whether the library name is a string)
 // The `lib` and `sym` GV returned may not be in the current module.
-static bool runtime_sym_gvs(jl_codegen_params_t &emission_context, const char *f_lib, const char *f_name,
+static bool runtime_sym_gvs(jl_codectx_t &ctx, const char *f_lib, const char *f_name,
                             GlobalVariable *&lib, GlobalVariable *&sym)
 {
-    auto &TSM = emission_context.shared_module(emission_context.tsctx);
+    auto &TSM = ctx.emission_context.shared_module(*jl_Module);
     //Safe b/c emission context holds context lock
     auto M = TSM.getModuleUnlocked();
     bool runtime_lib = false;
@@ -23,28 +23,28 @@ static bool runtime_sym_gvs(jl_codegen_params_t &emission_context, const char *f
 #ifdef _OS_WINDOWS_
     if ((intptr_t)f_lib == (intptr_t)JL_EXE_LIBNAME) {
         libptrgv = prepare_global_in(M, jlexe_var);
-        symMap = &emission_context.symMapExe;
+        symMap = &ctx.emission_context.symMapExe;
     }
     else if ((intptr_t)f_lib == (intptr_t)JL_LIBJULIA_INTERNAL_DL_LIBNAME) {
         libptrgv = prepare_global_in(M, jldlli_var);
-        symMap = &emission_context.symMapDlli;
+        symMap = &ctx.emission_context.symMapDlli;
     }
     else if ((intptr_t)f_lib == (intptr_t)JL_LIBJULIA_DL_LIBNAME) {
         libptrgv = prepare_global_in(M, jldll_var);
-        symMap = &emission_context.symMapDll;
+        symMap = &ctx.emission_context.symMapDll;
     }
     else
 #endif
     if (f_lib == NULL) {
         libptrgv = jl_emit_RTLD_DEFAULT_var(M);
-        symMap = &emission_context.symMapDefault;
+        symMap = &ctx.emission_context.symMapDefault;
     }
     else {
         std::string name = "ccalllib_";
         name += llvm::sys::path::filename(f_lib);
         name += std::to_string(globalUniqueGeneratedNames++);
         runtime_lib = true;
-        auto &libgv = emission_context.libMapGV[f_lib];
+        auto &libgv = ctx.emission_context.libMapGV[f_lib];
         if (libgv.first == NULL) {
             libptrgv = new GlobalVariable(*M, getInt8PtrTy(M->getContext()), false,
                                           GlobalVariable::ExternalLinkage,
@@ -177,7 +177,7 @@ static Value *runtime_sym_lookup(
                                     Constant::getNullValue(T_pvoidfunc), gvname);
     }
     else {
-        runtime_lib = runtime_sym_gvs(ctx.emission_context, f_lib, f_name, libptrgv, llvmgv);
+        runtime_lib = runtime_sym_gvs(ctx, f_lib, f_name, libptrgv, llvmgv);
         libptrgv = prepare_global_in(jl_Module, libptrgv);
     }
     llvmgv = prepare_global_in(jl_Module, llvmgv);
@@ -187,13 +187,13 @@ static Value *runtime_sym_lookup(
 // Emit a "PLT" entry that will be lazily initialized
 // when being called the first time.
 static GlobalVariable *emit_plt_thunk(
-        jl_codegen_params_t &emission_context,
+        jl_codectx_t &ctx,
         FunctionType *functype, const AttributeList &attrs,
         CallingConv::ID cc, const char *f_lib, const char *f_name,
         GlobalVariable *libptrgv, GlobalVariable *llvmgv,
         bool runtime_lib)
 {
-    auto &TSM = emission_context.shared_module(emission_context.tsctx);
+    auto &TSM = ctx.emission_context.shared_module(*jl_Module);
     Module *M = TSM.getModuleUnlocked();
     PointerType *funcptype = PointerType::get(functype, 0);
     libptrgv = prepare_global_in(M, libptrgv);
@@ -214,7 +214,7 @@ static GlobalVariable *emit_plt_thunk(
                                              fname);
     BasicBlock *b0 = BasicBlock::Create(M->getContext(), "top", plt);
     IRBuilder<> irbuilder(b0);
-    Value *ptr = runtime_sym_lookup(emission_context, irbuilder, NULL, funcptype, f_lib, NULL, f_name, plt, libptrgv,
+    Value *ptr = runtime_sym_lookup(ctx.emission_context, irbuilder, NULL, funcptype, f_lib, NULL, f_name, plt, libptrgv,
                                     llvmgv, runtime_lib);
     StoreInst *store = irbuilder.CreateAlignedStore(irbuilder.CreateBitCast(ptr, T_pvoidfunc), got, Align(sizeof(void*)));
     store->setAtomic(AtomicOrdering::Release);
@@ -269,14 +269,14 @@ static Value *emit_plt(
     assert(!functype->isVarArg());
     GlobalVariable *libptrgv;
     GlobalVariable *llvmgv;
-    bool runtime_lib = runtime_sym_gvs(ctx.emission_context, f_lib, f_name, libptrgv, llvmgv);
+    bool runtime_lib = runtime_sym_gvs(ctx, f_lib, f_name, libptrgv, llvmgv);
     PointerType *funcptype = PointerType::get(functype, 0);
 
     auto &pltMap = ctx.emission_context.allPltMap[attrs];
     auto key = std::make_tuple(llvmgv, functype, cc);
     GlobalVariable *&sharedgot = pltMap[key];
     if (!sharedgot) {
-        sharedgot = emit_plt_thunk(ctx.emission_context,
+        sharedgot = emit_plt_thunk(ctx,
                 functype, attrs, cc, f_lib, f_name, libptrgv, llvmgv, runtime_lib);
     }
     GlobalVariable *got = prepare_global_in(jl_Module, sharedgot);

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -19,7 +19,7 @@ JL_DLLEXPORT void jl_extern_c_fallback(jl_function_t *f, jl_value_t *rt, jl_valu
 JL_DLLEXPORT jl_value_t *jl_dump_method_asm_fallback(jl_method_instance_t *linfo, size_t world,
         char raw_mc, char getwrapper, const char* asm_variant, const char *debuginfo, char binary) UNAVAILABLE
 JL_DLLEXPORT jl_value_t *jl_dump_function_ir_fallback(void *f, char strip_ir_metadata, char dump_module, const char *debuginfo) UNAVAILABLE
-JL_DLLEXPORT void *jl_get_llvmf_defn_fallback(jl_method_instance_t *linfo, LLVMOrcThreadSafeContextRef ctxt, size_t world, char getwrapper, char optimize, const jl_cgparams_t params) UNAVAILABLE
+JL_DLLEXPORT void *jl_get_llvmf_defn_fallback(jl_method_instance_t *linfo, size_t world, char getwrapper, char optimize, const jl_cgparams_t params) UNAVAILABLE
 
 JL_DLLEXPORT void *jl_LLVMCreateDisasm_fallback(const char *TripleName, void *DisInfo, int TagType, void *GetOpInfo, void *SymbolLookUp) UNAVAILABLE
 JL_DLLEXPORT size_t jl_LLVMDisasmInstruction_fallback(void *DC, uint8_t *Bytes, uint64_t BytesSize, uint64_t PC, char *OutString, size_t OutStringSize) UNAVAILABLE
@@ -91,8 +91,6 @@ JL_DLLEXPORT void jl_dump_llvm_opt_fallback(void *s)
 JL_DLLEXPORT jl_value_t *jl_dump_fptr_asm_fallback(uint64_t fptr, char raw_mc, const char* asm_variant, const char *debuginfo, char binary) UNAVAILABLE
 
 JL_DLLEXPORT jl_value_t *jl_dump_function_asm_fallback(void *F, char raw_mc, const char* asm_variant, const char *debuginfo, char binary) UNAVAILABLE
-
-JL_DLLEXPORT LLVMOrcThreadSafeContextRef jl_get_ee_context_fallback(void) UNAVAILABLE
 
 JL_DLLEXPORT void jl_get_function_id_fallback(void *native_code, jl_code_instance_t *ncode,
         int32_t *func_idx, int32_t *specfunc_idx) UNAVAILABLE

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -74,7 +74,7 @@ JL_DLLEXPORT void jl_unlock_profile_fallback(void)
 {
 }
 
-JL_DLLEXPORT void *jl_create_native_fallback(jl_array_t *methods, LLVMOrcThreadSafeContextRef llvmctxt, const jl_cgparams_t *cgparams, int _policy) UNAVAILABLE
+JL_DLLEXPORT void *jl_create_native_fallback(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvmctxt, const jl_cgparams_t *cgparams, int _policy) UNAVAILABLE
 
 JL_DLLEXPORT void jl_dump_compiles_fallback(void *s)
 {

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -19,7 +19,7 @@ JL_DLLEXPORT void jl_extern_c_fallback(jl_function_t *f, jl_value_t *rt, jl_valu
 JL_DLLEXPORT jl_value_t *jl_dump_method_asm_fallback(jl_method_instance_t *linfo, size_t world,
         char raw_mc, char getwrapper, const char* asm_variant, const char *debuginfo, char binary) UNAVAILABLE
 JL_DLLEXPORT jl_value_t *jl_dump_function_ir_fallback(void *f, char strip_ir_metadata, char dump_module, const char *debuginfo) UNAVAILABLE
-JL_DLLEXPORT void *jl_get_llvmf_defn_fallback(jl_method_instance_t *linfo, LLVMContextRef ctxt, size_t world, char getwrapper, char optimize, const jl_cgparams_t params) UNAVAILABLE
+JL_DLLEXPORT void *jl_get_llvmf_defn_fallback(jl_method_instance_t *linfo, LLVMOrcThreadSafeContextRef ctxt, size_t world, char getwrapper, char optimize, const jl_cgparams_t params) UNAVAILABLE
 
 JL_DLLEXPORT void *jl_LLVMCreateDisasm_fallback(const char *TripleName, void *DisInfo, int TagType, void *GetOpInfo, void *SymbolLookUp) UNAVAILABLE
 JL_DLLEXPORT size_t jl_LLVMDisasmInstruction_fallback(void *DC, uint8_t *Bytes, uint64_t BytesSize, uint64_t PC, char *OutString, size_t OutStringSize) UNAVAILABLE
@@ -52,7 +52,7 @@ JL_DLLEXPORT uint32_t jl_get_LLVM_VERSION_fallback(void)
     return 0;
 }
 
-JL_DLLEXPORT int jl_compile_extern_c_fallback(LLVMModuleRef llvmmod, void *params, void *sysimg, jl_value_t *declrt, jl_value_t *sigt)
+JL_DLLEXPORT int jl_compile_extern_c_fallback(LLVMOrcThreadSafeModuleRef llvmmod, void *params, void *sysimg, jl_value_t *declrt, jl_value_t *sigt)
 {
     return 0;
 }
@@ -74,7 +74,7 @@ JL_DLLEXPORT void jl_unlock_profile_fallback(void)
 {
 }
 
-JL_DLLEXPORT void *jl_create_native_fallback(jl_array_t *methods, LLVMContextRef llvmctxt, const jl_cgparams_t *cgparams, int _policy) UNAVAILABLE
+JL_DLLEXPORT void *jl_create_native_fallback(jl_array_t *methods, LLVMOrcThreadSafeContextRef llvmctxt, const jl_cgparams_t *cgparams, int _policy) UNAVAILABLE
 
 JL_DLLEXPORT void jl_dump_compiles_fallback(void *s)
 {
@@ -92,16 +92,15 @@ JL_DLLEXPORT jl_value_t *jl_dump_fptr_asm_fallback(uint64_t fptr, char raw_mc, c
 
 JL_DLLEXPORT jl_value_t *jl_dump_function_asm_fallback(void *F, char raw_mc, const char* asm_variant, const char *debuginfo, char binary) UNAVAILABLE
 
-JL_DLLEXPORT LLVMContextRef jl_get_ee_context_fallback(void) UNAVAILABLE
+JL_DLLEXPORT LLVMOrcThreadSafeContextRef jl_get_ee_context_fallback(void) UNAVAILABLE
 
 JL_DLLEXPORT void jl_get_function_id_fallback(void *native_code, jl_code_instance_t *ncode,
         int32_t *func_idx, int32_t *specfunc_idx) UNAVAILABLE
 
-JL_DLLEXPORT void *jl_get_llvm_context_fallback(void *native_code) UNAVAILABLE
 
 JL_DLLEXPORT void *jl_get_llvm_function_fallback(void *native_code, uint32_t idx) UNAVAILABLE
 
-JL_DLLEXPORT void *jl_get_llvm_module_fallback(void *native_code) UNAVAILABLE
+JL_DLLEXPORT LLVMOrcThreadSafeModuleRef jl_get_llvm_module_fallback(void *native_code) UNAVAILABLE
 
 JL_DLLEXPORT void *jl_type_to_llvm_fallback(jl_value_t *jt, LLVMContextRef llvmctxt, bool_t *isboxed) UNAVAILABLE
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1305,7 +1305,7 @@ public:
     std::vector<jl_cgval_t> SAvalues;
     std::vector<std::tuple<jl_cgval_t, BasicBlock *, AllocaInst *, PHINode *, jl_value_t *>> PhiNodes;
     std::vector<bool> ssavalue_assigned;
-    std::vector<std::unique_ptr<Module>> oc_modules;
+    std::vector<orc::ThreadSafeModule> oc_modules;
     jl_module_t *module = NULL;
     jl_typecache_t type_cache;
     jl_tbaacache_t tbaa_cache;
@@ -1336,7 +1336,7 @@ public:
     bool use_cache = false;
     const jl_cgparams_t *params = NULL;
 
-    std::vector<std::unique_ptr<llvm::Module>> llvmcall_modules;
+    std::vector<orc::ThreadSafeModule> llvmcall_modules;
 
     jl_codectx_t(LLVMContext &llvmctx, jl_codegen_params_t &params)
       : builder(llvmctx),
@@ -1949,9 +1949,11 @@ static jl_cgval_t convert_julia_type(jl_codectx_t &ctx, const jl_cgval_t &v, jl_
     return jl_cgval_t(v, typ, new_tindex);
 }
 
-Module *_jl_create_llvm_module(StringRef name, LLVMContext &context, const jl_cgparams_t *params, const DataLayout &DL, const Triple &triple)
+orc::ThreadSafeModule _jl_create_llvm_module(StringRef name, orc::ThreadSafeContext context, const jl_cgparams_t *params, const DataLayout &DL, const Triple &triple)
 {
-    Module *m = new Module(name, context);
+    auto lock = context.getLock();
+    Module *m = new Module(name, *context.getContext());
+    orc::ThreadSafeModule TSM(std::unique_ptr<Module>(m), std::move(context));
     // Some linkers (*cough* OS X) don't understand DWARF v4, so we use v2 in
     // imaging mode. The structure of v4 is slightly nicer for debugging JIT
     // code.
@@ -1978,12 +1980,12 @@ Module *_jl_create_llvm_module(StringRef name, LLVMContext &context, const jl_cg
 #if defined(JL_DEBUG_BUILD) && JL_LLVM_VERSION >= 130000
     m->setStackProtectorGuard("global");
 #endif
-    return m;
+    return TSM;
 }
 
-Module *jl_create_llvm_module(StringRef name, LLVMContext &ctx, const DataLayout *DL, const Triple *triple)
+orc::ThreadSafeModule jl_create_llvm_module(StringRef name, orc::ThreadSafeContext ctx, const DataLayout *DL, const Triple *triple)
 {
-    return _jl_create_llvm_module(name, ctx, &jl_default_cgparams, DL ? *DL : jl_ExecutionEngine->getDataLayout(), triple ? *triple : jl_ExecutionEngine->getTargetTriple());
+    return _jl_create_llvm_module(name, std::move(ctx), &jl_default_cgparams, DL ? *DL : jl_ExecutionEngine->getDataLayout(), triple ? *triple : jl_ExecutionEngine->getTargetTriple());
 }
 
 static void jl_init_function(Function *F)
@@ -2882,13 +2884,12 @@ static bool emit_f_opfield(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
     return false;
 }
 
-static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
+static jl_compile_result_t
     emit_function(
         jl_method_instance_t *lam,
         jl_code_info_t *src,
         jl_value_t *jlrettype,
-        jl_codegen_params_t &params,
-        LLVMContext &ctxt);
+        jl_codegen_params_t &params);
 
 static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                               const jl_cgval_t *argv, size_t nargs, jl_value_t *rt,
@@ -4720,10 +4721,9 @@ static std::pair<Function*, Function*> get_oc_function(jl_codectx_t &ctx, jl_met
     ir = jl_uncompress_ir(closure_method, ci, (jl_array_t*)ci->inferred);
 
     // TODO: Emit this inline and outline it late using LLVM's coroutine support.
-    std::unique_ptr<Module> closure_m;
+    orc::ThreadSafeModule closure_m;
     jl_llvm_functions_t closure_decls;
-    std::tie(closure_m, closure_decls) = emit_function(mi, ir, rettype, ctx.emission_context,
-                                                       ctx.builder.getContext());
+    std::tie(closure_m, closure_decls) = emit_function(mi, ir, rettype, ctx.emission_context);
 
     assert(closure_decls.functionObject != "jl_fptr_sparam");
     bool isspecsig = closure_decls.functionObject != "jl_fptr_args";
@@ -4744,7 +4744,8 @@ static std::pair<Function*, Function*> get_oc_function(jl_codectx_t &ctx, jl_met
     if (!isspecsig) {
         specF = F;
     } else {
-        specF = closure_m->getFunction(closure_decls.specFunctionObject);
+        //emission context holds context lock so can get module
+        specF = closure_m.getModuleUnlocked()->getFunction(closure_decls.specFunctionObject);
         if (specF) {
             jl_returninfo_t returninfo = get_specsig_function(ctx, jl_Module,
                 closure_decls.specFunctionObject, sigtype, rettype, true);
@@ -5427,7 +5428,7 @@ static Function* gen_cfun_wrapper(
     std::string funcName;
     raw_string_ostream(funcName) << "jlcapi_" << name << "_" << globalUniqueGeneratedNames++;
 
-    Module *M = into;
+    Module *M = into; // Safe because ctx lock is held by params
     AttributeList attributes = sig.attributes;
     FunctionType *functype;
     if (nest) {
@@ -6094,7 +6095,7 @@ static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, con
 
 // do codegen to create a C-callable alias/wrapper, or if sysimg_handle is set,
 // restore one from a loaded system image.
-const char *jl_generate_ccallable(void *llvmmod, void *sysimg_handle, jl_value_t *declrt, jl_value_t *sigt, jl_codegen_params_t &params, LLVMContext &ctxt)
+const char *jl_generate_ccallable(LLVMOrcThreadSafeModuleRef llvmmod, void *sysimg_handle, jl_value_t *declrt, jl_value_t *sigt, jl_codegen_params_t &params)
 {
     jl_datatype_t *ft = (jl_datatype_t*)jl_tparam0(sigt);
     jl_value_t *ff = ft->instance;
@@ -6106,7 +6107,7 @@ const char *jl_generate_ccallable(void *llvmmod, void *sysimg_handle, jl_value_t
         crt = (jl_value_t*)jl_any_type;
     }
     bool toboxed;
-    Type *lcrt = _julia_struct_to_llvm(&params, ctxt, crt, &toboxed);
+    Type *lcrt = _julia_struct_to_llvm(&params, *params.tsctx.getContext(), crt, &toboxed);
     if (toboxed)
         lcrt = JuliaType::get_prjlvalue_ty(lcrt->getContext());
     size_t nargs = jl_nparams(sigt)-1;
@@ -6133,7 +6134,8 @@ const char *jl_generate_ccallable(void *llvmmod, void *sysimg_handle, jl_value_t
             }
             else {
                 jl_method_instance_t *lam = jl_get_specialization1((jl_tupletype_t*)sigt, world, &min_valid, &max_valid, 0);
-                gen_cfun_wrapper((Module*)llvmmod, params, sig, ff, name, declrt, lam, NULL, NULL, NULL);
+                //Safe b/c params holds context lock
+                gen_cfun_wrapper(reinterpret_cast<orc::ThreadSafeModule*>(llvmmod)->getModuleUnlocked(), params, sig, ff, name, declrt, lam, NULL, NULL, NULL);
             }
             JL_GC_POP();
             return name;
@@ -6429,17 +6431,16 @@ static jl_datatype_t *compute_va_type(jl_method_instance_t *lam, size_t nreq)
 }
 
 // Compile to LLVM IR, using a specialized signature if applicable.
-static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
+static jl_compile_result_t
     emit_function(
         jl_method_instance_t *lam,
         jl_code_info_t *src,
         jl_value_t *jlrettype,
-        jl_codegen_params_t &params,
-        LLVMContext &ctxt)
+        jl_codegen_params_t &params)
 {
     // step 1. unpack AST and allocate codegen context for this function
     jl_llvm_functions_t declarations;
-    jl_codectx_t ctx(ctxt, params);
+    jl_codectx_t ctx(*params.tsctx.getContext(), params);
     jl_datatype_t *vatyp = NULL;
     JL_GC_PUSH3(&ctx.code, &ctx.roots, &vatyp);
     ctx.code = src->code;
@@ -6589,7 +6590,9 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
     declarations.specFunctionObject = funcName.str();
 
     // allocate Function declarations and wrapper objects
-    Module *M = _jl_create_llvm_module(ctx.name, ctx.builder.getContext(), ctx.params, jl_ExecutionEngine->getDataLayout(), jl_ExecutionEngine->getTargetTriple());
+    auto TSM = _jl_create_llvm_module(ctx.name, ctx.emission_context.tsctx, ctx.params, jl_ExecutionEngine->getDataLayout(), jl_ExecutionEngine->getTargetTriple());
+    //Safe because params holds ctx lock
+    Module *M = TSM.getModuleUnlocked();
     jl_debugcache_t debuginfo;
     debuginfo.initialize(M);
     jl_returninfo_t returninfo = {};
@@ -7879,31 +7882,33 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
 
     // link the dependent llvmcall modules, but switch their function's linkage to internal
     // so that they don't conflict when they show up in the execution engine.
-    for (auto &Mod : ctx.llvmcall_modules) {
+    for (auto &TSMod : ctx.llvmcall_modules) {
         SmallVector<std::string, 1> Exports;
-        for (const auto &F: Mod->functions())
+        TSMod.withModuleDo([&](Module &Mod) { //TODO fix indentation after review
+        for (const auto &F: Mod.functions())
             if (!F.isDeclaration())
                 Exports.push_back(F.getName().str());
-        if (Linker::linkModules(*jl_Module, std::move(Mod))) {
-            jl_error("Failed to link LLVM bitcode");
-        }
+        });
+        jl_merge_module(TSM, std::move(TSMod));
         for (auto FN: Exports)
             jl_Module->getFunction(FN)->setLinkage(GlobalVariable::InternalLinkage);
     }
 
     // link in opaque closure modules
-    for (auto &Mod : ctx.oc_modules) {
+    for (auto &TSMod : ctx.oc_modules) {
         SmallVector<std::string, 1> Exports;
-        for (const auto &F: Mod->functions())
+        TSMod.withModuleDo([&](Module &Mod) { //TODO fix indentation after review
+        for (const auto &F: Mod.functions())
             if (!F.isDeclaration())
                 Exports.push_back(F.getName().str());
-        jl_merge_module(jl_Module, std::move(Mod));
+        });
+        jl_merge_module(TSM, std::move(TSMod));
         for (auto FN: Exports)
             jl_Module->getFunction(FN)->setLinkage(GlobalVariable::InternalLinkage);
     }
 
     JL_GC_POP();
-    return std::make_pair(std::unique_ptr<Module>(M), declarations);
+    return std::make_tuple(std::move(TSM), declarations);
 }
 
 // --- entry point ---
@@ -7915,18 +7920,17 @@ jl_compile_result_t jl_emit_code(
         jl_method_instance_t *li,
         jl_code_info_t *src,
         jl_value_t *jlrettype,
-        jl_codegen_params_t &params,
-        LLVMContext &context)
+        jl_codegen_params_t &params)
 {
     JL_TIMING(CODEGEN);
     // caller must hold codegen_lock
     jl_llvm_functions_t decls = {};
-    std::unique_ptr<Module> m;
+    orc::ThreadSafeModule m;
     assert((params.params == &jl_default_cgparams /* fast path */ || !params.cache ||
         compare_cgparams(params.params, &jl_default_cgparams)) &&
         "functions compiled with custom codegen params must not be cached");
     JL_TRY {
-        std::tie(m, decls) = emit_function(li, src, jlrettype, params, context);
+        std::tie(m, decls) = emit_function(li, src, jlrettype, params);
         if (dump_emitted_mi_name_stream != NULL) {
             jl_printf(dump_emitted_mi_name_stream, "%s\t", decls.specFunctionObject.c_str());
             // NOTE: We print the Type Tuple without surrounding quotes, because the quotes
@@ -7941,7 +7945,7 @@ jl_compile_result_t jl_emit_code(
     JL_CATCH {
         // Something failed! This is very, very bad.
         // Try to pretend that it isn't and attempt to recover.
-        m.reset();
+        m = orc::ThreadSafeModule();
         decls.functionObject = "";
         decls.specFunctionObject = "";
         const char *mname = name_from_method_instance(li);
@@ -7957,8 +7961,7 @@ jl_compile_result_t jl_emit_code(
 jl_compile_result_t jl_emit_codeinst(
         jl_code_instance_t *codeinst,
         jl_code_info_t *src,
-        jl_codegen_params_t &params,
-        LLVMContext &context)
+        jl_codegen_params_t &params)
 {
     JL_TIMING(CODEGEN);
     JL_GC_PUSH1(&src);
@@ -7972,19 +7975,20 @@ jl_compile_result_t jl_emit_codeinst(
             return jl_compile_result_t(); // failed
         }
     }
-    jl_compile_result_t result = jl_emit_code(codeinst->def, src, codeinst->rettype, params, context);
+    jl_compile_result_t result = jl_emit_code(codeinst->def, src, codeinst->rettype, params);
 
     const jl_llvm_functions_t &decls = std::get<1>(result);
     const std::string &specf = decls.specFunctionObject;
     const std::string &f = decls.functionObject;
     if (params.cache && !f.empty()) {
-        const Module *m = std::get<0>(result).get();
+        const auto &m = std::get<0>(result);
         // Prepare debug info to receive this function
         // record that this function name came from this linfo,
         // so we can build a reverse mapping for debug-info.
         bool toplevel = !jl_is_method(codeinst->def->def.method);
         if (!toplevel) {
-            const DataLayout &DL = m->getDataLayout();
+            //Safe b/c params holds context lock
+            const DataLayout &DL = m.getModuleUnlocked()->getDataLayout();
             // but don't remember toplevel thunks because
             // they may not be rooted in the gc for the life of the program,
             // and the runtime doesn't notify us when the code becomes unreachable :(
@@ -8034,7 +8038,7 @@ jl_compile_result_t jl_emit_codeinst(
 
 void jl_compile_workqueue(
     std::map<jl_code_instance_t*, jl_compile_result_t> &emitted,
-    jl_codegen_params_t &params, CompilationPolicy policy, LLVMContext &context)
+    jl_codegen_params_t &params, CompilationPolicy policy)
 {
     JL_TIMING(CODEGEN);
     jl_code_info_t *src = NULL;
@@ -8076,10 +8080,10 @@ void jl_compile_workqueue(
                     codeinst->inferred && codeinst->inferred == jl_nothing) {
                     src = jl_type_infer(codeinst->def, jl_atomic_load_acquire(&jl_world_counter), 0);
                     if (src)
-                        result = jl_emit_code(codeinst->def, src, src->rettype, params, context);
+                        result = jl_emit_code(codeinst->def, src, src->rettype, params);
                 }
                 else {
-                    result = jl_emit_codeinst(codeinst, NULL, params, context);
+                    result = jl_emit_codeinst(codeinst, NULL, params);
                 }
                 if (std::get<0>(result))
                     decls = &std::get<1>(result);

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -493,7 +493,8 @@ jl_value_t *jl_dump_function_ir_impl(void *f, char strip_ir_metadata, char dump_
     raw_string_ostream stream(code);
 
     {
-        Function *llvmf = dyn_cast_or_null<Function>((Function*)f);
+        std::unique_ptr<jl_llvmf_dump_t> dump(static_cast<jl_llvmf_dump_t*>(f));
+        Function *llvmf = dump->F;
         if (!llvmf || (!llvmf->isDeclaration() && !llvmf->getParent()))
             jl_error("jl_dump_function_ir: Expected Function* in a temporary Module");
 
@@ -505,21 +506,21 @@ jl_value_t *jl_dump_function_ir_impl(void *f, char strip_ir_metadata, char dump_
             delete llvmf;
         }
         else {
-            Module *m = llvmf->getParent();
+            dump->TSM.withModuleDo([&](Module &m) {
             if (strip_ir_metadata) {
                 std::string llvmfn(llvmf->getName());
-                jl_strip_llvm_addrspaces(m);
-                jl_strip_llvm_debug(m, true, &AAW);
+                jl_strip_llvm_addrspaces(&m);
+                jl_strip_llvm_debug(&m, true, &AAW);
                 // rewriting the function type creates a new function, so look it up again
-                llvmf = m->getFunction(llvmfn);
+                llvmf = m.getFunction(llvmfn);
             }
             if (dump_module) {
-                m->print(stream, &AAW);
+                m.print(stream, &AAW);
             }
             else {
                 llvmf->print(stream, &AAW);
             }
-            delete m;
+            });
         }
         JL_UNLOCK(&jl_codegen_lock); // Might GC
     }
@@ -1193,14 +1194,16 @@ jl_value_t *jl_dump_function_asm_impl(void *F, char raw_mc, const char* asm_vari
     // precise printing via IR assembler
     SmallVector<char, 4096> ObjBufferSV;
     { // scope block
-        Function *f = (Function*)F;
+        std::unique_ptr<jl_llvmf_dump_t> dump(static_cast<jl_llvmf_dump_t*>(F));
+        Function *f = dump->F;
         llvm::raw_svector_ostream asmfile(ObjBufferSV);
         assert(!f->isDeclaration());
-        std::unique_ptr<Module> m(f->getParent());
-        for (auto &f2 : m->functions()) {
+        dump->TSM.withModuleDo([&](Module &m) {//TODO fix indentation
+        for (auto &f2 : m.functions()) {
             if (f != &f2 && !f->isDeclaration())
                 f2.deleteBody();
         }
+        });
         LLVMTargetMachine *TM = static_cast<LLVMTargetMachine*>(&jl_ExecutionEngine->getTargetMachine());
         legacy::PassManager PM;
         addTargetPasses(&PM, TM);
@@ -1208,7 +1211,7 @@ jl_value_t *jl_dump_function_asm_impl(void *F, char raw_mc, const char* asm_vari
             raw_svector_ostream obj_OS(ObjBufferSV);
             if (TM->addPassesToEmitFile(PM, obj_OS, nullptr, CGFT_ObjectFile, false, nullptr))
                 return jl_an_empty_string;
-            PM.run(*m);
+            dump->TSM.withModuleDo([&](Module &m) { PM.run(m); });
         }
         else {
             MCContext *Context = addPassesToGenerateCode(TM, PM);
@@ -1247,7 +1250,7 @@ jl_value_t *jl_dump_function_asm_impl(void *F, char raw_mc, const char* asm_vari
                 return jl_an_empty_string;
             PM.add(Printer.release());
             PM.add(createFreeMachineFunctionPass());
-            PM.run(*m);
+            dump->TSM.withModuleDo([&](Module &m){ PM.run(m); });
         }
     }
     return jl_pchar_to_string(ObjBufferSV.data(), ObjBufferSV.size());

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -899,7 +899,7 @@ namespace {
     }
 }
 
-llvm::DataLayout create_jl_data_layout(TargetMachine &TM) {
+llvm::DataLayout jl_create_datalayout(TargetMachine &TM) {
     // Mark our address spaces as non-integral
     auto jl_data_layout = TM.createDataLayout();
     jl_data_layout.reset(jl_data_layout.getStringRepresentation() + "-ni:10:11:12:13");
@@ -908,7 +908,7 @@ llvm::DataLayout create_jl_data_layout(TargetMachine &TM) {
 
 JuliaOJIT::JuliaOJIT(LLVMContext *LLVMCtx)
   : TM(createTargetMachine()),
-    DL(create_jl_data_layout(*TM)),
+    DL(jl_create_datalayout(*TM)),
     TMs{
         cantFail(createJTMBFromTM(*TM, 0).createTargetMachine()),
         cantFail(createJTMBFromTM(*TM, 1).createTargetMachine()),

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -453,8 +453,7 @@ jl_value_t *jl_dump_method_asm_impl(jl_method_instance_t *mi, size_t world,
     }
 
     // whatever, that didn't work - use the assembler output instead
-    // just make a new context for this one operation
-    void *F = jl_get_llvmf_defn(mi, reinterpret_cast<LLVMOrcThreadSafeContextRef>(&jl_ExecutionEngine->getContext()), world, getwrapper, true, jl_default_cgparams);
+    void *F = jl_get_llvmf_defn(mi, world, getwrapper, true, jl_default_cgparams);
     if (!F)
         return jl_an_empty_string;
     return jl_dump_function_asm(F, raw_mc, asm_variant, debuginfo, binary);
@@ -1459,9 +1458,4 @@ extern "C" JL_DLLEXPORT
 size_t jl_jit_total_bytes_impl(void)
 {
     return jl_ExecutionEngine->getTotalBytes();
-}
-
-extern "C" JL_DLLEXPORT
-LLVMOrcThreadSafeContextRef jl_get_ee_context_impl(void) {
-    return reinterpret_cast<LLVMOrcThreadSafeContextRef>(&jl_ExecutionEngine->getContext());
 }

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -56,7 +56,7 @@ void addMachinePasses(legacy::PassManagerBase *PM, TargetMachine *TM, int optlev
 void jl_finalize_module(orc::ThreadSafeModule  m);
 void jl_merge_module(orc::ThreadSafeModule &dest, orc::ThreadSafeModule src);
 GlobalVariable *jl_emit_RTLD_DEFAULT_var(Module *M);
-DataLayout create_jl_data_layout(TargetMachine &TM);
+DataLayout jl_create_datalayout(TargetMachine &TM);
 
 typedef struct _jl_llvm_functions_t {
     std::string functionObject;     // jlcall llvm Function name

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -53,9 +53,9 @@ extern bool imaging_mode;
 void addTargetPasses(legacy::PassManagerBase *PM, TargetMachine *TM);
 void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool lower_intrinsics=true, bool dump_native=false);
 void addMachinePasses(legacy::PassManagerBase *PM, TargetMachine *TM, int optlevel);
-void jl_finalize_module(std::unique_ptr<Module>  m);
-void jl_merge_module(Module *dest, std::unique_ptr<Module> src);
-Module *jl_create_llvm_module(StringRef name, LLVMContext &ctx, const DataLayout *DL = nullptr, const Triple *triple = nullptr);
+void jl_finalize_module(orc::ThreadSafeModule  m);
+void jl_merge_module(orc::ThreadSafeModule &dest, orc::ThreadSafeModule src);
+orc::ThreadSafeModule jl_create_llvm_module(StringRef name, orc::ThreadSafeContext ctx, const DataLayout *DL = nullptr, const Triple *triple = nullptr);
 GlobalVariable *jl_emit_RTLD_DEFAULT_var(Module *M);
 DataLayout create_jl_data_layout(TargetMachine &TM);
 
@@ -79,10 +79,17 @@ struct jl_returninfo_t {
     unsigned return_roots;
 };
 
+struct jl_llvmf_dump_t {
+    orc::ThreadSafeModule TSM;
+    Function *F;
+};
+
 typedef std::vector<std::tuple<jl_code_instance_t*, jl_returninfo_t::CallingConv, unsigned, llvm::Function*, bool>> jl_codegen_call_targets_t;
-typedef std::tuple<std::unique_ptr<Module>, jl_llvm_functions_t> jl_compile_result_t;
+typedef std::tuple<orc::ThreadSafeModule, jl_llvm_functions_t> jl_compile_result_t;
 
 typedef struct _jl_codegen_params_t {
+    orc::ThreadSafeContext tsctx;
+    orc::ThreadSafeContext::Lock tsctx_lock;
     typedef StringMap<GlobalVariable*> SymMapGV;
     // outputs
     jl_codegen_call_targets_t workqueue;
@@ -108,8 +115,8 @@ typedef struct _jl_codegen_params_t {
     DenseMap<AttributeList, std::map<
         std::tuple<GlobalVariable*, FunctionType*, CallingConv::ID>,
         GlobalVariable*>> allPltMap;
-    Module *_shared_module = NULL;
-    Module *shared_module(LLVMContext &context) {
+    orc::ThreadSafeModule _shared_module;
+    orc::ThreadSafeModule &shared_module(orc::ThreadSafeContext context) {
         if (!_shared_module)
             _shared_module = jl_create_llvm_module("globals", context);
         return _shared_module;
@@ -118,20 +125,19 @@ typedef struct _jl_codegen_params_t {
     size_t world = 0;
     const jl_cgparams_t *params = &jl_default_cgparams;
     bool cache = false;
+    _jl_codegen_params_t(orc::ThreadSafeContext ctx) : tsctx(std::move(ctx)), tsctx_lock(tsctx.getLock()) {}
 } jl_codegen_params_t;
 
 jl_compile_result_t jl_emit_code(
         jl_method_instance_t *mi,
         jl_code_info_t *src,
         jl_value_t *jlrettype,
-        jl_codegen_params_t &params,
-        LLVMContext &context);
+        jl_codegen_params_t &params);
 
 jl_compile_result_t jl_emit_codeinst(
         jl_code_instance_t *codeinst,
         jl_code_info_t *src,
-        jl_codegen_params_t &params,
-        LLVMContext &context);
+        jl_codegen_params_t &params);
 
 enum CompilationPolicy {
     Default = 0,
@@ -142,8 +148,7 @@ enum CompilationPolicy {
 void jl_compile_workqueue(
     std::map<jl_code_instance_t*, jl_compile_result_t> &emitted,
     jl_codegen_params_t &params,
-    CompilationPolicy policy,
-    LLVMContext &ctxt);
+    CompilationPolicy policy);
 
 Function *jl_cfunction_object(jl_function_t *f, jl_value_t *rt, jl_tupletype_t *argt,
     jl_codegen_params_t &params);
@@ -225,7 +230,7 @@ public:
 #endif
 
     void addGlobalMapping(StringRef Name, uint64_t Addr);
-    void addModule(std::unique_ptr<Module> M);
+    void addModule(orc::ThreadSafeModule M);
 
     JL_JITSymbol findSymbol(StringRef Name, bool ExportedSymbolsOnly);
     JL_JITSymbol findUnmangledSymbol(StringRef Name);

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -523,7 +523,6 @@
     YY(jl_dump_function_ir) \
     YY(jl_dump_method_asm) \
     YY(jl_extern_c) \
-    YY(jl_get_ee_context) \
     YY(jl_get_llvmf_defn) \
     YY(jl_get_llvm_function) \
     YY(jl_get_llvm_module) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -524,7 +524,6 @@
     YY(jl_dump_method_asm) \
     YY(jl_extern_c) \
     YY(jl_get_ee_context) \
-    YY(jl_get_llvm_context) \
     YY(jl_get_llvmf_defn) \
     YY(jl_get_llvm_function) \
     YY(jl_get_llvm_module) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -849,7 +849,7 @@ JL_DLLEXPORT jl_value_t *jl_dump_function_ir(void *f, char strip_ir_metadata, ch
 JL_DLLEXPORT jl_value_t *jl_dump_function_asm(void *F, char raw_mc, const char* asm_variant, const char *debuginfo, char binary);
 JL_DLLEXPORT LLVMOrcThreadSafeContextRef jl_get_ee_context(void);
 
-void *jl_create_native(jl_array_t *methods, LLVMOrcThreadSafeContextRef llvmctxt, const jl_cgparams_t *cgparams, int policy);
+void *jl_create_native(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int policy);
 void jl_dump_native(void *native_code,
         const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *asm_fname,
         const char *sysimg_data, size_t sysimg_len);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -13,6 +13,7 @@
 #include "support/rle.h"
 #include <uv.h>
 #include <llvm-c/Types.h>
+#include <llvm-c/Orc.h>
 #if !defined(_WIN32)
 #include <unistd.h>
 #else
@@ -665,7 +666,7 @@ JL_DLLEXPORT void jl_binding_deprecation_warning(jl_module_t *m, jl_binding_t *b
 extern jl_array_t *jl_module_init_order JL_GLOBALLY_ROOTED;
 extern htable_t jl_current_modules JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_module_t *jl_precompile_toplevel_module JL_GLOBALLY_ROOTED;
-int jl_compile_extern_c(LLVMModuleRef llvmmod, void *params, void *sysimg, jl_value_t *declrt, jl_value_t *sigt);
+int jl_compile_extern_c(LLVMOrcThreadSafeModuleRef llvmmod, void *params, void *sysimg, jl_value_t *declrt, jl_value_t *sigt);
 
 jl_opaque_closure_t *jl_new_opaque_closure(jl_tupletype_t *argt, jl_value_t *rt_lb, jl_value_t *rt_ub,
     jl_value_t *source,  jl_value_t **env, size_t nenv);
@@ -842,13 +843,13 @@ void jl_gc_set_permalloc_region(void *start, void *end);
 
 JL_DLLEXPORT jl_value_t *jl_dump_method_asm(jl_method_instance_t *linfo, size_t world,
         char raw_mc, char getwrapper, const char* asm_variant, const char *debuginfo, char binary);
-JL_DLLEXPORT void *jl_get_llvmf_defn(jl_method_instance_t *linfo, LLVMContextRef ctxt, size_t world, char getwrapper, char optimize, const jl_cgparams_t params);
+JL_DLLEXPORT void *jl_get_llvmf_defn(jl_method_instance_t *linfo, LLVMOrcThreadSafeContextRef ctxt, size_t world, char getwrapper, char optimize, const jl_cgparams_t params);
 JL_DLLEXPORT jl_value_t *jl_dump_fptr_asm(uint64_t fptr, char raw_mc, const char* asm_variant, const char *debuginfo, char binary);
 JL_DLLEXPORT jl_value_t *jl_dump_function_ir(void *f, char strip_ir_metadata, char dump_module, const char *debuginfo);
 JL_DLLEXPORT jl_value_t *jl_dump_function_asm(void *F, char raw_mc, const char* asm_variant, const char *debuginfo, char binary);
-JL_DLLEXPORT LLVMContextRef jl_get_ee_context(void);
+JL_DLLEXPORT LLVMOrcThreadSafeContextRef jl_get_ee_context(void);
 
-void *jl_create_native(jl_array_t *methods, LLVMContextRef llvmctxt, const jl_cgparams_t *cgparams, int policy);
+void *jl_create_native(jl_array_t *methods, LLVMOrcThreadSafeContextRef llvmctxt, const jl_cgparams_t *cgparams, int policy);
 void jl_dump_native(void *native_code,
         const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *asm_fname,
         const char *sysimg_data, size_t sysimg_len);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -843,11 +843,10 @@ void jl_gc_set_permalloc_region(void *start, void *end);
 
 JL_DLLEXPORT jl_value_t *jl_dump_method_asm(jl_method_instance_t *linfo, size_t world,
         char raw_mc, char getwrapper, const char* asm_variant, const char *debuginfo, char binary);
-JL_DLLEXPORT void *jl_get_llvmf_defn(jl_method_instance_t *linfo, LLVMOrcThreadSafeContextRef ctxt, size_t world, char getwrapper, char optimize, const jl_cgparams_t params);
+JL_DLLEXPORT void *jl_get_llvmf_defn(jl_method_instance_t *linfo, size_t world, char getwrapper, char optimize, const jl_cgparams_t params);
 JL_DLLEXPORT jl_value_t *jl_dump_fptr_asm(uint64_t fptr, char raw_mc, const char* asm_variant, const char *debuginfo, char binary);
 JL_DLLEXPORT jl_value_t *jl_dump_function_ir(void *f, char strip_ir_metadata, char dump_module, const char *debuginfo);
 JL_DLLEXPORT jl_value_t *jl_dump_function_asm(void *F, char raw_mc, const char* asm_variant, const char *debuginfo, char binary);
-JL_DLLEXPORT LLVMOrcThreadSafeContextRef jl_get_ee_context(void);
 
 void *jl_create_native(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int policy);
 void jl_dump_native(void *native_code,

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -8,9 +8,9 @@
 //
 // TODO: add half-float support
 
+#include "APInt-C.h"
 #include "julia.h"
 #include "julia_internal.h"
-#include "APInt-C.h"
 
 const unsigned int host_char_bit = 8;
 

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -188,8 +188,7 @@ function _dump_function_linfo_native(linfo::Core.MethodInstance, world::UInt, wr
 end
 
 function _dump_function_linfo_native(linfo::Core.MethodInstance, world::UInt, wrapper::Bool, syntax::Symbol, debuginfo::Symbol, binary::Bool, params::CodegenParams)
-    llvmctxt = ccall(:jl_get_ee_context, Ptr{Cvoid}, ())
-    llvmf = ccall(:jl_get_llvmf_defn, Ptr{Cvoid}, (Any, Ptr{Cvoid}, UInt, Bool, Bool, CodegenParams), linfo, llvmctxt, world, wrapper, true, params)
+    llvmf = ccall(:jl_get_llvmf_defn, Ptr{Cvoid}, (Any, UInt, Bool, Bool, CodegenParams), linfo, world, wrapper, true, params)
     llvmf == C_NULL && error("could not compile the specified method")
     str = ccall(:jl_dump_function_asm, Ref{String},
                 (Ptr{Cvoid}, Bool, Ptr{UInt8}, Ptr{UInt8}, Bool),
@@ -202,8 +201,7 @@ function _dump_function_linfo_llvm(
         strip_ir_metadata::Bool, dump_module::Bool,
         optimize::Bool, debuginfo::Symbol,
         params::CodegenParams)
-    llvmctxt = ccall(:jl_get_ee_context, Ptr{Cvoid}, ())
-    llvmf = ccall(:jl_get_llvmf_defn, Ptr{Cvoid}, (Any, Ptr{Cvoid}, UInt, Bool, Bool, CodegenParams), linfo, llvmctxt, world, wrapper, optimize, params)
+    llvmf = ccall(:jl_get_llvmf_defn, Ptr{Cvoid}, (Any, UInt, Bool, Bool, CodegenParams), linfo, world, wrapper, optimize, params)
     llvmf == C_NULL && error("could not compile the specified method")
     str = ccall(:jl_dump_function_ir, Ref{String},
                 (Ptr{Cvoid}, Bool, Bool, Ptr{UInt8}),


### PR DESCRIPTION
orc::ThreadSafeModule and orc::ThreadSafeContext use reference-counted contexts to allow multiple contexts to be created and destroyed safely during codegen. Moving TSModule to be our API boundary gets us closer to parallelizing codegen without leaking contexts.

Depends on ~~#43770 to remove the global debug information with associated global context~~ #44454 to refactor a few globals. 