### PR TITLE
fix rounding edge cases on `cld`, `fld`, and `rem`

### DIFF
--- a/base/div.jl
+++ b/base/div.jl
@@ -367,4 +367,3 @@ end
 # NOTE: C89 fmod() and x87 FPREM implicitly provide truncating float division,
 # so it is used here as the basis of float div().
 div(x::T, y::T, r::RoundingMode) where {T<:AbstractFloat} = convert(T,round((x-rem(x,y,r))/y))
-rem(x::T, y::T, ::typeof(RoundUp)) where {T<:AbstractFloat} = convert(T,x-y*ceil(x/y))

--- a/base/div.jl
+++ b/base/div.jl
@@ -5,10 +5,10 @@
 """
     div(x, y, r::RoundingMode=RoundToZero)
 
-The quotient from Euclidean (integer) division. Computes x/y, rounded to
+The quotient from Euclidean (integer) division. Computes `x / y`, rounded to
 an integer according to the rounding mode `r`. In other words, the quantity
 
-    round(x/y,r)
+    round(x / y, r)
 
 without any intermediate rounding.
 
@@ -52,12 +52,12 @@ div(a, b) = div(a, b, RoundToZero)
 Compute the remainder of `x` after integer division by `y`, with the quotient rounded
 according to the rounding mode `r`. In other words, the quantity
 
-    x - y*round(x/y,r)
+    x - y * round(x / y, r)
 
 without any intermediate rounding.
 
 - if `r == RoundNearest`, then the result is exact, and in the interval
-  ``[-|y|/2, |y|/2]``. See also [`RoundNearest`](@ref).
+  ``[-|y| / 2, |y| / 2]``. See also [`RoundNearest`](@ref).
 
 - if `r == RoundToZero` (default), then the result is exact, and in the interval
   ``[0, |y|)`` if `x` is positive, or ``(-|y|, 0]`` otherwise. See also [`RoundToZero`](@ref).
@@ -66,12 +66,12 @@ without any intermediate rounding.
   ``(y, 0]`` otherwise. The result may not be exact if `x` and `y` have different signs, and
   `abs(x) < abs(y)`. See also [`RoundDown`](@ref).
 
-- if `r == RoundUp`, then the result is in the interval `(-y,0]` if `y` is positive, or
-  `[0,-y)` otherwise. The result may not be exact if `x` and `y` have the same sign, and
+- if `r == RoundUp`, then the result is in the interval ``(-y, 0]`` if `y` is positive, or
+  ``[0, -y)`` otherwise. The result may not be exact if `x` and `y` have the same sign, and
   `abs(x) < abs(y)`. See also [`RoundUp`](@ref).
 
-- if `r == RoundFromZero`, then the result is in the interval `(-y, 0]` if `y` is positive, or
-  `[0, -y)` otherwise. The result may not be exact if `x` and `y` have the same sign, and
+- if `r == RoundFromZero`, then the result is in the interval ``(-y, 0]`` if `y` is positive, or
+  ``[0, -y)`` otherwise. The result may not be exact if `x` and `y` have the same sign, and
   `abs(x) < abs(y)`. See also [`RoundFromZero`](@ref).
 
 !!! compat "Julia 1.9"
@@ -97,7 +97,7 @@ rem(x, y, r::RoundingMode)
 rem(x, y, ::RoundingMode{:ToZero}) = rem(x, y)
 rem(x, y, ::RoundingMode{:Down}) = mod(x, y)
 rem(x, y, ::RoundingMode{:Up}) = mod(x, -y)
-rem(x, y, r::RoundingMode{:Nearest}) = x - y*div(x, y, r)
+rem(x, y, r::RoundingMode{:Nearest}) = x - y * div(x, y, r)
 rem(x::Integer, y::Integer, r::RoundingMode{:Nearest}) = divrem(x, y, r)[2]
 
 function rem(x, y, ::typeof(RoundFromZero))
@@ -107,13 +107,13 @@ end
 """
     fld(x, y)
 
