### PR TITLE
Work around dlopen not working properly under sanitizer instrumentation

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -4,6 +4,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#ifdef __GLIBC__
+#include <link.h>
+#endif
 
 #include "platform.h"
 #include "julia.h"
@@ -97,9 +100,62 @@ static void win32_formatmessage(DWORD code, char *reason, int len) JL_NOTSAFEPOI
 }
 #endif
 
+#if defined(_COMPILER_MSAN_ENABLED_) || defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_)
+struct link_map;
+typedef void* (dlopen_prototype)(const char* filename, int flags);
+
+/* This function is copied from the memory sanitizer runtime.
+   Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+   See https://llvm.org/LICENSE.txt for license information.
+   SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+*/
+static inline uintptr_t RoundUpTo(uintptr_t size, uintptr_t boundary) {
+  return (size + boundary - 1) & ~(boundary - 1);
+}
+static inline uintptr_t RoundDownTo(uintptr_t x, uintptr_t boundary) {
+  return x & ~(boundary - 1);
+}
+void ForEachMappedRegion(struct link_map *map, void (*cb)(const void *, uintptr_t)) {
+#if !defined(_OS_FREEBSD_)
+  typedef ElfW(Phdr) Elf_Phdr;
+  typedef ElfW(Ehdr) Elf_Ehdr;
+#endif
+  char *base = (char *)map->l_addr;
+  Elf_Ehdr *ehdr = (Elf_Ehdr *)base;
+  char *phdrs = base + ehdr->e_phoff;
+  char *phdrs_end = phdrs + ehdr->e_phnum * ehdr->e_phentsize;
+
+  // Find the segment with the minimum base so we can "relocate" the p_vaddr
+  // fields.  Typically ET_DYN objects (DSOs) have base of zero and ET_EXEC
+  // objects have a non-zero base.
+  uintptr_t preferred_base = (uintptr_t)-1;
+  for (char *iter = phdrs; iter != phdrs_end; iter += ehdr->e_phentsize) {
+    Elf_Phdr *phdr = (Elf_Phdr *)iter;
+    if (phdr->p_type == PT_LOAD && preferred_base > (uintptr_t)phdr->p_vaddr)
+      preferred_base = (uintptr_t)phdr->p_vaddr;
+  }
+
+  // Compute the delta from the real base to get a relocation delta.
+  intptr_t delta = (uintptr_t)base - preferred_base;
+  // Now we can figure out what the loader really mapped.
+  for (char *iter = phdrs; iter != phdrs_end; iter += ehdr->e_phentsize) {
+    Elf_Phdr *phdr = (Elf_Phdr *)iter;
+    if (phdr->p_type == PT_LOAD) {
+      uintptr_t seg_start = phdr->p_vaddr + delta;
+      uintptr_t seg_end = seg_start + phdr->p_memsz;
+      // None of these values are aligned.  We consider the ragged edges of the
+      // load command as defined, since they are mapped from the file.
+      seg_start = RoundDownTo(seg_start, jl_page_size);
+      seg_end = RoundUpTo(seg_end, jl_page_size);
+      cb((void *)seg_start, seg_end - seg_start);
+    }
+  }
+}
+#endif
+
+#if defined(_OS_WINDOWS_)
 JL_DLLEXPORT void *jl_dlopen(const char *filename, unsigned flags) JL_NOTSAFEPOINT
 {
-#if defined(_OS_WINDOWS_)
     size_t len = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
     if (!len) return NULL;
     WCHAR *wfilename = (WCHAR*)alloca(len * sizeof(WCHAR));
@@ -108,8 +164,32 @@ JL_DLLEXPORT void *jl_dlopen(const char *filename, unsigned flags) JL_NOTSAFEPOI
     if (lib)
         needsSymRefreshModuleList = 1;
     return lib;
+}
 #else
