### PR TITLE
Fix timev compilation time tracking and add tests

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -353,9 +353,11 @@ macro timev(msg, ex)
         Experimental.@force_compile
         local stats = gc_num()
         local elapsedtime = time_ns()
+        cumulative_compile_timing(true)
         local compile_elapsedtimes = cumulative_compile_time_ns()
         local val = @__tryfinally($(esc(ex)),
             (elapsedtime = time_ns() - elapsedtime;
+            cumulative_compile_timing(false)
             compile_elapsedtimes = cumulative_compile_time_ns() .- compile_elapsedtimes)
         )
         local diff = GC_Diff(gc_num(), stats)

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -357,7 +357,7 @@ macro timev(msg, ex)
         local compile_elapsedtimes = cumulative_compile_time_ns()
         local val = @__tryfinally($(esc(ex)),
             (elapsedtime = time_ns() - elapsedtime;
-            cumulative_compile_timing(false)
+            cumulative_compile_timing(false);
             compile_elapsedtimes = cumulative_compile_time_ns() .- compile_elapsedtimes)
         )
         local diff = GC_Diff(gc_num(), stats)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -367,36 +367,64 @@ macro capture_stdout(ex)
 end
 
 # compilation reports in @time, @timev
-for m in ("@time",  "@timev")
-    let f = gensym("f"), callf = gensym("callf"), call2f = gensym("call2f")
-        @eval begin
-            $f(::Real) = 1
-            $callf(container) = $f(container[1])
-            $call2f(container) = $callf(container)
-            c64 = [1.0]
-            c32 = [1.0f0]
-            cabs = AbstractFloat[1.0]
+let f = gensym("f"), callf = gensym("callf"), call2f = gensym("call2f")
+    @eval begin
+        $f(::Real) = 1
+        $callf(container) = $f(container[1])
+        $call2f(container) = $callf(container)
+        c64 = [1.0]
+        c32 = [1.0f0]
+        cabs = AbstractFloat[1.0]
 
-            out = @capture_stdout $m $call2f(c64)
-            @test occursin("% compilation time", out)
-            out = @capture_stdout $m $call2f(c64)
-            @test occursin("% compilation time", out) == false
+        out = @capture_stdout @time $call2f(c64)
+        @test occursin("% compilation time", out)
+        out = @capture_stdout @time $call2f(c64)
+        @test occursin("% compilation time", out) == false
 
-            out = @capture_stdout $m $call2f(c32)
-            @test occursin("% compilation time", out)
-            out = @capture_stdout $m $call2f(c32)
-            @test occursin("% compilation time", out) == false
+        out = @capture_stdout @time $call2f(c32)
+        @test occursin("% compilation time", out)
+        out = @capture_stdout @time $call2f(c32)
+        @test occursin("% compilation time", out) == false
 
-            out = @capture_stdout $m $call2f(cabs)
-            @test occursin("% compilation time", out)
-            out = @capture_stdout $m $call2f(cabs)
-            @test occursin("% compilation time", out) == false
+        out = @capture_stdout @time $call2f(cabs)
+        @test occursin("% compilation time", out)
+        out = @capture_stdout @time $call2f(cabs)
+        @test occursin("% compilation time", out) == false
 
-            $f(::Float64) = 2
-            out = @capture_stdout $m $call2f(c64)
-            @test occursin("% compilation time:", out)
-            @test occursin("% of which was recompilation", out)
-        end
+        $f(::Float64) = 2
+        out = @capture_stdout @time $call2f(c64)
+        @test occursin("% compilation time:", out)
+        @test occursin("% of which was recompilation", out)
+    end
+end
+let f = gensym("f"), callf = gensym("callf"), call2f = gensym("call2f")
+    @eval begin
+        $f(::Real) = 1
+        $callf(container) = $f(container[1])
+        $call2f(container) = $callf(container)
+        c64 = [1.0]
+        c32 = [1.0f0]
+        cabs = AbstractFloat[1.0]
+
+        out = @capture_stdout @timev $call2f(c64)
+        @test occursin("% compilation time", out)
+        out = @capture_stdout @timev $call2f(c64)
+        @test occursin("% compilation time", out) == false
+
+        out = @capture_stdout @timev $call2f(c32)
+        @test occursin("% compilation time", out)
+        out = @capture_stdout @timev $call2f(c32)
+        @test occursin("% compilation time", out) == false
+
+        out = @capture_stdout @timev $call2f(cabs)
+        @test occursin("% compilation time", out)
+        out = @capture_stdout @timev $call2f(cabs)
+        @test occursin("% compilation time", out) == false
+
+        $f(::Float64) = 2
+        out = @capture_stdout @timev $call2f(c64)
+        @test occursin("% compilation time:", out)
+        @test occursin("% of which was recompilation", out)
     end
 end
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -366,35 +366,37 @@ macro capture_stdout(ex)
     end
 end
 
-# compilation reports in @time
-let f = gensym("f"), callf = gensym("callf"), call2f = gensym("call2f")
-    @eval begin
-        $f(::Real) = 1
-        $callf(container) = $f(container[1])
-        $call2f(container) = $callf(container)
-        c64 = [1.0]
-        c32 = [1.0f0]
-        cabs = AbstractFloat[1.0]
+# compilation reports in @time, @timev
+for m in ("@time",  "@timev")
+    let f = gensym("f"), callf = gensym("callf"), call2f = gensym("call2f")
+        @eval begin
+            $f(::Real) = 1
+            $callf(container) = $f(container[1])
+            $call2f(container) = $callf(container)
+            c64 = [1.0]
+            c32 = [1.0f0]
+            cabs = AbstractFloat[1.0]
 
-        out = @capture_stdout @time $call2f(c64)
-        @test occursin("% compilation time", out)
-        out = @capture_stdout @time $call2f(c64)
-        @test occursin("% compilation time", out) == false
+            out = @capture_stdout $m $call2f(c64)
+            @test occursin("% compilation time", out)
+            out = @capture_stdout $m $call2f(c64)
+            @test occursin("% compilation time", out) == false
 
-        out = @capture_stdout @time $call2f(c32)
-        @test occursin("% compilation time", out)
-        out = @capture_stdout @time $call2f(c32)
-        @test occursin("% compilation time", out) == false
+            out = @capture_stdout $m $call2f(c32)
+            @test occursin("% compilation time", out)
+            out = @capture_stdout $m $call2f(c32)
+            @test occursin("% compilation time", out) == false
 
-        out = @capture_stdout @time $call2f(cabs)
-        @test occursin("% compilation time", out)
-        out = @capture_stdout @time $call2f(cabs)
-        @test occursin("% compilation time", out) == false
+            out = @capture_stdout $m $call2f(cabs)
+            @test occursin("% compilation time", out)
+            out = @capture_stdout $m $call2f(cabs)
+            @test occursin("% compilation time", out) == false
 
-        $f(::Float64) = 2
-        out = @capture_stdout @time $call2f(c64)
-        @test occursin("% compilation time:", out)
-        @test occursin("% of which was recompilation", out)
+            $f(::Float64) = 2
+            out = @capture_stdout $m $call2f(c64)
+            @test occursin("% compilation time:", out)
+            @test occursin("% of which was recompilation", out)
+        end
     end
 end
 


### PR DESCRIPTION
As noted by @NHDaly https://github.com/JuliaLang/julia/pull/45015/files#r924872101 `@timev` compilation timing wasn't turned on after changes in https://github.com/JuliaLang/julia/pull/45015
