### PR TITLE
Add `pkgversion(m::Module)` to get the version of the package that loaded a given module

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -67,6 +67,8 @@ New library functions
 * `Iterators.flatmap` was added ([#44792]).
 * New helper `Splat(f)` which acts like `x -> f(x...)`, with pretty printing for
   inspecting which function `f` was originally wrapped. ([#42717])
+* New `pkgversion(m::Module)` function to get the version of the package that loaded
+  a given module, similar to `pkgdir(m::Module)`. ([#45607])
 
 Library changes
 ---------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -790,6 +790,7 @@ export
     parentmodule,
     pathof,
     pkgdir,
+    pkgversion,
     names,
     which,
     @isdefined,

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -441,11 +441,11 @@ end
     pkgversion(m::Module)
 
 Return the version of the package that imported module `m`,
-or `nothing` if `m` was not imported from a package or a
-package without a version field set.
+or `nothing` if `m` was not imported from a package, or imported
+from a package without a version field set.
 
-The version is read from the package's Project.toml at package
-load time.
+The version is read from the package's Project.toml during package
+load.
 
 !!! compat "Julia 1.9"
     This function was introduced in Julia 1.9.

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -453,8 +453,8 @@ load.
 function pkgversion(m::Module)
     rootmodule = moduleroot(m)
     pkg = PkgId(rootmodule)
-    pkgorigin = get!(PkgOrigin, pkgorigins, pkg)
-    return pkgorigin.version
+    pkgorigin = get(pkgorigins, pkg, nothing)
+    return pkgorigin === nothing ? nothing : pkgorigin.version
 end
 
 ## generic project & manifest API ##

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -418,6 +418,7 @@ Base.nameof(::Module)
 Base.parentmodule
 Base.pathof(::Module)
 Base.pkgdir(::Module)
+Base.pkgversion(::Module)
 Base.moduleroot
 __module__
 __source__

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -359,6 +359,13 @@ module NotPkgModule; end
         @test pkgdir(NotPkgModule, "src") === nothing
     end
 
+    @testset "pkgversion" begin
+        @test pkgversion(Foo) == v"1.2.3"
+        @test pkgversion(Foo.SubFoo1) == v"1.2.3"
+        @test pkgversion(Foo.SubFoo2) == v"1.2.3"
+        @test pkgversion(NotPkgModule) === nothing
+    end
+
 end
 
 ## systematic generation of test environments ##

--- a/test/project/deps/Foo1/Project.toml
+++ b/test/project/deps/Foo1/Project.toml
@@ -1,0 +1,3 @@
+name = "Foo"
+uuid = "1a6589dc-c33c-4d54-9a54-f7fc4b3ff616"
+version = "1.2.3"


### PR DESCRIPTION
Similar to `pkgdir(m::Module)` this returns the version of the package that loaded the given module or submodule.
(building on https://github.com/JuliaLang/julia/pull/44318)

```
(@v1.9) pkg> st
Status `~/.julia/environments/v1.9/Project.toml`
  [c46f51b8] ProfileView v1.5.1
  [295af30f] Revise v3.3.3

julia> using ProfileView, Revise

julia> pkgversion(ProfileView)
v"1.5.1"

julia> pkgversion(Revise)
v"3.3.3"
```
```
julia> module Foo end
Main.Foo

julia> pkgversion(Foo)

julia>
```
```
(@v1.9) pkg> st -m OrderedCollections
Status `~/.julia/environments/v1.9/Manifest.toml`
  [bac558e1] OrderedCollections v1.4.1

julia> pkgversion(Revise.OrderedCollections)
v"1.4.1"
```