### PR TITLE
[Make.inc] Require C11 standard

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -485,7 +485,7 @@ endif
 ifeq ($(USEGCC),1)
 CC := $(CROSS_COMPILE)gcc
 CXX := $(CROSS_COMPILE)g++
-JCFLAGS := -std=gnu99 -pipe $(fPIC) -fno-strict-aliasing -D_FILE_OFFSET_BITS=64
+JCFLAGS := -std=gnu11 -pipe $(fPIC) -fno-strict-aliasing -D_FILE_OFFSET_BITS=64
 # AArch64 needs this flag to generate the .eh_frame used by libunwind
 JCPPFLAGS := -fasynchronous-unwind-tables
 JCXXFLAGS := -pipe $(fPIC) -fno-rtti -std=c++14
@@ -500,7 +500,7 @@ endif
 ifeq ($(USECLANG),1)
 CC := $(CROSS_COMPILE)clang
 CXX := $(CROSS_COMPILE)clang++
-JCFLAGS := -std=gnu99 -pipe $(fPIC) -fno-strict-aliasing -D_FILE_OFFSET_BITS=64
+JCFLAGS := -std=gnu11 -pipe $(fPIC) -fno-strict-aliasing -D_FILE_OFFSET_BITS=64
 # AArch64 needs this flag to generate the .eh_frame used by libunwind
 JCPPFLAGS := -fasynchronous-unwind-tables
 JCXXFLAGS := -pipe $(fPIC) -fno-rtti -pedantic -std=c++14

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -77,7 +77,7 @@ end
 
 function cflags(doframework)
     flags = IOBuffer()
-    print(flags, "-std=gnu99")
+    print(flags, "-std=gnu11")
     if doframework
         include = shell_escape(frameworkDir())
         print(flags, " -F", include)

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -4,6 +4,7 @@
 #define JL_IOS_H
 
 #include <stdarg.h>
+#include <sys/types.h>
 #include "analyzer_annotations.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
Julia effectively requires C11 because of the use of [`_Atomic`](https://en.cppreference.com/w/c/language/atomic).  This is shown
when compiling with `-pedantic`.