### PR TITLE
optimizer: fixup `IR_FLAG_NOTHROW` flagging

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -208,9 +208,10 @@ function stmt_affects_purity(@nospecialize(stmt), ir)
 end
 
 """
-    stmt_effect_flags(stmt, rt, src::Union{IRCode,IncrementalCompact})
+    stmt_effect_flags(stmt, rt, src::Union{IRCode,IncrementalCompact}) ->
+        (consistent::Bool, effect_free_and_nothrow::Bool, nothrow::Bool)
 
-Returns a tuple of (consistent,  effect_free_and_nothrow, nothrow) for a given statement.
+Returns a tuple of `(:consistent, :effect_free_and_nothrow, :nothrow)` flags for a given statement.
 """
 function stmt_effect_flags(lattice::AbstractLattice, @nospecialize(stmt), @nospecialize(rt), src::Union{IRCode,IncrementalCompact})
     # TODO: We're duplicating analysis from inference here.

--- a/base/compiler/ssair/EscapeAnalysis/interprocedural.jl
+++ b/base/compiler/ssair/EscapeAnalysis/interprocedural.jl
@@ -1,12 +1,12 @@
 # TODO this file contains many duplications with the inlining analysis code, factor them out
 
 import Core.Compiler:
-    MethodInstance, InferenceResult, Signature, ConstPropResult, ConcreteResult,
+    MethodInstance, InferenceResult, Signature, ConstPropResult, ConcreteResult, SemiConcreteResult,
     MethodResultPure, MethodMatchInfo, UnionSplitInfo, ConstCallInfo, InvokeCallInfo,
     call_sig, argtypes_to_type, is_builtin, is_return_type, istopfunction, validate_sparams,
     specialize_method, invoke_rewrite
 
-const Linfo = Union{MethodInstance,InferenceResult,SemiConcreteResult}
+const Linfo = Union{MethodInstance,InferenceResult}
 struct CallInfo
     linfos::Vector{Linfo}
     nothrow::Bool
@@ -64,6 +64,10 @@ function analyze_invoke_call(sig::Signature, info::InvokeCallInfo)
     result = info.result
     if isa(result, ConstPropResult)
         return CallInfo(Linfo[result.result], true)
+    elseif isa(result, ConcreteResult)
+        return CallInfo(Linfo[result.mi], true)
+    elseif isa(result, SemiConcreteResult)
+        return CallInfo(Linfo[result.mi], true)
     else
         argtypes = invoke_rewrite(sig.argtypes)
         mi = analyze_match(match, length(argtypes))
@@ -97,6 +101,8 @@ function analyze_const_call(sig::Signature, cinfo::ConstCallInfo)
                 push!(linfos, mi)
             elseif isa(result, ConcreteResult)
                 # TODO we may want to feedback information that this call always throws if !isdefined(result, :result)
