### PR TITLE
Change timeout kill signals to SIGQUIT from SIGTERM

### DIFF
--- a/stdlib/LibGit2/test/libgit2-tests.jl
+++ b/stdlib/LibGit2/test/libgit2-tests.jl
@@ -63,7 +63,7 @@ function challenge_prompt(cmd::Cmd, challenges)
             end
 
             if process_running(p)
-                kill(p)
+                kill(p, Base.SIGQUIT)
                 put!(timer, :timeout)
             elseif success(p)
                 put!(timer, :success)

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -172,7 +172,7 @@ let cmd = Base.julia_cmd()
     t = Timer(120) do t
         # should be under 10 seconds, so give it 2 minutes then report failure
         println("KILLING debuginfo registration test BY PROFILE TEST WATCHDOG\n")
-        kill(p, Base.SIGTERM)
+        kill(p, Base.SIGQUIT)
         sleep(10)
         kill(p, Base.SIGKILL)
     end
@@ -202,7 +202,7 @@ if Sys.isbsd() || Sys.islinux()
             t = Timer(120) do t
                 # should be under 10 seconds, so give it 2 minutes then report failure
                 println("KILLING siginfo/sigusr1 test BY PROFILE TEST WATCHDOG\n")
-                kill(p, Base.SIGTERM)
+                kill(p, Base.SIGQUIT)
                 sleep(10)
                 kill(p, Base.SIGKILL)
                 close(notify_exit)

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -18,7 +18,7 @@ function killjob(d)
         ccall(:uv_kill, Cint, (Cint, Cint), getpid(), SIGINFO)
         sleep(5) # Allow time for profile to collect and print before killing
     end
-    ccall(:uv_kill, Cint, (Cint, Cint), getpid(), Base.SIGTERM)
+    ccall(:uv_kill, Cint, (Cint, Cint), getpid(), Base.SIGQUIT)
     nothing
 end
 sockets_watchdog_timer = Timer(t -> killjob("KILLING BY SOCKETS TEST WATCHDOG\n"), 600)

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -255,7 +255,7 @@ cmd = """
     sleep(100)
     isopen(stdin) || exit()
     println(stderr, "ERROR: Killing threads test due to watchdog expiry")
-    ccall(:uv_kill, Cint, (Cint, Cint), $(getpid()), Base.SIGTERM)
+    ccall(:uv_kill, Cint, (Cint, Cint), $(getpid()), Base.SIGQUIT)
 """
 proc = open(pipeline(`$(Base.julia_cmd()) -e $cmd`; stderr=stderr); write=true)
 


### PR DESCRIPTION
We've been having a lot of timeouts on CI recently.  Our coredumps might
be helpful in tracking these down, but when we send `SIGTERM` or
`SIGKILL` we don't get coredumps.  This allows customization of which
signal is sent during these timeout messages, to allow for CI to set it
to `SIGSEGV` or similar, to force core dumps for debugging purposes.