### PR TITLE
hopefully fix invalidations of REPL from HDF5.jl

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1490,7 +1490,7 @@ end
 end
 
 # returns the width of the written prompt
-function write_prompt(terminal::::AbstractTerminal, s::Union{AbstractString,Function}, color::Bool)
+function write_prompt(terminal::AbstractTerminal, s::Union{AbstractString,Function}, color::Bool)
     @static Sys.iswindows() && _reset_console_mode()
     promptstr = prompt_string(s)::String
     write(terminal, promptstr)

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1490,7 +1490,7 @@ end
 end
 
 # returns the width of the written prompt
-function write_prompt(terminal, s::Union{AbstractString,Function}, color::Bool)
+function write_prompt(terminal::::AbstractTerminal, s::Union{AbstractString,Function}, color::Bool)
     @static Sys.iswindows() && _reset_console_mode()
     promptstr = prompt_string(s)::String
     write(terminal, promptstr)


### PR DESCRIPTION
I'm new to fixing invalidations, so please help me understand whether I'm doing it correctly.

I ran the following code on Julia v1.8.0:

```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add("HDF5")

julia> using SnoopCompileCore

julia> invalidations = @snoopr using HDF5;

julia> using SnoopCompile

julia> length(uinvalidated(invalidations))
385

julia> trees = invalidation_trees(invalidations);

julia> trees[end]
inserting write(obj::HDF5.Dataset, x) in HDF5 at /home/hendrik/.julia/packages/HDF5/T4H0V/src/datasets.jl:296 invalidated:
   mt_backedges: 1: signature Tuple{typeof(write), Any, String} triggered MethodInstance for Base.create_expr_cache(::Base.PkgId, ::String, ::String, ::Vector{Pair{Base.PkgId, UInt64}}, ::IOBuffer, ::Base.DevNull) (1 children)
                 2: signature Tuple{typeof(write), Any, String} triggered MethodInstance for Base.create_expr_cache(::Base.PkgId, ::String, ::String, ::Vector{Pair{Base.PkgId, UInt64}}, ::IO, ::IO) (21 children)
                 3: signature Tuple{typeof(write), Any, String} triggered MethodInstance for REPL.LineEdit.write_prompt(::Any, ::Union{AbstractString, Function}, ::Bool) (435 children)

julia> method_invalidations = trees[end];

julia> root = method_invalidations.mt_backedges[end][2]
MethodInstance for REPL.LineEdit.write_prompt(::Any, ::Union{AbstractString, Function}, ::Bool) at depth 0 with 435 children

julia> ascend(root)
Choose a call for analysis (q to quit):
     write_prompt(::Any, ::Union{AbstractString, Function}, ::Bool)
 >     write_prompt(::REPL.Terminals.AbstractTerminal, ::REPL.LineEdit.Prompt, ::Bool)
         write_prompt(::REPL.Terminals.TerminalBuffer, ::REPL.LineEdit.PrefixSearchState, ::Bool)
           #refresh_multi_line#16(::Int64, ::Bool, ::typeof(REPL.LineEdit.refresh_multi_line), ::REPL.Terminals.T
             (::REPL.LineEdit.var"#refresh_multi_line##kw")(::NamedTuple{(:indent, :region_active), Tuple{Int64,
               #refresh_multi_line#41(::Bool, ::typeof(REPL.LineEdit.refresh_multi_line), ::REPL.Terminals.Termin
                 (::REPL.LineEdit.var"#refresh_multi_line##kw")(::NamedTuple{names, T} where {N, names, T<:Tuple{
                   #refresh_multi_line#14(::Base.Pairs{Symbol, V, Tuple{Vararg{Symbol, N}}, NamedTuple{names, T}}
                     #refresh_multi_line#15(::Base.Pairs{Symbol, V, Tuple{Vararg{Symbol, N}}, NamedTuple{names, T
v                      refresh_multi_line(::REPL.Terminals.TerminalBuffer, ::REPL.Terminals.UnixTerminal, ::REPL.

Choose possible caller of MethodInstance for REPL.LineEdit.write_prompt(::Any, ::Union{AbstractString, Function}, ::Bool) or proceed to typed code:
 > "/cache/build/default-amdci4-3/julialang/julia-release-1-dot-8/usr/share/julia/stdlib/v1.8/REPL/src/LineEdit.jl", write_prompt: lines [1346]
   Browse typed code

```

As far as I understand, 
- the invalidations happen since `terminal` is not specified further in the method I changed here
- this method is only called from https://github.com/JuliaLang/julia/blob/bea7b6f805b37023e9c31533b1c3ab7a4271a39f/stdlib/REPL/src/LineEdit.jl#L1451-L1460
  where `terminal::AbstractTerminal`
- restricting the method I changed to `terminal::AbstractTerminal` does not limit its current use and should fix the invalidations

Did I understand this correctly? Or is there something better we should do to fix these invalidations?