### PR TITLE
irinterp: Be sure to inline const values

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1760,7 +1760,7 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
             return abstract_finalizer(interp, argtypes, sv)
         end
         rt = abstract_call_builtin(interp, f, arginfo, sv, max_methods)
-        effects = builtin_effects(f, argtypes[2:end], rt)
+        effects = builtin_effects(typeinf_lattice(interp), f, argtypes[2:end], rt)
         return CallMeta(rt, effects, false)
     elseif isa(f, Core.OpaqueClosure)
         # calling an OpaqueClosure about which we have no information returns no information

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -24,11 +24,14 @@ const IR_FLAG_INLINE      = 0x01 << 1
 # This statement is marked as @noinline by user
 const IR_FLAG_NOINLINE    = 0x01 << 2
 const IR_FLAG_THROW_BLOCK = 0x01 << 3
-# This statement may be removed if its result is unused. In particular it must
-# thus be both pure and effect free.
+# This statement may be removed if its result is unused. In particular,
+# it must be both :effect_free and :nothrow.
+# TODO: Separate these out.
 const IR_FLAG_EFFECT_FREE = 0x01 << 4
 # This statement was proven not to throw
 const IR_FLAG_NOTHROW     = 0x01 << 5
+# This is :consistent
+const IR_FLAG_CONSISTENT  = 0x01 << 6
 
 const TOP_TUPLE = GlobalRef(Core, :tuple)
 
@@ -207,19 +210,20 @@ end
 """
     stmt_effect_flags(stmt, rt, src::Union{IRCode,IncrementalCompact})
 
-Returns a tuple of (effect_free_and_nothrow, nothrow) for a given statement.
+Returns a tuple of (consistent,  effect_free_and_nothrow, nothrow) for a given statement.
 """
-function stmt_effect_flags(@nospecialize(stmt), @nospecialize(rt), src::Union{IRCode,IncrementalCompact})
+function stmt_effect_flags(lattice::AbstractLattice, @nospecialize(stmt), @nospecialize(rt), src::Union{IRCode,IncrementalCompact})
     # TODO: We're duplicating analysis from inference here.
-    isa(stmt, PiNode) && return (true, true)
-    isa(stmt, PhiNode) && return (true, true)
-    isa(stmt, ReturnNode) && return (false, true)
-    isa(stmt, GotoNode) && return (false, true)
-    isa(stmt, GotoIfNot) && return (false, argextype(stmt.cond, src) ⊑ₒ Bool)
-    isa(stmt, Slot) && return (false, false) # Slots shouldn't occur in the IR at this point, but let's be defensive here
+    isa(stmt, PiNode) && return (true, true, true)
+    isa(stmt, PhiNode) && return (true, true, true)
+    isa(stmt, ReturnNode) && return (true, false, true)
+    isa(stmt, GotoNode) && return (true, false, true)
+    isa(stmt, GotoIfNot) && return (true, false, argextype(stmt.cond, src) ⊑ₒ Bool)
+    isa(stmt, Slot) && return (true, false, false) # Slots shouldn't occur in the IR at this point, but let's be defensive here
     if isa(stmt, GlobalRef)
         nothrow = isdefined(stmt.mod, stmt.name)
-        return (nothrow, nothrow)
+        consistent = nothrow && isconst(stmt.mod, stmt.name)
+        return (consistent, nothrow, nothrow)
     end
     if isa(stmt, Expr)
         (; head, args) = stmt
