### PR TITLE
Consistent info on isless and Base.isgreater

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -185,7 +185,7 @@ Not the inverse of `isless`! Test whether `x` is greater than `y`, according to
 a fixed total order compatible with `min`.
 
 Defined with `isless`, this function is usually `isless(y, x)`, but `NaN` and
-[`missing`](@ref) are ordered as smaller than any ordinary value with `missing`
+[`missing`](@ref) are ordered as smaller than any regular value with `missing`
 smaller than `NaN`.
 
 So `isless` defines an ascending total order with `NaN` and `missing` as the


### PR DESCRIPTION
```julia
help?> isless
search: isless disable_sigint islowercase

  isless(x, y)

  Values that are normally unordered, such as NaN, are ordered after
  regular values. missing values are ordered last.


help?> Base.isgreater
  isgreater(x, y)

  Defined with isless, this function is usually isless(y, x), but NaN
  and missing are ordered as smaller than any ordinary value with
  missing smaller than NaN.
```

`isless` says "are ordered after regular values". But then `Base.isgreater` says "are ordered as smaller than any ordinary value."

I believe the "regular" and "ordinary" are talking about same things, so its best if its stated as "regular" on both end.