### PR TITLE
Pool memory managers to ensure JIT backend thread safety

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -274,12 +274,12 @@ $(BUILDDIR)/julia_flisp.boot: $(addprefix $(SRCDIR)/,jlfrontend.scm flisp/aliase
 
 # additional dependency links
 $(BUILDDIR)/codegen-stubs.o $(BUILDDIR)/codegen-stubs.dbg.obj: $(SRCDIR)/intrinsics.h
-$(BUILDDIR)/aotcompile.o $(BUILDDIR)/aotcompile.dbg.obj: $(SRCDIR)/jitlayers.h $(SRCDIR)/codegen_shared.h $(SRCDIR)/debug-registry.h
+$(BUILDDIR)/aotcompile.o $(BUILDDIR)/aotcompile.dbg.obj: $(SRCDIR)/jitlayers.h $(SRCDIR)/codegen_shared.h $(SRCDIR)/debug-registry.h $(SRCDIR)/concurrency-utils.h
 $(BUILDDIR)/ast.o $(BUILDDIR)/ast.dbg.obj: $(BUILDDIR)/julia_flisp.boot.inc $(SRCDIR)/flisp/*.h
 $(BUILDDIR)/builtins.o $(BUILDDIR)/builtins.dbg.obj: $(SRCDIR)/iddict.c $(SRCDIR)/builtin_proto.h
 $(BUILDDIR)/codegen.o $(BUILDDIR)/codegen.dbg.obj: $(addprefix $(SRCDIR)/,\
-	intrinsics.cpp jitlayers.h debug-registry.h intrinsics.h codegen_shared.h cgutils.cpp ccall.cpp abi_*.cpp processor.h builtin_proto.h)
-$(BUILDDIR)/debuginfo.o $(BUILDDIR)/debuginfo.dbg.obj: $(addprefix $(SRCDIR)/,debuginfo.h processor.h jitlayers.h debug-registry.h)
+	intrinsics.cpp jitlayers.h debug-registry.h concurrency-utils.h intrinsics.h codegen_shared.h cgutils.cpp ccall.cpp abi_*.cpp processor.h builtin_proto.h)
+$(BUILDDIR)/debuginfo.o $(BUILDDIR)/debuginfo.dbg.obj: $(addprefix $(SRCDIR)/,debuginfo.h processor.h jitlayers.h debug-registry.h concurrency-utils.h)
 $(BUILDDIR)/disasm.o $(BUILDDIR)/disasm.dbg.obj: $(SRCDIR)/debuginfo.h $(SRCDIR)/processor.h
 $(BUILDDIR)/dump.o $(BUILDDIR)/dump.dbg.obj: $(addprefix $(SRCDIR)/,common_symbols1.inc common_symbols2.inc builtin_proto.h serialize.h)
 $(BUILDDIR)/gc-debug.o $(BUILDDIR)/gc-debug.dbg.obj: $(SRCDIR)/gc.h
@@ -287,12 +287,12 @@ $(BUILDDIR)/gc-pages.o $(BUILDDIR)/gc-pages.dbg.obj: $(SRCDIR)/gc.h
 $(BUILDDIR)/gc.o $(BUILDDIR)/gc.dbg.obj: $(SRCDIR)/gc.h $(SRCDIR)/gc-alloc-profiler.h
 $(BUILDDIR)/init.o $(BUILDDIR)/init.dbg.obj: $(SRCDIR)/builtin_proto.h
 $(BUILDDIR)/interpreter.o $(BUILDDIR)/interpreter.dbg.obj: $(SRCDIR)/builtin_proto.h
-$(BUILDDIR)/jitlayers.o $(BUILDDIR)/jitlayers.dbg.obj: $(SRCDIR)/jitlayers.h $(SRCDIR)/codegen_shared.h $(SRCDIR)/debug-registry.h
+$(BUILDDIR)/jitlayers.o $(BUILDDIR)/jitlayers.dbg.obj: $(SRCDIR)/jitlayers.h $(SRCDIR)/codegen_shared.h $(SRCDIR)/debug-registry.h $(SRCDIR)/concurrency-utils.h
 $(BUILDDIR)/jltypes.o $(BUILDDIR)/jltypes.dbg.obj: $(SRCDIR)/builtin_proto.h
 $(build_shlibdir)/libllvmcalltest.$(SHLIB_EXT): $(SRCDIR)/codegen_shared.h $(BUILDDIR)/julia_version.h
 $(BUILDDIR)/llvm-alloc-helpers.o $(BUILDDIR)/llvm-alloc-helpers.dbg.obj: $(SRCDIR)/codegen_shared.h $(SRCDIR)/llvm-pass-helpers.h $(SRCDIR)/llvm-alloc-helpers.h
 $(BUILDDIR)/llvm-alloc-opt.o $(BUILDDIR)/llvm-alloc-opt.dbg.obj: $(SRCDIR)/codegen_shared.h $(SRCDIR)/llvm-pass-helpers.h $(SRCDIR)/llvm-alloc-helpers.h
-$(BUILDDIR)/llvm-cpufeatures.o $(BUILDDIR)/llvm-cpufeatures.dbg.obj: $(SRCDIR)/jitlayers.h $(SRCDIR)/debug-registry.h
+$(BUILDDIR)/llvm-cpufeatures.o $(BUILDDIR)/llvm-cpufeatures.dbg.obj: $(SRCDIR)/jitlayers.h $(SRCDIR)/debug-registry.h $(SRCDIR)/concurrency-utils.h
 $(BUILDDIR)/llvm-final-gc-lowering.o $(BUILDDIR)/llvm-final-gc-lowering.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h $(SRCDIR)/codegen_shared.h
 $(BUILDDIR)/llvm-gc-invariant-verifier.o $(BUILDDIR)/llvm-gc-invariant-verifier.dbg.obj: $(SRCDIR)/codegen_shared.h
 $(BUILDDIR)/llvm-julia-licm.o $(BUILDDIR)/llvm-julia-licm.dbg.obj: $(SRCDIR)/codegen_shared.h $(SRCDIR)/llvm-alloc-helpers.h $(SRCDIR)/llvm-pass-helpers.h

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7959,8 +7959,6 @@ static jl_llvm_functions_t
 
 // --- entry point ---
 
-void jl_add_code_in_flight(StringRef name, jl_code_instance_t *codeinst, const DataLayout &DL);
-
 JL_GCC_IGNORE_START("-Wclobbered")
 jl_llvm_functions_t jl_emit_code(
         orc::ThreadSafeModule &m,
@@ -8040,9 +8038,9 @@ jl_llvm_functions_t jl_emit_codeinst(
             // they may not be rooted in the gc for the life of the program,
             // and the runtime doesn't notify us when the code becomes unreachable :(
             if (!specf.empty())
-                jl_add_code_in_flight(specf, codeinst, DL);
+                jl_ExecutionEngine->getDebugInfoRegistry().add_code_in_flight(specf, codeinst, DL);
             if (!f.empty() && f != "jl_fptr_args" && f != "jl_fptr_sparam")
-                jl_add_code_in_flight(f, codeinst, DL);
+                jl_ExecutionEngine->getDebugInfoRegistry().add_code_in_flight(f, codeinst, DL);
         }
 
         if (// don't alter `inferred` when the code is not directly being used

--- a/src/concurrency-utils.h
+++ b/src/concurrency-utils.h
@@ -122,6 +122,9 @@ namespace jl_cc {
         std::unique_ptr<WNMutex> mutex;
     };
 
+    template<typename ResourceT, size_t max = 0>
+    using QueuedResourcePool = ResourcePool<ResourceT, max, std::queue<ResourceT>>;
+
     template<typename ResourceT>
     struct Locked {
 

--- a/src/concurrency-utils.h
+++ b/src/concurrency-utils.h
@@ -10,7 +10,7 @@
 #include <queue>
 
 namespace jl_cc {
-    
+
     template
     <typename ResourceT, size_t max = 0,
         typename BackingT = std::stack<ResourceT,

--- a/src/concurrency-utils.h
+++ b/src/concurrency-utils.h
@@ -1,0 +1,181 @@
+#ifndef JL_CONCURRENCY_UTILS_H
+#define JL_CONCURRENCY_UTILS_H
+
+#include "julia_internal.h"
+
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <stack>
+#include <queue>
+
+namespace jl_cc {
+    
+    template
+    <typename ResourceT, size_t max = 0,
+        typename BackingT = std::stack<ResourceT,
+            std::conditional_t<max == 0,
+                SmallVector<ResourceT>,
+                SmallVector<ResourceT, max>
+            >
+        >
+    >
+    struct ResourcePool {
+        public:
+        ResourcePool(std::function<ResourceT()> creator) : creator(std::move(creator)), mutex(std::make_unique<WNMutex>()) {}
+        class OwningResource {
+            public:
+            OwningResource(ResourcePool &pool, ResourceT resource) : pool(pool), resource(std::move(resource)) {}
+            OwningResource(const OwningResource &) = delete;
+            OwningResource &operator=(const OwningResource &) = delete;
+            OwningResource(OwningResource &&other) : pool(other.pool), resource(std::move(*other)) {
+                other.resource.reset();
+            }
+            OwningResource &operator=(OwningResource &&other) {
+                assert(&pool == &other.pool);
+                resource = std::move(other.resource);
+                other.resource.reset();
+                return *this;
+            }
+            ~OwningResource() {
+                reset();
+            }
+            void reset() {
+                if (resource) {
+                    pool.release(std::move(**this));
+                    resource.reset();
+                }
+            }
+            ResourceT &operator*() {
+                return *resource;
+            }
+            ResourceT *operator->() {
+                return get();
+            }
+            ResourceT *get() {
+                return resource.getPointer();
+            }
+            const ResourceT &operator*() const {
+                return *resource;
+            }
+            const ResourceT *operator->() const {
+                return get();
+            }
+            const ResourceT *get() const {
+                return resource.getPointer();
+            }
+            explicit operator bool() const {
+                return resource;
+            }
+            private:
+            ResourcePool &pool;
+            llvm::Optional<ResourceT> resource;
+        };
+
+        OwningResource operator*() {
+            return OwningResource(*this, acquire());
+        }
+
+        OwningResource get() {
+            return **this;
+        }
+
+        ResourceT acquire() {
+            std::unique_lock<std::mutex> lock(mutex->mutex);
+            if (!pool.empty()) {
+                return pop(pool);
+            }
+            if (!max || created < max) {
+                created++;
+                return creator();
+            }
+            mutex->empty.wait(lock, [&](){ return !pool.empty(); });
+            assert(!pool.empty() && "Expected resource pool to have a value!");
+            return pop(pool);
+        }
+        void release(ResourceT &&resource) {
+            std::lock_guard<std::mutex> lock(mutex->mutex);
+            pool.push(std::move(resource));
+            mutex->empty.notify_one();
+        }
+        private:
+        template<typename T, typename Container>
+        static ResourceT pop(std::queue<T, Container> &pool) {
+            ResourceT top = std::move(pool.front());
+            pool.pop();
+            return top;
+        }
+        template<typename PoolT>
+        static ResourceT pop(PoolT &pool) {
+            ResourceT top = std::move(pool.top());
+            pool.pop();
+            return top;
+        }
+        std::function<ResourceT()> creator;
+        size_t created = 0;
+        BackingT pool;
+        struct WNMutex {
+            std::mutex mutex;
+            std::condition_variable empty;
+        };
+
+        std::unique_ptr<WNMutex> mutex;
+    };
+
+    template<typename ResourceT>
+    struct Locked {
+
+        template<typename CResourceT>
+        struct Lock {
+            std::unique_lock<std::mutex> lock;
+            CResourceT &resource;
+
+            Lock(std::mutex &mutex, CResourceT &resource) JL_NOTSAFEPOINT : lock(mutex), resource(resource) {}
+            Lock(Lock &&) JL_NOTSAFEPOINT = default;
+            Lock &operator=(Lock &&) JL_NOTSAFEPOINT = default;
+
+            CResourceT &operator*() JL_NOTSAFEPOINT {
+                return resource;
+            }
+
+            const CResourceT &operator*() const JL_NOTSAFEPOINT {
+                return resource;
+            }
+
+            CResourceT *operator->() JL_NOTSAFEPOINT {
+                return &**this;
+            }
+
+            const CResourceT *operator->() const JL_NOTSAFEPOINT {
+                return &**this;
+            }
+
+            operator const CResourceT &() const JL_NOTSAFEPOINT {
+                return resource;
+            }
+
+            ~Lock() JL_NOTSAFEPOINT = default;
+        };
+    private:
+
+        mutable std::mutex mutex;
+        ResourceT resource;
+    public:
+        typedef Lock<ResourceT> LockT;
+        typedef Lock<const ResourceT> ConstLockT;
+
+        Locked(ResourceT resource = ResourceT()) JL_NOTSAFEPOINT : mutex(), resource(std::move(resource)) {}
+
+        LockT operator*() JL_NOTSAFEPOINT {
+            return LockT(mutex, resource);
+        }
+
+        ConstLockT operator*() const JL_NOTSAFEPOINT {
+            return ConstLockT(mutex, resource);
+        }
+
+        ~Locked() JL_NOTSAFEPOINT = default;
+    };
+}
+
+#endif

--- a/src/concurrency-utils.h
+++ b/src/concurrency-utils.h
@@ -6,8 +6,12 @@
 #include <condition_variable>
 #include <memory>
 #include <mutex>
+#include <type_traits>
 #include <stack>
 #include <queue>
+
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/APInt.h>
 
 namespace jl_cc {
 
@@ -15,8 +19,8 @@ namespace jl_cc {
     <typename ResourceT, size_t max = 0,
         typename BackingT = std::stack<ResourceT,
             std::conditional_t<max == 0,
-                SmallVector<ResourceT>,
-                SmallVector<ResourceT, max>
+                llvm::SmallVector<ResourceT>,
+                llvm::SmallVector<ResourceT, max>
             >
         >
     >

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -121,12 +121,12 @@ void JITDebugInfoRegistry::set_sysimg_info(sysimg_info_t info) JL_NOTSAFEPOINT {
     (**this->sysimg_info) = info;
 }
 
-JITDebugInfoRegistry::Locked<JITDebugInfoRegistry::sysimg_info_t>::ConstLockT
+jl_cc::Locked<JITDebugInfoRegistry::sysimg_info_t>::ConstLockT
 JITDebugInfoRegistry::get_sysimg_info() const JL_NOTSAFEPOINT {
     return *this->sysimg_info;
 }
 
-JITDebugInfoRegistry::Locked<JITDebugInfoRegistry::objfilemap_t>::LockT
+jl_cc::Locked<JITDebugInfoRegistry::objfilemap_t>::LockT
 JITDebugInfoRegistry::get_objfile_map() JL_NOTSAFEPOINT {
     return *this->objfilemap;
 }
@@ -178,14 +178,6 @@ static void jl_profile_atomic(T f)
 #endif
     uv_rwlock_wrunlock(&getJITDebugRegistry().debuginfo_asyncsafe);
 }
-
-
-// --- storing and accessing source location metadata ---
-void jl_add_code_in_flight(StringRef name, jl_code_instance_t *codeinst, const DataLayout &DL)
-{
-    getJITDebugRegistry().add_code_in_flight(name, codeinst, DL);
-}
-
 
 #if defined(_OS_WINDOWS_)
 static void create_PRUNTIME_FUNCTION(uint8_t *Code, size_t Size, StringRef fnname,
@@ -406,13 +398,6 @@ void JITDebugInfoRegistry::registerJITObject(const object::ObjectFile &Object,
             }
         });
     }
-}
-
-void jl_register_jit_object(const object::ObjectFile &Object,
-                            std::function<uint64_t(const StringRef &)> getLoadAddress,
-                            std::function<void *(void *)> lookupWriteAddress)
-{
-    getJITDebugRegistry().registerJITObject(Object, getLoadAddress, lookupWriteAddress);
 }
 
 // TODO: convert the safe names from aotcomile.cpp:makeSafeName back into symbols

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -679,8 +679,15 @@ public:
 #else // !JL_USE_JITLINK
 
 RTDyldMemoryManager* createRTDyldMemoryManager(void);
+
+#if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
+#define REMAP_WR_ADDR
+#endif
+
+#ifdef REMAP_WR_ADDR
 void addAllocationMappings(RTDyldMemoryManager *memmgr, DenseMap<void *, void *> &mappings);
 void removeAllocationMappings(RTDyldMemoryManager *memmgr, DenseMap<void *, void *> &mappings);
+#endif
 
 class JuliaOJIT::PooledMemoryManager {
 private:
@@ -751,7 +758,7 @@ public:
         auto it = lock->allocated.find(identifier);
         assert(it != lock->allocated.end()
             && "Expected identifier to be assigned a memory manager!");
-#if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
+#ifdef REMAP_WR_ADDR
         removeAllocationMappings(it->second.get(), lock->WindowsDebugWriteAddrRemap);
 #endif
         bool fail = it->second->finalizeMemory(ErrMsg);
@@ -764,12 +771,12 @@ public:
         auto lock = *state;
         auto &MemMgr = lock->allocated[identifier];
         assert(MemMgr && "Expected memory manager to exist for identifier!");
-#if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
+#ifdef REMAP_WR_ADDR
         addAllocationMappings(MemMgr.get(), lock->WindowsDebugWriteAddrRemap);
 #endif
         return MemMgr->notifyObjectLoaded(RTDyld, Obj);
     }
-#if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
+#ifdef REMAP_WR_ADDR
     void *lookupWriteAddressFor(void *rt_addr) {
         auto lock = *state;
         auto wr_addr = lock->WindowsDebugWriteAddrRemap.find(rt_addr);
@@ -871,7 +878,7 @@ void registerRTDyldJITObject(const object::ObjectFile &Object,
     };
 
     jl_ExecutionEngine->getDebugInfoRegistry().registerJITObject(*DebugObj, getLoadAddress,
-#if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
+#ifdef REMAP_WR_ADDR
         [MemMgr](void *p) { return MemMgr->lookupWriteAddressFor(p); }
 #else
         nullptr

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -679,60 +679,162 @@ public:
 #else // !JL_USE_JITLINK
 
 RTDyldMemoryManager* createRTDyldMemoryManager(void);
+void addAllocationMappings(RTDyldMemoryManager *memmgr, DenseMap<void *, void *> &mappings);
+void removeAllocationMappings(RTDyldMemoryManager *memmgr, DenseMap<void *, void *> &mappings);
+
+class JuliaOJIT::PooledMemoryManager {
+private:
+    jl_cc::QueuedResourcePool<std::unique_ptr<RTDyldMemoryManager>> pool;
+    struct State {
+        DenseMap<void *, std::unique_ptr<RTDyldMemoryManager>> allocated;
+#if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
+        DenseMap<void *, void *> WindowsDebugWriteAddrRemap;
+#endif
+        size_t total_allocated;
+    };
+    jl_cc::Locked<State> state;
+
+    auto &MemMgr(void *identifier) {
+        auto lock = *state;
+        auto &alloc = lock->allocated[identifier];
+        assert(alloc && "Expected identifier to be assigned a memory manager!");
+        return *alloc;
+    }
+    auto &acquire(void *identifier) {
+        auto lock = *state;
+        assert(lock->allocated.find(identifier) == lock->allocated.end()
+            && "Expected identifier to not already be assigned a memory manager!");
+        return *(lock->allocated[identifier] = pool.acquire());
+    }
+public:
+
+    PooledMemoryManager() : pool([](){ return std::unique_ptr<RTDyldMemoryManager>(createRTDyldMemoryManager()); }) {}
+
+    virtual uint8_t *allocateCodeSection(void *identifier, uintptr_t Size, unsigned Alignment,
+                                     unsigned SectionID,
+                                     StringRef SectionName) {
+        auto locked = *state;
+        auto &MemMgr = locked->allocated[identifier];
+        assert(MemMgr && "Expected memory manager to exist for identifier!");
+        locked->total_allocated += Size;
+        return MemMgr->allocateCodeSection(Size, Alignment, SectionID, SectionName);
+    }
+    virtual uint8_t *allocateDataSection(void *identifier, uintptr_t Size, unsigned Alignment,
+                                     unsigned SectionID,
+                                     StringRef SectionName,
+                                     bool IsReadOnly) {
+        auto locked = *state;
+        auto &MemMgr = locked->allocated[identifier];
+        assert(MemMgr && "Expected memory manager to exist for identifier!");
+        locked->total_allocated += Size;
+        return MemMgr->allocateDataSection(Size, Alignment, SectionID, SectionName, IsReadOnly);
+    }
+    virtual void reserveAllocationSpace(void *identifier, uintptr_t CodeSize, uint32_t CodeAlign,
+                                        uintptr_t RODataSize,
+                                        uint32_t RODataAlign,
+                                        uintptr_t RWDataSize,
+                                        uint32_t RWDataAlign) {
+        return MemMgr(identifier).reserveAllocationSpace(CodeSize, CodeAlign, RODataSize, RODataAlign, RWDataSize, RWDataAlign);
+    }
+    virtual bool needsToReserveAllocationSpace(void *identifier) {
+        return acquire(identifier).needsToReserveAllocationSpace();
+    }
+    virtual void registerEHFrames(void *identifier, uint8_t *Addr, uint64_t LoadAddr,
+                                  size_t Size) {
+        return MemMgr(identifier).registerEHFrames(Addr, LoadAddr, Size);
+    }
+    virtual void deregisterEHFrames(void *identifier) {
+        return MemMgr(identifier).deregisterEHFrames();
+    }
+    virtual bool finalizeMemory(void *identifier, std::string *ErrMsg = nullptr) {
+        auto lock = *state;
+        auto it = lock->allocated.find(identifier);
+        assert(it != lock->allocated.end()
+            && "Expected identifier to be assigned a memory manager!");
+#if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
+        removeAllocationMappings(it->second.get(), lock->WindowsDebugWriteAddrRemap);
+#endif
+        bool fail = it->second->finalizeMemory(ErrMsg);
+        pool.release(std::move(it->second));
+        lock->allocated.erase(std::move(it));
+        return fail;
+    }
+    virtual void notifyObjectLoaded(void *identifier, RuntimeDyld &RTDyld,
+                                    const object::ObjectFile &Obj) {
+        auto lock = *state;
+        auto &MemMgr = lock->allocated[identifier];
+        assert(MemMgr && "Expected memory manager to exist for identifier!");
+#if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
+        addAllocationMappings(MemMgr.get(), lock->WindowsDebugWriteAddrRemap);
+#endif
+        return MemMgr->notifyObjectLoaded(RTDyld, Obj);
+    }
+#if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
+    void *lookupWriteAddressFor(void *rt_addr) {
+        auto lock = *state;
+        auto wr_addr = lock->WindowsDebugWriteAddrRemap.find(rt_addr);
+        if (wr_addr != lock->WindowsDebugWriteAddrRemap.end()) {
+            if (wr_addr->second) {
+                return wr_addr->second;
+            }
+        }
+        return rt_addr;
+    }
+#endif
+
+    size_t total_bytes() {
+        return (**state).total_allocated;
+    }
+};
 
 // A simple forwarding class, since OrcJIT v2 needs a unique_ptr, while we have a shared_ptr
 class ForwardingMemoryManager : public RuntimeDyld::MemoryManager {
 private:
-    std::shared_ptr<RuntimeDyld::MemoryManager> MemMgr;
+    std::shared_ptr<JuliaOJIT::PooledMemoryManager> MemMgr;
 
 public:
-    ForwardingMemoryManager(std::shared_ptr<RuntimeDyld::MemoryManager> MemMgr) : MemMgr(MemMgr) {}
+    ForwardingMemoryManager(std::shared_ptr<JuliaOJIT::PooledMemoryManager> MemMgr) : MemMgr(std::move(MemMgr)) {}
     virtual ~ForwardingMemoryManager() = default;
     virtual uint8_t *allocateCodeSection(uintptr_t Size, unsigned Alignment,
                                      unsigned SectionID,
                                      StringRef SectionName) override {
-        return MemMgr->allocateCodeSection(Size, Alignment, SectionID, SectionName);
+        return MemMgr->allocateCodeSection(this, Size, Alignment, SectionID, SectionName);
     }
     virtual uint8_t *allocateDataSection(uintptr_t Size, unsigned Alignment,
                                      unsigned SectionID,
                                      StringRef SectionName,
                                      bool IsReadOnly) override {
-        return MemMgr->allocateDataSection(Size, Alignment, SectionID, SectionName, IsReadOnly);
+        return MemMgr->allocateDataSection(this, Size, Alignment, SectionID, SectionName, IsReadOnly);
     }
     virtual void reserveAllocationSpace(uintptr_t CodeSize, uint32_t CodeAlign,
                                         uintptr_t RODataSize,
                                         uint32_t RODataAlign,
                                         uintptr_t RWDataSize,
                                         uint32_t RWDataAlign) override {
-        return MemMgr->reserveAllocationSpace(CodeSize, CodeAlign, RODataSize, RODataAlign, RWDataSize, RWDataAlign);
+        return MemMgr->reserveAllocationSpace(this, CodeSize, CodeAlign, RODataSize, RODataAlign, RWDataSize, RWDataAlign);
     }
     virtual bool needsToReserveAllocationSpace() override {
-        return MemMgr->needsToReserveAllocationSpace();
+        return MemMgr->needsToReserveAllocationSpace(this);
     }
     virtual void registerEHFrames(uint8_t *Addr, uint64_t LoadAddr,
                                   size_t Size) override {
-        return MemMgr->registerEHFrames(Addr, LoadAddr, Size);
+        return MemMgr->registerEHFrames(this, Addr, LoadAddr, Size);
     }
     virtual void deregisterEHFrames() override {
-        return MemMgr->deregisterEHFrames();
+        return MemMgr->deregisterEHFrames(this);
     }
     virtual bool finalizeMemory(std::string *ErrMsg = nullptr) override {
-        return MemMgr->finalizeMemory(ErrMsg);
+        return MemMgr->finalizeMemory(this, ErrMsg);
     }
     virtual void notifyObjectLoaded(RuntimeDyld &RTDyld,
                                     const object::ObjectFile &Obj) override {
-        return MemMgr->notifyObjectLoaded(RTDyld, Obj);
+        return MemMgr->notifyObjectLoaded(this, RTDyld, Obj);
     }
 };
 
-
-#if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
-void *lookupWriteAddressFor(RTDyldMemoryManager *MemMgr, void *rt_addr);
-#endif
-
 void registerRTDyldJITObject(const object::ObjectFile &Object,
                              const RuntimeDyld::LoadedObjectInfo &L,
-                             const std::shared_ptr<RTDyldMemoryManager> &MemMgr)
+                             const std::shared_ptr<JuliaOJIT::PooledMemoryManager> &MemMgr)
 {
     auto SavedObject = L.getObjectForDebug(Object).takeBinary();
     // If the debug object is unavailable, save (a copy of) the original object
@@ -770,7 +872,7 @@ void registerRTDyldJITObject(const object::ObjectFile &Object,
 
     jl_ExecutionEngine->getDebugInfoRegistry().registerJITObject(*DebugObj, getLoadAddress,
 #if defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)
-        [MemMgr](void *p) { return lookupWriteAddressFor(MemMgr.get(), p); }
+        [MemMgr](void *p) { return MemMgr->lookupWriteAddressFor(p); }
 #else
         nullptr
 #endif
@@ -1017,7 +1119,7 @@ JuliaOJIT::JuliaOJIT()
     ObjectLayer(ES, cantFail(jitlink::InProcessMemoryManager::Create())),
 # endif
 #else
-    MemMgr(createRTDyldMemoryManager()),
+    MemMgr(std::make_shared<PooledMemoryManager>()),
     ObjectLayer(
             ES,
             [this]() {
@@ -1263,11 +1365,10 @@ size_t JuliaOJIT::getTotalBytes() const
     return 0;
 }
 #else
-size_t getRTDyldMemoryManagerTotalBytes(RTDyldMemoryManager *mm);
 
 size_t JuliaOJIT::getTotalBytes() const
 {
-    return getRTDyldMemoryManagerTotalBytes(MemMgr.get());
+    return MemMgr->total_bytes();
 }
 #endif
 

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -221,7 +221,7 @@ public:
     };
 
 #ifndef JL_USE_JITLINK
-    struct PooledMemoryManager;
+    class PooledMemoryManager;
 #endif
 
 private:
@@ -232,6 +232,7 @@ private:
 public:
 
     JuliaOJIT();
+    ~JuliaOJIT();
 
     void enableJITDebuggingSupport();
 #ifndef JL_USE_JITLINK
@@ -295,6 +296,11 @@ private:
     struct ReverseLocalSymbolsT {
         int Unique = 0;
         DenseMap<void*, std::string> Table;
+
+        ReverseLocalSymbolsT() JL_NOTSAFEPOINT = default;
+        ReverseLocalSymbolsT(ReverseLocalSymbolsT &&) JL_NOTSAFEPOINT = default;
+        ReverseLocalSymbolsT &operator=(ReverseLocalSymbolsT &&) JL_NOTSAFEPOINT = default;
+        ~ReverseLocalSymbolsT() JL_NOTSAFEPOINT = default;
     };
     jl_cc::Locked<ReverseLocalSymbolsT> ReverseLocalSymbols;
 

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -286,14 +286,10 @@ private:
     const std::unique_ptr<TargetMachine> TM;
     const DataLayout DL;
 
-    orc::ExecutionSession ES;
-    orc::JITDylib &GlobalJD;
-    orc::JITDylib &JD;
-
     JITDebugInfoRegistry DebugRegistry;
 
     struct ReverseLocalSymbolsT {
-        int Unique;
+        int Unique = 0;
         DenseMap<void*, std::string> Table;
     };
     jl_cc::Locked<ReverseLocalSymbolsT> ReverseLocalSymbols;
@@ -302,6 +298,10 @@ private:
     jl_locked_stream dump_emitted_mi_name_stream;
     jl_locked_stream dump_compiles_stream;
     jl_locked_stream dump_llvm_opt_stream;
+
+    orc::ExecutionSession ES;
+    orc::JITDylib &GlobalJD;
+    orc::JITDylib &JD;
 
     jl_cc::ResourcePool<orc::ThreadSafeContext, 0, std::queue<orc::ThreadSafeContext>> ContextPool;
 

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -15,9 +15,6 @@
 #include "julia_assert.h"
 #include "debug-registry.h"
 
-#include <stack>
-#include <queue>
-
 // As of LLVM 13, there are two runtime JIT linker implementations, the older
 // RuntimeDyld (used via orc::RTDyldObjectLinkingLayer) and the newer JITLink
 // (used via orc::ObjectLinkingLayer).
@@ -64,33 +61,7 @@ static inline bool imaging_default() {
     return jl_options.image_codegen || (jl_generating_output() && !jl_options.incremental);
 }
 
-struct jl_locked_stream {
-    JL_STREAM *stream = nullptr;
-    std::mutex mutex;
-
-    struct lock {
-        std::unique_lock<std::mutex> lck;
-        JL_STREAM *&stream;
-
-        lock(std::mutex &mutex, JL_STREAM *&stream) : lck(mutex), stream(stream) {}
-
-        JL_STREAM *&operator*() {
-            return stream;
-        }
-
-        explicit operator bool() {
-            return !!stream;
-        }
-
-        operator JL_STREAM *() {
-            return stream;
-        }
-    };
-
-    lock operator*() {
-        return lock(mutex, stream);
-    }
-};
+typedef jl_cc::Locked<JL_STREAM*> jl_locked_stream;
 
 typedef struct _jl_llvm_functions_t {
     std::string functionObject;     // jlcall llvm Function name
@@ -225,111 +196,6 @@ public:
     typedef orc::IRCompileLayer CompileLayerT;
     typedef orc::IRTransformLayer OptimizeLayerT;
     typedef object::OwningBinary<object::ObjectFile> OwningObj;
-    template
-    <typename ResourceT, size_t max = 0,
-        typename BackingT = std::stack<ResourceT,
-            std::conditional_t<max == 0,
-                SmallVector<ResourceT>,
-                SmallVector<ResourceT, max>
-            >
-        >
-    >
-    struct ResourcePool {
-        public:
-        ResourcePool(std::function<ResourceT()> creator) : creator(std::move(creator)), mutex(std::make_unique<WNMutex>()) {}
-        class OwningResource {
-            public:
-            OwningResource(ResourcePool &pool, ResourceT resource) : pool(pool), resource(std::move(resource)) {}
-            OwningResource(const OwningResource &) = delete;
-            OwningResource &operator=(const OwningResource &) = delete;
-            OwningResource(OwningResource &&) = default;
-            OwningResource &operator=(OwningResource &&) = default;
-            ~OwningResource() {
-                if (resource) pool.release(std::move(*resource));
-            }
-            ResourceT release() {
-                ResourceT res(std::move(*resource));
-                resource.reset();
-                return res;
-            }
-            void reset(ResourceT res) {
-                *resource = std::move(res);
-            }
-            ResourceT &operator*() {
-                return *resource;
-            }
-            ResourceT *operator->() {
-                return get();
-            }
-            ResourceT *get() {
-                return resource.getPointer();
-            }
-            const ResourceT &operator*() const {
-                return *resource;
-            }
-            const ResourceT *operator->() const {
-                return get();
-            }
-            const ResourceT *get() const {
-                return resource.getPointer();
-            }
-            explicit operator bool() const {
-                return resource;
-            }
-            private:
-            ResourcePool &pool;
-            llvm::Optional<ResourceT> resource;
-        };
-
-        OwningResource operator*() {
-            return OwningResource(*this, acquire());
-        }
-
-        OwningResource get() {
-            return **this;
-        }
-
-        ResourceT acquire() {
-            std::unique_lock<std::mutex> lock(mutex->mutex);
-            if (!pool.empty()) {
-                return pop(pool);
-            }
-            if (!max || created < max) {
-                created++;
-                return creator();
-            }
-            mutex->empty.wait(lock, [&](){ return !pool.empty(); });
-            assert(!pool.empty() && "Expected resource pool to have a value!");
-            return pop(pool);
-        }
-        void release(ResourceT &&resource) {
-            std::lock_guard<std::mutex> lock(mutex->mutex);
-            pool.push(std::move(resource));
-            mutex->empty.notify_one();
-        }
-        private:
-        template<typename T, typename Container>
-        static ResourceT pop(std::queue<T, Container> &pool) {
-            ResourceT top = std::move(pool.front());
-            pool.pop();
-            return top;
-        }
-        template<typename PoolT>
-        static ResourceT pop(PoolT &pool) {
-            ResourceT top = std::move(pool.top());
-            pool.pop();
-            return top;
-        }
-        std::function<ResourceT()> creator;
-        size_t created = 0;
-        BackingT pool;
-        struct WNMutex {
-            std::mutex mutex;
-            std::condition_variable empty;
-        };
-
-        std::unique_ptr<WNMutex> mutex;
-    };
     struct PipelineT {
         PipelineT(orc::ObjectLayer &BaseLayer, TargetMachine &TM, int optlevel);
         CompileLayerT CompileLayer;
@@ -426,17 +292,18 @@ private:
 
     JITDebugInfoRegistry DebugRegistry;
 
-    //Map and inc are guarded by RLST_mutex
-    std::mutex RLST_mutex{};
-    int RLST_inc = 0;
-    DenseMap<void*, std::string> ReverseLocalSymbolTable;
+    struct ReverseLocalSymbolsT {
+        int Unique;
+        DenseMap<void*, std::string> Table;
+    };
+    jl_cc::Locked<ReverseLocalSymbolsT> ReverseLocalSymbols;
 
     //Compilation streams
     jl_locked_stream dump_emitted_mi_name_stream;
     jl_locked_stream dump_compiles_stream;
     jl_locked_stream dump_llvm_opt_stream;
 
-    ResourcePool<orc::ThreadSafeContext, 0, std::queue<orc::ThreadSafeContext>> ContextPool;
+    jl_cc::ResourcePool<orc::ThreadSafeContext, 0, std::queue<orc::ThreadSafeContext>> ContextPool;
 
 #ifndef JL_USE_JITLINK
     const std::shared_ptr<RTDyldMemoryManager> MemMgr;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -220,6 +220,10 @@ public:
         size_t count;
     };
 
+#ifndef JL_USE_JITLINK
+    struct PooledMemoryManager;
+#endif
+
 private:
     // Custom object emission notification handler for the JuliaOJIT
     template <typename ObjT, typename LoadResult>
@@ -306,7 +310,7 @@ private:
     jl_cc::ResourcePool<orc::ThreadSafeContext, 0, std::queue<orc::ThreadSafeContext>> ContextPool;
 
 #ifndef JL_USE_JITLINK
-    const std::shared_ptr<RTDyldMemoryManager> MemMgr;
+    const std::shared_ptr<PooledMemoryManager> MemMgr;
 #endif
     ObjLayerT ObjectLayer;
     const std::array<std::unique_ptr<PipelineT>, 4> Pipelines;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -307,7 +307,7 @@ private:
     orc::JITDylib &GlobalJD;
     orc::JITDylib &JD;
 
-    jl_cc::ResourcePool<orc::ThreadSafeContext, 0, std::queue<orc::ThreadSafeContext>> ContextPool;
+    jl_cc::QueuedResourcePool<orc::ThreadSafeContext> ContextPool;
 
 #ifndef JL_USE_JITLINK
     const std::shared_ptr<PooledMemoryManager> MemMgr;


### PR DESCRIPTION
This change makes our RTDyld linker robust against possibly-recursive and/or multithreaded linking attempts, which is useful for reducing the scope of our codegen lock.

Depends on #44926 