### PR TITLE
Profile: save a heap snapshot after a profile peek via SIGUSR1/SIGINFO (via opt-in)

### DIFF
--- a/stdlib/Profile/docs/src/index.md
+++ b/stdlib/Profile/docs/src/index.md
@@ -34,6 +34,9 @@ First, a single stack trace at the instant that the signal was thrown is shown, 
 followed by the profile report at the next yield point, which may be at task completion for code without yield points
 e.g. tight loops.
 
+Optionally set environment variable `JULIA_PROFILE_PEEK_HEAP_SNAPSHOT` to `1` to also automatically collect a
+[heap snapshot](@ref Heap-Snapshots).
+
 ```julia-repl
 julia> foo()
 ##== the user sends a trigger while foo is running ==##

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -38,8 +38,8 @@ function profile_printing_listener()
         while true
             wait(PROFILE_PRINT_COND[])
             peek_report[]()
-            if get(ENV, "JULIA_PROFILE_PEEK_HEAP_SNAPSHOT", "false") == "true"
-                println("Saving heap snapshot (`JULIA_PROFILE_PEEK_HEAP_SNAPSHOT=true`)")
+            if get(ENV, "JULIA_PROFILE_PEEK_HEAP_SNAPSHOT", nothing) === "1"
+                println("Saving heap snapshot...")
                 fname = take_heap_snapshot()
                 println("Heap snapshot saved to `$(fname)`")
             end


### PR DESCRIPTION
If the user is backed into a situation where the SIGUSR1/SIGINFO profile peek is useful, grabbing a heap snapshot may also be.

An env var is exposed to turn it off, although I guess that won't take effect with an already running julia process.

Needs docs and tests if approved.