### PR TITLE
make `get_binding_type` more precise for consts

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -386,6 +386,10 @@ JL_DLLEXPORT jl_value_t *jl_binding_type(jl_module_t *m, jl_sym_t *var)
     JL_UNLOCK(&m->lock);
     if (b == NULL)
         return jl_nothing;
+    if (b->constp) {
+        jl_value_t *val = jl_atomic_load_relaxed(&b->value);
+        return val ? jl_typeof(val) : jl_nothing;
+    }
     jl_value_t *ty = jl_atomic_load_relaxed(&b->ty);
     return ty ? ty : jl_nothing;
 }

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1112,3 +1112,6 @@ end
 @testset "Base/timing.jl" begin
     @test Base.jit_total_bytes() >= 0
 end
+
+const I_AM_A_CONSTANT_INT = 1
+@test Core.get_binding_type(@__MODULE__, :I_AM_A_CONSTANT_INT) == Int


### PR DESCRIPTION
replaces #44232