### PR TITLE
Replace kw... with kws...

### DIFF
--- a/base/accumulate.jl
+++ b/base/accumulate.jl
@@ -269,10 +269,10 @@ julia> accumulate(+, fill(1, 2, 5), dims=2, init=100.0)
  101.0  102.0  103.0  104.0  105.0
 ```
 """
-function accumulate(op, A; dims::Union{Nothing,Integer}=nothing, kw...)
+function accumulate(op, A; dims::Union{Nothing,Integer}=nothing, kws...)
     if dims === nothing && !(A isa AbstractVector)
         # This branch takes care of the cases not handled by `_accumulate!`.
-        return collect(Iterators.accumulate(op, A; kw...))
+        return collect(Iterators.accumulate(op, A; kws...))
     end
     nt = values(kw)
     if isempty(kw)
@@ -282,7 +282,7 @@ function accumulate(op, A; dims::Union{Nothing,Integer}=nothing, kw...)
     else
         throw(ArgumentError("acccumulate does not support the keyword arguments $(setdiff(keys(nt), (:init,)))"))
     end
-    accumulate!(op, out, A; dims=dims, kw...)
+    accumulate!(op, out, A; dims=dims, kws...)
 end
 
 function accumulate(op, xs::Tuple; init = _InitialValue())
@@ -334,7 +334,7 @@ julia> accumulate!(*, B, A, dims=2, init=10)
  40  200  1200
 ```
 """
-function accumulate!(op, B, A; dims::Union{Integer, Nothing} = nothing, kw...)
+function accumulate!(op, B, A; dims::Union{Integer, Nothing} = nothing, kws...)
     nt = values(kw)
     if isempty(kw)
         _accumulate!(op, B, A, dims, nothing)

--- a/base/io.jl
+++ b/base/io.jl
@@ -439,10 +439,10 @@ for f in (
 end
 read(io::AbstractPipe, byte::Type{UInt8}) = read(pipe_reader(io)::IO, byte)::UInt8
 unsafe_read(io::AbstractPipe, p::Ptr{UInt8}, nb::UInt) = unsafe_read(pipe_reader(io)::IO, p, nb)
-readuntil(io::AbstractPipe, arg::UInt8; kw...) = readuntil(pipe_reader(io)::IO, arg; kw...)
-readuntil(io::AbstractPipe, arg::AbstractChar; kw...) = readuntil(pipe_reader(io)::IO, arg; kw...)
-readuntil(io::AbstractPipe, arg::AbstractString; kw...) = readuntil(pipe_reader(io)::IO, arg; kw...)
-readuntil(io::AbstractPipe, arg::AbstractVector; kw...) = readuntil(pipe_reader(io)::IO, arg; kw...)
+readuntil(io::AbstractPipe, arg::UInt8; kws...) = readuntil(pipe_reader(io)::IO, arg; kws...)
+readuntil(io::AbstractPipe, arg::AbstractChar; kws...) = readuntil(pipe_reader(io)::IO, arg; kws...)
+readuntil(io::AbstractPipe, arg::AbstractString; kws...) = readuntil(pipe_reader(io)::IO, arg; kws...)
+readuntil(io::AbstractPipe, arg::AbstractVector; kws...) = readuntil(pipe_reader(io)::IO, arg; kws...)
 readuntil_vector!(io::AbstractPipe, target::AbstractVector, keep::Bool, out) = readuntil_vector!(pipe_reader(io)::IO, target, keep, out)
 readbytes!(io::AbstractPipe, target::AbstractVector{UInt8}, n=length(target)) = readbytes!(pipe_reader(io)::IO, target, n)
 peek(io::AbstractPipe, ::Type{T}) where {T} = peek(pipe_reader(io)::IO, T)::T
@@ -504,7 +504,7 @@ julia> readuntil("my_file.txt", '.', keep = true)
 julia> rm("my_file.txt")
 ```
 """
-readuntil(filename::AbstractString, args...; kw...) = open(io->readuntil(io, args...; kw...), convert(String, filename)::String)
+readuntil(filename::AbstractString, args...; kws...) = open(io->readuntil(io, args...; kws...), convert(String, filename)::String)
 
 """
     readline(io::IO=stdin; keep::Bool=false)
@@ -582,12 +582,12 @@ julia> readlines("my_file.txt", keep=true)
 julia> rm("my_file.txt")
 ```
 """
