### PR TITLE
More "thread-safe" LazyString

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -120,7 +120,7 @@ const DenseVecOrMat{T} = Union{DenseVector{T}, DenseMatrix{T}}
 
 ## Basic functions ##
 
-import Core: arraysize, arrayset, arrayref, const_arrayref
+using Core: arraysize, arrayset, const_arrayref
 
 vect() = Vector{Any}()
 vect(X::T...) where {T} = T[ X[i] for i = 1:length(X) ]
@@ -212,7 +212,6 @@ function bitsunionsize(u::Union)
     return sz
 end
 
-length(a::Array) = arraylen(a)
 elsize(@nospecialize _::Type{A}) where {T,A<:Array{T}} = aligned_sizeof(T)
 sizeof(a::Array) = Core.sizeof(a)
 
@@ -919,10 +918,6 @@ julia> getindex(A, "a")
 ```
 """
 function getindex end
-
-# This is more complicated than it needs to be in order to get Win64 through bootstrap
-@eval getindex(A::Array, i1::Int) = arrayref($(Expr(:boundscheck)), A, i1)
-@eval getindex(A::Array, i1::Int, i2::Int, I::Int...) = (@inline; arrayref($(Expr(:boundscheck)), A, i1, i2, I...))
 
 # Faster contiguous indexing using copyto! for AbstractUnitRange and Colon
 function getindex(A::Array, I::AbstractUnitRange{<:Integer})

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -1,10 +1,17 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Core: CodeInfo, SimpleVector, donotdelete
+using Core: CodeInfo, SimpleVector, donotdelete, arrayref
 
 const Callable = Union{Function,Type}
 
 const Bottom = Union{}
+
+# Define minimal array interface here to help code used in macros:
+length(a::Array) = arraylen(a)
+
+# This is more complicated than it needs to be in order to get Win64 through bootstrap
+eval(:(getindex(A::Array, i1::Int) = arrayref($(Expr(:boundscheck)), A, i1)))
+eval(:(getindex(A::Array, i1::Int, i2::Int, I::Int...) = (@inline; arrayref($(Expr(:boundscheck)), A, i1, i2, I...))))
 
 """
     AbstractSet{T}

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -1,5 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+isexpr(@nospecialize(ex), heads) = isa(ex, Expr) && in(ex.head, heads)
+isexpr(@nospecialize(ex), heads, n::Int) = isa(ex, Expr) && in(ex.head, heads) && length(ex.args) == n
+const is_expr = isexpr
+
 ## symbols ##
 
 """

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -74,8 +74,7 @@ julia> Meta.isexpr(ex, :call, 2)
 true
 ```
 """
-isexpr(@nospecialize(ex), heads) = isa(ex, Expr) && in(ex.head, heads)
-isexpr(@nospecialize(ex), heads, n::Int) = isa(ex, Expr) && in(ex.head, heads) && length(ex.args) == n
+isexpr
 
 """
     replace_sourceloc!(location, expr)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1478,8 +1478,6 @@ function operator_associativity(s::Symbol)
     return :left
 end
 
-const is_expr = isexpr
-
 is_quoted(ex)            = false
 is_quoted(ex::QuoteNode) = true
 is_quoted(ex::Expr)      = is_expr(ex, :quote, 1) || is_expr(ex, :inert, 1)

--- a/base/strings/lazy.jl
+++ b/base/strings/lazy.jl
@@ -37,6 +37,7 @@ mutable struct LazyString <: AbstractString
     const parts::Tuple
     # Created on first access
     @atomic str::Union{String,Nothing}
+    global _LazyString(parts, str) = new(parts, str)
     LazyString(args...) = new(args, nothing)
 end
 

--- a/base/strings/lazy.jl
+++ b/base/strings/lazy.jl
@@ -47,6 +47,15 @@ LazyString
 
 !!! compat "Julia 1.8"
     `lazy"str"` requires Julia 1.8 or later.
+
+# Extended help
+## Safety properties for concurrent programs
+
+A lazy string itself does not introduce any concurrency problems even if it is printed in
+multiple Julia tasks.  However, if `print` methods on a captured value can have a
+concurrency issue when invoked without synchronizations, printing the lazy string may cause
+an issue.  Furthermore, the `print` methods on the captured values may be invoked multiple
+times.
 """
 macro lazy_str(text)
     parts = Any[]

--- a/base/strings/lazy.jl
+++ b/base/strings/lazy.jl
@@ -63,14 +63,14 @@ macro lazy_str(text)
 end
 
 function String(l::LazyString)
-    old = @atomic :acquire l.str
+    old = getfield(l, :str, :acquire)
     old === nothing || return old
     str = sprint() do io
         for p in l.parts
             print(io, p)
         end
     end
-    old = @atomicswap :acquire_release l.str = str
+    old = swapfield!(l, :str, str, :acquire_release)
     return something(old, str)
 end
 

--- a/base/strings/lazy.jl
+++ b/base/strings/lazy.jl
@@ -55,7 +55,7 @@ A lazy string itself does not introduce any concurrency problems even if it is p
 multiple Julia tasks.  However, if `print` methods on a captured value can have a
 concurrency issue when invoked without synchronizations, printing the lazy string may cause
 an issue.  Furthermore, the `print` methods on the captured values may be invoked multiple
-times.
+times, though only exactly one result will be returned.
 """
 macro lazy_str(text)
     parts = Any[]

