### PR TITLE
Docs: Remove static scheduling warning

### DIFF
--- a/doc/src/manual/multi-threading.md
+++ b/doc/src/manual/multi-threading.md
@@ -361,9 +361,6 @@ threads in Julia:
     multiple threads where at least one thread modifies the collection
     (common examples include `push!` on arrays, or inserting
     items into a `Dict`).
-  * `@threads` currently uses a static schedule, using all threads and assigning
-    equal iteration counts to each. In the future the default schedule is likely
-    to change to be dynamic.
   * The schedule used by `@spawn` is nondeterministic and should not be relied on.
   * Compute-bound, non-memory-allocating tasks can prevent garbage collection from
     running in other threads that are allocating memory. In these cases it may


### PR DESCRIPTION
The docs on multithreading still warns that the default scheduler for @threads
uses static scheduling. However, since #44136, dynamic scheduling has been the
default. This commit removes the warning.