### PR TITLE
compiler: setup `ModifyFieldInfo` callinfo

### DIFF
--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -197,7 +197,17 @@ object type.
 """
 struct FinalizerInfo
     info::Any
-    effects::Effects
+    effects::Effects # the effects for the finalizer call
+end
+
+"""
+    info::ModifyFieldInfo
+
+Represents a resolved all of `modifyfield!(obj, name, op, x, [order])`.
+`info.info` wraps the call information of `op(getfield(obj, name), x)`.
+"""
+struct ModifyFieldInfo
+    info::Any # the callinfo for the `op(getfield(obj, name), x)` call
 end
 
 @specialize

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1172,7 +1172,7 @@ function abstract_modifyfield!(interp::AbstractInterpreter, argtypes::Vector{Any
         elseif isconcretetype(RT) && has_nontrivial_const_info(typeinf_lattice(interp), TF2) # isconcrete condition required to form a PartialStruct
             RT = PartialStruct(RT, Any[TF, TF2])
         end
-        info = callinfo.info
+        info = ModifyFieldInfo(callinfo.info)
     end
     return CallMeta(RT, Effects(), info)
 end


### PR DESCRIPTION
This makes it more explicit that `modifyfield!` call is special-cased. It would be more aligned with the other specially-handled builtins like `invoke` and `Core.finalizer`.