### PR TITLE
IncrementalCompact: fix display of basic block boundaries.

### DIFF
--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -842,9 +842,8 @@ function show_ir(io::IO, ci::CodeInfo, config::IRShowConfig=default_config(ci);
 end
 
 function show_ir(io::IO, compact::IncrementalCompact, config::IRShowConfig=default_config(compact.ir))
-    compact_cfg = CFG(compact.result_bbs, Int[first(compact.result_bbs[i].stmts) for i in 2:length(compact.result_bbs)])
     cfg = compact.ir.cfg
-    (_, width) = displaysize(io)
+
 
     # First print everything that has already been compacted
 
@@ -856,27 +855,66 @@ function show_ir(io::IO, compact::IncrementalCompact, config::IRShowConfig=defau
             push!(used_compacted, i)
         end
     end
+
+    # while compacting, the end of the active result bb will not have been determined
+    # (this is done post-hoc by `finish_current_bb!`), so determine it here from scratch.
+    result_bbs = copy(compact.result_bbs)
+    if compact.active_result_bb <= length(result_bbs)
+        # count the total number of nodes we'll add to this block
+        input_bb_idx = block_for_inst(compact.ir.cfg, compact.idx)
+        input_bb = compact.ir.cfg.blocks[input_bb_idx]
+        count = 0
+        for input_idx in input_bb.stmts.start:input_bb.stmts.stop
+            pop_new_node! = new_nodes_iter(compact.ir)
+            while pop_new_node!(input_idx) !== nothing
+                count += 1
+            end
+        end
+
+        result_bb = result_bbs[compact.active_result_bb]
+        result_bbs[compact.active_result_bb] = Core.Compiler.BasicBlock(result_bb,
+            Core.Compiler.StmtRange(first(result_bb.stmts), last(result_bb.stmts)+count))
+    end
+    compact_cfg = CFG(result_bbs, Int[first(result_bbs[i].stmts) for i in 2:length(result_bbs)])
+
     pop_new_node! = new_nodes_iter(compact)
     maxssaid = length(compact.result) + Core.Compiler.length(compact.new_new_nodes)
     bb_idx = let io = IOContext(io, :maxssaid=>maxssaid)
-        show_ir_stmts(io, compact, 1:compact.result_idx-1, config, used_compacted, compact_cfg, 1; pop_new_node!)
+        show_ir_stmts(io, compact, 1:compact.result_idx-1, config, used_compacted,
+                      compact_cfg, 1; pop_new_node!)
     end
+
 
     # Print uncompacted nodes from the original IR
 
     # print a separator
+    (_, width) = displaysize(io)
     stmts = compact.ir.stmts
     indent = length(string(length(stmts)))
     # config.line_info_preprinter(io, "", compact.idx)
     printstyled(io, "─"^(width-indent-1), '\n', color=:red)
 
+    # while compacting, the start of the active uncompacted bb will have been overwritten.
+    # this manifests as a stmt range end that is less than the start, so correct that.
+    inputs_bbs = copy(cfg.blocks)
+    for (i, bb) in enumerate(inputs_bbs)
+        if bb.stmts.stop < bb.stmts.start
+            inputs_bbs[i] = Core.Compiler.BasicBlock(bb,
+                Core.Compiler.StmtRange(last(bb.stmts), last(bb.stmts)))
+            # this is not entirely correct, and will result in the bb starting again,
+            # but is the best we can do without changing how `finish_current_bb!` works.
+        end
+    end
+    uncompacted_cfg = CFG(inputs_bbs, Int[first(inputs_bbs[i].stmts) for i in 2:length(inputs_bbs)])
+
     pop_new_node! = new_nodes_iter(compact.ir, compact.new_nodes_idx)
     maxssaid = length(compact.ir.stmts) + Core.Compiler.length(compact.ir.new_nodes)
     let io = IOContext(io, :maxssaid=>maxssaid)
-        show_ir_stmts(io, compact.ir, compact.idx:length(stmts), config, used_uncompacted, cfg, bb_idx; pop_new_node!)
+        show_ir_stmts(io, compact.ir, compact.idx:length(stmts), config, used_uncompacted,
+                      uncompacted_cfg, bb_idx; pop_new_node!)
     end
 
-    finish_show_ir(io, cfg, config)
+    finish_show_ir(io, uncompacted_cfg, config)
 end
 
 function effectbits_letter(effects::Effects, name::Symbol, suffix::Char)

--- a/test/show.jl
+++ b/test/show.jl
@@ -2479,3 +2479,40 @@ end
     ir = Core.Compiler.complete(compact)
     @test lines_shown(compact) == instructions + 1
 end
+
+@testset "#46424: IncrementalCompact displays wrong basic-block boundaries" begin
+    # get some cfg
+    function foo(i)
+        j = i+42
+        j == 1 ? 1 : 2
+    end
+    ir = only(Base.code_ircode(foo, (Int,)))[1]
+
+    # at every point we should be able to observe these three basic blocks
+    function verify_display(ir)
+        str = sprint(io->show(io, ir))
+        @test contains(str, "1 ─ %1 = ")
+        @test contains(str, r"2 ─ \s+ return 1")
+        @test contains(str, r"3 ─ \s+ return 2")
+    end
+    verify_display(ir)
+
+    # insert some instructions
+    for i in 1:3
+        inst = Core.Compiler.NewInstruction(Expr(:call, :identity, i), Int)
+        Core.Compiler.insert_node!(ir, 2, inst)
+    end
+
+    # compact
+    compact = Core.Compiler.IncrementalCompact(ir)
+    verify_display(compact)
+    state = Core.Compiler.iterate(compact)
+    while state !== nothing
+        verify_display(compact)
+        state = Core.Compiler.iterate(compact, state[2])
+    end
+
+    # complete
+    ir = Core.Compiler.complete(compact)
+    verify_display(ir)
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/46424 again, as the first attempt in https://github.com/JuliaLang/julia/pull/46644 was insufficient.

The problem with CFGs during incremental compaction is that the basic block boundaries are not properly determined until after compaction. We rely on `finish_current_bb!` to finalize a bb, but that only triggers when we've seen all the statements in a block. That's a problem when displaying part of a compacted block, resulting in an incorrect `bb_idx` and display breaking down:

```julia
# at some point during compaction

compact_cfg = CFG with 3 blocks:
  bb 1 (stmts 1:3) → bb 3, 2
  bb 2 (stmt 4)
  bb 3 (stmt 5)

91 1 ─ %1 = Base.add_int(_2, 42)::Int64                                 │╻ +
92 │        identity(1)::Int64 (inserted)                               │╻ ==
   └──      identity(2)::Int64 (inserted)                               │
   2 ─      identity(3)::Int64 (inserted)                               │
   3 ─      (%1 === 1)::Bool                                            │
──────────────────────────────────────────────────────────────────────────────
   !!! ─      goto #3 if not %2                                         │
   !!! ─      return 1                                                  │
   !!! ─      return 2                                                  │

# finish_current_bb! hasn't triggered yet, so `result_bbs` isn't updated,
# but we have already inserted 3 nodes!


# this is corrected at the next iteration when we encounter the terminator

compact_cfg = CFG with 3 blocks:
  bb 1 (stmts 1:6) → bb 3, 2
  bb 2 (stmts 7:4)
  bb 3 (stmt 5)

91 1 ─ %1 = Base.add_int(_2, 42)::Int64                                 │╻ +
92 │        identity(1)::Int64                                          │╻ ==
   │        identity(2)::Int64                                          │
   │        identity(3)::Int64                                          │
   │   %5 = (%1 === 1)::Bool                                            │
   └── %6 = goto #3 if not %5                                           !
──────────────────────────────────────────────────────────────────────────────
   2 ─      return 1                                                    │
   3 ─      return 2                                                    │
```

Similarly, `finish_current_bb!` also updates the start statement index of the next basic block. That's a problem when the boundary of the compacted and uncompacted nodes is at the boundary of two basic blocks, because we then call `show_ir_stmts` with a CFG where the current active block has a broken statement range (the start is an index into `result_bbs`, while the end is still an index into the original instruction stream).

```julia
# at some point during compaction (notice the stmt range 7:4)

cfg = compact.ir.cfg = CFG with 3 blocks:
  bb 1 (stmts 1:6) → bb 3, 2
  bb 2 (stmts 7:4)
  bb 3 (stmt 5)

91 1 ─ %1 = Base.add_int(_2, 42)::Int64                                 │╻ +
92 │        identity(1)::Int64                                          │╻ ==
   │        identity(2)::Int64                                          │
   │        identity(3)::Int64                                          │
   │   %5 = (%1 === 1)::Bool                                            │
   └── %6 = goto #3 if not %5                                           !
──────────────────────────────────────────────────────────────────────────────
   │        return 1                                                    │
   │        return 2                                                    │

# notice the lack of block reoprting, despite bb_idx correctly being set to 2


# this is corrected during the next iteration:

cfg = compact.ir.cfg = CFG with 3 blocks:
  bb 1 (stmts 1:6) → bb 3, 2
  bb 2 (stmt 7)
  bb 3 (stmts 8:5)

91 1 ─ %1 = Base.add_int(_2, 42)::Int64                                 │╻ +
92 │        identity(1)::Int64                                          │╻ ==
   │        identity(2)::Int64                                          │
   │        identity(3)::Int64                                          │
   │   %5 = (%1 === 1)::Bool                                            │
   └── %6 = goto #3 if not %5                                           !
   2 ─      return 1                                                    !
──────────────────────────────────────────────────────────────────────────────
   │        return 2                                                    │

# but now of course the same happens for bb 3
```

I don't particularly like the patching-up of CFGs in `show_ir`, but the alternative (changing how `finalize_current_bb!` works and is invoked) seemed like a way more riskier change.