### PR TITLE
zero(x) instead of 0 in signbit

### DIFF
--- a/base/number.jl
+++ b/base/number.jl
@@ -134,7 +134,7 @@ julia> signbit(-4.1)
 true
 ```
 """
-signbit(x::Real) = x < 0
+signbit(x::Real) = x < zero(x)
 
 """
     sign(x)


### PR DESCRIPTION
Isn't it better to compare `x` with `zero(x)` than `0`, especially for numbers that include units?
Also, it seems slightly faster (or at least not slower) when used in a `map!`:
```julia
julia> x = rand(1000) .- 0.5;
julia> y = zeros(Bool, length(x));
julia> signbit2(x::Real) = x < zero(x);
julia> bench_pr(y, x) = map!(signbit2, y, x);
julia> bench_master(y, x) = map!(signbit, y, x);
julia> @btime bench_pr($y, $x);
  469.898 ns (0 allocations: 0 bytes)
julia> @btime bench_master($y, $x);
  524.084 ns (0 allocations: 0 bytes)
```
I suppose this is breaking for numbers that don't define `zero(x)` though...
  