### PR TITLE
fix invalidations from loading ArrayInterface.jl

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -111,7 +111,8 @@ function NamedTuple{names}(nt::NamedTuple) where {names}
         types = Tuple{(fieldtype(nt, idx[n]) for n in 1:length(idx))...}
         Expr(:new, :(NamedTuple{names, $types}), Any[ :(getfield(nt, $(idx[n]))) for n in 1:length(idx) ]...)
     else
-        types = Tuple{(fieldtype(typeof(nt), names[n]) for n in 1:length(names))...}
+        length_names = length(names)::Integer
+        types = Tuple{(fieldtype(typeof(nt), names[n]) for n in 1:length_names)...}
         NamedTuple{names, types}(map(Fix1(getfield, nt), names))
     end
 end

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -24,7 +24,8 @@ function recursive_dotcalls!(ex, args, i=1)
         end
     end
     (start, branches) = ex.head === :. ? (1, ex.args[2].args) : (2, ex.args)
-    for j in start:length(branches)
+    length_branches = length(branches)::Integer
+    for j in start:length_branches
         branch, i = recursive_dotcalls!(branches[j], args, i)
         branches[j] = branch
     end


### PR DESCRIPTION
I improved type stability to fix some invalidations. This is based on the following code:

```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add("ArrayInterface")

julia> using SnoopCompileCore; invalidations = @snoopr(using ArrayInterface); using SnoopCompile

julia> trees = invalidation_trees(invalidations)
inserting (::Colon)(L::Integer, ::Static.StaticInt{U}) where U in ArrayInterface at ~/.julia/packages/ArrayInterface/eITVf/src/ranges.jl:157 invalidated:
   mt_backedges:  1: signature Tuple{Colon, Int64, Any} triggered MethodInstance for InteractiveUtils.recursive_dotcalls!(::Expr, ::Vector{Any}, ::Int64) (0 children)
...
                 11: signature Tuple{Colon, Int64, Any} triggered MethodInstance for InteractiveUtils.recursive_dotcalls!(::Any, ::Vector{Any}, ::Int64) (10 children)
...
                 15: signature Tuple{Colon, Int64, Any} triggered MethodInstance for (::Type{NamedTuple{_A}} where _A)(::NamedTuple) (186 children)
...
```

I suggest the labels `latency` and `backport-1.8`.