### PR TITLE
Use faster strncmp implementation

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -190,7 +190,7 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
     const char *const atPaths[] = {"@executable_path/", "@loader_path/", "@rpath/"};
     for (i = 0; i < sizeof(atPaths)/sizeof(char*); ++i) {
         size_t atLen = strlen(atPaths[i]);
-        if (nameLen >= atLen && 0 == strncmp(modname, atPaths[i], atLen)) {
+        if (nameLen >= atLen && 0 == strncmp_fast(modname, atPaths[i], atLen)) {
             is_atpath = 1;
         }
     }
@@ -217,7 +217,7 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
                     continue;
 
                 // Is this entry supposed to be relative to the bindir?
-                if (len >= 16 && strncmp(dl_path, "@executable_path", 16) == 0) {
+                if (len >= 16 && strncmp_fast(dl_path, "@executable_path", 16) == 0) {
                     snprintf(relocated, PATHBUF, "%s%s", jl_options.julia_bindir, dl_path + 16);
                     len = len - 16 + strlen(jl_options.julia_bindir);
                 } else {

--- a/src/gf.c
+++ b/src/gf.c
@@ -2025,7 +2025,7 @@ static void record_precompile_statement(jl_method_instance_t *mi)
         JL_LOCK(&precomp_statement_out_lock);
     if (s_precompile == NULL) {
         const char *t = jl_options.trace_compile;
-        if (!strncmp(t, "stderr", 6)) {
+        if (!strncmp_fast(t, "stderr", 6)) {
             s_precompile = JL_STDERR;
         }
         else {

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -924,9 +924,9 @@ JL_DLLEXPORT int jl_ispty(uv_pipe_t *pipe)
     // ^\\\\?\\pipe\\(msys|cygwin)-[0-9a-z]{16}-[pt]ty[1-9][0-9]*-
     //jl_printf(JL_STDERR,"pipe_name: %s\n", name);
     int n = 0;
-    if (!strncmp(name,"\\\\?\\pipe\\msys-",14))
+    if (!strncmp_fast(name,"\\\\?\\pipe\\msys-",14))
         n = 14;
-    else if (!strncmp(name,"\\\\?\\pipe\\cygwin-",16))
+    else if (!strncmp_fast(name,"\\\\?\\pipe\\cygwin-",16))
         n = 16;
     else
         return 0;

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -451,10 +451,10 @@ restart_switch:
             errno = 0;
             jl_options.nthreadpools = 1;
             long nthreads = -1, nthreadsi = 0;
-            if (!strncmp(optarg, "auto", 4)) {
+            if (!strncmp_fast(optarg, "auto", 4)) {
                 jl_options.nthreads = -1;
                 if (optarg[4] == ',') {
-                    if (!strncmp(&optarg[5], "auto", 4))
+                    if (!strncmp_fast(&optarg[5], "auto", 4))
                         nthreadsi = 1;
                     else {
                         errno = 0;
@@ -470,7 +470,7 @@ restart_switch:
                 if (errno != 0 || optarg == endptr || nthreads < 1 || nthreads >= INT16_MAX)
                     jl_errorf("julia: -t,--threads=<n>[,auto|<m>]; n must be an integer >= 1");
                 if (*endptr == ',') {
-                    if (!strncmp(&endptr[1], "auto", 4))
+                    if (!strncmp_fast(&endptr[1], "auto", 4))
                         nthreadsi = 1;
                     else {
                         errno = 0;
@@ -561,7 +561,7 @@ restart_switch:
                         codecov = JL_LOG_ALL;
                     jl_options.output_code_coverage = optarg;
                 }
-                else if (!strncmp(optarg, "@", 1)) {
+                else if (!strncmp_fast(optarg, "@", 1)) {
                     codecov = JL_LOG_PATH;
                     jl_options.tracked_path = optarg + 1; // skip `@`
                 }
@@ -581,7 +581,7 @@ restart_switch:
                     malloclog = JL_LOG_ALL;
                 else if (!strcmp(optarg,"none"))
                     malloclog = JL_LOG_NONE;
-                else if (!strncmp(optarg, "@", 1)) {
+                else if (!strncmp_fast(optarg, "@", 1)) {
                     malloclog = JL_LOG_PATH;
                     jl_options.tracked_path = optarg + 1; // skip `@`
                 }

--- a/src/julia.h
+++ b/src/julia.h
@@ -2203,6 +2203,8 @@ typedef struct {
 } jl_cgparams_t;
 extern JL_DLLEXPORT int jl_default_debug_info_kind;
 
+extern JL_DLLEXPORT int strncmp_fast( const char *ptr0, const char *ptr1, int len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -381,7 +381,7 @@ JL_UNUSED static uint32_t find_feature_bit(const FeatureName *features, size_t n
 {
     for (size_t i = 0; i < nfeatures; i++) {
         auto &feature = features[i];
-        if (strncmp(feature.name, str, len) == 0 && feature.name[len] == 0) {
+        if (strncmp_fast(feature.name, str, len) == 0 && feature.name[len] == 0) {
             return feature.bit;
         }
     }

--- a/src/processor_arm.cpp
+++ b/src/processor_arm.cpp
@@ -791,7 +791,7 @@ static inline void get_cpuinfo_sysfs(std::set<CPUID> &res)
     while (auto entry = readdir(dir)) {
         if (entry->d_type != DT_DIR)
             continue;
-        if (strncmp(entry->d_name, "cpu", 3) != 0)
+        if (strncmp_fast(entry->d_name, "cpu", 3) != 0)
             continue;
         std::string stm;
         llvm::raw_string_ostream(stm) << "/sys/devices/system/cpu/" << entry->d_name << "/regs/identification/midr_el1";

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -58,7 +58,7 @@ static jl_sym_t *symtab_lookup(_Atomic(jl_sym_t*) *ptree, const char *str, size_
     while (node != NULL) {
         intptr_t x = (intptr_t)(h - node->hash);
         if (x == 0) {
-            x = strncmp(str, jl_symbol_name(node), len);
+            x = strncmp_fast(str, jl_symbol_name(node), len);
             if (x == 0 && jl_symbol_name(node)[len] == 0) {
                 if (slot != NULL)
                     *slot = ptree;

--- a/src/threading.c
+++ b/src/threading.c
@@ -490,7 +490,7 @@ void jl_init_threading(void)
             nthreadsi = jl_options.nthreads_per_pool[1];
     }
     else if ((cp = getenv(NUM_THREADS_NAME))) { // ENV[NUM_THREADS_NAME] specified
-        if (!strncmp(cp, "auto", 4)) {
+        if (!strncmp_fast(cp, "auto", 4)) {
             nthreads = jl_effective_threads();
             cp += 4;
         }
@@ -503,7 +503,7 @@ void jl_init_threading(void)
         }
         if (*cp == ',') {
             cp++;
-            if (!strncmp(cp, "auto", 4))
+            if (!strncmp_fast(cp, "auto", 4))
                 nthreadsi = 1;
             else {
                 errno = 0;


### PR DESCRIPTION
I came across this that claims to be a faster strncmp implementation and thought I'd see if there were any gains to be had.
https://mgronhol.github.io/fast-strcmp/

MacOS
master
```
julia> @btime run(`./julia --startup-file=no -e "1"`)
  205.421 ms (49 allocations: 1.73 KiB)
```
this PR
```
julia> @btime run(`./julia --startup-file=no -e "1"`)
  196.657 ms (49 allocations: 1.73 KiB)
``` 
The timing gain appears to be repeatable on my system.

I guess most of the gains here are from the `strncmp` in `symtab_lookup`.

Marking as draft as I haven't reviewed the implementation, and can't find a license.

___

Gains aren't apparent on ubuntu
master `75.763 ms (49 allocations: 1.77 KiB)`
this PR `76.883 ms (49 allocations: 1.73 KiB)`
