### PR TITLE
fix `Base.return_types` for direct builtin calls

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3324,7 +3324,8 @@ f_generator_splat(t::Tuple) = tuple((identity(l) for l in t)...)
 @test Core.Compiler.sizeof_tfunc(UnionAll) === Int
 @test !Core.Compiler.sizeof_nothrow(UnionAll)
 
-@test Base.return_types(Expr) == Any[Expr]
+@test only(Base.return_types(Core._expr)) === Expr
+@test only(Base.return_types(Core.svec, (Any,))) === Core.SimpleVector
 
 # Use a global constant to rely less on unrelated constant propagation
 const const_int32_typename = Int32.name

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -202,7 +202,7 @@ end
 
 @test which(===, Tuple{Int, Int}) isa Method
 @test length(code_typed(===, Tuple{Int, Int})) === 1
-@test only(Base.return_types(===, Tuple{Int, Int})) === Any
+@test only(Base.return_types(===, Tuple{Int, Int})) === Bool
 
 module TestingExported
 using Test


### PR DESCRIPTION
This commit also changed this fragile test case
```
@test Base.return_types(Expr) == Any[Expr]
```
to
```
@test only(Base.return_types(Core._expr)) === Expr
```
since `Expr` is just a generic function and can be overloaded
in the future (e.g. the JuliaSyntax.jl integration PR).