### PR TITLE
Don't error when transposing a single character

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1087,8 +1087,9 @@ function edit_transpose_chars(s::MIState)
 end
 
 function edit_transpose_chars(buf::IOBuffer)
-    position(buf) == 0 && return false
+    # Moving left but not transpoing anything is intentional, and matches Emacs's behavior
     eof(buf) && char_move_left(buf)
+    position(buf) == 0 && return false
     char_move_left(buf)
     pos = position(buf)
     a, b = read(buf, Char), read(buf, Char)

--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -375,6 +375,16 @@ let buf = IOBuffer()
     @test content(buf) == "βγαεδ"
     LineEdit.edit_transpose_chars(buf)
     @test content(buf) == "βγαδε"
+
+    seek(buf, 0)
+    @inferred(LineEdit.edit_clear(buf))
+    edit_insert(buf, "a")
+    LineEdit.edit_transpose_chars(buf)
+    @test content(buf) == "a"
+    seekend(buf)
+    LineEdit.edit_transpose_chars(buf)
+    @test content(buf) == "a"
+    @test position(buf) == 0
 end
 
 @testset "edit_word_transpose" begin


### PR DESCRIPTION
This fixes an issue where an error would be thrown in the REPL if you tried to transpose an input that was a single character while your cursor was to the right of that character (e.g., "A|"). To fix this, let's move left once before we check for if we're at the start of a line. This does change behavior slightly in that the cursor can move left once without actually transposing anything, but this seems to match what Emacs does with M-x transpose-chars in an equivalent situation.

Fixes #45417.