### PR TITLE
effects: define `Core.Compiler.infer_effects`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1616,6 +1616,9 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
     elseif is_return_type(f)
         tristate_merge!(sv, EFFECTS_UNKNOWN) # TODO
         return return_type_tfunc(interp, argtypes, sv)
+    elseif is_infer_effects(f)
+        tristate_merge!(sv, EFFECTS_UNKNOWN) # TODO
+        return infer_effects_tfunc(interp, argtypes, sv)
     elseif la == 2 && istopfunction(f, :!)
         # handle Conditional propagation through !Bool
         aty = argtypes[2]

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -40,7 +40,9 @@ include("options.jl")
 
 # core operations & types
 function return_type end # promotion.jl expects this to exist
-is_return_type(@Core.nospecialize(f)) = f === return_type
+function infer_effects end
+is_return_type(@nospecialize f) = f === return_type
+is_infer_effects(@nospecialize f) = f === infer_effects
 include("promotion.jl")
 include("tuple.jl")
 include("pair.jl")

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -202,7 +202,7 @@ function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src::Union{IRC
             f = argextype(args[1], src)
             f = singleton_type(f)
             f === nothing && return false
-            is_return_type(f) && return true
+            (is_return_type(f) || is_infer_effects(f)) && return true
             if isa(f, IntrinsicFunction)
                 intrinsic_effect_free_if_nothrow(f) || return false
                 return intrinsic_nothrow(f,

--- a/base/compiler/ssair/EscapeAnalysis/interprocedural.jl
+++ b/base/compiler/ssair/EscapeAnalysis/interprocedural.jl
@@ -3,8 +3,8 @@
 import Core.Compiler:
     MethodInstance, InferenceResult, Signature, ConstResult,
     MethodResultPure, MethodMatchInfo, UnionSplitInfo, ConstCallInfo, InvokeCallInfo,
-    call_sig, argtypes_to_type, is_builtin, is_return_type, istopfunction, validate_sparams,
-    specialize_method, invoke_rewrite
+    call_sig, argtypes_to_type, is_builtin, is_return_type, is_infer_effects, istopfunction,
+    validate_sparams, specialize_method, invoke_rewrite
 
 const Linfo = Union{MethodInstance,InferenceResult}
 struct CallInfo
@@ -31,7 +31,7 @@ function resolve_call(ir::IRCode, stmt::Expr, @nospecialize(info))
         return true
     elseif f === UnionAll && length(argtypes) == 3 && (argtypes[2] ⊑ TypeVar)
         return true
-    elseif is_return_type(f)
+    elseif is_return_type(f) || is_infer_effects(f)
         return true
     end
     if info isa MethodResultPure
@@ -49,7 +49,7 @@ function resolve_call(ir::IRCode, stmt::Expr, @nospecialize(info))
         infos = MethodMatchInfo[info]
     elseif isa(info, UnionSplitInfo)
         infos = info.matches
-    else # isa(info, ReturnTypeCallInfo), etc.
+    else # isa(info, VirtualCallInfo), etc.
         return missing
     end
     return analyze_call(sig, infos)

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -166,13 +166,13 @@ end
 # the AbstractInterpreter.
 
 """
-    info::ReturnTypeCallInfo
+    info::VirtualCallInfo
 
-Represents a resolved call of `Core.Compiler.return_type`.
-`info.call` wraps the info corresponding to the call that `Core.Compiler.return_type` call
-was supposed to analyze.
+Represents a resolved call of `Core.Compiler.return_type` or `Core.Compiler.infer_effects`.
+`info.call` wraps the info corresponding to the call that the reflection function was
+supposed to analyze.
 """
-struct ReturnTypeCallInfo
+struct VirtualCallInfo
     info::Any
 end
 

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -2014,59 +2014,88 @@ function intrinsic_effects(f::IntrinsicFunction, argtypes::Vector{Any})
         nothrow = nothrow ? ALWAYS_TRUE : TRISTATE_UNKNOWN)
 end
 
-# TODO: this function is a very buggy and poor model of the return_type function
-# since abstract_call_gf_by_type is a very inaccurate model of _method and of typeinf_type,
+# TODO: this function is a very buggy and poor model of the `return_type` function
+# since `abstract_call_gf_by_type` is a very inaccurate model of `_method` and of `typeinf_type`,
 # while this assumes that it is an absolutely precise and accurate and exact model of both
 function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::InferenceState)
