### PR TITLE
convert some equalities to symbols to use === rather than ==

### DIFF
--- a/base/atomics.jl
+++ b/base/atomics.jl
@@ -20,7 +20,7 @@ export
 # - LLVM doesn't currently support atomics on floats for ppc64
 #   C++20 is adding limited support for atomics on float, but as of
 #   now Clang does not support that yet.
-if Sys.ARCH == :i686 || startswith(string(Sys.ARCH), "arm") ||
+if Sys.ARCH === :i686 || startswith(string(Sys.ARCH), "arm") ||
    Sys.ARCH === :powerpc64le || Sys.ARCH === :ppc64le
     const inttypes = (Int8, Int16, Int32, Int64,
                       UInt8, UInt16, UInt32, UInt64)

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -763,7 +763,7 @@ function statement_cost(ex::Expr, line::Int, src::Union{CodeInfo, IRCode}, sptyp
             return 0
         end
         return error_path ? params.inline_error_path_cost : params.inline_nonleaf_penalty
-    elseif head === :foreigncall || head === :invoke || head == :invoke_modify
+    elseif head === :foreigncall || head === :invoke || head === :invoke_modify
         # Calls whose "return type" is Union{} do not actually return:
         # they are errors. Since these are not part of the typical
         # run-time of the function, we omit them from

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -481,7 +481,7 @@ function domsort_ssa!(ir::IRCode, domtree::DomTree)
             result[inst_range[end]][:inst] = GotoIfNot(terminator.cond, bb_rename[terminator.dest])
         elseif !isa(terminator, ReturnNode)
             if isa(terminator, Expr)
-                if terminator.head == :enter
+                if terminator.head === :enter
                     terminator.args[1] = bb_rename[terminator.args[1]]
                 end
             end

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -155,7 +155,7 @@ the MethodTable).
 """
 macro max_methods(n::Int, fdef::Expr)
     0 < n <= 255 || error("We must have that `1 <= max_methods <= 255`, but `max_methods = $n`.")
-    (fdef.head == :function && length(fdef.args) == 1) || error("Second argument must be a function forward declaration")
+    (fdef.head === :function && length(fdef.args) == 1) || error("Second argument must be a function forward declaration")
     return :(typeof($(esc(fdef))).name.max_methods = $(UInt8(n)))
 end
 

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -96,7 +96,7 @@ rather than line 2 where `@test` is used as an implementation detail.
 """
 function replace_sourceloc!(sourceloc, @nospecialize(ex))
     if ex isa Expr
-        if ex.head == :macrocall
+        if ex.head === :macrocall
             ex.args[2] = sourceloc
         end
         map!(e -> replace_sourceloc!(sourceloc, e), ex.args, ex.args)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1642,7 +1642,7 @@ function bodyfunction(basemethod::Method)
     f = nothing
     if isa(ast, Core.CodeInfo) && length(ast.code) >= 2
         callexpr = ast.code[end-1]
-        if isa(callexpr, Expr) && callexpr.head == :call
+        if isa(callexpr, Expr) && callexpr.head === :call
             fsym = callexpr.args[1]
             if isa(fsym, Symbol)
                 f = getfield(fmod, fsym)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1195,7 +1195,7 @@ function sourceinfo_slotnames(src::CodeInfo)
     names = Dict{String,Int}()
     printnames = Vector{String}(undef, length(slotnames))
     for i in eachindex(slotnames)
-        if slotnames[i] == :var"#unused#"
+        if slotnames[i] === :var"#unused#"
             printnames[i] = "_"
             continue
         end
@@ -2019,7 +2019,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
     # other call-like expressions ("A[1,2]", "T{X,Y}", "f.(X,Y)")
     elseif haskey(expr_calls, head) && nargs >= 1  # :ref/:curly/:calldecl/:(.)
         funcargslike = head === :(.) ? (args[2]::Expr).args : args[2:end]
-        show_call(head == :ref ? IOContext(io, beginsym=>true) : io, head, args[1], funcargslike, indent, quote_level, head !== :curly)
+        show_call(head === :ref ? IOContext(io, beginsym=>true) : io, head, args[1], funcargslike, indent, quote_level, head !== :curly)
 
     # comprehensions
     elseif head === :typed_comprehension && nargs == 2

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -26,9 +26,9 @@ function nthreads end
 
 nthreads() = Int(unsafe_load(cglobal(:jl_n_threads, Cint)))
 function nthreads(pool::Symbol)
-    if pool == :default
+    if pool === :default
         tpid = Int8(0)
-    elseif pool == :interactive
+    elseif pool === :interactive
         tpid = Int8(1)
     else
         error("invalid threadpool specified")

