### PR TITLE
Recommend `@spawn` over `@async`

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -469,7 +469,7 @@ isolating the asynchronous code from changes to the variable's value in the curr
 
 !!! warning
     It is strongly encouraged to favor `Threads.@spawn` over `@async` always **even when no
-    parallelism is required** especially in publicily distributed libraries.  This is
+    parallelism is required** especially in publicly distributed libraries.  This is
     because a use of `@async` disables the migration of the *parent* task across worker
     threads in the current implementation of Julia.  Thus, seemingly innocent use of
     `@async` in a library function can have a large impact on the performance of very

--- a/base/task.jl
+++ b/base/task.jl
@@ -467,6 +467,14 @@ Values can be interpolated into `@async` via `\$`, which copies the value direct
 constructed underlying closure. This allows you to insert the _value_ of a variable,
 isolating the asynchronous code from changes to the variable's value in the current task.
 
+!!! warning
+    It is strongly encouraged to favor `Threads.@spawn` over `@async` always **even when no
+    parallelism is required** especially in publicily distributed libraries.  This is
+    because a use of `@async` disables the migration of the *parent* task across worker
+    threads in the current implementation of Julia.  Thus, seemingly innocent use of
+    `@async` in a library function can have a large impact on the performance of very
+    different parts of user applications.
+
 !!! compat "Julia 1.4"
     Interpolating values via `\$` is available as of Julia 1.4.
 """


### PR DESCRIPTION
Since arbitrary functions can use `@async` as an implementation detail, there's currently almost no way to protect against accidentally disabling migratability of a task. Unless we implement something like #41393 to mitigate this, I suggest recommending `@spawn` over `@async` always. I think this might be what we want to do eventually anyway to push the ecosystem to improve parallelism and concurrency support.
