### PR TITLE
effects: improve `:effect_free` analysis for local mutability

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2081,7 +2081,7 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
             override = decode_effects_override(v[2])
             effects = Effects(
                 override.consistent          ? ALWAYS_TRUE : effects.consistent,
-                override.effect_free         ? true        : effects.effect_free,
+                override.effect_free         ? ALWAYS_TRUE : effects.effect_free,
                 override.nothrow             ? true        : effects.nothrow,
                 override.terminates_globally ? true        : effects.terminates,
                 override.notaskstate         ? true        : effects.notaskstate,
@@ -2185,7 +2185,7 @@ function abstract_eval_global(M::Module, s::Symbol, frame::InferenceState)
 end
 
 function handle_global_assignment!(interp::AbstractInterpreter, frame::InferenceState, lhs::GlobalRef, @nospecialize(newty))
-    effect_free = false
+    effect_free = ALWAYS_FALSE
     nothrow = global_assignment_nothrow(lhs.mod, lhs.name, newty)
     inaccessiblememonly = ALWAYS_FALSE
     merge_effects!(frame, Effects(EFFECTS_TOTAL; effect_free, nothrow, inaccessiblememonly))

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -791,7 +791,7 @@ function show_ir(io::IO, code::Union{IRCode, CodeInfo}, config::IRShowConfig=def
 end
 
 function effectbits_letter(effects::Effects, name::Symbol, suffix::Char)
-    if name === :consistent || name === :inaccessiblememonly
+    if name === :consistent || name === :effect_free || name === :inaccessiblememonly
         prefix = getfield(effects, name) === ALWAYS_TRUE ? '+' :
                  getfield(effects, name) === ALWAYS_FALSE ? '!' : '?'
     else
@@ -801,7 +801,7 @@ function effectbits_letter(effects::Effects, name::Symbol, suffix::Char)
 end
 
 function effectbits_color(effects::Effects, name::Symbol)
-    if name === :consistent || name === :inaccessiblememonly
+    if name === :consistent || name === :effect_free || name === :inaccessiblememonly
         color = getfield(effects, name) === ALWAYS_TRUE ? :green :
                 getfield(effects, name) === ALWAYS_FALSE ? :red : :yellow
     else

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -451,6 +451,15 @@ function adjust_effects(sv::InferenceState)
             ipo_effects = Effects(ipo_effects; consistent=ALWAYS_FALSE)
         end
     end
+    if is_effect_free_if_inaccessiblememonly(ipo_effects)
+        if is_inaccessiblememonly(ipo_effects)
+            effect_free = ipo_effects.effect_free & ~EFFECT_FREE_IF_INACCESSIBLEMEMONLY
+            ipo_effects = Effects(ipo_effects; effect_free)
+        elseif is_inaccessiblemem_or_argmemonly(ipo_effects)
+        else # `:inaccessiblememonly` is already tainted, there will be no chance to refine this
+            ipo_effects = Effects(ipo_effects; effect_free=ALWAYS_FALSE)
+        end
+    end
 
     # override the analyzed effects using manually annotated effect settings
     def = sv.linfo.def
@@ -460,7 +469,7 @@ function adjust_effects(sv::InferenceState)
             ipo_effects = Effects(ipo_effects; consistent=ALWAYS_TRUE)
         end
         if is_effect_overridden(override, :effect_free)
-            ipo_effects = Effects(ipo_effects; effect_free=true)
+            ipo_effects = Effects(ipo_effects; effect_free=ALWAYS_TRUE)
         end
         if is_effect_overridden(override, :nothrow)
             ipo_effects = Effects(ipo_effects; nothrow=true)

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -432,3 +432,62 @@ global inconsistent_condition_ref = Ref{Bool}(false)
         return 1
     end
 end |> !Core.Compiler.is_consistent
+
+# the `:inaccessiblememonly` helper effect allows us to prove `:effect_free`-ness of frames
+# including `setfield!` modifying local mutable object
+
+const global_ref = Ref{Any}()
+global const global_bit::Int = 42
+makeref() = Ref{Any}()
+setref!(ref, @nospecialize v) = ref[] = v
+
+@noinline function removable_if_unused1()
+    x = makeref()
+    setref!(x, 42)
+    x
+end
+@noinline function removable_if_unused2()
+    x = makeref()
+    setref!(x, global_bit)
+    x
+end
+for f = Any[removable_if_unused1, removable_if_unused2]
+    effects = Base.infer_effects(f)
+    @test Core.Compiler.is_inaccessiblememonly(effects)
+    @test Core.Compiler.is_effect_free(effects)
+    @test Core.Compiler.is_removable_if_unused(effects)
+    @test @eval fully_eliminated() do
+        $f()
+        nothing
+    end
+end
+@noinline function removable_if_unused3(v)
+    x = makeref()
+    setref!(x, v)
+    x
+end
+let effects = Base.infer_effects(removable_if_unused3, (Int,))
+    @test Core.Compiler.is_inaccessiblememonly(effects)
+    @test Core.Compiler.is_effect_free(effects)
+    @test Core.Compiler.is_removable_if_unused(effects)
+end
+@test fully_eliminated((Int,)) do v
+    removable_if_unused3(v)
+    nothing
+end
+
+@noinline function unremovable_if_unused1!(x)
+    setref!(x, 42)
+end
+@test !Core.Compiler.is_removable_if_unused(Base.infer_effects(unremovable_if_unused1!, (typeof(global_ref),)))
+@test !Core.Compiler.is_removable_if_unused(Base.infer_effects(unremovable_if_unused1!, (Any,)))
+
+@noinline function unremovable_if_unused2!()
+    setref!(global_ref, 42)
+end
+@test !Core.Compiler.is_removable_if_unused(Base.infer_effects(unremovable_if_unused2!))
+
+@noinline function unremovable_if_unused3!()
+    getfield(@__MODULE__, :global_ref)[] = nothing
+end
+@test !Core.Compiler.is_removable_if_unused(Base.infer_effects(unremovable_if_unused3!))


### PR DESCRIPTION
This commit improves the accuracy of the `:effect-free`-ness analysis,
that currently doesn't handle `setfield!` call on local mutable object
pretty well.

The existing analysis taints `:effect_free`-ness upon any `setfield!`
call on mutable object because we really don't have a knowledge about
the object lifetime and so we need to conservatively take into account a
possibility of the mutable object being a global variable.

However we can "recover" `:effect_free`-cness tainted by `setfield!` on
mutable object when the newly added `:noglobal` helper effect has been
proven because in that case we can conclude that all mutable objects
accessed within the method are purely local and `setfield!` on them
are `:effect_free` (more precisely we also need to confirm that all the
call arguments are known not to be mutable global objects to derive this
conclusion).

For example now we can prove `:effect_free`-ness of the function below
and it will be DCE-eligible (and it will even be concrete-evaluated
after #46184):
```julia
julia> makeref() = Ref{Any}()
makeref (generic function with 1 method)

julia> setref!(ref, @nospecialize v) = ref[] = v
setref! (generic function with 1 method)

julia> @noinline function mutable_effect_free(v)
           x = makeref()
           setref!(x, v)
           x
       end
mutable_effect_free (generic function with 1 method)

julia> Base.infer_effects(mutable_effect_free, (String,))
(!c,+e,+n,+t,+s,+g)

julia> code_typed() do
           mutable_effect_free("foo") # will be DCE-ed
           nothing
       end
1-element Vector{Any}:
 CodeInfo(
1 ─     return Main.nothing
) => Nothing
```