### PR TITLE
Update distributed doc

### DIFF
--- a/doc/src/manual/distributed-computing.md
+++ b/doc/src/manual/distributed-computing.md
@@ -250,6 +250,11 @@ The base Julia installation has in-built support for two types of clusters:
     to 1. The optional `bind-to bind_addr[:port]` specifies the IP address and port that other workers
     should use to connect to this worker.
 
+!!! note
+    While Julia generally strives for backward compatability, distribution of code to worker processes relies on 
+    [`Serialization`](@ref). As pointed out in the corresponding documentation, this can not be guaranteed to work across 
+    different Julia versions, so it is advised that all workers on all machines use the same.
+
 Functions [`addprocs`](@ref), [`rmprocs`](@ref), [`workers`](@ref), and others are available
 as a programmatic means of adding, removing and querying the processes in a cluster.
 

--- a/doc/src/manual/distributed-computing.md
+++ b/doc/src/manual/distributed-computing.md
@@ -252,7 +252,7 @@ The base Julia installation has in-built support for two types of clusters:
 
 !!! note
     While Julia generally strives for backward compatability, distribution of code to worker processes relies on 
-    [`Serialization`](@ref). As pointed out in the corresponding documentation, this can not be guaranteed to work across 
+    [`Serialization.serialize`](@ref). As pointed out in the corresponding documentation, this can not be guaranteed to work across 
     different Julia versions, so it is advised that all workers on all machines use the same.
 
 Functions [`addprocs`](@ref), [`rmprocs`](@ref), [`workers`](@ref), and others are available

--- a/doc/src/manual/distributed-computing.md
+++ b/doc/src/manual/distributed-computing.md
@@ -253,7 +253,7 @@ The base Julia installation has in-built support for two types of clusters:
 !!! note
     While Julia generally strives for backward compatability, distribution of code to worker processes relies on 
     [`Serialization.serialize`](@ref). As pointed out in the corresponding documentation, this can not be guaranteed to work across 
-    different Julia versions, so it is advised that all workers on all machines use the same.
+    different Julia versions, so it is advised that all workers on all machines use the same version.
 
 Functions [`addprocs`](@ref), [`rmprocs`](@ref), [`workers`](@ref), and others are available
 as a programmatic means of adding, removing and querying the processes in a cluster.

--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -107,7 +107,9 @@ addprocs([
   processes. Default is `false`.
 
 * `exename`: name of the `julia` executable. Defaults to `"\$(Sys.BINDIR)/julia"` or
-  `"\$(Sys.BINDIR)/julia-debug"` as the case may be.
+  `"\$(Sys.BINDIR)/julia-debug"` as the case may be. It is recommended that a common Julia 
+  version is used on all remote machines because serialization and code distribution might 
+  fail otherwise.
 
 * `exeflags`: additional flags passed to the worker processes.
 


### PR DESCRIPTION
As discussed in https://github.com/JuliaLang/Distributed.jl/issues/49, the documentation should point out that Julia versions should be the same on all remote workers involved in distributed computing to guarantee that serialization works.