### PR TITLE
Add `skip(::BufferStream, n)`

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1568,3 +1568,5 @@ function flush(s::BufferStream)
         nothing
     end
 end
+
+skip(s::BufferStream, n) = skip(s.buffer, n)


### PR DESCRIPTION
The lack of this method means that we can't use `Tar` with a
`BufferStream` which seems a shame.  A minimal example:

```
julia> using Tar
       mktempdir() do dir
           touch("$(dir)/foo")
           touch("$(dir)/bar")
           mkdir("$(dir)/baz")
           open("$(dir)/baz/qux", write=true) do io
               println(io, rand(UInt8, 1000))
           end
           bs = Base.BufferStream()
           tar_stream = open(`tar c $(dir)`; read=true).out
           @async begin
               write(bs, read(tar_stream))
               close(bs)
           end
           Tar.list(bs)
       end
```

Results in:
```
ERROR: MethodError: no method matching skip(::Base.BufferStream, ::Int64)
Closest candidates are:
  skip(::Base.GenericIOBuffer, ::Integer) at iobuffer.jl:243
  skip(::IOStream, ::Integer) at iostream.jl:184
  skip(::Base.Filesystem.File, ::Integer) at filesystem.jl:251
```

Whereas adding the definition in this PR instead yields:
```
tar: Removing leading `/' from member names
5-element Vector{Tar.Header}:
 Tar.Header("tmp/jl_7b01pO/", :directory, 0o700, 0, "")
 Tar.Header("tmp/jl_7b01pO/foo", :file, 0o664, 0, "")
 Tar.Header("tmp/jl_7b01pO/bar", :file, 0o664, 0, "")
 Tar.Header("tmp/jl_7b01pO/baz/", :directory, 0o775, 0, "")
 Tar.Header("tmp/jl_7b01pO/baz/qux", :file, 0o664, 6006, "")
```