### PR TITLE
Update uninstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ are included in the [build documentation](https://github.com/JuliaLang/julia/blo
 
 ### Uninstalling Julia
 
-By defaut, Julia does not install anything outside the directory it was cloned
+By default, Julia does not install anything outside the directory it was cloned
 into and `~/.julia`. Julia and the vast majority of Julia packages can be
 completely uninstalled by deleting these two directories.
 

--- a/README.md
+++ b/README.md
@@ -120,10 +120,9 @@ are included in the [build documentation](https://github.com/JuliaLang/julia/blo
 
 ### Uninstalling Julia
 
-Julia does not install anything outside the directory it was cloned
-into. Julia can be completely uninstalled by deleting this
-directory. Julia packages are installed in `~/.julia` by default, and
-can be uninstalled by deleting `~/.julia`.
+By defaut, Julia does not install anything outside the directory it was cloned
+into and `~/.julia`. Julia and the vast majority of Julia packages can be
+completely uninstalled by deleting these two directories.
 
 ## Source Code Organization
 


### PR DESCRIPTION
to account for the fact that julia does install iteslf into ~/.julia (e.g. ~./julia/logs/repl_history.jl)
