### PR TITLE
Fewer warnings in 'make clean' in clean directory

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1396,7 +1396,7 @@ clean-$$(abspath $(2)/$(3)):
 ifeq ($(BUILD_OS), WINNT)
 	-cmd //C rmdir $$(call mingw_to_dos,$(2)/$(3),cd $(2) &&)
 else
-	-rm -rf $$(abspath $(2)/$(3))
+	rm -rf $$(abspath $(2)/$(3))
 endif
 $$(abspath $(2)/$(3)): | $$(abspath $(2))
 ifeq ($$(BUILD_OS), WINNT)

--- a/Make.inc
+++ b/Make.inc
@@ -1396,7 +1396,7 @@ clean-$$(abspath $(2)/$(3)):
 ifeq ($(BUILD_OS), WINNT)
 	-cmd //C rmdir $$(call mingw_to_dos,$(2)/$(3),cd $(2) &&)
 else
-	-rm -r $$(abspath $(2)/$(3))
+	-rm -rf $$(abspath $(2)/$(3))
 endif
 $$(abspath $(2)/$(3)): | $$(abspath $(2))
 ifeq ($$(BUILD_OS), WINNT)
@@ -1404,7 +1404,7 @@ ifeq ($$(BUILD_OS), WINNT)
 else ifneq (,$$(findstring CYGWIN,$$(BUILD_OS)))
 	@cmd /C mklink /J $$(call cygpath_w,$(2)/$(3)) $$(call cygpath_w,$(1))
 else ifdef JULIA_VAGRANT_BUILD
-	@rm -r $$@
+	@rm -rf $$@
 	@cp -R $$(abspath $(1)) $$@.tmp
 	@mv $$@.tmp $$@
 else

--- a/base/Makefile
+++ b/base/Makefile
@@ -169,7 +169,7 @@ $$(build_private_libdir)/$$(libname_$2):
 		REALPATH=$$(libpath_$2); \
 		$$(call resolve_path,REALPATH) && \
 		[ -e "$$$$REALPATH" ] && \
-		([ ! -e "$$@" ] || rm "$$@") && \
+		rm -f "$$@" && \
 		echo ln -sf "$$$$REALPATH" "$$@" && \
 		ln -sf "$$$$REALPATH" "$$@"; \
 	else \
@@ -193,7 +193,7 @@ endif
 
 $(build_bindir)/7z$(EXE):
 	[ -e "$(7Z_PATH)" ] && \
-	([ ! -e "$@" ] || rm "$@") && \
+	rm -f "$@" && \
 	ln -svf "$(7Z_PATH)" "$@"
 
 # the following excludes: libuv.a, libutf8proc.a
@@ -258,7 +258,7 @@ $(build_private_libdir)/libLLVM.$(SHLIB_EXT):
 	REALPATH=$(LLVM_CONFIG_HOST_LIBS) && \
 	$(call resolve_path,REALPATH) && \
 	[ -e "$$REALPATH" ] && \
-	([ ! -e "$@" ] || rm "$@") && \
+	rm -f "$@" && \
 	echo ln -sf "$$REALPATH" "$@" && \
 	ln -sf "$$REALPATH" "$@"
 ifneq ($(USE_SYSTEM_LLVM),0)

--- a/contrib/mac/frameworkapp/Makefile
+++ b/contrib/mac/frameworkapp/Makefile
@@ -116,8 +116,8 @@ signedproductarchive: $(PRODUCTARCHIVE)
 	mv $<.signed $<
 
 clean:
-	-rm -rf $(XCARCHIVE) $(XCDERIVEDDATA) $(XCEXPORT)
-	-rm -rf $(FRAMEWORK_DESTDIR)
+	rm -rf $(XCARCHIVE) $(XCDERIVEDDATA) $(XCEXPORT)
+	rm -rf $(FRAMEWORK_DESTDIR)
 	-rm -f $(PRODUCTARCHIVE)
 
 .PHONY: appexport clean productarchive signedproductarchive

--- a/deps/curl.mk
+++ b/deps/curl.mk
@@ -75,7 +75,7 @@ $(eval $(call staged-install, \
 	$$(INSTALL_NAME_CMD)libcurl.$$(SHLIB_EXT) $$(build_shlibdir)/libcurl.$$(SHLIB_EXT)))
 
 clean-curl:
