### PR TITLE
fix invalidations in `open` from Static.jl

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -430,7 +430,7 @@ function open(f::Function, cmds::AbstractCmd, args...; kwargs...)
         rethrow()
     end
     close(P.in)
-    if !eof(P.out)
+    if !(eof(P.out)::Bool)
         waitkill(P)
         throw(_UVError("open(do)", UV_EPIPE))
     end


### PR DESCRIPTION
This is based on the following code:

```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add("Static")

julia> using SnoopCompileCore; invalidations = @snoopr(using Static); using SnoopCompile

julia> trees = invalidation_trees(invalidations)
inserting !(::False) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:427 invalidated:
...
                 15: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.var"#open#734"(::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(open), ::Pkg.PlatformEngines.var"#26#28"{String}, ::Cmd) (0 children)
...
                 27: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.var"#open#734"(::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(open), ::Tar.var"#83#86"{Base.DevNull, Bool, _A, String} where _A, ::Cmd) (0 children)
                 28: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.var"#open#734"(::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(open), ::Tar.var"#83#86"{Base.DevNull, Bool, Tar.var"#1#2", String}, ::Cmd) (0 children)
...
                 65: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.var"#open#734"(::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(open), ::Function, ::Cmd) (20 children)
...
                 67: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.var"#open#734"(::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(open), ::Pkg.Registry.var"#11#14"{IOBuffer, Vector{UInt8}, Dict{String, String}}, ::Cmd) (28 children)
   15 mt_cache
...
```

I suggest the labels `latency` and `backport-1.8`.