### PR TITLE
Improve docs for `sin` and some friends

### DIFF
--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -24,7 +24,7 @@ abstract type AbstractIrrational <: Real end
 Number type representing an exact irrational value denoted by the
 symbol `sym`, such as [`π`](@ref pi), [`ℯ`](@ref) and [`γ`](@ref Base.MathConstants.eulergamma).
 
-See also [`@irrational`], [`AbstractIrrational`](@ref).
+See also [`@irrational`](@ref Base.@irrational), [`AbstractIrrational`](@ref).
 """
 struct Irrational{sym} <: AbstractIrrational end
 

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -24,7 +24,7 @@ abstract type AbstractIrrational <: Real end
 Number type representing an exact irrational value denoted by the
 symbol `sym`, such as [`π`](@ref pi), [`ℯ`](@ref) and [`γ`](@ref Base.MathConstants.eulergamma).
 
-See also [`@irrational`](@ref Base.@irrational), [`AbstractIrrational`](@ref).
+See also [`@irrational`], [`AbstractIrrational`](@ref).
 """
 struct Irrational{sym} <: AbstractIrrational end
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -309,6 +309,8 @@ end
 
 Convert `x` from radians to degrees.
 
+See also [`deg2rad`](@ref).
+
 # Examples
 ```jldoctest
 julia> rad2deg(pi)
@@ -322,7 +324,7 @@ rad2deg(z::AbstractFloat) = z * (180 / oftype(z, pi))
 
 Convert `x` from degrees to radians.
 
-See also: [`rad2deg`](@ref), [`sind`](@ref).
+See also [`rad2deg`](@ref), [`sind`](@ref), [`pi`](@ref).
 
 # Examples
 ```jldoctest
@@ -404,6 +406,8 @@ cosh(x::Number)
     tanh(x)
 
 Compute hyperbolic tangent of `x`.
+
+See also [`tan`](@ref), [`atanh`](@ref).
 """
 tanh(x::Number)
 
@@ -420,6 +424,8 @@ For two arguments, this is the angle in radians between the positive *x*-axis an
 point (*x*, *y*), returning a value in the interval ``[-\\pi, \\pi]``. This corresponds to a
 standard [`atan2`](https://en.wikipedia.org/wiki/Atan2) function. Note that by convention
 `atan(0.0,x)` is defined as ``\\pi`` and `atan(-0.0,x)` is defined as ``-\\pi`` when `x < 0`.
+
+See also [`atand`](@ref) for degrees.
 """
 atan(x::Number)
 
@@ -438,7 +444,7 @@ asinh(x::Number)
 
 # functions that return NaN on non-NaN argument for domain error
 """
-    sin(x)
+    sin(x::Number)
 
 Compute sine of `x`, where `x` is in radians.
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -477,7 +477,7 @@ asinh(x::Number)
 
 # functions that return NaN on non-NaN argument for domain error
 """
-    sin(x::Number)
+    sin(x)
 
 Compute sine of `x`, where `x` is in radians.
 
