### PR TITLE
@ref error on ⊈

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -366,7 +366,7 @@ function ⊋ end
 
 Determines if `a` is a subset of, but not equal to, `b`.
 
-See also [`issubset`](@ref) (`⊆`), [`⊈`](@ref).
+See also [`issubset`](@ref), [`⊆`](@ref), [`⊈`](@ref).
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
No @ref provided on `⊆` and also `isusbset` not spaced with comma.