### PR TITLE
inference: don't widen `iskindtype`-type to `Type` within `tuple_tfunc`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1558,6 +1558,8 @@ function tuple_tfunc(argtypes::Vector{Any})
                 else
                     params[i] = Type
                 end
+            elseif iskindtype(x)
+                params[i] = x
             elseif !isvarargtype(x) && hasintersect(x, Type)
                 params[i] = Union{x, Type}
             else

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1569,6 +1569,8 @@ let tuple_tfunc
     @test Core.Compiler.widenconst(tuple_tfunc(Type{Int})) === Tuple{DataType}
     # https://github.com/JuliaLang/julia/issues/44705
     @test tuple_tfunc(Union{Type{Int32},Type{Int64}}) === Tuple{Type}
+    @test tuple_tfunc(DataType) === Tuple{DataType}
+    @test tuple_tfunc(UnionAll) === Tuple{UnionAll}
 end
 
 function f23024(::Type{T}, ::Int) where T


### PR DESCRIPTION
Follows up #44725.