### PR TITLE
Make `for iter::CartesianIndices` better vectorized for 1d/2d cases.

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -416,6 +416,9 @@ module IteratorsMD
     # current column is consumed. The implementation is written recursively to achieve this.
     # `iterate` returns `Union{Nothing, Tuple}`, we explicitly pass a `valid` flag to eliminate
     # the type instability inside the core `__inc` logic, and this gives better runtime performance.
+    # The third argument ndim is used to preserve the original dimension information to help
+    # elliminate unnecessary boundary checks and thus enable vectorization -- this makes low
+    # dimensional case, especially 1d and 2d, much happier.
     __inc(::Tuple{}, ::Tuple{}, ::Val) = false, ()
     @inline function __inc(state::Tuple{Int}, indices::Tuple{OrdinalRangeInt}, ::Val{N}) where {N}
         rng = indices[1]

--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -295,9 +295,7 @@ end
     # check iteration behavior on boundary
     R = CartesianIndex(1, 1):CartesianIndex(2, 3):CartesianIndex(4, 5)
     @test R.indices == (1:2:3, 1:3:4)
-    i = CartesianIndex(4, 1)
-    i_next = CartesianIndex(1, 4)
-    @test !(i in R) && iterate(R, i) == (i_next, i_next)
+    @test last(R) == CartesianIndex(3, 4) && iterate(R, last(R)) == nothing
 
     for R in [
         CartesianIndices((1:-1:-1, 1:2:5)),
@@ -398,15 +396,15 @@ end
         @test iterate(I, i) === nothing
 
         I = CartesianIndices((1:2:typemax(Int), ))
-        i = CartesianIndex(typemax(Int)-1)
-        @test iterate(I, i) === nothing
-
-        I = CartesianIndices((1:(typemax(Int)-1),))
         i = CartesianIndex(typemax(Int))
         @test iterate(I, i) === nothing
 
-        I = CartesianIndices((1:2:typemax(Int)-1, ))
+        I = CartesianIndices((1:(typemax(Int)-1),))
         i = CartesianIndex(typemax(Int)-1)
+        @test iterate(I, i) === nothing
+
+        I = CartesianIndices((1:2:typemax(Int)-1, ))
+        i = CartesianIndex(typemax(Int)-2)
         @test iterate(I, i) === nothing
 
         I = CartesianIndices((1:typemax(Int), 1:typemax(Int)))
@@ -414,7 +412,7 @@ end
         @test iterate(I, i) === nothing
 
         I = CartesianIndices((1:2:typemax(Int), 1:2:typemax(Int)))
-        i = CartesianIndex(typemax(Int)-1, typemax(Int)-1)
+        i = last(I)
         @test iterate(I, i) === nothing
 
         I = CartesianIndices((1:typemax(Int), 1:typemax(Int)))
@@ -422,7 +420,7 @@ end
         @test iterate(I, i) === (CartesianIndex(1, 2), CartesianIndex(1,2))
 
         I = CartesianIndices((1:2:typemax(Int), 1:2:typemax(Int)))
-        i = CartesianIndex(typemax(Int)-1, 1)
+        i = CartesianIndex(typemax(Int), 1)
         @test iterate(I, i) === (CartesianIndex(1, 3), CartesianIndex(1, 3))
 
         I = CartesianIndices((typemin(Int):(typemin(Int)+3),))
@@ -496,9 +494,7 @@ end
 
     # test invalid state
     I = CartesianIndices((2:4, 3:5))
-    @test iterate(I, CartesianIndex(typemax(Int), 3))[1] == CartesianIndex(2,4)
-    @test iterate(I, CartesianIndex(typemax(Int), 4))[1] == CartesianIndex(2,5)
-    @test iterate(I, CartesianIndex(typemax(Int), 5))    === nothing
+    @test iterate(I, CartesianIndex(4, typemax(Int)))    === nothing
 
     @test iterate(I, CartesianIndex(3, typemax(Int)))[1] == CartesianIndex(4,typemax(Int))
     @test iterate(I, CartesianIndex(4, typemax(Int)))    === nothing


### PR DESCRIPTION
Local benchmark shows that this makes non-`@simd` 1d/2d loop faster.
```julia
function sumcart_iter(A)
    s = zero(eltype(A))
    for I in CartesianIndices(A)
        @inbounds @fastmath s += A[I] # use @fastmath to enable simd
    end
    s
end
```
on master:
```julia
julia> A = view(rand(256*20),1:256*20);
julia> @btime sumcart_iter($A)
  4.657 μs (0 allocations: 0 bytes)
2539.6790676561955

julia> B = view(rand(256,20),1:256,1:20);
julia> @btime sumcart_iter($B)
  4.657 μs (0 allocations: 0 bytes)
2557.7341880811764
```
This PR
```julia
julia> @btime sumcart_iter($A)
  305.200 ns (0 allocations: 0 bytes)
2539.6790676562046

julia> @btime sumcart_iter($B)
  406.500 ns (0 allocations: 0 bytes)
2557.734188081178
```