### PR TITLE
Fix some inference failures in Base.require call graph

### DIFF
--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -130,7 +130,7 @@ function show(io::IO, cmd::Cmd)
     print(io, '`')
     if print_cpus
         print(io, ", ")
-        show(io, collect(Int, something(cmd.cpus))
+        show(io, collect(Int, something(cmd.cpus)))
         print(io, ")")
     end
     print_env && (print(io, ","); show(io, cmd.env))

--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -130,7 +130,7 @@ function show(io::IO, cmd::Cmd)
     print(io, '`')
     if print_cpus
         print(io, ", ")
-        show(io, collect(Int, cmd.cpus::AbstractVector{<:Integer}))
+        show(io, collect(Int, something(cmd.cpus))
         print(io, ")")
     end
     print_env && (print(io, ","); show(io, cmd.env))

--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -130,7 +130,7 @@ function show(io::IO, cmd::Cmd)
     print(io, '`')
     if print_cpus
         print(io, ", ")
-        show(io, collect(Int, cmd.cpus))
+        show(io, collect(Int, cmd.cpus::AbstractVector{<:Integer}))
         print(io, ")")
     end
     print_env && (print(io, ","); show(io, cmd.env))

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -106,8 +106,12 @@ function depwarn(msg, funcsym; force::Bool=false)
         _module=begin
             bt = backtrace()
             frame, caller = firstcaller(bt, funcsym)
-            # TODO: Is it reasonable to attribute callers without linfo to Core?
-            caller.linfo isa Core.MethodInstance ? caller.linfo.def.module : Core
+            linfo = caller.linfo
+            if linfo isa Core.MethodInstance
+                linfo.def isa Module ? linfo.def : linfo.def.module
+            else
+                Core    # TODO: Is it reasonable to attribute callers without linfo to Core?
+            end
         end,
         _file=String(caller.file),
         _line=caller.line,

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -108,7 +108,8 @@ function depwarn(msg, funcsym; force::Bool=false)
             frame, caller = firstcaller(bt, funcsym)
             linfo = caller.linfo
             if linfo isa Core.MethodInstance
-                linfo.def isa Module ? linfo.def : linfo.def.module
+                def = linfo.def
+                def isa Module ? def : def.module
             else
                 Core    # TODO: Is it reasonable to attribute callers without linfo to Core?
             end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -599,7 +599,8 @@ end
 
 function is_v1_format_manifest(raw_manifest::Dict)
     if haskey(raw_manifest, "manifest_format")
-        if raw_manifest["manifest_format"] isa Dict && haskey(raw_manifest["manifest_format"], "uuid")
+        mf = raw_manifest["manifest_format"]
+        if mf isa Dict && haskey(mf, "uuid")
             # the off-chance where an old format manifest has a dep called "manifest_format"
             return true
         end
@@ -615,7 +616,7 @@ function get_deps(raw_manifest::Dict)
         return raw_manifest
     else
         # if the manifest has no deps, there won't be a `deps` field
-        return get(Dict{String, Any}, raw_manifest, "deps")
+        return get(Dict{String, Any}, raw_manifest, "deps")::Dict{String, Any}
     end
 end
 
@@ -896,6 +897,7 @@ const TIMING_IMPORTS = Threads.Atomic{Int}(0)
         if staledeps === true
             continue
         end
+        staledeps = staledeps::Vector{Any}
         try
             touch(path_to_try) # update timestamp of precompilation file
         catch # file might be read-only and then we fail to update timestamp, which is fine
@@ -1158,7 +1160,7 @@ function set_pkgorigin_version_path(pkg, path)
             d = parsed_toml(project_file)
             v = get(d, "version", nothing)
             if v !== nothing
-                pkgorigin.version = VersionNumber(v)
+                pkgorigin.version = VersionNumber(v)   # can we narrow the types on `v`?
             end
         end
     end
@@ -1307,8 +1309,11 @@ include_string(m::Module, txt::AbstractString, fname::AbstractString="string") =
 
 function source_path(default::Union{AbstractString,Nothing}="")
     s = current_task().storage
-    if s !== nothing && haskey(s::IdDict{Any,Any}, :SOURCE_PATH)
-        return s[:SOURCE_PATH]::Union{Nothing,String}
+    if s !== nothing
+        s = s::IdDict{Any,Any}
+        if haskey(s, :SOURCE_PATH)
+            return s[:SOURCE_PATH]::Union{Nothing,String}
+        end
     end
     return default
 end
@@ -1895,7 +1900,7 @@ function get_preferences_hash(uuid::Union{UUID, Nothing}, prefs_list::Vector{Str
     for name in prefs_list
         prefs_value = get(prefs, name, nothing)
         if prefs_value !== nothing
-            h = hash(prefs_value, h)
+            h = hash(prefs_value, h)::UInt
         end
     end
     # We always return a `UInt64` so that our serialization format is stable

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1160,7 +1160,7 @@ function set_pkgorigin_version_path(pkg, path)
             d = parsed_toml(project_file)
             v = get(d, "version", nothing)
             if v !== nothing
-                pkgorigin.version = VersionNumber(v)   # can we narrow the types on `v`?
+                pkgorigin.version = VersionNumber(v::AbstractString)
             end
         end
     end

--- a/base/process.jl
+++ b/base/process.jl
@@ -89,7 +89,7 @@ end
 @noinline function _spawn_primitive(file, cmd::Cmd, stdio::SpawnIOs)
     loop = eventloop()
     cpumask = cmd.cpus
-    cpumask === nothing || (cpumask = as_cpumask(cmd.cpus))
+    cpumask === nothing || (cpumask = as_cpumask(cpumask))
     GC.@preserve stdio begin
         iohandles = Tuple{Cint, UInt}[ # assuming little-endian layout
             let h = rawhandle(io)

--- a/base/show.jl
+++ b/base/show.jl
@@ -727,11 +727,11 @@ function show_typealias(io::IO, @nospecialize(x::Type))
 end
 
 function make_typealiases(@nospecialize(x::Type))
-    Any === x && return Core.svec(), Union{}
-    x <: Tuple && return Core.svec(), Union{}
+    aliases = SimpleVector[]
+    Any === x && return aliases, Union{}
+    x <: Tuple && return aliases, Union{}
     mods = modulesof!(Set{Module}(), x)
     Core in mods && push!(mods, Base)
-    aliases = SimpleVector[]
     vars = Dict{Symbol,TypeVar}()
     xenv = UnionAll[]
     each = Any[]
@@ -783,7 +783,7 @@ function make_typealiases(@nospecialize(x::Type))
         end
     end
     if isempty(aliases)
-        return Core.svec(), Union{}
+        return aliases, Union{}
     end
     sort!(aliases, by = x -> x[4]::Tuple{Int,Int}, rev = true) # heuristic sort by "best" environment
     let applied = Union{}

--- a/base/stat.jl
+++ b/base/stat.jl
@@ -146,7 +146,7 @@ show(io::IO, ::MIME"text/plain", st::StatStruct) = show_statstruct(io, st, false
 
 macro stat_call(sym, arg1type, arg)
     return quote
-        stat_buf = zeros(UInt8, ccall(:jl_sizeof_stat, Int32, ()))
+        stat_buf = zeros(UInt8, Int(ccall(:jl_sizeof_stat, Int32, ())))
         r = ccall($(Expr(:quote, sym)), Int32, ($(esc(arg1type)), Ptr{UInt8}), $(esc(arg)), stat_buf)
         if !(r in (0, Base.UV_ENOENT, Base.UV_ENOTDIR, Base.UV_EINVAL))
             uv_error(string("stat(", repr($(esc(arg))), ")"), r)

--- a/base/toml_parser.jl
+++ b/base/toml_parser.jl
@@ -1165,7 +1165,7 @@ function parse_string_continue(l::Parser, multiline::Bool, quoted::Bool)::Err{St
 end
 
 function take_chunks(l::Parser, unescape::Bool)::String
-    nbytes = sum(length, l.chunks)
+    nbytes = sum(length, l.chunks; init=0)
     str = Base._string_n(nbytes)
     offset = 1
     for chunk in l.chunks


### PR DESCRIPTION
I found another package, RoundingIntegers.jl, that invalidates `Base.require`, which is particularly bad to invalidate since it has to be recompiled before loading the next package; if it happens repeatedly it can substantially slow loading. I finally decided to just go through the JET report on `Base.require` and fix most of the things that I could fix that weren't already being handled in #44500.

I am not certain whether the change to `make_aliases` (always returning a `Vector{SimpleVector}`) is wise, but the tests pass so :shrug:.