### PR TITLE
inference: don't forget to add backedge for effect-free frame

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -7,6 +7,8 @@ isdispatchelem(@nospecialize x) = !isa(x, Type) || Core.Compiler.isdispatchelem(
 using Random, Core.IR
 using InteractiveUtils: code_llvm
 
+include("irutils.jl")
+
 f39082(x::Vararg{T}) where {T <: Number} = x[1]
 let ast = only(code_typed(f39082, Tuple{Vararg{Rational}}))[1]
     @test ast.slottypes == Any[Const(f39082), Tuple{Vararg{Rational}}]
@@ -4105,3 +4107,29 @@ invoke44763(x) = Base.@invoke increase_x44763!(x)
     invoke44763(42)
 end |> only === Int
 @test x44763 == 0
+
+# backedge insertion for Any-typed, effect-free frame
+const CONST_DICT = let d = Dict()
+    for c in 'A':'z'
+        push!(d, c => Int(c))
+    end
+    d
+end
+Base.@assume_effects :total_may_throw getcharid(c) = CONST_DICT[c]
+@noinline callf(f, args...) = f(args...)
+function entry_to_be_invalidated(c)
+    return callf(getcharid, c)
+end
+@test Base.infer_effects((Char,)) do x
+    entry_to_be_invalidated(x)
+end |> Core.Compiler.is_concrete_eval_eligible
+@test fully_eliminated(; retval=97) do
+    entry_to_be_invalidated('a')
+end
+getcharid(c) = CONST_DICT[c] # now this is not eligible for concrete evaluation
+@test Base.infer_effects((Char,)) do x
+    entry_to_be_invalidated(x)
+end |> !Core.Compiler.is_concrete_eval_eligible
+@test !fully_eliminated() do
+    entry_to_be_invalidated('a')
+end


### PR DESCRIPTION
Now our abstract interpretation system caches two separate lattice
properties return type and call effects, and the previous optimization
to avoid adding backedge for a frame whose return type is `Any` turns
out to be insufficient -- now we also need to make sure that the
inferred effects don't provide any useful IPO information.

Example:
```julia
julia> const CONST_DICT = let d = Dict()
           for c in 'A':'z'
               push!(d, c => Int(c))
           end
           d
       end;

julia> Base.@assume_effects :total_may_throw getcharid(c) = CONST_DICT[c];

julia> @noinline callf(f, args...) = f(args...);

julia> function entry_to_be_invalidated(c)
           return callf(getcharid, c)
       end;

julia> @test Base.infer_effects((Char,)) do x
           entry_to_be_invalidated(x)
       end |> Core.Compiler.is_concrete_eval_eligible
Test Passed

julia> @test fully_eliminated(; retval=97) do
           entry_to_be_invalidated('a')
       end
Test Passed

julia> getcharid(c) = CONST_DICT[c]; # now this is not eligible for concrete evaluation

julia> @test Base.infer_effects((Char,)) do x
           entry_to_be_invalidated(x)
       end |> !Core.Compiler.is_concrete_eval_eligible
Test Failed at REPL[10]:1
  Expression: Base.infer_effects((Char,)) do x
        entry_to_be_invalidated(x)
    end |> !(Core.Compiler.is_concrete_eval_eligible)
ERROR: There was an error during testing

julia> @test !fully_eliminated() do
           entry_to_be_invalidated('a')
       end
Test Failed at REPL[11]:1
  Expression: !(fully_eliminated() do
        entry_to_be_invalidated('a')
    end)
ERROR: There was an error during testing
```