### PR TITLE
Implement `jl_rec_backtrace` for ASM/SETJMP on FreeBSD

### DIFF
--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -1055,7 +1055,7 @@ void jl_rec_backtrace(jl_task_t *t)
     sigjmp_buf *mctx = &t->ctx.ctx.uc_mcontext;
     mcontext_t *mc = &c.uc_mcontext;
     // https://github.com/freebsd/freebsd-src/blob/releng/13.1/lib/libc/amd64/gen/_setjmp.S
-    mc->mc_rdx = ((long*)mctx)[0];
+    mc->mc_rip = ((long*)mctx)[0];
     mc->mc_rbx = ((long*)mctx)[1];
     mc->mc_rsp = ((long*)mctx)[2];
     mc->mc_rbp = ((long*)mctx)[3];

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -1051,6 +1051,19 @@ void jl_rec_backtrace(jl_task_t *t)
     (void)mctx;
     (void)c;
   #endif
+ #elif defined(_OS_FREEBSD_) && defined(_CPU_X86_64_)
+    sigjmp_buf *mctx = &t->ctx.ctx.uc_mcontext;
+    mcontext_t *mc = &c.uc_mcontext;
+    // https://github.com/freebsd/freebsd-src/blob/releng/13.1/lib/libc/amd64/gen/_setjmp.S
+    mc->mc_rdx = ((long*)mctx)[0];
+    mc->mc_rbx = ((long*)mctx)[1];
+    mc->mc_rsp = ((long*)mctx)[2];
+    mc->mc_rbp = ((long*)mctx)[3];
+    mc->mc_r12 = ((long*)mctx)[4];
+    mc->mc_r13 = ((long*)mctx)[5];
+    mc->mc_r14 = ((long*)mctx)[6];
+    mc->mc_r15 = ((long*)mctx)[7];
+    context = &c;
  #else
   #pragma message("jl_rec_backtrace not defined for ASM/SETJMP on unknown system")
   (void)c;


### PR DESCRIPTION
This removes the message emitted while compiling on FreeBSD that says it isn't supported.

That said, while the code compiles without issue, I'm not certain it's actually correct. It seems `jl_rec_backtrace` is only used in `jlbacktracet`, which is listed among the GDB utilities, so perhaps GDB (or LLDB?) could be used to check against the result on another system. I'd just need some guidance for how to do so as I'm generally unfamiliar with this part of the code.