### PR TITLE
Special purpose inliner for Core.ifelse

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1745,6 +1745,15 @@ function early_inline_special_case(
         setting === :const || setting === :conditional || setting === :type || return nothing
         # barriered successfully already, eliminate it
         return SomeCase(stmt.args[3])
+    elseif f === Core.ifelse && length(argtypes) == 4
+        cond = argtypes[2]
+        if isa(cond, Const)
+            if cond.val === true
+                return SomeCase(stmt.args[3])
+            elseif cond.val === false
+                return SomeCase(stmt.args[4])
+            end
+        end
     end
     return nothing
 end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1761,3 +1761,12 @@ let interp = Core.Compiler.NativeInterpreter()
     @test count(isinvoke(:*), ir.stmts.inst) == 0
     @test count(iscall((ir, Core.Intrinsics.mul_int)), ir.stmts.inst) == 1
 end
+
+# Test special purpose inliner for Core.ifelse
+f_ifelse_1(a, b) = Core.ifelse(true, a, b)
+f_ifelse_2(a, b) = Core.ifelse(false, a, b)
+f_ifelse_3(a, b) = Core.ifelse(a, true, b)
+
+@test fully_eliminated(f_ifelse_1, Tuple{Any, Any}; retval=Core.Argument(2))
+@test fully_eliminated(f_ifelse_2, Tuple{Any, Any}; retval=Core.Argument(3))
+@test !fully_eliminated(f_ifelse_3, Tuple{Any, Any})


### PR DESCRIPTION
This function isn't used as much anymore now that Base.ifelse is an actual generic function, but it's still used in a few places across the ecosystem, and there currently isn't anything that would fold it for constant conditions, so add a special case inliner for it. This probably doesn't have a huge impact, but I happened to run into a case where it was causing annoying suboptimialities and it's a quick fix.