### PR TITLE
Explicitness on the ismutable(v) function.

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -494,7 +494,7 @@ end
 
 Return `true` if and only if value `v` is mutable.  See [Mutable Composite Types](@ref)
 for a discussion of immutability. Note that this function works on values, so if you
-give it a `DataType`, it will tell you that a value of the `DataType` is mutable.
+give it a `DataType`, it will tell you that a value of the type is mutable.
 
 See also [`isbits`](@ref), [`isstructtype`](@ref).
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -493,8 +493,8 @@ end
     ismutable(v) -> Bool
 
 Return `true` if and only if value `v` is mutable.  See [Mutable Composite Types](@ref)
-for a discussion of immutability. Note that this function works on values, so if you give it
-a type, it will tell you that a value of `DataType` is mutable.
+for a discussion of immutability. Note that this function works on values, so if you
+give it a `DataType`, it will tell you that a value of the `DataType` is mutable.
 
 See also [`isbits`](@ref), [`isstructtype`](@ref).
 


### PR DESCRIPTION
Providing more information helps to distinguish on which types the `ismutable` function defaults to returning `false` on.

The function doc says:
> so if you give it a type, it will tell you that a value of DataType is mutable.

Well a type can mean any type and for types other than a `DataType`, this returns `false` going against what the doc says. This can cause confusions and subtle bugs.

For example:
```julia
julia> Complex isa Type
true

julia> typeof(Complex)
UnionAll

#= 👇this should return true if we're to go with the docs,
but it doesn't even, when Complex is a type in Julia. =#
julia> ismutable(Complex)
false
```

But by stating **explicitly** that only a `DataType` returns `true`, one can understand why:
```julia
julia> ismutable(Complex{Int64})
true
```
and:
```julia
julia> ismutable(Complex)
false
```
This is because the type of `Complex{Int64}` is a `DataType`, while `Complex` is not:
```julia
julia> typeof(Complex{Int64})
DataType

julia> typeof(Complex)
UnionAll
```

This is also evident when using the function with a `Union`. For example:
```julia
julia> Union{Int, Float64} isa Type
true

julia> typeof(Union{Int, Float64})
Union

# if we're to go with the docs, this 👇should return true also, but it doesn't
julia> ismutable(Union{Int, Float64})
false
```

Once again, if it's stated that only a `DataType` returns `true`, then one can understand why it doesn't since the type is not a `DataType`:
```julia
julia> typeof(Union{Int, Float64})
Union
```


