### PR TITLE
Stricter tests in int.jl

### DIFF
--- a/test/int.jl
+++ b/test/int.jl
@@ -55,37 +55,37 @@ using Random
     end
 end
 @testset "signed and unsigned" begin
-    @test signed(3) == 3
-    @test signed(UInt(3)) == 3
+    @test signed(3) === 3
+    @test signed(UInt(3)) === 3
     @test isa(signed(UInt(3)), Int)
-    @test signed(UInt(0) - 1) == -1
+    @test signed(UInt(0) - 1) === -1
     @test_throws InexactError signed(UInt(-3))
-    @test signed(true) == 1
+    @test signed(true) === 1
     @test unsigned(true) isa Unsigned
-    @test unsigned(true) == unsigned(1)
+    @test unsigned(true) === unsigned(1)
 
-    @test signed(Bool) == Int
-    @test signed(Bool) == typeof(signed(true))
-    @test unsigned(Bool) == UInt
-    @test unsigned(Bool) == typeof(unsigned(true))
+    @test signed(Bool) === Int
+    @test signed(Bool) === typeof(signed(true))
+    @test unsigned(Bool) === UInt
+    @test unsigned(Bool) === typeof(unsigned(true))
 end
 @testset "bswap" begin
     @test bswap(Int8(3)) == 3
-    @test bswap(UInt8(3)) == 3
+    @test bswap(UInt8(3)) === 0x3
     @test bswap(Int16(3)) == 256*3
     @test bswap(Int16(256)) == 1
     @test bswap(Int16(257)) == 257
     @test bswap(Int32(1)) == 2^(3*8)
     @test bswap(Int32(2)^(3*8)) == 1
-    @test bswap(Int64(1)) == Int64(2)^(7*8)
+    @test bswap(Int64(1)) === Int64(2)^(7*8)
     @test bswap(Int64(2)^(7*8)) == 1
-    @test bswap(Int128(1)) == Int128(2)^(15*8)
-    @test bswap(Int128(2)^(15*8)) == Int128(1)
-    @test bswap(UInt128(2)^(15*8)) == UInt128(1)
+    @test bswap(Int128(1)) === Int128(2)^(15*8)
+    @test bswap(Int128(2)^(15*8)) === Int128(1)
+    @test bswap(UInt128(2)^(15*8)) === UInt128(1)
 end
 @testset "count_zeros" begin
-    @test count_zeros(10) == Sys.WORD_SIZE - 2
-    @test count_zeros(UInt8(10)) == 6
+    @test count_zeros(10) === Sys.WORD_SIZE - 2
+    @test count_zeros(UInt8(10)) === 6
 end
 @testset "Conversions" begin
     @test convert(Signed, UInt128(3)) === Int128(3)
@@ -104,11 +104,11 @@ end
 end
 
 @testset "trunc, floor, ceil" begin
-    @test trunc(3) == 3
-    @test trunc(Integer, 3) == 3
+    @test trunc(3) === 3
+    @test trunc(Integer, 3) === 3
 
-    @test floor(3) == 3
-    @test ceil(3) == 3
+    @test floor(3) === 3
+    @test ceil(3) === 3
 end
 
 @testset "big" begin
@@ -120,7 +120,7 @@ end
 end
 
 @test round(UInt8, 123) == 123
-@test mod(123, UInt8) == 0x7b
+@test mod(123, UInt8) === 0x7b
 
 primitive type MyBitsType <: Integer 8 end
 @test_throws MethodError ~reinterpret(MyBitsType, 0x7b)
@@ -211,8 +211,8 @@ end
     end
 
     val2 = 0xabcd
-    @test 0x5e6d == bitrotate(val2, 3)
-    @test 0xb579 == bitrotate(val2, -3)
+    @test 0x5e6d === bitrotate(val2, 3)
+    @test 0xb579 === bitrotate(val2, -3)
 end
 
 @testset "widen/widemul" begin
@@ -240,12 +240,12 @@ end
     @test typeof(widen(Int64(-3))) == Int128
     @test typeof(widen(Int128(-3))) == BigInt
 
-    @test widemul(false, false) == false
-    @test widemul(false, 3) == 0
-    @test widemul(3, true) == widemul(true, 3) == 3
+    @test widemul(false, false) === false
+    @test widemul(false, 3) === 0
+    @test widemul(3, true) === widemul(true, 3) === 3
 
     let i=Int64(2)^63-1, k=widemul(i,i)
-        @test widemul(i,i)==85070591730234615847396907784232501249
+        @test widemul(i,i)===85070591730234615847396907784232501249
         j=div(k,2)
         @test div(k,j)==2
         j=div(k,5)
@@ -367,9 +367,9 @@ end
             (5, -3, -2, -2, -2))
         for sign in (+1, -1)
             (a, b) = (a*sign, b*sign)
