### PR TITLE
WIP: Semi-concrete IR interpreter

### DIFF
--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -131,6 +131,10 @@ include("compiler/methodtable.jl")
 include("compiler/inferenceresult.jl")
 include("compiler/inferencestate.jl")
 
+include("compiler/ssair/basicblock.jl")
+include("compiler/ssair/domtree.jl")
+include("compiler/ssair/ir.jl")
+
 include("compiler/typeutils.jl")
 include("compiler/typelimits.jl")
 include("compiler/typelattice.jl")
@@ -139,7 +143,7 @@ include("compiler/stmtinfo.jl")
 
 include("compiler/abstractinterpretation.jl")
 include("compiler/typeinfer.jl")
-include("compiler/optimize.jl") # TODO: break this up further + extract utilities
+include("compiler/optimize.jl")
 
 # required for bootstrap
 # TODO: find why this is needed and remove it.

--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -16,6 +16,36 @@ function is_forwardable_argtype(@nospecialize x)
            isa(x, PartialOpaque)
 end
 
+function va_process_argtypes(given_argtypes::Vector{Any}, mi::MethodInstance,
+                             condargs::Union{Vector{Tuple{Int,Int}}, Nothing}=nothing)
+    isva = mi.def.isva
+    nargs = Int(mi.def.nargs)
+    if isva || isvarargtype(given_argtypes[end])
+        isva_given_argtypes = Vector{Any}(undef, nargs)
+        for i = 1:(nargs - isva)
+            isva_given_argtypes[i] = argtype_by_index(given_argtypes, i)
+        end
+        if isva
+            if length(given_argtypes) < nargs && isvarargtype(given_argtypes[end])
+                last = length(given_argtypes)
+            else
+                last = nargs
+            end
+            isva_given_argtypes[nargs] = tuple_tfunc(given_argtypes[last:end])
+            # invalidate `Conditional` imposed on varargs
+            if condargs !== nothing
+                for (slotid, i) in condargs
+                    if slotid ≥ last
+                        isva_given_argtypes[i] = widenconditional(isva_given_argtypes[i])
+                    end
+                end
+            end
+        end
+        return isva_given_argtypes
+    end
+    return given_argtypes
+end
+
 # In theory, there could be a `cache` containing a matching `InferenceResult`
 # for the provided `linfo` and `given_argtypes`. The purpose of this function is
 # to return a valid value for `cache_lookup(linfo, argtypes, cache).argtypes`,
