### PR TITLE
Update docstring and tests for `isdiag`

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1373,7 +1373,9 @@ isbanded(A::AbstractMatrix, kl::Integer, ku::Integer) = istriu(A, kl) && istril(
 """
     isdiag(A) -> Bool
 
-Test whether a matrix is diagonal. This function doesn't check the matrix is square.
+Test whether a matrix is diagonal in the sense that `iszero(A[i,j])` is true unless `i == j`.
+Note that it is not necessary for `A` to be square;
+if you would also like to check that, you need to check that `size(A, 1) == size(A, 2)`.
 
 # Examples
 ```jldoctest

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1373,7 +1373,7 @@ isbanded(A::AbstractMatrix, kl::Integer, ku::Integer) = istriu(A, kl) && istril(
 """
     isdiag(A) -> Bool
 
-Test whether a matrix is diagonal.
+Test whether a matrix is diagonal. This function doesn't check the matrix is square.
 
 # Examples
 ```jldoctest
@@ -1392,6 +1392,22 @@ julia> b = [im 0; 0 -im]
 
 julia> isdiag(b)
 true
+
+julia> c = [1 0 0; 0 2 0]
+2×3 Matrix{Int64}:
+ 1  0  0
+ 0  2  0
+
+julia> isdiag(c)
+true
+
+julia> d = [1 0 0; 0 2 3]
+2×3 Matrix{Int64}:
+ 1  0  0
+ 0  2  3
+
+julia> isdiag(d)
+false
 ```
 """
 isdiag(A::AbstractMatrix) = isbanded(A, 0, 0)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1634,15 +1634,26 @@ end
 end
 
 @testset "isdiag, istril, istriu" begin
+    # Scalar
     @test isdiag(3)
     @test istril(4)
     @test istriu(5)
+
+    # Square matrix
     @test !isdiag([1 2; 3 4])
     @test !istril([1 2; 3 4])
     @test !istriu([1 2; 3 4])
     @test isdiag([1 0; 0 4])
     @test istril([1 0; 3 4])
     @test istriu([1 2; 0 4])
+
+    # Non-square matrix
+    @test !isdiag([1 2 0; 3 4 0])
+    @test !istril([1 2 0; 3 4 0])
+    @test !istriu([1 2 0; 3 4 0])
+    @test isdiag([1 0 0; 0 4 0])
+    @test istril([1 0 0; 3 4 0])
+    @test istriu([1 2 0; 0 4 0])
 end
 
 # issue 4228

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1654,6 +1654,12 @@ end
     @test isdiag([1 0 0; 0 4 0])
     @test istril([1 0 0; 3 4 0])
     @test istriu([1 2 0; 0 4 0])
+    @test !isdiag([1 2 0; 3 4 1])
+    @test !istril([1 2 0; 3 4 1])
+    @test !istriu([1 2 0; 3 4 1])
+    @test !isdiag([1 0 0; 0 4 1])
+    @test !istril([1 0 0; 3 4 1])
+    @test istriu([1 2 0; 0 4 1])
 end
 
 # issue 4228


### PR DESCRIPTION
This PR adds more docstring and tests for `isdiag` with a non-square matrix argument.

---

The `LinearAlgebra.isdiag` function checks a matrix is a diagonal matrix.

```julia
julia> using LinearAlgebra

julia> isdiag([1 0;0 3])
true

julia> isdiag([1 0;0 3;0 0])
true
```
The last behavior with a non-square matrix is not documented and tested.
At first, I thought that may be a bug, but I now think it is expected and just missing documentation for the following reasons.

* `DiagonalMatrixQ` function in Mathematica has the same behavior.
  * https://reference.wolfram.com/language/ref/DiagonalMatrixQ.html
* `isdiag` in MATLAB has the same behavior.
  * https://mathworks.com/help/matlab/ref/isdiag.html
* This is sometimes useful in practical aspects as well.
  * e.g. https://github.com/JuliaLang/julia/blob/v1.7.2/stdlib/LinearAlgebra/src/dense.jl#L1433