-function readlines(filename::AbstractString; kw...)
+function readlines(filename::AbstractString; kws...)
     open(filename) do f
-        readlines(f; kw...)
+        readlines(f; kws...)
     end
 end
-readlines(s=stdin; kw...) = collect(eachline(s; kw...))
+readlines(s=stdin; kws...) = collect(eachline(s; kws...))
 
 ## byte-order mark, ntoh & hton ##
 

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -90,7 +90,7 @@ function kwarg_decl(m::Method, kwtype = nothing)
             kwli = kwli::Method
             slotnames = ccall(:jl_uncompress_argnames, Vector{Symbol}, (Any,), kwli.slot_syms)
             kws = filter(x -> !(x === empty_sym || '#' in string(x)), slotnames[(kwli.nargs + 1):end])
-            # ensure the kwarg... is always printed last. The order of the arguments are not
+            # ensure the kwargs... is always printed last. The order of the arguments are not
             # necessarily the same as defined in the function
             i = findfirst(x -> endswith(string(x)::String, "..."), kws)
             if i !== nothing

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -904,7 +904,7 @@ _stable_typeof(::Type{T}) where {T} = @isdefined(T) ? Type{T} : DataType
 """
     f = Returns(value)
 
-Create a callable `f` such that `f(args...; kw...) === value` holds.
+Create a callable `f` such that `f(args...; kws...) === value` holds.
 
 # Examples
 
@@ -930,7 +930,7 @@ struct Returns{V} <: Function
     Returns(value) = new{_stable_typeof(value)}(value)
 end
 
-(obj::Returns)(@nospecialize(args...); @nospecialize(kw...)) = obj.value
+(obj::Returns)(@nospecialize(args...); @nospecialize(kws...)) = obj.value
 
 # function composition
 
@@ -980,7 +980,7 @@ function ∘ end
 
 Represents the composition of two callable objects `outer::Outer` and `inner::Inner`. That is
 ```julia
-ComposedFunction(outer, inner)(args...; kw...) === outer(inner(args...; kw...))
+ComposedFunction(outer, inner)(args...; kws...) === outer(inner(args...; kws...))
 ```
 The preferred way to construct instance of `ComposedFunction` is to use the composition operator [`∘`](@ref):
 ```jldoctest
@@ -1013,14 +1013,14 @@ struct ComposedFunction{O,I} <: Function
     ComposedFunction(outer, inner) = new{Core.Typeof(outer),Core.Typeof(inner)}(outer, inner)
 end
 
-(c::ComposedFunction)(x...; kw...) = call_composed(unwrap_composed(c), x, kw)
+(c::ComposedFunction)(x...; kws...) = call_composed(unwrap_composed(c), x, kw)
 unwrap_composed(c::ComposedFunction) = (unwrap_composed(c.outer)..., unwrap_composed(c.inner)...)
 unwrap_composed(c) = (maybeconstructor(c),)
 call_composed(fs, x, kw) = (@inline; fs[1](call_composed(tail(fs), x, kw)))
-call_composed(fs::Tuple{Any}, x, kw) = fs[1](x...; kw...)
+call_composed(fs::Tuple{Any}, x, kw) = fs[1](x...; kws...)
 
 struct Constructor{F} <: Function end
-(::Constructor{F})(args...; kw...) where {F} = (@inline; F(args...; kw...))
+(::Constructor{F})(args...; kws...) where {F} = (@inline; F(args...; kws...))
 maybeconstructor(::Type{F}) where {F} = Constructor{F}()
 maybeconstructor(f) = f
 

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -190,7 +190,7 @@ julia> accumulate(=>, (1,2,3,4))
 (1, 1 => 2, (1 => 2) => 3, ((1 => 2) => 3) => 4)
 ```
 """
-foldl(op, itr; kw...) = mapfoldl(identity, op, itr; kw...)
+foldl(op, itr; kws...) = mapfoldl(identity, op, itr; kws...)
 
 ## foldr & mapfoldr
 
