### PR TITLE
manage stackwalk/profile lock correctly

### DIFF
--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -66,14 +66,6 @@ JL_DLLEXPORT size_t jl_jit_total_bytes_fallback(void)
     return 0;
 }
 
-JL_DLLEXPORT void jl_lock_profile_fallback(void)
-{
-}
-
-JL_DLLEXPORT void jl_unlock_profile_fallback(void)
-{
-}
-
 JL_DLLEXPORT void *jl_create_native_fallback(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvmctxt, const jl_cgparams_t *cgparams, int _policy) UNAVAILABLE
 
 JL_DLLEXPORT void jl_dump_compiles_fallback(void *s)

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -52,12 +52,6 @@ struct debug_link_info {
     uint32_t crc32;
 };
 
-extern "C" JL_DLLEXPORT void jl_lock_profile_impl(void) JL_NOTSAFEPOINT;
-extern "C" JL_DLLEXPORT void jl_unlock_profile_impl(void) JL_NOTSAFEPOINT;
-
-template <typename T>
-static void jl_profile_atomic(T f);
-
 #if (defined(_OS_LINUX_) || defined(_OS_FREEBSD_) || (defined(_OS_DARWIN_) && defined(LLVM_SHLIB)))
 extern "C" void __register_frame(void*);
 extern "C" void __deregister_frame(void*);
