### PR TITLE
faster `isfinite`

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -494,7 +494,7 @@ See also: [`iszero`](@ref), [`isone`](@ref), [`isinf`](@ref), [`ismissing`](@ref
 isnan(x::AbstractFloat) = (x != x)::Bool
 isnan(x::Number) = false
 
-isfinite(x::AbstractFloat) = x - x == 0
+isfinite(x::AbstractFloat) = x - x === zero(x)
 isfinite(x::Real) = decompose(x)[3] != 0
 isfinite(x::Integer) = true
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -494,7 +494,8 @@ See also: [`iszero`](@ref), [`isone`](@ref), [`isinf`](@ref), [`ismissing`](@ref
 isnan(x::AbstractFloat) = (x != x)::Bool
 isnan(x::Number) = false
 
-isfinite(x::AbstractFloat) = x - x === zero(x)
+isfinite(x::IEEEFloat) = x - x === zero(x)
+isfinite(x::AbstractFloat) = x - x == 0
 isfinite(x::Real) = decompose(x)[3] != 0
 isfinite(x::Integer) = true
 


### PR DESCRIPTION
```
julia> function mytest!(f)
           s=0
           for x in typemin(UInt32):typemax(UInt32)
               s += f(reinterpret(Float32, x)) 
           end
           s
       end
mytest! (generic function with 1 method)

#old
julia> @btime mytest!(isfinite)
  1.971 s (0 allocations: 0 bytes)
4278190080

#new
julia> @btime mytest!(isfinite)
  1.770 s (0 allocations: 0 bytes)
4278190080
```
This has been tested exhaustively for `Float32` and `Float16`