### PR TITLE
linux32 debug: Try running the "read" tests without distributed

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,8 @@ move_to_node1("threads")
 move_to_node1("Distributed")
 # Ensure things like consuming all kernel pipe memory doesn't interfere with other tests
 move_to_node1("stress")
+# Try running this locally to investigate failure
+move_to_node1("read")
 
 # In a constrained memory environment, run the "distributed" test after all other tests
 # since it starts a lot of workers and can easily exceed the maximum memory


### PR DESCRIPTION
The following error on linux32 looks a bit like what was seen in https://github.com/JuliaLang/julia/issues/41943 and turned out to be a segfault. 

So try running the "read" tests on node1 to see if it is a segfault

```
Worker 5 terminated.
UNHANDLED TASK ERROR: EOFError: read end of file
Stacktrace:
 [1] (::Base.var"#wait_locked#674")(s::TCPSocket, buf::IOBuffer, nb::Int32)
   @ Base ./stream.jl:941
 [2] unsafe_read(s::TCPSocket, p::Ptr{UInt8}, nb::UInt32)
   @ Base ./stream.jl:950
 [3] unsafe_read
   @ ./io.jl:759 [inlined]
 [4] unsafe_read(s::TCPSocket, p::Base.RefValue{NTuple{4, Int32}}, n::Int32)
   @ Base ./io.jl:758
 [5] read!
   @ ./io.jl:760 [inlined]
 [6] deserialize_hdr_raw
   @ /buildworker/worker/tester_linux32/build/share/julia/stdlib/v1.9/Distributed/src/messages.jl:167 [inlined]
 [7] message_handler_loop(r_stream::TCPSocket, w_stream::TCPSocket, incoming::Bool)
   @ Distributed /buildworker/worker/tester_linux32/build/share/julia/stdlib/v1.9/Distributed/src/process_messages.jl:172
 [8] process_tcp_streams(r_stream::TCPSocket, w_stream::TCPSocket, incoming::Bool)
   @ Distributed /buildworker/worker/tester_linux32/build/share/julia/stdlib/v1.9/Distributed/src/process_messages.jl:133
 [9] (::Distributed.var"#99#100"{TCPSocket, TCPSocket, Bool})()
   @ Distributed ./task.jl:476
read                                     (5) |         failed at 2022-03-04T01:26:08.944
```