### PR TITLE
Fix `typeintersect` bug reported in #36443

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2877,6 +2877,11 @@ static jl_value_t *intersect_invariant(jl_value_t *x, jl_value_t *y, jl_stenv_t 
     jl_value_t *ii = intersect(x, y, e, 2);
     e->invdepth--;
     e->Rinvdepth--;
+    // Skip the following subtype check if `ii` was returned from `set_vat_to_const`.
+    // As `var_gt`/`var_lt` might not handle `Vararg` length offset correctly.
+    // TODO: fix this on subtype side and remove this branch.
+    if (jl_is_long(ii) && ((jl_is_typevar(x) && jl_is_long(y)) || (jl_is_typevar(y) && jl_is_long(x))))
+        return ii;
     if (jl_is_typevar(x) && jl_is_typevar(y) && (jl_is_typevar(ii) || !jl_is_type(ii)))
         return ii;
     if (ii == jl_bottom_type) {

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2170,7 +2170,7 @@ static jl_value_t *set_var_to_const(jl_varbinding_t *bb, jl_value_t *v JL_MAYBE_
         bb->lb = bb->ub = v;
     }
     else if (jl_is_long(v) && jl_is_long(bb->lb)) {
-        if (jl_unbox_long(v) != jl_unbox_long(bb->lb))
+        if (jl_unbox_long(v) + offset != jl_unbox_long(bb->lb))
             return jl_bottom_type;
     }
     else if (!jl_egal(v, bb->lb)) {


### PR DESCRIPTION
1. On master, we use a `offset` field to recode the valid length difference between 2 `Vararg`s.
It is set outside `intersect_varargs`, so when we check the `Vararg`'s eltype, the intersection result would be influenced when we have e.g. `Vararg{Val{N},N}`.
The first commit move the `offset` setting into `intersect_varargs` to fix the problem.
2. On master, `set_var_to_const` will ignore the `offset` if the `typevar` has been settled, thus gives many false `Union{}`. 
The second commit fix it.
3. At present, when we intersect 2 `Vararg`s length, we always return the length on the right. Which cause many order dependent error. In fact we should always return the shorter `Vararg`'s length, as the extra elements has been consumed within `intersect_tuple`.
4. At present, when we intersect 2 unbounded `Vararg`s length, we always set them equal, which is not correct if `offset != 0`. The 4th commit fix it (Not all, as some Vararg has `Null` length, which causes #39088)

close #36443, close #37257. Test added.