### PR TITLE
doc: LinearAlgebra.BLAS; add compat note for `spr!`, `spmv!`, `hpmv!`

### DIFF
--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -969,6 +969,9 @@ The scalar inputs `α` and `β` must be complex or real numbers.
 The array inputs `x`, `y` and `AP` must all be of `ComplexF32` or `ComplexF64` type.
 
 Return the updated `y`.
+
+!!! compat "Julia 1.5"
+    `hpmv!` requires at least Julia 1.5.
 """
 hpmv!
 

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -1194,6 +1194,9 @@ The scalar input `α` must be real.
 
 The array inputs `x` and `AP` must all be of `Float32` or `Float64` type.
 Return the updated `AP`.
+
+!!! compat "Julia 1.8"
+    `spr!` requires at least Julia 1.8.
 """
 spr!
 

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -1126,6 +1126,9 @@ The scalar inputs `α` and `β` must be real.
 The array inputs `x`, `y` and `AP` must all be of `Float32` or `Float64` type.
 
 Return the updated `y`.
+
+!!! compat "Julia 1.5"
+    `spmv!` requires at least Julia 1.5.
 """
 spmv!
 


### PR DESCRIPTION
After adding these three functions to doc in #45978, I forgot to check for version compatibility.

- `spr!` 1.8+
https://github.com/JuliaLang/julia/commit/ae336abc0ed7e63ab933d0073df28c51e981d8fc
- `spmv!` 1.5+
https://github.com/JuliaLang/julia/commit/d8b2209bba09b649afc3288fce3f7e17f97a495e
- `hpmv!` 1.5+
https://github.com/JuliaLang/julia/commit/0b034fd9fa7994b5f60b0f519f2038352e7c221c

You can check if other export functions in BLAS need to be marked for version compatibility, by looking at the last modified time of the line in the git blame: https://github.com/JuliaLang/julia/blame/master/stdlib/LinearAlgebra/src/blas.jl#L12-L63

`rot!` Already have a note: "requires at least Julia 1.5."
