### PR TITLE
Partially revert PR 42703 to fix embedding with MSVC

### DIFF
--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -116,7 +116,13 @@
 #  define NOINLINE_DECL(f) f __attribute__((noinline))
 #endif
 
-#if defined(__GNUC__)
+#ifdef _COMPILER_MICROSOFT_
+# ifdef _P64
+#  define JL_ATTRIBUTE_ALIGN_PTRSIZE(x) __declspec(align(8)) x
+# else
+#  define JL_ATTRIBUTE_ALIGN_PTRSIZE(x) __declspec(align(4)) x
+# endif
+#elif defined(__GNUC__)
 #  define JL_ATTRIBUTE_ALIGN_PTRSIZE(x) x __attribute__ ((aligned (sizeof(void*))))
 #else
 #  define JL_ATTRIBUTE_ALIGN_PTRSIZE(x)

--- a/src/support/platform.h
+++ b/src/support/platform.h
@@ -37,6 +37,8 @@
 #define _COMPILER_CLANG_
 #elif defined(__GNUC__)
 #define _COMPILER_GCC_
+#elif defined(_MSC_VER)
+#define _COMPILER_MICROSOFT_
 #else
 #error Unsupported compiler
 #endif


### PR DESCRIPTION
Due to the changes introduced in PR #42703 embedding Julia with MSVC fails with the current beta. A compile error is triggered in platform.h, and the definition of `ios_t` is hidden because `JL_ATTRIBUTE_ALIGN_PTRSIZE` is empty. This PR puts back a bit of the MSVC-related code that was removed to fix those two issues.