### PR TITLE
More info on particular class of variables

### DIFF
--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -111,16 +111,35 @@ variable name. For example, if `+ᵃ` is an operator, then `+ᵃx` must be writt
 it from `+ ᵃx` where `ᵃx` is the variable name.
 
 
-A particular class of variable names is one that contains only underscores. These identifiers can only be assigned values but cannot be used to assign values to other variables.
-More technically, they can only be used as an [L-value](https://en.wikipedia.org/wiki/Value_(computer_science)#lrvalue), but not as an
- [R-value](https://en.wikipedia.org/wiki/R-value):
+
+A particular class of variable names is one that contains only underscores. These identifiers can only be assigned values but cannot be used to assign values to other variables (or examined on their own). More technically, they can only be used as an [L-value](https://en.wikipedia.org/wiki/Value_(computer_science)#lrvalue), but not as an [R-value](https://en.wikipedia.org/wiki/R-value) or [non-L-value](https://en.wikipedia.org/wiki/Value_(computer_science)) (**non-L-value** is colloquially known as **R-value**):
 
 ```julia-repl
-julia> x, ___ = size([2 2; 1 1])
+julia> x, ___ = size([2 2; 1 1])                         # ___ is used as an L-value
 (2, 2)
 
-julia> y = ___
+julia> y = ___                                           # ___ is used as an R-value
 ERROR: syntax: all-underscore identifier used as rvalue
+
+julia> ___                                               # ___ is used as a non-L-value
+ERROR: all-underscore identifier used as rvalue
+```
+
+In Julia, a particular class of variable names is used when you only want a specific part of a collection (which has many values), and wants to "throw away" the rest of the values in the collection (regardless of the number)." Unlike languages like Python, the particular class of variables can not be examined on their own:
+```julia-repl
+julia> student1 = "Comprehensive High School", "Peter Pan", 13, "Grade 12", "Science";
+
+julia> student2 = "Greatness High School", "John Alan", 15, "Grade 6", "Arts";
+
+julia> ___, s1name, s1age, ___ = student1;
+
+julia> ___, s2name, s2age, ___ = student2;
+
+julia> print(s1name, " and ", s2name, " are ", s1age, " and ", s2age, " years old respectively.")
+Peter Pan and John Alan are 13 and 15 years old respectively.
+
+julia> ___    # trying to examine ___ throws an error because it's being used as a non-L-value
+ERROR: all-underscore identifier used as rvalue
 ```
 
 The only explicitly disallowed names for variables are the names of the built-in [Keywords](@ref Keywords):


### PR DESCRIPTION
From this article https://en.wikipedia.org/wiki/Value_(computer_science) on Wikipedia, it says:
> R-values can be l-values (see below) or non-l-values — a term only used to distinguish from l-values. Consider the C expression `4 + 9`. When executed, the computer generates an integer value of `13`, but because the program has not explicitly designated where in the computer this `13` is stored, the expression is a `non-l-value`. On the other hand, if a C program declares a variable `x` and assigns the value of `13` to `x`, then the expression `x` has a value of `13` and is an l-value.

> The l-value expression designates (refers to) an object. A non-modifiable l-value is addressable, but not assignable. A modifiable l-value allows the designated object to be changed as well as examined. An r-value is any expression, a non-l-value is any expression that is not an l-value. One example is an "immediate value" (look below) and consequently not addressable.

Also from this [cppreference.com value category](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwiNz7i_mef5AhUNVfEDHWK2A9IQFnoECAsQAw&url=https%3A%2F%2Fen.cppreference.com%2Fw%2Fc%2Flanguage%2Fvalue_category&usg=AOvVaw2rVRizLUSxzFUzOWHj9z9W), it says:
> Colloquially known as rvalues, non-lvalue object expressions are the expressions of object types that do not designate objects, but rather values that have no object identity or storage location. The address of a non-lvalue object expression cannot be taken.

From the above, it makes sense to understand whats happening below in Julia:
```julia
julia> x, ___ = 2, 5                                        # ___ is used as a l-value
(2, 5)

julia> a, b = x, ___
ERROR: syntax: all-underscore identifier used as rvalue     # ___ is used as a r-value
[...]

julia> ___                                                  # ___ is used as a non-l-value    
ERROR: all-underscore identifier used as rvalue
[...]
```

But it only made sense after some rigorous searching, something the docs should have just pointed out very neatly.

The error message can continue reading as `R-value`, since colloquially `non-l-value` is also called `r-value`, but the docs should just make it plain on the explanation part.

I feel this issue is a very paramount one, because in languages like Python they get the opposite behaviour of what Julia does, so its best if this is explained beforehand.

Here's a great example. In Julia, we have:
```julia
julia> username, password, auth_keys, log_keys, referral_keys = "John Pavard", "1234", "123csdx12", "xzzxwe2s434", "12idmne";

julia> user_info = username, password, auth_keys, log_keys, referral_keys;

julia> x, y, ___ = user_info;

julia> x
"John Pavard"

julia> y
"1234"

julia> ___
ERROR: all-underscore identifier used as rvalue
[...]
```

In Python, we have:
```python
>>> username, password, auth_keys, log_keys, referral_keys = "John Pavard", "1234", "123csdx12", "xzzxwe2s434", "12idmne"
>>> user_info = (username, password, auth_keys, log_keys, referral_keys)
>>> x, y, *___ = user_info
>>> x
    'John Pavard'
>>> y
    '1234'
>>> ___
    ['123csdx12', 'xzzxwe2s434', '12idmne']

>>> z = ___
>>> z
    ['123csdx12', 'xzzxwe2s434', '12idmne']
```

So as one can see, the above codes that threw an error in Julia are valid codes in languages like Python and they have great use for users there wanting to "throwing away values" they don't need from a tuple, list or any collection **but can still later refer or assign to them**.

So, it will be best if the doc states clearly what the "particular class" of variable is doing and how it can be used, to avoid arguments from users who would be coming from python and expecting same behaviours (since the docs does a poor job on explaining fronthand what and what it doesn't do).