### PR TITLE
signals: try harder to validate SEGV causes

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1947,7 +1947,7 @@ static void JL_NORETURN jl_method_error_bare(jl_function_t *f, jl_value_t *args,
         jl_static_show((JL_STREAM*)STDERR_FILENO,args); jl_printf((JL_STREAM*)STDERR_FILENO,"\n");
         jl_ptls_t ptls = jl_current_task->ptls;
         ptls->bt_size = rec_backtrace(ptls->bt_data, JL_MAX_BT_SIZE, 0);
-        jl_critical_error(0, NULL, jl_current_task);
+        jl_critical_error(0, 0, NULL, jl_current_task);
         abort();
     }
     // not reached

--- a/src/init.c
+++ b/src/init.c
@@ -846,9 +846,6 @@ static void post_boot_hooks(void)
     jl_memory_exception    = jl_new_struct_uninit((jl_datatype_t*)core("OutOfMemoryError"));
     jl_readonlymemory_exception = jl_new_struct_uninit((jl_datatype_t*)core("ReadOnlyMemoryError"));
     jl_typeerror_type      = (jl_datatype_t*)core("TypeError");
-#ifdef SEGV_EXCEPTION
-    jl_segv_exception      = jl_new_struct_uninit((jl_datatype_t*)core("SegmentationFault"));
-#endif
     jl_argumenterror_type  = (jl_datatype_t*)core("ArgumentError");
     jl_methoderror_type    = (jl_datatype_t*)core("MethodError");
     jl_loaderror_type      = (jl_datatype_t*)core("LoadError");

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1130,7 +1130,7 @@ size_t rec_backtrace_ctx(jl_bt_element_t *bt_data, size_t maxsize, bt_context_t 
 size_t rec_backtrace_ctx_dwarf(jl_bt_element_t *bt_data, size_t maxsize, bt_context_t *ctx, jl_gcframe_t *pgcstack) JL_NOTSAFEPOINT;
 #endif
 JL_DLLEXPORT jl_value_t *jl_get_backtrace(void);
-void jl_critical_error(int sig, bt_context_t *context, jl_task_t *ct);
+void jl_critical_error(int sig, int si_code, bt_context_t *context, jl_task_t *ct);
 JL_DLLEXPORT void jl_raise_debugger(void);
 int jl_getFunctionInfo(jl_frame_t **frames, uintptr_t pointer, int skipC, int noInline) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_gdblookup(void* ip) JL_NOTSAFEPOINT;
@@ -1246,10 +1246,6 @@ JL_DLLEXPORT const char *jl_dlfind_win32(const char *name);
 
 // libuv wrappers:
 JL_DLLEXPORT int jl_fs_rename(const char *src_path, const char *dst_path);
-
-#ifdef SEGV_EXCEPTION
-extern JL_DLLEXPORT jl_value_t *jl_segv_exception;
-#endif
 
 // -- Runtime intrinsics -- //
 JL_DLLEXPORT const char *jl_intrinsic_name(int f) JL_NOTSAFEPOINT;

--- a/src/options.h
+++ b/src/options.h
@@ -64,11 +64,6 @@
 #endif
 #endif
 
-// SEGV_EXCEPTION turns segmentation faults into catchable julia exceptions.
-// This is not recommended, as the memory state after such an exception should
-// be considered untrusted, but can be helpful during development
-// #define SEGV_EXCEPTION
-
 // profiling options
 
 // GC_FINAL_STATS prints total GC stats at exit

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -434,7 +434,7 @@ void jl_task_frame_noreturn(jl_task_t *ct)
 }
 
 // what to do on a critical error on a thread
