### PR TITLE
Typo in doc of `hypot()`

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -633,7 +633,7 @@ Compute the hypotenuse ``\\sqrt{|x|^2+|y|^2}`` avoiding overflow and underflow.
 This code is an implementation of the algorithm described in:
 An Improved Algorithm for `hypot(a,b)`
 by Carlos F. Borges
-The article is available online at ArXiv at the link
+The article is available online at arXiv at the link
   https://arxiv.org/abs/1904.09481
 
     hypot(x...)


### PR DESCRIPTION
There is a minor typo in the docs of `math.hypot()` 

The name of the organization that operates arxiv.org should be stylized as arXiv.

References to papers in arXiv exist in the following other places in the Julia code base:

- https://github.com/JuliaLang/julia/blob/ac51add4a610668835bb12db4913af1c2c16aaf8/base/complex.jl#L384
- https://github.com/JuliaLang/julia/blob/ac51add4a610668835bb12db4913af1c2c16aaf8/stdlib/Random/src/generation.jl#L325
- https://github.com/JuliaLang/julia/blob/ac51add4a610668835bb12db4913af1c2c16aaf8/stdlib/LinearAlgebra/src/hessenberg.jl#L310
- https://github.com/JuliaLang/julia/blob/ac51add4a610668835bb12db4913af1c2c16aaf8/base/compiler/ssair/domtree.jl#L66

All of these are well formatted due to being URLs or persistent IDs to articles in arXiv.

Let me know if the formating used at these locations would be preferred. Ex
```
This code is an implementation of the algorithm described in:

Carlos F. Borges
"An Improved Algorithm for `hypot(a,b)`"
arxiv:1904.09481 (2019)
```
