### PR TITLE
optimizer: refactors on SSAIR

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -524,20 +524,8 @@ scan_ssa_use!(used::IdSet, @nospecialize(stmt)) = foreachssa(ssa::SSAValue -> pu
 
 function insert_node!(ir::IRCode, pos::SSAValue, inst::NewInstruction, attach_after::Bool=false)
     node = add_inst!(ir.new_nodes, pos.id, attach_after)
-    node[:line] = something(inst.line, ir[pos][:line])
-    flag = inst.flag
-    if !inst.effect_free_computed
-        (consistent, effect_free_and_nothrow, nothrow) = stmt_effect_flags(fallback_lattice, inst.stmt, inst.type, ir)
-        if consistent
-            flag |= IR_FLAG_CONSISTENT
-        end
-        if effect_free_and_nothrow
-            flag |= IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW
-        elseif nothrow
-            flag |= IR_FLAG_NOTHROW
-        end
-    end
-    node[:inst], node[:type], node[:flag], node[:info] = inst.stmt, inst.type, flag, inst.info
+    node = inst_from_newinst!(node, inst, something(inst.line, ir[pos][:line]))
+    inst.effect_free_computed || (node[:flag] = recompute_inst_flag(inst, ir))
     return SSAValue(length(ir.stmts) + node.idx)
 end
 insert_node!(ir::IRCode, pos::Int, inst::NewInstruction, attach_after::Bool=false) =
@@ -784,20 +772,44 @@ function add_pending!(compact::IncrementalCompact, pos::Int, attach_after::Bool)
     return node
 end
 
+function inst_from_newinst!(node::Instruction, inst::NewInstruction, line::Int32=inst.line::Int32)
+    node[:inst] = inst.stmt
+    node[:type] = inst.type
+    node[:info] = inst.info
+    node[:line] = line
+    node[:flag] = inst.flag
+    return node
+end
+
+function recompute_inst_flag(inst::NewInstruction, src::Union{IRCode,IncrementalCompact})
+    flag = inst.flag
+    (consistent, effect_free_and_nothrow, nothrow) = stmt_effect_flags(
+        fallback_lattice, inst.stmt, inst.type, src)
+    if consistent
+        flag |= IR_FLAG_CONSISTENT
+    end
+    if effect_free_and_nothrow
+        flag |= IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW
+    elseif nothrow
+        flag |= IR_FLAG_NOTHROW
+    end
+    return flag
+end
+
 function insert_node!(compact::IncrementalCompact, before, inst::NewInstruction, attach_after::Bool=false)
     @assert inst.effect_free_computed
     if isa(before, SSAValue)
         if before.id < compact.result_idx
             count_added_node!(compact, inst.stmt)
-            line = something(inst.line, compact.result[before.id][:line])
+            newline = something(inst.line, compact.result[before.id][:line])
             node = add_inst!(compact.new_new_nodes, before.id, attach_after)
+            node = inst_from_newinst!(node, inst, newline)
             push!(compact.new_new_used_ssas, 0)
-            node[:inst], node[:type], node[:line], node[:flag] = inst.stmt, inst.type, line, inst.flag
             return NewSSAValue(-node.idx)
         else
-            line = something(inst.line, compact.ir.stmts[before.id][:line])
+            newline = something(inst.line, compact.ir.stmts[before.id][:line])
             node = add_pending!(compact, before.id, attach_after)
-            node[:inst], node[:type], node[:line], node[:flag] = inst.stmt, inst.type, line, inst.flag
+            node = inst_from_newinst!(node, inst, newline)
             os = OldSSAValue(length(compact.ir.stmts) + length(compact.ir.new_nodes) + length(compact.pending_nodes))
             push!(compact.ssa_rename, os)
             push!(compact.used_ssas, 0)
@@ -808,10 +820,10 @@ function insert_node!(compact::IncrementalCompact, before, inst::NewInstruction,
         if pos < compact.idx
             renamed = compact.ssa_rename[pos]::AnySSAValue
             count_added_node!(compact, inst.stmt)
-            line = something(inst.line, compact.result[renamed.id][:line])
+            newline = something(inst.line, compact.result[renamed.id][:line])
             node = add_inst!(compact.new_new_nodes, renamed.id, attach_after)
+            node = inst_from_newinst!(node, inst, newline)
             push!(compact.new_new_used_ssas, 0)
-            node[:inst], node[:type], node[:line], node[:flag] = inst.stmt, inst.type, line, inst.flag
             return NewSSAValue(-node.idx)
         else
             if pos > length(compact.ir.stmts)
@@ -819,9 +831,9 @@ function insert_node!(compact::IncrementalCompact, before, inst::NewInstruction,
                 info = compact.pending_nodes.info[pos - length(compact.ir.stmts) - length(compact.ir.new_nodes)]
                 pos, attach_after = info.pos, info.attach_after
             end
-            line = something(inst.line, compact.ir.stmts[pos][:line])
+            newline = something(inst.line, compact.ir.stmts[pos][:line])
             node = add_pending!(compact, pos, attach_after)
-            node[:inst], node[:type], node[:line], node[:flag] = inst.stmt, inst.type, line, inst.flag
+            node = inst_from_newinst!(node, inst, newline)
             os = OldSSAValue(length(compact.ir.stmts) + length(compact.ir.new_nodes) + length(compact.pending_nodes))
             push!(compact.ssa_rename, os)
             push!(compact.used_ssas, 0)
@@ -830,9 +842,9 @@ function insert_node!(compact::IncrementalCompact, before, inst::NewInstruction,
     elseif isa(before, NewSSAValue)
         # TODO: This is incorrect and does not maintain ordering among the new nodes
         before_entry = compact.new_new_nodes.info[-before.id]
-        line = something(inst.line, compact.new_new_nodes.stmts[-before.id][:line])
+        newline = something(inst.line, compact.new_new_nodes.stmts[-before.id][:line])
         new_entry = add_inst!(compact.new_new_nodes, before_entry.pos, attach_after)
-        new_entry[:inst], new_entry[:type], new_entry[:line], new_entry[:flag] = inst.stmt, inst.type, line, inst.flag
+        new_entry = inst_from_newinst!(new_entry, inst, newline)
         push!(compact.new_new_used_ssas, 0)
         return NewSSAValue(-new_entry.idx)
     else
@@ -854,20 +866,8 @@ function insert_node_here!(compact::IncrementalCompact, inst::NewInstruction, re
         @assert result_idx == length(compact.result) + 1
         resize!(compact, result_idx)
     end
-    flag = inst.flag
-    if !inst.effect_free_computed
-        (consistent, effect_free_and_nothrow, nothrow) = stmt_effect_flags(fallback_lattice, inst.stmt, inst.type, compact)
-        if consistent
-            flag |= IR_FLAG_CONSISTENT
-        end
-        if effect_free_and_nothrow
-            flag |= IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW
-        elseif nothrow
-            flag |= IR_FLAG_NOTHROW
-        end
-    end
-    node = compact.result[result_idx]
-    node[:inst], node[:type], node[:line], node[:flag] = inst.stmt, inst.type, inst.line, flag
+    node = inst_from_newinst!(compact.result[result_idx], inst)
+    inst.effect_free_computed || (node[:flag] = recompute_inst_flag(inst, compact))
     count_added_node!(compact, inst.stmt) && push!(compact.late_fixup, result_idx)
     compact.result_idx = result_idx + 1
     inst = SSAValue(result_idx)
@@ -1564,7 +1564,6 @@ function fixup_phinode_values!(compact::IncrementalCompact, old_values::Vector{A
     end
     return (values, fixup)
 end
-
 
 function fixup_node(compact::IncrementalCompact, @nospecialize(stmt), reify_new_nodes::Bool)
     if isa(stmt, PhiNode)

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1090,7 +1090,9 @@ function try_inline_finalizer!(ir::IRCode, argexprs::Vector{Any}, idx::Int,
             ssa_rename[ssa.id]
         end
         stmt′ = ssa_substitute_op!(InsertBefore(ir, SSAValue(idx)), inst, stmt′, argexprs, mi.specTypes, mi.sparam_vals, sp_ssa, :default)
-        ssa_rename[idx′] = insert_node!(ir, idx, NewInstruction(stmt′, inst; line = inst[:line] + linetable_offset), attach_after)
+        ssa_rename[idx′] = insert_node!(ir, idx,
+            NewInstruction(inst; stmt=stmt′, line=inst[:line]+linetable_offset),
+            attach_after)
     end
 
     return true
@@ -1459,7 +1461,7 @@ function canonicalize_typeassert!(compact::IncrementalCompact, idx::Int, stmt::E
         NewInstruction(
             PiNode(stmt.args[2], compact.result[idx][:type]),
             compact.result[idx][:type],
-            compact.result[idx][:line]), true)
+            compact.result[idx][:line]), #=reverse_affinity=#true)
     compact.ssa_rename[compact.idx-1] = pi
 end
 


### PR DESCRIPTION
This PR is composed of the following commits:
- SSAIR: refactor `NewInstruction` constructor: fe48e877d87f1ae0f839920f7d4443e9b2d65c57
- SSAIR: disambiguate `Core.Compiler.add!`: 2a599a209a39a18796b9a533b48d9a041c09fd09
- SSAIR: make sure to propagate info from `NewInstruction`: 8530d0f797dc0216fa1f22162f707dd28f2fe687
