### PR TITLE
Subsumes flatmap functionality under flatten

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -67,7 +67,8 @@ Build system changes
 New library functions
 ---------------------
 
-* `Iterators.flatmap` was added ([#44792]).
+* `flatten(f, c...)` was added ([#44792], ), which implements `flatmap` both as iterators and
+  producing arrays.
 * New helper `Splat(f)` which acts like `x -> f(x...)`, with pretty printing for
   inspecting which function `f` was originally wrapped. ([#42717])
 * New `pkgversion(m::Module)` function to get the version of the package that loaded

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3097,6 +3097,63 @@ julia> map(+, [1 2; 3 4], [1,10,100,1000], zeros(3,1))  # iterates until 3rd is 
 """
 map(f, iters...) = collect(Generator(f, iters...))
 
+"""
+    flatten(A)
+
+Takes a collection of collections and produce an array with the concatenation of all internal elements.
+
+See also [`Iterators.flatten`](@ref)
+
+!!! compat "Julia 1.9"
+    This function was added in Julia 1.9.
+
+# Examples
+```jldoctest
+julia> flatten([1:2,1:3,2:4])
+9-element Vector{Int64}:
+ 1
+ 2
+ 1
+ 2
+ 3
+ 2
+ 3
+ 4
+```
+"""
+flatten(A) = collect(Iterators.flatten(A))
+
+"""
+    flatten(f, c...)
+
+Equivalent to `flatten(map(f, c...))`.
+
+See also [`Iterators.flatten`](@ref), [`map`](@ref)
+
+!!! compat "Julia 1.9"
+    This function was added in Julia 1.9.
+
+# Examples
+```jldoctest
+julia> flatten(n -> -n:2:n, 1:3)
+9-element Vector{Int64}:
+ -1
+  1
+ -2
+  0
+  2
+ -3
+ -1
+  1
+  3
+```
+
+# Extended help
+
+This version of the `flatten` method essentialy implements what's called `flatmap` or `bind` in other languages.
+"""
+flatten(f, A...) = collect(Iterators.flatten(f, A...))
+
 # multi-item push!, pushfirst! (built on top of type-specific 1-item version)
 # (note: must not cause a dispatch loop when 1-item case is not defined)
 push!(A, a, b) = push!(push!(A, a), b)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -519,6 +519,7 @@ export
     lastindex,
     filter!,
     filter,
+    flatten,
     foldl,
     foldr,
     foreach,

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -31,7 +31,7 @@ import .Base:
     getindex, setindex!, get, iterate,
     popfirst!, isdone, peek, intersect
 
-export enumerate, zip, rest, countfrom, take, drop, takewhile, dropwhile, cycle, repeated, product, flatten, flatmap
+export enumerate, zip, rest, countfrom, take, drop, takewhile, dropwhile, cycle, repeated, product, flatten
 
 if Base !== Core.Compiler
 export partition
@@ -1141,6 +1141,33 @@ julia> [(x,y) for x in 0:1 for y in 'a':'c']  # collects generators involving It
 """
 flatten(itr) = Flatten(itr)
 
+"""
+    Iterators.flatten(f, iterators...)
+
+Equivalent to `flatten(map(f, iterators...))`.
+
+See also [`Iterators.flatten`](@ref), [`Iterators.map`](@ref).
+
+!!! compat "Julia 1.9"
+    This function was added in Julia 1.9.
+
+# Examples
+```jldoctest
+julia> Iterators.flatten(n -> -n:2:n, 1:3) |> collect
+9-element Vector{Int64}:
+ -1
+  1
+ -2
+  0
+  2
+ -3
+ -1
+  1
+  3
+```
+"""
+flatten(f, c...) = flatten(map(f, c...))
+
 eltype(::Type{Flatten{I}}) where {I} = eltype(eltype(I))
 eltype(::Type{Flatten{Tuple{}}}) = eltype(Tuple{})
 IteratorEltype(::Type{Flatten{I}}) where {I} = _flatteneltype(I, IteratorEltype(I))
@@ -1186,33 +1213,6 @@ end
 
 reverse(f::Flatten) = Flatten(reverse(itr) for itr in reverse(f.it))
 last(f::Flatten) = last(last(f.it))
-
-"""
-    Iterators.flatmap(f, iterators...)
-
-Equivalent to `flatten(map(f, iterators...))`.
-
-See also [`Iterators.flatten`](@ref), [`Iterators.map`](@ref).
-
-!!! compat "Julia 1.9"
-    This function was added in Julia 1.9.
-
-# Examples
-```jldoctest
-julia> Iterators.flatmap(n->-n:2:n, 1:3) |> collect
-9-element Vector{Int64}:
- -1
-  1
- -2
-  0
-  2
- -3
- -1
-  1
-  3
-```
-"""
-flatmap(f, c...) = flatten(map(f, c...))
 
 if Base !== Core.Compiler # views are not defined
 @doc """

--- a/doc/src/base/iterators.md
+++ b/doc/src/base/iterators.md
@@ -14,7 +14,6 @@ Base.Iterators.cycle
 Base.Iterators.repeated
 Base.Iterators.product
 Base.Iterators.flatten
-Base.Iterators.flatmap
 Base.Iterators.partition
 Base.Iterators.map
 Base.Iterators.filter

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -504,26 +504,26 @@ end
 # see #29112, #29464, #29548
 @test Base.return_types(Base.IteratorEltype, Tuple{Array}) == [Base.HasEltype]
 
-# flatmap
+# flatten as flatmap
 # -------
-@test flatmap(1:3) do j flatmap(1:3) do k
+@test flatten(1:3) do j flatten(1:3) do k
     j!=k ? ((j,k),) : ()
 end end |> collect == [(j,k) for j in 1:3 for k in 1:3 if j!=k]
 # Test inspired by the monad associativity law
 fmf(x) = x<0 ? () : (x^2,)
 fmg(x) = x<1 ? () : (x/2,)
 fmdata = -2:0.75:2
-fmv1 = flatmap(tuple.(fmdata)) do h
-    flatmap(h) do x
+fmv1 = flatten(tuple.(fmdata)) do h
+    flatten(h) do x
         gx = fmg(x)
-        flatmap(gx) do x
+        flatten(gx) do x
             fmf(x)
         end
     end
 end
-fmv2 = flatmap(tuple.(fmdata)) do h
-    gh = flatmap(h) do x fmg(x) end
-    flatmap(gh) do x fmf(x) end
+fmv2 = flatten(tuple.(fmdata)) do h
+    gh = flatten(h) do x fmg(x) end
+    flatten(gh) do x fmf(x) end
 end
 @test all(fmv1 .== fmv2)
 


### PR DESCRIPTION
A proposal following comments to #44792. This patch removes the new `Iterators.flatmap` and implements the same functionality as a new `flatten` method that can take a function parameter. `flatten` is also introduced to `Base` similar to `map`, producing concrete arrays.

I personally don't really like the name `flatten`. I believe many programmers are probably not very familiar with the great importance of flatmap when you're coding in this style that relies more on functional combinators than on procedural for-loops. That means, for those following this style, we'll be writing a lot of code using the term `flatten` where there's something else happening than just flattening. We are flat-mapping. It would be great to have a more accurate term.

This patch also extends what was done in #44792 by bringing `flatten` to `Base`, producing concrete vectors through `collect`.