### PR TITLE
Faster codegen for isa(::Any, Type)

### DIFF
--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -761,3 +761,7 @@ f_isdefined_nospecialize(@nospecialize(x)) = isdefined(x, 1)
 
 @test !occursin("jl_box_int", get_llvm(f_getfield_nospecialize, Tuple{Any}, true, false, false))
 @test !occursin("jl_box_int", get_llvm(f_isdefined_nospecialize, Tuple{Any}, true, false, false))
+
+# Test codegen for isa(::Any, Type)
+f_isa_type(@nospecialize(x)) = isa(x, Type)
+@test !occursin("jl_isa", get_llvm(f_isa_type, Tuple{Any}, true, false, false))


### PR DESCRIPTION
WIP because LLVM inserts an illegal ptrtoint for this in simplifycfg:

```
f (generic function with 1 method)

julia> code_llvm(f, Tuple{Any}; optimize=false)
Illegal inttoptr
	  %magicptr = ptrtoint {} addrspace(10)* %91 to i64, !dbg !85
Illegal inttoptr
	  %magicptr59 = ptrtoint {} addrspace(10)* %196 to i64, !dbg !85

[4162603] signal (6): Aborted
in expression starting at REPL[2]:1
gsignal at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
abort at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
runOnFunction at /home/keno/julia/src/llvm-gc-invariant-verifier.cpp:212
_ZN4llvm13FPPassManager13runOnFunctionERNS_8FunctionE at /home/keno/julia/usr/bin/../lib/libLLVM-14jl.so (unknown line)
_ZN4llvm13FPPassManager11runOnModuleERNS_6ModuleE at /home/keno/julia/usr/bin/../lib/libLLVM-14jl.so (unknown line)
_ZN4llvm6legacy15PassManagerImpl3runERNS_6ModuleE at /home/keno/julia/usr/bin/../lib/libLLVM-14jl.so (unknown line)
operator() at /home/keno/julia/src/jitlayers.cpp:1031 [inlined]
withModuleDo<(anonymous namespace)::OptimizerT::operator()(llvm::orc::ThreadSafeModule, llvm::orc::MaterializationResponsibility&)::<lambda(llvm::Module&)> > at /home/keno/julia/usr/include/llvm/ExecutionEngine/Orc/ThreadSafeModule.h:136 [inlined]
operator() at /home/keno/julia/src/jitlayers.cpp:1003 [inlined]
```

The issue is this unconditional ptrtoint here, which should make sure the ptrtoint is not non-integral: https://github.com/llvm/llvm-project/blob/main/llvm/lib/Transforms/Utils/SimplifyCFG.cpp#L1314-L1318.

The easy fix is to bail out, but ideally, we'd preserve the optimization and do it correctly for non-integral pointer types: 