### PR TITLE
Loosen type signature on Dates' otherperiod_seed

### DIFF
--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -480,7 +480,7 @@ Base.promote_rule(::Type{Quarter}, ::Type{Month}) = Month
 
 const zero_or_fixedperiod_seed = UInt === UInt64 ? 0x5b7fc751bba97516 : 0xeae0fdcb
 const nonzero_otherperiod_seed = UInt === UInt64 ? 0xe1837356ff2d2ac9 : 0x170d1b00
-otherperiod_seed(x::OtherPeriod) = iszero(value(x)) ? zero_or_fixedperiod_seed : nonzero_otherperiod_seed
+otherperiod_seed(x) = iszero(value(x)) ? zero_or_fixedperiod_seed : nonzero_otherperiod_seed
 # tons() will overflow for periods longer than ~300,000 years, implying a hash collision
 # which is relatively harmless given how infrequent such periods should appear
 Base.hash(x::FixedPeriod, h::UInt) = hash(tons(x), h + zero_or_fixedperiod_seed)


### PR DESCRIPTION
I want this change so that I can use `Dates.otherperiod_seed(x::Semester)` in ExtendedDates, even though `Semester` is not a subtype of `cost OtherPeriod = union{Year, Quarter, Month}`.

I think this is acceptable because the function is not exported and already has "otherperiod" in the name.

Adding a new identical declaration for `::Semester` in ExtendedDates is an easy workaround if folks don't like this change.