### PR TITLE
fix invalidations when loading ForwardDiff.jl and ChainRulesCore.jl

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -111,7 +111,7 @@ function NamedTuple{names}(nt::NamedTuple) where {names}
         types = Tuple{(fieldtype(nt, idx[n]) for n in 1:length(idx))...}
         Expr(:new, :(NamedTuple{names, $types}), Any[ :(getfield(nt, $(idx[n]))) for n in 1:length(idx) ]...)
     else
-        length_names = length(names)::Integer
+        length_names = length(names::Tuple)
         types = Tuple{(fieldtype(typeof(nt), names[n]) for n in 1:length_names)...}
         NamedTuple{names, types}(map(Fix1(getfield, nt), names))
     end

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -24,7 +24,7 @@ function recursive_dotcalls!(ex, args, i=1)
         end
     end
     (start, branches) = ex.head === :. ? (1, ex.args[2].args) : (2, ex.args)
-    length_branches = length(branches)::Integer
+    length_branches = length(branches)::Int
     for j in start:length_branches
         branch, i = recursive_dotcalls!(branches[j], args, i)
         branches[j] = branch
@@ -43,7 +43,7 @@ function gen_call_with_extracted_types(__module__, fcn, ex0, kws=Expr[])
             end
             i = findlast(a->(Meta.isexpr(a, :kw) || Meta.isexpr(a, :parameters)), ex0.args[1].args)
             args = copy(ex0.args[1].args)
-            insert!(args, (isnothing(i) ? 2 : i+1), ex0.args[2])
+            insert!(args, (isnothing(i) ? 2 : 1+i::Int), ex0.args[2])
             ex0 = Expr(:call, args...)
         end
         if ex0.head === :. || (ex0.head === :call && ex0.args[1] !== :.. && string(ex0.args[1])[1] == '.')


### PR DESCRIPTION
I improved type stability to fix some invalidations. This is based on the following code (executed with a local build using the `backports-release-1.8` branch):

```julia
julia> import Pkg; Pkg.activate(temp=true); Pkg.add("ForwardDiff")

julia> using SnoopCompileCore; invalidations = @snoopr(using ForwardDiff); using SnoopCompile

julia> length(uinvalidated(invalidations))
430

julia> trees = invalidation_trees(invalidations)
...
 inserting promote_rule(::Type{R}, ::Type{ForwardDiff.Dual{T, V, N}}) where {R<:Real, T, V, N} in ForwardDiff at ~/.julia/packages/ForwardDiff/pDtsf/src/dual.jl:425 invalidated:
   backedges: 1: superseding promote_rule(::Type, ::Type) in Base at promotion.jl:310 with MethodInstance for promote_rule(::Type{Int64}, ::Type{S} where S<:Real) (1 children)
              2: superseding promote_rule(::Type, ::Type) in Base at promotion.jl:310 with MethodInstance for promote_rule(::Type{Int64}, ::Type) (228 children)
   17 mt_cache
...
```

With this PR on top of the current `backports-release-1.8` branch:

```julia
julia> length(uinvalidated(invalidations))
191
```

Most of the remaining invalidations could be fixed around `sort_int_range!`. However, this part changed quite a bit on `master`, so I'm not sure whether it's better to wait until v1.9 is released to revisit this issue.

Edit: It's nice to observe that this fixes https://github.com/JuliaDiff/ChainRulesCore.jl/issues/576:

```julia
julia> import Pkg; Pkg.activate(temp=true); Pkg.add("ChainRulesCore")
  Activating new project at `/tmp/jl_8BxH6u`
    Updating registry at `~/.julia/registries/General.toml`
   Resolving package versions...
    Updating `/tmp/jl_8BxH6u/Project.toml`
  [d360d2e6] + ChainRulesCore v1.15.6
    Updating `/tmp/jl_8BxH6u/Manifest.toml`
  [d360d2e6] + ChainRulesCore v1.15.6
  [34da2185] + Compat v4.3.0
  [56f22d72] + Artifacts
  [ade2ca70] + Dates
  [8f399da3] + Libdl
  [37e2e46d] + LinearAlgebra
  [de0858da] + Printf
  [9a3f8284] + Random
  [ea8e919c] + SHA v0.7.0
  [9e88b42a] + Serialization
  [2f01184e] + SparseArrays
  [cf7118a7] + UUIDs
  [4ec0a83e] + Unicode
  [e66e0078] + CompilerSupportLibraries_jll v0.5.2+0
  [4536629a] + OpenBLAS_jll v0.3.21+0
  [8e850b90] + libblastrampoline_jll v5.2.0+0

julia> using SnoopCompileCore; invalidations = @snoopr(using ChainRulesCore); using SnoopCompile
[ Info: Precompiling SnoopCompile [aa65fe97-06da-5843-b5b1-d5d13cad87d2]

julia> length(uinvalidated(invalidations))
0

julia> trees = invalidation_trees(invalidations)
SnoopCompile.MethodInvalidations[]
```

(with this PR on top of the current `backports-release-1.8` branch).