### PR TITLE
`invoke`d calls: record invoke signature in backedges

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,8 @@ Compiler/Runtime improvements
   `@nospecialize`-d call sites and avoiding excessive compilation. ([#44512])
 * All the previous usages of `@pure`-macro in `Base` has been replaced with the preferred
   `Base.@assume_effects`-based annotations. ([#44776])
+* `invoke(f, invokesig, args...)` calls to a less-specific method than would normally be chosen
+  for `f(args...)` are no longer spuriously invalidated when loading package precompile files. ([#46010])
 
 Command-line option changes
 ---------------------------

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -801,6 +801,13 @@ function collect_const_args(argtypes::Vector{Any})
                 end for i = 2:length(argtypes) ]
 end
 
+function invoke_signature(invokesig::Vector{Any})
+    unwrapconst(x) = isa(x, Const) ? x.val : x
+
+    f, argtyps = unwrapconst(invokesig[2]), unwrapconst(invokesig[3])
+    return Tuple{typeof(f), unwrap_unionall(argtyps).parameters...}
+end
+
 function concrete_eval_call(interp::AbstractInterpreter,
     @nospecialize(f), result::MethodCallResult, arginfo::ArgInfo, sv::InferenceState)
     concrete_eval_eligible(interp, f, result, arginfo, sv) || return nothing
@@ -1631,7 +1638,7 @@ function abstract_invoke(interp::AbstractInterpreter, (; fargs, argtypes)::ArgIn
     ti = tienv[1]; env = tienv[2]::SimpleVector
     result = abstract_call_method(interp, method, ti, env, false, sv)
     (; rt, edge, effects) = result
-    edge !== nothing && add_backedge!(edge::MethodInstance, sv)
+    edge !== nothing && add_backedge!(edge::MethodInstance, sv, argtypes)
     match = MethodMatch(ti, env, method, argtype <: method.sig)
     res = nothing
     sig = match.spec_types

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -802,10 +802,8 @@ function collect_const_args(argtypes::Vector{Any})
 end
 
 function invoke_signature(invokesig::Vector{Any})
-    unwrapconst(x) = isa(x, Const) ? x.val : x
-
-    f, argtyps = unwrapconst(invokesig[2]), unwrapconst(invokesig[3])
-    return Tuple{typeof(f), unwrap_unionall(argtyps).parameters...}
+    ft, argtyps = widenconst(invokesig[2]), instanceof_tfunc(widenconst(invokesig[3]))[1]
+    return rewrap_unionall(Tuple{typeof(f), unwrap_unionall(argtyps).parameters...}, argtyps)
 end
 
 function concrete_eval_call(interp::AbstractInterpreter,
@@ -1638,7 +1636,7 @@ function abstract_invoke(interp::AbstractInterpreter, (; fargs, argtypes)::ArgIn
     ti = tienv[1]; env = tienv[2]::SimpleVector
     result = abstract_call_method(interp, method, ti, env, false, sv)
     (; rt, edge, effects) = result
-    edge !== nothing && add_backedge!(edge::MethodInstance, sv, argtypes)
+    edge !== nothing && add_backedge!(edge::MethodInstance, sv, types)
     match = MethodMatch(ti, env, method, argtype <: method.sig)
     res = nothing
     sig = match.spec_types

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -803,7 +803,7 @@ end
 
 function invoke_signature(invokesig::Vector{Any})
     ft, argtyps = widenconst(invokesig[2]), instanceof_tfunc(widenconst(invokesig[3]))[1]
-    return rewrap_unionall(Tuple{typeof(f), unwrap_unionall(argtyps).parameters...}, argtyps)
+    return rewrap_unionall(Tuple{ft, unwrap_unionall(argtyps).parameters...}, argtyps)
 end
 
 function concrete_eval_call(interp::AbstractInterpreter,

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -479,11 +479,14 @@ function add_cycle_backedge!(frame::InferenceState, caller::InferenceState, curr
 end
 
 # temporarily accumulate our edges to later add as backedges in the callee
-function add_backedge!(li::MethodInstance, caller::InferenceState)
+function add_backedge!(li::MethodInstance, caller::InferenceState, invokesig::Union{Nothing,Vector{Any}}=nothing)
     isa(caller.linfo.def, Method) || return # don't add backedges to toplevel exprs
     edges = caller.stmt_edges[caller.currpc]
     if edges === nothing
         edges = caller.stmt_edges[caller.currpc] = []
+    end
+    if invokesig !== nothing
+        push!(edges, invoke_signature(invokesig))
     end
     push!(edges, li)
     return nothing

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -479,14 +479,14 @@ function add_cycle_backedge!(frame::InferenceState, caller::InferenceState, curr
 end
 
 # temporarily accumulate our edges to later add as backedges in the callee
-function add_backedge!(li::MethodInstance, caller::InferenceState, invokesig::Union{Nothing,Vector{Any}}=nothing)
+function add_backedge!(li::MethodInstance, caller::InferenceState, invokesig::Union{Nothing,DataType}=nothing)
     isa(caller.linfo.def, Method) || return # don't add backedges to toplevel exprs
     edges = caller.stmt_edges[caller.currpc]
     if edges === nothing
         edges = caller.stmt_edges[caller.currpc] = []
     end
     if invokesig !== nothing
-        push!(edges, invoke_signature(invokesig))
+        push!(edges, invokesig)
     end
     push!(edges, li)
     return nothing

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -479,7 +479,7 @@ function add_cycle_backedge!(frame::InferenceState, caller::InferenceState, curr
 end
 
 # temporarily accumulate our edges to later add as backedges in the callee
-function add_backedge!(li::MethodInstance, caller::InferenceState, invokesig::Union{Nothing,DataType}=nothing)
+function add_backedge!(li::MethodInstance, caller::InferenceState, invokesig::Union{Nothing,Type}=nothing)
     isa(caller.linfo.def, Method) || return # don't add backedges to toplevel exprs
     edges = caller.stmt_edges[caller.currpc]
     if edges === nothing

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -62,6 +62,10 @@ intersect!(et::EdgeTracker, range::WorldRange) =
     et.valid_worlds[] = intersect(et.valid_worlds[], range)
 
 push!(et::EdgeTracker, mi::MethodInstance) = push!(et.edges, mi)
+function add_edge!(et::EdgeTracker, @nospecialize(invokesig), mi::MethodInstance)
+    invokesig === nothing && return push!(et.edges, mi)
+    push!(et.edges, invokesig, mi)
+end
 function push!(et::EdgeTracker, ci::CodeInstance)
     intersect!(et, WorldRange(min_world(li), max_world(li)))
     push!(et, ci.def)

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -29,7 +29,9 @@ pass to apply its own inlining policy decisions.
 struct DelayedInliningSpec
     match::Union{MethodMatch, InferenceResult}
     argtypes::Vector{Any}
+    invokesig    # either nothing or a signature (signature is for an `invoke` call)
 end
+DelayedInliningSpec(match, argtypes) = DelayedInliningSpec(match, argtypes, nothing)
 
 struct InliningTodo
     # The MethodInstance to be inlined
@@ -37,11 +39,11 @@ struct InliningTodo
     spec::Union{ResolvedInliningSpec, DelayedInliningSpec}
 end
 
-InliningTodo(mi::MethodInstance, match::MethodMatch, argtypes::Vector{Any}) =
-    InliningTodo(mi, DelayedInliningSpec(match, argtypes))
+InliningTodo(mi::MethodInstance, match::MethodMatch, argtypes::Vector{Any}, invokesig=nothing) =
+    InliningTodo(mi, DelayedInliningSpec(match, argtypes, invokesig))
 
-InliningTodo(result::InferenceResult, argtypes::Vector{Any}) =
-    InliningTodo(result.linfo, DelayedInliningSpec(result, argtypes))
+InliningTodo(result::InferenceResult, argtypes::Vector{Any}, invokesig=nothing) =
+    InliningTodo(result.linfo, DelayedInliningSpec(result, argtypes, invokesig))
 
 struct ConstantCase
     val::Any
@@ -810,7 +812,7 @@ end
 
 function resolve_todo(todo::InliningTodo, state::InliningState, flag::UInt8)
     mi = todo.mi
-    (; match, argtypes) = todo.spec::DelayedInliningSpec
+    (; match, argtypes, invokesig) = todo.spec::DelayedInliningSpec
     et = state.et
 
     #XXX: update_valid_age!(min_valid[1], max_valid[1], sv)
@@ -818,7 +820,7 @@ function resolve_todo(todo::InliningTodo, state::InliningState, flag::UInt8)
         inferred_src = match.src
         if isa(inferred_src, ConstAPI)
             # use constant calling convention
-            et !== nothing && push!(et, mi)
+            et !== nothing && add_edge!(et, invokesig, mi)
             return ConstantCase(quoted(inferred_src.val))
         else
             src = inferred_src # ::Union{Nothing,CodeInfo} for NativeInterpreter
@@ -829,7 +831,7 @@ function resolve_todo(todo::InliningTodo, state::InliningState, flag::UInt8)
         if code isa CodeInstance
             if use_const_api(code)
                 # in this case function can be inlined to a constant
-                et !== nothing && push!(et, mi)
+                et !== nothing && add_edge!(et, invokesig, mi)
                 return ConstantCase(quoted(code.rettype_const))
             else
                 src = @atomic :monotonic code.inferred
@@ -851,7 +853,7 @@ function resolve_todo(todo::InliningTodo, state::InliningState, flag::UInt8)
 
     src === nothing && return compileable_specialization(et, match, effects)
 
-    et !== nothing && push!(et, mi)
+    et !== nothing && add_edge!(et, invokesig, mi)
     return InliningTodo(mi, retrieve_ir_for_inlining(mi, src), effects)
 end
 
@@ -873,7 +875,7 @@ function validate_sparams(sparams::SimpleVector)
     return true
 end
 
-function analyze_method!(match::MethodMatch, argtypes::Vector{Any},
+function analyze_method!(match::MethodMatch, argtypes::Vector{Any}, invokesig,
                          flag::UInt8, state::InliningState)
     method = match.method
     spec_types = match.spec_types
@@ -905,7 +907,7 @@ function analyze_method!(match::MethodMatch, argtypes::Vector{Any},
     mi = specialize_method(match; preexisting=true) # Union{Nothing, MethodInstance}
     isa(mi, MethodInstance) || return compileable_specialization(et, match, Effects())
 
-    todo = InliningTodo(mi, match, argtypes)
+    todo = InliningTodo(mi, match, argtypes, invokesig)
     # If we don't have caches here, delay resolving this MethodInstance
     # until the batch inlining step (or an external post-processing pass)
     state.mi_cache === nothing && return todo
@@ -1100,9 +1102,10 @@ function inline_invoke!(
     if isa(result, ConcreteResult)
         item = concrete_result_item(result, state)
     else
+        invokesig = invoke_signature(sig.argtypes)
         argtypes = invoke_rewrite(sig.argtypes)
         if isa(result, ConstPropResult)
-            (; mi) = item = InliningTodo(result.result, argtypes)
+            (; mi) = item = InliningTodo(result.result, argtypes, invokesig)
             validate_sparams(mi.sparam_vals) || return nothing
             if argtypes_to_type(argtypes) <: mi.def.sig
                 state.mi_cache !== nothing && (item = resolve_todo(item, state, flag))
@@ -1110,7 +1113,7 @@ function inline_invoke!(
                 return nothing
             end
         end
-        item = analyze_method!(match, argtypes, flag, state)
+        item = analyze_method!(match, argtypes, invokesig, flag, state)
     end
     handle_single_case!(ir, idx, stmt, item, todo, state.params, true)
     return nothing
@@ -1328,7 +1331,7 @@ function handle_match!(
     # during abstract interpretation: for the purpose of inlining, we can just skip
     # processing this dispatch candidate
     _any(case->case.sig === spec_types, cases) && return true
-    item = analyze_method!(match, argtypes, flag, state)
+    item = analyze_method!(match, argtypes, nothing, flag, state)
     item === nothing && return false
     push!(cases, InliningCase(spec_types, item))
     return true
@@ -1475,7 +1478,7 @@ function assemble_inline_todo!(ir::IRCode, state::InliningState)
                 if isa(result, ConcreteResult)
                     item = concrete_result_item(result, state)
                 else
-                    item = analyze_method!(info.match, sig.argtypes, flag, state)
+                    item = analyze_method!(info.match, sig.argtypes, nothing, flag, state)
                 end
                 handle_single_case!(ir, idx, stmt, item, todo, state.params)
             end

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -268,10 +268,6 @@ end
 
 const empty_backedge_iter = BackedgeIterator(Any[])
 
-function BackedgeIterator(mi::MethodInstance)
-    isdefined(mi, :backedges) || return empty_backedge_iter
-    return BackedgeIterator(mi.backedges)
-end
 
 function iterate(iter::BackedgeIterator, i::Int=1)
     backedges = iter.backedges

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -228,12 +228,10 @@ is_no_constprop(method::Union{Method,CodeInfo}) = method.constprop == 0x02
 #############
 
 """
-    BackedgeIterator(mi::MethodInstance)
     BackedgeIterator(backedges::Vector{Any})
 
-Return an iterator over a list of backedges, which may be extracted
-from `mi`. Iteration returns `(sig, caller)` elements, which will be one of
-the following:
+Return an iterator over a list of backedges. Iteration returns `(sig, caller)` elements,
+which will be one of the following:
 
 - `(nothing, caller::MethodInstance)`: a call made by ordinary inferrable dispatch
 - `(invokesig, caller::MethodInstance)`: a call made by `invoke(f, invokesig, args...)`
@@ -254,7 +252,7 @@ julia> callyou(2.0)
 julia> mi = first(which(callme, (Any,)).specializations)
 MethodInstance for callme(::Float64)
 
-julia> @eval Core.Compiler for (sig, caller) in BackedgeIterator(Main.mi)
+julia> @eval Core.Compiler for (sig, caller) in BackedgeIterator(Main.mi.backedges)
            println(sig)
            println(caller)
        end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2280,7 +2280,8 @@ function precompile(@nospecialize(argt::Type))
 end
 
 # Variants that work for `invoke`d calls for which the signature may not be sufficient
-precompile(mi::Core.MethodInstance, world=get_world_counter()) = (ccall(:jl_compile_method_instance, Cvoid, (Any, Any, UInt), mi, C_NULL, world); return true)
+precompile(mi::Core.MethodInstance, world::UInt=get_world_counter()) =
+    (ccall(:jl_compile_method_instance, Cvoid, (Any, Any, UInt), mi, C_NULL, world); return true)
 
 """
     precompile(m::Method, argtypes::Tuple{Vararg{Any}})

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2262,12 +2262,12 @@ macro __DIR__()
 end
 
 """
-    precompile(f, args::Tuple{Vararg{Any}})
+    precompile(f, argtypes::Tuple{Vararg{Any}})
 
-Compile the given function `f` for the argument tuple (of types) `args`, but do not execute it.
+Compile the given function `f` for the argument tuple (of types) `argtypes`, but do not execute it.
 """
-function precompile(@nospecialize(f), @nospecialize(args::Tuple))
-    precompile(Tuple{Core.Typeof(f), args...})
+function precompile(@nospecialize(f), @nospecialize(argtypes::Tuple))
+    precompile(Tuple{Core.Typeof(f), argtypes...})
 end
 
 const ENABLE_PRECOMPILE_WARNINGS = Ref(false)
@@ -2277,6 +2277,29 @@ function precompile(@nospecialize(argt::Type))
         @warn "Inactive precompile statement" maxlog=100 form=argt _module=nothing _file=nothing _line=0
     end
     return ret
+end
+
+# Variants that work for `invoke`d calls for which the signature may not be sufficient
+precompile(mi::Core.MethodInstance, world=get_world_counter()) = (ccall(:jl_compile_method_instance, Cvoid, (Any, Any, UInt), mi, C_NULL, world); return true)
+
+"""
+    precompile(m::Method, argtypes::Tuple{Vararg{Any}})
+
+Precompile a specific method for the given argument types. This may be used to precompile
+a different method than the one that would ordinarily be chosen by dispatch.
+"""
+function precompile(m::Method, @nospecialize(argtypes::Tuple))
+    world = get_world_counter()
+    f = getglobal(m.module, m.name)
+    matches = _methods(f, argtypes, -1, world)::Vector
+    for mtch in matches
+        mtch = mtch::Core.MethodMatch
+        if mtch.method == m
+            mi = Core.Compiler.specialize_method(m, mtch.spec_types, mtch.sparams)
+            return precompile(mi)
+        end
+    end
+    return false
 end
 
 precompile(include_package_for_output, (PkgId, String, Vector{String}, Vector{String}, Vector{String}, typeof(_concrete_dependencies), Nothing))

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2284,20 +2284,20 @@ precompile(mi::Core.MethodInstance, world::UInt=get_world_counter()) =
     (ccall(:jl_compile_method_instance, Cvoid, (Any, Any, UInt), mi, C_NULL, world); return true)
 
 """
-    precompile(m::Method, argtypes::Tuple{Vararg{Any}})
+    precompile(f, argtypes::Tuple{Vararg{Any}}, m::Method)
 
 Precompile a specific method for the given argument types. This may be used to precompile
-a different method than the one that would ordinarily be chosen by dispatch.
+a different method than the one that would ordinarily be chosen by dispatch, for example
+mimicking `invoke`.
 """
-function precompile(m::Method, @nospecialize(argtypes::Tuple))
+function precompile(@nospecialize(f), @nospecialize(argtypes::Tuple), m::Method)
     world = get_world_counter()
-    f = getglobal(m.module, m.name)
     matches = _methods(f, argtypes, -1, world)::Vector
     for mtch in matches
         mtch = mtch::Core.MethodMatch
         if mtch.method == m
             mi = Core.Compiler.specialize_method(m, mtch.spec_types, mtch.sparams)
-            return precompile(mi)
+            return precompile(mi, world)
         end
     end
     return false

--- a/src/dump.c
+++ b/src/dump.c
@@ -2336,7 +2336,7 @@ static void jl_insert_method_instances(jl_array_t *list) JL_GC_DISABLED
                 // Is this still the method we'd be calling?
                 jl_methtable_t *mt = jl_method_table_for(mi->specTypes);
                 struct jl_typemap_assoc search = {(jl_value_t*)mi->specTypes, world, NULL, 0, ~(size_t)0};
-                jl_typemap_entry_t *entry = jl_typemap_assoc_by_type(mt->defs, &search, /*offs*/0, /*subtype*/1);
+                jl_typemap_entry_t *entry = jl_typemap_assoc_by_type(mt->defs, &search, /*offs*/0, /*subtype*/0);
                 if (entry) {
                     jl_value_t *mworld = entry->func.value;
                     if (jl_is_method(mworld) && mi->def.method != (jl_method_t*)mworld && jl_type_morespecific(((jl_method_t*)mworld)->sig, mi->def.method->sig)) {
@@ -2350,7 +2350,7 @@ static void jl_insert_method_instances(jl_array_t *list) JL_GC_DISABLED
                             j = get_next_backedge(mi->backedges, j, &invokeTypes, &caller);
                             if (invokeTypes) {
                                 struct jl_typemap_assoc search = {invokeTypes, world, NULL, 0, ~(size_t)0};
-                                entry = jl_typemap_assoc_by_type(mt->defs, &search, /*offs*/0, /*subtype*/1);
+                                entry = jl_typemap_assoc_by_type(mt->defs, &search, /*offs*/0, /*subtype*/0);
                                 if (entry) {
                                     jl_value_t *imworld = entry->func.value;
                                     if (jl_is_method(imworld) && mi->def.method == (jl_method_t*)imworld) {

--- a/src/dump.c
+++ b/src/dump.c
@@ -2443,7 +2443,8 @@ static void jl_insert_method_instances(jl_array_t *list) JL_GC_DISABLED
                         k = 0;
                         while (k < nlive) {
                             k = get_next_edge(milive->backedges, k, &invokeTypes2, &belive2);
-                            if (belive == belive2 && jl_egal(invokeTypes, invokeTypes2)) {
+                            if (belive == belive2 && ((invokeTypes == NULL && invokeTypes2 == NULL) ||
+                                    (invokeTypes && invokeTypes2 && jl_egal(invokeTypes, invokeTypes2)))) {
                                 found = 1;
                                 break;
                             }

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -97,6 +97,7 @@
     XX(jl_close_uv) \
     XX(jl_code_for_staged) \
     XX(jl_compile_hint) \
+    XX(jl_compile_method_instance) \
     XX(jl_compress_argnames) \
     XX(jl_compress_ir) \
     XX(jl_compute_fieldtypes) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2532,7 +2532,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             jl_any_type,
                             jl_simplevector_type,
                             jl_any_type,
-                            jl_any_type,
+                            jl_array_any_type,
                             jl_any_type,
                             jl_any_type,
                             jl_bool_type,

--- a/src/julia.h
+++ b/src/julia.h
@@ -362,7 +362,7 @@ struct _jl_method_instance_t {
     jl_value_t *specTypes;  // argument types this was specialized for
     jl_svec_t *sparam_vals; // static parameter values, indexed by def.method->sparam_syms
     jl_value_t *uninferred; // cached uncompressed code, for generated functions, top-level thunks, or the interpreter
-    jl_array_t *backedges; // list of method-instances which contain a call into this method-instance
+    jl_array_t *backedges; // list of method-instances which call this method-instance; `invoke` records (invokesig, caller) pairs
     jl_array_t *callbacks; // list of callback functions to inform external caches about invalidations
     _Atomic(struct _jl_code_instance_t*) cache;
     uint8_t inInference; // flags to tell if inference is running on this object
@@ -650,7 +650,7 @@ typedef struct _jl_methtable_t {
     intptr_t max_args;  // max # of non-vararg arguments in a signature
     jl_value_t *kwsorter;  // keyword argument sorter function
     jl_module_t *module; // used for incremental serialization to locate original binding
-    jl_array_t *backedges;
+    jl_array_t *backedges; // (sig, caller::MethodInstance) pairs
     jl_mutex_t writelock;
     uint8_t offs;  // 0, or 1 to skip splitting typemap on first (function) argument
     uint8_t frozen; // whether this accepts adding new methods

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -596,6 +596,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_method_inferred(
 jl_method_instance_t *jl_get_unspecialized_from_mi(jl_method_instance_t *method JL_PROPAGATES_ROOT);
 jl_method_instance_t *jl_get_unspecialized(jl_method_t *def JL_PROPAGATES_ROOT);
 
+JL_DLLEXPORT void jl_compile_method_instance(jl_method_instance_t *mi, jl_tupletype_t *types, size_t world);
 JL_DLLEXPORT int jl_compile_hint(jl_tupletype_t *types);
 jl_code_info_t *jl_code_for_interpreter(jl_method_instance_t *lam JL_PROPAGATES_ROOT);
 int jl_code_requires_compiler(jl_code_info_t *src);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -605,9 +605,9 @@ JL_DLLEXPORT jl_code_info_t *jl_new_code_info_uninit(void);
 void jl_resolve_globals_in_ir(jl_array_t *stmts, jl_module_t *m, jl_svec_t *sparam_vals,
                               int binding_effects);
 
-int get_next_backedge(jl_array_t *list, int i, jl_value_t** invokesig, jl_method_instance_t **caller) JL_NOTSAFEPOINT;
-int set_next_backedge(jl_array_t *list, int i, jl_value_t *invokesig, jl_method_instance_t *caller);
-void push_backedge(jl_array_t *list, jl_value_t *invokesig, jl_method_instance_t *caller);
+int get_next_edge(jl_array_t *list, int i, jl_value_t** invokesig, jl_method_instance_t **caller) JL_NOTSAFEPOINT;
+int set_next_edge(jl_array_t *list, int i, jl_value_t *invokesig, jl_method_instance_t *caller);
+void push_edge(jl_array_t *list, jl_value_t *invokesig, jl_method_instance_t *caller);
 
 JL_DLLEXPORT void jl_add_method_root(jl_method_t *m, jl_module_t *mod, jl_value_t* root);
 void jl_append_method_roots(jl_method_t *m, uint64_t modid, jl_array_t* roots);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -604,6 +604,10 @@ JL_DLLEXPORT jl_code_info_t *jl_new_code_info_uninit(void);
 void jl_resolve_globals_in_ir(jl_array_t *stmts, jl_module_t *m, jl_svec_t *sparam_vals,
                               int binding_effects);
 
+int get_next_backedge(jl_array_t *list, int i, jl_value_t** invokesig, jl_method_instance_t **caller) JL_NOTSAFEPOINT;
+int set_next_backedge(jl_array_t *list, int i, jl_value_t *invokesig, jl_method_instance_t *caller);
+void push_backedge(jl_array_t *list, jl_value_t *invokesig, jl_method_instance_t *caller);
+
 JL_DLLEXPORT void jl_add_method_root(jl_method_t *m, jl_module_t *mod, jl_value_t* root);
 void jl_append_method_roots(jl_method_t *m, uint64_t modid, jl_array_t* roots);
 int get_root_reference(rle_reference *rr, jl_method_t *m, size_t i);
@@ -949,7 +953,7 @@ JL_DLLEXPORT jl_value_t *jl_methtable_lookup(jl_methtable_t *mt, jl_value_t *typ
 JL_DLLEXPORT jl_method_instance_t *jl_specializations_get_linfo(
     jl_method_t *m JL_PROPAGATES_ROOT, jl_value_t *type, jl_svec_t *sparams);
 jl_method_instance_t *jl_specializations_get_or_insert(jl_method_instance_t *mi_ins);
-JL_DLLEXPORT void jl_method_instance_add_backedge(jl_method_instance_t *callee, jl_method_instance_t *caller);
+JL_DLLEXPORT void jl_method_instance_add_backedge(jl_method_instance_t *callee, jl_value_t *invokesig, jl_method_instance_t *caller);
 JL_DLLEXPORT void jl_method_table_add_backedge(jl_methtable_t *mt, jl_value_t *typ, jl_value_t *caller);
 
 uint32_t jl_module_next_counter(jl_module_t *m) JL_NOTSAFEPOINT;

--- a/src/method.c
+++ b/src/method.c
@@ -784,6 +784,49 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t *module)
     return m;
 }
 
+// backedges ------------------------------------------------------------------
+
+// Use this in a `while` loop to iterate over the backedges in a MethodInstance.
+// `*invokesig` will be NULL if the call was made by ordinary dispatch, otherwise
+// it will be the signature supplied in an `invoke` call.
+// If you don't need `invokesig`, you can set it to NULL on input.
+// Initialize iteration with `i = 0`. Returns `i` for the next backedge to be extracted.
+int get_next_backedge(jl_array_t *list, int i, jl_value_t** invokesig, jl_method_instance_t **caller) JL_NOTSAFEPOINT
+{
+    jl_value_t *item = jl_array_ptr_ref(list, i);
+    if (jl_is_method_instance(item)) {
+        // Not an `invoke` call, it's just the MethodInstance
+        if (invokesig != NULL)
+            *invokesig = NULL;
+        *caller = (jl_method_instance_t*)item;
+        return i + 1;
+    }
+    assert(jl_is_type(item));
+    // An `invoke` call, it's a (sig, MethodInstance) pair
+    if (invokesig != NULL)
+        *invokesig = item;
+    *caller = (jl_method_instance_t*)jl_array_ptr_ref(list, i + 1);
+    if (*caller)
+        assert(jl_is_method_instance(*caller));
+    return i + 2;
+}
+
+int set_next_backedge(jl_array_t *list, int i, jl_value_t *invokesig, jl_method_instance_t *caller)
+{
+    if (invokesig)
+        jl_array_ptr_set(list, i++, invokesig);
+    jl_array_ptr_set(list, i++, caller);
+    return i;
+}
+
+void push_backedge(jl_array_t *list, jl_value_t *invokesig, jl_method_instance_t *caller)
+{
+    if (invokesig)
+        jl_array_ptr_1d_push(list, invokesig);
+    jl_array_ptr_1d_push(list, (jl_value_t*)caller);
+    return;
+}
+
 // method definition ----------------------------------------------------------
 
 jl_method_t *jl_make_opaque_closure_method(jl_module_t *module, jl_value_t *name,

--- a/src/method.c
+++ b/src/method.c
@@ -791,7 +791,7 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t *module)
 // it will be the signature supplied in an `invoke` call.
 // If you don't need `invokesig`, you can set it to NULL on input.
 // Initialize iteration with `i = 0`. Returns `i` for the next backedge to be extracted.
-int get_next_backedge(jl_array_t *list, int i, jl_value_t** invokesig, jl_method_instance_t **caller) JL_NOTSAFEPOINT
+int get_next_edge(jl_array_t *list, int i, jl_value_t** invokesig, jl_method_instance_t **caller) JL_NOTSAFEPOINT
 {
     jl_value_t *item = jl_array_ptr_ref(list, i);
     if (jl_is_method_instance(item)) {
@@ -811,7 +811,7 @@ int get_next_backedge(jl_array_t *list, int i, jl_value_t** invokesig, jl_method
     return i + 2;
 }
 
-int set_next_backedge(jl_array_t *list, int i, jl_value_t *invokesig, jl_method_instance_t *caller)
+int set_next_edge(jl_array_t *list, int i, jl_value_t *invokesig, jl_method_instance_t *caller)
 {
     if (invokesig)
         jl_array_ptr_set(list, i++, invokesig);
@@ -819,7 +819,7 @@ int set_next_backedge(jl_array_t *list, int i, jl_value_t *invokesig, jl_method_
     return i;
 }
 
-void push_backedge(jl_array_t *list, jl_value_t *invokesig, jl_method_instance_t *caller)
+void push_edge(jl_array_t *list, jl_value_t *invokesig, jl_method_instance_t *caller)
 {
     if (invokesig)
         jl_array_ptr_1d_push(list, invokesig);

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -971,8 +971,8 @@ precompile_test_harness("invoke") do dir
     # Precompile specific methods for arbitrary arg types
     invokeme(x) = 1
     invokeme(::Int) = 2
-    m_any, m_int = sort(collect(methods(invokeme)); by=m->m.line)
-    precompile(invokeme, (Int,), m_any)
+    m_any, m_int = sort(collect(methods(invokeme)); by=m->(m.file,m.line))
+    @test precompile(invokeme, (Int,), m_any)
     @test m_any.specializations[1].specTypes === Tuple{typeof(invokeme), Int}
     @test isempty(m_int.specializations)
 end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -967,6 +967,14 @@ precompile_test_harness("invoke") do dir
     @test isempty(m.specializations)
     m = get_real_method(M.hnc)
     @test isempty(m.specializations)
+
+    # Precompile specific methods for arbitrary arg types
+    invokeme(x) = 1
+    invokeme(::Int) = 2
+    m_any, m_int = sort(collect(methods(invokeme)); by=m->m.line)
+    precompile(m_any, (Int,))
+    @test m_any.specializations[1].specTypes === Tuple{typeof(invokeme), Int}
+    @test isempty(m_int.specializations)
 end
 
 # test --compiled-modules=no command line option

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -972,7 +972,7 @@ precompile_test_harness("invoke") do dir
     invokeme(x) = 1
     invokeme(::Int) = 2
     m_any, m_int = sort(collect(methods(invokeme)); by=m->m.line)
-    precompile(m_any, (Int,))
+    precompile(invokeme, (Int,), m_any)
     @test m_any.specializations[1].specTypes === Tuple{typeof(invokeme), Int}
     @test isempty(m_int.specializations)
 end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -106,16 +106,18 @@ precompile_test_harness(false) do dir
     write(Foo2_file,
           """
           module $Foo2_module
-              export override
+              export override, overridenc
               override(x::Integer) = 2
               override(x::AbstractFloat) = Float64(override(1))
+              overridenc(x::Integer) = rand()+1
+              overridenc(x::AbstractFloat) = Float64(overridenc(1))
           end
           """)
     write(Foo_file,
           """
           module $Foo_module
               import $FooBase_module, $FooBase_module.typeA
-              import $Foo2_module: $Foo2_module, override
+              import $Foo2_module: $Foo2_module, override, overridenc
               import $FooBase_module.hash
               import Test
               module Inner
@@ -221,6 +223,8 @@ precompile_test_harness(false) do dir
 
               g() = override(1.0)
               Test.@test g() === 2.0 # compile this
+              gnc() = overridenc(1.0)
+              Test.@test 1 < gnc() < 5 # compile this
 
               const abigfloat_f() = big"12.34"
               const abigfloat_x = big"43.21"
@@ -257,6 +261,8 @@ precompile_test_harness(false) do dir
     Foo2 = Base.require(Main, Foo2_module)
     @eval $Foo2.override(::Int) = 'a'
     @eval $Foo2.override(::Float32) = 'b'
+    @eval $Foo2.overridenc(::Int) = rand() + 97.0
+    @eval $Foo2.overridenc(::Float32) = rand() + 100.0
 
     Foo = Base.require(Main, Foo_module)
     Base.invokelatest() do # use invokelatest to see the results of loading the compile
@@ -265,9 +271,13 @@ precompile_test_harness(false) do dir
 
         # Issue #21307
         @test Foo.g() === 97.0
+        @test 96 < Foo.gnc() < 99
         @test Foo.override(1.0e0) == Float64('a')
         @test Foo.override(1.0f0) == 'b'
         @test Foo.override(UInt(1)) == 2
+        @test 96 < Foo.overridenc(1.0e0) < 99
+        @test 99 < Foo.overridenc(1.0f0) < 102
+        @test 0 < Foo.overridenc(UInt(1)) < 3
 
         # Issue #15722
         @test Foo.abigfloat_f()::BigFloat == big"12.34"
@@ -873,6 +883,92 @@ precompile_test_harness("code caching") do dir
     @test hasvalid(mi, world)       # was compiled with the new method
 end
 
+precompile_test_harness("invoke") do dir
+    InvokeModule = :Invoke0x030e7e97c2365aad
+    CallerModule = :Caller0x030e7e97c2365aad
+    write(joinpath(dir, "$InvokeModule.jl"),
+          """
+          module $InvokeModule
+              export f, g, h, fnc, gnc, hnc   # nc variants do not infer to a Const
+              # f is for testing invoke that occurs within a dependency
+              f(x::Real) = 0
+              f(x::Int) = x < 5 ? 1 : invoke(f, Tuple{Real}, x)
+              fnc(x::Real) = rand()-1
+              fnc(x::Int) = x < 5 ? rand()+1 : invoke(fnc, Tuple{Real}, x)
+              # g is for testing invoke that occurs from a dependent
+              g(x::Real) = 0
+              g(x::Int) = 1
+              gnc(x::Real) = rand()-1
+              gnc(x::Int) = rand()+1
+              # h will be entirely superseded by a new method (full invalidation)
+              h(x::Real) = 0
+              h(x::Int) = x < 5 ? 1 : invoke(h, Tuple{Integer}, x)
+              hnc(x::Real) = rand()-1
+              hnc(x::Int) = x < 5 ? rand()+1 : invoke(hnc, Tuple{Integer}, x)
+          end
+          """)
+          write(joinpath(dir, "$CallerModule.jl"),
+          """
+          module $CallerModule
+              using $InvokeModule
+              # involving external modules
+              callf(x) = f(x)
+              callg(x) = x < 5 ? g(x) : invoke(g, Tuple{Real}, x)
+              callh(x) = h(x)
+              callfnc(x) = fnc(x)
+              callgnc(x) = x < 5 ? gnc(x) : invoke(gnc, Tuple{Real}, x)
+              callhnc(x) = hnc(x)
+
+              # Purely internal
+              internal(x::Real) = 0
+              internal(x::Int) = x < 5 ? 1 : invoke(internal, Tuple{Real}, x)
+              internalnc(x::Real) = rand()-1
+              internalnc(x::Int) = x < 5 ? rand()+1 : invoke(internalnc, Tuple{Real}, x)
+
+              # force precompilation
+              begin
+                  Base.Experimental.@force_compile
+                  callf(3)
+                  callg(3)
+                  callh(3)
+                  callfnc(3)
+                  callgnc(3)
+                  callhnc(3)
+                  internal(3)
+                  internalnc(3)
+              end
+
+              # Now that we've precompiled, invalidate with a new method that overrides the `invoke` dispatch
+              $InvokeModule.h(x::Integer) = -1
+              $InvokeModule.hnc(x::Integer) = rand() - 20
+          end
+          """)
+    Base.compilecache(Base.PkgId(string(CallerModule)))
+    @eval using $CallerModule
+    M = getfield(@__MODULE__, CallerModule)
+
+    function get_real_method(func)   # return the method func(::Real)
+        for m in methods(func)
+            m.sig.parameters[end] === Real && return m
+        end
+        error("no ::Real method found for $func")
+    end
+
+    for func in (M.f, M.g, M.internal, M.fnc, M.gnc, M.internalnc)
+        m = get_real_method(func)
+        mi = m.specializations[1]
+        @test length(mi.backedges) == 2
+        @test mi.backedges[1] === Tuple{typeof(func), Real}
+        @test isa(mi.backedges[2], Core.MethodInstance)
+        @test mi.cache.max_world == typemax(mi.cache.max_world)
+    end
+
+    m = get_real_method(M.h)
+    @test isempty(m.specializations)
+    m = get_real_method(M.hnc)
+    @test isempty(m.specializations)
+end
+
 # test --compiled-modules=no command line option
 precompile_test_harness("--compiled-modules=no") do dir
     Time_module = :Time4b3a94a1a081a8cb
@@ -1069,13 +1165,21 @@ precompile_test_harness("delete_method") do dir
           """
           module $A_module
 
-          export apc, anopc
+          export apc, anopc, apcnc, anopcnc
 
+          # Infer to a const
           apc(::Int, ::Int) = 1
           apc(::Any, ::Any) = 2
 
           anopc(::Int, ::Int) = 1
           anopc(::Any, ::Any) = 2
+
+          # Do not infer to a const
+          apcnc(::Int, ::Int) = rand() - 1
+          apcnc(::Any, ::Any) = rand() + 1
+
+          anopcnc(::Int, ::Int) = rand() - 1
+          anopcnc(::Any, ::Any) = rand() + 1
 
           end
           """)
@@ -1087,19 +1191,26 @@ precompile_test_harness("delete_method") do dir
 
           bpc(x) = apc(x, x)
           bnopc(x) = anopc(x, x)
+          bpcnc(x) = apcnc(x, x)
+          bnopcnc(x) = anopcnc(x, x)
 
           precompile(bpc, (Int,))
           precompile(bpc, (Float64,))
+          precompile(bpcnc, (Int,))
+          precompile(bpcnc, (Float64,))
 
           end
           """)
     A = Base.require(Main, A_module)
-    for mths in (collect(methods(A.apc)), collect(methods(A.anopc)))
-        Base.delete_method(mths[1])
+    for mths in (collect(methods(A.apc)), collect(methods(A.anopc)), collect(methods(A.apcnc)), collect(methods(A.anopcnc)))
+        idx = findfirst(m -> m.sig.parameters[end] === Int, mths)
+        Base.delete_method(mths[idx])
     end
     B = Base.require(Main, B_module)
-    @test Base.invokelatest(B.bpc, 1) == Base.invokelatest(B.bpc, 1.0) == 2
-    @test Base.invokelatest(B.bnopc, 1) == Base.invokelatest(B.bnopc, 1.0) == 2
+    for f in (B.bpc, B.bnopc, B.bpcnc, B.bnopcnc)
+        @test Base.invokelatest(f, 1) > 1
+        @test Base.invokelatest(f, 1.0) > 1
+    end
 end
 
 precompile_test_harness("Issues #19030 and #25279") do load_path


### PR DESCRIPTION
This PR fixes a corner case in our current scheme for invalidating outdated methods when loading `.ji` files. What we *want* to do is test whether a given MethodInstance would be compiled in the same way now as when the package was precompiled; for efficiency, what we actually do is test whether the dispatches would be to the same methods in the current world-age. It turns out that we've long had a "hole" in our assessment: for calls made by `invoke`,

```julia
f(arg::SpecificType) = invoke(f, Tuple{GenericType}, arg)
```

it looks like an outdated method got called because the signature is not the most specific one (`f(::GenericType)` gets compiled for specialization `f(::SpecificType)`, which looks like a wrong or outdated choice of method), and we have no record that a less-specific method was deliberately chosen via `invoke`. Incorrectly classifying this backedge as outdated triggers unnecessary invalidation, which propagates all the way up call chains; since we happen to have an `invoke` in our broadcasting infrastructure, it means that in practice this issue is much more significant than the relatively modest number of `invoke` calls one finds in Base, because almost all code that uses broadcasting gets invalidated, and that's quite a lot of package code.

This works by expanding the kinds of backedges to 3:
- (traditional) known dispatch backedges which record the `caller::MethodInstance` in `(callee::MethodInstance).backedges`
- (new) known dispatch backedges from `invoke` which record the `invokesig::Type, caller::MethodInstance` in `(callee::MethodInstance).backedges` as a sequential pair
- (traditional) for unknown dispatch, the `MethodTable` stores `signature, caller` pairs, where `signature` stores what is known by inference about the types of the arguments.

Thus the `invoke`d backedges are intermingled with traditional ones in `callee.backedges`, but they have a format similar to what one finds in `MethodTable`s.

By storing `invokesig` we get a second chance to check whether the method is the one that would currently be chosen by `invokesig` rather than the signature of the generated specialization of `callee`. Thus this should robustly fix the invalidation issue.

Closes #45001