### PR TITLE
Save global variable names to the JIT's reverse lookup table

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -136,7 +136,7 @@ void jl_dump_llvm_opt_impl(void *s)
 
 static void jl_add_to_ee(orc::ThreadSafeModule &M, StringMap<orc::ThreadSafeModule*> &NewExports);
 static void jl_decorate_module(Module &M);
-static uint64_t getAddressForFunction(StringRef fname);
+static JITTargetAddress getAddressForFunction(StringRef fname);
 
 void jl_link_global(GlobalVariable *GV, void *addr)
 {
@@ -249,21 +249,23 @@ static jl_callptr_t _jl_compile_codeinst(
             addr = jl_fptr_sparam_addr;
         }
         else {
-            addr = (jl_callptr_t)getAddressForFunction(decls.functionObject);
+            addr = jitTargetAddressToFunction<jl_callptr_t>(getAddressForFunction(decls.functionObject));
             isspecsig = true;
         }
         if (jl_atomic_load_relaxed(&this_code->invoke) == NULL) {
             // once set, don't change invoke-ptr, as that leads to race conditions
             // with the (not) simultaneous updates to invoke and specptr
             if (!decls.specFunctionObject.empty()) {
-                jl_atomic_store_release(&this_code->specptr.fptr, (void*)getAddressForFunction(decls.specFunctionObject));
+                jl_atomic_store_release(&this_code->specptr.fptr,
+                    jitTargetAddressToPointer<void*>(getAddressForFunction(decls.specFunctionObject)));
                 this_code->isspecsig = isspecsig;
             }
             jl_atomic_store_release(&this_code->invoke, addr);
         }
         else if (jl_atomic_load_relaxed(&this_code->invoke) == jl_fptr_const_return_addr && !decls.specFunctionObject.empty()) {
             // hack to export this pointer value to jl_dump_method_disasm
-            jl_atomic_store_release(&this_code->specptr.fptr, (void*)getAddressForFunction(decls.specFunctionObject));
+            jl_atomic_store_release(&this_code->specptr.fptr,
+                jitTargetAddressToPointer<void*>(getAddressForFunction(decls.specFunctionObject)));
         }
         if (this_code== codeinst)
             fptr = addr;
@@ -1271,9 +1273,10 @@ orc::SymbolStringPtr JuliaOJIT::mangle(StringRef Name)
     return ES.intern(MangleName);
 }
 
-void JuliaOJIT::addGlobalMapping(StringRef Name, uint64_t Addr)
+void JuliaOJIT::addGlobalMapping(StringRef Name, JITTargetAddress Addr)
 {
-    cantFail(JD.define(orc::absoluteSymbols({{mangle(Name), JITEvaluatedSymbol::fromPointer((void*)Addr)}})));
+    cantFail(JD.define(orc::absoluteSymbols({{mangle(Name),
+        JITEvaluatedSymbol::fromPointer(jitTargetAddressToPointer<void*>(Addr))}})));
 }
 
 void JuliaOJIT::addModule(orc::ThreadSafeModule TSM)
@@ -1334,7 +1337,7 @@ JL_JITSymbol JuliaOJIT::findUnmangledSymbol(StringRef Name)
     return findSymbol(getMangledName(Name), true);
 }
 
