### PR TITLE
Fix test stacktrace scrubbing

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -53,7 +53,7 @@ function scrub_backtrace(bt)
     if do_test_ind !== nothing && length(bt) > do_test_ind
         bt = bt[do_test_ind + 1:end]
     end
-    name_ind = findfirst(ip -> ip_has_file_and_func(ip, @__FILE__, (Symbol("macro expansion"),)), bt)
+    name_ind = findfirst(ip -> ip_has_file_and_func(ip, @__FILE__, (Symbol("macro expansion"), Symbol("top-level scope"))), bt)
     if name_ind !== nothing && length(bt) != 0
         bt = bt[1:name_ind]
     end


### PR DESCRIPTION
`scrub_backtrace` is looking for a `macro expansion` when printing an exception thrown in `@test`, but that doesn't seem to exist anymore in recent Julia versions:
```
julia> @test 0//0
Error During Test at REPL[2]:1
  Test threw exception
  Expression: 0 // 0
  ArgumentError: invalid rational: zero(Int64)//zero(Int64)
  Stacktrace:
    [1] __throw_rational_argerror_zero(T::Type)
      @ Base ./rational.jl:32
    [2] Rational{Int64}(num::Int64, den::Int64)
      @ Base ./rational.jl:34
    [3] Rational
      @ ./rational.jl:39 [inlined]
    [4] //(n::Int64, d::Int64)
      @ Base ./rational.jl:62
    [5] top-level scope
      @ ~/julia-9b2169181d/share/julia/stdlib/v1.9/Test/src/Test.jl:464
    [6] eval
      @ ./boot.jl:370 [inlined]
    [7] eval_user_input(ast::Any, backend::REPL.REPLBackend)
      @ REPL ~/julia-9b2169181d/share/julia/stdlib/v1.9/REPL/src/REPL.jl:151
    [8] repl_backend_loop(backend::REPL.REPLBackend)
      @ REPL ~/julia-9b2169181d/share/julia/stdlib/v1.9/REPL/src/REPL.jl:247
    [9] start_repl_backend(backend::REPL.REPLBackend, consumer::Any)
      @ REPL ~/julia-9b2169181d/share/julia/stdlib/v1.9/REPL/src/REPL.jl:232
   [10] run_repl(repl::REPL.AbstractREPL, consumer::Any; backend_on_current_task::Bool)
      @ REPL ~/julia-9b2169181d/share/julia/stdlib/v1.9/REPL/src/REPL.jl:369
   [11] run_repl(repl::REPL.AbstractREPL, consumer::Any)
      @ REPL ~/julia-9b2169181d/share/julia/stdlib/v1.9/REPL/src/REPL.jl:356
   [12] (::Base.var"#965#967"{Bool, Bool, Bool})(REPL::Module)
      @ Base ./client.jl:419
   [13] #invokelatest#2
      @ ./essentials.jl:729 [inlined]
   [14] invokelatest
      @ ./essentials.jl:727 [inlined]
   [15] run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_file::Bool, color_set::Bool)
      @ Base ./client.jl:404
   [16] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:318
   [17] _start()
      @ Base ./client.jl:518
ERROR: There was an error during testing
```
This PR discards everything after the first `top-level scope` in Test.jl.