### PR TITLE
effects: flip the meaning of `inbounds_taint_consistency`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2080,8 +2080,8 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
                 override.effect_free         ? ALWAYS_TRUE : effects.effect_free,
                 override.nothrow             ? ALWAYS_TRUE : effects.nothrow,
                 override.terminates_globally ? ALWAYS_TRUE : effects.terminates,
-                effects.nonoverlayed         ? true        : false,
-                override.notaskstate         ? ALWAYS_TRUE : effects.notaskstate)
+                override.notaskstate         ? ALWAYS_TRUE : effects.notaskstate,
+                effects.nonoverlayed         ? true        : false)
         end
         tristate_merge!(sv, effects)
     elseif ehead === :cfunction

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -178,9 +178,9 @@ mutable struct InferenceState
         #       are stronger than the inbounds assumptions, since the latter
         #       requires dynamic reachability, while the former is global).
         inbounds = inbounds_option()
-        inbounds_taints_consistency = !(inbounds === :on || (inbounds === :default && !any_inbounds(code)))
-        consistent = inbounds_taints_consistency ? ALWAYS_FALSE : ALWAYS_TRUE
-        ipo_effects = Effects(EFFECTS_TOTAL; consistent, inbounds_taints_consistency)
+        noinbounds = inbounds === :on || (inbounds === :default && !any_inbounds(code))
+        consistent = noinbounds ? ALWAYS_TRUE : ALWAYS_FALSE
+        ipo_effects = Effects(EFFECTS_TOTAL; consistent, noinbounds)
 
         params = InferenceParams(interp)
         restrict_abstract_call_sites = isa(linfo.def, Module)

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -426,7 +426,7 @@ function adjust_effects(sv::InferenceState)
     # that is currently modeled in a flow-insensitive way: ideally we want to model it
     # with a proper dataflow analysis instead
     rt = sv.bestguess
-    if !ipo_effects.inbounds_taints_consistency && rt === Bottom
+    if ipo_effects.noinbounds && rt === Bottom
         # always throwing an error counts or never returning both count as consistent
         ipo_effects = Effects(ipo_effects; consistent=ALWAYS_TRUE)
     end


### PR DESCRIPTION
This commit renames `inbounds_taint_consistency` to `noinbounds_inconsistency`
so that the meaning is flipped. This should be more aligned with the
other effects, where they generally mean an absence of "undesirable"
properties, e.g. `nonoverlayed`.