### PR TITLE
Do not use Stateful for cmp of AbstractString

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -300,7 +300,7 @@ function cmp(a::AbstractString, b::AbstractString)
     a === b && return 0
     (iv1, iv2) = (iterate(a), iterate(b))
     while iv1 !== nothing && iv2 !== nothing
-        (c, d) = (first(iv1), first(iv2))
+        (c, d) = (first(iv1)::AbstractChar, first(iv2)::AbstractChar)
         c ≠ d && return ifelse(c < d, -1, 1)
         (iv1, iv2) = (iterate(a, last(iv1)), iterate(b, last(iv2)))
     end

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -298,12 +298,13 @@ julia> cmp("b", "β")
 """
 function cmp(a::AbstractString, b::AbstractString)
     a === b && return 0
-    a, b = Iterators.Stateful(a), Iterators.Stateful(b)
-    for (c::AbstractChar, d::AbstractChar) in zip(a, b)
+    (iv1, iv2) = (iterate(a), iterate(b))
+    while iv1 !== nothing && iv2 !== nothing
+        (c, d) = (first(iv1), first(iv2))
         c ≠ d && return ifelse(c < d, -1, 1)
+        (iv1, iv2) = (iterate(a, last(iv1)), iterate(b, last(iv2)))
     end
-    isempty(a) && return ifelse(isempty(b), 0, -1)
-    return 1
+    return iv1 === nothing ? (iv2 === nothing ? 0 : -1) : 1
 end
 
 """


### PR DESCRIPTION
PR #45924 fixed length of `Stateful`, but this change requires `Stateful` to call
`length` on its wrapped iterator on instantiation.
The current implementation of `cmp(::AbstractString, ::AbstractString)` wraps the
strings in `Stateful` to efficiently check if one string is longer than the other
without needing an O(N) call to `length`.
However, with #45924 this length call is done anyway, which led to a performance
regression.

In this PR, the `cmp` method is changed so it no longer relies on `Stateful` to do
the same thing.

Fix #46719

Note to reviewers: I agree that it's not ideal that `Stateful` now calls `l`ength on instantiation. But I can't think of a way to ensure correct behaviour of `Stateful` without doing that. Furthermore, since `Stateful` now (after #45924) caches the `length` call, `Stateful` is only slower in the case where `length` is slow to compute and it's not called, as is the case for this particular `cmp` method.