### PR TITLE
Docstring for `outer` keyword

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -807,9 +807,7 @@ iterating over a sequence of values.
 
 The iteration variable is always a new variable, even if a variable of the same name
 exists in the enclosing scope.  
-Use `outer` to reuse an existing local variable for iteration.
-
-See also [`outer`](@ref).
+Use [`outer`](@ref) to reuse an existing local variable for iteration.
 
 # Examples
 ```jldoctest

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -806,7 +806,7 @@ kw"?", kw"?:"
 iterating over a sequence of values.
 
 The iteration variable is always a new variable, even if a variable of the same name
-exists in the enclosing scope.  
+exists in the enclosing scope.
 Use [`outer`](@ref) to reuse an existing local variable for iteration.
 
 # Examples

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -280,6 +280,53 @@ julia> z
 kw"global"
 
 """
+    for outer
+
+Reuse an existing local variable for iteration in a `for` loop.
+
+See the [manual section on variable scoping](@ref scope-of-variables) for more information.
+
+See also [`for`](@ref).
+
+
+# Examples
+```jldoctest
+julia> function f()
+           i = 0
+           for i = 1:3
+               # empty
+           end
+           return i
+       end;
+
+julia> f()
+0
+```
+
+```jldoctest
+julia> function f()
+           i = 0
+           for outer i = 1:3
+               # empty
+           end
+           return i
+       end;
+
+julia> f()
+3
+```
+
+```jldoctest
+julia> i = 0 # global variable
+       for outer i = 1:3
+       end
+ERROR: syntax: no outer local variable declaration exists for "for outer"
+[...]
+```
+"""
+kw"outer"
+
+"""
     ' '
 
 A pair of single-quote characters delimit a [`Char`](@ref) (that is, character) literal.
@@ -757,6 +804,12 @@ kw"?", kw"?:"
 
 `for` loops repeatedly evaluate a block of statements while
 iterating over a sequence of values.
+
+The iteration variable is always a new variable, even if a variable of the same name
+exists in the enclosing scope.  
+Use `outer` to reuse an existing local variable for iteration.
+
+See also [`outer`](@ref).
 
 # Examples
 ```jldoctest

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -59,8 +59,8 @@ However, you can create variables with names:
 Finally:
 `where` is parsed as an infix operator for writing parametric method and type definitions;
 `in` and `isa` are parsed as infix operators;
-and `outer` is parsed as a keyword when used to modify the scope of a variable in an iteration specification of a `for` loop or `generator` expression.
-Creation of variables named `where`, `in`, `isa` or `outer` is allowed though.
+and `outer` is parsed as a keyword when used to modify the scope of a variable in an iteration specification of a `for` loop.
+Creation of variables named `where`, `in`, `isa` or `outer` is allowed though.  
 
 ```@docs
 module

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -85,6 +85,7 @@ finally
 quote
 local
 global
+outer
 const
 struct
 mutable struct

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -60,7 +60,7 @@ Finally:
 `where` is parsed as an infix operator for writing parametric method and type definitions;
 `in` and `isa` are parsed as infix operators;
 and `outer` is parsed as a keyword when used to modify the scope of a variable in an iteration specification of a `for` loop.
-Creation of variables named `where`, `in`, `isa` or `outer` is allowed though.  
+Creation of variables named `where`, `in`, `isa` or `outer` is allowed though.
 
 ```@docs
 module

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -388,15 +388,13 @@ loop. Here is an example of a `while` loop:
 ```jldoctest
 julia> i = 1;
 
-julia> while i <= 5
+julia> while i <= 3
            println(i)
            global i += 1
        end
 1
 2
 3
-4
-5
 ```
 
 The `while` loop evaluates the condition expression (`i <= 5` in this case), and as long it remains
@@ -408,17 +406,15 @@ down like the above `while` loop does is so common, it can be expressed more con
 `for` loop:
 
 ```jldoctest
-julia> for i = 1:5
+julia> for i = 1:3
            println(i)
        end
 1
 2
 3
-4
-5
 ```
 
