### PR TITLE
Change description of underscore-only variables

### DIFF
--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -111,15 +111,17 @@ variable name. For example, if `+ᵃ` is an operator, then `+ᵃx` must be writt
 it from `+ ᵃx` where `ᵃx` is the variable name.
 
 
-A particular class of variable names is one that contains only underscores. These identifiers can only be assigned values but cannot be used to assign values to other variables.
-More technically, they can only be used as an [L-value](https://en.wikipedia.org/wiki/Value_(computer_science)#lrvalue), but not as an
- [R-value](https://en.wikipedia.org/wiki/R-value):
+A particular class of variable names is one that contains only underscores. These identifiers can only be assigned values, which are immediately discarded, and cannot therefore be used to assign values to other variables or use the last value
+assigned to them in any way.
 
 ```julia-repl
 julia> x, ___ = size([2 2; 1 1])
 (2, 2)
 
 julia> y = ___
+ERROR: syntax: all-underscore identifier used as rvalue
+
+julia> println(___)
 ERROR: syntax: all-underscore identifier used as rvalue
 ```
 

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -111,7 +111,7 @@ variable name. For example, if `+ᵃ` is an operator, then `+ᵃx` must be writt
 it from `+ ᵃx` where `ᵃx` is the variable name.
 
 
-A particular class of variable names is one that contains only underscores. These identifiers can only be assigned values, which are immediately discarded, and cannot therefore be used to assign values to other variables or use the last value
+A particular class of variable names is one that contains only underscores. These identifiers can only be assigned values, which are immediately discarded, and cannot therefore be used to assign values to other variables (i.e., they cannot be used as [`rvalues`](https://en.wikipedia.org/wiki/Value_(computer_science)#Assignment:_l-values_and_r-values)) or use the last value
 assigned to them in any way.
 
 ```julia-repl


### PR DESCRIPTION
Spawned by https://discourse.julialang.org/t/class-of-variables/83892

The rvalue/lvalue description does not seem benefitial. It confuse programmers that are not programming language nerds (it is a cool concept to learn, but this does not seem the place to learn it), and even programming language nerds may object. I for example, find kinda of a stretch to call `___` a lvalue because the linked wikipedia page says:

> An l-value refers to an object that persists beyond a single expression. An r-value is a temporary value that does not persist beyond the expression that uses it.[3]

Considering this description, the `___` matches more a rvalue than an lvalue (even if it is semantically a location and appear always in the left-hand side of an assignment).