### PR TITLE
effects: complements #43852, implement effect override mechanisms

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -606,10 +606,12 @@ function abstract_call_method(interp::AbstractInterpreter, method::Method, @nosp
     if edge === nothing
         edgecycle = edgelimited = true
     end
-    if is_effect_overrided(sv, :terminates_globally)
+    # we look for the termination effect override here as well, since the :terminates effect
+    # may have been tainted due to recursion at this point even if it's overridden
+    if is_effect_overridden(sv, :terminates_globally)
         # this frame is known to terminate
         edge_effects = Effects(edge_effects, terminates=ALWAYS_TRUE)
-    elseif is_effect_overrided(method, :terminates_globally)
+    elseif is_effect_overridden(method, :terminates_globally)
         # this edge is known to terminate
         edge_effects = Effects(edge_effects, terminates=ALWAYS_TRUE)
     elseif edgecycle
@@ -619,13 +621,6 @@ function abstract_call_method(interp::AbstractInterpreter, method::Method, @nosp
     end
     return MethodCallResult(rt, edgecycle, edgelimited, edge, edge_effects)
 end
-
-is_effect_overrided(sv::InferenceState, effect::Symbol) = is_effect_overrided(sv.linfo, effect)
-function is_effect_overrided(linfo::MethodInstance, effect::Symbol)
-    def = linfo.def
-    return isa(def, Method) && is_effect_overrided(def, effect)
-end
-is_effect_overrided(method::Method, effect::Symbol) = getfield(decode_effects_override(method.purity), effect)
 
 # keeps result and context information of abstract method call, will be used by succeeding constant-propagation
 struct MethodCallResult
@@ -2106,9 +2101,9 @@ end
 
 function handle_control_backedge!(frame::InferenceState, from::Int, to::Int)
     if from > to
-        if is_effect_overrided(frame, :terminates_globally)
+        if is_effect_overridden(frame, :terminates_globally)
             # this frame is known to terminate
-        elseif is_effect_overrided(frame, :terminates_locally)
+        elseif is_effect_overridden(frame, :terminates_locally)
             # this backedge is known to terminate
         else
             tristate_merge!(frame, Effects(EFFECTS_TOTAL, terminates=TRISTATE_UNKNOWN))

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -42,14 +42,33 @@ struct Effects
     # :consistent before caching. We may want to track it in the future.
     inbounds_taints_consistency::Bool
 end
-Effects(consistent::TriState, effect_free::TriState, nothrow::TriState, terminates::TriState) =
-    Effects(consistent, effect_free, nothrow, terminates, false)
+function Effects(
+    consistent::TriState,
+    effect_free::TriState,
+    nothrow::TriState,
+    terminates::TriState)
+    return Effects(
+        consistent,
+        effect_free,
+        nothrow,
+        terminates,
+        false)
+end
 Effects() = Effects(TRISTATE_UNKNOWN, TRISTATE_UNKNOWN, TRISTATE_UNKNOWN, TRISTATE_UNKNOWN)
 
-Effects(e::Effects; consistent::TriState=e.consistent,
-    effect_free::TriState = e.effect_free, nothrow::TriState=e.nothrow, terminates::TriState=e.terminates,
-    inbounds_taints_consistency::Bool = e.inbounds_taints_consistency) =
-        Effects(consistent, effect_free, nothrow, terminates, inbounds_taints_consistency)
+function Effects(e::Effects;
+    consistent::TriState = e.consistent,
+    effect_free::TriState = e.effect_free,
+    nothrow::TriState = e.nothrow,
+    terminates::TriState = e.terminates,
+    inbounds_taints_consistency::Bool = e.inbounds_taints_consistency)
+    return Effects(
+        consistent,
+        effect_free,
+        nothrow,
+        terminates,
+        inbounds_taints_consistency)
+end
 
 is_total_or_error(effects::Effects) =
     effects.consistent === ALWAYS_TRUE && effects.effect_free === ALWAYS_TRUE &&
@@ -65,15 +84,24 @@ is_removable_if_unused(effects::Effects) =
 
 const EFFECTS_TOTAL = Effects(ALWAYS_TRUE, ALWAYS_TRUE, ALWAYS_TRUE, ALWAYS_TRUE)
 
-encode_effects(e::Effects) = e.consistent.state | (e.effect_free.state << 2) | (e.nothrow.state << 4) | (e.terminates.state << 6)
-decode_effects(e::UInt8) =
-    Effects(TriState(e & 0x3),
+function encode_effects(e::Effects)
+    return e.consistent.state |
+           (e.effect_free.state << 2) |
+           (e.nothrow.state << 4) |
+           (e.terminates.state << 6)
+end
+function decode_effects(e::UInt8)
+    return Effects(
+        TriState(e & 0x3),
         TriState((e >> 2) & 0x3),
         TriState((e >> 4) & 0x3),
-        TriState((e >> 6) & 0x3), false)
+        TriState((e >> 6) & 0x3),
+        false)
+end
 
 function tristate_merge(old::Effects, new::Effects)
-    Effects(tristate_merge(
+    return Effects(
+        tristate_merge(
             old.consistent, new.consistent),
         tristate_merge(
             old.effect_free, new.effect_free),
@@ -81,8 +109,7 @@ function tristate_merge(old::Effects, new::Effects)
             old.nothrow, new.nothrow),
         tristate_merge(
             old.terminates, new.terminates),
-        old.inbounds_taints_consistency ||
-        new.inbounds_taints_consistency)
+        old.inbounds_taints_consistency | new.inbounds_taints_consistency)
 end
 
 struct EffectsOverride
@@ -100,16 +127,17 @@ function encode_effects_override(eo::EffectsOverride)
     eo.nothrow && (e |= 0x04)
     eo.terminates_globally && (e |= 0x08)
     eo.terminates_locally && (e |= 0x10)
-    e
+    return e
 end
 
-decode_effects_override(e::UInt8) =
-    EffectsOverride(
+function decode_effects_override(e::UInt8)
+    return EffectsOverride(
         (e & 0x01) != 0x00,
         (e & 0x02) != 0x00,
         (e & 0x04) != 0x00,
         (e & 0x08) != 0x00,
         (e & 0x10) != 0x00)
+end
 
 """
     InferenceResult

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1088,6 +1088,13 @@ recur_termination22(x) = x * recur_termination21(x-1)
     recur_termination21(12) + recur_termination22(12)
 end
 
+const ___CONST_DICT___ = Dict{Any,Any}(:a => 1, :b => 2)
+Base.@assume_effects :consistent :effect_free :terminates_globally consteval(
+    f, args...; kwargs...) = f(args...; kwargs...)
+@test fully_eliminated() do
+    consteval(getindex, ___CONST_DICT___, :a)
+end
+
 global x44200::Int = 0
 function f44200()
     global x = 0


### PR DESCRIPTION
The PR https://github.com/JuliaLang/julia/pull/43852 missed to implement the mechanism to override analyzed
effects with effect settings annotated by `Base.@assume_effects`.
This commits adds such an mechanism within `finish(::InferenceState, ::AbstractInterpreter)`,
just after inference analyzed frame effect.

Now we can do something like:
```julia
Base.@assume_effects :consistent :effect_free :terminates_globally consteval(
    f, args...; kwargs...) = f(args...; kwargs...)
const ___CONST_DICT___ = Dict{Any,Any}(:a => 1, :b => 2)
@test fully_eliminated() do
    consteval(getindex, ___CONST_DICT___, :a)
end
```