### PR TITLE
mark `setfield!` as consistent

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1844,7 +1844,8 @@ const _CONSISTENT_BUILTINS = Any[
     Core.ifelse,
     (<:),
     typeassert,
-    throw
+    throw,
+    setfield!
 ]
 
 const _SPECIAL_BUILTINS = Any[

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -314,3 +314,5 @@ end |> Core.Compiler.is_effect_free
     obj = c ? Some{String}("foo") : Some{Symbol}(:bar)
     return getfield(obj, :value)
 end |> Core.Compiler.is_consistent
+
+@test Core.Compiler.is_consistent(Base.infer_effects(setindex!, (Base.RefValue{Int}, Int)))


### PR DESCRIPTION
I believe `setfield!` is consistent, since it doesn't accept a boundscheck argument and always returns the value argument.