### PR TITLE
csl.mk: use libgcc_s 1.1 on aarch64-darwin

### DIFF
--- a/deps/csl.mk
+++ b/deps/csl.mk
@@ -76,7 +76,11 @@ else
 $(eval $(call copy_csl,$(call versioned_libname,libgcc_s_seh,1)))
 endif
 else
+ifeq ($(APPLE_ARCH),arm64)
+$(eval $(call copy_csl,$(call versioned_libname,libgcc_s,1.1)))
+else
 $(eval $(call copy_csl,$(call versioned_libname,libgcc_s,1)))
+endif
 endif
 # winpthread is only Windows, pthread is only others
 ifeq ($(OS),WINNT)


### PR DESCRIPTION
The PR at https://github.com/JuliaLang/julia/pull/44487 added correct support for `libgcc_s.1.1.dylib` on macOS on aarch64. But this missed the equivalent in `deps/csl.mk`, which is needed when running `make install-csl` (which we do in Homebrew).

In the current situation, the compiler does not correctly install `libgcc_s.1.1.dylib`, and `julia` fails to run once installed.