### PR TITLE
Gate llvm.dbg intrinsic generation behind a flag

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -50,6 +50,7 @@ struct JLOptions
     rr_detach::Int8
     strip_metadata::Int8
     strip_ir::Int8
+    debug_values::Int8
 end
 
 # This runs early in the sysimage != is not defined yet

--- a/base/util.jl
+++ b/base/util.jl
@@ -220,6 +220,9 @@ function julia_cmd(julia=joinpath(Sys.BINDIR, julia_exename()))
     if opts.use_sysimage_native_code == 0
         push!(addflags, "--sysimage-native-code=no")
     end
+    if opts.debug_values != 0
+        push!(addflags, "-gvalues")
+    end
     return `$julia -C$cpu_target -J$image_file $addflags`
 end
 

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -83,6 +83,7 @@ JL_DLLEXPORT void jl_init_options(void)
                         0, // rr-detach
                         0, // strip-metadata
                         0, // strip-ir
+                        0, // debug-values
     };
     jl_options_initialized = 1;
 }
@@ -373,6 +374,8 @@ restart_switch:
                     jl_options.debug_level = 1;
                 else if (!strcmp(optarg,"2"))
                     jl_options.debug_level = 2;
+                else if (!strcmp(optarg,"values"))
+                    jl_options.debug_values = 1;
                 else
                     jl_errorf("julia: invalid argument to -g (%s)", optarg);
                 break;

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -54,6 +54,7 @@ typedef struct {
     int8_t rr_detach;
     int8_t strip_metadata;
     int8_t strip_ir;
+    int8_t debug_values;
 } jl_options_t;
 
 #endif


### PR DESCRIPTION
Julia is capable of generating llvm.dbg intrinsics. These get
lowered into DWARF debug info and can be used by GDB to find variables.
At least that's the theory. In practice, in our current implementation
they're mostly useless, because we lose location information for local
variables during SSA generation (so we only end up generating these
for arguments anyway, and likely with an incorrect lifetime).
Additionally, by default, Julia does not even register its JIT frames
with GDB, so the information is doubly useless.

Now, generating this information is not super-costly, but does add about
5% to LLVM time in some benchmarks, which is more than I'm willing to pay.

This PR adds a `-gvalues` command line flag (off by default unless building
the sysimage or the GDB listener is manually turned on), which controls
generation of llvm.dbg intrinsics. I suspect nobody would miss them if
we simply deleted them, but I figure maybe somebody wants to try to
improve this situation in the future, so might as well keep it around
as it's off by default.