### PR TITLE
Test that *Error and *Exception types subtype Exception and fix cases where they don't

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -640,7 +640,7 @@ function intersect(p1::Padding, p2::Padding)
     Padding(start, max(0, stop-start))
 end
 
-struct PaddingError
+struct PaddingError <: Exception
     S::Type
     T::Type
 end

--- a/base/task.jl
+++ b/base/task.jl
@@ -526,7 +526,7 @@ function do_async_macro(expr; wrap=identity)
 end
 
 # task wrapper that doesn't create exceptions wrapped in TaskFailedException
-struct UnwrapTaskFailedException
+struct UnwrapTaskFailedException <: Exception
     task::Task
 end
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -525,10 +525,6 @@ function test_primitives(::Type{T}, shape, ::Type{TestAbstractArray}) where T
     @test_throws MethodError convert(Union{}, X)
 end
 
-@testset "CanonicalIndexError is a Exception" begin
-    @test Base.CanonicalIndexError <: Exception
-end
-
 mutable struct TestThrowNoGetindex{T} <: AbstractVector{T} end
 @testset "ErrorException if getindex is not defined" begin
     Base.length(::TestThrowNoGetindex) = 2

--- a/test/error.jl
+++ b/test/error.jl
@@ -101,16 +101,16 @@ end
 end
 
 @testset "All types ending with Exception or Error subtype Exception" begin
-    function test_exceptions(mod, visited=Set{Module}(), mod_exp=Symbol(mod))
+    function test_exceptions(mod, visited=Set{Module}())
         if mod ∉ visited
             push!(visited, mod)
             for name in names(mod, all=true)
                 isdefined(mod, name) || continue
-                joined_expr = Expr(:., mod_exp, QuoteNode(name))
-                value = eval(joined_expr)
-                value isa Module && test_exceptions(value, visited, joined_expr)
+                value = getfield(mod, name)
 
-                if value isa Type
+                if value isa Module
+                    test_exceptions(value, visited)
+                elseif value isa Type
                     str = string(value)
                     if endswith(str, "Exception") || endswith(str, "Error")
                         @test value <: Exception

--- a/test/error.jl
+++ b/test/error.jl
@@ -105,12 +105,9 @@ end
         if mod ∉ visited
             push!(visited, mod)
             for name in names(mod, all=true)
+                isdefined(mod, name) || continue
                 joined_expr = Expr(:., mod_exp, QuoteNode(name))
-                value = try
-                    eval(joined_expr)
-                catch
-                    @test joined_expr ∈ [:(Base.Sys.physical_free_memory), :(Base.Sys.physical_total_memory)]
-                end
+                value = eval(joined_expr)
                 value isa Module && test_exceptions(value, visited, joined_expr)
 
                 if value isa Type


### PR DESCRIPTION
From @cjdoris's comment in https://github.com/JuliaLang/julia/pull/47008
> It may be worth adding some generic type-hierarchy tests. e.g. any *Error type should be an Exception.

`PaddingError` and `UnwrapTaskFailedException` previously did not subtype `Exception`.

I'm not sure about `UnwrapTaskFailedException`. Perhaps that should stay not a subtype of `Exception` and we should make an exception for it in the test.

This doesn't check types from the standard libraries, but perhaps it should.