### PR TITLE
Add second reduce docstring to manual

### DIFF
--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -372,7 +372,7 @@ _mapreduce_dim(f, op, ::_InitialValue, A::AbstractArrayOrBroadcasted, dims) =
     mapreducedim!(f, op, reducedim_init(f, op, A, dims), A)
 
 """
-    reduce(f, A; dims=:, [init])
+    reduce(f, A::AbstractArray; dims=:, [init])
 
 Reduce 2-argument function `f` along dimensions of `A`. `dims` is a vector specifying the
 dimensions to reduce, and the keyword argument `init` is the initial value to use in the

--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -96,6 +96,7 @@ Base.unique!
 Base.allunique
 Base.allequal
 Base.reduce(::Any, ::Any)
+Base.reduce(::Any, ::AbstractArray)
 Base.foldl(::Any, ::Any)
 Base.foldr(::Any, ::Any)
 Base.maximum


### PR DESCRIPTION
This one is missing from the manual right now: https://github.com/JuliaLang/julia/blob/68d62ab3d3ca91ea882aa749c5825ca5fee48948/base/reducedim.jl#L374-L406