### PR TITLE
Define regular expressions; clarify PCRE version

### DIFF
--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -770,9 +770,10 @@ are some examples of non-standard string literals. Users and packages may also d
 Further documentation is given in the [Metaprogramming](@ref meta-non-standard-string-literals) section.
 
 ## [Regular Expressions](@id man-regex-literals)
+Sometimes you are not looking for an exact string, but a particular *pattern*. For example, suppose you are trying to extract a single date from a large text file. You don’t know what that date is (that’s why you are searching for it), but you do know it will look something like `YYYY-MM-DD`. Regular expressions allow you to specify these patterns and search for them.
 
-Julia has Perl-compatible regular expressions (regexes), as provided by the [PCRE](https://www.pcre.org/)
-library (a description of the syntax can be found [here](https://www.pcre.org/current/doc/html/pcre2syntax.html)). Regular expressions are related to strings in two ways: the obvious connection is that
+Julia uses version 2 of Perl-compatible regular expressions (regexes), as provided by the [PCRE](https://www.pcre.org/)
+library (see the [PCRE2 syntax description](https://www.pcre.org/current/doc/html/pcre2syntax.html) for more details). Regular expressions are related to strings in two ways: the obvious connection is that
 regular expressions are used to find regular patterns in strings; the other connection is that
 regular expressions are themselves input as strings, which are parsed into a state machine that
 can be used to efficiently search for patterns in strings. In Julia, regular expressions are input


### PR DESCRIPTION
Minor edits to the docs:
* Add a definition of regular expressions, with an illustrative example
* Clarify that Julia uses version 2 of PCRE
* Add semantic link descriptor to PCRE2 spec link