### PR TITLE
Inlining: Remove outdated code path for GlobalRef movement

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -699,18 +699,6 @@ function batch_inline!(todo::Vector{Pair{Int, Any}}, ir::IRCode, linetable::Vect
                     compact.active_result_bb -= 1
                     refinish = true
                 end
-                # It is possible for GlobalRefs and Exprs to be in argument position
-                # at this point in the IR, though in that case they are required
-                # to be effect-free. However, we must still move them out of argument
-                # position, since `Argument` is allowed in PhiNodes, but `GlobalRef`
-                # and `Expr` are not, so a substitution could anger the verifier.
-                for aidx in 1:length(argexprs)
-                    aexpr = argexprs[aidx]
-                    if isa(aexpr, Expr) || isa(aexpr, GlobalRef)
-                        ninst = effect_free(NewInstruction(aexpr, argextype(aexpr, compact), compact.result[idx][:line]))
-                        argexprs[aidx] = insert_node_here!(compact, ninst)
-                    end
-                end
                 if isa(item, InliningTodo)
                     compact.ssa_rename[old_idx] = ir_inline_item!(compact, idx, argexprs, linetable, item, boundscheck, state.todo_bbs)
                 elseif isa(item, UnionSplit)

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -2,7 +2,7 @@
 
 function maybe_show_ir(ir::IRCode)
     if isdefined(Core, :Main)
-        Core.Main.Base.display(ir)
+        invokelatest(Core.Main.Base.display, ir)
     end
 end
 

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1713,6 +1713,6 @@ end
 # Test that inlining doesn't unnecesarily move things to stmt position
 @noinline f_no_inline_invoke(x::Union{Symbol, Nothing}=nothing) = Base.donotdelete(x)
 g_no_inline_invoke(x) = f_no_inline_invoke(x)
-let src = code_typed1(g_no_inline_invoke, Tuple{Any})
+let src = code_typed1(g_no_inline_invoke, Tuple{Union{Symbol, Nothing}})
     @test count(x->isa(x, GlobalRef), src.code) == 0
 end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1709,3 +1709,10 @@ let src = code_typed1((Any,)) do x
     end
     @test count(iscall((src, f_union_unmatched)), src.code) == 0
 end
+
+# Test that inlining doesn't unnecesarily move things to stmt position
+@noinline f_no_inline_invoke(x::Union{Symbol, Nothing}=nothing) = Base.donotdelete(x)
+g_no_inline_invoke(x) = f_no_inline_invoke(x)
+let src = code_typed1(g_no_inline_invoke, Tuple{Any})
+    @test count(x->isa(x, GlobalRef), src.code) == 0
+end


### PR DESCRIPTION
We used to not allow GlobalRef in PhiNode at all (because they could have side effects). However, we then change the IR to make side-effecting GlobalRefs illegal in statement position in general, so now PhiNodes values are just regular value position, so there's no reason any more to try to move GlobalRefs out to statement position in inlining. Moreover, doing so introduces a bunch of unnecesary GlobalRefs that weren't being moved back. We could fix that separately by setting appropriate flags, but it's simpler to just get rid of this special case entirely.

While we're at it, fix the printing in the verifier, which didn't actually work if it was triggered during a bootstrap-built inference.