### PR TITLE
make `@invoke` macro available at bootstrapping time

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1769,11 +1769,20 @@ When an argument's type annotation is omitted, it's specified as `Any` argument,
 """
 macro invoke(ex)
     f, args, kwargs = destructure_callex(ex)
-    arg2typs = map(args) do x
-        isexpr(x, :(::)) ? (x.args...,) : (x, GlobalRef(Core, :Any))
+    newargs, newargtypes = Any[], Any[]
+    for i = 1:length(args)
+        x = args[i]
+        if isexpr(x, :(::))
+            a = x.args[1]
+            t = x.args[2]
+        else
+            a = x
+            t = GlobalRef(Core, :Any)
+        end
+        push!(newargs, a)
+        push!(newargtypes, t)
     end
-    args, argtypes = first.(arg2typs), last.(arg2typs)
-    return esc(:($(GlobalRef(Core, :invoke))($(f), Tuple{$(argtypes...)}, $(args...); $(kwargs...))))
+    return esc(:($(GlobalRef(Core, :invoke))($(f), Tuple{$(newargtypes...)}, $(newargs...); $(kwargs...))))
 end
 
 """


### PR DESCRIPTION
By avoiding using `collect` within the macro expansion,
as it internally uses `Core.Compiler.return_type`.