### PR TITLE
fix invalidations for Dicts from Static.jl

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -359,7 +359,7 @@ end
 
 function setindex!(h::Dict{K,V}, v0, key0) where V where K
     key = convert(K, key0)
-    if !isequal(key, key0)
+    if !(isequal(key, key0)::Bool)
         throw(ArgumentError("$(limitrepr(key0)) is not a valid key for type $K"))
     end
     setindex!(h, v0, key)


### PR DESCRIPTION
This should hopefully fix quite some invalidations coming from Static.jl.

<details>

<summary>
Here is the code:

</summary>

```julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.8.0 (2022-08-17)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

(@v1.8) pkg> activate --temp

(jl_PDrBpd) pkg> add Static
    Updating registry at `~/.julia/registries/General.toml`
   Resolving package versions...
    Updating `/tmp/jl_PDrBpd/Project.toml`
  [aedffcd0] + Static v0.7.6
    Updating `/tmp/jl_PDrBpd/Manifest.toml`
  [615f187c] + IfElse v0.1.1
  [aedffcd0] + Static v0.7.6

julia> using SnoopCompileCore

julia> invalidations = @snoopr using Static

julia> using SnoopCompile

julia> trees = invalidation_trees(invalidations)
7-element Vector{SnoopCompile.MethodInvalidations}:
...
 inserting !(::False) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:427 invalidated:
...
                 161: signature Tuple{typeof(!), Any} triggered MethodInstance for setindex!(::Dict{_A, Nothing} where _A, ::Nothing, ::Any) (193 children)
                 162: signature Tuple{typeof(!), Any} triggered MethodInstance for setindex!(::Dict, ::Any, ::Any) (424 children)
```

</details>

Since `!isequal(...)` is used here in an `if` stament - and `if` statements only accept `Bool`s -
it appears to be sane to assert that `isequal` returns a `Bool` here.

See also https://github.com/JuliaLang/julia/pull/46481
