### PR TITLE
Add effect modeling for Core.compilerbarrier

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1856,6 +1856,10 @@ function _builtin_nothrow(@specialize(lattice::AbstractLattice), @nospecialize(f
         2 <= length(argtypes) <= 4 || return false
         # Core.finalizer does no error checking - that's done in Base.finalizer
         return true
+    elseif f === Core.compilerbarrier
+        length(argtypes) == 2 || return false
+        a1 = argtypes[1]
+        return isa(a1, Const) && contains_is((:type, :const, :conditional), a1.val)
     end
     return false
 end
@@ -1868,7 +1872,7 @@ const _EFFECT_FREE_BUILTINS = [
     fieldtype, apply_type, isa, UnionAll,
     getfield, arrayref, const_arrayref, isdefined, Core.sizeof,
     Core.kwfunc, Core.ifelse, Core._typevar, (<:),
-    typeassert, throw, arraysize, getglobal,
+    typeassert, throw, arraysize, getglobal, compilerbarrier
 ]
 
 const _CONSISTENT_BUILTINS = Any[
@@ -1887,7 +1891,7 @@ const _CONSISTENT_BUILTINS = Any[
     (<:),
     typeassert,
     throw,
-    setfield!,
+    setfield!
 ]
 
 const _INACCESSIBLEMEM_BUILTINS = Any[
@@ -1906,6 +1910,7 @@ const _INACCESSIBLEMEM_BUILTINS = Any[
     tuple,
     typeassert,
     typeof,
+    compilerbarrier,
 ]
 
 const _ARGMEM_BUILTINS = Any[

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -204,6 +204,9 @@ function compare_inconsistent(x::T) where T
 end
 @test !compare_inconsistent(3)
 
+# Effect modeling for Core.compilerbarrier
+@test Base.infer_effects(Base.inferencebarrier, Tuple{Any}) |> Core.Compiler.is_removable_if_unused
+
 # allocation/access of uninitialized fields should taint the :consistent-cy
 struct Maybe{T}
     x::T

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4171,8 +4171,8 @@ for setting = (:type, :const, :conditional)
 end
 
 # https://github.com/JuliaLang/julia/issues/46426
-@noinline Base.@assume_effects :nothrow typebarrier() = Base.inferencebarrier(0.0)
-@noinline Base.@assume_effects :nothrow constbarrier() = Base.compilerbarrier(:const, 0.0)
+@noinline typebarrier() = Base.inferencebarrier(0.0)
+@noinline constbarrier() = Base.compilerbarrier(:const, 0.0)
 let src = code_typed1() do
         typebarrier()
     end


### PR DESCRIPTION
The compiler barrier itself doesn't have any effects, though of course by pessimizing type information, it may prevent the compiler from discovering effect information it would have otherwise obtained. Nevertheless, particularly the weaker barriers like `:const` and `:conditional` should not, by themselves taint any effects.