### PR TITLE
Remove complexity and ambiguity from function example

### DIFF
--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -716,23 +716,20 @@ string of those integers in a date format; instead of having the user pass the m
 we can make them optional by giving default values to them as `1`. This behavior can be expressed
 concisely as:
 
-```jldoctest
+```jldoctest datefunc
 julia> function date(year::Int, month::Int=1, day::Int=1)
            y = clamp(year,  1:typemax(Int))
            m = clamp(month, 1:12)
            d = clamp(day,   1:31)
-           
            if m == 2
-               leap_year = ((y%4 == 0) && (y%100 ≠ 0)) || (y%400 == 0) 
-               leap_year ? d = clamp(d, 1:29) : d = clamp(d, 1:28)
+               is_leap_year = ((y%4 == 0) && (y%100 ≠ 0)) || (y%400 == 0)
+               is_leap_year ? d = clamp(d, 1:29) : d = clamp(d, 1:28)
            elseif m in [4, 6, 9, 11]
                d = clamp(d, 1:30)
            end
-           
            yy = string(y, pad=4)
            mm = string(m, pad=2)
            dd = string(d, pad=2)
-           
            return "$yy-$mm-$dd"
        end
 date (generic function with 3 methods)
@@ -744,7 +741,7 @@ we have a function named `date`, and there are 3 "versions" (i.e. methods) of it
 With this definition, the function can be called with either one, two or three arguments, and
 `1` is automatically passed when only one or two of the arguments are specified:
 
-```jldoctest
+```jldoctest datefunc
 julia> date(2023, 2, 32)
 "2023-02-28"
 
@@ -759,7 +756,7 @@ Optional arguments are actually just a convenient syntax for writing multiple me
 with different numbers of arguments (see [Note on Optional and keyword Arguments](@ref)).
 This can be checked for our `date` function example by calling `methods` function:
 
-```julia
+```julia datefunc
 julia> methods(date)
 # 3 methods for generic function "date":
 [1] date(year::Int64) in Main at REPL[1]:1

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -727,9 +727,6 @@ julia> function date(y::Int64, m::Int64=1, d::Int64=1)
 date (generic function with 3 methods)
 ```
 
-Note how the signature says **"date (generic function with 3 methods)"**, denoting that
-we have a function named `date`, and there are 3 "versions" (i.e. methods) of it.
-
 With this definition, the function can be called with either one, two or three arguments, and
 `1` is automatically passed when only one or two of the arguments are specified:
 

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -709,12 +709,9 @@ call will fail, just as it would if too many arguments were given explicitly.
 
 ## Optional Arguments
 
-It is often possible to provide sensible default values for function arguments.
-This can save users from having to pass every argument on every call.
-For example, suppose we want to create a simple function to take in integers and then return a
-string of those integers in a date format; instead of having the user pass the month and day always,
-we can make them optional by giving default values to them as `1`. This behavior can be expressed
-concisely as:
+For example, the function [`Date(y, [m, d])`](@ref) from `Dates` module constructs a `Date` type for
+a given year `y`, month `m` and day `d`. However, `m` and `d` arguments are optional and their default
+value is `1`. This behavior can be expressed concisely as:
 
 ```julia-repl
 julia> using Dates

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -709,9 +709,12 @@ call will fail, just as it would if too many arguments were given explicitly.
 
 ## Optional Arguments
 
-For example, the function [`Date(y, [m, d])`](@ref) from `Dates` module constructs a `Date` type for
-a given year `y`, month `m` and day `d`. However, `m` and `d` arguments are optional and their default
-value is `1`. This behavior can be expressed concisely as:
+It is often possible to provide sensible default values for function arguments.
+This can save users from having to pass every argument on every call.
+For example, the function [`Date(y, [m, d])`](@ref)
+from `Dates` module constructs a `Date` type for a given year `y`, month `m` and day `d`.
+However, `m` and `d` arguments are optional and their default value is `1`.
+This behavior can be expressed concisely as:
 
 ```julia-repl
 julia> using Dates
@@ -723,6 +726,9 @@ julia> function date(y::Int64, m::Int64=1, d::Int64=1)
        end
 date (generic function with 3 methods)
 ```
+
+Observe, that this definition calls another method of the `Date` function that takes one argument
+of type `UTInstant{Day}`.
 
 With this definition, the function can be called with either one, two or three arguments, and
 `1` is automatically passed when only one or two of the arguments are specified:

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -716,7 +716,7 @@ from `Dates` module constructs a `Date` type for a given year `y`, month `m` and
 However, `m` and `d` arguments are optional and their default value is `1`.
 This behavior can be expressed concisely as:
 
-```julia-repl
+```jldoctest date_default_args
 julia> using Dates
 
 julia> function date(y::Int64, m::Int64=1, d::Int64=1)
@@ -733,7 +733,7 @@ of type `UTInstant{Day}`.
 With this definition, the function can be called with either one, two or three arguments, and
 `1` is automatically passed when only one or two of the arguments are specified:
 
