### PR TITLE
Fix missing codeblock in `donotdelete` docs

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -3000,7 +3000,7 @@ unused and delete the entire benchmark code).
 
 # Examples
 
-```
+```julia
 function loop()
     for i = 1:1000
         # The complier must guarantee that there are 1000 program points (in the correct

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -3000,6 +3000,7 @@ unused and delete the entire benchmark code).
 
 # Examples
 
+```
 function loop()
     for i = 1:1000
         # The complier must guarantee that there are 1000 program points (in the correct
@@ -3008,6 +3009,7 @@ function loop()
         donotdelete(i)
     end
 end
+```
 """
 Base.donotdelete
 


### PR DESCRIPTION
The triple backticks were missing.

Not sure if that's sufficient for the block to show up in the docs - should though. Please let me know if it's not sufficient.