### PR TITLE
[src] Fix compilation of `crc32.c` on aarch64 with Clang

### DIFF
--- a/src/crc32c.c
+++ b/src/crc32c.c
@@ -204,7 +204,11 @@ static crc32c_func_t crc32c_dispatch(void)
 #    define crc32c_dispatch_ifunc "crc32c_dispatch"
 #  endif
 #elif defined(_CPU_AARCH64_)
+#ifdef _COMPILER_CLANG_
+#define CRC_TARGET __attribute__((target("crc")))
+#else
 #define CRC_TARGET __attribute__((target("+crc")))
+#endif
 /* Compute CRC-32C using the ARMv8 CRC32 extension. */
 CRC_TARGET static inline uint32_t crc32cx(uint32_t crc, uint64_t val)
 {


### PR DESCRIPTION
Compilation of this file on aarch64 Linux with Clang currently fails with

```console
$ make crc32c.o CC=clang
    CC src/crc32c.o
In file included from /home/mose/repo/julia/src/crc32c.c:45:
In file included from ./julia_internal.h:1021:
In file included from /home/mose/repo/julia/usr/include/libunwind.h:7:
/home/mose/repo/julia/usr/include/libunwind-aarch64.h:60:9: warning: empty struct has size 0 in C, size 1 in C++ [-Wc++-compat]
typedef struct
        ^
/home/mose/repo/julia/usr/include/libunwind-aarch64.h:169:9: warning: empty struct has size 0 in C, size 1 in C++ [-Wc++-compat]
typedef struct unw_tdep_save_loc
        ^
/home/mose/repo/julia/src/crc32c.c:339:22: warning: unused function 'crc32c_dispatch' [-Wunused-function]
static crc32c_func_t crc32c_dispatch(unsigned long hwcap)
                     ^
'++crc' is not a recognized feature for this target (ignoring feature)
'++crc' is not a recognized feature for this target (ignoring feature)
/home/mose/repo/julia/src/crc32c.c:212:9: error: instruction requires: crc
    asm("crc32cx %w0, %w1, %2" : "=r"(res) : "r"(crc), "r"(val));
        ^
<inline asm>:1:2: note: instantiated into assembly here
        crc32cx w0, w0, x1
        ^
/home/mose/repo/julia/src/crc32c.c:218:9: error: instruction requires: crc
    asm("crc32cw %w0, %w1, %w2" : "=r"(res) : "r"(crc), "r"(val));
        ^
<inline asm>:1:2: note: instantiated into assembly here
        crc32cw w0, w0, w1
        ^
/home/mose/repo/julia/src/crc32c.c:224:9: error: instruction requires: crc
    asm("crc32ch %w0, %w1, %w2" : "=r"(res) : "r"(crc), "r"(val));
        ^
<inline asm>:1:2: note: instantiated into assembly here
        crc32ch w0, w0, w1
        ^
/home/mose/repo/julia/src/crc32c.c:230:9: error: instruction requires: crc
    asm("crc32cb %w0, %w1, %w2" : "=r"(res) : "r"(crc), "r"(val));
        ^
<inline asm>:1:2: note: instantiated into assembly here
        crc32cb w0, w0, w1
        ^
3 warnings and 4 errors generated.
make: *** [Makefile:217: crc32c.o] Error 1
```

Compilation on aarch64 macOS with Apple Clang is successful, but there is still
the message about the unrecognized feature:

```console
% rm -f crc32c.o; make crc32c.o
    CC src/crc32c.o
'++crc' is not a recognized feature for this target (ignoring feature)
'++crc' is not a recognized feature for this target (ignoring feature)
```

It appears GCC and Clang disagree on how the target attribute should be
specified: GCC wants `"+crc"`, while Clang wants `"crc"`.  Also Android's zlib
uses `"crc"` only when building with Clang: <https://android.googlesource.com/platform/external/zlib/+/refs/tags/android-platform-12.1.0_r2/crc32_simd.c#187>.

With this change, compilation of Julia on aarch64 Linux with Clang is now
successful.

Fix #44885.