### PR TITLE
improve inference in `afoldl`

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -530,9 +530,9 @@ const ⊽ = nor
 afoldl(op, a) = a
 function afoldl(op, a, bs...)
     l = length(bs)
-    i =  0; y = a;            l == i && return y
+    i =  0; l == i && return a
     #@nexprs 31 i -> (y = op(y, bs[i]); l == i && return y)
-    i =  1; y = op(y, bs[i]); l == i && return y
+    i =  1; y = op(a, bs[i]); l == i && return y
     i =  2; y = op(y, bs[i]); l == i && return y
     i =  3; y = op(y, bs[i]); l == i && return y
     i =  4; y = op(y, bs[i]); l == i && return y


### PR DESCRIPTION
This improves the type inference of the temporary variable `y`.

MWE, on master
```julia
julia> struct A end

julia> struct B end

julia> struct C end

julia> Base.:(+)(::A, ::B) = C()

julia> @code_warntype Base.afoldl(+, A(), B())
MethodInstance for Base.afoldl(::typeof(+), ::A, ::B)
  from afoldl(op, a, bs...) @ Base operators.jl:531
Arguments
  #self#::Core.Const(Base.afoldl)
  op::Core.Const(+)
  a::Core.Const(A())
  bs::Core.Const((B(),))
Locals
  @_5::Union{}
  y::Union{A, C}
  i@_7::Int64
  l::Int64
  i@_9::Union{}
Body::C
[...]
```
PR
```julia
julia> @code_warntype Base.afoldl(+, A(), B())
MethodInstance for Base.afoldl(::typeof(+), ::A, ::B)
  from afoldl(op, a, bs...) @ Base operators.jl:531
Arguments
  #self#::Core.Const(Base.afoldl)
  op::Core.Const(+)
  a::Core.Const(A())
  bs::Core.Const((B(),))
Locals
  @_5::Union{}
  y::C
  i@_7::Int64
  l::Int64
  i@_9::Union{}
Body::C
[...]
```