### PR TITLE
add `nospecialize` to deepcopy entry point

### DIFF
--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -21,7 +21,7 @@ so far within the recursion. Within the definition, `deepcopy_internal` should b
 in place of `deepcopy`, and the `dict` variable should be
 updated as appropriate before returning.
 """
-function deepcopy(x)
+function deepcopy(@nospecialize x)
     isbitstype(typeof(x)) && return x
     return deepcopy_internal(x, IdDict())::typeof(x)
 end


### PR DESCRIPTION
The next functions in the chain have nospecialize, so this probably should too. This works around an LLVM performance problem in a case like this:
```
struct A
    a::Symbol
    b::Int
    c::Symbol
    d::Int
end

fields = Any[:($(Symbol("x",i))::A = A(:x,1,:x,1)) for i = 1:250]

@eval @kwdef struct Big
    $(fields...)
end

@time @eval deepcopy(Big());
```
Goes from 14 seconds to 2 seconds with this PR.

This spends a lot of time compiling due to a large number of load and store instructions. We should try to fix that eventually by improving our LLVM IR not to use first-class aggregates in this case, but that's a bit difficult since our gc pass depends on this type information.