### PR TITLE
Disable even more FileWatching tests

### DIFF
--- a/stdlib/FileWatching/test/pidfile.jl
+++ b/stdlib/FileWatching/test/pidfile.jl
@@ -300,10 +300,8 @@ end
         sleep(3)
     end
     wait(t_loop)
-    if !(isbaseci && ismacos_arm) # https://github.com/JuliaLang/julia/issues/46185
-        @test maximum(lock_times) > 2
-        @test minimum(lock_times) < 1
-    end
+    @test maximum(lock_times) > 2
+    @test minimum(lock_times) < 1
 end
 
 @assert !ispath("pidfile")

--- a/stdlib/FileWatching/test/pidfile.jl
+++ b/stdlib/FileWatching/test/pidfile.jl
@@ -21,6 +21,10 @@ Base.Filesystem.mtime(io::MemoryFile) = io.mtime
 # and create a test environment temp directory
 umask(new_mask) = ccall((@static iswindows() ? :_umask : :umask), Cint, (Cint,), new_mask)
 
+isbaseci = get(ENV, "JULIA_TEST_IS_BASE_CI", nothing) == "true"
+ismacos_arm = ((Sys.ARCH == :aarch64) && (Sys.isapple())) #https://github.com/JuliaLang/julia/issues/46185
+ismacos_x86 = ((Sys.ARCH == :x86_64) && (Sys.isapple()))
+
 # TODO: Use targeted @test_log tests instead of suppressing all logs to hide the expected warnings
 Base.CoreLogging.with_logger(Base.CoreLogging.NullLogger()) do
 

--- a/stdlib/FileWatching/test/pidfile.jl
+++ b/stdlib/FileWatching/test/pidfile.jl
@@ -296,8 +296,10 @@ end
         sleep(3)
     end
     wait(t_loop)
-    @test maximum(lock_times) > 2
-    @test minimum(lock_times) < 1
+    if !(isbaseci && ismacos_arm) # https://github.com/JuliaLang/julia/issues/46185
+        @test maximum(lock_times) > 2
+        @test minimum(lock_times) < 1
+    end
 end
 
 @assert !ispath("pidfile")

--- a/stdlib/FileWatching/test/pidfile.jl
+++ b/stdlib/FileWatching/test/pidfile.jl
@@ -21,10 +21,6 @@ Base.Filesystem.mtime(io::MemoryFile) = io.mtime
 # and create a test environment temp directory
 umask(new_mask) = ccall((@static iswindows() ? :_umask : :umask), Cint, (Cint,), new_mask)
 
-isbaseci = get(ENV, "JULIA_TEST_IS_BASE_CI", nothing) == "true"
-ismacos_arm = ((Sys.ARCH == :aarch64) && (Sys.isapple())) #https://github.com/JuliaLang/julia/issues/46185
-ismacos_x86 = ((Sys.ARCH == :x86_64) && (Sys.isapple()))
-
 # TODO: Use targeted @test_log tests instead of suppressing all logs to hide the expected warnings
 Base.CoreLogging.with_logger(Base.CoreLogging.NullLogger()) do
 

--- a/stdlib/FileWatching/test/runtests.jl
+++ b/stdlib/FileWatching/test/runtests.jl
@@ -378,7 +378,7 @@ test_monitor_wait_poll()
 test_watch_file_timeout(0.2)
 test_watch_file_change(6)
 
-if !(isbaseci && ismacos_x86) 
+if !(isbaseci && ismacos_x86)
     test_dirmonitor_wait2(0.2)
     test_dirmonitor_wait2(0.2)
 

--- a/stdlib/FileWatching/test/runtests.jl
+++ b/stdlib/FileWatching/test/runtests.jl
@@ -12,7 +12,6 @@ using Base: uv_error, Experimental
 # Odd numbered pipes are tested for reads
 # Even numbered pipes are tested for timeouts
 # Writable ends are always tested for write-ability before a write
-isbaseci = get(ENV, "JULIA_TEST_IS_BASE_CI", nothing) == "true"
 ismacos_arm = ((Sys.ARCH == :aarch64) && (Sys.isapple())) #https://github.com/JuliaLang/julia/issues/46185
 ismacos_x86 = ((Sys.ARCH == :x86_64) && (Sys.isapple()))  #Used to disable the unreliable macos tests
 
@@ -36,7 +35,7 @@ for i in 1:n
     if !fd_in_limits && Sys.islinux()
         run(`ls -la /proc/$(getpid())/fd`)
     end
-    if !(isbaseci && ismacos_arm)
+    if ismacos_arm
         @test fd_in_limits
     end
 end
@@ -189,7 +188,7 @@ function test_init_afile()
     @test(watch_folder(dir) == (F_PATH => FileWatching.FileEvent(FileWatching.UV_RENAME)))
     @test close(open(file, "w")) === nothing
     sleep(3)
-    if !(isbaseci && ismacos_x86)
+    if !ismacos_x86
         let c
             c = watch_folder(dir, 0)
 
@@ -379,7 +378,7 @@ test_monitor_wait_poll()
 test_watch_file_timeout(0.2)
 test_watch_file_change(6)
 
-if !(isbaseci && ismacos_x86)
+if !ismacos_x86
     test_dirmonitor_wait2(0.2)
     test_dirmonitor_wait2(0.2)
 

--- a/stdlib/FileWatching/test/runtests.jl
+++ b/stdlib/FileWatching/test/runtests.jl
@@ -17,7 +17,6 @@ ismacos_x86 = ((Sys.ARCH == :x86_64) && (Sys.isapple()))  #Used to disable the u
 
 n = 20
 intvls = [2, .2, .1, .005, .00001]
-
 pipe_fds = fill((Base.INVALID_OS_HANDLE, Base.INVALID_OS_HANDLE), n)
 
 for i in 1:n
@@ -35,7 +34,7 @@ for i in 1:n
     if !fd_in_limits && Sys.islinux()
         run(`ls -la /proc/$(getpid())/fd`)
     end
-    if ismacos_arm
+    if !ismacos_arm
         @test fd_in_limits
     end
 end


### PR DESCRIPTION
These tests are also unreliable so disable them too for now. See https://github.com/JuliaLang/julia/issues/46185