### PR TITLE
Use more of the actual inliner in finalizer inlining

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -347,6 +347,35 @@ function ir_inline_linetable!(linetable::Vector{LineInfoNode}, inlinee_ir::IRCod
     return linetable_offset, extra_coverage_line
 end
 
+function ir_prepare_inlining!(insert_node_here!::Inserter, inline_target::Union{IRCode, IncrementalCompact},
+        linetable::Vector{LineInfoNode}, ir′::IRCode, sparam_vals::SimpleVector,
+        def::Method, inlined_at::Int32, argexprs::Vector{Any})
+    topline::Int32 = length(linetable) + Int32(1)
+    linetable_offset, extra_coverage_line = ir_inline_linetable!(linetable, ir′, def, inlined_at)
+    if extra_coverage_line != 0
+        insert_node_here!(NewInstruction(Expr(:code_coverage_effect), Nothing, extra_coverage_line))
+    end
+    sp_ssa = nothing
+    if !validate_sparams(sparam_vals)
+        # N.B. This works on the caller-side argexprs, (i.e. before the va fixup below)
+        sp_ssa = insert_node_here!(
+            effect_free(NewInstruction(Expr(:call, Core._compute_sparams, def, argexprs...), SimpleVector, topline)))
+    end
+    if def.isva
+        nargs_def = Int(def.nargs::Int32)
+        if nargs_def > 0
+            argexprs = fix_va_argexprs!(insert_node_here!, inline_target, argexprs, nargs_def, topline)
+        end
+    end
+    if def.is_for_opaque_closure
+        # Replace the first argument by a load of the capture environment
+        argexprs[1] = insert_node_here!(
+            NewInstruction(Expr(:call, GlobalRef(Core, :getfield), argexprs[1], QuoteNode(:captures)),
+            ir′.argtypes[1], topline))
+    end
+    return (Pair{Union{Nothing, SSAValue}, Vector{Any}}(sp_ssa, argexprs), linetable_offset)
+end
+
 function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector{Any},
                          linetable::Vector{LineInfoNode}, item::InliningTodo,
                          boundscheck::Symbol, todo_bbs::Vector{Tuple{Int, Int}})
@@ -355,30 +384,10 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
     sparam_vals = item.mi.sparam_vals
     def = item.mi.def::Method
     inlined_at = compact.result[idx][:line]
-    linetable_offset::Int32 = length(linetable)
-    topline::Int32 = linetable_offset + Int32(1)
-    linetable_offset, extra_coverage_line = ir_inline_linetable!(linetable, item.spec.ir, def, inlined_at)
-    if extra_coverage_line != 0
-        insert_node_here!(compact, NewInstruction(Expr(:code_coverage_effect), Nothing, extra_coverage_line))
-    end
-    sp_ssa = nothing
-    if !validate_sparams(sparam_vals)
-        # N.B. This works on the caller-side argexprs, (i.e. before the va fixup below)
-        sp_ssa = insert_node_here!(compact,
-            effect_free(NewInstruction(Expr(:call, Core._compute_sparams, def, argexprs...), SimpleVector, topline)))
-    end
-    if def.isva
-        nargs_def = Int(def.nargs::Int32)
-        if nargs_def > 0
-            argexprs = fix_va_argexprs!(compact, argexprs, nargs_def, topline)
-        end
-    end
-    if def.is_for_opaque_closure
-        # Replace the first argument by a load of the capture environment
-        argexprs[1] = insert_node_here!(compact,
-            NewInstruction(Expr(:call, GlobalRef(Core, :getfield), argexprs[1], QuoteNode(:captures)),
-            spec.ir.argtypes[1], topline))
-    end
+
+    ((sp_ssa, argexprs), linetable_offset) = ir_prepare_inlining!(InsertHere(compact), compact, linetable,
+            item.spec.ir, sparam_vals, def, inlined_at, argexprs)
+
     if boundscheck === :default || boundscheck === :propagate
         if (compact.result[idx][:flag] & IR_FLAG_INBOUNDS) != 0
             boundscheck = :off
@@ -399,7 +408,7 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
             # face of rename_arguments! mutating in place - should figure out
             # something better eventually.
             inline_compact[idx′] = nothing
