### PR TITLE
consistency on bitwise operators

### DIFF
--- a/base/bool.jl
+++ b/base/bool.jl
@@ -57,11 +57,14 @@ true
 julia> xor(true, true)
 false
 
-julia> xor(true, missing)
+julia> xor(false ⊻ false)
+false
+
+julia> true ⊻ missing
 missing
 
-julia> false ⊻ false
-false
+julia> false ⊻ missing
+missing
 
 julia> [true; true; false] .⊻ [true; false; false]
 3-element BitVector:
@@ -78,7 +81,8 @@ xor(x::Bool, y::Bool) = (x != y)
 
 Bitwise nand (not and) of `x` and `y`. Implements
 [three-valued logic](https://en.wikipedia.org/wiki/Three-valued_logic),
-returning [`missing`](@ref) if one of the arguments is `missing`.
+returning [`missing`](@ref) if one of the arguments is `missing` and
+the other is `true`.
 
 The infix operation `a ⊼ b` is a synonym for `nand(a,b)`, and
 `⊼` can be typed by tab-completing `\\nand` or `\\barwedge` in the Julia REPL.
@@ -91,10 +95,13 @@ true
 julia> nand(true, true)
 false
 
-julia> nand(true, missing)
+julia> nand(false, false)
+true
+
+julia> true ⊼ missing
 missing
 
-julia> false ⊼ false
+julia> false ⊼ missing
 true
 
 julia> [true; true; false] .⊼ [true; false; false]
@@ -126,11 +133,11 @@ false
 julia> nor(true, true)
 false
 
-julia> nor(true, missing)
-false
-
-julia> false ⊽ false
+julia> nor(false, false)
 true
+
+julia> true ⊽ missing
+false
 
 julia> false ⊽ missing
 missing

--- a/base/int.jl
+++ b/base/int.jl
@@ -316,6 +316,9 @@ julia> ~10
 
 julia> ~true
 false
+
+julia> ~false
+true
 ```
 """
 (~)(x::BitInteger)             = not_int(x)
@@ -342,6 +345,12 @@ missing
 
 julia> false & missing
 false
+
+julia> [true; true; false] .& [true; false; false]
+3-element BitVector:
+ 1
+ 0
+ 0
 ```
 """
 (&)(x::T, y::T) where {T<:BitInteger} = and_int(x, y)
@@ -367,6 +376,12 @@ true
 
 julia> false | missing
 missing
+
+julia> [true; true; false] .| [true; false; false]
+3-element BitVector:
+ 1
+ 1
+ 0
 ```
 """
 (|)(x::T, y::T) where {T<:BitInteger} = or_int(x, y)


### PR DESCRIPTION
I made a lot of changes and also this #46887  is related, so please pardon me to explain in the way you would understand. I know the docs and example don't mean much for you advanced programmers, but it will make a big deal for those newly into the world of programming learning with Julia. 

I intended to use just the function doc of each operator and the examples, no coding or anything, to teach bitwise operations and operators to a young chap. Well this was when I became fully aware of the inconsistencies in the bitwise operator docs and also the examples provided, which for no good reasons will complicate things just trying to follow them up.

Some of the reasons are:
- Some says returning `missing` if one of the argument is `missing`, but this isn't true for all. In some cases, it only returns `missing`, when the other is `false` and in some cases when the other is `true`. Some of the operators point this out, some don't:
```julia
help?> nand
  nand(x, y)
  ⊼(x, y)

  Bitwise nand (not and) of x and y. Implements three-valued logic
  (https://en.wikipedia.org/wiki/Three-valued_logic), returning missing if
  one of the arguments is missing.

  julia> true ⊼ missing
  missing
  
  julia> false ⊼ missing
  true
```

- The examples are scattered all round and don't match. For example, in all the examples you have `(true, false)`, `(true, true)`, and it makes sense for the next to be  `(false, false)`, but then we see `missing` and then down the line we see `false, false` again, like taking us back to the (`true`, `true`) part:
```julia
julia> nand(true, false)     # okay
true

julia> nand(true, true)      # okay
false

julia> nand(true, missing)
missing

julia> false ⊼ false         # why here and not above close to (true, true)
true

julia> [true; true; false] .⊼ [true; false; false]
3-element BitVector:
 0
 1
 1
```

- Some examples show the truth table i.e. using the dot operator on a collection to show the results it would return, making it akin to a truth table. Some of the operators, don't show this:
```julia
help?> &

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  julia> 4 & 10
  0
  
  julia> 4 & 12
  4
  
  julia> true & missing
  missing
  
  julia> false & missing
  false

help?> ⊼

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  julia> nand(true, false)
  true
  
  julia> nand(true, true)
  false
  
  julia> nand(true, missing)
  missing
  
  julia> false ⊼ false
  true
  
  julia> [true; true; false] .⊼ [true; false; false]
  3-element BitVector:
   0
   1
   1
```

Finally, I came across the example for Boolean not i.e. `!` which gives a good format of
how the examples should be:
```julia
julia> !true
false

julia> !false
true

julia> !missing
missing

julia> .![true false true]
1×3 BitMatrix:
 0  1  0
```

That is, show the operator first on `true`(would be `(true, true)` for a binary operator), then on `false` (would be `(false, false`) for a binary operator), then on `missing` and then finally on how it returns on a collection using a truth table.

I finally coded to restructure the examples so the chap can understand, and then said I would open a PR on the weekend and probably see where it goes.