### PR TITLE
RFC: remove deprecation warning for `@_inline_meta`

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -284,8 +284,8 @@ end
 
 # BEGIN 1.8 deprecations
 
-@deprecate var"@_inline_meta"   var"@inline"   false
-@deprecate var"@_noinline_meta" var"@noinline" false
+const var"@_inline_meta" = var"@inline"
+const var"@_noinline_meta" = var"@noinline"
 @deprecate getindex(t::Tuple, i::Real) t[convert(Int, i)]
 
 # END 1.8 deprecations


### PR DESCRIPTION
This shows up a bit everywhere in PkgEval and makes things kind of noisy. I don't see a strong reason to deprecate it since it is internal so imo it is better to just have it be backwards compatible since it doesn't really cost anything. 