### PR TITLE
effects: NFC refactor on effect-related code

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -521,3 +521,10 @@ function print_callstack(sv::InferenceState)
 end
 
 get_curr_ssaflag(sv::InferenceState) = sv.src.ssaflags[sv.currpc]
+
+function narguments(sv::InferenceState)
+    def = sv.linfo.def
+    isva = isa(def, Method) && def.isva
+    nargs = length(sv.result.argtypes) - isva
+    return nargs
+end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1416,9 +1416,9 @@ function infer_effects(@nospecialize(f), @nospecialize(types=default_tt(f));
     ccall(:jl_is_in_pure_context, Bool, ()) && error("code reflection cannot be used from generated functions")
     types = to_tuple_type(types)
     if isa(f, Core.Builtin)
-        args = Any[types.parameters...]
-        rt = Core.Compiler.builtin_tfunction(interp, f, args, nothing)
-        return Core.Compiler.builtin_effects(f, args, rt)
+        argtypes = Any[types.parameters...]
+        rt = Core.Compiler.builtin_tfunction(interp, f, argtypes, nothing)
+        return Core.Compiler.builtin_effects(f, argtypes, rt)
     else
         effects = Core.Compiler.EFFECTS_TOTAL
         matches = _methods(f, types, -1, world)::Vector

--- a/src/julia.h
+++ b/src/julia.h
@@ -234,19 +234,19 @@ typedef struct _jl_line_info_node_t {
     intptr_t inlined_at;
 } jl_line_info_node_t;
 
-// the following mirrors `struct EffectsOverride` in `base/compiler/types.jl`
+// the following mirrors `struct EffectsOverride` in `base/compiler/effects.jl`
 typedef union __jl_purity_overrides_t {
     struct {
-        uint8_t ipo_consistent  : 1;
-        uint8_t ipo_effect_free : 1;
-        uint8_t ipo_nothrow     : 1;
-        uint8_t ipo_terminates  : 1;
+        uint8_t ipo_consistent          : 1;
+        uint8_t ipo_effect_free         : 1;
+        uint8_t ipo_nothrow             : 1;
+        uint8_t ipo_terminates_globally : 1;
         // Weaker form of `terminates` that asserts
         // that any control flow syntactically in the method
         // is guaranteed to terminate, but does not make
         // assertions about any called functions.
-        uint8_t ipo_terminates_locally : 1;
-        uint8_t ipo_notaskstate : 1;
+        uint8_t ipo_terminates_locally  : 1;
+        uint8_t ipo_notaskstate         : 1;
     } overrides;
     uint8_t bits;
 } _jl_purity_overrides_t;
@@ -397,25 +397,27 @@ typedef struct _jl_code_instance_t {
 
     // purity results
 #ifdef JL_USE_ANON_UNIONS_FOR_PURITY_FLAGS
-    // see also encode_effects() and decode_effects() in `base/compiler/types.jl`,
+    // see also encode_effects() and decode_effects() in `base/compiler/effects.jl`,
     union {
         uint32_t ipo_purity_bits;
         struct {
-            uint8_t ipo_consistent:2;
-            uint8_t ipo_effect_free:2;
-            uint8_t ipo_nothrow:2;
-            uint8_t ipo_terminates:2;
-            uint8_t ipo_nonoverlayed:1;
+            uint8_t ipo_consistent   : 2;
+            uint8_t ipo_effect_free  : 2;
+            uint8_t ipo_nothrow      : 2;
+            uint8_t ipo_terminates   : 2;
+            uint8_t ipo_nonoverlayed : 1;
+            uint8_t ipo_notaskstate  : 2;
         } ipo_purity_flags;
     };
     union {
         uint32_t purity_bits;
         struct {
-            uint8_t consistent:2;
-            uint8_t effect_free:2;
-            uint8_t nothrow:2;
-            uint8_t terminates:2;
-            uint8_t nonoverlayed:1;
+            uint8_t consistent   : 2;
+            uint8_t effect_free  : 2;
+            uint8_t nothrow      : 2;
+            uint8_t terminates   : 2;
+            uint8_t nonoverlayed : 1;
+            uint8_t notaskstate  : 2;
         } purity_flags;
     };
 #else

--- a/src/method.c
+++ b/src/method.c
@@ -326,7 +326,7 @@ static void jl_code_info_set_ir(jl_code_info_t *li, jl_expr_t *ir)
                         li->purity.overrides.ipo_consistent = jl_unbox_bool(jl_exprarg(ma, 0));
                         li->purity.overrides.ipo_effect_free = jl_unbox_bool(jl_exprarg(ma, 1));
                         li->purity.overrides.ipo_nothrow = jl_unbox_bool(jl_exprarg(ma, 2));
-                        li->purity.overrides.ipo_terminates = jl_unbox_bool(jl_exprarg(ma, 3));
+                        li->purity.overrides.ipo_terminates_globally = jl_unbox_bool(jl_exprarg(ma, 3));
                         li->purity.overrides.ipo_terminates_locally = jl_unbox_bool(jl_exprarg(ma, 4));
                         li->purity.overrides.ipo_notaskstate = jl_unbox_bool(jl_exprarg(ma, 5));
                     }

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -995,4 +995,6 @@ function f_no_methods end
     # builtins
     @test Base.infer_effects(typeof, (Any,)) |> Core.Compiler.is_total
     @test Base.infer_effects(===, (Any,Any)) |> Core.Compiler.is_total
+    @test (Base.infer_effects(setfield!, ()); true) # `builtin_effects` shouldn't throw on empty `argtypes`
+    @test (Base.infer_effects(Core.Intrinsics.arraylen, ()); true) # `intrinsic_effects` shouldn't throw on empty `argtypes`
 end


### PR DESCRIPTION
This refactoring would make it clearer how to add new effect in
the future. These changes also improve the robustness of
`Base.infer_effects`: now it doesn't throw on empty input types.