### PR TITLE
fix type instability/invalidations from `nextind`

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -530,7 +530,7 @@ function iterate(iter::SplitIterator, (i, k, n)=(firstindex(iter.str), firstinde
     r = findnext(iter.splitter, iter.str, k)::Union{Nothing,Int,UnitRange{Int}}
     while r !== nothing && n != iter.limit - 1 && first(r) <= ncodeunits(iter.str)
         j, k = first(r), nextind(iter.str, last(r))::Int
-        k_ = k <= j ? nextind(iter.str, j) : k
+        k_ = k <= j ? nextind(iter.str, j)::Int : k
         if i < k
             substr = @inbounds SubString(iter.str, i, prevind(iter.str, j)::Int)
             (iter.keepempty || i < j) && return (substr, (k, k_, n + 1))


### PR DESCRIPTION
I found this while hunting some invalidations coming from ForwardDiff.jl
```
inserting promote_rule(::Type{R}, ::Type{ForwardDiff.Dual{T, V, N}}) where {R<:Real, T, V, N} in ForwardDiff at ~/.julia/packages/ForwardDiff/pDtsf/src/dual.jl:425 invalidated:
   backedges: 1: superseding promote_rule(::Type, ::Type) in Base at promotion.jl:310 with MethodInstance for promote_rule(::Type{Int64}, ::Type{S} where S<:Real) (1 children)
              2: superseding promote_rule(::Type, ::Type) in Base at promotion.jl:310 with MethodInstance for promote_rule(::Type{UInt8}, ::Type) (8 children)
              3: superseding promote_rule(::Type, ::Type) in Base at promotion.jl:310 with MethodInstance for promote_rule(::Type{Int64}, ::Type) (82 children)
   18 mt_cache
```

The output from `ascend` from SnoopCompile.jl showed that the output of `nextind` was inferred to `Any` but the documentation asserts that it should be an `Int`:
```julia
help?> nextind
search: nextind IndexCartesian MissingException current_exceptions InterruptException InvalidStateException

  nextind(str::AbstractString, i::Integer, n::Integer=1) -> Int
```

Note that the same type assertion is used in the line above the one I changed.