### PR TITLE
Revert "make simd loop over ranges perform better (#28166)"

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -687,11 +687,6 @@ step_hp(r::AbstractRange) = step(r)
 
 axes(r::AbstractRange) = (oneto(length(r)),)
 
-# Needed to fold the `firstindex` call in SimdLoop.simd_index
-firstindex(::UnitRange) = 1
-firstindex(::StepRange) = 1
-firstindex(::LinRange) = 1
-
 # n.b. checked_length for these is defined iff checked_add and checked_sub are
 # defined between the relevant types
 function checked_length(r::OrdinalRange{T}) where T


### PR DESCRIPTION
>Arguably it would be better to try to figure out why it cannot be folded but it is a quite deep chain of calls...

I think someone somewhere has fixed this upstream since 2018. To whom it may concern, thanks!

```julia
julia> using BenchmarkTools

julia> function perf_sumlinear_view(A)
           s = zero(eltype(A))
           @inbounds @simd for I in 1:length(A)
               val = view(A, I)
               s += val[]
           end
           return s
       end
perf_sumlinear_view (generic function with 1 method)

julia> A = 1:1000000
1:1000000

julia> B = 1:2:1000000
1:2:999999

julia> C = LinRange(1, 1000, 1000000)
1000000-element LinRange{Float64, Int64}:
 1.0, 1.001, 1.002, 1.003, 1.004, 1.005, 1.00599, 1.00699, 1.00799, 1.00899, 1.00999, …, 999.993, 999.994, 999.995, 999.996, 999.997, 999.998, 999.999, 1000.0

julia> @btime perf_sumlinear_view(A)
  25.040 ns (1 allocation: 16 bytes)
500000500000

julia> @btime perf_sumlinear_view(B)
  5.569 ms (1 allocation: 16 bytes)
250000000000

julia> @btime perf_sumlinear_view(C)
  763.762 μs (1 allocation: 16 bytes)
5.005e8

julia> Base.delete_method(@which firstindex(A))

julia> Base.delete_method(@which firstindex(B))

julia> Base.delete_method(@which firstindex(C))

julia> @btime perf_sumlinear_view(A)
  24.878 ns (1 allocation: 16 bytes)
500000500000

julia> @btime perf_sumlinear_view(B)
  5.569 ms (1 allocation: 16 bytes)
250000000000

julia> @btime perf_sumlinear_view(C)
  763.826 μs (1 allocation: 16 bytes)
5.005e8
```

Fixes #45223