### PR TITLE
inference: refactor the core loops to use less memory

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2251,15 +2251,21 @@ end
 
 @inline function update_bbstate!(frame::InferenceState, bb::Int, vartable::VarTable)
     bbtable = frame.bb_vartables[bb]
-    if bb in frame.analyzed_bbs
-        newstate = stupdate!(bbtable, vartable)
-    else
+    if bbtable === nothing
         # if a basic block hasn't been analyzed yet,
         # we can update its state a bit more aggressively
-        newstate = stoverwrite!(bbtable, vartable)
-        push!(frame.analyzed_bbs, bb)
+        return frame.bb_vartables[bb] = copy(vartable)
+    else
+        return stupdate!(bbtable, vartable)
     end
-    return newstate
+end
+
+function init_vartable!(vartable::VarTable, frame::InferenceState)
+    nargtypes = length(frame.result.argtypes)
+    for i = 1:length(vartable)
+        vartable[i] = VarState(Bottom, i > nargtypes)
+    end
+    return vartable
 end
 
 # make as much progress on `frame` as possible (without handling cycles)
@@ -2281,7 +2287,7 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
     end
 
     states = frame.bb_vartables
-    currstate = copy(states[currbb])
+    currstate = copy(states[currbb]::VarTable)
     while currbb <= nbbs
         delete!(W, currbb)
         bbstart = first(bbs[currbb].stmts)
@@ -2430,7 +2436,7 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
                         # propagate new type info to exception handler
                         # the handling for Expr(:enter) propagates all changes from before the try/catch
                         # so this only needs to propagate any changes
-                        if stupdate1!(states[exceptbb], changes)
+                        if stupdate1!(states[exceptbb]::VarTable, changes)
                             push!(W, exceptbb)
                         end
                         cur_hand = frame.handler_at[cur_hand]
@@ -2467,7 +2473,12 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
             currbb == -1 && break # the working set is empty
             currbb > nbbs && break
 
-            stoverwrite!(currstate, states[currbb])
+            nexttable = states[currbb]
+            if nexttable === nothing
+                init_vartable!(currstate, frame)
+            else
+                stoverwrite!(currstate, nexttable)
+            end
         end
     end # while currbb <= nbbs
 

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2251,7 +2251,7 @@ end
     end
 end
 
-@inline function update_bbstate!(frame::InferenceState, bb::Int, vartable::VarTable)
+function update_bbstate!(frame::InferenceState, bb::Int, vartable::VarTable)
     bbtable = frame.bb_vartables[bb]
     if bbtable === nothing
         # if a basic block hasn't been analyzed yet,

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2200,196 +2200,262 @@ function handle_control_backedge!(frame::InferenceState, from::Int, to::Int)
     return nothing
 end
 
+struct BasicStmtChange
+    changes::Union{Nothing,StateUpdate}
+    type::Any # ::Union{Type, Nothing} - `nothing` if this statement may not be used as an SSA Value
+    # TODO effects::Effects
+    BasicStmtChange(changes::Union{Nothing,StateUpdate}, @nospecialize type) = new(changes, type)
+end
+
+@inline function abstract_eval_basic_statement(interp::AbstractInterpreter,
+    @nospecialize(stmt), pc_vartable::VarTable, frame::InferenceState)
+    if isa(stmt, NewvarNode)
+        changes = StateUpdate(stmt.slot, VarState(Bottom, true), pc_vartable, false)
+        return BasicStmtChange(changes, nothing)
+    elseif !isa(stmt, Expr)
+        t = abstract_eval_statement(interp, stmt, pc_vartable, frame)
+        return BasicStmtChange(nothing, t)
+    end
+    changes = nothing
+    stmt = stmt::Expr
+    hd = stmt.head
+    if hd === :(=)
+        t = abstract_eval_statement(interp, stmt.args[2], pc_vartable, frame)
+        if t === Bottom
+            return BasicStmtChange(nothing, Bottom)
+        end
+        lhs = stmt.args[1]
+        if isa(lhs, SlotNumber)
+            changes = StateUpdate(lhs, VarState(t, false), pc_vartable, false)
+        elseif isa(lhs, GlobalRef)
+            handle_global_assignment!(interp, frame, lhs, t)
+        elseif !isa(lhs, SSAValue)
+            tristate_merge!(frame, EFFECTS_UNKNOWN)
+        end
+        return BasicStmtChange(changes, t)
+    elseif hd === :method
+        fname = stmt.args[1]
+        if isa(fname, SlotNumber)
+            changes = StateUpdate(fname, VarState(Any, false), pc_vartable, false)
+        end
+        return BasicStmtChange(changes, nothing)
+    elseif (hd === :code_coverage_effect || (
+            hd !== :boundscheck && # :boundscheck can be narrowed to Bool
+            is_meta_expr(stmt)))
+        return BasicStmtChange(nothing, Nothing)
+    else
+        t = abstract_eval_statement(interp, stmt, pc_vartable, frame)
+        return BasicStmtChange(nothing, t)
+    end
+end
+
 # make as much progress on `frame` as possible (without handling cycles)
 function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
     @assert !frame.inferred
     frame.dont_work_on_me = true # mark that this function is currently on the stack
     W = frame.ip
-    states = frame.stmt_types
     def = frame.linfo.def
     isva = isa(def, Method) && def.isva
     nargs = length(frame.result.argtypes) - isva
     slottypes = frame.slottypes
     ssavaluetypes = frame.src.ssavaluetypes::Vector{Any}
