### PR TITLE
allow artifact string macro to take an explicit path to the artifact file

### DIFF
--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -652,17 +652,17 @@ access a single file/directory within an artifact.  Example:
 !!! compat "Julia 1.6"
     Slash-indexing requires at least Julia 1.6.
 """
-macro artifact_str(name, platform=nothing, artifact_path=nothing)
+macro artifact_str(name, platform=nothing, artifacts_toml_path=nothing)
     # Find Artifacts.toml file we're going to load from
     srcfile = string(__source__.file)
     if ((isinteractive() && startswith(srcfile, "REPL[")) || (!isinteractive() && srcfile == "none")) && !isfile(srcfile)
         srcfile = pwd()
     end
     # Sometimes we know the exact path to the Artifacts.toml file, so we can save some lookups
-    local artifacts_toml = if artifact_path === nothing
+    local artifacts_toml = if artifacts_toml_path === nothing
         find_artifacts_toml(srcfile)
     else
-        artifact_path
+        artifacts_toml_path
     end
     if artifacts_toml === nothing
         error(string(

--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -652,13 +652,18 @@ access a single file/directory within an artifact.  Example:
 !!! compat "Julia 1.6"
     Slash-indexing requires at least Julia 1.6.
 """
-macro artifact_str(name, platform=nothing)
+macro artifact_str(name, platform=nothing, artifact_path=nothing)
     # Find Artifacts.toml file we're going to load from
     srcfile = string(__source__.file)
     if ((isinteractive() && startswith(srcfile, "REPL[")) || (!isinteractive() && srcfile == "none")) && !isfile(srcfile)
         srcfile = pwd()
     end
-    local artifacts_toml = find_artifacts_toml(srcfile)
+    # Sometimes we know the exact path to the Artifacts.toml file, so we can save some lookups
+    local artifacts_toml = if artifact_path === nothing
+        find_artifacts_toml(srcfile)
+    else
+        artifact_path
+    end
     if artifacts_toml === nothing
         error(string(
             "Cannot locate '(Julia)Artifacts.toml' file when attempting to use artifact '",

--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -659,10 +659,10 @@ macro artifact_str(name, platform=nothing, artifacts_toml_path=nothing)
         srcfile = pwd()
     end
     # Sometimes we know the exact path to the Artifacts.toml file, so we can save some lookups
-    local artifacts_toml = if artifacts_toml_path === nothing
+    local artifacts_toml = if artifacts_toml_path === nothing || artifacts_toml_path == :(nothing)
         find_artifacts_toml(srcfile)
     else
-        artifacts_toml_path
+        eval(artifacts_toml_path)
     end
     if artifacts_toml === nothing
         error(string(
@@ -693,7 +693,7 @@ macro artifact_str(name, platform=nothing, artifacts_toml_path=nothing)
 
     # If `name` is a constant, (and we're using the default `Platform`) we can actually load
     # and parse the `Artifacts.toml` file now, saving the work from runtime.
-    if isa(name, AbstractString) && platform === nothing
+    if isa(name, AbstractString) && (platform === nothing || platform == :(nothing))
         # To support slash-indexing, we need to split the artifact name from the path tail:
         platform = HostPlatform()
         artifact_name, artifact_path_tail, hash = artifact_slash_lookup(name, artifact_dict, artifacts_toml, platform)

--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -91,6 +91,9 @@ end
         HelloWorldC_exe_path = joinpath(HelloWorldC_dir, "bin", "hello_world$(exeext)")
         @test isfile(HelloWorldC_exe_path)
 
+        HelloWorldC_dir_explicit_artifact = eval(Expr(:macrocall, Symbol("@artifact_str"), nothing, "HelloWorldC", nothing, joinpath(@__DIR__, "Artifacts.toml")))
+        @test isdir(HelloWorldC_dir_explicit_artifact)
+
         # Simple slash-indexed lookup
         HelloWorldC_bin_path = artifact"HelloWorldC/bin"
         @test isdir(HelloWorldC_bin_path)

--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -91,7 +91,7 @@ end
         HelloWorldC_exe_path = joinpath(HelloWorldC_dir, "bin", "hello_world$(exeext)")
         @test isfile(HelloWorldC_exe_path)
 
-        HelloWorldC_dir_explicit_artifact = eval(Expr(:macrocall, Symbol("@artifact_str"), nothing, "HelloWorldC", nothing, joinpath(@__DIR__, "Artifacts.toml")))
+        HelloWorldC_dir_explicit_artifact = eval(:(@artifact_str "HelloWorldC" joinpath(@__DIR__, "Artifacts.toml")))
         @test isdir(HelloWorldC_dir_explicit_artifact)
 
         # Simple slash-indexed lookup

--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -91,7 +91,7 @@ end
         HelloWorldC_exe_path = joinpath(HelloWorldC_dir, "bin", "hello_world$(exeext)")
         @test isfile(HelloWorldC_exe_path)
 
-        HelloWorldC_dir_explicit_artifact = eval(:(@artifact_str "HelloWorldC" joinpath(@__DIR__, "Artifacts.toml")))
+        HelloWorldC_dir_explicit_artifact = eval(:(@artifact_str "HelloWorldC" nothing joinpath(@__DIR__, "Artifacts.toml")))
         @test isdir(HelloWorldC_dir_explicit_artifact)
 
         # Simple slash-indexed lookup


### PR DESCRIPTION
can be used by JLLs to avoid scouring through the file system for the Artifacts.toml when it already knows where it is

JLLWrappers PR at https://github.com/JuliaPackaging/JLLWrappers.jl/pull/45
