### PR TITLE
Improve docs for `vcat`, `cat`, etc.

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1923,8 +1923,8 @@ julia> col0 = Matrix(undef, 2, 0)  # empty matrix, size (2,0)
 
 julia> hcat([1.1, 9.9], col0, ms[3])
 2×3 Matrix{Any}:
- 1.1  50  60
- 9.9  70  80
+ 1.1  50.0  60.0
+ 9.9  70.0  80.0
 ```
 """
 hcat(X...) = cat(X...; dims=Val(2))

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3113,9 +3113,9 @@ julia> B = mapslices(f, A, dims=(1,2))
 [:, :, 3] =
  21  21  21  21
 
-julia> f(x::AbstractMatrix) = fill(x[1,1], 1,4);
+julia> f2(x::AbstractMatrix) = fill(x[1,1], 1,4);
 
-julia> B == stack(f, eachslice(A, dims=3))
+julia> B == stack(f2, eachslice(A, dims=3))
 true
 
 julia> g(x) = x[begin] // x[end-1];  # returns a number

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3082,7 +3082,7 @@ concatenated along the remaining dimensions.
 For example, if `dims = [1,2]` and `A` is 4-dimensional, then `f` is called on `x = A[:,:,i,j]`
 for all `i` and `j`, and `f(x)` becomes `R[:,:,i,j]` in the result `R`.
 
-See also [`eachcol`](@ref), [`eachslice`](@ref), [`mapreduce`](@ref).
+See also [`eachcol`](@ref) or [`eachslice`](@ref), used with [`map`](@ref) or [`stack`](@ref).
 
 # Examples
 ```jldoctest
@@ -3102,7 +3102,7 @@ julia> A = reshape(1:30,(2,5,3))
 
 julia> f(x::Matrix) = fill(x[1,1], 1,4);  # returns a 1×4 matrix
 
-julia> mapslices(f, A, dims=(1,2))
+julia> B = mapslices(f, A, dims=(1,2))
 1×4×3 Array{$Int, 3}:
 [:, :, 1] =
  1  1  1  1
@@ -3112,6 +3112,11 @@ julia> mapslices(f, A, dims=(1,2))
 
 [:, :, 3] =
  21  21  21  21
+
+julia> f(x::AbstractMatrix) = fill(x[1,1], 1,4);
+
+julia> B == stack(f, eachslice(A, dims=3))
+true
 
 julia> g(x) = x[begin] // x[end-1];  # returns a number
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1845,7 +1845,7 @@ julia> vcat(range(1, 2, length=3))  # collects lazy ranges
  1.5
  2.0
 
-julia> vcat(3, [], [4.5;;])  # empty vector Any[] affects the eltype 
+julia> vcat(3, [], [4.5;;])  # empty vector Any[] affects the eltype
 2×1 Matrix{Any}:
  3
  4.5
@@ -1869,9 +1869,9 @@ julia> reduce(vcat, vs)  # more efficient than vcat(vs...)
  4
  5
  6
- 
+
 julia> ans == collect(Iterators.flatten(vs))
-true 
+true
 ```
 """
 vcat(X...) = cat(X...; dims=Val(1))
@@ -1938,14 +1938,14 @@ typed_hcat(::Type{T}, X...) where T = _cat_t(Val(2), T, X...)
 Concatenate the input arrays along the dimensions specified in `dims`.
 
 Along a dimension `d in dims`, the size of the output array is `sum(size(a,d) for
-a in A)`. 
+a in A)`.
 Along other dimensions, all input arrays should have the same size,
 which will also be the size of the output array along those dimensions.
 
-If `dims` is a single number, the different arrays are tightly packed along that dimension. 
+If `dims` is a single number, the different arrays are tightly packed along that dimension.
 If `dims` is an iterable containing several dimensions, the positions along these dimensions
 are increased simultaneously for each input array, filling with zero elsewhere.
-This allows one to construct block-diagonal matrices as `cat(matrices...; dims=(1,2))`, 
+This allows one to construct block-diagonal matrices as `cat(matrices...; dims=(1,2))`,
 and their higher-dimensional analogues.
 
 The keyword also accepts `Val(dims)`.

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1814,7 +1814,7 @@ end
     vcat(A...)
 
 Concatenate arrays or numbers vertically. Equivalent to [`cat`](@ref)`(A...; dims=1)`,
-which is also called by the syntax `[a; b; c]`.
+and to the syntax `[a; b; c]`.
 
 To concatenate a large vector of arrays, `reduce(vcat, A)` calls an efficient method
 when `A isa AbstractVector{<:AbstractVecOrMat}`, rather than working pairwise.
@@ -1845,11 +1845,6 @@ julia> vcat(range(1, 2, length=3))  # collects lazy ranges
  1.5
  2.0
 
