### PR TITLE
Remove global target machine from cpufeatures

### DIFF
--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -53,6 +53,7 @@ extern bool imaging_mode;
 void addTargetPasses(legacy::PassManagerBase *PM, TargetMachine *TM);
 void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool lower_intrinsics=true, bool dump_native=false);
 void addMachinePasses(legacy::PassManagerBase *PM, TargetMachine *TM, int optlevel);
+std::unique_ptr<TargetMachine> createTargetMachine();
 void jl_finalize_module(std::unique_ptr<Module>  m);
 void jl_merge_module(Module *dest, std::unique_ptr<Module> src);
 Module *jl_create_llvm_module(StringRef name, LLVMContext &ctx, const DataLayout *DL = nullptr, const Triple *triple = nullptr);


### PR DESCRIPTION
This breaks the dependency of our CPUFeatures pass on the Julia runtime being initialized by simply creating a TargetMachine whenever we need it.