### PR TITLE
Build/win: Build with MSYS2

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1394,13 +1394,13 @@ define symlink_target # (from, to-dir, to-name)
 CLEAN_TARGETS += clean-$$(abspath $(2)/$(3))
 clean-$$(abspath $(2)/$(3)):
 ifeq ($(BUILD_OS), WINNT)
-	-cmd //C rmdir $$(call mingw_to_dos,$(2)/$(3),cd $(2) &&)
+	-cmd //C rmdir $$(call cygpath_w,$(2)/$(3))
 else
 	rm -rf $$(abspath $(2)/$(3))
 endif
 $$(abspath $(2)/$(3)): | $$(abspath $(2))
 ifeq ($$(BUILD_OS), WINNT)
-	@cmd //C mklink //J $$(call mingw_to_dos,$(2)/$(3),cd $(2) &&) $$(call mingw_to_dos,$(1),)
+	@cmd //C mklink //J $$(call cygpath_w,$(2)/$(3)) $$(call cygpath_w,$(1))
 else ifneq (,$$(findstring CYGWIN,$$(BUILD_OS)))
 	@cmd /C mklink /J $$(call cygpath_w,$(2)/$(3)) $$(call cygpath_w,$(1))
 else ifdef JULIA_VAGRANT_BUILD
@@ -1418,7 +1418,7 @@ WINE ?= wine
 # many of the following targets must be = not := because the expansion of the makefile functions (and $1) shouldn't happen until later
 ifeq ($(BUILD_OS), WINNT) # MSYS
 spawn = $(1)
-cygpath_w = $(1)
+cygpath_w = `cygpath -w $(1)`
 else ifneq (,$(findstring CYGWIN,$(BUILD_OS))) # Cygwin
 spawn = $(1)
 cygpath_w = `cygpath -w $(1)`

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -28,6 +28,13 @@ endif
 # Build list of dependent libraries that must be opened
 SHIPFLAGS  += -DDEP_LIBS="\"$(LOADER_BUILD_DEP_LIBS)\""
 DEBUGFLAGS += -DDEP_LIBS="\"$(LOADER_DEBUG_BUILD_DEP_LIBS)\""
+ifneq (,$(findstring MINGW,$(shell uname)))
+# In MSYS2, do not perform path conversion for `DEP_LIBS`.
+# https://www.msys2.org/wiki/Porting/#filesystem-namespaces
+CC_WITH_ENV := MSYS2_ARG_CONV_EXCL="-DDEP_LIBS=" $(CC)
+else
+CC_WITH_ENV := $(CC)
+endif # in MSYS2?
 
 EXE_OBJS := $(BUILDDIR)/loader_exe.o
 EXE_DOBJS := $(BUILDDIR)/loader_exe.dbg.obj
@@ -45,9 +52,9 @@ all: release debug
 release debug :  % : julia-% libjulia-%
 
 $(BUILDDIR)/loader_lib.o : $(SRCDIR)/loader_lib.c $(HEADERS) $(JULIAHOME)/VERSION
-	@$(call PRINT_CC, $(CC) -DLIBRARY_EXPORTS $(SHIPFLAGS) $(LOADER_CFLAGS) -c $< -o $@)
+	@$(call PRINT_CC, $(CC_WITH_ENV) -DLIBRARY_EXPORTS $(SHIPFLAGS) $(LOADER_CFLAGS) -c $< -o $@)
 $(BUILDDIR)/loader_lib.dbg.obj : $(SRCDIR)/loader_lib.c $(HEADERS) $(JULIAHOME)/VERSION
-	@$(call PRINT_CC, $(CC) -DLIBRARY_EXPORTS $(DEBUGFLAGS) $(LOADER_CFLAGS) -c $< -o $@)
+	@$(call PRINT_CC, $(CC_WITH_ENV) -DLIBRARY_EXPORTS $(DEBUGFLAGS) $(LOADER_CFLAGS) -c $< -o $@)
 $(BUILDDIR)/loader_exe.o : $(SRCDIR)/loader_exe.c $(HEADERS) $(JULIAHOME)/VERSION
 	@$(call PRINT_CC, $(CC) $(SHIPFLAGS) $(LOADER_CFLAGS) -c $< -o $@)
 $(BUILDDIR)/loader_exe.dbg.obj : $(SRCDIR)/loader_exe.c $(HEADERS) $(JULIAHOME)/VERSION

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -31,10 +31,11 @@ DEBUGFLAGS += -DDEP_LIBS="\"$(LOADER_DEBUG_BUILD_DEP_LIBS)\""
 ifneq (,$(findstring MINGW,$(shell uname)))
 # In MSYS2, do not perform path conversion for `DEP_LIBS`.
 # https://www.msys2.org/wiki/Porting/#filesystem-namespaces
-CC_WITH_ENV := MSYS2_ARG_CONV_EXCL="-DDEP_LIBS=" $(CC)
-else
-CC_WITH_ENV := $(CC)
-endif # in MSYS2?
+# We define this environment variable for only these two object files,
+# as they're the only ones that require it at the time of writing.
+$(BUILDDIR)/loader_lib.o: export MSYS2_ARG_CONV_EXCL = -DDEP_LIBS=
+$(BUILDDIR)/loader_lib.dbg.obj: export MSYS2_ARG_CONV_EXCL = -DDEP_LIBS=
+endif # MSYS2
 
 EXE_OBJS := $(BUILDDIR)/loader_exe.o
 EXE_DOBJS := $(BUILDDIR)/loader_exe.dbg.obj
@@ -52,9 +53,9 @@ all: release debug
 release debug :  % : julia-% libjulia-%
 
 $(BUILDDIR)/loader_lib.o : $(SRCDIR)/loader_lib.c $(HEADERS) $(JULIAHOME)/VERSION