-    while !isempty(W)
-        # make progress on the active ip set
-        local pc::Int = popfirst!(W)
-        local pc´::Int = pc + 1 # next program-counter (after executing instruction)
-        frame.currpc = pc
-        edges = frame.stmt_edges[pc]
-        edges === nothing || empty!(edges)
-        frame.stmt_info[pc] = nothing
-        stmt = frame.src.code[pc]
-        changes = states[pc]::VarTable
-        t = nothing
+    bbs = frame.cfg.blocks
+    nbbs = length(bbs)
 
-        hd = isa(stmt, Expr) ? stmt.head : nothing
+    if frame.currbb != 1
+        frame.currbb = _bits_findnext(W.bits, 1)::Int # next basic block
+    end
 
-        if isa(stmt, NewvarNode)
-            sn = slot_id(stmt.slot)
-            changes[sn] = VarState(Bottom, true)
-        elseif isa(stmt, GotoNode)
-            l = (stmt::GotoNode).label
-            handle_control_backedge!(frame, pc, l)
-            pc´ = l
-        elseif isa(stmt, GotoIfNot)
-            condx = stmt.cond
-            condt = abstract_eval_value(interp, condx, changes, frame)
-            if condt === Bottom
-                empty!(frame.pclimitations)
-                continue
-            end
-            if !(isa(condt, Const) || isa(condt, Conditional)) && isa(condx, SlotNumber)
-                # if this non-`Conditional` object is a slot, we form and propagate
-                # the conditional constraint on it
-                condt = Conditional(condx, Const(true), Const(false))
-            end
-            condval = maybe_extract_const_bool(condt)
-            l = stmt.dest::Int
-            if !isempty(frame.pclimitations)
-                # we can't model the possible effect of control
-                # dependencies on the return value, so we propagate it
-                # directly to all the return values (unless we error first)
-                condval isa Bool || union!(frame.limitations, frame.pclimitations)
-                empty!(frame.pclimitations)
-            end
-            # constant conditions
-            if condval === true
-            elseif condval === false
-                handle_control_backedge!(frame, pc, l)
-                pc´ = l
-            else
-                # general case
-                changes_else = changes
-                if isa(condt, Conditional)
-                    changes_else = conditional_changes(changes_else, condt.elsetype, condt.var)
-                    changes      = conditional_changes(changes,      condt.vtype,    condt.var)
-                end
-                newstate_else = stupdate!(states[l], changes_else)
-                if newstate_else !== nothing
-                    handle_control_backedge!(frame, pc, l)
-                    # add else branch to active IP list
-                    push!(W, l)
-                    states[l] = newstate_else
-                end
-            end
-        elseif isa(stmt, ReturnNode)
-            bestguess = frame.bestguess
-            rt = abstract_eval_value(interp, stmt.val, changes, frame)
-            rt = widenreturn(rt, bestguess, nargs, slottypes, changes)
-            # narrow representation of bestguess slightly to prepare for tmerge with rt
-            if rt isa InterConditional && bestguess isa Const
-                let slot_id = rt.slot
-                    old_id_type = slottypes[slot_id]
-                    if bestguess.val === true && rt.elsetype !== Bottom
-                        bestguess = InterConditional(slot_id, old_id_type, Bottom)
-                    elseif bestguess.val === false && rt.vtype !== Bottom
-                        bestguess = InterConditional(slot_id, Bottom, old_id_type)
+    stoverwrite!(frame.pc_vartable, frame.bb_vartables[frame.currbb])
+    while frame.currbb <= nbbs
+        delete!(W, frame.currbb)
+        frame.currpc = first(bbs[frame.currbb].stmts)
+        bbend = last(bbs[frame.currbb].stmts)
+
+        for frame.currpc in frame.currpc:bbend
+            stmt = frame.src.code[frame.currpc]
+            push!(frame.was_reached, frame.currpc)
+            # If we're at the end of the basic block ...
+            if frame.currpc == bbend
+                # Handle control flow
+                if isa(stmt, GotoNode)
+                    succs = bbs[frame.currbb].succs
+                    @assert length(succs) == 1
+                    nextbb = succs[1]
+                    ssavaluetypes[frame.currpc] = Any
+                    handle_control_backedge!(frame, frame.currpc, stmt.label)
+                    @goto branch
+                elseif isa(stmt, GotoIfNot)
+                    condx = stmt.cond
+                    condt = abstract_eval_value(interp, condx, frame.pc_vartable, frame)
+                    if condt === Bottom
+                        empty!(frame.pclimitations)
+                        @goto find_next_bb
                     end
-                end
-            end
-            # copy limitations to return value
-            if !isempty(frame.pclimitations)
-                union!(frame.limitations, frame.pclimitations)
-                empty!(frame.pclimitations)
-            end
-            if !isempty(frame.limitations)
-                rt = LimitedAccuracy(rt, copy(frame.limitations))
-            end
-            if tchanged(rt, bestguess)
-                # new (wider) return type for frame
-                bestguess = tmerge(bestguess, rt)
-                # TODO: if bestguess isa InterConditional && !interesting(bestguess); bestguess = widenconditional(bestguess); end
-                frame.bestguess = bestguess
-                for (caller, caller_pc) in frame.cycle_backedges
-                    # notify backedges of updated type information
-                    typeassert(caller.stmt_types[caller_pc], VarTable) # we must have visited this statement before
-                    if !((caller.src.ssavaluetypes::Vector{Any})[caller_pc] === Any)
-                        # no reason to revisit if that call-site doesn't affect the final result
-                        push!(caller.ip, caller_pc)
+                    if !(isa(condt, Const) || isa(condt, Conditional)) && isa(condx, SlotNumber)
+                        # if this non-`Conditional` object is a slot, we form and propagate
+                        # the conditional constraint on it
+                        condt = Conditional(condx, Const(true), Const(false))
                     end
