### PR TITLE
Fix effects modeling for return_type

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -205,7 +205,6 @@ function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src::Union{IRC
             f = argextype(args[1], src)
             f = singleton_type(f)
             f === nothing && return false
-            is_return_type(f) && return true
             if isa(f, IntrinsicFunction)
                 intrinsic_effect_free_if_nothrow(f) || return false
                 return intrinsic_nothrow(f,

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1217,9 +1217,6 @@ function process_simple!(ir::IRCode, idx::Int, state::InliningState, todo::Vecto
         ir[SSAValue(idx)][:inst] = lateres.val
         check_effect_free!(ir, idx, lateres.val, rt)
         return nothing
-    elseif is_return_type(sig.f)
-        check_effect_free!(ir, idx, stmt, rt)
-        return nothing
     end
 
     return stmt, sig

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -10,6 +10,7 @@ and any additional information (`call.info`) for a given generic call.
 """
 struct CallMeta
     rt::Any
+    effects::Effects
     info::Any
 end
 

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -82,7 +82,7 @@ effect-free, including being no-throw (typically because the value was computed
 by calling an `@pure` function).
 """
 struct MethodResultPure
-    info::Union{MethodMatchInfo,UnionSplitInfo,Bool}
+    info::Any
 end
 let instance = MethodResultPure(false)
     global MethodResultPure

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -2037,7 +2037,7 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
                     sv.restrict_abstract_call_sites = false
                     call = abstract_call(interp, ArgInfo(nothing, argtypes_vec), sv, -1)
                     sv.restrict_abstract_call_sites = old_restrict
-                    info = verbose_stmt_info(interp) ? ReturnTypeCallInfo(call.info) : false
+                    info = verbose_stmt_info(interp) ? MethodResultPure(ReturnTypeCallInfo(call.info)) : MethodResultPure()
                     rt = widenconditional(call.rt)
                     if isa(rt, Const)
                         # output was computed to be constant

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1041,10 +1041,10 @@ end
 function abstract_modifyfield!(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::InferenceState)
     nargs = length(argtypes)
     if !isempty(argtypes) && isvarargtype(argtypes[nargs])
-        nargs - 1 <= 6 || return CallMeta(Bottom, false)
-        nargs > 3 || return CallMeta(Any, false)
+        nargs - 1 <= 6 || return CallMeta(Bottom, EFFECTS_THROWS, false)
+        nargs > 3 || return CallMeta(Any, EFFECTS_UNKNOWN, false)
     else
-        5 <= nargs <= 6 || return CallMeta(Bottom, false)
+        5 <= nargs <= 6 || return CallMeta(Bottom, EFFECTS_THROWS, false)
     end
     o = unwrapva(argtypes[2])
     f = unwrapva(argtypes[3])
@@ -1067,7 +1067,7 @@ function abstract_modifyfield!(interp::AbstractInterpreter, argtypes::Vector{Any
         end
         info = callinfo.info
     end
-    return CallMeta(RT, info)
+    return CallMeta(RT, Effects(), info)
 end
 replacefield!_tfunc(o, f, x, v, success_order, failure_order) = (@nospecialize; replacefield!_tfunc(o, f, x, v))
 replacefield!_tfunc(o, f, x, v, success_order) = (@nospecialize; replacefield!_tfunc(o, f, x, v))
@@ -2028,7 +2028,7 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
                 if isa(af_argtype, DataType) && af_argtype <: Tuple
                     argtypes_vec = Any[aft, af_argtype.parameters...]
                     if contains_is(argtypes_vec, Union{})
-                        return CallMeta(Const(Union{}), false)
+                        return CallMeta(Const(Union{}), EFFECTS_TOTAL, false)
                     end
                     # Run the abstract_call without restricting abstract call
                     # sites. Otherwise, our behavior model of abstract_call
@@ -2041,32 +2041,32 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
                     rt = widenconditional(call.rt)
                     if isa(rt, Const)
                         # output was computed to be constant
-                        return CallMeta(Const(typeof(rt.val)), info)
+                        return CallMeta(Const(typeof(rt.val)), EFFECTS_TOTAL, info)
                     end
                     rt = widenconst(rt)
                     if rt === Bottom || (isconcretetype(rt) && !iskindtype(rt))
                         # output cannot be improved so it is known for certain
-                        return CallMeta(Const(rt), info)
+                        return CallMeta(Const(rt), EFFECTS_TOTAL, info)
                     elseif !isempty(sv.pclimitations)
                         # conservatively express uncertainty of this result
                         # in two ways: both as being a subtype of this, and
                         # because of LimitedAccuracy causes
-                        return CallMeta(Type{<:rt}, info)
+                        return CallMeta(Type{<:rt}, EFFECTS_TOTAL, info)
                     elseif (isa(tt, Const) || isconstType(tt)) &&
                         (isa(aft, Const) || isconstType(aft))
                         # input arguments were known for certain
                         # XXX: this doesn't imply we know anything about rt
-                        return CallMeta(Const(rt), info)
+                        return CallMeta(Const(rt), EFFECTS_TOTAL, info)
                     elseif isType(rt)
-                        return CallMeta(Type{rt}, info)
+                        return CallMeta(Type{rt}, EFFECTS_TOTAL, info)
                     else
-                        return CallMeta(Type{<:rt}, info)
+                        return CallMeta(Type{<:rt}, EFFECTS_TOTAL, info)
                     end
                 end
             end
         end
     end
-    return CallMeta(Type, false)
+    return CallMeta(Type, EFFECTS_THROWS, false)
 end
 
 # N.B.: typename maps type equivalence classes to a single value

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1275,3 +1275,7 @@ end
     return_type_unused(x)
     return nothing
 end
+
+# Test that inlining doesn't accidentally delete a bad return_type call
+f_bad_return_type() = Core.Compiler.return_type(+, 1, 2)
+@test_throws MethodError f_bad_return_type()

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1259,3 +1259,19 @@ end
 @test fully_eliminated() do
     return maybe_error_int(1)
 end
+
+# Test that effect modeling for return_type doesn't incorrectly pick
+# up the effects of the function being analyzed
+function f_throws()
+    error()
+end
+
+@noinline function return_type_unused(x)
+    Core.Compiler.return_type(f_throws, Tuple{})
+    return x+1
+end
+
+@test fully_eliminated(Tuple{Int}) do x
+    return_type_unused(x)
+    return nothing
+end


### PR DESCRIPTION
Effects modeling was bad in both directions (not precise in some cases, incorrect in others). This pair of commits refactors the code to make the effects modeling precise and then uses it in the optimizer to address the correctness issues.