### PR TITLE
In IR2OC constructor, widenconst OC argtypes

### DIFF
--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -59,7 +59,7 @@ Mainly used for testing or interactive use.
 """
 inflate_ir(ci::CodeInfo, linfo::MethodInstance) = inflate_ir!(copy(ci), linfo)
 inflate_ir(ci::CodeInfo, sptypes::Vector{Any}, argtypes::Vector{Any}) = inflate_ir!(copy(ci), sptypes, argtypes)
-inflate_ir(ci::CodeInfo) = inflate_ir(ci, Any[], Any[ ci.slottypes === nothing ? Any : ci.slottypes[i] for i = 1:length(ci.slotflags) ])
+inflate_ir(ci::CodeInfo) = inflate_ir(ci, Any[], Any[ ci.slottypes === nothing ? Any : (ci.slottypes::Vector{Any})[i] for i = 1:length(ci.slotflags) ])
 
 function replace_code_newstyle!(ci::CodeInfo, ir::IRCode, nargs::Int)
     @assert isempty(ir.new_nodes)

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -59,7 +59,7 @@ Mainly used for testing or interactive use.
 """
 inflate_ir(ci::CodeInfo, linfo::MethodInstance) = inflate_ir!(copy(ci), linfo)
 inflate_ir(ci::CodeInfo, sptypes::Vector{Any}, argtypes::Vector{Any}) = inflate_ir!(copy(ci), sptypes, argtypes)
-inflate_ir(ci::CodeInfo) = inflate_ir(ci, Any[], Any[ Any for i = 1:length(ci.slotflags) ])
+inflate_ir(ci::CodeInfo) = inflate_ir(ci, Any[], Any[ ci.slottypes === nothing ? Any : ci.slottypes[i] for i = 1:length(ci.slotflags) ])
 
 function replace_code_newstyle!(ci::CodeInfo, ir::IRCode, nargs::Int)
     @assert isempty(ir.new_nodes)

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -255,12 +255,18 @@ end
 
 let ci = code_typed((x, y...)->(x, y), (Int, Int))[1][1]
     ir = Core.Compiler.inflate_ir(ci)
-    @test OpaqueClosure(ir; nargs=2, isva=true)(40, 2) === (40, (2,))
-    @test OpaqueClosure(ci)(40, 2) === (40, (2,))
-end
+    let oc = OpaqueClosure(ir; nargs=2, isva=true)
+        @test oc(40, 2) === (40, (2,))
+        @test_throws MethodError oc(1,2,3)
+    end
+    let oc = OpaqueClosure(ci)
+        @test oc(40, 2) === (40, (2,))
+        @test_throws MethodError oc(1,2,3)
+    end
 
-let ci = code_typed((x, y...)->(x, y), (Int, Int))[1][1]
-    ir = Core.Compiler.inflate_ir(ci)
-    @test_throws MethodError OpaqueClosure(ir; nargs=2, isva=true)(1, 2, 3)
-    @test_throws MethodError OpaqueClosure(ci)(1, 2, 3)
+    ir = Core.Compiler.inflate_ir(ci, Any[], Any[Tuple{}, Int, Tuple{Int}])
+    let oc = OpaqueClosure(ir; nargs=2, isva=true)
+        @test oc(40, 2) === (40, (2,))
+        @test_throws MethodError oc(1,2,3)
+    end
 end


### PR DESCRIPTION
The IR argtypes are lattice elements, but OC needs types.