### PR TITLE
removed the function as per SocketsIssues

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -199,64 +199,6 @@ end
 isopen(c::Channel) = ((@atomic :monotonic c.state) === :open)
 
 """
-    bind(chnl::Channel, task::Task)
-
-Associate the lifetime of `chnl` with a task.
-`Channel` `chnl` is automatically closed when the task terminates.
-Any uncaught exception in the task is propagated to all waiters on `chnl`.
-
-The `chnl` object can be explicitly closed independent of task termination.
-Terminating tasks have no effect on already closed `Channel` objects.
-
-When a channel is bound to multiple tasks, the first task to terminate will
-close the channel. When multiple channels are bound to the same task,
-termination of the task will close all of the bound channels.
-
-# Examples
-```jldoctest
-julia> c = Channel(0);
-
-julia> task = @async foreach(i->put!(c, i), 1:4);
-
-julia> bind(c,task);
-
-julia> for i in c
-           @show i
-       end;
-i = 1
-i = 2
-i = 3
-i = 4
-
-julia> isopen(c)
-false
-```
-
-```jldoctest
-julia> c = Channel(0);
-
-julia> task = @async (put!(c, 1); error("foo"));
-
-julia> bind(c, task);
-
-julia> take!(c)
-1
-
-julia> put!(c, 1);
-ERROR: TaskFailedException
-Stacktrace:
-[...]
-    nested task error: foo
-[...]
-```
-"""
-function bind(c::Channel, task::Task)
-    T = Task(() -> close_chnl_on_taskdone(task, c))
-    _wait2(task, T)
-    return c
-end
-
-"""
     channeled_tasks(n::Int, funcs...; ctypes=fill(Any,n), csizes=fill(0,n))
 
 A convenience method to create `n` channels and bind them to tasks started


### PR DESCRIPTION
There is an additional method in [Sockets](https://docs.julialang.org/en/v1/stdlib/Sockets/#Base.bind)https://docs.julialang.org/en/v1/stdlib/Sockets/#Base.bind) that belongs to [Tasks](https://docs.julialang.org/en/v1/base/parallel).

It is already there, but it should be removed from Sockets.
![changesfirst](https://user-images.githubusercontent.com/78780005/183412835-ac77a967-8cd0-450d-ae4a-c6d0ea397c17.jpg)

