### PR TITLE
complex numbers should be given equal place in Julia

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1079,7 +1079,7 @@ base `base`.
 If the `sigdigits` keyword argument is provided, it rounds to the
 specified number of significant `digits`, in base `base`.
                                                     
-`RoundingModeReal` and `RoundingModeImaginary` defaults to `RoundNearest`,
+`RoundingModeReal` and `RoundingModeImaginary` default to `RoundNearest`,
 which rounds to the nearest integer, with ties (fractional values of 0.5)
 being rounded to the nearest even integer.
 

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1072,14 +1072,8 @@ breaking ties using the specified [`RoundingMode`](@ref)s. The first
 [`RoundingMode`](@ref) is used for rounding the real components while the
 second is used for rounding the imaginary components.
                                                     
-If the `digits` keyword argument is provided, it rounds to the specified
-number of digits after the decimal place (or before if negative), in
-base `base`.
-
-If the `sigdigits` keyword argument is provided, it rounds to the
-specified number of significant `digits`, in base `base`.
                                                     
-`RoundingModeReal` and `RoundingModeImaginary` default to `RoundNearest`,
+`RoundingModeReal` and `RoundingModeImaginary` default to [`RoundNearest`](@ref),
 which rounds to the nearest integer, with ties (fractional values of 0.5)
 being rounded to the nearest even integer.
 

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1071,8 +1071,8 @@ Return the nearest integral value of the same type as the complex-valued `z` to 
 breaking ties using the specified [`RoundingMode`](@ref)s. The first
 [`RoundingMode`](@ref) is used for rounding the real components while the
 second is used for rounding the imaginary components.
-                                                    
-                                                    
+
+
 `RoundingModeReal` and `RoundingModeImaginary` default to [`RoundNearest`](@ref),
 which rounds to the nearest integer, with ties (fractional values of 0.5)
 being rounded to the nearest even integer.

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1071,6 +1071,17 @@ Return the nearest integral value of the same type as the complex-valued `z` to 
 breaking ties using the specified [`RoundingMode`](@ref)s. The first
 [`RoundingMode`](@ref) is used for rounding the real components while the
 second is used for rounding the imaginary components.
+                                                    
+If the `digits` keyword argument is provided, it rounds to the specified
+number of digits after the decimal place (or before if negative), in
+base `base`.
+
+If the `sigdigits` keyword argument is provided, it rounds to the
+specified number of significant `digits`, in base `base`.
+                                                    
+`RoundingModeReal` and `RoundingModeImaginary` defaults to `RoundNearest`,
+which rounds to the nearest integer, with ties (fractional values of 0.5)
+being rounded to the nearest even integer.
 
 # Example
 ```jldoctest
@@ -1079,7 +1090,7 @@ julia> round(3.14 + 4.5im)
 
 julia> round(3.14 + 4.5im, RoundUp, RoundNearestTiesUp)
 4.0 + 5.0im
-                                                    
+
 julia> round(3.14159 + 4.512im; digits = 1)
 3.1 + 4.5im
 

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1064,8 +1064,8 @@ end
 #Requires two different RoundingModes for the real and imaginary components
 """
     round(z::Complex[, RoundingModeReal, [RoundingModeImaginary]])
-    round(z::Complex[, RoundingModeReal, [RoundingModeImaginary]]; digits=, base=10)
-    round(z::Complex[, RoundingModeReal, [RoundingModeImaginary]]; sigdigits=, base=10)
+    round(z::Complex[, RoundingModeReal, [RoundingModeImaginary]]; digits=0, base=10)
+    round(z::Complex[, RoundingModeReal, [RoundingModeImaginary]]; sigdigits, base=10)
 
 Return the nearest integral value of the same type as the complex-valued `z` to `z`,
 breaking ties using the specified [`RoundingMode`](@ref)s. The first
@@ -1076,6 +1076,15 @@ second is used for rounding the imaginary components.
 ```jldoctest
 julia> round(3.14 + 4.5im)
 3.0 + 4.0im
+
+julia> round(3.14 + 4.5im, RoundUp, RoundNearestTiesUp)
+4.0 + 5.0im
+                                                    
+julia> round(3.14159 + 4.512im; digits = 1)
+3.1 + 4.5im
+
+julia> round(3.14159 + 4.512im; sigdigits = 3)
+3.14 + 4.51im
 ```
 """
 function round(z::Complex, rr::RoundingMode=RoundNearest, ri::RoundingMode=rr; kwargs...)


### PR DESCRIPTION
Julia is a general purpose programming language but it has a domain where it shines most and that's **SCIENTIFIC COMPUTING**. This is to say that inasmuch as anything is related to numbers, it should be treated equally in Julia. The Julia docs IMO assumes we only use integers and floating points a lot, so they go in length when explaining any stuff on those types and show more examples on them; but for complex numbers, it's just isn't the case (few words and fewer examples is the trend).

If someone comes into Julia building an application or package that rigorously works with complex numbers and he is reading through the docs, he won't get the best experience as there are far fewer explanations on functions working with complex numbers and also far fewer examples of how the functions are even used.

**About the Pull Request**:
```julia
help?> round
search: round rounding RoundUp RoundDown RoundToZero RoundingMode

  round(z::Complex[, RoundingModeReal, [RoundingModeImaginary]])
  round(z::Complex[, RoundingModeReal, [RoundingModeImaginary]]; digits=, base=10)
  round(z::Complex[, RoundingModeReal, [RoundingModeImaginary]]; sigdigits=, base=10)
```

For the `round` function:
- `digits=,` is invalid a keyword argument in a function definition and should be `digits=0`.
- `sigdigits=,` is also invalid as well and should be `sigdigits,` since no default value is intended to be provided for the `sigdigits` keyword anyway and the `;` suffice to tell its a keyword argument.

This way it will be consistent with the floating point definition of `round`:
```julia
help?> round
search: round rounding RoundUp RoundDown RoundToZero RoundingMode

  round([T,] x, [r::RoundingMode])
  round(x, [r::RoundingMode]; digits::Integer=0, base = 10)
  round(x, [r::RoundingMode]; sigdigits::Integer, base = 10)
```

Also, it's best if a little more, say 2 or 3 more examples are provided on how the `round` function works with **complex numbers**, most importantly the **rounding modes**.