### PR TITLE
Detailed description on floatmin and floatmax

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -846,7 +846,7 @@ end
 
 Return the smallest positive non-subnormal number representable by the floating-point type T.
 
-This is not the opposite of `floatmax`! See the Extended help section for more info.
+This is not the negation of `floatmax`. See the Extended help section for more info.
 
 # Examples
 ```jldoctest

--- a/base/float.jl
+++ b/base/float.jl
@@ -845,8 +845,9 @@ end
     floatmin(T = Float64)
 
 Return the smallest positive non-subnormal number representable by the floating-point type T.
-
 This is not the negation of `floatmax`. See the Extended help section for more info.
+
+See also: [`typemin`](@ref), [`floatmax`](@ref), [`eps`](@ref).
 
 # Examples
 ```jldoctest
@@ -872,8 +873,6 @@ and [`typemin`](@ref)`(T)`, for a floating-point type `T`, would return.
 
 The smallest finite number representable by a floating-point type `T`
 is gotten by negating `floatmax` i.e. `-`[`floatmax`](@ref)`(T)`.
-
-See also: [`eps`](@ref), [`prevfloat`](@ref), [`nextfloat`](@ref).
 """
 floatmin(x::T) where {T<:AbstractFloat} = floatmin(T)
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -846,15 +846,7 @@ end
 
 Return the smallest positive floating-point number which is not sub-nomal.
 
-The smallest positive number without this restriction is [`nextfloat`](@ref)`(zero(T))`;
-see [`issubnormal`](@ref) for an explanation of sub-normal numbers.
-The most negative finite number is `-`[`floatmax`](@ref)`(T)`.
-
-Floating point numbers always include infinity [`Inf`](@ref)` and negative real infinity `-Inf`, 
-which is what [`typemax`](@ref) and [`typemin`](@ref) return.
-representable by the floating-point type `T`.
-
-See also: [`eps`](@ref), [`prevfloat`](@ref), [`nextfloat`](@ref).
+This is not the opposite of `floatmax`! See the Extended help section for more info.
 
 # Examples
 ```jldoctest
@@ -867,6 +859,21 @@ julia> floatmin(Float32)
 julia> floatmin()
 2.2250738585072014e-308
 ```
+
+# Extended help
+
+The smallest positive number without this restriction is
+[`nextfloat`](@ref)`(zero(T))`; see [`issubnormal`](@ref) for an explanation
+of sub-normal numbers.
+
+Floating point numbers always include infinity e.g [`Inf`](@ref) and
+negative real infinity e.g. `-Inf`, which is what [`typemax`](@ref)`(T)`
+and [`typemin`](@ref)`(T)`, for a floating-point type `T`, would return.
+
+The smallest finite number representable by a floating-point type `T`
+is gotten by negating `floatmax` i.e. `-`[`floatmax`](@ref)`(T)`.
+
+See also: [`eps`](@ref), [`prevfloat`](@ref), [`nextfloat`](@ref).
 """
 floatmin(x::T) where {T<:AbstractFloat} = floatmin(T)
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -844,8 +844,7 @@ end
 """
     floatmin(T = Float64)
 
-Return the smallest positive floating-point number (which is not sub-normal)
-representable by the floating-point type T.
+Return the smallest positive non-subnormal number representable by the floating-point type T.
 
 This is not the opposite of `floatmax`! See the Extended help section for more info.
 
@@ -867,8 +866,8 @@ The smallest positive number without this restriction is
 [`nextfloat`](@ref)`(zero(T))`; see [`issubnormal`](@ref) for an explanation
 of sub-normal numbers.
 
-Floating point numbers always include infinity, [`Inf`](@ref) and
-negative real infinity `-Inf`, which is what [`typemax`](@ref)`(T)`
+Floating point numbers always include infinity, [`Inf`](@ref), and
+negative real infinity, `-Inf`, which is what [`typemax`](@ref)`(T)`
 and [`typemin`](@ref)`(T)`, for a floating-point type `T`, would return.
 
 The smallest finite number representable by a floating-point type `T`

--- a/base/float.jl
+++ b/base/float.jl
@@ -844,7 +844,7 @@ end
 """
     floatmin(T = Float64)
 
-Return the smallest positive floating-point number which is not sub-normal
+Return the smallest positive floating-point number (which is not sub-normal)
 representable by the floating-point type T.
 
 This is not the opposite of `floatmax`! See the Extended help section for more info.

--- a/base/float.jl
+++ b/base/float.jl
@@ -844,7 +844,14 @@ end
 """
     floatmin(T = Float64)
 
-Not the inverse of `floatmax`! Return the smallest positive normal number
+Return the smallest positive floating-point number which is not sub-nomal.
+
+The smallest positive number without this restriction is [`nextfloat`](@ref)`(zero(T))`;
+see [`issubnormal`](@ref) for an explanation of sub-normal numbers.
+The most negative finite number is `-`[`floatmax`](@ref)`(T)`.
+
+Floating point numbers always include infinity [`Inf`](@ref)` and negative real infinity `-Inf`, 
+which is what [`typemax`](@ref) and [`typemin`](@ref) return.
 representable by the floating-point type `T`.
 
 See also: [`eps`](@ref), [`prevfloat`](@ref), [`nextfloat`](@ref).

--- a/base/float.jl
+++ b/base/float.jl
@@ -844,8 +844,8 @@ end
 """
     floatmin(T = Float64)
 
