### PR TITLE
Improve nothrow analysis of :new with missing sparam

### DIFF
--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -655,3 +655,13 @@ end # @testset "effects analysis on array ops" begin
 
 # Test that builtin_effects handles vararg correctly
 @test !Core.Compiler.is_nothrow(Core.Compiler.builtin_effects(Core.Compiler.fallback_lattice, Core.isdefined, Any[String, Vararg{Any}], Bool))
+
+# Test that :new can be eliminated even if an sparam is unknown
+struct SparamUnused{T}
+    x
+    SparamUnused(x::T) where {T} = new{T}(x)
+end
+mksparamunused(x) = (SparamUnused(x); nothing)
+let src = code_typed1(mksparamunused, (Any,))
+    @test count(isnew, src.code) == 0
+end


### PR DESCRIPTION
Similar to #46693, but for :new, rather than getfield. Unfortunately, this is somewhat limited as we don't really have the ability to encode type equality constraints in the lattice. In particular, it would be nice to analyze:

```
struct Foo{T}
    x::T
    Foo(x::T) where {T} = new{T}(x)
end
```

and be able to prove this nothrow. If it's really
important, we could probably pattern match it, but for the moment, this is not easy to do. Nevertheless, we can do something about the similar, but simpler pattern

```
struct Foo{T}
    x
    Foo(x::T) where {T} = new{T}(x)
end
```

which is what this PR does.