### PR TITLE
correct info on oftype

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -451,7 +451,7 @@ end
 """
     oftype(x, y)
 
-Convert `y` to the type of `x` (`convert(typeof(x), y)`).
+Convert `y` to the type of `x` i.e. `convert(typeof(x), y)`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
The current one says:
> Convert y to the type of x (convert(typeof(x), y)).

It's not kinda clear if `x` is a method being called with arguments `(convert(typeof(x), y))`, which is not.

So its best to separate this out for better understanding:
> Convert y to the type of x i.e. convert(typeof(x), y)