### PR TITLE
Better error messages for getindex(::Number)

### DIFF
--- a/base/number.jl
+++ b/base/number.jl
@@ -95,12 +95,12 @@ keys(::Number) = OneTo(1)
 getindex(x::Number) = x
 function getindex(x::Number, i::Integer)
     @inline
-    @boundscheck i == 1 || throw(BoundsError())
+    @boundscheck i == 1 || throw(BoundsError(x, i))
     x
 end
 function getindex(x::Number, I::Integer...)
     @inline
-    @boundscheck all(isone, I) || throw(BoundsError())
+    @boundscheck all(isone, I) || throw(BoundsError(x, i))
     x
 end
 get(x::Number, i::Integer, default) = isone(i) ? x : default

--- a/base/number.jl
+++ b/base/number.jl
@@ -100,7 +100,7 @@ function getindex(x::Number, i::Integer)
 end
 function getindex(x::Number, I::Integer...)
     @inline
-    @boundscheck all(isone, I) || throw(BoundsError(x, i))
+    @boundscheck all(isone, I) || throw(BoundsError(x, I))
     x
 end
 get(x::Number, i::Integer, default) = isone(i) ? x : default


### PR DESCRIPTION
Previously it threw a generic `BoundsError`. Now it includes a helpful message.

Before:
```julia
julia> function f(x, y, z)
    return x[round(Int, sqrt(y+7)-4)], z
end;

julia> f(17, 28, 4:6)
ERROR: BoundsError
Stacktrace:
 [1] getindex
   @ ./number.jl:98 [inlined]
 [2] f(x::Int64, y::Int64, z::UnitRange{Int64})
   @ Main ./REPL[121]:2
 [3] top-level scope
   @ REPL[123]:1
```
After:
```julia
julia> function f(x, y, z)
    return x[round(Int, sqrt(y+7)-4)], z
end;

julia> f(17, 28, 4:6)
ERROR: BoundsError: attempt to access Int64 at index [2]
Stacktrace:
 [1] getindex
   @ ./number.jl:98 [inlined]
 [2] f(x::Int64, y::Int64, z::UnitRange{Int64})
   @ Main ./REPL[121]:2
 [3] top-level scope
   @ REPL[123]:1
```