### PR TITLE
Use enum for `Threads.threadpool()`

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -67,6 +67,9 @@ include("coreio.jl")
 eval(x) = Core.eval(Base, x)
 eval(m::Module, x) = Core.eval(m, x)
 
+struct MIME{mime} end
+const MIME_text_plain = MIME{Symbol("text/plain")}
+
 # init core docsystem
 import Core: @doc, @__doc__, WrappedException, @int128_str, @uint128_str, @big_str, @cmd
 if isdefined(Core, :Compiler)
@@ -126,6 +129,10 @@ include("refvalue.jl")
 include("refpointer.jl")
 include("checked.jl")
 using .Checked
+
+# enums
+include("Enums.jl")
+using .Enums
 
 # Lazy strings
 include("strings/lazy.jl")
@@ -346,10 +353,6 @@ include("fastmath.jl")
 using .FastMath
 
 function deepcopy_internal end
-
-# enums
-include("Enums.jl")
-using .Enums
 
 # BigInts
 include("gmp.jl")

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -3,6 +3,7 @@
 module Enums
 
 import Core.Intrinsics.bitcast
+using Base: MIME_text_plain
 export Enum, @enum
 
 function namemap end
@@ -46,14 +47,14 @@ function Base.show(io::IO, x::Enum)
     print(io, sym)
 end
 
-function Base.show(io::IO, ::MIME"text/plain", x::Enum)
+function Base.show(io::IO, ::MIME_text_plain, x::Enum)
     print(io, x, "::")
     show(IOContext(io, :compact => true), typeof(x))
     print(io, " = ")
     show(io, Integer(x))
 end
 
-function Base.show(io::IO, m::MIME"text/plain", t::Type{<:Enum})
+function Base.show(io::IO, m::MIME_text_plain, t::Type{<:Enum})
     if isconcretetype(t)
         print(io, "Enum ")
         Base.show_datatype(io, t)
@@ -63,7 +64,7 @@ function Base.show(io::IO, m::MIME"text/plain", t::Type{<:Enum})
             show(io, Integer(x))
         end
     else
-        invoke(show, Tuple{IO, MIME"text/plain", Type}, io, m, t)
+        invoke(show, Tuple{IO, MIME_text_plain, Type}, io, m, t)
     end
 end
 
@@ -79,10 +80,10 @@ function membershiptest(expr, values)
     end
 end
 
-# give Enum types scalar behavior in broadcasting
-Base.broadcastable(x::Enum) = Ref(x)
-
-@noinline enum_argument_error(typename, x) = throw(ArgumentError(string("invalid value for Enum $(typename): $x")))
+function enum_argument_error(typename, x)
+    @noinline
+    throw(ArgumentError(string("invalid value for Enum $(typename): $x")))
+end
 
 """
     @enum EnumName[::BaseType] value1[=x] value2[=y]

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -697,7 +697,23 @@ julia> Broadcast.broadcastable("hello") # Strings break convention of matching i
 Base.RefValue{String}("hello")
 ```
 """
-broadcastable(x::Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,AbstractPattern,Pair,IO}) = Ref(x)
+broadcastable(
+    x::Union{
+        Symbol,
+        AbstractString,
+        Function,
+        UndefInitializer,
+        Nothing,
+        RoundingMode,
+        Missing,
+        Val,
+        Ptr,
+        AbstractPattern,
+        Pair,
+        IO,
+        Enum,
+    },
+) = Ref(x)
 broadcastable(::Type{T}) where {T} = Ref{Type{T}}(T)
 broadcastable(x::Union{AbstractArray,Number,AbstractChar,Ref,Tuple,Broadcasted}) = x
 # Default to collecting iterables — which will error for non-iterables

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -2,7 +2,7 @@
 
 module Multimedia
 
-import .Base: show, print, convert, repr
+import .Base: MIME, show, print, convert, repr
 
 export AbstractDisplay, display, pushdisplay, popdisplay, displayable, redisplay,
     MIME, @MIME_str, istextmime,
@@ -29,7 +29,7 @@ julia> show(stdout, MIME("text/plain"), "hi")
 "hi"
 ```
 """
-struct MIME{mime} end
+MIME
 
 """
     @MIME_str

--- a/base/task.jl
+++ b/base/task.jl
@@ -251,10 +251,8 @@ true
 istaskfailed(t::Task) = (load_state_acquire(t) === task_state_failed)
 
 Threads.threadid(t::Task) = Int(ccall(:jl_get_task_tid, Int16, (Any,), t)+1)
-function Threads.threadpool(t::Task)
-    tpid = ccall(:jl_get_task_threadpoolid, Int8, (Any,), t)
-    return tpid == 0 ? :default : :interactive
-end
+Threads.threadpool(t::Task) =
+    Threads.ThreadPoolID(ccall(:jl_get_task_threadpoolid, Int8, (Any,), t))
 
 task_result(t::Task) = t.result
 

--- a/test/threadpool_use.jl
+++ b/test/threadpool_use.jl
@@ -4,10 +4,13 @@ using Test
 using Base.Threads
 
 @test nthreadpools() == 2
-@test threadpool() == :default
-@test threadpool(2) == :interactive
-dtask() = @test threadpool(current_task()) == :default
-itask() = @test threadpool(current_task()) == :interactive
+@test threadpool() == THREADPOOL_DEFAULT
+@test threadpool(2) == THREADPOOL_INTERACTIVE
+@test nthreads(THREADPOOL_DEFAULT) == nthreads(:default)
+@test nthreads(THREADPOOL_INTERACTIVE) == nthreads(:interactive)
+@test nthreads(THREADPOOL_DEFAULT) + nthreads(THREADPOOL_INTERACTIVE) == nthreads()
+dtask() = @test threadpool(current_task()) == THREADPOOL_DEFAULT
+itask() = @test threadpool(current_task()) == THREADPOOL_INTERACTIVE
 dt1 = @spawn dtask()
 dt2 = @spawn :default dtask()
 it = @spawn :interactive itask()


### PR DESCRIPTION
Using a symbol for presenting threadpool ID has some downsides:

* Using a symbol makes detecting a typo like `if Threads.threadpool() === :interatcive` hard.
* _If_ we decide to support adding more threadpools at runtime, using a symbol as a thread pool identifier becomes very tedious and error prone.

I'm opening this PR to start discussing if `Threads.threadpool()` etc. should use a different representation for representing threadpool id. This PR uses an enum. It still keeps `@spawn :interactive` etc. syntax since it doesn't have the downsides discussed.
