### PR TITLE
optimizer: simplify inlining algorithm

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-@nospecialize
-
 struct Signature
     f::Any
     ft::Any
@@ -9,7 +7,9 @@ struct Signature
     Signature(@nospecialize(f), @nospecialize(ft), argtypes::Vector{Any}) = new(f, ft, argtypes)
 end
 
-struct ResolvedInliningSpec
+struct InliningTodo
+    # The MethodInstance to be inlined
+    mi::MethodInstance
     # The IR of the inlinee
     ir::IRCode
     # If the function being inlined is a single basic block we can use a
@@ -18,41 +18,18 @@ struct ResolvedInliningSpec
     # Effects of the call statement
     effects::Effects
 end
-ResolvedInliningSpec(ir::IRCode, effects::Effects) =
-    ResolvedInliningSpec(ir, linear_inline_eligible(ir), effects)
-
-"""
-Represents a callsite that our analysis has determined is legal to inline,
-but did not resolve during the analysis step to allow the outer inlining
-pass to apply its own inlining policy decisions.
-"""
-struct DelayedInliningSpec
-    match::Union{MethodMatch, InferenceResult}
-    argtypes::Vector{Any}
-    invokesig    # either nothing or a signature (signature is for an `invoke` call)
+function InliningTodo(mi::MethodInstance, ir::IRCode, effects::Effects)
+    return InliningTodo(mi, ir, linear_inline_eligible(ir), effects)
 end
-DelayedInliningSpec(match, argtypes) = DelayedInliningSpec(match, argtypes, nothing)
-
-struct InliningTodo
-    # The MethodInstance to be inlined
-    mi::MethodInstance
-    spec::Union{ResolvedInliningSpec, DelayedInliningSpec}
-end
-
-InliningTodo(mi::MethodInstance, match::MethodMatch, argtypes::Vector{Any}, invokesig=nothing) =
-    InliningTodo(mi, DelayedInliningSpec(match, argtypes, invokesig))
-
-InliningTodo(result::InferenceResult, argtypes::Vector{Any}, invokesig=nothing) =
-    InliningTodo(result.linfo, DelayedInliningSpec(result, argtypes, invokesig))
 
 struct ConstantCase
     val::Any
-    ConstantCase(val) = new(val)
+    ConstantCase(@nospecialize val) = new(val)
 end
 
 struct SomeCase
     val::Any
-    SomeCase(val) = new(val)
+    SomeCase(@nospecialize val) = new(val)
 end
 
 struct InvokeCase
@@ -80,18 +57,16 @@ end
 
 struct InliningEdgeTracker
     et::Union{Nothing,EdgeTracker}
-    invokesig # ::Union{Nothing,Type}
-    InliningEdgeTracker(et::Union{Nothing,EdgeTracker}, @nospecialize(invokesig=nothing)) = new(et, invokesig)
+    invokesig::Union{Nothing,Vector{Any}}
 end
-
-@specialize
+InliningEdgeTracker(et::Union{Nothing,EdgeTracker}) = InliningEdgeTracker(et, nothing)
 
 function add_inlining_backedge!((; et, invokesig)::InliningEdgeTracker, mi::MethodInstance)
     if et !== nothing
         if invokesig === nothing
             add_backedge!(et, mi)
         else
-            add_invoke_backedge!(et, invokesig, mi)
+            add_invoke_backedge!(et, invoke_signature(invokesig), mi)
         end
     end
     return nothing
@@ -147,8 +122,8 @@ function inline_into_block!(state::CFGInliningState, block::Int)
     return
 end
 
-function cfg_inline_item!(ir::IRCode, idx::Int, spec::ResolvedInliningSpec, state::CFGInliningState, from_unionsplit::Bool=false)
-    inlinee_cfg = spec.ir.cfg
+function cfg_inline_item!(ir::IRCode, idx::Int, todo::InliningTodo, state::CFGInliningState, from_unionsplit::Bool=false)
+    inlinee_cfg = todo.ir.cfg
     # Figure out if we need to split the BB
     need_split_before = false
     need_split = true
