### PR TITLE
Remove unnecessary name qualification in docstrings

### DIFF
--- a/stdlib/Dates/src/Dates.jl
+++ b/stdlib/Dates/src/Dates.jl
@@ -14,13 +14,13 @@ For time zone functionality, see the TimeZones.jl package.
 julia> dt = DateTime(2017,12,31,23,59,59,999)
 2017-12-31T23:59:59.999
 
-julia> d1 = Date(Dates.Month(12), Dates.Year(2017))
+julia> d1 = Date(Month(12), Year(2017))
 2017-12-01
 
-julia> d2 = Date("2017-12-31", Dates.DateFormat("y-m-d"))
+julia> d2 = Date("2017-12-31", DateFormat("y-m-d"))
 2017-12-31
 
-julia> Dates.yearmonthday(d2)
+julia> yearmonthday(d2)
 (2017, 12, 31)
 
 julia> d2-d1

--- a/stdlib/Dates/src/accessors.jl
+++ b/stdlib/Dates/src/accessors.jl
@@ -97,13 +97,13 @@ week of 2004.
 
 # Examples
 ```jldoctest
-julia> Dates.week(Date(1989, 6, 22))
+julia> week(Date(1989, 6, 22))
 25
 
-julia> Dates.week(Date(2005, 1, 1))
+julia> week(Date(2005, 1, 1))
 53
 
-julia> Dates.week(Date(2004, 12, 31))
+julia> week(Date(2004, 12, 31))
 53
 ```
 """

--- a/stdlib/Dates/src/adjusters.jl
+++ b/stdlib/Dates/src/adjusters.jl
@@ -29,7 +29,7 @@ Truncates the value of `dt` according to the provided `Period` type.
 
 # Examples
 ```jldoctest
-julia> trunc(Dates.DateTime("1996-01-01T12:30:00"), Dates.Day)
+julia> trunc(DateTime("1996-01-01T12:30:00"), Day)
 1996-01-01T00:00:00
 ```
 """
@@ -43,7 +43,7 @@ Adjusts `dt` to the Monday of its week.
 
 # Examples
 ```jldoctest
-julia> Dates.firstdayofweek(DateTime("1996-01-05T12:30:00"))
+julia> firstdayofweek(DateTime("1996-01-05T12:30:00"))
 1996-01-01T00:00:00
 ```
 """
@@ -59,7 +59,7 @@ Adjusts `dt` to the Sunday of its week.
 
 # Examples
 ```jldoctest
-julia> Dates.lastdayofweek(DateTime("1996-01-05T12:30:00"))
+julia> lastdayofweek(DateTime("1996-01-05T12:30:00"))
 1996-01-07T00:00:00
 ```
 """
@@ -75,7 +75,7 @@ Adjusts `dt` to the first day of its month.
 
 # Examples
 ```jldoctest
-julia> Dates.firstdayofmonth(DateTime("1996-05-20"))
+julia> firstdayofmonth(DateTime("1996-05-20"))
 1996-05-01T00:00:00
 ```
 """
@@ -91,7 +91,7 @@ Adjusts `dt` to the last day of its month.
 
 # Examples
 ```jldoctest
-julia> Dates.lastdayofmonth(DateTime("1996-05-20"))
+julia> lastdayofmonth(DateTime("1996-05-20"))
 1996-05-31T00:00:00
 ```
 """
@@ -110,7 +110,7 @@ Adjusts `dt` to the first day of its year.
 
 # Examples
 ```jldoctest
-julia> Dates.firstdayofyear(DateTime("1996-05-20"))
+julia> firstdayofyear(DateTime("1996-05-20"))
 1996-01-01T00:00:00
 ```
 """
@@ -126,7 +126,7 @@ Adjusts `dt` to the last day of its year.
 
 # Examples
 ```jldoctest
-julia> Dates.lastdayofyear(DateTime("1996-05-20"))
+julia> lastdayofyear(DateTime("1996-05-20"))
 1996-12-31T00:00:00
 ```
 """
@@ -145,10 +145,10 @@ Adjusts `dt` to the first day of its quarter.
 
 # Examples
 ```jldoctest
-julia> Dates.firstdayofquarter(DateTime("1996-05-20"))
+julia> firstdayofquarter(DateTime("1996-05-20"))
 1996-04-01T00:00:00
 
-julia> Dates.firstdayofquarter(DateTime("1996-08-20"))
+julia> firstdayofquarter(DateTime("1996-08-20"))
 1996-07-01T00:00:00
 ```
 """
@@ -168,10 +168,10 @@ Adjusts `dt` to the last day of its quarter.
 
 # Examples
 ```jldoctest
-julia> Dates.lastdayofquarter(DateTime("1996-05-20"))
+julia> lastdayofquarter(DateTime("1996-05-20"))
 1996-06-30T00:00:00
 
-julia> Dates.lastdayofquarter(DateTime("1996-08-20"))
+julia> lastdayofquarter(DateTime("1996-08-20"))
 1996-09-30T00:00:00
 ```
 """
