### PR TITLE
Support TATAS-like usage in `islocked` and `trylock` spec

### DIFF
--- a/base/lock.jl
+++ b/base/lock.jl
@@ -81,7 +81,7 @@ it in its docstring.
 
 * `islocked(lock)` is data-race-free.
 * If `islocked(lock)` returns `false`, an immediate invocation of `trylock(lock)` must
-  succeeds (returns `true`) if there is no interference from other tasks.
+  succeed (returns `true`) if there is no interference from other tasks.
 """
 function islocked end
 # Above docstring is a documentation for the abstract interface and not the one specific to

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -52,8 +52,41 @@ assert_havelock(l::ReentrantLock) = assert_havelock(l, l.locked_by)
     islocked(lock) -> Status (Boolean)
 
 Check whether the `lock` is held by any task/thread.
-This should not be used for synchronization (see instead [`trylock`](@ref)).
+This function alone should not be used for synchronization. However, `islocked` combined
+with [`trylock`](@ref) can be used for writing the test-and-test-and-set or exponential
+backoff algorithms *if it is supported by the `typeof(lock)`* (read its documentation).
+
+# Extended help
+
+For example, an exponential backoff can be implemented as follows if the `lock`
+implementation satisfied the properties documented below.
+
+```julia
+nspins = 0
+while true
+    while islocked(lock)
+        GC.safepoint()
+        nspins += 1
+        nspins > LIMIT && error("timeout")
+    end
+    trylock(lock) && break
+    backoff()
+end
+```
+
+## Implementation
+
+A lock implementation is advised to define `islocked` with the following properties and note
+it in their docstring.
+
+* `islocked(lock)` is data-race-free
+* If `islocked(lock)` returns `true`, an immediate invocation of `trylock(lock)` must
+  succeeds (returns `true`) if there is no interference from other tasks.
 """
+function islocked end
+# Above docstring is a documentation for the abstract interface and not the one specific to
+# `ReentrantLock`.
+
 function islocked(rl::ReentrantLock)
     return rl.havelock != 0
 end
@@ -67,7 +100,15 @@ If the lock is already locked by a different task/thread,
 return `false`.
 
 Each successful `trylock` must be matched by an [`unlock`](@ref).
+
+Function `trylock` combined with [`islocked`](@ref) can be used for writing the
+test-and-test-and-set or exponential backoff algorithms *if it is supported by the
+`typeof(lock)`* (read its documentation).
 """
+function trylock end
+# Above docstring is a documentation for the abstract interface and not the one specific to
+# `ReentrantLock`.
+
 @inline function trylock(rl::ReentrantLock)
     ct = current_task()
     if rl.locked_by === ct

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -77,9 +77,9 @@ end
 ## Implementation
 
 A lock implementation is advised to define `islocked` with the following properties and note
-it in their docstring.
+it in its docstring.
 
-* `islocked(lock)` is data-race-free
+* `islocked(lock)` is data-race-free.
 * If `islocked(lock)` returns `true`, an immediate invocation of `trylock(lock)` must
   succeeds (returns `true`) if there is no interference from other tasks.
 """

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -80,7 +80,7 @@ A lock implementation is advised to define `islocked` with the following propert
 it in its docstring.
 
 * `islocked(lock)` is data-race-free.
-* If `islocked(lock)` returns `true`, an immediate invocation of `trylock(lock)` must
+* If `islocked(lock)` returns `false`, an immediate invocation of `trylock(lock)` must
   succeeds (returns `true`) if there is no interference from other tasks.
 """
 function islocked end


### PR DESCRIPTION
_**NOTICE: THIS IS NOT AN ENDORSEMENT OF SPIN LOCKS**_

Currently, how `islocked` should behave is not well-specified. This PR is an RFC for allowing usage like test-and-test-and-set lock or exponential backoff lock:

```julia
nspins = 0
while true
    while islocked(lock)
        GC.safepoint()
        nspins += 1
        nspins > LIMIT && error("timeout")
    end
    trylock(lock) && break
    backoff()
end
```

Notably, this can be used for judging if a given implementation of `islocked` is correct for APIs like semaphore (#32299) and read-write lock where multiple tasks can enter the critical section in a certain way.

From this point of view, the API could have been clearer if the name was `islockable`. But I think the predicate `islocked` can also be interpreted as "am I locked out?" or "is it _completely_ locked?"

If we decide this API contract is a good direction, we need to fix `ReentrantLock` implementation (maybe in this PR or later).
