### PR TITLE
Fix IteratorSize for zip of mixed shapes

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -76,6 +76,7 @@ end
 and_iteratorsize(isz::T, ::T) where {T} = isz
 and_iteratorsize(::HasLength, ::HasShape) = HasLength()
 and_iteratorsize(::HasShape, ::HasLength) = HasLength()
+and_iteratorsize(::HasShape{A}, ::HasShape{B}) where {A, B} = HasLength()
 and_iteratorsize(a, b) = SizeUnknown()
 
 and_iteratoreltype(iel::T, ::T) where {T} = iel

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -77,6 +77,7 @@ and_iteratorsize(isz::T, ::T) where {T} = isz
 and_iteratorsize(::HasLength, ::HasShape) = HasLength()
 and_iteratorsize(::HasShape, ::HasLength) = HasLength()
 and_iteratorsize(::HasShape{A}, ::HasShape{B}) where {A, B} = HasLength()
+and_iteratorsize(::HasShape{A}, ::HasShape{A}) where A = HasShape{A}()
 and_iteratorsize(a, b) = SizeUnknown()
 
 and_iteratoreltype(iel::T, ::T) where {T} = iel

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -961,6 +961,7 @@ end
     @test Base.IteratorSize(zip(repeated(0), 1:5 )) == Base.HasLength()     # for zip of ::IsInfinite and ::HasShape
     @test Base.IteratorSize(zip((1,2,3), 1:5) ) == Base.HasLength()         # for zip of ::HasLength and ::HasShape
     @test Base.IteratorSize(zip(1:5, (1,2,3)) ) == Base.HasLength()         # for zip of ::HasShape and ::HasLength
+    @test Base.IteratorSize(zip(1:3, rand(3, 3))) == Base.HasLength()       # for zip of two different ::HasShape
 end
 
 @testset "proper patition for non-1-indexed vector" begin

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -962,6 +962,7 @@ end
     @test Base.IteratorSize(zip((1,2,3), 1:5) ) == Base.HasLength()         # for zip of ::HasLength and ::HasShape
     @test Base.IteratorSize(zip(1:5, (1,2,3)) ) == Base.HasLength()         # for zip of ::HasShape and ::HasLength
     @test Base.IteratorSize(zip(1:3, rand(3, 3))) == Base.HasLength()       # for zip of two different ::HasShape
+    @test Base.IteratorSize(zip(rand(3, 3), rand(3, 3))) == Base.HasShape{2}() # for same shape
 end
 
 @testset "proper patition for non-1-indexed vector" begin


### PR DESCRIPTION
Now make e.g. `zip([1], rand(2,2))` have `HasShape` instead of `SizeUnknown`. Discovered by Michael Abbott.