### PR TITLE
Update README clarify build from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,26 +88,25 @@ Then, acquire the source code by cloning the git repository:
 
     git clone https://github.com/JuliaLang/julia.git
 
-By default you will be building the latest unstable version of
+and then use the command prompt to change into the resulting julia directory. By default you will be building the latest unstable version of
 Julia. However, most users should use the [most recent stable version](https://github.com/JuliaLang/julia/releases)
-of Julia. You can get this version by changing to the Julia directory
-and running:
+of Julia. You can get this version by running:
 
     git checkout v1.7.3
 
-Now run `make` to build the `julia` executable.
+To build the `julia` executable, run `make` from within the julia directory.
 
 Building Julia requires 2GiB of disk space and approximately 4GiB of virtual memory.
 
 **Note:** The build process will fail badly if any of the build directory's parent directories have spaces or other shell meta-characters such as `$` or `:` in their names (this is due to a limitation in GNU make).
 
-Once it is built, you can run the `julia` executable after you enter your julia directory and run
+Once it is built, you can run the `julia` executable. From within the julia directory, run
 
     ./julia
 
 Your first test of Julia determines whether your build is working
-properly. From the UNIX/Windows command prompt inside the `julia`
-source directory, type `make testall`. You should see output that
+properly. From the julia
+directory, type `make testall`. You should see output that
 lists a series of running tests; if they complete without error, you
 should be in good shape to start using Julia.
 


### PR DESCRIPTION
I fixed a few minor ambiguities in README:
1.  Added explicit instruction to change into julia directory. This was previously conflated with checkout of latest release, but clearer to separate the two, since everyone needs to be in that directory regardless of whether they did a checkout.
2. Changed "from your Julia directory" to "change into the resulting julia directory" to make it clearer what directory is referred to. Changed upper- to lower-case to be consistent with subsequent references in README. 
3.  Rewrote instruction for `make` so that it assumes/clarifies user should already be in julia directory.
4.  Same for `./julia` because user should already be in directory. 
5. Removed "source" from "the julia source directory" because `make testall` should be executed from the same julia directory, and should not be confused with `src`.
I have followed my updated instructions and verified that they work for myself.