### PR TITLE
Don't create Type{...} for incomplete types in most cases

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -175,8 +175,8 @@ end
 Broadcasted(f::F, args::Args, axes=nothing) where {F, Args<:Tuple} =
     Broadcasted{typeof(combine_styles(args...))}(f, args, axes)
 function Broadcasted{Style}(f::F, args::Args, axes=nothing) where {Style, F, Args<:Tuple}
-    # using Core.Typeof rather than F preserves inferrability when f is a type
-    Broadcasted{Style, typeof(axes), Core.Typeof(f), Args}(f, args, axes)
+    # using TypeofValid rather than F preserves inferrability when f is a type
+    Broadcasted{Style, typeof(axes), Base.TypeofValid(f), Args}(f, args, axes)
 end
 
 struct AndAnd end

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -1018,7 +1018,7 @@ function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance)
                 tree.pure = true
                 set_inlineable!(tree, true)
                 tree.parent = mi
-                tree.rettype = Core.Typeof(rettype_const)
+                tree.rettype = TypeofValid(rettype_const)
                 tree.min_world = code.min_world
                 tree.max_world = code.max_world
                 return tree
@@ -1101,12 +1101,12 @@ end
 
 function return_type(@nospecialize(f), t::DataType) # this method has a special tfunc
     world = ccall(:jl_get_tls_world_age, UInt, ())
-    args = Any[_return_type, NativeInterpreter(world), Tuple{Core.Typeof(f), t.parameters...}]
+    args = Any[_return_type, NativeInterpreter(world), Tuple{TypeofValid(f), t.parameters...}]
     return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Ptr{Cvoid}}, Cint), args, length(args))
 end
 
 function return_type(@nospecialize(f), t::DataType, world::UInt)
-    return return_type(Tuple{Core.Typeof(f), t.parameters...}, world)
+    return return_type(Tuple{TypeofValid(f), t.parameters...}, world)
 end
 
 function return_type(t::DataType)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -101,7 +101,7 @@ macro deprecate(old, new, export_old=true)
             maybe_export,
             :($(esc(old)) = begin
                   $meta
-                  depwarn($"`$oldcall` is deprecated, use `$newcall` instead.", Core.Typeof($(esc(fnexpr))).name.mt.name)
+                  depwarn($"`$oldcall` is deprecated, use `$newcall` instead.", Base.TypeofValid($(esc(fnexpr))).name.mt.name)
                   $(esc(new))
               end))
     else
@@ -112,7 +112,7 @@ macro deprecate(old, new, export_old=true)
             export_old ? Expr(:export, esc(old)) : nothing,
             :(function $(esc(old))(args...; kwargs...)
                   $meta
-                  depwarn($"`$old` is deprecated, use `$new` instead.", Core.Typeof($(esc(old))).name.mt.name)
+                  depwarn($"`$old` is deprecated, use `$new` instead.", Base.TypeofValid($(esc(old))).name.mt.name)
                   $(esc(new))(args...; kwargs...)
               end))
     end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -175,7 +175,7 @@ function showerror(io::IO, ex::CanonicalIndexError)
     print(io, "CanonicalIndexError: ", ex.func, " not defined for ", ex.type)
 end
 
-typesof(@nospecialize args...) = Tuple{Any[ Core.Typeof(args[i]) for i in 1:length(args) ]...}
+typesof(@nospecialize args...) = Tuple{Any[ Base.TypeofValid(args[i]) for i in 1:length(args) ]...}
 
 function print_with_compare(io::IO, @nospecialize(a::DataType), @nospecialize(b::DataType), color::Symbol)
     if a.name === b.name

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2806,7 +2806,7 @@ end
 Compile the given function `f` for the argument tuple (of types) `argtypes`, but do not execute it.
 """
 function precompile(@nospecialize(f), @nospecialize(argtypes::Tuple))
-    precompile(Tuple{Core.Typeof(f), argtypes...})
+    precompile(Tuple{TypeofValid(f), argtypes...})
 end
 
 const ENABLE_PRECOMPILE_WARNINGS = Ref(false)
@@ -2830,7 +2830,7 @@ a different method than the one that would ordinarily be chosen by dispatch, thu
 mimicking `invoke`.
 """
 function precompile(@nospecialize(f), @nospecialize(argtypes::Tuple), m::Method)