-Largest integer less than or equal to `x/y`. Equivalent to `div(x, y, RoundDown)`.
+Largest integer less than or equal to `x / y`. Equivalent to `div(x, y, RoundDown)`.
 
 See also [`div`](@ref), [`cld`](@ref), [`fld1`](@ref).
 
 # Examples
 ```jldoctest
-julia> fld(7.3,5.5)
+julia> fld(7.3, 5.5)
 1.0
 
 julia> fld.(-5:5, 3)'
@@ -123,11 +123,11 @@ julia> fld.(-5:5, 3)'
 Because `fld(x, y)` implements strictly correct floored rounding based on the true
 value of floating-point numbers, unintuitive situations can arise. For example:
 ```jldoctest
-julia> fld(6.0,0.1)
+julia> fld(6.0, 0.1)
 59.0
-julia> 6.0/0.1
+julia> 6.0 / 0.1
 60.0
-julia> 6.0/big(0.1)
+julia> 6.0 / big(0.1)
 59.99999999999999666933092612453056361837965690217069245739573412231113406246995
 ```
 What is happening here is that the true value of the floating-point number written
@@ -141,13 +141,13 @@ fld(a, b) = div(a, b, RoundDown)
 """
     cld(x, y)
 
-Smallest integer larger than or equal to `x/y`. Equivalent to `div(x, y, RoundUp)`.
+Smallest integer larger than or equal to `x / y`. Equivalent to `div(x, y, RoundUp)`.
 
 See also [`div`](@ref), [`fld`](@ref).
 
 # Examples
 ```jldoctest
-julia> cld(5.5,2.2)
+julia> cld(5.5, 2.2)
 3.0
 
 julia> cld.(-5:5, 3)'
@@ -162,17 +162,17 @@ cld(a, b) = div(a, b, RoundUp)
     divrem(x, y, r::RoundingMode=RoundToZero)
 
 The quotient and remainder from Euclidean division.
-Equivalent to `(div(x,y,r), rem(x,y,r))`. Equivalently, with the default
-value of `r`, this call is equivalent to `(x÷y, x%y)`.
+Equivalent to `(div(x, y, r), rem(x, y, r))`. Equivalently, with the default
+value of `r`, this call is equivalent to `(x ÷ y, x % y)`.
 
 See also: [`fldmod`](@ref), [`cld`](@ref).
 
 # Examples
 ```jldoctest
-julia> divrem(3,7)
+julia> divrem(3, 7)
 (0, 3)
 
-julia> divrem(7,3)
+julia> divrem(7, 3)
 (2, 1)
 ```
 """
@@ -190,23 +190,24 @@ function divrem(a, b, r::RoundingMode)
         (div(a, b, r), rem(a, b, r))
     end
 end
-#avoids calling rem for Integers-Integers (all modes),
-#a-d*b not precise for Floats - AbstractFloat, AbstractIrrational. Rationals are still slower
+# avoids calling rem for Integers-Integers (all modes),
+# a - d * b not precise for Floats - AbstractFloat, AbstractIrrational.
+# Rationals are still slower
 function divrem(a::Integer, b::Integer, r::Union{typeof(RoundUp),
                                                 typeof(RoundDown),
                                                 typeof(RoundToZero)})
     if r === RoundToZero
         # For compat. Remove in 2.0.
         d = div(a, b)
-        (d, a - d*b)
+        (d, a - d * b)
     elseif r === RoundDown
         # For compat. Remove in 2.0.
         d = fld(a, b)
-        (d, a - d*b)
+        (d, a - d * b)
     elseif r === RoundUp
         # For compat. Remove in 2.0.
         d = div(a, b, r)
-        (d, a - d*b)
+        (d, a - d * b)
     end
 end
 function divrem(x::Integer, y::Integer, rnd::typeof(RoundNearest))
@@ -266,11 +267,11 @@ end
     fldmod(x, y)
 
 The floored quotient and modulus after division. A convenience wrapper for
-`divrem(x, y, RoundDown)`. Equivalent to `(fld(x,y), mod(x,y))`.
+`divrem(x, y, RoundDown)`. Equivalent to `(fld(x, y), mod(x, y))`.
 
 See also: [`fld`](@ref), [`cld`](@ref), [`fldmod1`](@ref).
 """
