### PR TITLE
staticdata: avoid needing unaligned loads

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -188,11 +188,6 @@ static jl_typename_t *jl_idtable_typename = NULL;
 static jl_value_t *jl_bigint_type = NULL;
 static int gmp_limb_size = 0;
 
-static void write_uint64(ios_t *s, uint64_t i) JL_NOTSAFEPOINT
-{
-    ios_write(s, (char*)&i, 8);
-}
-
 static void write_float64(ios_t *s, double x) JL_NOTSAFEPOINT
 {
     write_uint64(s, *((uint64_t*)&x));
@@ -1049,7 +1044,7 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
         }
         else {
             write_uint8(s->s, TAG_INT64);
-            write_int64(s->s, *(int64_t*)data);
+            write_uint64(s->s, *(int64_t*)data);
         }
     }
     else if (jl_typeis(v, jl_int32_type)) {
@@ -1626,7 +1621,7 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t **udepsp)
         ios_seek(s, initial_pos);
         write_uint64(s, pos - initial_pos);
         ios_seek(s, pos);
-        write_int64(s, 0);
+        write_uint64(s, 0);
     }
     return pos;
 }
@@ -2939,7 +2934,7 @@ JL_DLLEXPORT int jl_save_incremental(const char *fname, jl_array_t *worklist)
         // Go back and update the source-text position to point to the current position
         int64_t posfile = ios_pos(&f);
         ios_seek(&f, srctextpos);
-        write_int64(&f, posfile);
+        write_uint64(&f, posfile);
         ios_seek_end(&f);
         // Each source-text file is written as
         //   int32: length of abspath

--- a/src/ircode.c
+++ b/src/ircode.c
@@ -80,7 +80,7 @@ static void jl_encode_as_indexed_root(jl_ircode_state *s, jl_value_t *v)
     assert(id >= 0);
     if (rr.key) {
         write_uint8(s->s, TAG_RELOC_METHODROOT);
-        write_int64(s->s, rr.key);
+        write_uint64(s->s, rr.key);
     }
     if (id < 256) {
         write_uint8(s->s, TAG_METHODROOT);
@@ -283,7 +283,7 @@ static void jl_encode_value_(jl_ircode_state *s, jl_value_t *v, int as_literal) 
         }
         else {
             write_uint8(s->s, TAG_INT64);
-            write_int64(s->s, *(int64_t*)data);
+            write_uint64(s->s, *(int64_t*)data);
         }
     }
     else if (jl_typeis(v, jl_int32_type)) {

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -92,7 +92,7 @@ static inline uint64_t read_uint64(ios_t *s) JL_NOTSAFEPOINT
     return x;
 }
 
-static inline void write_int64(ios_t *s, int64_t i) JL_NOTSAFEPOINT
+static inline void write_uint64(ios_t *s, uint64_t i) JL_NOTSAFEPOINT
 {
     ios_write(s, (char*)&i, 8);
 }
@@ -120,6 +120,19 @@ static inline uint32_t read_uint32(ios_t *s) JL_NOTSAFEPOINT
     ios_read(s, (char*)&x, 4);
     return x;
 }
+
+#ifdef _P64
+#define write_uint(s, i) write_uint64(s, i)
+#else
+#define write_uint(s, i) write_uint32(s, i)
+#endif
+
+#ifdef _P64
+#define read_uint(s) read_uint64(s)
+#else
+#define read_uint(s) read_uint32(s)
+#endif
+
 
 void *jl_lookup_ser_tag(jl_value_t *v);
 void *jl_lookup_common_symbol(jl_value_t *v);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -363,9 +363,28 @@ typedef enum {
 } jl_callingconv_t;
 
 
+//#ifdef _P64
+//#define RELOC_TAG_OFFSET 61
+//#else
 // this supports up to 8 RefTags, 512MB of pointer data, and 4/2 (64/32-bit) GB of constant data.
-// if a larger size is required, will need to add support for writing larger relocations in many cases below
 #define RELOC_TAG_OFFSET 29
