### PR TITLE
struct and mutable struct declaration

### DIFF
--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -506,9 +506,9 @@ It's important to note that the `mutable struct` keyword does not declare a new 
 different from the one defined with the `struct` keyword and vice-versa, if both types have
 the same name and the declaration was done in the same namespace.
 
-As an example, declaring a type with name as `Point` using `struct` is also equivalent to the
-type declared with name as `Point` using `mutable struct`. Trying to declare these both in one
-namespace will throw an error:
+As an example, declaring a type with name as `Point` using `mutable struct` does not
+distinguish it from the type declared with name as `Point` using `struct`. Trying to declare
+these both in one namespace will throw an error:
 ```jldoctest
 julia> struct Point
            x

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -506,7 +506,7 @@ In Julia two different objects can't have the same name, so defining an object, 
 with `mutable struct`, will not create a new object if it's already been declared
 with `struct` with name as `Point`, even if the fields are different; rather, an error will
 be thrown:
-```julia
+```jldoctest
 julia> struct Point
            x
        end

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -502,6 +502,26 @@ ERROR: setfield!: const field .b of type Baz cannot be changed
 [...]
 ```
 
+It's important to note that the `mutable struct` keyword does not declare a new type that is
+different from the one defined with the `struct` keyword and vice-versa, if both types have
+the same name and the declaration was done in the same namespace.
+
+As an example, declaring a type with name as `Point` using `struct` is also equivalent to the
+type declared with name as `Point` using `mutable struct`. Trying to declare these both in one
+namespace will throw an error:
+```jldoctest
+julia> struct Point
+           x
+           y
+       end
+
+julia> mutable struct Point
+           x
+           y
+       end
+ERROR: invalid redefinition of constant Point
+```
+
 ## [Declared Types](@id man-declared-types)
 
 The three kinds of types (abstract, primitive, composite) discussed in the previous

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -502,17 +502,13 @@ ERROR: setfield!: const field .b of type Baz cannot be changed
 [...]
 ```
 
-It's important to note that the `mutable struct` keyword does not declare a new type that is
-different from the one defined with the `struct` keyword and vice-versa, if both types have
-the same name and the declaration was done in the same namespace.
-
-As an example, declaring a type with name as `Point` using `mutable struct` does not
-distinguish it from the type declared with name as `Point` using `struct`. Trying to declare
-these both in one namespace will throw an error:
-```jldoctest
+In Julia two different objects can't have the same name, so defining an object, say `Point`,
+with `mutable struct`, will not create a new object if it's already been declared
+with `struct` with name as `Point`, even if the fields are different; rather, an error will
+be thrown:
+```julia
 julia> struct Point
            x
-           y
        end
 
 julia> mutable struct Point


### PR DESCRIPTION
It's important to spell out the subtleness in declaring a type with `struct` and `mutable struct`.

I've come across people who ask if they can both have an immutable and mutable implementation of a type in one namespace. That is:
```julia
julia> mutable struct Point end

julia> struct Point end
```

And then wish when they construct the types it will be immutable and stay so; but then when they want to change it, it should somehow refer to the mutable one 🙀.