### PR TITLE
[win] Backport win MSYS2 build pr

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1391,13 +1391,13 @@ define symlink_target # (from, to-dir, to-name)
 CLEAN_TARGETS += clean-$$(abspath $(2)/$(3))
 clean-$$(abspath $(2)/$(3)):
 ifeq ($(BUILD_OS), WINNT)
-	-cmd //C rmdir $$(call mingw_to_dos,$(2)/$(3),cd $(2) &&)
+	-cmd //C rmdir $$(call cygpath_w,$(2)/$(3))
 else
 	-rm -r $$(abspath $(2)/$(3))
 endif
 $$(abspath $(2)/$(3)): | $$(abspath $(2))
 ifeq ($$(BUILD_OS), WINNT)
-	@cmd //C mklink //J $$(call mingw_to_dos,$(2)/$(3),cd $(2) &&) $$(call mingw_to_dos,$(1),)
+	@cmd //C mklink //J $$(call cygpath_w,$(2)/$(3)) $$(call cygpath_w,$(1))
 else ifneq (,$$(findstring CYGWIN,$$(BUILD_OS)))
 	@cmd /C mklink /J $$(call cygpath_w,$(2)/$(3)) $$(call cygpath_w,$(1))
 else ifdef JULIA_VAGRANT_BUILD
@@ -1415,7 +1415,7 @@ WINE ?= wine
 # many of the following targets must be = not := because the expansion of the makefile functions (and $1) shouldn't happen until later
 ifeq ($(BUILD_OS), WINNT) # MSYS
 spawn = $(1)
-cygpath_w = $(1)
+cygpath_w = `cygpath -w $(1)`
 else ifneq (,$(findstring CYGWIN,$(BUILD_OS))) # Cygwin
 spawn = $(1)
 cygpath_w = `cygpath -w $(1)`

--- a/Makefile
+++ b/Makefile
@@ -222,8 +222,10 @@ endif
 endif
 endif
 
+# Note that we disable MSYS2's path munging here, as otherwise
+# it replaces our `:`-separated list as a `;`-separated one.
 define stringreplace
-	$(build_depsbindir)/stringreplace $$(strings -t x - $1 | grep $2 | awk '{print $$1;}') $3 255 "$(call cygpath_w,$1)"
+	MSYS2_ARG_CONV_EXCL='*' $(build_depsbindir)/stringreplace $$(strings -t x - $1 | grep $2 | awk '{print $$1;}') $3 255 "$(call cygpath_w,$1)"
 endef
 
 

--- a/Makefile
+++ b/Makefile
@@ -448,8 +448,9 @@ endif
 
 
 exe:
-	# run Inno Setup to compile installer
-	$(call spawn,$(JULIAHOME)/dist-extras/inno/iscc.exe /DAppVersion=$(JULIA_VERSION) /DSourceDir="$(call cygpath_w,$(BUILDROOT)/julia-$(JULIA_COMMIT))" /DRepoDir="$(call cygpath_w,$(JULIAHOME))" /F"$(JULIA_BINARYDIST_FILENAME)" /O"$(call cygpath_w,$(BUILDROOT))" $(INNO_ARGS) $(call cygpath_w,$(JULIAHOME)/contrib/windows/build-installer.iss))
+	# run Inno Setup to compile installer.
+	# Note that we disable MSYS2 path munging, as it interferes with the `/` options:
+	MSYS2_ARG_CONV_EXCL='*' $(call spawn,$(JULIAHOME)/dist-extras/inno/iscc.exe /DAppVersion=$(JULIA_VERSION) /DSourceDir="$(call cygpath_w,$(BUILDROOT)/julia-$(JULIA_COMMIT))" /DRepoDir="$(call cygpath_w,$(JULIAHOME))" /F"$(JULIA_BINARYDIST_FILENAME)" /O"$(call cygpath_w,$(BUILDROOT))" $(INNO_ARGS) $(call cygpath_w,$(JULIAHOME)/contrib/windows/build-installer.iss))
 	chmod a+x "$(BUILDROOT)/$(JULIA_BINARYDIST_FILENAME).exe"
 
 app:
@@ -574,7 +575,7 @@ win-extras:
 	cd $(JULIAHOME)/dist-extras && \
 	$(JLDOWNLOAD) https://www.jrsoftware.org/download.php/is.exe && \
 	chmod a+x is.exe && \
