### PR TITLE
[release-1.8] Backport Darwin debug object construction error ignoring

### DIFF
--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -814,8 +814,10 @@ static objfileentry_t &find_object_file(uint64_t fbase, StringRef fname) JL_NOTS
                 StringRef((const char *)fbase, msize), "", false);
         auto origerrorobj = llvm::object::ObjectFile::createObjectFile(
             membuf->getMemBufferRef(), file_magic::unknown);
-        if (!origerrorobj)
+        if (!origerrorobj) {
+            ignoreError(origerrorobj);
             return entry;
+        }
 
         llvm::object::MachOObjectFile *morigobj = (llvm::object::MachOObjectFile*)
             origerrorobj.get().get();


### PR DESCRIPTION
From PR #44637, cherry picked from commit efa2430a2264fa3f159deb63b01a275d0b637b05. This may be necessary for a 1.8-beta2 M1 build.