### PR TITLE
Fix a typo in the docstring for `@testset let` in the Test stdlib

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1380,7 +1380,7 @@ of nesting in the test set hierarchy and are passed through directly to the
 parent test set (with the context object appended to any failing tests.)
 
     !!! compat "Julia 1.9"
-    `@testeset let` requires at least Julia 1.9.
+    `@testset let` requires at least Julia 1.9.
 
 ## Examples
 ```jldoctest


### PR DESCRIPTION
Follow-up to https://github.com/JuliaLang/julia/pull/46138