### PR TITLE
issubnormal info and example guide

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -809,6 +809,9 @@ end
 Test whether a floating point number is subnormal. A floating point number is recognized as
 subnormal whenever its exponent is the least value possible and its significand is zero.
 
+# External link
+https://en.wikipedia.org/wiki/Subnormal_number
+
 # Examples
 ```jldoctest
 julia> floatmin(Float32)

--- a/base/float.jl
+++ b/base/float.jl
@@ -806,11 +806,8 @@ end
 """
     issubnormal(f) -> Bool
 
-Test whether a floating point number is subnormal. A floating point number is recognized as
+Test whether a floating point number is [subnormal](https://en.wikipedia.org/wiki/Subnormal_number). A floating point number is recognized as
 subnormal whenever its exponent is the least value possible and its significand is zero.
-
-# External link
-https://en.wikipedia.org/wiki/Subnormal_number
 
 # Examples
 ```jldoctest

--- a/base/float.jl
+++ b/base/float.jl
@@ -806,7 +806,19 @@ end
 """
     issubnormal(f) -> Bool
 
-Test whether a floating point number is subnormal.
+Test whether a floating point number is subnormal. A floating point number is recognized as
+subnormal whenever its exponent is the least value possible and its significand is zero.
+
+# Examples
+```jldoctest
+julia> floatmin(Float32)
+1.1754944f-38
+
+julia> issubnormal(1.0f-37)
+false
+
+julia> issubnormal(1.0f-38)
+true
 """
 function issubnormal(x::T) where {T<:IEEEFloat}
     y = reinterpret(Unsigned, x)


### PR DESCRIPTION
For users who don't know what a ***"subnormal number"*** is, looking up the definition in wikipedia or anywhere on google breaks the REPL workflow.

I think its best to just hit the nail on the head and tell what a  ***"subnormal number"*** is in the best possible form and still keep the doc concise. This will keep the workflow in the REPL.

Moreover, this would help with `get_zero_subnormals` and `set_zero_subnormals` as well, since no definition are added there for what is a ***"subnormal number (denormals)"*** but the words are constantly used.

And an example showing the definition would help a lot too.