### PR TITLE
[src] Fix some compilation warnings on PowerPC

### DIFF
--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -190,7 +190,7 @@ static void jl_call_in_ctx(jl_ptls_t ptls, void (*fptr)(void), int sig, void *_c
     ctx->uc_mcontext64->__ss.__lr = 0;
 #endif
 #else
-#warning "julia: throw-in-context not supported on this platform"
+#pragma message("julia: throw-in-context not supported on this platform")
     // TODO Add support for PowerPC(64)?
     sigset_t sset;
     sigemptyset(&sset);
@@ -298,7 +298,7 @@ int is_write_fault(void *context) {
     return exc_reg_is_write_fault(ctx->uc_mcontext.mc_err);
 }
 #else
-#warning Implement this query for consistent PROT_NONE handling
+#pragma message("Implement this query for consistent PROT_NONE handling")
 int is_write_fault(void *context) {
     return 0;
 }

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -988,6 +988,7 @@ void jl_rec_backtrace(jl_task_t *t)
    #pragma message("jl_rec_backtrace not defined for ASM/SETJMP on unknown linux")
    (void)mc;
    (void)c;
+   (void)mctx;
   #endif
  #elif defined(_OS_DARWIN_)
     sigjmp_buf *mctx = &t->ctx.ctx.uc_mcontext;


### PR DESCRIPTION
Remaining warnings are about the empty libunwind structs I just fixed for other architectures with #45729 and then
```
/cache/build/default-power8bot2-0/julialang/julia-master/src/crc32c.c:363: warning: "jl_crc32c_sw" redefined
  363 | #define jl_crc32c_sw jl_crc32c
      |
In file included from /cache/build/default-power8bot2-0/julialang/julia-master/src/julia.h:7,
                 from /cache/build/default-power8bot2-0/julialang/julia-master/src/crc32c.c:44:
/cache/build/default-power8bot2-0/julialang/julia-master/src/jl_internal_funcs.inc:104: note: this is the location of the previous definition
  104 | #define jl_crc32c_sw ijl_crc32c_sw
      |
```
which comes from https://github.com/JuliaLang/julia/blob/aa17702e0e24a8a2afd511e6e869e68f31daf709/src/crc32c.c#L356-L363 I think I'm missing why `jl_crc32c_sw` is implemented to fall back on `jl_crc32c` and then immediately after a macro with the same name is defined to do the same thing, which clashes with https://github.com/JuliaLang/julia/blob/aa17702e0e24a8a2afd511e6e869e68f31daf709/src/jl_exported_funcs.inc#L107