### PR TITLE
Set `USECLANG` and `USEGCC` based on the actual compilers used

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -456,25 +456,20 @@ endif
 
 # Compiler specific stuff
 
-ifeq ($(USECLANG), 1)
+CC_VERSION_STRING = $(shell $(CC) --version)
+ifneq (,$(findstring clang,$(CC_VERSION_STRING)))
+USECLANG := 1
 USEGCC := 0
-else  # default to gcc
-USEGCC := 1
+else
 USECLANG := 0
+USEGCC := 1
 endif
 
 FC := $(CROSS_COMPILE)gfortran
 
-ifeq ($(OS), FreeBSD)
-USEGCC := 0
-USECLANG := 1
-endif
-
 # Note: Supporting only macOS Yosemite and above
 ifeq ($(OS), Darwin)
 APPLE_ARCH := $(shell uname -m)
-USEGCC := 0
-USECLANG := 1
 ifneq ($(APPLE_ARCH),arm64)
 MACOSX_VERSION_MIN := 10.10
 else


### PR DESCRIPTION
Following up from https://github.com/JuliaLang/julia/pull/44601#issuecomment-1066136341 and the last CI-dev call, this PR sets `USECLANG` based on the output of `$(CC) --version`, and then `USEGCC` as the complementary value.  The values can still be overridden in `Make.user` if necessary.  Now on Linux with `cc` being GCC I get:
```console
% make print-USECLANG print-USEGCC 
USECLANG=0
USEGCC=1
% make CC=clang print-USECLANG print-USEGCC 
USECLANG=1
USEGCC=0
% make CC=cc print-USECLANG print-USEGCC 
USECLANG=0
USEGCC=1
```

Note: it isn't reliable to check `cc --version` contains `gcc` because it looks like GCC shows at the beginning the basename of the file you call:
```console
% ln -s /usr/bin/gcc clang
% ./clang --version
clang (GCC) 11.2.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
This is in particular a problem when calling `gcc` as `cc`.  Matching `GCC` would be a bit better, but I see that other compilers that pretend to be GCC may not use the string `GCC`.  For example, the Fujitsu compiler:
```console
$ fccpx --version
fccpx (FCC) 4.7.0 20211110
simulating gcc version 6.1
Copyright FUJITSU LIMITED 2019-2021
```
but probably this shouldn't be our main target.