### PR TITLE
Enhance `StringIndexError` display (correct escaping)

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -17,10 +17,12 @@ function Base.showerror(io::IO, exc::StringIndexError)
     if firstindex(s) <= exc.index <= ncodeunits(s)
         iprev = thisind(s, exc.index)
         inext = nextind(s, iprev)
+        escprev = escape_string(s[iprev:iprev])
         if inext <= ncodeunits(s)
-            print(io, ", valid nearby indices [$iprev]=>'$(s[iprev])', [$inext]=>'$(s[inext])'")
+            escnext = escape_string(s[inext:inext])
+            print(io, ", valid nearby indices [$iprev]=>'$escprev', [$inext]=>'$escnext'")
         else
-            print(io, ", valid nearby index [$iprev]=>'$(s[iprev])'")
+            print(io, ", valid nearby index [$iprev]=>'$escprev'")
         end
     end
 end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -726,6 +726,11 @@ end
     @test_throws ArgumentError "abc"[BitArray([true, false, true])]
 end
 
+@testset "issue #46039 enhance StringIndexError display" begin
+    @test sprint(showerror, StringIndexError("αn", 2)) == "StringIndexError: invalid index [2], valid nearby indices [1]=>'α', [3]=>'n'"
+    @test sprint(showerror, StringIndexError("α\n", 2)) == "StringIndexError: invalid index [2], valid nearby indices [1]=>'α', [3]=>'\\n'"
+end
+
 @testset "concatenation" begin
     @test "ab" * "cd" == "abcd"
     @test 'a' * "bc" == "abc"


### PR DESCRIPTION
before
```jl
julia> "α\n"[2]
ERROR: StringIndexError: invalid index [2], valid nearby indices [1]=>'α', [3]=>'
'
Stacktrace:
```

after
```jl
julia> "α\n"[2]
ERROR: StringIndexError: invalid index [2], valid nearby indices [1]=>'α', [3]=>'\n'
Stacktrace:
```