### PR TITLE
function signature for the "^" operator for regex

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -801,7 +801,7 @@ end
 
 
 """
-    ^(s::Regex, n::Integer)
+    ^(s::Regex, n::Integer) -> Regex
 
 Repeat a regex `n` times.
 


### PR DESCRIPTION
I opened this because of the reason outlined on #46884 