@@ -234,7 +234,7 @@ julia> foldr(=>, 1:4; init=0)
 1 => (2 => (3 => (4 => 0)))
 ```
 """
-foldr(op, itr; kw...) = mapfoldr(identity, op, itr; kw...)
+foldr(op, itr; kws...) = mapfoldr(identity, op, itr; kws...)
 
 ## reduce & mapreduce
 
@@ -299,8 +299,8 @@ implementations may reuse the return value of `f` for elements that appear multi
 `itr`. Use [`mapfoldl`](@ref) or [`mapfoldr`](@ref) instead for
 guaranteed left or right associativity and invocation of `f` for every value.
 """
-mapreduce(f, op, itr; kw...) = mapfoldl(f, op, itr; kw...)
-mapreduce(f, op, itrs...; kw...) = reduce(op, Generator(f, itrs...); kw...)
+mapreduce(f, op, itr; kws...) = mapfoldl(f, op, itr; kws...)
+mapreduce(f, op, itrs...; kws...) = reduce(op, Generator(f, itrs...); kws...)
 
 # Note: sum_seq usually uses four or more accumulators after partial
 # unrolling, so each accumulator gets at most 256 numbers
@@ -480,7 +480,7 @@ julia> reduce(*, [2; 3; 4]; init=-1)
 -24
 ```
 """
-reduce(op, itr; kw...) = mapreduce(identity, op, itr; kw...)
+reduce(op, itr; kws...) = mapreduce(identity, op, itr; kws...)
 
 reduce(op, a::Number) = a  # Do we want this?
 
@@ -525,7 +525,7 @@ In the former case, the integers are widened to system word size and therefore
 the result is 128. In the latter case, no such widening happens and integer
 overflow results in -128.
 """
-sum(f, a; kw...) = mapreduce(f, add_sum, a; kw...)
+sum(f, a; kws...) = mapreduce(f, add_sum, a; kws...)
 
 """
     sum(itr; [init])
@@ -554,9 +554,9 @@ julia> sum(1:20; init = 0.0)
 210.0
 ```
 """
-sum(a; kw...) = sum(identity, a; kw...)
-sum(a::AbstractArray{Bool}; kw...) =
-    isempty(kw) ? count(a) : reduce(add_sum, a; kw...)
+sum(a; kws...) = sum(identity, a; kws...)
+sum(a::AbstractArray{Bool}; kws...) =
+    isempty(kw) ? count(a) : reduce(add_sum, a; kws...)
 
 ## prod
 """
@@ -581,7 +581,7 @@ julia> prod(abs2, [2; 3; 4])
 576
 ```
 """
-prod(f, a; kw...) = mapreduce(f, mul_prod, a; kw...)
+prod(f, a; kws...) = mapreduce(f, mul_prod, a; kws...)
 
 """
     prod(itr; [init])
@@ -610,7 +610,7 @@ julia> prod(1:5; init = 1.0)
 120.0
 ```
 """
-prod(a; kw...) = mapreduce(identity, mul_prod, a; kw...)
+prod(a; kws...) = mapreduce(identity, mul_prod, a; kws...)
 
 ## maximum, minimum, & extrema
 _fast(::typeof(min),x,y) = min(x,y)
@@ -695,7 +695,7 @@ julia> maximum(sin, Real[]; init=-1.0)  # good, since output of sin is >= -1
 -1.0
 ```
 """
-maximum(f, a; kw...) = mapreduce(f, max, a; kw...)
+maximum(f, a; kws...) = mapreduce(f, max, a; kws...)
 
 """
     minimum(f, itr; [init])
@@ -722,7 +722,7 @@ julia> minimum(sin, Real[]; init=1.0)  # good, since output of sin is <= 1
 1.0
 ```
 """
-minimum(f, a; kw...) = mapreduce(f, min, a; kw...)
+minimum(f, a; kws...) = mapreduce(f, min, a; kws...)
 
 """
     maximum(itr; [init])
@@ -754,7 +754,7 @@ julia> maximum((); init=-Inf)
 -Inf
 ```
 """
-maximum(a; kw...) = mapreduce(identity, max, a; kw...)
+maximum(a; kws...) = mapreduce(identity, max, a; kws...)
 
 """
     minimum(itr; [init])
@@ -786,7 +786,7 @@ julia> minimum([]; init=Inf)
 Inf
 ```
 """
-minimum(a; kw...) = mapreduce(identity, min, a; kw...)
+minimum(a; kws...) = mapreduce(identity, min, a; kws...)
 
 """
     extrema(itr; [init]) -> (mn, mx)
