### PR TITLE
add no-op constructor for `VersionNumber(::VersionNumber)`

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -80,6 +80,7 @@ VersionNumber(major::Integer, minor::Integer = 0, patch::Integer = 0,
         map(x->x isa Integer ? UInt64(x) : String(x), bld))
 
 VersionNumber(v::Tuple) = VersionNumber(v...)
+VersionNumber(v::VersionNumber) = v
 
 function print(io::IO, v::VersionNumber)
     v == typemax(VersionNumber) && return print(io, "∞")

--- a/test/version.jl
+++ b/test/version.jl
@@ -100,6 +100,12 @@ show(io,v"4.3.2+1.a")
 # construction from AbstractString
 @test VersionNumber("4.3.2+1.a") == v"4.3.2+1.a"
 
+# construct from VersionNumber
+let
+    v = VersionNumber("1.2.3")
+    @test VersionNumber(v) == v
+end
+
 # typemin and typemax
 @test typemin(VersionNumber) == v"0-"
 @test typemax(VersionNumber) == v"∞"


### PR DESCRIPTION
This adds a constructor for `VersionNumber(v::VersionNumber) = v`.  The constructor is currently quite convenient: given just about anything it'll return a version number for you.  The one exception is that given a version number, it'll error.  So we're forced to do things like

```julia
to_version(v) = VersionNumber(v)
to_version(v::VersionNumber) = v
```

which feels less than ideal.