### PR TITLE
Refactor lattice code to expose layering and enable easy extension

### DIFF
--- a/base/compiler/abstractlattice.jl
+++ b/base/compiler/abstractlattice.jl
@@ -1,0 +1,173 @@
+abstract type AbstractLattice; end
+function widenlattice end
+
+"""
+    struct JLTypeLattice
+
+A singleton type representing the lattice of Julia types, without any inference
+extensions.
+"""
+struct JLTypeLattice <: AbstractLattice; end
+widenlattice(::JLTypeLattice) = error("Type lattice is the least-precise lattice available")
+is_valid_lattice(::JLTypeLattice, @nospecialize(elem)) = isa(elem, Type)
+
+"""
+    struct ConstsLattice
+
+A lattice extending `JLTypeLattice` and adjoining `Const` and `PartialTypeVar`.
+"""
+struct ConstsLattice <: AbstractLattice; end
+widenlattice(::ConstsLattice) = JLTypeLattice()
+is_valid_lattice(lattice::ConstsLattice, @nospecialize(elem)) =
+    is_valid_lattice(widenlattice(lattice), elem) || isa(elem, Const) || isa(elem, PartialTypeVar)
+
+"""
+    struct PartialsLattice{L}
+
+A lattice extending lattice `L` and adjoining `PartialStruct` and `PartialOpaque`.
+"""
+struct PartialsLattice{L <: AbstractLattice} <: AbstractLattice
+    parent::L
+end
+widenlattice(L::PartialsLattice) = L.parent
+is_valid_lattice(lattice::PartialsLattice, @nospecialize(elem)) =
+    is_valid_lattice(widenlattice(lattice), elem) ||
+    isa(elem, PartialStruct) || isa(elem, PartialOpaque)
+
+"""
+    struct ConditionalsLattice{L}
+
+A lattice extending lattice `L` and adjoining `Conditional`.
+"""
+struct ConditionalsLattice{L <: AbstractLattice} <: AbstractLattice
+    parent::L
+end
+widenlattice(L::ConditionalsLattice) = L.parent
+is_valid_lattice(lattice::ConditionalsLattice, @nospecialize(elem)) =
+    is_valid_lattice(widenlattice(lattice), elem) || isa(elem, Conditional)
+
+struct InterConditionalsLattice{L <: AbstractLattice} <: AbstractLattice
+    parent::L
+end
+widenlattice(L::InterConditionalsLattice) = L.parent
+is_valid_lattice(lattice::InterConditionalsLattice, @nospecialize(elem)) =
+    is_valid_lattice(widenlattice(lattice), elem) || isa(elem, InterConditional)
+
+const AnyConditionalsLattice{L} = Union{ConditionalsLattice{L}, InterConditionalsLattice{L}}
+const BaseInferenceLattice = typeof(ConditionalsLattice(PartialsLattice(ConstsLattice())))
+const IPOResultLattice = typeof(InterConditionalsLattice(PartialsLattice(ConstsLattice())))
+
+"""
+    struct InferenceLattice{L}
+
+The full lattice used for abstract interpration during inference. Takes
+a base lattice and adjoins `LimitedAccuracy`.
+"""
+struct InferenceLattice{L} <: AbstractLattice
+    parent::L
+end
+widenlattice(L::InferenceLattice) = L.parent
+is_valid_lattice(lattice::InferenceLattice, @nospecialize(elem)) =
+    is_valid_lattice(widenlattice(lattice), elem) || isa(elem, LimitedAccuracy)
+
+"""
+    struct OptimizerLattice
+
+The lattice used by the optimizer. Extends
+`BaseInferenceLattice` with `MaybeUndef`.
+"""
+struct OptimizerLattice <: AbstractLattice; end
+widenlattice(L::OptimizerLattice) = BaseInferenceLattice.instance
+is_valid_lattice(lattice::OptimizerLattice, @nospecialize(elem)) =
+    is_valid_lattice(widenlattice(lattice), elem) || isa(elem, MaybeUndef)
+
+"""
+    tmeet(lattice, a, b::Type)
+
+Compute the lattice meet of lattice elements `a` and `b` over the lattice
+`lattice`. If `lattice` is `JLTypeLattice`, this is equiavalent to type
+intersection. Note that currently `b` is restricted to being a type (interpreted
+as a lattice element in the JLTypeLattice sub-lattice of `lattice`).
+"""
+function tmeet end
+
+function tmeet(::JLTypeLattice, @nospecialize(a::Type), @nospecialize(b::Type))
+    ti = typeintersect(a, b)
+    valid_as_lattice(ti) || return Bottom
+    return ti
+end
+
+"""
+    tmerge(lattice, a, b)
+
+Compute a lattice join of elements `a` and `b` over the lattice `lattice`.
+Note that the computed element need not be the least upper bound of `a` and
+`b`, but rather, we impose additional limitations on the complexity of the
+joined element, ideally without losing too much precision in common cases and
+remaining mostly associative and commutative.
+"""
+function tmerge end
+
+"""
+    ⊑(lattice, a, b)
+
+Compute the lattice ordering (i.e. less-than-or-equal) relationship between
+lattice elements `a` and `b` over the lattice `lattice`. If `lattice` is
+`JLTypeLattice`, this is equiavalent to subtyping.
+"""
+function ⊑ end
+
+⊑(::JLTypeLattice, @nospecialize(a::Type), @nospecialize(b::Type)) = a <: b
+
+"""
+    ⊏(lattice, a, b) -> Bool
+
+The strict partial order over the type inference lattice.
+This is defined as the irreflexive kernel of `⊑`.
+"""
+⊏(lattice::AbstractLattice, @nospecialize(a), @nospecialize(b)) = ⊑(lattice, a, b) && !⊑(lattice, b, a)
+
+"""
+    ⋤(lattice, a, b) -> Bool
+
+This order could be used as a slightly more efficient version of the strict order `⊏`,
+where we can safely assume `a ⊑ b` holds.
+"""
+⋤(lattice::AbstractLattice, @nospecialize(a), @nospecialize(b)) = !⊑(lattice, b, a)
+
+"""
+    is_lattice_equal(lattice, a, b) -> Bool
+
+Check if two lattice elements are partial order equivalent.
+This is basically `a ⊑ b && b ⊑ a` but (optionally) with extra performance optimizations.
+"""
+function is_lattice_equal(lattice::AbstractLattice, @nospecialize(a), @nospecialize(b))
+    a === b && return true
+    ⊑(lattice, a, b) && ⊑(lattice, b, a)
+end
+
+"""
+    has_nontrivial_const_info(lattice, t) -> Bool
+
+Determine whether the given lattice element `t` of `lattice` has non-trivial
+constant information that would not be available from the type itself.
+"""
+has_nontrivial_const_info(lattice::AbstractLattice, @nospecialize t) =
+    has_nontrivial_const_info(widenlattice(lattice), t)
+has_nontrivial_const_info(::JLTypeLattice, @nospecialize(t)) = false
+
+# Curried versions
+⊑(lattice::AbstractLattice) = (@nospecialize(a), @nospecialize(b)) -> ⊑(lattice, a, b)
+⊏(lattice::AbstractLattice) = (@nospecialize(a), @nospecialize(b)) -> ⊏(lattice, a, b)
+⋤(lattice::AbstractLattice) = (@nospecialize(a), @nospecialize(b)) -> ⋤(lattice, a, b)
+
+# Fallbacks for external packages using these methods
+const fallback_lattice = InferenceLattice(BaseInferenceLattice.instance)
+const fallback_ipo_lattice = InferenceLattice(IPOResultLattice.instance)
+
+⊑(@nospecialize(a), @nospecialize(b)) = ⊑(fallback_lattice, a, b)
+tmeet(@nospecialize(a), @nospecialize(b)) = tmeet(fallback_lattice, a, b)
+tmerge(@nospecialize(a), @nospecialize(b)) = tmerge(fallback_lattice, a, b)
+⊏(@nospecialize(a), @nospecialize(b)) = ⊏(fallback_lattice, a, b)
+⋤(@nospecialize(a), @nospecialize(b)) = ⋤(fallback_lattice, a, b)
+is_lattice_equal(@nospecialize(a), @nospecialize(b)) = is_lattice_equal(fallback_lattice, a, b)

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -153,6 +153,8 @@ include("compiler/ssair/basicblock.jl")
 include("compiler/ssair/domtree.jl")
 include("compiler/ssair/ir.jl")
 
