### PR TITLE
Improve attribution of backedge-triggered invalidation

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -2492,8 +2492,8 @@ static void jl_verify_edges(jl_array_t *targets, jl_array_t **pvalids)
     size_t i, l = jl_array_len(targets) / 3;
     jl_array_t *valids = jl_alloc_array_1d(jl_array_uint8_type, l);
     memset(jl_array_data(valids), 1, l);
-    jl_value_t *loctag = NULL;
-    JL_GC_PUSH1(&loctag);
+    jl_value_t *loctag = NULL, *matches = NULL;
+    JL_GC_PUSH2(&loctag, &matches);
     *pvalids = valids;
     for (i = 0; i < l; i++) {
         jl_value_t *invokesig = jl_array_ptr_ref(targets, i * 3);
@@ -2513,7 +2513,7 @@ static void jl_verify_edges(jl_array_t *targets, jl_array_t **pvalids)
         size_t max_valid = ~(size_t)0;
         int ambig = 0;
         // TODO: possibly need to included ambiguities too (for the optimizer correctness)?
-        jl_value_t *matches = jl_matching_methods((jl_tupletype_t*)sig, jl_nothing, -1, 0, jl_atomic_load_acquire(&jl_world_counter), &min_valid, &max_valid, &ambig);
+        matches = jl_matching_methods((jl_tupletype_t*)sig, jl_nothing, -1, 0, jl_atomic_load_acquire(&jl_world_counter), &min_valid, &max_valid, &ambig);
         if (matches == jl_false || jl_array_len(matches) != jl_array_len(expected)) {
             valid = 0;
         }

--- a/src/dump.c
+++ b/src/dump.c
@@ -2542,6 +2542,8 @@ static void jl_verify_edges(jl_array_t *targets, jl_array_t **pvalids)
             jl_array_ptr_1d_push(_jl_debug_method_invalidation, loctag);
             loctag = jl_box_int32((int32_t)i);
             jl_array_ptr_1d_push(_jl_debug_method_invalidation, loctag);
+            loctag = jl_box_uint64(jl_worklist_key(serializer_worklist));
+            jl_array_ptr_1d_push(_jl_debug_method_invalidation, loctag);
             if (matches != jl_false) {
                 // setdiff!(matches, expected)
                 size_t j, k, ins = 0;
@@ -2625,6 +2627,8 @@ static void jl_insert_backedges(jl_array_t *edges, jl_array_t *ext_targets)
             invalidate_backedges(&remove_code_instance_from_validation, caller, world, "insert_backedges");
             if (_jl_debug_method_invalidation) {
                 targetidx = jl_box_int32((int32_t)idxbad);
+                jl_array_ptr_1d_push(_jl_debug_method_invalidation, targetidx);
+                targetidx = jl_box_uint64(jl_worklist_key(serializer_worklist));
                 jl_array_ptr_1d_push(_jl_debug_method_invalidation, targetidx);
             }
         }

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -905,7 +905,11 @@ precompile_test_harness("code caching") do dir
         mi.def == m
     end
     idx = only(idxsbits)
-    @test invalidations[idx-1].specTypes.parameters[end] === Integer
+    for mi in m.specializations
+        mi === nothing && continue
+        hv = hasvalid(mi, world)
+        @test mi.specTypes.parameters[end] === Integer ? !hv : hv
+    end
 
     tagbad = invalidations[idx+1]
     buildid = invalidations[idx+2]
@@ -916,7 +920,7 @@ precompile_test_harness("code caching") do dir
     @test invalidations[j-1] == "insert_backedges_callee"
 
     m = only(methods(MB.map_nbits))
-    @test m.specializations[1].cache.max_world <= world   # insert_backedges invalidations also trigger their backedges
+    @test !hasvalid(m.specializations[1], world) # insert_backedges invalidations also trigger their backedges
 end
 
 precompile_test_harness("invoke") do dir

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -908,7 +908,10 @@ precompile_test_harness("code caching") do dir
     @test invalidations[idx-1].specTypes.parameters[end] === Integer
 
     tagbad = invalidations[idx+1]
+    buildid = invalidations[idx+2]
+    @test isa(buildid, UInt64)
     j = findfirst(==(tagbad), invalidations)
+    @test invalidations[j+1] == buildid
     @test isa(invalidations[j-2], Type)
     @test invalidations[j-1] == "insert_backedges_callee"
 

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -913,7 +913,7 @@ precompile_test_harness("code caching") do dir
     @test invalidations[j-1] == "insert_backedges_callee"
 
     m = only(methods(MB.map_nbits))
-    @test m.specializations[1].cache.max_world < Base.get_world_counter()   # insert_backedges invalidations also trigger their backedges
+    @test m.specializations[1].cache.max_world <= world   # insert_backedges invalidations also trigger their backedges
 end
 
 precompile_test_harness("invoke") do dir

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -817,6 +817,10 @@ precompile_test_harness("code caching") do dir
         build_stale(37)
         stale('c')
 
+        ## Reporting tests (unrelated to the above)
+        nbits(::Int8) = 8
+        nbits(::Int16) = 16
+
         end
         """
     )
@@ -834,6 +838,11 @@ precompile_test_harness("code caching") do dir
 
         # force precompilation
         useA()
+
+        ## Reporting tests
+        call_nbits(x::Integer) = $StaleA.nbits(x)
+        map_nbits() = map(call_nbits, Integer[Int8(1), Int16(1)])
+        map_nbits()
 
         end
         """
@@ -856,9 +865,12 @@ precompile_test_harness("code caching") do dir
         Base.compilecache(Base.PkgId(string(pkg)))
     end
     @eval using $StaleA
-    @eval using $StaleC
-    @eval using $StaleB
     MA = getfield(@__MODULE__, StaleA)
+    Base.eval(MA, :(nbits(::UInt8) = 8))
+    @eval using $StaleC
+    invalidations = ccall(:jl_debug_method_invalidation, Any, (Cint,), 1)
+    @eval using $StaleB
+    ccall(:jl_debug_method_invalidation, Any, (Cint,), 0)
     MB = getfield(@__MODULE__, StaleB)
     MC = getfield(@__MODULE__, StaleC)
     world = Base.get_world_counter()
@@ -883,6 +895,25 @@ precompile_test_harness("code caching") do dir
     m = only(methods(MC.call_buildstale))
     mi = m.specializations[1]
     @test hasvalid(mi, world)       # was compiled with the new method
+
+    # Reporting test
+    @test all(i -> isassigned(invalidations, i), eachindex(invalidations))
+    idxs = findall(==("insert_backedges"), invalidations)
+    m = only(methods(MB.call_nbits))
+    idxsbits = filter(idxs) do i
+        mi = invalidations[i-1]
+        mi.def == m
+    end
+    idx = only(idxsbits)
+    @test invalidations[idx-1].specTypes.parameters[end] === Integer
+
+    tagbad = invalidations[idx+1]
+    j = findfirst(==(tagbad), invalidations)
+    @test isa(invalidations[j-2], Type)
+    @test invalidations[j-1] == "insert_backedges_callee"
+
+    m = only(methods(MB.map_nbits))
+    @test m.specializations[1].cache.max_world < Base.get_world_counter()   # insert_backedges invalidations also trigger their backedges
 end
 
 precompile_test_harness("invoke") do dir

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -920,7 +920,7 @@ precompile_test_harness("code caching") do dir
     @test invalidations[j-1] == "insert_backedges_callee"
 
     m = only(methods(MB.map_nbits))
-    @test !hasvalid(m.specializations[1], world) # insert_backedges invalidations also trigger their backedges
+    @test !hasvalid(m.specializations[1], world+1) # insert_backedges invalidations also trigger their backedges
 end
 
 precompile_test_harness("invoke") do dir


### PR DESCRIPTION
SnoopCompile attempts to attribute invalidations to specific causes, but until now it has not generally been able to handle what it called "delayed" invalidations, which arise during package-loading when a MethodInstance backedge isn't valid anymore. This dumps more data to the reporting stream and should allow SnoopCompile to assemble the full chain of causes.

This also adds invalidation of the backedges of methods that fail to validate their external edges (see addition at line 2627). I'm confused about why we didn't seem to have that before, or whether I inadvertently deleted that in a previous PR. Or is that supposed to be handled by some other mechanism?