### PR TITLE
Ensure that `@threads` completes properly

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -69,12 +69,13 @@ function threading_run(fun, static)
         tasks[i] = t
         schedule(t)
     end
-    try
-        for i = 1:n
-            wait(tasks[i])
-        end
-    finally
-        ccall(:jl_exit_threaded_region, Cvoid, ())
+    for i = 1:n
+        Base._wait(tasks[i])
+    end
+    ccall(:jl_exit_threaded_region, Cvoid, ())
+    failed_tasks = filter(istaskfailed, tasks)
+    if !isempty(failed_tasks)
+        throw(CompositeException(map(TaskFailedException, failed_tasks)))
     end
 end
 

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -726,7 +726,7 @@ function _atthreads_with_error(a, err)
     end
     a
 end
-@test_throws TaskFailedException _atthreads_with_error(zeros(nthreads()), true)
+@test_throws CompositeException _atthreads_with_error(zeros(nthreads()), true)
 let a = zeros(nthreads())
     _atthreads_with_error(a, false)
     @test a == [1:nthreads();]


### PR DESCRIPTION
`@threads` fails eagerly which could potentially leave some tasks still running. Change this behavior such that all tasks are completed and _then_, if any of the tasks failed, a `CompositeException` containing `TaskFailedException`s for the failing tasks is thrown. This matches the behavior of `@sync`.

Given `test.jl`:
```julia
using Base.Threads

function foo()
    @threads for i = 1:nthreads()
        if i == 2 || i == 4
            error("2 and 4")
        else
            2 + 4
        end
    end
end

try
    foo()
catch e
    println(e)
end
```

With 1.8.0-rc1:
```
$ julia -t 4 test.jl
TaskFailedException(Task (failed) @0x00007f8355401880)
```

With this patch:
```
$ julia -t 4 test.jl
CompositeException(Any[TaskFailedException(Task (failed) @0x00007f5a74554e20), TaskFailedException(Task (failed) @0x00007f5a74555140)])
```