### PR TITLE
Replace BUNDLE_DEBUG_LIBS with `make install JULIA_BUILD_MODE=debug`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,10 +176,11 @@ JL_TARGETS := julia-debug
 endif
 
 # private libraries, that are installed in $(prefix)/lib/julia
+JL_PRIVATE_LIBS-0 := libccalltest libllvmcalltest
 ifeq ($(JULIA_BUILD_MODE),release)
-JL_PRIVATE_LIBS-0 := libccalltest libllvmcalltest libjulia-internal libjulia-codegen
+JL_PRIVATE_LIBS-0 += libjulia-internal libjulia-codegen
 else ifeq ($(JULIA_BUILD_MODE),debug)
-JL_PRIVATE_LIBS-0 := libjulia-internal-debug libjulia-codegen-debug
+JL_PRIVATE_LIBS-0 += libjulia-internal-debug libjulia-codegen-debug
 endif
 ifeq ($(USE_GPL_LIBS), 1)
 JL_PRIVATE_LIBS-$(USE_SYSTEM_LIBSUITESPARSE) += libamd libbtf libcamd libccolamd libcholmod libcolamd libklu libldl librbio libspqr libsuitesparseconfig libumfpack

--- a/contrib/fixup-libstdc++.sh
+++ b/contrib/fixup-libstdc++.sh
@@ -11,7 +11,8 @@ fi
 libdir="$1"
 private_libdir="$2"
 
-if [ ! -f "$private_libdir/libjulia-internal.so" ]; then
+if [ ! -f "$private_libdir/libjulia-internal.so" ] && \
+   [ ! -f "$private_libdir/libjulia-internal-debug.so" ]; then
     echo "ERROR: Could not open $private_libdir/libjulia-internal.so" >&2
     exit 2
 fi
@@ -24,7 +25,11 @@ find_shlib ()
 }
 
 # Discover libstdc++ location and name
-LIBSTD=$(find_shlib "$private_libdir/libjulia-internal.so" "libstdc++.so")
+if [ -f "$private_libdir/libjulia-internal.so" ]; then
+    LIBSTD=$(find_shlib "$private_libdir/libjulia-internal.so" "libstdc++.so")
+elif [ -f "$private_libdir/libjulia-internal-debug.so" ]; then
+    LIBSTD=$(find_shlib "$private_libdir/libjulia-internal-debug.so" "libstdc++.so")
+fi
 LIBSTD_NAME=$(basename $LIBSTD)
 LIBSTD_DIR=$(dirname $LIBSTD)
 


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/46317. I don't think BUNDLE_DEBUG_LIBS was used, or even documented, and for PkgEval it makes more sense to pick one or the other (and it simplifies the Makefile). Currently mostly implemented using conditionals, but could be cleaned up. (using `$(JULIA_EXECUTABLE_$(JULIA_BUILD_MODE))`-like tricks).