### PR TITLE
[Docs] Added Example for Using `abspath`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -358,7 +358,7 @@ Create a shallow copy of `x`: the outer structure is copied, but not all interna
 For example, copying an array produces a new array with identically-same elements as the
 original.
 
-See also [`copy!`](@ref Base.copy!), [`copyto!`](@ref).
+See also [`copy!`](@ref Base.copy!), [`copyto!`](@ref), [`deepcopy`](@ref).
 """
 copy
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -358,7 +358,7 @@ Create a shallow copy of `x`: the outer structure is copied, but not all interna
 For example, copying an array produces a new array with identically-same elements as the
 original.
 
-See also [`copy!`](@ref Base.copy!), [`copyto!`](@ref), [`deepcopy`](@ref).
+See also [`copy!`](@ref Base.copy!), [`copyto!`](@ref).
 """
 copy
 

--- a/base/path.jl
+++ b/base/path.jl
@@ -415,6 +415,16 @@ normpath(a::AbstractString, b::AbstractString...) = normpath(joinpath(a,b...))
 
 Convert a path to an absolute path by adding the current directory if necessary.
 Also normalizes the path as in [`normpath`](@ref).
+
+# Example
+
+If you are in a directory called `JuliaExample` and the data you are using is two levels up relative to the `JuliaExample` directory, you could write:
+
+abspath("../../data")
+
+Which gives a path like `"/home/JuliaUser/data/"`.
+
+See also [`joinpath`](@ref), [`pwd`](@ref), [`expanduser`](@ref).
 """
 function abspath(a::String)::String
     if !isabspath(a)


### PR DESCRIPTION
Added an example of using `abspath` to get an absolute path from a relative path.

Credit for raising this to Discourse user DNF 