### PR TITLE
Revert "type_lift_pass: Don't introduce unnecessary phi nodes"

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1214,13 +1214,6 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
             label = compact.bb_rename_succ[stmt.args[1]::Int]
             @assert label > 0
             stmt.args[1] = label
-        elseif isexpr(stmt, :throw_undef_if_not)
-            cond = stmt.args[2]
-            if isa(cond, Bool) && cond === true
-                # cond was folded to true - this statement
-                # is dead.
-                return result_idx
-            end
         end
         result[result_idx][:inst] = stmt
         result_idx += 1

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -220,9 +220,6 @@ function reprocess_instruction!(interp::AbstractInterpreter,
             if mi′ !== irsv.mi # prevent infinite loop
                 rt = concrete_eval_invoke(interp, inst, mi′, irsv)
             end
-        elseif inst.head === :throw_undef_if_not
-            # TODO: Terminate interpretation early if known false?
-            return false
         else
             ccall(:jl_, Cvoid, (Any,), inst)
             error()

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1727,8 +1727,6 @@ function type_lift_pass!(ir::IRCode)
                         first = false
                     end
                     local id::Int = 0
-                    all_same = true
-                    local last_val
                     for i = 1:length(values)
                         if !isassigned(def.values, i)
                             val = false
@@ -1769,25 +1767,17 @@ function type_lift_pass!(ir::IRCode)
                             end
                         end
                         if isa(def, PhiNode)
-                            if !@isdefined(last_val)
-                                last_val = val
-                            elseif all_same
-                                all_same &= last_val === val
-                            end
                             values[i] = val
                         else
                             values[i] = insert_node!(ir, up_id, NewInstruction(UpsilonNode(val), Bool))
                         end
                     end
-                    if all_same && @isdefined(last_val)
-                        # Decay the PhiNode back to the single value
-                        ir[new_phi][:inst] = last_val
-                    end
                     if which !== SSAValue(0)
                         phi = ir[which][:inst]
                         if isa(phi, PhiNode)
                             phi.values[use] = new_phi
-                        elseif isa(phi, PhiCNode)
+                        else
+                            phi = phi::PhiCNode
                             phi.values[use] = insert_node!(ir, w_up_id, NewInstruction(UpsilonNode(new_phi), Bool))
                         end
                     end


### PR DESCRIPTION
Reverts JuliaLang/julia#47119 due to https://github.com/JuliaLang/julia/issues/47127

I don't know quite enough about to fix it, though perhaps it is just missing an `all_same = false` in the else side of the branch that sets `all_same` usually?