### PR TITLE
propagate context through a few more printing functions

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -568,11 +568,11 @@ function typeinfo_prefix(io::IO, X)
 
     if X isa AbstractDict
         if eltype_X == eltype_ctx
-            sprint(show_type_name, typeof(X).name), false
+            sprint(show_type_name, typeof(X).name; context=io), false
         elseif !isempty(X) && typeinfo_implicit(keytype(X)) && typeinfo_implicit(valtype(X))
-            sprint(show_type_name, typeof(X).name), true
+            sprint(show_type_name, typeof(X).name; context=io), true
         else
-            string(typeof(X)), false
+            sprint(print, typeof(X); context=io), false
         end
     else
         # Types hard-coded here are those which are created by default for a given syntax
@@ -581,9 +581,9 @@ function typeinfo_prefix(io::IO, X)
         elseif !isempty(X) && typeinfo_implicit(eltype_X)
             "", true
         elseif print_without_params(eltype_X)
-            sprint(show_type_name, unwrap_unionall(eltype_X).name), false # Print "Array" rather than "Array{T,N}"
+            sprint(show_type_name, unwrap_unionall(eltype_X).name; context=io), false # Print "Array" rather than "Array{T,N}"
         else
-            string(eltype_X), false
+            sprint(print, eltype_X; context=io), false
         end
     end
 end


### PR DESCRIPTION
makes `:compact=>false` a way to avoid the expensive typealias checking (which seems to be what's desired looking at https://github.com/JuliaLang/julia/blob/7e51510f70a4d49d7b531f97c16aef8d856cf270/base/show.jl#L954-L960.

Before:

```julia
julia> d = Dict{String, Any}()

julia> @btime repr($d; context=:compact=>false);
  182.768 μs (35 allocations: 27.10 KiB)
```

After:

```julia
julia> d = Dict{String, Any}()

julia> @btime repr($d; context=:compact=>false);
  1.236 μs (22 allocations: 904 bytes)
```

I don't really know how the typealias printing works so not sure how to add a test.