### PR TITLE
Use SHIFT-TAB to force showing method suggestions

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1946,7 +1946,8 @@ jl_method_instance_t *jl_method_lookup(jl_value_t **args, size_t nargs, size_t w
 // full is a boolean indicating if that method fully covers the input
 //
 // lim is the max # of methods to return. if there are more, returns jl_false.
-// -1 for no limit.
+// Negative values stand for no limit.
+// Unless lim == -1, remove matches that are unambiguously covered by earler ones
 JL_DLLEXPORT jl_value_t *jl_matching_methods(jl_tupletype_t *types, jl_value_t *mt, int lim, int include_ambiguous,
                                              size_t world, size_t *min_valid, size_t *max_valid, int *ambig)
 {
@@ -3036,7 +3037,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt,
                 if (!subt2 && subt)
                     break;
                 if (subt == subt2) {
-                    if (lim >= 0) {
+                    if (lim != -1) {
                         if (subt || !jl_has_empty_intersection(m->sig, m2->sig))
                             if (!jl_type_morespecific((jl_value_t*)m->sig, (jl_value_t*)m2->sig))
                                 break;
@@ -3190,7 +3191,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt,
                 }
             }
             // when limited, skip matches that are covered by earlier ones (and aren't perhaps ambiguous with them)
-            if (lim >= 0) {
+            if (lim != -1) {
                 for (i = 0; i < len; i++) {
                     if (skip[i])
                         continue;

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -514,6 +514,17 @@ let s = """CompletionFoo.test4("\\"","""
     @test length(c) == 2
 end
 
+# Test max method suggestions
+let s = "convert("
+    c, _, res = test_complete_noshift(s)
+    @test !res
+    @test only(c) == "convert( too many methods, use SHIFT-TAB to show )"
+    c2, _, res2 = test_complete(s)
+    @test !res2
+    @test any(==(string(first(methods(convert)))), c2)
+    @test length(c2) > REPL.REPLCompletions.MAX_METHOD_COMPLETIONS
+end
+
 ########## Test where the current inference logic fails ########
 # Fails due to inference fails to determine a concrete type for arg 1
 # But it returns AbstractArray{T,N} and hence is able to remove test5(x::Float64) from the suggestions


### PR DESCRIPTION
Fix https://github.com/JuliaLang/julia/issues/45671

Before:
```
julia> convert(#TAB
convert( too many methods to show )
```

This PR:

```
julia> convert(#TAB
convert( too many methods, use SHIFT-TAB to show )

julia> convert(#SHIFT-TAB
convert(::Type{AbstractChar}, x::Number) in Base at char.jl:183
convert(::Type{T}, c::T) where T<:AbstractChar in Base at char.jl:187
convert(::Type{AbstractArray{T}}, a::AbstractArray) where T in Base at abstractarray.jl:17
# etc., all methods are shown
```

Someone should probably check that the small gf.c diff is legal.