### PR TITLE
[DO NOT MERGE] Delete the `Base.Threads.nthreads` function

### DIFF
--- a/base/partr.jl
+++ b/base/partr.jl
@@ -2,7 +2,7 @@
 
 module Partr
 
-using ..Threads: SpinLock, nthreads, threadid
+using ..Threads: SpinLock, threadid
 
 # a task minheap
 mutable struct taskheap

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -12,35 +12,6 @@ ID `1`.
 threadid() = Int(ccall(:jl_threadid, Int16, ())+1)
 
 """
-    Threads.nthreads([:default|:interactive]) -> Int
-
-Get the number of threads (across all thread pools or within the specified
-thread pool) available to Julia. The number of threads across all thread
-pools is the inclusive upper bound on [`threadid()`](@ref).
-
-See also: `BLAS.get_num_threads` and `BLAS.set_num_threads` in the
-[`LinearAlgebra`](@ref man-linalg) standard library, and `nprocs()` in the
-[`Distributed`](@ref man-distributed) standard library.
-"""
-function nthreads end
-
-nthreads() = Int(unsafe_load(cglobal(:jl_n_threads, Cint)))
-function nthreads(pool::Symbol)
-    if pool === :default
-        tpid = Int8(0)
-    elseif pool === :interactive
-        tpid = Int8(1)
-    else
-        error("invalid threadpool specified")
-    end
-    return _nthreads_in_pool(tpid)
-end
-function _nthreads_in_pool(tpid::Int8)
-    p = unsafe_load(cglobal(:jl_n_threads_per_pool, Ptr{Cint}))
-    return Int(unsafe_load(p, tpid + 1))
-end
-
-"""
     Threads.threadpool(tid = threadid()) -> Symbol
 
 Returns the specified thread's threadpool; either `:default` or `:interactive`.

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -1,9 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-if Threads.nthreads() != 1
-    @warn "Running this file with multiple Julia threads may lead to a build error" Threads.nthreads()
-end
-
 if Base.isempty(Base.ARGS) || Base.ARGS[1] !== "0"
 Sys.__init_build()
 # Prevent this from being put into the Main namespace


### PR DESCRIPTION
The only purpose of this PR is to do a PkgEval run.