### PR TITLE
effects: refactor `builtin_effects`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2161,16 +2161,15 @@ function abstract_eval_global(M::Module, s::Symbol)
 end
 
 function abstract_eval_global(M::Module, s::Symbol, frame::InferenceState)
-    ty = abstract_eval_global(M, s)
-    isa(ty, Const) && return ty
-    if isdefined(M,s)
-        tristate_merge!(frame, Effects(EFFECTS_TOTAL; consistent=ALWAYS_FALSE))
-    else
-        tristate_merge!(frame, Effects(EFFECTS_TOTAL;
-            consistent=ALWAYS_FALSE,
-            nothrow=ALWAYS_FALSE))
+    rt = abstract_eval_global(M, s)
+    consistent = nothrow = ALWAYS_FALSE
+    if isa(rt, Const)
+        consistent = nothrow = ALWAYS_TRUE
+    elseif isdefined(M,s)
+        nothrow = ALWAYS_TRUE
     end
-    return ty
+    tristate_merge!(frame, Effects(EFFECTS_TOTAL; consistent, nothrow))
+    return rt
 end
 
 function handle_global_assignment!(interp::AbstractInterpreter, frame::InferenceState, lhs::GlobalRef, @nospecialize(newty))

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -429,7 +429,8 @@ function adjust_effects(sv::InferenceState)
     if !ipo_effects.inbounds_taints_consistency && rt === Bottom
         # always throwing an error counts or never returning both count as consistent
         ipo_effects = Effects(ipo_effects; consistent=ALWAYS_TRUE)
-    elseif ipo_effects.consistent === TRISTATE_UNKNOWN && is_consistent_rt(rt)
+    end
+    if ipo_effects.consistent === TRISTATE_UNKNOWN && is_consistent_argtype(rt)
         # in a case when the :consistent-cy here is only tainted by mutable allocations
         # (indicated by `TRISTATE_UNKNOWN`), we may be able to refine it if the return
         # type guarantees that the allocations are never returned
@@ -458,14 +459,6 @@ function adjust_effects(sv::InferenceState)
     end
 
     return ipo_effects
-end
-
-is_consistent_rt(@nospecialize rt) = _is_consistent_rt(widenconst(ignorelimited(rt)))
-function _is_consistent_rt(@nospecialize ty)
-    if isa(ty, Union)
-        return _is_consistent_rt(ty.a) && _is_consistent_rt(ty.b)
-    end
-    return ty === Symbol || isbitstype(ty)
 end
 
 # inference completed on `me`


### PR DESCRIPTION
Factor special builtin handlings into separated functions
(e.g. `getfield_effects`) so that we can refactor them more easily.

This also improves analysis accuracy a bit, e.g.
```julia
julia> Base.infer_effects((Bool,)) do c
           obj = c ? Some{String}("foo") : Some{Symbol}(:bar)
           return getfield(obj, :value)
       end
(!c,+e,!n,+t,!s) # master
(+c,+e,!n,+t,+s) # this PR
```