### PR TITLE
Fix IR corruption in cfg_simplify!

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -945,17 +945,17 @@ function _oracle_check(compact::IncrementalCompact)
     observed_used_ssas = Core.Compiler.find_ssavalue_uses1(compact)
     for i = 1:length(observed_used_ssas)
         if observed_used_ssas[i] != compact.used_ssas[i]
-            return observed_used_ssas
+            return (observed_used_ssas, i)
         end
     end
-    return nothing
+    return (nothing, 0)
 end
 
 function oracle_check(compact::IncrementalCompact)
-    maybe_oracle_used_ssas = _oracle_check(compact)
+    (maybe_oracle_used_ssas, oracle_error_ssa) = _oracle_check(compact)
     if maybe_oracle_used_ssas !== nothing
-        @eval Main (compact = $compact; oracle_used_ssas = $maybe_oracle_used_ssas)
-        error("Oracle check failed, inspect Main.compact and Main.oracle_used_ssas")
+        @eval Main (compact = $compact; oracle_used_ssas = $maybe_oracle_used_ssas; oracle_error_ssa = $oracle_error_ssa)
+        error("Oracle check failed, inspect Main.{compact, oracle_used_ssas, oracle_error_ssa}")
     end
 end
 
@@ -1257,7 +1257,7 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
             values = Vector{Any}(undef, length(stmt.values))
             new_index = 1
             for old_index in 1:length(stmt.edges)
-                if stmt.edges[old_index] != -1
+                if stmt.edges[old_index] > 0
                     edges[new_index] = stmt.edges[old_index]
                     if isassigned(stmt.values, old_index)
                         values[new_index] = stmt.values[old_index]

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -2096,7 +2096,12 @@ function cfg_simplify!(ir::IRCode)
                     # If we merged a basic block, we need remove the trailing GotoNode (if any)
                     compact.result[compact.result_idx][:inst] = nothing
                 else
-                    process_node!(compact, compact.result_idx, node, i, i, ms, true)
+                    ri = process_node!(compact, compact.result_idx, node, i, i, ms, true)
+                    if ri == compact.result_idx
+                        # process_node! wanted this statement dropped. We don't do this,
+                        # but we still need to erase the node
+                        compact.result[compact.result_idx][:inst] = nothing
+                    end
                 end
                 # We always increase the result index to ensure a predicatable
                 # placement of the resulting nodes.


### PR DESCRIPTION
There were two issues here:
1. The code was assuming that any negative index in the BB rename array meant to skip the array, but the IncrementalCompact code was only processing -1. Adjust that to match the assumption.
2. A statement that was expected to be skipped was not properly erased. cfg_simplify overrode the `IncrementalCompact`-or's decision to skip a node, but didn't properly erase it. Since skipped nodes were not renamed, this would result in invalid IR.

While we're here, pass out a little more information in the oracle check, which caught these issues when turned on.