+include("compiler/abstractlattice.jl")
+
 include("compiler/inferenceresult.jl")
 include("compiler/inferencestate.jl")
 

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -92,7 +92,7 @@ function inlining_policy(interp::AbstractInterpreter, @nospecialize(src), stmt_f
         # inferred source in the local cache
         # we still won't find a source for recursive call because the "single-level" inlining
         # seems to be more trouble and complex than it's worth
-        inf_result = cache_lookup(mi, argtypes, get_inference_cache(interp))
+        inf_result = cache_lookup(optimizer_lattice(interp), mi, argtypes, get_inference_cache(interp))
         inf_result === nothing && return nothing
         src = inf_result.src
         if isa(src, CodeInfo)
@@ -215,7 +215,7 @@ function stmt_effect_flags(@nospecialize(stmt), @nospecialize(rt), src::Union{IR
     isa(stmt, PhiNode) && return (true, true)
     isa(stmt, ReturnNode) && return (false, true)
     isa(stmt, GotoNode) && return (false, true)
-    isa(stmt, GotoIfNot) && return (false, argextype(stmt.cond, src) ⊑ Bool)
+    isa(stmt, GotoIfNot) && return (false, argextype(stmt.cond, src) ⊑ₒ Bool)
     isa(stmt, Slot) && return (false, false) # Slots shouldn't occur in the IR at this point, but let's be defensive here
     if isa(stmt, GlobalRef)
         nothrow = isdefined(stmt.mod, stmt.name)
@@ -248,7 +248,7 @@ function stmt_effect_flags(@nospecialize(stmt), @nospecialize(rt), src::Union{IR
                 return (total, total)
             end
             rt === Bottom && return (false, false)
-            nothrow = _builtin_nothrow(f, Any[argextype(args[i], src) for i = 2:length(args)], rt)
+            nothrow = _builtin_nothrow(f, Any[argextype(args[i], src) for i = 2:length(args)], rt, OptimizerLattice())
             nothrow || return (false, false)
             return (contains_is(_EFFECT_FREE_BUILTINS, f), nothrow)
         elseif head === :new
@@ -262,7 +262,7 @@ function stmt_effect_flags(@nospecialize(stmt), @nospecialize(rt), src::Union{IR
             for fld_idx in 1:(length(args) - 1)
                 eT = argextype(args[fld_idx + 1], src)
                 fT = fieldtype(typ, fld_idx)
-                eT ⊑ fT || return (false, false)
+                eT ⊑ₒ fT || return (false, false)
             end
             return (true, true)
         elseif head === :foreigncall
@@ -277,11 +277,11 @@ function stmt_effect_flags(@nospecialize(stmt), @nospecialize(rt), src::Union{IR
             typ = argextype(args[1], src)
             typ, isexact = instanceof_tfunc(typ)
             isexact || return (false, false)
-            typ ⊑ Tuple || return (false, false)
+            typ ⊑ₒ Tuple || return (false, false)
             rt_lb = argextype(args[2], src)
             rt_ub = argextype(args[3], src)
             source = argextype(args[4], src)
-            if !(rt_lb ⊑ Type && rt_ub ⊑ Type && source ⊑ Method)
+            if !(rt_lb ⊑ₒ Type && rt_ub ⊑ₒ Type && source ⊑ₒ Method)
                 return (false, false)
             end
             return (true, true)
@@ -448,7 +448,7 @@ function finish(interp::AbstractInterpreter, opt::OptimizationState,
         else
             # compute the cost (size) of inlining this code
             cost_threshold = default = params.inline_cost_threshold
-            if result ⊑ Tuple && !isconcretetype(widenconst(result))
+            if ⊑(optimizer_lattice(interp), result, Tuple) && !isconcretetype(widenconst(result))
                 cost_threshold += params.inline_tupleret_bonus
             end
             # if the method is declared as `@inline`, increase the cost threshold 20x

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -188,7 +188,7 @@ function reprocess_instruction!(interp::AbstractInterpreter, ir::IRCode, mi::Met
                         ir.stmts[idx][:flag] |= IR_FLAG_EFFECT_FREE
                     end
                 end
-                if !(typ ⊑ rt)
+                if !⊑(typeinf_lattice(interp), typ, rt)
                     ir.stmts[idx][:type] = rt
                     return true
                 end
@@ -197,7 +197,7 @@ function reprocess_instruction!(interp::AbstractInterpreter, ir::IRCode, mi::Met
                 if mi′ !== mi # prevent infinite loop
                     rr = concrete_eval_invoke(interp, ir, mi_cache, sv, inst, mi′)
                     if rr !== nothing
-                        if !(typ ⊑ rr)
+                        if !⊑(typeinf_lattice(interp), typ, rr)
                             ir.stmts[idx][:type] = rr
                             return true
                         end
@@ -227,7 +227,7 @@ end
 function _ir_abstract_constant_propagation(interp::AbstractInterpreter, mi_cache,
     frame::InferenceState, mi::MethodInstance, ir::IRCode, argtypes::Vector{Any})
     argtypes = va_process_argtypes(argtypes, mi)
-    argtypes_refined = Bool[!(ir.argtypes[i] ⊑ argtypes[i]) for i = 1:length(argtypes)]
+    argtypes_refined = Bool[!⊑(typeinf_lattice(interp), ir.argtypes[i], argtypes[i]) for i = 1:length(argtypes)]
     empty!(ir.argtypes)
     append!(ir.argtypes, argtypes)
     ssa_refined = BitSet()

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -289,7 +289,7 @@ function walk_to_defs(compact::IncrementalCompact, @nospecialize(defssa), @nospe
                             # path, with a different type constraint. We may have
                             # to redo some work here with the wider typeconstraint
                             push!(worklist_defs, new_def)
-                            push!(worklist_constraints, tmerge(new_constraint, visited_constraints[new_def]))
+                            push!(worklist_constraints, tmerge(OptimizerLattice(), new_constraint, visited_constraints[new_def]))
                         end
                         continue
                     end
@@ -348,7 +348,7 @@ function is_getfield_captures(@nospecialize(def), compact::IncrementalCompact)
     isa(which, Const) || return false
     which.val === :captures || return false
     oc = argextype(def.args[2], compact)
-    return oc ⊑ Core.OpaqueClosure
+    return oc ⊑ₒ Core.OpaqueClosure
 end
 
 struct LiftedValue
@@ -528,13 +528,15 @@ function lift_comparison!(::typeof(===), compact::IncrementalCompact,
     lift_comparison_leaves!(egal_tfunc, compact, val, cmp, lifting_cache, idx)
 end
 
+isa_tfunc_opt(@nospecialize(v), @nospecialize(t)) = isa_tfunc(OptimizerLattice(), v, t)
+
 function lift_comparison!(::typeof(isa), compact::IncrementalCompact,
     idx::Int, stmt::Expr, lifting_cache::IdDict{Pair{AnySSAValue, Any}, AnySSAValue})
     args = stmt.args
     length(args) == 3 || return
     cmp = argextype(args[3], compact)
     val = args[2]
-    lift_comparison_leaves!(isa_tfunc, compact, val, cmp, lifting_cache, idx)
+    lift_comparison_leaves!(isa_tfunc_opt, compact, val, cmp, lifting_cache, idx)
 end
 
 function lift_comparison!(::typeof(isdefined), compact::IncrementalCompact,
@@ -1446,7 +1448,7 @@ function adce_pass!(ir::IRCode)
                 r = searchsorted(unionphis, val.id; by = first)
                 if !isempty(r)
                     unionphi = unionphis[first(r)]
-                    t = tmerge(unionphi[2], stmt.typ)
+                    t = tmerge(OptimizerLattice(), unionphi[2], stmt.typ)
                     unionphis[first(r)] = Pair{Int,Any}(unionphi[1], t)
                 end
             end
@@ -1454,7 +1456,7 @@ function adce_pass!(ir::IRCode)
             if is_known_call(stmt, typeassert, compact) && length(stmt.args) == 3
                 # nullify safe `typeassert` calls
                 ty, isexact = instanceof_tfunc(argextype(stmt.args[3], compact))
-                if isexact && argextype(stmt.args[2], compact) ⊑ ty
+                if isexact && argextype(stmt.args[2], compact) ⊑ₒ ty
                     compact[idx] = nothing
                     continue
                 end
@@ -1483,7 +1485,7 @@ function adce_pass!(ir::IRCode)
                     if !isempty(r)
                         unionphi = unionphis[first(r)]
                         unionphis[first(r)] = Pair{Int,Any}(unionphi[1],
-                            tmerge(unionphi[2], inst[:type]))
+                            tmerge(OptimizerLattice(), unionphi[2], inst[:type]))
                     end
                 end
             end
@@ -1499,7 +1501,7 @@ function adce_pass!(ir::IRCode)
             continue
         elseif t === Any
             continue
-        elseif compact.result[phi][:type] ⊑ t
+        elseif compact.result[phi][:type] ⊑ₒ t
             continue
         end
         to_drop = Int[]

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -72,7 +72,8 @@ function count_int(val::Int, arr::Vector{Int})
     n
 end
 
-function verify_ir(ir::IRCode, print::Bool=true, allow_frontend_forms::Bool=false)
+function verify_ir(ir::IRCode, print::Bool=true, allow_frontend_forms::Bool=false,
+                   lattice = OptimizerLattice())
     # For now require compact IR
     # @assert isempty(ir.new_nodes)
     # Verify CFG
@@ -182,7 +183,7 @@ function verify_ir(ir::IRCode, print::Bool=true, allow_frontend_forms::Bool=fals
                 val = stmt.values[i]
                 phiT = ir.stmts[idx][:type]
                 if isa(val, SSAValue)
-                    if !(types(ir)[val] ⊑ phiT)
+                    if !⊑(lattice, types(ir)[val], phiT)
                         #@verify_error """
                         #    PhiNode $idx, has operand $(val.id), whose type is not a sub lattice element.
                         #    PhiNode type was $phiT

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -651,7 +651,7 @@ function annotate_slot_load!(undefs::Vector{Bool}, idx::Int, sv::InferenceState,
             @assert typ !== NOT_FOUND "active slot in unreached region"
         end
         # add type annotations where needed
-        if !(sv.slottypes[id] ⊑ typ)
+        if !⊑(typeinf_lattice(sv.interp), sv.slottypes[id], typ)
             return TypedSlot(id, typ)
         end
         return x

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -174,10 +174,10 @@ widenwrappedconditional(typ::LimitedAccuracy) = LimitedAccuracy(widenconditional
 
 # `Conditional` and `InterConditional` are valid in opposite contexts
 # (i.e. local inference and inter-procedural call), as such they will never be compared
-function issubconditional(a::C, b::C) where {C<:AnyConditional}
+function issubconditional(lattice::AbstractLattice, a::C, b::C) where {C<:AnyConditional}
     if is_same_conditionals(a, b)
-        if a.thentype ⊑ b.thentype
-            if a.elsetype ⊑ b.elsetype
+        if ⊑(lattice, a.thentype, b.thentype)
+            if ⊑(lattice, a.elsetype, b.elsetype)
                 return true
             end
         end
@@ -187,7 +187,7 @@ end
 
 is_same_conditionals(a::C, b::C) where C<:AnyConditional = a.slot == b.slot
 
-is_lattice_bool(@nospecialize(typ)) = typ !== Bottom && typ ⊑ Bool
+is_lattice_bool(lattice::AbstractLattice, @nospecialize(typ)) = typ !== Bottom && ⊑(lattice, typ, Bool)
 
 maybe_extract_const_bool(c::Const) = (val = c.val; isa(val, Bool)) ? val : nothing
 function maybe_extract_const_bool(c::AnyConditional)
@@ -206,12 +206,7 @@ ignorelimited(typ::LimitedAccuracy) = typ.typ
 # lattice order
 # =============
 
-"""
-    a ⊑ b -> Bool
-
-The non-strict partial order over the type inference lattice.
-"""
-@nospecialize(a) ⊑ @nospecialize(b) = begin
+function ⊑(lattice::InferenceLattice, @nospecialize(a), @nospecialize(b))
     if isa(b, LimitedAccuracy)
         if !isa(a, LimitedAccuracy)
             return false
@@ -222,27 +217,39 @@ The non-strict partial order over the type inference lattice.
         b = b.typ
     end
     isa(a, LimitedAccuracy) && (a = a.typ)
+    return ⊑(widenlattice(lattice), a, b)
+end
+
+function ⊑(lattice::OptimizerLattice, @nospecialize(a), @nospecialize(b))
     if isa(a, MaybeUndef) && !isa(b, MaybeUndef)
         return false
     end
     isa(a, MaybeUndef) && (a = a.typ)
     isa(b, MaybeUndef) && (b = b.typ)
+    return ⊑(widenlattice(lattice), a, b)
+end
+
+function ⊑(lattice::AnyConditionalsLattice, @nospecialize(a), @nospecialize(b))
+    # Fast paths for common cases
     b === Any && return true
     a === Any && return false
     a === Union{} && return true
     b === Union{} && return false
-    @assert !isa(a, TypeVar) "invalid lattice item"
-    @assert !isa(b, TypeVar) "invalid lattice item"
-    if isa(a, AnyConditional)
-        if isa(b, AnyConditional)
-            return issubconditional(a, b)
+    T = isa(lattice, ConditionalsLattice) ? Conditional : InterConditional
+    if isa(a, T)
+        if isa(b, T)
+            return issubconditional(lattice, a, b)
         elseif isa(b, Const) && isa(b.val, Bool)
             return maybe_extract_const_bool(a) === b.val
         end
         a = Bool
-    elseif isa(b, AnyConditional)
+    elseif isa(b, T)
         return false
     end
+    return ⊑(widenlattice(lattice), a, b)
+end
+
+function ⊑(lattice::PartialsLattice, @nospecialize(a), @nospecialize(b))
     if isa(a, PartialStruct)
         if isa(b, PartialStruct)
             if !(length(a.fields) == length(b.fields) && a.typ <: b.typ)
@@ -262,7 +269,7 @@ The non-strict partial order over the type inference lattice.
                         continue
                     end
                 end
-                ⊑(af, bf) || return false
+                ⊑(lattice, af, bf) || return false
             end
             return true
         end
@@ -283,7 +290,7 @@ The non-strict partial order over the type inference lattice.
                 if i == nf
                     bf = unwrapva(bf)
                 end
-                ⊑(Const(getfield(a.val, i)), bf) || return false
+                ⊑(lattice, Const(getfield(a.val, i)), bf) || return false
             end
             return true
         end
@@ -293,12 +300,16 @@ The non-strict partial order over the type inference lattice.
         if isa(b, PartialOpaque)
             (a.parent === b.parent && a.source === b.source) || return false
             return (widenconst(a) <: widenconst(b)) &&
-                ⊑(a.env, b.env)
+                ⊑(lattice, a.env, b.env)
         end
-        return widenconst(a) ⊑ b
+        return ⊑(widenlattice(lattice), widenconst(a), b)
     elseif isa(b, PartialOpaque)
         return false
     end
+    return ⊑(widenlattice(lattice), a, b)
+end
+
+function ⊑(lattice::ConstsLattice, @nospecialize(a), @nospecialize(b))
     if isa(a, Const)
         if isa(b, Const)
             return a.val === b.val
@@ -315,84 +326,85 @@ The non-strict partial order over the type inference lattice.
     elseif isa(a, PartialTypeVar)
         return b === TypeVar || a === b
     elseif isa(b, PartialTypeVar)
-        return a === b
-    else
-        return a <: b
+        return false
     end
+    return ⊑(widenlattice(lattice), a, b)
 end
 
-"""
-    a ⊏ b -> Bool
+function is_lattice_equal(lattice::InferenceLattice, @nospecialize(a), @nospecialize(b))
+    if isa(a, LimitedAccuracy) || isa(b, LimitedAccuracy)
+        # TODO: Unwrap these and recurse to is_lattice_equal
+        return ⊑(lattice, a, b) && ⊑(lattice, b, a)
+    end
+    return is_lattice_equal(widenlattice(lattice), a, b)
+end
 
-The strict partial order over the type inference lattice.
-This is defined as the irreflexive kernel of `⊑`.
-"""
-@nospecialize(a) ⊏ @nospecialize(b) = a ⊑ b && !⊑(b, a)
+function is_lattice_equal(lattice::OptimizerLattice, @nospecialize(a), @nospecialize(b))
+    if isa(a, MaybeUndef) || isa(b, MaybeUndef)
+        # TODO: Unwrap these and recurse to is_lattice_equal
+        return ⊑(lattice, a, b) && ⊑(lattice, b, a)
+    end
+    return is_lattice_equal(widenlattice(lattice), a, b)
+end
 
-"""
-    a ⋤ b -> Bool
+function is_lattice_equal(lattice::AnyConditionalsLattice, @nospecialize(a), @nospecialize(b))
+    if isa(a, AnyConditional) || isa(b, AnyConditional)
+        # TODO: Unwrap these and recurse to is_lattice_equal
+        return ⊑(lattice, a, b) && ⊑(lattice, b, a)
+    end
+    return is_lattice_equal(widenlattice(lattice), a, b)
+end
 
-This order could be used as a slightly more efficient version of the strict order `⊏`,
-where we can safely assume `a ⊑ b` holds.
-"""
-@nospecialize(a) ⋤ @nospecialize(b) = !⊑(b, a)
-
-"""
-    is_lattice_equal(a, b) -> Bool
-
-Check if two lattice elements are partial order equivalent.
-This is basically `a ⊑ b && b ⊑ a` but with extra performance optimizations.
-"""
-function is_lattice_equal(@nospecialize(a), @nospecialize(b))
-    a === b && return true
+function is_lattice_equal(lattice::PartialsLattice, @nospecialize(a), @nospecialize(b))
     if isa(a, PartialStruct)
         isa(b, PartialStruct) || return false
         length(a.fields) == length(b.fields) || return false
         widenconst(a) == widenconst(b) || return false
+        a.fields === b.fields && return true # fast path
         for i in 1:length(a.fields)
             is_lattice_equal(a.fields[i], b.fields[i]) || return false
         end
         return true
     end
     isa(b, PartialStruct) && return false
+    if isa(a, PartialOpaque)
+        isa(b, PartialOpaque) || return false
+        widenconst(a) == widenconst(b) || return false
+        a.source === b.source || return false
+        a.parent === b.parent || return false
+        return is_lattice_equal(lattice, a.env, b.env)
+    end
+    isa(b, PartialOpaque) && return false
+    return is_lattice_equal(widenlattice(lattice), a, b)
+end
+
+function is_lattice_equal(lattice::ConstsLattice, @nospecialize(a), @nospecialize(b))
+    a === b && return true
     if a isa Const
         if issingletontype(b)
             return a.val === b.instance
         end
+        # N.B. Assumes a === b checked above
         return false
     end
     if b isa Const
         if issingletontype(a)
             return a.instance === b.val
         end
+        # N.B. Assumes a === b checked above
         return false
     end
-    if isa(a, PartialOpaque)
-        isa(b, PartialOpaque) || return false
-        widenconst(a) == widenconst(b) || return false
-        a.source === b.source || return false
-        a.parent === b.parent || return false
-        return is_lattice_equal(a.env, b.env)
+    if isa(a, PartialTypeVar) || isa(b, PartialTypeVar)
+        return false
     end
-    return a ⊑ b && b ⊑ a
+    return is_lattice_equal(widenlattice(lattice), a, b)
 end
 
 # lattice operations
 # ==================
 
-"""
-    tmeet(v, t::Type) -> x
-
-Computes typeintersect over the extended inference lattice, as precisely as we can,
-where `v` is in the extended lattice, and `t` is a `Type`.
-"""
-function tmeet(@nospecialize(v), @nospecialize(t::Type))
-    if isa(v, Const)
-        if !has_free_typevars(t) && !isa(v.val, t)
-            return Bottom
-        end
-        return v
-    elseif isa(v, PartialStruct)
+function tmeet(lattice::PartialsLattice, @nospecialize(v), @nospecialize(t::Type))
+    if isa(v, PartialStruct)
         has_free_typevars(t) && return v
         widev = widenconst(v)
         ti = typeintersect(widev, t)
@@ -407,13 +419,13 @@ function tmeet(@nospecialize(v), @nospecialize(t::Type))
             if isvarargtype(vfi)
                 new_fields[i] = vfi
             else
-                new_fields[i] = tmeet(vfi, widenconst(getfield_tfunc(t, Const(i))))
+                new_fields[i] = tmeet(lattice, vfi, widenconst(getfield_tfunc(t, Const(i))))
                 if new_fields[i] === Bottom
                     return Bottom
                 end
             end
         end
-        return tuple_tfunc(new_fields)
+        return tuple_tfunc(lattice, new_fields)
     elseif isa(v, PartialOpaque)
         has_free_typevars(t) && return v
         widev = widenconst(v)
@@ -423,15 +435,46 @@ function tmeet(@nospecialize(v), @nospecialize(t::Type))
         ti = typeintersect(widev, t)
         valid_as_lattice(ti) || return Bottom
         return PartialOpaque(ti, v.env, v.parent, v.source)
-    elseif isa(v, Conditional)
+    end
+    return tmeet(widenlattice(lattice), v, t)
+end
+
+function tmeet(lattice::ConstsLattice, @nospecialize(v), @nospecialize(t::Type))
+    if isa(v, Const)
+        if !has_free_typevars(t) && !isa(v.val, t)
+            return Bottom
+        end
+        return v
+    end
+    tmeet(widenlattice(lattice), widenconst(v), t)
+end
+
+function tmeet(lattice::ConditionalsLattice, @nospecialize(v), @nospecialize(t::Type))
+    if isa(v, Conditional)
         if !(Bool <: t)
             return Bottom
         end
         return v
     end
-    ti = typeintersect(widenconst(v), t)
-    valid_as_lattice(ti) || return Bottom
-    return ti
+    tmeet(widenlattice(lattice), v, t)
+end
+
+function tmeet(lattice::InferenceLattice, @nospecialize(v), @nospecialize(t::Type))
+    # TODO: This can probably happen and should be handled
+    @assert !isa(v, LimitedAccuracy)
+    tmeet(widenlattice(lattice), v, t)
+end
+
+function tmeet(lattice::InterConditionalsLattice, @nospecialize(v), @nospecialize(t::Type))
+    # TODO: This can probably happen and should be handled
+    @assert !isa(v, AnyConditional)
+    tmeet(widenlattice(lattice), v, t)
+end
+
+function tmeet(lattice::OptimizerLattice, @nospecialize(v), @nospecialize(t::Type))
+    # TODO: This can probably happen and should be handled
+    @assert !isa(v, MaybeUndef)
+    tmeet(widenlattice(lattice), v, t)
 end
 
 """
@@ -454,19 +497,22 @@ widenconst(::LimitedAccuracy) = error("unhandled LimitedAccuracy")
 # state management #
 ####################
 
-issubstate(a::VarState, b::VarState) = (a.typ ⊑ b.typ && a.undef <= b.undef)
+issubstate(lattice::AbstractLattice, a::VarState, b::VarState) =
+    ⊑(lattice, a.typ, b.typ) && a.undef <= b.undef
 
-function smerge(sa::Union{NotFound,VarState}, sb::Union{NotFound,VarState})
+function smerge(lattice::AbstractLattice, sa::Union{NotFound,VarState}, sb::Union{NotFound,VarState})
     sa === sb && return sa
     sa === NOT_FOUND && return sb
     sb === NOT_FOUND && return sa
-    issubstate(sa, sb) && return sb
-    issubstate(sb, sa) && return sa
-    return VarState(tmerge(sa.typ, sb.typ), sa.undef | sb.undef)
+    issubstate(lattice, sa, sb) && return sb
+    issubstate(lattice, sb, sa) && return sa
+    return VarState(tmerge(lattice, sa.typ, sb.typ), sa.undef | sb.undef)
 end
 
-@inline tchanged(@nospecialize(n), @nospecialize(o)) = o === NOT_FOUND || (n !== NOT_FOUND && !(n ⊑ o))
-@inline schanged(@nospecialize(n), @nospecialize(o)) = (n !== o) && (o === NOT_FOUND || (n !== NOT_FOUND && !issubstate(n::VarState, o::VarState)))
+@inline tchanged(lattice::AbstractLattice, @nospecialize(n), @nospecialize(o)) =
+    o === NOT_FOUND || (n !== NOT_FOUND && !⊑(lattice, n, o))
+@inline schanged(lattice::AbstractLattice, @nospecialize(n), @nospecialize(o)) =
+    (n !== o) && (o === NOT_FOUND || (n !== NOT_FOUND && !issubstate(lattice, n::VarState, o::VarState)))
 
 # remove any lattice elements that wrap the reassigned slot object from the vartable
 function invalidate_slotwrapper(vt::VarState, changeid::Int, ignore_conditional::Bool)
@@ -478,7 +524,7 @@ function invalidate_slotwrapper(vt::VarState, changeid::Int, ignore_conditional:
     return nothing
 end
 
-function stupdate!(state::VarTable, changes::StateUpdate)
+function stupdate!(lattice::AbstractLattice, state::VarTable, changes::StateUpdate)
     changed = false
     changeid = slot_id(changes.var)
     for i = 1:length(state)
@@ -492,28 +538,28 @@ function stupdate!(state::VarTable, changes::StateUpdate)
             newtype = invalidated
         end
         oldtype = state[i]
-        if schanged(newtype, oldtype)
-            state[i] = smerge(oldtype, newtype)
+        if schanged(lattice, newtype, oldtype)
+            state[i] = smerge(lattice, oldtype, newtype)
             changed = true
         end
     end
     return changed
 end
 
-function stupdate!(state::VarTable, changes::VarTable)
+function stupdate!(lattice::AbstractLattice, state::VarTable, changes::VarTable)
     changed = false
     for i = 1:length(state)
         newtype = changes[i]
         oldtype = state[i]
-        if schanged(newtype, oldtype)
-            state[i] = smerge(oldtype, newtype)
+        if schanged(lattice, newtype, oldtype)
+            state[i] = smerge(lattice, oldtype, newtype)
             changed = true
         end
     end
     return changed
 end
 
-function stupdate1!(state::VarTable, change::StateUpdate)
+function stupdate1!(lattice::AbstractLattice, state::VarTable, change::StateUpdate)
     changeid = slot_id(change.var)
     for i = 1:length(state)
         invalidated = invalidate_slotwrapper(state[i], changeid, change.conditional)
@@ -524,8 +570,8 @@ function stupdate1!(state::VarTable, change::StateUpdate)
     # and update the type of it
     newtype = change.vtype
     oldtype = state[changeid]
-    if schanged(newtype, oldtype)
-        state[changeid] = smerge(oldtype, newtype)
+    if schanged(lattice, newtype, oldtype)
+        state[changeid] = smerge(lattice, oldtype, newtype)
         return true
     end
     return false

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -273,3 +273,7 @@ to the call site signature.
 """
 infer_compilation_signature(::AbstractInterpreter) = false
 infer_compilation_signature(::NativeInterpreter) = true
+
+typeinf_lattice(::AbstractInterpreter) = InferenceLattice(BaseInferenceLattice.instance)
+ipo_lattice(::AbstractInterpreter) = InferenceLattice(IPOResultLattice.instance)
+optimizer_lattice(::AbstractInterpreter) = OptimizerLattice()

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -23,13 +23,18 @@ function hasuniquerep(@nospecialize t)
     return false
 end
 
-function has_nontrivial_const_info(@nospecialize t)
+function has_nontrivial_const_info(lattice::PartialsLattice, @nospecialize t)
     isa(t, PartialStruct) && return true
     isa(t, PartialOpaque) && return true
+    return has_nontrivial_const_info(widenlattice(lattice), t)
+end
+function has_nontrivial_const_info(lattice::ConstsLattice, @nospecialize t)
     isa(t, PartialTypeVar) && return true
-    isa(t, Const) || return false
-    val = t.val
-    return !isdefined(typeof(val), :instance) && !(isa(val, Type) && hasuniquerep(val))
+    if isa(t, Const)
+        val = t.val
+        return !isdefined(typeof(val), :instance) && !(isa(val, Type) && hasuniquerep(val))
+    end
+    return has_nontrivial_const_info(widenlattice(lattice), t)
 end
 
 has_const_info(@nospecialize x) = (!isa(x, Type) && !isvarargtype(x)) || isType(x)

--- a/test/compiler/AbstractInterpreter.jl
+++ b/test/compiler/AbstractInterpreter.jl
@@ -34,8 +34,9 @@ macro newinterp(name)
     end
 end
 
-# `OverlayMethodTable`
-# --------------------
+# OverlayMethodTable
+# ==================
+
 import Base.Experimental: @MethodTable, @overlay
 
 @newinterp MTOverlayInterp
@@ -110,3 +111,122 @@ Base.@assume_effects :total totalcall(f, args...) = f(args...)
         return missing
     end
 end |> only === Nothing
+
+# AbstractLattice
+# ===============
+
+using Core: SlotNumber, Argument
+using Core.Compiler: slot_id, tmerge_fast_path
+import .CC:
+    AbstractLattice, BaseInferenceLattice, IPOResultLattice, InferenceLattice, OptimizerLattice,
+    widen, is_valid_lattice, typeinf_lattice, ipo_lattice, optimizer_lattice,
+    widenconst, tmeet, tmerge, ⊑, abstract_eval_special_value, widenreturn,
+    widenlattice
+
+@newinterp TaintInterpreter
+struct TaintLattice{PL<:AbstractLattice} <: CC.AbstractLattice
+    parent::PL
+end
+CC.widen(𝕃::TaintLattice) = 𝕃.parent
+CC.is_valid_lattice(𝕃::TaintLattice, @nospecialize(elm)) =
+    is_valid_lattice(widenlattice(𝕃), elem) || isa(elm, Taint)
+
+struct InterTaintLattice{PL<:AbstractLattice} <: CC.AbstractLattice
+    parent::PL
+end
+CC.widen(𝕃::InterTaintLattice) = 𝕃.parent
+CC.is_valid_lattice(𝕃::InterTaintLattice, @nospecialize(elm)) =
+    is_valid_lattice(widenlattice(𝕃), elem) || isa(elm, InterTaint)
+
+const AnyTaintLattice{L} = Union{TaintLattice{L},InterTaintLattice{L}}
+
+CC.typeinf_lattice(::TaintInterpreter) = InferenceLattice(TaintLattice(BaseInferenceLattice.instance))
+CC.ipo_lattice(::TaintInterpreter) = InferenceLattice(InterTaintLattice(IPOResultLattice.instance))
+CC.optimizer_lattice(::TaintInterpreter) = InterTaintLattice(OptimizerLattice())
+
+struct Taint
+    typ
+    slots::BitSet
+    function Taint(@nospecialize(typ), slots::BitSet)
+        if typ isa Taint
+            slots = typ.slots ∪ slots
+            typ = typ.typ
+        end
+        return new(typ, slots)
+    end
+end
+Taint(@nospecialize(typ), id::Int) = Taint(typ, push!(BitSet(), id))
+
+struct InterTaint
+    typ
+    slots::BitSet
+    function InterTaint(@nospecialize(typ), slots::BitSet)
+        if typ isa InterTaint
+            slots = typ.slots ∪ slots
+            typ = typ.typ
+        end
+        return new(typ, slots)
+    end
+end
+InterTaint(@nospecialize(typ), id::Int) = InterTaint(typ, push!(BitSet(), id))
+
+const AnyTaint = Union{Taint, InterTaint}
+
+function CC.tmeet(𝕃::AnyTaintLattice, @nospecialize(v), @nospecialize(t::Type))
+    T = isa(𝕃, TaintLattice) ? Taint : InterTaint
+    if isa(v, T)
+        v = v.typ
+    end
+    return tmeet(widenlattice(𝕃), v, t)
+end
+function CC.tmerge(𝕃::AnyTaintLattice, @nospecialize(typea), @nospecialize(typeb))
+    r = tmerge_fast_path(𝕃, typea, typeb)
+    r !== nothing && return r
+    # type-lattice for Taint
+    T = isa(𝕃, TaintLattice) ? Taint : InterTaint
+    if isa(typea, T)
+        if isa(typeb, T)
+            return T(
+                tmerge(widenlattice(𝕃), typea.typ, typeb),
+                typea.slots ∪ typeb.slots)
+        else
+            typea = typea.typ
+        end
+    elseif isa(typeb, T)
+        typeb = typeb.typ
+    end
+    return tmerge(widenlattice(𝕃), typea, typeb)
+end
+function CC.:⊑(𝕃::AnyTaintLattice, @nospecialize(typea), @nospecialize(typeb))
+    T = isa(𝕃, TaintLattice) ? Taint : InterTaint
+    if isa(typea, T)
+        if isa(typeb, T)
+            typea.slots ⊆ typeb.slots || return false
+            return ⊑(widenlattice(𝕃), typea.typ, typeb.typ)
+        end
+        typea = typea.typ
+    elseif isa(typeb, T)
+        return false
+    end
+    return ⊑(widenlattice(𝕃), typea, typeb)
+end
+CC.widenconst(taint::AnyTaint) = widenconst(taint.typ)
+
+function CC.abstract_eval_special_value(interp::TaintInterpreter,
+    @nospecialize(e), vtypes::CC.VarTable, sv::CC.InferenceState)
+    ret = @invoke CC.abstract_eval_special_value(interp::CC.AbstractInterpreter,
+        e::Any, vtypes::CC.VarTable, sv::CC.InferenceState)
+    if isa(e, SlotNumber) || isa(e, Argument)
+        return Taint(ret, slot_id(e))
+    end
+    return ret
+end
+
+function CC.widenreturn(𝕃::InferenceLattice{<:InterTaintLattice}, @nospecialize(rt), @nospecialize(bestguess), nargs::Int, slottypes::Vector{Any}, changes::CC.VarTable)
+    if isa(rt, Taint)
+        return InterTaint(rt.typ, BitSet((id for id in rt.slots if id ≤ nargs)))
+    end
+    return CC.widenreturn(widenlattice(𝕃), rt, bestguess, nargs, slottypes, changes)
+end
+
+# code_typed(ifelse, (Bool, Int, Int); interp=TaintInterpreter())

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -163,7 +163,7 @@ tmerge_test(Tuple{}, Tuple{Complex, Vararg{Union{ComplexF32, ComplexF64}}},
 @test Core.Compiler.tmerge(Vector{Int}, Core.Compiler.tmerge(Vector{String}, Union{Vector{Bool}, Vector{Symbol}})) == Vector
 @test Core.Compiler.tmerge(Base.BitIntegerType, Union{}) === Base.BitIntegerType
 @test Core.Compiler.tmerge(Union{}, Base.BitIntegerType) === Base.BitIntegerType
-@test Core.Compiler.tmerge(Core.Compiler.InterConditional(1, Int, Union{}), Core.Compiler.InterConditional(2, String, Union{})) === Core.Compiler.Const(true)
+@test Core.Compiler.tmerge(Core.Compiler.fallback_ipo_lattice, Core.Compiler.InterConditional(1, Int, Union{}), Core.Compiler.InterConditional(2, String, Union{})) === Core.Compiler.Const(true)
 
 struct SomethingBits
     x::Base.BitIntegerType


### PR DESCRIPTION
There's been two threads of work involving the compiler's notion of
the inference lattice. One is that the lattice has gotten to complicated
and with too many internal constraints that are not manifest in the
type system. #42596 attempted to address this, but it's quite disruptive
as it changes the lattice types and all the signatures of the lattice
operations, which are used quite extensively throughout the ecosystem
(despite being internal), so that change is quite disruptive (and
something we'd ideally only make the ecosystem do once).

The other thread of work is that people would like to experiment with
a variety of extended lattices outside of base (either to prototype
potential additions to the lattice in base or to do custom abstract
interpretation over the julia code). At the moment, the lattice is
quite closely interwoven with the rest of the abstract interpreter.
In response to this request in #40992, I had proposed a `CustomLattice`
element with callbacks, but this doesn't compose particularly well,
is cumbersome and imposes overhead on some of the hottest parts of
the compiler, so it's a bit of a tough sell to merge into Base.

In this PR, I'd like to propose a refactoring that is relatively
non-invasive to non-Base users, but I think would allow easier
experimentation with changes to the lattice for these two use
cases. In essence, we're splitting the lattice into a ladder of
5 different lattices, each containing the previous lattice as a
sub-lattice. These 5 lattices are:

- JLTypeLattice (Anything that's a `Type`)
- ConstsLattice ( + `Const`, `PartialTypeVar`)
- PartialsLattice ( + `PartialStruct` )
- ConditionalsLattice ( + `Conditional` )
- InferenceLattice ( + `LimitedAccuracy`, `MaybeUndef` )

The idea is that where a lattice element contains another lattice
element (e.g. in `PartialStruct` or `Conditional`), the element
contained may only be from a wider lattice. In this PR, this
is not enforced by the type system. This is quite deliberate, as
I want to retain the types and object layouts of the lattice elements,
but of course a future #42596-like change could add such type
enforcement.

Of particular note is that the `PartialsLattice` and `ConditionalsLattice`
is parameterized and additional layers may be added in the stack.
For example, in #40992, I had proposed a lattice element that refines
`Int` and tracks symbolic expressions. In this setup, this could
be accomplished by adding an appropriate lattice in between the
`ConstsLattice` and the `PartialsLattice` (of course, additional
hooks would be required to make the tfuncs work, but that is
outside the scope of this PR).

I don't think this is a full solution, but I think it'll help us
play with some of these extended lattice options over the next
6-12 months in the packages that want to do this sort of thing.
Presumably once we know what all the potential lattice extensions
look like, we will want to take another look at this (likely
together with whatever solution we come up with for the
AbstractInterpreter composability problem and a rebase of #42596).

WIP because I didn't bother updating and plumbing through the lattice
in all the call sites yet, but that's mostly mechanical, so if we
like this direction, I will make that change and hope to merge this
in short order (because otherwise it'll accumulate massive merge
conflicts).