### PR TITLE
effects: add `:inaccessiblememonly` effect

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -462,7 +462,8 @@ macro _foldable_meta()
         #=:nothrow=#false,
         #=:terminates_globally=#true,
         #=:terminates_locally=#false,
-        #=:notaskstate=#false))
+        #=:notaskstate=#false,
+        #=:inaccessiblememonly=#false))
 end
 
 const NTuple{N,T} = Tuple{Vararg{T,N}}

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2081,10 +2081,11 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
             override = decode_effects_override(v[2])
             effects = Effects(
                 override.consistent          ? ALWAYS_TRUE : effects.consistent,
-                override.effect_free         ? true       : effects.effect_free,
-                override.nothrow             ? true       : effects.nothrow,
-                override.terminates_globally ? true       : effects.terminates,
-                override.notaskstate         ? true       : effects.notaskstate,
+                override.effect_free         ? true        : effects.effect_free,
+                override.nothrow             ? true        : effects.nothrow,
+                override.terminates_globally ? true        : effects.terminates,
+                override.notaskstate         ? true        : effects.notaskstate,
+                override.inaccessiblememonly ? ALWAYS_TRUE : effects.inaccessiblememonly,
                 effects.nonoverlayed)
         end
         merge_effects!(sv, effects)
@@ -2166,22 +2167,28 @@ end
 
 function abstract_eval_global(M::Module, s::Symbol, frame::InferenceState)
     rt = abstract_eval_global(M, s)
-    consistent = ALWAYS_FALSE
+    consistent = inaccessiblememonly = ALWAYS_FALSE
     nothrow = false
     if isa(rt, Const)
         consistent = ALWAYS_TRUE
-        nothrow = true
+        if is_mutation_free_argtype(rt)
+            inaccessiblememonly = ALWAYS_TRUE
+            nothrow = true
+        else
+            nothrow = true
+        end
     elseif isdefined(M,s)
         nothrow = true
     end
-    merge_effects!(frame, Effects(EFFECTS_TOTAL; consistent, nothrow))
+    merge_effects!(frame, Effects(EFFECTS_TOTAL; consistent, nothrow, inaccessiblememonly))
     return rt
 end
 
 function handle_global_assignment!(interp::AbstractInterpreter, frame::InferenceState, lhs::GlobalRef, @nospecialize(newty))
     effect_free = false
     nothrow = global_assignment_nothrow(lhs.mod, lhs.name, newty)
