### PR TITLE
Add `notasklocal` effect

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1998,7 +1998,8 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
                 effects.effect_free ? ALWAYS_TRUE : TRISTATE_UNKNOWN,
                 effects.nothrow ? ALWAYS_TRUE : TRISTATE_UNKNOWN,
                 effects.terminates_globally ? ALWAYS_TRUE : TRISTATE_UNKNOWN,
-                #=nonoverlayed=#true
+                #=nonoverlayed=#true,
+                #=notaskstate=#TRISTATE_UNKNOWN
             ))
         else
             tristate_merge!(sv, EFFECTS_UNKNOWN)

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -802,6 +802,8 @@ function Base.show(io::IO, e::Core.Compiler.Effects)
     printstyled(io, string(tristate_letter(e.nothrow), 'n'); color=tristate_color(e.nothrow))
     print(io, ',')
     printstyled(io, string(tristate_letter(e.terminates), 't'); color=tristate_color(e.terminates))
+    print(io, ',')
+    printstyled(io, string(tristate_letter(e.notaskstate), 's'); color=tristate_color(e.notaskstate))
     print(io, ')')
     e.nonoverlayed || printstyled(io, '′'; color=:red)
 end


### PR DESCRIPTION
Split out from #45272. This effect models the legality of moving code
between tasks. It is somewhat related to effect-free/consistent, but
only with respect to task-local state. As an example consider something
like:

```
global glob
function bar()
    @async (global glob = 1; some_other_code())
end
```

The newly created task is not effect-free, but it would be legal to inline
the assignment of `glob` into `bar` (as long it is inlined before the creation
of the task of `some_other_code` does not access `glob`). For comparison,
the following is neither `notls`, nor `effect_free`:

```
function bar()
    @async (task_local_storage()[:var] = 1; some_other_code())
end
```

The same implies to implicit task-local state such as the RNG state.

Implementation wise, there isn't a lot here, because the implicit
tainting by ccall is the correct conservative default. In the future,
we may want to annotate various ccalls as being permissible for
notls, but let's worry about that when we have a case that needs it.