### PR TITLE
Add `Base.ismutabletype` to doc

### DIFF
--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -172,6 +172,7 @@ Base.isdispatchtuple
 ```@docs
 Base.ismutable
 Base.isimmutable
+Base.ismutabletype
 Base.isabstracttype
 Base.isprimitivetype
 Base.issingletontype


### PR DESCRIPTION
It is exported but not listed in documentation.