### PR TITLE
compiler: Get rid of has_struct_const_info

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1583,12 +1583,6 @@ function apply_type_tfunc(@nospecialize(headtypetype), @nospecialize args...)
 end
 add_tfunc(apply_type, 1, INT_INF, apply_type_tfunc, 10)
 
-function has_struct_const_info(x)
-    isa(x, PartialTypeVar) && return true
-    isa(x, Conditional) && return true
-    return has_nontrivial_const_info(x)
-end
-
 # convert the dispatch tuple type argtype to the real (concrete) type of
 # the tuple of those values
 function tuple_tfunc(argtypes::Vector{Any})
@@ -1607,7 +1601,7 @@ function tuple_tfunc(argtypes::Vector{Any})
     anyinfo = false
     for i in 1:length(argtypes)
         x = argtypes[i]
-        if has_struct_const_info(x)
+        if has_nontrivial_const_info(x)
             anyinfo = true
         else
             if !isvarargtype(x)

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -26,6 +26,7 @@ end
 function has_nontrivial_const_info(@nospecialize t)
     isa(t, PartialStruct) && return true
     isa(t, PartialOpaque) && return true
+    isa(t, PartialTypeVar) && return true
     isa(t, Const) || return false
     val = t.val
     return !isdefined(typeof(val), :instance) && !(isa(val, Type) && hasuniquerep(val))


### PR DESCRIPTION
This was introduced by me in #39684, but the commit message has
no discussion as to why `has_struct_const_info` and
`has_nontrivial_const_info` are not the same function.

Moreover, I don't think the `isa(x, Conditional)` branch ever
did anything because even at the time of the commit, `tuple_tfunc`
applied `widenconditional` to all incoming argtypes. That leaves
`PartialTypeVar`, which seems reasonable to just include in the
definition of `has_nontrivial_const_info`, so that we may be
consistent between `tuple_tfunc` and `Expr(:new)`.