### PR TITLE
improve error message for invalid function args

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -359,7 +359,7 @@
                                    (append req opt vararg) rett)))))
    ;; no optional positional args
    (let* ((names (map car sparams))
-          (anames (map (lambda (x) (if (underscore-symbol? x) UNUSED x)) (llist-vars argl)))
+          (anames (map (lambda (x) (if (underscore-symbol? x) UNUSED x)) (llist-vars argl name)))
           (unused_anames (filter (lambda (x) (not (eq? x UNUSED))) anames))
           (ename (if (nodot-sym-ref? name) name
                     (if (overlay? name) (cadr name) `(null)))))
@@ -391,7 +391,7 @@
                                                       (false))))))
                              (list gf))
                            '()))
-            (types (llist-types argl))
+            (types (llist-types argl name))
             (body  (method-lambda-expr argl body rett))
             ;; HACK: the typevars need to be bound to ssavalues, since this code
             ;; might be moved to a different scope by closure-convert.
@@ -448,7 +448,7 @@
 
 (define (keywords-method-def-expr name sparams argl body rett)
   (let* ((kargl (cdar argl))  ;; keyword expressions (= k v)
-         (annotations (map (lambda (a) `(meta ,(cadr a) ,(arg-name (cadr (caddr a)))))
+         (annotations (map (lambda (a) `(meta ,(cadr a) ,(arg-name (cadr (caddr a)) name)))
                            (filter nospecialize-meta? kargl)))
          (kargl (map (lambda (a)
                        (if (nospecialize-meta? a) (caddr a) a))
@@ -464,7 +464,7 @@
                        (list l) '())))
          ;; expression to forward varargs to another call
          (splatted-vararg (if (null? vararg) '()
-                              (list `(... ,(arg-name (car vararg))))))
+                              (list `(... ,(arg-name (car vararg) name)))))
          ;; positional args with vararg
          (pargl-all pargl)
          ;; positional args without vararg
@@ -548,7 +548,7 @@
                    (ret `(return (call ,mangled
                                        ,@(if ordered-defaults keynames vals)
                                        ,@(if (null? restkw) '() `((call (top pairs) (call (core NamedTuple)))))
-                                       ,@(map arg-name pargl)
+                                       ,@(map (arg-name-🍛 name) pargl)
                                        ,@splatted-vararg))))
                (if ordered-defaults
                    (scopenest keynames vals ret)
@@ -618,7 +618,7 @@
                 (return (call ,mangled  ;; finally, call the core function
                               ,@keyvars
                               ,@(if (null? restkw) '() (list rkw))
-                              ,@(map arg-name pargl)
+                              ,@(map (arg-name-🍛 name) pargl)
                               ,@splatted-vararg))))))
         ;; return primary function
         ,(if (not (symbol? name))
@@ -675,11 +675,11 @@
                            ;; then add only one next argument
                            `(block
                              ,@prologue
-                             (call ,(arg-name (car req)) ,@(map arg-name (cdr passed)) ,(car vals)))
+                             (call ,(arg-name (car req) name) ,@(map (arg-name-🍛 name) (cdr passed)) ,(car vals)))
                            ;; otherwise add all
                            `(block
                              ,@prologue
-                             (call ,(arg-name (car req)) ,@(map arg-name (cdr passed)) ,@vals)))))
+                             (call ,(arg-name (car req) name) ,@(map (arg-name-🍛 name) (cdr passed)) ,@vals)))))
                  (method-def-expr- name sp passed body)))
              (iota (length opt)))
       ,(method-def-expr- name sparams overall-argl body rett))))
@@ -1173,7 +1173,7 @@
                   (sparams (map analyze-typevar raw-typevars))
                   (argl    (cdr name))
                   ;; strip @nospecialize
-                  (annotations (map (lambda (a) `(meta ,(cadr a) ,(arg-name (caddr a))))
+                  (annotations (map (lambda (a) `(meta ,(cadr a) ,(arg-name (caddr a) name)))
                                     (filter nospecialize-meta? argl)))
                   (body (insert-after-meta (caddr e) annotations))
                   (argl (map (lambda (a)
@@ -2364,7 +2364,7 @@
                          (lastarg (and (pair? arglist) (last arglist))))
                     (if (and ty (any (lambda (arg)
                                        (let ((arg (if (vararg? arg) (cadr arg) arg)))
-                                         (not (equal? (arg-type arg) '(core Any)))))
+                                         (not (equal? (arg-type arg '|#opaque-closure|) '(core Any)))))
                                      arglist))
                         (error "Opaque closure argument type may not be specified both in the method signature and separately"))
                     (if (or (varargexpr? lastarg) (vararg? lastarg))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -387,7 +387,9 @@ add_method_to_glob_fn!()
 @test Meta.lower(Main, Meta.parse("false(x) = x")) == Expr(:error, "invalid function name \"false\"")
 
 # issue #16355
-@test Meta.lower(Main, :(f(d:Int...) = nothing)) == Expr(:error, "\"d:Int\" is not a valid function argument name")
+@test Meta.lower(Main, :(f(d:Int...) = nothing)) == Expr(:error, """
+    "d:Int" is not a valid function argument name inside the function definition for "f". \
+    Perhaps you meant to write "==" instead of "=\"""")
 
 # issue #16517
 @test (try error(); catch; 0; end) === 0
@@ -2270,6 +2272,11 @@ end
 # Syntax desugaring pass errors contain line numbers
 @test Meta.lower(@__MODULE__, Expr(:block, LineNumberNode(101, :some_file), :(f(x,x)=1))) ==
     Expr(:error, "function argument name not unique: \"x\" around some_file:101")
+
+@test Meta.lower(@__MODULE__, Expr(:block, LineNumberNode(101, :some_file), :(foo(bar(a))=42))) ==
+    Expr(:error, """
+        "bar(a)" is not a valid function argument name inside the function definition for "foo". \
+        Perhaps you meant to write "==" instead of "=" around some_file:101""")
 
 # Ensure file names don't leak between `eval`s
 eval(LineNumberNode(11, :incorrect_file))


### PR DESCRIPTION
Not sure whether putting hints into the lowering pass like this is a
great solution. I thought about maybe using Julia-side error hints for
this instead, but using some kind of pattern-matching doesn't seem like
a great solution either.

fixes #45031
