### PR TITLE
Fix introspection macros on simple dot symbol call

### DIFF
--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -44,7 +44,7 @@ function gen_call_with_extracted_types(__module__, fcn, ex0, kws=Expr[])
         end
         if ex0.head === :. || (ex0.head === :call && ex0.args[1] !== :.. && string(ex0.args[1])[1] == '.')
             codemacro = startswith(string(fcn), "code_")
-            if codemacro && ex0.args[2] isa Expr
+            if codemacro && (ex0.head === :call || ex0.args[2] isa Expr)
                 # Manually wrap a dot call in a function
                 args = Any[]
                 ex, i = recursive_dotcalls!(copy(ex0), args)

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -383,6 +383,13 @@ a14637 = A14637(0)
 @test (@code_typed max.(Ref(true).x))[2] == Bool
 @test !isempty(@code_typed optimize=false max.(Ref.([5, 6])...))
 
+# Issue # 45889
+@test !isempty(@code_typed 3 .+ 6)
+@test !isempty(@code_typed 3 .+ 6 .+ 7)
+@test !isempty(@code_typed optimize=false (.- [3,4]))
+@test !isempty(@code_typed optimize=false (6 .- [3,4]))
+@test !isempty(@code_typed optimize=false (.- 0.5))
+
 # Issue #36261
 @test (@code_typed max.(1 .+ 3, 5 - 7))[2] == Int
 f36261(x,y) = 3x + 4y


### PR DESCRIPTION
Fix #45889. With this PR:
```julia
julia> @code_lowered 1 .+ 1
CodeInfo(
1 ─ %1 = Base.broadcasted(Main.:+, x1, x2)
│   %2 = Base.materialize(%1)
└──      return %2
)

julia> @code_lowered .- 0.5
CodeInfo(
1 ─ %1 = Base.broadcasted(Main.:-, x1)
│   %2 = Base.materialize(%1)
└──      return %2
)
```