### PR TITLE
Preserve ScalarEvolution/MemorySSA in JuliaLICM

### DIFF
--- a/src/llvm-demote-float16.cpp
+++ b/src/llvm-demote-float16.cpp
@@ -14,8 +14,6 @@
 
 #include "llvm-version.h"
 
-#define DEBUG_TYPE "demote_float16"
-
 #include "support/dtypes.h"
 #include "passes.h"
 
@@ -27,6 +25,8 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Verifier.h>
 #include <llvm/Support/Debug.h>
+
+#define DEBUG_TYPE "demote_float16"
 
 using namespace llvm;
 

--- a/src/llvm-muladd.cpp
+++ b/src/llvm-muladd.cpp
@@ -1,6 +1,5 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
-#define DEBUG_TYPE "combine_muladd"
 #undef DEBUG
 #include "llvm-version.h"
 #include "passes.h"
@@ -21,6 +20,7 @@
 #include <llvm/IR/Verifier.h>
 #include <llvm/Pass.h>
 #include <llvm/Support/Debug.h>
+#define DEBUG_TYPE "combine_muladd"
 
 #include "julia.h"
 #include "julia_assert.h"


### PR DESCRIPTION
In LLVM 14 LICM requires MSSA to be present in NewPM, so we must preserve it here. Also, NewPM requires that ScalarEvolution be preserved during all loop passes, so handle that case too. 