### PR TITLE
Hook up IR_FLAG_NOTHROW

### DIFF
--- a/base/compiler/ssair/EscapeAnalysis/EscapeAnalysis.jl
+++ b/base/compiler/ssair/EscapeAnalysis/EscapeAnalysis.jl
@@ -31,7 +31,7 @@ import Core.Compiler: # Core.Compiler specific definitions
     isbitstype, isexpr, is_meta_expr_head, println, widenconst, argextype, singleton_type,
     fieldcount_noerror, try_compute_field, try_compute_fieldidx, hasintersect, ⊑,
     intrinsic_nothrow, array_builtin_common_typecheck, arrayset_typecheck,
-    setfield!_nothrow, alloc_array_ndims, stmt_effect_free, check_effect_free!
+    setfield!_nothrow, alloc_array_ndims, check_effect_free!
 
 include(x) = _TOP_MOD.include(@__MODULE__, x)
 if _TOP_MOD === Core.Compiler
@@ -1333,7 +1333,7 @@ function escape_call!(astate::AnalysisState, pc::Int, args::Vector{Any})
         return # ThrownEscape is already checked
     else
         # we escape statements with the `ThrownEscape` property using the effect-freeness
-        # computed by `stmt_effect_free` invoked within inlining
+        # computed by `stmt_effect_flags` invoked within inlining
         # TODO throwness ≠ "effect-free-ness"
         if is_effect_free(astate.ir, pc)
             add_liveness_changes!(astate, pc, args, 2)

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1758,6 +1758,10 @@ function _builtin_nothrow(@nospecialize(f), argtypes::Array{Any,1}, @nospecializ
         return argtypes[1] ⊑ Module && argtypes[2] ⊑ Symbol
     elseif f === donotdelete
         return true
+    elseif f === Core.finalizer
+        2 <= length(argtypes) <= 4 || return false
+        # Core.finalizer does no error checking - that's done in Base.finalizer
+        return true
     end
     return false
 end


### PR DESCRIPTION
I added the flag in #45272, but didn't hook it up to the nothrow
model. In the fullness of time, these should forwarded from
inference and only recomputed if necessary, but for the moment,
just make it work.