+//#endif
+
+#if RELOC_TAG_OFFSET <= 32
+typedef uint32_t reloc_t;
+#else
+typedef uint64_t reloc_t;
+#endif
+static void write_reloc_t(ios_t *s, uintptr_t reloc_id) JL_NOTSAFEPOINT
+{
+    if (sizeof(reloc_t) <= sizeof(uint32_t)) {
+        assert(reloc_id < UINT32_MAX);
+        write_uint32(s, reloc_id);
+    }
+    else {
+        write_uint64(s, reloc_id);
+    }
+}
 
 // --- Static Compile ---
 
@@ -631,10 +650,9 @@ static void record_gvar(jl_serializer_state *s, int gid, uintptr_t reloc_id) JL_
 {
     if (gid == 0)
         return;
-    ios_ensureroom(s->gvar_record, gid * sizeof(uint32_t));
-    ios_seek(s->gvar_record, (gid - 1) * sizeof(uint32_t));
-    assert(reloc_id < UINT32_MAX);
-    write_uint32(s->gvar_record, reloc_id);
+    ios_ensureroom(s->gvar_record, gid * sizeof(reloc_t));
+    ios_seek(s->gvar_record, (gid - 1) * sizeof(reloc_t));
+    write_reloc_t(s->gvar_record, reloc_id);
 }
 
 
@@ -653,7 +671,7 @@ static void write_padding(ios_t *s, size_t nb) JL_NOTSAFEPOINT
 static void write_pointer(ios_t *s) JL_NOTSAFEPOINT
 {
     assert((ios_pos(s) & (sizeof(void*) - 1)) == 0 && "stream misaligned for writing a word-sized value");
-    write_padding(s, sizeof(void*));
+    write_uint(s, 0);
 }
 
 // Return the integer `id` for `v`. Generically this is looked up in `backref_table`,
@@ -1108,18 +1126,20 @@ static void jl_write_values(jl_serializer_state *s)
                                     assert(invokeptr_id > 0);
                                     ios_ensureroom(s->fptr_record, invokeptr_id * sizeof(void*));
                                     ios_seek(s->fptr_record, (invokeptr_id - 1) * sizeof(void*));
-                                    write_uint32(s->fptr_record, ~reloc_offset);
+                                    write_reloc_t(s->fptr_record, (uint32_t)~reloc_offset);
 #ifdef _P64
-                                    write_padding(s->fptr_record, 4);
+                                    if (sizeof(reloc_t) < 8)
+                                        write_padding(s->fptr_record, 8 - sizeof(reloc_t));
 #endif
                                 }
                                 if (specfptr_id) {
                                     assert(specfptr_id > invokeptr_id && specfptr_id > 0);
                                     ios_ensureroom(s->fptr_record, specfptr_id * sizeof(void*));
                                     ios_seek(s->fptr_record, (specfptr_id - 1) * sizeof(void*));
-                                    write_uint32(s->fptr_record, reloc_offset);
+                                    write_reloc_t(s->fptr_record, reloc_offset);
 #ifdef _P64
-                                    write_padding(s->fptr_record, 4);
+                                    if (sizeof(reloc_t) < 8)
+                                        write_padding(s->fptr_record, 8 - sizeof(reloc_t));
 #endif
                                 }
                             }
@@ -1242,14 +1262,6 @@ static void jl_write_gv_tagrefs(jl_serializer_state *s)
     }
 }
 
-static inline uint32_t load_uint32(uintptr_t *base)
-{
-    uint32_t v = jl_load_unaligned_i32((void*)*base);
-    *base += 4;
-    return v;
-}
-
-
 // In deserialization, create Symbols and set up the
 // index for backreferencing
 static void jl_read_symbols(jl_serializer_state *s)
