### PR TITLE
Fix shift direction of circshift! for vectors

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3473,8 +3473,9 @@ function circshift!(a::AbstractVector, shift::Integer)
     n == 0 && return
     shift = mod(shift, n)
     shift == 0 && return
-    reverse!(a, 1, shift)
-    reverse!(a, shift+1, length(a))
+    l = lastindex(a)
+    reverse!(a, firstindex(a), l-shift)
+    reverse!(a, l-shift+1, lastindex(a))
     reverse!(a)
     return a
 end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -769,6 +769,18 @@ end
     @test circshift(src, 1) == src
     src = zeros(Bool, (4,0))
     @test circshift(src, 1) == src
+
+    # 1d circshift! (https://github.com/JuliaLang/julia/issues/46533)
+    a = [1:5;]
+    @test circshift!(a, 1) === a
+    @test a == circshift([1:5;], 1) == [5, 1, 2, 3, 4]
+    a = [1:5;]
+    @test circshift!(a, -2) === a
+    @test a == circshift([1:5;], -2) == [3, 4, 5, 1, 2]
+    a = [1:5;]
+    oa = OffsetVector(copy(a), -1)
+    @test circshift!(oa, 1) === oa
+    @test oa == circshift(OffsetVector(a, -1), 1)
 end
 
 @testset "circcopy" begin


### PR DESCRIPTION
This patch fixes the shifting direction for
circshift!(x::AbstractVector, n::Integer), which was opposite the
direction of circshift(x, n) and circshift!(y, x, n). In addition, this
patch fixes the method to also work correctly with offset arrays.
Fixes #46533.