### PR TITLE
Do not allocate so many arrays in optimizer hot path

### DIFF
--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -551,13 +551,13 @@ function compute_live_ins(cfg::CFG, defs::Vector{Int}, uses::Vector{Int})
     extra_liveins = BitSet()
     worklist = Int[]
     for bb in bb_uses
-        append!(worklist, filter(p->p != 0 && !(p in bb_defs), cfg.blocks[bb].preds))
+        append!(worklist, Iterators.filter(p->p != 0 && !(p in bb_defs), cfg.blocks[bb].preds))
     end
     while !isempty(worklist)
         elem = pop!(worklist)
         (elem in bb_uses || elem in extra_liveins) && continue
         push!(extra_liveins, elem)
-        append!(worklist, filter(p->p != 0 && !(p in bb_defs), cfg.blocks[elem].preds))
+        append!(worklist, Iterators.filter(p->p != 0 && !(p in bb_defs), cfg.blocks[elem].preds))
     end
     append!(bb_uses, extra_liveins)
     BlockLiveness(bb_defs, bb_uses)


### PR DESCRIPTION
Before:
```
julia> @time Cthulhu.mkinterp(TortureTest.run_test1, Tuple{Int});
 12.851312 seconds (89.76 M allocations: 12.845 GiB, 39.38% gc time)

julia> @time Cthulhu.mkinterp(TortureTest.run_test1, Tuple{Int});
 10.862736 seconds (89.76 M allocations: 12.845 GiB, 26.90% gc time)
```

After:
```
julia> @time Cthulhu.mkinterp(TortureTest.run_test1, Tuple{Int});
 10.929275 seconds (59.01 M allocations: 10.987 GiB, 33.07% gc time)

julia> @time Cthulhu.mkinterp(TortureTest.run_test1, Tuple{Int});
  8.635190 seconds (59.01 M allocations: 10.987 GiB, 20.06% gc time)
```