### PR TITLE
Factor out active ip tracking from inference loop

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4056,3 +4056,13 @@ f_max_methods(x::Float64) = 2
 g_max_methods(x) = f_max_methods(x)
 @test Core.Compiler.return_type(g_max_methods, Tuple{Int}) === Int
 @test Core.Compiler.return_type(g_max_methods, Tuple{Any}) === Any
+
+# Unit tests for BitSetBoundedMinPrioritySet
+let bsbmp = Core.Compiler.BitSetBoundedMinPrioritySet(5)
+    Core.Compiler.push!(bsbmp, 2)
+    Core.Compiler.push!(bsbmp, 2)
+    @test Core.Compiler.popfirst!(bsbmp) == 2
+    Core.Compiler.push!(bsbmp, 1)
+    @test Core.Compiler.popfirst!(bsbmp) == 1
+    @test Core.Compiler.isempty(bsbmp)
+end


### PR DESCRIPTION
In preparation for using the same structure elsewhere.
Inference order should be exactly the same, modulo one very rare
corner case involving inference loops (where the new order is arguably
better). Retains the fast path of the previous version when statements
are visited in linear order (and even does slightly better, by avoiding an
unnecessary delete!).

Best reviewed with whitespace ignored.