### PR TITLE
Update docs to use `Threads.threadpoolsize` instead `Base`

### DIFF
--- a/base/threads_overloads.jl
+++ b/base/threads_overloads.jl
@@ -3,7 +3,7 @@
 """
     Threads.foreach(f, channel::Channel;
                     schedule::Threads.AbstractSchedule=Threads.FairSchedule(),
-                    ntasks=Base.threadpoolsize())
+                    ntasks=Threads.threadpoolsize())
 
 Similar to `foreach(f, channel)`, but iteration over `channel` and calls to
 `f` are split across `ntasks` tasks spawned by `Threads.@spawn`. This function

--- a/doc/src/manual/embedding.md
+++ b/doc/src/manual/embedding.md
@@ -670,7 +670,7 @@ int main()
     jl_eval_string("func(i) = ccall(:c_func, Float64, (Int32,), i)");
 
     // Call func() multiple times, using multiple threads to do so
-    jl_eval_string("println(Base.threadpoolsize())");
+    jl_eval_string("println(Threads.threadpoolsize())");
     jl_eval_string("use(i) = println(\"[J $(Threads.threadid())] i = $(i) -> $(func(i))\")");
     jl_eval_string("Threads.@threads for i in 1:5 use(i) end");
 


### PR DESCRIPTION
Update docs for

```julia
julia> Base.threadpoolsize
ERROR: UndefVarError: `threadpoolsize` not defined
Stacktrace:
 [1] getproperty(x::Module, f::Symbol)
   @ Base ./Base.jl:31
 [2] top-level scope
   @ REPL[1]:1
   
julia> Threads.threadpoolsize
threadpoolsize (generic function with 1 method)
   
julia> VERSION
v"1.9.0-DEV.1611"
```