### PR TITLE
Remove an unused method instance of Base.floatrange

### DIFF
--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -392,22 +392,6 @@ function floatrange(::Type{T}, start_n::Integer, step_n::Integer, len::Integer, 
     steprangelen_hp(T, (ref_n, den), (step_n, den), nb, len, imin)
 end
 
-function floatrange(a::AbstractFloat, st::AbstractFloat, len::Real, divisor::AbstractFloat)
-    len = len + 0 # promote with Int
-    T = promote_type(typeof(a), typeof(st), typeof(divisor))
-    m = maxintfloat(T, Int)
-    if abs(a) <= m && abs(st) <= m && abs(divisor) <= m
-        ia, ist, idivisor = round(Int, a), round(Int, st), round(Int, divisor)
-        if ia == a && ist == st && idivisor == divisor
-            # We can return the high-precision range
-            return floatrange(T, ia, ist, len, idivisor)
-        end
-    end
-    # Fallback (misses the opportunity to set offset different from 1,
-    # but otherwise this is still high-precision)
-    steprangelen_hp(T, (a,divisor), (st,divisor), nbitslen(T, len, 1), len, oneunit(len))
-end
-
 function (:)(start::T, step::T, stop::T) where T<:IEEEFloat
     step == 0 && throw(ArgumentError("range step cannot be zero"))
     # see if the inputs have exact rational approximations (and if so,

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -874,7 +874,6 @@ end
 @testset "Inexact errors on 32 bit architectures. #22613" begin
     @test first(range(log(0.2), stop=log(10.0), length=10)) == log(0.2)
     @test last(range(log(0.2), stop=log(10.0), length=10)) == log(10.0)
-    @test length(Base.floatrange(-3e9, 1.0, 1, 1.0)) == 1
 end
 
 @testset "ranges with very small endpoints for type $T" for T = (Float32, Float64)


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/issues/45336 for details.

The removed `Base.floatrange` instance is unused and incorrectly implemented because of different semantics of `steprangelen_hp`.