### PR TITLE
Disable `curl` linkage to `brotli`

### DIFF
--- a/deps/curl.mk
+++ b/deps/curl.mk
@@ -38,11 +38,11 @@ checksum-curl: $(SRCCACHE)/curl-$(CURL_VER).tar.bz2
 CURL_CONFIGURE_FLAGS := $(CONFIGURE_COMMON) \
 	--without-ssl --without-gnutls --without-libidn2 --without-librtmp \
 	--without-nss --without-libpsl --without-libgsasl --without-fish-functions-dir \
-	--disable-ares --disable-manual --disable-ldap --disable-ldaps --disable-static
+	--disable-ares --disable-manual --disable-ldap --disable-ldaps --disable-static \
+	--without-gssapi --without-brotli
 # A few things we actually enable
 CURL_CONFIGURE_FLAGS += --enable-versioned-symbols \
 	--with-libssh2=${build_prefix} --with-zlib=${build_prefix} --with-nghttp2=${build_prefix}
-CURL_CONFIGURE_FLAGS += --without-gssapi
 
 # We use different TLS libraries on different platforms.
 #   On Windows, we use schannel


### PR DESCRIPTION
On a local build, `curl` links to `brotli` if found, resulting in linkage against system libraries.

Since `brotli` is not bundled with `julia`, it would be safer to disable it by default.