### PR TITLE
Allow constprop to improve constant results to Bottom

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -902,7 +902,13 @@ function const_prop_entry_heuristic(interp::AbstractInterpreter, result::MethodC
         add_remark!(interp, sv, "[constprop] Disabled by entry heuristic (limited accuracy)")
         return false
     else
-        add_remark!(interp, sv, "[constprop] Disabled by entry heuristic (unimprovable return type)")
+        if isa(rt, Const)
+            if result.edge_effects.nothrow !== ALWAYS_TRUE
+                # Could still be improved to Bottom (or at least could see the effects improved)
+                return true
+            end
+        end
+        add_remark!(interp, sv, "[constprop] Disabled by entry heuristic (unimprovable result)")
         return false
     end
 end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1136,14 +1136,14 @@ ambig_effect_test(a, b::Int) = 1
 ambig_effect_test(a, b) = 1
 global ambig_unknown_type_global=1
 @noinline function conditionally_call_ambig(b::Bool, a)
-	if b
-		ambig_effect_test(a, ambig_unknown_type_global)
-	end
-	return 0
+    if b
+        ambig_effect_test(a, ambig_unknown_type_global)
+    end
+    return 0
 end
 function call_call_ambig(b::Bool)
-	conditionally_call_ambig(b, 1)
-	return 1
+    conditionally_call_ambig(b, 1)
+    return 1
 end
 @test !fully_eliminated(call_call_ambig, Tuple{Bool})
 
@@ -1245,4 +1245,17 @@ const my_defined_var = 42
 end
 @test !fully_eliminated() do
     getglobal(@__MODULE__, :my_defined_var, :foo)
+end
+
+# Test for deletion of value-dependent control flow that is apparent
+# at inference time, but hard to delete later.
+function maybe_error_int(x::Int)
+    if x > 2
+        Base.donotdelete(Base.inferencebarrier(x))
+        error()
+    end
+    return 1
+end
+@test fully_eliminated() do
+    return maybe_error_int(1)
 end


### PR DESCRIPTION
This is consistent with what we would do for a non-constant return.
This helps the compiler dump less code onto LLVM in situations
where there is a big basic block that our constprop can see is
dead. That said, for that particular situation, it might be better
to have a constant propagation pass at the IR level that runs
after inlining. We can revisit that after #44660.