### PR TITLE
cache `Type{wrapper}` for faster lookups

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -69,6 +69,7 @@ JL_DLLEXPORT jl_typename_t *jl_new_typename_in(jl_sym_t *name, jl_module_t *modu
     tn->name = name;
     tn->module = module;
     tn->wrapper = NULL;
+    jl_atomic_store_release(&tn->Typeofwrapper, NULL);
     jl_atomic_store_relaxed(&tn->cache, jl_emptysvec);
     jl_atomic_store_relaxed(&tn->linearcache, jl_emptysvec);
     tn->names = NULL;

--- a/src/dump.c
+++ b/src/dump.c
@@ -2009,6 +2009,7 @@ static jl_value_t *jl_deserialize_value_any(jl_serializer_state *s, uint8_t tag,
             jl_gc_wb(tn, tn->names);
             tn->wrapper = jl_deserialize_value(s, &tn->wrapper);
             jl_gc_wb(tn, tn->wrapper);
+            tn->Typeofwrapper = NULL;
             tn->mt = (jl_methtable_t*)jl_deserialize_value(s, (jl_value_t**)&tn->mt);
             jl_gc_wb(tn, tn->mt);
             ios_read(s->s, (char*)&tn->hash, sizeof(tn->hash));

--- a/src/julia.h
+++ b/src/julia.h
@@ -457,6 +457,7 @@ typedef struct {
     // `wrapper` is either the only instantiation of the type (if no parameters)
     // or a UnionAll accepting parameters to make an instantiation.
     jl_value_t *wrapper;
+    _Atomic(jl_value_t*) Typeofwrapper;  // cache for Type{wrapper}
     _Atomic(jl_svec_t*) cache;        // sorted array
     _Atomic(jl_svec_t*) linearcache;  // unsorted array
     struct _jl_methtable_t *mt;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -568,6 +568,7 @@ static void jl_serialize_value__(jl_serializer_state *s, jl_value_t *v, int recu
         jl_serialize_value(s, tn->module);
         jl_serialize_value(s, tn->names);
         jl_serialize_value(s, tn->wrapper);
+        jl_serialize_value(s, tn->Typeofwrapper);
         jl_serialize_value_(s, (jl_value_t*)tn->cache, 0);
         jl_serialize_value_(s, (jl_value_t*)tn->linearcache, 0);
         jl_serialize_value(s, tn->mt);


### PR DESCRIPTION
Benchmark from #44402:
```
julia> @btime Core.Compiler.widenconst(c1)
  98.999 ns (0 allocations: 0 bytes)
Type{Base.RefValue}

julia> @btime Core.Compiler.widenconst(c2)
  25.269 ns (0 allocations: 0 bytes)
```

alternative to #44447

mostly fixes #44402

