### PR TITLE
Disable MSYS2's path munging for `stringreplace`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,8 +229,10 @@ endif
 endif
 endif
 
+# Note that we disable MSYS2's path munging here, as otherwise
+# it replaces our `:`-separated list as a `;`-separated one.
 define stringreplace
-	$(build_depsbindir)/stringreplace $$(strings -t x - $1 | grep $2 | awk '{print $$1;}') $3 255 "$(call cygpath_w,$1)"
+	MSYS2_ARG_CONV_EXCL='*' $(build_depsbindir)/stringreplace $$(strings -t x - $1 | grep $2 | awk '{print $$1;}') $3 255 "$(call cygpath_w,$1)"
 endef
 
 


### PR DESCRIPTION
This was causing our rewriting of the loader's RPATH emulation to fail after running `make install`, as MSYS2 was rewriting our list that looks like:

```
../bin/libgcc_s_seh-1.dll:../bin/libopenlibm.dll:@../bin/libjulia-internal.dll:@../bin/libjulia-codegen.dll:
```

Into one that looked like:
```
..\bin\libgcc_s_seh-1.dll;..\bin\libopenlibm.dll;@..\bin\libjulia-internal.dll;@..\bin\libjulia-codegen.dll;
```

By exporting `MSYS2_ARG_CONV_EXCL='*'` for all `stringreplace` invocations, we dodge this issue, as documented by MSYS2 [0].

[0] https://www.msys2.org/wiki/Porting/#filesystem-namespaces