### PR TITLE
Allow the user to customize the value of `RELOC_TAG_OFFSET` when building Julia

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -366,12 +366,14 @@ typedef enum {
 } jl_callingconv_t;
 
 
+#if !defined(RELOC_TAG_OFFSET)
 //#ifdef _P64
 //#define RELOC_TAG_OFFSET 61
 //#else
 // this supports up to 8 RefTags, 512MB of pointer data, and 4/2 (64/32-bit) GB of constant data.
 #define RELOC_TAG_OFFSET 29
 //#endif
+#endif
 
 #if RELOC_TAG_OFFSET <= 32
 typedef uint32_t reloc_t;


### PR DESCRIPTION
Example usage:

```
make JL_CFLAGS="-Werror -DRELOC_TAG_OFFSET=61"
```