### PR TITLE
consistency on typemax and typemin docs

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -772,13 +772,24 @@ promote_rule(::Type{UInt128}, ::Type{Int128}) = UInt128
 
 The lowest value representable by the given (real) numeric DataType `T`.
 
+See also: [`floatmin`](@ref), [`typemax`](@ref), [`eps`](@ref).
+
 # Examples
 ```jldoctest
+julia> typemin(Int8)
+-128
+
+julia> typemin(UInt32)
+0x00000000
+
 julia> typemin(Float16)
 -Inf16
 
 julia> typemin(Float32)
 -Inf32
+
+julia> nextfloat(-Inf32)  # smallest finite floating point number
+-3.4028235f38
 ```
 """
 function typemin end
@@ -800,6 +811,9 @@ julia> typemax(UInt32)
 
 julia> typemax(Float64)
 Inf
+
+julia> typemax(Float32)
+Inf32
 
 julia> floatmax(Float32)  # largest finite floating point number
 3.4028235f38

--- a/base/int.jl
+++ b/base/int.jl
@@ -788,7 +788,7 @@ julia> typemin(Float16)
 julia> typemin(Float32)
 -Inf32
 
-julia> nextfloat(-Inf32)  # smallest finite floating point number
+julia> nextfloat(-Inf32)  # smallest finite Float32 floating point number
 -3.4028235f38
 ```
 """
@@ -815,7 +815,7 @@ Inf
 julia> typemax(Float32)
 Inf32
 
-julia> floatmax(Float32)  # largest finite floating point number
+julia> floatmax(Float32)  # largest finite Float32 floating point number
 3.4028235f38
 ```
 """


### PR DESCRIPTION
The `typemax` and `typemin` docs isn't consistent with each other on its examples and `see also` section (see reasons below).

While this isn't an issue when looking up the function with `help>` to work with integers, for floating-point types, its a big deal because:
- On the `typemax` examples, there is a very good example there with a great comment, pointing users to look into `floatmax`, if `typemax` doesn't serves them; but the `typemin` doesn't have this - which isn't great, since both `typemax` and `typemin` have great use.

- The `see also` section on `typemax` point users to other available functions which might prove or introduce other points to consider if `typemax` isn't what they're looking for; for `typemin`, this isn't present.

I provided examples on integers, just so the function isn't thought of like working for only floating points.

Moreover, I feel like the current docs were written assuming users would always lookup `typemin` and `typemax` in `help>`, before using anyone of them. Most time this is true, but I think it's best not to assume.