### PR TITLE
codegen: warn on unbound static parameter

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1867,6 +1867,7 @@ function abstract_eval_value_expr(interp::AbstractInterpreter, e::Expr, vtypes::
         t = Any
         if 1 <= n <= length(sv.sptypes)
             t = sv.sptypes[n]
+            sv.spbound[n] = true
         end
         return t
     elseif e.head === :boundscheck
@@ -2086,9 +2087,9 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
         elseif isexpr(sym, :static_parameter)
             n = sym.args[1]::Int
             if 1 <= n <= length(sv.sptypes)
-                spty = sv.sptypes[n]
-                if isa(spty, Const)
+                if isa(sv.sptypes[n], Const)
                     t = Const(true)
+                    sv.spbound[n] = true
                 end
             end
         end

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -86,6 +86,7 @@ mutable struct InferenceState
     world::UInt
     mod::Module
     sptypes::Vector{Any}
+    spbound::Vector{Bool}  # bound static parameter
     slottypes::Vector{Any}
     src::CodeInfo
     cfg::CFG
@@ -188,7 +189,7 @@ mutable struct InferenceState
         cached = cache === :global
 
         frame = new(
-            linfo, world, mod, sptypes, slottypes, src, cfg,
+            linfo, world, mod, sptypes, fill(false, length(sptypes)), slottypes, src, cfg,
             currbb, currpc, ip, handler_at, ssavalue_uses, bb_vartables, ssavaluetypes, stmt_edges, stmt_info,
             pclimitations, limitations, cycle_backedges, callers_in_cycle, dont_work_on_me, parent, inferred,
             result, valid_worlds, bestguess, ipo_effects,

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -1037,6 +1037,16 @@ function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance)
     frame === nothing && return nothing
     typeinf(interp, frame)
     ccall(:jl_typeinf_end, Cvoid, ())
+    for (sparam, bound) in zip(mi.sparam_vals, frame.spbound)
+        if sparam isa TypeVar && has_free_typevars(sparam) && !bound
+            println(
+                stderr,
+                "WARNING: [", mi.def.file, ':', mi.def.line, "] in method ",
+                mi.def.name, ", static parameter ", sparam.name, " is unbound",
+            )
+        end
+    end
+
     frame.src.inferred || return nothing
     return frame.src
 end

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -39,7 +39,7 @@ static int typeenv_has(jl_typeenv_t *env, jl_tvar_t *v) JL_NOTSAFEPOINT
 
 static int layout_uses_free_typevars(jl_value_t *v, jl_typeenv_t *env)
 {
-    if (jl_typeis(v, jl_tvar_type))
+    if (jl_is_typevar(v))
         return !typeenv_has(env, (jl_tvar_t*)v);
     if (jl_is_uniontype(v))
         return layout_uses_free_typevars(((jl_uniontype_t*)v)->a, env) ||
@@ -84,7 +84,7 @@ static int layout_uses_free_typevars(jl_value_t *v, jl_typeenv_t *env)
 
 static int has_free_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT
 {
-    if (jl_typeis(v, jl_tvar_type)) {
+    if (jl_is_typevar(v)) {
         return !typeenv_has(env, (jl_tvar_t*)v);
     }
     if (jl_is_uniontype(v))
@@ -125,7 +125,7 @@ JL_DLLEXPORT int jl_has_free_typevars(jl_value_t *v) JL_NOTSAFEPOINT
 
 static void find_free_typevars(jl_value_t *v, jl_typeenv_t *env, jl_array_t *out)
 {
-    if (jl_typeis(v, jl_tvar_type)) {
+    if (jl_is_typevar(v)) {
         if (!typeenv_has(env, (jl_tvar_t*)v))
             jl_array_ptr_1d_push(out, v);
     }
@@ -170,7 +170,7 @@ JL_DLLEXPORT jl_array_t *jl_find_free_typevars(jl_value_t *v)
 // test whether a type has vars bound by the given environment
 static int jl_has_bound_typevars(jl_value_t *v, jl_typeenv_t *env) JL_NOTSAFEPOINT
 {
-    if (jl_typeis(v, jl_tvar_type))
+    if (jl_is_typevar(v))
         return typeenv_has(env, (jl_tvar_t*)v);
     if (jl_is_uniontype(v))
         return jl_has_bound_typevars(((jl_uniontype_t*)v)->a, env) ||


### PR DESCRIPTION
This is a proposal which fixes https://github.com/JuliaLang/julia/issues/29393, specifically by adding a warning as proposed in https://github.com/JuliaLang/julia/issues/29393#issuecomment-425145817.

With this PR applied, some of the following examples collected from the linked issues of https://github.com/JuliaLang/julia/issues/29393 are throwing a warning (format to be discussed ?) when unnecessary boxing occurs because of some unbound static parameter:

**unbound.jl**
```julia
using InteractiveUtils

f1(y::T) where {T} = 2y
f2(y::T) where {N, T} = 2y  # 29393
f3(x::Union{Vector{T}, NTuple{N, T}}) where {N, T} = x[1]  # 40681
f4(::Type{T}, x) where {T} = 2x  # 33847
f5(x::Int) where {T} = 2x  # 35935, 45846

@code_llvm f1(1)  # good
@code_llvm f2(1)  # bad
@code_llvm f3([1])  # bad
@code_llvm f3((1, 2))  # good
@code_llvm f4(Bool, 1)  # good
@code_llvm f5(1)  # bad
```

<details><summary>Output running $ julia unbound.jl</summary>

```llvm
;  @ [...]/unbound.jl:3 within `f1`
define i64 @julia_f1_236(i64 signext %0) #0 {
top:
; ┌ @ int.jl:88 within `*`
   %1 = shl i64 %0, 1
; └
  ret i64 %1
}

WARNING: [Symbol("[...]/unbound.jl"):4] in method :f2, static parameter :N is unbound
;  @ [...]/unbound.jl:4 within `f2`
define nonnull {}* @japi3_f2_269({}* %0, {}** %1, i32 %2, {}** %3) #0 {
top:
  %4 = alloca {}**, align 8
  store volatile {}** %1, {}*** %4, align 8
  %5 = bitcast {}** %1 to i64**
  %6 = load i64*, i64** %5, align 8
; ┌ @ int.jl:88 within `*`
   %7 = load i64, i64* %6, align 8
   %8 = shl i64 %7, 1
; └
  %9 = call nonnull {}* @jl_box_int64(i64 signext %8)
  ret {}* %9
}

WARNING: [Symbol("[...]/unbound.jl"):5] in method :f3, static parameter :N is unbound
;  @ [...]/unbound.jl:5 within `f3`
define nonnull {}* @japi3_f3_270({}* %0, {}** %1, i32 %2, {}** %3) #0 {
top:
  %4 = alloca {}**, align 8
  store volatile {}** %1, {}*** %4, align 8
  %5 = load {}*, {}** %1, align 8
; ┌ @ array.jl:861 within `getindex`
   %6 = bitcast {}* %5 to { i8*, i64, i16, i16, i32 }*
   %7 = getelementptr inbounds { i8*, i64, i16, i16, i32 }, { i8*, i64, i16, i16, i32 }* %6, i64 0, i32 1
   %8 = load i64, i64* %7, align 8
   %.not = icmp eq i64 %8, 0
   br i1 %.not, label %oob, label %idxend

oob:                                              ; preds = %top
   %9 = alloca i64, align 8
   store i64 1, i64* %9, align 8
   call void @jl_bounds_error_ints({}* %5, i64* nonnull %9, i64 1)
   unreachable

idxend:                                           ; preds = %top
   %10 = bitcast {}* %5 to i64**
   %11 = load i64*, i64** %10, align 8
   %12 = load i64, i64* %11, align 8
; └
  %13 = call nonnull {}* @jl_box_int64(i64 signext %12)
  ret {}* %13
}

;  @ [...]/unbound.jl:5 within `f3`
define i64 @julia_f3_271([2 x i64]* nocapture nonnull readonly align 8 dereferenceable(16) %0) #0 {
top:
; ┌ @ tuple.jl:29 within `getindex`
   %1 = getelementptr inbounds [2 x i64], [2 x i64]* %0, i64 0, i64 0
; └
  %2 = load i64, i64* %1, align 8
  ret i64 %2
}

;  @ [...]/unbound.jl:6 within `f4`
define i64 @julia_f4_274(i64 signext %0) #0 {
top:
; ┌ @ int.jl:88 within `*`
   %1 = shl i64 %0, 1
; └
  ret i64 %1
}

WARNING: [Symbol("[...]/unbound.jl"):7] in method :f5, static parameter :T is unbound
;  @ [...]/unbound.jl:7 within `f5`
define nonnull {}* @japi3_f5_276({}* %0, {}** %1, i32 %2, {}** %3) #0 {
top:
  %4 = alloca {}**, align 8
  store volatile {}** %1, {}*** %4, align 8
  %5 = bitcast {}** %1 to i64**
  %6 = load i64*, i64** %5, align 8
; ┌ @ int.jl:88 within `*`
   %7 = load i64, i64* %6, align 8
   %8 = shl i64 %7, 1
; └
  %9 = call nonnull {}* @jl_box_int64(i64 signext %8)
  ret {}* %9
}
```
</details>

While working on this PR, I modified a few things in `codegen.cpp` and `jltypes.c` (I thought it wasn't worth making a separate PR): I'd be happy to split that to another PR if I was wrong.

I'm unsure how to write corresponding tests for these new warnings in `CI` (if needed), so any advice is welcome. From the warnings thrown by the test suite, there doesn't seem to be false positives at first glance.