### PR TITLE
Improve inference in hashed_unique

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -458,7 +458,7 @@ function _hashed_allunique(C)
     x = iterate(C)
     if haslength(C) && length(C) > 1000
         for i in OneTo(1000)
-            v, s = x
+            v, s = something(x)
             in!(v, seen) && return false
             x = iterate(C, s)
         end


### PR DESCRIPTION
This showed up in static analysis as a potential error.
Using `something` silences the error and also improves the error message slightly if the iterator's `length` is wrongly implemented.