### PR TITLE
Fix LLVM IR dumping in `jl_dump_function_ir`

### DIFF
--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -497,7 +497,7 @@ jl_value_t *jl_dump_function_ir_impl(void *f, char strip_ir_metadata, char dump_
 
     {
         std::unique_ptr<jl_llvmf_dump_t> dump(static_cast<jl_llvmf_dump_t*>(f));
-        dump->TSM.withModuleDo([&](Module &m) {
+        dump->TSM->withModuleDo([&](Module &m) {
             Function *llvmf = dump->F;
             if (!llvmf || (!llvmf->isDeclaration() && !llvmf->getParent()))
                 jl_error("jl_dump_function_ir: Expected Function* in a temporary Module");
@@ -1203,7 +1203,7 @@ jl_value_t *jl_dump_function_asm_impl(void *F, char raw_mc, const char* asm_vari
         Function *f = dump->F;
         llvm::raw_svector_ostream asmfile(ObjBufferSV);
         assert(!f->isDeclaration());
-        dump->TSM.withModuleDo([&](Module &m) {
+        dump->TSM->withModuleDo([&](Module &m) {
             for (auto &f2 : m.functions()) {
                 if (f != &f2 && !f->isDeclaration())
                     f2.deleteBody();
@@ -1217,7 +1217,7 @@ jl_value_t *jl_dump_function_asm_impl(void *F, char raw_mc, const char* asm_vari
             raw_svector_ostream obj_OS(ObjBufferSV);
             if (TM->addPassesToEmitFile(PM, obj_OS, nullptr, CGFT_ObjectFile, false, nullptr))
                 return jl_an_empty_string;
-            dump->TSM.withModuleDo([&](Module &m) { PM.run(m); });
+            dump->TSM->withModuleDo([&](Module &m) { PM.run(m); });
         }
         else {
             MCContext *Context = addPassesToGenerateCode(TM, PM);
@@ -1261,7 +1261,7 @@ jl_value_t *jl_dump_function_asm_impl(void *F, char raw_mc, const char* asm_vari
                 return jl_an_empty_string;
             PM.add(Printer.release());
             PM.add(createFreeMachineFunctionPass());
-            dump->TSM.withModuleDo([&](Module &m){ PM.run(m); });
+            dump->TSM->withModuleDo([&](Module &m){ PM.run(m); });
         }
     }
     return jl_pchar_to_string(ObjBufferSV.data(), ObjBufferSV.size());

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -115,7 +115,7 @@ struct jl_returninfo_t {
 };
 
 struct jl_llvmf_dump_t {
-    orc::ThreadSafeModule TSM;
+    orc::ThreadSafeModule *TSM;
     Function *F;
 };
 


### PR DESCRIPTION
Some recent changes seem to have broken the C compatibility of `jl_dump_function_ir` by passing C++ objects by-value through `jl_llvmf_dump_t`. This PR instead passes a pointer to the object in question, which we can construct via LLVM's C APIs.

Needed for https://github.com/JuliaGPU/GPUCompiler.jl/pull/324

@pchintalapudi @vchuravy I would appreciate scrutiny on the changes to `aotcompile.cpp`. I couldn't figure out what the right alternative to `std::move` is when we want to be able to preserve the new TSM over the C call boundary.