### PR TITLE
[Makefile] Fix codesign of libjulia when installing it on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,16 +374,16 @@ endif
 ifneq ($(LOADER_BUILD_DEP_LIBS),$(LOADER_INSTALL_DEP_LIBS))
 	# Next, overwrite relative path to libjulia-internal in our loader if $$(LOADER_BUILD_DEP_LIBS) != $$(LOADER_INSTALL_DEP_LIBS)
 	$(call stringreplace,$(DESTDIR)$(shlibdir)/libjulia.$(JL_MAJOR_MINOR_SHLIB_EXT),$(LOADER_BUILD_DEP_LIBS)$$,$(LOADER_INSTALL_DEP_LIBS))
-ifeq ($(OS), Darwin)
-	# Fix codesign of the libjulia we just modified
-	$(call spawn,$(build_bindir)/julia$(EXE) --startup-file=no -e 'using Pkg; Pkg.activate(;temp=true); Pkg.add("ldid_jll"); using ldid_jll; run(`$$(ldid()) -S -d $(DESTDIR)$(shlibdir)/libjulia.$(JL_MAJOR_MINOR_SHLIB_EXT)`)')
+ifeq ($(OS),Darwin)
+	# Codesign the libjulia we just modified
+	$(JULIAHOME)/contrib/codesign.sh "$(MACOS_CODESIGN_IDENTITY)" "$(DESTDIR)$(shlibdir)/libjulia.$(JL_MAJOR_MINOR_SHLIB_EXT)"
 endif
 
 ifeq ($(BUNDLE_DEBUG_LIBS),1)
 	$(call stringreplace,$(DESTDIR)$(shlibdir)/libjulia-debug.$(JL_MAJOR_MINOR_SHLIB_EXT),$(LOADER_DEBUG_BUILD_DEP_LIBS)$$,$(LOADER_DEBUG_INSTALL_DEP_LIBS))
-ifeq ($(OS), Darwin)
-	# Fix codesign of the libjulia we just modified
-	$(call spawn,$(build_bindir)/julia$(EXE) --startup-file=no -e 'using Pkg; Pkg.activate(;temp=true); Pkg.add("ldid_jll"); using ldid_jll; run(`$$(ldid()) -S -d $(DESTDIR)$(shlibdir)/libjulia-debug.$(JL_MAJOR_MINOR_SHLIB_EXT)`)')
+ifeq ($(OS),Darwin)
+	# Codesign the libjulia we just modified
+	$(JULIAHOME)/contrib/codesign.sh "$(MACOS_CODESIGN_IDENTITY)" "$(DESTDIR)$(shlibdir)/libjulia-debug.$(JL_MAJOR_MINOR_SHLIB_EXT)"
 endif
 endif
 endif
@@ -436,16 +436,9 @@ endif
 ifeq ($(OS), WINNT)
 	cd $(BUILDROOT)/julia-$(JULIA_COMMIT)/bin && rm -f llvm* llc.exe lli.exe opt.exe LTO.dll bugpoint.exe macho-dump.exe
 endif
-	# If we're on macOS, and we have a codesigning identity, then codesign the binary-dist tarball!
 ifeq ($(OS),Darwin)
-ifneq ($(MACOS_CODESIGN_IDENTITY),)
-	echo "Codesigning with identity $(MACOS_CODESIGN_IDENTITY)"; \
-	MACHO_FILES=$$(find "$(BUILDROOT)/julia-$(JULIA_COMMIT)" -type f -perm -0111 | cut -d: -f1); \
-	for f in $${MACHO_FILES}; do \
-		echo "Codesigning $${f}..."; \
-		codesign -s "$(MACOS_CODESIGN_IDENTITY)" --option=runtime --entitlements $(JULIAHOME)/contrib/mac/app/Entitlements.plist -vvv --timestamp --deep --force "$${f}"; \
-	done
-endif
+	# If we're on macOS, and we have a codesigning identity, then codesign the binary-dist tarball!
+	$(JULIAHOME)/contrib/codesign.sh "$(MACOS_CODESIGN_IDENTITY)" "$(BUILDROOT)/julia-$(JULIA_COMMIT)"
 endif
 	cd $(BUILDROOT) && $(TAR) zcvf $(JULIA_BINARYDIST_FILENAME).tar.gz julia-$(JULIA_COMMIT)
 

