### PR TITLE
inlining: follow #45272, improve the finalizer inlining implementation

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -496,13 +496,13 @@ function abstract_call_method(interp::AbstractInterpreter, method::Method, @nosp
         add_remark!(interp, sv, "Refusing to infer into `depwarn`")
         return MethodCallResult(Any, false, false, nothing, Effects())
     end
-    topmost = nothing
+
     # Limit argument type tuple growth of functions:
     # look through the parents list to see if there's a call to the same method
     # and from the same method.
     # Returns the topmost occurrence of that repeated edge.
-    edgecycle = false
-    edgelimited = false
+    edgecycle = edgelimited = false
+    topmost = nothing
 
     for infstate in InfStackUnwind(sv)
         if method === infstate.linfo.def

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -30,7 +30,6 @@ const IR_FLAG_EFFECT_FREE = 0x01 << 4
 # This statement was proven not to throw
 const IR_FLAG_NOTHROW     = 0x01 << 5
 
-
 const TOP_TUPLE = GlobalRef(Core, :tuple)
 
 #####################

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -14,7 +14,7 @@ GetfieldUse(idx::Int)  = SSAUse(:getfield, idx)
 PreserveUse(idx::Int)  = SSAUse(:preserve, idx)
 NoPreserve()           = SSAUse(:nopreserve, 0)
 IsdefinedUse(idx::Int) = SSAUse(:isdefined, idx)
-AddFinalizerUse(idx::Int) = SSAUse(:add_finalizer, idx)
+FinalizerUse(idx::Int) = SSAUse(:finalizer, idx)
 
 """
     du::SSADefUse
@@ -882,7 +882,7 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing, InliningState} = nothin
                 elseif is_isdefined
                     push!(defuse.uses, IsdefinedUse(idx))
                 elseif is_finalizer
-                    push!(defuse.uses, AddFinalizerUse(idx))
+                    push!(defuse.uses, FinalizerUse(idx))
                 else
                     push!(defuse.uses, GetfieldUse(idx))
                 end
@@ -948,12 +948,15 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing, InliningState} = nothin
     end
 end
 
+# NOTE we resolve the inlining source here as we don't want to serialize `Core.Compiler`
+# data structure into the global cache (see the comment in `handle_finalizer_call!`)
 function try_inline_finalizer!(ir::IRCode, argexprs::Vector{Any}, idx::Int, mi::MethodInstance, inlining::InliningState)
     code = get(inlining.mi_cache, mi, nothing)
+    et = inlining.et
     if code isa CodeInstance
         if use_const_api(code)
             # No code in the function - Nothing to do
-            inlining.et !== nothing && push!(inlining.et, mi)
+            et !== nothing && push!(et, mi)
             return true
         end
         src = code.inferred
@@ -969,15 +972,14 @@ function try_inline_finalizer!(ir::IRCode, argexprs::Vector{Any}, idx::Int, mi::
     length(src.cfg.blocks) == 1 || return false
 
     # Ok, we're committed to inlining the finalizer
-    inlining.et !== nothing && push!(inlining.et, mi)
+    et !== nothing && push!(et, mi)
 
     linetable_offset, extra_coverage_line = ir_inline_linetable!(ir.linetable, src, mi.def, ir[SSAValue(idx)][:line])
     if extra_coverage_line != 0
         insert_node!(ir, idx, NewInstruction(Expr(:code_coverage_effect), Nothing, extra_coverage_line))
     end
 
-    # TODO: Use the actual inliner here rather than open coding this special
-    # purpose inliner.
+    # TODO: Use the actual inliner here rather than open coding this special purpose inliner.
     spvals = mi.sparam_vals
     ssa_rename = Vector{Any}(undef, length(src.stmts))
     for idx′ = 1:length(src.stmts)
@@ -1001,6 +1003,58 @@ function try_inline_finalizer!(ir::IRCode, argexprs::Vector{Any}, idx::Int, mi::
 end
 
 is_nothrow(ir::IRCode, pc::Int) = ir.stmts[pc][:flag] & (IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW) ≠ 0
+
+function try_resolve_finalizer!(ir::IRCode, idx::Int, finalizer_idx::Int, defuse::SSADefUse, inlining::InliningState)
+    # For now: Require that all uses and defs are in the same basic block,
+    # so that live range calculations are easy.
+    bb = ir.cfg.blocks[block_for_inst(ir.cfg, first(defuse.uses).idx)]
+    minval::Int = typemax(Int)
+    maxval::Int = 0
+
+    function check_in_range(x::Union{Int,SSAUse})
+        if isa(x, SSAUse)
+            didx = x.idx
+        else
+            didx = x
+        end
+        didx in bb.stmts || return false
+        if didx < minval
+            minval = didx
+        end
+        if didx > maxval
+            maxval = didx
+        end
+        return true
+    end
+
+    check_in_range(idx) || return nothing
+    all(check_in_range, defuse.uses) || return nothing
+    all(check_in_range, defuse.defs) || return nothing
+
+    # For now: Require all statements in the basic block range to be nothrow.
+    all(minval:maxval) do idx::Int
+        return is_nothrow(ir, idx) || idx == finalizer_idx
+    end || return nothing
+
+    # Ok, `finalizer` rewrite is legal.
+    finalizer_stmt = ir[SSAValue(finalizer_idx)][:inst]
+    argexprs = Any[finalizer_stmt.args[2], finalizer_stmt.args[3]]
+    inline = finalizer_stmt.args[4]
+    if inline === nothing
+        # No code in the function - Nothing to do
+    else
+        mi = finalizer_stmt.args[5]::MethodInstance
+        if inline::Bool && try_inline_finalizer!(ir, argexprs, maxval, mi, inlining)
+            # the finalizer body has been inlined
+        else
+            insert_node!(ir, maxval, NewInstruction(Expr(:invoke, mi, argexprs...), Nothing), true)
+        end
+    end
+    # Erase the call to `finalizer`
+    ir[SSAValue(finalizer_idx)][:inst] = nothing
+    return nothing
+end
+
 function sroa_mutables!(ir::IRCode, defuses::IdDict{Int, Tuple{SPCSet, SSADefUse}}, used_ssas::Vector{Int}, lazydomtree::LazyDomtree, inlining::Union{Nothing, InliningState})
     for (idx, (intermediaries, defuse)) in defuses
         intermediaries = collect(intermediaries)
@@ -1024,72 +1078,22 @@ function sroa_mutables!(ir::IRCode, defuses::IdDict{Int, Tuple{SPCSet, SSADefUse
         # error at runtime, but is not illegal to have in the IR.
         ismutabletype(typ) || continue
         typ = typ::DataType
-        # First check for any add_finalizer calls
-        add_finalizer_idx = nothing
+        # First check for any finalizer calls
+        finalizer_idx = nothing
         for use in defuse.uses
-            if use.kind === :add_finalizer
-                # For now: Only allow one add_finalizer per allocation
-                add_finalizer_idx !== nothing && @goto skip
-                add_finalizer_idx = use.idx
+            if use.kind === :finalizer
+                # For now: Only allow one finalizer per allocation
+                finalizer_idx !== nothing && @goto skip
+                finalizer_idx = use.idx
             end
         end
-        if add_finalizer_idx !== nothing
-            # For now: Require that all uses and defs are in the same basic block,
-            # so that live range calculations are easy.
-            bb = ir.cfg.blocks[block_for_inst(ir.cfg, first(defuse.uses).idx)]
-            minval::Int = typemax(Int)
-            maxval::Int = 0
-
-            check_in_range(defuse) = check_in_range(defuse.idx)
-            function check_in_range(didx::Int)
-                didx in bb.stmts || return false
-                if didx < minval
-                    minval = didx
-                end
-                if didx > maxval
-                    maxval = didx
-                end
-                return true
-            end
-
-            check_in_range(idx) || continue
-            _all(check_in_range, defuse.uses) || continue
-            _all(check_in_range, defuse.defs) || continue
-
-            # For now: Require all statements in the basic block range to be
-            # nothrow.
-            all_nothrow = _all(idx->is_nothrow(ir, idx) || idx == add_finalizer_idx, minval:maxval)
-            all_nothrow || continue
-
-            # Ok, finalizer rewrite is legal.
-            add_finalizer_stmt = ir[SSAValue(add_finalizer_idx)][:inst]
-            argexprs = Any[add_finalizer_stmt.args[2], add_finalizer_stmt.args[3]]
-            may_inline = add_finalizer_stmt.args[4]::Bool
-            mi = add_finalizer_stmt.args[5]::Union{MethodInstance, Nothing}
-            if may_inline && mi !== nothing
-                if try_inline_finalizer!(ir, argexprs, maxval, add_finalizer_stmt.args[5], inlining)
-                    @goto done_finalizer
-                end
-                mi = compileable_specialization(inlining.et, mi, Effects()).invoke
-            end
-            if mi !== nothing
-                insert_node!(ir, maxval,
-                    NewInstruction(Expr(:invoke, mi, argexprs...), Nothing),
-                    true)
-            else
-                insert_node!(ir, maxval,
-                    NewInstruction(Expr(:call, argexprs...), Nothing),
-                    true)
-            end
-            @label done_finalizer
-            # Erase call to add_finalizer
-            ir[SSAValue(add_finalizer_idx)][:inst] = nothing
+        if finalizer_idx !== nothing && inlining !== nothing
+            try_resolve_finalizer!(ir, idx, finalizer_idx, defuse, inlining)
             continue
         end
         # Partition defuses by field
         fielddefuse = SSADefUse[SSADefUse() for _ = 1:fieldcount(typ)]
         all_eliminated = all_forwarded = true
-        has_finalizer = false
         for use in defuse.uses
             if use.kind === :preserve
                 for du in fielddefuse

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -916,14 +916,11 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing, InliningState} = nothin
             visited_phinodes, field, lifting_cache, result_t, lifted_leaves, val, lazydomtree)
 
         # Insert the undef check if necessary
-        if any_undef
-            if val === nothing
-                insert_node!(compact, SSAValue(idx),
-                    non_effect_free(NewInstruction(Expr(:throw_undef_if_not, Symbol("##getfield##"), false), Nothing)))
-            else
-                # val must be defined
-            end
+        if any_undef && val === nothing
+            insert_node!(compact, SSAValue(idx), non_effect_free(NewInstruction(
+                Expr(:throw_undef_if_not, Symbol("##getfield##"), false), Nothing)))
         else
+            # val must be defined
             @assert val !== nothing
         end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1192,8 +1192,8 @@ function print_fullname(io::IO, m::Module)
     end
 end
 
-function sourceinfo_slotnames(src::CodeInfo)
-    slotnames = src.slotnames
+sourceinfo_slotnames(src::CodeInfo) = sourceinfo_slotnames(src.slotnames)
+function sourceinfo_slotnames(slotnames::Vector{Symbol})
     names = Dict{String,Int}()
     printnames = Vector{String}(undef, length(slotnames))
     for i in eachindex(slotnames)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1602,6 +1602,7 @@ JL_CALLABLE(jl_f_donotdelete)
 
 JL_CALLABLE(jl_f_finalizer)
 {
+    // NOTE the compiler may temporarily insert additional argument for the later inlining pass
     JL_NARGS(finalizer, 2, 4);
     jl_task_t *ct = jl_current_task;
     jl_gc_add_finalizer_(ct->ptls, args[1], args[0]);

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1300,10 +1300,68 @@ mutable struct DoAllocNoEscape
         end
     end
 end
-
 let src = code_typed1() do
         for i = 1:1000
             DoAllocNoEscape()
+        end
+    end
+    @test count(isnew, src.code) == 0
+end
+
+# Test that a case when `Core.finalizer` is registered interprocedurally,
+# but still eligible for SROA after inlining
+mutable struct DoAllocNoEscapeInter end
+
+let src = code_typed1() do
+        for i = 1:1000
+            obj = DoAllocNoEscapeInter()
+            finalizer(obj) do this
+                nothrow_side_effect(nothing)
+            end
+        end
+    end
+    @test count(isnew, src.code) == 0
+end
+
+function register_finalizer!(obj)
+    finalizer(obj) do this
+        nothrow_side_effect(nothing)
+    end
+end
+let src = code_typed1() do
+        for i = 1:1000
+            obj = DoAllocNoEscapeInter()
+            register_finalizer!(obj)
+        end
+    end
+    @test count(isnew, src.code) == 0
+end
+
+function genfinalizer(val)
+    return function (this)
+        nothrow_side_effect(val)
+    end
+end
+let src = code_typed1() do
+        for i = 1:1000
+            obj = DoAllocNoEscapeInter()
+            finalizer(genfinalizer(nothing), obj)
+        end
+    end
+    @test count(isnew, src.code) == 0
+end
+
+# Test that we can inline a finalizer that just returns a constant value
+mutable struct DoAllocConst
+    function DoAllocConst()
+        finalizer(new()) do this
+            return nothing
+        end
+    end
+end
+let src = code_typed1() do
+        for i = 1:1000
+            DoAllocConst()
         end
     end
     @test count(isnew, src.code) == 0
@@ -1334,7 +1392,6 @@ end
 @test f_finalizer_throws()
 
 # Test finalizers with static parameters
-global last_finalizer_type::Type = Any
 mutable struct DoAllocNoEscapeSparam{T}
     x::T
     function finalizer_sparam(d::DoAllocNoEscapeSparam{T}) where {T}
@@ -1346,7 +1403,6 @@ mutable struct DoAllocNoEscapeSparam{T}
     end
 end
 DoAllocNoEscapeSparam(x::T) where {T} = DoAllocNoEscapeSparam{T}(x)
-
 let src = code_typed1(Tuple{Any}) do x
         for i = 1:1000
             DoAllocNoEscapeSparam(x)
@@ -1366,7 +1422,6 @@ mutable struct DoAllocNoEscapeNoInline
         finalizer(noinline_finalizer, new())
     end
 end
-
 let src = code_typed1() do
         for i = 1:1000
             DoAllocNoEscapeNoInline()
@@ -1374,6 +1429,28 @@ let src = code_typed1() do
     end
     @test count(isnew, src.code) == 1
     @test count(isinvoke(:noinline_finalizer), src.code) == 1
+end
+
+# Test that we resolve a `finalizer` call that we don't handle currently
+mutable struct DoAllocNoEscapeBranch
+    val::Int
+    function DoAllocNoEscapeBranch(val::Int)
+        finalizer(new(val)) do this
+            if this.val > 500
+                nothrow_side_effect(this.val)
+            else
+                nothrow_side_effect(nothing)
+            end
+        end
+    end
+end
+let src = code_typed1() do
+        for i = 1:1000
+            DoAllocNoEscapeBranch(i)
+        end
+    end
+    @test !any(iscall((src, Core.finalizer)), src.code)
+    @test !any(isinvoke(:finalizer), src.code)
 end
 
 # optimize `[push!|pushfirst!](::Vector{Any}, x...)`


### PR DESCRIPTION
- added more comments to explain the purpose of code
- properly handle `ConstantCase`
- erase `Core.finalizer` call more aggressively
- improved type stabilities by handling edge cases
- renamed `AddFianlizerUse` to `FinalizerUse`
- removed dead pieces of code