### PR TITLE
Make `isdispatchtuple` consistent for `typeof(Union{})`

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1215,6 +1215,7 @@ void jl_precompute_memoized_dt(jl_datatype_t *dt, int cacheable)
         if (dt->isdispatchtuple) {
             dt->isdispatchtuple = jl_is_datatype(p) &&
                 ((!jl_is_kind(p) && ((jl_datatype_t*)p)->isconcretetype) ||
+                 (p == (jl_value_t*)jl_typeofbottom_type) || // == Type{Union{}}, so needs to be consistent
                  (((jl_datatype_t*)p)->name == jl_type_typename && !((jl_datatype_t*)p)->hasfreetypevars));
         }
         if (istuple && dt->has_concrete_subtype) {

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1982,3 +1982,8 @@ end
 @test_throws TypeError(:typeassert, Type, Vararg{Int}) typeintersect(Int, Vararg{Int})
 @test_throws TypeError(:typeassert, Type, 1) typeintersect(1, Int)
 @test_throws TypeError(:typeassert, Type, 1) typeintersect(Int, 1)
+
+let A = Tuple{typeof(identity), Type{Union{}}},
+    B = Tuple{typeof(identity), typeof(Union{})}
+    @test A == B && (Base.isdispatchtuple(A) == Base.isdispatchtuple(B))
+end


### PR DESCRIPTION
We have `typeof(Union{}) == Type{Union{}}`, but were treating them
differently in the calculation of `isdispatchtuple`. The compiler
expects `isdispatchtuple` to commute with type equality in various
places, so try to make this consistent.

Fixes #45347