### PR TITLE
Amend __init__ docstring, add it to docs

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -106,10 +106,10 @@ kw"module"
 """
     __init__
 
-`__init__()` function in your module would executes immediately *after* the module is loaded at
-runtime for the first time (i.e., it is only called once and only after all statements in the
-module have been executed). Because it is called *after* fully importing the module, `__init__`
-functions of submodules will be executed *first*. Two typical uses of `__init__` are calling
+The `__init__()` function in a module executes immediately *after* the module is loaded at
+runtime for the first time. It is called once, after all other statements in the module
+have been executed. Because it is called after fully importing the module, `__init__`
+functions of submodules will be executed first. Two typical uses of `__init__` are calling
 runtime initialization functions of external C libraries and initializing global constants
 that involve pointers returned by external libraries.
 See the [manual section about modules](@ref modules) for more details.

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -32,6 +32,7 @@ Base.include
 Base.MainInclude.include
 Base.include_string
 Base.include_dependency
+__init__
 Base.which(::Any, ::Any)
 Base.methods
 Base.@show


### PR DESCRIPTION
Addresses #45518 . Also rephrases the docstring, as there were some grammatical errors.

It shows up as being "Keyword" in the docs with this PR. That's weird. Is there any reason the docstring is added to the keyword and not the function in `base/doc/basedocs.jl`?