### PR TITLE
don't stall the CPU when using rr with threads

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -190,22 +190,7 @@ NOINLINE uintptr_t gc_get_stack_ptr(void)
 
 #define should_timeout() 0
 
-static void jl_gc_wait_for_the_world(void)
-{
-    if (jl_n_threads > 1)
-        jl_wake_libuv();
-    for (int i = 0; i < jl_n_threads; i++) {
-        jl_ptls_t ptls2 = jl_all_tls_states[i];
-        // This acquire load pairs with the release stores
-        // in the signal handler of safepoint so we are sure that
-        // all the stores on those threads are visible.
-        // We're currently also using atomic store release in mutator threads
-        // (in jl_gc_state_set), but we may want to use signals to flush the
-        // memory operations on those threads lazily instead.
-        while (!jl_atomic_load_relaxed(&ptls2->gc_state) || !jl_atomic_load_acquire(&ptls2->gc_state))
-            jl_cpu_pause(); // yield?
-    }
-}
+void jl_gc_wait_for_the_world(void);
 
 // malloc wrappers, aligned allocation
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -109,7 +109,7 @@ static jl_method_instance_t *jl_specializations_get_linfo_(jl_method_t *m JL_PRO
     for (int locked = 0; ; locked++) {
         jl_array_t *speckeyset = jl_atomic_load_acquire(&m->speckeyset);
         jl_svec_t *specializations = jl_atomic_load_relaxed(&m->specializations);
-        size_t i, cl = jl_svec_len(specializations);
+        size_t i = -1, cl = jl_svec_len(specializations);
         if (hv) {
             ssize_t idx = jl_smallintset_lookup(speckeyset, speccache_eq, type, specializations, hv);
             if (idx != -1) {

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -8,6 +8,7 @@
     small_arraylist_grow;
     jl_*;
     ijl_*;
+    _jl_mutex_*;
     rec_backtrace;
     julia_*;
     libsupport_init;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1295,7 +1295,6 @@ JL_DLLEXPORT void jl_set_next_task(jl_task_t *task) JL_NOTSAFEPOINT;
 
 extern jl_mutex_t typecache_lock;
 extern JL_DLLEXPORT jl_mutex_t jl_codegen_lock;
-extern uv_mutex_t safepoint_lock;
 
 #if defined(__APPLE__)
 void jl_mach_gc_end(void);

--- a/src/julia_locks.h
+++ b/src/julia_locks.h
@@ -17,25 +17,16 @@ extern "C" {
 // The JL_LOCK* and JL_UNLOCK* macros are no-op for non-threading build
 // while the jl_mutex_* functions are always locking and unlocking the locks.
 
+JL_DLLEXPORT void _jl_mutex_wait(jl_task_t *self, jl_mutex_t *lock, int safepoint);
+JL_DLLEXPORT void _jl_mutex_lock(jl_task_t *self, jl_mutex_t *lock);
+JL_DLLEXPORT int _jl_mutex_trylock_nogc(jl_task_t *self, jl_mutex_t *lock) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int _jl_mutex_trylock(jl_task_t *self, jl_mutex_t *lock);
+JL_DLLEXPORT void _jl_mutex_unlock(jl_task_t *self, jl_mutex_t *lock);
+JL_DLLEXPORT void _jl_mutex_unlock_nogc(jl_mutex_t *lock) JL_NOTSAFEPOINT;
+
 static inline void jl_mutex_wait(jl_mutex_t *lock, int safepoint)
 {
-    jl_task_t *self = jl_current_task;
-    jl_task_t *owner = jl_atomic_load_relaxed(&lock->owner);
-    if (owner == self) {
-        lock->count++;
-        return;
-    }
-    while (1) {
-        if (owner == NULL && jl_atomic_cmpswap(&lock->owner, &owner, self)) {
-            lock->count = 1;
-            return;
-        }
-        if (safepoint) {
-            jl_gc_safepoint_(self->ptls);
-        }
-        jl_cpu_pause();
-        owner = jl_atomic_load_relaxed(&lock->owner);
-    }
+    _jl_mutex_wait(jl_current_task, lock, safepoint);
 }
 
 static inline void jl_mutex_lock_nogc(jl_mutex_t *lock) JL_NOTSAFEPOINT
@@ -46,26 +37,6 @@ static inline void jl_mutex_lock_nogc(jl_mutex_t *lock) JL_NOTSAFEPOINT
     // not reach the safepoint, but the analyzer can't figure that out
     jl_mutex_wait(lock, 0);
 #endif
-}
-
-static inline void jl_lock_frame_push(jl_mutex_t *lock)
-{
-    jl_ptls_t ptls = jl_current_task->ptls;
-    small_arraylist_t *locks = &ptls->locks;
-    uint32_t len = locks->len;
-    if (__unlikely(len >= locks->max)) {
-        small_arraylist_grow(locks, 1);
-    }
-    else {
-        locks->len = len + 1;
-    }
-    locks->items[len] = (void*)lock;
-}
-static inline void jl_lock_frame_pop(void)
-{
-    jl_ptls_t ptls = jl_current_task->ptls;
-    assert(ptls->locks.len > 0);
-    ptls->locks.len--;
 }
 
 #define JL_SIGATOMIC_BEGIN() do {               \
@@ -79,57 +50,40 @@ static inline void jl_lock_frame_pop(void)
         }                                                       \
     } while (0)
 
+#define JL_SIGATOMIC_BEGIN_self() do {          \
+        self->ptls->defer_signal++;             \
+        jl_signal_fence();                      \
+    } while (0)
+#define JL_SIGATOMIC_END_self() do {            \
+        jl_signal_fence();                      \
+        if (--self->ptls->defer_signal == 0) {  \
+            jl_sigint_safepoint(self->ptls);    \
+        }                                       \
+    } while (0)
+
 static inline void jl_mutex_lock(jl_mutex_t *lock)
 {
-    JL_SIGATOMIC_BEGIN();
-    jl_mutex_wait(lock, 1);
-    jl_lock_frame_push(lock);
+    _jl_mutex_lock(jl_current_task, lock);
 }
 
