### PR TITLE
wip: restore base/ prefix to base coverage paths

### DIFF
--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -28,9 +28,9 @@
     jlbacktrace;
     jlbacktracet;
     _IO_stdin_used;
-    _Z24jl_coverage_data_pointerN4llvm9StringRefEi;
-    _Z22jl_coverage_alloc_lineN4llvm9StringRefEi;
-    _Z22jl_malloc_data_pointerN4llvm9StringRefEi;
+    _Z24jl_coverage_data_pointerN4llvm9StringRefEi*;
+    _Z22jl_coverage_alloc_lineN4llvm9StringRefEi*;
+    _Z22jl_malloc_data_pointerN4llvm9StringRefEi*;
     LLVMExtra*;
     llvmGetPassPluginInfo;
 


### PR DESCRIPTION
Trying to fix the first issue in https://github.com/JuliaCI/julia-buildkite/issues/188

i.e. put the `base/` prefix back to base file names in coverage `.info` files, so that codecov & coveralls know which files to annotate, which they don't currently so just error https://app.codecov.io/gh/JuliaLang/julia