### PR TITLE
Move Statistics out of the sysimage

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -57,7 +57,6 @@ let
         # 3-depth packages
         :REPL,
         :SharedArrays,
-        :Statistics,
         :SuiteSparse,
         :TOML,
         :Test,

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -85,20 +85,14 @@ julia> for item in Squares(7)
 ```
 
 We can use many of the builtin methods that work with iterables,
-like [`in`](@ref), or [`mean`](@ref) and [`std`](@ref) from the
-`Statistics` standard library module:
+like [`in`](@ref) or [`sum`](@ref):
 
 ```jldoctest squaretype
 julia> 25 in Squares(10)
 true
 
-julia> using Statistics
-
-julia> mean(Squares(100))
-3383.5
-
-julia> std(Squares(100))
-3024.355854282583
+julia> sum(Squares(100))
+338350
 ```
 
 There are a few more methods we can extend to give Julia more information about this iterable

--- a/doc/src/manual/missing.md
+++ b/doc/src/manual/missing.md
@@ -325,15 +325,15 @@ julia> sum(skipmissing([1, missing]))
 This convenience function returns an iterator which filters out `missing` values
 efficiently. It can therefore be used with any function which supports iterators:
 
-```jldoctest skipmissing; setup = :(using Statistics)
+```jldoctest skipmissing
 julia> x = skipmissing([3, missing, 2, 1])
 skipmissing(Union{Missing, Int64}[3, missing, 2, 1])
 
 julia> maximum(x)
 3
 
-julia> mean(x)
-2.0
+julia> sum(x)
+6
 
 julia> mapreduce(sqrt, +, x)
 4.146264369941973

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -2,7 +2,6 @@
 
 using Test, SparseArrays
 using Test: guardseed
-using Statistics: mean
 
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
 isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "OffsetArrays.jl"))
@@ -988,9 +987,9 @@ end
     # Test that shuffle! is uniformly random on BitArrays
     rng = MersenneTwister(123)
     a = (reshape(1:(4*5), 4, 5) .<= 2) # 4x5 BitMatrix whose first two elements are true, rest are false
-    m = mean(1:50_000) do _
+    m = sum(1:50_000) do _
         shuffle!(rng, a)
-    end # mean result of shuffle!-ing a 50_000 times. If the shuffle! is uniform, then each index has a
+    end/50_000 # mean result of shuffle!-ing a 50_000 times. If the shuffle! is uniform, then each index has a
     # 10% chance of having a true in it, so each value should converge to 0.1.
     @test minimum(m) >= 0.094
     @test maximum(m) <= 0.106

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -5,7 +5,6 @@ using .Main.OffsetArrays
 import .Main.OffsetArrays: IdOffsetRange
 using Random
 using LinearAlgebra
-using Statistics
 using Base: IdentityUnitRange
 
 if !isdefined(@__MODULE__, :T24Linear)
@@ -457,13 +456,10 @@ I = findall(!iszero, z)
 @test findall(x->x>0, h) == [-1,1]
 @test findall(x->x<0, h) == [-2,0]
 @test findall(x->x==0, h) == [2]
-@test mean(A_3_3) == median(A_3_3) == 5
-@test mean(x->2x, A_3_3) == 10
-@test mean(A_3_3, dims=1) == median(A_3_3, dims=1) == OffsetArray([2 5 8], A_3_3.offsets)
-@test mean(A_3_3, dims=2) == median(A_3_3, dims=2) == OffsetArray(reshape([4,5,6],(3,1)), A_3_3.offsets)
-@test var(A_3_3) == 7.5
-@test std(A_3_3, dims=1) == OffsetArray([1 1 1], A_3_3.offsets)
-@test std(A_3_3, dims=2) == OffsetArray(reshape([3,3,3], (3,1)), A_3_3.offsets)
+@test sum(A_3_3) == 45
+@test sum(x->2x, A_3_3) == 90
+@test sum(A_3_3, dims=1) == OffsetArray([6 15 24], A_3_3.offsets)
+@test sum(A_3_3, dims=2) == OffsetArray(reshape([12,15,18],(3,1)), A_3_3.offsets)
 @test sum(OffsetArray(fill(1,3000), -1000)) == 3000
 
 # https://github.com/JuliaArrays/OffsetArrays.jl/issues/92

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -364,7 +364,7 @@ precompile_test_harness(false) do dir
                  :LazyArtifacts, :LibCURL, :LibCURL_jll, :LibGit2, :Libdl, :LinearAlgebra,
                  :Logging, :Markdown, :Mmap, :MozillaCACerts_jll, :NetworkOptions, :OpenBLAS_jll, :Pkg, :Printf,
                  :Profile, :p7zip_jll, :REPL, :Random, :SHA, :Serialization, :SharedArrays, :Sockets,
-                 :SparseArrays, :Statistics, :SuiteSparse, :TOML, :Tar, :Test, :UUIDs, :Unicode,
+                 :SparseArrays, :SuiteSparse, :TOML, :Tar, :Test, :UUIDs, :Unicode,
                  :nghttp2_jll]
             ),
         )


### PR DESCRIPTION
And remove uses of it in the manual and tests.

Follow-up from https://github.com/JuliaLang/julia/pull/44247. Should probably run PkgEval if the PR looks OK.

I'd suggest trying this, and only move `mean` and/or `std` to Base if people complain too loudly before 1.9 is released. Personally I would rather keep these in Statistics to be group statistics function in a single package at last (merging with StatsBase). This makes sense e.g. because these have methods taking weight vectors that we have considered turning into a keyword argument. Also `std` relies on `var` so these cannot really be separated.