### PR TITLE
Fix eltype determination in `det`

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1542,9 +1542,9 @@ julia> det(M)
 2.0
 ```
 """
-function det(A::AbstractMatrix{T}) where T
+function det(A::AbstractMatrix{T}) where {T}
     if istriu(A) || istril(A)
-        S = typeof((one(T)*zero(T) + zero(T))/one(T))
+        S = promote_type(T, typeof((one(T)*zero(T) + zero(T))/one(T)))
         return convert(S, det(UpperTriangular(A)))
     end
     return det(lu(A; check = false))


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#634. I checked that it fixes the issue there, but need to think about a number type to test this.

Co-authored-by: Andreas Noack <andreas@noack.dk>