### PR TITLE
Consider additional default ssh keys for LibGit2.

### DIFF
--- a/stdlib/LibGit2/src/callbacks.jl
+++ b/stdlib/LibGit2/src/callbacks.jl
@@ -91,12 +91,15 @@ function authenticate_ssh(libgit2credptr::Ptr{Ptr{Cvoid}}, p::CredentialPayload,
             cred.user = unsafe_string(username_ptr)
         end
 
-        cred.prvkey = Base.get(ENV, "SSH_KEY_PATH") do
-            default = joinpath(homedir(), ".ssh", "id_rsa")
-            if isempty(cred.prvkey) && isfile(default)
-                default
-            else
-                cred.prvkey
+        if haskey(ENV, "SSH_KEY_PATH")
+            cred.prvkey = ENV["SSH_KEY_PATH"]
+        elseif isempty(cred.prvkey)
+            for keytype in ("rsa", "ecdsa")
+                private_key_file = joinpath(homedir(), ".ssh", "id_$keytype")
+                if isfile(private_key_file)
+                    cred.prvkey = private_key_file
+                    break
+                end
             end
         end
 


### PR DESCRIPTION
When LibGit2 needs an ssh key, it will by default only look for `~/.ssh/id_rsa`. Since GitHub [dropped support for certain keys](https://github.blog/2021-09-01-improving-git-protocol-security-github/), new RSA keys will not work with Julia's default build of LibGit2/LibSSH2 to connect to GitHub (sufficiently old RSA keys should still be ok and other git services than GitHub may still work fine).

For Julia 1.8 and later, ECDSA keys work with LibGit2/LibSSH2 and are accepted by GitHub, but Julia will not find that key without prompting unless you specify it with `SSH_KEY_PATH`.

With this PR Julia will default to `~/.ssh/id_ecdsa` if no `~/.ssh/id_rsa` is found. Arguably the list of keys should be longer but at this point RSA and ECDSA keys are the only ones Julia's LibSSH2 understands (up to 1.7, RSA only).

Further discussion in https://github.com/JuliaLang/Pkg.jl/issues/3030.