### PR TITLE
Use `max(1, Sys.CPU_THREADS)` BLAS threads for `aarch64`.

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -582,7 +582,11 @@ function __init__()
     Base.at_disable_library_threading(() -> BLAS.set_num_threads(1))
 
     if !haskey(ENV, "OPENBLAS_NUM_THREADS")
-        BLAS.set_num_threads(max(1, Sys.CPU_THREADS ÷ 2))
+        if Sys.ARCH === :aarch64
+            BLAS.set_num_threads(max(1, Sys.CPU_THREADS))
+        else
+            BLAS.set_num_threads(max(1, Sys.CPU_THREADS ÷ 2))
+        end
     end
 end
 

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -582,7 +582,7 @@ function __init__()
     Base.at_disable_library_threading(() -> BLAS.set_num_threads(1))
 
     if !haskey(ENV, "OPENBLAS_NUM_THREADS")
-        if Sys.ARCH === :aarch64
+        @static if Sys.isapple() && Base.BinaryPlatforms.arch(Base.BinaryPlatforms.HostPlatform()) == "aarch64"
             BLAS.set_num_threads(max(1, Sys.CPU_THREADS))
         else
             BLAS.set_num_threads(max(1, Sys.CPU_THREADS ÷ 2))


### PR DESCRIPTION
None of the common ARM CPUs that come to mind have hyperthreading.

Fixes JuliaLang/LinearAlgebra.jl#934