### PR TITLE
effects: fix correctness issues of `:consistent`-cy analysis

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1887,18 +1887,21 @@ function abstract_eval_cfunction(interp::AbstractInterpreter, e::Expr, vtypes::V
 end
 
 function abstract_eval_value_expr(interp::AbstractInterpreter, e::Expr, vtypes::VarTable, sv::InferenceState)
-    if e.head === :static_parameter
+    head = e.head
+    if head === :static_parameter
         n = e.args[1]::Int
         t = Any
         if 1 <= n <= length(sv.sptypes)
             t = sv.sptypes[n]
         end
         return t
-    elseif e.head === :boundscheck
+    elseif head === :boundscheck
         return Bool
-    else
+    elseif head === :the_exception
+        tristate_merge!(sv, Effects(EFFECTS_TOTAL; consistent=ALWAYS_FALSE))
         return Any
     end
+    return Any
 end
 
 function abstract_eval_special_value(interp::AbstractInterpreter, @nospecialize(e), vtypes::VarTable, sv::InferenceState)

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -104,6 +104,77 @@ function compare_inconsistent(x::T) where T
 end
 @test !compare_inconsistent(3)
 
+# allocation/access of uninitialized fields should taint the :consistent-cy
+struct Maybe{T}
+    x::T
+    Maybe{T}() where T = new{T}()
+    Maybe{T}(x) where T = new{T}(x)
+    Maybe(x::T) where T = new{T}(x)
+end
+Base.getindex(x::Maybe) = x.x
+
+import Core.Compiler: Const, getfield_notundefined
+for T = (Base.RefValue, Maybe) # both mutable and immutable
+    for name = (Const(1), Const(:x))
+        @test getfield_notundefined(T{String}, name)
+        @test getfield_notundefined(T{Integer}, name)
+        @test getfield_notundefined(T{Union{String,Integer}}, name)
+        @test getfield_notundefined(Union{T{String},T{Integer}}, name)
+        @test !getfield_notundefined(T{Int}, name)
+        @test !getfield_notundefined(T{<:Integer}, name)
+        @test !getfield_notundefined(T{Union{Int32,Int64}}, name)
+        @test !getfield_notundefined(T, name)
+    end
+    # throw doesn't account for undefined behavior
+    for name = (Const(0), Const(2), Const(1.0), Const(:y), Const("x"),
+                Float64, String, Nothing)
+        @test getfield_notundefined(T{String}, name)
+        @test getfield_notundefined(T{Int}, name)
+        @test getfield_notundefined(T{Integer}, name)
+        @test getfield_notundefined(T{<:Integer}, name)
+        @test getfield_notundefined(T{Union{Int32,Int64}}, name)
+        @test getfield_notundefined(T, name)
+    end
+    # should not be too conservative when field isn't known very well but object information is accurate
+    @test getfield_notundefined(T{String}, Int)
+    @test getfield_notundefined(T{String}, Symbol)
+    @test getfield_notundefined(T{Integer}, Int)
+    @test getfield_notundefined(T{Integer}, Symbol)
+    @test !getfield_notundefined(T{Int}, Int)
+    @test !getfield_notundefined(T{Int}, Symbol)
+    @test !getfield_notundefined(T{<:Integer}, Int)
+    @test !getfield_notundefined(T{<:Integer}, Symbol)
+end
+# should be conservative when object information isn't accurate
+@test !getfield_notundefined(Any, Const(1))
+@test !getfield_notundefined(Any, Const(:x))
+# tuples and namedtuples should be okay if not given accurate information
+for TupleType = Any[Tuple{Int,Int,Int}, Tuple{Int,Vararg{Int}}, Tuple{Any}, Tuple,
+                    NamedTuple{(:a, :b), Tuple{Int,Int}}, NamedTuple{(:x,),Tuple{Any}}, NamedTuple],
+    FieldType = Any[Int, Symbol, Any]
+    @test getfield_notundefined(TupleType, FieldType)
+end
+
+# TODO add equivalent test cases for `Ref` once we handle mutability more nicely
+@test Base.infer_effects() do
+    Maybe{Int}()
+end |> !Core.Compiler.is_consistent
+@test Base.infer_effects() do
+    Maybe{Int}()[]
+end |> !Core.Compiler.is_consistent
+@test !fully_eliminated() do
+    Maybe{Int}()[]
+end
+@test Base.infer_effects() do
+    Maybe{String}()
+end |> Core.Compiler.is_consistent
+@test Base.infer_effects() do
+    Maybe{String}()[]
+end |> Core.Compiler.is_consistent
+@test Base.return_types() do
+    Maybe{String}()[] # this expression should be concrete evaluated
+end |> only === Union{}
+
 # effects propagation for `Core.invoke` calls
 # https://github.com/JuliaLang/julia/issues/44763
 global x44763::Int = 0


### PR DESCRIPTION
Today @vtjnash and I found two correctness issues for `:consistent`-cy:
- `:the_exception` should taint `:consistent`-cy as much like an allocation
- access to (potentially) undefined field should also taint `:consistent`-cy
  (in a way that even a return type information can't later refine it)