### PR TITLE
fix potential error within `multiq_sift_down`

### DIFF
--- a/base/partr.jl
+++ b/base/partr.jl
@@ -45,14 +45,15 @@ end
 
 function multiq_sift_down(heap::taskheap, idx::Int32)
     if idx <= heap.ntasks
-        for child = (heap_d * idx - heap_d + Int32(2)):(heap_d * idx + Int32(1))
+        for child = (heap_d * idx - heap_d + 2):(heap_d * idx + 1)
+            child = Int(child)
             child > length(heap.tasks) && break
-            if isassigned(heap.tasks, Int(child)) &&
+            if isassigned(heap.tasks, child) &&
                     heap.tasks[child].priority < heap.tasks[idx].priority
                 t = heap.tasks[idx]
                 heap.tasks[idx] = heap.tasks[child]
                 heap.tasks[child] = t
-                multiq_sift_down(heap, child)
+                multiq_sift_down(heap, Int32(child))
             end
         end
     end


### PR DESCRIPTION
This commit fixes the following error possibility:
```
julia> using JET

julia> @report_call println(nothing)
═════ 1 possible error found ═════
┌ @ coreio.jl:4 Base.println(Core.tuple(Base.stdout), xs...)
│┌ @ strings/io.jl:75 Base.print(Core.tuple(io), xs, Core.tuple("\n")...)
││┌ @ strings/io.jl:43 Base.lock(io)
│││┌ @ show.jl:334 Base.lock(Base.getproperty(io, :io))
││││┌ @ stream.jl:283 Base.lock(Base.getproperty(s, :lock))
│││││┌ @ lock.jl:103 slowlock(rl)
││││││┌ @ lock.jl:112 Base.wait(c)
│││││││┌ @ condition.jl:124  = Base.wait()
││││││││┌ @ task.jl:940 Base.poptask(W)
│││││││││┌ @ task.jl:929 task = Base.trypoptask(W)
││││││││││┌ @ task.jl:923 Base.Partr.multiq_deletemin()
│││││││││││┌ @ partr.jl:162 Base.Partr.multiq_sift_down(heap, Base.Partr.Int32(1))
││││││││││││┌ @ partr.jl:55 Base.Partr.multiq_sift_down(heap, child)
│││││││││││││ no matching method found for call signature (Tuple{typeof(Base.Partr.multiq_sift_down), Base.Partr.taskheap, UInt32}): Base.Partr.multiq_sift_down(heap::Base.Partr.taskheap, child::UInt32)
││││││││││││└───────────────
```