### PR TITLE
Propagate var's offset to its `ub` to avoid invalid bounds setting.

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -3046,7 +3046,15 @@ static jl_value_t *intersect(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int pa
                         record_var_occurrence(yy, e, param);
                         return y;
                     }
-                    return intersect(y, xub, e, param);
+                    if (!xx || xx->offset == 0)
+                        return intersect(y, xub, e, param);
+                    // try to propagate the x's offset to xub.
+                    jl_varbinding_t *tvb = lookup(e, (jl_tvar_t*)xub);
+                    assert(tvb && tvb->offset == 0);
+                    tvb->offset = xx->offset;
+                    jl_value_t *res = intersect(y, xub, e, param);
+                    tvb->offset = 0;
+                    return res;
                 }
                 record_var_occurrence(yy, e, param);
                 if (!jl_is_type(ylb) && !jl_is_typevar(ylb)) {

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2134,3 +2134,13 @@ end
 
 # Example from pr#39098
 @testintersect(NTuple, Tuple{Any,Vararg}, Tuple{T, Vararg{T}} where {T})
+
+let A = Pair{NTuple{N, Int}, Val{N}} where N,
+    Bs = (Pair{<:Tuple{Int, Vararg{Int}}, <:Val},
+          Pair{Tuple{Int, Vararg{Int,N1}}, Val{N2}} where {N1,N2})
+    Cerr = Pair{Tuple{Int, Vararg{Int,N}}, Val{N}} where N
+    for B in Bs
+        @testintersect(A, B, !Cerr)
+        @testintersect(A, B, !Union{})
+    end
+end


### PR DESCRIPTION
Follow up b7f47d5394ba7593b90be68d7203f1f055f6c4f9, make sure `xub`'s lb/ub is not set if `x` has non-zero offset.
MWE
```julia
julia> A = Tuple{NTuple{N, Int}, Val{N}} where N
Tuple{Tuple{Vararg{Int64, N}}, Val{N}} where N

julia> T = Tuple{Tuple{Int, Vararg{Int, N1}}, Val{N2}} where {N1,N2}
Tuple{Tuple{Int64, Vararg{Int64, N1}}, Val{N2}} where {N1, N2}

julia> typeintersect(T, A)
Tuple{Tuple{Int64, Vararg{Int64, N1}}, Val{N1}} where N1  # this PR: Tuple{Tuple{Int64, Vararg{Int64, N1}}, Val{N2}} where {N1, N2}

julia> typeintersect(A, T)
Tuple{Tuple{Int64, Vararg{Int64, N1}}, Val{N}} where {N, N1}
```