### PR TITLE
change logic for enabling GDB JIT event listener

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8578,12 +8578,11 @@ extern "C" void jl_init_llvm(void)
     // Register GDB event listener
 #if defined(JL_DEBUG_BUILD)
     jl_using_gdb_jitevents = true;
-# else
-    const char *jit_gdb = getenv("ENABLE_GDBLISTENER");
-    if (jit_gdb && atoi(jit_gdb)) {
-        jl_using_gdb_jitevents = true;
-    }
 #endif
+    const char *jit_gdb = getenv("ENABLE_GDBLISTENER");
+    if (jit_gdb) {
+        jl_using_gdb_jitevents = !!atoi(jit_gdb);
+    }
     if (jl_using_gdb_jitevents)
         jl_ExecutionEngine->enableJITDebuggingSupport();
 


### PR DESCRIPTION
- default to false in release build, true in debug build
- ENABLE_GDBLISTENER env var overrides that in all builds

Previously, in a debug build the flag was just forced to true.