### PR TITLE
make Tuple(x) inferable for number type

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -404,6 +404,7 @@ _totuple(::Type{Tuple}, itr, s...) = (collect(Iterators.rest(itr,s...))...,)
 _totuple(::Type{Tuple}, itr::Array) = (itr...,)
 _totuple(::Type{Tuple}, itr::SimpleVector) = (itr...,)
 _totuple(::Type{Tuple}, itr::NamedTuple) = (itr...,)
+_totuple(::Type{Tuple}, x::Number) = (x,) # to make Tuple(x) inferable
 
 end
 

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -43,6 +43,9 @@ end
     let x = @inferred(convert(Tuple{Integer, UInt8, UInt16, UInt32, Int, Vararg{Real}}, (2.0, 3, 5, 6.0, 42, 3.0+0im)))
         @test x == (2, 0x03, 0x0005, 0x00000006, 42, 3.0)
     end
+    for x in (Int(2), UInt8(3), UInt16(5), UInt32(6), 42, 5.0, 3.0+0im)
+        @test (x,) == @inferred Tuple(x)
+    end
 
     @test_throws MethodError convert(Tuple{Int}, ())
     @test_throws MethodError convert(Tuple{Any}, ())


### PR DESCRIPTION
This need arises from the fact that `dims` keyword in many functions typically support `Int`, `Dims`, and range inputs. Thus it would be a good idea to make the conversion from `Int` to `Dims` type inferable.