### PR TITLE
Make Base.show_supertypes more visible

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1090,6 +1090,7 @@ function show_supertypes(io::IO, typ::DataType)
         typ = supertype(typ)
         print(io, " <: ", typ)
     end
+    println()
 end
 
 show_supertypes(typ::DataType) = show_supertypes(stdout, typ)


### PR DESCRIPTION
A lot of the time, to see where I'm currently at in a type definition tree, I often call on `Base.show_supertypes` (though its not yet exported). This has been helpful to my eyes and development time.

But then, the printed result is too close to the next `Julia>` line, it makes development work rough and a bit harder to see at "first sight". This 👇 is the current way `Base.show_supertypes` prints it results:

```Julia
julia> abstract type Animal end

julia> abstract type Vertebrate <: Animal end

julia> abstract type Amphibian <: Vertebrate end

julia> Base.show_supertypes(Amphibian)
Amphibian <: Vertebrate <: Animal <: Any
julia> struct Frog <: Amphibian end

julia> Base.show_supertypes(Frog)
Frog <: Amphibian <: Vertebrate <: Animal <: Any
julia> struct Toad <: Amphibian end

julia> Base.show_supertypes(Toad)
Toad <: Amphibian <: Vertebrate <: Animal <: Any
julia>
``` 

This 👇is what I'm proposing, as I believe the workflow would be more elegant and clearer this way:
```Julia
julia> abstract type Animal end

julia> abstract type Vertebrate <: Animal end

julia> abstract type Amphibian <: Vertebrate end

julia> Base.show_supertypes(Amphibian)
Amphibian <: Vertebrate <: Animal <: Any

julia> struct Frog <: Amphibian end

julia> Base.show_supertypes(Frog)
Frog <: Amphibian <: Vertebrate <: Animal <: Any

julia> struct Toad <: Amphibian end

julia> Base.show_supertypes(Toad)
Toad <: Amphibian <: Vertebrate <: Animal <: Any

julia>
```