### PR TITLE
preserve -- in ARGS when it follows a non-option argument

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -207,10 +207,6 @@ function incomplete_tag(ex::Expr)
 end
 
 function exec_options(opts)
-    if !isempty(ARGS)
-        idxs = findall(x -> x == "--", ARGS)
-        length(idxs) > 0 && deleteat!(ARGS, idxs[1])
-    end
     quiet                 = (opts.quiet != 0)
     startup               = (opts.startupfile != 2)
     history_file          = (opts.historyfile != 0)

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -309,17 +309,8 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
     const char **cmds = NULL;
     int codecov = JL_LOG_NONE;
     int malloclog = JL_LOG_NONE;
-    // getopt handles argument parsing up to -- delineator
     int argc = *argcp;
     char **argv = *argvp;
-    if (argc > 0) {
-        for (int i = 0; i < argc; i++) {
-            if (!strcmp(argv[i], "--")) {
-                argc = i;
-                break;
-            }
-        }
-    }
     char *endptr;
     opterr = 0; // suppress getopt warning messages
     while (1) {

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -531,10 +531,20 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
         withenv("JULIA_DEPOT_PATH" => dir) do
             output = "[\"foo\", \"-bar\", \"--baz\"]"
             @test readchomp(`$exename $testfile foo -bar --baz`) == output
-            @test readchomp(`$exename $testfile -- foo -bar --baz`) == output
+            @test readchomp(`$exename -- $testfile foo -bar --baz`) == output
             @test readchomp(`$exename -L $testfile -e 'exit(0)' -- foo -bar --baz`) ==
                 output
             @test readchomp(`$exename --startup-file=yes -e 'exit(0)' -- foo -bar --baz`) ==
+                output
+
+            output = "[\"foo\", \"--\", \"-bar\", \"--baz\"]"
+            @test readchomp(`$exename $testfile foo -- -bar --baz`) == output
+            @test readchomp(`$exename -- $testfile foo -- -bar --baz`) == output
+            @test readchomp(`$exename -L $testfile -e 'exit(0)' foo -- -bar --baz`) ==
+                output
+            @test readchomp(`$exename -L $testfile -e 'exit(0)' -- foo -- -bar --baz`) ==
+                output
+            @test readchomp(`$exename --startup-file=yes -e 'exit(0)' foo -- -bar --baz`) ==
                 output
 
             output = "String[]\nString[]"
@@ -542,8 +552,6 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             @test readchomp(`$exename --startup-file=yes $testfile`) == output
 
             @test !success(`$exename --foo $testfile`)
-            @test readchomp(`$exename -L $testfile -e 'exit(0)' -- foo -bar -- baz`) ==
-                "[\"foo\", \"-bar\", \"--\", \"baz\"]"
         end
     end
 


### PR DESCRIPTION
Rebase of https://github.com/JuliaLang/julia/pull/37010 since that PR does not allow updating the author's branch.

> This is a proposed fix for #37009. It removes manual processing of `--` and relies on `getopt()` to handle it correctly. The expected behavior:
> 1. If `--` appears before the first non-option argument, it forces the end of option processing and does not appear in `ARGS`.
> 2. If `--` appears after a non-option argument, it is preserved in `ARGS`. This `--` has no effect on option processing since it's already stopped on the first non-option argument.