### PR TITLE
follow #45440, add assertion to check concrete-eval call is compileable

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -788,20 +788,20 @@ end
 
 function compileable_specialization(et::Union{EdgeTracker, Nothing}, match::MethodMatch, effects::Effects)
     mi = specialize_method(match; compilesig=true)
+    mi !== nothing && et !== nothing && push!(et, mi::MethodInstance)
     mi === nothing && return nothing
-    et !== nothing && push!(et, mi)
     return InvokeCase(mi, effects)
 end
 
 function compileable_specialization(et::Union{EdgeTracker, Nothing}, linfo::MethodInstance, effects::Effects)
     mi = specialize_method(linfo.def::Method, linfo.specTypes, linfo.sparam_vals; compilesig=true)
+    mi !== nothing && et !== nothing && push!(et, mi::MethodInstance)
     mi === nothing && return nothing
-    et !== nothing && push!(et, mi)
     return InvokeCase(mi, effects)
 end
 
-function compileable_specialization(et::Union{EdgeTracker, Nothing}, result::InferenceResult, effects::Effects)
-    return compileable_specialization(et, result.linfo, effects)
+function compileable_specialization(et::Union{EdgeTracker, Nothing}, (; linfo)::InferenceResult, effects::Effects)
+    return compileable_specialization(et, linfo, effects)
 end
 
 function resolve_todo(todo::InliningTodo, state::InliningState, flag::UInt8)
@@ -1283,11 +1283,7 @@ function handle_const_call!(
             any_fully_covered |= match.fully_covers
             if isa(result, ConcreteResult)
                 case = concrete_result_item(result, state)
-                if case === nothing
-                    handled_all_cases = false
-                else
-                    push!(cases, InliningCase(result.mi.specTypes, case))
-                end
+                push!(cases, InliningCase(result.mi.specTypes, case))
             elseif isa(result, ConstPropResult)
                 handled_all_cases &= handle_const_prop_result!(result, argtypes, flag, state, cases, true)
             else


### PR DESCRIPTION
Partially reverts #45451 as #45440 should be fixed by #45348.
In addition to that revert, this commit adds assertion to check concrete-evaled callsite is compileable rather than having a special case for spurious uncomileable case.

In order to backport this, we should:
- backport https://github.com/JuliaLang/julia/pull/45348
- backport the two commits on this branch