### PR TITLE
Update `Documenter` version, deploy to tarball

### DIFF
--- a/doc/Manifest.toml
+++ b/doc/Manifest.toml
@@ -24,9 +24,9 @@ version = "0.8.6"
 
 [[deps.Documenter]]
 deps = ["ANSIColoredPrinters", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "122d031e8dcb2d3e767ed434bc4d1ae1788b5a7f"
+git-tree-sha1 = "e4967ebb9dce1328d582200b03bcc44c69372312"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.27.17"
+version = "0.27.20"
 
 [[deps.IOCapture]]
 deps = ["Logging", "Random"]
@@ -64,9 +64,9 @@ version = "1.2.0"
 
 [[deps.Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "1285416549ccfcdf0c50d4997a94331e88d68413"
+git-tree-sha1 = "0044b23da09b5608b4ecacb4e5e6c6332f833a7e"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.3.1"
+version = "2.3.2"
 
 [[deps.Printf]]
 deps = ["Unicode"]

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -336,6 +336,8 @@ end
 
 # Define our own DeployConfig
 struct BuildBotConfig <: Documenter.DeployConfig end
+Documenter.authentication_method(::Documenter.DeployConfig) = Documenter.HTTPS
+Documenter.authenticated_repo_url(::Documenter.DeployConfig) = "https://github.com/JuliaLang/docs.julialang.org.git"
 function Documenter.deploy_folder(::BuildBotConfig; devurl, repo, branch, kwargs...)
     haskey(ENV, "DOCUMENTER_KEY") || return Documenter.DeployDecision(; all_ok=false)
     if Base.GIT_VERSION_INFO.tagged_commit
@@ -381,4 +383,5 @@ deploydocs(
     dirname = "en",
     devurl = devurl,
     versions = Versions(["v#.#", devurl => devurl]),
+    archive = get(ENV, "DOCUMENTER_ARCHIVE", nothing),
 )

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -336,8 +336,8 @@ end
 
 # Define our own DeployConfig
 struct BuildBotConfig <: Documenter.DeployConfig end
-Documenter.authentication_method(::Documenter.DeployConfig) = Documenter.HTTPS
-Documenter.authenticated_repo_url(::Documenter.DeployConfig) = "https://github.com/JuliaLang/docs.julialang.org.git"
+Documenter.authentication_method(::BuildBotConfig) = Documenter.HTTPS
+Documenter.authenticated_repo_url(::BuildBotConfig) = "https://github.com/JuliaLang/docs.julialang.org.git"
 function Documenter.deploy_folder(::BuildBotConfig; devurl, repo, branch, kwargs...)
     haskey(ENV, "DOCUMENTER_KEY") || return Documenter.DeployDecision(; all_ok=false)
     if Base.GIT_VERSION_INFO.tagged_commit


### PR DESCRIPTION
This is a necessary change to get documentation deployed in buildkite,
where we deploy first to a tarball, then upload in a separate step.