### PR TITLE
fix invalidations in logging

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -672,7 +672,7 @@ function handle_message(logger::SimpleLogger, level::LogLevel, message, _module,
     end
     buf = IOBuffer()
     stream = logger.stream
-    if !isopen(stream)
+    if !(isopen(stream)::Bool)
         stream = stderr
     end
     iob = IOContext(buf, stream)


### PR DESCRIPTION
This should hopefully fix 905 invalidations coming from Static.jl.

<details>

<summary>
Here is the code:

</summary>

```julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.8.0 (2022-08-17)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

(@v1.8) pkg> activate --temp
  Activating new project at `/tmp/jl_PDrBpd`

(jl_PDrBpd) pkg> add Static
    Updating registry at `~/.julia/registries/General.toml`
   Resolving package versions...
    Updating `/tmp/jl_PDrBpd/Project.toml`
  [aedffcd0] + Static v0.7.6
    Updating `/tmp/jl_PDrBpd/Manifest.toml`
  [615f187c] + IfElse v0.1.1
  [aedffcd0] + Static v0.7.6

julia> using SnoopCompileCore

julia> invalidations = @snoopr using Static

julia> using SnoopCompile

julia> length(uinvalidated(invalidations))
1723

julia> trees = invalidation_trees(invalidations)
7-element Vector{SnoopCompile.MethodInvalidations}:
...
 inserting !(::False) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:427 invalidated:
...
                 163: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.CoreLogging.var"#handle_message#2"(::Base.Pairs{Symbol, V, Tuple{Vararg{Symbol, N}}, NamedTuple{names, T}} where {V, N, names, T<:Tuple{Vararg{Any, N}}}, ::typeof(Base.CoreLogging.handle_message), ::Base.CoreLogging.SimpleLogger, ::Base.CoreLogging.LogLevel, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) (905 children)

help?> isopen
search: isopen partialsortperm partialsortperm! isconcretetype

  isopen(object) -> Bool

  Determine whether an object - such as a stream or timer – is not yet closed. Once an object is closed, it
  will never produce a new event. However, since a closed stream may still have data to read in its buffer, use
  eof to check for the ability to read data. Use the FileWatching package to be notified when a stream might be
  writable or readable.

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  julia> io = open("my_file.txt", "w+");
  
  julia> isopen(io)
  true
  
  julia> close(io)
  
  julia> isopen(io)
  false
```

</details>

Since `isopen` is documented to return a `Bool`, this type annotation should help prevent some invalidations.