### PR TITLE
CI (`Create Buildbot Statuses`): remove `tester_macos64` from the list

### DIFF
--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -49,7 +49,6 @@ jobs:
           declare -a CONTEXT_LIST=(
                 "buildbot/tester_freebsd64"
                 "buildbot/tester_linux32"
-                "buildbot/tester_macos64"
                 "buildbot/tester_win32"
                 "buildbot/tester_win64"
                 )


### PR DESCRIPTION
Since we have migrated macOS to Buildkite.