### PR TITLE
Add channel state checks to reduce exceptions

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -493,14 +493,18 @@ function show(io::IO, ::MIME"text/plain", c::Channel)
 end
 
 function iterate(c::Channel, state=nothing)
-    try
-        return (take!(c), nothing)
-    catch e
-        if isa(e, InvalidStateException) && e.state === :closed
-            return nothing
-        else
-            rethrow()
+    if isopen(c) || isready(c)
+        try
+            return (take!(c), nothing)
+        catch e
+            if isa(e, InvalidStateException) && e.state === :closed
+                return nothing
+            else
+                rethrow()
+            end
         end
+    else
+        return nothing
     end
 end
 


### PR DESCRIPTION
Fixes two performance issues:
- `iterate` on a `Channel` uses an exception to discover that the `Channel` is closed when we could simply check.
- In `sync_end` in the 'racy' check, we always iterate on the `Channel` created for an `@sync` block when we could simply check if there's anything in it first.