### PR TITLE
Fix attributes for `donotdelete` intrinsic

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -500,7 +500,7 @@ static AttributeList get_donotdelete_func_attrs(LLVMContext &C)
     FnAttrs = FnAttrs.addAttribute(C, Attribute::NoUnwind);
     return AttributeList::get(C,
             FnAttrs,
-            Attributes(C, {Attribute::NonNull}),
+            Attributes(C, {}),
             None);
 }
 


### PR DESCRIPTION
The change in #44793 changed the signature of the donotdelete intrinsic,
but didn't change the corresponding attributes, leaving a `nonnull` attribute
on a `void` return, which fails the verifier.