### PR TITLE
Make the "system image too large" error message more descriptive

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -59,6 +59,7 @@ done by `get_item_for_reloc`.
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h> // printf
+#include <inttypes.h> // PRIxPTR
 
 #include "julia.h"
 #include "julia_internal.h"
@@ -1947,9 +1948,22 @@ static void jl_save_system_image_to_stream(ios_t *f) JL_GC_DISABLED
         jl_write_gv_tagrefs(&s);
     }
 
-    if (sysimg.size > ((uintptr_t)1 << RELOC_TAG_OFFSET) ||
-        const_data.size > ((uintptr_t)1 << RELOC_TAG_OFFSET)*sizeof(void*)) {
-        jl_printf(JL_STDERR, "ERROR: system image too large\n");
+    if (sysimg.size > ((uintptr_t)1 << RELOC_TAG_OFFSET)) {
+        jl_printf(
+            JL_STDERR,
+            "ERROR: system image too large: sysimg.size is %jd but the limit is %" PRIxPTR "\n",
+            (intmax_t)sysimg.size,
+            ((uintptr_t)1 << RELOC_TAG_OFFSET)
+        );
+        jl_exit(1);
+    }
+    if (const_data.size > ((uintptr_t)1 << RELOC_TAG_OFFSET)*sizeof(void*)) {
+        jl_printf(
+            JL_STDERR,
+            "ERROR: system image too large: sysimg.size is %jd but the limit is %" PRIxPTR "\n",
+            (intmax_t)const_data.size,
+            ((uintptr_t)1 << RELOC_TAG_OFFSET)*sizeof(void*)
+        );
         jl_exit(1);
     }
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1960,7 +1960,7 @@ static void jl_save_system_image_to_stream(ios_t *f) JL_GC_DISABLED
     if (const_data.size > ((uintptr_t)1 << RELOC_TAG_OFFSET)*sizeof(void*)) {
         jl_printf(
             JL_STDERR,
-            "ERROR: system image too large: sysimg.size is %jd but the limit is %" PRIxPTR "\n",
+            "ERROR: system image too large: const_data.size is %jd but the limit is %" PRIxPTR "\n",
             (intmax_t)const_data.size,
             ((uintptr_t)1 << RELOC_TAG_OFFSET)*sizeof(void*)
         );


### PR DESCRIPTION
1. Specify which of the two conditions was met.
2. Print the actual numerical values.

Follow-up to #37613