### PR TITLE
Generalize 2-arg `eigen` towards `AbstractMatrix`

### DIFF
--- a/stdlib/LinearAlgebra/src/bunchkaufman.jl
+++ b/stdlib/LinearAlgebra/src/bunchkaufman.jl
@@ -197,7 +197,7 @@ julia> S.L*S.D*S.L' - A[S.p, S.p]
 ```
 """
 bunchkaufman(A::AbstractMatrix{T}, rook::Bool=false; check::Bool = true) where {T} =
-    bunchkaufman!(copymutable_oftype(A, typeof(sqrt(oneunit(T)))), rook; check = check)
+    bunchkaufman!(eigencopy_oftype(A, typeof(sqrt(oneunit(T)))), rook; check = check)
 
 BunchKaufman{T}(B::BunchKaufman) where {T} =
     BunchKaufman(convert(Matrix{T}, B.LD), B.ipiv, B.uplo, B.symmetric, B.rook, B.info)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -773,7 +773,7 @@ function eigen(A::AbstractMatrix, D::Diagonal; sortby::Union{Function,Nothing}=n
         throw(ArgumentError("right-hand side diagonal matrix contains Infs or NaNs or is singular"))
     end
     if size(A, 1) == size(A, 2) && isdiag(A)
-        return eigen(Diagonal(A), D)
+        return eigen(Diagonal(A), D; sortby)
     elseif ishermitian(A)
         S = promote_type(eigtype(eltype(A)), eltype(D))
         return eigen!(eigencopy_oftype(Hermitian(A), S), Diagonal{S}(D); sortby)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -763,14 +763,17 @@ function eigen(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{
     Eigen(λ, evecs)
 end
 function eigen(Da::Diagonal, Db::Diagonal; sortby::Union{Function,Nothing}=nothing)
-    if any(!isfinite, Da.diag) || any(!isfinite, Db.diag) || any(iszero, Db.diag)
-        throw(ArgumentError("matrix contains Infs or NaNs"))
+    if any(!isfinite, Da.diag) || any(!isfinite, Db.diag)
+        throw(ArgumentError("matrices contain Infs or NaNs"))
+    end
+    if !isposdef(Db)
+        throw(ArgumentError("right-hand side diagonal matrix is not positive definit"))
     end
     return GeneralizedEigen(eigen(Db \ Da; sortby)...)
 end
 function eigen(A::AbstractMatrix, D::Diagonal; sortby::Union{Function,Nothing}=nothing)
-    if any(!isfinite, D.diag) || any(iszero, D.diag)
-        throw(ArgumentError("right-hand side diagonal matrix contains Infs or NaNs or is singular"))
+    if !isposdef(D)
+        throw(ArgumentError("right-hand side diagonal matrix is not positive definit"))
     end
     if size(A, 1) == size(A, 2) && isdiag(A)
         return eigen(Diagonal(A), D; sortby)
@@ -778,9 +781,8 @@ function eigen(A::AbstractMatrix, D::Diagonal; sortby::Union{Function,Nothing}=n
         S = promote_type(eigtype(eltype(A)), eltype(D))
         return eigen!(eigencopy_oftype(Hermitian(A), S), Diagonal{S}(D); sortby)
     else
-        DA = D \ A
-        E = DA isa Matrix ? eigen!(DA; sortby) : eigen(DA; sortby)
-        return GeneralizedEigen(E...)
+        S = promote_type(eigtype(eltype(A)), eltype(D))
+        return eigen!(eigencopy_oftype(A, S), Diagonal{S}(D); sortby)
     end
 end
 

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -762,6 +762,20 @@ function eigen(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{
     end
     Eigen(λ, evecs)
 end
+function eigen(Da::Diagonal, Db::Diagonal; sortby::Union{Function,Nothing}=nothing)
+    if any(!isfinite, Da.diag) || any(!isfinite, Db.diag) || any(iszero, Db.diag)
+        throw(ArgumentError("matrix contains Infs or NaNs"))
+    end
+    return GeneralizedEigen(eigen(Db \ Da; sortby)...)
+end
+function eigen(A::AbstractMatrix, D::Diagonal; sortby::Union{Function,Nothing}=nothing)
+    if any(!isfinite, D.diag) || any(iszero, D.diag)
+        throw(ArgumentError("right-hand side diagonal matrix contains Infs or NaNs or is singular"))
+    end
+    DA = D \ A
+    E = DA isa Matrix ? eigen!(DA; sortby) : eigen(DA; sortby)
+    return GeneralizedEigen(E...)
+end
 
 #Singular system
 svdvals(D::Diagonal{<:Number}) = sort!(abs.(D.diag), rev = true)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -752,7 +752,7 @@ function eigen(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{
     λ = eigvals(D)
     if !isnothing(sortby)
         p = sortperm(λ; alg=QuickSort, by=sortby)
-        λ = λ[p] # make a copy, otherwise this permutes D.diag
+        λ = λ[p]
         evecs = zeros(Td, size(D))
         @inbounds for i in eachindex(p)
             evecs[p[i],i] = one(Td)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -766,14 +766,14 @@ function eigen(Da::Diagonal, Db::Diagonal; sortby::Union{Function,Nothing}=nothi
     if any(!isfinite, Da.diag) || any(!isfinite, Db.diag)
         throw(ArgumentError("matrices contain Infs or NaNs"))
     end
-    if !isposdef(Db)
-        throw(ArgumentError("right-hand side diagonal matrix is not positive definit"))
+    if any(iszero, Db.diag)
+        throw(ArgumentError("right-hand side diagonal matrix is singular"))
     end
     return GeneralizedEigen(eigen(Db \ Da; sortby)...)
 end
 function eigen(A::AbstractMatrix, D::Diagonal; sortby::Union{Function,Nothing}=nothing)
-    if !isposdef(D)
-        throw(ArgumentError("right-hand side diagonal matrix is not positive definit"))
+    if any(iszero, D.diag)
+        throw(ArgumentError("right-hand side diagonal matrix is singular"))
     end
     if size(A, 1) == size(A, 2) && isdiag(A)
         return eigen(Diagonal(A), D; sortby)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -772,9 +772,16 @@ function eigen(A::AbstractMatrix, D::Diagonal; sortby::Union{Function,Nothing}=n
     if any(!isfinite, D.diag) || any(iszero, D.diag)
         throw(ArgumentError("right-hand side diagonal matrix contains Infs or NaNs or is singular"))
     end
-    DA = D \ A
-    E = DA isa Matrix ? eigen!(DA; sortby) : eigen(DA; sortby)
-    return GeneralizedEigen(E...)
+    if size(A, 1) == size(A, 2) && isdiag(A)
+        return eigen(Diagonal(A), D)        
+    elseif ishermitian(A)
+        S = promote_type(eigtype(eltype(A)), eltype(D))
+        return eigen!(eigencopy_oftype(Hermitian(A), S), Diagonal{S}(D); sortby)
+    else
+        DA = D \ A
+        E = DA isa Matrix ? eigen!(DA; sortby) : eigen(DA; sortby)
+        return GeneralizedEigen(E...)
+    end
 end
 
 #Singular system

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -773,7 +773,7 @@ function eigen(A::AbstractMatrix, D::Diagonal; sortby::Union{Function,Nothing}=n
         throw(ArgumentError("right-hand side diagonal matrix contains Infs or NaNs or is singular"))
     end
     if size(A, 1) == size(A, 2) && isdiag(A)
-        return eigen(Diagonal(A), D)        
+        return eigen(Diagonal(A), D)
     elseif ishermitian(A)
         S = promote_type(eigtype(eltype(A)), eltype(D))
         return eigen!(eigencopy_oftype(Hermitian(A), S), Diagonal{S}(D); sortby)

--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -508,10 +508,13 @@ true
 """
 function eigen(A::AbstractMatrix{TA}, B::AbstractMatrix{TB}; kws...) where {TA,TB}
     S = promote_type(eigtype(TA),TB)
-    eigen!(copymutable_oftype(A, S), copymutable_oftype(B, S); kws...)
+    eigen!(eigencopy_oftype(A, S), eigencopy_oftype(B, S); kws...)
 end
-
 eigen(A::Number, B::Number) = eigen(fill(A,1,1), fill(B,1,1))
+
+eigencopy_oftype(A, S) = copy_similar(A, S) # creates a dense matrix of eltype S
+# the following line is placed in symmetriceigen.jl for bootstrap reasons
+# eigencopy_oftype(A::HermOrSym, S) = copymutable_oftype(A, S) # preserves HermOrSym wrapper
 
 """
     eigvals!(A, B; sortby) -> values

--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -513,8 +513,6 @@ end
 eigen(A::Number, B::Number) = eigen(fill(A,1,1), fill(B,1,1))
 
 eigencopy_oftype(A, S) = copy_similar(A, S) # creates a dense matrix of eltype S
-# the following line is placed in symmetriceigen.jl for bootstrap reasons
-# eigencopy_oftype(A::HermOrSym, S) = copymutable_oftype(A, S) # preserves HermOrSym wrapper
 
 """
     eigvals!(A, B; sortby) -> values

--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -233,16 +233,20 @@ true
 ```
 """
 function eigen(A::AbstractMatrix{T}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) where T
-    AA = copymutable_oftype(A, eigtype(T))
-    isdiag(AA) && return eigen(Diagonal(AA); permute=permute, scale=scale, sortby=sortby)
-    return eigen!(AA; permute=permute, scale=scale, sortby=sortby)
+    isdiag(A) && return eigen(Diagonal{eigtype(T)}(diag(A)); sortby)
+    ishermitian(A) && return eigen!(eigencopy_oftype(Hermitian(A), eigtype(T)); sortby)
+    AA = eigencopy_oftype(A, eigtype(T))
+    return eigen!(AA; permute, scale, sortby)
 end
 function eigen(A::AbstractMatrix{T}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) where {T <: Union{Float16,Complex{Float16}}}
-    AA = copymutable_oftype(A, eigtype(T))
-    isdiag(AA) && return eigen(Diagonal(AA); permute=permute, scale=scale, sortby=sortby)
-    A = eigen!(AA; permute, scale, sortby)
-    values = convert(AbstractVector{isreal(A.values) ? Float16 : Complex{Float16}}, A.values)
-    vectors = convert(AbstractMatrix{isreal(A.vectors) ? Float16 : Complex{Float16}}, A.vectors)
+    isdiag(A) && return eigen(Diagonal{eigtype(T)}(diag(A)); sortby)
+    E = if ishermitian(A)
+        eigen!(eigencopy_oftype(Hermitian(A), eigtype(T)); sortby)
+    else
+        eigen!(eigencopy_oftype(A, eigtype(T)); permute, scale, sortby)
+    end
+    values = convert(AbstractVector{isreal(E.values) ? Float16 : Complex{Float16}}, E.values)
+    vectors = convert(AbstractMatrix{isreal(E.vectors) ? Float16 : Complex{Float16}}, E.vectors)
     return Eigen(values, vectors)
 end
 eigen(x::Number) = Eigen([x], fill(one(x), 1, 1))
@@ -333,7 +337,7 @@ julia> eigvals(diag_matrix)
 ```
 """
 eigvals(A::AbstractMatrix{T}; kws...) where T =
