### PR TITLE
Fix `@time` compat description

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -228,9 +228,8 @@ See also [`@showtime`](@ref), [`@timev`](@ref), [`@timed`](@ref), [`@elapsed`](@
 
 !!! compat "Julia 1.8"
     The option to add a description was introduced in Julia 1.8.
-
-!!! compat "Julia 1.9"
-    Recompilation time being shown separately from compilation time was introduced in Julia 1.9
+    
+    Recompilation time being shown separately from compilation time was introduced in Julia 1.8
 
 ```julia-repl
 julia> x = rand(10,10);


### PR DESCRIPTION
In the docstring it says that the recompilation time feature was added in 1.9, but this is available in 1.8. 