### PR TITLE
add a note on how long it takes to build julia on WSL

### DIFF
--- a/doc/src/devdocs/build/windows.md
+++ b/doc/src/devdocs/build/windows.md
@@ -152,7 +152,7 @@ install wine wget mingw-w64`, as appropriate.
  1. `git clone https://github.com/JuliaLang/julia.git julia-win32`
  2. `cd julia-win32`
  3. `echo override XC_HOST = i686-w64-mingw32 >> Make.user`
- 4. `make`
+ 4. `make` # this can take over an hour, so be prepared
  5. `make win-extras` (Necessary before running `make binary-dist`)
  6. `make binary-dist` then `make exe` to create the Windows installer.
  7. move the `julia-*.exe` installer to the target machine


### PR DESCRIPTION
There was a thread on Discourse about how this looks like it has stopped working

https://discourse.julialang.org/t/installing-julia-from-source-on-wsl-halts-for-an-infinite-time/77923

I tried it myself and it sat at 100% CPU with no output on the console for over an hour, but it *did* eventually finish.

It was suggested by the original poster to add a note, which I think is reasonable. 