### PR TITLE
[WIP] Alternative attempt at compile-on-demand layer integration

### DIFF
--- a/doc/src/devdocs/locks.md
+++ b/doc/src/devdocs/locks.md
@@ -29,6 +29,7 @@ The following are definitely leaf locks (level 1), and must not try to acquire a
 >   * flisp
 >   * jl_in_stackwalk (Win32)
 >   * ResourcePool<?>::mutex
+>   * RLST_mutex
 >
 >     > flisp itself is already threadsafe, this lock only protects the `jl_ast_context_list_t` pool
 >     > likewise, the ResourcePool<?>::mutexes just protect the associated resource pool

--- a/doc/src/devdocs/locks.md
+++ b/doc/src/devdocs/locks.md
@@ -30,6 +30,7 @@ The following are definitely leaf locks (level 1), and must not try to acquire a
 >   * jl_in_stackwalk (Win32)
 >   * ResourcePool<?>::mutex
 >   * RLST_mutex
+>   * jl_locked_stream::mutex
 >
 >     > flisp itself is already threadsafe, this lock only protects the `jl_ast_context_list_t` pool
 >     > likewise, the ResourcePool<?>::mutexes just protect the associated resource pool

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -186,11 +186,11 @@ typedef Instruction TerminatorInst;
 #include "processor.h"
 #include "julia_assert.h"
 
