### PR TITLE
Clarify that `modifyproperty!` does not call `convert`

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2758,6 +2758,11 @@ The syntax `@atomic! max(a().b, c)` returns `modifyproperty!(a(), :b,
 max, c, :sequentially_consistent))`, where the first argument must be a
 `getfield` expression and is modified atomically.
 
+Unlike [`setproperty!`](@ref Base.setproperty!), the default implementation of
+`modifyproperty!` does not call `convert` automatically.  Thus, `op` must return a value
+that can be stored in the field `f` directly when invoking the default `modifyproperty!`
+implementation.
+
 See also [`modifyfield!`](@ref Core.modifyfield!)
 and [`setproperty!`](@ref Base.setproperty!).
 """


### PR DESCRIPTION
Is this behavior documented somewhere?

```julia
julia> mutable struct Atomic{T}; @atomic x::T; end

julia> a = Atomic(0);

julia> @atomic a.x = 0.0;

julia> @atomic a.x += 0.0;
ERROR: TypeError: in modifyfield!, expected Int64, got a value of type Float64
```

I don't know if we should fix the documentation or the implementation. Or maybe note it as a possible future fix. So, just as a starter, I implemented the easiest change which is to simply document it.