### PR TITLE
effects: change the `overlayed::Bool` property to `nonoverlayed::Bool`

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -198,7 +198,7 @@ mutable struct InferenceState
             #=parent=#nothing,
             #=cached=#cache === :global,
             #=inferred=#false, #=dont_work_on_me=#false, #=restrict_abstract_call_sites=# isa(linfo.def, Module),
-            #=ipo_effects=#Effects(consistent, ALWAYS_TRUE, ALWAYS_TRUE, ALWAYS_TRUE, false, inbounds_taints_consistency),
+            #=ipo_effects=#Effects(EFFECTS_TOTAL; consistent, inbounds_taints_consistency),
             interp)
         result.result = frame
         cache !== :no && push!(get_inference_cache(interp), result)

--- a/base/compiler/methodtable.jl
+++ b/base/compiler/methodtable.jl
@@ -46,7 +46,7 @@ getindex(result::MethodLookupResult, idx::Int) = getindex(result.matches, idx)::
 Find all methods in the given method table `view` that are applicable to the given signature `sig`.
 If no applicable methods are found, an empty result is returned.
 If the number of applicable methods exceeded the specified limit, `missing` is returned.
-`overlayed` indicates if any matching method is defined in an overlayed method table.
+`overlayed` indicates if any of the matching methods comes from an overlayed method table.
 """
 function findall(@nospecialize(sig::Type), table::InternalMethodTable; limit::Int=Int(typemax(Int32)))
     result = _findall(sig, nothing, table.world, limit)
@@ -101,15 +101,15 @@ It is possible that no method is an upper bound of `sig`, or
 it is possible that among the upper bounds, there is no least element.
 In both cases `nothing` is returned.
 
-`overlayed` indicates if the matching method is defined in an overlayed method table.
+`overlayed` indicates if any of the matching methods comes from an overlayed method table.
 """
 function findsup(@nospecialize(sig::Type), table::InternalMethodTable)
-    return (_findsup(sig, nothing, table.world)..., false)
+    return (_findsup(sig, nothing, table.world)..., true)
 end
 
 function findsup(@nospecialize(sig::Type), table::OverlayMethodTable)
     match, valid_worlds = _findsup(sig, table.mt, table.world)
-    match !== nothing && return match, valid_worlds, true
+    match !== nothing && return match, valid_worlds, false
     # fall back to the internal method table
     fallback_match, fallback_valid_worlds = _findsup(sig, nothing, table.world)
     return (
@@ -117,7 +117,7 @@ function findsup(@nospecialize(sig::Type), table::OverlayMethodTable)
         WorldRange(
             max(valid_worlds.min_world, fallback_valid_worlds.min_world),
             min(valid_worlds.max_world, fallback_valid_worlds.max_world)),
-        false)
+        true)
 end
 
 function _findsup(@nospecialize(sig::Type), mt::Union{Nothing,Core.MethodTable}, world::UInt)

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -803,7 +803,7 @@ function Base.show(io::IO, e::Core.Compiler.Effects)
     print(io, ',')
     printstyled(io, string(tristate_letter(e.terminates), 't'); color=tristate_color(e.terminates))
     print(io, ')')
-    e.overlayed && printstyled(io, '′'; color=:red)
+    e.nonoverlayed || printstyled(io, '′'; color=:red)
 end
 
 @specialize

--- a/src/julia.h
+++ b/src/julia.h
@@ -397,7 +397,7 @@ typedef struct _jl_code_instance_t {
             uint8_t ipo_effect_free:2;
             uint8_t ipo_nothrow:2;
             uint8_t ipo_terminates:2;
-            uint8_t ipo_overlayed:1;
+            uint8_t ipo_nonoverlayed:1;
         } ipo_purity_flags;
     };
     union {
@@ -407,7 +407,7 @@ typedef struct _jl_code_instance_t {
             uint8_t effect_free:2;
             uint8_t nothrow:2;
             uint8_t terminates:2;
-            uint8_t overlayed:1;
+            uint8_t nonoverlayed:1;
         } purity_flags;
     };
     jl_value_t *argescapes; // escape information of call arguments


### PR DESCRIPTION
The current naming of `overlayed` is a bit confusing since
`overlayed === true`, which is the conservative default value, actually
means "it _may_ be overlayed" while `overlayed === false` means
"this is absolutely not overlayed".
I think it should be named as `nonoverlayed`, and then a query name like
`is_nonoverlayed` would be more sensible than the alternative
`is_overlayed`, which actually should be something like `can_be_overlayed`.