### PR TITLE
inference: simplify error-case handling within `abstract_eval_statement`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1968,7 +1968,7 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
             ismutable = ismutabletype(t)
             fcount = fieldcount(t)
             nargs = length(e.args) - 1
-            @assert fcount ≥ nargs # syntactically enforced by the front-end
+            @assert fcount ≥ nargs "malformed :new expression" # syntactically enforced by the front-end
             ats = Vector{Any}(undef, nargs)
             local anyrefine = false
             local allconst = true


### PR DESCRIPTION
Separated from #46111.
This really doesn't matter usually though as the frontend doesn't form
`:new` expression anyway.