### PR TITLE
Optionally use NewPM for optimization

### DIFF
--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -74,10 +74,6 @@ static inline bool imaging_default() {
     return jl_options.image_codegen || (jl_generating_output() && !jl_options.incremental);
 }
 
-#ifndef _COMPILER_ASAN_ENABLED_
-#define JL_USE_NEW_PM
-#endif
-
 struct OptimizationOptions {
     bool lower_intrinsics;
     bool dump_native;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -74,6 +74,10 @@ static inline bool imaging_default() {
     return jl_options.image_codegen || (jl_generating_output() && !jl_options.incremental);
 }
 
+#ifndef _COMPILER_ASAN_ENABLED_
+#define JL_USE_NEW_PM
+#endif
+
 struct OptimizationOptions {
     bool lower_intrinsics;
     bool dump_native;


### PR DESCRIPTION
This continues from #46175 and enables NewPM on all of our optimization pipelines, unless ASAN is active. This is because the combination of ASAN, our JIT, and NewPM results in a recursive lookup during codegen, which triggers an assert for our memory manager. 

This is the other half of #44365.