### PR TITLE
propagate method metadata to keyword sorter methods

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -799,8 +799,7 @@ function const_prop_enabled(interp::AbstractInterpreter, sv::InferenceState, mat
         add_remark!(interp, sv, "[constprop] Disabled by parameter")
         return false
     end
-    method = match.method
-    if method.constprop == 0x02
+    if is_no_constprop(match.method)
         add_remark!(interp, sv, "[constprop] Disabled by method parameter")
         return false
     end
@@ -1003,7 +1002,7 @@ function is_all_overridden((; fargs, argtypes)::ArgInfo, sv::InferenceState)
 end
 
 function force_const_prop(interp::AbstractInterpreter, @nospecialize(f), method::Method)
-    return method.constprop == 0x01 ||
+    return is_aggressive_constprop(method) ||
            InferenceParams(interp).aggressive_constant_propagation ||
            istopfunction(f, :getproperty) ||
            istopfunction(f, :setproperty!)

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -209,6 +209,20 @@ function specialize_method(match::MethodMatch; kwargs...)
     return specialize_method(match.method, match.spec_types, match.sparams; kwargs...)
 end
 
+"""
+    is_aggressive_constprop(method::Union{Method,CodeInfo}) -> Bool
+
+Check if `method` is declared as `Base.@constprop :aggressive`.
+"""
+is_aggressive_constprop(method::Union{Method,CodeInfo}) = method.constprop == 0x01
+
+"""
+    is_no_constprop(method::Union{Method,CodeInfo}) -> Bool
+
+Check if `method` is declared as `Base.@constprop :none`.
+"""
+is_no_constprop(method::Union{Method,CodeInfo}) = method.constprop == 0x02
+
 #########
 # types #
 #########

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -523,9 +523,20 @@
   (and (if one (length= e 3) (length> e 2))
        (eq? (car e) 'meta) (memq (cadr e) '(nospecialize specialize))))
 
-(define (inline-meta? e)
-  (and (length= e 2)
-       (eq? (car e) 'meta) (memq (cadr e) '(inline noinline))))
+(define (meta? e)
+  (and (length> e 1) (eq? (car e) 'meta)))
+
+(define (method-meta-sym? x)
+  (memq x '(inline noinline aggressive_constprop no_constprop propagate_inbounds)))
+
+(define (propagate-method-meta e)
+  `(meta ,@(filter (lambda (x)
+                     (or (method-meta-sym? x)
+                         (and (pair? x) (eq? (car x) 'purity))))
+                   (cdr e))))
+
+(define (argwide-nospecialize-meta? e)
+  (and (length= e 2) (eq? (car e) 'meta) (memq (cadr e) '(nospecialize specialize))))
 
 (define (if-generated? e)
   (and (length= e 4) (eq? (car e) 'if) (equal? (cadr e) '(generated))))

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -523,6 +523,10 @@
   (and (if one (length= e 3) (length> e 2))
        (eq? (car e) 'meta) (memq (cadr e) '(nospecialize specialize))))
 
+(define (inline-meta? e)
+  (and (length= e 2)
+       (eq? (car e) 'meta) (memq (cadr e) '(inline noinline))))
+
 (define (if-generated? e)
   (and (length= e 4) (eq? (car e) 'if) (equal? (cadr e) '(generated))))
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -562,7 +562,9 @@
              ,(if (any kwarg? pargl) (gensy) UNUSED)
              (call (core kwftype) ,ftype)) ,kw ,@pargl ,@vararg)
           `(block
-            ,@(filter inline-meta? prologue)
+            ;; propagate method metadata to keyword sorter
+            ,@(map propagate-method-meta (filter meta? prologue))
+            ,@(filter argwide-nospecialize-meta? prologue)
             ,@(let ((lnns (filter linenum? prologue)))
                 (if (pair? lnns)
                     (list (car lnns))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -562,6 +562,7 @@
              ,(if (any kwarg? pargl) (gensy) UNUSED)
              (call (core kwftype) ,ftype)) ,kw ,@pargl ,@vararg)
           `(block
+            ,@(filter inline-meta? prologue)
             ,@(let ((lnns (filter linenum? prologue)))
                 (if (pair? lnns)
                     (list (car lnns))


### PR DESCRIPTION
Arguably, if a method is declared `@inline` we should propagate that to all the methods we generate for it, including the keyword sorter. However, AFAICT #45028 still needs a `@constprop` declaration to function.