-    if length(argtypes) == 3
-        tt = argtypes[3]
-        if isa(tt, Const) || (isType(tt) && !has_free_typevars(tt))
-            aft = argtypes[2]
-            if isa(aft, Const) || (isType(aft) && !has_free_typevars(aft)) ||
-                   (isconcretetype(aft) && !(aft <: Builtin))
-                af_argtype = isa(tt, Const) ? tt.val : (tt::DataType).parameters[1]
-                if isa(af_argtype, DataType) && af_argtype <: Tuple
-                    argtypes_vec = Any[aft, af_argtype.parameters...]
-                    if contains_is(argtypes_vec, Union{})
-                        return CallMeta(Const(Union{}), false)
-                    end
-                    # Run the abstract_call without restricting abstract call
-                    # sites. Otherwise, our behavior model of abstract_call
-                    # below will be wrong.
-                    old_restrict = sv.restrict_abstract_call_sites
-                    sv.restrict_abstract_call_sites = false
-                    call = abstract_call(interp, ArgInfo(nothing, argtypes_vec), sv, -1)
-                    sv.restrict_abstract_call_sites = old_restrict
-                    info = verbose_stmt_info(interp) ? ReturnTypeCallInfo(call.info) : false
-                    rt = widenconditional(call.rt)
-                    if isa(rt, Const)
-                        # output was computed to be constant
-                        return CallMeta(Const(typeof(rt.val)), info)
-                    end
-                    rt = widenconst(rt)
-                    if rt === Bottom || (isconcretetype(rt) && !iskindtype(rt))
-                        # output cannot be improved so it is known for certain
-                        return CallMeta(Const(rt), info)
-                    elseif !isempty(sv.pclimitations)
-                        # conservatively express uncertainty of this result
-                        # in two ways: both as being a subtype of this, and
-                        # because of LimitedAccuracy causes
-                        return CallMeta(Type{<:rt}, info)
-                    elseif (isa(tt, Const) || isconstType(tt)) &&
-                        (isa(aft, Const) || isconstType(aft))
-                        # input arguments were known for certain
-                        # XXX: this doesn't imply we know anything about rt
-                        return CallMeta(Const(rt), info)
-                    elseif isType(rt)
-                        return CallMeta(Type{rt}, info)
-                    else
-                        return CallMeta(Type{<:rt}, info)
-                    end
-                end
-            end
-        end
+    length(argtypes) == 3 || return CallMeta(Type, false)
+    aft = argtypes[2]
+    if !(isa(aft, Const) ||
+         (isType(aft) && !has_free_typevars(aft)) ||
+         (isconcretetype(aft) && !(aft <: Builtin)))
+        return CallMeta(Type, false)
     end