-fldmod(x,y) = divrem(x, y, RoundDown)
+fldmod(x, y) = divrem(x, y, RoundDown)
 
 # We definite generic rounding methods for other rounding modes in terms of
 # RoundToZero.
@@ -322,11 +323,11 @@ div(a::UInt128, b::UInt128, ::typeof(RoundToZero)) = div(a, b)
 rem(a::Int128, b::Int128, ::typeof(RoundToZero)) = rem(a, b)
 rem(a::UInt128, b::UInt128, ::typeof(RoundToZero)) = rem(a, b)
 
-# These are kept for compatibility with external packages overriding fld/cld.
-# In 2.0, packages should extend div(a,b,r) instead, in which case, these can
+# These are kept for compatibility with external packages overriding fld / cld.
+# In 2.0, packages should extend div(a, b, r) instead, in which case, these can
 # be removed.
-fld(x::Real, y::Real) = div(promote(x,y)..., RoundDown)
-cld(x::Real, y::Real) = div(promote(x,y)..., RoundUp)
+fld(x::Real, y::Real) = div(promote(x, y)..., RoundDown)
+cld(x::Real, y::Real) = div(promote(x, y)..., RoundUp)
 fld(x::Signed, y::Unsigned) = div(x, y, RoundDown)
 fld(x::Unsigned, y::Signed) = div(x, y, RoundDown)
 cld(x::Signed, y::Unsigned) = div(x, y, RoundUp)
@@ -346,14 +347,14 @@ function div(x::Real, y::Real, r::RoundingMode)
 end
 
 # Integers
-# fld(x,y) == div(x,y) - ((x>=0) != (y>=0) && rem(x,y) != 0 ? 1 : 0)
-div(x::T, y::T, ::typeof(RoundDown)) where {T<:Unsigned} = div(x,y)
+# fld(x, y) == div(x, y) - ((x >= 0) != (y >= 0) && rem(x, y) != 0 ? 1 : 0)
+div(x::T, y::T, ::typeof(RoundDown)) where {T<:Unsigned} = div(x, y)
 function div(x::T, y::T, ::typeof(RoundDown)) where T<:Integer
     d = div(x, y, RoundToZero)
     return d - (signbit(x ⊻ y) & (d * y != x))
 end
 
-# cld(x,y) = div(x,y) + ((x>0) == (y>0) && rem(x,y) != 0 ? 1 : 0)
+# cld(x, y) = div(x, y) + ((x > 0) == (y > 0) && rem(x, y) != 0 ? 1 : 0)
 function div(x::T, y::T, ::typeof(RoundUp)) where T<:Unsigned
     d = div(x, y, RoundToZero)
     return d + (d * y != x)
@@ -366,4 +367,4 @@ end
 # Real
 # NOTE: C89 fmod() and x87 FPREM implicitly provide truncating float division,
 # so it is used here as the basis of float div().
-div(x::T, y::T, r::RoundingMode) where {T<:AbstractFloat} = convert(T,round((x-rem(x,y,r))/y))
+div(x::T, y::T, r::RoundingMode) where {T<:AbstractFloat} = convert(T, round((x - rem(x, y, r)) / y))

--- a/base/float.jl
+++ b/base/float.jl
@@ -393,8 +393,6 @@ muladd(x::T, y::T, z::T) where {T<:IEEEFloat} = muladd_float(x, y, z)
 
 rem(x::T, y::T) where {T<:IEEEFloat} = rem_float(x, y)
 
-cld(x::T, y::T) where {T<:AbstractFloat} = -fld(-x,y)
-
 function mod(x::T, y::T) where T<:AbstractFloat
     r = rem(x,y)
     if r == 0

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1650,8 +1650,17 @@ end
         @test rem(prevfloat(1.0),1.0) == prevfloat(1.0)
         @test mod(prevfloat(1.0),1.0) == prevfloat(1.0)
     end
