### PR TITLE
Fix whitespace check for cross-bootstrap case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,12 +151,12 @@ docs: julia-sysimg-$(JULIA_BUILD_MODE) stdlibs-cache-$(JULIA_BUILD_MODE)
 docs-revise:
 	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/doc JULIA_EXECUTABLE='$(call spawn,$(JULIA_EXECUTABLE_$(JULIA_BUILD_MODE))) --startup-file=no' revise=true
 
+WS_CHECK_PATTERNS = *.1 *.c *.cpp *.h *.inc *.jl *.lsp *.make *.md *.mk *.rst *.scm *.sh *.yml *Makefile
+
 .PHONY: check-whitespace
 check-whitespace:
 ifneq ($(NO_GIT), 1)
-	@# Append the directory containing the julia we just built to the end of `PATH`,
-	@# to give us the best chance of being able to run this check.
-	@PATH="$(PATH):$(dir $(JULIA_EXECUTABLE))" julia $(call cygpath_w,$(JULIAHOME)/contrib/check-whitespace.jl)
+	@git ls-files -- $(WS_CHECK_PATTERNS:%='%') | PATH="$(PATH):$(dir $(JULIA_EXECUTABLE))" julia $(call cygpath_w,$(JULIAHOME)/contrib/check-whitespace.jl) --stdin
 else
 	$(warn "Skipping whitespace check because git is unavailable")
 endif
@@ -164,9 +164,7 @@ endif
 .PHONY: fix-whitespace
 fix-whitespace:
 ifneq ($(NO_GIT), 1)
-	@# Append the directory containing the julia we just built to the end of `PATH`,
-	@# to give us the best chance of being able to run this check.
-	@PATH="$(PATH):$(dir $(JULIA_EXECUTABLE))" julia $(call cygpath_w,$(JULIAHOME)/contrib/check-whitespace.jl) --fix
+	@git ls-files -- $(WS_CHECK_PATTERNS:%='%') | PATH="$(PATH):$(dir $(JULIA_EXECUTABLE))" julia $(call cygpath_w,$(JULIAHOME)/contrib/check-whitespace.jl) --stdin --fix
 else
 	$(warn "Skipping whitespace fix because git is unavailable")
 endif

--- a/contrib/check-whitespace.jl
+++ b/contrib/check-whitespace.jl
@@ -33,11 +33,14 @@ allow_tabs(path) =
     endswith(path, "test/triplequote.jl")
 
 function check_whitespace()
-    # Get file list from ARGS if provided, otherwise use git ls-files
     errors = Set{Tuple{String,Int,String}}()
-    files_to_check = filter(arg -> arg != "--fix", ARGS)
+    files_to_check = filter(arg -> !startswith(arg, "-"), ARGS)
     if isempty(files_to_check)
-        files_to_check = eachline(`git ls-files -- $patterns`)
+        if "--stdin" in ARGS
+            files_to_check = collect(eachline(stdin))
+        else
+            files_to_check = collect(eachline(`git ls-files -- $patterns`))
+        end
     end
 
     files_fixed = 0


### PR DESCRIPTION
Pass in the list of files via stdin rather than having julia
run `git` itself. The latter assumes the existance of a `git`
exectuable for the build environment, when we only want to
assume that one exists in the host environment. Fixes
check-whitespace when bootstrapping windows under wine.