### PR TITLE
Update eachsplit example in documentation

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -500,7 +500,10 @@ See also [`split`](@ref).
 julia> a = "Ma.rch"
 "Ma.rch"
 
-julia> collect(eachsplit(a, "."))
+julia> b = eachsplit(a, ".")
+Base.SplitIterator{String, String}("Ma.rch", ".", 0, true)
+
+julia> collect(b)
 2-element Vector{SubString{String}}:
  "Ma"
  "rch"


### PR DESCRIPTION
This PR makes the example in the documentation for `eachsplit` more clear, as suggested in #46751.