### PR TITLE
Detect bad arguments to code_native

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -863,7 +863,7 @@ function to_tuple_type(@nospecialize(t))
         t = Tuple{t...}
     end
     if isa(t, Type) && t <: Tuple
-        for p in unwrap_unionall(t).parameters
+        for p in (unwrap_unionall(t)::DataType).parameters
             if isa(p, Core.TypeofVararg)
                 p = unwrapva(p)
             end
@@ -878,13 +878,10 @@ function to_tuple_type(@nospecialize(t))
 end
 
 function signature_type(@nospecialize(f), @nospecialize(argtypes))
+    argtypes = to_tuple_type(argtypes)
     ft = Core.Typeof(f)
-    if isa(argtypes, Type)
-        u = unwrap_unionall(argtypes)
-        return rewrap_unionall(Tuple{ft, u.parameters...}, argtypes)
-    else
-        return Tuple{ft, argtypes...}
-    end
+    u = unwrap_unionall(argtypes)::DataType
+    return rewrap_unionall(Tuple{ft, u.parameters...}, argtypes)
 end
 
 """
@@ -990,7 +987,6 @@ See also: [`which`](@ref) and `@which`.
 """
 function methods(@nospecialize(f), @nospecialize(t),
                  mod::Union{Tuple{Module},AbstractArray{Module},Nothing}=nothing)
-    t = to_tuple_type(t)
     world = get_world_counter()
     # Lack of specialization => a comprehension triggers too many invalidations via _collect, so collect the methods manually
     ms = Method[]
@@ -1398,9 +1394,9 @@ function return_types(@nospecialize(f), @nospecialize(types=default_tt(f));
         _, rt = only(code_typed_opaque_closure(f))
         return Any[rt]
     end
-    types = to_tuple_type(types)
+
     if isa(f, Core.Builtin)
-        argtypes = Any[types.parameters...]
+        argtypes = Any[to_tuple_type(types).parameters...]
         rt = Core.Compiler.builtin_tfunction(interp, f, argtypes, nothing)
         return Any[rt]
     end
@@ -1418,8 +1414,8 @@ function infer_effects(@nospecialize(f), @nospecialize(types=default_tt(f));
                        world = get_world_counter(),
                        interp = Core.Compiler.NativeInterpreter(world))
     ccall(:jl_is_in_pure_context, Bool, ()) && error("code reflection cannot be used from generated functions")
-    types = to_tuple_type(types)
     if isa(f, Core.Builtin)
+        types = to_tuple_type(types)
         argtypes = Any[types.parameters...]
         rt = Core.Compiler.builtin_tfunction(interp, f, argtypes, nothing)
         return Core.Compiler.builtin_effects(Core.Compiler.typeinf_lattice(interp), f, argtypes, rt)
@@ -1505,7 +1501,6 @@ If `types` is an abstract type, then the method that would be called by `invoke`
 See also: [`parentmodule`](@ref), and `@which` and `@edit` in [`InteractiveUtils`](@ref man-interactive-utils).
 """
 function which(@nospecialize(f), @nospecialize(t))
-    t = to_tuple_type(t)
     tt = signature_type(f, t)
     return which(tt)
 end
@@ -1613,7 +1608,6 @@ true
 ```
 """
 function hasmethod(@nospecialize(f), @nospecialize(t); world::UInt=get_world_counter())
-    t = to_tuple_type(t)
     t = signature_type(f, t)
     return ccall(:jl_gf_invoke_lookup, Any, (Any, Any, UInt), t, nothing, world) !== nothing
 end

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -11,7 +11,7 @@ export apropos, edit, less, code_warntype, code_llvm, code_native, methodswith, 
 import Base.Docs.apropos
 
 using Base: unwrap_unionall, rewrap_unionall, isdeprecated, Bottom, show_unquoted, summarysize,
-    to_tuple_type, signature_type, format_bytes
+    signature_type, format_bytes
 
 using Markdown
 

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -456,6 +456,8 @@ end # module ReflectionTest
 
 @test_throws ArgumentError("argument is not a generic function") code_llvm(===, Tuple{Int, Int})
 @test_throws ArgumentError("argument is not a generic function") code_native(===, Tuple{Int, Int})
+@test_throws ErrorException("argument tuple type must contain only types") code_native(sum, (Int64,1))
+@test_throws ErrorException("expected tuple type") code_native(sum, Vector{Int64})
 
 # Issue #18883, code_llvm/code_native for generated functions
 @generated f18883() = nothing


### PR DESCRIPTION
The types for `code_native()` must be given as a tuple of types. Added checking to `signature_type()` with `to_tuple_type()` to validate this.

Fixes #45414