### PR TITLE
IncrementalCompact: always show the separator.

### DIFF
--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -855,13 +855,14 @@ function show_ir(io::IO, compact::IncrementalCompact, config::IRShowConfig=defau
     end
 
     # Print uncompacted nodes from the original IR
+
+    # print a separator
     stmts = compact.ir.stmts
+    indent = length(string(length(stmts)))
+    # config.line_info_preprinter(io, "", compact.idx)
+    printstyled(io, "─"^(width-indent-1), '\n', color=:red)
+
     pop_new_node! = new_nodes_iter(compact.ir)
-    if compact.idx < length(stmts)
-        indent = length(string(length(stmts)))
-        # config.line_info_preprinter(io, "", compact.idx)
-        printstyled(io, "─"^(width-indent-1), '\n', color=:red)
-    end
     let io = IOContext(io, :maxssaid=>length(compact.ir.stmts))
         show_ir_stmts(io, compact.ir, compact.idx:length(stmts), config, used_uncompacted, cfg, bb_idx; pop_new_node!)
     end


### PR DESCRIPTION
There was an off-by-one error, but always showing the separator is clearer IMO, and consistent with how it's shown at the top when nothing has been compacted yet.

Test:

```julia
foo(i) = i == 1 ? 1 : 2

ir = only(Base.code_ircode(foo, (Int,)))[1]
compact = Core.Compiler.IncrementalCompact(ir)
println("Initial state:\n$compact")

state = Core.Compiler.iterate(compact)
while state !== nothing
    println("Iterating:\n$compact")
    state = Core.Compiler.iterate(compact, state[2])
end
```

Before:

```
Initial state:
──────────────────────────────────────────────────────────────────────────────
1 1 ─ %1 = (_2 === 1)::Bool
  └──      goto #3 if not %1
  2 ─      return 1
  3 ─      return 2

Current:
1 1 ─ %1 = (_2 === 1)::Bool
──────────────────────────────────────────────────────────────────────────────
  └──      goto #3 if not %1
  2 ─      return 1
  3 ─      return 2

Iterating:
1 1 ─ %1 = (_2 === 1)::Bool
  └──      goto #3 if not %1
──────────────────────────────────────────────────────────────────────────────
  2 ─      return 1
  3 ─      return 2

Iterating:
1 1 ─ %1 = (_2 === 1)::Bool
  └──      goto #3 if not %1
  2 ─      return 1
  3 ─      return 2

Iterating:
1 1 ─ %1 = (_2 === 1)::Bool
  └──      goto #3 if not %1
  2 ─      return 1
  3 ─      return 2
```

Proposed:

```
Initial state:
──────────────────────────────────────────────────────────────────────────────
19 1 ─ %1 = (_2 === 1)::Bool
   └──      goto #3 if not %1
   2 ─      return 1
   3 ─      return 2

Iterating:
19 1 ─ %1 = (_2 === 1)::Bool
──────────────────────────────────────────────────────────────────────────────
   └──      goto #3 if not %1
   2 ─      return 1
   3 ─      return 2

Iterating:
19 1 ─ %1 = (_2 === 1)::Bool
   └──      goto #3 if not %1
──────────────────────────────────────────────────────────────────────────────
   2 ─      return 1
   3 ─      return 2

Iterating:
19 1 ─ %1 = (_2 === 1)::Bool
   └──      goto #3 if not %1
   2 ─      return 1
──────────────────────────────────────────────────────────────────────────────
   3 ─      return 2

Iterating:
19 1 ─ %1 = (_2 === 1)::Bool
   └──      goto #3 if not %1
   2 ─      return 1
   3 ─      return 2
──────────────────────────────────────────────────────────────────────────────
```