### PR TITLE
ccall: Add probecall for user-defined probe points

### DIFF
--- a/base/partr.jl
+++ b/base/partr.jl
@@ -68,6 +68,8 @@ function multiq_size(tpid::Int8)
     heap_c = UInt32(2)
     heap_p = UInt32(length(tpheaps))
 
+    ccall("multiq_size", probecall, Cvoid, (Int8,), tpid)
+
     if heap_c * nt <= heap_p
         return heap_p
     end

--- a/src/Makefile
+++ b/src/Makefile
@@ -46,7 +46,8 @@ SRCS := \
 	simplevector runtime_intrinsics precompile jloptions \
 	threading partr stackwalk gc gc-debug gc-pages gc-stacks gc-alloc-profiler method \
 	jlapi signal-handling safepoint timing subtype rtutils gc-heap-snapshot \
-	crc32c APInt-C processor ircode opaque_closure codegen-stubs coverage runtime_ccall
+	crc32c APInt-C processor ircode opaque_closure codegen-stubs coverage runtime_ccall \
+	probes
 
 RT_LLVMLINK :=
 CG_LLVMLINK :=

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -2030,15 +2030,15 @@ jl_cgval_t function_sig_t::emit_a_ccall(
         ++EmittedProbeCalls;
         if (symarg.jl_ptr != NULL) {
             emit_error(ctx, "probecall doesn't support dynamic pointers");
-            return jl_cgval_t(ctx.builder.getContext());
+            return jl_cgval_t();
         }
         else if (symarg.fptr != NULL) {
             emit_error(ctx, "probecall doesn't support static pointers");
-            return jl_cgval_t(ctx.builder.getContext());
+            return jl_cgval_t();
         }
         else if (symarg.f_lib != NULL) {
             emit_error(ctx, "probecall doesn't support dynamic libraries");
-            return jl_cgval_t(ctx.builder.getContext());
+            return jl_cgval_t();
         }
         else {
             assert(symarg.f_name != NULL);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6140,7 +6140,7 @@ static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, con
     if (rt != declrt && rt != (jl_value_t*)jl_any_type)
         rt = jl_ensure_rooted(ctx, rt);
 
-    function_sig_t sig("cfunction", lrt, rt, retboxed, argt, unionall_env, false, CallingConv::C, false, &ctx.emission_context);
+    function_sig_t sig("cfunction", lrt, rt, retboxed, argt, unionall_env, false, CallingConv::C, false, false, &ctx.emission_context);
     assert(sig.fargt.size() + sig.sret == sig.fargt_sig.size());
     if (!sig.err_msg.empty()) {
         emit_error(ctx, sig.err_msg);
@@ -6280,7 +6280,8 @@ const char *jl_generate_ccallable(LLVMOrcThreadSafeModuleRef llvmmod, void *sysi
     jl_value_t *err;
     { // scope block for sig
         function_sig_t sig("cfunction", lcrt, crt, toboxed,
-                           argtypes, NULL, false, CallingConv::C, false, &params);
+                           argtypes, NULL, false, CallingConv::C, false, false,
+                           &params);
         if (sig.err_msg.empty()) {
             size_t world = jl_atomic_load_acquire(&jl_world_counter);
             size_t min_valid = 0;

--- a/src/init.c
+++ b/src/init.c
@@ -736,6 +736,7 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
     jl_prep_sanitizers();
     void *stack_lo, *stack_hi;
     jl_init_stack_limits(1, &stack_lo, &stack_hi);
+    jl_init_probes();
 
     jl_libjulia_internal_handle = jl_load_dynamic_library(NULL, JL_RTLD_DEFAULT, 1);
 #ifdef _OS_WINDOWS_

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -379,6 +379,8 @@
     XX(jl_prepend_cwd) \
     XX(jl_printf) \
     XX(jl_print_backtrace) \
+    XX(jl_probe_lookup) \
+    XX(jl_probe_register) \
     XX(jl_process_events) \
     XX(jl_profile_clear_data) \
     XX(jl_profile_delay_nsec) \

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2613,7 +2613,7 @@
                  ((eq? f 'ccall)
                   (if (not (length> e 4)) (error "too few arguments to ccall"))
                   (let* ((cconv (cadddr e))
-                         (have-cconv (memq cconv '(cdecl stdcall fastcall thiscall llvmcall)))
+                         (have-cconv (memq cconv '(cdecl stdcall fastcall thiscall llvmcall probecall)))
                          (after-cconv (if have-cconv (cddddr e) (cdddr e)))
                          (name (caddr e))
                          (RT   (car after-cconv))
@@ -4444,7 +4444,7 @@ f(x) = yt(x)
     ;; from the current function.
     (define (compile e break-labels value tail)
       (if (or (not (pair? e)) (memq (car e) '(null true false ssavalue quote inert top core copyast the_exception $
-                                                   globalref outerref thismodule cdecl stdcall fastcall thiscall llvmcall)))
+                                                   globalref outerref thismodule cdecl stdcall fastcall thiscall llvmcall probecall)))
           (let ((e1 (if (and arg-map (symbol? e))
                         (get arg-map e e)
                         e)))

--- a/src/julia.h
+++ b/src/julia.h
@@ -2241,6 +2241,16 @@ typedef struct {
 } jl_cgparams_t;
 extern JL_DLLEXPORT int jl_default_debug_info_kind;
 
+// probes interface
+typedef struct {
+    const char *name;
+    void *probe_addr;
+    void *semaphore_addr;
+} jl_probe_spec_t;
+JL_DLLEXPORT void jl_init_probes(void);
+JL_DLLEXPORT jl_probe_spec_t *jl_probe_register(const char *);
+JL_DLLEXPORT jl_probe_spec_t *jl_probe_lookup(const char *);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/probes.c
+++ b/src/probes.c
@@ -22,10 +22,10 @@ JL_DLLEXPORT jl_probe_spec_t *jl_probe_register(const char *name) {
             return spec;
         }
     }
-    spec = (jl_probe_spec_t *)malloc(sizeof(jl_probe_spec_t));
+    spec = (jl_probe_spec_t *)calloc(1, sizeof(jl_probe_spec_t));
     spec->name = strdup(name);
-    spec->probe_addr = calloc(1, sizeof(void*));
-    spec->semaphore_addr = calloc(1, sizeof(int64_t));
+    //spec->probe_addr = calloc(1, sizeof(void*));
+    //spec->semaphore_addr = calloc(1, sizeof(int64_t));
     arraylist_push(jl_probes, (void *)spec);
 
     JL_UNLOCK(&jl_probes_mutex);

--- a/src/probes.c
+++ b/src/probes.c
@@ -1,0 +1,46 @@
+#include <string.h>
+#include "julia.h"
+#include "julia_internal.h"
+
+// FIXME: htable
+arraylist_t *jl_probes;
+jl_mutex_t jl_probes_mutex;
+
+void jl_init_probes(void) {
+    jl_probes = arraylist_new((arraylist_t *)malloc(sizeof(arraylist_t)), 1);
+    JL_MUTEX_INIT(&jl_probes_mutex);
+}
+
+JL_DLLEXPORT jl_probe_spec_t *jl_probe_register(const char *name) {
+    JL_LOCK(&jl_probes_mutex);
+
+    jl_probe_spec_t *spec;
+    for (int i = 0; i < jl_probes->len; i++) {
+        spec = (jl_probe_spec_t *)jl_probes->items[i];
+        if (strcmp(spec->name, name) == 0) {
+            JL_UNLOCK(&jl_probes_mutex);
+            return spec;
+        }
+    }
+    spec = (jl_probe_spec_t *)malloc(sizeof(jl_probe_spec_t));
+    spec->name = strdup(name);
+    spec->probe_addr = calloc(1, sizeof(void*));
+    spec->semaphore_addr = calloc(1, sizeof(int64_t));
+    arraylist_push(jl_probes, (void *)spec);
+
+    JL_UNLOCK(&jl_probes_mutex);
+    return spec;
+}
+
+JL_DLLEXPORT jl_probe_spec_t *jl_probe_lookup(const char *name) {
+    JL_LOCK(&jl_probes_mutex);
+    for (int i = 0; i < jl_probes->len; i++) {
+        jl_probe_spec_t *spec = (jl_probe_spec_t *)jl_probes->items[i];
+        if (strcmp(spec->name, name) == 0) {
+            JL_UNLOCK(&jl_probes_mutex);
+            return spec;
+        }
+    }
+    JL_UNLOCK(&jl_probes_mutex);
+    return (jl_probe_spec_t *)NULL;
+}


### PR DESCRIPTION
Adds a new `probecall` calling convention to `ccall`, which, when compiled, generates a new USDT-compatible probe slot (and associated semaphore), which, when executed via `ccall`, calls the loaded probe with the provided arguments.

Todo:
- [x] Register added probes in runtime (@pchintalapudi @vchuravy)
- [x] Add runtime functions for querying and controlling probes
- [x] Emit USDT notes
- [ ] Fix semaphore semantics
- [ ] Save probe names during precompilation, restore probe data during init
- [ ] Validate probes work with `bpftrace`/`BPFnative.jl`
- [ ] Switch from `ccall` special form to builtin
- [ ] Re-introduce probes lost in #44653 (will fix #44746)