### PR TITLE
Pass along backlog keyword argument in Sockets.listen

### DIFF
--- a/stdlib/Sockets/src/Sockets.jl
+++ b/stdlib/Sockets/src/Sockets.jl
@@ -625,7 +625,7 @@ listen(port::Integer; backlog::Integer=BACKLOG_DEFAULT) = listen(localhost, port
 listen(host::IPAddr, port::Integer; backlog::Integer=BACKLOG_DEFAULT) = listen(InetAddr(host, port); backlog=backlog)
 
 function listen(sock::LibuvServer; backlog::Integer=BACKLOG_DEFAULT)
-    uv_error("listen", trylisten(sock))
+    uv_error("listen", trylisten(sock; backlog=backlog))
     return sock
 end
 


### PR DESCRIPTION
I'm not crazy right? This is just not getting passed through?