### PR TITLE
Fix layout of REPL completions with newlines

### DIFF
--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -906,3 +906,17 @@ end
     @test get_last_word("a[b[]]") == "b"
     @test get_last_word("a[]") == "a[]"
 end
+
+@testset "issue #45836" begin
+    term = FakeTerminal(IOBuffer(), IOBuffer(), IOBuffer())
+    promptstate = REPL.LineEdit.init_state(term, REPL.LineEdit.mode(new_state()))
+    strings = ["abcdef", "123456", "ijklmn"]
+    REPL.LineEdit.show_completions(promptstate, strings)
+    completion = String(take!(term.out_stream))
+    @test completion == "\033[0B\n\rabcdef\r\033[8C123456\r\033[16Cijklmn\n"
+    strings2 = ["abcdef", "123456\nijklmn"]
+    promptstate = REPL.LineEdit.init_state(term, REPL.LineEdit.mode(new_state()))
+    REPL.LineEdit.show_completions(promptstate, strings2)
+    completion2 = String(take!(term.out_stream))
+    @test completion2 == "\033[0B\nabcdef\n123456\nijklmn\n"
+end


### PR DESCRIPTION
Fix #45836 by forcing REPL completions that include a newline to print on a single column.

The behaviour on this PR is like for a small terminal:
```julia
julia> include(<tab>
include(mapexpr::Function, fname::AbstractString)
     @ Base.MainInclude client.jl:469
include(fname::AbstractString)
     @ Base.MainInclude client.jl:470
```

I didn't know how to test this so feel free to comment if you think the test can be improved.