### PR TITLE
[Docs] Move scalar `setindex!` to optional methods of the AbstractArray interface.

### DIFF
--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -220,10 +220,10 @@ ourselves, we can officially define it as a subtype of an [`AbstractArray`](@ref
 | `size(A)`                                       |                                        | Returns a tuple containing the dimensions of `A`                                      |
 | `getindex(A, i::Int)`                           |                                        | (if `IndexLinear`) Linear scalar indexing                                             |
 | `getindex(A, I::Vararg{Int, N})`                |                                        | (if `IndexCartesian`, where `N = ndims(A)`) N-dimensional scalar indexing             |
-| `setindex!(A, v, i::Int)`                       |                                        | (if `IndexLinear`) Scalar indexed assignment                                          |
-| `setindex!(A, v, I::Vararg{Int, N})`            |                                        | (if `IndexCartesian`, where `N = ndims(A)`) N-dimensional scalar indexed assignment   |
 | **Optional methods**                            | **Default definition**                 | **Brief description**                                                                 |
 | `IndexStyle(::Type)`                            | `IndexCartesian()`                     | Returns either `IndexLinear()` or `IndexCartesian()`. See the description below.      |
+| `setindex!(A, v, i::Int)`                       |                                        | (if `IndexLinear`) Scalar indexed assignment                                          |
+| `setindex!(A, v, I::Vararg{Int, N})`            |                                        | (if `IndexCartesian`, where `N = ndims(A)`) N-dimensional scalar indexed assignment   |
 | `getindex(A, I...)`                             | defined in terms of scalar `getindex`  | [Multidimensional and nonscalar indexing](@ref man-array-indexing)                    |
 | `setindex!(A, X, I...)`                            | defined in terms of scalar `setindex!` | [Multidimensional and nonscalar indexed assignment](@ref man-array-indexing)          |
 | `iterate`                                       | defined in terms of scalar `getindex`  | Iteration                                                                             |


### PR DESCRIPTION
AbstractArrays have never been required to be mutable, and we have many subtypes of `AbstractArray` in `Base` and `LinearAlgebra` that do not implement `setindex!` since they are immutable, or only implement it for a subset of their indices (e.g. `CartesianIndices`, the various range types, `Symmetric`, `Hermitian`, `Diagonal`, ). There is also a lot of hope and plans for more immutable, dynamic array support from Base, and of course a rich set of immutable arrays out there in the package ecosystem which do not have `setindex!`

As far as I can tell, it is simply a false characterization of the AbstractArray interface to say that `setindex!` is *not* an optional method. 

This PR will move the two lines in the red box here to the Optional methods section, between `IndexStyle` and the `getindex` on non-scalar indices. 
![image](https://user-images.githubusercontent.com/29157027/191090250-2f933823-9fa1-4e21-af7c-8429a898a689.png)
