### PR TITLE
document unique(i -> a[i], eachindex(a)) trick

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -196,7 +196,7 @@ julia> unique(x -> x^2, [1, -1, 3, -3, 4])
  4
 ```
 This functionality can also be used to extract the *indices* of the first
-occurrence of unique elements in an array:
+occurrences of unique elements in an array:
 ```jldoctest
 julia> a = [3.1, 4.2, 5.3, 3.1, 3.1, 3.1, 4.2, 1.7];
 

--- a/base/set.jl
+++ b/base/set.jl
@@ -195,8 +195,8 @@ julia> unique(x -> x^2, [1, -1, 3, -3, 4])
  3
  4
 ```
-This functionality can also be used to extract the *indices* of the unique elements
-in an array:
+This functionality can also be used to extract the *indices* of the first
+occurrence of unique elements in an array:
 ```jldoctest
 julia> a = [3.1, 4.2, 5.3, 3.1, 3.1, 3.1, 4.2, 1.7];
 

--- a/base/set.jl
+++ b/base/set.jl
@@ -198,7 +198,7 @@ julia> unique(x -> x^2, [1, -1, 3, -3, 4])
 This functionality can also be used to extract the *indices* of the unique elements
 in an array:
 ```jldoctest
-julia> a = [3,4,5,3,3,3,4,1];
+julia> a = [3.1, 4.2, 5.3, 3.1, 3.1, 3.1, 4.2, 1.7];
 
 julia> i = unique(i -> a[i], eachindex(a))
 4-element Vector{Int64}:
@@ -208,11 +208,14 @@ julia> i = unique(i -> a[i], eachindex(a))
  8
 
 julia> a[i]
-4-element Vector{Int64}:
- 3
- 4
- 5
- 1
+4-element Vector{Float64}:
+ 3.1
+ 4.2
+ 5.3
+ 1.7
+
+julia> a[i] == unique(a)
+true
 ```
 """
 function unique(f, C; seen::Union{Nothing,Set}=nothing)

--- a/base/set.jl
+++ b/base/set.jl
@@ -195,6 +195,25 @@ julia> unique(x -> x^2, [1, -1, 3, -3, 4])
  3
  4
 ```
+This functionality can also be used to extract the *indices* of the unique elements
+in an array:
+```jldoctest
+julia> a = [3,4,5,3,3,3,4,1];
+
+julia> i = unique(i -> a[i], eachindex(a))
+4-element Vector{Int64}:
+ 1
+ 2
+ 3
+ 8
+
+julia> a[i]
+4-element Vector{Int64}:
+ 3
+ 4
+ 5
+ 1
+```
 """
 function unique(f, C; seen::Union{Nothing,Set}=nothing)
     out = Vector{eltype(C)}()


### PR DESCRIPTION
As noted in #1845, indices of unique elements in `a` can be computed with `unique(i -> a[i], eachindex(a))`, and this PR adds that as an example in the documentation as suggested by @nalimilan .

This is equivalent to the second output of the [Matlab `unique`](https://www.mathworks.com/help/matlab/ref/double.unique.html) function or to to [`return_index=True` in `numpy.unique`](https://numpy.org/doc/stable/reference/generated/numpy.unique.html).