### PR TITLE
Make @specialize actually work if the module was @nospecialize'd

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -7837,3 +7837,11 @@ fvarargN(x::Tuple{Vararg{Int, N}}) where {N} = N
 fvarargN(args...) = fvarargN(args)
 finvokevarargN() = Base.inferencebarrier(fvarargN)(1, 2, 3)
 @test finvokevarargN() == 3
+
+# Make sure that @specialize actually overrides a module annotation
+module SpecializeModuleTest
+    @nospecialize
+    f(@specialize(x), y) = 2
+    @specialize
+end
+@test methods(SpecializeModuleTest.f)[1].nospecialize & 0b11 == 0b10


### PR DESCRIPTION
In compiler/tfuncs.jl, we're assuming that after a `@nospecialize` at top level, a subsequent `@specialize` on the argument will override the toplevel `@nospecialize` (just like an argument-level `@nospecialize` overrides a toplevel `@specialize`). However, it turns out we never implemented that support, so the annotation was silently ignored. Fix that and add a test.

@nanosoldier `runbenchmarks("inference", vs=":master")`