### PR TITLE
Add \neq tab completion to ≠

### DIFF
--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -596,6 +596,7 @@ const latex_symbols = Dict(
     "\\triangleq" => "≜",
     "\\questeq" => "≟",
     "\\ne" => "≠",
+    "\\neq" => "≠",
     "\\equiv" => "≡",
     "\\nequiv" => "≢",
     "\\le" => "≤",
@@ -2662,4 +2663,5 @@ const symbols_latex_canonical = Dict(
     "⊻" => "\\xor",
     "⊼" => "\\nand",
     "⊽" => "\\nor",
+    "≠" => "\\ne",
 )


### PR DESCRIPTION
Adds `\neq` as an alternative to `\ne` for tab completing to `≠`, just like `\le` and `\leq` both tab complete to `≤`.

