### PR TITLE
Pool more JIT resources to reduce memory usage/contention

### DIFF
--- a/doc/src/devdocs/locks.md
+++ b/doc/src/devdocs/locks.md
@@ -28,7 +28,6 @@ The following are definitely leaf locks (level 1), and must not try to acquire a
 >   * gc_perm_lock
 >   * flisp
 >   * jl_in_stackwalk (Win32)
->   * PM_mutex[i]
 >   * ResourcePool<?>::mutex
 >
 >     > flisp itself is already threadsafe, this lock only protects the `jl_ast_context_list_t` pool

--- a/doc/src/devdocs/locks.md
+++ b/doc/src/devdocs/locks.md
@@ -29,10 +29,10 @@ The following are definitely leaf locks (level 1), and must not try to acquire a
 >   * flisp
 >   * jl_in_stackwalk (Win32)
 >   * PM_mutex[i]
->   * ContextPool::mutex
+>   * ResourcePool<?>::mutex
 >
 >     > flisp itself is already threadsafe, this lock only protects the `jl_ast_context_list_t` pool
->     > likewise, orc::ThreadSafeContexts carry their own lock, the ContextPool::mutex just protects the pool
+>     > likewise, the ResourcePool<?>::mutexes just protect the associated resource pool
 
 The following is a leaf lock (level 2), and only acquires level 1 locks (safepoint) internally:
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -921,7 +921,7 @@ namespace {
                 JL_TIMING(LLVM_OPT);
 
                 {
-                    (**PMs.acquire()).run(M);
+                    (***PMs).run(M);
                 }
 
                 uint64_t end_time = 0;
@@ -955,7 +955,7 @@ namespace {
         : orc::IRCompileLayer::IRCompiler(MO), TMs(TMCreator(TM, optlevel)) {}
 
         Expected<std::unique_ptr<MemoryBuffer>> operator()(Module &M) override {
-            return orc::SimpleCompiler(**TMs.acquire())(M);
+            return orc::SimpleCompiler(***TMs)(M);
         }
 
         JuliaOJIT::ResourcePool<std::unique_ptr<TargetMachine>> TMs;

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -862,7 +862,7 @@ namespace {
 
     struct TMCreator {
         orc::JITTargetMachineBuilder JTMB;
-        
+
         TMCreator(TargetMachine &TM, int optlevel) : JTMB(createJTMBFromTM(TM, optlevel)) {}
 
         std::unique_ptr<TargetMachine> operator()() {

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -920,9 +920,8 @@ namespace {
 
                 JL_TIMING(LLVM_OPT);
 
-                {
-                    (***PMs).run(M);
-                }
+                //Run the optimization
+                (***PMs).run(M);
 
                 uint64_t end_time = 0;
                 if (dump_llvm_opt_stream != NULL) {

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -193,7 +193,6 @@ public:
     typedef orc::IRCompileLayer CompileLayerT;
     typedef orc::IRTransformLayer OptimizeLayerT;
     typedef object::OwningBinary<object::ObjectFile> OwningObj;
-private:
     template<typename ResourceT, size_t max = 0>
     struct ResourcePool {
         public:
@@ -277,22 +276,9 @@ private:
     };
     struct PipelineT {
         PipelineT(orc::ObjectLayer &BaseLayer, TargetMachine &TM, int optlevel);
-        ResourcePool<std::unique_ptr<legacy::PassManager>> PMs;
         CompileLayerT CompileLayer;
         OptimizeLayerT OptimizeLayer;
-        int optlevel;
     };
-    struct OptimizerT {
-        OptimizerT(ResourcePool<std::unique_ptr<legacy::PassManager>> &PMs, int optlevel) : optlevel(optlevel), PMs(PMs) {}
-
-        OptimizerResultT operator()(orc::ThreadSafeModule M, orc::MaterializationResponsibility &R);
-    private:
-        int optlevel;
-        ResourcePool<std::unique_ptr<legacy::PassManager>> &PMs;
-    };
-    // Custom object emission notification handler for the JuliaOJIT
-    template <typename ObjT, typename LoadResult>
-    void registerObject(const ObjT &Obj, const LoadResult &LO);
 
     struct OptSelLayerT : orc::IRLayer {
 
@@ -307,6 +293,11 @@ private:
         std::unique_ptr<PipelineT> *optimizers;
         size_t count;
     };
+
+private:
+    // Custom object emission notification handler for the JuliaOJIT
+    template <typename ObjT, typename LoadResult>
+    void registerObject(const ObjT &Obj, const LoadResult &LO);
 
 public:
 

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -240,7 +240,7 @@ public:
             ResourcePool &pool;
             llvm::Optional<ResourceT> resource;
         };
-        
+
         OwningResource operator*() {
             return OwningResource(*this, acquire());
         }


### PR DESCRIPTION
Rather than create a new TargetMachine/PassManager for every single compilation (which uses a lot of memory/construction+destruction time) or guarding a single one with a mutex (no parallelism), we can instead share PassManagers/TargetMachines between threads using a simple resource pool. This should hopefully reduce the latency impact in #44568 back to what it was before #44364.

Depends on #44605 for the resource pool implementation. 