### PR TITLE
Empty reshapes legalization (issue #45589)

### DIFF
--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -132,7 +132,7 @@ reshape(parent::AbstractArray, dims::Tuple{Vararg{Union{Int,Colon}}}) = reshape(
     else
         divrem(length(A), prod(pre)*prod(post))
     end
-    remainder == 0 || throw2(A, dims)
+    length(A) == 0 || remainder == 0 || throw2(A, dims)
     (pre..., Int(sz), post...)
 end
 @inline _any_colon() = false

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1650,16 +1650,27 @@ end
     @test (@inferred to_indices([], (1, CIdx(1, 1), 1, CIdx(1, 1), 1, CIdx(1, 1), 1))) == ntuple(Returns(1), 10)
 end
 
-@testset "reshape inference for empty arrays preserves size of non-empty dimensions (issue #45589)" begin
+@testset "reshape inference for empty arrays does not fail, and attempts to preserve size of non-empty dimensions (issue #45589)" begin
     @test size(reshape(zeros(0,2), :)) == (0,)
     @test size(reshape(zeros(0,2), 0,:)) == (0,2)
+    @test size(reshape(zeros(0,2), 1,:)) == (1,0)
+    @test size(reshape(zeros(0,2), 2,:)) == (2,0)
+    @test size(reshape(zeros(0,2), 3,:)) == (3,0)
     @test size(reshape(zeros(0,0,0), 0,:,0)) == (0,0,0)
     @test size(reshape(zeros(0,0,0), 0,:,1)) == (0,0,1)
     @test size(reshape(zeros(0,0,0), 0,:,1111)) == (0,0,1111)
     @test size(reshape(zeros(0,2,3), 0,:)) == (0,6)
+    @test size(reshape(zeros(0,2,3), 5,:)) == (5,0)
+    @test size(reshape(zeros(0,2,3), 6,:)) == (6,0)
+    @test size(reshape(zeros(0,2,3), 7,:)) == (7,0)
     @test size(reshape(zeros(0,2,3), 0,:,2)) == (0,3,2)
-    @test size(reshape(zeros(0,2,3), 3,:,2)) == (3,0,2)
+    @test size(reshape(zeros(0,2,3), 0,:,3)) == (0,2,3)
+    @test size(reshape(zeros(0,2,3), 0,:,5)) == (0,1,5)
     @test size(reshape(zeros(0,2,3), 0,:,6)) == (0,1,6)
-    @test size(reshape(zeros(0,2,3), 1,:,6)) == (1,0,6)
+    @test size(reshape(zeros(0,2,3), 0,:,7)) == (0,0,7)
     @test size(reshape(zeros(0,2,3), 1,:,3)) == (1,0,3)
+    @test size(reshape(zeros(0,2,3), 1,:,5)) == (1,0,5)
+    @test size(reshape(zeros(0,2,3), 1,:,6)) == (1,0,6)
+    @test size(reshape(zeros(0,2,3), 1,:,7)) == (1,0,7)
+    @test size(reshape(zeros(0,2,3), 3,:,2)) == (3,0,2)
 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1649,3 +1649,17 @@ end
     @test (@inferred A[i,i,i]) === A[1]
     @test (@inferred to_indices([], (1, CIdx(1, 1), 1, CIdx(1, 1), 1, CIdx(1, 1), 1))) == ntuple(Returns(1), 10)
 end
+
+@testset "reshape inference for empty arrays preserves size of non-empty dimensions (issue #45589)" begin
+    @test size(reshape(zeros(0,2), :)) == (0,)
+    @test size(reshape(zeros(0,2), 0,:)) == (0,2)
+    @test size(reshape(zeros(0,0,0), 0,:,0)) == (0,0,0)
+    @test size(reshape(zeros(0,0,0), 0,:,1)) == (0,0,1)
+    @test size(reshape(zeros(0,0,0), 0,:,1111)) == (0,0,1111)
+    @test size(reshape(zeros(0,2,3), 0,:)) == (0,6)
+    @test size(reshape(zeros(0,2,3), 0,:,2)) == (0,3,2)
+    @test size(reshape(zeros(0,2,3), 3,:,2)) == (3,0,2)
+    @test size(reshape(zeros(0,2,3), 0,:,6)) == (0,1,6)
+    @test size(reshape(zeros(0,2,3), 1,:,6)) == (1,0,6)
+    @test size(reshape(zeros(0,2,3), 1,:,3)) == (1,0,3)
+end


### PR DESCRIPTION
In `reshape`, one dimension from the output can be specified as `:`, and then it's inferred from the input size and the remaining specified dimensions.

If any specified output dimension is `zero`, the function today raises a zero division error. On the case of an empty input, though, we might simply infer anything consistent with another empty matrix. It's more of a case of "0/0"... And indeed, you can do
```
julia> reshape(zeros(0,4), 234,:)
234×0 Matrix{Float64}
```

#45589 points this out, and this patch proposes a solution.

If both input and output sizes contain a `0`, we compute a dimension from products of both sides ignoring zeros. This preserves the property that the input is recovered if the output contains the same values, except for one `:` (as long as the input has a single `0`). The size of the remaining dimensions may also be relevant in applications where arrays are being concatenated, and this makes it more likely that the produced array still matches some application constraint.