### PR TITLE
fix sort(Union{}[])

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -736,8 +736,8 @@ end
 # For AbstractVector{Bool}, counting sort is always best.
 # This is an implementation of counting sort specialized for Bools.
 # Accepts unused buffer to avoid method ambiguity.
-function sort!(v::AbstractVector{B}, lo::Integer, hi::Integer, a::AdaptiveSort, o::Ordering,
-        t::Union{AbstractVector{B}, Nothing}=nothing) where {B <: Bool}
+function sort!(v::AbstractVector{Bool}, lo::Integer, hi::Integer, a::AdaptiveSort, o::Ordering,
+        t::Union{AbstractVector{Bool}, Nothing}=nothing)
     first = lt(o, false, true) ? false : lt(o, true, false) ? true : return v
     count = 0
     @inbounds for i in lo:hi
@@ -1405,7 +1405,7 @@ uint_unmap(::Type{T}, u::Unsigned, ::ForwardOrdering) where T <: Signed =
 
 # unsigned(Int) is not available during bootstrapping.
 for (U, S) in [(UInt8, Int8), (UInt16, Int16), (UInt32, Int32), (UInt64, Int64), (UInt128, Int128)]
-    @eval UIntMappable(::Type{<:Union{$U, $S}}, ::ForwardOrdering) = $U
+    @eval UIntMappable(::Union{Type{$U}, Type{$S}}, ::ForwardOrdering) = $U
 end
 
 # Floats are not UIntMappable under regular orderings because they fail on NaN edge cases.

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -75,6 +75,7 @@ end
     @test sum(randperm(6)) == 21
     @test length(reverse(0x1:0x2)) == 2
     @test issorted(sort(rand(UInt64(1):UInt64(2), 7); rev=true); rev=true) # issue #43034
+    @test sort(Union{}[]) == Union{}[] # issue #45280
 end
 
 @testset "partialsort" begin
@@ -678,6 +679,8 @@ end
             end
         end
     end
+
+    @test Base.Sort.UIntMappable(Union{Int, UInt}, Base.Forward) === nothing # issue #45280
 end
 
 @testset "sort(x; buffer)" begin


### PR DESCRIPTION
Implements @vtjnash's suggestions to fix #45280