### PR TITLE
follow up #44448, correct `findall`/`findsup` for `OverlayMethodTable`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1482,11 +1482,10 @@ function abstract_invoke(interp::AbstractInterpreter, (; fargs, argtypes)::ArgIn
     types = rewrap_unionall(Tuple{ft, unwrap_unionall(types).parameters...}, types)::Type
     nargtype = Tuple{ft, nargtype.parameters...}
     argtype = Tuple{ft, argtype.parameters...}
-    result = findsup(types, method_table(interp))
-    result === nothing && return CallMeta(Any, false)
-    match, valid_worlds = result
-    method = match.method
+    match, valid_worlds = findsup(types, method_table(interp))
+    match === nothing && return CallMeta(Any, false)
     update_valid_age!(sv, valid_worlds)
+    method = match.method
     (ti, env::SimpleVector) = ccall(:jl_type_intersection_with_env, Any, (Any, Any), nargtype, method.sig)::SimpleVector
     (; rt, edge) = result = abstract_call_method(interp, method, ti, env, false, sv)
     edge !== nothing && add_backedge!(edge::MethodInstance, sv)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1347,11 +1347,11 @@ end
 print_statement_costs(args...; kwargs...) = print_statement_costs(stdout, args...; kwargs...)
 
 function _which(@nospecialize(tt::Type), world=get_world_counter())
-    result = Core.Compiler._findsup(tt, nothing, world)
-    if result === nothing
+    match, _ = Core.Compiler._findsup(tt, nothing, world)
+    if match === nothing
         error("no unique matching method found for the specified argument types")
     end
-    return first(result)::Core.MethodMatch
+    return match
 end
 
 """


### PR DESCRIPTION
Address the review comments by @vtjnash on #44448:

- respect world range of failed lookup into `OverlayMethodTable`:
  <https://github.com/JuliaLang/julia/pull/44448#discussion_r821220641>
- fix calculation of merged valid world range:
  <https://github.com/JuliaLang/julia/pull/44448#discussion_r821220108>
- make `findsup` return valid `WorldRange` unconditionally, and enable
  more strict world validation within `abstract_invoke`:
  <https://github.com/JuliaLang/julia/pull/44448#discussion_r821221947>
- fix the default `limit::Int` value of `findall`