### PR TITLE
Remove global metadata nodes from JuliaPassContext

### DIFF
--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -41,6 +41,7 @@ private:
     Function *poolAllocFunc;
     Function *bigAllocFunc;
     Instruction *pgcstack;
+    MDNode *tbaa_gcframe;
 
     // Lowers a `julia.new_gc_frame` intrinsic.
     Value *lowerNewGCFrame(CallInst *target, Function &F);
@@ -212,6 +213,7 @@ bool FinalLowerGC::doInitialization(Module &M) {
     queueBindingFunc = getOrDeclare(jl_well_known::GCQueueBinding);
     poolAllocFunc = getOrDeclare(jl_well_known::GCPoolAlloc);
     bigAllocFunc = getOrDeclare(jl_well_known::GCBigAlloc);
+    tbaa_gcframe = tbaa_make_child_with_context(M.getContext(), "jtbaa_gcframe").first;
 
     GlobalValue *functionList[] = {queueRootFunc, queueBindingFunc, poolAllocFunc, bigAllocFunc};
     unsigned j = 0;

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -20,9 +20,6 @@ using namespace llvm;
 
 JuliaPassContext::JuliaPassContext()
     : T_prjlvalue(nullptr),
-
-        tbaa_gcframe(nullptr), tbaa_tag(nullptr),
-
         pgcstack_getter(nullptr), gc_flush_func(nullptr),
         gc_preserve_begin_func(nullptr), gc_preserve_end_func(nullptr),
         pointer_from_objref_func(nullptr), alloc_obj_func(nullptr),
@@ -34,13 +31,6 @@ JuliaPassContext::JuliaPassContext()
 void JuliaPassContext::initFunctions(Module &M)
 {
     module = &M;
-    LLVMContext &llvmctx = M.getContext();
-
-    tbaa_gcframe = tbaa_make_child_with_context(llvmctx, "jtbaa_gcframe").first;
-    MDNode *tbaa_data;
-    MDNode *tbaa_data_scalar;
-    std::tie(tbaa_data, tbaa_data_scalar) = tbaa_make_child_with_context(llvmctx, "jtbaa_data");
-    tbaa_tag = tbaa_make_child_with_context(llvmctx, "jtbaa_tag", tbaa_data_scalar).first;
 
     pgcstack_getter = M.getFunction("julia.get_pgcstack");
     gc_flush_func = M.getFunction("julia.gcroot_flush");
@@ -58,11 +48,8 @@ void JuliaPassContext::initAll(Module &M)
     // First initialize the functions.
     initFunctions(M);
 
-    // Then initialize types and metadata nodes.
-    auto &ctx = M.getContext();
-
     // Construct derived types.
-    T_prjlvalue = JuliaType::get_prjlvalue_ty(ctx);
+    T_prjlvalue = JuliaType::get_prjlvalue_ty(M.getContext());
 }
 
 llvm::CallInst *JuliaPassContext::getPGCstack(llvm::Function &F) const

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -44,10 +44,6 @@ struct JuliaPassContext {
     // Types derived from 'jl_value_t'.
     llvm::PointerType *T_prjlvalue;
 
-    // TBAA metadata nodes.
-    llvm::MDNode *tbaa_gcframe;
-    llvm::MDNode *tbaa_tag;
-
     // Intrinsics.
     llvm::Function *pgcstack_getter;
     llvm::Function *gc_flush_func;


### PR DESCRIPTION
These metadata nodes are only used by two passes, they don't need to be initialized in every pass that inherits from JuliaPassContext.

Depends on #44469