### PR TITLE
Fix Dict limit printing of small values ending with color

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -2,37 +2,6 @@
 
 ## printing with color ##
 
-const text_colors = Dict{Union{Symbol,Int},String}(
-    :black         => "\033[30m",
-    :red           => "\033[31m",
-    :green         => "\033[32m",
-    :yellow        => "\033[33m",
-    :blue          => "\033[34m",
-    :magenta       => "\033[35m",
-    :cyan          => "\033[36m",
-    :white         => "\033[37m",
-    :light_black   => "\033[90m", # gray
-    :light_red     => "\033[91m",
-    :light_green   => "\033[92m",
-    :light_yellow  => "\033[93m",
-    :light_blue    => "\033[94m",
-    :light_magenta => "\033[95m",
-    :light_cyan    => "\033[96m",
-    :light_white   => "\033[97m",
-    :normal        => "\033[0m",
-    :default       => "\033[39m",
-    :bold          => "\033[1m",
-    :underline     => "\033[4m",
-    :blink         => "\033[5m",
-    :reverse       => "\033[7m",
-    :hidden        => "\033[8m",
-    :nothing       => "",
-)
-
-for i in 0:255
-    text_colors[i] = "\033[38;5;$(i)m"
-end
-
 const disable_text_style = Dict{Symbol,String}(
     :bold      => "\033[22m",
     :underline => "\033[24m",

--- a/base/util.jl
+++ b/base/util.jl
@@ -2,6 +2,37 @@
 
 ## printing with color ##
 
+const text_colors = Dict{Union{Symbol,Int},String}(
+    :black         => "\033[30m",
+    :red           => "\033[31m",
+    :green         => "\033[32m",
+    :yellow        => "\033[33m",
+    :blue          => "\033[34m",
+    :magenta       => "\033[35m",
+    :cyan          => "\033[36m",
+    :white         => "\033[37m",
+    :light_black   => "\033[90m", # gray
+    :light_red     => "\033[91m",
+    :light_green   => "\033[92m",
+    :light_yellow  => "\033[93m",
+    :light_blue    => "\033[94m",
+    :light_magenta => "\033[95m",
+    :light_cyan    => "\033[96m",
+    :light_white   => "\033[97m",
+    :normal        => "\033[0m",
+    :default       => "\033[39m",
+    :bold          => "\033[1m",
+    :underline     => "\033[4m",
+    :blink         => "\033[5m",
+    :reverse       => "\033[7m",
+    :hidden        => "\033[8m",
+    :nothing       => "",
+)
+
+for i in 0:255
+    text_colors[i] = "\033[38;5;$(i)m"
+end
+
 const disable_text_style = Dict{Symbol,String}(
     :bold      => "\033[22m",
     :underline => "\033[24m",

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -452,6 +452,10 @@ end
     str10 = sprint(io -> show(io, MIME("text/plain"), d10); context = (:displaysize=>(30,15), :color=>true, :limit=>true))
     @test endswith(str10, "\033[0m…")
     @test count('苹', str10) == 2
+
+    d11 = Dict(RainbowString("abcdefgh", false, true, false) => 0, "123456" => 1)
+    str11 = sprint(io -> show(io, MIME("text/plain"), dict); context = (:displaysize=>(30,80), :color=>true, :limit=>true))
+    @test endswith(str11, "\033[0m => 0")
 end
 
 @testset "Issue #15739" begin # Compact REPL printouts of an `AbstractDict` use brackets when appropriate

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -379,8 +379,12 @@ RainbowString(s, bold=false) = RainbowString(s, bold, true)
 function Base.show(io::IO, rbs::RainbowString)
     for s in rbs.s
         _, color = rand(Base.text_colors)
-        printstyled(io, color, s; bold=rbs.bold)
-        rbs.valid && print(io, "\e[0m") # end of color marker
+        if rbs.bold
+            printstyled(io, color, s; bold=true)
+        else
+            print(io, color, s)
+        end
+        rbs.valid && print(io, "\e[39m") # end of color marker
     end
 end
 
@@ -388,7 +392,7 @@ end
     d = Dict([randstring(8) => [RainbowString(randstring(8)) for i in 1:10] for j in 1:5]...)
     str = sprint(io -> show(io, MIME("text/plain"), d); context = (:displaysize=>(30,80), :color=>true, :limit=>true))
     lines = split(str, '\n')
-    @test all(endswith("\e[39m…"), lines[2:end])
+    @test all(endswith("\e[0m…"), lines[2:end])
     @test all(x -> length(x) > 100, lines[2:end])
 
     d2 = Dict(:foo => RainbowString("bar"))
@@ -397,20 +401,20 @@ end
 
     d3 = Dict(:foo => RainbowString("bar", true))
     str3 = sprint(io -> show(io, MIME("text/plain"), d3); context = (:displaysize=>(30,80), :color=>true, :limit=>true))
-    @test endswith(str3, "r\e[0m\e[22m")
+    @test endswith(str3, "\e[0m")
 
     d4 = Dict(RainbowString(randstring(20), true) => nothing)
     str4 = sprint(io -> show(io, MIME("text/plain"), d4); context = (:displaysize=>(30,20), :color=>true, :limit=>true))
-    @test endswith(str4, "\e[22m\e[39m… => nothing")
+    @test endswith(str4, "\e[0m… => nothing")
 
     d5 = Dict(RainbowString(randstring(20), true, false) => nothing)
     str5 = sprint(io -> show(io, MIME("text/plain"), d5); context = (:displaysize=>(30,20), :color=>true, :limit=>true))
-    @test endswith(str5, "\e[22m\e[39m… => nothing")
+    @test endswith(str5, "\e[0m… => nothing")
 
     d6 = Dict(randstring(8) => RainbowString(randstring(70), false, false) for _ in 1:3)
     str6 = sprint(io -> show(io, MIME("text/plain"), d6); context = (:displaysize=>(30,80), :color=>true, :limit=>true))
     lines6 = split(str6, '\n')
-    @test all(endswith("\e[39m…"), lines6[2:end])
+    @test all(endswith("\e[0m…"), lines6[2:end])
     @test all(x -> length(x) > 100, lines6[2:end])
 end
 

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -378,13 +378,13 @@ RainbowString(s, bold=false) = RainbowString(s, bold, true)
 
 function Base.show(io::IO, rbs::RainbowString)
     for s in rbs.s
-        _, color = rand(Base.text_colors)
+        color = Base.text_colors[rand(0:255)]
         if rbs.bold
             printstyled(io, color, s; bold=true)
         else
             print(io, color, s)
         end
-        rbs.valid && print(io, "\e[39m") # end of color marker
+        rbs.valid && print(io, "\033[39m") # end of color marker
     end
 end
 
@@ -392,7 +392,7 @@ end
     d = Dict([randstring(8) => [RainbowString(randstring(8)) for i in 1:10] for j in 1:5]...)
     str = sprint(io -> show(io, MIME("text/plain"), d); context = (:displaysize=>(30,80), :color=>true, :limit=>true))
     lines = split(str, '\n')
-    @test all(endswith("\e[0m…"), lines[2:end])
+    @test all(endswith("\033[0m…"), lines[2:end])
     @test all(x -> length(x) > 100, lines[2:end])
 
     d2 = Dict(:foo => RainbowString("bar"))
@@ -401,21 +401,27 @@ end
 
     d3 = Dict(:foo => RainbowString("bar", true))
     str3 = sprint(io -> show(io, MIME("text/plain"), d3); context = (:displaysize=>(30,80), :color=>true, :limit=>true))
-    @test endswith(str3, "\e[0m")
+    @test endswith(str3, "\033[0m")
 
     d4 = Dict(RainbowString(randstring(20), true) => nothing)
     str4 = sprint(io -> show(io, MIME("text/plain"), d4); context = (:displaysize=>(30,20), :color=>true, :limit=>true))
-    @test endswith(str4, "\e[0m… => nothing")
+    @test endswith(str4, "\033[0m… => nothing")
 
     d5 = Dict(RainbowString(randstring(20), true, false) => nothing)
     str5 = sprint(io -> show(io, MIME("text/plain"), d5); context = (:displaysize=>(30,20), :color=>true, :limit=>true))
-    @test endswith(str5, "\e[0m… => nothing")
+    @test endswith(str5, "\033[0m… => nothing")
 
     d6 = Dict(randstring(8) => RainbowString(randstring(70), false, false) for _ in 1:3)
-    str6 = sprint(io -> show(io, MIME("text/plain"), d6); context = (:displaysize=>(30,80), :color=>true, :limit=>true))
+    str6 = sprint(io -> show(io, MIME("text/plain"), d6); context = (:displaysize=>(30,30), :color=>true, :limit=>true))
     lines6 = split(str6, '\n')
-    @test all(endswith("\e[0m…"), lines6[2:end])
+    @test all(endswith("\033[0m…"), lines6[2:end])
     @test all(x -> length(x) > 100, lines6[2:end])
+
+    d7 = Dict(randstring(8) => RainbowString(randstring(70), false, false))
+    str7 = sprint(io -> show(io, MIME("text/plain"), d7); context = (:displaysize=>(30,20), :color=>true, :limit=>true))
+    line7 = split(str7, '\n')[2]
+    @test endswith(line7, "\033[0m…")
+    @test length(line7) > 100
 end
 
 @testset "Issue #15739" begin # Compact REPL printouts of an `AbstractDict` use brackets when appropriate

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -406,18 +406,19 @@ end
     d2 = Dict(:foo => RainbowString("bar"))
     str2 = sprint(io -> show(io, MIME("text/plain"), d2); context = (:displaysize=>(30,80), :color=>true, :limit=>true))
     @test !occursin('…', str2)
-    @test endswith(str2, "\033[39m")
+    @test endswith(str2, "\033[0m")
 
     d3 = Dict(:foo => RainbowString("bar", true))
     str3 = sprint(io -> show(io, MIME("text/plain"), d3); context = (:displaysize=>(30,80), :color=>true, :limit=>true))
-    @test endswith(str3, "\033[22m\033[39m")
+    @test !occursin('…', str3)
+    @test endswith(str3, "\033[0m")
 
     d4 = Dict(RainbowString(randstring(8), true) => nothing)
     str4 = sprint(io -> show(io, MIME("text/plain"), d4); context = (:displaysize=>(30,20), :color=>true, :limit=>true))
     @test endswith(str4, "\033[0m… => nothing")
 
-    d5 = Dict(RainbowString(randstring(20), false, true, false) => nothing)
-    str5 = sprint(io -> show(io, MIME("text/plain"), d5); context = (:displaysize=>(30,20), :color=>true, :limit=>true))
+    d5 = Dict(RainbowString(randstring(30), false, true, false) => nothing)
+    str5 = sprint(io -> show(io, MIME("text/plain"), d5); context = (:displaysize=>(30,30), :color=>true, :limit=>true))
     @test endswith(str5, "\033[0m… => nothing")
 
     d6 = Dict(randstring(8) => RainbowString(randstring(30), true, true, false) for _ in 1:3)
@@ -426,21 +427,31 @@ end
     @test all(endswith("\033[0m…"), lines6[2:end])
     @test all(x -> length(x) > 100, lines6[2:end])
 
-    d7 = Dict(randstring(8) => RainbowString(randstring(30), false, false))
+    d7 = Dict(randstring(8) => RainbowString(randstring(30)))
     str7 = sprint(io -> show(io, MIME("text/plain"), d7); context = (:displaysize=>(30,20), :color=>true, :limit=>true))
     line7 = split(str7, '\n')[2]
     @test endswith(line7, "\033[0m…")
     @test length(line7) > 100
 
     d8 = Dict(:x => RainbowString(randstring(10), false, false, false, 6))
-    str8 = sprint(io -> show(io, MIME("text/plain"), d8); context = (:displaysize=>(30,15), :color=>true, :limit=>true))
+    str8 = sprint(io -> show(io, MIME("text/plain"), d8); context = (:displaysize=>(30,14), :color=>true, :limit=>true))
     line8 = split(str8, '\n')[2]
     @test !occursin(line8, "\033[")
-    @test length(line8) == 15
+    @test length(line8) == 14
     str8_long = sprint(io -> show(io, MIME("text/plain"), d8); context = (:displaysize=>(30,16), :color=>true, :limit=>true))
     line8_long = split(str8_long, '\n')[2]
     @test endswith(line8_long, "\033[0m…")
     @test length(line8_long) > 20
+
+    d9 = Dict(:x => RainbowString(repeat('苹', 5), false, true, false))
+    str9 = sprint(io -> show(io, MIME("text/plain"), d9); context = (:displaysize=>(30,15), :color=>true, :limit=>true))
+    @test endswith(str9, "\033[0m…")
+    @test count('苹', str9) == 3
+
+    d10 = Dict(:xy => RainbowString(repeat('苹', 5), false, true, false))
+    str10 = sprint(io -> show(io, MIME("text/plain"), d10); context = (:displaysize=>(30,15), :color=>true, :limit=>true))
+    @test endswith(str10, "\033[0m…")
+    @test count('苹', str10) == 2
 end
 
 @testset "Issue #15739" begin # Compact REPL printouts of an `AbstractDict` use brackets when appropriate

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -436,7 +436,7 @@ end
     d8 = Dict(:x => RainbowString(randstring(10), false, false, false, 6))
     str8 = sprint(io -> show(io, MIME("text/plain"), d8); context = (:displaysize=>(30,14), :color=>true, :limit=>true))
     line8 = split(str8, '\n')[2]
-    @test !occursin(line8, "\033[")
+    @test !occursin("\033[", line8)
     @test length(line8) == 14
     str8_long = sprint(io -> show(io, MIME("text/plain"), d8); context = (:displaysize=>(30,16), :color=>true, :limit=>true))
     line8_long = split(str8_long, '\n')[2]
@@ -454,7 +454,7 @@ end
     @test count('苹', str10) == 2
 
     d11 = Dict(RainbowString("abcdefgh", false, true, false) => 0, "123456" => 1)
-    str11 = sprint(io -> show(io, MIME("text/plain"), dict); context = (:displaysize=>(30,80), :color=>true, :limit=>true))
+    str11 = sprint(io -> show(io, MIME("text/plain"), d11); context = (:displaysize=>(30,80), :color=>true, :limit=>true))
     @test endswith(str11, "\033[0m => 0")
 end
 

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -458,7 +458,18 @@ end
 
     d11 = Dict(RainbowString("abcdefgh", false, true, false) => 0, "123456" => 1)
     str11 = sprint(io -> show(io, MIME("text/plain"), d11); context = (:displaysize=>(30,80), :color=>true, :limit=>true))
-    @test endswith(str11, "\033[0m => 0")
+    _, line11_a, line11_b = split(str11, '\n')
+    @test endswith(line11_a, "h\033[0m => 0") || endswith(line11_b, "h\033[0m => 0")
+    @test endswith(line11_a, "6\" => 1") || endswith(line11_b, "6\" => 1")
+
+    d12 = Dict(RainbowString(repeat(Char(48+i), 4), (i&1)==1, (i&2)==2, (i&4)==4) => i for i in 1:8)
+    str12 = sprint(io -> show(io, MIME("text/plain"), d12); context = (:displaysize=>(30,80), :color=>true, :limit=>true))
+    @test !occursin('…', str12)
+
+    d13 = Dict(RainbowString("foo\nbar") => 74)
+    str13 = sprint(io -> show(io, MIME("text/plain"), d13); context = (:displaysize=>(30,80), :color=>true, :limit=>true))
+    @test count('\n', str13) == 1
+    @test occursin('…', str13)
 end
 
 @testset "Issue #15739" begin # Compact REPL printouts of an `AbstractDict` use brackets when appropriate

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -426,6 +426,9 @@ end
     lines6 = split(str6, '\n')
     @test all(endswith("\033[0m…"), lines6[2:end])
     @test all(x -> length(x) > 100, lines6[2:end])
+    str6_long = sprint(io -> show(io, MIME("text/plain"), d6); context = (:displaysize=>(30,80), :color=>true, :limit=>true))
+    lines6_long = split(str6_long, '\n')
+    @test all(endswith("\033[0m"), lines6_long[2:end])
 
     d7 = Dict(randstring(8) => RainbowString(randstring(30)))
     str7 = sprint(io -> show(io, MIME("text/plain"), d7); context = (:displaysize=>(30,20), :color=>true, :limit=>true))


### PR DESCRIPTION
The recent #37568 added handling of colors in `Dict` printing with `:limit => true` in the `IOContext`. There is a lingering bug when the last character of the printed value is colored, which results in an additional `…` character being printed and color-bleeding, for example in the following picture:
![bugsmall](https://user-images.githubusercontent.com/23532352/171006789-8117d41d-890a-4d00-9e7b-75e75a782782.png)

This is due to `IgnoreAnsiIterator` skipping the last characters of the value (since they are ANSI end delimiters), then seeing that the entire line has not been printed, and thus wrongly assuming that the `limit` size has been reached.

With this PR:
![fixsmall](https://user-images.githubusercontent.com/23532352/171007180-3440d109-7b4a-4576-a95e-8e840cad598d.png)