### PR TITLE
type_lift_pass: Don't introduce unnecessary phi nodes

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1214,6 +1214,13 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
             label = compact.bb_rename_succ[stmt.args[1]::Int]
             @assert label > 0
             stmt.args[1] = label
+        elseif isexpr(stmt, :throw_undef_if_not)
+            cond = stmt.args[2]
+            if isa(cond, Bool) && cond === true
+                # cond was folded to true - this statement
+                # is dead.
+                return result_idx
+            end
         end
         result[result_idx][:inst] = stmt
         result_idx += 1

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -220,6 +220,9 @@ function reprocess_instruction!(interp::AbstractInterpreter,
             if mi′ !== irsv.mi # prevent infinite loop
                 rt = concrete_eval_invoke(interp, inst, mi′, irsv)
             end
+        elseif inst.head === :throw_undef_if_not
+            # TODO: Terminate interpretation early if known false?
+            return false
         else
             ccall(:jl_, Cvoid, (Any,), inst)
             error()


### PR DESCRIPTION
Try to avoid introducing phi nodes whos edges all have the same value. This cuts down the generated IR a bit and exposes more optimization opportunities. While we're at it, also allow IncrementalCompact to fold :throw_undef_if_not nodes with constant condition (which happen more frequently now, since a condition that is proven defined on all reachable paths now has some chance to end up as a constant condition rather than a PhiNode SSAValue).