### PR TITLE
Fix formatting issue in print statement in gc-debug.c

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -982,12 +982,12 @@ void gc_time_summary(int sweep_full, uint64_t start, uint64_t end,
                      uint64_t pause)
 {
     if (sweep_full > 0)
-        jl_safe_printf("TS: %" PRIu64 " Major collection: estimate freed = %" PRIu64 
+        jl_safe_printf("TS: %" PRIu64 " Major collection: estimate freed = %" PRIu64
                        " live = %" PRIu64 "m new interval = %" PRIu64 "m time = %" PRIu64 "ms\n",
                        end - start, freed, live/1024/1024,
                        interval/1024/1024, pause/1000000 );
     else
-        jl_safe_printf("TS: %" PRIu64 " Minor collection: estimate freed = %" PRIu64 " live = %" PRIu64 
+        jl_safe_printf("TS: %" PRIu64 " Minor collection: estimate freed = %" PRIu64 " live = %" PRIu64
                        "m new interval = %" PRIu64 "m time = %" PRIu64 "ms\n",
                        end - start, freed, live/1024/1024,
                        interval/1024/1024, pause/1000000 );

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -982,13 +982,13 @@ void gc_time_summary(int sweep_full, uint64_t start, uint64_t end,
                      uint64_t pause)
 {
     if (sweep_full > 0)
-        jl_safe_printf("%ld Major collection: estimate freed = %ld\n"
-                       "live = %ldm new interval = %ldm time = %ldms\n",
+        jl_safe_printf("TS: %" PRIu64 " Major collection: estimate freed = %" PRIu64 
+                       " live = %" PRIu64 "m new interval = %" PRIu64 "m time = %" PRIu64 "ms\n",
                        end - start, freed, live/1024/1024,
                        interval/1024/1024, pause/1000000 );
     else
-        jl_safe_printf("%ld Minor collection: estimate freed = %ld live = %ldm\n"
-                       "new interval = %ldm time = %ldms\n",
+        jl_safe_printf("TS: %" PRIu64 " Minor collection: estimate freed = %" PRIu64 " live = %" PRIu64 
+                       "m new interval = %" PRIu64 "m time = %" PRIu64 "ms\n",
                        end - start, freed, live/1024/1024,
                        interval/1024/1024, pause/1000000 );
 }


### PR DESCRIPTION
This %ld format was causing a compile error and PRIu64 is a better choice anyway.