### PR TITLE
Remove out of date advice about github notifications

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -345,7 +345,6 @@ please remove the `backport-X.Y` tag from the originating pull request for the c
  - If you see any unrelated changes to submodules like `deps/libuv`, `deps/openlibm`, etc., try running `git submodule update` first.
  - Descriptive commit messages are good.
  - Using `git add -p` or `git add -i` can be useful to avoid accidentally committing unrelated changes.
- - GitHub does not send notifications when you push a new commit to a pull request, so please add a comment to the pull request thread to let reviewers know when you've made changes.
  - When linking to specific lines of code in discussion of an issue or pull request, hit the `y` key while viewing code on GitHub to reload the page with a URL that includes the specific version that you're viewing. That way any lines of code that you refer to will still make sense in the future, even if the content of the file changes.
  - Whitespace can be automatically removed from existing commits with `git rebase`.
    - To remove whitespace for the previous commit, run


### PR DESCRIPTION
For example, I have received this notification

> [@pcjentsch](https://github.com/pcjentsch) pushed 1 commit.
> 
> [ae4eb80](https://github.com/JuliaLang/julia/commit/ae4eb80c14330e7d49fd17661a3c7d415e30d4de) Apply suggestions from code review
> —
> [View it on GitHub](https://github.com/JuliaLang/julia/pull/45211/files/f2bfb275cd64f87e4aafaa00c8fd11245f91ea8a..ae4eb80c14330e7d49fd17661a3c7d415e30d4de) or [unsubscribe](https://github.com/notifications/unsubscribe-auth/KEY).
You are receiving this because you are subscribed to this thread.
