### PR TITLE
Improve the Core.Compiler.@show helper.

### DIFF
--- a/base/compiler/ssair/driver.jl
+++ b/base/compiler/ssair/driver.jl
@@ -3,8 +3,14 @@
 if false
     import Base: Base, @show
 else
-    macro show(s)
-        return :(println(stdout, $(QuoteNode(s)), " = ", $(esc(s))))
+    macro show(ex...)
+        blk = Expr(:block)
+        for s in ex
+            push!(blk.args, :(println(stdout, $(QuoteNode(s)), " = ",
+                                              begin local value = $(esc(s)) end)))
+        end
+        isempty(ex) || push!(blk.args, :value)
+        blk
     end
 end
 


### PR DESCRIPTION
Add support for multiple arguments, returning the last value, just like how `Base.@show` works.