### PR TITLE
inference: make `Core.Compiler.return_type` respect `max_methods` setting

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -3441,10 +3441,15 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
         return Future(CallMeta(Const(Union{}), Union{}, RT_CALL_EFFECTS, NoCallInfo()))
     end
 
-    # Run the abstract_call without restricting abstract call
-    # sites. Otherwise, our behavior model of abstract_call
-    # below will be wrong.
+    # NOTE We need to sync the implementation here with that of `Core.Compiler.return_type`.
+    # In particular, this tfunc should not use the module-wide `max_methods` setting
+    # until we refactor the `Core.Compiler.return_type` API so that it can observe
+    # the caller module context.
+    f = singleton_type(argtypes_vec[1])
+    max_methods = get_max_methods(interp, f)
     if isa(sv, InferenceState)
+        # Run the abstract_call without restricting abstract call sites.
+        # Otherwise, our behavior model of abstract_call below will be wrong.
         old_restrict = sv.restrict_abstract_call_sites
         sv.restrict_abstract_call_sites = false
     end
@@ -3452,7 +3457,7 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
     # in return_type inference. Currently passing `nothing` which means any
     # slot-dependent refinements will be widened. This is conservative but
     # may miss some precision opportunities.
-    call = abstract_call(interp, ArgInfo(nothing, argtypes_vec), si, nothing, sv, #=max_methods=#-1)
+    call = abstract_call(interp, ArgInfo(nothing, argtypes_vec), si, nothing, sv, max_methods)
     tt = Core.Box(tt)
     return Future{CallMeta}(call, interp, sv) do call, _, sv
         if isa(sv, InferenceState)

--- a/Compiler/src/typeinfer.jl
+++ b/Compiler/src/typeinfer.jl
@@ -1901,6 +1901,9 @@ function _return_type_opaque_closure(@nospecialize(oc::Core.OpaqueClosure), t::D
     return ocrt
 end
 
+# TODO change the interface of `return_type` to allow it to recognize caller module context
+# so that we can see its `get_max_methods` setting as the ordinary inference
+
 function return_type(@nospecialize(f), t::DataType) # this method has a special tfunc
     isa(f, Core.OpaqueClosure) && return _return_type_opaque_closure(f, t)
     world = tls_world_age()
@@ -1932,7 +1935,10 @@ function _return_type(interp::AbstractInterpreter, t::DataType)
         rt = builtin_tfunction(interp, f, args, nothing)
         rt = widenconst(rt)
     else
-        for match in _methods_by_ftype(t, -1, get_inference_world(interp))::Vector
+        lim = get_max_methods(interp, f)
+        ms = _methods_by_ftype(t, lim, get_inference_world(interp))
+        ms isa Vector || return Any
+        for match in ms
             ty = typeinf_type(interp, match::MethodMatch)
             ty === nothing && return Any
             rt = tmerge(rt, ty)

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -3683,15 +3683,27 @@ j30385(T, y) = k30385(f30385(T, y))
 @test Base.return_types(Tuple, (NamedTuple{<:Any,Tuple{Any,Int}},)) == Any[Tuple{Any,Int}]
 @test Base.return_types(Base.splat(tuple), (typeof((a=1,)),)) == Any[Tuple{Int}]
 
-# test that return_type_tfunc isn't affected by max_methods differently than return_type
-_rttf_test(::Int8) = 0
-_rttf_test(::Int16) = 0
-_rttf_test(::Int32) = 0
-_rttf_test(::Int64) = 0
-_rttf_test(::Int128) = 0
-_call_rttf_test() = Base._return_type(_rttf_test, Tuple{Any})
-@test Base._return_type(_rttf_test, Tuple{Any}) === Int
-@test _call_rttf_test() === Int
+# test that return_type_tfunc uses the same `max_methods` configuration as
+# the dynamic implementation
+Base.Experimental.@max_methods 1 function _rttf_test1 end
+_rttf_test1(::Int8) = 0
+_rttf_test1(::Int16) = 0
+_rttf_test1(::Int32) = 0
+@test Base._return_type(_rttf_test1, Tuple{Any}) === Any
+@test Base.return_types() do
+    Compiler.return_type(_rttf_test1, Tuple{Any})
+end |> only === Core.TypeEgal{Any}
+
+Base.Experimental.@max_methods 5 function _rttf_test5 end
+_rttf_test5(::Int8) = 0
+_rttf_test5(::Int16) = 0
+_rttf_test5(::Int32) = 0
+_rttf_test5(::Int64) = 0
+_rttf_test5(::Int128) = 0
+@test Base._return_type(_rttf_test5, Tuple{Any}) === Int
+@test Base.return_types() do
+    Compiler.return_type(_rttf_test5, Tuple{Any})
+end |> only === Core.TypeEgal{Int}
 
 f_with_Type_arg(::Type{T}) where {T} = T
 @test Base.return_types(f_with_Type_arg, (Any,)) == Any[Type]


### PR DESCRIPTION
Previously we didn't limit the number of matching methods for
`Core.Compiler.return_type`, which could lead to a potential latency
problem.
This commit makes `Core.Compiler.return_type` and the corresponding
tfunc `return_type_tfunc` respect `max_methods` setting as like the
ordinary inference.
One caveat here is that the current `Core.Compiler.return_type` interface
unfortunately doesn't allow it to see the caller module context, so it
can't respect module-wide `max_methods` setting (I guess the change to
the interface should be made as of version 2.0), that I think can lead
to a potential confusion.