### PR TITLE
clear info on the exponent function

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -930,9 +930,10 @@ end
 ldexp(x::Float16, q::Integer) = Float16(ldexp(Float32(x), q))
 
 """
-    exponent(x::AbstractFloat) -> Int
+    exponent(x) -> Int
 
 Get the exponent of a normalized floating-point number.
+
 Returns the largest integer `y` such that `2^y ≤ abs(x)`.
 
 # Examples

--- a/base/math.jl
+++ b/base/math.jl
@@ -932,9 +932,8 @@ ldexp(x::Float16, q::Integer) = Float16(ldexp(Float32(x), q))
 """
     exponent(x) -> Int
 
-Get the exponent of a normalized floating-point number.
-
 Returns the largest integer `y` such that `2^y ≤ abs(x)`.
+For a normalized floating-point number `x` this corresponds to the exponent of `x`.
 
 # Examples
 ```jldoctest

--- a/base/math.jl
+++ b/base/math.jl
@@ -938,11 +938,20 @@ Returns the largest integer `y` such that `2^y ≤ abs(x)`.
 
 # Examples
 ```jldoctest
+julia> exponent(8)
+3
+
+julia> exponent(64//1)
+6
+
 julia> exponent(6.5)
 2
 
 julia> exponent(16.0)
 4
+
+julia> exponent(3.142e-4)
+-12
 ```
 """
 function exponent(x::T) where T<:IEEEFloat

--- a/base/math.jl
+++ b/base/math.jl
@@ -933,7 +933,7 @@ ldexp(x::Float16, q::Integer) = Float16(ldexp(Float32(x), q))
     exponent(x) -> Int
 
 Returns the largest integer `y` such that `2^y ≤ abs(x)`.
-For a normalized floating-point number `x` this corresponds to the exponent of `x`.
+For a normalized floating-point number `x`, this corresponds to the exponent of `x`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
```julia
julia> methods(exponent)
# 4 methods for generic function "exponent":
[1] exponent(x::T) where T<:Union{Float16, Float32, Float64} in Base.Math at math.jl:843
[2] exponent(::Missing) in Base.Math at math.jl:1374
[3] exponent(x::BigFloat) in Base.MPFR at mpfr.jl:858
[4] exponent(x::Real) in Base.Math at math.jl:1369
```

This is the part on `math.jl` where I believe the `exponent(x::Real)` comes from:
```julia
for f in (:sin, :cos, :tan, :asin, :atan, :acos,
          :sinh, :cosh, :tanh, :asinh, :acosh, :atanh,
          :exp, :exp2, :exp10, :expm1, :log, :log2, :log10, :log1p,
          :exponent, :sqrt, :cbrt)
    @eval function ($f)(x::Real)
        xf = float(x)
        x === xf && throw(MethodError($f, (x,)))
        return ($f)(xf)
    end
    @eval $(f)(::Missing) = missing
end
```

But then there is no function docs for it, making the `exponent` function show this on `help`:
```julia
help?> exponent
search: exponent ExponentialBackOff

  exponent(x::AbstractFloat) -> Int

  Get the exponent of a normalized floating-point number. Returns the largest
  integer y such that 2^y ≤ abs(x).
```

If `x` should ONLY be `AbstractFloat`, then the others like `Integer` and `Rational` should fail, which doesn't:
```julia
julia> exponent(8)
3

julia> exponent(64//1)
6
```

Moreover the current doc tries to sell it like the function is for only floating points with the definition of:
```julia
Get the exponent of a normalized floating-point number.
```

So maybe its best to have a space between that and the other part, so its like:
```julia
Get the exponent of a normalized floating-point number.

Returns the largest integer y such that 2^y ≤ abs(x).
```

So its clear that when its not an `AbstractFloat`, its just goes to return `2^y ≤ abs(x)`. This won't keep anyone preoccupied with the "normalized floating-point number"` words.