### PR TITLE
Also merge var with unchanged bounds.

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -3248,16 +3248,15 @@ static int merge_env(jl_stenv_t *e, jl_value_t **root, jl_savedenv_t *se, int co
     }
     int n = 0;
     jl_varbinding_t *v = e->vars;
-    jl_value_t *ub = NULL, *vub = NULL;
-    JL_GC_PUSH2(&ub, &vub);
+    jl_value_t *b1 = NULL, *b2 = NULL;
+    JL_GC_PUSH2(&b1, &b2);
     while (v != NULL) {
-        jl_value_t *lb = jl_svecref(*root, n);
-        if (v->lb != lb)
-            jl_svecset(*root, n, lb ? v->var->lb : v->lb);
-        ub = jl_svecref(*root, n+1);
-        vub = v->ub;
-        if (vub != ub)
-            jl_svecset(*root, n+1, ub ? simple_join(ub, vub) : vub);
+        b1 = jl_svecref(*root, n);
+        b2 = v->lb;
+        jl_svecset(*root, n, simple_meet(b1, b2));
+        b1 = jl_svecref(*root, n+1);
+        b2 = v->ub;
+        jl_svecset(*root, n+1, simple_join(b1, b2));
         n = n + 3;
         v = v->prev;
     }

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -3251,15 +3251,13 @@ static int merge_env(jl_stenv_t *e, jl_value_t **root, jl_savedenv_t *se, int co
     jl_value_t *ub = NULL, *vub = NULL;
     JL_GC_PUSH2(&ub, &vub);
     while (v != NULL) {
-        if (v->ub != v->var->ub || v->lb != v->var->lb) {
-            jl_value_t *lb = jl_svecref(*root, n);
-            if (v->lb != lb)
-                jl_svecset(*root, n, lb ? jl_bottom_type : v->lb);
-            ub = jl_svecref(*root, n+1);
-            vub = v->ub;
-            if (vub != ub)
-                jl_svecset(*root, n+1, ub ? simple_join(ub, vub) : vub);
-        }
+        jl_value_t *lb = jl_svecref(*root, n);
+        if (v->lb != lb)
+            jl_svecset(*root, n, lb ? v->var->lb : v->lb);
+        ub = jl_svecref(*root, n+1);
+        vub = v->ub;
+        if (vub != ub)
+            jl_svecset(*root, n+1, ub ? simple_join(ub, vub) : vub);
         n = n + 3;
         v = v->prev;
     }

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2171,3 +2171,14 @@ let
     @test env_tuple(TT2, TT0) === Base.setindex(all_var(TT0), Int, 1)
     @test env_tuple(TT2, TT1) === Base.setindex(all_var(TT1), Int, 2)
 end
+
+#issue #46735
+T46735{B<:Real} = Pair{<:Union{B, Val{<:B}}, <:Union{AbstractMatrix{B}, AbstractMatrix{Vector{B}}}}
+@testintersect(T46735{B} where {B}, T46735, !Union{})
+@testintersect(T46735{B} where {B<:Integer}, T46735, !Union{})
+S46735{B<:Val, M<:AbstractMatrix} = Tuple{<:Union{B, <:Val{<:B}},M,<:(Union{AbstractMatrix{B}, AbstractMatrix{<:Vector{<:B}}})}
+@testintersect(S46735{B} where {B}, S46735, !Union{})
+@testintersect(S46735{B, M} where {B, M}, S46735, !Union{})
+A46735{B<:Val, M<:AbstractMatrix} = Tuple{<:Union{B, <:Val{<:B}},M,Union{AbstractMatrix{B}, AbstractMatrix{<:Vector{<:B}}}}
+@testintersect(A46735{B} where {B}, A46735, !Union{})
+@testintersect(A46735{B, M} where {B, M}, A46735, !Union{})


### PR DESCRIPTION
I skipped it as I thought unchanged bounds means there's no restriction added on this var.
But examples from #46735 show that it should not be skiped as the current `env` might not be valid if the var's bounds get fixed (by another Unions decision.)

close #46735. Test added.