### PR TITLE
Fix error and formatting in subnormal docstring

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -806,8 +806,10 @@ end
 """
     issubnormal(f) -> Bool
 
-Test whether a floating point number is [subnormal](https://en.wikipedia.org/wiki/Subnormal_number). A floating point number is recognized as
-subnormal whenever its exponent is the least value possible and its significand is zero.
+Test whether a floating point number is subnormal.
+
+A floating point number is recognized as [subnormal](https://en.wikipedia.org/wiki/Subnormal_number)
+whenever its exponent is the least value possible and its significand is not zero.
 
 # Examples
 ```jldoctest

--- a/base/float.jl
+++ b/base/float.jl
@@ -808,8 +808,8 @@ end
 
 Test whether a floating point number is subnormal.
 
-An IEEE floating point number is recognized as [subnormal](https://en.wikipedia.org/wiki/Subnormal_number)
-whenever its exponent bits are zero and its significand is not zero.
+An IEEE floating point number is [subnormal](https://en.wikipedia.org/wiki/Subnormal_number)
+when its exponent bits are zero and its significand is not zero.
 
 # Examples
 ```jldoctest

--- a/base/float.jl
+++ b/base/float.jl
@@ -808,8 +808,8 @@ end
 
 Test whether a floating point number is subnormal.
 
-A floating point number is recognized as [subnormal](https://en.wikipedia.org/wiki/Subnormal_number)
-whenever its exponent is the least value possible and its significand is not zero.
+An IEEE floating point number is recognized as [subnormal](https://en.wikipedia.org/wiki/Subnormal_number)
+whenever its exponent bits are zero and its significand is not zero.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
- Fix an objective error "...whenever its exponent is the least value possible and its significand is **not** zero."
- Follow the [documentation style guide](https://docs.julialang.org/en/v1/manual/documentation/#Writing-Documentation): "Include a single one-line sentence describing what the function does or what the object represents after the simplified signature block. If needed, provide more details in a second paragraph, after a blank line."


Fixup for #46899 cc @udohjeremiah, @fredrikekre, @oscardssmith 