### PR TITLE
inference: fixes and improvements for backedge computation

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -126,7 +126,6 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
             for sig_n in splitsigs
                 result = abstract_call_method(interp, method, sig_n, svec(), multiple_matches, sv)
                 (; rt, edge, effects) = result
-                edge === nothing || push!(edges, edge)
                 this_argtypes = isa(matches, MethodMatches) ? argtypes : matches.applicable_argtypes[i]
                 this_arginfo = ArgInfo(fargs, this_argtypes)
                 const_call_result = abstract_call_method_with_const_args(interp, result,
@@ -135,12 +134,13 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
                 if const_call_result !== nothing
                     if const_call_result.rt ⊑ᵢ rt
                         rt = const_call_result.rt
-                        (; effects, const_result) = const_call_result
+                        (; effects, const_result, edge) = const_call_result
                     end
                 end
                 all_effects = merge_effects(all_effects, effects)
                 push!(const_results, const_result)
                 any_const_result |= const_result !== nothing
+                edge === nothing || push!(edges, edge)
                 this_rt = tmerge(this_rt, rt)
                 if bail_out_call(interp, this_rt, sv)
                     break
@@ -153,7 +153,6 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
             (; rt, edge, effects) = result
             this_conditional = ignorelimited(rt)
             this_rt = widenwrappedconditional(rt)
-            edge === nothing || push!(edges, edge)
             # try constant propagation with argtypes for this match
             # this is in preparation for inlining, or improving the return result
             this_argtypes = isa(matches, MethodMatches) ? argtypes : matches.applicable_argtypes[i]
@@ -169,12 +168,13 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
                 if this_const_rt ⊑ᵢ this_rt
                     this_conditional = this_const_conditional
                     this_rt = this_const_rt
-                    (; effects, const_result) = const_call_result
+                    (; effects, const_result, edge) = const_call_result
                 end
             end
             all_effects = merge_effects(all_effects, effects)
             push!(const_results, const_result)
             any_const_result |= const_result !== nothing
+            edge === nothing || push!(edges, edge)
         end
         @assert !(this_conditional isa Conditional) "invalid lattice element returned from inter-procedural context"
         seen += 1
@@ -838,17 +838,18 @@ function concrete_eval_call(interp::AbstractInterpreter,
             f = invoke
         end
         world = get_world_counter(interp)
+        edge = result.edge::MethodInstance
         value = try
             Core._call_in_world_total(world, f, args...)
         catch
             # The evaluation threw. By :consistent-cy, we're guaranteed this would have happened at runtime
-            return ConstCallResults(Union{}, ConcreteResult(result.edge::MethodInstance, result.effects), result.effects)
+            return ConstCallResults(Union{}, ConcreteResult(edge, result.effects), result.effects, edge)
         end
         if is_inlineable_constant(value) || call_result_unused(sv)
             # If the constant is not inlineable, still do the const-prop, since the
             # code that led to the creation of the Const may be inlineable in the same
             # circumstance and may be optimizable.
-            return ConstCallResults(Const(value), ConcreteResult(result.edge::MethodInstance, EFFECTS_TOTAL, value), EFFECTS_TOTAL)
+            return ConstCallResults(Const(value), ConcreteResult(edge, EFFECTS_TOTAL, value), EFFECTS_TOTAL, edge)
         end
         return false
     else # eligible for semi-concrete evaluation
@@ -875,10 +876,12 @@ struct ConstCallResults
     rt::Any
     const_result::ConstResult
     effects::Effects
+    edge::MethodInstance
     ConstCallResults(@nospecialize(rt),
                      const_result::ConstResult,
-                     effects::Effects) =
-        new(rt, const_result, effects)
+                     effects::Effects,
+                     edge::MethodInstance) =
+        new(rt, const_result, effects, edge)
 end
 
 function abstract_call_method_with_const_args(interp::AbstractInterpreter,
@@ -888,14 +891,7 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter,
         return nothing
     end
     res = concrete_eval_call(interp, f, result, arginfo, sv, invokecall)
-    if isa(res, ConstCallResults)
-        if invokecall === nothing
-            add_backedge!(sv, res.const_result.mi)
-        else
-            add_invoke_backedge!(sv, invokecall.lookupsig, res.const_result.mi)
-        end
-        return res
-    end
+    isa(res, ConstCallResults) && return res
     mi = maybe_get_const_prop_profitable(interp, result, f, arginfo, match, sv)
     mi === nothing && return nothing
     # try semi-concrete evaluation
@@ -907,7 +903,7 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter,
             if isa(ir, IRCode)
                 T = ir_abstract_constant_propagation(interp, mi_cache, sv, mi, ir, arginfo.argtypes)
                 if !isa(T, Type) || typeintersect(T, Bool) === Union{}
-                    return ConstCallResults(T, SemiConcreteResult(mi, ir, result.effects), result.effects)
+                    return ConstCallResults(T, SemiConcreteResult(mi, ir, result.effects), result.effects, mi)
                 end
             end
         end
@@ -940,8 +936,7 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter,
     result = inf_result.result
     # if constant inference hits a cycle, just bail out
     isa(result, InferenceState) && return nothing
-    add_backedge!(sv, mi)
-    return ConstCallResults(result, ConstPropResult(inf_result), inf_result.ipo_effects)
+    return ConstCallResults(result, ConstPropResult(inf_result), inf_result.ipo_effects, mi)
 end
 
 # if there's a possibility we could get a better result with these constant arguments
@@ -1696,7 +1691,6 @@ function abstract_invoke(interp::AbstractInterpreter, (; fargs, argtypes)::ArgIn
     ti = tienv[1]; env = tienv[2]::SimpleVector
     result = abstract_call_method(interp, method, ti, env, false, sv)
     (; rt, edge, effects) = result
-    edge !== nothing && add_invoke_backedge!(sv, lookupsig, edge::MethodInstance)
     match = MethodMatch(ti, env, method, argtype <: method.sig)
     res = nothing
     sig = match.spec_types
@@ -1715,10 +1709,11 @@ function abstract_invoke(interp::AbstractInterpreter, (; fargs, argtypes)::ArgIn
     const_result = nothing
     if const_call_result !== nothing
         if ⊑(typeinf_lattice(interp), const_call_result.rt, rt)
-            (; rt, effects, const_result) = const_call_result
+            (; rt, effects, const_result, edge) = const_call_result
         end
     end
     effects = Effects(effects; nonoverlayed=!overlayed)
+    edge !== nothing && add_invoke_backedge!(sv, lookupsig, edge)
     return CallMeta(from_interprocedural!(ipo_lattice(interp), rt, sv, arginfo, sig), effects, InvokeCallInfo(match, const_result))
 end
 
@@ -1852,7 +1847,6 @@ function abstract_call_opaque_closure(interp::AbstractInterpreter,
     sig = argtypes_to_type(arginfo.argtypes)
     result = abstract_call_method(interp, closure.source, sig, Core.svec(), false, sv)
     (; rt, edge, effects) = result
-    edge !== nothing && add_backedge!(sv, edge)
     tt = closure.typ
     sigT = (unwrap_unionall(tt)::DataType).parameters[1]
     match = MethodMatch(sig, Core.svec(), closure.source, sig <: rewrap_unionall(sigT, tt))
@@ -1862,7 +1856,7 @@ function abstract_call_opaque_closure(interp::AbstractInterpreter,
             nothing, arginfo, match, sv)
         if const_call_result !== nothing
             if const_call_result.rt ⊑ rt
-                (; rt, effects, const_result) = const_call_result
+                (; rt, effects, const_result, edge) = const_call_result
             end
         end
     end
@@ -1878,6 +1872,7 @@ function abstract_call_opaque_closure(interp::AbstractInterpreter,
         end
     end
     rt = from_interprocedural!(ipo, rt, sv, arginfo, match.spec_types)
+    edge !== nothing && add_backedge!(sv, edge)
     return CallMeta(rt, effects, info)
 end
 

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -65,9 +65,13 @@ intersect!(et::EdgeTracker, range::WorldRange) =
     et.valid_worlds[] = intersect(et.valid_worlds[], range)
 
 push!(et::EdgeTracker, mi::MethodInstance) = push!(et.edges, mi)
-function add_edge!(et::EdgeTracker, @nospecialize(invokesig), mi::MethodInstance)
-    invokesig === nothing && return push!(et.edges, mi)
+function add_backedge!(et::EdgeTracker, mi::MethodInstance)
+    push!(et.edges, mi)
+    return nothing
+end
+function add_invoke_backedge!(et::EdgeTracker, @nospecialize(invokesig), mi::MethodInstance)
     push!(et.edges, invokesig, mi)
+    return nothing
 end
 function push!(et::EdgeTracker, ci::CodeInstance)
     intersect!(et, WorldRange(min_world(li), max_world(li)))

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -64,7 +64,6 @@ EdgeTracker() = EdgeTracker(Any[], 0:typemax(UInt))
 intersect!(et::EdgeTracker, range::WorldRange) =
     et.valid_worlds[] = intersect(et.valid_worlds[], range)
 
-push!(et::EdgeTracker, mi::MethodInstance) = push!(et.edges, mi)
 function add_backedge!(et::EdgeTracker, mi::MethodInstance)
     push!(et.edges, mi)
     return nothing
@@ -72,10 +71,6 @@ end
 function add_invoke_backedge!(et::EdgeTracker, @nospecialize(invokesig), mi::MethodInstance)
     push!(et.edges, invokesig, mi)
     return nothing
-end
-function push!(et::EdgeTracker, ci::CodeInstance)
-    intersect!(et, WorldRange(min_world(li), max_world(li)))
-    push!(et, ci.def)
 end
 
 struct InliningState{S <: Union{EdgeTracker, Nothing}, MICache, I<:AbstractInterpreter}

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -567,13 +567,13 @@ function store_backedges(frame::InferenceResult, edges::Vector{Any})
     nothing
 end
 
-function store_backedges(caller::MethodInstance, edges::Vector{Any})
-    for (typ, to) in BackedgeIterator(edges)
-        if isa(to, MethodInstance)
-            ccall(:jl_method_instance_add_backedge, Cvoid, (Any, Any, Any), to, typ, caller)
+function store_backedges(frame::MethodInstance, edges::Vector{Any})
+    for (; sig, caller) in BackedgeIterator(edges)
+        if isa(caller, MethodInstance)
+            ccall(:jl_method_instance_add_backedge, Cvoid, (Any, Any, Any), caller, sig, frame)
         else
-            typeassert(to, Core.MethodTable)
-            ccall(:jl_method_table_add_backedge, Cvoid, (Any, Any, Any), to, typ, caller)
+            typeassert(caller, Core.MethodTable)
+            ccall(:jl_method_table_add_backedge, Cvoid, (Any, Any, Any), caller, sig, frame)
         end
     end
 end

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -806,7 +806,7 @@ function merge_call_chain!(interp::AbstractInterpreter, parent::InferenceState, 
     # of recursion.
     merge_effects!(interp, parent, Effects(EFFECTS_TOTAL; terminates=false))
     while true
-        add_cycle_backedge!(child, parent, parent.currpc)
+        add_cycle_backedge!(parent, child, parent.currpc)
         union_caller_cycle!(ancestor, child)
         merge_effects!(interp, child, Effects(EFFECTS_TOTAL; terminates=false))
         child = parent

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -235,9 +235,9 @@ is_no_constprop(method::Union{Method,CodeInfo}) = method.constprop == 0x02
 Return an iterator over a list of backedges. Iteration returns `(sig, caller)` elements,
 which will be one of the following:
 
-- `(nothing, caller::MethodInstance)`: a call made by ordinary inferrable dispatch
-- `(invokesig, caller::MethodInstance)`: a call made by `invoke(f, invokesig, args...)`
-- `(specsig, mt::MethodTable)`: an abstract call
+- `BackedgePair(nothing, caller::MethodInstance)`: a call made by ordinary inferrable dispatch
+- `BackedgePair(invokesig, caller::MethodInstance)`: a call made by `invoke(f, invokesig, args...)`
+- `BackedgePair(specsig, mt::MethodTable)`: an abstract call
 
 # Examples
 
@@ -254,7 +254,7 @@ julia> callyou(2.0)
 julia> mi = first(which(callme, (Any,)).specializations)
 MethodInstance for callme(::Float64)
 
-julia> @eval Core.Compiler for (sig, caller) in BackedgeIterator(Main.mi.backedges)
+julia> @eval Core.Compiler for (; sig, caller) in BackedgeIterator(Main.mi.backedges)
            println(sig)
            println(caller)
        end
@@ -268,8 +268,11 @@ end
 
 const empty_backedge_iter = BackedgeIterator(Any[])
 
-const MethodInstanceOrTable = Union{MethodInstance, Core.MethodTable}
-const BackedgePair = Pair{Union{Type, Nothing, MethodInstanceOrTable}, MethodInstanceOrTable}
+struct BackedgePair
+    sig # ::Union{Nothing,Type}
+    caller::Union{MethodInstance,Core.MethodTable}
+    BackedgePair(@nospecialize(sig), caller::Union{MethodInstance,Core.MethodTable}) = new(sig, caller)
+end
 
 function iterate(iter::BackedgeIterator, i::Int=1)
     backedges = iter.backedges

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -226,13 +226,13 @@ g38435(x) = f38435(x, x)
 f38435(::Int, ::Int) = 3.0
 @test g38435(1) === 3.0
 
+# Invalidation
+# ============
 
-## Invalidation tests
-
-function instance(f, types)
+function method_instance(f, types=Base.default_tt(f))
     m = which(f, types)
     inst = nothing
-    tt = Tuple{typeof(f), types...}
+    tt = Base.signature_type(f, types)
     specs = m.specializations
     if isa(specs, Nothing)
     elseif isa(specs, Core.SimpleVector)
@@ -290,30 +290,30 @@ f35855(::Float64) = 2
 applyf35855([1])
 applyf35855([1.0])
 applyf35855(Any[1])
-wint   = worlds(instance(applyf35855, (Vector{Int},)))
-wfloat = worlds(instance(applyf35855, (Vector{Float64},)))
-wany2  = worlds(instance(applyf35855, (Vector{Any},)))
+wint   = worlds(method_instance(applyf35855, (Vector{Int},)))
+wfloat = worlds(method_instance(applyf35855, (Vector{Float64},)))
+wany2  = worlds(method_instance(applyf35855, (Vector{Any},)))
 src2 = code_typed(applyf35855, (Vector{Any},))[1]
 f35855(::String) = 3
 applyf35855(Any[1])
-@test worlds(instance(applyf35855, (Vector{Int},))) == wint
-@test worlds(instance(applyf35855, (Vector{Float64},))) == wfloat
-wany3 = worlds(instance(applyf35855, (Vector{Any},)))
+@test worlds(method_instance(applyf35855, (Vector{Int},))) == wint
+@test worlds(method_instance(applyf35855, (Vector{Float64},))) == wfloat
+wany3 = worlds(method_instance(applyf35855, (Vector{Any},)))
 src3 = code_typed(applyf35855, (Vector{Any},))[1]
 @test !(wany3 == wany2) || equal(src3, src2) # code doesn't change unless you invalidate
 f35855(::AbstractVector) = 4
 applyf35855(Any[1])
-wany4 = worlds(instance(applyf35855, (Vector{Any},)))
+wany4 = worlds(method_instance(applyf35855, (Vector{Any},)))
 src4 = code_typed(applyf35855, (Vector{Any},))[1]
 @test !(wany4 == wany3) || equal(src4, src3) # code doesn't change unless you invalidate
 f35855(::Dict) = 5
 applyf35855(Any[1])
-wany5 = worlds(instance(applyf35855, (Vector{Any},)))
+wany5 = worlds(method_instance(applyf35855, (Vector{Any},)))
 src5 = code_typed(applyf35855, (Vector{Any},))[1]
 @test (wany5 == wany4) == equal(src5, src4)
 f35855(::Set) = 6    # with current settings, this shouldn't invalidate
 applyf35855(Any[1])
-wany6 = worlds(instance(applyf35855, (Vector{Any},)))
+wany6 = worlds(method_instance(applyf35855, (Vector{Any},)))
 src6 = code_typed(applyf35855, (Vector{Any},))[1]
 @test wany6 == wany5
 @test equal(src6, src5)
@@ -322,11 +322,11 @@ applyf35855_2(c) = f35855_2(c[1])
 f35855_2(::Int) = 1
 f35855_2(::Float64) = 2
 applyf35855_2(Any[1])
-wany3 = worlds(instance(applyf35855_2, (Vector{Any},)))
+wany3 = worlds(method_instance(applyf35855_2, (Vector{Any},)))
 src3 = code_typed(applyf35855_2, (Vector{Any},))[1]
 f35855_2(::AbstractVector) = 4
 applyf35855_2(Any[1])
-wany4 = worlds(instance(applyf35855_2, (Vector{Any},)))
+wany4 = worlds(method_instance(applyf35855_2, (Vector{Any},)))
 src4 = code_typed(applyf35855_2, (Vector{Any},))[1]
 @test !(wany4 == wany3) || equal(src4, src3) # code doesn't change unless you invalidate
 
@@ -343,25 +343,60 @@ end
 (::Type{X})(x::Real) where {T, X<:FixedPoint35855{T}} = X(round(T, typemax(T)*x), 0)
 @test worlds(mi) == w
 
-mi = instance(convert, (Type{Nothing}, String))
+mi = method_instance(convert, (Type{Nothing}, String))
 w = worlds(mi)
 abstract type Colorant35855 end
 Base.convert(::Type{C}, c) where {C<:Colorant35855} = false
 @test worlds(mi) == w
 
-# NamedTuple and extensions of eltype
+## NamedTuple and extensions of eltype
 outer(anyc) = inner(anyc[])
 inner(s::Union{Vector,Dict}; kw=false) = inneri(s, kwi=maximum(s), kwb=kw)
 inneri(s, args...; kwargs...) = inneri(IOBuffer(), s, args...; kwargs...)
 inneri(io::IO, s::Union{Vector,Dict}; kwi=0, kwb=false) = (print(io, first(s), " "^kwi, kwb); String(take!(io)))
 @test outer(Ref{Any}([1,2,3])) == "1   false"
-mi = instance(Core.kwfunc(inneri), (NamedTuple{(:kwi,:kwb),TT} where TT<:Tuple{Any,Bool}, typeof(inneri), Vector{T} where T))
+mi = method_instance(Core.kwfunc(inneri), (NamedTuple{(:kwi,:kwb),TT} where TT<:Tuple{Any,Bool}, typeof(inneri), Vector{T} where T))
 w = worlds(mi)
 abstract type Container{T} end
 Base.eltype(::Type{C}) where {T,C<:Container{T}} = T
 @test worlds(mi) == w
 
+## invoke call
+
+_invoke46741(a::Int) = a > 0 ? :int : println(a)
+_invoke46741(a::Integer) = a > 0 ? :integer : println(a)
+invoke46741(a) = @invoke _invoke46741(a::Integer)
+@test invoke46741(42) === :integer
+invoke46741_world = worlds(method_instance(invoke46741, (Int,)))
+_invoke46741(a::Int) = a > 0 ? :int2 : println(a)
+@test invoke46741(42) === :integer
+@test worlds(method_instance(invoke46741, (Int,))) == invoke46741_world
+_invoke46741(a::UInt) = a > 0 ? :uint2 : println(a)
+@test invoke46741(42) === :integer
+@test worlds(method_instance(invoke46741, (Int,))) == invoke46741_world
+_invoke46741(a::Integer) = a > 0 ? :integer2 : println(a)
+@test invoke46741(42) === :integer2
+@test worlds(method_instance(invoke46741, (Int,))) ≠ invoke46741_world
+
+# const-prop'ed call
+_invoke46741(a::Int) = a > 0 ? :int : println(a)
+_invoke46741(a::Integer) = a > 0 ? :integer : println(a)
+invoke46741() = @invoke _invoke46741(42::Integer)
+@test invoke46741() === :integer
+invoke46741_world = worlds(method_instance(invoke46741, ()))
+_invoke46741(a::Int) = a > 0 ? :int2 : println(a)
+@test invoke46741() === :integer
+@test worlds(method_instance(invoke46741, ())) == invoke46741_world
+_invoke46741(a::UInt) = a > 0 ? :uint2 : println(a)
+@test invoke46741() === :integer
+@test worlds(method_instance(invoke46741, ())) == invoke46741_world
+_invoke46741(a::Integer) = a > 0 ? :integer2 : println(a)
+@test invoke46741() === :integer2
+@test worlds(method_instance(invoke46741, ())) ≠ invoke46741_world
+
 # invoke_in_world
+# ===============
+
 f_inworld(x) = "world one; x=$x"
 g_inworld(x; y) = "world one; x=$x, y=$y"
 wc_aiw1 = get_world_counter()


### PR DESCRIPTION
This PR consists of the following commits:
- [inference: setup separate functions for each backedge kind](https://github.com/JuliaLang/julia/commit/386e2c7f2c97f23b757b24d03a42173b8b62256b) 
  Hopefully make it clear what kind of backedge is being added at each place.
  This commit also changes the argument list so that they are ordered as
  `(caller, [backedge information])`.
- [inference: fix backedge computation for const-prop'ed callsite](https://github.com/JuliaLang/julia/commit/4b8c9dc1fcec074f54d0a0e5e9d7b21ae2a47e39) 
  With this commit `abstract_call_method_with_const_args` doesn't add
  backedge but rather returns the backedge to the caller, letting the
  callers like `abstract_call_gf_by_type` and `abstract_invoke` take the
  responsibility to add backedge to current context appropriately.

  As a result, this fixes the backedge calculation for const-prop'ed
  `invoke` callsite.

  For example, for the following call graph,
  ```julia
  foo(a::Int) = a > 0 ? :int : println(a)
  foo(a::Integer) = a > 0 ? "integer" : println(a)

  bar(a::Int) = @invoke foo(a::Integer)
  ```

  Previously we added the wrong backedge `nothing, bar(Int64) from bar(Int64)`:
  ```julia
  julia> last(only(code_typed(()->bar(42))))
  String

  julia> let m = only(methods(foo, (UInt,)))
             @eval Core.Compiler for (sig, caller) in BackedgeIterator($m.specializations[1].backedges)
                 println(sig, ", ", caller)
             end
         end
  Tuple{typeof(Main.foo), Integer}, bar(Int64) from bar(Int64)
  nothing, bar(Int64) from bar(Int64)
  ```
  but now we only add `invoke`-backedge:
  ```julia
  julia> last(only(code_typed(()->bar(42))))
  String

  julia> let m = only(methods(foo, (UInt,)))
             @eval Core.Compiler for (; sig, caller) in BackedgeIterator($m.specializations[1].backedges)
                 println(sig, ", ", caller)
             end
         end
  Tuple{typeof(Main.foo), Integer}, bar(Int64) from bar(Int64)
  ```