-    return CallMeta(Type, false)
+    tt = argtypes[3]
+    isa(tt, Const) || (isType(tt) && !has_free_typevars(tt)) || return CallMeta(Type, false)
+    af_argtype = isa(tt, Const) ? tt.val : (tt::DataType).parameters[1]
+    (isa(af_argtype, DataType) && af_argtype <: Tuple) || return CallMeta(Type, false)
+    argtypes_vec = Any[aft, af_argtype.parameters...]
+    if contains_is(argtypes_vec, Union{})
+        return CallMeta(Const(Union{}), false)
+    end
+    call, _ = virtual_abstract_call(interp, argtypes_vec, sv)
+    rt = widenconditional(call.rt)
+    info = verbose_stmt_info(interp) ? VirtualCallInfo(call.info) : false
+    if isa(rt, Const)
+        # output was computed to be constant
+        return CallMeta(Const(typeof(rt.val)), info)
+    end
+    rt = widenconst(rt)
+    if rt === Bottom || (isconcretetype(rt) && !iskindtype(rt))
+        # output cannot be improved so it is known for certain
+        return CallMeta(Const(rt), info)
+    elseif !isempty(sv.pclimitations)
+        # conservatively express uncertainty of this result in two ways:
+        # both as being a subtype of this, and because of LimitedAccuracy causes
+        return CallMeta(Type{<:rt}, info)
+    end
+    aft = argtypes[2]
+    tt = argtypes[3]
+    if (isa(tt, Const) || isconstType(tt)) && (isa(aft, Const) || isconstType(aft))
+        # input arguments were known for certain
+        # XXX: this doesn't imply we know anything about rt
+        return CallMeta(Const(rt), info)
+    elseif isType(rt)
+        return CallMeta(Type{rt}, info)
+    end
+    return CallMeta(Type{<:rt}, info)
+end
+
+# XXX this tfunc has the same unreliability as `return_type_tfunc`, and also some duplications with it
+function infer_effects_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::InferenceState)
+    length(argtypes) == 3 || return CallMeta(Effects, false)
+    aft = argtypes[2]
+    tt = argtypes[3]
+    # models the infer_effects function only when the input arguments are fully known
+    if !((isa(tt, Const) || isconstType(tt)) && (isa(aft, Const) || isconstType(aft)))
+        return CallMeta(Effects, false)
+    end
+    af_argtype = isa(tt, Const) ? tt.val : (tt::DataType).parameters[1]
+    (isa(af_argtype, DataType) && af_argtype <: Tuple) || return CallMeta(Effects, false)
+    argtypes_vec = Any[aft, af_argtype.parameters...]
+    call, effects = virtual_abstract_call(interp, argtypes_vec, sv)
+    info = verbose_stmt_info(interp) ? VirtualCallInfo(call.info) : false
+    if !isempty(sv.pclimitations)
+        # conservatively express uncertainty of this result
+        return CallMeta(Effects, false)
+    end
+    return CallMeta(Const(effects), info)
+end
+
+# first set temporal states, then model inference on this call with the virtual `abstract_call`,
+# and finally reset to the original states
+function virtual_abstract_call(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::InferenceState)
+    old_restrict = sv.restrict_abstract_call_sites
+    old_effects = sv.ipo_effects
+    # Run the `abstract_call` without restricting abstract call sites.
+    # Otherwise, our behavior model of `abstract_call` below will be wrong.
+    sv.restrict_abstract_call_sites = false
+    sv.ipo_effects = EFFECTS_TOTAL # XXX respect inbounds_taints_consistency?
+    call = abstract_call(interp, ArgInfo(nothing, argtypes), sv, -1)
+    effects = sv.ipo_effects
+    sv.restrict_abstract_call_sites = old_restrict
+    sv.ipo_effects = old_effects
+    return call, effects
 end
 
 # N.B.: typename maps type equivalence classes to a single value

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -1030,26 +1030,10 @@ function typeinf_ext_toplevel(interp::AbstractInterpreter, linfo::MethodInstance
     return src
 end
 
-function return_type(@nospecialize(f), t::DataType) # this method has a special tfunc
-    world = ccall(:jl_get_tls_world_age, UInt, ())
-    args = Any[_return_type, NativeInterpreter(world), Tuple{Core.Typeof(f), t.parameters...}]
-    return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Ptr{Cvoid}}, Cint), args, length(args))
-end
-
-function return_type(@nospecialize(f), t::DataType, world::UInt)
-    return return_type(Tuple{Core.Typeof(f), t.parameters...}, world)
-end
-
-function return_type(t::DataType)
-    world = ccall(:jl_get_tls_world_age, UInt, ())
-    return return_type(t, world)
-end
-
-function return_type(t::DataType, world::UInt)
-    args = Any[_return_type, NativeInterpreter(world), t]
-    return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Ptr{Cvoid}}, Cint), args, length(args))
-end
-
+return_type(@nospecialize(f), t::DataType) = return_type(f, t, get_tsl_world_counter()) # this method has a special tfunc
+return_type(@nospecialize(f), t::DataType, world::UInt) = return_type(Tuple{Core.Typeof(f), t.parameters...}, world)
+return_type(t::DataType) = return_type(t, get_tsl_world_counter())
+return_type(t::DataType, world::UInt) = call_in_typeinf_world(Any[_return_type, NativeInterpreter(world), t])
 function _return_type(interp::AbstractInterpreter, t::DataType)
     rt = Union{}
     f = singleton_type(t.parameters[1])
