### PR TITLE
Fix infinite recursion bug with type mismatch in `unsafe_wrap()`

### DIFF
--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -92,7 +92,8 @@ function unsafe_wrap(::Union{Type{Array},Type{Array{T}},Type{Array{T,1}}},
     ccall(:jl_ptr_to_array_1d, Array{T,1},
           (Any, Ptr{Cvoid}, Csize_t, Cint), Array{T,1}, p, d, own)
 end
-unsafe_wrap(Atype::Type, p::Ptr, dims::NTuple{N,<:Integer}; own::Bool = false) where {N} =
+unsafe_wrap(Atype::Union{Type{Array},Type{Array{T}},Type{Array{T,N}}},
+            p::Ptr{T}, dims::NTuple{N,<:Integer}; own::Bool = false) where {T,N} =
     unsafe_wrap(Atype, p, convert(Tuple{Vararg{Int}}, dims), own = own)
 
 """

--- a/test/core.jl
+++ b/test/core.jl
@@ -1407,6 +1407,7 @@ let
     @test occursin("is not properly aligned to $(sizeof(Int)) bytes", res.value.msg)
     res = @test_throws ArgumentError unsafe_wrap(Array, pointer(a) + 1, (1, 1))
     @test occursin("is not properly aligned to $(sizeof(Int)) bytes", res.value.msg)
+    res = @test_throws MethodError unsafe_wrap(Vector{UInt8}, pointer(Int32[1]), (sizeof(Int32),))
 end
 
 struct FooBar2515


### PR DESCRIPTION
If a user provides an incorrect pointer type in `unsafe_wrap()`, this
can cause an infinite recursion due to lax type constraints in the last
method of `unsafe_wrap()`.  Example:

```
julia> x = zeros(10)
       unsafe_wrap(Vector{UInt8}, pointer(x), (10*sizeof(eltype(x)),))
ERROR: StackOverflowError:
Stacktrace:
 [1] unsafe_wrap(Atype::Type, p::Ptr{Float64}, dims::Tuple{Int64};
own::Bool) (repeats 19993 times)
   @ Base ./pointer.jl:92
```