+                push!(linfos, result.mi)
+            elseif isa(result, SemiConcreteResult)
                 push!(linfos, result.mi)
             elseif isa(result, ConstPropResult)
                 push!(linfos, result.result)

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -590,10 +590,9 @@ function ir_inline_unionsplit!(compact::IncrementalCompact, idx::Int,
         if isa(case, InliningTodo)
             val = ir_inline_item!(compact, idx, argexprs′, linetable, case, boundscheck, todo_bbs)
         elseif isa(case, InvokeCase)
-            effect_free = is_removable_if_unused(case.effects)
-            val = insert_node_here!(compact,
-                NewInstruction(Expr(:invoke, case.invoke, argexprs′...), typ, nothing,
-                    line, effect_free ? IR_FLAG_EFFECT_FREE : IR_FLAG_NULL, effect_free))
+            inst = Expr(:invoke, case.invoke, argexprs′...)
+            flag = flags_for_effects(case.effects)
+            val = insert_node_here!(compact, NewInstruction(inst, typ, nothing, line, flag, true))
         else
             case = case::ConstantCase
             val = case.val

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1148,11 +1148,13 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
         result_idx += 1
     elseif isa(stmt, GlobalRef)
         total_flags = IR_FLAG_CONSISTENT | IR_FLAG_EFFECT_FREE
-        if (result[result_idx][:flag] & total_flags) == total_flags
+        flag = result[result_idx][:flag]
+        if (flag & total_flags) == total_flags
             ssa_rename[idx] = stmt
         else
             result[result_idx][:inst] = stmt
             result[result_idx][:type] = argextype(stmt, compact)
+            result[result_idx][:flag] = flag
             result_idx += 1
         end
     elseif isa(stmt, GotoNode)

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1103,7 +1103,7 @@ function try_inline_finalizer!(ir::IRCode, argexprs::Vector{Any}, idx::Int, mi::
     return true
 end
 
-is_nothrow(ir::IRCode, pc::Int) = ir.stmts[pc][:flag] & (IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW) ≠ 0
+is_nothrow(ir::IRCode, pc::Int) = (ir.stmts[pc][:flag] & IR_FLAG_NOTHROW) ≠ 0
 
 function try_resolve_finalizer!(ir::IRCode, idx::Int, finalizer_idx::Int, defuse::SSADefUse, inlining::InliningState, info::Union{FinalizerInfo, Nothing})
     # For now: Require that all uses and defs are in the same basic block,

--- a/test/compiler/EscapeAnalysis/EAUtils.jl
+++ b/test/compiler/EscapeAnalysis/EAUtils.jl
@@ -70,8 +70,7 @@ import Core:
 import .CC:
     InferenceResult, OptimizationState, IRCode, copy as cccopy,
     @timeit, convert_to_ircode, slot2reg, compact!, ssa_inlining_pass!, sroa_pass!,
-    adce_pass!, type_lift_pass!, JLOptions, verify_ir, verify_linetable,
-    SemiConcreteResult
+    adce_pass!, type_lift_pass!, JLOptions, verify_ir, verify_linetable
 import .EA: analyze_escapes, ArgEscapeCache, EscapeInfo, EscapeState, is_ipo_profitable
 
 # when working outside of Core.Compiler,
@@ -177,10 +176,8 @@ function cache_escapes!(interp::EscapeAnalyzer,
 end
 
 function get_escape_cache(interp::EscapeAnalyzer)
-    return function (linfo::Union{InferenceResult,MethodInstance,SemiConcreteResult})
+    return function (linfo::Union{InferenceResult,MethodInstance})
         if isa(linfo, InferenceResult)
-            ecache = get(interp.cache, linfo, nothing)
-        elseif isa(linfo, SemiConcreteResult)
             ecache = get(interp.cache, linfo, nothing)
         else
             ecache = get(GLOBAL_ESCAPE_CACHE, linfo, nothing)

--- a/test/compiler/contextual.jl
+++ b/test/compiler/contextual.jl
@@ -1,5 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+# Cassette
+# ========
+
 module MiniCassette
     # A minimal demonstration of the cassette mechanism. Doesn't support all the
     # fancy features, but sufficient to exercise this code path in the compiler.
@@ -129,17 +132,12 @@ foo(i) = i+bar(Val(1))
 # Check that misbehaving pure functions propagate their error
 Base.@pure func1() = 42
 Base.@pure func2() = (this_is_an_exception; func1())
-
-let method = which(func2, ())
-    mi = Core.Compiler.specialize_method(method, Tuple{typeof(func2)}, Core.svec())
-    mi.inInference = true
-end
 func3() = func2()
 @test_throws UndefVarError func3()
 
 
-
-## overlay method tables
+# overlay method tables
+# =====================
 
 module OverlayModule
 
@@ -157,7 +155,7 @@ end
 # parametric function def
 @overlay mt tan(x::T) where {T} = 3
 
-end
+end # module OverlayModule
 
 methods = Base._methods_by_ftype(Tuple{typeof(sin), Float64}, nothing, 1, Base.get_world_counter())
 @test only(methods).method.module === Base.Math


### PR DESCRIPTION
Properly mark `IR_FLAG_NOTHROW` at several places in optimizer.

Also updates `EscapeAnalysis`-related things, that are required to make CI pass.