### PR TITLE
optimizer: inline constant `String` return value

### DIFF
--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -78,7 +78,7 @@ function quoted(@nospecialize(x))
 end
 
 function count_const_size(@nospecialize(x), count_self::Bool = true)
-    (x isa Type || x isa Symbol) && return 0
+    (x isa Type || x isa Symbol || x isa String) && return 0
     ismutable(x) && return MAX_INLINE_CONST_SIZE + 1
     isbits(x) && return Core.sizeof(x)
     dt = typeof(x)


### PR DESCRIPTION
The purpose of `is_inlineable_constant` is to avoid code size increases
from copying objects too much. `String`s would be fine since they are
generally copied around by reference only.