### PR TITLE
Avoid overflow in first/last (continue #45843)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -496,7 +496,7 @@ first(itr, n::Integer) = collect(Iterators.take(itr, n))
 # Faster method for vectors
 function first(v::AbstractVector, n::Integer)
     n < 0 && throw(ArgumentError("Number of elements must be nonnegative"))
-    @inbounds v[range(begin, length=min(n, length(v)))]
+    v[range(begin, length=min(n, length(v)))]
 end
 
 """
@@ -546,7 +546,7 @@ last(itr, n::Integer) = reverse!(collect(Iterators.take(Iterators.reverse(itr), 
 # Faster method for arrays
 function last(v::AbstractVector, n::Integer)
     n < 0 && throw(ArgumentError("Number of elements must be nonnegative"))
-    @inbounds v[range(stop=lastindex(v), length=min(n, length(v)))]
+    v[range(stop=lastindex(v), length=min(n, length(v)))]
 end
 
 """

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -496,7 +496,7 @@ first(itr, n::Integer) = collect(Iterators.take(itr, n))
 # Faster method for vectors
 function first(v::AbstractVector, n::Integer)
     n < 0 && throw(ArgumentError("Number of elements must be nonnegative"))
-    @inbounds v[begin:min(begin + n - 1, end)]
+    @inbounds v[range(begin, length=min(n, length(v)))]
 end
 
 """
@@ -546,7 +546,7 @@ last(itr, n::Integer) = reverse!(collect(Iterators.take(Iterators.reverse(itr), 
 # Faster method for arrays
 function last(v::AbstractVector, n::Integer)
     n < 0 && throw(ArgumentError("Number of elements must be nonnegative"))
-    @inbounds v[max(begin, end - n + 1):end]
+    @inbounds v[range(stop=lastindex(v), length=min(n, length(v)))]
 end
 
 """

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -496,7 +496,7 @@ first(itr, n::Integer) = collect(Iterators.take(itr, n))
 # Faster method for vectors
 function first(v::AbstractVector, n::Integer)
     n < 0 && throw(ArgumentError("Number of elements must be nonnegative"))
-    v[range(begin, length=min(n, length(v)))]
+    v[range(begin, length=min(n, checked_length(v)))]
 end
 
 """
@@ -546,7 +546,7 @@ last(itr, n::Integer) = reverse!(collect(Iterators.take(Iterators.reverse(itr), 
 # Faster method for arrays
 function last(v::AbstractVector, n::Integer)
     n < 0 && throw(ArgumentError("Number of elements must be nonnegative"))
-    v[range(stop=lastindex(v), length=min(n, length(v)))]
+    v[range(stop=lastindex(v), length=min(n, checked_length(v)))]
 end
 
 """

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1268,6 +1268,13 @@ end
     @test last(itr, 25) !== itr
     @test last(itr, 1) == [itr[end]]
     @test_throws ArgumentError last(itr, -6)
+
+    @testset "overflow (issue #45842)" begin
+        @test_throws OverflowError first(typemin(Int):typemax(Int), 10)
+        @test first(2:typemax(Int)-1, typemax(Int)÷2) === 2:((typemax(Int)÷2) + 1)
+        @test last(2:typemax(Int), typemax(Int)÷2) ===
+            range(stop=typemax(Int), length=typemax(Int)÷2)
+    end
 end
 
 @testset "Base.rest" begin

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -658,6 +658,14 @@ end
     @test last(v, 100) == v0
     @test last(v, 100) !== v
     @test last(v, 1) == [v[end]]
+
+    @testset "overflow (issue #45842)" begin
+        a = [2,3,4]
+        b = OffsetArray(a, 2:4)
+        @test first(a, typemax(Int)) == first(b, typemax(Int))
+        b = OffsetArray(a, typemin(Int))
+        @test last(a, 100) == last(b, 100)
+    end
 end
 
 @testset "Resizing OffsetVectors" begin


### PR DESCRIPTION
Continue and close #45843. This fixes https://github.com/JuliaLang/julia/issues/45842, but doesn't work correctly for non-compliant array types such as a `StarWarsArray`. However, once you're not complying with the `AbstractArray` interface, all bets are off.

Theoretically, we may work around this failure by checking if the axis is an `AbstractUnitRange`, and calling the fallback method if it isn't. This still produces an incorrect answer as of now, but at least makes the result consistent. Currently, the answers are inconsistent (they're wrong in different ways).

Bearing this in mind, it might make sense to remove the `@inbounds` annotation in these two functions. This will turn the incorrect result for `StarWarsArrays` into an error (as `checkbounds` is not defined for a `Vector` axis), but might help avoid segfaults in certain cases. Benchmarking for simple cases, I don't see any performance difference without `@inbounds`.