### PR TITLE
REPL-docview: fallback to doc(typeof(x)) for objects x

### DIFF
--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -262,7 +262,8 @@ function summarize(binding::Binding, sig)
     if defined(binding)
         binding_res = resolve(binding)
         !isa(binding_res, Module) && println(io, "No documentation found.\n")
-        summarize(io, binding_res, binding) === nothing && return nothing
+        io = summarize!(io, binding_res, binding)
+        io === nothing && return nothing
     else
         println(io, "No documentation found.\n")
         quot = any(isspace, sprint(print, binding)) ? "'" : ""
@@ -276,13 +277,14 @@ function summarize(binding::Binding, sig)
     return md
 end
 
-function summarize(io::IO, λ::Function, binding::Binding)
+function summarize!(io::IO, λ::Function, binding::Binding)
     kind = startswith(string(binding.var), '@') ? "macro" : "`Function`"
     println(io, "`", binding, "` is a ", kind, ".")
     println(io, "```\n", methods(λ), "\n```")
+    io
 end
 
-function summarize(io::IO, TT::Type, binding::Binding)
+function summarize!(io::IO, TT::Type, binding::Binding)
     println(io, "# Summary")
     T = Base.unwrap_unionall(TT)
     if T isa DataType
@@ -329,6 +331,7 @@ function summarize(io::IO, TT::Type, binding::Binding)
     else # unreachable?
         println(io, "`", binding, "` is of type `", typeof(TT), "`.\n")
     end
+    io
 end
 
 function find_readme(m::Module)::Union{String, Nothing}
@@ -347,7 +350,7 @@ function find_readme(m::Module)::Union{String, Nothing}
     end
     return nothing
 end
-function summarize(io::IO, m::Module, binding::Binding; nlines::Int = 200)
+function summarize!(io::IO, m::Module, binding::Binding; nlines::Int = 200)
     readme_path = find_readme(m)
     if isnothing(readme_path)
         println(io, "No docstring or readme file found for module `$m`.\n")
@@ -372,9 +375,10 @@ function summarize(io::IO, m::Module, binding::Binding; nlines::Int = 200)
         end
         length(readme_lines) > nlines && println(io, "\n[output truncated to first $nlines lines]")
     end
+    io
 end
 
-summarize(io::IO, @nospecialize(T), binding::Binding) = nothing
+summarize!(io::IO, @nospecialize(T), binding::Binding) = nothing
 
 # repl search and completions for help
 

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -187,7 +187,7 @@ function doc(binding::Binding, sig::Type = Union{})
         alias = aliasof(binding)
         if alias != binding
             return doc(alias, sig)
-        elseif isdefined(binding) && !(resolve(binding) isa Union{Type, Module, Function})
+        elseif defined(binding) && !(resolve(binding) isa Union{Type, Module, Function})
             println("`", binding, "` is of type `", typeof(resolve(binding)), "`\n")
             return doc(typeof(resolve(binding)), sig)
         else

--- a/stdlib/REPL/test/docview.jl
+++ b/stdlib/REPL/test/docview.jl
@@ -75,7 +75,13 @@ end
 end
 
 @testset "object documentation" begin
-    @test occursin("Example docstring A", sprint(show, ExampleStructs.eval(REPL.helpmode(IOBuffer(), "a"))))
+    @test sprint(show, ExampleStructs.eval(REPL.helpmode(IOBuffer(), "a"))) == """
+    `Main.DocviewTest.ExampleStructs.a` is of type `Main.DocviewTest.ExampleStructs.A`
+
+    ---
+
+    Example docstring A
+    """
     @test occursin("Example docstring A", sprint(show, ExampleStructs.eval(REPL.helpmode(IOBuffer(), "A()"))))
 end
 end

--- a/stdlib/REPL/test/docview.jl
+++ b/stdlib/REPL/test/docview.jl
@@ -4,6 +4,13 @@ using Test
 import REPL, REPL.REPLCompletions
 import Markdown
 
+module ExampleStructs
+    """Example docstring A"""
+    struct A end
+    a = A()
+end
+
+@testset "docview" begin
 @testset "symbol completion" begin
     @test startswith(let buf = IOBuffer()
             Core.eval(Main, REPL.helpmode(buf, "α"))
@@ -50,6 +57,7 @@ end
         @test r ∈ REPL.doc_completions(i)
     end
 end
+
 @testset "fuzzy score" begin
     # https://github.com/JunoLab/FuzzyCompletions.jl/issues/7
     # shouldn't throw when there is a space in a middle of query
@@ -64,4 +72,10 @@ end
     R = Complex{<:Integer}
     b = REPL.Binding(@__MODULE__, :R)
     @test REPL.summarize(b, Tuple{}) isa Markdown.MD
+end
+
+@testset "object documentation" begin
+    @test occursin("Example docstring A", sprint(show, ExampleStructs.eval(REPL.helpmode(IOBuffer(), "a"))))
+    @test occursin("Example docstring A", sprint(show, ExampleStructs.eval(REPL.helpmode(IOBuffer(), "A()"))))
+end
 end


### PR DESCRIPTION
Fix #45154, e.g. for `x=1` let `?x` give the doc string of `Int`.

As I got somewhat confused by the level of indirection, I also added a comment to provide an overview over the internal control flow of the help mode implementation.