### PR TITLE
Allow `BUILDKITE_BRANCH` to provide branch name

### DIFF
--- a/base/version_git.sh
+++ b/base/version_git.sh
@@ -41,7 +41,15 @@ if [ -n "$(git status --porcelain)" ]; then
     # append dirty mark '*' if the repository has uncommitted changes
     commit_short="$commit_short"*
 fi
-branch=$(git rev-parse --abbrev-ref HEAD)
+
+# Our CI system checks commits out as a detached head, and so we must
+# use the provided branch name, as we cannot autodetect this commit as
+# the tip of any such branch.
+if [ -b "${BUILDKITE_BRANCH}" ]; then
+    branch="${BUILDKITE_BRANCH}"
+else
+    branch=$(git rev-parse --abbrev-ref HEAD)
+fi
 
 topdir=$(git rev-parse --show-toplevel)
 verchanged=$(git blame -L ,1 -sl -- "$topdir/VERSION" | cut -f 1 -d " ")

--- a/base/version_git.sh
+++ b/base/version_git.sh
@@ -45,7 +45,7 @@ fi
 # Our CI system checks commits out as a detached head, and so we must
 # use the provided branch name, as we cannot autodetect this commit as
 # the tip of any such branch.
-if [ -b "${BUILDKITE_BRANCH}" ]; then
+if [ -n "${BUILDKITE_BRANCH}" ]; then
     branch="${BUILDKITE_BRANCH}"
 else
     branch=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
Our CI system checks commits out as a detached head, which breaks our
`Base.GIT_VERSION_INFO.branch` information.