### PR TITLE
Allow an IPv6 address to be returned for `localhost`

### DIFF
--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -3121,7 +3121,7 @@ mktempdir() do dir
             catch
             end
 
-            loopback = ip"127.0.0.1"
+            loopbacks = (ip"127.0.0.1", ip"::1")
             for hostname in hostnames
                 local addr
                 try
@@ -3130,7 +3130,7 @@ mktempdir() do dir
                     continue
                 end
 
-                if addr == loopback
+                if addr ∈ loopbacks
                     common_name = hostname
                     break
                 end

--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -3186,9 +3186,9 @@ mktempdir() do dir
                     err = open(errfile, "r") do f
                         deserialize(f)
                     end
-                    @test err.code == LibGit2.Error.ECERTIFICATE
+                    @test err.code == LibGit2.Error.ERROR
                     @test startswith(lowercase(err.msg),
-                                     lowercase("The SSL certificate is invalid"))
+                                     lowercase("user rejected certificate for localhost"))
 
                     rm(errfile)
 


### PR DESCRIPTION
On our CI machines, there is an IPv6 loopback available, which causes
`getaddrinfo` to return an IPv6 address (`::1`) by default.  We could
specifically request `getaddrinfo()` to return an `IPv4` address,
however this would needlessly restrict our test suite to only work on
machines that have a valid IPv4 loopback interface.  Best to be flexible.