### PR TITLE
Reduce invalidations from convert methods

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -277,7 +277,6 @@ See also: [`round`](@ref), [`trunc`](@ref), [`oftype`](@ref), [`reinterpret`](@r
 """
 function convert end
 
-convert(::Type{Union{}}, @nospecialize x) = throw(MethodError(convert, (Union{}, x)))
 convert(::Type{Type}, x::Type) = x # the ssair optimizer is strongly dependent on this method existing to avoid over-specialization
                                    # in the absence of inlining-enabled
                                    # (due to fields typed as `Type`, which is generally a bad idea)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -416,7 +416,7 @@ function _mapreduce(f, op, ::IndexLinear, A::AbstractArrayOrBroadcasted)
     inds = LinearIndices(A)
     n = length(inds)
     if n == 0
-        return mapreduce_empty_iter(f, op, A, IteratorEltype(A))
+        return reduce_empty_iter(MappingRF(f, op), A, IteratorEltype(A))
     elseif n == 1
         @inbounds a1 = A[first(inds)]
         return mapreduce_first(f, op, a1)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1987,7 +1987,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
 
     # comparison (i.e. "x < y < z")
     elseif head === :comparison && nargs >= 3 && (nargs&1==1)
-        comp_prec = minimum(operator_precedence, args[2:2:end])
+        comp_prec = minimum(operator_precedence, args[2:2:end]; init=typemax(Int))
         if comp_prec <= prec
             show_enclosed_list(io, '(', args, " ", ')', indent, comp_prec, quote_level)
         else


### PR DESCRIPTION
On nightly (but not earlier Julia versions), loading ColorTypes causes
more than 1800 invalidations. These changes eliminate all but ~20.

The `convert(TypeOfBottom, x)` method was added in #31602, I think to help with invalidations. Consequently I'd be grateful for a quick glance from @vtjnash. It now seems to be counterproductive, perhaps because we may have turned off invalidations in the case of method ambiguity. While this can't be the only issue, the method may simply be unnecessary now.