### PR TITLE
Follow-up #46693 - Also exclude `Type{Tuple{Union{...}, ...}}`

### DIFF
--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -28,7 +28,7 @@ end
 
 For a type `t` test whether ∀S s.t. `isa(S, rewrap_unionall(Type{t}, ...))`,
 we have `isa(S, DataType)`. In particular, if a statement is typed as `Type{t}`
-(potentiall wrapped in some UnionAll), then we are guaranteed that this statement
+(potentially wrapped in some UnionAll), then we are guaranteed that this statement
 will be a DataType at runtime (and not e.g. a Union or UnionAll typeequal to it).
 """
 function isTypeDataType(@nospecialize t)
@@ -39,7 +39,7 @@ function isTypeDataType(@nospecialize t)
     if t.name === Tuple.name
         # If we have a Union parameter, could have been redistributed at runtime,
         # e.g. `Tuple{Union{Int, Float64}, Int}` is a DataType, but
-        # `Union{Tuple{Inr, Int}, Tuple{Float64, Int}}` is typeequal to it and
+        # `Union{Tuple{Int, Int}, Tuple{Float64, Int}}` is typeequal to it and
         # is not.
         return _all(isTypeDataType, t.parameters)
     end

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -23,6 +23,29 @@ function hasuniquerep(@nospecialize t)
     return false
 end
 
+"""
+    isTypeDataType(@nospecialize t)
+
+For a type `t` test whether ∀S s.t. `isa(S, rewrap_unionall(Type{t}, ...))`,
+we have `isa(S, DataType)`. In particular, if a statement is typed as `Type{t}`
+(potentiall wrapped in some UnionAll), then we are guaranteed that this statement
+will be a DataType at runtime (and not e.g. a Union or UnionAll typeequal to it).
+"""
+function isTypeDataType(@nospecialize t)
+    isa(t, DataType) || return false
+    isType(t) && return false
+    # Could be Union{} at runtime
+    t === Core.TypeofBottom && return false
+    if t.name === Tuple.name
+        # If we have a Union parameter, could have been redistributed at runtime,
+        # e.g. `Tuple{Union{Int, Float64}, Int}` is a DataType, but
+        # `Union{Tuple{Inr, Int}, Tuple{Float64, Int}}` is typeequal to it and
+        # is not.
+        return _all(isTypeDataType, t.parameters)
+    end
+    return true
+end
+
 function has_nontrivial_const_info(lattice::PartialsLattice, @nospecialize t)
     isa(t, PartialStruct) && return true
     isa(t, PartialOpaque) && return true

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1511,4 +1511,5 @@ end
 
 # Test getfield modeling of Type{Ref{_A}} where _A
 @test Core.Compiler.getfield_tfunc(Type, Core.Compiler.Const(:parameters)) !== Union{}
+@test !isa(Core.Compiler.getfield_tfunc(Type{Tuple{Union{Int, Float64}, Int}}, Core.Compiler.Const(:name)), Core.Compiler.Const)
 @test fully_eliminated(Base.ismutable, Tuple{Base.RefValue})


### PR DESCRIPTION
The check in #46693 was attempting to guarantee that the runtime value was a `DataType`, but was missing at least the case where a tuple of unions could have been re-distributed. Fix that up and refactor while we're at it.