### PR TITLE
add partition specialization for Strings

### DIFF
--- a/base/strings/strings.jl
+++ b/base/strings/strings.jl
@@ -6,5 +6,7 @@ include("strings/unicode.jl")
 import .Unicode: textwidth, islowercase, isuppercase, isletter, isdigit, isnumeric, iscntrl, ispunct,
     isspace, isprint, isxdigit, lowercase, uppercase, titlecase, lowercasefirst, uppercasefirst
 
+import .Iterators: PartitionIterator
+
 include("strings/util.jl")
 include("strings/io.jl")

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -543,6 +543,15 @@ function iterate(iter::SplitIterator, (i, k, n)=(firstindex(iter.str), firstinde
     @inbounds SubString(iter.str, i), (ncodeunits(iter.str) + 2, k, n + 1)
 end
 
+# Specialization for partition(s,n) to return a SubString
+eltype(::Type{PartitionIterator{T}}) where {T<:AbstractString} = SubString{T}
+
+function iterate(itr::PartitionIterator{<:AbstractString}, state = firstindex(itr.c))
+    state > ncodeunits(itr.c) && return nothing
+    r = min(nextind(itr.c, state, itr.n - 1), lastindex(itr.c))
+    return SubString(itr.c, state, r), nextind(itr.c, r)
+end
+
 eachsplit(str::T, splitter; limit::Integer=0, keepempty::Bool=true) where {T<:AbstractString} =
     SplitIterator(str, splitter, limit, keepempty)
 

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -91,6 +91,26 @@ end
     @test rstrip("ello", ['e','o']) == "ell"
 end
 
+@testset "partition" begin
+    # AbstractString to partition into SubString
+    let v=collect(Iterators.partition("foobars",1))
+    @test v==SubString{String}["f","o","o","b","a","r","s"]
+    end
+
+    let v=collect(Iterators.partition("foobars",2))
+    @test v==SubString{String}["fo","ob","ar","s"]
+    end
+
+    for n in [7,8]
+        @test collect(Iterators.partition("foobars",n))[1]=="foobars"
+    end
+
+    # HOWEVER enumerate explicitly slices String "atoms" so `Chars` are returned
+    let v=collect(Iterators.partition(enumerate("foobars"),1))
+        @test v==Vector{Tuple{Int64, Char}}[[(1, 'f')],[(2, 'o')],[(3, 'o')],[(4, 'b')],[(5, 'a')],[(6, 'r')], [(7, 's')]]
+    end
+end
+
 @testset "rsplit/split" begin
     @test split("foo,bar,baz", 'x') == ["foo,bar,baz"]
     @test split("foo,bar,baz", ',') == ["foo","bar","baz"]


### PR DESCRIPTION
This PR fixes JuliaLang/julia#45768 #45768 
!!! code builds and relevant tests run without a problem but `testall` fails (more below - I believe it's not related to the PR)

**TL;DR** Proposal for partition(string,n) to return SubString (similar to how partition(array,n) returns views) 

**Existing behaviour:** partition of a string returns a vector of vectors of Chars
**Proposal:** partition of a string should return a vector of SubStrings

**Rationale:** 
- Follows the logic currently applied to AbstractVectors where `partition()` of a vector returns views
- If the requested `partition()` is for n>1 then the return object is awkward
- This specialization speeds up string parsing as one skips the back and forth with Chars
- New behaviour does not conflict with any existing documentation (for Strings and Iterators)

**Implementation:**
- closely follows [Stevengj's proposal](https://github.com/JuliaLang/julia/issues/45768#issuecomment-1162258319) (with exception of variable naming to be consistent with the original `partition()` implementation)
- placed in strings/utils.jl where other specializations seem to reside 
- AbstractVector has also a specialized `IteratorEltype()` but it seems that default behaviour here would be sufficient, so I haven't added it (benefits were unclear to me as per [related post](https://stackoverflow.com/questions/47439004/why-do-we-need-iteratoreltype))

**Tests:** 
- Mimics the tests for arrays (string "foobars", tests n=1,2,7,8 to validate various edge cases)
- I have added a test for `partition(enumerate(string,n))` to communicate difference to default behaviour (it will return vector of chars) - more below!
- relevant tests pass but `testall` fails for anything related to `SparseArrays`. I cannot even import it (using...) and it is the same when I use the latest master branch version - maybe it's related to my M1 ARM architecture? 

**Edge cases / breaking changes:**
- ? There could (theoretically) be users who used the original behaviour to extract Chars from a string by `collect(partition("foo",1))`, but that's unlikely as simple `collect("foo")` would suffice
- If someone was using the previous behaviour and then manually converting to String, this PR would have no effect on them (mere duplication)
- ! `collect(partition(enumerate("foo")))` will NOT return a vector of SubStrings but it will return a vector of vectors of tuples of Int and Char. I believe that should be expected given that enumerate works with atomic elements (eg, Chars in case of a String). This would be consistent with behaviour for AbstractVectors, where the same operation would similarly return a Vector of tuples of Int and Number (not a view anymore which is the partition default)
- Separately, I have tested it for some other AbstractString subtypes (InlineStrings) - can you think of any type where the new behaviour would be problematic?
	

**References:**
- The original [Discourse question](https://discourse.julialang.org/t/efficient-way-to-split-string-at-specific-index/83115)
- [Github issue](https://github.com/JuliaLang/julia/issues/45768)