-            @test div(a, b, RoundNearest) == nearest
-            @test div(a, b, RoundNearestTiesAway) == away
-            @test div(a, b, RoundNearestTiesUp) == up
+            @test div(a, b, RoundNearest) === nearest
+            @test div(a, b, RoundNearestTiesAway) === away
+            @test div(a, b, RoundNearestTiesUp) === up
         end
     end
 
@@ -377,7 +377,7 @@ end
     @test div(-typemax(Int64), typemax(Int64)-1, RoundNearest) == -1
     @test div(typemax(Int64), 2, RoundNearest) == 4611686018427387904
     @test div(-typemax(Int64), 2, RoundNearestTiesUp) == -4611686018427387903
-    @test div(typemax(Int)-2, typemax(Int), RoundNearest) == 1
+    @test div(typemax(Int)-2, typemax(Int), RoundNearest) === 1
 
     # Exhaustively test (U)Int8 to catch any overflow-style issues
     for r in (RoundNearest, RoundNearestTiesAway, RoundNearestTiesUp)
@@ -407,25 +407,25 @@ end
 end
 
 @testset "min/max of datatype" begin
-    @test typemin(Int8) == Int8(-128)
-    @test typemin(UInt8) == UInt8(0)
-    @test typemin(Int16) == Int16(-32768)
-    @test typemin(UInt16) == UInt16(0)
-    @test typemin(Int32) == Int32(-2147483648)
-    @test typemin(UInt32) == UInt32(0)
-    @test typemin(Int64) == Int64(-9223372036854775808)
-    @test typemin(UInt64) == UInt64(0)
-    @test typemin(Int128) == Int128(-170141183460469231731687303715884105728)
-    @test typemin(UInt128) == UInt128(0)
+    @test typemin(Int8) === Int8(-128)
+    @test typemin(UInt8) === UInt8(0)
+    @test typemin(Int16) === Int16(-32768)
+    @test typemin(UInt16) === UInt16(0)
+    @test typemin(Int32) === Int32(-2147483648)
+    @test typemin(UInt32) === UInt32(0)
+    @test typemin(Int64) === Int64(-9223372036854775808)
+    @test typemin(UInt64) === UInt64(0)
+    @test typemin(Int128) === Int128(-170141183460469231731687303715884105728)
+    @test typemin(UInt128) === UInt128(0)
 
-    @test typemax(Int8) == Int8(127)
-    @test typemax(UInt8) == UInt8(255)
-    @test typemax(Int16) == Int16(32767)
-    @test typemax(UInt16) == UInt16(65535)
-    @test typemax(Int32) == Int32(2147483647)
-    @test typemax(UInt32) == UInt32(4294967295)
-    @test typemax(Int64) == Int64(9223372036854775807)
-    @test typemax(UInt64) == UInt64(0xffffffffffffffff)
-    @test typemax(Int128) == Int128(170141183460469231731687303715884105727)
-    @test typemax(UInt128) == UInt128(0xffffffffffffffffffffffffffffffff)
+    @test typemax(Int8) === Int8(127)
+    @test typemax(UInt8) === UInt8(255)
+    @test typemax(Int16) === Int16(32767)
+    @test typemax(UInt16) === UInt16(65535)
+    @test typemax(Int32) === Int32(2147483647)
+    @test typemax(UInt32) === UInt32(4294967295)
+    @test typemax(Int64) === Int64(9223372036854775807)
+    @test typemax(UInt64) === UInt64(0xffffffffffffffff)
+    @test typemax(Int128) === Int128(170141183460469231731687303715884105727)
+    @test typemax(UInt128) === UInt128(0xffffffffffffffffffffffffffffffff)
 end

--- a/test/int.jl
+++ b/test/int.jl
@@ -122,8 +122,9 @@ end
 @test round(UInt8, 123) == 123
 @test mod(123, UInt8) === 0x7b
 
-primitive type MyBitsType <: Integer 8 end
+primitive type MyBitsType <: Signed 8 end
 @test_throws MethodError ~reinterpret(MyBitsType, 0x7b)
+@test signed(MyBitsType) === MyBitsType
 
 UItypes = Base.BitUnsigned_types
 SItypes = Base.BitSigned_types
@@ -428,4 +429,11 @@ end
     @test typemax(UInt64) === UInt64(0xffffffffffffffff)
     @test typemax(Int128) === Int128(170141183460469231731687303715884105727)
     @test typemax(UInt128) === UInt128(0xffffffffffffffffffffffffffffffff)
+end
+
+@testset "BitIntegerType" begin
+    @test Int isa Base.BitIntegerType
+    @test Base.BitIntegerType === Union{
+        Type{ Int8}, Type{ Int16}, Type{ Int32}, Type{ Int64}, Type{ Int128},
+        Type{UInt8}, Type{UInt16}, Type{UInt32}, Type{UInt64}, Type{UInt128}}
 end


### PR DESCRIPTION
Require stricter equality where possible, test `BitIntegerType`, and test `signed` on a custom type.