### PR TITLE
Adding perm version of sortslices

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -444,6 +444,7 @@ export
     sortperm,
     sortperm!,
     sortslices,
+    sortslicesperm,
     dropdims,
     step,
     stride,

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1792,7 +1792,7 @@ If `dims` is `(2, 1)` instead, the same slices will be taken,
 but the result order will be row-major instead.
 
 # Higher dimensional examples
-```
+```jldoctest
 julia> A = permutedims(reshape([4 3; 2 1; 'A' 'B'; 'C' 'D'], (2, 2, 2)), (1, 3, 2))
 2×2×2 Array{Any, 3}:
 [:, :, 1] =
@@ -1952,7 +1952,7 @@ If `dims` is `(2, 1)` instead, the same slices will be taken,
 but the result order will be row-major instead.
 
 # Higher dimensional examples
-```
+```jldoctest
 julia> A = permutedims(reshape([4 3; 2 1; 'A' 'B'; 'C' 'D'], (2, 2, 2)), (1, 3, 2))
 2×2×2 Array{Any, 3}:
 [:, :, 1] =

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1880,3 +1880,28 @@ end
 
 getindex(b::Ref, ::CartesianIndex{0}) = getindex(b)
 setindex!(b::Ref, x, ::CartesianIndex{0}) = setindex!(b, x)
+
+## sortslicesperm
+
+"""
+    sortslicesperm(A; dims, alg::Algorithm=DEFAULT_UNSTABLE, lt=isless, by=identity, rev::Bool=false, order::Ordering=Forward)
+
+Return a permutation vector `I` that sorts slices of an array `A`. The required keyword argument `dims` must
+be either an integer or a tuple of integers. It specifies the
+dimension(s) over which the slices are sorted.
+
+E.g., if `A` is a matrix, `dims=1` will sort rows, `dims=2` will sort columns.
+Note that the default comparison function on one dimensional slices sorts
+lexicographically.
+
+For the remaining keyword arguments, see the documentation of [`sort!`](@ref).
+"""
+function sortslicesperm(A::AbstractArray; dims::Union{Integer, Tuple{Vararg{Integer}}}, kws...)
+    _sortslicesperm(A, Val{dims}(); kws...)
+end
+
+function _sortslicesperm(A::AbstractArray, d::Val{dims}; kws...) where dims
+    itspace = compute_itspace(A, d)
+    vecs = map(its->view(A, its...), itspace)
+    p = sortperm(vecs; kws...)
+end


### PR DESCRIPTION
I saw that #45211 mentioned #9258 was still open because we need a perm version of sortslices, so here is an attempt simply snipping out the assignment lines from the existing sortslices function and returning the vector it creates for how the sort will go down.