### PR TITLE
CI (Create Buildbot Statuses): remove `tester_win64` and `tester_win32` from the list

### DIFF
--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -48,8 +48,6 @@ jobs:
       - run: |
           declare -a CONTEXT_LIST=(
                 "buildbot/tester_freebsd64"
-                "buildbot/tester_win32"
-                "buildbot/tester_win64"
                 )
           for CONTEXT in "${CONTEXT_LIST[@]}"
           do


### PR DESCRIPTION
Now that we have migrated Win32 and Win64 to Buildkite.