### PR TITLE
effects: improve `:consistent`-cy analysis on `getfield`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1894,7 +1894,7 @@ function getfield_effects(argtypes::Vector{Any}, @nospecialize(rt))
     isempty(argtypes) && return EFFECTS_THROWS
     obj = argtypes[1]
     isvarargtype(obj) && return Effects(EFFECTS_THROWS; consistent=ALWAYS_FALSE)
-    consistent = is_immutable_argtype(obj) ? ALWAYS_TRUE : ALWAYS_FALSE
+    consistent = is_immutable_argtype(obj) ? ALWAYS_TRUE : CONSISTENT_IF_INACCESSIBLEMEMONLY
     # access to `isbitstype`-field initialized with undefined value leads to undefined behavior
     # so should taint `:consistent`-cy while access to uninitialized non-`isbitstype` field
     # throws `UndefRefError` so doesn't need to taint it

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -442,6 +442,15 @@ function adjust_effects(sv::InferenceState)
         consistent = ipo_effects.consistent & ~CONSISTENT_IF_NOTRETURNED
         ipo_effects = Effects(ipo_effects; consistent)
     end
+    if is_consistent_if_inaccessiblememonly(ipo_effects)
+        if is_inaccessiblememonly(ipo_effects)
+            consistent = ipo_effects.consistent & ~CONSISTENT_IF_INACCESSIBLEMEMONLY
+            ipo_effects = Effects(ipo_effects; consistent)
+        elseif is_inaccessiblemem_or_argmemonly(ipo_effects)
+        else # `:inaccessiblememonly` is already tainted, there will be no chance to refine this
+            ipo_effects = Effects(ipo_effects; consistent=ALWAYS_FALSE)
+        end
+    end
 
     # override the analyzed effects using manually annotated effect settings
     def = sv.linfo.def


### PR DESCRIPTION
This commit improves the accuracy of the `:consistent`-cy effect analysis
by handling `getfield` accessing local mutable objects.

The existing analysis taints `:consistent`-cy upon any `getfield` call
accessing mutable object because we really don't have a knowledge about
the object lifetime and so we need to conservatively take into account a
possibility of the mutable object being a global variable.

However we can "recover" `:consistent`-cy tainted by access to mutable
object when the newly added `:noglobal` helper effect has been proven
because in that case we can conclude that all mutable objects accessed
within the method are purely local and thus `:consistent` (more
precisely we also need to confirm that all the call arguments are known
not to be mutable global objects to derive this conclusion).

For example now we can prove `:consistent`-cy of the function below and
it will be concrete-evaluated:
```julia
julia> @noinline function mutable_consistent(s)
           broadcast(identity, Ref(s))
       end
mutable_consistent (generic function with 1 method)

julia> Base.infer_effects(mutable_consistent, (String,))
(+c,+e,!n,+t,+s,+g)

julia> code_typed() do
           mutable_consistent(:foo)
       end
1-element Vector{Any}:
 CodeInfo(
1 ─     return :foo
) => Symbol
```