### PR TITLE
[build] Allow using our self-built julia for whitespace check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ docs-revise:
 check-whitespace:
 ifneq ($(NO_GIT), 1)
 	@# Append the directory containing the julia we just built to the end of `PATH`,
-   	@# to give us the best chance of being able to run this check.
+	@# to give us the best chance of being able to run this check.
 	@PATH=$(PATH):$(dirname $(JULIA_EXECUTABLE)) $(JULIAHOME)/contrib/check-whitespace.jl
 else
 	$(warn "Skipping whitespace check because git is unavailable")

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,9 @@ docs-revise:
 
 check-whitespace:
 ifneq ($(NO_GIT), 1)
-	@$(JULIAHOME)/contrib/check-whitespace.jl
+	@# Append the directory containing the julia we just built to the end of `PATH`,
+   	@# to give us the best chance of being able to run this check.
+	@PATH=$(PATH):$(dirname $(JULIA_EXECUTABLE)) $(JULIAHOME)/contrib/check-whitespace.jl
 else
 	$(warn "Skipping whitespace check because git is unavailable")
 endif


### PR DESCRIPTION
This falls back to using the Julia just built in the current build tree
to run the whitespace check, so that if someone tries to run `make test`
it always works.