### PR TITLE
Precompile correct invoke-targets

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -2556,7 +2556,8 @@ static void jl_verify_edges(jl_array_t *targets, jl_array_t **pvalids)
     jl_array_t *valids = jl_alloc_array_1d(jl_array_uint8_type, l);
     memset(jl_array_data(valids), 1, l);
     jl_value_t *loctag = NULL, *matches = NULL;
-    JL_GC_PUSH2(&loctag, &matches);
+    jl_methtable_t *mt = NULL;
+    JL_GC_PUSH3(&loctag, &matches, &mt);
     *pvalids = valids;
     size_t world = jl_get_world_counter();
     for (i = 0; i < l; i++) {
@@ -2602,7 +2603,7 @@ static void jl_verify_edges(jl_array_t *targets, jl_array_t **pvalids)
                 }
             }
         } else {
-            jl_methtable_t *mt = jl_method_get_table(((jl_method_instance_t*)callee)->def.method);
+            mt = jl_method_get_table(((jl_method_instance_t*)callee)->def.method);
             size_t min_world, max_world;
             matches = jl_gf_invoke_lookup_worlds(invokesig, (jl_value_t*)mt, world, &min_world, &max_world);
             if (matches == jl_nothing || expected != (jl_value_t*)((jl_method_match_t*)matches)->method) {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -723,7 +723,7 @@ JL_DLLEXPORT jl_value_t *jl_argument_datatype(jl_value_t *argt JL_PROPAGATES_ROO
 JL_DLLEXPORT jl_methtable_t *jl_method_table_for(
     jl_value_t *argtypes JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_methtable_t *jl_method_get_table(
-    jl_method_t *method) JL_NOTSAFEPOINT;
+    jl_method_t *method JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
 jl_methtable_t *jl_argument_method_table(jl_value_t *argt JL_PROPAGATES_ROOT);
 
 JL_DLLEXPORT int jl_pointer_egal(jl_value_t *t);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -716,6 +716,7 @@ jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value
 jl_value_t *jl_gf_invoke(jl_value_t *types, jl_value_t *f, jl_value_t **args, size_t nargs);
 JL_DLLEXPORT jl_value_t *jl_matching_methods(jl_tupletype_t *types, jl_value_t *mt, int lim, int include_ambiguous,
                                              size_t world, size_t *min_valid, size_t *max_valid, int *ambig);
+JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup_worlds(jl_value_t *types, jl_value_t *mt, size_t world, size_t *min_world, size_t *max_world);
 
 JL_DLLEXPORT jl_datatype_t *jl_first_argument_datatype(jl_value_t *argtypes JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_argument_datatype(jl_value_t *argt JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;


### PR DESCRIPTION
This fixes backedge-based invalidation when a precompiled `invoke` is followed by loading a package that adds new specializations  for the `invoke`d function. An example is LowRankApprox.jl, where FillArrays adds a specialization to `unique` which `invoke`s `unique` for an arbitrary `itr`. CC @jishnub.

~~This also allows one to set `intersections=false` so that one can compute matching methods for `invoke` calls.~~
