### PR TITLE
sparam inlining: Handle undefined sparams

### DIFF
--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1512,3 +1512,12 @@ end
 # Test getfield modeling of Type{Ref{_A}} where _A
 @test Core.Compiler.getfield_tfunc(Type, Core.Compiler.Const(:parameters)) !== Union{}
 @test fully_eliminated(Base.ismutable, Tuple{Base.RefValue})
+
+# TODO: Remove compute sparams for vararg_retrival
+fvarargN_inline(x::Tuple{Vararg{Int, N}}) where {N} = N
+fvarargN_inline(args...) = fvarargN_inline(args)
+let src = code_typed1(fvarargN_inline, (Tuple{Vararg{Int}},))
+    @test_broken count(iscall((src, Core._compute_sparams)), src.code) == 0 &&
+                 count(iscall((src, Core._svec_ref)), src.code) == 0 &&
+                 count(iscall((src, Core.nfields)), src.code) == 1
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -7831,3 +7831,9 @@ end
 # Correct isdefined error for isdefined of Module of Int fld
 f_isdefined_one(@nospecialize(x)) = isdefined(x, 1)
 @test (try; f_isdefined_one(@__MODULE__); catch err; err; end).got === 1
+
+# Unspecialized retrieval of vararg length
+fvarargN(x::Tuple{Vararg{Int, N}}) where {N} = N
+fvarargN(args...) = fvarargN(args)
+finvokevarargN() = Base.inferencebarrier(fvarargN)(1, 2, 3)
+@test finvokevarargN() == 3


### PR DESCRIPTION
`_compute_sparams` is not required to be able to resolve an sparam, it can leave it as a `TypeVar`, in which case accessing it should throw an UndefVarError. This needs to be appropriately handled in inlining. We have a test case like this in the test suite, but it was being papered over by an incorrect check in can_inline_typevar. Remove that check and implement proper undef checking in inlining.