-	@$(call PRINT_CC, $(CC_WITH_ENV) -DLIBRARY_EXPORTS $(SHIPFLAGS) $(LOADER_CFLAGS) -c $< -o $@)
+	@$(call PRINT_CC, $(CC) -DLIBRARY_EXPORTS $(SHIPFLAGS) $(LOADER_CFLAGS) -c $< -o $@)
 $(BUILDDIR)/loader_lib.dbg.obj : $(SRCDIR)/loader_lib.c $(HEADERS) $(JULIAHOME)/VERSION
-	@$(call PRINT_CC, $(CC_WITH_ENV) -DLIBRARY_EXPORTS $(DEBUGFLAGS) $(LOADER_CFLAGS) -c $< -o $@)
+	@$(call PRINT_CC, $(CC) -DLIBRARY_EXPORTS $(DEBUGFLAGS) $(LOADER_CFLAGS) -c $< -o $@)
 $(BUILDDIR)/loader_exe.o : $(SRCDIR)/loader_exe.c $(HEADERS) $(JULIAHOME)/VERSION
 	@$(call PRINT_CC, $(CC) $(SHIPFLAGS) $(LOADER_CFLAGS) -c $< -o $@)
 $(BUILDDIR)/loader_exe.dbg.obj : $(SRCDIR)/loader_exe.c $(HEADERS) $(JULIAHOME)/VERSION

--- a/doc/src/devdocs/build/windows.md
+++ b/doc/src/devdocs/build/windows.md
@@ -155,18 +155,31 @@ Note: MSYS2 requires **64 bit** Windows 7 or newer.
 
  2. Build Julia and its dependencies with pre-build dependencies.
 
