### PR TITLE
Seperate `LinearAlgebra.axp(b)y!` and `BLAS.axp(b)y!`.

### DIFF
--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -322,6 +322,8 @@ LinearAlgebra.ZeroPivotException
 LinearAlgebra.dot
 LinearAlgebra.dot(::Any, ::Any, ::Any)
 LinearAlgebra.cross
+LinearAlgebra.axpy!
+LinearAlgebra.axpby!
 LinearAlgebra.factorize
 LinearAlgebra.Diagonal
 LinearAlgebra.Bidiagonal
@@ -532,8 +534,8 @@ LinearAlgebra.BLAS.dotc
 LinearAlgebra.BLAS.blascopy!
 LinearAlgebra.BLAS.nrm2
 LinearAlgebra.BLAS.asum
-LinearAlgebra.axpy!
-LinearAlgebra.axpby!
+LinearAlgebra.BLAS.axpy!
+LinearAlgebra.BLAS.axpby!
 LinearAlgebra.BLAS.scal!
 LinearAlgebra.BLAS.scal
 LinearAlgebra.BLAS.iamax

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -5,7 +5,6 @@ Interface to BLAS subroutines.
 """
 module BLAS
 
-import ..axpy!, ..axpby!
 import Base: copyto!
 using Base: require_one_based_indexing, USE_BLAS64
 
@@ -456,15 +455,13 @@ Overwrite `Y` with `X*a + Y`, where `a` is a scalar. Return `Y`.
 
 # Examples
 ```jldoctest
-julia> x = [1; 2; 3];
+julia> x = [1.; 2; 3];
 
-julia> y = [4; 5; 6];
+julia> y = [4. ;; 5 ;; 6];
 
 julia> BLAS.axpy!(2, x, y)
-3-element Vector{Int64}:
-  6
-  9
- 12
+1×3 Matrix{Float64}:
+ 6.0  9.0  12.0
 ```
 """
 function axpy! end
