### PR TITLE
inference×effects: improve the const-prop' heuristics

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1264,8 +1264,6 @@ function const_prop_methodinstance_heuristic(interp::AbstractInterpreter,
     elseif is_stmt_noinline(flag)
         # this call won't be inlined, thus this constant-prop' will most likely be unfruitful
         return false
-    elseif any_const_prop_profitable_args(effects, arginfo.argtypes)
-        return true
     end
     # Peek at the inferred result for the method to determine if the optimizer
     # was able to cut it down to something simple (inlineable in particular).
@@ -1275,8 +1273,9 @@ function const_prop_methodinstance_heuristic(interp::AbstractInterpreter,
     if isa(code, CodeInstance)
         inferred = @atomic :monotonic code.inferred
         rt = code.rettype
+        boost = any_const_prop_profitable_args(effects, arginfo.argtypes)
         # TODO propagate a specific `CallInfo` that conveys information about this call
-        iinfo = InliningInfo(rt, mi, arginfo.argtypes, NoCallInfo(), IR_FLAG_NULL)
+        iinfo = InliningInfo(rt, mi, arginfo.argtypes, NoCallInfo(), IR_FLAG_NULL, boost)
         if inlining_policy(interp, inferred, iinfo) !== nothing
             return true
         end

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -169,7 +169,9 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
         all_effects = Effects(all_effects; nothrow=false)
     end
 
-    rettype = from_interprocedural!(𝕃ₚ, rettype, sv, arginfo, conditionals)
+    ret = from_interprocedural!(𝕃ₚ, rettype, all_effects, sv, arginfo, conditionals)
+    rettype = ret.rt
+    all_effects = ret.effects
 
     # Also considering inferring the compilation signature for this method, so
     # it is available to the compiler in case it ends up needing it.
@@ -180,7 +182,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
         method = match.method
         sig = match.spec_types
         mi = specialize_method(match; preexisting=true)
-        if mi !== nothing && !const_prop_methodinstance_heuristic(interp, mi, arginfo, sv)
+        if mi !== nothing && !const_prop_methodinstance_heuristic(interp, mi, arginfo, Effects(), sv)
             csig = get_compileable_sig(method, sig, match.sparams)
             if csig !== nothing && csig !== sig
                 abstract_call_method(interp, method, csig, match.sparams, multiple_matches, StmtInfo(false), sv)
@@ -315,15 +317,24 @@ function find_matching_methods(𝕃::AbstractLattice,
     end
 end
 
-"""
-    from_interprocedural!(𝕃ₚ::AbstractLattice, rt, sv::AbsIntState, arginfo::ArgInfo, maybecondinfo) -> newrt
+struct InterproceduralResult
+    rt
+    effects::Effects
+    InterproceduralResult(@nospecialize(rt), effects::Effects) = new(rt, effects)
+end
 
-Converts inter-procedural return type `rt` into a local lattice element `newrt`,
-that is appropriate in the context of current local analysis frame `sv`, especially:
+"""
+    from_interprocedural!(𝕃ₚ::AbstractLattice, rt, effects::Effects,
+        sv::AbsIntState, arginfo::ArgInfo, maybecondinfo) -> InterproceduralResult
+
+Converts extended lattice element `rt` and `effects::Effects` that represent inferred
+return type and method call effects into new lattice ement and `Effects` that are
+appropriate in the context of current local analysis frame `sv`, especially:
 - unwraps `rt::LimitedAccuracy` and collects its limitations into the current frame `sv`
 - converts boolean `rt` to new boolean `newrt` in a way `newrt` can propagate extra conditional
   refinement information, e.g. translating `rt::InterConditional` into `newrt::Conditional`
   that holds a type constraint information about a variable in `sv`
+- recomputes `effects.const_prop_profitable_args` so that they are imposed on call arguments of `sv`
 
 This function _should_ be used wherever we propagate results returned from
 `abstract_call_method` or `abstract_call_method_with_const_args`.
@@ -335,7 +346,8 @@ In such cases `maybecondinfo` should be either of:
 When we deal with multiple `MethodMatch`es, it's better to precompute `maybecondinfo` by
 `tmerge`ing argument signature type of each method call.
 """
-function from_interprocedural!(𝕃ₚ::AbstractLattice, @nospecialize(rt), sv::AbsIntState, arginfo::ArgInfo, @nospecialize(maybecondinfo))
+function from_interprocedural!(𝕃ₚ::AbstractLattice, @nospecialize(rt), effects::Effects,
+    sv::AbsIntState, arginfo::ArgInfo, @nospecialize(maybecondinfo))
     rt = collect_limitations!(rt, sv)
     if isa(rt, InterMustAlias)
         rt = from_intermustalias(rt, arginfo)
@@ -347,7 +359,23 @@ function from_interprocedural!(𝕃ₚ::AbstractLattice, @nospecialize(rt), sv::
         end
     end
     @assert !(rt isa InterConditional || rt isa InterMustAlias) "invalid lattice element returned from inter-procedural context"
-    return rt
+    if effects.const_prop_profitable_args !== NO_PROFITABLE_ARGS
+        argsbits = 0x00
+        fargs = arginfo.fargs
+        if fargs !== nothing
+            for i = 1:length(fargs)
+                if is_const_prop_profitable_arg(effects, i)
+                    arg = fargs[i]
+                    if is_call_argument(arg, sv) && 1 ≤ slot_id(arg) ≤ 8
+                        argsbits |= 0x01 << (slot_id(arg)-1)
+                    end
+                end
+            end
+        end
+        const_prop_profitable_args = ConstPropProfitableArgs(argsbits)
+        effects = Effects(effects; const_prop_profitable_args)
+    end
+    return InterproceduralResult(rt, effects)
 end
 
 function collect_limitations!(@nospecialize(typ), sv::InferenceState)
@@ -1058,7 +1086,7 @@ function maybe_get_const_prop_profitable(interp::AbstractInterpreter,
         return nothing
     end
     mi = mi::MethodInstance
-    if !force && !const_prop_methodinstance_heuristic(interp, mi, arginfo, sv)
+    if !force && !const_prop_methodinstance_heuristic(interp, mi, arginfo, result.effects, sv)
         add_remark!(interp, sv, "[constprop] Disabled by method instance heuristic")
         return nothing
     end
@@ -1211,7 +1239,7 @@ end
 # where we would spend a lot of time, but are probably unlikely to get an improved
 # result anyway.
 function const_prop_methodinstance_heuristic(interp::AbstractInterpreter,
-    mi::MethodInstance, arginfo::ArgInfo, sv::AbsIntState)
+    mi::MethodInstance, arginfo::ArgInfo, effects::Effects, sv::AbsIntState)
     method = mi.def::Method
     if method.is_for_opaque_closure
         # Not inlining an opaque closure can be very expensive, so be generous
@@ -1236,23 +1264,39 @@ function const_prop_methodinstance_heuristic(interp::AbstractInterpreter,
     elseif is_stmt_noinline(flag)
         # this call won't be inlined, thus this constant-prop' will most likely be unfruitful
         return false
-    else
-        # Peek at the inferred result for the method to determine if the optimizer
-        # was able to cut it down to something simple (inlineable in particular).
-        # If so, there will be a good chance we might be able to const prop
-        # all the way through and learn something new.
-        code = get(code_cache(interp), mi, nothing)
-        if isa(code, CodeInstance)
-            inferred = @atomic :monotonic code.inferred
-            rt = code.rettype
-            # TODO propagate a specific `CallInfo` that conveys information about this call
-            iinfo = InliningInfo(rt, mi, arginfo.argtypes, NoCallInfo(), IR_FLAG_NULL)
-            if inlining_policy(interp, inferred, iinfo) !== nothing
-                return true
-            end
+    elseif any_const_prop_profitable_args(effects, arginfo.argtypes)
+        return true
+    end
+    # Peek at the inferred result for the method to determine if the optimizer
+    # was able to cut it down to something simple (inlineable in particular).
+    # If so, there will be a good chance we might be able to const prop
+    # all the way through and learn something new.
+    code = get(code_cache(interp), mi, nothing)
+    if isa(code, CodeInstance)
+        inferred = @atomic :monotonic code.inferred
+        rt = code.rettype
+        # TODO propagate a specific `CallInfo` that conveys information about this call
+        iinfo = InliningInfo(rt, mi, arginfo.argtypes, NoCallInfo(), IR_FLAG_NULL)
+        if inlining_policy(interp, inferred, iinfo) !== nothing
+            return true
         end
     end
     return false # the cache isn't inlineable, so this constant-prop' will most likely be unfruitful
+end
+
+# check if constant information is available on any call argument that has been analyzed as
+# const-prop' profitable
+function any_const_prop_profitable_args(effects::Effects, argtypes::Vector{Any})
+    if effects.const_prop_profitable_args === NO_PROFITABLE_ARGS
+        return false
+    end
+    for i in 1:length(argtypes)
+        ai = widenconditional(argtypes[i])
+        if isa(ai, Const) && is_const_prop_profitable_arg(effects, i)
+            return true
+        end
+    end
+    return false
 end
 
 # This is only for use with `Conditional`.
@@ -1921,8 +1965,8 @@ function abstract_invoke(interp::AbstractInterpreter, (; fargs, argtypes)::ArgIn
             (; rt, effects, const_result, edge) = const_call_result
         end
     end
-    rt = from_interprocedural!(𝕃ₚ, rt, sv, arginfo, sig)
     effects = Effects(effects; nonoverlayed=!overlayed)
+    (; rt, effects) = from_interprocedural!(𝕃ₚ, rt, effects, sv, arginfo, sig)
     info = InvokeCallInfo(match, const_result)
     edge !== nothing && add_invoke_backedge!(sv, lookupsig, edge)
     return CallMeta(rt, effects, info)
@@ -2035,6 +2079,20 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
         return CallMeta(typename_static(argtypes[2]), EFFECTS_TOTAL, MethodResultPure())
     elseif f === Core._hasmethod
         return _hasmethod_tfunc(interp, argtypes, sv)
+    elseif la == 2 && istoptype(f, :Val)
+        # `Val` generally encodes constant information into the type domain, so there is
+        # generally a high profitability for constant propagation if the argument of the
+        # `Val` constructor is a call argument
+        fargs = arginfo.fargs
+        if fargs !== nothing
+            arg = arginfo.fargs[2]
+            if is_call_argument(arg, sv) && !isempty(sv.ssavalue_uses[sv.currpc])
+                if 1 ≤ slot_id(arg) ≤ 8
+                    const_prop_profitable_args = ConstPropProfitableArgs(0x01 << (slot_id(arg)-1))
+                    merge_effects!(interp, sv, Effects(EFFECTS_TOTAL; const_prop_profitable_args))
+                end
+            end
+        end
     end
     atype = argtypes_to_type(argtypes)
     return abstract_call_gf_by_type(interp, f, arginfo, si, atype, sv, max_methods)
@@ -2068,7 +2126,7 @@ function abstract_call_opaque_closure(interp::AbstractInterpreter,
             effects = Effects(effects; nothrow=false)
         end
     end
-    rt = from_interprocedural!(𝕃ₚ, rt, sv, arginfo, match.spec_types)
+    (; rt, effects) = from_interprocedural!(𝕃ₚ, rt, effects, sv, arginfo, match.spec_types)
     info = OpaqueClosureCallInfo(match, const_result)
     edge !== nothing && add_backedge!(sv, edge)
     return CallMeta(rt, effects, info)
@@ -2522,8 +2580,7 @@ function abstract_eval_foreigncall(interp::AbstractInterpreter, e::Expr, vtypes:
             override.terminates_globally ? true        : effects.terminates,
             override.notaskstate         ? true        : effects.notaskstate,
             override.inaccessiblememonly ? ALWAYS_TRUE : effects.inaccessiblememonly,
-            effects.nonoverlayed,
-            effects.noinbounds)
+            effects.nonoverlayed, effects.noinbounds, effects.const_prop_profitable_args)
     end
     return RTEffects(t, effects)
 end
@@ -2907,6 +2964,15 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
                     @goto branch
                 elseif isa(stmt, GotoIfNot)
                     condx = stmt.cond
+                    if is_call_argument(condx, frame)
+                        # if this condition object is a call argument, there will be a high
+                        # profitability for constant-propagating it, since it can shape up
+                        # the generated code by cutting off the dead branch entirely
+                        if 1 ≤ slot_id(condx) ≤ 8
+                            const_prop_profitable_args = ConstPropProfitableArgs(0x01 << (slot_id(condx)-1))
+                            merge_effects!(interp, frame, Effects(EFFECTS_TOTAL; const_prop_profitable_args))
+                        end
+                    end
                     condt = abstract_eval_value(interp, condx, currstate, frame)
                     if condt === Bottom
                         ssavaluetypes[currpc] = Bottom

--- a/base/compiler/effects.jl
+++ b/base/compiler/effects.jl
@@ -1,3 +1,7 @@
+struct ConstPropProfitableArgs
+    argsbits::UInt8
+end
+
 """
     effects::Effects
 
@@ -95,6 +99,7 @@ struct Effects
     inaccessiblememonly::UInt8
     nonoverlayed::Bool
     noinbounds::Bool
+    const_prop_profitable_args::ConstPropProfitableArgs
     function Effects(
         consistent::UInt8,
         effect_free::UInt8,
@@ -103,7 +108,8 @@ struct Effects
         notaskstate::Bool,
         inaccessiblememonly::UInt8,
         nonoverlayed::Bool,
-        noinbounds::Bool)
+        noinbounds::Bool,
+        const_prop_profitable_args::ConstPropProfitableArgs = NO_PROFITABLE_ARGS)
         return new(
             consistent,
             effect_free,
@@ -112,7 +118,8 @@ struct Effects
             notaskstate,
             inaccessiblememonly,
             nonoverlayed,
-            noinbounds)
+            noinbounds,
+            const_prop_profitable_args)
     end
 end
 
@@ -129,6 +136,9 @@ const EFFECT_FREE_IF_INACCESSIBLEMEMONLY = 0x01 << 1
 # :inaccessiblememonly bits
 const INACCESSIBLEMEM_OR_ARGMEMONLY = 0x01 << 1
 
+# :const_prop_profitable_args bits
+const NO_PROFITABLE_ARGS = ConstPropProfitableArgs(0x00)
+
 const EFFECTS_TOTAL    = Effects(ALWAYS_TRUE,  ALWAYS_TRUE,  true,  true,  true,  ALWAYS_TRUE,  true,  true)
 const EFFECTS_THROWS   = Effects(ALWAYS_TRUE,  ALWAYS_TRUE,  false, true,  true,  ALWAYS_TRUE,  true,  true)
 const EFFECTS_UNKNOWN  = Effects(ALWAYS_FALSE, ALWAYS_FALSE, false, false, false, ALWAYS_FALSE, true,  false)  # unknown mostly, but it's not overlayed at least (e.g. it's not a call)
@@ -142,7 +152,8 @@ function Effects(e::Effects = _EFFECTS_UNKNOWN;
     notaskstate::Bool = e.notaskstate,
     inaccessiblememonly::UInt8 = e.inaccessiblememonly,
     nonoverlayed::Bool = e.nonoverlayed,
-    noinbounds::Bool = e.noinbounds)
+    noinbounds::Bool = e.noinbounds,
+    const_prop_profitable_args::ConstPropProfitableArgs = e.const_prop_profitable_args)
     return Effects(
         consistent,
         effect_free,
@@ -151,7 +162,8 @@ function Effects(e::Effects = _EFFECTS_UNKNOWN;
         notaskstate,
         inaccessiblememonly,
         nonoverlayed,
-        noinbounds)
+        noinbounds,
+        const_prop_profitable_args)
 end
 
 function merge_effects(old::Effects, new::Effects)
