### PR TITLE
Revert "don't stall the CPU when using rr with threads"

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -190,7 +190,22 @@ NOINLINE uintptr_t gc_get_stack_ptr(void)
 
 #define should_timeout() 0
 
-void jl_gc_wait_for_the_world(void);
+static void jl_gc_wait_for_the_world(void)
+{
+    if (jl_n_threads > 1)
+        jl_wake_libuv();
+    for (int i = 0; i < jl_n_threads; i++) {
+        jl_ptls_t ptls2 = jl_all_tls_states[i];
+        // This acquire load pairs with the release stores
+        // in the signal handler of safepoint so we are sure that
+        // all the stores on those threads are visible.
+        // We're currently also using atomic store release in mutator threads
+        // (in jl_gc_state_set), but we may want to use signals to flush the
+        // memory operations on those threads lazily instead.
+        while (!jl_atomic_load_relaxed(&ptls2->gc_state) || !jl_atomic_load_acquire(&ptls2->gc_state))
+            jl_cpu_pause(); // yield?
+    }
+}
 
 // malloc wrappers, aligned allocation
 

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -85,7 +85,6 @@ static int jl_mach_gc_wait(jl_ptls_t ptls2,
     arraylist_push(&suspended_threads, (void*)item);
     thread_suspend(thread);
     uv_mutex_unlock(&safepoint_lock);
-    uv_cond_broadcast(&safepoint_cond);
     return 1;
 }
 


### PR DESCRIPTION
I think this might have been making CI unstable. Reverts JuliaLang/julia#45561