### PR TITLE
Fix error in validating complex row-first hvncat

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2406,7 +2406,7 @@ function _typed_hvncat_dims(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, as
             for i ∈ offset .+ (2:dims[d])
                 for dd ∈ 1:N
                     dd == d && continue
-                    if size(as[startelementi], dd) != size(as[i], dd)
+                    if cat_size(as[startelementi], dd) != cat_size(as[i], dd)
                         throw(ArgumentError("incompatible shape in element $i"))
                     end
                 end

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2396,6 +2396,9 @@ function _typed_hvncat_dims(::Type{T}, dims::NTuple{N, Int}, row_first::Bool, as
     # validate shapes for lowest level of concatenation
     d = findfirst(>(1), dims)
     if d !== nothing # all dims are 1
+        if row_first && d < 3
+            d = d == 1 ? 2 : 1
+        end
         nblocks = length(as) ÷ dims[d]
         for b ∈ 1:nblocks
             offset = ((b - 1) * dims[d])

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1544,7 +1544,7 @@ using Base: typed_hvncat
     @test_throws ArgumentError [[1 1]; 2 ;; 3 ; [3 4]]
     @test_throws ArgumentError [[1 ;;; 1]; 2 ;;; 3 ; [3 ;;; 4]]
 
-    @test [[1 2; 3 4] [5; 6]; [7 8] 9;;;] == [1 2 5; 3 4 6; 7 8 9]
+    @test [[1 2; 3 4] [5; 6]; [7 8] 9;;;] == [1 2 5; 3 4 6; 7 8 9;;;]
 end
 
 @testset "keepat!" begin

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1543,6 +1543,8 @@ using Base: typed_hvncat
     # Issue 43933 - semicolon precedence mistake should produce an error
     @test_throws ArgumentError [[1 1]; 2 ;; 3 ; [3 4]]
     @test_throws ArgumentError [[1 ;;; 1]; 2 ;;; 3 ; [3 ;;; 4]]
+
+    @test [[1 2; 3 4] [5; 6]; [7 8] 9;;;] == [1 2 5; 3 4 6; 7 8 9]
 end
 
 @testset "keepat!" begin


### PR DESCRIPTION
With the validation logic implemented in #43940 , a complex input can fail in row-first mode:

```
[[1 2; 3 4] [5; 6]; [7 8] 9;;;]
ERROR: ArgumentError: incompatible shape in element 2
Stacktrace:
 [1] _typed_hvncat_dims(#unused#::Type{Int64}, dims::Tuple{Int64, Int64, Int64}, row_first::Bool, as::Tuple{Matrix{Int64}, Vector{Int64}, Matrix{Int64}, Int64})
   @ Base .\abstractarray.jl:2386
 [2] _typed_hvncat(::Type, ::Tuple{Int64, Int64, Int64}, ::Bool, ::Matrix{Int64}, ::Vararg{Any})
   @ Base .\abstractarray.jl:2361
 [3] _hvncat(::Tuple{Int64, Int64, Int64}, ::Bool, ::Matrix{Int64}, ::Vararg{Any})
   @ Base .\abstractarray.jl:2190
 [4] hvncat(::Tuple{Int64, Int64, Int64}, ::Bool, ::Matrix{Int64}, ::Vararg{Any})
   @ Base .\abstractarray.jl:2186
 [5] top-level scope
   @ REPL[39]:1

# Expected
3×3×1 Array{Int64, 3}:
[:, :, 1] =
 1  2  5
 3  4  6
 7  8  9
```

This was due to failing to adjust the check for the row first mode. This PR fixes it.

This should probably be backported into 1.8 and 1.7.3 before release.