@@ -485,17 +485,9 @@ See also [`sind`](@ref), [`sinpi`](@ref), [`sincos`](@ref), [`cis`](@ref), [`asi
 
 # Examples
 ```jldoctest
-julia> round.(sin.(range(0, 2pi, length=9)), digits=3)
-9-element Vector{Float64}:
-  0.0
-  0.707
-  1.0
-  0.707
-  0.0
- -0.707
- -1.0
- -0.707
- -0.0
+julia> round.(sin.(range(0, 2pi, length=9)'), digits=3)
+1×9 Matrix{Float64}:
+ 0.0  0.707  1.0  0.707  0.0  -0.707  -1.0  -0.707  -0.0
 
 julia> sind(45)
 0.7071067811865476

--- a/base/math.jl
+++ b/base/math.jl
@@ -408,6 +408,26 @@ cosh(x::Number)
 Compute hyperbolic tangent of `x`.
 
 See also [`tan`](@ref), [`atanh`](@ref).
+
+# Examples
+
+```jldoctest
+julia> tanh.(-3:3f0)
+7-element Vector{Float32}:
+ -0.9950548
+ -0.9640276
+ -0.7615942
+  0.0
+  0.7615942
+  0.9640276
+  0.9950548
+
+julia> tan.(im .* (1:3f0))
+3-element Vector{ComplexF32}:
+ 0.0f0 + 0.7615941f0im
+ 0.0f0 + 0.96402764f0im
+ 0.0f0 + 0.9950547f0im
+```
 """
 tanh(x::Number)
 
@@ -426,6 +446,19 @@ standard [`atan2`](https://en.wikipedia.org/wiki/Atan2) function. Note that by c
 `atan(0.0,x)` is defined as ``\\pi`` and `atan(-0.0,x)` is defined as ``-\\pi`` when `x < 0`.
 
 See also [`atand`](@ref) for degrees.
+
+# Examples
+
+```jldoctest
+julia> rad2deg(atan(-1/√3))
+-30.000000000000004
+
+julia> rad2deg(atan(-1, √3))
+-30.000000000000004
+
+julia> rad2deg(atan(1, -√3))
+150.0
+```
 """
 atan(x::Number)
 
@@ -449,6 +482,33 @@ asinh(x::Number)
 Compute sine of `x`, where `x` is in radians.
 
 See also [`sind`](@ref), [`sinpi`](@ref), [`sincos`](@ref), [`cis`](@ref), [`asin`](@ref).
+
+# Examples
+```jldoctest
+julia> round.(sin.(range(0, 2pi, length=9)), digits=3)
+9-element Vector{Float64}:
+  0.0
+  0.707
+  1.0
+  0.707
+  0.0
+ -0.707
+ -1.0
+ -0.707
+ -0.0
+
+julia> sind(45)
+0.7071067811865476
+
+julia> sinpi(1/4)
+0.7071067811865476
+
+julia> sincos(pi/6)
+(0.49999999999999994, 0.8660254037844387)
+
+julia> cis(pi/6)
+0.8660254037844387 + 0.49999999999999994im
+```
 """
 sin(x::Number)
 
@@ -472,6 +532,17 @@ tan(x::Number)
     asin(x)
 
 Compute the inverse sine of `x`, where the output is in radians.
+
+See also [`asind`](@ref) for output in degrees.
+
+# Examples
+```jldoctest
+julia> asin.((0, 1/2, 1))
+(0.0, 0.5235987755982989, 1.5707963267948966)
+
+julia> asind.((0, 1/2, 1))
+(0.0, 30.000000000000004, 90.0)
+```
 """
 asin(x::Number)
 
@@ -515,6 +586,12 @@ log will only return a complex result if called with a complex argument. Try log
 Stacktrace:
  [1] throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:31
 [...]
+
+julia> log.(exp.(-1:1))
+3-element Vector{Float64}:
+ -1.0
+  0.0
+  1.0
 ```
 """
 log(x::Number)
@@ -541,6 +618,12 @@ log2 will only return a complex result if called with a complex argument. Try lo
 Stacktrace:
  [1] throw_complex_domainerror(f::Symbol, x::Float64) at ./math.jl:31
 [...]
+
+julia> log2.(2.0 .^ (-1:1))
+3-element Vector{Float64}:
+ -1.0
+  0.0
+  1.0
 ```
 """
 log2(x)

--- a/base/math.jl
+++ b/base/math.jl
@@ -17,7 +17,7 @@ export sin, cos, sincos, tan, sinh, cosh, tanh, asin, acos, atan,
 
 import .Base: log, exp, sin, cos, tan, sinh, cosh, tanh, asin,
              acos, atan, asinh, acosh, atanh, sqrt, log2, log10,
-             max, min, min<<<<<<<max, ^, exp2, muladd, rem,
+             max, min, minmax, ^, exp2, muladd, rem,
              exp10, expm1, log1p, @constprop, @assume_effects
 
 using .Base: sign_mask, exponent_mask, exponent_one,

--- a/base/math.jl
+++ b/base/math.jl
@@ -503,11 +503,14 @@ julia> sind(45)
 julia> sinpi(1/4)
 0.7071067811865476
 
-julia> sincos(pi/6)
-(0.49999999999999994, 0.8660254037844387)
+julia> round.(sincos(pi/6), digits=3)
+(0.5, 0.866)
 
-julia> cis(pi/6)
-0.8660254037844387 + 0.49999999999999994im
+julia> round(cis(pi/6), digits=3)
+0.866 + 0.5im
+
+julia> round(exp(im*pi/6), digits=3)
+0.866 + 0.5im
 ```
 """
 sin(x::Number)

--- a/base/math.jl
+++ b/base/math.jl
@@ -17,7 +17,7 @@ export sin, cos, sincos, tan, sinh, cosh, tanh, asin, acos, atan,
 
 import .Base: log, exp, sin, cos, tan, sinh, cosh, tanh, asin,
              acos, atan, asinh, acosh, atanh, sqrt, log2, log10,
-             max, min, minmax, ^, exp2, muladd, rem,
+             max, min, min<<<<<<<max, ^, exp2, muladd, rem,
              exp10, expm1, log1p, @constprop, @assume_effects
 
 using .Base: sign_mask, exponent_mask, exponent_one,
@@ -442,7 +442,7 @@ asinh(x::Number)
 
 Compute sine of `x`, where `x` is in radians.
 
-See also [`sind`](@ref), [`sinpi`](@ref), [`sincos`](@ref), [`cis`](@ref).
+See also [`sind`](@ref), [`sinpi`](@ref), [`sincos`](@ref), [`cis`](@ref), [`asin`](@ref).
 """
 sin(x::Number)
 
@@ -496,7 +496,7 @@ atanh(x::Number)
 Compute the natural logarithm of `x`. Throws [`DomainError`](@ref) for negative
 [`Real`](@ref) arguments. Use complex negative arguments to obtain complex results.
 
-See also [`log1p`](@ref), [`log2`](@ref), [`log10`](@ref).
+See also [`ℯ`](@ref), [`log1p`](@ref), [`log2`](@ref), [`log10`](@ref).
 
 # Examples
 ```jldoctest; filter = r"Stacktrace:(\\n \\[[0-9]+\\].*)*"

--- a/base/math.jl
+++ b/base/math.jl
@@ -412,7 +412,7 @@ See also [`tan`](@ref), [`atanh`](@ref).
 # Examples
 
 ```jldoctest
-julia> tanh.(-3:3f0)
+julia> tanh.(-3:3f0)  # Here 3f0 isa Float32
 7-element Vector{Float32}:
  -0.9950548
  -0.9640276
@@ -422,11 +422,11 @@ julia> tanh.(-3:3f0)
   0.9640276
   0.9950548
 
-julia> tan.(im .* (1:3f0))
-3-element Vector{ComplexF32}:
- 0.0f0 + 0.7615941f0im
- 0.0f0 + 0.96402764f0im
- 0.0f0 + 0.9950547f0im
+julia> tan.(im .* (1:3))
+3-element Vector{ComplexF64}:
+ 0.0 + 0.7615941559557649im
+ 0.0 + 0.9640275800758169im
+ 0.0 + 0.9950547536867306im
 ```
 """
 tanh(x::Number)

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -320,12 +320,25 @@ promote_result(::Type{T},::Type{S},::Type{Bottom},::Type{Bottom}) where {T,S} = 
 Convert all arguments to a common type, and return them all (as a tuple).
 If no arguments can be converted, an error is raised.
 
-See also: [`promote_type`], [`promote_rule`].
+See also: [`promote_type`](@ref), [`promote_rule`](@ref).
 
 # Examples
 ```jldoctest
 julia> promote(Int8(1), Float16(4.5), Float32(4.1))
 (1.0f0, 4.5f0, 4.1f0)
+
+julia> promote_type(Int8, Float16, Float32)
+Float32
+
+julia> reduce(Base.promote_typejoin, (Int8, Float16, Float32))
+Real
+
+julia> promote(1, "x")
+ERROR: promotion of types Int64 and String failed to change any arguments
+[...]
+
+julia> promote_type(Int, String)
+Any
 ```
 """
 function promote end


### PR DESCRIPTION
Some "see also" links from #38606 were missing `(@ref)` and thus not really links. 

Also adds a few more such links, and adds examples for `sin` and a few other functions. 