### PR TITLE
Reduce `Integer` invalidations

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -810,7 +810,7 @@ to_shape(dims::Dims) = dims
 to_shape(dims::DimsOrInds) = map(to_shape, dims)::DimsOrInds
 # each dimension
 to_shape(i::Int) = i
-to_shape(i::Integer) = Int(i)
+to_shape(@nospecialize(i::Integer)) = Int(i)
 to_shape(r::OneTo) = Int(last(r))
 to_shape(r::AbstractUnitRange) = r
 


### PR DESCRIPTION
These invalidations are a recurring issue we have with `StaticInt`. I can go through and add `@nospecialize(i::Integer)` on a bunch of other methods too, but I'm not sure if this is the right approach. @timholy usually does invalidation PRs and might have a better idea.