### PR TITLE
add `@something!` for updating the first arg to something

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -717,6 +717,7 @@ export
     missing,
     skipmissing,
     @something,
+    @something!,
     something,
     isnothing,
     nonmissingtype,

--- a/base/some.jl
+++ b/base/some.jl
@@ -77,7 +77,7 @@ Return the first value in the arguments which is not equal to [`nothing`](@ref),
 if any. Otherwise throw an error.
 Arguments of type [`Some`](@ref) are unwrapped.
 
-See also [`coalesce`](@ref), [`skipmissing`](@ref), [`@something`](@ref).
+See also [`coalesce`](@ref), [`skipmissing`](@ref), [`@something`](@ref), [`@something!`](@ref).
 
 # Examples
 ```jldoctest
@@ -134,6 +134,7 @@ true
 
 !!! compat "Julia 1.7"
     This macro is available as of Julia 1.7.
+
 """
 macro something(args...)
     expr = :(nothing)
@@ -142,4 +143,33 @@ macro something(args...)
     end
     something = GlobalRef(Base, :something)
     return :($something($expr))
+end
+
+
+"""
+    @something!(x, y...)
+
+Short-circuiting version of [`something`](@ref), similar to [`@something`](@ref) but
+assigns the result back to the first arg.
+
+# Examples
+```jldoctest
+julia> x = nothing
+
+julia> @something! x 1
+1
+
+julia> x
+1
+```
+
+!!! compat "Julia 1.9"
+    This macro is available as of Julia 1.9.
+"""
+macro something!(args...)
+    length(args) < 2 && return :(throw(ArgumentError("Two or more arguments must be provided")))
+    first(args) isa Symbol || return :(throw(ArgumentError("The first argument must be a variable")))
+    quote
+        $(esc(first(args))) = @something($(esc(first(args))), $(esc(args[2:end]...)))
+    end
 end

--- a/test/some.jl
+++ b/test/some.jl
@@ -94,6 +94,14 @@ end
     end == 1
 end
 
+@testset "@something!" begin
+    @test_throws ArgumentError @something!()
+    @test_throws ArgumentError @something!(nothing)
+    x = nothing
+    @test @something!(x, 1) === 1
+    @test x === 1
+end
+
 # issue #26927
 a = [missing, nothing, Some(nothing), Some(missing)]
 @test a isa Vector{Union{Missing, Nothing, Some}}


### PR DESCRIPTION
I find that most of the time I use `@something` is like
```
x = @something x y z
```

This adds `@something!` so you can just do this, and the first arg value is updated
```
@something! x y z
```

Original PR for `@something` https://github.com/JuliaLang/julia/pull/40729

