### PR TITLE
inference: NFC refactoring on `Conditional`/`InterConditional`

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -434,7 +434,7 @@ eval(Core, quote
     Const(@nospecialize(v)) = $(Expr(:new, :Const, :v))
     PartialStruct(typ::DataType, fields::Array{Any, 1}) = $(Expr(:new, :PartialStruct, :typ, :fields))
     PartialOpaque(@nospecialize(typ), @nospecialize(env), parent::MethodInstance, source::Method) = $(Expr(:new, :PartialOpaque, :typ, :env, :parent, :source))
-    InterConditional(slot::Int, @nospecialize(vtype), @nospecialize(elsetype)) = $(Expr(:new, :InterConditional, :slot, :vtype, :elsetype))
+    InterConditional(slot::Int, @nospecialize(thentype), @nospecialize(elsetype)) = $(Expr(:new, :InterConditional, :slot, :thentype, :elsetype))
     MethodMatch(@nospecialize(spec_types), sparams::SimpleVector, method::Method, fully_covers::Bool) = $(Expr(:new, :MethodMatch, :spec_types, :sparams, :method, :fully_covers))
 end)
 

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -434,7 +434,6 @@ eval(Core, quote
     Const(@nospecialize(v)) = $(Expr(:new, :Const, :v))
     PartialStruct(typ::DataType, fields::Array{Any, 1}) = $(Expr(:new, :PartialStruct, :typ, :fields))
     PartialOpaque(@nospecialize(typ), @nospecialize(env), parent::MethodInstance, source::Method) = $(Expr(:new, :PartialOpaque, :typ, :env, :parent, :source))
-    InterConditional(slot::Int, @nospecialize(thentype), @nospecialize(elsetype)) = $(Expr(:new, :InterConditional, :slot, :thentype, :elsetype))
     MethodMatch(@nospecialize(spec_types), sparams::SimpleVector, method::Method, fully_covers::Bool) = $(Expr(:new, :MethodMatch, :spec_types, :sparams, :method, :fully_covers))
 end)
 

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -196,7 +196,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
             end
             for i = 1:length(argtypes)
                 cnd = conditional_argtype(this_conditional, sig, argtypes, i)
-                conditionals[1][i] = tmerge(conditionals[1][i], cnd.vtype)
+                conditionals[1][i] = tmerge(conditionals[1][i], cnd.thentype)
                 conditionals[2][i] = tmerge(conditionals[2][i], cnd.elsetype)
             end
         end
@@ -386,7 +386,7 @@ end
 function from_interconditional(@nospecialize(typ), sv::InferenceState, (; fargs, argtypes)::ArgInfo, @nospecialize(maybecondinfo))
     fargs === nothing && return widenconditional(typ)
     slot = 0
-    vtype = elsetype = Any
+    thentype = elsetype = Any
     condval = maybe_extract_const_bool(typ)
     for i in 1:length(fargs)
         # find the first argument which supports refinement,
