### PR TITLE
make CanonicalIndexError an Exception type

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1282,7 +1282,7 @@ function unsafe_getindex(A::AbstractArray, I...)
     r
 end
 
-struct CanonicalIndexError
+struct CanonicalIndexError <: Exception
     func::String
     type::Any
     CanonicalIndexError(func::String, @nospecialize(type)) = new(func, type)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -525,6 +525,10 @@ function test_primitives(::Type{T}, shape, ::Type{TestAbstractArray}) where T
     @test_throws MethodError convert(Union{}, X)
 end
 
+@testset "CanonicalIndexError is a Exception" begin
+    @test Base.CanonicalIndexError <: Exception
+end
+
 mutable struct TestThrowNoGetindex{T} <: AbstractVector{T} end
 @testset "ErrorException if getindex is not defined" begin
     Base.length(::TestThrowNoGetindex) = 2


### PR DESCRIPTION
It appears `CanonicalIndexError` was mistakenly not declared to be a subtype of `Exception`, so I have fixed this and added a test.

Should be backported to 1.8, where `CanonicalIndexError` was added.

Aside: it may be worth adding some generic type-hierarchy tests. e.g. any `*Error` type should be an `Exception`. Or `@test_throws FooError ...` could check that `FooError <: Exception` (this is how I came across this in the first place).