### PR TITLE
inference: improve `ssa_def_slot` tracking

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2191,6 +2191,14 @@ function conflicting_assignment_conditional()
 end
 @test @inferred(conflicting_assignment_conditional()) === 4
 
+# https://github.com/JuliaLang/julia/issues/45499
+@test Base.return_types((Vector{Int},Int,)) do xs, x
+    if (i = findfirst(==(x), xs)) !== nothing
+        return i
+    end
+    return 0
+end |> only === Int
+
 # 26826 constant prop through varargs
 
 struct Foo26826{A,B}


### PR DESCRIPTION
This change allows us to propagate conditional information through
this kind of pattern (see #45499):
```
%init = [...]
        [...]
        SlotNumber(x) = %init
        [...]
        goto if not isa(%init, T)
```

If `SlotNumber(x)` is only assigned by `%init` between the definition of
`%init` and the `goto` usage, we can impose a conditional constraint on
`SlotNumber(x)`.

---

@nanosoldier `runbenchmarks("inference", vs=":master")`
fix #45499.