### PR TITLE
Clarify domain in argmin/argmax docstring

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -989,7 +989,7 @@ _findmin(a, ::Colon) = findmin(identity, a)
 """
     argmax(f, domain)
 
-Return a value `x` in the domain of `f` for which `f(x)` is maximised.
+Return a value `x` from `domain` for which `f(x)` is maximised.
 If there are multiple maximal values for `f(x)` then the first one will be found.
 
 `domain` must be a non-empty iterable.
@@ -1041,7 +1041,7 @@ argmax(itr) = findmax(itr)[2]
 """
     argmin(f, domain)
 
-Return a value `x` in the domain of `f` for which `f(x)` is minimised.
+Return a value `x` from `domain` for which `f(x)` is minimised.
 If there are multiple minimal values for `f(x)` then the first one will be found.
 
 `domain` must be a non-empty iterable.


### PR DESCRIPTION
The current phrasing "Return a value `x` in the domain of `f`" is a bit misleading, as the domain of `f` may be much larger than the argument `domain`. It's better to be clear that the value returned will be an element of the `domain` that is provided.