### PR TITLE
remove compat annotations applicable only for pre-LTS

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -120,9 +120,6 @@ has_offset_axes(::Colon) = false
 
 Throw an `ArgumentError` if the indices of any argument start with something other than `1` along any axis.
 See also [`has_offset_axes`](@ref).
-
-!!! compat "Julia 1.2"
-     This function requires at least Julia 1.2.
 """
 require_one_based_indexing(A...) = !has_offset_axes(A...) || throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))
 
@@ -165,9 +162,6 @@ true
 julia> keytype([1 2; 3 4])
 CartesianIndex{2}
 ```
-
-!!! compat "Julia 1.2"
-     For arrays, this function requires at least Julia 1.2.
 """
 keytype(a::AbstractArray) = keytype(typeof(a))
 
@@ -188,9 +182,6 @@ provided mainly for compatibility with the dictionary interface.
 julia> valtype(["one", "two", "three"])
 String
 ```
-
-!!! compat "Julia 1.2"
-     For arrays, this function requires at least Julia 1.2.
 """
 valtype(A::Type{<:AbstractArray}) = eltype(A)
 
@@ -455,9 +446,6 @@ long enough.
 
 See also: [`startswith`](@ref), [`Iterators.take`](@ref).
 
-!!! compat "Julia 1.6"
-    This method requires at least Julia 1.6.
-
 # Examples
 ```jldoctest
 julia> first(["foo", "bar", "qux"], 2)
@@ -504,9 +492,6 @@ last(a) = a[end]
 
 Get the last `n` elements of the iterable collection `itr`, or fewer elements if `itr` is not
 long enough.
-
-!!! compat "Julia 1.6"
-    This method requires at least Julia 1.6.
 
 # Examples
 ```jldoctest
@@ -894,10 +879,6 @@ the call. If `dst` and `src` are multidimensional arrays, they must have
 equal [`axes`](@ref).
 
 See also [`copyto!`](@ref).
-
-!!! compat "Julia 1.1"
-    This method requires at least Julia 1.1. In Julia 1.0 this method
-    is available from the `Future` standard library as `Future.copy!`.
 """
 function copy!(dst::AbstractVector, src::AbstractVector)
     firstindex(dst) == firstindex(src) || throw(ArgumentError(

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -241,9 +241,6 @@ Method `merge!(combine::Union{Function,Type}, args...)` as an alias of
 `mergewith!(combine, args...)` is still available for backward
 compatibility.
 
-!!! compat "Julia 1.5"
-    `mergewith!` requires Julia 1.5 or later.
-
 # Examples
 ```jldoctest
 julia> d1 = Dict(1 => 2, 3 => 4);
@@ -366,9 +363,6 @@ combiner function.  The curried form `mergewith(combine)` returns the function
 
 Method `merge(combine::Union{Function,Type}, args...)` as an alias of
 `mergewith(combine, args...)` is still available for backward compatibility.
-
-!!! compat "Julia 1.5"
-    `mergewith` requires Julia 1.5 or later.
 
 # Examples
 ```jldoctest
@@ -596,9 +590,6 @@ end
 Modifies `dict` by transforming each value from `val` to `f(val)`.
 Note that the type of `dict` cannot be changed: if `f(val)` is not an instance of the value type
 of `dict` then it will be converted to the value type if possible and otherwise raise an error.
-
-!!! compat "Julia 1.2"
-    `map!(f, values(dict::AbstractDict))` requires Julia 1.2 or later.
 
 # Examples
 ```jldoctest

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -454,9 +454,6 @@ Equivalent to `isempty(a ∩ b)` but more efficient when possible.
 
 See also: [`intersect`](@ref), [`isempty`](@ref), [`issetequal`](@ref).
 
-!!! compat "Julia 1.5"
-    This function requires at least Julia 1.5.
-
 # Examples
 ```jldoctest
 julia> isdisjoint([1, 2], [2, 3, 4])

--- a/base/accumulate.jl
+++ b/base/accumulate.jl
@@ -120,9 +120,6 @@ Cumulative sum of an iterator.
 
 See also [`accumulate`](@ref) to apply functions other than `+`.
 
-!!! compat "Julia 1.5"
-    `cumsum` on a non-array iterator requires at least Julia 1.5.
-
 # Examples
 ```jldoctest
 julia> cumsum(1:3)
@@ -195,9 +192,6 @@ Cumulative product of an iterator.
 
 See also [`cumprod!`](@ref), [`accumulate`](@ref), [`cumsum`](@ref).
 
-!!! compat "Julia 1.5"
-    `cumprod` on a non-array iterator requires at least Julia 1.5.
-
 # Examples
 ```jldoctest
 julia> cumprod(fill(1//2, 3))
@@ -233,9 +227,6 @@ to control the precision of the output (e.g. to avoid overflow).
 For common operations there are specialized variants of `accumulate`,
 see [`cumsum`](@ref), [`cumprod`](@ref). For a lazy version, see
 [`Iterators.accumulate`](@ref).
-
-!!! compat "Julia 1.5"
-    `accumulate` on a non-array iterator requires at least Julia 1.5.
 
 # Examples
 ```jldoctest

--- a/base/array.jl
+++ b/base/array.jl
@@ -1073,9 +1073,6 @@ end
 For an ordered container `collection`, add the elements of each `collections`
 to the end of it.
 
-!!! compat "Julia 1.6"
-    Specifying multiple collections to be appended requires at least Julia 1.6.
-
 # Examples
 ```jldoctest
 julia> append!([1], [2, 3])
@@ -1140,9 +1137,6 @@ Insert the elements of each `collections` to the beginning of `a`.
 
 When `collections` specifies multiple collections, order is maintained:
 elements of `collections[1]` will appear leftmost in `a`, and so on.
-
-!!! compat "Julia 1.6"
-    Specifying multiple collections to be prepended requires at least Julia 1.6.
 
 # Examples
 ```jldoctest
@@ -1328,9 +1322,6 @@ When `i` is not a valid index for `a`, return `default`, or throw an error if
 `default` is not specified.
 
 See also: [`pop!`](@ref), [`popfirst!`](@ref), [`deleteat!`](@ref), [`splice!`](@ref).
-
-!!! compat "Julia 1.5"
-    This function is available as of Julia 1.5.
 
 # Examples
 ```jldoctest
@@ -1698,9 +1689,6 @@ place of the removed items; in this case, `indices` must be a `AbstractUnitRange
 
 To insert `replacement` before an index `n` without removing any items, use
 `splice!(collection, n:n-1, replacement)`.
-
-!!! compat "Julia 1.5"
-    Prior to Julia 1.5, `indices` must always be a `UnitRange`.
 
 !!! compat "Julia 1.8"
     Prior to Julia 1.8, `indices` must be a `UnitRange` if splicing in replacement values.
@@ -2551,9 +2539,6 @@ end
 
 Return a copy of collection `a`, removing elements for which `f` is `false`.
 The function `f` is passed one argument.
-
-!!! compat "Julia 1.4"
-    Support for `a` as a tuple requires at least Julia 1.4.
 
 See also: [`filter!`](@ref), [`Iterators.filter`](@ref).
 

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -52,9 +52,6 @@ julia> reverse(b)
  4  3
  2  1
 ```
-
-!!! compat "Julia 1.6"
-    Prior to Julia 1.6, only single-integer `dims` are supported in `reverse`.
 """
 reverse(A::AbstractArray; dims=:) = _reverse(A, dims)
 _reverse(A, dims) = reverse!(copymutable(A); dims)
@@ -63,9 +60,6 @@ _reverse(A, dims) = reverse!(copymutable(A); dims)
     reverse!(A; dims=:)
 
 Like [`reverse`](@ref), but operates in-place in `A`.
-
-!!! compat "Julia 1.6"
-    Multidimensional `reverse!` requires Julia 1.6.
 """
 reverse!(A::AbstractArray; dims=:) = _reverse!(A, dims)
 _reverse!(A::AbstractArray{<:Any,N}, ::Colon) where {N} = _reverse!(A, ntuple(identity, Val{N}()))

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1340,9 +1340,6 @@ julia> map(.*, a, b)
 julia> Base.BroadcastFunction(+)(a, b) == a .+ b
 true
 ```
-
-!!! compat "Julia 1.6"
-    `BroadcastFunction` and the standalone `.op` syntax are available as of Julia 1.6.
 """
 struct BroadcastFunction{F} <: Function
     f::F

--- a/base/c.jl
+++ b/base/c.jl
@@ -501,9 +501,6 @@ and in Julia script run with `-i` option.
 If `true`, `InterruptException` is not thrown by Ctrl-C.  Running code
 upon such event requires [`atexit`](@ref).  This is the default
 behavior in Julia script run without `-i` option.
-
-!!! compat "Julia 1.5"
-    Function `exit_on_sigint` requires at least Julia 1.5.
 """
 function exit_on_sigint(on::Bool)
     ccall(:jl_exit_on_sigint, Cvoid, (Cint,), on)

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -25,9 +25,6 @@ Other constructors:
 * `Channel()`: default constructor, equivalent to `Channel{Any}(0)`
 * `Channel(Inf)`: equivalent to `Channel{Any}(typemax(Int))`
 * `Channel(sz)`: equivalent to `Channel{Any}(sz)`
-
-!!! compat "Julia 1.3"
-    The default constructor `Channel()` and default `size=0` were added in Julia 1.3.
 """
 mutable struct Channel{T} <: AbstractChannel{T}
     cond_take::Threads.Condition                 # waiting for data to become available
@@ -110,14 +107,7 @@ Hello
 
 julia> istaskdone(taskref[])
 true
-```
 
-!!! compat "Julia 1.3"
-    The `spawn=` parameter was added in Julia 1.3. This constructor was added in Julia 1.3.
-    In earlier versions of Julia, Channel used keyword arguments to set `size` and `T`, but
-    those constructors are deprecated.
-
-```jldoctest
 julia> chnl = Channel{Char}(1, spawn=true) do ch
            for c in "hello world"
                put!(ch, c)
@@ -311,9 +301,6 @@ Append an item `v` to the channel `c`. Blocks if the channel is full.
 
 For unbuffered channels, blocks until a [`take!`](@ref) is performed by a different
 task.
-
-!!! compat "Julia 1.1"
-    `v` now gets converted to the channel's type with [`convert`](@ref) as `put!` is called.
 """
 function put!(c::Channel{T}, v) where T
     check_channel_state(c)

--- a/base/char.jl
+++ b/base/char.jl
@@ -57,10 +57,6 @@ Char
 Return the number of code units required to encode a character as UTF-8.
 This is the number of bytes which will be printed if the character is written
 to an output stream, or `ncodeunits(string(c))` but computed efficiently.
-
-!!! compat "Julia 1.1"
-    This method requires at least Julia 1.1. In Julia 1.0 consider
-    using `ncodeunits(string(c))`.
 """
 ncodeunits(c::Char) = write(devnull, c) # this is surprisingly efficient
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -507,9 +507,6 @@ it is evaluated: for each parsed expression `expr` in `path`, the `include` func
 actually evaluates `mapexpr(expr)`.  If it is omitted, `mapexpr` defaults to [`identity`](@ref).
 
 Use [`Base.include`](@ref) to evaluate a file into another module.
-
-!!! compat "Julia 1.5"
-    Julia 1.5 is required for passing the `mapexpr` argument.
 """
 MainInclude.include
 

--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -280,9 +280,6 @@ it inherits the current environment at time of `addenv()` call if `inherit` is `
 Keys with value `nothing` are deleted from the env.
 
 See also [`Cmd`](@ref), [`setenv`](@ref), [`ENV`](@ref).
-
-!!! compat "Julia 1.6"
-    This function requires Julia 1.6 or later.
 """
 function addenv(cmd::Cmd, env::Dict; inherit::Bool = true)
     new_env = Dict{String,String}()

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -321,9 +321,6 @@ julia> nextprod((2, 3), 105)
 julia> 2^2 * 3^3
 108
 ```
-
-!!! compat "Julia 1.6"
-    The method that accepts a tuple requires Julia 1.6 or later.
 """
 function nextprod(a::Union{Tuple{Vararg{Integer}},AbstractVector{<:Integer}}, x::Real)
     if x > typemax(Int)

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -596,9 +596,6 @@ julia> cispi(10000)
 julia> cispi(0.25 + 1im)
 0.030556854645954562 + 0.030556854645954562im
 ```
-
-!!! compat "Julia 1.6"
-    This function requires Julia 1.6 or later.
 """
 function cispi end
 cispi(theta::Real) = Complex(reverse(sincospi(theta))...)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -22,11 +22,6 @@ with the specified signature in the process.
 
 To prevent `old` from being exported, set `export_old` to `false`.
 
