### PR TITLE
effects: add `nothrow` modeling for `setglobal!`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2090,14 +2090,8 @@ function abstract_eval_global(M::Module, s::Symbol, frame::InferenceState)
     return ty
 end
 
-function handle_global_assignment!(interp::AbstractInterpreter, frame::InferenceState, lhs::GlobalRef, @nospecialize(rhs))
-    M = lhs.mod
-    s = lhs.name
-    nothrow = false
-    if isdefined(M, s) && !isconst(M, s)
-        ty = ccall(:jl_binding_type, Any, (Any, Any), M, s)
-        nothrow = ty === nothing || rhs ⊑ ty
-    end
+function handle_global_assignment!(interp::AbstractInterpreter, frame::InferenceState, lhs::GlobalRef, @nospecialize(newty))
+    nothrow = global_assignemnt_nothrow(lhs.mod, lhs.name, newty)
     tristate_merge!(frame, Effects(EFFECTS_TOTAL,
         effect_free=TRISTATE_UNKNOWN,
         nothrow=nothrow ? ALWAYS_TRUE : TRISTATE_UNKNOWN))

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2091,7 +2091,7 @@ function abstract_eval_global(M::Module, s::Symbol, frame::InferenceState)
 end
 
 function handle_global_assignment!(interp::AbstractInterpreter, frame::InferenceState, lhs::GlobalRef, @nospecialize(newty))
-    nothrow = global_assignemnt_nothrow(lhs.mod, lhs.name, newty)
+    nothrow = global_assignment_nothrow(lhs.mod, lhs.name, newty)
     tristate_merge!(frame, Effects(EFFECTS_TOTAL,
         effect_free=TRISTATE_UNKNOWN,
         nothrow=nothrow ? ALWAYS_TRUE : TRISTATE_UNKNOWN))

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -2134,12 +2134,12 @@ function setglobal!_nothrow(argtypes::Vector{Any})
     M, s, newty = argtypes
     if M isa Const && s isa Const
         M, s = M.val, s.val
-        return global_assignemnt_nothrow(M, s, newty)
+        return global_assignment_nothrow(M, s, newty)
     end
     return false
 end
 
-function global_assignemnt_nothrow(M::Module, s::Symbol, @nospecialize(newty))
+function global_assignment_nothrow(M::Module, s::Symbol, @nospecialize(newty))
     if isdefined(M, s) && !isconst(M, s)
         ty = ccall(:jl_binding_type, Any, (Any, Any), M, s)
         return ty === nothing || newty ⊑ ty

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4152,30 +4152,30 @@ end
 # we should taint `nothrow` if the binding doesn't exist and isn't fixed yet,
 # as the cached effects can be easily wrong otherwise
 # since the inference curently doesn't track "world-age" of global variables
-@eval global_assignment_undefiendyet() = $(GlobalRef(@__MODULE__, :UNDEFINEDYET)) = 42
-setglobal!_nothrow_undefiendyet() = setglobal!(@__MODULE__, :UNDEFINEDYET, 42)
+@eval global_assignment_undefinedyet() = $(GlobalRef(@__MODULE__, :UNDEFINEDYET)) = 42
+setglobal!_nothrow_undefinedyet() = setglobal!(@__MODULE__, :UNDEFINEDYET, 42)
 let effects = Base.infer_effects() do
-        global_assignment_undefiendyet()
+        global_assignment_undefinedyet()
     end
     @test !Core.Compiler.is_nothrow(effects)
 end
 let effects = Base.infer_effects() do
-        setglobal!_nothrow_undefiendyet()
+        setglobal!_nothrow_undefinedyet()
     end
     @test !Core.Compiler.is_nothrow(effects)
 end
 global UNDEFINEDYET::String = "0"
 let effects = Base.infer_effects() do
-        global_assignment_undefiendyet()
+        global_assignment_undefinedyet()
     end
     @test !Core.Compiler.is_nothrow(effects)
 end
 let effects = Base.infer_effects() do
-        setglobal!_nothrow_undefiendyet()
+        setglobal!_nothrow_undefinedyet()
     end
     @test !Core.Compiler.is_nothrow(effects)
 end
-@test_throws ErrorException setglobal!_nothrow_undefiendyet()
+@test_throws ErrorException setglobal!_nothrow_undefinedyet()
 
 # Nothrow for setfield!
 mutable struct SetfieldNothrow


### PR DESCRIPTION
Also adds some test cases to assert that we're not doing too aggressive
`nothrow` modeling for undefined bindings, which would require a new
system to track "world-age" of global variables:
```julia
# we should taint `nothrow` if the binding doesn't exist and isn't fixed yet,
# as the cached effects can be easily wrong otherwise
# since the inference curently doesn't track "world-age" of global variables
@eval global_assignment_undefinedyet() = $(GlobalRef(@__MODULE__, :UNDEFINEDYET)) = 42
setglobal!_nothrow_undefinedyet() = setglobal!(@__MODULE__, :UNDEFINEDYET, 42)
let effects = Base.infer_effects() do
        global_assignment_undefinedyet()
    end
    @test !Core.Compiler.is_nothrow(effects)
end
let effects = Base.infer_effects() do
        setglobal!_nothrow_undefinedyet()
    end
    @test !Core.Compiler.is_nothrow(effects)
end
global UNDEFINEDYET::String = "0"
let effects = Base.infer_effects() do
        global_assignment_undefinedyet()
    end
    @test !Core.Compiler.is_nothrow(effects)
end
let effects = Base.infer_effects() do
        setglobal!_nothrow_undefinedyet()
    end
    @test !Core.Compiler.is_nothrow(effects)
end
@test_throws ErrorException setglobal!_nothrow_undefinedyet()
```