### PR TITLE
code loading fixes for cases where wrong version of package is loaded 

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -298,9 +298,9 @@ end
 
 # Used by Pkg but not used in loading itself
 function find_package(arg)
-    pkg = identify_package(arg)
+    pkg, env = identify_package_env(arg)
     pkg === nothing && return nothing
-    return locate_package(pkg)
+    return locate_package(pkg, env)
 end
 
 """
@@ -329,25 +329,31 @@ julia> Base.identify_package(LinearAlgebra, "Pkg") # Pkg is not a dependency of 
 
 ````
 """
-identify_package(where::Module, name::String) = identify_package(PkgId(where), name)
-function identify_package(where::PkgId, name::String)::Union{Nothing,PkgId}
-    where.name === name && return where
-    where.uuid === nothing && return identify_package(name) # ignore `where`
+identify_package_env(where::Module, name::String) = identify_package_env(PkgId(where), name)
+function identify_package_env(where::PkgId, name::String)
+    where.name === name && return where, nothing
+    where.uuid === nothing && return identify_package_env(name) # ignore `where`
     for env in load_path()
         pkgid = manifest_deps_get(env, where, name)
         pkgid === nothing && continue # not found--keep looking
-        pkgid.uuid === nothing || return pkgid # found in explicit environment--use it
+        pkgid.uuid === nothing || return pkgid, env # found in explicit environment--use it
         return nothing # found in implicit environment--return "not found"
     end
     return nothing
 end
-function identify_package(name::String)::Union{Nothing,PkgId}
+function identify_package_env(name::String)
     for env in load_path()
         uuid = project_deps_get(env, name)
-        uuid === nothing || return uuid # found--return it
+        uuid === nothing || return uuid, env # found--return it
     end
     return nothing
 end
+
+_nothing_or_first(x) = x === nothing ? nothing : first(x)
+identify_package(where::Module, name::String) = _nothing_or_first(identify_package_env(where, name))
+identify_package(where::PkgId, name::String)  = _nothing_or_first(identify_package_env(where, name))
+identify_package(name::String)                = _nothing_or_first(identify_package_env(name))
+
 
 """
     Base.locate_package(pkg::PkgId)::Union{String, Nothing}
@@ -363,7 +369,7 @@ julia> Base.locate_package(pkg)
 "/path/to/julia/stdlib/v$(VERSION.major).$(VERSION.minor)/Pkg/src/Pkg.jl"
 ```
 """
-function locate_package(pkg::PkgId)::Union{Nothing,String}
+function locate_package(pkg::PkgId, stopenv::Union{String, Nothing}=nothing)::Union{Nothing,String}
     if pkg.uuid === nothing
         for env in load_path()
             # look for the toplevel pkg `pkg.name` in this entry
@@ -377,6 +383,7 @@ function locate_package(pkg::PkgId)::Union{Nothing,String}
                     return implicit_manifest_uuid_path(env, pkg)
                 end
             end
+            stopenv == env && return nothing
         end
     else
         for env in load_path()
@@ -384,6 +391,7 @@ function locate_package(pkg::PkgId)::Union{Nothing,String}
             # missing is used as a sentinel to stop looking further down in envs
             path === missing && return nothing
             path === nothing || return entry_path(path, pkg.name)
+            stopenv == env && break
         end
         # Allow loading of stdlibs if the name/uuid are given
         # e.g. if they have been explicitly added to the project/manifest
@@ -1207,9 +1215,9 @@ function require(into::Module, mod::Symbol)
     @lock require_lock begin
     LOADING_CACHE[] = LoadingCache()
     try
-        uuidkey = identify_package(into, String(mod))
-        # Core.println("require($(PkgId(into)), $mod) -> $uuidkey")
-        if uuidkey === nothing
+        uuidkey_env = identify_package_env(into, String(mod))
+        # Core.println("require($(PkgId(into)), $mod) -> $uuidkey from env \"$env\"")
+        if uuidkey_env === nothing
             where = PkgId(into)
             if where.uuid === nothing
                 hint, dots = begin