+                    condval = maybe_extract_const_bool(condt)
+                    if !isempty(frame.pclimitations)
+                        # we can't model the possible effect of control
+                        # dependencies on the return
+                        # directly to all the return values (unless we error first)
+                        condval isa Bool || union!(frame.limitations, frame.pclimitations)
+                        empty!(frame.pclimitations)
+                    end
+                    ssavaluetypes[frame.currpc] = Any
+                    if condval === true
+                        @goto fallthrough
+                    else
+                        succs = bbs[frame.currbb].succs
+                        if length(succs) == 1
+                            @assert condval === false || (stmt.dest === frame.currpc + 1)
+                            nextbb = succs[1]
+                            @goto branch
+                        end
+                        @assert length(succs) == 2
+                        truebb = frame.currbb + 1
+                        falsebb = succs[1] == truebb ? succs[2] : succs[1]
+                        if condval === false
+                            nextbb = falsebb
+                            handle_control_backedge!(frame, frame.currpc, stmt.dest)
+                            @goto branch
+                        else
+                            # We continue with the true branch, but process the false
+                            # branch here.
+                            if isa(condt, Conditional)
+                                newstate = stupdate!(frame.bb_vartables[falsebb], frame.pc_vartable,
+                                    conditional_changes(frame.pc_vartable, condt.elsetype, condt.var))
+                                stoverwrite1!(frame.pc_vartable,
+                                    conditional_changes(frame.pc_vartable, condt.vtype, condt.var))
+                            else
+                                newstate = stupdate!(frame.bb_vartables[falsebb], frame.pc_vartable)
+                            end
+                            if newstate !== nothing || !was_reached(frame, first(bbs[falsebb].stmts))
+                                handle_control_backedge!(frame, frame.currpc, stmt.dest)
+                                push!(W, falsebb)
+                            end
+                            @goto fallthrough
+                        end
+                    end
+                elseif isa(stmt, ReturnNode)
+                    bestguess = frame.bestguess
+                    rt = abstract_eval_value(interp, stmt.val, frame.pc_vartable, frame)
+                    rt = widenreturn(rt, bestguess, nargs, slottypes, frame.pc_vartable)
+                    # narrow representation of bestguess slightly to prepare for tmerge with rt
+                    if rt isa InterConditional && bestguess isa Const
+                        let slot_id = rt.slot
+                            old_id_type = slottypes[slot_id]
+                            if bestguess.val === true && rt.elsetype !== Bottom
+                                bestguess = InterConditional(slot_id, old_id_type, Bottom)
+                            elseif bestguess.val === false && rt.vtype !== Bottom
+                                bestguess = InterConditional(slot_id, Bottom, old_id_type)
+                            end
+                        end
+                    end
+                    # copy limitations to return value
+                    if !isempty(frame.pclimitations)
+                        union!(frame.limitations, frame.pclimitations)
+                        empty!(frame.pclimitations)
+                    end
+                    if !isempty(frame.limitations)
+                        rt = LimitedAccuracy(rt, copy(frame.limitations))
+                    end
+                    if tchanged(rt, bestguess)
+                        # new (wider) return type for frame
+                        bestguess = tmerge(bestguess, rt)
+                        # TODO: if bestguess isa InterConditional && !interesting(bestguess); bestguess = widenconditional(bestguess); end
+                        frame.bestguess = bestguess
+                        for (caller, caller_pc) in frame.cycle_backedges
+                            if !((caller.src.ssavaluetypes::Vector{Any})[caller_pc] === Any)
+                                # no reason to revisit if that call-site doesn't affect the final result
+                                push!(caller.ip, block_for_inst(caller.cfg, caller_pc))
+                            end
+                        end
+                    end
+                    ssavaluetypes[frame.currpc] = Any
+                    @goto find_next_bb
+                elseif isexpr(stmt, :enter)
+                    # Propagate entry info to exception handler
+                    l = stmt.args[1]::Int
+                    catchbb = block_for_inst(frame.cfg, l)
+                    if stupdate!(frame.bb_vartables[catchbb], frame.pc_vartable) !== nothing
+                        push!(W, catchbb)
+                    end
+                    ssavaluetypes[frame.currpc] = Any
+                    @goto fallthrough
                 end
+                # Fall through terminator - treat as regular stmt
             end
-            continue
-        elseif hd === :enter
-            stmt = stmt::Expr
-            l = stmt.args[1]::Int
-            # propagate type info to exception handler
-            old = states[l]
-            newstate_catch = stupdate!(old, changes)
-            if newstate_catch !== nothing
-                push!(W, l)
-                states[l] = newstate_catch
+            # Process non control-flow statements
+            (; changes, type) = abstract_eval_basic_statement(interp,
+                stmt, frame.pc_vartable, frame)
+            if type === Union{}
+                @goto find_next_bb
             end
-            typeassert(states[l], VarTable)
-        elseif hd === :leave
-        else
-            if hd === :(=)
-                stmt = stmt::Expr
-                t = abstract_eval_statement(interp, stmt.args[2], changes, frame)
-                if t === Bottom
-                    continue
-                end
-                ssavaluetypes[pc] = t
-                lhs = stmt.args[1]
-                if isa(lhs, SlotNumber)
-                    changes = StateUpdate(lhs, VarState(t, false), changes, false)
-                elseif isa(lhs, GlobalRef)
-                    handle_global_assignment!(interp, frame, lhs, t)
-                elseif !isa(lhs, SSAValue)
-                    tristate_merge!(frame, EFFECTS_UNKNOWN)
-                end
-            elseif hd === :method
-                stmt = stmt::Expr
-                fname = stmt.args[1]
-                if isa(fname, SlotNumber)
-                    changes = StateUpdate(fname, VarState(Any, false), changes, false)
-                end
-            elseif hd === :code_coverage_effect || (
-                    hd !== :boundscheck && # :boundscheck can be narrowed to Bool
-                    is_meta_expr(stmt))
-                # these do not generate code
-            else
-                t = abstract_eval_statement(interp, stmt, changes, frame)
-                if t === Bottom
-                    continue
-                end
-                if !isempty(frame.ssavalue_uses[pc])
-                    record_ssa_assign(pc, t, frame)
-                else
-                    ssavaluetypes[pc] = t
-                end
-            end
-            if isa(changes, StateUpdate)
-                let cur_hand = frame.handler_at[pc], l, enter
+            if changes !== nothing
+                stoverwrite1!(frame.pc_vartable, changes)
+                let cur_hand = frame.handler_at[frame.currpc], l, enter
                     while cur_hand != 0
