### PR TITLE
Add preallocating constructor for BitSet(::AbstractVector)

### DIFF
--- a/test/bitset.jl
+++ b/test/bitset.jl
@@ -351,8 +351,10 @@ end
     @test union!(x, BitSet(a:b)) == union!(y, BitSet(a:1:b))
     @test_throws ArgumentError BitSet(Int128(typemin(Int))-1:typemin(Int))
     @test_throws ArgumentError BitSet(typemax(Int):Int128(typemax(Int))+1)
-    # union! with an empty range doesn't modify the BitSet
+    # union! with an empty collection doesn't modify the BitSet
     @test union!(x, b:a) == y
+    @test union!(x, Int[]) == y
+    @test union!(x, Set{Int}()) == y
 end
 
 @testset "union!(::BitSet, ::AbstractUnitRange) when two ranges do not overlap" begin

--- a/test/bitset.jl
+++ b/test/bitset.jl
@@ -16,6 +16,7 @@ end
     @test eltype(BitSet()) === Int
     @test eltype(BitSet) === Int
     @test isequal(empty(BitSet([1,2,3])), BitSet())
+    @test BitSet() == BitSet([]) == BitSet(error() for _ in 1:0)
 end
 
 @testset "show" begin


### PR DESCRIPTION
Ideally, we would dispatch to the new method for any efficient iterable that can be iterated twice; the closest type I could find was `AbstractVector`.

Benchmarking code:
```julia
using BenchmarkTools

function f(n)
    for x in 0:n
        for y in 0:n
            v = rand(1:10^x, 10^y)
            t0 = @belapsed invoke(BitSet, Tuple{Any}, x) setup=(x=rand(1:10^$x, 10^$y))
            t1 = @belapsed invoke(BitSet, Tuple{AbstractVector}, x) setup=(x=rand(1:10^$x, 10^$y))
            println((x, y, t1/t0))
        end
    end
end

f(4)
```
Results:
```
(0, 0, 0.5087067955287577)
(0, 1, 0.5685897660058082)
(0, 2, 0.8094049703272072)
(0, 3, 0.9940489071629518)
(0, 4, 1.0221360750603967)
(1, 0, 0.5116265190362661)
(1, 1, 0.5650601757040765)
(1, 2, 0.8121002300412222)
(1, 3, 0.9947459646842162)
(1, 4, 1.0287911101133684)
(2, 0, 0.5057934999240832)
(2, 1, 0.5449234307575512)
(2, 2, 0.5740818095718663)
(2, 3, 0.6302809463455852)
(2, 4, 0.6970214171667677)
(3, 0, 0.5130559674850138)
(3, 1, 0.43196437834607615)
(3, 2, 0.446386627588529)
(3, 3, 0.4864293121327341)
(3, 4, 0.5411990145086231)
(4, 0, 0.5008046726069136)
(4, 1, 0.5656207899942374)
(4, 2, 0.5709920816285192)
(4, 3, 0.4394107178168875)
(4, 4, 0.5164604626143088)
```