@@ -815,7 +815,7 @@ julia> extrema([]; init = (Inf, -Inf))
 (Inf, -Inf)
 ```
 """
-extrema(itr; kw...) = extrema(identity, itr; kw...)
+extrema(itr; kws...) = extrema(identity, itr; kws...)
 
 """
     extrema(f, itr; [init]) -> (mn, mx)
@@ -845,7 +845,7 @@ julia> extrema(sin, Real[]; init = (1.0, -1.0))  # good, since -1 ≤ sin(::Real
 (1.0, -1.0)
 ```
 """
-extrema(f, itr; kw...) = mapreduce(ExtremaMap(f), _extrema_rf, itr; kw...)
+extrema(f, itr; kws...) = mapreduce(ExtremaMap(f), _extrema_rf, itr; kws...)
 
 # Not using closure since `extrema(type, itr)` is a very likely use-case and it's better
 # to avoid type-instability (#23618).

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -356,8 +356,8 @@ julia> mapreduce(isodd, |, a, dims=1)
 """
 mapreduce(f, op, A::AbstractArrayOrBroadcasted; dims=:, init=_InitialValue()) =
     _mapreduce_dim(f, op, init, A, dims)
-mapreduce(f, op, A::AbstractArrayOrBroadcasted...; kw...) =
-    reduce(op, map(f, A...); kw...)
+mapreduce(f, op, A::AbstractArrayOrBroadcasted...; kws...) =
+    reduce(op, map(f, A...); kws...)
 
 _mapreduce_dim(f, op, nt, A::AbstractArrayOrBroadcasted, ::Colon) =
     mapfoldl_impl(f, op, nt, A)
