### PR TITLE
Add indirection in == fallback

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -116,7 +116,13 @@ include("range.jl")
 include("error.jl")
 
 # core numeric operations & types
-==(x, y) = x === y
+unwrap_isequal(x) = x
+function ==(x, y)
+    ux = unwrap_isequal(x)
+    uy = unwrap_isequal(y)
+    ux === x && uy === y && return x === y
+    return ux == uy
+end
 include("bool.jl")
 include("number.jl")
 include("int.jl")

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -1,8 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-==(w::WeakRef, v::WeakRef) = isequal(w.value, v.value)
-==(w::WeakRef, v) = isequal(w.value, v)
-==(w, v::WeakRef) = isequal(w, v.value)
+unwrap_isequal(w::WeakRef) = w.value
 
 """
     finalizer(f, x)


### PR DESCRIPTION
The fallback for `==` just calls `===`. However, we also have types
like `WeakRef` that add three specializations of `==` that just
unwrap the `WeakRef`. It turns out this pattern is also used in
packages, and one of them, ChainRulesCore, has >2300 dependent
packages as of now. Unfortunately, when ChainRulesCore is loaded,
it invalidates code that calls `==` on `WeakRef`. This includes
much of the Serialization stdlib.

Since I have a personal goal of getting Makie's TTFP to less than one second (see #44527), and I recently learned from @SimonDanisch that Makie uses the Serialization stdlib, I will need to find a way to fix this.

This addresses the problem by defining the notion of "unwrapping
for ==" by introducing the non-exported function `unwrap_isequal`.
The fallback is just

```
unwrap_isequal(x) = x
```

but one can add specializations.

Now, the obvious concern about this implementation is that it may hurt performance. In cases of concrete inference it might have no impact, as something that uses the fallback like
```julia
julia> struct M
           x::Int
       end

julia> @code_llvm M(2) == M(2)
```
produces the same code before and after. However, `@code_typed` shows that the extra steps are not entirely DCEd:
```julia
julia> @code_typed M(2) == M(2)
CodeInfo(
1 ─ %1 = (x === x)::Bool
└──      goto #5 if not %1
2 ─ %3 = (y === y)::Bool
└──      goto #4 if not %3
3 ─ %5 = (x === y)::Bool
└──      return %5
4 ─      nothing::Nothing
5 ┄ %8 = invoke Base.:(==)(x::M, y::M)::Bool
└──      return %8
) => Bool
```
and so this might affect inlining. Moreover, there is also a chance for a performance regression in poorly-inferred code. So benchmarks are crucial: @nanosoldier `runbenchmarks(ALL, vs=":master")`.

To show that this fixes the problem, on master:
```julia
julia> using SnoopCompileCore

julia> invs = @snoopr using ChainRulesCore;

julia> using SnoopCompile
[ Info: Precompiling SnoopCompile [aa65fe97-06da-5843-b5b1-d5d13cad87d2]

julia> trees = invalidation_trees(invs)
4-element Vector{SnoopCompile.MethodInvalidations}:
 inserting *(::Any, ::ZeroTangent) in ChainRulesCore at /home/tim/.julia/packages/ChainRulesCore/IzITE/src/tangent_arithmetic.jl:105 invalidated:
   mt_backedges: 1: signature Tuple{typeof(*), String, Any} triggered MethodInstance for (::Test.var"#7#9")(::Any) (0 children)
                 2: signature Tuple{typeof(*), String, Any} triggered MethodInstance for (::Test.var"#8#10")(::Any) (0 children)
   12 mt_cache

 inserting convert(::Type{<:Thunk}, a::AbstractZero) in ChainRulesCore at /home/tim/.julia/packages/ChainRulesCore/IzITE/src/tangent_types/thunks.jl:205 invalidated:
   backedges: 1: superseding convert(::Type{Union{}}, x) in Base at essentials.jl:213 with MethodInstance for convert(::Core.TypeofBottom, ::Any) (1 children)
   15 mt_cache

 inserting ==(a::AbstractThunk, b) in ChainRulesCore at /home/tim/.julia/packages/ChainRulesCore/IzITE/src/tangent_types/thunks.jl:28 invalidated:
   backedges: 1: superseding ==(x, y) in Base at Base.jl:119 with MethodInstance for ==(::Any, ::Task) (4 children)
              2: superseding ==(x, y) in Base at Base.jl:119 with MethodInstance for ==(::Any, ::Base.UUID) (9 children)
              3: superseding ==(x, y) in Base at Base.jl:119 with MethodInstance for ==(::Any, ::FileWatching._FDWatcher) (22 children)

 inserting ==(a, b::AbstractThunk) in ChainRulesCore at /home/tim/.julia/packages/ChainRulesCore/IzITE/src/tangent_types/thunks.jl:29 invalidated:
   backedges: 1: superseding ==(x, y) in Base at Base.jl:119 with MethodInstance for ==(::Base.UUID, ::Any) (6 children)
              2: superseding ==(x, y) in Base at Base.jl:119 with MethodInstance for ==(::Module, ::Any) (12 children)
              3: superseding ==(x, y) in Base at Base.jl:119 with MethodInstance for ==(::Method, ::Any) (24 children)
              4: superseding ==(x, y) in Base at Base.jl:119 with MethodInstance for ==(::Symbol, ::Any) (46 children)
              5: superseding ==(x, y) in Base at Base.jl:119 with MethodInstance for ==(::Core.TypeName, ::Any) (124 children)


julia> tree = trees[end]
inserting ==(a, b::AbstractThunk) in ChainRulesCore at /home/tim/.julia/packages/ChainRulesCore/IzITE/src/tangent_types/thunks.jl:29 invalidated:
   backedges: 1: superseding ==(x, y) in Base at Base.jl:119 with MethodInstance for ==(::Base.UUID, ::Any) (6 children)
              2: superseding ==(x, y) in Base at Base.jl:119 with MethodInstance for ==(::Module, ::Any) (12 children)
              3: superseding ==(x, y) in Base at Base.jl:119 with MethodInstance for ==(::Method, ::Any) (24 children)
              4: superseding ==(x, y) in Base at Base.jl:119 with MethodInstance for ==(::Symbol, ::Any) (46 children)
              5: superseding ==(x, y) in Base at Base.jl:119 with MethodInstance for ==(::Core.TypeName, ::Any) (124 children)
```
but with this diff in ChainRulesCore:
```diff
diff --git a/src/tangent_types/thunks.jl b/src/tangent_types/thunks.jl
index 82f2e415..ffd1bdb8 100644
--- a/src/tangent_types/thunks.jl
+++ b/src/tangent_types/thunks.jl
@@ -24,9 +24,13 @@ end
     return element, (underlying_object, new_state)
 end
 
-Base.:(==)(a::AbstractThunk, b::AbstractThunk) = unthunk(a) == unthunk(b)
-Base.:(==)(a::AbstractThunk, b) = unthunk(a) == b
-Base.:(==)(a, b::AbstractThunk) = a == unthunk(b)
+if isdefined(Base, :unwrap_isequal)
+    Base.unwrap_isequal(a::AbstractThunk) = unthunk(a)
+else
+    Base.:(==)(a::AbstractThunk, b::AbstractThunk) = unthunk(a) == unthunk(b)
+    Base.:(==)(a::AbstractThunk, b) = unthunk(a) == b
+    Base.:(==)(a, b::AbstractThunk) = a == unthunk(b)
+end
 
 Base.:(-)(a::AbstractThunk) = -unthunk(a)
 Base.:(-)(a::AbstractThunk, b) = unthunk(a) - b
```
one gets
```julia
julia> trees = invalidation_trees(invs)
2-element Vector{SnoopCompile.MethodInvalidations}:
 inserting *(::Any, ::ZeroTangent) in ChainRulesCore at /home/tim/.julia/dev/ChainRulesCore/src/tangent_arithmetic.jl:105 invalidated:
   mt_backedges: 1: signature Tuple{typeof(*), String, Any} triggered MethodInstance for (::Test.var"#7#9")(::Any) (0 children)
                 2: signature Tuple{typeof(*), String, Any} triggered MethodInstance for (::Test.var"#8#10")(::Any) (0 children)

 inserting convert(::Type{<:Number}, x::ChainRulesCore.NotImplemented) in ChainRulesCore at /home/tim/.julia/dev/ChainRulesCore/src/tangent_types/notimplemented.jl:63 invalidated:
   backedges: 1: superseding convert(::Type{Union{}}, x) in Base at essentials.jl:213 with MethodInstance for convert(::Core.TypeofBottom, ::Any) (1 children)
   24 mt_cache
```
```
