### PR TITLE
backport invalidation fixes to 1.8

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -1027,7 +1027,7 @@ function platforms_match(a::AbstractPlatform, b::AbstractPlatform)
 
         # Call the comparator, passing in which objects requested this comparison (one, the other, or both)
         # For some comparators this doesn't matter, but for non-symmetrical comparisons, it does.
-        if !comparator(ak, bk, a_comp == comparator, b_comp == comparator)
+        if !(comparator(ak, bk, a_comp == comparator, b_comp == comparator)::Bool)
             return false
         end
     end

--- a/base/process.jl
+++ b/base/process.jl
@@ -430,7 +430,7 @@ function open(f::Function, cmds::AbstractCmd, args...; kwargs...)
         rethrow()
     end
     close(P.in)
-    if !eof(P.out)
+    if !(eof(P.out)::Bool)
         waitkill(P)
         throw(_UVError("open(do)", UV_EPIPE))
     end


### PR DESCRIPTION
I backported two PRs with invalidation fixes (merged into `master`) to `release-1.8`. They fix a few hundred invalidations when loading Static.jl, ArrayInterface.jl or anything using that (basically everything from JuliaSIMD with LoopVectorization.jl, SciML with OrdinaryDiffEq.jl etc.).
The original PRs #46547 and #46551 had the `backport-1.8` label but were not included in #46376.