### PR TITLE
Fix typo in test/spawn.jl

### DIFF
--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -26,7 +26,7 @@ function _tryonce_download_from_cache(desired_url::AbstractString)
     cache_output_filename = joinpath(mktempdir(), "myfile")
     cache_response = Downloads.request(
         cache_url;
-        output = cache_output,
+        output = cache_output_filename,
         throw = false,
         timeout = 60,
     )


### PR DESCRIPTION
Fixes the error introduced by #47015 for windows tests.