### PR TITLE
Shrink typeinf lock to just newly_inferred

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -391,8 +391,10 @@ function cache_result!(interp::AbstractInterpreter, result::InferenceResult)
         code_cache(interp)[linfo] = CodeInstance(result, inferred_result, valid_worlds)
         if track_newly_inferred[]
             m = linfo.def
-            if isa(m, Method)
-                m.module != Core && push!(newly_inferred, linfo)
+            if isa(m, Method) && m.module != Core
+                ccall(:jl_typeinf_lock_begin, Cvoid, ())
+                push!(newly_inferred, linfo)
+                ccall(:jl_typeinf_lock_end, Cvoid, ())
             end
         end
     end
@@ -976,10 +978,10 @@ function typeinf_ircode(
     sparams::SimpleVector,
     optimize_until::Union{Integer,AbstractString,Nothing},
 )
-    ccall(:jl_typeinf_begin, Cvoid, ())
+    ccall(:jl_typeinf_timing_begin, Cvoid, ())
     frame = typeinf_frame(interp, method, atype, sparams, false)
     if frame === nothing
-        ccall(:jl_typeinf_end, Cvoid, ())
+        ccall(:jl_typeinf_timing_end, Cvoid, ())
         return nothing, Any
     end
     (; result) = frame
@@ -987,19 +989,19 @@ function typeinf_ircode(
     opt = OptimizationState(frame, opt_params, interp)
     ir = run_passes(opt.src, opt, result, optimize_until)
     rt = widenconst(ignorelimited(result.result))
-    ccall(:jl_typeinf_end, Cvoid, ())
+    ccall(:jl_typeinf_timing_end, Cvoid, ())
     return ir, rt
 end
 
 # compute an inferred frame
 function typeinf_frame(interp::AbstractInterpreter, method::Method, @nospecialize(atype), sparams::SimpleVector, run_optimizer::Bool)
     mi = specialize_method(method, atype, sparams)::MethodInstance
-    ccall(:jl_typeinf_begin, Cvoid, ())
+    ccall(:jl_typeinf_timing_begin, Cvoid, ())
     result = InferenceResult(mi)
     frame = InferenceState(result, run_optimizer ? :global : :no, interp)
     frame === nothing && return nothing
     typeinf(interp, frame)
-    ccall(:jl_typeinf_end, Cvoid, ())
+    ccall(:jl_typeinf_timing_end, Cvoid, ())
     return frame
 end
 
@@ -1007,13 +1009,13 @@ end
 function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance)
     method = mi.def::Method
     for i = 1:2 # test-and-lock-and-test
-        i == 2 && ccall(:jl_typeinf_begin, Cvoid, ())
+        i == 2 && ccall(:jl_typeinf_timing_begin, Cvoid, ())
         code = get(code_cache(interp), mi, nothing)
         if code isa CodeInstance
             # see if this code already exists in the cache
             inf = @atomic :monotonic code.inferred
             if use_const_api(code)
-                i == 2 && ccall(:jl_typeinf_end, Cvoid, ())
+                i == 2 && ccall(:jl_typeinf_timing_end, Cvoid, ())
                 tree = ccall(:jl_new_code_info_uninit, Ref{CodeInfo}, ())
                 rettype_const = code.rettype_const
                 tree.code = Any[ ReturnNode(quoted(rettype_const)) ]
@@ -1033,7 +1035,7 @@ function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance)
                 tree.max_world = code.max_world
                 return tree
             elseif isa(inf, CodeInfo)
-                i == 2 && ccall(:jl_typeinf_end, Cvoid, ())
+                i == 2 && ccall(:jl_typeinf_timing_end, Cvoid, ())
                 if !(inf.min_world == code.min_world &&
                      inf.max_world == code.max_world &&
                      inf.rettype === code.rettype)
@@ -1044,7 +1046,7 @@ function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance)
                 end
                 return inf
             elseif isa(inf, Vector{UInt8})
