### PR TITLE
Clean up duplicated calls to the same target in LLVM output

### DIFF
--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -1,5 +1,7 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
+#include <llvm/ADT/MapVector.h>
+
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Module.h>
@@ -114,14 +116,14 @@ struct jl_llvmf_dump_t {
     Function *F;
 };
 
-typedef std::vector<std::tuple<jl_code_instance_t*, jl_returninfo_t::CallingConv, unsigned, llvm::Function*, bool>> jl_codegen_call_targets_t;
+typedef std::tuple<jl_returninfo_t::CallingConv, unsigned, llvm::Function*, bool> jl_codegen_call_target_t;
 
 typedef struct _jl_codegen_params_t {
     orc::ThreadSafeContext tsctx;
     orc::ThreadSafeContext::Lock tsctx_lock;
     typedef StringMap<GlobalVariable*> SymMapGV;
     // outputs
-    jl_codegen_call_targets_t workqueue;
+    std::vector<std::pair<jl_code_instance_t*, jl_codegen_call_target_t>> workqueue;
     std::map<void*, GlobalVariable*> globals;
     std::map<jl_datatype_t*, DIType*> ditypes;
     std::map<jl_datatype_t*, Type*> llvmtypes;


### PR DESCRIPTION
Currently, every not-previously-emitted reference to a julia function
gets a unique new name when we generate LLVM ir and we resolve all
those names later when we actually emit the referenced function.
This causes confusion in LLVM IR output (e.g. in #44998, where
we had tens of thousands of unique names for the exact same
function). It doesn't so much matter for the JIT, since the
references get merged before the JIT runs, but for output to
IR, this change will make the result much nicer.