@@ -227,72 +231,70 @@ function stmt_effect_flags(@nospecialize(stmt), @nospecialize(rt), src::Union{IR
             etyp = (isa(src, IRCode) ? src.sptypes : src.ir.sptypes)[args[1]::Int]
             # if we aren't certain enough about the type, it might be an UndefVarError at runtime
             nothrow = isa(etyp, Const)
-            return (nothrow, nothrow)
+            return (true, nothrow, nothrow)
         end
         if head === :call
             f = argextype(args[1], src)
             f = singleton_type(f)
-            f === nothing && return (false, false)
-            if isa(f, IntrinsicFunction)
-                nothrow = intrinsic_nothrow(f,
-                    Any[argextype(args[i], src) for i = 2:length(args)])
-                nothrow || return (false, false)
-                return (intrinsic_effect_free_if_nothrow(f), nothrow)
+            f === nothing && return (false, false, false)
+            if f === UnionAll
+                # TODO: This is a weird special case - should be determined in inference
+                argtypes = Any[argextype(args[arg], src) for arg in 2:length(args)]
+                nothrow = _builtin_nothrow(lattice, f, argtypes, rt)
+                return (true, nothrow, nothrow)
             end
-            contains_is(_PURE_BUILTINS, f) && return (true, true)
-            # `get_binding_type` sets the type to Any if the binding doesn't exist yet
-            if f === Core.get_binding_type
-                length(args) == 3 || return false
-                M, s = argextype(args[2], src), argextype(args[3], src)
-                total = get_binding_type_effect_free(M, s)
-                return (total, total)
-            end
-            rt === Bottom && return (false, false)
-            nothrow = _builtin_nothrow(f, Any[argextype(args[i], src) for i = 2:length(args)], rt, OptimizerLattice())
-            nothrow || return (false, false)
-            return (contains_is(_EFFECT_FREE_BUILTINS, f), nothrow)
+            isa(f, Builtin) || return (false, false, false)
+            # Needs to be handled in inlining to look at the callee effects
+            f === Core._apply_iterate && return (false, false, false)
+            argtypes = Any[argextype(args[arg], src) for arg in 2:length(args)]
+            effects = builtin_effects(lattice, f, argtypes, rt)
+            consistent = is_consistent(effects)
+            effect_free = is_effect_free(effects)
+            nothrow = is_nothrow(effects)
+            return (consistent, effect_free & nothrow, nothrow)
         elseif head === :new
             typ = argextype(args[1], src)
             # `Expr(:new)` of unknown type could raise arbitrary TypeError.
             typ, isexact = instanceof_tfunc(typ)
-            isexact || return (false, false)
-            isconcretedispatch(typ) || return (false, false)
+            isexact || return (false, false, false)
+            isconcretedispatch(typ) || return (false, false, false)
             typ = typ::DataType
-            fieldcount(typ) >= length(args) - 1 || return (false, false)
+            fieldcount(typ) >= length(args) - 1 || return (false, false, false)
             for fld_idx in 1:(length(args) - 1)
                 eT = argextype(args[fld_idx + 1], src)
                 fT = fieldtype(typ, fld_idx)
-                eT ⊑ₒ fT || return (false, false)
+                eT ⊑ₒ fT || return (false, false, false)
             end
-            return (true, true)
+            return (false, true, true)
         elseif head === :foreigncall
             effects = foreigncall_effects(stmt) do @nospecialize x
                 argextype(x, src)
             end
+            consistent = is_consistent(effects)
             effect_free = is_effect_free(effects)
             nothrow = is_nothrow(effects)
-            return (effect_free & nothrow, nothrow)
+            return (consistent, effect_free & nothrow, nothrow)
         elseif head === :new_opaque_closure
-            length(args) < 4 && return (false, false)
+            length(args) < 4 && return (false, false, false)
             typ = argextype(args[1], src)
             typ, isexact = instanceof_tfunc(typ)
-            isexact || return (false, false)
-            typ ⊑ₒ Tuple || return (false, false)
+            isexact || return (false, false, false)
+            typ ⊑ₒ Tuple || return (false, false, false)
             rt_lb = argextype(args[2], src)
             rt_ub = argextype(args[3], src)
             source = argextype(args[4], src)
             if !(rt_lb ⊑ₒ Type && rt_ub ⊑ₒ Type && source ⊑ₒ Method)
-                return (false, false)
+                return (false, false, false)
             end
-            return (true, true)
+            return (false, true, true)
         elseif head === :isdefined || head === :the_exception || head === :copyast || head === :inbounds || head === :boundscheck
-            return (true, true)
+            return (true, true, true)
         else
             # e.g. :loopinfo
-            return (false, false)
+            return (false, false, false)
         end
     end
-    return (true, true)
+    return (true, true, true)
 end
 
 """
@@ -383,7 +385,7 @@ function finish(interp::AbstractInterpreter, opt::OptimizationState,
             for i in 1:length(ir.stmts)
                 node = ir.stmts[i]
                 stmt = node[:inst]
-                if stmt_affects_purity(stmt, ir) && !stmt_effect_flags(stmt, node[:type], ir)[1]
+                if stmt_affects_purity(stmt, ir) && !stmt_effect_flags(optimizer_lattice(interp), stmt, node[:type], ir)[2]
                     proven_pure = false
                     break
                 end

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -509,7 +509,10 @@ function insert_node!(ir::IRCode, pos::Int, inst::NewInstruction, attach_after::
     node[:line] = something(inst.line, ir.stmts[pos][:line])
     flag = inst.flag
     if !inst.effect_free_computed
-        (effect_free_and_nothrow, nothrow) = stmt_effect_flags(inst.stmt, inst.type, ir)
+        (consistent, effect_free_and_nothrow, nothrow) = stmt_effect_flags(fallback_lattice, inst.stmt, inst.type, ir)
+        if consistent
+            flag |= IR_FLAG_CONSISTENT
+        end
         if effect_free_and_nothrow
             flag |= IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW
         elseif nothrow
@@ -831,7 +834,10 @@ function insert_node_here!(compact::IncrementalCompact, inst::NewInstruction, re
     end
     flag = inst.flag
     if !inst.effect_free_computed
-        (effect_free_and_nothrow, nothrow) = stmt_effect_flags(inst.stmt, inst.type, compact)
+        (consistent, effect_free_and_nothrow, nothrow) = stmt_effect_flags(fallback_lattice, inst.stmt, inst.type, compact)
+        if consistent
+            flag |= IR_FLAG_CONSISTENT
+        end
         if effect_free_and_nothrow
             flag |= IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW
         elseif nothrow
@@ -1136,9 +1142,14 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
         result[result_idx][:inst] = GotoNode(compact.bb_rename_succ[stmt.label])
         result_idx += 1
     elseif isa(stmt, GlobalRef)
-        result[result_idx][:inst] = stmt
-        result[result_idx][:type] = argextype(stmt, compact)
-        result_idx += 1
+        total_flags = IR_FLAG_CONSISTENT | IR_FLAG_EFFECT_FREE
+        if (result[result_idx][:flag] & total_flags) == total_flags
+            ssa_rename[idx] = stmt
+        else
+            result[result_idx][:inst] = stmt
+            result[result_idx][:type] = argextype(stmt, compact)
+            result_idx += 1
+        end
     elseif isa(stmt, GotoNode)
         result[result_idx][:inst] = stmt
         result_idx += 1

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -182,7 +182,11 @@ function reprocess_instruction!(interp::AbstractInterpreter, ir::IRCode, mi::Met
                     (;rt, effects) = abstract_eval_statement_expr(interp, inst, nothing, ir, mi)
                     # All other effects already guaranteed effect free by construction
                     if is_nothrow(effects)
-                        ir.stmts[idx][:flag] |= IR_FLAG_EFFECT_FREE
+                        if isa(rt, Const) && is_inlineable_constant(rt.val)
+                            ir.stmts[idx][:inst] = quoted(rt.val)
+                        else
+                            ir.stmts[idx][:flag] |= IR_FLAG_EFFECT_FREE
+                        end
                     end
                 end
                 if !⊑(typeinf_lattice(interp), typ, rt)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1413,7 +1413,7 @@ function infer_effects(@nospecialize(f), @nospecialize(types=default_tt(f));
     if isa(f, Core.Builtin)
         argtypes = Any[types.parameters...]
         rt = Core.Compiler.builtin_tfunction(interp, f, argtypes, nothing)
-        return Core.Compiler.builtin_effects(f, argtypes, rt)
+        return Core.Compiler.builtin_effects(Core.Compiler.typeinf_lattice(interp), f, argtypes, rt)
     end
     tt = signature_type(f, types)
     result = Core.Compiler.findall(tt, Core.Compiler.method_table(interp))

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -348,7 +348,7 @@ end |> !Core.Compiler.is_foldable
     entry_to_be_invalidated('a')
 end
 
-@test !Core.Compiler.builtin_nothrow(Core.get_binding_type, Any[Rational{Int}, Core.Const(:foo)], Any)
+@test !Core.Compiler.builtin_nothrow(Core.Compiler.fallback_lattice, Core.get_binding_type, Any[Rational{Int}, Core.Const(:foo)], Any)
 
 # Nothrow for assignment to globals
 global glob_assign_int::Int = 0
@@ -654,4 +654,4 @@ end # @testset "effects analysis on array construction" begin
 end # @testset "effects analysis on array ops" begin
 
 # Test that builtin_effects handles vararg correctly
-@test !Core.Compiler.is_nothrow(Core.Compiler.builtin_effects(Core.isdefined, Any[String, Vararg{Any}], Bool))
+@test !Core.Compiler.is_nothrow(Core.Compiler.builtin_effects(Core.Compiler.fallback_lattice, Core.isdefined, Any[String, Vararg{Any}], Bool))

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1451,3 +1451,15 @@ end
         @test !any(@nospecialize(x) -> isexpr(x, :call) && length(x.args) == 1, src.code)
     end
 end
+
+# Test that semi-concrete eval can inline constant results
+function twice_sitofp(x::Int, y::Int)
+    x = Base.sitofp(Float64, x)
+    y = Base.sitofp(Float64, y)
+    return (x, y)
+end
+call_twice_sitofp(x::Int) = twice_sitofp(x, 2)
+
+let src = code_typed1(call_twice_sitofp, (Int,))
+    @test count(iscall((src, Base.sitofp)), src.code) == 1
+end


### PR DESCRIPTION
Ordinarily, annotating a `Const` type on a statement is sufficent
to ensure that it eventually gets moved into statement position.
The actual transformation is usually done by the inlining pass.
However, since no inlining pass runs on the result of semi-concrete
evaulation, we need to do here what it would have otherwise done
if it did run.

The other change here is to move const GlobalRefs back into argument
position, which is required to make the test work. The issue here
is that we round-trip the IR through the global cache, which widens
all constants, so the type field no longer reflects that `sitofp`
is `Const(sitofp)` but rather widens it to `IntrinsicFunction`.
This is a bit unfortunate in general, as it means that irinterp
doesn't have access to constant information that was discovered
during regular inference. In the future we may want to consider
trying to perseve that constant information longer. However,
for the time being, I think moving const bindings (by far the
most common source of Const information in the IR that doesn't
get immediately transformed into const values) back into argument
position provides a tempoary solution.