### PR TITLE
Test suite: If the `deprecation_exec` test fails, print the subcommand's `stdout` and `stderr` to the log

### DIFF
--- a/test/misc.jl
+++ b/test/misc.jl
@@ -970,12 +970,14 @@ include("testenv.jl")
 @testset "deprecation_exec" begin
     flags = Cmd(filter(a->!occursin("depwarn", a), collect(test_exeflags)))
     cmd = `$test_exename $flags --depwarn=yes deprecation_exec.jl`
-    io = IOBuffer()
+    io = Base.BufferStream()
     pipln = pipeline(cmd; stdout=io, stderr=io)
     proc = run(ignorestatus(pipln))
+    close(io)
+    proc_output = String(read(io))
     if !success(proc)
         # If the test failed, we print the stdout and stderr to the log.
-        println(String(take!(io)))
+        println(proc_output)
         @error "Deprecation test failed" cmd proc.exitcode proc.termsignal
         @test false
     end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -970,9 +970,10 @@ include("testenv.jl")
 @testset "deprecation_exec" begin
     flags = Cmd(filter(a->!occursin("depwarn", a), collect(test_exeflags)))
     cmd = `$test_exename $flags --depwarn=yes deprecation_exec.jl`
+    cmd = ignorestatus(cmd)
     io = Base.BufferStream()
     pipln = pipeline(cmd; stdout=io, stderr=io)
-    proc = run(ignorestatus(pipln))
+    proc = run(pipln)
     close(io)
     proc_output = String(read(io))
     if !success(proc)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -972,8 +972,7 @@ include("testenv.jl")
     cmd = `$test_exename $flags --depwarn=yes deprecation_exec.jl`
     io = IOBuffer()
     pipln = pipeline(cmd; stdout=io, stderr=io)
-    proc = run(pipln; wait = false)
-    wait(proc)
+    proc = run(ignorestatus(pipln))
     if !success(proc)
         # If the test failed, we print the stdout and stderr to the log.
         println(String(take!(io)))


### PR DESCRIPTION
This should help a little bit when trying to diagnose failures in the `deprecation_exec` test set (e.g. the failures seen in https://github.com/JuliaLang/julia/pull/46039).