### PR TITLE
Document UInt64 return type of time_ns()

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -87,7 +87,7 @@ if false
 end
 
 """
-    time_ns()
+    time_ns() -> UInt64
 
 Get the time in nanoseconds. The time corresponding to 0 is undefined, and wraps every 5.8 years.
 """


### PR DESCRIPTION
I found it necessary to document this, because running `typeof(time_ns())` on a 64-bit computer might leave you wondering if the return type is `UInt` or `UInt64`.