### PR TITLE
[src] Silence GCC 12 warnings about dangling pointers

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ FLAGS := \
 	-I$(LIBUV_INC) -I$(build_includedir) \
 	-I$(JULIAHOME)/deps/valgrind
 FLAGS += -Wall -Wno-strict-aliasing -fno-omit-frame-pointer -fvisibility=hidden -fno-common \
-		 -Wno-comment -Wpointer-arith -Wundef -Wno-pragmas
+		 -Wno-comment -Wpointer-arith -Wundef
 ifeq ($(USEGCC),1) # GCC bug #25509 (void)__attribute__((warn_unused_result))
 FLAGS += -Wno-unused-result
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ FLAGS := \
 	-I$(LIBUV_INC) -I$(build_includedir) \
 	-I$(JULIAHOME)/deps/valgrind
 FLAGS += -Wall -Wno-strict-aliasing -fno-omit-frame-pointer -fvisibility=hidden -fno-common \
-		 -Wno-comment -Wpointer-arith -Wundef
+		 -Wno-comment -Wpointer-arith -Wundef -Wno-pragmas
 ifeq ($(USEGCC),1) # GCC bug #25509 (void)__attribute__((warn_unused_result))
 FLAGS += -Wno-unused-result
 endif

--- a/src/init.c
+++ b/src/init.c
@@ -73,7 +73,9 @@ void jl_init_stack_limits(int ismaster, void **stack_lo, void **stack_hi)
         pthread_attr_destroy(&attr);
         *stack_lo = (void*)stackaddr;
 #pragma GCC diagnostic push
+#if defined(_COMPILER_GCC_) && __GNUC__ >= 12
 #pragma GCC diagnostic ignored "-Wdangling-pointer"
+#endif
         *stack_hi = (void*)&stacksize;
 #pragma GCC diagnostic pop
         return;
@@ -108,7 +110,9 @@ void jl_init_stack_limits(int ismaster, void **stack_lo, void **stack_hi)
 #  ifndef __clang_analyzer__
     *stack_hi = (void*)&stacksize;
 #pragma GCC diagnostic push
+#if defined(_COMPILER_GCC_) && __GNUC__ >= 12
 #pragma GCC diagnostic ignored "-Wdangling-pointer"
+#endif
     *stack_lo = (void*)((char*)*stack_hi - stacksize);
 #pragma GCC diagnostic pop
 #  else
@@ -728,9 +732,11 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
 
     jl_gc_init();
     jl_ptls_t ptls = jl_init_threadtls(0);
-    // warning: this changes `jl_current_task`, so be careful not to call that from this function
 #pragma GCC diagnostic push
+#if defined(_COMPILER_GCC_) && __GNUC__ >= 12
 #pragma GCC diagnostic ignored "-Wdangling-pointer"
+#endif
+    // warning: this changes `jl_current_task`, so be careful not to call that from this function
     jl_task_t *ct = jl_init_root_task(ptls, stack_lo, stack_hi);
 #pragma GCC diagnostic pop
     JL_GC_PROMISE_ROOTED(ct);

--- a/src/init.c
+++ b/src/init.c
@@ -72,7 +72,10 @@ void jl_init_stack_limits(int ismaster, void **stack_lo, void **stack_hi)
         pthread_attr_getstack(&attr, &stackaddr, &stacksize);
         pthread_attr_destroy(&attr);
         *stack_lo = (void*)stackaddr;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-pointer"
         *stack_hi = (void*)&stacksize;
+#pragma GCC diagnostic pop
         return;
 #  elif defined(_OS_DARWIN_)
         extern void *pthread_get_stackaddr_np(pthread_t thread);
@@ -104,7 +107,10 @@ void jl_init_stack_limits(int ismaster, void **stack_lo, void **stack_hi)
 // We intentionally leak a stack address here core.StackAddressEscape
 #  ifndef __clang_analyzer__
     *stack_hi = (void*)&stacksize;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-pointer"
     *stack_lo = (void*)((char*)*stack_hi - stacksize);
+#pragma GCC diagnostic pop
 #  else
     *stack_hi = 0;
     *stack_lo = 0;
@@ -723,7 +729,10 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
     jl_gc_init();
     jl_ptls_t ptls = jl_init_threadtls(0);
     // warning: this changes `jl_current_task`, so be careful not to call that from this function
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdangling-pointer"
     jl_task_t *ct = jl_init_root_task(ptls, stack_lo, stack_hi);
+#pragma GCC diagnostic pop
     JL_GC_PROMISE_ROOTED(ct);
     _finish_julia_init(rel, ptls, ct);
 }


### PR DESCRIPTION
GCC 12 introduced some new warnings (ref: #45400).  This PR silence some of them, my understanding is that the dangling pointers are used on purpose here.  If not, this should be resolved in some other ways.