### PR TITLE
Quiet some noisy tests

### DIFF
--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -157,7 +157,7 @@ begin # tuple indexed by float deprecation
     @test_throws Exception @test_warn r"`getindex(t::Tuple, i::Real)` is deprecated" getindex((1,2), -1.0)
 end
 
-@testset "@deprecated error message" begin
+begin #@deprecated error message
     @test_throws(
         "if the third `export_old` argument is not specified or `true`,",
         @eval @deprecate M.f() g()

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -811,8 +811,10 @@ end
         try
             push!(LOAD_PATH, tmp)
             write(joinpath(tmp, "BadCase.jl"), "module badcase end")
-            @test_throws ErrorException("package `BadCase` did not define the expected module `BadCase`, \
-                                        check for typos in package module name") (@eval using BadCase)
+            @test_logs (:warn, r"The call to compilecache failed.*") match_mode=:any begin
+                @test_throws ErrorException("package `BadCase` did not define the expected module `BadCase`, \
+                    check for typos in package module name") (@eval using BadCase)
+            end
         finally
             copy!(LOAD_PATH, old_loadpath)
         end


### PR DESCRIPTION
Quiets:
```
  | From worker 13:	┌ Warning: The call to compilecache failed to create a usable precompiled cache file for BadCase [top-level]
  | From worker 13:	│   exception = Required dependency BadCase [top-level] failed to load from a cache file.
  | From worker 13:	└ @ Base loading.jl:1409
  | From worker 13:	┌ Warning: Replacing module `badcase`
  | From worker 13:	└ @ Base loading.jl:1291
```
```
   From worker 4:	Test Summary:             | Pass  Total  Time
   From worker 4:	@deprecated error message |    3      3  0.7s
```