### PR TITLE
Handle `PhiNode` with `edge==0`

### DIFF
--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -86,7 +86,7 @@ function replace_code_newstyle!(ci::CodeInfo, ir::IRCode, nargs::Int)
         elseif isa(stmt, GotoIfNot)
             code[i] = GotoIfNot(stmt.cond, first(ir.cfg.blocks[stmt.dest].stmts))
         elseif isa(stmt, PhiNode)
-            code[i] = PhiNode(Int32[last(ir.cfg.blocks[edge].stmts) for edge in stmt.edges], stmt.values)
+            code[i] = PhiNode(Int32[edge == 0 ? 0 : last(ir.cfg.blocks[edge].stmts) for edge in stmt.edges], stmt.values)
         elseif isexpr(stmt, :enter)
             stmt.args[1] = first(ir.cfg.blocks[stmt.args[1]::Int].stmts)
             code[i] = stmt

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4111,3 +4111,15 @@ struct Issue45780
 end
 f45780() = Val{Issue45780(@Base.Experimental.opaque ()->1).oc()}()
 @test (@inferred f45780()) == Val{1}()
+
+# issue #45600
+@test only(code_typed() do
+    while true
+        x = try finally end
+    end
+end)[2] == Union{}
+@test only(code_typed() do
+    while true
+        @time 1
+    end
+end)[2] == Union{}


### PR DESCRIPTION
I'm not entirely sure this makes sense. Maybe we shouldn't produce `PhiNode`s with an edge of 0 in the first place (inserting a dummy instruction as first BB before it instead or something). But I do get the same `@code_llvm` for `f() = while true x = try finally end end` and `g() = (nothing; while true x = try finally end end)`, where before, inference of `f()` would give an internal error. Also, I note that once upon a time, we used to do something similar:
https://github.com/JuliaLang/julia/blob/61b75ef38bfe3f5e4a7f6029fc3880dc27c10d51/base/compiler/ssair/legacy.jl#L197-L201

I'm not sure a `0`-edge might cause trouble elsewhere, though. But then again, it would not have worked at all before and did not seem to cause too much trouble, so those `PhiNode`s seem to be quite rare, and at least the case at hand is fixed by this.

Fixes #45600.