### PR TITLE
Fix `show_unquoted` invalidations

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -2006,7 +2006,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
             na = length(func_args)
             if (na == 2 || (na > 2 && isa(func, Symbol) && func in (:+, :++, :*)) || (na == 3 && func === :(:))) &&
                     all(a -> !isa(a, Expr) || a.head !== :..., func_args)
-                    sep = func === :(:) ? "$func" : " " * string(func)::String * " "   # if func::Any, avoid string interpolation (invalidation)
+                sep = func === :(:) ? "$func" : " " * string(func)::String * " "   # if func::Any, avoid string interpolation (invalidation)
 
                 if func_prec <= prec
                     show_enclosed_list(io, '(', func_args, sep, ')', indent, func_prec, quote_level, true)

--- a/base/show.jl
+++ b/base/show.jl
@@ -2006,7 +2006,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
             na = length(func_args)
             if (na == 2 || (na > 2 && isa(func, Symbol) && func in (:+, :++, :*)) || (na == 3 && func === :(:))) &&
                     all(a -> !isa(a, Expr) || a.head !== :..., func_args)
-                sep = func === :(:) ? "$func" : " " * convert(String, string(func))::String * " "   # if func::Any, avoid string interpolation (invalidation)
+                    sep = func === :(:) ? "$func" : " " * string(func)::String * " "   # if func::Any, avoid string interpolation (invalidation)
 
                 if func_prec <= prec
                     show_enclosed_list(io, '(', func_args, sep, ')', indent, func_prec, quote_level, true)


### PR DESCRIPTION
This PR fixes about 1k method invalidations on Julia nightly for multiple separate packages. The following table lists the number of invalidations on Julia 1.8.2, Julia nightly and this PR:

Code | 1.8.2 | 1.9.0-DEV.1506 | This PR
--- | --- | --- | ---
using CSV | 3173 | 5452 | 4560
using CategoricalArrays | 3482 | 4713 | 3668
using InlineStrings | 1376 | 654 | 654
using ProgressLogging | 246 | 2990 | 2049

Generated with:

```julia
using Pkg

Pkg.activate(; temp=true)

Pkg.add(["SnoopCompileCore", "SnoopCompile", "InlineStrings"])

using SnoopCompileCore

invs = @snoopr using InlineStrings

using SnoopCompile

trees = invalidation_trees(invs)

print('\n', trees, '\n')

@show length(invs)
```

and running for various packages and Julia versions with `--startup-file=no`.

Note that this PR reverts a change introduced by https://github.com/JuliaLang/julia/pull/44500. It changes a `convert(String, X)` back to `string(X)`.

Based on this PR reverting an earlier PR and the seemingly random increases and decreases in the table, adding invalidations tests should help avoid regressions (https://github.com/JuliaLang/julia/issues/47022). I'll see whether I can find time to work on that.

cc: @timholy, @ranocha 

I suggest the `latency` label.