### PR TITLE
make `exp(::Float32)` and friends vectorize

### DIFF
--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -278,7 +278,10 @@ end
     power = (N+Int32(127))
     x > MAX_EXP(base, T) && return Inf32
     x < MIN_EXP(base, T) && return 0.0f0
-    x <= -SUBNORM_EXP(base, T) && (power+=Int32(24); small_part*=Float32(0x1p-24))
+    if x <= -SUBNORM_EXP(base, T)
+        power += Int32(24)
+        small_part *= Float32(0x1p-24)
+    end
     N == 128 && (power-=Int32(1); small_part*=2f0)
     return small_part * reinterpret(T, power << Int32(23))
 end

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -282,7 +282,10 @@ end
         power += Int32(24)
         small_part *= Float32(0x1p-24)
     end
-    N == 128 && (power-=Int32(1); small_part*=2f0)
+    if N == 128
+        power -= Int32(1)
+        small_part *= 2f0
+    end
     return small_part * reinterpret(T, power << Int32(23))
 end
 

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -267,10 +267,9 @@ end
     twopk = Int64(k) << 52
     return reinterpret(T, twopk + reinterpret(Int64, small_part))
 end
-            
+
 @inline function exp_impl(x::Float32, base)
     T = Float32
-    bad = (abs(x) <= SUBNORM_EXP(base, T))
     N_float = round(x*LogBINV(base, T))
     N = unsafe_trunc(Int32, N_float)
     r = muladd(N_float, LogBU(base, T), x)


### PR DESCRIPTION
with
```
x32 = randn(Float32, 1024); y32 = similar(x32);
```
old
```
julia> @btime @. $y32.=exp($x32);
  5.492 μs (0 allocations: 0 bytes)
```
new
```
@btime @. $y32.=exp($x32);
  629.982 ns (0 allocations: 0 bytes)
```

Results are identical, and performance for scalars are also identical.