### PR TITLE
Make print_sorted_stdlibs robust to stray files

### DIFF
--- a/contrib/print_sorted_stdlibs.jl
+++ b/contrib/print_sorted_stdlibs.jl
@@ -27,9 +27,9 @@ end
 
 project_deps = Dict{String,Set{String}}()
 for project_dir in readdir(STDLIB_DIR, join=true)
-    files = readdir(project_dir)
-    if "Project.toml" in files
-        project = TOML.parsefile(joinpath(project_dir, "Project.toml"))
+    project_file = joinpath(project_dir, "Project.toml")
+    if isfile(project_file)
+        project = TOML.parsefile(project_file)
 
         if !haskey(project, "name")
             continue


### PR DESCRIPTION
It is already robust to stray directories that do not contain Project.toml.
I ran into problems with a .DS_Store file and a .gitignore file.