### PR TITLE
add documentation about using `@cfunction` to call Julia functions when embedding

### DIFF
--- a/doc/src/manual/embedding.md
+++ b/doc/src/manual/embedding.md
@@ -241,6 +241,17 @@ jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, int32_t nargs)
 Its second argument `args` is an array of `jl_value_t*` arguments and `nargs` is the number of
 arguments.
 
+There is also an alternative, possibly simpler, way of calling Julia functions and that is via [`@cfunction`](@ref).
+Using `@cfunction` allows you to do the type conversions on the Julia side which typically is easier than doing it on
+the C side. The `sqrt` example above would with `@cfunction` be written as:
+
+```c
+double (*sqrt_ptr)(double) = jl_unbox_voidpointer(jl_eval_string("@cfunction(sqrt, Float64, (Float64,))"));
+double ret = (*sqrt_ptr)(2.0);
+```
+
+where we first define a C callable function in Julia, extract the function pointer from it and finally call it.
+
 ## Memory Management
 
 As we have seen, Julia objects are represented in C as pointers of type `jl_value_t*`. This raises the question of who

--- a/doc/src/manual/embedding.md
+++ b/doc/src/manual/embedding.md
@@ -246,8 +246,8 @@ Using `@cfunction` allows you to do the type conversions on the Julia side which
 the C side. The `sqrt` example above would with `@cfunction` be written as:
 
 ```c
-double (*sqrt_ptr)(double) = jl_unbox_voidpointer(jl_eval_string("@cfunction(sqrt, Float64, (Float64,))"));
-double ret = (*sqrt_ptr)(2.0);
+double (*sqrt_jl)(double) = jl_unbox_voidpointer(jl_eval_string("@cfunction(sqrt, Float64, (Float64,))"));
+double ret = sqrt_jl(2.0);
 ```
 
 where we first define a C callable function in Julia, extract the function pointer from it and finally call it.

--- a/test/embedding/embedding-test.jl
+++ b/test/embedding/embedding-test.jl
@@ -23,10 +23,13 @@ end
     @test readline(err) == "MethodError: no method matching this_function_has_no_methods()"
     @test success(p)
     lines = fetch(out_task)
-    @test length(lines) == 10
+    @test length(lines) == 11
     @test parse(Float64, lines[1]) ≈ sqrt(2)
-    @test lines[8] == "called bar"
-    @test lines[9] == "calling new bar"
-    @test lines[10] == "      From worker 2:\tTaking over the world..."
+    @test lines[2] == "sqrt(2.0) in C: 1.414214e+00"
+    @test lines[3] == "sqrt(2.0) in C: 1.414214e+00"
+    @test lines[4] == "sqrt(2.0) in C: 1.414214e+00"
+    @test lines[9] == "called bar"
+    @test lines[10] == "calling new bar"
+    @test lines[11] == "      From worker 2:\tTaking over the world..."
     @test readline(err) == "exception caught from C"
 end

--- a/test/embedding/embedding.c
+++ b/test/embedding/embedding.c
@@ -72,7 +72,7 @@ int main()
     {
         // Same as above but using `@cfunction`
         double (*sqrt_ptr)(double) = jl_unbox_voidpointer(jl_eval_string("@cfunction(sqrt, Float64, (Float64,))"));
-        double retDouble = (*sqrt_ptr)(2.0);
+        double retDouble = sqrt_ptr(2.0);
         printf("sqrt(2.0) in C: %e\n", retDouble);
         fflush(stdout);
     }

--- a/test/embedding/embedding.c
+++ b/test/embedding/embedding.c
@@ -71,8 +71,8 @@ int main()
 
     {
         // Same as above but using `@cfunction`
-        double (*sqrt_ptr)(double) = jl_unbox_voidpointer(jl_eval_string("@cfunction(sqrt, Float64, (Float64,))"));
-        double retDouble = sqrt_ptr(2.0);
+        double (*sqrt_jl)(double) = jl_unbox_voidpointer(jl_eval_string("@cfunction(sqrt, Float64, (Float64,))"));
+        double retDouble = sqrt_jl(2.0);
         printf("sqrt(2.0) in C: %e\n", retDouble);
         fflush(stdout);
     }

--- a/test/embedding/embedding.c
+++ b/test/embedding/embedding.c
@@ -70,6 +70,14 @@ int main()
     }
 
     {
+        // Same as above but using `@cfunction`
+        double (*sqrt_ptr)(double) = jl_unbox_voidpointer(jl_eval_string("@cfunction(sqrt, Float64, (Float64,))"));
+        double retDouble = (*sqrt_ptr)(2.0);
+        printf("sqrt(2.0) in C: %e\n", retDouble);
+        fflush(stdout);
+    }
+
+    {
         // 1D arrays
 
         jl_value_t* array_type = jl_apply_array_type((jl_value_t*)jl_float64_type, 1);


### PR DESCRIPTION
I'm not sure if the value from `jl_eval_string` needs to be rooted here.

Fixes https://github.com/JuliaLang/julia/issues/38932