### PR TITLE
fix invalidations in REPL LineEdit.jl from Static.jl

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1548,7 +1548,7 @@ function normalize_keys(keymap::Union{Dict{Char,Any},AnyDict})
     return ret
 end
 
-function add_nested_key!(keymap::Dict, key::Union{String, Char}, value; override::Bool = false)
+function add_nested_key!(keymap::Dict{Char, Any}, key::Union{String, Char}, value; override::Bool = false)
     y = iterate(key)
     while y !== nothing
         c, i = y
@@ -1560,10 +1560,10 @@ function add_nested_key!(keymap::Dict, key::Union{String, Char}, value; override
         if y === nothing
             keymap[c] = value
             break
-        elseif !((c in keys(keymap))::Bool && isa(keymap[c], Dict))
+        elseif !(c in keys(keymap) && isa(keymap[c], Dict))
             keymap[c] = Dict{Char,Any}()
         end
-        keymap = keymap[c]
+        keymap = keymap[c]::Dict{Char, Any}
     end
 end
 

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1548,7 +1548,7 @@ function normalize_keys(keymap::Union{Dict{Char,Any},AnyDict})
     return ret
 end
 
-function add_nested_key!(keymap::Dict, key::Union{String, Char}, value; override = false)
+function add_nested_key!(keymap::Dict, key::Union{String, Char}, value; override::Bool = false)
     y = iterate(key)
     while y !== nothing
         c, i = y
@@ -1560,7 +1560,7 @@ function add_nested_key!(keymap::Dict, key::Union{String, Char}, value; override
         if y === nothing
             keymap[c] = value
             break
-        elseif !(c in keys(keymap) && isa(keymap[c], Dict))
+        elseif !((c in keys(keymap))::Bool && isa(keymap[c], Dict))
             keymap[c] = Dict{Char,Any}()
         end
         keymap = keymap[c]


### PR DESCRIPTION
This is based on the following code:

```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add("Static")

julia> using SnoopCompileCore; invalidations = @snoopr(using Static); using SnoopCompile

julia> trees = invalidation_trees(invalidations)
inserting !(::False) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:427 invalidated:
...
                 75: signature Tuple{typeof(!), Any} triggered MethodInstance for REPL.LineEdit.var"#add_nested_key!#24"(::Any, ::typeof(REPL.LineEdit.add_nested_key!), ::Dict, ::Union{Char, String}, ::Any) (60 children)
...
```

I suggest the labels `latency` and `backport-1.8`.