### PR TITLE
Reduce codegen lock scope

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -3416,8 +3416,6 @@ int jl_has_concrete_subtype(jl_value_t *typ)
     return ((jl_datatype_t*)typ)->has_concrete_subtype;
 }
 
-#define typeinf_lock jl_codegen_lock
-
 JL_DLLEXPORT void jl_typeinf_timing_begin(void)
 {
     jl_task_t *ct = jl_current_task;

--- a/src/gf.c
+++ b/src/gf.c
@@ -3438,7 +3438,7 @@ JL_DLLEXPORT void jl_typeinf_timing_end(void)
 
 JL_DLLEXPORT void jl_typeinf_lock_begin(void)
 {
-    JL_LOCK(&typeinf_lock);
+    JL_LOCK(&jl_codegen_lock);
     //Although this is claiming to be a typeinfer lock, it is actually
     //affecting the codegen lock count, not type inference's inferencing count
     jl_task_t *ct = jl_current_task;
@@ -3449,7 +3449,7 @@ JL_DLLEXPORT void jl_typeinf_lock_end(void)
 {
     jl_task_t *ct = jl_current_task;
     ct->reentrant_codegen--;
-    JL_UNLOCK(&typeinf_lock);
+    JL_UNLOCK(&jl_codegen_lock);
 }
 
 #ifdef __cplusplus

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -544,9 +544,9 @@ jl_value_t *jl_dump_method_asm_impl(jl_method_instance_t *mi, size_t world,
                 }
                 JL_GC_POP();
             }
+            JL_UNLOCK(&jl_codegen_lock);
             if (!--ct->reentrant_codegen && measure_compile_time_enabled)
                 jl_atomic_fetch_add_relaxed(&jl_cumulative_compile_time, (jl_hrtime() - compiler_start_time));
-            JL_UNLOCK(&jl_codegen_lock);
         }
         if (specfptr != 0)
             return jl_dump_fptr_asm(specfptr, raw_mc, asm_variant, debuginfo, binary);


### PR DESCRIPTION
Depends on #46825 for type inference lock removal.