### PR TITLE
Fix opaque closure inlining performance

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1379,8 +1379,7 @@ function handle_const_opaque_closure_call!(
     ir::IRCode, idx::Int, stmt::Expr, result::ConstPropResult, flag::UInt8,
     sig::Signature, state::InliningState, todo::Vector{Pair{Int, Any}})
     item = InliningTodo(result.result, sig.argtypes)
-    isdispatchtuple(item.mi.specTypes) || return
-    validate_sparams(item.mi.sparam_vals) || return
+    validate_sparams(item.mi.sparam_vals) || return nothing
     state.mi_cache !== nothing && (item = resolve_todo(item, state, flag))
     handle_single_case!(ir, idx, stmt, item, todo, state.params)
     return nothing

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1525,3 +1525,11 @@ end
         @test Core.Compiler.decode_effects_override(only(methods(Core.kwfunc(f))).purity).notaskstate
     end
 end
+
+# Test that one opaque closure capturing another gets inlined properly.
+function oc_capture_oc(z)
+    oc1 = @opaque x->x
+    oc2 = @opaque y->oc1(y)
+    return oc2(z)
+end
+@test fully_eliminated(oc_capture_oc, (Int,))


### PR DESCRIPTION
At some point over the last few months, the opaque closure inlining
path got an extra check for `isdispatchtuple` that is both unnecessary
and causes significant performance regressions for Diffractor. Get
rid of it and add a test to make sure this doesn't regress again.