-void jl_critical_error(int sig, bt_context_t *context, jl_task_t *ct)
+void jl_critical_error(int sig, int si_code, bt_context_t *context, jl_task_t *ct)
 {
     jl_bt_element_t *bt_data = ct ? ct->ptls->bt_data : NULL;
     size_t *bt_size = ct ? &ct->ptls->bt_size : NULL;
@@ -462,7 +462,10 @@ void jl_critical_error(int sig, bt_context_t *context, jl_task_t *ct)
             sigaddset(&sset, sig);
         pthread_sigmask(SIG_UNBLOCK, &sset, NULL);
 #endif
-        jl_safe_printf("\n[%d] signal (%d): %s\n", getpid(), sig, strsignal(sig));
+        if (si_code)
+            jl_safe_printf("\n[%d] signal (%d.%d): %s\n", getpid(), sig, si_code, strsignal(sig));
+        else
+            jl_safe_printf("\n[%d] signal (%d): %s\n", getpid(), sig, strsignal(sig));
     }
     jl_safe_printf("in expression starting at %s:%d\n", jl_filename, jl_lineno);
     if (context && ct) {

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -85,14 +85,16 @@ void __cdecl crt_sig_handler(int sig, int num)
             jl_try_throw_sigint();
         }
         break;
-    default: // SIGSEGV, (SSIGTERM, IGILL)
-        if (jl_get_safe_restore())
-            jl_rethrow();
+    default: // SIGSEGV, SIGTERM, SIGILL, SIGABRT
+        if (sig == SIGSEGV && jl_get_safe_restore()) {
+            signal(sig, (void (__cdecl *)(int))crt_sig_handler);
+            jl_sig_throw();
+        }
         memset(&Context, 0, sizeof(Context));
         RtlCaptureContext(&Context);
         if (sig == SIGILL)
             jl_show_sigill(&Context);
-        jl_critical_error(sig, &Context, jl_get_current_task());
+        jl_critical_error(sig, 0, &Context, jl_get_current_task());
         raise(sig);
     }
 }
