### PR TITLE
Disambiguate invalidation types in jl_insert_method_instance

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -2368,7 +2368,7 @@ static void jl_insert_method_instances(jl_array_t *list) JL_GC_DISABLED
                                     }
                                 }
                             }
-                            invalidate_backedges(&remove_code_instance_from_validation, caller, world, "jl_insert_method_instance");
+                            invalidate_backedges(&remove_code_instance_from_validation, caller, world, "jl_insert_method_instance caller");
                             // The codeinst of this mi haven't yet been removed
                             jl_code_instance_t *codeinst = caller->cache;
                             while (codeinst) {


### PR DESCRIPTION
SnoopCompile parses the invalidation log to construct a causal chain
for each invalidation. It turns out to be necessary to disambiguate
invalidation of callers from invalidation of the primary trigger
in `jl_insert_method_instance`.

This is a follow-on to #46010