### PR TITLE
Add `showarg(io, ::Slices)` printing for `eachslice`

### DIFF
--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -270,18 +270,24 @@ end
 
 parent(s::Slices) = s.parent
 
+function _element_size(s::Slices)
+    long = map((n,l) -> l === (:) ? n : nothing, size(s.parent), s.slicemap)
+    filter(!isnothing, long)
+end
+
+# These control summary printing, like `3-element eachcol(adjoint(::Matrix{Int64})) of ...`
 function showarg(io::IO, s::ColumnSlices, toplevel)
     print(io, "eachcol(")
     showarg(io, parent(s), false)
     print(io, ')')
-    toplevel && !isempty(s) && print(io, " of ", dims2string(size(first(s))), " slices with eltype ", eltype(eltype(s)))
+    toplevel && print(io, " of ", dims2string(_element_size(s)), " slices with eltype ", eltype(eltype(s)))
     return nothing
 end
 function showarg(io::IO, s::RowSlices, toplevel)
     print(io, "eachrow(")
     showarg(io, parent(s), false)
     print(io, ')')
-    toplevel && !isempty(s) && print(io, " of ", dims2string(size(first(s))), " slices with eltype ", eltype(eltype(s)))
+    toplevel && print(io, " of ", dims2string(_element_size(s)), " slices with eltype ", eltype(eltype(s)))
     return nothing
 end
 function showarg(io::IO, s::Slices, toplevel)
@@ -291,6 +297,6 @@ function showarg(io::IO, s::Slices, toplevel)
     print(io, "eachslice(")
     showarg(io, parent(s), false)
     print(io, ", dims = ", dims, drop ? ", drop = false)" : ")")
-    toplevel && !isempty(s) && print(io, " of ", dims2string(size(first(s))), " slices with eltype ", eltype(eltype(s)))
+    toplevel && print(io, " of ", dims2string(_element_size(s)), " slices with eltype ", eltype(eltype(s)))
     return nothing
 end

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -243,3 +243,28 @@ end
 end
 
 parent(s::Slices) = s.parent
+
+function showarg(io::IO, s::ColumnSlices, toplevel)
+    print(io, "eachcol(")
+    Base.showarg(io, parent(s), false)
+    print(io, ')')
+    toplevel && !isempty(s) && print(io, " of ", dims2string(size(first(s))), " slices with eltype ", eltype(eltype(s)))
+    return nothing
+end
+function showarg(io::IO, s::RowSlices, toplevel)
+    print(io, "eachrow(")
+    Base.showarg(io, parent(s), false)
+    print(io, ')')
+    toplevel && !isempty(s) && print(io, " of ", dims2string(size(first(s))), " slices with eltype ", eltype(eltype(s)))
+    return nothing
+end
+function showarg(io::IO, s::Slices, toplevel)
+    drop = ndims(s) + ndims(eltype(s)) > ndims(parent(s))
+    dims_vec = filter(c -> c isa Integer, [findfirst(==(d), s.slicemap) for d in 1:ndims(parent(s))])
+    dims = length(dims_vec) == 1 ? only(dims_vec) : Tuple(dims_vec)
+    print(io, "eachslice(")
+    Base.showarg(io, parent(s), false)
+    print(io, ", dims = ", dims, drop ? ", drop = false)" : ")")
+    toplevel && !isempty(s) && print(io, " of ", dims2string(size(first(s))), " slices with eltype ", eltype(eltype(s)))
+    return nothing
+end

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -301,5 +301,7 @@ function showarg(io::IO, s::Slices, toplevel)
     return nothing
 end
 
-# This hides the SubArray type in compact printing, e.g. (0, eachcol(Float32[1 2; 3 4]), 5)
+# This affects compact printing, 2-arg show. By default an array of arrays prints e.g. `Vector{Int}[[1,2], [3,4]]`.
+# Since the element type for Slices ia a complicated SubArray, this hides it, while still printing inner types
+# if nontrivial. Thus `(eachcol(Float32[1 2; 3 4]),)` prints `([Float32[1.0, 3.0], Float32[2.0, 4.0]],)`
 typeinfo_prefix(io::IO, @nospecialize s::Slices) = ("", true)

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -106,7 +106,7 @@ julia> m = [1 2 3; 4 5 6; 7 8 9]
  4  5  6
  7  8  9
 
