### PR TITLE
Fix length of Iterators.Stateful with underlying mutable iterator

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1447,6 +1447,7 @@ function length(s::Stateful)
         length(s.itr) - (one(rem) - rem)
     end
 end
+end # if statement several hundred lines above
 
 """
     only(x)

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1422,7 +1422,6 @@ convert(::Type{Stateful}, itr) = Stateful(itr)
         val, state = vs
         Core.setfield!(s, :nextvalstate, iterate(s.itr, state))
         rem = s.remaining
-        @assert !iszero(rem)
         s.remaining = rem - one(rem)
         return val
     end

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1354,7 +1354,7 @@ julia> sum(a) # Sum the remaining elements
 7
 ```
 """
-mutable struct Stateful{T, VS}
+mutable struct Stateful{T, VS, N<:Integer}
     itr::T
     # A bit awkward right now, but adapted to the new iteration protocol
     nextvalstate::Union{VS, Nothing}

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1377,7 +1377,7 @@ end
 
 function iterlength(it)::Signed
     if IteratorSize(it) isa Union{HasShape, HasLength}
-        signed(length(it))
+       return length(it)
     else
         -1
     end

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1432,15 +1432,15 @@ end
     return ns !== nothing ? ns[1] : sentinel
 end
 @inline iterate(s::Stateful, state=nothing) = s.nextvalstate === nothing ? nothing : (popfirst!(s), nothing)
-IteratorSize(::Type{<:Stateful{T}) where {T} = IteratorSize(T) isa HasShape ? HasLength() : IteratorSize(T)
-eltype(::Type{<:Stateful{T}} where {T} = eltype(T)
-IteratorEltype(::Type{<:Stateful{T}) where {T} = IteratorEltype(T)
+IteratorSize(::Type{<:Stateful{T}}) where {T} = IteratorSize(T) isa HasShape ? HasLength() : IteratorSize(T)
+eltype(::Type{<:Stateful{T}}) where {T} = eltype(T)
+IteratorEltype(::Type{<:Stateful{T}}) where {T} = IteratorEltype(T)
 
 function length(s::Stateful)
     rem = s.remaining
     # If rem is actually remaining length, return it.
     # else, rem is number of consumed elements.
-    if rem > 0
+    if rem >= 0
         rem
     else
         length(s.itr) - (typeof(rem)(1) - rem)

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1432,9 +1432,9 @@ end
     return ns !== nothing ? ns[1] : sentinel
 end
 @inline iterate(s::Stateful, state=nothing) = s.nextvalstate === nothing ? nothing : (popfirst!(s), nothing)
-IteratorSize(::Type{Stateful{T,VS}}) where {T,VS} = IteratorSize(T) isa HasShape ? HasLength() : IteratorSize(T)
-eltype(::Type{Stateful{T, VS}} where VS) where {T} = eltype(T)
-IteratorEltype(::Type{Stateful{T,VS}}) where {T,VS} = IteratorEltype(T)
+IteratorSize(::Type{<:Stateful{T}) where {T} = IteratorSize(T) isa HasShape ? HasLength() : IteratorSize(T)
+eltype(::Type{<:Stateful{T}} where {T} = eltype(T)
+IteratorEltype(::Type{<:Stateful{T}) where {T} = IteratorEltype(T)
 
 function length(s::Stateful)
     rem = s.remaining

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1422,7 +1422,7 @@ convert(::Type{Stateful}, itr) = Stateful(itr)
         val, state = vs
         Core.setfield!(s, :nextvalstate, iterate(s.itr, state))
         rem = s.remaining
-        s.remaining = rem - one(rem)
+        s.remaining = rem - typeof(rem)(1)
         return val
     end
 end
@@ -1443,7 +1443,7 @@ function length(s::Stateful)
     if rem > 0
         rem
     else
-        length(s.itr) - (one(rem) - rem)
+        length(s.itr) - (typeof(rem)(1) - rem)
     end
 end
 end # if statement several hundred lines above

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -843,7 +843,7 @@ end
         v, s = iterate(z)
         @test Base.isdone(z, s)
     end
-    # Stateful wrapping mutable iterators of known length (#43245) 
+    # Stateful wrapping mutable iterators of known length (#43245)
     @test length(Iterators.Stateful(Iterators.Stateful(1:5))) == 5
 end
 

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -843,6 +843,8 @@ end
         v, s = iterate(z)
         @test Base.isdone(z, s)
     end
+    # Stateful wrapping mutable iterators of known length (#43245) 
+    @test length(Iterators.Stateful(Iterators.Stateful(1:5))) == 5
 end
 
 @testset "pair for Svec" begin

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -683,6 +683,7 @@ end
 Base.iterate(x::CharStr) = iterate(x.chars)
 Base.iterate(x::CharStr, i::Int) = iterate(x.chars, i)
 Base.lastindex(x::CharStr) = lastindex(x.chars)
+Base.length(x::CharStr) = length(x.chars)
 @testset "cmp without UTF-8 indexing" begin
     # Simple case, with just ANSI Latin 1 characters
     @test "áB" != CharStr("áá") # returns false with bug

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -681,7 +681,7 @@ mutable struct CharStr <: AbstractString
     CharStr(x) = new(collect(x))
 end
 Base.iterate(x::CharStr) = iterate(x.chars)
-Base.ncodeunits(x::CharStr) = length(x.chars)
+Base.length(x::CharStr) = length(x.chars)
 Base.iterate(x::CharStr, i::Int) = iterate(x.chars, i)
 Base.lastindex(x::CharStr) = lastindex(x.chars)
 @testset "cmp without UTF-8 indexing" begin

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -681,6 +681,7 @@ mutable struct CharStr <: AbstractString
     CharStr(x) = new(collect(x))
 end
 Base.iterate(x::CharStr) = iterate(x.chars)
+Base.ncodeunits(x::CharStr) = length(x.chars)
 Base.iterate(x::CharStr, i::Int) = iterate(x.chars, i)
 Base.lastindex(x::CharStr) = lastindex(x.chars)
 @testset "cmp without UTF-8 indexing" begin

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -681,7 +681,6 @@ mutable struct CharStr <: AbstractString
     CharStr(x) = new(collect(x))
 end
 Base.iterate(x::CharStr) = iterate(x.chars)
-Base.length(x::CharStr) = length(x.chars)
 Base.iterate(x::CharStr, i::Int) = iterate(x.chars, i)
 Base.lastindex(x::CharStr) = lastindex(x.chars)
 @testset "cmp without UTF-8 indexing" begin


### PR DESCRIPTION
Previously, Iterators.Stateful kept track of how many elements have been taken,
and reported its length as the length of the underlying iterator minus the
number of taken elements.
However, this assumes the underlying iterator is immutable. If it is mutable,
then the reported length is the same as the number of remaining elements,
meaning the wrapper Stateful should not subtract the number of taken elements.

After this PR, Stateful instead stores the length of the underlying iterator,
if that can be known, and subtracts one every time an element is taken. Hence,
the number of remaining elements is being kept track of directly.

Fixes #43245