### PR TITLE
Specialize tuple setindex to avoid ntuple-related performance regression.

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -55,9 +55,9 @@ function setindex(x::Tuple, v, i::Integer)
     _setindex(v, i, x...)
 end
 
-function _setindex(v, i::Integer, args...)
+function _setindex(v, i::Integer, args::Vararg{Any,N}) where {N}
     @inline
-    return ntuple(j -> ifelse(j == i, v, args[j]), length(args))
+    return ntuple(j -> ifelse(j == i, v, args[j]), Val{N}())
 end
 
 

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -754,3 +754,6 @@ g42457(a, b) = Base.isequal(a, b) ? 1 : 2.0
 @test only(Base.return_types(g42457, (NTuple{3, Int}, Tuple))) === Union{Float64, Int}
 @test only(Base.return_types(g42457, (NTuple{3, Int}, NTuple))) === Union{Float64, Int}
 @test only(Base.return_types(g42457, (NTuple{3, Int}, NTuple{4}))) === Float64
+
+# issue #46049: setindex(::Tuple) regression
+@inferred Base.setindex((1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16), 42, 1)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/46049. Not sure what a good test would be, as this does infer correctly.

cc @OlivierHnt