### PR TITLE
Remove trailing \ from last line of exported function macros

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -514,7 +514,7 @@
     XX(jl_vexceptionf) \
     XX(jl_vprintf) \
     XX(jl_wakeup_thread) \
-    XX(jl_yield) \
+    XX(jl_yield)
 
 #define JL_RUNTIME_EXPORTED_FUNCS_WIN(XX) \
     XX(jl_setjmp)
@@ -569,4 +569,4 @@
     YY(LLVMExtraAddRemoveNIPass) \
     YY(LLVMExtraAddGCInvariantVerifierPass) \
     YY(LLVMExtraAddDemoteFloat16Pass) \
-    YY(LLVMExtraAddCPUFeaturesPass) \
+    YY(LLVMExtraAddCPUFeaturesPass)


### PR DESCRIPTION
The slash shouldn't be included on the last line of the macro, since it tells the compiler the next line should be considered as part of the current macro. This PR removes the slash from the last line of two macros inside `jl_exported_funcs.inc`, which also makes them consistent in style with the macros in the `jl_exported_data.inc` file. This also triggered a GCC warning on my machine because one of them was at the end of the file:

```
    CC cli/loader_lib.o
In file included from /home/imcinerney/dev/julia/main/v1.6/cli/jl_exports.h:6,
                 from /home/imcinerney/dev/julia/main/v1.6/cli/loader_lib.c:10:
/home/imcinerney/dev/julia/main/v1.6/cli/../src/jl_exported_funcs.inc:1:31: warning: backslash-newline at end of file
    1 | #define JL_EXPORTED_FUNCS(XX) \
      |                                
    CC cli/loader_trampolines.o
In file included from /home/imcinerney/dev/julia/main/v1.6/cli/trampolines/trampolines_x86_64.S:2:
/home/imcinerney/dev/julia/main/v1.6/cli/trampolines/../../src/jl_exported_funcs.inc:1:31: warning: backslash-newline at end of file
    1 | #define JL_EXPORTED_FUNCS(XX) \
      |                                
```

Note this warning clean-up is not contained in #44350 already.