### PR TITLE
ccall: add support for automatic llvmcall mangling

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1935,7 +1935,7 @@ jl_cgval_t function_sig_t::emit_a_ccall(
                 if (!isa<Function>(llvmf) || cast<Function>(llvmf)->isIntrinsic() || cast<Function>(llvmf)->getFunctionType() != functype)
                     llvmf = NULL;
             }
-            else {
+            else if (f_name.startswith("llvm.") {
                 // compute and verify auto-mangling for intrinsic name
                 auto ID = Function::lookupIntrinsicID(f_name);
                 if (ID != Intrinsic::not_intrinsic) {

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1935,7 +1935,7 @@ jl_cgval_t function_sig_t::emit_a_ccall(
                 if (!isa<Function>(llvmf) || cast<Function>(llvmf)->isIntrinsic() || cast<Function>(llvmf)->getFunctionType() != functype)
                     llvmf = NULL;
             }
-            else if (f_name.startswith("llvm.") {
+            else if (f_name.startswith("llvm.")) {
                 // compute and verify auto-mangling for intrinsic name
                 auto ID = Function::lookupIntrinsicID(f_name);
                 if (ID != Intrinsic::not_intrinsic) {

--- a/src/llvm-alloc-opt.cpp
+++ b/src/llvm-alloc-opt.cpp
@@ -517,8 +517,8 @@ void Optimizer::replaceIntrinsicUseWith(IntrinsicInst *call, Intrinsic::ID ID,
         auto res = Intrinsic::matchIntrinsicSignature(newfType, TableRef, overloadTys);
         assert(res == Intrinsic::MatchIntrinsicTypes_Match);
         (void)res;
-        bool matchvararg = Intrinsic::matchIntrinsicVarArg(newfType->isVarArg(), TableRef);
-        assert(!matchvararg);
+        bool matchvararg = !Intrinsic::matchIntrinsicVarArg(newfType->isVarArg(), TableRef);
+        assert(matchvararg);
         (void)matchvararg;
     }
     auto newF = Intrinsic::getDeclaration(call->getModule(), ID, overloadTys);

--- a/test/llvmcall2.jl
+++ b/test/llvmcall2.jl
@@ -37,10 +37,26 @@ function ceilfloor(x::Float64)
 end
 @test ceilfloor(7.4) == 8.0
 
-# support for calling external functions
-begin
-    f() = ccall("time", llvmcall, Cvoid, (Ptr{Cvoid},), C_NULL)
-    @test_throws ErrorException f()
+let err = ErrorException("llvmcall only supports intrinsic calls")
+    # support for calling external functions
+    @test_throws err @eval ccall("time", llvmcall, Cvoid, (Ptr{Cvoid},), C_NULL)
     g() = ccall("extern time", llvmcall, Cvoid, (Ptr{Cvoid},), C_NULL)
     g()
+    @test_throws err @eval ccall("extern llvm.floor", llvmcall, Float64, (Float64,), 0.0)
+
+    # support for mangling
+    @test (@eval ccall("llvm.floor.f64", llvmcall, Float64, (Float64,), 0.0)) === 0.0
+    @test (@eval ccall("llvm.floor", llvmcall, Float64, (Float64,), 0.0),
+                 ccall("llvm.floor", llvmcall, Float32, (Float32,), 0.0)) === (0.0, 0.0f0)
+    @test_throws err @eval ccall("llvm.floor.f64", llvmcall, Float32, (Float64,), 0.0)
+    @test_throws err @eval ccall("llvm.floor.f64", llvmcall, Float32, (Float32,), 0.0f0)
+    @test_throws err @eval ccall("llvm.floor.f64", llvmcall, Float64, (Float32,), 0.0f0)
+    @test_throws err @eval ccall("llvm.floor.f64", llvmcall, Float64, (Int,), 0)
+    @test_throws err @eval ccall("llvm.floor.f64", llvmcall, Int, (Int,), 0)
+    @test_throws err @eval ccall("llvm.floor", llvmcall, Float64, (Float32,), 0.0f0)
+    @test_throws err @eval ccall("llvm.floor", llvmcall, Float64, (Int,), 0)
+    @test_throws err @eval ccall("llvm.floor", llvmcall, Int, (Int,), 0)
+
+    @test_throws err (@eval ccall("llvm.floor.f64", llvmcall, Float64, (Float64, Float64...,), 0.0)) === 0.0
+    @test_throws err (@eval ccall("llvm.floor", llvmcall, Float64, (Float64, Float64...,), 0.0)) === 0.0
 end


### PR DESCRIPTION
Sometimes the mangling changes by version, or is unclear, so we allow that to auto-upgrade here.

Code from llvm-alloc-opt.cpp.
Fix #44694

Always been something I thought it should support/verify. While we won't, in general, fix your mistakes by protecting you from the mistake of using ccall or llvmcall. I think this is something that makes sense.