### PR TITLE
improve type stability of `handle_message(logger, ...`

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -671,7 +671,7 @@ function handle_message(logger::SimpleLogger, level::LogLevel, message, _module,
         remaining > 0 || return
     end
     buf = IOBuffer()
-    stream = logger.stream
+    stream::IO = logger.stream
     if !(isopen(stream)::Bool)
         stream = stderr
     end

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -117,7 +117,7 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
     # Generate a text representation of the message and all key value pairs,
     # split into lines.
     msglines = [(indent=0, msg=l) for l in split(chomp(convert(String, string(message))::String), '\n')]
-    stream = logger.stream
+    stream::IO = logger.stream
     if !(isopen(stream)::Bool)
         stream = stderr
     end


### PR DESCRIPTION
I improved type stability to fix some invalidations. This is based on the following code:

```julia
julia> import Pkg; Pkg.activate(temp=true); Pkg.add("HTTP")

julia> using SnoopCompileCore; invalidations = @snoopr(using HTTP); using SnoopCompile

julia> length(uinvalidated(invalidations))
752

julia> trees = invalidation_trees(invalidations)
...
inserting write(ctx::MbedTLS.MD, buf::Vector{UInt8}) in MbedTLS at ~/.julia/packages/MbedTLS/yELM7/src/md.jl:138 invalidated:
...
                 20: signature Tuple{typeof(write), Any, Vector{UInt8}} triggered MethodInstance for Logging.var"#handle_message#3"(::Base.Pairs{Symbol, _A, Tuple{Symbol}, NamedTuple{names, T}} where {_A, names, T<:Tuple{Vararg{Any, N}}}, ::typeof(Base.CoreLogging.handle_message), ::Logging.ConsoleLogger, ::Base.CoreLogging.LogLevel, ::LazyString, ::Module, ::Symbol, ::Symbol, ::String, ::Int64) (3 children)
                 21: signature Tuple{typeof(write), Any, Vector{UInt8}} triggered MethodInstance for Logging.var"#handle_message#3"(::Base.Pairs{Symbol, _A, Tuple{Symbol}, NamedTuple{names, T}} where {_A, names, T<:Tuple{Vararg{Any, N}}}, ::typeof(Base.CoreLogging.handle_message), ::Logging.ConsoleLogger, ::Base.CoreLogging.LogLevel, ::String, ::Module, ::Symbol, ::Symbol, ::String, ::Int64) (3 children)
                 22: signature Tuple{typeof(write), Any, Vector{UInt8}} triggered MethodInstance for Logging.var"#handle_message#3"(::Base.Pairs{Symbol, V, Tuple{Vararg{Symbol, N}}, NamedTuple{names, T}} where {V, N, names, T<:Tuple{Vararg{Any, N}}}, ::typeof(Base.CoreLogging.handle_message), ::Logging.ConsoleLogger, ::Base.CoreLogging.LogLevel, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) (29 children)
                 23: signature Tuple{typeof(write), Any, Vector{UInt8}} triggered MethodInstance for Base.CoreLogging.var"#handle_message#2"(::Base.Pairs{Symbol, V, Tuple{Vararg{Symbol, N}}, NamedTuple{names, T}} where {V, N, names, T<:Tuple{Vararg{Any, N}}}, ::typeof(Base.CoreLogging.handle_message), ::Base.CoreLogging.SimpleLogger, ::Base.CoreLogging.LogLevel, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) (123 children)
                 24: signature Tuple{typeof(write), Any, Vector{UInt8}} triggered MethodInstance for Base.CoreLogging.var"#handle_message#2"(::Base.Pairs{Symbol, _A, Tuple{Symbol}, NamedTuple{names, T}} where {_A, names, T<:Tuple{Vararg{Any, N}}}, ::typeof(Base.CoreLogging.handle_message), ::Base.CoreLogging.SimpleLogger, ::Base.CoreLogging.LogLevel, ::LazyString, ::Module, ::Symbol, ::Symbol, ::String, ::Int64) (1106 children)

```

With this PR on top of the current `release-1.8` branch:

```julia
julia> length(uinvalidated(invalidations))
22

julia> trees = invalidation_trees(invalidations)
2-element Vector{SnoopCompile.MethodInvalidations}:
 inserting joinpath(uri::URIs.URI, parts::String...) in URIs at ~/.julia/packages/URIs/JmxRD/src/URIs.jl:554 invalidated:
   mt_backedges: 1: signature Tuple{typeof(joinpath), Any, String} triggered MethodInstance for Artifacts.jointail(::Any, ::String) (1 children)
   6 mt_cache

 inserting write(bio::OpenSSL.BIO, out_data) in OpenSSL at ~/.julia/packages/OpenSSL/flREB/src/OpenSSL.jl:1544 invalidated:
   mt_backedges: 1: signature Tuple{typeof(write), Any, String} triggered MethodInstance for Base.create_expr_cache(::Base.PkgId, ::String, ::String, ::Vector{Pair{Base.PkgId, UInt64}}, ::IOBuffer, ::Base.DevNull) (1 children)
                 2: signature Tuple{typeof(write), Any, String} triggered MethodInstance for Base.create_expr_cache(::Base.PkgId, ::String, ::String, ::Vector{Pair{Base.PkgId, UInt64}}, ::IO, ::IO) (21 children)
   9 mt_cache
```

CC @quinnj 