### PR TITLE
Improve inference for string operations

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -667,7 +667,7 @@ const libstdcxx_version_mapping = Dict{String,String}(
 
 Parses a string platform triplet back into a `Platform` object.
 """
-function Base.parse(::Type{Platform}, triplet::AbstractString; validate_strict::Bool = false)
+function Base.parse(::Type{Platform}, triplet::String; validate_strict::Bool = false)
     # Helper function to collapse dictionary of mappings down into a regex of
     # named capture groups joined by "|" operators
     c(mapping) = string("(",join(["(?<$k>$v)" for (k, v) in mapping], "|"), ")")
@@ -751,6 +751,8 @@ function Base.parse(::Type{Platform}, triplet::AbstractString; validate_strict::
     end
     throw(ArgumentError("Platform `$(triplet)` is not an officially supported platform"))
 end
+Base.parse(::Type{Platform}, triplet::AbstractString; kwargs...) =
+    parse(Platform, convert(String, triplet)::String; kwargs...)
 
 function Base.tryparse(::Type{Platform}, triplet::AbstractString)
     try

--- a/base/io.jl
+++ b/base/io.jl
@@ -445,7 +445,7 @@ wait_close(io::AbstractPipe) = (wait_close(pipe_writer(io)::IO); wait_close(pipe
 
 # Exception-safe wrappers (io = open(); try f(io) finally close(io))
 
-write(filename::AbstractString, a1, args...) = open(io->write(io, a1, args...), filename, "w")
+write(filename::AbstractString, a1, args...) = open(io->write(io, a1, args...), convert(String, filename)::String, "w")
 
 """
     read(filename::AbstractString, args...)
@@ -457,9 +457,9 @@ Open a file and read its contents. `args` is passed to `read`: this is equivalen
 
 Read the entire contents of a file as a string.
 """
-read(filename::AbstractString, args...) = open(io->read(io, args...), filename)
+read(filename::AbstractString, args...) = open(io->read(io, args...), convert(String, filename)::String)
 
-read(filename::AbstractString, ::Type{T}) where {T} = open(io->read(io, T), filename)
+read(filename::AbstractString, ::Type{T}) where {T} = open(io->read(io, T), convert(String, filename)::String)
 
 """
     read!(stream::IO, array::AbstractArray)
@@ -469,7 +469,7 @@ Read binary data from an I/O stream or file, filling in `array`.
 """
 function read! end
 
-read!(filename::AbstractString, a) = open(io->read!(io, a), filename)
+read!(filename::AbstractString, a) = open(io->read!(io, a), convert(String, filename)::String)
 
 """
     readuntil(stream::IO, delim; keep::Bool = false)
@@ -496,7 +496,7 @@ julia> readuntil("my_file.txt", '.', keep = true)
 julia> rm("my_file.txt")
 ```
 """
-readuntil(filename::AbstractString, args...; kw...) = open(io->readuntil(io, args...; kw...), filename)
+readuntil(filename::AbstractString, args...; kw...) = open(io->readuntil(io, args...; kw...), convert(String, filename)::String)
 
 """
     readline(io::IO=stdin; keep::Bool=false)

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -272,7 +272,7 @@ safe multi-threaded access.
 !!! compat "Julia 1.5"
     The `lock` argument is available as of Julia 1.5.
 """
-function open(fname::AbstractString; lock = true,
+function open(fname::String; lock = true,
     read     :: Union{Bool,Nothing} = nothing,
     write    :: Union{Bool,Nothing} = nothing,
     create   :: Union{Bool,Nothing} = nothing,
@@ -299,6 +299,7 @@ function open(fname::AbstractString; lock = true,
     end
     return s
 end
+open(fname::AbstractString; kwargs...) = open(convert(String, fname)::String; kwargs...)
 
 """
     open(filename::AbstractString, [mode::AbstractString]; lock = true) -> IOStream

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -457,7 +457,7 @@ end
     msg = try
               "Exception while generating log record in module $_module at $filepath:$line"
           catch ex
-              "Exception handling log message: $ex"
+              "Exception handling log message: $(ex::Exception)"
           end
     bt = real ? catch_backtrace() : backtrace()
     handle_message(

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -457,7 +457,7 @@ end
     msg = try
               "Exception while generating log record in module $_module at $filepath:$line"
           catch ex
-              "Exception handling log message: $(ex::Exception)"
+              LazyString("Exception handling log message: ", ex)
           end
     bt = real ? catch_backtrace() : backtrace()
     handle_message(

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -674,7 +674,7 @@ function handle_message(logger::SimpleLogger, level::LogLevel, message, _module,
     end
     iob = IOContext(buf, stream)
     levelstr = level == Warn ? "Warning" : string(level)
-    msglines = eachsplit(chomp(string(message)::String), '\n')
+    msglines = eachsplit(chomp(convert(String, message)::String), '\n')
     msg1, rest = Iterators.peel(msglines)
     println(iob, "┌ ", levelstr, ": ", msg1)
     for msg in rest

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -674,7 +674,7 @@ function handle_message(logger::SimpleLogger, level::LogLevel, message, _module,
     end
     iob = IOContext(buf, stream)
     levelstr = level == Warn ? "Warning" : string(level)
-    msglines = eachsplit(chomp(convert(String, message)::String), '\n')
+    msglines = eachsplit(chomp(convert(String, string(message))::String), '\n')
     msg1, rest = Iterators.peel(msglines)
     println(iob, "┌ ", levelstr, ": ", msg1)
     for msg in rest

--- a/base/process.jl
+++ b/base/process.jl
@@ -69,7 +69,7 @@ function _uv_hook_close(proc::Process)
     nothing
 end
 
-const SpawnIO  = Union{IO, RawFD}
+const SpawnIO  = Union{IO, RawFD, OS_HANDLE}
 const SpawnIOs = Vector{SpawnIO} # convenience name for readability
 
 function as_cpumask(cpus::Vector{UInt16})

--- a/base/process.jl
+++ b/base/process.jl
@@ -69,7 +69,7 @@ function _uv_hook_close(proc::Process)
     nothing
 end
 
-const SpawnIO  = Redirectable
+const SpawnIO  = Union{IO, RawFD}
 const SpawnIOs = Vector{SpawnIO} # convenience name for readability
 
 function as_cpumask(cpus::Vector{UInt16})

--- a/base/show.jl
+++ b/base/show.jl
@@ -1919,7 +1919,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
             na = length(func_args)
             if (na == 2 || (na > 2 && isa(func, Symbol) && func in (:+, :++, :*)) || (na == 3 && func === :(:))) &&
                     all(a -> !isa(a, Expr) || a.head !== :..., func_args)
-                sep = func === :(:) ? "$func" : " " * repr(func) * " "   # if func::Any, avoid string interpolation (invalidation)
+                sep = func === :(:) ? "$func" : " " * string(func) * " "   # if func::Any, avoid string interpolation (invalidation)
 
                 if func_prec <= prec
                     show_enclosed_list(io, '(', func_args, sep, ')', indent, func_prec, quote_level, true)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1919,7 +1919,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
             na = length(func_args)
             if (na == 2 || (na > 2 && isa(func, Symbol) && func in (:+, :++, :*)) || (na == 3 && func === :(:))) &&
                     all(a -> !isa(a, Expr) || a.head !== :..., func_args)
-                sep = func === :(:) ? "$func" : " $func "
+                sep = func === :(:) ? "$func" : " " * repr(func) * " "   # if func::Any, avoid string interpolation (invalidation)
 
                 if func_prec <= prec
                     show_enclosed_list(io, '(', func_args, sep, ')', indent, func_prec, quote_level, true)
@@ -2289,7 +2289,8 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
     elseif head === :meta && nargs == 1 && args[1] === :pop_loc
         print(io, "# meta: pop location")
     elseif head === :meta && nargs == 2 && args[1] === :pop_loc
-        print(io, "# meta: pop locations ($(args[2]))")
+        loc = args[2]::Int
+        print(io, "# meta: pop locations ($loc)")
     # print anything else as "Expr(head, args...)"
     else
         unhandled = true

--- a/base/show.jl
+++ b/base/show.jl
@@ -2289,8 +2289,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
     elseif head === :meta && nargs == 1 && args[1] === :pop_loc
         print(io, "# meta: pop location")
     elseif head === :meta && nargs == 2 && args[1] === :pop_loc
-        loc = args[2]::Int
-        print(io, "# meta: pop locations ($loc)")
+        print(io, "# meta: pop locations ($(args[2]::Int))")
     # print anything else as "Expr(head, args...)"
     else
         unhandled = true

--- a/base/show.jl
+++ b/base/show.jl
@@ -1919,7 +1919,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
             na = length(func_args)
             if (na == 2 || (na > 2 && isa(func, Symbol) && func in (:+, :++, :*)) || (na == 3 && func === :(:))) &&
                     all(a -> !isa(a, Expr) || a.head !== :..., func_args)
-                sep = func === :(:) ? "$func" : " " * string(func) * " "   # if func::Any, avoid string interpolation (invalidation)
+                sep = func === :(:) ? "$func" : " " * convert(String, string(func))::String * " "   # if func::Any, avoid string interpolation (invalidation)
 
                 if func_prec <= prec
                     show_enclosed_list(io, '(', func_args, sep, ')', indent, func_prec, quote_level, true)

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -229,7 +229,13 @@ function string(a::Union{Char, String, SubString{String}, Symbol}...)
     out = _string_n(n)
     offs = 1
     for v in a
-        offs += __unsafe_string!(out, v, offs)
+        if v isa Char
+            offs += __unsafe_string!(out, v, offs)
+        elseif v isa String || v isa SubString{String}
+            offs += __unsafe_string!(out, v, offs)
+        else
+            offs += __unsafe_string!(out, v::Symbol, offs)
+        end
     end
     return out
 end

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -55,6 +55,11 @@ convert(::Type{SubString{S}}, s::AbstractString) where {S<:AbstractString} =
     SubString(convert(S, s))
 convert(::Type{T}, s::T) where {T<:SubString} = s
 
+# Regex match allows only Union{String, SubString{String}} so define conversion to this type
+convert(::Type{Union{String, SubString{String}}}, s::String) = s
+convert(::Type{Union{String, SubString{String}}}, s::SubString{String}) = s
+convert(::Type{Union{String, SubString{String}}}, s::AbstractString) = convert(String, s)
+
 function String(s::SubString{String})
     parent = s.string
     copy = GC.@preserve parent unsafe_string(pointer(parent, s.offset+1), s.ncodeunits)

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -116,7 +116,7 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
 
     # Generate a text representation of the message and all key value pairs,
     # split into lines.
-    msglines = [(indent=0, msg=l) for l in split(chomp(convert(String, message)::String), '\n')]
+    msglines = [(indent=0, msg=l) for l in split(chomp(convert(String, string(message))::String), '\n')]
     stream = logger.stream
     if !isopen(stream)
         stream = stderr

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -116,7 +116,7 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
 
     # Generate a text representation of the message and all key value pairs,
     # split into lines.
-    msglines = [(indent=0, msg=l) for l in split(chomp(string(message)::String), '\n')]
+    msglines = [(indent=0, msg=l) for l in split(chomp(convert(String, message)::String), '\n')]
     stream = logger.stream
     if !isopen(stream)
         stream = stderr

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1646,7 +1646,7 @@ end
 throw_eager_redirection_cycle(key::Union{Char, String}) =
     error("Eager redirection cycle detected for key ", repr(key))
 throw_could_not_find_redirected_value(key::Union{Char, String}) =
-    error("Could not find redirected value ", repl(key))
+    error("Could not find redirected value ", repr(key))
 
 function keymap_unify(keymaps)
     ret = Dict{Char,Any}()

--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -192,7 +192,7 @@ function request(term::REPL.Terminals.TTYTerminal, m::AbstractMenu; cursor::Unio
         REPL.Terminals.raw!(term, true)
         true
     catch err
-        suppress_output || @warn("TerminalMenus: Unable to enter raw mode: $err")
+        suppress_output || @warn("TerminalMenus: Unable to enter raw mode: $(err::Exception)")
         false
     end
     # hide the cursor

--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -192,7 +192,7 @@ function request(term::REPL.Terminals.TTYTerminal, m::AbstractMenu; cursor::Unio
         REPL.Terminals.raw!(term, true)
         true
     catch err
-        suppress_output || @warn(LazyString("TerminalMenus: Unable to enter raw mode: ", err))
+        suppress_output || @warn "TerminalMenus: Unable to enter raw mode: " exception=(err, catch_backtrace())
         false
     end
     # hide the cursor

--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -192,7 +192,7 @@ function request(term::REPL.Terminals.TTYTerminal, m::AbstractMenu; cursor::Unio
         REPL.Terminals.raw!(term, true)
         true
     catch err
-        suppress_output || @warn("TerminalMenus: Unable to enter raw mode: $(err::Exception)")
+        suppress_output || @warn(LazyString("TerminalMenus: Unable to enter raw mode: ", err))
         false
     end
     # hide the cursor

--- a/stdlib/p7zip_jll/src/p7zip_jll.jl
+++ b/stdlib/p7zip_jll/src/p7zip_jll.jl
@@ -35,7 +35,7 @@ else
     const pathsep = ':'
 end
 
-function adjust_ENV!(env::Dict, PATH::String, LIBPATH::String, adjust_PATH::Bool, adjust_LIBPATH::Bool)
+function adjust_ENV!(env::Dict{keytype(Base.EnvDict),valtype(Base.EnvDict)}, PATH::String, LIBPATH::String, adjust_PATH::Bool, adjust_LIBPATH::Bool)
     if adjust_LIBPATH
         LIBPATH_base = get(env, LIBPATH_env, expanduser(LIBPATH_default))
         if !isempty(LIBPATH_base)

--- a/test/corelogging.jl
+++ b/test/corelogging.jl
@@ -151,6 +151,21 @@ end
     @test_throws MethodError @macrocall(@error)
 end
 
+@testset "Any type" begin
+    @test_logs (:info, sum) @info sum
+    # TODO: make this work (here we want `@test_logs` to fail)
+    # @test_fails @test_logs (:info, "sum") @info sum   # `sum` works, `"sum"` does not
+
+    # check that the message delivered to the user works
+    mktempdir() do dir
+        path_stdout = joinpath(dir, "stdout.txt")
+        path_stderr = joinpath(dir, "stderr.txt")
+        redirect_stdio(stdout=path_stdout, stderr=path_stderr) do
+            @info sum
+        end
+        @test occursin("Info: sum", read(path_stderr, String))
+    end
+end
 
 #-------------------------------------------------------------------------------
 # Early log level filtering


### PR DESCRIPTION
Together with https://github.com/JuliaIO/Tar.jl/pull/135, this eliminates nearly ~1400~>1700 invalidations mostly caused by InlineStrings.jl, and knocks about 300ms off the load time of CSV.jl (CC @quinnj).

More benefit still could be achieved from some version of https://github.com/JuliaLang/Pkg.jl/pull/3017 and #44486, but this already helps a lot.