### PR TITLE
BitVector: construct from Unsigned; l/r-shift(!), including in-place

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -116,6 +116,7 @@ IndexStyle(::Type{<:BitArray}) = IndexLinear()
 ## aux functions ##
 
 const _msk64 = ~UInt64(0)
+const _msk128 = ~UInt128(0)
 @inline _div64(l) = l >> 6
 @inline _mod64(l) = l & 63
 @inline _blsr(x)= x & (x-1) #zeros the last set bit. Has native instruction on many archs. needed in multidimensional.jl
@@ -712,7 +713,7 @@ function BitVector(x::Unsigned, n::Integer)
     B = BitVector(undef, n)
     Bc = B.chunks
     n != 0 && (Bc[1] = _msk64 >> (64 - n) & x)
-    n > 64 && (Bc[2] = 0x0000000000000000)
+    n > 64 && (Bc[2] = ~_msk64)
     return B
 end
 
@@ -767,7 +768,7 @@ function BitVector(x::UInt128, n::Integer)
     B = BitVector(undef, n)
     if n != 0
         Bc = B.chunks
-        y = 0xffffffffffffffffffffffffffffffff >> (128 - n) & x
+        y = _msk128 >> (128 - n) & x
         Bc[1] = y % UInt64
         n > 64 && (Bc[2] = y >> 64 % UInt64)
     end

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -664,6 +664,115 @@ function fill_bitarray_from_itr!(B::BitArray, itr)
     return B
 end
 
+## Constructors from Unsigned ##
+@noinline throw_invalid_nbits(n::Integer) = throw(ArgumentError("length must be ≤ 128, got $n"))
+
+"""
+    BitVector(x::Unsigned, n::Integer)
+
+Construct a `BitVector` of length 0 ≤ `n` ≤ 128 from an unsigned integer.
+If `n < 8sizeof(x)`, only the first `n` bits, numbering from the right, will be
+preserved; this is equivalent to `m = 8sizeof(x) - n; BitVector(x << m >> m, n)`.
+If `n > 8sizeof(x)`, the leading bit positions (reading left to right) are
+zero-filled analogously to unsigned integer literals.
+
+# Examples
+```jldoctest
+julia> B = BitVector(0b101, 4)
+4-element BitVector:
+ 1
+ 0
+ 1
+ 0
+
+julia> B == BitVector((true, false, true, false))
+true
+
+julia> B == BitVector(0xf5, 4)
+true
+
+julia> BitVector(0xff, 0)
+0-element BitVector
+
+julia> m = 8sizeof(0xf5) - 3
+5
+
+julia> BitVector(0xf5 << m >> m, 3) == BitVector(0xf5, 3)
+true
+
+julia> BitVector(0b110, 8sizeof(0b110) - leading_zeros(0b110))
+3-element BitVector:
+ 0
+ 1
+ 1
+```
+"""
+function BitVector(x::Unsigned, n::Integer)
+    n ≤ 128 || throw_invalid_nbits(n)
+    B = BitVector(undef, n)
+    Bc = B.chunks
+    n != 0 && (Bc[1] = _msk64 >> (64 - n) & x)
+    n > 64 && (Bc[2] = 0x0000000000000000)
+    return B
+end
+
+"""
+    BitVector(x::Unsigned)
+
+Construct a `BitVector` of length `8sizeof(x)` from an unsigned integer following
+the [LSB 0 bit numbering scheme](https://en.wikipedia.org/wiki/Bit_numbering)
+(except 1-indexed). Leading bit positions are zero-filled analogously to unsigned
+integer literals.
+
+# Examples
+```jldoctest
+julia> BitVector(0b10010100)
+8-element BitVector:
+ 0
+ 0
+ 1
+ 0
+ 1
+ 0
+ 0
+ 1
+
+julia> BitVector(0b10100)
+8-element BitVector:
+ 0
+ 0
+ 1
+ 0
+ 1
+ 0
+ 0
+ 0
+
+julia> BitVector(0xff) == trues(8)
+true
+```
+"""
+BitVector(x::Unsigned) = BitVector(x, 8 * sizeof(x))
+
+function BitVector(x::UInt128)
+    B = BitVector(undef, 128)
+    Bc = B.chunks
+    Bc[1] = x % UInt64
+    Bc[2] = x >> 64 % UInt64
+    return B
+end
+
+function BitVector(x::UInt128, n::Integer)
+    n ≤ 128 || throw_invalid_nbits(n)
+    B = BitVector(undef, n)
+    if n != 0
+        Bc = B.chunks
+        y = 0xffffffffffffffffffffffffffffffff >> (128 - n) & x
+        Bc[1] = y % UInt64
+        n > 64 && (Bc[2] = y >> 64 % UInt64)
+    end
+    return B
+end
 
 ## Indexing: getindex ##
 