@@ -101,16 +95,16 @@ void JITDebugInfoRegistry::add_code_in_flight(StringRef name, jl_code_instance_t
 
 jl_method_instance_t *JITDebugInfoRegistry::lookupLinfo(size_t pointer) JL_NOTSAFEPOINT
 {
-    jl_lock_profile_impl();
+    jl_lock_profile();
     auto region = linfomap.lower_bound(pointer);
     jl_method_instance_t *linfo = NULL;
     if (region != linfomap.end() && pointer < region->first + region->second.first)
         linfo = region->second.second;
-    jl_unlock_profile_impl();
+    jl_unlock_profile();
     return linfo;
 }
 
-//Protected by debuginfo_asyncsafe
+//Protected by debuginfo_asyncsafe (profile) lock
 JITDebugInfoRegistry::objectmap_t &
 JITDebugInfoRegistry::getObjectMap() JL_NOTSAFEPOINT
 {
@@ -131,10 +125,7 @@ JITDebugInfoRegistry::get_objfile_map() JL_NOTSAFEPOINT {
     return *this->objfilemap;
 }
 
-JITDebugInfoRegistry::JITDebugInfoRegistry() JL_NOTSAFEPOINT {
-    uv_rwlock_init(&debuginfo_asyncsafe);
-    debuginfo_asyncsafe_held.init();
-}
+JITDebugInfoRegistry::JITDebugInfoRegistry() JL_NOTSAFEPOINT { }
 
 struct unw_table_entry
 {
@@ -142,30 +133,13 @@ struct unw_table_entry
     int32_t fde_offset;
 };
 
-extern "C" JL_DLLEXPORT void jl_lock_profile_impl(void) JL_NOTSAFEPOINT
-{
-    uintptr_t held = getJITDebugRegistry().debuginfo_asyncsafe_held;
-    if (held++ == 0)
-        uv_rwlock_rdlock(&getJITDebugRegistry().debuginfo_asyncsafe);
-    getJITDebugRegistry().debuginfo_asyncsafe_held = held;
-}
-
-extern "C" JL_DLLEXPORT void jl_unlock_profile_impl(void) JL_NOTSAFEPOINT
-{
-    uintptr_t held = getJITDebugRegistry().debuginfo_asyncsafe_held;
-    assert(held);
-    if (--held == 0)
-        uv_rwlock_rdunlock(&getJITDebugRegistry().debuginfo_asyncsafe);
-    getJITDebugRegistry().debuginfo_asyncsafe_held = held;
-}
-
 // some actions aren't signal (especially profiler) safe so we acquire a lock
 // around them to establish a mutual exclusion with unwinding from a signal
 template <typename T>
 static void jl_profile_atomic(T f)
 {
-    assert(0 == getJITDebugRegistry().debuginfo_asyncsafe_held);
-    uv_rwlock_wrlock(&getJITDebugRegistry().debuginfo_asyncsafe);
+    assert(0 == jl_lock_profile_rd_held());
+    jl_lock_profile_wr();
 #ifndef _OS_WINDOWS_
     sigset_t sset;
     sigset_t oset;
@@ -176,7 +150,7 @@ static void jl_profile_atomic(T f)
 #ifndef _OS_WINDOWS_
     pthread_sigmask(SIG_SETMASK, &oset, NULL);
 #endif
-    uv_rwlock_wrunlock(&getJITDebugRegistry().debuginfo_asyncsafe);
+    jl_unlock_profile_wr();
 }
 
 
@@ -482,10 +456,10 @@ static int lookup_pointer(
 
     // DWARFContext/DWARFUnit update some internal tables during these queries, so
     // a lock is needed.
-    assert(0 == getJITDebugRegistry().debuginfo_asyncsafe_held);
-    uv_rwlock_wrlock(&getJITDebugRegistry().debuginfo_asyncsafe);
+    assert(0 == jl_lock_profile_rd_held());
+    jl_lock_profile_wr();
     auto inlineInfo = context->getInliningInfoForAddress(makeAddress(Section, pointer + slide), infoSpec);
-    uv_rwlock_wrunlock(&getJITDebugRegistry().debuginfo_asyncsafe);
+    jl_unlock_profile_wr();
 
     int fromC = (*frames)[0].fromC;
     int n_frames = inlineInfo.getNumberOfFrames();
@@ -508,9 +482,9 @@ static int lookup_pointer(
             info = inlineInfo.getFrame(i);
         }
         else {
-            uv_rwlock_wrlock(&getJITDebugRegistry().debuginfo_asyncsafe);
+            jl_lock_profile_wr();
             info = context->getLineInfoForAddress(makeAddress(Section, pointer + slide), infoSpec);
-            uv_rwlock_wrunlock(&getJITDebugRegistry().debuginfo_asyncsafe);
+            jl_unlock_profile_wr();
         }
 
         jl_frame_t *frame = &(*frames)[i];
@@ -1197,8 +1171,9 @@ int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, int64_t *slide,
         object::SectionRef *Section, llvm::DIContext **context) JL_NOTSAFEPOINT
 {
     int found = 0;
-    assert(0 == getJITDebugRegistry().debuginfo_asyncsafe_held);
-    uv_rwlock_wrlock(&getJITDebugRegistry().debuginfo_asyncsafe);
+    assert(0 == jl_lock_profile_rd_held());
+    jl_lock_profile_wr();
+
     if (symsize)
         *symsize = 0;
 
@@ -1214,7 +1189,7 @@ int jl_DI_for_fptr(uint64_t fptr, uint64_t *symsize, int64_t *slide,
         }
         found = 1;
     }
-    uv_rwlock_wrunlock(&getJITDebugRegistry().debuginfo_asyncsafe);
+    jl_unlock_profile_wr();
     return found;
 }
 
@@ -1613,13 +1588,13 @@ extern "C" JL_DLLEXPORT
 uint64_t jl_getUnwindInfo_impl(uint64_t dwAddr)
 {
     // Might be called from unmanaged thread
-    jl_lock_profile_impl();
+    jl_lock_profile();
     auto &objmap = getJITDebugRegistry().getObjectMap();
     auto it = objmap.lower_bound(dwAddr);
     uint64_t ipstart = 0; // ip of the start of the section (if found)
     if (it != objmap.end() && dwAddr < it->first + it->second.SectionSize) {
         ipstart = (uint64_t)(uintptr_t)(*it).first;
     }
-    jl_unlock_profile_impl();
+    jl_unlock_profile();
     return ipstart;
 }

--- a/src/init.c
+++ b/src/init.c
@@ -706,6 +706,7 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
     }
 
     jl_init_rand();
+    jl_init_profile_lock();
     jl_init_runtime_ccall();
     jl_init_tasks();
     jl_init_threading();

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -124,10 +124,12 @@
     XX(jl_vecelement_typename) \
     XX(jl_voidpointer_type) \
     XX(jl_void_type) \
