### PR TITLE
Make ASAN actually do something and fix all the things

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -689,7 +689,7 @@ SANITIZE_OPTS += -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-fra
 SANITIZE_LDFLAGS += $(SANITIZE_OPTS)
 endif
 ifeq ($(SANITIZE_ADDRESS),1)
-SANITIZE_OPTS += -fsanitize=address -mllvm -asan-stack=0
+SANITIZE_OPTS += -fsanitize=address
 SANITIZE_LDFLAGS += -fsanitize=address
 endif
 ifeq ($(SANITIZE_THREAD),1)

--- a/src/ccalltest.c
+++ b/src/ccalltest.c
@@ -13,7 +13,9 @@
 #ifdef _OS_WINDOWS_
 #  define DLLEXPORT __declspec(dllexport)
 #else
-# if defined(_OS_LINUX_)
+# if defined(_OS_LINUX_) && !defined(_COMPILER_CLANG_)
+// Clang and ld disagree about the proper relocation for STV_PROTECTED, causing
+// linker errors.
 #  define DLLEXPORT __attribute__ ((visibility("protected")))
 # else
 #  define DLLEXPORT __attribute__ ((visibility("default")))

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2119,6 +2119,9 @@ static void jl_init_function(Function *F)
     attr.addAttribute("probe-stack", "inline-asm");
     //attr.addAttribute("stack-probe-size", "4096"); // can use this to change the default
 #endif
