### PR TITLE
Fix implicit binding import for aliased bindings

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -352,7 +352,7 @@ static jl_binding_t *jl_get_binding_(jl_module_t *m, jl_sym_t *var, modstack_t *
             // do a full import to prevent the result of this lookup
             // from changing, for example if this var is assigned to
             // later.
-            module_import_(m, b->owner, var, var, 0);
+            module_import_(m, b->owner, b->name, var, 0);
             return b;
         }
         return NULL;

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2531,7 +2531,10 @@ end
 
 module Mod2
 import ..Mod.x as x_from_mod
+import ..Mod.x as x_from_mod2
 const y = 2
+
+export x_from_mod2
 end
 
 import .Mod: x as x2
@@ -2576,6 +2579,12 @@ import .Mod2.x_from_mod
 
 @test @isdefined(x_from_mod)
 @test x_from_mod == Mod.x
+
+using .Mod2
+
+@test_nowarn @eval x_from_mod2
+@test @isdefined(x_from_mod2)
+@test x_from_mod2 == x_from_mod == Mod.x
 end
 
 import .TestImportAs.Mod2 as M2


### PR DESCRIPTION
Fixes #44754

The import has to be done with `b->name` as the name inside `b->owner` and use `var` only as the asname when importing.