### PR TITLE
Make jl_datatype_size reflect non-padded field size

### DIFF
--- a/test/atomics.jl
+++ b/test/atomics.jl
@@ -46,7 +46,7 @@ swap(x, y) = y
 let T1 = Refxy{NTuple{3,UInt8}},
     T2 = ARefxy{NTuple{3,UInt8}}
     @test sizeof(T1) == 6
-    @test sizeof(T2) == 8
+    @test sizeof(T2) == 7
     @test fieldoffset(T1, 1) == 0
     @test fieldoffset(T2, 1) == 0
     @test fieldoffset(T1, 2) == 3

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -540,10 +540,10 @@ let a = Core.Intrinsics.trunc_int(UInt24, 3),
     f(t) = t[2]
     @test f((a, true)) === true
     @test f((a, false)) === false
-    @test sizeof(Tuple{UInt24,Bool}) == 8
+    @test sizeof(Tuple{UInt24,Bool}) == 5
     @test sizeof(UInt24) == 3
     @test sizeof(Union{UInt8,UInt24}) == 3
-    @test sizeof(Base.RefValue{Union{UInt8,UInt24}}) == 8
+    @test sizeof(Base.RefValue{Union{UInt8,UInt24}}) == 5
 end
 
 # issue #39232

--- a/test/core.jl
+++ b/test/core.jl
@@ -6085,7 +6085,7 @@ let
     @test b.x === Int8(91)
     @test b.z === Int8(23)
     @test b.y === A23367((Int8(1), Int8(2), Int8(3), Int8(4), Int8(5), Int8(6), Int8(7)))
-    @test sizeof(b) == 12
+    @test sizeof(b) == 11
     @test A23367(Int8(1)).x === Int8(1)
     @test A23367(Int8(0)).x === Int8(0)
     @test A23367(Int16(1)).x === Int16(1)
@@ -6118,17 +6118,17 @@ struct UnionFieldInlineStruct
     y::Union{Float64, Missing}
 end
 
-@test sizeof(Vector{UnionFieldInlineStruct}(undef, 2)) == sizeof(UnionFieldInlineStruct) * 2
+@test sizeof(Vector{UnionFieldInlineStruct}(undef, 2)) >= sizeof(UnionFieldInlineStruct) * 2
 
 let x = UnionFieldInlineStruct(1, 3.14)
     AInlineUnion = [x for i = 1:10]
-    @test sizeof(AInlineUnion) == sizeof(UnionFieldInlineStruct) * 10
+    @test sizeof(AInlineUnion) >= sizeof(UnionFieldInlineStruct) * 10
     BInlineUnion = Vector{UnionFieldInlineStruct}(undef, 10)
     copyto!(BInlineUnion, AInlineUnion)
     @test AInlineUnion == BInlineUnion
     @test BInlineUnion[end] == x
     CInlineUnion = vcat(AInlineUnion, BInlineUnion)
-    @test sizeof(CInlineUnion) == sizeof(UnionFieldInlineStruct) * 20
+    @test sizeof(CInlineUnion) >= sizeof(UnionFieldInlineStruct) * 20
     @test CInlineUnion[end] == x
 end
 


### PR DESCRIPTION
Padding is then added when creating the struct layout, but otherwise
the memory layout should be unchanged. This is an alternative to
the proposal in #46260. LLVM size and julia size should now be
aligned.