### PR TITLE
`AbstractInterpreter`: implement `findsup` for `OverlayMethodTable`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1484,7 +1484,8 @@ function abstract_invoke(interp::AbstractInterpreter, (; fargs, argtypes)::ArgIn
     argtype = Tuple{ft, argtype.parameters...}
     result = findsup(types, method_table(interp))
     result === nothing && return CallMeta(Any, false)
-    method, valid_worlds = result
+    match, valid_worlds = result
+    method = match.method
     update_valid_age!(sv, valid_worlds)
     (ti, env::SimpleVector) = ccall(:jl_type_intersection_with_env, Any, (Any, Any), nargtype, method.sig)::SimpleVector
     (; rt, edge) = result = abstract_call_method(interp, method, ti, env, false, sv)

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1774,7 +1774,7 @@ function detect_unbound_args(mods...;
                 params = tuple_sig.parameters[1:(end - 1)]
                 tuple_sig = Base.rewrap_unionall(Tuple{params...}, m.sig)
                 world = Base.get_world_counter()
-                mf = ccall(:jl_gf_invoke_lookup, Any, (Any, UInt), tuple_sig, world)
+                mf = ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), tuple_sig, nothing, world)
                 if mf !== nothing && mf !== m && mf.sig <: tuple_sig
                     continue
                 end

--- a/test/compiler/AbstractInterpreter.jl
+++ b/test/compiler/AbstractInterpreter.jl
@@ -45,3 +45,21 @@ CC.method_table(interp::MTOverlayInterp) = CC.OverlayMethodTable(CC.get_world_co
 @test Base.return_types((Int,), MTOverlayInterp()) do x
     sin(x)
 end == Any[Int]
+@test Base.return_types((Any,), MTOverlayInterp()) do x
+    Base.@invoke sin(x::Float64)
+end == Any[Int]
+
+# fallback to the internal method table
+@test Base.return_types((Int,), MTOverlayInterp()) do x
+    cos(x)
+end == Any[Float64]
+@test Base.return_types((Any,), MTOverlayInterp()) do x
+    Base.@invoke cos(x::Float64)
+end == Any[Float64]
+
+# not fully covered overlay method match
+overlay_match(::Any) = nothing
+@overlay OverlayedMT overlay_match(::Int) = missing
+@test Base.return_types((Any,), MTOverlayInterp()) do x
+    overlay_match(x)
+end == Any[Union{Nothing,Missing}]


### PR DESCRIPTION
Previously `findsup` doesn't support `OverlayMethodTable` at all.
This hasn't been recognized since `abstract_invoke` didn't use
the `method_table` interface properly until #44389 , 
but now we need this support.

xref: <https://github.com/JuliaGPU/GPUCompiler.jl/pull/303#issuecomment-1058282757>