-```julia-repl
+```jldoctest date_default_args
 julia> date(2000, 12, 12)
 2000-12-12
 

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -758,10 +758,10 @@ This can be checked for our `date` function example by calling `methods` functio
 
 ```jldoctest datefunc
 julia> methods(date)
-# 3 methods for generic function "date":
-[1] date(year::Int64) in Main at REPL[1]:1
-[2] date(year::Int64, month::Int64) in Main at REPL[1]:1
-[3] date(year::Int64, month::Int64, day::Int64) in Main at REPL[1]:1
+# 3 methods for generic function "date" from Main:
+[1] date(year::Int64) @ none:1
+[2] date(year::Int64, month::Int64) @ none:1
+[3] date(year::Int64, month::Int64, day::Int64) @ none:1
 ```
 
 ## Keyword Arguments

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -723,8 +723,10 @@ julia> function date(year::Int, month::Int=1, day::Int=1)
            d = clamp(day,   1:31)
            
            if m == 2
-           leap_year = ((y%4 == 0) && (y%100 ≠ 0)) || (y%400 == 0) 
-           leap_year ? d = clamp(d, 1:29) : d = clamp(d, 1:28)
+               leap_year = ((y%4 == 0) && (y%100 ≠ 0)) || (y%400 == 0) 
+               leap_year ? d = clamp(d, 1:29) : d = clamp(d, 1:28)
+           elseif m in [4, 6, 9, 11]
+               d = clamp(d, 1:30)
            end
            
            yy = string(y, pad=4)

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -716,21 +716,13 @@ string of those integers in a date format; instead of having the user pass the m
 we can make them optional by giving default values to them as `1`. This behavior can be expressed
 concisely as:
 
-```jldoctest datefunc
-julia> function date(year::Int, month::Int=1, day::Int=1)
-           y = clamp(year,  1:typemax(Int))
-           m = clamp(month, 1:12)
-           d = clamp(day,   1:31)
-           if m == 2
-               is_leap_year = ((y%4 == 0) && (y%100 ≠ 0)) || (y%400 == 0)
-               is_leap_year ? d = clamp(d, 1:29) : d = clamp(d, 1:28)
-           elseif m in [4, 6, 9, 11]
-               d = clamp(d, 1:30)
-           end
-           yy = string(y, pad=4)
-           mm = string(m, pad=2)
-           dd = string(d, pad=2)
-           return "$yy-$mm-$dd"
+```julia-repl
+julia> using Dates
+
+julia> function date(y::Int64, m::Int64=1, d::Int64=1)
+           err = Dates.validargs(Date, y, m, d)
+           err === nothing || throw(err)
+           return Date(Dates.UTD(Dates.totaldays(y, m, d)))
        end
 date (generic function with 3 methods)
 ```
@@ -741,27 +733,27 @@ we have a function named `date`, and there are 3 "versions" (i.e. methods) of it
 With this definition, the function can be called with either one, two or three arguments, and
 `1` is automatically passed when only one or two of the arguments are specified:
 
-```jldoctest datefunc
-julia> date(2023, 2, 32)
-"2023-02-28"
+```julia-repl
+julia> date(2000, 12, 12)
+2000-12-12
 
-julia> date(2023, 2)
-"2023-02-01"
+julia> date(2000, 12)
+2000-12-01
 
-julia> date(2023)
-"2023-01-01"
+julia> date(2000)
+2000-01-01
 ```
 
 Optional arguments are actually just a convenient syntax for writing multiple method definitions
 with different numbers of arguments (see [Note on Optional and keyword Arguments](@ref)).
-This can be checked for our `date` function example by calling `methods` function:
+This can be checked for our `date` function example by calling the `methods` function:
 
-```jldoctest datefunc
+```julia-repl
 julia> methods(date)
-# 3 methods for generic function "date" from Main:
-[1] date(year::Int64) @ none:1
-[2] date(year::Int64, month::Int64) @ none:1
-[3] date(year::Int64, month::Int64, day::Int64) @ none:1
+# 3 methods for generic function "date":
+[1] date(y::Int64) in Main at REPL[1]:1
+[2] date(y::Int64, m::Int64) in Main at REPL[1]:1
+[3] date(y::Int64, m::Int64, d::Int64) in Main at REPL[1]:1
 ```
 
 ## Keyword Arguments

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -718,7 +718,7 @@ concisely as:
 
 ```jldoctest
 julia> function date(year::Int, month::Int=1, day::Int=1)
-           y = clamp(year,  1:2023)
+           y = clamp(year,  1:typemax(Int))
            m = clamp(month, 1:12)
            d = clamp(day,   1:31)
            

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -711,41 +711,59 @@ call will fail, just as it would if too many arguments were given explicitly.
 
 It is often possible to provide sensible default values for function arguments.
 This can save users from having to pass every argument on every call.
-For example, the function [`Date(y, [m, d])`](@ref)
-from `Dates` module constructs a `Date` type for a given year `y`, month `m` and day `d`.
-However, `m` and `d` arguments are optional and their default value is `1`.
-This behavior can be expressed concisely as:
+For example, suppose we want to create a simple function to take in integers and then return a
+string of those integers in a date format; instead of having the user pass the month and day always,
+we can make them optional by giving default values to them as `1`. This behavior can be expressed
+concisely as:
 
