### PR TITLE
Fix union!(s::BitSet, r::AbstractUnitRange{<:Integer}) when two ranges do not overlap.

### DIFF
--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -138,19 +138,9 @@ function union!(s::BitSet, r::AbstractUnitRange{<:Integer})
     # grow s.bits as necessary
     if diffb >= len
         _growend0!(s.bits, diffb - len + 1)
-        # we set only some values to CHK0, those which will not be
-        # fully overwritten (i.e. only or'ed with `|`)
-        s.bits[end] = CHK0 # end == diffb + 1
-        if diffa >= len
-            s.bits[diffa + 1] = CHK0
-        end
     end
     if diffa < 0
         _growbeg0!(s.bits, -diffa)
-        s.bits[1] = CHK0
-        if diffb < 0
-            s.bits[diffb - diffa + 1] = CHK0
-        end
         s.offset = cidxa # s.offset += diffa
         diffb -= diffa
         diffa = 0

--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -137,7 +137,7 @@ function union!(s::BitSet, r::AbstractUnitRange{<:Integer})
 
     # grow s.bits as necessary
     if diffb >= len
-        _growend!(s.bits, diffb - len + 1)
+        _growend0!(s.bits, diffb - len + 1)
         # we set only some values to CHK0, those which will not be
         # fully overwritten (i.e. only or'ed with `|`)
         s.bits[end] = CHK0 # end == diffb + 1
@@ -146,7 +146,7 @@ function union!(s::BitSet, r::AbstractUnitRange{<:Integer})
         end
     end
     if diffa < 0
-        _growbeg!(s.bits, -diffa)
+        _growbeg0!(s.bits, -diffa)
         s.bits[1] = CHK0
         if diffb < 0
             s.bits[diffb - diffa + 1] = CHK0

--- a/test/bitset.jl
+++ b/test/bitset.jl
@@ -351,3 +351,12 @@ end
     # union! with an empty range doesn't modify the BitSet
     @test union!(x, b:a) == y
 end
+
+@testset "union!(::BitSet, ::AbstractUnitRange) when two ranges do not overlap" begin
+    # see #45574
+    a, b = minmax(rand(-1000:1000, 2)...)
+    c, d = minmax(rand(2000:3000, 2)...)
+    @test length(union!(BitSet(a:b), c:d)) == length(a:b) + length(c:d)
+    c, d = minmax(rand(-3000:-2000, 2)...)
+    @test length(union!(BitSet(a:b), c:d)) == length(a:b) + length(c:d)
+end

--- a/test/bitset.jl
+++ b/test/bitset.jl
@@ -354,9 +354,9 @@ end
 
 @testset "union!(::BitSet, ::AbstractUnitRange) when two ranges do not overlap" begin
     # see #45574
-    a, b = minmax(rand(-1000:1000, 2)...)
-    c, d = minmax(rand(2000:3000, 2)...)
+    a, b = rand(-10000:-5000), rand(5000:10000)
+    c, d = minmax(rand(20000:30000, 2)...)
     @test length(union!(BitSet(a:b), c:d)) == length(a:b) + length(c:d)
-    c, d = minmax(rand(-3000:-2000, 2)...)
+    c, d = minmax(rand(-30000:-20000, 2)...)
     @test length(union!(BitSet(a:b), c:d)) == length(a:b) + length(c:d)
 end


### PR DESCRIPTION
Fix https://github.com/JuliaLang/julia/issues/45574