### PR TITLE
Docs: Clarify docs of watch_file and watch_folder

### DIFF
--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -744,7 +744,9 @@ end
     watch_file(path::AbstractString, timeout_s::Real=-1)
 
 Watch file or directory `path` for changes until a change occurs or `timeout_s` seconds have
-elapsed.
+elapsed. This function does not poll the file system and instead uses platform-specific
+functionality to receive notifications from the operating system (e.g. via inotify on Linux).
+See the NodeJS documentation linked below for details.
 
 The returned value is an object with boolean fields `changed`, `renamed`, and `timedout`,
 giving the result of watching the file.
@@ -773,7 +775,9 @@ watch_file(s::AbstractString, timeout_s::Real=-1) = watch_file(String(s), Float6
     watch_folder(path::AbstractString, timeout_s::Real=-1)
 
 Watches a file or directory `path` for changes until a change has occurred or `timeout_s`
-seconds have elapsed.
+seconds have elapsed. This function does not poll the file system and instead uses platform-specific
+functionality to receive notifications from the operating system (e.g. via inotify on Linux).
+See the NodeJS documentation linked below for details.
 
 This will continuing tracking changes for `path` in the background until
 `unwatch_folder` is called on the same `path`.


### PR DESCRIPTION
This change adds additional information regarding the behavior of the functions "watch_file" and "watch_folder".
Specifically, the use of events (as opposed to polling) is clarified.