### PR TITLE
Fix typo/boolean usage in stream eof comments

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -105,8 +105,8 @@ function eof(s::LibuvStream)
     bytesavailable(s) > 0 && return false
     wait_readnb(s, 1)
     # This function is race-y if used from multiple threads, but we guarantee
-    # it to never return false until the stream is definitively exhausted
-    # and that we won't return true if there's a readerror pending (it'll instead get thrown).
+    # it to never return true until the stream is definitively exhausted
+    # and that we won't return false if there's a readerror pending (it'll instead get thrown).
     # This requires some careful ordering here (TODO: atomic loads)
     bytesavailable(s) > 0 && return false
     open = isreadable(s) # must precede readerror check

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -106,7 +106,7 @@ function eof(s::LibuvStream)
     wait_readnb(s, 1)
     # This function is race-y if used from multiple threads, but we guarantee
     # it to never return true until the stream is definitively exhausted
-    # and that we won't return false if there's a readerror pending (it'll instead get thrown).
+    # and that we won't return true if there's a readerror pending (it'll instead get thrown).
     # This requires some careful ordering here (TODO: atomic loads)
     bytesavailable(s) > 0 && return false
     open = isreadable(s) # must precede readerror check


### PR DESCRIPTION
I'm not crazy, right? These should be the opposite?