### PR TITLE
Add efficient evalpoly implementation for an AbstractVector of coefficients

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -187,30 +187,18 @@ function evalpoly(x, p::Tuple)
     end
 end
 
-function evalpoly(x, p::AbstractVector)
+evalpoly(x, p::AbstractVector) = _evalpoly(x, p)
+
+function _evalpoly(x, p)
+    isempty(p) && return zero(eltype(p)) * one(x)
     i = lastindex(p)
-
-    # without the annotation v is not type stable in some cases,
-    # e.g. if p contains Float32 but x is Float64
-    T = promote_type(typeof(x), eltype(p))
-    @inbounds v::T = p[i]
+    @inbounds v = p[i] * one(x)
     i -= 1
-
     while i >= firstindex(p)
         @inbounds v = muladd(v, x, p[i])
         i -= 1
     end
-
     return v
-end
-
-function _evalpoly(x, p)
-    N = length(p)
-    ex = p[end]
-    for i in N-1:-1:1
-        ex = muladd(x, ex, p[i])
-    end
-    ex
 end
 
 function evalpoly(z::Complex, p::Tuple)
@@ -239,7 +227,6 @@ function evalpoly(z::Complex, p::Tuple)
     end
 end
 evalpoly(z::Complex, p::Tuple{<:Any}) = p[1]
-
 
 evalpoly(z::Complex, p::AbstractVector) = _evalpoly(z, p)
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -190,7 +190,10 @@ end
 function evalpoly(x, p::AbstractVector)
     i = lastindex(p)
 
-    @inbounds v = p[i]
+    # without the annotation v is not type stable in some cases,
+    # e.g. if p contains Float32 but x is Float64
+    T = promote_type(typeof(x), eltype(p))
+    @inbounds v::T = p[i]
     i -= 1
 
     while i >= firstindex(p)

--- a/base/math.jl
+++ b/base/math.jl
@@ -187,7 +187,19 @@ function evalpoly(x, p::Tuple)
     end
 end
 
-evalpoly(x, p::AbstractVector) = _evalpoly(x, p)
+function evalpoly(x, p::AbstractVector)
+    i = lastindex(p)
+
+    @inbounds v = p[i]
+    i -= 1
+
+    while i >= firstindex(p)
+        @inbounds v = muladd(v, x, p[i])
+        i -= 1
+    end
+
+    return v
+end
 
 function _evalpoly(x, p)
     N = length(p)

--- a/test/math.jl
+++ b/test/math.jl
@@ -632,8 +632,12 @@ end
     end
 
     @inferred evalpoly(2.3, Float32[3, 2.2, -0.02])
-    @inferred evalpoly(1.5f0, Float32[3.3, -2.2, 1.1])
+    @inferred evalpoly(1.5, Float32[])
     @inferred evalpoly(-0.33f0, Float64[-7.9, 8.9, 2.33])
+    @inferred evalpoly(-9.8f0, Float64[])
+
+    @test evalpoly(2.3, Float32[2.1f0]) === Float64(2.1f0)
+    @test evalpoly(3.7f0, Float64[]) === 0.0
 end
 
 @testset "evalpoly complex" begin

--- a/test/math.jl
+++ b/test/math.jl
@@ -630,6 +630,10 @@ end
         @test evalpoly(x, (p1, p2, p3)) == evpm
         @test evalpoly(x, [p1, p2, p3]) == evpm
     end
+
+    @inferred evalpoly(2.3, Float32[3, 2.2, -0.02])
+    @inferred evalpoly(1.5f0, Float32[3.3, -2.2, 1.1])
+    @inferred evalpoly(-0.33f0, Float64[-7.9, 8.9, 2.33])
 end
 
 @testset "evalpoly complex" begin


### PR DESCRIPTION
This implementation is about twice as fast as the current implementation for an `AbstractVector` of coefficients. See my benchmarks and a comparison with other implementations [here](https://discourse.julialang.org/t/i-have-a-much-faster-version-of-evalpoly-why-is-it-faster/79899?u=luapulu).

The implementation works with custom array indices. Because I use `@inbounds`, the AbstractVector subtype must, for safety reasons, guarantee that all integer indices greater than or equal to `firstindex` and smaller than or equal to `lastindex` are valid.