### PR TITLE
export CanonicalIndexError

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -122,6 +122,7 @@ export
     Cwstring,
 
 # Exceptions
+    CanonicalIndexError,
     CapturedException,
     CompositeException,
     DimensionMismatch,


### PR DESCRIPTION
This new exception was introduced in https://github.com/JuliaLang/julia/pull/43852 but since it is thrown to user code it should probably be exported.