### PR TITLE
docs: fix `Base.include` docstring signature

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1324,7 +1324,7 @@ function source_dir()
 end
 
 """
-    Base.include([mapexpr::Function,] [m::Module,] path::AbstractString)
+    Base.include([mapexpr::Function,] m::Module, path::AbstractString)
 
 Evaluate the contents of the input source file in the global scope of module `m`.
 Every module (except those defined with [`baremodule`](@ref)) has its own


### PR DESCRIPTION
The `m::Module` argument is not optional.