### PR TITLE
Do not set MCPU on Apple Silicon

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -898,10 +898,6 @@ OPENBLAS_DYNAMIC_ARCH:=0
 OPENBLAS_TARGET_ARCH:=ARMV8
 USE_BLAS64:=1
 BINARY:=64
-ifeq ($(OS),Darwin)
-# Apple Chips are all at least A12Z
-MCPU:=apple-m1
-endif
 endif
 
 # Set MARCH-specific flags


### PR DESCRIPTION
This fixes build from source on Apple Silicon: https://github.com/JuliaLang/julia/issues/44517

This `MCPU:=apple-m1` leads to `-mcpu=apple-m1` being passed to `CC`, `CXX`, and `FC`. However, `apple-m1` is a valid option name for `clang`, but not for `gcc` and `gfortran`, and this leads to a build failure in OpenBLAS.

In fact, passing `-mcpu=apple-m1` to the compilers is actually unnecessary: all macOS ARM compilers know what the baseline for support on this target is, and already compile code accordingly (this is true of clang and gcc/gfortran). So the simplest fix here is to remove this special case entirely. It was introduced in https://github.com/JuliaLang/julia/pull/36624, I think with the intent of allowing better optimisation. poke @Keno 