### PR TITLE
Clear info on isabstracttype and isprimitivetype

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -547,7 +547,7 @@ end
     isprimitivetype(T) -> Bool
 
 Determine whether type `T` was declared as a primitive type
-(i.e. using the `primitive type` keyword).
+(i.e. using the `primitive type` syntax).
 """
 function isprimitivetype(@nospecialize t)
     @_total_meta

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -648,7 +648,7 @@ isconcretetype(@nospecialize(t)) = (@_total_meta; isa(t, DataType) && (t.flags &
     isabstracttype(T)
 
 Determine whether type `T` was declared as an abstract type
-(i.e. using the `abstract type` keyword).
+(i.e. using the `abstract type` syntax).
 
 # Examples
 ```jldoctest

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -547,7 +547,7 @@ end
     isprimitivetype(T) -> Bool
 
 Determine whether type `T` was declared as a primitive type
-(i.e. using the `primitive` keyword).
+(i.e. using the `primitive type` keyword).
 """
 function isprimitivetype(@nospecialize t)
     @_total_meta
@@ -648,7 +648,7 @@ isconcretetype(@nospecialize(t)) = (@_total_meta; isa(t, DataType) && (t.flags &
     isabstracttype(T)
 
 Determine whether type `T` was declared as an abstract type
-(i.e. using the `abstract` keyword).
+(i.e. using the `abstract type` keyword).
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
```julia
help?> isabstracttype
search: isabstracttype

  isabstracttype(T)

  Determine whether type T was declared as an abstract type (i.e.
  using the abstract keyword).

help?> isprimitivetype
search: isprimitivetype

  isprimitivetype(T) -> Bool

  Determine whether type T was declared as a primitive type (i.e.
  using the primitive keyword).
```

`isabstracttype` and `isprimitivetype` should be more said as "using the abstract type keyword" and "using the primitive type keyword", since technically no keyword exists as just `abstract` or `primitive`.

For others like “struct” it makes sense when we say using the “struct” keyword, or “mutable struct” keyword:
```julia
help?> isstructtype
search: isstructtype

  isstructtype(T) -> Bool

  Determine whether type T was declared as a struct type (i.e. using
  the struct or mutable struct keyword).

help?> ismutabletype
search: ismutabletype ismutable isimmutable

  ismutabletype(T) -> Bool

  Determine whether type T was declared as a mutable type (i.e. using
  mutable struct keyword).
```

Since those keywords exists technically.