### PR TITLE
Make sure `UnionAll` is handled by `subtype_unionall`

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -562,7 +562,7 @@ static int subtype_ccheck(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)
 
 static int subtype_left_var(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param)
 {
-    if (x == y)
+    if (x == y && !(jl_is_unionall(y)))
         return 1;
     if (x == jl_bottom_type && jl_is_type(y))
         return 1;

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2193,6 +2193,12 @@ struct Q38497{o,e<:NTuple{o},g} <: C38497{e,g,Array{o}} end
 #issue #33138
 @test Vector{Vector{Tuple{T,T}} where Int<:T<:Int} <: Vector{Vector{Tuple{S1,S1} where S<:S1<:S}} where S
 
+#issue #46970
+@test only(intersection_env(Union{S, Matrix{Int}} where S<:Matrix, Matrix)[2]) isa TypeVar
+T46784{B<:Val, M<:AbstractMatrix} = Tuple{<:Union{B, <:Val{<:B}}, M, Union{AbstractMatrix{B}, AbstractMatrix{<:Vector{<:B}}}}
+@testintersect(T46784{T,S} where {T,S}, T46784, !Union{})
+@test_broken T46784 <: T46784{T,S} where {T,S}
+
 @testset "known subtype/intersect issue" begin
     #issue 45874
     let S = Pair{Val{P}, AbstractVector{<:Union{P,<:AbstractMatrix{P}}}} where P,


### PR DESCRIPTION
This is needed to keep the correctness of `envout`
Close #46970. Example from #46784 has been added. 