### PR TITLE
Fix `length(::Iterators.Drop)` for unsigned lengths

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -55,7 +55,10 @@ _min_length(a, b, A, B) = min(length(a),length(b))
 _diff_length(a, b, A, ::IsInfinite) = 0
 _diff_length(a, b, ::IsInfinite, ::IsInfinite) = 0
 _diff_length(a, b, ::IsInfinite, B) = length(a) # inherit behaviour, error
-_diff_length(a, b, A, B) = max(length(a)-length(b), 0)
+function _diff_length(a, b, A, B)
+    (m, n) = length.((a, b))
+    return m > n ? m - n : oftype(m - n, 0)
+end
 
 and_iteratorsize(isz::T, ::T) where {T} = isz
 and_iteratorsize(::HasLength, ::HasShape) = HasLength()

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -56,8 +56,8 @@ _diff_length(a, b, A, ::IsInfinite) = 0
 _diff_length(a, b, ::IsInfinite, ::IsInfinite) = 0
 _diff_length(a, b, ::IsInfinite, B) = length(a) # inherit behaviour, error
 function _diff_length(a, b, A, B)
-    (m, n) = length.((a, b))
-    return m > n ? m - n : oftype(m - n, 0)
+    m, n = length(a), length(b)
+    return m > n ? m - n : zero(n - m)
 end
 
 and_iteratorsize(isz::T, ::T) where {T} = isz

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -187,6 +187,8 @@ end
 @test isempty(collect(drop(0:2:10, 100)))
 @test_throws ArgumentError drop(0:2:8, -1)
 @test length(drop(1:3,typemax(Int))) == 0
+@test length(drop(UInt(1):2, 3)) == 0
+@test length(drop(StepRangeLen(1, 1, UInt(2)), 3)) == 0
 @test Base.IteratorSize(drop(countfrom(1),3)) == Base.IsInfinite()
 @test_throws MethodError length(drop(countfrom(1), 3))
 @test Base.IteratorSize(Iterators.drop(Iterators.filter(i -> i>0, 1:10), 2)) == Base.SizeUnknown()


### PR DESCRIPTION
Currently, `length` can overflow for `Iterators.Drop` when the parent iterator has an unsigned length:

```julia
julia> length(Iterators.drop(UInt(1):2, 3))
0xffffffffffffffff
```

This PR fixes that.