### PR TITLE
Test suite: set the `JULIA_TEST_IS_BASE_TESTS` environment variable

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -647,6 +647,7 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS / 2),
     ENV2 = copy(ENV)
     ENV2["JULIA_CPU_THREADS"] = "$ncores"
     ENV2["JULIA_DEPOT_PATH"] = mktempdir(; cleanup = true)
+    ENV2["JULIA_TEST_IS_BASE_TESTS"] = "true"
     delete!(ENV2, "JULIA_LOAD_PATH")
     delete!(ENV2, "JULIA_PROJECT")
     try


### PR DESCRIPTION
This allows the authors of external stdlibs to write tests that are executed during the external stdlib repo's GitHub Actions CI but are skipped as part of the Base Julia Buildkite CI on this repo.