### PR TITLE
fix bug when error is infinite

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -1176,8 +1176,8 @@ end
         xnlo += err
         n >>>= 1
     end
-    !isfinite(x) && return x*y
-    return muladd(x, y, muladd(y, xnlo, x*ynlo))
+    err = muladd(y, xnlo, x*ynlo)
+    return ifelse(isfinite(x) & isfinite(err), muladd(x, y, err), x*y)
 end
 
 function ^(x::Float32, n::Integer)

--- a/test/math.jl
+++ b/test/math.jl
@@ -1362,6 +1362,7 @@ end
     end
     # test for large negative exponent where error compensation matters
     @test 0.9999999955206014^-1.0e8 == 1.565084574870928
+    @test 3e18^20 == Inf
 end
 
 # Test that sqrt behaves correctly and doesn't exhibit fp80 double rounding.


### PR DESCRIPTION
Previously I had assumed that the error terms were strictly smaller than the result (which is true), but the error terms can never the less be infinite, and because of the order in which things are computed (having to do with `fma`) the error term was sometimes choosing the sign of the infinity which is bad.