### PR TITLE
Make log color ranges centered on named log level

### DIFF
--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -57,11 +57,17 @@ function showvalue(io, e::Tuple{Exception,Any})
 end
 showvalue(io, ex::Exception) = showerror(io, ex)
 
+
+
 function default_logcolor(level::LogLevel)
-    level < Info  ? Base.debug_color() :
-    level < Warn  ? Base.info_color()  :
-    level < Error ? Base.warn_color()  :
-                    Base.error_color()
+    # Log colors occupy the area between the midpoints of adjacent levels
+    # so that Info+1 is the same color as Info-1, is the same color as Info
+    below_midpoint(x, a, b) = x.level < (a.level + b.level)/2
+
+	below_midpoint(level, Debug, Info) ? Base.debug_color() :
+    below_midpoint(level, Info, Warn)  ? Base.info_color()  :
+    below_midpoint(level, Warn, Error) ? Base.warn_color()  :
+                                         Base.error_color()
 end
 
 function default_metafmt(level::LogLevel, _module, group, id, file, line)

--- a/stdlib/Logging/test/runtests.jl
+++ b/stdlib/Logging/test/runtests.jl
@@ -53,6 +53,10 @@ end
             (:blue,      "Debug:",   "@ Base ~/somefile.jl:42")
         @test Logging.default_metafmt(Logging.Info,  Main, :g, :i, "a.jl", 1) ==
             (:cyan,      "Info:",    "")
+        @test Logging.default_metafmt(Logging.Info+1,  Main, :g, :i, "a.jl", 1) ==
+            (:cyan,      "LogLevel(1):",    "")
+        @test Logging.default_metafmt(Logging.Info-1,  Main, :g, :i, "a.jl", 1) ==
+            (:cyan,      "LogLevel(-1):",    "")
         @test Logging.default_metafmt(Logging.Warn,  Main, :g, :i, "b.jl", 2) ==
             (:yellow,    "Warning:", "@ Main b.jl:2")
         @test Logging.default_metafmt(Logging.Error, Main, :g, :i, "", 0) ==


### PR DESCRIPTION
Sometimes one want to create a log-level that is just above or below an existing one.
Right now that technically works fine, but colors wrong.
Creating one just above say `Warn` and it is colored brown like `Warn`,
but create one just below `Warn` and it is colored cyan like `Info`.

![logs demonstrating current coloring problem described above](https://user-images.githubusercontent.com/5127634/174075870-516d5e84-81da-47ef-9e92-8ea26a533f87.png)

This changes it so that the standard levels are at the center of their color ranges
So that just above *and just below* are both brown.
![logs demonstrating new behavour](https://user-images.githubusercontent.com/5127634/174076451-718e5886-302a-4003-ada8-31e29990637d.png)

Probably some other behavour also should be centered in this way, but I thought we can start with the color

cc @quinnj @fredrikekre 
This should resolve the discussion in https://github.com/JuliaLogging/LoggingExtras.jl/pull/64#discussion_r881282421

