### PR TITLE
Revert "Enable manual shrinkage of Dict"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,9 +54,9 @@ Library changes
   tasks mutating the dictionary or set ([#44534]).
 * Predicate function negation `!f` now returns a composed function `(!) ∘ f` instead of an anonymous function ([#44752]).
 * `RoundFromZero` now works for non-`BigFloat` types ([#41246]).
-* `Dict` can be now shrunk manually by `sizehint!` ([#45004]).
 * `@time` now separates out % time spent recompiling invalidated methods ([#45015]).
 * `@time_imports` now shows any compilation and recompilation time percentages per import ([#45064]).
+
 
 Standard library changes
 ------------------------

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -240,10 +240,16 @@ end
 function sizehint!(d::Dict{T}, newsz) where T
     oldsz = length(d.slots)
     # limit new element count to max_values of the key type
-    newsz = min(max(newsz, length(d)), max_values(T)::Int)
+    newsz = min(newsz, max_values(T)::Int)
     # need at least 1.5n space to hold n elements
-    newsz = _tablesz(cld(3 * newsz, 2))
-    return newsz == oldsz ? d : rehash!(d, newsz)
+    newsz = cld(3 * newsz, 2)
+    if newsz <= oldsz
+        # todo: shrink
+        # be careful: rehash!() assumes everything fits. it was only designed
+        # for growing.
+        return d
+    end
+    rehash!(d, newsz)
 end
 
 """

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1252,10 +1252,3 @@ end
 let c = bar()
     @test c === missing || c == ComparesWithGC38727(1)
 end
-
-@testset "shrinking" begin
-    d = Dict(i => i for i = 1:1000)
-    filter!(x -> x.first < 10, d)
-    sizehint!(d, 10)
-    @test length(d.slots) < 100
-end


### PR DESCRIPTION
Reverts JuliaLang/julia#45004

---

Quoting @aviatesk in [this comment](https://github.com/JuliaLang/julia/pull/45004#issuecomment-1120707326):

> Bisected this commit seems to have introduced the regression within `collection` benchmark suite. See [8c61f40#commitcomment-73182869](https://github.com/JuliaLang/julia/commit/8c61f404385073bbb6d60c7768cb9bd3074b6135#commitcomment-73182869) for the regressed examples.