-            stmt′ = ssa_substitute!(idx′, stmt′, argexprs, sig, sparam_vals, sp_ssa, linetable_offset, boundscheck, inline_compact)
+            stmt′ = ssa_substitute!(InsertBefore(inline_compact, SSAValue(idx′)), inline_compact[SSAValue(idx′)], stmt′, argexprs, sig, sparam_vals, sp_ssa, linetable_offset, boundscheck)
             if isa(stmt′, ReturnNode)
                 val = stmt′.val
                 return_value = SSAValue(idx′)
@@ -426,7 +435,7 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
         inline_compact = IncrementalCompact(compact, spec.ir, compact.result_idx)
         for ((_, idx′), stmt′) in inline_compact
             inline_compact[idx′] = nothing
-            stmt′ = ssa_substitute!(idx′, stmt′, argexprs, sig, sparam_vals, sp_ssa, linetable_offset, boundscheck, inline_compact)
+            stmt′ = ssa_substitute!(InsertBefore(inline_compact, SSAValue(idx′)), inline_compact[SSAValue(idx′)], stmt′, argexprs, sig, sparam_vals, sp_ssa, linetable_offset, boundscheck)
             if isa(stmt′, ReturnNode)
                 if isdefined(stmt′, :val)
                     val = stmt′.val
@@ -459,7 +468,7 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
     return_value
 end
 