@@ -403,7 +403,7 @@ julia> reduce(max, a, dims=1)
  4  8  12  16
 ```
 """
-reduce(op, A::AbstractArray; kw...) = mapreduce(identity, op, A; kw...)
+reduce(op, A::AbstractArray; kws...) = mapreduce(identity, op, A; kws...)
 
 ##### Specific reduction functions #####
 
@@ -991,12 +991,12 @@ for (fname, _fname, op) in [(:sum,     :_sum,     :add_sum), (:prod,    :_prod, 
     mapf = fname === :extrema ? :(ExtremaMap(f)) : :f
     @eval begin
         # User-facing methods with keyword arguments
-        @inline ($fname)(a::AbstractArray; dims=:, kw...) = ($_fname)(a, dims; kw...)
-        @inline ($fname)(f, a::AbstractArray; dims=:, kw...) = ($_fname)(f, a, dims; kw...)
+        @inline ($fname)(a::AbstractArray; dims=:, kws...) = ($_fname)(a, dims; kws...)
+        @inline ($fname)(f, a::AbstractArray; dims=:, kws...) = ($_fname)(f, a, dims; kws...)
 
         # Underlying implementations using dispatch
-        ($_fname)(a, ::Colon; kw...) = ($_fname)(identity, a, :; kw...)
-        ($_fname)(f, a, ::Colon; kw...) = mapreduce($mapf, $op, a; kw...)
+        ($_fname)(a, ::Colon; kws...) = ($_fname)(identity, a, :; kws...)
+        ($_fname)(f, a, ::Colon; kws...) = mapreduce($mapf, $op, a; kws...)
     end
 end
 
@@ -1019,8 +1019,8 @@ for (fname, op) in [(:sum, :add_sum), (:prod, :mul_prod),
             mapreducedim!($mapf, $(op), initarray!(r, $mapf, $(op), init, A), A)
         $(fname!)(r::AbstractArray, A::AbstractArray; init::Bool=true) = $(fname!)(identity, r, A; init=init)
 
-        $(_fname)(A, dims; kw...)    = $(_fname)(identity, A, dims; kw...)
-        $(_fname)(f, A, dims; kw...) = mapreduce($mapf, $(op), A; dims=dims, kw...)
+        $(_fname)(A, dims; kws...)    = $(_fname)(identity, A, dims; kws...)
+        $(_fname)(f, A, dims; kws...) = mapreduce($mapf, $(op), A; dims=dims, kws...)
     end
 end
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1177,7 +1177,7 @@ function func_for_method_checked(m::Method, @nospecialize(types), sparams::Simpl
 end
 
 """
-    code_typed(f, types; kw...)
+    code_typed(f, types; kws...)
 
 Returns an array of type-inferred lowered form (IR) for the methods matching the given
 generic function and type signature.

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -412,7 +412,7 @@ false
      `insorted` was added in Julia 1.6.
 """
 function insorted end
-insorted(x, v::AbstractVector; kw...) = !isempty(searchsorted(v, x; kw...))
+insorted(x, v::AbstractVector; kws...) = !isempty(searchsorted(v, x; kws...))
 insorted(x, r::AbstractRange) = in(x, r)
 
 ## sorting algorithms ##

--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -167,7 +167,7 @@ function isdiff(repo::GitRepo, treeish::AbstractString, paths::AbstractString=""
 end
 
 """
-    diff_files(repo::GitRepo, branch1::AbstractString, branch2::AbstractString; kwarg...) -> Vector{AbstractString}
+    diff_files(repo::GitRepo, branch1::AbstractString, branch2::AbstractString; kwargs...) -> Vector{AbstractString}
 
 Show which files have changed in the git repository `repo` between branches `branch1`
 and `branch2`.

--- a/stdlib/LibGit2/src/repository.jl
+++ b/stdlib/LibGit2/src/repository.jl
@@ -263,7 +263,7 @@ end
 peel(obj::GitObject) = peel(GitObject, obj)
 
 """
-    LibGit2.GitDescribeResult(committish::GitObject; kwarg...)
+    LibGit2.GitDescribeResult(committish::GitObject; kwargs...)
 
 Produce a `GitDescribeResult` of the `committish` `GitObject`, which
 contains detailed information about it based on the keyword argument:
@@ -292,7 +292,7 @@ function GitDescribeResult(committish::GitObject;
 end
 
 """
-    LibGit2.GitDescribeResult(repo::GitRepo; kwarg...)
+    LibGit2.GitDescribeResult(repo::GitRepo; kwargs...)
 
 Produce a `GitDescribeResult` of the repository `repo`'s working directory.
 The `GitDescribeResult` contains detailed information about the workdir based
@@ -319,7 +319,7 @@ function GitDescribeResult(repo::GitRepo; options::DescribeOptions=DescribeOptio
 end
 
 """
-    LibGit2.format(result::GitDescribeResult; kwarg...) -> String
+    LibGit2.format(result::GitDescribeResult; kwargs...) -> String
 
 Produce a formatted string based on a `GitDescribeResult`.
 Formatting options are controlled by the keyword argument:

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -216,8 +216,8 @@ function svd!(M::Bidiagonal{<:BlasReal}; full::Bool = false)
     d, e, U, Vt, Q, iQ = LAPACK.bdsdc!(M.uplo, 'I', M.dv, M.ev)
     SVD(U, d, Vt)
 end
-function svd(M::Bidiagonal; kw...)
-    svd!(copy(M), kw...)
+function svd(M::Bidiagonal; kws...)
+    svd!(copy(M), kws...)
 end
 
 ####################

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -416,16 +416,16 @@ prompt_string(p::Prompt) = prompt_string(p.prompt)
 prompt_string(s::AbstractString) = s
 prompt_string(f::Function) = Base.invokelatest(f)
 
-function refresh_multi_line(s::PromptState; kw...)
+function refresh_multi_line(s::PromptState; kws...)
     if s.refresh_wait !== nothing
         close(s.refresh_wait)
         s.refresh_wait = nothing
     end
-    refresh_multi_line(terminal(s), s; kw...)
+    refresh_multi_line(terminal(s), s; kws...)
 end
-refresh_multi_line(s::ModeState; kw...) = refresh_multi_line(terminal(s), s; kw...)
-refresh_multi_line(termbuf::TerminalBuffer, s::ModeState; kw...) = refresh_multi_line(termbuf, terminal(s), s; kw...)
-refresh_multi_line(termbuf::TerminalBuffer, term, s::ModeState; kw...) = (@assert term === terminal(s); refresh_multi_line(termbuf,s; kw...))
+refresh_multi_line(s::ModeState; kws...) = refresh_multi_line(terminal(s), s; kws...)
+refresh_multi_line(termbuf::TerminalBuffer, s::ModeState; kws...) = refresh_multi_line(termbuf, terminal(s), s; kws...)
+refresh_multi_line(termbuf::TerminalBuffer, term, s::ModeState; kws...) = (@assert term === terminal(s); refresh_multi_line(termbuf,s; kws...))
 
 function refresh_multi_line(termbuf::TerminalBuffer, terminal::UnixTerminal, buf::IOBuffer,
                             state::InputAreaState, prompt = "";

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -346,7 +346,7 @@ result_type9232(::Type{T1}, ::Type{T2}) where {T1<:Number,T2<:Number} = arithtyp
 
 
 # issue #10878
-function g10878(x; kw...); end
+function g10878(x; kws...); end
 invoke_g10878() = invoke(g10878, Tuple{Any}, 1)
 code_typed(invoke_g10878, ())
 code_llvm(devnull, invoke_g10878, ())

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -51,7 +51,7 @@ end
     @test kwf9(write=true) === (true,true)
 end
 # rest keywords
-kwdelegator(ones;kw...) = kwf1(ones;kw...)
+kwdelegator(ones;kws...) = kwf1(ones;kws...)
 @test kwdelegator(4,hundreds=8) == 804
 
 @testset "optional positional args" begin
@@ -93,7 +93,7 @@ end
     @test_throws MethodError kwf5(1)
 end
 
-extravagant_args(x,y=0,rest...;color="blue",kw...) = (x,y,rest,color,kwf1(6;tens=8,kw...))
+extravagant_args(x,y=0,rest...;color="blue",kws...) = (x,y,rest,color,kwf1(6;tens=8,kws...))
 @testset "with every feature!" begin
     @test isequal(extravagant_args(1), (1,0,(),"blue",86))
     @test isequal(extravagant_args(1;hundreds=7), (1,0,(),"blue",786))

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -556,12 +556,12 @@ end
     @test searchsortedlast(o, 1.5) == -1
 end
 
-function adaptive_sort_test(v; trusted=InsertionSort, kw...)
+function adaptive_sort_test(v; trusted=InsertionSort, kws...)
     sm = sum(hash.(v))
-    truth = sort!(deepcopy(v); alg=trusted, kw...)
+    truth = sort!(deepcopy(v); alg=trusted, kws...)
     return (
-        v === sort!(v; kw...) &&
-        issorted(v; kw...) &&
+        v === sort!(v; kws...) &&
+        issorted(v; kws...) &&
         sum(hash.(v)) == sm &&
         all(v .=== truth))
 end

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -804,7 +804,7 @@ end
 @test Meta.parse("@a(b=1, c=2)") == Expr(:macrocall, Symbol("@a"), LineNumberNode(1, :none), :(b=1), :(c=2))
 
 # issue #19685
-let f = function (x; kw...)
+let f = function (x; kws...)
             return (x, kw)
         end,
     g = function (x; a = 2)
@@ -1931,7 +1931,7 @@ b32121 = 9
 @test @id28992((a32121=a32121, b32121=b32121)) === (a32121=8, b32121=9)
 
 # issue #31596
-f31596(x; kw...) = x
+f31596(x; kws...) = x
 @test f31596((a=1,), b = 1.0) === (a=1,)
 
 # issue #32325
@@ -2308,7 +2308,7 @@ f35201(c) = h35201((;c...), k=true)
 @test f35201(Dict(:a=>1,:b=>3)) === ((a=1,b=3), true)
 
 # issue #44343
-f44343(;kw...) = NamedTuple(kw)
+f44343(;kws...) = NamedTuple(kw)
 @test f44343(u = (; :a => 1)) === (u = (; :a => 1),)
 
 @testset "issue #34544/35367" begin


### PR DESCRIPTION
EDIT: This is backward, I actually changed `kw` to `kws` (See discussion).

I notice that we use both `kws...` and `kw...` with little apparent pattern. I prefer using one consistently, so I changed almost all occurrences of `kws...` to `kw...`. I chose `kw` because it is already more common.
```
grep -owr 'kws\.\.\.' base stdlib test | wc -l
      77
grep -owr 'kw\.\.\.' base stdlib test | wc -l 
     160
```

Most of this pr comes from the command 
```
grep -rlw 'kws\.\.\.' base stdlib/Sockets stdlib/Test stdlib/Markdown stdlib/REPL stdlib/InteractiveUtils/ stdlib/LinearAlgebra/ stdlib/Logging/ test | xargs sed -I '' 's/kws\.\.\./kw.../'
```
I only dealt with stdlibs that are a part of the julia repo and contain the string `kws...`.