### PR TITLE
Add basetype to strip type parameters from type

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -402,6 +402,23 @@ function typename(a::Union)
 end
 typename(union::UnionAll) = typename(union.body)
 
+"""
+    basetype(x::Type)
+Strips the type parameter from given type x. 
+# Examples
+```jldoctest
+julia> basetype(Array{Int64, 3})
+Array
+
+julia> basetype(Vector{Vector{ComplexF32}})
+Array
+
+julia> basetype(Int)
+Int64
+```
+"""
+basetype(::Type{T}) where T = T.name.wrapper
+
 _tuple_error(T::Type, x) = (@noinline; throw(MethodError(convert, (T, x))))
 
 convert(::Type{T}, x::T) where {T<:Tuple} = x


### PR DESCRIPTION
This is a followup of [this issue](https://github.com/JuliaLang/julia/issues/35543).
Recently I have had the need to get the "base type" of a type, ie to strip type parameters from type. It seems that I am far from being the first to have such a problem, and having to call `T.name.wrapper` every single time is a bit tedious. Following what I read in the different issues which have been opened, I created the `basetype` function which does just this. 
I just didn't know exactly where to put this script: I saw that `typename` was already defined in essentials, so that's why I put it there, but maybe it needs to go elsewhere.