### PR TITLE
Export LLVM module custom tagging

### DIFF
--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -102,6 +102,8 @@ JL_DLLEXPORT LLVMOrcThreadSafeModuleRef jl_get_llvm_module_fallback(void *native
 
 JL_DLLEXPORT void *jl_type_to_llvm_fallback(jl_value_t *jt, LLVMContextRef llvmctxt, bool_t *isboxed) UNAVAILABLE
 
+JL_DLLEXPORT void jl_tag_llvm_module_fallback(LLVMModuleRef mod, int imaging_mode, LLVMTargetDataRef DL, const char *triple) UNAVAILABLE;
+
 JL_DLLEXPORT jl_value_t *jl_get_libllvm_fallback(void) JL_NOTSAFEPOINT
 {
     return jl_nothing;

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -548,6 +548,7 @@
     YY(jl_dump_fptr_asm) \
     YY(jl_get_function_id) \
     YY(jl_type_to_llvm) \
+    YY(jl_tag_llvm_module) \
     YY(jl_getUnwindInfo) \
     YY(jl_get_libllvm) \
     YY(jl_add_optimization_passes) \


### PR DESCRIPTION
GPUCompiler would like to access the standard flags that Julia adds to its LLVM modules.

cc @jpsamaroo 