### PR TITLE
Add tests for hvncat to avoid issues with non-numeric types

### DIFF
--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1545,8 +1545,12 @@ using Base: typed_hvncat
     @test [[1 2; 3 4] [5; 6]; [7 8] 9;;;] == [1 2 5; 3 4 6; 7 8 9;;;]
 
     #45461, #46133 - ensure non-numeric types do not error
+    [1;;; 2;;; nothing;;; 4]
     [1 2;;; nothing 4]
+    [[1 2];;; nothing 4]
+    ["A";;"B";;"C";;"D"]
     ["A";"B";;"C";"D"]
+    [["A";"B"];;"C";"D"]
 end
 
 @testset "keepat!" begin

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1543,6 +1543,10 @@ using Base: typed_hvncat
     @test_throws ArgumentError [[1 ;;; 1]; 2 ;;; 3 ; [3 ;;; 4]]
 
     @test [[1 2; 3 4] [5; 6]; [7 8] 9;;;] == [1 2 5; 3 4 6; 7 8 9;;;]
+
+    #45461, #46133 - ensure non-numeric types do not error
+    [1 2;;; nothing 4]
+    ["A";"B";;"C";"D"]
 end
 
 @testset "keepat!" begin

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1545,12 +1545,12 @@ using Base: typed_hvncat
     @test [[1 2; 3 4] [5; 6]; [7 8] 9;;;] == [1 2 5; 3 4 6; 7 8 9;;;]
 
     #45461, #46133 - ensure non-numeric types do not error
-    [1;;; 2;;; nothing;;; 4]
-    [1 2;;; nothing 4]
-    [[1 2];;; nothing 4]
-    ["A";;"B";;"C";;"D"]
-    ["A";"B";;"C";"D"]
-    [["A";"B"];;"C";"D"]
+    @test [1;;; 2;;; nothing;;; 4] == reshape([1; 2; nothing; 4], (1, 1, 4))
+    @test [1 2;;; nothing 4] == reshape([1; nothing; 2; 4], (1, 2, 2))
+    @test [[1 2];;; nothing 4] == reshape([1; nothing; 2; 4], (1, 2, 2))
+    @test ["A";;"B";;"C";;"D"] == ["A" "B" "C" "D"]
+    @test ["A";"B";;"C";"D"] == ["A" "C"; "B" "D"]
+    @test [["A";"B"];;"C";"D"] == ["A" "C"; "B" "D"]
 end
 
 @testset "keepat!" begin

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1546,8 +1546,8 @@ using Base: typed_hvncat
 
     #45461, #46133 - ensure non-numeric types do not error
     @test [1;;; 2;;; nothing;;; 4] == reshape([1; 2; nothing; 4], (1, 1, 4))
-    @test [1 2;;; nothing 4] == reshape([1; nothing; 2; 4], (1, 2, 2))
-    @test [[1 2];;; nothing 4] == reshape([1; nothing; 2; 4], (1, 2, 2))
+    @test [1 2;;; nothing 4] == reshape([1; 2; nothing; 4], (1, 2, 2))
+    @test [[1 2];;; nothing 4] == reshape([1; 2; nothing; 4], (1, 2, 2))
     @test ["A";;"B";;"C";;"D"] == ["A" "B" "C" "D"]
     @test ["A";"B";;"C";"D"] == ["A" "C"; "B" "D"]
     @test [["A";"B"];;"C";"D"] == ["A" "C"; "B" "D"]


### PR DESCRIPTION
The fixes for #45461 and #46133 are already integrated in 1.8 and slated for 1.7 backport. This PR adds test coverage that would have caught those errors.