--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -281,7 +281,7 @@ function launch_on_machine(manager::SSHManager, machine::AbstractString, cnt, pa
     end
 
     # Julia process with passed in command line flag arguments
-    if shell == :posix
+    if shell === :posix
         # ssh connects to a POSIX shell
 
         cmds = "exec $(shell_escape_posixly(exename)) $(shell_escape_posixly(exeflags))"
@@ -297,7 +297,7 @@ function launch_on_machine(manager::SSHManager, machine::AbstractString, cnt, pa
         # shell login (-l) with string command (-c) to launch julia process
         remotecmd = shell_escape_posixly(`sh -l -c $cmds`)
 
-    elseif shell == :csh
+    elseif shell === :csh
         # ssh connects to (t)csh
 
         remotecmd = "exec $(shell_escape_csh(exename)) $(shell_escape_csh(exeflags))"
@@ -313,7 +313,7 @@ function launch_on_machine(manager::SSHManager, machine::AbstractString, cnt, pa
             remotecmd = "cd $(shell_escape_csh(dir))\n$remotecmd"
         end
 
-    elseif shell == :wincmd
+    elseif shell === :wincmd
         # ssh connects to Windows cmd.exe
 
         any(c -> c == '"', exename) && throw(ArgumentError("invalid exename"))

--- a/stdlib/InteractiveUtils/src/clipboard.jl
+++ b/stdlib/InteractiveUtils/src/clipboard.jl
@@ -51,7 +51,7 @@ elseif Sys.islinux() || Sys.KERNEL === :FreeBSD
         _clipboardcmd !== nothing && return _clipboardcmd
         for cmd in (:xclip, :xsel, :wlclipboard)
             # wl-clipboard ships wl-copy/paste individually
-            c = cmd == :wlclipboard ? Symbol("wl-copy") : cmd
+            c = cmd === :wlclipboard ? Symbol("wl-copy") : cmd
             success(pipeline(`which $c`, devnull)) && return _clipboardcmd = cmd
         end
         pkgs = @static if Sys.KERNEL === :FreeBSD
@@ -83,7 +83,7 @@ elseif Sys.iswindows()
         x_u16 = Base.cwstring(x)
         pdata = Ptr{UInt16}(C_NULL)
         function cleanup(cause)
-            errno = cause == :success ? UInt32(0) : Libc.GetLastError()
+            errno = cause === :success ? UInt32(0) : Libc.GetLastError()
             if cause !== :OpenClipboard
                 if cause !== :success && pdata != C_NULL
                     ccall((:GlobalFree, "kernel32"), stdcall, Cint, (Ptr{UInt16},), pdata)

--- a/stdlib/LinearAlgebra/src/lbt.jl
+++ b/stdlib/LinearAlgebra/src/lbt.jl
@@ -159,9 +159,9 @@ function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, lbt::LBTConfig)
     println(io, "Libraries: ")
     for (i,l) in enumerate(lbt.loaded_libs)
         char = i == length(lbt.loaded_libs) ? "└" : "├"
-        interface_str = if l.interface == :ilp64
+        interface_str = if l.interface === :ilp64
             "ILP64"
-        elseif l.interface == :lp64
+        elseif l.interface === :lp64
             " LP64"
         else
             "UNKWN"

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -242,7 +242,7 @@ function print(io::IO,
         tasks::Union{UInt,AbstractVector{UInt}} = typemin(UInt):typemax(UInt))
 
     pf = ProfileFormat(;C, combine, maxdepth, mincount, noisefloor, sortedby, recur)
-    if groupby == :none
+    if groupby === :none
         print(io, data, lidict, pf, format, threads, tasks, false)
     else
         if !in(groupby, [:thread, :task, [:task, :thread], [:thread, :task]])
@@ -285,7 +285,7 @@ function print(io::IO,
                     end
                 end
             end
-        elseif groupby == :task
+        elseif groupby === :task
             threads = 1:typemax(Int)
             for taskid in intersect(get_task_ids(data), tasks)
                 printstyled(io, "Task $(Base.repr(taskid)) "; bold=true, color=Base.debug_color())
@@ -293,7 +293,7 @@ function print(io::IO,
                 nosamples && (any_nosamples = true)
                 println(io)
             end
-        elseif groupby == :thread
+        elseif groupby === :thread
             tasks = 1:typemax(UInt)
             for threadid in intersect(get_thread_ids(data), threads)
                 printstyled(io, "Thread $threadid "; bold=true, color=Base.info_color())

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1323,9 +1323,9 @@ end
 function edit_input(s, f = (filename, line, column) -> InteractiveUtils.edit(filename, line, column))
     mode_name = guess_current_mode_name(s)
     filename = tempname()
-    if mode_name == :julia
+    if mode_name === :julia
         filename *= ".jl"
-    elseif mode_name == :shell
+    elseif mode_name === :shell
         filename *= ".sh"
     end
     buf = buffer(s)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -179,7 +179,7 @@ function check_for_missing_packages_and_run_hooks(ast)
 end
 
 function modules_to_be_loaded(ast::Expr, mods::Vector{Symbol} = Symbol[])
-    ast.head == :quote && return mods # don't search if it's not going to be run during this eval
+    ast.head === :quote && return mods # don't search if it's not going to be run during this eval
     if ast.head in [:using, :import]
         for arg in ast.args
             arg = arg::Expr

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -180,7 +180,7 @@ end
 
 function modules_to_be_loaded(ast::Expr, mods::Vector{Symbol} = Symbol[])
     ast.head === :quote && return mods # don't search if it's not going to be run during this eval
-    if ast.head in [:using, :import]
+    if ast.head === :using || ast.head === :import
         for arg in ast.args
             arg = arg::Expr
             arg1 = first(arg.args)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1323,7 +1323,7 @@ fake_repl() do stdin_write, stdout_read, repl
     # necessary to read at least some part of the buffer,
     # for the "region_active" to have time to be updated
 
-    @test LineEdit.state(repl.mistate).region_active == :off
+    @test LineEdit.state(repl.mistate).region_active === :off
     @test s4 == "anything" # no control characters between the last two occurrences of "anything"
     write(stdin_write, "\x15\x04")
     Base.wait(repltask)


### PR DESCRIPTION
I am not sure this optimization is still applicable to inference. But there seems to be consensus in the source that `===` for `Symbol` is the correct mechanism for equality comparison.