### PR TITLE
fix #45952, improve type stability of `_typed_hvncat`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2244,7 +2244,8 @@ _typed_hvncat(::Type, ::Val{0}, ::AbstractArray...) = _typed_hvncat_0d_only_one(
 _typed_hvncat_0d_only_one() =
     throw(ArgumentError("a 0-dimensional array may only contain exactly one element"))
 
-_typed_hvncat(T::Type, dim::Int, ::Bool, xs...) = _typed_hvncat(T, Val(dim), xs...) # catches from _hvncat type promoters
+# `@constprop :aggressive` here to form constant `Val(dim)` type to get type stability
+@constprop :aggressive _typed_hvncat(T::Type, dim::Int, ::Bool, xs...) = _typed_hvncat(T, Val(dim), xs...) # catches from _hvncat type promoters
 
 function _typed_hvncat(::Type{T}, ::Val{N}) where {T, N}
     N < 0 &&

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1815,3 +1815,7 @@ end
     a, b = zeros(2, 2, 2), zeros(2, 2)
     @test_broken IRUtils.fully_eliminated(_has_offset_axes, Base.typesof(a, a, b, b))
 end
+
+# type stable [x;;] (https://github.com/JuliaLang/julia/issues/45952)
+f45952(x) = [x;;]
+@inferred f45952(1.0)


### PR DESCRIPTION
A short-term fix for the type-stability issue reported in #45952.