### PR TITLE
Add lattice element to represent valid tparams

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1957,7 +1957,7 @@ function abstract_eval_value_expr(interp::AbstractInterpreter, e::Expr, sv::Unio
     head = e.head
     if head === :static_parameter
         n = e.args[1]::Int
-        t = Any
+        t = AnySParam()
         if 1 <= n <= length(sv.sptypes)
             t = sv.sptypes[n]
         end

--- a/base/compiler/abstractlattice.jl
+++ b/base/compiler/abstractlattice.jl
@@ -14,12 +14,12 @@ is_valid_lattice(::JLTypeLattice, @nospecialize(elem)) = isa(elem, Type)
 """
     struct ConstsLattice
 
-A lattice extending `JLTypeLattice` and adjoining `Const` and `PartialTypeVar`.
+A lattice extending `JLTypeLattice` and adjoining `Const`, `PartialTypeVar` and `AnySParam`
 """
 struct ConstsLattice <: AbstractLattice; end
 widenlattice(::ConstsLattice) = JLTypeLattice()
 is_valid_lattice(lattice::ConstsLattice, @nospecialize(elem)) =
-    is_valid_lattice(widenlattice(lattice), elem) || isa(elem, Const) || isa(elem, PartialTypeVar)
+    is_valid_lattice(widenlattice(lattice), elem) || isa(elem, Const) || isa(elem, PartialTypeVar) || isa(elem, AnySParam)
 
 """
     struct PartialsLattice{L}

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -427,7 +427,7 @@ function sptypes_from_meth_instance(linfo::MethodInstance)
                     lb = Bottom
                 end
                 if Any <: ub && lb <: Bottom
-                    ty = Any
+                    ty = AnySParam()
                 else
                     tv = TypeVar(v.name, lb, ub)
                     ty = UnionAll(tv, Type{tv})

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1408,7 +1408,7 @@ function apply_type_nothrow(@specialize(lattice::AbstractLattice), argtypes::Arr
     for i = 2:length(argtypes)
         isa(u, UnionAll) || return false
         ai = widenconditional(argtypes[i])
-        if ⊑(lattice, ai, TypeVar) || ai === DataType
+        if ⊑(lattice, ai, TypeVar) || ai === DataType || ai === AnySParam()
             # We don't know anything about the bounds of this typevar, but as
             # long as the UnionAll is not constrained, that's ok.
             if !(u.var.lb === Union{} && u.var.ub === Any)

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -438,6 +438,12 @@ end |> Core.Compiler.is_consistent
 
 @test Core.Compiler.is_consistent(Base.infer_effects(setindex!, (Base.RefValue{Int}, Int)))
 
+# Test that :apply_type can be eliminated if it came from a static parameter
+f_apply_type_sparam(x::Ref{T}) where {T} = (Ref{T}; nothing)
+let src = code_typed1(f_apply_type_sparam, (Ref,))
+    @test count(iscall((src, Core.apply_type)), src.code) == 0
+end
+
 # :inaccessiblememonly effect
 const global constant_global::Int = 42
 const global ConstantType = Ref


### PR DESCRIPTION
Currently we represent an unknown :static_parameter, as `Any`. However, we actually have a fair bit of additional information about it. In particular, a value that came from a static parameter must have been a `valid_tparam` and thus if it's used in `apply_type` again, we're guaranteed that such a use will be nothrow. This adds a special lattice element to encode this set of values. The primary benefit is to be able to prove the nothrow fact about many more apply_type calls and thus cut down the size of the IR. That said, at the moment, we cannot prove nothrow for unknown `:static_parameter` either, but that's a separate bit of work (and we need to do both to really be able to eliminate common patterns).