### PR TITLE
Track const type information in a separate lattice element

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -666,7 +666,7 @@ function _pure_eval_call(@nospecialize(f), arginfo::ArgInfo)
     args = collect_const_args(arginfo)
     try
         value = Core._apply_pure(f, args)
-        return Const(value)
+        return mkConst(value)
     catch
         return nothing
     end
@@ -684,7 +684,7 @@ end
 function is_all_const_arg((; argtypes)::ArgInfo)
     for i = 2:length(argtypes)
         a = widenconditional(argtypes[i])
-        isa(a, Const) || isconstType(a) || issingletontype(a) || return false
+        isa(a, Const) || isa(a, ConstType) || isconstType(a) || issingletontype(a) || return false
     end
     return true
 end
@@ -692,6 +692,7 @@ end
 function collect_const_args((; argtypes)::ArgInfo)
     return Any[ let a = widenconditional(argtypes[i])
                     isa(a, Const) ? a.val :
+                    isa(a, ConstType) ? a.val :
                     isconstType(a) ? (a::DataType).parameters[1] :
                     (a::DataType).instance
                 end for i in 2:length(argtypes) ]
@@ -707,7 +708,7 @@ function concrete_eval_call(interp::AbstractInterpreter,
             # If the constant is not inlineable, still do the const-prop, since the
             # code that led to the creation of the Const may be inlineable in the same
             # circumstance and may be optimizable.
-            return ConstCallResults(Const(value), ConstResult(result.edge, value), EFFECTS_TOTAL)
+            return ConstCallResults(mkConst(value), ConstResult(result.edge, value), EFFECTS_TOTAL)
         end
     catch
         # The evaulation threw. By :consistent-cy, we're guaranteed this would have happened at runtime
@@ -877,6 +878,7 @@ function is_const_prop_profitable_arg(@nospecialize(arg))
         end
     end
     isa(arg, PartialOpaque) && return true
+    isa(arg, ConstType) && return true
     isa(arg, Const) || return true
     val = arg.val
     # don't consider mutable values or Strings useful constants
@@ -1044,7 +1046,7 @@ function precise_container_type(interp::AbstractInterpreter, @nospecialize(itft)
     if isa(typ, Const)
         val = typ.val
         if isa(val, SimpleVector) || isa(val, Tuple)
-            return Any[ Const(val[i]) for i in 1:length(val) ], nothing # avoid making a tuple Generator here!
+            return Any[ mkConst(val[i]) for i in 1:length(val) ], nothing # avoid making a tuple Generator here!
         end
     end
 
@@ -1102,7 +1104,7 @@ end
 
 # simulate iteration protocol on container type up to fixpoint
 function abstract_iteration(interp::AbstractInterpreter, @nospecialize(itft), @nospecialize(itertype), sv::InferenceState)
-    if isa(itft, Const)
+    if isConst(itft)
         iteratef = itft.val
     else
         return Any[Vararg{Any}], nothing
@@ -1142,7 +1144,7 @@ function abstract_iteration(interp::AbstractInterpreter, @nospecialize(itft), @n
         valtype = getfield_tfunc(stateordonet, Const(1))
         push!(ret, valtype)
         statetype = nstatetype
-        call = abstract_call_known(interp, iteratef, ArgInfo(nothing, Any[Const(iteratef), itertype, statetype]), sv)
+        call = abstract_call_known(interp, iteratef, ArgInfo(nothing, Any[mkConst(iteratef), itertype, statetype]), sv)
         stateordonet = call.rt
         stateordonet_widened = widenconst(stateordonet)
         push!(calls, call)
@@ -1177,7 +1179,7 @@ function abstract_iteration(interp::AbstractInterpreter, @nospecialize(itft), @n
         end
         valtype = tmerge(valtype, nounion.parameters[1])
         statetype = tmerge(statetype, nounion.parameters[2])
-        stateordonet = abstract_call_known(interp, iteratef, ArgInfo(nothing, Any[Const(iteratef), itertype, statetype]), sv).rt
+        stateordonet = abstract_call_known(interp, iteratef, ArgInfo(nothing, Any[mkConst(iteratef), itertype, statetype]), sv).rt
         stateordonet_widened = widenconst(stateordonet)
     end
     if valtype !== Union{}
@@ -1194,7 +1196,7 @@ function abstract_apply(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::
     (itft === Bottom || aft === Bottom) && return CallMeta(Bottom, false)
     aargtypes = argtype_tail(argtypes, 4)
     aftw = widenconst(aft)
-    if !isa(aft, Const) && !isa(aft, PartialOpaque) && (!isType(aftw) || has_free_typevars(aftw))
+    if !isConst(aft) && !isa(aft, PartialOpaque) && (!isType(aftw) || has_free_typevars(aftw))
         if !isconcretetype(aftw) || (aftw <: Builtin)
             add_remark!(interp, sv, "Core._apply_iterate called on a function of a non-concrete type")
             tristate_merge!(sv, Effects())
@@ -1357,7 +1359,7 @@ function abstract_call_builtin(interp::AbstractInterpreter, f::Builtin, (; fargs
             aty = argtypes[2]
             bty = argtypes[3]
             # if doing a comparison to a singleton, consider returning a `Conditional` instead
-            if isa(aty, Const) && isa(b, SlotNumber)
+            if isConst(aty) && isa(b, SlotNumber)
                 if rt === Const(false)
                     aty = Union{}
                 elseif rt === Const(true)
@@ -1367,7 +1369,7 @@ function abstract_call_builtin(interp::AbstractInterpreter, f::Builtin, (; fargs
                 end
                 return Conditional(b, aty, bty)
             end
-            if isa(bty, Const) && isa(a, SlotNumber)
+            if isConst(bty) && isa(a, SlotNumber)
                 if rt === Const(false)
                     bty = Union{}
                 elseif rt === Const(true)
@@ -1428,7 +1430,7 @@ function abstract_call_unionall(argtypes::Vector{Any})
     if length(argtypes) == 3
         canconst = true
         a3 = argtypes[3]
-        if isa(a3, Const)
+        if isConst(a3)
             body = a3.val
         elseif isType(a3)
             body = a3.parameters[1]
@@ -1452,7 +1454,7 @@ function abstract_call_unionall(argtypes::Vector{Any})
             !isa(tv, TypeVar) && return Any
             body = UnionAll(tv, body)
         end
-        ret = canconst ? Const(body) : Type{body}
+        ret = canconst ? ConstType(body) : Type{body}
         return ret
     end
     return Any
@@ -1558,8 +1560,8 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
         tristate_merge!(sv, Effects()) # TODO
         (la < 2 || la > 4) && return CallMeta(Union{}, false)
         n = argtypes[2]
-        ub_var = Const(Any)
-        lb_var = Const(Union{})
+        ub_var = ConstType(Any, Type{Any})
+        lb_var = ConstType(Union{}, Type{Union{}})
         if la == 4
             ub_var = argtypes[4]
             lb_var = argtypes[3]
@@ -1617,7 +1619,7 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
            istopfunction(f, :getindex)
         # mark getindex(::SimpleVector, i::Int) as @pure
         if 1 <= idx <= length(svecval) && isassigned(svecval, idx)
-            return CallMeta(Const(getindex(svecval, idx)), MethodResultPure())
+            return CallMeta(mkConst(getindex(svecval, idx)), MethodResultPure())
         end
     elseif la == 2 && istopfunction(f, :typename)
         return CallMeta(typename_static(argtypes[2]), MethodResultPure())
@@ -1756,7 +1758,7 @@ end
 
 function abstract_eval_special_value(interp::AbstractInterpreter, @nospecialize(e), vtypes::VarTable, sv::InferenceState)
     if isa(e, QuoteNode)
-        return Const(e.value)
+        return mkConst(e.value)
     elseif isa(e, SSAValue)
         return abstract_eval_ssavalue(e, sv)
     elseif isa(e, SlotNumber) || isa(e, Argument)
@@ -1765,7 +1767,7 @@ function abstract_eval_special_value(interp::AbstractInterpreter, @nospecialize(
         return abstract_eval_global(e.mod, e.name, sv)
     end
 
-    return Const(e)
+    return mkConst(e)
 end
 
 function abstract_eval_value(interp::AbstractInterpreter, @nospecialize(e), vtypes::VarTable, sv::InferenceState)
@@ -1834,7 +1836,7 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
                         ALWAYS_TRUE, # N.B depends on !ismutabletype(t) above
                         ALWAYS_TRUE, ALWAYS_FALSE, ALWAYS_TRUE))
                     @goto t_computed
-                elseif !isa(at, Const)
+                elseif !isConst(at)
                     allconst = false
                 end
                 if !anyrefine
@@ -1850,7 +1852,7 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
                 if allconst
                     argvals = Vector{Any}(undef, nargs)
                     for j in 1:nargs
-                        argvals[j] = (ats[j]::Const).val
+                        argvals[j] = (ats[j]::Union{Const, ConstType}).val
                     end
                     t = Const(ccall(:jl_new_structv, Any, (Any, Ptr{Cvoid}, UInt32), t, argvals, nargs))
                 elseif anyrefine
@@ -1964,7 +1966,7 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
             n = sym.args[1]::Int
             if 1 <= n <= length(sv.sptypes)
                 spty = sv.sptypes[n]
-                if isa(spty, Const)
+                if isConst(spty)
                     t = Const(true)
                 end
             end
@@ -1974,12 +1976,9 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
     end
     @label t_computed
     @assert !isa(t, TypeVar) "unhandled TypeVar"
-    if isa(t, DataType) && isdefined(t, :instance)
-        # replace singleton types with their equivalent Const object
-        t = Const(t.instance)
-    end
+    t = maybe_singleton_const(t)
     if !isempty(sv.pclimitations)
-        if t isa Const || t === Union{}
+        if t isa Const || t isa ConstType || t === Union{}
             empty!(sv.pclimitations)
         else
             t = LimitedAccuracy(t, sv.pclimitations)
@@ -1992,7 +1991,7 @@ end
 function abstract_eval_global(M::Module, s::Symbol)
     if isdefined(M,s)
         if isconst(M,s)
-            return Const(getfield(M,s))
+            return mkConst(getfield(M,s))
         end
     end
     ty = ccall(:jl_binding_type, Any, (Any, Any), M, s)
@@ -2002,7 +2001,7 @@ end
 
 function abstract_eval_global(M::Module, s::Symbol, frame::InferenceState)
     ty = abstract_eval_global(M, s)
-    isa(ty, Const) && return ty
+    isConst(ty) && return ty
     if isdefined(M,s)
         tristate_merge!(frame, Effects(EFFECTS_TOTAL, consistent=ALWAYS_FALSE))
     else
@@ -2072,6 +2071,7 @@ function widenreturn(@nospecialize(rt), @nospecialize(bestguess), nslots::Int, s
 end
 
 function widenreturn_noconditional(@nospecialize(rt))
+    isa(rt, ConstType) && return rt
     isa(rt, Const) && return rt
     isa(rt, Type) && return rt
     if isa(rt, PartialStruct)

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -331,7 +331,7 @@ function sptypes_from_meth_instance(linfo::MethodInstance)
         elseif isvarargtype(v)
             ty = Int
         else
-            ty = Const(v)
+            ty = mkConst(v)
         end
         sp[i] = ty
     end

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -661,7 +661,7 @@ function rewrite_apply_exprargs!(
                 def_argtypes = Any[]
                 if isa(def_type, Const) # && isa(def_type.val, Union{Tuple, SimpleVector}) is implied
                     for p in def_type.val
-                        push!(def_argtypes, Const(p))
+                        push!(def_argtypes, mkConst(p))
                     end
                 else
                     ti = widenconst(def_type)::DataType # checked by `is_valid_type_for_apply_rewrite`
@@ -669,20 +669,14 @@ function rewrite_apply_exprargs!(
                         ti = ti.parameters[2]::DataType # checked by `is_valid_type_for_apply_rewrite`
                     end
                     for p in ti.parameters
-                        if isa(p, DataType) && isdefined(p, :instance)
-                            # replace singleton types with their equivalent Const object
-                            p = Const(p.instance)
-                        elseif isconstType(p)
-                            p = Const(p.parameters[1])
-                        end
-                        push!(def_argtypes, p)
+                        push!(def_argtypes, maybe_singleton_const(p))
                     end
                 end
             end
             # now push flattened types into new_argtypes and getfield exprs into new_argexprs
             for j in 1:length(def_argtypes)
                 def_atype = def_argtypes[j]
-                if isa(def_atype, Const) && is_inlineable_constant(def_atype.val)
+                if isConst(def_atype) && is_inlineable_constant(def_atype.val)
                     new_argexpr = quoted(def_atype.val)
                 else
                     new_call = Expr(:call, GlobalRef(Core, :getfield), def, j)
@@ -1369,7 +1363,7 @@ end
 
 function inline_const_if_inlineable!(inst::Instruction)
     rt = inst[:type]
-    if rt isa Const && is_inlineable_constant(rt.val)
+    if isConst(rt) && is_inlineable_constant(rt.val)
         inst[:inst] = quoted(rt.val)
         return true
     end
@@ -1471,7 +1465,7 @@ function early_inline_special_case(
     params.inlining || return nothing
     (; f, ft, argtypes) = sig
 
-    if isa(type, Const) # || isconstType(type)
+    if isConst(type) # || isconstType(type)
         val = type.val
         is_inlineable_constant(val) || return nothing
         if isa(f, IntrinsicFunction)
@@ -1505,7 +1499,7 @@ function late_inline_special_case!(
     if length(argtypes) == 3 && istopfunction(f, :!==)
         # special-case inliner for !== that precedes _methods_by_ftype union splitting
         # and that works, even though inference generally avoids inferring the `!==` Method
-        if isa(type, Const)
+        if isConst(type)
             return SomeCase(quoted(type.val))
         end
         cmp_call = Expr(:call, GlobalRef(Core, :(===)), stmt.args[2], stmt.args[3])
@@ -1515,7 +1509,7 @@ function late_inline_special_case!(
     elseif length(argtypes) == 3 && istopfunction(f, :(>:))
         # special-case inliner for issupertype
         # that works, even though inference generally avoids inferring the `>:` Method
-        if isa(type, Const) && _builtin_nothrow(<:, Any[argtypes[3], argtypes[2]], type)
+        if isConst(type) && _builtin_nothrow(<:, Any[argtypes[3], argtypes[2]], type)
             return SomeCase(quoted(type.val))
         end
         subtype_call = Expr(:call, GlobalRef(Core, :(<:)), stmt.args[3], stmt.args[2])
@@ -1532,7 +1526,7 @@ function late_inline_special_case!(
     elseif is_return_type(f)
         if isconstType(type)
             return SomeCase(quoted(type.parameters[1]))
-        elseif isa(type, Const)
+        elseif isConst(type)
             return SomeCase(quoted(type.val))
         end
     end

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -41,7 +41,7 @@ function try_compute_field(ir::Union{IncrementalCompact,IRCode}, @nospecialize(f
     else
         # try to resolve other constants, e.g. global reference
         field = argextype(field, ir)
-        if isa(field, Const)
+        if isConst(field)
             field = field.val
         else
             return nothing
@@ -400,7 +400,7 @@ function lift_leaves(compact::IncrementalCompact,
                 return nothing
             else
                 typ = argextype(leaf, compact)
-                if !isa(typ, Const)
+                if !isConst(typ)
                     # TODO: (disabled since #27126)
                     # If the leaf is an old ssa value, insert a getfield here
                     # We will revisit this getfield later when compaction gets
@@ -495,11 +495,11 @@ function lift_comparison!(::typeof(===), compact::IncrementalCompact,
     lhs, rhs = args[2], args[3]
     vl = argextype(lhs, compact)
     vr = argextype(rhs, compact)
-    if isa(vl, Const)
-        isa(vr, Const) && return
+    if isConst(vl)
+        isConst(vr) && return
         val = rhs
         cmp = vl
-    elseif isa(vr, Const)
+    elseif isConst(vr)
         val = lhs
         cmp = vr
     else
@@ -522,7 +522,7 @@ function lift_comparison!(::typeof(isdefined), compact::IncrementalCompact,
     args = stmt.args
     length(args) == 3 || return
     cmp = argextype(args[3], compact)
-    isa(cmp, Const) || return # `isdefined_tfunc` won't return Const
+    isConst(cmp) || return # `isdefined_tfunc` won't return Const
     val = args[2]
     lift_comparison_leaves!(isdefined_tfunc, compact, val, cmp, lifting_cache, idx)
 end
@@ -543,7 +543,7 @@ function lift_comparison_leaves!(@specialize(tfunc),
     for i = 1:length(leaves)
         leaf = leaves[i]
         result = tfunc(argextype(leaf, compact), cmp)
-        if isa(result, Const)
+        if isConst(result)
             if lifted_leaves === nothing
                 lifted_leaves = LiftedLeaves()
             end

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -221,9 +221,9 @@ function typ_for_val(@nospecialize(x), ci::CodeInfo, sptypes::Vector{Any}, idx::
     isa(x, SSAValue) && return (ci.ssavaluetypes::Vector{Any})[x.id]
     isa(x, Argument) && return slottypes[x.n]
     isa(x, NewSSAValue) && return DelayedTyp(x)
-    isa(x, QuoteNode) && return Const(x.value)
+    isa(x, QuoteNode) && return mkConst(x.value)
     isa(x, Union{Symbol, PiNode, PhiNode, SlotNumber, TypedSlot}) && error("unexpected val type")
-    return Const(x)
+    return mkConst(x)
 end
 
 struct BlockLiveness

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -220,7 +220,10 @@ function finish!(interp::AbstractInterpreter, caller::InferenceResult)
     opt = caller.src
     if opt isa OptimizationState # implies `may_optimize(interp) === true`
         if opt.ir !== nothing
+            # Already done in the cache
             caller.src = ir_to_codeinf!(opt)
+        else
+            caller.src = opt.src
         end
     end
     return caller.src
@@ -292,7 +295,7 @@ function CodeInstance(
         const_flags = 0x3
         inferred_result = nothing
     else
-        if isa(result_type, Const)
+        if isConst(result_type)
             rettype_const = result_type.val
             const_flags = 0x2
         elseif isa(result_type, PartialOpaque)
@@ -831,7 +834,7 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
                 elseif isa(rettype_const, InterConditional) && !(InterConditional <: rettype)
                     return rettype_const, mi, effects
                 else
-                    return Const(rettype_const), mi, effects
+                    return mkConst(rettype_const), mi, effects
                 end
             else
                 return rettype, mi, effects

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -399,8 +399,8 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
         return Bool
     end
     # type-lattice for Const and PartialStruct wrappers
-    if ((isa(typea, PartialStruct) || isa(typea, Const)) &&
-        (isa(typeb, PartialStruct) || isa(typeb, Const)))
+    if ((isa(typea, PartialStruct) || isConst(typea)) &&
+        (isa(typeb, PartialStruct) || isConst(typeb)))
         aty = widenconst(typea)
         bty = widenconst(typeb)
         if aty === bty
@@ -614,7 +614,7 @@ end
 # compute typeintersect over the extended inference lattice
 # where v is in the extended lattice, and t is a Type
 function tmeet(@nospecialize(v), @nospecialize(t))
-    if isa(v, Const)
+    if isConst(v)
         if !has_free_typevars(t) && !isa(v.val, t)
             return Bottom
         end

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -28,9 +28,12 @@ end
 function has_nontrivial_const_info(@nospecialize t)
     isa(t, PartialStruct) && return true
     isa(t, PartialOpaque) && return true
+    if isa(t, ConstType)
+        return !hasuniquerep(t.val)
+    end
     isa(t, Const) || return false
     val = t.val
-    return !isdefined(typeof(val), :instance) && !(isa(val, Type) && hasuniquerep(val))
+    return !isdefined(typeof(val), :instance)
 end
 
 has_const_info(@nospecialize x) = (!isa(x, Type) && !isvarargtype(x)) || isType(x)

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -230,7 +230,7 @@ end
 #########
 
 function singleton_type(@nospecialize(ft))
-    if isa(ft, Const)
+    if isConst(ft)
         return ft.val
     elseif isconstType(ft)
         return ft.parameters[1]
@@ -238,6 +238,19 @@ function singleton_type(@nospecialize(ft))
         return ft.instance
     end
     return nothing
+end
+
+function maybe_singleton_const(@nospecialize(t))
+    if isa(t, DataType) && isdefined(t, :instance)
+        if t === typeof(Bottom)
+            return ConstType(Bottom)
+        else
+            return Const(t.instance)
+        end
+    elseif isconstType(t)
+        return ConstType(t.parameters[1], t)
+    end
+    return t
 end
 
 ###################

--- a/base/show.jl
+++ b/base/show.jl
@@ -2489,6 +2489,7 @@ module IRShow
     import .Compiler: IRCode, ReturnNode, GotoIfNot, CFG, scan_ssa_use!, Argument,
         isexpr, compute_basic_blocks, block_for_inst,
         TriState, Effects, ALWAYS_TRUE, ALWAYS_FALSE
+    Base.:(==)(a::Compiler.ConstType, b::Compiler.ConstType) = Compiler.:(==)(a, b)
     Base.getindex(r::Compiler.StmtRange, ind::Integer) = Compiler.getindex(r, ind)
     Base.size(r::Compiler.StmtRange) = Compiler.size(r)
     Base.first(r::Compiler.StmtRange) = Compiler.first(r)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -983,7 +983,10 @@
                                '()))
                   ;; otherwise do an assignment to trigger an error
                   (= (outerref ,name) ,name)))
-             (= (outerref ,name) ,name))
+             (block
+              (call (core set_binding_type!) (thismodule) (inert ,name) (call (core apply_type) (core Type) ,name))
+              (= (outerref ,name) ,name)))
+         ;; Set the binding type to Type{...} to speed up inference
          (call (core _typebody!) ,name (call (core svec) ,@field-types))
          (null)))
        ;; "inner" constructors


### PR DESCRIPTION
As mentioned in #44402, `widenconst` on a `Const` whose value is a `Type` can be quite slow - slow enough to show up noticeably in profiles. This attempts to address that by splitting the `Const` lattice element into two: `Const` and `ConstType`, the former being used for non-`Type` values and the latter being used for `Type`s, additionally tracking the `Type{T}` for the constant type `T`, thus saving the lookup on widenconst.

Now, not every `Const` actually passes through widenconst, which would cause a performance regression, but it turns out that most `ConstType`s originate from global references. Thus, we can take advantage of the recently added binding type field to cache the `Type{T}` value for bindings and directly feed that into ConstType.

As a second enhancement, when we don't already have a Type{T} value, we could make the corresponding `ConstType` field lazily computed on the first `widenconst`. However, because this would requires making `ConstType` mutable, this change is a bit of a wash performance wise. I included it in the anticipation that codegen for mutable types with const fields will improve in the future, but it's optional.