### PR TITLE
Correcting inconsistencies

### DIFF
--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -62,7 +62,7 @@ then paste the symbol.)
 Julia will even let you shadow existing exported constants and functions with local ones
 (although this is not recommended to avoid potential confusions):
 
-```jldoctest; filter = "with \d+ methods"
+```jldoctest; filter = r"with \d+ methods"
 julia> pi = 3
 3
 

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -59,21 +59,7 @@ name `δ` can be entered by typing `\delta`-*tab*, or even `α̂⁽²⁾` by `\a
 that you don't know how to type, the REPL help will tell you: just type `?` and
 then paste the symbol.)
 
-Julia will even let you redefine built-in constants and functions if needed (although
-this is not recommended to avoid potential confusions):
-
-```jldoctest
-julia> pi = 3
-3
-
-julia> pi
-3
-
-julia> sqrt = 4
-4
-```
-
-However, if you try to redefine a built-in constant or function already in use, Julia will give
+If you try to redefine a built-in constant or function already in use, Julia will give
 you an error:
 
 ```jldoctest

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -59,7 +59,7 @@ name `δ` can be entered by typing `\delta`-*tab*, or even `α̂⁽²⁾` by `\a
 that you don't know how to type, the REPL help will tell you: just type `?` and
 then paste the symbol.)
 
-Julia will even let you shadow exported exported constants and functions with local ones
+Julia will even let you shadow existing exported constants and functions with local ones
 (although this is not recommended to avoid potential confusions):
 
 ```jldoctest

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -62,7 +62,7 @@ then paste the symbol.)
 Julia will even let you shadow existing exported constants and functions with local ones
 (although this is not recommended to avoid potential confusions):
 
-```jldoctest
+```jldoctest filter="with \d+ methods"
 julia> pi = 3
 3
 

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -59,7 +59,27 @@ name `δ` can be entered by typing `\delta`-*tab*, or even `α̂⁽²⁾` by `\a
 that you don't know how to type, the REPL help will tell you: just type `?` and
 then paste the symbol.)
 
-If you try to redefine a built-in constant or function already in use, Julia will give
+Julia will even let you shadow exported exported constants and functions with local ones
+(although this is not recommended to avoid potential confusions):
+
+```jldoctest
+julia> pi = 3
+3
+
+julia> pi
+3
+
+julia> sqrt = 4
+4
+
+julia> length() = 5
+length (generic function with 1 method)
+
+julia> Base.length
+length (generic function with 79 methods)
+```
+
+However, if you try to redefine a built-in constant or function already in use, Julia will give
 you an error:
 
 ```jldoctest

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -62,7 +62,7 @@ then paste the symbol.)
 Julia will even let you shadow existing exported constants and functions with local ones
 (although this is not recommended to avoid potential confusions):
 
-```jldoctest filter="with \d+ methods"
+```jldoctest; filter = "with \d+ methods"
 julia> pi = 3
 3
 


### PR DESCRIPTION
The documentation stated that built-in constants and functions could both be redefined and _not_ be redefined. Testing on Julia 1.7.3 it appears that built-in constant and functions cannot be redefined.