### PR TITLE
`Core.ifelse` calls to avoid invalidations from defining custom `Base.ifelse` methods

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -464,7 +464,7 @@ julia> max(2, 5, 1)
 5
 ```
 """
-max(x, y) = ifelse(isless(y, x), x, y)
+max(x, y) = Core.ifelse(isless(y, x), x, y)
 
 """
     min(x, y, ...)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -616,15 +616,15 @@ prod(a; kw...) = mapreduce(identity, mul_prod, a; kw...)
 _fast(::typeof(min),x,y) = min(x,y)
 _fast(::typeof(max),x,y) = max(x,y)
 function _fast(::typeof(max), x::AbstractFloat, y::AbstractFloat)
-    ifelse(isnan(x),
+    Core.ifelse(isnan(x),
         x,
-        ifelse(x > y, x, y))
+        Core.ifelse(x > y, x, y))
 end
 
 function _fast(::typeof(min),x::AbstractFloat, y::AbstractFloat)
-    ifelse(isnan(x),
+    Core.ifelse(isnan(x),
         x,
-        ifelse(x < y, x, y))
+        Core.ifelse(x < y, x, y))
 end
 
 isbadzero(::typeof(max), x::AbstractFloat) = (x == zero(x)) & signbit(x)
@@ -860,8 +860,8 @@ ExtremaMap(::Type{T}) where {T} = ExtremaMap{Type{T}}(T)
 function _extrema_rf(x::NTuple{2,T}, y::NTuple{2,T}) where {T<:IEEEFloat}
     (x1, x2), (y1, y2) = x, y
     anynan = isnan(x1)|isnan(y1)
-    z1 = ifelse(anynan, x1-y1, ifelse(signbit(x1-y1), x1, y1))
-    z2 = ifelse(anynan, x1-y1, ifelse(signbit(x2-y2), y2, x2))
+    z1 = Core.ifelse(anynan, x1-y1, Core.ifelse(signbit(x1-y1), x1, y1))
+    z2 = Core.ifelse(anynan, x1-y1, Core.ifelse(signbit(x2-y2), y2, x2))
     z1, z2
 end
 


### PR DESCRIPTION
Addresses `ifelse` invalidations reported here:
https://github.com/SciML/Static.jl/issues/77#issuecomment-1216654548

After this PR:
```julia
julia> using SnoopCompileCore

julia> invals = @snoopr using Static
104-element Vector{Any}:
  MethodInstance for to_indices(::AbstractArray, ::Tuple{Any, CartesianIndex{0}})
 1
  MethodInstance for setindex!(::AbstractArray, ::Any, ::Any, ::CartesianIndex{0})
 2
  MethodInstance for to_indices(::AbstractArray, ::Any, ::Tuple{Any, CartesianIndex{0}})
  "jl_method_table_insert"
  to_indices(A, inds, I::Tuple{AbstractArray{NDIndex{N, J}}, Vararg{Any}}) where {N, J} @ Static ~/.julia/dev/Static/src/Static.jl:919
  "jl_method_table_insert"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
 ⋮
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for promote_rule(::Type, ::Type)
  "invalidate_mt_cache"
  MethodInstance for Base._cutdim(::Any, ::CartesianIndex{0})
 1
  MethodInstance for Base.IteratorsMD.split(::Any, ::Val{0})
  "jl_method_table_insert"
  split(i::NDIndex, V::Val) @ Static ~/.julia/dev/Static/src/Static.jl:855
  "jl_method_table_insert"
  MethodInstance for ∘(::Function, ::Function)
  "invalidate_mt_cache"

julia> using SnoopCompileCore

julia> using SnoopCompile

julia> tree = invalidation_trees(invals)
2-element Vector{SnoopCompile.MethodInvalidations}:
 inserting split(i::NDIndex, V::Val) @ Static ~/.julia/dev/Static/src/Static.jl:855 invalidated:
   backedges: 1: superseding split(t, V::Val) @ Base.IteratorsMD multidimensional.jl:480 with MethodInstance for Base.IteratorsMD.split(::Any, ::Val{0}) (1 children)
   44 mt_cache

 inserting to_indices(A, inds, I::Tuple{AbstractArray{NDIndex{N, J}}, Vararg{Any}}) where {N, J} @ Static ~/.julia/dev/Static/src/Static.jl:919 invalidated:
   backedges: 1: superseding to_indices(A, inds, I::Tuple{Any, Vararg{Any}}) @ Base indices.jl:352 with MethodInstance for to_indices(::AbstractArray, ::Any, ::Tuple{Any, CartesianIndex{0}}) (2 children)
```