### PR TITLE
[Dates] Define a method for `(:)(a::Date, b::Date)` with default step

### DIFF
--- a/stdlib/Dates/src/ranges.jl
+++ b/stdlib/Dates/src/ranges.jl
@@ -4,6 +4,7 @@
 
 StepRange{<:Dates.DatePeriod,<:Real}(start, step, stop) =
     throw(ArgumentError("must specify step as a Period when constructing Dates ranges"))
+Base.:(:)(a::T, b::T) where {T<:Date} = (:)(a, Day(1), b)
 
 # Given a start and end date, how many steps/periods are in between
 guess(a::DateTime, b::DateTime, c) = floor(Int64, (Int128(value(b)) - Int128(value(a))) / toms(c))

--- a/stdlib/Dates/test/ranges.jl
+++ b/stdlib/Dates/test/ranges.jl
@@ -596,4 +596,11 @@ a = Dates.Time(23, 1, 1)
     @test length(utm_typemin:-Millisecond(1):utm_typemin) == 1
 end
 
+# Issue #45816
+@testset "default step for date ranges" begin
+    r = Date(2000, 1, 1):Date(2000, 12, 31)
+    @test step(r) === Day(1)
+    @test length(r) == 366
+end
+
 end  # RangesTest module


### PR DESCRIPTION
At the moment we have
```julia
julia> Date(2000,1,1):Date(2000,1,2)
ERROR: MethodError: Cannot `convert` an object of type Int64 to an object of type Day
```
The method https://github.com/JuliaLang/julia/blob/a60c76ea57de012b04ed7af6affe1d133c06cbda/base/range.jl#L7 is trying to convert `1` to a `Day`, but it fails to do the conversion, I think defining a method for `Date` ranges with the default step that this is trying to use anyway makes sense.

A more generic alternative to this PR, not specific to dates, may be to define
```julia
(:)(start::T, stop::T) where {T} = (:)(start, oneunit(stop >= start ? stop - start : start - stop), stop) 
```
but I have no idea whether this would cause issues elsewhere.

Fix #45816.