### PR TITLE
predicate function negation with ComposedFunction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@ Library changes
   as `keys(::Dict)`, `values(::Dict)`, and `Set` is fixed.  These methods of `iterate` can
   now be called on a dictionary or set shared by arbitrary tasks provided that there are no
   tasks mutating the dictionary or set ([#44534]).
+* Predicate function negation `!f` now returns a composed function `(!) ∘ f` instead of an anonymous function ([#44752]).
 
 
 Standard library changes

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1035,7 +1035,7 @@ end
 ∘(f, g, h...) = ∘(f ∘ g, h...)
 
 function show(io::IO, c::ComposedFunction)
-    _showcomposed(io, c.outer)
+    c.outer isa ComposedFunction ? show(io, c.outer) : _showcomposed(io, c.outer)
     print(io, " ∘ ")
     _showcomposed(io, c.inner)
 end
@@ -1052,7 +1052,21 @@ _showcomposed(io::IO, f::Function) = isoperator(Symbol(f)) ? (print(io, '('); sh
 #nesting for chained composition
 _showcomposed(io::IO, f::ComposedFunction) = (print(io, '('); show(io, f); print(io, ')'))
 #no nesting when ! is the outer function in a composition chain
-_showcomposed(io::IO, f::ComposedFunction{typeof(!)}) = (print(io, '!'); show(io, f.inner))
+_showcomposed(io::IO, f::ComposedFunction{typeof(!)}) = show(io, f)
+
+function show_function(io::IO, c::ComposedFunction, compact::Bool)
+    if compact
+        show(io, c)
+    else
+        print(io, "ComposedFunction(")
+        show_function(io, c.outer, false)
+        print(io, ", ")
+        show_function(io, c.inner, false)
+        print(io, ')')
+    end
+end
+
+show_function(io::IO, x, ::Bool) = show(io, x)
 
 """
     !f::Function

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1069,8 +1069,7 @@ end
 """
     !f::Function
 
-Predicate function negation: when the argument of `!` is a function, it returns a
-function which computes the boolean negation of `f`.
+Predicate function negation: when the argument of `!` is a function, it returns a composed function which computes the boolean negation of `f`.
 
 See also [`∘`](@ref).
 
@@ -1084,6 +1083,9 @@ julia> filter(isletter, str)
 
 julia> filter(!isletter, str)
 "∀  > 0, ∃  > 0: |-| <  ⇒ |()-()| < "
+
+!!! compat "Julia 1.9"
+    Starting with Julia 1.9, `!f` returns a [`ComposedFunction`](@ref) instead of an anonymous function.
 ```
 """
 !(f::Function) = (!) ∘ f

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1083,10 +1083,10 @@ julia> filter(isletter, str)
 
 julia> filter(!isletter, str)
 "∀  > 0, ∃  > 0: |-| <  ⇒ |()-()| < "
+```
 
 !!! compat "Julia 1.9"
     Starting with Julia 1.9, `!f` returns a [`ComposedFunction`](@ref) instead of an anonymous function.
-```
 """
 !(f::Function) = (!) ∘ f
 !(f::ComposedFunction{typeof(!)}) = f.inner #allows !!f === f

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1066,8 +1066,6 @@ function show_function(io::IO, c::ComposedFunction, compact::Bool)
     end
 end
 
-show_function(io::IO, x, ::Bool) = show(io, x)
-
 """
     !f::Function
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1035,8 +1035,17 @@ end
 ∘(f, g, h...) = ∘(f ∘ g, h...)
 
 function show(io::IO, c::ComposedFunction)
-    show(io, c.outer)
+    if c.outer |> Symbol |> Base.isoperator
+        print(io, '(', c.outer, ')')
+    else
+        show(io, c.outer)
+    end
     print(io, " ∘ ")
+    show(io, c.inner)
+end
+
+function show(io::IO, c::ComposedFunction{typeof(!)})
+    print(io, "!")
     show(io, c.inner)
 end
 
@@ -1060,7 +1069,10 @@ julia> filter(!isletter, str)
 "∀  > 0, ∃  > 0: |-| <  ⇒ |()-()| < "
 ```
 """
-!(f::Function) = (x...)->!f(x...)
+!(f::Function) = (!) ∘ f
+
+#allows !!f === f
+!(f::ComposedFunction{typeof(!)}) = f.inner
 
 """
     Fix1(f, x)

--- a/base/show.jl
+++ b/base/show.jl
@@ -465,8 +465,11 @@ function show_function(io::IO, f::Function, compact::Bool)
     end
 end
 
+show_function(io::IO, x, ::Bool) = show(io, x)
+
 show(io::IO, f::Function) = show_function(io, f, get(io, :compact, false)::Bool)
 print(io::IO, f::Function) = show_function(io, f, true)
+
 
 function show(io::IO, f::Core.IntrinsicFunction)
     if !(get(io, :compact, false)::Bool)

--- a/base/show.jl
+++ b/base/show.jl
@@ -468,6 +468,20 @@ end
 show(io::IO, f::Function) = show_function(io, f, get(io, :compact, false)::Bool)
 print(io::IO, f::Function) = show_function(io, f, true)
 
+function show_function(io::IO, c::ComposedFunction, compact::Bool)
+    if compact
+        show(io, c)
+    else
+        print(io, "ComposedFunction(")
+        show_function(io, c.outer, false)
+        print(io, ", ")
+        show_function(io, c.inner, false)
+        print(io, ')')
+    end
+end
+
+show_function(io::IO, x, ::Bool) = show(io, x)
+
 function show(io::IO, f::Core.IntrinsicFunction)
     if !(get(io, :compact, false)::Bool)
         print(io, "Core.Intrinsics.")

--- a/base/show.jl
+++ b/base/show.jl
@@ -468,20 +468,6 @@ end
 show(io::IO, f::Function) = show_function(io, f, get(io, :compact, false)::Bool)
 print(io::IO, f::Function) = show_function(io, f, true)
 
-function show_function(io::IO, c::ComposedFunction, compact::Bool)
-    if compact
-        show(io, c)
-    else
-        print(io, "ComposedFunction(")
-        show_function(io, c.outer, false)
-        print(io, ", ")
-        show_function(io, c.inner, false)
-        print(io, ')')
-    end
-end
-
-show_function(io::IO, x, ::Bool) = show(io, x)
-
 function show(io::IO, f::Core.IntrinsicFunction)
     if !(get(io, :compact, false)::Bool)
         print(io, "Core.Intrinsics.")

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -180,6 +180,10 @@ end
     @test filter(!isuppercase, str) == replace(str, r"[A-Z]" => "")
     @test filter(!islowercase, str) == replace(str, r"[a-z]" => "")
     @test !!isnan === isnan
+    @test repr(!isnan) == "!isnan"
+    @test repr((-) ∘ sin) == "(-) ∘ sin"
+    @test repr(cos ∘ (sin ∘ tan)) == "cos ∘ (sin ∘ tan)"
+    @test repr(!(cos ∘ !sin)) == "!(cos ∘ !sin)"
 end
 
 # issue #19891

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -184,6 +184,7 @@ end
     @test repr((-) ∘ sin) == "(-) ∘ sin"
     @test repr(cos ∘ (sin ∘ tan)) == "cos ∘ (sin ∘ tan)"
     @test repr(!(cos ∘ !sin)) == "!(cos ∘ !sin)"
+    @test repr(cos ∘ sin ∘ tan) == "cos ∘ sin ∘ tan" == repr((cos ∘ sin) ∘ tan)
 end
 
 # issue #19891

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -179,6 +179,7 @@ end
     str = randstring(20)
     @test filter(!isuppercase, str) == replace(str, r"[A-Z]" => "")
     @test filter(!islowercase, str) == replace(str, r"[a-z]" => "")
+    @test !!isnan === isnan
 end
 
 # issue #19891


### PR DESCRIPTION
Closes #44748 , this small PR does the following
* redefines predicate function negation `!(f::Function) = (!) ∘ f`
* updates the `show` method for `ComposedFunction` to print operators in parentheses
* adds a method for `!(f::ComposedFunction{typeof(!)})` that allows `!!f === f`
* adds a test for `!!f === f` and a few tests for showing composed functions

thanks for the tutelage @stevengj ! 