### PR TITLE
fix invalidations from loading Static.jl

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -516,7 +516,8 @@ const SMALL_ALGORITHM  = InsertionSort
 const SMALL_THRESHOLD  = 20
 
 function sort!(v::AbstractVector, lo::Integer, hi::Integer, ::InsertionSortAlg, o::Ordering)
-    @inbounds for i = lo+1:hi
+    lo_plus_1 = (lo + 1)::Integer
+    @inbounds for i = lo_plus_1:hi
         j = i
         x = v[i]
         while j > lo

--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -281,7 +281,7 @@ end
 @inline function fmt(buf, pos, arg, spec::Spec{T}) where {T <: Strings}
     leftalign, hash, width, prec = spec.leftalign, spec.hash, spec.width, spec.precision
     str = string(arg)
-    slen = textwidth(str) + (hash ? arg isa AbstractString ? 2 : 1 : 0)
+    slen = textwidth(str)::Int + (hash ? arg isa AbstractString ? 2 : 1 : 0)
     op = p = prec == -1 ? slen : min(slen, prec)
     if !leftalign && width > p
         for _ = 1:(width - p)


### PR DESCRIPTION
I improved type stability of two methods to fix some invalidations. This is based on the following code:

```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add("ArrayInterface")

julia> using SnoopCompileCore; invalidations = @snoopr(using ArrayInterface); using SnoopCompile

julia> trees = invalidation_trees(invalidations)
...
inserting (::Colon)(L::Integer, ::Static.StaticInt{U}) where U in ArrayInterface at ~/.julia/packages/ArrayInterface/eITVf/src/ranges.jl:157 invalidated:
...
inserting (::Colon)(::Static.StaticInt{L}, U::Integer) where L in ArrayInterface at ~/.julia/packages/ArrayInterface/eITVf/src/ranges.jl:158 invalidated:
...
```
