### PR TITLE
Switch from sorted vector to heap in optimizer

### DIFF
--- a/base/compiler/ssair/driver.jl
+++ b/base/compiler/ssair/driver.jl
@@ -8,6 +8,7 @@ else
     end
 end
 
+include("compiler/ssair/heap.jl")
 include("compiler/ssair/slot2ssa.jl")
 include("compiler/ssair/inlining.jl")
 include("compiler/ssair/verify.jl")

--- a/base/compiler/ssair/heap.jl
+++ b/base/compiler/ssair/heap.jl
@@ -1,4 +1,4 @@
-# This contains code that was formerly a part of Julia. License is MIT: http://julialang.org/license
+# This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Base.Order: Forward, Ordering, lt
 

--- a/base/compiler/ssair/heap.jl
+++ b/base/compiler/ssair/heap.jl
@@ -1,11 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Base.Order: Forward, Ordering, lt
-
-const DefaultReverseOrdering = Base.ReverseOrdering{Base.ForwardOrdering}
-
-# Heap operations on flat arrays
-# ------------------------------
+# Heap operations on flat vectors
+# -------------------------------
 
 
 # Binary heap indexing
@@ -15,7 +11,7 @@ heapparent(i::Integer) = div(i, 2)
 
 
 # Binary min-heap percolate down.
-function percolate_down!(xs::AbstractArray, i::Integer, x=xs[i], o::Ordering=Forward, len::Integer=length(xs))
+function percolate_down!(xs::Vector, i::Integer, x, o::Ordering, len::Integer=length(xs))
     @inbounds while (l = heapleft(i)) <= len
         r = heapright(i)
         j = r > len || lt(o, xs[l], xs[r]) ? l : r
