### PR TITLE
lattice: Properly percolate down `tmerge`

### DIFF
--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -555,6 +555,8 @@ function tmerge(lattice::PartialsLattice, @nospecialize(typea), @nospecialize(ty
 end
 
 function tmerge(lattice::ConstsLattice, @nospecialize(typea), @nospecialize(typeb))
+    # the equality of the constants can be checked here, but the equivalent check is usually
+    # done by `tmerge_fast_path` at earlier lattice stage
     return tmerge(widenlattice(lattice), widenconst(typea), widenconst(typeb))
 end
 


### PR DESCRIPTION
We were skipping the parent lattice of the partials lattice, which is exactly where lattices like the `TaintLattice` we have in the tests sit, so their `tmerge` method was ineffective.