### PR TITLE
make `@fastmath` `Complex` multiplication use `muladd`

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -215,7 +215,7 @@ ComplexTypes = Union{ComplexF32, ComplexF64}
 
     mul_fast(x::T, y::T) where {T<:ComplexTypes} =
         T(complex(muladd(-imag(x), imag(y), real(x)*real(y)),
-                  muladd( real(x), imag(y), imag(x)*real(y)))
+                  muladd( real(x), imag(y), imag(x)*real(y))))
     mul_fast(x::Complex{T}, b::T) where {T<:FloatTypes} =
         Complex{T}(real(x)*b, imag(x)*b)
     mul_fast(a::T, y::Complex{T}) where {T<:FloatTypes} =

--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -214,8 +214,8 @@ ComplexTypes = Union{ComplexF32, ComplexF64}
         Complex{T}(a-real(y), -imag(y))
 
     mul_fast(x::T, y::T) where {T<:ComplexTypes} =
-        T(complex(muladd(-imag(x), imag(y), real(x)*real(y)),
-                  muladd( real(x), imag(y), imag(x)*real(y))))
+        T(muladd(-imag(x), imag(y), real(x)*real(y)),
+          muladd( real(x), imag(y), imag(x)*real(y)))
     mul_fast(x::Complex{T}, b::T) where {T<:FloatTypes} =
         Complex{T}(real(x)*b, imag(x)*b)
     mul_fast(a::T, y::Complex{T}) where {T<:FloatTypes} =

--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -214,7 +214,7 @@ ComplexTypes = Union{ComplexF32, ComplexF64}
         Complex{T}(a-real(y), -imag(y))
 
     mul_fast(x::T, y::T) where {T<:ComplexTypes} =
-        T(complex(muladd(-imag(x), imag(y), real(x)*real(y))
+        T(complex(muladd(-imag(x), imag(y), real(x)*real(y)),
                   muladd( real(x), imag(y), imag(x)*real(y)))
     mul_fast(x::Complex{T}, b::T) where {T<:FloatTypes} =
         Complex{T}(real(x)*b, imag(x)*b)

--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -214,8 +214,8 @@ ComplexTypes = Union{ComplexF32, ComplexF64}
         Complex{T}(a-real(y), -imag(y))
 
     mul_fast(x::T, y::T) where {T<:ComplexTypes} =
-        T(real(x)*real(y) - imag(x)*imag(y),
-          real(x)*imag(y) + imag(x)*real(y))
+        T(complex(muladd(-imag(x), imag(y), real(x)*real(y))
+                  muladd( real(x), imag(y), imag(x)*real(y)))
     mul_fast(x::Complex{T}, b::T) where {T<:FloatTypes} =
         Complex{T}(real(x)*b, imag(x)*b)
     mul_fast(a::T, y::Complex{T}) where {T<:FloatTypes} =


### PR DESCRIPTION
Discovered from https://discourse.julialang.org/t/hard-to-beat-numba-jax-loop-for-generating-mandelbrot/82725/20.

benchmarking with
```
xc64 = rand(Complex{Float64}, 1024)*170; yc64 = similar(xc64);
```

Before:
```
julia> @btime @. yc64=xc64 * yc64;
  898.909 ns (2 allocations: 64 bytes)
```
after.
```
julia> @btime @. yc64=xc64 * yc64;
  809.895 ns (2 allocations: 64 bytes
```