### PR TITLE
Make the zero-argument `Base.task_local_storage()` method part of the public API by adding it to the manual

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -258,7 +258,13 @@ end
 
 task_result(t::Task) = t.result
 
+"""
+    task_local_storage()::AbstractDict
+
+Returns the current task's task-local storage in the form of an `AbstractDict`.
+"""
 task_local_storage() = get_task_tls(current_task())
+
 function get_task_tls(t::Task)
     if t.storage === nothing
         t.storage = IdDict()

--- a/doc/src/base/parallel.md
+++ b/doc/src/base/parallel.md
@@ -10,6 +10,7 @@ Base.current_task
 Base.istaskdone
 Base.istaskstarted
 Base.istaskfailed
+Base.task_local_storage()
 Base.task_local_storage(::Any)
 Base.task_local_storage(::Any, ::Any)
 Base.task_local_storage(::Function, ::Any, ::Any)


### PR DESCRIPTION
Alternative to #46259