### PR TITLE
use `invokelatest` to call `REPL.active_module`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -496,7 +496,7 @@ end
 function active_module()
     isassigned(REPL_MODULE_REF) || return Main
     REPL = REPL_MODULE_REF[]
-    return REPL.active_module()::Module
+    return invokelatest(REPL.active_module)::Module
 end
 
 # Check if a particular symbol is exported from a standard library module


### PR DESCRIPTION
REPL_MODULE_REF might be populated during execution, in which case we won't be able to see REPL methods yet.

For example I got this using PackageCompiler on master:
```
✔ [01m:50s] PackageCompiler: compiling base system image (incremental=false)
ERROR: LoadError: MethodError: no method matching active_module()
You may have intended to import Base.active_module
The applicable method may be too new: running in world age 18121, while current world is 18132.

Closest candidates are:
  active_module() (method too new to be called from this world context.)
   @ REPL ~/src/julia/usr/share/julia/stdlib/v1.9/REPL/src/REPL.jl:498
...
```
