### PR TITLE
Provide unknown-object codegen fast paths for getfield/isdefined

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -1790,6 +1790,17 @@ JL_DLLEXPORT int jl_field_isdefined(jl_value_t *v, size_t i) JL_NOTSAFEPOINT
     return fval != NULL ? 1 : 0;
 }
 
+JL_DLLEXPORT int jl_field_isdefined_checked(jl_value_t *v, size_t i)
+{
+    if (jl_is_module(v)) {
+        jl_type_error("isdefined", (jl_value_t*)jl_symbol_type, jl_box_long(i + 1));
+    }
+    if (i >= jl_nfields(v))
+        return 0;
+    return !!jl_field_isdefined(v, i);
+}
+
+
 JL_DLLEXPORT size_t jl_get_field_offset(jl_datatype_t *ty, int field)
 {
     if (!jl_struct_try_layout(ty) || field > jl_datatype_nfields(ty) || field < 1)

--- a/src/julia.h
+++ b/src/julia.h
@@ -1549,6 +1549,7 @@ JL_DLLEXPORT jl_value_t *jl_get_nth_field_noalloc(jl_value_t *v JL_PROPAGATES_RO
 JL_DLLEXPORT jl_value_t *jl_get_nth_field_checked(jl_value_t *v, size_t i);
 JL_DLLEXPORT void        jl_set_nth_field(jl_value_t *v, size_t i, jl_value_t *rhs) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int         jl_field_isdefined(jl_value_t *v, size_t i) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int         jl_field_isdefined_checked(jl_value_t *v, size_t i);
 JL_DLLEXPORT jl_value_t *jl_get_field(jl_value_t *o, const char *fld);
 JL_DLLEXPORT jl_value_t *jl_value_ptr(jl_value_t *a);
 int jl_uniontype_size(jl_value_t *ty, size_t *sz);

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -754,3 +754,10 @@ struct MaybeTuple45476
 end
 
 @test MaybeTuple45476((0,)).val[1] == 0f0
+
+# Test int paths for getfield/isdefined
+f_getfield_nospecialize(@nospecialize(x)) = getfield(x, 1)
+f_isdefined_nospecialize(@nospecialize(x)) = isdefined(x, 1)
+
+@test !occursin("jl_box_int", get_llvm(f_getfield_nospecialize, Tuple{Any}, true, false, false))
+@test !occursin("jl_box_int", get_llvm(f_isdefined_nospecialize, Tuple{Any}, true, false, false))

--- a/test/core.jl
+++ b/test/core.jl
@@ -7826,3 +7826,7 @@ end
 @testset "error message for getfield with bad integer type" begin
     @test_throws "expected Union{$Int, Symbol}" getfield((1,2), Int8(1))
 end
+
+# Correct isdefined error for isdefined of Module of Int fld
+f_isdefined_one(@nospecialize(x)) = isdefined(x, 1)
+@test (try; f_isdefined_one(@__MODULE__); catch err; err; end).got === 1


### PR DESCRIPTION
I thought this might make inference a bit faster, but benchmark
results seem to be in the noise locally, probably because the
int being boxed is part of the box cache, so no allocation
actually happens. Nevertheless, it's a nice, simple, optimization.