### PR TITLE
Specialize `inv` for cholesky of `Diagonal`

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -828,6 +828,8 @@ end
 @deprecate cholesky!(A::Diagonal, ::Val{false}; check::Bool = true) cholesky!(A::Diagonal, NoPivot(); check) false
 @deprecate cholesky(A::Diagonal, ::Val{false}; check::Bool = true) cholesky(A::Diagonal, NoPivot(); check) false
 
+inv(C::Cholesky{<:Any,<:Diagonal}) = Diagonal(map(inv∘abs2, C.factors.diag))
+
 @inline cholcopy(A::Diagonal) = copymutable_oftype(A, choltype(A))
 @inline cholcopy(A::RealHermSymComplexHerm{<:Real,<:Diagonal}) = copymutable_oftype(A, choltype(A))
 

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -303,6 +303,7 @@ end
     v = rand(5)
     @test cholesky(Diagonal(v)) \ B ≈ Diagonal(v) \ B
     @test B / cholesky(Diagonal(v)) ≈ B / Diagonal(v)
+    @test inv(cholesky(Diagonal(v)))::Diagonal ≈ Diagonal(1 ./ v)
 end
 
 struct WrappedVector{T} <: AbstractVector{T}


### PR DESCRIPTION
Closes JuliaLang/LinearAlgebra.jl#952.

As I understand, this trivial case does appear in the wild and is worth being optimized.