### PR TITLE
irinterp: Remove InferenceState argument

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -105,7 +105,7 @@ function getindex(tpdum::TwoPhaseDefUseMap, idx::Int)
 end
 
 function concrete_eval_invoke(interp::AbstractInterpreter, ir::IRCode, mi_cache,
-    sv::InferenceState, inst::Expr, mi::MethodInstance)
+    inst::Expr, mi::MethodInstance)
     code = get(mi_cache, mi, nothing)
     code === nothing && return nothing
     argtypes = collect_argtypes(interp, inst.args[2:end], nothing, ir)
@@ -118,23 +118,20 @@ function concrete_eval_invoke(interp::AbstractInterpreter, ir::IRCode, mi_cache,
         catch
             return Union{}
         end
-        if is_inlineable_constant(value) || call_result_unused(sv)
-            # If the constant is not inlineable, still do the const-prop, since the
-            # code that led to the creation of the Const may be inlineable in the same
-            # circumstance and may be optimizable.
+        if is_inlineable_constant(value)
             return Const(value)
         end
     else
         ir′ = codeinst_to_ir(interp, code)
         if ir′ !== nothing
-            return ir_abstract_constant_propagation(interp, mi_cache, sv, mi, ir′, argtypes)
+            return _ir_abstract_constant_propagation(interp, mi_cache, mi, ir′, argtypes)
         end
     end
     return nothing
 end
 
 function reprocess_instruction!(interp::AbstractInterpreter, ir::IRCode, mi::MethodInstance,
-                                mi_cache, sv::InferenceState,
+                                mi_cache,
                                 tpdum::TwoPhaseDefUseMap, idx::Int, bb::Union{Int, Nothing},
                                 @nospecialize(inst), @nospecialize(typ),
                                 phi_revisit::BitSet)
@@ -195,7 +192,7 @@ function reprocess_instruction!(interp::AbstractInterpreter, ir::IRCode, mi::Met
             elseif inst.head === :invoke
                 mi′ = inst.args[1]::MethodInstance
                 if mi′ !== mi # prevent infinite loop
-                    rr = concrete_eval_invoke(interp, ir, mi_cache, sv, inst, mi′)
+                    rr = concrete_eval_invoke(interp, ir, mi_cache, inst, mi′)
                     if rr !== nothing
                         if !⊑(typeinf_lattice(interp), typ, rr)
                             ir.stmts[idx][:type] = rr
@@ -225,7 +222,7 @@ function reprocess_instruction!(interp::AbstractInterpreter, ir::IRCode, mi::Met
 end
 
 function _ir_abstract_constant_propagation(interp::AbstractInterpreter, mi_cache,
-    frame::InferenceState, mi::MethodInstance, ir::IRCode, argtypes::Vector{Any})
+        mi::MethodInstance, ir::IRCode, argtypes::Vector{Any})
     argtypes = va_process_argtypes(argtypes, mi)
     argtypes_refined = Bool[!⊑(typeinf_lattice(interp), ir.argtypes[i], argtypes[i]) for i = 1:length(argtypes)]
     empty!(ir.argtypes)
@@ -298,7 +295,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, mi_cache
                 delete!(ssa_refined, idx)
             end
             if any_refined && reprocess_instruction!(interp, ir, mi, mi_cache,
-                    frame, tpdum, idx, bb, inst, typ, ssa_refined)
+                    tpdum, idx, bb, inst, typ, ssa_refined)
                 push!(ssa_refined, idx)
             end
             if idx == lstmt && process_terminator!(ip, bb, idx)
@@ -364,7 +361,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, mi_cache
         idx = popfirst!(stmt_ip)
         inst = ir.stmts[idx][:inst]
         typ = ir.stmts[idx][:type]
-        if reprocess_instruction!(interp, ir, mi, mi_cache, frame,
+        if reprocess_instruction!(interp, ir, mi, mi_cache,
                 tpdum, idx, nothing, inst, typ, ssa_refined)
             append!(stmt_ip, tpdum[idx])
         end
@@ -382,6 +379,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, mi_cache
         rt = argextype(inst.val, ir)
         ultimate_rt = tmerge(ultimate_rt, rt)
     end
+
     return ultimate_rt
 end
 
@@ -390,12 +388,12 @@ function ir_abstract_constant_propagation(interp::AbstractInterpreter, mi_cache,
     if __measure_typeinf__[]
         inf_frame = Timings.InferenceFrameInfo(mi, frame.world, Any[], Any[], length(ir.argtypes))
         Timings.enter_new_timer(inf_frame)
-        v = _ir_abstract_constant_propagation(interp, mi_cache, frame, mi, ir, argtypes)
+        v = _ir_abstract_constant_propagation(interp, mi_cache, mi, ir, argtypes)
         append!(inf_frame.slottypes, ir.argtypes)
         Timings.exit_current_timer(inf_frame)
         return v
     else
-        T = _ir_abstract_constant_propagation(interp, mi_cache, frame, mi, ir, argtypes)
+        T = _ir_abstract_constant_propagation(interp, mi_cache, mi, ir, argtypes)
         return T
     end
 end


### PR DESCRIPTION
The only remaining usage of the `sv` argument here was pretty
nonsensical (it was copied from the other concrete eval path
where it makes more sense). Drop it, so we can stop passing
through the sv parameter entirely.