@@ -490,8 +487,7 @@ for (fname, elty) in ((:daxpy_,:Float64),
     end
 end
 
-#TODO: replace with `x::AbstractArray{T}` once we separate `BLAS.axpy!` and `LinearAlgebra.axpy!`
-function axpy!(alpha::Number, x::Union{DenseArray{T},StridedVector{T}}, y::Union{DenseArray{T},StridedVector{T}}) where T<:BlasFloat
+function axpy!(alpha::Number, x::AbstractArray{T}, y::AbstractArray{T}) where T<:BlasFloat
     if length(x) != length(y)
         throw(DimensionMismatch(lazy"x has length $(length(x)), but y has length $(length(y))"))
     end
@@ -563,8 +559,7 @@ for (fname, elty) in ((:daxpby_,:Float64), (:saxpby_,:Float32),
     end
 end
 
-#TODO: replace with `x::AbstractArray{T}` once we separate `BLAS.axpby!` and `LinearAlgebra.axpby!`
-function axpby!(alpha::Number, x::Union{DenseArray{T},AbstractVector{T}}, beta::Number, y::Union{DenseArray{T},AbstractVector{T}},) where T<:BlasFloat
+function axpby!(alpha::Number, x::AbstractArray{T}, beta::Number, y::AbstractArray{T}) where T<:BlasFloat
     require_one_based_indexing(x, y)
     if length(x) != length(y)
         throw(DimensionMismatch(lazy"x has length $(length(x)), but y has length $(length(y))"))

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1404,7 +1404,7 @@ isdiag(x::Number) = true
 Overwrite `y` with `x * α + y` and return `y`.
 If `x` and `y` have the same axes, it's equivalent with `y .+= x .* a`
 
-See also [BLAS.axpy!](@ref)
+See also [`BLAS.axpy!`](@ref)
 
 # Examples
 ```jldoctest
@@ -1417,6 +1417,7 @@ julia> axpy!(2, x, y)
   6
   9
  12
+```
 """
 function axpy!(α, x::AbstractArray, y::AbstractArray)
     n = length(x)
@@ -1449,7 +1450,7 @@ end
 Overwrite `y` with `x * α + y * β` and return `y`.
 If `x` and `y` have the same axes, it's equivalent with `y .= x .* a .+ y .* β`
 
-See also [BLAS.axpby!](@ref)
+See also [`BLAS.axpby!`](@ref)
 
 # Examples
 ```jldoctest
@@ -1462,6 +1463,7 @@ julia> axpby!(2, x, 2, y)
  10
  14
  18
+```
 """
 function axpby!(α, x::AbstractArray, β, y::AbstractArray)
     if length(x) != length(y)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -11,8 +11,8 @@ matprod(x, y) = x*y + x*y
 
 # dot products
 
-dot(x::Union{DenseArray{T},StridedVector{T}}, y::Union{DenseArray{T},StridedVector{T}}) where {T<:BlasReal} = BLAS.dot(x, y)
-dot(x::Union{DenseArray{T},StridedVector{T}}, y::Union{DenseArray{T},StridedVector{T}}) where {T<:BlasComplex} = BLAS.dotc(x, y)
+dot(x::StridedVecLike{T}, y::StridedVecLike{T}) where {T<:BlasReal} = BLAS.dot(x, y)
+dot(x::StridedVecLike{T}, y::StridedVecLike{T}) where {T<:BlasComplex} = BLAS.dotc(x, y)
 
 function dot(x::Vector{T}, rx::AbstractRange{TI}, y::Vector{T}, ry::AbstractRange{TI}) where {T<:BlasReal,TI<:Integer}
     if length(rx) != length(ry)

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -333,12 +333,14 @@ end
 end
 
 @testset "LinearAlgebra.axp(b)y! for stride-vector like input" begin
-    a = rand(5, 5)
-    @test LinearAlgebra.axpby!(1, view(a, :, 5), 1, zeros(size(a))) == a
-    @test LinearAlgebra.axpy!(1, view(a, :, 5), zeros(size(a))) == a
-    b = view(a, 25:-2:1)
-    @test LinearAlgebra.axpby!(1, b, 1, zeros(size(b))) == b
-    @test LinearAlgebra.axpy!(1, b, zeros(size(b))) == b
+    for T in (Float32, Float64, ComplexF32, ComplexF64)
+        a = rand(T, 5, 5)
+        @test LinearAlgebra.axpby!(1, view(a, :, 1:5), 1, zeros(T, size(a))) == a
+        @test LinearAlgebra.axpy!(1, view(a, :, 1:5), zeros(T, size(a))) == a
+        b = view(a, 25:-2:1)
+        @test LinearAlgebra.axpby!(1, b, 1, zeros(T, size(b))) == b
+        @test LinearAlgebra.axpy!(1, b, zeros(T, size(b))) == b
+    end
 end
 
 @testset "norm and normalize!" begin

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -327,9 +327,18 @@ end
 @testset "LinearAlgebra.axp(b)y! for non strides input" begin
     a = rand(5, 5)
     @test LinearAlgebra.axpby!(1, Hermitian(a), 1, zeros(size(a))) == Hermitian(a)
-    @test_broken LinearAlgebra.axpby!(1, 1.:5, 1, zeros(5)) == 1.:5
+    @test LinearAlgebra.axpby!(1, 1.:5, 1, zeros(5)) == 1.:5
     @test LinearAlgebra.axpy!(1, Hermitian(a), zeros(size(a))) == Hermitian(a)
     @test LinearAlgebra.axpy!(1, 1.:5, zeros(5)) == 1.:5
+end
+
+@testset "LinearAlgebra.axp(b)y! for stride-vector like input" begin
+    a = rand(5, 5)
+    @test LinearAlgebra.axpby!(1, view(a, :, 5), 1, zeros(size(a))) == a
+    @test LinearAlgebra.axpy!(1, view(a, :, 5), zeros(size(a))) == a
+    b = view(a, 25:-2:1)
+    @test LinearAlgebra.axpby!(1, b, 1, zeros(size(b))) == b
+    @test LinearAlgebra.axpy!(1, b, zeros(size(b))) == b
 end
 
 @testset "norm and normalize!" begin

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -226,6 +226,19 @@ end
     end
 end
 
+@testset "dot product of stride-vector like input" begin
+    for T in (Float32, Float64, ComplexF32, ComplexF64)
+        a = randn(T, 10)
+        b = view(a, 1:10)
+        c = reshape(b, 5, 2)
+        d = view(c, :, 1:2)
+        r = sum(abs2, a)
+        for x in (a,b,c,d), y in (a,b,c,d)
+            @test dot(x, y) ≈ r
+        end
+    end
+end
+
 @testset "Complex matrix x real MatOrVec etc (issue #29224)" for T in (Float32, Float64)
     A0 = randn(complex(T), 10, 10)
     B0 = randn(T, 10, 10)


### PR DESCRIPTION
At present we have `BLAS.axp(b)y! === LinearAlgebra.axp(b)y!`, which seems strange as `BLAS.axp(b)y!` should always call BLAS.
This PR seperate them, and make `LinearAlgebra.axp(b)y!` call `BLAS.axp(b)y!` if inputs are stride-vector like. (Thus there should be no performance regression.)