### PR TITLE
gf: detect more ambiguities

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -3314,12 +3314,8 @@ static jl_value_t *ml_matches(jl_methtable_t *mt,
                                 if (!jl_type_morespecific((jl_value_t*)m->sig, (jl_value_t*)m2->sig) &&
                                     !jl_type_morespecific((jl_value_t*)m2->sig, (jl_value_t*)m->sig)) {
                                     ambig1 = 1;
+                                    break;
                                 }
-                            }
-                            else {
-                                // otherwise some aspect of m is not ambiguous
-                                ambig1 = 0;
-                                break;
                             }
                         }
                     }


### PR DESCRIPTION
As long as we find at least one other method that conflicts fully, we know they will exist together for all subtypes, and always be ambiguous for all subtypes too. This is already the algorithm used by method insertion to decide if the new method is ambiguous with a "missing" method.

Fix #46601