### PR TITLE
wip: pass around `CallInfo` object to the inlining algorithm

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -72,7 +72,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
         # which is all that's required for :consistent-cy. Of course, we don't
         # know anything else about this statement.
         effects = Effects(; consistent=ALWAYS_TRUE, nonoverlayed)
-        return CallMeta(Any, effects, NoCallInfo())
+        return CallMeta(Any, NoCallInfo(effects))
     end
 
     argtypes = arginfo.argtypes
@@ -80,10 +80,10 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
         InferenceParams(interp).MAX_UNION_SPLITTING, max_methods)
     if isa(matches, FailedMethodMatch)
         add_remark!(interp, sv, matches.reason)
-        return CallMeta(Any, Effects(), NoCallInfo())
+        return CallMeta(Any, NoCallInfo())
     end
 
-    (; valid_worlds, applicable, info) = matches
+    (; valid_worlds, applicable, lookup_results) = matches
     update_valid_age!(sv, valid_worlds)
     napplicable = length(applicable)
     rettype = Bottom
@@ -104,7 +104,12 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
 
     # try pure-evaluation
     val = pure_eval_call(interp, f, applicable, arginfo, sv)
-    val !== nothing && return CallMeta(val, all_effects, MethodResultPure(info)) # TODO: add some sort of edge(s)
+    if val !== nothing
+        # TODO: add some sort of edge(s)
+        info = (lookup_results isa MethodLookupResult ? MethodMatchInfo : UnionSplitInfo)(lookup_results, all_effects)
+        info = MethodResultPure(info)
+        return CallMeta(val, info)
+    end
 
     for i in 1:napplicable
         match = applicable[i]::MethodMatch
@@ -195,11 +200,6 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
         end
     end
 
-    if any_const_result && seen == napplicable
-        @assert napplicable == nmatches(info) == length(const_results)
-        info = ConstCallInfo(info, const_results)
-    end
-
     if seen != napplicable
         # there may be unanalyzed effects within unseen dispatch candidate,
         # but we can still ignore nonoverlayed effect here since we already accounted for it
@@ -232,6 +232,12 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
         end
     end
 
+    info = (lookup_results isa MethodLookupResult ? MethodMatchInfo : UnionSplitInfo)(lookup_results, all_effects)
+    if any_const_result && seen == napplicable
+        @assert napplicable == nmatches(info) == length(const_results)
+        info = ConstCallInfo(info, const_results)
+    end
+
     if call_result_unused(sv) && !(rettype === Bottom)
         add_remark!(interp, sv, "Call result type was widened because the return value is unused")
         # We're mainly only here because the optimizer might want this code,
@@ -249,7 +255,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
             delete!(sv.pclimitations, caller)
         end
     end
-    return CallMeta(rettype, all_effects, info)
+    return CallMeta(rettype, info)
 end
 
 struct FailedMethodMatch
@@ -258,32 +264,44 @@ end
 
 struct MethodMatches
     applicable::Vector{Any}
-    info::MethodMatchInfo
+    lookup_results::MethodLookupResult
     valid_worlds::WorldRange
     mt::Core.MethodTable
     fullmatch::Bool
     nonoverlayed::Bool
 end
-any_ambig(info::MethodMatchInfo) = info.results.ambig
-any_ambig(m::MethodMatches) = any_ambig(m.info)
 
 struct UnionSplitMethodMatches
     applicable::Vector{Any}
     applicable_argtypes::Vector{Vector{Any}}
-    info::UnionSplitInfo
+    lookup_results::Vector{MethodLookupResult}
     valid_worlds::WorldRange
     mts::Vector{Core.MethodTable}
     fullmatches::Vector{Bool}
     nonoverlayed::Bool
 end
-any_ambig(m::UnionSplitMethodMatches) = _any(any_ambig, m.info.matches)
+
+
+any_ambig(result::MethodLookupResult) = result.ambig
+any_ambig(m::MethodMatches) = any_ambig(m.lookup_results)
+any_ambig(m::UnionSplitMethodMatches) = any(any_ambig, m.lookup_results)
+
+nmatches(result::MethodLookupResult) = length(result)
+nmatches(info::MethodMatchInfo) = nmatches(info.results)
+function nmatches(info::UnionSplitInfo)
+    n = 0
+    for result in info.matches
+        n += nmatches(result)
+    end
+    return n
+end
 
 function find_matching_methods(argtypes::Vector{Any}, @nospecialize(atype), method_table::MethodTableView,
                                union_split::Int, max_methods::Int)
     # NOTE this is valid as far as any "constant" lattice element doesn't represent `Union` type
     if 1 < unionsplitcost(argtypes) <= union_split
         split_argtypes = switchtupleunion(argtypes)
-        infos = MethodMatchInfo[]
+        lookup_results = MethodLookupResult[]
         applicable = Any[]
         applicable_argtypes = Vector{Any}[] # arrays like `argtypes`, including constants, for each match
         valid_worlds = WorldRange()
