### PR TITLE
clear example on % for integers representable

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -578,8 +578,17 @@ if nameof(@__MODULE__) === :Base
 
         # Examples
         ```jldoctest
-        julia> 129 % Int8
+        julia> x = 129 % Int8
         -127
+
+        julia> typeof(x)
+        Int8
+
+        julia> x = 129 % BigInt
+        129
+
+        julia> typeof(x)
+        BigInt
         ```
         """ $fname(x::Integer, T::Type{<:Integer})
     end


### PR DESCRIPTION
```julia
help?> %

  rem(x::Integer, T::Type{<:Integer}) -> T
  mod(x::Integer, T::Type{<:Integer}) -> T
  %(x::Integer, T::Type{<:Integer}) -> T

  Find y::T such that x ≡ y (mod n), where n is the number of integers
  representable in T, and y is an integer in [typemin(T),typemax(T)]. If T
  can represent any integer (e.g. T == BigInt), then this operation
  corresponds to a conversion to T.

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  julia> 129 % Int8
  -127
```

The `-127` there isn't understood to have wraparound. Yes it has wraparound, but that's for advance Julia users who know about modular arithmetic. So its best to provide an example where the type is shown not to have changed, and also provide an example to show:
> If T can represent any integer (e.g. T == BigInt), then this operation corresponds to a conversion to T.

Just to chip in my own words, I think it will be great if docs in Julia are written with **"newbies"** in mind (when possible). A lot of the doc in my view somehow assumes you're a s mart guy and already knows about programming. **"newbies"** are coming in now, so please go a little simpler on the examples.