### PR TITLE
make `CallInfo` propagate effects

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -132,7 +132,7 @@ end
 function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
                                   arginfo::ArgInfo, si::StmtInfo, @nospecialize(atype),
                                   sv::IRCode, max_methods::Int)
-    return CallMeta(Any, Effects(), NoCallInfo())
+    return CallMeta(Any, NoCallInfo())
 end
 
 function collect_limitations!(@nospecialize(typ), ::IRCode)

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -888,7 +888,7 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing, InliningState} = nothin
             3 <= length(stmt.args) <= 5 || continue
             info = compact[SSAValue(idx)][:info]
             if isa(info, FinalizerInfo)
-                is_finalizer_inlineable(info.effects) || continue
+                is_finalizer_inlineable(info.finalizer_effects) || continue
             else
                 # Inlining performs legality checks on the finalizer to determine
                 # whether or not we may inline it. If so, it appends extra arguments
@@ -1234,7 +1234,7 @@ function try_resolve_finalizer!(ir::IRCode, idx::Int, finalizer_idx::Int, defuse
 
     finalizer_stmt = ir[SSAValue(finalizer_idx)][:inst]
     argexprs = Any[finalizer_stmt.args[2], finalizer_stmt.args[3]]
-    flags = info isa FinalizerInfo ? flags_for_effects(info.effects) : IR_FLAG_NULL
+    flags = info isa FinalizerInfo ? flags_for_effects(info.finalizer_effects) : IR_FLAG_NULL
     if length(finalizer_stmt.args) >= 4
         inline = finalizer_stmt.args[4]
         if inline === nothing

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -10,11 +10,15 @@ and any additional information (`call.info`) for a given generic call.
 """
 struct CallMeta
     rt::Any
-    effects::Effects
     info::CallInfo
+    CallMeta(@nospecialize(rt), @nospecialize(info::CallInfo)) = new(rt, info)
 end
 
-struct NoCallInfo <: CallInfo end
+struct NoCallInfo <: CallInfo
+    effects::Effects
+end
+NoCallInfo() = NoCallInfo(Effects())
+call_effects_impl(info::NoCallInfo) = info.effects
 
 """
     info::MethodMatchInfo <: CallInfo
@@ -26,10 +30,12 @@ not a call to a generic function.
 """
 struct MethodMatchInfo <: CallInfo
     results::MethodLookupResult
+    effects::Effects
 end
 nsplit_impl(info::MethodMatchInfo) = 1
 getsplit_impl(info::MethodMatchInfo, idx::Int) = (@assert idx == 1; info.results)
 getresult_impl(::MethodMatchInfo, ::Int) = nothing
+call_effects_impl(info::MethodMatchInfo) = info.effects
 
 """
     info::UnionSplitInfo <: CallInfo
@@ -41,20 +47,13 @@ each partition (`info.matches::Vector{MethodMatchInfo}`).
 This info is illegal on any statement that is not a call to a generic function.
 """
 struct UnionSplitInfo <: CallInfo
-    matches::Vector{MethodMatchInfo}
-end
-
-nmatches(info::MethodMatchInfo) = length(info.results)
-function nmatches(info::UnionSplitInfo)
-    n = 0
-    for mminfo in info.matches
-        n += nmatches(mminfo)
-    end
-    return n
+    matches::Vector{MethodLookupResult}
+    effects::Effects
 end
 nsplit_impl(info::UnionSplitInfo) = length(info.matches)
-getsplit_impl(info::UnionSplitInfo, idx::Int) = getsplit_impl(info.matches[idx], 1)
+getsplit_impl(info::UnionSplitInfo, idx::Int) = info.matches[idx]
 getresult_impl(::UnionSplitInfo, ::Int) = nothing
+call_effects_impl(info::UnionSplitInfo) = info.effects
 
 struct ConstPropResult
     result::InferenceResult
@@ -84,12 +83,13 @@ In addition to the original call information `info.call`, this info also keeps t
 of constant inference `info.results::Vector{Union{Nothing,ConstResult}}`.
 """
 struct ConstCallInfo <: CallInfo
-    call::Union{MethodMatchInfo,UnionSplitInfo}
+    call::CallInfo
     results::Vector{Union{Nothing,ConstResult}}
 end
 nsplit_impl(info::ConstCallInfo) = nsplit(info.call)
 getsplit_impl(info::ConstCallInfo, idx::Int) = getsplit(info.call, idx)
 getresult_impl(info::ConstCallInfo, idx::Int) = info.results[idx]
+call_effects_impl(info::ConstCallInfo) = call_effects(info.call)
 
 """
     info::MethodResultPure <: CallInfo
@@ -101,10 +101,11 @@ by calling an `@pure` function).
 struct MethodResultPure <: CallInfo
     info::CallInfo
 end
-let instance = MethodResultPure(NoCallInfo())
+let instance = MethodResultPure(NoCallInfo(EFFECTS_TOTAL))
     global MethodResultPure
     MethodResultPure() = instance
 end
+call_effects_impl(info::MethodResultPure) = call_effects(info.info)
 
 """
     ainfo::AbstractIterationInfo
@@ -116,7 +117,6 @@ struct AbstractIterationInfo
     each::Vector{CallMeta}
     complete::Bool
 end
-
 const MaybeAbstractIterationInfo = Union{Nothing, AbstractIterationInfo}
 
 """
@@ -131,10 +131,11 @@ not an `_apply_iterate` call.
 """
 struct ApplyCallInfo <: CallInfo
     # The info for the call itself
-    call::Any
+    call::CallInfo
     # AbstractIterationInfo for each argument, if applicable
     arginfo::Vector{MaybeAbstractIterationInfo}
 end
+call_effects_impl(info::ApplyCallInfo) = call_effects(info.call)
 
 """
     info::UnionSplitApplyCallInfo <: CallInfo
@@ -144,6 +145,13 @@ This info is illegal on any statement that is not an `_apply_iterate` call.
 """
 struct UnionSplitApplyCallInfo <: CallInfo
     infos::Vector{ApplyCallInfo}
+end
+function call_effects_impl(info::UnionSplitApplyCallInfo)
+    all_effects = EFFECTS_TOTAL
+    for ainfo in info.infos
+        all_effects = merge_effects(all_effects, call_effects(ainfo))
+    end
+    return all_effects
 end
 
 """
@@ -156,10 +164,12 @@ Optionally keeps `info.result::InferenceResult` that keeps constant information.
 struct InvokeCallInfo <: CallInfo
     match::MethodMatch
     result::Union{Nothing,ConstResult}
+    effects::Effects
 end
+call_effects_impl(info::InvokeCallInfo) = info.effects
 
 """
-    info::OpaqueClosureCallInfo
+    info::OpaqueClosureCallInfo <: CallInfo
 
 Represents a resolved call of opaque closure, carrying the `info.match::MethodMatch` of
 the method that has been processed.
@@ -168,7 +178,9 @@ Optionally keeps `info.result::InferenceResult` that keeps constant information.
 struct OpaqueClosureCallInfo <: CallInfo
     match::MethodMatch
     result::Union{Nothing,ConstResult}
+    effects::Effects
 end
+call_effects_impl(info::OpaqueClosureCallInfo) = info.effects
 
 """
     info::OpaqueClosureCreateInfo <: CallInfo
@@ -185,6 +197,7 @@ struct OpaqueClosureCreateInfo <: CallInfo
         return new(unspec)
     end
 end
+call_effects_impl(::OpaqueClosureCreateInfo) = Effects()
 
 # Stmt infos that are used by external consumers, but not by optimization.
 # These are not produced by default and must be explicitly opted into by
@@ -194,12 +207,13 @@ end
     info::ReturnTypeCallInfo <: CallInfo
 
 Represents a resolved call of `Core.Compiler.return_type`.
-`info.call` wraps the info corresponding to the call that `Core.Compiler.return_type` call
-was supposed to analyze.
+`info.call` wraps the call information corresponding to the call that
+the `Core.Compiler.return_type` call was supposed to analyze.
 """
 struct ReturnTypeCallInfo <: CallInfo
     info::CallInfo
 end
+call_effects_impl(::ReturnTypeCallInfo) = EFFECTS_TOTAL
 
 """
     info::FinalizerInfo <: CallInfo
@@ -208,9 +222,10 @@ Represents the information of a potential (later) call to the finalizer on the g
 object type.
 """
 struct FinalizerInfo <: CallInfo
-    info::CallInfo   # the callinfo for the finalizer call
-    effects::Effects # the effects for the finalizer call
+    info::CallInfo             # the callinfo for the finalizer call
+    finalizer_effects::Effects # the effects for the finalizer call
 end
+call_effects_impl(::FinalizerInfo) = Effects()
 
 """
     info::ModifyFieldInfo <: CallInfo
@@ -221,5 +236,6 @@ Represents a resolved all of `modifyfield!(obj, name, op, x, [order])`.
 struct ModifyFieldInfo <: CallInfo
     info::CallInfo # the callinfo for the `op(getfield(obj, name), x)` call
 end
+call_effects_impl(::ModifyFieldInfo) = Effects()
 
 @specialize

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1310,10 +1310,10 @@ end
 function abstract_modifyfield!(interp::AbstractInterpreter, argtypes::Vector{Any}, si::StmtInfo, sv::InferenceState)
     nargs = length(argtypes)
     if !isempty(argtypes) && isvarargtype(argtypes[nargs])
-        nargs - 1 <= 6 || return CallMeta(Bottom, EFFECTS_THROWS, NoCallInfo())
+        nargs - 1 <= 6 || return CallMeta(Bottom, NoCallInfo(EFFECTS_THROWS))
         nargs > 3 || return CallMeta(Any, EFFECTS_UNKNOWN, NoCallInfo())
     else
-        5 <= nargs <= 6 || return CallMeta(Bottom, EFFECTS_THROWS, NoCallInfo())
+        5 <= nargs <= 6 || return CallMeta(Bottom, NoCallInfo(EFFECTS_THROWS))
     end
     𝕃ᵢ = typeinf_lattice(interp)
     o = unwrapva(argtypes[2])
@@ -1335,7 +1335,7 @@ function abstract_modifyfield!(interp::AbstractInterpreter, argtypes::Vector{Any
         end
         info = ModifyFieldInfo(callinfo.info)
     end
-    return CallMeta(RT, Effects(), info)
+    return CallMeta(RT, info)
 end
 @nospecs function replacefield!_tfunc(𝕃::AbstractLattice, o, f, x, v, success_order, failure_order)
     return replacefield!_tfunc(𝕃, o, f, x, v)
@@ -2408,7 +2408,7 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
                 if isa(af_argtype, DataType) && af_argtype <: Tuple
                     argtypes_vec = Any[aft, af_argtype.parameters...]
                     if contains_is(argtypes_vec, Union{})
-                        return CallMeta(Const(Union{}), EFFECTS_TOTAL, NoCallInfo())
+                        return CallMeta(Const(Union{}), NoCallInfo(EFFECTS_TOTAL))
                     end
                     #
                     # Run the abstract_call without restricting abstract call
@@ -2422,36 +2422,40 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
                     else
                         call = abstract_call(interp, ArgInfo(nothing, argtypes_vec), si, sv, -1)
                     end
-                    info = verbose_stmt_info(interp) ? MethodResultPure(ReturnTypeCallInfo(call.info)) : MethodResultPure()
+                    if verbose_stmt_info(interp)
+                        info = MethodResultPure(ReturnTypeCallInfo(call.info))
+                    else
+                        info = MethodResultPure(NoCallInfo(EFFECTS_TOTAL))
+                    end
                     rt = widenslotwrapper(call.rt)
                     if isa(rt, Const)
                         # output was computed to be constant
-                        return CallMeta(Const(typeof(rt.val)), EFFECTS_TOTAL, info)
+                        return CallMeta(Const(typeof(rt.val)), info)
                     end
                     rt = widenconst(rt)
                     if rt === Bottom || (isconcretetype(rt) && !iskindtype(rt))
                         # output cannot be improved so it is known for certain
-                        return CallMeta(Const(rt), EFFECTS_TOTAL, info)
+                        return CallMeta(Const(rt), info)
                     elseif isa(sv, InferenceState) && !isempty(sv.pclimitations)
                         # conservatively express uncertainty of this result
                         # in two ways: both as being a subtype of this, and
                         # because of LimitedAccuracy causes
-                        return CallMeta(Type{<:rt}, EFFECTS_TOTAL, info)
+                        return CallMeta(Type{<:rt}, info)
                     elseif (isa(tt, Const) || isconstType(tt)) &&
                         (isa(aft, Const) || isconstType(aft))
                         # input arguments were known for certain
                         # XXX: this doesn't imply we know anything about rt
-                        return CallMeta(Const(rt), EFFECTS_TOTAL, info)
+                        return CallMeta(Const(rt), info)
                     elseif isType(rt)
-                        return CallMeta(Type{rt}, EFFECTS_TOTAL, info)
+                        return CallMeta(Type{rt}, info)
                     else
-                        return CallMeta(Type{<:rt}, EFFECTS_TOTAL, info)
+                        return CallMeta(Type{<:rt}, info)
                     end
                 end
             end
         end
     end
-    return CallMeta(Type, EFFECTS_THROWS, NoCallInfo())
+    return CallMeta(Type, NoCallInfo(EFFECTS_THROWS))
 end
 
 # N.B.: typename maps type equivalence classes to a single value

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -429,9 +429,11 @@ abstract type CallInfo end
 nsplit(info::CallInfo) = nsplit_impl(info)::Union{Nothing,Int}
 getsplit(info::CallInfo, idx::Int) = getsplit_impl(info, idx)::MethodLookupResult
 getresult(info::CallInfo, idx::Int) = getresult_impl(info, idx)
+call_effects(info::CallInfo) = call_effects_impl(info)::Effects
 
 nsplit_impl(::CallInfo) = nothing
 getsplit_impl(::CallInfo, ::Int) = error("unexpected call into `getsplit`")
 getresult_impl(::CallInfo, ::Int) = nothing
+call_effects_impl(::CallInfo) = Effects()
 
 @specialize

--- a/test/compiler/AbstractInterpreter.jl
+++ b/test/compiler/AbstractInterpreter.jl
@@ -303,13 +303,14 @@ end
 CC.nsplit_impl(info::NoinlineCallInfo) = CC.nsplit(info.info)
 CC.getsplit_impl(info::NoinlineCallInfo, idx::Int) = CC.getsplit(info.info, idx)
 CC.getresult_impl(info::NoinlineCallInfo, idx::Int) = CC.getresult(info.info, idx)
+CC.call_effects_impl(info::NoinlineCallInfo) = CC.call_effects(info.info)
 
 function CC.abstract_call(interp::NoinlineInterpreter,
     arginfo::CC.ArgInfo, si::CC.StmtInfo, sv::CC.InferenceState, max_methods::Union{Int,Nothing})
     ret = @invoke CC.abstract_call(interp::CC.AbstractInterpreter,
         arginfo::CC.ArgInfo, si::CC.StmtInfo, sv::CC.InferenceState, max_methods::Union{Int,Nothing})
     if sv.mod in interp.noinline_modules
-        return CC.CallMeta(ret.rt, ret.effects, NoinlineCallInfo(ret.info))
+        return CC.CallMeta(ret.rt, NoinlineCallInfo(ret.info))
     end
     return ret
 end


### PR DESCRIPTION
Add `call_effects(::CallInfo) -> Effects` feature to the `CallInfo` interface. This change will make it easier for the inlining algorithm to see the effects of a call in question.

This commit also setups new `ModifyFieldInfo` callinfo type so that it can propagate `modifyfield!`-specific information to the inliner, which implements a special handling for the call.

@nanosoldier `runbenchmarks("inference", vs=":master")`