### PR TITLE
Improve documentation of unary `:` again

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -685,11 +685,13 @@ Expr
 Expr
 
 """
-    (:)(expr)
+    :("expres" * "sion")
+    :symbol
+    :"literal"
 
 `:expr` quotes the expression `expr`, returning the abstract syntax tree (AST) of `expr`.
 The AST may be of type `Expr`, `Symbol`, or a literal value.
-Which of these three types are returned for any given expression is an
+`:identifier` will evaluate to a `Symbol`, but the type of other usages is an
 implementation detail.
 
 See also: [`Expr`](@ref), [`Symbol`](@ref), [`Meta.parse`](@ref)

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -689,8 +689,7 @@ Expr
 
 Quote an expression `expr`, returning the abstract syntax tree (AST) of `expr`.
 The AST may be of type `Expr`, `Symbol`, or a literal value.
-`:identifier` will evaluate to a `Symbol`, but the type of other usages is an
-implementation detail.
+`:identifier` will evaluate to a `Symbol`.
 
 See also: [`Expr`](@ref), [`Symbol`](@ref), [`Meta.parse`](@ref)
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -689,7 +689,7 @@ Expr
 
 Quote an expression `expr`, returning the abstract syntax tree (AST) of `expr`.
 The AST may be of type `Expr`, `Symbol`, or a literal value.
-`:identifier` will evaluate to a `Symbol`.
+The syntax `:identifier` evaluates to a `Symbol`.
 
 See also: [`Expr`](@ref), [`Symbol`](@ref), [`Meta.parse`](@ref)
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -687,7 +687,7 @@ Expr
 """
     :expr
 
-quote an expression `expr`, returning the abstract syntax tree (AST) of `expr`.
+Quote an expression `expr`, returning the abstract syntax tree (AST) of `expr`.
 The AST may be of type `Expr`, `Symbol`, or a literal value.
 `:identifier` will evaluate to a `Symbol`, but the type of other usages is an
 implementation detail.

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -685,11 +685,9 @@ Expr
 Expr
 
 """
-    :("expres" * "sion")
-    :symbol
-    :"literal"
+    :expr
 
-`:expr` quotes the expression `expr`, returning the abstract syntax tree (AST) of `expr`.
+quote an expression `expr`, returning the abstract syntax tree (AST) of `expr`.
 The AST may be of type `Expr`, `Symbol`, or a literal value.
 `:identifier` will evaluate to a `Symbol`, but the type of other usages is an
 implementation detail.


### PR DESCRIPTION
See also: #45426

`(:)(expr)` is not a valid expression and falsely implies that the unary `:` is a function.

`df[:, :x]` is very common and would break if `:x` evaluated to an `Expr`. We should guarantee that it keeps evaluating to a Symbol.