### PR TITLE
Print more context when FileWatching test fails; also make small tweaks to the `ContextTestSet` (`@testset let ...`) functionality in the Test stdlib

### DIFF
--- a/stdlib/FileWatching/test/runtests.jl
+++ b/stdlib/FileWatching/test/runtests.jl
@@ -324,8 +324,10 @@ function test_dirmonitor_wait2(tval)
                     fname, events = wait(fm)
                 end
                 for i = 1:3
-                    @test fname == "$F_PATH$i"
-                    @test !events.changed && !events.timedout && events.renamed
+                    @testset let (fname, events) = (fname, events)
+                        @test fname == "$F_PATH$i"
+                        @test !events.changed && !events.timedout && events.renamed
+                    end
                     i == 3 && break
                     fname, events = wait(fm)
                 end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -976,7 +976,10 @@ struct ContextTestSet <: AbstractTestSet
 end
 
 function ContextTestSet(name::Union{Symbol, Expr}, @nospecialize(context))
-    ContextTestSet(get_testset(), name, context)
+    if (name isa Expr) && (name.head != :tuple)
+        error("Invalid syntax: $(name)")
+    end
+    return ContextTestSet(get_testset(), name, context)
 end
 record(c::ContextTestSet, t) = record(c.parent_ts, t)
 function record(c::ContextTestSet, t::Fail)

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -971,16 +971,16 @@ about a context object that is being tested.
 """
 struct ContextTestSet <: AbstractTestSet
     parent_ts::AbstractTestSet
-    context_sym::Symbol
+    context_name::Union{Symbol, Expr}
     context::Any
 end
 
-function ContextTestSet(sym::Symbol, @nospecialize(context))
-    ContextTestSet(get_testset(), sym, context)
+function ContextTestSet(name::Union{Symbol, Expr}, @nospecialize(context))
+    ContextTestSet(get_testset(), name, context)
 end
 record(c::ContextTestSet, t) = record(c.parent_ts, t)
 function record(c::ContextTestSet, t::Fail)
-    context = string(c.context_sym, " = ", c.context)
+    context = string(c.context_name, " = ", c.context)
     context = t.context === nothing ? context : string(t.context, "\n              ", context)
     record(c.parent_ts, Fail(t.test_type, t.orig_expr, t.data, t.value, context, t.source, t.message_only))
 end


### PR DESCRIPTION
Follow-up to https://github.com/JuliaLang/julia/pull/46138