### PR TITLE
Disallow infix macro syntax

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@ New language features
 Language changes
 ----------------
 
+* A parser bug allowed "infix macro syntax" such as `@(x + y)` to parse as a
+  macro call to `@+` with arguments `x` and `y`. This is now a parser error.
 
 Compiler/Runtime improvements
 -----------------------------

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1661,7 +1661,10 @@
   (with-space-sensitive
    (if (eq? (peek-token s) '|.|)
        (begin (take-token s) '__dot__)
-       (parse-atom s #f))))
+       (let ((name (parse-atom s #f)))
+         (if (and (pair? name) (eq? (car name) 'call))
+             (error (string "invalid macro name \"" (deparse name) "\"")))
+         name))))
 
 (define (parse-atsym s)
   (let ((t (peek-token s)))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -3268,3 +3268,6 @@ end
     @test m.Foo.bar === 1
     @test Core.get_binding_type(m.Foo, :bar) == Any
 end
+
+# Issue #44532 (disallow infix macros)
+@test_throws ParseError Meta.parse("@(x + y)")


### PR DESCRIPTION
A parser bug allowed "infix macro syntax" such as `@(x + y)` to parse as a
macro call to `@+` with arguments `x` and `y`. This is now a parser error.

Fixes #44532