-    XX(jl_weakref_type)
+    XX(jl_weakref_type) \
 
 // Data symbols that are defined inside the public libjulia
 #define JL_EXPORTED_DATA_SYMBOLS(XX) \
     XX(jl_n_threadpools, int) \
     XX(jl_n_threads, int) \
-    XX(jl_options, jl_options_t)
+    XX(jl_options, jl_options_t) \
+
+// end of file

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -515,10 +515,10 @@
     XX(jl_vexceptionf) \
     XX(jl_vprintf) \
     XX(jl_wakeup_thread) \
-    XX(jl_yield)
+    XX(jl_yield) \
 
 #define JL_RUNTIME_EXPORTED_FUNCS_WIN(XX) \
-    XX(jl_setjmp)
+    XX(jl_setjmp) \
 
 // use YY instead of XX to avoid jl -> ijl renaming in libjulia-codegen
 #define JL_CODEGEN_EXPORTED_FUNCS(YY) \
@@ -542,8 +542,6 @@
     YY(jl_compile_extern_c) \
     YY(jl_teardown_codegen) \
     YY(jl_jit_total_bytes) \
-    YY(jl_lock_profile) \
-    YY(jl_unlock_profile) \
     YY(jl_create_native) \
     YY(jl_dump_compiles) \
     YY(jl_dump_emitted_mi_name) \
@@ -568,4 +566,6 @@
     YY(LLVMExtraAddRemoveNIPass) \
     YY(LLVMExtraAddGCInvariantVerifierPass) \
     YY(LLVMExtraAddDemoteFloat16Pass) \
-    YY(LLVMExtraAddCPUFeaturesPass)
+    YY(LLVMExtraAddCPUFeaturesPass) \
+
+// end of file

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -135,6 +135,13 @@ JL_DLLEXPORT void jl_set_peek_cond(uintptr_t);
 JL_DLLEXPORT double jl_get_profile_peek_duration(void);
 JL_DLLEXPORT void jl_set_profile_peek_duration(double);
 