-	-rm $(BUILDDIR)/curl-$(CURL_VER)/build-configured $(BUILDDIR)/curl-$(CURL_VER)/build-compiled
+	-rm -f $(BUILDDIR)/curl-$(CURL_VER)/build-configured $(BUILDDIR)/curl-$(CURL_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/curl-$(CURL_VER) clean
 
 distclean-curl:

--- a/deps/curl.mk
+++ b/deps/curl.mk
@@ -79,7 +79,7 @@ clean-curl:
 	-$(MAKE) -C $(BUILDDIR)/curl-$(CURL_VER) clean
 
 distclean-curl:
-	-rm -rf $(SRCCACHE)/curl-$(CURL_VER).tar.bz2 $(SRCCACHE)/curl-$(CURL_VER) $(BUILDDIR)/curl-$(CURL_VER)
+	rm -rf $(SRCCACHE)/curl-$(CURL_VER).tar.bz2 $(SRCCACHE)/curl-$(CURL_VER) $(BUILDDIR)/curl-$(CURL_VER)
 
 get-curl: $(SRCCACHE)/curl-$(CURL_VER).tar.bz2
 extract-curl: $(SRCCACHE)/curl-$(CURL_VER)/source-extracted

--- a/deps/dsfmt.mk
+++ b/deps/dsfmt.mk
@@ -15,7 +15,7 @@ $(SRCCACHE)/dsfmt-$(DSFMT_VER).tar.gz: | $(SRCCACHE)
 
 $(BUILDDIR)/dsfmt-$(DSFMT_VER)/source-extracted: $(SRCCACHE)/dsfmt-$(DSFMT_VER).tar.gz
 	$(JLCHECKSUM) $<
-	-rm -r $(dir $@)
+	-rm -rf $(dir $@)
 	mkdir -p $(dir $@)
 	$(TAR) -C $(dir $@) --strip-components 1 -xf $<
 	echo 1 > $@
@@ -47,8 +47,8 @@ $(eval $(call staged-install, \
 	$$(INSTALL_NAME_CMD)libdSFMT.$$(SHLIB_EXT) $$(build_shlibdir)/libdSFMT.$$(SHLIB_EXT)))
 
 clean-dsfmt:
-	-rm $(BUILDDIR)/dsfmt-$(DSFMT_VER)/build-compiled
-	-rm $(BUILDDIR)/dsfmt-$(DSFMT_VER)/libdSFMT.$(SHLIB_EXT)
+	-rm -f $(BUILDDIR)/dsfmt-$(DSFMT_VER)/build-compiled
+	-rm -f $(BUILDDIR)/dsfmt-$(DSFMT_VER)/libdSFMT.$(SHLIB_EXT)
 
 distclean-dsfmt:
 	-rm -rf $(SRCCACHE)/dsfmt*.tar.gz $(SRCCACHE)/dsfmt-$(DSFMT_VER) $(BUILDDIR)/dsfmt-$(DSFMT_VER)

--- a/deps/dsfmt.mk
+++ b/deps/dsfmt.mk
@@ -15,7 +15,7 @@ $(SRCCACHE)/dsfmt-$(DSFMT_VER).tar.gz: | $(SRCCACHE)
 
 $(BUILDDIR)/dsfmt-$(DSFMT_VER)/source-extracted: $(SRCCACHE)/dsfmt-$(DSFMT_VER).tar.gz
 	$(JLCHECKSUM) $<
-	-rm -rf $(dir $@)
+	rm -rf $(dir $@)
 	mkdir -p $(dir $@)
 	$(TAR) -C $(dir $@) --strip-components 1 -xf $<
 	echo 1 > $@
@@ -51,7 +51,7 @@ clean-dsfmt:
 	-rm -f $(BUILDDIR)/dsfmt-$(DSFMT_VER)/libdSFMT.$(SHLIB_EXT)
 
 distclean-dsfmt:
-	-rm -rf $(SRCCACHE)/dsfmt*.tar.gz $(SRCCACHE)/dsfmt-$(DSFMT_VER) $(BUILDDIR)/dsfmt-$(DSFMT_VER)
+	rm -rf $(SRCCACHE)/dsfmt*.tar.gz $(SRCCACHE)/dsfmt-$(DSFMT_VER) $(BUILDDIR)/dsfmt-$(DSFMT_VER)
 
 get-dsfmt: $(SRCCACHE)/dsfmt-$(DSFMT_VER).tar.gz
 extract-dsfmt: $(BUILDDIR)/dsfmt-$(DSFMT_VER)/source-extracted

--- a/deps/gmp.mk
+++ b/deps/gmp.mk
@@ -76,7 +76,7 @@ clean-gmp:
 	-$(MAKE) -C $(BUILDDIR)/gmp-$(GMP_VER) clean
 
 distclean-gmp:
-	-rm -rf $(SRCCACHE)/gmp-$(GMP_VER).tar.bz2 \
+	rm -rf $(SRCCACHE)/gmp-$(GMP_VER).tar.bz2 \
 		$(SRCCACHE)/gmp-$(GMP_VER) \
 		$(BUILDDIR)/gmp-$(GMP_VER)
 

--- a/deps/gmp.mk
+++ b/deps/gmp.mk
@@ -72,7 +72,7 @@ $(eval $(call staged-install, \
 	$$(INSTALL_NAME_CMD)libgmp.$$(SHLIB_EXT) $$(build_shlibdir)/libgmp.$$(SHLIB_EXT)))
 
 clean-gmp:
-	-rm $(BUILDDIR)/gmp-$(GMP_VER)/build-configured $(BUILDDIR)/gmp-$(GMP_VER)/build-compiled
+	-rm -f $(BUILDDIR)/gmp-$(GMP_VER)/build-configured $(BUILDDIR)/gmp-$(GMP_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/gmp-$(GMP_VER) clean
 
 distclean-gmp:

--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -80,8 +80,8 @@ $(eval $(call staged-install, \
 	$$(INSTALL_NAME_CMD)libgit2.$$(SHLIB_EXT) $$(build_shlibdir)/libgit2.$$(SHLIB_EXT)))
 
 clean-libgit2:
-	-rm $(build_datarootdir)/julia/cert.pem
-	-rm $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-compiled
+	-rm -f $(build_datarootdir)/julia/cert.pem
+	-rm -f $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/$(LIBGIT2_SRC_DIR) clean
 
 get-libgit2: $(LIBGIT2_SRC_FILE)

--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -61,7 +61,7 @@ $(eval $(call staged-install, \
 	$$(INSTALL_NAME_CMD)libssh2.$$(SHLIB_EXT) $$(build_shlibdir)/libssh2.$$(SHLIB_EXT)))
 
 clean-libssh2:
-	-rm $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-compiled
+	-rm -f $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-configured $(BUILDDIR)/$(LIBSSH2_SRC_DIR)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/$(LIBSSH2_SRC_DIR) clean
 
 

--- a/deps/libsuitesparse.mk
+++ b/deps/libsuitesparse.mk
@@ -80,7 +80,7 @@ $(build_prefix)/manifest/libsuitesparse: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARS
 	echo $(UNINSTALL_libsuitesparse) > $@
 
 clean-libsuitesparse: uninstall-libsuitesparse
-	-rm $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled
+	-rm -f $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled
 	-rm -fr $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/lib
 	-rm -fr $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/include
 	-$(MAKE) -C $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER) clean
@@ -107,6 +107,6 @@ endif
 
 define manual_libsuitesparse
 uninstall-libsuitesparse:
-	-rm $(build_prefix)/manifest/libsuitesparse
-	-rm $(addprefix $(build_shlibdir)/lib,$3)
+	-rm -f $(build_prefix)/manifest/libsuitesparse
+	-rm -f $(addprefix $(build_shlibdir)/lib,$3)
 endef

--- a/deps/libsuitesparse.mk
+++ b/deps/libsuitesparse.mk
@@ -86,7 +86,7 @@ clean-libsuitesparse: uninstall-libsuitesparse
 	-$(MAKE) -C $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER) clean
 
 distclean-libsuitesparse:
