### PR TITLE
syntax: deparse function end

### DIFF
--- a/src/ast.scm
+++ b/src/ast.scm
@@ -177,7 +177,7 @@
                   (cdr e)
                   (list e)))
             (deparse-block (string (car e) " " (deparse (cadr e)))
-                           (block-stmts (caddr e))
+                           (if (null? (cddr e)) '() (block-stmts (caddr e)))
                            ilvl))
            ((return)         (string "return " (deparse (cadr e))))
            ((break continue) (string (car e)))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1452,6 +1452,14 @@ invalid assignment location "function (s, o...)
 end\""""
 end
 
+let ex = Meta.lower(@__MODULE__, :(function g end = 1))
+    @test isa(ex, Expr) && ex.head === :error
+    @test ex.args[1] == """
+invalid assignment location "function g
+end\""""
+end
+
+
 # issue #15229
 @test Meta.lower(@__MODULE__, :(function f(x); local x; 0; end)) ==
     Expr(:error, "local variable name \"x\" conflicts with an argument")


### PR DESCRIPTION
Just happened to notice this missing case