### PR TITLE
llvm: add NDEBUG when assertion mode is off

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -449,6 +449,8 @@ SKIP_IMPLICIT_ATOMICS := dump.c module.c staticdata.c codegen.cpp
  # these need to be annotated (and possibly fixed)
 SKIP_GC_CHECK := codegen.cpp rtutils.c
 
+# make sure LLVM's invariant information is not discarded with -DNDEBUG
+clang-sagc-%: JL_CXXFLAGS += -UNDEBUG
 clang-sagc-%: $(SRCDIR)/%.c $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) .FORCE | analyzegc-deps-check
 	@$(call PRINT_ANALYZE, $(build_depsbindir)/clang -D__clang_gcanalyzer__ --analyze -Xanalyzer -analyzer-werror -Xanalyzer -analyzer-output=text --analyzer-no-default-checks \
 		-Xclang -load -Xclang $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) -Xclang -analyzer-checker=core$(COMMA)julia.GCChecker \
@@ -460,6 +462,7 @@ clang-sagc-%: $(SRCDIR)/%.cpp $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT) 
 		$(SA_EXCEPTIONS-$(notdir $<)) \
 		$(CLANGSA_FLAGS) $(CLANGSA_CXXFLAGS) $(LLVM_CXXFLAGS) $(JCPPFLAGS) $(JCXXFLAGS) $(JL_CXXFLAGS) $(DEBUGFLAGS) -fcolor-diagnostics -x c++ $<)
 
+clang-sa-%: JL_CXXFLAGS += -UNDEBUG
 clang-sa-%: $(SRCDIR)/%.c .FORCE | analyzegc-deps-check
 	@$(call PRINT_ANALYZE, $(build_depsbindir)/clang --analyze -Xanalyzer -analyzer-werror -Xanalyzer -analyzer-output=text \
 		-Xanalyzer -analyzer-disable-checker=deadcode.DeadStores \

--- a/src/Makefile
+++ b/src/Makefile
@@ -110,6 +110,11 @@ PUBLIC_HEADER_TARGETS := $(addprefix $(build_includedir)/julia/,$(notdir $(PUBLI
 LLVM_LDFLAGS := $(shell $(LLVM_CONFIG_HOST) --ldflags)
 LLVM_CXXFLAGS := $(shell $(LLVM_CONFIG_HOST) --cxxflags)
 
+# llvm-config --cxxflags does not return -DNDEBUG
+ifeq ($(shell $(LLVM_CONFIG_HOST) --assertion-mode),OFF)
+LLVM_CXXFLAGS += -DNDEBUG
+endif
+
 ifeq ($(JULIACODEGEN),LLVM)
 ifneq ($(USE_SYSTEM_LLVM),0)
 CG_LLVMLINK += $(LLVM_LDFLAGS) $(shell $(LLVM_CONFIG_HOST) --libs --system-libs)


### PR DESCRIPTION
`llvm-config --cxxflags` unfortunately does not return `-DNDEBUG` when LLVM is
built with it, but Julia is required to have this define when including LLVM
header files. I didn't check if llvm-config --cxxflags has changed at some
point in LLVM (I think so because Julia switched from explicit `-DNDEBUG` to
`llvm-config --cxxflags` in v0.2.0 ages ago [1]), but the `llvm-config --assertion-mode`
flag was introduced a little after Julia dropped explicit `-DNDEBUG` [2].

Found this when compiling Julia with PGO enabled, which simply fails to link
because of virtual functions LLVM guards behind ifdefs.

[1] https://github.com/JuliaLang/julia/commit/d2f6a780fa5ac4e5d3b1d855daecbf21badd58e2
[2] https://github.com/llvm-mirror/llvm/commit/042795734d3697fc3a6318460544b44a060d179f
