### PR TITLE
Tests for bunchkaufman and cholesky of AbstractMatrix

### DIFF
--- a/stdlib/LinearAlgebra/test/bunchkaufman.jl
+++ b/stdlib/LinearAlgebra/test/bunchkaufman.jl
@@ -190,4 +190,10 @@ end
     @test_throws ArgumentError("adjoint not implemented for complex symmetric matrices") F'
 end
 
+@testset "BunchKaufman for AbstractMatrix" begin
+    S = SymTridiagonal(fill(2.0, 4), ones(3))
+    B = bunchkaufman(S)
+    @test B.U * B.D * B.U' ≈ S
+end
+
 end # module TestBunchKaufman

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -407,6 +407,12 @@ end
     @test_throws InexactError cholesky!(Diagonal([2, 1]))
 end
 
+@testset "Cholesky for AbstractMatrix" begin
+    S = SymTridiagonal(fill(2.0, 4), ones(3))
+    C = cholesky(S)
+    @test C.L * C.U ≈ S
+end
+
 @testset "constructor with non-BlasInt arguments" begin
 
     x = rand(5,5)


### PR DESCRIPTION
Closes JuliaLang/LinearAlgebra.jl#377. It was actually resolved in JuliaLang/julia#44076 and  JuliaLang/julia#46797.