@@ -26,11 +22,8 @@ function percolate_down!(xs::AbstractArray, i::Integer, x=xs[i], o::Ordering=For
     xs[i] = x
 end
 
-percolate_down!(xs::AbstractArray, i::Integer, o::Ordering, len::Integer=length(xs)) = percolate_down!(xs, i, xs[i], o, len)
-
-
 # Binary min-heap percolate up.
-function percolate_up!(xs::AbstractArray, i::Integer, x=xs[i], o::Ordering=Forward)
+function percolate_up!(xs::Vector, i::Integer, x, o::Ordering)
     @inbounds while (j = heapparent(i)) >= 1
         lt(o, x, xs[j]) || break
         xs[i] = xs[j]
@@ -39,15 +32,13 @@ function percolate_up!(xs::AbstractArray, i::Integer, x=xs[i], o::Ordering=Forwa
     xs[i] = x
 end
 
-@inline percolate_up!(xs::AbstractArray, i::Integer, o::Ordering) = percolate_up!(xs, i, xs[i], o)
-
 """
-    heappop!(v, [ord])
+    heappop!(v, ord)
 
 Given a binary heap-ordered array, remove and return the lowest ordered element.
 For efficiency, this function does not check that the array is indeed heap-ordered.
 """
-function heappop!(xs::AbstractArray, o::Ordering=Forward)
+function heappop!(xs::Vector, o::Ordering)
     x = xs[1]
     y = pop!(xs)
     if !isempty(xs)
@@ -57,83 +48,27 @@ function heappop!(xs::AbstractArray, o::Ordering=Forward)
 end
 
 """
-    heappush!(v, x, [ord])
+    heappush!(v, x, ord)
 
 Given a binary heap-ordered array, push a new element `x`, preserving the heap property.
 For efficiency, this function does not check that the array is indeed heap-ordered.
 """
-@inline function heappush!(xs::AbstractArray, x, o::Ordering=Forward)
+function heappush!(xs::Vector, x, o::Ordering)
     push!(xs, x)
-    percolate_up!(xs, length(xs), o)
+    i = lastindex(xs)
+    percolate_up!(xs, i, @inbounds(xs[i]), o)
     return xs
 end
 
 
-# Turn an arbitrary array into a binary min-heap (by default) in linear time.
 """
-    heapify!(v, ord::Ordering=Forward)
+    heapify!(v, ord::Ordering)
 
-In-place [`heapify`](@ref).
+Turn an arbitrary vector into a binary min-heap in linear time.
 """
-function heapify!(xs::AbstractArray, o::Ordering=Forward)
-    for i in heapparent(length(xs)):-1:1
-        percolate_down!(xs, i, o)
+function heapify!(xs::Vector, o::Ordering)
+    for i in heapparent(lastindex(xs)):-1:1
+        percolate_down!(xs, i, @inbounds(xs[i]), o)
     end
     return xs
-end
-
-"""
-    heapify(v, ord::Ordering=Forward)
-
-Returns a new vector in binary heap order, optionally using the given ordering.
-```jldoctest
-julia> a = [1,3,4,5,2];
-
-julia> heapify(a)
-5-element Array{Int64,1}:
- 1
- 2
- 4
- 5
- 3
-
-julia> heapify(a, Base.Order.Reverse)
-5-element Array{Int64,1}:
- 5
- 3
- 4
- 1
- 2
-```
-"""
-# Todo, benchmarking shows copy(xs) outperforms copyto!(similar(xs), xs) for 10^6 Float64
-heapify(xs::AbstractArray, o::Ordering=Forward) = heapify!(copyto!(similar(xs), xs), o)
-
-"""
-    isheap(v, ord::Ordering=Forward)
-
-Return `true` if an array is heap-ordered according to the given order.
-
-```jldoctest
-julia> a = [1,2,3]
-3-element Vector{Int64}:
- 1
- 2
- 3
-
-julia> isheap(a,Base.Order.Forward)
-true
-
-julia> isheap(a,Base.Order.Reverse)
-false
-```
-"""
-function isheap(xs::AbstractArray, o::Ordering=Forward)
-    for i in 1:div(length(xs), 2)
-        if lt(o, xs[heapleft(i)], xs[i]) ||
-           (heapright(i) <= length(xs) && lt(o, xs[heapright(i)], xs[i]))
-            return false
-        end
-    end
-    return true
 end

--- a/base/compiler/ssair/heap.jl
+++ b/base/compiler/ssair/heap.jl
@@ -1,0 +1,139 @@
+# This contains code that was formerly a part of Julia. License is MIT: http://julialang.org/license
+
+using Base.Order: Forward, Ordering, lt
+
+const DefaultReverseOrdering = Base.ReverseOrdering{Base.ForwardOrdering}
+
+# Heap operations on flat arrays
+# ------------------------------
+
+
+# Binary heap indexing
+heapleft(i::Integer) = 2i
+heapright(i::Integer) = 2i + 1
+heapparent(i::Integer) = div(i, 2)
+
+
+# Binary min-heap percolate down.
+function percolate_down!(xs::AbstractArray, i::Integer, x=xs[i], o::Ordering=Forward, len::Integer=length(xs))
+    @inbounds while (l = heapleft(i)) <= len
+        r = heapright(i)
+        j = r > len || lt(o, xs[l], xs[r]) ? l : r
+        lt(o, xs[j], x) || break
+        xs[i] = xs[j]
+        i = j
+    end
+    xs[i] = x
+end
+
+percolate_down!(xs::AbstractArray, i::Integer, o::Ordering, len::Integer=length(xs)) = percolate_down!(xs, i, xs[i], o, len)
+
+
+# Binary min-heap percolate up.
+function percolate_up!(xs::AbstractArray, i::Integer, x=xs[i], o::Ordering=Forward)
+    @inbounds while (j = heapparent(i)) >= 1
+        lt(o, x, xs[j]) || break
+        xs[i] = xs[j]
+        i = j
+    end
+    xs[i] = x
+end
+
+@inline percolate_up!(xs::AbstractArray, i::Integer, o::Ordering) = percolate_up!(xs, i, xs[i], o)
+
+"""
+    heappop!(v, [ord])
+
+Given a binary heap-ordered array, remove and return the lowest ordered element.
+For efficiency, this function does not check that the array is indeed heap-ordered.
+"""
+function heappop!(xs::AbstractArray, o::Ordering=Forward)
+    x = xs[1]
+    y = pop!(xs)
+    if !isempty(xs)
+        percolate_down!(xs, 1, y, o)
+    end
+    return x
+end
+
+"""
+    heappush!(v, x, [ord])
+
+Given a binary heap-ordered array, push a new element `x`, preserving the heap property.
+For efficiency, this function does not check that the array is indeed heap-ordered.
+"""
+@inline function heappush!(xs::AbstractArray, x, o::Ordering=Forward)
+    push!(xs, x)
+    percolate_up!(xs, length(xs), o)
+    return xs
+end
+
+
+# Turn an arbitrary array into a binary min-heap (by default) in linear time.
+"""
+    heapify!(v, ord::Ordering=Forward)
+
+In-place [`heapify`](@ref).
+"""
+function heapify!(xs::AbstractArray, o::Ordering=Forward)
+    for i in heapparent(length(xs)):-1:1
+        percolate_down!(xs, i, o)
+    end
+    return xs
+end
+
+"""
+    heapify(v, ord::Ordering=Forward)
+
+Returns a new vector in binary heap order, optionally using the given ordering.
+```jldoctest
+julia> a = [1,3,4,5,2];
+
+julia> heapify(a)
+5-element Array{Int64,1}:
+ 1
+ 2
+ 4
+ 5
+ 3
+
+julia> heapify(a, Base.Order.Reverse)
+5-element Array{Int64,1}:
+ 5
+ 3
+ 4
+ 1
+ 2
+```
+"""
+# Todo, benchmarking shows copy(xs) outperforms copyto!(similar(xs), xs) for 10^6 Float64
+heapify(xs::AbstractArray, o::Ordering=Forward) = heapify!(copyto!(similar(xs), xs), o)
+
+"""
+    isheap(v, ord::Ordering=Forward)
+
+Return `true` if an array is heap-ordered according to the given order.
+
+```jldoctest
+julia> a = [1,2,3]
+3-element Vector{Int64}:
+ 1
+ 2
+ 3
+
+julia> isheap(a,Base.Order.Forward)
+true
+
+julia> isheap(a,Base.Order.Reverse)
+false
+```
+"""
+function isheap(xs::AbstractArray, o::Ordering=Forward)
+    for i in 1:div(length(xs), 2)
+        if lt(o, xs[heapleft(i)], xs[i]) ||
+           (heapright(i) <= length(xs) && lt(o, xs[heapright(i)], xs[i]))
+            return false
+        end
+    end
+    return true
+end

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -141,9 +141,10 @@ function choosetests(choices = [])
     # do subarray before sparse but after linalg
     filtertests!(tests, "subarray")
     filtertests!(tests, "compiler", ["compiler/inference", "compiler/effects",
-        "compiler/validation", "compiler/ssair", "compiler/irpasses", "compiler/codegen",
-        "compiler/inline", "compiler/contextual", "compiler/AbstractInterpreter",
-        "compiler/EscapeAnalysis/local", "compiler/EscapeAnalysis/interprocedural"])
+        "compiler/validation", "compiler/heap", "compiler/ssair", "compiler/irpasses",
+        "compiler/codegen", "compiler/inline", "compiler/contextual",
+        "compiler/AbstractInterpreter", "compiler/EscapeAnalysis/local",
+        "compiler/EscapeAnalysis/interprocedural"])
     filtertests!(tests, "compiler/EscapeAnalysis", [
         "compiler/EscapeAnalysis/local", "compiler/EscapeAnalysis/interprocedural"])
     filtertests!(tests, "stdlib", STDLIBS)

