### PR TITLE
Set `intersection = 1` during `intersect_sub_datatype`

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2897,7 +2897,7 @@ static jl_value_t *intersect_sub_datatype(jl_datatype_t *xd, jl_datatype_t *yd, 
         JL_GC_PUSHARGS(env, envsz);
         jl_stenv_t tempe;
         init_stenv(&tempe, env, envsz);
-        tempe.ignore_free = 1;
+        tempe.intersection = tempe.ignore_free = 1;
         if (subtype_in_env(isuper, super_pattern, &tempe)) {
             jl_value_t *wr = wrapper;
             int i;

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2182,3 +2182,10 @@ S46735{B<:Val, M<:AbstractMatrix} = Tuple{<:Union{B, <:Val{<:B}},M,<:(Union{Abst
 A46735{B<:Val, M<:AbstractMatrix} = Tuple{<:Union{B, <:Val{<:B}},M,Union{AbstractMatrix{B}, AbstractMatrix{<:Vector{<:B}}}}
 @testintersect(A46735{B} where {B}, A46735, !Union{})
 @testintersect(A46735{B, M} where {B, M}, A46735, !Union{})
+
+#issue #46871
+struct A46871{T, N, M} <: AbstractArray{T, N} end
+struct B46871{T, N} <: Ref{A46871{T, N, N}} end
+for T in (B46871{Int, N} where {N}, B46871{Int}) # intentional duplication
+    @testintersect(T, Ref{<:AbstractArray{<:Real, 3}}, B46871{Int, 3})
+end


### PR DESCRIPTION
At present, the `subtype_in_env` check is performed without this flag, thus `var_lt`/`var_gt` might set the wrong bounds.
close #46871.