### PR TITLE
More info on nor(x, y)

### DIFF
--- a/base/bool.jl
+++ b/base/bool.jl
@@ -113,7 +113,7 @@ nand(x...) = ~(&)(x...)
 Bitwise nor (not or) of `x` and `y`. Implements
 [three-valued logic](https://en.wikipedia.org/wiki/Three-valued_logic),
 returning [`missing`](@ref) if one of the arguments is `missing` and the
-other is not [`true`](@ref).
+other is not `true`.
 
 The infix operation `a ⊽ b` is a synonym for `nor(a,b)`, and
 `⊽` can be typed by tab-completing `\\nor` or `\\barvee` in the Julia REPL.

--- a/base/bool.jl
+++ b/base/bool.jl
@@ -112,7 +112,8 @@ nand(x...) = ~(&)(x...)
 
 Bitwise nor (not or) of `x` and `y`. Implements
 [three-valued logic](https://en.wikipedia.org/wiki/Three-valued_logic),
-returning [`missing`](@ref) if one of the arguments is `missing`.
+returning [`missing`](@ref) if one of the arguments is `missing` and the
+other is not [`true`](@ref).
 
 The infix operation `a ⊽ b` is a synonym for `nor(a,b)`, and
 `⊽` can be typed by tab-completing `\\nor` or `\\barvee` in the Julia REPL.
@@ -130,6 +131,9 @@ false
 
 julia> false ⊽ false
 true
+
+julia> false ⊽ missing
+missing
 
 julia> [true; true; false] .⊽ [true; false; false]
 3-element BitVector:


### PR DESCRIPTION
The current doc on the `nor` function isn't straightforward to understand on this part:

> returning missing if one of the arguments is missing. 

But then, `missing` is only returned when one of the argument is `missing` and the other is not `true`:
```Julia
 # one of the argument is missing, so why not return missing?
julia> true ⊽ missing
false

#= but if stated that it returns missing only when one
of the argument is missing and the other is not true,
we understand this part very well. =#
julia> false ⊽ missing
missing

julia> 1 ⊽ missing
missing

julia> [true; true; missing] .⊽ [missing; false; false]
3-element Vector{Union{Missing, Bool}}:
 false
 false
      missing
```

More importantly, an example where `missing` is returned would be great, as it will be expressing what the doc is trying to say on the `missing` part.