### PR TITLE
fix another invalidation from Static.jl

### DIFF
--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -118,7 +118,7 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
     # split into lines.
     msglines = [(indent=0, msg=l) for l in split(chomp(convert(String, string(message))::String), '\n')]
     stream = logger.stream
-    if !isopen(stream)
+    if !(isopen(stream)::Bool)
         stream = stderr
     end
     dsize = displaysize(stream)::Tuple{Int,Int}


### PR DESCRIPTION
This is a follow-up to https://github.com/JuliaLang/julia/pull/46481 and fixes additional invalidations from Static.jl. I suggest the labels `latency` and `backport-1.8`.