@@ -1258,7 +1270,8 @@ static void jl_read_symbols(jl_serializer_state *s)
     uintptr_t base = (uintptr_t)&s->symbols->buf[0];
     uintptr_t end = base + s->symbols->size;
     while (base < end) {
-        uint32_t len = load_uint32(&base);
+        uint32_t len = jl_load_unaligned_i32((void*)base);
+        base += 4;
         const char *str = (const char*)base;
         base += len + 1;
         //printf("symbol %3d: %s\n", len, str);
@@ -1316,7 +1329,7 @@ static uintptr_t get_reloc_for_item(uintptr_t reloc_item, size_t reloc_offset)
 }
 
 // Compute target location at deserialization
-static inline uintptr_t get_item_for_reloc(jl_serializer_state *s, uintptr_t base, size_t size, uint32_t reloc_id)
+static inline uintptr_t get_item_for_reloc(jl_serializer_state *s, uintptr_t base, size_t size, uintptr_t reloc_id)
 {
     enum RefTags tag = (enum RefTags)(reloc_id >> RELOC_TAG_OFFSET);
     size_t offset = (reloc_id & (((uintptr_t)1 << RELOC_TAG_OFFSET) - 1));
@@ -1388,10 +1401,9 @@ static void jl_write_skiplist(ios_t *s, char *base, size_t size, arraylist_t *li
         *pv = get_reloc_for_item(item, *pv);
         // record pos in relocations list
         // TODO: save space by using delta-compression
-        assert(pos < UINT32_MAX);
-        write_uint32(s, pos);
+        write_reloc_t(s, pos);
     }
-    write_uint32(s, 0);
+    write_reloc_t(s, 0);
 }
 
 
@@ -1408,9 +1420,8 @@ static void jl_read_relocations(jl_serializer_state *s, uint8_t bits)
     uintptr_t base = (uintptr_t)&s->s->buf[0];
     size_t size = s->s->size;
     while (1) {
-        uintptr_t val = (uintptr_t)&s->relocs->buf[s->relocs->bpos];
-        uint32_t offset = load_uint32(&val);
-        s->relocs->bpos += sizeof(uint32_t);
+        uintptr_t offset = *(reloc_t*)&s->relocs->buf[(uintptr_t)s->relocs->bpos];
+        s->relocs->bpos += sizeof(reloc_t);
         if (offset == 0)
             break;
         uintptr_t *pv = (uintptr_t*)(base + offset);
@@ -1420,16 +1431,17 @@ static void jl_read_relocations(jl_serializer_state *s, uint8_t bits)
     }
 }
 
