### PR TITLE
Move DEBUG_TYPE below LLVM headers

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1,6 +1,5 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
-#define DEBUG_TYPE "julia_irgen_codegen"
 #undef DEBUG
 #include "llvm-version.h"
 #include "platform.h"
@@ -86,6 +85,8 @@
 #include "llvm/Support/Path.h" // for llvm::sys::path
 #include <llvm/Bitcode/BitcodeReader.h>
 #include <llvm/Linker/Linker.h>
+
+#define DEBUG_TYPE "julia_irgen_codegen"
 
 using namespace llvm;
 

--- a/src/llvm-alloc-opt.cpp
+++ b/src/llvm-alloc-opt.cpp
@@ -1,6 +1,5 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
-#define DEBUG_TYPE "alloc_opt"
 #undef DEBUG
 #include "llvm-version.h"
 
@@ -38,6 +37,7 @@
 #include <map>
 #include <set>
 
+#define DEBUG_TYPE "alloc_opt"
 #include "julia_assert.h"
 
 using namespace llvm;


### PR DESCRIPTION
Some LLVM headers set DEBUG_TYPE internally (and undef it later),
causing build failures with the newly added STATISTICs. Fix that
by moving DEBUG_TYPE below the headers.

[1] https://github.com/llvm/llvm-project/blob/09c2b7c35af8c4bad39f03e9f60df8bd07323028/llvm/include/llvm/Support/GenericDomTreeConstruction.h#L49