-julia> s = eachslice(m, dims=1)  # same as eachrow(m)
+julia> s = eachslice(m, dims=1)
 3-element eachrow(::Matrix{Int64}) of 3-element slices with eltype Int64:
  [1, 2, 3]
  [4, 5, 6]
@@ -123,6 +123,14 @@ julia> eachslice(m, dims=1, drop=false)  # keyword changes size of container
  [1, 2, 3]
  [4, 5, 6]
  [7, 8, 9]
+
+julia> x3 = rand(Int8, 3,4,5);
+
+julia> eachslice(x3, dims=(3,2)) |> summary  # order of dims matters here
+"5×4 eachslice(::Array{Int8, 3}, dims = (3, 2)) of 3-element slices with eltype Int8"
+
+julia> eachslice(x3, dims=(3,2), drop=false) |> summary
+"1×4×5 eachslice(::Array{Int8, 3}, dims = (2, 3), drop = false) of 3-element slices with eltype Int8"
 
 julia> eachslice(Any[pi, 2pi], dims=1)  # eachrow would produce vector slices
 2-element eachslice(::Vector{Any}, dims = 1) of 0-dimensional slices with eltype Any:

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -300,3 +300,6 @@ function showarg(io::IO, s::Slices, toplevel)
     toplevel && print(io, " of ", dims2string(_element_size(s)), " slices with eltype ", eltype(eltype(s)))
     return nothing
 end
+
+# This hides the SubArray type in compact printing, e.g. (0, eachcol(Float32[1 2; 3 4]), 5)
+typeinfo_prefix(io::IO, @nospecialize s::Slices) = ("", true)

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -118,7 +118,7 @@ julia> s[1]
  2
  3
 
-julia> eachslice(m, dims=1, drop=false)  # keyword changes outer size
+julia> eachslice(m, dims=1, drop=false)  # keyword changes size of container
 3×1 eachslice(::Matrix{Int64}, dims = 1, drop = false) of 3-element slices with eltype Int64:
  [1, 2, 3]
  [4, 5, 6]
@@ -300,8 +300,3 @@ function showarg(io::IO, s::Slices, toplevel)
     toplevel && print(io, " of ", dims2string(_element_size(s)), " slices with eltype ", eltype(eltype(s)))
     return nothing
 end
-
-# This affects compact printing, 2-arg show. By default an array of arrays prints e.g. `Vector{Int}[[1,2], [3,4]]`.
-# Since the element type for Slices ia a complicated SubArray, this hides it, while still printing inner types
-# if nontrivial. Thus `(eachcol(Float32[1 2; 3 4]),)` prints `([Float32[1.0, 3.0], Float32[2.0, 4.0]],)`
-typeinfo_prefix(io::IO, @nospecialize s::Slices) = ("", true)

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -86,7 +86,7 @@ the ordering of the dimensions will match those in `dims`. If `drop = false`, th
 `Slices` will have the same dimensionality as the underlying array, with inner
 dimensions having size 1.
 
-For matrices, the case `dims = 1` is [`eachrow`](@ref), and `dims = 2` is [`eachcol`](@ref). 
+For matrices, the case `dims = 1` is [`eachrow`](@ref), and `dims = 2` is [`eachcol`](@ref).
 
 [`stack`](@ref)`(slices; dims)` is the inverse of `eachslice(A; dims::Integer, drop=true)`.
 See also [`mapslices`](@ref) and [`selectdim`](@ref).
@@ -272,14 +272,14 @@ parent(s::Slices) = s.parent
 
 function showarg(io::IO, s::ColumnSlices, toplevel)
     print(io, "eachcol(")
-    Base.showarg(io, parent(s), false)
+    showarg(io, parent(s), false)
     print(io, ')')
     toplevel && !isempty(s) && print(io, " of ", dims2string(size(first(s))), " slices with eltype ", eltype(eltype(s)))
     return nothing
 end
 function showarg(io::IO, s::RowSlices, toplevel)
     print(io, "eachrow(")
-    Base.showarg(io, parent(s), false)
+    showarg(io, parent(s), false)
     print(io, ')')
     toplevel && !isempty(s) && print(io, " of ", dims2string(size(first(s))), " slices with eltype ", eltype(eltype(s)))
     return nothing
@@ -289,7 +289,7 @@ function showarg(io::IO, s::Slices, toplevel)
     dims_vec = filter(c -> c isa Integer, [findfirst(==(d), s.slicemap) for d in 1:ndims(parent(s))])
     dims = length(dims_vec) == 1 ? only(dims_vec) : Tuple(dims_vec)
     print(io, "eachslice(")