-    precompile(Tuple{Core.Typeof(f), argtypes...}, m)
+    precompile(Tuple{TypeofValid(f), argtypes...}, m)
 end
 
 function precompile(@nospecialize(argt::Type), m::Method)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -906,9 +906,6 @@ julia> [0 1; 2 3] .|> (x -> x^2) |> sum
 """
 |>(x, f) = f(x)
 
-_stable_typeof(x) = typeof(x)
-_stable_typeof(::Type{T}) where {T} = @isdefined(T) ? Type{T} : DataType
-
 """
     f = Returns(value)
 
@@ -935,7 +932,7 @@ julia> f.value
 struct Returns{V} <: Function
     value::V
     Returns{V}(value) where {V} = new{V}(value)
-    Returns(value) = new{_stable_typeof(value)}(value)
+    Returns(value) = new{TypeofValid(value)}(value)
 end
 
 (obj::Returns)(@nospecialize(args...); @nospecialize(kw...)) = obj.value
@@ -1101,8 +1098,7 @@ struct Fix1{F,T} <: Function
     f::F
     x::T
 
-    Fix1(f::F, x) where {F} = new{F,_stable_typeof(x)}(f, x)
-    Fix1(f::Type{F}, x) where {F} = new{Type{F},_stable_typeof(x)}(f, x)
+    Fix1(f, x) = new{TypeofValid(f),TypeofValid(x)}(f, x)
 end
 
 (f::Fix1)(y) = f.f(f.x, y)
@@ -1118,8 +1114,7 @@ struct Fix2{F,T} <: Function
     f::F
     x::T
 
-    Fix2(f::F, x) where {F} = new{F,_stable_typeof(x)}(f, x)
-    Fix2(f::Type{F}, x) where {F} = new{Type{F},_stable_typeof(x)}(f, x)
+    Fix2(f, x) = new{TypeofValid(f),TypeofValid(x)}(f, x)
 end
 
 (f::Fix2)(y) = f.f(y, f.x)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1025,7 +1025,7 @@ struct ComposedFunction{O,I} <: Function
     outer::O
     inner::I
     ComposedFunction{O, I}(outer, inner) where {O, I} = new{O, I}(outer, inner)
-    ComposedFunction(outer, inner) = new{Core.Typeof(outer),Core.Typeof(inner)}(outer, inner)
+    ComposedFunction(outer, inner) = new{TypeofValid(outer),TypeofValid(inner)}(outer, inner)
 end
 
 (c::ComposedFunction)(x...; kw...) = call_composed(unwrap_composed(c), x, kw)
@@ -1256,7 +1256,7 @@ See also [`splat`](@ref).
 """
 struct Splat{F} <: Function
     f::F
-    Splat(f) = new{Core.Typeof(f)}(f)
+    Splat(f) = new{TypeofValid(f)}(f)
 end
 (s::Splat)(args) = s.f(args...)
 print(io::IO, s::Splat) = print(io, "splat(", s.f, ')')

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -664,7 +664,7 @@ end
 
 iskindtype(@nospecialize t) = (t === DataType || t === UnionAll || t === Union || t === typeof(Bottom))
 isconcretedispatch(@nospecialize t) = isconcretetype(t) && !iskindtype(t)
-has_free_typevars(@nospecialize(t)) = ccall(:jl_has_free_typevars, Cint, (Any,), t) != 0
+has_free_typevars(@nospecialize t) = ccall(:jl_has_free_typevars, Cint, (Any,), t) != 0
 
 # equivalent to isa(v, Type) && isdispatchtuple(Tuple{v}) || v === Union{}
 # and is thus perhaps most similar to the old (pre-1.0) `isleaftype` query
@@ -1963,7 +1963,7 @@ Behaves like `Core.Typeof`, except that a type with a free typevar does not get
 turned into `Type` and is thus valid in a signature without further UnionAll
 rewrapping.
 """
