### PR TITLE
Reorder FileEvent field names in the documentation

### DIFF
--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -748,7 +748,7 @@ elapsed. This function does not poll the file system and instead uses platform-s
 functionality to receive notifications from the operating system (e.g. via inotify on Linux).
 See the NodeJS documentation linked below for details.
 
-The returned value is an object with boolean fields `changed`, `renamed`, and `timedout`,
+The returned value is an object with boolean fields `renamed`, `changed`, and `timedout`,
 giving the result of watching the file.
 
 This behavior of this function varies slightly across platforms. See
@@ -783,7 +783,7 @@ This will continuing tracking changes for `path` in the background until
 `unwatch_folder` is called on the same `path`.
 
 The returned value is an pair where the first field is the name of the changed file (if available)
-and the second field is an object with boolean fields `changed`, `renamed`, and `timedout`,
+and the second field is an object with boolean fields `renamed`, `changed`, and `timedout`,
 giving the event.
 
 This behavior of this function varies slightly across platforms. See


### PR DESCRIPTION
When printing a FileEvent the user sees a text in the format `"path" => FileWatching.FileEvent(bool, bool, bool)` and by reading the documentation the user expect the three booleans to correspond to `changed`, `renamed`, `timedout` while instead the correct order is `renamed`, `changed`, `timedout`. This is just a correction to that.