### PR TITLE
mark two_mul as consistent

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -42,7 +42,7 @@ end
 
 # non-type specific math functions
 
-@inline function two_mul(x::Float64, y::Float64)
+@assume_effects :consistent @inline function two_mul(x::Float64, y::Float64)
     if Core.Intrinsics.have_fma(Float64)
         xy = x*y
         return xy, fma(x, y, -xy)
@@ -50,7 +50,7 @@ end
     return Base.twomul(x,y)
 end
 
-@inline function two_mul(x::T, y::T) where T<: Union{Float16, Float32}
+@assume_effects :consistent @inline function two_mul(x::T, y::T) where T<: Union{Float16, Float32}
     if Core.Intrinsics.have_fma(T)
         xy = x*y
         return xy, fma(x, y, -xy)

--- a/test/math.jl
+++ b/test/math.jl
@@ -1468,4 +1468,6 @@ for fn in (:sin, :cos, :tan, :log, :log2, :log10, :log1p, :exponent, :sqrt, :cbr
         end
     end
 end
-@test Core.Compiler.is_foldable(Base.infer_effects(^, (Float32,Int)))
+for T in (Float32, Float64)
+    @test Core.Compiler.is_foldable(Base.infer_effects(^, (T,Int)))
+end


### PR DESCRIPTION
should let the compiler prove that float64^int always gives the same result.