-JL_STREAM *dump_emitted_mi_name_stream = NULL;
+jl_locked_stream dump_emitted_mi_name_stream;
 extern "C" JL_DLLEXPORT
 void jl_dump_emitted_mi_name_impl(void *s)
 {
-    dump_emitted_mi_name_stream = (JL_STREAM*)s;
+    **dump_emitted_mi_name_stream = (JL_STREAM*)s;
 }
 
 extern "C" {
@@ -7978,15 +7978,16 @@ jl_llvm_functions_t jl_emit_code(
         "functions compiled with custom codegen params must not be cached");
     JL_TRY {
         decls = emit_function(m, li, src, jlrettype, params);
-        if (dump_emitted_mi_name_stream != NULL) {
-            jl_printf(dump_emitted_mi_name_stream, "%s\t", decls.specFunctionObject.c_str());
+        auto stream = *dump_emitted_mi_name_stream;
+        if (stream) {
+            jl_printf(stream, "%s\t", decls.specFunctionObject.c_str());
             // NOTE: We print the Type Tuple without surrounding quotes, because the quotes
             // break CSV parsing if there are any internal quotes in the Type name (e.g. in
             // Symbol("...")). The \t delineator should be enough to ensure whitespace is
             // handled correctly. (And we don't need to worry about any tabs in the printed
             // string, because tabs are printed as "\t" by `show`.)
-            jl_static_show(dump_emitted_mi_name_stream, li->specTypes);
-            jl_printf(dump_emitted_mi_name_stream, "\n");
+            jl_static_show(stream, li->specTypes);
+            jl_printf(stream, "\n");
         }
     }
     JL_CATCH {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -186,11 +186,10 @@ typedef Instruction TerminatorInst;
 #include "processor.h"
 #include "julia_assert.h"
 
-jl_locked_stream dump_emitted_mi_name_stream;
 extern "C" JL_DLLEXPORT
 void jl_dump_emitted_mi_name_impl(void *s)
 {
-    **dump_emitted_mi_name_stream = (JL_STREAM*)s;
+    **jl_ExecutionEngine->get_dump_emitted_mi_name_stream() = (JL_STREAM*)s;
 }
 
 extern "C" {
@@ -7978,7 +7977,7 @@ jl_llvm_functions_t jl_emit_code(
         "functions compiled with custom codegen params must not be cached");
     JL_TRY {
         decls = emit_function(m, li, src, jlrettype, params);
-        auto stream = *dump_emitted_mi_name_stream;
+        auto stream = *jl_ExecutionEngine->get_dump_emitted_mi_name_stream();
         if (stream) {
             jl_printf(stream, "%s\t", decls.specFunctionObject.c_str());
             // NOTE: We print the Type Tuple without surrounding quotes, because the quotes

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -1208,9 +1208,10 @@ jl_value_t *jl_dump_function_asm_impl(void *F, char raw_mc, const char* asm_vari
                     f2.deleteBody();
             }
         });
-        LLVMTargetMachine *TM = static_cast<LLVMTargetMachine*>(&jl_ExecutionEngine->getTargetMachine());
+        auto TMBase = jl_ExecutionEngine->cloneTargetMachine();
+        LLVMTargetMachine *TM = static_cast<LLVMTargetMachine*>(TMBase.get());
         legacy::PassManager PM;
-        addTargetPasses(&PM, TM);
+        addTargetPasses(&PM, TM->getTargetTriple(), TM->getTargetIRAnalysis());
         if (raw_mc) {
             raw_svector_ostream obj_OS(ObjBufferSV);
             if (TM->addPassesToEmitFile(PM, obj_OS, nullptr, CGFT_ObjectFile, false, nullptr))

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1166,7 +1166,7 @@ uint64_t JuliaOJIT::getFunctionAddress(StringRef Name)
 
 StringRef JuliaOJIT::getFunctionAtAddress(uint64_t Addr, jl_code_instance_t *codeinst)
 {
-    static int globalUnique = 0;
+    std::lock_guard<std::mutex> lock(RLST_mutex);
     std::string *fname = &ReverseLocalSymbolTable[(void*)(uintptr_t)Addr];
     if (fname->empty()) {
         std::string string_fname;
@@ -1186,7 +1186,7 @@ StringRef JuliaOJIT::getFunctionAtAddress(uint64_t Addr, jl_code_instance_t *cod
             stream_fname << "jlsys_";
         }
         const char* unadorned_name = jl_symbol_name(codeinst->def->def.method->name);
-        stream_fname << unadorned_name << "_" << globalUnique++;
+        stream_fname << unadorned_name << "_" << RLST_inc++;
         *fname = std::move(stream_fname.str()); // store to ReverseLocalSymbolTable
         addGlobalMapping(*fname, Addr);
     }

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -480,13 +480,6 @@ CodeGenOpt::Level CodeGenOptLevelFor(int optlevel)
 #endif
 }
 
-static void addPassesForOptLevel(legacy::PassManager &PM, TargetMachine &TM, int optlevel)
-{
-    addTargetPasses(&PM, &TM);
-    addOptimizationPasses(&PM, optlevel);
-    addMachinePasses(&PM, &TM, optlevel);
-}
-
 static auto countBasicBlocks(const Function &F)
 {
     return std::distance(F.begin(), F.end());
@@ -899,7 +892,9 @@ namespace {
         }
         std::unique_ptr<legacy::PassManager> operator()() {
             auto PM = std::make_unique<legacy::PassManager>();
-            addPassesForOptLevel(*PM, *TM, optlevel);
+            addTargetPasses(PM.get(), TM->getTargetTriple(), TM->getTargetIRAnalysis());
+            addOptimizationPasses(PM.get(), optlevel);
+            addMachinePasses(PM.get(), optlevel);
             return PM;
         }
     };
@@ -1232,16 +1227,6 @@ const DataLayout& JuliaOJIT::getDataLayout() const
     return DL;
 }
 
-TargetMachine &JuliaOJIT::getTargetMachine()
-{
-    return *TM;
-}
-
-const Triple& JuliaOJIT::getTargetTriple() const
-{
-    return TM->getTargetTriple();
-}
-
 std::string JuliaOJIT::getMangledName(StringRef Name)
 {
     SmallString<128> FullName;
@@ -1410,6 +1395,40 @@ void JuliaOJIT::shareStrings(Module &M)
     }
     for (auto GV : erase)
         GV->eraseFromParent();
+}
+
+//TargetMachine pass-through methods
+
+std::unique_ptr<TargetMachine> JuliaOJIT::cloneTargetMachine() const
+{
+    return std::unique_ptr<TargetMachine>(getTarget()
+        .createTargetMachine(
+            getTargetTriple().str(),
+            getTargetCPU(),
+            getTargetFeatureString(),
+            getTargetOptions(),
+            TM->getRelocationModel(),
+            TM->getCodeModel(),
+            TM->getOptLevel()));
+}
+
+const Triple& JuliaOJIT::getTargetTriple() const {
+    return TM->getTargetTriple();
+}
+StringRef JuliaOJIT::getTargetFeatureString() const {
+    return TM->getTargetFeatureString();
+}
+StringRef JuliaOJIT::getTargetCPU() const {
+    return TM->getTargetCPU();
+}
+const TargetOptions &JuliaOJIT::getTargetOptions() const {
+    return TM->Options;
+}
+const Target &JuliaOJIT::getTarget() const {
+    return TM->getTarget();
+}
+TargetIRAnalysis JuliaOJIT::getTargetIRAnalysis() const {
+    return TM->getTargetIRAnalysis();
 }
 
 static void jl_decorate_module(Module &M) {

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1085,6 +1085,10 @@ JuliaOJIT::JuliaOJIT()
         });
 #endif
 
+#if defined(JL_COMPILE_ON_DEMAND) && !defined(JL_USE_JITLINK)
+    CODLayer.setPartitionFunction(CODLayerT::compileWholeModule);
+#endif
+
     // Make sure SectionMemoryManager::getSymbolAddressInProcess can resolve
     // symbols in the program as well. The nullptr argument to the function
     // tells DynamicLibrary to load the program, not a library.

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -49,9 +49,9 @@ using namespace llvm;
 
 extern "C" jl_cgparams_t jl_default_cgparams;
 
-void addTargetPasses(legacy::PassManagerBase *PM, TargetMachine *TM);
+void addTargetPasses(legacy::PassManagerBase *PM, const Triple &triple, TargetIRAnalysis analysis);
 void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool lower_intrinsics=true, bool dump_native=false, bool external_use=false);
-void addMachinePasses(legacy::PassManagerBase *PM, TargetMachine *TM, int optlevel);
+void addMachinePasses(legacy::PassManagerBase *PM, int optlevel);
 void jl_finalize_module(orc::ThreadSafeModule  m);
 void jl_merge_module(orc::ThreadSafeModule &dest, orc::ThreadSafeModule src);
 GlobalVariable *jl_emit_RTLD_DEFAULT_var(Module *M);
@@ -336,8 +336,16 @@ public:
         ContextPool.release(std::move(ctx));
     }
     const DataLayout& getDataLayout() const;
