### PR TITLE
Test: fixup issues detected by JET

### DIFF
--- a/stdlib/Test/src/logging.jl
+++ b/stdlib/Test/src/logging.jl
@@ -120,9 +120,9 @@ end
 # Log testing tools
 
 # Failure result type for log testing
-mutable struct LogTestFailure <: Result
+struct LogTestFailure <: Result
     orig_expr
-    source::Union{Nothing,LineNumberNode}
+    source::LineNumberNode
     patterns
     logs
 end
@@ -153,8 +153,8 @@ function record(ts::DefaultTestSet, t::LogTestFailure)
         println()
     end
     # Hack: convert to `Fail` so that test summarization works correctly
-    push!(ts.results, Fail(:test, t.orig_expr, t.logs, nothing, nothing, t.source))
-    t
+    push!(ts.results, Fail(:test, t.orig_expr, t.logs, nothing, nothing, t.source, false))
+    return t
 end
 
 """


### PR DESCRIPTION
This commit:
- removes stale definition of `test_approx_eq` (this seems to have been reserved for the 0.7 compat, but is currently broken as `full` is really not defined anymore)
- fix invalid construction of `Fail` object
- makes `LogTestFailure` more type stable struct
- improves type stabilities slightly