-                        enter = frame.src.code[cur_hand]
-                        l = (enter::Expr).args[1]::Int
+                        enter = frame.src.code[cur_hand]::Expr
+                        l = enter.args[1]::Int
+                        exceptbb = block_for_inst(frame.cfg, l)
                         # propagate new type info to exception handler
                         # the handling for Expr(:enter) propagates all changes from before the try/catch
                         # so this only needs to propagate any changes
-                        if stupdate1!(states[l]::VarTable, changes::StateUpdate) !== false
-                            push!(W, l)
+                        if stupdate1!(frame.bb_vartables[exceptbb], changes) || !was_reached(frame, first(bbs[exceptbb].stmts))
+                            push!(frame.ip, exceptbb)
                         end
                         cur_hand = frame.handler_at[cur_hand]
                     end
                 end
             end
+            if type === nothing
+                ssavaluetypes[frame.currpc] = Any
+                continue
+            end
+            if !isempty(frame.ssavalue_uses[frame.currpc])
+                record_ssa_assign!(frame.currpc, type, frame)
+            else
+                ssavaluetypes[frame.currpc] = type
+            end
+        end # for frame.currpc in frame.currpc:bbend
+
+    # Case 1: Fallthrough termination
+    @label fallthrough
+        nextbb = frame.currbb + 1
+
+    # Case 2: Directly branch to a different BB
+    @label branch
+        newstate = stupdate!(frame.bb_vartables[nextbb], frame.pc_vartable)
+        if newstate !== nothing || !was_reached(frame, first(bbs[nextbb].stmts))
+            push!(W, nextbb)
+        end
+        @goto find_next_bb
+
+        # TODO: Restore optimization
+        if nextbb <= nbbs
+            newstate = stupdate!(frame.bb_vartables[nextbb], frame.pc_vartable)
+            if newstate !== nothing
+                frame.currbb = nextbb
+                frame.currpc = first(bbs[nextbb].stmts)
+                stoverwrite!(frame.pc_vartable, newstate)
+                continue
+            end
         end
 
-        @assert isempty(frame.pclimitations) "unhandled LimitedAccuracy"
+    # Case 3: Control flow ended along the current path (converged, return or throw)
+    @label find_next_bb
+        frame.currbb = _bits_findnext(W.bits, 1)::Int # next basic block
+        frame.currbb == -1 && break # the working set is empty
+        frame.currbb > nbbs && break
 
-        if t === nothing
-            # mark other reached expressions as `Any` to indicate they don't throw
-            ssavaluetypes[pc] = Any
-        end
+        frame.currpc = first(bbs[frame.currbb].stmts)
+        stoverwrite!(frame.pc_vartable, frame.bb_vartables[frame.currbb])
+    end # while frame.currbb <= nbbs
 
-        newstate = stupdate!(states[pc´], changes)
-        if newstate !== nothing
-            states[pc´] = newstate
-            push!(W, pc´)
-        end
-    end
     frame.dont_work_on_me = false
     nothing
 end
