### PR TITLE
added new command line option heap_size_hint for greedy GC

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,9 @@ Command-line option changes
 * `--math-mode=fast` is now a no-op ([#41638]). Users are encouraged to use the @fastmath macro instead, which has more well-defined semantics.
 * The `--threads` command-line option now accepts `auto|N[,auto|M]` where `M` specifies the
   number of interactive threads to create (`auto` currently means 1) ([#42302]).
+* New option `--heap-size-hint=<size>` gives a memory hint for triggering greedy garbage
+  collection. The size might be specified in bytes, kilobytes(1000k), megabytes(300M),
+  gigabytes(1.5G)
 
 Multi-threading changes
 -----------------------

--- a/base/options.jl
+++ b/base/options.jl
@@ -52,6 +52,7 @@ struct JLOptions
     rr_detach::Int8
     strip_metadata::Int8
     strip_ir::Int8
+    heap_size_hint::UInt64
 end
 
 # This runs early in the sysimage != is not defined yet

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -217,6 +217,11 @@ fallbacks to the latest compatible BugReporting.jl if not. For more information,
 --bug-report=help.
 
 .TP
+--heap-size-hint=<size>
+Forces garbage collection if memory usage is higher that value. The memory hint might be
+specified in megabytes (500M) or gigabytes (1.5G)
+
+.TP
 --compile={yes*|no|all|min}
 Enable or disable JIT compiler, or request exhaustive or minimal compilation
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -589,17 +589,19 @@ static int64_t last_gc_total_bytes = 0;
 // max_total_memory is a suggestion.  We try very hard to stay
 // under this limit, but we will go above it rather than halting.
 #ifdef _P64
+typedef uint64_t memsize_t;
 #define default_collect_interval (5600*1024*sizeof(void*))
 static size_t max_collect_interval = 1250000000UL;
 // Eventually we can expose this to the user/ci.
-static uint64_t max_total_memory = (uint64_t) 2 * 1024 * 1024 * 1024 * 1024 * 1024;
+memsize_t max_total_memory = (memsize_t) 2 * 1024 * 1024 * 1024 * 1024 * 1024;
 #else
+typedef memsize_t uint32_t;
 #define default_collect_interval (3200*1024*sizeof(void*))
 static size_t max_collect_interval =  500000000UL;
 // Work really hard to stay within 2GB
 // Alternative is to risk running out of address space
 // on 32 bit architectures.
-static uint32_t max_total_memory = (uint32_t) 2 * 1024 * 1024 * 1024;
+memsize_t max_total_memory = (memsize_t) 2 * 1024 * 1024 * 1024;
 #endif
 
 // global variables for GC stats
@@ -3444,6 +3446,13 @@ void jl_gc_init(void)
     jl_gc_mark_sp_t sp = {NULL, NULL, NULL, NULL};
     gc_mark_loop(NULL, sp);
     t_start = jl_hrtime();
+}
+
+void jl_gc_set_max_memory(uint64_t max_mem) {
+    if (max_mem > 0
+        && max_mem < (uint64_t)1 << (sizeof(memsize_t) * 8 - 1)) {
+        max_total_memory = max_mem;
+    }
 }
 
 // callback for passing OOM errors from gmp

--- a/src/gc.c
+++ b/src/gc.c
@@ -595,7 +595,7 @@ static size_t max_collect_interval = 1250000000UL;
 // Eventually we can expose this to the user/ci.
 memsize_t max_total_memory = (memsize_t) 2 * 1024 * 1024 * 1024 * 1024 * 1024;
 #else
-typedef memsize_t uint32_t;
+typedef uint32_t memsize_t;
 #define default_collect_interval (3200*1024*sizeof(void*))
 static size_t max_collect_interval =  500000000UL;
 // Work really hard to stay within 2GB

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -56,6 +56,7 @@ typedef struct {
     int8_t rr_detach;
     int8_t strip_metadata;
     int8_t strip_ir;
+    uint64_t heap_size_hint;
 } jl_options_t;
 
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -467,6 +467,9 @@ void jl_gc_count_allocd(size_t sz) JL_NOTSAFEPOINT;
 void jl_gc_run_all_finalizers(jl_task_t *ct);
 void jl_release_task_stack(jl_ptls_t ptls, jl_task_t *task);
 
+// Set GC memory trigger in bytes for greedy memory collecting
+void jl_gc_set_max_memory(uint64_t max_mem);
+
 JL_DLLEXPORT void jl_gc_queue_binding(jl_binding_t *bnd) JL_NOTSAFEPOINT;
 void gc_setmark_buf(jl_ptls_t ptls, void *buf, uint8_t, size_t) JL_NOTSAFEPOINT;
 


### PR DESCRIPTION
The changes add a new command-line option `--heap_size_hint` for triggering aggressive garbage collection.

The following code might be used for checking that option.
```julia
using Dates

const mem_size = 0x1_000_000

counter = let
    counter = 0
    start_t = now()

    while (now() - start_t) / Millisecond(1000) < 15
        counter += 1
        arr = Vector{Int32}(undef, mem_size)
        arr[rand(1:mem_size)] = rand(Int32, 1)[begin]
        # sleep(1)
    end
    counter
end

@show counter, mem_size
```

Memory consumption might be estimated with `% gtime --verbose usr/bin/julia memory_test.jl `:
```
(counter, mem_size) = (348403, 0x01000000)
	Command being timed: "usr/bin/julia memory_test.jl"
	User time (seconds): 20.86
...
	Maximum resident set size (kbytes): 440704
...
```

Use `time` for Linux and `gtime` for MacOS.

And, memory consumption after adding the hint
`% gtime --verbose usr/bin/julia --heap-size-hint=100m memory_test.jl`:
```
(counter, mem_size) = (436, 0x01000000)
	Command being timed: "usr/bin/julia --heap-size-hint=100m memory_test.jl"
	User time (seconds): 15.24
...
	Maximum resident set size (kbytes): 267024
...
```