### PR TITLE
fix #45162, function arg not specialized if only called with keywords

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3342,6 +3342,11 @@
          (let ((vi (get tab (cadr e) #f)))
            (if vi
                (vinfo:set-called! vi #t))
+           ;; calls to functions with keyword args go through `kwfunc` first
+           (if (and (length= e 3) (equal? (cadr e) '(core kwfunc)))
+               (let ((vi2 (get tab (caddr e) #f)))
+                 (if vi2
+                     (vinfo:set-called! vi2 #t))))
            (for-each (lambda (x) (analyze-vars x env captvars sp tab))
                      (cdr e))))
         ((decl)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -3365,3 +3365,7 @@ struct InnerCtorRT{T}
 end
 @test_throws MethodError InnerCtorRT()
 @test InnerCtorRT{Int}()() isa InnerCtorRT{Int}
+
+# issue #45162
+f45162(f) = f(x=1)
+@test first(methods(f45162)).called != 0


### PR DESCRIPTION
fix #45162
