### PR TITLE
[Profile] `threads` here is wrong to use `nthreads`

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -220,7 +220,7 @@ The keyword arguments can be any combination of:
     `:flatc` does the same but also includes collapsing of C frames (may do odd things around `jl_apply`).
 
  - `threads::Union{Int,AbstractVector{Int}}` -- Specify which threads to include snapshots from in the report. Note that
-    this does not control which threads samples are collected on (which might have been from another also machine also).
+    this does not control which threads samples are collected on (which may also have been collected on another machine).
 
  - `tasks::Union{Int,AbstractVector{Int}}` -- Specify which tasks to include snapshots from in the report. Note that this
     does not control which tasks samples are collected within.

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -220,7 +220,7 @@ The keyword arguments can be any combination of:
     `:flatc` does the same but also includes collapsing of C frames (may do odd things around `jl_apply`).
 
  - `threads::Union{Int,AbstractVector{Int}}` -- Specify which threads to include snapshots from in the report. Note that
-    this does not control which threads samples are collected on.
+    this does not control which threads samples are collected on (which might have been from another also machine also).
 
  - `tasks::Union{Int,AbstractVector{Int}}` -- Specify which tasks to include snapshots from in the report. Note that this
     does not control which tasks samples are collected within.
@@ -238,7 +238,7 @@ function print(io::IO,
         sortedby::Symbol = :filefuncline,
         groupby::Union{Symbol,AbstractVector{Symbol}} = :none,
         recur::Symbol = :off,
-        threads::Union{Int,AbstractVector{Int}} = 1:Threads.nthreads(),
+        threads::Union{Int,AbstractVector{Int}} = 1:typemax(Int),
         tasks::Union{UInt,AbstractVector{UInt}} = typemin(UInt):typemax(UInt))
 
     pf = ProfileFormat(;C, combine, maxdepth, mincount, noisefloor, sortedby, recur)

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -64,8 +64,8 @@ end
     iobuf = IOBuffer()
     with_logger(NullLogger()) do
         @testset for format in [:flat, :tree]
-            @testset for threads in Any[1:Threads.nthreads(), 1, 1:1, 1:2, [1,2]]
-                @testset for groupby in [:none, :thread, :task, [:thread, :task], [:task, :thread]]
+            @testset for threads in Any[1:typemax(Int), 1, 1:1, 1:2, [1,2]]
+                @testset for groupby in Any[:none, :thread, :task, [:thread, :task], [:task, :thread]]
                     Profile.print(iobuf; groupby, threads, format)
                     @test !isempty(String(take!(iobuf)))
                 end


### PR DESCRIPTION
Since the `data` argument possibly does not come from the current
configuration, we should not use `nthreads` here either to filter out
possibly significant data.