### PR TITLE
Add example of broadcasting a Pair

### DIFF
--- a/base/pair.jl
+++ b/base/pair.jl
@@ -29,10 +29,10 @@ julia> for x in p
 foo
 7
 
-julia> join.(["one"=>1, "two"=>2]) # same as join.([["one", 1], ["two", 2]])
+julia> replace.(["xops", "oxps"], "x" => "o")
 2-element Vector{String}:
- "one1"
- "two2"
+ "oops"
+ "oops"
 ```
 """
 Pair, =>

--- a/base/pair.jl
+++ b/base/pair.jl
@@ -28,6 +28,11 @@ julia> for x in p
        end
 foo
 7
+
+julia> join.(["one"=>1, "two"=>2]) # same as join.([["one", 1], ["two", 2]])
+2-element Vector{String}:
+ "one1"
+ "two2"
 ```
 """
 Pair, =>


### PR DESCRIPTION
```julia
help?> =>

  Pair(x, y)
  x => y

  Construct a Pair object with type Pair{typeof(x), typeof(y)}. The
  elements are stored in the fields first and second. They can also be
  accessed via iteration (but a Pair is treated as a single "scalar" for
  broadcasting operations).

  See also Dict.

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  julia> p = "foo" => 7
  "foo" => 7
  
  julia> typeof(p)
  Pair{String, Int64}
  
  julia> p.first
  "foo"
  
  julia> for x in p
             println(x)
         end
  foo
  7
```

As seen above, on each part being explained, an example was provided in the `# Example` section except for this section:
> but a Pair is treated as a single "scalar" for broadcasting operations

Providing just one example on that statement would do a lot to convey what is meant there, other than intuitively "assuming" we would understand just like that.