### PR TITLE
Fix a small mistake in timing code.

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -3258,7 +3258,7 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
 
     _report_gc_finished(pause, gc_num.freed, sweep_full, recollect);
 
-    gc_final_pause_end(t0, gc_end_time);
+    gc_final_pause_end(gc_start_time, gc_end_time);
     gc_time_sweep_pause(gc_end_time, actual_allocd, live_bytes,
                         estimate_freed, sweep_full);
     gc_num.full_sweep += sweep_full;


### PR DESCRIPTION
We were using the wrong start time when measuring gc pause time.