### PR TITLE
Concise info on creating and using a module without core and base

### DIFF
--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -335,7 +335,7 @@ add (generic function with 1 method)
 
 julia> """
            add(x, y)
-
+       
        This sums up `x` and `y` and returns the result.
        """
        arithmetic.add

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -335,7 +335,7 @@ add (generic function with 1 method)
 
 julia> """
            add(x, y)
-       
+
        This sums up `x` and `y` and returns the result.
        """
        arithmetic.add

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -326,16 +326,16 @@ end
 ```
 
 If even `Core` is not wanted, a module that imports nothing and defines no names at all can be defined with `Module(:YourNameHere, false, false)` and code can be evaluated into it with [`@eval`](@ref) or [`Core.eval`](@ref):
-```julia
+```jldoctest
 julia> arithmetic = Module(:arithmetic, false, false)
 Main.arithmetic
 
 julia> @eval arithmetic add(x, y) = $(+)(x, y)
 add (generic function with 1 method)
 
-julia> @doc """
+julia> """
            add(x, y)
-           
+
        This sums up `x` and `y` and returns the result.
        """
        arithmetic.add

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -333,12 +333,6 @@ Main.arithmetic
 julia> @eval arithmetic add(x, y) = $(+)(x, y)
 add (generic function with 1 method)
 
-julia> @doc "`add(x,y)` adds `x` and `y` together." arithmetic.add
-Main.arithmetic.add
-
-help?> arithmetic.add
-  add(x,y) adds x and y together.
-
 julia> arithmetic.add(12, 13)
 25
 ```

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -333,18 +333,11 @@ Main.arithmetic
 julia> @eval arithmetic add(x, y) = $(+)(x, y)
 add (generic function with 1 method)
 
-julia> """
-           add(x, y)
-
-       This sums up `x` and `y` and returns the result.
-       """
-       arithmetic.add
+julia> @doc "`add(x,y)` adds `x` and `y` together." arithmetic.add
 Main.arithmetic.add
 
 help?> arithmetic.add
-  add(x, y)
-
-  This sums up x and y and returns the result.
+  add(x,y) adds x and y together.
 
 julia> arithmetic.add(12, 13)
 25

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -325,7 +325,30 @@ include(p) = Base.include(Mod, p)
 end
 ```
 
-If even `Core` is not wanted, a module that imports nothing and defines no names at all can be defined with `Module(:YourNameHere, false, false)` and code can be evaluated into it with [`@eval`](@ref) or [`Core.eval`](@ref).
+If even `Core` is not wanted, a module that imports nothing and defines no names at all can be defined with `Module(:YourNameHere, false, false)` and code can be evaluated into it with [`@eval`](@ref) or [`Core.eval`](@ref):
+```julia
+julia> arithmetic = Module(:arithmetic, false, false)
+Main.arithmetic
+
+julia> @eval arithmetic add(x, y) = $(+)(x, y)
+add (generic function with 1 method)
+
+julia> @doc """
+           add(x, y)
+           
+       This sums up `x` and `y` and returns the result.
+       """
+       arithmetic.add
+Main.arithmetic.add
+
+help?> arithmetic.add
+  add(x, y)
+
+  This sums up x and y and returns the result.
+
+julia> arithmetic.add(12, 13)
+25
+```
 
 ### Standard modules
 


### PR DESCRIPTION
I had a hard time solving this  - (using `@eval` to write code into the module and then writing a function doc for the new function evaluated using `@eval`).

Thank God for the helpful and timely answers I got from slack and discourse, then I finally knew how to use `@eval` on working with functions on the module without `core` and `base`.

Then finally documenting the function was another series of asking questions and finally the timely answers came. And I could add a function docstring to it.

But the point is, why not just show a quick demo of this in the documentation so others don't have to pass through this stress?