### PR TITLE
WIP/RFC: Add intrinsics for querying the debug level

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1871,6 +1871,13 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
             return mark_or_box_ccall_result(ctx, ret, retboxed, rt, unionall, static_rt);
         }
     }
+    else if (is_libjulia_func(jl_debug_level)) {
+        assert(lrt == getInt32Ty(ctx.builder.getContext()));
+        assert(!isVa && !llvmcall && nccallargs == 0);
+        JL_GC_POP();
+        auto level = ConstantInt::get(getInt32Ty(ctx.builder.getContext()), jl_options.debug_level);
+        return mark_or_box_ccall_result(ctx, level, retboxed, rt, unionall, static_rt);
+    }
 
     jl_cgval_t retval = sig.emit_a_ccall(
             ctx,

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -112,6 +112,7 @@
     XX(jl_declare_constant) \
     XX(jl_defines_or_exports_p) \
     XX(jl_deprecate_binding) \
+    XX(jl_debug_level) \
     XX(jl_dlclose) \
     XX(jl_dlopen) \
     XX(jl_dlsym) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1291,6 +1291,8 @@ JL_DLLEXPORT jl_array_t *jl_array_copy(jl_array_t *ary);
 JL_DLLEXPORT uintptr_t jl_object_id_(jl_value_t *tv, jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_set_next_task(jl_task_t *task) JL_NOTSAFEPOINT;
 
+JL_DLLEXPORT int jl_debug_level(void);
+
 // -- synchronization utilities -- //
 
 extern jl_mutex_t typecache_lock;

--- a/src/llvm-cpufeatures.cpp
+++ b/src/llvm-cpufeatures.cpp
@@ -90,6 +90,11 @@ void lowerHaveFMA(Function &intr, Function &caller, CallInst *I) {
     return;
 }
 
+void lowerDebugLevel(Function &intr, Function &caller, CallInst *I) {
+    I->replaceAllUsesWith(ConstantInt::get(I->getType(), jl_options.debug_level));
+    return;
+}
+
 bool lowerCPUFeatures(Module &M)
 {
     SmallVector<Instruction*,6> Materialized;
@@ -102,6 +107,13 @@ bool lowerCPUFeatures(Module &M)
                 User *RU = U.getUser();
                 CallInst *I = cast<CallInst>(RU);
                 lowerHaveFMA(F, *I->getParent()->getParent(), I);
+                Materialized.push_back(I);
+            }
+        } else if (FN == "julia.debug_level") {
+            for (Use &U: F.uses()) {
+                User *RU = U.getUser();
+                CallInst *I = cast<CallInst>(RU);
+                lowerDebugLevel(F, *I->getParent()->getParent(), I);
                 Materialized.push_back(I);
             }
         }

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1460,3 +1460,8 @@ JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *typ)
     // TODO: run-time feature check?
     return jl_false;
 }
+
+JL_DLLEXPORT int jl_debug_level()
+{
+    return jl_options.debug_level;
+}


### PR DESCRIPTION
To enable a cheaper version of https://github.com/JuliaLang/julia/pull/37874, we want compiler support for querying the debug level. This PR prototypes such a feature in two different ways:
- a Julia intrinsic function lowered by codegen;
- an LLVM intrinsic that's lowered by the (to-be generalized) CPU features pas.

The former is the simplest, but ideally we also want this functionality for the system image. That normally done with the multiversioning pass, which would require the intrinsic to be an LLVM intrinsic, hence the second form. I'm however not sure how to best adapt the multiversioning pass, if it even is suitable for this, so @yuyichao I'd appreciate some thoughts here.

Alternatively we could only have this supported for JITted code and basically require users to `make debug` in order to get a debug sysimg, but that would be much less user friendly.

cc @KristofferC 