### PR TITLE
Fix codegen test on debug version

### DIFF
--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -675,10 +675,14 @@ U41096 = Term41096{:U}(Modulate41096(:U, false))
 
 @test !newexpand41096((t=t41096, μ=μ41096, U=U41096), :U)
 
+function libjulia_codegen_name()
+    (ccall(:jl_is_debugbuild, Cint, ()) != 0) ? "libjulia-codegen-debug" : "libjulia-codegen"
+end
+
 # test that we can start julia with libjulia-codegen removed; PR #41936
 mktempdir() do pfx
     cp(dirname(Sys.BINDIR), pfx; force=true)
-    libpath = relpath(dirname(dlpath("libjulia-codegen")), dirname(Sys.BINDIR))
+    libpath = relpath(dirname(dlpath(libjulia_codegen_name())), dirname(Sys.BINDIR))
     libs_deleted = 0
     for f in filter(f -> startswith(f, "libjulia-codegen"), readdir(joinpath(pfx, libpath)))
         rm(joinpath(pfx, libpath, f); force=true, recursive=true)


### PR DESCRIPTION
xref: #46064

- Fix the name of the `libjulia-codegen` library in the debug version
- skip some llvm codegen test

reproduction steps
```sh
make -j `nproc`  debug
make -C test/  compiler/codegen debug
```


### `get_llvm` test
```jl
using InteractiveUtils
using Test

const opt_level = Base.JLOptions().opt_level

# `_dump_function` might be more efficient but it doesn't really matter here...
get_llvm(@nospecialize(f), @nospecialize(t), raw=true, dump_module=false, optimize=true) =
    sprint(code_llvm, f, t, raw, dump_module, optimize)

get_llvm(identity, Tuple{String}) |> print
if opt_level > 0
    # Make sure getptls call is removed at IR level with optimization on
    @test !occursin(" call ", get_llvm(identity, Tuple{String}))
end
```
In the debug version, the `@test` fails because the output of `llvm` contains the string `"call"`.
For now I'm just skipping them in the debug version. Maybe there is a better solution.

```jl
julia> get_llvm(identity, Tuple{String}) |> print
;  @ operators.jl:513 within `identity`
; Function Attrs: sspstrong
define nonnull {} addrspace(10)* @julia_identity_55({} addrspace(10)* noundef nonnull %0) #0 !dbg !5 {
top:
;  @ operators.jl within `identity`
  call void @llvm.dbg.value(metadata {} addrspace(10)* null, metadata !17, metadata !DIExpression(DW_OP_deref)), !dbg !18
  call void @llvm.dbg.value(metadata {} addrspace(10)* %0, metadata !17, metadata !DIExpression(DW_OP_deref)), !dbg !18
;  @ operators.jl:513 within `identity`
  ret {} addrspace(10)* %0, !dbg !19
}
```