-                i == 2 && ccall(:jl_typeinf_end, Cvoid, ())
+                i == 2 && ccall(:jl_typeinf_timing_end, Cvoid, ())
                 inf = _uncompressed_ir(code, inf)
                 return inf
             end
@@ -1057,7 +1059,7 @@ function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance)
     frame = InferenceState(InferenceResult(mi), #=cache=#:global, interp)
     frame === nothing && return nothing
     typeinf(interp, frame)
-    ccall(:jl_typeinf_end, Cvoid, ())
+    ccall(:jl_typeinf_timing_end, Cvoid, ())
     frame.src.inferred || return nothing
     return frame.src
 end
@@ -1069,17 +1071,17 @@ function typeinf_type(interp::AbstractInterpreter, method::Method, @nospecialize
     end
     mi = specialize_method(method, atype, sparams)::MethodInstance
     for i = 1:2 # test-and-lock-and-test
-        i == 2 && ccall(:jl_typeinf_begin, Cvoid, ())
+        i == 2 && ccall(:jl_typeinf_timing_begin, Cvoid, ())
         code = get(code_cache(interp), mi, nothing)
         if code isa CodeInstance
             # see if this rettype already exists in the cache
-            i == 2 && ccall(:jl_typeinf_end, Cvoid, ())
+            i == 2 && ccall(:jl_typeinf_timing_end, Cvoid, ())
             return code.rettype
         end
     end
     result = InferenceResult(mi)
     typeinf(interp, result, :global)
-    ccall(:jl_typeinf_end, Cvoid, ())
+    ccall(:jl_typeinf_timing_end, Cvoid, ())
     result.result isa InferenceState && return nothing
     return widenconst(ignorelimited(result.result))
 end
@@ -1094,7 +1096,7 @@ function typeinf_ext_toplevel(interp::AbstractInterpreter, linfo::MethodInstance
         src = linfo.uninferred::CodeInfo
         if !src.inferred
             # toplevel lambda - infer directly
-            ccall(:jl_typeinf_begin, Cvoid, ())
+            ccall(:jl_typeinf_timing_begin, Cvoid, ())
             if !src.inferred
                 result = InferenceResult(linfo)
                 frame = InferenceState(result, src, #=cache=#:global, interp)
@@ -1102,7 +1104,7 @@ function typeinf_ext_toplevel(interp::AbstractInterpreter, linfo::MethodInstance
                 @assert frame.inferred # TODO: deal with this better
                 src = frame.src
             end
-            ccall(:jl_typeinf_end, Cvoid, ())
+            ccall(:jl_typeinf_timing_end, Cvoid, ())
         end
     end
     return src

--- a/doc/src/devdocs/locks.md
+++ b/doc/src/devdocs/locks.md
@@ -32,6 +32,7 @@ The following are definitely leaf locks (level 1), and must not try to acquire a
 >   * RLST_mutex
 >   * jl_locked_stream::mutex
 >   * debuginfo_asyncsafe
+>   * inference_timing_mutex
 >
 >     > flisp itself is already threadsafe, this lock only protects the `jl_ast_context_list_t` pool
 >     > likewise, the ResourcePool<?>::mutexes just protect the associated resource pool

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -479,8 +479,10 @@
     XX(jl_tty_set_mode) \
     XX(jl_tupletype_fill) \
     XX(jl_typeassert) \
-    XX(jl_typeinf_begin) \
-    XX(jl_typeinf_end) \
+    XX(jl_typeinf_lock_begin) \
+    XX(jl_typeinf_lock_end) \
+    XX(jl_typeinf_timing_begin) \
+    XX(jl_typeinf_timing_end) \
     XX(jl_typename_str) \
     XX(jl_typeof_str) \
     XX(jl_types_equal) \


### PR DESCRIPTION
This shrinks the typeinf lock to just around the newly inferred array, but preserves the C-level timing points in type inference. 

Stripped down from #44968