### PR TITLE
Faster rem_pio2 kernel for `Float32`

### DIFF
--- a/base/special/rem_pio2.jl
+++ b/base/special/rem_pio2.jl
@@ -23,6 +23,7 @@
 #        @printf "0x%016x,\n" k
 #        I -= k
 #    end
+
 const INV_2PI = (
     0x28be_60db_9391_054a,
     0x7f09_d5f4_7d4d_3770,
@@ -43,6 +44,16 @@ const INV_2PI = (
     0xcf41_ce7d_e294_a4ba,
     0x9afe_d7ec_47e3_5742,
     0x1580_cc11_bf1e_daea)
+
+@inline function cody_waite_2c_pio2(x::Float64, fn, n)
+    pio2_1 = 1.57079632673412561417e+00
+    pio2_1t = 6.07710050650619224932e-11
+
+    z = muladd(-fn, pio2_1, x) # x - fn*pio2_1
+    y1 = muladd(-fn, pio2_1t, z) # z - fn*pio2_1t
+    y2 = muladd(-fn, pio2_1t, (z - y1)) # (z - y1) - fn*pio2_1t
+    n, DoubleFloat64(y1, y2)
+end
 
 @inline function cody_waite_ext_pio2(x::Float64, xhp)
     pio2_1 = 1.57079632673412561417e+00
@@ -83,9 +94,9 @@ const INV_2PI = (
     return unsafe_trunc(Int, fn), DoubleFloat64(y1, y2)
 end
 
+
 """
     fromfraction(f::Int128)
-
 Compute a tuple of values `(z1,z2)` such that
     ``z1 + z2 == f / 2^128``
 and the significand of `z1` has 27 trailing zeros.
@@ -203,39 +214,84 @@ end
 
 """
     rem_pio2_kernel(x::Union{Float32, Float64})
-
 Calculate `x` divided by `π/2` accurately for arbitrarily large `x`.
 Returns a pair `(k, r)`, where `k` is the quadrant of the result
 (multiple of π/2) and `r` is the remainder, such that ``k * π/2 = x - r``.
 The remainder is given as a double-double pair.
 `k` is positive if `x > 0` and is negative if `x ≤ 0`.
 """
-@inline function rem_pio2_kernel(x::Float64)
+@inline function rem_pio2_kernel(x::Float64) # accurate to 1e-22
     xhp = poshighword(x)
+    #  xhp <= highword(5pi/4) implies |x| ~<= 5pi/4,
+    if xhp <= 0x400f6a7a
+        #  last five bits of xhp == last five bits of highword(pi/2) or
+        #  highword(2pi/2) implies |x| ~= pi/2 or 2pi/2,
+        if (xhp & 0xfffff) == 0x921fb # use precise Cody Waite scheme
+            return cody_waite_ext_pio2(x, xhp)
+        end
+        # use Cody Waite with two constants
+        #  xhp <= highword(3pi/4) implies |x| ~<= 3pi/4
+        if xhp <= 0x4002d97c
+            if x > 0.0
+                return cody_waite_2c_pio2(x, 1.0, 1)
+            else
+                return cody_waite_2c_pio2(x, -1.0, -1)
+            end
+        # 3pi/4 < |x| <= 5pi/4
+        else
+            if x > 0.0
+                return cody_waite_2c_pio2(x, 2.0, 2)
+            else
+                return cody_waite_2c_pio2(x, -2.0, -2)
+            end
+        end
+    end
+    #  xhp <= highword(9pi/4) implies |x| ~<= 9pi/4
+    if xhp <= 0x401c463b
+        #  xhp <= highword(7pi/4) implies |x| ~<= 7pi/4
+        if xhp <= 0x4015fdbc
+            #  xhp == highword(3pi/2) implies |x| ~= 3pi/2
+            if xhp == 0x4012d97c # use precise Cody Waite scheme
+                return cody_waite_ext_pio2(x, xhp)
+            end
+            # use Cody Waite with two constants
+            if x > 0.0
+                return cody_waite_2c_pio2(x, 3.0, 3)
+            else
+                return cody_waite_2c_pio2(x, -3.0, -3)
+            end
+        # 7pi/4 < |x| =< 9pi/4
+        else
+            #  xhp == highword(4pi/2) implies |x| ~= 4pi/2
+            if xhp == 0x401921fb # use precise Cody Waite scheme
+                return cody_waite_ext_pio2(x, xhp)
+            end
+            # use Cody Waite with two constants
+            if x > 0.0
+                return cody_waite_2c_pio2(x, 4.0, 4)
+            else
+                return cody_waite_2c_pio2(x, -4.0, -4)
+            end
+        end
+    end
+    #  xhp < highword(2.0^20*pi/2) implies |x| ~< 2^20*pi/2
+    if xhp < 0x413921fb # use precise Cody Waite scheme
+        return cody_waite_ext_pio2(x, xhp)
+    end
     # if |x| >= 2^20*pi/2 switch to Payne Hanek
-    if xhp >= 0x413921fb
-        return paynehanek(x)
-    end
-    fn = round(x * (2/pi))
-    r  = fma(fn, -pi/2, x)
-    w  = fn * 6.123233995736766e-17 # big(pi)/2 - pi/2 remainder
-    y = r-w
-    ylo = (r-y)-w
-    if reinterpret(UInt64, ylo) & 0xff != 0 #no tricky rounding
-        return unsafe_trunc(Int, fn), DoubleFloat64(y, ylo)
-    end
-    return cody_waite_ext_pio2(x, xhp)
+    return paynehanek(x)
 end
 
 @inline function rem_pio2_kernel(x::Float32)
     xd = convert(Float64, x)
-    if abs(x) < Float32(0x1p20) # x < 2^20
-        # use Cody Waite reduction with two coefficients
+    # use Cody Waite reduction with two coefficients
+    if abs(x) < Float32(pi*0x1p27) # x < 2^28 * pi/2
         fn = round(xd * (2/pi))
         r  = fma(fn, -pi/2, xd)
         y = fma(fn, -6.123233995736766e-17, r) # big(pi)/2 - pi/2 remainder
         return unsafe_trunc(Int, fn), DoubleFloat32(y)
     end
-    n, y = rem_pio2_kernel(xd)
+    n, y = @noinline paynehanek(xd)
     return n, DoubleFloat32(y.hi)
 end
+

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -28,7 +28,12 @@ end
 @noinline sin_domain_error(x) = throw(DomainError(x, "sin(x) is only defined for finite x."))
 function sin(x::T) where T<:Union{Float32, Float64}
     absx = abs(x)
-    if isnan(x)
+    if absx < T(pi)/4 #|x| ~<= pi/4, no need for reduction
+        if absx < sqrt(eps(T))
+            return x
+        end
+        return sin_kernel(x)
+    elseif isnan(x)
         return T(NaN)
     elseif isinf(x)
         sin_domain_error(x)
@@ -92,7 +97,12 @@ end
 @noinline cos_domain_error(x) = throw(DomainError(x, "cos(x) is only defined for finite x."))
 function cos(x::T) where T<:Union{Float32, Float64}
     absx = abs(x)
-    if isnan(x)
+    if absx < T(pi)/4
+        if absx < sqrt(eps(T)/T(2.0))
+            return T(1.0)
+        end
+        return cos_kernel(x)
+    elseif isnan(x)
         return T(NaN)
     elseif isinf(x)
         cos_domain_error(x)

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -28,12 +28,7 @@ end
 @noinline sin_domain_error(x) = throw(DomainError(x, "sin(x) is only defined for finite x."))
 function sin(x::T) where T<:Union{Float32, Float64}
     absx = abs(x)
-    if absx < T(pi)/4 #|x| ~<= pi/4, no need for reduction
-        if absx < sqrt(eps(T))
-            return x
-        end
-        return sin_kernel(x)
-    elseif isnan(x)
+    if isnan(x)
         return T(NaN)
     elseif isinf(x)
         sin_domain_error(x)
@@ -97,12 +92,7 @@ end
 @noinline cos_domain_error(x) = throw(DomainError(x, "cos(x) is only defined for finite x."))
 function cos(x::T) where T<:Union{Float32, Float64}
     absx = abs(x)
-    if absx < T(pi)/4
-        if absx < sqrt(eps(T)/T(2.0))
-            return T(1.0)
-        end
-        return cos_kernel(x)
-    elseif isnan(x)
+    if isnan(x)
         return T(NaN)
     elseif isinf(x)
         cos_domain_error(x)


### PR DESCRIPTION
This has been tested to give the correct answer on every `Float32` and makes `sin(::Float32)` roughly .5ns faster.

Before:
```julia> x32 = 16 *rand(Float32, 1024); y32 = similar(x32);

julia> @benchmark @. $y32 = sin($x32)
BenchmarkTools.Trial: 10000 samples with 7 evaluations.
 Range (min … max):  4.252 μs …   9.946 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     4.428 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.478 μs ± 225.102 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

    ▁▆▄█▆▅▃▁▂ ▂ ▁                                              
  ▃▇██████████████▇▇▇▇▆▆▅▅▄▄▄▄▄▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂ ▄
  4.25 μs         Histogram: frequency by time        5.25 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> x32 = 2^20 *rand(Float32, 1024); y32 = similar(x32);

julia> @benchmark @. $y32 = sin($x32)
BenchmarkTools.Trial: 10000 samples with 7 evaluations.
 Range (min … max):  4.697 μs …  37.738 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     4.929 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.951 μs ± 615.364 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █ █▆ ▆ ▅  ▂▇ █ ▄▄ ▄ ▁▅▁▄▃ ▂  ▁  ▁▂ ▂                        ▂
  █▃██▂█▂██▃████▇██▅█▆████████████████▇▇▇▇▆▆▇▆▆▆▇▆▃▆▅▅▂▂▅▅▅▄▄ █
  4.7 μs       Histogram: log(frequency) by time      5.93 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
After:
```
julia> x32 = 16 *rand(Float32, 1024); y32 = similar(x32);

julia> @benchmark @. $y32 = sin($x32)
BenchmarkTools.Trial: 10000 samples with 8 evaluations.
 Range (min … max):  3.666 μs …   9.352 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.752 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.853 μs ± 445.950 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ██ ▅ ▁▆▄▁                                                   ▂
  ██████████▇▆▆▆▅▅▄▆▄▆▅▅▁▅▅▃▄▄▄▃▃▁▃▁▅▄▁▃▃▁▃▁▁▃▄▃▄▅▄▇▅▅▅▅▄▄▅▄▆ █
  3.67 μs      Histogram: log(frequency) by time      6.64 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> x32 = 2^20 *rand(Float32, 1024); y32 = similar(x32);

julia> @benchmark @. $y32 = sin($x32)
BenchmarkTools.Trial: 10000 samples with 8 evaluations.
 Range (min … max):  3.759 μs …  14.508 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.784 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.863 μs ± 289.041 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ██  ▁█▂  ▂          ▃▄                                      ▂
  ██▇▃███▆▇███████▇▇▇▇██▇▇█▇▇█▇▇▇▆▆▆▅▄▄▅▆▅▁▄▃▄▄▃▅▄▃▃▅▃▅▃▄▃▄▄▄ █
  3.76 μs      Histogram: log(frequency) by time      4.79 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```