### PR TITLE
Fix oracle check failure in adce_pass

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1582,7 +1582,7 @@ function adce_pass!(ir::IRCode)
         phi = unionphi[1]
         t = unionphi[2]
         if t === Union{}
-            compact.result[phi][:inst] = nothing
+            compact[SSAValue(phi)] = nothing
             continue
         elseif t === Any
             continue
@@ -1604,6 +1604,9 @@ function adce_pass!(ir::IRCode)
         end
         compact.result[phi][:type] = t
         isempty(to_drop) && continue
+        for d in to_drop
+            isassigned(stmt.values, d) && kill_current_use(compact, stmt.values[d])
+        end
         deleteat!(stmt.values, to_drop)
         deleteat!(stmt.edges, to_drop)
     end


### PR DESCRIPTION
This is probably a real issue, though I did not see it cause an actual issue, only an oracle check failure if the verification is turned on. The issue was that we were failing to count the removal of phi node edges during the adce pass, so we were left with excessive counts at completion.