### PR TITLE
WIP/RFC: Ensure debug info refers to fully-qualified files and directories.

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -544,6 +544,18 @@ static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, jl_module_t *m
             name = scm_to_julia_(fl_ctx, car_(lst), mod);
             lst = cdr_(lst);
             file = scm_to_julia_(fl_ctx, car_(lst), mod);
+
+            if ((jl_sym_t*)file != jl_symbol("none") && (jl_sym_t*)file != jl_symbol("stdin")) {
+                char *path = realpath(jl_symbol_name((jl_sym_t*)file), NULL);
+                if (path) {
+                    file = jl_symbol(path);
+                    free(path);
+                } else {
+                    jl_printf(JL_STDERR, "WARNING: could not resolve path for %s\n", jl_symbol_name((jl_sym_t*)file));
+                }
+                // TODO: probably better change the parser to construct lineinfo nodes
+                //       with absolute paths in the first place?
+            }
             lst = cdr_(lst);
             linenum = scm_to_julia_(fl_ctx, car_(lst), mod);
             lst = cdr_(lst);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6892,7 +6892,8 @@ static jl_llvm_functions_t
         else {
             tableKind = DICompileUnit::DebugNameTableKind::None;
         }
-        topfile = dbuilder.createFile(ctx.file, ".");
+        SmallString<256> Path(ctx.file);
+        topfile = dbuilder.createFile(Path, sys::path::parent_path(Path));
         DICompileUnit *CU =
             dbuilder.createCompileUnit(llvm::dwarf::DW_LANG_Julia
                                        ,topfile      // File

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -1088,9 +1088,15 @@ static jl_value_t *jl_file_content_as_string(jl_value_t *filename)
 // statements into `module` after applying `mapexpr` to each one.
 JL_DLLEXPORT jl_value_t *jl_load_(jl_module_t *module, jl_value_t *filename)
 {
+    jl_value_t *path = NULL;
     jl_value_t *text = jl_file_content_as_string(filename);
-    JL_GC_PUSH1(&text);
-    jl_value_t *result = jl_parse_eval_all(module, text, filename);
+    JL_GC_PUSH2(&text, &path);
+    char *c_filename = jl_string_data(filename);
+    char *c_path = realpath(c_filename, NULL);
+    assert(c_path);
+    path = jl_cstr_to_string(c_path);
+    free(c_path);
+    jl_value_t *result = jl_parse_eval_all(module, text, path);
     JL_GC_POP();
     return result;
 }


### PR DESCRIPTION
In working on BugReporting.jl, I noticed that our debug info was missing two things: DW_AT_comp_dir was just set to `.`, which I guess can be OK if DW_AT_name is absolute all the time, however it isn't for many files from the sysimg. That makes it difficult to configure gdb to find source code for these files. This PR is a hacky POC that rectifies that by (1) ensuring we always have the absolute paths in the LineNumberNodes, and (2) set that in our debug info. I'm using `realpath` which is probably too heavy-handed (and apparently unavailable on Windows), and some of the changes are likely better made in the parser, so I'd appreciate some comments here.

---

It's not clear to me how we should set DW_AT_name/DW_AT_comp_dir; looking at what gcc does with the Julia binary it seems like the information in there is redundant:

```
 <0><f8>: Abbrev Number: 1 (DW_TAG_compile_unit)
    <f9>   DW_AT_producer    : (indirect string, offset: 0x3a9): GNU C99 9.1.0 -m64 -momit-leaf-frame-pointer -mtune=generic -march=x86-64 -ggdb2 -O3 -std=gnu99 -falign-functions -fPIC -fno-strict-aliasing -ffreestanding
    <fd>   DW_AT_language    : 12       (ANSI C99)
    <fe>   DW_AT_name        : (indirect string, offset: 0xec): /cache/build/default-amdci5-5/julialang/julia-release-1-dot-8/cli/loader_exe.c
    <102>   DW_AT_comp_dir    : (indirect string, offset: 0x358): /cache/build/default-amdci5-5/julialang/julia-release-1-dot-8/cli
```

... while older versions of GCC seemed to set it in a way that requires combining them:

```
 <0><7a>: Abbrev Number: 1 (DW_TAG_compile_unit)
    <7b>   DW_AT_producer    : (indirect string, offset: 0x3c): GNU C 4.8.5 -mtune=generic -march=core2 -g -O2 -std=gnu99 -frandom-seed=0xadf6d374 -fgnu89-inline -fme
rge-all-constants
    <7f>   DW_AT_language    : 1        (ANSI C)
    <80>   DW_AT_name        : (indirect string, offset: 0x574): init.c
    <84>   DW_AT_comp_dir    : (indirect string, offset: 0x0): /workspace/srcdir/glibc-2.12.2/csu
```

I'm currently doing the former, but `gdb` seems to be fine with both. One advantage of a shorter DW_AT_name is that it looks much more nice in GDB. We could, e.g., set DW_AT_comp_dir to BINDIR/DATAROOTDIR and compute a relative file path. Or maybe just to the current directory, as per the spec:

> A DW_AT_comp_dir attribute whose value is a null-terminated string containing
> the current working directory of the compilation command that produced this
> compilation unit in whatever form makes sense for the host system."