### PR TITLE
Make gcd/lcm effect-free by using LazyString

### DIFF
--- a/base/checked.jl
+++ b/base/checked.jl
@@ -152,7 +152,7 @@ end
 
 
 throw_overflowerr_binaryop(op, x, y) = (@noinline;
-    throw(OverflowError(Base.invokelatest(string, x, " ", op, " ", y, " overflowed for type ", typeof(x)))))
+    throw(OverflowError(LazyString(x, " ", op, " ", y, " overflowed for type ", typeof(x)))))
 
 """
     Base.checked_add(x, y)

--- a/base/checked.jl
+++ b/base/checked.jl
@@ -115,9 +115,10 @@ function checked_abs end
 
 function checked_abs(x::SignedInt)
     r = ifelse(x<0, -x, x)
-    r<0 && throw(OverflowError(string("checked arithmetic: cannot compute |x| for x = ", x, "::", typeof(x))))
-    r
- end
+    r<0 || return r
+    msg = LazyString("checked arithmetic: cannot compute |x| for x = ", x, "::", typeof(x))
+    throw(OverflowError(msg))
+end
 checked_abs(x::UnsignedInt) = x
 checked_abs(x::Bool) = x
 

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -54,7 +54,7 @@ function gcd(a::T, b::T) where T<:BitInteger
     signbit(r) && __throw_gcd_overflow(a, b)
     return r
 end
-@noinline __throw_gcd_overflow(a, b) = throw(OverflowError("gcd($a, $b) overflows"))
+@noinline __throw_gcd_overflow(a, b) = throw(OverflowError(lazy"gcd($a, $b) overflows"))
 
 # binary GCD (aka Stein's) algorithm
 # about 1.7x (2.1x) faster for random Int64s (Int128s)

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -54,7 +54,8 @@ function gcd(a::T, b::T) where T<:BitInteger
     signbit(r) && __throw_gcd_overflow(a, b)
     return r
 end
-@noinline __throw_gcd_overflow(a, b) = throw(OverflowError(lazy"gcd($a, $b) overflows"))
+@noinline __throw_gcd_overflow(a, b) =
+    throw(OverflowError(LazyString("gcd(", a, ", ", b, ") overflows")))
 
 # binary GCD (aka Stein's) algorithm
 # about 1.7x (2.1x) faster for random Int64s (Int128s)

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -151,7 +151,7 @@ is_effect_free(args...) = Core.Compiler.is_effect_free(Base.infer_effects(args..
 
     @testset "effects" begin
         @test is_effect_free(gcd, Tuple{Int,Int})
-        # @test is_effect_free(lcm, Tuple{Int,Int})
+        @test is_effect_free(lcm, Tuple{Int,Int})
     end
 end
 

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -2,6 +2,8 @@
 
 using Random
 
+is_effect_free(args...) = Core.Compiler.is_effect_free(Base.infer_effects(args...))
+
 @testset "gcd/lcm" begin
     # All Integer data types take different code paths -- test all
     # TODO: Test gcd and lcm for BigInt.
@@ -146,6 +148,11 @@ using Random
     @test gcd(0xf, 20) == 5
     @test gcd(UInt32(6), Int8(-50)) == 2
     @test gcd(typemax(UInt), -16) == 1
+
+    @testset "effects" begin
+        @test is_effect_free(gcd, Tuple{Int,Int})
+        # @test is_effect_free(lcm, Tuple{Int,Int})
+    end
 end
 
 @testset "gcd/lcm for arrays" begin


### PR DESCRIPTION
Before:

```
julia> Base.infer_effects(gcd, Tuple{Int,Int})
(?c,?e,?n,?t)′
```

After:

```
julia> Base.infer_effects(gcd, Tuple{Int,Int})
(?c,+e,?n,?t)
```

When playing with auto-parallelization (https://github.com/JuliaLang/julia/pull/43910, https://github.com/JuliaFolds/ParallelMagics.jl), I wanted to use `gcd` in a demo but it didn't work. I think it's a relatively simple change and also in general it's nice to have. But it's a relatively low-stakes "fix" for me and so I'm OK to not do this if there are some potential problems.