-    eigvals!(copymutable_oftype(A, eigtype(T)); kws...)
+    eigvals!(eigencopy_oftype(A, eigtype(T)); kws...)
 
 """
 For a scalar input, `eigvals` will return a scalar.
@@ -507,12 +511,19 @@ true
 ```
 """
 function eigen(A::AbstractMatrix{TA}, B::AbstractMatrix{TB}; kws...) where {TA,TB}
-    S = promote_type(eigtype(TA),TB)
+    S = promote_type(eigtype(TA), TB)
     eigen!(eigencopy_oftype(A, S), eigencopy_oftype(B, S); kws...)
 end
 eigen(A::Number, B::Number) = eigen(fill(A,1,1), fill(B,1,1))
 
-eigencopy_oftype(A, S) = copy_similar(A, S) # creates a dense matrix of eltype S
+"""
+    LinearAlgebra.eigencopy_oftype(A::AbstractMatrix, ::Type{S})
+
+Creates a dense copy of `A` with eltype `S` by calling `copy_similar(A, S)`.
+In the case of `Hermitian` or `Symmetric` matrices additionally retains the wrapper,
+together with the `uplo` field.
+"""
+eigencopy_oftype(A, S) = copy_similar(A, S)
 
 """
     eigvals!(A, B; sortby) -> values
@@ -587,8 +598,8 @@ julia> eigvals(A,B)
 ```
 """
 function eigvals(A::AbstractMatrix{TA}, B::AbstractMatrix{TB}; kws...) where {TA,TB}
