### PR TITLE
clarification of export list

### DIFF
--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -78,7 +78,7 @@ module-local.
 ### Export lists
 
 Names (referring to functions, types, global variables, and constants) can be added to the
-*export list* of a module with `export`. Typically, they are at or near the top of the module definition
+*export list* of a module with `export`: these are the symbols that are exported when `using` the module. Typically, they are at or near the top of the module definition
 so that readers of the source code can find them easily, as in
 
 ```jldoctest module_manual

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -78,7 +78,7 @@ module-local.
 ### Export lists
 
 Names (referring to functions, types, global variables, and constants) can be added to the
-*export list* of a module with `export`: these are the symbols that are exported when `using` the module. Typically, they are at or near the top of the module definition
+*export list* of a module with `export`: these are the symbols that are imported when `using` the module. Typically, they are at or near the top of the module definition
 so that readers of the source code can find them easily, as in
 
 ```jldoctest module_manual


### PR DESCRIPTION
Just a slight tweak.  From [this discussion](https://discourse.julialang.org/t/use-of-export-keyword/78457), I noticed that the section on `export` did not explicitly mention its connection to `using`.