### PR TITLE
IRCode display: consider new nodes when determining max SSA id.

### DIFF
--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -818,7 +818,8 @@ function show_ir(io::IO, ir::IRCode, config::IRShowConfig=default_config(ir);
                  pop_new_node! = new_nodes_iter(ir))
     used = stmts_used(io, ir)
     cfg = ir.cfg
-    let io = IOContext(io, :maxssaid=>length(ir.stmts))
+    maxssaid = length(ir.stmts) + Core.Compiler.length(ir.new_nodes)
+    let io = IOContext(io, :maxssaid=>maxssaid)
         show_ir_stmts(io, ir, 1:length(ir.stmts), config, used, cfg, 1; pop_new_node!)
     end
     finish_show_ir(io, cfg, config)
@@ -850,7 +851,8 @@ function show_ir(io::IO, compact::IncrementalCompact, config::IRShowConfig=defau
         end
     end
     pop_new_node! = new_nodes_iter(compact)
-    bb_idx = let io = IOContext(io, :maxssaid=>length(compact.result))
+    maxssaid = length(compact.result) + Core.Compiler.length(compact.new_new_nodes)
+    bb_idx = let io = IOContext(io, :maxssaid=>maxssaid)
         show_ir_stmts(io, compact, 1:compact.result_idx-1, config, used_compacted, compact_cfg, 1; pop_new_node!)
     end
 
@@ -863,7 +865,8 @@ function show_ir(io::IO, compact::IncrementalCompact, config::IRShowConfig=defau
     printstyled(io, "─"^(width-indent-1), '\n', color=:red)
 
     pop_new_node! = new_nodes_iter(compact.ir)
-    let io = IOContext(io, :maxssaid=>length(compact.ir.stmts))
+    maxssaid = length(compact.ir.stmts) + Core.Compiler.length(compact.ir.new_nodes)
+    let io = IOContext(io, :maxssaid=>maxssaid)
         show_ir_stmts(io, compact.ir, compact.idx:length(stmts), config, used_uncompacted, cfg, bb_idx; pop_new_node!)
     end
 


### PR DESCRIPTION
Otherwise newly-inserted nodes are always colored in red:

```julia
# get some IR
julia> function foo(i)
           j = i+42
           j == 1 ? 1 : 2
       end
julia> ir = only(Base.code_ircode(foo, (Int,)))[1]
2 1 ─ %1 = Base.add_int(_2, 42)::Int64
3 │   %2 = (%1 === 1)::Bool
  └──      goto #3 if not %2
  2 ─      return 1
  3 ─      return 2

# insert a new instruction and replace the addition
julia> add_stmt = ir.stmts[1]
julia> inst = Core.Compiler.NewInstruction(Expr(:call, add_stmt[:inst].args[1], add_stmt[:inst].args[2], 999), Int)
julia> node = Core.Compiler.insert_node!(ir, 1, inst)
julia> Core.Compiler.setindex!(add_stmt, node, :inst)

julia> ir
```

<img width="280" alt="image" src="https://user-images.githubusercontent.com/383068/192999884-8c0fbebe-7e90-49e0-b7fb-a4f75cd50dc9.png">
