### PR TITLE
Improve color for code_warntype types

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1554,8 +1554,6 @@ unquoted(ex::Expr)       = ex.args[1]
 function printstyled end
 function with_output_color end
 
-is_expected_union(u::Union) = u.a == Nothing || u.b == Nothing || u.a == Missing || u.b == Missing
-
 emphasize(io, str::AbstractString, col = Base.error_color()) = get(io, :color, false) ?
     printstyled(io, str; color=col, bold=true) :
     print(io, uppercase(str))

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -45,13 +45,13 @@ end
 # True if one can be pretty certain that the compiler handles this union well,
 # i.e. must be small with concrete types.
 function is_expected_union(u::Union)
-	Base.unionlen(u) < 4 || return false
-	for x in Base.uniontypes(u)
-	    if !Base.isdispatchelem(x) || x == Core.Box
-	        return false
+    Base.unionlen(u) < 4 || return false
+    for x in Base.uniontypes(u)
+        if !Base.isdispatchelem(x) || x == Core.Box
+            return false
         end
     end
-	return true
+    return true
 end
 
 """

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -47,10 +47,10 @@ end
 function is_expected_union(u::Union)
 	Base.unionlen(u) < 4 || return false
 	for x in Base.uniontypes(u)
-	    if !Base.isdispatchelem(ua) || ua == Core.Box
+	    if !Base.isdispatchelem(x) || x == Core.Box
 	        return false
-	    end
         end
+    end
 	return true
 end
 

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -46,11 +46,12 @@ end
 # i.e. must be small with concrete types.
 function is_expected_union(u::Union)
 	Base.unionlen(u) < 4 || return false
-	ua, ub = u.a, u.b
-	if !Base.isdispatchelem(ua) || ua == Core.Box
-	    return false
-	end
-	ub isa Union ? is_expected_union(ub) : Base.isdispatchelem(ub)
+	for x in Base.uniontypes(u)
+	    if !Base.isdispatchelem(ua) || ua == Core.Box
+	        return false
+	    end
+        end
+	return true
 end
 
 """

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -32,14 +32,23 @@ function warntype_type_printer(io::IO, @nospecialize(ty), used::Bool)
     str = "::$ty"
     if !highlighting[:warntype]
         print(io, str)
-    elseif ty isa Union && Base.is_expected_union(ty)
-        Base.emphasize(io, str, Base.warn_color()) # more mild user notification
     elseif ty isa Type && (!Base.isdispatchelem(ty) || ty == Core.Box)
         Base.emphasize(io, str)
+    elseif ty isa Union && is_expected_union(ty)
+        Base.emphasize(io, str, Base.warn_color()) # more mild user notification
     else
         Base.printstyled(io, str, color=:cyan) # show the "good" type
     end
     nothing
+end
+
+# True if one can be pretty certain that the compiler handles this union well,
+# i.e. must be small with concrete types.
+function is_expected_union(u::Union)
+	Base.unionlen(u) < 4 || return false
+	Base.isdispatchelem(u.a) || return false
+	ub = u.b
+	ub isa Union ? is_expected_union(ub) : Base.isdispatchelem(ub)
 end
 
 """

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -32,10 +32,10 @@ function warntype_type_printer(io::IO, @nospecialize(ty), used::Bool)
     str = "::$ty"
     if !highlighting[:warntype]
         print(io, str)
-    elseif ty isa Type && (!Base.isdispatchelem(ty) || ty == Core.Box)
-        Base.emphasize(io, str)
     elseif ty isa Union && is_expected_union(ty)
         Base.emphasize(io, str, Base.warn_color()) # more mild user notification
+    elseif ty isa Type && (!Base.isdispatchelem(ty) || ty == Core.Box)
+        Base.emphasize(io, str)
     else
         Base.printstyled(io, str, color=:cyan) # show the "good" type
     end
@@ -46,8 +46,10 @@ end
 # i.e. must be small with concrete types.
 function is_expected_union(u::Union)
 	Base.unionlen(u) < 4 || return false
-	Base.isdispatchelem(u.a) || return false
-	ub = u.b
+	ua, ub = u.a, u.b
+	if !Base.isdispatchelem(ua) || ua == Core.Box
+	    return false
+	end
 	ub isa Union ? is_expected_union(ub) : Base.isdispatchelem(ub)
 end
 

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -52,21 +52,21 @@ tag = "UNION"
 @test !warntype_hastag(pos_stable, Tuple{Float64}, tag)
 
 for u in Any[
-	Union{Int, UInt},
-	Union{Nothing, Vector{Tuple{String, Tuple{Char, Char}}}},
-	Union{Char, UInt8, UInt},
-	Union{Tuple{Int, Int}, Tuple{Char, Int}, Nothing},
-	Union{Missing, Nothing}
+    Union{Int, UInt},
+    Union{Nothing, Vector{Tuple{String, Tuple{Char, Char}}}},
+    Union{Char, UInt8, UInt},
+    Union{Tuple{Int, Int}, Tuple{Char, Int}, Nothing},
+    Union{Missing, Nothing}
 ]
-	@test InteractiveUtils.is_expected_union(u)
+    @test InteractiveUtils.is_expected_union(u)
 end
 
 for u in Any[
-	Union{Nothing, Tuple{Vararg{Char}}},
-	Union{Missing, Array},
-	Union{Int, Tuple{Any, Int}}
+    Union{Nothing, Tuple{Vararg{Char}}},
+    Union{Missing, Array},
+    Union{Int, Tuple{Any, Int}}
 ]
-	@test !InteractiveUtils.is_expected_union(u)
+    @test !InteractiveUtils.is_expected_union(u)
 end
 mutable struct Stable{T,N}
     A::Array{T,N}

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -55,7 +55,7 @@ for u in Any[
 	Union{Int, UInt},
 	Union{Nothing, Vector{Tuple{String, Tuple{Char, Char}}}},
 	Union{Char, UInt8, UInt},
-	Union{Tuple{Int, Int}, Tuple{Char, Int}, Nothing}.
+	Union{Tuple{Int, Int}, Tuple{Char, Int}, Nothing},
 	Union{Missing, Nothing}
 ]
 	@test InteractiveUtils.is_expected_union(u)

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -51,6 +51,23 @@ tag = "UNION"
 @test warntype_hastag(pos_unstable, Tuple{Float64}, tag)
 @test !warntype_hastag(pos_stable, Tuple{Float64}, tag)
 
+for u in Any[
+	Union{Int, UInt},
+	Union{Nothing, Vector{Tuple{String, Tuple{Char, Char}}}},
+	Union{Char, UInt8, UInt},
+	Union{Tuple{Int, Int}, Tuple{Char, Int}, Nothing}.
+	Union{Missing, Nothing}
+]
+	@test InteractiveUtils.is_expected_union(u)
+end
+
+for u in Any[
+	Union{Nothing, Tuple{Vararg{Char}}},
+	Union{Missing, Array},
+	Union{Int, Tuple{Any, Int}}
+]
+	@test !InteractiveUtils.is_expected_union(u)
+end
 mutable struct Stable{T,N}
     A::Array{T,N}
 end


### PR DESCRIPTION
This PR makes two changes: First, the "expected" union, i.e. the ones printed
yellow is now defined as one with at most 3 types, and where every element
of the union is Base.isdispatchelem. This is intended to be a conservative
threshold for when the compiler definitely ought to be able to create efficient
code for the union.

Second, now, "red" types override "yellow" types, where it was the opposite
before.

See #45501, #45502

Please let me know how I should test this properly - I couldn't find existing test suites for the color printing of `code_warntype`, and it seems the colors are not preserved when printing to an IOBuffer.