### PR TITLE
add tuple type printing with `Vararg`, and port to static_show

### DIFF
--- a/test/show.jl
+++ b/test/show.jl
@@ -1338,6 +1338,8 @@ test_repr("(:).a")
 @test repr(NTuple{7,Int64}) == "NTuple{7, Int64}"
 @test repr(Tuple{Float64, Float64, Float64, Float64}) == "NTuple{4, Float64}"
 @test repr(Tuple{Float32, Float32, Float32}) == "Tuple{Float32, Float32, Float32}"
+@test repr(Tuple{String, Int64, Int64, Int64}) == "Tuple{String, Int64, Int64, Int64}"
+@test repr(Tuple{String, Int64, Int64, Int64, Int64}) == "Tuple{String, Vararg{Int64, 4}}"
 
 @testset "issue #42931" begin
     @test repr(NTuple{4, :A}) == "NTuple{4, :A}"


### PR DESCRIPTION
This adds the ability to print long tuple types with `Vararg`, and adds the logic for printing as `NTuple` or `Vararg` to static_show.