@@ -226,102 +228,113 @@ static BOOL WINAPI sigint_handler(DWORD wsig) //This needs winapi types to guara
 
 LONG WINAPI jl_exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo)
 {
-    jl_task_t *ct = jl_current_task;
-    jl_ptls_t ptls = ct->ptls;
-    if (ExceptionInfo->ExceptionRecord->ExceptionFlags == 0) {
+    if (ExceptionInfo->ExceptionRecord->ExceptionFlags != 0)
+        return EXCEPTION_CONTINUE_SEARCH;
+    jl_task_t *ct = jl_get_current_task();
+    if (ct != NULL && ct->ptls != NULL && ct->ptls->gc_state != JL_GC_STATE_WAITING) {
+        jl_ptls_t ptls = ct->ptls;
         switch (ExceptionInfo->ExceptionRecord->ExceptionCode) {
-            case EXCEPTION_INT_DIVIDE_BY_ZERO:
+        case EXCEPTION_INT_DIVIDE_BY_ZERO:
+            if (ct->eh != NULL) {
                 fpreset();
                 jl_throw_in_ctx(jl_diverror_exception, ExceptionInfo->ContextRecord);
                 return EXCEPTION_CONTINUE_EXECUTION;
-            case EXCEPTION_STACK_OVERFLOW:
+            }
+            break;
+        case EXCEPTION_STACK_OVERFLOW:
+            if (ct->eh != NULL) {
                 ptls->needs_resetstkoflw = 1;
                 jl_throw_in_ctx(jl_stackovf_exception, ExceptionInfo->ContextRecord);
                 return EXCEPTION_CONTINUE_EXECUTION;
-            case EXCEPTION_ACCESS_VIOLATION:
-                if (jl_addr_is_safepoint(ExceptionInfo->ExceptionRecord->ExceptionInformation[1])) {
-                    jl_set_gc_and_wait();
-                    // Do not raise sigint on worker thread
-                    if (ptls->tid != 0)
-                        return EXCEPTION_CONTINUE_EXECUTION;
-                    if (ptls->defer_signal) {
-                        jl_safepoint_defer_sigint();
-                    }
-                    else if (jl_safepoint_consume_sigint()) {
-                        jl_clear_force_sigint();
-                        jl_throw_in_ctx(jl_interrupt_exception, ExceptionInfo->ContextRecord);
-                    }
+            }
+            break;
+        case EXCEPTION_ACCESS_VIOLATION:
+            if (jl_addr_is_safepoint(ExceptionInfo->ExceptionRecord->ExceptionInformation[1])) {
+                jl_set_gc_and_wait();
+                // Do not raise sigint on worker thread
+                if (ptls->tid != 0)
                     return EXCEPTION_CONTINUE_EXECUTION;
+                if (ptls->defer_signal) {
+                    jl_safepoint_defer_sigint();
                 }
-                if (jl_get_safe_restore()) {
-                    jl_throw_in_ctx(NULL, ExceptionInfo->ContextRecord);
-                    return EXCEPTION_CONTINUE_EXECUTION;
+                else if (jl_safepoint_consume_sigint()) {
+                    jl_clear_force_sigint();
+                    jl_throw_in_ctx(jl_interrupt_exception, ExceptionInfo->ContextRecord);
                 }
+                return EXCEPTION_CONTINUE_EXECUTION;
+            }
+            if (jl_get_safe_restore()) {
+                jl_throw_in_ctx(NULL, ExceptionInfo->ContextRecord);
+                return EXCEPTION_CONTINUE_EXECUTION;
+            }
+            if (ct->eh != NULL) {
                 if (ExceptionInfo->ExceptionRecord->ExceptionInformation[0] == 1) { // writing to read-only memory (e.g. mmap)
                     jl_throw_in_ctx(jl_readonlymemory_exception, ExceptionInfo->ContextRecord);
                     return EXCEPTION_CONTINUE_EXECUTION;
                 }
+            }
+        default:
+            break;
         }
-        if (ExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_ILLEGAL_INSTRUCTION) {
-            jl_safe_printf("\n");
-            jl_show_sigill(ExceptionInfo->ContextRecord);
-        }
-        jl_safe_printf("\nPlease submit a bug report with steps to reproduce this fault, and any error messages that follow (in their entirety). Thanks.\nException: ");
-        switch (ExceptionInfo->ExceptionRecord->ExceptionCode) {
-            case EXCEPTION_ACCESS_VIOLATION:
-                jl_safe_printf("EXCEPTION_ACCESS_VIOLATION"); break;
-            case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
-                jl_safe_printf("EXCEPTION_ARRAY_BOUNDS_EXCEEDED"); break;
-            case EXCEPTION_BREAKPOINT:
-                jl_safe_printf("EXCEPTION_BREAKPOINT"); break;
-            case EXCEPTION_DATATYPE_MISALIGNMENT:
-                jl_safe_printf("EXCEPTION_DATATYPE_MISALIGNMENT"); break;
-            case EXCEPTION_FLT_DENORMAL_OPERAND:
-                jl_safe_printf("EXCEPTION_FLT_DENORMAL_OPERAND"); break;
-            case EXCEPTION_FLT_DIVIDE_BY_ZERO:
-                jl_safe_printf("EXCEPTION_FLT_DIVIDE_BY_ZERO"); break;
-            case EXCEPTION_FLT_INEXACT_RESULT:
-                jl_safe_printf("EXCEPTION_FLT_INEXACT_RESULT"); break;
-            case EXCEPTION_FLT_INVALID_OPERATION:
-                jl_safe_printf("EXCEPTION_FLT_INVALID_OPERATION"); break;
-            case EXCEPTION_FLT_OVERFLOW:
-                jl_safe_printf("EXCEPTION_FLT_OVERFLOW"); break;
-            case EXCEPTION_FLT_STACK_CHECK:
-                jl_safe_printf("EXCEPTION_FLT_STACK_CHECK"); break;
-            case EXCEPTION_FLT_UNDERFLOW:
-                jl_safe_printf("EXCEPTION_FLT_UNDERFLOW"); break;
-            case EXCEPTION_ILLEGAL_INSTRUCTION:
-                jl_safe_printf("EXCEPTION_ILLEGAL_INSTRUCTION"); break;
-            case EXCEPTION_IN_PAGE_ERROR:
-                jl_safe_printf("EXCEPTION_IN_PAGE_ERROR"); break;
-            case EXCEPTION_INT_DIVIDE_BY_ZERO:
-                jl_safe_printf("EXCEPTION_INT_DIVIDE_BY_ZERO"); break;
-            case EXCEPTION_INT_OVERFLOW:
-                jl_safe_printf("EXCEPTION_INT_OVERFLOW"); break;
-            case EXCEPTION_INVALID_DISPOSITION:
-                jl_safe_printf("EXCEPTION_INVALID_DISPOSITION"); break;
-            case EXCEPTION_NONCONTINUABLE_EXCEPTION:
-                jl_safe_printf("EXCEPTION_NONCONTINUABLE_EXCEPTION"); break;
-            case EXCEPTION_PRIV_INSTRUCTION:
-                jl_safe_printf("EXCEPTION_PRIV_INSTRUCTION"); break;
-            case EXCEPTION_SINGLE_STEP:
-                jl_safe_printf("EXCEPTION_SINGLE_STEP"); break;
-            case EXCEPTION_STACK_OVERFLOW:
-                jl_safe_printf("EXCEPTION_STACK_OVERFLOW"); break;
-            default:
-                jl_safe_printf("UNKNOWN"); break;
-        }
-        jl_safe_printf(" at 0x%Ix -- ", (size_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
-        jl_print_native_codeloc((uintptr_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
-
-        jl_critical_error(0, ExceptionInfo->ContextRecord, ct);
-        static int recursion = 0;
-        if (recursion++)
-            exit(1);
-        else
-            jl_exit(1);
     }
-    return EXCEPTION_CONTINUE_SEARCH;
+    if (ExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_ILLEGAL_INSTRUCTION) {
+        jl_safe_printf("\n");
+        jl_show_sigill(ExceptionInfo->ContextRecord);
+    }
+    jl_safe_printf("\nPlease submit a bug report with steps to reproduce this fault, and any error messages that follow (in their entirety). Thanks.\nException: ");
+    switch (ExceptionInfo->ExceptionRecord->ExceptionCode) {
+    case EXCEPTION_ACCESS_VIOLATION:
+        jl_safe_printf("EXCEPTION_ACCESS_VIOLATION"); break;
+    case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
+        jl_safe_printf("EXCEPTION_ARRAY_BOUNDS_EXCEEDED"); break;
+    case EXCEPTION_BREAKPOINT:
+        jl_safe_printf("EXCEPTION_BREAKPOINT"); break;
+    case EXCEPTION_DATATYPE_MISALIGNMENT:
+        jl_safe_printf("EXCEPTION_DATATYPE_MISALIGNMENT"); break;
+    case EXCEPTION_FLT_DENORMAL_OPERAND:
+        jl_safe_printf("EXCEPTION_FLT_DENORMAL_OPERAND"); break;
+    case EXCEPTION_FLT_DIVIDE_BY_ZERO:
+        jl_safe_printf("EXCEPTION_FLT_DIVIDE_BY_ZERO"); break;
+    case EXCEPTION_FLT_INEXACT_RESULT:
+        jl_safe_printf("EXCEPTION_FLT_INEXACT_RESULT"); break;
+    case EXCEPTION_FLT_INVALID_OPERATION:
+        jl_safe_printf("EXCEPTION_FLT_INVALID_OPERATION"); break;
+    case EXCEPTION_FLT_OVERFLOW:
+        jl_safe_printf("EXCEPTION_FLT_OVERFLOW"); break;
+    case EXCEPTION_FLT_STACK_CHECK:
+        jl_safe_printf("EXCEPTION_FLT_STACK_CHECK"); break;
+    case EXCEPTION_FLT_UNDERFLOW:
+        jl_safe_printf("EXCEPTION_FLT_UNDERFLOW"); break;
+    case EXCEPTION_ILLEGAL_INSTRUCTION:
+        jl_safe_printf("EXCEPTION_ILLEGAL_INSTRUCTION"); break;
+    case EXCEPTION_IN_PAGE_ERROR:
+        jl_safe_printf("EXCEPTION_IN_PAGE_ERROR"); break;
+    case EXCEPTION_INT_DIVIDE_BY_ZERO:
+        jl_safe_printf("EXCEPTION_INT_DIVIDE_BY_ZERO"); break;
+    case EXCEPTION_INT_OVERFLOW:
+        jl_safe_printf("EXCEPTION_INT_OVERFLOW"); break;
+    case EXCEPTION_INVALID_DISPOSITION:
+        jl_safe_printf("EXCEPTION_INVALID_DISPOSITION"); break;
+    case EXCEPTION_NONCONTINUABLE_EXCEPTION:
+        jl_safe_printf("EXCEPTION_NONCONTINUABLE_EXCEPTION"); break;
+    case EXCEPTION_PRIV_INSTRUCTION:
+        jl_safe_printf("EXCEPTION_PRIV_INSTRUCTION"); break;
+    case EXCEPTION_SINGLE_STEP:
+        jl_safe_printf("EXCEPTION_SINGLE_STEP"); break;
+    case EXCEPTION_STACK_OVERFLOW:
+        jl_safe_printf("EXCEPTION_STACK_OVERFLOW"); break;
+    default:
+        jl_safe_printf("UNKNOWN"); break;
+    }
+    jl_safe_printf(" at 0x%Ix -- ", (size_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
+    jl_print_native_codeloc((uintptr_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
+
+    jl_critical_error(0, 0, ExceptionInfo->ContextRecord, ct);
+    static int recursion = 0;
+    if (recursion++)
+        exit(1);
+    else
+        jl_exit(1);
 }
 
 JL_DLLEXPORT void jl_install_sigint_handler(void)

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -259,14 +259,8 @@ jl_value_t **const*const get_tags(void) {
         INSERT_TAG(jl_builtin_getglobal);
         INSERT_TAG(jl_builtin_setglobal);
         // n.b. must update NUM_TAGS when you add something here
-
-        // All optional tags must be placed at the end, so that we
-        // don't accidentally have a `NULL` in the middle
-#ifdef SEGV_EXCEPTION
-        INSERT_TAG(jl_segv_exception);
-#endif
 #undef INSERT_TAG
-        assert(i >= (NUM_TAGS-2) && i < NUM_TAGS);
+        assert(i == NUM_TAGS - 1);
     }
     return (jl_value_t**const*const) _tags;
 }


### PR DESCRIPTION
Before turning a signal into a Julia exception, we would like to be fairly certain it is not:
 - caused by the GC (and going to hang the system waiting to finish)
 - occurring during GC (and going to corrupt the mark bits)
 - occurring on a "foreign" thread (and lacking an exception handler and/or ptls object)
 - actually an alignment fault
 - send by the user with `kill`
 - the page actually is non-existant

The `msync` code calls can be directly checked instead by making sure the `code[0]` is not KERN_INVALID_ADDRESS, which answers the same question for us. Equivalent to how the check is done on other unix: `sig == SIGSEGV && info->si_code == SEGV_ACCERR`

This would have helped some with debugging the recent CI hangs, since those were getting stuck here. Now if we inject a failure into the gc like:

```diff
diff --git a/src/gc.c b/src/gc.c
index 05a223ce9f..d3f46f77b5 100644
--- a/src/gc.c
+++ b/src/gc.c
@@ -3241,6 +3241,8 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
     JL_PROBE_GC_MARK_BEGIN();
     uint64_t start_mark_time = jl_hrtime();
 
+    *(void*volatile*)_jl_gc_collect = 0;
+
     // 1. fix GC bits of objects in the remset.
     assert(gc_n_threads);
     for (int t_i = 0; t_i < gc_n_threads; t_i++) {
```
we can be certain it will fail hard:
```
$ ./julia -e 'GC.gc()'

[300396] signal (11): Segmentation fault
in expression starting at none:1
_jl_gc_collect at /data/vtjnash/julia/src/gc.c:3244
```