### PR TITLE
LinearAlgebra/qr: Stop trying to factorize uninitialized memory

### DIFF
--- a/stdlib/LinearAlgebra/test/qr.jl
+++ b/stdlib/LinearAlgebra/test/qr.jl
@@ -244,7 +244,7 @@ end
 end
 
 @testset "Issue 16520" begin
-    @test_throws DimensionMismatch Matrix{Float64}(undef,3,2)\(1:5)
+    @test_throws DimensionMismatch rand(3,2)\(1:5)
 end
 
 @testset "Issue 22810" begin


### PR DESCRIPTION
It's fine for the test as is, but msan won't like this when enabled,
just use a random matrix rather than an uninitialized one.