### PR TITLE
fix freeze on `@threads` loop exit

### DIFF
--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -60,6 +60,7 @@ void JL_UV_LOCK(void)
     }
     else {
         jl_atomic_fetch_add_relaxed(&jl_uv_n_waiters, 1);
+        jl_fence(); // [^store_buffering_2]
         jl_wake_libuv();
         JL_LOCK(&jl_uv_mutex);
         jl_atomic_fetch_add_relaxed(&jl_uv_n_waiters, -1);


### PR DESCRIPTION
Closes #45626, hopefully. I don't have the hardware available to reproduce this, but I think this fence was missing.

It also perhaps might be considered a defect in libuv, since it explicitly does a "cheap read" here:
https://github.com/libuv/libuv/blob/master/src/unix/async.c#L65
https://github.com/libuv/libuv/blob/master/src/win/async.c#L58
But that might not agree with the doc's claim that "If uv_async_send() is called again after the callback was called, it will be called again", if we think that means there should exist an implied happens-before edge. But the wording is imprecise as to how it defines "after the callback" on the other thread. The fast-read optimization is never required to observe the other thread's behavior, so it is never required to call the callback again, unless the user of libuv inserts their own synchronization fences that enforce progress.
http://docs.libuv.org/en/v1.x/async.html#c.uv_async_send