### PR TITLE
Clarify docstring for `exponent`, again

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -935,20 +935,20 @@ ldexp(x::Float16, q::Integer) = Float16(ldexp(Float32(x), q))
 Returns the largest integer `y` such that `2^y ≤ abs(x)`.
 
 Throws a `DomainError` when `x` is zero, infinite, or [`NaN`](@ref).
-For any other non-subnormal floating-point number `x`, this reads the exponent bits of `x`.
+For any other non-subnormal floating-point number `x`, this corresponds to the exponent bits of `x`.
 
-See also [`significand`](@ref), [`frexp`](@ref), [`issubnormal`](@ref), [`log2`](@ref).
+See also [`signbit`](@ref), [`significand`](@ref), [`frexp`](@ref), [`issubnormal`](@ref), [`log2`](@ref).
 
 # Examples
 ```jldoctest
 julia> exponent(8)
 3
 
-julia> exponent(-6.5)
+julia> exponent(6.5)
 2
 
-julia> exponent(3.142e-4)
--12
+julia> exponent(-1//4)
+-2
 
 julia> exponent(floatmin(Float32)), exponent(nextfloat(0.0f0))
 (-126, -149)

--- a/base/math.jl
+++ b/base/math.jl
@@ -930,27 +930,28 @@ end
 ldexp(x::Float16, q::Integer) = Float16(ldexp(Float32(x), q))
 
 """
-    exponent(x) -> Int
+    exponent(x::Real) -> Int
 
 Returns the largest integer `y` such that `2^y ≤ abs(x)`.
-For a normalized floating-point number `x`, this corresponds to the exponent of `x`.
+
+Throws a `DomainError` when `x` is zero, infinite, or [`NaN`](@ref).
+For any other non-subnormal floating-point number `x`, this reads the exponent bits of `x`.
+
+See also [`significand`](@ref), [`frexp`](@ref), [`issubnormal`](@ref), [`log2`](@ref).
 
 # Examples
 ```jldoctest
 julia> exponent(8)
 3
 
-julia> exponent(64//1)
-6
-
-julia> exponent(6.5)
+julia> exponent(-6.5)
 2
-
-julia> exponent(16.0)
-4
 
 julia> exponent(3.142e-4)
 -12
+
+julia> exponent(floatmin(Float32)), exponent(nextfloat(0.0f0))
+(-126, -149)
 ```
 """
 function exponent(x::T) where T<:IEEEFloat


### PR DESCRIPTION
In #47035 we realised that `issubnormal` used the word "exponent" quite loosely, and this is also true of `exponent`'s docstring. So this tries to fix it...

* Saying "this corresponds to the exponent of `x`." seems a bit circular, but I think it wants to say that in such cases it corresponds to the exponent bits?
* Saying "normalized floating-point number" does not mean like `normalize(1.0)`... I think it means not-subnormal. Maybe it's better to say that? (Although I don't love this sentence.) 
* From "largest integer y such that `2^y ≤ abs(x)`" it sounds like `exponent(8+im)` should work, but it does not. So I marked it `::Real`.
* I think it is nice to mention that 0, Inf, Nan give an error. As they must, for `2^y ≤ abs(x)`... but `0.0` is not subnormal, so the claim about reading the bit pattern isn't quite correct without excluding these cases.
* Better examples, progressively adding detail, not too repetitive.
* See also related functions.

Recently edited in #46815. 

And I forgot, but "See also" and errors also overlap with this (approved) PR:  https://github.com/JuliaLang/julia/pull/45221/files#diff-faa5f0835bd28c4a33e6603e208a9236034568a4abc7adec4995afb64550d0bdR940 . That should go first. 