### PR TITLE
make `copyto_unaliased` more type-stable

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1076,7 +1076,7 @@ function copyto_unaliased!(deststyle::IndexStyle, dest::AbstractArray, srcstyle:
             # Dual-iterator implementation
             ret = iterate(iterdest)
             @inbounds for a in src
-                idx, state = ret
+                idx, state = ret::NTuple{2,Any}
                 dest[idx] = a
                 ret = iterate(iterdest, state)
             end


### PR DESCRIPTION
This change makes static analysis happier.
xref: <https://github.com/aviatesk/JET.jl/issues/374>

/cc @Krastanov