-Return the smallest positive normal number representable by the floating-point
-type `T`.
+Not the inverse of `floatmax`! Return the smallest positive normal number
+representable by the floating-point type `T`.
 
 # Examples
 ```jldoctest

--- a/base/float.jl
+++ b/base/float.jl
@@ -847,6 +847,8 @@ end
 Not the inverse of `floatmax`! Return the smallest positive normal number
 representable by the floating-point type `T`.
 
+See also: [`eps`](@ref), [`prevfloat`](@ref), [`nextfloat`](@ref).
+
 # Examples
 ```jldoctest
 julia> floatmin(Float16)

--- a/base/float.jl
+++ b/base/float.jl
@@ -862,8 +862,7 @@ julia> floatmin()
 ```
 
 # Extended help
-
-The smallest positive number without this restriction is
+The smallest positive number without the "non-subnormal" restriction is
 [`nextfloat`](@ref)`(zero(T))`; see [`issubnormal`](@ref) for an explanation
 of sub-normal numbers.
 
@@ -871,7 +870,7 @@ Floating point numbers always include infinity, [`Inf`](@ref), and
 negative real infinity, `-Inf`, which is what [`typemax`](@ref)`(T)`
 and [`typemin`](@ref)`(T)`, for a floating-point type `T`, would return.
 
-The smallest finite number representable by a floating-point type `T`
+The lowest finite number representable by a floating-point type `T`
 is gotten by negating `floatmax` i.e. `-`[`floatmax`](@ref)`(T)`.
 """
 floatmin(x::T) where {T<:AbstractFloat} = floatmin(T)
@@ -879,7 +878,7 @@ floatmin(x::T) where {T<:AbstractFloat} = floatmin(T)
 """
     floatmax(T = Float64)
 
-Return the largest finite number representable by the floating-point type `T`.
+Return the highest finite number representable by the floating-point type `T`.
 
 See also: [`typemax`](@ref), [`floatmin`](@ref), [`eps`](@ref).
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -845,6 +845,7 @@ end
     floatmin(T = Float64)
 
 Return the smallest positive non-subnormal number representable by the floating-point type T.
+
 This is not the negation of `floatmax`. See the Extended help section for more info.
 
 See also: [`typemin`](@ref), [`floatmax`](@ref), [`eps`](@ref).

--- a/base/float.jl
+++ b/base/float.jl
@@ -844,7 +844,8 @@ end
 """
     floatmin(T = Float64)
 
-Return the smallest positive floating-point number which is not sub-nomal.
+Return the smallest positive floating-point number which is not sub-normal
+representable by the floating-point type T.
 
 This is not the opposite of `floatmax`! See the Extended help section for more info.
 
@@ -866,8 +867,8 @@ The smallest positive number without this restriction is
 [`nextfloat`](@ref)`(zero(T))`; see [`issubnormal`](@ref) for an explanation
 of sub-normal numbers.
 
-Floating point numbers always include infinity e.g [`Inf`](@ref) and
-negative real infinity e.g. `-Inf`, which is what [`typemax`](@ref)`(T)`
+Floating point numbers always include infinity, [`Inf`](@ref) and
+negative real infinity `-Inf`, which is what [`typemax`](@ref)`(T)`
 and [`typemin`](@ref)`(T)`, for a floating-point type `T`, would return.
 
 The smallest finite number representable by a floating-point type `T`


### PR DESCRIPTION
It's intuitive to think that `typemin` will do the opposite of what `typemax` does - which it does:
```julia
help> typemin
  typemin(T)

  The lowest value representable by the given (real) numeric DataType T.

help?> typemax
  typemax(T)

  The highest value representable by the given (real) numeric DataType.
```

It's intuitive to think that `Base.isless` will do the opposite of what `Base.isgreater` does - which it does not (and the docs spelled it out):
```julia
help> isless
  isless(x, y)

  Test whether x is less than y, according to a fixed total order (defined
  together with isequal).

help> Base.isgreater
  isgreater(x, y)

  Not the inverse of isless! Test whether x is greater than y, according to
  a fixed total order compatible with min.
```

It intuitive to think that `floatmin` will do the opposite of what `floatmax` does - which it does not (and the docs didn't spelled it out):
```julia
help?> floatmin
  floatmin(T = Float64)

  Return the smallest positive normal number representable by the
  floating-point type T.

help?> floatmax
  floatmax(T = Float64)

  Return the largest finite number representable by the floating-point type
  T.
```

Both `floatmin` and `floatmax` return **positive values**, which isn't intuitive for anyone first using the function. So its best to spell this out, as have been done for other cases like `Base.isless` and `Base.isgreater`.

Moreover, since `floatmin` doesn't return the "**smallest** finite number representable by the floating-point type", a link in the `see also` section should be provided for users pointing to `prevfloat`, `nextfloat`, because:
```julia
julia> prevfloat(Inf)
1.7976931348623157e308

julia> nextfloat(-Inf)
-1.7976931348623157e308
```
helps return the largest and smallest finite number representable, which users can easily call other than the one provided for only largest finite numbers in `floatmax`.