### PR TITLE
logging: string->String

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -674,7 +674,7 @@ function handle_message(logger::SimpleLogger, level::LogLevel, message, _module,
     end
     iob = IOContext(buf, stream)
     levelstr = level == Warn ? "Warning" : string(level)
-    msglines = eachsplit(chomp(String(message)::String), '\n')
+    msglines = eachsplit(chomp(convert(String, string(message))::String), '\n')
     msg1, rest = Iterators.peel(msglines)
     println(iob, "┌ ", levelstr, ": ", msg1)
     for msg in rest

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -674,7 +674,7 @@ function handle_message(logger::SimpleLogger, level::LogLevel, message, _module,
     end
     iob = IOContext(buf, stream)
     levelstr = level == Warn ? "Warning" : string(level)
-    msglines = eachsplit(chomp(string(message)::String), '\n')
+    msglines = eachsplit(chomp(String(message)::String), '\n')
     msg1, rest = Iterators.peel(msglines)
     println(iob, "┌ ", levelstr, ": ", msg1)
     for msg in rest

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -116,7 +116,7 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
 
     # Generate a text representation of the message and all key value pairs,
     # split into lines.
-    msglines = [(indent=0, msg=l) for l in split(chomp(String(message)::String), '\n')]
+    msglines = [(indent=0, msg=l) for l in split(chomp(convert(String, string(message))::String), '\n')]
     stream = logger.stream
     if !isopen(stream)
         stream = stderr

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -116,7 +116,7 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
 
     # Generate a text representation of the message and all key value pairs,
     # split into lines.
-    msglines = [(indent=0, msg=l) for l in split(chomp(string(message)::String), '\n')]
+    msglines = [(indent=0, msg=l) for l in split(chomp(String(message)::String), '\n')]
     stream = logger.stream
     if !isopen(stream)
         stream = stderr

--- a/test/corelogging.jl
+++ b/test/corelogging.jl
@@ -151,6 +151,21 @@ end
     @test_throws MethodError @macrocall(@error)
 end
 
+@testset "Any type" begin
+    @test_logs (:info, sum) @info sum
+    # TODO: make this work (here we want `@test_logs` to fail)
+    # @test_fails @test_logs (:info, "sum") @info sum   # `sum` works, `"sum"` does not
+
+    # check that the message delivered to the user works
+    mktempdir() do dir
+        path_stdout = joinpath(dir, "stdout.txt")
+        path_stderr = joinpath(dir, "stderr.txt")
+        redirect_stdio(stdout=path_stdout, stderr=path_stderr) do
+            @info sum
+        end
+        @test occursin("Info: sum", read(path_stderr, String))
+    end
+end
 
 #-------------------------------------------------------------------------------
 # Early log level filtering


### PR DESCRIPTION
This is from #44500. Note it's against `backports-release-1.8`

This is good material for 1.8 because of the introduction of LazyString, which will probably be used heavily by the logging framework.