### PR TITLE
Hoist object allocation before inner field initialization

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3164,6 +3164,33 @@ static Value *box_union(jl_codectx_t &ctx, const jl_cgval_t &vinfo, const SmallB
     return box_merge;
 }
 
+static void recursively_adjust_ptr_type(llvm::Value *Val, unsigned FromAS, unsigned ToAS)
+{
+    for (auto *User : Val->users()) {
+        if (isa<GetElementPtrInst>(User)) {
+            GetElementPtrInst *Inst = cast<GetElementPtrInst>(User);
+            Inst->mutateType(PointerType::getWithSamePointeeType(cast<PointerType>(Inst->getType()), ToAS));
+            recursively_adjust_ptr_type(Inst, FromAS, ToAS);
+        }
+        else if (isa<IntrinsicInst>(User)) {
+            IntrinsicInst *II = cast<IntrinsicInst>(User);
+            SmallVector<Type*, 3> ArgTys;
+            Intrinsic::getIntrinsicSignature(II->getCalledFunction(), ArgTys);
+            assert(ArgTys.size() <= II->arg_size());
+            for (size_t i = 0; i < ArgTys.size(); ++i)
+                ArgTys[i] = II->getArgOperand(i)->getType();
+            II->setCalledFunction(Intrinsic::getDeclaration(II->getModule(), II->getIntrinsicID(), ArgTys));
+        }
+#ifndef JL_LLVM_OPAQUE_POINTERS
+        else if (isa<BitCastInst>(User)) {
+            BitCastInst *Inst = cast<BitCastInst>(User);
+            Inst->mutateType(PointerType::getWithSamePointeeType(cast<PointerType>(Inst->getType()), ToAS));
+            recursively_adjust_ptr_type(Inst, FromAS, ToAS);
+        }
+#endif
+    }
+}
+
 // this is used to wrap values for generic contexts, where a
 // dynamically-typed value is required (e.g. argument to unknown function).
 // if it's already a pointer it's left alone.
@@ -3197,8 +3224,27 @@ static Value *boxed(jl_codectx_t &ctx, const jl_cgval_t &vinfo)
         assert(!type_is_ghost(t)); // ghost values should have been handled by vinfo.constant above!
         box = _boxed_special(ctx, vinfo, t);
         if (!box) {
-            box = emit_allocobj(ctx, jl_datatype_size(jt), literal_pointer_val(ctx, (jl_value_t*)jt));
-            init_bits_cgval(ctx, box, vinfo, jl_is_mutable(jt) ? ctx.tbaa().tbaa_mutab : ctx.tbaa().tbaa_immut);
+            bool do_promote = vinfo.promotion_point;
+            if (do_promote) {
+                auto IP = ctx.builder.saveIP();
+                ctx.builder.SetInsertPoint(vinfo.promotion_point);
+                box = emit_allocobj(ctx, jl_datatype_size(jt), literal_pointer_val(ctx, (jl_value_t*)jt));
+                Value *decayed = decay_derived(ctx, box);
+                AllocaInst *originalAlloca = cast<AllocaInst>(vinfo.V);
+#ifndef JL_LLVM_OPAQUE_POINTERS
+                decayed = maybe_bitcast(ctx, decayed, PointerType::get(originalAlloca->getType()->getPointerElementType(), AddressSpace::Derived));
+#endif
+                // Warning: Very illegal IR here temporarily
+                originalAlloca->mutateType(decayed->getType());
+                recursively_adjust_ptr_type(originalAlloca, 0, AddressSpace::Derived);
+                originalAlloca->replaceAllUsesWith(decayed);
+                // end illegal IR
+                cast<Instruction>(vinfo.V)->eraseFromParent();
+                ctx.builder.restoreIP(IP);
+            } else {
+                box = emit_allocobj(ctx, jl_datatype_size(jt), literal_pointer_val(ctx, (jl_value_t*)jt));
+                init_bits_cgval(ctx, box, vinfo, jl_is_mutable(jt) ? ctx.tbaa().tbaa_mutab : ctx.tbaa().tbaa_immut);
+            }
         }
     }
     return box;
