### PR TITLE
doc: clarify edge cases when converting rational to float

### DIFF
--- a/doc/src/manual/complex-and-rational-numbers.md
+++ b/doc/src/manual/complex-and-rational-numbers.md
@@ -254,7 +254,7 @@ julia> float(3//4)
 ```
 
 Conversion from rational to floating-point respects the following identity for any integral values
-of `a` and `b`, with the exception of the case `a == 0` and `b == 0`:
+of `a` and `b`, with the exception of the two cases `b == 0` and `a == 0 && b < 0`:
 
 ```jldoctest
 julia> a = 1; b = 2;


### PR DESCRIPTION
We state that for any integral `a` and `b`, the expression
`isequal(float(a//b), a/b)` is true unless `a` and `b` are zero.
This is confusing because there are two such cases, which both require
only one of `a` or `b` to be zero. The first case is the division
by zero and the second case uses a negative divisor to make float
division evaluate to -0.0 which has no equivalent rational number:

	julia> isequal(float(0//-1), 0/-1)
	false

Clarify the conditions of the exceptional cases.
