### PR TITLE
inference: early const-prop' pass

### DIFF
--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -185,6 +185,11 @@ function decode_effects_override(e::UInt8)
         (e & 0x10) != 0x00)
 end
 
+is_concrete_eval_eligible(eo::EffectsOverride) =
+    eo.consistent &&
+    eo.effect_free &&
+    eo.terminates_globally
+
 """
     InferenceResult
 


### PR DESCRIPTION
We discussed that for certain methods like `:total`ly-declared method or
`@nospecialize`d method we may want to only do constant propagation
while disabling preceding only-type-level inference.

This commit implements a simple infrastructure for such early constant
propagation, and especially setups early concrete evaluation pass.

This commit should recover the regression reported at <https://github.com/JuliaLang/julia/pull/44776#issuecomment-1087339762>
while preserving the advantages and correctness improvements of the
`@assume_effects`-based concrete evaluation enabled in the PR.

---

@nanosoldier `runbenchmarks("inference", vs=":master")`