-    # issue #3046
-    @test mod(Int64(2),typemax(Int64)) == 2
+    @test mod(Int64(2), typemax(Int64)) == 2  # issue #3046
+    @testset "issue #45875" begin
+        @test cld(+1.1, 0.1) == +12.0
+        @test fld(+1.1, 0.1) == +11.0
+        @test cld(-1.1, 0.1) == -11.0
+        @test fld(-1.1, 0.1) == -12.0
+        @test div(+1.1, 0.1, RoundDown) == +11.0
+        @test div(+1.1, 0.1, RoundUp) == +12.0
+        @test div(-1.1, 0.1, RoundDown) == -12.0
+        @test div(-1.1, 0.1, RoundUp) == -11.0
+    end
 end
 @testset "return types" begin
     for T in (Int8,Int16,Int32,Int64,Int128, UInt8,UInt16,UInt32,UInt64,UInt128)
@@ -2550,13 +2559,12 @@ end
         @test isnan(rem(T(1), T(0), mode))
         @test isnan(rem(T(Inf), T(2), mode))
         @test isnan(rem(T(1), T(NaN), mode))
-        # FIXME: The broken case erroneously returns -Inf
-        @test rem(T(4), floatmin(T) * 2, mode) == 0 broken=(T == BigFloat && mode in (RoundUp,RoundFromZero))
+        @test rem(T(4), floatmin(T) * 2, mode) == 0
     end
     @test isequal(rem(nextfloat(typemin(T)), T(2), RoundToZero),  -0.0)
     @test isequal(rem(nextfloat(typemin(T)), T(2), RoundNearest), -0.0)
     @test isequal(rem(nextfloat(typemin(T)), T(2), RoundDown),     0.0)
-    @test isequal(rem(nextfloat(typemin(T)), T(2), RoundUp),       0.0)
+    @test isequal(rem(nextfloat(typemin(T)), T(2), RoundUp),      -0.0)
     @test isequal(rem(nextfloat(typemin(T)), T(2), RoundFromZero), 0.0)
 end
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1652,14 +1652,10 @@ end
     end
     @test mod(Int64(2), typemax(Int64)) == 2  # issue #3046
     @testset "issue #45875" begin
-        @test cld(+1.1, 0.1) == +12.0
-        @test fld(+1.1, 0.1) == +11.0
-        @test cld(-1.1, 0.1) == -11.0
-        @test fld(-1.1, 0.1) == -12.0
-        @test div(+1.1, 0.1, RoundDown) == +11.0
-        @test div(+1.1, 0.1, RoundUp) == +12.0
-        @test div(-1.1, 0.1, RoundDown) == -12.0
-        @test div(-1.1, 0.1, RoundUp) == -11.0
+        @test cld(+1.1, 0.1) == div(+1.1, 0.1, RoundUp)   ==  ceil(big(+1.1)/big(0.1)) == +12.0
+        @test fld(+1.1, 0.1) == div(+1.1, 0.1, RoundDown) == floor(big(+1.1)/big(0.1)) == +11.0
+        @test cld(-1.1, 0.1) == div(-1.1, 0.1, RoundUp)   ==  ceil(big(-1.1)/big(0.1)) == -11.0
+        @test fld(-1.1, 0.1) == div(-1.1, 0.1, RoundDown) == floor(big(-1.1)/big(0.1)) == -12.0
     end
 end
 @testset "return types" begin


### PR DESCRIPTION
- fix https://github.com/JuliaLang/julia/issues/45875;
- make docstrings more consistent (spacing around operators and after commas).

cc @eschnett for removal of `cld` def introduced in https://github.com/JuliaLang/julia/pull/8111.

Two tests marked broken before are now passing at https://github.com/JuliaLang/julia/blob/f4801ff2b50594568f0bb66a1b4d8ee9181d76bf/test/numbers.jl#L2554
One test had its sign modified (`0.0` -> `-0.0`): `isequal(rem(nextfloat(typemin(T)), T(2), RoundUp), -0.0)`.