### PR TITLE
Profile.getdict!: Revert drive-by change-of-behavior in performance patch

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -405,8 +405,7 @@ function getdict(data::Vector{UInt})
 end
 
 function getdict!(dict::LineInfoDict, data::Vector{UInt})
-    # we don't want metadata here as we're just looking up ips
-    unique_ips = unique(has_meta(data) ? strip_meta(data) : data)
+    unique_ips = unique(data)
     n_unique_ips = length(unique_ips)
     n_unique_ips == 0 && return dict
     iplookups = similar(unique_ips, Vector{StackFrame})


### PR DESCRIPTION
The pull request #43816 is supposed to be a performance improvement (only), but also changes behaviour: it's now possible for `getdict!(dict, data)` to return with some elements of `data` not a valid key in `dict`.

Maybe this is a desired improvement now that `data` also contains metadata about taskid and threadid, but it's certainly breaking at least one registered package (which I reported as #45361).

I propose we keep the performance improvement but revert the change in behaviour. We can then discuss the behaviour's merit in a separate pull request if desired, without the time pressure of the imminent v1.8 release.