### PR TITLE
complete info on the |> operator

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -897,7 +897,7 @@ the definition to get the intended chain.
 julia> 4 |> inv
 0.25
 
-julia> [2,3,5] |> sum |> inv
+julia> [2, 3, 5] |> sum |> inv
 0.1
 
 julia> [0 1; 2 3] .|> (x -> x^2) |> sum

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -902,7 +902,7 @@ julia> 1:5 |> join
 julia> 1:5 |> collect |> sum |> inv
 0.06666666666666667
 
-julia> 1:5 |> collect .|> (x -> x^2) |> sum |> inv 
+julia> 1:5 |> collect .|> (x -> x^2) |> sum |> inv
 0.01818181818181818
 ```
 """

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -889,8 +889,6 @@ widen(x::Type{T}) where {T} = throw(MethodError(widen, (T,)))
 
 Infix operator which applies function `f` to the argument `x`.
 This allows `f(g(x))` to be written `x |> g |> f`.
-Such a pipe, or function chain, is often useful in interactive use.
-
 When used with anonymous functions, parentheses are typically required around
 the definition to get the intended chain.
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -887,12 +887,22 @@ widen(x::Type{T}) where {T} = throw(MethodError(widen, (T,)))
 """
     |>(x, f)
 
-Applies a function to the preceding argument. This allows for easy function chaining.
-When used with anonymous functions, parentheses are typically required around the definition to get the intended chain.
+Applies a function to the preceding argument. This allows for easy function
+chaining, where the results returned from a function on the chain is passed
+to the next function on the chain, until the last function is called.
+
+When used with anonymous functions, parentheses are typically required around
+the definition to get the intended chain.
 
 # Examples
 ```jldoctest
-julia> [1:5;] .|> (x -> x^2) |> sum |> inv
+julia> 1:5 |> join
+"12345"
+
+julia> 1:5 |> collect |> sum |> inv
+0.06666666666666667
+
+julia> 1:5 |> collect .|> (x -> x^2) |> sum |> inv 
 0.01818181818181818
 ```
 """

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -887,9 +887,9 @@ widen(x::Type{T}) where {T} = throw(MethodError(widen, (T,)))
 """
     |>(x, f)
 
-Applies a function to the preceding argument. This allows for easy function
-chaining, where the results returned from a function on the chain is passed
-to the next function on the chain, until the last function is called.
+Infix operator which applies function `f` to the argument `x`.
+This allows `f(g(x))` to be written `x |> g |> f`.
+Such a pipe, or function chain, is often useful in interactive use.
 
 When used with anonymous functions, parentheses are typically required around
 the definition to get the intended chain.

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -896,14 +896,14 @@ the definition to get the intended chain.
 
 # Examples
 ```jldoctest
-julia> 1:5 |> join
-"12345"
+julia> 4 |> inv
+0.25
 
-julia> 1:5 |> collect |> sum |> inv
-0.06666666666666667
+julia> [2,3,5] |> sum |> inv
+0.1
 
-julia> 1:5 |> collect .|> (x -> x^2) |> sum |> inv
-0.01818181818181818
+julia> [0 1; 2 3] .|> (x -> x^2) |> sum
+14
 ```
 """
 |>(x, f) = f(x)


### PR DESCRIPTION
This is Julia 1.8.2
```julia
help?> add

  |>(x, f)

  Applies a function to the preceding argument. This allows for easy
  function chaining. When used with anonymous functions, parentheses are
  typically required around the definition to get the intended chain.

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  julia> [1:5;] .|> (x -> x^2) |> sum |> inv
  0.01818181818181818
```

This statement:
> Applies a function to the preceding argument.

wasn't emphasised on the example. And I think understanding just that statement would help a lot in understanding the chaining part as well. And moreover, it won't make the `|>` operator look more like an operator that can only be used for function chaining.

This statement:
> This allows for easy function chaining.

is great but few words should be said on it, to make known explicitly what is meant by **"function chaining"**.

Finally, I think the`[1:5;]` and `.|>` makes things complex for some reasons:
- `[1:5;]` isn't a common syntax i.e. it behaviour isn't intuitive for anyone not versed with arrays, and searching the `;` docstring won't show you this usage as an example. That is, everyone knows of `[1 2 3; 4 5 6]` but `[1:5;]` isn't. So its best to just use `collect` i.e. `1:5 |> collect`, since searching up `collect` shows you what it does.
- `.|>` operator takes the energy from understanding what `|>` does into what does `.|>` does, which should be a different thing. That is, the energy should be on `|>` and not the broadcast operation of `|>`. I didn't find a solution for this (since the current example is great), so provided another example without it, so users see the original behaviour of `|>`.