### PR TITLE
Add new constructor for Set and BitSet

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ Julia v1.9 Release Notes
 
 New language features
 ---------------------
+* New Set(x,y,z) constructor is equivalent to Set((x,y,z))
+* New BitSet(x,y,z) constructor is equivalent to BitSet((x,y,z))
 
 
 Language changes

--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -27,6 +27,7 @@ If the set will be sparse (for example, holding a few
 very large integers), use [`Set`](@ref) instead.
 """
 BitSet(itr) = union!(BitSet(), itr)
+BitSet(x...) = BitSet(x)
 
 # Special implementation for BitSet, which lacks a fast `length` method.
 function union!(s::BitSet, itr)

--- a/base/set.jl
+++ b/base/set.jl
@@ -10,6 +10,8 @@ Set{T}() where {T} = _Set(Dict{T,Nothing}())
 Set{T}(s::Set{T}) where {T} = _Set(Dict{T,Nothing}(s.dict))
 Set{T}(itr) where {T} = union!(Set{T}(), itr)
 Set() = Set{Any}()
+Set{T}(x...) where {T} = Set(x)
+Set(x...) = Set(x)
 
 function Set{T}(s::KeySet{T, <:Dict{T}}) where {T}
     d = s.dict

--- a/test/bitset.jl
+++ b/test/bitset.jl
@@ -10,6 +10,7 @@ using Random
     data_out = collect(s)
     @test all(map(in(data_out), data_in))
     @test length(data_out) === length(data_in)
+    @test BitSet(1,5,100) == s
 end
 
 @testset "eltype, empty" begin

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -37,6 +37,12 @@ using Dates
         @test !("baz2" in s1)
         @test "baz2" in s2
     end
+    @test Set(1,2,3,1) == Set(1,2,3)
+    @test Set((1,2,3)) == Set([1,2,3])
+    @test Set(1,2,3) == Set([1,2,3])
+    @test Set(1,2,3.0) == Set(1.0,2,3)
+    @test Set(1,2,3.0) == Set((1,2,3.0))
+    @test Set{Int}(1,2,3) == Set(1,2,3)
 end
 
 @testset "hash" begin
@@ -95,6 +101,9 @@ end
     s3 = empty(Set([1,"hello"]),Float32)
     @test isequal(s3, Set())
     @test ===(eltype(s3), Float32)
+    @test ===(eltype(Set((1,2,3.0))), eltype((1,2,3.0)))
+    @test ===(eltype(Set([1,2,3.0])), eltype([1,2,3.0]))
+    @test ===(eltype(Set(1,2,"three")), Any)
 end
 @testset "show" begin
     @test sprint(show, Set()) == "Set{Any}()"


### PR DESCRIPTION
Currently, `Dict` has a constructor which accepts an arbitrary amount of pairs that aren't contained inside a single iterable argument. E.g. we can do `Dict(1 => 'a', 2 => 'b')` in addition to `Dict([1 => 'a', 2 => 'b'])`.

In contrast, `Set` does not support this type of constructor; there is no `Set(1, 2, 3)`. This pull request adds that constructor and an analogous one for `BitSet`.

I tried searching for related discussions of this in the past, but had trouble finding anything due to how common any such keywords would be. I also recognize that this is opening up a whole can of worms with things like `Vector(x...)` and `Tuple(x...)`, but those at least already have other syntaxes available like `[x...]` and `(x...)`.

Constructors added by this pull request:
```
Set(x...)
Set{T}(x...)
BitSet(x...)
```

Current implementation is to just leverage the fact that varargs are already wrapped in a tuple, so `Set(a, b, c) == Set((a, b, c))`

This does not affect any existing behavior to my knowledge, e.g. `Set(c)` still does the same thing that it currently does if `c` is not iterable.