### PR TITLE
GC bug fix for `max_collect_interval` computation

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -3447,12 +3447,12 @@ void jl_gc_init(void)
     gc_num.max_memory = 0;
 
 #ifdef _P64
-    // on a big memory machine, set max_collect_interval to totalmem / ncores / 2
+    // on a big memory machine, set max_collect_interval to totalmem / nthreads / 2
     uint64_t total_mem = uv_get_total_memory();
     uint64_t constrained_mem = uv_get_constrained_memory();
     if (constrained_mem > 0 && constrained_mem < total_mem)
         total_mem = constrained_mem;
-    size_t maxmem = total_mem / jl_cpu_threads() / 2;
+    size_t maxmem = total_mem / jl_n_threads / 2;
     if (maxmem > max_collect_interval)
         max_collect_interval = maxmem;
 #endif


### PR DESCRIPTION
Currently, `max_collect_interval` is constrained to `totalmem / ncores / 2` for `_P64` which results in a very short collect interval when you're running with a smaller number of threads on a machine with many cores.

Change this to `totalmem / nthreads / 2` which, for two of our tests, resulted in 40% and 60% runtime reduction (!!) as well as
GC time reduction from 46% to 10% and 64% to 11%.

Spotted by @janrous-rai.