### PR TITLE
codegen: mark argument array with tbaa_const

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6326,10 +6326,10 @@ static Function *gen_invoke_wrapper(jl_method_instance_t *lam, jl_value_t *jlret
         }
         else {
             Value *argPtr = ctx.builder.CreateConstInBoundsGEP1_32(ctx.types().T_prjlvalue, argArray, i - 1);
-            theArg = maybe_mark_load_dereferenceable(
+            theArg = tbaa_decorate(ctx.tbaa().tbaa_const, maybe_mark_load_dereferenceable(
                     ctx.builder.CreateAlignedLoad(ctx.types().T_prjlvalue, argPtr, Align(sizeof(void*))),
                     false,
-                    ty);
+                    ty));
         }
         if (!isboxed) {
             theArg = decay_derived(ctx, emit_bitcast(ctx, theArg, PointerType::get(lty, 0)));
@@ -7121,10 +7121,10 @@ static jl_llvm_functions_t
                         argType : vi.value.typ);
                 }
                 else {
-                    Value *argPtr = ctx.builder.CreateInBoundsGEP(ctx.types().T_prjlvalue, argArray, ConstantInt::get(getSizeTy(ctx.builder.getContext()), i-1));
-                    Value *load = maybe_mark_load_dereferenceable(
+                    Value *argPtr = ctx.builder.CreateConstInBoundsGEP1_32(ctx.types().T_prjlvalue, argArray, i - 1);
+                    Value *load = tbaa_decorate(ctx.tbaa().tbaa_const, maybe_mark_load_dereferenceable(
                             ctx.builder.CreateAlignedLoad(ctx.types().T_prjlvalue, argPtr, Align(sizeof(void*))),
-                            false, vi.value.typ);
+                            false, vi.value.typ));
                     theArg = mark_julia_type(ctx, load, true, vi.value.typ);
                     if (ctx.debug_enabled && vi.dinfo && !vi.boxroot && !vi.value.V) {
                         SmallVector<uint64_t, 8> addr;


### PR DESCRIPTION
At some point our codegen roots for this became terrible, this fixes it. Afterwards:
```llvm
define nonnull {}* @jfptr_AmulB_359({}* %0, {}** %1, i32 %2) #1 { 
top:                                                
  %thread_ptr = call i8* asm "movq %fs:0, $0", "=r"() #6          
  %ppgcstack_i8 = getelementptr i8, i8* %thread_ptr, i64 -8                                                                         
  %ppgcstack = bitcast i8* %ppgcstack_i8 to {}****                
  %pgcstack = load {}***, {}**** %ppgcstack, align 8
  %3 = alloca [1 x [49 x double]], align 8                                                                                          
  %4 = bitcast {}** %1 to [1 x [49 x double]]**                                                                                     
  %5 = load [1 x [49 x double]]*, [1 x [49 x double]]** %4, align 8                                                                 
  %6 = getelementptr inbounds {}*, {}** %1, i64 1                 
  %7 = bitcast {}** %6 to [1 x [49 x double]]**      
  %8 = load [1 x [49 x double]]*, [1 x [49 x double]]** %7, align 8                                                                 
  call void @julia_AmulB_358([1 x [49 x double]]* noalias nocapture nonnull sret([1 x [49 x double]]) %3, [1 x [49 x double]]* nocapture readonly %5, [1 x [49 x double]]* nocapture readonly %8) #0                                                                    
  %ptls_field2 = getelementptr inbounds {}**, {}*** %pgcstack, i64 2                                                                
  %9 = bitcast {}*** %ptls_field2 to i8**                         
  %ptls_load34 = load i8*, i8** %9, align 8                       
  %10 = call noalias nonnull {}* @ijl_gc_pool_alloc(i8* %ptls_load34, i32 2088, i32 400) #7                                         
  %11 = bitcast {}* %10 to i64*                                                                                                     
  %12 = getelementptr inbounds i64, i64* %11, i64 -1              
  store atomic i64 140681847811104, i64* %12 unordered, align 8
  %13 = bitcast {}* %10 to i8*                                                                                                      
  %14 = bitcast [1 x [49 x double]]* %3 to i8*                   
  call void @llvm.memcpy.p0i8.p0i8.i64(i8* noundef nonnull align 8 dereferenceable(392) %13, i8* noundef nonnull align 8 dereferenceable(392) %14, i64 392, i1 false)                                                                                                   
  ret {}* %10                                                                                                                                                                                                                                                           
}         
```