### PR TITLE
Don't export `axp(b)y!` from `LinearAlgebra.BLAS`

### DIFF
--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -556,8 +556,8 @@ LinearAlgebra.BLAS.rot!
 LinearAlgebra.BLAS.scal!
 LinearAlgebra.BLAS.scal
 LinearAlgebra.BLAS.blascopy!
-LinearAlgebra.BLAS.axpy!
-LinearAlgebra.BLAS.axpby!
+# xAXPY!
+# xAXPBY!
 LinearAlgebra.BLAS.dot
 LinearAlgebra.BLAS.dotu
 LinearAlgebra.BLAS.dotc

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -20,8 +20,8 @@ export
     scal!,
     scal,
     blascopy!,
-    axpy!,
-    axpby!,
+    # xAXPY!,
+    # xAXPBY!,
     # xDOT
     dotc,
     dotu,

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1419,9 +1419,7 @@ isdiag(x::Number) = true
     axpy!(α, x::AbstractArray, y::AbstractArray)
 
 Overwrite `y` with `x * α + y` and return `y`.
-If `x` and `y` have the same axes, it's equivalent with `y .+= x .* a`
-
-See also [`BLAS.axpy!`](@ref)
+If `x` and `y` have the same axes, it's equivalent with `y .+= x .* a`.
 
 # Examples
 ```jldoctest
@@ -1465,9 +1463,7 @@ end
     axpby!(α, x::AbstractArray, β, y::AbstractArray)
 
 Overwrite `y` with `x * α + y * β` and return `y`.
-If `x` and `y` have the same axes, it's equivalent with `y .= x .* a .+ y .* β`
-
-See also [`BLAS.axpby!`](@ref)
+If `x` and `y` have the same axes, it's equivalent with `y .= x .* a .+ y .* β`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Closes JuliaLang/LinearAlgebra.jl#954, following https://github.com/JuliaLang/LinearAlgebra.jl/issues/954. This probably requires a nanosoldier run. Tests pass locally.