### PR TITLE
Fix different .cachepath initialization points for precompile load

### DIFF
--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -313,7 +313,7 @@ precompile_test_harness(false) do dir
     # the module doesn't reload from the image:
     @test_warn "@ccallable was already defined for this method name" begin
         @test_logs (:warn, "Replacing module `$Foo_module`") begin
-            ms = Base._require_from_serialized(cachefile)
+            ms = Base._require_from_serialized(Base.PkgId(Foo), cachefile)
             @test isa(ms, Array{Any,1})
         end
     end
@@ -1277,4 +1277,16 @@ end
     end
     @test any(mi -> mi.specTypes.parameters[2] === Any, mis)
     @test all(mi -> isa(mi.cache, Core.CodeInstance), mis)
+end
+
+# Test that the cachepath is available in pkgorigins during the
+# __init__ callback
+precompile_test_harness("__init__ cachepath") do load_path
+    write(joinpath(load_path, "InitCachePath.jl"),
+          """
+          module InitCachePath
+            __init__() = Base.pkgorigins[Base.PkgId(InitCachePath)]
+          end
+          """)
+    @test isa((@eval (using InitCachePath; InitCachePath)), Module)
 end


### PR DESCRIPTION
For quite some time I've been observing Revise randomly not pick
up changes to my packages. Usually I just write that off to Revise
getting into a bad state and restarting Julia fixes it. Today, I
got very annoyed by this again and decided to finally track it down.
What turns out to happen here is the packages in question are those
which:

A. Are being precompiled on load
B. Use Requires
C. Have an `@require`'d-dependency already loaded
D. The change to be revised is made in a file not loaded via
   Requires.jl.

In this case the `__init__` of the package triggers Requires,
which in turn calls back to Revise, which tries to start watching
the package. However, on the `compilecache` path (but not on the
path where we just find a pre-existing cache file), we used to
not set the .cachepath property of `pkgorigins` until after
the `__init__` callbacks run, causing Revise not to be able
to see those files. Infuriatingly, restarting julia fixes this
because it just loads the .ji file that was just compiled.

Fix this by unifying the point at which the .cachepath is set,
always setting it just prior to the module initialization callback.