### PR TITLE
Revert "add a test to ensure conj! is not called on uninitialized memory in matmul"

### DIFF
--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -825,17 +825,6 @@ end
     @test Matrix{Int}(undef, 2, 0) * Matrix{Int}(undef, 0, 3) == zeros(Int, 2, 3)
 end
 
-struct BrokenInt <: Number
-   i::Int
-end
-Base.:*(::BrokenInt, ::BrokenInt) = BrokenInt(42)
-Base.:+(::BrokenInt, ::BrokenInt) = BrokenInt(42)
-Base.zero(::BrokenInt) = BrokenInt(0)
-Base.conj(b::BrokenInt) = b.i == 42 ? b : error()
-@testset "matmul uninit memory #40481" begin
-    @test fill(BrokenInt(42), 10,100)' * fill(BrokenInt(42), 100,10)' == fill(BrokenInt(42), 100, 100)
-end
-
 @testset "3-arg *, order by type" begin
     x = [1, 2im]
     y = [im, 20, 30 + 40im]


### PR DESCRIPTION
Reverts JuliaLang/julia#40491

Seems to cause ambiguity errors, https://github.com/JuliaLang/julia/issues/45270

Fixes https://github.com/JuliaLang/julia/issues/45270