-    TargetMachine &getTargetMachine();
+
+    // TargetMachine pass-through methods
+    std::unique_ptr<TargetMachine> cloneTargetMachine() const;
     const Triple& getTargetTriple() const;
+    StringRef getTargetFeatureString() const;
+    StringRef getTargetCPU() const;
+    const TargetOptions &getTargetOptions() const;
+    const Target &getTarget() const;
+    TargetIRAnalysis getTargetIRAnalysis() const;
+
     size_t getTotalBytes() const;
 
     JITDebugInfoRegistry &getDebugInfoRegistry() JL_NOTSAFEPOINT {

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -288,14 +288,18 @@ public:
     struct OptSelLayerT : orc::IRLayer {
 
         template<size_t N>
-        OptSelLayerT(std::unique_ptr<PipelineT> (&optimizers)[N]) : orc::IRLayer(optimizers[0]->OptimizeLayer.getExecutionSession(), optimizers[0]->OptimizeLayer.getManglingOptions()), optimizers(optimizers), count(N) {
+        OptSelLayerT(const std::array<std::unique_ptr<PipelineT>, N> &optimizers)
+            : orc::IRLayer(optimizers[0]->OptimizeLayer.getExecutionSession(),
+                optimizers[0]->OptimizeLayer.getManglingOptions()),
+            optimizers(optimizers.data()),
+            count(N) {
             static_assert(N > 0, "Expected array with at least one optimizer!");
         }
 
         void emit(std::unique_ptr<orc::MaterializationResponsibility> R, orc::ThreadSafeModule TSM) override;
 
         private:
-        std::unique_ptr<PipelineT> *optimizers;
+        const std::unique_ptr<PipelineT> * const optimizers;
         size_t count;
     };
 
@@ -344,8 +348,8 @@ private:
     std::string getMangledName(const GlobalValue *GV);
     void shareStrings(Module &M);
 
-    std::unique_ptr<TargetMachine> TM;
-    DataLayout DL;
+    const std::unique_ptr<TargetMachine> TM;
+    const DataLayout DL;
 
     orc::ExecutionSession ES;
     orc::JITDylib &GlobalJD;
@@ -356,13 +360,16 @@ private:
     ResourcePool<orc::ThreadSafeContext> ContextPool;
 
 #ifndef JL_USE_JITLINK
-    std::shared_ptr<RTDyldMemoryManager> MemMgr;
+    const std::shared_ptr<RTDyldMemoryManager> MemMgr;
 #endif
     ObjLayerT ObjectLayer;
-    std::unique_ptr<PipelineT> Pipelines[4];
+    const std::array<std::unique_ptr<PipelineT>, 4> Pipelines;
     OptSelLayerT OptSelLayer;
 
+    //Map and inc are guarded by RLST_mutex
     DenseMap<void*, std::string> ReverseLocalSymbolTable;
+    int RLST_inc = 0;
+    std::mutex RLST_mutex;
 };
 extern JuliaOJIT *jl_ExecutionEngine;
 orc::ThreadSafeModule jl_create_llvm_module(StringRef name, orc::ThreadSafeContext ctx, bool imaging_mode, const DataLayout &DL = jl_ExecutionEngine->getDataLayout(), const Triple &triple = jl_ExecutionEngine->getTargetTriple());

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -48,6 +48,11 @@
 # include <llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h>
 #endif
 
+//COD works with 64-bit linux/freebsd or if we're on an M1 CPU
+#if ((defined(_OS_LINUX_) || defined(_OS_FREEBSD_)) && defined(_P64)) || (defined(JL_USE_JITLINK) && defined(_OS_DARWIN_))
+#define JL_COMPILE_ON_DEMAND
+#endif
+
 using namespace llvm;
 
 extern "C" jl_cgparams_t jl_default_cgparams;
@@ -242,18 +247,22 @@ public:
             OwningResource(ResourcePool &pool, ResourceT resource) : pool(pool), resource(std::move(resource)) {}
             OwningResource(const OwningResource &) = delete;
             OwningResource &operator=(const OwningResource &) = delete;
-            OwningResource(OwningResource &&) = default;
-            OwningResource &operator=(OwningResource &&) = default;
+            OwningResource(OwningResource &&other) : pool(other.pool), resource(std::move(other.resource)) {
+                other.resource.reset();
+            }
+            OwningResource &operator=(OwningResource &&other) {
+                assert(&other.pool == &pool && "Tried to move from one pool to another!");
+                resource = std::move(other.resource);
+                other.resource.reset();
+            }
             ~OwningResource() {
-                if (resource) pool.release(std::move(*resource));
+                reset();
             }
-            ResourceT release() {
-                ResourceT res(std::move(*resource));
-                resource.reset();
-                return res;
-            }
-            void reset(ResourceT res) {
-                *resource = std::move(res);
+            void reset() {
+                if (resource) {
+                    pool.release(std::move(**this));
+                    resource.reset();
+                }
             }
             ResourceT &operator*() {
                 return *resource;
@@ -274,7 +283,7 @@ public:
                 return resource.getPointer();
             }
             explicit operator bool() const {
-                return resource;
+                return !!resource;
             }
             private:
             ResourcePool &pool;
@@ -330,6 +339,13 @@ public:
 
         std::unique_ptr<WNMutex> mutex;
     };
+
+    template<typename ResourceT, size_t max = 0>
+    using QueuedResourcePool = ResourcePool<ResourceT, max, std::queue<ResourceT>>;
+
+#ifdef JL_COMPILE_ON_DEMAND
+    typedef QueuedResourcePool<std::unique_ptr<RTDyldMemoryManager>> MemMgrPoolT;
+#endif
     struct PipelineT {
         PipelineT(orc::ObjectLayer &BaseLayer, TargetMachine &TM, int optlevel);
         CompileLayerT CompileLayer;
@@ -436,10 +452,14 @@ private:
     jl_locked_stream dump_compiles_stream;
     jl_locked_stream dump_llvm_opt_stream;
 
-    ResourcePool<orc::ThreadSafeContext, 0, std::queue<orc::ThreadSafeContext>> ContextPool;
+    QueuedResourcePool<orc::ThreadSafeContext> ContextPool;
 
 #ifndef JL_USE_JITLINK
+#ifndef JL_COMPILE_ON_DEMAND
     const std::shared_ptr<RTDyldMemoryManager> MemMgr;
+#else
+    MemMgrPoolT MemMgrs;
+#endif
 #endif
     ObjLayerT ObjectLayer;
     const std::array<std::unique_ptr<PipelineT>, 4> Pipelines;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -9,6 +9,7 @@
 
 #include <llvm/ExecutionEngine/Orc/IRCompileLayer.h>
 #include <llvm/ExecutionEngine/Orc/IRTransformLayer.h>
+#include <llvm/ExecutionEngine/Orc/CompileOnDemandLayer.h>
 #include <llvm/ExecutionEngine/JITEventListener.h>
 
 #include <llvm/Target/TargetMachine.h>
@@ -229,6 +230,7 @@ public:
 #endif
     typedef orc::IRCompileLayer CompileLayerT;
     typedef orc::IRTransformLayer OptimizeLayerT;
+    typedef orc::CompileOnDemandLayer CODLayerT;
     typedef object::OwningBinary<object::ObjectFile> OwningObj;
     template
     <typename ResourceT, size_t max = 0,
@@ -458,12 +460,16 @@ private:
 #ifndef JL_COMPILE_ON_DEMAND
     const std::shared_ptr<RTDyldMemoryManager> MemMgr;
 #else
+    std::unique_ptr<orc::LazyCallThroughManager> LCTM;
     MemMgrPoolT MemMgrs;
 #endif
 #endif
     ObjLayerT ObjectLayer;
     const std::array<std::unique_ptr<PipelineT>, 4> Pipelines;
     OptSelLayerT OptSelLayer;
+#ifdef JL_COMPILE_ON_DEMAND
+    CODLayerT CODLayer;
+#endif
 };
 extern JuliaOJIT *jl_ExecutionEngine;
 orc::ThreadSafeModule jl_create_llvm_module(StringRef name, orc::ThreadSafeContext ctx, bool imaging_mode, const DataLayout &DL = jl_ExecutionEngine->getDataLayout(), const Triple &triple = jl_ExecutionEngine->getTargetTriple());

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -61,6 +61,34 @@ static inline bool imaging_default() {
     return jl_options.image_codegen || (jl_generating_output() && !jl_options.incremental);
 }
 
+struct jl_locked_stream {
+    JL_STREAM *stream = nullptr;
+    std::mutex mutex;
+
+    struct lock {
+        std::unique_lock<std::mutex> lck;
+        JL_STREAM *&stream;
+
+        lock(std::mutex &mutex, JL_STREAM *&stream) : lck(mutex), stream(stream) {}
+
+        JL_STREAM *&operator*() {
+            return stream;
+        }
+
+        explicit operator bool() {
+            return !!stream;
+        }
+
+        operator JL_STREAM *() {
+            return stream;
+        }
+    };
+
+    lock operator*() {
+        return lock(mutex, stream);
+    }
+};
+
 typedef struct _jl_llvm_functions_t {
     std::string functionObject;     // jlcall llvm Function name
     std::string specFunctionObject; // specialized llvm Function name

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -379,6 +379,16 @@ public:
     JITDebugInfoRegistry &getDebugInfoRegistry() JL_NOTSAFEPOINT {
         return DebugRegistry;
     }
+
+    jl_locked_stream &get_dump_emitted_mi_name_stream() JL_NOTSAFEPOINT {
+        return dump_emitted_mi_name_stream;
+    }
+    jl_locked_stream &get_dump_compiles_stream() JL_NOTSAFEPOINT {
+        return dump_compiles_stream;
+    }
+    jl_locked_stream &get_dump_llvm_opt_stream() JL_NOTSAFEPOINT {
+        return dump_llvm_opt_stream;
+    }
 private:
     std::string getMangledName(StringRef Name);
     std::string getMangledName(const GlobalValue *GV);
@@ -397,6 +407,11 @@ private:
     std::mutex RLST_mutex{};
     int RLST_inc = 0;
     DenseMap<void*, std::string> ReverseLocalSymbolTable;
+
+    //Compilation streams
+    jl_locked_stream dump_emitted_mi_name_stream;
+    jl_locked_stream dump_compiles_stream;
+    jl_locked_stream dump_llvm_opt_stream;
 
     ResourcePool<orc::ThreadSafeContext> ContextPool;
 

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -405,7 +405,7 @@ private:
     //Map and inc are guarded by RLST_mutex
     DenseMap<void*, std::string> ReverseLocalSymbolTable;
     int RLST_inc = 0;
-    std::mutex RLST_mutex;
+    std::mutex RLST_mutex{};
 };
 extern JuliaOJIT *jl_ExecutionEngine;
 orc::ThreadSafeModule jl_create_llvm_module(StringRef name, orc::ThreadSafeContext ctx, bool imaging_mode, const DataLayout &DL = jl_ExecutionEngine->getDataLayout(), const Triple &triple = jl_ExecutionEngine->getTargetTriple());

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -393,6 +393,11 @@ private:
 
     JITDebugInfoRegistry DebugRegistry;
 
+    //Map and inc are guarded by RLST_mutex
+    std::mutex RLST_mutex{};
+    int RLST_inc = 0;
+    DenseMap<void*, std::string> ReverseLocalSymbolTable;
+
     ResourcePool<orc::ThreadSafeContext> ContextPool;
 
 #ifndef JL_USE_JITLINK
@@ -401,11 +406,6 @@ private:
     ObjLayerT ObjectLayer;
     const std::array<std::unique_ptr<PipelineT>, 4> Pipelines;
     OptSelLayerT OptSelLayer;
-
-    //Map and inc are guarded by RLST_mutex
-    DenseMap<void*, std::string> ReverseLocalSymbolTable;
-    int RLST_inc = 0;
-    std::mutex RLST_mutex{};
 };
 extern JuliaOJIT *jl_ExecutionEngine;
 orc::ThreadSafeModule jl_create_llvm_module(StringRef name, orc::ThreadSafeContext ctx, bool imaging_mode, const DataLayout &DL = jl_ExecutionEngine->getDataLayout(), const Triple &triple = jl_ExecutionEngine->getTargetTriple());

--- a/src/llvm-cpufeatures.cpp
+++ b/src/llvm-cpufeatures.cpp
@@ -61,7 +61,7 @@ bool have_fma(Function &intr, Function &caller) {
 
     Attribute FSAttr = caller.getFnAttribute("target-features");
     StringRef FS =
-        FSAttr.isValid() ? FSAttr.getValueAsString() : jl_ExecutionEngine->getTargetMachine().getTargetFeatureString();
+        FSAttr.isValid() ? FSAttr.getValueAsString() : jl_ExecutionEngine->getTargetFeatureString();
 
     SmallVector<StringRef, 6> Features;
     FS.split(Features, ',');


### PR DESCRIPTION
This PR is an alternative to #44575. As opposed to that PR, this version works<sup>TM</sup> on LLVM 13 and with our current memory manager, by not splitting up modules (thus avoiding a recursive memory manager allocation). Where JITLink is available, we will split up modules more aggressively, although the performance impact from this is unknown as we emit modules with fairly fine granularity anyways. 

Known failures include something in the ccall testset and in InteractiveUtils.

~~Depends on #44605 for increased parallelism gains from multiple contexts.~~ Depends on #44926 for various thread safety improvements. 