-    S = promote_type(eigtype(TA),TB)
-    return eigvals!(copymutable_oftype(A, S), copymutable_oftype(B, S); kws...)
+    S = promote_type(eigtype(TA), TB)
+    return eigvals!(eigencopy_oftype(A, S), eigencopy_oftype(B, S); kws...)
 end
 
 """

--- a/stdlib/LinearAlgebra/src/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/src/symmetriceigen.jl
@@ -1,13 +1,14 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+eigencopy_oftype(A::HermOrSym, S) = copymutable_oftype(A, S) # preserves HermOrSym wrapper
+
 # Eigensolvers for symmetric and Hermitian matrices
 eigen!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; sortby::Union{Function,Nothing}=nothing) =
     Eigen(sorteig!(LAPACK.syevr!('V', 'A', A.uplo, A.data, 0.0, 0.0, 0, 0, -1.0)..., sortby)...)
 
 function eigen(A::RealHermSymComplexHerm; sortby::Union{Function,Nothing}=nothing)
-    T = eltype(A)
-    S = eigtype(T)
-    eigen!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), sortby=sortby)
+    S = eigtype(eltype(A))
+    eigen!(eigencopy_oftype(A, S), sortby=sortby)
 end
 
 eigen!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}, irange::UnitRange) =
@@ -31,9 +32,8 @@ The [`UnitRange`](@ref) `irange` specifies indices of the sorted eigenvalues to 
     will be a *truncated* factorization.
 """
 function eigen(A::RealHermSymComplexHerm, irange::UnitRange)
