### PR TITLE
Fix call to `jl_apply_array_type` in multidimensional array example for embedding

### DIFF
--- a/doc/src/manual/embedding.md
+++ b/doc/src/manual/embedding.md
@@ -487,7 +487,7 @@ that creates a 2D array and accesses its properties:
 
 ```c
 // Create 2D array of float64 type
-jl_value_t *array_type = jl_apply_array_type(jl_float64_type, 2);
+jl_value_t *array_type = jl_apply_array_type((jl_value_t*)jl_float64_type, 2);
 jl_array_t *x  = jl_alloc_array_2d(array_type, 10, 5);
 
 // Get array pointer


### PR DESCRIPTION
Without an explicit cast I get an error when compiling this code:
```
fast_cholesky.cpp:9:50: error: cannot convert ‘jl_datatype_t*’ {aka ‘_jl_datatype_t*’} to ‘jl_value_t*’ {aka ‘_jl_value_t*’}
    9 |     jl_value_t *array_type = jl_apply_array_type(jl_float64_type, 2);
      |                                                  ^~~~~~~~~~~~~~~
      |                                                  |
      |                                                  jl_datatype_t* {aka _jl_datatype_t*}
In file included from fast_cholesky.cpp:1:
/usr/include/julia/julia.h:1533:58: note:   initializing argument 1 of ‘jl_value_t* jl_apply_array_type(jl_value_t*, size_t)’
 1533 | JL_DLLEXPORT jl_value_t *jl_apply_array_type(jl_value_t *type, size_t dim);
      |                                              ~~~~~~~~~~~~^~~~
```