### PR TITLE
Add structured matrix notes to `ldiv!`/`rdiv!` docstring

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -281,6 +281,10 @@ The reason for this is that factorization itself is both expensive and typically
 and performance-critical situations requiring `ldiv!` usually also require fine-grained
 control over the factorization of `A`.
 
+!!! note
+    Certain structured matrix types, such as `Diagonal` and `UpperTriangular`, are permitted, as
+    these are already in a factorized form
+
 # Examples
 ```jldoctest
 julia> A = [1 2.2 4; 3.1 0.2 3; 4 1 2];
@@ -317,6 +321,10 @@ The reason for this is that factorization itself is both expensive and typically
 (although it can also be done in-place via, e.g., [`lu!`](@ref)),
 and performance-critical situations requiring `ldiv!` usually also require fine-grained
 control over the factorization of `A`.
+
+!!! note
+    Certain structured matrix types, such as `Diagonal` and `UpperTriangular`, are permitted, as
+    these are already in a factorized form
 
 # Examples
 ```jldoctest
@@ -355,6 +363,10 @@ The reason for this is that factorization itself is both expensive and typically
 (although it can also be done in-place via, e.g., [`lu!`](@ref)),
 and performance-critical situations requiring `rdiv!` usually also require fine-grained
 control over the factorization of `B`.
+
+!!! note
+    Certain structured matrix types, such as `Diagonal` and `UpperTriangular`, are permitted, as
+    these are already in a factorized form
 """
 rdiv!(A, B)
 


### PR DESCRIPTION
Certain structured matrix types are actually permitted as arguments to `ldiv!` and `rdiv!` despite the admonition against using matrices as arguments, so it's best to be clear about this.
E.g.
```julia
julia> U = UpperTriangular(rand(2,2))
2×2 UpperTriangular{Float64, Matrix{Float64}}:
 0.303616  0.129732
  ⋅        0.269387

julia> ldiv!(U, rand(2))
2-element Vector{Float64}:
 1.6539496185029805
 0.061592851259199104
```