### PR TITLE
note that base/compiler/ssair/show.jl is not part of Core.Compiler

### DIFF
--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+# This file is not loaded into Core.Compiler and does not participate in bootstrapping.
+
 @nospecialize
 
 if Pair != Base.Pair

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-# This file is not loaded into Core.Compiler and does not participate in bootstrapping.
+# This file is not loaded into `Core.Compiler` but rather loaded into the context of 
+# `Base.IRShow` and thus does not participate in bootstrapping.
 
 @nospecialize
 


### PR DESCRIPTION
This is true, right?

Looking at https://github.com/JuliaLang/julia/blob/master/base/compiler/ssair/driver.jl, https://github.com/JuliaLang/julia/blob/852e3130b34408193e81c111ddfd9733b39fca9f/base/show.jl#L2593
and `grep -r "show.jl" base`.

I think it's worth noting because I think all the other files in this directory are included in Core.Compiler.