### PR TITLE
[deps] Use newer `config.sub` when building nghttp2

### DIFF
--- a/deps/nghttp2.mk
+++ b/deps/nghttp2.mk
@@ -8,6 +8,7 @@ $(SRCCACHE)/nghttp2-$(NGHTTP2_VER).tar.bz2: | $(SRCCACHE)
 $(SRCCACHE)/nghttp2-$(NGHTTP2_VER)/source-extracted: $(SRCCACHE)/nghttp2-$(NGHTTP2_VER).tar.bz2
 	$(JLCHECKSUM) $<
 	cd $(dir $<) && $(TAR) -jxf $<
+	cp $(SRCDIR)/patches/config.sub $(SRCCACHE)/nghttp2-$(NGHTTP2_VER)/config.sub
 	touch -c $(SRCCACHE)/nghttp2-$(NGHTTP2_VER)/configure # old target
 	echo 1 > $@
 


### PR DESCRIPTION
Successfully tested locally with `make -C deps install-nghttp2 USE_BINARYBUILDER_NGHTTP2=0`.  Fix #45201.  CC: @fxcoudert.