@@ -55,30 +85,7 @@ function matching_cache_argtypes(
         end
         given_argtypes[i] = widenconditional(argtype)
     end
-    isva = linfo.def.isva
-    if isva || isvarargtype(given_argtypes[end])
-        isva_given_argtypes = Vector{Any}(undef, nargs)
-        for i = 1:(nargs - isva)
-            isva_given_argtypes[i] = argtype_by_index(given_argtypes, i)
-        end
-        if isva
-            if length(given_argtypes) < nargs && isvarargtype(given_argtypes[end])
-                last = length(given_argtypes)
-            else
-                last = nargs
-            end
-            isva_given_argtypes[nargs] = tuple_tfunc(given_argtypes[last:end])
-            # invalidate `Conditional` imposed on varargs
-            if condargs !== nothing
-                for (slotid, i) in condargs
-                    if slotid ≥ last
-                        isva_given_argtypes[i] = widenconditional(isva_given_argtypes[i])
-                    end
-                end
-            end
-        end
-        given_argtypes = isva_given_argtypes
-    end
+    given_argtypes = va_process_argtypes(given_argtypes, linfo, condargs)
     @assert length(given_argtypes) == nargs
     for i in 1:nargs
         given_argtype = given_argtypes[i]

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -82,6 +82,12 @@ function in(idx::Int, bsbmp::BitSetBoundedMinPrioritySet)
     return idx in bsbmp.elems
 end
 
+function append!(bsbmp::BitSetBoundedMinPrioritySet, itr)
+    for val in itr
+        push!(bsbmp, val)
+    end
+end
+
 mutable struct InferenceState
     params::InferenceParams
     result::InferenceResult # remember where to put the result

--- a/base/compiler/ssair/EscapeAnalysis/EscapeAnalysis.jl
+++ b/base/compiler/ssair/EscapeAnalysis/EscapeAnalysis.jl
@@ -31,7 +31,8 @@ import Core.Compiler: # Core.Compiler specific definitions
     isbitstype, isexpr, is_meta_expr_head, println, widenconst, argextype, singleton_type,
     fieldcount_noerror, try_compute_field, try_compute_fieldidx, hasintersect, ⊑,
     intrinsic_nothrow, array_builtin_common_typecheck, arrayset_typecheck,
-    setfield!_nothrow, alloc_array_ndims, stmt_effect_free, check_effect_free!
+    setfield!_nothrow, alloc_array_ndims, stmt_effect_free, check_effect_free!,
+    SemiConcreteResult
 
 include(x) = _TOP_MOD.include(@__MODULE__, x)
 if _TOP_MOD === Core.Compiler

--- a/base/compiler/ssair/EscapeAnalysis/interprocedural.jl
+++ b/base/compiler/ssair/EscapeAnalysis/interprocedural.jl
@@ -6,7 +6,7 @@ import Core.Compiler:
     call_sig, argtypes_to_type, is_builtin, is_return_type, istopfunction, validate_sparams,
     specialize_method, invoke_rewrite
 
-const Linfo = Union{MethodInstance,InferenceResult}
+const Linfo = Union{MethodInstance,InferenceResult,SemiConcreteResult}
 struct CallInfo
     linfos::Vector{Linfo}
     nothrow::Bool

--- a/base/compiler/ssair/driver.jl
+++ b/base/compiler/ssair/driver.jl
@@ -13,12 +13,10 @@ function stmt_effect_free end # imported by EscapeAnalysis
 function alloc_array_ndims end # imported by EscapeAnalysis
 function try_compute_field end # imported by EscapeAnalysis
 
-include("compiler/ssair/basicblock.jl")
-include("compiler/ssair/domtree.jl")
-include("compiler/ssair/ir.jl")
 include("compiler/ssair/slot2ssa.jl")
 include("compiler/ssair/inlining.jl")
 include("compiler/ssair/verify.jl")
 include("compiler/ssair/legacy.jl")
 include("compiler/ssair/EscapeAnalysis/EscapeAnalysis.jl")
 include("compiler/ssair/passes.jl")
+include("compiler/ssair/irinterp.jl")

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1281,6 +1281,8 @@ function handle_const_call!(
                 push!(cases, InliningCase(result.mi.specTypes, case))
             elseif isa(result, InferenceResult)
                 handled_all_cases &= handle_inf_result!(result, argtypes, flag, state, cases)
+            elseif isa(result, SemiConcreteResult)
+                handled_all_cases &= handle_semi_concrete_result!(result, cases)
             else
                 @assert result === nothing
                 handled_all_cases &= handle_match!(match, argtypes, flag, state, cases)
@@ -1294,8 +1296,13 @@ function handle_const_call!(
     if length(cases) == 0
         length(results) == 1 || return nothing
         result = results[1]
-        isa(result, InferenceResult) || return nothing
-        handle_inf_result!(result, argtypes, flag, state, cases, true) || return nothing
+        if isa(result, InferenceResult)
+            handle_inf_result!(result, argtypes, flag, state, cases, true) || return nothing
+        elseif isa(result, SemiConcreteResult)
+            handle_semi_concrete_result!(result, cases) || return nothing
+        else
+            return nothing
+        end
         spec_types = cases[1].sig
         any_covers_full = handled_all_cases = atype <: spec_types
     end
@@ -1325,6 +1332,15 @@ function handle_inf_result!(
     state.mi_cache !== nothing && (item = resolve_todo(item, state, flag))
     item === nothing && return false
     push!(cases, InliningCase(spec_types, item))
+    return true
+end
+
+function handle_semi_concrete_result!(result::SemiConcreteResult, cases::Vector{InliningCase}, allow_abstract::Bool = false)
+    mi = result.mi
+    spec_types = mi.specTypes
+    allow_abstract || isdispatchtuple(spec_types) || return false
+    validate_sparams(mi.sparam_vals) || return false
+    push!(cases, InliningCase(spec_types, InliningTodo(mi, result.ir, result.effects)))
     return true
 end
 

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1030,15 +1030,22 @@ function renumber_ssa2!(@nospecialize(stmt), ssanums::Vector{Any}, used_ssas::Ve
 end
 
 # Used in inlining before we start compacting - Only works at the CFG level
-function kill_edge!(bbs::Vector{BasicBlock}, from::Int, to::Int)
+function kill_edge!(bbs::Vector{BasicBlock}, from::Int, to::Int, callback=nothing)
     preds, succs = bbs[to].preds, bbs[from].succs
     deleteat!(preds, findfirst(x->x === from, preds)::Int)
     deleteat!(succs, findfirst(x->x === to, succs)::Int)
     if length(preds) == 0
         for succ in copy(bbs[to].succs)
-            kill_edge!(bbs, to, succ)
+            kill_edge!(bbs, to, succ, callback)
         end
     end
+    if callback !== nothing
+        callback(from, to)
+    end
+end
+
+function kill_edge!(ir::IRCode, from::Int, to::Int, callback=nothing)
+    kill_edge!(ir.cfg.blocks, from, to, callback)
 end
 
 # N.B.: from and to are non-renamed indices

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -1,0 +1,405 @@
+
+function codeinst_to_ir(interp::AbstractInterpreter, code::CodeInstance)
+    src = code.inferred
+    mi = code.def
+
+    src === nothing && return src
+
+    if !isa(src, CodeInfo)
+        src = ccall(:jl_uncompress_ir, Any, (Any, Ptr{Cvoid}, Any), mi.def, C_NULL, src::Vector{UInt8})::CodeInfo
+    end
+
+    return inflate_ir(src, mi)
+end
+
+function tristate_merge!(ir::IRCode, e::Effects)
+    nothing
+end
+
+function collect_const_args2(argtypes::Vector{Any})
+    return Any[ let a = widenconditional(argtypes[i])
+                    isa(a, Const) ? a.val :
+                    isconstType(a) ? (a::DataType).parameters[1] :
+                    (a::DataType).instance
+                end for i in 1:length(argtypes) ]
+end
+
+function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
+                                  arginfo::ArgInfo, @nospecialize(atype),
+                                  sv::IRCode, max_methods::Int)
+    return CallMeta(Any, false, Effects())
+end
+
+mutable struct TwoPhaseVectorView <: AbstractVector{Int}
+    const data::Vector{Int}
+    count::Int
+    const range::UnitRange{Int}
+end
+size(tpvv::TwoPhaseVectorView) = (tpvv.count,)
+function getindex(tpvv::TwoPhaseVectorView, i::Int)
+    checkbounds(tpvv, i)
+    @inbounds tpvv.data[first(tpvv.range) + i - 1]
+end
+function push!(tpvv::TwoPhaseVectorView, v::Int)
+    tpvv.count += 1
+    tpvv.data[first(tpvv.range) + tpvv.count - 1] = v
+    return nothing
+end
+
+"""
+    mutable struct TwoPhaseDefUseMap
+
+This struct is intended as a memory- and GC-pressure-efficient mechanism
+for incrementally computing def-use maps. The idea is that the def-use map
+is constructed into two passes over the IR. In the first, we simply count the
+the number of uses, computing the number of uses for each def as well as the
+total number of uses. In the second pass, we actually fill in the def-use
+information.
+
+The idea is that either of these two phases can be combined with other useful
+work that needs to scan the instruction stream anyway, while avoiding the
+significant allocation pressure of e.g. allocating an array for every SSA value
+or attempting to dynamically move things around as new uses are discovered.
+
+The def-use map is presented as a vector of vectors. For every def, indexing
+into the map will return a vector of uses.
+"""
+mutable struct TwoPhaseDefUseMap <: AbstractVector{TwoPhaseVectorView}
+    ssa_uses::Vector{Int}
+    data::Vector{Int}
+    complete::Bool
+end
+
+function complete!(tpdum::TwoPhaseDefUseMap)
+    cumsum = 0
+    for i = 1:length(tpdum.ssa_uses)
+        this_val = cumsum + 1
+        cumsum += tpdum.ssa_uses[i]
+        tpdum.ssa_uses[i] = this_val
+    end
+    resize!(tpdum.data, cumsum)
+    fill!(tpdum.data, 0)
+    tpdum.complete = true
+end
+
+function TwoPhaseDefUseMap(nssas::Int)
+    TwoPhaseDefUseMap(zeros(Int, nssas),
+        Int[], false)
+end
+
+function count!(tpdum::TwoPhaseDefUseMap, arg::SSAValue)
+    @assert !tpdum.complete
+    tpdum.ssa_uses[arg.id] += 1
+end
+
+function kill_def_use!(tpdum::TwoPhaseDefUseMap, def::Int, use::Int)
+    if !tpdum.complete
+        tpdum.ssa_uses[def] -= 1
+    else
+        @assert false && "TODO"
+    end
+end
+kill_def_use!(tpdum::TwoPhaseDefUseMap, def::SSAValue, use::Int) =
+    kill_def_use!(tpdum::TwoPhaseDefUseMap, def.id, use)
+
+function getindex(tpdum::TwoPhaseDefUseMap, idx::Int)
+    @assert tpdum.complete
+    range = tpdum.ssa_uses[idx]:(idx == length(tpdum.ssa_uses) ? length(tpdum.data) : (tpdum.ssa_uses[idx + 1] - 1))
+    # TODO: Make logarithmic
+    nelems = 0
+    for i in range
+        tpdum.data[i] == 0 && break
+        nelems += 1
+    end
+    return TwoPhaseVectorView(tpdum.data, nelems, range)
+end
+
+function reprocess_instruction!(interp::AbstractInterpreter, ir::IRCode, mi_cache,
+                                frame::InferenceState,
+                                tpdum::TwoPhaseDefUseMap, idx::Int, bb::Union{Int, Nothing},
+                                @nospecialize(inst), @nospecialize(typ),
+                                phi_revisit)
+    isnothrow = false
+
+    function update_phi!(from, to)
+        if length(ir.cfg.blocks[to].preds) == 0
+            return
+        end
+        for idx in ir.cfg.blocks[to].stmts
+            stmt = ir.stmts[idx][:inst]
+            isa(stmt, Nothing) && continue
+            isa(stmt, PhiNode) || break
+            for (i, edge) in enumerate(stmt.edges)
+                if edge == from
+                    deleteat!(stmt.edges, i)
+                    deleteat!(stmt.values, i)
+                    push!(phi_revisit, idx)
+                    break
+                end
+            end
+        end
+    end
+
+    if isa(inst, GotoIfNot)
+        cond = argextype(inst.cond, ir)
+        if isa(cond, Const)
+            if isa(inst.cond, SSAValue)
+                kill_def_use!(tpdum, inst.cond, idx)
+            end
+            if bb === nothing
+                bb = block_for_inst(ir, idx)
+            end
+            if (cond.val)::Bool
+                ir.stmts[idx][:inst] = nothing
+                kill_edge!(ir, bb, inst.dest, update_phi!)
+            else
+                ir.stmts[idx][:inst] = GotoNode(inst.dest)
+                kill_edge!(ir, bb, bb+1, update_phi!)
+            end
+            return true
+        end
+        return false
+    else
+        if isa(inst, Expr) || isa(inst, PhiNode)
+            if isa(inst, PhiNode) || inst.head === :call || inst.head === :new
+                if isa(inst, PhiNode)
+                    rt = abstract_eval_phi(interp, inst, nothing, ir)
+                else
+                    (;rt, effects) = abstract_eval_statement_expr(interp, inst, nothing, ir)
+                    # All other effects already guaranteed effect free by construction
+                    if effects.nothrow === ALWAYS_TRUE
+                        ir.stmts[idx][:flag] |= IR_FLAG_EFFECT_FREE
+                    end
+                end
+                if !(typ ⊑ rt)
+                    ir.stmts[idx][:type] = rt
+                    return true
+                end
+            elseif inst.head === :invoke
+                mi′ = inst.args[1]
+                argtypes = collect_argtypes(interp, inst.args[2:end], nothing, ir)
+                code = get(mi_cache, mi′, nothing)
+                if code !== nothing
+                    effects = decode_effects(code.ipo_purity_bits)
+                    if is_total_or_error(effects) && is_all_const_arg(argtypes)
+                        args = collect_const_args2(argtypes)
+                        try
+                            value = Core._call_in_world_total(get_world_counter(interp), args...)
+                            if is_inlineable_constant(value) || call_result_unused(sv)
+                                # If the constant is not inlineable, still do the const-prop, since the
+                                # code that led to the creation of the Const may be inlineable in the same
+                                # circumstance and may be optimizable.
+                                rr = Const(value)
+                            end
+                            isnothrow = true
+                        catch
+                            rr = Union{}
+                        end
+                    else
+                        ir′ = codeinst_to_ir(interp, code)
+                        if ir′ !== nothing
+                            rr = ir_abstract_constant_propagation(interp, mi_cache, frame, mi′, ir′, argtypes)
+                        else
+                            rr = typ
+                        end
+                    end
+                    if !(typ ⊑ rr)
+                        ir.stmts[idx][:type] = rr
+                        return true
+                    end
+                end
+            else
+                ccall(:jl_, Cvoid, (Any,), inst)
+                error()
+            end
+        elseif isa(inst, ReturnNode)
+            # Handled at the very end
+            return false
+        elseif isa(inst, PiNode)
+            rr = tmeet(argextype(inst.val, ir), inst.typ)
+            if !(typ ⊑ rr)
+                ir.stmts[idx][:type] = rr
+                return true
+            end
+        else
+            ccall(:jl_, Cvoid, (Any,), inst)
+            error()
+        end
+    end
+    return false
+end
+
+function _ir_abstract_constant_propagation(interp::AbstractInterpreter, mi_cache, frame::InferenceState, mi::MethodInstance, ir, argtypes)
+    argtypes = va_process_argtypes(argtypes, mi)
+    argtypes_refined = Bool[!(ir.argtypes[i] ⊑ argtypes[i]) for i = 1:length(argtypes)]
+    empty!(ir.argtypes)
+    append!(ir.argtypes, argtypes)
+    ssa_refined = BitSet()
+
+    ultimate_rt = Union{}
+    bbs = ir.cfg.blocks
+    ip = BitSetBoundedMinPrioritySet(length(bbs))
+    push!(ip, 1)
+    all_rets = Int[]
+
+    tpdum = TwoPhaseDefUseMap(length(ir.stmts))
+
+    """
+        process_terminator!
+
+    Process the terminator and add the successor to `ip`. Returns whether a
+    backedge was seen.
+    """
+    function process_terminator!(ip, bb, idx)
+        inst = ir.stmts[idx][:inst]
+        if isa(inst, ReturnNode)
+            if isdefined(inst, :val)
+                push!(all_rets, idx)
+            end
+            return false
+        elseif isa(inst, GotoNode)
+            backedge = inst.label < bb
+            !backedge && push!(ip, inst.label)
+            return backedge
+        elseif isa(inst, GotoIfNot)
+            backedge = inst.dest < bb
+            !backedge && push!(ip, inst.dest)
+            push!(ip, bb + 1)
+            return backedge
+        elseif isexpr(inst, :enter)
+            dest = inst.args[1]::Int
+            @assert dest > bb
+            push!(ip, dest)
+            push!(ip, bb + 1)
+            return false
+        else
+            push!(ip, bb + 1)
+            return false
+        end
+    end
+
+    # Fast path: Scan both use counts and refinement in one single pass of
+    #            of the instructions. In the absence of backedges, this will
+    #            converge.
+    while !isempty(ip)
+        bb = popfirst!(ip)
+        stmts = bbs[bb].stmts
+        lstmt = last(stmts)
+        for idx = stmts
+            inst = ir.stmts[idx][:inst]
+            typ = ir.stmts[idx][:type]
+            any_refined = false
+            for ur in userefs(inst)
+                val = ur[]
+                if isa(val, Argument)
+                    any_refined |= argtypes_refined[val.n]
+                elseif isa(val, SSAValue)
+                    any_refined |= val.id in ssa_refined
+                    count!(tpdum, val)
+                end
+            end
+            if isa(inst, PhiNode) && idx in ssa_refined
+                any_refined = true
+                delete!(ssa_refined, idx)
+            end
+            if any_refined && reprocess_instruction!(interp, ir, mi_cache,
+                    frame, tpdum, idx, bb, inst, typ, ssa_refined)
+                push!(ssa_refined, idx)
+            end
+            if idx == lstmt && process_terminator!(ip, bb, idx)
+                @goto residual_scan
+            end
+            if ir.stmts[idx][:type] === Bottom
+                break
+            end
+        end
+    end
+    @goto compute_rt
+
+@label residual_scan
+    stmt_ip = BitSetBoundedMinPrioritySet(length(ir.stmts))
+    # Slow Path Phase 1.A: Complete use scanning
+    while !isempty(ip)
+        bb = popfirst!(ip)
+        stmts = bbs[bb].stmts
+        lstmt = last(stmts)
+        for idx = stmts
+            inst = ir.stmts[idx][:inst]
+            typ = ir.stmts[idx][:type]
+            for ur in userefs(inst)
+                val = ur[]
+                if isa(val, Argument)
+                    if argtypes_refined[val.n]
+                        push!(stmt_ip, idx)
+                    end
+                elseif isa(val, SSAValue)
+                    count!(tpdum, val)
+                end
+            end
+            idx == lstmt && process_terminator!(ip, bb, idx)
+        end
+    end
+
+    # Slow Path Phase 1.B: Assemble def-use map
+    complete!(tpdum)
+    push!(ip, 1)
+    while !isempty(ip)
+        bb = popfirst!(ip)
+        stmts = bbs[bb].stmts
+        lstmt = last(stmts)
+        for idx = stmts
+            inst = ir.stmts[idx][:inst]
+            typ = ir.stmts[idx][:type]
+            for ur in userefs(inst)
+                val = ur[]
+                if isa(val, SSAValue)
+                    push!(tpdum[val.id], idx)
+                end
+            end
+            idx == lstmt && process_terminator!(ip, bb, idx)
+        end
+    end
+
+    # Slow Path Phase 2: Use def-use map to converge cycles.
+    # TODO: It would be possible to return to the fast path after converging
+    #       each cycle, but that's somewhat complicated.
+    for val in ssa_refined
+        append!(stmt_ip, tpdum[val])
+    end
+
+    while !isempty(stmt_ip)
+        idx = popfirst!(stmt_ip)
+        inst = ir.stmts[idx][:inst]
+        typ = ir.stmts[idx][:type]
+        if reprocess_instruction!(interp, ir, mi_cache, frame,
+                tpdum, idx, nothing, inst, typ, ssa_refined)
+            append!(stmt_ip, tpdum[idx])
+        end
+    end
+
+@label compute_rt
+    ultimate_rt = Union{}
+    for idx in all_rets
+        bb = block_for_inst(ir.cfg, idx)
+        if bb != 1 && length(ir.cfg.blocks[bb].preds) == 0
+            # Could have discovered this block is dead after the initial scan
+            continue
+        end
+        inst = ir.stmts[idx][:inst]
+        ultimate_rt = tmerge(ultimate_rt, argextype(inst.val, ir))
+    end
+    return ultimate_rt
+end
+
+function ir_abstract_constant_propagation(interp::AbstractInterpreter, mi_cache, frame::InferenceState, mi::MethodInstance, ir, argtypes)
+    if __measure_typeinf__[]
+        inf_frame = Timings.InferenceFrameInfo(mi, frame.world, Any[], Any[], length(ir.argtypes))
+        Timings.enter_new_timer(inf_frame)
+        v = _ir_abstract_constant_propagation(interp, mi_cache, frame, mi, ir, argtypes)
+        append!(inf_frame.slottypes, ir.argtypes)
+        Timings.exit_current_timer(inf_frame)
+        return v
+    else
+        return _ir_abstract_constant_propagation(interp, mi_cache, frame, mi, ir, argtypes)
+    end
+end

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -11,6 +11,7 @@ and any additional information (`call.info`) for a given generic call.
 struct CallMeta
     rt::Any
     info::Any
+    effects::Effects
 end
 
 """
@@ -54,6 +55,12 @@ struct ConstResult
     ConstResult(mi::MethodInstance, @nospecialize val) = new(mi, val)
 end
 
+struct SemiConcreteResult
+    mi::MethodInstance
+    ir::IRCode
+    effects::Effects
+end
+
 """
     info::ConstCallInfo
 
@@ -63,7 +70,7 @@ the inference results with constant information `info.results::Vector{Union{Noth
 """
 struct ConstCallInfo
     call::Union{MethodMatchInfo,UnionSplitInfo}
-    results::Vector{Union{Nothing,InferenceResult,ConstResult}}
+    results::Vector{Union{Nothing,InferenceResult,SemiConcreteResult,ConstResult}}
 end
 
 """
@@ -129,7 +136,7 @@ Optionally keeps `info.result::InferenceResult` that keeps constant information.
 """
 struct InvokeCallInfo
     match::MethodMatch
-    result::Union{Nothing,InferenceResult,ConstResult}
+    result::Union{Nothing,InferenceResult,ConstResult,SemiConcreteResult}
 end
 
 """
@@ -141,7 +148,7 @@ Optionally keeps `info.result::InferenceResult` that keeps constant information.
 """
 struct OpaqueClosureCallInfo
     match::MethodMatch
-    result::Union{Nothing,InferenceResult,ConstResult}
+    result::Union{Nothing,InferenceResult,ConstResult,SemiConcreteResult}
 end
 
 """

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -240,6 +240,15 @@ function singleton_type(@nospecialize(ft))
     return nothing
 end
 
+function maybe_singleton_const(@nospecialize(t))
+    if isa(t, DataType) && isdefined(t, :instance)
+        return Const(t.instance)
+    elseif isconstType(t)
+        return Const(t.parameters[1])
+    end
+    return t
+end
+
 ###################
 # SSAValues/Slots #
 ###################

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -688,6 +688,12 @@ struct Colon <: Function
 end
 const (:) = Colon()
 
+# TODO: Change lowering to do this automatically
+@eval struct Val{x}
+    (T::Type{Val{x}} where x)() = $(Expr(:new, :T))
+end
+
+
 """
     Val(c)
 
@@ -708,8 +714,7 @@ julia> f(Val(true))
 "Good"
 ```
 """
-struct Val{x}
-end
+Val
 
 Val(x) = Val{x}()
 

--- a/test/compiler/EscapeAnalysis/EAUtils.jl
+++ b/test/compiler/EscapeAnalysis/EAUtils.jl
@@ -72,7 +72,8 @@ import Core:
 import .CC:
     InferenceResult, OptimizationState, IRCode, copy as cccopy,
     @timeit, convert_to_ircode, slot2reg, compact!, ssa_inlining_pass!, sroa_pass!,
-    adce_pass!, type_lift_pass!, JLOptions, verify_ir, verify_linetable
+    adce_pass!, type_lift_pass!, JLOptions, verify_ir, verify_linetable,
+    SemiConcreteResult
 import .EA: analyze_escapes, ArgEscapeCache, EscapeInfo, EscapeState, is_ipo_profitable
 
 # when working outside of Core.Compiler,
@@ -188,8 +189,10 @@ function cache_escapes!(interp::EscapeAnalyzer,
 end
 
 function get_escape_cache(interp::EscapeAnalyzer)
-    return function (linfo::Union{InferenceResult,MethodInstance})
+    return function (linfo::Union{InferenceResult,MethodInstance,SemiConcreteResult})
         if isa(linfo, InferenceResult)
+            ecache = get(interp.cache, linfo, nothing)
+        elseif isa(linfo, SemiConcreteResult)
             ecache = get(interp.cache, linfo, nothing)
         else
             ecache = get(GLOBAL_ESCAPE_CACHE, linfo, nothing)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4073,3 +4073,13 @@ end
     Base.Experimental.@force_compile
     Core.Compiler.return_type(+, NTuple{2, Rational})
 end == Rational
+
+# Test that semi-concrete interpretation doesn't break on functions with while loops in them.
+@Base.assume_effects :consistent :effect_free :terminates_globally function pure_annotated_loop(x::Int, y::Int)
+    for i = 1:2
+        x += y
+    end
+    return y
+end
+call_pure_annotated_loop(x) = Val{pure_annotated_loop(x, 1)}()
+@test Core.Compiler.return_type(call_pure_annotated_loop, Tuple{Int}) == Val{1}


### PR DESCRIPTION
# Background

in #43852, the compiler learned how to make use of the codegen'd version of a function in order to speed up constant propagation by 1000x, assuming two conditions are fulfilled:
1. All arguments are known to be constant at inference time
2. The evaluation is legal according to appropriate effect conditions

This mechanism works well, but leaves some very sharp performance edges in inference. For example, adding an unused argument to an otherwise consteval-eligible function will fall back to inference-based constant propagation and thus incur the 1000x penalty (even though the argument is entirely unused).

This PR attempts to address this by adding a new middle-of-the-road fallback that sits between the super fast constant, concrete evaluation from #43852 and the original inference based constant propagation.

# This PR
The core idea is to use inference's existing abstract interpretation lattice, but rather than performing abstract interpretation over untyped source, we perform it over the typed/optimized julia IR that the non-constant inference pass produced.

Now, this is not legal to do in general, but the `:consistent` and `:terminates_globally` effects from #43852, do ensure legality (in the currently implementation we additionally require `:effect_free` for consistency with consteval, but that could be easily relaxed).

# Why is this a good idea
The are several benefits to performing abstract evaluation over optimized IR rather than untyped IR:

1. We do not need to perform any method lookups and thus can also avoid inference's relatively complicated tracking of potential recursions. Method lookups were performed during the non-constant inference pass and the `:termiantes_globally` effect ensures the absence of recursion (at least when proven by the compiler - the property I documented for manual annotation is slightly too weak than what we need, so we may need to split out these effects).

2. Optimized IR is likely to be smaller (in terms of total number of instructions that need to be visited for a given set of input arguments) because some optimizations/simplification/DCE have been performed.

3. Optimized IR does not have any slots in it, so we avoid #43999-like problems around inference memory usage.

4. The same optimized IR can be re-used many times for different sets of constants.

# Threats to validity
Now, there are some challenges also. For one, it is not guaranteed that this will have the same precision as the inference-based constant propagation. I've done some testing here and precision is decent, but there are some cases where precision is worse than the inference-based constant propagation:

1. In the current implementation, we never perform any method matching, instead relying on methods annotated in `:invoke` statements. This mostly works, but there are certain situations (e.g. the cases that #44512 is supposed to fix), where we currently cannot produce `:invoke`, even though inference was able to compute a full method match. My preferred solution to this is to extend the semantics of `:invoke` to always make it possible to generate an `:invoke` node when the full method match set is known (even if codegen does not make use of it). However, I haven't really seen this be much of a problem in my testing.

2. There are certain branching patterns that would require the insertion of additional Pi nodes in order to avoid overapproximation of the lattice elements. This is one of the reasons that we currently don't do regular inference on SSA IR (the other being debuggability of lowered code). We've been thinking about some solutions to this, but this particular case is somewhat simpler than inference because 1) the branching patterns that inference can prove `:consistent` are limited anyway 2) regular inference may have already inserted the requisite PiNodes in which case there isn't a problem. In particular, in my testing I haven't actually seen any case of precision regressions due to this issue.

# Benchmark results

The benchmarks for this are looking very attractive. On my ongoing inference torture test (https://gist.github.com/Keno/5587fbfe89bff96c863c8eeb1477defa), this gives an additional 2x improvement in inference time on top of the improvements already merged on master and those pending in #44447 and #44494. I should note that this is total inference time. By the nature of the benchmark, it basically performs inference and constant propagation once for each specialized call site. The 2x improvement here essentially comes down to the constant-propagation portion of that time dropping down to noise level.

The performance is even better on the real world benchmark that motivated https://gist.github.com/Keno/5587fbfe89bff96c863c8eeb1477defa. There constant propagation is performed multiple times with different constants for each non-constant inference, so the performance improvement is proportionally better, to the point where inference time is no longer dominating in that benchmark (down to about 30s from several hours in early January before all the recent compile-time perf improvements).

# Current status

This passes tests for me locally, but I'm convinced that issues will show up during PkgEval. The re-use of the abstract interpreter pieces is also quite janky and should be factored better. 