### PR TITLE
Don't rely on implicit information for statement used-ness.

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -13,8 +13,9 @@ const _REF_NAME = Ref.body.name
 # See if the inference result of the current statement's result value might affect
 # the final answer for the method (aside from optimization potential and exceptions).
 # To do that, we need to check both for slot assignment and SSA usage.
-call_result_unused(frame::InferenceState) =
-    isexpr(frame.src.code[frame.currpc], :call) && isempty(frame.ssavalue_uses[frame.currpc])
+call_result_unused(frame::InferenceState, currpc::Int) =
+    isexpr(frame.src.code[currpc], :call) && isempty(frame.ssavalue_uses[currpc])
+call_result_unused(si::StmtInfo) = !si.used
 
 function get_max_methods(mod::Module, interp::AbstractInterpreter)
     max_methods = ccall(:jl_get_module_max_methods, Cint, (Any,), mod) % Int
@@ -50,7 +51,7 @@ function should_infer_for_effects(sv::InferenceState)
 end
 
 function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
-                                  arginfo::ArgInfo, @nospecialize(atype),
+                                  arginfo::ArgInfo, si::StmtInfo, @nospecialize(atype),
                                   sv::InferenceState, max_methods::Int)
     ⊑ᵢ = ⊑(typeinf_lattice(interp))
     if !should_infer_this_call(sv)
@@ -103,7 +104,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
     end
 
     # try pure-evaluation
-    val = pure_eval_call(interp, f, applicable, arginfo, sv)
+    val = pure_eval_call(interp, f, applicable, arginfo)
     val !== nothing && return CallMeta(val, all_effects, MethodResultPure(info)) # TODO: add some sort of edge(s)
 
     for i in 1:napplicable
@@ -124,12 +125,12 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
         if splitunions
             splitsigs = switchtupleunion(sig)
             for sig_n in splitsigs
-                result = abstract_call_method(interp, method, sig_n, svec(), multiple_matches, sv)
+                result = abstract_call_method(interp, method, sig_n, svec(), multiple_matches, si, sv)
                 (; rt, edge, effects) = result
                 this_argtypes = isa(matches, MethodMatches) ? argtypes : matches.applicable_argtypes[i]
                 this_arginfo = ArgInfo(fargs, this_argtypes)
                 const_call_result = abstract_call_method_with_const_args(interp, result,
-                    f, this_arginfo, match, sv)
+                    f, this_arginfo, si, match, sv)
                 const_result = nothing
                 if const_call_result !== nothing
                     if const_call_result.rt ⊑ᵢ rt
@@ -149,7 +150,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
             this_conditional = ignorelimited(this_rt)
             this_rt = widenwrappedconditional(this_rt)
         else
-            result = abstract_call_method(interp, method, sig, match.sparams, multiple_matches, sv)
+            result = abstract_call_method(interp, method, sig, match.sparams, multiple_matches, si, sv)
             (; rt, edge, effects) = result
             this_conditional = ignorelimited(rt)
             this_rt = widenwrappedconditional(rt)
@@ -158,7 +159,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
             this_argtypes = isa(matches, MethodMatches) ? argtypes : matches.applicable_argtypes[i]
             this_arginfo = ArgInfo(fargs, this_argtypes)
             const_call_result = abstract_call_method_with_const_args(interp, result,
-                f, this_arginfo, match, sv)
+                f, this_arginfo, si, match, sv)
             const_result = nothing
             if const_call_result !== nothing
                 this_const_conditional = ignorelimited(const_call_result.rt)
@@ -222,17 +223,12 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
         if mi !== nothing && !const_prop_methodinstance_heuristic(interp, match, mi::MethodInstance, arginfo, sv)
             csig = get_compileable_sig(method, sig, match.sparams)
             if csig !== nothing && csig !== sig
-                # The result of this inference is not directly used, so temporarily empty
-                # the use set for the current SSA value.
-                saved_uses = sv.ssavalue_uses[sv.currpc]
-                sv.ssavalue_uses[sv.currpc] = empty_bitset
-                abstract_call_method(interp, method, csig, match.sparams, multiple_matches, sv)
-                sv.ssavalue_uses[sv.currpc] = saved_uses
+                abstract_call_method(interp, method, csig, match.sparams, multiple_matches, StmtInfo(false), sv)
             end
         end
     end
 
