### PR TITLE
don't mark `SLOT_USEDUNDEF` upon `:isdefined` usage

### DIFF
--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -127,16 +127,11 @@ function fixemup!(@specialize(slot_filter), @specialize(rename_slot), ir::IRCode
     if isexpr(stmt, :isdefined)
         val = stmt.args[1]
         if isa(val, UnoptSlot)
-            slot = slot_id(val)
-            if (ci.slotflags[slot] & SLOT_USEDUNDEF) == 0
+            ssa = rename_slot(val)
+            if ssa === UNDEF_TOKEN
+                return false
+            elseif !isa(ssa, SSAValue) && !isa(ssa, NewSSAValue)
                 return true
-            else
-                ssa = rename_slot(val)
-                if ssa === UNDEF_TOKEN
-                    return false
-                elseif !isa(ssa, SSAValue) && !isa(ssa, NewSSAValue)
-                    return true
-                end
             end
             # temporarily corrupt the isdefined node. type_lift_pass! will fix it
             stmt.args[1] = ssa

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -654,7 +654,7 @@ function annotate_slot_load!(undefs::Vector{Bool}, idx::Int, sv::InferenceState,
     elseif isa(x, Expr)
         head = x.head
         i0 = 1
-        if is_meta_expr_head(head) || head === :const
+        if is_meta_expr_head(head) || head === :const || head === :isdefined
             return x
         end
         if head === :(=) || head === :method


### PR DESCRIPTION
`SLOT_USEDUNDEF` is such a flag that has the following meaning:
> slot has uses that might raise UndefVarError

Since `Expr(:isdefined, slot)` doesn't raise `UndefVarError`, it sounds
incorrect conceptually to look for it when folding a `:isdefined`
expression to `true`.