### PR TITLE
improve type stability of `tail/front(::NamedTuple)`

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -319,8 +319,8 @@ values(nt::NamedTuple) = Tuple(nt)
 haskey(nt::NamedTuple, key::Union{Integer, Symbol}) = isdefined(nt, key)
 get(nt::NamedTuple, key::Union{Integer, Symbol}, default) = isdefined(nt, key) ? getfield(nt, key) : default
 get(f::Callable, nt::NamedTuple, key::Union{Integer, Symbol}) = isdefined(nt, key) ? getfield(nt, key) : f()
-tail(t::NamedTuple{names}) where names = NamedTuple{tail(names)}(t)
-front(t::NamedTuple{names}) where names = NamedTuple{front(names)}(t)
+tail(t::NamedTuple{names}) where names = NamedTuple{tail(names::Tuple)}(t)
+front(t::NamedTuple{names}) where names = NamedTuple{front(names::Tuple)}(t)
 reverse(nt::NamedTuple) = NamedTuple{reverse(keys(nt))}(reverse(values(nt)))
 
 @assume_effects :total function diff_names(an::Tuple{Vararg{Symbol}}, bn::Tuple{Vararg{Symbol}})


### PR DESCRIPTION
I improved type stability to fix some invalidations when loading ChainRulesCore.jl.. This is based on the following code:

```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add("ChainRulesCore")

julia> using SnoopCompileCore; invalidations = @snoopr(using ChainRulesCore); using SnoopCompile

julia> trees = invalidation_trees(invalidations)
...
 inserting tail(t::Tangent{<:NamedTuple{<:Any, <:Tuple{}}}) in ChainRulesCore at ~/.julia/packages/ChainRulesCore/Z4Jry/src/tangent_types/tangent.jl:110 invalidated:
...
                 9: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.tail(::NamedTuple{names}) where names (335 children)
```
