### PR TITLE
[REPL] Fix a REPL test failure by removing an erroneous space in test (introduced by #33805)

### DIFF
--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -264,7 +264,7 @@ fake_repl(options = REPL.Options(confirm_exit=false,hascolor=true)) do stdin_wri
         write(stdin_write, ";")
         readuntil(stdout_read, "shell> ")
         Base.print_shell_escaped(stdin_write, Base.julia_cmd().exec..., special=Base.shell_special)
-        write(stdin_write, """ -e "println(\\"HI\\")\" """)
+        write(stdin_write, """ -e "println(\\"HI\\")\"""")
         readuntil(stdout_read, ")\"")
         proc_stdout_read, proc_stdout = redirect_stdout()
         get_stdout = @async read(proc_stdout_read, String)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,11 +78,6 @@ move_to_node1("Distributed")
 # Ensure things like consuming all kernel pipe memory doesn't interfere with other tests
 move_to_node1("stress")
 
-# TODO: remove `REPL` from the "move to node 1" tests.
-# We first need to fix the underlying bugs that are causing the `REPL` tests to frequently
-# fail on the `test x86_64-apple-darwin` tester on Buildkite.
-move_to_node1("REPL")
-
 # In a constrained memory environment, run the "distributed" test after all other tests
 # since it starts a lot of workers and can easily exceed the maximum memory
 limited_worker_rss && move_to_node1("Distributed")


### PR DESCRIPTION
Fixes the REPL test failure introduced by #33805 a couple years ago