### PR TITLE
Note that the compiler performs loop unrolling

### DIFF
--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -1353,7 +1353,8 @@ Both these implementations, although different, do essentially the same thing: a
 over the dimensions of the array, collecting the offset in each dimension into the final index.
 
 However, all the information we need for the loop is embedded in the type information of the arguments.
-Thus, we can utilize generated functions to move the iteration to compile-time; in compiler parlance,
+This allows the compiler to move the iteration to compile time and eliminate the runtime loops
+altogether. We can utilize generated functions to achieve a simmilar effect; in compiler parlance,
 we use generated functions to manually unroll the loop. The body becomes almost identical, but
 instead of calculating the linear index, we build up an *expression* that calculates the index:
 


### PR DESCRIPTION
This makes the `@generated` example obsolete, though it is still illustrative. I drew this conclusion from copying the doc examples into a 1.8.0-rc1 REPL and running `@code_llvm`:
```julia
julia> function sub2ind_loop(dims::NTuple{N}, I::Integer...) where N
           ind = I[N] - 1
           for i = N-1:-1:1
               ind = I[i]-1 + dims[i]*ind
           end
           return ind + 1
       end
sub2ind_loop (generic function with 1 method)

julia> sub2ind_loop((3, 5), 1, 2)
4

julia> @code_llvm sub2ind_loop((3, 5), 1, 2)
;  @ REPL[19]:1 within `sub2ind_loop`
define i64 @julia_sub2ind_loop_1609([2 x i64]* nocapture nonnull readonly align 8 dereferenceable(16) %0, i64 signext %1, i64 signext %2) #0 {
top:
;  @ REPL[19]:2 within `sub2ind_loop`
; ┌ @ int.jl:86 within `-`
   %3 = add i64 %2, -1
; └
;  @ REPL[19]:4 within `sub2ind_loop`
; ┌ @ tuple.jl:29 within `getindex`
   %4 = getelementptr inbounds [2 x i64], [2 x i64]* %0, i64 0, i64 0
; └
; ┌ @ int.jl:88 within `*`
   %5 = load i64, i64* %4, align 8
   %6 = mul i64 %5, %3
; └
;  @ REPL[19]:6 within `sub2ind_loop`
; ┌ @ int.jl:87 within `+`
   %7 = add i64 %6, %1
; └
  ret i64 %7
}

julia> @generated function sub2ind_gen(dims::NTuple{N}, I::Integer...) where N
           ex = :(I[$N] - 1)
           for i = (N - 1):-1:1
               ex = :(I[$i] - 1 + dims[$i] * $ex)
           end
           return :($ex + 1)
       end
sub2ind_gen (generic function with 1 method)

julia> sub2ind_gen((3, 5), 1, 2)
4

julia> @code_llvm sub2ind_gen((3, 5), 1, 2)
;  @ REPL[22]:1 within `sub2ind_gen`
define i64 @julia_sub2ind_gen_1624([2 x i64]* nocapture nonnull readonly align 8 dereferenceable(16) %0, i64 signext %1, i64 signext %2) #0 {
top:
; ┌ @ REPL[22] within `macro expansion`
; │┌ @ tuple.jl:29 within `getindex`
    %3 = getelementptr inbounds [2 x i64], [2 x i64]* %0, i64 0, i64 0
; │└
; │┌ @ int.jl:86 within `-`
    %4 = add i64 %2, -1
; │└
; │┌ @ int.jl:88 within `*`
    %5 = load i64, i64* %3, align 8
    %6 = mul i64 %5, %4
; │└
; │┌ @ int.jl:87 within `+`
    %7 = add i64 %6, %1
; │└
   ret i64 %7
; └
}
```