### PR TITLE
Make array `isapprox` more generic by avoiding zip/explicit iteration

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1774,6 +1774,7 @@ function isapprox(x::AbstractArray, y::AbstractArray;
         return d <= max(atol, rtol*max(norm(x), norm(y)))
     else
         # Fall back to a component-wise approximate comparison
+        # (mapreduce instead of all for greater generality [#44893])
         return mapreduce((a, b) -> isapprox(a, b; rtol=rtol, atol=atol, nans=nans), &, x, y)
     end
 end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1774,7 +1774,7 @@ function isapprox(x::AbstractArray, y::AbstractArray;
         return d <= max(atol, rtol*max(norm(x), norm(y)))
     else
         # Fall back to a component-wise approximate comparison
-        return all(ab -> isapprox(ab[1], ab[2]; rtol=rtol, atol=atol, nans=nans), zip(x, y))
+        return mapreduce((a, b) -> isapprox(a, b; rtol=rtol, atol=atol, nans=nans), &, x, y)
     end
 end
 


### PR DESCRIPTION
Hi all, I was going to raise an issue but figured I might as well frame it in terms of a proposed solution.

I stumbled upon a case where I couldn't `isapprox` two GPU arrays because they hit this `zip` trying to pull elements one by one. Using `mapreduce` instead should fix the problem for these and any other array types that don't like sequential iteration.

The drawback is that this hurts performance for regular CPU arrays (#38558). The slowdown is worse in cases that admit an early short-circuit:

```julia
julia> A = randn(100000); B = copy(A); A[end] = Inf;  # No short-circuit

julia> @btime isapprox(A, B);
  172.186 μs (2 allocations: 781.30 KiB)

julia> @btime isapprox_new(A, B)
  292.771 μs (12 allocations: 879.28 KiB)

julia> A[1] = 0;  # Immediate short-circuit possible

julia> @btime isapprox(A, B);
  79.641 μs (2 allocations: 781.30 KiB)

julia> @btime isapprox_new(A, B);
  292.528 μs (12 allocations: 879.28 KiB)
```

However, note that:

* This branch is a fallback for an exceptional case
* Much worse performance can occur for unrelated reasons, for example:

```julia
julia> A[1] = Inf;  # Why does this make norm(A - B) an order of magnitude slower??

julia> @btime isapprox(A, B);
  726.410 μs (2 allocations: 781.30 KiB)

julia> @btime isapprox_new(A, B);
  966.347 μs (12 allocations: 879.28 KiB)
```

So maybe a temporary slowdown (until `mapreduce` is improved) in this exceptional branch is an acceptable price to pay for more generic code? That way GPUArrays.jl won't have to duplicate the entire method just to change one line.

~Bonus: some `mapreduce` calls in `generic_norm` are really just straightforward applications of `minimum/maximum/sum`, so I rewrote them as such for improved clarity. The behavior should be unchanged. Since this change also concerns reductions in generic linear algebra routines I thought a single PR might suffice even if this is really a separate issue.~

**About tests**

* `isapprox` isn't explicitly tested on arrays. On the other hand, it's the foundation for almost every other test, so in that sense, it's very thoroughly tested.
* ~The `generic_norm` rewrites shouldn't change behavior, so existing tests should suffice.~

EDIT: rolled back the mapreduce simplifications in `norm` since they trigger #44906 and are unrelated to the main issue here.