@@ -221,13 +221,13 @@ pursue before throwing an error (given that `f::Function` is never satisfied).
 
 # Examples
 ```jldoctest
-julia> Date(date -> Dates.week(date) == 20, 2010, 01, 01)
+julia> Date(date -> week(date) == 20, 2010, 01, 01)
 2010-05-17
 
-julia> Date(date -> Dates.year(date) == 2010, 2000, 01, 01)
+julia> Date(date -> year(date) == 2010, 2000, 01, 01)
 2010-01-01
 
-julia> Date(date -> Dates.month(date) == 10, 2000, 01, 01; limit = 5)
+julia> Date(date -> month(date) == 10, 2000, 01, 01; limit = 5)
 ERROR: ArgumentError: Adjustment limit reached: 5 iterations
 Stacktrace:
 [...]
@@ -248,10 +248,10 @@ pursue before throwing an error (in the case that `f::Function` is never satisfi
 
 # Examples
 ```jldoctest
-julia> DateTime(dt -> Dates.second(dt) == 40, 2010, 10, 20, 10; step = Dates.Second(1))
+julia> DateTime(dt -> second(dt) == 40, 2010, 10, 20, 10; step = Second(1))
 2010-10-20T10:00:40
 
-julia> DateTime(dt -> Dates.hour(dt) == 20, 2010, 10, 20, 10; step = Dates.Hour(1), limit = 5)
+julia> DateTime(dt -> hour(dt) == 20, 2010, 10, 20, 10; step = Hour(1), limit = 5)
 ERROR: ArgumentError: Adjustment limit reached: 5 iterations
 Stacktrace:
 [...]
@@ -291,13 +291,13 @@ arguments are provided, the default step will be `Millisecond(1)` instead of `Se
 
 # Examples
 ```jldoctest
-julia> Dates.Time(t -> Dates.minute(t) == 30, 20)
+julia> Time(t -> minute(t) == 30, 20)
 20:30:00
 
-julia> Dates.Time(t -> Dates.minute(t) == 0, 20)
+julia> Time(t -> minute(t) == 0, 20)
 20:00:00
 
-julia> Dates.Time(t -> Dates.hour(t) == 10, 3; limit = 5)
+julia> Time(t -> hour(t) == 10, 3; limit = 5)
 ERROR: ArgumentError: Adjustment limit reached: 5 iterations
 Stacktrace:
 [...]

--- a/stdlib/Dates/src/periods.jl
+++ b/stdlib/Dates/src/periods.jl
@@ -250,16 +250,16 @@ Reduces the `CompoundPeriod` into its canonical form by applying the following r
 
 # Examples
 ```jldoctest
-julia> Dates.canonicalize(Dates.CompoundPeriod(Dates.Hour(12), Dates.Hour(13)))
+julia> canonicalize(Dates.CompoundPeriod(Dates.Hour(12), Dates.Hour(13)))
 1 day, 1 hour
 
-julia> Dates.canonicalize(Dates.CompoundPeriod(Dates.Hour(-1), Dates.Minute(1)))
+julia> canonicalize(Dates.CompoundPeriod(Dates.Hour(-1), Dates.Minute(1)))
 -59 minutes
 
-julia> Dates.canonicalize(Dates.CompoundPeriod(Dates.Month(1), Dates.Week(-2)))
+julia> canonicalize(Dates.CompoundPeriod(Dates.Month(1), Dates.Week(-2)))
 1 month, -2 weeks
 
-julia> Dates.canonicalize(Dates.CompoundPeriod(Dates.Minute(50000)))
+julia> canonicalize(Dates.CompoundPeriod(Dates.Minute(50000)))
 4 weeks, 6 days, 17 hours, 20 minutes
 ```
 """

--- a/stdlib/Dates/src/query.jl
+++ b/stdlib/Dates/src/query.jl
@@ -93,10 +93,10 @@ Return 366 if the year of `dt` is a leap year, otherwise return 365.
 
 # Examples
 ```jldoctest
-julia> Dates.daysinyear(1999)
+julia> daysinyear(1999)
 365
 
-julia> Dates.daysinyear(2000)
+julia> daysinyear(2000)
 366
 ```
 """
