### PR TITLE
Use EmittedUndefVarErrors Statistic

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4028,6 +4028,7 @@ static jl_cgval_t emit_call(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt)
 
 static void undef_var_error_ifnot(jl_codectx_t &ctx, Value *ok, jl_sym_t *name)
 {
+    ++EmittedUndefVarErrors;
     BasicBlock *err = BasicBlock::Create(ctx.builder.getContext(), "err", ctx.f);
     BasicBlock *ifok = BasicBlock::Create(ctx.builder.getContext(), "ok");
     ctx.builder.CreateCondBr(ok, ifok, err);


### PR DESCRIPTION
Fixes the unused variable warning from #44595 