### PR TITLE
Handle Vararg in PartialStruct fields in lattice ⊑

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4185,3 +4185,6 @@ let src = code_typed1() do
         constbarrier()
     end |> only === Float64
 end
+
+# Test that Const ⊑ PartialStruct respects vararg
+@test Const((1,2)) ⊑ PartialStruct(Tuple{Vararg{Int}}, [Const(1), Vararg{Int}])


### PR DESCRIPTION
This was an existing todo. While we're at it, also explicitly
check the remaining cases where lattice elements survived
all the way to the conservative fallback and remove it in
preparation for some refactoring here.