### PR TITLE
build: include sysimage output in timing report

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -514,6 +514,8 @@ MainInclude.include
 function _start()
     empty!(ARGS)
     append!(ARGS, Core.ARGS)
+    # clear any postoutput hooks that were saved in the sysimage
+    empty!(Base.postoutput_hooks)
     try
         exec_options(JLOptions())
     catch

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -378,6 +378,26 @@ function _atexit()
     end
 end
 
+## postoutput: register post output hooks ##
+## like atexit but runs after any requested output.
+## any hooks saved in the sysimage are cleared in Base._start
+const postoutput_hooks = Callable[]
+
+postoutput(f::Function) = (pushfirst!(postoutput_hooks, f); nothing)
+
+function _postoutput()
+    while !isempty(postoutput_hooks)
+        f = popfirst!(postoutput_hooks)
+        try
+            f()
+        catch ex
+            showerror(stderr, ex)
+            Base.show_backtrace(stderr, catch_backtrace())
+            println(stderr)
+        end
+    end
+end
+
 ## hook for disabling threaded libraries ##
 
 library_threading_enabled = true

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -114,12 +114,12 @@ let
     tot_time = tot_time_base + tot_time_stdlib + tot_time_userimg
 
     println("Sysimage built. Summary:")
-    print("Total ─────── "); Base.time_print(tot_time               * 10^9); print(" \n");
-    print("Base: ─────── "); Base.time_print(tot_time_base          * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (tot_time_base          / tot_time) * 100); println("%")
-    print("Stdlibs: ──── "); Base.time_print(tot_time_stdlib * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (tot_time_stdlib / tot_time) * 100); println("%")
+    print("Base ──────── "); Base.time_print(tot_time_base    * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (tot_time_base    / tot_time) * 100); println("%")
+    print("Stdlibs ───── "); Base.time_print(tot_time_stdlib  * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (tot_time_stdlib  / tot_time) * 100); println("%")
     if isfile("userimg.jl")
-    print("Userimg: ──── "); Base.time_print(tot_time_userimg       * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (tot_time_userimg       / tot_time) * 100); println("%")
+    print("Userimg ───── "); Base.time_print(tot_time_userimg * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (tot_time_userimg / tot_time) * 100); println("%")
     end
+    print("Total ─────── "); Base.time_print(tot_time         * 10^9); println();
 
     empty!(LOAD_PATH)
     empty!(DEPOT_PATH)

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -421,21 +421,15 @@ function generate_precompile_statements()
         n_succeeded > 1200 || @warn "Only $n_succeeded precompile statements"
     end
 
-    println("Outputting sysimage file...")
-
     include_time *= 1e9
     gen_time = (time_ns() - start_time) - include_time
+    tot_time = time_ns() - start_time
 
-    # Print report after sysimage has been saved so all time spent can be captured
-    Base.postoutput() do
-        tot_time = time_ns() - start_time
-        output_time = tot_time - gen_time - include_time
-        println("Precompilation complete. Summary:")
-        print("Generation ── "); Base.time_print(gen_time);     print(" "); show(IOContext(stdout, :compact=>true), gen_time / tot_time * 100);     println("%")
-        print("Execution ─── "); Base.time_print(include_time); print(" "); show(IOContext(stdout, :compact=>true), include_time / tot_time * 100); println("%")
-        print("Output ────── "); Base.time_print(output_time);  print(" "); show(IOContext(stdout, :compact=>true), output_time / tot_time * 100);  println("%")
-        print("Total ─────── "); Base.time_print(tot_time);     println()
-    end
+    println("Precompilation complete. Summary:")
+    print("Generation ── "); Base.time_print(gen_time);     print(" "); show(IOContext(stdout, :compact=>true), gen_time / tot_time * 100);     println("%")
+    print("Execution ─── "); Base.time_print(include_time); print(" "); show(IOContext(stdout, :compact=>true), include_time / tot_time * 100); println("%")
+    print("Total ─────── "); Base.time_print(tot_time);     println()
+
     return
 end
 