+JL_DLLEXPORT void jl_init_profile_lock(void);
+JL_DLLEXPORT uintptr_t jl_lock_profile_rd_held(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_lock_profile(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_unlock_profile(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_lock_profile_wr(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_unlock_profile_wr(void) JL_NOTSAFEPOINT;
+
 // number of cycles since power-on
 static inline uint64_t cycleclock(void) JL_NOTSAFEPOINT
 {
@@ -831,6 +838,10 @@ typedef DWORD jl_pgcstack_key_t;
 typedef jl_gcframe_t ***(*jl_pgcstack_key_t)(void) JL_NOTSAFEPOINT;
 #endif
 JL_DLLEXPORT void jl_pgcstack_getkey(jl_get_pgcstack_func **f, jl_pgcstack_key_t *k);
+
+#if !defined(_OS_WINDOWS_) && !defined(__APPLE__) && !defined(JL_DISABLE_LIBUNWIND)
+extern pthread_mutex_t in_signal_lock;
+#endif
 
 #if !defined(__clang_gcanalyzer__) && !defined(_OS_DARWIN_)
 static inline void jl_set_gc_and_wait(void)

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -201,6 +201,7 @@ typedef struct {
 } jl_gc_mark_cache_t;
 
 struct _jl_bt_element_t;
+
 // This includes all the thread local states we care about for a thread.
 // Changes to TLS field types must be reflected in codegen.
 #define JL_MAX_BT_SIZE 80000

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -25,15 +25,114 @@ static volatile size_t bt_size_cur = 0;
 static volatile uint64_t nsecprof = 0;
 static volatile int running = 0;
 static const    uint64_t GIGA = 1000000000ULL;
-static uint64_t profile_cong_rng_seed = 0;
-static uint64_t profile_cong_rng_unbias = 0;
-static volatile uint64_t *profile_round_robin_thread_order = NULL;
 // Timers to take samples at intervals
 JL_DLLEXPORT void jl_profile_stop_timer(void);
 JL_DLLEXPORT int jl_profile_start_timer(void);
-void jl_lock_profile(void);
-void jl_unlock_profile(void);
-void jl_shuffle_int_array_inplace(volatile uint64_t *carray, size_t size, uint64_t *seed);
+
+// Any function that acquires this lock must be either a unmanaged thread
+// or in the GC safe region and must NOT allocate anything through the GC
+// while holding this lock.
+// Certain functions in this file might be called from an unmanaged thread
+// and cannot have any interaction with the julia runtime
+// They also may be re-entrant, and operating while threads are paused, so we
+// separately manage the re-entrant count behavior for safety across platforms
+// Note that we cannot safely upgrade read->write
+uv_rwlock_t debuginfo_asyncsafe;
+#ifndef _OS_WINDOWS_
+pthread_key_t debuginfo_asyncsafe_held;
+#else
+DWORD debuginfo_asyncsafe_held;
+#endif
+
+void jl_init_profile_lock(void)
+{
+    uv_rwlock_init(&debuginfo_asyncsafe);
+#ifndef _OS_WINDOWS_
+    pthread_key_create(&debuginfo_asyncsafe_held, NULL);
+#else
+    debuginfo_asyncsafe_held = TlsAlloc();
+#endif
+}
+
+uintptr_t jl_lock_profile_rd_held(void)
+{
+#ifndef _OS_WINDOWS_
+    return (uintptr_t)pthread_getspecific(debuginfo_asyncsafe_held);
+#else
+    return (uintptr_t)TlsGetValue(debuginfo_asyncsafe_held);
+#endif
+}
+
+void jl_lock_profile(void)
+{
+    uintptr_t held = jl_lock_profile_rd_held();
+    if (held++ == 0)
+        uv_rwlock_rdlock(&debuginfo_asyncsafe);
+#ifndef _OS_WINDOWS_
+    pthread_setspecific(debuginfo_asyncsafe_held, (void*)held);
+#else
+    TlsSetValue(debuginfo_asyncsafe_held, (void*)held);
+#endif
+}
+
+JL_DLLEXPORT void jl_unlock_profile(void)
+{
+    uintptr_t held = jl_lock_profile_rd_held();
+    assert(held);
+    if (--held == 0)
+        uv_rwlock_rdunlock(&debuginfo_asyncsafe);
+#ifndef _OS_WINDOWS_
+    pthread_setspecific(debuginfo_asyncsafe_held, (void*)held);
+#else
+    TlsSetValue(debuginfo_asyncsafe_held, (void*)held);
+#endif
+}
+
+void jl_lock_profile_wr(void)
+{
+    uv_rwlock_wrlock(&debuginfo_asyncsafe);
+}
+
+void jl_unlock_profile_wr(void)
+{
+    uv_rwlock_wrunlock(&debuginfo_asyncsafe);
+}
+
+
+#ifndef _OS_WINDOWS_
+static uint64_t profile_cong_rng_seed = 0;
+static int *profile_round_robin_thread_order = NULL;
+static int profile_round_robin_thread_order_size = 0;
+
+static void jl_shuffle_int_array_inplace(int *carray, int size, uint64_t *seed)
+{
+    // The "modern Fisher–Yates shuffle" - O(n) algorithm
+    // https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
+    for (int i = size; i-- > 1; ) {
+        uint64_t unbias = UINT64_MAX; // slightly biased, but i is very small
+        size_t j = cong(i, unbias, seed);
+        uint64_t tmp = carray[j];
+        carray[j] = carray[i];
+        carray[i] = tmp;
+    }
+}
+
+
+static int *profile_get_randperm(int size)
+{
+    if (profile_round_robin_thread_order_size < size) {
+        free(profile_round_robin_thread_order);
+        profile_round_robin_thread_order = (int*)malloc_s(size * sizeof(int));
+        for (int i = 0; i < size; i++)
+            profile_round_robin_thread_order[i] = i;
+        profile_round_robin_thread_order_size = size;
+        profile_cong_rng_seed = jl_rand();
+    }
+    jl_shuffle_int_array_inplace(profile_round_robin_thread_order, size, &profile_cong_rng_seed);
+    return profile_round_robin_thread_order;
+}
+#endif
+
 
 JL_DLLEXPORT int jl_profile_is_buffer_full(void)
 {
@@ -336,33 +435,11 @@ JL_DLLEXPORT int jl_profile_init(size_t maxsize, uint64_t delay_nsec)
     nsecprof = delay_nsec;
     if (bt_data_prof != NULL)
         free((void*)bt_data_prof);
-    if (profile_round_robin_thread_order == NULL) {
-        // NOTE: We currently only allocate this once, since jl_n_threads cannot change
-        // during execution of a julia process. If/when this invariant changes in the
-        // future, this will have to be adjusted.
-        profile_round_robin_thread_order = (uint64_t*) calloc(jl_n_threads, sizeof(uint64_t));
-        for (int i = 0; i < jl_n_threads; i++) {
-            profile_round_robin_thread_order[i] = i;
-        }
-    }
-    profile_cong_rng_seed = jl_rand();
-    unbias_cong(jl_n_threads, &profile_cong_rng_unbias);
     bt_data_prof = (jl_bt_element_t*) calloc(maxsize, sizeof(jl_bt_element_t));
     if (bt_data_prof == NULL && maxsize > 0)
         return -1;
     bt_size_cur = 0;
     return 0;
-}
-
-void jl_shuffle_int_array_inplace(volatile uint64_t *carray, size_t size, uint64_t *seed) {
-    // The "modern Fisher–Yates shuffle" - O(n) algorithm
-    // https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
-    for (size_t i = size - 1; i >= 1; --i) {
-        size_t j = cong(i, profile_cong_rng_unbias, seed);
-        uint64_t tmp = carray[j];
-        carray[j] = carray[i];
-        carray[i] = tmp;
-    }
 }
 
 JL_DLLEXPORT uint8_t *jl_profile_get_data(void)

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -605,10 +605,11 @@ void *mach_profile_listener(void *arg)
         // sample each thread, round-robin style in reverse order
         // (so that thread zero gets notified last)
         int keymgr_locked = jl_lock_profile_mach(0);
-        jl_shuffle_int_array_inplace(profile_round_robin_thread_order, jl_n_threads, &profile_cong_rng_seed);
+
+        int *randperm = profile_get_randperm(jl_n_threads);
         for (int idx = jl_n_threads; idx-- > 0; ) {
-            // Stop the threads in the random round-robin order.
-            int i = profile_round_robin_thread_order[idx];
+            // Stop the threads in the random or reverse round-robin order.
+            int i = randperm[idx];
             // if there is no space left, break early
             if (jl_profile_is_buffer_full()) {
                 jl_profile_stop_timer();

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -362,7 +362,7 @@ static void segv_handler(int sig, siginfo_t *info, void *context)
 
 #if !defined(JL_DISABLE_LIBUNWIND)
 static unw_context_t *volatile signal_context;
-static pthread_mutex_t in_signal_lock;
+pthread_mutex_t in_signal_lock;
 static pthread_cond_t exit_signal_cond;
 static pthread_cond_t signal_caught_cond;
 
@@ -809,11 +809,12 @@ static void *signal_listener(void *arg)
         // (so that thread zero gets notified last)
         if (critical || profile) {
             jl_lock_profile();
-            if (!critical)
-                jl_shuffle_int_array_inplace(profile_round_robin_thread_order, jl_n_threads, &profile_cong_rng_seed);
+            int *randperm;
+            if (profile)
+                 randperm = profile_get_randperm(jl_n_threads);
             for (int idx = jl_n_threads; idx-- > 0; ) {
-                // Stop the threads in the random round-robin order.
-                int i = critical ? idx : profile_round_robin_thread_order[idx];
+                // Stop the threads in the random or reverse round-robin order.
+                int i = profile ? randperm[idx] : idx;
                 // notify thread to stop
                 jl_thread_suspend_and_get_state(i, &signal_context);
                 if (signal_context == NULL)


### PR DESCRIPTION
Previously we had the wrong number of them (it was not global) and it
was in the wrong shared library (it was part of codegen instead of
profiling).

The profile_round_robin_thread_order buffer was not allocated on the
thread that exclusively used it, so it sometimes could end up somewhat
awkwardly (in incorrectly) shared between 2 threads.