@@ -1436,6 +1545,266 @@ function _circshift_int!(dest::BitVector, src::BitVector, i::Int)
 end
 
 circshift!(B::BitVector, i::Integer) = circshift!(B, B, i)
+
+# Necessary for avoiding a copy on rshift! when dest===src
+# -- several of the bitshifts involving ld0 can probably be eliminated.
+function copy_chunks_rshift!(dest::Vector{UInt64}, pos_d::Int, src::Vector{UInt64}, pos_s::Int, numbits::Int)
+    numbits == 0 && return
+    if dest === src && pos_d > pos_s
+        return copy_chunks_rtol!(dest, pos_d, pos_s, numbits)
+    end
+
+    kd0, ld0 = get_chunks_id(pos_d)
+    kd1, ld1 = get_chunks_id(pos_d + numbits - 1)
+    ks0, ls0 = get_chunks_id(pos_s)
+    ks1, ls1 = get_chunks_id(pos_s + numbits - 1)
+
+    delta_kd = kd1 - kd0
+    delta_ks = ks1 - ks0
+
+    u = _msk64
+    if delta_kd == 0
+        msk_d0 = ~(u << ld0) | (u << (ld1+1))
+    else
+        msk_d0 = ~(u << ld0)
+        msk_d1 = (u << (ld1+1))
+    end
+    if delta_ks == 0
+        msk_s0 = (u << ls0) & ~(u << (ls1+1))
+    else
+        msk_s0 = (u << ls0)
+    end
+
+    chunk_s0 = glue_src_bitchunks(src, ks0, ks1, msk_s0, ls0)
+
+    dest[kd0] = ((chunk_s0 << ld0) & ~msk_d0)
+
+    if delta_kd == 0
+        for i = kd0+1:length(dest)
+            dest[i] = ~_msk64
+        end
+        return
+    end
+
+    for i = 1 : kd1 - kd0 - 1
+        chunk_s1 = glue_src_bitchunks(src, ks0 + i, ks1, msk_s0, ls0)
+
+        chunk_s = (chunk_s0 >>> (64 - ld0)) | (chunk_s1 << ld0)
+
+        dest[kd0 + i] = chunk_s
+
+        chunk_s0 = chunk_s1
+    end
+
+    if ks1 >= ks0 + delta_kd
+        chunk_s1 = glue_src_bitchunks(src, ks0 + delta_kd, ks1, msk_s0, ls0)
+    else
+        chunk_s1 = UInt64(0)
+    end
+
+    chunk_s = (chunk_s0 >>> (64 - ld0)) | (chunk_s1 << ld0)
+
+    dest[kd1] = (chunk_s & ~msk_d1)
+
+    for i = kd1+1:length(dest)
+        dest[i] = ~_msk64
+    end
+
+    return
+end
+
+@inline function _msk_rtol!(dest::Vector{UInt64}, i::Int)
+    kd1, ld1 = get_chunks_id(i)
+    dest[kd1] &= (_msk64 << (ld1+1))
+    for k = kd1-1:-1:1
+        dest[k] = ~_msk64
+    end
+    return
+end
+
+function rshift!(dest::BitVector, src::BitVector, i::Int)
+    length(dest) == length(src) || throw(ArgumentError("destination and source should be of same size"))
+    n = length(dest)
+    abs(i) < n || return fill!(dest, false)
+    i == 0 && return (src === dest ? src : copyto!(dest, src))
+    if i > 0 # right
+        copy_chunks_rshift!(dest.chunks, 1, src.chunks, i+1, n-i)
+    else # left
+        i = -i
+        copy_chunks_rshift!(dest.chunks, i+1, src.chunks, 1, n-i)
+        _msk_rtol!(dest.chunks, i)
+    end
+    return dest
+end
+
+"""
+    rshift!(dest::BitVector, src::BitVector, i::Integer)
+
+Shift the elements of `src` right by `n` bit positions, filling with `false` values,
+storing the result in `dest`. If `n < 0`, elements are shifted to the left.
+
+See also: [`rshift`](@ref), [`lshift!`](@ref)
+
+# Examples
+```jldoctest
+julia> B = BitVector((false, false, false));
+
+julia> rshift!(B, BitVector((true, true, true,)), 2)
+3-element BitVector:
+ 1
+ 0
+ 0
+
+julia> rshift!(B, BitVector((true, true, true,)), -2)
+3-element BitVector:
+ 0
+ 0
+ 1
+```
+"""
+rshift!(dest::BitVector, src::BitVector, i::Integer) = rshift!(dest, src, Int(i))
+
+"""
+    rshift!(B::BitVector, i::Integer)
+
+Shift the elements of `B` right by `n` bit positions, filling with `false` values.
+If `n < 0`, elements are shifted to the left.
+
+# Examples
+```jldoctest
+julia> B = BitVector((true, true, true));
+
+julia> rshift!(B, 2)
+3-element BitVector:
+ 1
+ 0
+ 0
+
+julia> rshift!(B, 1)
+3-element BitVector:
+ 0
+ 0
+ 0
+```
+"""
+rshift!(B::BitVector, i::Integer) = rshift!(B, B, i)
+
+# Same as (<<)(B::BitVector, i::UInt)
+"""
+    rshift(B::BitVector, n::Integer)
+
+Return `B` with the elements shifted right by `n` bit positions, filling with
+`false` values. If `n < 0`, elements are shifted to the left.
+
+See also: [`rshift!`](@ref), [`lshift`](@ref)
+
+# Examples
+```jldoctest
+julia> B = BitVector([true, false, true, false, false])
+5-element BitVector:
+ 1
+ 0
+ 1
+ 0
+ 0
+julia> rshift(B, 1) == B << 1    # Notice opposite behavior
+true
+
+julia> rshift(B, 2)
+5-element BitVector:
+ 1
+ 0
+ 0
+ 0
+ 0
+```
+"""
+rshift(B::BitVector, i::Integer) = rshift!(similar(B), B, i)
+
+
+"""
+    lshift!(dest::BitVector, src::BitVector, i::Integer)
+
+Shift the elements of `src` left by `n` bit positions, filling with `false` values,
+storing the result in `dest`. If `n < 0`, elements are shifted to the right.
+
+See also: [`lshift`](@ref), [`rshift!`](@ref)
+
+# Examples
+```jldoctest
+julia> B = BitVector((false, false, false));
+
+julia> lshift!(B, BitVector((true, true, true,)), 2)
+3-element BitVector:
+ 0
+ 0
+ 1
+
+julia> lshift!(B, BitVector((true, true, true,)), -2)
+3-element BitVector:
+ 1
+ 0
+ 0
+```
+"""
+lshift!(dest::BitVector, src::BitVector, i::Integer) = rshift!(dest, src, -i)
+lshift!(dest::BitVector, src::BitVector, i::Unsigned) = rshift!(dest, src, -Int(i))
+
+"""
+    lshift!(B::BitVector, i::Integer)
+
+Shift the elements of `B` left by `n` bit positions, filling with `false` values.
+If `n < 0`, elements are shifted to the right.
+
+# Examples
+```jldoctest
+julia> B = BitVector((true, true, true));
+
+julia> lshift!(B, 2)
+3-element BitVector:
+ 0
+ 0
+ 1
+
+julia> lshift!(B, 1)
+3-element BitVector:
+ 0
+ 0
+ 0
+"""
+lshift!(B::BitVector, i::Integer) = lshift!(B, B, i)
+
+# Same as (>>>)(B::BitVector, i::UInt)
+"""
+    lshift(B::BitVector, n::Integer)
+
+Return `B` with the elements shifted left by `n` bit positions, filling with
+`false` values. If `n < 0`, elements are shifted to the right.
+
+See also: [`rshift`](@ref)
+
+# Examples
+```jldoctest
+julia> B = BitVector([true, false, true, false, false])
+5-element BitVector:
+ 1
+ 0
+ 1
+ 0
+ 0
+julia> lshift(B, 1) == B >> 1    # Notice opposite behavior
+true
+
+julia> lshift(B, 2)
+5-element BitVector:
+ 0
+ 0
+ 1
+ 0
+ 1
+```
+"""
+lshift(B::BitVector, i::Integer) = lshift!(similar(B), B, i)
 
 ## count & find ##
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -487,6 +487,10 @@ export
 # bitarrays
     falses,
     trues,
