### PR TITLE
Don't mutate the hashtable with forward edges during final iteration.

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -1273,9 +1273,10 @@ static void jl_collect_backedges_to(jl_method_instance_t *caller, htable_t *all_
 {
     if (module_in_worklist(caller->def.method->module) || method_instance_in_queue(caller))
         return;
-    jl_array_t **pcallees = (jl_array_t**)ptrhash_bp(&edges_map, (void*)caller),
-                *callees = *pcallees;
-    if (callees != HT_NOTFOUND) {
+    if (ptrhash_has(&edges_map, caller)) {
+        jl_array_t **pcallees = (jl_array_t**)ptrhash_bp(&edges_map, (void*)caller),
+                    *callees = *pcallees;
+        assert(callees != HT_NOTFOUND);
         *pcallees = (jl_array_t*) HT_NOTFOUND;
         size_t i, l = jl_array_len(callees);
         for (i = 0; i < l; i++) {
@@ -1298,7 +1299,10 @@ static void jl_collect_backedges( /* edges */ jl_array_t *s, /* ext_targets */ j
     htable_new(&all_callees, 0);
     size_t i;
     void **table = edges_map.table;    // edges is caller => callees
-    for (i = 0; i < edges_map.size; i += 2) {
+    size_t table_size = edges_map.size;
+    for (i = 0; i < table_size; i += 2) {
+        assert(table == edges_map.table && table_size == edges_map.size &&
+               "edges_map changed during iteration");
         jl_method_instance_t *caller = (jl_method_instance_t*)table[i];
         jl_array_t *callees = (jl_array_t*)table[i + 1];
         if (callees == HT_NOTFOUND)


### PR DESCRIPTION
By looking up keys using `ptrhash_bp`, we possibly grow the hash table, invalidating the iteration we were doing in `jl_collect_backedges`. First perform a non-mutating check instead, and assert that the hashtable doesn't change during iteration.

It's possible there's other cases of the map being mutated, so this may not be sufficient, but hopefully the added assertion will help us detect this issue (which only occurred when a failed lookup caused the hash table to grow, which is unlikely).

Hopefully fixes https://github.com/JuliaLang/julia/issues/45444. I'm not sure how far to backport this; If my understanding of this bug is correct it's been lurking since forever, while we've only been seeing this on PkgEval for a couple of months...