### PR TITLE
Replace ```julia with ```julia-repl in Documentation docs

### DIFF
--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -55,7 +55,7 @@ Compute the Bar index between `x` and `y`.
 If `y` is unspecified, compute the Bar index between all pairs of columns of `x`.
 
 # Examples
-```julia-repl
+```julia
 julia> bar([1, 2], [1, 2])
 1
 ```


### PR DESCRIPTION
Right now there is `@jldoctest`, `julia`, and `julia-repl`. At least visually `julia` and `julia-repl` looks the same. Maybe there is a difference I'm not aware of, but if so that should be explained?