-```julia
-function Date(y::Int64, m::Int64=1, d::Int64=1)
-    err = validargs(Date, y, m, d)
-    err === nothing || throw(err)
-    return Date(UTD(totaldays(y, m, d)))
-end
+```jldoctest
+julia> function date(year::Int, month::Int=1, day::Int=1)
+           y = clamp(year,  1:2023)
+           m = clamp(month, 1:12)
+           d = clamp(day,   1:31)
+           
+           if m == 2
+           leap_year = ((y%4 == 0) && (y%100 ≠ 0)) || (y%400 == 0) 
+           leap_year ? d = clamp(d, 1:29) : d = clamp(d, 1:28)
+           end
+           
+           yy = string(y, pad=4)
+           mm = string(m, pad=2)
+           dd = string(d, pad=2)
+           
+           return "$yy-$mm-$dd"
+       end
+date (generic function with 3 methods)
 ```
 
-Observe, that this definition calls another method of the `Date` function that takes one argument
-of type `UTInstant{Day}`.
+Note how the signature says **"date (generic function with 3 methods)"**, denoting that
+we have a function named `date`, and there are 3 "versions" (i.e. methods) of it.
 
 With this definition, the function can be called with either one, two or three arguments, and
 `1` is automatically passed when only one or two of the arguments are specified:
 
 ```jldoctest
-julia> using Dates
+julia> date(2023, 2, 32)
+"2023-02-28"
 
-julia> Date(2000, 12, 12)
-2000-12-12
+julia> date(2023, 2)
+"2023-02-01"
 
-julia> Date(2000, 12)
-2000-12-01
-
-julia> Date(2000)
-2000-01-01
+julia> date(2023)
+"2023-01-01"
 ```
 
 Optional arguments are actually just a convenient syntax for writing multiple method definitions
 with different numbers of arguments (see [Note on Optional and keyword Arguments](@ref)).
-This can be checked for our `Date` function example by calling `methods` function.
+This can be checked for our `date` function example by calling `methods` function:
+
+```julia
+julia> methods(date)
+# 3 methods for generic function "date":
+[1] date(year::Int64) in Main at REPL[1]:1
+[2] date(year::Int64, month::Int64) in Main at REPL[1]:1
+[3] date(year::Int64, month::Int64, day::Int64) in Main at REPL[1]:1
+```
 
 ## Keyword Arguments
 

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -756,7 +756,7 @@ Optional arguments are actually just a convenient syntax for writing multiple me
 with different numbers of arguments (see [Note on Optional and keyword Arguments](@ref)).
 This can be checked for our `date` function example by calling `methods` function:
 
-```julia datefunc
+```jldoctest datefunc
 julia> methods(date)
 # 3 methods for generic function "date":
 [1] date(year::Int64) in Main at REPL[1]:1


### PR DESCRIPTION
IMO, the current example on the [Optional Arguments](https://docs.julialang.org/en/v1/manual/functions/#Optional-Arguments) section of the [function section of the documentation](https://docs.julialang.org/en/v1/manual/functions/) is too complex and it introduces a lot of ambiguity for people following up with the docs from the beginning to the function section.

My reasons are as follows:
1. It introduces too much of another section of the docs into a section, when nothing was said yet about the former section. The section on **"Modules"** is introduced into the **"Functions"** section, when nothing has been said yet about modules. This then goes on to introduce a few noteworthy things:
    - for users reading the documentation stage by stage from the beginning or complete beginners to programming, they can't understand or follow up with the example, to see what's happening inside the function.

2. The example itself isn't complete and can't be copied and pasted into the REPL to see what's happening, causing more confusion for beginners:
```julia
julia> function Date(y::Int64, m::Int64=1, d::Int64=1)
           err = validargs(Date, y, m, d)
           err === nothing || throw(err)
           return Date(UTD(totaldays(y, m, d)))
       end
Date (generic function with 3 methods)

julia> using Dates
WARNING: using Dates.Date in module Main conflicts with an existing identifier.

julia> Date(2000, 12, 12)
ERROR: UndefVarError: validargs not defined

julia> Date(2000, 12)
ERROR: UndefVarError: validargs not defined

julia> Date(2000)
ERROR: UndefVarError: validargs not defined
```

3. The statement made here in that section: **"Observe, that this definition calls another method of the Date function that takes one argument of type UTInstant{Day}."**. For users not exposed to the `Date` module yet, this isn't understand and people can't follow up with it.

4. Then there is a closing statement there: **"This can be checked for our Date function example by calling methods function."** An example wasn't provided for this, which is understand as the `Date` isn't a **"real"** function. Using a custom method will enable showing this right away and then users can see what's being said.

My point is this: Since this is talking about **"Optional Arguments"** and its introducing functions to beginners of programming, giving a simple function with optional arguments would enable beginners and people reading the docs stage by stage easily follow with the example.