### PR TITLE
fix invalidations of `isinf` from Static.jl

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -505,7 +505,7 @@ Test whether a number is infinite.
 
 See also: [`Inf`](@ref), [`iszero`](@ref), [`isfinite`](@ref), [`isnan`](@ref).
 """
-isinf(x::Real) = !(isnan(x)::Bool) & !(isfinite(x)::Bool)
+isinf(x::Real) = !isnan(x) & !isfinite(x)
 
 const hx_NaN = hash_uint64(reinterpret(UInt64, NaN))
 let Tf = Float64, Tu = UInt64, Ti = Int64

--- a/base/float.jl
+++ b/base/float.jl
@@ -505,7 +505,7 @@ Test whether a number is infinite.
 
 See also: [`Inf`](@ref), [`iszero`](@ref), [`isfinite`](@ref), [`isnan`](@ref).
 """
-isinf(x::Real) = !isnan(x) & !isfinite(x)
+isinf(x::Real) = !(isnan(x)::Bool) & !(isfinite(x)::Bool)
 
 const hx_NaN = hash_uint64(reinterpret(UInt64, NaN))
 let Tf = Float64, Tu = UInt64, Ti = Int64

--- a/stdlib/TOML/src/print.jl
+++ b/stdlib/TOML/src/print.jl
@@ -78,7 +78,7 @@ printvalue(f::MbyFunc, io::IO, value::Integer; _...) =
     Base.print(io, Int64(value))  # TOML specifies 64-bit signed long range for integer
 printvalue(f::MbyFunc, io::IO, value::AbstractFloat; _...) =
     Base.print(io, isnan(value) ? "nan" :
-                   isinf(value) ? string(value > 0 ? "+" : "-", "inf") :
+                   !(isfinite(value)::Bool) ? string(value > 0 ? "+" : "-", "inf") :
                    Float64(value))  # TOML specifies IEEE 754 binary64 for float
 function printvalue(f::MbyFunc, io::IO, value::AbstractString; _...)
     Base.print(io, "\"")


### PR DESCRIPTION
This should hopefully fix quite some invalidations coming from Static.jl.

<details>

<summary>
Here is the code:

</summary>

```julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.8.0 (2022-08-17)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

(@v1.8) pkg> activate --temp

(jl_PDrBpd) pkg> add Static
    Updating registry at `~/.julia/registries/General.toml`
   Resolving package versions...
    Updating `/tmp/jl_PDrBpd/Project.toml`
  [aedffcd0] + Static v0.7.6
    Updating `/tmp/jl_PDrBpd/Manifest.toml`
  [615f187c] + IfElse v0.1.1
  [aedffcd0] + Static v0.7.6

julia> using SnoopCompileCore

julia> invalidations = @snoopr using Static

julia> using SnoopCompile

julia> trees = invalidation_trees(invalidations)
7-element Vector{SnoopCompile.MethodInvalidations}:
...
 inserting !(::False) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:427 invalidated:
...
                 155: signature Tuple{typeof(!), Any} triggered MethodInstance for isinf(::AbstractFloat) (30 children)

help?> isnan
search: isnan isinteractive isignorable issubnormal DimensionMismatch

  isnan(f) -> Bool

  Test whether a number value is a NaN, an indeterminate value which is neither an infinity nor a finite number
  ("not a number").

  See also: iszero, isone, isinf, ismissing.

help?> isfinite
search: isfinite

  isfinite(f) -> Bool

  Test whether a number is finite.

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  julia> isfinite(5)
  true

  julia> isfinite(NaN32)
  false
```

</details>

Since `isnan` and `isfinite` are documented to return `Bool`s, it appears to be sane to assert that they do here.
