### PR TITLE
docs: fix off-by-one error in C array indexing example

### DIFF
--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -296,7 +296,7 @@ For users coming to Julia from R, these are some noteworthy differences:
   * In Julia, the division operator [`/`](@ref) returns a floating point number when both operands
     are of integer type.  To perform integer division, use [`div`](@ref) or [`÷`](@ref div).
   * Indexing an `Array` with floating point types is generally an error in Julia. The Julia
-    equivalent of the C expression `a[i / 2]` is `a[i ÷ 2 + 1]`, where `i` is of integer type.
+    equivalent of the C expression `a[i / 2]` is `a[i ÷ 2]`, where `i` is of integer type.
   * String literals can be delimited with either `"`  or `"""`, `"""` delimited literals can contain
     `"` characters without quoting it like `"\""`. String literals can have values of other variables
     or expressions interpolated into them, indicated by `$variablename` or `$(expression)`, which


### PR DESCRIPTION
Integer division is truncated in C.