### PR TITLE
Fix integer overflow in `reverse!`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1885,14 +1885,13 @@ julia> A
 """
 function reverse!(v::AbstractVector, start::Integer, stop::Integer=lastindex(v))
     s, n = Int(start), Int(stop)
-    liv = LinearIndices(v)
-    if n <= s  # empty case; ok
-    elseif !(first(liv) ≤ s ≤ last(liv))
-        throw(BoundsError(v, s))
-    elseif !(first(liv) ≤ n ≤ last(liv))
-        throw(BoundsError(v, n))
-    end
-    if n > s # non-empty
+    if n > s # non-empty and non-trivial
+        liv = LinearIndices(v)
+        if !(first(liv) ≤ s ≤ last(liv))
+            throw(BoundsError(v, s))
+        elseif !(first(liv) ≤ n ≤ last(liv))
+            throw(BoundsError(v, n))
+        end
         r = n
         @inbounds for i in s:midpoint(s, n-1)
             v[i], v[r] = v[r], v[i]

--- a/base/array.jl
+++ b/base/array.jl
@@ -1852,6 +1852,11 @@ function reverseind(a::AbstractVector, i::Integer)
     first(li) + last(li) - i
 end
 
+# This implementation of `midpoint` is performance-optimized but safe
+# only if `lo <= hi`.
+midpoint(lo::T, hi::T) where T<:Integer = lo + ((hi - lo) >>> 0x01)
+midpoint(lo::Integer, hi::Integer) = midpoint(promote(lo, hi)...)
+
 """
     reverse!(v [, start=firstindex(v) [, stop=lastindex(v) ]]) -> v
 
@@ -1888,7 +1893,7 @@ function reverse!(v::AbstractVector, start::Integer, stop::Integer=lastindex(v))
         throw(BoundsError(v, n))
     end
     r = n
-    @inbounds for i in s:div(s+n-1, 2)
+    @inbounds for i in s:midpoint(s, n-1)
         v[i], v[r] = v[r], v[i]
         r -= 1
     end

--- a/base/array.jl
+++ b/base/array.jl
@@ -1892,10 +1892,12 @@ function reverse!(v::AbstractVector, start::Integer, stop::Integer=lastindex(v))
     elseif !(first(liv) ≤ n ≤ last(liv))
         throw(BoundsError(v, n))
     end
-    r = n
-    @inbounds for i in s:midpoint(s, n-1)
-        v[i], v[r] = v[r], v[i]
-        r -= 1
+    if n > s # non-empty
+        r = n
+        @inbounds for i in s:midpoint(s, n-1)
+            v[i], v[r] = v[r], v[i]
+            r -= 1
+        end
     end
     return v
 end

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -11,7 +11,8 @@ using .Base: copymutable, LinearIndices, length, (:), iterate, OneTo,
     AbstractMatrix, AbstractUnitRange, isless, identity, eltype, >, <, <=, >=, |, +, -, *, !,
     extrema, sub_with_overflow, add_with_overflow, oneunit, div, getindex, setindex!,
     length, resize!, fill, Missing, require_one_based_indexing, keytype, UnitRange,
-    min, max, reinterpret, signed, unsigned, Signed, Unsigned, typemin, xor, Type, BitSigned, Val
+    min, max, reinterpret, signed, unsigned, Signed, Unsigned, typemin, xor, Type, BitSigned, Val,
+    midpoint
 
 using .Base: >>>, !==
 
@@ -164,11 +165,6 @@ same thing as `partialsort!` but leaving `v` unmodified.
 """
 partialsort(v::AbstractVector, k::Union{Integer,OrdinalRange}; kws...) =
     partialsort!(copymutable(v), k; kws...)
-
-# This implementation of `midpoint` is performance-optimized but safe
-# only if `lo <= hi`.
-midpoint(lo::T, hi::T) where T<:Integer = lo + ((hi - lo) >>> 0x01)
-midpoint(lo::Integer, hi::Integer) = midpoint(promote(lo, hi)...)
 
 # reference on sorted binary search:
 #   http://www.tbray.org/ongoing/When/200x/2003/03/22/Binary

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -414,6 +414,18 @@ rv = reverse(v)
 cv = copy(v)
 @test reverse!(cv) == rv
 
+@testset "reverse! (issue #45870)" begin
+    @testset for n in [4,5]
+        offset = typemax(Int)-n
+        vo = OffsetArray([1:n;], offset)
+        vo2 = OffsetArray([1:n;], offset)
+        @test reverse!(vo) == OffsetArray(n:-1:1, offset)
+        @test reverse!(vo) == vo2
+        @test reverse!(vo, firstindex(vo)+1) == OffsetArray([1;n:-1:2], offset)
+        @test reverse!(vo2, firstindex(vo)+1, lastindex(vo)-1) == OffsetArray([1;n-1:-1:2;n], offset)
+    end
+end
+
 A = OffsetArray(rand(4,4), (-3,5))
 @test lastindex(A) == 16
 @test lastindex(A, 1) == 1

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -421,6 +421,11 @@ cv = copy(v)
         vo2 = OffsetArray([1:n;], offset)
         @test reverse!(vo) == OffsetArray(n:-1:1, offset)
         @test reverse!(vo) == vo2
+        @test_throws BoundsError reverse!(vo, firstindex(vo)-1, firstindex(vo))
+        @test reverse!(vo, firstindex(vo), firstindex(vo)-1) == vo2
+        @test reverse!(vo, firstindex(vo), firstindex(vo)) == vo2
+        @test reverse!(vo, lastindex(vo), lastindex(vo)) == vo2
+        @test reverse!(vo, lastindex(vo), lastindex(vo)+1) == vo2 # overflow in stop
         @test reverse!(vo, firstindex(vo)+1) == OffsetArray([1;n:-1:2], offset)
         @test reverse!(vo2, firstindex(vo)+1, lastindex(vo)-1) == OffsetArray([1;n-1:-1:2;n], offset)
     end


### PR DESCRIPTION
Move `midpoint` from `Base.Sort` to `Base` and use it to avoid integer overflow. Now
```julia
julia> vo = OffsetArray([1:4;], typemax(Int)-4)
4-element OffsetArray(::Vector{Int64}, 9223372036854775804:9223372036854775807) with eltype Int64 with indices 9223372036854775804:9223372036854775807:
 1
 2
 3
 4

julia> reverse!(vo)
4-element OffsetArray(::Vector{Int64}, 9223372036854775804:9223372036854775807) with eltype Int64 with indices 9223372036854775804:9223372036854775807:
 4
 3
 2
 1
```
Fixes #45870