-!!! compat "Julia 1.5"
-    As of Julia 1.5, functions defined by `@deprecate` do not print warning when `julia`
-    is run without the `--depwarn=yes` flag set, as the default value of `--depwarn` option
-    is `no`.  The warnings are printed from tests run by `Pkg.test()`.
-
 # Examples
 ```jldoctest
 julia> @deprecate old(x) new(x)

--- a/base/div.jl
+++ b/base/div.jl
@@ -12,9 +12,6 @@ an integer according to the rounding mode `r`. In other words, the quantity
 
 without any intermediate rounding.
 
-!!! compat "Julia 1.4"
-    The three-argument method taking a `RoundingMode` requires Julia 1.4 or later.
-
 See also [`fld`](@ref) and [`cld`](@ref), which are special cases of this function.
 
 !!! compat "Julia 1.9"

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1406,9 +1406,6 @@ hygiene or otherwise contains variable names which can't be parsed normally.
 Note that this syntax requires parser support so it is expanded directly by the
 parser rather than being implemented as a normal string macro `@var_str`.
 
-!!! compat "Julia 1.3"
-    This syntax requires at least Julia 1.3.
-
 """
 kw"var\"name\"", kw"@var_str"
 
@@ -2819,9 +2816,6 @@ NamedTuple{names}(nt::NamedTuple)
 
 Construct a named tuple from an iterator of key-value pairs (where the keys must be
 `Symbol`s). Equivalent to `(; itr...)`.
-
-!!! compat "Julia 1.6"
-    This method requires at least Julia 1.6.
 """
 NamedTuple(itr)
 

--- a/base/error.jl
+++ b/base/error.jl
@@ -275,9 +275,6 @@ Return an anonymous function that calls function `f`.  If an exception arises,
 number of seconds specified in `delays`.  `check` should input `delays`'s
 current state and the `Exception`.
 
-!!! compat "Julia 1.2"
-    Before Julia 1.2 this signature was restricted to `f::Function`.
-
 # Examples
 ```julia
 retry(f, delays=fill(5.0, 3))

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -944,9 +944,6 @@ julia> position(b)
 julia> peek(b, Char)
 'j': ASCII/Unicode U+006A (category Ll: Letter, lowercase)
 ```
-
-!!! compat "Julia 1.5"
-    The method which accepts a type requires Julia 1.5 or later.
 """
 function peek end
 

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -283,8 +283,6 @@ Closest candidates are:
     ...
 ```
 
-!!! compat "Julia 1.5"
-    Custom error hints are available as of Julia 1.5.
 !!! warning
     This interface is experimental and subject to change or removal without notice.
     To insulate yourself against changes, consider putting any registrations inside an
@@ -305,8 +303,6 @@ Invoke all handlers from [`Experimental.register_error_hint`](@ref) for the part
 exception type `typeof(ex)`. `args` must contain any other arguments expected by
 the handler for that type.
 
-!!! compat "Julia 1.5"
-    Custom error hints are available as of Julia 1.5.
 !!! warning
     This interface is experimental and subject to change or removal without notice.
 """

--- a/base/file.jl
+++ b/base/file.jl
@@ -644,10 +644,6 @@ function does not create any file or directory at the returned location, so
 there is nothing to cleanup unless you create a file or directory there. If
 you do and `clean` is `true` it will be deleted upon process termination.
 
-!!! compat "Julia 1.4"
-    The `parent` and `cleanup` arguments were added in 1.4. Prior to Julia 1.4
-    the path `tempname` would never be cleaned up at process termination.
-
 !!! warning
 
     This can lead to security holes if another process obtains the same
@@ -663,11 +659,6 @@ tempname()
 Return `(path, io)`, where `path` is the path of a new temporary file in `parent`
 and `io` is an open file object for this path. The `cleanup` option controls whether
 the temporary file is automatically deleted when the process exits.
-
-!!! compat "Julia 1.3"
-    The `cleanup` keyword argument was added in Julia 1.3. Relatedly, starting from 1.3,
-    Julia will remove the temporary paths created by `mktemp` when the Julia process exits,
-    unless `cleanup` is explicitly set to `false`.
 """
 mktemp(parent)
 
@@ -679,14 +670,6 @@ constructed from the given prefix and a random suffix, and return its path.
 Additionally, any trailing `X` characters may be replaced with random characters.
 If `parent` does not exist, throw an error. The `cleanup` option controls whether
 the temporary directory is automatically deleted when the process exits.
-
-!!! compat "Julia 1.2"
-    The `prefix` keyword argument was added in Julia 1.2.
-
-!!! compat "Julia 1.3"
-    The `cleanup` keyword argument was added in Julia 1.3. Relatedly, starting from 1.3,
-    Julia will remove the temporary paths created by `mktempdir` when the Julia process
-    exits, unless `cleanup` is explicitly set to `false`.
 
 See also: [`mktemp`](@ref), [`mkdir`](@ref).
 """
@@ -749,9 +732,6 @@ Apply the function `f` to the result of [`mktempdir(parent; prefix)`](@ref) and 
 temporary directory all of its contents upon completion.
 
 See also: [`mktemp`](@ref), [`mkdir`](@ref).
-
-!!! compat "Julia 1.2"
-    The `prefix` keyword argument was added in Julia 1.2.
 """
 function mktempdir(fn::Function, parent::AbstractString=tempdir();
     prefix::AbstractString=temp_prefix)
@@ -794,9 +774,6 @@ sorting the names and get them in the order that the file system lists them,
 you can use `readdir(dir, sort=false)` to opt out of sorting.
 
 See also: [`walkdir`](@ref).
-
-!!! compat "Julia 1.4"
-    The `join` and `sort` keyword arguments require at least Julia 1.4.
 
 # Examples
 ```julia-repl
@@ -1059,11 +1036,6 @@ See also: [`hardlink`](@ref).
 !!! note
     This function raises an error under operating systems that do not support
     soft symbolic links, such as Windows XP.
-
-!!! compat "Julia 1.6"
-    The `dir_target` keyword argument was added in Julia 1.6.  Prior to this,
-    symlinks to nonexistent paths on windows would always be file symlinks, and
-    relative symlinks to directories were not supported.
 """
 function symlink(target::AbstractString, link::AbstractString;
                  dir_target::Bool = false)

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -273,10 +273,6 @@ for example, in `x - y ≈ 0`, `atol=1e-9` is an absurdly small tolerance if `x`
 but an absurdly large tolerance if `x` is the
 [radius of a Hydrogen atom](https://en.wikipedia.org/wiki/Bohr_radius) in meters.
 
-!!! compat "Julia 1.6"
-    Passing the `norm` keyword argument when comparing numeric (non-array) arguments
-    requires Julia 1.6 or later.
-
 # Examples
 ```jldoctest
 julia> isapprox(0.1, 0.15; atol=0.05)
@@ -313,9 +309,6 @@ end
 Create a function that compares its argument to `x` using `≈`, i.e. a function equivalent to `y -> y ≈ x`.
 
 The keyword arguments supported here are the same as those in the 2-argument `isapprox`.
-
-!!! compat "Julia 1.5"
-    This method requires Julia 1.5 or later.
 """
 isapprox(y; kwargs...) = x -> isapprox(x, y; kwargs...)
 

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -196,9 +196,6 @@ are allocating memory (and hence may need to run GC) but other threads are doing
 only simple operations (no allocation, task switches, or I/O).
 Calling this function periodically in non-allocating threads allows garbage
 collection to run.
-
-!!! compat "Julia 1.4"
-    This function is available as of Julia 1.4.
 """
 safepoint() = ccall(:jl_gc_safepoint, Cvoid, ())
 

--- a/base/int.jl
+++ b/base/int.jl
@@ -539,9 +539,6 @@ end
 It returns the value of `x` with its bits rotated left `k` times.
 A negative value of `k` will rotate to the right instead.
 
-!!! compat "Julia 1.5"
-    This function requires Julia 1.5 or later.
-
 See also: [`<<`](@ref), [`circshift`](@ref), [`BitArray`](@ref).
 
 ```jldoctest
@@ -1029,9 +1026,6 @@ const _mask4_uint128 = (UInt128(0x0f0f0f0f0f0f0f0f) << 64) | UInt128(0x0f0f0f0f0
 
 Reverse the order of bits in integer `x`. `x` must have a fixed bit width,
 e.g. be an `Int16` or `Int32`.
-
-!!! compat "Julia 1.5"
-    This function requires Julia 1.5 or later.
 
 # Examples
 ```jldoctest

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -8,9 +8,6 @@
 Greatest common (positive) divisor (or zero if all arguments are zero).
 The arguments may be integer and rational numbers.
 
-!!! compat "Julia 1.4"
-    Rational arguments require Julia 1.4 or later.
-
 # Examples
 ```jldoctest
 julia> gcd(6, 9)
@@ -84,9 +81,6 @@ end
 Least common (positive) multiple (or zero if any argument is zero).
 The arguments may be integer and rational numbers.
 
-!!! compat "Julia 1.4"
-    Rational arguments require Julia 1.4 or later.
-
 # Examples
 ```jldoctest
 julia> lcm(2, 3)
@@ -159,9 +153,6 @@ coefficients, i.e. the integer coefficients `u` and `v` that satisfy
 ``ua+vb = d = gcd(a, b)``. ``gcdx(a, b)`` returns ``(d, u, v)``.
 
 The arguments may be integer and rational numbers.
-
-!!! compat "Julia 1.4"
-    Rational arguments require Julia 1.4 or later.
 
 # Examples
 ```jldoctest
@@ -420,9 +411,6 @@ true
 julia> ispow2(1//8)
 true
 ```
