### PR TITLE
IRShow: call `line_info_postprinter` for all statements

### DIFF
--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -158,8 +158,9 @@ function should_print_ssa_type(@nospecialize node)
 end
 
 function default_expr_type_printer(io::IO, @nospecialize(typ), used::Bool)
+    get(io, :show_type, true) || return nothing
     printstyled(io, "::", typ, color=(used ? :cyan : :light_black))
-    nothing
+    return nothing
 end
 
 normalize_method_name(m::Method) = m.name
@@ -647,8 +648,11 @@ function show_ir_stmt(io::IO, code::Union{IRCode, CodeInfo, IncrementalCompact},
 
         if new_node_type === UNDEF # try to be robust against errors
             printstyled(io, "::#UNDEF", color=:red)
-        elseif show_type
-            line_info_postprinter(IOContext(io, :idx => node_idx), new_node_type, node_idx in used)
+        else
+            ioctx = IOContext(io,
+                :show_type => show_type,
+                :idx => node_idx)
+            line_info_postprinter(ioctx, new_node_type, node_idx in used)
         end
         println(io)
         i += 1
@@ -662,8 +666,11 @@ function show_ir_stmt(io::IO, code::Union{IRCode, CodeInfo, IncrementalCompact},
         if type === UNDEF
             # This is an error, but can happen if passes don't update their type information
             printstyled(io, "::#UNDEF", color=:red)
-        elseif show_type
-            line_info_postprinter(IOContext(io, :idx => idx), type, idx in used)
+        else
+            ioctx = IOContext(io,
+                :show_type => show_type,
+                :idx => idx)
+            line_info_postprinter(ioctx, type, idx in used)
         end
     end
     println(io)

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -28,7 +28,8 @@ end
 # displaying type warnings
 
 function warntype_type_printer(io::IO, @nospecialize(ty), used::Bool)
-    used || return
+    used || return nothing
+    get(io, :show_type, true) || return nothing
     str = "::$ty"
     if !highlighting[:warntype]
         print(io, str)
@@ -39,7 +40,7 @@ function warntype_type_printer(io::IO, @nospecialize(ty), used::Bool)
     else
         Base.printstyled(io, str, color=:cyan) # show the "good" type
     end
-    nothing
+    return nothing
 end
 
 # True if one can be pretty certain that the compiler handles this union well,

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -27,15 +27,14 @@ end
 
 # displaying type warnings
 
-function warntype_type_printer(io::IO, @nospecialize(ty), used::Bool)
-    used || return nothing
-    get(io, :show_type, true) || return nothing
-    str = "::$ty"
+function warntype_type_printer(io::IO; @nospecialize(type), used::Bool, show_type::Bool=true, _...)
+    (show_type && used) || return nothing
+    str = "::$type"
     if !highlighting[:warntype]
         print(io, str)
-    elseif ty isa Union && is_expected_union(ty)
+    elseif type isa Union && is_expected_union(type)
         Base.emphasize(io, str, Base.warn_color()) # more mild user notification
-    elseif ty isa Type && (!Base.isdispatchelem(ty) || ty == Core.Box)
+    elseif type isa Type && (!Base.isdispatchelem(type) || type == Core.Box)
         Base.emphasize(io, str)
     else
         Base.printstyled(io, str, color=:cyan) # show the "good" type
@@ -141,13 +140,13 @@ function code_warntype(io::IO, @nospecialize(f), @nospecialize(t=Base.default_tt
                 end
                 print(io, "  ", slotnames[i])
                 if isa(slottypes, Vector{Any})
-                    warntype_type_printer(io, slottypes[i], true)
+                    warntype_type_printer(io; type=slottypes[i], used=true)
                 end
                 println(io)
             end
         end
         print(io, "Body")
-        warntype_type_printer(io, rettype, true)
+        warntype_type_printer(io; type=rettype, used=true)
         println(io)
         irshow_config = Base.IRShow.IRShowConfig(lineprinter(src), warntype_type_printer)
         Base.IRShow.show_ir(lambda_io, src, irshow_config)


### PR DESCRIPTION
Previously we only call `line_info_postprinter` for call expressions,
because `line_info_postprinter` is supposed to print their return type
information.
But sometimes, external consumers like Cthulhu want to show additional
information like per-statement effects and remarks, and in such cases,
we want `line_info_postprinter` to be called on all statements other
than call expressions.

This commit refactors the `IRShow` code a bit so that we call
`line_info_postprinter` on all statements, while packing
`show_type::Bool` information into the `IOContext` object.
This is a slightly breaking change, but hopefully won't be
too much destructive. I'm happy to make corresponding changes
(like what is done for `InteractiveUtils.warntype_type_printer` by
this commit) to the ecosystem after merge.