### PR TITLE
add warning for function declaration with undefined static parameter

### DIFF
--- a/src/method.c
+++ b/src/method.c
@@ -957,12 +957,6 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
     size_t i, na = jl_svec_len(atypes);
 
     argtype = (jl_value_t*)jl_apply_tuple_type(atypes);
-    for (i = jl_svec_len(tvars); i > 0; i--) {
-        jl_value_t *tv = jl_svecref(tvars, i - 1);
-        if (!jl_is_typevar(tv))
-            jl_type_error("method signature", (jl_value_t*)jl_tvar_type, tv);
-        argtype = jl_new_struct(jl_unionall_type, tv, argtype);
-    }
 
     jl_methtable_t *external_mt = mt;
     if (!mt)
@@ -971,6 +965,12 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
         jl_error("Method dispatch is unimplemented currently for this method signature");
     if (mt->frozen)
         jl_error("cannot add methods to a builtin function");
+
+    assert(jl_is_linenode(functionloc));
+    jl_sym_t *file = (jl_sym_t*)jl_linenode_file(functionloc);
+    if (!jl_is_symbol(file))
+        file = jl_empty_sym;
+    int32_t line = jl_linenode_line(functionloc);
 
     // TODO: derive our debug name from the syntax instead of the type
     name = mt->name;
@@ -988,6 +988,29 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
             }
         }
     }
+
+    for (i = jl_svec_len(tvars); i > 0; i--) {
+        jl_value_t *tv = jl_svecref(tvars, i - 1);
+        if (!jl_is_typevar(tv))
+            jl_type_error("method signature", (jl_value_t*)jl_tvar_type, tv);
+        if (!jl_has_typevar(argtype, (jl_tvar_t*)tv)) // deprecate this to an error in v2
+            jl_printf(JL_STDERR,
+                      "WARNING: method definition for %s at %s:%d declares type variable %s but does not use it.\n",
+                      jl_symbol_name(name),
+                      jl_symbol_name(file),
+                      line,
+                      jl_symbol_name(((jl_tvar_t*)tv)->name));
+        argtype = jl_new_struct(jl_unionall_type, tv, argtype);
+    }
+    if (jl_has_free_typevars(argtype)) {
+        jl_exceptionf(jl_argumenterror_type,
+                      "method definition for %s at %s:%d has free type variables",
+                      jl_symbol_name(name),
+                      jl_symbol_name(file),
+                      line);
+    }
+
+
     if (!jl_is_code_info(f)) {
         // this occurs when there is a closure being added to an out-of-scope function
         // the user should only do this at the toplevel
@@ -1002,19 +1025,9 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
     m->name = name;
     m->isva = isva;
     m->nargs = nargs;
-    assert(jl_is_linenode(functionloc));
-    jl_value_t *file = jl_linenode_file(functionloc);
-    m->file = jl_is_symbol(file) ? (jl_sym_t*)file : jl_empty_sym;
-    m->line = jl_linenode_line(functionloc);
+    m->file = file;
+    m->line = line;
     jl_method_set_source(m, f);
-
-    if (jl_has_free_typevars(argtype)) {
-        jl_exceptionf(jl_argumenterror_type,
-                      "method definition for %s at %s:%d has free type variables",
-                      jl_symbol_name(name),
-                      jl_symbol_name(m->file),
-                      m->line);
-    }
 
     for (i = 0; i < na; i++) {
         jl_value_t *elt = jl_svecref(atypes, i);
@@ -1025,22 +1038,22 @@ JL_DLLEXPORT jl_method_t* jl_method_def(jl_svec_t *argdata,
                               "invalid type for argument number %d in method definition for %s at %s:%d",
                               i,
                               jl_symbol_name(name),
-                              jl_symbol_name(m->file),
-                              m->line);
+                              jl_symbol_name(file),
+                              line);
             else
                 jl_exceptionf(jl_argumenterror_type,
                               "invalid type for argument %s in method definition for %s at %s:%d",
                               jl_symbol_name(argname),
                               jl_symbol_name(name),
-                              jl_symbol_name(m->file),
-                              m->line);
+                              jl_symbol_name(file),
+                              line);
         }
         if (jl_is_vararg(elt) && i < na-1)
             jl_exceptionf(jl_argumenterror_type,
                           "Vararg on non-final argument in method definition for %s at %s:%d",
                           jl_symbol_name(name),
-                          jl_symbol_name(m->file),
-                          m->line);
+                          jl_symbol_name(file),
+                          line);
     }
 
 #ifdef RECORD_METHOD_ORDER

--- a/stdlib/LinearAlgebra/src/bunchkaufman.jl
+++ b/stdlib/LinearAlgebra/src/bunchkaufman.jl
@@ -80,7 +80,7 @@ BunchKaufman(A::AbstractMatrix{T}, ipiv::AbstractVector{<:Integer}, uplo::Abstra
              symmetric::Bool, rook::Bool, info::BlasInt) where {T} =
         BunchKaufman{T,typeof(A),typeof(ipiv)}(A, ipiv, uplo, symmetric, rook, info)
 # backwards-compatible constructors (remove with Julia 2.0)
-@deprecate(BunchKaufman(LD, ipiv, uplo, symmetric, rook, info) where {T,S},
+@deprecate(BunchKaufman{T,S}(LD, ipiv, uplo, symmetric, rook, info) where {T,S},
            BunchKaufman{T,S,typeof(ipiv)}(LD, ipiv, uplo, symmetric, rook, info), false)
 
 # iteration for destructuring into components


### PR DESCRIPTION
Refs #27813 (does not fix it)

n.b. The change is very simple (just adding the `jl_has_typevar` call), but I had to shift around a lot of other code to make it so I had access to the file/line/name variables here for the warning message, so the diff is a big mess.

Includes a fix for #42594 detected by this change during the sysimg build.

n.b. this emits a few warnings in the tests, since we have a couple existing tests that explicitly try this
```
WARNING: method definition for f33135 at /Users/jameson/julia1/test/syntax.jl:1997 declares type variable C1 but does not use it.
WARNING: method definition for bad_tvars at /Users/jameson/julia1/test/core.jl:5211 declares type variable T but does not use it.
WARNING: method definition for bad_tvars2 at /Users/jameson/julia1/test/core.jl:5214 declares type variable T but does not use it.
```