### PR TITLE
Activate NewPM support

### DIFF
--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -100,9 +100,7 @@ struct OptimizationOptions {
 // for middle-end IR optimizations. However, we have not qualified the new
 // pass manager on our optimization pipeline yet, so this remains an optional
 // define
-#if defined(HAS_SANITIZER) && JL_LLVM_VERSION >= 150000
 #define JL_USE_NEW_PM
-#endif
 
 struct NewPM {
     std::unique_ptr<TargetMachine> TM;

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -361,7 +361,8 @@ static void buildFullPipeline(ModulePassManager &MPM, PassBuilder *PB, Optimizat
     {
         FunctionPassManager FPM;
         FPM.addPass(SROAPass());
-        FPM.addPass(InstSimplifyPass());
+        // SROA can duplicate PHI nodes which can block LowerSIMD
+        FPM.addPass(InstCombinePass());
         FPM.addPass(JumpThreadingPass());
         FPM.addPass(CorrelatedValuePropagationPass());
         FPM.addPass(ReassociatePass());

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -397,11 +397,11 @@ static void buildFullPipeline(ModulePassManager &MPM, PassBuilder *PB, Optimizat
             LPM.addPass(LoopIdiomRecognizePass());
             LPM.addPass(IndVarSimplifyPass());
             LPM.addPass(LoopDeletionPass());
+            LPM.addPass(LoopFullUnrollPass());
             invokeLoopOptimizerEndCallbacks(LPM, PB, O);
             //We don't know if the loop end callbacks support MSSA
             FPM.addPass(createFunctionToLoopPassAdaptor(std::move(LPM), /*UseMemorySSA = */false));
         }
-        FPM.addPass(LoopUnrollPass(LoopUnrollOptions().setRuntime(false)));
         JULIA_PASS(FPM.addPass(AllocOptPass()));
         FPM.addPass(SROAPass());
         FPM.addPass(InstSimplifyPass());


### PR DESCRIPTION
The NewPM changes have gone in under a #define statement due to verification errors; this PR will be used to track how many of those errors still exist.