### PR TITLE
clarify show docs

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -434,8 +434,8 @@ Julia code when possible.
 
 [`repr`](@ref) returns the output of `show` as a string.
 
-To customize human-readable text output for objects of type `T`, define
-`show(io::IO, ::MIME"text/plain", ::T)` instead. Checking the `:compact`
+For a more verbose human-readable text output for objects of type `T`, define
+`show(io::IO, ::MIME"text/plain", ::T)` in addition. Checking the `:compact`
 [`IOContext`](@ref) property of `io` in such methods is recommended,
 since some containers show their elements by calling this method with
 `:compact => true`.


### PR DESCRIPTION
I noticed that the `Base.show` docs recommend defining a 3-argument `show` method *instead* of the 2-argument `show` method for "human-readable" output.  This seems misleading — the 3-argument `show` is normally customized in *addition* to the 2-argument `show`