### PR TITLE
Darwin: use libgcc_s version 1.1 on all targets

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1473,11 +1473,7 @@ LIBGCC_NAME := libgcc_s_seh-1.$(SHLIB_EXT)
 endif
 endif
 ifeq ($(OS),Darwin)
-ifeq ($(ARCH),aarch64)
 LIBGCC_NAME := libgcc_s.1.1.$(SHLIB_EXT)
-else
-LIBGCC_NAME := libgcc_s.1.$(SHLIB_EXT)
-endif
 endif
 ifneq ($(findstring $(OS),Linux FreeBSD),)
 LIBGCC_NAME := libgcc_s.$(SHLIB_EXT).1

--- a/base/Makefile
+++ b/base/Makefile
@@ -235,10 +235,8 @@ else ifneq ($(USE_SYSTEM_OPENLIBM),0)
 $(eval $(call symlink_system_library,OPENLIBM,$(LIBMNAME)))
 endif
 
-ifeq ($(APPLE_ARCH),arm64)
+ifeq ($(OS), Darwin)
 $(eval $(call symlink_system_library,CSL,libgcc_s,1.1))
-else
-$(eval $(call symlink_system_library,CSL,libgcc_s,1))
 endif
 ifneq (,$(LIBGFORTRAN_VERSION))
 $(eval $(call symlink_system_library,CSL,libgfortran,$(LIBGFORTRAN_VERSION)))

--- a/deps/csl.mk
+++ b/deps/csl.mk
@@ -76,7 +76,7 @@ else
 $(eval $(call copy_csl,$(call versioned_libname,libgcc_s_seh,1)))
 endif
 else
-ifeq ($(APPLE_ARCH),arm64)
+ifeq ($(OS), Darwin)
 $(eval $(call copy_csl,$(call versioned_libname,libgcc_s,1.1)))
 else
 $(eval $(call copy_csl,$(call versioned_libname,libgcc_s,1)))


### PR DESCRIPTION
The libgcc support shared library on modern GCC versions (11 and later) is called `libgcc_s.1.1.dylib` on all Darwin platforms. While a `libgcc_s.1.dylib` is still provided for backward compatibility on Intel Darwin, it is not recommended to use it.

On aarch64-darwin, `libgcc_s.1.dylib` is not provided at all, which is why this was special-cased in the build system. But actually, linking against `libgcc_s.1.1.dylib` in all cases on Darwin is the right way to go.