### PR TITLE
Explicitly derive alloca AS from DL

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -121,7 +121,10 @@ static Value *stringConstPtr(
     GlobalVariable *gv = get_pointer_to_constant(emission_context, Data, "_j_str", *M);
     Value *zero = ConstantInt::get(Type::getInt32Ty(irbuilder.getContext()), 0);
     Value *Args[] = { zero, zero };
-    return irbuilder.CreateInBoundsGEP(gv->getValueType(), gv, Args);
+    return irbuilder.CreateInBoundsGEP(gv->getValueType(),
+                                       // Addrspacecast in case globals are in non-0 AS
+                                       irbuilder.CreateAddrSpaceCast(gv, gv->getValueType()->getPointerTo(0)),
+                                       Args);
 }
 
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6473,7 +6473,9 @@ static jl_returninfo_t get_specsig_function(jl_codectx_t &ctx, Module *M, String
             if (tracked.count && !tracked.all)
                 props.return_roots = tracked.count;
             props.cc = jl_returninfo_t::SRet;
-            fsig.push_back(rt->getPointerTo());
+            // sret is always passed from alloca
+            assert(M);
+            fsig.push_back(rt->getPointerTo(M->getDataLayout().getAllocaAddrSpace()));
             srt = rt;
             rt = getVoidTy(ctx.builder.getContext());
         }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1565,7 +1565,7 @@ static GlobalVariable *get_pointer_to_constant(jl_codegen_params_t &emission_con
 static AllocaInst *emit_static_alloca(jl_codectx_t &ctx, Type *lty)
 {
     ++EmittedAllocas;
-    return new AllocaInst(lty, 0, "", /*InsertBefore=*/ctx.topalloca);
+    return new AllocaInst(lty, ctx.topalloca->getModule()->getDataLayout().getAllocaAddrSpace(), "", /*InsertBefore=*/ctx.topalloca);
 }
 
 static void undef_derived_strct(IRBuilder<> &irbuilder, Value *ptr, jl_datatype_t *sty, MDNode *tbaa)
@@ -7053,7 +7053,7 @@ static jl_llvm_functions_t
             Type *vtype = julia_type_to_llvm(ctx, jt, &isboxed);
             assert(!isboxed);
             assert(!type_is_ghost(vtype) && "constants should already be handled");
-            Value *lv = new AllocaInst(vtype, 0, jl_symbol_name(s), /*InsertBefore*/ctx.topalloca);
+            Value *lv = new AllocaInst(vtype, M->getDataLayout().getAllocaAddrSpace(), jl_symbol_name(s), /*InsertBefore*/ctx.topalloca);
             if (CountTrackedPointers(vtype).count) {
                 StoreInst *SI = new StoreInst(Constant::getNullValue(vtype), lv, false, Align(sizeof(void*)));
                 SI->insertAfter(ctx.topalloca);
@@ -7072,7 +7072,7 @@ static jl_llvm_functions_t
             specsig || // for arguments, give them stack slots if they aren't in `argArray` (otherwise, will use that pointer)
             (va && (int)i == ctx.vaSlot) || // or it's the va arg tuple
             i == 0) { // or it is the first argument (which isn't in `argArray`)
-            AllocaInst *av = new AllocaInst(ctx.types().T_prjlvalue, 0,
+            AllocaInst *av = new AllocaInst(ctx.types().T_prjlvalue, M->getDataLayout().getAllocaAddrSpace(),
                 jl_symbol_name(s), /*InsertBefore*/ctx.topalloca);
             StoreInst *SI = new StoreInst(Constant::getNullValue(ctx.types().T_prjlvalue), av, false, Align(sizeof(void*)));
             SI->insertAfter(ctx.topalloca);

--- a/src/codegen_shared.h
+++ b/src/codegen_shared.h
@@ -34,8 +34,8 @@ namespace JuliaType {
         return llvm::StructType::get(C);
     }
 
-    static inline llvm::PointerType* get_pjlvalue_ty(llvm::LLVMContext &C) {
-        return llvm::PointerType::get(get_jlvalue_ty(C), 0);
+    static inline llvm::PointerType* get_pjlvalue_ty(llvm::LLVMContext &C, unsigned addressSpace=0) {
+        return llvm::PointerType::get(get_jlvalue_ty(C), addressSpace);
     }
 
     static inline llvm::PointerType* get_prjlvalue_ty(llvm::LLVMContext &C) {

--- a/test/llvmpasses/alloc-opt-gcframe-addrspaces.jl
+++ b/test/llvmpasses/alloc-opt-gcframe-addrspaces.jl
@@ -1,0 +1,40 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# RUN: julia --startup-file=no %s | opt -enable-new-pm=0 -load libjulia-codegen%shlibext -AllocOpt -S - | FileCheck %s
+# RUN: julia --startup-file=no %s | opt -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='function(AllocOpt)' -S - | FileCheck %s
+
+isz = sizeof(UInt) == 8 ? "i64" : "i32"
+
+println("""
+target triple = "amdgcn-amd-amdhsa"
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7-ni:10:11:12:13"
+
+@tag = external addrspace(10) global {}
+
+declare {}*** @julia.ptls_states()
+declare {}*** @julia.get_pgcstack()
+declare noalias {} addrspace(10)* @julia.gc_alloc_obj(i8*, $isz, {} addrspace(10)*)
+declare {}* @julia.pointer_from_objref({} addrspace(11)*)
+""")
+
+# Test that non-0 addrspace allocas are properly emitted and handled
+
+# CHECK-LABEL: @non_zero_addrspace
+# CHECK: %1 = alloca i32, align 8, addrspace(5)
+# CHECK: %2 = bitcast i32 addrspace(5)* %1 to i8 addrspace(5)*
+# CHECK: %3 = bitcast i8 addrspace(5)* %2 to {} addrspace(5)*
+# CHECK: %var1 = addrspacecast {} addrspace(5)* %3 to {} addrspace(10)*
+# CHECK: call void @llvm.lifetime.start.p5i8(i64 4, i8 addrspace(5)* %2)
+# CHECK: ret void
+println("""
+define void @non_zero_addrspace() {
+  %pgcstack = call {}*** @julia.get_pgcstack()
+  %ptls = call {}*** @julia.ptls_states()
+  %ptls_i8 = bitcast {}*** %ptls to i8*
+  %var1 = call {} addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 4, {} addrspace(10)* @tag)
+  %var2 = addrspacecast {} addrspace(10)* %var1 to {} addrspace(11)*
+  %var3 = call {}* @julia.pointer_from_objref({} addrspace(11)* %var2)
+  ret void
+}
+""")
+# CHECK-LABEL: }{{$}}

--- a/test/llvmpasses/final-lower-gc-addrspaces.ll
+++ b/test/llvmpasses/final-lower-gc-addrspaces.ll
@@ -1,0 +1,41 @@
+; RUN: opt -enable-new-pm=0 -load libjulia-codegen%shlibext -FinalLowerGC -S %s | FileCheck %s
+; RUN: opt -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='FinalLowerGC' -S %s | FileCheck %s
+
+target triple = "amdgcn-amd-amdhsa"
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7-ni:10:11:12:13"
+
+@tag = external addrspace(10) global {}
+
+declare void @boxed_simple({} addrspace(10)*, {} addrspace(10)*)
+declare {} addrspace(10)* @ijl_box_int64(i64)
+declare {}*** @julia.ptls_states()
+declare {}*** @julia.get_pgcstack()
+
+declare noalias nonnull {} addrspace(10)** @julia.new_gc_frame(i32)
+declare void @julia.push_gc_frame({} addrspace(10)**, i32)
+declare {} addrspace(10)** @julia.get_gc_frame_slot({} addrspace(10)**, i32)
+declare void @julia.pop_gc_frame({} addrspace(10)**)
+declare noalias nonnull {} addrspace(10)* @julia.gc_alloc_bytes(i8*, i64) #0
+
+attributes #0 = { allocsize(1) }
+
+define void @gc_frame_addrspace(i64 %a, i64 %b) {
+top:
+; CHECK-LABEL: @gc_frame_addrspace
+; CHECK: %0 = alloca {} addrspace(10)*, i32 4, align 16, addrspace(5)
+; CHECK: %gcframe = addrspacecast {} addrspace(10)* addrspace(5)* %0 to {} addrspace(10)**
+; CHECK: %1 = bitcast {} addrspace(10)** %gcframe to i8*
+  %gcframe = call {} addrspace(10)** @julia.new_gc_frame(i32 2)
+  %pgcstack = call {}*** @julia.get_pgcstack()
+  call void @julia.push_gc_frame({} addrspace(10)** %gcframe, i32 2)
+  %aboxed = call {} addrspace(10)* @ijl_box_int64(i64 signext %a)
+  %frame_slot_1 = call {} addrspace(10)** @julia.get_gc_frame_slot({} addrspace(10)** %gcframe, i32 1)
+  store {} addrspace(10)* %aboxed, {} addrspace(10)** %frame_slot_1, align 8
+  %bboxed = call {} addrspace(10)* @ijl_box_int64(i64 signext %b)
+  %frame_slot_2 = call {} addrspace(10)** @julia.get_gc_frame_slot({} addrspace(10)** %gcframe, i32 0)
+  store {} addrspace(10)* %bboxed, {} addrspace(10)** %frame_slot_2, align 8
+  call void @boxed_simple({} addrspace(10)* %aboxed, {} addrspace(10)* %bboxed)
+  call void @julia.pop_gc_frame({} addrspace(10)** %gcframe)
+; CHECK: ret void
+  ret void
+}

--- a/test/llvmpasses/late-lower-gc-addrspaces.ll
+++ b/test/llvmpasses/late-lower-gc-addrspaces.ll
@@ -1,0 +1,153 @@
+; RUN: opt -enable-new-pm=0 -load libjulia-codegen%shlibext -LateLowerGCFrame -S %s | FileCheck %s
+; RUN: opt -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='function(LateLowerGCFrame)' -S %s | FileCheck %s
+
+target triple = "amdgcn-amd-amdhsa"
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7-ni:10:11:12:13"
+
+@tag = external addrspace(10) global {}, align 16
+
+declare void @boxed_simple({} addrspace(10)*, {} addrspace(10)*)
+declare {} addrspace(10)* @jl_box_int64(i64)
+declare {}*** @julia.get_pgcstack()
+declare void @jl_safepoint()
+declare {} addrspace(10)* @jl_apply_generic({} addrspace(10)*, {} addrspace(10)**, i32)
+declare noalias nonnull {} addrspace(10)* @julia.gc_alloc_obj({}**, i64, {} addrspace(10)*)
+declare i32 @rooting_callee({} addrspace(12)*, {} addrspace(12)*)
+
+define void @gc_frame_lowering(i64 %a, i64 %b) {
+top:
+; CHECK-LABEL: @gc_frame_lowering
+; CHECK: %gcframe = call {} addrspace(10)** @julia.new_gc_frame(i32 2)
+; CHECK:  %pgcstack = call {}*** @julia.get_pgcstack()
+    %pgcstack = call {}*** @julia.get_pgcstack()
+; CHECK-NEXT: call void @julia.push_gc_frame({} addrspace(10)** %gcframe, i32 2)
+; CHECK-NEXT: call {} addrspace(10)* @jl_box_int64
+    %aboxed = call {} addrspace(10)* @jl_box_int64(i64 signext %a)
+; CHECK: [[GEP0:%.*]] = call {} addrspace(10)** @julia.get_gc_frame_slot({} addrspace(10)** %gcframe, i32 [[GEPSLOT0:[0-9]+]])
+; CHECK-NEXT: store {} addrspace(10)* %aboxed, {} addrspace(10)** [[GEP0]]
+    %bboxed = call {} addrspace(10)* @jl_box_int64(i64 signext %b)
+; CHECK-NEXT: %bboxed =
+; Make sure the same gc slot isn't re-used
+; CHECK-NOT: call {} addrspace(10)** @julia.get_gc_frame_slot({} addrspace(10)** %gcframe, i32 [[GEPSLOT0]])
+; CHECK: [[GEP1:%.*]] = call {} addrspace(10)** @julia.get_gc_frame_slot({} addrspace(10)** %gcframe, i32 [[GEPSLOT1:[0-9]+]])
+; CHECK-NEXT: store {} addrspace(10)* %bboxed, {} addrspace(10)** [[GEP1]]
+; CHECK-NEXT: call void @boxed_simple
+    call void @boxed_simple({} addrspace(10)* %aboxed,
+                            {} addrspace(10)* %bboxed)
+; CHECK-NEXT: call void @julia.pop_gc_frame({} addrspace(10)** %gcframe)
+    ret void
+}
+
+define {} addrspace(10)* @gc_alloc_lowering() {
+top:
+; CHECK-LABEL: @gc_alloc_lowering
+    %pgcstack = call {}*** @julia.get_pgcstack()
+    %0 = bitcast {}*** %pgcstack to {}**
+    %current_task = getelementptr inbounds {}*, {}** %0, i64 -12
+; CHECK: %current_task = getelementptr inbounds {}*, {}** %0, i64 -12
+; CHECK-NEXT: [[ptls_field:%.*]] = getelementptr inbounds {}*, {}** %current_task, i64 15
+; CHECK-NEXT: [[ptls_load:%.*]] = load {}*, {}** [[ptls_field]], align 8, !tbaa !0
+; CHECK-NEXT: [[ppjl_ptls:%.*]] = bitcast {}* [[ptls_load]] to {}**
+; CHECK-NEXT: [[ptls_i8:%.*]] = bitcast {}** [[ppjl_ptls]] to i8*
+; CHECK-NEXT: %v = call {} addrspace(10)* @julia.gc_alloc_bytes(i8* [[ptls_i8]], [[SIZE_T:i.[0-9]+]] 8)
+; CHECK-NEXT: [[V2:%.*]] = bitcast {} addrspace(10)* %v to {} addrspace(10)* addrspace(10)*
+; CHECK-NEXT: [[V_HEADROOM:%.*]] = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)* addrspace(10)* [[V2]], i64 -1
+; CHECK-NEXT: store atomic {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* [[V_HEADROOM]] unordered, align 8, !tbaa !4
+    %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, i64 8, {} addrspace(10)* @tag)
+; CHECK-NEXT: ret {} addrspace(10)* %v
+    ret {} addrspace(10)* %v
+}
+
+; Confirm that loadedval instruction does not contain invariant.load metadata
+; after the gc placement pass, but still contains the range metadata.
+; Since loadedval is marked invariant, passes are allowed to move the use.
+; But after the placement pass, must ensure it won't be relocated after our
+; last gc-root use
+define void @gc_drop_aliasing() {
+top:
+; CHECK-LABEL: @gc_drop_aliasing
+    %pgcstack = call {}*** @julia.get_pgcstack()
+    %0 = bitcast {}*** %pgcstack to {}**
+    %current_task = getelementptr inbounds {}*, {}** %0, i64 -12
+; CHECK: %current_task = getelementptr inbounds {}*, {}** %0, i64 -12
+; CHECK-NEXT: [[ptls_field:%.*]] = getelementptr inbounds {}*, {}** %current_task, i64 15
+; CHECK-NEXT: [[ptls_load:%.*]] = load {}*, {}** [[ptls_field]], align 8, !tbaa !0
+; CHECK-NEXT: [[ppjl_ptls:%.*]] = bitcast {}* [[ptls_load]] to {}**
+; CHECK-NEXT: [[ptls_i8:%.*]] = bitcast {}** [[ppjl_ptls]] to i8*
+; CHECK-NEXT: %v = call {} addrspace(10)* @julia.gc_alloc_bytes(i8* [[ptls_i8]], [[SIZE_T:i.[0-9]+]] 8)
+; CHECK-NEXT: [[V2:%.*]] = bitcast {} addrspace(10)* %v to {} addrspace(10)* addrspace(10)*
+; CHECK-NEXT: [[V_HEADROOM:%.*]] = getelementptr inbounds {} addrspace(10)*, {} addrspace(10)* addrspace(10)* [[V2]], i64 -1
+; CHECK-NEXT: store atomic {} addrspace(10)* @tag, {} addrspace(10)* addrspace(10)* [[V_HEADROOM]] unordered, align 8, !tbaa !4
+    %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj({}** %current_task, i64 8, {} addrspace(10)* @tag)
+; CHECK-NEXT: %v64 = bitcast {} addrspace(10)* %v to i64 addrspace(10)*
+    %v64 = bitcast {} addrspace(10)* %v to i64 addrspace(10)*
+; CHECK-NEXT: %loadedval = load i64, i64 addrspace(10)* %v64, align 8, !range !7
+    %loadedval = load i64, i64 addrspace(10)* %v64, align 8, !range !0, !invariant.load !1
+; CHECK-NEXT: store i64 %loadedval, i64 addrspace(10)* %v64, align 8, !noalias !8
+    store i64 %loadedval, i64 addrspace(10)* %v64, align 8, !noalias !2
+; CHECK-NEXT: %lv2 = load i64, i64 addrspace(10)* %v64, align 8, !tbaa !11, !range !7
+    %lv2 = load i64, i64 addrspace(10)* %v64, align 8, !range !0, !tbaa !4
+; CHECK-NEXT: ret void
+    ret void
+}
+
+define i32 @callee_root({} addrspace(10)* %v0, {} addrspace(10)* %v1) {
+top:
+; CHECK-LABEL: @callee_root
+; CHECK-NOT: @julia.new_gc_frame
+  %v2 = call {}*** @julia.get_pgcstack()
+  %v3 = bitcast {} addrspace(10)* %v0 to {} addrspace(10)* addrspace(10)*
+  %v4 = addrspacecast {} addrspace(10)* addrspace(10)* %v3 to {} addrspace(10)* addrspace(11)*
+  %v5 = load atomic {} addrspace(10)*, {} addrspace(10)* addrspace(11)* %v4 unordered, align 8
+  %v6 = bitcast {} addrspace(10)* %v1 to {} addrspace(10)* addrspace(10)*
+  %v7 = addrspacecast {} addrspace(10)* addrspace(10)* %v6 to {} addrspace(10)* addrspace(11)*
+  %v8 = load atomic {} addrspace(10)*, {} addrspace(10)* addrspace(11)* %v7 unordered, align 8
+  %v9 = addrspacecast {} addrspace(10)* %v5 to {} addrspace(12)*
+  %v10 = addrspacecast {} addrspace(10)* %v8 to {} addrspace(12)*
+  %v11 = call i32 @rooting_callee({} addrspace(12)* %v9, {} addrspace(12)* %v10)
+  ret i32 %v11
+; CHECK: ret i32
+}
+
+define i32 @freeze({} addrspace(10)* %v0, {} addrspace(10)* %v1) {
+top:
+; CHECK-LABEL: @freeze
+; CHECK-NOT: @julia.new_gc_frame
+  %v2 = call {}*** @julia.get_pgcstack()
+  %v3 = bitcast {} addrspace(10)* %v0 to {} addrspace(10)* addrspace(10)*
+  %v4 = addrspacecast {} addrspace(10)* addrspace(10)* %v3 to {} addrspace(10)* addrspace(11)*
+  %v5 = load atomic {} addrspace(10)*, {} addrspace(10)* addrspace(11)* %v4 unordered, align 8
+  %v6 = bitcast {} addrspace(10)* %v1 to {} addrspace(10)* addrspace(10)*
+  %v7 = addrspacecast {} addrspace(10)* addrspace(10)* %v6 to {} addrspace(10)* addrspace(11)*
+  %v8 = load atomic {} addrspace(10)*, {} addrspace(10)* addrspace(11)* %v7 unordered, align 8
+  %fv8 = freeze {} addrspace(10)* %v8
+  %v9 = addrspacecast {} addrspace(10)* %v5 to {} addrspace(12)*
+  %v10 = addrspacecast {} addrspace(10)* %fv8 to {} addrspace(12)*
+  %v11 = call i32 @rooting_callee({} addrspace(12)* %v9, {} addrspace(12)* %v10)
+  ret i32 %v11
+; CHECK: ret i32
+}
+
+!0 = !{i64 0, i64 23}
+!1 = !{!1}
+!2 = !{!7} ; scope list
+!3 = !{!4, !4, i64 0, i64 1}
+!4 = !{!"jtbaa_const", !5}
+!5 = !{!"jtbaa"}
+!6 = distinct !{!6} ; alias domain
+!7 = distinct !{!7, !6} ; alias scope
+
+
+; CHECK:      !0 = !{!1, !1, i64 0}
+; CHECK-NEXT: !1 = !{!"jtbaa_gcframe", !2, i64 0}
+; CHECK-NEXT: !2 = !{!"jtbaa", !3, i64 0}
+; CHECK-NEXT: !3 = !{!"jtbaa"}
+; CHECK-NEXT: !4 = !{!5, !5, i64 0}
+; CHECK-NEXT: !5 = !{!"jtbaa_tag", !6, i64 0}
+; CHECK-NEXT: !6 = !{!"jtbaa_data", !2, i64 0}
+; CHECK-NEXT: !7 = !{i64 0, i64 23}
+; CHECK-NEXT: !8 = !{!9}
+; CHECK-NEXT: !9 = distinct !{!9, !10}
+; CHECK-NEXT: !10 = distinct !{!10}
+; CHECK-NEXT: !11 = !{!12, !12, i64 0}
+; CHECK-NEXT: !12 = !{!"jtbaa_const", !3}

--- a/test/llvmpasses/lower-handlers-addrspaces.ll
+++ b/test/llvmpasses/lower-handlers-addrspaces.ll
@@ -1,0 +1,30 @@
+; RUN: opt -enable-new-pm=0 -load libjulia-codegen%shlibext -LowerExcHandlers -print-before-all -S %s | FileCheck %s
+; RUN: opt -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='function(LowerExcHandlers)' -S %s | FileCheck %s
+
+target triple = "amdgcn-amd-amdhsa"
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7-ni:10:11:12:13"
+
+attributes #1 = { returns_twice }
+declare i32 @julia.except_enter() #1
+declare void @ijl_pop_handler(i32)
+declare i8**** @julia.ptls_states()
+declare i8**** @julia.get_pgcstack()
+
+define void @simple() {
+top:
+    %pgcstack = call i8**** @julia.get_pgcstack()
+; CHECK: call void @llvm.lifetime.start
+; CHECK: call void @ijl_enter_handler
+; CHECK: setjmp
+    %r = call i32 @julia.except_enter()
+    %cmp = icmp eq i32 %r, 0
+    br i1 %cmp, label %try, label %catch
+try:
+    br label %after
+catch:
+    br label %after
+after:
+    call void @ijl_pop_handler(i32 1)
+; CHECK: llvm.lifetime.end
+    ret void
+}

--- a/test/llvmpasses/propagate-addrspace-non-zero.ll
+++ b/test/llvmpasses/propagate-addrspace-non-zero.ll
@@ -1,0 +1,64 @@
+; RUN: opt -enable-new-pm=0 -load libjulia-codegen%shlibext -PropagateJuliaAddrspaces -dce -S %s | FileCheck %s
+; RUN: opt -enable-new-pm=1 --load-pass-plugin=libjulia-codegen%shlibext -passes='PropagateJuliaAddrspaces,dce' -S %s | FileCheck %s
+
+target triple = "amdgcn-amd-amdhsa"
+target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7-ni:10:11:12:13"
+
+define i64 @simple() {
+; CHECK-LABEL: @simple
+; CHECK-NOT: addrspace(11)
+    %stack = alloca i64, addrspace(5)
+    %casted = addrspacecast i64 addrspace(5)*%stack to i64 addrspace(11)*
+    %loaded = load i64, i64 addrspace(11)* %casted
+    ret i64 %loaded
+}
+
+define i64 @twogeps() {
+; CHECK-LABEL: @twogeps
+; CHECK-NOT: addrspace(11)
+    %stack = alloca i64, addrspace(5)
+    %casted = addrspacecast i64 addrspace(5)*%stack to i64 addrspace(11)*
+    %gep1 = getelementptr i64, i64 addrspace(11)* %casted, i64 1
+    %gep2 = getelementptr i64, i64 addrspace(11)* %gep1, i64 1
+    %loaded = load i64, i64 addrspace(11)* %gep2
+    ret i64 %loaded
+}
+
+define i64 @phi(i1 %cond) {
+; CHECK-LABEL: @phi
+; CHECK-NOT: addrspace(11)
+top:
+    %stack1 = alloca i64, addrspace(5)
+    %stack2 = alloca i64, addrspace(5)
+    %stack1_casted = addrspacecast i64 addrspace(5)*%stack1 to i64 addrspace(11)*
+    %stack2_casted = addrspacecast i64 addrspace(5)*%stack2 to i64 addrspace(11)*
+    br i1 %cond, label %A, label %B
+A:
+    br label %B
+B:
+    %phi = phi i64 addrspace(11)* [ %stack1_casted, %top ], [ %stack2_casted, %A ]
+    %load = load i64, i64 addrspace(11)* %phi
+    ret i64 %load
+}
+
+
+define i64 @select(i1 %cond) {
+; CHECK-LABEL: @select
+; CHECK-NOT: addrspace(11)
+top:
+    %stack1 = alloca i64, addrspace(5)
+    %stack2 = alloca i64, addrspace(5)
+    %stack1_casted = addrspacecast i64 addrspace(5)*%stack1 to i64 addrspace(11)*
+    %stack2_casted = addrspacecast i64 addrspace(5)*%stack2 to i64 addrspace(11)*
+    %select = select i1 %cond, i64 addrspace(11)* %stack1_casted, i64 addrspace(11)* %stack2_casted
+    %load = load i64, i64 addrspace(11)* %select
+    ret i64 %load
+}
+
+define i64 @nullptr() {
+; CHECK-LABEL: @nullptr
+; CHECK-NOT: addrspace(11)
+    %casted = addrspacecast i64 addrspace(5)*null to i64 addrspace(11)*
+    %load = load i64, i64 addrspace(11)* %casted
+    ret i64 %load
+}


### PR DESCRIPTION
Fixes issues around usage of the AMDGPU LLVM target by GPUCompiler

Supersedes #45544