### PR TITLE
Remove inlining special case for effectful GlobalRef in statement pos…

### DIFF
--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -153,8 +153,10 @@ function fixemup!(cond, rename, ir::IRCode, ci::CodeInfo, idx::Int, @nospecializ
                 return nothing
             end
             op[] = x
-        elseif isa(val, GlobalRef) && !(isdefined(val.mod, val.name) && isconst(val.mod, val.name))
-            op[] = NewSSAValue(insert_node!(ir, idx, NewInstruction(val, Any)).id - length(ir.stmts))
+        elseif isa(val, GlobalRef) && !(isdefined(val.mod, val.name) && isconst(val.mod, val.name)) ||
+               (isa(val, Expr) && val.head === :static_parameter)
+            op[] = NewSSAValue(insert_node!(ir, idx,
+                NewInstruction(val, typ_for_val(val, ci, ir.sptypes, idx, Any[]))).id - length(ir.stmts))
         end
     end
     return urs[]

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1279,3 +1279,12 @@ end
 # Test that inlining doesn't accidentally delete a bad return_type call
 f_bad_return_type() = Core.Compiler.return_type(+, 1, 2)
 @test_throws MethodError f_bad_return_type()
+
+# Test that inlining doesn't leave useless globalrefs around
+f_ret_nothing(x) = (Base.donotdelete(x); return nothing)
+let src = code_typed1(Tuple{Int}) do x
+        f_ret_nothing(x)
+        return 1
+    end
+    @test count(x -> isa(x, Core.GlobalRef) && x.name === :nothing, src.code) == 0
+end


### PR DESCRIPTION
…ition

Having an effectful GlobalRef in statement position has been illegal in
IRCode since 39c278b728deb04c3a32d70e3e35dcef7822c0c0. This code predates that
and probably should have been adjusted at the time. It used to not really
cause an issue, but now that we're using ir-flags to determine effectfulness
rather than recomputing it every time, we were littering the IR with
undeleted GlobalRefs. Removing the special case fixes that up and results
in (marginally) smaller and cleaner IR.