### PR TITLE
Allow reentrant Inference profiling.

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -402,7 +402,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
 end
 
 function ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IRInterpretationState)
-    if __measure_typeinf__[]
+    if __measure_typeinf()
         inf_frame = Timings.InferenceFrameInfo(irsv.mi, irsv.world, Any[], Any[], length(irsv.ir.argtypes))
         Timings.enter_new_timer(inf_frame)
         v = _ir_abstract_constant_propagation(interp, irsv)


### PR DESCRIPTION
A follow-up to https://github.com/JuliaLang/julia/pull/47258.

Change start/stop measuring type inference timings to an atomic counter.

This allows multiple tasks to start timing and then all stop timing, without the timing being disabled by the first tasks to finish.

I'm not entirely sure if this Atomic Int is overkill.. 🤔 maybe we should just grab the inference lock when we update the integer? I'm also not sure if this will pass bootstrap or not. We'll see when it builds, i guess.

I also left the old `__set_measure_typeinf(onoff::Bool)` function, rather than deleting it, so that this wouldn't be a backwards-incompatible breaking change, breaking older versions of SnoopCompile.jl. I wanted to mark the function with `@deprecate`, but it seems to not be available from `Core.Compiler.