### PR TITLE
Report any recompilation in time macro

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,7 @@ Library changes
   tasks mutating the dictionary or set ([#44534]).
 * Predicate function negation `!f` now returns a composed function `(!) ∘ f` instead of an anonymous function ([#44752]).
 * `RoundFromZero` now works for non-`BigFloat` types ([#41246]).
+* `@time` now separates out % time spent recompiling invalidated methods ([#45015]).
 
 
 Standard library changes

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -131,7 +131,7 @@ function time_print(elapsedtime, bytes=0, gctime=0, allocs=0, compile_time=0, re
     str = sprint() do io
         _lpad && print(io, length(timestr) < 10 ? (" "^(10 - length(timestr))) : "")
         print(io, timestr, " seconds")
-        parens = bytes != 0 || allocs != 0 || gctime > 0 || compile_time > 0 || recompile_time > 0
+        parens = bytes != 0 || allocs != 0 || gctime > 0 || compile_time > 0
         parens && print(io, " (")
         if bytes != 0 || allocs != 0
             allocs, ma = prettyprint_getunits(allocs, length(_cnt_units), Int64(1000))
@@ -155,10 +155,8 @@ function time_print(elapsedtime, bytes=0, gctime=0, allocs=0, compile_time=0, re
             print(io, Ryu.writefixed(Float64(100*compile_time/elapsedtime), 2), "% compilation time")
         end
         if recompile_time > 0
-            if bytes != 0 || allocs != 0 || gctime > 0 || compile_time > 0
-                print(io, ", ")
-            end
-            print(io, Ryu.writefixed(Float64(100*recompile_time/elapsedtime), 2), "% recompilation time")
+            amount = recompile_time == compile_time ? "all" : Ryu.writefixed(Float64(100*recompile_time/compile_time), 0) * "%"
+            print(io, ": $amount of which was recompilation")
         end
         parens && print(io, ")")
     end

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -161,7 +161,9 @@ end
 
 function timev_print(elapsedtime, diff::GC_Diff, compile_times, _lpad)
     allocs = gc_alloc_count(diff)
-    time_print(elapsedtime, diff.allocd, diff.total_time, allocs, compile_times, true, _lpad)
+    compile_time = first(compile_times)
+    recompile_time = last(compile_times)
+    time_print(elapsedtime, diff.allocd, diff.total_time, allocs, compile_time, recompile_time, true, _lpad)
     padded_nonzero_print(elapsedtime,       "elapsed time (ns)")
     padded_nonzero_print(diff.total_time,   "gc time (ns)")
     padded_nonzero_print(diff.allocd,       "bytes allocated")

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -201,8 +201,8 @@ end
 
 A macro to execute an expression, printing the time it took to execute, the number of
 allocations, and the total number of bytes its execution caused to be allocated, before
-returning the value of the expression. Any time spent garbage collecting (gc) or
-compiling is shown as a percentage.
+returning the value of the expression. Any time spent garbage collecting (gc), compiling
+new code, or recompiling invalidated code is shown as a percentage.
 
 Optionally provide a description string to print before the time report.
 
@@ -220,6 +220,9 @@ See also [`@showtime`](@ref), [`@timev`](@ref), [`@timed`](@ref), [`@elapsed`](@
 
 !!! compat "Julia 1.8"
     The option to add a description was introduced in Julia 1.8.
+
+!!! compat "Julia 1.9"
+    Recompilation time being shown separately from compilation time was introduced in Julia 1.9
 
 ```julia-repl
 julia> x = rand(10,10);

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -155,8 +155,7 @@ function time_print(elapsedtime, bytes=0, gctime=0, allocs=0, compile_time=0, re
             print(io, Ryu.writefixed(Float64(100*compile_time/elapsedtime), 2), "% compilation time")
         end
         if recompile_time > 0
-            amount = recompile_time == compile_time ? "all" : Ryu.writefixed(Float64(100*recompile_time/compile_time), 0) * "%"
-            print(io, ": $amount of which was recompilation")
+            print(io, ": ", Ryu.writefixed(Float64(100*recompile_time/compile_time), 0), "% of which was recompilation")
         end
         parens && print(io, ")")
     end

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -365,7 +365,8 @@ jl_code_instance_t *jl_generate_fptr_impl(jl_method_instance_t *mi JL_PROPAGATES
         uint64_t t_comp = jl_hrtime() - compiler_start_time;
         if (is_recompile)
             jl_atomic_fetch_add_relaxed(&jl_cumulative_recompile_time, t_comp);
-        jl_atomic_fetch_add_relaxed(&jl_cumulative_compile_time, t_comp);
+        else
+            jl_atomic_fetch_add_relaxed(&jl_cumulative_compile_time, t_comp);
     }
     JL_UNLOCK(&jl_codegen_lock);
     JL_GC_POP();

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -365,8 +365,7 @@ jl_code_instance_t *jl_generate_fptr_impl(jl_method_instance_t *mi JL_PROPAGATES
         uint64_t t_comp = jl_hrtime() - compiler_start_time;
         if (is_recompile)
             jl_atomic_fetch_add_relaxed(&jl_cumulative_recompile_time, t_comp);
-        else
-            jl_atomic_fetch_add_relaxed(&jl_cumulative_compile_time, t_comp);
+        jl_atomic_fetch_add_relaxed(&jl_cumulative_compile_time, t_comp);
     }
     JL_UNLOCK(&jl_codegen_lock);
     JL_GC_POP();

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -471,26 +471,24 @@ JL_DLLEXPORT void (jl_cpu_wake)(void)
     jl_cpu_wake();
 }
 
-JL_DLLEXPORT uint64_t jl_cumulative_compile_time_ns_before(void)
+JL_DLLEXPORT void jl_cumulative_compile_timing_enable(void)
 {
     // Increment the flag to allow reentrant callers to `@time`.
     jl_atomic_fetch_add(&jl_measure_compile_time_enabled, 1);
-    return jl_atomic_load_relaxed(&jl_cumulative_compile_time);
 }
 
-JL_DLLEXPORT uint64_t jl_cumulative_compile_time_ns_after(void)
+JL_DLLEXPORT void jl_cumulative_compile_timing_disable(void)
 {
     // Decrement the flag when done measuring, allowing other callers to continue measuring.
     jl_atomic_fetch_add(&jl_measure_compile_time_enabled, -1);
+}
+
+JL_DLLEXPORT uint64_t jl_cumulative_compile_time_ns(void)
+{
     return jl_atomic_load_relaxed(&jl_cumulative_compile_time);
 }
 
-JL_DLLEXPORT uint64_t jl_cumulative_recompile_time_ns_before(void)
-{
-    return jl_atomic_load_relaxed(&jl_cumulative_recompile_time);
-}
-
-JL_DLLEXPORT uint64_t jl_cumulative_recompile_time_ns_after(void)
+JL_DLLEXPORT uint64_t jl_cumulative_recompile_time_ns(void)
 {
     return jl_atomic_load_relaxed(&jl_cumulative_recompile_time);
 }

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -485,6 +485,16 @@ JL_DLLEXPORT uint64_t jl_cumulative_compile_time_ns_after(void)
     return jl_atomic_load_relaxed(&jl_cumulative_compile_time);
 }
 
+JL_DLLEXPORT uint64_t jl_cumulative_recompile_time_ns_before(void)
+{
+    return jl_atomic_load_relaxed(&jl_cumulative_recompile_time);
+}
+
+JL_DLLEXPORT uint64_t jl_cumulative_recompile_time_ns_after(void)
+{
+    return jl_atomic_load_relaxed(&jl_cumulative_recompile_time);
+}
+
 JL_DLLEXPORT void jl_get_fenv_consts(int *ret)
 {
     ret[0] = FE_INEXACT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -171,6 +171,7 @@ static inline uint64_t cycleclock(void) JL_NOTSAFEPOINT
 // Global *atomic* integers controlling *process-wide* measurement of compilation time.
 extern JL_DLLEXPORT _Atomic(uint8_t) jl_measure_compile_time_enabled;
 extern JL_DLLEXPORT _Atomic(uint64_t) jl_cumulative_compile_time;
+extern JL_DLLEXPORT _Atomic(uint64_t) jl_cumulative_recompile_time;
 
 #define jl_return_address() ((uintptr_t)__builtin_return_address(0))
 

--- a/src/threading.c
+++ b/src/threading.c
@@ -289,6 +289,7 @@ void jl_pgcstack_getkey(jl_get_pgcstack_func **f, jl_pgcstack_key_t *k)
 jl_ptls_t *jl_all_tls_states JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT _Atomic(uint8_t) jl_measure_compile_time_enabled = 0;
 JL_DLLEXPORT _Atomic(uint64_t) jl_cumulative_compile_time = 0;
+JL_DLLEXPORT _Atomic(uint64_t) jl_cumulative_recompile_time = 0;
 
 // return calling thread's ID
 // Also update the suspended_threads list in signals-mach when changing the

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -334,7 +334,7 @@ function timev_macro_scope()
 end
 @test timev_macro_scope() == 1
 
-before = Base.cumulative_compile_time_ns_before();
+before_comp, before_recomp = Base.cumulative_compile_time_ns_before();
 
 # exercise concurrent calls to `@time` for reentrant compilation time measurement.
 t1 = @async @time begin
@@ -347,8 +347,8 @@ t2 = @async begin
     @time 2 + 2
 end
 
-after = Base.cumulative_compile_time_ns_after();
-@test after >= before;
+after_comp, after_recomp = Base.cumulative_compile_time_ns_after();
+@test after_comp >= before_comp;
 
 # wait for completion of these tasks before restoring stdout, to suppress their @time prints.
 wait(t1); wait(t2)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -334,7 +334,7 @@ function timev_macro_scope()
 end
 @test timev_macro_scope() == 1
 
-before_comp, before_recomp = Base.cumulative_compile_time_ns_before();
+before_comp, before_recomp = Base.cumulative_compile_time_ns_before()
 
 # exercise concurrent calls to `@time` for reentrant compilation time measurement.
 t1 = @async @time begin
@@ -347,7 +347,7 @@ t2 = @async begin
     @time 2 + 2
 end
 
-after_comp, after_recomp = Base.cumulative_compile_time_ns_after();
+after_comp, after_recomp = Base.cumulative_compile_time_ns_after()
 @test after_comp >= before_comp;
 
 # wait for completion of these tasks before restoring stdout, to suppress their @time prints.

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -334,7 +334,8 @@ function timev_macro_scope()
 end
 @test timev_macro_scope() == 1
 
-before_comp, before_recomp = Base.cumulative_compile_time_ns_before()
+cumulative_compile_timing(true)
+before_comp, before_recomp = Base.cumulative_compile_time_ns()
 
 # exercise concurrent calls to `@time` for reentrant compilation time measurement.
 t1 = @async @time begin
@@ -347,7 +348,8 @@ t2 = @async begin
     @time 2 + 2
 end
 
-after_comp, after_recomp = Base.cumulative_compile_time_ns_after()
+cumulative_compile_timing(false)
+after_comp, after_recomp = Base.cumulative_compile_time_ns()
 @test after_comp >= before_comp;
 
 # wait for completion of these tasks before restoring stdout, to suppress their @time prints.

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -334,26 +334,23 @@ function timev_macro_scope()
 end
 @test timev_macro_scope() == 1
 
-cumulative_compile_timing(true)
-before_comp, before_recomp = Base.cumulative_compile_time_ns()
+before_comp, before_recomp = Base.cumulative_compile_time_ns() # no need to turn timing on, @time will do that
 
 # exercise concurrent calls to `@time` for reentrant compilation time measurement.
-t1 = @async @time begin
-    sleep(2)
-    @eval module M ; f(x,y) = x+y ; end
-    @eval M.f(2,3)
-end
-t2 = @async begin
-    sleep(1)
-    @time 2 + 2
+@sync begin
+    t1 = @async @time begin
+        sleep(2)
+        @eval module M ; f(x,y) = x+y ; end
+        @eval M.f(2,3)
+    end
+    t2 = @async begin
+        sleep(1)
+        @time 2 + 2
+    end
 end
 
-cumulative_compile_timing(false)
-after_comp, after_recomp = Base.cumulative_compile_time_ns()
+after_comp, after_recomp = Base.cumulative_compile_time_ns() # no need to turn timing off, @time will do that
 @test after_comp >= before_comp;
-
-# wait for completion of these tasks before restoring stdout, to suppress their @time prints.
-wait(t1); wait(t2)
 
 end # redirect_stdout
 


### PR DESCRIPTION
It may be helpful if `@time` indicates if any of the compilation time was recompilation, i.e. of invalidated methods. If the % is high the user could use the SnoopCompile tooling to see what's happening, for instance.

~~I'm not sure the heuristic is correct or broad-enough here~~ Updated after review. It appears to work with the example from the SnoopCompile manual.

Note the final report here (updated)

```julia
julia> f(::Real) = 1; callf(container) = f(container[1]); call2f(container) = callf(container);

julia> c64  = [1.0]; c32 = [1.0f0]; cabs = AbstractFloat[1.0];

julia> @time call2f(c64)
  0.003696 seconds (1.50 k allocations: 104.287 KiB, 99.54% compilation time)
1

julia> @time call2f(c32)
  0.004363 seconds (1.49 k allocations: 102.053 KiB, 99.48% compilation time)
1

julia> @time call2f(cabs)
  0.005143 seconds (1.94 k allocations: 133.236 KiB, 99.63% compilation time)
1

julia> f(::Float64) = 2;

julia> @time call2f(c64)
  0.004225 seconds (1.48 k allocations: 101.584 KiB, 99.80% compilation time: 100% of which was recompilation)
2
```