### PR TITLE
Allow elimination of `isbits` for non-const argument

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -588,7 +588,7 @@ isbitstype(@nospecialize t) = (@_total_meta; isa(t, DataType) && (t.flags & 0x8)
 
 Return `true` if `x` is an instance of an [`isbitstype`](@ref) type.
 """
-isbits(@nospecialize x) = (@_total_meta; typeof(x).flags & 0x8 == 0x8)
+isbits(@nospecialize x) = isbitstype(typeof(x))
 
 """
     isdispatchtuple(T)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -2,6 +2,8 @@
 
 using Test
 
+include("compiler/irutils.jl")
+
 # code_native / code_llvm (issue #8239)
 # It's hard to really test these, but just running them should be
 # sufficient to catch segfault bugs.
@@ -66,6 +68,7 @@ end # module ReflectionTest
 @test isbits((1,2))
 @test !isbits([1])
 @test isbits(nothing)
+@test fully_eliminated(isbits, (Int,))
 
 # issue #16670
 @test isconcretetype(Int)


### PR DESCRIPTION
It should be sufficient for the _type_ of `x` to be known at compile time to fully eliminate `isbits(x)`. However, the pevious code relied on `isbits` being called on its argument during inference (by declaring it `:total`) for eliminating it. But if the value of `x` was not known, only its type, this would not work. The new implementation has the added benefit of being simpler and DRYer (wrt. `isbitstype`).

In passing, I've noted that declaring `isbitstype` as `:total` (which this PR does not touch) might not be 100% valid:
```julia
julia> f(::Type{T}) where T = Val{isbitstype(T)}
f (generic function with 1 method)

julia> struct T; x::f(T); end

julia> f(T)
Val{false}

julia> isbitstype(T)
true
```
But I guess fixing that would do more harm than good.

Closes #46204.