-    return dlopen(filename,
+JL_DLLEXPORT JL_NO_SANITIZE void *jl_dlopen(const char *filename, unsigned flags) JL_NOTSAFEPOINT
+{
+    /* The sanitizers break RUNPATH use in dlopen for annoying reasons that are
+       are hard to fix. Specifically, libc will use the return address of the
+       caller to determine certain paths and flags that affect .so location lookup.
+       To work around this, we need to avoid using the sanitizer's dlopen interposition,
+       instead using the real dlopen directly from the current shared library.
+       Of course, this does mean that we need to manually perform the work that
+       the sanitizers would otherwise do. */
+#if (defined(_COMPILER_MSAN_ENABLED_) || defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_TSAN_ENABLED_)) && __GLIBC__
+    static dlopen_prototype *dlopen = NULL;
+    if (!dlopen) {
+        dlopen = (dlopen_prototype*)dlsym(RTLD_NEXT, "dlopen");
+        if (!dlopen)
+            return NULL;
+        void *libdl_handle = dlopen("libdl.so", RTLD_NOW | RTLD_NOLOAD);
+        dlopen = (dlopen_prototype*)dlsym(libdl_handle, "dlopen");
+        dlclose(libdl_handle);
+        assert(dlopen);
+    }
+    // The real interceptors check the validty of the string here, but let's
+    // just skip that for the time being.
+#endif
+    void *hnd = dlopen(filename,
                   (flags & JL_RTLD_NOW ? RTLD_NOW : RTLD_LAZY)
                   | JL_RTLD(flags, LOCAL)
                   | JL_RTLD(flags, GLOBAL)
@@ -126,8 +206,15 @@ JL_DLLEXPORT void *jl_dlopen(const char *filename, unsigned flags) JL_NOTSAFEPOI
                   | JL_RTLD(flags, FIRST)
 #endif
                   );
+#if defined(_COMPILER_MSAN_ENABLED_) && defined(__GLIBC__)
+    link_map *map = (link_map*)handle;
+    if (filename && map)
+      ForEachMappedRegion(map, __msan_unpoison);
 #endif
+    return hnd;
 }
+#endif
+
 
 JL_DLLEXPORT int jl_dlclose(void *handle) JL_NOTSAFEPOINT
 {

--- a/src/support/platform.h
+++ b/src/support/platform.h
@@ -43,24 +43,37 @@
 #error Unsupported compiler
 #endif
 
+
+#define JL_NO_ASAN
+#define JL_NO_MSAN
+#define JL_NO_TSAN
 #if defined(__has_feature) // Clang flavor
 #if __has_feature(address_sanitizer)
 #define _COMPILER_ASAN_ENABLED_
+#undef JL_NO_ASAN
+#define JL_NO_ASAN __attribute__((no_sanitize("address")))
 #endif
 #if __has_feature(memory_sanitizer)
 #define _COMPILER_MSAN_ENABLED_
+#undef JL_NO_MSAN
+#define JL_NO_MSAN __attribute__((no_sanitize("mempry")))
 #endif
 #if __has_feature(thread_sanitizer)
 #if __clang_major__ < 11
 #error Thread sanitizer runtime libraries in clang < 11 leak memory and cannot be used
 #endif
 #define _COMPILER_TSAN_ENABLED_
+#undef JL_NO_TSAN
+#define JL_NO_TSAN __attribute__((no_sanitize("thread")))
 #endif
 #else // GCC flavor
 #if defined(__SANITIZE_ADDRESS__)
 #define _COMPILER_ASAN_ENABLED_
+#undef JL_NO_ASAN
+#define JL_NO_ASAN __attribute__((no_sanitize("address")))
 #endif
 #endif // __has_feature
+#define JL_NO_SANITIZE JL_NO_ASAN JL_NO_MSAN JL_NO_TSAN
 
 /*******************************************************************************
 *                               OS                                             *


### PR DESCRIPTION
`dlopen` has a mis-feature where it looks at the return address to determine
the calling object to look at it's RUNPATH. Because asan intercepts `dlopen`,
the calling object check finds asan rather than julia, causing an incorrect
RUNPATH (and other flags to be used). Arguably, this is mostly a libc problem,
because there isn't really a way to directly specify the resolution scope.
I have sent a proposal to libc-coord [1] to fix this, but of course, we can't
wait for that to percolate down to us. Instead, this takes advantage of the
fact that almost all of our dlopen calls go through a single entrypoint in
jl_dlopen, so we can insert additional logic here to make this work. This
doesn't catch uses of `dlopen` in jlls (which is a problem for things like
plugin loading in various jlls), but it at least makes base julia work.
We can punt the jll question to another day - either with a patched libc
in PkgEval or by patching the jll source with an analogous patch.

Regardless, with this, Julia bootstraps properly under asan, without any
special LD_LIBRARY_PATH hacks.

[1] https://www.openwall.com/lists/libc-coord/2022/08/04/1