### PR TITLE
Fix roundoff bugs in `prevpow`/`nextpow`

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -462,6 +462,7 @@ function nextpow(a::Real, x::Real)
     n = ceil(Integer,log(a, x))
     # round-off error of log can go either direction, so need some checks
     p = a^(n-1)
+    x > typemax(p) && throw(DomainError(x,"argument is beyond the range of type of the base"))
     p >= x && return p
     p = a^n
     p >= x && return p
@@ -499,6 +500,7 @@ function prevpow(a::T, x::Real) where T <: Real
     n = floor(Integer,log(a, x))
     # round-off error of log can go either direction, so need some checks
     p = a^n
+    x > typemax(p) && throw(DomainError(x,"argument is beyond the range of type of the base"))
     if a isa Integer
         wp, overflow = mul_with_overflow(a, p)
         wp <= x && !overflow && return wp

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -464,9 +464,12 @@ function nextpow(a::Real, x::Real)
     p = a^(n-1)
     x > typemax(p) && throw(DomainError(x,"argument is beyond the range of type of the base"))
     p >= x && return p
-    p = a^n
-    p >= x && return p
-    return a^(n+1)
+    wp = a^n
+    wp > p || throw(OverflowError("result is beyond the range of type of the base"))
+    wp >= x && return wp
+    wwp = a^(n+1)
+    wwp > wp || throw(OverflowError("result is beyond the range of type of the base"))
+    return wp
 end
 
 """

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -460,9 +460,12 @@ function nextpow(a::Real, x::Real)
     a <= 1 && throw(DomainError(a, "`a` must be greater than 1."))
     x <= 1 && return one(a)
     n = ceil(Integer,log(a, x))
+    # round-off error of log can go either direction, so need some checks
     p = a^(n-1)
-    # guard against roundoff error, e.g., with a=5 and x=125
-    p >= x ? p : a^n
+    p >= x && return p
+    p = a^n
+    p >= x && return p
+    return a^(n+1)
 end
 
 """
@@ -494,13 +497,17 @@ function prevpow(a::T, x::Real) where T <: Real
     a == 2 && isa(x, Integer) && return _prevpow2(x)
     a <= 1 && throw(DomainError(a, "`a` must be greater than 1."))
     n = floor(Integer,log(a, x))
+    # round-off error of log can go either direction, so need some checks
     p = a^n
     if a isa Integer
         wp, overflow = mul_with_overflow(a, p)
-        return (wp <= x && !overflow) ? wp : p
+        wp <= x && !overflow && return wp
+    else
+        wp = a^(n+1)
+        wp <= x && return wp
     end
-    wp = p*a
-    return wp <= x ? wp : p
+    p <= x && return p
+    return a^(n-1)
 end
 
 ## ndigits (number of digits) in base 10 ##

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -469,7 +469,7 @@ function nextpow(a::Real, x::Real)
     wp >= x && return wp
     wwp = a^(n+1)
     wwp > wp || throw(OverflowError("result is beyond the range of type of the base"))
-    return wp
+    return wwp
 end
 
 """

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2013,6 +2013,7 @@ end
     @test prevpow(2, 56789) == 32768
     @test_throws DomainError prevpow(2, -56789)
     @test_throws DomainError prevpow(Int8(4), 128)
+    @test_throws OverflowError nextpow(Int8(4), 65)
     for i = 1:100
         @test nextpow(2, i) == nextpow(2, big(i))
         @test prevpow(2, i) == prevpow(2, big(i))

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2019,6 +2019,14 @@ end
         @test nextpow(2, T(42)) === T(64)
         @test prevpow(2, T(42)) === T(32)
     end
+    for T in (Float16, Float32, Float64)
+        @test prevpow(2, prevfloat(T(1024.0))) == T(512.0)
+        @test nextpow(2, nextfloat(T(1024.0))) == T(2048.0)
+        @test prevpow(T(2.0), prevfloat(T(1024.0))) == T(512.0)
+        @test nextpow(T(2.0), nextfloat(T(1024.0))) == T(2048.0)
+        @test prevpow(T(2.0), prevfloat(T(Inf))) < T(Inf)
+        @test nextpow(T(2.0), prevfloat(T(Inf))) == T(Inf)
+    end
 end
 @testset "ispow2" begin
     @test  ispow2(64)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2009,8 +2009,10 @@ end
     end
     @test nextpow(2, 56789) == 65536
     @test_throws DomainError nextpow(2, -56789)
+    @test_throws DomainError nextpow(Int8(4), 128)
     @test prevpow(2, 56789) == 32768
     @test_throws DomainError prevpow(2, -56789)
+    @test_throws DomainError prevpow(Int8(4), 128)
     for i = 1:100
         @test nextpow(2, i) == nextpow(2, big(i))
         @test prevpow(2, i) == prevpow(2, big(i))


### PR DESCRIPTION
This PR fixes a bug where `prevpow(2.0,prevfloat(1024.0)) == 1024.0` and a matching bug for `nextpow`. The previous implementation didn't cover all the possible cases of roundoff in the logarithm, (eg: didn't consider that `log(2.0,prevfloat(1024.0))==10.0`, which `floor`s to 10 instead of the mathematically correct 9).

It also adds a `DomainError` in the case that the input is beyond the range of the returned type. Previously, for example, `prevpow(Int8(4),200) == 0` was a silent incorrect result. The only exception is a base of `2::Integer` for any `Integer`, which has its own special case. One could technically only throw an error when the result is out-of-range (eg, `prevpow(Int8(4),200)` could correctly return `64` even though `200>typemax(Int8)`), but that was more complicated (and the previous behavior was to return `0`).

It also adds an `OverflowError` to `nextpow` when the result is not representable.  Previously, `nextpow(Int8(4),65) == 0`.

The added errors could be considered breaking. It's hard to imagine anybody was intentionally using this behavior, but they could be split off if controversial.