### PR TITLE
fix #46918, unstable `jl_binding_type` behavior

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -394,12 +394,11 @@ JL_DLLEXPORT jl_value_t *jl_binding_owner(jl_module_t *m, jl_sym_t *var)
 JL_DLLEXPORT jl_value_t *jl_binding_type(jl_module_t *m, jl_sym_t *var)
 {
     JL_LOCK(&m->lock);
-    jl_binding_t *b = (jl_binding_t*)ptrhash_get(&m->bindings, var);
-    if (b == HT_NOTFOUND || b->owner == NULL)
-        b = using_resolve_binding(m, var, NULL, 0);
+    jl_binding_t *b = _jl_get_module_binding(m, var);
     JL_UNLOCK(&m->lock);
-    if (b == NULL)
+    if (b == HT_NOTFOUND || b->owner == NULL)
         return jl_nothing;
+    b = jl_get_binding(m, var);
     jl_value_t *ty = jl_atomic_load_relaxed(&b->ty);
     return ty ? ty : jl_nothing;
 }

--- a/test/core.jl
+++ b/test/core.jl
@@ -7845,3 +7845,24 @@ module SpecializeModuleTest
     @specialize
 end
 @test methods(SpecializeModuleTest.f)[1].nospecialize & 0b11 == 0b10
+
+let # https://github.com/JuliaLang/julia/issues/46918
+    # jl_binding_type shouldn't be unstable
+    code = quote
+        res1 = ccall(:jl_binding_type, Any, (Any, Any), Main, :stderr)
+
+        stderr
+
+        res2 = ccall(:jl_binding_type, Any, (Any, Any), Main, :stderr)
+
+        res3 = ccall(:jl_binding_type, Any, (Any, Any), Main, :stderr)
+
+        print(stdout, res1, " ", res2, " ", res3)
+    end |> x->join(x.args, ';')
+    cmd = `$(Base.julia_cmd()) -e $code` # N.B make sure not to pass this code as `:block`
+    stdout = IOBuffer()
+    stderr = IOBuffer()
+    @test success(pipeline(Cmd(cmd); stdout, stderr))
+    @test isempty(String(take!(stderr))) # make sure no error has happened
+    @test String(take!(stdout)) == "nothing IO IO"
+end


### PR DESCRIPTION
fix #46918

Now it will return `nothing` before the binding has been resolved, and afterward fully look up the binding as declared by the owner.
I followed the comment here, which says the function doesn't resolve the binding.