-	-rm -rf $(SRCCACHE)/SuiteSparse-$(LIBSUITESPARSE_VER).tar.gz \
+	rm -rf $(SRCCACHE)/SuiteSparse-$(LIBSUITESPARSE_VER).tar.gz \
 		$(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)
 
 get-libsuitesparse: $(SRCCACHE)/SuiteSparse-$(LIBSUITESPARSE_VER).tar.gz

--- a/deps/libuv.mk
+++ b/deps/libuv.mk
@@ -43,7 +43,7 @@ $(eval $(call staged-install, \
 	$$(INSTALL_NAME_CMD)libuv.$$(SHLIB_EXT) $$(build_shlibdir)/libuv.$$(SHLIB_EXT)))
 
 clean-libuv:
-	-rm -rf $(LIBUV_BUILDDIR)/build-configured $(LIBUV_BUILDDIR)/build-compiled
+	rm -rf $(LIBUV_BUILDDIR)/build-configured $(LIBUV_BUILDDIR)/build-compiled
 	-$(MAKE) -C $(LIBUV_BUILDDIR) clean
 
 

--- a/deps/libwhich.mk
+++ b/deps/libwhich.mk
@@ -25,7 +25,7 @@ $(eval $(call staged-install, \
 	LIBWHICH_INSTALL,,,))
 
 clean-libwhich:
-	-rm $(BUILDDIR)/$(LIBWHICH_SRC_DIR)/build-compiled
+	-rm -f $(BUILDDIR)/$(LIBWHICH_SRC_DIR)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/$(LIBWHICH_SRC_DIR) clean
 
 get-libwhich: $(LIBWHICH_SRC_FILE)

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -281,7 +281,7 @@ $(eval $(call staged-install, \
 	LLVM_INSTALL,,,))
 
 clean-llvm:
