### PR TITLE
Add debugging function to print all the Task backtraces on a given thread (`jl_wassup`)

### DIFF
--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -788,6 +788,30 @@ JL_DLLEXPORT void jl_print_backtrace(void) JL_NOTSAFEPOINT
     jlbacktrace();
 }
 
+JL_DLLEXPORT void jl_thread_print_all_task_backtraces(void)
+{
+    jl_safe_printf("Wassup!\n");
+    jl_task_t *ct = jl_current_task;
+    jl_ptls_t ptls = ct->ptls;
+    arraylist_t *live_tasks = &ptls->heap.live_tasks;
+    size_t i, l;
+    l = live_tasks->len;
+    jl_safe_printf("%zu live tasks\n", 1 + l);
+    void **lst = live_tasks->items;
+    jl_safe_printf("==== Task Root\n");
+    jlbacktracet(ptls->root_task);
+    // Note: length of live tasks might change?
+    for (i = 0; i < live_tasks->len; i++) {
+        jl_safe_printf("==== Task %lu\n", i+1);
+        if (((jl_task_t*)lst[i])->stkbuf != NULL) {
+            jlbacktracet((jl_task_t*)lst[i]);
+        } else {
+            jl_safe_printf("stkbuf == NULL\n");
+        }
+    }
+    jl_safe_printf("==== Done ==== \n", i+1);
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Not as cool of a name as `jl_wassup`:

```julia
julia> @ccall jl_thread_print_all_task_backtraces()::Nothing
Wassup!
2 live tasks
==== Task Root
jl_rec_backtrace at /Users/nathandaly/src/julia/src/stackwalk.c:708 [inlined]
jlbacktracet at /Users/nathandaly/src/julia/src/stackwalk.c:778 [inlined]
jl_thread_print_all_task_backtraces at /Users/nathandaly/src/julia/src/stackwalk.c:802
top-level scope at ./REPL[2]:1
jl_toplevel_eval_flex at /Users/nathandaly/src/julia/src/toplevel.c:900
jl_toplevel_eval_flex at /Users/nathandaly/src/julia/src/toplevel.c:853
ijl_toplevel_eval at /Users/nathandaly/src/julia/src/toplevel.c:918 [inlined]
ijl_toplevel_eval_in at /Users/nathandaly/src/julia/src/toplevel.c:968
eval at ./boot.jl:370 [inlined]
eval_user_input at /Users/nathandaly/src/julia/usr/share/julia/stdlib/v1.9/REPL/src/REPL.jl:151
repl_backend_loop at /Users/nathandaly/src/julia/usr/share/julia/stdlib/v1.9/REPL/src/REPL.jl:246
start_repl_backend at /Users/nathandaly/src/julia/usr/share/julia/stdlib/v1.9/REPL/src/REPL.jl:231
run_repl at /Users/nathandaly/src/julia/usr/share/julia/stdlib/v1.9/REPL/src/REPL.jl:355
jfptr_run_repl_64448 at /Users/nathandaly/src/julia/usr/lib/julia/sys.dylib (unknown line)
_jl_invoke at /Users/nathandaly/src/julia/src/gf.c:0 [inlined]
ijl_apply_generic at /Users/nathandaly/src/julia/src/gf.c:2549
jfptr_YY.966_32792 at /Users/nathandaly/src/julia/usr/lib/julia/sys.dylib (unknown line)
_jl_invoke at /Users/nathandaly/src/julia/src/gf.c:0 [inlined]
ijl_apply_generic at /Users/nathandaly/src/julia/src/gf.c:2549
jl_apply at /Users/nathandaly/src/julia/src/./julia.h:1837 [inlined]
jl_f__call_latest at /Users/nathandaly/src/julia/src/builtins.c:774
invokelatest at ./essentials.jl:755 [inlined]
run_main_repl at ./client.jl:404
exec_options at ./client.jl:318
_start at ./client.jl:518
jfptr__start_31542 at /Users/nathandaly/src/julia/usr/lib/julia/sys.dylib (unknown line)
_jl_invoke at /Users/nathandaly/src/julia/src/gf.c:0 [inlined]
ijl_apply_generic at /Users/nathandaly/src/julia/src/gf.c:2549
jl_apply at /Users/nathandaly/src/julia/src/./julia.h:1837 [inlined]
true_main at /Users/nathandaly/src/julia/src/jlapi.c:558
jl_repl_entrypoint at /Users/nathandaly/src/julia/src/jlapi.c:702
==== Task 1
==== Done ====
```