### PR TITLE
Using MADV_FREE in jl_gc_free_page(), with fallback to MADV_DONTNEED.

### DIFF
--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -302,6 +302,17 @@ void jl_gc_free_page(void *p) JL_NOTSAFEPOINT
     }
 #ifdef _OS_WINDOWS_
     VirtualFree(p, decommit_size, MEM_DECOMMIT);
+#elif MADV_FREE
+    static int supports_madv_free = 1;
+    if (supports_madv_free) {
+        if (madvise(p, decommit_size, MADV_FREE) == -1) {
+            assert(errno == EINVAL);
+            supports_madv_free = 0;
+        }
+    }
+    if (!supports_madv_free) {
+        madvise(p, decommit_size, MADV_DONTNEED);
+    }
 #else
     madvise(p, decommit_size, MADV_DONTNEED);
 #endif

--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -302,7 +302,7 @@ void jl_gc_free_page(void *p) JL_NOTSAFEPOINT
     }
 #ifdef _OS_WINDOWS_
     VirtualFree(p, decommit_size, MEM_DECOMMIT);
-#elif MADV_FREE
+#elif defined(MADV_FREE)
     static int supports_madv_free = 1;
     if (supports_madv_free) {
         if (madvise(p, decommit_size, MADV_FREE) == -1) {


### PR DESCRIPTION
`MADV_FREE` is faster than `MADV_DONTNEED` (in most cases, for more info see https://lwn.net/Articles/591214/), but has only been available since Linux 4.5. Since Julia might be cross compiled for an earlier kernel, we have to call `madvise()` with `MADV_FREE` and try again with `MADV_DONTNEED` in case the first `MADV_FREE` fails.