@@ -302,13 +320,13 @@ function find_matching_methods(argtypes::Vector{Any}, @nospecialize(atype), meth
             end
             (; matches, overlayed) = result
             nonoverlayed &= !overlayed
-            push!(infos, MethodMatchInfo(matches))
+            push!(lookup_results, matches)
             for m in matches
                 push!(applicable, m)
                 push!(applicable_argtypes, arg_n)
             end
             valid_worlds = intersect(valid_worlds, matches.valid_worlds)
-            thisfullmatch = _any(match->(match::MethodMatch).fully_covers, matches)
+            thisfullmatch = any(match->(match::MethodMatch).fully_covers, matches)
             found = false
             for (i, mt′) in enumerate(mts)
                 if mt′ === mt
@@ -324,7 +342,7 @@ function find_matching_methods(argtypes::Vector{Any}, @nospecialize(atype), meth
         end
         return UnionSplitMethodMatches(applicable,
                                        applicable_argtypes,
-                                       UnionSplitInfo(infos),
+                                       lookup_results,
                                        valid_worlds,
                                        mts,
                                        fullmatches,
@@ -342,9 +360,9 @@ function find_matching_methods(argtypes::Vector{Any}, @nospecialize(atype), meth
             return FailedMethodMatch("Too many methods matched")
         end
         (; matches, overlayed) = result
-        fullmatch = _any(match->(match::MethodMatch).fully_covers, matches)
+        fullmatch = any(match->(match::MethodMatch).fully_covers, matches)
         return MethodMatches(matches.matches,
-                             MethodMatchInfo(matches),
+                             matches,
                              matches.valid_worlds,
                              mt,
                              fullmatch,
@@ -857,7 +875,7 @@ function concrete_eval_call(interp::AbstractInterpreter,
     end
 end
 
-has_conditional(argtypes::Vector{Any}) = _any(@nospecialize(x)->isa(x, Conditional), argtypes)
+has_conditional(argtypes::Vector{Any}) = any(@nospecialize(x)->isa(x, Conditional), argtypes)
 has_conditional((; argtypes)::ArgInfo) = has_conditional(argtypes)
 
 function const_prop_enabled(interp::AbstractInterpreter, sv::InferenceState, match::MethodMatch)
@@ -1312,7 +1330,7 @@ function abstract_iteration(interp::AbstractInterpreter, @nospecialize(itft), @n
     # WARNING: Changes to the iteration protocol must be reflected here,
     # this is not just an optimization.
     # TODO: this doesn't realize that Array, SimpleVector, Tuple, and NamedTuple do not use the iterate protocol
-    stateordonet === Bottom && return Any[Bottom], AbstractIterationInfo(CallMeta[CallMeta(Bottom, call.effects, info)])
+    stateordonet === Bottom && return Any[Bottom], AbstractIterationInfo(CallMeta[CallMeta(Bottom, info)])
     valtype = statetype = Bottom
     ret = Any[]
     calls = CallMeta[call]
@@ -1388,7 +1406,7 @@ function abstract_apply(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::
                         max_methods::Int = get_max_methods(sv.mod, interp))
     itft = argtype_by_index(argtypes, 2)
     aft = argtype_by_index(argtypes, 3)
-    (itft === Bottom || aft === Bottom) && return CallMeta(Bottom, EFFECTS_THROWS, NoCallInfo())
+    (itft === Bottom || aft === Bottom) && return CallMeta(Bottom, NoCallInfo(EFFECTS_THROWS))
     aargtypes = argtype_tail(argtypes, 4)
     aftw = widenconst(aft)
     if !isa(aft, Const) && !isa(aft, PartialOpaque) && (!isType(aftw) || has_free_typevars(aftw))
@@ -1396,7 +1414,7 @@ function abstract_apply(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::
             add_remark!(interp, sv, "Core._apply_iterate called on a function of a non-concrete type")
             # bail now, since it seems unlikely that abstract_call will be able to do any better after splitting
             # this also ensures we don't call abstract_call_gf_by_type below on an IntrinsicFunction or Builtin
-            return CallMeta(Any, Effects(), NoCallInfo())
+            return CallMeta(Any, NoCallInfo())
         end
     end
     res = Union{}
@@ -1404,7 +1422,6 @@ function abstract_apply(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::
     splitunions = 1 < unionsplitcost(aargtypes) <= InferenceParams(interp).MAX_APPLY_UNION_ENUM
     ctypes = [Any[aft]]
     infos = Vector{MaybeAbstractIterationInfo}[MaybeAbstractIterationInfo[]]
-    effects = EFFECTS_TOTAL
     for i = 1:nargs
         ctypes´ = Vector{Any}[]
         infos′ = Vector{MaybeAbstractIterationInfo}[]
@@ -1453,7 +1470,6 @@ function abstract_apply(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::
     retinfo = UnionSplitApplyCallInfo(retinfos)
     for i = 1:length(ctypes)
         ct = ctypes[i]
-        arginfo = infos[i]
         lct = length(ct)
         # truncate argument list at the first Vararg
         for i = 1:lct-1
@@ -1465,9 +1481,8 @@ function abstract_apply(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::
             end
         end
         call = abstract_call(interp, ArgInfo(nothing, ct), sv, max_methods)
-        push!(retinfos, ApplyCallInfo(call.info, arginfo))
+        push!(retinfos, ApplyCallInfo(call.info, infos[i]))
         res = tmerge(res, call.rt)
-        effects = merge_effects(effects, call.effects)
         if bail_out_apply(interp, res, sv)
             if i != length(ctypes)
                 # No point carrying forward the info, we're not gonna inline it anyway
@@ -1478,7 +1493,7 @@ function abstract_apply(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::
     end
     # TODO: Add a special info type to capture all the iteration info.
     # For now, only propagate info if we don't also union-split the iteration
-    return CallMeta(res, effects, retinfo)
+    return CallMeta(res, retinfo)
 end
 
 function argtype_by_index(argtypes::Vector{Any}, i::Int)
@@ -1671,21 +1686,21 @@ end
 function abstract_invoke(interp::AbstractInterpreter, (; fargs, argtypes)::ArgInfo, sv::InferenceState)
     ft′ = argtype_by_index(argtypes, 2)
     ft = widenconst(ft′)
-    ft === Bottom && return CallMeta(Bottom, EFFECTS_THROWS, NoCallInfo())
+    ft === Bottom && return CallMeta(Bottom, NoCallInfo(EFFECTS_THROWS))
     (types, isexact, isconcrete, istype) = instanceof_tfunc(argtype_by_index(argtypes, 3))
-    types === Bottom && return CallMeta(Bottom, EFFECTS_THROWS, NoCallInfo())
-    isexact || return CallMeta(Any, Effects(), NoCallInfo())
+    types === Bottom && return CallMeta(Bottom, NoCallInfo(EFFECTS_THROWS))
+    isexact || return CallMeta(Any, NoCallInfo())
     argtype = argtypes_to_type(argtype_tail(argtypes, 4))
     nargtype = typeintersect(types, argtype)
-    nargtype === Bottom && return CallMeta(Bottom, EFFECTS_THROWS, NoCallInfo())
-    nargtype isa DataType || return CallMeta(Any, Effects(), NoCallInfo()) # other cases are not implemented below
-    isdispatchelem(ft) || return CallMeta(Any, Effects(), NoCallInfo()) # check that we might not have a subtype of `ft` at runtime, before doing supertype lookup below
+    nargtype === Bottom && return CallMeta(Bottom, NoCallInfo(EFFECTS_THROWS))
+    nargtype isa DataType || return CallMeta(Any, NoCallInfo()) # other cases are not implemented below
+    isdispatchelem(ft) || return CallMeta(Any, NoCallInfo()) # check that we might not have a subtype of `ft` at runtime, before doing supertype lookup below
     ft = ft::DataType
     lookupsig = rewrap_unionall(Tuple{ft, unwrap_unionall(types).parameters...}, types)::Type
     nargtype = Tuple{ft, nargtype.parameters...}
     argtype = Tuple{ft, argtype.parameters...}
     match, valid_worlds, overlayed = findsup(lookupsig, method_table(interp))
-    match === nothing && return CallMeta(Any, Effects(), NoCallInfo())
+    match === nothing && return CallMeta(Any, NoCallInfo())
     update_valid_age!(sv, valid_worlds)
     method = match.method
     tienv = ccall(:jl_type_intersection_with_env, Any, (Any, Any), nargtype, method.sig)::SimpleVector
@@ -1713,9 +1728,11 @@ function abstract_invoke(interp::AbstractInterpreter, (; fargs, argtypes)::ArgIn
             (; rt, effects, const_result, edge) = const_call_result
         end
     end
+    rt = from_interprocedural!(ipo_lattice(interp), rt, sv, arginfo, sig)
     effects = Effects(effects; nonoverlayed=!overlayed)
+    info = InvokeCallInfo(match, const_result, effects)
     edge !== nothing && add_invoke_backedge!(sv, lookupsig, edge)
-    return CallMeta(from_interprocedural!(ipo_lattice(interp), rt, sv, arginfo, sig), effects, InvokeCallInfo(match, const_result))
+    return CallMeta(rt, info)
 end
 
 function invoke_rewrite(xs::Vector{Any})
@@ -1729,9 +1746,9 @@ function abstract_finalizer(interp::AbstractInterpreter, argtypes::Vector{Any}, 
     if length(argtypes) == 3
         finalizer_argvec = Any[argtypes[2], argtypes[3]]
         call = abstract_call(interp, ArgInfo(nothing, finalizer_argvec), sv, 1)
-        return CallMeta(Nothing, Effects(), FinalizerInfo(call.info, call.effects))
+        return CallMeta(Nothing, FinalizerInfo(call.info, call_effects(call.info)))
     end
-    return CallMeta(Nothing, Effects(), NoCallInfo())
+    return CallMeta(Nothing, NoCallInfo())
 end
 
 # call where the function is known exactly
@@ -1753,25 +1770,25 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
         end
         rt = abstract_call_builtin(interp, f, arginfo, sv, max_methods)
         effects = builtin_effects(typeinf_lattice(interp), f, argtypes[2:end], rt)
-        return CallMeta(rt, effects, NoCallInfo())
+        return CallMeta(rt, NoCallInfo(effects))
     elseif isa(f, Core.OpaqueClosure)
         # calling an OpaqueClosure about which we have no information returns no information
-        return CallMeta(Any, Effects(), NoCallInfo())
+        return CallMeta(Any, NoCallInfo())
     elseif f === Core.kwfunc
         if la == 2
             aty = argtypes[2]
             if !isvarargtype(aty)
                 ft = widenconst(aty)
                 if isa(ft, DataType) && isdefined(ft.name, :mt) && isdefined(ft.name.mt, :kwsorter)
-                    return CallMeta(Const(ft.name.mt.kwsorter), EFFECTS_TOTAL, MethodResultPure())
+                    return CallMeta(Const(ft.name.mt.kwsorter), MethodResultPure())
                 end
             end
         end
-        return CallMeta(Any, EFFECTS_UNKNOWN, NoCallInfo())
+        return CallMeta(Any, NoCallInfo(EFFECTS_UNKNOWN))
     elseif f === TypeVar
         # Manually look through the definition of TypeVar to
         # make sure to be able to get `PartialTypeVar`s out.
-        (la < 2 || la > 4) && return CallMeta(Union{}, EFFECTS_UNKNOWN, NoCallInfo())
+        (la < 2 || la > 4) && return CallMeta(Union{}, NoCallInfo(EFFECTS_UNKNOWN))
         n = argtypes[2]
         ub_var = Const(Any)
         lb_var = Const(Union{})
@@ -1781,14 +1798,14 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
         elseif la == 3
             ub_var = argtypes[3]
         end
-        return CallMeta(typevar_tfunc(n, lb_var, ub_var), EFFECTS_UNKNOWN, NoCallInfo())
+        return CallMeta(typevar_tfunc(n, lb_var, ub_var), NoCallInfo(EFFECTS_UNKNOWN))
     elseif f === UnionAll
-        return CallMeta(abstract_call_unionall(argtypes), EFFECTS_UNKNOWN, NoCallInfo())
+        return CallMeta(abstract_call_unionall(argtypes), NoCallInfo(EFFECTS_UNKNOWN))
     elseif f === Tuple && la == 2
         aty = argtypes[2]
         ty = isvarargtype(aty) ? unwrapva(aty) : widenconst(aty)
         if !isconcretetype(ty)
-            return CallMeta(Tuple, EFFECTS_UNKNOWN, NoCallInfo())
+            return CallMeta(Tuple, NoCallInfo(EFFECTS_UNKNOWN))
         end
     elseif is_return_type(f)
         return return_type_tfunc(interp, argtypes, sv)
@@ -1797,17 +1814,17 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
         aty = argtypes[2]
         if isa(aty, Conditional)
             call = abstract_call_gf_by_type(interp, f, ArgInfo(fargs, Any[Const(f), Bool]), Tuple{typeof(f), Bool}, sv, max_methods) # make sure we've inferred `!(::Bool)`
-            return CallMeta(Conditional(aty.slot, aty.elsetype, aty.thentype), call.effects, call.info)
+            return CallMeta(Conditional(aty.slot, aty.elsetype, aty.thentype), call.info)
         end
     elseif la == 3 && istopfunction(f, :!==)
         # mark !== as exactly a negated call to ===
         rty = abstract_call_known(interp, (===), arginfo, sv, max_methods).rt
         if isa(rty, Conditional)
-            return CallMeta(Conditional(rty.slot, rty.elsetype, rty.thentype), EFFECTS_TOTAL, NoCallInfo()) # swap if-else
+            return CallMeta(Conditional(rty.slot, rty.elsetype, rty.thentype), NoCallInfo(EFFECTS_TOTAL)) # swap if-else
         elseif isa(rty, Const)
-            return CallMeta(Const(rty.val === false), EFFECTS_TOTAL, MethodResultPure())
+            return CallMeta(Const(rty.val === false), MethodResultPure())
         end
-        return CallMeta(rty, EFFECTS_TOTAL, NoCallInfo())
+        return CallMeta(rty, NoCallInfo(EFFECTS_TOTAL))
     elseif la == 3 && istopfunction(f, :(>:))
         # mark issupertype as a exact alias for issubtype
         # swap T1 and T2 arguments and call <:
@@ -1817,26 +1834,26 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
             fargs = nothing
         end
         argtypes = Any[typeof(<:), argtypes[3], argtypes[2]]
-        return CallMeta(abstract_call_known(interp, <:, ArgInfo(fargs, argtypes), sv, max_methods).rt, EFFECTS_TOTAL, NoCallInfo())
+        return CallMeta(abstract_call_known(interp, <:, ArgInfo(fargs, argtypes), sv, max_methods).rt, NoCallInfo(EFFECTS_TOTAL))
     elseif la == 2 &&
            (a2 = argtypes[2]; isa(a2, Const)) && (svecval = a2.val; isa(svecval, SimpleVector)) &&
            istopfunction(f, :length)
         # mark length(::SimpleVector) as @pure
-        return CallMeta(Const(length(svecval)), EFFECTS_TOTAL, MethodResultPure())
+        return CallMeta(Const(length(svecval)), MethodResultPure())
     elseif la == 3 &&
            (a2 = argtypes[2]; isa(a2, Const)) && (svecval = a2.val; isa(svecval, SimpleVector)) &&
            (a3 = argtypes[3]; isa(a3, Const)) && (idx = a3.val; isa(idx, Int)) &&
            istopfunction(f, :getindex)
         # mark getindex(::SimpleVector, i::Int) as @pure
         if 1 <= idx <= length(svecval) && isassigned(svecval, idx)
-            return CallMeta(Const(getindex(svecval, idx)), EFFECTS_TOTAL, MethodResultPure())
+            return CallMeta(Const(getindex(svecval, idx)), MethodResultPure())
         end
     elseif la == 2 && istopfunction(f, :typename)
-        return CallMeta(typename_static(argtypes[2]), EFFECTS_TOTAL, MethodResultPure())
+        return CallMeta(typename_static(argtypes[2]), MethodResultPure())
     elseif la == 3 && istopfunction(f, :typejoin)
         if is_all_const_arg(arginfo, #=start=#2)
             val = _pure_eval_call(f, arginfo)
-            return CallMeta(val === nothing ? Type : val, EFFECTS_TOTAL, MethodResultPure())
+            return CallMeta(val === nothing ? Type : val, MethodResultPure())
         end
     end
     atype = argtypes_to_type(argtypes)
@@ -1861,7 +1878,6 @@ function abstract_call_opaque_closure(interp::AbstractInterpreter,
             end
         end
     end
-    info = OpaqueClosureCallInfo(match, const_result)
     ipo = ipo_lattice(interp)
     ⊑ₚ = ⊑(ipo)
     if check # analyze implicit type asserts on argument and return type
@@ -1873,8 +1889,9 @@ function abstract_call_opaque_closure(interp::AbstractInterpreter,
         end
     end
     rt = from_interprocedural!(ipo, rt, sv, arginfo, match.spec_types)
+    info = OpaqueClosureCallInfo(match, const_result, effects)
     edge !== nothing && add_backedge!(sv, edge)
-    return CallMeta(rt, effects, info)
+    return CallMeta(rt, info)
 end
 
 function most_general_argtypes(closure::PartialOpaque)
@@ -1899,13 +1916,13 @@ function abstract_call(interp::AbstractInterpreter, arginfo::ArgInfo,
         return abstract_call_opaque_closure(interp,
             ft, ArgInfo(arginfo.fargs, newargtypes), sv, #=check=#true)
     elseif (uft = unwrap_unionall(widenconst(ft)); isa(uft, DataType) && uft.name === typename(Core.OpaqueClosure))
-        return CallMeta(rewrap_unionall((uft::DataType).parameters[2], widenconst(ft)), Effects(), NoCallInfo())
+        return CallMeta(rewrap_unionall((uft::DataType).parameters[2], widenconst(ft)), NoCallInfo())
     elseif f === nothing
         # non-constant function, but the number of arguments is known
         # and the ft is not a Builtin or IntrinsicFunction
         if hasintersect(widenconst(ft), Union{Builtin, Core.OpaqueClosure})
             add_remark!(interp, sv, "Could not identify method table for call")
-            return CallMeta(Any, Effects(), NoCallInfo())
+            return CallMeta(Any, NoCallInfo())
         end
         max_methods = max_methods === nothing ? get_max_methods(sv.mod, interp) : max_methods
         return abstract_call_gf_by_type(interp, nothing, arginfo, argtypes_to_type(argtypes), sv, max_methods)
@@ -2041,7 +2058,8 @@ function abstract_eval_statement_expr(interp::AbstractInterpreter, e::Expr, vtyp
             rt = Bottom
             effects = Effects()
         else
-            (; rt, effects, info) = abstract_call(interp, ArgInfo(ea, argtypes), sv)
+            (; rt, info) = abstract_call(interp, ArgInfo(ea, argtypes), sv)
+            effects = call_effects(info)
             merge_effects!(interp, sv, effects)
             if isa(sv, InferenceState)
                 sv.stmt_info[sv.currpc] = info

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -133,8 +133,8 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
                 (; rt, edge, effects) = result
                 this_argtypes = isa(matches, MethodMatches) ? argtypes : matches.applicable_argtypes[i]
                 this_arginfo = ArgInfo(fargs, this_argtypes)
-                const_call_result = abstract_call_method_with_const_args(interp, result,
-                    f, this_arginfo, match, sv)
+                const_call_result = abstract_call_method_with_const_args(interp,
+                    result, f, this_arginfo, match, sv)
                 const_result = nothing
                 if const_call_result !== nothing
                     if const_call_result.rt ⊑ᵢ rt
@@ -162,8 +162,8 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
             # this is in preparation for inlining, or improving the return result
             this_argtypes = isa(matches, MethodMatches) ? argtypes : matches.applicable_argtypes[i]
             this_arginfo = ArgInfo(fargs, this_argtypes)
-            const_call_result = abstract_call_method_with_const_args(interp, result,
-                f, this_arginfo, match, sv)
+            const_call_result = abstract_call_method_with_const_args(interp,
+                result, f, this_arginfo, match, sv)
             const_result = nothing
             if const_call_result !== nothing
                 this_const_conditional = ignorelimited(const_call_result.rt)
@@ -960,9 +960,9 @@ end
 
 # if there's a possibility we could get a better result with these constant arguments
 # (hopefully without doing too much work), returns `MethodInstance`, or nothing otherwise
-function maybe_get_const_prop_profitable(interp::AbstractInterpreter, result::MethodCallResult,
-                                         @nospecialize(f), arginfo::ArgInfo, match::MethodMatch,
-                                         sv::InferenceState)
+function maybe_get_const_prop_profitable(interp::AbstractInterpreter,
+    result::MethodCallResult, @nospecialize(f), arginfo::ArgInfo, match::MethodMatch,
+    sv::InferenceState)
     method = match.method
     force = force_const_prop(interp, f, method)
     force || const_prop_entry_heuristic(interp, result, sv) || return nothing
@@ -1149,9 +1149,8 @@ end
 # This is a heuristic to avoid trying to const prop through complicated functions
 # where we would spend a lot of time, but are probably unlikely to get an improved
 # result anyway.
-function const_prop_methodinstance_heuristic(
-    interp::AbstractInterpreter, match::MethodMatch, mi::MethodInstance,
-    (; argtypes)::ArgInfo, sv::InferenceState)
+function const_prop_methodinstance_heuristic(interp::AbstractInterpreter,
+    match::MethodMatch, mi::MethodInstance, arginfo::ArgInfo, sv::InferenceState)
     method = match.method
     if method.is_for_opaque_closure
         # Not inlining an opaque closure can be very expensive, so be generous
@@ -1184,7 +1183,8 @@ function const_prop_methodinstance_heuristic(
                 else
                     inferred = code.inferred
                 end
-                if inlining_policy(interp, inferred, IR_FLAG_NULL, mi, argtypes) !== nothing
+                # TODO propagate a specific `CallInfo` that conveys information about this call
+                if inlining_policy(interp, inferred, NoCallInfo(), IR_FLAG_NULL, mi, arginfo.argtypes) !== nothing
                     return true
                 end
             end

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -106,7 +106,7 @@ mutable struct InferenceState
     bb_vartables::Vector{Union{Nothing,VarTable}} # nothing if not analyzed yet
     ssavaluetypes::Vector{Any}
     stmt_edges::Vector{Union{Nothing,Vector{Any}}}
-    stmt_info::Vector{Any}
+    stmt_info::Vector{CallInfo}
 
     #= intermediate states for interprocedural abstract interpretation =#
     pclimitations::IdSet{InferenceState} # causes of precision restrictions (LimitedAccuracy) on currpc ssavalue
@@ -152,7 +152,7 @@ mutable struct InferenceState
         ssavalue_uses = find_ssavalue_uses(code, nssavalues)
         nstmts = length(code)
         stmt_edges = Union{Nothing, Vector{Any}}[ nothing for i = 1:nstmts ]
-        stmt_info = Any[ nothing for i = 1:nstmts ]
+        stmt_info = CallInfo[ NoCallInfo() for i = 1:nstmts ]
 
         nslots = length(src.slotflags)
         slottypes = Vector{Any}(undef, nslots)

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -83,8 +83,9 @@ end
 is_source_inferred(@nospecialize(src::Union{CodeInfo, Vector{UInt8}})) =
     ccall(:jl_ir_flag_inferred, Bool, (Any,), src)
 
-function inlining_policy(interp::AbstractInterpreter, @nospecialize(src), stmt_flag::UInt8,
-                         mi::MethodInstance, argtypes::Vector{Any})
+function inlining_policy(interp::AbstractInterpreter,
+    @nospecialize(src), @nospecialize(info::CallInfo), stmt_flag::UInt8, mi::MethodInstance,
+    argtypes::Vector{Any})
     if isa(src, CodeInfo) || isa(src, Vector{UInt8})
         src_inferred = is_source_inferred(src)
         src_inlineable = is_stmt_inline(stmt_flag) || is_inlineable(src)

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -113,7 +113,7 @@ mutable struct OptimizationState
     linfo::MethodInstance
     src::CodeInfo
     ir::Union{Nothing, IRCode}
-    stmt_info::Vector{Any}
+    stmt_info::Vector{CallInfo}
     mod::Module
     sptypes::Vector{Any} # static parameters
     slottypes::Vector{Any}
@@ -146,7 +146,7 @@ mutable struct OptimizationState
         if slottypes === nothing
             slottypes = Any[ Any for i = 1:nslots ]
         end
-        stmt_info = Any[nothing for i = 1:nssavalues]
+        stmt_info = CallInfo[ NoCallInfo() for i = 1:nssavalues ]
         # cache some useful state computations
         def = linfo.def
         mod = isa(def, Method) ? def.module : def
@@ -598,7 +598,7 @@ function convert_to_ircode(ci::CodeInfo, sv::OptimizationState)
             insert!(code, idx, Expr(:code_coverage_effect))
             insert!(codelocs, idx, codeloc)
             insert!(ssavaluetypes, idx, Nothing)
-            insert!(stmtinfo, idx, nothing)
+            insert!(stmtinfo, idx, NoCallInfo())
             insert!(ssaflags, idx, IR_FLAG_NULL)
             if ssachangemap === nothing
                 ssachangemap = fill(0, nstmts)
@@ -619,7 +619,7 @@ function convert_to_ircode(ci::CodeInfo, sv::OptimizationState)
                 insert!(code, idx + 1, ReturnNode())
                 insert!(codelocs, idx + 1, codelocs[idx])
                 insert!(ssavaluetypes, idx + 1, Union{})
-                insert!(stmtinfo, idx + 1, nothing)
+                insert!(stmtinfo, idx + 1, NoCallInfo())
                 insert!(ssaflags, idx + 1, ssaflags[idx])
                 if ssachangemap === nothing
                     ssachangemap = fill(0, nstmts)

--- a/base/compiler/ssair/EscapeAnalysis/EscapeAnalysis.jl
+++ b/base/compiler/ssair/EscapeAnalysis/EscapeAnalysis.jl
@@ -1290,7 +1290,7 @@ function escape_call!(astate::AnalysisState, pc::Int, args::Vector{Any}, callinf
         # now cascade to the builtin handling
         escape_call!(astate, pc, args)
         return
-    elseif isa(info, CallInfo)
+    elseif isa(info, EACallInfo)
         for linfo in info.linfos
             escape_invoke!(astate, pc, args, linfo, 1)
         end

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1091,14 +1091,14 @@ function inline_apply!(
         if isa(info, UnionSplitApplyCallInfo)
             if length(info.infos) != 1
                 # TODO: Handle union split applies?
-                new_info = info = false
+                new_info = info = NoCallInfo()
             else
                 info = info.infos[1]
                 new_info = info.call
             end
         else
-            @assert info === nothing || info === false
-            new_info = info = false
+            @assert info === NoCallInfo()
+            new_info = info = NoCallInfo()
         end
         arg_start = 3
         argtypes = sig.argtypes
@@ -1618,7 +1618,7 @@ function assemble_inline_todo!(ir::IRCode, state::InliningState)
             inline_const_if_inlineable!(ir[SSAValue(idx)]) && continue
             info = info.info
         end
-        if info === false
+        if info === NoCallInfo()
             # Inference determined this couldn't be analyzed. Don't question it.
             continue
         end

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -188,15 +188,15 @@ const AnySSAValue = Union{SSAValue, OldSSAValue, NewSSAValue}
 struct InstructionStream
     inst::Vector{Any}
     type::Vector{Any}
-    info::Vector{Any}
+    info::Vector{CallInfo}
     line::Vector{Int32}
     flag::Vector{UInt8}
 end
 function InstructionStream(len::Int)
-    insts = Array{Any}(undef, len)
-    types = Array{Any}(undef, len)
-    info = Array{Any}(undef, len)
-    fill!(info, nothing)
+    insts = Vector{Any}(undef, len)
+    types = Vector{Any}(undef, len)
+    info = Vector{CallInfo}(undef, len)
+    fill!(info, NoCallInfo())
     lines = fill(Int32(0), len)
     flags = fill(IR_FLAG_NULL, len)
     return InstructionStream(insts, types, info, lines, flags)
@@ -227,7 +227,7 @@ function resize!(stmts::InstructionStream, len)
     for i in (old_length + 1):len
         stmts.line[i] = 0
         stmts.flag[i] = IR_FLAG_NULL
-        stmts.info[i] = nothing
+        stmts.info[i] = NoCallInfo()
     end
     return stmts
 end

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -119,7 +119,7 @@ end
 function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
                                   arginfo::ArgInfo, @nospecialize(atype),
                                   sv::IRCode, max_methods::Int)
-    return CallMeta(Any, Effects(), false)
+    return CallMeta(Any, Effects(), NoCallInfo())
 end
 
 function collect_limitations!(@nospecialize(typ), ::IRCode)

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -39,7 +39,7 @@ function inflate_ir!(ci::CodeInfo, sptypes::Vector{Any}, argtypes::Vector{Any})
     if !isa(ssavaluetypes, Vector{Any})
         ssavaluetypes = Any[ Any for i = 1:ssavaluetypes::Int ]
     end
-    info = Any[nothing for i = 1:nstmts]
+    info = CallInfo[NoCallInfo() for i = 1:nstmts]
     stmts = InstructionStream(code, ssavaluetypes, info, ci.codelocs, ci.ssaflags)
     linetable = ci.linetable
     if !isa(linetable, Vector{LineInfoNode})

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -872,7 +872,7 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing, InliningState} = nothin
             3 <= length(stmt.args) <= 5 || continue
             info = compact[SSAValue(idx)][:info]
             if isa(info, FinalizerInfo)
-                is_finalizer_inlineable(info.effects) || continue
+                is_finalizer_inlineable(info.finalizer_effects) || continue
             else
                 # Inlining performs legality checks on the finalizer to determine
                 # whether or not we may inline it. If so, it appends extra arguments
@@ -1212,7 +1212,7 @@ function try_resolve_finalizer!(ir::IRCode, idx::Int, finalizer_idx::Int, defuse
 
     finalizer_stmt = ir[SSAValue(finalizer_idx)][:inst]
     argexprs = Any[finalizer_stmt.args[2], finalizer_stmt.args[3]]
-    flags = info isa FinalizerInfo ? flags_for_effects(info.effects) : IR_FLAG_NULL
+    flags = info isa FinalizerInfo ? flags_for_effects(info.finalizer_effects) : IR_FLAG_NULL
     if length(finalizer_stmt.args) >= 4
         inline = finalizer_stmt.args[4]
         if inline === nothing

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1116,7 +1116,7 @@ end
 
 function try_resolve_finalizer!(ir::IRCode, idx::Int, finalizer_idx::Int, defuse::SSADefUse,
         inlining::InliningState, lazydomtree::LazyDomtree,
-        lazypostdomtree::LazyPostDomtree, info::Union{FinalizerInfo, Nothing})
+        lazypostdomtree::LazyPostDomtree, @nospecialize(info::CallInfo))
     # For now, require that:
     # 1. The allocation dominates the finalizer registration
     # 2. The finalizer registration dominates all uses reachable from the
@@ -1212,7 +1212,7 @@ function try_resolve_finalizer!(ir::IRCode, idx::Int, finalizer_idx::Int, defuse
 
     finalizer_stmt = ir[SSAValue(finalizer_idx)][:inst]
     argexprs = Any[finalizer_stmt.args[2], finalizer_stmt.args[3]]
-    flags = info === nothing ? UInt8(0) : flags_for_effects(info.effects)
+    flags = info isa FinalizerInfo ? flags_for_effects(info.effects) : IR_FLAG_NULL
     if length(finalizer_stmt.args) >= 4
         inline = finalizer_stmt.args[4]
         if inline === nothing

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -172,7 +172,7 @@ function rename_uses!(ir::IRCode, ci::CodeInfo, idx::Int, @nospecialize(stmt), r
     return fixemup!(stmt->true, stmt->renames[slot_id(stmt)], ir, ci, idx, stmt)
 end
 
-function strip_trailing_junk!(ci::CodeInfo, code::Vector{Any}, info::Vector{Any})
+function strip_trailing_junk!(ci::CodeInfo, code::Vector{Any}, info::Vector{CallInfo})
     # Remove `nothing`s at the end, we don't handle them well
     # (we expect the last instruction to be a terminator)
     ssavaluetypes = ci.ssavaluetypes::Vector{Any}
@@ -194,7 +194,7 @@ function strip_trailing_junk!(ci::CodeInfo, code::Vector{Any}, info::Vector{Any}
         push!(code, ReturnNode())
         push!(ssavaluetypes, Union{})
         push!(codelocs, 0)
-        push!(info, nothing)
+        push!(info, NoCallInfo())
         push!(ssaflags, IR_FLAG_NULL)
     end
     nothing

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -33,6 +33,9 @@ struct MethodMatchInfo <: CallInfo
     effects::Effects
 end
 call_effects_impl(info::MethodMatchInfo) = info.effects
+nsplit_impl(info::MethodMatchInfo) = 1
+getsplit_impl(info::MethodMatchInfo, idx::Int) = (@assert idx == 1; info.results)
+getresult_impl(::MethodMatchInfo, ::Int) = nothing
 
 """
     info::UnionSplitInfo <: CallInfo
@@ -48,6 +51,9 @@ struct UnionSplitInfo <: CallInfo
     effects::Effects
 end
 call_effects_impl(info::UnionSplitInfo) = info.effects
+nsplit_impl(info::UnionSplitInfo) = length(info.matches)
+getsplit_impl(info::UnionSplitInfo, idx::Int) = info.matches[idx]
+getresult_impl(::UnionSplitInfo, ::Int) = nothing
 
 struct ConstPropResult
     result::InferenceResult
@@ -81,6 +87,9 @@ struct ConstCallInfo <: CallInfo
     results::Vector{Union{Nothing,ConstResult}}
 end
 call_effects_impl(info::ConstCallInfo) = call_effects(info.call)
+nsplit_impl(info::ConstCallInfo) = nsplit(info.call)
+getsplit_impl(info::ConstCallInfo, idx::Int) = getsplit(info.call, idx)
+getresult_impl(info::ConstCallInfo, idx::Int) = info.results[idx]
 
 """
     info::MethodResultPure <: CallInfo
@@ -216,6 +225,9 @@ struct FinalizerInfo <: CallInfo
     finalizer_effects::Effects # the effects for the finalizer call
 end
 call_effects_impl(::FinalizerInfo) = Effects()
+nsplit_impl(info::FinalizerInfo) = nsplit(info.info)
+getsplit_impl(info::FinalizerInfo, idx::Int) = getsplit(info.info, idx)
+getresult_impl(info::FinalizerInfo, idx::Int) = getresult(info.info, idx)
 
 """
     info::ModifyFieldInfo <: CallInfo

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -11,23 +11,25 @@ and any additional information (`call.info`) for a given generic call.
 struct CallMeta
     rt::Any
     effects::Effects
-    info::Any
+    info::CallInfo
 end
 
+struct NoCallInfo <: CallInfo end
+
 """
-    info::MethodMatchInfo
+    info::MethodMatchInfo <: CallInfo
 
 Captures the result of a `:jl_matching_methods` lookup for the given call (`info.results`).
 This info may then be used by the optimizer to inline the matches, without having
 to re-consult the method table. This info is illegal on any statement that is
 not a call to a generic function.
 """
-struct MethodMatchInfo
+struct MethodMatchInfo <: CallInfo
     results::MethodLookupResult
 end
 
 """
-    info::UnionSplitInfo
+    info::UnionSplitInfo <: CallInfo
 
 If inference decides to partition the method search space by splitting unions,
 it will issue a method lookup query for each such partition. This info indicates
@@ -35,7 +37,7 @@ that such partitioning happened and wraps the corresponding `MethodMatchInfo` fo
 each partition (`info.matches::Vector{MethodMatchInfo}`).
 This info is illegal on any statement that is not a call to a generic function.
 """
-struct UnionSplitInfo
+struct UnionSplitInfo <: CallInfo
     matches::Vector{MethodMatchInfo}
 end
 
@@ -69,37 +71,37 @@ end
 const ConstResult = Union{ConstPropResult,ConcreteResult, SemiConcreteResult}
 
 """
-    info::ConstCallInfo
+    info::ConstCallInfo <: CallInfo
 
 The precision of this call was improved using constant information.
 In addition to the original call information `info.call`, this info also keeps the results
 of constant inference `info.results::Vector{Union{Nothing,ConstResult}}`.
 """
-struct ConstCallInfo
+struct ConstCallInfo <: CallInfo
     call::Union{MethodMatchInfo,UnionSplitInfo}
     results::Vector{Union{Nothing,ConstResult}}
 end
 
 """
-    info::MethodResultPure
+    info::MethodResultPure <: CallInfo
 
 This struct represents a method result constant was proven to be
 effect-free, including being no-throw (typically because the value was computed
 by calling an `@pure` function).
 """
-struct MethodResultPure
-    info::Any
+struct MethodResultPure <: CallInfo
+    info::CallInfo
 end
-let instance = MethodResultPure(false)
+let instance = MethodResultPure(NoCallInfo())
     global MethodResultPure
     MethodResultPure() = instance
 end
 
 """
-    info::AbstractIterationInfo
+    ainfo::AbstractIterationInfo
 
 Captures all the information for abstract iteration analysis of a single value.
-Each (abstract) call to `iterate`, corresponds to one entry in `info.each::Vector{CallMeta}`.
+Each (abstract) call to `iterate`, corresponds to one entry in `ainfo.each::Vector{CallMeta}`.
 """
 struct AbstractIterationInfo
     each::Vector{CallMeta}
@@ -108,7 +110,7 @@ end
 const MaybeAbstractIterationInfo = Union{Nothing, AbstractIterationInfo}
 
 """
-    info::ApplyCallInfo
+    info::ApplyCallInfo <: CallInfo
 
 This info applies to any call of `_apply_iterate(...)` and captures both the
 info of the actual call being applied and the info for any implicit call
@@ -117,7 +119,7 @@ to be yet another `_apply_iterate`, in which case the `info.call` field will
 be another `ApplyCallInfo`. This info is illegal on any statement that is
 not an `_apply_iterate` call.
 """
-struct ApplyCallInfo
+struct ApplyCallInfo <: CallInfo
     # The info for the call itself
     call::Any
     # AbstractIterationInfo for each argument, if applicable
@@ -125,12 +127,12 @@ struct ApplyCallInfo
 end
 
 """
-    info::UnionSplitApplyCallInfo
+    info::UnionSplitApplyCallInfo <: CallInfo
 
 Like `UnionSplitInfo`, but for `ApplyCallInfo` rather than `MethodMatchInfo`.
 This info is illegal on any statement that is not an `_apply_iterate` call.
 """
-struct UnionSplitApplyCallInfo
+struct UnionSplitApplyCallInfo <: CallInfo
     infos::Vector{ApplyCallInfo}
 end
 
@@ -141,7 +143,7 @@ Represents a resolved call to `Core.invoke`, carrying the `info.match::MethodMat
 the method that has been processed.
 Optionally keeps `info.result::InferenceResult` that keeps constant information.
 """
-struct InvokeCallInfo
+struct InvokeCallInfo <: CallInfo
     match::MethodMatch
     result::Union{Nothing,ConstResult}
 end
@@ -153,20 +155,20 @@ Represents a resolved call of opaque closure, carrying the `info.match::MethodMa
 the method that has been processed.
 Optionally keeps `info.result::InferenceResult` that keeps constant information.
 """
-struct OpaqueClosureCallInfo
+struct OpaqueClosureCallInfo <: CallInfo
     match::MethodMatch
     result::Union{Nothing,ConstResult}
 end
 
 """
-    info::OpaqueClosureCreateInfo
+    info::OpaqueClosureCreateInfo <: CallInfo
 
 This info may be constructed upon opaque closure construction, with `info.unspec::CallMeta`
 carrying out inference result of an unreal, partially specialized call (i.e. specialized on
 the closure environment, but not on the argument types of the opaque closure) in order to
 allow the optimizer to rewrite the return type parameter of the `OpaqueClosure` based on it.
 """
-struct OpaqueClosureCreateInfo
+struct OpaqueClosureCreateInfo <: CallInfo
     unspec::CallMeta
     function OpaqueClosureCreateInfo(unspec::CallMeta)
         @assert isa(unspec.info, OpaqueClosureCallInfo)
@@ -179,24 +181,24 @@ end
 # the AbstractInterpreter.
 
 """
-    info::ReturnTypeCallInfo
+    info::ReturnTypeCallInfo <: CallInfo
 
 Represents a resolved call of `Core.Compiler.return_type`.
 `info.call` wraps the info corresponding to the call that `Core.Compiler.return_type` call
 was supposed to analyze.
 """
-struct ReturnTypeCallInfo
-    info::Any
+struct ReturnTypeCallInfo <: CallInfo
+    info::CallInfo
 end
 
 """
-    info::FinalizerInfo
+    info::FinalizerInfo <: CallInfo
 
 Represents the information of a potential (later) call to the finalizer on the given
 object type.
 """
-struct FinalizerInfo
-    info::Any
+struct FinalizerInfo <: CallInfo
+    info::CallInfo
     effects::Effects
 end
 

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1148,10 +1148,10 @@ end
 function abstract_modifyfield!(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::InferenceState)
     nargs = length(argtypes)
     if !isempty(argtypes) && isvarargtype(argtypes[nargs])
-        nargs - 1 <= 6 || return CallMeta(Bottom, EFFECTS_THROWS, false)
-        nargs > 3 || return CallMeta(Any, EFFECTS_UNKNOWN, false)
+        nargs - 1 <= 6 || return CallMeta(Bottom, EFFECTS_THROWS, NoCallInfo())
+        nargs > 3 || return CallMeta(Any, EFFECTS_UNKNOWN, NoCallInfo())
     else
-        5 <= nargs <= 6 || return CallMeta(Bottom, EFFECTS_THROWS, false)
+        5 <= nargs <= 6 || return CallMeta(Bottom, EFFECTS_THROWS, NoCallInfo())
     end
     o = unwrapva(argtypes[2])
     f = unwrapva(argtypes[3])
@@ -2237,7 +2237,7 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
                 if isa(af_argtype, DataType) && af_argtype <: Tuple
                     argtypes_vec = Any[aft, af_argtype.parameters...]
                     if contains_is(argtypes_vec, Union{})
-                        return CallMeta(Const(Union{}), EFFECTS_TOTAL, false)
+                        return CallMeta(Const(Union{}), EFFECTS_TOTAL, NoCallInfo())
                     end
                     # Run the abstract_call without restricting abstract call
                     # sites. Otherwise, our behavior model of abstract_call
@@ -2279,7 +2279,7 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
             end
         end
     end
-    return CallMeta(Type, EFFECTS_THROWS, false)
+    return CallMeta(Type, EFFECTS_THROWS, NoCallInfo())
 end
 
 # N.B.: typename maps type equivalence classes to a single value

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -284,3 +284,5 @@ infer_compilation_signature(::NativeInterpreter) = true
 typeinf_lattice(::AbstractInterpreter) = InferenceLattice(BaseInferenceLattice.instance)
 ipo_lattice(::AbstractInterpreter) = InferenceLattice(IPOResultLattice.instance)
 optimizer_lattice(::AbstractInterpreter) = OptimizerLattice()
+
+abstract type CallInfo end

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -286,4 +286,17 @@ ipo_lattice(::AbstractInterpreter) = InferenceLattice(IPOResultLattice.instance)
 optimizer_lattice(::AbstractInterpreter) = OptimizerLattice()
 
 abstract type CallInfo end
-call_effects(@nospecialize info::CallInfo) = call_effects_impl(info)::Effects
+
+@nospecialize
+
+call_effects(info::CallInfo) = call_effects_impl(info)::Effects
+nsplit(info::CallInfo) = nsplit_impl(info)::Union{Nothing,Int}
+getsplit(info::CallInfo, idx::Int) = getsplit_impl(info, idx)::MethodLookupResult
+getresult(info::CallInfo, idx::Int) = getresult_impl(info, idx)
+
+call_effects_impl(::CallInfo) = Effects()
+nsplit_impl(::CallInfo) = nothing
+getsplit_impl(::CallInfo, ::Int) = error("unexpected call into `getsplit`")
+getresult_impl(::CallInfo, ::Int) = nothing
+
+@specialize

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -286,3 +286,4 @@ ipo_lattice(::AbstractInterpreter) = InferenceLattice(IPOResultLattice.instance)
 optimizer_lattice(::AbstractInterpreter) = OptimizerLattice()
 
 abstract type CallInfo end
+call_effects(@nospecialize info::CallInfo) = call_effects_impl(info)::Effects


### PR DESCRIPTION
So that `inlining_policy` can see user-`CallInfo` object. It allows us to implement a customized inlining heuristics by just seeing a callsite information, without requiring the inlining cost of cached code to be tweaked.