### PR TITLE
Optimized heap snapshot write

### DIFF
--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -469,14 +469,14 @@ void serialize_heap_snapshot(ios_t *stream, HeapSnapshot &snapshot, char all_one
             ios_printf(stream, ",");
         }
         // ["type","name","id","self_size","edge_count","trace_node_id","detachedness"]
-        ios_printf(stream, "%zu", from_node.type);
-        ios_printf(stream, ",%zu", from_node.name);
-        ios_printf(stream, ",%zu", from_node.id);
-        ios_printf(stream, ",%zu", all_one ? (size_t)1 : from_node.self_size);
-        ios_printf(stream, ",%zu", from_node.edges.size());
-        ios_printf(stream, ",%zu", from_node.trace_node_id);
-        ios_printf(stream, ",%d", from_node.detachedness);
-        ios_printf(stream, "\n");
+        ios_printf(stream, "%zu,%zu,%zu,%zu,%zu,%zu,%d\n",
+                            from_node.type,
+                            from_node.name,
+                            from_node.id,
+                            all_one ? (size_t)1 : from_node.self_size,
+                            from_node.edges.size(),
+                            from_node.trace_node_id,
+                            from_node.detachedness);
     }
     ios_printf(stream, "],\n");
 
@@ -490,10 +490,10 @@ void serialize_heap_snapshot(ios_t *stream, HeapSnapshot &snapshot, char all_one
             else {
                 ios_printf(stream, ",");
             }
-            ios_printf(stream, "%zu", edge.type);
-            ios_printf(stream, ",%zu", edge.name_or_index);
-            ios_printf(stream, ",%zu", edge.to_node * k_node_number_of_fields);
-            ios_printf(stream, "\n");
+            ios_printf(stream, "%zu,%zu,%zu\n",
+                                edge.type,
+                                edge.name_or_index,
+                                edge.to_node * k_node_number_of_fields);
         }
     }
     ios_printf(stream, "],\n"); // end "edges"

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -24,26 +24,26 @@ using llvm::StringRef;
 // https://stackoverflow.com/a/33799784/751061
 void print_str_escape_json(ios_t *stream, StringRef s)
 {
-    ios_printf(stream, "\"");
+    ios_putc('"', stream);
     for (auto c = s.begin(); c != s.end(); c++) {
         switch (*c) {
-        case '"': ios_printf(stream, "\\\""); break;
-        case '\\': ios_printf(stream, "\\\\"); break;
-        case '\b': ios_printf(stream, "\\b"); break;
-        case '\f': ios_printf(stream, "\\f"); break;
-        case '\n': ios_printf(stream, "\\n"); break;
-        case '\r': ios_printf(stream, "\\r"); break;
-        case '\t': ios_printf(stream, "\\t"); break;
+        case '"':  ios_write(stream, "\\\"", 2); break;
+        case '\\': ios_write(stream, "\\\\", 2); break;
+        case '\b': ios_write(stream, "\\b",  2); break;
+        case '\f': ios_write(stream, "\\f",  2); break;
+        case '\n': ios_write(stream, "\\n",  2); break;
+        case '\r': ios_write(stream, "\\r",  2); break;
+        case '\t': ios_write(stream, "\\t",  2); break;
         default:
-            if ('\x00' <= *c && *c <= '\x1f') {
+            if (('\x00' <= *c) & (*c <= '\x1f')) {
                 ios_printf(stream, "\\u%04x", (int)*c);
             }
             else {
-                ios_printf(stream, "%c", *c);
+                ios_putc(*c, stream);
             }
         }
     }
-    ios_printf(stream, "\"");
+    ios_putc('"', stream);
 }
 
 


### PR DESCRIPTION
As discussed on #47134, most the time of taking a heap snapshot is spent writing the result. Just combining the `ios_printf` calls makes that significantly faster. Also calling `ios_putc()` instead of `ios_printf()` takes off another half second or so.

```julia
using Profile;
@time Profile.take_heap_snapshot(tempname());

# Before:
# apaz[x][master][~/git/julia]$ ./julia snap.jl 
#  5.397448 seconds (20 allocations: 1.930 KiB, 34.34% gc time)

# After:
# apaz[x][ap/snapshot-write][~/git/julia]$ ./julia snap.jl 
#  3.808458 seconds (20 allocations: 1.930 KiB, 47.86% gc time)
```

```julia
using LoopVectorization;
using Profile;
@time Profile.take_heap_snapshot(tempname());

# Before:
# apaz[x][master][~/git/julia]$ ./julia biggersnap.jl 
#  7.153016 seconds (20 allocations: 1.930 KiB, 35.07% gc time)

# After:
# apaz[x][ap/snapshot-write][~/git/julia]$ ./julia biggersnap.jl
#  5.280476 seconds (20 allocations: 1.930 KiB, 49.39% gc time)
```

These "benchmarks" are not very scientific. This is a single run on my laptop, while using it for other things, and there's significant (~.5s) variability between runs. Still, a noteable improvement.