### PR TITLE
Remove unnecessary `reducedim_init` specialization

### DIFF
--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -2,13 +2,6 @@
 
 # Methods operating on different special matrix types
 
-
-# Usually, reducedim_initarray calls similar, which yields a sparse matrix for a
-# Diagonal/Bidiagonal/Tridiagonal/SymTridiagonal matrix. However, reducedim should
-# yield a dense vector to increase performance.
-Base.reducedim_initarray(A::Union{Diagonal,Bidiagonal,Tridiagonal,SymTridiagonal}, region, init, ::Type{R}) where {R} = fill(convert(R, init), Base.reduced_indices(A,region))
-
-
 # Interconversion between special matrix types
 
 # conversions from Diagonal to other special matrix types

--- a/stdlib/LinearAlgebra/test/special.jl
+++ b/stdlib/LinearAlgebra/test/special.jl
@@ -256,8 +256,7 @@ end
         @test hvcat((1,1), specialmata, specialmatb) == hvcat((1,1), MA, MB)
         @test cat(specialmata, specialmatb; dims=(1,2)) == cat(MA, MB; dims=(1,2))
     end
-    # Test concatenating pairwise combinations of special matrices with sparse matrices,
-    # dense matrices, or dense vectors
+    # Test concatenating pairwise combinations of special matrices with dense matrices or dense vectors
     densevec = fill(1., N)
     densemat = diagm(0 => densevec)
     for specialmat in specialmats


### PR DESCRIPTION
With the excision of `SparseArrays.jl`, `similar` of structured matrices yields dense arrays anyway, so this specialization is obsolete.