### PR TITLE
Add system info to start of testsuite. Profile: don't spawn profile listener on windows

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -140,9 +140,12 @@ function __init__()
         delay = 0.001
     end
     init(n, delay, limitwarn = false)
-    PROFILE_PRINT_COND[] = Base.AsyncCondition()
-    ccall(:jl_set_peek_cond, Cvoid, (Ptr{Cvoid},), PROFILE_PRINT_COND[].handle)
-    errormonitor(Threads.@spawn(profile_printing_listener()))
+    @static if !Sys.iswindows()
+        # triggering a profile via signals is not implemented on windows
+        PROFILE_PRINT_COND[] = Base.AsyncCondition()
+        ccall(:jl_set_peek_cond, Cvoid, (Ptr{Cvoid},), PROFILE_PRINT_COND[].handle)
+        errormonitor(Threads.@spawn(profile_printing_listener()))
+    end
 end
 
 """

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -181,9 +181,11 @@ let cmd = Base.julia_cmd()
         sleep(10)
         kill(p, Base.SIGKILL)
     end
-    s = read(p, String)
+    @time s = read(p, String)
     close(t)
-    @test success(p)
+    @time @test success(p)
+    @show s
+    @show read(p, String)
     @test parse(Int, s) > 100
 end
 

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -185,10 +185,9 @@ let cmd = Base.julia_cmd()
         sleep(10)
         kill(p, Base.SIGKILL)
     end
-    @showtime s = read(p, String)
+    s = read(p, String)
     close(t)
     @test success(p)
-    @show s
     @test !isempty(s)
     @test occursin("done", s)
     @test parse(Int, split(s, '\n')[end]) > 100

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using Dates
 import REPL
 using Printf: @sprintf
 using Base: Experimental
+using InteractiveUtils: versioninfo
 
 include("choosetests.jl")
 include("testenv.jl")
@@ -122,6 +123,11 @@ cd(@__DIR__) do
     if use_revise
         Base.invokelatest(revise_trackall)
         Distributed.remotecall_eval(Main, workers(), revise_init_expr)
+    end
+
+    if tryparse(Bool, get(ENV, "CI", "false")) == true
+        # start report on CI with info for debugging
+        versioninfo()
     end
 
     #pretty print the information about gc and mem usage

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -124,7 +124,7 @@ cd(@__DIR__) do
         Distributed.remotecall_eval(Main, workers(), revise_init_expr)
     end
 
-    println("""\n
+    println("""
         Running parallel tests with:
           nworkers() = $(nworkers())
           nthreads() = $(Threads.nthreads())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,6 @@ using Dates
 import REPL
 using Printf: @sprintf
 using Base: Experimental
-using InteractiveUtils: versioninfo
 
 include("choosetests.jl")
 include("testenv.jl")
@@ -125,10 +124,14 @@ cd(@__DIR__) do
         Distributed.remotecall_eval(Main, workers(), revise_init_expr)
     end
 
-    if tryparse(Bool, get(ENV, "CI", "false")) == true
-        # start report on CI with info for debugging
-        versioninfo()
-    end
+    println("""\n
+        Running parallel tests with:
+          nworkers() = $(nworkers())
+          nthreads() = $(Threads.nthreads())
+          Sys.CPU_THREADS = $(Sys.CPU_THREADS)
+          Sys.total_memory() = $(Base.format_bytes(Sys.total_memory()))
+          Sys.free_memory() = $(Base.format_bytes(Sys.free_memory()))
+        """)
 
     #pretty print the information about gc and mem usage
     testgroupheader = "Test"


### PR DESCRIPTION
Firstly adds some info to the start of CI runs, to try and help debug recent spurious OOMs or hangs, especially on 32-bit runners.

Secondly disables a spawned task for a profiling feature that isn't functional on windows.
The overhead of having the thread spawned should be negligible, but probably good to do.