-TypeofValid(@nospecialize(x)) = isa(x, Type) && !has_free_typevars(x) ? Type{x} : typeof(x)
+TypeofValid(@nospecialize(x)) = x isa Type && x isa Type{x} ? Type{x} : typeof(x)
 
 """
     @invoke f(arg::T, ...; kwargs...)

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -98,7 +98,7 @@ function gen_call_with_extracted_types(__module__, fcn, ex0, kws=Expr[])
                 local arg1 = $(esc(ex0.args[1]))
                 local args, kwargs = $separate_kwargs($(map(esc, ex0.args[2:end])...))
                 $(fcn)(Core.kwcall,
-                       Tuple{typeof(kwargs), Core.Typeof(arg1), map(Core.Typeof, args)...};
+                       Tuple{typeof(kwargs), Base.TypeofValid(arg1), map(Base.TypeofValid, args)...};
                        $(kws...))
             end
         elseif ex0.head === :call
@@ -146,7 +146,7 @@ function gen_call_with_extracted_types(__module__, fcn, ex0, kws=Expr[])
         end
     end
     if isa(ex0, Expr) && ex0.head === :macrocall # Make @edit @time 1+2 edit the macro by using the types of the *expressions*
-        return Expr(:call, fcn, esc(ex0.args[1]), Tuple{#=__source__=#LineNumberNode, #=__module__=#Module, Any[ Core.Typeof(a) for a in ex0.args[3:end] ]...}, kws...)
+        return Expr(:call, fcn, esc(ex0.args[1]), Tuple{#=__source__=#LineNumberNode, #=__module__=#Module, Any[ Base.TypeofValid(a) for a in ex0.args[3:end] ]...}, kws...)
     end
 
     ex = Meta.lower(__module__, ex0)

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -458,7 +458,7 @@ end
 # Returns the return type. example: get_type(:(Base.strip("", ' ')), Main) returns (SubString{String}, true)
 function try_get_type(sym::Expr, fn::Module)
     val, found = get_value(sym, fn)
-    found && return Core.Typeof(val), found
+    found && return Base.TypeofValid(val), found
     if sym.head === :call
         # getfield call is special cased as the evaluation of getfield provides good type information,
         # is inexpensive and it is also performed in the complete_symbol function.
@@ -517,7 +517,7 @@ end
 
 function get_type(sym, fn::Module)
     val, found = get_value(sym, fn)
-    return found ? Core.Typeof(val) : Any, found
+    return found ? Base.TypeofValid(val) : Any, found
 end
 
 function get_type(T, found::Bool, default_any::Bool)
@@ -565,7 +565,7 @@ function complete_any_methods(ex_org::Expr, callee_module::Module, context_modul
         if !Base.isdeprecated(callee_module, name) && isdefined(callee_module, name) && !startswith(string(name), '#')
             func = getfield(callee_module, name)
             if !isa(func, Module)
-                funct = Core.Typeof(func)
+                funct = Base.TypeofValid(func)
                 if !in(funct, seen)
                     push!(seen, funct)
                     complete_methods!(out, funct, args_ex, kwargs_ex, MAX_ANY_METHOD_COMPLETIONS, false)
@@ -576,7 +576,7 @@ function complete_any_methods(ex_org::Expr, callee_module::Module, context_modul
                     if !Base.isdeprecated(callee_module2, name) && isdefined(callee_module2, name) && !startswith(string(name), '#')
                         func = getfield(callee_module, name)
                         if !isa(func, Module)
-                            funct = Core.Typeof(func)
+                            funct = Base.TypeofValid(func)
                             if !in(funct, seen)
                                 push!(seen, funct)
                                 complete_methods!(out, funct, args_ex, kwargs_ex, MAX_ANY_METHOD_COMPLETIONS, false)


### PR DESCRIPTION
Core.Typeof is used implicitly in the system, but for types with free type parameters, e.g. `Vector{Core.TypeVar(:T)}`, it expects to subsequently be wrapped in a UnionAll. In particular, it is not in general valid to perform type queries on the result of `Core.Typeof` (without wrapping it in a UnionAll), but we were attempting to do so in a number of places. Of course, this is a bit of a rare sitatuation, since we're not in a habit of passing around types with free typevars, but since those are valid objects I think it is better to be defensive.

This introduces `Base.TypeofValid` (better name suggestions welcome), which is like `Core.Typeof`, except that types with free typevars get mapped to `DataType`, rather than `Type{}` with a free typevars. As a result, it is always valid to perform type system operations on the result of this call.