### PR TITLE
inlining: Add an option to not generate compilesig :invoke statements

### DIFF
--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -60,6 +60,7 @@ struct OptimizationParams
     inline_tupleret_bonus::Int  # extra inlining willingness for non-concrete tuple return types (in hopes of splitting it up)
     inline_error_path_cost::Int # cost of (un-optimized) calls in blocks that throw
 
+    compilesig_invokes::Bool
     trust_inference::Bool
 
     # Duplicating for now because optimizer inlining requires it.
@@ -77,6 +78,7 @@ struct OptimizationParams
             max_methods::Int = 3,
             tuple_splat::Int = 32,
             union_splitting::Int = 4,
+            compilesig_invokes::Bool = true,
             trust_inference::Bool = false
         )
         return new(
@@ -85,6 +87,7 @@ struct OptimizationParams
             inline_nonleaf_penalty,
             inline_tupleret_bonus,
             inline_error_path_cost,
+            compilesig_invokes,
             trust_inference,
             max_methods,
             tuple_splat,


### PR DESCRIPTION
In general, when we inline we may change which MethodInstance to invoke
to avoid over-specializing. This makes sense when generating IR to
be codegen-ed, but makes less sense when we are using inlining as
part of a code analysis pipeline, since the compilesig signature
will often have not been inferred yet. Add an optimizer option to
turn on/off generation of compilesig :invokes.