-uint64_t JuliaOJIT::getGlobalValueAddress(StringRef Name)
+JITTargetAddress JuliaOJIT::getGlobalValueAddress(StringRef Name)
 {
     auto addr = findSymbol(getMangledName(Name), false);
     if (!addr) {
@@ -1344,21 +1347,16 @@ uint64_t JuliaOJIT::getGlobalValueAddress(StringRef Name)
     return cantFail(addr.getAddress());
 }
 
-uint64_t JuliaOJIT::getFunctionAddress(StringRef Name)
+JITTargetAddress JuliaOJIT::getFunctionAddress(StringRef Name)
 {
-    auto addr = findSymbol(getMangledName(Name), false);
-    if (!addr) {
-        consumeError(addr.takeError());
-        return 0;
-    }
-    return cantFail(addr.getAddress());
+    return getGlobalValueAddress(Name);
 }
 
-StringRef JuliaOJIT::getFunctionAtAddress(uint64_t Addr, jl_code_instance_t *codeinst)
+StringRef JuliaOJIT::getFunctionAtAddress(JITTargetAddress Addr, jl_code_instance_t *codeinst)
 {
     std::lock_guard<std::mutex> lock(RLST_mutex);
-    std::string *fname = &ReverseLocalSymbolTable[(void*)(uintptr_t)Addr];
-    if (fname->empty()) {
+    auto &fname = ReverseLocalSymbolTable[Addr];
+    if (!fname) {
         std::string string_fname;
         raw_string_ostream stream_fname(string_fname);
         // try to pick an appropriate name that describes it
@@ -1377,7 +1375,7 @@ StringRef JuliaOJIT::getFunctionAtAddress(uint64_t Addr, jl_code_instance_t *cod
         }
         const char* unadorned_name = jl_symbol_name(codeinst->def->def.method->name);
         stream_fname << unadorned_name << "_" << RLST_inc++;
-        *fname = std::move(stream_fname.str()); // store to ReverseLocalSymbolTable
+        fname = ES.intern(stream_fname.str()); // store to ReverseLocalSymbolTable
         addGlobalMapping(*fname, Addr);
     }
     return *fname;
@@ -1719,7 +1717,7 @@ static void jl_add_to_ee(orc::ThreadSafeModule &M, StringMap<orc::ThreadSafeModu
 }
 
 
-static uint64_t getAddressForFunction(StringRef fname)
+static JITTargetAddress getAddressForFunction(StringRef fname)
 {
     auto addr = jl_ExecutionEngine->getFunctionAddress(fname);
     assert(addr);
@@ -1729,7 +1727,7 @@ static uint64_t getAddressForFunction(StringRef fname)
 // helper function for adding a DLLImport (dlsym) address to the execution engine
 void add_named_global(StringRef name, void *addr)
 {
-    jl_ExecutionEngine->addGlobalMapping(name, (uint64_t)(uintptr_t)addr);
+    jl_ExecutionEngine->addGlobalMapping(name, pointerToJITTargetAddress(addr));
 }
 
 extern "C" JL_DLLEXPORT

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -410,14 +410,14 @@ public:
 #endif
 
     orc::SymbolStringPtr mangle(StringRef Name);
-    void addGlobalMapping(StringRef Name, uint64_t Addr);
+    void addGlobalMapping(StringRef Name, JITTargetAddress Addr);
     void addModule(orc::ThreadSafeModule M);
 
     JL_JITSymbol findSymbol(StringRef Name, bool ExportedSymbolsOnly);
     JL_JITSymbol findUnmangledSymbol(StringRef Name);
-    uint64_t getGlobalValueAddress(StringRef Name);
-    uint64_t getFunctionAddress(StringRef Name);
-    StringRef getFunctionAtAddress(uint64_t Addr, jl_code_instance_t *codeinst);
+    JITTargetAddress getGlobalValueAddress(StringRef Name);
+    JITTargetAddress getFunctionAddress(StringRef Name);
+    StringRef getFunctionAtAddress(JITTargetAddress Addr, jl_code_instance_t *codeinst);
     auto getContext() {
         return *ContextPool;
     }
@@ -470,7 +470,7 @@ private:
     //Map and inc are guarded by RLST_mutex
     std::mutex RLST_mutex{};
     int RLST_inc = 0;
-    DenseMap<void*, std::string> ReverseLocalSymbolTable;
+    DenseMap<JITTargetAddress, orc::SymbolStringPtr> ReverseLocalSymbolTable;
 
     //Compilation streams
     jl_locked_stream dump_emitted_mi_name_stream;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -417,7 +417,10 @@ public:
     JL_JITSymbol findUnmangledSymbol(StringRef Name);
     JITTargetAddress getGlobalValueAddress(StringRef Name);
     JITTargetAddress getFunctionAddress(StringRef Name);
+
     StringRef getFunctionAtAddress(JITTargetAddress Addr, jl_code_instance_t *codeinst);
+    JITTargetAddress getAssemblyPointer(StringRef Name);
+
     auto getContext() {
         return *ContextPool;
     }
@@ -457,6 +460,7 @@ private:
     std::string getMangledName(StringRef Name);
     std::string getMangledName(const GlobalValue *GV);
     void shareStrings(Module &M);
+    void registerGlobalName(StringRef Name, JITTargetAddress Addr);
 
     const std::unique_ptr<TargetMachine> TM;
     const DataLayout DL;


### PR DESCRIPTION
For compile on demand to support native code introspection, we need to do a reverse lookup to identify the function name from the stub pointer. This PR just sets up the machinery required to make use of the reverse lookup table, without actually performing the reverse lookup (since we don't support compile on demand yet). There's also a few additional changes rolled in (more use of JITTargetAddress vs uint64_t, using interned strings to try to save on the memory in the reverse lookup table). 