### PR TITLE
effects: add effects analysis for array construction

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2075,7 +2075,9 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
                 @goto always_throw
             end
         end
-        effects = EFFECTS_UNKNOWN
+        effects = foreigncall_effects(e) do @nospecialize x
+            abstract_eval_value(interp, x, vtypes, sv)
+        end
         cconv = e.args[5]
         if isa(cconv, QuoteNode) && (v = cconv.value; isa(v, Tuple{Symbol, UInt8}))
             override = decode_effects_override(v[2])

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -2300,4 +2300,88 @@ function get_binding_type_tfunc(@nospecialize(M), @nospecialize(s))
 end
 add_tfunc(Core.get_binding_type, 2, 2, get_binding_type_tfunc, 0)
 
+# foreigncall
+# ===========
+
+# N.B. the `abstract_eval` callback below allows us to use these queries
+# both during abstract interpret and optimization
+
+const FOREIGNCALL_ARG_START = 6
+
+function foreigncall_effects(@specialize(abstract_eval), e::Expr)
+    args = e.args
+    name = args[1]
+    isa(name, QuoteNode) && (name = name.value)
+    isa(name, Symbol) || return EFFECTS_UNKNOWN
+    ndims = alloc_array_ndims(name)
+    if ndims !== nothing
+        if ndims ≠ 0
+            return alloc_array_effects(abstract_eval, args, ndims)
+        else
+            return new_array_effects(abstract_eval, args)
+        end
+    end
+    return EFFECTS_UNKNOWN
+end
+
+function alloc_array_ndims(name::Symbol)
+    if name === :jl_alloc_array_1d
+        return 1
+    elseif name === :jl_alloc_array_2d
+        return 2
+    elseif name === :jl_alloc_array_3d
+        return 3
+    elseif name === :jl_new_array
+        return 0
+    end
+    return nothing
+end
+
+function alloc_array_effects(@specialize(abstract_eval), args::Vector{Any}, ndims::Int)
+    nothrow = alloc_array_nothrow(abstract_eval, args, ndims)
+    return Effects(EFFECTS_TOTAL; consistent=CONSISTENT_IF_NOTRETURNED, nothrow)
+end
+
+function alloc_array_nothrow(@specialize(abstract_eval), args::Vector{Any}, ndims::Int)
+    length(args) ≥ ndims+FOREIGNCALL_ARG_START || return false
+    atype = instanceof_tfunc(abstract_eval(args[FOREIGNCALL_ARG_START]))[1]
+    dims = Csize_t[]
+    for i in 1:ndims
+        dim = abstract_eval(args[i+FOREIGNCALL_ARG_START])
+        isa(dim, Const) || return false
+        dimval = dim.val
+        isa(dimval, Int) || return false
+        push!(dims, reinterpret(Csize_t, dimval))
+    end
+    return _new_array_nothrow(atype, ndims, dims)
+end
+
+function new_array_effects(@specialize(abstract_eval), args::Vector{Any})
+    nothrow = new_array_nothrow(abstract_eval, args)
+    return Effects(EFFECTS_TOTAL; consistent=CONSISTENT_IF_NOTRETURNED, nothrow)
+end
+
+function new_array_nothrow(@specialize(abstract_eval), args::Vector{Any})
+    length(args) ≥ FOREIGNCALL_ARG_START+1 || return false
+    atype = instanceof_tfunc(abstract_eval(args[FOREIGNCALL_ARG_START]))[1]
+    dims = abstract_eval(args[FOREIGNCALL_ARG_START+1])
+    isa(dims, Const) || return dims === Tuple{}
+    dimsval = dims.val
+    isa(dimsval, Tuple{Vararg{Int}}) || return false
+    ndims = nfields(dimsval)
+    isa(ndims, Int) || return false
+    dims = Csize_t[reinterpret(Csize_t, dimval) for dimval in dimsval]
+    return _new_array_nothrow(atype, ndims, dims)
+end
+
+function _new_array_nothrow(@nospecialize(atype), ndims::Int, dims::Vector{Csize_t})
+    isa(atype, DataType) || return false
+    eltype = atype.parameters[1]
+    iskindtype(typeof(eltype)) || return false
+    elsz = aligned_sizeof(eltype)
+    return ccall(:jl_array_validate_dims, Cint,
+        (Ptr{Csize_t}, Ptr{Csize_t}, UInt32, Ptr{Csize_t}, Csize_t),
+        #=nel=#RefValue{Csize_t}(), #=tot=#RefValue{Csize_t}(), ndims, dims, elsz) == 0
+end
+
 @specialize

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -491,3 +491,42 @@ end
     getfield(@__MODULE__, :global_ref)[] = nothing
 end
 @test !Core.Compiler.is_removable_if_unused(Base.infer_effects(unremovable_if_unused3!))
+
+@testset "effects analysis on array ops" begin
+
+@testset "effects analysis on array construction" begin
+
+@noinline construct_array(@nospecialize(T), args...) = Array{T}(undef, args...)
+
+# should eliminate safe but dead allocations
+let good_dims = 1:10
+    for dim in good_dims, N in 0:10
+        dims = ntuple(i->dim, N)
+        @test @eval Base.infer_effects() do
+            $construct_array(Int, $(dims...))
+        end |> Core.Compiler.is_removable_if_unused
+        @test @eval fully_eliminated() do
+            $construct_array(Int, $(dims...))
+            nothing
+        end
+    end
+end
+
+# should analyze throwness correctly
+let bad_dims = [-1, typemax(Int)]
+    for dim in bad_dims, N in 1:10
+        dims = ntuple(i->dim, N)
+        @test @eval Base.infer_effects() do
+            $construct_array(Int, $(dims...))
+        end |> !Core.Compiler.is_removable_if_unused
+        @test @eval !fully_eliminated() do
+            $construct_array(Int, $(dims...))
+            nothing
+        end
+        @test_throws "invalid Array" @eval $construct_array(Int, $(dims...))
+    end
+end
+
+end # @testset "effects analysis on array construction" begin
+
+end # @testset "effects analysis on array ops" begin

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -950,36 +950,39 @@ end
 let # effect-freeness computation for array allocation
 
     # should eliminate dead allocations
-    good_dims = (0, 2)
+    good_dims = 1:10
     for dim in good_dims, N in 0:10
         dims = ntuple(i->dim, N)
-        @eval @test fully_eliminated(()) do
+        @test @eval fully_eliminated() do
             Array{Int,$N}(undef, $(dims...))
             nothing
         end
     end
 
     # shouldn't eliminate errorneous dead allocations
-    bad_dims = [-1,           # should keep "invalid Array dimensions"
-                typemax(Int)] # should keep "invalid Array size"
+    bad_dims = [-1, typemax(Int)]
     for dim in bad_dims, N in 1:10
         dims = ntuple(i->dim, N)
-        @eval @test !fully_eliminated(()) do
+        @test @eval !fully_eliminated() do
+            Array{Int,$N}(undef, $(dims...))
+            nothing
+        end
+        @test_throws "invalid Array" @eval let
             Array{Int,$N}(undef, $(dims...))
             nothing
         end
     end
 
     # some high-level examples
-    @test fully_eliminated(()) do
+    @test fully_eliminated() do
         Int[]
         nothing
     end
-    @test fully_eliminated(()) do
+    @test fully_eliminated() do
         Matrix{Tuple{String,String}}(undef, 4, 4)
         nothing
     end
-    @test fully_eliminated(()) do
+    @test fully_eliminated() do
         IdDict{Any,Any}()
         nothing
     end


### PR DESCRIPTION
This commit implements an infrastructure to analyze effects of
`:foreigncall` expression, and especially implements effects
analysis for array constructions.

Some improvements:
```julia
julia> @noinline construct_array(@nospecialize(T), args...) = Array{T}(undef, args...);

julia> function check_dims(T, dims)
           construct_array(T, dims...)
           return  nothing
       end;
```

```julia
julia> code_typed() do
           check_dims(Int, (1,2,3))
       end
```
```diff
diff --git a/_master b/_pr
index b0ed0eaac1..38e2d3553d 100644
--- a/_master
+++ b/_pr
@@ -1,6 +1,4 @@
 1-element Vector{Any}:
  CodeInfo(
-1 ─      invoke Main.construct_array(Int64::Any, -1::Int64, 2::Vararg{Int64}, 3)::Any
-│   %2 = Main.nothing::Nothing
-└──      return %2
+1 ─     return nothing
 ) => Nothing
```

```julia
julia> code_typed() do
          check_dims(Int, (-1,2,3))
      end
```
```diff
diff --git a/_master b/_pr
index b0ed0eaac1..e5e724db10 100644
--- a/_master
+++ b/_pr
@@ -1,6 +1,5 @@
 1-element Vector{Any}:
  CodeInfo(
-1 ─      invoke Main.construct_array(Int64::Any, -1::Int64, 2::Vararg{Int64}, 3)::Any
-│   %2 = Main.nothing::Nothing
-└──      return %2
-) => Nothing
+1 ─     invoke Main.check_dims(Main.Int::Type, (-1, 2, 3)::Tuple{Int64, Int64, Int64})::Union{}
+└──     unreachable
+) => Union{}
```