@@ -1237,10 +1245,11 @@ function require(into::Module, mod::Symbol)
                 - Otherwise you may need to report an issue with $(where.name)"""))
             end
         end
+        uuidkey, env = uuidkey_env
         if _track_dependencies[]
             push!(_require_dependencies, (into, binpack(uuidkey), 0.0))
         end
-        return _require_prelocked(uuidkey)
+        return _require_prelocked(uuidkey, env)
     finally
         LOADING_CACHE[] = nothing
     end
@@ -1257,10 +1266,10 @@ const pkgorigins = Dict{PkgId,PkgOrigin}()
 
 require(uuidkey::PkgId) = @lock require_lock _require_prelocked(uuidkey)
 
-function _require_prelocked(uuidkey::PkgId)
+function _require_prelocked(uuidkey::PkgId, env=nothing)
     assert_havelock(require_lock)
     if !root_module_exists(uuidkey)
-        newm = _require(uuidkey)
+        newm = _require(uuidkey, env)
         if newm === nothing
             error("package `$(uuidkey.name)` did not define the expected \
                   module `$(uuidkey.name)`, check for typos in package module name")
@@ -1349,7 +1358,7 @@ function set_pkgorigin_version_path(pkg::PkgId, path::Union{String,Nothing})
 end
 
 # Returns `nothing` or the new(ish) module
-function _require(pkg::PkgId)
+function _require(pkg::PkgId, env=nothing)
     assert_havelock(require_lock)
     # handle recursive calls to require
     loading = get(package_locks, pkg, false)
@@ -1364,7 +1373,7 @@ function _require(pkg::PkgId)
     try
         toplevel_load[] = false
         # perform the search operation to select the module file require intends to load
-        path = locate_package(pkg)
+        path = locate_package(pkg, env)
         if path === nothing
             throw(ArgumentError("""
                 Package $pkg is required but does not seem to be installed:

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -298,8 +298,9 @@ end
 
 # Used by Pkg but not used in loading itself
 function find_package(arg)
-    pkg, env = identify_package_env(arg)
-    pkg === nothing && return nothing
+    pkgenv = identify_package_env(arg)
+    pkgenv === nothing && return nothing
+    pkg, env = pkgenv
     return locate_package(pkg, env)
 end
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -945,10 +945,10 @@ end
 
         # This SHA does not exist in the depot.
         write(joinpath(tmp, "Env1", "Manifest.toml"), """
-        [[Baz]]
-        uuid = "6801f525-dc68-44e8-a4e8-cabd286279e7"
-        git-tree-sha1 = "5f2f6e72d001b014b48b26ec462f3714c342e167"
-        """)
+            [[Baz]]
+            uuid = "6801f525-dc68-44e8-a4e8-cabd286279e7"
+            git-tree-sha1 = "5f2f6e72d001b014b48b26ec462f3714c342e167"
+            """)
 
 
         old_load_path = copy(LOAD_PATH)
@@ -957,15 +957,18 @@ end
             empty!(LOAD_PATH)
             push!(empty!(DEPOT_PATH), joinpath(tmp, "depot"))
             
-            push!(LOAD_PATH, joinpath(tmp, "Env1"), joinpath(tmp, "Global"))
+            push!(LOAD_PATH, joinpath(tmp, "Global"))
 
             pkg = Base.identify_package("Baz")
             # Package in manifest in current env not present in depot
+            @test Base.locate_package(pkg) !== nothing
+
+            pushfirst!(LOAD_PATH, joinpath(tmp, "Env1"))
+
             @test Base.locate_package(pkg) === nothing
 
             write(joinpath(tmp, "Env1", "Manifest.toml"), """
             """)
-
             # Package in current env not present in manifest
             pkg, env = Base.identify_package_env("Baz")
             @test Base.locate_package(pkg, env) === nothing

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -956,7 +956,7 @@ end
         try
             empty!(LOAD_PATH)
             push!(empty!(DEPOT_PATH), joinpath(tmp, "depot"))
-            
+
             push!(LOAD_PATH, joinpath(tmp, "Global"))
 
             pkg = Base.identify_package("Baz")


### PR DESCRIPTION
This fixes the two cases given in https://github.com/JuliaLang/julia/issues/45977 where the wrong package version gets loaded.

The first case is where the package version is not found in the depot. In that case, we now return a `missing` to signal not to look any further through the env stack.

The second case is where a manifest entry is not present for a package identified in the current env. This is fixed by returning the env a package got identified with and then stopping searching through envs in `locate_package` when that env is hit.

Fixes #45977 