-    merge_effects!(frame, Effects(EFFECTS_TOTAL; effect_free, nothrow))
+    inaccessiblememonly = ALWAYS_FALSE
+    merge_effects!(frame, Effects(EFFECTS_TOTAL; effect_free, nothrow, inaccessiblememonly))
     return nothing
 end
 

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -791,9 +791,9 @@ function show_ir(io::IO, code::Union{IRCode, CodeInfo}, config::IRShowConfig=def
 end
 
 function effectbits_letter(effects::Effects, name::Symbol, suffix::Char)
-    if name === :consistent
-        prefix = effects.consistent === ALWAYS_TRUE ? '+' :
-                 effects.consistent === ALWAYS_FALSE ? '!' : '?'
+    if name === :consistent || name === :inaccessiblememonly
+        prefix = getfield(effects, name) === ALWAYS_TRUE ? '+' :
+                 getfield(effects, name) === ALWAYS_FALSE ? '!' : '?'
     else
         prefix = getfield(effects, name) ? '+' : '!'
     end
@@ -801,9 +801,9 @@ function effectbits_letter(effects::Effects, name::Symbol, suffix::Char)
 end
 
 function effectbits_color(effects::Effects, name::Symbol)
-    if name === :consistent
-        color = effects.consistent === ALWAYS_TRUE ? :green :
-                 effects.consistent === ALWAYS_FALSE ? :red : :yellow
+    if name === :consistent || name === :inaccessiblememonly
+        color = getfield(effects, name) === ALWAYS_TRUE ? :green :
+                getfield(effects, name) === ALWAYS_FALSE ? :red : :yellow
     else
         color = getfield(effects, name) ? :green : :red
     end
@@ -821,6 +821,8 @@ function Base.show(io::IO, e::Effects)
     printstyled(io, effectbits_letter(e, :terminates,  't'); color=effectbits_color(e, :terminates))
     print(io, ',')
     printstyled(io, effectbits_letter(e, :notaskstate, 's'); color=effectbits_color(e, :notaskstate))
+    print(io, ',')
+    printstyled(io, effectbits_letter(e, :inaccessiblememonly, 'm'); color=effectbits_color(e, :inaccessiblememonly))
     print(io, ')')
     e.nonoverlayed || printstyled(io, '′'; color=:red)
 end

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1845,11 +1845,38 @@ const _CONSISTENT_BUILTINS = Any[
     (<:),
     typeassert,
     throw,
-    setfield!
+    setfield!,
+]
+
+const _INACCESSIBLEMEM_BUILTINS = Any[
+    (<:),
+    (===),
+    apply_type,
+    arraysize,
+    Core.ifelse,
+    sizeof,
+    svec,
+    fieldtype,
+    isa,
+    isdefined,
+    nfields,
+    throw,
+    tuple,
+    typeassert,
+    typeof,
+]
+
+const _ARGMEM_BUILTINS = Any[
+    arrayref,
+    arrayset,
+    modifyfield!,
+    replacefield!,
+    setfield!,
+    swapfield!,
 ]
 
 const _SPECIAL_BUILTINS = Any[
-    Core._apply_iterate
+    Core._apply_iterate,
 ]
 
 function isdefined_effects(argtypes::Vector{Any})
@@ -1891,11 +1918,18 @@ function getfield_effects(argtypes::Vector{Any}, @nospecialize(rt))
     else
         nothrow = getfield_nothrow(argtypes)
     end
-    return Effects(EFFECTS_TOTAL; consistent, nothrow)
+    if hasintersect(widenconst(obj), Module)
+        inaccessiblememonly = getglobal_effects(argtypes, rt).inaccessiblememonly
+    elseif is_mutation_free_argtype(obj)
+        inaccessiblememonly = ALWAYS_TRUE
+    else
+        inaccessiblememonly = INACCESSIBLEMEM_OR_ARGMEMONLY
+    end
+    return Effects(EFFECTS_TOTAL; consistent, nothrow, inaccessiblememonly)
 end
 
 function getglobal_effects(argtypes::Vector{Any}, @nospecialize(rt))
-    consistent = ALWAYS_FALSE
+    consistent = inaccessiblememonly = ALWAYS_FALSE
     nothrow = false
     if getglobal_nothrow(argtypes)
         nothrow = true
@@ -1903,9 +1937,12 @@ function getglobal_effects(argtypes::Vector{Any}, @nospecialize(rt))
         M, s = (argtypes[1]::Const).val::Module, (argtypes[2]::Const).val::Symbol
         if isconst(M, s)
             consistent = ALWAYS_TRUE
+            if is_mutation_free_argtype(rt)
+                inaccessiblememonly = ALWAYS_TRUE
+            end
         end
     end
-    return Effects(EFFECTS_TOTAL; consistent, nothrow)
+    return Effects(EFFECTS_TOTAL; consistent, nothrow, inaccessiblememonly)
 end
 
 function builtin_effects(f::Builtin, argtypes::Vector{Any}, @nospecialize(rt))
@@ -1925,7 +1962,14 @@ function builtin_effects(f::Builtin, argtypes::Vector{Any}, @nospecialize(rt))
         consistent = contains_is(_CONSISTENT_BUILTINS, f) ? ALWAYS_TRUE : ALWAYS_FALSE
         effect_free = (contains_is(_EFFECT_FREE_BUILTINS, f) || contains_is(_PURE_BUILTINS, f))
         nothrow = (!(!isempty(argtypes) && isvarargtype(argtypes[end])) && builtin_nothrow(f, argtypes, rt))
-        return Effects(EFFECTS_TOTAL; consistent, effect_free, nothrow)
+        if contains_is(_INACCESSIBLEMEM_BUILTINS, f)
+            inaccessiblememonly = ALWAYS_TRUE
+        elseif contains_is(_ARGMEM_BUILTINS, f)
+            inaccessiblememonly = INACCESSIBLEMEM_OR_ARGMEMONLY
+        else
+            inaccessiblememonly = ALWAYS_FALSE
+        end
+        return Effects(EFFECTS_TOTAL; consistent, effect_free, nothrow, inaccessiblememonly)
     end
 end
 

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -430,6 +430,11 @@ function adjust_effects(sv::InferenceState)
         # always throwing an error counts or never returning both count as consistent
         ipo_effects = Effects(ipo_effects; consistent=ALWAYS_TRUE)
     end
+    if is_inaccessiblemem_or_argmemonly(ipo_effects) && all(1:narguments(sv)) do i::Int
+            return is_mutation_free_argtype(sv.slottypes[i])
+        end
+        ipo_effects = Effects(ipo_effects; inaccessiblememonly=ALWAYS_TRUE)
+    end
     if is_consistent_if_notreturned(ipo_effects) && is_consistent_argtype(rt)
         # in a case when the :consistent-cy here is only tainted by mutable allocations
         # (indicated by `CONSISTENT_IF_NOTRETURNED`), we may be able to refine it if the return
@@ -456,6 +461,9 @@ function adjust_effects(sv::InferenceState)
         end
         if is_effect_overridden(override, :notaskstate)
             ipo_effects = Effects(ipo_effects; notaskstate=true)
+        end
+        if is_effect_overridden(override, :inaccessiblememonly)
+            ipo_effects = Effects(ipo_effects; inaccessiblememonly=ALWAYS_TRUE)
         end
     end
 

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -317,7 +317,24 @@ is_immutable_argtype(@nospecialize ty) = is_immutable_type(widenconst(ignorelimi
 is_immutable_type(@nospecialize ty) = _is_immutable_type(unwrap_unionall(ty))
 function _is_immutable_type(@nospecialize ty)
     if isa(ty, Union)
-        return is_immutable_type(ty.a) && is_immutable_type(ty.b)
+        return _is_immutable_type(ty.a) && _is_immutable_type(ty.b)
     end
     return !isabstracttype(ty) && !ismutabletype(ty)
+end
+
+is_mutation_free_argtype(@nospecialize argtype) =
+    is_mutation_free_type(widenconst(ignorelimited(argtype)))
+is_mutation_free_type(@nospecialize ty) =
+    _is_mutation_free_type(unwrap_unionall(ty))
+function _is_mutation_free_type(@nospecialize ty)
+    if isa(ty, Union)
+        return _is_mutation_free_type(ty.a) && _is_mutation_free_type(ty.b)
+    end
+    if isType(ty) || ty === DataType || ty === String || ty === Symbol || ty === SimpleVector
+        return true
+    end
+    # this is okay as access and modifcation on global state are tracked separately
+    ty === Module && return true
+    # TODO improve this analysis, e.g. allow `Some{Symbol}`
+    return isbitstype(ty)
 end

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -210,7 +210,8 @@ macro _total_meta()
         #=:nothrow=#true,
         #=:terminates_globally=#true,
         #=:terminates_locally=#false,
-        #=:notaskstate=#true))
+        #=:notaskstate=#true,
+        #=:inaccessiblememonly=#true))
 end
 # can be used in place of `@assume_effects :foldable` (supposed to be used for bootstrapping)
 macro _foldable_meta()
@@ -220,7 +221,8 @@ macro _foldable_meta()
         #=:nothrow=#false,
         #=:terminates_globally=#true,
         #=:terminates_locally=#false,
-        #=:notaskstate=#false))
+        #=:notaskstate=#false,
+        #=:inaccessiblememonly=#true))
 end
 
 # another version of inlining that propagates an inbounds context

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -433,6 +433,7 @@ The following `setting`s are supported.
 - `:terminates_globally`
 - `:terminates_locally`
 - `:notaskstate`
+- `:inaccessiblememonly`
 - `:foldable`
 - `:total`
 
@@ -571,6 +572,24 @@ moved between tasks without observable results.
     may still be dead-code-eliminated and thus promoted to `:total`.
 
 ---
+## `:inaccessiblememonly`
+
+The `:inaccessiblememonly` setting asserts that the method does not access or modify
+externally accessible mutable memory. This means the method can access or modify mutable
+memory for newly allocated objects that is not accessible by other methods or top-level
+execution before return from the method, but it can not access or modify any mutable
+global state or mutable memory pointed to by its arguments.
+
+!!! note
+    Below is an incomplete list of examples that invalidate this assumption:
+    - a global reference or `getglobal` call to access a mutable global variable
+    - a global assignment or `setglobal!` call to perform assignment to a non-constant global variable
+    - `setfield!` call that changes a field of a global mutable variable
+
+!!! note
+    This `:inaccessiblememonly` assertion covers any other methods called by the annotated method.
+
+---
 ## `:foldable`
 
 This setting is a convenient shortcut for the set of effects that the compiler
@@ -597,6 +616,7 @@ the following other `setting`s:
 - `:nothrow`
 - `:terminates_globally`
 - `:notaskstate`
+- `:inaccessiblememonly`
 
 !!! warning
     `:total` is a very strong assertion and will likely gain additional semantics
@@ -625,8 +645,8 @@ Another advantage is that effects introduced by `@assume_effects` are propagated
 callers interprocedurally while a purity defined by `@pure` is not.
 """
 macro assume_effects(args...)
-    (consistent, effect_free, nothrow, terminates_globally, terminates_locally, notaskstate) =
-        (false, false, false, false, false, false, false)
+    (consistent, effect_free, nothrow, terminates_globally, terminates_locally, notaskstate, inaccessiblememonly) =
+        (false, false, false, false, false, false, false, false)
     for org_setting in args[1:end-1]
         (setting, val) = compute_assumed_setting(org_setting)
         if setting === :consistent
@@ -641,10 +661,12 @@ macro assume_effects(args...)
             terminates_locally = val
         elseif setting === :notaskstate
             notaskstate = val
+        elseif setting === :inaccessiblememonly
+            inaccessiblememonly = val
         elseif setting === :foldable
             consistent = effect_free = terminates_globally = val
         elseif setting === :total
-            consistent = effect_free = nothrow = terminates_globally = notaskstate = val
+            consistent = effect_free = nothrow = terminates_globally = notaskstate = inaccessiblememonly = val
         else
             throw(ArgumentError("@assume_effects $org_setting not supported"))
         end
@@ -654,11 +676,11 @@ macro assume_effects(args...)
     if ex.head === :macrocall && ex.args[1] === Symbol("@ccall")
         ex.args[1] = GlobalRef(Base, Symbol("@ccall_effects"))
         insert!(ex.args, 3, Core.Compiler.encode_effects_override(Core.Compiler.EffectsOverride(
-            consistent, effect_free, nothrow, terminates_globally, terminates_locally, notaskstate
+            consistent, effect_free, nothrow, terminates_globally, terminates_locally, notaskstate, inaccessiblememonly,
         )))
         return esc(ex)
     end
-    return esc(pushmeta!(ex, :purity, consistent, effect_free, nothrow, terminates_globally, terminates_locally, notaskstate))
+    return esc(pushmeta!(ex, :purity, consistent, effect_free, nothrow, terminates_globally, terminates_locally, notaskstate, inaccessiblememonly))
 end
 
 function compute_assumed_setting(@nospecialize(setting), val::Bool=true)

--- a/src/julia.h
+++ b/src/julia.h
@@ -247,6 +247,7 @@ typedef union __jl_purity_overrides_t {
         // assertions about any called functions.
         uint8_t ipo_terminates_locally  : 1;
         uint8_t ipo_notaskstate         : 1;
+        uint8_t ipo_inaccessiblememonly : 1;
     } overrides;
     uint8_t bits;
 } _jl_purity_overrides_t;
@@ -401,23 +402,25 @@ typedef struct _jl_code_instance_t {
     union {
         uint32_t ipo_purity_bits;
         struct {
-            uint8_t ipo_consistent   : 2;
-            uint8_t ipo_effect_free  : 2;
-            uint8_t ipo_nothrow      : 2;
-            uint8_t ipo_terminates   : 2;
-            uint8_t ipo_nonoverlayed : 1;
-            uint8_t ipo_notaskstate  : 2;
+            uint8_t ipo_consistent          : 2;
+            uint8_t ipo_effect_free         : 2;
+            uint8_t ipo_nothrow             : 2;
+            uint8_t ipo_terminates          : 2;
+            uint8_t ipo_nonoverlayed        : 1;
+            uint8_t ipo_notaskstate         : 2;
+            uint8_t ipo_inaccessiblememonly : 2;
         } ipo_purity_flags;
     };
     union {
         uint32_t purity_bits;
         struct {
-            uint8_t consistent   : 2;
-            uint8_t effect_free  : 2;
-            uint8_t nothrow      : 2;
-            uint8_t terminates   : 2;
-            uint8_t nonoverlayed : 1;
-            uint8_t notaskstate  : 2;
+            uint8_t consistent          : 2;
+            uint8_t effect_free         : 2;
+            uint8_t nothrow             : 2;
+            uint8_t terminates          : 2;
+            uint8_t nonoverlayed        : 1;
+            uint8_t notaskstate         : 2;
+            uint8_t inaccessiblememonly : 2;
         } purity_flags;
     };
 #else

--- a/src/method.c
+++ b/src/method.c
@@ -322,13 +322,14 @@ static void jl_code_info_set_ir(jl_code_info_t *li, jl_expr_t *ir)
                 else if (ma == (jl_value_t*)jl_no_constprop_sym)
                     li->constprop = 2;
                 else if (jl_is_expr(ma) && ((jl_expr_t*)ma)->head == jl_purity_sym) {
-                    if (jl_expr_nargs(ma) == 6) {
+                    if (jl_expr_nargs(ma) == 7) {
                         li->purity.overrides.ipo_consistent = jl_unbox_bool(jl_exprarg(ma, 0));
                         li->purity.overrides.ipo_effect_free = jl_unbox_bool(jl_exprarg(ma, 1));
                         li->purity.overrides.ipo_nothrow = jl_unbox_bool(jl_exprarg(ma, 2));
                         li->purity.overrides.ipo_terminates_globally = jl_unbox_bool(jl_exprarg(ma, 3));
                         li->purity.overrides.ipo_terminates_locally = jl_unbox_bool(jl_exprarg(ma, 4));
                         li->purity.overrides.ipo_notaskstate = jl_unbox_bool(jl_exprarg(ma, 5));
+                        li->purity.overrides.ipo_inaccessiblememonly = jl_unbox_bool(jl_exprarg(ma, 6));
                     }
                 }
                 else


### PR DESCRIPTION
This is a preparatory PR for future improvements on the effects analysis.
This commit adds the `:inaccessiblememonly` helper effect, that tracks
if a method involves any access or modification on any mutable state.
This effect property is basically same as LLVM's `inaccessiblememonly`
function attribute, except that it only reasons about mutable memory.
This effect property can be considered as a very limited and coarse
version of escape analysis and allow us prove `:consistent`-cy or
`:effect_free`-ness even in a presence of accesses or modifications
on local mutable allocations in cases when we can prove they are local
and don't escape. Separate PRs that actually improve the effect analysis
accuracy will follow.