-static inline int jl_mutex_trylock_nogc(jl_mutex_t *lock)
+static inline int jl_mutex_trylock_nogc(jl_mutex_t *lock) JL_NOTSAFEPOINT
 {
-    jl_task_t *self = jl_current_task;
-    jl_task_t *owner = jl_atomic_load_acquire(&lock->owner);
-    if (owner == self) {
-        lock->count++;
-        return 1;
-    }
-    if (owner == NULL && jl_atomic_cmpswap(&lock->owner, &owner, self)) {
-        lock->count = 1;
-        return 1;
-    }
-    return 0;
+    return _jl_mutex_trylock_nogc(jl_current_task, lock);
 }
 
 static inline int jl_mutex_trylock(jl_mutex_t *lock)
 {
-    int got = jl_mutex_trylock_nogc(lock);
-    if (got) {
-        JL_SIGATOMIC_BEGIN();
-        jl_lock_frame_push(lock);
-    }
-    return got;
-}
-static inline void jl_mutex_unlock_nogc(jl_mutex_t *lock) JL_NOTSAFEPOINT
-{
-#ifndef __clang_gcanalyzer__
-    assert(jl_atomic_load_relaxed(&lock->owner) == jl_current_task &&
-           "Unlocking a lock in a different thread.");
-    if (--lock->count == 0) {
-        jl_atomic_store_release(&lock->owner, (jl_task_t*)NULL);
-        jl_cpu_wake();
-    }
-#endif
+    return _jl_mutex_trylock(jl_current_task, lock);
 }
 
 static inline void jl_mutex_unlock(jl_mutex_t *lock)
 {
-    jl_mutex_unlock_nogc(lock);
-    jl_lock_frame_pop();
-    JL_SIGATOMIC_END();
-    if (jl_atomic_load_relaxed(&jl_gc_have_pending_finalizers)) {
-        jl_gc_run_pending_finalizers(jl_current_task); // may GC
-    }
+    _jl_mutex_unlock(jl_current_task, lock);
+}
+
+static inline void jl_mutex_unlock_nogc(jl_mutex_t *lock) JL_NOTSAFEPOINT
+{
+    _jl_mutex_unlock_nogc(lock);
 }
 
 static inline void jl_mutex_init(jl_mutex_t *lock) JL_NOTSAFEPOINT

