### PR TITLE
inexact conversion on rationalize function

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -156,6 +156,10 @@ widen(::Type{Rational{T}}) where {T} = Rational{widen(T)}
 Approximate floating point number `x` as a [`Rational`](@ref) number with components
 of the given integer type. The result will differ from `x` by no more than `tol`.
 
+!!! note
+    `rationalize` does inexact conversion; it produces a `Rational` value equal to the
+     decimal value `x`. Use the `Rational` constructor or `convert` for exact conversion.
+
 # Examples
 ```jldoctest
 julia> rationalize(5.6)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -4,27 +4,7 @@
     Rational{T<:Integer} <: Real
 
 Rational number type, with numerator and denominator of type `T`.
-
-The preferred way of creating `Rational` numbers is using the
-`//` operator. `Rational`s are also checked for overflow.
-
-`Rational(x)` where `x` is a subtype of `AbstractFloat` returns
-the exact conversion of `x` to a `Rational` number.
-
-# Examples
-```jldoctest
-julia> Rational(Int8(127))
-127//1
-
-julia> Rational(Int8(1))
-1//1
-
-julia> Rational(Int8(127)) + Rational(Int8(1))
-ERROR: OverflowError: 127 + 1 overflowed for type Int8
-
-julia> Rational(1.29)
-1452410879826985//1125899906842624
-```
+Rationals are checked for overflow.
 """
 struct Rational{T<:Integer} <: Real
     num::T
@@ -150,6 +130,20 @@ function (::Type{T})(x::Rational{S}) where T<:AbstractFloat where S
     convert(T, convert(P,x.num)/convert(P,x.den))::T
 end
 
+"""
+    Rational(x::AbstractFloat)
+
+Returns the exact conversion of `x` to a `Rational` number that is representable in `typeof(x)`.
+
+# Examples
+```jldoctest
+julia> Rational(5.6f0)
+11744051//2097152
+
+julia> Rational(5.6)
+3152519739159347//562949953421312
+```
+"""
 function Rational{T}(x::AbstractFloat) where T<:Integer
     r = rationalize(T, x, tol=0)
     x == convert(typeof(x), r) || throw(InexactError(:Rational, Rational{T}, x))
@@ -177,7 +171,8 @@ Approximate floating point number `x` as a [`Rational`](@ref) number with compon
 of the given integer type. The result will differ from `x` by no more than `tol`.
 
 !!! note
-    `rationalize` may perform inexact conversion even when `tol = 0`; for exact conversion use the [`Rational`](@ref) constructor.
+    `rationalize` may perform inexact conversion, even when `tol = 0`;
+    for exact conversion use the [`Rational`](@ref) constructor.
 
 # Examples
 ```jldoctest

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -4,7 +4,27 @@
     Rational{T<:Integer} <: Real
 
 Rational number type, with numerator and denominator of type `T`.
-Rationals are checked for overflow.
+
+The preferred way of creating `Rational` numbers is using the
+`//` operator. `Rational`s are also checked for overflow.
+
+`Rational(x)` where `x` is a subtype of `AbstractFloat` returns
+the exact conversion of `x` to a `Rational` number.
+
+# Examples
+```jldoctest
+julia> Rational(Int8(127))
+127//1
+
+julia> Rational(Int8(1))
+1//1
+
+julia> Rational(Int8(127)) + Rational(Int8(1))
+ERROR: OverflowError: 127 + 1 overflowed for type Int8
+
+julia> Rational(1.29)
+1452410879826985//1125899906842624
+```
 """
 struct Rational{T<:Integer} <: Real
     num::T

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -177,7 +177,7 @@ Approximate floating point number `x` as a [`Rational`](@ref) number with compon
 of the given integer type. The result will differ from `x` by no more than `tol`.
 
 !!! note
-    `rationalize` does inexact conversion; for exact conversion use `convert` or the `Rational` constructor.
+    `rationalize` may perform inexact conversion even when `tol = 0`; for exact conversion use the [`Rational`](@ref) constructor.
 
 # Examples
 ```jldoctest

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -157,8 +157,7 @@ Approximate floating point number `x` as a [`Rational`](@ref) number with compon
 of the given integer type. The result will differ from `x` by no more than `tol`.
 
 !!! note
-    `rationalize` does inexact conversion; it produces a `Rational` value equal to the
-     decimal value `x`. Use the `Rational` constructor or `convert` for exact conversion.
+    `rationalize` does inexact conversion; for exact conversion use `convert` or the `Rational` constructor.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
This is a very good link on discourse where @StefanKarpinski  pointed out the differences on `Rational` and `rationalize`: https://discourse.julialang.org/t/float-rational-numbers/37856/12.

While it's a good link where the `Rational` and `rationalize` function was discussed on that thread, I think not many will come across it. It's best if it's just pointed out on the docs direct about the "inexact conversion" it does.

The example below is a copy of the one Stefan provided:
```julia
julia> x = 2.64
2.64

julia> y = Rational(x)
5944751508129055//2251799813685248

julia> z = rationalize(x)
66//25

julia> x == y
true

julia> x == z
false

julia> y == z
false
```

As seen above, the returned values aren't the same. This is of great importance, to make it clear that `rationalize` and `Rational` somehow returns different values; so its best to spell it out in the docs.