### PR TITLE
Fix performance issue with diagonal multiplication

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -276,7 +276,7 @@ function *(D::Diagonal, transA::Transpose{<:Any,<:AbstractMatrix})
     lmul!(D, At)
 end
 
-function __muldiag!(out, D::Diagonal, B, alpha, beta)
+@inline function __muldiag!(out, D::Diagonal, B, alpha, beta)
     require_one_based_indexing(out)
     if iszero(alpha)
         _rmul_or_fill!(out, beta)
@@ -297,7 +297,7 @@ function __muldiag!(out, D::Diagonal, B, alpha, beta)
     end
     return out
 end
-function __muldiag!(out, A, D::Diagonal, alpha, beta)
+@inline function __muldiag!(out, A, D::Diagonal, alpha, beta)
     require_one_based_indexing(out)
     if iszero(alpha)
         _rmul_or_fill!(out, beta)
@@ -320,25 +320,18 @@ function __muldiag!(out, A, D::Diagonal, alpha, beta)
     end
     return out
 end
-function __muldiag!(out::Diagonal, D1::Diagonal, D2::Diagonal, alpha, beta)
+@inline function __muldiag!(out::Diagonal, D1::Diagonal, D2::Diagonal, alpha, beta)
     d1 = D1.diag
     d2 = D2.diag
-    if iszero(alpha)
-        _rmul_or_fill!(out.diag, beta)
-    else
-        if iszero(beta)
-            @inbounds @simd for i in eachindex(out.diag)
-                out.diag[i] = d1[i] * d2[i] * alpha
-            end
-        else
-            @inbounds @simd for i in eachindex(out.diag)
-                out.diag[i] = d1[i] * d2[i] * alpha + out.diag[i] * beta
-            end
+    _rmul_or_fill!(out.diag, beta)
+    if !iszero(alpha)
+        @inbounds @simd for i in eachindex(out.diag)
+            out.diag[i] += d1[i] * d2[i] * alpha
         end
     end
     return out
 end
-function __muldiag!(out, D1::Diagonal, D2::Diagonal, alpha, beta)
+@inline function __muldiag!(out, D1::Diagonal, D2::Diagonal, alpha, beta)
     require_one_based_indexing(out)
     mA = size(D1, 1)
     d1 = D1.diag
@@ -352,7 +345,7 @@ function __muldiag!(out, D1::Diagonal, D2::Diagonal, alpha, beta)
     return out
 end
 
-function _muldiag!(out, A, B, alpha, beta)
+@inline function _muldiag!(out, A, B, alpha, beta)
     _muldiag_size_check(out, A, B)
     __muldiag!(out, A, B, alpha, beta)
     return out

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -323,10 +323,17 @@ end
 @inline function __muldiag!(out::Diagonal, D1::Diagonal, D2::Diagonal, alpha, beta)
     d1 = D1.diag
     d2 = D2.diag
-    _rmul_or_fill!(out.diag, beta)
-    if !iszero(alpha)
-        @inbounds @simd for i in eachindex(out.diag)
-            out.diag[i] += d1[i] * d2[i] * alpha
+    if iszero(alpha)
+        _rmul_or_fill!(out.diag, beta)
+    else
+        if iszero(beta)
+            @inbounds @simd for i in eachindex(out.diag)
+                out.diag[i] = d1[i] * d2[i] * alpha
+            end
+        else
+            @inbounds @simd for i in eachindex(out.diag)
+                out.diag[i] = d1[i] * d2[i] * alpha + out.diag[i] * beta
+            end
         end
     end
     return out

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -241,8 +241,8 @@ end
 (*)(D::Diagonal, A::AbstractMatrix) =
     mul!(similar(A, promote_op(*, eltype(A), eltype(D.diag)), size(A)), D, A)
 
-rmul!(A::AbstractMatrix, D::Diagonal) = mul!(A, A, D)
-lmul!(D::Diagonal, B::AbstractVecOrMat) = mul!(B, D, B)
+rmul!(A::AbstractMatrix, D::Diagonal) = @inline mul!(A, A, D)
+lmul!(D::Diagonal, B::AbstractVecOrMat) = @inline mul!(B, D, B)
 
 #TODO: It seems better to call (D' * adjA')' directly?
 function *(adjA::Adjoint{<:Any,<:AbstractMatrix}, D::Diagonal)
@@ -276,11 +276,7 @@ function *(D::Diagonal, transA::Transpose{<:Any,<:AbstractMatrix})
     lmul!(D, At)
 end
 
-# in __muldiag! below we unroll the loops manually, since broadcasting may be unable to
-# prove that they are vectorizable
 function __muldiag!(out, D::Diagonal, B, alpha, beta)
-    # TODO: check if this code can be replaced by a single line
-    # out .= (D.diag .* B) .*ₛ alpha .+ out .*ₛ beta
     require_one_based_indexing(out)
     if iszero(alpha)
         _rmul_or_fill!(out, beta)
@@ -302,8 +298,6 @@ function __muldiag!(out, D::Diagonal, B, alpha, beta)
     return out
 end
 function __muldiag!(out, A, D::Diagonal, alpha, beta)
-    # TODO: check if this code can be replaced by a single line
-    # out .= (B .* permutedims(D.diag)) .*ₛ alpha .+ out .*ₛ beta
     require_one_based_indexing(out)
     if iszero(alpha)
         _rmul_or_fill!(out, beta)
@@ -327,8 +321,6 @@ function __muldiag!(out, A, D::Diagonal, alpha, beta)
     return out
 end
 function __muldiag!(out::Diagonal, D1::Diagonal, D2::Diagonal, alpha, beta)
-    # TODO: check if this code can be replaced by a single line
-    # out.diag .= (D1.diag .* D2.diag) .*ₛ alpha .+ out.diag .*ₛ beta
     d1 = D1.diag
     d2 = D2.diag
     if iszero(alpha)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -8,8 +8,7 @@
 # inside this function.
 function *ₛ end
 Broadcast.broadcasted(::typeof(*ₛ), out, beta) =
-    iszero(beta::Number) ? false :
-    isone(beta::Number) ? broadcasted(identity, out) : broadcasted(*, out, beta)
+    iszero(beta::Number) ? false : broadcasted(*, out, beta)
 
 """
     MulAddMul(alpha, beta)


### PR DESCRIPTION
This an attempt to fix a major performance regression in diagonal multiplication, see https://github.com/JuliaLang/julia/pull/42321#issuecomment-1043582540, following suggestions by @N5N3. @staticfloat may want to keep an eye on CI runtime here.

On my machine, in a complete `test-LinearAlgebra` run, I had a runtime of the Diagonal test only of nearly 1000 seconds (of course including compilation time). Locally, my `make test-LinearAlgebra` is currently broken, but when I ran the Diagonal test suite, it finished in less than 300 seconds. Not sure if this is fair comparison, but let's see what the online CI says.