### PR TITLE
State why we redefine `extrema`

### DIFF
--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -141,8 +141,10 @@ include("compiler/abstractinterpretation.jl")
 include("compiler/typeinfer.jl")
 include("compiler/optimize.jl") # TODO: break this up further + extract utilities
 
-# required for bootstrap
-# TODO: find why this is needed and remove it.
+# required for bootstrap because sort.jl uses extrema
+# to decide whether to dispatch to counting sort.
+#
+# TODO: remove it.
 function extrema(x::Array)
     isempty(x) && throw(ArgumentError("collection must be non-empty"))
     vmin = vmax = x[1]


### PR DESCRIPTION
Used right here: https://github.com/JuliaLang/julia/blob/6e061322438f13c6548200f115f3c31b20860a30/base/sort.jl#L1108
I hope to remove this eventually but, until then, this is half the TODO.