### PR TITLE
Fix codegen error path for imported non-owned bindings

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4608,27 +4608,27 @@ static void emit_assignment(jl_codectx_t &ctx, jl_value_t *l, jl_value_t *r, ssi
     assert(!jl_is_ssavalue(l));
     jl_cgval_t rval_info = emit_expr(ctx, r, ssaval);
 
+    if (jl_is_slot(l)) {
+        int sl = jl_slot_number(l) - 1;
+        // it's a local variable
+        jl_varinfo_t &vi = ctx.slots[sl];
+        return emit_varinfo_assign(ctx, vi, rval_info, l);
+    }
+
     jl_binding_t *bnd = NULL;
     Value *bp = NULL;
     if (jl_is_symbol(l))
-        bp = global_binding_pointer(ctx, ctx.module, (jl_sym_t*)l, &bnd, true); // now bp != NULL or bnd != NULL
-    else if (jl_is_globalref(l))
-        bp = global_binding_pointer(ctx, jl_globalref_mod(l), jl_globalref_name(l), &bnd, true); // now bp != NULL or bnd != NULL
-    else
-        assert(jl_is_slot(l));
-    if (bp != NULL || bnd != NULL) { // it is a global
-        if (bp != NULL) {
-            emit_globalset(ctx, bnd, bp, rval_info, AtomicOrdering::Unordered);
-            // Global variable. Does not need debug info because the debugger knows about
-            // its memory location.
-        }
-        return;
+        bp = global_binding_pointer(ctx, ctx.module, (jl_sym_t*)l, &bnd, true);
+    else {
+        assert(jl_is_globalref(l));
+        bp = global_binding_pointer(ctx, jl_globalref_mod(l), jl_globalref_name(l), &bnd, true);
     }
-
-    int sl = jl_slot_number(l) - 1;
-    // it's a local variable
-    jl_varinfo_t &vi = ctx.slots[sl];
-    emit_varinfo_assign(ctx, vi, rval_info, l);
+    if (bp != NULL) {
+        emit_globalset(ctx, bnd, bp, rval_info, AtomicOrdering::Unordered);
+        // Global variable. Does not need debug info because the debugger knows about
+        // its memory location.
+    }
+    return;
 }
 
 static void emit_upsilonnode(jl_codectx_t &ctx, ssize_t phic, jl_value_t *val)

--- a/test/core.jl
+++ b/test/core.jl
@@ -7800,3 +7800,11 @@ end
     m.x = 4.
     @test m.x === 4
 end
+
+# #45350 - Codegen for assignment to binding imported from module
+module Foo45350
+    global x45350::Int = 1
+end
+import .Foo45350: x45350
+f45350() = (global x45350 = 2)
+@test_throws ErrorException f45350()


### PR DESCRIPTION
The code assumed that a null return from `global_binding_pointer`
was impossible. However, it happens in the error path, causing
a bad memory reference later when the lhs is treated as a slot.

Fixes #45350