--- a/src/safepoint.c
+++ b/src/safepoint.c
@@ -43,6 +43,7 @@ uint8_t jl_safepoint_enable_cnt[3] = {0, 0, 0};
 // load/store so that threads waiting for the GC doesn't have to also
 // fight on the safepoint lock...
 uv_mutex_t safepoint_lock;
+uv_cond_t safepoint_cond;
 
 static void jl_safepoint_enable(int idx) JL_NOTSAFEPOINT
 {
@@ -87,6 +88,7 @@ static void jl_safepoint_disable(int idx) JL_NOTSAFEPOINT
 void jl_safepoint_init(void)
 {
     uv_mutex_init(&safepoint_lock);
+    uv_cond_init(&safepoint_cond);
     // jl_page_size isn't available yet.
     size_t pgsz = jl_getpagesize();
 #ifdef _OS_WINDOWS_
@@ -105,6 +107,31 @@ void jl_safepoint_init(void)
     // The signal page is for the gc safepoint.
     // The page before it is the sigint pending flag.
     jl_safepoint_pages = addr;
+}
+
+void jl_gc_wait_for_the_world(void)
+{
+    assert(jl_n_threads);
+    if (jl_n_threads > 1)
+        jl_wake_libuv();
+    for (int i = 0; i < jl_n_threads; i++) {
+        jl_ptls_t ptls2 = jl_all_tls_states[i];
+        // This acquire load pairs with the release stores
+        // in the signal handler of safepoint so we are sure that
+        // all the stores on those threads are visible.
+        // We're currently also using atomic store release in mutator threads
+        // (in jl_gc_state_set), but we may want to use signals to flush the
+        // memory operations on those threads lazily instead.
+        while (!jl_atomic_load_relaxed(&ptls2->gc_state) || !jl_atomic_load_acquire(&ptls2->gc_state)) {
+            // Use system mutexes rather than spin locking to minimize wasted CPU time
+            // while we wait for other threads reach a safepoint.
+            // This is particularly important when run under rr.
+            uv_mutex_lock(&safepoint_lock);
+            if (!jl_atomic_load_relaxed(&ptls2->gc_state))
+                uv_cond_wait(&safepoint_cond, &safepoint_lock);
+            uv_mutex_unlock(&safepoint_lock);
+        }
+    }
 }
 
 int jl_safepoint_start_gc(void)
@@ -157,6 +184,7 @@ void jl_safepoint_wait_gc(void)
 {
     // The thread should have set this is already
     assert(jl_atomic_load_relaxed(&jl_current_task->ptls->gc_state) != 0);
+    uv_cond_broadcast(&safepoint_cond);
     // Use normal volatile load in the loop for speed until GC finishes.
     // Then use an acquire load to make sure the GC result is visible on this thread.
     while (jl_atomic_load_relaxed(&jl_gc_running) || jl_atomic_load_acquire(&jl_gc_running)) {

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -41,6 +41,8 @@ static void attach_exception_port(thread_port_t thread, int segv_only);
 
 // low 16 bits are the thread id, the next 8 bits are the original gc_state
 static arraylist_t suspended_threads;
+extern uv_mutex_t safepoint_lock;
+extern uv_cond_t safepoint_cond;
 void jl_mach_gc_end(void)
 {
     // Requires the safepoint lock to be held
@@ -83,6 +85,7 @@ static int jl_mach_gc_wait(jl_ptls_t ptls2,
     arraylist_push(&suspended_threads, (void*)item);
     thread_suspend(thread);
     uv_mutex_unlock(&safepoint_lock);
+    uv_cond_broadcast(&safepoint_cond);
     return 1;
 }
 

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -549,7 +549,9 @@ function test_load_and_lookup_18020(n)
             ccall(:jl_load_and_lookup,
                   Ptr{Cvoid}, (Cstring, Cstring, Ref{Ptr{Cvoid}}),
                   "$i", :f, C_NULL)
-        catch
+        catch ex
+            ex isa ErrorException || rethrow()
+            startswith(ex.msg, "could not load library") || rethrow()
         end
     end
 end


### PR DESCRIPTION
For example, this lets us run the thread_exec.jl test in finite time. Please see individual commit diffs.