### PR TITLE
Refresh stale file handles for REPL history.

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -526,6 +526,7 @@ end
 
 mutable struct REPLHistoryProvider <: HistoryProvider
     history::Vector{String}
+    file_path::String
     history_file::Union{Nothing,IO}
     start_idx::Int
     cur_idx::Int
@@ -536,7 +537,7 @@ mutable struct REPLHistoryProvider <: HistoryProvider
     modes::Vector{Symbol}
 end
 REPLHistoryProvider(mode_mapping::Dict{Symbol}) =
-    REPLHistoryProvider(String[], nothing, 0, 0, -1, IOBuffer(),
+    REPLHistoryProvider(String[], "", nothing, 0, 0, -1, IOBuffer(),
                         nothing, mode_mapping, UInt8[])
 
 invalid_history_message(path::String) = """
@@ -548,6 +549,12 @@ Invalid character: """
 munged_history_message(path::String) = """
 Invalid history file ($path) format:
 An editor may have converted tabs to spaces at line """
+
+function hist_open_file(hp::REPLHistoryProvider)
+    f = open(hp.file_path, read=true, write=true, create=true)
+    hp.history_file = f
+    seekend(f)
+end
 
 function hist_from_file(hp::REPLHistoryProvider, path::String)
     getline(lines, i) = i > length(lines) ? "" : lines[i]
@@ -617,7 +624,14 @@ function add_history(hist::REPLHistoryProvider, s::PromptState)
     $(replace(str, r"^"ms => "\t"))
     """
     # TODO: write-lock history file
-    seekend(hist.history_file)
+    try
+        seekend(hist.history_file)
+    catch err
+        (err isa SystemError) || rethrow()
+        # File handle might get stale after a while, especially under network file systems
+        # If this doesn't fix it (e.g. when file is deleted), we'll end up rethrowing anyway
+        hist_open_file(hist)
+    end
     print(hist.history_file, entry)
     flush(hist.history_file)
     nothing
@@ -993,11 +1007,10 @@ function setup_interface(
         try
             hist_path = find_hist_file()
             mkpath(dirname(hist_path))
-            f = open(hist_path, read=true, write=true, create=true)
-            hp.history_file = f
-            seekend(f)
+            hp.file_path = hist_path
+            hist_open_file(hp)
             finalizer(replc) do replc
-                close(f)
+                close(hp.history_file)
             end
             hist_from_file(hp, hist_path)
         catch


### PR DESCRIPTION
Often, when running multiple Julia REPLs on a Linux cluster with network-mounted home directories, the REPL's history file handle becomes stale and each new line errors out with the following:

```
┌ Error: Error in the keymap
│   exception =
│    SystemError: seekend: Stale file handle
│    Stacktrace:
│      [1] systemerror(p::String, errno::Int32; extrainfo::Nothing)
│        @ Base ./error.jl:168
│      [2] #systemerror#62
│        @ ./error.jl:167 [inlined]
│      [3] systemerror
│        @ ./error.jl:167 [inlined]
│      [4] seekend(s::IOStream)
│        @ Base ./iostream.jl:163
│      [5] add_history(hist::REPL.REPLHistoryProvider, s::REPL.LineEdit.PromptState)
│        @ REPL /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/REPL.jl:562
│      [6] add_history(s::REPL.LineEdit.PromptState)
│        @ REPL.LineEdit /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/LineEdit.jl:1248
│      [7] add_history(::REPL.LineEdit.MIState)
│        @ REPL.LineEdit /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/LineEdit.jl:227
│      [8] commit_line(s::REPL.LineEdit.MIState)
│        @ REPL.LineEdit /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/LineEdit.jl:2081
│      [9] (::REPL.LineEdit.var"#110#163")(::REPL.LineEdit.MIState, ::Any, ::Vararg{Any, N} where N)
│        @ REPL.LineEdit /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/LineEdit.jl:2163
│     [10] #invokelatest#2
│        @ ./essentials.jl:708 [inlined]
│     [11] invokelatest
│        @ ./essentials.jl:706 [inlined]
│     [12] (::REPL.LineEdit.var"#22#23"{REPL.LineEdit.var"#110#163", String})(s::Any, p::Any)
│        @ REPL.LineEdit /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/LineEdit.jl:1414
│     [13] prompt!(term::REPL.Terminals.TextTerminal, prompt::REPL.LineEdit.ModalInterface, s::REPL.LineEdit.MIState)
│        @ REPL.LineEdit /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/LineEdit.jl:2534
│     [14] run_interface(terminal::REPL.Terminals.TextTerminal, m::REPL.LineEdit.ModalInterface, s::REPL.LineEdit.MIState)
│        @ REPL.LineEdit /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/LineEdit.jl:2436
│     [15] run_frontend(repl::REPL.LineEditREPL, backend::REPL.REPLBackendRef)
│        @ REPL /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/REPL.jl:1126
│     [16] (::REPL.var"#44#49"{REPL.LineEditREPL, REPL.REPLBackendRef})()
│        @ REPL ./task.jl:406
└ @ REPL.LineEdit /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/LineEdit.jl:2536
```

I introduced a small fix to attempt reopening the file after a `SystemError`, thus refreshing the handle. This is my first time contributing so all feedback is welcome.