-	-rm $(LLVM_BUILDDIR_withtype)/build-configured $(LLVM_BUILDDIR_withtype)/build-compiled
+	-rm -f $(LLVM_BUILDDIR_withtype)/build-configured $(LLVM_BUILDDIR_withtype)/build-compiled
 	-$(MAKE) -C $(LLVM_BUILDDIR_withtype) clean
 
 get-llvm: $(LLVM_SRC_FILE)

--- a/deps/mbedtls.mk
+++ b/deps/mbedtls.mk
@@ -71,7 +71,7 @@ $(eval $(call staged-install, \
 
 
 clean-mbedtls:
-	-rm $(BUILDDIR)/$(MBEDTLS_SRC)/build-configured \
+	-rm -f $(BUILDDIR)/$(MBEDTLS_SRC)/build-configured \
 		$(BUILDDIR)/$(MBEDTLS_SRC)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/$(MBEDTLS_SRC) clean
 

--- a/deps/mbedtls.mk
+++ b/deps/mbedtls.mk
@@ -76,7 +76,7 @@ clean-mbedtls:
 	-$(MAKE) -C $(BUILDDIR)/$(MBEDTLS_SRC) clean
 
 distclean-mbedtls:
-	-rm -rf $(SRCCACHE)/$(MBEDTLS_SRC).tar.gz \
+	rm -rf $(SRCCACHE)/$(MBEDTLS_SRC).tar.gz \
 		$(SRCCACHE)/$(MBEDTLS_SRC) \
 		$(BUILDDIR)/$(MBEDTLS_SRC)
 

--- a/deps/mpfr.mk
+++ b/deps/mpfr.mk
@@ -64,7 +64,7 @@ clean-mpfr:
 	-$(MAKE) -C $(BUILDDIR)/mpfr-$(MPFR_VER) clean
 
 distclean-mpfr:
-	-rm -rf $(SRCCACHE)/mpfr-$(MPFR_VER).tar.bz2 \
+	rm -rf $(SRCCACHE)/mpfr-$(MPFR_VER).tar.bz2 \
 		$(SRCCACHE)/mpfr-$(MPFR_VER) \
 		$(BUILDDIR)/mpfr-$(MPFR_VER)
 

--- a/deps/mpfr.mk
+++ b/deps/mpfr.mk
@@ -60,7 +60,7 @@ $(eval $(call staged-install, \
 	$$(INSTALL_NAME_CMD)libmpfr.$$(SHLIB_EXT) $$(build_shlibdir)/libmpfr.$$(SHLIB_EXT)))
 
 clean-mpfr:
-	-rm $(BUILDDIR)/mpfr-$(MPFR_VER)/build-configured $(BUILDDIR)/mpfr-$(MPFR_VER)/build-compiled
+	-rm -f $(BUILDDIR)/mpfr-$(MPFR_VER)/build-configured $(BUILDDIR)/mpfr-$(MPFR_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/mpfr-$(MPFR_VER) clean
 
 distclean-mpfr:

--- a/deps/nghttp2.mk
+++ b/deps/nghttp2.mk
@@ -36,7 +36,7 @@ $(eval $(call staged-install, \
 	$$(INSTALL_NAME_CMD)libnghttp2.$$(SHLIB_EXT) $$(build_shlibdir)/libnghttp2.$$(SHLIB_EXT)))
 
 clean-nghttp2:
-	-rm $(BUILDDIR)/nghttp2-$(NGHTTP2_VER)/build-configured $(BUILDDIR)/nghttp2-$(NGHTTP2_VER)/build-compiled
+	-rm -f $(BUILDDIR)/nghttp2-$(NGHTTP2_VER)/build-configured $(BUILDDIR)/nghttp2-$(NGHTTP2_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/nghttp2-$(NGHTTP2_VER) clean
 
 distclean-nghttp2:

--- a/deps/nghttp2.mk
+++ b/deps/nghttp2.mk
@@ -40,7 +40,7 @@ clean-nghttp2:
 	-$(MAKE) -C $(BUILDDIR)/nghttp2-$(NGHTTP2_VER) clean
 
 distclean-nghttp2:
-	-rm -rf $(SRCCACHE)/nghttp2-$(NGHTTP2_VER).tar.bz2 \
+	rm -rf $(SRCCACHE)/nghttp2-$(NGHTTP2_VER).tar.bz2 \
 		$(SRCCACHE)/nghttp2-$(NGHTTP2_VER) \
 		$(BUILDDIR)/nghttp2-$(NGHTTP2_VER)
 

--- a/deps/objconv.mk
+++ b/deps/objconv.mk
@@ -6,7 +6,7 @@ $(SRCCACHE)/objconv.zip: | $(SRCCACHE)
 	$(JLDOWNLOAD) $@ https://www.agner.org/optimize/objconv.zip
 
 $(BUILDDIR)/objconv/source-extracted: $(SRCCACHE)/objconv.zip
-	-rm -rf $(dir $@)
+	rm -rf $(dir $@)
 	mkdir -p $(BUILDDIR)
 	unzip -d $(dir $@) $<
 	cd $(dir $@) && unzip source.zip
@@ -24,7 +24,7 @@ clean-objconv:
 	-rm -f $(BUILDDIR)/objconv/build-compiled $(build_depsbindir)/objconv
 
 distclean-objconv:
-	-rm -rf $(SRCCACHE)/objconv.zip $(BUILDDIR)/objconv
+	rm -rf $(SRCCACHE)/objconv.zip $(BUILDDIR)/objconv
 
 
 get-objconv: $(SRCCACHE)/objconv.zip

--- a/deps/objconv.mk
+++ b/deps/objconv.mk
@@ -6,7 +6,7 @@ $(SRCCACHE)/objconv.zip: | $(SRCCACHE)
 	$(JLDOWNLOAD) $@ https://www.agner.org/optimize/objconv.zip
 
 $(BUILDDIR)/objconv/source-extracted: $(SRCCACHE)/objconv.zip
-	-rm -r $(dir $@)
+	-rm -rf $(dir $@)
 	mkdir -p $(BUILDDIR)
 	unzip -d $(dir $@) $<
 	cd $(dir $@) && unzip source.zip
@@ -21,7 +21,7 @@ $(eval $(call staged-install, \
 	BINFILE_INSTALL,$$(BUILDDIR)/objconv/objconv,,))
 
 clean-objconv:
-	-rm $(BUILDDIR)/objconv/build-compiled $(build_depsbindir)/objconv
+	-rm -f $(BUILDDIR)/objconv/build-compiled $(build_depsbindir)/objconv
 
 distclean-objconv:
 	-rm -rf $(SRCCACHE)/objconv.zip $(BUILDDIR)/objconv

--- a/deps/openblas.mk
+++ b/deps/openblas.mk
@@ -190,7 +190,7 @@ clean-lapack:
 	-$(MAKE) -C $(BUILDDIR)/lapack-$(LAPACK_VER) clean
 
 distclean-lapack:
-	-rm -rf $(SRCCACHE)/lapack-$(LAPACK_VER).tgz $(BUILDDIR)/lapack-$(LAPACK_VER)
+	rm -rf $(SRCCACHE)/lapack-$(LAPACK_VER).tgz $(BUILDDIR)/lapack-$(LAPACK_VER)
 
 
 get-lapack: $(SRCCACHE)/lapack-$(LAPACK_VER).tgz

--- a/deps/openblas.mk
+++ b/deps/openblas.mk
@@ -115,7 +115,7 @@ $(eval $(call staged-install, \
 	$$(INSTALL_NAME_CMD)libopenblas$$(OPENBLAS_LIBNAMESUFFIX).$$(SHLIB_EXT) $$(build_shlibdir)/libopenblas$$(OPENBLAS_LIBNAMESUFFIX).$$(SHLIB_EXT)))
 
 clean-openblas:
-	-rm $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-compiled
+	-rm -f $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/$(OPENBLAS_SRC_DIR) clean
 
 
@@ -186,7 +186,7 @@ $(eval $(call staged-install, \
 	$$(INSTALL_NAME_CMD)liblapack.$$(SHLIB_EXT) $$(build_shlibdir)/liblapack.$$(SHLIB_EXT)))
 
 clean-lapack:
-	-rm $(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled0 $(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled
+	-rm -f $(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled0 $(BUILDDIR)/lapack-$(LAPACK_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/lapack-$(LAPACK_VER) clean
 
 distclean-lapack:

--- a/deps/openlibm.mk
+++ b/deps/openlibm.mk
@@ -16,7 +16,7 @@ $(eval $(call staged-install, \
 	$(INSTALL_NAME_CMD)libopenlibm.$(SHLIB_EXT) $(build_shlibdir)/libopenlibm.$(SHLIB_EXT)))
 
 clean-openlibm:
-	-rm $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/build-compiled $(build_libdir)/libopenlibm.a
+	-rm -f $(BUILDDIR)/$(OPENLIBM_SRC_DIR)/build-compiled $(build_libdir)/libopenlibm.a
 	-$(MAKE) -C $(BUILDDIR)/$(OPENLIBM_SRC_DIR) distclean $(OPENLIBM_FLAGS)
 
 

--- a/deps/p7zip.mk
+++ b/deps/p7zip.mk
@@ -49,7 +49,7 @@ clean-p7zip:
 	-$(MAKE) -C $(BUILDDIR)/p7zip-$(P7ZIP_VER) clean
 
 distclean-p7zip:
-	-rm -rf $(SRCCACHE)/p7zip-$(P7ZIP_VER).tar.bz2 $(SRCCACHE)/p7zip-$(P7ZIP_VER) $(BUILDDIR)/p7zip-$(P7ZIP_VER)
+	rm -rf $(SRCCACHE)/p7zip-$(P7ZIP_VER).tar.bz2 $(SRCCACHE)/p7zip-$(P7ZIP_VER) $(BUILDDIR)/p7zip-$(P7ZIP_VER)
 
 
 get-p7zip: $(SRCCACHE)/p7zip-$(P7ZIP_VER).tar.bz2

--- a/deps/p7zip.mk
+++ b/deps/p7zip.mk
@@ -44,8 +44,8 @@ $(eval $(call staged-install, \
 	P7ZIP_INSTALL,,,))
 
 clean-p7zip:
-	-rm $(BUILDDIR)/p7zip-$(P7ZIP_VER)/build-configured $(BUILDDIR)/p7zip-$(P7ZIP_VER)/build-compiled
-	-rm $(build_bindir)/7za
+	-rm -f $(BUILDDIR)/p7zip-$(P7ZIP_VER)/build-configured $(BUILDDIR)/p7zip-$(P7ZIP_VER)/build-compiled
+	-rm -f $(build_bindir)/7za
 	-$(MAKE) -C $(BUILDDIR)/p7zip-$(P7ZIP_VER) clean
 
 distclean-p7zip:

--- a/deps/patchelf.mk
+++ b/deps/patchelf.mk
@@ -43,7 +43,7 @@ clean-patchelf:
 	-$(MAKE) -C $(BUILDDIR)/patchelf-$(PATCHELF_VER) clean
 
 distclean-patchelf:
-	-rm -rf $(SRCCACHE)/patchelf-$(PATCHELF_VER).tar.bz2 \
+	rm -rf $(SRCCACHE)/patchelf-$(PATCHELF_VER).tar.bz2 \
 		$(SRCCACHE)/patchelf-$(PATCHELF_VER) \
 		$(BUILDDIR)/patchelf-$(PATCHELF_VER)
 

--- a/deps/patchelf.mk
+++ b/deps/patchelf.mk
@@ -38,7 +38,7 @@ $(eval $(call staged-install, \
 	MAKE_INSTALL,$$(LIBTOOL_CCLD),,))
 
 clean-patchelf:
-	-rm $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-configured \
+	-rm -f $(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-configured \
 		$(BUILDDIR)/patchelf-$(PATCHELF_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/patchelf-$(PATCHELF_VER) clean
 

--- a/deps/pcre.mk
+++ b/deps/pcre.mk
@@ -54,7 +54,7 @@ clean-pcre:
 	-$(MAKE) -C $(BUILDDIR)/pcre2-$(PCRE_VER) clean
 
 distclean-pcre:
-	-rm -rf $(SRCCACHE)/pcre2-$(PCRE_VER).tar.bz2 $(SRCCACHE)/pcre2-$(PCRE_VER) $(BUILDDIR)/pcre2-$(PCRE_VER)
+	rm -rf $(SRCCACHE)/pcre2-$(PCRE_VER).tar.bz2 $(SRCCACHE)/pcre2-$(PCRE_VER) $(BUILDDIR)/pcre2-$(PCRE_VER)
 
 
 get-pcre: $(SRCCACHE)/pcre2-$(PCRE_VER).tar.bz2

--- a/deps/pcre.mk
+++ b/deps/pcre.mk
@@ -46,11 +46,11 @@ endif
 $(eval $(call staged-install, \
 	pcre,pcre2-$$(PCRE_VER), \
 	MAKE_INSTALL,$$(LIBTOOL_CCLD),, \
-	rm $$(build_shlibdir)/libpcre2-posix.* && \
+	rm -f $$(build_shlibdir)/libpcre2-posix.* && \
 	$$(INSTALL_NAME_CMD)libpcre2-8.$$(SHLIB_EXT) $$(build_shlibdir)/libpcre2-8.$$(SHLIB_EXT)))
 
 clean-pcre:
-	-rm $(BUILDDIR)/pcre2-$(PCRE_VER)/build-configured $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled
+	-rm -f $(BUILDDIR)/pcre2-$(PCRE_VER)/build-configured $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/pcre2-$(PCRE_VER) clean
 
 distclean-pcre:

--- a/deps/tools/bb-install.mk
+++ b/deps/tools/bb-install.mk
@@ -79,5 +79,5 @@ endef
 define bb-uninstaller
 uninstall-$(strip $1):
 	-cd $$(build_prefix) && rm -fv -- $$$$($$(TAR) -tzf $$(SRCCACHE)/$2.tar.gz | grep -v '/$$$$')
-	-rm $$(build_prefix)/manifest/$(strip $1)
+	-rm -f $$(build_prefix)/manifest/$(strip $1)
 endef

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -156,7 +156,7 @@ endif
 
 reinstall-$(strip $1):
 	+$$(MAKE) uninstall-$(strip $1)
-	-rm $$(build_staging)/$2.tgz
+	-rm -f $$(build_staging)/$2.tgz
 	+$$(MAKE) stage-$(strip $1)
 	+$$(MAKE) install-$(strip $1)
 
@@ -180,7 +180,7 @@ endef
 define staged-uninstaller
 uninstall-$(strip $1):
 	-cd $$(build_prefix) && rm -fv -- $$$$($$(TAR) -tzf $$(build_staging)/$2.tgz | grep -v '/$$$$')
-	-rm $$(build_prefix)/manifest/$(strip $1)
+	-rm -f $$(build_prefix)/manifest/$(strip $1)
 endef
 
 
@@ -216,9 +216,9 @@ uninstall-$1:
 ifeq ($$(BUILD_OS), WINNT)
 	-cmd //C rmdir $$(call mingw_to_dos,$3/$1,cd $3 &&)
 else
-	-rm -r $3/$1
+	-rm -rf $3/$1
 endif
-	-rm $$(build_prefix)/manifest/$1
+	-rm -f $$(build_prefix)/manifest/$1
 endef
 
 

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -216,7 +216,7 @@ uninstall-$1:
 ifeq ($$(BUILD_OS), WINNT)
 	-cmd //C rmdir $$(call mingw_to_dos,$3/$1,cd $3 &&)
 else
-	-rm -rf $3/$1
+	rm -rf $3/$1
 endif
 	-rm -f $$(build_prefix)/manifest/$1
 endef

--- a/deps/tools/git-external.mk
+++ b/deps/tools/git-external.mk
@@ -74,5 +74,5 @@ endif # DEPS_GIT
 
 $$(build_prefix)/manifest/$1: $$(SRCDIR)/$1.version # make the manifest stale if the version file is touched (causing re-install for compliant targets)
 distclean-$1:
-	-rm -rf $5/$$($2_SRC_DIR) $$($2_SRC_FILE) $$(BUILDDIR)/$$($2_SRC_DIR)
+	rm -rf $5/$$($2_SRC_DIR) $$($2_SRC_FILE) $$(BUILDDIR)/$$($2_SRC_DIR)
 endef

--- a/deps/tools/git-external.mk
+++ b/deps/tools/git-external.mk
@@ -63,7 +63,7 @@ $$($2_SRC_FILE): | $$(SRCCACHE)
 	$$(JLDOWNLOAD) $$@ $$(call $2_TAR_URL,$$($2_SHA1))
 $5/$$($2_SRC_DIR)/source-extracted: $$($2_SRC_FILE)
 	$$(JLCHECKSUM) $$<
-	-[ ! \( -e $$(dir $$@) -o -h $$(dir $$@) \) ] || rm -r $$(dir $$@)
+	-[ ! \( -e $$(dir $$@) -o -h $$(dir $$@) \) ] || rm -rf $$(dir $$@)
 	mkdir -p $$(dir $$@)
 	$(TAR) -C $$(dir $$@) --strip-components 1 -xf $$<
 	echo 1 > $$@

--- a/deps/tools/stdlib-external.mk
+++ b/deps/tools/stdlib-external.mk
@@ -18,7 +18,7 @@ $$(BUILDDIR)/$$($2_SRC_DIR)/build-compiled: $$(BUILDDIR)/$$($2_SRC_DIR)/source-e
 	echo 1 > $$@
 $$(eval $$(call symlink_install,$1,$$$$($2_SRC_DIR),$$$$(build_datarootdir)/julia/stdlib/$$$$(VERSDIR)))
 clean-$1:
-	-rm $$(BUILDDIR)/$$($2_SRC_DIR)/build-compiled
+	-rm -f $$(BUILDDIR)/$$($2_SRC_DIR)/build-compiled
 get-$1: $$($2_SRC_FILE)
 extract-$1: $$(BUILDDIR)/$$($2_SRC_DIR)/source-extracted
 configure-$1: extract-$1

--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -57,7 +57,7 @@ $(eval $(call staged-install, \
 	MAKE_INSTALL,,,))
 
 clean-unwind:
-	-rm $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-compiled
+	-rm -f $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/libunwind-$(UNWIND_VER) clean
 
 distclean-unwind:
@@ -114,8 +114,8 @@ $(eval $(call staged-install, \
 	cp -fR $(SRCCACHE)/llvmunwind-$(LLVMUNWIND_VER)/include/* $(build_includedir)))
 
 clean-llvmunwind:
-	-rm $(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER)/build-configured $(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER)/build-compiled
-	-rm -r $(build_includedir)/mach-o/ $(build_includedir)/unwind.h $(build_includedir)/libunwind.h
+	-rm -f $(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER)/build-configured $(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER)/build-compiled
+	-rm -rf $(build_includedir)/mach-o/ $(build_includedir)/unwind.h $(build_includedir)/libunwind.h
 	-$(MAKE) -C $(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER) clean
 
 distclean-llvmunwind:

--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -61,7 +61,7 @@ clean-unwind:
 	-$(MAKE) -C $(BUILDDIR)/libunwind-$(UNWIND_VER) clean
 
 distclean-unwind:
-	-rm -rf $(SRCCACHE)/libunwind-$(UNWIND_VER).tar.gz \
+	rm -rf $(SRCCACHE)/libunwind-$(UNWIND_VER).tar.gz \
 		$(SRCCACHE)/libunwind-$(UNWIND_VER) \
 		$(BUILDDIR)/libunwind-$(UNWIND_VER)
 
@@ -115,11 +115,11 @@ $(eval $(call staged-install, \
 
 clean-llvmunwind:
 	-rm -f $(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER)/build-configured $(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER)/build-compiled
-	-rm -rf $(build_includedir)/mach-o/ $(build_includedir)/unwind.h $(build_includedir)/libunwind.h
+	rm -rf $(build_includedir)/mach-o/ $(build_includedir)/unwind.h $(build_includedir)/libunwind.h
 	-$(MAKE) -C $(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER) clean
 
 distclean-llvmunwind:
-	-rm -rf $(SRCCACHE)/llvmunwind-$(LLVMUNWIND_VER).tar.xz \
+	rm -rf $(SRCCACHE)/llvmunwind-$(LLVMUNWIND_VER).tar.xz \
 		$(SRCCACHE)/llvmunwind-$(LLVMUNWIND_VER) \
 		$(BUILDDIR)/llvmunwind-$(LLVMUNWIND_VER)
 

--- a/deps/utf8proc.mk
+++ b/deps/utf8proc.mk
@@ -29,7 +29,7 @@ $(eval $(call staged-install, \
 	UTF8PROC_INSTALL,,,))
 
 clean-utf8proc:
-	-rm $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/build-compiled
+	-rm -f $(BUILDDIR)/$(UTF8PROC_SRC_DIR)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/$(UTF8PROC_SRC_DIR) clean
 
 get-utf8proc: $(UTF8PROC_SRC_FILE)

--- a/deps/zlib.mk
+++ b/deps/zlib.mk
@@ -19,7 +19,7 @@ $(eval $(call staged-install, \
 	$(INSTALL_NAME_CMD)libz.$(SHLIB_EXT) $(build_shlibdir)/libz.$(SHLIB_EXT)))
 
 clean-zlib:
-	-rm $(BUILDDIR)/$(ZLIB_SRC_DIR)/build-compiled $(build_libdir)/libz.a* $(build_libdir)/libz.so* $(build_includedir)/zlib.h $(build_includedir)/zconf.h
+	-rm -f $(BUILDDIR)/$(ZLIB_SRC_DIR)/build-compiled $(build_libdir)/libz.a* $(build_libdir)/libz.so* $(build_includedir)/zlib.h $(build_includedir)/zconf.h
 	-$(MAKE) -C $(BUILDDIR)/$(ZLIB_SRC_DIR) distclean $(ZLIB_FLAGS)
 
 get-zlib: $(ZLIB_SRC_FILE)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -38,7 +38,7 @@ checksum-unicodedata: $(SRCCACHE)/UnicodeData-$(UNICODE_DATA_VERSION).txt
 	$(JLCHECKSUM) "$<"
 
 clean:
-	-rm -rf _build/* deps/* docbuild.log UnicodeData.txt
+	rm -rf _build/* deps/* docbuild.log UnicodeData.txt
 
 cleanall: clean
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -259,7 +259,7 @@ endif
 	@## clang should have made the dSYM split-debug directory,
 	@## but we are intentionally not going to give it the correct name
 	@## because we want to test the non-default debug configuration
-	@#rm -r $@.dSYM && mv $@.tmp.dSYM $@.dSYM
+	@#rm -rf $@.dSYM && mv $@.tmp.dSYM $@.dSYM
 	mv $@.tmp $@
 	$(INSTALL_NAME_CMD)libccalltest.$(SHLIB_EXT) $@
 


### PR DESCRIPTION
E.g. if one does `rm -rf usr && make clean && make` then there are tons of errors because `rm` is asked to delete files that don't exist (anymore). So just pass the `-f` option to `rm` to suppress those useless errors.