-
-!!! compat "Julia 1.6"
-    Support for non-`Integer` arguments was added in Julia 1.6.
 """
 ispow2(x::Number) = isreal(x) && ispow2(real(x))
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -1187,9 +1187,6 @@ Return an iterable object yielding [`read(io, T)`](@ref).
 
 See also [`skipchars`](@ref), [`eachline`](@ref), [`readuntil`](@ref).
 
-!!! compat "Julia 1.6"
-    `readeach` requires Julia 1.6 or later.
-
 # Examples
 ```jldoctest
 julia> io = IOBuffer("JuliaLang is a GitHub organization.\\n It has many members.\\n");

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -268,9 +268,6 @@ Returns a stream for accessing the opened file.
 
 The `lock` keyword argument controls whether operations will be locked for
 safe multi-threaded access.
-
-!!! compat "Julia 1.5"
-    The `lock` argument is available as of Julia 1.5.
 """
 function open(fname::String; lock = true,
     read     :: Union{Bool,Nothing} = nothing,
@@ -348,9 +345,6 @@ julia> close(io)
 
 julia> rm("myfile.txt")
 ```
-
-!!! compat "Julia 1.5"
-    The `lock` argument is available as of Julia 1.5.
 """
 function open(fname::AbstractString, mode::AbstractString; lock = true)
     mode == "r"  ? open(fname, lock = lock, read = true)                  :

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -43,9 +43,6 @@ end
 Create a lazy mapping.  This is another syntax for writing
 `(f(args...) for args in zip(iterators...))`.
 
-!!! compat "Julia 1.6"
-    This function requires at least Julia 1.6.
-
 # Examples
 ```jldoctest
 julia> collect(Iterators.map(x -> x^2, 1:3))
@@ -539,9 +536,6 @@ next element of `itr`.
 
 This is effectively a lazy version of [`Base.accumulate`](@ref).
 
-!!! compat "Julia 1.5"
-    Keyword argument `init` is added in Julia 1.5.
-
 # Examples
 ```jldoctest
 julia> a = Iterators.accumulate(+, [1,2,3,4]);
@@ -823,9 +817,6 @@ end
 An iterator that generates element from `iter` as long as predicate `pred` is true,
 afterwards, drops every element.
 
-!!! compat "Julia 1.4"
-    This function requires at least Julia 1.4.
-
 # Examples
 
 ```jldoctest
@@ -869,9 +860,6 @@ end
 
 An iterator that drops element from `iter` as long as predicate `pred` is true,
 afterwards, returns every element.
-
-!!! compat "Julia 1.4"
-    This function requires at least Julia 1.4.
 
 # Examples
 
@@ -1483,9 +1471,6 @@ Return the one and only element of collection `x`, or throw an [`ArgumentError`]
 collection has zero or multiple elements.
 
 See also [`first`](@ref), [`last`](@ref).
-
-!!! compat "Julia 1.4"
-    This method requires at least Julia 1.4.
 
 # Examples
 ```jldoctest

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1487,9 +1487,6 @@ Like [`include`](@ref), except reads code from the given string rather than from
 The optional first argument `mapexpr` can be used to transform the included code before
 it is evaluated: for each parsed expression `expr` in `code`, the `include_string` function
 actually evaluates `mapexpr(expr)`.  If it is omitted, `mapexpr` defaults to [`identity`](@ref).
-
-!!! compat "Julia 1.5"
-    Julia 1.5 is required for passing the `mapexpr` argument.
 """
 function include_string(mapexpr::Function, mod::Module, code::AbstractString,
                         filename::AbstractString="string")
@@ -1552,9 +1549,6 @@ interactively, or to combine files in packages that are broken into multiple sou
 The optional first argument `mapexpr` can be used to transform the included code before
 it is evaluated: for each parsed expression `expr` in `path`, the `include` function
 actually evaluates `mapexpr(expr)`.  If it is omitted, `mapexpr` defaults to [`identity`](@ref).
-
-!!! compat "Julia 1.5"
-    Julia 1.5 is required for passing the `mapexpr` argument.
 """
 Base.include # defined in Base.jl
 

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -309,9 +309,6 @@ end
         unlock(c)
     end
     ```
-
-    !!! compat "Julia 1.2"
-        This functionality requires at least Julia 1.2.
     """
     const Condition = Base.GenericCondition{Base.ReentrantLock}
 
@@ -427,9 +424,6 @@ If `autoreset` is true, at most one task will be released from `wait` for
 each call to `notify`.
 
 This provides an acquire & release memory ordering on notify/wait.
-
-!!! compat "Julia 1.1"
-    This functionality requires at least Julia 1.1.
 
 !!! compat "Julia 1.8"
     The `autoreset` functionality and memory ordering guarantee requires at least Julia 1.8.

--- a/base/math.jl
+++ b/base/math.jl
@@ -68,9 +68,6 @@ are promoted to a common type.
 
 See also [`clamp!`](@ref), [`min`](@ref), [`max`](@ref).
 
-!!! compat "Julia 1.3"
-    `missing` as the first argument requires at least Julia 1.3.
-
 # Examples
 ```jldoctest
 julia> clamp.([pi, 1.0, big(10)], 2.0, 9.0)
@@ -120,9 +117,6 @@ clamp(x, ::Type{T}) where {T<:Integer} = clamp(x, typemin(T), typemax(T)) % T
 Restrict values in `array` to the specified range, in-place.
 See also [`clamp`](@ref).
 
-!!! compat "Julia 1.3"
-    `missing` entries in `array` require at least Julia 1.3.
-
 # Examples
 ```jldoctest
 julia> row = collect(-4:4)';
@@ -147,9 +141,6 @@ end
     clamp(x::Integer, r::AbstractUnitRange)
 
 Clamp `x` to lie within range `r`.
-
-!!! compat "Julia 1.6"
-     This method requires at least Julia 1.6.
 """
 clamp(x::Integer, r::AbstractUnitRange{<:Integer}) = clamp(x, first(r), last(r))
 
@@ -164,9 +155,6 @@ This function generates efficient code using Horner's method if `x` is real, or 
 a Goertzel-like [^DK62] algorithm if `x` is complex.
 
 [^DK62]: Donald Knuth, Art of Computer Programming, Volume 2: Seminumerical Algorithms, Sec. 4.6.4.
-
-!!! compat "Julia 1.4"
-    This function requires Julia 1.4 or later.
 
 # Example
 ```jldoctest

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -32,9 +32,6 @@ Int64
 julia> nonmissingtype(Any)
 Any
 ```
-
-!!! compat "Julia 1.3"
-    This function is exported as of Julia 1.3.
 """
 nonmissingtype(::Type{T}) where {T} = typesplit(T, Missing)
 
@@ -374,9 +371,6 @@ end
 
 Return a vector similar to the array wrapped by the given `SkipMissing` iterator
 but with all missing elements and those for which `f` returns `false` removed.
-
-!!! compat "Julia 1.2"
-    This method requires Julia 1.2 or later.
 
 # Examples
 ```jldoctest

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -156,10 +156,6 @@ See also:
 - [`rounding`](@ref) and [`setrounding`](@ref)
 - [`precision`](@ref) and [`setprecision`](@ref)
 
-!!! compat "Julia 1.1"
-    `precision` as a keyword argument requires at least Julia 1.1.
-    In Julia 1.0 `precision` is the second positional argument (`BigFloat(x, precision)`).
-
 # Examples
 ```jldoctest
 julia> BigFloat(2.1) # 2.1 here is a Float64

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -183,10 +183,6 @@ module IteratorsMD
     As a convenience, constructing a `CartesianIndices` from an array makes a
     range of its indices.
 
-    !!! compat "Julia 1.6"
-        The step range method `CartesianIndices((istart:istep:istop, jstart:[jstep:]jstop, ...))`
-        requires at least Julia 1.6.
-
     # Examples
     ```jldoctest
     julia> foreach(println, CartesianIndices((2, 2, 2)))
@@ -225,9 +221,6 @@ module IteratorsMD
     ## Broadcasting
 
     `CartesianIndices` support broadcasting arithmetic (+ and -) with a `CartesianIndex`.
-
-    !!! compat "Julia 1.1"
-        Broadcasting of CartesianIndices requires at least Julia 1.1.
 
     ```jldoctest
     julia> CIs = CartesianIndices((2:3, 5:6))
@@ -276,12 +269,6 @@ module IteratorsMD
         (:)(start::CartesianIndex, [step::CartesianIndex], stop::CartesianIndex)
 
     Construct [`CartesianIndices`](@ref) from two `CartesianIndex` and an optional step.
-
-    !!! compat "Julia 1.1"
-        This method requires at least Julia 1.1.
-
-    !!! compat "Julia 1.6"
-        The step range method start:step:stop requires at least Julia 1.6.
 
     # Examples
     ```jldoctest
@@ -957,9 +944,6 @@ diff(a::AbstractVector) = diff(a, dims=1)
 Finite difference operator on a vector or a multidimensional array `A`. In the
 latter case the dimension to operate on needs to be specified with the `dims`
 keyword argument.
-
-!!! compat "Julia 1.1"
-    `diff` for arrays with dimension higher than 2 requires at least Julia 1.1.
 
 # Examples
 ```jldoctest

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -77,9 +77,6 @@ julia> (; t.x)
 (x = 0,)
 ```
 
-!!! compat "Julia 1.5"
-    Implicit names from identifiers and dot expressions are available as of Julia 1.5.
-
 !!! compat "Julia 1.7"
     Use of `getindex` methods with multiple `Symbol`s is available as of Julia 1.7.
 """
@@ -246,9 +243,6 @@ contains that field. Fields present in only the rightmost named tuple of a pair 
 A fallback is implemented for when only a single named tuple is supplied,
 with signature `merge(a::NamedTuple)`.
 
-!!! compat "Julia 1.1"
-    Merging 3 or more `NamedTuple` requires at least Julia 1.1.
-
 # Examples
 ```jldoctest
 julia> merge((a=1, b=2, c=3), (b=4, d=5))
@@ -402,9 +396,6 @@ julia> @NamedTuple begin
        end
 NamedTuple{(:a, :b), Tuple{Float64, String}}
 ```
-
-!!! compat "Julia 1.5"
-    This macro is available as of Julia 1.5.
 """
 macro NamedTuple(ex)
     Meta.isexpr(ex, :braces) || Meta.isexpr(ex, :block) ||

--- a/base/number.jl
+++ b/base/number.jl
@@ -248,9 +248,6 @@ julia> inv(1 + 2im) * (1 + 2im)
 julia> inv(2//3)
 3//2
 ```
-
-!!! compat "Julia 1.2"
-    `inv(::Missing)` requires at least Julia 1.2.
 """
 inv(x::Number) = one(x)/x
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -944,12 +944,6 @@ Function composition also works in prefix form: `∘(f, g)` is the same as `f �
 The prefix form supports composition of multiple functions: `∘(f, g, h) = f ∘ g ∘ h`
 and splatting `∘(fs...)` for composing an iterable collection of functions.
 
-!!! compat "Julia 1.4"
-    Multiple function composition requires at least Julia 1.4.
-
-!!! compat "Julia 1.5"
-    Composition of one function ∘(f) requires at least Julia 1.5.
-
 !!! compat "Julia 1.7"
     Using keyword arguments requires at least Julia 1.7.
 
@@ -1001,8 +995,6 @@ true
 julia> composition.inner === cos
 true
 ```
-!!! compat "Julia 1.6"
-    ComposedFunction requires at least Julia 1.6. In earlier versions `∘` returns an anonymous function instead.
 
 See also [`∘`](@ref).
 """
@@ -1138,9 +1130,6 @@ Create a function that compares its argument to `x` using [`!=`](@ref), i.e.
 a function equivalent to `y -> y != x`.
 The returned function is of type `Base.Fix2{typeof(!=)}`, which can be
 used to implement specialized methods.
-
-!!! compat "Julia 1.2"
-    This functionality requires at least Julia 1.2.
 """
 !=(x) = Fix2(!=, x)
 
@@ -1151,9 +1140,6 @@ Create a function that compares its argument to `x` using [`>=`](@ref), i.e.
 a function equivalent to `y -> y >= x`.
 The returned function is of type `Base.Fix2{typeof(>=)}`, which can be
 used to implement specialized methods.
-
-!!! compat "Julia 1.2"
-    This functionality requires at least Julia 1.2.
 """
 >=(x) = Fix2(>=, x)
 
@@ -1164,9 +1150,6 @@ Create a function that compares its argument to `x` using [`<=`](@ref), i.e.
 a function equivalent to `y -> y <= x`.
 The returned function is of type `Base.Fix2{typeof(<=)}`, which can be
 used to implement specialized methods.
-
-!!! compat "Julia 1.2"
-    This functionality requires at least Julia 1.2.
 """
 <=(x) = Fix2(<=, x)
 
@@ -1177,9 +1160,6 @@ Create a function that compares its argument to `x` using [`>`](@ref), i.e.
 a function equivalent to `y -> y > x`.
 The returned function is of type `Base.Fix2{typeof(>)}`, which can be
 used to implement specialized methods.
-
-!!! compat "Julia 1.2"
-    This functionality requires at least Julia 1.2.
 """
 >(x) = Fix2(>, x)
 
@@ -1190,9 +1170,6 @@ Create a function that compares its argument to `x` using [`<`](@ref), i.e.
 a function equivalent to `y -> y < x`.
 The returned function is of type `Base.Fix2{typeof(<)}`, which can be
 used to implement specialized methods.
-
-!!! compat "Julia 1.2"
-    This functionality requires at least Julia 1.2.
 """
 <(x) = Fix2(<, x)
 
@@ -1207,9 +1184,6 @@ i.e. given a function returns a new function that takes one argument and splats
 its argument into the original function. This is useful as an adaptor to pass
 a multi-argument function in a context that expects a single argument, but
 passes a tuple as that single argument. Additionally has pretty printing.
-
-!!! compat "Julia 1.9"
-    This function was introduced in Julia 1.9, replacing `Base.splat(f)`.
 
 # Example usage:
 ```jldoctest
@@ -1279,9 +1253,6 @@ Avoid adding methods to this function; define `in` instead.
 
 Create a function that checks whether its argument contains the given `item`, i.e.
 a function equivalent to `y -> item in y`.
-
-!!! compat "Julia 1.6"
-    This method requires Julia 1.6 or later.
 """
 ∋(x) = Fix2(∋, x)
 

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -14,9 +14,6 @@ of the form `"R±Iim"` as a `Complex(R,I)` of the requested type; `"i"` or `"j"`
 used instead of `"im"`, and `"R"` or `"Iim"` are also permitted.
 If the string does not contain a valid number, an error is raised.
 
-!!! compat "Julia 1.1"
-    `parse(Bool, str)` requires at least Julia 1.1.
-
 # Examples
 ```jldoctest
 julia> parse(Int, "1234")

--- a/base/path.jl
+++ b/base/path.jl
@@ -221,9 +221,6 @@ Split a file path into all its path components. This is the opposite of
 `joinpath`. Returns an array of substrings, one for each directory or file in
 the path, including the root directory if present.
 
-!!! compat "Julia 1.1"
-    This function requires at least Julia 1.1.
-
 # Examples
 ```jldoctest
 julia> splitpath("/home/myuser/example.jl")

--- a/base/process.jl
+++ b/base/process.jl
@@ -605,9 +605,6 @@ kill(ps::ProcessChain, signum::Integer=SIGTERM) = kill(ps.processes, signum)
     getpid(process) -> Int32
 
 Get the child process ID, if it still exists.
-
-!!! compat "Julia 1.1"
-    This function requires at least Julia 1.1.
 """
 function Libc.getpid(p::Process)
     # TODO: due to threading, this method is only weakly synchronized with the user application

--- a/base/range.jl
+++ b/base/range.jl
@@ -108,9 +108,6 @@ julia> range(1, 3.5, step=2)
 Special care is taken to ensure intermediate values are computed rationally.
 To avoid this induced overhead, see the [`LinRange`](@ref) constructor.
 
-!!! compat "Julia 1.1"
-    `stop` as a positional argument requires at least Julia 1.1.
-
 !!! compat "Julia 1.7"
     The versions without keyword arguments and `start` as a keyword argument
     require at least Julia 1.7.
@@ -1475,9 +1472,6 @@ julia> mod(0, Base.OneTo(3))  # mod1(0, 3)
 julia> mod(3, 0:2)  # mod(3, 3)
 0
 ```
-
-!!! compat "Julia 1.3"
-     This method requires at least Julia 1.3.
 """
 mod(i::Integer, r::OneTo) = mod1(i, last(r))
 mod(i::Integer, r::AbstractUnitRange{<:Integer}) = mod(i-first(r), length(r)) + first(r)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -285,9 +285,6 @@ In general, it will be necessary to provide `init` to work with empty collection
 intermediate collection needs to be created. See documentation for [`reduce`](@ref) and
 [`map`](@ref).
 
-!!! compat "Julia 1.2"
-    `mapreduce` with multiple iterators requires Julia 1.2 or later.
-
 # Examples
 ```jldoctest
 julia> mapreduce(x->x^2, +, [1:3;]) # == 1 + 4 + 9
@@ -501,9 +498,6 @@ The value returned for empty `itr` can be specified by `init`. It must be
 the additive identity (i.e. zero) as it is unspecified whether `init` is used
 for non-empty collections.
 
-!!! compat "Julia 1.6"
-    Keyword argument `init` requires Julia 1.6 or later.
-
 # Examples
 ```jldoctest
 julia> sum(abs2, [2; 3; 4])
@@ -540,9 +534,6 @@ The value returned for empty `itr` can be specified by `init`. It must be
 the additive identity (i.e. zero) as it is unspecified whether `init` is used
 for non-empty collections.
 
-!!! compat "Julia 1.6"
-    Keyword argument `init` requires Julia 1.6 or later.
-
 See also: [`reduce`](@ref), [`mapreduce`](@ref), [`count`](@ref), [`union`](@ref).
 
 # Examples
@@ -572,9 +563,6 @@ The value returned for empty `itr` can be specified by `init`. It must be the
 multiplicative identity (i.e. one) as it is unspecified whether `init` is used
 for non-empty collections.
 
-!!! compat "Julia 1.6"
-    Keyword argument `init` requires Julia 1.6 or later.
-
 # Examples
 ```jldoctest
 julia> prod(abs2, [2; 3; 4])
@@ -595,9 +583,6 @@ arguments, a common return type is found to which all arguments are promoted.
 The value returned for empty `itr` can be specified by `init`. It must be the
 multiplicative identity (i.e. one) as it is unspecified whether `init` is used
 for non-empty collections.
-
-!!! compat "Julia 1.6"
-    Keyword argument `init` requires Julia 1.6 or later.
 
 See also: [`reduce`](@ref), [`cumprod`](@ref), [`any`](@ref).
 
@@ -680,9 +665,6 @@ a neutral element for `max` (i.e. which is less than or equal to any
 other element) as it is unspecified whether `init` is used
 for non-empty collections.
 
-!!! compat "Julia 1.6"
-    Keyword argument `init` requires Julia 1.6 or later.
-
 # Examples
 ```jldoctest
 julia> maximum(length, ["Julion", "Julia", "Jule"])
@@ -707,9 +689,6 @@ a neutral element for `min` (i.e. which is greater than or equal to any
 other element) as it is unspecified whether `init` is used
 for non-empty collections.
 
-!!! compat "Julia 1.6"
-    Keyword argument `init` requires Julia 1.6 or later.
-
 # Examples
 ```jldoctest
 julia> minimum(length, ["Julion", "Julia", "Jule"])
@@ -733,9 +712,6 @@ The value returned for empty `itr` can be specified by `init`. It must be
 a neutral element for `max` (i.e. which is less than or equal to any
 other element) as it is unspecified whether `init` is used
 for non-empty collections.
-
-!!! compat "Julia 1.6"
-    Keyword argument `init` requires Julia 1.6 or later.
 
 # Examples
 ```jldoctest
@@ -765,9 +741,6 @@ The value returned for empty `itr` can be specified by `init`. It must be
 a neutral element for `min` (i.e. which is greater than or equal to any
 other element) as it is unspecified whether `init` is used
 for non-empty collections.
-
-!!! compat "Julia 1.6"
-    Keyword argument `init` requires Julia 1.6 or later.
 
 # Examples
 ```jldoctest
@@ -829,9 +802,6 @@ first and second elements are neutral elements for `min` and `max` respectively
 collections. Note: it implies that, for empty `itr`, the returned value `(mn, mx)` satisfies
 `mn ≥ mx` even though for non-empty `itr` it  satisfies `mn ≤ mx`.  This is a "paradoxical"
 but yet expected result.
-
-!!! compat "Julia 1.2"
-    This method requires Julia 1.2 or later.
 
 !!! compat "Julia 1.8"
     Keyword argument `init` requires Julia 1.8 or later.
@@ -1324,9 +1294,6 @@ Count the number of elements in `itr` for which the function `f` returns `true`.
 If `f` is omitted, count the number of `true` elements in `itr` (which
 should be a collection of boolean values). `init` optionally specifies the value
 to start counting from and therefore also determines the output type.
-
-!!! compat "Julia 1.6"
-    `init` keyword was added in Julia 1.6.
 
 See also: [`any`](@ref), [`sum`](@ref).
 

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -333,9 +333,6 @@ reducedim!(op, R::AbstractArray{RT}, A::AbstractArrayOrBroadcasted) where {RT} =
 Evaluates to the same as `reduce(op, map(f, A...); dims=dims, init=init)`, but is generally
 faster because the intermediate array is avoided.
 
-!!! compat "Julia 1.2"
-    `mapreduce` with multiple iterators requires Julia 1.2 or later.
-
 # Examples
 ```jldoctest
 julia> a = reshape(Vector(1:16), (4,4))
@@ -413,12 +410,6 @@ reduce(op, A::AbstractArray; kw...) = mapreduce(identity, op, A; kw...)
 Count the number of elements in `A` for which `f` returns `true` over the given
 dimensions.
 
-!!! compat "Julia 1.5"
-    `dims` keyword was added in Julia 1.5.
-
-!!! compat "Julia 1.6"
-    `init` keyword was added in Julia 1.6.
-
 # Examples
 ```jldoctest
 julia> A = [1 2; 3 4]
@@ -447,9 +438,6 @@ _count(f, A::AbstractArrayOrBroadcasted, dims, init) = mapreduce(_bool(f), add_s
 
 Count the number of elements in `A` for which `f` returns `true` over the
 singleton dimensions of `r`, writing the result into `r` in-place.
-
-!!! compat "Julia 1.5"
-    inplace `count!` was added in Julia 1.5.
 
 # Examples
 ```jldoctest
@@ -807,9 +795,6 @@ extrema(A::AbstractArray; dims)
 
 Compute the minimum and maximum of `f` applied to each element in the given dimensions
 of `A`.
-
-!!! compat "Julia 1.2"
-    This method requires Julia 1.2 or later.
 """
 extrema(f, A::AbstractArray; dims)
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -196,9 +196,6 @@ Return a boolean indicating whether `T` has `name` as one of its own fields.
 
 See also [`fieldnames`](@ref), [`fieldcount`](@ref), [`hasproperty`](@ref).
 
-!!! compat "Julia 1.2"
-     This function requires at least Julia 1.2.
-
 # Examples
 ```jldoctest
 julia> struct Foo
@@ -293,9 +290,6 @@ end
 
 Construct a dictionary of the names (as symbols) and values of all local
 variables defined as of the call site.
-
-!!! compat "Julia 1.1"
-    This macro requires at least Julia 1.1.
 
 # Examples
 ```jldoctest
@@ -506,9 +500,6 @@ false
 julia> ismutable([1,2])
 true
 ```
-
-!!! compat "Julia 1.5"
-    This function requires at least Julia 1.5.
 """
 ismutable(@nospecialize(x)) = (@_total_meta; typeof(x).name.flags & 0x2 == 0x2)
 
@@ -818,9 +809,6 @@ end
 
 The declared types of all fields in a composite DataType `T` as a tuple.
 
-!!! compat "Julia 1.1"
-    This function requires at least Julia 1.1.
-
 # Examples
 ```jldoctest
 julia> struct Foo
@@ -976,9 +964,6 @@ Return the method table for `f`.
 If `types` is specified, return an array of methods whose types match.
 If `module` is specified, return an array of methods defined in that module.
 A list of modules can also be specified as an array.
-
-!!! compat "Julia 1.4"
-    At least Julia 1.4 is required for specifying a module.
 
 See also: [`which`](@ref) and `@which`.
 """
@@ -1581,9 +1566,6 @@ the provided names must be a subset of the method's keyword arguments.
 
 See also [`applicable`](@ref).
 
-!!! compat "Julia 1.2"
-    Providing keyword argument names requires Julia 1.2 or later.
-
 # Examples
 ```jldoctest
 julia> hasmethod(length, Tuple{Array})
@@ -1846,9 +1828,6 @@ propertynames(x, private::Bool) = propertynames(x) # ignore private flag by defa
     hasproperty(x, s::Symbol)
 
 Return a boolean indicating whether the object `x` has `s` as one of its own properties.
-
-!!! compat "Julia 1.2"
-     This function requires at least Julia 1.2.
 
 See also: [`propertynames`](@ref), [`hasfield`](@ref).
 """

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -197,9 +197,6 @@ That is, `idx` will be in the return value even if `m[idx] == nothing`.
 Unnamed capture groups will have integer keys corresponding to their index.
 Named capture groups will have string keys.
 
-!!! compat "Julia 1.6"
-    This method was added in Julia 1.6
-
 # Examples
 ```jldoctest
 julia> keys(match(r"(?<hour>\\d+):(?<minute>\\d+)(am|pm)?", "11:30"))
@@ -277,9 +274,6 @@ Return `true` if `s` starts with the regex pattern, `prefix`.
 
 See also [`occursin`](@ref) and [`endswith`](@ref).
 
-!!! compat "Julia 1.2"
-    This method requires at least Julia 1.2.
-
 # Examples
 ```jldoctest
 julia> startswith("JuliaLang", r"Julia|Romeo")
@@ -308,9 +302,6 @@ Return `true` if `s` ends with the regex pattern, `suffix`.
     `occursin(r"...\$", s)` is faster than `endswith(s, r"...")`.
 
 See also [`occursin`](@ref) and [`startswith`](@ref).
-
-!!! compat "Julia 1.2"
-    This method requires at least Julia 1.2.
 
 # Examples
 ```jldoctest
@@ -460,9 +451,6 @@ calling `length(findall(pattern, string))` but more efficient.
 
 If `overlap=true`, the matching sequences are allowed to overlap indices in the
 original string, otherwise they must be from disjoint character ranges.
-
-!!! compat "Julia 1.3"
-     This method requires at least Julia 1.3.
 
 !!! compat "Julia 1.7"
       Using a character as the pattern requires at least Julia 1.7.
@@ -726,9 +714,6 @@ String and character arguments must be matched exactly in the resulting regex,
 meaning that the contained characters are devoid of any special meaning
 (they are quoted with "\\Q" and "\\E").
 
-!!! compat "Julia 1.3"
-    This method requires at least Julia 1.3.
-
 # Examples
 ```jldoctest
 julia> match(r"Hello|Good bye" * ' ' * "world", "Hello world")
@@ -804,9 +789,6 @@ end
     ^(s::Regex, n::Integer)
 
 Repeat a regex `n` times.
-
-!!! compat "Julia 1.3"
-    This method requires at least Julia 1.3.
 
 # Examples
 ```jldoctest

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -104,9 +104,6 @@ If `sizeof(T) = n*sizeof(S)` for `n>1`, `A`'s first dimension must be
 of size `n` and `B` lacks `A`'s first dimension. Conversely, if `sizeof(S) = n*sizeof(T)` for `n>1`,
 `B` gets a new first dimension of size `n`. The dimensionality is unchanged if `sizeof(T) == sizeof(S)`.
 
-!!! compat "Julia 1.6"
-    This method requires at least Julia 1.6.
-
 # Examples
 
 ```jldoctest

--- a/base/set.jl
+++ b/base/set.jl
@@ -293,9 +293,6 @@ end
 Selects one value from `A` for each unique value produced by `f` applied to
 elements of `A`, then return the modified A.
 
-!!! compat "Julia 1.1"
-    This method is available as of Julia 1.1.
-
 # Examples
 ```jldoctest
 julia> unique!(x -> x^2, [1, -1, 3, -3, 4])

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -87,9 +87,6 @@ dimensions having size 1.
 
 See also [`eachrow`](@ref), [`eachcol`](@ref), [`mapslices`](@ref) and [`selectdim`](@ref).
 
-!!! compat "Julia 1.1"
-     This function requires at least Julia 1.1.
-
 !!! compat "Julia 1.9"
      Prior to Julia 1.9, this returned an iterator, and only a single dimension `dims` was supported.
 
@@ -133,9 +130,6 @@ Row slices are returned as `AbstractVector` views of `A`.
 
 See also [`eachcol`](@ref), [`eachslice`](@ref) and [`mapslices`](@ref).
 
-!!! compat "Julia 1.1"
-     This function requires at least Julia 1.1.
-
 !!! compat "Julia 1.9"
      Prior to Julia 1.9, this returned an iterator.
 
@@ -168,9 +162,6 @@ Create a [`ColumnSlices`](@ref) object that is a vector of columns of matrix or 
 Column slices are returned as `AbstractVector` views of `A`.
 
 See also [`eachrow`](@ref), [`eachslice`](@ref) and [`mapslices`](@ref).
-
-!!! compat "Julia 1.1"
-     This function requires at least Julia 1.1.
 
 !!! compat "Julia 1.9"
      Prior to Julia 1.9, this returned an iterator.

--- a/base/some.jl
+++ b/base/some.jl
@@ -60,9 +60,6 @@ notnothing(::Nothing) = throw(ArgumentError("nothing passed to notnothing"))
 
 Return `true` if `x === nothing`, and return `false` if not.
 
-!!! compat "Julia 1.1"
-    This function requires at least Julia 1.1.
-
 See also [`something`](@ref), [`Base.notnothing`](@ref), [`ismissing`](@ref).
 """
 isnothing(x) = x === nothing

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -409,9 +409,6 @@ false
 julia> insorted(0, [1, 2, 4, 5, 5, 7]) # no match
 false
 ```
-
-!!! compat "Julia 1.6"
-     `insorted` was added in Julia 1.6.
 """
 function insorted end
 insorted(x, v::AbstractVector; kw...) = !isempty(searchsorted(v, x; kw...))
@@ -1318,9 +1315,6 @@ Sort the multidimensional array `A` along dimension `dims`.
 See [`sort!`](@ref) for a description of possible keyword arguments.
 
 To sort slices of an array, refer to [`sortslices`](@ref).
-
-!!! compat "Julia 1.1"
-    This function requires at least Julia 1.1.
 
 # Examples
 ```jldoctest

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -865,9 +865,6 @@ end
 Simultaneously compute [`sinpi(x)`](@ref) and [`cospi(x)`](@ref) (the sine and cosine of `π*x`,
 where `x` is in radians), returning a tuple `(sine, cosine)`.
 
-!!! compat "Julia 1.6"
-    This function requires Julia 1.6 or later.
-
 See also: [`cispi`](@ref), [`sincosd`](@ref), [`sinpi`](@ref).
 """
 function sincospi(x::T) where T<:AbstractFloat
@@ -1250,9 +1247,6 @@ tand(x::Real) = sind(x) / cosd(x)
     sincosd(x)
 
 Simultaneously compute the sine and cosine of `x`, where `x` is in degrees.
-
-!!! compat "Julia 1.3"
-    This function requires at least Julia 1.3.
 """
 sincosd(x) = (sind(x), cosd(x))
 # It turns out that calling these functions separately yields better

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -4,9 +4,6 @@
 An abstract type representing any sort of pattern matching expression
 (typically a regular expression). `AbstractPattern` objects can be used to
 match strings with [`match`](@ref).
-
-!!! compat "Julia 1.6"
-    This type is available in Julia 1.6 and later.
 """
 abstract type AbstractPattern end
 
@@ -125,9 +122,6 @@ findfirst(pattern::AbstractString, string::AbstractString) =
 
 Find the first occurrence of character `ch` in `string`.
 
-!!! compat "Julia 1.3"
-    This method requires at least Julia 1.3.
-
 # Examples
 ```jldoctest
 julia> findfirst('a', "happy")
@@ -144,9 +138,6 @@ findfirst(ch::AbstractChar, string::AbstractString) = findfirst(==(ch), string)
               A::AbstractVector{<:Union{Int8,UInt8}})
 
 Find the first occurrence of sequence `pattern` in vector `A`.
-
-!!! compat "Julia 1.6"
-    This method requires at least Julia 1.6.
 
 # Examples
 ```jldoctest
@@ -323,9 +314,6 @@ findnext(t::AbstractString, s::AbstractString, start::Integer) = _search(s, t, I
 
 Find the next occurrence of character `ch` in `string` starting at position `start`.
 
-!!! compat "Julia 1.3"
-    This method requires at least Julia 1.3.
-
 # Examples
 ```jldoctest
 julia> findnext('z', "Hello to the world", 1) === nothing
@@ -344,9 +332,6 @@ findnext(ch::AbstractChar, string::AbstractString, start::Integer) =
              start::Integer)
 
 Find the next occurrence of the sequence `pattern` in vector `A` starting at position `start`.
-
-!!! compat "Julia 1.6"
-    This method requires at least Julia 1.6.
 
 # Examples
 ```jldoctest
@@ -402,9 +387,6 @@ findlast(pattern::AbstractVector{<:Union{Int8,UInt8}},
 
 Find the last occurrence of character `ch` in `string`.
 
-!!! compat "Julia 1.3"
-    This method requires at least Julia 1.3.
-
 # Examples
 ```jldoctest
 julia> findlast('p', "happy")
@@ -456,9 +438,6 @@ julia> findall(UInt8[1,2], UInt8[1,2,3,1,2])
  1:2
  4:5
 ```
-
-!!! compat "Julia 1.3"
-     This method requires at least Julia 1.3.
 """
 
 function findall(t::Union{AbstractString, AbstractPattern, AbstractVector{<:Union{Int8,UInt8}}},
@@ -638,9 +617,6 @@ findprev(t::AbstractString, s::AbstractString, i::Integer) = _rsearch(s, t, Int(
 
 Find the previous occurrence of character `ch` in `string` starting at position `start`.
 
-!!! compat "Julia 1.3"
-    This method requires at least Julia 1.3.
-
 # Examples
 ```jldoctest
 julia> findprev('z', "Hello to the world", 18) === nothing
@@ -659,9 +635,6 @@ findprev(ch::AbstractChar, string::AbstractString, start::Integer) =
              start::Integer)
 
 Find the previous occurrence of the sequence `pattern` in vector `A` starting at position `start`.
-
-!!! compat "Julia 1.6"
-    This method requires at least Julia 1.6.
 
 # Examples
 ```jldoctest
@@ -706,9 +679,6 @@ Create a function that checks whether its argument occurs in `haystack`, i.e.
 a function equivalent to `needle -> occursin(needle, haystack)`.
 
 The returned function is of type `Base.Fix2{typeof(occursin)}`.
-
-!!! compat "Julia 1.6"
-    This method requires Julia 1.6 or later.
 """
 occursin(haystack) = Base.Fix2(occursin, haystack)
 

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -47,9 +47,6 @@ true
 julia> isvalid(Char, 0xd799)
 true
 ```
-
-!!! compat "Julia 1.6"
-    Support for subarray values was added in Julia 1.6.
 """
 isvalid(T,value)
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -103,9 +103,6 @@ true
 julia> contains("abba", r"a.a")
 false
 ```
-
-!!! compat "Julia 1.5"
-    The `contains` function requires at least Julia 1.5.
 """
 contains(haystack::AbstractString, needle) = occursin(needle, haystack)
 
@@ -117,9 +114,6 @@ a function equivalent to `y -> endswith(y, suffix)`.
 
 The returned function is of type `Base.Fix2{typeof(endswith)}`, which can be
 used to implement specialized methods.
-
-!!! compat "Julia 1.5"
-    The single argument `endswith(suffix)` requires at least Julia 1.5.
 
 # Examples
 ```jldoctest
@@ -140,9 +134,6 @@ a function equivalent to `y -> startswith(y, prefix)`.
 
 The returned function is of type `Base.Fix2{typeof(startswith)}`, which can be
 used to implement specialized methods.
-
-!!! compat "Julia 1.5"
-    The single argument `startswith(prefix)` requires at least Julia 1.5.
 
 # Examples
 ```jldoctest
@@ -398,9 +389,6 @@ The optional `chars` argument specifies which characters to remove: it can be a 
 character, vector or set of characters.
 
 See also [`lstrip`](@ref) and [`rstrip`](@ref).
-
-!!! compat "Julia 1.2"
-    The method which accepts a predicate function requires Julia 1.2 or later.
 
 # Examples
 ```jldoctest

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -141,10 +141,6 @@ Some immutable parent arrays (like ranges) may choose to simply
 recompute a new array in some circumstances instead of returning
 a `SubArray` if doing so is efficient and provides compatible semantics.
 
-!!! compat "Julia 1.6"
-    In Julia 1.6 or later, `view` can be called on an `AbstractString`, returning a
-    `SubString`.
-
 # Examples
 ```jldoctest
 julia> A = [1 2; 3 4]

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -343,10 +343,7 @@ See documentation in [Handling Operating System Variation](@ref).
 
 !!! note
     Not to be confused with `Sys.isbsd()`, which is `true` on FreeBSD but also on
-    other BSD-based systems. `Sys.isfreebsd()` refers only to FreeBSD.
-!!! compat "Julia 1.1"
-    This function requires at least Julia 1.1.
-"""
+    other BSD-based systems. `Sys.isfreebsd()` refers only to FreeBSD."""
 isfreebsd(os::Symbol) = (os === :FreeBSD)
 
 """
@@ -357,10 +354,7 @@ See documentation in [Handling Operating System Variation](@ref).
 
 !!! note
     Not to be confused with `Sys.isbsd()`, which is `true` on OpenBSD but also on
-    other BSD-based systems. `Sys.isopenbsd()` refers only to OpenBSD.
-!!! compat "Julia 1.1"
-    This function requires at least Julia 1.1.
-"""
+    other BSD-based systems. `Sys.isopenbsd()` refers only to OpenBSD."""
 isopenbsd(os::Symbol) = (os === :OpenBSD)
 
 """
@@ -371,10 +365,7 @@ See documentation in [Handling Operating System Variation](@ref).
 
 !!! note
     Not to be confused with `Sys.isbsd()`, which is `true` on NetBSD but also on
-    other BSD-based systems. `Sys.isnetbsd()` refers only to NetBSD.
-!!! compat "Julia 1.1"
-    This function requires at least Julia 1.1.
-"""
+    other BSD-based systems. `Sys.isnetbsd()` refers only to NetBSD."""
 isnetbsd(os::Symbol) = (os === :NetBSD)
 
 """
@@ -385,10 +376,7 @@ See documentation in [Handling Operating System Variation](@ref).
 
 !!! note
     Not to be confused with `Sys.isbsd()`, which is `true` on DragonFly but also on
-    other BSD-based systems. `Sys.isdragonfly()` refers only to DragonFly.
-!!! compat "Julia 1.1"
-    This function requires at least Julia 1.1.
-"""
+    other BSD-based systems. `Sys.isdragonfly()` refers only to DragonFly."""
 isdragonfly(os::Symbol) = (os === :DragonFly)
 
 """
@@ -412,9 +400,6 @@ isapple(os::Symbol) = (os === :Apple || os === :Darwin)
 
 Predicate for testing if Julia is running in a JavaScript VM (JSVM),
 including e.g. a WebAssembly JavaScript embedding in a web browser.
-
-!!! compat "Julia 1.2"
-    This function requires at least Julia 1.2.
 """
 isjsvm(os::Symbol) = (os === :Emscripten)
 

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -376,7 +376,8 @@ See documentation in [Handling Operating System Variation](@ref).
 
 !!! note
     Not to be confused with `Sys.isbsd()`, which is `true` on DragonFly but also on
-    other BSD-based systems. `Sys.isdragonfly()` refers only to DragonFly."""
+    other BSD-based systems. `Sys.isdragonfly()` refers only to DragonFly.
+"""
 isdragonfly(os::Symbol) = (os === :DragonFly)
 
 """

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -343,7 +343,8 @@ See documentation in [Handling Operating System Variation](@ref).
 
 !!! note
     Not to be confused with `Sys.isbsd()`, which is `true` on FreeBSD but also on
-    other BSD-based systems. `Sys.isfreebsd()` refers only to FreeBSD."""
+    other BSD-based systems. `Sys.isfreebsd()` refers only to FreeBSD.
+"""
 isfreebsd(os::Symbol) = (os === :FreeBSD)
 
 """

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -355,7 +355,8 @@ See documentation in [Handling Operating System Variation](@ref).
 
 !!! note
     Not to be confused with `Sys.isbsd()`, which is `true` on OpenBSD but also on
-    other BSD-based systems. `Sys.isopenbsd()` refers only to OpenBSD."""
+    other BSD-based systems. `Sys.isopenbsd()` refers only to OpenBSD.
+"""
 isopenbsd(os::Symbol) = (os === :OpenBSD)
 
 """

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -365,7 +365,8 @@ See documentation in [Handling Operating System Variation](@ref).
 
 !!! note
     Not to be confused with `Sys.isbsd()`, which is `true` on NetBSD but also on
-    other BSD-based systems. `Sys.isnetbsd()` refers only to NetBSD."""
+    other BSD-based systems. `Sys.isnetbsd()` refers only to NetBSD.
+"""
 isnetbsd(os::Symbol) = (os === :NetBSD)
 
 """

--- a/base/task.jl
+++ b/base/task.jl
@@ -244,9 +244,6 @@ julia> yield();
 julia> istaskfailed(b)
 true
 ```
-
-!!! compat "Julia 1.3"
-    This function requires at least Julia 1.3.
 """
 istaskfailed(t::Task) = (load_state_acquire(t) === task_state_failed)
 
@@ -498,9 +495,6 @@ isolating the asynchronous code from changes to the variable's value in the curr
     threads in the current implementation of Julia.  Thus, seemingly innocent use of
     `@async` in a library function can have a large impact on the performance of very
     different parts of user applications.
-
-!!! compat "Julia 1.4"
-    Interpolating values via `\$` is available as of Julia 1.4.
 """
 macro async(expr)
     do_async_macro(expr)

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -173,9 +173,6 @@ For example, the above conditions imply that:
 Without the scheduler argument, the exact scheduling is unspecified and varies across Julia
 releases. Currently, `:dynamic` is used when the scheduler is not specified.
 
-!!! compat "Julia 1.5"
-    The `schedule` argument is available as of Julia 1.5.
-
 ### `:dynamic` (default)
 
 `:dynamic` scheduler executes iterations dynamically to available worker threads. Current
@@ -285,12 +282,6 @@ the variable's value in the current task.
 !!! note
     See the manual chapter on [multi-threading](@ref man-multithreading)
     for important caveats. See also the chapter on [threadpools](@ref man-threadpools).
-
-!!! compat "Julia 1.3"
-    This macro is available as of Julia 1.3.
-
-!!! compat "Julia 1.4"
-    Interpolating values via `\$` is available as of Julia 1.4.
 
 !!! compat "Julia 1.9"
     A threadpool may be specified as of Julia 1.9.

--- a/base/threads_overloads.jl
+++ b/base/threads_overloads.jl
@@ -34,9 +34,6 @@ julia> d = Channel{Int}(n) do ch
 julia> collect(d)
 collect(d) = [1, 4, 9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196, 225, 256, 289, 324, 361, 400]
 ```
-
-!!! compat "Julia 1.6"
-    This function requires Julia 1.6 or later.
 """
 function Threads.foreach(f, channel::Channel;
                          schedule::Threads.AbstractSchedule=Threads.FairSchedule(),

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -462,9 +462,6 @@ julia> propertynames(stats.gcstats)
 julia> stats.gcstats.total_time
 5576500
 ```
-
-!!! compat "Julia 1.5"
-    The return type of this macro was changed from `Tuple` to `NamedTuple` in Julia 1.5.
 """
 macro timed(ex)
     quote

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -110,9 +110,6 @@ if `collection` is an `AbstractString`, and an arbitrary iterator, falling back 
 Can be overloaded for user-defined collection types to customize the behavior of [slurping
 in assignments](@ref destructuring-assignment) in final position, like `a, b... = collection`.
 
-!!! compat "Julia 1.6"
-    `Base.rest` requires at least Julia 1.6.
-
 See also: [`first`](@ref first), [`Iterators.rest`](@ref), [`Base.split_rest`](@ref).
 
 # Examples

--- a/base/util.jl
+++ b/base/util.jl
@@ -142,12 +142,6 @@ Propagates any of the `--cpu-target`, `--sysimage`, `--compile`, `--sysimage-nat
 command line arguments that are not at their default values.
 
 Among others, `--math-mode`, `--warn-overwrite`, and `--trace-compile` are notably not propagated currently.
-
-!!! compat "Julia 1.1"
-    Only the `--cpu-target`, `--sysimage`, `--depwarn`, `--compile` and `--check-bounds` flags were propagated before Julia 1.1.
-
-!!! compat "Julia 1.5"
-    The flags `--color` and `--startup-file` were added in Julia 1.5.
 """
 function julia_cmd(julia=joinpath(Sys.BINDIR, julia_exename()))
     opts = JLOptions()
@@ -502,10 +496,6 @@ a required keyword argument in the resulting type constructor.
 Inner constructors can still be defined, but at least one should accept arguments in the
 same form as the default inner constructor (i.e. one positional argument per field) in
 order to function correctly with the keyword outer constructor.
-
-!!! compat "Julia 1.1"
-    `Base.@kwdef` for parametric structs, and structs with supertypes
-    requires at least Julia 1.1.
 
 !!! compat "Julia 1.9"
     This macro is exported as of Julia 1.9.

--- a/base/views.jl
+++ b/base/views.jl
@@ -95,10 +95,6 @@ copy without the `@view`.
 
 See also [`@views`](@ref) to switch an entire block of code to use views for non-scalar indexing.
 
-!!! compat "Julia 1.5"
-    Using `begin` in an indexing expression to refer to the first index requires at least
-    Julia 1.5.
-
 # Examples
 ```jldoctest
 julia> A = [1 2; 3 4]
@@ -222,10 +218,6 @@ Similarly, `@views` converts string slices into [`SubString`](@ref) views.
     The `@views` macro only affects `array[...]` expressions
     that appear explicitly in the given `expression`, not array slicing that
     occurs in functions called by that code.
-
-!!! compat "Julia 1.5"
-    Using `begin` in an indexing expression to refer to the first index requires at least
-    Julia 1.5.
 
 # Examples
 ```jldoctest

--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -404,10 +404,6 @@ These symbols appear in the `head` field of [`Expr`](@ref)s in lowered form.
     A 4-argument expression that defines a new primitive type. Arguments 1, 2, and 4
     are the same as `struct_type`. Argument 3 is the number of bits.
 
-    !!! compat "Julia 1.5"
-        `struct_type`, `abstract_type`, and `primitive_type` were removed in Julia 1.5
-        and replaced by calls to new builtins.
-
   * `global`
 
     Declares a global binding.
@@ -453,9 +449,6 @@ These symbols appear in the `head` field of [`Expr`](@ref)s in lowered form.
 
     Pop the stack of current exceptions back to the state at the associated `enter` when leaving a
     catch block. `args[1]` contains the token from the associated `enter`.
-
-    !!! compat "Julia 1.1"
-        `pop_exception` is new in Julia 1.1.
 
   * `inbounds`
 

--- a/doc/src/manual/command-line-interface.md
+++ b/doc/src/manual/command-line-interface.md
@@ -138,9 +138,3 @@ The following is a complete list of command-line switches available when launchi
 |`--output-incremental={yes\|no*}`      |Generate an incremental output file (rather than complete)|
 |`--trace-compile={stderr,name}`        |Print precompile statements for methods compiled during execution or save to a path|
 |`--image-codegen`                      |Force generate code in imaging mode|
-
-
-!!! compat "Julia 1.1"
-    In Julia 1.0, the default `--project=@.` option did not search up from the root
-    directory of a Git repository for the `Project.toml` file. From Julia 1.1 forward, it
-    does.

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -184,15 +184,9 @@ The default directory used by [`Pkg.develop`](https://pkgdocs.julialang.org/v1/a
 
 If set to `1`, this will ignore incorrect hashes in artifacts. This should be used carefully, as it disables verification of downloads, but can resolve issues when moving files across different types of file systems. See [Pkg.jl issue #2317](https://github.com/JuliaLang/Pkg.jl/issues/2317) for more details.
 
-!!! compat "Julia 1.6"
-    This is only supported in Julia 1.6 and above.
-
 ### `JULIA_PKG_OFFLINE`
 
 If set to `true`, this will enable offline mode: see [`Pkg.offline`](https://pkgdocs.julialang.org/v1/api/#Pkg.offline).
-
-!!! compat "Julia 1.5"
-    Pkg's offline mode requires Julia 1.5 or later.
 
 ### `JULIA_PKG_PRECOMPILE_AUTO`
 
@@ -296,10 +290,6 @@ to the number of CPU threads.
 !!! note
     `JULIA_NUM_THREADS` must be defined before starting julia; defining it in
     `startup.jl` is too late in the startup process.
-
-!!! compat "Julia 1.5"
-    In Julia 1.5 and above the number of threads can also be specified on startup
-    using the `-t`/`--threads` command line argument.
 
 !!! compat "Julia 1.7"
     The `auto` value for `$JULIA_NUM_THREADS` requires Julia 1.7 or above.

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -446,9 +446,6 @@ julia> b
 3
 ```
 
-!!! compat "Julia 1.6"
-    `...` with assignment requires Julia 1.6
-
 If the last symbol in the assignment list is suffixed by `...` (known as _slurping_), then
 it will be assigned a collection or lazy iterator of the remaining elements of the
 right-hand side iterator:

--- a/doc/src/manual/multi-threading.md
+++ b/doc/src/manual/multi-threading.md
@@ -22,10 +22,6 @@ The number of threads can either be specified as an integer (`--threads=4`) or a
 (`--threads=auto`), where `auto` tries to infer a useful default number of threads to use
 (see [Command-line Options](@ref command-line-interface) for more details).
 
-!!! compat "Julia 1.5"
-    The `-t`/`--threads` command line argument requires at least Julia 1.5.
-    In older versions you must use the environment variable instead.
-
 !!! compat "Julia 1.7"
     Using `auto` as value of the environment variable `JULIA_NUM_THREADS` requires at least Julia 1.7.
     In older versions, this value is ignored.

--- a/doc/src/manual/stacktraces.md
+++ b/doc/src/manual/stacktraces.md
@@ -187,9 +187,6 @@ ERROR: Whoops!
 
 ## Exception stacks and [`current_exceptions`](@ref)
 
-!!! compat "Julia 1.1"
-    Exception stacks requires at least Julia 1.1.
-
 While handling an exception further exceptions may be thrown. It can be useful to inspect all these exceptions to
 identify the root cause of a problem. The julia runtime supports this by pushing each exception onto an internal
 *exception stack* as it occurs. When the code exits a `catch` normally, any exceptions which were pushed onto the stack

--- a/stdlib/Artifacts/docs/src/index.md
+++ b/stdlib/Artifacts/docs/src/index.md
@@ -8,11 +8,6 @@ Starting with Julia 1.6, the artifacts support has moved from `Pkg.jl` to Julia 
 Until proper documentation can be added here, you can learn more about artifacts in the
 `Pkg.jl` manual at <https://julialang.github.io/Pkg.jl/v1/artifacts/>.
 
-!!! compat "Julia 1.6"
-    Julia's artifacts API requires at least Julia 1.6. In Julia
-    versions 1.3 to 1.5, you can use `Pkg.Artifacts` instead.
-
-
 ```@docs
 Artifacts.artifact_meta
 Artifacts.artifact_hash

--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -220,9 +220,6 @@ end
 
 Given an artifact (identified by SHA1 git tree hash), return its installation path.  If
 the artifact does not exist, returns the location it would be installed to.
-
-!!! compat "Julia 1.3"
-    This function requires at least Julia 1.3.
 """
 function artifact_path(hash::SHA1; honor_overrides::Bool=true)
     # Get all possible paths (rooted in all depots)
@@ -245,9 +242,6 @@ end
 Returns whether or not the given artifact (identified by its sha1 git tree hash) exists
 on-disk.  Note that it is possible that the given artifact exists in multiple locations
 (e.g. within multiple depots).
-
-!!! compat "Julia 1.3"
-    This function requires at least Julia 1.3.
 """
 function artifact_exists(hash::SHA1; honor_overrides::Bool=true)
     return any(isdir, artifact_paths(hash; honor_overrides=honor_overrides))
@@ -359,9 +353,6 @@ process_overrides(artifact_dict::Dict, pkg_uuid::Nothing) = nothing
 Get metadata about a given artifact (identified by name) stored within the given
 `(Julia)Artifacts.toml` file.  If the artifact is platform-specific, use `platform` to choose the
 most appropriate mapping.  If none is found, return `nothing`.
-
-!!! compat "Julia 1.3"
-    This function requires at least Julia 1.3.
 """
 function artifact_meta(name::String, artifacts_toml::String;
                        platform::AbstractPlatform = HostPlatform(),
@@ -412,9 +403,6 @@ end
 
 Thin wrapper around `artifact_meta()` to return the hash of the specified, platform-
 collapsed artifact.  Returns `nothing` if no mapping can be found.
-
-!!! compat "Julia 1.3"
-    This function requires at least Julia 1.3.
 """
 function artifact_hash(name::String, artifacts_toml::String;
                        platform::AbstractPlatform = HostPlatform(),
@@ -477,9 +465,6 @@ end
 Given the path to a `.jl` file, (such as the one returned by `__source__.file` in a macro
 context), find the `(Julia)Artifacts.toml` that is contained within the containing project (if it
 exists), otherwise return `nothing`.
-
-!!! compat "Julia 1.3"
-    This function requires at least Julia 1.3.
 """
 function find_artifacts_toml(path::String)
     if !isdir(path)
@@ -645,12 +630,6 @@ be taken to be path names indexing into the artifact, allowing for an easy one-l
 access a single file/directory within an artifact.  Example:
 
     ffmpeg_path = @artifact"FFMPEG/bin/ffmpeg"
-
-!!! compat "Julia 1.3"
-    This macro requires at least Julia 1.3.
-
-!!! compat "Julia 1.6"
-    Slash-indexing requires at least Julia 1.6.
 """
 macro artifact_str(name, platform=nothing)
     # Find Artifacts.toml file we're going to load from

--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -377,9 +377,6 @@ Construct a `DateTime` type by `Date` and `Time`.
 Non-zero microseconds or nanoseconds in the `Time` type will result in an
 `InexactError`.
 
-!!! compat "Julia 1.1"
-    This function requires at least Julia 1.1.
-
 ```jldoctest
 julia> d = Date(2018, 1, 1)
 2018-01-01

--- a/stdlib/Distributed/src/macros.jl
+++ b/stdlib/Distributed/src/macros.jl
@@ -35,9 +35,6 @@ Future(3, 1, 7, nothing)
 julia> fetch(f)
 3
 ```
-
-!!! compat "Julia 1.3"
-    As of Julia 1.3 this macro is deprecated. Use `@spawnat :any` instead.
 """
 macro spawn(expr)
     thunk = esc(:(()->($expr)))
@@ -75,9 +72,6 @@ Future(3, 1, 7, nothing)
 julia> fetch(f)
 3
 ```
-
-!!! compat "Julia 1.3"
-    The `:any` argument is available as of Julia 1.3.
 """
 macro spawnat(p, expr)
     thunk = esc(:(()->($expr)))

--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -141,10 +141,6 @@ addprocs([
    may hang with Windows workers that use older (pre-ConPTY) Julia or Windows versions,
    in which case `cmdline_cookie=true` offers a work-around.
 
-!!! compat "Julia 1.6"
-    The keyword arguments `ssh`, `shell`, `env` and `cmdline_cookie`
-    were added in Julia 1.6.
-
 Environment variables:
 
 If the master process fails to establish a connection with a newly launched worker within

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -84,9 +84,6 @@ The following defines the usage of terminal-based `emacs`:
         r"\\bemacs\\b.*\\s(-nw|--no-window-system)\\b", wait=true) do cmd, path, line
         `\$cmd +\$line \$path`
     end
-
-!!! compat "Julia 1.4"
-    `define_editor` was introduced in Julia 1.4.
 """
 function define_editor(fn::Function, pattern; wait::Bool=false)
     callback = function (cmd::Cmd, path::AbstractString, line::Integer, column::Integer)
@@ -240,9 +237,6 @@ end
 Edit the definition of a function, optionally specifying a tuple of types to indicate which
 method to edit. For modules, open the main source file. The module needs to be loaded with
 `using` or `import` first.
-
-!!! compat "Julia 1.1"
-    `edit` on modules requires at least Julia 1.1.
 
 To ensure that the file can be opened at the given line, you may need to call
 `define_editor` first.

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -533,10 +533,6 @@ If the keyword argument `parallel` is set to `true`, `peakflops` is run in paral
 the worker processors. The flop rate of the entire parallel computer is returned. When
 running in parallel, only 1 BLAS thread is used. The argument `n` still refers to the size
 of the problem that is solved on each processor.
-
-!!! compat "Julia 1.1"
-    This function requires at least Julia 1.1. In Julia 1.0 it is available from
-    the standard library `InteractiveUtils`.
 """
 function peakflops(n::Integer=2000; parallel::Bool=false)
     a = fill(1.,100,100)

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -135,9 +135,6 @@ end
     get_num_threads()
 
 Get the number of threads the BLAS library is using.
-
-!!! compat "Julia 1.6"
-    `get_num_threads` requires at least Julia 1.6.
 """
 get_num_threads()::Int = lbt_get_num_threads()
 
@@ -212,9 +209,6 @@ end
 
 Overwrite `X` with `c*X + s*Y` and `Y` with `-conj(s)*X + c*Y` for the first `n` elements of array `X` with stride `incx` and
 first `n` elements of array `Y` with stride `incy`. Returns `X` and `Y`.
-
-!!! compat "Julia 1.5"
-    `rot!` requires at least Julia 1.5.
 """
 function rot! end
 
@@ -988,10 +982,7 @@ The scalar inputs `α` and `β` must be complex or real numbers.
 
 The array inputs `x`, `y` and `AP` must all be of `ComplexF32` or `ComplexF64` type.
 
-Return the updated `y`.
-
-!!! compat "Julia 1.5"
-    `hpmv!` requires at least Julia 1.5.
+Return the updated `y`..
 """
 hpmv!
 
@@ -1149,9 +1140,6 @@ The scalar inputs `α` and `β` must be real.
 The array inputs `x`, `y` and `AP` must all be of `Float32` or `Float64` type.
 
 Return the updated `y`.
-
-!!! compat "Julia 1.5"
-    `spmv!` requires at least Julia 1.5.
 """
 spmv!
 

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -982,7 +982,7 @@ The scalar inputs `α` and `β` must be complex or real numbers.
 
 The array inputs `x`, `y` and `AP` must all be of `ComplexF32` or `ComplexF64` type.
 
-Return the updated `y`..
+Return the updated `y`.
 """
 hpmv!
 

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -359,9 +359,6 @@ _kronsize(A::AbstractVector, B::AbstractMatrix) = (length(A)*size(B, 1), size(B,
 
 Computes the Kronecker product of `A` and `B` and stores the result in `C`,
 overwriting the existing content of `C`. This is the in-place version of [`kron`](@ref).
-
-!!! compat "Julia 1.6"
-    This function requires Julia 1.6 or later.
 """
 function kron!(C::AbstractVecOrMat, A::AbstractVecOrMat, B::AbstractVecOrMat)
     size(C) == _kronsize(A, B) || throw(DimensionMismatch("kron!"))
@@ -623,10 +620,6 @@ exp_maybe_inplace(A) = exp(A)
     ^(b::Number, A::AbstractMatrix)
 
 Matrix exponential, equivalent to ``\\exp(\\log(b)A)``.
-
-!!! compat "Julia 1.1"
-    Support for raising `Irrational` numbers (like `ℯ`)
-    to a matrix was added in Julia 1.1.
 
 # Examples
 ```jldoctest

--- a/stdlib/LinearAlgebra/src/factorization.jl
+++ b/stdlib/LinearAlgebra/src/factorization.jl
@@ -24,10 +24,7 @@ checknonsingular(info) = checknonsingular(info, RowMaximum())
 """
     issuccess(F::Factorization)
 
-Test that a factorization of a matrix succeeded.
-
-!!! compat "Julia 1.6"
-    `issuccess(::CholeskyPivoted)` requires Julia 1.6 or later.
+Test that a factorization of a matrix succeeded..
 
 ```jldoctest
 julia> F = cholesky([1 0; 0 1]);

--- a/stdlib/LinearAlgebra/src/factorization.jl
+++ b/stdlib/LinearAlgebra/src/factorization.jl
@@ -24,7 +24,7 @@ checknonsingular(info) = checknonsingular(info, RowMaximum())
 """
     issuccess(F::Factorization)
 
-Test that a factorization of a matrix succeeded..
+Test that a factorization of a matrix succeeded.
 
 ```jldoctest
 julia> F = cholesky([1 0; 0 1]);

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -157,10 +157,6 @@ respects the semantics of the multiplication [`*`](@ref) between an
 element of `A` and `b`.  In particular, this also applies to
 multiplication involving non-finite numbers such as `NaN` and `±Inf`.
 
-!!! compat "Julia 1.1"
-    Prior to Julia 1.1, `NaN` and `±Inf` entries in `A` were treated
-    inconsistently.
-
 # Examples
 ```jldoctest
 julia> A = [1 2; 3 4]
@@ -194,10 +190,6 @@ Scale an array `B` by a scalar `a` overwriting `B` in-place.  Use
 respects the semantics of the multiplication [`*`](@ref) between `a`
 and an element of `B`.  In particular, this also applies to
 multiplication involving non-finite numbers such as `NaN` and `±Inf`.
-
-!!! compat "Julia 1.1"
-    Prior to Julia 1.1, `NaN` and `±Inf` entries in `B` were treated
-    inconsistently.
 
 # Examples
 ```jldoctest
@@ -898,9 +890,6 @@ without storing the intermediate result of `A*y`. As for the two-argument
 [`dot(_,_)`](@ref), this acts recursively. Moreover, for complex vectors, the
 first vector is conjugated.
 
-!!! compat "Julia 1.4"
-    Three-argument `dot` requires at least Julia 1.4.
-
 # Examples
 ```jldoctest
 julia> dot([1; 1], [1 2; 3 4], [2; 3])
@@ -948,11 +937,6 @@ values of `A` have magnitude greater than `max(atol, rtol*σ₁)` where `σ₁` 
 tolerances, respectively. The default relative tolerance is `n*ϵ`, where `n`
 is the size of the smallest dimension of `A`, and `ϵ` is the [`eps`](@ref) of
 the element type of `A`.
-
-!!! compat "Julia 1.1"
-    The `atol` and `rtol` keyword arguments requires at least Julia 1.1.
-    In Julia 1.0 `rtol` is available as a positional argument, but this
-    will be deprecated in Julia 2.0.
 
 # Examples
 ```jldoctest
@@ -1515,9 +1499,6 @@ end
 
 Overwrite `x` with `c*x + s*y` and `y` with `-conj(s)*x + c*y`.
 Returns `x` and `y`.
-
-!!! compat "Julia 1.5"
-    `rotate!` requires at least Julia 1.5.
 """
 function rotate!(x::AbstractVector, y::AbstractVector, c, s)
     require_one_based_indexing(x, y)
@@ -1538,9 +1519,6 @@ end
 
 Overwrite `x` with `c*x + s*y` and `y` with `conj(s)*x - c*y`.
 Returns `x` and `y`.
-
-!!! compat "Julia 1.5"
-    `reflect!` requires at least Julia 1.5.
 """
 function reflect!(x::AbstractVector, y::AbstractVector, c, s)
     require_one_based_indexing(x, y)

--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -9,9 +9,6 @@
 Construct an `UpperHessenberg` view of the matrix `A`.
 Entries of `A` below the first subdiagonal are ignored.
 
-!!! compat "Julia 1.3"
-    This type was added in Julia 1.3.
-
 Efficient algorithms are implemented for `H \\ b`, `det(H)`, and similar.
 
 See also the [`hessenberg`](@ref) function to factor any matrix into a similar

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -191,9 +191,6 @@ end
 Combined multiply-add, `A*y .+ z`, for matrix-matrix or matrix-vector multiplication.
 The result is always the same size as `A*y`, but `z` may be smaller, or a scalar.
 
-!!! compat "Julia 1.6"
-     These methods require Julia 1.6 or later.
-
 # Examples
 ```jldoctest
 julia> A=[1.0 2.0; 3.0 4.0]; B=[1.0 1.0; 1.0 1.0]; z=[0, 100];
@@ -282,9 +279,6 @@ end
 Combined inplace matrix-matrix or matrix-vector multiply-add ``A B α + C β``.
 The result is stored in `C` by overwriting it.  Note that `C` must not be
 aliased with either `A` or `B`.
-
-!!! compat "Julia 1.3"
-    Five-argument `mul!` requires at least Julia 1.3.
 
 # Examples
 ```jldoctest

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -303,9 +303,6 @@ but saves space by overwriting the input `A`, instead of creating a copy.
 An [`InexactError`](@ref) exception is thrown if the factorization produces a number not
 representable by the element type of `A`, e.g. for integer types.
 
-!!! compat "Julia 1.4"
-    The `blocksize` keyword argument requires Julia 1.4 or later.
-
 # Examples
 ```jldoctest
 julia> a = [1. 2.; 3. 4.]
@@ -388,9 +385,6 @@ orthogonal matrix.
 The block size for QR decomposition can be specified by keyword argument
 `blocksize :: Integer` when `pivot == NoPivot()` and `A isa StridedMatrix{<:BlasFloat}`.
 It is ignored when `blocksize > minimum(size(A))`.  See [`QRCompactWY`](@ref).
-
-!!! compat "Julia 1.4"
-    The `blocksize` keyword argument requires Julia 1.4 or later.
 
 # Examples
 ```jldoctest

--- a/stdlib/LinearAlgebra/src/svd.jl
+++ b/stdlib/LinearAlgebra/src/svd.jl
@@ -152,9 +152,6 @@ number of singular values.
 If `alg = DivideAndConquer()` a divide-and-conquer algorithm is used to calculate the SVD.
 Another (typically slower but more accurate) option is `alg = QRIteration()`.
 
-!!! compat "Julia 1.3"
-    The `alg` keyword argument requires Julia 1.3 or later.
-
 # Examples
 ```jldoctest
 julia> A = rand(4,3);

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -11,9 +11,6 @@ the identity operator, `λ*I`. Although without an explicit `size`, it
 acts similarly to a matrix in many cases and includes support for some
 indexing. See also [`I`](@ref).
 
-!!! compat "Julia 1.6"
-     Indexing using ranges is available as of Julia 1.6.
-
 # Examples
 ```jldoctest
 julia> J = UniformScaling(2.)
@@ -62,9 +59,6 @@ const I = UniformScaling(true)
     (I::UniformScaling)(n::Integer)
 
 Construct a `Diagonal` matrix from a `UniformScaling`.
-
-!!! compat "Julia 1.2"
-     This method is available as of Julia 1.2.
 
 # Examples
 ```jldoctest
@@ -366,10 +360,6 @@ isapprox(A::AbstractMatrix, J::UniformScaling; kwargs...) = isapprox(J, A; kwarg
     copyto!(dest::AbstractMatrix, src::UniformScaling)
 
 Copies a [`UniformScaling`](@ref) onto a matrix.
-
-!!! compat "Julia 1.1"
-    In Julia 1.0 this method only supported a square destination matrix. Julia 1.1. added
-    support for a rectangular matrix.
 """
 function copyto!(A::AbstractMatrix, J::UniformScaling)
     require_one_based_indexing(A)

--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -61,9 +61,6 @@ formatted string directly to `io`.
 
 For convenience, the `Printf.format"..."` string macro form can be used for building
 a `Printf.Format` object at macro-expansion-time.
-
-!!! compat "Julia 1.6"
-    `Printf.Format` requires Julia 1.6 or later.
 """
 struct Format{S, T}
     str::S # original full format string as CodeUnits
@@ -421,9 +418,6 @@ For arbitrary precision numerics, you might extend the method like:
 ```julia
 Printf.tofloat(x::MyArbitraryPrecisionType) = BigFloat(x)
 ```
-
-!!! compat "Julia 1.6"
-    This function requires Julia 1.6 or later.
 """
 tofloat(x) = Float64(x)
 tofloat(x::Base.IEEEFloat) = x

--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -149,9 +149,6 @@ keypress(m::AbstractMenu, i::UInt32) = false
     numoptions(m::AbstractMenu) -> Int
 
 Return the number of options in menu `m`. Defaults to `length(options(m))`.
-
-!!! compat "Julia 1.6"
-    This function requires Julia 1.6 or later.
 """
 numoptions(m::AbstractMenu) = length(options(m))
 
@@ -172,9 +169,6 @@ number used for the initial cursor position. `cursor` can be either an
 control of the cursor position from the outside.
 
 Returns `selected(m)`.
-
-!!! compat "Julia 1.6"
-    The `cursor` argument requires Julia 1.6 or later.
 """
 request(m::AbstractMenu; kwargs...) = request(terminal, m; kwargs...)
 

--- a/stdlib/REPL/src/TerminalMenus/MultiSelectMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/MultiSelectMenu.jl
@@ -51,9 +51,6 @@ were selected by the user.
   - `selected=[]`: pre-selected items. `i ∈ selected` means that `options[i]` is preselected.
 
 Any additional keyword arguments will be passed to [`TerminalMenus.MultiSelectConfig`](@ref).
-
-!!! compat "Julia 1.6"
-    The `selected` argument requires Julia 1.6 or later.
 """
 function MultiSelectMenu(options::Array{String,1}; pagesize::Int=10, selected=Int[], warn::Bool=true, kwargs...)
     length(options) < 1 && error("MultiSelectMenu must have at least one option")

--- a/stdlib/REPL/src/TerminalMenus/config.jl
+++ b/stdlib/REPL/src/TerminalMenus/config.jl
@@ -38,9 +38,6 @@ Configure behavior for selection menus via keyword arguments:
 
 Subtypes of `ConfiguredMenu` will print `cursor`, `up_arrow`, and `down_arrow` automatically
 as needed, your `writeline` method should not print them.
-
-!!! compat "Julia 1.6"
-    `Config` is available as of Julia 1.6. On older releases use the global `CONFIG`.
 """
 function Config(;
                 charset::Symbol = :ascii,
@@ -80,9 +77,6 @@ Configure behavior for a multiple-selection menu via keyword arguments:
 All other keyword arguments are as described for [`TerminalMenus.Config`](@ref).
 `checked` and `unchecked` are not printed automatically, and should be printed by
 your `writeline` method.
-
-!!! compat "Julia 1.6"
-    `MultiSelectConfig` is available as of Julia 1.6. On older releases use the global `CONFIG`.
 """
 function MultiSelectConfig(;
                            charset::Symbol = :ascii,
@@ -108,9 +102,6 @@ end
     CONFIG
 
 Global menu configuration parameters
-
-!!! compat "Julia 1.6"
-    `CONFIG` is deprecated, instead configure menus via their constructors.
 """
 const CONFIG = Dict{Symbol,Union{Char,String,Bool}}()
 
@@ -129,9 +120,6 @@ Keyword-only function to configure global menu parameters
  - `scroll::Symbol=:nowrap`: If `:wrap` wrap cursor around top and bottom, if :`nowrap` do not wrap cursor
  - `supress_output::Bool=false`: Ignored legacy argument, pass `suppress_output` as a keyword argument to `request` instead.
  - `ctrl_c_interrupt::Bool=true`: If `false`, return empty on ^C, if `true` throw InterruptException() on ^C
-
-!!! compat "Julia 1.6"
-    As of Julia 1.6, `config` is deprecated. Use `Config` or `MultiSelectConfig` instead.
 """
 function config(;charset::Symbol = :na,
                 scroll::Symbol = :na,

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -339,9 +339,6 @@ Return the default global random number generator (RNG).
     What the default RNG is is an implementation detail.  Across different versions of
     Julia, you should not expect the default RNG to be always the same, nor that it will
     return the same stream of random numbers for a given seed.
-
-!!! compat "Julia 1.3"
-    This function was introduced in Julia 1.3.
 """
 @inline default_rng() = TaskLocalRNG()
 @inline default_rng(tid::Int) = TaskLocalRNG()

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -325,10 +325,6 @@ Pick a random element or array of random elements from the set of values specifi
 When only one argument is passed besides the optional `rng` and is a `Tuple`, it is interpreted
 as a collection of values (`S`) and not as `dims`.
 
-
-!!! compat "Julia 1.1"
-    Support for `S` as a tuple requires at least Julia 1.1.
-
 # Examples
 ```julia-repl
 julia> rand(Int, 2)

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -279,10 +279,6 @@ of `n`.
 To randomly permute an arbitrary vector, see [`shuffle`](@ref) or
 [`shuffle!`](@ref).
 
-!!! compat "Julia 1.1"
-    In Julia 1.1 `randperm` returns a vector `v` with `eltype(v) == typeof(n)`
-    while in Julia 1.0 `eltype(v) == Int`.
-
 # Examples
 ```jldoctest
 julia> randperm(MersenneTwister(1234), 4)
@@ -342,10 +338,6 @@ randperm!(a::Array{<:Integer}) = randperm!(default_rng(), a)
 Construct a random cyclic permutation of length `n`. The optional `rng`
 argument specifies a random number generator, see [Random Numbers](@ref).
 The element type of the result is the same as the type of `n`.
-
-!!! compat "Julia 1.1"
-    In Julia 1.1 `randcycle` returns a vector `v` with `eltype(v) == typeof(n)`
-    while in Julia 1.0 `eltype(v) == Int`.
 
 # Examples
 ```jldoctest

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -782,9 +782,6 @@ end
     serialize(filename::AbstractString, value)
 
 Open a file and serialize the given value to it.
-
-!!! compat "Julia 1.1"
-    This method is available as of Julia 1.1.
 """
 serialize(filename::AbstractString, x) = open(io->serialize(io, x), filename, "w")
 
@@ -805,9 +802,6 @@ deserialize(s::IO) = deserialize(Serializer(s))
     deserialize(filename::AbstractString)
 
 Open a file and deserialize its contents.
-
-!!! compat "Julia 1.1"
-    This method is available as of Julia 1.1.
 """
 deserialize(filename::AbstractString) = open(deserialize, filename)
 

--- a/stdlib/Sockets/src/IPAddr.jl
+++ b/stdlib/Sockets/src/IPAddr.jl
@@ -293,9 +293,6 @@ InetAddr(ip::IPAddr, port) = InetAddr{typeof(ip)}(ip, port)
 Return an `InetAddr` object from ip address `str` formatted as [`AbstractString`](@ref)
 and port number `port`.
 
-!!! compat "Julia 1.3"
-    This constructor requires at least Julia 1.3.
-
 # Examples
 ```jldoctest
 julia> Sockets.InetAddr("127.0.0.1", 8000)

--- a/stdlib/Sockets/src/Sockets.jl
+++ b/stdlib/Sockets/src/Sockets.jl
@@ -332,10 +332,6 @@ function uv_recvcb end
 
 Read a UDP packet from the specified socket, returning a tuple of `(host_port, data)`, where
 `host_port` will be an InetAddr{IPv4} or InetAddr{IPv6}, as appropriate.
-
-!!! compat "Julia 1.3"
-    Prior to Julia version 1.3, the first returned value was an address (`IPAddr`).
-    In version 1.3 it was changed to an `InetAddr`.
 """
 function recvfrom(sock::UDPSocket)
     iolock_begin()
@@ -568,9 +564,6 @@ end
     nagle(socket::Union{TCPServer, TCPSocket}, enable::Bool)
 
 Enables or disables Nagle's algorithm on a given TCP server or socket.
-
-!!! compat "Julia 1.3"
-    This function requires Julia 1.3 or later.
 """
 function nagle(sock::Union{TCPServer, TCPSocket}, enable::Bool)
     # disable or enable Nagle's algorithm on all OSes

--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -285,9 +285,6 @@ Setting the optional `addr_type` parameter to `IPv4` or `IPv6` causes only addre
 
 The `loopback` keyword argument dictates whether loopback addresses (e.g. `ip"127.0.0.1"`, `ip"::1"`) are included.
 
-!!! compat "Julia 1.2"
-    This function is available as of Julia 1.2.
-
 # Examples
 ```julia-repl
 julia> getipaddrs()

--- a/stdlib/UUIDs/src/UUIDs.jl
+++ b/stdlib/UUIDs/src/UUIDs.jl
@@ -48,9 +48,6 @@ an argument should be expected to return a unique identifier. Importantly, the o
 `uuid1` uses `Random.RandomDevice` as the default rng. However, this is an implementation
 detail that may change in the future.
 
-!!! compat "Julia 1.6"
-    The output of `uuid1` does not depend on `GLOBAL_RNG` as of Julia 1.6.
-
 # Examples
 ```jldoctest; filter = r"[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}"
 julia> rng = MersenneTwister(1234);
@@ -94,9 +91,6 @@ an argument should be expected to return a unique identifier. Importantly, the o
 `uuid4` uses `Random.RandomDevice` as the default rng. However, this is an implementation
 detail that may change in the future.
 
-!!! compat "Julia 1.6"
-    The output of `uuid4` does not depend on `GLOBAL_RNG` as of Julia 1.6.
-
 # Examples
 ```jldoctest
 julia> rng = MersenneTwister(1234);
@@ -117,9 +111,6 @@ end
 
 Generates a version 5 (namespace and domain-based) universally unique identifier (UUID),
 as specified by RFC 4122.
-
-!!! compat "Julia 1.1"
-    This function requires at least Julia 1.1.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
These are starting to clutter the documentation quite heavily. For people stuck on very old Julia versions, there are always the older builds of the manual. 