### PR TITLE
Throw descriptive BoundsError in `copyto!`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -322,9 +322,8 @@ end
 function _copyto_impl!(dest::Array, doffs::Integer, src::Array, soffs::Integer, n::Integer)
     n == 0 && return dest
     n > 0 || _throw_argerror()
-    if soffs < 1 || doffs < 1 || soffs+n-1 > length(src) || doffs+n-1 > length(dest)
-        throw(BoundsError())
-    end
+    @boundscheck checkbounds(dest, doffs:doffs+n-1)
+    @boundscheck checkbounds(src, soffs:soffs+n-1)
     unsafe_copyto!(dest, doffs, src, soffs, n)
     return dest
 end


### PR DESCRIPTION
Before, we got a `BoundsError`, now we should get a `BoundsError` that describes the Array and indices. The errors thrown are the same as for `dest[doffs:doffs+n-1] .= src[soffs:soffs+n-1]`.

```julia
julia> x = rand(Int, 4); y = rand(4);

julia> copyto!(x, 1, y, 2, 4) # before
ERROR: BoundsError
Stacktrace:
 [1] _copyto_impl!(dest::Vector{Int64}, doffs::Int64, src::Vector{Float64}, soffs::Int64, n::Int64)
   @ Base ./array.jl:326
 [2] copyto!(dest::Vector{Int64}, doffs::Int64, src::Vector{Float64}, soffs::Int64, n::Int64)
   @ Base ./array.jl:319
 [3] top-level scope
   @ REPL[97]:1

julia> copyto!(x, 1, y, 2, 4) # after
ERROR: BoundsError: attempt to access 4-element Vector{Float64} at index [2:5]
Stacktrace:
 [1] throw_boundserror(A::Vector{Float64}, I::Tuple{UnitRange{Int64}})
   @ Base ./abstractarray.jl:715
 [2] checkbounds
   @ ./abstractarray.jl:680 [inlined]
 [3] _copyto_impl!(dest::Vector{Int64}, doffs::Int64, src::Vector{Float64}, soffs::Int64, n::Int64)
   @ Main ./REPL[99]:5
 [4] copyto!(dest::Vector{Int64}, doffs::Int64, src::Vector{Float64}, soffs::Int64, n::Int64)
   @ Base ./array.jl:314
 [5] top-level scope
   @ REPL[103]:1

julia> copyto!(x, 2, y, 2, 4)
ERROR: BoundsError: attempt to access 4-element Vector{Int64} at index [2:5]
Stacktrace:
 [1] throw_boundserror(A::Vector{Int64}, I::Tuple{UnitRange{Int64}})
   @ Base ./abstractarray.jl:715
 [2] checkbounds
   @ ./abstractarray.jl:680 [inlined]
 [3] _copyto_impl!(dest::Vector{Int64}, doffs::Int64, src::Vector{Float64}, soffs::Int64, n::Int64)
   @ Main ./REPL[99]:4
 [4] copyto!(dest::Vector{Int64}, doffs::Int64, src::Vector{Float64}, soffs::Int64, n::Int64)
   @ Base ./array.jl:314
 [5] top-level scope
   @ REPL[104]:1

julia> x[1:4] .= y[2:5]
ERROR: BoundsError: attempt to access 4-element Vector{Float64} at index [2:5]
Stacktrace:
 [1] throw_boundserror(A::Vector{Float64}, I::Tuple{UnitRange{Int64}})
   @ Base ./abstractarray.jl:715
 [2] checkbounds
   @ ./abstractarray.jl:680 [inlined]
 [3] getindex(A::Vector{Float64}, I::UnitRange{Int64})
   @ Base ./array.jl:922
 [4] top-level scope
   @ REPL[105]:1

julia> x[2:5] .= y[2:5]
ERROR: BoundsError: attempt to access 4-element Vector{Int64} at index [2:5]
Stacktrace:
 [1] throw_boundserror(A::Vector{Int64}, I::Tuple{UnitRange{Int64}})
   @ Base ./abstractarray.jl:715
 [2] checkbounds
   @ ./abstractarray.jl:680 [inlined]
 [3] view
   @ ./subarray.jl:177 [inlined]
 [4] maybeview
   @ ./views.jl:148 [inlined]
 [5] dotview(::Vector{Int64}, ::UnitRange{Int64})
   @ Base.Broadcast ./broadcast.jl:1214
 [6] top-level scope
   @ REPL[106]:1
```