+#if defined(_COMPILER_ASAN_ENABLED_)
+    attr.addAttribute(Attribute::SanitizeAddress);
+#endif
 #if JL_LLVM_VERSION >= 140000
     F->addFnAttrs(attr);
 #else

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -74,6 +74,7 @@ JL_DLLEXPORT jl_typename_t *jl_new_typename_in(jl_sym_t *name, jl_module_t *modu
     jl_atomic_store_relaxed(&tn->linearcache, jl_emptysvec);
     tn->names = NULL;
     tn->hash = bitmix(bitmix(module ? module->build_id : 0, name->hash), 0xa1ada1da);
+    tn->_reserved = 0;
     tn->abstract = abstract;
     tn->mutabl = mutabl;
     tn->mayinlinealloc = 0;

--- a/src/dump.c
+++ b/src/dump.c
@@ -2090,6 +2090,7 @@ static jl_value_t *jl_deserialize_value_any(jl_serializer_state *s, uint8_t tag,
             jl_gc_wb(tn, tn->mt);
             ios_read(s->s, (char*)&tn->hash, sizeof(tn->hash));
             int8_t flags = read_int8(s->s);
+            tn->_reserved = 0;
             tn->abstract = flags & 1;
             tn->mutabl = (flags>>1) & 1;
             tn->mayinlinealloc = (flags>>2) & 1;

--- a/src/flisp/flmain.c
+++ b/src/flisp/flmain.c
@@ -8,14 +8,6 @@
 extern "C" {
 #endif
 
-#if defined(__has_feature)
-#if __has_feature(address_sanitizer)
-const char* __asan_default_options() {
-    return "detect_leaks=0";
-}
-#endif
-#endif
-
 static value_t argv_list(fl_context_t *fl_ctx, int argc, char *argv[])
 {
     int i;

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -535,7 +535,7 @@ void gc_scrub_record_task(jl_task_t *t)
     arraylist_push(&jl_gc_debug_tasks, t);
 }
 
-static void gc_scrub_range(char *low, char *high)
+JL_NO_ASAN static void gc_scrub_range(char *low, char *high)
 {
     jl_ptls_t ptls = jl_current_task->ptls;
     jl_jmp_buf *old_buf = jl_get_safe_restore();

--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -106,6 +106,9 @@ static unsigned select_pool(size_t nb) JL_NOTSAFEPOINT
 
 static void _jl_free_stack(jl_ptls_t ptls, void *stkbuf, size_t bufsz)
 {
+#ifdef _COMPILER_ASAN_ENABLED_
+    __asan_unpoison_stack_memory((uintptr_t)stkbuf, bufsz);
+#endif
     if (bufsz <= pool_sizes[JL_N_STACK_POOLS - 1]) {
         unsigned pool_id = select_pool(bufsz);
         if (pool_sizes[pool_id] == bufsz) {
@@ -135,6 +138,9 @@ void jl_release_task_stack(jl_ptls_t ptls, jl_task_t *task)
         unsigned pool_id = select_pool(bufsz);
         if (pool_sizes[pool_id] == bufsz) {
             task->stkbuf = NULL;
+#ifdef _COMPILER_ASAN_ENABLED_
+            __asan_unpoison_stack_memory((uintptr_t)stkbuf, bufsz);
+#endif
             arraylist_push(&ptls->heap.free_stacks[pool_id], stkbuf);
         }
     }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -542,6 +542,7 @@ static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, size_t ip,
                 // leave happens during normal control flow, but we must
                 // longjmp to pop the eval_body call for each enter.
                 s->continue_at = next_ip;
+                asan_unpoison_task_stack(ct, &eh->eh_ctx);
                 jl_longjmp(eh->eh_ctx, 1);
             }
             else if (head == jl_pop_exception_sym) {

--- a/src/julia.h
+++ b/src/julia.h
@@ -485,6 +485,7 @@ typedef struct {
     uint8_t abstract:1;
     uint8_t mutabl:1;
     uint8_t mayinlinealloc:1;
+    uint8_t _reserved:5;
     uint8_t max_methods; // override for inference's max_methods setting (0 = no additional limit or relaxation)
 } jl_typename_t;
 
@@ -1984,7 +1985,13 @@ void (ijl_longjmp)(jmp_buf _Buf, int _Value);
 #define jl_setjmp_name "sigsetjmp"
 #endif
 #define jl_setjmp(a,b) sigsetjmp(a,b)
+#if defined(_COMPILER_ASAN_ENABLED_) && __GLIBC__
+// Bypass the ASAN longjmp wrapper - we're unpoisoning the stack ourselves.
+extern int __attribute__ ((nothrow)) (__libc_siglongjmp)(jl_jmp_buf buf, int val);
+#define jl_longjmp(a,b) __libc_siglongjmp(a,b)
+#else
 #define jl_longjmp(a,b) siglongjmp(a,b)
+#endif
 #endif
 
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -25,8 +25,45 @@
 extern "C" {
 #endif
 #ifdef _COMPILER_ASAN_ENABLED_
+#if defined(__GLIBC__) && defined(_CPU_X86_64_)
+/* TODO: This is terrible - we're reaching deep into glibc internals here.
+   We should probably just switch to our own setjmp/longjmp implementation. */
+#define JB_RSP 6
+static inline uintptr_t demangle_ptr(uintptr_t var)
+{
+    asm ("ror $17, %0\n\t"
+         "xor %%fs:0x30, %0\n\t"
+        : "=r" (var)
+        : "0" (var));
+    return var;
+}
+static inline uintptr_t jmpbuf_sp(jl_jmp_buf *buf)
+{
+    return demangle_ptr((uintptr_t)(*buf)[0].__jmpbuf[JB_RSP]);
+}
+#else
+#error Need to implement jmpbuf_sp for this architecture
+#endif
 void __sanitizer_start_switch_fiber(void**, const void*, size_t);
 void __sanitizer_finish_switch_fiber(void*, const void**, size_t*);
+extern void __asan_unpoison_stack_memory(uintptr_t addr, size_t size);
+static inline void asan_unpoison_task_stack(jl_task_t *ct, jl_jmp_buf *buf)
+{
+    if (!ct)
+        return;
+    /* Unpoison everything from the base of the stack allocation to the address
+       that we're resetting to. The idea is to remove the posion from the frames
+       that we're skipping over, since they won't be unwound. */
+    uintptr_t top = jmpbuf_sp(buf);
+    uintptr_t bottom = (uintptr_t)ct->stkbuf;
+    __asan_unpoison_stack_memory(bottom, top - bottom);
+}
+static inline void asan_unpoison_stack_memory(uintptr_t addr, size_t size) {
+    __asan_unpoison_stack_memory(addr, size);
+}
+#else
+static inline void asan_unpoison_task_stack(jl_task_t *ct, jl_jmp_buf *buf) JL_NOTSAFEPOINT {}
+static inline void asan_unpoison_stack_memory(uintptr_t addr, size_t size) JL_NOTSAFEPOINT {}
 #endif
 #ifdef _COMPILER_TSAN_ENABLED_
 void *__tsan_create_fiber(unsigned flags);

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -98,6 +98,9 @@ typedef struct {
 #if defined(_COMPILER_TSAN_ENABLED_)
     void *tsan_state;
 #endif
+#if defined(_COMPILER_ASAN_ENABLED_)
+    void *asan_fake_stack;
+#endif
 } jl_ucontext_t;
 
 

--- a/src/options.h
+++ b/src/options.h
@@ -113,7 +113,9 @@
 
 // When not using COPY_STACKS the task-system is less memory efficient so
 // you probably want to choose a smaller default stack size (factor of 8-10)
-#ifdef _P64
+#if defined(_COMPILER_ASAN_ENABLED_) || defined(_COMPILER_MSAN_ENABLED_)
+#define JL_STACK_SIZE (64*1024*1024)
+#elif defined(_P64)
 #define JL_STACK_SIZE (4*1024*1024)
 #else
 #define JL_STACK_SIZE (2*1024*1024)

--- a/src/task.c
+++ b/src/task.c
@@ -42,15 +42,27 @@ extern "C" {
 #endif
 
 #if defined(_COMPILER_ASAN_ENABLED_)
-static inline void sanitizer_start_switch_fiber(const void* bottom, size_t size) {
-    __sanitizer_start_switch_fiber(NULL, bottom, size);
+static inline void sanitizer_start_switch_fiber(jl_ptls_t ptls, jl_task_t *from, jl_task_t *to) {
+    if (to->copy_stack)
+        __sanitizer_start_switch_fiber(&from->ctx.asan_fake_stack, (char*)ptls->stackbase-ptls->stacksize, ptls->stacksize);
+    else
+        __sanitizer_start_switch_fiber(&from->ctx.asan_fake_stack, to->stkbuf, to->bufsz);
 }
-static inline void sanitizer_finish_switch_fiber(void) {
-    __sanitizer_finish_switch_fiber(NULL, NULL, NULL);
+static inline void sanitizer_start_switch_fiber_killed(jl_ptls_t ptls, jl_task_t *to) {
+    if (to->copy_stack)
+        __sanitizer_start_switch_fiber(NULL, (char*)ptls->stackbase-ptls->stacksize, ptls->stacksize);
+    else
+        __sanitizer_start_switch_fiber(NULL, to->stkbuf, to->bufsz);
+}
+static inline void sanitizer_finish_switch_fiber(jl_task_t *last, jl_task_t *current) {
+    __sanitizer_finish_switch_fiber(current->ctx.asan_fake_stack, NULL, NULL);
+        //(const void**)&last->stkbuf,
+        //&last->bufsz);
 }
 #else
-static inline void sanitizer_start_switch_fiber(const void* bottom, size_t size) {}
-static inline void sanitizer_finish_switch_fiber(void) {}
+static inline void sanitizer_start_switch_fiber(jl_ptls_t ptls, jl_task_t *from, jl_task_t *to) JL_NOTSAFEPOINT {}
+static inline void sanitizer_start_switch_fiber_killed(jl_ptls_t ptls, jl_task_t *to) JL_NOTSAFEPOINT {}
+static inline void sanitizer_finish_switch_fiber(jl_task_t *last, jl_task_t *current) JL_NOTSAFEPOINT {}
 #endif
 
 #if defined(_COMPILER_TSAN_ENABLED_)
@@ -109,7 +121,11 @@ static inline void sanitizer_finish_switch_fiber(void) {}
 #define MINSTKSZ 131072
 #endif
 
+#ifdef _COMPILER_ASAN_ENABLED_
+#define ROOT_TASK_STACK_ADJUSTMENT 0
+#else
 #define ROOT_TASK_STACK_ADJUSTMENT 3000000
+#endif
 
 #ifdef JL_HAVE_ASYNCIFY
 // Switching logic is implemented in JavaScript
@@ -133,13 +149,62 @@ static int always_copy_stacks = 1;
 static int always_copy_stacks = 0;
 #endif
 
+#if defined(_COMPILER_ASAN_ENABLED_)
+extern void __asan_get_shadow_mapping(size_t *shadow_scale, size_t *shadow_offset);
+
+JL_NO_ASAN void *memcpy_noasan(void *dest, const void *src, size_t n) {
+  char *d = (char*)dest;
+  const char *s = (const char *)src;
+  for (size_t i = 0; i < n; ++i)
+    d[i] = s[i];
+  return dest;
+}
+
+JL_NO_ASAN void *memcpy_a16_noasan(uint64_t *dest, const uint64_t *src, size_t nb) {
+  uint64_t *end = (uint64_t*)((char*)src + nb);
+  while (src < end)
+    *(dest++) = *(src++);
+  return dest;
+}
+
+/* Copy stack are allocated as regular bigval objects and do no go through free_stack,
+   which would otherwise unpoison it before returning to the GC pool */
+static void asan_free_copy_stack(void *stkbuf, size_t bufsz) {
+    __asan_unpoison_stack_memory((uintptr_t)stkbuf, bufsz);
+}
+#else
+static void asan_free_copy_stack(void *stkbuf, size_t bufsz) {}
+#endif
+
 #ifdef COPY_STACKS
-static void memcpy_a16(uint64_t *to, uint64_t *from, size_t nb)
+static void JL_NO_ASAN JL_NO_MSAN memcpy_stack_a16(uint64_t *to, uint64_t *from, size_t nb)
 {
+#if defined(_COMPILER_ASAN_ENABLED_)
+    /* Asan keeps shadow memory for everything on the stack. However, in general,
+       this function may touch invalid portions of the stack, since it just moves
+       the stack around. To keep ASAN's stack tracking capability intact, we need
+       to move the shadow memory along with the stack memory itself. */
+    size_t shadow_offset;
+    size_t shadow_scale;
+    __asan_get_shadow_mapping(&shadow_scale, &shadow_offset);
+    uintptr_t from_addr = (((uintptr_t)from) >> shadow_scale) + shadow_offset;
+    uintptr_t to_addr = (((uintptr_t)to) >> shadow_scale) + shadow_offset;
+    // Make sure that the shadow scale is compatible with the alignment, so
+    // we can copy whole bytes.
+    assert(shadow_scale <= 4);
+    size_t shadow_nb = nb >> shadow_scale;
+    // Copy over the shadow memory
+    memcpy_noasan((char*)to_addr, (char*)from_addr, shadow_nb);
+    memcpy_a16_noasan(jl_assume_aligned(to, 16), jl_assume_aligned(from, 16), nb);
+#elif defined(_COMPILER_MSAN_ENABLED_)
+# warning This function is imcompletely implemented for MSAN (TODO).
+    memcpy((char*)jl_assume_aligned(to, 16), (char*)jl_assume_aligned(from, 16), nb);
+#else
     memcpy((char*)jl_assume_aligned(to, 16), (char*)jl_assume_aligned(from, 16), nb);
     //uint64_t *end = (uint64_t*)((char*)from + nb);
     //while (from < end)
     //    *(to++) = *(from++);
+#endif
 }
 
 static void NOINLINE save_stack(jl_ptls_t ptls, jl_task_t *lastt, jl_task_t **pt)
@@ -150,6 +215,7 @@ static void NOINLINE save_stack(jl_ptls_t ptls, jl_task_t *lastt, jl_task_t **pt
     size_t nb = stackbase - frame_addr;
     void *buf;
     if (lastt->bufsz < nb) {
+        asan_free_copy_stack(lastt->stkbuf, lastt->bufsz);
         buf = (void*)jl_gc_alloc_buf(ptls, nb);
         lastt->stkbuf = buf;
         lastt->bufsz = nb;
@@ -160,14 +226,14 @@ static void NOINLINE save_stack(jl_ptls_t ptls, jl_task_t *lastt, jl_task_t **pt
     *pt = NULL; // clear the gc-root for the target task before copying the stack for saving
     lastt->copy_stack = nb;
     lastt->sticky = 1;
-    memcpy_a16((uint64_t*)buf, (uint64_t*)frame_addr, nb);
+    memcpy_stack_a16((uint64_t*)buf, (uint64_t*)frame_addr, nb);
     // this task's stack could have been modified after
     // it was marked by an incremental collection
     // move the barrier back instead of walking it again here
     jl_gc_wb_back(lastt);
 }
 
-static void NOINLINE JL_NORETURN restore_stack(jl_task_t *t, jl_ptls_t ptls, char *p)
+JL_NO_ASAN static void NOINLINE JL_NORETURN restore_stack(jl_task_t *t, jl_ptls_t ptls, char *p)
 {
     size_t nb = t->copy_stack;
     char *_x = (char*)ptls->stackbase - nb;
@@ -181,9 +247,8 @@ static void NOINLINE JL_NORETURN restore_stack(jl_task_t *t, jl_ptls_t ptls, cha
     }
     void *_y = t->stkbuf;
     assert(_x != NULL && _y != NULL);
-    memcpy_a16((uint64_t*)_x, (uint64_t*)_y, nb); // destroys all but the current stackframe
+    memcpy_stack_a16((uint64_t*)_x, (uint64_t*)_y, nb); // destroys all but the current stackframe
 
-    sanitizer_start_switch_fiber(t->stkbuf, t->bufsz);
 #if defined(_OS_WINDOWS_)
     jl_setcontext(&t->ctx.copy_ctx);
 #else
@@ -192,14 +257,14 @@ static void NOINLINE JL_NORETURN restore_stack(jl_task_t *t, jl_ptls_t ptls, cha
     abort(); // unreachable
 }
 
-static void restore_stack2(jl_task_t *t, jl_ptls_t ptls, jl_task_t *lastt)
+JL_NO_ASAN static void restore_stack2(jl_task_t *t, jl_ptls_t ptls, jl_task_t *lastt)
 {
     assert(t->copy_stack && !lastt->copy_stack);
     size_t nb = t->copy_stack;
     char *_x = (char*)ptls->stackbase - nb;
     void *_y = t->stkbuf;
     assert(_x != NULL && _y != NULL);
-    memcpy_a16((uint64_t*)_x, (uint64_t*)_y, nb); // destroys all but the current stackframe
+    memcpy_stack_a16((uint64_t*)_x, (uint64_t*)_y, nb); // destroys all but the current stackframe
 #if defined(JL_HAVE_UNW_CONTEXT)
     volatile int returns = 0;
     int r = unw_getcontext(&lastt->ctx.ctx);
@@ -213,7 +278,6 @@ static void restore_stack2(jl_task_t *t, jl_ptls_t ptls, jl_task_t *lastt)
 #else
 #error COPY_STACKS is incompatible with this platform
 #endif
-    sanitizer_start_switch_fiber(t->stkbuf, t->bufsz);
     tsan_switch_to_copyctx(&t->ctx);
 #if defined(_OS_WINDOWS_)
     jl_setcontext(&t->ctx.copy_ctx);
@@ -235,8 +299,10 @@ void JL_NORETURN jl_finish_task(jl_task_t *t)
         jl_atomic_store_release(&t->_state, JL_TASK_STATE_FAILED);
     else
         jl_atomic_store_release(&t->_state, JL_TASK_STATE_DONE);
-    if (t->copy_stack) // early free of stkbuf
+    if (t->copy_stack) { // early free of stkbuf
+        asan_free_copy_stack(t->stkbuf, t->bufsz);
         t->stkbuf = NULL;
+    }
     // ensure that state is cleared
     ct->ptls->in_finalizer = 0;
     ct->ptls->in_pure_callback = 0;
@@ -362,7 +428,7 @@ JL_DLLEXPORT jl_task_t *jl_get_next_task(void) JL_NOTSAFEPOINT
 const char tsan_state_corruption[] = "TSAN state corrupted. Exiting HARD!\n";
 #endif
 
-static void ctx_switch(jl_task_t *lastt)
+JL_NO_ASAN static void ctx_switch(jl_task_t *lastt)
 {
     jl_ptls_t ptls = lastt->ptls;
     jl_task_t **pt = &ptls->next_task;
@@ -416,7 +482,7 @@ static void ctx_switch(jl_task_t *lastt)
         if (lastt->copy_stack) { // save the old copy-stack
             save_stack(ptls, lastt, pt); // allocates (gc-safepoint, and can also fail)
             if (jl_setjmp(lastt->ctx.copy_ctx.uc_mcontext, 0)) {
-                sanitizer_finish_switch_fiber();
+                sanitizer_finish_switch_fiber(ptls->previous_task, jl_atomic_load_relaxed(&ptls->current_task));
                 // TODO: mutex unlock the thread we just switched from
                 return;
             }
@@ -441,12 +507,25 @@ static void ctx_switch(jl_task_t *lastt)
     if (t->started) {
 #ifdef COPY_STACKS
         if (t->copy_stack) {
-            if (!killed && !lastt->copy_stack)
+            if (lastt->copy_stack) {
+                // Switching from copystack to copystack. Clear any shadow stack
+                // memory above the saved shadow stack.
+                uintptr_t stacktop = (uintptr_t)ptls->stackbase - t->copy_stack;
+                uintptr_t stackbottom = ((uintptr_t)jl_get_frame_addr() & ~15);
+                if (stackbottom < stacktop)
+                    asan_unpoison_stack_memory(stackbottom, stacktop-stackbottom);
+            }
+            if (!killed && !lastt->copy_stack) {
+                sanitizer_start_switch_fiber(ptls, lastt, t);
                 restore_stack2(t, ptls, lastt);
-            else {
+            } else {
                 tsan_switch_to_copyctx(&t->ctx);
-                if (killed)
+                if (killed) {
+                    sanitizer_start_switch_fiber_killed(ptls, t);
                     tsan_destroy_copyctx(ptls, &lastt->ctx);
+                } else {
+                    sanitizer_start_switch_fiber(ptls, lastt, t);
+                }
 
                 if (lastt->copy_stack) {
                     restore_stack(t, ptls, NULL); // (doesn't return)
@@ -459,14 +538,26 @@ static void ctx_switch(jl_task_t *lastt)
         else
 #endif
         {
-            sanitizer_start_switch_fiber(t->stkbuf, t->bufsz);
+            if (lastt->copy_stack) {
+                // Switching away from a copystack to a non-copystack. Clear
+                // the whole shadow stack now, because otherwise we won't know
+                // how much stack memory to clear the next time we switch to
+                // a copystack.
+                uintptr_t stacktop = (uintptr_t)ptls->stackbase;
+                uintptr_t stackbottom = ((uintptr_t)jl_get_frame_addr() & ~15);
+                // We're not restoring the stack, but we still need to unpoison the
+                // stack, so it starts with a pristine stack.
+                asan_unpoison_stack_memory(stackbottom, stacktop-stackbottom);
+            }
             if (killed) {
+                sanitizer_start_switch_fiber_killed(ptls, t);
                 tsan_switch_to_ctx(&t->ctx);
                 tsan_destroy_ctx(ptls, &lastt->ctx);
                 jl_set_fiber(&t->ctx); // (doesn't return)
                 abort(); // unreachable
             }
             else {
+                sanitizer_start_switch_fiber(ptls, lastt, t);
                 if (lastt->copy_stack) {
                     // Resume at the jl_setjmp earlier in this function,
                     // don't do a full task swap
@@ -480,11 +571,20 @@ static void ctx_switch(jl_task_t *lastt)
         }
     }
     else {
-        sanitizer_start_switch_fiber(t->stkbuf, t->bufsz);
+        if (lastt->copy_stack) {
+            uintptr_t stacktop = (uintptr_t)ptls->stackbase;
+            uintptr_t stackbottom = ((uintptr_t)jl_get_frame_addr() & ~15);
+            // We're not restoring the stack, but we still need to unpoison the
+            // stack, so it starts with a pristine stack.
+            asan_unpoison_stack_memory(stackbottom, stacktop-stackbottom);
+        }
         if (t->copy_stack && always_copy_stacks) {
             tsan_switch_to_ctx(&t->ctx);
             if (killed) {
+                sanitizer_start_switch_fiber_killed(ptls, t);
                 tsan_destroy_ctx(ptls, &lastt->ctx);
+            } else {
+                sanitizer_start_switch_fiber(ptls, lastt, t);
             }
 #ifdef COPY_STACKS
 #if defined(_OS_WINDOWS_)
@@ -497,12 +597,14 @@ static void ctx_switch(jl_task_t *lastt)
         }
         else {
             if (killed) {
+                sanitizer_start_switch_fiber_killed(ptls, t);
                 tsan_switch_to_ctx(&t->ctx);
                 tsan_destroy_ctx(ptls, &lastt->ctx);
                 jl_start_fiber_set(&t->ctx); // (doesn't return)
                 abort();
             }
-            else if (lastt->copy_stack) {
+            sanitizer_start_switch_fiber(ptls, lastt, t);
+            if (lastt->copy_stack) {
                 // Resume at the jl_setjmp earlier in this function
                 tsan_switch_to_ctx(&t->ctx);
                 jl_start_fiber_set(&t->ctx); // (doesn't return)
@@ -513,7 +615,7 @@ static void ctx_switch(jl_task_t *lastt)
             }
         }
     }
-    sanitizer_finish_switch_fiber();
+    sanitizer_finish_switch_fiber(ptls->previous_task, jl_atomic_load_relaxed(&ptls->current_task));
 }
 
 JL_DLLEXPORT void jl_switch(void)
@@ -606,48 +708,76 @@ JL_DLLEXPORT JL_NORETURN void jl_no_exc_handler(jl_value_t *e)
     jl_exit(1);
 }
 
-// yield to exception handler
+/* throw_internal - yield to exception handler */
+
+#ifdef ENABLE_TIMINGS
+#define pop_timings_stack()                                                    \
+        jl_timing_block_t *cur_block = ptls->timing_stack;                     \
+        while (cur_block && eh->timing_stack != cur_block) {                   \
+            cur_block = jl_pop_timing_block(cur_block);                        \
+        }                                                                      \
+        assert(cur_block == eh->timing_stack);
+#else
+#define pop_timings_stack() /* Nothing */
+#endif
+
+#define throw_internal_body()                                                  \
+    assert(!jl_get_safe_restore());                                            \
+    jl_ptls_t ptls = ct->ptls;                                                 \
+    ptls->io_wait = 0;                                                         \
+    JL_GC_PUSH1(&exception);                                                   \
+    jl_gc_unsafe_enter(ptls);                                                  \
+    if (exception) {                                                           \
+        /* The temporary ptls->bt_data is rooted by special purpose code in the\
+           GC. This exists only for the purpose of preserving bt_data until we \
+           set ptls->bt_size=0 below. */                                       \
+        jl_push_excstack(&ct->excstack, exception,                             \
+                          ptls->bt_data, ptls->bt_size);                       \
+        ptls->bt_size = 0;                                                     \
+    }                                                                          \
+    assert(ct->excstack && ct->excstack->top);                                 \
+    jl_handler_t *eh = ct->eh;                                                 \
+    if (eh != NULL) {                                                          \
+        pop_timings_stack()                                                    \
+        asan_unpoison_task_stack(ct, &eh->eh_ctx);                             \
+        jl_longjmp(eh->eh_ctx, 1);                                             \
+    }                                                                          \
+    else {                                                                     \
+        jl_no_exc_handler(exception);                                          \
+    }                                                                          \
+    assert(0);
+
 static void JL_NORETURN throw_internal(jl_task_t *ct, jl_value_t *exception JL_MAYBE_UNROOTED)
 {
-    assert(!jl_get_safe_restore());
-    jl_ptls_t ptls = ct->ptls;
-    ptls->io_wait = 0;
-    JL_GC_PUSH1(&exception);
-    jl_gc_unsafe_enter(ptls);
-    if (exception) {
-        // The temporary ptls->bt_data is rooted by special purpose code in the
-        // GC. This exists only for the purpose of preserving bt_data until we
-        // set ptls->bt_size=0 below.
-        jl_push_excstack(&ct->excstack, exception,
-                          ptls->bt_data, ptls->bt_size);
-        ptls->bt_size = 0;
-    }
-    assert(ct->excstack && ct->excstack->top);
-    jl_handler_t *eh = ct->eh;
-    if (eh != NULL) {
-#ifdef ENABLE_TIMINGS
-        jl_timing_block_t *cur_block = ptls->timing_stack;
-        while (cur_block && eh->timing_stack != cur_block) {
-            cur_block = jl_pop_timing_block(cur_block);
-        }
-        assert(cur_block == eh->timing_stack);
-#endif
-        jl_longjmp(eh->eh_ctx, 1);
-    }
-    else {
-        jl_no_exc_handler(exception);
-    }
-    assert(0);
+CFI_NORETURN
+    throw_internal_body()
+    jl_unreachable();
 }
+
+#ifdef _COMPILER_ASAN_ENABLED_
+/* On the signal stack, we don't want to create any asan frames, but we do on the
+   normal, stack, so we split this function in two, depending on which context
+   we're calling it in */
+JL_NO_ASAN static void JL_NORETURN throw_internal_altstack(jl_task_t *ct, jl_value_t *exception JL_MAYBE_UNROOTED)
+{
+CFI_NORETURN
+    throw_internal_body()
+    jl_unreachable();
+}
+#else
+#define throw_internal_altstack throw_internal
+#endif
 
 // record backtrace and raise an error
 JL_DLLEXPORT void jl_throw(jl_value_t *e JL_MAYBE_UNROOTED)
 {
     assert(e != NULL);
     jl_jmp_buf *safe_restore = jl_get_safe_restore();
-    if (safe_restore)
-        jl_longjmp(*safe_restore, 1);
     jl_task_t *ct = jl_get_current_task();
+    if (safe_restore) {
+        asan_unpoison_task_stack(ct, safe_restore);
+        jl_longjmp(*safe_restore, 1);
+    }
     if (ct == NULL) // During startup
         jl_no_exc_handler(e);
     record_backtrace(ct->ptls, 1);
@@ -667,17 +797,19 @@ JL_DLLEXPORT void jl_rethrow(void)
 // Special case throw for errors detected inside signal handlers.  This is not
 // (cannot be) called directly in the signal handler itself, but is returned to
 // after the signal handler exits.
-JL_DLLEXPORT void JL_NORETURN jl_sig_throw(void)
+JL_DLLEXPORT JL_NO_ASAN void JL_NORETURN jl_sig_throw(void)
 {
 CFI_NORETURN
     jl_jmp_buf *safe_restore = jl_get_safe_restore();
-    if (safe_restore)
-        jl_longjmp(*safe_restore, 1);
     jl_task_t *ct = jl_current_task;
+    if (safe_restore) {
+        asan_unpoison_task_stack(ct, safe_restore);
+        jl_longjmp(*safe_restore, 1);
+    }
     jl_ptls_t ptls = ct->ptls;
     jl_value_t *e = ptls->sig_exception;
     ptls->sig_exception = NULL;
-    throw_internal(ct, e);
+    throw_internal_altstack(ct, e);
 }
 
 JL_DLLEXPORT void jl_rethrow_other(jl_value_t *e JL_MAYBE_UNROOTED)
@@ -819,6 +951,9 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, jl_value_t *completion
 #ifdef _COMPILER_TSAN_ENABLED_
     t->ctx.tsan_state = __tsan_create_fiber(0);
 #endif
+#ifdef _COMPILER_ASAN_ENABLED_
+    t->ctx.asan_fake_stack = NULL;
+#endif
     return t;
 }
 
@@ -892,11 +1027,30 @@ void jl_init_tasks(void) JL_GC_DISABLED
 #endif
 }
 
-STATIC_OR_JS void NOINLINE JL_NORETURN start_task(void)
+#if defined(_COMPILER_ASAN_ENABLED_)
+STATIC_OR_JS void NOINLINE JL_NORETURN _start_task(void);
+#endif
+
+STATIC_OR_JS void NOINLINE JL_NORETURN JL_NO_ASAN start_task(void)
 {
 CFI_NORETURN
+#if defined(_COMPILER_ASAN_ENABLED_)
+    // First complete the fiber switch, otherwise ASAN will be confused
+    // when it unpoisons the stack in _start_task
+#ifdef __clang_gcanalyzer__
+    jl_task_t *ct = jl_get_current_task();
+#else
+    jl_task_t *ct = jl_current_task;
+#endif
+    jl_ptls_t ptls = ct->ptls;
+    sanitizer_finish_switch_fiber(ptls->previous_task, ct);
+    _start_task();
+}
+STATIC_OR_JS void NOINLINE JL_NORETURN _start_task(void)
+{
+CFI_NORETURN
+#endif
     // this runs the first time we switch to a task
-    sanitizer_finish_switch_fiber();
 #ifdef __clang_gcanalyzer__
     jl_task_t *ct = jl_get_current_task();
 #else
@@ -1112,7 +1266,7 @@ static void jl_start_fiber_swap(jl_ucontext_t *lastt, jl_ucontext_t *t)
 #endif
 
 #if defined(JL_HAVE_ASM)
-static void jl_start_fiber_swap(jl_ucontext_t *lastt, jl_ucontext_t *t)
+JL_NO_ASAN static void jl_start_fiber_swap(jl_ucontext_t *lastt, jl_ucontext_t *t)
 {
     assert(lastt);
 #ifdef JL_HAVE_UNW_CONTEXT
@@ -1129,7 +1283,7 @@ static void jl_start_fiber_swap(jl_ucontext_t *lastt, jl_ucontext_t *t)
     tsan_switch_to_ctx(t);
     jl_start_fiber_set(t); // doesn't return
 }
-static void jl_start_fiber_set(jl_ucontext_t *t)
+JL_NO_ASAN static void jl_start_fiber_set(jl_ucontext_t *t)
 {
     char *stk = ((char**)&t->ctx)[0];
     size_t ssize = ((size_t*)&t->ctx)[1];
@@ -1373,6 +1527,9 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
 
 #ifdef _COMPILER_TSAN_ENABLED_
     ct->ctx.tsan_state = __tsan_get_current_fiber();
+#endif
+#ifdef _COMPILER_ASAN_ENABLED_
+    ct->ctx.asan_fake_stack = NULL;
 #endif
 
 #ifdef COPY_STACKS


### PR DESCRIPTION
We've had the ability to build with ASAN for quite a while, but
at some point the LLVM pass stopped doing anything unless you
also annotated the function with the `sanitize_address` attribute,
so if you built Julia with asan enabled, very few things were
actually built with asan and those that were didn't have one
of asan's most crucial features enabled: Tracking out of bounds
stack accesses.

This PR enabled asan-stack handling, adds the appropriate asan
poison handling to our tasks and fixes a plethora of other things
that didn't work with asan enabled. The result of this PR (together
with a few other PRs still pending) should be that asan passes
tests on master.

This was a significant amount of work, and the changes required
quite subtle. As a result, I think we should make sure to quickly
set up CI to test this configuration and make sure it doesn't
regress.