### PR TITLE
make converting to `NTuple` throw consistently

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -383,7 +383,7 @@ function _totuple(::Type{T}, itr, s::Vararg{Any,N}) where {T,N}
     # inference may give up in recursive calls, so annotate here to force accurate return type to be propagated
     rT = tuple_type_tail(T)
     ts = _totuple(rT, itr, y[2])::rT
-    return (t1, ts...)
+    return (t1, ts...)::T
 end
 
 # use iterative algorithm for long tuples

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -64,6 +64,9 @@ end
     @test_throws MethodError convert(Tuple{Int, Int, Int}, (1, 2))
     # issue #26589
     @test_throws MethodError convert(NTuple{4}, (1.0,2.0,3.0,4.0,5.0))
+    # issue #44179
+    @test_throws TypeError convert(NTuple{3}, [1, nothing, nothing])
+    @test_throws TypeError convert(NTuple{3}, [nothing, 1, nothing])
     # issue #31824
     @test convert(NTuple, (1, 1.0)) === (1, 1.0)
     let T = Tuple{Vararg{T}} where T<:Integer, v = (1.0, 2, 0x3)

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -65,8 +65,8 @@ end
     # issue #26589
     @test_throws MethodError convert(NTuple{4}, (1.0,2.0,3.0,4.0,5.0))
     # issue #44179
-    @test_throws TypeError convert(NTuple{3}, [1, nothing, nothing])
-    @test_throws TypeError convert(NTuple{3}, [nothing, 1, nothing])
+    @test_throws TypeError NTuple{3}([1, nothing, nothing])
+    @test_throws TypeError NTuple{3}([nothing, 1, nothing])
     # issue #31824
     @test convert(NTuple, (1, 1.0)) === (1, 1.0)
     let T = Tuple{Vararg{T}} where T<:Integer, v = (1.0, 2, 0x3)


### PR DESCRIPTION
fix #44179