### PR TITLE
make `LazyString` immutable

### DIFF
--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1565,7 +1565,4 @@ function deserialize(s::AbstractSerializer, ::Type{T}) where T<:Base.GenericCond
     return cond
 end
 
-serialize(s::AbstractSerializer, l::LazyString) =
-    invoke(serialize, Tuple{AbstractSerializer,Any}, s, Base._LazyString((), string(l)))
-
 end

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -642,11 +642,3 @@ let c1 = Threads.Condition()
     unlock(c2)
     wait(t)
 end
-
-@testset "LazyString" begin
-    l1 = lazy"a $1 b $2"
-    l2 = deserialize(IOBuffer(sprint(serialize, l1)))
-    @test l2.str === l1.str
-    @test l2 == l1
-    @test l2.parts === ()
-end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -1129,6 +1129,12 @@ end
     @test codeunit(l) == UInt8
     @test codeunit(l,2) == 0x2b
     @test isvalid(l, 1)
+    @test Base.infer_effects() do
+        lazy"1+2=3"
+    end |> Core.Compiler.is_foldable
+    @test Base.infer_effects((Any,)) do a
+        lazy"a is $a"
+    end |> Core.Compiler.is_foldable
     @test Base.infer_effects((Any,)) do a
         throw(lazy"a is $a")
     end |> Core.Compiler.is_foldable


### PR DESCRIPTION
Currently a function that constructs `LazyString` but isn't decided to
throw isn't concrete-foldable because `LazyString` is defined as mutable
type and the effect analysis conservatively taints `:consistent`-cy on
a construction of mutable object:
```julia
julia> let eff = Base.infer_effects((Int,)) do a
               if a < 0
                   throw(DomainError(lazy"$a isn't positive"))
               end
               return a
           end
           display(eff)
           Core.Compiler.is_foldable(eff)
       end
(?c,+e,?n,+t,+s)
false
```

This commit makes `LazyString` immutable and let it re-construct actual
string representation on every access. This of course may lead to
worse performance when we print the same `LazyString` object again and
again, but presumably such an case would be very rare given that
`LazyString` is supposed to be mainly used on error path.

---

This PR also adds a commit which improves concrete-foldability of intfuncs,
which initially motivated the change.