### PR TITLE
Fix performance of merging Dicts by sizehint!

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -217,6 +217,7 @@ Dict{Int64, Int64} with 3 entries:
 """
 function merge!(d::AbstractDict, others::AbstractDict...)
     for other in others
+        sizehint!(d, length(d) + length(other))
         for (k,v) in other
             d[k] = v
         end

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -217,7 +217,7 @@ Dict{Int64, Int64} with 3 entries:
 """
 function merge!(d::AbstractDict, others::AbstractDict...)
     for other in others
-        sizehint!(d, length(d) + length(other))
+        haslength(other) && sizehint!(d, length(d) + length(other))
         for (k,v) in other
             d[k] = v
         end

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -746,6 +746,7 @@ function map!(f, iter::ValueIterator{<:Dict})
 end
 
 function mergewith!(combine, d1::Dict{K, V}, d2::AbstractDict) where {K, V}
+    sizehint!(d1, length(d1) + length(d2))
     for (k, v) in d2
         i = ht_keyindex2!(d1, k)
         if i > 0

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -746,7 +746,7 @@ function map!(f, iter::ValueIterator{<:Dict})
 end
 
 function mergewith!(combine, d1::Dict{K, V}, d2::AbstractDict) where {K, V}
-    sizehint!(d1, length(d1) + length(d2))
+    haslength(d2) && sizehint!(d1, length(d1) + length(d2))
     for (k, v) in d2
         i = ht_keyindex2!(d1, k)
         if i > 0


### PR DESCRIPTION
Fixes #40412. The problem was that the elements were sorted based on the hash. Thus, there are many collisions and long sequences are generated by linear probing, before the automatic resize is triggered. Maybe it would be nice to be more restrictive to the maximum probe length.
https://github.com/JuliaLang/julia/blob/b9b2a3cc01404e019682e75e3c5241f105031511/base/dict.jl#L48-L50

Old

``` julia
julia> for n in 4_100_000:50_000:4_250_000
           a = Dict(k => true for k in 1:n)
           b = Dict(-k => true for k in 1:n)
           print("n = $n: ")
           @time mergewith!(*, a, b)
       end
n = 4100000:   0.285087 seconds (12 allocations: 160.000 MiB, 8.77% gc time)
n = 4150000:   0.311986 seconds (12 allocations: 160.000 MiB, 5.29% gc time)
n = 4200000:   2.375610 seconds (12 allocations: 160.000 MiB)
n = 4250000:  32.344895 seconds (12 allocations: 160.000 MiB)

julia> for n in 4_100_000:50_000:4_250_000
           a = Dict(k => true for k in 1:n)
           b = Dict(-k => true for k in 1:n)
           print("n = $n: ")
           @time merge(a, b)
       end
n = 4100000:   0.313683 seconds (39.77 k allocations: 242.227 MiB, 8.03% compilation time)
n = 4150000:   0.313875 seconds (19 allocations: 240.001 MiB)
n = 4200000:   2.397114 seconds (19 allocations: 240.001 MiB, 0.21% gc time)
n = 4250000:  30.312298 seconds (19 allocations: 240.001 MiB, 0.05% gc time)
```

PR

``` julia
julia> for n in 4_100_000:50_000:4_250_000
           a = Dict(k => true for k in 1:n)
           b = Dict(-k => true for k in 1:n)
           print("n = $n: ")
           @time mergewith!(*, a, b)
       end
n = 4100000:   0.244038 seconds (42.62 k allocations: 162.201 MiB, 4.46% gc time, 10.62% compilation time)
n = 4150000:   0.257953 seconds (12 allocations: 160.000 MiB, 21.66% gc time)
n = 4200000:   0.207655 seconds (12 allocations: 160.000 MiB, 2.12% gc time)
n = 4250000:   0.208645 seconds (12 allocations: 160.000 MiB, 3.58% gc time)

julia> for n in 4_100_000:50_000:4_250_000
           a = Dict(k => true for k in 1:n)
           b = Dict(-k => true for k in 1:n)
           print("n = $n: ")
           @time merge(a, b)
       end
n = 4100000:   0.282340 seconds (102.46 k allocations: 245.687 MiB, 6.91% gc time, 11.79% compilation time)
n = 4150000:   0.232964 seconds (19 allocations: 240.001 MiB)
n = 4200000:   0.229429 seconds (19 allocations: 240.001 MiB)
n = 4250000:   0.224806 seconds (19 allocations: 240.001 MiB)
```