### PR TITLE
`leq` for reals falls back to `le` and `eq`

### DIFF
--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -498,7 +498,7 @@ xor(x::T, y::T) where {T<:Integer} = no_op_err("xor", T)
 
 (==)(x::T, y::T) where {T<:Number} = x === y
 (< )(x::T, y::T) where {T<:Real} = no_op_err("<" , T)
-(<=)(x::T, y::T) where {T<:Real} = no_op_err("<=", T)
+(<=)(x::T, y::T) where {T<:Real} = (x == y) | (x < y)
 
 rem(x::T, y::T) where {T<:Real} = no_op_err("rem", T)
 mod(x::T, y::T) where {T<:Real} = no_op_err("mod", T)

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -328,3 +328,14 @@ end
     illtype = Vector{Core._typevar(:T, Union{}, Any)}
     @test Returns(illtype) == Returns{DataType}(illtype)
 end
+
+@testset "<= (issue #46327)" begin
+    struct A46327 <: Real end
+    Base.:(==)(::A46327, ::A46327) = false
+    Base.:(<)(::A46327, ::A46327) = false
+    @test !(A46327() <= A46327())
+    struct B46327 <: Real end
+    Base.:(==)(::B46327, ::B46327) = true
+    Base.:(<)(::B46327, ::B46327) = false
+    @test B46327() <= B46327()
+end


### PR DESCRIPTION
Fixes #46327.
After this,
```julia
julia> struct A <: Real end

julia> Base.:(<)(::A, ::A) = false

julia> Base.:(==)(::A, ::A) = false

julia> A() <= A()
false
```