### PR TITLE
Fix "anonymous types declared in an anonymous union" warnings

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -230,6 +230,7 @@ typedef struct _jl_line_info_node_t {
     intptr_t inlined_at;
 } jl_line_info_node_t;
 
+// the following mirrors `struct EffectsOverride` in `base/compiler/types.jl`
 typedef union __jl_purity_overrides_t {
     struct {
         uint8_t ipo_consistent  : 1;
@@ -390,6 +391,8 @@ typedef struct _jl_code_instance_t {
     //TODO: uint8_t absolute_max; // whether true max world is unknown
 
     // purity results
+#ifdef JL_USE_ANON_UNIONS_FOR_PURITY_FLAGS
+    // see also encode_effects() and decode_effects() in `base/compiler/types.jl`,
     union {
         uint32_t ipo_purity_bits;
         struct {
@@ -410,6 +413,10 @@ typedef struct _jl_code_instance_t {
             uint8_t nonoverlayed:1;
         } purity_flags;
     };
+#else
+    uint32_t ipo_purity_bits;
+    uint32_t purity_bits;
+#endif
     jl_value_t *argescapes; // escape information of call arguments
 
     // compilation state cache


### PR DESCRIPTION
They look like this:
```
    CC src/processor.o
In file included from /Users/mhorn/Projekte/Julia/julia.master/src/processor.cpp:10:
In file included from ./processor.h:5:
./julia.h:395:9: warning: anonymous types declared in an anonymous union are an extension [-Wnested-anon-types]
        struct {
        ^
./julia.h:405:9: warning: anonymous types declared in an anonymous union are an extension [-Wnested-anon-types]
        struct {
        ^
2 warnings generated.
```
and come from code that was introduced by @keno in PR #43852.

But it turns out that the union is not used at all! So I'm simply removing
the offending union. Perhaps it is needed for some future work, but it should
be trivial to add it back if needed. If that happens, I suggest a comment
is added that explain why this looks similar to but has different layout
compared to the `typedef _jl_purity_overrides_t` also in `julia.h`.
