### PR TITLE
Extend code_warntype to take existing code_typed output

### DIFF
--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -59,9 +59,13 @@ See [`@code_warntype`](@ref man-code-warntype) for more information.
 """
 function code_warntype(io::IO, @nospecialize(f), @nospecialize(t=Base.default_tt(f));
                        debuginfo::Symbol=:default, optimize::Bool=false, kwargs...)
+    code_warntype(io, code_typed(f, t; optimize, kwargs...))
+end
+
+function code_warntype(io::IO, code_typed_output::Vector{Any})
     debuginfo = Base.IRShow.debuginfo(debuginfo)
     lineprinter = Base.IRShow.__debuginfo[debuginfo]
-    for (src, rettype) in code_typed(f, t; optimize, kwargs...)
+    for (src, rettype) in code_typed_output
         if !(src isa Core.CodeInfo)
             println(io, src)
             println(io, "  failed to infer")


### PR DESCRIPTION
This is one of several upstream changes necessary to simplify the ability for GPUCompiler (and downstream users like Enzyme) to generate code off of the type of a function, rather than the function itself.

See https://github.com/JuliaGPU/GPUCompiler.jl/pull/323

cc @vchuravy @maleadt 