### PR TITLE
Fix htable cleanup

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -312,8 +312,8 @@ static size_t queue_external_mis(jl_array_t *list)
                 }
             }
         }
+        htable_free(&visited);
     }
-    htable_free(&visited);
     return n;
 }
 


### PR DESCRIPTION
This htable was allocated conditionally, so the cleanup must be too.
