### PR TITLE
Don't optimize invoke wrapper functions

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6659,6 +6659,8 @@ static Function *gen_invoke_wrapper(jl_method_instance_t *lam, jl_value_t *jlret
     Function *w = Function::Create(get_func_sig(M->getContext()), GlobalVariable::ExternalLinkage, funcName, M);
     jl_init_function(w, params.TargetTriple);
     w->setAttributes(AttributeList::get(M->getContext(), {get_func_attrs(M->getContext()), w->getAttributes()}));
+    w->addFnAttr(Attribute::OptimizeNone);
+    w->addFnAttr(Attribute::NoInline);
     Function::arg_iterator AI = w->arg_begin();
     Value *funcArg = &*AI++;
     Value *argArray = &*AI++;

--- a/src/passes.h
+++ b/src/passes.h
@@ -54,10 +54,12 @@ struct CPUFeatures : PassInfoMixin<CPUFeatures> {
 
 struct RemoveNI : PassInfoMixin<RemoveNI> {
     PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM) JL_NOTSAFEPOINT;
+    static bool isRequired() { return true; }
 };
 
 struct LowerSIMDLoop : PassInfoMixin<LowerSIMDLoop> {
     PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM) JL_NOTSAFEPOINT;
+    static bool isRequired() { return true; }
 };
 
 struct FinalLowerGCPass : PassInfoMixin<FinalLowerGCPass> {


### PR DESCRIPTION
We might be able to save a little bit of work during our optimization pipeline by not looking at invoke wrapper functions, which don't seem to get optimized that much anyways. 