### PR TITLE
Forward `length` to the parent in `ReshapedArray`

### DIFF
--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -205,6 +205,7 @@ function __reshape(p::Tuple{AbstractArray,IndexLinear}, dims::Dims)
 end
 
 size(A::ReshapedArray) = A.dims
+length(A::ReshapedArray) = length(parent(A))
 similar(A::ReshapedArray, eltype::Type, dims::Dims) = similar(parent(A), eltype, dims)
 IndexStyle(::Type{<:ReshapedArrayLF}) = IndexLinear()
 parent(A::ReshapedArray) = A.parent

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1567,8 +1567,12 @@ end
 end
 
 @testset "reshape methods for AbstractVectors" begin
-    r = Base.IdentityUnitRange(3:4)
-    @test reshape(r, :) === reshape(r, (:,)) === r
+    for r in Any[1:3, Base.IdentityUnitRange(3:4)]
+        @test reshape(r, :) === reshape(r, (:,)) === r
+    end
+    r = 3:5
+    rr = reshape(r, 1, 3)
+    @test length(rr) == length(r)
 end
 
 @testset "strides for ReshapedArray" begin


### PR DESCRIPTION
Since `reshape` asserts that the dimensions of the `ReshapedArray` are consistent with the length of the parent array, we may forward `length` to the parent. This may help if the parent's length is easy to compute, e.g. for static arrays. 

On master:
```julia
julia> A = reshape(SA[1,2,3,4], 2, 2)
2×2 reshape(::SVector{4, Int64}, 2, 2) with eltype Int64:
 1  3
 2  4

julia> @code_typed length(A)
CodeInfo(
1 ─ %1 = Base.getfield(t, :dims)::Tuple{Int64, Int64}
│   %2 = Core.getfield(%1, 1)::Int64
│   %3 = Core.getfield(%1, 2)::Int64
│   %4 = Base.mul_int(%2, %3)::Int64
└──      return %4
) => Int64
```

This PR:
```julia
julia> @code_typed length(A)
CodeInfo(
1 ─     return 4
) => Int64
```