### PR TITLE
Improve `hvcat` signature in its docstring

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1972,7 +1972,7 @@ typed_hcat(T::Type, A::AbstractArray...) = _cat_t(Val(2), T, A...)
 hvcat_rows(rows::Tuple...) = hvcat(map(length, rows), (rows...)...)
 typed_hvcat_rows(T::Type, rows::Tuple...) = typed_hvcat(T, map(length, rows), (rows...)...)
 
-function hvcat(nbc::Integer, as...)
+function hvcat(nbc::Int, as...)
     # nbc = # of block columns
     n = length(as)
     mod(n,nbc) != 0 &&

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2015,6 +2015,9 @@ julia> hvcat((2,2,2), a,b,c,d,e,f)
  1  2
  3  4
  5  6
+ 
+julia> hvcat((2,2,2), a,b,c,d,e,f) == hvcat(2, a,b,c,d,e,f)
+true
 ```
 """
 hvcat(rows::Tuple{Vararg{Int}}, xs::AbstractVecOrMat...) = typed_hvcat(promote_eltype(xs...), rows, xs...)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1982,7 +1982,7 @@ function hvcat(nbc::Integer, as...)
 end
 
 """
-    hvcat(blocks_per_row::Union{Tuple{Vararg{Int}}, Integer}, values...)
+    hvcat(blocks_per_row::Union{Tuple{Vararg{Int}}, Int}, values...)
 
 Horizontal and vertical concatenation in one call. This function is called for block matrix
 syntax. The first argument specifies the number of arguments to concatenate in each block

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2015,7 +2015,6 @@ julia> hvcat((2,2,2), a,b,c,d,e,f)
  1  2
  3  4
  5  6
- 
 julia> hvcat((2,2,2), a,b,c,d,e,f) == hvcat(2, a,b,c,d,e,f)
 true
 ```

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1982,11 +1982,12 @@ function hvcat(nbc::Integer, as...)
 end
 
 """
-    hvcat(rows::Tuple{Vararg{Int}}, values...)
+    hvcat(blocks_per_row::Union{Tuple{Vararg{Int}}, Integer}, values...)
 
 Horizontal and vertical concatenation in one call. This function is called for block matrix
 syntax. The first argument specifies the number of arguments to concatenate in each block
-row.
+row. If the first argument is a single integer `n`, then all block rows are assumed to have `n`
+block columns.
 
 # Examples
 ```jldoctest
@@ -2015,9 +2016,6 @@ julia> hvcat((2,2,2), a,b,c,d,e,f)
  3  4
  5  6
 ```
-
-If the first argument is a single integer `n`, then all block rows are assumed to have `n`
-block columns.
 """
 hvcat(rows::Tuple{Vararg{Int}}, xs::AbstractVecOrMat...) = typed_hvcat(promote_eltype(xs...), rows, xs...)
 hvcat(rows::Tuple{Vararg{Int}}, xs::AbstractVecOrMat{T}...) where {T} = typed_hvcat(T, rows, xs...)


### PR DESCRIPTION
Replace the name of the first argument in the docstring from `rows` to `blocks_per_row`, which is closer to what the argument stands for.