### PR TITLE
array.jl: filter(f) compat should be 1.9 not 1.8

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -2653,8 +2653,8 @@ julia> map(filter(iseven), [1:3, 2:4, 3:5])
  [2, 4]
  [4]
 ```
-!!! compat "Julia 1.8"
-    This method requires at least Julia 1.8.
+!!! compat "Julia 1.9"
+    This method requires at least Julia 1.9.
 """
 function filter(f)
     Fix1(filter, f)


### PR DESCRIPTION
Fix inaccurate compat note version in https://github.com/JuliaLang/julia/pull/41173.