### PR TITLE
== and missing relationship should be more clear

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -61,8 +61,24 @@ This operator follows IEEE semantics for floating-point numbers: `0.0 == -0.0` a
 The result is of type `Bool`, except when one of the operands is [`missing`](@ref),
 in which case `missing` is returned
 ([three-valued logic](https://en.wikipedia.org/wiki/Three-valued_logic)).
-For collections, `missing` is returned if at least one of the operands contains
-a `missing` value and all non-missing values are equal.
+
+For collections, `missing` is returned if at least one of the operands contains a
+`missing` value and `==` performed element-wise on the operands does not contain
+`false` in the returned value. Otherwise, `false` is returned:
+```jldoctests
+julia> (missing, 1, 10) .== (21, 1, 10)
+(missing, true, true)
+
+julia> (missing, 1, 10) == (21, 1, 10)
+missing
+
+julia> (missing, 1, 10) .== (10, 1, 44)
+(missing, true, false)
+
+julia> (missing, 1, 10) == (10, 1, 44)
+false
+```
+
 Use [`isequal`](@ref) or [`===`](@ref) to always get a `Bool` result.
 
 # Implementation


### PR DESCRIPTION
Regarding the returned value of a collection when compared with `==` and one of the operands contains `missing`, this is what the function doc currently say:
```julia
For collections, missing is returned if at least one of the operands contains a missing value
and all non-missing values are equal.
```

The above introduces a little headache for anyone new to these system of things.

All `non-missing values are equal` can be viewed from different angles:
- order isn't important, they just have to be equal once `missing` is removed, since its says all non-missing value:
```julia
julia> [missing, 1, 10] == [missing, 1, 10]
missing

julia> [missing, 1, 10] == [1, 10, missing]
false
```
They both should have returned `missing` since we assume `missing` is removed and then we have `[1, 10] == [1, 10]`. 

But this isn't true since the `missing` affects the order. But then the doc says `all non-missing value`, so if `missing` is removed what stands in there to make `[missing, 1, 10] == [1, 10, missing]` return `false`.

It goes on and on with confusion, and the real deal is `missing` is never removed as the current doc tries to say it with `all non-missing value`.

I was confused about this until I asked on slack. So long story short, if viewed from the angle where each elements in the operands are compared element-wise to each other, then it becomes clearer on where `missing` and `false` is returned.

The current `all non-missing` values just complicates understanding.