@@ -3505,7 +3551,7 @@ static jl_cgval_t emit_setfield(jl_codectx_t &ctx,
     }
 }
 
-static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t nargs, const jl_cgval_t *argv)
+static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t nargs, const jl_cgval_t *argv, bool is_promotable)
 {
     ++EmittedNewStructs;
     assert(jl_is_datatype(ty));
@@ -3528,6 +3574,8 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                 init_as_value = true;
             }
 
+            Instruction *promotion_point = nullptr;
+            ssize_t promotion_ssa = -1;
             Value *strct;
             if (type_is_ghost(lt)) {
                 strct = NULL;
@@ -3547,8 +3595,17 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
             for (unsigned i = 0; i < na; i++) {
                 jl_value_t *jtype = jl_svecref(sty->types, i); // n.b. ty argument must be concrete
                 jl_cgval_t fval_info = argv[i];
+
+                IRBuilderBase::InsertPoint savedIP;
                 emit_typecheck(ctx, fval_info, jtype, "new");
                 fval_info = update_julia_type(ctx, fval_info, jtype);
+                // TODO: Use (post-)domination instead.
+                bool field_promotable = !init_as_value && fval_info.promotion_ssa != -1 &&
+                    fval_info.promotion_point && fval_info.promotion_point->getParent() == ctx.builder.GetInsertBlock();
+                if (field_promotable) {
+                    savedIP = ctx.builder.saveIP();
+                    ctx.builder.SetInsertPoint(fval_info.promotion_point);
+                }
                 if (type_is_ghost(lt))
                     continue;
                 Type *fty = julia_type_to_llvm(ctx, jtype);
@@ -3560,7 +3617,26 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                 if (!init_as_value) {
                     // avoid unboxing the argument explicitly
                     // and use memcpy instead
-                    dest = ctx.builder.CreateConstInBoundsGEP2_32(lt, strct, 0, llvm_idx);
+                    Instruction *inst;
+#ifndef JL_LLVM_OPAQUE_POINTERS
+                    dest = inst = cast<Instruction>(ctx.builder.CreateConstInBoundsGEP2_32(lt, strct, 0, llvm_idx));
+#else
+                    dest = inst = cast<Instruction>(ctx.builder.CreateConstInBoundsGEP1_32(getInt8Ty(ctx.builder.getContext()), strct, offs));
+#endif
+                    // Our promotion point needs to come before
+                    //  A) All of our arguments' promotion points
+                    //  B) Any instructions we insert at any of our arguments' promotion points
+                    // N.B.: Do not use Instruction::comesBefore here. LLVM invalidates its instruction numbering after
+                    // every insert, so querying it here makes code generation accidentally quadartic.
+                    if (!promotion_point) {
+                        promotion_point = inst;
+                        promotion_ssa = fval_info.promotion_ssa;
+                    } else if (field_promotable) {
+                        if (promotion_ssa == -1 || fval_info.promotion_ssa < promotion_ssa) {
+                            promotion_point = inst;
+                            promotion_ssa = fval_info.promotion_ssa;
+                        }
+                    }
                 }
                 Value *fval = NULL;
                 if (jl_field_isptr(sty, i)) {
@@ -3571,6 +3647,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                                 ->setOrdering(AtomicOrdering::Unordered);
                 }
                 else if (jl_is_uniontype(jtype)) {
+                    assert(!field_promotable);
                     // compute tindex from rhs
                     jl_cgval_t rhs_union = convert_julia_type(ctx, fval_info, jtype);
                     if (rhs_union.typ == jl_bottom_type)
@@ -3623,7 +3700,12 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                     }
                 }
                 else {
-                    fval = emit_unbox(ctx, fty, fval_info, jtype, dest, ctx.tbaa().tbaa_stack);
+                    if (field_promotable) {
+                        fval_info.V->replaceAllUsesWith(dest);
+                        cast<Instruction>(fval_info.V)->eraseFromParent();
+                    } else {
+                        fval = emit_unbox(ctx, fty, fval_info, jtype, dest, ctx.tbaa().tbaa_stack);
+                    }
                 }
                 if (init_as_value) {
                     assert(fval);
@@ -3635,6 +3717,9 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                         strct = ctx.builder.CreateInsertValue(strct, fval, makeArrayRef(llvm_idx));
                     else
                         assert(false);
+                }
+                if (field_promotable) {
+                    ctx.builder.restoreIP(savedIP);
                 }
             }
             for (size_t i = nargs; i < nf; i++) {
@@ -3655,8 +3740,14 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                 return mark_julia_const(ctx, sty->instance);
             else if (init_as_value)
                 return mark_julia_type(ctx, strct, false, ty);
-            else
-                return mark_julia_slot(strct, ty, NULL, ctx.tbaa(), ctx.tbaa().tbaa_stack);
+            else {
+                jl_cgval_t ret = mark_julia_slot(strct, ty, NULL, ctx.tbaa(), ctx.tbaa().tbaa_stack);
+                if (is_promotable && promotion_point) {
+                    ret.promotion_point = promotion_point;
+                    ret.promotion_ssa = promotion_ssa;
+                }
+                return ret;
+            }
         }
         Value *strct = emit_allocobj(ctx, jl_datatype_size(sty),
                                      literal_pointer_val(ctx, (jl_value_t*)ty));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1217,6 +1217,13 @@ struct jl_cgval_t {
     bool isboxed; // whether this value is a jl_value_t* allocated on the heap with the right type tag
     bool isghost; // whether this value is "ghost"
     MDNode *tbaa; // The related tbaa node. Non-NULL iff this holds an address.
+    // If non-null, this memory location may be promoted on use, by hoisting the
+    // destination memory above the promotion point.
+    Instruction *promotion_point;
+    // If promotion_ssa is non-null, the julia src ssa value that corresponds
+    // to the promotion point. This is used for dominator analysis, since LLVM's
+    // dominator analysis has algorithmic problems for large basic blocks.
+    ssize_t promotion_ssa;
     bool ispointer() const
     {
         // whether this value is compatible with `data_pointer`
@@ -1230,7 +1237,9 @@ struct jl_cgval_t {
         typ(typ),
         isboxed(isboxed),
         isghost(false),
-        tbaa(isboxed ? best_tbaa(tbaa_cache, typ) : nullptr)
+        tbaa(isboxed ? best_tbaa(tbaa_cache, typ) : nullptr),
+        promotion_point(nullptr),
+        promotion_ssa(-1)
     {
         if (Vboxed)
             assert(Vboxed->getType() == JuliaType::get_prjlvalue_ty(Vboxed->getContext()));
@@ -1247,7 +1256,9 @@ struct jl_cgval_t {
         typ(typ),
         isboxed(false),
         isghost(true),
-        tbaa(nullptr)
+        tbaa(nullptr),
+        promotion_point(nullptr),
+        promotion_ssa(-1)
     {
         assert(jl_is_datatype(typ));
         assert(constant);
@@ -1260,7 +1271,9 @@ struct jl_cgval_t {
         typ(typ),
         isboxed(v.isboxed),
         isghost(v.isghost),
-        tbaa(v.tbaa)
+        tbaa(v.tbaa),
+        promotion_point(v.promotion_point),
+        promotion_ssa(v.promotion_ssa)
     {
         if (Vboxed)
             assert(Vboxed->getType() == JuliaType::get_prjlvalue_ty(Vboxed->getContext()));
@@ -1281,7 +1294,9 @@ struct jl_cgval_t {
         typ(jl_bottom_type),
         isboxed(false),
         isghost(true),
-        tbaa(nullptr)
+        tbaa(nullptr),
+        promotion_point(nullptr),
+        promotion_ssa(-1)
     {
     }
 };
@@ -1330,6 +1345,7 @@ public:
     std::vector<jl_cgval_t> SAvalues;
     std::vector<std::tuple<jl_cgval_t, BasicBlock *, AllocaInst *, PHINode *, jl_value_t *>> PhiNodes;
     std::vector<bool> ssavalue_assigned;
+    std::vector<int> ssavalue_usecount;
     std::vector<orc::ThreadSafeModule> oc_modules;
     jl_module_t *module = NULL;
     jl_typecache_t type_cache;
@@ -1410,7 +1426,7 @@ static CallInst *emit_jlcall(jl_codectx_t &ctx, JuliaFunction *theFptr, Value *t
                              const jl_cgval_t *args, size_t nargs, CallingConv::ID cc);
 static Value *emit_f_is(jl_codectx_t &ctx, const jl_cgval_t &arg1, const jl_cgval_t &arg2,
                         Value *nullcheck1 = nullptr, Value *nullcheck2 = nullptr);
-static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t nargs, const jl_cgval_t *argv);
+static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t nargs, const jl_cgval_t *argv, bool is_promotable=false);
 static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, const jl_cgval_t *argv, size_t nargs, jl_value_t *rt);
 
 static Value *literal_pointer_val(jl_codectx_t &ctx, jl_value_t *p);
@@ -2368,54 +2384,55 @@ static void mark_volatile_vars(jl_array_t *stmts, std::vector<jl_varinfo_t> &slo
 
 // a very simple, conservative use analysis
 // to eagerly remove slot assignments that are never read from
-static void simple_use_analysis(jl_codectx_t &ctx, jl_value_t *expr)
+
+template <typename callback>
+static void general_use_analysis(jl_codectx_t &ctx, jl_value_t *expr, callback &f)
 {
-    if (jl_is_slot(expr) || jl_is_argument(expr)) {
-        int i = jl_slot_number(expr) - 1;
-        ctx.slots[i].used = true;
+    if (f(expr)) {
+        return;
     }
     else if (jl_is_expr(expr)) {
         jl_expr_t *e = (jl_expr_t*)expr;
         if (e->head == jl_method_sym) {
-            simple_use_analysis(ctx, jl_exprarg(e, 0));
+            general_use_analysis(ctx, jl_exprarg(e, 0), f);
             if (jl_expr_nargs(e) > 1) {
-                simple_use_analysis(ctx, jl_exprarg(e, 1));
-                simple_use_analysis(ctx, jl_exprarg(e, 2));
+                general_use_analysis(ctx, jl_exprarg(e, 1), f);
+                general_use_analysis(ctx, jl_exprarg(e, 2), f);
             }
         }
         else if (e->head == jl_assign_sym) {
             // don't consider assignment LHS as a variable "use"
-            simple_use_analysis(ctx, jl_exprarg(e, 1));
+            general_use_analysis(ctx, jl_exprarg(e, 1), f);
         }
         else {
             size_t i, elen = jl_array_dim0(e->args);
             for (i = 0; i < elen; i++) {
-                simple_use_analysis(ctx, jl_exprarg(e, i));
+                general_use_analysis(ctx, jl_exprarg(e, i), f);
             }
         }
     }
     else if (jl_is_returnnode(expr)) {
         jl_value_t *retexpr = jl_returnnode_value(expr);
         if (retexpr != NULL)
-            simple_use_analysis(ctx, retexpr);
+            general_use_analysis(ctx, retexpr, f);
     }
     else if (jl_is_gotoifnot(expr)) {
-        simple_use_analysis(ctx, jl_gotoifnot_cond(expr));
+        general_use_analysis(ctx, jl_gotoifnot_cond(expr), f);
     }
     else if (jl_is_pinode(expr)) {
-        simple_use_analysis(ctx, jl_fieldref_noalloc(expr, 0));
+        general_use_analysis(ctx, jl_fieldref_noalloc(expr, 0), f);
     }
     else if (jl_is_upsilonnode(expr)) {
         jl_value_t *val = jl_fieldref_noalloc(expr, 0);
         if (val)
-            simple_use_analysis(ctx, val);
+            general_use_analysis(ctx, val, f);
     }
     else if (jl_is_phicnode(expr)) {
         jl_array_t *values = (jl_array_t*)jl_fieldref_noalloc(expr, 0);
         size_t i, elen = jl_array_len(values);
         for (i = 0; i < elen; i++) {
             jl_value_t *v = jl_array_ptr_ref(values, i);
-            simple_use_analysis(ctx, v);
+            general_use_analysis(ctx, v, f);
         }
     }
     else if (jl_is_phinode(expr)) {
@@ -2424,9 +2441,22 @@ static void simple_use_analysis(jl_codectx_t &ctx, jl_value_t *expr)
         for (i = 0; i < elen; i++) {
             jl_value_t *v = jl_array_ptr_ref(values, i);
             if (v)
-                simple_use_analysis(ctx, v);
+                general_use_analysis(ctx, v, f);
         }
     }
+}
+
+static void simple_use_analysis(jl_codectx_t &ctx, jl_value_t *expr)
+{
+    auto scan_slot_arg = [&](jl_value_t *expr) {
+        if (jl_is_slot(expr) || jl_is_argument(expr)) {
+            int i = jl_slot_number(expr) - 1;
+            ctx.slots[i].used = true;
+            return true;
+        }
+        return false;
+    };
+    return general_use_analysis(ctx, expr, scan_slot_arg);
 }
 
 // --- gc root utils ---
@@ -2923,7 +2953,7 @@ static jl_llvm_functions_t
 
 static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                               const jl_cgval_t *argv, size_t nargs, jl_value_t *rt,
-                              jl_expr_t *ex)
+                              jl_expr_t *ex, bool is_promotable)
 // returns true if the call has been handled
 {
     ++EmittedBuiltinCalls;
@@ -3004,7 +3034,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             return true;
         }
         if (jl_is_tuple_type(rt) && jl_is_concrete_type(rt) && nargs == jl_datatype_nfields(rt)) {
-            *ret = emit_new_struct(ctx, rt, nargs, &argv[1]);
+            *ret = emit_new_struct(ctx, rt, nargs, &argv[1], is_promotable);
             return true;
         }
     }
@@ -3974,7 +4004,7 @@ static jl_cgval_t emit_invoke_modify(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_
     return mark_julia_type(ctx, callval, true, rt);
 }
 
-static jl_cgval_t emit_call(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt)
+static jl_cgval_t emit_call(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt, bool is_promotable)
 {
     ++EmittedCalls;
     jl_value_t **args = (jl_value_t**)jl_array_data(ex->args);
@@ -4007,7 +4037,7 @@ static jl_cgval_t emit_call(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt)
         if (f.constant == jl_builtin_ifelse && nargs == 4)
             return emit_ifelse(ctx, argv[1], argv[2], argv[3], rt);
         jl_cgval_t result(ctx.builder.getContext());
-        bool handled = emit_builtin_call(ctx, &result, f.constant, argv, nargs - 1, rt, ex);
+        bool handled = emit_builtin_call(ctx, &result, f.constant, argv, nargs - 1, rt, ex, is_promotable);
         if (handled) {
             return result;
         }
@@ -4471,36 +4501,36 @@ static void emit_phinode_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r)
     return;
 }
 
-static void emit_ssaval_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r)
+static void emit_ssaval_assign(jl_codectx_t &ctx, ssize_t ssaidx_0based, jl_value_t *r)
 {
-    assert(!ctx.ssavalue_assigned.at(idx));
+    assert(!ctx.ssavalue_assigned.at(ssaidx_0based));
     if (jl_is_phinode(r)) {
-        return emit_phinode_assign(ctx, idx, r);
+        return emit_phinode_assign(ctx, ssaidx_0based, r);
     }
 
     jl_cgval_t slot(ctx.builder.getContext());
     if (jl_is_phicnode(r)) {
-        auto it = ctx.phic_slots.find(idx);
+        auto it = ctx.phic_slots.find(ssaidx_0based);
         if (it == ctx.phic_slots.end()) {
-            it = ctx.phic_slots.emplace(idx, jl_varinfo_t(ctx.builder.getContext())).first;
+            it = ctx.phic_slots.emplace(ssaidx_0based, jl_varinfo_t(ctx.builder.getContext())).first;
         }
         slot = emit_varinfo(ctx, it->second, jl_symbol("phic"));
     } else {
-        slot = emit_expr(ctx, r, idx); // slot could be a jl_value_t (unboxed) or jl_value_t* (ispointer)
+        slot = emit_expr(ctx, r, ssaidx_0based); // slot could be a jl_value_t (unboxed) or jl_value_t* (ispointer)
     }
     if (slot.isboxed || slot.TIndex) {
         // see if inference suggested a different type for the ssavalue than the expression
         // e.g. sometimes the information is inconsistent after inlining getfield on a Tuple
         jl_value_t *ssavalue_types = (jl_value_t*)ctx.source->ssavaluetypes;
         if (jl_is_array(ssavalue_types)) {
-            jl_value_t *declType = jl_array_ptr_ref(ssavalue_types, idx);
+            jl_value_t *declType = jl_array_ptr_ref(ssavalue_types, ssaidx_0based);
             if (declType != slot.typ) {
                 slot = update_julia_type(ctx, slot, declType);
             }
         }
     }
-    ctx.SAvalues.at(idx) = slot; // now SAvalues[idx] contains the SAvalue
-    ctx.ssavalue_assigned.at(idx) = true;
+    ctx.SAvalues.at(ssaidx_0based) = slot; // now SAvalues[ssaidx_0based] contains the SAvalue
+    ctx.ssavalue_assigned.at(ssaidx_0based) = true;
 }
 
 static void emit_varinfo_assign(jl_codectx_t &ctx, jl_varinfo_t &vi, jl_cgval_t rval_info, jl_value_t *l=NULL)
@@ -4799,7 +4829,7 @@ static std::pair<Function*, Function*> get_oc_function(jl_codectx_t &ctx, jl_met
 
 // `expr` is not clobbered in JL_TRY
 JL_GCC_IGNORE_START("-Wclobbered")
-static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
+static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaidx_0based)
 {
     if (jl_is_symbol(expr)) {
         jl_sym_t *sym = (jl_sym_t*)expr;
@@ -4891,27 +4921,33 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
         return ghostValue(ctx, jl_nothing_type);
     }
     else if (head == jl_invoke_sym) {
-        assert(ssaval >= 0);
+        assert(ssaidx_0based >= 0);
         jl_value_t *expr_t = jl_is_long(ctx.source->ssavaluetypes) ? (jl_value_t*)jl_any_type :
-            jl_array_ptr_ref(ctx.source->ssavaluetypes, ssaval);
+            jl_array_ptr_ref(ctx.source->ssavaluetypes, ssaidx_0based);
         return emit_invoke(ctx, ex, expr_t);
     }
     else if (head == jl_invoke_modify_sym) {
-        assert(ssaval >= 0);
+        assert(ssaidx_0based >= 0);
         jl_value_t *expr_t = jl_is_long(ctx.source->ssavaluetypes) ? (jl_value_t*)jl_any_type :
-            jl_array_ptr_ref(ctx.source->ssavaluetypes, ssaval);
+            jl_array_ptr_ref(ctx.source->ssavaluetypes, ssaidx_0based);
         return emit_invoke_modify(ctx, ex, expr_t);
     }
     else if (head == jl_call_sym) {
         jl_value_t *expr_t;
-        if (ssaval < 0)
+        bool is_promotable = false;
+        if (ssaidx_0based < 0)
             // TODO: this case is needed for the call to emit_expr in emit_llvmcall
             expr_t = (jl_value_t*)jl_any_type;
-        else
-            expr_t = jl_is_long(ctx.source->ssavaluetypes) ? (jl_value_t*)jl_any_type : jl_array_ptr_ref(ctx.source->ssavaluetypes, ssaval);
-        jl_cgval_t res = emit_call(ctx, ex, expr_t);
+        else {
+            expr_t = jl_is_long(ctx.source->ssavaluetypes) ? (jl_value_t*)jl_any_type : jl_array_ptr_ref(ctx.source->ssavaluetypes, ssaidx_0based);
+            is_promotable = ctx.ssavalue_usecount[ssaidx_0based] == 1;
+        }
+        jl_cgval_t res = emit_call(ctx, ex, expr_t, is_promotable);
         // some intrinsics (e.g. typeassert) can return a wider type
         // than what's actually possible
+        if (is_promotable && res.promotion_point) {
+            res.promotion_ssa = ssaidx_0based;
+        }
         res = update_julia_type(ctx, res, expr_t);
         if (res.typ == jl_bottom_type || expr_t == jl_bottom_type) {
             CreateTrap(ctx.builder);
@@ -4928,7 +4964,7 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
     }
     else if (head == jl_assign_sym) {
         assert(nargs == 2);
-        emit_assignment(ctx, args[0], args[1], ssaval);
+        emit_assignment(ctx, args[0], args[1], ssaidx_0based);
         return ghostValue(ctx, jl_nothing_type);
     }
     else if (head == jl_static_parameter_sym) {
@@ -5020,6 +5056,10 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
         }
     }
     else if (head == jl_new_sym) {
+        bool is_promotable = false;
+        if (ssaidx_0based >= 0) {
+            is_promotable = ctx.ssavalue_usecount[ssaidx_0based] == 1;
+        }
         assert(nargs > 0);
         jl_cgval_t *argv = (jl_cgval_t*)alloca(sizeof(jl_cgval_t) * nargs);
         for (size_t i = 0; i < nargs; ++i) {
@@ -5030,7 +5070,10 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
                 jl_is_datatype(jl_tparam0(ty)) &&
                 jl_is_concrete_type(jl_tparam0(ty))) {
             assert(nargs <= jl_datatype_nfields(jl_tparam0(ty)) + 1);
-            return emit_new_struct(ctx, jl_tparam0(ty), nargs - 1, &argv[1]);
+            jl_cgval_t res = emit_new_struct(ctx, jl_tparam0(ty), nargs - 1, &argv[1], is_promotable);
+            if (is_promotable && res.promotion_point)
+                res.promotion_ssa = ssaidx_0based;
+            return res;
         }
         Value *val = emit_jlcall(ctx, jlnew_func, nullptr, argv, nargs, JLCALL_F_CC);
         // temporarily mark as `Any`, expecting `emit_ssaval_assign` to update
@@ -6475,6 +6518,7 @@ static jl_datatype_t *compute_va_type(jl_method_instance_t *lam, size_t nreq)
     return typ;
 }
 
+
 // Compile to LLVM IR, using a specialized signature if applicable.
 static jl_llvm_functions_t
     emit_function(
@@ -6565,6 +6609,7 @@ static jl_llvm_functions_t
     // create SAvalue locations for SSAValue objects
     ctx.ssavalue_assigned.assign(n_ssavalues, false);
     ctx.SAvalues.assign(n_ssavalues, jl_cgval_t(ctx.builder.getContext()));
+    ctx.ssavalue_usecount.assign(n_ssavalues, 0);
 
     bool specsig, needsparams;
     std::tie(specsig, needsparams) = uses_specsig(lam, jlrettype, params.params->prefer_specsig);
@@ -6966,9 +7011,20 @@ static jl_llvm_functions_t
 
     // Scan for PhiC nodes, emit their slots and record which upsilon nodes
     // yield to them.
+    // Also count ssavalue uses.
     {
         for (size_t i = 0; i < jl_array_len(stmts); ++i) {
             jl_value_t *stmt = jl_array_ptr_ref(stmts, i);
+
+            auto scan_ssavalue = [&](jl_value_t *val) {
+                if (jl_is_ssavalue(val)) {
+                    ctx.ssavalue_usecount[((jl_ssavalue_t*)val)->id-1] += 1;
+                    return true;
+                }
+                return false;
+            };
+            general_use_analysis(ctx, stmt, scan_ssavalue);
+
             if (jl_is_phicnode(stmt)) {
                 jl_array_t *values = (jl_array_t*)jl_fieldref_noalloc(stmt, 0);
                 for (size_t j = 0; j < jl_array_len(values); ++j) {


### PR DESCRIPTION
Consider the following pattern for building up nested objects
```
%obj = Expr(:new, obj, ...)
%obj_wrapper = Expr(:new, obj_wrapper, ..., %obj)
%obj_wrapper2 = Expr(:new, obj_wrapper2, ..., %obj_wrapper)
%outer = Expr(:new, outer, %obj_wrapper2)
```

Asssuming everything except `struct outer` is struct-inlineable,
the LLVM IR we emit looks something like the following:

```
%obj = alloca
%obj_wrapper = alloca
%obj_wrapper_wrapper = alloca
%obj = alloca

init(%obj, <obj>)
init(%obj_wrapper, <obj_wrapper>); memcpy(%obj_wrapper, %obj)
init(%obj_wrapper2, <obj_wrapper2>); memcpy(%obj_wrapper2, %obj_wrapper)
init(%outer, <outer>); memcpy(%outer, %obj_wrapper2)

%outer_boxed = julia.gc_alloc
memcpy(%outer_boxed, %outer)
```

While LLVM is capable of removing all the allocas and memcpys, it's
taking an unreasonable amount of time to do so.

This PR introduces a small optimization into the frontend lowering
for `:new`: If all the :new calls are in the same LLVM basic block,
then we delete the alloca, and hoist the allocation of the object
to the earliest point before the initialization of the fields.

This gives essentially the same result as LLVM would have given us
post-optimization, but is much cheaper to do because we don't have
to perform any analysis to tell us that it is a legal optimization.

In the above example, we would end up with something like:
```
%outer_boxed = julia.gc_alloc
init(%outer_boxed, <obj>)
init(%outer_boxed, <obj_wrapper>);
init(%outer_boxed, <obj_wrapper2>);
init(%outer_boxed, <outer>);
```

Of course this does extend the liftime of the outer object, but I
don't think that's a particular problem as long as we're careful
not to hoist any boxings out of error paths. In the current
implementation, I only allow this optimization to occur in the
same LLVM basic block, but I think it should be fine to extend
it to allow the same julia basic block or more generally, any
allocation that post-dominates the relevant promotion points.

# Timings

On the benchmark from #44998, this does quite well, essentially fixing the issue
modulo the noted issue where SLPVectorizer spends a significant chunk of time
on this function without actually doing anything. Our timings are as follows
(ignore the memory allocations, those depend on whether inference had already
run or not when I benchmarked it, which I wasn't careful about because it
only takes ~2 seconds):

master:
```
julia> @time code_llvm(devnull, torture)
365.975286 seconds (12.67 M allocations: 1.344 GiB, 0.38% gc time, 96.59% compilation time)
```

master - SLPVectorizer
```
julia> @time code_llvm(devnull, torture)
106.107186 seconds (5.62 M allocations: 613.950 MiB, 0.55% gc time, 94.83% compilation time)
```

This PR:
```
julia> @time code_llvm(devnull, torture)
134.521880 seconds (12.24 M allocations: 644.399 MiB, 0.38% gc time, 99.18% compilation time)
```

This PR - SLPVectorizer:
```
julia> @time code_llvm(devnull, torture)
  6.975649 seconds (12.24 M allocations: 644.399 MiB, 7.49% gc time, 83.60% compilation time)
```