### PR TITLE
test cleanup for #44444

### DIFF
--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1070,7 +1070,7 @@ end
                 GC.enable_logging(false)
             end
         end
-        @test occursin("GC: pause", read(open(tmppath), String))
+        @test occursin("GC: pause", read(tmppath, String))
     end
 end
 


### PR DESCRIPTION
This warning was un-ironically introduced by "Fix or suppress some noisy tests".
```
┌ Error: mktemp cleanup
│   exception =
│    IOError: unlink("C:\\Windows\\TEMP\\jl_A49B.tmp"): resource busy or locked (EBUSY)
│    Stacktrace:
│      [1] uv_error
│        @ .\libuv.jl:100 [inlined]
│      [2] unlink(p::String)
│        @ Base.Filesystem .\file.jl:968
│      [3] rm(path::String; force::Bool, recursive::Bool)
│        @ Base.Filesystem .\file.jl:283
│      [4] rm
│        @ .\file.jl:274 [inlined]
│      [5] mktemp(fn::Main.Test49Main_misc.var"#110#113", parent::String)
│        @ Base.Filesystem .\file.jl:736
│      [6] mktemp(fn::Function)
│        @ Base.Filesystem .\file.jl:730
│      [7] macro expansion
│        @ C:\buildbot\worker-tabularasa\tester_win64\build\share\julia\test\misc.jl:1065 [inlined]
│      [8] macro expansion
│        @ C:\buildbot\worker-tabularasa\tester_win64\build\share\julia\stdlib\v1.9\Test\src\Test.jl:1360 [inlined]
│      [9] top-level scope
│        @ C:\buildbot\worker-tabularasa\tester_win64\build\share\julia\test\misc.jl:1060
│     [10] include
│        @ .\Base.jl:427 [inlined]
│     [11] macro expansion
│        @ C:\buildbot\worker-tabularasa\tester_win64\build\share\julia\test\testdefs.jl:24 [inlined]
│     [12] macro expansion
│        @ C:\buildbot\worker-tabularasa\tester_win64\build\share\julia\stdlib\v1.9\Test\src\Test.jl:1360 [inlined]
│     [13] macro expansion
│        @ C:\buildbot\worker-tabularasa\tester_win64\build\share\julia\test\testdefs.jl:23 [inlined]
│     [14] macro expansion
│        @ .\timing.jl:440 [inlined]
│     [15] runtests(name::String, path::String, isolate::Bool; seed::UInt128)
│        @ Main C:\buildbot\worker-tabularasa\tester_win64\build\share\julia\test\testdefs.jl:21
│     [16] invokelatest(::Any, ::Any, ::Vararg{Any}; kwargs::Base.Pairs{Symbol, UInt128, Tuple{Symbol}, NamedTuple{(:seed,), Tuple{UInt128}}})
│        @ Base .\essentials.jl:798
│     [17] (::Distributed.var"#110#112"{Distributed.CallMsg{:call_fetch}})()
│        @ Distributed C:\buildbot\worker-tabularasa\tester_win64\build\share\julia\stdlib\v1.9\Distributed\src\process_messages.jl:285
│     [18] run_work_thunk(thunk::Distributed.var"#110#112"{Distributed.CallMsg{:call_fetch}}, print_error::Bool)
│        @ Distributed C:\buildbot\worker-tabularasa\tester_win64\build\share\julia\stdlib\v1.9\Distributed\src\process_messages.jl:70
│     [19] macro expansion
│        @ C:\buildbot\worker-tabularasa\tester_win64\build\share\julia\stdlib\v1.9\Distributed\src\process_messages.jl:285 [inlined]
│     [20] (::Distributed.var"#109#111"{Distributed.CallMsg{:call_fetch}, Distributed.MsgHeader, Sockets.TCPSocket})()
│        @ Distributed .\task.jl:490
└ @ Base.Filesystem file.jl:738
```