### PR TITLE
Updates to findmin/findmax: function application over multidims

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -908,7 +908,8 @@ julia> findmax([1, 7, 7, NaN])
 (NaN, 4)
 ```
 """
-findmax(itr) = findmax(identity, itr)
+findmax(itr) = _findmax(itr, :)
+_findmax(a, ::Colon) = findmax(identity, a)
 
 """
     findmin(f, domain) -> (f(x), index)
@@ -967,7 +968,8 @@ julia> findmin([1, 7, 7, NaN])
 (NaN, 4)
 ```
 """
-findmin(itr) = findmin(identity, itr)
+findmin(itr) = _findmin(itr, :)
+_findmin(a, ::Colon) = findmin(identity, a)
 
 """
     argmax(f, domain)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -882,7 +882,8 @@ julia> findmax(cos, 0:π/2:2π)
 (1.0, 1)
 ```
 """
-findmax(f, domain) = mapfoldl( ((k, v),) -> (f(v), k), _rf_findmax, pairs(domain) )
+findmax(f, domain) = _findmax(f, domain, :)
+_findmax(f, domain, ::Colon) = mapfoldl( ((k, v),) -> (f(v), k), _rf_findmax, pairs(domain) )
 _rf_findmax((fm, im), (fx, ix)) = isless(fm, fx) ? (fx, ix) : (fm, im)
 
 """
@@ -907,8 +908,7 @@ julia> findmax([1, 7, 7, NaN])
 (NaN, 4)
 ```
 """
-findmax(itr) = _findmax(itr, :)
-_findmax(a, ::Colon) = findmax(identity, a)
+findmax(itr) = findmax(identity, itr)
 
 """
     findmin(f, domain) -> (f(x), index)
