### PR TITLE
speed up Ryu.pow5

### DIFF
--- a/base/ryu/utils.jl
+++ b/base/ryu/utils.jl
@@ -65,14 +65,7 @@ lengthforindex(idx) = div(((Int64(16 * idx) * 1292913986) >> 32) + 1 + 16 + 8, 9
 Return `true` if `5^p` is a divisor of `x`.
 """
 @inline function pow5(x, p)
-    count = 0
-    while true
-        q = div(x, 5)
-        r = x - 5 * q
-        r != 0 && return count >= p
-        x = q
-        count += 1
-    end
+    x % (5^p) == 0
 end
 
 """


### PR DESCRIPTION
The current algorithm does up to `p` divisions, while this algorithm does only 1. I've assigned @quinnj  to review since I'm not 100% sure that there isn't a very good reason that this function isn't written like this.