### PR TITLE
fix more invalidations in REPL LineEdit.jl from Static.jl

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1708,7 +1708,7 @@ end
 function getEntry(keymap::Dict{Char,Any},key::Union{String,Char})
     v = keymap
     for c in key
-        if !haskey(v,c)
+        if !(haskey(v,c)::Bool)
             return nothing
         end
         v = v[c]


### PR DESCRIPTION
This is based on the following code:

```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add("Static")

julia> using SnoopCompileCore; invalidations = @snoopr(using Static); using SnoopCompile

julia> trees = invalidation_trees(invalidations)
inserting !(::False) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:427 invalidated:
...
                 68: signature Tuple{typeof(!), Any} triggered MethodInstance for REPL.LineEdit.getEntry(::Dict{Char, Any}, ::Union{Char, String}) (62 children)
...
```

I suggest the labels `latency` and `backport-1.8`.