### PR TITLE
eliminate uninferrable `typeof(x) === T` conditions

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -844,8 +844,8 @@ function collect_to!(dest::AbstractArray{T}, itr, offs, st) where T
         y = iterate(itr, st)
         y === nothing && break
         el, st = y
-        if el isa T || typeof(el) === T
-            @inbounds dest[i] = el::T
+        if el isa T
+            @inbounds dest[i] = el
             i += 1
         else
             new = setindex_widen_up_to(dest, el, i)
@@ -881,8 +881,8 @@ function grow_to!(dest, itr, st)
     y = iterate(itr, st)
     while y !== nothing
         el, st = y
-        if el isa T || typeof(el) === T
-            push!(dest, el::T)
+        if el isa T
+            push!(dest, el)
         else
             new = push_widen(dest, el)
             return grow_to!(new, itr, st)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1053,7 +1053,7 @@ function copyto_nonleaf!(dest, bc::Broadcasted, iter, state, count)
         y === nothing && break
         I, state = y
         @inbounds val = bc[I]
-        if val isa T || typeof(val) === T
+        if val isa T
             @inbounds dest[I] = val
         else
             # This element type doesn't fit in dest. Allocate a new dest with wider eltype,

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -104,7 +104,7 @@ UInt8
 
 See also [`ncodeunits`](@ref), [`checkbounds`](@ref).
 """
-@propagate_inbounds codeunit(s::AbstractString, i::Integer) = typeof(i) === Int ?
+@propagate_inbounds codeunit(s::AbstractString, i::Integer) = i isa Int ?
     throw(MethodError(codeunit, (s, i))) : codeunit(s, Int(i))
 
 """
@@ -140,7 +140,7 @@ Stacktrace:
 [...]
 ```
 """
-@propagate_inbounds isvalid(s::AbstractString, i::Integer) = typeof(i) === Int ?
+@propagate_inbounds isvalid(s::AbstractString, i::Integer) = i isa Int ?
     throw(MethodError(isvalid, (s, i))) : isvalid(s, Int(i))
 
 """
@@ -154,7 +154,7 @@ protocol may assume that `i` is the start of a character in `s`.
 
 See also [`getindex`](@ref), [`checkbounds`](@ref).
 """
-@propagate_inbounds iterate(s::AbstractString, i::Integer) = typeof(i) === Int ?
+@propagate_inbounds iterate(s::AbstractString, i::Integer) = i isa Int ?
     throw(MethodError(iterate, (s, i))) : iterate(s, Int(i))
 
 ## basic generic definitions ##

--- a/base/toml_parser.jl
+++ b/base/toml_parser.jl
@@ -672,7 +672,7 @@ function push!!(v::Vector, el)
         out[1] = el
         return out
     else
-        if typeof(T) === Union
+        if T isa Union
             newT = Any
         else
             newT = Union{T, typeof(el)}


### PR DESCRIPTION
Most of these conditions were introduced in #25828 and #30480 for some
performance reasons atm, but now they seem just unnecessary or even
harmful in terms of inferrability.

There doesn't seem to be any performance difference in the benchmark
used at #25828:
```julia
using BenchmarkTools
x = rand(Int, 100_000);
y = convert(Vector{Union{Int,Missing}}, x);
z = copy(y); z[2] = missing;
```

> master:
```julia
julia> @btime map(identity, x);
  57.814 μs (3 allocations: 781.31 KiB)

julia> @btime map(identity, y);
  94.040 μs (3 allocations: 781.31 KiB)

julia> @btime map(identity, z);
  127.554 μs (5 allocations: 1.62 MiB)

julia> @btime broadcast(x->x, x);
  59.248 μs (2 allocations: 781.30 KiB)

julia> @btime broadcast(x->x, y);
  74.693 μs (2 allocations: 781.30 KiB)

julia> @btime broadcast(x->x, z);
  126.262 μs (4 allocations: 1.62 MiB)
```

> this commit:
```
julia> @btime map(identity, x);
  58.668 μs (3 allocations: 781.31 KiB)

julia> @btime map(identity, y);
  94.013 μs (3 allocations: 781.31 KiB)

julia> @btime map(identity, z);
  126.600 μs (5 allocations: 1.62 MiB)

julia> @btime broadcast(x->x, x);
  57.531 μs (2 allocations: 781.30 KiB)

julia> @btime broadcast(x->x, y);
  69.561 μs (2 allocations: 781.30 KiB)

julia> @btime broadcast(x->x, z);
  125.578 μs (4 allocations: 1.62 MiB)
```

---

@nanosoldier `runbenchmarks("union", vs=":master")`