### PR TITLE
use grep instead of the deprecated egrep

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -705,7 +705,7 @@ JLDFLAGS += $(SANITIZE_LDFLAGS)
 endif # SANITIZE
 
 TAR := $(shell which gtar 2>/dev/null || which tar 2>/dev/null)
-TAR_TEST := $(shell $(TAR) --help 2>&1  | egrep 'bsdtar|strip-components')
+TAR_TEST := $(shell $(TAR) --help 2>&1  | grep -E 'bsdtar|strip-components')
 ifeq (,$(findstring components,$(TAR_TEST)))
 ifneq (bsdtar,$(findstring bsdtar,$(TAR_TEST)))
 $(error "please install either GNU tar or bsdtar")


### PR DESCRIPTION
grep -E is the new (since POSIX) way to use the "extended" regexp.

The latest GNU Grep release complains each time egrep is invoked (egrep is implemented as just a wrapper script around grep).

See:

https://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html

https://www.gnu.org/software/grep/manual/grep.html

Fixes #46649