### PR TITLE
incorrect wordings on sentence

### DIFF
--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -247,8 +247,8 @@ default method by many combinations of concrete types. Thanks to multiple dispat
 has full control over whether the default or more specific method is used.
 
 An important point to note is that there is no loss in performance if the programmer relies on
-a function whose arguments are abstract types, because it is recompiled for each tuple of argument
-concrete types with which it is invoked. (There may be a performance issue, however, in the case
+a function whose arguments are abstract types, because it is recompiled for each tuple of concrete
+types argument with which it is invoked. (There may be a performance issue, however, in the case
 of function arguments that are containers of abstract types; see [Performance Tips](@ref man-performance-abstract-container).)
 
 ## Primitive Types

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -248,7 +248,7 @@ has full control over whether the default or more specific method is used.
 
 An important point to note is that there is no loss in performance if the programmer relies on
 a function whose arguments are abstract types, because it is recompiled for each tuple of concrete
-types argument with which it is invoked. (There may be a performance issue, however, in the case
+argument types with which it is invoked. (There may be a performance issue, however, in the case
 of function arguments that are containers of abstract types; see [Performance Tips](@ref man-performance-abstract-container).)
 
 ## Primitive Types


### PR DESCRIPTION
This statement isn't correct and it's hard to understand what is meant:
> tuple of argument concrete types.

A better way would be:
> tuple of concrete types argument.

Which is easy to understand as a tuple that contains arguments that are concrete types.