### PR TITLE
Clarify usage of the second argument to `hash`

### DIFF
--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -6,7 +6,7 @@
     hash(x[, h::UInt]) -> UInt
 
 Compute an integer hash code such that `isequal(x,y)` implies `hash(x)==hash(y)`. The
-optional second argument `h` is a hash code to be mixed with the result.
+optional second argument `h` is another hash code to be mixed with the result.
 
 New types should implement the 2-argument form, typically by calling the 2-argument `hash`
 method recursively in order to mix hashes of the contents with each other (and with `h`).
@@ -14,6 +14,14 @@ Typically, any type that implements `hash` should also implement its own [`==`](
 [`isequal`](@ref)) to guarantee the property mentioned above. Types supporting subtraction
 (operator `-`) should also implement [`widen`](@ref), which is required to hash
 values inside heterogeneous arrays.
+
+```jldoctest
+julia> a = hash(10)
+0x95ea2955abd45275
+
+julia> hash(10, a) # only use the output of another hash function as the second argument
+0xd42bad54a8575b16
+```
 
 See also: [`objectid`](@ref), [`Dict`](@ref), [`Set`](@ref).
 """


### PR DESCRIPTION
There was a little bit of confusion in how the second argument of `hash` should be used. I think the word change and doctests help.