### PR TITLE
rename `is_concrete_eval_eligible` utility query to `is_foldable`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -746,7 +746,7 @@ function concrete_eval_eligible(interp::AbstractInterpreter,
     isoverlayed(method_table(interp)) && !is_nonoverlayed(result.edge_effects) && return false
     return f !== nothing &&
            result.edge !== nothing &&
-           is_concrete_eval_eligible(result.edge_effects) &&
+           is_foldable(result.edge_effects) &&
            is_all_const_arg(arginfo)
 end
 

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -125,13 +125,13 @@ is_notaskstate(effects::Effects)  = effects.notaskstate === ALWAYS_TRUE
 is_nonoverlayed(effects::Effects) = effects.nonoverlayed
 
 # implies :notaskstate, but not explicitly checked here
-is_concrete_eval_eligible(effects::Effects) =
+is_foldable(effects::Effects) =
     is_consistent(effects) &&
     is_effect_free(effects) &&
     is_terminates(effects)
 
 is_total(effects::Effects) =
-    is_concrete_eval_eligible(effects) &&
+    is_foldable(effects) &&
     is_nothrow(effects)
 
 is_removable_if_unused(effects::Effects) =

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1119,4 +1119,4 @@ end
 # test that `Broadcast` definition is defined as total and eligible for concrete evaluation
 import Base.Broadcast: BroadcastStyle, DefaultArrayStyle
 @test Base.infer_effects(BroadcastStyle, (DefaultArrayStyle{1},DefaultArrayStyle{2},)) |>
-    Core.Compiler.is_concrete_eval_eligible
+    Core.Compiler.is_foldable

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4130,14 +4130,14 @@ function entry_to_be_invalidated(c)
 end
 @test Base.infer_effects((Char,)) do x
     entry_to_be_invalidated(x)
-end |> Core.Compiler.is_concrete_eval_eligible
+end |> Core.Compiler.is_foldable
 @test fully_eliminated(; retval=97) do
     entry_to_be_invalidated('a')
 end
 getcharid(c) = CONST_DICT[c] # now this is not eligible for concrete evaluation
 @test Base.infer_effects((Char,)) do x
     entry_to_be_invalidated(x)
-end |> !Core.Compiler.is_concrete_eval_eligible
+end |> !Core.Compiler.is_foldable
 @test !fully_eliminated() do
     entry_to_be_invalidated('a')
 end


### PR DESCRIPTION
`is_foldable` should be more aligned with `Base.@assume_effects`.
This should be backported to 1.8 also.