@@ -399,20 +399,20 @@ function from_interconditional(@nospecialize(typ), sv::InferenceState, (; fargs,
         if slot == 0 || id == slot
             if isa(maybecondinfo, Tuple{Vector{Any},Vector{Any}})
                 # if we have already computed argument refinement information, apply that now to get the result
-                new_vtype = maybecondinfo[1][i]
+                new_thentype = maybecondinfo[1][i]
                 new_elsetype = maybecondinfo[2][i]
             else
                 # otherwise compute it on the fly
                 cnd = conditional_argtype(typ, maybecondinfo, argtypes, i)
-                new_vtype = cnd.vtype
+                new_thentype = cnd.thentype
                 new_elsetype = cnd.elsetype
             end
             if condval === false
-                vtype = Bottom
-            elseif new_vtype ⊑ vtype
-                vtype = new_vtype
+                thentype = Bottom
+            elseif new_thentype ⊑ thentype
+                thentype = new_thentype
             else
-                vtype = tmeet(vtype, widenconst(new_vtype))
+                thentype = tmeet(thentype, widenconst(new_thentype))
             end
             if condval === true
                 elsetype = Bottom
@@ -421,22 +421,22 @@ function from_interconditional(@nospecialize(typ), sv::InferenceState, (; fargs,
             else
                 elsetype = tmeet(elsetype, widenconst(new_elsetype))
             end
-            if (slot > 0 || condval !== false) && vtype ⋤ old
+            if (slot > 0 || condval !== false) && thentype ⋤ old
                 slot = id
             elseif (slot > 0 || condval !== true) && elsetype ⋤ old
                 slot = id
             else # reset: no new useful information for this slot
-                vtype = elsetype = Any
+                thentype = elsetype = Any
                 if slot > 0
                     slot = 0
                 end
             end
         end
     end
-    if vtype === Bottom && elsetype === Bottom
+    if thentype === Bottom && elsetype === Bottom
         return Bottom # accidentally proved this call to be dead / throw !
     elseif slot > 0
-        return Conditional(SlotNumber(slot), vtype, elsetype) # record a Conditional improvement to this slot
+        return Conditional(SlotNumber(slot), thentype, elsetype) # record a Conditional improvement to this slot
     end
     return widenconditional(typ)
 end
@@ -445,11 +445,11 @@ function conditional_argtype(@nospecialize(rt), @nospecialize(sig), argtypes::Ve
     if isa(rt, InterConditional) && rt.slot == i
         return rt
     else
-        vtype = elsetype = tmeet(argtypes[i], fieldtype(sig, i))
+        thentype = elsetype = tmeet(argtypes[i], fieldtype(sig, i))
         condval = maybe_extract_const_bool(rt)
         condval === true && (elsetype = Bottom)
-        condval === false && (vtype = Bottom)
-        return InterConditional(i, vtype, elsetype)
+        condval === false && (thentype = Bottom)
+        return InterConditional(i, thentype, elsetype)
     end
 end
 
@@ -1396,7 +1396,7 @@ function abstract_call_builtin(interp::AbstractInterpreter, f::Builtin, (; fargs
                 a = ssa_def_slot(fargs[3], sv)
                 b = ssa_def_slot(fargs[4], sv)
                 if isa(a, SlotNumber) && slot_id(cnd.var) == slot_id(a)
-                    tx = (cnd.vtype ⊑ tx ? cnd.vtype : tmeet(tx, widenconst(cnd.vtype)))
+                    tx = (cnd.thentype ⊑ tx ? cnd.thentype : tmeet(tx, widenconst(cnd.thentype)))
                 end
                 if isa(b, SlotNumber) && slot_id(cnd.var) == slot_id(b)
                     ty = (cnd.elsetype ⊑ ty ? cnd.elsetype : tmeet(ty, widenconst(cnd.elsetype)))
@@ -1465,7 +1465,7 @@ function abstract_call_builtin(interp::AbstractInterpreter, f::Builtin, (; fargs
             aty = argtypes[2]
             if isa(aty, Conditional)
                 ifty = aty.elsetype
-                elty = aty.vtype
+                elty = aty.thentype
                 if rt === Const(false)
                     ifty = Union{}
                 elseif rt === Const(true)
@@ -1478,22 +1478,22 @@ function abstract_call_builtin(interp::AbstractInterpreter, f::Builtin, (; fargs
             a = ssa_def_slot(fargs[2], sv)
             if isa(uty, Union) && isa(a, SlotNumber)
                 fld = argtypes[3]
-                vtype = Union{}
-                elsetype = Union{}
+                thentype = Bottom
+                elsetype = Bottom
                 for ty in uniontypes(uty)
                     cnd = isdefined_tfunc(ty, fld)
                     if isa(cnd, Const)
                         if cnd.val::Bool
-                            vtype = tmerge(vtype, ty)
+                            thentype = tmerge(thentype, ty)
                         else
                             elsetype = tmerge(elsetype, ty)
                         end
                     else
-                        vtype = tmerge(vtype, ty)
+                        thentype = tmerge(thentype, ty)
                         elsetype = tmerge(elsetype, ty)
                     end
                 end
-                return Conditional(a, vtype, elsetype)
+                return Conditional(a, thentype, elsetype)
             end
         end
     end
@@ -1650,13 +1650,13 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
         aty = argtypes[2]
         if isa(aty, Conditional)
             call = abstract_call_gf_by_type(interp, f, ArgInfo(fargs, Any[Const(f), Bool]), Tuple{typeof(f), Bool}, sv, max_methods) # make sure we've inferred `!(::Bool)`
-            return CallMeta(Conditional(aty.var, aty.elsetype, aty.vtype), call.effects, call.info)
+            return CallMeta(Conditional(aty.var, aty.elsetype, aty.thentype), call.effects, call.info)
         end
     elseif la == 3 && istopfunction(f, :!==)
         # mark !== as exactly a negated call to ===
         rty = abstract_call_known(interp, (===), arginfo, sv, max_methods).rt
         if isa(rty, Conditional)
-            return CallMeta(Conditional(rty.var, rty.elsetype, rty.vtype), EFFECTS_TOTAL, false) # swap if-else
+            return CallMeta(Conditional(rty.var, rty.elsetype, rty.thentype), EFFECTS_TOTAL, false) # swap if-else
         elseif isa(rty, Const)
             return CallMeta(Const(rty.val === false), EFFECTS_TOTAL, MethodResultPure())
         end
@@ -2118,7 +2118,7 @@ function widenreturn(@nospecialize(rt), @nospecialize(bestguess), nargs::Int, sl
             id = slot_id(rt.var)
             if 1 ≤ id ≤ nargs
                 old_id_type = widenconditional(slottypes[id]) # same as `(states[1]::VarTable)[id].typ`
-                if (!(rt.vtype ⊑ old_id_type) || old_id_type ⊑ rt.vtype) &&
+                if (!(rt.thentype ⊑ old_id_type) || old_id_type ⊑ rt.thentype) &&
                    (!(rt.elsetype ⊑ old_id_type) || old_id_type ⊑ rt.elsetype)
                    # discard this `Conditional` since it imposes
                    # no new constraint on the argument type
@@ -2133,7 +2133,7 @@ function widenreturn(@nospecialize(rt), @nospecialize(bestguess), nargs::Int, sl
             end
         end
         if isa(rt, Conditional)
-            rt = InterConditional(slot_id(rt.var), rt.vtype, rt.elsetype)
+            rt = InterConditional(slot_id(rt.var), rt.thentype, rt.elsetype)
         elseif is_lattice_bool(rt)
             if isa(bestguess, InterConditional)
                 # if the bestguess so far is already `Conditional`, try to convert
@@ -2154,7 +2154,7 @@ function widenreturn(@nospecialize(rt), @nospecialize(bestguess), nargs::Int, sl
 
     # only propagate information we know we can store
     # and is valid and good inter-procedurally
-    isa(rt, Conditional) && return InterConditional(slot_id(rt.var), rt.vtype, rt.elsetype)
+    isa(rt, Conditional) && return InterConditional(slot_id(rt.var), rt.thentype, rt.elsetype)
     isa(rt, InterConditional) && return rt
     return widenreturn_noconditional(rt)
 end
@@ -2353,7 +2353,7 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
                                     false_vartable = currstate
                                 end
                                 changed = update_bbstate!(frame, falsebb, false_vartable)
-                                then_change = conditional_change(currstate, condt.vtype, condt.var)
+                                then_change = conditional_change(currstate, condt.thentype, condt.var)
                                 if then_change !== nothing
                                     stoverwrite1!(currstate, then_change)
                                 end
@@ -2377,7 +2377,7 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
                             old_id_type = slottypes[slot_id]
                             if bestguess.val === true && rt.elsetype !== Bottom
                                 bestguess = InterConditional(slot_id, old_id_type, Bottom)
-                            elseif bestguess.val === false && rt.vtype !== Bottom
+                            elseif bestguess.val === false && rt.thentype !== Bottom
                                 bestguess = InterConditional(slot_id, Bottom, old_id_type)
                             end
                         end

--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -49,7 +49,7 @@ function matching_cache_argtypes(
                         condargs = Tuple{Int,Int}[]
                     end
                     push!(condargs, (slotid, i))
-                    given_argtypes[i] = Conditional(SlotNumber(slotid), thentype, elsetype)
+                    given_argtypes[i] = Conditional(slotid, thentype, elsetype)
                 end
                 continue
             end

--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -38,9 +38,9 @@ function matching_cache_argtypes(
             if slotid !== nothing
                 # using union-split signature, we may be able to narrow down `Conditional`
                 sigt = widenconst(slotid > nargs ? argtypes[slotid] : cache_argtypes[slotid])
-                vtype = tmeet(cnd.vtype, sigt)
+                thentype = tmeet(cnd.thentype, sigt)
                 elsetype = tmeet(cnd.elsetype, sigt)
-                if vtype === Bottom && elsetype === Bottom
+                if thentype === Bottom && elsetype === Bottom
                     # we accidentally proved this method match is impossible
                     # TODO bail out here immediately rather than just propagating Bottom ?
                     given_argtypes[i] = Bottom
@@ -49,7 +49,7 @@ function matching_cache_argtypes(
                         condargs = Tuple{Int,Int}[]
                     end
                     push!(condargs, (slotid, i))
-                    given_argtypes[i] = Conditional(SlotNumber(slotid), vtype, elsetype)
+                    given_argtypes[i] = Conditional(SlotNumber(slotid), thentype, elsetype)
                 end
                 continue
             end

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -226,11 +226,11 @@ function egal_tfunc(@nospecialize(x), @nospecialize(y))
     xx = widenconditional(x)
     yy = widenconditional(y)
     if isa(x, Conditional) && isa(yy, Const)
-        yy.val === false && return Conditional(x.var, x.elsetype, x.thentype)
+        yy.val === false && return Conditional(x.slot, x.elsetype, x.thentype)
         yy.val === true && return x
         return Const(false)
     elseif isa(y, Conditional) && isa(xx, Const)
-        xx.val === false && return Conditional(y.var, y.elsetype, y.thentype)
+        xx.val === false && return Conditional(y.slot, y.elsetype, y.thentype)
         xx.val === true && return y
         return Const(false)
     elseif isa(xx, Const) && isa(yy, Const)

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -226,11 +226,11 @@ function egal_tfunc(@nospecialize(x), @nospecialize(y))
     xx = widenconditional(x)
     yy = widenconditional(y)
     if isa(x, Conditional) && isa(yy, Const)
-        yy.val === false && return Conditional(x.var, x.elsetype, x.vtype)
+        yy.val === false && return Conditional(x.var, x.elsetype, x.thentype)
         yy.val === true && return x
         return Const(false)
     elseif isa(y, Conditional) && isa(xx, Const)
-        xx.val === false && return Conditional(y.var, y.elsetype, y.vtype)
+        xx.val === false && return Conditional(y.var, y.elsetype, y.thentype)
         xx.val === true && return y
         return Const(false)
     elseif isa(xx, Const) && isa(yy, Const)

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -4,7 +4,7 @@
 # structs/constants #
 #####################
 
-# N.B.: Const/PartialStruct/InterConditional are defined in Core, to allow them to be used
+# N.B.: Const/PartialStruct are defined in Core, to allow them to be used
 # inside the global code cache.
 #
 # # The type of a value might be constant
@@ -48,22 +48,21 @@ end
 Conditional(var::SlotNumber, @nospecialize(thentype), @nospecialize(elsetype)) =
     Conditional(slot_id(var), thentype, elsetype)
 
-# """
-#     cnd::InterConditional
-#
-# Similar to `Conditional`, but conveys inter-procedural constraints imposed on call arguments.
-# This is separate from `Conditional` to catch logic errors: the lattice element name is `InterConditional`
-# while processing a call, then `Conditional` everywhere else. Thus `InterConditional` does not appear in
-# `CompilerTypes`—these type's usages are disjoint—though we define the lattice for `InterConditional`.
-# """
-# struct InterConditional
-#     slot::Int
-#     thentype
-#     elsetype
-#     InterConditional(slot::Int, @nospecialize(thentype), @nospecialize(elsetype)) =
-#         new(slot, thentype, elsetype)
-# end
-import Core: InterConditional
+"""
+    cnd::InterConditional
+
+Similar to `Conditional`, but conveys inter-procedural constraints imposed on call arguments.
+This is separate from `Conditional` to catch logic errors: the lattice element name is `InterConditional`
+while processing a call, then `Conditional` everywhere else. Thus `InterConditional` does not appear in
+`CompilerTypes`—these type's usages are disjoint—though we define the lattice for `InterConditional`.
+"""
+struct InterConditional
+    slot::Int
+    thentype
+    elsetype
+    InterConditional(slot::Int, @nospecialize(thentype), @nospecialize(elsetype)) =
+        new(slot, thentype, elsetype)
+end
 InterConditional(var::SlotNumber, @nospecialize(thentype), @nospecialize(elsetype)) =
     InterConditional(slot_id(var), thentype, elsetype)
 

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -335,13 +335,13 @@ function issimplertype(@nospecialize(typea), @nospecialize(typeb))
       typeb isa Const && return true
       typeb isa Conditional || return false
       is_same_conditionals(typea, typeb) || return false
-      issimplertype(typea.vtype, typeb.vtype) || return false
+      issimplertype(typea.thentype, typeb.thentype) || return false
       issimplertype(typea.elsetype, typeb.elsetype) || return false
     elseif typea isa InterConditional # ibid
       typeb isa Const && return true
       typeb isa InterConditional || return false
       is_same_conditionals(typea, typeb) || return false
-      issimplertype(typea.vtype, typeb.vtype) || return false
+      issimplertype(typea.thentype, typeb.thentype) || return false
       issimplertype(typea.elsetype, typeb.elsetype) || return false
     elseif typea isa PartialOpaque
         # TODO
@@ -405,10 +405,10 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
     end
     if isa(typea, Conditional) && isa(typeb, Conditional)
         if is_same_conditionals(typea, typeb)
-            vtype = tmerge(typea.vtype, typeb.vtype)
+            thentype = tmerge(typea.thentype, typeb.thentype)
             elsetype = tmerge(typea.elsetype, typeb.elsetype)
-            if vtype !== elsetype
-                return Conditional(typea.var, vtype, elsetype)
+            if thentype !== elsetype
+                return Conditional(typea.var, thentype, elsetype)
             end
         end
         val = maybe_extract_const_bool(typea)
@@ -434,10 +434,10 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
     end
     if isa(typea, InterConditional) && isa(typeb, InterConditional)
         if is_same_conditionals(typea, typeb)
-            vtype = tmerge(typea.vtype, typeb.vtype)
+            thentype = tmerge(typea.thentype, typeb.thentype)
             elsetype = tmerge(typea.elsetype, typeb.elsetype)
-            if vtype !== elsetype
-                return InterConditional(typea.slot, vtype, elsetype)
+            if thentype !== elsetype
+                return InterConditional(typea.slot, thentype, elsetype)
             end
         end
         val = maybe_extract_const_bool(typea)

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -391,16 +391,16 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
     # type-lattice for Conditional wrapper
     if isa(typea, Conditional) && isa(typeb, Const)
         if typeb.val === true
-            typeb = Conditional(typea.var, Any, Union{})
+            typeb = Conditional(typea.slot, Any, Union{})
         elseif typeb.val === false
-            typeb = Conditional(typea.var, Union{}, Any)
+            typeb = Conditional(typea.slot, Union{}, Any)
         end
     end
     if isa(typeb, Conditional) && isa(typea, Const)
         if typea.val === true
-            typea = Conditional(typeb.var, Any, Union{})
+            typea = Conditional(typeb.slot, Any, Union{})
         elseif typea.val === false
-            typea = Conditional(typeb.var, Union{}, Any)
+            typea = Conditional(typeb.slot, Union{}, Any)
         end
     end
     if isa(typea, Conditional) && isa(typeb, Conditional)
@@ -408,7 +408,7 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
             thentype = tmerge(typea.thentype, typeb.thentype)
             elsetype = tmerge(typea.elsetype, typeb.elsetype)
             if thentype !== elsetype
-                return Conditional(typea.var, thentype, elsetype)
+                return Conditional(typea.slot, thentype, elsetype)
             end
         end
         val = maybe_extract_const_bool(typea)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2010,7 +2010,6 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("Const", (jl_value_t*)jl_const_type);
     add_builtin("PartialStruct", (jl_value_t*)jl_partial_struct_type);
     add_builtin("PartialOpaque", (jl_value_t*)jl_partial_opaque_type);
-    add_builtin("InterConditional", (jl_value_t*)jl_interconditional_type);
     add_builtin("MethodMatch", (jl_value_t*)jl_method_match_type);
     add_builtin("IntrinsicFunction", (jl_value_t*)jl_intrinsic_type);
     add_builtin("Function", (jl_value_t*)jl_function_type);

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -52,7 +52,6 @@
     XX(jl_int32_type) \
     XX(jl_int64_type) \
     XX(jl_int8_type) \
-    XX(jl_interconditional_type) \
     XX(jl_interrupt_exception) \
     XX(jl_intrinsic_type) \
     XX(jl_lineinfonode_type) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2577,7 +2577,7 @@ void jl_init_types(void) JL_GC_DISABLED
                                        jl_emptysvec, 0, 0, 2);
 
     jl_interconditional_type = jl_new_datatype(jl_symbol("InterConditional"), core, jl_any_type, jl_emptysvec,
-                                          jl_perm_symsvec(3, "slot", "vtype", "elsetype"),
+                                          jl_perm_symsvec(3, "slot", "thentype", "elsetype"),
                                           jl_svec(3, jl_long_type, jl_any_type, jl_any_type),
                                           jl_emptysvec, 0, 0, 3);
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2576,11 +2576,6 @@ void jl_init_types(void) JL_GC_DISABLED
                                        jl_svec2(jl_datatype_type, jl_array_any_type),
                                        jl_emptysvec, 0, 0, 2);
 
-    jl_interconditional_type = jl_new_datatype(jl_symbol("InterConditional"), core, jl_any_type, jl_emptysvec,
-                                          jl_perm_symsvec(3, "slot", "thentype", "elsetype"),
-                                          jl_svec(3, jl_long_type, jl_any_type, jl_any_type),
-                                          jl_emptysvec, 0, 0, 3);
-
     jl_method_match_type = jl_new_datatype(jl_symbol("MethodMatch"), core, jl_any_type, jl_emptysvec,
                                        jl_perm_symsvec(4, "spec_types", "sparams", "method", "fully_covers"),
                                        jl_svec(4, jl_type_type, jl_simplevector_type, jl_method_type, jl_bool_type),

--- a/src/julia.h
+++ b/src/julia.h
@@ -684,7 +684,6 @@ extern JL_DLLIMPORT jl_datatype_t *jl_argument_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_const_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_partial_struct_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_partial_opaque_type JL_GLOBALLY_ROOTED;
-extern JL_DLLIMPORT jl_datatype_t *jl_interconditional_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_method_match_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_simplevector_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_typename_t *jl_tuple_typename JL_GLOBALLY_ROOTED;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -80,7 +80,7 @@ extern "C" {
 // TODO: put WeakRefs on the weak_refs list during deserialization
 // TODO: handle finalizers
 
-#define NUM_TAGS    155
+#define NUM_TAGS    154
 
 // An array of references that need to be restored from the sysimg
 // This is a manually constructed dual of the gvars array, which would be produced by codegen for Julia code, for C.
@@ -119,7 +119,6 @@ jl_value_t **const*const get_tags(void) {
         INSERT_TAG(jl_const_type);
         INSERT_TAG(jl_partial_struct_type);
         INSERT_TAG(jl_partial_opaque_type);
-        INSERT_TAG(jl_interconditional_type);
         INSERT_TAG(jl_method_match_type);
         INSERT_TAG(jl_pinode_type);
         INSERT_TAG(jl_phinode_type);

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1464,8 +1464,8 @@ let egal_tfunc
         @test egal_tfunc(c, Any) === Bool
     end
     let c = Conditional(Core.SlotNumber(0), Const(Union{}), Union{}) # === Const(true)
-        @test egal_tfunc(c, Const(false)) === Conditional(c.var, Union{}, c.vtype)
-        @test egal_tfunc(c, Const(true)) === Conditional(c.var, c.vtype, Union{})
+        @test egal_tfunc(c, Const(false)) === Conditional(c.var, Union{}, c.thentype)
+        @test egal_tfunc(c, Const(true)) === Conditional(c.var, c.thentype, Union{})
         @test egal_tfunc(c, Const(nothing)) === Const(false)
         @test egal_tfunc(c, Int) === Const(false)
         @test egal_tfunc(c, Bool) === Bool

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2037,17 +2037,14 @@ end
         return nothing
     end == Any[Union{Nothing,Expr}]
 
-    # handle the edge case
-    let ts = @eval Module() begin
-            edgecase(_) = $(Core.Compiler.InterConditional(2, Int, Any))
-            # create cache
-            Base.return_types(edgecase, (Any,))
-            Base.return_types((Any,)) do x
-                edgecase(x) ? x : nothing # ::Any
-            end
+    # handle edge case
+    @test (@eval Module() begin
+        edgecase(_) = $(Core.Compiler.InterConditional(2, Int, Any))
+        Base.return_types(edgecase, (Any,)) # create cache
+        Base.return_types((Any,)) do x
+            edgecase(x)
         end
-        @test ts == Any[Any]
-    end
+    end) == Any[Core.Compiler.InterConditional]
 
     # a tricky case: if constant inference derives `Const` while non-constant inference has
     # derived `InterConditional`, we should not discard that constant information

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1350,7 +1350,7 @@ let isa_tfunc = Core.Compiler.isa_tfunc
     @test isa_tfunc(typeof(Union{}), Union{}) === Union{} # any result is ok
     @test isa_tfunc(typeof(Union{}), Type{typeof(Union{})}) === Const(true)
     @test isa_tfunc(typeof(Union{}), Const(typeof(Union{}))) === Const(true)
-    let c = Conditional(Core.SlotNumber(0), Const(Union{}), Const(Union{}))
+    let c = Conditional(0, Const(Union{}), Const(Union{}))
         @test isa_tfunc(c, Const(Bool)) === Const(true)
         @test isa_tfunc(c, Type{Bool}) === Const(true)
         @test isa_tfunc(c, Const(Real)) === Const(true)
@@ -1401,7 +1401,7 @@ let subtype_tfunc = Core.Compiler.subtype_tfunc
     @test subtype_tfunc(Type{Union{}}, Any) === Const(true) # Union{} <: Any
     @test subtype_tfunc(Type{Union{}}, Union{Type{Int64}, Type{Float64}}) === Const(true)
     @test subtype_tfunc(Type{Union{}}, Union{Type{T}, Type{Float64}} where T) === Const(true)
-    let c = Conditional(Core.SlotNumber(0), Const(Union{}), Const(Union{}))
+    let c = Conditional(0, Const(Union{}), Const(Union{}))
         @test subtype_tfunc(c, Const(Bool)) === Const(true) # any result is ok
     end
     @test subtype_tfunc(Type{Val{1}}, Type{Val{T}} where T) === Bool
@@ -1444,7 +1444,7 @@ let egal_tfunc
     @test egal_tfunc(Type{Union{Float32, Float64}}, Type{Union{Float32, Float64}}) === Bool
     @test egal_tfunc(typeof(Union{}), typeof(Union{})) === Bool # could be improved
     @test egal_tfunc(Const(typeof(Union{})), Const(typeof(Union{}))) === Const(true)
-    let c = Conditional(Core.SlotNumber(0), Const(Union{}), Const(Union{}))
+    let c = Conditional(0, Const(Union{}), Const(Union{}))
         @test egal_tfunc(c, Const(Bool)) === Const(false)
         @test egal_tfunc(c, Type{Bool}) === Const(false)
         @test egal_tfunc(c, Const(Real)) === Const(false)
@@ -1455,17 +1455,17 @@ let egal_tfunc
         @test egal_tfunc(c, Bool) === Bool
         @test egal_tfunc(c, Any) === Bool
     end
-    let c = Conditional(Core.SlotNumber(0), Union{}, Const(Union{})) # === Const(false)
-        @test egal_tfunc(c, Const(false)) === Conditional(c.var, c.elsetype, Union{})
-        @test egal_tfunc(c, Const(true)) === Conditional(c.var, Union{}, c.elsetype)
+    let c = Conditional(0, Union{}, Const(Union{})) # === Const(false)
+        @test egal_tfunc(c, Const(false)) === Conditional(c.slot, c.elsetype, Union{})
+        @test egal_tfunc(c, Const(true)) === Conditional(c.slot, Union{}, c.elsetype)
         @test egal_tfunc(c, Const(nothing)) === Const(false)
         @test egal_tfunc(c, Int) === Const(false)
         @test egal_tfunc(c, Bool) === Bool
         @test egal_tfunc(c, Any) === Bool
     end
-    let c = Conditional(Core.SlotNumber(0), Const(Union{}), Union{}) # === Const(true)
-        @test egal_tfunc(c, Const(false)) === Conditional(c.var, Union{}, c.thentype)
-        @test egal_tfunc(c, Const(true)) === Conditional(c.var, c.thentype, Union{})
+    let c = Conditional(0, Const(Union{}), Union{}) # === Const(true)
+        @test egal_tfunc(c, Const(false)) === Conditional(c.slot, Union{}, c.thentype)
+        @test egal_tfunc(c, Const(true)) === Conditional(c.slot, c.thentype, Union{})
         @test egal_tfunc(c, Const(nothing)) === Const(false)
         @test egal_tfunc(c, Int) === Const(false)
         @test egal_tfunc(c, Bool) === Bool


### PR DESCRIPTION
When I introduced this new lattice within #38905, I defined this in
`Core` for some performance reason, but now I'm sure it is really
unnecessary. Rather, it is easier to develop Julia-level inference routine
in pure Julia, so the first commit commit moves the definition of 
`InterConditional` to `Core.Compiler`.

The second commit renames `.vtype` field of `Conditional` to `.thentype`.
The rational here is that the "vtype" term is a bit confusing since it is
used for "variable state" managed by `InferenceState`. Rather, the `.thentype`
naming is more consistent with the counterpart field `.elsetype`, and 
would make its meaning more explicit.

Finally, the third commit makes them more symmetic by renaming the 
`.var::SlotNumber` field of `Conditional` to `.slot::Int` as like 
`InterConditional`. This change may also cut off few allocations of `SlotNumber`.
We may want `Conditional` to propagate constraints about non-local binding
(like global references) in the future, but I think that won't happen that
soonish. For the meanwhile, it would be reasonable to keep the field
specific `SlotNumber`.

NOTE: I'd like to merge these commits separately.

@nanosoldier `runbenchmarks("inference", vs=":master")`