### PR TITLE
Update Statistics.version to pull from the JuliaStats org

### DIFF
--- a/stdlib/Statistics.version
+++ b/stdlib/Statistics.version
@@ -1,4 +1,4 @@
 STATISTICS_BRANCH = master
 STATISTICS_SHA1 = c38dd4418738bc595bd8229eb4ee91b717de64af
-STATISTICS_GIT_URL := https://github.com/JuliaLang/Statistics.jl.git
-STATISTICS_TAR_URL = https://api.github.com/repos/JuliaLang/Statistics.jl/tarball/$1
+STATISTICS_GIT_URL := https://github.com/JuliaStats/Statistics.jl.git
+STATISTICS_TAR_URL = https://api.github.com/repos/JuliaStats/Statistics.jl/tarball/$1


### PR DESCRIPTION
Statistics.jl is now in the JuliaStats org, and this PR updates the location. Are there other places we need to make this change?