-	$(call spawn, $(JULIAHOME)/dist-extras/is.exe /DIR="$(call cygpath_w,$(JULIAHOME)/dist-extras/inno)" /PORTABLE=1 /CURRENTUSER /VERYSILENT)
+	MSYS2_ARG_CONV_EXCL='*' $(call spawn, $(JULIAHOME)/dist-extras/is.exe /DIR="$(call cygpath_w,$(JULIAHOME)/dist-extras/inno)" /PORTABLE=1 /CURRENTUSER /VERYSILENT)
 
 # various statistics about the build that may interest the user
 ifeq ($(USE_SYSTEM_LLVM), 1)

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -29,6 +29,14 @@ endif
 # Build list of dependent libraries that must be opened
 SHIPFLAGS  += -DDEP_LIBS="\"$(LOADER_BUILD_DEP_LIBS)\""
 DEBUGFLAGS += -DDEP_LIBS="\"$(LOADER_DEBUG_BUILD_DEP_LIBS)\""
+ifneq (,$(findstring MINGW,$(shell uname)))
+# In MSYS2, do not perform path conversion for `DEP_LIBS`.
+# https://www.msys2.org/wiki/Porting/#filesystem-namespaces
+# We define this environment variable for only these two object files,
+# as they're the only ones that require it at the time of writing.
+$(BUILDDIR)/loader_lib.o: export MSYS2_ARG_CONV_EXCL = -DDEP_LIBS=
+$(BUILDDIR)/loader_lib.dbg.obj: export MSYS2_ARG_CONV_EXCL = -DDEP_LIBS=
+endif # MSYS2
 
 EXE_OBJS := $(BUILDDIR)/loader_exe.o
 EXE_DOBJS := $(BUILDDIR)/loader_exe.dbg.obj

--- a/doc/src/devdocs/build/windows.md
+++ b/doc/src/devdocs/build/windows.md
@@ -118,11 +118,67 @@ MinGW-w64 compilers available through Cygwin's package manager.
 
 ### Compiling with MinGW/MSYS2
 
-Compiling Julia from source using [MSYS2](https://msys2.github.io) has worked in the past
-but is not actively supported. Pull requests to restore support would be welcome. See a
-[past version of this
-file](https://github.com/JuliaLang/julia/blob/v0.6.0/README.windows.md) for the former
-instructions for compiling using MSYS2.
+> MSYS2 provides a robust MSYS experience.
+
+Note: MSYS2 requires **64 bit** Windows 7 or newer.
+
+ 1. Install and configure [MSYS2](https://www.msys2.org/), Software Distribution
+    and Building Platform for Windows.
+
+    1. Download and run the latest installer for the
+        [64-bit](https://github.com/msys2/msys2-installer/releases/latest) distribution.
+        The installer will have a name like `msys2-x86_64-yyyymmdd.exe`.
+
+    2. Open MSYS2. Update package database and base packages:
+        ```sh
+        pacman -Syu
+        ```
+
+    3. Exit and restart MSYS2, Update the rest of the base packages:
+        ```sh
+        pacman -Syu
+        ```
+
+    3. Then install tools required to build julia:
+        ```sh
+        # tools
+        pacman -S cmake diffutils git m4 make patch tar p7zip curl python
+
+        # For 64 bit Julia, install x86_64
+        pacman -S mingw-w64-x86_64-gcc
+        # For 32 bit Julia, install i686
+        pacman -S mingw-w64-i686-gcc
+        ```
+
+    4. Configuration of MSYS2 is complete. Now `exit` the MSYS2 shell.
+
+
+ 2. Build Julia and its dependencies with pre-build dependencies.
+
+    1. Open a new [**MINGW64/MINGW32 shell**](https://www.msys2.org/docs/environments/#overview).
+        Currently we can't use both mingw32 and mingw64,
+        so if you want to build the x86_64 and i686 versions,
+        you'll need to build them in each environment separately.
+
+    2. and clone the Julia sources
+        ```sh
+        git clone https://github.com/JuliaLang/julia.git
+        cd julia
+        ```
+
+    3. Start the build
+        ```sh
+        make -j$(nproc)
+        ```
+
+    > Protip: build in dir
+    > ```sh
+    > make O=julia-mingw-w64 configure
+    > echo 'ifeq ($(BUILDROOT),$(JULIAHOME))
+    >         $(error "in-tree build disabled")
+    >       endif' >> Make.user
+    > make -C julia-mingw-w64
+    > ```
 
 
 ### Cross-compiling from Unix (Linux/Mac/WSL)


### PR DESCRIPTION
fix build error: "ERROR: Too few special library names specified, check LOADER_BUILD_DEP_LIBS and friends!"
- #46140
- #46803
- #46867