@@ -223,7 +198,7 @@ function cfg_inline_item!(ir::IRCode, idx::Int, spec::ResolvedInliningSpec, stat
     for (old_block, new_block) in enumerate(bb_rename_range)
         if (length(state.new_cfg_blocks[new_block].succs) == 0)
             terminator_idx = last(inlinee_cfg.blocks[old_block].stmts)
-            terminator = spec.ir[SSAValue(terminator_idx)][:inst]
+            terminator = todo.ir[SSAValue(terminator_idx)][:inst]
             if isa(terminator, ReturnNode) && isdefined(terminator, :val)
                 any_edges = true
                 push!(state.new_cfg_blocks[new_block].succs, post_bb_id)
@@ -256,9 +231,8 @@ function cfg_inline_unionsplit!(ir::IRCode, idx::Int,
         push!(state.new_cfg_blocks[cond_bb].succs, cond_bb+1)
         case = cases[i].item
         if isa(case, InliningTodo)
-            spec = case.spec::ResolvedInliningSpec
-            if !spec.linear_inline_eligible
-                cfg_inline_item!(ir, idx, spec, state, true)
+            if !case.linear_inline_eligible
+                cfg_inline_item!(ir, idx, case, state, true)
             end
         end
         push!(from_bbs, length(state.new_cfg_blocks))
@@ -397,13 +371,12 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
                          linetable::Vector{LineInfoNode}, item::InliningTodo,
                          boundscheck::Symbol, todo_bbs::Vector{Tuple{Int, Int}})
     # Ok, do the inlining here
-    spec = item.spec::ResolvedInliningSpec
     sparam_vals = item.mi.sparam_vals
     def = item.mi.def::Method
     inlined_at = compact.result[idx][:line]
 
-    ((sp_ssa, argexprs), linetable_offset) = ir_prepare_inlining!(InsertHere(compact), compact, linetable,
-            item.spec.ir, sparam_vals, def, inlined_at, argexprs)
+    ((sp_ssa, argexprs), linetable_offset) = ir_prepare_inlining!(InsertHere(compact),
+        compact, linetable, item.ir, sparam_vals, def, inlined_at, argexprs)
 
     if boundscheck === :default || boundscheck === :propagate
         if (compact.result[idx][:flag] & IR_FLAG_INBOUNDS) != 0
@@ -417,9 +390,9 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
     # Special case inlining that maintains the current basic block if there's only one BB in the target
     new_new_offset = length(compact.new_new_nodes)
     late_fixup_offset = length(compact.late_fixup)
-    if spec.linear_inline_eligible
+    if item.linear_inline_eligible
         #compact[idx] = nothing
-        inline_compact = IncrementalCompact(compact, spec.ir, compact.result_idx)
+        inline_compact = IncrementalCompact(compact, item.ir, compact.result_idx)
         for ((_, idx′), stmt′) in inline_compact
             # This dance is done to maintain accurate usage counts in the
             # face of rename_arguments! mutating in place - should figure out
@@ -443,13 +416,13 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
     else
         bb_offset, post_bb_id = popfirst!(todo_bbs)
         # This implements the need_split_before flag above
-        need_split_before = !isempty(spec.ir.cfg.blocks[1].preds)
+        need_split_before = !isempty(item.ir.cfg.blocks[1].preds)
         if need_split_before
             finish_current_bb!(compact, 0)
         end
         pn = PhiNode()
         #compact[idx] = nothing
-        inline_compact = IncrementalCompact(compact, spec.ir, compact.result_idx)
+        inline_compact = IncrementalCompact(compact, item.ir, compact.result_idx)
         for ((_, idx′), stmt′) in inline_compact
             inline_compact[idx′] = nothing
             stmt′ = ssa_substitute!(InsertBefore(inline_compact, SSAValue(idx′)), inline_compact[SSAValue(idx′)], stmt′, argexprs, sig, sparam_vals, sp_ssa, linetable_offset, boundscheck)
@@ -664,10 +637,9 @@ function batch_inline!(ir::IRCode, todo::Vector{Pair{Int,Any}}, propagate_inboun
             cfg_inline_unionsplit!(ir, idx, item, state, params)
         else
             item = item::InliningTodo
-            spec = item.spec::ResolvedInliningSpec
             # A linear inline does not modify the CFG
-            spec.linear_inline_eligible && continue
-            cfg_inline_item!(ir, idx, spec, state, false)
+            item.linear_inline_eligible && continue
+            cfg_inline_item!(ir, idx, item, state, false)
         end
     end
     finish_cfg_inline!(state)
@@ -683,8 +655,7 @@ function batch_inline!(ir::IRCode, todo::Vector{Pair{Int,Any}}, propagate_inboun
         nn = 0
         for (_, item) in todo
             if isa(item, InliningTodo)
-                spec = item.spec::ResolvedInliningSpec
-                nn += (length(spec.ir.stmts) + length(spec.ir.new_nodes))
+                nn += (length(item.ir.stmts) + length(item.ir.new_nodes))
             end
         end
         nnewnodes = length(compact.result) + nn
@@ -864,20 +835,21 @@ end
     end
 end
 
-function resolve_todo(todo::InliningTodo, state::InliningState, @nospecialize(info::CallInfo), flag::UInt8)
-    mi = todo.mi
-    (; match, argtypes, invokesig) = todo.spec::DelayedInliningSpec
+# the general resolver for usual and const-prop'ed calls
+function resolve_todo(mi::MethodInstance, result::Union{MethodMatch,InferenceResult},
+    argtypes::Vector{Any}, @nospecialize(info::CallInfo), flag::UInt8,
+    state::InliningState; invokesig::Union{Nothing,Vector{Any}}=nothing)
     et = InliningEdgeTracker(state.et, invokesig)
 
     #XXX: update_valid_age!(min_valid[1], max_valid[1], sv)
-    if isa(match, InferenceResult)
-        src = match.src
+    if isa(result, InferenceResult)
+        src = result.src
         if isa(src, ConstAPI)
             # use constant calling convention
             add_inlining_backedge!(et, mi)
             return ConstantCase(quoted(src.val))
         end
-        effects = match.ipo_effects
+        effects = result.ipo_effects
     else
         cached_result = get_cached_result(state, mi)
         if cached_result isa ConstantCase
@@ -890,7 +862,7 @@ function resolve_todo(todo::InliningTodo, state::InliningState, @nospecialize(in
     # the duplicated check might have been done already within `analyze_method!`, but still
     # we need it here too since we may come here directly using a constant-prop' result
     if !state.params.inlining || is_stmt_noinline(flag)
-        return compileable_specialization(match, effects, et;
+        return compileable_specialization(result, effects, et;
             compilesig_invokes=state.params.compilesig_invokes)
     end
 
@@ -905,15 +877,16 @@ function resolve_todo(todo::InliningTodo, state::InliningState, @nospecialize(in
         return ConstantCase(quoted(src.val))
     end
 
-    src === nothing && return compileable_specialization(match, effects, et;
+    src === nothing && return compileable_specialization(result, effects, et;
         compilesig_invokes=state.params.compilesig_invokes)
 
     add_inlining_backedge!(et, mi)
     return InliningTodo(mi, retrieve_ir_for_inlining(mi, src), effects)
 end
 
-function resolve_todo(mi::MethodInstance, argtypes::Vector{Any}, state::InliningState,
-    @nospecialize(info::CallInfo), flag::UInt8)
+# the special resolver for :invoke-d call
+function resolve_todo(mi::MethodInstance, argtypes::Vector{Any},
+    @nospecialize(info::CallInfo), flag::UInt8, state::InliningState)
     if !state.params.inlining || is_stmt_noinline(flag)
         return nothing
     end
@@ -933,17 +906,6 @@ function resolve_todo(mi::MethodInstance, argtypes::Vector{Any}, state::Inlining
 
     add_inlining_backedge!(et, mi)
     return InliningTodo(mi, retrieve_ir_for_inlining(mi, src), effects)
-end
-
-function resolve_todo((; fully_covered, atype, cases, #=bbs=#)::UnionSplit, state::InliningState, flag::UInt8)
-    ncases = length(cases)
-    newcases = Vector{InliningCase}(undef, ncases)
-    for i in 1:ncases
-        (; sig, item) = cases[i]
-        newitem = resolve_todo(item, state, flag)
-        push!(newcases, InliningCase(sig, newitem))
-    end
-    return UnionSplit(fully_covered, atype, newcases)
 end
 
 function validate_sparams(sparams::SimpleVector)
@@ -972,8 +934,9 @@ function can_inline_typevars(method::Method, argtypes::Vector{Any})
 end
 can_inline_typevars(m::MethodMatch, argtypes::Vector{Any}) = can_inline_typevars(m.method, argtypes)
 
-function analyze_method!(match::MethodMatch, argtypes::Vector{Any}, @nospecialize(invokesig),
-                         @nospecialize(info::CallInfo), flag::UInt8, state::InliningState, allow_typevars::Bool = false)
+function analyze_method!(match::MethodMatch, argtypes::Vector{Any},
+    @nospecialize(info::CallInfo), flag::UInt8, state::InliningState;
+    allow_typevars::Bool, invokesig::Union{Nothing,Vector{Any}}=nothing)
     method = match.method
     spec_types = match.spec_types
 
@@ -1007,15 +970,7 @@ function analyze_method!(match::MethodMatch, argtypes::Vector{Any}, @nospecializ
             compilesig_invokes=state.params.compilesig_invokes)
     end
 
-    todo = InliningTodo(mi, match, argtypes, invokesig)
-    # If we don't have caches here, delay resolving this MethodInstance
-    # until the batch inlining step (or an external post-processing pass)
-    state.mi_cache === nothing && return todo
-    return resolve_todo(todo, state, info, flag)
-end
-
-function InliningTodo(mi::MethodInstance, ir::IRCode, effects::Effects)
-    return InliningTodo(mi, ResolvedInliningSpec(ir, effects))
+    return resolve_todo(mi, match, argtypes, info, flag, state; invokesig)
 end
 
 function retrieve_ir_for_inlining(mi::MethodInstance, src::Array{UInt8, 1})
@@ -1131,8 +1086,7 @@ function call_sig(ir::IRCode, stmt::Expr)
 end
 
 function inline_apply!(todo::Vector{Pair{Int,Any}},
-    ir::IRCode, idx::Int, stmt::Expr, sig::Signature,
-    state::InliningState)
+    ir::IRCode, idx::Int, stmt::Expr, sig::Signature, state::InliningState)
     while sig.f === Core._apply_iterate
         info = ir.stmts[idx][:info]
         if isa(info, UnionSplitApplyCallInfo)
@@ -1214,21 +1168,21 @@ function handle_invoke_call!(todo::Vector{Pair{Int,Any}},
         return nothing
     end
     result = info.result
-    invokesig = invoke_signature(sig.argtypes)
+    invokesig = sig.argtypes
     if isa(result, ConcreteResult)
-        item = concrete_result_item(result, state, invokesig)
+        item = concrete_result_item(result, state; invokesig)
     else
         argtypes = invoke_rewrite(sig.argtypes)
         if isa(result, ConstPropResult)
-            item = InliningTodo(result.result, argtypes, invokesig)
-            validate_sparams(item.mi.sparam_vals) || return nothing
-            if argtypes_to_type(argtypes) <: item.mi.def.sig
-                state.mi_cache !== nothing && (item = resolve_todo(item, state, info, flag))
+            mi = result.result.linfo
+            validate_sparams(mi.sparam_vals) || return nothing
+            if argtypes_to_type(argtypes) <: mi.def.sig
+                item = resolve_todo(mi, result.result, argtypes, info, flag, state; invokesig)
                 handle_single_case!(todo, ir, idx, stmt, item, state.params, true)
                 return nothing
             end
         end
-        item = analyze_method!(match, argtypes, invokesig, info, flag, state)
+        item = analyze_method!(match, argtypes, info, flag, state; allow_typevars=false, invokesig)
     end
     handle_single_case!(todo, ir, idx, stmt, item, state.params, true)
     return nothing
@@ -1277,7 +1231,7 @@ end
 # Handles all analysis and inlining of intrinsics and builtins. In particular,
 # this method does not access the method table or otherwise process generic
 # functions.
-function process_simple!(ir::IRCode, idx::Int, state::InliningState, todo::Vector{Pair{Int,Any}})
+function process_simple!(todo::Vector{Pair{Int,Any}}, ir::IRCode, idx::Int, state::InliningState)
     stmt = ir.stmts[idx][:inst]
     rt = ir.stmts[idx][:type]
     if !(stmt isa Expr)
@@ -1492,7 +1446,7 @@ function handle_match!(cases::Vector{InliningCase},
     # during abstract interpretation: for the purpose of inlining, we can just skip
     # processing this dispatch candidate (unless unmatched type parameters are present)
     !allow_typevars && _any(case->case.sig === spec_types, cases) && return true
-    item = analyze_method!(match, argtypes, nothing, info, flag, state, allow_typevars)
+    item = analyze_method!(match, argtypes, info, flag, state; allow_typevars)
     item === nothing && return false
     push!(cases, InliningCase(spec_types, item))
     return true
@@ -1502,13 +1456,13 @@ function handle_const_prop_result!(cases::Vector{InliningCase},
     result::ConstPropResult, argtypes::Vector{Any}, @nospecialize(info::CallInfo),
     flag::UInt8, state::InliningState;
     allow_abstract::Bool, allow_typevars::Bool)
-    item = InliningTodo(result.result, argtypes)
-    spec_types = item.mi.specTypes
+    mi = result.result.linfo
+    spec_types = mi.specTypes
     allow_abstract || isdispatchtuple(spec_types) || return false
-    if !validate_sparams(item.mi.sparam_vals)
-        (allow_typevars && can_inline_typevars(item.mi.def, argtypes)) || return false
+    if !validate_sparams(mi.sparam_vals)
+        (allow_typevars && can_inline_typevars(mi.def, argtypes)) || return false
     end
-    state.mi_cache !== nothing && (item = resolve_todo(item, state, info, flag))
+    item = resolve_todo(mi, result.result, argtypes, info, flag, state)
     item === nothing && return false
     push!(cases, InliningCase(spec_types, item))
     return true
@@ -1529,7 +1483,8 @@ function handle_concrete_result!(cases::Vector{InliningCase}, result::ConcreteRe
     return true
 end
 
-function concrete_result_item(result::ConcreteResult, state::InliningState, @nospecialize(invokesig=nothing))
+function concrete_result_item(result::ConcreteResult, state::InliningState;
+    invokesig::Union{Nothing,Vector{Any}}=nothing)
     if !isdefined(result, :result) || !is_inlineable_constant(result.result)
         et = InliningEdgeTracker(state.et, invokesig)
         case = compileable_specialization(result.mi, result.effects, et;
@@ -1566,13 +1521,13 @@ function handle_opaque_closure_call!(todo::Vector{Pair{Int,Any}},
     flag::UInt8, sig::Signature, state::InliningState)
     result = info.result
     if isa(result, ConstPropResult)
-        item = InliningTodo(result.result, sig.argtypes)
-        validate_sparams(item.mi.sparam_vals) || return nothing
-        state.mi_cache !== nothing && (item = resolve_todo(item, state, info, flag))
+        mi = result.result.linfo
+        validate_sparams(mi.sparam_vals) || return nothing
+        item = resolve_todo(mi, result.result, sig.argtypes, info, flag, state)
     elseif isa(result, ConcreteResult)
         item = concrete_result_item(result, state)
     else
-        item = analyze_method!(info.match, sig.argtypes, nothing, info, flag, state)
+        item = analyze_method!(info.match, sig.argtypes, info, flag, state; allow_typevars=false)
     end
     handle_single_case!(todo, ir, idx, stmt, item, state.params)
     return nothing
@@ -1641,7 +1596,7 @@ end
 function handle_invoke_expr!(todo::Vector{Pair{Int,Any}},
     idx::Int, stmt::Expr, @nospecialize(info::CallInfo), flag::UInt8, sig::Signature, state::InliningState)
     mi = stmt.args[1]::MethodInstance
-    case = resolve_todo(mi, sig.argtypes, state, info, flag)
+    case = resolve_todo(mi, sig.argtypes, info, flag, state)
     if case !== nothing
         push!(todo, idx=>(case::InliningTodo))
     end
@@ -1662,7 +1617,7 @@ function assemble_inline_todo!(ir::IRCode, state::InliningState)
     todo = Pair{Int, Any}[]
 
     for idx in 1:length(ir.stmts)
-        simpleres = process_simple!(ir, idx, state, todo)
+        simpleres = process_simple!(todo, ir, idx, state)
         simpleres === nothing && continue
         stmt, sig = simpleres
 


### PR DESCRIPTION
The main purpose of this commit is to try to simplify our inlining
algorithm by removing the delayed callee resolving mechanism (i.e.
`DelayedInliningSpec` stuff), since that kind of mechanism currently
has no users and we provide more fine grained control with
`inlining_policy` now.

This commit also adds some more cleanups, changing argument ordering of
some subroutines so that they are aligned with the other ones, and
removing dead subroutines.
