### PR TITLE
Fix `libgit2-hostkey.patch` for source build

### DIFF
--- a/deps/patches/libgit2-hostkey.patch
+++ b/deps/patches/libgit2-hostkey.patch
@@ -1,8 +1,8 @@
 diff --git a/src/transports/ssh.c b/src/transports/ssh.c
-index 471c3273ed..32189d0979 100644
+index 89f085230..b8bdca61a 100644
 --- a/src/transports/ssh.c
 +++ b/src/transports/ssh.c
-@@ -525,6 +525,7 @@ static int _git_ssh_setup_conn(
+@@ -467,6 +467,7 @@ static int _git_ssh_setup_conn(
  	git_credential *cred = NULL;
  	LIBSSH2_SESSION *session=NULL;
  	LIBSSH2_CHANNEL *channel=NULL;
@@ -10,20 +10,23 @@ index 471c3273ed..32189d0979 100644
  
  	t->current_stream = NULL;
  
-@@ -636,7 +637,15 @@ post_extract:
+@@ -567,10 +568,18 @@ static int _git_ssh_setup_conn(
  
  		cert_ptr = &cert;
  
--		error = t->owner->certificate_check_cb((git_cert *) cert_ptr, 0, urldata.host, t->owner->message_cb_payload);
-+		if (atoi(urldata.port) == SSH_DEFAULT_PORT) {
-+			host_and_port = urldata.host;
++		if (atoi(s->url.port) == SSH_DEFAULT_PORT) {
++			host_and_port = s->url.host;
 +		} else {
-+			size_t n = strlen(urldata.host) + strlen(urldata.port) + 2;
++			size_t n = strlen(s->url.host) + strlen(s->url.port) + 2;
 +			host_and_port = alloca(n);
-+			sprintf(host_and_port, "%s:%s", urldata.host, urldata.port);
++			sprintf(host_and_port, "%s:%s", s->url.host, s->url.port);
 +		}
 +
-+		error = t->owner->certificate_check_cb((git_cert *) cert_ptr, 0, host_and_port, t->owner->message_cb_payload);
+ 		error = t->owner->connect_opts.callbacks.certificate_check(
+ 			(git_cert *)cert_ptr,
+ 			0,
+-			s->url.host,
++			host_and_port,
+ 			t->owner->connect_opts.callbacks.payload);
  
  		if (error < 0 && error != GIT_PASSTHROUGH) {
- 			if (!git_error_last())


### PR DESCRIPTION
When we upgraded LibGit2 to `v1.4.X` we needed to update this patch as
well.  This syncs the libgit2 build with Yggdrasil.