### PR TITLE
Don't error when transposing an empty buffer

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1101,7 +1101,7 @@ end
 
 function edit_transpose_chars(buf::IOBuffer)
     # Moving left but not transpoing anything is intentional, and matches Emacs's behavior
-    eof(buf) && char_move_left(buf)
+    eof(buf) && position(buf) !== 0 && char_move_left(buf)
     position(buf) == 0 && return false
     char_move_left(buf)
     pos = position(buf)

--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -376,6 +376,8 @@ let buf = IOBuffer()
     LineEdit.edit_transpose_chars(buf)
     @test content(buf) == "βγαδε"
 
+
+    # Transposing a one-char buffer should behave like Emacs
     seek(buf, 0)
     @inferred(LineEdit.edit_clear(buf))
     edit_insert(buf, "a")
@@ -384,6 +386,13 @@ let buf = IOBuffer()
     seekend(buf)
     LineEdit.edit_transpose_chars(buf)
     @test content(buf) == "a"
+    @test position(buf) == 0
+
+    # Transposing an empty buffer shouldn't implode
+    seek(buf, 0)
+    LineEdit.edit_clear(buf)
+    LineEdit.edit_transpose_chars(buf)
+    @test content(buf) == ""
     @test position(buf) == 0
 end
 


### PR DESCRIPTION
This fixes an issue where transposing an empty buffer in the REPL with ^T would cause an error.

Fixes #45417—for real this time! (See also #45420, which introduced this bug.)