### PR TITLE
Test for setting/getting rounding for F32 and F64

### DIFF
--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -341,3 +341,13 @@ end
         @test f.(a, digits=9, base = 2) == map(x->f(x, digits=9, base = 2), a)
     end
 end
+
+@testset "rounding for F32/F64" begin
+    for T in [Float32, Float64]
+        old = rounding(T)
+        Base.Rounding.setrounding_raw(T, Base.Rounding.JL_FE_TOWARDZERO)
+        @test rounding(T) == RoundToZero
+        @test round(T(2.7)) == T(2.0)
+        Base.Rounding.setrounding_raw(T, Base.Rounding.to_fenv(old))
+    end
+end


### PR DESCRIPTION
Note that `setrounding(T, mode)` only works when `T == BigFloat`. However we have these raw methods defined for `Float32` and `Float64`, and they're untested, so here are some simple tests for them.