### PR TITLE
Improve documentation of unary :

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -683,7 +683,7 @@ Expr
 Expr
 
 """
-	(:)(expr)
+    (:)(expr)
 
 `:expr` quotes `expr`, returning an abstract syntax tree (AST) of `expr`.
 The AST may be of type `Expr`, `Symbol`, or a literal value.

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -685,7 +685,7 @@ Expr
 """
     (:)(expr)
 
-`:expr` quotes `expr`, returning an abstract syntax tree (AST) of `expr`.
+`:expr` quotes the expression `expr`, returning the abstract syntax tree (AST) of `expr`.
 The AST may be of type `Expr`, `Symbol`, or a literal value.
 Which of these three types are returned for any given expression is an
 implementation detail.

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -683,6 +683,33 @@ Expr
 Expr
 
 """
+	(:)(expr)
+
+`:expr` quotes `expr`, returning an abstract syntax tree (AST) of `expr`.
+The AST may be of type `Expr`, `Symbol`, or a literal value.
+Which of these three types are returned for any given expression is an
+implementation detail.
+
+See also: [`Expr`](@ref), [`Symbol`](@ref), [`Meta.parse`](@ref)
+
+# Examples
+```jldoctest
+julia> expr = :(a = b + 2*x)
+:(a = b + 2x)
+
+julia> sym = :some_identifier
+:some_identifier
+
+julia> value = :0xff
+0xff
+
+julia> typeof((expr, sym, value))
+Tuple{Expr, Symbol, UInt8}
+```
+"""
+(:)
+
+"""
     \$
 
 Interpolation operator for interpolating into e.g. [strings](@ref string-interpolation)

--- a/base/range.jl
+++ b/base/range.jl
@@ -29,13 +29,39 @@ _colon(::Any, ::Any, start::T, step, stop::T) where {T} =
     StepRangeLen(start, step, floor(Integer, (stop-start)/step)+1)
 
 """
+	(:)(expr)
+
+`:expr` quotes `expr`, returning an abstract syntax tree (AST) of `expr`.
+The AST may be of type `Expr`, `Symbol`, or a literal value.
+Which of these three types are returned for any given expression is an
+implementation detail.
+
+See also: [`Expr`](@ref), [`Symbol`](@ref), [`Meta.parse`](@ref)
+
+# Examples
+```jldoctest
+julia> expr = :(a = b + 2*x)
+:(a = b + 2x)
+
+julia> sym = :some_identifier
+:some_identifier
+
+julia> value = :0xff
+0xff
+
+julia> typeof((expr, sym, value))
+Tuple{Expr, Symbol, UInt8}
+```
+"""
+(:)
+
+"""
     (:)(start, [step], stop)
 
 Range operator. `a:b` constructs a range from `a` to `b` with a step size of 1 (a [`UnitRange`](@ref))
 , and `a:s:b` is similar but uses a step size of `s` (a [`StepRange`](@ref)).
 
-`:` is also used in indexing to select whole dimensions
- and for [`Symbol`](@ref) literals, as in e.g. `:hello`.
+`:` is also used in indexing to select whole dimensions, e.g. in `A[:, 1]`.
 """
 (:)(start::T, step, stop::T) where {T} = _colon(start, step, stop)
 (:)(start::T, step, stop::T) where {T<:Real} = _colon(start, step, stop)

--- a/base/range.jl
+++ b/base/range.jl
@@ -29,33 +29,6 @@ _colon(::Any, ::Any, start::T, step, stop::T) where {T} =
     StepRangeLen(start, step, floor(Integer, (stop-start)/step)+1)
 
 """
-	(:)(expr)
-
-`:expr` quotes `expr`, returning an abstract syntax tree (AST) of `expr`.
-The AST may be of type `Expr`, `Symbol`, or a literal value.
-Which of these three types are returned for any given expression is an
-implementation detail.
-
-See also: [`Expr`](@ref), [`Symbol`](@ref), [`Meta.parse`](@ref)
-
-# Examples
-```jldoctest
-julia> expr = :(a = b + 2*x)
-:(a = b + 2x)
-
-julia> sym = :some_identifier
-:some_identifier
-
-julia> value = :0xff
-0xff
-
-julia> typeof((expr, sym, value))
-Tuple{Expr, Symbol, UInt8}
-```
-"""
-(:)
-
-"""
     (:)(start, [step], stop)
 
 Range operator. `a:b` constructs a range from `a` to `b` with a step size of 1 (a [`UnitRange`](@ref))


### PR DESCRIPTION
Unary `:` was poorly documented previously. The previous docs stated it would
return a Symbol, but in fact also Expr objects and literal values can be
returned from code quoting.

See #43054