@@ -163,7 +175,8 @@ function merge_effects(old::Effects, new::Effects)
         merge_effectbits(old.notaskstate, new.notaskstate),
         merge_effectbits(old.inaccessiblememonly, new.inaccessiblememonly),
         merge_effectbits(old.nonoverlayed, new.nonoverlayed),
-        merge_effectbits(old.noinbounds, new.noinbounds))
+        merge_effectbits(old.noinbounds, new.noinbounds),
+        merge_effectbits(old.const_prop_profitable_args, new.const_prop_profitable_args))
 end
 
 function merge_effectbits(old::UInt8, new::UInt8)
@@ -173,6 +186,7 @@ function merge_effectbits(old::UInt8, new::UInt8)
     return old | new
 end
 merge_effectbits(old::Bool, new::Bool) = old & new
+merge_effectbits(old::ConstPropProfitableArgs, new::ConstPropProfitableArgs) = ConstPropProfitableArgs(old.argsbits | new.argsbits)
 
 is_consistent(effects::Effects)          = effects.consistent === ALWAYS_TRUE
 is_effect_free(effects::Effects)         = effects.effect_free === ALWAYS_TRUE
@@ -208,15 +222,18 @@ is_effect_free_if_inaccessiblememonly(effects::Effects) = !iszero(effects.effect
 
 is_inaccessiblemem_or_argmemonly(effects::Effects) = effects.inaccessiblememonly === INACCESSIBLEMEM_OR_ARGMEMONLY
 
+is_const_prop_profitable_arg(effects::Effects, arg::Int) = !iszero(effects.const_prop_profitable_args.argsbits & (0x01 << (arg-1)))
+
 function encode_effects(e::Effects)
-    return ((e.consistent          % UInt32) << 0) |
-           ((e.effect_free         % UInt32) << 3) |
-           ((e.nothrow             % UInt32) << 5) |
-           ((e.terminates          % UInt32) << 6) |
-           ((e.notaskstate         % UInt32) << 7) |
-           ((e.inaccessiblememonly % UInt32) << 8) |
-           ((e.nonoverlayed        % UInt32) << 10)|
-           ((e.noinbounds          % UInt32) << 11)
+    return ((e.consistent          % UInt32) << 0)  |
+           ((e.effect_free         % UInt32) << 3)  |
+           ((e.nothrow             % UInt32) << 5)  |
+           ((e.terminates          % UInt32) << 6)  |
+           ((e.notaskstate         % UInt32) << 7)  |
+           ((e.inaccessiblememonly % UInt32) << 8)  |
+           ((e.nonoverlayed        % UInt32) << 10) |
+           ((e.noinbounds          % UInt32) << 11) |
+           ((e.const_prop_profitable_args.argsbits % UInt32) << 12)
 end
 
 function decode_effects(e::UInt32)
@@ -228,7 +245,8 @@ function decode_effects(e::UInt32)
         _Bool((e >> 7) & 0x01),
         UInt8((e >> 8) & 0x03),
         _Bool((e >> 10) & 0x01),
-        _Bool((e >> 11) & 0x01))
+        _Bool((e >> 11) & 0x01),
+        ConstPropProfitableArgs(UInt8((e >> 12) & 0x7f)))
 end
 
 struct EffectsOverride

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -860,3 +860,7 @@ should_infer_this_call(::AbstractInterpreter, ::IRInterpretationState) = true
 
 add_remark!(::AbstractInterpreter, ::InferenceState, remark) = return
 add_remark!(::AbstractInterpreter, ::IRInterpretationState, remark) = return
