### PR TITLE
Export jl_setjmp on Windows

### DIFF
--- a/cli/jl_exports.h
+++ b/cli/jl_exports.h
@@ -18,12 +18,18 @@ JL_EXPORTED_DATA_SYMBOLS(XX)
 // Define holder locations for function addresses as `const void * $(name)_addr`
 #define XX(name)    JL_HIDDEN const void * name##_addr;
 JL_EXPORTED_FUNCS(XX)
+#ifdef _OS_WINDOWS_
+JL_EXPORTED_FUNCS_WIN(XX)
+#endif
 #undef XX
 
 // Generate lists of function names and addresses
 #define XX(name)    #name,
 static const char *const jl_exported_func_names[] = {
     JL_EXPORTED_FUNCS(XX)
+#ifdef _OS_WINDOWS_
+    JL_EXPORTED_FUNCS_WIN(XX)
+#endif
     NULL
 };
 #undef XX
@@ -31,6 +37,9 @@ static const char *const jl_exported_func_names[] = {
 #define XX(name)    &name##_addr,
 static const void ** jl_exported_func_addrs[] = {
     JL_EXPORTED_FUNCS(XX)
+#ifdef _OS_WINDOWS_
+    JL_EXPORTED_FUNCS_WIN(XX)
+#endif
     NULL
 };
 #undef XX

--- a/cli/trampolines/common.h
+++ b/cli/trampolines/common.h
@@ -1,3 +1,5 @@
+#include "../../src/support/platform.h"
+
 // Preprocessor annoyances
 #define CONCAT_(x,y)    x##y
 #define CONCAT(x,y)     CONCAT_(x, y)

--- a/cli/trampolines/trampolines_aarch64.S
+++ b/cli/trampolines/trampolines_aarch64.S
@@ -12,4 +12,7 @@ CNAME(name)##: SEP \
 .cfi_endproc SEP \
 
 JL_EXPORTED_FUNCS(XX)
+#ifdef _OS_WINDOWS_
+JL_EXPORTED_FUNCS_WIN(XX)
+#endif
 #undef XX

--- a/cli/trampolines/trampolines_arm.S
+++ b/cli/trampolines/trampolines_arm.S
@@ -15,4 +15,7 @@ CONCAT(.L,CNAMEADDR(name))##: ; \
 .cfi_endproc; \
 
 JL_EXPORTED_FUNCS(XX)
+#ifdef _OS_WINDOWS_
+JL_EXPORTED_FUNCS_WIN(XX)
+#endif
 #undef XX

--- a/cli/trampolines/trampolines_i686.S
+++ b/cli/trampolines/trampolines_i686.S
@@ -13,4 +13,7 @@ CNAME(name)##:; \
 EXPORT(name); \
 
 JL_EXPORTED_FUNCS(XX)
+#ifdef _OS_WINDOWS_
+JL_EXPORTED_FUNCS_WIN(XX)
+#endif
 #undef XX

--- a/cli/trampolines/trampolines_x86_64.S
+++ b/cli/trampolines/trampolines_x86_64.S
@@ -17,4 +17,7 @@ SEH_END(); \
 EXPORT(name); \
 
 JL_EXPORTED_FUNCS(XX)
+#ifdef _OS_WINDOWS_
+JL_EXPORTED_FUNCS_WIN(XX)
+#endif
 #undef XX

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -757,3 +757,6 @@
     XX(jl_xor_int) \
     XX(jl_yield) \
     XX(jl_zext_int) \
+
+#define JL_EXPORTED_FUNCS_WIN(XX) \
+    XX(jl_setjmp)

--- a/src/julia.h
+++ b/src/julia.h
@@ -1791,10 +1791,10 @@ JL_DLLEXPORT void jl_restore_excstack(size_t state) JL_NOTSAFEPOINT;
 
 #if defined(_OS_WINDOWS_)
 #if defined(_COMPILER_GCC_)
-int __attribute__ ((__nothrow__,__returns_twice__)) (jl_setjmp)(jmp_buf _Buf);
+JL_DLLEXPORT int __attribute__ ((__nothrow__,__returns_twice__)) (jl_setjmp)(jmp_buf _Buf);
 __declspec(noreturn) __attribute__ ((__nothrow__)) void (jl_longjmp)(jmp_buf _Buf, int _Value);
 #else
-int (jl_setjmp)(jmp_buf _Buf);
+JL_DLLEXPORT int (jl_setjmp)(jmp_buf _Buf);
 void (jl_longjmp)(jmp_buf _Buf, int _Value);
 #endif
 #define jl_setjmp_f jl_setjmp

--- a/test/embedding/embedding-test.jl
+++ b/test/embedding/embedding-test.jl
@@ -20,8 +20,7 @@ end
     close(out.in)
     close(err.in)
     out_task = @async readlines(out)
-    err = read(err, String)
-    @test err == "MethodError: no method matching this_function_has_no_methods()\n"
+    @test readline(err) == "MethodError: no method matching this_function_has_no_methods()"
     @test success(p)
     lines = fetch(out_task)
     @test length(lines) == 10
@@ -29,4 +28,5 @@ end
     @test lines[8] == "called bar"
     @test lines[9] == "calling new bar"
     @test lines[10] == "      From worker 2:\tTaking over the world..."
+    @test readline(err) == "exception caught from C"
 end

--- a/test/embedding/embedding.c
+++ b/test/embedding/embedding.c
@@ -175,6 +175,13 @@ int main()
         checked_eval_string("f28825()");
     }
 
+    JL_TRY {
+        jl_error("exception thrown");
+    }
+    JL_CATCH {
+        jl_printf(jl_stderr_stream(), "exception caught from C\n");
+    }
+
     int ret = 0;
     jl_atexit_hook(ret);
     return ret;


### PR DESCRIPTION
This PR exports `jl_setjmp` on Windows. It's based on #42267. Fixes #43340.