### PR TITLE
WIP: Allow inlining method matches with unmatched type parameters

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -605,13 +605,7 @@ end
 
 # SimpleVector
 
-function getindex(v::SimpleVector, i::Int)
-    @boundscheck if !(1 <= i <= length(v))
-        throw(BoundsError(v,i))
-    end
-    return ccall(:jl_svec_ref, Any, (Any, Int), v, i - 1)
-end
-
+@eval getindex(v::SimpleVector, i::Int) = Core._svec_ref($(Expr(:boundscheck)), v, i)
 function length(v::SimpleVector)
     return ccall(:jl_svec_len, Int, (Any,), v)
 end

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -56,6 +56,8 @@ DECLARE_BUILTIN(typeof);
 DECLARE_BUILTIN(_typevar);
 DECLARE_BUILTIN(donotdelete);
 DECLARE_BUILTIN(getglobal);
+DECLARE_BUILTIN(_compute_sparams);
+DECLARE_BUILTIN(_svec_ref);
 
 JL_CALLABLE(jl_f_invoke_kwsorter);
 #ifdef DEFINE_BUILTIN_GLOBALS
@@ -72,6 +74,8 @@ JL_CALLABLE(jl_f_get_binding_type);
 JL_CALLABLE(jl_f_set_binding_type);
 JL_CALLABLE(jl_f_donotdelete);
 JL_CALLABLE(jl_f_setglobal);
+JL_CALLABLE(jl_f__compute_sparams);
+JL_CALLABLE(jl_f__svec_ref);
 
 #ifdef __cplusplus
 }

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1586,6 +1586,35 @@ JL_CALLABLE(jl_f_donotdelete)
     return jl_nothing;
 }
 
+JL_CALLABLE(jl_f__compute_sparams)
+{
+    JL_NARGSV(_compute_sparams, 1);
+    jl_method_t *m = (jl_method_t*)args[0];
+    JL_TYPECHK(_compute_sparams, method, (jl_value_t*)m);
+    jl_datatype_t *tt = jl_inst_arg_tuple_type(args[1], &args[2], nargs-1, 1);
+    jl_svec_t *env = jl_emptysvec;
+    JL_GC_PUSH2(&env, &tt);
+    jl_type_intersection_env((jl_value_t*)tt, m->sig, &env);
+    JL_GC_POP();
+    return (jl_value_t*)env;
+}
+
+JL_CALLABLE(jl_f__svec_ref)
+{
+    JL_NARGS(_svec_ref, 3, 3);
+    jl_value_t *b = args[0];
+    jl_svec_t *s = (jl_svec_t*)args[1];
+    jl_value_t *i = (jl_value_t*)args[2];
+    JL_TYPECHK(_svec_ref, bool, b);
+    JL_TYPECHK(_svec_ref, simplevector, (jl_value_t*)s);
+    JL_TYPECHK(_svec_ref, long, i);
+    ssize_t idx = jl_unbox_long(i);
+    if (idx < 1 || idx > jl_svec_len(s)) {
+        jl_bounds_error_int(s, i);
+    }
+    return jl_svec_ref(s, jl_unbox_long(i)-1);
+}
+
 static int equiv_field_types(jl_value_t *old, jl_value_t *ft)
 {
     size_t nf = jl_svec_len(ft);
@@ -1956,6 +1985,8 @@ void jl_init_primitives(void) JL_GC_DISABLED
     jl_builtin__typebody = add_builtin_func("_typebody!", jl_f__typebody);
     add_builtin_func("_equiv_typedef", jl_f__equiv_typedef);
     jl_builtin_donotdelete = add_builtin_func("donotdelete", jl_f_donotdelete);
+    add_builtin_func("_compute_sparams", jl_f__compute_sparams);
+    add_builtin_func("_svec_ref", jl_f__svec_ref);
 
     // builtin types
     add_builtin("Any", (jl_value_t*)jl_any_type);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -311,7 +311,7 @@ static const jl_fptr_args_t id_to_fptrs[] = {
     &jl_f_ifelse, &jl_f__structtype, &jl_f__abstracttype, &jl_f__primitivetype,
     &jl_f__typebody, &jl_f__setsuper, &jl_f__equiv_typedef, &jl_f_get_binding_type,
     &jl_f_set_binding_type, &jl_f_opaque_closure_call, &jl_f_donotdelete,
-    &jl_f_getglobal, &jl_f_setglobal,
+    &jl_f_getglobal, &jl_f_setglobal, &jl_f__compute_sparams, &jl_f__svec_ref,
     NULL };
 
 typedef struct {


### PR DESCRIPTION
Currently we do not allow inlining any methods that have unmatched
type parameters. The original reason for this restriction is that
I didn't really know what to put for an inlined :static_parameter,
so I just had inlining bail. As a result, in code like:

```
f(x) = Val{x}()
```

the call to `Val{x}()` would not be inlined unless `x` was known
through constant propagation.

This PR attempts to remidy that. A new builtin is added that computes
the static parameters for a given method/argument list. Additionally,
sroa gains the ability to simplify and fold this builtin. As a result,
inlining can insert an expression that computes the correct values
for the inlinees static parameters.

The change benchmarks favorably:

Before:
```
julia> function foo()
          for i = 1:10000
              Base.donotdelete(Val{i}())
          end
       end
foo (generic function with 1 method)

julia> @time foo()
  0.375567 seconds (4.24 M allocations: 274.440 MiB, 14.67% gc time, 72.96% compilation time)

julia> @time foo()
  0.012387 seconds (9.49 k allocations: 148.266 KiB)
```

After:
```
julia> function foo()
          for i = 1:10000
              Base.donotdelete(Val{i}())
          end
       end
foo (generic function with 1 method)

julia> @time foo()
  0.003058 seconds (29.47 k allocations: 1.546 MiB)

julia> @time foo()
  0.001200 seconds (9.49 k allocations: 148.266 KiB)
```

Note that this particular benchmark could also be fixed by #44654,
but this change is more general.

There is a potential downside, which is that we remove a specialization
barrier here. We already do that in the case when all type parameters
are matched, so it's not eggregious. However, there is anectodal
knowledge in the community that extra type parameters force specialization.
Some of that is due to the handling of type parameters in the specialization
code, but some of it might also be due to inlining's prior refusal
to perform this inlining. We'll have to keep an eye out for any
regressions.