### PR TITLE
fix C struct definition of LineInfoNode

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -230,8 +230,8 @@ typedef struct _jl_line_info_node_t {
     struct _jl_module_t *module;
     jl_value_t *method;
     jl_sym_t *file;
-    intptr_t line;
-    intptr_t inlined_at;
+    int32_t line;
+    int32_t inlined_at;
 } jl_line_info_node_t;
 
 // the following mirrors `struct EffectsOverride` in `base/compiler/effects.jl`


### PR DESCRIPTION
Fix regression introduced by #44548. Fix #45310.

Found via rr trace in https://buildkite.com/julialang/julia-master/builds/14475#01825f4d-8c0c-4f70-938c-cd1c8ee4d202, resulting in a compiler error test calling jlbacktrace, and dereferencing invalid memory, if the object happened not to be zero initialized. Otherwise, if the undefined memory was zero initialized, it would probably instead just be missing inlined frames.