### PR TITLE
assigning [ ] for array replacement

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -411,8 +411,19 @@ julia> push!(a, 2, 3)
  3
 
 ```
-Assigning `[]` does not eliminate elements from a collection; instead use [`filter!`](@ref).
+Assigning `[]` does not replace or eliminate elements from a collection; instead use [`replace`](@ref) or [`filter!`](@ref)
+respectively; howeover, replacing an element with `[]` should be avoided for performance reasons.
 ```jldoctest
+julia> a = collect(1:3); a[2] = []
+ERROR: MethodError: Cannot `convert` an object of type Vector{Any} to an object of type Int64
+[...]
+
+julia> replace(a, a[2]=>[])
+3-element Vector{Any}:
+ 1
+  Any[]
+ 3
+
 julia> a = collect(1:3); a[a .<= 1] = []
 ERROR: DimensionMismatch: tried to assign 0 elements to 1 destinations
 [...]


### PR DESCRIPTION
I came from a language like python were there was no talk on **"performance"**, so its very common and I mean SO COMMON, a lot of AI and DS experts write codes like:
```python
>>> data = [1, 2, 3, 4]
>>> data
>>> [1, 2, 3, 4]
>>> data[2] = []
>>> data
>>> [1, 2, [], 4]
>>> data[2].append(10); data[2].append(20)
>>> data
[1, 2, [10, 20], 4]
```
As seen above by assigning `[]` to an array, one can **"replace"** an element.

The `=` section pointed a lot of things I usually do in Python and it made me know right away, some examples are:
```julia
help?> =

Assignment at out-of-bounds indices does not grow a collection. If the
collection is a Vector it can instead be grown with push! or append!.

Assigning [] does not eliminate elements from a collection; instead use
filter!.
```

From Julia's survey, it shows a lot of users come from Python (me included), so it's best not to assume no one would want to do something of this nature - assigning `[]` to replace an array. So it should be added to the doc as well and then told that it shouldn't be used for performance reasons. This way python users know first hand and avoid it, other than assuming.