### PR TITLE
Remove redundancy in docstrings for >> and >>> 

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -658,9 +658,9 @@ end
     >>(x, n)
 
 Right bit shift operator, `x >> n`. For `n >= 0`, the result is `x` shifted
-right by `n` bits, where `n >= 0`, filling with `0`s if `x >= 0`, `1`s if `x <
-0`, preserving the sign of `x`. This is equivalent to `fld(x, 2^n)`. For `n <
-0`, this is equivalent to `x << -n`.
+right by `n` bits, filling with `0`s if `x >= 0`, `1`s if `x < 0`, preserving
+the sign of `x`. This is equivalent to `fld(x, 2^n)`. For `n < 0`, this is
+equivalent to `x << -n`.
 
 # Examples
 ```jldoctest
@@ -699,8 +699,8 @@ end
     >>>(x, n)
 
 Unsigned right bit shift operator, `x >>> n`. For `n >= 0`, the result is `x`
-shifted right by `n` bits, where `n >= 0`, filling with `0`s. For `n < 0`, this
-is equivalent to `x << -n`.
+shifted right by `n` bits, filling with `0`s. For `n < 0`, this is equivalent
+to `x << -n`.
 
 For [`Unsigned`](@ref) integer types, this is equivalent to [`>>`](@ref). For
 [`Signed`](@ref) integer types, this is equivalent to `signed(unsigned(x) >> n)`.


### PR DESCRIPTION
The `<<` operator says this and its clearly understandable:
```julia
help?> <<

  <<(x, n)

  Left bit shift operator, x << n. For n >= 0, the result is x shifted left
  by n bits, filling with 0s. This is equivalent to x * 2^n. For n < 0,
  this is equivalent to x >> -n.
```

But then the `>>` and `>>>` operator both use the word `where n >= 0`, even after stating `For n >= 0` in the beginning:
```julia
help?> >>

  >>(x, n)

  Right bit shift operator, x >> n. For n >= 0, the result is x shifted
  right by n bits, where n >= 0, filling with 0s if x >= 0, 1s if x < 0,
  preserving the sign of x. This is equivalent to fld(x, 2^n). For n < 0,
  this is equivalent to x << -n.

help?> >>>

  >>>(x, n)

  Unsigned right bit shift operator, x >>> n. For n >= 0, the result is x
  shifted right by n bits, where n >= 0, filling with 0s. For n < 0, this
  is equivalent to x << -n.
```

The `<<` does not have this `where n >= 0` confusion, so I don't know why it's coming into `>>` and `>>>` even after stating `For n >= 0` in the beginning of the statement.

The `For n >= 0` already states what's happening, so the `where n >= 0` complicates things, and gets one confused, which I think was a typo error.