--- a/base/strings/lazy.jl
+++ b/base/strings/lazy.jl
@@ -20,6 +20,18 @@ See also [`lazy"str"`](@ref).
 
 !!! compat "Julia 1.8"
     `LazyString` requires Julia 1.8 or later.
+
+# Extended help
+## Safety properties for concurrent programs
+
+A lazy string itself does not introduce any concurrency problems even if it is printed in
+multiple Julia tasks.  However, if `print` methods on a captured value can have a
+concurrency issue when invoked without synchronizations, printing the lazy string may cause
+an issue.  Furthermore, the `print` methods on the captured values may be invoked multiple
+times.
+
+!!! compat "Julia 1.9"
+    `LazyString` is safe in the above sense in Julia 1.9 and later.
 """
 mutable struct LazyString <: AbstractString
     const parts::Tuple
@@ -35,6 +47,8 @@ Create a [`LazyString`](@ref) using regular string interpolation syntax.
 Note that interpolations are *evaluated* at LazyString construction time,
 but *printing* is delayed until the first access to the string.
 
+See [`LazyString`](@ref) documentation for the safety properties for concurrent programs.
+
 # Examples
 
 ```
@@ -47,15 +61,6 @@ LazyString
 
 !!! compat "Julia 1.8"
     `lazy"str"` requires Julia 1.8 or later.
-
-# Extended help
-## Safety properties for concurrent programs
-
-A lazy string itself does not introduce any concurrency problems even if it is printed in
-multiple Julia tasks.  However, if `print` methods on a captured value can have a
-concurrency issue when invoked without synchronizations, printing the lazy string may cause
-an issue.  Furthermore, the `print` methods on the captured values may be invoked multiple
-times.
 """
 macro lazy_str(text)
     parts = Any[]

--- a/base/strings/lazy.jl
+++ b/base/strings/lazy.jl
@@ -79,8 +79,8 @@ function String(l::LazyString)
             print(io, p)
         end
     end
-    old = swapfield!(l, :str, str, :acquire_release)
-    return something(old, str)
+    old, ok = replacefield!(l, :str, nothing, str, :acquire_release, :acquire)
+    return ok ? str : (old::String)
 end
 
 hash(s::LazyString, h::UInt64) = hash(String(s), h)

--- a/base/strings/lazy.jl
+++ b/base/strings/lazy.jl
@@ -78,16 +78,14 @@ macro lazy_str(text)
 end
 
 function String(l::LazyString)
-    # Note: Not using `@atomic*` macros since they cannot be invoked due to a missing
-    # `length` method.
-    old = getfield(l, :str, :acquire)
+    old = @atomic :acquire l.str
     old === nothing || return old
     str = sprint() do io
         for p in l.parts
             print(io, p)
         end
     end
-    old, ok = replacefield!(l, :str, nothing, str, :acquire_release, :acquire)
+    old, ok = @atomicreplace :acquire_release :acquire l.str nothing => str
     return ok ? str : (old::String)
 end
 

--- a/base/strings/lazy.jl
+++ b/base/strings/lazy.jl
@@ -72,6 +72,8 @@ macro lazy_str(text)
 end
 
 function String(l::LazyString)
+    # Note: Not using `@atomic*` macros since they cannot be invoked due to a missing
+    # `length` method.
     old = getfield(l, :str, :acquire)
     old === nothing || return old
     str = sprint() do io

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1565,5 +1565,7 @@ function deserialize(s::AbstractSerializer, ::Type{T}) where T<:Base.GenericCond
     return cond
 end
 
+serialize(s::AbstractSerializer, l::LazyString) =
+    invoke(serialize, Tuple{AbstractSerializer,Any}, s, Base._LazyString((), string(l)))
 
 end

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -642,3 +642,11 @@ let c1 = Threads.Condition()
     unlock(c2)
     wait(t)
 end
+
+@testset "LazyString" begin
+    l1 = lazy"a $1 b $2"
+    l2 = deserialize(IOBuffer(sprint(serialize, l1)))
+    @test l2.str === l1.str
+    @test l2 == l1
+    @test l2.parts === ()
+end


### PR DESCRIPTION
This patch makes `LazyString` thread-safe in the sense that

https://github.com/JuliaLang/julia/blob/4b7b1fd21184447076118e3198a8168235b486a8/base/strings/lazy.jl#L52-L58

It's probably a non-issue ATM but it's also very cheap to do this anyway. I just noticed it while writing #44935.