### PR TITLE
irshow: Fix CFG display with directly inserted new nodes

### DIFF
--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -918,9 +918,11 @@ function show_ir(io::IO, compact::IncrementalCompact, config::IRShowConfig=defau
             end
         end
 
+        still_to_be_inserted = (last(input_bb.stmts) - compact.idx) + count
+
         result_bb = result_bbs[compact.active_result_bb]
         result_bbs[compact.active_result_bb] = Core.Compiler.BasicBlock(result_bb,
-            Core.Compiler.StmtRange(first(result_bb.stmts), last(result_bb.stmts)+count))
+            Core.Compiler.StmtRange(first(result_bb.stmts), compact.result_idx+still_to_be_inserted))
     end
     compact_cfg = CFG(result_bbs, Int[first(result_bbs[i].stmts) for i in 2:length(result_bbs)])
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -2502,10 +2502,20 @@ end
     # compact
     compact = Core.Compiler.IncrementalCompact(ir)
     verify_display(compact)
+
+    # Compact the first instruction
     state = Core.Compiler.iterate(compact)
-    while state !== nothing
+
+    # Insert some instructions here
+    for i in 1:2
+        inst = Core.Compiler.NewInstruction(Expr(:call, :identity, i), Int, Int32(1))
+        Core.Compiler.insert_node_here!(compact, inst)
         verify_display(compact)
+    end
+
+    while state !== nothing
         state = Core.Compiler.iterate(compact, state[2])
+        verify_display(compact)
     end
 
     # complete


### PR DESCRIPTION
Slight fix to #47043 for the case where nodes where inserted using `insert_node_here!`.