### PR TITLE
fix invalidations in sort! from Static.jl

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -519,7 +519,7 @@ function sort!(v::AbstractVector, lo::Integer, hi::Integer, ::InsertionSortAlg, 
         x = v[i]
         while j > lo
             y = v[j-1]
-            if !lt(o, x, y)
+            if !(lt(o, x, y)::Bool)
                 break
             end
             v[j] = y
@@ -1486,8 +1486,8 @@ right(::DirectOrdering) = Right()
 left(o::Perm) = Perm(left(o.order), o.data)
 right(o::Perm) = Perm(right(o.order), o.data)
 
-lt(::Left, x::T, y::T)::Bool where {T<:Floats} = slt_int(y, x)
-lt(::Right, x::T, y::T)::Bool where {T<:Floats} = slt_int(x, y)
+lt(::Left, x::T, y::T) where {T<:Floats} = slt_int(y, x)
+lt(::Right, x::T, y::T) where {T<:Floats} = slt_int(x, y)
 
 uint_map(x::Float16, ::Left) = ~reinterpret(UInt16, x)
 uint_unmap(::Type{Float16}, u::UInt16, ::Left) = reinterpret(Float16, ~u)

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -519,7 +519,7 @@ function sort!(v::AbstractVector, lo::Integer, hi::Integer, ::InsertionSortAlg, 
         x = v[i]
         while j > lo
             y = v[j-1]
-            if !lt(o, x, y)
+            if !(lt(o, x, y)::Bool)
                 break
             end
             v[j] = y

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -519,7 +519,7 @@ function sort!(v::AbstractVector, lo::Integer, hi::Integer, ::InsertionSortAlg, 
         x = v[i]
         while j > lo
             y = v[j-1]
-            if !(lt(o, x, y)::Bool)
+            if !lt(o, x, y)
                 break
             end
             v[j] = y
@@ -1486,8 +1486,8 @@ right(::DirectOrdering) = Right()
 left(o::Perm) = Perm(left(o.order), o.data)
 right(o::Perm) = Perm(right(o.order), o.data)
 
-lt(::Left, x::T, y::T) where {T<:Floats} = slt_int(y, x)
-lt(::Right, x::T, y::T) where {T<:Floats} = slt_int(x, y)
+lt(::Left, x::T, y::T)::Bool where {T<:Floats} = slt_int(y, x)
+lt(::Right, x::T, y::T)::Bool where {T<:Floats} = slt_int(x, y)
 
 uint_map(x::Float16, ::Left) = ~reinterpret(UInt16, x)
 uint_unmap(::Type{Float16}, u::UInt16, ::Left) = reinterpret(Float16, ~u)

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1486,12 +1486,8 @@ right(::DirectOrdering) = Right()
 left(o::Perm) = Perm(left(o.order), o.data)
 right(o::Perm) = Perm(right(o.order), o.data)
 
-function lt(::Left, x::T, y::T)::Bool where {T<:Floats}
-    slt_int(y, x)
-end
-function lt(::Right, x::T, y::T)::Bool where {T<:Floats}
-    slt_int(x, y)
-end
+lt(::Left, x::T, y::T)::Bool where {T<:Floats} = slt_int(y, x)
+lt(::Right, x::T, y::T)::Bool where {T<:Floats} = slt_int(x, y)
 
 uint_map(x::Float16, ::Left) = ~reinterpret(UInt16, x)
 uint_unmap(::Type{Float16}, u::UInt16, ::Left) = reinterpret(Float16, ~u)

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1486,8 +1486,12 @@ right(::DirectOrdering) = Right()
 left(o::Perm) = Perm(left(o.order), o.data)
 right(o::Perm) = Perm(right(o.order), o.data)
 
-lt(::Left, x::T, y::T)::Bool where {T<:Floats} = slt_int(y, x)
-lt(::Right, x::T, y::T)::Bool where {T<:Floats} = slt_int(x, y)
+function lt(::Left, x::T, y::T)::Bool where {T<:Floats}
+    slt_int(y, x)
+end
+function lt(::Right, x::T, y::T)::Bool where {T<:Floats}
+    slt_int(x, y)
+end
 
 uint_map(x::Float16, ::Left) = ~reinterpret(UInt16, x)
 uint_unmap(::Type{Float16}, u::UInt16, ::Left) = reinterpret(Float16, ~u)


### PR DESCRIPTION
This should hopefully fix quite some invalidations coming from Static.jl.

<details>

<summary>
Here is the code:

</summary>

```julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.8.0 (2022-08-17)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

(@v1.8) pkg> activate --temp

(jl_PDrBpd) pkg> add Static
    Updating registry at `~/.julia/registries/General.toml`
   Resolving package versions...
    Updating `/tmp/jl_PDrBpd/Project.toml`
  [aedffcd0] + Static v0.7.6
    Updating `/tmp/jl_PDrBpd/Manifest.toml`
  [615f187c] + IfElse v0.1.1
  [aedffcd0] + Static v0.7.6

julia> using SnoopCompileCore

julia> invalidations = @snoopr using Static

julia> using SnoopCompile

julia> trees = invalidation_trees(invalidations)
7-element Vector{SnoopCompile.MethodInvalidations}:
...
 inserting !(::False) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:427 invalidated:
...
                 160: signature Tuple{typeof(!), Any} triggered MethodInstance for sort!(::Vector{String}, ::Int64, ::Int64, ::Base.Sort.InsertionSortAlg, ::Base.Order.Ordering) (127 children)
```

</details>

Since `!lt(...)` is used here in an `if` stament - and `if` statements only accept `Bool`s -
it appears to be sane to assert that `lt` returns a `Bool` here.

See also https://github.com/JuliaLang/julia/pull/46481, https://github.com/JuliaLang/julia/pull/46490
