### PR TITLE
Fix libjulia install name and libjulia-internal rpath on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,8 +361,17 @@ endif
 	fi;
 endif
 	
-	# Set rpath for libjulia-internal, which is moving from `../lib` to `../lib/julia`.  We only need to do this for Linux/FreeBSD
-ifneq (,$(findstring $(OS),Linux FreeBSD))
+	# Set rpath for libjulia-internal, which is moving from `../lib` to `../lib/julia`.
+ifeq ($(OS), Darwin)
+ifneq ($(DARWIN_FRAMEWORK),1)
+	install_name_tool -rpath '@loader_path/' '@loader_path/$(reverse_private_libdir_rel)/' $(DESTDIR)$(private_libdir)/libjulia-internal.$(SHLIB_EXT)
+	install_name_tool -rpath '@loader_path/julia/' '@loader_path/' $(DESTDIR)$(private_libdir)/libjulia-internal.$(SHLIB_EXT)
+ifeq ($(BUNDLE_DEBUG_LIBS),1)
+	install_name_tool -rpath '@loader_path/' '@loader_path/$(reverse_private_libdir_rel)/' $(DESTDIR)$(private_libdir)/libjulia-internal-debug.$(SHLIB_EXT)
+	install_name_tool -rpath '@loader_path/julia/' '@loader_path/' $(DESTDIR)$(private_libdir)/libjulia-internal-debug.$(SHLIB_EXT)
+endif
+endif
+else ifneq (,$(findstring $(OS),Linux FreeBSD))
 	$(PATCHELF) --set-rpath '$$ORIGIN:$$ORIGIN/$(reverse_private_libdir_rel)' $(DESTDIR)$(private_libdir)/libjulia-internal.$(SHLIB_EXT)
 ifeq ($(BUNDLE_DEBUG_LIBS),1)
 	$(PATCHELF) --set-rpath '$$ORIGIN:$$ORIGIN/$(reverse_private_libdir_rel)' $(DESTDIR)$(private_libdir)/libjulia-internal-debug.$(SHLIB_EXT)

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -119,7 +119,7 @@ endif
 
 $(build_shlibdir)/libjulia.$(JL_MAJOR_MINOR_SHLIB_EXT): $(LIB_OBJS) | $(build_shlibdir) $(build_libdir)
 	@$(call PRINT_LINK, $(CC) $(call IMPLIB_FLAGS,$@) $(LOADER_CFLAGS) -DLIBRARY_EXPORTS -shared $(SHIPFLAGS) $(LIB_OBJS) -o $@ $(JLIBLDFLAGS) $(LOADER_LDFLAGS) $(RPATH_LIB)) $(call SONAME_FLAGS,libjulia.$(JL_MAJOR_SHLIB_EXT))
-	$(INSTALL_NAME_CMD)libjulia.$(SHLIB_EXT) $@
+	$(INSTALL_NAME_CMD)libjulia.$(JL_MAJOR_SHLIB_EXT) $@
 ifneq ($(OS), WINNT)
 	@ln -sf $(notdir $@) $(build_shlibdir)/libjulia.$(JL_MAJOR_SHLIB_EXT)
 	@ln -sf $(notdir $@) $(build_shlibdir)/libjulia.$(SHLIB_EXT)
@@ -129,7 +129,7 @@ endif
 
 $(build_shlibdir)/libjulia-debug.$(JL_MAJOR_MINOR_SHLIB_EXT): $(LIB_DOBJS) | $(build_shlibdir) $(build_libdir)
 	@$(call PRINT_LINK, $(CC) $(call IMPLIB_FLAGS,$@) $(LOADER_CFLAGS) -DLIBRARY_EXPORTS -shared $(DEBUGFLAGS) $(LIB_DOBJS) -o $@ $(JLIBLDFLAGS) $(LOADER_LDFLAGS) $(RPATH_LIB)) $(call SONAME_FLAGS,libjulia-debug.$(JL_MAJOR_SHLIB_EXT))
