### PR TITLE
improve type stability of `lt(p::Perm, a::Integer, b::Integer)`

### DIFF
--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -122,7 +122,7 @@ lt(o::Lt,                    a, b) = o.lt(a,b)
 @propagate_inbounds function lt(p::Perm, a::Integer, b::Integer)
     da = p.data[a]
     db = p.data[b]
-    lt(p.order, da, db) | (!lt(p.order, db, da) & (a < b))
+    (lt(p.order, da, db)::Bool) | (!(lt(p.order, db, da)::Bool) & (a < b))
 end
 
 _ord(lt::typeof(isless), by::typeof(identity), order::Ordering) = order


### PR DESCRIPTION
This fixes a few hundred invalidations when loading Static/jl/ArrayInterface.jl. It's based on the following code.

```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add("ArrayInterface")

julia> using SnoopCompileCore; invalidations = @snoopr(using ArrayInterface); using SnoopCompile

julia> trees = invalidation_trees(invalidations);

julia> ftrees = filtermod(Base.Sort, trees; recursive=true)
...
 inserting &(x::Static.True, y::Bool) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:411 invalidated:
   mt_backedges: 1: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{<:Base.Order.ForwardOrdering, <:Union{AbstractVector{Union{Missing, Float32}}, AbstractVector{Union{Missing, Float64}}, AbstractVector{Missing}, AbstractVector{Float32}, AbstractVector{Float64}}}, ::Int64, ::Int64) (9 children)
                 2: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{_A, Vector{Base.StackTraces.StackFrame}} where _A<:Base.Order.Ordering, ::Int64, ::Int64) (13 children)
                 3: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{_A, Vector{Int64}} where _A<:Base.Order.Ordering, ::Int64, ::Int64) (18 children)
                 4: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{_A, Vector{Float64}} where _A<:Base.Order.Ordering, ::Int64, ::Int64) (28 children)
                 5: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{_A, Vector{Tuple{Float64, Float64}}} where _A<:Base.Order.Ordering, ::Int64, ::Int64) (49 children)
                 6: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{<:Base.Order.ReverseOrdering{Base.Order.ForwardOrdering}, <:Union{AbstractVector{Union{Missing, Float32}}, AbstractVector{Union{Missing, Float64}}, AbstractVector{Missing}, AbstractVector{Float32}, AbstractVector{Float64}}}, ::Int64, ::Int64) (23 children)

julia> ftrees = filtermod(Base.Order, trees; recursive=true)
2-element Vector{SnoopCompile.MethodInvalidations}:
 inserting !(::Static.False) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:427 invalidated:
   mt_backedges: 1: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{<:Base.Order.ReverseOrdering{Base.Order.ForwardOrdering}, <:Union{AbstractVector{Union{Missing, Float32}}, AbstractVector{Union{Missing, Float64}}, AbstractVector{Missing}, AbstractVector{Float32}, AbstractVector{Float64}}}, ::Int64, ::Int64) (0 children)
                 2: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{<:Base.Order.ForwardOrdering, <:Union{AbstractVector{Union{Missing, Float32}}, AbstractVector{Union{Missing, Float64}}, AbstractVector{Missing}, AbstractVector{Float32}, AbstractVector{Float64}}}, ::Int64, ::Int64) (0 children)
                 3: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{_A, Vector{Float64}} where _A<:Base.Order.Ordering, ::Int64, ::Int64) (0 children)
                 4: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{_A, Vector{Tuple{Float64, Float64}}} where _A<:Base.Order.Ordering, ::Int64, ::Int64) (0 children)
                 5: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{_A, Vector{Int64}} where _A<:Base.Order.Ordering, ::Int64, ::Int64) (0 children)
                 6: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{_A, Vector{Base.StackTraces.StackFrame}} where _A<:Base.Order.Ordering, ::Int64, ::Int64) (0 children)

 inserting &(x::Static.True, y::Bool) in Static at ~/.julia/packages/Static/sVI3g/src/Static.jl:411 invalidated:
   mt_backedges: 1: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{<:Base.Order.ForwardOrdering, <:Union{AbstractVector{Union{Missing, Float32}}, AbstractVector{Union{Missing, Float64}}, AbstractVector{Missing}, AbstractVector{Float32}, AbstractVector{Float64}}}, ::Int64, ::Int64) (9 children)
                 2: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{_A, Vector{Base.StackTraces.StackFrame}} where _A<:Base.Order.Ordering, ::Int64, ::Int64) (13 children)
                 3: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{_A, Vector{Int64}} where _A<:Base.Order.Ordering, ::Int64, ::Int64) (18 children)
                 4: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{_A, Vector{Float64}} where _A<:Base.Order.Ordering, ::Int64, ::Int64) (28 children)
                 5: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{_A, Vector{Tuple{Float64, Float64}}} where _A<:Base.Order.Ordering, ::Int64, ::Int64) (49 children)
                 6: signature Tuple{typeof(&), Any, Bool} triggered MethodInstance for Base.Order.lt(::Base.Order.Perm{<:Base.Order.ReverseOrdering{Base.Order.ForwardOrdering}, <:Union{AbstractVector{Union{Missing, Float32}}, AbstractVector{Union{Missing, Float64}}, AbstractVector{Missing}, AbstractVector{Float32}, AbstractVector{Float64}}}, ::Int64, ::Int64) (166 children)
```

With this PR, all of these invalidations are gone (but some others are still left, of course).

We cannot fix the type instabilities at a higher level since `sort!` (or its kwarg handler) avoids specialization on the keyword arguments `by` and `lt` given as functions.