### PR TITLE
gc-ext: only sweep unmarked objects

### DIFF
--- a/test/gcext/gcext.c
+++ b/test/gcext/gcext.c
@@ -561,8 +561,10 @@ void sweep_stack_data(jl_value_t *p)
 {
     obj_sweeps++;
     dynstack_t *stk = (dynstack_t *)p;
-    if (stk->size > stk->capacity)
-        jl_error("internal error during sweeping");
+    if (stk->size > stk->capacity) {
+        assert(0 && "internal error during sweeping");
+        abort();
+    }
 }
 
 // Safely execute Julia code


### PR DESCRIPTION
This prior conditional was a fixed constant branch on `!(v | 1)`, which was always true, since the pointer is never tagged by gc, so this seems more like the intent?

@fingolfin @rbehrends from #28368