### PR TITLE
[RemoveAddrspaces] make MappedTypes non-static

### DIFF
--- a/src/llvm-remove-addrspaces.cpp
+++ b/src/llvm-remove-addrspaces.cpp
@@ -113,7 +113,7 @@ public:
     }
 
 private:
-    static DenseMap<Type *, Type *> MappedTypes;
+    DenseMap<Type *, Type *> MappedTypes;
 };
 
 DenseMap<Type *, Type *> AddrspaceRemoveTypeRemapper::MappedTypes;

--- a/src/llvm-remove-addrspaces.cpp
+++ b/src/llvm-remove-addrspaces.cpp
@@ -116,7 +116,6 @@ private:
     DenseMap<Type *, Type *> MappedTypes;
 };
 
-DenseMap<Type *, Type *> AddrspaceRemoveTypeRemapper::MappedTypes;
 
 class AddrspaceRemoveValueMaterializer : public ValueMaterializer {
     ValueToValueMapTy &VM;


### PR DESCRIPTION
IIUC correctly `static` means that the member variable will be shared across all instances.
If you use this with multiple context, some of them having short-live times, you can get into
the situation where we believe to have seen the pointer already.

https://en.cppreference.com/w/cpp/language/static
