### PR TITLE
only store version of packages during load time when generating sysimage

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -460,6 +460,18 @@ function pkgdir(m::Module, paths::String...)
     return joinpath(dirname(dirname(path)), paths...)
 end
 
+function get_pkgversion_from_path(path)
+    project_file = locate_project_file(path)
+    if project_file isa String
+        d = parsed_toml(project_file)
+        v = get(d, "version", nothing)
+        if v !== nothing
+            return VersionNumber(v::String)
+        end
+    end
+    return nothing
+end
+
 """
     pkgversion(m::Module)
 
@@ -477,12 +489,17 @@ the form `pkgversion(@__MODULE__)` can be used.
     This function was introduced in Julia 1.9.
 """
 function pkgversion(m::Module)
-    rootmodule = moduleroot(m)
-    pkg = PkgId(rootmodule)
-    pkgorigin = @lock require_lock begin
-        get(pkgorigins, pkg, nothing)
+    path = pkgdir(m)
+    path === nothing && return nothing
+    @lock require_lock begin
+        v = get_pkgversion_from_path(path)
+        pkgorigin = get(pkgorigins, PkgId(moduleroot(m)), nothing)
+        # Cache the version
+        if pkgorigin !== nothing && pkgorigin.version === nothing
+            pkgorigin.version = v
+        end
+        return v
     end
-    return pkgorigin === nothing ? nothing : pkgorigin.version
 end
 
 ## generic project & manifest API ##
@@ -1356,13 +1373,9 @@ function set_pkgorigin_version_path(pkg::PkgId, path::Union{String,Nothing})
     assert_havelock(require_lock)
     pkgorigin = get!(PkgOrigin, pkgorigins, pkg)
     if path !== nothing
-        project_file = locate_project_file(joinpath(dirname(path), ".."))
-        if project_file isa String
-            d = parsed_toml(project_file)
-            v = get(d, "version", nothing)
-            if v !== nothing
-                pkgorigin.version = VersionNumber(v::AbstractString)
-            end
+        # Pkg needs access to the version of packages in the sysimage.
+        if Core.Compiler.generating_sysimg()
+            pkgorigin.version = get_pkgversion_from_path(joinpath(dirname(path), ".."))
         end
     end
     pkgorigin.path = path

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -662,7 +662,7 @@ finally
     Base.set_active_project(old_act_proj)
     popfirst!(LOAD_PATH)
 end
-@test Base.pkgorigins[Base.PkgId(UUID("69145d58-7df6-11e8-0660-cf7622583916"), "TestPkg")].version == v"1.2.3"
+@test pkgversion(TestPkg) == v"1.2.3"
 
 @testset "--project and JULIA_PROJECT paths should be absolutified" begin
     mktempdir() do dir; cd(dir) do


### PR DESCRIPTION
I am looking at the number of stat calls during code loading (precompilation). One somewhat significant source of these is the lookup of the `version` field in the project file of packages (added in https://github.com/JuliaLang/julia/pull/44318) that happens as soon as a package is loaded. Due to the way the precompilation process work (IIUC), the number of these lookup scales quadratically with the depth of the dependency tree of a package.

This PR changes it so that the lookup only happens when a call to `pkgversion` actually requests the version. An exception is when a sysimage is generated (for example from PackageCompiler) because then we want to also store the version to support the functionality in https://github.com/JuliaLang/Pkg.jl/pull/3002.

The script I am using to measure the number of stat calls is:
```
❯ rm -rf ~/.julia/compiled/v1.9;  strace -f -o stat_gr~/juliaarray/julia --project -e 'using GR_jll'

❯ cat stat_gr | grep -c statx
```

executed in an environment with only `GR_jll` installed. The results are

```
❯ cat stat_master | grep -c statx
23789
``` 

```
❯ cat stat_master | grep -c statx
21236
```

This may not seem like a huge reduction but further work on https://github.com/JuliaLang/julia/pull/46690 brings the baseline down heavily where this absolute difference is quite significant.