@@ -1068,4 +1052,40 @@ function _return_type(interp::AbstractInterpreter, t::DataType)
         end
     end
     return rt
+end
+
+infer_effects(@nospecialize(f), t::DataType) = infer_effects(f, t, get_tsl_world_counter())
+infer_effects(@nospecialize(f), t::DataType, world::UInt) = infer_effects(Tuple{Core.Typeof(f), t.parameters...}, world)
+infer_effects(t::DataType) = infer_effects(t, get_tsl_world_counter())
+infer_effects(t::DataType, world::UInt) = call_in_typeinf_world(Any[_infer_effects, NativeInterpreter(world), t])
+function _infer_effects(interp::AbstractInterpreter, t::DataType)
+    f = singleton_type(t.parameters[1])
+    if isa(f, Builtin)
+        args = Any[t.parameters...]
+        popfirst!(args)
+        rt = builtin_tfunction(interp, f, args, nothing)
+        return builtin_effects(f, args, rt)
+    else
+        effects = EFFECTS_TOTAL
+        matches = _methods_by_ftype(t, -1, get_world_counter(interp))::Vector
+        if isempty(matches)
+            # although this call is known to throw MethodError (thus `nothrow=ALWAYS_FALSE`),
+            # still mark it `TRISTATE_UNKNOWN` just in order to be consistent with a result
+            # derived by the effect analysis, which can't prove guaranteed throwness at this moment
+            return Effects(effects; nothrow=TRISTATE_UNKNOWN)
+        end
+        for match in matches
+            match = match::MethodMatch
+            frame = typeinf_frame(interp, match.method, match.spec_types, match.sparams, #=run_optimizer=#false)
+            frame === nothing && return Effects()
+            effects = tristate_merge(effects, frame.ipo_effects)
+        end
+    end
+    return effects
+end
+
+get_tsl_world_counter() = ccall(:jl_get_tls_world_age, UInt, ())
+
+function call_in_typeinf_world(args::Vector{Any})
+    return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Ptr{Cvoid}}, Cint), args, length(args))
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1310,6 +1310,7 @@ function return_types(@nospecialize(f), @nospecialize(types=default_tt(f));
     return rt
 end
 
+if nameof(@__MODULE__) === :Base
 function infer_effects(@nospecialize(f), @nospecialize(types=default_tt(f));
                        world = get_world_counter(),
                        interp = Core.Compiler.NativeInterpreter(world))
@@ -1338,6 +1339,7 @@ function infer_effects(@nospecialize(f), @nospecialize(types=default_tt(f));
         return effects
     end
 end
+end # if nameof(@__MODULE__) === :Base
 
 """
     print_statement_costs(io::IO, f, types)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4100,3 +4100,78 @@ invoke44763(x) = Base.@invoke increase_x44763!(x)
     invoke44763(42)
 end |> only === Int
 @test x44763 == 0
+
+Base.@assume_effects :terminates_locally function pow(x::Int)
+    res = 1
+    1 < x < 20 || error("bad pow")
+    while x > 1
+        res *= x
+        x -= 1
+    end
+    return res
+end
+maybe_effectful(x::Int) = 42
+maybe_effectful(x::Any) = unknown_operation()
+function f_no_methods end
+
+function nothing_or_missing(f, tt; pred=Core.Compiler.is_terminates)
+    @nospecialize f tt
+    effects = Core.Compiler.infer_effects(f, tt)
+    if pred(effects)
+        return nothing
+    else
+        return missing
+    end
+end
+
+@testset "Core.Compiler.infer_effects" begin
+    # basic
+    @test Core.Compiler.is_terminates(Core.Compiler.infer_effects(pow, Tuple{Int}))
+    @test Base.return_types() do
+        nothing_or_missing(pow, Tuple{Int})
+    end |> only === Nothing
+    @test Base.return_types() do
+        nothing_or_missing(Tuple{Int}) do x
+            pow(x)
+        end
+    end |> only === Nothing
+
+    # union split
+    let effects = Core.Compiler.infer_effects(maybe_effectful, Tuple{Any}) # union split
+        @test !Core.Compiler.is_consistent(effects)
+        @test !Core.Compiler.is_effect_free(effects)
+        @test !Core.Compiler.is_nothrow(effects)
+        @test !Core.Compiler.is_terminates(effects)
+        @test !Core.Compiler.is_nonoverlayed(effects)
+    end
+    @test Base.return_types() do
+        nothing_or_missing(maybe_effectful, Tuple{Any})
+    end |> only === Missing
+
+    # no matching methods
+    let effects = Core.Compiler.infer_effects(f_no_methods, Tuple{Any})
+        @test Core.Compiler.is_terminates(effects)
+        @test !Core.Compiler.is_nothrow(effects)
+    end
+    @test Base.return_types() do
+        nothing_or_missing(f_no_methods, Tuple{Any})
+    end |> only === Nothing
+    @test Base.return_types() do
+        nothing_or_missing(f_no_methods, Tuple{Any}; pred=Core.Compiler.is_nothrow)
+    end |> only === Missing
+
+    # unknown arguments
+    @test Base.return_types((Any,Any)) do f, tt
+        nothing_or_missing(f, tt)
+    end |> only === Union{Nothing,Missing}
+
+    # builtins
+    @test Core.Compiler.infer_effects(typeof, Tuple{Any}) |> Core.Compiler.is_total
+    @test Base.return_types() do
+        nothing_or_missing(typeof, Tuple{Any}; pred=Core.Compiler.is_total)
+    end |> only === Nothing
+    @test Core.Compiler.infer_effects(===, Tuple{Any,Any}) |> Core.Compiler.is_total
+    @test Base.return_types() do
+        nothing_or_missing(===, Tuple{Any,Any}; pred=Core.Compiler.is_total)
+    end |> only === Nothing
+end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1235,6 +1235,21 @@ let src = code_typed1(g_call_peel, Tuple{Any})
     @test count(isinvoke(:f_peel), src.code) == 2
 end
 
+@test fully_eliminated((Any,); retval=true) do f
+    tt = Tuple{Int}
+    rt = Core.Compiler.return_type(sin, tt)
+    effects = Core.Compiler.infer_effects(sin, tt)
+    rt === Float64 && Core.Compiler.is_effect_free(effects)
+end
+@test fully_eliminated((Any,)) do f
+    tt = Tuple{Int}
+    Core.Compiler.return_type(sin, tt)
+    Core.Compiler.infer_effects(sin, tt)
+    Core.Compiler.return_type(f, tt)
+    Core.Compiler.infer_effects(f, tt)
+    nothing
+end
+
 const my_defined_var = 42
 @test fully_eliminated((); retval=42) do
     getglobal(@__MODULE__, :my_defined_var, :monotonic)


### PR DESCRIPTION
This new reflection utility is similar to `Core.Compiler.return_type` but
for the effect analysis. It comes with its own tfunc and similar compiler
optimizations so that we can fold inferred effects at compiler time when
possible (albeit it is as unreliable as `Core.Compiler.return_type`).

For now `Core.Compiler.infer_effects` is folded at compile time only when
all the input arguments are fully known.