### PR TITLE
Do not include NEWS in the PDF of the docs

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -176,7 +176,6 @@ const PAGES = [
     "Base" => BaseDocs,
     "Standard Library" => StdlibDocs,
     "Developer Documentation" => DevDocs,
-    hide("NEWS.md"),
 ]
 else
 const PAGES = [


### PR DESCRIPTION
I feel the NEWS entries are not particularly valuable in the PDF documentation. They get rendered a bit weirdly with each section of NEWS as a new chapter. That drew my attention, but upon reflection, I feel that we could just remove it altogether.

