### PR TITLE
effects: fix #46591, make `Base.infer_effects` accounts for all possible `MethodError`

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -247,9 +247,9 @@ function bail_out_apply(::AbstractInterpreter, @nospecialize(rt), sv::Union{Infe
 end
 
 function any_inbounds(code::Vector{Any})
-    for i=1:length(code)
+    for i = 1:length(code)
         stmt = code[i]
-        if isa(stmt, Expr) && stmt.head === :inbounds
+        if isexpr(stmt, :inbounds)
             return true
         end
     end

--- a/base/compiler/methodtable.jl
+++ b/base/compiler/methodtable.jl
@@ -104,7 +104,7 @@ function _findall(@nospecialize(sig::Type), mt::Union{Nothing,Core.MethodTable},
     return MethodLookupResult(ms::Vector{Any}, WorldRange(_min_val[], _max_val[]), _ambig[] != 0)
 end
 
-function findall(@nospecialize(sig::Type), table::CachedMethodTable; limit::Int=typemax(Int))
+function findall(@nospecialize(sig::Type), table::CachedMethodTable; limit::Int=Int(typemax(Int32)))
     if isconcretetype(sig)
         # as for concrete types, we cache result at on the next level
         return findall(sig, table.table; limit)

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -32,7 +32,7 @@ end
 ambig_effects_test(a::Int, b) = 1
 ambig_effects_test(a, b::Int) = 1
 ambig_effects_test(a, b) = 1
-@test_broken !Core.Compiler.is_nothrow(Base.infer_effects(ambig_effects_test, (Int, Any)))
+@test !Core.Compiler.is_nothrow(Base.infer_effects(ambig_effects_test, (Int, Any)))
 global ambig_unknown_type_global::Any = 1
 @noinline function conditionally_call_ambig(b::Bool, a)
     if b

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -980,8 +980,12 @@ end
 maybe_effectful(x::Int) = 42
 maybe_effectful(x::Any) = unknown_operation()
 function f_no_methods end
+ambig_effects_test(a::Int, b) = 1
+ambig_effects_test(a, b::Int) = 1
+ambig_effects_test(a, b) = 1
 
 @testset "infer_effects" begin
+    # generic functions
     @test Base.infer_effects(issue41694, (Int,)) |> Core.Compiler.is_terminates
     @test Base.infer_effects((Int,)) do x
         issue41694(x)
@@ -994,7 +998,12 @@ function f_no_methods end
         @test !Core.Compiler.is_terminates(effects)
         @test !Core.Compiler.is_nonoverlayed(effects)
     end
-    @test Base.infer_effects(f_no_methods) |> !Core.Compiler.is_nothrow
+    # should account for MethodError
+    @test Base.infer_effects(issue41694, (Float64,)) |> !Core.Compiler.is_nothrow # definitive dispatch error
+    @test Base.infer_effects(issue41694, (Integer,)) |> !Core.Compiler.is_nothrow # possible dispatch error
+    @test Base.infer_effects(f_no_methods) |> !Core.Compiler.is_nothrow # no possible matching methods
+    @test Base.infer_effects(ambig_effects_test, (Int,Int)) |> !Core.Compiler.is_nothrow # ambiguity error
+    @test Base.infer_effects(ambig_effects_test, (Int,Any)) |> !Core.Compiler.is_nothrow # ambiguity error
     # builtins
     @test Base.infer_effects(typeof, (Any,)) |> Core.Compiler.is_total
     @test Base.infer_effects(===, (Any,Any)) |> Core.Compiler.is_total


### PR DESCRIPTION
Added some more test cases as well as some other cleanups.

Somewhat related question: Shouldn't we use `all` instead of `any` here?
https://github.com/JuliaLang/julia/blob/131f7b973d2f4dcf4105e16a942fdf6bc2d990ef/base/compiler/abstractinterpretation.jl#L339
