### PR TITLE
improve Base.summarysize for BigInt

### DIFF
--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -192,3 +192,5 @@ function (ss::SummarySize)(obj::Task)
     # TODO: add stack size, and possibly traverse stack roots
     return size
 end
+
+(ss::SummarySize)(obj::BigInt) = _summarysize(ss, obj) + obj.alloc*sizeof(Base.GMP.Limb)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -398,6 +398,9 @@ let s = Set(1:100)
     @test summarysize([s]) > summarysize(s)
 end
 
+# issue #44780
+@test summarysize(BigInt(2)^1000) > summarysize(BigInt(2))
+
 ## test conversion from UTF-8 to UTF-16 (for Windows APIs)
 
 # empty arrays


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/44780

Take allocations of limbs into account.