### PR TITLE
Make inference slightly faster

### DIFF
--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -482,16 +482,19 @@ end
 
 Widens extended lattice element `x` to native `Type` representation.
 """
-widenconst(::AnyConditional) = Bool
-widenconst(c::Const) = (v = c.val; isa(v, Type) ? Type{v} : typeof(v))
-widenconst(m::MaybeUndef) = widenconst(m.typ)
-widenconst(::PartialTypeVar) = TypeVar
-widenconst(t::PartialStruct) = t.typ
-widenconst(t::PartialOpaque) = t.typ
-widenconst(t::Type) = t
-widenconst(::TypeVar) = error("unhandled TypeVar")
-widenconst(::TypeofVararg) = error("unhandled Vararg")
-widenconst(::LimitedAccuracy) = error("unhandled LimitedAccuracy")
+_widenconst(::AnyConditional) = Bool
+_widenconst(c::Const) = (v = c.val; isa(v, Type) ? Type{v} : typeof(v))
+_widenconst(m::MaybeUndef) = widenconst(m.typ)
+_widenconst(::PartialTypeVar) = TypeVar
+_widenconst(t::PartialStruct) = t.typ
+_widenconst(t::PartialOpaque) = t.typ
+_widenconst(t::Type) = t
+_widenconst(::TypeVar) = error("unhandled TypeVar")
+_widenconst(::TypeofVararg) = error("unhandled Vararg")
+_widenconst(::LimitedAccuracy) = error("unhandled LimitedAccuracy")
+typeof(_widenconst).name.max_methods = UInt8(length(methods(_widenconst)))
+
+widenconst(@nospecialize(t)) = _widenconst(t)
 
 ####################
 # state management #

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -335,10 +335,16 @@ function _is_immutable_type(@nospecialize ty)
     return !isabstracttype(ty) && !ismutabletype(ty)
 end
 
-is_mutation_free_argtype(@nospecialize argtype) =
-    is_mutation_free_type(widenconst(ignorelimited(argtype)))
-is_mutation_free_type(@nospecialize ty) =
-    _is_mutation_free_type(unwrap_unionall(ty))
+function is_mutation_free_argtype(@nospecialize argtype)
+    argtype = ignorelimited(argtype)
+    if isa(argtype, Const)
+        if isa(argtype.val, Type)
+            return true
+        end
+        return _is_mutation_free_type(typeof(argtype.val))
+    end
+    return _is_mutation_free_type(widenconst(argtype))
+end
 function _is_mutation_free_type(@nospecialize ty)
     if isa(ty, Union)
         return _is_mutation_free_type(ty.a) && _is_mutation_free_type(ty.b)


### PR DESCRIPTION
1. Force inference to union-split the `widenconst` dispatch rather than
   joing through dynamic dispatch.

2. Avoid widenconst(::Const) in a hot path when not necessary. This got
   faster (#44402), but is not quite fast yet.

Makes inference a few % faster.