### PR TITLE
fix `hvncat` docstring

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2188,14 +2188,13 @@ julia> hvncat(((3, 3), (3, 3), (6,)), true, a, b, c, d, e, f)
  4  5  6
 ```
 
-
-# Examples for construction of the arguments:
-```julia
+# Examples for construction of the arguments
+```
 [a b c ; d e f ;;;
  g h i ; j k l ;;;
  m n o ; p q r ;;;
  s t u ; v w x]
-=> dims = (2, 3, 4)
+⟹ dims = (2, 3, 4)
 
 [a b ; c ;;; d ;;;;]
  ___   _     _
@@ -2206,7 +2205,7 @@ julia> hvncat(((3, 3), (3, 3), (6,)), true, a, b, c, d, e, f)
  4             = elements in each 3d slice (4,)
  _____________
  4             = elements in each 4d slice (4,)
- => shape = ((2, 1, 1), (3, 1), (4,), (4,)) with `rowfirst` = true
+⟹ shape = ((2, 1, 1), (3, 1), (4,), (4,)) with `row_first` = true
 ```
 """
 hvncat(dimsshape::Tuple, row_first::Bool, xs...) = _hvncat(dimsshape, row_first, xs...)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2194,7 +2194,7 @@ julia> hvncat(((3, 3), (3, 3), (6,)), true, a, b, c, d, e, f)
  g h i ; j k l ;;;
  m n o ; p q r ;;;
  s t u ; v w x]
-⟹ dims = (2, 3, 4)
+⇒ dims = (2, 3, 4)
 
 [a b ; c ;;; d ;;;;]
  ___   _     _
@@ -2205,7 +2205,7 @@ julia> hvncat(((3, 3), (3, 3), (6,)), true, a, b, c, d, e, f)
  4             = elements in each 3d slice (4,)
  _____________
  4             = elements in each 4d slice (4,)
-⟹ shape = ((2, 1, 1), (3, 1), (4,), (4,)) with `row_first` = true
+⇒ shape = ((2, 1, 1), (3, 1), (4,), (4,)) with `row_first` = true
 ```
 """
 hvncat(dimsshape::Tuple, row_first::Bool, xs...) = _hvncat(dimsshape, row_first, xs...)


### PR DESCRIPTION
Fix https://github.com/JuliaLang/julia/issues/46013.
Fix https://github.com/JuliaLang/julia/issues/41107.

`help?> hvncat` now looks,  as expected, like:

![hvncat](https://user-images.githubusercontent.com/13423344/178737294-157caebe-319e-4da6-8b31-bf6a8ee68b5c.png)

