### PR TITLE
Add @isscript macro

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -68,7 +68,7 @@ New library functions
   inspecting which function `f` was originally wrapped. ([#42717])
 * New `pkgversion(m::Module)` function to get the version of the package that loaded
   a given module, similar to `pkgdir(m::Module)`. ([#45607])
-* The new `Base.@ismain` macro checks if it is being expanded in the same file as
+* The new `Base.@isscript` macro checks if it is being expanded in the same file as
   `PROGRAM_FILE`, i.e. if the file is run as a script from command line.
   It is preferred in place of the idiom `abspath(PROGRAM_FILE) == @__FILE__`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -68,6 +68,9 @@ New library functions
   inspecting which function `f` was originally wrapped. ([#42717])
 * New `pkgversion(m::Module)` function to get the version of the package that loaded
   a given module, similar to `pkgdir(m::Module)`. ([#45607])
+* The new `Base.@ismain` macro checks if it is being expanded in the same file as
+  `PROGRAM_FILE`, i.e. if the file is run as a script from command line.
+  It is preferred in place of the idiom `abspath(PROGRAM_FILE) == @__FILE__`.
 
 Library changes
 ---------------

--- a/base/client.jl
+++ b/base/client.jl
@@ -371,7 +371,7 @@ end
 _atreplinit(repl) = invokelatest(__atreplinit, repl)
 
 """
-    @ismain
+    @isscript
 
 Check if the current file is the file passed to Julia from command line.
 
@@ -383,14 +383,14 @@ script, e.g. invoking command-line parsing.
 
 # Examples
 ```
-if @ismain
+if @isscript
     args = parse_arguments(ARGS)
     [...]
 ```
 
 See also: [`PROGRAM_FILE`](@ref), [`@__FILE__`](@ref)
 """
-macro ismain()
+macro isscript()
     file = __source__.file
     file === nothing ? false : String(file) == abspath(PROGRAM_FILE)
 end

--- a/base/client.jl
+++ b/base/client.jl
@@ -370,6 +370,31 @@ function __atreplinit(repl)
 end
 _atreplinit(repl) = invokelatest(__atreplinit, repl)
 
+"""
+    @ismain
+
+Check if the current file is the file passed to Julia from command line.
+
+Evaluates to `true` when placed in the `PROGRAM_FILE`, and `false` when placed
+in any other file. Is `false` when evaluated by `julia -e`.
+
+This macro can be used to check if the script should behave like an executable
+script, e.g. invoking command-line parsing.
+
+# Examples
+```
+if @ismain
+    args = parse_arguments(ARGS)
+    [...]
+```
+
+See also: [`PROGRAM_FILE`](@ref), [`@__FILE__`](@ref)
+"""
+macro ismain()
+    file = __source__.file
+    file === nothing ? false : String(file) == abspath(PROGRAM_FILE)
+end
+
 function load_InteractiveUtils(mod::Module=Main)
     # load interactive-only libraries
     if !isdefined(mod, :InteractiveUtils)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1050,4 +1050,5 @@ export
     @goto,
     @view,
     @views,
-    @static
+    @static,
+    @ismain

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1051,4 +1051,4 @@ export
     @view,
     @views,
     @static,
-    @ismain
+    @isscript

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -6,8 +6,9 @@
     PROGRAM_FILE
 
 A string containing the script name passed to Julia from the command line. Note that the
-script name remains unchanged from within included files. Alternatively see
-[`@__FILE__`](@ref).
+script name remains unchanged from within included files.
+
+See also: [`@__FILE__`](@ref), [`@isscript`](@ref)
 """
 global PROGRAM_FILE = ""
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2241,7 +2241,8 @@ end
 Expand to a string with the path to the file containing the
 macrocall, or an empty string if evaluated by `julia -e <expr>`.
 Return `nothing` if the macro was missing parser source information.
-Alternatively see [`PROGRAM_FILE`](@ref).
+
+See also: [`PROGRAM_FILE`](@ref), [`@isscript`](@ref)
 """
 macro __FILE__()
     __source__.file === nothing && return nothing

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -428,7 +428,7 @@ Base.@__MODULE__
 Base.@__FILE__
 Base.@__DIR__
 Base.@__LINE__
-Base.@ismain
+Base.@isscript
 Base.fullname
 Base.names
 Base.nameof(::Function)

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -428,6 +428,7 @@ Base.@__MODULE__
 Base.@__FILE__
 Base.@__DIR__
 Base.@__LINE__
+Base.@ismain
 Base.fullname
 Base.names
 Base.nameof(::Function)

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -91,8 +91,17 @@ obj3 = MyModule.someotherfunction(obj2, c)
 ### How do I check if the current file is being run as the main script?
 
 When a file is run as the main script using `julia file.jl` one might want to activate extra
-functionality like command line argument handling. A way to determine that a file is run in
-this fashion is to check if `abspath(PROGRAM_FILE) == @__FILE__` is `true`.
+functionality like command line argument handling. The preferred way to handle this is to
+use the macro `@ismain`, as so:
+```julia
+function main()
+    [...]
+end
+
+if @ismain
+    main()
+end
+```
 
 ### [How do I catch CTRL-C in a script?](@id catch-ctrl-c)
 

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -92,13 +92,13 @@ obj3 = MyModule.someotherfunction(obj2, c)
 
 When a file is run as the main script using `julia file.jl` one might want to activate extra
 functionality like command line argument handling. The preferred way to handle this is to
-use the macro `@ismain`, as so:
+use the macro `@isscript`, as so:
 ```julia
 function main()
     [...]
 end
 
-if @ismain
+if @isscript
     main()
 end
 ```

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -579,11 +579,13 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
         write(a, """
             println(@__FILE__)
             println(PROGRAM_FILE)
+            println(@isscript)
             include(\"$(escape_string(b))\")
             """)
         write(b, """
             println(@__FILE__)
             println(PROGRAM_FILE)
+            println(@isscript)
             """)
         mkpath(dirname(c))
         cp(b, c)
@@ -592,24 +594,24 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
 
         withenv("JULIA_DEPOT_PATH" => dir) do
             @test readsplit(`$exename $a`) ==
-                [a, a,
-                 b, a]
+                [a, a, "true",
+                 b, a, "false"]
             @test readsplit(`$exename -L $b -e 'exit(0)'`) ==
-                [b, ""]
+                [b, "", "false"]
             @test readsplit(`$exename -L $b $a`) ==
-                [b, a,
-                 a, a,
-                 b, a]
+                [b, a, "false",
+                 a, a, "true",
+                 b, a, "false"]
             @test readsplit(`$exename --startup-file=yes -e 'exit(0)'`) ==
-                [c, ""]
+                [c, "", "false"]
             @test readsplit(`$exename --startup-file=yes -L $b -e 'exit(0)'`) ==
-                [c, "",
-                 b, ""]
+                [c, "", "false",
+                 b, "", "false"]
             @test readsplit(`$exename --startup-file=yes -L $b $a`) ==
-                [c, a,
-                 b, a,
-                 a, a,
-                 b, a]
+                [c, a, "false",
+                 b, a, "false",
+                 a, a, "true",
+                 b, a, "false"]
         end
     end
 


### PR DESCRIPTION
Adds and exports the macro `@ismain`. Previously, to check if a file was being
run from command line as a script, doing `if abspath(PROGRAM_FILE) == @__FILE__`
was suggested. The new `@ismain` macro does the same thing, but is simpler,
more discoverable, and easier to use and remember.

EDIT: This is now renamed to `@isscript` per discussion below.