### PR TITLE
@Base.irrational better explained for users.

### DIFF
--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -173,7 +173,7 @@ and arbitrary-precision definition in terms of `BigFloat`s given by the expressi
 
 An `AssertionError` is thrown when either `big(def) isa BigFloat` or `Float64(val) == Float64(def)`
 returns `false`.
-    
+
 # Examples
 ```jldoctest
 julia> Base.@irrational(twoπ, 6.2831853071795864769, 2*big(π))
@@ -185,10 +185,10 @@ julia> Base.@irrational sqrt2  1.4142135623730950488  √big(2)
 
 julia> sqrt2
 sqrt2 = 1.4142135623730...
-    
+
 julia> Base.@irrational sqrt2  1.4142135623730950488  big(2)
 ERROR: AssertionError: big($(Expr(:escape, :sqrt2))) isa BigFloat
-    
+
 julia> Base.@irrational sqrt2  1.41421356237309  √big(2)
 ERROR: AssertionError: Float64($(Expr(:escape, :sqrt2))) == Float64(big($(Expr(:escape, :sqrt2))))
 ```

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -170,6 +170,28 @@ round(x::Irrational, r::RoundingMode) = round(float(x), r)
 
 Define a new `Irrational` value, `sym`, with pre-computed `Float64` value `val`,
 and arbitrary-precision definition in terms of `BigFloat`s given by the expression `def`.
+
+An `AssertionError` is thrown when either `big(def) isa BigFloat` or `Float64(val) == Float64(def)`
+returns `false`.
+    
+# Examples
+```jldoctest
+julia> Base.@irrational(twoπ, 6.2831853071795864769, 2*big(π))
+
+julia> twoπ
+twoπ = 6.2831853071795...
+
+julia> Base.@irrational sqrt2  1.4142135623730950488  √big(2)
+
+julia> sqrt2
+sqrt2 = 1.4142135623730...
+    
+julia> Base.@irrational sqrt2  1.4142135623730950488  big(2)
+ERROR: AssertionError: big($(Expr(:escape, :sqrt2))) isa BigFloat
+    
+julia> Base.@irrational sqrt2  1.41421356237309  √big(2)
+ERROR: AssertionError: Float64($(Expr(:escape, :sqrt2))) == Float64(big($(Expr(:escape, :sqrt2))))
+```
 """
 macro irrational(sym, val, def)
     esym = esc(sym)


### PR DESCRIPTION
The `Irrational` type is something I think is unique to Julia and the way to create one is using the macro `Base.@irrational`; so the function's doc on `Base.@irrational` should do a good job of stating how exactly `Irrational` can be created and why and how errors are thrown when using the macro.

More examples should be given on how to create these kind of types since new users I guess from nearly all languages wouldn't be aware of how these works at first sight, since other languages do not implement this. This is where Julia shines, so users shouldn't have to look at the `irrationals.jl` file or `MathConstants.jl` file before learning how `Base.@irrational` works.

To add to it, most of the other macros like `big_str`, `@doc`, `@time`, etc all have examples to help the user with, so I don't see why `Base.@irrational` shouldn't?