### PR TITLE
Fix segfault in `Diagonal` * `OffsetMatrix`

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -285,6 +285,7 @@ function *(D::Diagonal, transA::Transpose{<:Any,<:AbstractMatrix})
 end
 
 @inline function __muldiag!(out, D::Diagonal, B, alpha, beta)
+    require_one_based_indexing(B)
     require_one_based_indexing(out)
     if iszero(alpha)
         _rmul_or_fill!(out, beta)
@@ -306,6 +307,7 @@ end
     return out
 end
 @inline function __muldiag!(out, A, D::Diagonal, alpha, beta)
+    require_one_based_indexing(A)
     require_one_based_indexing(out)
     if iszero(alpha)
         _rmul_or_fill!(out, beta)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -5,12 +5,12 @@ module TestDiagonal
 using Test, LinearAlgebra, Random
 using LinearAlgebra: BlasFloat, BlasComplex
 
-include("../../../test/testhelpers/OffsetArrays.jl")
-using .OffsetArrays
-
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
 isdefined(Main, :Furlongs) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "Furlongs.jl"))
 using .Main.Furlongs
+
+isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "OffsetArrays.jl"))
+using .Main.OffsetArrays
 
 n=12 #Size of matrix problem to test
 Random.seed!(1)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -5,6 +5,9 @@ module TestDiagonal
 using Test, LinearAlgebra, Random
 using LinearAlgebra: BlasFloat, BlasComplex
 
+include("../../../test/testhelpers/OffsetArrays.jl")
+using .OffsetArrays
+
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
 isdefined(Main, :Furlongs) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "Furlongs.jl"))
 using .Main.Furlongs
@@ -783,6 +786,16 @@ end
     @test Diagonal(A) * Diagonal(A) == A * A
     @test_throws DimensionMismatch [1 0;0 1] * Diagonal([2 3])   # Issue #40726
     @test_throws DimensionMismatch lmul!(Diagonal([1]), [1,2,3]) # nearby
+end
+
+@testset "Multiplication of a Diagonal with an OffsetArray" begin
+    # Offset indices should throw
+    D = Diagonal(1:4)
+    A = OffsetArray(rand(4,4), 2, 2)
+    @test_throws ArgumentError D * A
+    @test_throws ArgumentError A * D
+    @test_throws ArgumentError mul!(similar(A, size(A)), A, D)
+    @test_throws ArgumentError mul!(similar(A, size(A)), D, A)
 end
 
 @testset "Triangular division by Diagonal #27989" begin


### PR DESCRIPTION
This fixes a segfault in `Diagonal` * `OffsetMatrix` if the axes of the offset matrix are not 1-based. On master, the check was for sizes of the inputs, and not axes. I've added appropriate `require_one_based_indexing` checks.

This should be back-ported to 1.8.