### PR TITLE
gc: add missing root for binding->ty field

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -2472,6 +2472,16 @@ module_binding: {
             void *vb = jl_astaggedvalue(b);
             verify_parent1("module", binding->parent, &vb, "binding_buff");
             (void)vb;
+            jl_value_t *ty = jl_atomic_load_relaxed(&b->ty);
+            if (ty && ty != (jl_value_t*)jl_any_type) {
+                verify_parent2("module", binding->parent,
+                               &b->typ, "binding(%s)", jl_symbol_name(b->name));
+                if (gc_try_setmark(ty, &binding->nptr, &tag, &bits)) {
+                    new_obj = ty;
+                    gc_repush_markdata(&sp, gc_mark_binding_t);
+                    goto mark;
+                }
+            }
             jl_value_t *value = jl_atomic_load_relaxed(&b->value);
             jl_value_t *globalref = jl_atomic_load_relaxed(&b->globalref);
             if (value) {


### PR DESCRIPTION
Previously, we might observe this code segfault if the memory at `binding->ty` eventually was reused due to this missing GC root.
```
julia> x::Union{Int,Nothing} = 2
2

julia> GC.gc()

julia> Core.get_binding_type(Main, :x)
Union{Nothing, Int64}
```