### PR TITLE
Proof performance tips for clarity

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1050,8 +1050,8 @@ That is, `fdot(x)` is ten times faster and allocates 1/6 the
 memory of `f(x)`, because each `*` and `+` operation in `f(x)` allocates
 a new temporary array and executes in a separate loop. In this example
 `f.(x)` is as fast as `fdot(x)` but in many contexts it is more
-convenient to just sprinkle some dots in your expressions rather than
-defining a separate function for each vectorized operation.
+convenient to sprinkle some dots in your expressions than to
+define a separate function for each vectorized operation.
 
 ## [Consider using views for slices](@id man-performance-views)
 

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1048,11 +1048,10 @@ julia> @time f.(x);
 
 That is, `fdot(x)` is ten times faster and allocates 1/6 the
 memory of `f(x)`, because each `*` and `+` operation in `f(x)` allocates
-a new temporary array and executes in a separate loop. (Of course,
-if you just do `f.(x)` then it is as fast as `fdot(x)` in this
-example, but in many contexts it is more convenient to just sprinkle
-some dots in your expressions rather than defining a separate function
-for each vectorized operation.)
+a new temporary array and executes in a separate loop. In this example
+`f.(x)` is as fast as `fdot(x)` but in many contexts it is more
+convenient to just sprinkle some dots in your expressions rather than
+defining a separate function for each vectorized operation.
 
 ## [Consider using views for slices](@id man-performance-views)
 


### PR DESCRIPTION
Cutting "of course" because `f.(x)` uses dotted operators on scalars which, while functional, is not obvious to me.
This sentence feels important. I removed it from parentheses.
Word order for concision and clarity.