### PR TITLE
CI (`Create Buildbot Statuses`): remove `tester_linux32` from the list

### DIFF
--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -48,7 +48,6 @@ jobs:
       - run: |
           declare -a CONTEXT_LIST=(
                 "buildbot/tester_freebsd64"
-                "buildbot/tester_linux32"
                 "buildbot/tester_win32"
                 "buildbot/tester_win64"
                 )


### PR DESCRIPTION
The Linux i686 Buildbots are broken. (See e.g. https://github.com/JuliaLang/julia/issues/45045 for a symptom of the breakage.) As a result, these `tester_linux32` statuses end up perpetually yellow, which is not useful.