### PR TITLE
fix some invalidations when loading Static.jl

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1492,7 +1492,7 @@ Perform a conservative test to check if arrays `A` and `B` might share the same 
 By default, this simply checks if either of the arrays reference the same memory
 regions, as identified by their [`Base.dataids`](@ref).
 """
-mightalias(A::AbstractArray, B::AbstractArray) = !isbits(A) && !isbits(B) && !_isdisjoint(dataids(A), dataids(B))
+mightalias(A::AbstractArray, B::AbstractArray) = !(isbits(A)::Bool) && !(isbits(B)::Bool) && !_isdisjoint(dataids(A), dataids(B))
 mightalias(x, y) = false
 
 _isdisjoint(as::Tuple{}, bs::Tuple{}) = true

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1492,7 +1492,7 @@ Perform a conservative test to check if arrays `A` and `B` might share the same 
 By default, this simply checks if either of the arrays reference the same memory
 regions, as identified by their [`Base.dataids`](@ref).
 """
-mightalias(A::AbstractArray, B::AbstractArray) = !(isbits(A)::Bool) && !(isbits(B)::Bool) && !_isdisjoint(dataids(A), dataids(B))
+mightalias(A::AbstractArray, B::AbstractArray) = !isbits(A) && !isbits(B) && !_isdisjoint(dataids(A), dataids(B))
 mightalias(x, y) = false
 
 _isdisjoint(as::Tuple{}, bs::Tuple{}) = true

--- a/base/array.jl
+++ b/base/array.jl
@@ -2325,7 +2325,7 @@ findall(testf::Function, A) = collect(first(p) for p in pairs(A) if testf(last(p
 
 # Broadcasting is much faster for small testf, and computing
 # integer indices from logical index using findall has a negligible cost
-findall(testf::Function, A::AbstractArray) = findall(map(testf, A))
+findall(testf::F, A::AbstractArray) where {F<:Function} = findall(testf.(A))
 
 """
     findall(A)

--- a/base/array.jl
+++ b/base/array.jl
@@ -2325,7 +2325,7 @@ findall(testf::Function, A) = collect(first(p) for p in pairs(A) if testf(last(p
 
 # Broadcasting is much faster for small testf, and computing
 # integer indices from logical index using findall has a negligible cost
-findall(testf::Function, A::AbstractArray) = findall(testf.(A))
+findall(testf::Function, A::AbstractArray) = findall(map(testf, A))
 
 """
     findall(A)


### PR DESCRIPTION
This improvement prevents some invalidations in abstractarray.jl when loading Static.jl.

This is based on the following code:

```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add("Static")

julia> using SnoopCompileCore; invalidations = @snoopr(using Static); using SnoopCompile

julia> trees = invalidation_trees(invalidations)
inserting !(::False) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:427 invalidated:
...
                 51: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.mightalias(::Vector, ::Vector{Any}) (10 children)
                 52: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.mightalias(::Vector, ::Vector{String}) (11 children)
                 57: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.mightalias(::Vector, ::Vector{Pkg.Types.PackageSpec}) (16 children)
...
```

I suggest the labels `latency` and `backport-1.8`.