@@ -114,7 +114,7 @@ Return the day of the week as an [`Int64`](@ref) with `1 = Monday, 2 = Tuesday, 
 
 # Examples
 ```jldoctest
-julia> Dates.dayofweek(Date("2000-01-01"))
+julia> dayofweek(Date("2000-01-01"))
 6
 ```
 """
@@ -159,10 +159,10 @@ the given `locale`. Also accepts `Integer`.
 
 # Examples
 ```jldoctest
-julia> Dates.dayname(Date("2000-01-01"))
+julia> dayname(Date("2000-01-01"))
 "Saturday"
 
-julia> Dates.dayname(4)
+julia> dayname(4)
 "Thursday"
 ```
 """
@@ -179,10 +179,10 @@ in the given `locale`. Also accepts `Integer`.
 
 # Examples
 ```jldoctest
-julia> Dates.dayabbr(Date("2000-01-01"))
+julia> dayabbr(Date("2000-01-01"))
 "Sat"
 
-julia> Dates.dayabbr(3)
+julia> dayabbr(3)
 "Wed"
 ```
 """
@@ -209,13 +209,13 @@ month, etc.` In the range 1:5.
 
 # Examples
 ```jldoctest
-julia> Dates.dayofweekofmonth(Date("2000-02-01"))
+julia> dayofweekofmonth(Date("2000-02-01"))
 1
 
-julia> Dates.dayofweekofmonth(Date("2000-02-08"))
+julia> dayofweekofmonth(Date("2000-02-08"))
 2
 
-julia> Dates.dayofweekofmonth(Date("2000-02-15"))
+julia> dayofweekofmonth(Date("2000-02-15"))
 3
 ```
 """
@@ -240,10 +240,10 @@ function.
 
 # Examples
 ```jldoctest
-julia> Dates.daysofweekinmonth(Date("2005-01-01"))
+julia> daysofweekinmonth(Date("2005-01-01"))
 5
 
-julia> Dates.daysofweekinmonth(Date("2005-01-04"))
+julia> daysofweekinmonth(Date("2005-01-04"))
 4
 ```
 """
@@ -569,10 +569,10 @@ Return the full name of the month of the `Date` or `DateTime` or `Integer` in th
 
 # Examples
 ```jldoctest
-julia> Dates.monthname(Date("2005-01-04"))
+julia> monthname(Date("2005-01-04"))
 "January"
 
-julia> Dates.monthname(2)
+julia> monthname(2)
 "February"
 ```
 """
@@ -588,7 +588,7 @@ Return the abbreviated month name of the `Date` or `DateTime` or `Integer` in th
 
 # Examples
 ```jldoctest
-julia> Dates.monthabbr(Date("2005-01-04"))
+julia> monthabbr(Date("2005-01-04"))
 "Jan"
 
 julia> monthabbr(2)
@@ -606,13 +606,13 @@ Return the number of days in the month of `dt`. Value will be 28, 29, 30, or 31.
 
 # Examples
 ```jldoctest
-julia> Dates.daysinmonth(Date("2000-01"))
+julia> daysinmonth(Date("2000-01"))
 31
 
-julia> Dates.daysinmonth(Date("2001-02"))
+julia> daysinmonth(Date("2001-02"))
 28
 
-julia> Dates.daysinmonth(Date("2000-02"))
+julia> daysinmonth(Date("2000-02"))
 29
 ```
 """
@@ -626,10 +626,10 @@ Return `true` if the year of `dt` is a leap year.
 
 # Examples
 ```jldoctest
-julia> Dates.isleapyear(Date("2004"))
+julia> isleapyear(Date("2004"))
 true
 
-julia> Dates.isleapyear(Date("2005"))
+julia> isleapyear(Date("2005"))
 false
 ```
 """

--- a/stdlib/Dates/src/rounding.jl
+++ b/stdlib/Dates/src/rounding.jl
@@ -94,13 +94,13 @@ For convenience, `precision` may be a type instead of a value: `floor(x, Dates.H
 shortcut for `floor(x, Dates.Hour(1))`.
 
 ```jldoctest
-julia> floor(Dates.Day(16), Dates.Week)
+julia> floor(Day(16), Week)
 2 weeks
 
-julia> floor(Dates.Minute(44), Dates.Minute(15))
+julia> floor(Minute(44), Minute(15))
 30 minutes
 
-julia> floor(Dates.Hour(36), Dates.Day)
+julia> floor(Hour(36), Day)
 1 day
 ```
 
@@ -122,13 +122,13 @@ For convenience, `p` may be a type instead of a value: `floor(dt, Dates.Hour)` i
 for `floor(dt, Dates.Hour(1))`.
 
 ```jldoctest
-julia> floor(Date(1985, 8, 16), Dates.Month)
+julia> floor(Date(1985, 8, 16), Month)
 1985-08-01
 
-julia> floor(DateTime(2013, 2, 13, 0, 31, 20), Dates.Minute(15))
+julia> floor(DateTime(2013, 2, 13, 0, 31, 20), Minute(15))
 2013-02-13T00:30:00
 
-julia> floor(DateTime(2016, 8, 6, 12, 0, 0), Dates.Day)
+julia> floor(DateTime(2016, 8, 6, 12, 0, 0), Day)
 2016-08-06T00:00:00
 ```
 """
