### PR TITLE
add special case for findlast on tuples of length >= 32, fixes #45117

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -418,7 +418,12 @@ function _findfirst_loop(f::Function, t)
     return nothing
 end
 findfirst(f::Function, t::Tuple) = length(t) < 32 ? _findfirst_rec(f, 1, t) : _findfirst_loop(f, t)
-findlast(f::Function, t::Tuple) = length(t) < 32 ? findfirst(f, reverse(t)) : _findlast_loop(f, t)
+
+findlast(f::Function, t::Tuple) = length(t) < 32 ? _findlast_rec(f, t) : _findlast_loop(f, t)
+function _findlast_rec(f::Function, x::Tuple)
+    r = findfirst(f, reverse(x))
+    return isnothing(r) ? r : length(x) - r + 1
+end
 function _findlast_loop(f::Function, t)
     for i in reverse(1:length(t))
         f(t[i]) && return i

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -418,10 +418,12 @@ function _findfirst_loop(f::Function, t)
     return nothing
 end
 findfirst(f::Function, t::Tuple) = length(t) < 32 ? _findfirst_rec(f, 1, t) : _findfirst_loop(f, t)
-
-function findlast(f::Function, x::Tuple)
-    r = findfirst(f, reverse(x))
-    return isnothing(r) ? r : length(x) - r + 1
+findlast(f::Function, t::Tuple) = length(t) < 32 ? findfirst(f, reverse(t)) : _findlast_loop(f, t)
+function _findlast_loop(f::Function, t)
+    for i in reverse(1:length(t))
+        f(t[i]) && return i
+    end
+    return nothing
 end
 
 ## filter ##

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -568,6 +568,12 @@ end
     @test Base.return_types() do
         findlast(==(0), (1.0,2,3f0))
     end == Any[Nothing]
+
+    @testset "long tuples" begin
+        longtuple = ntuple(i -> i in (15,17) ? 1 : 0, 40)
+        @test findfirst(isequal(1), longtuple) == 15
+        @test findlast(isequal(1), longtuple) == 17
+    end
 end
 
 @testset "properties" begin


### PR DESCRIPTION
This PR fixes issue #45117.

The problem was that `findfirst` has a special case `_findfirst_loop` for tuples of length >= 32, whereas `findlast` always call `findfirst(f, reverse(t))`. Since `reverse(t)` involves a splat, performance rapidly drops at 32 elements.

This PR simply adds a corresponding method `_findlast_loop` that loops over tuples of length >= 32 instead of splatting.

<details>
<summary> Benchmarks </summary>

```
using BenchmarkTools

symvector = collect(Symbol.("a" * string(i) for i = 1:36));
symtuple = Tuple(symvector);
firstsym = :a1;
lastsym = :a36;
@btime findlast(==($lastsym), $symtuple);
@btime findlast(==($lastsym), $(symtuple[1:32]));
@btime findlast(==($lastsym), $(symtuple[1:33]));

# before PR
# 11.940 μs (72 allocations: 6.47 KiB)
# 125.766 ns (0 allocations: 0 bytes)
# 10.490 μs (66 allocations: 5.53 KiB)

# after PR
# 2.349 ns (0 allocations: 0 bytes)
# 9.279 ns (0 allocations: 0 bytes)
# 9.699 ns (0 allocations: 0 bytes)
```

</details>