@@ -453,4 +447,13 @@ empty!(Base.ARGS)
 empty!(Core.ARGS)
 
 end # @eval
+end # if
+
+println("Outputting sysimage file...")
+let pre_output_time = time_ns()
+    # Print report after sysimage has been saved so all time spent can be captured
+    Base.postoutput() do
+        output_time = time_ns() - pre_output_time
+        print("Output ────── "); Base.time_print(output_time); println()
+    end
 end

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -421,14 +421,21 @@ function generate_precompile_statements()
         n_succeeded > 1200 || @warn "Only $n_succeeded precompile statements"
     end
 
-    tot_time = time_ns() - start_time
-    include_time *= 1e9
-    gen_time = tot_time - include_time
-    println("Precompilation complete. Summary:")
-    print("Total ─────── "); Base.time_print(tot_time); println()
-    print("Generation ── "); Base.time_print(gen_time);     print(" "); show(IOContext(stdout, :compact=>true), gen_time / tot_time * 100); println("%")
-    print("Execution ─── "); Base.time_print(include_time); print(" "); show(IOContext(stdout, :compact=>true), include_time / tot_time * 100); println("%")
+    println("Outputting sysimage file...")
 
+    include_time *= 1e9
+    gen_time = (time_ns() - start_time) - include_time
+
+    # Print report after sysimage has been saved so all time spent can be captured
+    Base.postoutput() do
+        tot_time = time_ns() - start_time
+        output_time = tot_time - gen_time - include_time
+        println("Precompilation complete. Summary:")
+        print("Generation ── "); Base.time_print(gen_time);     print(" "); show(IOContext(stdout, :compact=>true), gen_time / tot_time * 100);     println("%")
+        print("Execution ─── "); Base.time_print(include_time); print(" "); show(IOContext(stdout, :compact=>true), include_time / tot_time * 100); println("%")
+        print("Output ────── "); Base.time_print(output_time);  print(" "); show(IOContext(stdout, :compact=>true), output_time / tot_time * 100);  println("%")
+        print("Total ─────── "); Base.time_print(tot_time);     println()
+    end
     return
 end
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -1727,6 +1727,7 @@ JL_DLLEXPORT void jl_init_with_image(const char *julia_bindir,
 JL_DLLEXPORT const char *jl_get_default_sysimg_path(void);
 JL_DLLEXPORT int jl_is_initialized(void);
 JL_DLLEXPORT void jl_atexit_hook(int status);
+JL_DLLEXPORT void jl_postoutput_hook(void);
 JL_DLLEXPORT void JL_NORETURN jl_exit(int status);
 JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle);
 

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -97,6 +97,7 @@ void jl_write_compiler_output(void)
                            jl_options.outputo,
                            jl_options.outputasm,
                            (const char*)s->buf, (size_t)s->size);
+            jl_postoutput_hook();
         }
     }
     for (size_t i = 0; i < jl_current_modules.size; i += 2) {


### PR DESCRIPTION
Currently the time spent outputting the sysimage files isn't included in the "Total"s of each sysimage build step, yet it takes longer than the time reported.

This PR includes that time in the report.

Update: It seems from some offline discussion like the approach from https://github.com/JuliaLang/julia/pull/42303 might actually be ok, so I brought that here. (couldn't reopen that PR)

The approach is to introduce a `postoutput` hook that runs after any output is generated.

This PR also moves the "Total" to the bottom of the report as it was noted that that might make more sense.

With this PR (updated):
```
Sysimage built. Summary:
Base ────────  27.306616 seconds 40.1941%
Stdlibs ─────  40.628288 seconds 59.803%
Total ───────  67.936891 seconds
    JULIA usr/lib/julia/sys-o.a
Generating REPL precompile statements... 40/40
Executing precompile statements... 1894/1926
Precompilation complete. Summary:
Generation ── 101.490691 seconds 74.2266%
Execution ───  35.240176 seconds 25.7734%
Total ─────── 136.730867 seconds
Outputting sysimage file...
Output ────── 149.910727 seconds
    LINK usr/lib/julia/sys.dylib
```
