### PR TITLE
Add assume_fatal_throw optimizer option

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1185,30 +1185,32 @@ function try_resolve_finalizer!(ir::IRCode, idx::Int, finalizer_idx::Int, defuse
     # Check #3
     dominates(domtree, finalizer_bb, bb_insert_block) || return nothing
 
-    # Collect all reachable blocks between the finalizer registration and the
-    # insertion point
-    blocks = finalizer_bb == bb_insert_block ? Int[finalizer_bb] :
-        reachable_blocks(ir.cfg, finalizer_bb, bb_insert_block)
+    if !inlining.params.assume_fatal_throw
+        # Collect all reachable blocks between the finalizer registration and the
+        # insertion point
+        blocks = finalizer_bb == bb_insert_block ? Int[finalizer_bb] :
+            reachable_blocks(ir.cfg, finalizer_bb, bb_insert_block)
 
-    # Check #4
-    function check_range_nothrow(ir::IRCode, s::Int, e::Int)
-        return all(s:e) do sidx::Int
-            sidx == finalizer_idx && return true
-            sidx == idx && return true
-            return is_nothrow(ir, sidx)
+        # Check #4
+        function check_range_nothrow(ir::IRCode, s::Int, e::Int)
+            return all(s:e) do sidx::Int
+                sidx == finalizer_idx && return true
+                sidx == idx && return true
+                return is_nothrow(ir, sidx)
+            end
         end
-    end
-    for bb in blocks
-        range = ir.cfg.blocks[bb].stmts
-        s, e = first(range), last(range)
-        if bb == bb_insert_block
-            bb_insert_idx === nothing && continue
-            e = bb_insert_idx
+        for bb in blocks
+            range = ir.cfg.blocks[bb].stmts
+            s, e = first(range), last(range)
+            if bb == bb_insert_block
+                bb_insert_idx === nothing && continue
+                e = bb_insert_idx
+            end
+            if bb == finalizer_bb
+                s = finalizer_idx
+            end
+            check_range_nothrow(ir, s, e) || return nothing
         end
-        if bb == finalizer_bb
-            s = finalizer_idx
-        end
-        check_range_nothrow(ir, s, e) || return nothing
     end
 
     # Ok, legality check complete. Figure out the exact statement where we're

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -63,6 +63,16 @@ struct OptimizationParams
     compilesig_invokes::Bool
     trust_inference::Bool
 
+    """
+        assume_fatal_throw::Bool
+
+    If `true`, gives the optimizer license to assume that any `throw` is fatal
+    and thus the state after a `throw` is not externally observable. In particular,
+    this gives the optimizer license to move side effects (that are proven not observed
+    within a particular code path) across a throwing call. Defaults to `false`.
+    """
+    assume_fatal_throw::Bool
+
     MAX_TUPLE_SPLAT::Int
 
     function OptimizationParams(;
@@ -73,7 +83,8 @@ struct OptimizationParams
             inline_error_path_cost::Int = 20,
             tuple_splat::Int = 32,
             compilesig_invokes::Bool = true,
-            trust_inference::Bool = false
+            trust_inference::Bool = false,
+            assume_fatal_throw::Bool = false
         )
         return new(
             inlining,
@@ -83,6 +94,7 @@ struct OptimizationParams
             inline_error_path_cost,
             compilesig_invokes,
             trust_inference,
+            assume_fatal_throw,
             tuple_splat,
         )
     end


### PR DESCRIPTION
This option frees the optimizer from having to prove nothrow in order to move certain side effects across call sites. It is currently enabled in finalizer inlining, but there may be opportunities to use it elsewhere in the future, as well as potentially plumbing it down to LLVM. The intended use case is not in the main compilation pipeline, but rather for alternative compilation modes where thrown errors are fatal and the state of the heap can not be observed after a thrown error.