### PR TITLE
Enable opaque pointers for LLVM master

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2035,6 +2035,8 @@ static void emit_memcpy_llvm(jl_codectx_t &ctx, Value *dst, MDNode *tbaa_dst, Va
     // If the types are small and simple, use load and store directly.
     // Going through memcpy can cause LLVM (e.g. SROA) to create bitcasts between float and int
     // that interferes with other optimizations.
+#ifndef JL_LLVM_OPAQUE_POINTERS
+    // TODO: Restore this for opaque pointers? Needs extra type information from the caller.
     if (sz <= 64) {
         // The size limit is arbitrary but since we mainly care about floating points and
         // machine size vectors this should be enough.
@@ -2073,6 +2075,7 @@ static void emit_memcpy_llvm(jl_codectx_t &ctx, Value *dst, MDNode *tbaa_dst, Va
             return;
         }
     }
+#endif
     // the memcpy intrinsic does not allow to specify different alias tags
     // for the load part (x.tbaa) and the store part (ctx.tbaa().tbaa_stack).
     // since the tbaa lattice has to be a tree we have unfortunately

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -981,7 +981,13 @@ JuliaOJIT::JuliaOJIT()
 #endif
     GlobalJD(ES.createBareJITDylib("JuliaGlobals")),
     JD(ES.createBareJITDylib("JuliaOJIT")),
-    ContextPool([](){ return orc::ThreadSafeContext(std::make_unique<LLVMContext>()); }),
+    ContextPool([](){
+        auto ctx = std::make_unique<LLVMContext>();
+#ifdef JL_LLVM_OPAQUE_POINTERS
+        ctx->enableOpaquePointers();
+#endif
+        return orc::ThreadSafeContext(std::move(ctx));
+    }),
 #ifdef JL_USE_JITLINK
     // TODO: Port our memory management optimisations to JITLink instead of using the
     // default InProcessMemoryManager.

--- a/src/llvm-version.h
+++ b/src/llvm-version.h
@@ -13,6 +13,10 @@
     #error Only LLVM versions >= 12.0.0 are supported by Julia
 #endif
 
+#if JL_LLVM_VERSION >= 150000
+#define JL_LLVM_OPAQUE_POINTERS 1
+#endif
+
 #ifdef __cplusplus
 #if defined(__GNUC__) && (__GNUC__ >= 9)
 // Added in GCC 9, this warning is annoying


### PR DESCRIPTION
Essentially a rebase of #44334 to current master. I would like to work on
some IR canonicalization improvements, but it doesn't make much sense
to that without opaque pointers, since canonical forms will change.

This bootstraps fine on LLVM master, though there are test failures
both with and without this change. I think we'll just have to address
those as part of the regular upgrade cycle as usual (though we should
probably do LLVM 14 first to catch any 13->14 regressions).