### PR TITLE
Revise workspace/buffer to be ::UInt8[] instead of ::AbstractVector{eltype(input)}

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -765,8 +765,8 @@ workspace(v::AbstractVector, ::Nothing, len::Integer) = similar(v, len)
 workspace(v::AbstractVector, data::Vector{UInt8}, len::Integer) = Workspace(eltype(v), data, len)
 
 Base.size(w::Workspace) = size(w.wrapper)
-Base.@propagate_inbounds getindex(w::Workspace, i::Int) = getindex(w.wrapper, i)
-Base.@propagate_inbounds setindex!(w::Workspace, v, i::Int) = setindex!(w.wrapper, v, i)
+Base.@propagate_inbounds Base.getindex(w::Workspace, i::Int) = getindex(w.wrapper, i)
+Base.@propagate_inbounds Base.setindex!(w::Workspace, v, i::Int) = setindex!(w.wrapper, v, i)
 
 maybe_unsigned(x::Integer) = x # this is necessary to avoid calling unsigned on BigInt
 maybe_unsigned(x::BitSigned) = unsigned(x)

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -655,8 +655,8 @@ end
 end
 
 @testset "workspace()" begin
-    for v in [[1, 2, 3], [0.0]]
-        for t0 in vcat([nothing], [similar(v,i) for i in 1:5]), len in 0:5
+    for v in [Int16[1, 2, 3], [0.0], [[7], [2]]]
+        for t0 in vcat([nothing], [Vector{UInt8}(undef, i) for i in 1:13]), len in 0:5
             t = Base.Sort.workspace(v, t0, len)
             @test eltype(t) == eltype(v)
             @test length(t) >= len
@@ -665,14 +665,14 @@ end
     end
 end
 
-@testset "sort(x; workspace=w) " begin
+@testset "sort(x; workspace=w)" begin
     for n in [1,10,100,1000]
         v = rand(n)
-        w = [0.0]
+        w = UInt8[]
         @test sort(v) == sort(v; workspace=w)
         @test sort!(copy(v)) == sort!(copy(v); workspace=w)
-        @test sortperm(v) == sortperm(v; workspace=[4])
-        @test sortperm!(Vector{Int}(undef, n), v) == sortperm!(Vector{Int}(undef, n), v; workspace=[4])
+        @test sortperm(v) == sortperm(v; workspace=w)
+        @test sortperm!(Vector{Int}(undef, n), v) == sortperm!(Vector{Int}(undef, n), v; workspace=w)
 
         n > 100 && continue
         M = rand(n, n)
@@ -681,7 +681,7 @@ end
     end
 end
 
-
+# This testset is at the end of the file because it is slow
 @testset "searchsorted" begin
     numTypes = [ Int8,  Int16,  Int32,  Int64,  Int128,
                 UInt8, UInt16, UInt32, UInt64, UInt128,


### PR DESCRIPTION
The workspace/buffer used in sorting is merely a place to put things. It need not have a fixed type. I believe the most natural way to represent a place to put things is a `Vector{UInt8}`, as [suggested originally by cjdoris](https://discourse.julialang.org/t/how-to-support-passing-temporary-buffers-around/70880/14?u=lilith). The impact of this change is perhaps best understood by seeing how the "sort(x; workspace=w)" test set changes.

To use a workspace/buffer, one needs to designate some space `workspace = UInt8[]` and then give that space to multiple different sorting functions, each of which will temporarily assume ownership of that Vector, resize/reinterpret it as needed, and then return ownership back to the caller upon return. To quote cjdoris, "The caller can then preallocate an empty such vector and pass it in to repeated calls without needing to know how it will be used."

This is better than `workspace::AbstractVector{eltype(input)}` because it is more natural, extensible, and reusable (subjective) and because it allows for the workspace to be used both to store elements of the input array and to store other relevant collections with different element types like the count vector in radix sort (objective).

See discussion leading to this PR [here](https://discourse.julialang.org/t/how-to-support-passing-temporary-buffers-around/70880/13) and more recently [here](https://discourse.julialang.org/t/reinterpret-to-non-bits-type/82307/30). This follows up on #45330.