### PR TITLE
define rank(::AbstractVector)

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -978,7 +978,7 @@ function rank(A::AbstractMatrix; atol::Real = 0.0, rtol::Real = (min(size(A)...)
     tol = max(atol, rtol*s[1])
     count(x -> x > tol, s)
 end
-rank(x::Number) = iszero(x) ? 0 : 1
+rank(x::Union{Number,AbstractVector}) = iszero(x) ? 0 : 1
 
 """
     tr(M)

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -235,6 +235,8 @@ end
     @test norm(NaN, 0) === NaN
 end
 
+@test rank(zeros(4)) == 0
+@test rank(1:10) == 1
 @test rank(fill(0, 0, 0)) == 0
 @test rank([1.0 0.0; 0.0 0.9],0.95) == 1
 @test rank([1.0 0.0; 0.0 0.9],rtol=0.95) == 1


### PR DESCRIPTION
Since we define `svd(::Vector)` and `qr(::Vector)`, in both cases punning on a vector as a 1-column matrix, it seems like we should define `rank` as well.

It seems like there is only one sensible way to define `LinearAlgebra.rank(::Vector)` if you are going to define it at all, so I don't see much risk here.

(Came across this omission today in code by @eewing1 and @baddoo.)