### PR TITLE
Reintroduce SparseArrays in the system image

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -50,6 +50,7 @@ let
         :InteractiveUtils,
         :LibGit2,
         :Profile,
+        :SparseArrays,
         :UUIDs,
 
         # 3-depth packages

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -364,7 +364,7 @@ precompile_test_harness(false) do dir
                  :LazyArtifacts, :LibCURL, :LibCURL_jll, :LibGit2, :Libdl, :LinearAlgebra,
                  :Logging, :Markdown, :Mmap, :MozillaCACerts_jll, :NetworkOptions, :OpenBLAS_jll, :Pkg, :Printf,
                  :Profile, :p7zip_jll, :REPL, :Random, :SHA, :Serialization, :SharedArrays, :Sockets,
-                 :TOML, :Tar, :Test, :UUIDs, :Unicode,
+                 :SparseArrays, :TOML, :Tar, :Test, :UUIDs, :Unicode,
                  :nghttp2_jll]
             ),
         )


### PR DESCRIPTION
Reverting https://github.com/JuliaLang/julia/pull/44247 in order to avoid the impact on startup time for several packages. The impact is about 2 seconds, but it affects several packages that do not always need SparseArrays, but are forced to have that dependency due to lack of conditional dependencies, which we hope to have in 1.10.

We do not need to reintroduce `SuiteSparse` separately since it was reintegrated into SparseArrays.jl in order to maintain backwards compatibility.

cc @Wimmerer 