### PR TITLE
inlining: Also apply statement effects when declining to inline

### DIFF
--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1522,3 +1522,13 @@ let src = code_typed1(fvarargN_inline, (Tuple{Vararg{Int}},))
                  count(iscall((src, Core._svec_ref)), src.code) == 0 &&
                  count(iscall((src, Core.nfields)), src.code) == 1
 end
+
+# Test effect annotation of declined inline unionsplit
+f_union_unmatched(x::Union{Nothing, Type{T}}) where {T} = nothing
+function g_union_unmatched(x)
+    if isa(x, Union{Nothing, Type})
+        foo(x)
+    end
+    return nothing
+end
+@test fully_eliminated(g_union_unmatched, Tuple{Any})

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1525,10 +1525,11 @@ end
 
 # Test effect annotation of declined inline unionsplit
 f_union_unmatched(x::Union{Nothing, Type{T}}) where {T} = nothing
-function g_union_unmatched(x)
-    if isa(x, Union{Nothing, Type})
-        foo(x)
+let src = code_typed1((Any,)) do x
+        if isa(x, Union{Nothing, Type})
+            f_union_unmatched(x)
+        end
+        nothing
     end
-    return nothing
+    @test count(iscall((src, f_union_unmatched)), src.code) == 0
 end
-@test fully_eliminated(g_union_unmatched, Tuple{Any})


### PR DESCRIPTION
When inlining, we already determine what the effects for all the different cases are, so that we can apply appropriate statement flags on each of the edges. However, if for some reason we decided to decline to inline, we weren't making use of this information. Fix that.