@@ -941,7 +941,8 @@ julia> findmin(cos, 0:π/2:2π)
 ```
 
 """
-findmin(f, domain) = mapfoldl( ((k, v),) -> (f(v), k), _rf_findmin, pairs(domain) )
+findmin(f, domain) = _findmin(f, domain, :)
+_findmin(f, domain, ::Colon) = mapfoldl( ((k, v),) -> (f(v), k), _rf_findmin, pairs(domain) )
 _rf_findmin((fm, im), (fx, ix)) = isgreater(fm, fx) ? (fx, ix) : (fm, im)
 
 """
@@ -966,8 +967,7 @@ julia> findmin([1, 7, 7, NaN])
 (NaN, 4)
 ```
 """
-findmin(itr) = _findmin(itr, :)
-_findmin(a, ::Colon) = findmin(identity, a)
+findmin(itr) = findmin(identity, itr)
 
 """
     argmax(f, domain)

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -200,9 +200,6 @@ function reducedim_init(f::ExtremaMap, op::typeof(_extrema_rf), A::AbstractArray
     return reducedim_initarray(A, region, v0, Tuple{Tmin,Tmax})
 end
 
-# Why is this defined for `max` but not also `min`?
-# It leads to improper behavior, e.g. maximum(abs2, Matrix{Int}(undef, 0, 1), dims=1)
-# Moreover, reducedim_init (above) handles the cases acceptably.
 reducedim_init(f::Union{typeof(abs),typeof(abs2)}, op::typeof(max), A::AbstractArray{T}, region) where {T} =
     reducedim_initarray(A, region, zero(f(zero(T))), _realtype(f, T))
 

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -1109,7 +1109,8 @@ julia> findmin(A, dims=2)
 ([1.0; 3.0;;], CartesianIndex{2}[CartesianIndex(1, 1); CartesianIndex(2, 1);;])
 ```
 """
-findmin(A::AbstractArray; dims=:) = _findmin(identity, A, dims)
+findmin(A::AbstractArray; dims=:) = _findmin(A, dims)
+_findmin(A, dims) = _findmin(identity, A, dims)
 
 """
     findmin(f, A; dims) -> (f(x), index)
@@ -1176,7 +1177,8 @@ julia> findmax(A, dims=2)
 ([2.0; 4.0;;], CartesianIndex{2}[CartesianIndex(1, 2); CartesianIndex(2, 2);;])
 ```
 """
-findmax(A::AbstractArray; dims=:) = _findmax(identity, A, dims)
+findmax(A::AbstractArray; dims=:) = _findmax(A, dims)
+_findmax(A, dims) = _findmax(identity, A, dims)
 
 """
     findmax(f, A; dims) -> (f(x), index)

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -1027,7 +1027,7 @@ end
 ##### findmin & findmax #####
 # The initial values of Rval are not used if the corresponding indices in Rind are 0.
 #
-function findminmax!(f, Rval, Rind, A::AbstractArray{T,N}) where {T,N}
+function findminmax!(f, op, Rval, Rind, A::AbstractArray{T,N}) where {T,N}
     (isempty(Rval) || isempty(A)) && return Rval, Rind
     lsiz = check_reducedims(Rval, A)
     for i = 1:N
@@ -1048,8 +1048,8 @@ function findminmax!(f, Rval, Rind, A::AbstractArray{T,N}) where {T,N}
             tmpRi = Rind[i1,IR]
             for i in axes(A,1)
                 k, kss = y::Tuple
-                tmpAv = A[i,IA]
-                if tmpRi == zi || f(tmpRv, tmpAv)
+                tmpAv = f(A[i,IA])
+                if tmpRi == zi || op(tmpRv, tmpAv)
                     tmpRv = tmpAv
                     tmpRi = k
                 end
@@ -1063,10 +1063,10 @@ function findminmax!(f, Rval, Rind, A::AbstractArray{T,N}) where {T,N}
             IR = Broadcast.newindex(IA, keep, Idefault)
             for i in axes(A, 1)
                 k, kss = y::Tuple
-                tmpAv = A[i,IA]
+                tmpAv = f(A[i,IA])
                 tmpRv = Rval[i,IR]
                 tmpRi = Rind[i,IR]
-                if tmpRi == zi || f(tmpRv, tmpAv)
+                if tmpRi == zi || op(tmpRv, tmpAv)
                     Rval[i,IR] = tmpAv
                     Rind[i,IR] = k
                 end
@@ -1086,7 +1086,7 @@ dimensions of `rval` and `rind`, and store the results in `rval` and `rind`.
 """
 function findmin!(rval::AbstractArray, rind::AbstractArray, A::AbstractArray;
                   init::Bool=true)
-    findminmax!(isgreater, init && !isempty(A) ? fill!(rval, first(A)) : rval, fill!(rind,zero(eltype(keys(A)))), A)
+    findminmax!(identity, isgreater, init && !isempty(A) ? fill!(rval, first(A)) : rval, fill!(rind,zero(eltype(keys(A)))), A)
 end
 
 """
@@ -1109,17 +1109,37 @@ julia> findmin(A, dims=2)
 ([1.0; 3.0;;], CartesianIndex{2}[CartesianIndex(1, 1); CartesianIndex(2, 1);;])
 ```
 """
-findmin(A::AbstractArray; dims=:) = _findmin(A, dims)
+findmin(A::AbstractArray; dims=:) = _findmin(identity, A, dims)
 
-function _findmin(A, region)
+"""
+    findmin(f, A; dims) -> (f(x), index)
+
+For an array input, returns the value in the codomain and index of the corresponding value
+which minimize `f` over the given dimensions.
+
+# Examples
+```jldoctest
+julia> A = [-1.0 1; -0.5 2]
+2×2 Matrix{Float64}:
+ -1.0  1.0
+ -0.5  2.0
+
+julia> findmin(abs2, A, dims=2)
+([1.0; 0.25;;], CartesianIndex{2}[CartesianIndex(1, 1); CartesianIndex(2, 1);;])
+```
+"""
+findmin(f::Function, A::AbstractArray; dims=:) = _findmin(f, A, dims)
+
+function _findmin(f, A, region)
     ri = reduced_indices0(A, region)
     if isempty(A)
         if prod(map(length, reduced_indices(A, region))) != 0
             throw(ArgumentError("collection slices must be non-empty"))
         end
-        (similar(A, ri), zeros(eltype(keys(A)), ri))
+        (similar(A, promote_op(f, eltype(A)), ri), zeros(eltype(keys(A)), ri))
     else
-        findminmax!(isgreater, fill!(similar(A, ri), first(A)),
+        fA = f(first(A))
+        findminmax!(f, isgreater, fill!(similar(A, typeof(fA), ri), fA),
                     zeros(eltype(keys(A)), ri), A)
     end
 end
@@ -1133,7 +1153,7 @@ dimensions of `rval` and `rind`, and store the results in `rval` and `rind`.
 """
 function findmax!(rval::AbstractArray, rind::AbstractArray, A::AbstractArray;
                   init::Bool=true)
-    findminmax!(isless, init && !isempty(A) ? fill!(rval, first(A)) : rval, fill!(rind,zero(eltype(keys(A)))), A)
+    findminmax!(identity, isless, init && !isempty(A) ? fill!(rval, first(A)) : rval, fill!(rind,zero(eltype(keys(A)))), A)
 end
 
 """
@@ -1156,17 +1176,37 @@ julia> findmax(A, dims=2)
 ([2.0; 4.0;;], CartesianIndex{2}[CartesianIndex(1, 2); CartesianIndex(2, 2);;])
 ```
 """
-findmax(A::AbstractArray; dims=:) = _findmax(A, dims)
+findmax(A::AbstractArray; dims=:) = _findmax(identity, A, dims)
 
-function _findmax(A, region)
+"""
+    findmax(f, A; dims) -> (f(x), index)
+
+For an array input, returns the value in the codomain and index of the corresponding value
+which maximize `f` over the given dimensions.
+
+# Examples
+```jldoctest
+julia> A = [-1.0 1; -0.5 2]
+2×2 Matrix{Float64}:
+ -1.0  1.0
+ -0.5  2.0
+
+julia> findmax(abs2, A, dims=2)
+([1.0; 4.0;;], CartesianIndex{2}[CartesianIndex(1, 1); CartesianIndex(2, 2);;])
+```
+"""
+findmax(f::Function, A::AbstractArray; dims=:) = _findmax(f, A, dims)
+
+function _findmax(f, A, region)
     ri = reduced_indices0(A, region)
     if isempty(A)
         if prod(map(length, reduced_indices(A, region))) != 0
             throw(ArgumentError("collection slices must be non-empty"))
         end
-        similar(A, ri), zeros(eltype(keys(A)), ri)
+        similar(A, promote_op(f, eltype(A)), ri), zeros(eltype(keys(A)), ri)
     else
-        findminmax!(isless, fill!(similar(A, ri), first(A)),
+        fA = f(first(A))
+        findminmax!(f, isless, fill!(similar(A, typeof(fA), ri), fA),
                     zeros(eltype(keys(A)), ri), A)
     end
 end

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -1128,7 +1128,7 @@ julia> findmin(abs2, A, dims=2)
 ([1.0; 0.25;;], CartesianIndex{2}[CartesianIndex(1, 1); CartesianIndex(2, 1);;])
 ```
 """
-findmin(f::Function, A::AbstractArray; dims=:) = _findmin(f, A, dims)
+findmin(f, A::AbstractArray; dims=:) = _findmin(f, A, dims)
 
 function _findmin(f, A, region)
     ri = reduced_indices0(A, region)
@@ -1139,7 +1139,7 @@ function _findmin(f, A, region)
         (similar(A, promote_op(f, eltype(A)), ri), zeros(eltype(keys(A)), ri))
     else
         fA = f(first(A))
-        findminmax!(f, isgreater, fill!(similar(A, typeof(fA), ri), fA),
+        findminmax!(f, isgreater, fill!(similar(A, promote_type(eltype(A), typeof(fA)), ri), fA),
                     zeros(eltype(keys(A)), ri), A)
     end
 end
@@ -1195,7 +1195,7 @@ julia> findmax(abs2, A, dims=2)
 ([1.0; 4.0;;], CartesianIndex{2}[CartesianIndex(1, 1); CartesianIndex(2, 2);;])
 ```
 """
-findmax(f::Function, A::AbstractArray; dims=:) = _findmax(f, A, dims)
+findmax(f, A::AbstractArray; dims=:) = _findmax(f, A, dims)
 
 function _findmax(f, A, region)
     ri = reduced_indices0(A, region)
@@ -1206,7 +1206,7 @@ function _findmax(f, A, region)
         similar(A, promote_op(f, eltype(A)), ri), zeros(eltype(keys(A)), ri)
     else
         fA = f(first(A))
-        findminmax!(f, isless, fill!(similar(A, typeof(fA), ri), fA),
+        findminmax!(f, isless, fill!(similar(A, promote_type(eltype(A), typeof(fA)), ri), fA),
                     zeros(eltype(keys(A)), ri), A)
     end
 end

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -200,6 +200,9 @@ function reducedim_init(f::ExtremaMap, op::typeof(_extrema_rf), A::AbstractArray
     return reducedim_initarray(A, region, v0, Tuple{Tmin,Tmax})
 end
 
+# Why is this defined for `max` but not also `min`?
+# It leads to improper behavior, e.g. maximum(abs2, Matrix{Int}(undef, 0, 1), dims=1)
+# Moreover, reducedim_init (above) handles the cases acceptably.
 reducedim_init(f::Union{typeof(abs),typeof(abs2)}, op::typeof(max), A::AbstractArray{T}, region) where {T} =
     reducedim_initarray(A, region, zero(f(zero(T))), _realtype(f, T))
 

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -1128,6 +1128,9 @@ julia> A = [-1.0 1; -0.5 2]
  -1.0  1.0
  -0.5  2.0
 
+julia> findmin(abs2, A, dims=1)
+([0.25 1.0], CartesianIndex{2}[CartesianIndex(2, 1) CartesianIndex(1, 2)])
+
 julia> findmin(abs2, A, dims=2)
 ([1.0; 0.25;;], CartesianIndex{2}[CartesianIndex(1, 1); CartesianIndex(2, 1);;])
 ```
@@ -1195,6 +1198,9 @@ julia> A = [-1.0 1; -0.5 2]
 2×2 Matrix{Float64}:
  -1.0  1.0
  -0.5  2.0
+
+julia> findmax(abs2, A, dims=1)
+([1.0 4.0], CartesianIndex{2}[CartesianIndex(1, 1) CartesianIndex(2, 2)])
 
 julia> findmax(abs2, A, dims=2)
 ([1.0; 4.0;;], CartesianIndex{2}[CartesianIndex(1, 1); CartesianIndex(2, 2);;])

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -197,6 +197,10 @@ end
         @test isequal(f(A, dims=2), (zeros(Int, 0, 1), zeros(Int, 0, 1)))
         @test_throws ArgumentError f(A, dims=(1, 2))
         @test isequal(f(A, dims=3), (zeros(Int, 0, 1), zeros(Int, 0, 1)))
+        @test_throws ArgumentError f(abs2, A, dims=1)
+        @test isequal(f(abs2, A, dims=2), (zeros(Int, 0, 1), zeros(Int, 0, 1)))
+        @test_throws ArgumentError f(abs2, A, dims=(1, 2))
+        @test isequal(f(abs2, A, dims=3), (zeros(Int, 0, 1), zeros(Int, 0, 1)))
     end
 
 end
@@ -225,15 +229,76 @@ for (tup, rval, rind) in [((1,), [5.0 5.0 6.0], [CartesianIndex(2,1) CartesianIn
     @test isequal(maximum!(copy(rval), A, init=false), rval)
 end
 
+@testset "findmin/findmax transformed arguments, numeric values" begin
+    A = [1.0 -5.0 -6.0;
+         -5.0 2.0 4.0]
+    TA = [((1,), [1.0 2.0 4.0], [CartesianIndex(1,1) CartesianIndex(2,2) CartesianIndex(2,3)]),
+          ((2,), reshape([1.0, 2.0], 2, 1), reshape([CartesianIndex(1,1), CartesianIndex(2,2)], 2, 1)),
+          ((1,2), fill(1.0,1,1), fill(CartesianIndex(1,1),1,1))]
+    TA2 = [((1,), [1.0 4.0 16.0], [CartesianIndex(1,1) CartesianIndex(2,2) CartesianIndex(2,3)]),
+           ((2,), reshape([1.0, 4.0], 2, 1), reshape([CartesianIndex(1,1), CartesianIndex(2,2)], 2, 1)),
+           ((1,2), fill(1.0,1,1), fill(CartesianIndex(1,1),1,1))]
+    TAc = [((1,), [0.28366218546322625 -0.4161468365471424 -0.6536436208636119], [CartesianIndex(2,1) CartesianIndex(2,2) CartesianIndex(2,3)]),
+           ((2,), reshape([0.28366218546322625, -0.6536436208636119], 2, 1), reshape([CartesianIndex(1,2), CartesianIndex(2,3)], 2, 1)),
+           ((1,2), fill(-0.6536436208636119,1,1), fill(CartesianIndex(2,3),1,1))]
+    for (f, At) in ((abs, TA), (abs2, TA2), (cos, TAc))
+        A′ = map(f, A)
+        for (tup, rval, rind) in At
+            (rval′, rind′) = findmin(f, A, dims=tup)
+            @test all(rval′ .≈ rval)
+            @test rind′ == rind
+            @test findmin(f, A, dims=tup) == (rval, rind)
+            @test (rval′, rind′) == findmin(A′, dims=tup)
+        end
+    end
+
+    TA = [((1,), [5.0 5.0 6.0], [CartesianIndex(2,1) CartesianIndex(1,2) CartesianIndex(1,3)]),
+          ((2,), reshape([6.0,5.0], 2, 1), reshape([CartesianIndex(1,3), CartesianIndex(2,1)], 2, 1)),
+          ((1,2), fill(6.0,1,1),fill(CartesianIndex(1,3),1,1))]
+    TA2 = [((1,), [25.0 25.0 36.0], [CartesianIndex(2,1) CartesianIndex(1,2) CartesianIndex(1,3)]),
+           ((2,), reshape([36.0, 25.0], 2, 1), reshape([CartesianIndex(1,3), CartesianIndex(2,1)], 2, 1)),
+           ((1,2), fill(36.0,1,1), fill(CartesianIndex(1,3),1,1))]
+    TAc = [((1,), [0.5403023058681398 0.28366218546322625 0.960170286650366], [CartesianIndex(1,1) CartesianIndex(1,2) CartesianIndex(1,3)]),
+           ((2,), reshape([0.960170286650366, 0.28366218546322625], 2, 1), reshape([CartesianIndex(1,3), CartesianIndex(2,1)], 2, 1)),
+           ((1,2), fill(0.960170286650366,1,1), fill(CartesianIndex(1,3),1,1))]
+    for (f, At) in ((abs, TA), (abs2, TA2), (cos, TAc))
+        A′ = map(f, A)
+        for (tup, rval, rind) in At
+            (rval′, rind′) = findmax(f, A, dims=tup)
+            @test all(rval′ .≈ rval)
+            @test rind′ == rind
+            @test findmax(f, A, dims=tup) == (rval, rind)
+            @test (rval′, rind′) == findmax(A′, dims=tup)
+        end
+    end
+end
+
+# findmin/findmax function arguments: output type inference
+A = ["1" "22"; "333" "4444"]
+for (tup, rval, rind) in [((1,), [1 2], [CartesianIndex(1, 1) CartesianIndex(1, 2)]),
+                          ((2,), reshape([1, 3], 2, 1), reshape([CartesianIndex(1, 1), CartesianIndex(2, 1)], 2, 1)),
+                          ((1,2), fill(1,1,1), fill(CartesianIndex(1,1),1,1))]
+    @test (rval, rind) == findmin(length, A, dims=tup)
+end
+for (tup, rval, rind) in [((1,), [3 4], [CartesianIndex(2, 1) CartesianIndex(2, 2)]),
+                          ((2,), reshape([2, 4], 2, 1), reshape([CartesianIndex(1, 2), CartesianIndex(2, 2)], 2, 1)),
+                          ((1,2), fill(4,1,1), fill(CartesianIndex(2,2),1,1))]
+    @test (rval, rind) == findmax(length, A, dims=tup)
+end
+
+
 @testset "missing in findmin/findmax" begin
     B = [1.0 missing NaN;
          5.0 NaN missing]
+    B′ = [1.0 missing NaN;
+          -5.0 NaN missing]
     for (tup, rval, rind) in [(1, [5.0 missing missing], [CartesianIndex(2, 1) CartesianIndex(1, 2) CartesianIndex(2, 3)]),
                               (2, [missing; missing],    [CartesianIndex(1, 2) CartesianIndex(2, 3)] |> permutedims)]
         (rval′, rind′) = findmax(B, dims=tup)
         @test all(rval′ .=== rval)
         @test all(rind′ .== rind)
         @test all(maximum(B, dims=tup) .=== rval)
+        @test (rval′, rind′) == findmax(abs, B′, dims=tup)
     end
 
     for (tup, rval, rind) in [(1, [1.0 missing missing], [CartesianIndex(1, 1) CartesianIndex(1, 2) CartesianIndex(2, 3)]),
@@ -242,6 +307,7 @@ end
         @test all(rval′ .=== rval)
         @test all(rind′ .== rind)
         @test all(minimum(B, dims=tup) .=== rval)
+        @test (rval′, rind′) == findmin(abs, B′, dims=tup)
     end
 end
 
@@ -266,6 +332,7 @@ for (tup, rval, rind) in [((1,), [NaN 2.0 4.0], [CartesianIndex(2,1) CartesianIn
                           ((2,), reshape([1.0, NaN], 2, 1), reshape([CartesianIndex(1,1),CartesianIndex(2,1)], 2, 1)),
                           ((1,2), fill(NaN,1,1),fill(CartesianIndex(2,1),1,1))]
     @test isequal(findmin(A, dims=tup), (rval, rind))
+    @test isequal(findmin(abs, A, dims=tup), (rval, rind))
     @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
     @test isequal(minimum(A, dims=tup), rval)
     @test isequal(minimum!(similar(rval), A), rval)
@@ -277,6 +344,7 @@ for (tup, rval, rind) in [((1,), [NaN 3.0 6.0], [CartesianIndex(2,1) CartesianIn
                           ((2,), reshape([6.0, NaN], 2, 1), reshape([CartesianIndex(1,3),CartesianIndex(2,1)], 2, 1)),
                           ((1,2), fill(NaN,1,1),fill(CartesianIndex(2,1),1,1))]
     @test isequal(findmax(A, dims=tup), (rval, rind))
+    @test isequal(findmax(abs, A, dims=tup), (rval, rind))
     @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
     @test isequal(maximum(A, dims=tup), rval)
     @test isequal(maximum!(similar(rval), A), rval)
@@ -286,125 +354,153 @@ end
 
 # issue #28320
 @testset "reducedim issue with abstract complex arrays" begin
-let A = Complex[1.5 0.5]
-    @test mapreduce(abs2, +, A, dims=2) == reshape([2.5], 1, 1)
-    @test sum(abs2, A, dims=2) == reshape([2.5], 1, 1)
-    @test prod(abs2, A, dims=2) == reshape([0.5625], 1, 1)
-    @test maximum(abs2, A, dims=2) == reshape([2.25], 1, 1)
-    @test minimum(abs2, A, dims=2) == reshape([0.25], 1, 1)
-end
-end
-
-A = [1.0 NaN 6.0;
-     NaN 2.0 4.0]
-for (tup, rval, rind) in [((1,), [NaN NaN 4.0], [CartesianIndex(2,1) CartesianIndex(1,2) CartesianIndex(2,3)]),
-                          ((2,), reshape([NaN, NaN], 2, 1), reshape([CartesianIndex(1,2),CartesianIndex(2,1)], 2, 1)),
-                          ((1,2), fill(NaN,1,1),fill(CartesianIndex(2,1),1,1))]
-    @test isequal(findmin(A, dims=tup), (rval, rind))
-    @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
-    @test isequal(minimum(A, dims=tup), rval)
-    @test isequal(minimum!(similar(rval), A), rval)
-    @test isequal(minimum!(copy(rval), A, init=false), rval)
+    let A = Complex[1.5 0.5]
+        @test mapreduce(abs2, +, A, dims=2) == reshape([2.5], 1, 1)
+        @test sum(abs2, A, dims=2) == reshape([2.5], 1, 1)
+        @test prod(abs2, A, dims=2) == reshape([0.5625], 1, 1)
+        @test maximum(abs2, A, dims=2) == reshape([2.25], 1, 1)
+        @test minimum(abs2, A, dims=2) == reshape([0.25], 1, 1)
+        @test findmin(abs2, A, dims=2) == (fill(0.25, 1, 1), fill(CartesianIndex(1, 2), 1, 1))
+        @test findmax(abs2, A, dims=2) == (fill(2.25, 1, 1), fill(CartesianIndex(1, 1), 1, 1))
+    end
 end
 
-for (tup, rval, rind) in [((1,), [NaN NaN 6.0], [CartesianIndex(2,1) CartesianIndex(1,2) CartesianIndex(1,3)]),
-                          ((2,), reshape([NaN, NaN], 2, 1), reshape([CartesianIndex(1,2),CartesianIndex(2,1)], 2, 1)),
-                          ((1,2), fill(NaN,1,1),fill(CartesianIndex(2,1),1,1))]
-    @test isequal(findmax(A, dims=tup), (rval, rind))
-    @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
-    @test isequal(maximum(A, dims=tup), rval)
-    @test isequal(maximum!(similar(rval), A), rval)
-    @test isequal(maximum!(copy(rval), A, init=false), rval)
+@testset "NaN in findmin/findmax/minimum/maximum" begin
+    A = [1.0 NaN 6.0;
+         NaN 2.0 4.0]
+    A′ = [-1.0 NaN -6.0;
+          NaN -2.0 4.0]
+    for (tup, rval, rind) in [((1,), [NaN NaN 4.0], [CartesianIndex(2,1) CartesianIndex(1,2) CartesianIndex(2,3)]),
+                              ((2,), reshape([NaN, NaN], 2, 1), reshape([CartesianIndex(1,2),CartesianIndex(2,1)], 2, 1)),
+                              ((1,2), fill(NaN,1,1),fill(CartesianIndex(2,1),1,1))]
+        @test isequal(findmin(A, dims=tup), (rval, rind))
+        @test isequal(findmin(abs, A′, dims=tup), (rval, rind))
+        @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
+        @test isequal(minimum(A, dims=tup), rval)
+        @test isequal(minimum!(similar(rval), A), rval)
+        @test isequal(minimum!(copy(rval), A, init=false), rval)
+    end
+
+    for (tup, rval, rind) in [((1,), [NaN NaN 6.0], [CartesianIndex(2,1) CartesianIndex(1,2) CartesianIndex(1,3)]),
+                              ((2,), reshape([NaN, NaN], 2, 1), reshape([CartesianIndex(1,2),CartesianIndex(2,1)], 2, 1)),
+                              ((1,2), fill(NaN,1,1),fill(CartesianIndex(2,1),1,1))]
+        @test isequal(findmax(A, dims=tup), (rval, rind))
+        @test isequal(findmax(abs, A′, dims=tup), (rval, rind))
+        @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
+        @test isequal(maximum(A, dims=tup), rval)
+        @test isequal(maximum!(similar(rval), A), rval)
+        @test isequal(maximum!(copy(rval), A, init=false), rval)
+    end
 end
 
-A = [Inf -Inf Inf  -Inf;
-     Inf  Inf -Inf -Inf]
-for (tup, rval, rind) in [((1,), [Inf -Inf -Inf -Inf], [CartesianIndex(1,1) CartesianIndex(1,2) CartesianIndex(2,3) CartesianIndex(1,4)]),
-                          ((2,), reshape([-Inf -Inf], 2, 1), reshape([CartesianIndex(1,2),CartesianIndex(2,3)], 2, 1)),
-                          ((1,2), fill(-Inf,1,1),fill(CartesianIndex(1,2),1,1))]
-    @test isequal(findmin(A, dims=tup), (rval, rind))
-    @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
-    @test isequal(minimum(A, dims=tup), rval)
-    @test isequal(minimum!(similar(rval), A), rval)
-    @test isequal(minimum!(copy(rval), A, init=false), rval)
+@testset "+/-Inf in findmin/findmax/minimum/maximum" begin
+    A = [Inf -Inf Inf  -Inf;
+         Inf  Inf -Inf -Inf]
+    A′ = [1 0 1 0;
+          1 1 0 0]
+    for (tup, rval, rind) in [((1,), [Inf -Inf -Inf -Inf], [CartesianIndex(1,1) CartesianIndex(1,2) CartesianIndex(2,3) CartesianIndex(1,4)]),
+                              ((2,), reshape([-Inf -Inf], 2, 1), reshape([CartesianIndex(1,2),CartesianIndex(2,3)], 2, 1)),
+                              ((1,2), fill(-Inf,1,1),fill(CartesianIndex(1,2),1,1))]
+        @test isequal(findmin(A, dims=tup), (rval, rind))
+        @test isequal(findmin(x -> x == 1 ? Inf : -Inf, A′, dims=tup), (rval, rind))
+        @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
+        @test isequal(minimum(A, dims=tup), rval)
+        @test isequal(minimum!(similar(rval), A), rval)
+        @test isequal(minimum!(copy(rval), A, init=false), rval)
+    end
+
+    for (tup, rval, rind) in [((1,), [Inf Inf Inf -Inf], [CartesianIndex(1,1) CartesianIndex(2,2) CartesianIndex(1,3) CartesianIndex(1,4)]),
+                              ((2,), reshape([Inf Inf], 2, 1), reshape([CartesianIndex(1,1),CartesianIndex(2,1)], 2, 1)),
+                              ((1,2), fill(Inf,1,1),fill(CartesianIndex(1,1),1,1))]
+        @test isequal(findmax(A, dims=tup), (rval, rind))
+        @test isequal(findmax(x -> x == 1 ? Inf : -Inf, A′, dims=tup), (rval, rind))
+        @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
+        @test isequal(maximum(A, dims=tup), rval)
+        @test isequal(maximum!(similar(rval), A), rval)
+        @test isequal(maximum!(copy(rval), A, init=false), rval)
+    end
 end
 
-for (tup, rval, rind) in [((1,), [Inf Inf Inf -Inf], [CartesianIndex(1,1) CartesianIndex(2,2) CartesianIndex(1,3) CartesianIndex(1,4)]),
-                          ((2,), reshape([Inf Inf], 2, 1), reshape([CartesianIndex(1,1),CartesianIndex(2,1)], 2, 1)),
-                          ((1,2), fill(Inf,1,1),fill(CartesianIndex(1,1),1,1))]
-    @test isequal(findmax(A, dims=tup), (rval, rind))
-    @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
-    @test isequal(maximum(A, dims=tup), rval)
-    @test isequal(maximum!(similar(rval), A), rval)
-    @test isequal(maximum!(copy(rval), A, init=false), rval)
+@testset "BigInt in findmin/findmax/minimum/maximum" begin
+    A = [BigInt(10)]
+    A′ = [BigInt(1)]
+    for (tup, rval, rind) in [((2,), [BigInt(10)], [1])]
+        @test isequal(findmin(A, dims=tup), (rval, rind))
+        @test isequal(findmin(x -> 10^x, A′, dims=tup), (rval, rind))
+        @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
+        @test isequal(minimum(A, dims=tup), rval)
+        @test isequal(minimum!(similar(rval), A), rval)
+        @test isequal(minimum!(copy(rval), A, init=false), rval)
+    end
+
+    for (tup, rval, rind) in [((2,), [BigInt(10)], [1])]
+        @test isequal(findmax(A, dims=tup), (rval, rind))
+        @test isequal(findmax(x -> 10^x, A′, dims=tup), (rval, rind))
+        @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
+        @test isequal(maximum(A, dims=tup), rval)
+        @test isequal(maximum!(similar(rval), A), rval)
+        @test isequal(maximum!(copy(rval), A, init=false), rval)
+    end
+
+    A = [BigInt(-10)]
+    for (tup, rval, rind) in [((2,), [BigInt(-10)], [1])]
+        @test isequal(findmin(A, dims=tup), (rval, rind))
+        @test isequal(findmin(x -> -(x + 20), A, dims=tup), (rval, rind))
+        @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
+        @test isequal(minimum(A, dims=tup), rval)
+        @test isequal(minimum!(similar(rval), A), rval)
+        @test isequal(minimum!(copy(rval), A, init=false), rval)
+    end
+
+    for (tup, rval, rind) in [((2,), [BigInt(-10)], [1])]
+        @test isequal(findmax(A, dims=tup), (rval, rind))
+        @test isequal(findmax(x -> -(x + 20), A, dims=tup), (rval, rind))
+        @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
+        @test isequal(maximum(A, dims=tup), rval)
+        @test isequal(maximum!(similar(rval), A), rval)
+        @test isequal(maximum!(copy(rval), A, init=false), rval)
+    end
+
+    A = [BigInt(10) BigInt(-10)]
+    A′ = [BigInt(1) BigInt(10)]
+    for (tup, rval, rind) in [((2,), reshape([BigInt(-10)], 1, 1), reshape([CartesianIndex(1,2)], 1, 1))]
+        @test isequal(findmin(A, dims=tup), (rval, rind))
+        @test isequal(findmin(x -> x == 1 ? 10^x : x - 20, A′, dims=tup), (rval, rind))
+        @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
+        @test isequal(minimum(A, dims=tup), rval)
+        @test isequal(minimum!(similar(rval), A), rval)
+        @test isequal(minimum!(copy(rval), A, init=false), rval)
+    end
+
+    for (tup, rval, rind) in [((2,), reshape([BigInt(10)], 1, 1), reshape([CartesianIndex(1,1)], 1, 1))]
+        @test isequal(findmax(A, dims=tup), (rval, rind))
+        @test isequal(findmax(x -> x == 1 ? 10^x : x - 20, A′, dims=tup), (rval, rind))
+        @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
+        @test isequal(maximum(A, dims=tup), rval)
+        @test isequal(maximum!(similar(rval), A), rval)
+        @test isequal(maximum!(copy(rval), A, init=false), rval)
+    end
 end
 
-A = [BigInt(10)]
-for (tup, rval, rind) in [((2,), [BigInt(10)], [1])]
-    @test isequal(findmin(A, dims=tup), (rval, rind))
-    @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
-    @test isequal(minimum(A, dims=tup), rval)
-    @test isequal(minimum!(similar(rval), A), rval)
-    @test isequal(minimum!(copy(rval), A, init=false), rval)
-end
+@testset "String in findmin/findmax/minimum/maximum" begin
+    A = ["a", "b"]
+    for (tup, rval, rind) in [((1,), ["a"], [1])]
+        @test isequal(findmin(A, dims=tup), (rval, rind))
+        @test isequal(findmin(x -> (x^2)[1:1], A, dims=tup), (rval, rind))
+        @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
+        @test isequal(minimum(A, dims=tup), rval)
+        @test isequal(minimum!(similar(rval), A), rval)
+        @test isequal(minimum!(copy(rval), A, init=false), rval)
+    end
 
-for (tup, rval, rind) in [((2,), [BigInt(10)], [1])]
-    @test isequal(findmax(A, dims=tup), (rval, rind))
-    @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
-    @test isequal(maximum(A, dims=tup), rval)
-    @test isequal(maximum!(similar(rval), A), rval)
-    @test isequal(maximum!(copy(rval), A, init=false), rval)
-end
-
-A = [BigInt(-10)]
-for (tup, rval, rind) in [((2,), [BigInt(-10)], [1])]
-    @test isequal(findmin(A, dims=tup), (rval, rind))
-    @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
-    @test isequal(minimum(A, dims=tup), rval)
-    @test isequal(minimum!(similar(rval), A), rval)
-    @test isequal(minimum!(copy(rval), A, init=false), rval)
-end
-
-for (tup, rval, rind) in [((2,), [BigInt(-10)], [1])]
-    @test isequal(findmax(A, dims=tup), (rval, rind))
-    @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
-    @test isequal(maximum(A, dims=tup), rval)
-    @test isequal(maximum!(similar(rval), A), rval)
-    @test isequal(maximum!(copy(rval), A, init=false), rval)
-end
-
-A = [BigInt(10) BigInt(-10)]
-for (tup, rval, rind) in [((2,), reshape([BigInt(-10)], 1, 1), reshape([CartesianIndex(1,2)], 1, 1))]
-    @test isequal(findmin(A, dims=tup), (rval, rind))
-    @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
-    @test isequal(minimum(A, dims=tup), rval)
-    @test isequal(minimum!(similar(rval), A), rval)
-    @test isequal(minimum!(copy(rval), A, init=false), rval)
-end
-
-for (tup, rval, rind) in [((2,), reshape([BigInt(10)], 1, 1), reshape([CartesianIndex(1,1)], 1, 1))]
-    @test isequal(findmax(A, dims=tup), (rval, rind))
-    @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
-    @test isequal(maximum(A, dims=tup), rval)
-    @test isequal(maximum!(similar(rval), A), rval)
-    @test isequal(maximum!(copy(rval), A, init=false), rval)
-end
-
-A = ["a", "b"]
-for (tup, rval, rind) in [((1,), ["a"], [1])]
-    @test isequal(findmin(A, dims=tup), (rval, rind))
-    @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
-    @test isequal(minimum(A, dims=tup), rval)
-    @test isequal(minimum!(similar(rval), A), rval)
-    @test isequal(minimum!(copy(rval), A, init=false), rval)
-end
-
-for (tup, rval, rind) in [((1,), ["b"], [2])]
-    @test isequal(findmax(A, dims=tup), (rval, rind))
-    @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
-    @test isequal(maximum(A, dims=tup), rval)
-    @test isequal(maximum!(similar(rval), A), rval)
-    @test isequal(maximum!(copy(rval), A, init=false), rval)
+    for (tup, rval, rind) in [((1,), ["b"], [2])]
+        @test isequal(findmax(A, dims=tup), (rval, rind))
+        @test isequal(findmax(x -> (x^2)[1:1], A, dims=tup), (rval, rind))
+        @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
+        @test isequal(maximum(A, dims=tup), rval)
+        @test isequal(maximum!(similar(rval), A), rval)
+        @test isequal(maximum!(copy(rval), A, init=false), rval)
+    end
 end
 
 # issue #6672

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -274,16 +274,22 @@ end
 end
 
 # findmin/findmax function arguments: output type inference
-A = ["1" "22"; "333" "4444"]
-for (tup, rval, rind) in [((1,), [1 2], [CartesianIndex(1, 1) CartesianIndex(1, 2)]),
-                          ((2,), reshape([1, 3], 2, 1), reshape([CartesianIndex(1, 1), CartesianIndex(2, 1)], 2, 1)),
-                          ((1,2), fill(1,1,1), fill(CartesianIndex(1,1),1,1))]
-    @test (rval, rind) == findmin(length, A, dims=tup)
-end
-for (tup, rval, rind) in [((1,), [3 4], [CartesianIndex(2, 1) CartesianIndex(2, 2)]),
-                          ((2,), reshape([2, 4], 2, 1), reshape([CartesianIndex(1, 2), CartesianIndex(2, 2)], 2, 1)),
-                          ((1,2), fill(4,1,1), fill(CartesianIndex(2,2),1,1))]
-    @test (rval, rind) == findmax(length, A, dims=tup)
+@testset "findmin/findmax output type inference" begin
+    A = ["1" "22"; "333" "4444"]
+    for (tup, rval, rind) in [((1,), [1 2], [CartesianIndex(1, 1) CartesianIndex(1, 2)]),
+                              ((2,), reshape([1, 3], 2, 1), reshape([CartesianIndex(1, 1), CartesianIndex(2, 1)], 2, 1)),
+                              ((1,2), fill(1,1,1), fill(CartesianIndex(1,1),1,1))]
+        rval′, rind′ = findmin(length, A, dims=tup)
+        @test (rval, rind) == (rval′, rind′)
+        @test typeof(rval′) <: Array{Int}
+    end
+    for (tup, rval, rind) in [((1,), [3 4], [CartesianIndex(2, 1) CartesianIndex(2, 2)]),
+                              ((2,), reshape([2, 4], 2, 1), reshape([CartesianIndex(1, 2), CartesianIndex(2, 2)], 2, 1)),
+                              ((1,2), fill(4,1,1), fill(CartesianIndex(2,2),1,1))]
+        rval′, rind′ = findmax(length, A, dims=tup)
+        @test (rval, rind) == (rval′, rind′)
+        @test typeof(rval) <: Array{Int}
+    end
 end
 
 

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -290,7 +290,7 @@ end
 @testset "missing in findmin/findmax" begin
     B = [1.0 missing NaN;
          5.0 NaN missing]
-    B′ = [1.0 missing NaN;
+    B′ = [1.0 missing -NaN;
           -5.0 NaN missing]
     for (tup, rval, rind) in [(1, [5.0 missing missing], [CartesianIndex(2, 1) CartesianIndex(1, 2) CartesianIndex(2, 3)]),
                               (2, [missing; missing],    [CartesianIndex(1, 2) CartesianIndex(2, 3)] |> permutedims)]

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -281,14 +281,25 @@ end
                               ((1,2), fill(1,1,1), fill(CartesianIndex(1,1),1,1))]
         rval′, rind′ = findmin(length, A, dims=tup)
         @test (rval, rind) == (rval′, rind′)
-        @test typeof(rval′) <: Array{Int}
+        @test typeof(rval′) == Matrix{Int}
     end
     for (tup, rval, rind) in [((1,), [3 4], [CartesianIndex(2, 1) CartesianIndex(2, 2)]),
                               ((2,), reshape([2, 4], 2, 1), reshape([CartesianIndex(1, 2), CartesianIndex(2, 2)], 2, 1)),
                               ((1,2), fill(4,1,1), fill(CartesianIndex(2,2),1,1))]
         rval′, rind′ = findmax(length, A, dims=tup)
         @test (rval, rind) == (rval′, rind′)
-        @test typeof(rval) <: Array{Int}
+        @test typeof(rval) == Matrix{Int}
+    end
+    B = [1.5 1.0; 5.5 6.0]
+    for (tup, rval, rind) in [((1,), [3//2 1//1], [CartesianIndex(1, 1) CartesianIndex(1, 2)]),
+                              ((2,), reshape([1//1, 11//2], 2, 1), reshape([CartesianIndex(1, 2), CartesianIndex(2, 1)], 2, 1)),
+                              ((1,2), fill(1//1,1,1), fill(CartesianIndex(1,2),1,1))]
+        rval′, rind′ = findmin(Rational, B, dims=tup)
+        @test (rval, rind) == (rval′, rind′)
+        @test typeof(rval) == Matrix{Rational{Int}}
+        rval′, rind′ = findmin(Rational ∘ abs ∘ complex, B, dims=tup)
+        @test (rval, rind) == (rval′, rind′)
+        @test typeof(rval) == Matrix{Rational{Int}}
     end
 end
 

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -298,7 +298,7 @@ end
         @test all(rval′ .=== rval)
         @test all(rind′ .== rind)
         @test all(maximum(B, dims=tup) .=== rval)
-        @test (rval′, rind′) == findmax(abs, B′, dims=tup)
+        @test isequal(findmax(abs, B′, dims=tup), (rval′, rind′))
     end
 
     for (tup, rval, rind) in [(1, [1.0 missing missing], [CartesianIndex(1, 1) CartesianIndex(1, 2) CartesianIndex(2, 3)]),
@@ -307,7 +307,7 @@ end
         @test all(rval′ .=== rval)
         @test all(rind′ .== rind)
         @test all(minimum(B, dims=tup) .=== rval)
-        @test (rval′, rind′) == findmin(abs, B′, dims=tup)
+        @test isequal(findmin(abs, B′, dims=tup), (rval′, rind′))
     end
 end
 


### PR DESCRIPTION
This adds support for findmin (and findmax) syntax: findmin(f, A;
dims). It is a natural extension of the extant findmin versions,
and required only small changes to the core algorithm (findminmax!).
However, it was necessary to redirect the 2-arg version in
reduce.jl in order to provide a single call site for
_findmin(f, A, :).