### PR TITLE
[doc] Change PDF cover font to DejaVu Sans

### DIFF
--- a/doc/src/assets/custom.sty
+++ b/doc/src/assets/custom.sty
@@ -40,6 +40,7 @@ contents={
 }}%
 
 % ---- Heading font style
-\DeclareFixedFont{\MainHeading}{T1}{phv}{b}{n}{1.5cm}
-\DeclareFixedFont{\SecondaryHeading}{T1}{phv}{b}{n}{0.8cm}
+\usepackage{anyfontsize}
+\newcommand{\MainHeading}{\fontspec{DejaVu Sans}\fontsize{40}{40}\selectfont\bfseries}
+\newcommand{\SecondaryHeading}{\fontspec{DejaVu Sans}\LARGE}
 %% cover page END -------------------------------------------------------------


### PR DESCRIPTION
Changes the font on the PDF title/cover page (cf. https://github.com/JuliaLang/julia/pull/45034#discussion_r862570324) away from Helvetica to DejaVu Sans, which is actually available on the Docker image. This should fix the building of the nightly PDFs on CI. The updated cover should look like this:

![Screenshot from 2022-05-12 16-45-45](https://user-images.githubusercontent.com/147757/167994091-a5c6bee0-23e1-4b86-b00b-593f7be84f9c.png)

@inkydragon: This is intended as a workaround until we have a better solution. For what it's worth, I noticed that even when building natively on my Ubuntu machine those fonts are still falling back to `lmr` (Latin Moden Roman).

I think we could definitely pick a nicer font for the cover page. However, Helvetica appears to be a proprietary font and so not easily available. If you have time, I think the best option would be to pick a nice open source font from  [Google Fonts](https://fonts.google.com/), and we can bake it into the Docker image ([as we do for Roboto](https://github.com/JuliaDocs/DocumenterLaTeX.jl/blob/a2603071c20ad2e35f71da4d30afe235aeb2190a/docker/Dockerfile#L15-L20)).