-    Base.showarg(io, parent(s), false)
+    showarg(io, parent(s), false)
     print(io, ", dims = ", dims, drop ? ", drop = false)" : ")")
     toplevel && !isempty(s) && print(io, " of ", dims2string(size(first(s))), " slices with eltype ", eltype(eltype(s)))
     return nothing

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -15,7 +15,7 @@ An `AbstractArray` of slices into a parent array over specified dimension(s),
 returning views that select all the data from the other dimension(s).
 
 These should typically be constructed by [`eachslice`](@ref), [`eachcol`](@ref) or
-[`eachrow`](@ref).
+[`eachrow`](@ref). [`ColumnSlices`](@ref) and [`RowSlices`](@ref) are special cases.
 
 [`parent(s::Slices)`](@ref) will return the parent array.
 """
@@ -86,9 +86,10 @@ the ordering of the dimensions will match those in `dims`. If `drop = false`, th
 `Slices` will have the same dimensionality as the underlying array, with inner
 dimensions having size 1.
 
-See [`stack`](@ref)`(slices; dims)` for the inverse of `eachslice(A; dims::Integer)`.
+For matrices, the case `dims = 1` is [`eachrow`](@ref), and `dims = 2` is [`eachcol`](@ref). 
 
-See also [`eachrow`](@ref), [`eachcol`](@ref), [`mapslices`](@ref) and [`selectdim`](@ref).
+[`stack`](@ref)`(slices; dims)` is the inverse of `eachslice(A; dims::Integer, drop=true)`.
+See also [`mapslices`](@ref) and [`selectdim`](@ref).
 
 !!! compat "Julia 1.1"
      This function requires at least Julia 1.1.
@@ -105,8 +106,8 @@ julia> m = [1 2 3; 4 5 6; 7 8 9]
  4  5  6
  7  8  9
 
-julia> s = eachslice(m, dims=1)
-3-element RowSlices{Matrix{Int64}, Tuple{Base.OneTo{Int64}}, SubArray{Int64, 1, Matrix{Int64}, Tuple{Int64, Base.Slice{Base.OneTo{Int64}}}, true}}:
+julia> s = eachslice(m, dims=1)  # same as eachrow(m)
+3-element eachrow(::Matrix{Int64}) of 3-element slices with eltype Int64:
  [1, 2, 3]
  [4, 5, 6]
  [7, 8, 9]
@@ -117,11 +118,16 @@ julia> s[1]
  2
  3
 
-julia> eachslice(m, dims=1, drop=false)
-3×1 Slices{Matrix{Int64}, Tuple{Int64, Colon}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}, SubArray{Int64, 1, Matrix{Int64}, Tuple{Int64, Base.Slice{Base.OneTo{Int64}}}, true}, 2}:
+julia> eachslice(m, dims=1, drop=false)  # keyword changes outer size
+3×1 eachslice(::Matrix{Int64}, dims = 1, drop = false) of 3-element slices with eltype Int64:
  [1, 2, 3]
  [4, 5, 6]
  [7, 8, 9]
+
+julia> eachslice(Any[pi, 2pi], dims=1)  # eachrow would produce vector slices
+2-element eachslice(::Vector{Any}, dims = 1) of 0-dimensional slices with eltype Any:
+ fill(π)
+ fill(6.283185307179586)
 ```
 """
 @inline function eachslice(A; dims, drop=true)
