### PR TITLE
Set `@nospecialize` for `something`

### DIFF
--- a/base/some.jl
+++ b/base/some.jl
@@ -95,9 +95,9 @@ ERROR: ArgumentError: No value arguments present
 function something end
 
 something() = throw(ArgumentError("No value arguments present"))
-something(x::Nothing, y...) = something(y...)
-something(x::Some, y...) = x.value
-something(x::Any, y...) = x
+something(x::Nothing, @nospecialize(y...)) = something(y...)
+something(x::Some, @nospecialize(y...)) = x.value
+something(@nospecialize(x::Any), @nospecialize(y...)) = x
 
 
 """


### PR DESCRIPTION
This reduces the time to first `something` and shouldn't have a negative effect on performance. Benchmarked with Julia 1.8-rc3:

```julia
_something() = throw(ArgumentError("No value arguments present"))
_something(x::Nothing, @nospecialize(y...)) = something(y...)
_something(x::Some, @nospecialize(y...)) = x.value
_something(@nospecialize(x::Any), @nospecialize(y...)) = x

println("\nWarmup")
warmup(x) = x
@time @eval warmup(1)

data(n) = Tuple(rand([1, 2, nothing], n))
data(10)

println("\n`@time @eval` with `data(10)`")
@time @eval _something(data(10))
@time @eval something(data(10))

println("\n`@time @eval` with `data(10)`")
@time @eval _something(data(10))
@time @eval something(data(10))

println("\n`@time @eval` with `data(100)`")
@time @eval _something(data(100))
@time @eval something(data(100))

using BenchmarkTools: @btime

println("\n`@btime` with `data(10)`")
@btime _something(data(10))
@btime something(data(10))

println("\n`@btime` with `data(100)`")
@btime _something(data(100))
@btime something(data(100))
```

```
Warmup
  0.008335 seconds (715 allocations: 46.219 KiB, 26.85% compilation time)

`@time @eval` with `data(10)`
  0.002522 seconds (475 allocations: 31.594 KiB, 90.09% compilation time) # _something
  0.003608 seconds (437 allocations: 29.297 KiB, 92.91% compilation time) # something

`@time @eval` with `data(10)`
  0.000231 seconds (58 allocations: 2.984 KiB) # _something
  0.003566 seconds (436 allocations: 29.234 KiB, 93.21% compilation time) # something

`@time @eval` with `data(100)`
  0.000229 seconds (58 allocations: 4.969 KiB) # _something
  0.003454 seconds (436 allocations: 31.250 KiB, 92.85% compilation time) # something

`@btime` with `data(10)`
  7.765 μs (6 allocations: 406 bytes) # _something
  6.893 μs (6 allocations: 403 bytes) # something

`@btime` with `data(100)`
  52.839 μs (8 allocations: 2.53 KiB) # _something
  54.913 μs (8 allocations: 2.48 KiB) # something
```

The benchmark shows that `_something` has no compilation time for arbitrary tuples after the first invocation. The original method `something` does have compilation time. Furthermore, the running time does not seem to be affected and I cannot think of a reason where it would since `f(@nospecialize(x)) = x` correctly infers the return type even with the `@nospecialize` annotation.