### PR TITLE
improve inferrability of `sort!`

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1160,9 +1160,9 @@ function sortperm(A::AbstractArray;
         n = length(A)
         if n > 1
             min, max = extrema(A)
-            (diff, o1) = sub_with_overflow(max, min)::Tuple{Any, Bool}
-            (rangelen, o2) = add_with_overflow(diff, oneunit(diff))::Tuple{Any, Bool}
-            if !o1 && !o2 && rangelen < div(n,2)
+            (diff, o1) = sub_with_overflow(max, min)
+            (rangelen, o2) = add_with_overflow(diff, oneunit(diff))
+            if !(o1 || o2)::Bool && rangelen < div(n,2)
                 return sortperm_int_range(A, rangelen, min)
             end
         end

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1160,8 +1160,8 @@ function sortperm(A::AbstractArray;
         n = length(A)
         if n > 1
             min, max = extrema(A)
-            (diff, o1) = sub_with_overflow(max, min)
-            (rangelen, o2) = add_with_overflow(diff, oneunit(diff))
+            (diff, o1) = sub_with_overflow(max, min)::Tuple{Any, Bool}
+            (rangelen, o2) = add_with_overflow(diff, oneunit(diff))::Tuple{Any, Bool}
             if !o1 && !o2 && rangelen < div(n,2)
                 return sortperm_int_range(A, rangelen, min)
             end


### PR DESCRIPTION
I improved type stability to fix some invalidations. This is based on the following code:

```julia
julia> import Pkg; Pkg.activate(temp=true); Pkg.add("Static")

julia> using SnoopCompileCore; invalidations = @snoopr(using Static); using SnoopCompile

julia> length(uinvalidated(invalidations))
195

julia> trees = invalidation_trees(invalidations)
...
 inserting !(::False) in Static at ~/.julia/packages/Static/maaLb/src/Static.jl:428 invalidated:
 ...
                 34: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.Sort.var"#sort!#8"(::Base.Sort.Algorithm, ::typeof(isless), ::Function, ::Nothing, ::Base.Order.ForwardOrdering, ::typeof(sort!), ::Vector) (10 children)
...
                 37: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.Sort.var"#sort!#8"(::Base.Sort.Algorithm, ::typeof(isless), ::typeof(identity), ::Nothing, ::Base.Order.ForwardOrdering, ::typeof(sort!), ::AbstractVector) (15 children)
...
                 39: signature Tuple{typeof(!), Any} triggered MethodInstance for Base.Sort.var"#sort!#8"(::Base.Sort.Algorithm, ::typeof(isless), ::typeof(identity), ::Nothing, ::Base.Order.ForwardOrdering, ::typeof(sort!), ::Vector) (45 children)
```

With this PR on top of the current `release-1.8` branch:

```julia
julia> length(uinvalidated(invalidations))
132
```

and all invalidations in `sort!` are gone.

This requires a manual backport (which is relatively straightforward) since quite a bit changed in sort.jl - searching for all instances of `sub_with_overflow`/`add_with_overflow` in sort.jl and applying the change there.