### PR TITLE
introduce GenericDateTime to allow expansion of DateTime to new precisions

### DIFF
--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -140,15 +140,25 @@ abstract type TimeType <: AbstractTime end
 abstract type AbstractDateTime <: TimeType end
 
 """
+    GenericDateTime
+
+`GenericDateTime` wraps a user-parameterized `UTInstant` and interprets it according to the proleptic
+Gregorian calendar.
+"""
+struct GenericDateTime{P<:Period} <: AbstractDateTime
+    instant::UTInstant{P}
+    GenericDateTime(instant::UTInstant{P}) where {P} = new{P}(instant)
+end
+
+"""
     DateTime
 
 `DateTime` wraps a `UTInstant{Millisecond}` and interprets it according to the proleptic
 Gregorian calendar.
 """
-struct DateTime <: AbstractDateTime
-    instant::UTInstant{Millisecond}
-    DateTime(instant::UTInstant{Millisecond}) = new(instant)
-end
+const DateTime = GenericDateTime{Millisecond}
+DateTime(instant::UTInstant) =
+    GenericDateTime(UTInstant(Millisecond(Dates.toms(instant.periods))))
 
 """
     Date

--- a/stdlib/Dates/test/types.jl
+++ b/stdlib/Dates/test/types.jl
@@ -277,4 +277,9 @@ end
     @test timedwait(() -> false, Second(0); pollint=Millisecond(1)) === :timed_out
 end
 
+@testset "GenericDateTime" begin
+    nanodt = Dates.GenericDateTime(Dates.UTInstant(Nanosecond(123)))
+    @test nanodt.instant == Dates.UTInstant(Nanosecond(123))
+end
+
 end


### PR DESCRIPTION
This is a proposal for how we could extend `DateTime` to support new precisions (e.g. `NanoDateTime`) without breaking existing code.  Feedback appreciated.