### PR TITLE
flisp: Fix memory leaks

### DIFF
--- a/src/flisp/cvalues.c
+++ b/src/flisp/cvalues.c
@@ -108,7 +108,7 @@ static value_t cprim(fl_context_t *fl_ctx, fltype_t *type, size_t sz)
     return tagptr(pcp, TAG_CPRIM);
 }
 
-value_t _cvalue(fl_context_t *fl_ctx, fltype_t *type, size_t sz, int may_finalize)
+static value_t _cvalue(fl_context_t *fl_ctx, fltype_t *type, size_t sz, int may_finalize)
 {
     cvalue_t *pcv;
     int str=0;

--- a/src/flisp/cvalues.c
+++ b/src/flisp/cvalues.c
@@ -108,7 +108,7 @@ static value_t cprim(fl_context_t *fl_ctx, fltype_t *type, size_t sz)
     return tagptr(pcp, TAG_CPRIM);
 }
 
-value_t cvalue(fl_context_t *fl_ctx, fltype_t *type, size_t sz)
+value_t _cvalue(fl_context_t *fl_ctx, fltype_t *type, size_t sz, int may_finalize)
 {
     cvalue_t *pcv;
     int str=0;
@@ -127,7 +127,7 @@ value_t cvalue(fl_context_t *fl_ctx, fltype_t *type, size_t sz)
         pcv = (cvalue_t*)alloc_words(fl_ctx, nw);
         pcv->type = type;
         pcv->data = &pcv->_space[0];
-        if (type->vtable != NULL && type->vtable->finalize != NULL)
+        if (may_finalize && type->vtable != NULL && type->vtable->finalize != NULL)
             add_finalizer(fl_ctx, pcv);
     }
     else {
@@ -146,6 +146,16 @@ value_t cvalue(fl_context_t *fl_ctx, fltype_t *type, size_t sz)
     }
     pcv->len = sz;
     return tagptr(pcv, TAG_CVALUE);
+}
+
+value_t cvalue(fl_context_t *fl_ctx, fltype_t *type, size_t sz)
+{
+    return _cvalue(fl_ctx, type, sz, 1);
+}
+
+value_t cvalue_no_finalizer(fl_context_t *fl_ctx, fltype_t *type, size_t sz)
+{
+    return _cvalue(fl_ctx, type, sz, 0);
 }
 
 value_t cvalue_from_data(fl_context_t *fl_ctx, fltype_t *type, void *data, size_t sz)

--- a/src/flisp/flisp.h
+++ b/src/flisp/flisp.h
@@ -328,6 +328,7 @@ typedef float    fl_float_t;
 typedef value_t (*builtin_t)(fl_context_t*, value_t*, uint32_t);
 
 value_t cvalue(fl_context_t *fl_ctx, fltype_t *type, size_t sz) JL_NOTSAFEPOINT;
+value_t cvalue_no_finalizer(fl_context_t *fl_ctx, fltype_t *type, size_t sz) JL_NOTSAFEPOINT;
 void add_finalizer(fl_context_t *fl_ctx, cvalue_t *cv);
 void cv_autorelease(fl_context_t *fl_ctx, cvalue_t *cv);
 void cv_pin(fl_context_t *fl_ctx, cvalue_t *cv);


### PR DESCRIPTION
There's two independent issues here:

1. The table allocator assumes that small tables will be stored inline
   and do not need a finalizer. This is mostly true, except that hash collisions
   can cause premature growing of the inline table, so even for relatively small
   tables, we need to validate that the storage was not allocated out-of-line.

2. It is unsafe to clear the vtable finalizer pointer during the table allocation
   to supress the `add_finalizer` call. This is because the allocation of the table
   object itself may trigger GC of a different table, and without the finalizer set
   in the vtable, freeing of that table's memory space would get skipped.