-    1. Open a new [**MINGW64/32 shell**](https://www.msys2.org/docs/environments/#overview)
-        and clone the Julia sources
+    1. Open a new [**MINGW64/MINGW32 shell**](https://www.msys2.org/docs/environments/#overview).  
+        Currently we can't use both mingw32 and mingw64,
+        so if you want to build the x86_64 and i686 versions,
+        you'll need to build them in each environment separately.
+
+    2. and clone the Julia sources
         ```sh
         git clone https://github.com/JuliaLang/julia.git
         cd julia
         ```
 
-    2. Start the build
+    3. Start the build
         ```sh
         # Adjust the number of cores (4) to match your build environment.
         make -j 4
         ```
+
+    > Protip: build in dir
+    > ```sh
+    > make O=julia-mingw-w64 configure
+    > echo 'ifeq ($(BUILDROOT),$(JULIAHOME))
+    >         $(error "in-tree build disabled")
+    >       endif' >> Make.user
+    > make -C julia-mingw-w64
+    > ```
 
 
 ### Cross-compiling from Unix (Linux/Mac/WSL)

--- a/doc/src/devdocs/build/windows.md
+++ b/doc/src/devdocs/build/windows.md
@@ -145,9 +145,9 @@ Note: MSYS2 requires **64 bit** Windows 7 or newer.
         pacman -S cmake diffutils git m4 make patch tar p7zip curl python
 
         # For 64 bit Julia, install x86_64
-        pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-gcc-fortran
+        pacman -S mingw-w64-x86_64-gcc
         # For 32 bit Julia, install i686
-        pacman -S mingw-w64-i686-gcc mingw-w64-i686-gcc-fortran
+        pacman -S mingw-w64-i686-gcc
         ```
 
     4. Configuration of MSYS2 is complete. Now `exit` the MSYS2 shell.
@@ -168,8 +168,7 @@ Note: MSYS2 requires **64 bit** Windows 7 or newer.
 
     3. Start the build
         ```sh
-        # Adjust the number of cores (4) to match your build environment.
-        make -j 4
+        make -j$(nproc)
         ```
 
     > Protip: build in dir

--- a/doc/src/devdocs/build/windows.md
+++ b/doc/src/devdocs/build/windows.md
@@ -155,7 +155,7 @@ Note: MSYS2 requires **64 bit** Windows 7 or newer.
 
  2. Build Julia and its dependencies with pre-build dependencies.
 
-    1. Open a new [**MINGW64/MINGW32 shell**](https://www.msys2.org/docs/environments/#overview).  
+    1. Open a new [**MINGW64/MINGW32 shell**](https://www.msys2.org/docs/environments/#overview).
         Currently we can't use both mingw32 and mingw64,
         so if you want to build the x86_64 and i686 versions,
         you'll need to build them in each environment separately.

--- a/doc/src/devdocs/build/windows.md
+++ b/doc/src/devdocs/build/windows.md
@@ -118,11 +118,55 @@ MinGW-w64 compilers available through Cygwin's package manager.
 
 ### Compiling with MinGW/MSYS2
 
-Compiling Julia from source using [MSYS2](https://msys2.github.io) has worked in the past
-but is not actively supported. Pull requests to restore support would be welcome. See a
-[past version of this
-file](https://github.com/JuliaLang/julia/blob/v0.6.0/README.windows.md) for the former
-instructions for compiling using MSYS2.
+> MSYS2 provides a robust MSYS experience.
+
+Note: MSYS2 requires **64 bit** Windows 7 or newer.
+
+ 1. Install and configure [MSYS2](https://www.msys2.org/), Software Distribution
+    and Building Platform for Windows.
+
+    1. Download and run the latest installer for the
+        [64-bit](https://github.com/msys2/msys2-installer/releases/latest) distribution.
+        The installer will have a name like `msys2-x86_64-yyyymmdd.exe`.
+
+    2. Open MSYS2. Update package database and base packages:
+        ```sh
+        pacman -Syu
+        ```
+
+    3. Exit and restart MSYS2, Update the rest of the base packages:
+        ```sh
+        pacman -Syu
+        ```
+
+    3. Then install tools required to build julia:
+        ```sh
+        # tools
+        pacman -S cmake diffutils git m4 make patch tar p7zip curl python
+
+        # For 64 bit Julia, install x86_64
+        pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-gcc-fortran
+        # For 32 bit Julia, install i686
+        pacman -S mingw-w64-i686-gcc mingw-w64-i686-gcc-fortran
+        ```
+
+    4. Configuration of MSYS2 is complete. Now `exit` the MSYS2 shell.
+
+
+ 2. Build Julia and its dependencies with pre-build dependencies.
+
+    1. Open a new [**MINGW64/32 shell**](https://www.msys2.org/docs/environments/#overview)
+        and clone the Julia sources
+        ```sh
+        git clone https://github.com/JuliaLang/julia.git
+        cd julia
+        ```
+
+    2. Start the build
+        ```sh
+        # Adjust the number of cores (4) to match your build environment.
+        make -j 4
+        ```
 
 
 ### Cross-compiling from Unix (Linux/Mac/WSL)


### PR DESCRIPTION
Close #46139 

- [x] build with MINGW64 + pre-build deps
  - [x] run test locally
- [x] build with MINGW32 + pre-build deps
  - [x] run test locally
- [x] build with cygwin
- [x] add docs

MSYS2 v.s. Cygwin build and test time

| Shell   env              |    MSYS2 |   Cygwin |    MSYS2 |   Cygwin |
|--------------------------|---------:|---------:|---------:|---------:|
| toolchain                |  mingw64 |  mingw64 |  mingw32 |  mingw32 |
| arch                     |   x86_64 |   x86_64 |      x86 |      x86 |
| Build                    |        . |        . |        . |        . |
| Sysimage built/s         |     55.9 |     55.9 |     87.7 |     85.9 |
| Precompilation/s         |    148.9 |    147.1 |    691.6 |    672.4 |
| Pre--Generation          |    115.4 |    113.9 |    440.5 |    433.2 |
| Pre--Execution           |     33.5 |     33.2 |    251.1 |    239.2 |
| Output sysimage/s        |    150.6 |    149.1 |    156.6 |    155.7 |
| Test                     |        . |        . |        . |        . |
| Overall                  | 27m02.3s | 26m27.7s | 70m14.0s | 72m15.3s |
| LinearAlgebra/triangular | 10m58.9s | 10m52.0s | 14m35.1s | 14m07.8s |
| LinearAlgebra/addmul     |  9m19.5s |  9m07.8s | 12m05.8s |  6m28.2s |
| intfuncs                 |    10.1s |    10.0s | 12m05.4s | 12m43.9s |
| bitarray                 |  3m40.3s |  3m42.3s | 23m17.4s | 24m01.3s |
| Profile                  |    30.8s |    32.1s | 34m35.5s | 38m22.2s |

raw test output: https://gist.github.com/inkydragon/548d2eb99955c758b6c6b907b03aeaa8

<details>
<summary>mingw64 test log</summary>


### build
```
Sysimage built. Summary:
Base ────────  26.613768 seconds 47.5633%
Stdlibs ─────  29.338653 seconds 52.4332%
Total ───────  55.954380 seconds
make[1]: Leaving directory '/v/julia/julia-mingw64'
make[1]: Entering directory '/v/julia/julia-mingw64'
    JULIA julia-mingw64/usr/lib/julia/sys-o.a
Generating REPL precompile statements... 40/40
Executing precompile statements... 2028/2061
Precompilation complete. Summary:
Generation ── 115.457198 seconds 77.5291%
Execution ───  33.463985 seconds 22.4709%
Total ─────── 148.921183 seconds
Outputting sysimage file...
Output ────── 150.625233 seconds
```

### test

version
```
julia> versioninfo()
Julia Version 1.9.0-DEV.1040
Commit c7ff32668c* (2022-07-28 07:53 UTC)
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
  CPU: 6 × Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.5 (ORCJIT, skylake)
  Threads: 1 on 6 virtual cores
```

- Downloads: Fail x4

```
Test Summary:                                     |     Pass  Fail  Broken     Total      Time
  Overall                                         | 40433277     4  352668  40785949  27m02.3s
    LinearAlgebra/schur                           |      496                     496     45.5s
    LinearAlgebra/eigen                           |      512                     512   1m13.2s
    LinearAlgebra/qr                              |     4705                    4705   2m14.8s
    LinearAlgebra/bunchkaufman                    |     5688                    5688     39.7s
    LinearAlgebra/lapack                          |      802                     802     37.0s
    LinearAlgebra/svd                             |      566                     566   1m08.1s
    LinearAlgebra/special                         |     2942                    2942   4m16.0s
    LinearAlgebra/tridiag                         |     1541                    1541   1m01.1s
    LinearAlgebra/dense                           |     8475                    8475   5m46.5s
    LinearAlgebra/cholesky                        |     2509                    2509   1m56.7s
    LinearAlgebra/matmul                          |     1486                    1486   6m39.2s
    LinearAlgebra/bidiag                          |     4736                    4736   3m49.1s
    LinearAlgebra/generic                         |      630                     630     49.1s
    LinearAlgebra/lu                              |     1368                    1368   2m00.0s
    LinearAlgebra/uniformscaling                  |      446                     446   1m17.7s
    LinearAlgebra/lq                              |     2938                    2938   1m08.1s
    LinearAlgebra/hessenberg                      |      631                     631   1m08.4s
    LinearAlgebra/pinv                            |      500                     500      9.6s
    LinearAlgebra/adjtrans                        |      347                     347     30.8s
    LinearAlgebra/givens                          |     1847                    1847      5.5s
    LinearAlgebra/blas                            |     1629                    1629   1m07.2s
    LinearAlgebra/ldlt                            |        8                       8      1.0s
    LinearAlgebra/factorization                   |       80            16        96      4.5s
    ambiguous                                     |      104             2       106      7.6s
    LinearAlgebra/diagonal                        |     2877                    2877   5m48.1s
    compiler/effects                              |       35                      35      0.7s
    compiler/validation                           |       28                      28      0.4s
    LinearAlgebra/structuredbroadcast             |      670                     670     59.1s
    compiler/inference                            |     1200             2      1202     16.0s
    compiler/irpasses                             |      139             4       143      4.4s
    compiler/ssair                                |       69                      69      5.7s
    compiler/contextual                           |       12                      12      2.9s
    compiler/inline                               |      226             1       227      5.9s
    compiler/AbstractInterpreter                  |       12                      12      8.0s
    compiler/codegen                              |      173                     173     17.6s
    compiler/EscapeAnalysis/interprocedural       |       32             4        36      8.9s
    compiler/EscapeAnalysis/local                 |      347            21       368     15.5s
    strings/search                                |      876                     876      8.0s
    strings/basic                                 |    87693                   87693     13.5s
    strings/io                                    |    12764                   12764      4.1s
    strings/types                                 |  2302691                 2302691      3.8s
    unicode/utf8                                  |       19                      19      0.1s
    strings/util                                  |     1147                    1147     13.8s
    worlds                                        |       88                      88      2.5s
    LinearAlgebra/triangular                      |    37908                   37908  10m58.9s
    keywordargs                                   |      151                     151      1.9s
    atomics                                       |     3448                    3448     19.0s
    subtype                                       |   337681            19    337700     16.4s
    LinearAlgebra/symmetric                       |     2847                    2847   5m19.7s
    triplequote                                   |       29                      29      0.0s
    char                                          |     1639                    1639      3.4s
    intrinsics                                    |      309                     309      3.1s
    hashing                                       |    12519                   12519     20.5s
    iobuffer                                      |      209                     209      1.7s
    staged                                        |       65                      65      3.4s
    dict                                          |   144426                  144426     29.9s
    numbers                                       |  1584712             1   1584713   1m23.5s
    core                                          |  8445940             3   8445943   1m34.4s
    tuple                                         |      666                     666     10.3s
    offsetarray                                   |      502             3       505     47.6s
    reduce                                        |     8591                    8591     27.4s
    intfuncs                                      |   227881                  227881     10.1s
    simdloop                                      |      240                     240      2.3s
    vecelement                                    |      678                     678      7.8s
    rational                                      |    98695             2     98697     33.2s
    subarray                                      |   318323                  318323   3m30.6s
    copy                                          |      544                     544      3.4s
    reducedim                                     |     1225             6      1231   1m30.1s
    fastmath                                      |      946                     946      6.8s
    functional                                    |       98                      98      7.2s
    arrayops                                      |     2089             6      2095   2m18.4s
    operators                                     |    13052                   13052     14.4s
    math                                          |  1910225                 1910225     41.9s
    path                                          |     1051            12      1063      1.3s
    ordering                                      |       37                      37      3.5s
    parse                                         |    16098                   16098      5.4s
    abstractarray                                 |    55298         24795     80093   2m23.4s
    gmp                                           |     2444                    2444     15.3s
    iterators                                     |    86614                   86614   1m56.5s
    spawn                                         |      236             4       240     30.0s
    backtrace                                     |       39             1        40      4.8s
    exceptions                                    |       70                      70      1.6s
    file                                          |      767                     767     12.8s
    bitarray                                      |   914220                  914220   3m40.3s
    version                                       |     2453                    2453      1.1s
    ccall                                         |     5395                    5395   2m50.7s
    namedtuple                                    |      216                     216      3.2s
    mpfr                                          |     1137             1      1138     20.0s
    complex                                       |     8480             2      8482     12.8s
    floatapprox                                   |       49                      49      0.8s
    reflection                                    |      427                     427      5.6s
    regex                                         |      142                     142      3.6s
    sorting                                       |    24209             9     24218   2m52.9s
    float16                                       |   762093                  762093      7.5s
    sysinfo                                       |        4                       4      0.2s
    env                                           |      177                     177      0.8s
    LinearAlgebra/addmul                          |     5832                    5832   9m19.5s
    rounding                                      |   150016                  150016      6.1s
    combinatorics                                 |      170                     170      8.9s
    mod2pi                                        |       80                      80      0.6s
    euler                                         |       12                      12      1.5s
    client                                        |        5                       5      2.3s
    errorshow                                     |      246                     246      7.4s
    show                                          |   128892             8    128900     37.1s
    goto                                          |       19                      19      0.1s
    broadcast                                     |      525                     525   1m35.7s
    llvmcall2                                     |       20                      20      0.1s
    llvmcall                                      |       19                      19      0.5s
    some                                          |       72                      72      1.4s
    ryu                                           |    31215                   31215      2.0s
    meta                                          |       69                      69      0.9s
    stacktraces                                   |       48                      48      1.9s
    read                                          |     3810                    3810   2m09.8s
    docs                                          |      239                     239      4.9s
    sets                                          |     3643             1      3644     34.7s
    enums                                         |      100                     100      3.9s
    binaryplatforms                               |      341                     341      8.0s
    atexit                                        |       40                      40      8.3s
    interpreter                                   |        3                       3      1.9s
    int                                           |   736188                  736188      9.3s
    ranges                                        | 12110619        327682  12438301   1m04.5s
    bitset                                        |      195                     195      3.2s
    checked                                       |     1239                    1239     10.1s
    error                                         |       33                      33      1.5s
    boundscheck                                   |                             None      9.0s
    osutils                                       |       57                      57      0.1s
    cartesian                                     |      349             3       352      9.7s
    iostream                                      |       50                      50      1.9s
    secretbuffer                                  |       30                      30      1.8s
    specificity                                   |      175                     175      0.2s
    misc                                          |  1282200                 1282200     50.3s
    loading                                       |   151329                  151329   5m15.7s
    corelogging                                   |      235                     235      4.4s
    channels                                      |      256                     256     28.2s
    reinterpretarray                              |      421                     421     22.8s
    smallarrayshrink                              |       36                      36      0.6s
    syntax                                        |     1659             1      1660     12.5s
    opaque_closure                                |       66             1        67      0.5s
    filesystem                                    |        6                       6      0.3s
    SparseArrays/ambiguous                        |        1                       1      5.7s
    download                                      |                             None      6.1s
    asyncmap                                      |      307                     307     12.7s
    missing                                       |      574             1       575     20.5s
    SparseArrays/sparsematrix_ops                 |      415                     415     52.3s
    floatfuncs                                    |      232                     232   2m27.2s
    SparseArrays/linalg                           |     1814                    1814   1m42.3s
    SparseArrays/issues                           |      326                     326   1m24.4s
    SparseArrays/linalg_solvers                   |      364                     364     28.0s
    SparseArrays/cholmod                          |      611                     611     33.9s
    cmdlineargs                                   |      274             5       279   3m57.5s
    SparseArrays/spqr                             |       91                      91      7.6s
    SparseArrays/higherorderfns                   |     7145             1      7146   3m03.2s
    Dates/accessors                               |  7723858                 7723858      7.0s
    Dates/query                                   |     1004                    1004      1.3s
    Dates/adjusters                               |     3149                    3149      7.6s
    SparseArrays/umfpack                          |      288                     288   1m11.4s
    Dates/periods                                 |      953                     953     22.1s
    LibGit2/libgit2                               |      595                     595     33.5s
    Dates/types                                   |      232                     232      1.8s
    Dates/rounding                                |      315                     315      2.9s
    Dates/ranges                                  |   350639                  350639     20.9s
    Dates/conversions                             |      160                     160      1.2s
    ArgTools                                      |      180                     180      6.8s
    Dates/arithmetic                              |      385                     385     10.2s
    Base64                                        |     2031                    2031      2.8s
    CompilerSupportLibraries_jll                  |        4                       4      0.0s
    CRC32c                                        |      664                     664      0.8s
    Dates/io                                      |      332                     332     15.2s
    DelimitedFiles                                |       89                      89      6.0s
    Future                                        |                             None      0.0s
    GMP_jll                                       |        1                       1      0.0s
    Artifacts                                     |     1452                    1452     16.6s
    LLVMLibUnwind_jll                             |                             None      0.0s
    LazyArtifacts                                 |        4                       4      5.6s
    LibCURL                                       |        6                       6      2.7s
    LibCURL_jll                                   |        1                       1      0.0s
    LibGit2_jll                                   |        2                       2      0.1s
    LibSSH2_jll                                   |                             None      0.0s
    LibUV_jll                                     |        1                       1      0.1s
    LibUnwind_jll                                 |                             None      0.0s
    Libdl                                         |      130             1       131      0.8s
    Logging                                       |       40                      40      1.3s
    MPFR_jll                                      |        1                       1      0.1s
    Markdown                                      |      257                     257      5.1s
    MbedTLS_jll                                   |        1                       1      0.1s
    SparseArrays/sparsematrix_constructors_indexing |     1830                    1830   4m03.8s
    MozillaCACerts_jll                            |        1                       1      0.0s
    NetworkOptions                                |     3518                    3518      1.5s
    OpenBLAS_jll                                  |        1                       1      0.0s
    OpenLibm_jll                                  |        1                       1      0.1s
    PCRE2_jll                                     |        2                       2      0.1s
    InteractiveUtils                              |      301             1       302     23.3s
    Printf                                        |     1017                    1017     15.1s
    Mmap                                          |      138                     138     27.0s
    Profile                                       |      109                     109     30.8s
    REPL                                          |     1545             3      1548     28.7s
    Serialization                                 |      129             1       130      7.6s
    Downloads                                     |      232     4               236   1m41.7s
    Random                                        |   204839                  204839   1m00.3s
    SuiteSparse                                   |                             None      0.1s
    SuiteSparse_jll                               |        1                       1      0.1s
    SparseArrays/sparsevector                     |    10365             4     10369   3m55.5s
    SHA                                           |      107                     107     58.6s
    TOML                                          |      415             8       423     12.2s
    UUIDs                                         |     1029                    1029      0.3s
    FileWatching                                  |      590                     590   2m00.8s
    Zlib_jll                                      |        1                       1      0.1s
    dSFMT_jll                                     |        1                       1      0.1s
    libLLVM_jll                                   |        1                       1      0.0s
    libblastrampoline_jll                         |        1                       1      0.0s
    nghttp2_jll                                   |        1                       1      0.1s
    p7zip_jll                                     |        1                       1      0.0s
    Unicode                                       |      795                     795      5.2s
    Tar                                           |     1675            11      1686     31.6s
    Test                                          |      457            18       475     44.8s
    Sockets                                       |      170             1       171   1m25.6s
    Statistics                                    |      810                     810   1m11.8s
    precompile                                    |      155                     155     36.0s
    SharedArrays                                  |      114                     114     25.8s
    threads                                       |       45             3        48   2m40.5s
    Distributed                                   |       15                      15   4m02.6s
    stress                                        |                             None      0.0s
    FAILURE

The global RNG seed was 0x50899771fb1b987f4e0bc680062ccf9b.

Error in testset Downloads:
Test Failed at V:\julia\julia-mingw64\usr\share\julia\stdlib\v1.9\Downloads\test\runtests.jl:328
  Expression: startswith(err.message, "Could not resolve host")
   Evaluated: startswith("schannel: failed to receive handshake, SSL/TLS connection failed", "Could not resolve host")
Error in testset Downloads:
Test Failed at V:\julia\julia-mingw64\usr\share\julia\stdlib\v1.9\Downloads\test\runtests.jl:329
  Expression: err.response.proto === nothing
   Evaluated: "https" === nothing
Error in testset Downloads:
Test Failed at V:\julia\julia-mingw64\usr\share\julia\stdlib\v1.9\Downloads\test\runtests.jl:334
  Expression: startswith(err.message, "Could not resolve host")
   Evaluated: startswith("schannel: failed to receive handshake, SSL/TLS connection failed", "Could not resolve host")
Error in testset Downloads:
Test Failed at V:\julia\julia-mingw64\usr\share\julia\stdlib\v1.9\Downloads\test\runtests.jl:335
  Expression: err.response.proto === nothing
   Evaluated: "https" === nothing
ERROR: LoadError: Test run finished with errors
in expression starting at V:\julia\test\runtests.jl:93
make[1]: *** [/v/julia/test/Makefile:25: default] Error 1
make[1]: Leaving directory '/v/julia/julia-mingw64/test'
make: *** [/v/julia/Makefile:554：test] Error 2
make: Leaving directory “/v/julia/julia-mingw64”
```
</details>

<details>
<summary>mingw32 test log</summary>


### build
```
Sysimage built. Summary:
Base ────────  44.956533 seconds 51.2369%
Stdlibs ─────  42.784159 seconds 48.7611%
Total ───────  87.742447 seconds
make[1]: Leaving directory '/v/julia/julia-mingw32'
make[1]: Entering directory '/v/julia/julia-mingw32'
    JULIA julia-mingw32/usr/lib/julia/sys-o.a
Generating REPL precompile statements... 40/40
Executing precompile statements... 2021/2055
Precompilation complete. Summary:
Generation ── 440.473837 seconds 63.686%
Execution ─── 251.159706 seconds 36.314%
Total ─────── 691.633543 seconds
Outputting sysimage file...
Output ────── 156.656760 seconds
```

### test

version
```
julia> versioninfo()
Julia Version 1.9.0-DEV.1040
Commit c7ff32668c* (2022-07-28 07:53 UTC)
Platform Info:
  OS: Windows (i686-w64-mingw32)
  CPU: 6 × Intel(R) Core(TM) i5-9400F CPU @ 2.90GHz
  WORD_SIZE: 32
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.5 (ORCJIT, skylake)
  Threads: 1 on 6 virtual cores
```

- Downloads: Fail x1
```
Test Summary:                                     |     Pass  Error  Broken     Total      Time
  Overall                                         | 40435126      1  352668  40787795  70m14.0s
    LinearAlgebra/schur                           |      496                      496   1m05.1s
    LinearAlgebra/eigen                           |      512                      512   1m20.3s
    LinearAlgebra/qr                              |     4705                     4705   3m00.4s
    LinearAlgebra/bunchkaufman                    |     5688                     5688     42.6s
    LinearAlgebra/lapack                          |      802                      802     44.4s
    LinearAlgebra/svd                             |      566                      566   1m17.9s
    LinearAlgebra/special                         |     2942                     2942   4m47.9s
    LinearAlgebra/tridiag                         |     1541                     1541   1m10.3s
    LinearAlgebra/dense                           |     8475                     8475   6m31.8s
    LinearAlgebra/cholesky                        |     2509                     2509   2m17.9s
    LinearAlgebra/matmul                          |     1486                     1486   7m51.5s
    LinearAlgebra/bidiag                          |     4736                     4736   4m17.3s
    LinearAlgebra/lu                              |     1368                     1368   2m13.9s
    LinearAlgebra/generic                         |      630                      630     58.6s
    LinearAlgebra/lq                              |     2938                     2938     57.5s
    LinearAlgebra/uniformscaling                  |      446                      446   1m23.7s
    LinearAlgebra/hessenberg                      |      631                      631   1m28.6s
    LinearAlgebra/adjtrans                        |      347                      347     35.6s
    LinearAlgebra/pinv                            |      500                      500     18.5s
    LinearAlgebra/blas                            |     1629                     1629   1m05.7s
    LinearAlgebra/givens                          |     1847                     1847     16.4s
    LinearAlgebra/ldlt                            |        8                        8      1.1s
    LinearAlgebra/factorization                   |       80             16        96      4.5s
    ambiguous                                     |      104              2       106      8.9s
    compiler/inference                            |     1200              2      1202     23.5s
    compiler/effects                              |       35                       35      0.9s
    compiler/validation                           |       28                       28      0.4s
    LinearAlgebra/diagonal                        |     2877                     2877   6m48.1s
    compiler/ssair                                |       69                       69      6.8s
    compiler/irpasses                             |      139              4       143      5.2s
    compiler/inline                               |      226              1       227      7.2s
    LinearAlgebra/structuredbroadcast             |      670                      670   1m13.5s
    compiler/contextual                           |       12                       12      4.7s
    compiler/codegen                              |      173                      173     20.7s
    compiler/AbstractInterpreter                  |       12                       12      8.9s
    compiler/EscapeAnalysis/local                 |      347             21       368     16.2s
    compiler/EscapeAnalysis/interprocedural       |       32              4        36     11.2s
    strings/search                                |      876                      876      9.0s
    strings/basic                                 |    87693                    87693     16.0s
    strings/io                                    |    12764                    12764      4.6s
    strings/util                                  |     1147                     1147     16.1s
    unicode/utf8                                  |       19                       19      0.2s
    strings/types                                 |  2302691                  2302691      6.8s
    worlds                                        |       88                       88      3.6s
    LinearAlgebra/symmetric                       |     2847                     2847   5m25.0s
    keywordargs                                   |      151                      151      3.0s
    atomics                                       |     3448                     3448     51.8s
    subtype                                       |   337681             19    337700     15.1s
    char                                          |     1639                     1639      4.2s
    triplequote                                   |       29                       29      0.6s
    intrinsics                                    |      309                      309      5.5s
    core                                          |  8445939              3   8445942   1m56.6s
    LinearAlgebra/triangular                      |    37908                    37908  14m35.1s
    dict                                          |   144426                   144426     37.1s
    iobuffer                                      |      209                      209      2.4s
    staged                                        |       65                       65     10.6s
    hashing                                       |    12519                    12519     21.9s
    numbers                                       |  1584721              1   1584722   2m05.7s
    tuple                                         |      666                      666     16.7s
    reduce                                        |     8591                     8591     46.8s
    offsetarray                                   |      502              3       505   1m07.9s
    subarray                                      |   318323                   318323   4m35.8s
    simdloop                                      |      240                      240      3.2s
    vecelement                                    |      678                      678      7.7s
    rational                                      |    98695              2     98697     39.0s
    reducedim                                     |     1225              6      1231   2m15.0s
    copy                                          |      544                      544      4.9s
    arrayops                                      |     2089              6      2095   2m53.7s
    fastmath                                      |      946                      946      6.8s
    functional                                    |       98                       98     10.5s
    math                                          |  1909879                  1909879     44.4s
    operators                                     |    13052                    13052     14.0s
    ordering                                      |       37                       37      3.7s
    path                                          |     1051             12      1063      1.2s
    ccall                                         |     5390                     5390   2m38.3s
    parse                                         |    16098                    16098      7.2s
    iterators                                     |    86614                    86614   4m45.8s
    gmp                                           |     2444                     2444     10.4s
    LinearAlgebra/addmul                          |     5562                     5562  12m05.8s
    spawn                                         |      236              4       240     38.0s
    backtrace                                     |       39              1        40      8.5s
    exceptions                                    |       70                       70      8.4s
    abstractarray                                 |    55542          24795     80337   8m22.2s
    file                                          |      767                      767     22.0s
    version                                       |     2453                     2453      1.4s
    namedtuple                                    |      216                      216      6.6s
    mpfr                                          |     1137              1      1138     23.5s
    broadcast                                     |      525                      525   1m35.6s
    sorting                                       |    24193              9     24202   3m26.2s
    loading                                       |   154923                   154923   5m00.1s
    floatapprox                                   |       49                       49      2.3s
    regex                                         |      142                      142      3.3s
    reflection                                    |      427                      427     10.5s
    complex                                       |     8480              2      8482     12.6s
    sysinfo                                       |        4                        4      0.1s
    env                                           |      178                      178      0.7s
    float16                                       |   762093                   762093      8.4s
    combinatorics                                 |      172                      172      9.0s
    rounding                                      |   150016                   150016      7.6s
    mod2pi                                        |       80                       80      0.6s
    euler                                         |       12                       12      2.2s
    client                                        |        5                        5      2.7s
    errorshow                                     |      246                      246     19.9s
    read                                          |     3810                     3810   3m14.9s
    goto                                          |       19                       19      0.1s
    llvmcall                                      |       19                       19      1.0s
    show                                          |   128892              8    128900     39.7s
    llvmcall2                                     |       20                       20      0.3s
    some                                          |       72                       72      1.6s
    ryu                                           |    31215                    31215      1.9s
    stacktraces                                   |       48                       48      2.4s
    meta                                          |       69                       69      2.6s
    docs                                          |      239                      239      7.5s
    binaryplatforms                               |      341                      341      9.0s
    sets                                          |     3643              1      3644     36.9s
    enums                                         |      100                      100      5.1s
    ranges                                        | 12110694         327682  12438376   1m15.2s
    intfuncs                                      |   227811                   227811  12m05.4s
    interpreter                                   |        3                        3      2.5s
    atexit                                        |       40                       40     12.7s
    bitset                                        |      195                      195      3.8s
    checked                                       |     1239                     1239     12.5s
    misc                                          |  1282197                  1282197     52.9s
    error                                         |       33                       33      4.1s
    boundscheck                                   |                              None     20.5s
    osutils                                       |       57                       57      0.2s
    cartesian                                     |      349              3       352     13.0s
    iostream                                      |       50                       50      1.6s
    int                                           |   736188                   736188     48.2s
    specificity                                   |      175                      175      1.0s
    secretbuffer                                  |       30                       30      1.9s
    syntax                                        |     1659              1      1660     16.2s
    channels                                      |      256                      256     30.8s
    reinterpretarray                              |      421                      421     22.7s
    corelogging                                   |      235                      235      7.7s
    smallarrayshrink                              |       36                       36      0.5s
    opaque_closure                                |       66              1        67      1.3s
    filesystem                                    |        6                        6      0.6s
    download                                      |                              None      6.4s
    SparseArrays/ambiguous                        |        1                        1      7.1s
    missing                                       |      574              1       575     30.1s
    asyncmap                                      |      307                      307     27.2s
    SparseArrays/sparsematrix_ops                 |      415                      415     58.5s
    floatfuncs                                    |      232                      232   3m41.0s
    SparseArrays/linalg                           |     1814                     1814   1m45.6s
    cmdlineargs                                   |      274              5       279   4m32.3s
    SparseArrays/higherorderfns                   |     7145              1      7146   3m27.1s
    SparseArrays/linalg_solvers                   |      364                      364     37.6s
    SparseArrays/issues                           |      326                      326   1m49.2s
    SparseArrays/cholmod                          |      607                      607     44.3s
    SparseArrays/spqr                             |       91                       91     14.5s
    SparseArrays/umfpack                          |      200                      200   1m03.1s
    Dates/accessors                               |  7723858                  7723858      8.4s
    SparseArrays/sparsematrix_constructors_indexing |     1830                     1830   4m23.5s
    Dates/query                                   |     1004                     1004      1.2s
    Dates/adjusters                               |     3149                     3149      6.8s
    Dates/rounding                                |      315                      315      4.4s
    Dates/types                                   |      232                      232      2.8s
    LibGit2/libgit2                               |      595                      595     33.4s
    Dates/periods                                 |      953                      953     27.9s
    Dates/conversions                             |      160                      160      1.8s
    Dates/ranges                                  |   350639                   350639     29.9s
    Dates/io                                      |      332                      332     20.2s
    Base64                                        |     2031                     2031      3.8s
    CRC32c                                        |      664                      664      0.7s
    CompilerSupportLibraries_jll                  |        4                        4      0.0s
    Dates/arithmetic                              |      385                      385     13.0s
    DelimitedFiles                                |       89                       89      9.6s
    Artifacts                                     |     1452                     1452     18.5s
    Future                                        |                              None      0.0s
    GMP_jll                                       |        1                        1      0.0s
    ArgTools                                      |      180                      180     46.9s
    LLVMLibUnwind_jll                             |                              None      0.0s
    LazyArtifacts                                 |        4                        4      7.6s
    InteractiveUtils                              |      301              1       302     36.5s
    LibCURL_jll                                   |        1                        1      0.0s
    LibGit2_jll                                   |        2                        2      0.1s
    LibSSH2_jll                                   |                              None      0.0s
    LibUV_jll                                     |        1                        1      0.0s
    LibUnwind_jll                                 |                              None      0.0s
    Libdl                                         |      119              1       120      1.0s
    LibCURL                                       |        6                        6      2.5s
    MPFR_jll                                      |        1                        1      0.1s
    Logging                                       |       40                       40      1.5s
    MbedTLS_jll                                   |        1                        1      0.0s
    Markdown                                      |      257                      257      8.8s
    MozillaCACerts_jll                            |        1                        1      0.0s
    NetworkOptions                                |     3518                     3518      1.5s
    OpenBLAS_jll                                  |        1                        1      0.0s
    OpenLibm_jll                                  |        1                        1      0.1s
    Downloads                                     |               1                 1   1m01.1s
    PCRE2_jll                                     |        2                        2      0.3s
    Printf                                        |     1017                     1017     16.0s
    Mmap                                          |      138                      138     26.4s
    SparseArrays/sparsevector                     |    10365              4     10369   3m50.7s
    REPL                                          |     1545              3      1548     39.9s
    Serialization                                 |      129              1       130      7.4s
    FileWatching                                  |      590                      590   2m02.7s
    Random                                        |   204833                   204833   1m10.4s
    SuiteSparse                                   |                              None      0.1s
    SuiteSparse_jll                               |        1                        1      0.1s
    TOML                                          |      415              8       423     20.5s
    Sockets                                       |      170              1       171   1m28.1s
    Statistics                                    |      810                      810   1m28.9s
    UUIDs                                         |     1029                     1029      0.6s
    Unicode                                       |      795                      795      6.1s
    Zlib_jll                                      |        1                        1      0.1s
    dSFMT_jll                                     |        1                        1      0.0s
    libLLVM_jll                                   |        1                        1      0.0s
    libblastrampoline_jll                         |        1                        1      0.0s
    nghttp2_jll                                   |        1                        1      0.1s
    p7zip_jll                                     |        1                        1      0.0s
    SHA                                           |      107                      107   2m14.2s
    Test                                          |      457             18       475   1m01.6s
    Tar                                           |     1675             11      1686   2m13.4s
    bitarray                                      |   913196                   913196  23m17.4s
    Profile                                       |      109                      109  34m35.5s
    precompile                                    |      155                      155     48.6s
    SharedArrays                                  |      114                      114     45.3s
    threads                                       |       45              3        48   5m15.9s
    Distributed                                   |       15                       15   6m48.2s
    stress                                        |                              None      0.0s
    FAILURE

The global RNG seed was 0x3af2fbe3ce42df5abab7ba751263a17d.

Error in testset Downloads:
Error During Test at none:1
  Got exception outside of a @test
  ProcessExitedException(4)
  Stacktrace:
    [1] try_yieldto(undo::typeof(Base.ensure_rescheduled))
      @ Base .\task.jl:888
    [2] wait()
      @ Base .\task.jl:952
    [3] wait(c::Base.GenericCondition{ReentrantLock})
      @ Base .\condition.jl:124
    [4] take_buffered(c::Channel{Any})
      @ Base .\channels.jl:416
    [5] take!(c::Channel{Any})
      @ Base .\channels.jl:410
    [6] take!(::Distributed.RemoteValue)
      @ Distributed V:\julia\julia-mingw32\usr\share\julia\stdlib\v1.9\Distributed\src\remotecall.jl:726
    [7] remotecall_fetch(::Function, ::Distributed.Worker, ::String, ::Vararg{String}; kwargs::Base.Pairs{Symbol, UInt128, Tuple{Symbol}, NamedTuple{(:seed,), Tuple{UInt128}}})
      @ Distributed V:\julia\julia-mingw32\usr\share\julia\stdlib\v1.9\Distributed\src\remotecall.jl:461
    [8] remotecall_fetch(::Function, ::Int32, ::String, ::Vararg{String}; kwargs::Base.Pairs{Symbol, UInt128, Tuple{Symbol}, NamedTuple{(:seed,), Tuple{UInt128}}})
      @ Distributed V:\julia\julia-mingw32\usr\share\julia\stdlib\v1.9\Distributed\src\remotecall.jl:492
    [9] macro expansion
      @ V:\julia\test\runtests.jl:260 [inlined]
   [10] (::var"#45#57"{Vector{Task}, var"#print_testworker_errored#53"{ReentrantLock, Int32, Int32}, var"#print_testworker_stats#51"{ReentrantLock, Int32, Int32, Int32, Int32, Int32, Int32}, Vector{Any}, Dict{String, DateTime}})()
      @ Main .\task.jl:501
ERROR: LoadError: Test run finished with errors
in expression starting at V:\julia\test\runtests.jl:93
make[1]: *** [/v/julia/test/Makefile:25: default] Error 1
make[1]: Leaving directory '/v/julia/julia-mingw32/test'
make: *** [/v/julia/Makefile:554：test] Error 2
make: Leaving directory “/v/julia/julia-mingw32”
```
</details>

----

Next step todo:
- [x] make a Dockerfile
