### PR TITLE
rationalize function on irrational types

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -156,6 +156,9 @@ widen(::Type{Rational{T}}) where {T} = Rational{widen(T)}
 Approximate floating point number `x` as a [`Rational`](@ref) number with components
 of the given integer type. The result will differ from `x` by no more than `tol`.
 
+!!! note
+    If `x` is an `Irrational` number, then `T` is a required argument.
+
 # Examples
 ```jldoctest
 julia> rationalize(5.6)
@@ -166,6 +169,13 @@ julia> a = rationalize(BigInt, 10.3)
 
 julia> typeof(numerator(a))
 BigInt
+
+julia> rationalize(π)
+ERROR: MethodError: no method matching rationalize(::Irrational{:π})
+[...]
+
+julia> rationalize(Int8, π)
+22//7
 ```
 """
 function rationalize(::Type{T}, x::AbstractFloat, tol::Real) where T<:Integer


### PR DESCRIPTION
`rationalize([T<:Integer=Int,] x; tol::Real=eps(x))`

While the `T` argument is stated as optional, this is only true is `x` is any type other than an `Irrational`.

For `Irrational` types an error is thrown if the `T` argument is not provided.
```julia
julia> rationalize(π)
ERROR: MethodError: no method matching rationalize(::Irrational{:π})
[...]

julia> rationalize(Int8, π)
22//7
```

So it will be best if a note is provided on this regarding `rationalize` with `Irrational` numbers.