### PR TITLE
Deprecate Dates.argerror

### DIFF
--- a/stdlib/Dates/src/deprecated.jl
+++ b/stdlib/Dates/src/deprecated.jl
@@ -65,3 +65,6 @@ for op in (:+, :-)
         end
     end
 end
+
+@deprecate argerror(msg::String) ArgumentError(msg)
+@deprecate argerror() nothing

--- a/stdlib/Dates/src/deprecated.jl
+++ b/stdlib/Dates/src/deprecated.jl
@@ -66,5 +66,5 @@ for op in (:+, :-)
     end
 end
 
-@deprecate argerror(msg::String) ArgumentError(msg)
-@deprecate argerror() nothing
+@deprecate argerror(msg::String) ArgumentError(msg) false
+@deprecate argerror() nothing false

--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -204,15 +204,6 @@ Returns either an `ArgumentError`, or [`nothing`](@ref) in case of success.
 """
 function validargs end
 
-"""
-    argerror([msg]) -> Union{ArgumentError, Nothing}
-
-Return an `ArgumentError` object with the given message,
-or [`nothing`](@ref) if no message is provided. For use by `validargs`.
-"""
-argerror(msg::String) = ArgumentError(msg)
-argerror() = nothing
-
 # Julia uses 24-hour clocks internally, but user input can be AM/PM with 12pm == noon and 12am == midnight.
 @enum AMPM AM PM TWENTYFOURHOUR
 function adjusthour(h::Int64, ampm::AMPM)
@@ -240,18 +231,18 @@ end
 
 function validargs(::Type{DateTime}, y::Int64, m::Int64, d::Int64,
                    h::Int64, mi::Int64, s::Int64, ms::Int64, ampm::AMPM=TWENTYFOURHOUR)
-    0 < m < 13 || return argerror("Month: $m out of range (1:12)")
-    0 < d < daysinmonth(y, m) + 1 || return argerror("Day: $d out of range (1:$(daysinmonth(y, m)))")
+    0 < m < 13 || return ArgumentError("Month: $m out of range (1:12)")
+    0 < d < daysinmonth(y, m) + 1 || return ArgumentError("Day: $d out of range (1:$(daysinmonth(y, m)))")
     if ampm == TWENTYFOURHOUR # 24-hour clock
         -1 < h < 24 || (h == 24 && mi==s==ms==0) ||
-            return argerror("Hour: $h out of range (0:23)")
+            return ArgumentError("Hour: $h out of range (0:23)")
     else
-        0 < h < 13 || return argerror("Hour: $h out of range (1:12)")
+        0 < h < 13 || return ArgumentError("Hour: $h out of range (1:12)")
     end
-    -1 < mi < 60 || return argerror("Minute: $mi out of range (0:59)")
-    -1 < s < 60 || return argerror("Second: $s out of range (0:59)")
-    -1 < ms < 1000 || return argerror("Millisecond: $ms out of range (0:999)")
-    return argerror()
+    -1 < mi < 60 || return ArgumentError("Minute: $mi out of range (0:59)")
+    -1 < s < 60 || return ArgumentError("Second: $s out of range (0:59)")
+    -1 < ms < 1000 || return ArgumentError("Millisecond: $ms out of range (0:999)")
+    return nothing
 end
 
 DateTime(dt::Base.Libc.TmStruct) = DateTime(1900 + dt.year, 1 + dt.month, dt.mday, dt.hour, dt.min, dt.sec)
@@ -268,9 +259,9 @@ function Date(y::Int64, m::Int64=1, d::Int64=1)
 end
 
 function validargs(::Type{Date}, y::Int64, m::Int64, d::Int64)
-    0 < m < 13 || return argerror("Month: $m out of range (1:12)")
-    0 < d < daysinmonth(y, m) + 1 || return argerror("Day: $d out of range (1:$(daysinmonth(y, m)))")
-    return argerror()
+    0 < m < 13 || return ArgumentError("Month: $m out of range (1:12)")
+    0 < d < daysinmonth(y, m) + 1 || return ArgumentError("Day: $d out of range (1:$(daysinmonth(y, m)))")
+    return nothing
 end
 
 Date(dt::Base.Libc.TmStruct) = Date(1900 + dt.year, 1 + dt.month, dt.mday)
@@ -289,16 +280,16 @@ end
 
 function validargs(::Type{Time}, h::Int64, mi::Int64, s::Int64, ms::Int64, us::Int64, ns::Int64, ampm::AMPM=TWENTYFOURHOUR)
     if ampm == TWENTYFOURHOUR # 24-hour clock
-        -1 < h < 24 || return argerror("Hour: $h out of range (0:23)")
+        -1 < h < 24 || return ArgumentError("Hour: $h out of range (0:23)")
     else
-        0 < h < 13 || return argerror("Hour: $h out of range (1:12)")
+        0 < h < 13 || return ArgumentError("Hour: $h out of range (1:12)")
     end
-    -1 < mi < 60 || return argerror("Minute: $mi out of range (0:59)")
-    -1 < s < 60 || return argerror("Second: $s out of range (0:59)")
-    -1 < ms < 1000 || return argerror("Millisecond: $ms out of range (0:999)")
-    -1 < us < 1000 || return argerror("Microsecond: $us out of range (0:999)")
-    -1 < ns < 1000 || return argerror("Nanosecond: $ns out of range (0:999)")
-    return argerror()
+    -1 < mi < 60 || return ArgumentError("Minute: $mi out of range (0:59)")
+    -1 < s < 60 || return ArgumentError("Second: $s out of range (0:59)")
+    -1 < ms < 1000 || return ArgumentError("Millisecond: $ms out of range (0:999)")
+    -1 < us < 1000 || return ArgumentError("Microsecond: $us out of range (0:999)")
+    -1 < ns < 1000 || return ArgumentError("Nanosecond: $ns out of range (0:999)")
+    return nothing
 end
 
 Time(dt::Base.Libc.TmStruct) = Time(dt.hour, dt.min, dt.sec)


### PR DESCRIPTION
I don't see what this function does besides adding a layer of indirection to stack traces and code analysis.