### PR TITLE
Also record overriden ipo effects in InferenceState

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -512,7 +512,7 @@ function finish(me::InferenceState, interp::AbstractInterpreter)
             ipo_effects = Effects(ipo_effects; terminates=ALWAYS_TRUE)
         end
     end
-    me.result.ipo_effects = ipo_effects
+    me.ipo_effects = me.result.ipo_effects = ipo_effects
     validate_code_in_debug_mode(me.linfo, me.src, "inferred")
     nothing
 end


### PR DESCRIPTION
Otherwise the first time a new method is inferred, `typeinf_edge` will
not respect the override, leading to lots of confusion.