### PR TITLE
NFC cosmetic cleanup for compiler code

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -840,11 +840,11 @@ ipo_effects(code::CodeInstance) = decode_effects(code.ipo_purity_bits)
 struct EdgeCallResult
     rt #::Type
     edge::Union{Nothing,MethodInstance}
-    edge_effects::Effects
+    effects::Effects
     function EdgeCallResult(@nospecialize(rt),
                             edge::Union{Nothing,MethodInstance},
-                            edge_effects::Effects)
-        return new(rt, edge, edge_effects)
+                            effects::Effects)
+        return new(rt, edge, effects)
     end
 end
 

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -184,7 +184,7 @@ function normalize_typevars(method::Method, @nospecialize(atype), sparams::Simpl
         sp_ = ccall(:jl_type_intersection_with_env, Any, (Any, Any), at2, method.sig)::SimpleVector
         sparams = sp_[2]::SimpleVector
     end
-    return atype, sparams
+    return Pair{Any,SimpleVector}(atype, sparams)
 end
 
 # get a handle to the unique specialization object representing a particular instantiation of a call

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1108,10 +1108,10 @@ const SLOT_USED = 0x8
 ast_slotflag(@nospecialize(code), i) = ccall(:jl_ir_slotflag, UInt8, (Any, Csize_t), code, i - 1)
 
 """
-    may_invoke_generator(method, atype, sparams)
+    may_invoke_generator(method, atype, sparams) -> Bool
 
 Computes whether or not we may invoke the generator for the given `method` on
-the given atype and sparams. For correctness, all generated function are
+the given `atype` and `sparams`. For correctness, all generated function are
 required to return monotonic answers. However, since we don't expect users to
 be able to successfully implement this criterion, we only call generated
 functions on concrete types. The one exception to this is that we allow calling
@@ -1122,8 +1122,8 @@ computes whether we are in either of these cases.
 Unlike normal functions, the compilation heuristics still can't generate good dispatch
 in some cases, but this may still allow inference not to fall over in some limited cases.
 """
-function may_invoke_generator(method::MethodInstance)
-    return may_invoke_generator(method.def::Method, method.specTypes, method.sparam_vals)
+function may_invoke_generator(mi::MethodInstance)
+    return may_invoke_generator(mi.def::Method, mi.specTypes, mi.sparam_vals)
 end
 function may_invoke_generator(method::Method, @nospecialize(atype), sparams::SimpleVector)
     # If we have complete information, we may always call the generator


### PR DESCRIPTION
- clean up `abstract_call_method` interface
- tidy up `abstract_call_opaque_closure` interface
- miscellaneous improvements for reflections.jl

@nanosoldier `runbenchmarks("inference", vs=":master")`