### PR TITLE
Better Libdl.dlopen error when using non-standard extension

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -351,6 +351,10 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
 #ifdef _OS_WINDOWS_
         err = GetLastError();
         break; // LoadLibrary already tested the rest
+#else
+        // bail out and show the error if file actually exists
+        if (jl_stat(path, (char*)&stbuf) == 0)
+            break;
 #endif
     }
 


### PR DESCRIPTION
When trying to dlopen a file with non-standard extension (e.g. `foo.so` instead of `foo.dylib` when running on macOS), if this failed (e.g. because of a reference to an undefined symbol), then instead of printing the error message returned by `dlerror` with a helpful notice what went wrong, a message indicating something to the effect that "foo.so.dylib was not found" was shown, which was not helpful at all.

To get the actual helpful error message, add a check so that when dlopen fails for a file that actually exists, we don't retry loading from a file with the standard extension attached, which might not even exist; instead we just give up.

This matches what is already being done for relative paths. This patch simply copies the relevant check to also be applied to the case dealing with absolute paths.