### PR TITLE
Fix jl_init_stack_limits regression

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -102,12 +102,13 @@ void jl_init_stack_limits(int ismaster, void **stack_lo, void **stack_hi)
     getrlimit(RLIMIT_STACK, &rl);
     size_t stacksize = rl.rlim_cur;
 // We intentionally leak a stack address here core.StackAddressEscape
-#ifndef __clang_analyzer__
+#  ifndef __clang_analyzer__
     *stack_hi = (void*)&stacksize;
     *stack_lo = (void*)((char*)*stack_hi - stacksize);
-#endif
+#  else
     *stack_hi = 0;
     *stack_lo = 0;
+#  endif
 #endif
 }
 


### PR DESCRIPTION
We noticed that Julia nightly started to crash GAP.jl and Oscar.jl, and bisected this to 805cf874c51f1a2a0e4b46a9c0f6b16da5fd96cf .