### PR TITLE
Document simple ASAN build

### DIFF
--- a/doc/src/devdocs/sanitizers.md
+++ b/doc/src/devdocs/sanitizers.md
@@ -1,5 +1,24 @@
 # Sanitizer support
 
+[Sanitizers](https://github.com/google/sanitizers) can be used in custom Julia builds to make it
+easier to detect certain kinds of errors in Julia's internal C/C++ code.
+
+## Address Sanitizer: easy build
+
+From a source-checkout of Julia, you should be able to build a version
+supporting address sanitization in Julia and LLVM as follows:
+
+```sh
+$ mkdir /tmp/julia
+$ contrib/asan/build.sh /tmp/julia/
+```
+
+Here we've chosen `/tmp/julia` as a build directory, but you can
+choose whatever you wish. Once built, run the workload you wish to
+test with `/tmp/julia/julia`. Memory bugs will result in errors.
+
+If you require customization or further detail, see the documentation below.
+
 ## General considerations
 
 Using Clang's sanitizers obviously requires you to use Clang (`USECLANG=1`), but there's another


### PR DESCRIPTION
This splits out the documentation piece of #44396, which was superseded by #44420.