-Here the `1:5` is a range object, representing the sequence of numbers 1, 2, 3, 4, 5. The `for`
+Here the `1:3` is a range object, representing the sequence of numbers 1, 2, 3. The `for`
 loop iterates through these values, assigning each one in turn to the variable `i`. One rather
 important distinction between the previous `while` loop form and the `for` loop form is the scope
 during which the variable is visible. A `for` loop always introduces a new iteration variable in
@@ -429,31 +425,26 @@ You'll either need a new interactive session instance or a different variable
 name to test this:
 
 ```jldoctest
-julia> for j = 1:5
+julia> for j = 1:3
            println(j)
        end
 1
 2
 3
-4
-5
 
 julia> j
 ERROR: UndefVarError: j not defined
 ```
 
 ```jldoctest
-julia> j = 0
-0
+julia> j = 0;
 
-julia> for j = 1:5
+julia> for j = 1:3
            println(j)
        end
 1
 2
 3
-4
-5
 
 julia> j
 0
@@ -496,7 +487,7 @@ julia> i = 1;
 
 julia> while true
            println(i)
-           if i >= 5
+           if i >= 3
                break
            end
            global i += 1
@@ -504,20 +495,16 @@ julia> while true
 1
 2
 3
-4
-5
 
 julia> for j = 1:1000
            println(j)
-           if j >= 5
+           if j >= 3
                break
            end
        end
 1
 2
 3
-4
-5
 ```
 
 Without the `break` keyword, the above `while` loop would never terminate on its own, and the `for` loop would iterate up to 1000. These loops are both exited early by using `break`.

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -421,9 +421,11 @@ julia> for i = 1:5
 Here the `1:5` is a range object, representing the sequence of numbers 1, 2, 3, 4, 5. The `for`
 loop iterates through these values, assigning each one in turn to the variable `i`. One rather
 important distinction between the previous `while` loop form and the `for` loop form is the scope
-during which the variable is visible. If the variable `i` has not been introduced in another
-scope, in the `for` loop form, it is visible only inside of the `for` loop, and not
-outside/afterwards. You'll either need a new interactive session instance or a different variable
+during which the variable is visible. A `for` loop always introduces a new iteration variable in
+its body, regardless of whether a variable of the same name exists in the enclosing scope.
+This implies that on the one hand `i` need not be declared before the loop. On the other hand it
+will not be visible outside the loop, nor will an outside variable of the same name be affected.
+You'll either need a new interactive session instance or a different variable
 name to test this:
 
 ```jldoctest
@@ -440,7 +442,26 @@ julia> j
 ERROR: UndefVarError: j not defined
 ```
 
-See [Scope of Variables](@ref scope-of-variables) for a detailed explanation of variable scope and how it works in
+```jldoctest
+julia> j = 0
+0
+
+julia> for j = 1:5
+           println(j)
+       end
+1
+2
+3
+4
+5
+
+julia> j
+0
+```
+
+Use `for outer` to modify the latter behavior and reuse an existing local variable.
+
+See [Scope of Variables](@ref scope-of-variables) for a detailed explanation of variable scope, [`outer`](@ref), and how it works in
 Julia.
 
 In general, the `for` loop construct can iterate over any container. In these cases, the alternative


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/37492

Add a keyword docstring to `outer`.

The [manual claims](https://docs.julialang.org/en/v1.9-dev/base/base/#Keywords) that `outer` is valid in generator expressions, yet
```julia
julia> let
        i = 0
        [i^2 for outer i = 1:5]
        i
        end
ERROR: syntax: invalid assignment location "(outer i)" around REPL[85]:3
Stacktrace:
 [1] top-level scope
   @ REPL[85]:1
```
Remove that passage from the docs.  Maybe I misunderstand how `outer` is supposed to work here.


