### PR TITLE
Support `begin` and `end` in `gen_call_with_extracted_types` users

### DIFF
--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -2,7 +2,7 @@
 
 # macro wrappers for various reflection functions
 
-import Base: typesof, insert!
+import Base: typesof, insert!, replace_ref_begin_end!
 
 separate_kwargs(args...; kwargs...) = (args, values(kwargs))
 
@@ -32,6 +32,9 @@ function recursive_dotcalls!(ex, args, i=1)
 end
 
 function gen_call_with_extracted_types(__module__, fcn, ex0, kws=Expr[])
+    if Meta.isexpr(ex0, :ref)
+        ex0 = replace_ref_begin_end!(ex0)
+    end
     if isa(ex0, Expr)
         if ex0.head === :do && Meta.isexpr(get(ex0.args, 1, nothing), :call)
             if length(ex0.args) != 2

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -706,3 +706,14 @@ end
         end
     end
 end
+
+@testset "begin/end in gen_call_with_extracted_types users" begin
+    mktemp() do f, io
+        redirect_stdout(io) do
+            a = [1,2]
+            @test (@code_typed a[1:end]).second == Vector{Int}
+            @test (@code_llvm a[begin:2]) === nothing
+            @test (@code_native a[begin:end]) === nothing
+        end
+    end
+end


### PR DESCRIPTION
Fixes #45428 #37379 https://github.com/JuliaDebug/Cthulhu.jl/issues/291

Locally passes relevant tests (`Base.runtests("InteractiveUtils show reflection staged")`, but its a pretty naive approach so would like to see results of CI and get further comments. Seems to generally fix what its supposed to though:

Before:
```julia
julia> a = [1,2]; @which a[1:end]
ERROR: UndefVarError: end not defined
Stacktrace:
 [1] top-level scope
   @ REPL[25]:1

julia> @code_typed a[1:end]
ERROR: UndefVarError: end not defined
Stacktrace:
 [1] top-level scope

```

After:
```julia
julia> a = [1,2]; @which a[1:end]
getindex(A::Array, I::AbstractUnitRange{<:Integer})
     @ Base array.jl:921

julia> @code_typed a[1:end]
CodeInfo(
1 ─       goto #6 if not $(Expr(:boundscheck))
2 ─ %2  = Core.tuple(I)::Tuple{UnitRange{Int64}}
[snip...]
) => Vector{Int64}

```