@@ -143,13 +143,13 @@ For convenience, `p` may be a type instead of a value: `ceil(dt, Dates.Hour)` is
 for `ceil(dt, Dates.Hour(1))`.
 
 ```jldoctest
-julia> ceil(Date(1985, 8, 16), Dates.Month)
+julia> ceil(Date(1985, 8, 16), Month)
 1985-09-01
 
-julia> ceil(DateTime(2013, 2, 13, 0, 31, 20), Dates.Minute(15))
+julia> ceil(DateTime(2013, 2, 13, 0, 31, 20), Minute(15))
 2013-02-13T00:45:00
 
-julia> ceil(DateTime(2016, 8, 6, 12, 0, 0), Dates.Day)
+julia> ceil(DateTime(2016, 8, 6, 12, 0, 0), Day)
 2016-08-07T00:00:00
 ```
 """
@@ -168,13 +168,13 @@ For convenience, `precision` may be a type instead of a value: `ceil(x, Dates.Ho
 shortcut for `ceil(x, Dates.Hour(1))`.
 
 ```jldoctest
-julia> ceil(Dates.Day(16), Dates.Week)
+julia> ceil(Day(16), Week)
 3 weeks
 
-julia> ceil(Dates.Minute(44), Dates.Minute(15))
+julia> ceil(Minute(44), Minute(15))
 45 minutes
 
-julia> ceil(Dates.Hour(36), Dates.Day)
+julia> ceil(Hour(36), Day)
 2 days
 ```
 
@@ -218,13 +218,13 @@ For convenience, `p` may be a type instead of a value: `round(dt, Dates.Hour)` i
 for `round(dt, Dates.Hour(1))`.
 
 ```jldoctest
-julia> round(Date(1985, 8, 16), Dates.Month)
+julia> round(Date(1985, 8, 16), Month)
 1985-08-01
 
-julia> round(DateTime(2013, 2, 13, 0, 31, 20), Dates.Minute(15))
+julia> round(DateTime(2013, 2, 13, 0, 31, 20), Minute(15))
 2013-02-13T00:30:00
 
-julia> round(DateTime(2016, 8, 6, 12, 0, 0), Dates.Day)
+julia> round(DateTime(2016, 8, 6, 12, 0, 0), Day)
 2016-08-07T00:00:00
 ```
 
@@ -248,13 +248,13 @@ For convenience, `precision` may be a type instead of a value: `round(x, Dates.H
 shortcut for `round(x, Dates.Hour(1))`.
 
 ```jldoctest
-julia> round(Dates.Day(16), Dates.Week)
+julia> round(Day(16), Week)
 2 weeks
 
-julia> round(Dates.Minute(44), Dates.Minute(15))
+julia> round(Minute(44), Minute(15))
 45 minutes
 
-julia> round(Dates.Hour(36), Dates.Day)
+julia> round(Hour(36), Day)
 2 days
 ```
 

--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -87,7 +87,7 @@ is in the repository.
 
 # Examples
 ```julia-repl
-julia> repo = LibGit2.GitRepo(repo_path);
+julia> repo = GitRepo(repo_path);
 
 julia> LibGit2.add!(repo, test_file);
 
@@ -230,7 +230,7 @@ Return `true` if `a`, a [`GitHash`](@ref) in string form, is an ancestor of
 
 # Examples
 ```julia-repl
-julia> repo = LibGit2.GitRepo(repo_path);
+julia> repo = GitRepo(repo_path);
 
 julia> LibGit2.add!(repo, test_file1);
 

--- a/stdlib/LibGit2/src/reference.jl
+++ b/stdlib/LibGit2/src/reference.jl
@@ -53,7 +53,7 @@ Return a shortened version of the name of `ref` that's
 "human-readable".
 
 ```julia-repl
-julia> repo = LibGit2.GitRepo(path_to_repo);
+julia> repo = GitRepo(path_to_repo);
 
 julia> branch_ref = LibGit2.head(repo);
 

--- a/stdlib/LinearAlgebra/src/factorization.jl
+++ b/stdlib/LinearAlgebra/src/factorization.jl
@@ -32,12 +32,12 @@ Test that a factorization of a matrix succeeded.
 ```jldoctest
 julia> F = cholesky([1 0; 0 1]);
 
-julia> LinearAlgebra.issuccess(F)
+julia> issuccess(F)
 true
 
 julia> F = lu([1 0; 0 0]; check = false);
 
-julia> LinearAlgebra.issuccess(F)
+julia> issuccess(F)
 false
 ```
 """

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -315,9 +315,9 @@ see [`QR`](@ref).
 ```jldoctest
 julia> A = [0 1; 1 0];
 
-julia> B = LinearAlgebra.UpperTriangular([1 2; 0 3]);
+julia> B = UpperTriangular([1 2; 0 3]);
 
-julia> LinearAlgebra.rmul!(A, B);
+julia> rmul!(A, B);
 
 julia> A
 2×2 Matrix{Int64}:
@@ -348,9 +348,9 @@ see [`QR`](@ref).
 ```jldoctest
 julia> B = [0 1; 1 0];
 
