### PR TITLE
Specialize Diagonal * Matrix * Diagonal

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -371,10 +371,7 @@ end
 function (*)(Da::Diagonal, A::AbstractMatrix, Db::Diagonal)
     _muldiag_size_check(Da, A)
     _muldiag_size_check(A, Db)
-    dda = Da.diag
-    ddb = Db.diag
-    n = length(dda)
-    return broadcast(*, dda, A, reshape(ddb, 1, n))
+    return broadcast(*, Da.diag, A, permutedims(Db.diag))
 end
 
 # Get ambiguous method if try to unify AbstractVector/AbstractMatrix here using AbstractVecOrMat

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -374,7 +374,7 @@ function (*)(Da::Diagonal, A::AbstractMatrix, Db::Diagonal)
     dda = Da.diag
     ddb = Db.diag
     n = length(dda)
-    return broadcast(*, reshape(dda, n, 1), A, reshape(ddb, 1, n))
+    return broadcast(*, dda, A, reshape(ddb, 1, n))
 end
 
 # Get ambiguous method if try to unify AbstractVector/AbstractMatrix here using AbstractVecOrMat

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -368,6 +368,15 @@ end
     return out
 end
 
+function (*)(Da::Diagonal, A::AbstractMatrix, Db::Diagonal)
+    _muldiag_size_check(Da, A)
+    _muldiag_size_check(A, Db)
+    dda = Da.diag
+    ddb = Db.diag
+    n = length(dda)
+    return broadcast(*, reshape(dda, n, 1), A, reshape(ddb, 1, n))
+end
+
 # Get ambiguous method if try to unify AbstractVector/AbstractMatrix here using AbstractVecOrMat
 @inline mul!(out::AbstractVector, D::Diagonal, V::AbstractVector, alpha::Number, beta::Number) =
     _muldiag!(out, D, V, alpha, beta)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -659,6 +659,8 @@ end
     D2 = Diagonal(randn(10))
     @test D * A * D2 ≈ D * (A * D2)
     @test D * A * D2 ≈ (D * A) * D2
+    @test_throws DimensionMismatch Diagonal(ones(9)) * A * D2
+    @test_throws DimensionMismatch D * A * Diagonal(ones(9))
 end
 
 @testset "multiplication of QR Q-factor and Diagonal (#16615 spot test)" begin

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -653,6 +653,14 @@ end
     @test D2 == D * D
 end
 
+@testset "multiplication of 2 Diagonal and a Matix (#46400)" begin
+    A = randn(10, 10)
+    D = Diagonal(randn(10))
+    D2 = Diagonal(randn(10))
+    @test D * A * D2 ≈ D * (A * D2)
+    @test D * A * D2 ≈ (D * A) * D2
+end
+
 @testset "multiplication of QR Q-factor and Diagonal (#16615 spot test)" begin
     D = Diagonal(randn(5))
     Q = qr(randn(5, 5)).Q


### PR DESCRIPTION
This is a fast path for a 3 argument matrix multiplication where the first and third matrix is a `Diagonal`. This 3 arg matmul is commonly used in graph theory (e.g. computing graph laplacian, cc @yuehhua). With this fast path we get a performance boost that is about 2 times faster.

```julia
using LinearAlgebra, BenchmarkTools

A = randn(2000, 2000);
D = Diagonal(randn(2000));
D2 = Diagonal(randn(2000));

# on master
julia> @btime $D * $A * $D2;
  8.501 ms (4 allocations: 61.04 MiB)

# with this PR
julia> @btime $D * $A * $D2;
  4.151 ms (6 allocations: 30.52 MiB)
```
