### PR TITLE
fix handling of `.op` in lowering

### DIFF
--- a/src/ast.scm
+++ b/src/ast.scm
@@ -79,13 +79,15 @@
         ((char? e) (string "'" e "'"))
         ((atom? e) (string e))
         ((eq? (car e) '|.|)
-         (string (deparse (cadr e)) '|.|
-                 (cond ((and (pair? (caddr e)) (memq (caaddr e) '(quote inert)))
-                        (deparse-colon-dot (cadr (caddr e))))
-                       ((and (pair? (caddr e)) (eq? (caaddr e) 'copyast))
-                        (deparse-colon-dot (cadr (cadr (caddr e)))))
-                       (else
-                        (string #\( (deparse (caddr e)) #\))))))
+         (if (length= e 2)
+             (string "(." (deparse (cadr e)) ")")
+             (string (deparse (cadr e)) '|.|
+                     (cond ((and (pair? (caddr e)) (memq (caaddr e) '(quote inert)))
+                            (deparse-colon-dot (cadr (caddr e))))
+                           ((and (pair? (caddr e)) (eq? (caaddr e) 'copyast))
+                            (deparse-colon-dot (cadr (cadr (caddr e)))))
+                           (else
+                            (string #\( (deparse (caddr e)) #\)))))))
         ((memq (car e) '(... |'|))
          (string (deparse (cadr e)) (car e)))
         ((or (syntactic-op? (car e)) (eq? (car e) '|<:|) (eq? (car e) '|>:|) (eq? (car e) '-->))
@@ -445,7 +447,7 @@
   (if (dotop-named? e)
       (error (string "invalid function name \"" (deparse e) "\""))
       (if (pair? e)
-          (if (eq? (car e) '|.|)
+          (if (and (eq? (car e) '|.|) (length= e 3))
               (check-dotop (caddr e))
               (if (quoted? e)
                   (check-dotop (cadr e))))))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1917,7 +1917,12 @@ f31404(a, b; kws...) = (a, b, values(kws))
 # issue #28992
 macro id28992(x) x end
 @test @id28992(1 .+ 2) == 3
-@test Meta.isexpr(Meta.lower(@__MODULE__, :(@id28992((.+)(a,b) = 0))), :error)
+@test Meta.@lower(.+(a,b) = 0) == Expr(:error, "invalid function name \".+\"")
+@test Meta.@lower((.+)(a,b) = 0) == Expr(:error, "invalid function name \"(.+)\"")
+let m = @__MODULE__
+    @test Meta.lower(m, :($m.@id28992(.+(a,b) = 0))) == Expr(:error, "invalid function name \"$(nameof(m)).:.+\"")
+    @test Meta.lower(m, :($m.@id28992((.+)(a,b) = 0))) == Expr(:error, "invalid function name \"(.$(nameof(m)).+)\"")
+end
 @test @id28992([1] .< [2] .< [3]) == [true]
 @test @id28992(2 ^ -2) == 0.25
 @test @id28992(2 .^ -2) == 0.25


### PR DESCRIPTION
Discovered while running the syntax tests with lines 25-28 of
`jlfrontend.scm` commented out. Turned out we didn't handle `.op`
correctly in neither `check-dotop` nor in `deparse`. This meant we just
got `error: malformed expression` instead of an actually useful error
message.
