### PR TITLE
Revert "Inlining: Remove outdated code path for GlobalRef movement"

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -699,6 +699,18 @@ function batch_inline!(todo::Vector{Pair{Int, Any}}, ir::IRCode, linetable::Vect
                     compact.active_result_bb -= 1
                     refinish = true
                 end
+                # It is possible for GlobalRefs and Exprs to be in argument position
+                # at this point in the IR, though in that case they are required
+                # to be effect-free. However, we must still move them out of argument
+                # position, since `Argument` is allowed in PhiNodes, but `GlobalRef`
+                # and `Expr` are not, so a substitution could anger the verifier.
+                for aidx in 1:length(argexprs)
+                    aexpr = argexprs[aidx]
+                    if isa(aexpr, Expr) || isa(aexpr, GlobalRef)
+                        ninst = effect_free(NewInstruction(aexpr, argextype(aexpr, compact), compact.result[idx][:line]))
+                        argexprs[aidx] = insert_node_here!(compact, ninst)
+                    end
+                end
                 if isa(item, InliningTodo)
                     compact.ssa_rename[old_idx] = ir_inline_item!(compact, idx, argexprs, linetable, item, boundscheck, state.todo_bbs)
                 elseif isa(item, UnionSplit)

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -2,7 +2,7 @@
 
 function maybe_show_ir(ir::IRCode)
     if isdefined(Core, :Main)
-        invokelatest(Core.Main.Base.display, ir)
+        Core.Main.Base.display(ir)
     end
 end
 

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1709,10 +1709,3 @@ let src = code_typed1((Any,)) do x
     end
     @test count(iscall((src, f_union_unmatched)), src.code) == 0
 end
-
-# Test that inlining doesn't unnecesarily move things to stmt position
-@noinline f_no_inline_invoke(x::Union{Symbol, Nothing}=nothing) = Base.donotdelete(x)
-g_no_inline_invoke(x) = f_no_inline_invoke(x)
-let src = code_typed1(g_no_inline_invoke, Tuple{Union{Symbol, Nothing}})
-    @test count(x->isa(x, GlobalRef), src.code) == 0
-end


### PR DESCRIPTION
Reverts JuliaLang/julia#46880 (@keno). This seems to be exposing (or less likely actually causing) some problems with GC rooting, dead-code elimination, and/or valid ir:
https://github.com/JuliaLang/julia/issues/46940
https://github.com/JuliaLang/julia/issues/46943