### PR TITLE
fully normalize `x == ::Symbol` to `x === ::Symbol`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -803,7 +803,7 @@ function getfield_nothrow(@nospecialize(s00), @nospecialize(name), boundscheck::
     elseif isa(s, DataType)
         # Can't say anything about abstract types
         isabstracttype(s) && return false
-        s.name.atomicfields == C_NULL || return false # TODO: currently we're only testing for ordering == :not_atomic
+        s.name.atomicfields == C_NULL || return false # TODO: currently we're only testing for ordering === :not_atomic
         # If all fields are always initialized, and bounds check is disabled, we can assume
         # we don't throw
         if !boundscheck && s.name.n_uninitialized == 0
@@ -1020,7 +1020,7 @@ function setfield!_nothrow(s00, name, v)
         # Can't say anything about abstract types
         isabstracttype(s) && return false
         ismutabletype(s) || return false
-        s.name.atomicfields == C_NULL || return false # TODO: currently we're only testing for ordering == :not_atomic
+        s.name.atomicfields == C_NULL || return false # TODO: currently we're only testing for ordering === :not_atomic
         isa(name, Const) || return false
         field = try_compute_fieldidx(s, name.val)
         field === nothing && return false

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -649,7 +649,7 @@ macro assume_effects(args...)
     end
     ex = args[end]
     isa(ex, Expr) || throw(ArgumentError("Bad expression `$ex` in `@assume_effects [settings] ex`"))
-    if ex.head === :macrocall && ex.args[1] == Symbol("@ccall")
+    if ex.head === :macrocall && ex.args[1] === Symbol("@ccall")
         ex.args[1] = GlobalRef(Base, Symbol("@ccall_effects"))
         insert!(ex.args, 3, Core.Compiler.encode_effects_override(Core.Compiler.EffectsOverride(
             consistent, effect_free, nothrow, terminates_globally, terminates_locally, notaskstate

--- a/base/task.jl
+++ b/base/task.jl
@@ -924,7 +924,7 @@ function trypoptask(W::StickyWorkqueue)
             # can't throw here, because it's probably not the fault of the caller to wait
             # and don't want to use print() here, because that may try to incur a task switch
             ccall(:jl_safe_printf, Cvoid, (Ptr{UInt8}, Int32...),
-                "\nWARNING: Workqueue inconsistency detected: popfirst!(Workqueue).state != :runnable\n")
+                "\nWARNING: Workqueue inconsistency detected: popfirst!(Workqueue).state !== :runnable\n")
             continue
         end
         return t

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -785,9 +785,9 @@ defined to add new functionality:
 julia> Base.propertynames(::Point, private::Bool=false) = private ? (:x, :y, :r, :ϕ) : (:x, :y)
 
 julia> function Base.getproperty(p::Point, s::Symbol)
-           if s == :x
+           if s === :x
                return getfield(p, :r) * cos(getfield(p, :ϕ))
-           elseif s == :y
+           elseif s === :y
                return getfield(p, :r) * sin(getfield(p, :ϕ))
            else
                # This allows accessing fields with p.r and p.ϕ
@@ -796,12 +796,12 @@ julia> function Base.getproperty(p::Point, s::Symbol)
        end
 
 julia> function Base.setproperty!(p::Point, s::Symbol, f)
-           if s == :x
+           if s === :x
                y = p.y
                setfield!(p, :r, sqrt(f^2 + y^2))
                setfield!(p, :ϕ, atan(y, f))
                return f
-           elseif s == :y
+           elseif s === :y
                x = p.x
                setfield!(p, :r, sqrt(x^2 + f^2))
                setfield!(p, :ϕ, atan(f, x))

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -116,7 +116,7 @@ The [`Symbol`](@ref) constructor takes any number of arguments and creates a new
 their string representations together:
 
 ```jldoctest
-julia> :foo == Symbol("foo")
+julia> :foo === Symbol("foo")
 true
 
 julia> Symbol("func",10)

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -126,7 +126,7 @@ function testf(id)
     @test_throws ErrorException put!(f, :OK) # Cannot put! to a already set future
     @test_throws MethodError take!(f) # take! is unsupported on a Future
 
-    @test fetch(f) == :OK
+    @test fetch(f) === :OK
 end
 
 testf(id_me)
@@ -218,7 +218,7 @@ isready(f)
 @test remotecall_fetch(k->haskey(Distributed.PGRP.refs, k), wid1, fid) == true
 put!(f, :OK)
 @test remotecall_fetch(k->haskey(Distributed.PGRP.refs, k), wid1, fid) == false
-@test fetch(f) == :OK
+@test fetch(f) === :OK
 
 # RemoteException should be thrown on a put! when another process has set the value
 f = Future(wid1)
@@ -270,7 +270,7 @@ function test_remoteref_dgc(id)
 
     # remote value should be deleted after finalizing the ref
     @test remotecall_fetch(k->(yield();haskey(Distributed.PGRP.refs, k)), id, rrid) == true
-    @test fetch(rr) == :OK
+    @test fetch(rr) === :OK
     @test remotecall_fetch(k->(yield();haskey(Distributed.PGRP.refs, k)), id, rrid) == true
     finalize(rr)
     yield(); # flush gc msgs
@@ -349,7 +349,7 @@ function test_regular_io_ser(ref::Distributed.AbstractRemoteRef)
         v = getfield(ref2, fld)
         if isa(v, Number)
             @test v === zero(typeof(v))
-        elseif fld == :lock
+        elseif fld === :lock
             @test v isa ReentrantLock
             @test !islocked(v)
         elseif v !== nothing
@@ -528,7 +528,7 @@ let ex
     bt = ex.captured.processed_bt::Array{Any,1}
     @test length(bt) > 1
     frame, repeated = bt[1]::Tuple{Base.StackTraces.StackFrame, Int}
-    @test frame.func == :foo
+    @test frame.func === :foo
     @test frame.linfo === nothing
     @test repeated == 1
 end
@@ -815,11 +815,11 @@ function f13168(n)
     return val
 end
 let t = schedule(@task f13168(100))
-    @test t.state == :runnable
+    @test t.state === :runnable
     @test t.queue !== nothing
     @test_throws ErrorException schedule(t)
     yield()
-    @test t.state == :done
+    @test t.state === :done
     @test t.queue === nothing
     @test_throws ErrorException schedule(t)
     @test isa(fetch(t), Float64)
@@ -900,7 +900,7 @@ end
             take!(rc)[1] != float(i) && error("Failed")
         end
         return :OK
-    end, id_other, rc_unbuffered) == :OK
+    end, id_other, rc_unbuffered) === :OK
 
 # github issue 33972
 rc_unbuffered_other = RemoteChannel(()->Channel{Int}(0), id_other)
@@ -997,7 +997,7 @@ let
     @test_throws RemoteException remotecall_fetch(bad_thunk, 2)
 
     # Test that the stream is still usable
-    @test remotecall_fetch(()->:test,2) == :test
+    @test remotecall_fetch(()->:test,2) === :test
     ref = remotecall(bad_thunk, 2)
     @test_throws RemoteException fetch(ref)
 end
@@ -1175,11 +1175,11 @@ function launch(manager::ErrorSimulator, params::Dict, launched::Array, c::Condi
     dir = params[:dir]
 
     cmd = `$(Base.julia_cmd(exename)) --startup-file=no`
-    if manager.mode == :timeout
+    if manager.mode === :timeout
         cmd = `$cmd -e "sleep(10)"`
-    elseif manager.mode == :ntries
+    elseif manager.mode === :ntries
         cmd = `$cmd -e "[println(x) for x in 1:1001]"`
-    elseif manager.mode == :exit
+    elseif manager.mode === :exit
         cmd = `$cmd -e "exit(-1)"`
     else
         error("Unknown mode")

--- a/stdlib/Distributed/test/topology.jl
+++ b/stdlib/Distributed/test/topology.jl
@@ -62,9 +62,9 @@ end
 
 const map_pid_ident=Dict()
 function manage(manager::TopoTestManager, id::Integer, config::WorkerConfig, op::Symbol)
-    if op == :register
+    if op === :register
         map_pid_ident[id] = config.ident
-    elseif op == :interrupt
+    elseif op === :interrupt
         kill(config.process, 2)
     end
 end

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -60,11 +60,11 @@ function varinfo(m::Module=Base.active_module(), pattern::Regex=r""; all::Bool =
             end
         end
     end
-    let (col, rev) = if sortby == :name
+    let (col, rev) = if sortby === :name
             1, false
-        elseif sortby == :size
+        elseif sortby === :size
             4, true
-        elseif sortby == :summary
+        elseif sortby === :summary
             3, false
         else
             @assert "unreachable"

--- a/stdlib/InteractiveUtils/src/clipboard.jl
+++ b/stdlib/InteractiveUtils/src/clipboard.jl
@@ -90,7 +90,7 @@ elseif Sys.iswindows()
                 end
                 ccall((:CloseClipboard, "user32"), stdcall, Cint, ()) == 0 && Base.windowserror(:CloseClipboard) # this should never fail
             end
-            cause == :success || Base.windowserror(cause, errno)
+            cause === :success || Base.windowserror(cause, errno)
             nothing
         end
         ccall((:OpenClipboard, "user32"), stdcall, Cint, (Ptr{Cvoid},), C_NULL) == 0 && return Base.windowserror(:OpenClipboard)
@@ -110,7 +110,7 @@ elseif Sys.iswindows()
     clipboard(x) = clipboard(sprint(print, x)::String)
     function clipboard()
         function cleanup(cause)
-            errno = cause == :success ? UInt32(0) : Libc.GetLastError()
+            errno = cause === :success ? UInt32(0) : Libc.GetLastError()
             if cause !== :OpenClipboard
                 ccall((:CloseClipboard, "user32"), stdcall, Cint, ()) == 0 && Base.windowserror(:CloseClipboard) # this should never fail
             end

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -245,7 +245,7 @@ const curmod_str = curmod === Main ? "Main" : join(curmod_name, ".")
 
 @test_throws ErrorException("\"this_is_not_defined\" is not defined in module $curmod_str") @which this_is_not_defined
 # issue #13264
-@test (@which vcat(1...)).name == :vcat
+@test (@which vcat(1...)).name === :vcat
 
 # PR #28122, issue #25474
 @test (@which [1][1]).name === :getindex
@@ -373,7 +373,7 @@ struct A14637
     x
 end
 a14637 = A14637(0)
-@test (@which a14637.x).name == :getproperty
+@test (@which a14637.x).name === :getproperty
 @test (@functionloc a14637.x)[2] isa Integer
 
 # Issue #28615
@@ -615,7 +615,7 @@ end
     export B41010
 
     ms = methodswith(A41010, @__MODULE__) |> collect
-    @test ms[1].name == :B41010
+    @test ms[1].name === :B41010
 end
 
 # macro options should accept both literals and variables

--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -98,8 +98,8 @@ function challenge_prompt(cmd::Cmd, challenges; timeout::Integer=60, debug::Bool
 
         status = fetch(timer)
         close(ptm)
-        if status != :success
-            if status == :timeout
+        if status !== :success
+            if status === :timeout
                 error("Process timed out possibly waiting for a response. ",
                       format_output(out))
             else

--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -5455,7 +5455,7 @@ for (bdsdc, elty) in
             elseif compq == 'P'
                 @warn "COMPQ='P' is not tested"
                 #TODO turn this into an actual LAPACK call
-                #smlsiz=ilaenv(9, $elty==:Float64 ? 'dbdsqr' : 'sbdsqr', string(uplo, compq), n,n,n,n)
+                #smlsiz=ilaenv(9, $elty === :Float64 ? 'dbdsqr' : 'sbdsqr', string(uplo, compq), n,n,n,n)
                 smlsiz=100 #For now, completely overkill
                 ldq = n*(11+2*smlsiz+8*round(Int,log((n/(smlsiz+1)))/log(2)))
                 ldiq = n*(3+3*round(Int,log(n/(smlsiz+1))/log(2)))

--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -82,7 +82,7 @@ convert(T::Type{<:UpperTriangular}, m::PossibleTriangularMatrix) = m isa T ? m :
 #     f(x::S, y::T) where {S,T} = x+y
 #     f(y::T, x::S) where {S,T} = f(x, y)
 macro commutative(myexpr)
-    @assert myexpr.head===:(=) || myexpr.head===:function # Make sure it is a function definition
+    @assert Base.is_function_def(myexpr) # Make sure it is a function definition
     y = copy(myexpr.args[1].args[2:end])
     reverse!(y)
     reversed_call = Expr(:(=), Expr(:call,myexpr.args[1].args[1],y...), myexpr.args[1])

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -126,12 +126,12 @@ Random.seed!(1)
         @testset "Constructor and basic properties" begin
             @test size(T, 1) == size(T, 2) == n
             @test size(T) == (n, n)
-            @test Array(T) == diagm(0 => dv, (uplo == :U ? 1 : -1) => ev)
+            @test Array(T) == diagm(0 => dv, (uplo === :U ? 1 : -1) => ev)
             @test Bidiagonal(Array(T), uplo) == T
             @test big.(T) == T
-            @test Array(abs.(T)) == abs.(diagm(0 => dv, (uplo == :U ? 1 : -1) => ev))
-            @test Array(real(T)) == real(diagm(0 => dv, (uplo == :U ? 1 : -1) => ev))
-            @test Array(imag(T)) == imag(diagm(0 => dv, (uplo == :U ? 1 : -1) => ev))
+            @test Array(abs.(T)) == abs.(diagm(0 => dv, (uplo === :U ? 1 : -1) => ev))
+            @test Array(real(T)) == real(diagm(0 => dv, (uplo === :U ? 1 : -1) => ev))
+            @test Array(imag(T)) == imag(diagm(0 => dv, (uplo === :U ? 1 : -1) => ev))
         end
 
         @testset for func in (conj, transpose, adjoint)
@@ -356,7 +356,7 @@ Random.seed!(1)
 
         @testset "diag" begin
             @test (@inferred diag(T))::typeof(dv) == dv
-            @test (@inferred diag(T, uplo == :U ? 1 : -1))::typeof(dv) == ev
+            @test (@inferred diag(T, uplo === :U ? 1 : -1))::typeof(dv) == ev
             @test (@inferred diag(T,2))::typeof(dv) == zeros(elty, n-2)
             @test_throws ArgumentError diag(T, -n - 1)
             @test_throws ArgumentError diag(T,  n + 1)
@@ -364,7 +364,7 @@ Random.seed!(1)
             gdv, gev = GenericArray(dv), GenericArray(ev)
             G = Bidiagonal(gdv, gev, uplo)
             @test (@inferred diag(G))::typeof(gdv) == gdv
-            @test (@inferred diag(G, uplo == :U ? 1 : -1))::typeof(gdv) == gev
+            @test (@inferred diag(G, uplo === :U ? 1 : -1))::typeof(gdv) == gev
             @test (@inferred diag(G,2))::typeof(gdv) == GenericArray(zeros(elty, n-2))
         end
 
@@ -372,9 +372,9 @@ Random.seed!(1)
             if relty <: AbstractFloat
                 d1, v1 = eigen(T)
                 d2, v2 = eigen(map(elty<:Complex ? ComplexF64 : Float64,Tfull), sortby=nothing)
-                @test (uplo == :U ? d1 : reverse(d1)) ≈ d2
+                @test (uplo === :U ? d1 : reverse(d1)) ≈ d2
                 if elty <: Real
-                    test_approx_eq_modphase(v1, uplo == :U ? v2 : v2[:,n:-1:1])
+                    test_approx_eq_modphase(v1, uplo === :U ? v2 : v2[:,n:-1:1])
                 end
             end
         end

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -11,7 +11,7 @@ fabs(x::Complex) = abs(real(x)) + abs(imag(x))
 function pack(A, uplo)
     AP = eltype(A)[]
     n = size(A, 1)
-    for j in 1:n, i in (uplo==:L ? (j:n) : (1:j))
+    for j in 1:n, i in (uplo === :L ? (j:n) : (1:j))
         push!(AP, A[i,j])
     end
     return AP

--- a/stdlib/LinearAlgebra/test/bunchkaufman.jl
+++ b/stdlib/LinearAlgebra/test/bunchkaufman.jl
@@ -70,10 +70,10 @@ bimg  = randn(n,2)/2
                 @test getproperty(bc1, uplo)*bc1.D*transpose(getproperty(bc1, uplo)) ≈ asym[bc1.p, bc1.p]
                 @test getproperty(bc1, uplo)*bc1.D*transpose(getproperty(bc1, uplo)) ≈ bc1.P*asym*transpose(bc1.P)
                 @test_throws ErrorException bc1.Z
-                @test_throws ArgumentError uplo == :L ? bc1.U : bc1.L
+                @test_throws ArgumentError uplo === :L ? bc1.U : bc1.L
             end
             # test Base.iterate
-            ref_objs = (bc1.D, uplo == :L ? bc1.L : bc1.U, bc1.p)
+            ref_objs = (bc1.D, uplo === :L ? bc1.L : bc1.U, bc1.p)
             for (bki, bkobj) in enumerate(bc1)
                 @test bkobj == ref_objs[bki]
             end
@@ -162,7 +162,7 @@ end
         @test B.D == Tridiagonal([], [], [])
         @test B.P == ones(0, 0)
         @test B.p == []
-        if ul == :U
+        if ul === :U
             @test B.U == UnitUpperTriangular(ones(0, 0))
             @test_throws ArgumentError B.L
         else

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -574,13 +574,13 @@ end
         # Hermitian
         A = Hermitian(fill(1.0+0im, 2, 2), uplo)
         @test fill!(A, 2) == fill(2, 2, 2)
-        @test A.data == (uplo == :U ? [2 2; 1.0+0im 2] : [2 1.0+0im; 2 2])
+        @test A.data == (uplo === :U ? [2 2; 1.0+0im 2] : [2 1.0+0im; 2 2])
         @test_throws ArgumentError fill!(A, 2+im)
 
         # Symmetric
         A = Symmetric(fill(1.0+im, 2, 2), uplo)
         @test fill!(A, 2) == fill(2, 2, 2)
-        @test A.data == (uplo == :U ? [2 2; 1.0+im 2] : [2 1.0+im; 2 2])
+        @test A.data == (uplo === :U ? [2 2; 1.0+im 2] : [2 1.0+im; 2 2])
     end
 end
 

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -26,7 +26,7 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
                         (UnitLowerTriangular, :L))
 
         # Construct test matrix
-        A1 = t1(elty1 == Int ? rand(1:7, n, n) : convert(Matrix{elty1}, (elty1 <: Complex ? complex.(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> cholesky(t't).U |> t -> uplo1 == :U ? t : copy(t')))
+        A1 = t1(elty1 == Int ? rand(1:7, n, n) : convert(Matrix{elty1}, (elty1 <: Complex ? complex.(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> cholesky(t't).U |> t -> uplo1 === :U ? t : copy(t')))
         @test t1(A1) === A1
         @test t1{elty1}(A1) === A1
         # test the ctor works for AbstractMatrix
@@ -77,7 +77,7 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
         A1c = copy(A1)
         for i = 1:size(A1, 1)
             for j = 1:size(A1, 2)
-                if uplo1 == :U
+                if uplo1 === :U
                     if i > j
                         A1c[i,j] = 0
                         @test_throws ArgumentError A1c[i,j] = 1
@@ -104,7 +104,7 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
         end
 
         # istril/istriu
-        if uplo1 == :L
+        if uplo1 === :L
             @test istril(A1)
             @test !istriu(A1)
             @test istriu(A1')
@@ -121,7 +121,7 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
         end
 
         #tril/triu
-        if uplo1 == :L
+        if uplo1 === :L
             @test tril(A1,0)  == A1
             @test tril(A1,-1) == LowerTriangular(tril(Matrix(A1), -1))
             @test tril(A1,1)  == t1(tril(tril(Matrix(A1), 1)))
@@ -319,7 +319,7 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
 
                 debug && println("elty1: $elty1, A1: $t1, elty2: $elty2")
 
-                A2 = t2(elty2 == Int ? rand(1:7, n, n) : convert(Matrix{elty2}, (elty2 <: Complex ? complex.(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> cholesky(t't).U |> t -> uplo2 == :U ? t : copy(t')))
+                A2 = t2(elty2 == Int ? rand(1:7, n, n) : convert(Matrix{elty2}, (elty2 <: Complex ? complex.(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> cholesky(t't).U |> t -> uplo2 === :U ? t : copy(t')))
 
                 # Convert
                 if elty1 <: Real && !(elty2 <: Integer)

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -151,14 +151,14 @@ end
     @profile busywait(1, 20)
     _, fdict0 = Profile.flatten(Profile.retrieve()...)
     Base.update_stackframes_callback[] = function(list)
-        modify((sf, n)) = sf.func == :busywait ? (StackTraces.StackFrame(sf.func, sf.file, sf.line+2, sf.linfo, sf.from_c, sf.inlined, sf.pointer), n) : (sf, n)
+        modify((sf, n)) = sf.func === :busywait ? (StackTraces.StackFrame(sf.func, sf.file, sf.line+2, sf.linfo, sf.from_c, sf.inlined, sf.pointer), n) : (sf, n)
         map!(modify, list, list)
     end
     _, fdictc = Profile.flatten(Profile.retrieve()...)
     Base.update_stackframes_callback[] = identity
     function getline(sfs)
         for sf in sfs
-            sf.func == :busywait && return sf.line
+            sf.func === :busywait && return sf.line
         end
         nothing
     end
@@ -263,7 +263,7 @@ end
     Profile.tree!(root, backtraces, lidict, #= C =# true, :off)
     @test length(root.down) == 2
     for k in keys(root.down)
-        @test k.file == :file1
+        @test k.file === :file1
         @test k.line ∈ (1, 2)
     end
     node = root.down[stackframe(:f1, :file1, 2)]

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -819,14 +819,14 @@ function completions(string::String, pos::Int, context_module::Module=Main, shif
         end
 
         #Latex symbols can be completed for strings
-        (success || inc_tag==:cmd) && return sort!(paths, by=p->p.path), r, success
+        (success || inc_tag === :cmd) && return sort!(paths, by=p->p.path), r, success
     end
 
     ok, ret = bslash_completions(string, pos)
     ok && return ret
 
     # Make sure that only bslash_completions is working on strings
-    inc_tag==:string && return Completion[], 0:-1, false
+    inc_tag === :string && return Completion[], 0:-1, false
     if inc_tag === :other && should_method_complete(partial)
         frange, method_name_end = find_start_brace(partial)
         # strip preceding ! operator

--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -29,7 +29,7 @@ function transform!(f, s, i = -1) # i is char-based (not bytes) buffer position
     # simulate what happens in LineEdit.set_action!
     s isa LineEdit.MIState && (s.current_action = :unknown)
     status = f(s)
-    if s isa LineEdit.MIState && status != :ignore
+    if s isa LineEdit.MIState && status !== :ignore
         # simulate what happens in LineEdit.prompt!
         s.last_action = s.current_action
     end

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -325,8 +325,8 @@ main_ex = quote
         local g2 = deserialize(ds)
         Base.invokelatest() do
             $Test.@test g2 !== g
-            $Test.@test g2() == :magic_token_anon_fun_test
-            $Test.@test g2() == :magic_token_anon_fun_test
+            $Test.@test g2() === :magic_token_anon_fun_test
+            $Test.@test g2() === :magic_token_anon_fun_test
             $Test.@test deserialize(ds) === g2
         end
 
@@ -354,7 +354,7 @@ create_serialization_stream() do s # user-defined type array
     seek(s, 0)
     r = deserialize(s)
     @test r.storage[:v] == 2
-    @test r.state == :done
+    @test r.state === :done
     @test r.exception === nothing
 end
 
@@ -366,7 +366,7 @@ create_serialization_stream() do s # user-defined type array
     serialize(s, t)
     seek(s, 0)
     r = deserialize(s)
-    @test r.state == :failed
+    @test r.state === :failed
 end
 
 # corner case: undefined inside immutable struct

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1331,7 +1331,7 @@ macro testset(args...)
     tests = args[end]
 
     # Determine if a single block or for-loop style
-    if !isa(tests,Expr) || (tests.head !== :for && tests.head !== :block && tests.head != :call)
+    if !isa(tests,Expr) || (tests.head !== :for && tests.head !== :block && tests.head !== :call)
 
         error("Expected function call, begin/end block or for loop as argument to @testset")
     end

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -409,19 +409,19 @@ end
                 @test true
                 @test false
                 @test 1 == 1
-                @test 2 == :foo
+                @test 2 === :foo
                 @test 3 == 3
                 @testset "d" begin
                     @test 4 == 4
                 end
                 @testset begin
-                    @test :blank != :notblank
+                    @test :blank !== :notblank
                 end
             end
             @testset "inner1" begin
                 @test 1 == 1
                 @test 2 == 2
-                @test 3 == :bar
+                @test 3 === :bar
                 @test 4 == 4
                 @test_throws ErrorException 1+1
                 @test_throws ErrorException error()
@@ -1387,12 +1387,12 @@ Test.finish(ts::PassInformationTestSet) = ts
     end
     test_line_number = (@__LINE__) - 3
     test_throws_line_number =  (@__LINE__) - 3
-    @test ts.results[1].test_type == :test
+    @test ts.results[1].test_type === :test
     @test ts.results[1].orig_expr == :(1 == 1)
     @test ts.results[1].data == Expr(:comparison, 1, :(==), 1)
     @test ts.results[1].value == true
     @test ts.results[1].source == LineNumberNode(test_line_number, @__FILE__)
-    @test ts.results[2].test_type == :test_throws
+    @test ts.results[2].test_type === :test_throws
     @test ts.results[2].orig_expr == :(throw(ErrorException("Msg")))
     @test ts.results[2].data == ErrorException
     @test ts.results[2].value == ErrorException("Msg")

--- a/test/asyncmap.jl
+++ b/test/asyncmap.jl
@@ -64,7 +64,7 @@ let
     end
     @test e isa CapturedException
     @test e.ex == ErrorException("captured")
-    @test e.processed_bt[2][1].func == :f42105
+    @test e.processed_bt[2][1].func === :f42105
 end
 
 include("generic_map_tests.jl")

--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -35,7 +35,7 @@ catch err
     @test endswith(string(lkup[2].file), "backtrace.jl")
     @test lkup[2].line == 42
     # TODO: we don't support surface AST locations with inlined function names
-    @test_broken lkup[1].func == :inlfunc
+    @test_broken lkup[1].func === :inlfunc
     @test endswith(string(lkup[1].file), "backtrace.jl")
     @test lkup[1].line == 37
 end
@@ -106,10 +106,10 @@ lkup = map(lookup, bt())
 hasbt = hasbt2 = false
 for sfs in lkup
     for sf in sfs
-        if sf.func == :bt
+        if sf.func === :bt
             global hasbt = true
         end
-        if sf.func == :bt2
+        if sf.func === :bt2
             global hasbt2 = true
         end
     end
@@ -125,10 +125,10 @@ lkup = map(lookup, btmacro())
 hasme = hasbtmacro = false
 for sfs in lkup
     for sf in sfs
-        if sf.func == Symbol("macro expansion")
+        if sf.func === Symbol("macro expansion")
             global hasme = true
         end
-        if sf.func == :btmacro
+        if sf.func === :btmacro
             global hasbtmacro = true
         end
     end
@@ -175,7 +175,7 @@ let bt, found = false
         bt = backtrace()
     end
     for frame in map(lookup, bt)
-        if frame[1].line == @__LINE__() - 3 && frame[1].file == Symbol(@__FILE__)
+        if frame[1].line == @__LINE__() - 3 && frame[1].file === Symbol(@__FILE__)
             found = true; break
         end
     end
@@ -187,7 +187,7 @@ let bt, found = false
     @debug ""
     bt = backtrace()
     for frame in map(lookup, bt)
-        if frame[1].line == @__LINE__() - 2 && frame[1].file == Symbol(@__FILE__)
+        if frame[1].line == @__LINE__() - 2 && frame[1].file === Symbol(@__FILE__)
             found = true; break
         end
     end
@@ -205,8 +205,8 @@ let trace = try
     catch
         stacktrace(catch_backtrace())
     end
-    @test trace[1].func == Symbol("top-level scope")
-    @test trace[1].file == :a_filename
+    @test trace[1].func === Symbol("top-level scope")
+    @test trace[1].file === :a_filename
     @test trace[1].line == 2
 end
 let trace = try
@@ -219,8 +219,8 @@ let trace = try
     catch
         stacktrace(catch_backtrace())
     end
-    @test trace[1].func == Symbol("top-level scope")
-    @test trace[1].file == :a_filename
+    @test trace[1].func === Symbol("top-level scope")
+    @test trace[1].file === :a_filename
     @test trace[1].line == 2
 end
 

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -359,7 +359,7 @@ end
         redirect_stderr(oldstderr)
         close(newstderr[2])
     end
-    @test fetch(errstream) == "\nWARNING: Workqueue inconsistency detected: popfirst!(Workqueue).state != :runnable\n"
+    @test fetch(errstream) == "\nWARNING: Workqueue inconsistency detected: popfirst!(Workqueue).state !== :runnable\n"
 end
 
 @testset "throwto" begin

--- a/test/compiler/EscapeAnalysis/EAUtils.jl
+++ b/test/compiler/EscapeAnalysis/EAUtils.jl
@@ -51,7 +51,7 @@ function code_escapes(@nospecialize(f), @nospecialize(types=Base.default_tt(f));
     interp = EscapeAnalyzer(interp, tt, optimize)
     results = Base.code_typed_by_type(tt; optimize=true, world, interp)
     isone(length(results)) || throw(ArgumentError("`code_escapes` only supports single analysis result"))
-    return EscapeResult(interp.ir, interp.state, interp.linfo, debuginfo===:source)
+    return EscapeResult(interp.ir, interp.state, interp.linfo, debuginfo === :source)
 end
 
 # in order to run a whole analysis from ground zero (e.g. for benchmarking, etc.)

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -713,9 +713,9 @@ struct A44921{T}
     x::T
 end
 function f44921(a)
-    if a == :x
+    if a === :x
         A44921(_f) # _f purposefully undefined
-    elseif a == :p
+    elseif a === :p
         g44921(a)
     end
 end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1817,10 +1817,10 @@ function f24852_kernel_cinfo(fsig::Type)
     Meta.partially_inline!(code_info.code, Any[], match.spec_types, Any[match.sparams...], 1, 0, :propagate)
     if startswith(String(match.method.name), "f24852")
         for a in code_info.code
-            if a isa Expr && a.head == :(=)
+            if Meta.isexpr(a, :(=))
                 a = a.args[2]
             end
-            if a isa Expr && length(a.args) === 3 && a.head === :call
+            if Meta.isexpr(a, :call) && length(a.args) === 3
                 pushfirst!(a.args, Core.SlotNumber(1))
             end
         end
@@ -2801,7 +2801,7 @@ foo_inlining_apply(args...) = ccall(:jl_, Nothing, (Any,), args[1])
 bar_inlining_apply() = Core._apply_iterate(iterate, Core._apply_iterate, (iterate,), (foo_inlining_apply,), ((1,),))
 let ci = code_typed(bar_inlining_apply, Tuple{})[1].first
     @test length(ci.code) == 2
-    @test ci.code[1].head == :foreigncall
+    @test ci.code[1].head === :foreigncall
 end
 
 # Test that inference can infer .instance of types

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -128,8 +128,8 @@ end
 @testset "issue #19122: [no]inline of short func. def. with return type annotation" begin
     exf19122 = @macroexpand(@inline f19122()::Bool = true)
     exg19122 = @macroexpand(@noinline g19122()::Bool = true)
-    @test exf19122.args[2].args[1].args[1] == :inline
-    @test exg19122.args[2].args[1].args[1] == :noinline
+    @test exf19122.args[2].args[1].args[1] === :inline
+    @test exg19122.args[2].args[1].args[1] === :noinline
 
     @inline f19122()::Bool = true
     @noinline g19122()::Bool = true

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -933,8 +933,8 @@ let
         end |> only |> first
     end
 
-    refs = map(Core.SSAValue, findall(x->x isa Expr && x.head == :new, src.code))
-    some_ccall = findfirst(x -> x isa Expr && x.head == :foreigncall && x.args[1] == :(:some_ccall), src.code)
+    refs = map(Core.SSAValue, findall(@nospecialize(x)->Meta.isexpr(x, :new), src.code))
+    some_ccall = findfirst(@nospecialize(x) -> Meta.isexpr(x, :foreigncall) && x.args[1] == :(:some_ccall), src.code)
     @assert some_ccall !== nothing
     stmt = src.code[some_ccall]
     nccallargs = length(stmt.args[3]::Core.SimpleVector)

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -205,7 +205,7 @@ let ci = make_ci([
     # come after it.
     for i in 1:length(ir.stmts)
         s = ir.stmts[i]
-        if isa(s, Expr) && s.head == :call && s.args[1] == :something
+        if Meta.isexpr(s, :call) && s.args[1] === :something
             if isa(s.args[2], SSAValue)
                 @test s.args[2].id <= i
             end

--- a/test/core.jl
+++ b/test/core.jl
@@ -2838,10 +2838,10 @@ let f
     end
 end
 for m in methods(f10373)
-    @test m.name == :f10373
+    @test m.name === :f10373
 end
 for m in methods(g10373)
-    @test m.name == :g10373
+    @test m.name === :g10373
 end
 
 # issue #7221
@@ -3607,7 +3607,7 @@ let
         @test false
     catch err
         @test isa(err, TypeError)
-        @test err.func == :Vararg
+        @test err.func === :Vararg
         @test err.expected == Int
         @test err.got == Int
     end
@@ -3617,7 +3617,7 @@ let
         @test false
     catch err
         @test isa(err, TypeError)
-        @test err.func == :Vararg
+        @test err.func === :Vararg
         @test err.expected == Int
         @test err.got == 0x1
     end
@@ -4229,7 +4229,7 @@ end
 let ex = quote
              $(if true; :(test); end)
          end
-    @test ex.args[2] == :test
+    @test ex.args[2] === :test
 end
 
 # issue #15180

--- a/test/corelogging.jl
+++ b/test/corelogging.jl
@@ -120,8 +120,8 @@ end
     @test length(logger.logs) == 1
     record = logger.logs[1]
     @test record._module == Base.Core
-    @test record.group == :somegroup
-    @test record.id == :asdf
+    @test record.group === :somegroup
+    @test record.id === :asdf
     @test record.file == "/a/file"
     @test record.line == -10
     # Test consistency with shouldlog() function arguments
@@ -435,7 +435,7 @@ end
     (record,), _ = collect_test_logs() do
         @info "test"
     end
-    @test record.group == :corelogging  # name of this file
+    @test record.group === :corelogging  # name of this file
 end
 
 @testset "complicated kwargs logging macro" begin

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -132,7 +132,7 @@ f25130()
 testlogs = testlogger.logs
 @test length(testlogs) == 2
 @test testlogs[1].id != testlogs[2].id
-@test testlogs[1].kwargs[:caller].func == Symbol("top-level scope")
+@test testlogs[1].kwargs[:caller].func === Symbol("top-level scope")
 @test all(l.message == "f25130 message" for l in testlogs)
 global_logger(prev_logger)
 

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -196,7 +196,7 @@ end
     bestkey(d, key) = key
     bestkey(d::AbstractDict{K,V}, key) where {K<:AbstractString,V} = string(key)
     bar(x) = bestkey(x, :y)
-    @test bar(Dict(:x => [1,2,5])) == :y
+    @test bar(Dict(:x => [1,2,5])) === :y
     @test bar(Dict("x" => [1,2,5])) == "y"
 end
 
@@ -1150,7 +1150,7 @@ end
     @test isempty(findall(isequal(1), Dict()))
     @test isempty(findall(isequal(1), Dict(:a=>2, :b=>3)))
 
-    @test findfirst(isequal(1), Dict(:a=>1, :b=>2)) == :a
+    @test findfirst(isequal(1), Dict(:a=>1, :b=>2)) === :a
     @test findfirst(isequal(1), Dict(:a=>1, :b=>1, :c=>3)) in (:a, :b)
     @test findfirst(isequal(1), Dict()) === nothing
     @test findfirst(isequal(1), Dict(:a=>2, :b=>3)) === nothing

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -794,7 +794,7 @@ end
 # Issue #13905.
 let err = try; @macroexpand(@doc "" f() = @x); false; catch ex; ex; end
     err::UndefVarError
-    @test err.var == Symbol("@x")
+    @test err.var === Symbol("@x")
  end
 
 
@@ -1302,9 +1302,9 @@ dynamic_test.x = "test 2"
 function striptrimdocs(expr)
     if Meta.isexpr(expr, :call)
         fex = expr.args[1]
-        if Meta.isexpr(fex, :.) && fex.args[1] == :REPL
+        if Meta.isexpr(fex, :.) && fex.args[1] === :REPL
             fmex = fex.args[2]
-            if isa(fmex, QuoteNode) && fmex.value == :trimdocs
+            if isa(fmex, QuoteNode) && fmex.value === :trimdocs
                 expr = expr.args[2]
             end
         end
@@ -1316,28 +1316,28 @@ let dt1 = striptrimdocs(_repl(:(dynamic_test(1.0))))
     @test dt1 isa Expr
     @test dt1.args[1] isa Expr
     @test dt1.args[1].head === :macrocall
-    @test dt1.args[1].args[1] == Symbol("@doc")
+    @test dt1.args[1].args[1] === Symbol("@doc")
     @test dt1.args[1].args[3] == :(dynamic_test(::typeof(1.0)))
 end
 let dt2 = striptrimdocs(_repl(:(dynamic_test(::String))))
     @test dt2 isa Expr
     @test dt2.args[1] isa Expr
     @test dt2.args[1].head === :macrocall
-    @test dt2.args[1].args[1] == Symbol("@doc")
+    @test dt2.args[1].args[1] === Symbol("@doc")
     @test dt2.args[1].args[3] == :(dynamic_test(::String))
 end
 let dt3 = striptrimdocs(_repl(:(dynamic_test(a))))
     @test dt3 isa Expr
     @test dt3.args[1] isa Expr
     @test dt3.args[1].head === :macrocall
-    @test dt3.args[1].args[1] == Symbol("@doc")
-    @test dt3.args[1].args[3].args[2].head == :(::) # can't test equality due to line numbers
+    @test dt3.args[1].args[1] === Symbol("@doc")
+    @test dt3.args[1].args[3].args[2].head === :(::) # can't test equality due to line numbers
 end
 let dt4 = striptrimdocs(_repl(:(dynamic_test(1.0,u=2.0))))
     @test dt4 isa Expr
     @test dt4.args[1] isa Expr
     @test dt4.args[1].head === :macrocall
-    @test dt4.args[1].args[1] == Symbol("@doc")
+    @test dt4.args[1].args[1] === Symbol("@doc")
     @test dt4.args[1].args[3] == :(dynamic_test(::typeof(1.0); u::typeof(2.0)=2.0))
 end
 

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -680,7 +680,7 @@ end
     getbt() = backtrace()
     bt = getbt()
     Base.update_stackframes_callback[] = function(list)
-        modify((sf, n)) = sf.func == :getbt ? (StackTraces.StackFrame(sf.func, sf.file, sf.line+2, sf.linfo, sf.from_c, sf.inlined, sf.pointer), n) : (sf, n)
+        modify((sf, n)) = sf.func === :getbt ? (StackTraces.StackFrame(sf.func, sf.file, sf.line+2, sf.linfo, sf.from_c, sf.inlined, sf.pointer), n) : (sf, n)
         map!(modify, list, list)
     end
     io = IOBuffer()

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -276,7 +276,7 @@ end
             exc
         end
         yield(t)
-        @test t.state == :done
+        @test t.state === :done
         @test t.result == ErrorException("B")
         # Task exception state is preserved around task switches
         @test length(current_exceptions()) == 1
@@ -296,7 +296,7 @@ end
                 exc
             end
             yield(t)
-            @test t.state == :done
+            @test t.state === :done
             @test t.result == ErrorException("B")
             @test bt == catch_backtrace()
             rethrow()
@@ -318,7 +318,7 @@ end
                 exc
             end
             yield(t)
-            @test t.state == :done
+            @test t.state === :done
             @test t.result == ErrorException("B")
             bt = catch_backtrace()
             rethrow(ErrorException("C"))
@@ -335,7 +335,7 @@ end
         error("B")
     end
     yield(t)
-    @test t.state == :failed
+    @test t.state === :failed
     @test t.result == ErrorException("B")
     @test current_exceptions(t, backtrace=false) == [
         (exception=ErrorException("A"),backtrace=nothing),

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -288,7 +288,7 @@ end
 end
 @testset "issue #21510" begin
     f21510(; @nospecialize a = 2) = a
-    @test f21510(a=:b) == :b
+    @test f21510(a=:b) === :b
     @test f21510() == 2
 end
 @testset "issue #34516" begin

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -221,8 +221,8 @@ let a = 1
     @test @macroexpand @is_dollar_expr $a
 end
 
-@test Meta.parseatom("@foo", 1, filename=:bar)[1].args[2].file == :bar
-@test Meta.parseall("@foo", filename=:bar).args[1].file == :bar
+@test Meta.parseatom("@foo", 1, filename=:bar)[1].args[2].file === :bar
+@test Meta.parseall("@foo", filename=:bar).args[1].file === :bar
 
 _lower(m::Module, ex, world::UInt) = ccall(:jl_expand_in_world, Any, (Any, Ref{Module}, Cstring, Cint, Csize_t), ex, m, "none", 0, world)
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -191,7 +191,7 @@ end
                 sleep(rand(0:0.01:0.1))
                 history[Threads.atomic_add!(clock, 1)] = Threads.atomic_sub!(occupied, 1) - 1
                 return :resultvalue
-            end == :resultvalue
+            end === :resultvalue
         end
     end
     @test all(<=(sem_size), history)

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -257,10 +257,10 @@ abstr_nt_22194_3()
 @test findall(isequal(1), (a=1, b=1)) == [:a, :b]
 @test isempty(findall(isequal(1), NamedTuple()))
 @test isempty(findall(isequal(1), (a=2, b=3)))
-@test findfirst(isequal(1), (a=1, b=2)) == :a
-@test findlast(isequal(1), (a=1, b=2)) == :a
-@test findfirst(isequal(1), (a=1, b=1)) == :a
-@test findlast(isequal(1), (a=1, b=1)) == :b
+@test findfirst(isequal(1), (a=1, b=2)) === :a
+@test findlast(isequal(1), (a=1, b=2)) === :a
+@test findfirst(isequal(1), (a=1, b=1)) === :a
+@test findlast(isequal(1), (a=1, b=1)) === :b
 @test findfirst(isequal(1), ()) === nothing
 @test findlast(isequal(1), ()) === nothing
 @test findfirst(isequal(1), (a=2, b=3)) === nothing

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2820,7 +2820,7 @@ end
 @testset "constructor inferability for BigFloat" begin
     T = BigFloat
     @test_broken all(R -> R<:T, Base.return_types(T))
-    @test all(m -> m.file == Symbol("deprecated.jl"),
+    @test all(m -> m.file === Symbol("deprecated.jl"),
         collect(methods(T))[findall(R -> !(R<:T), Base.return_types(T))])
 end
 

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -44,11 +44,11 @@ end
 
     p = 1=>:foo
     @test first(p) == 1
-    @test last(p)  == :foo
-    @test first(reverse(p)) == :foo
+    @test last(p)  === :foo
+    @test first(reverse(p)) === :foo
     @test last(reverse(p))  == 1
     @test lastindex(p) == 2
-    @test p[lastindex(p)] == p[end] == p[2] == :foo
+    @test p[lastindex(p)] == p[end] == p[2] === :foo
 end
 
 # Infix `isa`

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -147,7 +147,7 @@ module TestModSub9475
     let
         @test Base.binding_module(@__MODULE__, :a9475) == @__MODULE__
         @test Base.binding_module(@__MODULE__, :c7648) == TestMod7648
-        @test Base.nameof(@__MODULE__) == :TestModSub9475
+        @test Base.nameof(@__MODULE__) === :TestModSub9475
         @test Base.fullname(@__MODULE__) == (curmod_name..., :TestMod7648, :TestModSub9475)
         @test Base.parentmodule(@__MODULE__) == TestMod7648
     end
@@ -158,7 +158,7 @@ using .TestModSub9475
 let
     @test Base.binding_module(@__MODULE__, :d7648) == @__MODULE__
     @test Base.binding_module(@__MODULE__, :a9475) == TestModSub9475
-    @test Base.nameof(@__MODULE__) == :TestMod7648
+    @test Base.nameof(@__MODULE__) === :TestMod7648
     @test Base.parentmodule(@__MODULE__) == curmod
 end
 end # module TestMod7648
@@ -183,14 +183,14 @@ let
     using .TestMod7648
     @test Base.binding_module(@__MODULE__, :a9475) == TestMod7648.TestModSub9475
     @test Base.binding_module(@__MODULE__, :c7648) == TestMod7648
-    @test nameof(foo7648) == :foo7648
+    @test nameof(foo7648) === :foo7648
     @test parentmodule(foo7648, (Any,)) == TestMod7648
     @test parentmodule(foo7648) == TestMod7648
     @test parentmodule(foo7648_nomethods) == TestMod7648
     @test parentmodule(foo9475, (Any,)) == TestMod7648.TestModSub9475
     @test parentmodule(foo9475) == TestMod7648.TestModSub9475
     @test parentmodule(Foo7648) == TestMod7648
-    @test nameof(Foo7648) == :Foo7648
+    @test nameof(Foo7648) === :Foo7648
     @test basename(functionloc(foo7648, (Any,))[1]) == "reflection.jl"
     @test first(methods(TestMod7648.TestModSub9475.foo7648)) == which(foo7648, (Int,))
     @test TestMod7648 == which(@__MODULE__, :foo7648)
@@ -724,7 +724,7 @@ Base.delete_method(m)
 # Methods with keyword arguments
 fookw(x; direction=:up) = direction
 fookw(y::Int) = 2
-@test fookw("string") == :up
+@test fookw("string") === :up
 @test fookw(1) == 2
 m = collect(methods(fookw))[2]
 Base.delete_method(m)

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -115,7 +115,7 @@ end
     @test in(2,s)
     @test length(s) == 2
     @test_throws KeyError pop!(s,1)
-    @test pop!(s,1,:foo) == :foo
+    @test pop!(s,1,:foo) === :foo
     @test length(delete!(s,2)) == 1
     @test !in(1,s)
     @test !in(2,s)

--- a/test/show.jl
+++ b/test/show.jl
@@ -603,7 +603,7 @@ let q1 = Meta.parse(repr(:("$(a)b"))),
     @test q1.args[1].args == [:a, "b"]
 
     @test isa(q2, Expr)
-    @test q2.args[1].head == :string
+    @test q2.args[1].head === :string
     @test q2.args[1].args == [:ab,]
 end
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -418,7 +418,7 @@ end
     end
     @test nextind("fóobar", 0, 3) == 4
 
-    @test Symbol(gstr) == Symbol("12")
+    @test Symbol(gstr) === Symbol("12")
 
     @test sizeof(gstr) == 2
     @test ncodeunits(gstr) == 2

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -649,7 +649,7 @@ function get_expr_list(ex::Core.CodeInfo)
     return ex.code::Array{Any,1}
 end
 function get_expr_list(ex::Expr)
-    if ex.head == :thunk
+    if ex.head === :thunk
         return get_expr_list(ex.args[1])
     else
         return ex.args
@@ -755,7 +755,7 @@ end
 if test + test == test
     println(test)
 end
-```.head == :if
+```.head === :if
 
 end
 
@@ -853,7 +853,7 @@ end
 # Check that the body of a `where`-qualified short form function definition gets
 # a :block for its body
 short_where_call = :(f(x::T) where T = T)
-@test short_where_call.args[2].head == :block
+@test short_where_call.args[2].head === :block
 
 # `where` with multi-line anonymous functions
 let f = function (x::T) where T
@@ -2212,7 +2212,7 @@ end
 
 # only allow certain characters after interpolated vars (#25231)
 @test Meta.parse("\"\$x෴  \"",raise=false) == Expr(:error, "interpolated variable \$x ends with invalid character \"෴\"; use \"\$(x)\" instead.")
-@test Base.incomplete_tag(Meta.parse("\"\$foo", raise=false)) == :string
+@test Base.incomplete_tag(Meta.parse("\"\$foo", raise=false)) === :string
 
 @testset "issue #30341" begin
     @test Meta.parse("x .~ y") == Expr(:call, :.~, :x, :y)
@@ -3039,10 +3039,10 @@ end
 end
 
 # issue #19012
-@test Meta.parse("\U2200", raise=false) == Symbol("∀")
-@test Meta.parse("\U2203", raise=false) == Symbol("∃")
-@test Meta.parse("a\U2203", raise=false) == Symbol("a∃")
-@test Meta.parse("\U2204", raise=false) == Symbol("∄")
+@test Meta.parse("\U2200", raise=false) === Symbol("∀")
+@test Meta.parse("\U2203", raise=false) === Symbol("∃")
+@test Meta.parse("a\U2203", raise=false) === Symbol("a∃")
+@test Meta.parse("\U2204", raise=false) === Symbol("∄")
 
 # issue 42220
 macro m42220()

--- a/test/threadpool_use.jl
+++ b/test/threadpool_use.jl
@@ -4,10 +4,10 @@ using Test
 using Base.Threads
 
 @test nthreadpools() == 2
-@test threadpool() == :default
-@test threadpool(2) == :interactive
-dtask() = @test threadpool(current_task()) == :default
-itask() = @test threadpool(current_task()) == :interactive
+@test threadpool() === :default
+@test threadpool(2) === :interactive
+dtask() = @test threadpool(current_task()) === :default
+itask() = @test threadpool(current_task()) === :interactive
 dt1 = @spawn dtask()
 dt2 = @spawn :default dtask()
 it = @spawn :interactive itask()

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -265,7 +265,7 @@ end
 @test_throws TypeError Atomic{BigInt}
 @test_throws TypeError Atomic{ComplexF64}
 
-if Sys.ARCH == :i686 || startswith(string(Sys.ARCH), "arm") ||
+if Sys.ARCH === :i686 || startswith(string(Sys.ARCH), "arm") ||
    Sys.ARCH === :powerpc64le || Sys.ARCH === :ppc64le
 
     @test_throws TypeError Atomic{Int128}()

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -617,7 +617,7 @@ end
 @testset "properties" begin
     ttest = (:a, :b, :c)
     @test propertynames(ttest) == (1, 2, 3)
-    @test getproperty(ttest, 2) == :b
+    @test getproperty(ttest, 2) === :b
     @test map(p->getproperty(ttest, p), propertynames(ttest)) == ttest
     @test_throws ErrorException setproperty!(ttest, 1, :d)
 end


### PR DESCRIPTION
It would be better to use a consistent style in our code base.
The changes are big, but all merely cosmetic changes made
half-automatically with a find-and-replace.