### PR TITLE
Update doc on global variables type annotations

### DIFF
--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -108,9 +108,26 @@ local x::Int8  # in a local declaration
 x::Int8 = 10   # as the left-hand side of an assignment
 ```
 
-and applies to the whole current scope, even before the declaration. Currently, type declarations
-cannot be used in global scope, e.g. in the REPL, since Julia does not yet have constant-type
-globals.
+and applies to the whole current scope, even before the declaration.
+
+As of Julia 1.8 and later versions, type declarations can now be used in global scope i.e.
+type annotations can be added to global variables to make accessing them type stable.
+```julia
+julia> x::Int = 10
+10
+
+julia> x = 3.5
+ERROR: InexactError: Int64(3.5)
+
+julia> function foo(y)
+           global x = 15.8    # throws an error when foo is called
+           return x + y
+       end
+foo (generic function with 1 method)
+
+julia> foo(10)
+ERROR: InexactError: Int64(15.8)
+```
 
 Declarations can also be attached to function definitions:
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -110,7 +110,7 @@ x::Int8 = 10   # as the left-hand side of an assignment
 
 and applies to the whole current scope, even before the declaration.
 
-As of Julia 1.8 and later versions, type declarations can now be used in global scope i.e.
+As of Julia 1.8, type declarations can now be used in global scope i.e.
 type annotations can be added to global variables to make accessing them type stable.
 ```julia
 julia> x::Int = 10


### PR DESCRIPTION
Closes  #46682 

> Currently, type declarations cannot be used in global scope, e.g. in the REPL, since Julia does not yet have constant-type globals.