### PR TITLE
Revert "Clarify that `modifyproperty!` does not call `convert`"

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2758,11 +2758,6 @@ The syntax `@atomic max(a().b, c)` returns `modifyproperty!(a(), :b,
 max, c, :sequentially_consistent))`, where the first argument must be a
 `getfield` expression and is modified atomically.
 
-Unlike [`setproperty!`](@ref Base.setproperty!), the default implementation of
-`modifyproperty!` does not call `convert` automatically.  Thus, `op` must return a value
-that can be stored in the field `f` directly when invoking the default `modifyproperty!`
-implementation.
-
 See also [`modifyfield!`](@ref Core.modifyfield!)
 and [`setproperty!`](@ref Base.setproperty!).
 """


### PR DESCRIPTION
Reverts JuliaLang/julia#45178 for now just in case: https://github.com/JuliaLang/julia/pull/45178#issuecomment-1119595983