### PR TITLE
faster min/max for IEEEFloats

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -770,7 +770,7 @@ function max(x::T, y::T) where {T<:IEEEFloat}
     b = y > x ? y : x
     # if either argument is NaN, a != b and at least one is NaN
     # else if they are opposite zeros, a == b and a !== b
-    # else a == b and a ==== b
+    # else a == b and a === b
     argplus = a + b # a+b is NaN iff x or y is NaN or they are are opposite-signed Infs - opposite Infs are impossible given the preceding comparisons
     argand = reinterpret(T, reinterpret(Unsigned, a) & reinterpret(Unsigned, b)) # no-op for a==b except to prefer +0.0 over -0.0
     return isnan(argplus) ? argplus : argand
@@ -781,7 +781,7 @@ function min(x::T, y::T) where {T<:IEEEFloat}
     b = y < x ? y : x
     # if either argument is NaN, a != b and at least one is NaN
     # else if they are opposite zeros, a == b and a !== b
-    # else a == b and a ==== b
+    # else a == b and a === b
     argplus = a + b # a+b is NaN iff x or y is NaN or they are are opposite-signed Infs - opposite Infs are impossible given the preceding comparisons
     argor = reinterpret(T, reinterpret(Unsigned, a) | reinterpret(Unsigned, b)) # no-op for a==b except to prefer -0.0 over +0.0
     return isnan(argplus) ? argplus : argor

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -487,6 +487,6 @@ minmax(x::Real) = (x, x)
 
 max(x::T, y::T) where {T<:Real} = ifelse(y < x, x, y)
 min(x::T, y::T) where {T<:Real} = ifelse(y < x, y, x)
-minmax(x::T, y::T) where {T<:Real} = y < x ? (y, x) : (x, y)
+minmax(x::T, y::T) where {T<:Real} = (min(x, y), max(x, y))
 
 flipsign(x::T, y::T) where {T<:Signed} = no_op_err("flipsign", T)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -104,8 +104,8 @@ end
     @test minmax(-Inf, NaN) ≣ (NaN, NaN)
     @test minmax(NaN, -Inf) ≣ (NaN, NaN)
     @test minmax(NaN, NaN) ≣ (NaN, NaN)
-    @test min(-0.0,0.0) === min(0.0,-0.0)
-    @test max(-0.0,0.0) === max(0.0,-0.0)
+    @test min(-0.0,0.0) === min(0.0,-0.0) === -0.0
+    @test max(-0.0,0.0) === max(0.0,-0.0) === 0.0
     @test minmax(-0.0,0.0) === minmax(0.0,-0.0)
     @test max(-3.2, 5.1) == max(5.1, -3.2) == 5.1
     @test min(-3.2, 5.1) == min(5.1, -3.2) == -3.2


### PR DESCRIPTION
Faster `min`, `max`, and `minmax` for `IEEEFloat` (`Float16`, `Float32`, `Float64`) types.

Setup:
```julia
using BenchmarkTools

a = randn(1000);
b = randn(size(a));
z = similar(a);
zz = Array{NTuple{2,Float64}}(undef,size(a));

@btime map!(min, $z, $a, $b);
@btime map!(max, $z, $a, $b);
@btime map!(minmax, $zz, $a, $b);

@btime broadcast!(min, $z, $a, $b);
@btime broadcast!(max, $z, $a, $b);
@btime broadcast!(minmax, $zz, $a, $b);
```

Before:
```
  1.790 μs (0 allocations: 0 bytes)
  1.780 μs (0 allocations: 0 bytes)
  2.244 μs (0 allocations: 0 bytes)
  308.502 ns (0 allocations: 0 bytes)
  307.631 ns (0 allocations: 0 bytes)
  1.970 μs (0 allocations: 0 bytes)
```

After:
```
  1.240 μs (0 allocations: 0 bytes)
  1.240 μs (0 allocations: 0 bytes)
  1.790 μs (0 allocations: 0 bytes)
  227.292 ns (0 allocations: 0 bytes)
  227.292 ns (0 allocations: 0 bytes)
  552.128 ns (0 allocations: 0 bytes)
```

`map!` indicates the straight-line performance while `broadcast!` allows for SIMD. This PR increases throughput for `min`/`max` by about 35%, `minmax` by 25%, and enables `minmax` to SIMD (additional 225% throughput).

Note that the `AbstractFloat`-specialized `minmax` was deleted and the `Real` version redefined to simply `minmax(x,y) = min(x,y),max(x,y)`. The new version is faster for `IEEEFloat` (with the `min`/`max` changes), does not change performance for `BitInteger`, and does not apply to `BigFloat`.

The `AbstractFloat`-specialized versions of `min`/`max` are now dead to `Base` types (`BigFloat` has its own specialization and `IEEEFloat` is superseded by the new specializations in this PR). I was tempted to remove these methods, but that would be breaking for any user-defined `AbstractFloat` types that rely on them. I'm not sure that any do, but I didn't feel the need to break things in this PR.