### PR TITLE
remove dead code in jitlayers

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -538,7 +538,7 @@ void JuliaOJIT::OptSelLayerT::emit(std::unique_ptr<orc::MaterializationResponsib
                     StringRef val = attr.getValueAsString();
                     if (val != "") {
                         size_t ol = (size_t)val[0] - '0';
-                        if (ol >= 0 && ol < optlevel)
+                        if (ol < optlevel)
                             optlevel = ol;
                     }
                 }


### PR DESCRIPTION
`size_t` can't be smaller than 0 right?