### PR TITLE
CI (`Create Buildbot Statuses`): add `linux32` to the list

### DIFF
--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -48,6 +48,7 @@ jobs:
       - run: |
           declare -a CONTEXT_LIST=(
                 "buildbot/tester_freebsd64"
+                "buildbot/tester_linux32"
                 "buildbot/tester_macos64"
                 "buildbot/tester_win32"
                 "buildbot/tester_win64"


### PR DESCRIPTION
Currently, we are not running `linux32` on Buildkite. So, for now, we should make sure that the `Create Buildbot Statuses` workflow creates the pending (yellow) commit status for the `linux32` Buildbot tester job.