### PR TITLE
[src] Fix warnings when compiling for i686-linux-gnu

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2943,7 +2943,7 @@ static bool emit_f_opfield(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         }
         else if (fld.constant && fld.typ == (jl_value_t*)jl_long_type) {
             ssize_t i = jl_unbox_long(fld.constant);
-            if (i > 0 && i <= jl_datatype_nfields(uty))
+            if (i > 0 && i <= (ssize_t)jl_datatype_nfields(uty))
                 idx = i - 1;
         }
         if (idx != -1) {

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -2,6 +2,7 @@
 
 #include "llvm-version.h"
 #include "platform.h"
+#include <stdint.h>
 
 #include "llvm/IR/Mangler.h"
 #include <llvm/ADT/StringMap.h>
@@ -496,7 +497,7 @@ static auto countBasicBlocks(const Function &F)
 }
 
 void JuliaOJIT::OptSelLayerT::emit(std::unique_ptr<orc::MaterializationResponsibility> R, orc::ThreadSafeModule TSM) {
-    size_t optlevel = ~0ull;
+    size_t optlevel = SIZE_MAX;
     TSM.withModuleDo([&](Module &M) {
         if (jl_generating_output()) {
             optlevel = 0;
@@ -518,7 +519,7 @@ void JuliaOJIT::OptSelLayerT::emit(std::unique_ptr<orc::MaterializationResponsib
             optlevel = std::min(std::max(optlevel, optlevel_min), this->count);
         }
     });
-    assert(optlevel != ~0ull && "Failed to select a valid optimization level!");
+    assert(optlevel != SIZE_MAX && "Failed to select a valid optimization level!");
     this->optimizers[optlevel]->OptimizeLayer.emit(std::move(R), std::move(TSM));
 }
 
@@ -934,7 +935,7 @@ namespace {
                             // Each function is printed as a YAML object with several attributes
                             jl_printf(stream, "    \"%s\":\n", F.getName().str().c_str());
                             jl_printf(stream, "        instructions: %u\n", F.getInstructionCount());
-                            jl_printf(stream, "        basicblocks: %lu\n", countBasicBlocks(F));
+                            jl_printf(stream, "        basicblocks: %zd\n", countBasicBlocks(F));
                         }
 
                         start_time = jl_hrtime();
@@ -962,7 +963,7 @@ namespace {
                             }
                             jl_printf(stream, "    \"%s\":\n", F.getName().str().c_str());
                             jl_printf(stream, "        instructions: %u\n", F.getInstructionCount());
-                            jl_printf(stream, "        basicblocks: %lu\n", countBasicBlocks(F));
+                            jl_printf(stream, "        basicblocks: %zd\n", countBasicBlocks(F));
                         }
                     }
                 }


### PR DESCRIPTION
Addressed warnings:

```
/cache/build/default-amdci5-0/julialang/julia-master/src/jitlayers.cpp:499:23: warning: conversion from 'long long unsigned int' to 'size_t' {aka 'unsigned int'} changes value from '18446744073709551615' to '4294967295' [-Woverflow]
  499 |     size_t optlevel = ~0ull;
      |                       ^~~~~
[...]
/cache/build/default-amdci5-0/julialang/julia-master/src/jitlayers.cpp:937:71: warning: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'int' [-Wformat=]
  937 |                             jl_printf(stream, "        basicblocks: %lu\n", countBasicBlocks(F));
      |                                                                     ~~^     ~~~~~~~~~~~~~~~~~~~
      |                                                                       |                     |
      |                                                                       long unsigned int     int
      |                                                                     %u
/cache/build/default-amdci5-0/julialang/julia-master/src/jitlayers.cpp:965:71: warning: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'int' [-Wformat=]
  965 |                             jl_printf(stream, "        basicblocks: %lu\n", countBasicBlocks(F));
      |                                                                     ~~^     ~~~~~~~~~~~~~~~~~~~
      |                                                                       |                     |
      |                                                                       long unsigned int     int
      |                                                                     %u
[...]
/cache/build/default-amdci5-0/julialang/julia-master/src/codegen.cpp:2934:28: warning: comparison of integer expressions of different signedness: 'ssize_t' {aka 'int'} and 'const uint32_t' {aka 'const unsigned int'} [-Wsign-compare]
 2934 |             if (i > 0 && i <= jl_datatype_nfields(uty))
```

---

If this is correct, together with #45729 this should fix all compilation warnings on i686-linux-gnu.