### PR TITLE
Create a table for badges in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,17 @@
 </a>
 </div>
 
-Documentation:
-[![Documentation][docs-img]][docs-url]
+| Type | Badge/Status |
+|------|--------------|
+| Documentation | [![Documentation][docs-img]][docs-url]|
+| Continuous integration | [![Continuous integration (master)][buildkite-master-img]][buildkite-master-url] |
+| Code coverage | [![Code coverage (Coveralls)][coveralls-img]][coveralls-url] [![Code coverage (Codecov)][codecov-img]][codecov-url] |
 
+<!-- Docs -->
 [docs-img]: https://img.shields.io/badge/docs-v1-blue.svg "Documentation (version 1)"
 [docs-url]: https://docs.julialang.org
 
-Continuous integration:
-[![Continuous integration (master)][buildkite-master-img]][buildkite-master-url]
-
+<!-- Continuous integration -->
 <!--
 To change the badge to point to a different pipeline, it is not sufficient to simply change the `?branch=` part.
 You need to go to the Buildkite website and get the SVG URL for the correct pipeline.
@@ -21,10 +23,7 @@ You need to go to the Buildkite website and get the SVG URL for the correct pipe
 [buildkite-master-img]: https://badge.buildkite.com/f28e0d28b345f9fad5856ce6a8d64fffc7c70df8f4f2685cd8.svg?branch=master "Continuous integration (master)"
 [buildkite-master-url]: https://buildkite.com/julialang/julia-master
 
-Code coverage:
-[![Code coverage (Coveralls)][coveralls-img]][coveralls-url]
-[![Code coverage (Codecov)][codecov-img]][codecov-url]
-
+<!-- Coverage -->
 [coveralls-img]: https://img.shields.io/coveralls/github/JuliaLang/julia/master.svg?label=coveralls "Code coverage (Coveralls)"
 [coveralls-url]: https://coveralls.io/r/JuliaLang/julia?branch=master
 

--- a/README.md
+++ b/README.md
@@ -5,30 +5,31 @@
 </a>
 </div>
 
-| Type | Badge/Status |
-|------|--------------|
-| Documentation | [![Documentation][docs-img]][docs-url]|
-| Continuous integration | [![Continuous integration (master)][buildkite-master-img]][buildkite-master-url] |
-| Code coverage | [![Code coverage (Coveralls)][coveralls-img]][coveralls-url] [![Code coverage (Codecov)][codecov-img]][codecov-url] |
-
-<!-- Docs -->
-[docs-img]: https://img.shields.io/badge/docs-v1-blue.svg "Documentation (version 1)"
-[docs-url]: https://docs.julialang.org
-
-<!-- Continuous integration -->
-<!--
-To change the badge to point to a different pipeline, it is not sufficient to simply change the `?branch=` part.
-You need to go to the Buildkite website and get the SVG URL for the correct pipeline.
--->
-[buildkite-master-img]: https://badge.buildkite.com/f28e0d28b345f9fad5856ce6a8d64fffc7c70df8f4f2685cd8.svg?branch=master "Continuous integration (master)"
-[buildkite-master-url]: https://buildkite.com/julialang/julia-master
-
-<!-- Coverage -->
-[coveralls-img]: https://img.shields.io/coveralls/github/JuliaLang/julia/master.svg?label=coveralls "Code coverage (Coveralls)"
-[coveralls-url]: https://coveralls.io/r/JuliaLang/julia?branch=master
-
-[codecov-img]: https://img.shields.io/codecov/c/github/JuliaLang/julia/master.svg?label=codecov "Code coverage (Codecov)"
-[codecov-url]: https://codecov.io/github/JuliaLang/julia?branch=master
+<table>
+    <!-- Docs -->
+    <tr>
+        <td>Documentation</td>
+        <td>
+            <a href="https://docs.julialang.org"><img src='https://img.shields.io/badge/docs-v1-blue.svg'/></a>
+        </td>
+    </tr>
+    <!-- Continuous integration
+    To change the badge to point to a different pipeline, it is not sufficient to simply change the `?branch=` part.
+    You need to go to the Buildkite website and get the SVG URL for the correct pipeline. -->
+    <tr>
+        <td>Continuous integration</td>
+        <td>
+            <a href="https://buildkite.com/julialang/julia-master"><img src='https://badge.buildkite.com/f28e0d28b345f9fad5856ce6a8d64fffc7c70df8f4f2685cd8.svg?branch=master'/></a>
+        </td>
+    </tr>
+    <!-- Coverage -->
+    <tr>
+        <td>Code coverage</td>
+        <td>
+            <a href="https://coveralls.io/r/JuliaLang/julia?branch=master"><img src='https://img.shields.io/coveralls/github/JuliaLang/julia/master.svg?label=coveralls'/></a> <a href="https://codecov.io/github/JuliaLang/julia?branch=master"><img src='https://img.shields.io/codecov/c/github/JuliaLang/julia/master.svg?label=codecov'/></a>
+        </td>
+    </tr>
+</table>
 
 ## The Julia Language
 


### PR DESCRIPTION
This makes the `README` file a bit more organized. I did not create a new issue for this as the change was very minor, and this PR can be easily closed if the maintainers don't want this change. I can also add other badges (for instance, the communication channels) if required!

Please let me know if any changes are required! 

Before:

![image](https://user-images.githubusercontent.com/74055102/157933917-54fdc542-8c27-43c2-a9b5-f05435d59513.png)

Now:

![image](https://user-images.githubusercontent.com/74055102/157933875-7078a231-2dd5-4183-bde3-4521c4b54a0a.png)