-julia> vcat(3, [], [4.5;;])  # empty vector Any[] affects the eltype
-2×1 Matrix{Any}:
- 3
- 4.5
-
 julia> two = ([10, 20, 30]', Float64[4 5 6; 7 8 9])  # row vector and a matrix
 ([10 20 30], [4.0 5.0 6.0; 7.0 8.0 9.0])
 
@@ -1879,7 +1874,7 @@ vcat(X...) = cat(X...; dims=Val(1))
     hcat(A...)
 
 Concatenate arrays or numbers horizontally. Equivalent to [`cat`](@ref)`(A...; dims=2)`,
-which is also called by the syntax `[a b c]` or `[a;;]`.
+and to the syntax `[a b c]` or `[a;; b;; c]`.
 
 For a large vector of arrays, `reduce(hcat, A)` calls an efficient method
 when `A isa AbstractVector{<:AbstractVecOrMat}`.
@@ -1894,16 +1889,16 @@ julia> hcat([1,2], [3,4], [5,6])
  1  3  5
  2  4  6
 
-julia> hcat(1, 2, [30 40], [5, 6]')
-1×6 Matrix{Int64}:
- 1  2  30  40  5  6
+julia> hcat(1, 2, [30 40], [5, 6, 7]')  # accepts numbers
+1×7 Matrix{Int64}:
+ 1  2  30  40  5  6  7
 
-julia> ans == [1 2 [30 40] [5, 6]']  # syntax for the same operation
+julia> ans == [1 2 [30 40] [5, 6, 7]']  # syntax for the same operation
 true
 
-julia> Float32[1 2 [30 40] [5, 6]']  # syntax for supplying the eltype
-1×6 Matrix{Float32}:
- 1.0  2.0  30.0  40.0  5.0  6.0
+julia> Float32[1 2 [30 40] [5, 6, 7]']  # syntax for supplying the eltype
+1×7 Matrix{Float32}:
+ 1.0  2.0  30.0  40.0  5.0  6.0  7.0
 
 julia> ms = [zeros(2,2), [1 2; 3 4], [50 60; 70 80]];
 
@@ -1918,13 +1913,10 @@ julia> stack(ms) |> summary  # disagrees on a vector of matrices
 julia> hcat(Int[], Int[], Int[])  # empty vectors, each of size (0,)
 0×3 Matrix{Int64}
 
-julia> col0 = Matrix(undef, 2, 0)  # empty matrix, size (2,0)
-2×0 Matrix{Any}
-
-julia> hcat([1.1, 9.9], col0, ms[3])
-2×3 Matrix{Any}:
- 1.1  50.0  60.0
- 9.9  70.0  80.0
+julia> hcat([1.1, 9.9], Matrix(undef, 2, 0))  # hcat with empty 2×0 Matrix
+2×1 Matrix{Any}:
+ 1.1
+ 9.9
 ```
 """
 hcat(X...) = cat(X...; dims=Val(2))
@@ -1948,23 +1940,23 @@ are increased simultaneously for each input array, filling with zero elsewhere.
 This allows one to construct block-diagonal matrices as `cat(matrices...; dims=(1,2))`,
 and their higher-dimensional analogues.
 
-The keyword also accepts `Val(dims)`.
-
 The special case `dims=1` is [`vcat`](@ref), and `dims=2` is [`hcat`](@ref).
 See also [`hvcat`](@ref), [`stack`](@ref), [`repeat`](@ref).
 
+The keyword also accepts `Val(dims)`.
+
+!!! compat "Julia 1.8"
+    For multiple dimensions `dims = Val(::Tuple)` was added in Julia 1.8.
+
 # Examples
 ```jldoctest
-julia> cat([1 2; 3 4], [pi, pi], fill(10, 2,3,1); dims=2)
+julia> cat([1 2; 3 4], [pi, pi], fill(10, 2,3,1); dims=2)  # same as hcat
 2×6×1 Array{Float64, 3}:
 [:, :, 1] =
  1.0  2.0  3.14159  10.0  10.0  10.0
  3.0  4.0  3.14159  10.0  10.0  10.0
 
-julia> size([pi, pi], 3)
-1
-
-julia> cat(true, trues(2,2), trues(4)', dims=(1,2))
+julia> cat(true, trues(2,2), trues(4)', dims=(1,2))  # block-diagonal
 4×7 Matrix{Bool}:
  1  0  0  0  0  0  0
  0  1  1  0  0  0  0

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -459,8 +459,10 @@ For empty collections, providing `init` will be necessary, except for some speci
 neutral element of `op`.
 
 Reductions for certain commonly-used operators may have special implementations, and
-should be used instead: `maximum(itr)`, `minimum(itr)`, `sum(itr)`, `prod(itr)`,
- `any(itr)`, `all(itr)`.
+should be used instead: [`maximum`](@ref)`(itr)`, [`minimum`](@ref)`(itr)`, [`sum`](@ref)`(itr)`,
+[`prod`](@ref)`(itr)`, [`any`](@ref)`(itr)`, [`all`](@ref)`(itr)`.
+There are efficient methods for concatenating certain arrays of arrays
+by calling `reduce(`[`vcat`](@ref)`, arr)` or `reduce(`[`hcat`](@ref)`, arr)`.
 
 The associativity of the reduction is implementation dependent. This means that you can't
 use non-associative operations like `-` because it is undefined whether `reduce(-,[1,2,3])`

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -382,7 +382,7 @@ The associativity of the reduction is implementation-dependent; if you need a pa
 associativity, e.g. left-to-right, you should write your own loop or consider using
 [`foldl`](@ref) or [`foldr`](@ref). See documentation for [`reduce`](@ref).
 
-There are special efficient methods for `reduce(`[`vcat`](@ref)`, xs)` and 
+There are special efficient methods for `reduce(`[`vcat`](@ref)`, xs)` and
 `reduce(`[`hcat`](@ref)`, xs)` for certain arrays of arrays; see also [`stack`](@ref).
 
 # Examples

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -382,6 +382,9 @@ The associativity of the reduction is implementation-dependent; if you need a pa
 associativity, e.g. left-to-right, you should write your own loop or consider using
 [`foldl`](@ref) or [`foldr`](@ref). See documentation for [`reduce`](@ref).
 
+There are special efficient methods for `reduce(`[`vcat`](@ref)`, xs)` and 
+`reduce(`[`hcat`](@ref)`, xs)` for certain arrays of arrays; see also [`stack`](@ref).
+
 # Examples
 ```jldoctest
 julia> a = reshape(Vector(1:16), (4,4))

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -382,9 +382,6 @@ The associativity of the reduction is implementation-dependent; if you need a pa
 associativity, e.g. left-to-right, you should write your own loop or consider using
 [`foldl`](@ref) or [`foldr`](@ref). See documentation for [`reduce`](@ref).
 
-There are special efficient methods for `reduce(`[`vcat`](@ref)`, xs)` and
-`reduce(`[`hcat`](@ref)`, xs)` for certain arrays of arrays; see also [`stack`](@ref).
-
 # Examples
 ```jldoctest
 julia> a = reshape(Vector(1:16), (4,4))

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -85,6 +85,8 @@ the ordering of the dimensions will match those in `dims`. If `drop = false`, th
 `Slices` will have the same dimensionality as the underlying array, with inner
 dimensions having size 1.
 
+See [`stack`](@ref)`(slices; dims)` for the inverse of `eachcol(A; dims::Integer, drop=true)`.
+
 See also [`eachrow`](@ref), [`eachcol`](@ref), [`mapslices`](@ref) and [`selectdim`](@ref).
 
 !!! compat "Julia 1.1"
@@ -131,6 +133,8 @@ end
 Create a [`RowSlices`](@ref) object that is a vector of rows of matrix or vector `A`.
 Row slices are returned as `AbstractVector` views of `A`.
 
+For the inverse, see [`stack`](@ref)`(rows; dims=1)`.
+
 See also [`eachcol`](@ref), [`eachslice`](@ref) and [`mapslices`](@ref).
 
 !!! compat "Julia 1.1"
@@ -166,6 +170,8 @@ eachrow(A::AbstractVector) = eachrow(reshape(A, size(A,1), 1))
 
 Create a [`ColumnSlices`](@ref) object that is a vector of columns of matrix or vector `A`.
 Column slices are returned as `AbstractVector` views of `A`.
+
+For the inverse, see [`stack`](@ref)`(cols)` or `reduce(`[`hcat`](@ref)`, cols)`.
 
 See also [`eachrow`](@ref), [`eachslice`](@ref) and [`mapslices`](@ref).
 


### PR DESCRIPTION
This wants to:
* Mention the fast methods for `reduce(vcat, A)` under `reduce` and under `vcat`, and state *exactly* what types they accept. As far as I know this was documented nowhere besides `methods(reduce)`.
* Mention `stack` from [#43334](https://github.com/JuliaLang/julia/pull/43334) as an alternative where appropriate, including under `eachslice` and `mapslices`.
* Provide better examples for `vcat`, `hcat`. They are about the same length, but try not to print out things like `b = [6 7; 8 9; 10 11; 12 13; 14 15]` too often, instead illustrating more uses, from simple to complex.
* Break up the wall of text for `cat(A...; dims)`, and avoid saying the word "stacked" there.