### PR TITLE
inference: allow semi-concrete interpretation on non-inlineable code

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -130,6 +130,15 @@ function concrete_eval_invoke(interp::AbstractInterpreter, ir::IRCode, mi_cache,
     return nothing
 end
 
+function collect_semi_const_args(argtypes::Vector{Any}, start::Int=2)
+    return Any[ let a = widenconditional(argtypes[i])
+                    isa(a, Const) ? a.val :
+                    isconstType(a) ? (a::DataType).parameters[1] :
+                    isdefined(a, :instance) ? (a::DataType).instance :
+                    nothing
+                end for i in start:length(argtypes) ]
+end
+
 function reprocess_instruction!(interp::AbstractInterpreter, ir::IRCode, mi::MethodInstance,
                                 mi_cache,
                                 tpdum::TwoPhaseDefUseMap, idx::Int, bb::Union{Int, Nothing},


### PR DESCRIPTION
Currently we require `const_prop_methodinstance_heuristic` to do the
semi-concrete interpretation, and thus non-inlineable functions are
not eligible for the semi-concrete interpretation.
Especially that can happen for function marked with `@noinline`.

This commit drops the condition for the semi-concrete interpretation,
and widens the eligibility of it.