### PR TITLE
function signature for the "^" operator for strings

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -715,7 +715,7 @@ julia> repeat("ha", 3)
 repeat(s::AbstractString, r::Integer) = repeat(String(s), r)
 
 """
-    ^(s::Union{AbstractString,AbstractChar}, n::Integer)
+    ^(s::Union{AbstractString,AbstractChar}, n::Integer) -> AbstractString
 
 Repeat a string or character `n` times. This can also be written as `repeat(s, n)`.
 


### PR DESCRIPTION
The returned value of this function should be shown so as to clear ambiguities on some scenarios.

As an example, it doesn't matter if the string is of length `0` or `1`, the returned value will always be a string. This isn't intuitive to think of as first glance:
```julia
julia> 'a' ^ 1
"a"

julia> 'a' ^ 0
""
```

Since it's said no where for the function to always return a string, its best to be in the function signature. And this will clear the ambiguities as pointed above.

A great example of this is in the `*` operator for strings and regex:
```julia
help?> *

  *(s::Union{AbstractString, AbstractChar}, t::Union{AbstractString, AbstractChar}...) -> AbstractString

  *(s::Regex, t::Union{Regex,AbstractString,AbstractChar}) -> Regex
  *(s::Union{Regex,AbstractString,AbstractChar}, t::Regex) -> Regex
```

As seen above, the `^` operator should follow the same standard too!

I opened #46885 on the regex part as well, so its balanced.