### PR TITLE
in operator with missing on Dicts keys and values

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1305,9 +1305,6 @@ Some collections follow a slightly different definition. For example,
 [`isequal`](@ref). To test for the presence of a key in a dictionary, use [`haskey`](@ref)
 or `k in keys(dict)`. For these collections, the result is always a `Bool` and never `missing`.
 
-To determine whether an item is not in a given collection, see [`∉`](@ref).
-You may also negate the `in` by doing `!(a in b)` which is logically similar to "not in".
-
 When broadcasting with `in.(items, collection)` or `items .∈ collection`, both
 `item` and `collection` are broadcasted over, which is often not what is intended.
 For example, if both arguments are vectors (and the dimensions match), the result is
@@ -1315,6 +1312,8 @@ a vector indicating whether each value in collection `items` is `in` the value a
 corresponding position in `collection`. To get a vector indicating whether each value
 in `items` is in `collection`, wrap `collection` in a tuple or a `Ref` like this:
 `in.(items, Ref(collection))` or `items .∈ Ref(collection)`.
+
+See also: [`∉`](@ref).
 
 # Examples
 ```jldoctest
@@ -1339,17 +1338,8 @@ true
 julia> missing in Set([1, 2])
 false
 
-julia> (missing=>1) in Dict(1=>10, 2=>20, missing=>1)
-true
-
-julia> (1=>missing) in Dict(1=>10, 2=>20, missing=>NaN) # value contains missing
+julia> (1=>missing) in Dict(1=>10, 2=>20)
 missing
-
-julia> !(21 in a)
-true
-
-julia> !(19 in a)
-false
 
 julia> [1, 2] .∈ [2, 3]
 2-element BitVector:

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1300,14 +1300,10 @@ contains `missing` but not `item`, in which case `missing` is returned
 matching the behavior of [`any`](@ref) and [`==`](@ref)).
 
 Some collections follow a slightly different definition. For example,
-[`Set`](@ref)s check whether the item [`isequal`](@ref) to one of the elements.
-[`Dict`](@ref)s look for `key=>value` pairs, and the `key` (not the `value`)
-is compared using [`isequal`](@ref). To test for the presence of a key in
-a dictionary, use [`haskey`](@ref) or `k in keys(dict)`.
-
-For [`Set`](@ref)s, the result is always a `Bool`. As for [`Dict`](@ref)s,
-the result is always a `Bool` if `value` in `(key=>value) in Dict` is not
-`missing`, otherwise `missing` is returned.
+[`Set`](@ref)s check whether the item [`isequal`](@ref) to one of the elements;
+[`Dict`](@ref)s look for `key=>value` pairs, and the `key` is compared using
+[`isequal`](@ref). To test for the presence of a key in a dictionary, use [`haskey`](@ref)
+or `k in keys(dict)`. For these collections, the result is always a `Bool` and never `missing`.
 
 To determine whether an item is not in a given collection, see [`∉`](@ref).
 You may also negate the `in` by doing `!(a in b)` which is logically similar to "not in".
@@ -1343,10 +1339,10 @@ true
 julia> missing in Set([1, 2])
 false
 
-julia> (missing=>NaN) in Dict(1=>10, 2=>20, 3=>30, missing=>NaN)
-false
+julia> (missing=>1) in Dict(1=>10, 2=>20, missing=>1)
+true
 
-julia> (2=>missing) in Dict(1=>10, 2=>20, 3=>30, missing=>NaN)
+julia> (1=>missing) in Dict(1=>10, 2=>20, missing=>NaN) # value contains missing
 missing
 
 julia> !(21 in a)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1305,7 +1305,8 @@ Some collections follow a slightly different definition. For example,
 [`isequal`](@ref).
 
 To test for the presence of a key in a dictionary, use [`haskey`](@ref)
-or `k in keys(dict)`. For these collections, the result is always a `Bool` and never `missing`.
+or `k in keys(dict)`. For the collections mentioned above,
+the result is always a `Bool`.
 
 When broadcasting with `in.(items, collection)` or `items .∈ collection`, both
 `item` and `collection` are broadcasted over, which is often not what is intended.

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1302,7 +1302,9 @@ matching the behavior of [`any`](@ref) and [`==`](@ref)).
 Some collections follow a slightly different definition. For example,
 [`Set`](@ref)s check whether the item [`isequal`](@ref) to one of the elements;
 [`Dict`](@ref)s look for `key=>value` pairs, and the `key` is compared using
-[`isequal`](@ref). To test for the presence of a key in a dictionary, use [`haskey`](@ref)
+[`isequal`](@ref).
+
+To test for the presence of a key in a dictionary, use [`haskey`](@ref)
 or `k in keys(dict)`. For these collections, the result is always a `Bool` and never `missing`.
 
 When broadcasting with `in.(items, collection)` or `items .∈ collection`, both

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1303,8 +1303,11 @@ Some collections follow a slightly different definition. For example,
 [`Set`](@ref)s check whether the item [`isequal`](@ref) to one of the elements.
 [`Dict`](@ref)s look for `key=>value` pairs, and the key is compared using
 [`isequal`](@ref). To test for the presence of a key in a dictionary,
-use [`haskey`](@ref) or `k in keys(dict)`. For these collections, the result
-is always a `Bool` and never `missing`.
+use [`haskey`](@ref) or `k in keys(dict)`.
+
+For [`Set`](@ref)s, the result is always a `Bool`. As for [`Dict`](@ref)s,
+the result is always a `Bool` if `value` in `(key=>value) in Dict` is not
+`missing`, otherwise `missing` is returned.
 
 To determine whether an item is not in a given collection, see [`∉`](@ref).
 You may also negate the `in` by doing `!(a in b)` which is logically similar to "not in".
@@ -1339,6 +1342,12 @@ true
 
 julia> missing in Set([1, 2])
 false
+
+julia> (missing=>NaN) in Dict(1=>10, 2=>20, 3=>30, missing=>NaN)
+false
+
+julia> (2=>missing) in Dict(1=>10, 2=>20, 3=>30, missing=>NaN)
+missing
 
 julia> !(21 in a)
 true

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1301,9 +1301,9 @@ matching the behavior of [`any`](@ref) and [`==`](@ref)).
 
 Some collections follow a slightly different definition. For example,
 [`Set`](@ref)s check whether the item [`isequal`](@ref) to one of the elements.
-[`Dict`](@ref)s look for `key=>value` pairs, and the key is compared using
-[`isequal`](@ref). To test for the presence of a key in a dictionary,
-use [`haskey`](@ref) or `k in keys(dict)`.
+[`Dict`](@ref)s look for `key=>value` pairs, and the `key` (not the `value`)
+is compared using [`isequal`](@ref). To test for the presence of a key in
+a dictionary, use [`haskey`](@ref) or `k in keys(dict)`.
 
 For [`Set`](@ref)s, the result is always a `Bool`. As for [`Dict`](@ref)s,
 the result is always a `Bool` if `value` in `(key=>value) in Dict` is not


### PR DESCRIPTION
The statement made here about the `in` operator with `Dicts` is too strong and it has edge cases where it fails:
> Some collections follow a slightly different definition. For example, Sets check whether the item isequal to one of the elements. Dicts look for key=>value pairs, and the key is compared using isequal. To test for the presence of a key in a dictionary, use haskey or k in keys(dict). For these collections, the result is always a Bool and never missing.

On `Sets` the above is utterly true, but the statement fails when the `value` in `key=>value in Dict` is `missing`:
```julia
julia> X = Dict(1=>10, 2=>20, 3=>30, missing=>NaN);

julia> (missing=>10) in X
false

julia> (missing=>NaN) ∈ X
false

julia> (1=>missing) ∈ X
missing

julia> (missing=>missing) ∈ X
missing
```

As the above shows, for `Dict`s, a `Bool` is not always returned. So its best to state this out.

Moreover, since only the `key` is compared using `isequal` for `Dicts`. key should be “`key` (not the `value`)” so emphasis is seen as being placed on `key` only.