### PR TITLE
Help inference of uninferred callers of `read(::IO, ::Type{String})`

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -1001,7 +1001,7 @@ function read(s::IO, nb::Integer = typemax(Int))
     return resize!(b, nr)
 end
 
-read(s::IO, ::Type{String}) = String(read(s))
+read(s::IO, ::Type{String}) = String(read(s)) :: String
 read(s::IO, T::Type) = error("The IO stream does not support reading objects of type $T.")
 
 ## high-level iterator interfaces ##

--- a/base/io.jl
+++ b/base/io.jl
@@ -1001,7 +1001,7 @@ function read(s::IO, nb::Integer = typemax(Int))
     return resize!(b, nr)
 end
 
-read(s::IO, ::Type{String}) = String(read(s)) :: String
+read(s::IO, ::Type{String}) = String(read(s)::Vector{UInt8})
 read(s::IO, T::Type) = error("The IO stream does not support reading objects of type $T.")
 
 ## high-level iterator interfaces ##


### PR DESCRIPTION
There exist several callers of `displaysize(tty::TTY)` with abstractly inferred `tty`. On Windows, this apparently gives to some poorly inferred calls to `materialize` and `similar` which then become an invalidation source.
The issue arises due to an uninferred `String` result of `read` [here](https://github.com/JuliaLang/julia/blob/cb5f401aaadcd17fbe366a64afdbf7e6fc71ac69/base/stream.jl#L578).

We can fix this by helping inference see that `read(::IO, ::Type{String})` returns a `String` rather than `Any`:

```jl
# Master
julia> Base.return_types(read, (IO, Type{String}))
1-element Vector{Any}:
 Any

# PR
julia> Base.return_types(read, (IO, Type{String}))
1-element Vector{Any}:
 String
```