### PR TITLE
Temporarily move the `REPL` test suite to node 1, to buy us time until we fix the underlying bugs

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,6 +78,11 @@ move_to_node1("Distributed")
 # Ensure things like consuming all kernel pipe memory doesn't interfere with other tests
 move_to_node1("stress")
 
+# TODO: remove `REPL` from the "move to node 1" tests.
+# We first need to fix the underlying bugs that are causing the `REPL` tests to frequently
+# fail on the `test x86_64-apple-darwin` tester on Buildkite.
+move_to_node1("REPL")
+
 # In a constrained memory environment, run the "distributed" test after all other tests
 # since it starts a lot of workers and can easily exceed the maximum memory
 limited_worker_rss && move_to_node1("Distributed")


### PR DESCRIPTION
Just a band-aid to get CI green while we try to fix the underlying bugs that are causing the `REPL` tests to fail on `test x86_64-apple-darwin` when they are not run on node 1.

Closes #44963