### PR TITLE
Implement `mapreduce_impl` for `IndexCartesian`.

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -242,7 +242,8 @@ Base.IndexStyle(bc::Broadcasted) = IndexStyle(typeof(bc))
 Base.IndexStyle(::Type{<:Broadcasted{<:Any,<:Tuple{Any}}}) = IndexLinear()
 Base.IndexStyle(::Type{<:Broadcasted{<:Any}}) = IndexCartesian()
 
-Base.LinearIndices(bc::Broadcasted{<:Any,<:Tuple{Any}}) = LinearIndices(axes(bc))::LinearIndices{1}
+Base.LinearIndices(bc::Broadcasted) = LinearIndices(axes(bc))::LinearIndices{1}
+Base.CartesianIndices(bc::Broadcasted) = CartesianIndices(axes(bc))
 
 Base.ndims(bc::Broadcasted) = ndims(typeof(bc))
 Base.ndims(::Type{<:Broadcasted{<:Any,<:NTuple{N,Any}}}) where {N} = N

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1895,3 +1895,50 @@ end
 
 getindex(b::Ref, ::CartesianIndex{0}) = getindex(b)
 setindex!(b::Ref, x, ::CartesianIndex{0}) = setindex!(b, x)
+
+# `mapreduce` for `IndexCartesian`
+@inline function _mapreduce(f, op, ::IndexCartesian, A::AbstractArrayOrBroadcasted)
+    ndims(A) == 1 && return _mapreduce(f, op, IndexLinear(), A)
+    length(A) <= 16 && return mapfoldl(f, op, A)
+    inds = CartesianIndices(A)
+    return mapreduce_impl(f, op, A, first(inds), last(inds))
+end
+
+function mapreduce_impl(f, op,
+    A::AbstractArrayOrBroadcasted,
+    fi::CartesianIndex{N},
+    li::CartesianIndex{N},
+    blksize::Int=pairwise_blocksize(f, op)) where {N}
+    iter = fi:li
+    @inbounds if length(iter) <= blksize
+        A1 = A[fi]
+        temp = iterate(iter, fi)
+        temp === nothing && return mapreduce_first(f, op, A1)
+        I, state = temp
+        v = op(f(A1), f(A[I]))
+        if size(iter, 1) <= 16
+            for I in Iterators.rest(iter, state)
+                v = op(v, f(A[I]))
+            end
+        else
+            J1 = CartesianIndex(tail(I.I))
+            ax1, out = iter.indices[1], CartesianIndices(tail(iter.indices))
+            @simd for i in I[1]+1:last(ax1)
+                v = op(v, f(A[i, J1]))
+            end
+            for J in Iterators.rest(out, J1)
+                @simd for i in ax1
+                    v = op(v, f(A[i, J]))
+                end
+            end
+        end
+        return v
+    else
+        # pairwise portion
+        n = findlast(i -> li[i] != fi[i], 1:N)::Int
+        mid = fi[n] + (li[n] - fi[n] + 1) >> 1
+        v1 = @noinline mapreduce_impl(f, op, A, fi, setindex(li, mid - 1, n), blksize)
+        v2 = @noinline mapreduce_impl(f, op, A, setindex(fi, mid, n), li, blksize)
+        return op(v1, v2)
+    end
+end

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -437,8 +437,6 @@ end
 
 mapreduce(f, op, a::Number) = mapreduce_first(f, op, a)
 
-_mapreduce(f, op, ::IndexCartesian, A::AbstractArrayOrBroadcasted) = mapfoldl(f, op, A)
-
 """
     reduce(op, itr; [init])
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -942,14 +942,14 @@ end
     # Now let's try it with `Broadcasted`:
     bcraw = Broadcast.broadcasted(identity, xs)
     bc = Broadcast.instantiate(bcraw)
-    # If `Broadcasted` has `IndexLinear` style, it should hit the
-    # `reduce` branch:
-    @test IndexStyle(bc) == IndexLinear()
+    # `Broadcasted` should behave like a `AbstractArray` with the same `IndexStyle`
+    # `IndexLinear` branch:
+    @test IndexStyle(bc) == IndexStyle(xs) == IndexLinear()
     @test reduce(paren, bc) == reduce(paren, xs)
-    # If `Broadcasted` does not have `IndexLinear` style, it should
-    # hit the `foldl` branch:
-    @test IndexStyle(bcraw) == IndexCartesian()
-    @test reduce(paren, bcraw) == foldl(paren, xs)
+    # `IndexCartesian` branch:
+    xscart = view(xs, collect(eachindex(xs)))
+    @test IndexStyle(bcraw) == IndexStyle(xscart) == IndexCartesian()
+    @test reduce(paren, bcraw) == reduce(paren, xscart)
 
     # issue #41055
     bc = Broadcast.instantiate(Broadcast.broadcasted(Base.literal_pow, Ref(^), [1,2], Ref(Val(2))))

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -677,3 +677,16 @@ end
         @test mapreduce(+, +, oa, oa) == 2len
     end
 end
+
+@testset "mapreduce for IndexCartesian" begin
+    fslow(a) = view(a, axes(a)...)
+    a = ones(2000)
+    for _a in (reshape(a, 10, 10, :), reshape(a, 20, :), reshape(a, 4, 4, 5, :))
+        @test @inferred sum(fslow(_a)) == 2000
+    end
+    # order test
+    a = randn(10000)
+    for _a in (reshape(a, 10, 10, 10, 10), reshape(a, 20, 20, 25), reshape(a, 4, 4, 5, :))
+        @test reduce((x,y)->vcat(x,y), fslow(_a)) == a
+    end
+end

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -613,9 +613,9 @@ end
         end
     end
 end
-@test_broken minimum([missing;BigInt(1)], dims = 1)
-@test_broken maximum([missing;BigInt(1)], dims = 1)
-@test_broken extrema([missing;BigInt(1)], dims = 1)
+@test_broken minimum([missing;BigInt(1)], dims = 1)[1] === missing
+@test_broken maximum([missing;BigInt(1)], dims = 1)[1] === missing
+@test_broken extrema([missing;BigInt(1)], dims = 1)[1] === (missing, missing)
 
 # issue #26709
 @testset "dimensional reduce with custom non-bitstype types" begin


### PR DESCRIPTION
On master, `mapreduce` calls `mapfoldl` for inputs with `IndexCartesian` style, which brings performance pain if the 1st dimension is long enough for vectorlization.

This PR implements pairwise `mapreduce_impl` for better performance by cutting the highest splitable dimension in half. 
(As we can't reorder the inputs, and `CartesianPartition` has much higher overhead)

Test added.

A simple benchmark
```julia
julia> a = randn(100, 100);

julia> slow(a) = view(a, axes(a)...)
slow (generic function with 1 method)

julia> @btime reduce(+, slow($a))
  1.870 μs (0 allocations: 0 bytes)
88.67608098492965

julia> @btime foldl(+, slow($a))
  9.700 μs (0 allocations: 0 bytes)
88.67608098492977
```
