### PR TITLE
add a .gitignore to `src/base` to prevent double results when searching with editors

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -21,6 +21,7 @@
 /julia_version.h
 /flisp/host
 /support/host
+/base/
 
 # Clang compilation database
 /compile_commands*.json


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/commit/f0b1c5fa0e57f60446bba7d0c83bfda93a2b8b63#r75822156