### PR TITLE
Information for specific operating system

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -251,7 +251,7 @@ unsafe_securezero!(p::Ptr{Cvoid}, len::Integer=1) = Ptr{Cvoid}(unsafe_securezero
 Display a message and wait for the user to input a secret, returning an `IO`
 object containing the secret.
 
-!!! info "Windows OS"
+!!! info "Windows"
     Note that on Windows, the secret might be displayed as it is typed; see
     `Base.winprompt` for securely retrieving username/password pairs from a
     graphical interface.

--- a/base/util.jl
+++ b/base/util.jl
@@ -251,9 +251,10 @@ unsafe_securezero!(p::Ptr{Cvoid}, len::Integer=1) = Ptr{Cvoid}(unsafe_securezero
 Display a message and wait for the user to input a secret, returning an `IO`
 object containing the secret.
 
-Note that on Windows, the secret might be displayed as it is typed; see
-`Base.winprompt` for securely retrieving username/password pairs from a
-graphical interface.
+!!! info "Windows OS"
+    Note that on Windows, the secret might be displayed as it is typed; see
+    `Base.winprompt` for securely retrieving username/password pairs from a
+    graphical interface.
 """
 function getpass end
 
@@ -347,7 +348,7 @@ Displays the `message` then waits for user input. Input is terminated when a new
 is encountered or EOF (^D) character is entered on a blank line. If a `default` is provided
 then the user can enter just a newline character to select the `default`.
 
-See also `Base.getpass` and `Base.winprompt` for secure entry of passwords.
+See also `Base.winprompt` (if your OS is Windows) and `Base.getpass` for secure entry of passwords.
 
 # Example
 

--- a/base/util.jl
+++ b/base/util.jl
@@ -348,7 +348,7 @@ Displays the `message` then waits for user input. Input is terminated when a new
 is encountered or EOF (^D) character is entered on a blank line. If a `default` is provided
 then the user can enter just a newline character to select the `default`.
 
-See also `Base.winprompt` (if your OS is Windows) and `Base.getpass` for secure entry of passwords.
+See also `Base.winprompt` (for Windows) and `Base.getpass` for secure entry of passwords.
 
 # Example
 


### PR DESCRIPTION
To not cause ambiguities, when a message is going to a specific operating system, say windows, its will be best if an info is spelled at the top indicating its for windows user or a note on a bracket saying this is available for windows users only, so the reader on the docs can know what's happening, other than assuming with the prefix of `win`, one would immediately figure out its talking about Windows.

If this culture persists of using just `win` and is ingrained into every first time user on Julia, packages using names whose prefix starts with `win` base on related field, might be mistaken for talking about a Windows thing and would cause a lot of bugs where different aspects of the package and windows functionality needs to be added together. Another reason is that when its talking about MacOs, no `Mac` prefix is applied, causing more ambiguities.