### PR TITLE
effects: improve effects analysis for `Type`-objects

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1,15 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-#############
-# constants #
-#############
-
-const _REF_NAME = Ref.body.name
-
-#########
-# logic #
-#########
-
 # See if the inference result of the current statement's result value might affect
 # the final answer for the method (aside from optimization potential and exceptions).
 # To do that, we need to check both for slot assignment and SSA usage.
@@ -1906,7 +1896,7 @@ function sp_type_rewrap(@nospecialize(T), linfo::MethodInstance, isreturn::Bool)
     if T === Bottom
         return Bottom
     elseif isa(T, Type)
-        if isa(T, DataType) && (T::DataType).name === _REF_NAME
+        if isa(T, DataType) && (T::DataType).name === Ref.body.name
             isref = true
             T = T.parameters[1]
             if isreturn && T === Any

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1034,6 +1034,9 @@ function getfield_notundefined(@nospecialize(typ0), @nospecialize(name))
         # tuples and named tuples can't be instantiated with undefined fields,
         # so we don't need to be conservative here
         return true
+    elseif isType(typ) || typ === DataType
+        # types have never undefined fields
+        return true
     end
     if !isa(name, Const)
         isvarargtype(name) && return false

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -332,6 +332,9 @@ function _is_immutable_type(@nospecialize ty)
     if isa(ty, Union)
         return _is_immutable_type(ty.a) && _is_immutable_type(ty.b)
     end
+    if isType(ty) || ty === DataType
+        return true
+    end
     return !isabstracttype(ty) && !ismutabletype(ty)
 end
 

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -78,7 +78,7 @@ function quoted(@nospecialize(x))
 end
 
 function count_const_size(@nospecialize(x), count_self::Bool = true)
-    (x isa Type || x isa Symbol) && return 0
+    (x isa Type || x isa Core.TypeName || x isa Symbol) && return 0
     ismutable(x) && return MAX_INLINE_CONST_SIZE + 1
     isbits(x) && return Core.sizeof(x)
     dt = typeof(x)

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -254,6 +254,13 @@ for TupleType = Any[Tuple{Int,Int,Int}, Tuple{Int,Vararg{Int}}, Tuple{Any}, Tupl
     FieldType = Any[Int, Symbol, Any]
     @test getfield_notundefined(TupleType, FieldType)
 end
+# access to `Type`-object is always safe
+@test getfield_notundefined(Type{Ref}, Const(:body))
+@test getfield_notundefined(Type{Ref}, Symbol)
+@test getfield_notundefined(Type{Ref{Int}}, Const(:body))
+@test getfield_notundefined(Type{Ref{Int}}, Symbol)
+@test getfield_notundefined(DataType, Const(:hash))
+@test getfield_notundefined(DataType, Symbol)
 # high-level tests for `getfield_notundefined`
 @test Base.infer_effects() do
     Maybe{Int}()
@@ -292,6 +299,8 @@ let f() = Ref{String}()[]
         f() # this call should be concrete evaluated
     end |> only === Union{}
 end
+@test Base.infer_effects(getproperty, (Type{Ref}, Symbol)) |> Core.Compiler.is_consistent
+@test Base.infer_effects(getproperty, (Type{Ref}, Symbol)) |> Core.Compiler.is_foldable
 
 # effects propagation for `Core.invoke` calls
 # https://github.com/JuliaLang/julia/issues/44763

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1512,3 +1512,7 @@ end
 # Test getfield modeling of Type{Ref{_A}} where _A
 @test Core.Compiler.getfield_tfunc(Type, Core.Compiler.Const(:parameters)) !== Union{}
 @test fully_eliminated(Base.ismutable, Tuple{Base.RefValue})
+
+@test fully_eliminated() do
+    Ref.body.name
+end


### PR DESCRIPTION
This PR is composed of the following two changes:
- [effects: improve analysis for getfield on Type-object](https://github.com/JuliaLang/julia/commit/007d23224cf933f64467a19cce5d6646c6afa768) 
  `Type`-object are immutable (essentially on Julia-level) and never has "undef" field,
  and so we should prove `getfield` access to `Type`-object is `:consistent`.
- [optimizer: allow inlining of TypeName constant](https://github.com/JuliaLang/julia/commit/a1a6e2b29d739c7b1b228070c9ae0ac4d40956b9)
  This is particularly useful as it allows us to inline `Ref.body.name` and such.