### PR TITLE
Allow negative numbers to be used as random number seed

### DIFF
--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -291,7 +291,7 @@ function make_seed()
 end
 
 function make_seed(n::Integer)
-    n < 0 && throw(DomainError(n, "`n` must be non-negative."))
+    n = unsigned(n)
     seed = UInt32[]
     while true
         push!(seed, n & 0xffffffff)


### PR DESCRIPTION
I sadly couldn't run the tests locally without rebuilding julia, not even with the "change the `Project.toml` UUID" trick described in [CONTRIBUTING.md](https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md#contributing-to-the-standard-library). I suspect the mechanism is broken somehow. The existing `DomainError` here is untested either way.