### PR TITLE
build: allow `Make.user` to tweak bootstrap debug level

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -21,6 +21,9 @@ JULIA_PRECOMPILE ?= 1
 # and LLVM_ASSERTIONS=1.
 FORCE_ASSERTIONS ?= 0
 
+# Set BOOTSTRAP_DEBUG_LEVEL to 1 to enable Julia-level stacktrace during bootstrapping.
+BOOTSTRAP_DEBUG_LEVEL ?= 0
+
 # OPENBLAS build options
 OPENBLAS_TARGET_ARCH:=
 OPENBLAS_SYMBOLSUFFIX:=

--- a/sysimage.mk
+++ b/sysimage.mk
@@ -60,7 +60,7 @@ RELBUILDROOT := $(call rel_path,$(JULIAHOME)/base,$(BUILDROOT)/base)/ # <-- make
 $(build_private_libdir)/corecompiler.ji: $(COMPILER_SRCS)
 	@$(call PRINT_JULIA, cd $(JULIAHOME)/base && \
 	$(call spawn,$(JULIA_EXECUTABLE)) -C "$(JULIA_CPU_TARGET)" --output-ji $(call cygpath_w,$@).tmp \
-		--startup-file=no --warn-overwrite=yes -g0 -O0 compiler/compiler.jl)
+		--startup-file=no --warn-overwrite=yes -g$(BOOTSTRAP_DEBUG_LEVEL) -O0 compiler/compiler.jl)
 	@mv $@.tmp $@
 
 $(build_private_libdir)/sys.ji: $(build_private_libdir)/corecompiler.ji $(JULIAHOME)/VERSION $(BASE_SRCS) $(STDLIB_SRCS)


### PR DESCRIPTION
The `-g1` option for bootstrapping is especially useful to get Julia-level
stacktrace in a case when some hard-to-debug error happened inside `Core.Compiler`.
Now we can define to enable it locally without modification on Make.inc:
> Make.user
```
BOOTSTRAP_DEBUG_LEVEL=1
```