### PR TITLE
dot operation on composed function

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -945,7 +945,7 @@ The prefix form supports composition of multiple functions: `∘(f, g, h) = f �
 and splatting `∘(fs...)` for composing an iterable collection of functions.
 
 When using the `∘` operator with the vectorized dot "`.`", `.` comes as an infix operator between the composed
-functions and the argument: `∘(f, g).(args...; kwargs...)`.
+functions and the argument: `(f ∘ g).(args...; kwargs...)`.
 
 !!! compat "Julia 1.4"
     Multiple function composition requires at least Julia 1.4.

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -944,6 +944,9 @@ Function composition also works in prefix form: `∘(f, g)` is the same as `f �
 The prefix form supports composition of multiple functions: `∘(f, g, h) = f ∘ g ∘ h`
 and splatting `∘(fs...)` for composing an iterable collection of functions.
 
+When using the `∘` operator with the vectorized dot "`.`", `.` comes as an infix operator between the composed
+functions and the argument: `∘(f, g).(args...; kwargs...)`.
+
 !!! compat "Julia 1.4"
     Multiple function composition requires at least Julia 1.4.
 


### PR DESCRIPTION
The `∘` operator is seen as an operator like the `+`, `^`, `-`, etc (which one can argue it's not).

If its seen like those operators, so it makes sense to think we would vectorise it using `.∘`, just we would had done for `.+` or `.^`:
```julia
julia> .+([2, 3], 2)
2-element Vector{Int64}:
 4
 5

julia> (+).([2, 3], 2)
2-element Vector{Int64}:
 4
 5
```

But it doesn't work that way (and when the operation fails, the error messages don't given an hint on what's happening):
```julia
julia> .∘(first, uppercase)(["apple", "orange"]) 
ERROR: MethodError: no method matching uppercase(::Vector{String})

julia> (∘).(first, uppercase)(["apple", "orange"])
ERROR: MethodError: no method matching uppercase(::Vector{String})
```

So its best to point out the right way to do it:
```julia
julia> ∘(first, uppercase).(["apple", "orange"])
2-element Vector{Char}:
 'A': ASCII/Unicode U+0041 (category Lu: Letter, uppercase)
 'O': ASCII/Unicode U+004F (category Lu: Letter, uppercase)
```

Some will say `∘(first, uppercase)` is a `ComposedFunction` and that's why it has to be that way - I agree if you say so, but providing an info on how to correctly do it isn't that bad.