### PR TITLE
Do not mark as C extern functions with C++ types

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2,6 +2,7 @@
 
 #include "llvm-version.h"
 #include "platform.h"
+#include "processor.h"
 
 #include "llvm/IR/Mangler.h"
 #include <llvm/ADT/StringMap.h>
@@ -38,7 +39,6 @@ using namespace llvm;
 #include "codegen_shared.h"
 #include "jitlayers.h"
 #include "julia_assert.h"
-#include "processor.h"
 
 #ifdef JL_USE_JITLINK
 # if JL_LLVM_VERSION >= 140000

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -30,6 +30,9 @@
     _Z24jl_coverage_data_pointerN4llvm9StringRefEi;
     _Z22jl_coverage_alloc_lineN4llvm9StringRefEi;
     _Z22jl_malloc_data_pointerN4llvm9StringRefEi;
+    _Z18jl_get_llvm_targetB5cxx11bRj;
+    _Z25jl_get_llvm_disasm_targetB5cxx11v;
+    _Z25jl_get_llvm_clone_targetsv;
     LLVMExtra*;
     llvmGetPassPluginInfo;
 

--- a/src/processor.h
+++ b/src/processor.h
@@ -187,14 +187,14 @@ extern JL_DLLEXPORT bool jl_processor_print_help;
  * If the detected/specified CPU name is not available on the LLVM version specified,
  * a fallback CPU name will be used. Unsupported features will be ignored.
  */
-extern "C" JL_DLLEXPORT std::pair<std::string,std::vector<std::string>> jl_get_llvm_target(bool imaging, uint32_t &flags);
+JL_DLLEXPORT std::pair<std::string,std::vector<std::string>> jl_get_llvm_target(bool imaging, uint32_t &flags);
 
 /**
  * Returns the CPU name and feature string to be used by LLVM disassembler.
  *
  * This will return a generic CPU name and a full feature string.
  */
-extern "C" JL_DLLEXPORT const std::pair<std::string,std::string> &jl_get_llvm_disasm_target(void);
+JL_DLLEXPORT const std::pair<std::string,std::string> &jl_get_llvm_disasm_target(void);
 
 struct jl_target_spec_t {
     // LLVM target name
@@ -211,7 +211,7 @@ struct jl_target_spec_t {
 /**
  * Return the list of targets to clone
  */
-extern "C" JL_DLLEXPORT std::vector<jl_target_spec_t> jl_get_llvm_clone_targets(void);
+JL_DLLEXPORT std::vector<jl_target_spec_t> jl_get_llvm_clone_targets(void);
 std::string jl_get_cpu_name_llvm(void);
 std::string jl_get_cpu_features_llvm(void);
 #endif

--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -1001,21 +1001,21 @@ jl_sysimg_fptrs_t jl_init_processor_sysimg(void *hdl)
     return parse_sysimg(hdl, sysimg_init_cb);
 }
 
-extern "C" JL_DLLEXPORT std::pair<std::string,std::vector<std::string>> jl_get_llvm_target(bool imaging, uint32_t &flags)
+JL_DLLEXPORT std::pair<std::string,std::vector<std::string>> jl_get_llvm_target(bool imaging, uint32_t &flags)
 {
     ensure_jit_target(imaging);
     flags = jit_targets[0].en.flags;
     return get_llvm_target_vec(jit_targets[0]);
 }
 
-extern "C" JL_DLLEXPORT const std::pair<std::string,std::string> &jl_get_llvm_disasm_target(void)
+JL_DLLEXPORT const std::pair<std::string,std::string> &jl_get_llvm_disasm_target(void)
 {
     static const auto res = get_llvm_target_str(TargetData<feature_sz>{"generic", "",
             {feature_masks, 0}, {{}, 0}, 0});
     return res;
 }
 
-extern "C" JL_DLLEXPORT std::vector<jl_target_spec_t> jl_get_llvm_clone_targets(void)
+JL_DLLEXPORT std::vector<jl_target_spec_t> jl_get_llvm_clone_targets(void)
 {
     if (jit_targets.empty())
         jl_error("JIT targets not initialized");


### PR DESCRIPTION
Some functions with a C++ return type were marked as `extern "C"`, but this
would cause warnings when compiling with clang:

```
./processor.h:190:73: warning: 'jl_get_llvm_target' has C-linkage specified, but returns incomplete type 'std::pair<std::string, std::vector<std::string>>' (aka 'pair<basic_string<char>, vector<basic_string<char>>>') which could be incompatible with C [-Wreturn-type-c-linkage]
extern "C" JL_DLLEXPORT std::pair<std::string,std::vector<std::string>> jl_get_llvm_target(bool imaging, uint32_t &flags);
                                                                        ^
./processor.h:197:67: warning: 'jl_get_llvm_disasm_target' has C-linkage specified, but returns user-defined type 'const std::pair<std::string, std::string> &' (aka 'const pair<basic_string<char>, basic_string<char>> &') which is incompatible with C [-Wreturn-type-c-linkage]
extern "C" JL_DLLEXPORT const std::pair<std::string,std::string> &jl_get_llvm_disasm_target(void);
                                                                  ^
./processor.h:214:55: warning: 'jl_get_llvm_clone_targets' has C-linkage specified, but returns incomplete type 'std::vector<jl_target_spec_t>' which could be incompatible with C [-Wreturn-type-c-linkage]
extern "C" JL_DLLEXPORT std::vector<jl_target_spec_t> jl_get_llvm_clone_targets(void);
                                                      ^
```

We also need to explicitly mark the C++-mangled names of these functions to the
list of exported symbols, otherwise they'd be hidden in `libjulia-internal.so`,
and linking `libjulia-codegen.so` would fail because of the undefined symbols.
This wasn't needed when the functions were marked as `extern "C"` because the
exported symbols wouldn't have the C++ name-mangling and so they'd match the
`jl_*` entry.

---

This commit was originally in #44350, but I took it out from that PR because it's slightly orthogonal (this fixes a warning from Clang, not GCC), it's also a bit more convoluted that the rest of changes in #44350, and with this error I was seeing a strange build error on FreeBSD which I didn't quite understand.