-static char* sysimg_base;
-static char* sysimg_relocs;
+static char *sysimg_base;
+static char *sysimg_relocs;
 void gc_sweep_sysimg(void)
 {
-    uintptr_t base = (uintptr_t)sysimg_base;
-    uintptr_t relocs = (uintptr_t)sysimg_relocs;
-    if (relocs == 0)
+    char *base = sysimg_base;
+    reloc_t *relocs = (reloc_t*)sysimg_relocs;
+    if (relocs == NULL)
         return;
     while (1) {
-        uint32_t offset = load_uint32(&relocs);
+        uintptr_t offset = *relocs;
+        relocs++;
         if (offset == 0)
             break;
         jl_taggedvalue_t *o = (jl_taggedvalue_t*)(base + offset);
@@ -1441,13 +1453,12 @@ void gc_sweep_sysimg(void)
 static void _jl_write_value(jl_serializer_state *s, jl_value_t *v)
 {
     if (v == NULL) {
-        write_uint32(s->s, 0);
+        write_reloc_t(s->s, 0);
         return;
     }
     uintptr_t item = backref_id(s, v);
     uintptr_t reloc = get_reloc_for_item(item, 0);
-    assert(reloc < UINT32_MAX);
-    write_uint32(s->s, reloc);
+    write_reloc_t(s->s, reloc);
 }
 
 
@@ -1455,9 +1466,8 @@ static jl_value_t *jl_read_value(jl_serializer_state *s)
 {
     uintptr_t base = (uintptr_t)&s->s->buf[0];
     size_t size = s->s->size;
-    uintptr_t val = base + s->s->bpos;
-    uint32_t offset = load_uint32(&val);
-    s->s->bpos += sizeof(uint32_t);
+    uintptr_t offset = *(reloc_t*)(base + (uintptr_t)s->s->bpos);
+    s->s->bpos += sizeof(reloc_t);
     if (offset == 0)
         return NULL;
     return (jl_value_t*)get_item_for_reloc(s, base, size, offset);
@@ -1480,12 +1490,11 @@ static void jl_update_all_fptrs(jl_serializer_state *s)
     jl_method_instance_t **linfos = (jl_method_instance_t**)&s->fptr_record->buf[0];
     uint32_t clone_idx = 0;
     for (i = 0; i < sysimg_fvars_max; i++) {
-        uintptr_t val = (uintptr_t)&linfos[i];
-        uint32_t offset = load_uint32(&val);
+        reloc_t offset = *(reloc_t*)&linfos[i];
         linfos[i] = NULL;
         if (offset != 0) {
             int specfunc = 1;
-            if (offset & ((uintptr_t)1 << (8 * sizeof(uint32_t) - 1))) {
+            if (offset & ((uintptr_t)1 << (8 * sizeof(reloc_t) - 1))) {
                 // if high bit is set, this is the func wrapper, not the specfunc
                 specfunc = 0;
                 offset = ~offset;
@@ -1527,15 +1536,16 @@ static void jl_update_all_gvars(jl_serializer_state *s)
     size_t gvname_index = 0;
     uintptr_t base = (uintptr_t)&s->s->buf[0];
     size_t size = s->s->size;
-    uintptr_t gvars = (uintptr_t)&s->gvar_record->buf[0];
-    uintptr_t end = gvars + s->gvar_record->size;
+    reloc_t *gvars = (reloc_t*)&s->gvar_record->buf[0];
+    reloc_t *end = gvars + s->gvar_record->size / sizeof(reloc_t);
     while (gvars < end) {
-        uint32_t offset = load_uint32(&gvars);
+        uintptr_t offset = *gvars;
         if (offset) {
             uintptr_t v = get_item_for_reloc(s, base, size, offset);
             *sysimg_gvars(sysimg_gvars_base, gvname_index) = v;
         }
         gvname_index += 1;
+        gvars++;
     }
 }
 
@@ -1551,14 +1561,14 @@ static void jl_finalize_serializer(jl_serializer_state *s, arraylist_t *list)
         size_t item = (size_t)list->items[i];
         size_t reloc_offset = (size_t)layout_table.items[item];
         assert(reloc_offset != 0);
-        write_uint32(s->s, (uint32_t)reloc_offset);
-        write_uint32(s->s, (uint32_t)((uintptr_t)list->items[i + 1]));
+        write_reloc_t(s->s, reloc_offset);
+        write_uint8(s->s, (uintptr_t)list->items[i + 1]);
     }
-    write_uint32(s->s, 0);
+    write_reloc_t(s->s, 0);
 }
 
 
-static void jl_reinit_item(jl_value_t *v, int how) JL_GC_DISABLED
+static void jl_reinit_item(jl_value_t *v, uint8_t how) JL_GC_DISABLED
 {
     switch (how) {
         case 1: { // rehash IdDict
@@ -1610,11 +1620,17 @@ static void jl_finalize_deserializer(jl_serializer_state *s) JL_GC_DISABLED
     // run reinitialization functions
     uintptr_t base = (uintptr_t)&s->s->buf[0];
     while (1) {
-        size_t offset = read_uint32(s->s);
+        size_t offset;
+        if (sizeof(reloc_t) <= 4) {
+            offset = read_uint32(s->s);
+        }
+        else {
+            offset = read_uint64(s->s);
+        }
         if (offset == 0)
             break;
         jl_value_t *v = (jl_value_t*)(base + offset);
-        jl_reinit_item(v, read_uint32(s->s));
+        jl_reinit_item(v, read_uint8(s->s));
     }
 }
 
@@ -1945,7 +1961,7 @@ static void jl_save_system_image_to_stream(ios_t *f) JL_GC_DISABLED
     }
 
     { // step 2: build all the sysimg sections
-        write_padding(&sysimg, sizeof(uint32_t));
+        write_padding(&sysimg, sizeof(uintptr_t));
         jl_write_values(&s);
         jl_write_relocations(&s);
         jl_write_gv_syms(&s, jl_get_root_symbol());
@@ -1961,7 +1977,7 @@ static void jl_save_system_image_to_stream(ios_t *f) JL_GC_DISABLED
         );
         jl_exit(1);
     }
-    if (const_data.size > ((uintptr_t)1 << RELOC_TAG_OFFSET)*sizeof(void*)) {
+    if (const_data.size / sizeof(void*) > ((uintptr_t)1 << RELOC_TAG_OFFSET)) {
         jl_printf(
             JL_STDERR,
             "ERROR: system image too large: const_data.size is %jd but the limit is %" PRIxPTR "\n",
@@ -1972,40 +1988,45 @@ static void jl_save_system_image_to_stream(ios_t *f) JL_GC_DISABLED
     }
 
     // step 3: combine all of the sections into one file
-    write_uint32(f, sysimg.size - sizeof(uint32_t));
-    ios_seek(&sysimg, sizeof(uint32_t));
+    write_uint(f, sysimg.size - sizeof(uintptr_t));
+    ios_seek(&sysimg, sizeof(uintptr_t));
     ios_copyall(f, &sysimg);
     ios_close(&sysimg);
 
-    write_uint32(f, const_data.size);
+    write_uint(f, const_data.size);
     // realign stream to max-alignment for data
-    write_padding(f, LLT_ALIGN(ios_pos(f), 16) - ios_pos(f));
+    write_padding(f, LLT_ALIGN(ios_pos(f), JL_CACHE_BYTE_ALIGNMENT) - ios_pos(f));
     ios_seek(&const_data, 0);
     ios_copyall(f, &const_data);
     ios_close(&const_data);
 
-    write_uint32(f, symbols.size);
+    write_uint(f, symbols.size);
+    write_padding(f, LLT_ALIGN(ios_pos(f), 8) - ios_pos(f));
     ios_seek(&symbols, 0);
     ios_copyall(f, &symbols);
     ios_close(&symbols);
 
-    write_uint32(f, relocs.size);
+    write_uint(f, relocs.size);
+    write_padding(f, LLT_ALIGN(ios_pos(f), 8) - ios_pos(f));
     ios_seek(&relocs, 0);
     ios_copyall(f, &relocs);
     ios_close(&relocs);
 
-    write_uint32(f, gvar_record.size);
+    write_uint(f, gvar_record.size);
+    write_padding(f, LLT_ALIGN(ios_pos(f), 8) - ios_pos(f));
     ios_seek(&gvar_record, 0);
     ios_copyall(f, &gvar_record);
     ios_close(&gvar_record);
 
-    write_uint32(f, fptr_record.size);
+    write_uint(f, fptr_record.size);
+    write_padding(f, LLT_ALIGN(ios_pos(f), 8) - ios_pos(f));
     ios_seek(&fptr_record, 0);
     ios_copyall(f, &fptr_record);
     ios_close(&fptr_record);
 
     { // step 4: record locations of special roots
         s.s = f;
+        write_padding(f, LLT_ALIGN(ios_pos(f), 8) - ios_pos(f));
         size_t i;
         for (i = 0; tags[i] != NULL; i++) {
             jl_value_t *tag = *tags[i];
@@ -2014,8 +2035,8 @@ static void jl_save_system_image_to_stream(ios_t *f) JL_GC_DISABLED
         jl_write_value(&s, jl_global_roots_table);
         jl_write_value(&s, s.ptls->root_task->tls);
         write_uint32(f, jl_get_gs_ctr());
-        write_uint32(f, jl_atomic_load_acquire(&jl_world_counter));
-        write_uint32(f, jl_typeinf_world);
+        write_uint(f, jl_atomic_load_acquire(&jl_world_counter));
+        write_uint(f, jl_typeinf_world);
         jl_finalize_serializer(&s, &reinit_list);
         jl_finalize_serializer(&s, &ccallable_list);
     }
@@ -2102,37 +2123,43 @@ static void jl_restore_system_image_from_stream(ios_t *f) JL_GC_DISABLED
 
     // step 1: read section map
     assert(ios_pos(f) == 0 && f->bm == bm_mem);
-    size_t sizeof_sysimg = read_uint32(f);
-    ios_static_buffer(&sysimg, f->buf, sizeof_sysimg + sizeof(uint32_t));
+    size_t sizeof_sysimg = read_uint(f);
+    ios_static_buffer(&sysimg, f->buf, sizeof_sysimg + sizeof(uintptr_t));
     ios_skip(f, sizeof_sysimg);
 
-    size_t sizeof_constdata = read_uint32(f);
+    size_t sizeof_constdata = read_uint(f);
     // realign stream to max-alignment for data
-    ios_seek(f, LLT_ALIGN(ios_pos(f), 16));
+    ios_seek(f, LLT_ALIGN(ios_pos(f), JL_CACHE_BYTE_ALIGNMENT));
     ios_static_buffer(&const_data, f->buf + f->bpos, sizeof_constdata);
     ios_skip(f, sizeof_constdata);
 
-    size_t sizeof_symbols = read_uint32(f);
+    size_t sizeof_symbols = read_uint(f);
+    ios_seek(f, LLT_ALIGN(ios_pos(f), 8));
     ios_static_buffer(&symbols, f->buf + f->bpos, sizeof_symbols);
     ios_skip(f, sizeof_symbols);
 
-    size_t sizeof_relocations = read_uint32(f);
+    size_t sizeof_relocations = read_uint(f);
+    ios_seek(f, LLT_ALIGN(ios_pos(f), 8));
     assert(!ios_eof(f));
     ios_static_buffer(&relocs, f->buf + f->bpos, sizeof_relocations);
     ios_skip(f, sizeof_relocations);
 
-    size_t sizeof_gvar_record = read_uint32(f);
+    size_t sizeof_gvar_record = read_uint(f);
+    ios_seek(f, LLT_ALIGN(ios_pos(f), 8));
     assert(!ios_eof(f));
     ios_static_buffer(&gvar_record, f->buf + f->bpos, sizeof_gvar_record);
     ios_skip(f, sizeof_gvar_record);
 
-    size_t sizeof_fptr_record = read_uint32(f);
+    size_t sizeof_fptr_record = read_uint(f);
+    ios_seek(f, LLT_ALIGN(ios_pos(f), 8));
     assert(!ios_eof(f));
     ios_static_buffer(&fptr_record, f->buf + f->bpos, sizeof_fptr_record);
     ios_skip(f, sizeof_fptr_record);
 
     // step 2: get references to special values
     s.s = f;
+    ios_seek(f, LLT_ALIGN(ios_pos(f), 8));
+    assert(!ios_eof(f));
     size_t i;
     for (i = 0; tags[i] != NULL; i++) {
         jl_value_t **tag = tags[i];
@@ -2148,8 +2175,8 @@ static void jl_restore_system_image_from_stream(ios_t *f) JL_GC_DISABLED
     jl_init_box_caches();
 
     uint32_t gs_ctr = read_uint32(f);
-    jl_atomic_store_release(&jl_world_counter, read_uint32(f));
-    jl_typeinf_world = read_uint32(f);
+    jl_atomic_store_release(&jl_world_counter, read_uint(f));
+    jl_typeinf_world = read_uint(f);
     jl_set_gs_ctr(gs_ctr);
     s.s = NULL;
 


### PR DESCRIPTION
Noted by @apaz-cli, there is no reason these need to be unaligned loads, since they are in very simple sections of the system image