### PR TITLE
Add test for AbstractString ends/startswith

### DIFF
--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -435,6 +435,9 @@ end
         @test all(x -> x == "12", svec)
         @test svec isa Vector{AbstractString}
     end
+    # test startswith and endswith for AbstractString
+    @test endswith(GenericString("abcd"), GenericString("cd"))
+    @test startswith(GenericString("abcd"), GenericString("ab"))
 end
 
 @testset "issue #10307" begin


### PR DESCRIPTION
Coverage shows the `endswith` method isn't tested. 