+    rshift!,
+    rshift,
+    lshift!,
+    lshift,
 
 # dequeues
     append!,


### PR DESCRIPTION
Preface: there are two distinct concepts here -- a constructor for
`BitVector` from unsigned integers, and l/r-`shift[!]` methods which
match the corresponding shifts on bit indices.

When writing the code for `BitVector(x::Unsigned)`, I realized
that the shift operators (`>>`, `>>>`, `<<`) have the opposite
behavior w.r.t. the corresponding bitshifts. Odd, I thought, then
found [this](https://github.com/JuliaLang/julia/issues/30958) --
sufficient motivation to write the l/r-`shift[!]`
methods. Incidentally, these shifts happen to be quite useful when
testing the behavior of the construction-from-unsigned, which is why
these two concepts are initially being submitted as part of the same
PR.

Admittedly, I would normally have preferred to submit separate ideas
as separate PRs so as to facilitate rejecting one or the other; my
apologies for the inconvenience.

Miscellaneous: the implementation of the l/r-`shift[!]` methods
enables copy-free, in-place shifts on `BitVector`s, but it is not as
efficient as it possibly could be -- there are some partial passes
over the backing `Vector{UInt64}` which could probably be eliminated
by properly re-writing `copy_chunks_rshift!`. I also notice the
existence of a potentially dangerous but gainful opportunity for
`@inbounds` in `_msk_rtol!`.