### PR TITLE
lu should throw on matrix of NaNs

### DIFF
--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -550,6 +550,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         #       DOUBLE PRECISION   A( LDA, * )
         function getrf!(A::AbstractMatrix{$elty})
             require_one_based_indexing(A)
+            chkfinite(A)
             chkstride1(A)
             m, n = size(A)
             lda  = max(1,stride(A, 2))

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -136,7 +136,6 @@ lu!(A::StridedMatrix, pivot::Union{RowMaximum,NoPivot,RowNonZero} = lupivottype(
     generic_lufact!(A, pivot; check = check)
 function generic_lufact!(A::StridedMatrix{T}, pivot::Union{RowMaximum,NoPivot,RowNonZero} = lupivottype(T);
                          check::Bool = true) where {T}
-   
     LAPACK.chkfinite(A)
     # Extract values
     m, n = size(A)

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -136,6 +136,8 @@ lu!(A::StridedMatrix, pivot::Union{RowMaximum,NoPivot,RowNonZero} = lupivottype(
     generic_lufact!(A, pivot; check = check)
 function generic_lufact!(A::StridedMatrix{T}, pivot::Union{RowMaximum,NoPivot,RowNonZero} = lupivottype(T);
                          check::Bool = true) where {T}
+   
+    LAPACK.chkfinite(A)
     # Extract values
     m, n = size(A)
     minmn = min(m,n)

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -238,6 +238,15 @@ end
     @test pinv(M,rtol=0.5)== M
 end
 
+@testset "Test inv of matrix of NaNs" begin
+    for eltya in (NaN16, NaN32, NaN32)
+        r = fill(eltya, 2, 2)
+        @test_throws ArgumentError inv(r)
+        c = fill(complex(eltya, eltya), 2, 2)
+        @test_throws ArgumentError inv(c)
+    end
+end
+
 @testset "test out of bounds triu/tril" begin
     local m, n = 5, 7
     ainit = rand(m, n)

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -445,6 +445,7 @@ Base.:-(a::ModInt{n}) where {n} = ModInt{n}(-a.k)
 Base.inv(a::ModInt{n}) where {n} = ModInt{n}(invmod(a.k, n))
 Base.:/(a::ModInt{n}, b::ModInt{n}) where {n} = a*inv(b)
 
+Base.isfinite(a::ModInt{n}) where {n} = isfinite(a.k)
 Base.zero(::Type{ModInt{n}}) where {n} = ModInt{n}(0)
 Base.zero(::ModInt{n}) where {n} = ModInt{n}(0)
 Base.one(::Type{ModInt{n}}) where {n} = ModInt{n}(1)

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -440,4 +440,13 @@ end
     @test length(b) == 4
 end
 
+@testset "NaN matrix should throw error" begin
+    for eltya in (NaN16, NaN32, NaN64, BigFloat(NaN))
+        r = fill(eltya, 2, 3)
+        c = fill(complex(eltya, eltya), 2, 3)
+        @test_throws ArgumentError lu(r)
+        @test_throws ArgumentError lu(c)
+    end
+end
+
 end # module TestLU

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -252,6 +252,14 @@ end
                         end
                     end
                 end
+                if eltya <: AbstractFloat
+                @testset "inv should error with NaNs/Infs" begin
+                    h = Hermitian(fill(eltya(NaN), 2, 2))
+                    @test_throws ArgumentError inv(h)
+                    s = Symmetric(fill(eltya(NaN), 2, 2))
+                    @test_throws ArgumentError inv(s)
+                end
+                end
             end
 
             # Revisit when implemented in julia

--- a/stdlib/LinearAlgebra/test/trickyarithmetic.jl
+++ b/stdlib/LinearAlgebra/test/trickyarithmetic.jl
@@ -8,12 +8,15 @@ module TrickyArithmetic
     Base.convert(::Type{A}, i::Int) = A(i)
     Base.zero(::Union{A, Type{A}}) = A(0)
     Base.one(::Union{A, Type{A}}) = A(1)
+    Base.isfinite(a::A) = isfinite(a.x)
     struct B
         x::Int
     end
     struct C
         x::Int
     end
+    Base.isfinite(b::B) = isfinite(b.x)
+    Base.isfinite(c::C) = isfinite(c.x)
     C(a::A) = C(a.x)
     Base.zero(::Union{C, Type{C}}) = C(0)
     Base.one(::Union{C, Type{C}}) = C(1)
@@ -40,6 +43,7 @@ module TrickyArithmetic
     Base.:(*)(a::Union{A,B,C}, b::D) = b * a
     Base.inv(a::Union{A,B,C}) = A(1) / a
     Base.inv(a::D) = a.d / a.n
+    Base.isfinite(a::D) = isfinite(a.n) && isfinite(a.d)
     Base.:(/)(a::Union{A,B,C}, b::Union{A,B,C}) = D(a, b)
     Base.:(/)(a::D, b::Union{A,B,C}) = a.n / (a.d*b)
     Base.:(/)(a::Union{A,B,C,D}, b::D) = a * inv(b)


### PR DESCRIPTION
It seems odd to me that:

```julia
julia> using LinearAlgebra

julia> h = Hermitian(fill(complex(NaN), 2, 2));

julia> inv(h)
2×2 Hermitian{ComplexF64, Matrix{ComplexF64}}:
 NaN+0.0im   NaN+NaN*im
 NaN+NaN*im  NaN+0.0im
```
Runs no problemo. At least for Hermitians or square matrices, if `eigen` errors shouldn't `inv` as well?