### PR TITLE
Update manual heading for arrays

### DIFF
--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -1,4 +1,4 @@
-# [Multi-dimensional Arrays](@id man-multi-dim-arrays)
+# [Single- and multi-dimensional Arrays](@id man-multi-dim-arrays)
 
 Julia, like most technical computing languages, provides a first-class array implementation. Most
 technical computing languages pay a lot of attention to their array implementation at the expense


### PR DESCRIPTION
I was skimming the manual looking for where arrays are first introduced. I think this is the section, but it wasn't clear based on the old heading which implied, to me, that single-dimensional arrays were introduced earlier.

An alternative, shorter, heading would be "Arrays",  but for folks used to arrays being single-dimensional and looking for multidimensional arrays, that would be more difficult.