### PR TITLE
Improve the memory profiler documentation

### DIFF
--- a/doc/src/manual/profile.md
+++ b/doc/src/manual/profile.md
@@ -346,7 +346,7 @@ allocation while it is running. It can be invoked with
 This information about the allocations is returned as an array of `Alloc`
 objects, wrapped in an `AllocResults` object. The best way to visualize
 these is currently with the [PProf.jl](https://github.com/JuliaPerf/PProf.jl)
-library, which can visualize the call stacks which are making the most
+package, which can visualize the call stacks which are making the most
 allocations.
 
 The allocation profiler does have significant overhead, so a `sample_rate`
@@ -362,7 +362,7 @@ Passing `sample_rate=1.0` will make it record everything (which is slow);
     `Profile.Allocs.UnknownType`.
 
     You can read more about the missing types and the plan to improve this, here:
-    https://github.com/JuliaLang/julia/issues/43688.
+    <https://github.com/JuliaLang/julia/issues/43688>.
 
 ## External Profiling
 

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -47,6 +47,10 @@ julia> last(sort(results.allocs, by=x->x.size))
 Profile.Allocs.Alloc(Vector{Any}, Base.StackTraces.StackFrame[_new_array_ at array.c:127, ...], 5576)
 ```
 
+The best way to visualize these is currently with the
+[PProf.jl](https://github.com/JuliaPerf/PProf.jl) package,
+by invoking `PProf.Allocs.pprof`.
+
 !!! note
     The current implementation of the Allocations Profiler does not
     capture types for all allocations. Allocations for which the profiler
@@ -54,7 +58,7 @@ Profile.Allocs.Alloc(Vector{Any}, Base.StackTraces.StackFrame[_new_array_ at arr
     `Profile.Allocs.UnknownType`.
 
     You can read more about the missing types and the plan to improve this, here:
-    https://github.com/JuliaLang/julia/issues/43688.
+    <https://github.com/JuliaLang/julia/issues/43688>.
 
 !!! compat "Julia 1.8"
     The allocation profiler was added in Julia 1.8.


### PR DESCRIPTION
- PProf is a package, not a library
- mention PProf in the docstring and say how to invoke it
- turn URLs into markdown links