--- a/test/compiler/heap.jl
+++ b/test/compiler/heap.jl
@@ -1,0 +1,31 @@
+@testset "basic heap functionality" begin
+    v = [2,3,1]
+    @test Core.Compiler.heapify!(v, Core.Compiler.Forward) === v
+    @test Core.Compiler.heappop!(v, Core.Compiler.Forward) === 1
+    @test Core.Compiler.heappush!(v, 4, Core.Compiler.Forward) === v
+    @test Core.Compiler.heappop!(v, Core.Compiler.Forward) === 2
+    @test Core.Compiler.heappop!(v, Core.Compiler.Forward) === 3
+    @test Core.Compiler.heappop!(v, Core.Compiler.Forward) === 4
+end
+
+@testset "randomized heap correctness tests" begin
+    order = Core.Compiler.By(x -> -x[2])
+    for i in 1:6
+        heap = Tuple{Int, Int}[(rand(1:i), rand(1:i)) for _ in 1:2i]
+        mock = copy(heap)
+        @test Core.Compiler.heapify!(heap, order) === heap
+        sort!(mock, by=last)
+
+        for _ in 1:6i
+            if rand() < .5 && !isempty(heap)
+                # The first entries may differ because heaps are not stable
+                @test last(Core.Compiler.heappop!(heap, order)) === last(pop!(mock))
+            else
+                new = (rand(1:i), rand(1:i))
+                Core.Compiler.heappush!(heap, new, order)
+                push!(mock, new)
+                sort!(mock, by=last)
+            end
+        end
+    end
+end


### PR DESCRIPTION
Addresses a TODO dating back to #26079 which calls for a more efficient datastructure.

This is primarily copied from https://github.com/JuliaCollections/DataStructures.jl/blob/7d2e3c6e9898bed492a40af31920a5a369728d6d/src/heaps/arrays_as_heaps.jl and stripped down to what we actually need.

This is motivated by my belief that almost all uses of `sort` can be replaced with more performant alternatives.