### PR TITLE
inference: properly compare vararg-tuple `PartialStruct`s

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1280,7 +1280,6 @@ function abstract_apply(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::
                     # This is vararg, we're not gonna be able to do any inling,
                     # drop the info
                     info = nothing
-
                     tail = tuple_tail_elem(unwrapva(ct[end]), cti)
                     push!(ctypes´, push!(ct[1:(end - 1)], tail))
                 else
@@ -1300,8 +1299,9 @@ function abstract_apply(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::
         lct = length(ct)
         # truncate argument list at the first Vararg
         for i = 1:lct-1
-            if isvarargtype(ct[i])
-                ct[i] = tuple_tail_elem(ct[i], ct[(i+1):lct])
+            cti = ct[i]
+            if isvarargtype(cti)
+                ct[i] = tuple_tail_elem(unwrapva(cti), ct[(i+1):lct])
                 resize!(ct, i)
                 break
             end

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -313,7 +313,7 @@ function issimplertype(@nospecialize(typea), @nospecialize(typeb))
     if typea isa PartialStruct
         aty = widenconst(typea)
         for i = 1:length(typea.fields)
-            ai = typea.fields[i]
+            ai = unwrapva(typea.fields[i])
             bi = fieldtype(aty, i)
             is_lattice_equal(ai, bi) && continue
             tni = _typename(widenconst(ai))

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4092,6 +4092,11 @@ end
     Core.Compiler.return_type(+, NTuple{2, Rational})
 end == Rational
 
+# https://github.com/JuliaLang/julia/issues/44965
+let t = Core.Compiler.tuple_tfunc(Any[Core.Const(42), Vararg{Any}])
+    @test Core.Compiler.issimplertype(t, t)
+end
+
 # https://github.com/JuliaLang/julia/issues/44763
 global x44763::Int = 0
 increase_x44763!(n) = (global x44763; x44763 += n)


### PR DESCRIPTION
Within the `issimplertype` query.
Fix #44965.

---

Unrelated but another commit also adds
one more missing `Vararg` handling 
found from a code review.