### PR TITLE
Elaborate 'ccall' requires the compiler error message

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -328,10 +328,10 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         return eval_methoddef(ex, s);
     }
     else if (head == jl_foreigncall_sym) {
-        jl_error("`ccall` requires the compiler");
+        jl_error("`ccall` requires the compiler. julia codegen library might have failed to load.");
     }
     else if (head == jl_cfunction_sym) {
-        jl_error("`cfunction` requires the compiler");
+        jl_error("`cfunction` requires the compiler. julia codegen library might have failed to load.");
     }
     jl_errorf("unsupported or misplaced expression %s", jl_symbol_name(head));
     abort();


### PR DESCRIPTION
Recently, I was building julia with USE_BINARYBUILDER_LLVM=0 in order to try out my own llvm fork. Since I had a higher glibc in my local machine, libllvm failed to load as libstdc++ inside julia/usr/lib was outdated. 

However, since the error message from load_library was intentioanlly silenced (err paramter is 0), there was no helpful error message printed out. The actual error message I got was in the screenshot below. As it points to completely unreleated direction, I had to spend lot of hours to track down what was going on. 

![image](https://user-images.githubusercontent.com/12246126/176480898-cf48c56e-fac5-4a36-9d11-d9eb92b2117e.png)

This pr makes it better by priting warning message to stdout when codegen library failed to load so that we can identify this kind of llvm load error right away.
