### PR TITLE
Dispatch shuffle(::Base.OneTo) to randperm

### DIFF
--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -264,6 +264,7 @@ julia> shuffle(rng, Vector(1:10))
 shuffle(r::AbstractRNG, a::AbstractArray) = shuffle!(r, copymutable(a))
 shuffle(a::AbstractArray) = shuffle(default_rng(), a)
 
+shuffle(r::AbstractRNG, a::Base.OneTo) = randperm(r, last(a))
 
 ## randperm & randperm!
 


### PR DESCRIPTION
I think this is worth specializing because it is easy and because `shuffle(eachindex(v))` can be an indexing agnostic equivalent of `randperm(length(v))`, and it would be nice to not have an overhead on `Base.OneTo`. I did not dispatch other ranges to a post-processed `randperm` because the post-processing makes `shuffle` faster.

As a benchmark,
```julia
[@belapsed(shuffle(Base.OneTo($n))) for n in [5, 50, 500]]
```
Before:
```
3-element Vector{Float64}:
 1.011334768568353e-7
 5.178526315789474e-7
 4.749142857142857e-6
```
After:
```
3-element Vector{Float64}:
 8.417879417879417e-8
 4.9225e-7
 4.345428571428572e-6
```