### PR TITLE
clear info on colon operator

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -34,6 +34,7 @@ _colon(::Any, ::Any, start::T, step, stop::T) where {T} =
 Range operator. `a:b` constructs a range from `a` to `b` with an implicit step size
 of 1 (often a [`UnitRange`](@ref)), and `a:s:b` is similar but uses an explicit step
 size of `s` (a [`StepRange`](@ref) or [`StepRangeLen`](@ref)).
+See also [`range`](@ref) for more control.
 
 `:` is also used in indexing to select whole dimensions, e.g. in `A[:, 1]`.
 """

--- a/base/range.jl
+++ b/base/range.jl
@@ -32,9 +32,8 @@ _colon(::Any, ::Any, start::T, step, stop::T) where {T} =
     (:)(start, [step], stop)
 
 Range operator. `a:b` constructs a range from `a` to `b` with an implicit step size
-of 1 (a [`UnitRange`](@ref)), and `a:s:b` is similar but uses an explicit step size
-of `s` (a [`StepRange`](@ref)). `a:s:b` where either `a`, `s` or `b` is a floating
-point produces a `StepRangeLen`.
+of 1 (often a [`UnitRange`](@ref)), and `a:s:b` is similar but uses an explicit step
+size of `s` (a [`StepRange`](@ref) or [`StepRangeLen`](@ref)).
 
 `:` is also used in indexing to select whole dimensions, e.g. in `A[:, 1]`.
 """

--- a/base/range.jl
+++ b/base/range.jl
@@ -31,8 +31,10 @@ _colon(::Any, ::Any, start::T, step, stop::T) where {T} =
 """
     (:)(start, [step], stop)
 
-Range operator. `a:b` constructs a range from `a` to `b` with a step size of 1 (a [`UnitRange`](@ref))
-, and `a:s:b` is similar but uses a step size of `s` (a [`StepRange`](@ref)).
+Range operator. `a:b` constructs a range from `a` to `b` with an implicit step size
+of 1 (a [`UnitRange`](@ref)), and `a:s:b` is similar but uses an explicit step size
+of `s` (a [`StepRange`](@ref)). `a:s:b` where either `a`, `s` or `b` is a floating
+point produces a `StepRangeLen`.
 
 `:` is also used in indexing to select whole dimensions, e.g. in `A[:, 1]`.
 """

--- a/base/range.jl
+++ b/base/range.jl
@@ -36,7 +36,10 @@ of 1 (often a [`UnitRange`](@ref)), and `a:s:b` is similar but uses an explicit 
 size of `s` (a [`StepRange`](@ref) or [`StepRangeLen`](@ref)).
 See also [`range`](@ref) for more control.
 
-`:` is also used in indexing to select whole dimensions, e.g. in `A[:, 1]`.
+The operator `:` is also used in indexing to select whole dimensions, e.g. in `A[:, 1]`.
+
+`:` is also used to [`quote`](@ref) code, e.g. `:(x + y) isa Expr` and `:x isa Symbol`.
+Since `:2 isa Int`, it does *not* create a range in indexing: `v[:2] == v[2] != v[begin:2]`.
 """
 (:)(start::T, step, stop::T) where {T} = _colon(start, step, stop)
 (:)(start::T, step, stop::T) where {T<:Real} = _colon(start, step, stop)

--- a/base/range.jl
+++ b/base/range.jl
@@ -31,8 +31,8 @@ _colon(::Any, ::Any, start::T, step, stop::T) where {T} =
 """
     (:)(start, [step], stop)
 
-Range operator. `a:b` constructs a range from `a` to `b` with an implicit step size
-of 1 (often a [`UnitRange`](@ref)), and `a:s:b` is similar but uses an explicit step
+Range operator. `a:b` constructs a range from `a` to `b` with a step size
+of 1 (often a [`UnitRange`](@ref)), and `a:s:b` is similar but uses a step
 size of `s` (a [`StepRange`](@ref) or [`StepRangeLen`](@ref)).
 See also [`range`](@ref) for more control.
 


### PR DESCRIPTION
This is what the doc currently says on the `:` operator:
```julia
help?> :

  (:)(start, [step], stop)

  Range operator. a:b constructs a range from a to b with a step size of 1
  (a UnitRange) , and a:s:b is similar but uses a step size of s (a
  StepRange).

  : is also used in indexing to select whole dimensions and for Symbol
  literals, as in e.g. :hello.
```

Assuming we go with that info, it will be intuitive to think all Range objects with a step size of `1` will always be a `UnitRange` - but that isn't the case:
```julia
julia> typeof(1:10)
UnitRange{Int64}

julia> typeof(1:1:10)
StepRange{Int64, Int64}
```

A `UnitRange` is only produce when we have an **"IMPLICIT"** step size of `1`, not when it's **"EXPLICIT"**. The words **"implicit"** and **"explicit"** is very needed here because it would help to indicate that anytime we pass a `step` size, regardless of what the `step` is, a `StepRange` or `StepRangeLen` will always be produced.

On the second part, its worth noting that there is `StepRangeLen`, which is produced if `a`, `s` or `b` is a floating-point:
```julia
julia> typeof(1.0:1:10)
StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}

julia> typeof(1:1.0:10)
StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}

julia> typeof(1:1:10.0)
StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}
```

So it's worth pointing out too, so users are aware of this right from the `:` documentation, other than having to figure this out in some obscure way.