### PR TITLE
optimize: parameterize `OptimizationState` with `InliningState` properly

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -73,13 +73,6 @@ function add_invoke_backedge!(et::EdgeTracker, @nospecialize(invokesig), mi::Met
     return nothing
 end
 
-struct InliningState{S <: Union{EdgeTracker, Nothing}, MICache, I<:AbstractInterpreter}
-    params::OptimizationParams
-    et::S
-    mi_cache::MICache # TODO move this to `OptimizationState` (as used by EscapeAnalysis as well)
-    interp::I
-end
-
 is_source_inferred(@nospecialize(src::Union{CodeInfo, Vector{UInt8}})) =
     ccall(:jl_ir_flag_inferred, Bool, (Any,), src)
 
@@ -114,60 +107,67 @@ function inlining_policy(interp::AbstractInterpreter,
     return nothing
 end
 
+struct InliningState{Interp<:AbstractInterpreter}
+    params::OptimizationParams
+    et::Union{EdgeTracker,Nothing}
+    world::UInt
+    interp::Interp
+end
+function InliningState(frame::InferenceState, params::OptimizationParams, interp::AbstractInterpreter)
+    et = EdgeTracker(frame.stmt_edges[1]::Vector{Any}, frame.valid_worlds)
+    return InliningState(params, et, frame.world, interp)
+end
+function InliningState(params::OptimizationParams, interp::AbstractInterpreter)
+    return InliningState(params, nothing, get_world_counter(interp), interp)
+end
+
+# get `code_cache(::AbstractInterpreter)` from `state::InliningState`
+code_cache(state::InliningState) = WorldView(code_cache(state.interp), state.world)
+
 include("compiler/ssair/driver.jl")
 
-mutable struct OptimizationState
+mutable struct OptimizationState{IState<:InliningState}
     linfo::MethodInstance
     src::CodeInfo
     ir::Union{Nothing, IRCode}
     stmt_info::Vector{CallInfo}
     mod::Module
-    sptypes::Vector{Any} # static parameters
+    sptypes::Vector{Any}
     slottypes::Vector{Any}
-    inlining::InliningState
+    inlining::IState
     cfg::Union{Nothing,CFG}
-    function OptimizationState(frame::InferenceState, params::OptimizationParams,
-                               interp::AbstractInterpreter, recompute_cfg::Bool=true)
-        s_edges = frame.stmt_edges[1]::Vector{Any}
-        inlining = InliningState(params,
-            EdgeTracker(s_edges, frame.valid_worlds),
-            WorldView(code_cache(interp), frame.world),
-            interp)
-        cfg = recompute_cfg ? nothing : frame.cfg
-        return new(frame.linfo, frame.src, nothing, frame.stmt_info, frame.mod,
-                   frame.sptypes, frame.slottypes, inlining, cfg)
-    end
-    function OptimizationState(linfo::MethodInstance, src::CodeInfo, params::OptimizationParams,
-                               interp::AbstractInterpreter)
-        # prepare src for running optimization passes
-        # if it isn't already
-        nssavalues = src.ssavaluetypes
-        if nssavalues isa Int
-            src.ssavaluetypes = Any[ Any for i = 1:nssavalues ]
-        else
-            nssavalues = length(src.ssavaluetypes::Vector{Any})
-        end
-        sptypes = sptypes_from_meth_instance(linfo)
-        nslots = length(src.slotflags)
-        slottypes = src.slottypes
-        if slottypes === nothing
-            slottypes = Any[ Any for i = 1:nslots ]
-        end
-        stmt_info = CallInfo[ NoCallInfo() for i = 1:nssavalues ]
-        # cache some useful state computations
-        def = linfo.def
-        mod = isa(def, Method) ? def.module : def
-        # Allow using the global MI cache, but don't track edges.
-        # This method is mostly used for unit testing the optimizer
-        inlining = InliningState(params,
-            nothing,
-            WorldView(code_cache(interp), get_world_counter(interp)),
-            interp)
-        return new(linfo, src, nothing, stmt_info, mod,
-                   sptypes, slottypes, inlining, nothing)
-    end
 end
-
+function OptimizationState(frame::InferenceState, params::OptimizationParams,
+                           interp::AbstractInterpreter, recompute_cfg::Bool=true)
+    inlining = InliningState(frame, params, interp)
+    cfg = recompute_cfg ? nothing : frame.cfg
+    return OptimizationState(frame.linfo, frame.src, nothing, frame.stmt_info, frame.mod,
+               frame.sptypes, frame.slottypes, inlining, cfg)
+end
+function OptimizationState(linfo::MethodInstance, src::CodeInfo, params::OptimizationParams,
+                           interp::AbstractInterpreter)
+    # prepare src for running optimization passes if it isn't already
+    nssavalues = src.ssavaluetypes
+    if nssavalues isa Int
+        src.ssavaluetypes = Any[ Any for i = 1:nssavalues ]
+    else
+        nssavalues = length(src.ssavaluetypes::Vector{Any})
+    end
+    sptypes = sptypes_from_meth_instance(linfo)
+    nslots = length(src.slotflags)
+    slottypes = src.slottypes
+    if slottypes === nothing
+        slottypes = Any[ Any for i = 1:nslots ]
+    end
+    stmt_info = CallInfo[ NoCallInfo() for i = 1:nssavalues ]
+    # cache some useful state computations
+    def = linfo.def
+    mod = isa(def, Method) ? def.module : def
+    # Allow using the global MI cache, but don't track edges.
+    # This method is mostly used for unit testing the optimizer
+    inlining = InliningState(params, interp)
+    return OptimizationState(linfo, src, nothing, stmt_info, mod, sptypes, slottypes, inlining, nothing)
+end
 function OptimizationState(linfo::MethodInstance, params::OptimizationParams, interp::AbstractInterpreter)
     src = retrieve_code_info(linfo)
     src === nothing && return nothing

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -820,7 +820,7 @@ struct CachedResult
     CachedResult(@nospecialize(src), effects::Effects) = new(src, effects)
 end
 @inline function get_cached_result(state::InliningState, mi::MethodInstance)
-    code = get(state.mi_cache, mi, nothing)
+    code = get(code_cache(state), mi, nothing)
     if code isa CodeInstance
         if use_const_api(code)
             # in this case function can be inlined to a constant
@@ -1322,7 +1322,7 @@ function info_effects(@nospecialize(result), match::MethodMatch, state::Inlining
     else
         mi = specialize_method(match; preexisting=true)
         if isa(mi, MethodInstance)
-            code = get(state.mi_cache, mi, nothing)
+            code = get(code_cache(state), mi, nothing)
             if code isa CodeInstance
                 return decode_effects(code.ipo_purity_bits)
             end

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1064,7 +1064,7 @@ end
 function try_inline_finalizer!(ir::IRCode, argexprs::Vector{Any}, idx::Int,
     mi::MethodInstance, @nospecialize(info::CallInfo), inlining::InliningState,
     attach_after::Bool)
-    code = get(inlining.mi_cache, mi, nothing)
+    code = get(code_cache(inlining), mi, nothing)
     et = InliningEdgeTracker(inlining.et)
     if code isa CodeInstance
         if use_const_api(code)

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1754,7 +1754,7 @@ let interp = Core.Compiler.NativeInterpreter()
     # ok, now delete the callsite flag, and see the second inlining pass can inline the call
     @eval Core.Compiler $ir.stmts[$i][:flag] &= ~IR_FLAG_NOINLINE
     inlining = Core.Compiler.InliningState(Core.Compiler.OptimizationParams(interp), nothing,
-        Core.Compiler.code_cache(interp), interp)
+        Core.Compiler.get_world_counter(interp), interp)
     ir = Core.Compiler.ssa_inlining_pass!(ir, inlining, false)
     @test count(isinvoke(:*), ir.stmts.inst) == 0
     @test count(iscall((ir, Core.Intrinsics.mul_int)), ir.stmts.inst) == 1


### PR DESCRIPTION
Should improve the inlining pass performance a bit. External `AbstractInterpreter` has been required to recompile all inlining subroutines parameterized with `InliningState` anyway.

@nanosoldier `runbenchmarks("inference", vs=":master")`