### PR TITLE
Remove examples of time_imports nesting given it was a bug

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -115,7 +115,8 @@ Standard library changes
 
 #### InteractiveUtils
 
-* New macro `@time_imports` for reporting any time spent importing packages and their dependencies ([#41612]).
+* New macro `@time_imports` for reporting any time spent importing packages and their dependencies, highlighting
+  compilation and recompilation time as percentages per import ([#41612],[#45064]).
 
 #### LinearAlgebra
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -84,7 +84,6 @@ Library changes
 * `RoundFromZero` now works for non-`BigFloat` types ([#41246]).
 * `Dict` can be now shrunk manually by `sizehint!` ([#45004]).
 * `@time` now separates out % time spent recompiling invalidated methods ([#45015]).
-* `@time_imports` now shows any compilation and recompilation time percentages per import ([#45064]).
 * `eachslice` now works over multiple dimensions; `eachslice`, `eachrow` and `eachcol` return
   a `Slices` object, which allows dispatching to provide more efficient methods ([#32310]).
 

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -356,39 +356,31 @@ See also: [`code_native`](@ref), [`@code_llvm`](@ref), [`@code_typed`](@ref) and
 A macro to execute an expression and produce a report of any time spent importing packages and their
 dependencies. Any compilation time will be reported as a percentage, and how much of which was recompilation, if any.
 
-If a package's dependencies have already been imported either globally or by another dependency they will
-not appear under that package and the package will accurately report a faster load time than if it were to
-be loaded in isolation.
-
-!!! compat "Julia 1.9"
-    Reporting of any compilation and recompilation time was added in Julia 1.9
+!!! note
+    During the load process a package sequentially imports all of its dependencies, not just its direct dependencies.
 
 ```julia-repl
 julia> @time_imports using CSV
-      0.4 ms    ┌ IteratorInterfaceExtensions
-     11.1 ms  ┌ TableTraits 84.88% compilation time
-    145.4 ms  ┌ SentinelArrays 66.73% compilation time
-     42.3 ms  ┌ Parsers 19.66% compilation time
-      4.1 ms  ┌ Compat
-      8.2 ms  ┌ OrderedCollections
-      1.4 ms    ┌ Zlib_jll
-      2.3 ms    ┌ TranscodingStreams
-      6.1 ms  ┌ CodecZlib
-      0.3 ms  ┌ DataValueInterfaces
-     15.2 ms  ┌ FilePathsBase 30.06% compilation time
-      9.3 ms    ┌ InlineStrings
-      1.5 ms    ┌ DataAPI
-     31.4 ms  ┌ WeakRefStrings
-     14.8 ms  ┌ Tables
-     24.2 ms  ┌ PooledArrays
-   2002.4 ms  CSV 83.49% compilation time
+     50.7 ms  Parsers 17.52% compilation time
+      0.2 ms  DataValueInterfaces
+      1.6 ms  DataAPI
+      0.1 ms  IteratorInterfaceExtensions
+      0.1 ms  TableTraits
+     17.5 ms  Tables
+     26.8 ms  PooledArrays
+    193.7 ms  SentinelArrays 75.12% compilation time
+      8.6 ms  InlineStrings
+     20.3 ms  WeakRefStrings
+      2.0 ms  TranscodingStreams
+      1.4 ms  Zlib_jll
+      1.8 ms  CodecZlib
+      0.8 ms  Compat
+     13.1 ms  FilePathsBase 28.39% compilation time
+   1681.2 ms  CSV 92.40% compilation time
 ```
 
-!!! note
-    During the load process a package sequentially imports where necessary all of its dependencies, not just
-    its direct dependencies. That is also true for the dependencies themselves so nested importing will likely
-    occur, but not always. Therefore the nesting shown in this output report is not equivalent to the dependency
-    tree, but does indicate where import time has accumulated.
+!!! compat "Julia 1.8"
+    This macro requires at least Julia 1.8
 
 """
 :@time_imports


### PR DESCRIPTION
As noted in https://github.com/JuliaLang/julia/pull/45861#issuecomment-1186269074 the nested loading was a bug that https://github.com/JuliaLang/julia/pull/45861 fixed.

That means that the nesting in `@time_imports` is no longer seen, so this updates the docs. Also fixes up the changelog, which needs manual backport.

Note that it means that the times shown are purely the import time of each package now (not the sum of all nested times), given that its deps are loaded further up the order.

So, previously, something like
```
julia> @time_imports using CSV
      0.4 ms    ┌ IteratorInterfaceExtensions
     11.1 ms  ┌ TableTraits 84.88% compilation time
    145.4 ms  ┌ SentinelArrays 66.73% compilation time
     42.3 ms  ┌ Parsers 19.66% compilation time
      4.1 ms  ┌ Compat
      8.2 ms  ┌ OrderedCollections
      1.4 ms    ┌ Zlib_jll
      2.3 ms    ┌ TranscodingStreams
      6.1 ms  ┌ CodecZlib
      0.3 ms  ┌ DataValueInterfaces
     15.2 ms  ┌ FilePathsBase 30.06% compilation time
      9.3 ms    ┌ InlineStrings
      1.5 ms    ┌ DataAPI
     31.4 ms  ┌ WeakRefStrings
     14.8 ms  ┌ Tables
     24.2 ms  ┌ PooledArrays
   2002.4 ms  CSV 83.49% compilation time
   ```

Now:
```
julia> @time_imports using CSV
     50.7 ms  Parsers 17.52% compilation time
      0.2 ms  DataValueInterfaces
      1.6 ms  DataAPI
      0.1 ms  IteratorInterfaceExtensions
      0.1 ms  TableTraits
     17.5 ms  Tables
     26.8 ms  PooledArrays
    193.7 ms  SentinelArrays 75.12% compilation time
      8.6 ms  InlineStrings
     20.3 ms  WeakRefStrings
      2.0 ms  TranscodingStreams
      1.4 ms  Zlib_jll
      1.8 ms  CodecZlib
      0.8 ms  Compat
     13.1 ms  FilePathsBase 28.39% compilation time
   1681.2 ms  CSV 92.40% compilation time
```

(These timings haven't been tested on the same CSV & dep versions. They shouldn't be taken to mean there's a load speed improvement)