-function fix_va_argexprs!(compact::IncrementalCompact,
+function fix_va_argexprs!(insert_node_here!::Inserter, inline_target::Union{IRCode, IncrementalCompact},
     argexprs::Vector{Any}, nargs_def::Int, line_idx::Int32)
     newargexprs = argexprs[1:(nargs_def-1)]
     tuple_call = Expr(:call, TOP_TUPLE)
@@ -467,11 +476,11 @@ function fix_va_argexprs!(compact::IncrementalCompact,
     for i in nargs_def:length(argexprs)
         arg = argexprs[i]
         push!(tuple_call.args, arg)
-        push!(tuple_typs, argextype(arg, compact))
+        push!(tuple_typs, argextype(arg, inline_target))
     end
     tuple_typ = tuple_tfunc(OptimizerLattice(), tuple_typs)
     tuple_inst = NewInstruction(tuple_call, tuple_typ, line_idx)
-    push!(newargexprs, insert_node_here!(compact, tuple_inst))
+    push!(newargexprs, insert_node_here!(tuple_inst))
     return newargexprs
 end
 
@@ -1722,32 +1731,35 @@ function late_inline_special_case!(
     return nothing
 end
 
-function ssa_substitute!(idx::Int, @nospecialize(val), arg_replacements::Vector{Any},
+function ssa_substitute!(insert_node_before!,
+                         subst_inst::Instruction, @nospecialize(val), arg_replacements::Vector{Any},
                          @nospecialize(spsig), spvals::SimpleVector,
                          spvals_ssa::Union{Nothing, SSAValue},
-                         linetable_offset::Int32, boundscheck::Symbol, compact::IncrementalCompact)
-    compact.result[idx][:flag] &= ~IR_FLAG_INBOUNDS
-    compact.result[idx][:line] += linetable_offset
-    return ssa_substitute_op!(val, arg_replacements, spsig, spvals, spvals_ssa, boundscheck, compact, idx)
+                         linetable_offset::Int32, boundscheck::Symbol)
+    subst_inst[:flag] &= ~IR_FLAG_INBOUNDS
+    subst_inst[:line] += linetable_offset
+    return ssa_substitute_op!(insert_node_before!, subst_inst,
+        val, arg_replacements, spsig, spvals, spvals_ssa, boundscheck)
 end
 
-function insert_spval!(compact::IncrementalCompact, idx::Int, spvals_ssa::SSAValue, spidx::Int, do_isdefined::Bool)
-    ret = insert_node!(compact, SSAValue(idx),
+function insert_spval!(insert_node_before!, spvals_ssa::SSAValue, spidx::Int, do_isdefined::Bool)
+    ret = insert_node_before!(
         effect_free(NewInstruction(Expr(:call, Core._svec_ref, false, spvals_ssa, spidx), Any)))
     tcheck_not = nothing
     if do_isdefined
-        tcheck = insert_node!(compact, SSAValue(idx),
+        tcheck = insert_node_before!(
             effect_free(NewInstruction(Expr(:call, Core.isa, ret, Core.TypeVar), Bool)))
-        tcheck_not = insert_node!(compact, SSAValue(idx),
+        tcheck_not = insert_node_before!(
             effect_free(NewInstruction(Expr(:call, not_int, tcheck), Bool)))
     end
     return (ret, tcheck_not)
 end
 
-function ssa_substitute_op!(@nospecialize(val), arg_replacements::Vector{Any},
+function ssa_substitute_op!(insert_node_before!, subst_inst::Instruction,
+                            @nospecialize(val), arg_replacements::Vector{Any},
                             @nospecialize(spsig), spvals::SimpleVector,
                             spvals_ssa::Union{Nothing, SSAValue},
-                            boundscheck::Symbol, compact::IncrementalCompact, idx::Int)
+                            boundscheck::Symbol)
     if isa(val, Argument)
         return arg_replacements[val.n]
     end
@@ -1760,11 +1772,11 @@ function ssa_substitute_op!(@nospecialize(val), arg_replacements::Vector{Any},
             if !isa(val, TypeVar) && val !== Vararg
                 return quoted(val)
             else
-                flag = compact[SSAValue(idx)][:flag]
+                flag = subst_inst[:flag]
                 maybe_undef = (flag & IR_FLAG_NOTHROW) == 0 && isa(val, TypeVar)
-                (ret, tcheck_not) = insert_spval!(compact, idx, spvals_ssa, spidx, maybe_undef)
+                (ret, tcheck_not) = insert_spval!(insert_node_before!, spvals_ssa, spidx, maybe_undef)
                 if maybe_undef
-                    insert_node!(compact, SSAValue(idx),
+                    insert_node_before!(
                         non_effect_free(NewInstruction(Expr(:throw_undef_if_not, val.name, tcheck_not), Nothing)))
                 end
                 return ret
@@ -1775,7 +1787,7 @@ function ssa_substitute_op!(@nospecialize(val), arg_replacements::Vector{Any},
             if !isa(val, TypeVar)
                 return true
             else
-                (_, tcheck_not) = insert_spval!(compact, idx, spvals_ssa, spidx, true)
+                (_, tcheck_not) = insert_spval!(insert_node_before!, spvals_ssa, spidx, true)
                 return tcheck_not
             end
         elseif head === :cfunction && spvals_ssa === nothing
@@ -1808,7 +1820,7 @@ function ssa_substitute_op!(@nospecialize(val), arg_replacements::Vector{Any},
     isa(val, Union{SSAValue, NewSSAValue}) && return val # avoid infinite loop
     urs = userefs(val)
     for op in urs
-        op[] = ssa_substitute_op!(op[], arg_replacements, spsig, spvals, spvals_ssa, boundscheck, compact, idx)
+        op[] = ssa_substitute_op!(insert_node_before!, subst_inst, op[], arg_replacements, spsig, spvals, spvals_ssa, boundscheck)
     end
     return urs[]
 end

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1755,7 +1755,7 @@ function insert_spval!(insert_node_before!, spvals_ssa::SSAValue, spidx::Int, do
     return (ret, tcheck_not)
 end
 
-function ssa_substitute_op!(insert_node_before!, subst_inst::Instruction,
+function ssa_substitute_op!(insert_node_before!::Inserter, subst_inst::Instruction,
                             @nospecialize(val), arg_replacements::Vector{Any},
                             @nospecialize(spsig), spvals::SimpleVector,
                             spvals_ssa::Union{Nothing, SSAValue},

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -1,5 +1,11 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+function maybe_show_ir(ir::IRCode)
+    if isdefined(Core, :Main)
+        Core.Main.Base.display(ir)
+    end
+end
+
 if !isdefined(@__MODULE__, Symbol("@verify_error"))
     macro verify_error(arg)
         arg isa String && return esc(:(print && println(stderr, $arg)))
@@ -7,7 +13,10 @@ if !isdefined(@__MODULE__, Symbol("@verify_error"))
         pushfirst!(arg.args, GlobalRef(Core, :stderr))
         pushfirst!(arg.args, :println)
         arg.head = :call
-        return esc(arg)
+        return esc(quote
+            $arg
+            maybe_show_ir(ir)
+        end)
     end
 end
 


### PR DESCRIPTION
Currently the special-case inliner for finalizer generated incorrect code for unmatched sparams (which we had a test for, but which was unfortunately broken) and varargs (which we did not have a test for). Of course, we handle these cases correctly in actual inlining, so do some light refactoring to share more code between the two inlining paths.