### PR TITLE
make sure `basic_block_index` is sorted

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -88,7 +88,7 @@ function compute_basic_blocks(stmts::Vector{Any})
     bb_starts = basic_blocks_starts(stmts)
     # Compute ranges
     pop!(bb_starts, 1)
-    basic_block_index = collect(bb_starts)
+    basic_block_index = sort!(collect(bb_starts); alg=QuickSort)
     blocks = BasicBlock[]
     sizehint!(blocks, length(basic_block_index))
     let first = 1


### PR DESCRIPTION
Found `block_for_inst(index::Vector{Int}, ::Int)` expects `index` to be
sorted, but we didn't sort it explicitly previously.