### PR TITLE
Add example to LazyString docstring

### DIFF
--- a/base/strings/lazy.jl
+++ b/base/strings/lazy.jl
@@ -14,13 +14,9 @@ as much work as possible to either the macro or later printing operations.
 ```jldoctest
 julia> n = 5; str = LazyString("n is ", n)
 "n is 5"
-
-julia> str2 = lazy"n is \$n"
-"n is 5"
-
-julia> typeof(str2)
-LazyString
 ```
+
+See also [`lazy"str"`](@ref).
 
 !!! compat "Julia 1.8"
     `LazyString` requires Julia 1.8 or later.
@@ -38,6 +34,16 @@ end
 Create a [`LazyString`](@ref) using regular string interpolation syntax.
 Note that interpolations are *evaluated* at LazyString construction time,
 but *printing* is delayed until the first access to the string.
+
+# Examples
+
+```
+julia> n = 5; str = lazy"n is \$n"
+"n is 5"
+
+julia> typeof(str)
+LazyString
+```
 
 !!! compat "Julia 1.8"
     `lazy"str"` requires Julia 1.8 or later.

--- a/base/strings/lazy.jl
+++ b/base/strings/lazy.jl
@@ -15,7 +15,7 @@ as much work as possible to either the macro or later printing operations.
 julia> n = 5; str = LazyString("n is ", n)
 "n is 5"
 
-julia> str2 = lazy"n is $n"
+julia> str2 = lazy"n is \$n"
 "n is 5"
 
 julia> typeof(str2)

--- a/base/strings/lazy.jl
+++ b/base/strings/lazy.jl
@@ -9,6 +9,19 @@ of functions).
 This type is designed to be cheap to construct at runtime, trying to offload
 as much work as possible to either the macro or later printing operations.
 
+# Examples
+
+```jldoctest
+julia> n = 5; str = LazyString("n is ", n)
+"n is 5"
+
+julia> str2 = lazy"n is $n"
+"n is 5"
+
+julia> typeof(str2)
+LazyString
+```
+
 !!! compat "Julia 1.8"
     `LazyString` requires Julia 1.8 or later.
 """


### PR DESCRIPTION
The docstring for LazyString is admirably clear about its purpose but less clear about how you build one.

It's worth reporting that I just guessed without looking at the code, and I was impressed by the fact that both of my guesses (`Lazy(...)` and `lazy"..."`) proved to work exactly as expected. Hats off to the implementation, and that's evidence that perhaps an example isn't necessary. But I still think it's better with one.