### PR TITLE
Base64 optional padding tests

### DIFF
--- a/stdlib/Base64/src/decode.jl
+++ b/stdlib/Base64/src/decode.jl
@@ -150,7 +150,6 @@ function decode_slow(b1, b2, b3, b4, buffer, i, input, ptr, n, rest)
             b4 = decode(read(input, UInt8))
         else
             b4 = BASE64_CODE_END
-            break
         end
     end
 
@@ -158,13 +157,13 @@ function decode_slow(b1, b2, b3, b4, buffer, i, input, ptr, n, rest)
     k = 0
     if b1 < 0x40 && b2 < 0x40 && b3 < 0x40 && b4 < 0x40
         k = 3
-    elseif b1 < 0x40 && b2 < 0x40 && b3 < 0x40 && b4 == BASE64_CODE_PAD
+    elseif b1 < 0x40 && b2 < 0x40 && b3 < 0x40 && (b4 == BASE64_CODE_PAD || b4 == BASE64_CODE_END)
         b4 = 0x00
         k = 2
-    elseif b1 < 0x40 && b2 < 0x40 && b3 == b4 == BASE64_CODE_PAD
+    elseif b1 < 0x40 && b2 < 0x40 && (b3 == BASE64_CODE_PAD || b3 == BASE64_CODE_END) && (b4 == BASE64_CODE_PAD || b4 == BASE64_CODE_END)
         b3 = b4 = 0x00
         k = 1
-    elseif b1 == b2 == b3 == BASE64_CODE_IGN && b4 == BASE64_CODE_END
+    elseif b1 == b2 == b3 == b4 == BASE64_CODE_END
         b1 = b2 = b3 = b4 = 0x00
     else
         throw(ArgumentError("malformed base64 sequence"))

--- a/stdlib/Base64/test/runtests.jl
+++ b/stdlib/Base64/test/runtests.jl
@@ -87,18 +87,18 @@ const longDecodedText = "name = \"Genie\"\nuuid = \"c43c736e-a2d1-11e8-161f-af95
 
     # issue #32397
     @test String(base64decode(longEncodedText)) == longDecodedText;
-    
+
     # Optional padding
     @test base64decode("AQ==") == base64decode("AQ")
     @test base64decode("zzzzAQ==") == base64decode("zzzzAQ")
     @test base64decode("AQI=") == base64decode("AQI")
-    
+
     # Too short, 6 bits do not cover a full byte.
     @test_throws ArgumentError base64decode("a")
     @test_throws ArgumentError base64decode("a===")
     @test_throws ArgumentError base64decode("ZZZZa")
     @test_throws ArgumentError base64decode("ZZZZa===")
-    
+
     # Bit padding should be ignored, which means that `jl` and `jk` should give the same result.
     @test base64decode("jl") == base64decode("jk") == base64decode("jk==") == [142]
     @test base64decode("Aa") == base64decode("AS") == base64decode("AS==") == [1]

--- a/stdlib/Base64/test/runtests.jl
+++ b/stdlib/Base64/test/runtests.jl
@@ -89,6 +89,7 @@ const longDecodedText = "name = \"Genie\"\nuuid = \"c43c736e-a2d1-11e8-161f-af95
     @test String(base64decode(longEncodedText)) == longDecodedText;
     
     @test base64decode("AQ==") == base64decode("AQ")
+    @test base64decode("zzzzAQ==") == base64decode("zzzzAQ")
     @test base64decode("AQI=") == base64decode("AQI")
 end
 

--- a/stdlib/Base64/test/runtests.jl
+++ b/stdlib/Base64/test/runtests.jl
@@ -88,9 +88,20 @@ const longDecodedText = "name = \"Genie\"\nuuid = \"c43c736e-a2d1-11e8-161f-af95
     # issue #32397
     @test String(base64decode(longEncodedText)) == longDecodedText;
     
+    # Optional padding
     @test base64decode("AQ==") == base64decode("AQ")
     @test base64decode("zzzzAQ==") == base64decode("zzzzAQ")
     @test base64decode("AQI=") == base64decode("AQI")
+    
+    # Too short, 6 bits do not cover a full byte.
+    @test_throws ArgumentError base64decode("a")
+    @test_throws ArgumentError base64decode("a===")
+    @test_throws ArgumentError base64decode("ZZZZa")
+    @test_throws ArgumentError base64decode("ZZZZa===")
+    
+    # Bit padding should be ignored, which means that `jl` and `jk` should give the same result.
+    @test base64decode("jl") == base64decode("jk") == base64decode("jk==") == [142]
+    @test base64decode("Aa") == base64decode("AS") == base64decode("AS==") == [1]
 end
 
 @testset "Random data" begin

--- a/stdlib/Base64/test/runtests.jl
+++ b/stdlib/Base64/test/runtests.jl
@@ -87,6 +87,9 @@ const longDecodedText = "name = \"Genie\"\nuuid = \"c43c736e-a2d1-11e8-161f-af95
 
     # issue #32397
     @test String(base64decode(longEncodedText)) == longDecodedText;
+    
+    @test base64decode("AQ==") == base64decode("AQ")
+    @test base64decode("AQI=") == base64decode("AQI")
 end
 
 @testset "Random data" begin


### PR DESCRIPTION
The pad character `=` is required in base64 encoding, but not in decoding. Padding characters are not needed to correctly decode: https://en.wikipedia.org/wiki/Base64#Output_padding 

This PR makes it possible to decode base64-encoded strings/streams without padding 🎉, matching [the behaviour in V8 and in the browser (in data urls)](https://user-images.githubusercontent.com/6933510/157058942-53538eed-af03-4f11-8447-82a00bb14227.png).

(The [official spec](https://datatracker.ietf.org/doc/html/rfc4648#section-4) for Base64 states that padding is required for base64-encoding, but it does not specify a requirement for decoding.)