### PR TITLE
use native Julia code in round example

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -99,12 +99,12 @@ julia> round(357.913; sigdigits=4, base=2)
     value represented by `1.15` is actually *less* than 1.15, yet will be
     rounded to 1.2. For example:
 
-    ```jldoctest; setup = :(using Printf)
+    ```jldoctest
     julia> x = 1.15
     1.15
 
-    julia> @sprintf "%.20f" x
-    "1.14999999999999991118"
+    julia> big(1.15)
+    1.149999999999999911182158029987476766109466552734375
 
     julia> x < 115//100
     true


### PR DESCRIPTION
This `!!! note` section on `round` introduces a concept or function not native to Julia code, where a better Julia solution could have been used:
```julia
  │ Note
  │
  │  Rounding to specified digits in bases other than 2 can be
  │  inexact when operating on binary floating point numbers. For
  │  example, the Float64 value represented by 1.15 is actually less
  │  than 1.15, yet will be rounded to 1.2. For example:
  |
  │  julia> @sprintf "%.20f" x
  │  "1.14999999999999991118"
```

The `@sprintf` function introduced there complicates things for some number of reasons:
- Julia users not acquainted with the `Printf` module or `C printf` style would not get the understanding of what that part is trying to do or explain. Sure they can lookup `@sprintf` in the docs, but then they have to figure out what the `%.20f` does and all that stuffs, just to understand the example.
- Trying to replicate the example fails because it does not show where `@sprintf` comes from (i.e. no `using Printf` is shown there, so users know its exported).

Just to understand an example, and then one has to figure out all that sutff - Huh, I think its uncalled for. Why not just use Julia's `big` to show what's happening there, its same with the `@sprintf` (just the difference being that `@sprintf` shows the results in 20 digits after decimal point):
```julia
julia> using Printf

julia> x = 1.15
1.15

julia> big(x)
1.149999999999999911182158029987476766109466552734375

julia> @sprintf "%.20f" x
"1.14999999999999991118"
```