### PR TITLE
Add `Base.is_serializing_code()` for guarding precompilation code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,8 @@ New library functions
   inspecting which function `f` was originally wrapped. ([#42717])
 * New `pkgversion(m::Module)` function to get the version of the package that loaded
   a given module, similar to `pkgdir(m::Module)`. ([#45607])
+* New function `Base.is_serializing_code()` to replace `ccall(:jl_generating_output, Cint, ()) == 1` which is being
+  used widely for guarding precompilation code. ([#45650])
 
 Library changes
 ---------------

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2156,6 +2156,7 @@ It is therefore recommended, where possible, to find minimal code to execute to 
 Guarding precompilation code behind this check is also best practice because in some situations, 
 downstream users may not want to use the precompilation caching, which can be disabled globally
 via `--compiled-modules=no`.
+
 See also [`precompile`](@ref).
 """
 function is_serializing_code()

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2153,7 +2153,7 @@ automated via tooling such as the package `SnoopCompile.jl`.
 
 It is therefore recommended, where possible, to find minimal code to execute to get the desired precompilation coverage.
 
-Guarding precompilation code behind this check is also best practice because in some situations, 
+Guarding precompilation code behind this check is also best practice because in some situations,
 downstream users may not want to use the precompilation caching, which can be disabled globally
 via `--compiled-modules=no`.
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2147,8 +2147,8 @@ end # module
 
 Note that the first example here actually executes `foo(1, 1.0)` so can be slower, but is usually more robust
 to changes in the codebase than the latter approach of using `precompile` statements. The latter requires explicitly
-calling `precompile` on methods that cannot be inferred. i.e. if `foo(1, 1.0)` calls some methods by runtime dispatch, the dispatched calls must be independently `precompile`d.
-which will also need `precompile` statements. Consequently the latter can be more work to maintain, but can be
+calling `precompile` on methods that cannot be inferred. i.e. if `foo(1, 1.0)` calls some methods by runtime dispatch,
+the dispatched calls must be independently `precompile`d. Consequently the latter can be more work to maintain, but can be
 automated via tooling such as the package `SnoopCompile.jl`.
 
 It is therefore recommended, where possible, to find minimal code to execute to get the desired precompilation coverage.

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2156,7 +2156,7 @@ It is therefore recommended, where possible, to find minimal code to execute to 
 See also [`precompile`](@ref).
 """
 function is_serializing_code()
-    return ccall(:jl_generating_output, Cint, ()) == 1
+    return ccall(:jl_generating_output, Cint, ()) != 0
 end
 
 """

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1074,7 +1074,7 @@ If a module or file is *not* safely precompilable, it should call `__precompile_
 order to throw an error if Julia attempts to precompile it.
 """
 @noinline function __precompile__(isprecompilable::Bool=true)
-    if !isprecompilable && ccall(:jl_generating_output, Cint, ()) != 0
+    if !isprecompilable && is_serializing_code()
         throw(PrecompilableError())
     end
     nothing
@@ -1285,7 +1285,7 @@ function _require(pkg::PkgId)
         end
 
         if JLOptions().use_compiled_modules != 0
-            if (0 == ccall(:jl_generating_output, Cint, ())) || (JLOptions().incremental != 0)
+            if !is_serializing_code() || (JLOptions().incremental != 0)
                 # spawn off a new incremental pre-compile task for recursive `require` calls
                 # or if the require search declared it was pre-compiled before (and therefore is expected to still be pre-compilable)
                 cachefile = compilecache(pkg, path)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2147,12 +2147,15 @@ end # module
 
 Note that the first example here actually executes `foo(1, 1.0)` so can be slower, but is usually more robust
 to changes in the codebase than the latter approach of using `precompile` statements. The latter requires explicitly
-calling `precompile` on all methods, not just the entry method. i.e. `foo(1, 1.0)` will likely call other methods
+calling `precompile` on methods that cannot be inferred. i.e. if `foo(1, 1.0)` calls some methods by runtime dispatch, the dispatched calls must be independently `precompile`d.
 which will also need `precompile` statements. Consequently the latter can be more work to maintain, but can be
 automated via tooling such as the package `SnoopCompile.jl`.
 
 It is therefore recommended, where possible, to find minimal code to execute to get the desired precompilation coverage.
 
+Guarding precompilation code behind this check is also best practice because in some situations, 
+downstream users may not want to use the precompilation caching, which can be disabled globally
+via `--compiled-modules=no`.
 See also [`precompile`](@ref).
 """
 function is_serializing_code()

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -464,6 +464,7 @@ Base.@macroexpand
 Base.@macroexpand1
 Base.code_lowered
 Base.code_typed
+Base.is_serializing_code
 Base.precompile
 Base.jit_total_bytes
 ```


### PR DESCRIPTION
`ccall(:jl_generating_output, Cint, ()) == 1` is used in the ecosystem widely to guard precompilation code. It seems like it should be formally in the API.

A slack discussion with @timholy arrived at this name. `is_precompiling` seemed like a good name at first, but is confused by `precompile` calls, which _precompile_ code at a time where `jl_generating_output != 1`. And `is_generating_output` seemed a bit vague.
