### PR TITLE
Fix LibGit2 tests on `x86_64-linux-musl`

### DIFF
--- a/base/secretbuffer.jl
+++ b/base/secretbuffer.jl
@@ -79,8 +79,17 @@ function SecretBuffer!(d::Vector{UInt8})
     s
 end
 
-unsafe_SecretBuffer!(s::Cstring) = unsafe_SecretBuffer!(convert(Ptr{UInt8}, s), Int(ccall(:strlen, Csize_t, (Cstring,), s)))
+function unsafe_SecretBuffer!(s::Cstring)
+    if s == C_NULL
+        throw(ArgumentError("cannot convert NULL to SecretBuffer"))
+    end
+    len = Int(ccall(:strlen, Csize_t, (Cstring,), s))
+    unsafe_SecretBuffer!(convert(Ptr{UInt8}, s), len)
+end
 function unsafe_SecretBuffer!(p::Ptr{UInt8}, len=1)
+    if p == C_NULL
+        throw(ArgumentError("cannot convert NULL to SecretBuffer"))
+    end
     s = SecretBuffer(sizehint=len)
     for i in 1:len
         write(s, unsafe_load(p, i))

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -199,6 +199,7 @@
     XX(jl_generic_function_def) \
     XX(jl_gensym) \
     XX(jl_getallocationgranularity) \
+    XX(jl_getch) \
     XX(jl_getnameinfo) \
     XX(jl_getpagesize) \
     XX(jl_get_ARCH) \

--- a/src/julia.h
+++ b/src/julia.h
@@ -2057,6 +2057,7 @@ extern JL_DLLEXPORT JL_STREAM *JL_STDERR;
 JL_DLLEXPORT JL_STREAM *jl_stdout_stream(void);
 JL_DLLEXPORT JL_STREAM *jl_stdin_stream(void);
 JL_DLLEXPORT JL_STREAM *jl_stderr_stream(void);
+JL_DLLEXPORT int jl_getch(void);
 
 // showing and std streams
 JL_DLLEXPORT void jl_flush_cstdio(void) JL_NOTSAFEPOINT;

--- a/src/sys.c
+++ b/src/sys.c
@@ -27,6 +27,9 @@
 #include <sys/mman.h>
 #include <dlfcn.h>
 #include <grp.h>
+
+// For `struct termios`
+#include <termios.h>
 #endif
 
 #ifndef _OS_WINDOWS_
@@ -513,6 +516,31 @@ JL_STREAM *JL_STDERR = (JL_STREAM*)STDERR_FILENO;
 JL_DLLEXPORT JL_STREAM *jl_stdin_stream(void)  { return JL_STDIN; }
 JL_DLLEXPORT JL_STREAM *jl_stdout_stream(void) { return JL_STDOUT; }
 JL_DLLEXPORT JL_STREAM *jl_stderr_stream(void) { return JL_STDERR; }
+
+// terminal workarounds
+JL_DLLEXPORT int jl_getch(void) JL_NOTSAFEPOINT
+{
+#if defined(_OS_WINDOWS_)
+    // Windows has an actual `_getch()`, use that:
+    return _getch();
+#else
+    // On all other platforms, we do the POSIX terminal manipulation dance
+    char c;
+    int r;
+    struct termios old_termios = {0};
+    struct termios new_termios = {0};
+    if (tcgetattr(0, &old_termios) != 0)
+        return -1;
+    new_termios = old_termios;
+    cfmakeraw(&new_termios);
+    if (tcsetattr(0, TCSADRAIN, &new_termios) != 0)
+        return -1;
+    r = read(0, &c, 1);
+    if (tcsetattr(0, TCSADRAIN, &old_termios) != 0)
+        return -1;
+    return r == 1 ? c : -1;
+#endif
+}
 
 // -- processor native alignment information --
 

--- a/test/secretbuffer.jl
+++ b/test/secretbuffer.jl
@@ -122,4 +122,11 @@ using Test
         @test hash(sb1, UInt(5)) === hash(sb2, UInt(5))
         shred!(sb1); shred!(sb2)
     end
+    @testset "NULL initialization" begin
+        null_ptr = Cstring(C_NULL)
+        @test_throws ArgumentError Base.unsafe_SecretBuffer!(null_ptr)
+        null_ptr = Ptr{UInt8}(C_NULL)
+        @test_throws ArgumentError Base.unsafe_SecretBuffer!(null_ptr)
+        @test_throws ArgumentError Base.unsafe_SecretBuffer!(null_ptr, 0)
+    end
 end


### PR DESCRIPTION
The LibGit2 tests have been failing on musl for a while now; Jameson, Alex and I have been investigating on Slack, and I'm assembling the fixes here.