### PR TITLE
Deploy release-* branch docs too into vX.Y-dev

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -343,6 +343,7 @@ function Documenter.deploy_folder(::BuildBotConfig; devurl, repo, branch, kwargs
         @info "Unable to deploy the documentation: DOCUMENTER_KEY missing"
         return Documenter.DeployDecision(; all_ok=false)
     end
+    release = match(r"release-([0-9]+\.[0-9]+)", Base.GIT_VERSION_INFO.branch)
     if Base.GIT_VERSION_INFO.tagged_commit
         # Strip extra pre-release info (1.5.0-rc2.0 -> 1.5.0-rc2)
         ver = VersionNumber(VERSION.major, VERSION.minor, VERSION.patch,
@@ -351,6 +352,10 @@ function Documenter.deploy_folder(::BuildBotConfig; devurl, repo, branch, kwargs
         return Documenter.DeployDecision(; all_ok=true, repo, branch, subfolder)
     elseif Base.GIT_VERSION_INFO.branch == "master"
         return Documenter.DeployDecision(; all_ok=true, repo, branch, subfolder=devurl)
+    elseif !isnothing(release)
+        # If this is a non-tag build from a release-* branch, we deploy them as dev docs into the
+        # appropriate vX.Y-dev subdirectory.
+        return Documenter.DeployDecision(; all_ok=true, repo, branch, subfolder="v$(release[1])-dev")
     end
     @info """
     Unable to deploy the documentation: invalid GIT_VERSION_INFO


### PR DESCRIPTION
This should make the `release-X.Y` branches deploy their docs into `vX.Y-dev` when backport PRs are merged, making sure we test the docs deployment before tagging. (cc @DilumAluthge, x-ref: https://github.com/JuliaCI/julia-buildkite/issues/197)

I know the backports for 1.8.1 have been merged, but would there be any chance to add this commit to the `release-1.8` branch to make sure it works properly? Also, possibly together with https://github.com/JuliaLang/julia/pull/46030? Both just touch `doc/make.jl`. No worries though if that ship has sailed. (cc @KristofferC)