### PR TITLE
Track JITLink-allocated bytes

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -741,11 +741,13 @@ public:
 };
 
 class JLMemoryUsagePlugin : public ObjectLinkingLayer::Plugin {
-    private:
+private:
     std::atomic<size_t> &total_size;
-    public:
 
-    JLMemoryUsagePlugin(std::atomic<size_t> &total_size) : total_size(total_size) {}
+public:
+
+    JLMemoryUsagePlugin(std::atomic<size_t> &total_size)
+        : total_size(total_size) {}
 
     Error notifyFailed(orc::MaterializationResponsibility &MR) override {
         return Error::success();
@@ -754,11 +756,11 @@ class JLMemoryUsagePlugin : public ObjectLinkingLayer::Plugin {
         return Error::success();
     }
     void notifyTransferringResources(orc::ResourceKey DstKey,
-                                    orc::ResourceKey SrcKey) override {}
+                                     orc::ResourceKey SrcKey) override {}
 
     void modifyPassConfig(orc::MaterializationResponsibility &,
-                            jitlink::LinkGraph &,
-                            jitlink::PassConfiguration &Config) override {
+                          jitlink::LinkGraph &,
+                          jitlink::PassConfiguration &Config) override {
         Config.PostAllocationPasses.push_back([this](jitlink::LinkGraph &G) {
             size_t graph_size = 0;
             for (auto block : G.blocks()) {
@@ -770,6 +772,8 @@ class JLMemoryUsagePlugin : public ObjectLinkingLayer::Plugin {
     }
 };
 
+// TODO: Port our memory management optimisations to JITLink instead of using the
+// default InProcessMemoryManager.
 std::unique_ptr<jitlink::JITLinkMemoryManager> createJITLinkMemoryManager() {
 #if JL_LLVM_VERSION < 140000
     return std::make_unique<jitlink::InProcessMemoryManager>();
@@ -1191,8 +1195,6 @@ JuliaOJIT::JuliaOJIT()
         return orc::ThreadSafeContext(std::move(ctx));
     }),
 #ifdef JL_USE_JITLINK
-    // TODO: Port our memory management optimisations to JITLink instead of using the
-    // default InProcessMemoryManager.
     MemMgr(createJITLinkMemoryManager()),
     ObjectLayer(ES, *MemMgr),
 #else

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -47,6 +47,9 @@ using namespace llvm;
 # endif
 # include <llvm/ExecutionEngine/JITLink/EHFrameSupport.h>
 # include <llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h>
+# if JL_LLVM_VERSION >= 150000
+# include <llvm/ExecutionEngine/Orc/MapperJITLinkMemoryManager.h>
+# endif
 #else
 # include <llvm/ExecutionEngine/SectionMemoryManager.h>
 #endif
@@ -736,6 +739,46 @@ public:
         });
     }
 };
+
+class JLMemoryUsagePlugin : public ObjectLinkingLayer::Plugin {
+    private:
+    std::atomic<size_t> &total_size;
+    public:
+
+    JLMemoryUsagePlugin(std::atomic<size_t> &total_size) : total_size(total_size) {}
+
+    Error notifyFailed(orc::MaterializationResponsibility &MR) override {
+        return Error::success();
+    }
+    Error notifyRemovingResources(orc::ResourceKey K) override {
+        return Error::success();
+    }
+    void notifyTransferringResources(orc::ResourceKey DstKey,
+                                    orc::ResourceKey SrcKey) override {}
+
+    void modifyPassConfig(orc::MaterializationResponsibility &,
+                            jitlink::LinkGraph &,
+                            jitlink::PassConfiguration &Config) override {
+        Config.PostAllocationPasses.push_back([this](jitlink::LinkGraph &G) {
+            size_t graph_size = 0;
+            for (auto block : G.blocks()) {
+                graph_size += block->getSize();
+            }
+            this->total_size.fetch_add(graph_size, std::memory_order_relaxed);
+            return Error::success();
+        });
+    }
+};
+
+std::unique_ptr<jitlink::JITLinkMemoryManager> createJITLinkMemoryManager() {
+#if JL_LLVM_VERSION < 140000
+    return std::make_unique<jitlink::InProcessMemoryManager>();
+#elif JL_LLVM_VERSION < 150000
+    return cantFail(jitlink::InProcessMemoryManager::Create());
+#else
+    return cantFail(orc::MapperJITLinkMemoryManager::CreateWithMapper<orc::InProcessMemoryMapper>());
+#endif
+}
 }
 
 # ifdef LLVM_SHLIB
@@ -1150,11 +1193,8 @@ JuliaOJIT::JuliaOJIT()
 #ifdef JL_USE_JITLINK
     // TODO: Port our memory management optimisations to JITLink instead of using the
     // default InProcessMemoryManager.
-# if JL_LLVM_VERSION < 140000
-    ObjectLayer(ES, std::make_unique<jitlink::InProcessMemoryManager>()),
-# else
-    ObjectLayer(ES, cantFail(jitlink::InProcessMemoryManager::Create())),
-# endif
+    MemMgr(createJITLinkMemoryManager()),
+    ObjectLayer(ES, *MemMgr),
 #else
     MemMgr(createRTDyldMemoryManager()),
     ObjectLayer(
@@ -1185,6 +1225,7 @@ JuliaOJIT::JuliaOJIT()
         ES, std::move(ehRegistrar)));
 
     ObjectLayer.addPlugin(std::make_unique<JLDebuginfoPlugin>());
+    ObjectLayer.addPlugin(std::make_unique<JLMemoryUsagePlugin>(total_size));
 #else
     ObjectLayer.setNotifyLoaded(
         [this](orc::MaterializationResponsibility &MR,
@@ -1435,8 +1476,7 @@ std::string JuliaOJIT::getMangledName(const GlobalValue *GV)
 #ifdef JL_USE_JITLINK
 size_t JuliaOJIT::getTotalBytes() const
 {
-    // TODO: Implement in future custom JITLink memory manager.
-    return 0;
+    return total_size.load(std::memory_order_relaxed);
 }
 #else
 size_t getRTDyldMemoryManagerTotalBytes(RTDyldMemoryManager *mm);

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -41,7 +41,9 @@
 // and feature support (e.g. Windows, JITEventListeners for various profilers,
 // etc.). Thus, we currently only use JITLink where absolutely required, that is,
 // for Mac/aarch64.
-#if defined(_OS_DARWIN_) && defined(_CPU_AARCH64_)
+// #define JL_FORCE_JITLINK
+
+#if defined(_OS_DARWIN_) && defined(_CPU_AARCH64_) || defined(JL_FORCE_JITLINK)
 # if JL_LLVM_VERSION < 130000
 #  pragma message("On aarch64-darwin, LLVM version >= 13 is required for JITLink; fallback suffers from occasional segfaults")
 # endif
@@ -486,6 +488,9 @@ private:
 
 #ifndef JL_USE_JITLINK
     const std::shared_ptr<RTDyldMemoryManager> MemMgr;
+#else
+    std::atomic<size_t> total_size;
+    const std::unique_ptr<jitlink::JITLinkMemoryManager> MemMgr;
 #endif
     ObjLayerT ObjectLayer;
     const std::array<std::unique_ptr<PipelineT>, 4> Pipelines;


### PR DESCRIPTION
Also use MappedJITLinkMemoryManager on >= LLVM 15 for JITLink.