### PR TITLE
ndigits relationship with zero

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -649,6 +649,9 @@ See also [`digits`](@ref), [`count_ones`](@ref).
 
 # Examples
 ```jldoctest
+julia> ndigits(0)
+1
+
 julia> ndigits(12345)
 5
 


### PR DESCRIPTION
An example should be shown where `ndigits` returns `1` even when the digit is `0`:
```julia
julia> ndigits(0)
1
```

The reason is because this isn't intuitive and users would assume it returns `0`. This can cause subtle bugs, so its best to show an example where it returns `1`.

The `Base.ndigits0z` shows this in its doc and I think its trying to show how its different from `ndigits`:
```julia
help?> Base.ndigits0z
  ndigits0z(n::Integer, b::Integer=10)

  Return 0 if n == 0, otherwise compute the number of digits in integer n
  written in base b (i.e. equal to ndigits(n, base=b) in this case). The
  base b must not be in [-1, 0, 1].
```

Moreover, I think `Base.ndigits0z` should be exported 😉 and then provided in the `ndigits` **"see also"** section, so users who want a behaviour of `0` returning `0` can look into using that.