### PR TITLE
`Core.sizeof` isn't the same as `Core.Compiler.sizeof`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1854,7 +1854,7 @@ const _INACCESSIBLEMEM_BUILTINS = Any[
     apply_type,
     arraysize,
     Core.ifelse,
-    sizeof,
+    Core.sizeof,
     svec,
     fieldtype,
     isa,


### PR DESCRIPTION
Found this because it made effects analysis very confused about what effects `sizeof` has.