### PR TITLE
Show basic block statement ranges in CFG output [NFC]

### DIFF
--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -16,10 +16,18 @@ import Base: show_unquoted
 using Base: printstyled, with_output_color, prec_decl, @invoke
 
 function Base.show(io::IO, cfg::CFG)
+    print(io, "CFG with $(length(cfg.blocks)) blocks:")
     for (idx, block) in enumerate(cfg.blocks)
-        print(io, idx, "\t=>\t")
-        join(io, block.succs, ", ")
-        println(io)
+        print(io, "\n  bb ", idx)
+        if block.stmts.start == block.stmts.stop
+            print(io, " (stmt ", block.stmts.start, ")")
+        else
+            print(io, " (stmts ", block.stmts.start, ":", block.stmts.stop, ")")
+        end
+        if !isempty(block.succs)
+            print(io, " → bb ")
+            join(io, block.succs, ", ")
+        end
     end
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -2516,3 +2516,17 @@ end
     ir = Core.Compiler.complete(compact)
     verify_display(ir)
 end
+
+@testset "IRCode: CFG display" begin
+    # get a cfg
+    function foo(i)
+        j = i+42
+        j == 1 ? 1 : 2
+    end
+    ir = only(Base.code_ircode(foo, (Int,)))[1]
+    cfg = ir.cfg
+
+    str = sprint(io->show(io, cfg))
+    @test contains(str, r"CFG with \d+ blocks")
+    @test contains(str, r"bb 1 \(stmt.+\) → bb.*")
+end


### PR DESCRIPTION
The CFG `show` output was not immediately obvious to me, so annotate it, and include statement ranges:

```julia
julia> # get some ir
       function foo(i)
           j = i+42
           j == 1 ? 1 : 2
       end

julia> ir = only(Base.code_ircode(foo, (Int,)))[1]
3 1 ─ %1 = Base.add_int(_2, 42)::Int64
4 │   %2 = (%1 === 1)::Bool
  └──      goto #3 if not %2
  2 ─      return 1
  3 ─      return 2

julia> ir.cfg
1	=>	3, 2
2	=>
3	=>


julia> using Revise
julia> Revise.track(Base)

julia> ir.cfg
CFG with 3 blocks:
  bb 1 (stmts 1:3) ⇨ bb 3, 2
  bb 2 (stmt 4)
  bb 3 (stmt 5)
```

Feel free to bikeshed or give ideas on how to further improve the output.