### PR TITLE
complete info on the splat operator

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1108,23 +1108,48 @@ kw"do"
     ...
 
 The "splat" operator, `...`, represents a sequence of arguments.
-`...` can be used in function definitions, to indicate that the function
-accepts an arbitrary number of arguments.
-`...` can also be used to apply a function to a sequence of arguments.
+
+It means three different things, depending on the context where its used.
+* In the context of function definitions, the `...` operator is used to combine many
+  different arguments into a single argument. This use of `...` is called **slurping**.
+
+* In the context of function calls, the `...` operator is used to cause a single function
+  argument to be split into many different arguments. This use of `...` is called **splatting**.
+
+* In the context of variable assignments, the `...` operator is used to unpack part of a
+  collection into a variable. This use of `...` is called **unpacking**.
 
 # Examples
-```jldoctest
+As in function definitions, to indicate that a function accepts an arbitrary number of
+arguments:
+```julia
 julia> add(xs...) = reduce(+, xs)
 add (generic function with 1 method)
 
+julia> add(2, 4, 6)
+12
+
 julia> add(1, 2, 3, 4, 5)
 15
+```
 
-julia> add([1, 2, 3]...)
+As in function calls, to apply a function to a sequence of arguments:
+```julia
+julia> +([1, 2, 3]...)
 6
 
-julia> add(7, 1:100..., 1000:1100...)
+julia> +(7, 1:100..., 1000:1100...)
 111107
+```
+
+As in assignment, to unpack a collection into a variable:
+```julia
+julia> a, b, c... = [1, 2, 3, 4];
+
+julia> c
+2-element Vector{Int64}:
+3
+4
 ```
 """
 kw"..."

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1116,8 +1116,8 @@ It means three different things, depending on the context where its used.
 * In the context of function calls, the `...` operator is used to cause a single function
   argument to be split into many different arguments. This use of `...` is called **splatting**.
 
-* In the context of variable assignments, the `...` operator is used to unpack part of a
-  collection into a variable. This use of `...` is called **unpacking**.
+* In the context of variable assignments, the `...` operator is used to unpack a collection
+  into variables. This use of `...` is called **unpacking**.
 
 # Examples
 As in function definitions, to indicate that a function accepts an arbitrary number of


### PR DESCRIPTION
I think what's concise enough for the docs should be pointed out in the docs, what's not concise should be in an Extended help section, and if its just too verbose and would need nitty details, then add it to the FAQ section.

Having to go a FAQ section for simply "what does this function do" breaks the REPL workflow and I don't think its worth it! This is the case with the splat operator, `...`.

I think this docs section on the FAQ: https://docs.julialang.org/en/v1/manual/faq/#What-does-the-...-operator-do? should be in the docstring for `...` in the concise way as possible.

Even the title tells something is wrong: **"What does the ... operator do?"**. Why should a FAQ section tell what an operator does when there is a docstring for that.

The `=` gives a perfect example on this:
```julia
help?> =

  =

  = is the assignment operator.

    •  For variable a and expression b, a = b makes a refer to the
       value of b.

    •  For functions f(x), f(x) = x defines a new function constant f,
       or adds a new method to f if f is already defined; this usage
       is equivalent to function f(x); x; end.

    •  a[i] = v calls setindex!(a,v,i).

    •  a.b = c calls setproperty!(a,:b,c).

    •  Inside a function call, f(a=b) passes b as the value of keyword
       argument a.

    •  Inside parentheses with commas, (a=1,) constructs a NamedTuple.

  Examples
  ≡≡≡≡≡≡≡≡≡≡
```

As seen above, the `=` gives an hint on what's happening on each case and then goes down to give examples. What would it be like to have those section of `=` on the FAQ section and then expect users to go read about it there. If the `=` spells it out, I think the `...` should too, and then be removed (if possible) from the FAQ section on the doc.

Another example is the `;` operator, it follows same format for the `=` operator:
```julia
help?> ;

  ;

  ; has a similar role in Julia as in many C-like languages, and is used to
  delimit the end of the previous statement.

  ; is not necessary at the end of a line, but can be used to separate
  statements on a single line or to join statements into a single
  expression.

  Adding ; at the end of a line in the REPL will suppress printing the
  result of that expression.

  In function declarations, and optionally in calls, ; separates regular
  arguments from keywords.

  While constructing arrays, if the arguments inside the square brackets
  are separated by ; then their contents are vertically concatenated
  together.

  In the standard REPL, typing ; on an empty line will switch to shell
  mode.

  Examples
  ≡≡≡≡≡≡≡≡≡≡
```

Imagine having to go to a FAQ section to know those stuffs, it would have been bad. So I think its best if the `...` just follows same format.