### PR TITLE
set number of openblas threads to 1 while precompiling

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1684,12 +1684,14 @@ function create_expr_cache(pkg::PkgId, input::String, output::String, concrete_d
     deps_eltype = sprint(show, eltype(concrete_deps); context = :module=>nothing)
     deps = deps_eltype * "[" * join(deps_strs, ",") * "]"
     trace = isassigned(PRECOMPILE_TRACE_COMPILE) ? `--trace-compile=$(PRECOMPILE_TRACE_COMPILE[])` : ``
-    io = open(pipeline(`$(julia_cmd()::Cmd) -O0
-                       --output-ji $output --output-incremental=yes
-                       --startup-file=no --history-file=no --warn-overwrite=yes
-                       --color=$(have_color === nothing ? "auto" : have_color ? "yes" : "no")
-                       $trace
-                       -`, stderr = internal_stderr, stdout = internal_stdout),
+    io = open(pipeline(addenv(`$(julia_cmd()::Cmd) -O0
+                              --output-ji $output --output-incremental=yes
+                              --startup-file=no --history-file=no --warn-overwrite=yes
+                              --color=$(have_color === nothing ? "auto" : have_color ? "yes" : "no")
+                              $trace
+                              -`,
+                              "OPENBLAS_NUM_THREADS" => 1),
+                       stderr = internal_stderr, stdout = internal_stdout),
               "w", stdout)
     # write data over stdin to avoid the (unlikely) case of exceeding max command line size
     write(io.in, """


### PR DESCRIPTION
With the increased number of openblas threads by defaults, there have been reports about various types of crashes when precompilation is done in parallel. Limit the number of openblas threads during precompilation to reduce resource usage slightly. 