### PR TITLE
effects: improve the `:consistent`-cy analysis accuracy

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1953,9 +1953,7 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
                 at = tmeet(at, ft)
                 if at === Bottom
                     t = Bottom
-                    tristate_merge!(sv, Effects(EFFECTS_TOTAL;
-                        # consistent = ALWAYS_TRUE, # N.B depends on !ismutabletype(t) above
-                        nothrow = TRISTATE_UNKNOWN))
+                    tristate_merge!(sv, EFFECTS_THROWS)
                     @goto t_computed
                 elseif !isa(at, Const)
                     allconst = false
@@ -2003,7 +2001,7 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
             end
         end
         tristate_merge!(sv, Effects(EFFECTS_TOTAL;
-            consistent = ismutabletype(t) ? TRISTATE_UNKNOWN : ALWAYS_TRUE,
+            consistent = !ismutabletype(t) ? ALWAYS_TRUE : TRISTATE_UNKNOWN,
             nothrow = is_nothrow ? ALWAYS_TRUE : TRISTATE_UNKNOWN))
     elseif ehead === :new_opaque_closure
         tristate_merge!(sv, Effects()) # TODO
@@ -2040,7 +2038,7 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
             effects = v[2]
             effects = decode_effects_override(effects)
             tristate_merge!(sv, Effects(
-                effects.consistent ? ALWAYS_TRUE : TRISTATE_UNKNOWN,
+                effects.consistent ? ALWAYS_TRUE : ALWAYS_FALSE,
                 effects.effect_free ? ALWAYS_TRUE : TRISTATE_UNKNOWN,
                 effects.nothrow ? ALWAYS_TRUE : TRISTATE_UNKNOWN,
                 effects.terminates_globally ? ALWAYS_TRUE : TRISTATE_UNKNOWN,
@@ -2127,20 +2125,20 @@ function abstract_eval_global(M::Module, s::Symbol, frame::InferenceState)
     ty = abstract_eval_global(M, s)
     isa(ty, Const) && return ty
     if isdefined(M,s)
-        tristate_merge!(frame, Effects(EFFECTS_TOTAL; consistent=TRISTATE_UNKNOWN))
+        tristate_merge!(frame, Effects(EFFECTS_TOTAL; consistent=ALWAYS_FALSE))
     else
         tristate_merge!(frame, Effects(EFFECTS_TOTAL;
-            consistent=TRISTATE_UNKNOWN,
+            consistent=ALWAYS_FALSE,
             nothrow=TRISTATE_UNKNOWN))
     end
     return ty
 end
 
 function handle_global_assignment!(interp::AbstractInterpreter, frame::InferenceState, lhs::GlobalRef, @nospecialize(newty))
-    nothrow = global_assignment_nothrow(lhs.mod, lhs.name, newty)
-    tristate_merge!(frame, Effects(EFFECTS_TOTAL,
-        effect_free=TRISTATE_UNKNOWN,
-        nothrow=nothrow ? ALWAYS_TRUE : TRISTATE_UNKNOWN))
+    effect_free = TRISTATE_UNKNOWN
+    nothrow = global_assignment_nothrow(lhs.mod, lhs.name, newty) ?
+        ALWAYS_TRUE : TRISTATE_UNKNOWN
+    tristate_merge!(frame, Effects(EFFECTS_TOTAL; effect_free, nothrow))
 end
 
 abstract_eval_ssavalue(s::SSAValue, sv::InferenceState) = abstract_eval_ssavalue(s, sv.ssavaluetypes)
@@ -2230,9 +2228,7 @@ end
 
 function handle_control_backedge!(frame::InferenceState, from::Int, to::Int)
     if from > to
-        if is_effect_overridden(frame, :terminates_globally)
-            # this frame is known to terminate
-        elseif is_effect_overridden(frame, :terminates_locally)
+        if is_effect_overridden(frame, :terminates_locally)
             # this backedge is known to terminate
         else
             tristate_merge!(frame, Effects(EFFECTS_TOTAL; terminates=TRISTATE_UNKNOWN))

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -179,7 +179,7 @@ mutable struct InferenceState
         #       requires dynamic reachability, while the former is global).
         inbounds = inbounds_option()
         inbounds_taints_consistency = !(inbounds === :on || (inbounds === :default && !any_inbounds(code)))
-        consistent = inbounds_taints_consistency ? TRISTATE_UNKNOWN : ALWAYS_TRUE
+        consistent = inbounds_taints_consistency ? ALWAYS_FALSE : ALWAYS_TRUE
         ipo_effects = Effects(EFFECTS_TOTAL; consistent, inbounds_taints_consistency)
 
         params = InferenceParams(interp)

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -791,7 +791,11 @@ function show_ir(io::IO, code::Union{IRCode, CodeInfo}, config::IRShowConfig=def
 end
 
 tristate_letter(t::TriState) = t === ALWAYS_TRUE ? '+' : t === ALWAYS_FALSE ? '!' : '?'
-tristate_color(t::TriState) = t === ALWAYS_TRUE ? :green : t === ALWAYS_FALSE ? :red : :orange
+tristate_color(t::TriState) = t === ALWAYS_TRUE ? :green : t === ALWAYS_FALSE ? :red : :yellow
+tristate_repr(t::TriState) =
+    t === ALWAYS_TRUE ? "ALWAYS_TRUE" :
+    t === ALWAYS_FALSE ? "ALWAYS_FALSE" :
+    t === TRISTATE_UNKNOWN ? "TRISTATE_UNKNOWN" : nothing
 
 function Base.show(io::IO, e::Core.Compiler.Effects)
     print(io, "(")
@@ -806,6 +810,15 @@ function Base.show(io::IO, e::Core.Compiler.Effects)
     printstyled(io, string(tristate_letter(e.notaskstate), 's'); color=tristate_color(e.notaskstate))
     print(io, ')')
     e.nonoverlayed || printstyled(io, '′'; color=:red)
+end
+
+function Base.show(io::IO, t::TriState)
+    s = tristate_repr(t)
+    if s !== nothing
+        printstyled(io, s; color = tristate_color(t))
+    else # unknown state, redirect to the fallback printing
+        Base.@invoke show(io::IO, t::Any)
+    end
 end
 
 @specialize

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1794,14 +1794,14 @@ const _SPECIAL_BUILTINS = Any[
     Core._apply_iterate
 ]
 
-function builtin_effects(f::Builtin, argtypes::Vector{Any}, rt)
+function builtin_effects(f::Builtin, argtypes::Vector{Any}, @nospecialize rt)
     if isa(f, IntrinsicFunction)
         return intrinsic_effects(f, argtypes)
     end
 
     @assert !contains_is(_SPECIAL_BUILTINS, f)
 
-    nothrow = false
+    argtypes′ = argtypes[2:end]
     if (f === Core.getfield || f === Core.isdefined) && length(argtypes) >= 3
         # consistent if the argtype is immutable
         if isvarargtype(argtypes[2])
@@ -1812,37 +1812,44 @@ function builtin_effects(f::Builtin, argtypes::Vector{Any}, rt)
             return Effects(; effect_free=ALWAYS_TRUE, terminates=ALWAYS_TRUE, nonoverlayed=true)
         end
         s = s::DataType
-        ipo_consistent = !ismutabletype(s)
-        nothrow = false
-        if f === Core.getfield && !isvarargtype(argtypes[end]) &&
-                getfield_boundscheck(argtypes[2:end]) !== true
+        consistent = !ismutabletype(s) ? ALWAYS_TRUE : ALWAYS_FALSE
+        if f === Core.getfield && !isvarargtype(argtypes[end]) && getfield_boundscheck(argtypes′) !== true
             # If we cannot independently prove inboundsness, taint consistency.
             # The inbounds-ness assertion requires dynamic reachability, while
             # :consistent needs to be true for all input values.
             # N.B. We do not taint for `--check-bounds=no` here -that happens in
             # InferenceState.
-            nothrow = getfield_nothrow(argtypes[2], argtypes[3], true)
-            ipo_consistent &= nothrow
+            if getfield_nothrow(argtypes[2], argtypes[3], true)
+                nothrow = ALWAYS_TRUE
+            else
+                consistent = ALWAYS_FALSE
+                nothrow = TRISTATE_UNKNOWN
+            end
         else
-            nothrow = isvarargtype(argtypes[end]) ? false :
-                builtin_nothrow(f, argtypes[2:end], rt)
+            nothrow = (!isvarargtype(argtypes[end]) && builtin_nothrow(f, argtypes′, rt)) ?
+                ALWAYS_TRUE : TRISTATE_UNKNOWN
         end
-        effect_free = true
+        effect_free = ALWAYS_TRUE
     elseif f === getglobal && length(argtypes) >= 3
-        nothrow = getglobal_nothrow(argtypes[2:end])
-        ipo_consistent = nothrow && isconst( # types are already checked in `getglobal_nothrow`
-            (argtypes[2]::Const).val::Module, (argtypes[3]::Const).val::Symbol)
-        effect_free = true
+        if getglobal_nothrow(argtypes′)
+            consistent = isconst( # types are already checked in `getglobal_nothrow`
+                (argtypes[2]::Const).val::Module, (argtypes[3]::Const).val::Symbol) ?
+                ALWAYS_TRUE : ALWAYS_FALSE
+            nothrow = ALWAYS_TRUE
+        else
+            consistent = ALWAYS_FALSE
+            nothrow = TRISTATE_UNKNOWN
+        end
+        effect_free = ALWAYS_TRUE
     else
-        ipo_consistent = contains_is(_CONSISTENT_BUILTINS, f)
-        effect_free = contains_is(_EFFECT_FREE_BUILTINS, f) || contains_is(_PURE_BUILTINS, f)
-        nothrow = isvarargtype(argtypes[end]) ? false : builtin_nothrow(f, argtypes[2:end], rt)
+        consistent = contains_is(_CONSISTENT_BUILTINS, f) ? ALWAYS_TRUE : ALWAYS_FALSE
+        effect_free = (contains_is(_EFFECT_FREE_BUILTINS, f) || contains_is(_PURE_BUILTINS, f)) ?
+            ALWAYS_TRUE : TRISTATE_UNKNOWN
+        nothrow = (!isvarargtype(argtypes[end]) && builtin_nothrow(f, argtypes′, rt)) ?
+            ALWAYS_TRUE : TRISTATE_UNKNOWN
     end
 
-    return Effects(EFFECTS_TOTAL;
-        consistent = ipo_consistent ? ALWAYS_TRUE : TRISTATE_UNKNOWN,
-        effect_free = effect_free ? ALWAYS_TRUE : TRISTATE_UNKNOWN,
-        nothrow = nothrow ? ALWAYS_TRUE : TRISTATE_UNKNOWN)
+    return Effects(EFFECTS_TOTAL; consistent, effect_free, nothrow)
 end
 
 function builtin_nothrow(@nospecialize(f), argtypes::Array{Any, 1}, @nospecialize(rt))
@@ -2008,19 +2015,18 @@ function intrinsic_effects(f::IntrinsicFunction, argtypes::Vector{Any})
         return Effects()
     end
 
-    ipo_consistent = !(
+    consistent = !(
         f === Intrinsics.pointerref ||      # this one is volatile
         f === Intrinsics.arraylen ||        # this one is volatile
         f === Intrinsics.sqrt_llvm_fast ||  # this one may differ at runtime (by a few ulps)
         f === Intrinsics.have_fma ||        # this one depends on the runtime environment
-        f === Intrinsics.cglobal)           # cglobal lookup answer changes at runtime
-    effect_free = !(f === Intrinsics.pointerset)
-    nothrow = !isvarargtype(argtypes[end]) && intrinsic_nothrow(f, argtypes[2:end])
+        f === Intrinsics.cglobal            # cglobal lookup answer changes at runtime
+        ) ? ALWAYS_TRUE : ALWAYS_FALSE
+    effect_free = !(f === Intrinsics.pointerset) ? ALWAYS_TRUE : TRISTATE_UNKNOWN
+    nothrow = (!isvarargtype(argtypes[end]) && intrinsic_nothrow(f, argtypes[2:end])) ?
+        ALWAYS_TRUE : TRISTATE_UNKNOWN
 
-    return Effects(EFFECTS_TOTAL;
-        consistent = ipo_consistent ? ALWAYS_TRUE : TRISTATE_UNKNOWN,
-        effect_free = effect_free ? ALWAYS_TRUE : TRISTATE_UNKNOWN,
-        nothrow = nothrow ? ALWAYS_TRUE : TRISTATE_UNKNOWN)
+    return Effects(EFFECTS_TOTAL; consistent, effect_free, nothrow)
 end
 
 # TODO: this function is a very buggy and poor model of the return_type function

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1822,12 +1822,11 @@ function builtin_effects(f::Builtin, argtypes::Vector{Any}, @nospecialize rt)
             if getfield_nothrow(argtypes[2], argtypes[3], true)
                 nothrow = ALWAYS_TRUE
             else
-                consistent = ALWAYS_FALSE
-                nothrow = TRISTATE_UNKNOWN
+                consistent = nothrow = ALWAYS_FALSE
             end
         else
             nothrow = (!isvarargtype(argtypes[end]) && builtin_nothrow(f, argtypes′, rt)) ?
-                ALWAYS_TRUE : TRISTATE_UNKNOWN
+                ALWAYS_TRUE : ALWAYS_FALSE
         end
         effect_free = ALWAYS_TRUE
     elseif f === getglobal && length(argtypes) >= 3
@@ -1837,16 +1836,15 @@ function builtin_effects(f::Builtin, argtypes::Vector{Any}, @nospecialize rt)
                 ALWAYS_TRUE : ALWAYS_FALSE
             nothrow = ALWAYS_TRUE
         else
-            consistent = ALWAYS_FALSE
-            nothrow = TRISTATE_UNKNOWN
+            consistent = nothrow = ALWAYS_FALSE
         end
         effect_free = ALWAYS_TRUE
     else
         consistent = contains_is(_CONSISTENT_BUILTINS, f) ? ALWAYS_TRUE : ALWAYS_FALSE
         effect_free = (contains_is(_EFFECT_FREE_BUILTINS, f) || contains_is(_PURE_BUILTINS, f)) ?
-            ALWAYS_TRUE : TRISTATE_UNKNOWN
+            ALWAYS_TRUE : ALWAYS_FALSE
         nothrow = (!isvarargtype(argtypes[end]) && builtin_nothrow(f, argtypes′, rt)) ?
-            ALWAYS_TRUE : TRISTATE_UNKNOWN
+            ALWAYS_TRUE : ALWAYS_FALSE
     end
 
     return Effects(EFFECTS_TOTAL; consistent, effect_free, nothrow)
@@ -2022,9 +2020,9 @@ function intrinsic_effects(f::IntrinsicFunction, argtypes::Vector{Any})
         f === Intrinsics.have_fma ||        # this one depends on the runtime environment
         f === Intrinsics.cglobal            # cglobal lookup answer changes at runtime
         ) ? ALWAYS_TRUE : ALWAYS_FALSE
-    effect_free = !(f === Intrinsics.pointerset) ? ALWAYS_TRUE : TRISTATE_UNKNOWN
+    effect_free = !(f === Intrinsics.pointerset) ? ALWAYS_TRUE : ALWAYS_FALSE
     nothrow = (!isvarargtype(argtypes[end]) && intrinsic_nothrow(f, argtypes[2:end])) ?
-        ALWAYS_TRUE : TRISTATE_UNKNOWN
+        ALWAYS_TRUE : ALWAYS_FALSE
 
     return Effects(EFFECTS_TOTAL; consistent, effect_free, nothrow)
 end

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -791,11 +791,11 @@ function merge_call_chain!(parent::InferenceState, ancestor::InferenceState, chi
     # and ensure that walking the parent list will get the same result (DAG) from everywhere
     # Also taint the termination effect, because we can no longer guarantee the absence
     # of recursion.
-    tristate_merge!(parent, Effects(EFFECTS_TOTAL; terminates=TRISTATE_UNKNOWN))
+    tristate_merge!(parent, Effects(EFFECTS_TOTAL; terminates=ALWAYS_FALSE))
     while true
         add_cycle_backedge!(child, parent, parent.currpc)
         union_caller_cycle!(ancestor, child)
-        tristate_merge!(child, Effects(EFFECTS_TOTAL; terminates=TRISTATE_UNKNOWN))
+        tristate_merge!(child, Effects(EFFECTS_TOTAL; terminates=ALWAYS_FALSE))
         child = parent
         child === ancestor && break
         parent = child.parent::InferenceState

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -94,10 +94,10 @@ function Effects(
         false)
 end
 
-const EFFECTS_TOTAL    = Effects(ALWAYS_TRUE,      ALWAYS_TRUE,      ALWAYS_TRUE,      ALWAYS_TRUE,      true, ALWAYS_TRUE)
-const EFFECTS_THROWS   = Effects(ALWAYS_TRUE,      ALWAYS_TRUE,      TRISTATE_UNKNOWN, ALWAYS_TRUE,      true, ALWAYS_TRUE)
-const EFFECTS_UNKNOWN  = Effects(TRISTATE_UNKNOWN, TRISTATE_UNKNOWN, TRISTATE_UNKNOWN, TRISTATE_UNKNOWN, true, TRISTATE_UNKNOWN)  # mostly unknown, but it's not overlayed at least (e.g. it's not a call)
-const EFFECTS_UNKNOWN′ = Effects(TRISTATE_UNKNOWN, TRISTATE_UNKNOWN, TRISTATE_UNKNOWN, TRISTATE_UNKNOWN, false, TRISTATE_UNKNOWN) # unknown, really
+const EFFECTS_TOTAL    = Effects(ALWAYS_TRUE,  ALWAYS_TRUE,      ALWAYS_TRUE,      ALWAYS_TRUE,      true,  ALWAYS_TRUE)
+const EFFECTS_THROWS   = Effects(ALWAYS_TRUE,  ALWAYS_TRUE,      TRISTATE_UNKNOWN, ALWAYS_TRUE,      true,  ALWAYS_TRUE)
+const EFFECTS_UNKNOWN  = Effects(ALWAYS_FALSE, TRISTATE_UNKNOWN, TRISTATE_UNKNOWN, TRISTATE_UNKNOWN, true,  TRISTATE_UNKNOWN)  # mostly unknown, but it's not overlayed at least (e.g. it's not a call)
+const EFFECTS_UNKNOWN′ = Effects(ALWAYS_FALSE, TRISTATE_UNKNOWN, TRISTATE_UNKNOWN, TRISTATE_UNKNOWN, false, TRISTATE_UNKNOWN) # unknown, really
 
 function Effects(e::Effects = EFFECTS_UNKNOWN′;
     consistent::TriState = e.consistent,

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -56,15 +56,20 @@ Along the abstract interpretation, `Effects` at each statement are analyzed loca
 they are merged into the single global `Effects` that represents the entire effects of
 the analyzed method (see `tristate_merge!`).
 Each effect property is represented as tri-state and managed separately.
-The tri-state consists of `ALWAYS_TRUE`, `TRISTATE_UNKNOWN` and `ALWAYS_FALSE`.
+The tri-state consists of `ALWAYS_TRUE`, `TRISTATE_UNKNOWN` and `ALWAYS_FALSE`, where they
+have the following meanings:
+- `ALWAYS_TRUE`: this method is guaranteed to not have this effect.
+- `ALWAYS_FALSE`: this method may have this effect, and there is no need to do any further
+  analysis w.r.t. this effect property as this conclusion will not be refined anyway.
+- `TRISTATE_UNKNOWN`: this effect property may still be refined to `ALWAYS_TRUE` or
+  `ALWAYS_FALSE`, e.g. using return type information.
+
 An effect property is initialized with `ALWAYS_TRUE` and then transitioned towards
-`TRISTATE_UNKNOWN` or `ALWAYS_FALSE`. When we find a statement that has some effect,
-`ALWAYS_TRUE` is propagated if that effect is known to _always_ happen, otherwise
-`TRISTATE_UNKNOWN` is propagated. If a property is known to be `ALWAYS_FALSE`,
-there is no need to do additional analysis as it can not be refined anyway.
-Note that however, within the current data-flow analysis design, it is hard to derive a global
-conclusion from a local analysis on each statement, and as a result, the effect analysis
-usually propagates `TRISTATE_UNKNOWN` currently.
+`ALWAYS_FALSE`. When we find a statement that has some effect, either of `TRISTATE_UNKNOWN`
+or `ALWAYS_FALSE` is propagated. Note that however, within the current flow-insensitive
+analysis design, it is usually difficult to derive a global conclusion accurately from local
+analysis on each statement, and therefore, the effect analysis usually propagates the
+`ALWAYS_FALSE` state conservatively.
 """
 struct Effects
     consistent::TriState
@@ -94,10 +99,10 @@ function Effects(
         false)
 end
 
-const EFFECTS_TOTAL    = Effects(ALWAYS_TRUE,  ALWAYS_TRUE,      ALWAYS_TRUE,      ALWAYS_TRUE,      true,  ALWAYS_TRUE)
-const EFFECTS_THROWS   = Effects(ALWAYS_TRUE,  ALWAYS_TRUE,      TRISTATE_UNKNOWN, ALWAYS_TRUE,      true,  ALWAYS_TRUE)
-const EFFECTS_UNKNOWN  = Effects(ALWAYS_FALSE, TRISTATE_UNKNOWN, TRISTATE_UNKNOWN, TRISTATE_UNKNOWN, true,  TRISTATE_UNKNOWN)  # mostly unknown, but it's not overlayed at least (e.g. it's not a call)
-const EFFECTS_UNKNOWN′ = Effects(ALWAYS_FALSE, TRISTATE_UNKNOWN, TRISTATE_UNKNOWN, TRISTATE_UNKNOWN, false, TRISTATE_UNKNOWN) # unknown, really
+const EFFECTS_TOTAL    = Effects(ALWAYS_TRUE,  ALWAYS_TRUE,  ALWAYS_TRUE,  ALWAYS_TRUE,  true,  ALWAYS_TRUE)
+const EFFECTS_THROWS   = Effects(ALWAYS_TRUE,  ALWAYS_TRUE,  ALWAYS_FALSE, ALWAYS_TRUE,  true,  ALWAYS_TRUE)
+const EFFECTS_UNKNOWN  = Effects(ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_FALSE, true,  ALWAYS_FALSE)  # mostly unknown, but it's not overlayed at least (e.g. it's not a call)
+const EFFECTS_UNKNOWN′ = Effects(ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_FALSE, false, ALWAYS_FALSE) # unknown, really
 
 function Effects(e::Effects = EFFECTS_UNKNOWN′;
     consistent::TriState = e.consistent,

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -183,7 +183,7 @@ julia> gcdx(240, 46)
     their `typemax`, and the identity then holds only via the unsigned
     integers' modulo arithmetic.
 """
-function gcdx(a::Integer, b::Integer)
+Base.@assume_effects :terminates_locally function gcdx(a::Integer, b::Integer)
     T = promote_type(typeof(a), typeof(b))
     # a0, b0 = a, b
     s0, s1 = oneunit(T), zero(T)
@@ -233,7 +233,7 @@ function invmod(n::Integer, m::Integer)
         n == typeof(n)(-1) && m == typemin(typeof(n)) && return T(-1)
     end
     g, x, y = gcdx(n, m)
-    g != 1 && throw(DomainError((n, m), "Greatest common divisor is $g."))
+    g != 1 && throw(DomainError((n, m), LazyString("Greatest common divisor is ", g, ".")))
     # Note that m might be negative here.
     if n isa Unsigned && hastypemax(typeof(n)) && x > typemax(n)>>1
         # x might have wrapped if it would have been negative
@@ -1057,7 +1057,7 @@ julia> binomial(-5, 3)
 # External links
 * [Binomial coefficient](https://en.wikipedia.org/wiki/Binomial_coefficient) on Wikipedia.
 """
-function binomial(n::T, k::T) where T<:Integer
+Base.@assume_effects :terminates_locally function binomial(n::T, k::T) where T<:Integer
     n0, k0 = n, k
     k < 0 && return zero(T)
     sgn = one(T)
@@ -1079,7 +1079,7 @@ function binomial(n::T, k::T) where T<:Integer
     while rr <= k
         xt = div(widemul(x, nn), rr)
         x = xt % T
-        x == xt || throw(OverflowError("binomial($n0, $k0) overflows"))
+        x == xt || throw(OverflowError(LazyString("binomial(", n0, ", ", k0, " overflows")))
         rr += one(T)
         nn += one(T)
     end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1421,10 +1421,8 @@ function infer_effects(@nospecialize(f), @nospecialize(types=default_tt(f));
         effects = Core.Compiler.EFFECTS_TOTAL
         matches = _methods(f, types, -1, world)::Vector
         if isempty(matches)
-            # although this call is known to throw MethodError (thus `nothrow=ALWAYS_FALSE`),
-            # still mark it `TRISTATE_UNKNOWN` just in order to be consistent with a result
-            # derived by the effect analysis, which can't prove guaranteed throwness at this moment
-            return Core.Compiler.Effects(effects; nothrow=Core.Compiler.TRISTATE_UNKNOWN)
+            # this call is known to throw MethodError
+            return Core.Compiler.Effects(effects; nothrow=Core.Compiler.ALWAYS_FALSE)
         end
         for match in matches
             match = match::Core.MethodMatch

--- a/base/show.jl
+++ b/base/show.jl
@@ -2558,7 +2558,7 @@ module IRShow
     import ..Base
     import .Compiler: IRCode, ReturnNode, GotoIfNot, CFG, scan_ssa_use!, Argument,
         isexpr, compute_basic_blocks, block_for_inst,
-        TriState, Effects, ALWAYS_TRUE, ALWAYS_FALSE
+        TriState, Effects, ALWAYS_TRUE, ALWAYS_FALSE, TRISTATE_UNKNOWN
     Base.getindex(r::Compiler.StmtRange, ind::Integer) = Compiler.getindex(r, ind)
     Base.size(r::Compiler.StmtRange) = Compiler.size(r)
     Base.first(r::Compiler.StmtRange) = Compiler.first(r)

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -519,3 +519,9 @@ end
         @test binomial(x...) == (x != (false,true))
     end
 end
+
+# concrete-foldability
+@test Base.infer_effects(gcd, (Int,Int)) |> Core.Compiler.is_foldable
+@test Base.infer_effects(gcdx, (Int,Int)) |> Core.Compiler.is_foldable
+@test Base.infer_effects(invmod, (Int,Int)) |> Core.Compiler.is_foldable
+@test Base.infer_effects(binomial, (Int,Int)) |> Core.Compiler.is_foldable

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -1129,4 +1129,13 @@ end
     @test codeunit(l) == UInt8
     @test codeunit(l,2) == 0x2b
     @test isvalid(l, 1)
+    @test Base.infer_effects((Any,)) do a
+        throw(lazy"a is $a")
+    end |> Core.Compiler.is_foldable
+    @test Base.infer_effects((Int,)) do a
+        if a < 0
+            throw(DomainError(a, lazy"$a isn't positive"))
+        end
+        return a
+    end |> Core.Compiler.is_foldable
 end


### PR DESCRIPTION
This is an alternative to #45674 and allows the effect analysis to prove
`:consistent`-cy even in a presence of mutable allocation.
Instead of modeling the effect using a proper flow-sensitive way, this
commit takes a fairly simpler approach to adjust it using the derived
return type information: in a case when the `:consistent`-cy is only
tainted by mutable allocations, we may be able to refine it if the
return type guarantees that the allocations are never returned.

This commit is working, but the implementation "abuses" the tri-states
in order to distinguish a case when the `:consistent`-cy is only tainted
by mutable allocation (indicated by `TRISTATE_UNKNOWN`) from those when
it is tainted by other possibilities (indicated by `ALWAYS_FALSE`).
Such usages of `TRISTATE_UNKNOWN`/`ALWAYS_FALSE` doesn't seem to fit with
the meanings we currently give to the tri-states. It may be clearer to
extend the tri-state futher and allow other states like `MAYBE_REFINED`.

EDIT: see [my comment below](https://github.com/JuliaLang/julia/pull/45701#issuecomment-1160036471) for the new tri-state management.