-    T = eltype(A)
-    S = eigtype(T)
-    eigen!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), irange)
+    S = eigtype(eltype(A))
+    eigen!(eigencopy_oftype(A, S), irange)
 end
 
 eigen!(A::RealHermSymComplexHerm{T,<:StridedMatrix}, vl::Real, vh::Real) where {T<:BlasReal} =
@@ -57,9 +57,8 @@ The following functions are available for `Eigen` objects: [`inv`](@ref), [`det`
     will be a *truncated* factorization.
 """
 function eigen(A::RealHermSymComplexHerm, vl::Real, vh::Real)
-    T = eltype(A)
-    S = eigtype(T)
-    eigen!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), vl, vh)
+    S = eigtype(eltype(A))
+    eigen!(eigencopy_oftype(A, S), vl, vh)
 end
 
 function eigvals!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; sortby::Union{Function,Nothing}=nothing)
@@ -69,9 +68,8 @@ function eigvals!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; sortby:
 end
 
 function eigvals(A::RealHermSymComplexHerm; sortby::Union{Function,Nothing}=nothing)
-    T = eltype(A)
-    S = eigtype(T)
-    eigvals!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), sortby=sortby)
+    S = eigtype(eltype(A))
+    eigvals!(eigencopy_oftype(A, S), sortby=sortby)
 end
 
 """
@@ -110,9 +108,8 @@ julia> eigvals(A)
 ```
 """
 function eigvals(A::RealHermSymComplexHerm, irange::UnitRange)
-    T = eltype(A)
-    S = eigtype(T)
-    eigvals!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), irange)
+    S = eigtype(eltype(A))
+    eigvals!(eigencopy_oftype(A, S), irange)
 end
 
 """
@@ -150,9 +147,8 @@ julia> eigvals(A)
 ```
 """
 function eigvals(A::RealHermSymComplexHerm, vl::Real, vh::Real)
-    T = eltype(A)
-    S = eigtype(T)
-    eigvals!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), vl, vh)
+    S = eigtype(eltype(A))
+    eigvals!(eigencopy_oftype(A, S), vl, vh)
 end
 
 eigmax(A::RealHermSymComplexHerm{<:Real,<:StridedMatrix}) = eigvals(A, size(A, 1):size(A, 1))[1]

--- a/stdlib/LinearAlgebra/src/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/src/symmetriceigen.jl
@@ -1,6 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-eigencopy_oftype(A::HermOrSym, S) = copymutable_oftype(A, S) # preserves HermOrSym wrapper
+# preserve HermOrSym wrapper
+eigencopy_oftype(A::Hermitian, S) = Hermitian(copy_similar(A, S), sym_uplo(A.uplo))
+eigencopy_oftype(A::Symmetric, S) = Symmetric(copy_similar(A, S), sym_uplo(A.uplo))
 
 # Eigensolvers for symmetric and Hermitian matrices
 eigen!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; sortby::Union{Function,Nothing}=nothing) =

--- a/stdlib/LinearAlgebra/src/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/src/symmetriceigen.jl
@@ -162,7 +162,6 @@ function eigen!(A::Hermitian{T,S}, B::Hermitian{T,S}; sortby::Union{Function,Not
     vals, vecs, _ = LAPACK.sygvd!(1, 'V', A.uplo, A.data, B.uplo == A.uplo ? B.data : copy(B.data'))
     GeneralizedEigen(sorteig!(vals, vecs, sortby)...)
 end
-
 function eigen!(A::RealHermSymComplexHerm{T,S}, B::AbstractMatrix{T}; sortby::Union{Function,Nothing}=nothing) where {T<:Number,S<:StridedMatrix}
     U = cholesky(B).U
     vals, w = eigen!(UtiAUi!(A, U))

--- a/stdlib/LinearAlgebra/src/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/src/symmetriceigen.jl
@@ -167,7 +167,7 @@ end
 function eigen!(A::RealHermSymComplexHerm{T,S}, B::AbstractMatrix{T}; sortby::Union{Function,Nothing}=nothing) where {T<:Number,S<:StridedMatrix}
     return _choleigen!(A, B, sortby)
 end
-function eigen!(A::StridedMatrix{T}, B::RealHermSymComplexHerm{T}; sortby::Union{Function,Nothing}=nothing) where {T<:Number}
+function eigen!(A::StridedMatrix{T}, B::Union{RealHermSymComplexHerm{T},Diagonal{T}}; sortby::Union{Function,Nothing}=nothing) where {T<:Number}
     return _choleigen!(A, B, sortby)
 end
 function _choleigen!(A, B, sortby)

--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -98,6 +98,13 @@ aimg  = randn(n,n)/2
             @test abs.(fh.vectors) ≈ abs.(f.vectors)  # may change sign
             gh = eigen(Hermitian(asym_sg), Diagonal(a_sg'a_sg))
             @test Hermitian(asym_sg)*gh.vectors ≈ (Diagonal(a_sg'a_sg)*gh.vectors) * Diagonal(gh.values)
+            gd = eigen(Diagonal(a_sg'a_sg), Diagonal(a_sg'a_sg))
+            @test all(isone, gd.values)
+            @test Diagonal(a_sg'a_sg) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
+            gd = eigen(Matrix(Diagonal(a_sg'a_sg)), Diagonal(a_sg'a_sg))
+            @test Diagonal(a_sg'a_sg) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
+            gd = eigen(Diagonal(a_sg'a_sg), Matrix(Diagonal(a_sg'a_sg)))
+            @test Diagonal(a_sg'a_sg) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
         end
         @testset "Non-symmetric generalized eigenproblem" begin
             if isa(a, Array)

--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -103,6 +103,8 @@ aimg  = randn(n,n)/2
             @test Diagonal(a_sg'a_sg) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
             gd = eigen(Matrix(Diagonal(a_sg'a_sg)), Diagonal(a_sg'a_sg))
             @test Diagonal(a_sg'a_sg) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
+            gd = eigen(Matrix(Hermitian(a_sg'a_sg)), Diagonal(a_sg'a_sg))
+            @test Hermitian(a_sg'a_sg) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
             gd = eigen(Diagonal(a_sg'a_sg), Matrix(Diagonal(a_sg'a_sg)))
             @test Diagonal(a_sg'a_sg) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
         end
@@ -121,6 +123,8 @@ aimg  = randn(n,n)/2
             @test prod(f.values) ≈ prod(eigvals(a1_nsg/a2_nsg, sortby = sortfunc)) atol=50000ε
             @test eigvecs(a1_nsg, a2_nsg; sortby = sortfunc) == f.vectors
             @test_throws ErrorException f.Z
+            g = eigen(a1_nsg, Diagonal(a2_nsg); sortby = sortfunc)
+            @test a1_nsg*g.vectors ≈ (Diagonal(a2_nsg)*g.vectors) * Diagonal(g.values)
 
             d,v = eigen(a1_nsg, a2_nsg; sortby = sortfunc)
             @test d == f.values

--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -99,7 +99,7 @@ aimg  = randn(n,n)/2
             gh = eigen(Hermitian(asym_sg), Diagonal(a_sg'a_sg))
             @test Hermitian(asym_sg)*gh.vectors ≈ (Diagonal(a_sg'a_sg)*gh.vectors) * Diagonal(gh.values)
             gd = eigen(Diagonal(a_sg'a_sg), Diagonal(a_sg'a_sg))
-            @test all(isone, gd.values)
+            @test all(≈(1), gd.values)
             @test Diagonal(a_sg'a_sg) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
             gd = eigen(Matrix(Diagonal(a_sg'a_sg)), Diagonal(a_sg'a_sg))
             @test Diagonal(a_sg'a_sg) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)

--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -45,6 +45,16 @@ aimg  = randn(n,n)/2
             @test eigvecs(f) === f.vectors
             @test Array(f) ≈ a
 
+            for T in (Tridiagonal(a), Hermitian(Tridiagonal(a)))
+                f = eigen(T)
+                d, v = f
+                for i in 1:size(a,2)
+                    @test T*v[:,i] ≈ d[i]*v[:,i]
+                end
+                @test det(T) ≈ det(f)
+                @test inv(T) ≈ inv(f)
+            end
+
             num_fact = eigen(one(eltya))
             @test num_fact.values[1] == one(eltya)
             h = asym
@@ -107,6 +117,10 @@ aimg  = randn(n,n)/2
             @test Hermitian(a_sg'a_sg) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
             gd = eigen(Diagonal(a_sg'a_sg), Matrix(Diagonal(a_sg'a_sg)))
             @test Diagonal(a_sg'a_sg) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
+            gd = eigen(Hermitian(Tridiagonal(a_sg'a_sg)), Diagonal(a_sg'a_sg))
+            @test Hermitian(Tridiagonal(a_sg'a_sg)) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
+            gd = eigen(Tridiagonal(a_sg'a_sg), Matrix(Diagonal(a_sg'a_sg)))
+            @test Tridiagonal(a_sg'a_sg) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
         end
         @testset "Non-symmetric generalized eigenproblem" begin
             if isa(a, Array)

--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -71,16 +71,17 @@ aimg  = randn(n,n)/2
                 asym_sg = view(asym, 1:n1, 1:n1)
                 a_sg = view(a, 1:n, n1+1:n2)
             end
-            f = eigen(asym_sg, a_sg'a_sg)
-            @test asym_sg*f.vectors ≈ (a_sg'a_sg*f.vectors) * Diagonal(f.values)
-            @test f.values ≈ eigvals(asym_sg, a_sg'a_sg)
-            @test prod(f.values) ≈ prod(eigvals(asym_sg/(a_sg'a_sg))) atol=200ε
-            @test eigvecs(asym_sg, a_sg'a_sg) == f.vectors
+            ASG2 = a_sg'a_sg
+            f = eigen(asym_sg, ASG2)
+            @test asym_sg*f.vectors ≈ (ASG2*f.vectors) * Diagonal(f.values)
+            @test f.values ≈ eigvals(asym_sg, ASG2)
+            @test prod(f.values) ≈ prod(eigvals(asym_sg/(ASG2))) atol=200ε
+            @test eigvecs(asym_sg, ASG2) == f.vectors
             @test eigvals(f) === f.values
             @test eigvecs(f) === f.vectors
             @test_throws ErrorException f.Z
 
-            d,v = eigen(asym_sg, a_sg'a_sg)
+            d,v = eigen(asym_sg, ASG2)
             @test d == f.values
             @test v == f.vectors
 
@@ -89,40 +90,41 @@ aimg  = randn(n,n)/2
                 for atyp in (eltya <: Real ? (Symmetric, Hermitian) : (Hermitian,))
                     for utyp in (UpperTriangular, Diagonal), uplo in (:L, :U)
                         A = atyp(asym_sg, uplo)
-                        U = utyp(a_sg'a_sg)
+                        U = utyp(ASG2)
                         @test UtiAUi!(copy(A), U) ≈ U' \ A / U
                     end
                 end
             end
 
             # matrices of different types (#14896)
+            D = Diagonal(ASG2)
             for uplo in (:L, :U)
                 if eltya <: Real
-                    fs = eigen(Symmetric(asym_sg, uplo), a_sg'a_sg)
+                    fs = eigen(Symmetric(asym_sg, uplo), ASG2)
                     @test fs.values ≈ f.values
                     @test abs.(fs.vectors) ≈ abs.(f.vectors)  # may change sign
-                    gs = eigen(Symmetric(asym_sg, uplo), Diagonal(a_sg'a_sg))
-                    @test Symmetric(asym_sg, uplo)*gs.vectors ≈ (Diagonal(a_sg'a_sg)*gs.vectors) * Diagonal(gs.values)
+                    gs = eigen(Symmetric(asym_sg, uplo), D)
+                    @test Symmetric(asym_sg, uplo)*gs.vectors ≈ (D*gs.vectors) * Diagonal(gs.values)
                 end
-                fh = eigen(Hermitian(asym_sg, uplo), a_sg'a_sg)
+                fh = eigen(Hermitian(asym_sg, uplo), ASG2)
                 @test fh.values ≈ f.values
                 @test abs.(fh.vectors) ≈ abs.(f.vectors)  # may change sign
-                gh = eigen(Hermitian(asym_sg, uplo), Diagonal(a_sg'a_sg))
-                @test Hermitian(asym_sg, uplo)*gh.vectors ≈ (Diagonal(a_sg'a_sg)*gh.vectors) * Diagonal(gh.values)
-                gd = eigen(Matrix(Hermitian(a_sg'a_sg, uplo)), Diagonal(a_sg'a_sg))
-                @test Hermitian(a_sg'a_sg, uplo) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
-                gd = eigen(Hermitian(Tridiagonal(a_sg'a_sg), uplo), Diagonal(a_sg'a_sg))
-                @test Hermitian(Tridiagonal(a_sg'a_sg), uplo) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
+                gh = eigen(Hermitian(asym_sg, uplo), D)
+                @test Hermitian(asym_sg, uplo)*gh.vectors ≈ (D*gh.vectors) * Diagonal(gh.values)
+                gd = eigen(Matrix(Hermitian(ASG2, uplo)), D)
+                @test Hermitian(ASG2, uplo) * gd.vectors ≈ D * gd.vectors * Diagonal(gd.values)
+                gd = eigen(Hermitian(Tridiagonal(ASG2), uplo), D)
+                @test Hermitian(Tridiagonal(ASG2), uplo) * gd.vectors ≈ D * gd.vectors * Diagonal(gd.values)
             end
-            gd = eigen(Diagonal(a_sg'a_sg), Diagonal(a_sg'a_sg))
+            gd = eigen(D, D)
             @test all(≈(1), gd.values)
-            @test Diagonal(a_sg'a_sg) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
-            gd = eigen(Matrix(Diagonal(a_sg'a_sg)), Diagonal(a_sg'a_sg))
-            @test Diagonal(a_sg'a_sg) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
-            gd = eigen(Diagonal(a_sg'a_sg), Matrix(Diagonal(a_sg'a_sg)))
-            @test Diagonal(a_sg'a_sg) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
-            gd = eigen(Tridiagonal(a_sg'a_sg), Matrix(Diagonal(a_sg'a_sg)))
-            @test Tridiagonal(a_sg'a_sg) * gd.vectors ≈ Diagonal(a_sg'a_sg) * gd.vectors * Diagonal(gd.values)
+            @test D * gd.vectors ≈ D * gd.vectors * Diagonal(gd.values)
+            gd = eigen(Matrix(D), D)
+            @test D * gd.vectors ≈ D * gd.vectors * Diagonal(gd.values)
+            gd = eigen(D, Matrix(D))
+            @test D * gd.vectors ≈ D * gd.vectors * Diagonal(gd.values)
+            gd = eigen(Tridiagonal(ASG2), Matrix(D))
+            @test Tridiagonal(ASG2) * gd.vectors ≈ D * gd.vectors * Diagonal(gd.values)
         end
         @testset "Non-symmetric generalized eigenproblem" begin
             if isa(a, Array)
@@ -139,8 +141,9 @@ aimg  = randn(n,n)/2
             @test prod(f.values) ≈ prod(eigvals(a1_nsg/a2_nsg, sortby = sortfunc)) atol=50000ε
             @test eigvecs(a1_nsg, a2_nsg; sortby = sortfunc) == f.vectors
             @test_throws ErrorException f.Z
-            g = eigen(a1_nsg, Diagonal(a2_nsg); sortby = sortfunc)
-            @test a1_nsg*g.vectors ≈ (Diagonal(a2_nsg)*g.vectors) * Diagonal(g.values)
+
+            g = eigen(a1_nsg, Diagonal(1:n1))
+            @test a1_nsg*g.vectors ≈ (Diagonal(1:n1)*g.vectors) * Diagonal(g.values)
 
             d,v = eigen(a1_nsg, a2_nsg; sortby = sortfunc)
             @test d == f.values


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#953, and cleans up `symmetriceigen.jl` code a bit (without functional changes).