### PR TITLE
rad-deg conversions for more types

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -220,8 +220,8 @@ reim(A::AbstractArray)
 +(x::AbstractArray{<:Number}) = x
 *(x::AbstractArray{<:Number,2}) = x
 
-rad2deg(A::AbstractArray) = rad2deg.(A)
-deg2rad(A::AbstractArray) = deg2rad.(A)
+rad2deg(A::AbstractArray) = broadcast_preserving_zero_d(rad2deg, A)
+deg2rad(A::AbstractArray) = broadcast_preserving_zero_d(deg2rad, A)
 
 # index A[:,:,...,i,:,:,...] where "i" is in dimension "d"
 

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -220,6 +220,9 @@ reim(A::AbstractArray)
 +(x::AbstractArray{<:Number}) = x
 *(x::AbstractArray{<:Number,2}) = x
 
+rad2deg(A::AbstractArray) = rad2deg.(A)
+deg2rad(A::AbstractArray) = deg2rad.(A)
+
 # index A[:,:,...,i,:,:,...] where "i" is in dimension "d"
 
 """

--- a/base/math.jl
+++ b/base/math.jl
@@ -333,8 +333,8 @@ julia> deg2rad(90)
 deg2rad(z::AbstractFloat) = z * (oftype(z, pi) / 180)
 rad2deg(z::Real) = rad2deg(float(z))
 deg2rad(z::Real) = deg2rad(float(z))
-rad2deg(z::Number) = (z/pi)*180
-deg2rad(z::Number) = (z*pi)/180
+rad2deg(z) = (z/pi)*180
+deg2rad(z) = (z*pi)/180
 
 log(b::T, x::T) where {T<:Number} = log(x)/log(b)
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -333,8 +333,8 @@ julia> deg2rad(90)
 deg2rad(z::AbstractFloat) = z * (oftype(z, pi) / 180)
 rad2deg(z::Real) = rad2deg(float(z))
 deg2rad(z::Real) = deg2rad(float(z))
-rad2deg(z) = (z/pi)*180
-deg2rad(z) = (z*pi)/180
+rad2deg(z::Union{Number,Missing}) = (z/pi)*180
+deg2rad(z::Union{Number,Missing}) = (z*pi)/180
 
 log(b::T, x::T) where {T<:Number} = log(x)/log(b)
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -1257,8 +1257,11 @@ function -(r::LinRange)
     LinRange{typeof(start)}(start, -r.stop, length(r))
 end
 
-rad2deg(r::AbstractRange) = LinRange(rad2deg(first(r)), rad2deg(last(r)), length(r))
-deg2rad(r::AbstractRange) = LinRange(deg2rad(first(r)), deg2rad(last(r)), length(r))
+for f in (rad2deg, deg2rad)
+    @eval $f(r::AbstractRange) = StepRangeLen($f(first(r)), $f(step(r)), length(r))
+    @eval $f(r::StepRangeLen{T}) where {T} = StepRangeLen{typeof($f(T(r.ref)))}($f(r.ref), $f(r.step), length(r), r.offset)
+    @eval $f(r::LinRange) = LinRange($f(r.start), $f(r.stop), r.len)
+end
 
 # promote eltype if at least one container wouldn't change, otherwise join container types.
 el_same(::Type{T}, a::Type{<:AbstractArray{T,n}}, b::Type{<:AbstractArray{T,n}}) where {T,n}   = a # we assume a === b

--- a/base/range.jl
+++ b/base/range.jl
@@ -1257,6 +1257,9 @@ function -(r::LinRange)
     LinRange{typeof(start)}(start, -r.stop, length(r))
 end
 
+rad2deg(r::AbstractRange) = LinRange(rad2deg(r.start), rad2deg(r.stop), length(r))
+deg2rad(r::AbstractRange) = LinRange(deg2rad(r.start), deg2rad(r.stop), length(r))
+
 # promote eltype if at least one container wouldn't change, otherwise join container types.
 el_same(::Type{T}, a::Type{<:AbstractArray{T,n}}, b::Type{<:AbstractArray{T,n}}) where {T,n}   = a # we assume a === b
 el_same(::Type{T}, a::Type{<:AbstractArray{T,n}}, b::Type{<:AbstractArray{S,n}}) where {T,S,n} = a

--- a/base/range.jl
+++ b/base/range.jl
@@ -1257,8 +1257,8 @@ function -(r::LinRange)
     LinRange{typeof(start)}(start, -r.stop, length(r))
 end
 
-rad2deg(r::AbstractRange) = LinRange(rad2deg(r.start), rad2deg(r.stop), length(r))
-deg2rad(r::AbstractRange) = LinRange(deg2rad(r.start), deg2rad(r.stop), length(r))
+rad2deg(r::AbstractRange) = LinRange(rad2deg(first(r)), rad2deg(last(r)), length(r))
+deg2rad(r::AbstractRange) = LinRange(deg2rad(first(r)), deg2rad(last(r)), length(r))
 
 # promote eltype if at least one container wouldn't change, otherwise join container types.
 el_same(::Type{T}, a::Type{<:AbstractArray{T,n}}, b::Type{<:AbstractArray{T,n}}) where {T,n}   = a # we assume a === b

--- a/base/range.jl
+++ b/base/range.jl
@@ -1257,7 +1257,7 @@ function -(r::LinRange)
     LinRange{typeof(start)}(start, -r.stop, length(r))
 end
 
-for f in (rad2deg, deg2rad)
+for f in (:rad2deg, :deg2rad)
     @eval $f(r::AbstractRange) = StepRangeLen($f(first(r)), $f(step(r)), length(r))
     @eval $f(r::StepRangeLen{T}) where {T} = StepRangeLen{typeof($f(T(r.ref)))}($f(r.ref), $f(r.step), length(r), r.offset)
     @eval $f(r::LinRange) = LinRange($f(r.start), $f(r.stop), r.len)


### PR DESCRIPTION
rad-deg conversion is basically a simple scaling, and removing the explicit restriction makes it work for all types defining `*, /` both in Base and in packages