### PR TITLE
add a `.git-blame-ignore-revs` file and populate it with a few commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,7 @@
-# Some whitespace formatting fixes
+# .git-blame-ignore-revs
+# whitespace: end text files with single newlines
 3903fa54a638d4546ef50e56f91f0705a8ab11ef
+# whitespace: use only UNIX line endings (\n)
 e66bfa5dd32f93e76068c00ad882c1fc839c5af8
+# whitespace: replace non-breaking space => space
 100a741e7ab38c91d48cc929bb001afc8e09261f

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# Some whitespace formatting fixes
+3903fa54a638d4546ef50e56f91f0705a8ab11ef
+e66bfa5dd32f93e76068c00ad882c1fc839c5af8
+100a741e7ab38c91d48cc929bb001afc8e09261f


### PR DESCRIPTION
GitHub supports hiding commits from showing up in the diff view (https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file\#ignore-commits-in-the-blame-view). This is useful to hide commits that made (automatic) style/whitespace changes that would otherwise clutter up the blame view.

Commits added:
3903fa54a638d4546ef50e56f91f0705a8ab11ef
e66bfa5dd32f93e76068c00ad882c1fc839c5af8
100a741e7ab38c91d48cc929bb001afc8e09261f