### PR TITLE
IncrementalCompact: trim undef nodes introduced by copy propagation.

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1663,6 +1663,19 @@ function complete(compact::IncrementalCompact)
     if __check_ssa_counts__[]
         oracle_check(compact)
     end
+
+    # trim trailing undefined statements due to copy propagation
+    nundef = 0
+    for i in length(compact.result):-1:1
+        if isassigned(compact.result.inst, i)
+            break
+        end
+        nundef += 1
+    end
+    if nundef > 0
+        resize!(compact.result, length(compact.result) - nundef)
+    end
+
     return IRCode(compact.ir, compact.result, cfg, compact.new_new_nodes)
 end
 


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/46967

Alternatively, if the compiler needs to handle undef entries in ir.stmts just fine, we could add an isassigned check to the failing show method, but the fact that there is a warning for exactly that right below (checking for undef in ir.new_nodes) made me assume that avoiding undef entries in the first place is the better option:

https://github.com/JuliaLang/julia/blob/9fd408723aab0974f399b8ffc952af4b4d20b6f7/base/compiler/ssair/show.jl#L773-L778