### PR TITLE
WIP: remove `CFG.index` field

### DIFF
--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -505,7 +505,7 @@ function domsort_ssa!(ir::IRCode, domtree::DomTree)
     for i in 1:length(result)
         result[i][:inst] = renumber_ssa!(result[i][:inst], inst_rename, true)
     end
-    cfg = CFG(new_bbs, Int[first(bb.stmts) for bb in new_bbs[2:end]])
+    cfg = CFG(new_bbs)
     new_new_nodes = NewNodeStream(length(ir.new_nodes))
     for i = 1:length(ir.new_nodes)
         new_info = ir.new_nodes.info[i]

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -66,7 +66,7 @@ let cfg = CFG(BasicBlock[
     make_bb([1]    , [4]   ),
     make_bb([2, 3] , [5]   ),
     make_bb([2, 4] , []    ),
-], Int[])
+])
     dfs = Compiler.DFS(cfg.blocks)
     @test dfs.from_pre[dfs.to_parent_pre[dfs.to_pre[5]]] == 4
     let correct_idoms = Compiler.naive_idoms(cfg.blocks)
@@ -80,7 +80,7 @@ let cfg = CFG(BasicBlock[
                 b && (blocks[2] = make_bb(blocks[2].preds, reverse(blocks[2].succs)))
                 c && (blocks[4] = make_bb(reverse(blocks[4].preds), blocks[4].succs))
                 d && (blocks[5] = make_bb(reverse(blocks[5].preds), blocks[5].succs))
-                cfg′ = CFG(blocks, cfg.index)
+                cfg′ = CFG(blocks)
                 @test Compiler.construct_domtree(cfg′.blocks).idoms_bb == correct_idoms
             end
         end
@@ -119,7 +119,7 @@ let cfg = CFG(BasicBlock[
     make_bb([]        , [4]   ), # should be removed
     make_bb([0, 1, 2] , [5]   ), # 0 predecessor should be preserved
     make_bb([2, 3]    , []    ),
-], Int[])
+])
     insts = Compiler.InstructionStream([], [], Any[], Int32[], UInt8[])
     code = Compiler.IRCode(insts, cfg, LineInfoNode[], [], Expr[], [])
     compact = Compiler.IncrementalCompact(code, true)
@@ -259,7 +259,7 @@ let cfg = CFG(BasicBlock[
         make_bb([3],    [6]),
         make_bb([2, 6], []),
         make_bb([4],    [5, 3]),
-    ], Int[])
+    ])
     domtree = Compiler.construct_domtree(cfg.blocks)
     @test domtree.dfs_tree.to_pre == [1, 2, 4, 5, 3, 6]
     @test domtree.idoms_bb == Compiler.naive_idoms(cfg.blocks) == [0, 1, 1, 3, 1, 4]


### PR DESCRIPTION
Also avoids collecting an sorted array from `bb_starts::BitSet` as it is
already sorted.

---

WIP since there seems to be few cases that turn out to be invalid by this change, especially within `compiler/codegen` test case.