### PR TITLE
pass around `CallInfo` object to the inlining algorithm [alternative]

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -83,8 +83,9 @@ end
 is_source_inferred(@nospecialize(src::Union{CodeInfo, Vector{UInt8}})) =
     ccall(:jl_ir_flag_inferred, Bool, (Any,), src)
 
-function inlining_policy(interp::AbstractInterpreter, @nospecialize(src), stmt_flag::UInt8,
-                         mi::MethodInstance, argtypes::Vector{Any})
+function inlining_policy(interp::AbstractInterpreter,
+    @nospecialize(src), @nospecialize(info::CallInfo), stmt_flag::UInt8, mi::MethodInstance,
+    argtypes::Vector{Any})
     if isa(src, CodeInfo) || isa(src, Vector{UInt8})
         src_inferred = is_source_inferred(src)
         src_inlineable = is_stmt_inline(stmt_flag) || is_inlineable(src)

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -103,7 +103,7 @@ function ssa_inlining_pass!(ir::IRCode, state::InliningState, propagate_inbounds
     @timeit "analysis" todo = assemble_inline_todo!(ir, state)
     isempty(todo) && return ir
     # Do the actual inlining for every call we identified
-    @timeit "execution" ir = batch_inline!(todo, ir, propagate_inbounds, state.params)
+    @timeit "execution" ir = batch_inline!(ir, todo, propagate_inbounds, state.params)
     return ir
 end
 
@@ -656,7 +656,7 @@ function ir_inline_unionsplit!(compact::IncrementalCompact, idx::Int,
     return insert_node_here!(compact, NewInstruction(pn, typ, line))
 end
 
-function batch_inline!(todo::Vector{Pair{Int, Any}}, ir::IRCode, propagate_inbounds::Bool, params::OptimizationParams)
+function batch_inline!(ir::IRCode, todo::Vector{Pair{Int,Any}}, propagate_inbounds::Bool, params::OptimizationParams)
     # Compute the new CFG first (modulo statement ranges, which will be computed below)
     state = CFGInliningState(ir)
     for (idx, item) in todo
@@ -745,9 +745,9 @@ function batch_inline!(todo::Vector{Pair{Int, Any}}, ir::IRCode, propagate_inbou
 end
 
 # This assumes the caller has verified that all arguments to the _apply_iterate call are Tuples.
-function rewrite_apply_exprargs!(
+function rewrite_apply_exprargs!(todo::Vector{Pair{Int,Any}},
     ir::IRCode, idx::Int, stmt::Expr, argtypes::Vector{Any},
-    arginfos::Vector{MaybeAbstractIterationInfo}, arg_start::Int, istate::InliningState, todo::Vector{Pair{Int, Any}})
+    arginfos::Vector{MaybeAbstractIterationInfo}, arg_start::Int, istate::InliningState)
     flag = ir.stmts[idx][:flag]
     argexprs = stmt.args
     new_argexprs = Any[argexprs[arg_start]]
@@ -803,17 +803,8 @@ function rewrite_apply_exprargs!(
                 state1 = insert_node!(ir, idx, NewInstruction(new_stmt, call.rt))
                 new_sig = call_sig(ir, new_stmt)::Signature
                 new_info = call.info
-                if isa(new_info, ConstCallInfo)
-                    handle_const_call!(
-                        ir, state1.id, new_stmt, new_info, flag,
-                        new_sig, istate, todo)
-                elseif isa(new_info, MethodMatchInfo) || isa(new_info, UnionSplitInfo)
-                    new_infos = isa(new_info, MethodMatchInfo) ? MethodMatchInfo[new_info] : new_info.matches
-                    # See if we can inline this call to `iterate`
-                    handle_call!(
-                        ir, state1.id, new_stmt, new_infos, flag,
-                        new_sig, istate, todo)
-                end
+                # See if we can inline this call to `iterate`
+                handle_call!(todo, ir, state1.id, new_stmt, new_info, flag, new_sig, istate)
                 if i != length(thisarginfo.each)
                     valT = getfield_tfunc(call.rt, Const(1))
                     val_extracted = insert_node!(ir, idx, NewInstruction(
@@ -873,7 +864,7 @@ end
     end
 end
 
-function resolve_todo(todo::InliningTodo, state::InliningState, flag::UInt8)
+function resolve_todo(todo::InliningTodo, state::InliningState, @nospecialize(info::CallInfo), flag::UInt8)
     mi = todo.mi
     (; match, argtypes, invokesig) = todo.spec::DelayedInliningSpec
     et = InliningEdgeTracker(state.et, invokesig)
@@ -905,7 +896,7 @@ function resolve_todo(todo::InliningTodo, state::InliningState, flag::UInt8)
             compilesig_invokes=state.params.compilesig_invokes)
     end
 
-    src = inlining_policy(state.interp, src, flag, mi, argtypes)
+    src = inlining_policy(state.interp, src, info, flag, mi, argtypes)
 
     src === nothing && return compileable_specialization(match, effects, et;
         compilesig_invokes=state.params.compilesig_invokes)
@@ -914,7 +905,8 @@ function resolve_todo(todo::InliningTodo, state::InliningState, flag::UInt8)
     return InliningTodo(mi, retrieve_ir_for_inlining(mi, src), effects)
 end
 
-function resolve_todo(mi::MethodInstance, argtypes::Vector{Any}, state::InliningState, flag::UInt8)
+function resolve_todo(mi::MethodInstance, argtypes::Vector{Any}, state::InliningState,
+    @nospecialize(info::CallInfo), flag::UInt8)
     if !state.params.inlining || is_stmt_noinline(flag)
         return nothing
     end
@@ -928,7 +920,7 @@ function resolve_todo(mi::MethodInstance, argtypes::Vector{Any}, state::Inlining
     end
     (; src, effects) = cached_result
 
-    src = inlining_policy(state.interp, src, flag, mi, argtypes)
+    src = inlining_policy(state.interp, src, info, flag, mi, argtypes)
 
     src === nothing && return nothing
 
@@ -949,7 +941,8 @@ end
 
 function validate_sparams(sparams::SimpleVector)
     for i = 1:length(sparams)
-        (isa(sparams[i], TypeVar) || isvarargtype(sparams[i])) && return false
+        spᵢ = sparams[i]
+        (isa(spᵢ, TypeVar) || isvarargtype(spᵢ)) && return false
     end
     return true
 end
@@ -973,7 +966,7 @@ end
 can_inline_typevars(m::MethodMatch, argtypes::Vector{Any}) = can_inline_typevars(m.method, argtypes)
 
 function analyze_method!(match::MethodMatch, argtypes::Vector{Any}, @nospecialize(invokesig),
-                         flag::UInt8, state::InliningState, allow_typevars::Bool = false)
+                         @nospecialize(info::CallInfo), flag::UInt8, state::InliningState, allow_typevars::Bool = false)
     method = match.method
     spec_types = match.spec_types
 
@@ -1011,7 +1004,7 @@ function analyze_method!(match::MethodMatch, argtypes::Vector{Any}, @nospecializ
     # If we don't have caches here, delay resolving this MethodInstance
     # until the batch inlining step (or an external post-processing pass)
     state.mi_cache === nothing && return todo
-    return resolve_todo(todo, state, flag)
+    return resolve_todo(todo, state, info, flag)
 end
 
 function InliningTodo(mi::MethodInstance, ir::IRCode, effects::Effects)
@@ -1038,9 +1031,9 @@ function flags_for_effects(effects::Effects)
     return flags
 end
 
-function handle_single_case!(
-    ir::IRCode, idx::Int, stmt::Expr,
-    @nospecialize(case), todo::Vector{Pair{Int, Any}}, params::OptimizationParams, isinvoke::Bool = false)
+function handle_single_case!(todo::Vector{Pair{Int,Any}},
+    ir::IRCode, idx::Int, stmt::Expr, @nospecialize(case), params::OptimizationParams,
+    isinvoke::Bool = false)
     if isa(case, ConstantCase)
         ir[SSAValue(idx)][:inst] = case.val
     elseif isa(case, InvokeCase)
@@ -1130,9 +1123,9 @@ function call_sig(ir::IRCode, stmt::Expr)
     return Signature(f, ft, argtypes)
 end
 
-function inline_apply!(
+function inline_apply!(todo::Vector{Pair{Int,Any}},
     ir::IRCode, idx::Int, stmt::Expr, sig::Signature,
-    state::InliningState, todo::Vector{Pair{Int, Any}})
+    state::InliningState)
     while sig.f === Core._apply_iterate
         info = ir.stmts[idx][:info]
         if isa(info, UnionSplitApplyCallInfo)
@@ -1188,9 +1181,8 @@ function inline_apply!(
         end
         # Independent of whether we can inline, the above analysis allows us to rewrite
         # this apply call to a regular call
-        argtypes = rewrite_apply_exprargs!(
-            ir, idx, stmt, argtypes,
-            arginfos, arg_start, state, todo)
+        argtypes = rewrite_apply_exprargs!(todo,
+            ir, idx, stmt, argtypes, arginfos, arg_start, state)
         ir.stmts[idx][:info] = new_info
         has_free_typevars(ft) && return nothing
         f = singleton_type(ft)
@@ -1206,9 +1198,9 @@ is_builtin(s::Signature) =
     isa(s.f, Builtin) ||
     s.ft ⊑ₒ Builtin
 
-function inline_invoke!(
+function handle_invoke_call!(todo::Vector{Pair{Int,Any}},
     ir::IRCode, idx::Int, stmt::Expr, info::InvokeCallInfo, flag::UInt8,
-    sig::Signature, state::InliningState, todo::Vector{Pair{Int, Any}})
+    sig::Signature, state::InliningState)
     match = info.match
     if !match.fully_covers
         # TODO: We could union split out the signature check and continue on
@@ -1221,17 +1213,17 @@ function inline_invoke!(
     else
         argtypes = invoke_rewrite(sig.argtypes)
         if isa(result, ConstPropResult)
-            (; mi) = item = InliningTodo(result.result, argtypes, invokesig)
-            validate_sparams(mi.sparam_vals) || return nothing
-            if argtypes_to_type(argtypes) <: mi.def.sig
-                state.mi_cache !== nothing && (item = resolve_todo(item, state, flag))
-                handle_single_case!(ir, idx, stmt, item, todo, state.params, true)
+            item = InliningTodo(result.result, argtypes, invokesig)
+            validate_sparams(item.mi.sparam_vals) || return nothing
+            if argtypes_to_type(argtypes) <: item.mi.def.sig
+                state.mi_cache !== nothing && (item = resolve_todo(item, state, info, flag))
+                handle_single_case!(todo, ir, idx, stmt, item, state.params, true)
                 return nothing
             end
         end
-        item = analyze_method!(match, argtypes, invokesig, flag, state)
+        item = analyze_method!(match, argtypes, invokesig, info, flag, state)
     end
-    handle_single_case!(ir, idx, stmt, item, todo, state.params, true)
+    handle_single_case!(todo, ir, idx, stmt, item, state.params, true)
     return nothing
 end
 
@@ -1240,7 +1232,7 @@ function invoke_signature(argtypes::Vector{Any})
     return rewrap_unionall(Tuple{ft, unwrap_unionall(argtyps).parameters...}, argtyps)
 end
 
-function narrow_opaque_closure!(ir::IRCode, stmt::Expr, @nospecialize(info), state::InliningState)
+function narrow_opaque_closure!(ir::IRCode, stmt::Expr, @nospecialize(info::CallInfo), state::InliningState)
     if isa(info, OpaqueClosureCreateInfo)
         lbt = argextype(stmt.args[2], ir)
         lb, exact = instanceof_tfunc(lbt)
@@ -1278,7 +1270,7 @@ end
 # Handles all analysis and inlining of intrinsics and builtins. In particular,
 # this method does not access the method table or otherwise process generic
 # functions.
-function process_simple!(ir::IRCode, idx::Int, state::InliningState, todo::Vector{Pair{Int, Any}})
+function process_simple!(ir::IRCode, idx::Int, state::InliningState, todo::Vector{Pair{Int,Any}})
     stmt = ir.stmts[idx][:inst]
     rt = ir.stmts[idx][:type]
     if !(stmt isa Expr)
@@ -1304,7 +1296,7 @@ function process_simple!(ir::IRCode, idx::Int, state::InliningState, todo::Vecto
     sig === nothing && return nothing
 
     # Handle _apply_iterate
-    sig = inline_apply!(ir, idx, stmt, sig, state, todo)
+    sig = inline_apply!(todo, ir, idx, stmt, sig, state)
     sig === nothing && return nothing
 
     # Check if we match any of the early inliners
@@ -1338,18 +1330,19 @@ function process_simple!(ir::IRCode, idx::Int, state::InliningState, todo::Vecto
     return stmt, sig
 end
 
-function handle_any_const_result!(cases::Vector{InliningCase}, @nospecialize(result), match::MethodMatch, argtypes::Vector{Any}, flag::UInt8, state::InliningState, allow_typevars::Bool=false)
+function handle_any_const_result!(cases::Vector{InliningCase},
+    @nospecialize(result), match::MethodMatch, argtypes::Vector{Any},
+    @nospecialize(info::CallInfo), flag::UInt8, state::InliningState;
+    allow_abstract::Bool, allow_typevars::Bool)
     if isa(result, ConcreteResult)
-        case = concrete_result_item(result, state)
-        push!(cases, InliningCase(result.mi.specTypes, case))
-        return true
-    elseif isa(result, ConstPropResult)
-        return handle_const_prop_result!(result, argtypes, flag, state, cases, #=allow_abstract=#true, allow_typevars)
+        return handle_concrete_result!(cases, result, state)
     elseif isa(result, SemiConcreteResult)
-        return handle_semi_concrete_result!(result, cases, #=allow_abstract=#true)
+        return handle_semi_concrete_result!(cases, result; allow_abstract)
+    elseif isa(result, ConstPropResult)
+        return handle_const_prop_result!(cases, result, argtypes, info, flag, state; allow_abstract, allow_typevars)
     else
         @assert result === nothing
-        return handle_match!(match, argtypes, flag, state, cases, #=allow_abstract=#true, allow_typevars)
+        return handle_match!(cases, match, argtypes, info, flag, state; allow_abstract, allow_typevars)
     end
 end
 
@@ -1372,17 +1365,12 @@ function info_effects(@nospecialize(result), match::MethodMatch, state::Inlining
     end
 end
 
-function compute_inlining_cases(info::Union{ConstCallInfo, Vector{MethodMatchInfo}},
-    flag::UInt8, sig::Signature, state::InliningState)
-    argtypes = sig.argtypes
-    if isa(info, ConstCallInfo)
-        (; call, results) = info
-        infos = isa(call, MethodMatchInfo) ? MethodMatchInfo[call] : call.matches
-    else
-        results = nothing
-        infos = info
-    end
+function compute_inlining_cases(@nospecialize(info::CallInfo), flag::UInt8, sig::Signature,
+    state::InliningState)
+    nunion = nsplit(info)
+    nunion === nothing && return nothing
     cases = InliningCase[]
+    argtypes = sig.argtypes
     local any_fully_covered = false
     local handled_all_cases::Bool = true
     local revisit_idx = nothing
@@ -1391,8 +1379,8 @@ function compute_inlining_cases(info::Union{ConstCallInfo, Vector{MethodMatchInf
     local all_result_count = 0
     local joint_effects::Effects = EFFECTS_TOTAL
     local nothrow::Bool = true
-    for i in 1:length(infos)
-        meth = infos[i].results
+    for i = 1:nunion
+        meth = getsplit(info, i)
         if meth.ambig
             # Too many applicable methods
             # Or there is a (partial?) ambiguity
@@ -1414,7 +1402,7 @@ function compute_inlining_cases(info::Union{ConstCallInfo, Vector{MethodMatchInf
         end
         for (j, match) in enumerate(meth)
             all_result_count += 1
-            result = results === nothing ? nothing : results[all_result_count]
+            result = getresult(info, all_result_count)
             joint_effects = merge_effects(joint_effects, info_effects(result, match, state))
             nothrow &= match.fully_covers
             any_fully_covered |= match.fully_covers
@@ -1430,7 +1418,8 @@ function compute_inlining_cases(info::Union{ConstCallInfo, Vector{MethodMatchInf
                     revisit_idx = nothing
                 end
             else
-                handled_all_cases &= handle_any_const_result!(cases, result, match, argtypes, flag, state, false)
+                handled_all_cases &= handle_any_const_result!(cases,
+                    result, match, argtypes, info, flag, state; allow_abstract=true, allow_typevars=false)
             end
         end
     end
@@ -1441,15 +1430,16 @@ function compute_inlining_cases(info::Union{ConstCallInfo, Vector{MethodMatchInf
         # we handled everything except one match with unmatched sparams,
         # so try to handle it by bypassing validate_sparams
         (i, j, k) = revisit_idx
-        match = infos[i].results[j]
-        result = results === nothing ? nothing : results[k]
-        handled_all_cases &= handle_any_const_result!(cases, result, match, argtypes, flag, state, true)
+        match = getsplit(info, i)[j]
+        result = getresult(info, k)
+        handled_all_cases &= handle_any_const_result!(cases,
+            result, match, argtypes, info, flag, state; allow_abstract=true, allow_typevars=true)
     elseif length(cases) == 0 && only_method isa Method
         # if the signature is fully covered and there is only one applicable method,
         # we can try to inline it even in the presence of unmatched sparams
         # -- But don't try it if we already tried to handle the match in the revisit_idx
         # case, because that'll (necessarily) be the same method.
-        if length(infos) > 1
+        if nsplit(info) > 1
             atype = argtypes_to_type(argtypes)
             (metharg, methsp) = ccall(:jl_type_intersection_with_env, Any, (Any, Any), atype, only_method.sig)::SimpleVector
             match = MethodMatch(metharg, methsp::SimpleVector, only_method, true)
@@ -1457,9 +1447,10 @@ function compute_inlining_cases(info::Union{ConstCallInfo, Vector{MethodMatchInf
         else
             @assert length(meth) == 1
             match = meth[1]
-            result = results === nothing ? nothing : results[1]
+            result = getresult(info, 1)
         end
-        handle_any_const_result!(cases, result, match, argtypes, flag, state, true)
+        handle_any_const_result!(cases,
+            result, match, argtypes, info, flag, state; allow_abstract=true, allow_typevars=true)
         any_fully_covered = handled_all_cases = match.fully_covers
     elseif !handled_all_cases
         # if we've not seen all candidates, union split is valid only for dispatch tuples
@@ -1469,62 +1460,60 @@ function compute_inlining_cases(info::Union{ConstCallInfo, Vector{MethodMatchInf
     return cases, (handled_all_cases & any_fully_covered), joint_effects
 end
 
-function handle_call!(
-    ir::IRCode, idx::Int, stmt::Expr, infos::Vector{MethodMatchInfo}, flag::UInt8,
-    sig::Signature, state::InliningState, todo::Vector{Pair{Int, Any}})
-    cases = compute_inlining_cases(infos, flag, sig, state)
-    cases === nothing && return nothing
-    cases, all_covered, joint_effects = cases
-    handle_cases!(ir, idx, stmt, argtypes_to_type(sig.argtypes), cases,
-        all_covered, todo, state.params, joint_effects)
-end
-
-function handle_const_call!(
-    ir::IRCode, idx::Int, stmt::Expr, info::ConstCallInfo, flag::UInt8,
-    sig::Signature, state::InliningState, todo::Vector{Pair{Int, Any}})
+function handle_call!(todo::Vector{Pair{Int,Any}},
+    ir::IRCode, idx::Int, stmt::Expr, @nospecialize(info::CallInfo), flag::UInt8, sig::Signature,
+    state::InliningState)
     cases = compute_inlining_cases(info, flag, sig, state)
     cases === nothing && return nothing
     cases, all_covered, joint_effects = cases
-    handle_cases!(ir, idx, stmt, argtypes_to_type(sig.argtypes), cases,
-        all_covered, todo, state.params, joint_effects)
+    handle_cases!(todo, ir, idx, stmt, argtypes_to_type(sig.argtypes), cases,
+        all_covered, joint_effects, state.params)
 end
 
-function handle_match!(
-    match::MethodMatch, argtypes::Vector{Any}, flag::UInt8, state::InliningState,
-    cases::Vector{InliningCase}, allow_abstract::Bool, allow_typevars::Bool)
+function handle_match!(cases::Vector{InliningCase},
+    match::MethodMatch, argtypes::Vector{Any}, @nospecialize(info::CallInfo), flag::UInt8,
+    state::InliningState;
+    allow_abstract::Bool, allow_typevars::Bool)
     spec_types = match.spec_types
     allow_abstract || isdispatchtuple(spec_types) || return false
     # We may see duplicated dispatch signatures here when a signature gets widened
     # during abstract interpretation: for the purpose of inlining, we can just skip
     # processing this dispatch candidate (unless unmatched type parameters are present)
     !allow_typevars && _any(case->case.sig === spec_types, cases) && return true
-    item = analyze_method!(match, argtypes, nothing, flag, state, allow_typevars)
+    item = analyze_method!(match, argtypes, nothing, info, flag, state, allow_typevars)
     item === nothing && return false
     push!(cases, InliningCase(spec_types, item))
     return true
 end
 
-function handle_const_prop_result!(
-    result::ConstPropResult, argtypes::Vector{Any}, flag::UInt8, state::InliningState,
-    cases::Vector{InliningCase}, allow_abstract::Bool, allow_typevars::Bool = false)
-    (; mi) = item = InliningTodo(result.result, argtypes)
-    spec_types = mi.specTypes
+function handle_const_prop_result!(cases::Vector{InliningCase},
+    result::ConstPropResult, argtypes::Vector{Any}, @nospecialize(info::CallInfo),
+    flag::UInt8, state::InliningState;
+    allow_abstract::Bool, allow_typevars::Bool)
+    item = InliningTodo(result.result, argtypes)
+    spec_types = item.mi.specTypes
     allow_abstract || isdispatchtuple(spec_types) || return false
-    if !validate_sparams(mi.sparam_vals)
-        (allow_typevars && can_inline_typevars(mi.def, argtypes)) || return false
+    if !validate_sparams(item.mi.sparam_vals)
+        (allow_typevars && can_inline_typevars(item.mi.def, argtypes)) || return false
     end
-    state.mi_cache !== nothing && (item = resolve_todo(item, state, flag))
+    state.mi_cache !== nothing && (item = resolve_todo(item, state, info, flag))
     item === nothing && return false
     push!(cases, InliningCase(spec_types, item))
     return true
 end
 
-function handle_semi_concrete_result!(result::SemiConcreteResult, cases::Vector{InliningCase}, allow_abstract::Bool = false)
+function handle_semi_concrete_result!(cases::Vector{InliningCase}, result::SemiConcreteResult; allow_abstract::Bool)
     mi = result.mi
     spec_types = mi.specTypes
     allow_abstract || isdispatchtuple(spec_types) || return false
     validate_sparams(mi.sparam_vals) || return false
     push!(cases, InliningCase(spec_types, InliningTodo(mi, result.ir, result.effects)))
+    return true
+end
+
+function handle_concrete_result!(cases::Vector{InliningCase}, result::ConcreteResult, state::InliningState)
+    case = concrete_result_item(result, state)
+    push!(cases, InliningCase(result.mi.specTypes, case))
     return true
 end
 
@@ -1540,14 +1529,14 @@ function concrete_result_item(result::ConcreteResult, state::InliningState, @nos
     return ConstantCase(quoted(result.result))
 end
 
-function handle_cases!(ir::IRCode, idx::Int, stmt::Expr, @nospecialize(atype),
-    cases::Vector{InliningCase}, fully_covered::Bool, todo::Vector{Pair{Int, Any}},
-    params::OptimizationParams, joint_effects::Effects)
+function handle_cases!(todo::Vector{Pair{Int,Any}}, ir::IRCode, idx::Int, stmt::Expr,
+    @nospecialize(atype), cases::Vector{InliningCase}, fully_covered::Bool,
+    joint_effects::Effects, params::OptimizationParams)
     # If we only have one case and that case is fully covered, we may either
     # be able to do the inlining now (for constant cases), or push it directly
     # onto the todo list
     if fully_covered && length(cases) == 1
-        handle_single_case!(ir, idx, stmt, cases[1].item, todo, params)
+        handle_single_case!(todo, ir, idx, stmt, cases[1].item, params)
     elseif length(cases) > 0
         isa(atype, DataType) || return nothing
         for case in cases
@@ -1560,13 +1549,20 @@ function handle_cases!(ir::IRCode, idx::Int, stmt::Expr, @nospecialize(atype),
     return nothing
 end
 
-function handle_const_opaque_closure_call!(
-    ir::IRCode, idx::Int, stmt::Expr, result::ConstPropResult, flag::UInt8,
-    sig::Signature, state::InliningState, todo::Vector{Pair{Int, Any}})
-    item = InliningTodo(result.result, sig.argtypes)
-    validate_sparams(item.mi.sparam_vals) || return nothing
-    state.mi_cache !== nothing && (item = resolve_todo(item, state, flag))
-    handle_single_case!(ir, idx, stmt, item, todo, state.params)
+function handle_opaque_closure_call!(todo::Vector{Pair{Int,Any}},
+    ir::IRCode, idx::Int, stmt::Expr, info::OpaqueClosureCallInfo,
+    flag::UInt8, sig::Signature, state::InliningState)
+    result = info.result
+    if isa(result, ConstPropResult)
+        item = InliningTodo(result.result, sig.argtypes)
+        validate_sparams(item.mi.sparam_vals) || return nothing
+        state.mi_cache !== nothing && (item = resolve_todo(item, state, info, flag))
+    elseif isa(result, ConcreteResult)
+        item = concrete_result_item(result, state)
+    else
+        item = analyze_method!(info.match, sig.argtypes, nothing, info, flag, state)
+    end
+    handle_single_case!(todo, ir, idx, stmt, item, state.params)
     return nothing
 end
 
@@ -1587,8 +1583,8 @@ function handle_modifyfield!_call!(ir::IRCode, idx::Int, stmt::Expr, info::Modif
     return nothing
 end
 
-function handle_finalizer_call!(
-    ir::IRCode, idx::Int, stmt::Expr, info::FinalizerInfo, state::InliningState)
+function handle_finalizer_call!(ir::IRCode, idx::Int, stmt::Expr, info::FinalizerInfo,
+    state::InliningState)
 
     # Finalizers don't return values, so if their execution is not observable,
     # we can just not register them
@@ -1601,20 +1597,6 @@ function handle_finalizer_call!(
     # This avoids having to set up state for finalizer isolation
     is_finalizer_inlineable(info.effects) || return nothing
 
-    info = info.info
-    if isa(info, ConstCallInfo)
-        # NOTE currently mutable objects are not represented as `Const`
-        # but `finalizer` function can be
-        info = info.call
-    end
-    if isa(info, MethodMatchInfo)
-        infos = MethodMatchInfo[info]
-    elseif isa(info, UnionSplitInfo)
-        infos = info.matches
-    else
-        return nothing
-    end
-
     ft = argextype(stmt.args[2], ir)
     has_free_typevars(ft) && return nothing
     f = singleton_type(ft)
@@ -1623,7 +1605,7 @@ function handle_finalizer_call!(
     argtypes[2] = argextype(stmt.args[3], ir)
     sig = Signature(f, ft, argtypes)
 
-    cases = compute_inlining_cases(infos, #=flag=#UInt8(0), sig, state)
+    cases = compute_inlining_cases(info.info, #=flag=#UInt8(0), sig, state)
     cases === nothing && return nothing
     cases, all_covered, _ = cases
     if all_covered && length(cases) == 1
@@ -1644,10 +1626,10 @@ function handle_finalizer_call!(
     return nothing
 end
 
-function handle_invoke!(todo::Vector{Pair{Int,Any}},
-    idx::Int, stmt::Expr, flag::UInt8, sig::Signature, state::InliningState)
+function handle_invoke_expr!(todo::Vector{Pair{Int,Any}},
+    idx::Int, stmt::Expr, @nospecialize(info::CallInfo), flag::UInt8, sig::Signature, state::InliningState)
     mi = stmt.args[1]::MethodInstance
-    case = resolve_todo(mi, sig.argtypes, state, flag)
+    case = resolve_todo(mi, sig.argtypes, state, info, flag)
     if case !== nothing
         push!(todo, idx=>(case::InliningTodo))
     end
@@ -1673,15 +1655,14 @@ function assemble_inline_todo!(ir::IRCode, state::InliningState)
         stmt, sig = simpleres
 
         flag = ir.stmts[idx][:flag]
+        info = ir.stmts[idx][:info]
 
         # `NativeInterpreter` won't need this, but provide a support for `:invoke` exprs here
         # for external `AbstractInterpreter`s that may run the inlining pass multiple times
         if isexpr(stmt, :invoke)
-            handle_invoke!(todo, idx, stmt, flag, sig, state)
+            handle_invoke_expr!(todo, idx, stmt, info, flag, sig, state)
             continue
         end
-
-        info = ir.stmts[idx][:info]
 
         # Check whether this call was @pure and evaluates to a constant
         if info isa MethodResultPure
@@ -1693,53 +1674,19 @@ function assemble_inline_todo!(ir::IRCode, state::InliningState)
             continue
         end
 
-        if isa(info, OpaqueClosureCallInfo)
-            result = info.result
-            if isa(result, ConstPropResult)
-                handle_const_opaque_closure_call!(
-                    ir, idx, stmt, result, flag,
-                    sig, state, todo)
-            else
-                if isa(result, ConcreteResult)
-                    item = concrete_result_item(result, state)
-                else
-                    item = analyze_method!(info.match, sig.argtypes, nothing, flag, state)
-                end
-                handle_single_case!(ir, idx, stmt, item, todo, state.params)
-            end
-            continue
-        end
-
         # handle special cased builtins
-        if isa(info, ModifyFieldInfo)
+        if isa(info, OpaqueClosureCallInfo)
+            handle_opaque_closure_call!(todo, ir, idx, stmt, info, flag, sig, state)
+        elseif isa(info, ModifyFieldInfo)
             handle_modifyfield!_call!(ir, idx, stmt, info, state)
-            continue
         elseif isa(info, InvokeCallInfo)
-            inline_invoke!(ir, idx, stmt, info, flag, sig, state, todo)
-            continue
+            handle_invoke_call!(todo, ir, idx, stmt, info, flag, sig, state)
         elseif isa(info, FinalizerInfo)
             handle_finalizer_call!(ir, idx, stmt, info, state)
-        end
-
-        # if inference arrived here with constant-prop'ed result(s),
-        # we can perform a specialized analysis for just this case
-        if isa(info, ConstCallInfo)
-            handle_const_call!(
-                ir, idx, stmt, info, flag,
-                sig, state, todo)
-            continue
-        end
-
-        # Ok, now figure out what method to call
-        if isa(info, MethodMatchInfo)
-            infos = MethodMatchInfo[info]
-        elseif isa(info, UnionSplitInfo)
-            infos = info.matches
         else
-            continue # isa(info, ReturnTypeCallInfo), etc.
+            # cascade to the generic (and extendable) handler
+            handle_call!(todo, ir, idx, stmt, info, flag, sig, state)
         end
-
-        handle_call!(ir, idx, stmt, infos, flag, sig, state, todo)
     end
 
     return todo

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -294,3 +294,15 @@ ipo_lattice(::AbstractInterpreter) = InferenceLattice(IPOResultLattice.instance)
 optimizer_lattice(::AbstractInterpreter) = OptimizerLattice()
 
 abstract type CallInfo end
+
+@nospecialize
+
+nsplit(info::CallInfo) = nsplit_impl(info)::Union{Nothing,Int}
+getsplit(info::CallInfo, idx::Int) = getsplit_impl(info, idx)::MethodLookupResult
+getresult(info::CallInfo, idx::Int) = getresult_impl(info, idx)
+
+nsplit_impl(::CallInfo) = nothing
+getsplit_impl(::CallInfo, ::Int) = error("unexpected call into `getsplit`")
+getresult_impl(::CallInfo, ::Int) = nothing
+
+@specialize

--- a/test/compiler/AbstractInterpreter.jl
+++ b/test/compiler/AbstractInterpreter.jl
@@ -5,6 +5,8 @@ const CC = Core.Compiler
 import Core: MethodInstance, CodeInstance
 import .CC: WorldRange, WorldView
 
+include("irutils.jl")
+
 # define new `AbstractInterpreter` that satisfies the minimum interface requirements
 # while managing its cache independently
 macro newinterp(name)
@@ -238,3 +240,114 @@ end
 @test CC.tmerge(typeinf_lattice(TaintInterpreter()), Taint(Int, 1), Taint(Int, 2)) == Taint(Int, BitSet(1:2))
 
 # code_typed(ifelse, (Bool, Int, Int); interp=TaintInterpreter())
+
+# CallInfo × inlining
+# ===================
+
+import .CC: CallInfo
+
+struct NoinlineInterpreterCache
+    dict::IdDict{MethodInstance,CodeInstance}
+end
+
+"""
+    NoinlineInterpreter(noinline_modules::Set{Module}) <: AbstractInterpreter
+
+An `AbstractInterpreter` that has additional inlineability rules based on caller module context.
+"""
+struct NoinlineInterpreter <: CC.AbstractInterpreter
+    noinline_modules::Set{Module}
+    interp::CC.NativeInterpreter
+    cache::NoinlineInterpreterCache
+    NoinlineInterpreter(noinline_modules::Set{Module}, world = Base.get_world_counter();
+        interp = CC.NativeInterpreter(world),
+        cache = NoinlineInterpreterCache(IdDict{MethodInstance,CodeInstance}())
+        ) = new(noinline_modules, interp, cache)
+end
+CC.InferenceParams(interp::NoinlineInterpreter) = CC.InferenceParams(interp.interp)
+CC.OptimizationParams(interp::NoinlineInterpreter) = CC.OptimizationParams(interp.interp)
+CC.get_world_counter(interp::NoinlineInterpreter) = CC.get_world_counter(interp.interp)
+CC.get_inference_cache(interp::NoinlineInterpreter) = CC.get_inference_cache(interp.interp)
+CC.code_cache(interp::NoinlineInterpreter) = WorldView(interp.cache, WorldRange(CC.get_world_counter(interp)))
+CC.get(wvc::WorldView{<:NoinlineInterpreterCache}, mi::MethodInstance, default) = get(wvc.cache.dict, mi, default)
+CC.getindex(wvc::WorldView{<:NoinlineInterpreterCache}, mi::MethodInstance) = getindex(wvc.cache.dict, mi)
+CC.haskey(wvc::WorldView{<:NoinlineInterpreterCache}, mi::MethodInstance) = haskey(wvc.cache.dict, mi)
+CC.setindex!(wvc::WorldView{<:NoinlineInterpreterCache}, ci::CodeInstance, mi::MethodInstance) = setindex!(wvc.cache.dict, ci, mi)
+
+struct NoinlineCallInfo <: CallInfo
+    info::CallInfo # wrapped call
+end
+CC.nsplit_impl(info::NoinlineCallInfo) = CC.nsplit(info.info)
+CC.getsplit_impl(info::NoinlineCallInfo, idx::Int) = CC.getsplit(info.info, idx)
+CC.getresult_impl(info::NoinlineCallInfo, idx::Int) = CC.getresult(info.info, idx)
+
+function CC.abstract_call(interp::NoinlineInterpreter,
+    arginfo::CC.ArgInfo, si::CC.StmtInfo, sv::CC.InferenceState, max_methods::Union{Int,Nothing})
+    ret = @invoke CC.abstract_call(interp::CC.AbstractInterpreter,
+        arginfo::CC.ArgInfo, si::CC.StmtInfo, sv::CC.InferenceState, max_methods::Union{Int,Nothing})
+    if sv.mod in interp.noinline_modules
+        return CC.CallMeta(ret.rt, ret.effects, NoinlineCallInfo(ret.info))
+    end
+    return ret
+end
+function CC.inlining_policy(interp::NoinlineInterpreter,
+    @nospecialize(src), @nospecialize(info::CallInfo), stmt_flag::UInt8, mi::MethodInstance,
+    argtypes::Vector{Any})
+    if isa(info, NoinlineCallInfo)
+        return nothing
+    end
+    return @invoke CC.inlining_policy(interp::CC.AbstractInterpreter,
+        src::Any, info::CallInfo, stmt_flag::UInt8, mi::MethodInstance,
+        argtypes::Vector{Any})
+end
+
+@inline function inlined_usually(x, y, z)
+    return x * y + z
+end
+
+# check if the inlining algorithm works as expected
+let src = code_typed1((Float64,Float64,Float64)) do x, y, z
+        inlined_usually(x, y, z)
+    end
+    @test count(isinvoke(:inlined_usually), src.code) == 0
+    @test count(iscall((src, inlined_usually)), src.code) == 0
+end
+let NoinlineModule = Module()
+    interp = NoinlineInterpreter(Set((NoinlineModule,)))
+
+    # this anonymous function's context is Main -- it should be inlined as usual
+    let src = code_typed1((Float64,Float64,Float64); interp) do x, y, z
+            inlined_usually(x, y, z)
+        end
+        @test count(isinvoke(:inlined_usually), src.code) == 0
+        @test count(iscall((src, inlined_usually)), src.code) == 0
+    end
+
+    # it should work for cached results
+    method = only(methods(inlined_usually, (Float64,Float64,Float64,)))
+    mi = CC.specialize_method(method, Tuple{typeof(inlined_usually),Float64,Float64,Float64}, Core.svec())
+    @test haskey(interp.cache.dict, mi)
+    let src = code_typed1((Float64,Float64,Float64); interp) do x, y, z
+            inlined_usually(x, y, z)
+        end
+        @test count(isinvoke(:inlined_usually), src.code) == 0
+        @test count(iscall((src, inlined_usually)), src.code) == 0
+    end
+
+    # now the context module is `NoinlineModule` -- it should not be inlined
+    let src = @eval NoinlineModule $code_typed1((Float64,Float64,Float64); interp=$interp) do x, y, z
+            $inlined_usually(x, y, z)
+        end
+        @test count(isinvoke(:inlined_usually), src.code) == 1
+        @test count(iscall((src, inlined_usually)), src.code) == 0
+    end
+
+    # the context module is totally irrelevant -- it should be inlined as usual
+    OtherModule = Module()
+    let src = @eval OtherModule $code_typed1((Float64,Float64,Float64); interp=$interp) do x, y, z
+            $inlined_usually(x, y, z)
+        end
+        @test count(isinvoke(:inlined_usually), src.code) == 0
+        @test count(iscall((src, inlined_usually)), src.code) == 0
+    end
+end


### PR DESCRIPTION
This is another trial of #46963. 
The purpose is to drop #46962 and see if it cuts off the allocation regressions.

The original description follows:

---

So that `inlining_policy` can see user-`CallInfo` object. It allows us to implement a customized inlining heuristics by just seeing a callsite information, without requiring the inlining cost of cached code to be tweaked.