### PR TITLE
win: Propagate crashes to OS crash handlers

### DIFF
--- a/src/win32_ucontext.c
+++ b/src/win32_ucontext.c
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-extern LONG WINAPI jl_exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo);
+extern LONG WINAPI jl_exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo, int global);
 
 // Instead of using ntdll!_except_handler4, we call directly to our UnhandledExceptionFilter.
 // This seems to work better, since it's unclear if we have made a valid frame
@@ -25,7 +25,7 @@ JL_DLLEXPORT EXCEPTION_DISPOSITION NTAPI __julia_personality(
     ExceptionInfo.ContextRecord = ContextRecord;
 
     EXCEPTION_DISPOSITION rval;
-    switch (jl_exception_handler(&ExceptionInfo)) {
+    switch (jl_exception_handler(&ExceptionInfo, 0)) {
         case EXCEPTION_EXECUTE_HANDLER:
             rval = ExceptionExecuteHandler;
             break;


### PR DESCRIPTION
Similar in spirit to #46157. We'd like to collect crashdumps
when julia crashes on CI, but currently we just cleanly exit
the pocess in this case. By continuing exception handling into
the global crash handler, the OS's crash reporter gets invoked
and can dump out a minidump for us. In the future, we may want
to add our own crash reported, but this should hopefully help
debug crashes for the moment.