### PR TITLE
fix unreliable `jldoctest`

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1319,7 +1319,7 @@ internals.
 
 One can put the argument types in a tuple to get the corresponding `code_ircode`.
 
-```jldoctest
+```julia
 julia> Base.code_ircode(+, (Float64, Int64))
 1-element Vector{Any}:
  388 1 ─ %1 = Base.sitofp(Float64, _3)::Float64


### PR DESCRIPTION
Fix unreliable `jldoctest` introduced in https://github.com/JuliaLang/julia/pull/45306.

As shown e.g. in the `doctest` job https://buildkite.com/julialang/julia-master/builds/13830#0181f7c7-9994-4f84-a690-9cdb86480cbc.

Specifically, the incriminated number change will keep changing on addition / removal of any `jldoctest`s in the source docstrings: e.g. it changed after merging https://github.com/JuliaLang/julia/pull/45137.