### PR TITLE
Fix fast path for `strides(::ReinterpretArray)` with dense parent.

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -153,7 +153,7 @@ stride(A::Union{DenseArray,StridedReshapedArray,StridedReinterpretArray}, k::Int
     k ≤ ndims(A) ? strides(A)[k] : length(A)
 
 function strides(a::ReinterpretArray{T,<:Any,S,<:AbstractArray{S},IsReshaped}) where {T,S,IsReshaped}
-    _checkcontiguous(Bool, a) && return size_to_strides(1, size(a))
+    _checkcontiguous(Bool, a) && return size_to_strides(1, size(a)...)
     stp = strides(parent(a))
     els, elp = sizeof(T), sizeof(S)
     els == elp && return stp # 0dim parent is also handled here.

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1623,6 +1623,9 @@ Base.size(::FakeZeroDimArray) = ()
     # Zero dimensional parent
     a = reshape(FakeZeroDimArray(),1,1,1)
     @test @inferred(strides(a)) == (1, 1, 1)
+    # Dense parent (but not StridedArray)
+    A = reinterpret(Int8, reinterpret(reshape, Int16, rand(Int8, 2, 3, 3)))
+    @test check_strides(reshape(A, 3, 2, 3))
 end
 
 @testset "stride for 0 dims array #44087" begin

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -197,6 +197,9 @@ end
         end
         @test check_strides(reinterpret(Float32, view(A, 8:-1:1, viewax2)))
     end
+    # issue 46113
+    A = reinterpret(Int8, reinterpret(reshape, Int16, rand(Int8, 2, 3, 3)))
+    @test check_strides(A)
 end
 
 @testset "strides for ReshapedReinterpretArray" begin


### PR DESCRIPTION
Fix #46113.