### PR TITLE
Also update phi counts in adce pass

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -950,6 +950,8 @@ end
 __set_check_ssa_counts(onoff::Bool) = __check_ssa_counts__[] = onoff
 const __check_ssa_counts__ = fill(false)
 
+should_check_ssa_counts() = __check_ssa_counts__[]
+
 function _oracle_check(compact::IncrementalCompact)
     observed_used_ssas = Core.Compiler.find_ssavalue_uses1(compact)
     for i = 1:length(observed_used_ssas)
@@ -1683,7 +1685,7 @@ end
 function complete(compact::IncrementalCompact)
     result_bbs = resize!(compact.result_bbs, compact.active_result_bb-1)
     cfg = CFG(result_bbs, Int[first(result_bbs[i].stmts) for i in 2:length(result_bbs)])
-    if __check_ssa_counts__[]
+    if should_check_ssa_counts()
         oracle_check(compact)
     end
 

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1092,3 +1092,13 @@ let src = code_typed1(foo_defined_last_iter, Tuple{Int})
         end
     end
 end
+
+# Issue #47180, incorrect phi counts in CmdRedirect
+function a47180(b; stdout )
+    c = setenv(b, b.env)
+    if true
+        c = pipeline(c, stdout)
+    end
+    c
+end
+@test isa(a47180(``; stdout), Base.AbstractCmd)


### PR DESCRIPTION
The whole point of this pass is to compute and compare the counts of all SSA value uses vs those of only-phi uses to find SSA values that have no real uses. In #47080, I updated the code to properly account for removal of phi edges in the SSA count, but neglected to do the same in the phi-only count, leading to #47180. Fix that.

Fixes #47180