### PR TITLE
[release-1.6] Limit whitespace job to run on only x86_64 machines

### DIFF
--- a/.buildkite/pipelines/main/misc/doctest.yml
+++ b/.buildkite/pipelines/main/misc/doctest.yml
@@ -3,6 +3,7 @@ agents:
   # Only run on `sandbox.jl` machines (not `docker`-isolated ones) since we need nestable sandboxing
   sandbox.jl: "true"
   os: "linux"
+  arch: "x86_64"
 steps:
   - label: "doctest"
     key: doctest

--- a/.buildkite/pipelines/main/misc/embedding.yml
+++ b/.buildkite/pipelines/main/misc/embedding.yml
@@ -3,6 +3,7 @@ agents:
   # Only run on `sandbox.jl` machines (not `docker`-isolated ones) since we need nestable sandboxing
   sandbox.jl: "true"
   os: "linux"
+  arch: "x86_64"
 steps:
   - label: "embedding"
     key: "embedding"

--- a/.buildkite/pipelines/main/misc/llvmpasses.yml
+++ b/.buildkite/pipelines/main/misc/llvmpasses.yml
@@ -3,6 +3,7 @@ agents:
   # Only run on `sandbox.jl` machines (not `docker`-isolated ones) since we need nestable sandboxing
   sandbox.jl: "true"
   os: "linux"
+  arch: "x86_64"
 steps:
   - label: "analyzegc"
     key: "analyzegc"

--- a/.buildkite/pipelines/main/misc/sanitizers.yml
+++ b/.buildkite/pipelines/main/misc/sanitizers.yml
@@ -3,6 +3,7 @@ agents:
   # Only run on `sandbox.jl` machines (not `docker`-isolated ones) since we need nestable sandboxing
   sandbox.jl: "true"
   os: "linux"
+  arch: "x86_64"
 steps:
   - label: "asan"
     key: "asan"

--- a/.buildkite/pipelines/main/misc/whitespace.yml
+++ b/.buildkite/pipelines/main/misc/whitespace.yml
@@ -3,6 +3,7 @@ agents:
   # Only run on `sandbox.jl` machines (not `docker`-isolated ones) since we need nestable sandboxing
   sandbox.jl: "true"
   os: "linux"
+  arch: "x86_64"
 steps:
   - label: "whitespace"
     key: "whitespace"

--- a/.buildkite/pipelines/main/platforms/package_linux.yml
+++ b/.buildkite/pipelines/main/platforms/package_linux.yml
@@ -3,6 +3,7 @@ agents:
   # Only run on `sandbox.jl` machines (not `docker`-isolated ones) since we need nestable sandboxing
   sandbox.jl: "true"
   os: "linux"
+  arch: "x86_64"
 steps:
   - label: "package_${PLATFORM?}${LABEL?}"
     key: package_${PLATFORM?}${LABEL?}

--- a/.buildkite/pipelines/main/platforms/tester_linux.yml
+++ b/.buildkite/pipelines/main/platforms/tester_linux.yml
@@ -3,6 +3,7 @@ agents:
   # Only run on `sandbox.jl` machines (not `docker`-isolated ones) since we need nestable sandboxing
   sandbox.jl: "true"
   os: "linux"
+  arch: "x86_64"
 steps:
   - label: "tester_${PLATFORM?}${LABEL?}"
     key: tester_${PLATFORM?}${LABEL?}


### PR DESCRIPTION
This should fix the `Exec format error` problems we've had recently due to us adding some non-x86_64 linux workers to the pool.