### PR TITLE
Speed up `searchsortedfirst`.

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -172,18 +172,20 @@ partialsort(v::AbstractVector, k::Union{Integer,OrdinalRange}; kws...) =
 # index of the first value of vector a that is greater than or equal to x;
 # returns lastindex(v)+1 if x is greater than all values in v.
 function searchsortedfirst(v::AbstractVector, x, lo::T, hi::T, o::Ordering)::keytype(v) where T<:Integer
-    u = T(1)
-    lo = lo - u
-    hi = hi + u
-    @inbounds while lo < hi - u
-        m = midpoint(lo, hi)
+    hi = hi + T(1)
+	len = hi - lo
+    @inbounds while len != 0
+		half_len = len >> 1
+        m = lo + half_len
         if lt(o, v[m], x)
-            lo = m
+            lo = m + 1
+			len -= half_len + 1
         else
             hi = m
+			len = half_len
         end
     end
-    return hi
+    return lo
 end
 
 # index of the last value of vector a that is less than or equal to x;

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -173,16 +173,16 @@ partialsort(v::AbstractVector, k::Union{Integer,OrdinalRange}; kws...) =
 # returns lastindex(v)+1 if x is greater than all values in v.
 function searchsortedfirst(v::AbstractVector, x, lo::T, hi::T, o::Ordering)::keytype(v) where T<:Integer
     hi = hi + T(1)
-	len = hi - lo
+    len = hi - lo
     @inbounds while len != 0
-		half_len = len >>> 0x01
+        half_len = len >>> 0x01
         m = lo + half_len
         if lt(o, v[m], x)
             lo = m + 1
-			len -= half_len + 1
+            len -= half_len + 1
         else
             hi = m
-			len = half_len
+            len = half_len
         end
     end
     return lo

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -174,8 +174,8 @@ partialsort(v::AbstractVector, k::Union{Integer,OrdinalRange}; kws...) =
 function searchsortedfirst(v::AbstractVector, x, lo::T, hi::T, o::Ordering)::keytype(v) where T<:Integer
     hi = hi + T(1)
 	len = hi - lo
-    @inbounds while len != 0
-		half_len = len >> 1
+    @inbounds while !(len == 0)
+		half_len = len >>> 1
         m = lo + half_len
         if lt(o, v[m], x)
             lo = m + 1

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -14,7 +14,7 @@ using .Base: copymutable, LinearIndices, length, (:), iterate, OneTo,
     min, max, reinterpret, signed, unsigned, Signed, Unsigned, typemin, xor, Type, BitSigned, Val,
     midpoint, @boundscheck, checkbounds
 
-using .Base: >>>, !==
+using .Base: >>>, !==, !=
 
 import .Base:
     sort,
@@ -174,7 +174,7 @@ partialsort(v::AbstractVector, k::Union{Integer,OrdinalRange}; kws...) =
 function searchsortedfirst(v::AbstractVector, x, lo::T, hi::T, o::Ordering)::keytype(v) where T<:Integer
     hi = hi + T(1)
 	len = hi - lo
-    @inbounds while !(len == 0)
+    @inbounds while len != 0
 		half_len = len >>> 1
         m = lo + half_len
         if lt(o, v[m], x)

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -175,7 +175,7 @@ function searchsortedfirst(v::AbstractVector, x, lo::T, hi::T, o::Ordering)::key
     hi = hi + T(1)
 	len = hi - lo
     @inbounds while len != 0
-		half_len = len >>> 1
+		half_len = len >>> 0x01
         m = lo + half_len
         if lt(o, v[m], x)
             lo = m + 1


### PR DESCRIPTION
This implementation:
- replaces midpoint computation with binary shift (division by 2)
- starts with a slightly narrower range `[lo, hi + 1]` instead of `[lo-1, hi+1]`
- narrows the range slightly faster by bumping `lo` to `m+1` instead of `m`
Overall this results in faster performance according to 
```julia
using Base.Order
using Base.Sort

function mysearchsortedfirst(v::AbstractVector, x, lo::T, hi::T, o::Ordering)::keytype(v) where T<:Integer
    hi = hi + T(1)
	len = hi - lo
    @inbounds while len != 0
		half_len = len >> 1
        m = lo + half_len
        if lt(o, v[m], x)
            lo = m + 1
			len -= half_len + 1
        else
            hi = m
			len = half_len
        end
    end
    return lo
end

xs = sort(randn(10000))
x = rand(xs)

using BenchmarkTools

@benchmark searchsortedfirst(xs, x, firstindex(xs), lastindex(xs), Forward)
```
BenchmarkTools.Trial: 10000 samples with 916 evaluations.
 Range (min … max):  118.512 ns …  2.973 μs  ┊ GC (min … max): 0.00% … 93.91%
 Time  (median):     121.469 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   125.719 ns ± 58.368 ns  ┊ GC (mean ± σ):  1.07% ±  2.26%

  ▄▇█▇▇▆▅▅▄▄▃▃▃▃▂▂▂▂▂▁▁                                        ▂
  ██████████████████████▇████▇▇▆█▇▇▇▇▇▇▇▆▇▆▆▆▇▅▆▇▅▅▅▆▅▅▅▅▆▅▅▅▅ █
  119 ns        Histogram: log(frequency) by time       162 ns <

 Memory estimate: 32 bytes, allocs estimate: 2.
```julia
@benchmark mysearchsortedfirst(xs, x, firstindex(xs), lastindex(xs), Forward)
```
BenchmarkTools.Trial: 10000 samples with 923 evaluations.
 Range (min … max):  113.570 ns …  2.627 μs  ┊ GC (min … max): 0.00% … 93.76%
 Time  (median):     116.356 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   120.122 ns ± 43.933 ns  ┊ GC (mean ± σ):  0.75% ±  2.04%

  ▁▆█▇▆▆▅▅▄▄▃▃▃▂▃▂▂▂▂▁▁▁                                       ▂
  ████████████████████████▇▇▇▇▆▇▇▇▇▆▅▇▆▇▇▆▆▆▆▆▆▆▇▄▆▅▅▅▅▅▅▄▄▃▅▄ █
  114 ns        Histogram: log(frequency) by time       154 ns <

I also ran some tests
```julia
using Test

for t in xs
	@test mysearchsortedfirst(xs, x, firstindex(xs), lastindex(xs), Forward) == searchsortedfirst(xs, x, firstindex(xs), lastindex(xs), Forward)
end

@test mysearchsortedfirst(xs, xs[1] - 1, firstindex(xs), lastindex(xs), Forward) == 1
@test mysearchsortedfirst(xs, xs[lastindex(xs)] + 1, firstindex(xs), lastindex(xs), Forward) == lastindex(xs) + 1
```
and all of them passed.

Apologies for the poor formatting. I was doing these changes in my Pluto notebook and they looked much better there.