### PR TITLE
Document that `L`ength parameter needs Julia 1.7

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -469,7 +469,7 @@ with `TwicePrecision` this can be used to implement ranges that are
 free of roundoff error.
 
 !!! compat "Julia 1.7"
-The 4th type parameter `L` requires at least Julia 1.7.
+    The 4th type parameter `L` requires at least Julia 1.7.
 """
 struct StepRangeLen{T,R,S,L<:Integer} <: AbstractRange{T}
     ref::R       # reference value (might be smallest-magnitude value in the range)

--- a/base/range.jl
+++ b/base/range.jl
@@ -467,6 +467,9 @@ value `r[1]`, but alternatively you can supply it as the value of
 `r[offset]` for some other index `1 <= offset <= len`. In conjunction
 with `TwicePrecision` this can be used to implement ranges that are
 free of roundoff error.
+
+!!! compat "Julia 1.7"
+The 4th type argument `L` requires at least Julia 1.7.
 """
 struct StepRangeLen{T,R,S,L<:Integer} <: AbstractRange{T}
     ref::R       # reference value (might be smallest-magnitude value in the range)

--- a/base/range.jl
+++ b/base/range.jl
@@ -469,7 +469,7 @@ with `TwicePrecision` this can be used to implement ranges that are
 free of roundoff error.
 
 !!! compat "Julia 1.7"
-The 4th type argument `L` requires at least Julia 1.7.
+The 4th type parameter `L` requires at least Julia 1.7.
 """
 struct StepRangeLen{T,R,S,L<:Integer} <: AbstractRange{T}
     ref::R       # reference value (might be smallest-magnitude value in the range)


### PR DESCRIPTION
@vjnash added the 4th type parameter `L` in #41619 to `StepRangeLen`.
That addition seems to have appeared in Julia 1.7 so it should be documented as such.
I found this out the hard way because my CI for code that used `L` is failing with Julia 1.6.