+
+is_call_argument(@nospecialize(x), sv::InferenceState) =
+    isa(x, SlotNumber) && slot_id(x) ≤ narguments(sv)
+is_call_argument(@nospecialize(x), sv::IRInterpretationState) = isa(x, Argument)

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -61,7 +61,8 @@ is_source_inferred(@nospecialize src::MaybeCompressed) =
 struct InlineabilityInfo
     rt
     mi::MethodInstance
-    InlineabilityInfo(@nospecialize(rt), mi::MethodInstance) = new(rt, mi)
+    boost::Bool
+    InlineabilityInfo(@nospecialize(rt), mi::MethodInstance, boost::Bool=false) = new(rt, mi, boost)
 end
 
 """
@@ -80,7 +81,7 @@ function is_inlineable(interp::AbstractInterpreter, @nospecialize(src::MaybeComp
     params = OptimizationParams(interp)
     cost_threshold = default = params.inline_cost_threshold
     # if the method is declared as `@inline`, increase the cost threshold 20x
-    if is_declared_inline(src)
+    if is_declared_inline(src) || ibinfo.boost
         cost_threshold += 19*default
     end
     if ibinfo !== nothing
@@ -110,9 +111,10 @@ struct InliningInfo
     argtypes::Vector{Any}
     info::CallInfo
     stmt_flag::UInt8
+    boost::Bool
     function InliningInfo(@nospecialize(rt), mi::MethodInstance, argtypes::Vector{Any},
-                          @nospecialize(info::CallInfo), stmt_flag::UInt8)
-        return new(rt, mi, argtypes, info, stmt_flag)
+                          @nospecialize(info::CallInfo), stmt_flag::UInt8, boost::Bool=false)
+        return new(rt, mi, argtypes, info, stmt_flag, boost)
     end
 end
 
@@ -125,7 +127,8 @@ inlined by the inlining algorithm, otherwise return `nothing`.
 function inlining_policy(interp::AbstractInterpreter, @nospecialize(src), iinfo::InliningInfo)
     if isa(src, MaybeCompressed)
         if is_source_inferred(src)
-            if is_stmt_inline(iinfo.stmt_flag) || is_inlineable(interp, src, InlineabilityInfo(iinfo.rt, iinfo.mi))
+            if (is_stmt_inline(iinfo.stmt_flag) ||
+                is_inlineable(interp, src, InlineabilityInfo(iinfo.rt, iinfo.mi, iinfo.boost)))
                 return src
             end
         end

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -134,7 +134,8 @@ function inlining_policy(interp::AbstractInterpreter, @nospecialize(src), iinfo:
         # inferred source in the local cache
         # we still won't find a source for recursive call because the "single-level" inlining
         # seems to be more trouble and complex than it's worth
-        inf_result = cache_lookup(optimizer_lattice(interp), iinfo.mi, iinfo.argtypes, get_inference_cache(interp))
+        inf_cache = get_inference_cache(interp)
+        inf_result = cache_lookup(optimizer_lattice(interp), iinfo.mi, iinfo.argtypes, inf_cache)
         if inf_result !== nothing
             src = inf_result.src
             if isa(src, CodeInfo) && is_source_inferred(src)

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -50,9 +50,19 @@ _topmod(m::Module) = ccall(:jl_base_relative_to, Any, (Any,), m)::Module
 
 function istopfunction(@nospecialize(f), name::Symbol)
     tn = typeof(f).name
-    if tn.mt.name === name
+    mn = tn.mt.name
+    if mn === name
         top = _topmod(tn.module)
         return isdefined(top, name) && isconst(top, name) && f === getglobal(top, name)
+    end
+    return false
+end
+
+function istoptype(@nospecialize(T), name::Symbol)
+    t = unwrap_unionall(T)
+    if isa(t, DataType) && t.name.name === name
+        top = _topmod(t.name.module)
+        return isdefined(top, name) && isconst(top, name) && T === getglobal(top, name)
     end
     return false
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1133,3 +1133,10 @@ end
 import Base.Broadcast: BroadcastStyle, DefaultArrayStyle
 @test Base.infer_effects(BroadcastStyle, (DefaultArrayStyle{1},DefaultArrayStyle{2},)) |>
     Core.Compiler.is_foldable
+
+function f44330(x; isreal=true)
+    y = similar(x)
+    y .= x
+    isreal ? real(y) : y
+end
+@inferred f44330(randn(ComplexF64, 1))

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -982,3 +982,61 @@ isassigned_effects(s) = isassigned(Ref(s))
 @test fully_eliminated(; retval=true) do
     isassigned_effects(:foo)
 end
+
+# :const_prop_profitable_args bits
+# `Val`-profitability
+val_func(::Val{0}) = :zero
+val_func(::Val{1}) = "one"
+val_func(::Val{2}) = '2'
+let effects = Base.infer_effects((Int,)) do a
+                  Val(a)
+              end
+    @test Core.Compiler.is_const_prop_profitable_arg(effects, 2)
+end
+let effects = Base.infer_effects((Int,)) do a
+                  val_func(Val(a))
+              end
+    @test Core.Compiler.is_const_prop_profitable_arg(effects, 2)
+end
+let effects = Base.infer_effects((Int,)) do a
+                  Val(a) # unused, no profitability
+                  nothing
+              end
+    @test !Core.Compiler.is_const_prop_profitable_arg(effects, 2)
+end
+# branching-profitability
+let effects = Base.infer_effects((Bool,)) do c
+                  c ? nothing : missing
+              end
+    @test Core.Compiler.is_const_prop_profitable_arg(effects, 2)
+end
+# inter-procedural conversion of the :const_prop_profitable_args bits
+inter_constprop_profitable_inner1(a) = Val(a)
+function inter_constprop_profitable1(a, b)
+    v = inter_constprop_profitable_inner1(b)
+    if isa(val_func(v), Symbol)
+        return Symbol
+    end
+    return a
+end
+let effects = Base.infer_effects(inter_constprop_profitable1, (Type{Any},Int))
+    effects_inner = Base.infer_effects(inter_constprop_profitable_inner1, (Int,))
+    @test Core.Compiler.is_const_prop_profitable_arg(effects_inner, 2)
+    @test !Core.Compiler.is_const_prop_profitable_arg(effects, 2)
+    @test Core.Compiler.is_const_prop_profitable_arg(effects, 3)
+end
+inter_constprop_profitable_inner2(c) = c ? nothing : missing
+function inter_constprop_profitable2(a, b)
+    v = inter_constprop_profitable_inner2(b)
+    if v === nothing
+        return nothing
+    else
+        return a
+    end
+end
+let effects = Base.infer_effects(inter_constprop_profitable2, (Int,Bool))
+    effects_inner = Base.infer_effects(inter_constprop_profitable_inner2, (Bool,))
+    @test Core.Compiler.is_const_prop_profitable_arg(effects_inner, 2)
+    @test !Core.Compiler.is_const_prop_profitable_arg(effects, 2)
+    @test Core.Compiler.is_const_prop_profitable_arg(effects, 3)
+end

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -308,6 +308,8 @@ end
     @test eltype([tryparse(Int, s, base=16) for s in String[]]) == Union{Nothing, Int}
     @test eltype([tryparse(Float64, s) for s in String[]]) == Union{Nothing, Float64}
     @test eltype([tryparse(Complex{Int}, s) for s in String[]]) == Union{Nothing, Complex{Int}}
+    # JET.@test_opt parse(UInt8, "12")
+    # JET.@test_opt parse(BigInt, "12")
 end
 
 @testset "issue #29980" begin


### PR DESCRIPTION
This commit improves the heuristics to judge const-prop' profitability
with new effect property `:const_prop_profitable_args`. This is supposed
to supplement our primary const-prop' heuristic based on inlining cost
and is supposed to be a general fix for type stabilities issues discussed
at e.g. #45952 and #46430 (and eliminating the need for manual 
`@constprop :aggressive` clutters in such situations).

The new effect property `:const_prop_profitable_args` tracks call
arguments that can be considered to shape up generated code if
their constant information is available. Currently this commit
exploits the following const-prop' profitabilities:
- `Val(x)`-profitability: as `Val` generally encodes constant information
  into the type domain, it is generally profitable to constant prop' `x`
  if the constructed `Val(x)` is used later (e.g. for dispatch).
  This basically tries to exploit const-prop' profitability in the
  following kind of case:
  ```julia
  kernel(::Val{1}, args...) = ...
  kernel(::Val{2}, args...) = ...

  function profitable1(x::Int, args...)
      kernel(Val(x), args...)
  end
  ```
  This allows the compiler to perform const-prop' for case like #45952
  even if the primary heuristics based on inlining cost gets confused.
- branching-profitability: constant branch condition is generally very
  profitable as it can shape up generated code as well as narrow down
  the return type inference by cutting off the dead branch.
  ```julia
  function profitable2(raise::Bool, args...)
      v = op(args...)
      if v === nothing && raise
          return nothing
      end
      return v
  end
  ```

Currently this commit passes all the test cases and also actually 
improves target type stabilities, but doesn't work very ideally as it 
seems to be a bit too aggressive (this commit right now strictly 
increases the chances of const-propagation). I'd like to further tweak 
this heuristic to keep the latency in general cases.

---

fixes #45952, closes #46430.

/cc @Keno Do you have any opinion on this?