-    if call_result_unused(sv) && !(rettype === Bottom)
+    if call_result_unused(si) && !(rettype === Bottom)
         add_remark!(interp, sv, "Call result type was widened because the return value is unused")
         # We're mainly only here because the optimizer might want this code,
         # but we ourselves locally don't typically care about it locally
@@ -499,7 +495,7 @@ end
 const RECURSION_UNUSED_MSG = "Bounded recursion detected with unused result. Annotated return type may be wider than true result."
 const RECURSION_MSG = "Bounded recursion detected. Call was widened to force convergence."
 
-function abstract_call_method(interp::AbstractInterpreter, method::Method, @nospecialize(sig), sparams::SimpleVector, hardlimit::Bool, sv::InferenceState)
+function abstract_call_method(interp::AbstractInterpreter, method::Method, @nospecialize(sig), sparams::SimpleVector, hardlimit::Bool, si::StmtInfo, sv::InferenceState)
     if method.name === :depwarn && isdefined(Main, :Base) && method.module === Main.Base
         add_remark!(interp, sv, "Refusing to infer into `depwarn`")
         return MethodCallResult(Any, false, false, nothing, Effects())
@@ -517,7 +513,7 @@ function abstract_call_method(interp::AbstractInterpreter, method::Method, @nosp
             if infstate.linfo.specTypes::Type == sig::Type
                 # avoid widening when detecting self-recursion
                 # TODO: merge call cycle and return right away
-                if call_result_unused(sv)
+                if call_result_unused(si)
                     add_remark!(interp, sv, RECURSION_UNUSED_MSG)
                     # since we don't use the result (typically),
                     # we have a self-cycle in the call-graph, but not in the inference graph (typically):
@@ -565,7 +561,7 @@ function abstract_call_method(interp::AbstractInterpreter, method::Method, @nosp
         if newsig !== sig
             # continue inference, but note that we've limited parameter complexity
             # on this call (to ensure convergence), so that we don't cache this result
-            if call_result_unused(sv)
+            if call_result_unused(si)
                 add_remark!(interp, sv, RECURSION_UNUSED_MSG)
                 # if we don't (typically) actually care about this result,
                 # don't bother trying to examine some complex abstract signature
@@ -745,7 +741,7 @@ struct MethodCallResult
 end
 
 function pure_eval_eligible(interp::AbstractInterpreter,
-    @nospecialize(f), applicable::Vector{Any}, arginfo::ArgInfo, sv::InferenceState)
+    @nospecialize(f), applicable::Vector{Any}, arginfo::ArgInfo)
     # XXX we need to check that this pure function doesn't call any overlayed method
     return f !== nothing &&
            length(applicable) == 1 &&
@@ -767,8 +763,8 @@ end
 is_method_pure(match::MethodMatch) = is_method_pure(match.method, match.spec_types, match.sparams)
 
 function pure_eval_call(interp::AbstractInterpreter,
-    @nospecialize(f), applicable::Vector{Any}, arginfo::ArgInfo, sv::InferenceState)
-    pure_eval_eligible(interp, f, applicable, arginfo, sv) || return nothing
+    @nospecialize(f), applicable::Vector{Any}, arginfo::ArgInfo)
+    pure_eval_eligible(interp, f, applicable, arginfo) || return nothing
     return _pure_eval_call(f, arginfo)
 end
 function _pure_eval_call(@nospecialize(f), arginfo::ArgInfo)
@@ -785,7 +781,7 @@ end
 # - false: eligible for semi-concrete evaluation
 # - nothing: not eligible for either of it
 function concrete_eval_eligible(interp::AbstractInterpreter,
-    @nospecialize(f), result::MethodCallResult, arginfo::ArgInfo, sv::InferenceState)
+    @nospecialize(f), result::MethodCallResult, arginfo::ArgInfo)
     # disable all concrete-evaluation if this function call is tainted by some overlayed
     # method since currently there is no direct way to execute overlayed methods
     isoverlayed(method_table(interp)) && !is_nonoverlayed(result.effects) && return nothing