-julia> A = LinearAlgebra.UpperTriangular([1 2; 0 3]);
+julia> A = UpperTriangular([1 2; 0 3]);
 
-julia> LinearAlgebra.lmul!(A, B);
+julia> lmul!(A, B);
 
 julia> B
 2×2 Matrix{Int64}:

--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -170,7 +170,7 @@ using the operating system's underlying `getnameinfo` implementation.
 
 # Examples
 ```julia-repl
-julia> getnameinfo(Sockets.IPv4("8.8.8.8"))
+julia> getnameinfo(IPv4("8.8.8.8"))
 "google-public-dns-a.google.com"
 ```
 """


### PR DESCRIPTION
When we give an example usage of an exported name such as
```julia
julia> Dates.lastdayofweek(DateTime("1996-01-05T12:30:00"))
1996-01-07T00:00:00
```
We should not qualify the name because this implies (falsely) that `lastdayofweek` is not exported.

Specifically, any example REPL usage of an exported symbol from a stdlib, when the example comes from a docstring defined by that stdlib, should use the unqualified name. I define "exported" to be `Main.sybmol` is defined and `Main.symbol === Stdlib.symbol`.

I made these changes with the following script:

```julia
function f()
    stdlibs = filter(readdir("stdlib")) do name
        
        # IDK how _jll's work, but I bet it makes sense to skip them.
        endswith(name, "_jll") && return false

        try
            @eval using $(Symbol(name))
            true
        catch 
            false
        end
    end

    count = 0
    for (root, _, files) in walkdir("stdlib")
        for file in files
            if endswith(file, ".jl")
                replacements = Pair{String, String}[]
                path = joinpath(root, file)

                match = "julia> "
                i = firstindex(match)
                open(path) do f
                    while !eof(f)
                        char = read(f, Char)
                        i = char == match[i] ? i + 1 : firstindex(match)
                        if i == lastindex(match) + 1
                            i = firstindex(match)
                            buff = Char[]
                            while !eof(f)
                                char = read(f, Char)
                                char == '\n' && break
                                push!(buff, char)
                            end
                            str = String(buff)
                            for stdlib in stdlibs
                                if contains(str, stdlib * '.')
                                    loc = findfirst(stdlib * '.', str)
                                    buff2 = Char[]
                                    for i in last(loc)+1:lastindex(str)
                                        char = str[i]
                                        char ∈ vcat('a':'z', 'A':'Z', '0':'9', ['_','!']) || break
                                        push!(buff2, char)
                                    end
                                    str2 = String(buff2)
                                    
                                    if isdefined(Main, Symbol(str2)) && occursin(stdlib, root) && 
                                            @eval(Main.$(Symbol(str2))) === @eval($(Symbol(stdlib)).$(Symbol(str2)))

                                        push!(replacements, "julia> " * str => "julia> " * str[begin:first(loc)-1] * str[last(loc)+1:end])
                                        count += 1
                                    end
                                end
                            end
                        end
                    end
                end

                if !isempty(replacements)
                    contents = read(path, String)
                    contents = replace(contents, replacements...)
                    write(path, contents)
                end
            end
        end
    end
    count
end
for _ in 1:3
    println(f())
end
# 77
# 16
# 0
```