### PR TITLE
inference: rename `ConstResult` to `ConcreteResult`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -84,7 +84,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
     conditionals = nothing # keeps refinement information of call argument types when the return type is boolean
     seen = 0               # number of signatures actually inferred
     any_const_result = false
-    const_results = Union{InferenceResult,Nothing,ConstResult}[]
+    const_results = Union{Nothing,ConstResult}[]
     multiple_matches = napplicable > 1
     if !matches.nonoverlayed
         # currently we don't have a good way to execute the overlayed method definition,
@@ -744,13 +744,13 @@ function concrete_eval_call(interp::AbstractInterpreter,
         Core._call_in_world_total(world, f, args...)
     catch
         # The evaulation threw. By :consistent-cy, we're guaranteed this would have happened at runtime
-        return ConstCallResults(Union{}, ConstResult(result.edge, result.edge_effects), result.edge_effects)
+        return ConstCallResults(Union{}, ConcreteResult(result.edge, result.edge_effects), result.edge_effects)
     end
     if is_inlineable_constant(value) || call_result_unused(sv)
         # If the constant is not inlineable, still do the const-prop, since the
         # code that led to the creation of the Const may be inlineable in the same
         # circumstance and may be optimizable.
-        return ConstCallResults(Const(value), ConstResult(result.edge, EFFECTS_TOTAL, value), EFFECTS_TOTAL)
+        return ConstCallResults(Const(value), ConcreteResult(result.edge, EFFECTS_TOTAL, value), EFFECTS_TOTAL)
     end
     return nothing
 end
@@ -770,10 +770,10 @@ end
 
 struct ConstCallResults
     rt::Any
-    const_result::Union{InferenceResult, ConstResult}
+    const_result::ConstResult
     effects::Effects
     ConstCallResults(@nospecialize(rt),
-                     const_result::Union{InferenceResult, ConstResult},
+                     const_result::ConstResult,
                      effects::Effects) =
         new(rt, const_result, effects)
 end

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -823,7 +823,7 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter, resul
     # if constant inference hits a cycle, just bail out
     isa(result, InferenceState) && return nothing
     add_backedge!(mi, sv)
-    return ConstCallResults(result, inf_result, inf_result.ipo_effects)
+    return ConstCallResults(result, ConstPropResult(inf_result), inf_result.ipo_effects)
 end
 
 # if there's a possibility we could get a better result (hopefully without doing too much work)

--- a/base/compiler/ssair/EscapeAnalysis/interprocedural.jl
+++ b/base/compiler/ssair/EscapeAnalysis/interprocedural.jl
@@ -1,7 +1,7 @@
 # TODO this file contains many duplications with the inlining analysis code, factor them out
 
 import Core.Compiler:
-    MethodInstance, InferenceResult, Signature, ConstResult,
+    MethodInstance, InferenceResult, Signature, ConcreteResult,
     MethodResultPure, MethodMatchInfo, UnionSplitInfo, ConstCallInfo, InvokeCallInfo,
     call_sig, argtypes_to_type, is_builtin, is_return_type, istopfunction, validate_sparams,
     specialize_method, invoke_rewrite
@@ -95,7 +95,7 @@ function analyze_const_call(sig::Signature, cinfo::ConstCallInfo)
                 mi = analyze_match(match, length(sig.argtypes))
                 mi === nothing && return missing
                 push!(linfos, mi)
-            elseif isa(result, ConstResult)
+            elseif isa(result, ConcreteResult)
                 # TODO we may want to feedback information that this call always throws if !isdefined(result, :result)
                 push!(linfos, result.mi)
             else

--- a/base/compiler/ssair/EscapeAnalysis/interprocedural.jl
+++ b/base/compiler/ssair/EscapeAnalysis/interprocedural.jl
@@ -1,7 +1,7 @@
 # TODO this file contains many duplications with the inlining analysis code, factor them out
 
 import Core.Compiler:
-    MethodInstance, InferenceResult, Signature, ConcreteResult,
+    MethodInstance, InferenceResult, Signature, ConstPropResult, ConcreteResult,
     MethodResultPure, MethodMatchInfo, UnionSplitInfo, ConstCallInfo, InvokeCallInfo,
     call_sig, argtypes_to_type, is_builtin, is_return_type, istopfunction, validate_sparams,
     specialize_method, invoke_rewrite
@@ -62,8 +62,8 @@ function analyze_invoke_call(sig::Signature, info::InvokeCallInfo)
         return missing
     end
     result = info.result
-    if isa(result, InferenceResult)
-        return CallInfo(Linfo[result], true)
+    if isa(result, ConstPropResult)
+        return CallInfo(Linfo[result.result], true)
     else
         argtypes = invoke_rewrite(sig.argtypes)
         mi = analyze_match(match, length(argtypes))
@@ -98,8 +98,8 @@ function analyze_const_call(sig::Signature, cinfo::ConstCallInfo)
             elseif isa(result, ConcreteResult)
                 # TODO we may want to feedback information that this call always throws if !isdefined(result, :result)
                 push!(linfos, result.mi)
-            else
-                push!(linfos, result)
+            elseif isa(result, ConstPropResult)
+                push!(linfos, result.result)
             end
             nothrow &= match.fully_covers
         end

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1098,8 +1098,8 @@ function inline_invoke!(
         return nothing
     end
     result = info.result
-    if isa(result, ConstResult)
-        item = const_result_item(result, state)
+    if isa(result, ConcreteResult)
+        item = concrete_result_item(result, state)
     else
         argtypes = invoke_rewrite(sig.argtypes)
         if isa(result, InferenceResult)
@@ -1285,8 +1285,8 @@ function handle_const_call!(
             j += 1
             result = results[j]
             any_fully_covered |= match.fully_covers
-            if isa(result, ConstResult)
-                case = const_result_item(result, state)
+            if isa(result, ConcreteResult)
+                case = concrete_result_item(result, state)
                 push!(cases, InliningCase(result.mi.specTypes, case))
             elseif isa(result, InferenceResult)
                 handled_all_cases &= handle_inf_result!(result, argtypes, flag, state, cases, true)
@@ -1334,7 +1334,7 @@ function handle_inf_result!(
     return true
 end
 
-function const_result_item(result::ConstResult, state::InliningState)
+function concrete_result_item(result::ConcreteResult, state::InliningState)
     if !isdefined(result, :result) || !is_inlineable_constant(result.result)
         return compileable_specialization(state.et, result.mi, result.effects)
     end
@@ -1412,8 +1412,8 @@ function assemble_inline_todo!(ir::IRCode, state::InliningState)
                     ir, idx, stmt, result, flag,
                     sig, state, todo)
             else
-                if isa(result, ConstResult)
-                    item = const_result_item(result, state)
+                if isa(result, ConcreteResult)
+                    item = concrete_result_item(result, state)
                 else
                     item = analyze_method!(info.match, sig.argtypes, flag, state)
                 end

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -47,24 +47,26 @@ function nmatches(info::UnionSplitInfo)
     return n
 end
 
-struct ConstResult
+struct ConcreteResult
     mi::MethodInstance
     effects::Effects
     result
-    ConstResult(mi::MethodInstance, effects::Effects) = new(mi, effects)
-    ConstResult(mi::MethodInstance, effects::Effects, @nospecialize val) = new(mi, effects, val)
+    ConcreteResult(mi::MethodInstance, effects::Effects) = new(mi, effects)
+    ConcreteResult(mi::MethodInstance, effects::Effects, @nospecialize val) = new(mi, effects, val)
 end
+
+const ConstResult = Union{InferenceResult,ConcreteResult}
 
 """
     info::ConstCallInfo
 
 The precision of this call was improved using constant information.
-In addition to the original call information `info.call`, this info also keeps
-the inference results with constant information `info.results::Vector{Union{Nothing,InferenceResult}}`.
+In addition to the original call information `info.call`, this info also keeps the results
+of constant inference `info.results::Vector{Union{Nothing,ConstResult}}`.
 """
 struct ConstCallInfo
     call::Union{MethodMatchInfo,UnionSplitInfo}
-    results::Vector{Union{Nothing,InferenceResult,ConstResult}}
+    results::Vector{Union{Nothing,ConstResult}}
 end
 
 """
@@ -130,7 +132,7 @@ Optionally keeps `info.result::InferenceResult` that keeps constant information.
 """
 struct InvokeCallInfo
     match::MethodMatch
-    result::Union{Nothing,InferenceResult,ConstResult}
+    result::Union{Nothing,ConstResult}
 end
 
 """
@@ -142,7 +144,7 @@ Optionally keeps `info.result::InferenceResult` that keeps constant information.
 """
 struct OpaqueClosureCallInfo
     match::MethodMatch
-    result::Union{Nothing,InferenceResult,ConstResult}
+    result::Union{Nothing,ConstResult}
 end
 
 """

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -47,6 +47,10 @@ function nmatches(info::UnionSplitInfo)
     return n
 end
 
+struct ConstPropResult
+    result::InferenceResult
+end
+
 struct ConcreteResult
     mi::MethodInstance
     effects::Effects
@@ -55,7 +59,7 @@ struct ConcreteResult
     ConcreteResult(mi::MethodInstance, effects::Effects, @nospecialize val) = new(mi, effects, val)
 end
 
-const ConstResult = Union{InferenceResult,ConcreteResult}
+const ConstResult = Union{ConstPropResult,ConcreteResult}
 
 """
     info::ConstCallInfo


### PR DESCRIPTION
The naming `ConstResult` is a bit ambiguous, given that we have several
different concepts of "constant" inference:
- constant prop': `InferenceResult`
- concrete evaluation: `ConstResult`
- WIP: semi-concrete evaluation: `SemiConcreteResult`
- (and more in the future...?)

 (better to be `ConcreteResult` instead)

Now I'd like to rename `ConstResult` to `ConcreteResult` and also setup
a specific data type `ConstPropResult` representing const-prop'ed result:
- constant prop': `ConstPropResult`
- concrete evaluation: `ConcreteResult`
- WIP: semi-concrete evaluation: `SemiConcreteResult`
- (and more in the future...?)

And now `ConstResult` is a general type alias that is equivalent to
`Union{ConstPropResult,ConcreteResult,...}`.