### PR TITLE
Add particular warning about `1:length(A)` pattern

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -639,7 +639,7 @@ end
     for out-of-bounds indices. The user is responsible for checking it manually.
     Only use `@inbounds` when it is certain from the information locally available
     that all accesses are in bounds. In particular, using `1:length(A)` instead of 
-    `eachindex` in a function like the one above is _not_ safely inbounds because
+    `eachindex(A)` in a function like the one above is _not_ safely inbounds because
     the first index of `A` may not be `1` for all user defined types that subtype
     `AbstractArray`.
 """

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -638,7 +638,10 @@ end
     Using `@inbounds` may return incorrect results/crashes/corruption
     for out-of-bounds indices. The user is responsible for checking it manually.
     Only use `@inbounds` when it is certain from the information locally available
-    that all accesses are in bounds.
+    that all accesses are in bounds. In particular, using `1:length(A)` instead of 
+    `eachindex` in a function like the one above are _not_ safely inbounds because
+    the first index of `A` may not be `1` for all user defined types that subtype
+    `AbstractArray`.
 """
 macro inbounds(blk)
     return Expr(:block,

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -638,7 +638,7 @@ end
     Using `@inbounds` may return incorrect results/crashes/corruption
     for out-of-bounds indices. The user is responsible for checking it manually.
     Only use `@inbounds` when it is certain from the information locally available
-    that all accesses are in bounds. In particular, using `1:length(A)` instead of 
+    that all accesses are in bounds. In particular, using `1:length(A)` instead of
     `eachindex(A)` in a function like the one above is _not_ safely inbounds because
     the first index of `A` may not be `1` for all user defined types that subtype
     `AbstractArray`.

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -639,7 +639,7 @@ end
     for out-of-bounds indices. The user is responsible for checking it manually.
     Only use `@inbounds` when it is certain from the information locally available
     that all accesses are in bounds. In particular, using `1:length(A)` instead of 
-    `eachindex` in a function like the one above are _not_ safely inbounds because
+    `eachindex` in a function like the one above is _not_ safely inbounds because
     the first index of `A` may not be `1` for all user defined types that subtype
     `AbstractArray`.
 """


### PR DESCRIPTION
Call out `1:length(A)` as a bad pattern to use when `@inbounds` is desired.

[ci-skip]