### PR TITLE
[WIP] adding pre-commit CI and JuliaFormatter

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,27 @@
+name: Format suggestions
+
+on:
+  pull_request:
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: 1
+      - run: |
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="1.0.10"))'
+          julia  -e 'using JuliaFormatter; format(".", MinimalStyle(); normalize_line_endings = "unix")'
+      - uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: JuliaFormatter
+          fail_on_error: true
+          filter_mode: added

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@19bd4db8c427e07d56602f1c432e1a26a55d6735 # v1.8.2
         with:
           version: 1
       - run: |

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,9 +17,12 @@ jobs:
       - uses: julia-actions/setup-julia@19bd4db8c427e07d56602f1c432e1a26a55d6735 # v1.8.2
         with:
           version: 1
+      - shell: julia --color=yes {0}
       - run: |
-          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="1.0.10"))'
-          julia  -e 'using JuliaFormatter; format(".", MinimalStyle(); normalize_line_endings = "unix")'
+          using Pkg
+          Pkg.add(PackageSpec(name="JuliaFormatter", version="1.0.10"))
+          using JuliaFormatter
+          format(".", MinimalStyle(); normalize_line_endings = "unix")
       - uses: reviewdog/action-suggester@v1
         with:
           tool_name: JuliaFormatter

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,7 +13,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@19bd4db8c427e07d56602f1c432e1a26a55d6735 # v1.8.2
         with:
           version: 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,9 @@ repos:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v15.0.0
+    hooks:
+    -   id: clang-format
+        types_or: [c++, c]


### PR DESCRIPTION
fix #47052

waiting admin of this repo:

- [ ] ~~enable pre-commit ci for this repo: https://pre-commit.ci/~~
- [ ] ~~check what other hooks we may want before JuliaFormatter can replace them: https://pre-commit.com/hooks.html~~

Waiting for upstream:

- [x] https://github.com/domluna/JuliaFormatter.jl/issues/644
- [ ] https://github.com/domluna/JuliaFormatter.jl/issues/561

Test drive:
- [ ] https://github.com/JuliaLang/julia/pull/47151
