### PR TITLE
add bswap(x::Bool)=x

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -387,7 +387,7 @@ julia> string(bswap(1), base = 2)
 "100000000000000000000000000000000000000000000000000000000"
 ```
 """
-bswap(x::Union{Int8, UInt8}) = x
+bswap(x::Union{Int8, UInt8, Bool}) = x
 bswap(x::Union{Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128}) =
     bswap_int(x)
 

--- a/test/int.jl
+++ b/test/int.jl
@@ -70,6 +70,7 @@ end
     @test unsigned(Bool) === typeof(unsigned(true))
 end
 @testset "bswap" begin
+    @test bswap(true) == true
     @test bswap(Int8(3)) == 3
     @test bswap(UInt8(3)) === 0x3
     @test bswap(Int16(3)) == 256*3


### PR DESCRIPTION
This seems like a minor oversight?

(Noticed in thinking about automated recursive `ntoh` for structs [here](https://discourse.julialang.org/t/change-endianness-in-reinterpret/80815/4?u=stevengj).)