### PR TITLE
fix bug in --strip-ir when fields are replaced with NULL

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1079,8 +1079,8 @@ static void jl_write_values(jl_serializer_state *s)
                 if (fld != NULL) {
                     arraylist_push(&s->relocs_list, (void*)(uintptr_t)(offset + reloc_offset)); // relocation location
                     arraylist_push(&s->relocs_list, (void*)backref_id(s, fld)); // relocation target
-                    memset(&s->s->buf[offset + reloc_offset], 0, sizeof(fld)); // relocation offset (none)
                 }
+                memset(&s->s->buf[offset + reloc_offset], 0, sizeof(fld)); // relocation offset (none)
             }
 
             // A few objects need additional handling beyond the generic serialization above


### PR DESCRIPTION
In this case the replacement is NULL but the original value is not, so we still need to zero out the field data.