### PR TITLE
Move to a pool of threadsafecontexts

### DIFF
--- a/doc/src/devdocs/locks.md
+++ b/doc/src/devdocs/locks.md
@@ -29,8 +29,10 @@ The following are definitely leaf locks (level 1), and must not try to acquire a
 >   * flisp
 >   * jl_in_stackwalk (Win32)
 >   * PM_mutex[i]
+>   * ContextPool::mutex
 >
 >     > flisp itself is already threadsafe, this lock only protects the `jl_ast_context_list_t` pool
+>     > likewise, orc::ThreadSafeContexts carry their own lock, the ContextPool::mutex just protects the pool
 
 The following is a leaf lock (level 2), and only acquires level 1 locks (safepoint) internally:
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8371,7 +8371,7 @@ extern "C" void jl_init_llvm(void)
     if (clopt && clopt->getNumOccurrences() == 0)
         cl::ProvidePositionalOption(clopt, "4", 1);
 
-    jl_ExecutionEngine = new JuliaOJIT(new LLVMContext());
+    jl_ExecutionEngine = new JuliaOJIT();
 
     bool jl_using_gdb_jitevents = false;
     // Register GDB event listener

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -936,6 +936,7 @@ JuliaOJIT::JuliaOJIT()
 #endif
     GlobalJD(ES.createBareJITDylib("JuliaGlobals")),
     JD(ES.createBareJITDylib("JuliaOJIT")),
+    ContextPool([](){ return orc::ThreadSafeContext(std::make_unique<LLVMContext>()); }),
 #ifdef JL_USE_JITLINK
     // TODO: Port our memory management optimisations to JITLink instead of using the
     // default InProcessMemoryManager.


### PR DESCRIPTION
Moving to a pool of contexts gets us closer to running compilation on multiple threads once we can get rid of the codegen lock. However, this series of PRs is starting to veer into territory of potential locking issues, so review with an eye for those errors would be appreciated. 
I don't believe there are locking issues here because although we have differences in the order in which we unlock locks (due to RAII and explicit unlock calls coexisting), we don't really call any functions between our unlock calls which could reacquire an out-of-order lock. 

Depends on #44600 to remove imaging_mode.