### PR TITLE
Mark as `inline` functions implemented in `src/serialize.h`

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -67,54 +67,54 @@ extern "C" {
 #define LAST_TAG 57
 
 #define write_uint8(s, n) ios_putc((n), (s))
-#define read_uint8(s) ((uint8_t)ios_getc(s))
-#define write_int8(s, n) write_uint8(s, n)
-#define read_int8(s) read_uint8(s)
+#define read_uint8(s) ((uint8_t)ios_getc((s)))
+#define write_int8(s, n) write_uint8((s), (n))
+#define read_int8(s) read_uint8((s))
 
 /* read and write in host byte order */
 
-static void write_int32(ios_t *s, int32_t i) JL_NOTSAFEPOINT
+static inline void write_int32(ios_t *s, int32_t i) JL_NOTSAFEPOINT
 {
     ios_write(s, (char*)&i, 4);
 }
 
-static int32_t read_int32(ios_t *s) JL_NOTSAFEPOINT
+static inline int32_t read_int32(ios_t *s) JL_NOTSAFEPOINT
 {
     int32_t x = 0;
     ios_read(s, (char*)&x, 4);
     return x;
 }
 
-static uint64_t read_uint64(ios_t *s) JL_NOTSAFEPOINT
+static inline uint64_t read_uint64(ios_t *s) JL_NOTSAFEPOINT
 {
     uint64_t x = 0;
     ios_read(s, (char*)&x, 8);
     return x;
 }
 
-static void write_int64(ios_t *s, int64_t i) JL_NOTSAFEPOINT
+static inline void write_int64(ios_t *s, int64_t i) JL_NOTSAFEPOINT
 {
     ios_write(s, (char*)&i, 8);
 }
 
-static void write_uint16(ios_t *s, uint16_t i) JL_NOTSAFEPOINT
+static inline void write_uint16(ios_t *s, uint16_t i) JL_NOTSAFEPOINT
 {
     ios_write(s, (char*)&i, 2);
 }
 
-static uint16_t read_uint16(ios_t *s) JL_NOTSAFEPOINT
+static inline uint16_t read_uint16(ios_t *s) JL_NOTSAFEPOINT
 {
     int16_t x = 0;
     ios_read(s, (char*)&x, 2);
     return x;
 }
 
-static void write_uint32(ios_t *s, uint32_t i) JL_NOTSAFEPOINT
+static inline void write_uint32(ios_t *s, uint32_t i) JL_NOTSAFEPOINT
 {
     ios_write(s, (char*)&i, 4);
 }
 
-static uint32_t read_uint32(ios_t *s) JL_NOTSAFEPOINT
+static inline uint32_t read_uint32(ios_t *s) JL_NOTSAFEPOINT
 {
     uint32_t x = 0;
     ios_read(s, (char*)&x, 4);

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -66,12 +66,27 @@ extern "C" {
 
 #define LAST_TAG 57
 
-#define write_uint8(s, n) ios_putc((n), (s))
-#define read_uint8(s) ((uint8_t)ios_getc((s)))
-#define write_int8(s, n) write_uint8((s), (n))
-#define read_int8(s) read_uint8((s))
-
 /* read and write in host byte order */
+
+static inline void write_uint8(ios_t *s, uint8_t n) JL_NOTSAFEPOINT
+{
+    ios_putc(n, s);
+}
+
+static inline uint8_t read_uint8(ios_t *s) JL_NOTSAFEPOINT
+{
+    return (uint8_t)ios_getc(s);
+}
+
+static inline void write_int8(ios_t *s, int8_t n) JL_NOTSAFEPOINT
+{
+    ios_putc(n, s);
+}
+
+static inline int8_t read_int8(ios_t *s) JL_NOTSAFEPOINT
+{
+    return (int8_t)ios_getc(s);
+}
 
 static inline void write_int32(ios_t *s, int32_t i) JL_NOTSAFEPOINT
 {

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -66,27 +66,12 @@ extern "C" {
 
 #define LAST_TAG 57
 
+#define write_uint8(s, n) ios_putc((n), (s))
+#define read_uint8(s) ((uint8_t)ios_getc((s)))
+#define write_int8(s, n) write_uint8((s), (n))
+#define read_int8(s) read_uint8((s))
+
 /* read and write in host byte order */
-
-static inline void write_uint8(ios_t *s, uint8_t n) JL_NOTSAFEPOINT
-{
-    ios_putc(n, s);
-}
-
-static inline uint8_t read_uint8(ios_t *s) JL_NOTSAFEPOINT
-{
-    return (uint8_t)ios_getc(s);
-}
-
-static inline void write_int8(ios_t *s, int8_t n) JL_NOTSAFEPOINT
-{
-    ios_putc(n, s);
-}
-
-static inline int8_t read_int8(ios_t *s) JL_NOTSAFEPOINT
-{
-    return (int8_t)ios_getc(s);
-}
 
 static inline void write_int32(ios_t *s, int32_t i) JL_NOTSAFEPOINT
 {

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -64,6 +64,7 @@ done by `get_item_for_reloc`.
 #include "julia_internal.h"
 #include "builtin_proto.h"
 #include "processor.h"
+#include "serialize.h"
 
 #ifndef _OS_WINDOWS_
 #include <dlfcn.h>
@@ -363,25 +364,6 @@ typedef enum {
 // this supports up to 8 RefTags, 512MB of pointer data, and 4/2 (64/32-bit) GB of constant data.
 // if a larger size is required, will need to add support for writing larger relocations in many cases below
 #define RELOC_TAG_OFFSET 29
-
-
-/* read and write in host byte order */
-
-#define write_uint8(s, n) ios_putc((n), (s))
-#define read_uint8(s) ((uint8_t)ios_getc((s)))
-
-static void write_uint32(ios_t *s, uint32_t i) JL_NOTSAFEPOINT
-{
-    ios_write(s, (char*)&i, 4);
-}
-
-static uint32_t read_uint32(ios_t *s) JL_NOTSAFEPOINT
-{
-    uint32_t x = 0;
-    ios_read(s, (char*)&x, 4);
-    return x;
-}
-
 
 // --- Static Compile ---
 


### PR DESCRIPTION
In https://github.com/JuliaLang/julia/pull/44634#discussion_r834296271 it was suggested that these functions were implemented in the header to allow inlining, but they weren't annotated with `inline`, thus causing a warning when the functions were unused.

Also, remove duplicate definitions from `src/staticdata.c` and include
`serialize.h` in there.