### PR TITLE
Insert bitcast after any additional phi nodes

### DIFF
--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -781,6 +781,9 @@ void LateLowerGCFrame::LiftPhi(State &S, PHINode *Phi) {
                             assert(isa<Instruction>(BaseElem) && "Unknown value type detected!");
                             InsertBefore = cast<Instruction>(BaseElem)->getNextNonDebugInstruction();
                         }
+                        while (isa<PHINode>(InsertBefore)) {
+                            InsertBefore = InsertBefore->getNextNonDebugInstruction();
+                        }
                         remap = new BitCastInst(BaseElem, T_prjlvalue, "", InsertBefore);
                     }
                 }


### PR DESCRIPTION
Fixes #46852, adjusts the relevant test to catch this type of error.