### PR TITLE
NFC Windows build improvements

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -772,6 +772,8 @@ else ifeq (cygwin, $(shell $(CC) -dumpmachine | cut -d\- -f3))
 $(error "cannot build julia with cygwin-target compilers. set XC_HOST to i686-w64-mingw32 or x86_64-w64-mingw32 for mingw cross-compile")
 else ifeq (msys, $(shell $(CC) -dumpmachine | cut -d\- -f3))
 $(error "cannot build julia with msys-target compilers. please see the README.windows document for instructions on setting up mingw-w64 compilers")
+else ifneq (,$(findstring MSYS,$(shell uname)))
+$(error "cannot build julia from a msys shell. please launch a mingw shell instead by setting MSYSTEM=MINGW64")
 endif
 
 ifeq ($(BUILD_OS),Darwin)

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -6,8 +6,8 @@
 #include <inttypes.h>
 #include "julia.h"
 #include "julia_internal.h"
-#ifndef _OS_WINDOWS_
 #include <unistd.h>
+#ifndef _OS_WINDOWS_
 #include <sys/mman.h>
 #endif
 


### PR DESCRIPTION
Include `unistd.h` to avoid:

```
    CC src/signal-handling.o
C:/Users/Tim/Julia/src/julia/src/signal-handling.c: In function 'jl_critical_error':
C:/Users/Tim/Julia/src/julia/src/signal-handling.c:461:52: warning: implicit declaration of function 'getpid'; did you mean 'getcwd'? [-Wimplicit-function-declaration]
  461 |         jl_safe_printf("\n[%d] signal (%d): %s\n", getpid(), sig, strsignal(sig));
      |                                                    ^~~~~~
      |                                                    getcwd
```

Also warn when running in an msys shell. I had set up msys2 and installed mingw64 compilers (adding `/mingw64` to PATH), but forgot to set MSYSTEM so the following didn't trigger: https://github.com/JuliaLang/julia/blob/0fabe5428095fcbeca225e4d44b57e7f9aef3476/cli/Makefile#L31-L38

That resulted in a very weird error (`Too few special library names specified`), so warn about it beforehand.