### PR TITLE
Add docstring for fallback `fetch(::Any)` method

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -347,6 +347,11 @@ function wait(t::Task)
     nothing
 end
 
+"""
+    fetch(x::Any)
+
+Return `x`.
+"""
 fetch(@nospecialize x) = x
 
 """

--- a/doc/src/base/parallel.md
+++ b/doc/src/base/parallel.md
@@ -33,6 +33,7 @@ Base.errormonitor
 Base.@sync
 Base.wait
 Base.fetch(t::Task)
+Base.fetch(x::Any)
 Base.timedwait
 
 Base.Condition


### PR DESCRIPTION
We cannot just include `Base.fetch` in the `@docs` block as some methods should keep being documented in the Distributed stdlib rather than in Base.

The method was imported from stdlib by https://github.com/JuliaLang/julia/pull/30961.