-	$(INSTALL_NAME_CMD)libjulia-debug.$(SHLIB_EXT) $@
+	$(INSTALL_NAME_CMD)libjulia-debug.$(JL_MAJOR_SHLIB_EXT) $@
 ifneq ($(OS), WINNT)
 	@ln -sf $(notdir $@) $(build_shlibdir)/libjulia-debug.$(JL_MAJOR_SHLIB_EXT)
 	@ln -sf $(notdir $@) $(build_shlibdir)/libjulia-debug.$(SHLIB_EXT)

--- a/src/Makefile
+++ b/src/Makefile
@@ -119,6 +119,9 @@ CLANG_LDFLAGS := $(LLVM_LDFLAGS)
 ifeq ($(OS), Darwin)
 CLANG_LDFLAGS += -Wl,-undefined,dynamic_lookup
 OSLIBS += $(SRCDIR)/mach_dyld_atfork.tbd
+LIBJULIA_PATH_REL := @rpath/libjulia
+else
+LIBJULIA_PATH_REL := libjulia
 endif
 
 COMMON_LIBPATHS := -L$(build_libdir) -L$(build_shlibdir)
@@ -136,8 +139,8 @@ SHIPFLAGS  += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys.$(SHLIB_
 DEBUGFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys-debug.$(SHLIB_EXT)\""
 
 # Add SONAME defines so we can embed proper `dlopen()` calls.
-SHIPFLAGS  += "-DJL_LIBJULIA_SONAME=\"libjulia.$(JL_MAJOR_SHLIB_EXT)\""       "-DJL_LIBJULIA_INTERNAL_SONAME=\"libjulia-internal.$(JL_MAJOR_SHLIB_EXT)\""
-DEBUGFLAGS += "-DJL_LIBJULIA_SONAME=\"libjulia-debug.$(JL_MAJOR_SHLIB_EXT)\"" "-DJL_LIBJULIA_INTERNAL_SONAME=\"libjulia-internal-debug.$(JL_MAJOR_SHLIB_EXT)\""
+SHIPFLAGS  += "-DJL_LIBJULIA_SONAME=\"$(LIBJULIA_PATH_REL).$(JL_MAJOR_SHLIB_EXT)\""
+DEBUGFLAGS += "-DJL_LIBJULIA_SONAME=\"$(LIBJULIA_PATH_REL)-debug.$(JL_MAJOR_SHLIB_EXT)\""
 
 ifeq ($(USE_CROSS_FLISP), 1)
 FLISPDIR := $(BUILDDIR)/flisp/host


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/40246.

This PR makes 3 main changes:
- change the RPATH of `libjulia-internal.dylib`, by analogy with `libjulia-internal.so`
- set the install name of `libjulia.dylib` to `libjulia.1.dylib`
- change `JL_LIBJULIA_SONAME` to `@rpath/libjulia.1.dylib` on Mac

I'm not sure if all 3 are necessary but I think they're all good changes in any case. In particular #2 means you can package `libjulia.1.dylib` without a `libjulia.dylib` symlink.

I also removed `JL_LIBJULIA_INTERNAL_SONAME` because it seems to be unused.

I made a [small test case](https://github.com/jonathan-conder-sm/julia/tree/mac_embedding_test/mac_embedding_test) to check that this fixes the issue (for me, at least).

It builds and runs a `test` program which embeds julia indirectly, via `libtest.dylib`. These both live in the parent directory of `libjulia.dylib`, with RPATHs set accordingly.

The test results can be viewed [here](https://github.com/jonathan-conder-sm/julia/actions/runs/3187183474/jobs/5198510393). Note that `src/mac_embedding_test/test.sh julia` is the patched build, and prints `sqrt(2.0)` successfully. On the other hand `src/mac_embedding_test/test.sh julia-1.6.7` uses the official Julia 1.6.7 build, and segfaults when `libjulia-internal.dylib` tries to get a handle to `libjulia.dylib`.