### PR TITLE
IncrementalCompact: fix display of just-compacted new nodes

### DIFF
--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -675,7 +675,7 @@ function show_ir_stmt(io::IO, code::Union{IRCode, CodeInfo, IncrementalCompact},
     return bb_idx
 end
 
-function _new_nodes_iter(stmts, new_nodes, new_nodes_info)
+function _new_nodes_iter(stmts, new_nodes, new_nodes_info, new_nodes_idx)
     new_nodes_perm = filter(i -> isassigned(new_nodes.inst, i), 1:length(new_nodes))
     sort!(new_nodes_perm, by = x -> (x = new_nodes_info[x]; (x.pos, x.attach_after)))
     perm_idx = Ref(1)
@@ -683,7 +683,7 @@ function _new_nodes_iter(stmts, new_nodes, new_nodes_info)
     return function (idx::Int)
         perm_idx[] <= length(new_nodes_perm) || return nothing
         node_idx = new_nodes_perm[perm_idx[]]
-        if new_nodes_info[node_idx].pos != idx
+        if node_idx < new_nodes_idx || new_nodes_info[node_idx].pos != idx
             return nothing
         end
         perm_idx[] += 1
@@ -695,18 +695,18 @@ function _new_nodes_iter(stmts, new_nodes, new_nodes_info)
     end
 end
 
-function new_nodes_iter(ir::IRCode)
+function new_nodes_iter(ir::IRCode, new_nodes_idx=1)
     stmts = ir.stmts
     new_nodes = ir.new_nodes.stmts
     new_nodes_info = ir.new_nodes.info
-    return _new_nodes_iter(stmts, new_nodes, new_nodes_info)
+    return _new_nodes_iter(stmts, new_nodes, new_nodes_info, new_nodes_idx)
 end
 
 function new_nodes_iter(compact::IncrementalCompact)
     stmts = compact.result
     new_nodes = compact.new_new_nodes.stmts
     new_nodes_info = compact.new_new_nodes.info
-    return _new_nodes_iter(stmts, new_nodes, new_nodes_info)
+    return _new_nodes_iter(stmts, new_nodes, new_nodes_info, 1)
 end
 
 # print only line numbers on the left, some of the method names and nesting depth on the right
@@ -864,7 +864,7 @@ function show_ir(io::IO, compact::IncrementalCompact, config::IRShowConfig=defau
     # config.line_info_preprinter(io, "", compact.idx)
     printstyled(io, "─"^(width-indent-1), '\n', color=:red)
 
-    pop_new_node! = new_nodes_iter(compact.ir)
+    pop_new_node! = new_nodes_iter(compact.ir, compact.new_nodes_idx)
     maxssaid = length(compact.ir.stmts) + Core.Compiler.length(compact.ir.new_nodes)
     let io = IOContext(io, :maxssaid=>maxssaid)
         show_ir_stmts(io, compact.ir, compact.idx:length(stmts), config, used_uncompacted, cfg, bb_idx; pop_new_node!)

--- a/test/show.jl
+++ b/test/show.jl
@@ -2448,3 +2448,40 @@ end
     end
     @test contains(str, "%1 = \e[31m%7")
 end
+
+@testset "issue #46947: IncrementalCompact double display of just-compacted nodes" begin
+    # get some IR
+    foo(i) = i == 1 ? 1 : 2
+    ir = only(Base.code_ircode(foo, (Int,)))[1]
+
+    instructions = length(ir.stmts)
+    lines_shown(obj) = length(findall('\n', sprint(io->show(io, obj))))
+    @test lines_shown(ir) == instructions
+
+    # insert a couple of instructions
+    let inst = Core.Compiler.NewInstruction(Expr(:identity, 1), Nothing)
+        Core.Compiler.insert_node!(ir, 2, inst)
+    end
+    let inst = Core.Compiler.NewInstruction(Expr(:identity, 2), Nothing)
+        Core.Compiler.insert_node!(ir, 2, inst)
+    end
+    let inst = Core.Compiler.NewInstruction(Expr(:identity, 3), Nothing)
+        Core.Compiler.insert_node!(ir, 4, inst)
+    end
+    instructions += 3
+    @test lines_shown(ir) == instructions
+
+    # compact the IR, ensuring we always show the same number of lines
+    # (the instructions + a separator line)
+    compact = Core.Compiler.IncrementalCompact(ir)
+    @test lines_shown(compact) == instructions + 1
+    state = Core.Compiler.iterate(compact)
+    while state !== nothing
+        @test lines_shown(compact) == instructions + 1
+        state = Core.Compiler.iterate(compact, state[2])
+    end
+    @test lines_shown(compact) == instructions + 1
+
+    ir = Core.Compiler.complete(compact)
+    @test lines_shown(compact) == instructions + 1
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/46947

As far as I understand the exact problem (and IncrementalCompact design), the problem is that the printer displays statements from `begin:compact.result_idx-1` and `compact.idx:end`, however when the iterator compacts a node from `compact.ir.new_nodes`, `compact.idx` isn't incremented, but only `compact.result_idx` and `compact.new_nodes_idx` are. That results in the newly compacted node being shown twice. We can't just increment `compact.idx` to avoid that, because then it'd miss the following instruction too (as for a given index it prints both new instructions from `ir.new_nodes` and the instruction itself).

So instead, pass `new_nodes_idx` down to `new_nodes_iter` so that it can appropriately handle that situation. To also handle the case where we have multiple inserted nodes at a given index, don't just bail from `new_nodes_iter` when we encounter an already-compacted node, but proceed to the next local index.

Test case:

```julia
foo(i) = i == 1 ? 1 : 2

ir = only(Base.code_ircode(foo, (Int,)))[1]
println("original IR:")
display(ir)

inst = Core.Compiler.NewInstruction(Expr(:identity, 1), Nothing)
node = Core.Compiler.insert_node!(ir, 2, inst)

inst = Core.Compiler.NewInstruction(Expr(:identity, 2), Nothing)
node = Core.Compiler.insert_node!(ir, 2, inst)

inst = Core.Compiler.NewInstruction(Expr(:identity, 3), Nothing)
node = Core.Compiler.insert_node!(ir, 4, inst)

println("inserted nodes:")
display(ir)

compact = Core.Compiler.IncrementalCompact(ir)
println("incremental compact:")
display(compact)

count = 1
state = Core.Compiler.iterate(compact)
while state !== nothing
    println("incremental compact (iterating):")
    display(compact)
    state = Core.Compiler.iterate(compact, state[2])
    count += 1
end

println("incremental compact (iterated):")
display(compact)

ir = Core.Compiler.complete(compact)

println("compacted ir:")
display(ir)
```

```
original IR:
1 1 ─ %1 = (_2 === 1)::Bool
  └──      goto #3 if not %1
  2 ─      return 1
  3 ─      return 2

inserted nodes:
1 1 ─ %1 = (_2 === 1)::Bool
  │        $(Expr(:identity, 1))::Nothing
  │        $(Expr(:identity, 2))::Nothing
  └──      goto #3 if not %1
  2 ─      return 1
  3 ─      $(Expr(:identity, 3))::Nothing
  └──      return 2

incremental compact:
------------------------------------------
1 1 ─ %1 = (_2 === 1)::Bool
  │        $(Expr(:identity, 1))::Nothing
  │        $(Expr(:identity, 2))::Nothing
  └──      goto #3 if not %1
  2 ─      return 1
  3 ─      $(Expr(:identity, 3))::Nothing
  └──      return 2

incremental compact (iterating):
1 1 ─ %1 = (_2 === 1)::Bool
------------------------------------------
  │        $(Expr(:identity, 1))::Nothing
  │        $(Expr(:identity, 2))::Nothing
  └──      goto #3 if not %1
  2 ─      return 1
  3 ─      $(Expr(:identity, 3))::Nothing
  └──      return 2

incremental compact (iterating):
1 1 ─ %1 = (_2 === 1)::Bool
  └──      $(Expr(:identity, 1))::Nothing
------------------------------------------
  │        $(Expr(:identity, 2))::Nothing
  │        goto #3 if not %1
  2 ─      return 1
  3 ─      $(Expr(:identity, 3))::Nothing
  └──      return 2

incremental compact (iterating):
1 1 ─ %1 = (_2 === 1)::Bool
  └──      $(Expr(:identity, 1))::Nothing
  2 ─      $(Expr(:identity, 2))::Nothing
------------------------------------------
  │        goto #3 if not %1
  │        return 1
  3 ─      $(Expr(:identity, 3))::Nothing
  └──      return 2

incremental compact (iterating):
1 1 ─ %1 = (_2 === 1)::Bool
  │        $(Expr(:identity, 1))::Nothing
  │        $(Expr(:identity, 2))::Nothing
  └──      goto #3 if not %1
------------------------------------------
  │        return 1
  │        $(Expr(:identity, 3))::Nothing
  └──      return 2

incremental compact (iterating):
1 1 ─ %1 = (_2 === 1)::Bool
  │        $(Expr(:identity, 1))::Nothing
  │        $(Expr(:identity, 2))::Nothing
  └──      goto #3 if not %1
  2 ─      return 1
------------------------------------------
  │        $(Expr(:identity, 3))::Nothing
  │        return 2

incremental compact (iterating):
1 1 ─ %1 = (_2 === 1)::Bool
  │        $(Expr(:identity, 1))::Nothing
  │        $(Expr(:identity, 2))::Nothing
  └──      goto #3 if not %1
  2 ─      return 1
  3 ─      $(Expr(:identity, 3))::Nothing
------------------------------------------
  │        return 2

incremental compact (iterating):
1 1 ─ %1 = (_2 === 1)::Bool
  │        $(Expr(:identity, 1))::Nothing
  │        $(Expr(:identity, 2))::Nothing
  └──      goto #3 if not %1
  2 ─      return 1
  3 ─      $(Expr(:identity, 3))::Nothing
  └──      return 2
------------------------------------------

incremental compact (iterated):
1 1 ─ %1 = (_2 === 1)::Bool
  │        $(Expr(:identity, 1))::Nothing
  │        $(Expr(:identity, 2))::Nothing
  └──      goto #3 if not %1
  2 ─      return 1
  3 ─      $(Expr(:identity, 3))::Nothing
  └──      return 2
------------------------------------------

compacted ir:
1 1 ─ %1 = (_2 === 1)::Bool
  │        $(Expr(:identity, 1))::Nothing
  │        $(Expr(:identity, 2))::Nothing
  └──      goto #3 if not %1
  2 ─      return 1
  3 ─      $(Expr(:identity, 3))::Nothing
  └──      return 2
```