### PR TITLE
Add support for external functions to pkgimage

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -85,7 +85,7 @@ DEP_LIBS += dsfmt
 endif
 
 ifeq ($(USE_SYSTEM_LLVM), 0)
-DEP_LIBS += llvm
+DEP_LIBS += llvm lld
 endif
 
 ifeq ($(USE_SYSTEM_LLD), 0)

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -308,8 +308,8 @@ LLVM_TOOLS_JLL_TAGS := -llvm_version+$(LLVM_VER_MAJ)
 endif
 
 $(eval $(call bb-install,llvm,LLVM,false,true))
-$(eval $(call bb-install,clang,CLANG,false,true))
 $(eval $(call bb-install,lld,LLD,false,true))
+$(eval $(call bb-install,clang,CLANG,false,true))
 $(eval $(call bb-install,llvm-tools,LLVM_TOOLS,false,true))
 
 endif # USE_BINARYBUILDER_LLVM

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -267,10 +267,12 @@ static void jl_ci_cache_lookup(const jl_cgparams_t &cgparams, jl_method_instance
 // takes the running content that has collected in the shadow module and dump it to disk
 // this builds the object file portion of the sysimage files for fast startup, and can
 // also be used be extern consumers like GPUCompiler.jl to obtain a module containing
-// all reachable & inferrrable functions. The `policy` flag switches between the default
-// mode `0`, the extern mode `1`.
+// all reachable & inferrrable functions.
+// The `policy` flag switches between the default mode `0` and the extern mode `1` used by GPUCompiler.
+// `_imaging_mode` controls if raw pointers can be embedded (e.g. the code will be loaded into the same session).
+// `_external_linkage` create linkages between pkgimages.
 extern "C" JL_DLLEXPORT
-void *jl_create_native_impl(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int _policy, int _imaging_mode)
+void *jl_create_native_impl(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int _policy, int _imaging_mode, int _external_linkage)
 {
     ++CreateNativeCalls;
     CreateNativeMax.updateMax(jl_array_len(methods));
@@ -300,6 +302,7 @@ void *jl_create_native_impl(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvm
         compiler_start_time = jl_hrtime();
 
     params.imaging = imaging;
+    params.external_linkage = _external_linkage;
 
     // compile all methods for the current world and type-inference world
     size_t compile_for[] = { jl_typeinf_world, jl_atomic_load_acquire(&jl_world_counter) };

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -137,6 +137,17 @@ void jl_iterate_llvm_gv_impl(void *native_code, void (*callback)(void*, int32_t,
 }
 
 extern "C" JL_DLLEXPORT
+void jl_iterate_llvm_external_fns_impl(void *native_code, void (*callback)(void*, int32_t, jl_code_instance_t*, uint8_t), void* ctx)
+{
+    jl_native_code_desc_t *data = (jl_native_code_desc_t*)native_code;
+    if (data) {
+        for (std::pair<std::tuple<jl_code_instance_t*, uint8_t>, int32_t> pair : data->jl_external_to_llvm) {
+            callback(ctx, pair.second, std::get<0>(pair.first), std::get<1>(pair.first));
+        }
+    }
+}
+
+extern "C" JL_DLLEXPORT
 LLVMOrcThreadSafeModuleRef jl_get_llvm_module_impl(void *native_code)
 {
     jl_native_code_desc_t *data = (jl_native_code_desc_t*)native_code;

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -15,6 +15,7 @@ JL_DLLEXPORT void jl_dump_native_fallback(void *native_code,
         const char *sysimg_data, size_t sysimg_len) UNAVAILABLE
 JL_DLLEXPORT int32_t jl_get_llvm_gv_fallback(void *native_code, jl_value_t *p) UNAVAILABLE
 JL_DLLEXPORT void jl_iterate_llvm_gv_fallback(void *native_code, void (*callback)(void*, int32_t, void*), void* ctx) UNAVAILABLE
+JL_DLLEXPORT void jl_iterate_llvm_external_fns_fallback(void *native_code, void (*callback)(void*, int32_t, jl_code_instance_t*, uint8_t), void* ctx) UNAVAILABLE
 
 JL_DLLEXPORT void jl_extern_c_fallback(jl_function_t *f, jl_value_t *rt, jl_value_t *argt, char *name) UNAVAILABLE
 JL_DLLEXPORT jl_value_t *jl_dump_method_asm_fallback(jl_method_instance_t *linfo, size_t world,

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -67,7 +67,7 @@ JL_DLLEXPORT size_t jl_jit_total_bytes_fallback(void)
     return 0;
 }
 
-JL_DLLEXPORT void *jl_create_native_fallback(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int _policy, int _imaging_mode) UNAVAILABLE
+JL_DLLEXPORT void *jl_create_native_fallback(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int _policy, int _imaging_mode, int _external_linkage) UNAVAILABLE
 
 JL_DLLEXPORT void jl_dump_compiles_fallback(void *s)
 {

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -14,6 +14,7 @@ JL_DLLEXPORT void jl_dump_native_fallback(void *native_code,
         const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *asm_fname,
         const char *sysimg_data, size_t sysimg_len) UNAVAILABLE
 JL_DLLEXPORT int32_t jl_get_llvm_gv_fallback(void *native_code, jl_value_t *p) UNAVAILABLE
+JL_DLLEXPORT void jl_iterate_llvm_gv_fallback(void *native_code, void (*callback)(void*, int32_t, void*), void* ctx) UNAVAILABLE
 
 JL_DLLEXPORT void jl_extern_c_fallback(jl_function_t *f, jl_value_t *rt, jl_value_t *argt, char *name) UNAVAILABLE
 JL_DLLEXPORT jl_value_t *jl_dump_method_asm_fallback(jl_method_instance_t *linfo, size_t world,
@@ -66,7 +67,7 @@ JL_DLLEXPORT size_t jl_jit_total_bytes_fallback(void)
     return 0;
 }
 
-JL_DLLEXPORT void *jl_create_native_fallback(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvmctxt, const jl_cgparams_t *cgparams, int _policy) UNAVAILABLE
+JL_DLLEXPORT void *jl_create_native_fallback(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int _policy, int _imaging_mode) UNAVAILABLE
 
 JL_DLLEXPORT void jl_dump_compiles_fallback(void *s)
 {

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -16,6 +16,7 @@ JL_DLLEXPORT void jl_dump_native_fallback(void *native_code,
 JL_DLLEXPORT int32_t jl_get_llvm_gv_fallback(void *native_code, jl_value_t *p) UNAVAILABLE
 JL_DLLEXPORT void jl_iterate_llvm_gv_fallback(void *native_code, void (*callback)(void*, int32_t, void*), void* ctx) UNAVAILABLE
 JL_DLLEXPORT void jl_iterate_llvm_external_fns_fallback(void *native_code, void (*callback)(void*, int32_t, jl_code_instance_t*, uint8_t), void* ctx) UNAVAILABLE
+JL_DLLEXPORT int32_t jl_get_llvm_external_fns_begin_fallback(void *native_code) UNAVAILABLE;
 
 JL_DLLEXPORT void jl_extern_c_fallback(jl_function_t *f, jl_value_t *rt, jl_value_t *argt, char *name) UNAVAILABLE
 JL_DLLEXPORT jl_value_t *jl_dump_method_asm_fallback(jl_method_instance_t *linfo, size_t world,

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1414,7 +1414,7 @@ public:
     jl_codegen_params_t &emission_context;
     llvm::MapVector<jl_code_instance_t*, jl_codegen_call_target_t> call_targets;
     std::map<void*, GlobalVariable*> &global_targets;
-    std::map<jl_code_instance_t*, GlobalVariable*> &external_calls;
+    std::map<std::tuple<jl_code_instance_t*, bool>, Function*> &external_calls;
     Function *f = NULL;
     // local var info. globals are not in here.
     std::vector<jl_varinfo_t> slots;
@@ -4063,22 +4063,11 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, const 
                         result = emit_call_specfun_boxed(ctx, codeinst->rettype, protoname, argv, nargs, rt);
                     if (external) {
                         assert(!need_to_emit);
-                        llvm::outs() << *(result.V) << "\n";
                         if (auto CI = dyn_cast<llvm::CallInst>(result.V)) {
-                            // TODO: Avoid this non-sense with RAUW
-                            // TODO: Make sure that we can call the same function and get the same GV
-                            // TODO: We probably need the calling convention?
-                            Value *Callee = CI->getCalledOperand();
-                            Module *M = ctx.f->getParent();
-                            auto T_pvoidfunc = JuliaType::get_pvoidfunc_ty(M->getContext());
-                            GlobalVariable *GV = new GlobalVariable(*M, T_pvoidfunc, false,
-                                                        GlobalVariable::ExternalLinkage,
-                                                        Constant::getNullValue(T_pvoidfunc), protoname);
-                            Value *FN = ctx.builder.CreatePointerCast(GV, CI->getFunctionType()->getPointerTo());
-                            Callee->replaceAllUsesWith(FN);
-                            ctx.external_calls[codeinst] = GV;
+                            ctx.external_calls[std::make_tuple(codeinst, specsig)] = CI->getCalledFunction();
+                        } else {
+                            assert(false);
                         }
-                        llvm::outs() << *(result.V) << "\n";
                     }
                     handled = true;
                     if (need_to_emit) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4015,6 +4015,8 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, const 
                     std::string name;
                     StringRef protoname;
                     bool need_to_emit = true;
+                    // TODO: We should check if the code is available externally
+                    //       and then emit a trampoline.
                     if (ctx.use_cache) {
                         // optimization: emit the correct name immediately, if we know it
                         // TODO: use `emitted` map here too to try to consolidate names?
@@ -6765,6 +6767,8 @@ static jl_llvm_functions_t
         funcName << "japi3_";
     else
         funcName << "japi1_";
+    if (jl_precompile_toplevel_module != NULL)
+        funcName << jl_precompile_toplevel_module->build_id << "_";
     const char* unadorned_name = ctx.name;
 #if defined(_OS_LINUX_)
     if (unadorned_name[0] == '@')
@@ -6812,7 +6816,11 @@ static jl_llvm_functions_t
         }();
 
         std::string wrapName;
-        raw_string_ostream(wrapName) << "jfptr_" << unadorned_name << "_" << globalUniqueGeneratedNames++;
+        raw_string_ostream wrapNameStream(wrapName);
+        wrapNameStream << "jfptr_" << unadorned_name;
+        if (jl_precompile_toplevel_module)
+            wrapNameStream << "_" << jl_precompile_toplevel_module->build_id;
+        wrapNameStream << "_"  << globalUniqueGeneratedNames++;
         declarations.functionObject = wrapName;
         (void)gen_invoke_wrapper(lam, jlrettype, returninfo, retarg, declarations.functionObject, M, ctx.emission_context);
         // TODO: add attributes: maybe_mark_argument_dereferenceable(Arg, argType)
@@ -8284,6 +8292,10 @@ void jl_compile_workqueue(
         StringRef preal_decl = "";
         bool preal_specsig = false;
         auto invoke = jl_atomic_load_relaxed(&codeinst->invoke);
+        // TODO: available_extern
+        // We need to emit a trampoline that loads the target address in an extern_module from a GV
+        // Right now we will unecessarily emit a function we have already compiled in a native module
+        // again in a calling module.
         if (params.cache && invoke != NULL) {
             auto fptr = jl_atomic_load_relaxed(&codeinst->specptr.fptr);
             if (invoke == jl_fptr_args_addr) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4063,11 +4063,10 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, const 
                         result = emit_call_specfun_boxed(ctx, codeinst->rettype, protoname, argv, nargs, rt);
                     if (external) {
                         assert(!need_to_emit);
-                        if (auto CI = dyn_cast<llvm::CallInst>(result.V)) {
-                            ctx.external_calls[std::make_tuple(codeinst, specsig)] = CI->getCalledFunction();
-                        } else {
-                            assert(false);
-                        }
+                        auto calledF = jl_Module->getFunction(protoname);
+                        assert(calledF);
+                        // TODO: Check if already present?
+                        ctx.external_calls[std::make_tuple(codeinst, specsig)] = calledF;
                     }
                     handled = true;
                     if (need_to_emit) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1414,6 +1414,7 @@ public:
     jl_codegen_params_t &emission_context;
     llvm::MapVector<jl_code_instance_t*, jl_codegen_call_target_t> call_targets;
     std::map<void*, GlobalVariable*> &global_targets;
+    std::map<jl_code_instance_t*, GlobalVariable*> &external_calls;
     Function *f = NULL;
     // local var info. globals are not in here.
     std::vector<jl_varinfo_t> slots;
@@ -1460,6 +1461,7 @@ public:
         emission_context(params),
         call_targets(),
         global_targets(params.globals),
+        external_calls(params.external_fns),
         world(params.world),
         use_cache(params.cache),
         external_linkage(params.external_linkage),
@@ -4063,14 +4065,18 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, const 
                         assert(!need_to_emit);
                         llvm::outs() << *(result.V) << "\n";
                         if (auto CI = dyn_cast<llvm::CallInst>(result.V)) {
+                            // TODO: Avoid this non-sense with RAUW
+                            // TODO: Make sure that we can call the same function and get the same GV
+                            // TODO: We probably need the calling convention?
                             Value *Callee = CI->getCalledOperand();
                             Module *M = ctx.f->getParent();
                             auto T_pvoidfunc = JuliaType::get_pvoidfunc_ty(M->getContext());
-                            Value *GV = new GlobalVariable(*M, T_pvoidfunc, false,
+                            GlobalVariable *GV = new GlobalVariable(*M, T_pvoidfunc, false,
                                                         GlobalVariable::ExternalLinkage,
                                                         Constant::getNullValue(T_pvoidfunc), protoname);
-                            GV = ctx.builder.CreatePointerCast(GV, CI->getFunctionType()->getPointerTo());
-                            Callee->replaceAllUsesWith(GV); 
+                            Value *FN = ctx.builder.CreatePointerCast(GV, CI->getFunctionType()->getPointerTo());
+                            Callee->replaceAllUsesWith(FN);
+                            ctx.external_calls[codeinst] = GV;
                         }
                         llvm::outs() << *(result.V) << "\n";
                     }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8292,11 +8292,15 @@ void jl_compile_workqueue(
         StringRef preal_decl = "";
         bool preal_specsig = false;
         auto invoke = jl_atomic_load_relaxed(&codeinst->invoke);
-        // TODO: available_extern
         // We need to emit a trampoline that loads the target address in an extern_module from a GV
         // Right now we will unecessarily emit a function we have already compiled in a native module
         // again in a calling module.
+
         if (params.cache && invoke != NULL) {
+            uint64_t build_id = codeinst->build_id;
+            if (build_id && build_id != jl_current_build_id()) {
+                    // TODO(vchuravy)
+            }
             auto fptr = jl_atomic_load_relaxed(&codeinst->specptr.fptr);
             if (invoke == jl_fptr_args_addr) {
                 preal_decl = jl_ExecutionEngine->getFunctionAtAddress((uintptr_t)fptr, codeinst);

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -104,6 +104,7 @@ jl_datatype_t *jl_new_uninitialized_datatype(void)
     t->zeroinit = 0;
     t->has_concrete_subtype = 1;
     t->cached_by_hash = 0;
+    t->imgcache = 0;
     t->name = NULL;
     t->super = NULL;
     t->parameters = NULL;

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -73,7 +73,7 @@ const char *jl_crtdll_name = CRTDLL_BASENAME ".dll";
 #define JL_RTLD(flags, FLAG) (flags & JL_RTLD_ ## FLAG ? RTLD_ ## FLAG : 0)
 
 #ifdef _OS_WINDOWS_
-static void win32_formatmessage(DWORD code, char *reason, int len) JL_NOTSAFEPOINT
+void win32_formatmessage(DWORD code, char *reason, int len) JL_NOTSAFEPOINT
 {
     DWORD res;
     LPWSTR errmsg;

--- a/src/dump.c
+++ b/src/dump.c
@@ -150,7 +150,7 @@ static arraylist_t reinit_list;
 // list of modules being serialized
 // This is not quite globally rooted, but we take care to only
 // ever assigned rooted values here.
-static jl_array_t *serializer_worklist JL_GLOBALLY_ROOTED;
+jl_array_t *serializer_worklist JL_GLOBALLY_ROOTED;
 // The set of external MethodInstances we want to serialize
 // (methods owned by other modules that were first inferred for a
 //  module currently being serialized)
@@ -237,7 +237,7 @@ static void jl_serialize_cnull(jl_serializer_state *s, jl_value_t *t)
     jl_serialize_value(s, t);
 }
 
-static int module_in_worklist(jl_module_t *mod) JL_NOTSAFEPOINT
+int module_in_worklist(jl_module_t *mod) JL_NOTSAFEPOINT
 {
     int i, l = jl_array_len(serializer_worklist);
     for (i = 0; i < l; i++) {
@@ -933,7 +933,7 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
                     rletable = (uint64_t*)jl_array_data(m->root_blocks);
                     nblocks2 = jl_array_len(m->root_blocks);
                 }
-                // this visits every item, if it becomes a bottlneck we could hop blocks
+                // this visits every item, if it becomes a bottleneck we could hop blocks
                 while (rle_iter_increment(&rootiter, nroots, rletable, nblocks2))
                     if (rootiter.key == key)
                         jl_serialize_value(s, jl_array_ptr_ref(m->roots, rootiter.i));

--- a/src/dump.c
+++ b/src/dump.c
@@ -754,6 +754,7 @@ static void jl_serialize_code_instance(jl_serializer_state *s, jl_code_instance_
         jl_serialize_value(s, jl_nothing);
     }
     write_uint8(s->s, codeinst->relocatability);
+    write_uint64(s->s, codeinst->build_id);
     jl_serialize_code_instance(s, codeinst->next, skip_partial_opaque, internal, 0);
 }
 
@@ -2018,6 +2019,7 @@ static jl_value_t *jl_deserialize_value_code_instance(jl_serializer_state *s, jl
         codeinst->precompile = 1;
     codeinst->relocatability = read_uint8(s->s);
     assert(codeinst->relocatability <= 1);
+    codeinst->build_id = read_uint64(s->s);
     codeinst->next = (jl_code_instance_t*)jl_deserialize_value(s, (jl_value_t**)&codeinst->next);
     jl_gc_wb(codeinst, codeinst->next);
     if (validate) {

--- a/src/gc.c
+++ b/src/gc.c
@@ -2884,6 +2884,8 @@ static void mark_roots(jl_gc_mark_cache_t *gc_cache, jl_gc_mark_sp_t *sp)
         gc_mark_queue_obj(gc_cache, sp, jl_all_methods);
     if (_jl_debug_method_invalidation != NULL)
         gc_mark_queue_obj(gc_cache, sp, _jl_debug_method_invalidation);
+    if (jl_build_ids != NULL)
+        gc_mark_queue_obj(gc_cache, sp, jl_build_ids);
 
     // constants
     gc_mark_queue_obj(gc_cache, sp, jl_emptytuple_type);

--- a/src/gf.c
+++ b/src/gf.c
@@ -391,6 +391,13 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_method_inferred(
     return codeinst;
 }
 
+JL_DLLEXPORT uint64_t jl_current_build_id()
+{
+    if (jl_precompile_toplevel_module != NULL)
+        return jl_precompile_toplevel_module->build_id;
+    return 0;
+}
+
 JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
         jl_method_instance_t *mi, jl_value_t *rettype,
         jl_value_t *inferred_const, jl_value_t *inferred,
@@ -425,6 +432,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
     jl_atomic_store_relaxed(&codeinst->purity_bits, effects);
     codeinst->argescapes = argescapes;
     codeinst->relocatability = relocatability;
+    codeinst->build_id = jl_current_build_id();
     return codeinst;
 }
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -391,7 +391,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_method_inferred(
     return codeinst;
 }
 
-JL_DLLEXPORT uint64_t jl_current_build_id()
+JL_DLLEXPORT uint64_t jl_current_build_id(void)
 {
     if (jl_precompile_toplevel_module != NULL)
         return jl_precompile_toplevel_module->build_id;

--- a/src/gf.c
+++ b/src/gf.c
@@ -461,7 +461,7 @@ static int get_method_unspec_list(jl_typemap_entry_t *def, void *closure)
     return 1;
 }
 
-static int foreach_mtable_in_module(
+int foreach_mtable_in_module(
         jl_module_t *m,
         int (*visit)(jl_methtable_t *mt, void *env),
         void *env)

--- a/src/init.c
+++ b/src/init.c
@@ -719,6 +719,9 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
         jl_install_default_signal_handlers();
 
     jl_gc_init();
+
+    arraylist_new(&jl_linkage_blobs, 0);
+
     jl_ptls_t ptls = jl_init_threadtls(0);
 #pragma GCC diagnostic push
 #if defined(_COMPILER_GCC_) && __GNUC__ >= 12

--- a/src/init.c
+++ b/src/init.c
@@ -721,6 +721,7 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
     jl_gc_init();
 
     arraylist_new(&jl_linkage_blobs, 0);
+    arraylist_new(&jl_image_relocs, 0);
 
     jl_ptls_t ptls = jl_init_threadtls(0);
 #pragma GCC diagnostic push

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -220,7 +220,6 @@ jl_llvm_functions_t jl_emit_codeinst(
 enum CompilationPolicy {
     Default = 0,
     Extern = 1,
-    ImagingMode = 2
 };
 
 typedef std::map<jl_code_instance_t*, std::pair<orc::ThreadSafeModule, jl_llvm_functions_t>> jl_workqueue_t;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -173,6 +173,7 @@ typedef struct _jl_codegen_params_t {
     // outputs
     std::vector<std::pair<jl_code_instance_t*, jl_codegen_call_target_t>> workqueue;
     std::map<void*, GlobalVariable*> globals;
+    std::map<jl_code_instance_t*, GlobalVariable*> external_fns;
     std::map<jl_datatype_t*, DIType*> ditypes;
     std::map<jl_datatype_t*, Type*> llvmtypes;
     DenseMap<Constant*, GlobalVariable*> mergedConstants;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -200,6 +200,7 @@ typedef struct _jl_codegen_params_t {
     size_t world = 0;
     const jl_cgparams_t *params = &jl_default_cgparams;
     bool cache = false;
+    bool external_linkage = false;
     bool imaging;
     _jl_codegen_params_t(orc::ThreadSafeContext ctx) : tsctx(std::move(ctx)), tsctx_lock(tsctx.getLock()), imaging(imaging_default()) {}
 } jl_codegen_params_t;

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -173,7 +173,7 @@ typedef struct _jl_codegen_params_t {
     // outputs
     std::vector<std::pair<jl_code_instance_t*, jl_codegen_call_target_t>> workqueue;
     std::map<void*, GlobalVariable*> globals;
-    std::map<jl_code_instance_t*, GlobalVariable*> external_fns;
+    std::map<std::tuple<jl_code_instance_t*,bool>, Function*> external_fns;
     std::map<jl_datatype_t*, DIType*> ditypes;
     std::map<jl_datatype_t*, Type*> llvmtypes;
     DenseMap<Constant*, GlobalVariable*> mergedConstants;

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -542,6 +542,7 @@
     YY(jl_get_llvm_gv) \
     YY(jl_iterate_llvm_gv) \
     YY(jl_iterate_llvm_external_fns) \
+    YY(jl_get_llvm_external_fns_begin) \
     YY(jl_dump_function_asm) \
     YY(jl_LLVMCreateDisasm) \
     YY(jl_LLVMDisasmInstruction) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -401,6 +401,7 @@
     XX(jl_restore_excstack) \
     XX(jl_restore_incremental) \
     XX(jl_restore_incremental_from_buf) \
+    XX(jl_restore_package_image_from_file) \
     XX(jl_restore_system_image) \
     XX(jl_restore_system_image_data) \
     XX(jl_rethrow) \
@@ -521,6 +522,7 @@
     XX(jl_vexceptionf) \
     XX(jl_vprintf) \
     XX(jl_wakeup_thread) \
+    XX(jl_write_compiler_output) \
     XX(jl_yield) \
 
 #define JL_RUNTIME_EXPORTED_FUNCS_WIN(XX) \
@@ -537,6 +539,7 @@
     YY(jl_get_LLVM_VERSION) \
     YY(jl_dump_native) \
     YY(jl_get_llvm_gv) \
+    YY(jl_iterate_llvm_gv) \
     YY(jl_dump_function_asm) \
     YY(jl_LLVMCreateDisasm) \
     YY(jl_LLVMDisasmInstruction) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -323,6 +323,7 @@
     XX(jl_method_table_insert) \
     XX(jl_methtable_lookup) \
     XX(jl_mi_cache_insert) \
+    XX(jl_current_build_id) \
     XX(jl_module_build_id) \
     XX(jl_module_export) \
     XX(jl_module_exports_p) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -541,6 +541,7 @@
     YY(jl_dump_native) \
     YY(jl_get_llvm_gv) \
     YY(jl_iterate_llvm_gv) \
+    YY(jl_iterate_llvm_external_fns) \
     YY(jl_dump_function_asm) \
     YY(jl_LLVMCreateDisasm) \
     YY(jl_LLVMDisasmInstruction) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2541,7 +2541,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_code_instance_type =
         jl_new_datatype(jl_symbol("CodeInstance"), core,
                         jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(15,
+                        jl_perm_symsvec(16,
                             "def",
                             "next",
                             "min_world",
@@ -2554,8 +2554,9 @@ void jl_init_types(void) JL_GC_DISABLED
                             "ipo_purity_bits", "purity_bits",
                             "argescapes",
                             "isspecsig", "precompile", "invoke", "specptr", // function object decls
-                            "relocatability"),
-                        jl_svec(15,
+                            "relocatability",
+                            "build_id"),
+                        jl_svec(16,
                             jl_method_instance_type,
                             jl_any_type,
                             jl_ulong_type,
@@ -2570,7 +2571,8 @@ void jl_init_types(void) JL_GC_DISABLED
                             jl_bool_type,
                             jl_bool_type,
                             jl_any_type, jl_any_type, // fptrs
-                            jl_uint8_type),
+                            jl_uint8_type,
+                            jl_uint64_type),
                         jl_emptysvec,
                         0, 1, 1);
     jl_svecset(jl_code_instance_type->types, 1, jl_code_instance_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -552,6 +552,7 @@ typedef struct _jl_datatype_t {
     uint8_t zeroinit:1; // if one or more fields requires zero-initialization
     uint8_t has_concrete_subtype:1; // If clear, no value will have this datatype
     uint8_t cached_by_hash:1; // stored in hash-based set cache (instead of linear cache)
+    uint8_t imgcache:1; // true if this type was loaded from sysimg/pkgimg
 } jl_datatype_t;
 
 typedef struct _jl_vararg_t {
@@ -1759,14 +1760,17 @@ JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle);
 JL_DLLEXPORT int jl_deserialize_verify_header(ios_t *s);
 JL_DLLEXPORT void jl_preload_sysimg_so(const char *fname);
 JL_DLLEXPORT void jl_set_sysimg_so(void *handle);
-JL_DLLEXPORT ios_t *jl_create_system_image(void *);
+JL_DLLEXPORT ios_t *jl_create_system_image(void *, jl_array_t *worklist);
 JL_DLLEXPORT void jl_save_system_image(const char *fname);
 JL_DLLEXPORT void jl_restore_system_image(const char *fname);
-JL_DLLEXPORT void jl_restore_system_image_data(const char *buf, size_t len);
+JL_DLLEXPORT jl_value_t *jl_restore_system_image_data(const char *buf, size_t len);
+JL_DLLEXPORT jl_value_t *jl_restore_package_image_from_file(const char *fname);
 JL_DLLEXPORT void jl_set_newly_inferred(jl_value_t *newly_inferred);
 JL_DLLEXPORT int jl_save_incremental(const char *fname, jl_array_t *worklist);
 JL_DLLEXPORT jl_value_t *jl_restore_incremental(const char *fname, jl_array_t *depmods);
 JL_DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(const char *buf, size_t sz, jl_array_t *depmods);
+
+JL_DLLEXPORT void jl_write_compiler_output(void);
 
 // parsing
 JL_DLLEXPORT jl_value_t *jl_parse_all(const char *text, size_t text_len,

--- a/src/julia.h
+++ b/src/julia.h
@@ -442,6 +442,7 @@ typedef struct _jl_code_instance_t {
         // 4 interpreter
     } specptr; // private data for `jlcall entry point
     uint8_t relocatability;  // nonzero if all roots are built into sysimg or tagged by module key
+    uint64_t build_id;
 } jl_code_instance_t;
 
 // all values are callable as Functions

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -294,6 +294,7 @@ extern arraylist_t jl_linkage_blobs;                        // external linkage:
 extern jl_array_t *jl_build_ids JL_GLOBALLY_ROOTED;         // external linkage: corresponding build_ids
 extern arraylist_t jl_image_relocs;                        // external linkage: sysimg/pkgimages
 extern uint64_t jl_worklist_key(jl_array_t *worklist);
+JL_DLLEXPORT uint64_t jl_current_build_id();
 
 extern JL_DLLEXPORT size_t jl_page_size;
 extern jl_function_t *jl_typeinf_func;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -976,6 +976,7 @@ void jl_dump_native(void *native_code,
         const char *sysimg_data, size_t sysimg_len);
 int32_t jl_get_llvm_gv(void *native_code, jl_value_t *p) JL_NOTSAFEPOINT;
 void jl_iterate_llvm_gv(void *native_code, void (*callback)(void*, int32_t, void*), void*) JL_NOTSAFEPOINT;
+void jl_iterate_llvm_external_fns(void *native_code, void (*callback)(void*, int32_t, jl_code_instance_t*, uint8_t), void*) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_get_function_id(void *native_code, jl_code_instance_t *ncode,
         int32_t *func_idx, int32_t *specfunc_idx);
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -977,6 +977,7 @@ void jl_dump_native(void *native_code,
 int32_t jl_get_llvm_gv(void *native_code, jl_value_t *p) JL_NOTSAFEPOINT;
 void jl_iterate_llvm_gv(void *native_code, void (*callback)(void*, int32_t, void*), void*) JL_NOTSAFEPOINT;
 void jl_iterate_llvm_external_fns(void *native_code, void (*callback)(void*, int32_t, jl_code_instance_t*, uint8_t), void*) JL_NOTSAFEPOINT;
+int32_t jl_get_llvm_external_fns_begin(void *native_code);
 JL_DLLEXPORT void jl_get_function_id(void *native_code, jl_code_instance_t *ncode,
         int32_t *func_idx, int32_t *specfunc_idx);
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -294,7 +294,7 @@ extern arraylist_t jl_linkage_blobs;                        // external linkage:
 extern jl_array_t *jl_build_ids JL_GLOBALLY_ROOTED;         // external linkage: corresponding build_ids
 extern arraylist_t jl_image_relocs;                        // external linkage: sysimg/pkgimages
 extern uint64_t jl_worklist_key(jl_array_t *worklist);
-JL_DLLEXPORT uint64_t jl_current_build_id();
+JL_DLLEXPORT uint64_t jl_current_build_id(void);
 
 extern JL_DLLEXPORT size_t jl_page_size;
 extern jl_function_t *jl_typeinf_func;
@@ -970,7 +970,7 @@ JL_DLLEXPORT jl_value_t *jl_dump_fptr_asm(uint64_t fptr, char raw_mc, const char
 JL_DLLEXPORT jl_value_t *jl_dump_function_ir(jl_llvmf_dump_t *dump, char strip_ir_metadata, char dump_module, const char *debuginfo);
 JL_DLLEXPORT jl_value_t *jl_dump_function_asm(jl_llvmf_dump_t *dump, char raw_mc, const char* asm_variant, const char *debuginfo, char binary);
 
-void *jl_create_native(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int policy, int imaging_mode);
+void *jl_create_native(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int policy, int imaging_mode, int cache);
 void jl_dump_native(void *native_code,
         const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *asm_fname,
         const char *sysimg_data, size_t sysimg_len);

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -354,7 +354,7 @@ static int precompile_enq_all_specializations_(jl_methtable_t *mt, void *env)
     return jl_typemap_visitor(jl_atomic_load_relaxed(&mt->defs), precompile_enq_all_specializations__, env);
 }
 
-static void *jl_precompile_(jl_array_t *m)
+static void *jl_precompile_(jl_array_t *m, int external_linkage)
 {
     jl_array_t *m2 = NULL;
     jl_method_instance_t *mi = NULL;
@@ -377,7 +377,7 @@ static void *jl_precompile_(jl_array_t *m)
             jl_array_ptr_1d_push(m2, item);
         }
     }
-    void *native_code = jl_create_native(m2, NULL, NULL, 0, 1);
+    void *native_code = jl_create_native(m2, NULL, NULL, 0, 1, external_linkage);
     JL_GC_POP();
     return native_code;
 }
@@ -390,7 +390,7 @@ static void *jl_precompile(int all)
     if (all)
         jl_compile_all_defs(m);
     jl_foreach_reachable_mtable(precompile_enq_all_specializations_, m);
-    void *native_code = jl_precompile_(m);
+    void *native_code = jl_precompile_(m, 0);
     JL_GC_POP();
     return native_code;
 }
@@ -409,7 +409,7 @@ static void *jl_precompile_worklist(jl_array_t *worklist)
         assert(jl_is_module(mod));
         foreach_mtable_in_module(mod, precompile_enq_all_specializations_, m);
     }
-    void *native_code = jl_precompile_(m);
+    void *native_code = jl_precompile_(m, 1);
     JL_GC_POP();
     return native_code;
 }

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -627,10 +627,14 @@ static inline jl_sysimg_fptrs_t parse_sysimg(void *hdl, F &&callback)
 
     // .data base
     char *data_base;
-    jl_dlsym(hdl, "jl_sysimg_gvars_base", (void**)&data_base, 1);
+    if (!jl_dlsym(hdl, "jl_sysimg_gvars_base", (void**)&data_base, 0)) {
+        data_base = NULL;
+    }
     // .text base
     char *text_base;
-    jl_dlsym(hdl, "jl_sysimg_fvars_base", (void**)&text_base, 1);
+    if (!jl_dlsym(hdl, "jl_sysimg_fvars_base", (void**)&text_base, 0)) {
+        text_base = NULL;
+    }
     res.base = text_base;
 
     int32_t *offsets;

--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -1013,8 +1013,9 @@ JL_DLLEXPORT jl_value_t *jl_get_cpu_name(void)
 
 jl_sysimg_fptrs_t jl_init_processor_sysimg(void *hdl)
 {
-    if (!jit_targets.empty())
-        jl_error("JIT targets already initialized");
+    // FIXME: Load package image corresponding to sysimage
+    // if (!jit_targets.empty())
+        // jl_error("JIT targets already initialized");
     return parse_sysimg(hdl, sysimg_init_cb);
 }
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2614,6 +2614,19 @@ JL_DLLEXPORT jl_value_t *jl_restore_package_image_from_file(const char *fname)
     sysimg_gvars_offsets += 1;
     jl_value_t* mod = jl_restore_system_image_data(pkgimg_data, *plen);
     sysimg_fptrs = old_sysimg_fptrs;
+
+    void *pgcstack_func_slot;
+    jl_dlsym(pkgimg_handle, "jl_pgcstack_func_slot", &pgcstack_func_slot, 0);
+    if (pgcstack_func_slot) { // Empty package images might miss these
+        void *pgcstack_key_slot;
+        jl_dlsym(pkgimg_handle, "jl_pgcstack_key_slot", &pgcstack_key_slot, 1);
+        jl_pgcstack_getkey((jl_get_pgcstack_func**)pgcstack_func_slot, (jl_pgcstack_key_t*)pgcstack_key_slot);
+
+        size_t *tls_offset_idx;
+        jl_dlsym(pkgimg_handle, "jl_tls_offset", (void **)&tls_offset_idx, 1);
+        *tls_offset_idx = (uintptr_t)(jl_tls_offset == -1 ? 0 : jl_tls_offset);
+    }
+
     return mod;
 }
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -431,6 +431,7 @@ static int externally_linked(jl_value_t *v)
     // To be continued in a future PR.
     
     // What about MethodInstances that are instantiated from a pkgimage, and don't exist prior.
+    // TODO(@timholy): This turned problematic for some of our test-cases
     // if (jl_is_method_instance(v))
     //     return externally_linked(((jl_method_instance_t*)v)->def.value);
     // else if (jl_is_code_instance(v))
@@ -1023,7 +1024,7 @@ static void jl_write_values(jl_serializer_state *s)
         record_gvar(s, GV, ((uintptr_t)DataRef << RELOC_TAG_OFFSET) + reloc_offset);
 
         if (externally_linked(v)) {
-            assert(!GV);
+            // assert(!GV); TODO (@timholy) why the assert
             write_pointerfield(s, v);
             continue;
         }

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -7,14 +7,17 @@
   dump.c has no knowledge of native code (and simply discards it), whereas this supports native code caching in .o files.
   Duplication is avoided by elevating the .o-serialized versions of global variables and native-compiled functions to become
   the authoritative source for such entities in the system image, with references to these objects appropriately inserted into
-  the (de)serialized version of Julia's internal data. This makes deserialization simple and fast: we only need to deal with
-  pointer relocation, registering with the garbage collector, and making note of special internal types. During serialization,
-  we also need to pay special attention to things like builtin functions, C-implemented types (those in jltypes.c), the metadata
-  for documentation, optimal layouts, integration with native system image generation, and preparing other preprocessing
-  directives.
+  the (de)serialized version of Julia's internal data.
 
-  dump.c has capabilities missing from this serializer, most notably the ability to handle external references. This is not needed
-  for system images as they are self-contained. However, it would be needed to support incremental compilation of packages.
+  Another difference is that while dump.c defines a serialization format that it writes item-by-item, this serializer creates and
+  saves a compact binary blob. This makes deserialization simple and fast: we only need to deal with pointer relocation,
+  registering with the garbage collector, and making note of special internal types. During serialization, we also need to
+  pay special attention to things like builtin functions, C-implemented types (those in jltypes.c), the metadata for documentation,
+  optimal layouts, integration with native system image generation, and preparing other preprocessing directives.
+
+  dump.c has capabilities missing from this serializer, most notably the ability to manage (and merge) method tables.
+  This is not needed for system images as they are self-contained. However, it would be needed to support incremental
+  compilation of packages.
 
   During serialization, the flow has several steps:
 
@@ -54,6 +57,17 @@
 
 The tables written to the serializer stream make deserialization fairly straightforward. Much of the "real work" is
 done by `get_item_for_reloc`.
+
+Encoding of a pointer:
+- in the location of the pointer, we initially write zero padding
+- for both relocs_list and gctags_list, we write loc/backrefid (for gctags_list this is handled by the caller of write_gctaggedfield,
+  for relocs_list it's handled by write_pointerfield)
+- when writing to disk, both call get_reloc_for_item, and its return value (subject to modification by gc bits)
+  ends up being written into the data stream (s->s), and the data stream's position written to s->relocs
+
+External links:
+- location holds the offset
+- loc/0 in relocs_list
 
 */
 #include <stdlib.h>
@@ -276,6 +290,8 @@ static uintptr_t nsym_tag;
 // array of definitions for the predefined tagged object types
 // (reverse of symbol_table)
 static arraylist_t deser_sym;
+// Predefined tags that do not have special handling in `externally_linked`
+static htable_t external_objects;
 
 // table of all objects that are serialized
 static htable_t backref_table;
@@ -286,13 +302,19 @@ static arraylist_t object_worklist;  // used to mimic recursion by jl_serialize_
 // Both `reinit_list` and `ccallable_list` are lists of (size_t pos, code) entries
 // for the serializer to mark values in need of rework during deserialization
 // codes:
-//   1: typename   (reinit_list)
+//   1: IdDict     (reinit_list)
 //   2: module     (reinit_list)
 //   3: method     (ccallable_list)
 static arraylist_t reinit_list;
 
 // @ccallable entry points to install
 static arraylist_t ccallable_list;
+
+// Permanent list of void* (begin, end+1) pairs of system/package images we've loaded previously
+// togther with their module build_ids (used for external linkage)
+// jl_linkage_blobs.items[2i:2i+1] correspond to jl_build_ids[i]   (0-offset indexing)
+arraylist_t jl_linkage_blobs;
+jl_array_t *jl_build_ids JL_GLOBALLY_ROOTED = NULL;
 
 // hash of definitions for predefined function pointers
 static htable_t fptr_to_id;
@@ -328,6 +350,14 @@ typedef struct {
     ios_t *fptr_record;         // serialized array mapping fptrid => spos
     arraylist_t relocs_list;    // a list of (location, target) pairs, see description at top
     arraylist_t gctags_list;    //      "
+    // record of build_ids for all external linkages, in order of serialization for the current sysimg/pkgimg
+    // conceptually, the base pointer for the jth externally-linked item is determined from
+    //     i = findfirst(==(link_ids[j]), jl_build_ids)
+    //     blob_base = jl_linkage_blobs.items[2i]                     # 0-offset indexing
+    // We need separate lists since they are intermingled at creation but split when written.
+    jl_array_t *link_ids_relocs;
+    jl_array_t *link_ids_gctags;
+    jl_array_t *link_ids_gvars;
     jl_ptls_t ptls;
 } jl_serializer_state;
 
@@ -341,13 +371,14 @@ static jl_sym_t *jl_docmeta_sym = NULL;
 // Tags of category `t` are located at offsets `t << RELOC_TAG_OFFSET`
 // Consequently there is room for 2^RELOC_TAG_OFFSET pointers, etc
 enum RefTags {
-    DataRef,           // mutable data
-    ConstDataRef,      // constant data (e.g., layouts)
-    TagRef,            // items serialized via their tags
-    SymbolRef,         // symbols
-    BindingRef,        // module bindings
-    FunctionRef,       // generic functions
-    BuiltinFunctionRef // builtin functions
+    DataRef,            // mutable data
+    ConstDataRef,       // constant data (e.g., layouts)
+    TagRef,             // items serialized via their tags
+    SymbolRef,          // symbols
+    BindingRef,         // module bindings
+    FunctionRef,        // generic functions
+    BuiltinFunctionRef, // builtin functions
+    ExternalLinkage     // items defined externally (used when serializing packages)
 };
 
 // calling conventions for internal entry points.
@@ -384,6 +415,34 @@ static void write_reloc_t(ios_t *s, uintptr_t reloc_id) JL_NOTSAFEPOINT
     else {
         write_uint64(s, reloc_id);
     }
+}
+
+static int externally_linked(jl_value_t *v)
+{
+    if (!serializer_worklist)   // disabled when writing sysimg
+        return 0;
+    if (jl_is_datatype(v) && ((jl_datatype_t*)v)->imgcache)
+        return 1;
+
+    // The special handling for a few items here represents a downpayment on a
+    // more extensive mirroring/porting of functionality from dump.c.
+    // To be continued in a future PR.
+    if (jl_is_method_instance(v))
+        return externally_linked(((jl_method_instance_t*)v)->def.value);
+    else if (jl_is_code_instance(v))
+        return externally_linked(((jl_code_instance_t*)v)->def->def.value);
+
+    jl_module_t *vmod = NULL;
+    if (jl_is_module(v))
+        vmod = (jl_module_t*)v;
+    else if (jl_is_typename(v))
+        vmod = ((jl_typename_t*)v)->module;
+    else if (jl_is_method(v))
+        vmod = ((jl_method_t*)v)->module;
+    if (vmod && !module_in_worklist(vmod))
+        return 1;
+
+    return ptrhash_get(&external_objects, v) != HT_NOTFOUND;
 }
 
 // --- Static Compile ---
@@ -538,6 +597,10 @@ static void jl_serialize_value__(jl_serializer_state *s, jl_value_t *v, int recu
     char *pos = (char*)HT_NOTFOUND + item;
     *bp = (void*)pos;
 
+    // Don't recurse into things we already cached in an earlier sysimg/pkgimg
+    if (externally_linked(v))
+        return;
+
     // some values have special representations
     jl_datatype_t *t = (jl_datatype_t*)jl_typeof(v);
     jl_serialize_value(s, t);
@@ -674,11 +737,55 @@ static void write_pointer(ios_t *s) JL_NOTSAFEPOINT
     write_uint(s, 0);
 }
 
+static size_t n_linkage_blobs(void)
+{
+    if (!jl_build_ids)
+        return 0;
+    assert(jl_is_array(jl_build_ids));
+    return jl_array_len(jl_build_ids);
+}
+
+static size_t external_blob_index(jl_value_t *v) {
+    size_t nblobs = n_linkage_blobs();
+    if (nblobs == 0)
+        return nblobs;
+    assert(jl_linkage_blobs.len == 2*nblobs);
+    for (size_t i = 0; i < 2*nblobs; i+=2) {
+        uintptr_t left = (uintptr_t)jl_linkage_blobs.items[i], right = (uintptr_t)jl_linkage_blobs.items[i+1];
+        if (left <= (uintptr_t)v && (uintptr_t)v < right) {
+            return i>>1;
+        }
+    }
+    return nblobs;
+}
+
+static uintptr_t external_linkage(jl_serializer_state *s, jl_value_t *v, jl_array_t *link_ids) {
+    size_t i = external_blob_index(v);
+    if (i < n_linkage_blobs()) {
+        assert(link_ids && jl_is_array(link_ids));
+        assert(jl_build_ids && jl_is_array(jl_build_ids));
+        uint64_t *build_id_data = (uint64_t*)jl_array_data(jl_build_ids);
+        // We found the sysimg/pkg that this item links against
+        // Store the image key in `link_ids`
+        jl_array_grow_end(link_ids, 1);
+        uint64_t *link_id_data  = (uint64_t*)jl_array_data(link_ids);
+        link_id_data[jl_array_len(link_ids)-1] = build_id_data[i];
+        // Compute the relocation code
+        size_t offset = (uintptr_t)v - (uintptr_t)jl_linkage_blobs.items[2*i];
+        offset /= sizeof(void*);
+        assert(offset < ((uintptr_t)1 << RELOC_TAG_OFFSET) && "offset to external image too large");
+        // jl_printf(JL_STDOUT, "External link %ld against blob %d with key %ld at position 0x%lx with offset 0x%lx to \n", jl_array_len(link_ids), i, build_id_data[i>>1], ios_pos(s->s), offset);
+        // jl_(v);
+        return ((uintptr_t)ExternalLinkage << RELOC_TAG_OFFSET) + offset;
+    }
+    return 0;
+}
+
 // Return the integer `id` for `v`. Generically this is looked up in `backref_table`,
 // but symbols, small integers, and a couple of special items (`nothing` and the root Task)
 // have special handling.
-#define backref_id(s, v) _backref_id(s, (jl_value_t*)(v))
-static uintptr_t _backref_id(jl_serializer_state *s, jl_value_t *v) JL_NOTSAFEPOINT
+#define backref_id(s, v, link_ids) _backref_id(s, (jl_value_t*)(v), link_ids)
+static uintptr_t _backref_id(jl_serializer_state *s, jl_value_t *v, jl_array_t *link_ids) JL_NOTSAFEPOINT
 {
     assert(v != NULL && "cannot get backref to NULL object");
     void *idx = HT_NOTFOUND;
@@ -715,6 +822,20 @@ static uintptr_t _backref_id(jl_serializer_state *s, jl_value_t *v) JL_NOTSAFEPO
         uint8_t u8 = *(uint8_t*)v;
         return ((uintptr_t)TagRef << RELOC_TAG_OFFSET) + u8 + 2 + NBOX_C + NBOX_C;
     }
+    else if (externally_linked(v)) {
+        assert(link_ids);
+        uintptr_t item = external_linkage(s, v, link_ids);
+        if (!item) {
+            // If we got here, we failed to find the expected external linkage. Print debugging info.
+            for (size_t i = 0; i < jl_linkage_blobs.len; i+=2) {
+                jl_printf(JL_STDOUT, "i = %ld: %p to %p\n", i>>1, jl_linkage_blobs.items[i], jl_linkage_blobs.items[i+1]);
+            }
+            jl_printf(JL_STDOUT, "Object pointer %p for ", v);
+            jl_(v);
+            jl_error("no external linkage identified");
+        }
+        return item;
+    }
     if (idx == HT_NOTFOUND) {
         idx = ptrhash_get(&backref_table, v);
         assert(idx != HT_NOTFOUND && "object missed during jl_serialize_value pass");
@@ -729,7 +850,7 @@ static void write_pointerfield(jl_serializer_state *s, jl_value_t *fld) JL_NOTSA
 {
     if (fld != NULL) {
         arraylist_push(&s->relocs_list, (void*)(uintptr_t)ios_pos(s->s));
-        arraylist_push(&s->relocs_list, (void*)backref_id(s, fld));
+        arraylist_push(&s->relocs_list, (void*)backref_id(s, fld, s->link_ids_relocs));
     }
     write_pointer(s->s);
 }
@@ -738,6 +859,7 @@ static void write_pointerfield(jl_serializer_state *s, jl_value_t *fld) JL_NOTSA
 // in `gctags_list`.
 static void write_gctaggedfield(jl_serializer_state *s, uintptr_t ref) JL_NOTSAFEPOINT
 {
+    // jl_printf(JL_STDOUT, "gctaggedfield: position %p, value 0x%lx\n", (void*)(uintptr_t)ios_pos(s->s), ref);
     arraylist_push(&s->gctags_list, (void*)(uintptr_t)ios_pos(s->s));
     arraylist_push(&s->gctags_list, (void*)ref);
     write_pointer(s->s);
@@ -754,10 +876,10 @@ static void jl_write_module(jl_serializer_state *s, uintptr_t item, jl_module_t 
     jl_module_t *newm = (jl_module_t*)&s->s->buf[reloc_offset];
     newm->name = NULL;
     arraylist_push(&s->relocs_list, (void*)(reloc_offset + offsetof(jl_module_t, name)));
-    arraylist_push(&s->relocs_list, (void*)backref_id(s, m->name));
+    arraylist_push(&s->relocs_list, (void*)backref_id(s, m->name, s->link_ids_relocs));
     newm->parent = NULL;
     arraylist_push(&s->relocs_list, (void*)(reloc_offset + offsetof(jl_module_t, parent)));
-    arraylist_push(&s->relocs_list, (void*)backref_id(s, m->parent));
+    arraylist_push(&s->relocs_list, (void*)backref_id(s, m->parent, s->link_ids_relocs));
     newm->primary_world = jl_atomic_load_acquire(&jl_world_counter);
 
     // write out the bindings table as a list
@@ -805,7 +927,7 @@ static void jl_write_module(jl_serializer_state *s, uintptr_t item, jl_module_t 
         size_t i;
         for (i = 0; i < m->usings.len; i++) {
             arraylist_push(&s->relocs_list, (void*)(reloc_offset + offsetof(jl_module_t, usings._space[i])));
-            arraylist_push(&s->relocs_list, (void*)backref_id(s, m->usings._space[i]));
+            arraylist_push(&s->relocs_list, (void*)backref_id(s, m->usings._space[i], s->link_ids_relocs));
         }
     }
     else {
@@ -887,6 +1009,14 @@ static void jl_write_values(jl_serializer_state *s)
     }
     assert(backref_table_numel * 2 == objects_list.len);
     qsort(objects_list.items, backref_table_numel, sizeof(void*) * 2, sysimg_sort_order);
+    // if (serializer_worklist)
+    //     for (i = 0; i < objects_list.len; i+= 2) {
+    //         size_t id = (uintptr_t)objects_list.items[i+1];
+    //         jl_value_t *v = objects_list.items[i];
+    //         char *linkcode = externally_linked(v) ? "*" : "";
+    //         jl_printf(JL_STDOUT, "%ld%s: ", id, linkcode);
+    //         jl_(v);
+    //     }
 
     // Serialize all entries
     for (i = 0, len = backref_table_numel * 2; i < len; i += 2) {
@@ -899,11 +1029,22 @@ static void jl_write_values(jl_serializer_state *s)
         uintptr_t skip_header_pos = ios_pos(s->s) + sizeof(jl_taggedvalue_t);
         write_padding(s->s, LLT_ALIGN(skip_header_pos, 16) - skip_header_pos);
         // write header
-        write_gctaggedfield(s, backref_id(s, t));
+        write_gctaggedfield(s, backref_id(s, t, s->link_ids_gctags));
         size_t reloc_offset = ios_pos(s->s);
         assert(item < layout_table.len && layout_table.items[item] == NULL);
-        layout_table.items[item] = (void*)reloc_offset;               // store the inverse mapping of `backref_table` (`id` => object)
-        record_gvar(s, jl_get_llvm_gv(native_functions, v), ((uintptr_t)DataRef << RELOC_TAG_OFFSET) + reloc_offset);
+        layout_table.items[item] = (void*)reloc_offset;               // store the inverse mapping of `backref_table` (`id` => object-as-streampos)
+        // if (jl_get_llvm_gv(native_functions, v) != 0) {
+        //     jl_printf(JL_STDOUT, "Recording gvar of id %d for ", jl_get_llvm_gv(native_functions, v));
+        //     jl_(v);
+        // }
+        int GV = jl_get_llvm_gv(native_functions, v);
+        record_gvar(s, GV, ((uintptr_t)DataRef << RELOC_TAG_OFFSET) + reloc_offset);
+
+        if (externally_linked(v)) {
+            assert(!GV);
+            write_pointerfield(s, v);
+            continue;
+        }
 
         // write data
         if (jl_is_cpointer(v)) {
@@ -988,7 +1129,7 @@ static void jl_write_values(jl_serializer_state *s)
                             jl_value_t *fld = *(jl_value_t**)&data[offset];
                             if (fld != NULL) {
                                 arraylist_push(&s->relocs_list, (void*)(uintptr_t)(reloc_offset + headersize + offset)); // relocation location
-                                arraylist_push(&s->relocs_list, (void*)backref_id(s, fld)); // relocation target
+                                arraylist_push(&s->relocs_list, (void*)backref_id(s, fld, s->link_ids_relocs)); // relocation target
                                 memset(&s->s->buf[reloc_offset + headersize + offset], 0, sizeof(fld)); // relocation offset (none)
                             }
                             else {
@@ -1017,10 +1158,10 @@ static void jl_write_values(jl_serializer_state *s)
         }
         else if (jl_is_svec(v)) {
             ios_write(s->s, (char*)v, sizeof(void*));
-            size_t i, l = jl_svec_len(v);
+            size_t ii, l = jl_svec_len(v);
             assert(l > 0 || (jl_svec_t*)v == jl_emptysvec);
-            for (i = 0; i < l; i++) {
-                write_pointerfield(s, jl_svecref(v, i));
+            for (ii = 0; ii < l; ii++) {
+                write_pointerfield(s, jl_svecref(v, ii));
             }
         }
         else if (jl_is_string(v)) {
@@ -1028,6 +1169,7 @@ static void jl_write_values(jl_serializer_state *s)
             write_uint8(s->s, '\0'); // null-terminated strings for easier C-compatibility
         }
         else if (jl_datatype_nfields(t) == 0) {
+            // The object has no fields, so we just snapshot its byte representation
             assert(t->layout->npointers == 0);
             if (t->size > 0)
                 ios_write(s->s, (char*)v, t->size);
@@ -1078,7 +1220,7 @@ static void jl_write_values(jl_serializer_state *s)
                 jl_value_t *fld = get_replaceable_field((jl_value_t**)&data[offset]);
                 if (fld != NULL) {
                     arraylist_push(&s->relocs_list, (void*)(uintptr_t)(offset + reloc_offset)); // relocation location
-                    arraylist_push(&s->relocs_list, (void*)backref_id(s, fld)); // relocation target
+                    arraylist_push(&s->relocs_list, (void*)backref_id(s, fld, s->link_ids_relocs)); // relocation target
                     memset(&s->s->buf[offset + reloc_offset], 0, sizeof(fld)); // relocation offset (none)
                 }
             }
@@ -1163,6 +1305,7 @@ static void jl_write_values(jl_serializer_state *s)
             else if (jl_is_datatype(v)) {
                 jl_datatype_t *dt = (jl_datatype_t*)v;
                 jl_datatype_t *newdt = (jl_datatype_t*)&s->s->buf[reloc_offset];
+                newdt->imgcache = 1;
                 if (dt->layout != NULL) {
                     size_t nf = dt->layout->nfields;
                     size_t np = dt->layout->npointers;
@@ -1216,6 +1359,25 @@ static void jl_write_values(jl_serializer_state *s)
     }
 }
 
+static void jl_ensure_extern(void* ctx, int32_t GV, void* v) {
+    jl_serializer_state *s = (jl_serializer_state*)ctx;
+    // externally_linked is insufficient as a check because it doesn't visit
+    // everything needed by LLVM and can't efficiently identify whether a
+    // global variable is external.
+    uintptr_t item = external_linkage(s, (jl_value_t*)v, s->link_ids_gvars);
+    if (item == 0)
+        return;
+
+    // TODO: Check that we don't override an existing entry
+    // jl_printf(JL_STDOUT, "GV: %ld, record_gvar for %lx, build_id: %lx\n", GV, item, jl_array_data(s->link_ids_gvars)[jl_array_len(s->link_ids_gvars)-1]);
+    assert(item >> RELOC_TAG_OFFSET == ExternalLinkage);
+    record_gvar(s, GV, item);
+}
+
+static void jl_ensure_extern_gv(jl_serializer_state *s) {
+    jl_iterate_llvm_gv(native_functions, jl_ensure_extern, (void*)s);
+}
+
 
 // Record all symbols that get referenced by the generated code
 // and queue them for pointer relocation
@@ -1225,7 +1387,7 @@ static void jl_write_gv_syms(jl_serializer_state *s, jl_sym_t *v)
     // reference anywhere in the code image other than here
     int32_t gv = jl_get_llvm_gv(native_functions, (jl_value_t*)v);
     if (gv != 0) {
-        uintptr_t item = backref_id(s, v);
+        uintptr_t item = backref_id(s, v, NULL);
         assert(item >> RELOC_TAG_OFFSET == SymbolRef);
         record_gvar(s, gv, item);
     }
@@ -1241,7 +1403,7 @@ static void jl_write_gv_tagref(jl_serializer_state *s, jl_value_t *v)
 {
     int32_t gv = jl_get_llvm_gv(native_functions, (jl_value_t*)v);
     if (gv != 0) {
-        uintptr_t item = backref_id(s, v);
+        uintptr_t item = backref_id(s, v, NULL);
         assert(item >> RELOC_TAG_OFFSET == TagRef);
         record_gvar(s, gv, item);
     }
@@ -1322,6 +1484,8 @@ static uintptr_t get_reloc_for_item(uintptr_t reloc_item, size_t reloc_offset)
         case FunctionRef:
             assert(offset < JL_API_MAX && "unknown function pointer id");
             break;
+        case ExternalLinkage:
+            break;
         case DataRef:
         default:
             assert(0 && "corrupt relocation item id");
@@ -1333,7 +1497,7 @@ static uintptr_t get_reloc_for_item(uintptr_t reloc_item, size_t reloc_offset)
 }
 
 // Compute target location at deserialization
-static inline uintptr_t get_item_for_reloc(jl_serializer_state *s, uintptr_t base, size_t size, uintptr_t reloc_id)
+static inline uintptr_t get_item_for_reloc(jl_serializer_state *s, uintptr_t base, size_t size, uintptr_t reloc_id, jl_array_t *link_ids, int *link_index)
 {
     enum RefTags tag = (enum RefTags)(reloc_id >> RELOC_TAG_OFFSET);
     size_t offset = (reloc_id & (((uintptr_t)1 << RELOC_TAG_OFFSET) - 1));
@@ -1389,6 +1553,27 @@ static inline uintptr_t get_item_for_reloc(jl_serializer_state *s, uintptr_t bas
         //default:
             assert("corrupt relocation item id");
         }
+    case ExternalLinkage:
+        assert(link_ids);
+        assert(link_index);
+        assert(jl_build_ids);
+        uint64_t *link_id_data  = (uint64_t*)jl_array_data(link_ids);
+        uint64_t *build_id_data = (uint64_t*)jl_array_data(jl_build_ids);
+        assert(0 <= *link_index && *link_index < jl_array_len(link_ids));
+        uint64_t build_id = link_id_data[*link_index];
+        *link_index += 1;
+        // jl_printf(JL_STDOUT, "Relocating external link %d to buildid %ld with offset 0x%lx\n", link_index, build_id, offset);
+        size_t i = 0, nids = jl_array_len(jl_build_ids);
+        while (i < nids) {
+            if (build_id == build_id_data[i])
+                break;
+            i++;
+        }
+        // jl_printf(JL_STDOUT, "i = %ld\n", i);
+        assert(i < nids);
+        assert(2*i < jl_linkage_blobs.len);
+        // jl_printf(JL_STDOUT, "Restoring link %ld with offset 0x%lx and base position %p\n", link_index, offset, jl_linkage_blobs.items[2*i]);
+        return (uintptr_t)jl_linkage_blobs.items[2*i] + offset*sizeof(void*);
     }
     abort();
 }
@@ -1399,7 +1584,7 @@ static void jl_write_skiplist(ios_t *s, char *base, size_t size, arraylist_t *li
     size_t i;
     for (i = 0; i < list->len; i += 2) {
         size_t pos = (size_t)list->items[i];
-        size_t item = (size_t)list->items[i + 1];
+        size_t item = (size_t)list->items[i + 1];   // item is tagref-encoded
         uintptr_t *pv = (uintptr_t*)(base + pos);
         assert(pos < size && pos != 0);
         *pv = get_reloc_for_item(item, *pv);
@@ -1419,10 +1604,11 @@ static void jl_write_relocations(jl_serializer_state *s)
 }
 
 
-static void jl_read_relocations(jl_serializer_state *s, uint8_t bits)
+static void jl_read_relocations(jl_serializer_state *s, jl_array_t *link_ids, uint8_t bits)
 {
     uintptr_t base = (uintptr_t)&s->s->buf[0];
     size_t size = s->s->size;
+    int link_index = 0;
     while (1) {
         uintptr_t offset = *(reloc_t*)&s->relocs->buf[(uintptr_t)s->relocs->bpos];
         s->relocs->bpos += sizeof(reloc_t);
@@ -1430,9 +1616,10 @@ static void jl_read_relocations(jl_serializer_state *s, uint8_t bits)
             break;
         uintptr_t *pv = (uintptr_t*)(base + offset);
         uintptr_t v = *pv;
-        v = get_item_for_reloc(s, base, size, v);
+        v = get_item_for_reloc(s, base, size, v, link_ids, &link_index);
         *pv = v | bits;
     }
+    assert(!link_ids || link_index == jl_array_len(link_ids));
 }
 
 static char *sysimg_base;
@@ -1460,7 +1647,7 @@ static void _jl_write_value(jl_serializer_state *s, jl_value_t *v)
         write_reloc_t(s->s, 0);
         return;
     }
-    uintptr_t item = backref_id(s, v);
+    uintptr_t item = backref_id(s, v, NULL);
     uintptr_t reloc = get_reloc_for_item(item, 0);
     write_reloc_t(s->s, reloc);
 }
@@ -1474,7 +1661,7 @@ static jl_value_t *jl_read_value(jl_serializer_state *s)
     s->s->bpos += sizeof(reloc_t);
     if (offset == 0)
         return NULL;
-    return (jl_value_t*)get_item_for_reloc(s, base, size, offset);
+    return (jl_value_t*)get_item_for_reloc(s, base, size, offset, NULL, NULL);
 }
 
 
@@ -1542,17 +1729,18 @@ static void jl_update_all_gvars(jl_serializer_state *s)
     size_t size = s->s->size;
     reloc_t *gvars = (reloc_t*)&s->gvar_record->buf[0];
     reloc_t *end = gvars + s->gvar_record->size / sizeof(reloc_t);
+    int link_index = 0;
     while (gvars < end) {
         uintptr_t offset = *gvars;
         if (offset) {
-            uintptr_t v = get_item_for_reloc(s, base, size, offset);
+            uintptr_t v = get_item_for_reloc(s, base, size, offset, s->link_ids_gvars, &link_index);
             *sysimg_gvars(sysimg_gvars_base, gvname_index) = v;
         }
         gvname_index += 1;
         gvars++;
     }
+    assert(!s->link_ids_gvars || link_index == jl_array_len(s->link_ids_gvars));
 }
-
 
 // Reinitialization
 static void jl_finalize_serializer(jl_serializer_state *s, arraylist_t *list)
@@ -1871,7 +2059,8 @@ JL_DLLEXPORT jl_value_t *jl_as_global_root(jl_value_t *val JL_MAYBE_UNROOTED)
     return val;
 }
 
-static void jl_save_system_image_to_stream(ios_t *f) JL_GC_DISABLED
+// In addtion to the system image (where `worklist = NULL`), this can also save incremental images with external linkage
+static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *worklist) JL_GC_DISABLED
 {
     jl_gc_collect(JL_GC_FULL);
     jl_gc_collect(JL_GC_INCREMENTAL);   // sweep finalizers
@@ -1881,7 +2070,8 @@ static void jl_save_system_image_to_stream(ios_t *f) JL_GC_DISABLED
     // strip metadata and IR when requested
     if (jl_options.strip_metadata || jl_options.strip_ir)
         jl_strip_all_codeinfos();
-    jl_set_nroots_sysimg();
+    if (worklist == NULL)
+        jl_set_nroots_sysimg();
 
     int en = jl_gc_enable(0);
     jl_init_serializer2(1);
@@ -1897,6 +2087,7 @@ static void jl_save_system_image_to_stream(ios_t *f) JL_GC_DISABLED
     ios_mem(&relocs,      100000);
     ios_mem(&gvar_record, 100000);
     ios_mem(&fptr_record, 100000);
+    serializer_worklist = worklist;   // NULL means "serialize everything"
     jl_serializer_state s;
     s.s = &sysimg;
     s.const_data = &const_data;
@@ -1907,37 +2098,55 @@ static void jl_save_system_image_to_stream(ios_t *f) JL_GC_DISABLED
     s.ptls = jl_current_task->ptls;
     arraylist_new(&s.relocs_list, 0);
     arraylist_new(&s.gctags_list, 0);
-    jl_value_t **const*const tags = get_tags();
+    s.link_ids_relocs = jl_alloc_array_1d(jl_array_uint64_type, 0);
+    s.link_ids_gctags = jl_alloc_array_1d(jl_array_uint64_type, 0);
+    s.link_ids_gvars = jl_alloc_array_1d(jl_array_uint64_type, 0);
+    jl_value_t **const*const tags = get_tags(); // worklist == NULL ? get_tags() : NULL;
 
-    // empty!(Core.ARGS)
-    if (jl_core_module != NULL) {
-        jl_array_t *args = (jl_array_t*)jl_get_global(jl_core_module, jl_symbol("ARGS"));
-        if (args != NULL) {
-            jl_array_del_end(args, jl_array_len(args));
+    if (worklist == NULL) {
+        // empty!(Core.ARGS)
+        if (jl_core_module != NULL) {
+            jl_array_t *args = (jl_array_t*)jl_get_global(jl_core_module, jl_symbol("ARGS"));
+            if (args != NULL) {
+                jl_array_del_end(args, jl_array_len(args));
+            }
         }
-    }
 
-    jl_idtable_type = jl_base_module ? jl_get_global(jl_base_module, jl_symbol("IdDict")) : NULL;
-    jl_idtable_typename = jl_base_module ? ((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_idtable_type))->name : NULL;
-    jl_bigint_type = jl_base_module ? jl_get_global(jl_base_module, jl_symbol("BigInt")) : NULL;
-    if (jl_bigint_type) {
-        gmp_limb_size = jl_unbox_long(jl_get_global((jl_module_t*)jl_get_global(jl_base_module, jl_symbol("GMP")),
-                                                    jl_symbol("BITS_PER_LIMB"))) / 8;
-    }
-    if (jl_base_module) {
-        jl_value_t *docs = jl_get_global(jl_base_module, jl_symbol("Docs"));
-        if (docs && jl_is_module(docs)) {
-            jl_docmeta_sym = (jl_sym_t*)jl_get_global((jl_module_t*)docs, jl_symbol("META"));
+        jl_idtable_type = jl_base_module ? jl_get_global(jl_base_module, jl_symbol("IdDict")) : NULL;
+        jl_idtable_typename = jl_base_module ? ((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_idtable_type))->name : NULL;
+        jl_bigint_type = jl_base_module ? jl_get_global(jl_base_module, jl_symbol("BigInt")) : NULL;
+        if (jl_bigint_type) {
+            gmp_limb_size = jl_unbox_long(jl_get_global((jl_module_t*)jl_get_global(jl_base_module, jl_symbol("GMP")),
+                                                        jl_symbol("BITS_PER_LIMB"))) / 8;
+        }
+        if (jl_base_module) {
+            jl_value_t *docs = jl_get_global(jl_base_module, jl_symbol("Docs"));
+            if (docs && jl_is_module(docs)) {
+                jl_docmeta_sym = (jl_sym_t*)jl_get_global((jl_module_t*)docs, jl_symbol("META"));
+            }
         }
     }
 
     { // step 1: record values (recursively) that need to go in the image
         size_t i;
-        for (i = 0; tags[i] != NULL; i++) {
-            jl_value_t *tag = *tags[i];
-            jl_serialize_value(&s, tag);
+        if (worklist == NULL) {
+            for (i = 0; tags[i] != NULL; i++) {
+                jl_value_t *tag = *tags[i];
+                jl_serialize_value(&s, tag);
+            }
+            jl_serialize_value(&s, jl_global_roots_table);
+        } else {
+            // To ensure we don't have to manually update the list, go through all tags and queue any that are not otherwise
+            // judged to be externally-linked
+            htable_new(&external_objects, NUM_TAGS);
+            for (size_t i = 0; tags[i] != NULL; i++) {
+                jl_value_t *tag = *tags[i];
+                if (!externally_linked(tag))
+                    ptrhash_put(&external_objects, tag, tag);
+            }
+            // Queue the worklist itself as the first item we serialize
+            jl_serialize_value(&s, worklist);
         }
-        jl_serialize_value(&s, jl_global_roots_table);
         jl_serialize_reachable(&s);
         // step 1.1: check for values only found in the generated code
         arraylist_t typenames;
@@ -1967,6 +2176,8 @@ static void jl_save_system_image_to_stream(ios_t *f) JL_GC_DISABLED
     { // step 2: build all the sysimg sections
         write_padding(&sysimg, sizeof(uintptr_t));
         jl_write_values(&s);
+        if (worklist)
+            jl_ensure_extern_gv(&s);
         jl_write_relocations(&s);
         jl_write_gv_syms(&s, jl_get_root_symbol());
         jl_write_gv_tagrefs(&s);
@@ -2029,21 +2240,35 @@ static void jl_save_system_image_to_stream(ios_t *f) JL_GC_DISABLED
     ios_close(&fptr_record);
 
     { // step 4: record locations of special roots
-        s.s = f;
         write_padding(f, LLT_ALIGN(ios_pos(f), 8) - ios_pos(f));
-        size_t i;
-        for (i = 0; tags[i] != NULL; i++) {
-            jl_value_t *tag = *tags[i];
-            jl_write_value(&s, tag);
+        s.s = f;
+        if (worklist == NULL) {
+            size_t i;
+            for (i = 0; tags[i] != NULL; i++) {
+                jl_value_t *tag = *tags[i];
+                jl_write_value(&s, tag);
+            }
+            jl_write_value(&s, jl_global_roots_table);
+            jl_write_value(&s, s.ptls->root_task->tls);
+            write_uint32(f, jl_get_gs_ctr());
+            write_uint(f, jl_atomic_load_acquire(&jl_world_counter));
+            write_uint(f, jl_typeinf_world);
         }
-        jl_write_value(&s, jl_global_roots_table);
-        jl_write_value(&s, s.ptls->root_task->tls);
-        write_uint32(f, jl_get_gs_ctr());
-        write_uint(f, jl_atomic_load_acquire(&jl_world_counter));
-        write_uint(f, jl_typeinf_world);
+        write_uint32(f, jl_array_len(s.link_ids_gctags));
+        ios_write(f, (char*)jl_array_data(s.link_ids_gctags), jl_array_len(s.link_ids_gctags)*sizeof(uint64_t));
+        write_uint32(f, jl_array_len(s.link_ids_relocs));
+        ios_write(f, (char*)jl_array_data(s.link_ids_relocs), jl_array_len(s.link_ids_relocs)*sizeof(uint64_t));
+        write_uint32(f, jl_array_len(s.link_ids_gvars));
+        ios_write(f, (char*)jl_array_data(s.link_ids_gvars), jl_array_len(s.link_ids_gvars)*sizeof(uint64_t));
         jl_finalize_serializer(&s, &reinit_list);
         jl_finalize_serializer(&s, &ccallable_list);
     }
+    // Write the build_id key
+    uint64_t buildid = 0;
+    if (worklist)
+        buildid = jl_worklist_key(worklist);
+    write_uint32(f, buildid >> 32);
+    write_uint32(f, buildid & (((uint64_t)1 << 32) - 1));
 
     assert(object_worklist.len == 0);
     arraylist_free(&object_worklist);
@@ -2053,17 +2278,20 @@ static void jl_save_system_image_to_stream(ios_t *f) JL_GC_DISABLED
     arraylist_free(&s.relocs_list);
     arraylist_free(&s.gctags_list);
     htable_free(&field_replace);
+    if (worklist)
+        htable_free(&external_objects);
     jl_cleanup_serializer2();
+    serializer_worklist = NULL;
 
     jl_gc_enable(en);
 }
 
-JL_DLLEXPORT ios_t *jl_create_system_image(void *_native_data)
+JL_DLLEXPORT ios_t *jl_create_system_image(void *_native_data, jl_array_t *worklist)
 {
     ios_t *f = (ios_t*)malloc_s(sizeof(ios_t));
     ios_mem(f, 0);
     native_functions = _native_data;
-    jl_save_system_image_to_stream(f);
+    jl_save_system_image_to_stream(f, worklist);
     return f;
 }
 
@@ -2075,7 +2303,7 @@ JL_DLLEXPORT void jl_save_system_image(const char *fname)
         jl_errorf("cannot open system image file \"%s\" for writing", fname);
     }
     JL_SIGATOMIC_BEGIN();
-    jl_save_system_image_to_stream(&f);
+    jl_save_system_image_to_stream(&f, NULL);
     ios_close(&f);
     JL_SIGATOMIC_END();
 }
@@ -2107,7 +2335,7 @@ JL_DLLEXPORT void jl_set_sysimg_so(void *handle)
     sysimg_fptrs = jl_init_processor_sysimg(handle);
 }
 
-static void jl_restore_system_image_from_stream(ios_t *f) JL_GC_DISABLED
+static jl_value_t *jl_restore_system_image_from_stream(ios_t *f) JL_GC_DISABLED
 {
     JL_TIMING(SYSIMG_LOAD);
     int en = jl_gc_enable(0);
@@ -2123,7 +2351,10 @@ static void jl_restore_system_image_from_stream(ios_t *f) JL_GC_DISABLED
     s.ptls = jl_current_task->ptls;
     arraylist_new(&s.relocs_list, 0);
     arraylist_new(&s.gctags_list, 0);
+    s.link_ids_relocs = s.link_ids_gctags = s.link_ids_gvars = NULL;
     jl_value_t **const*const tags = get_tags();
+
+    int incremental = jl_linkage_blobs.len > 0;
 
     // step 1: read section map
     assert(ios_pos(f) == 0 && f->bm == bm_mem);
@@ -2161,27 +2392,44 @@ static void jl_restore_system_image_from_stream(ios_t *f) JL_GC_DISABLED
     ios_skip(f, sizeof_fptr_record);
 
     // step 2: get references to special values
-    s.s = f;
     ios_seek(f, LLT_ALIGN(ios_pos(f), 8));
     assert(!ios_eof(f));
-    size_t i;
-    for (i = 0; tags[i] != NULL; i++) {
-        jl_value_t **tag = tags[i];
-        *tag = jl_read_value(&s);
-    }
-    jl_global_roots_table = (jl_array_t*)jl_read_value(&s);
-    // set typeof extra-special values now that we have the type set by tags above
-    jl_astaggedvalue(jl_current_task)->header = (uintptr_t)jl_task_type | jl_astaggedvalue(jl_current_task)->header;
-    jl_astaggedvalue(jl_nothing)->header = (uintptr_t)jl_nothing_type | jl_astaggedvalue(jl_nothing)->header;
-    s.ptls->root_task->tls = jl_read_value(&s);
-    jl_gc_wb(s.ptls->root_task, s.ptls->root_task->tls);
-    jl_init_int32_int64_cache();
-    jl_init_box_caches();
+    if (!incremental) {
+        s.s = f;
+        size_t i;
+        for (i = 0; tags[i] != NULL; i++) {
+            jl_value_t **tag = tags[i];
+            *tag = jl_read_value(&s);
+        }
+        jl_global_roots_table = (jl_array_t*)jl_read_value(&s);
+        // set typeof extra-special values now that we have the type set by tags above
+        jl_astaggedvalue(jl_current_task)->header = (uintptr_t)jl_task_type | jl_astaggedvalue(jl_current_task)->header;
+        jl_astaggedvalue(jl_nothing)->header = (uintptr_t)jl_nothing_type | jl_astaggedvalue(jl_nothing)->header;
+        s.ptls->root_task->tls = jl_read_value(&s);
+        jl_gc_wb(s.ptls->root_task, s.ptls->root_task->tls);
+        jl_init_int32_int64_cache();
+        jl_init_box_caches();
 
-    uint32_t gs_ctr = read_uint32(f);
-    jl_atomic_store_release(&jl_world_counter, read_uint(f));
-    jl_typeinf_world = read_uint(f);
-    jl_set_gs_ctr(gs_ctr);
+        uint32_t gs_ctr = read_uint32(f);
+        jl_atomic_store_release(&jl_world_counter, read_uint(f));
+        jl_typeinf_world = read_uint(f);
+        jl_set_gs_ctr(gs_ctr);
+    }
+    size_t nlinks_gctags = read_uint32(f);
+    if (nlinks_gctags > 0) {
+        s.link_ids_gctags = jl_alloc_array_1d(jl_array_uint64_type, nlinks_gctags);
+        ios_read(f, (char*)jl_array_data(s.link_ids_gctags), nlinks_gctags * sizeof(uint64_t));
+    }
+    size_t nlinks_relocs = read_uint32(f);
+    if (nlinks_relocs > 0) {
+        s.link_ids_relocs = jl_alloc_array_1d(jl_array_uint64_type, nlinks_relocs);
+        ios_read(f, (char*)jl_array_data(s.link_ids_relocs), nlinks_relocs * sizeof(uint64_t));
+    }
+    size_t nlinks_gvars = read_uint32(f);
+    if (nlinks_gvars > 0) {
+        s.link_ids_gvars = jl_alloc_array_1d(jl_array_uint64_type, nlinks_gvars);
+        ios_read(f, (char*)jl_array_data(s.link_ids_gvars), nlinks_gvars * sizeof(uint64_t));
+    }
     s.s = NULL;
 
     // step 3: apply relocations
@@ -2189,15 +2437,21 @@ static void jl_restore_system_image_from_stream(ios_t *f) JL_GC_DISABLED
     jl_read_symbols(&s);
     ios_close(&symbols);
 
-    sysimg_base = &sysimg.buf[0];
-    sysimg_relocs = &relocs.buf[0];
-    jl_gc_set_permalloc_region((void*)sysimg_base, (void*)(sysimg_base + sysimg.size));
+    jl_value_t *image_base = (jl_value_t*)&sysimg.buf[0];
+    if (!incremental) {
+        sysimg_base = (char*)image_base;
+        sysimg_relocs = &relocs.buf[0];
+        jl_gc_set_permalloc_region((void*)sysimg_base, (void*)(sysimg_base + sysimg.size));
+    }
 
+    //if (incremental)
+    //    jl_printf(JL_STDOUT, "Pointer location of Base: %p; at offset 0x%lx\n", jl_base_module, ((uintptr_t)jl_base_module - (uintptr_t)jl_linkage_blobs.items[0])/sizeof(void*));
     s.s = &sysimg;
-    jl_read_relocations(&s, GC_OLD_MARKED); // gctags
+    jl_read_relocations(&s, s.link_ids_gctags, GC_OLD_MARKED);
     size_t sizeof_tags = ios_pos(&relocs);
     (void)sizeof_tags;
-    jl_read_relocations(&s, 0); // general relocs
+    jl_read_relocations(&s, s.link_ids_relocs, 0);
+    // s.link_ids_gvars will be processed in `jl_update_all_gvars`
     ios_close(&relocs);
     ios_close(&const_data);
     jl_update_all_gvars(&s); // gvars relocs
@@ -2241,6 +2495,22 @@ static void jl_restore_system_image_from_stream(ios_t *f) JL_GC_DISABLED
     jl_gc_reset_alloc_count();
     jl_gc_enable(en);
     jl_cleanup_serializer2();
+
+    // Prepare for later external linkage against the sysimg
+    arraylist_push(&jl_linkage_blobs, image_base);
+    arraylist_push(&jl_linkage_blobs, (char*)image_base + sizeof_sysimg);
+    // jl_printf(JL_STDOUT, "%ld blobs to link against\n", jl_linkage_blobs.len >> 1);
+    uint64_t buildid = (((uint64_t)read_uint32(f)) << 32) | read_uint32(f);
+    if (!jl_build_ids)
+        jl_build_ids = jl_alloc_array_1d(jl_array_uint64_type, 0);
+    jl_array_grow_end(jl_build_ids, 1);
+    uint64_t *build_id_data = (uint64_t*)jl_array_data(jl_build_ids);
+    build_id_data[jl_array_len(jl_build_ids)-1] = buildid;
+
+    if (!incremental)
+        return jl_nothing;
+    // Get the worklist
+    return (jl_value_t*)((char*)jl_valueof(image_base) + sizeof(void*));
 }
 
 // TODO: need to enforce that the alignment of the buffer is suitable for vectors
@@ -2276,14 +2546,48 @@ JL_DLLEXPORT void jl_restore_system_image(const char *fname)
     }
 }
 
-JL_DLLEXPORT void jl_restore_system_image_data(const char *buf, size_t len)
+JL_DLLEXPORT jl_value_t *jl_restore_system_image_data(const char *buf, size_t len)
 {
     ios_t f;
     JL_SIGATOMIC_BEGIN();
     ios_static_buffer(&f, (char*)buf, len);
-    jl_restore_system_image_from_stream(&f);
+    jl_value_t *worklist = jl_restore_system_image_from_stream(&f);
     ios_close(&f);
     JL_SIGATOMIC_END();
+    return worklist;
+}
+
+JL_DLLEXPORT jl_value_t *jl_restore_package_image_from_file(const char *fname)
+{
+    void *pkgimg_handle = jl_dlopen(fname, JL_RTLD_LAZY);
+    if (!pkgimg_handle) {
+#ifdef _OS_WINDOWS_
+        int err;
+        char reason[256];
+        err = GetLastError();
+        win32_formatmessage(err, reason, sizeof(reason));
+#else
+        const char *reason = dlerror();
+#endif
+        jl_errorf("Error opening package file %s: %s\n", fname, reason);
+    }
+    const char *pkgimg_data;
+    jl_dlsym(pkgimg_handle, "jl_system_image_data", (void **)&pkgimg_data, 1);
+    size_t *plen;
+    jl_dlsym(pkgimg_handle, "jl_system_image_size", (void **)&plen, 1);
+    //jl_printf(JL_STDOUT, "pkg_img_size %ld\n", *plen);
+    jl_sysimg_fptrs_t old_sysimg_fptrs = sysimg_fptrs;
+    // sysimg_fptrs = parse_sysimg(hdl, sysimg_init_cb);
+    // TODO: Do this properly without clobbering global data
+    sysimg_fptrs = jl_init_processor_sysimg(pkgimg_handle);
+    if (!jl_dlsym(pkgimg_handle, "jl_sysimg_gvars_base", (void **)&sysimg_gvars_base, 0)) {
+        sysimg_gvars_base = NULL;
+    }
+    jl_dlsym(pkgimg_handle, "jl_sysimg_gvars_offsets", (void **)&sysimg_gvars_offsets, 1);
+    sysimg_gvars_offsets += 1;
+    jl_value_t* mod = jl_restore_system_image_data(pkgimg_data, *plen);
+    sysimg_fptrs = old_sysimg_fptrs;
+    return mod;
 }
 
 // --- init ---

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -429,10 +429,12 @@ static int externally_linked(jl_value_t *v)
     // The special handling for a few items here represents a downpayment on a
     // more extensive mirroring/porting of functionality from dump.c.
     // To be continued in a future PR.
-    if (jl_is_method_instance(v))
-        return externally_linked(((jl_method_instance_t*)v)->def.value);
-    else if (jl_is_code_instance(v))
-        return externally_linked(((jl_code_instance_t*)v)->def->def.value);
+    
+    // What about MethodInstances that are instantiated from a pkgimage, and don't exist prior.
+    // if (jl_is_method_instance(v))
+    //     return externally_linked(((jl_method_instance_t*)v)->def.value);
+    // else if (jl_is_code_instance(v))
+    //     return externally_linked(((jl_code_instance_t*)v)->def->def.value); // Use build_id instead of "derivation"
 
     jl_module_t *vmod = NULL;
     if (jl_is_module(v))

--- a/stdlib/LLD_jll/src/LLD_jll.jl
+++ b/stdlib/LLD_jll/src/LLD_jll.jl
@@ -1,4 +1,3 @@
-
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 ## dummy stub for https://github.com/JuliaBinaryWrappers/LLD_jll.jl

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -27,6 +27,15 @@ JLL_NAMES := MozillaCACerts_jll
 get-MozillaCACerts_jll:
 install-MozillaCACerts_jll:
 
+JLL_NAMES += LLD_jll
+LLD_STDLIB_PATH := $(JULIAHOME)/stdlib/LLD_jll
+LLD_JLL_VER ?= $(shell [ -f $(LLD_STDLIB_PATH)/Project.toml ] && grep "^version" $(LLD_STDLIB_PATH)/Project.toml | sed -E 's/version[[:space:]]*=[[:space:]]*"?([^"]+)"?/\1/')
+
+$(LLD_STDLIB_PATH)/StdlibArtifacts.toml:
+	$(JLDOWNLOAD) $@ https://github.com/JuliaBinaryWrappers/LLVM_jll.jl/raw/LLVM-v$(LLD_JLL_VER)/Artifacts.toml
+get-LLD_jll: $(LLD_STDLIB_PATH)/StdlibArtifacts.toml
+install-LLD_jll: get-LLD_jll
+
 # Define rule to download `StdlibArtifacts.toml` files for each JLL we bundle.
 define download-artifacts-toml
 JLL_NAMES += $$($(1)_JLL_NAME)_jll

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1672,6 +1672,43 @@ end
     CNE = wl[1]   # the CacheNativeEmpty module
 end
 
+@testset "linking against sysimage" begin
+    srcdir   = mktempdir()
+    cachedir = mktempdir()
+    cnpath = joinpath(srcdir, "CacheNativeSysimg.jl")
+    open(cnpath, "w") do io
+        write(io, """
+        module CacheNativeSysimg
+        my_fce() = println("hello")
+        precompile(my_fce, ())
+        end
+        """)
+    end
+    p, arfile = compilecache(Base.PkgId("CacheNativeSysimg"), cnpath, cachedir)
+    @test success(p)
+    libfile = arfile * ".so"
+    link_jilib(arfile, libfile)
+    wl = ccall(:jl_restore_package_image_from_file, Any, (Ptr{UInt8},), libfile)
+    CNS = wl[1]   # the CacheNativeSysimg module
+    f = getfield(CNS, :my_fce)
+    m = only(methods(f))
+    mi = m.specializations[1]
+    ci = mi.cache
+    @test build_id(CNS) != 0
+    @test ci.build_id == build_id(CNS)
+    @test ci.specptr != C_NULL
+
+    let filename = tempname()
+        ret = open(filename, "w") do io
+            redirect_stdout(io) do
+                f()
+            end
+        end
+        @test ret === nothing
+        @test chomp(read(filename, String)) == "hello"
+    end
+end
+
 @testset "static compilation" begin
     srcdir   = mktempdir()
     cachedir = mktempdir()

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1650,6 +1650,10 @@ function link_jilib(path, out, args=``)
     end
 end
 
+function build_id(m::Module)
+    ccall(:jl_module_build_id, UInt64, (Any,), m)
+end
+
 @testset "empty module" begin
     srcdir   = mktempdir()
     cachedir = mktempdir()
@@ -1692,6 +1696,8 @@ end
     m = only(methods(f))
     mi = m.specializations[1]
     ci = mi.cache
+    @test build_id(CN1) != 0
+    @test ci.build_id == build_id(CN1)
     @test ci.specptr != C_NULL
     @test f() == 22
     # Can we reference this first module from a second?

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1686,13 +1686,12 @@ end
         my_fce2() = println("result = ", 42) 
         precompile(my_fce2, ())
 
-        # TODO:
-        # my_ptls() = Core.getptls()
-        # precompile(my_ptls, ())
-        # my_alloc(val) = Ref(val)
-        # precompile(my_alloc, (Int,))
-        # my_alloc2() = Ref(10)
-        # precompile(my_alloc2, ())
+        my_ptls() = Core.getptls()
+        precompile(my_ptls, ())
+        my_alloc() = Ref(10)
+        precompile(my_alloc, ())
+        my_alloc2(val) = Ref(val)
+        precompile(my_alloc2, (Int,))
         end
         """)
     end
@@ -1728,6 +1727,14 @@ end
         @test ret === nothing
         @test chomp(read(filename, String)) == "hello\nresult = 42"
     end
+
+    alloc =  getfield(CNS, :my_alloc)
+    alloc2 =  getfield(CNS, :my_alloc2)
+    get_ptls = getfield(CNS, :my_ptls)
+
+    @test alloc()[] == 10
+    @test alloc2(5)[] == 5
+    @test get_ptls() === Core.getptls()
 end
 
 @testset "static compilation" begin

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 original_depot_path = copy(Base.DEPOT_PATH)
+original_load_path = copy(Base.LOAD_PATH)
 
 using Test, Distributed, Random
 
@@ -1563,5 +1564,191 @@ precompile_test_harness("issue #46296") do load_path
     (@eval (using CodeInstancePrecompile))
 end
 
+## Static compilation of external modules
+
+# Currently this is limited to modules that do not trigger compilation
+# of external methods
+
+# Mirror of `Base.create_expr_cache`, with `--output-ji` replaced by `--output-o` and usage of default optimization level
+function create_expr_cache(pkg::Base.PkgId, input::String, output::String, concrete_deps::typeof(Base._concrete_dependencies), internal_stderr::IO = stderr, internal_stdout::IO = stdout)
+    @nospecialize internal_stderr internal_stdout
+    rm(output, force=true)   # Remove file if it exists
+    depot_path = map(abspath, DEPOT_PATH)
+    dl_load_path = map(abspath, Base.DL_LOAD_PATH)
+    load_path = map(abspath, Base.load_path())
+    path_sep = Sys.iswindows() ? ';' : ':'
+    any(path -> path_sep in path, load_path) &&
+        error("LOAD_PATH entries cannot contain $(repr(path_sep))")
+
+    deps_strs = String[]
+    function pkg_str(_pkg::Base.PkgId)
+        if _pkg.uuid === nothing
+            "Base.PkgId($(repr(_pkg.name)))"
+        else
+            "Base.PkgId(Base.UUID(\"$(_pkg.uuid)\"), $(repr(_pkg.name)))"
+        end
+    end
+    for (pkg, build_id) in concrete_deps
+        push!(deps_strs, "$(pkg_str(pkg)) => $(repr(build_id))")
+    end
+    deps_eltype = sprint(show, eltype(concrete_deps); context = :module=>nothing)
+    deps = deps_eltype * "[" * join(deps_strs, ",") * "]"
+    trace = ``
+    io = open(pipeline(`$(Base.julia_cmd()::Cmd)
+                       --output-o $output --output-incremental=yes
+                       --startup-file=no --history-file=no --warn-overwrite=yes
+                       --color=$(Base.have_color === nothing ? "auto" : Base.have_color ? "yes" : "no")
+                       $trace
+                       -`, stderr = internal_stderr, stdout = internal_stdout),
+              "w", stdout)
+    # write data over stdin to avoid the (unlikely) case of exceeding max command line size
+    write(io.in, """
+        Base.include_package_for_output($(pkg_str(pkg)), $(repr(abspath(input))), $(repr(depot_path)), $(repr(dl_load_path)),
+            $(repr(load_path)), $deps, $(repr(Base.source_path(nothing))))
+        """)
+    close(io.in)
+    return io
+end
+# A simplified version of `Base.compilecache` that calls our `create_expr_cache` above
+function compilecache(pkg::Base.PkgId, path::String, cachedir::String, internal_stderr::IO = stderr, internal_stdout::IO = stdout,
+                      ignore_loaded_modules::Bool = true)
+    @nospecialize internal_stderr internal_stdout
+    # decide where to put the resulting cache file
+    cachepath = joinpath(cachedir, pkg.name)
+
+    # build up the list of modules that we want the precompile process to preserve
+    concrete_deps = copy(Base._concrete_dependencies)
+    if ignore_loaded_modules
+        for (key, mod) in Base.loaded_modules
+            if !(mod === Main || mod === Core || mod === Base)
+                push!(concrete_deps, key => Base.module_build_id(mod))
+            end
+        end
+    end
+
+    mkpath(cachepath)
+    tmppath, tmpio = mktemp(cachepath)
+    close(tmpio)
+    return create_expr_cache(pkg, path, tmppath, concrete_deps, internal_stderr, internal_stdout), tmppath
+end
+
+using LLD_jll
+
+function ld(f)
+    LLD_jll.lld() do lld
+        f(`$lld -flavor gnu`)
+    end
+end
+
+is_debug() = ccall(:jl_is_debugbuild, Cint, ()) == 1
+
+function link_jilib(path, out, args=``)
+    LIBDIR = joinpath(Sys.BINDIR, "..", "lib")
+    LIBS = is_debug() ? `-ljulia-debug -ljulia-internal-debug` : `-ljulia -ljulia-internal`
+    ld() do ld
+        run(`$ld --shared --output=$out --whole-archive $path --no-whole-archive -L$(LIBDIR) $LIBS $args`, stdin, stdout, stderr)
+    end
+end
+
+@testset "empty module" begin
+    srcdir   = mktempdir()
+    cachedir = mktempdir()
+    cnpath = joinpath(srcdir, "CacheNativeEmpty.jl")
+    open(cnpath, "w") do io
+        write(io, """
+        module CacheNativeEmpty
+        end
+        """)
+    end
+    p, arfile = compilecache(Base.PkgId("CacheNativeEmpty"), cnpath, cachedir)
+    @test success(p)
+    libfile = arfile * ".so"
+    link_jilib(arfile, libfile)
+    wl = ccall(:jl_restore_package_image_from_file, Any, (Ptr{UInt8},), libfile)
+    CNE = wl[1]   # the CacheNativeEmpty module
+end
+
+@testset "static compilation" begin
+    srcdir   = mktempdir()
+    cachedir = mktempdir()
+    cnpath = joinpath(srcdir, "CacheNative1.jl")
+    open(cnpath, "w") do io
+        write(io, """
+        module CacheNative1
+        const data1 = [11, 22, 33]
+        const data2 = [44, 55, 66]
+        @noinline uses_data1() = data1[2]
+        precompile(uses_data1, ())
+        end
+        """)
+    end
+    p, arfile = compilecache(Base.PkgId("CacheNative1"), cnpath, cachedir)
+    @test success(p)
+    libfile = arfile * ".so"
+    link_jilib(arfile, libfile)
+    wl1 = ccall(:jl_restore_package_image_from_file, Any, (Ptr{UInt8},), libfile)
+    CN1 = wl1[1]   # the CacheNative1 module
+    f = getfield(CN1, :uses_data1)
+    m = only(methods(f))
+    mi = m.specializations[1]
+    ci = mi.cache
+    @test ci.specptr != C_NULL
+    @test f() == 22
+    # Can we reference this first module from a second?
+    # In particular, test whether we can access `data2` from code.
+    # That's a global variable that wasn't code-referenced in CacheNative1,
+    # and thus wasn't inserted into the .data section of CacheNative1's .o file.
+    # Until this is hooked fully into `using CacheNative1` then it will not be
+    # fully obvious whether the dynamic linker can resolve such references,
+    # because we need to get it by an explicit GlobalRef.
+    push!(LOAD_PATH, srcdir)
+    cnpath = joinpath(srcdir, "CacheNative2.jl")
+    open(cnpath, "w") do io
+        write(io, """
+        module CacheNative2
+        const CacheNative1 = ccall(:jl_restore_package_image_from_file, Any, (Ptr{UInt8},), $(repr(libfile)))[1]::Module
+        const data = CacheNative1.data1
+        @noinline uses_cn1_data1() = CacheNative1.data1[3]
+        @noinline uses_cn1_data2() = CacheNative1.data2[2]
+        @noinline      calls_cn1() = CacheNative1.uses_data1()       # not precompiled
+        @noinline also_calls_cn1() = CacheNative1.uses_data1()       # precompiled
+        uses_cn2_data() = data[3]
+
+        precompile(uses_cn1_data1, ())
+        precompile(uses_cn1_data2, ())
+        precompile(also_calls_cn1, ())
+        precompile(uses_cn2_data, ())
+        end
+        """)
+    end
+    p, arfile = compilecache(Base.PkgId("CacheNative2"), cnpath, cachedir)
+    @test success(p)
+    libfile = arfile * ".so"
+    link_jilib(arfile, libfile)
+    wl2 = ccall(:jl_restore_package_image_from_file, Any, (Ptr{UInt8},), libfile)
+    CN2 = wl2[1]   # the CacheNative2 module
+    @test getfield(CN2, :Base) === Base
+    @test getfield(CN2, :CacheNative1) === CN1
+    f = getfield(CN2, :calls_cn1)
+    @test f() == 22
+    f = getfield(CN2, :also_calls_cn1)
+    @test f() == 22
+    # f1 (aka, uses_cn1_data1) uses an item stored in another package as an LLVM gvar
+    # f2 (aka, uses_cn1_data2) uses an item stored in another package that was never stored as an LLVM gvar
+    f1 = getfield(CN2, :uses_cn1_data1)
+    f2 = getfield(CN2, :uses_cn1_data2)
+    f3 = getfield(CN2, :uses_cn2_data)
+    m1 = only(methods(f1))
+    m2 = only(methods(f2))
+    @test f1() == 33
+    @test f2() == 55
+    @test f3() == f1()
+
+    CN1.data1[3] = 77
+    @test f1() == 77
+end
+
 empty!(Base.DEPOT_PATH)
 append!(Base.DEPOT_PATH, original_depot_path)
+empty!(Base.LOAD_PATH)
+append!(Base.LOAD_PATH, original_load_path)


### PR DESCRIPTION
- add build_id field to codeinst
- WIP: Try to use cache
- WIP: Replace function with GV -- TODO: Initialize on the other side
- WIP: Record external calls
- Handle specsig and move complicated code into common place
- WIP: External functions in sysimage
- Fix warning for jl_current_build_id
- Move processing of extern_fns to update_all_gvars
- resolve extern_functions through codeinstance
- add test for calling Base function
- add more broken things
- initialize tls variables in pkgimage
- Fixup some smaller test-cases