--- a/Makefile
+++ b/Makefile
@@ -374,14 +374,22 @@ endif
 ifneq ($(LOADER_BUILD_DEP_LIBS),$(LOADER_INSTALL_DEP_LIBS))
 	# Next, overwrite relative path to libjulia-internal in our loader if $$(LOADER_BUILD_DEP_LIBS) != $$(LOADER_INSTALL_DEP_LIBS)
 	$(call stringreplace,$(DESTDIR)$(shlibdir)/libjulia.$(JL_MAJOR_MINOR_SHLIB_EXT),$(LOADER_BUILD_DEP_LIBS)$$,$(LOADER_INSTALL_DEP_LIBS))
+ifeq ($(OS), Darwin)
+	# Fix codesign of the libjulia we just modified
+	$(call spawn,$(build_bindir)/julia$(EXE) --startup-file=no -e 'using Pkg; Pkg.activate(;temp=true); Pkg.add("ldid_jll"); using ldid_jll; run(`$$(ldid()) -S -d $(DESTDIR)$(shlibdir)/libjulia.$(JL_MAJOR_MINOR_SHLIB_EXT)`)')
+endif
 
 ifeq ($(BUNDLE_DEBUG_LIBS),1)
 	$(call stringreplace,$(DESTDIR)$(shlibdir)/libjulia-debug.$(JL_MAJOR_MINOR_SHLIB_EXT),$(LOADER_DEBUG_BUILD_DEP_LIBS)$$,$(LOADER_DEBUG_INSTALL_DEP_LIBS))
+ifeq ($(OS), Darwin)
+	# Fix codesign of the libjulia we just modified
+	$(call spawn,$(build_bindir)/julia$(EXE) --startup-file=no -e 'using Pkg; Pkg.activate(;temp=true); Pkg.add("ldid_jll"); using ldid_jll; run(`$$(ldid()) -S -d $(DESTDIR)$(shlibdir)/libjulia-debug.$(JL_MAJOR_MINOR_SHLIB_EXT)`)')
+endif
 endif
 endif
 
-	# On FreeBSD, remove the build's libdir from each library's RPATH
 ifeq ($(OS),FreeBSD)
+	# On FreeBSD, remove the build's libdir from each library's RPATH
 	$(JULIAHOME)/contrib/fixup-rpath.sh "$(PATCHELF)" $(DESTDIR)$(libdir) $(build_libdir)
 	$(JULIAHOME)/contrib/fixup-rpath.sh "$(PATCHELF)" $(DESTDIR)$(private_libdir) $(build_libdir)
 	$(JULIAHOME)/contrib/fixup-rpath.sh "$(PATCHELF)" $(DESTDIR)$(bindir) $(build_libdir)

--- a/contrib/codesign.sh
+++ b/contrib/codesign.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Codesign binary files for macOS.
+
+usage() {
+    echo "Usage: ${0} MACOS_CODESIGN_IDENTITY FILE-OR-DIRECTORY"
+    exit 0
+}
+
+# Default codesign identity to `-` if not provided
+if [ -z "${1}" ]; then
+    MACOS_CODESIGN_IDENTITY="-"
+    ENTITLEMENTS=""
+else
+    MACOS_CODESIGN_IDENTITY="${1}"
+    ENTITLEMENTS="--entitlements $(dirname "${0}")/mac/app/Entitlements.plist"
+fi
+
+if [ "${#}" -eq 2 ]; then
+    if [ -f "${2}" ]; then
+        # Codesign only the given file
+        MACHO_FILES="${2}"
+    elif [ -d "${2}" ]; then
+        # Find all files in the given directory
+        MACHO_FILES=$(find "${2}" -type f -perm -0111 | cut -d: -f1)
+    else
+        usage
+    fi
+else
+    usage
+fi
+
+echo "Codesigning with identity ${MACOS_CODESIGN_IDENTITY}"
+for f in ${MACHO_FILES}; do
+    echo "Codesigning ${f}..."
+    codesign -s "${MACOS_CODESIGN_IDENTITY}" --option=runtime ${ENTITLEMENTS} -vvv --timestamp --deep --force "${f}"
+done


### PR DESCRIPTION
Probably it isn't the cleanest solution possible, but it does the job for me :slightly_smiling_face: 

Fix #44502

```console
% prefix=$(mktemp -d)
% make install prefix=$prefix
# ...
% $prefix/bin/julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.9.0-DEV.154 (2022-03-08)
 _/ |\__'_|_|_|\__'_|  |  mg/macos-codesign-install/31c7573f8f (fork: 1 commits, 0 days)
|__/                   |

julia>
```