### PR TITLE
Improve docstring for `Core.Symbol`

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1970,9 +1970,8 @@ julia> eval(:x)
 `Symbol`s can also be constructed from strings or other values by calling the
 constructor `Symbol(x...)`.
 
-`Symbol`s are immutable and should be compared using `===`.
-The implementation re-uses the same object for all `Symbol`s with the same name,
-so comparison tends to be efficient (it can just compare pointers).
+`Symbol`s are immutable and their implementation re-uses the same object for all `Symbol`s
+with the same name.
 
 Unlike strings, `Symbol`s are "atomic" or "scalar" entities that do not support
 iteration over characters.


### PR DESCRIPTION
I have slightly modified the docstring for `Core.Symbol`. The removed line possibly misled new users to do something like:
```
function comp(a::Symbol)
    return a === :b || :c 
end
```
For the following function call, an error is thrown:
```
comp(:c) #TypeError: non-boolean (Symbol) used in boolean context
```
The correct way would be to rather define the function as:
```
function comp(a::Symbol)
    return a in (:b, :c) 
end
```
Thanks @oscardssmith for the clarification.