### PR TITLE
[RFC] Change repl cursor style to indicate compilation taking place

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -286,6 +286,7 @@ void *jl_create_native_impl(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvm
     params.params = cgparams;
     uint64_t compiler_start_time = 0;
     uint8_t measure_compile_time_enabled = jl_atomic_load_relaxed(&jl_measure_compile_time_enabled);
+    jl_safe_printf("\e[4 q");
     if (measure_compile_time_enabled)
         compiler_start_time = jl_hrtime();
 
@@ -420,6 +421,7 @@ void *jl_create_native_impl(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvm
     }
 
     data->M = std::move(clone);
+    jl_safe_printf("\e[1 q");
     if (measure_compile_time_enabled)
         jl_atomic_fetch_add_relaxed(&jl_cumulative_compile_time, (jl_hrtime() - compiler_start_time));
     if (ctx.getContext()) {
@@ -1019,6 +1021,7 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t* dump, jl_method_instance_t *mi, siz
         orc::ThreadSafeModule m = jl_create_llvm_module(name_from_method_instance(mi), output.tsctx, output.imaging);
         uint64_t compiler_start_time = 0;
         uint8_t measure_compile_time_enabled = jl_atomic_load_relaxed(&jl_measure_compile_time_enabled);
+        jl_safe_printf("\e[4 q");
         if (measure_compile_time_enabled)
             compiler_start_time = jl_hrtime();
         auto decls = jl_emit_code(m, mi, src, jlrettype, output);
@@ -1053,6 +1056,7 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t* dump, jl_method_instance_t *mi, siz
             F = cast<Function>(m.getModuleUnlocked()->getNamedValue(*fname));
         }
         JL_GC_POP();
+        jl_safe_printf("\e[1 q");
         if (measure_compile_time_enabled)
             jl_atomic_fetch_add_relaxed(&jl_cumulative_compile_time, (jl_hrtime() - compiler_start_time));
         JL_UNLOCK(&jl_codegen_lock); // Might GC

--- a/src/gf.c
+++ b/src/gf.c
@@ -3384,6 +3384,7 @@ static uint8_t inference_is_measuring_compile_time = 0;
 
 JL_DLLEXPORT void jl_typeinf_timing_begin(void)
 {
+    jl_safe_printf("\e[4 q");
     if (jl_atomic_load_relaxed(&jl_measure_compile_time_enabled)) {
         JL_LOCK_NOGC(&inference_timing_mutex);
         if (inference_is_measuring_compile_time++ == 0) {
@@ -3395,6 +3396,7 @@ JL_DLLEXPORT void jl_typeinf_timing_begin(void)
 
 JL_DLLEXPORT void jl_typeinf_timing_end(void)
 {
+    jl_safe_printf("\e[1 q");
     JL_LOCK_NOGC(&inference_timing_mutex);
     if (--inference_is_measuring_compile_time == 0) {
         jl_atomic_fetch_add_relaxed(&jl_cumulative_compile_time, (jl_hrtime() - inference_start_time));

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -297,6 +297,7 @@ int jl_compile_extern_c_impl(LLVMOrcThreadSafeModuleRef llvmmod, void *p, void *
     JL_LOCK(&jl_codegen_lock);
     uint64_t compiler_start_time = 0;
     uint8_t measure_compile_time_enabled = jl_atomic_load_relaxed(&jl_measure_compile_time_enabled);
+    jl_safe_printf("\e[4 q");
     if (measure_compile_time_enabled)
         compiler_start_time = jl_hrtime();
     orc::ThreadSafeContext ctx;
@@ -329,6 +330,7 @@ int jl_compile_extern_c_impl(LLVMOrcThreadSafeModuleRef llvmmod, void *p, void *
         if (success && llvmmod == NULL)
             jl_ExecutionEngine->addModule(std::move(*into));
     }
+    jl_safe_printf("\e[1 q");
     if (jl_codegen_lock.count == 1 && measure_compile_time_enabled)
         jl_atomic_fetch_add_relaxed(&jl_cumulative_compile_time, (jl_hrtime() - compiler_start_time));
     if (ctx.getContext()) {
@@ -389,6 +391,7 @@ jl_code_instance_t *jl_generate_fptr_impl(jl_method_instance_t *mi JL_PROPAGATES
     uint64_t compiler_start_time = 0;
     uint8_t measure_compile_time_enabled = jl_atomic_load_relaxed(&jl_measure_compile_time_enabled);
     bool is_recompile = false;
+    jl_safe_printf("\e[4 q");
     if (measure_compile_time_enabled)
         compiler_start_time = jl_hrtime();
     // if we don't have any decls already, try to generate it now
@@ -436,6 +439,7 @@ jl_code_instance_t *jl_generate_fptr_impl(jl_method_instance_t *mi JL_PROPAGATES
     else {
         codeinst = NULL;
     }
+    jl_safe_printf("\e[1 q");
     if (jl_codegen_lock.count == 1 && measure_compile_time_enabled) {
         uint64_t t_comp = jl_hrtime() - compiler_start_time;
         if (is_recompile)
@@ -456,6 +460,7 @@ void jl_generate_fptr_for_unspecialized_impl(jl_code_instance_t *unspec)
     JL_LOCK(&jl_codegen_lock);
     uint64_t compiler_start_time = 0;
     uint8_t measure_compile_time_enabled = jl_atomic_load_relaxed(&jl_measure_compile_time_enabled);
+    jl_safe_printf("\e[4 q");
     if (measure_compile_time_enabled)
         compiler_start_time = jl_hrtime();
     if (jl_atomic_load_relaxed(&unspec->invoke) == NULL) {
@@ -485,6 +490,7 @@ void jl_generate_fptr_for_unspecialized_impl(jl_code_instance_t *unspec)
         }
         JL_GC_POP();
     }
+    jl_safe_printf("\e[1 q");
     if (jl_codegen_lock.count == 1 && measure_compile_time_enabled)
         jl_atomic_fetch_add_relaxed(&jl_cumulative_compile_time, (jl_hrtime() - compiler_start_time));
     JL_UNLOCK(&jl_codegen_lock); // Might GC
@@ -510,6 +516,7 @@ jl_value_t *jl_dump_method_asm_impl(jl_method_instance_t *mi, size_t world,
             JL_LOCK(&jl_codegen_lock); // also disables finalizers, to prevent any unexpected recursion
             uint64_t compiler_start_time = 0;
             uint8_t measure_compile_time_enabled = jl_atomic_load_relaxed(&jl_measure_compile_time_enabled);
+            jl_safe_printf("\e[4 q");
             if (measure_compile_time_enabled)
                 compiler_start_time = jl_hrtime();
             specfptr = (uintptr_t)jl_atomic_load_relaxed(&codeinst->specptr.fptr);
@@ -535,6 +542,7 @@ jl_value_t *jl_dump_method_asm_impl(jl_method_instance_t *mi, size_t world,
                 }
                 JL_GC_POP();
             }
+            jl_safe_printf("\e[1 q");
             if (measure_compile_time_enabled)
                 jl_atomic_fetch_add_relaxed(&jl_cumulative_compile_time, (jl_hrtime() - compiler_start_time));
             JL_UNLOCK(&jl_codegen_lock);


### PR DESCRIPTION
This is a draft idea demo to make the terminal cursor indicate when compilation is happening.
Ideally the cursor color could subtly change, say a bit darker/lighter, but I can't find ansi escape codes for that.

Instead this changes the cursor to a non-blinking underscore during compilation.

[Screencast from 10-13-2022 11:10:48 PM.webm](https://user-images.githubusercontent.com/1694067/195753713-b02b692c-f4fc-4c7c-bb41-ef0eface96dd.webm)


Thoughts:
- 
- The fast switching between the two styles comes across as a bit glitchy. That might be less jarring with a subtle color change
- There would need to be cursor style resets after errors/exits to prevent the cursor getting stuck as an underscore
- It would need to be disabled for terminals that don't support ansi codes

