### PR TITLE
Fix a few JITLink nits

### DIFF
--- a/doc/src/devdocs/locks.md
+++ b/doc/src/devdocs/locks.md
@@ -31,6 +31,7 @@ The following are definitely leaf locks (level 1), and must not try to acquire a
 >   * ResourcePool<?>::mutex
 >   * RLST_mutex
 >   * jl_locked_stream::mutex
+>   * debuginfo_asyncsafe
 >
 >     > flisp itself is already threadsafe, this lock only protects the `jl_ast_context_list_t` pool
 >     > likewise, the ResourcePool<?>::mutexes just protect the associated resource pool
@@ -39,6 +40,7 @@ The following is a leaf lock (level 2), and only acquires level 1 locks (safepoi
 
 >   * typecache
 >   * Module->lock
+>   * JLDebuginfoPlugin::PluginMutex
 
 The following is a level 3 lock, which can only acquire level 1 or level 2 locks internally:
 
@@ -50,10 +52,13 @@ The following is a level 4 lock, which can only recurse to acquire level 1, 2, o
 
 No Julia code may be called while holding a lock above this point.
 
-orc::ThreadSafeContext locks occupy a special spot in the locking diagram. They are used to protect
-LLVM's global non-threadsafe state, but there may be an arbitrary number of them. For now, there is
-only one global context, and thus acquiring it is a level 5 lock. However, acquiring such a lock
-should only be done at the same time that the codegen lock is acquired.
+orc::ThreadSafeContext (TSCtx) locks occupy a special spot in the locking hierarchy. They are used to
+protect LLVM's global non-threadsafe state, but there may be an arbitrary number of them. By default,
+all of these locks may be treated as level 5 locks for the purposes of comparing with the rest of the
+hierarchy. Acquiring a TSCtx should only be done from the JIT's pool of TSCtx's, and all locks on
+that TSCtx should be released prior to returning it to the pool. If multiple TSCtx locks must be
+acquired at the same time (due to recursive compilation), then locks should be acquired in the order
+that the TSCtxs were borrowed from the pool.
 
 The following are a level 6 lock, which can only recurse to acquire locks at lower levels:
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8603,7 +8603,7 @@ extern "C" void jl_init_llvm(void)
     defined(JL_USE_OPROFILE_JITEVENTS) || \
     defined(JL_USE_PERF_JITEVENTS)
 #ifdef JL_USE_JITLINK
-#error "JIT profiling support (JL_USE_*_JITEVENTS) not yet available on platforms that use JITLink"
+#pragma message("JIT profiling support (JL_USE_*_JITEVENTS) not yet available on platforms that use JITLink")
 #else
     const char *jit_profiling = getenv("ENABLE_JITPROFILING");
 
@@ -8625,6 +8625,7 @@ extern "C" void jl_init_llvm(void)
     }
 #endif
 
+#ifndef JL_USE_JITLINK
 #ifdef JL_USE_INTEL_JITEVENTS
     if (jl_using_intel_jitevents)
         jl_ExecutionEngine->RegisterJITEventListener(JITEventListener::createIntelJITEventListener());
@@ -8638,6 +8639,7 @@ extern "C" void jl_init_llvm(void)
 #ifdef JL_USE_PERF_JITEVENTS
     if (jl_using_perf_jitevents)
         jl_ExecutionEngine->RegisterJITEventListener(JITEventListener::createPerfJITEventListener());
+#endif
 #endif
 #endif
 #endif


### PR DESCRIPTION
This PR steals the JITLink improvements from #45859, and also introduces a mutex to the debuginfo JITLink plugin to make it concurrency-safe. It also updates the locking documentation. 