### PR TITLE
[wip] add sysimage size to make output report

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -453,6 +453,6 @@ let pre_output_time = time_ns()
     # Print report after sysimage has been saved so all time spent can be captured
     Base.postoutput() do
         output_time = time_ns() - pre_output_time
-        print("Output ────── "); Base.time_print(output_time); println()
+        print("Output ────── "); Base.time_print(output_time)
     end
 end

--- a/sysimage.mk
+++ b/sysimage.mk
@@ -79,7 +79,8 @@ $$(build_private_libdir)/sys$1-o.a $$(build_private_libdir)/sys$1-bc.a : $$(buil
 	if ! JULIA_BINDIR=$$(call cygpath_w,$(build_bindir)) WINEPATH="$$(call cygpath_w,$$(build_bindir));$$$$WINEPATH" \
 			JULIA_NUM_THREADS=1 \
 			$$(call spawn, $3) $2 -C "$$(JULIA_CPU_TARGET)" --output-$$* $$(call cygpath_w,$$@).tmp $$(JULIA_SYSIMG_BUILD_FLAGS) \
-			--startup-file=no --warn-overwrite=yes --sysimage $$(call cygpath_w,$$<) $$(call cygpath_w,$$(JULIAHOME)/contrib/generate_precompile.jl) $(JULIA_PRECOMPILE); then \
+			--startup-file=no --warn-overwrite=yes --sysimage $$(call cygpath_w,$$<) $$(call cygpath_w,$$(JULIAHOME)/contrib/generate_precompile.jl) $(JULIA_PRECOMPILE) \
+			|| ! $$(call spawn, $3) --startup-file=no --sysimage $$(call cygpath_w,$$<)--sysimage $$(call cygpath_w,$$<) -e 'println(", sysimage size: ", Base.format_bytes(filesize(unsafe_string(Base.JLOptions().image_file))))'; then \
 		echo '*** This error is usually fixed by running `make clean`. If the error persists$$(COMMA) try `make cleanall`. ***'; \
 		false; \
 	fi )


### PR DESCRIPTION
~~This seems the wrong way to report size because the file isn't finished being written to~~ Now calculates the size later

```
Generating REPL precompile statements... 40/40
Executing precompile statements... 1828/1871
Precompilation complete. Summary:
Generation ── 106.718929 seconds 75.3884%
Execution ───  34.839853 seconds 24.6116%
Total ─────── 141.558782 seconds
Outputting sysimage file...
Output ────── 146.560538 seconds, sysimage size: 153.216 MiB
    LINK usr/lib/julia/sys.dylib
```