### PR TITLE
Forward keyword arguments when using @deprecate without a signature

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -36,9 +36,18 @@ julia> @deprecate old(x) new(x) false
 old (generic function with 1 method)
 ```
 
-Calls to `@deprecate` without explicit type-annotations will define deprecated methods
-accepting arguments of type `Any`. To restrict deprecation to a specific signature, annotate
-the arguments of `old`. For example,
+Calls to `@deprecate` without explicit type-annotations will define
+deprecated methods accepting any number of positional and keyword
+arguments of type `Any`.
+
+!!! compat "Julia 1.9"
+    Keyword arguments are forwarded when there is no explicit type
+    annotation as of Julia 1.9. For older versions, you can manually
+    forward positional and keyword arguments by doing `@deprecate
+    old(args...; kwargs...) new(args...; kwargs...)`.
+
+To restrict deprecation to a specific signature, annotate the
+arguments of `old`. For example,
 ```jldoctest; filter = r"@ .*"
 julia> new(x::Int) = x;
 
@@ -101,10 +110,10 @@ macro deprecate(old, new, export_old=true)
         end
         Expr(:toplevel,
             export_old ? Expr(:export, esc(old)) : nothing,
-            :(function $(esc(old))(args...)
+            :(function $(esc(old))(args...; kwargs...)
                   $meta
                   depwarn($"`$old` is deprecated, use `$new` instead.", Core.Typeof($(esc(old))).name.mt.name)
-                  $(esc(new))(args...)
+                  $(esc(new))(args...; kwargs...)
               end))
     end
 end

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -37,9 +37,9 @@ module DeprecationTests # to test @deprecate
     Base.@deprecate_moved foo1234 "Foo"
     Base.@deprecate_moved bar "Bar" false
 
-    # test that positional arguments are forwarded when there is no
-    # explicit type annotation
-    new_return_args(args...) = args
+    # test that positional and keyword arguments are forwarded when
+    # there is no explicit type annotation
+    new_return_args(args...; kwargs...) = args, NamedTuple(kwargs)
     @deprecate old_return_args new_return_args
 end # module
 module Foo1234
@@ -114,9 +114,10 @@ begin # @deprecate
     end
     @test_deprecated "something" f21972()
 
-    # test that positional arguments are forwarded when there is no
-    # explicit type annotation
-    @test DeprecationTests.old_return_args(1, 2, 3) == (1, 2, 3)
+    # test that positional and keyword arguments are forwarded when
+    # there is no explicit type annotation
+    @test DeprecationTests.old_return_args(1, 2, 3) == ((1, 2, 3),(;))
+    @test DeprecationTests.old_return_args(1, 2, 3; a = 4, b = 5) == ((1, 2, 3), (a = 4, b = 5))
 end
 
 f24658() = depwarn24658()

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -36,6 +36,11 @@ module DeprecationTests # to test @deprecate
     # test that @deprecate_moved can be overridden by an import
     Base.@deprecate_moved foo1234 "Foo"
     Base.@deprecate_moved bar "Bar" false
+
+    # test that positional arguments are forwarded when there is no
+    # explicit type annotation
+    new_return_args(args...) = args
+    @deprecate old_return_args new_return_args
 end # module
 module Foo1234
     export foo1234
@@ -108,6 +113,10 @@ begin # @deprecate
         T21972()
     end
     @test_deprecated "something" f21972()
+
+    # test that positional arguments are forwarded when there is no
+    # explicit type annotation
+    @test DeprecationTests.old_return_args(1, 2, 3) == (1, 2, 3)
 end
 
 f24658() = depwarn24658()


### PR DESCRIPTION
When using the `@deprecate` macro without specifying the deprecated
signature, a method is created for the old name that accepts a
variable number of positional arguments. This PR makes the created
method also accept a variable number of keyword arguments.

This came up with a recent issue with with Interpolations.jl: JuliaMath/Interpolations.jl#507