### PR TITLE
Fix a typo in Base.setproperty! docs

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2882,7 +2882,7 @@ Base.getproperty
 
 The syntax `a.b = c` calls `setproperty!(a, :b, c)`.
 The syntax `@atomic order a.b = c` calls `setproperty!(a, :b, c, :order)`
-and the syntax `@atomic a.b = c` calls `setproperty!(a, :b, :c, :sequentially_consistent)`.
+and the syntax `@atomic a.b = c` calls `setproperty!(a, :b, c, :sequentially_consistent)`.
 
 !!! compat "Julia 1.8"
     `setproperty!` on modules requires at least Julia 1.8.

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2882,7 +2882,7 @@ Base.getproperty
 
 The syntax `a.b = c` calls `setproperty!(a, :b, c)`.
 The syntax `@atomic order a.b = c` calls `setproperty!(a, :b, c, :order)`
-and the syntax `@atomic a.b = c` calls `getproperty(a, :b, :sequentially_consistent)`.
+and the syntax `@atomic a.b = c` calls `setproperty!(a, :b, :c, :sequentially_consistent)`.
 
 !!! compat "Julia 1.8"
     `setproperty!` on modules requires at least Julia 1.8.


### PR DESCRIPTION
This is also in Julia 1.8, so you might want to backport it