### PR TITLE
More info on how where, isa, outer behaves

### DIFF
--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -61,6 +61,23 @@ Finally:
 and `outer` is parsed as a keyword when used to modify the scope of a variable in an iteration specification of a `for` loop.
 Creation of variables named `where`, `in`, `isa` or `outer` is allowed though.
 
+Unlike `in`, `isa` and `outer`, `where` remains being an operator when used in special operations as stated above
+(regardless of the fact that it may have been used as a name of a variable in that same global namespace):
+```julia
+julia> begin
+
+       where = 10
+
+       function add(x::T, y::T) where T<:Integer
+           x + y
+       end
+
+       print(add(where, where))
+
+       end
+20
+```
+
 ```@docs
 module
 export


### PR DESCRIPTION
`where`, `in`, `isa`, `outer` are keywords when used under some special circumstances.

As stated here from the docs:
> Finally: where is parsed as an infix operator for writing parametric method and type definitions; in and isa are parsed as infix operators; and outer is parsed as a keyword when used to modify the scope of a variable in an iteration specification of a for loop or generator expression. Creation of variables named where, in, isa or outer is allowed though.

However, `in`, `isa`, and `outer` behaves in a different way when they are used as variables names differently from `where`.

For example, when used as a variable name, `in` and `isa` throws an error:
```julia
julia> isa = 10
10

julia> Int isa Integer
ERROR: MethodError: objects of type Int64 are not callable

julia> in = 4
4

julia> 5 in [1, 2, 3]
ERROR: MethodError: objects of type Int64 are not callable

julia> where = 10
10

julia> function add(x::T, y::T) where T<:Integer
           x + y
       end
add (generic function with 1 method)

julia> add(where, where)
20
```

However as I highlighted in the example, this situation does not happen for `where`. So its best to be stated explicitly about this.