### PR TITLE
fix error in StepRange documentation

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -265,8 +265,7 @@ multiples of [`oneunit`](@ref), and `T` should be a "discrete"
 type, which cannot have values smaller than `oneunit`. For example,
 `Integer` or `Date` types would qualify, whereas `Float64` would not (since this
 type can represent values smaller than `oneunit(Float64)`.
-[`UnitRange`](@ref), [`
-            `](@ref), and other types are subtypes of this.
+[`UnitRange`](@ref), [`StepRange`](@ref), and other types are subtypes of this.
 """
 abstract type OrdinalRange{T,S} <: AbstractRange{T} end
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -265,7 +265,8 @@ multiples of [`oneunit`](@ref), and `T` should be a "discrete"
 type, which cannot have values smaller than `oneunit`. For example,
 `Integer` or `Date` types would qualify, whereas `Float64` would not (since this
 type can represent values smaller than `oneunit(Float64)`.
-[`UnitRange`](@ref), [`StepRange`](@ref), and other types are subtypes of this.
+[`UnitRange`](@ref), [`
+            `](@ref), and other types are subtypes of this.
 """
 abstract type OrdinalRange{T,S} <: AbstractRange{T} end
 
@@ -283,7 +284,7 @@ abstract type AbstractUnitRange{T} <: OrdinalRange{T,T} end
 Ranges with elements of type `T` with spacing of type `S`. The step
 between each element is constant, and the range is defined in terms
 of a `start` and `stop` of type `T` and a `step` of type `S`. Neither
-`T` nor `S` should be floating point types. The syntax `a:b:c` with `b > 1`
+`T` nor `S` should be floating point types. The syntax `a:b:c` with `b != 0`
 and `a`, `b`, and `c` all integers creates a `StepRange`.
 
 # Examples


### PR DESCRIPTION
The doc says:
```julia
help?> StepRange

  StepRange{T, S} <: OrdinalRange{T, S}

  Ranges with elements of type T with spacing of type S. The step between each
  element is constant, and the range is defined in terms of a start and stop of
  type T and a step of type S. Neither T nor S should be floating point types. The
  syntax a:b:c with b > 1 and a, b, and c all integers creates a StepRange.
```

The part where it says:
> The syntax a : b : c with b > 1 and a, b, and c all integers creates a StepRange.

is very misleading and confusing because `b = 1` creates a `StepRange`:
```julia
julia> typeof(1:1:5)
StepRange{Int64, Int64}
```

And even `b < 1` creates a `StepRange` as well:
```julia
julia> typeof(5:-1:1)
StepRange{Int64, Int64}

julia> collect(5:-1:1)
5-element Vector{Int64}:
 5
 4
 3
 2
 1
```

So I think the intended action of that word is to say: **"zero as a step is not allowed."**. If that's not it, then the `b>0` or `b!= 0` part can just be removed all together since the error message even tells that:
```julia
julia> 1:0:5
ERROR: ArgumentError: step cannot be zero
```