### PR TITLE
Fix various bugs in maybe-undef handling

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1983,7 +1983,11 @@ function abstract_eval_special_value(interp::AbstractInterpreter, @nospecialize(
     elseif isa(e, SSAValue)
         return abstract_eval_ssavalue(e, sv)
     elseif isa(e, SlotNumber)
-        return vtypes[slot_id(e)].typ
+        vtyp = vtypes[slot_id(e)]
+        if vtyp.undef
+            merge_effects!(interp, sv, Effects(EFFECTS_TOTAL; nothrow=false))
+        end
+        return vtyp.typ
     elseif isa(e, Argument)
         if !isa(vtypes, Nothing)
             return vtypes[slot_id(e)].typ

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1759,6 +1759,8 @@ function type_lift_pass!(ir::IRCode)
                                         if haskey(processed, id)
                                             val = processed[id]
                                         else
+                                            # TODO: Re-check after convergence whether all the values are the same
+                                            all_same = false
                                             push!(worklist, (id, up_id, new_phi::SSAValue, i))
                                             continue
                                         end
@@ -1782,6 +1784,7 @@ function type_lift_pass!(ir::IRCode)
                     if all_same && @isdefined(last_val)
                         # Decay the PhiNode back to the single value
                         ir[new_phi][:inst] = last_val
+                        isa(last_val, Bool) && (processed[item] = last_val)
                     end
                     if which !== SSAValue(0)
                         phi = ir[which][:inst]


### PR DESCRIPTION
We weren't accounting for the possiblity that a slot could be undef in our effect handling and the recently introduced shortcut in the type lifting pass wasn't quite correct. Ironically, the test case I have here compiles correctly on master, because the compiler miscompiles itself (due to this issue) to always make the `@isdefined(last_val)` check `false` in this test case. We can still look at the IR though, which this does.

Fixes #47127