### PR TITLE
Fix `deepcopy` for `Base.GenericCondition`

### DIFF
--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -140,7 +140,7 @@ function deepcopy_internal(x::GenericCondition, stackdict::IdDict)
     if haskey(stackdict, x)
         return stackdict[x]
     end
-    y = typeof(x)(deepcopy_internal(x.lock))
+    y = typeof(x)(deepcopy_internal(x.lock, stackdict))
     stackdict[x] = y
     return y
 end

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -255,6 +255,7 @@ end
 
 @testset "`deepcopy` a `GenericCondition`" begin
     a = Base.GenericCondition(ReentrantLock())
+    @test !islocked(a.lock)
     lock(a.lock)
     @test islocked(a.lock)
     b = deepcopy(a)

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -262,6 +262,9 @@ end
     @test typeof(a) === typeof(b)
     @test a != b
     @test a !== b
+    @test typeof(a.lock) === typeof(b.lock)
+    @test a.lock != b.lock
+    @test a.lock !== b.lock
     @test islocked(a.lock)
     @test !islocked(b.lock)
 end

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -252,3 +252,15 @@ end
     a = [1:3;]
     @test copyto!(a, 2:3, 1:1, a, 1:2, 1:1) == [1;1:2;]
 end
+
+@testset "`deepcopy` a `GenericCondition`" begin
+    a = Base.GenericCondition(ReentrantLock())
+    lock(a.lock)
+    @test islocked(a.lock)
+    b = deepcopy(a)
+    @test typeof(a) === typeof(b)
+    @test a != b
+    @test a !== b
+    @test islocked(a.lock)
+    @test !islocked(b.lock)
+end


### PR DESCRIPTION
Fixes #46405 (which was introduced in #43325).