### PR TITLE
Avoid race condition in cleaning up cache files

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1575,7 +1575,7 @@ function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, in
                 cachefiles = filter!(x -> startswith(x, entryfile * "_"), readdir(cachepath))
                 if length(cachefiles) >= MAX_NUM_PRECOMPILE_FILES[]
                     idx = findmin(mtime.(joinpath.(cachepath, cachefiles)))[2]
-                    rm(joinpath(cachepath, cachefiles[idx]))
+                    rm(joinpath(cachepath, cachefiles[idx]); force=true)
                 end
             end
 


### PR DESCRIPTION
If multiple processes attempt to clean up cache files at the same time, a race condition can result, e.g.
https://buildkite.com/clima/climaatmos-ci/builds/812#6a961e99-e2a1-488b-a116-2a45dee26d38/102-104