### PR TITLE
improve type stability of `process_overrides(artifact_dict::Dict, pkk_uuid::Base.UUID)`

### DIFF
--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -329,7 +329,7 @@ function process_overrides(artifact_dict::Dict, pkg_uuid::Base.UUID)
 
         for name in keys(artifact_dict)
             # Skip names that we're not overriding
-            if !haskey(pkg_overrides, name)
+            if !(haskey(pkg_overrides, name)::Bool)
                 continue
             end
 

--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -325,7 +325,7 @@ function process_overrides(artifact_dict::Dict, pkg_uuid::Base.UUID)
     # override for this UUID, and inserting new overrides for those hashes.
     overrides = load_overrides()
     if haskey(overrides[:UUID], pkg_uuid)
-        pkg_overrides = overrides[:UUID][pkg_uuid]::Dict{String, :<Any}
+        pkg_overrides = overrides[:UUID][pkg_uuid]::Dict{String, <:Any}
 
         for name in keys(artifact_dict)
             # Skip names that we're not overriding

--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -325,7 +325,7 @@ function process_overrides(artifact_dict::Dict, pkg_uuid::Base.UUID)
     # override for this UUID, and inserting new overrides for those hashes.
     overrides = load_overrides()
     if haskey(overrides[:UUID], pkg_uuid)
-        pkg_overrides = overrides[:UUID][pkg_uuid]::Dict{String}
+        pkg_overrides = overrides[:UUID][pkg_uuid]::Dict{String, :<Any}
 
         for name in keys(artifact_dict)
             # Skip names that we're not overriding

--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -325,7 +325,7 @@ function process_overrides(artifact_dict::Dict, pkg_uuid::Base.UUID)
     # override for this UUID, and inserting new overrides for those hashes.
     overrides = load_overrides()
     if haskey(overrides[:UUID], pkg_uuid)
-        pkg_overrides = overrides[:UUID][pkg_uuid]::Dict{String, Any}
+        pkg_overrides = overrides[:UUID][pkg_uuid]::Dict{String}
 
         for name in keys(artifact_dict)
             # Skip names that we're not overriding

--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -325,11 +325,11 @@ function process_overrides(artifact_dict::Dict, pkg_uuid::Base.UUID)
     # override for this UUID, and inserting new overrides for those hashes.
     overrides = load_overrides()
     if haskey(overrides[:UUID], pkg_uuid)
-        pkg_overrides = overrides[:UUID][pkg_uuid]
+        pkg_overrides = overrides[:UUID][pkg_uuid]::Dict{String, Any}
 
         for name in keys(artifact_dict)
             # Skip names that we're not overriding
-            if !(haskey(pkg_overrides, name)::Bool)
+            if !haskey(pkg_overrides, name)
                 continue
             end
 


### PR DESCRIPTION
This fixes some invalidations when loading Static.jl.

I used the following code to find this problem:
```julia
julia> import Pkg; Pkg.activate(temp=true); Pkg.add("Static")

julia> using SnoopCompileCore; invalidations = @snoopr(using Static); using SnoopCompile

julia> trees = invalidation_trees(invalidations);

julia> import Artifacts; ftrees = filtermod(Artifacts, trees)
1-element Vector{SnoopCompile.MethodInvalidations}:
 inserting !(::False) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:427 invalidated:
   mt_backedges: 1: signature Tuple{typeof(!), Any} triggered MethodInstance for Artifacts.process_overrides(::Dict{String, Any}, ::Base.UUID) (3 children)
```
This PR gets us one step closer to finally fixing https://github.com/SciML/Static.jl/issues/77.

I suggest the labels `latency` and `backport-1.8`.