### PR TITLE
Aggressive constant propagation in `_eachslice`

### DIFF
--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -51,7 +51,7 @@ function _slice_check_dims(N, dim, dims...)
     _slice_check_dims(N,dims...)
 end
 
-@inline function _eachslice(A::AbstractArray{T,N}, dims::NTuple{M,Integer}, drop::Bool) where {T,N,M}
+@constprop :aggressive function _eachslice(A::AbstractArray{T,N}, dims::NTuple{M,Integer}, drop::Bool) where {T,N,M}
     _slice_check_dims(N,dims...)
     if drop
         # if N = 4, dims = (3,1) then

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1617,11 +1617,3 @@ end
     @test (@inferred A[i,i,i]) === A[1]
     @test (@inferred to_indices([], (1, CIdx(1, 1), 1, CIdx(1, 1), 1, CIdx(1, 1), 1))) == ntuple(Returns(1), 10)
 end
-
-@testset "eachslice inference" begin
-    a = [1 2; 3 4]
-    f1(a) = eachslice(a, dims=1)
-    @test (@inferred f1(a)) == eachrow(a)
-    f2(a) = eachslice(a, dims=2)
-    @test (@inferred f2(a)) == eachcol(a)
-end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1617,3 +1617,11 @@ end
     @test (@inferred A[i,i,i]) === A[1]
     @test (@inferred to_indices([], (1, CIdx(1, 1), 1, CIdx(1, 1), 1, CIdx(1, 1), 1))) == ntuple(Returns(1), 10)
 end
+
+@testset "eachslice inference" begin
+    a = [1 2; 3 4]
+    f1(a) = eachslice(a, dims=1)
+    @test (@inferred f1(a)) == eachrow(a)
+    f2(a) = eachslice(a, dims=2)
+    @test (@inferred f2(a)) == eachcol(a)
+end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2269,6 +2269,14 @@ end
     @test S32K isa AbstractSlices{<:AbstractArray{Int, 2}, 4}
     @test size(S32K) == (1,2,2,1)
     @test S32K[1,2,1,1] == M[:,2,1,:]
+
+    @testset "eachslice inference (#45923)" begin
+        a = [1 2; 3 4]
+        f1(a) = eachslice(a, dims=1)
+        @test (@inferred f1(a)) == eachrow(a)
+        f2(a) = eachslice(a, dims=2)
+        @test (@inferred f2(a)) == eachcol(a)
+    end
 end
 
 ###


### PR DESCRIPTION
This helps with inference in `eachslice` by constant-propagating the keyword arguments. 
On master
```julia
julia> f(a) = eachslice(a; dims = 2)
f (generic function with 1 method)

julia> a = randn(50,30,2);

julia> @inferred f(a)
ERROR: return type Slices{Array{Float64, 3}, Tuple{Colon, Int64, Colon}, Tuple{Base.OneTo{Int64}}, SubArray{Float64, 2, Array{Float64, 3}, Tuple{Base.Slice{Base.OneTo{Int64}}, Int64, Base.Slice{Base.OneTo{Int64}}}, false}, 1} does not match inferred return type Slices{Array{Float64, 3}, _A, Tuple{Base.OneTo{Int64}}, _B, 1} where {_A, _B}
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] top-level scope
   @ REPL[20]:1

julia> @btime sum(f($a));
  3.393 μs (33 allocations: 25.50 KiB)
```
This PR
```julia
julia> @inferred f(a);

julia> @btime sum(f($a));
  3.102 μs (30 allocations: 25.44 KiB)
```

Solution suggested by @N5N3 on [discourse](https://discourse.julialang.org/t/why-is-the-kwarg-dims-not-being-constant-propagated/83610/2?u=jishnub)