@@ -826,9 +822,9 @@ struct InvokeCall
 end
 
 function concrete_eval_call(interp::AbstractInterpreter,
-    @nospecialize(f), result::MethodCallResult, arginfo::ArgInfo, sv::InferenceState,
+    @nospecialize(f), result::MethodCallResult, arginfo::ArgInfo, si::StmtInfo,
     invokecall::Union{Nothing,InvokeCall}=nothing)
-    eligible = concrete_eval_eligible(interp, f, result, arginfo, sv)
+    eligible = concrete_eval_eligible(interp, f, result, arginfo)
     eligible === nothing && return false
     if eligible
         args = collect_const_args(arginfo, #=start=#2)
@@ -845,7 +841,7 @@ function concrete_eval_call(interp::AbstractInterpreter,
             # The evaluation threw. By :consistent-cy, we're guaranteed this would have happened at runtime
             return ConstCallResults(Union{}, ConcreteResult(edge, result.effects), result.effects, edge)
         end
-        if is_inlineable_constant(value) || call_result_unused(sv)
+        if is_inlineable_constant(value) || call_result_unused(si)
             # If the constant is not inlineable, still do the const-prop, since the
             # code that led to the creation of the Const may be inlineable in the same
             # circumstance and may be optimizable.
@@ -885,14 +881,14 @@ struct ConstCallResults
 end
 
 function abstract_call_method_with_const_args(interp::AbstractInterpreter,
-    result::MethodCallResult, @nospecialize(f), arginfo::ArgInfo, match::MethodMatch,
+    result::MethodCallResult, @nospecialize(f), arginfo::ArgInfo, si::StmtInfo, match::MethodMatch,
     sv::InferenceState, invokecall::Union{Nothing,InvokeCall}=nothing)
     if !const_prop_enabled(interp, sv, match)
         return nothing
     end
-    res = concrete_eval_call(interp, f, result, arginfo, sv, invokecall)
+    res = concrete_eval_call(interp, f, result, arginfo, si, invokecall)
     isa(res, ConstCallResults) && return res
-    mi = maybe_get_const_prop_profitable(interp, result, f, arginfo, match, sv)
+    mi = maybe_get_const_prop_profitable(interp, result, f, arginfo, si, match, sv)
     mi === nothing && return nothing
     # try semi-concrete evaluation
     if res::Bool && !has_conditional(arginfo)
@@ -943,11 +939,11 @@ end
 # if there's a possibility we could get a better result with these constant arguments
 # (hopefully without doing too much work), returns `MethodInstance`, or nothing otherwise
 function maybe_get_const_prop_profitable(interp::AbstractInterpreter, result::MethodCallResult,
-                                         @nospecialize(f), arginfo::ArgInfo, match::MethodMatch,
+                                         @nospecialize(f), arginfo::ArgInfo, si::StmtInfo, match::MethodMatch,
                                          sv::InferenceState)
     method = match.method
     force = force_const_prop(interp, f, method)
-    force || const_prop_entry_heuristic(interp, result, sv) || return nothing
+    force || const_prop_entry_heuristic(interp, result, si, sv) || return nothing
     nargs::Int = method.nargs
     method.isva && (nargs -= 1)
     length(arginfo.argtypes) < nargs && return nothing
@@ -975,8 +971,8 @@ function maybe_get_const_prop_profitable(interp::AbstractInterpreter, result::Me
     return mi
 end
 
-function const_prop_entry_heuristic(interp::AbstractInterpreter, result::MethodCallResult, sv::InferenceState)
-    if call_result_unused(sv) && result.edgecycle
+function const_prop_entry_heuristic(interp::AbstractInterpreter, result::MethodCallResult, si::StmtInfo, sv::InferenceState)
+    if call_result_unused(si) && result.edgecycle
         add_remark!(interp, sv, "[constprop] Disabled by entry heuristic (edgecycle with unused result)")
         return false
     end
@@ -1305,7 +1301,7 @@ function abstract_iteration(interp::AbstractInterpreter, @nospecialize(itft), @n
         return Any[Vararg{Any}], nothing
     end
     @assert !isvarargtype(itertype)
-    call = abstract_call_known(interp, iteratef, ArgInfo(nothing, Any[itft, itertype]), sv)
+    call = abstract_call_known(interp, iteratef, ArgInfo(nothing, Any[itft, itertype]), StmtInfo(true), sv)
     stateordonet = call.rt
     info = call.info
     # Return Bottom if this is not an iterator.
@@ -1339,7 +1335,7 @@ function abstract_iteration(interp::AbstractInterpreter, @nospecialize(itft), @n
         valtype = getfield_tfunc(stateordonet, Const(1))
         push!(ret, valtype)
         statetype = nstatetype
-        call = abstract_call_known(interp, iteratef, ArgInfo(nothing, Any[Const(iteratef), itertype, statetype]), sv)
+        call = abstract_call_known(interp, iteratef, ArgInfo(nothing, Any[Const(iteratef), itertype, statetype]), StmtInfo(true), sv)
         stateordonet = call.rt
         stateordonet_widened = widenconst(stateordonet)
         push!(calls, call)
@@ -1374,7 +1370,7 @@ function abstract_iteration(interp::AbstractInterpreter, @nospecialize(itft), @n
         end
         valtype = tmerge(valtype, nounion.parameters[1])
         statetype = tmerge(statetype, nounion.parameters[2])
-        stateordonet = abstract_call_known(interp, iteratef, ArgInfo(nothing, Any[Const(iteratef), itertype, statetype]), sv).rt
+        stateordonet = abstract_call_known(interp, iteratef, ArgInfo(nothing, Any[Const(iteratef), itertype, statetype]), StmtInfo(true), sv).rt
         stateordonet_widened = widenconst(stateordonet)
     end
     if valtype !== Union{}
@@ -1384,7 +1380,8 @@ function abstract_iteration(interp::AbstractInterpreter, @nospecialize(itft), @n
 end
 
 # do apply(af, fargs...), where af is a function value
-function abstract_apply(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::Union{InferenceState, IRCode},
+function abstract_apply(interp::AbstractInterpreter, argtypes::Vector{Any}, si::StmtInfo,
+                        sv::Union{InferenceState, IRCode},
                         max_methods::Int = get_max_methods(sv.mod, interp))
     itft = argtype_by_index(argtypes, 2)
     aft = argtype_by_index(argtypes, 3)
@@ -1464,7 +1461,7 @@ function abstract_apply(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::
                 break
             end
         end
-        call = abstract_call(interp, ArgInfo(nothing, ct), sv, max_methods)
+        call = abstract_call(interp, ArgInfo(nothing, ct), si, sv, max_methods)
         push!(retinfos, ApplyCallInfo(call.info, arginfo))
         res = tmerge(res, call.rt)
         effects = merge_effects(effects, call.effects)
@@ -1668,7 +1665,7 @@ function abstract_call_unionall(argtypes::Vector{Any})
     return Any
 end
 
-function abstract_invoke(interp::AbstractInterpreter, (; fargs, argtypes)::ArgInfo, sv::InferenceState)
+function abstract_invoke(interp::AbstractInterpreter, (; fargs, argtypes)::ArgInfo, si::StmtInfo, sv::InferenceState)
     ft′ = argtype_by_index(argtypes, 2)
     ft = widenconst(ft′)
     ft === Bottom && return CallMeta(Bottom, EFFECTS_THROWS, false)
@@ -1690,7 +1687,7 @@ function abstract_invoke(interp::AbstractInterpreter, (; fargs, argtypes)::ArgIn
     method = match.method
     tienv = ccall(:jl_type_intersection_with_env, Any, (Any, Any), nargtype, method.sig)::SimpleVector
     ti = tienv[1]; env = tienv[2]::SimpleVector
-    result = abstract_call_method(interp, method, ti, env, false, sv)
+    result = abstract_call_method(interp, method, ti, env, false, si, sv)
     (; rt, edge, effects) = result
     match = MethodMatch(ti, env, method, argtype <: method.sig)
     res = nothing
@@ -1706,7 +1703,7 @@ function abstract_invoke(interp::AbstractInterpreter, (; fargs, argtypes)::ArgIn
     f = overlayed ? nothing : singleton_type(ft′)
     invokecall = InvokeCall(types, lookupsig)
     const_call_result = abstract_call_method_with_const_args(interp,
-        result, f, arginfo, match, sv, invokecall)
+        result, f, arginfo, si, match, sv, invokecall)
     const_result = nothing
     if const_call_result !== nothing
         if ⊑(typeinf_lattice(interp), const_call_result.rt, rt)
@@ -1728,7 +1725,7 @@ end
 function abstract_finalizer(interp::AbstractInterpreter, argtypes::Vector{Any}, sv::InferenceState)
     if length(argtypes) == 3
         finalizer_argvec = Any[argtypes[2], argtypes[3]]
-        call = abstract_call(interp, ArgInfo(nothing, finalizer_argvec), sv, 1)
+        call = abstract_call(interp, ArgInfo(nothing, finalizer_argvec), StmtInfo(false), sv, 1)
         return CallMeta(Nothing, Effects(), FinalizerInfo(call.info, call.effects))
     end
     return CallMeta(Nothing, Effects(), false)
@@ -1736,18 +1733,18 @@ end
 
 # call where the function is known exactly
 function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
-        arginfo::ArgInfo, sv::Union{InferenceState, IRCode},
+        arginfo::ArgInfo, si::StmtInfo, sv::Union{InferenceState, IRCode},
         max_methods::Int = isa(sv, InferenceState) ? get_max_methods(f, sv.mod, interp) : 0)
     (; fargs, argtypes) = arginfo
     la = length(argtypes)
 
     if isa(f, Builtin)
         if f === _apply_iterate
-            return abstract_apply(interp, argtypes, sv, max_methods)
+            return abstract_apply(interp, argtypes, si, sv, max_methods)
         elseif f === invoke
-            return abstract_invoke(interp, arginfo, sv)
+            return abstract_invoke(interp, arginfo, si, sv)
         elseif f === modifyfield!
-            return abstract_modifyfield!(interp, argtypes, sv)
+            return abstract_modifyfield!(interp, argtypes, si, sv)
         elseif f === Core.finalizer
             return abstract_finalizer(interp, argtypes, sv)
         end
@@ -1791,17 +1788,17 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
             return CallMeta(Tuple, EFFECTS_UNKNOWN, false)
         end
     elseif is_return_type(f)
-        return return_type_tfunc(interp, argtypes, sv)
+        return return_type_tfunc(interp, argtypes, si, sv)
     elseif la == 2 && istopfunction(f, :!)
         # handle Conditional propagation through !Bool
         aty = argtypes[2]
         if isa(aty, Conditional)
-            call = abstract_call_gf_by_type(interp, f, ArgInfo(fargs, Any[Const(f), Bool]), Tuple{typeof(f), Bool}, sv, max_methods) # make sure we've inferred `!(::Bool)`
+            call = abstract_call_gf_by_type(interp, f, ArgInfo(fargs, Any[Const(f), Bool]), si, Tuple{typeof(f), Bool}, sv, max_methods) # make sure we've inferred `!(::Bool)`
             return CallMeta(Conditional(aty.slot, aty.elsetype, aty.thentype), call.effects, call.info)
         end
     elseif la == 3 && istopfunction(f, :!==)
         # mark !== as exactly a negated call to ===
-        rty = abstract_call_known(interp, (===), arginfo, sv, max_methods).rt
+        rty = abstract_call_known(interp, (===), arginfo, si, sv, max_methods).rt
         if isa(rty, Conditional)
             return CallMeta(Conditional(rty.slot, rty.elsetype, rty.thentype), EFFECTS_TOTAL, false) # swap if-else
         elseif isa(rty, Const)
@@ -1817,7 +1814,7 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
             fargs = nothing
         end
         argtypes = Any[typeof(<:), argtypes[3], argtypes[2]]
-        return CallMeta(abstract_call_known(interp, <:, ArgInfo(fargs, argtypes), sv, max_methods).rt, EFFECTS_TOTAL, false)
+        return CallMeta(abstract_call_known(interp, <:, ArgInfo(fargs, argtypes), si, sv, max_methods).rt, EFFECTS_TOTAL, false)
     elseif la == 2 &&
            (a2 = argtypes[2]; isa(a2, Const)) && (svecval = a2.val; isa(svecval, SimpleVector)) &&
            istopfunction(f, :length)
@@ -1840,13 +1837,13 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
         end
     end
     atype = argtypes_to_type(argtypes)
-    return abstract_call_gf_by_type(interp, f, arginfo, atype, sv, max_methods)
+    return abstract_call_gf_by_type(interp, f, arginfo, si, atype, sv, max_methods)
 end
 
 function abstract_call_opaque_closure(interp::AbstractInterpreter,
-    closure::PartialOpaque, arginfo::ArgInfo, sv::InferenceState, check::Bool=true)
+    closure::PartialOpaque, arginfo::ArgInfo, si::StmtInfo, sv::InferenceState, check::Bool=true)
     sig = argtypes_to_type(arginfo.argtypes)
-    result = abstract_call_method(interp, closure.source, sig, Core.svec(), false, sv)
+    result = abstract_call_method(interp, closure.source, sig, Core.svec(), false, si, sv)
     (; rt, edge, effects) = result
     tt = closure.typ
     sigT = (unwrap_unionall(tt)::DataType).parameters[1]
@@ -1854,7 +1851,7 @@ function abstract_call_opaque_closure(interp::AbstractInterpreter,
     const_result = nothing
     if !result.edgecycle
         const_call_result = abstract_call_method_with_const_args(interp, result,
-            nothing, arginfo, match, sv)
+            nothing, arginfo, si, match, sv)
         if const_call_result !== nothing
             if const_call_result.rt ⊑ rt
                 (; rt, effects, const_result, edge) = const_call_result
@@ -1888,7 +1885,7 @@ function most_general_argtypes(closure::PartialOpaque)
 end
 
 # call where the function is any lattice element
-function abstract_call(interp::AbstractInterpreter, arginfo::ArgInfo,
+function abstract_call(interp::AbstractInterpreter, arginfo::ArgInfo, si::StmtInfo,
                        sv::Union{InferenceState, IRCode}, max_methods::Union{Int, Nothing} = isa(sv, IRCode) ? 0 : nothing)
     argtypes = arginfo.argtypes
     ft = argtypes[1]
@@ -1897,7 +1894,7 @@ function abstract_call(interp::AbstractInterpreter, arginfo::ArgInfo,
         newargtypes = copy(argtypes)
         newargtypes[1] = ft.env
         return abstract_call_opaque_closure(interp,
-            ft, ArgInfo(arginfo.fargs, newargtypes), sv, #=check=#true)
+            ft, ArgInfo(arginfo.fargs, newargtypes), si, sv, #=check=#true)
     elseif (uft = unwrap_unionall(widenconst(ft)); isa(uft, DataType) && uft.name === typename(Core.OpaqueClosure))
         return CallMeta(rewrap_unionall((uft::DataType).parameters[2], widenconst(ft)), Effects(), false)
     elseif f === nothing
@@ -1908,10 +1905,10 @@ function abstract_call(interp::AbstractInterpreter, arginfo::ArgInfo,
             return CallMeta(Any, Effects(), false)
         end
         max_methods = max_methods === nothing ? get_max_methods(sv.mod, interp) : max_methods
-        return abstract_call_gf_by_type(interp, nothing, arginfo, argtypes_to_type(argtypes), sv, max_methods)
+        return abstract_call_gf_by_type(interp, nothing, arginfo, si, argtypes_to_type(argtypes), sv, max_methods)
     end
     max_methods = max_methods === nothing ? get_max_methods(f, sv.mod, interp) : max_methods
-    return abstract_call_known(interp, f, arginfo, sv, max_methods)
+    return abstract_call_known(interp, f, arginfo, si, sv, max_methods)
 end
 
 function sp_type_rewrap(@nospecialize(T), linfo::MethodInstance, isreturn::Bool)
@@ -1958,7 +1955,7 @@ function abstract_eval_cfunction(interp::AbstractInterpreter, e::Expr, vtypes::V
     # this may be the wrong world for the call,
     # but some of the result is likely to be valid anyways
     # and that may help generate better codegen
-    abstract_call(interp, ArgInfo(nothing, at), sv)
+    abstract_call(interp, ArgInfo(nothing, at), StmtInfo(false), sv)
     nothing
 end
 
@@ -2041,7 +2038,9 @@ function abstract_eval_statement_expr(interp::AbstractInterpreter, e::Expr, vtyp
             rt = Bottom
             effects = Effects()
         else
-            (; rt, effects, info) = abstract_call(interp, ArgInfo(ea, argtypes), sv)
+            arginfo = ArgInfo(ea, argtypes)
+            si = StmtInfo(isa(sv, IRCode) ? true : !call_result_unused(sv, sv.currpc))
+            (; rt, effects, info) = abstract_call(interp, arginfo, si, sv)
             merge_effects!(interp, sv, effects)
             if isa(sv, InferenceState)
                 sv.stmt_info[sv.currpc] = info
@@ -2139,13 +2138,13 @@ function abstract_eval_statement_expr(interp::AbstractInterpreter, e::Expr, vtyp
                 mi′ = isa(sv, InferenceState) ? sv.linfo : mi
                 t = _opaque_closure_tfunc(argtypes[1], argtypes[2], argtypes[3],
                     argtypes[4], argtypes[5:end], mi′)
-                if isa(t, PartialOpaque) && isa(sv, InferenceState)
+                if isa(t, PartialOpaque) && isa(sv, InferenceState) && !call_result_unused(sv, sv.currpc)
                     # Infer this now so that the specialization is available to
                     # optimization.
                     argtypes = most_general_argtypes(t)
                     pushfirst!(argtypes, t.env)
                     callinfo = abstract_call_opaque_closure(interp, t,
-                        ArgInfo(nothing, argtypes), sv, #=check=#false)
+                        ArgInfo(nothing, argtypes), StmtInfo(true), sv, #=check=#false)
                     sv.stmt_info[sv.currpc] = OpaqueClosureCreateInfo(callinfo)
                 end
             end

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -117,7 +117,7 @@ function codeinst_to_ir(interp::AbstractInterpreter, code::CodeInstance)
 end
 
 function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
-                                  arginfo::ArgInfo, @nospecialize(atype),
+                                  arginfo::ArgInfo, si::StmtInfo, @nospecialize(atype),
                                   sv::IRCode, max_methods::Int)
     return CallMeta(Any, Effects(), false)
 end

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -23,6 +23,14 @@ struct ArgInfo
     argtypes::Vector{Any}
 end
 
+struct StmtInfo
+    """
+    If `used` is false, we know that the return value is statically unused and
+    need thus not be computed.
+    """
+    used::Bool
+end
+
 """
     InferenceResult
 

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4222,3 +4222,14 @@ end |> Core.Compiler.is_foldable
     Base.Experimental.@force_compile
     @invoke invoke_concretized2(42::Integer)
 end === :integer
+
+# Test that abstract_apply doesn't fail to fully infer if the result is unused
+struct FiniteIteration
+    n::Int
+end
+Base.iterate(f::FiniteIteration, i::Int = 0) = i < f.n ? (i, i+1) : nothing
+function unused_apply_iterate()
+    tuple(FiniteIteration(4)...)
+    return nothing
+end
+@test fully_eliminated(unused_apply_iterate, ())


### PR DESCRIPTION
Currently, we were relying on the implicitly passed in sv.currpc to determine whether a call result type was needed or not. This is usually correct, but not always. For example, in apply_iterate, we actually end up calling various `iterate` methods and inspect their result, so the used-ness of the outer apply_iterate is irrelevant. Similar examples occur in external packages. Fix this issue by refactoring the code to thread through an extra `StmtInfo` object that record used-ness (and potentially other stmt attributes in the future).