### PR TITLE
Reduce the range of elements sorted by partialsort

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -86,7 +86,7 @@ issorted(itr;
     issorted(itr, ord(lt,by,rev,order))
 
 function partialsort!(v::AbstractVector, k::Union{Integer,OrdinalRange}, o::Ordering)
-    sort!(v, PartialQuickSort(k, k), o)
+    sort!(v, _PartialQuickSort(k), o)
     maybeview(v, k)
 end
 
@@ -436,6 +436,8 @@ struct PartialQuickSort{L<:Union{Integer,Missing}, H<:Union{Integer,Missing}} <:
 end
 PartialQuickSort(k::Integer) = PartialQuickSort(missing, k)
 PartialQuickSort(k::OrdinalRange) = PartialQuickSort(first(k), last(k))
+_PartialQuickSort(k::Integer) = PartialQuickSort(k, k)
+_PartialQuickSort(k::OrdinalRange) = PartialQuickSort(k)
 
 """
     InsertionSort
@@ -1082,7 +1084,7 @@ function partialsortperm!(ix::AbstractVector{<:Integer}, v::AbstractVector,
     end
 
     # do partial quicksort
-    sort!(ix, PartialQuickSort(k, k), Perm(ord(lt, by, rev, order), v))
+    sort!(ix, _PartialQuickSort(k), Perm(ord(lt, by, rev, order), v))
 
     maybeview(ix, k)
 end

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -434,7 +434,7 @@ struct PartialQuickSort{L<:Union{Integer,Missing}, H<:Union{Integer,Missing}} <:
     lo::L
     hi::H
 end
-PartialQuickSort(k::Integer) = PartialQuickSort(missing, k)
+PartialQuickSort(k::Integer) = PartialQuickSort(k, k)
 PartialQuickSort(k::OrdinalRange) = PartialQuickSort(first(k), last(k))
 
 """

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -86,7 +86,7 @@ issorted(itr;
     issorted(itr, ord(lt,by,rev,order))
 
 function partialsort!(v::AbstractVector, k::Union{Integer,OrdinalRange}, o::Ordering)
-    sort!(v, PartialQuickSort(k), o)
+    sort!(v, PartialQuickSort(k, k), o)
     maybeview(v, k)
 end
 
@@ -434,7 +434,7 @@ struct PartialQuickSort{L<:Union{Integer,Missing}, H<:Union{Integer,Missing}} <:
     lo::L
     hi::H
 end
-PartialQuickSort(k::Integer) = PartialQuickSort(k, k)
+PartialQuickSort(k::Integer) = PartialQuickSort(missing, k)
 PartialQuickSort(k::OrdinalRange) = PartialQuickSort(first(k), last(k))
 
 """
@@ -1082,7 +1082,7 @@ function partialsortperm!(ix::AbstractVector{<:Integer}, v::AbstractVector,
     end
 
     # do partial quicksort
-    sort!(ix, PartialQuickSort(k), Perm(ord(lt, by, rev, order), v))
+    sort!(ix, PartialQuickSort(k, k), Perm(ord(lt, by, rev, order), v))
 
     maybeview(ix, k)
 end

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -381,7 +381,7 @@ end
         end
 
         v = randn_with_nans(n,0.1)
-        for alg in [InsertionSort, MergeSort, QuickSort, PartialQuickSort(n), Base.DEFAULT_UNSTABLE, Base.DEFAULT_STABLE],
+        for alg in [InsertionSort, MergeSort, QuickSort, Base.DEFAULT_UNSTABLE, Base.DEFAULT_STABLE],
             rev in [false,true]
             alg === InsertionSort && n >= 3000 && continue
             # test float sorting with NaNs

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -381,7 +381,7 @@ end
         end
 
         v = randn_with_nans(n,0.1)
-        for alg in [InsertionSort, MergeSort, QuickSort, Base.DEFAULT_UNSTABLE, Base.DEFAULT_STABLE],
+        for alg in [InsertionSort, MergeSort, QuickSort, PartialQuickSort(n), Base.DEFAULT_UNSTABLE, Base.DEFAULT_STABLE],
             rev in [false,true]
             alg === InsertionSort && n >= 3000 && continue
             # test float sorting with NaNs


### PR DESCRIPTION
`missing` means the end of the vector (e.g. `PartialQuickSort(missing, missing) === QuickSort`). There is no need to sort the elements `begin:k-1` for `partialsort(k)`.

Fixup for #45222

```julia
julia> @btime partialsort(rand(10_000), 10_000)
@btime sort(rand(10_000), alg=PartialQuickSort(10_000))
  526.527 μs (8 allocations: 312.69 KiB)
0.9998857291289974

julia> @btime sort(rand(10_000), alg=PartialQuickSort(10_000))
@btime sort(rand(10_000), alg=PartialQuickSort(missing, 10_000))[10_000]
  517.977 μs (8 allocations: 312.69 KiB)
 0.9999893337886981

julia> @btime sort(rand(10_000), alg=PartialQuickSort(missing, 10_000))[10_000]
  521.084 μs (8 allocations: 312.69 KiB)
 0.999986247898864

julia> @btime sort(rand(10_000), alg=PartialQuickSort(10_000, 10_000))[10_000]
  67.384 μs (8 allocations: 312.69 KiB)
 0.9997135092971121
```