### PR TITLE
Relax type of `PartialOpaque` source field

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -434,7 +434,7 @@ eval(Core, quote
     Const(@nospecialize(v)) = $(Expr(:new, :Const, :v))
     # NOTE the main constructor is defined within `Core.Compiler`
     _PartialStruct(typ::DataType, fields::Array{Any, 1}) = $(Expr(:new, :PartialStruct, :typ, :fields))
-    PartialOpaque(@nospecialize(typ), @nospecialize(env), parent::MethodInstance, source::Method) = $(Expr(:new, :PartialOpaque, :typ, :env, :parent, :source))
+    PartialOpaque(@nospecialize(typ), @nospecialize(env), parent::MethodInstance, source) = $(Expr(:new, :PartialOpaque, :typ, :env, :parent, :source))
     InterConditional(slot::Int, @nospecialize(thentype), @nospecialize(elsetype)) = $(Expr(:new, :InterConditional, :slot, :thentype, :elsetype))
     MethodMatch(@nospecialize(spec_types), sparams::SimpleVector, method::Method, fully_covers::Bool) = $(Expr(:new, :MethodMatch, :spec_types, :sparams, :method, :fully_covers))
 end)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2699,7 +2699,7 @@ void jl_init_types(void) JL_GC_DISABLED
 
     jl_partial_opaque_type = jl_new_datatype(jl_symbol("PartialOpaque"), core, jl_any_type, jl_emptysvec,
         jl_perm_symsvec(4, "typ", "env", "parent", "source"),
-        jl_svec(4, jl_type_type, jl_any_type, jl_method_instance_type, jl_method_type),
+        jl_svec(4, jl_type_type, jl_any_type, jl_method_instance_type, jl_any_type),
         jl_emptysvec, 0, 0, 4);
 
     // complete builtin type metadata


### PR DESCRIPTION
We type this as `::Method`, which is what's expected in Base. However,
Diffractor wants to be able to generate the source lazyily, so it needs
to be able to stash some information here to be able to perform
type inference before generating the method source. When that code
was originally written (pre-OpaqueClosure), this used a custom lattice
element, but `PartialOpaque` seems appropriate, since these do widen
to an OpaqueClosure and what's happening here is essentially just
that the `source` is being generated lazily.

We may want to revisit this if we switch the way that we represent
lattice elements, but for now, this seems like the path of least
resistance.