### PR TITLE
Limit initial OpenBLAS thread count

### DIFF
--- a/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
+++ b/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
@@ -37,6 +37,15 @@ function __init__()
         ENV["OPENBLAS_MAIN_FREE"] = "1"
     end
 
+    # Ensure that OpenBLAS does not grab a huge amount of memory at first,
+    # since it instantly allocates scratch buffer space for the number of
+    # threads it thinks it needs to use.
+    if !haskey(ENV, "OPENBLAS_NUM_THREADS")
+        # We set this to `1` here, and then LinearAlgebra will update
+        # to the true value in its `__init__()` function.
+        ENV["OPENBLAS_NUM_THREADS"] = "1"
+    end
+
     global libopenblas_handle = dlopen(libopenblas)
     global libopenblas_path = dlpath(libopenblas_handle)
     global artifact_dir = dirname(Sys.BINDIR)

--- a/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
+++ b/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
@@ -40,7 +40,11 @@ function __init__()
     # Ensure that OpenBLAS does not grab a huge amount of memory at first,
     # since it instantly allocates scratch buffer space for the number of
     # threads it thinks it needs to use.
-    if !haskey(ENV, "OPENBLAS_NUM_THREADS")
+    # X-ref: https://github.com/xianyi/OpenBLAS/blob/c43ec53bdd00d9423fc609d7b7ecb35e7bf41b85/README.md#setting-the-number-of-threads-using-environment-variables
+    # X-ref: https://github.com/JuliaLang/julia/issues/45434
+    if !haskey(ENV, "OPENBLAS_NUM_THREADS") &&
+       !haskey(ENV, "GOTO_NUM_THREADS") &&
+       !haskey(ENV, "OMP_NUM_THREADS")
         # We set this to `1` here, and then LinearAlgebra will update
         # to the true value in its `__init__()` function.
         ENV["OPENBLAS_NUM_THREADS"] = "1"


### PR DESCRIPTION
We set OpenBLAS's initial thread count to `1` to prevent runaway allocation within OpenBLAS's initial thread startup.  LinearAlgebra will later call `BLAS.set_num_threads()` to the actual value we require.