@@ -147,20 +153,29 @@ See also [`eachcol`](@ref), [`eachslice`](@ref) and [`mapslices`](@ref).
 # Example
 
 ```jldoctest
-julia> a = [1 2; 3 4]
-2×2 Matrix{Int64}:
- 1  2
- 3  4
+julia> a = [1 2 3; 40 50 60]
+2×3 Matrix{Int64}:
+  1   2   3
+ 40  50  60
 
 julia> s = eachrow(a)
-2-element RowSlices{Matrix{Int64}, Tuple{Base.OneTo{Int64}}, SubArray{Int64, 1, Matrix{Int64}, Tuple{Int64, Base.Slice{Base.OneTo{Int64}}}, true}}:
- [1, 2]
- [3, 4]
+2-element eachrow(::Matrix{Int64}) of 3-element slices with eltype Int64:
+ [1, 2, 3]
+ [40, 50, 60]
 
 julia> s[1]
-2-element view(::Matrix{Int64}, 1, :) with eltype Int64:
+3-element view(::Matrix{Int64}, 1, :) with eltype Int64:
  1
  2
+ 3
+
+julia> s isa RowSlices, s[1] isa SubArray
+(true, true)
+
+julia> eachrow(Any[pi, 2pi])  # reshapes vector to matrix before slicing
+2-element eachrow(::Matrix{Any}) of 1-element slices with eltype Any:
+ [π]
+ [6.283185307179586]
 ```
 """
 eachrow(A::AbstractMatrix) = _eachslice(A, (1,), true)
@@ -185,20 +200,31 @@ See also [`eachrow`](@ref), [`eachslice`](@ref) and [`mapslices`](@ref).
 # Example
 
 ```jldoctest
-julia> a = [1 2; 3 4]
-2×2 Matrix{Int64}:
- 1  2
- 3  4
+julia> a = [1 2 3; 40 50 60]
+2×3 Matrix{Int64}:
+  1   2   3
+ 40  50  60
 
 julia> s = eachcol(a)
-2-element ColumnSlices{Matrix{Int64}, Tuple{Base.OneTo{Int64}}, SubArray{Int64, 1, Matrix{Int64}, Tuple{Base.Slice{Base.OneTo{Int64}}, Int64}, true}}:
- [1, 3]
- [2, 4]
+3-element eachcol(::Matrix{Int64}) of 2-element slices with eltype Int64:
+ [1, 40]
+ [2, 50]
+ [3, 60]
 
-julia> s[1]
-2-element view(::Matrix{Int64}, :, 1) with eltype Int64:
- 1
- 3
+julia> s[3]
+2-element view(::Matrix{Int64}, :, 3) with eltype Int64:
+  3
+ 60
+
+julia> s isa ColumnSlices
+true
+
+julia> parent(s) === a
+true
+
+julia> eachcol('a':'c')  # accepts AbstractVector too, reshapes to 1-colum matrix:
+1-element eachcol(reshape(::StepRange{Char, Int64}, 3, 1)) of 3-element slices with eltype Char:
+ ['a', 'b', 'c']
 ```
 """
 eachcol(A::AbstractMatrix) = _eachslice(A, (2,), true)


### PR DESCRIPTION
This proposes to print the `Slices` objects from #32310 in a similar way to `SubArray`, `ReshapedArray`, etc. These compose nicely:
```julia
julia> view(rand(10)', 2:3)
2-element view(reshape(adjoint(::Vector{Float64}), 10), 2:3) with eltype Float64:
 0.09114060604932506
 0.6108851444289344

julia> eachcol(ans)
1-element eachcol(reshape(view(reshape(adjoint(::Vector{Float64}), 10), 2:3), 2, 1)) of 2-element slices with eltype Float64:
 [0.09114060604932506, 0.6108851444289344]

julia> eltype(ans)
SubArray{Float64, 1, Base.ReshapedArray{Float64, 2, SubArray{Float64, 1, Base.ReshapedArray{Float64, 1, Adjoint{Float64, Vector{Float64}}, Tuple{}}, Tuple{UnitRange{Int64}}, true}, Tuple{}}, Tuple{Base.Slice{Base.OneTo{Int64}}, Int64}, true}
```
Most `showarg` methods have the outermost one print the `eltype` of the object. Here this is a long and not especially illuminating SubArray type, so instead it prints the size of the elements, and `eltype(eltype(s))`. Examples (edit: focusing on the empty case, as initially this needed special treatment):
```julia
julia> eachrow(Int[])
0-element eachrow(::Matrix{Int64}) of 1-element slices with eltype Int64

julia> eachcol(Int[])
1-element eachcol(::Matrix{Int64}) of 0-element slices with eltype Int64:
 0-element view(::Matrix{Int64}, :, 1) with eltype Int64
```

~~Finally, it also hides this `SubArray` type in compact show. Not completely sure that's a good idea:~~ (removed for now)
```julia
julia> eachcol([1 2 3; 44 55 66]) |> repr
"[[1, 44], [2, 55], [3, 66]]"

julia> (0, eachcol(Float32[1 2; 3 4]), 5)  # array within a tuple uses 2-arg show
(0, [Float32[1.0, 3.0], Float32[2.0, 4.0]], 5)
```