### PR TITLE
Fix intersect error reported in #41096

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -3175,18 +3175,22 @@ static int merge_env(jl_stenv_t *e, jl_value_t **root, jl_savedenv_t *se, int co
     }
     int n = 0;
     jl_varbinding_t *v = e->vars;
+    jl_value_t *ub = NULL, *vub = NULL;
+    JL_GC_PUSH2(&ub, &vub);
     while (v != NULL) {
         if (v->ub != v->var->ub || v->lb != v->var->lb) {
             jl_value_t *lb = jl_svecref(*root, n);
             if (v->lb != lb)
                 jl_svecset(*root, n, lb ? jl_bottom_type : v->lb);
-            jl_value_t *ub = jl_svecref(*root, n+1);
-            if (v->ub != ub)
-                jl_svecset(*root, n+1, ub ? simple_join(ub, v->ub) : v->ub);
+            ub = jl_svecref(*root, n+1);
+            vub = v->ub;
+            if (vub != ub)
+                jl_svecset(*root, n+1, ub ? simple_join(ub, vub) : vub);
         }
         n = n + 3;
         v = v->prev;
     }
+    JL_GC_POP();
     return count;
 }
 

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -3168,7 +3168,8 @@ static jl_value_t *intersect(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int pa
     return jl_bottom_type;
 }
 
-static int merge_env(jl_stenv_t *e, jl_value_t **root, jl_savedenv_t *se, int count) {
+static int merge_env(jl_stenv_t *e, jl_value_t **root, jl_savedenv_t *se, int count)
+{
     if (!count) {
         save_env(e, root, se);
         return 1;

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1996,3 +1996,10 @@ let T = TypeVar(:T, Real),
     @test !(UnionAll(T, UnionAll(V, UnionAll(T, Type{Pair{T, V}}))) <: UnionAll(T, UnionAll(V, Type{Pair{T, V}})))
     @test !(UnionAll(T, UnionAll(V, UnionAll(T, S))) <: UnionAll(T, UnionAll(V, S)))
 end
+
+# issue 41096
+let C = Val{Val{B}} where {B}
+    @testintersect(Val{<:Union{Missing, Val{false}, Val{true}}}, C, Val{<:Union{Val{true}, Val{false}}})
+    @testintersect(Val{<:Union{Nothing, Val{true}, Val{false}}}, C, Val{<:Union{Val{true}, Val{false}}})
+    @testintersect(Val{<:Union{Nothing, Val{false}}}, C, Val{Val{false}})
+end

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2010,9 +2010,13 @@ let T = TypeVar(:T, Real),
     @test !(UnionAll(T, UnionAll(V, UnionAll(T, S))) <: UnionAll(T, UnionAll(V, S)))
 end
 
-# issue 41096
+# issue #41096
 let C = Val{Val{B}} where {B}
     @testintersect(Val{<:Union{Missing, Val{false}, Val{true}}}, C, Val{<:Union{Val{true}, Val{false}}})
     @testintersect(Val{<:Union{Nothing, Val{true}, Val{false}}}, C, Val{<:Union{Val{true}, Val{false}}})
     @testintersect(Val{<:Union{Nothing, Val{false}}}, C, Val{Val{false}})
 end
+
+#issue #43082
+struct X43082{A, I, B<:Union{Ref{I},I}}; end
+@testintersect(Tuple{X43082{T}, Int} where T, Tuple{X43082{Int}, Any}, Tuple{X43082{Int}, Int})


### PR DESCRIPTION
MWE
```julia
julia> A = Val{<:Union{Nothing, Val{true},Val{false}}}
Val{<:Union{Val{true}, Val{false}, Nothing}}

julia> B = Val{Val{B}} where {B}
Val{Val{B}} where B

julia> (Base.typeintersect(B, A))
Val{<:Union{Val{true}, Val{false}}}  # Val{Val{true}} before this PR
```

This PR makes sure `env` is restored between every 2 adjacent `intersect`s during `intersect_all`.
The valid env changes are tracked (and merged) with a new function `merge_env`.
Not sure this is the correct direction to fix the problem.

Close #41096.
Edit: looks like this PR also fixes #43082.