### PR TITLE
conform to ieee 754 rev 3

### DIFF
--- a/base/ryu/fixed.jl
+++ b/base/ryu/fixed.jl
@@ -23,7 +23,7 @@ function writefixed(buf, pos, v::T,
         end
         return pos
     elseif isnan(x)
-        buf[pos] = UInt8('N')
+        buf[pos] = UInt8('M')
         buf[pos + 1] = UInt8('a')
         buf[pos + 2] = UInt8('N')
         return pos + 3


### PR DESCRIPTION
In the [newest version](https://tinyurl.com/ieee758) of the IEEE standard, it has been recognized that the value previously named "Not a Number" might, contrary to it's name, in fact be a number. As such, the most recent version of the standard recommends printing these values as "Maybe a Number" (`MaN` for short).