@@ -2404,7 +2470,7 @@ function conditional_changes(changes::VarTable, @nospecialize(typ), var::SlotNum
         oldtyp isa LimitedAccuracy && (typ = tmerge(typ, LimitedAccuracy(Bottom, oldtyp.causes)))
         return StateUpdate(var, VarState(typ, vtype.undef), changes, true)
     end
-    return changes
+    return nothing
 end
 
 function bool_rt_to_conditional(@nospecialize(rt), slottypes::Vector{Any}, state::VarTable, slot_id::Int)

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2298,6 +2298,7 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
 
         for currpc in bbstart:bbend
             frame.currpc = currpc
+            empty_backedges!(frame, currpc)
             stmt = frame.src.code[currpc]
             # If we're at the end of the basic block ...
             if currpc == bbend

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2058,7 +2058,7 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
         t = Const(t.instance)
     end
     if !isempty(sv.pclimitations)
-        if t isa Const || t === Union{}
+        if t isa Const || t === Bottom
             empty!(sv.pclimitations)
         else
             t = LimitedAccuracy(t, sv.pclimitations)
@@ -2288,7 +2288,6 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
 
         for frame.currpc in frame.currpc:bbend
             stmt = frame.src.code[frame.currpc]
-            push!(frame.was_reached, frame.currpc)
             # If we're at the end of the basic block ...
             if frame.currpc == bbend
                 # Handle control flow
@@ -2303,6 +2302,7 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
                     condx = stmt.cond
                     condt = abstract_eval_value(interp, condx, currstate, frame)
                     if condt === Bottom
+                        ssavaluetypes[frame.currpc] = Bottom
                         empty!(frame.pclimitations)
                         @goto find_next_bb
                     end
@@ -2414,7 +2414,8 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
             # Process non control-flow statements
             (; changes, type) = abstract_eval_basic_statement(interp,
                 stmt, currstate, frame)
-            if type === Union{}
+            if type === Bottom
+                ssavaluetypes[frame.currpc] = Bottom
                 @goto find_next_bb
             end
             if changes !== nothing

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -128,6 +128,14 @@ include("compiler/utilities.jl")
 include("compiler/validation.jl")
 include("compiler/methodtable.jl")
 
+function argextype end # imported by EscapeAnalysis
+function stmt_effect_free end # imported by EscapeAnalysis
+function alloc_array_ndims end # imported by EscapeAnalysis
+function try_compute_field end # imported by EscapeAnalysis
+include("compiler/ssair/basicblock.jl")
+include("compiler/ssair/domtree.jl")
+include("compiler/ssair/ir.jl")
+
 include("compiler/inferenceresult.jl")
 include("compiler/inferencestate.jl")
 

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -99,7 +99,6 @@ mutable struct InferenceState
     ssavalue_uses::Vector{BitSet} # ssavalue sparsity and restart info
     # TODO: Could keep this sparsely by doing structural liveness analysis ahead of time.
     bb_vartables::Vector{VarTable}
-    pc_vartable::VarTable
     stmt_edges::Vector{Union{Nothing, Vector{Any}}}
     stmt_info::Vector{Any}
 
@@ -152,17 +151,17 @@ mutable struct InferenceState
 
         nslots = length(src.slotflags)
         slottypes = Vector{Any}(undef, nslots)
-        pc_vartable = VarTable(undef, nslots)
+        bb_vartable1 = VarTable(undef, nslots)
         bb_vartable_proto = VarTable(undef, nslots)
         argtypes = result.argtypes
         nargtypes = length(argtypes)
         for i in 1:nslots
             argtyp = (i > nargtypes) ? Bottom : argtypes[i]
-            pc_vartable[i] = VarState(argtyp, i > nargtypes)
+            bb_vartable1[i] = VarState(argtyp, i > nargtypes)
             bb_vartable_proto[i] = VarState(Bottom, i > nargtypes)
             slottypes[i] = argtyp
         end
-        bb_vartables = VarTable[i == 1 ? copy(pc_vartable) : copy(bb_vartable_proto)
+        bb_vartables = VarTable[i == 1 ? bb_vartable1 : copy(bb_vartable_proto)
             for i = 1:length(cfg.blocks)]
 
         pclimitations = IdSet{InferenceState}()
@@ -193,7 +192,7 @@ mutable struct InferenceState
 
         frame = new(
             linfo, world, mod, sptypes, slottypes, src, cfg,
-            currbb, currpc, ip, was_reached, handler_at, ssavalue_uses, bb_vartables, pc_vartable, stmt_edges, stmt_info,
+            currbb, currpc, ip, was_reached, handler_at, ssavalue_uses, bb_vartables, stmt_edges, stmt_info,
             pclimitations, limitations, cycle_backedges, callers_in_cycle, dont_work_on_me, parent, inferred,
             result, valid_worlds, bestguess, ipo_effects,
             params, restrict_abstract_call_sites, cached,

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -98,6 +98,7 @@ mutable struct InferenceState
     ssavalue_uses::Vector{BitSet} # ssavalue sparsity and restart info
     # TODO: Could keep this sparsely by doing structural liveness analysis ahead of time.
     bb_vartables::Vector{VarTable}
+    analyzed_bbs::BitSet
     stmt_edges::Vector{Union{Nothing, Vector{Any}}}
     stmt_info::Vector{Any}
 
@@ -161,6 +162,7 @@ mutable struct InferenceState
         end
         bb_vartables = VarTable[i == 1 ? bb_vartable1 : copy(bb_vartable_proto)
             for i = 1:length(cfg.blocks)]
+        analyzed_bbs = BitSet()
 
         pclimitations = IdSet{InferenceState}()
         limitations = IdSet{InferenceState}()
@@ -190,7 +192,7 @@ mutable struct InferenceState
 
         frame = new(
             linfo, world, mod, sptypes, slottypes, src, cfg,
-            currbb, currpc, ip, handler_at, ssavalue_uses, bb_vartables, stmt_edges, stmt_info,
+            currbb, currpc, ip, handler_at, ssavalue_uses, bb_vartables, analyzed_bbs, stmt_edges, stmt_info,
             pclimitations, limitations, cycle_backedges, callers_in_cycle, dont_work_on_me, parent, inferred,
             result, valid_worlds, bestguess, ipo_effects,
             params, restrict_abstract_call_sites, cached,

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -468,7 +468,7 @@ function add_backedge!(li::MethodInstance, caller::InferenceState)
         edges = caller.stmt_edges[caller.currpc] = []
     end
     push!(edges, li)
-    nothing
+    return nothing
 end
 
 # used to temporarily accumulate our no method errors to later add as backedges in the callee method table
@@ -480,7 +480,13 @@ function add_mt_backedge!(mt::Core.MethodTable, @nospecialize(typ), caller::Infe
     end
     push!(edges, mt)
     push!(edges, typ)
-    nothing
+    return nothing
+end
+
+function empty_backedges!(frame::InferenceState, currpc::Int = frame.currpc)
+    edges = frame.stmt_edges[currpc]
+    edges === nothing || empty!(edges)
+    return nothing
 end
 
 function print_callstack(sv::InferenceState)

--- a/base/compiler/ssair/driver.jl
+++ b/base/compiler/ssair/driver.jl
@@ -8,14 +8,6 @@ else
     end
 end
 
-function argextype end # imported by EscapeAnalysis
-function stmt_effect_free end # imported by EscapeAnalysis
-function alloc_array_ndims end # imported by EscapeAnalysis
-function try_compute_field end # imported by EscapeAnalysis
-
-include("compiler/ssair/basicblock.jl")
-include("compiler/ssair/domtree.jl")
-include("compiler/ssair/ir.jl")
 include("compiler/ssair/slot2ssa.jl")
 include("compiler/ssair/inlining.jl")
 include("compiler/ssair/verify.jl")

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -704,7 +704,7 @@ function dominates_ssa(compact::IncrementalCompact, domtree::DomTree, x::AnySSAV
             elseif xinfo !== nothing
                 return !xinfo.attach_after
             else
-                return yinfo.attach_after
+                return (yinfo::NewNodeInfo).attach_after
             end
         end
         return x′.id < y′.id

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1413,7 +1413,7 @@ function type_lift_pass!(ir::IRCode)
                                     end
                                 else
                                     while isa(node, PiNode)
-                                        id = node.val.id
+                                        id = (node.val::SSAValue).id
                                         node = insts[id][:inst]
                                     end
                                     if isa(node, Union{PhiNode, PhiCNode})

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1825,7 +1825,8 @@ function builtin_effects(f::Builtin, argtypes::Vector{Any}, rt)
         effect_free = true
     elseif f === getglobal && length(argtypes) >= 3
         nothrow = getglobal_nothrow(argtypes[2:end])
-        ipo_consistent = nothrow && isconst((argtypes[2]::Const).val, (argtypes[3]::Const).val)
+        ipo_consistent = nothrow && isconst( # types are already checked in `getglobal_nothrow`
+            (argtypes[2]::Const).val::Module, (argtypes[3]::Const).val::Symbol)
         effect_free = true
     else
         ipo_consistent = contains_is(_CONSISTENT_BUILTINS, f)

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -485,7 +485,7 @@ function finish(me::InferenceState, interp::AbstractInterpreter)
     limited_ret = me.bestguess isa LimitedAccuracy
     limited_src = false
     if !limited_ret
-        gt = me.src.ssavaluetypes::Vector{Any}
+        gt = me.ssavaluetypes
         for j = 1:length(gt)
             gt[j] = gtj = cycle_fix_limited(gt[j], me)
             if gtj isa LimitedAccuracy && me.parent !== nothing
@@ -582,7 +582,7 @@ function record_slot_assign!(sv::InferenceState)
     # to compute a lower bound on the storage required
     body = sv.src.code::Vector{Any}
     slottypes = sv.slottypes::Vector{Any}
-    ssavaluetypes = sv.src.ssavaluetypes::Vector{Any}
+    ssavaluetypes = sv.ssavaluetypes
     for i = 1:length(body)
         expr = body[i]
         # find all reachable assignments to locals
@@ -628,7 +628,7 @@ function annotate_slot_load!(undefs::Vector{Bool}, idx::Int, sv::InferenceState,
             undefs[id] |= vt.undef
             typ = widenconditional(ignorelimited(vt.typ))
         else
-            typ = sv.src.ssavaluetypes[pc]
+            typ = sv.ssavaluetypes[pc]
             @assert typ !== NOT_FOUND "active slot in unreached region"
         end
         # add type annotations where needed
@@ -689,7 +689,7 @@ function type_annotate!(sv::InferenceState, run_optimizer::Bool)
     body = copy(src.code::Vector{Any})
     nexpr = length(body)
     codelocs = src.codelocs
-    ssavaluetypes = copy(src.ssavaluetypes)
+    ssavaluetypes = copy(sv.ssavaluetypes)
     ssaflags = src.ssaflags
     slotflags = src.slotflags
     nslots = length(slotflags)

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -623,11 +623,9 @@ function annotate_slot_load!(undefs::Vector{Bool}, idx::Int, sv::InferenceState,
         pc = find_dominating_assignment(id, idx, sv)
         if pc === nothing
             block = block_for_inst(sv.cfg, idx)
-            state = sv.bb_vartables[block]
+            state = sv.bb_vartables[block]::VarTable
             vt = state[id]
-            if vt.undef
-                undefs[id] = true
-            end
+            undefs[id] |= vt.undef
             typ = widenconditional(ignorelimited(vt.typ))
         else
             typ = sv.src.ssavaluetypes[pc]

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -568,6 +568,14 @@ function widen_all_consts!(src::CodeInfo)
     return src
 end
 
+function widen_ssavaluetypes!(ssavaluetypes::Vector{Any})
+    for j = 1:length(ssavaluetypes)
+        t = ssavaluetypes[j]
+        ssavaluetypes[j] = t === NOT_FOUND ? Bottom : widenconditional(t)
+    end
+    return ssavaluetypes
+end
+
 function record_slot_assign!(sv::InferenceState)
     # look at all assignments to slots
     # and union the set of types stored there
@@ -667,14 +675,6 @@ function find_dominating_assignment(id::Int, idx::Int, sv::InferenceState)
     return nothing
 end
 
-function widen_ssavaluetypes!(ssavaluetypes::Vector{Any})
-    for j = 1:length(ssavaluetypes)
-        t = ssavaluetypes[j]
-        ssavaluetypes[j] = t === NOT_FOUND ? Bottom : widenconditional(t)
-    end
-    return ssavaluetypes
-end
-
 # annotate types of all symbols in AST
 function type_annotate!(sv::InferenceState, run_optimizer::Bool)
     # compute the required type for each slot
@@ -688,7 +688,7 @@ function type_annotate!(sv::InferenceState, run_optimizer::Bool)
     # and compute which variables may be used undef
     stmt_info = sv.stmt_info
     src = sv.src
-    body = copy_exprargs(src.code::Vector{Any})
+    body = copy(src.code::Vector{Any})
     nexpr = length(body)
     codelocs = src.codelocs
     ssavaluetypes = copy(src.ssavaluetypes)

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -424,7 +424,7 @@ function stupdate!(state::VarTable, changes::StateUpdate)
     return newstate
 end
 
-function stupdate!(state::VarTable, changes::VarTable, ::Nothing=nothing)
+function stupdate!(state::VarTable, changes::VarTable)
     newstate = nothing
     for i = 1:length(state)
         newtype = changes[i]
@@ -437,36 +437,7 @@ function stupdate!(state::VarTable, changes::VarTable, ::Nothing=nothing)
     return newstate
 end
 
-function stupdate!(state::VarTable, changes::VarTable, update::StateUpdate)
-    newstate = nothing
-    changeid = slot_id(update.var)
-    for i = 1:length(state)
-        if i == changeid
-            newtype = update.vtype
-        else
-            newtype = changes[i]
-        end
-        oldtype = state[i]
-        # remove any Conditional for this slot from the vtable
-        # (unless this change is came from the conditional)
-        if !update.conditional && isa(newtype, VarState)
-            newtypetyp = ignorelimited(newtype.typ)
-            if isa(newtypetyp, Conditional) && slot_id(newtypetyp.var) == changeid
-                newtypetyp = widenwrappedconditional(newtype.typ)
-                newtype = VarState(newtypetyp, newtype.undef)
-            end
-        end
-        if schanged(newtype, oldtype)
-            newstate = state
-            state[i] = smerge(oldtype, newtype)
-        end
-    end
-    return newstate
-end
-
-stupdate!(state::Nothing, changes::VarTable) = copy(changes)
-
-stupdate!(state::Nothing, changes::Nothing) = nothing
+stupdate!(::Nothing, changes::VarTable) = copy(changes)
 
 function stupdate1!(state::VarTable, change::StateUpdate)
     changeid = slot_id(change.var)
@@ -501,7 +472,7 @@ function stoverwrite!(state::VarTable, newstate::VarTable)
     for i = 1:length(state)
         state[i] = newstate[i]
     end
-    return nothing
+    return state
 end
 
 function stoverwrite1!(state::VarTable, change::StateUpdate)
@@ -526,6 +497,6 @@ function stoverwrite1!(state::VarTable, change::StateUpdate)
     # and update the type of it
     newtype = change.vtype
     state[changeid] = newtype
-    return nothing
+    return state
 end
-stoverwrite1!(state::VarTable, ::Nothing) = nothing
+stoverwrite1!(state::VarTable, ::Nothing) = state

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -376,27 +376,6 @@ widenwrappedconditional(typ::LimitedAccuracy) = LimitedAccuracy(widenconditional
 ignorelimited(@nospecialize typ) = typ
 ignorelimited(typ::LimitedAccuracy) = typ.typ
 
-function stupdate!(state::Nothing, changes::StateUpdate)
-    newst = copy(changes.state)
-    changeid = slot_id(changes.var)
-    newst[changeid] = changes.vtype
-    # remove any Conditional for this slot from the vtable
-    # (unless this change is came from the conditional)
-    if !changes.conditional
-        for i = 1:length(newst)
-            newtype = newst[i]
-            if isa(newtype, VarState)
-                newtypetyp = ignorelimited(newtype.typ)
-                if isa(newtypetyp, Conditional) && slot_id(newtypetyp.var) == changeid
-                    newtypetyp = widenwrappedconditional(newtype.typ)
-                    newst[i] = VarState(newtypetyp, newtype.undef)
-                end
-            end
-        end
-    end
-    return newst
-end
-
 function stupdate!(state::VarTable, changes::StateUpdate)
     newstate = nothing
     changeid = slot_id(changes.var)
@@ -436,8 +415,6 @@ function stupdate!(state::VarTable, changes::VarTable)
     end
     return newstate
 end
-
-stupdate!(::Nothing, changes::VarTable) = copy(changes)
 
 function stupdate1!(state::VarTable, change::StateUpdate)
     changeid = slot_id(change.var)
@@ -499,4 +476,3 @@ function stoverwrite1!(state::VarTable, change::StateUpdate)
     state[changeid] = newtype
     return state
 end
-stoverwrite1!(state::VarTable, ::Nothing) = state

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -424,11 +424,38 @@ function stupdate!(state::VarTable, changes::StateUpdate)
     return newstate
 end
 
-function stupdate!(state::VarTable, changes::VarTable)
+function stupdate!(state::VarTable, changes::VarTable, ::Nothing=nothing)
     newstate = nothing
     for i = 1:length(state)
         newtype = changes[i]
         oldtype = state[i]
+        if schanged(newtype, oldtype)
+            newstate = state
+            state[i] = smerge(oldtype, newtype)
+        end
+    end
+    return newstate
+end
+
+function stupdate!(state::VarTable, changes::VarTable, update::StateUpdate)
+    newstate = nothing
+    changeid = slot_id(update.var)
+    for i = 1:length(state)
+        if i == changeid
+            newtype = update.vtype
+        else
+            newtype = changes[i]
+        end
+        oldtype = state[i]
+        # remove any Conditional for this slot from the vtable
+        # (unless this change is came from the conditional)
+        if !update.conditional && isa(newtype, VarState)
+            newtypetyp = ignorelimited(newtype.typ)
+            if isa(newtypetyp, Conditional) && slot_id(newtypetyp.var) == changeid
+                newtypetyp = widenwrappedconditional(newtype.typ)
+                newtype = VarState(newtypetyp, newtype.undef)
+            end
+        end
         if schanged(newtype, oldtype)
             newstate = state
             state[i] = smerge(oldtype, newtype)
@@ -469,3 +496,36 @@ function stupdate1!(state::VarTable, change::StateUpdate)
     end
     return false
 end
+
+function stoverwrite!(state::VarTable, newstate::VarTable)
+    for i = 1:length(state)
+        state[i] = newstate[i]
+    end
+    return nothing
+end
+
+function stoverwrite1!(state::VarTable, change::StateUpdate)
+    changeid = slot_id(change.var)
+    # remove any Conditional for this slot from the catch block vtable
+    # (unless this change is came from the conditional)
+    if !change.conditional
+        for i = 1:length(state)
+            oldtype = state[i]
+            if isa(oldtype, VarState)
+                oldtypetyp = ignorelimited(oldtype.typ)
+                if isa(oldtypetyp, Conditional) && slot_id(oldtypetyp.var) == changeid
+                    oldtypetyp = widenconditional(oldtypetyp)
+                    if oldtype.typ isa LimitedAccuracy
+                        oldtypetyp = LimitedAccuracy(oldtypetyp, (oldtype.typ::LimitedAccuracy).causes)
+                    end
+                    state[i] = VarState(oldtypetyp, oldtype.undef)
+                end
+            end
+        end
+    end
+    # and update the type of it
+    newtype = change.vtype
+    state[changeid] = newtype
+    return nothing
+end
+stoverwrite1!(state::VarTable, ::Nothing) = nothing

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -377,7 +377,7 @@ ignorelimited(@nospecialize typ) = typ
 ignorelimited(typ::LimitedAccuracy) = typ.typ
 
 function stupdate!(state::VarTable, changes::StateUpdate)
-    newstate = nothing
+    changed = false
     changeid = slot_id(changes.var)
     for i = 1:length(state)
         if i == changeid
@@ -396,24 +396,24 @@ function stupdate!(state::VarTable, changes::StateUpdate)
             end
         end
         if schanged(newtype, oldtype)
-            newstate = state
             state[i] = smerge(oldtype, newtype)
+            changed = true
         end
     end
-    return newstate
+    return changed
 end
 
 function stupdate!(state::VarTable, changes::VarTable)
-    newstate = nothing
+    changed = false
     for i = 1:length(state)
         newtype = changes[i]
         oldtype = state[i]
         if schanged(newtype, oldtype)
-            newstate = state
             state[i] = smerge(oldtype, newtype)
+            changed = true
         end
     end
-    return newstate
+    return changed
 end
 
 function stupdate1!(state::VarTable, change::StateUpdate)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4134,6 +4134,11 @@ end |> !Core.Compiler.is_concrete_eval_eligible
     entry_to_be_invalidated('a')
 end
 
+# control flow backedge should taint `terminates`
+@test Base.infer_effects((Int,)) do n
+    for i = 1:n; end
+end |> !Core.Compiler.is_terminates
+
 # Nothrow for assignment to globals
 global glob_assign_int::Int = 0
 f_glob_assign_int() = global glob_assign_int += 1

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1940,19 +1940,22 @@ function foo25261()
         next = f25261(Core.getfield(next, 2))
     end
 end
-opt25261 = code_typed(foo25261, Tuple{}, optimize=false)[1].first.code
-i = 1
-# Skip to after the branch
-while !isa(opt25261[i], GotoIfNot); global i += 1; end
-foundslot = false
-for expr25261 in opt25261[i:end]
-    if expr25261 isa TypedSlot && expr25261.typ === Tuple{Int, Int}
-        # This should be the assignment to the SSAValue into the getfield
-        # call - make sure it's a TypedSlot
-        global foundslot = true
+let opt25261 = code_typed(foo25261, Tuple{}, optimize=false)[1].first.code
+    i = 1
+    # Skip to after the branch
+    while !isa(opt25261[i], GotoIfNot)
+        i += 1
     end
+    foundslot = false
+    for expr25261 in opt25261[i:end]
+        if expr25261 isa TypedSlot && expr25261.typ === Tuple{Int, Int}
+            # This should be the assignment to the SSAValue into the getfield
+            # call - make sure it's a TypedSlot
+            foundslot = true
+        end
+    end
+    @test foundslot
 end
-@test foundslot
 
 @testset "inter-procedural conditional constraint propagation" begin
     # simple cases
@@ -4158,3 +4161,13 @@ let effects = Base.infer_effects(f_setfield_nothrow, ())
     #@test Core.Compiler.is_effect_free(effects)
     @test Core.Compiler.is_nothrow(effects)
 end
+
+# check the inference convergence with an empty vartable:
+# the inference state for the toplevel chunk below will have an empty vartable,
+# and so we may fail to terminate (or optimize) it if we don't update vartables correctly
+let # NOTE make sure this toplevel chunk doesn't contain any local binding
+    Base.Experimental.@force_compile
+    global xcond::Bool = false
+    while xcond end
+end
+@test !xcond


### PR DESCRIPTION
A minimum version of #43999, without any apparent regressions.

The original PR description by @Keno will follow:

---

Currently inference uses `O(<number of statements>*<number of slots>)` state
in the core inference loop. This is usually fine, because users don't tend
to write functions that are particularly long. However, MTK does generate
functions that are excessively long and we've observed MTK models that spend
99% of their inference time just allocating and copying this state.
It is possible to get away with significantly smaller state, and this PR is
a first step in that direction, reducing the state to `O(<number of basic blocks>*<number of slots>)`.
Further improvements are possible by making use of slot liveness information
and only storing those slots that are live across a particular basic block.

The core change here is to keep a full set of `slottypes` only at
basic block boundaries rather than at each statement. For statements
in between, the full variable state can be fully recovered by
linearly scanning throughout the basic block, taking note of
slot assignments (together with the SSA type) and NewVarNodes.

~~The current status of this branch is that the changes appear correct
(no known functional regressions) and significantly improve the MTK
test cases in question (no exact benchmarks here for now, since
the branch still needs a number of fixes before final numbers make
sense), but somewhat regress optimizer quality (which is expected
and just a missing TODO) and bootstrap time (which is not expected
and something I need to dig into).~~

---

@nanosoldier `runbenchmarks(!"scalar", vs=":master")`