### PR TITLE
mention Ref for scalarizing a broadcast argument

### DIFF
--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -1076,7 +1076,7 @@ julia> string.(1:3, ". ", ["First", "Second", "Third"])
 
 Sometimes, you want a container (like an array) that would normally participate in broadcast to be "protected"
 from broadcast's behavior of iterating over all of its elements. By placing it inside another container,
-like a single element [`Tuple`](@ref) or a [`Ref`](@ref) (which acts like a 0-dimensional array), broadcast will treat it as a single value.
+like a single-element [`Tuple`](@ref) or a [`Ref`](@ref) (which acts like a 0-dimensional array), broadcast will treat it as a single value rather than as a container.
 ```jldoctest
 julia> ([1, 2, 3], [4, 5, 6]) .+ ([1, 2, 3],)
 ([2, 4, 6], [5, 7, 9])

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -1075,13 +1075,13 @@ julia> string.(1:3, ". ", ["First", "Second", "Third"])
 ```
 
 Sometimes, you want a container (like an array) that would normally participate in broadcast to be "protected"
-from broadcast's behavior of iterating over all of its elements. By placing it inside another container
-(like a single element [`Tuple`](@ref)) broadcast will treat it as a single value.
+from broadcast's behavior of iterating over all of its elements. By placing it inside another container,
+like a single element [`Tuple`](@ref) or a [`Ref`](@ref) (which acts like a 0-dimensional array), broadcast will treat it as a single value.
 ```jldoctest
 julia> ([1, 2, 3], [4, 5, 6]) .+ ([1, 2, 3],)
 ([2, 4, 6], [5, 7, 9])
 
-julia> ([1, 2, 3], [4, 5, 6]) .+ tuple([1, 2, 3])
+julia> ([1, 2, 3], [4, 5, 6]) .+ Ref([1, 2, 3])
 ([2, 4, 6], [5, 7, 9])
 ```
 


### PR DESCRIPTION
The manual mentions tuples for treating a broadcast argument as a scalar, but it doesn't mention `Ref` (which seems to be quite common, and is even mentioned in the docstring for `Ref`).