### PR TITLE
REPL docs: Document existing ^U keybind

### DIFF
--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -259,6 +259,7 @@ to do so), or pressing Esc and then the key.
 | `^W`                | Delete previous text up to the nearest whitespace                                                          |
 | `meta-w`            | Copy the current region in the kill ring                                                                   |
 | `meta-W`            | "Kill" the current region, placing the text in the kill ring                                               |
+| `^U`                | "Kill" to beginning of line, placing the text in the kill ring                                             |
 | `^K`                | "Kill" to end of line, placing the text in the kill ring                                                   |
 | `^Y`                | "Yank" insert the text from the kill ring                                                                  |
 | `meta-y`            | Replace a previously yanked text with an older entry from the kill ring                                    |


### PR DESCRIPTION
[This keybinding](https://github.com/JuliaLang/julia/blob/61b5a0844249254a37fa62fe219450713e579613/stdlib/REPL/src/LineEdit.jl#L2404) currently exists in Julia and is functional, but it wasn't mentioned in the manual.