### PR TITLE
LibGit2: correct regex for credential helpers

### DIFF
--- a/stdlib/LibGit2/src/gitcredential.jl
+++ b/stdlib/LibGit2/src/gitcredential.jl
@@ -219,7 +219,7 @@ function credential_helpers(cfg::GitConfig, cred::GitCredential)
     helpers = GitCredentialHelper[]
 
     # https://git-scm.com/docs/gitcredentials#gitcredentials-helper
-    for entry in GitConfigIter(cfg, r"credential.*\.helper")
+    for entry in GitConfigIter(cfg, r"credential.*\.helper$")
         section, url, name, value = split_cfg_entry(entry)
         @assert name == "helper"
 

--- a/stdlib/LibGit2/test/libgit2-tests.jl
+++ b/stdlib/LibGit2/test/libgit2-tests.jl
@@ -1994,7 +1994,7 @@ mktempdir() do dir
             @test parse(GitCredentialHelper, "store") == GitCredentialHelper(`git credential-store`)
         end
 
-        @testset "empty helper" begin
+        @testset "credential_helpers" begin
             config_path = joinpath(dir, config_file)
 
             # Note: LibGit2.set! doesn't allow us to set duplicates or ordering
@@ -2007,16 +2007,14 @@ mktempdir() do dir
                     [credential]
                         helper = !echo second
                     """)
+                # Git for Windows uses this config (see issue #45693)
+                write(fp,"""
+                    [credential "helperselector"]
+                        selected = manager-core
+                    """)
             end
 
             LibGit2.with(LibGit2.GitConfig(config_path, LibGit2.Consts.CONFIG_LEVEL_APP)) do cfg
-                iter = LibGit2.GitConfigIter(cfg, r"credential.*\.helper")
-                @test LibGit2.split_cfg_entry.(iter) == [
-                    ("credential", "", "helper", "!echo first"),
-                    ("credential", "https://mygithost", "helper", ""),
-                    ("credential", "", "helper", "!echo second"),
-                ]
-
                 expected = [
                     GitCredentialHelper(`echo first`),
                     GitCredentialHelper(`echo second`),


### PR DESCRIPTION
The previous regex for credential helpers included even the following
credential:

```
[credential "helperselector"]
    selected = manager-core
```

which gets introduced by Git for Windows and fails our assumption about
what a credential helper is.

The commit also removes a test that mirrors what `credential_helpers`
does (otherwise, we would have to maintain the same regex at two places,
the definition of `credential_helpers` and the test case).

Fixes #45693