### PR TITLE
More specificity about the isreal(x) function

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -126,12 +126,16 @@ real(C::Type{<:Complex}) = fieldtype(C, 1)
 
 Test whether `x` or all its elements are numerically equal to some real number
 including infinities and NaNs. `isreal(x)` is true if `isequal(x, real(x))`
-is true.
+is true - this means, for `Complex` types, isreal(x) is only `true` when the
+imaginary part is `0`.
 
 # Examples
 ```jldoctest
 julia> isreal(5.)
 true
+                
+julia> isreal(1 - 3im)
+false
 
 julia> isreal(Inf + 0im)
 true

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -126,7 +126,7 @@ real(C::Type{<:Complex}) = fieldtype(C, 1)
 
 Test whether `x` or all its elements are numerically equal to some real number
 including infinities and NaNs. `isreal(x)` is true if `isequal(x, real(x))`
-is true - this means, for `Complex` types, isreal(x) is only `true` when the
+is true - this means, for `Complex` numbers, `isreal(x)` would `true` if the
 imaginary part is `0`.
 
 # Examples

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -126,8 +126,7 @@ real(C::Type{<:Complex}) = fieldtype(C, 1)
 
 Test whether `x` or all its elements are numerically equal to some real number
 including infinities and NaNs. `isreal(x)` is true if `isequal(x, real(x))`
-is true - this means, for `Complex` numbers, `isreal(x)` would `true` if the
-imaginary part is `0`.
+is true.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
It's clear what `isinteger` does at first sight. It's clear what `isnumeric` does at first sight. It's also clear what `isdigit` at first sight. But what does `isreal` does at first sight, confusing right?

`isreal(x)` seems to be too vague a function name when it's applied on `Complex` numbers. My reasons are because:
1. We don't know if it's trying to ask if just the real part of the complex number is subtype of `Real` i.e. a real number.
2. We also don't know if its trying to ask if the whole number i.e. it's real and imaginary part(if it has any) is a real number.

Number 2 reason is very important as we know technically speaking `1` is a real number and `2 + 3im` is a complex number. So one would naturally expect `isreal(x)` to return `false` for all complex numbers (which in Julia does not). So you see it's kinda ambiguous.

I'm not proposing a function name change. What I'm saying is it will help if the `isreal` documentation provides more information on how it relates with complex numbers and probably more examples in regard to complex numbers, to at least lessen the ambiguities for users who care to check on the `isreal(x)` definition before using it.

```
Julia> typeof(1 + 0im)
Complex{Int64}

Julia> isreal(1 + 0im)
true
```

So even though the imaginary part is `0` as we can see above, in Julia the number is still regarded as a complex number, which returns `true` as an argument to the `isreal(x)` function, causing more confusion and painful subtle bugs (when you only want subtypes of `Real` numbers and not `Complex` numbers of any type). So it will be best if it's stated explicitly, that this is the only way for complex numbers to return `true` from the `isreal(x)` function, as a way to serve as a caution upfront.

To add to it, the docs examples and specificity on the relationship of isreal with complex numbers is too small - I believe the function is used more when working with complex numbers, so it makes sense to add a little info about how the isreal works with complex numbers and maybe one or two more examples where it will be helpful.