### PR TITLE
add a bit more information upon artifact load failure

### DIFF
--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -137,7 +137,7 @@ end
         mktempdir() do tempdir
             with_artifacts_directory(tempdir) do
                 ex = @test_throws ErrorException artifact"HelloWorldC"
-                @test startswith(ex.value.msg, "Artifact \"HelloWorldC\" was not installed correctly. ")
+                @test startswith(ex.value.msg, "Artifact \"HelloWorldC\" was not found ")
                 ex = @test_throws ErrorException artifact"socrates"
                 @test startswith(ex.value.msg, "Artifact \"socrates\" is a lazy artifact; ")
 

--- a/stdlib/LazyArtifacts/test/runtests.jl
+++ b/stdlib/LazyArtifacts/test/runtests.jl
@@ -10,7 +10,7 @@ mktempdir() do tempdir
             @test isdir(socrates_dir)
         end
         ex = @test_throws ErrorException artifact"HelloWorldC"
-        @test startswith(ex.value.msg, "Artifact \"HelloWorldC\" was not installed correctly. ")
+        @test startswith(ex.value.msg, "Artifact \"HelloWorldC\" was not found")
     end
 end
 


### PR DESCRIPTION
Shows the paths that we tried to look in when loading an artifact and also tweak the suggestion from `instantiate` to checking `Overrides.toml` if we notice an override file.

Examples:

```
julia> using IntelOpenMP_jll
ERROR: InitError: Artifact "IntelOpenMP" (with tree hash 947793e42b663bacd09f00d96aa96a47095f3b1c) was not found by looking in the path "/path/to/my/custom/artifact/".
Check that your `Overrides.toml` file is correct (https://pkgdocs.julialang.org/v1/artifacts/#Overriding-artifact-locations).
```

```
julia> using IntelOpenMP_jll
ERROR: InitError: Artifact "IntelOpenMP" was not found by looking in the paths:
  ~/.julia/artifacts/947793e42b663bacd09f00d96aa96a47095f3b1c
  ~/julia/usr/local/share/julia/artifacts/947793e42b663bacd09f00d96aa96a47095f3b1c
  ~/julia/usr/share/julia/artifacts/947793e42b663bacd09f00d96aa96a47095f3b1c
Try `using Pkg; Pkg.instantiate()` to re-install all missing resources.
```