### PR TITLE
Recommend a workflow for methodswith in the REPL

### DIFF
--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -182,6 +182,38 @@ The optional second argument restricts the search to a particular module or func
 
 If keyword `supertypes` is `true`, also return arguments with a parent type of `typ`,
 excluding type `Any`.
+
+```jldoctest
+julia> methodswith(Integer)
+...
+[721] Pkg.Types.UpgradeLevel(x::Integer) in Pkg.Types at Enums.jl:197
+```
+
+As can be seen above, the results were truncated. Oftentimes the array
+of methods is too long and would be hard to fully inspect in the REPL.
+
+There are two recommended ways to effectively solve this:
+- assign the array of methods to a variable and manually go through it:
+```jldoctest
+julia> x = methodswith(Integer);
+
+julia> x[7:8]
+1] rem(y::Integer, x::Rational) in Base at rational.jl:327
+[2] rem(x::Integer, ::Type{BigInt}) in Base.GMP at gmp.jl:345
+
+julia> x[13:14]
+[1] rem(x::Integer, T::Type{<:Integer}) in Base at int.jl:584
+[2] &(::Missing, ::Integer) in Base at missing.jl:169
+
+- read each method line by line using a `for` loop and the `readline` function.
+  You go to the next function with the "ENTER" key and exit out of the loop with "CTRL-D":
+``jldoctest
+julia> for i in methodswith(Int)
+           print(i)
+           readline()
+       end
+AbstractFloat(x::Int64) in Base at float.jl:243
+Float16(x::Int64) in Base at float.jl:146
 """
 function methodswith(t::Type, f::Base.Callable, meths = Method[]; supertypes::Bool=false)
     for d in methods(f)

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -204,16 +204,23 @@ julia> x[7:8]
 julia> x[13:14]
 [1] rem(x::Integer, T::Type{<:Integer}) in Base at int.jl:584
 [2] &(::Missing, ::Integer) in Base at missing.jl:169
+```
 
 - read each method line by line using a `for` loop and the `readline` function.
-  You go to the next function with the "ENTER" key and exit out of the loop with "CTRL-D":
-``julia
+  You go to the next function with the "ENTER" key and exit out of the loop with
+  "CTRL-C" or "CTRL-D":
+```julia
 julia> for i in methodswith(Int)
            print(i)
            readline()
        end
 AbstractFloat(x::Int64) in Base at float.jl:243
 Float16(x::Int64) in Base at float.jl:146
+Float32(x::Int64) in Base at float.jl:146^C
+ERROR: InterruptException:
+Stacktrace:
+[...]
+```
 """
 function methodswith(t::Type, f::Base.Callable, meths = Method[]; supertypes::Bool=false)
     for d in methods(f)

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -183,7 +183,7 @@ The optional second argument restricts the search to a particular module or func
 If keyword `supertypes` is `true`, also return arguments with a parent type of `typ`,
 excluding type `Any`.
 
-```jldoctest
+```julia
 julia> methodswith(Integer)
 ...
 [721] Pkg.Types.UpgradeLevel(x::Integer) in Pkg.Types at Enums.jl:197
@@ -194,7 +194,7 @@ of methods is too long and would be hard to fully inspect in the REPL.
 
 There are two recommended ways to effectively solve this:
 - assign the array of methods to a variable and manually go through it:
-```jldoctest
+```julia
 julia> x = methodswith(Integer);
 
 julia> x[7:8]
@@ -207,7 +207,7 @@ julia> x[13:14]
 
 - read each method line by line using a `for` loop and the `readline` function.
   You go to the next function with the "ENTER" key and exit out of the loop with "CTRL-D":
-``jldoctest
+``julia
 julia> for i in methodswith(Int)
            print(i)
            readline()


### PR DESCRIPTION
I've often seen first timers coming from OOP language and then they complain about having to break their workflows and ask questions or google just to know a simple function to use, where in the classical OOP-style, all they needed was an IDE and a dot syntax to list all available methods.

My point is, anything that can help with stuffs like this should be documented in a simple way. My first time using Julia, I certainly didn't wanted the `methodswith` function, because it broke the whole REPL and won't even show the first 100 functions if the methods is more than 700.

Until recently I started using the workflow I recommended in this patch. So it will be nice if something of that nature is done and then point users to it to keep their workflow stable, ALL IN THE REPL.