### PR TITLE
inference: pass `𝕃::AbstractLattice` to more `nothrow`-tfuncs

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -221,6 +221,11 @@ function ifelse_tfunc(@nospecialize(cnd), @nospecialize(x), @nospecialize(y))
 end
 add_tfunc(Core.ifelse, 3, 3, ifelse_tfunc, 1)
 
+function ifelse_nothrow(@specialize(𝕃::AbstractLattice), @nospecialize(cond), @nospecialize(x), @nospecialize(y))
+    ⊑ = Core.Compiler.:⊑(𝕃)
+    return cond ⊑ Bool
+end
+
 function egal_tfunc(@nospecialize(x), @nospecialize(y))
     xx = widenconditional(x)
     yy = widenconditional(y)
@@ -244,13 +249,12 @@ function egal_tfunc(@nospecialize(x), @nospecialize(y))
 end
 add_tfunc(===, 2, 2, egal_tfunc, 1)
 
-function isdefined_nothrow(argtypes::Array{Any, 1})
-    length(argtypes) == 2 || return false
-    a1, a2 = argtypes[1], argtypes[2]
-    if hasintersect(widenconst(a1), Module)
-        return a2 ⊑ Symbol
+function isdefined_nothrow(@specialize(𝕃::AbstractLattice), @nospecialize(x), @nospecialize(name))
+    ⊑ = Core.Compiler.:⊑(𝕃)
+    if hasintersect(widenconst(x), Module)
+        return name ⊑ Symbol
     else
-        return a2 ⊑ Symbol || a2 ⊑ Int
+        return name ⊑ Symbol || name ⊑ Int
     end
 end
 
@@ -482,10 +486,7 @@ function arraysize_tfunc(@nospecialize(ary), @nospecialize(dim))
 end
 add_tfunc(arraysize, 2, 2, arraysize_tfunc, 4)
 
-function arraysize_nothrow(argtypes::Vector{Any})
-    length(argtypes) == 2 || return false
-    ary = argtypes[1]
-    dim = argtypes[2]
+function arraysize_nothrow(@nospecialize(ary), @nospecialize(dim))
     ary ⊑ Array || return false
     if isa(dim, Const)
         dimval = dim.val
@@ -592,6 +593,10 @@ end
 add_tfunc(compilerbarrier, 2, 2, compilerbarrier_tfunc, 5)
 add_tfunc(Core.finalizer, 2, 4, (@nospecialize args...)->Nothing, 5)
 
+function compilerbarrier_nothrow(@nospecialize(setting), @nospecialize(val))
+    return isa(setting, Const) && contains_is((:type, :const, :conditional), setting.val)
+end
+
 # more accurate typeof_tfunc for vararg tuples abstract only in length
 function typeof_concrete_vararg(t::DataType)
     np = length(t.parameters)
@@ -664,6 +669,17 @@ function typeassert_tfunc(@nospecialize(v), @nospecialize(t))
 end
 add_tfunc(typeassert, 2, 2, typeassert_tfunc, 4)
 
+function typeassert_nothrow(@specialize(𝕃::AbstractLattice), @nospecialize(v), @nospecialize(t))
+    ⊑ = Core.Compiler.:⊑(𝕃)
+    # ty, exact = instanceof_tfunc(t)
+    # return exact && v ⊑ ty
+    if (isType(t) && !has_free_typevars(t) && v ⊑ t.parameters[1]) ||
+        (isa(t, Const) && isa(t.val, Type) && v ⊑ t.val)
+        return true
+    end
+    return false
+end
+
 function isa_tfunc(@specialize(𝕃::AbstractLattice), @nospecialize(v), @nospecialize(tt))
     t, isexact = instanceof_tfunc(tt)
     if t === Bottom
@@ -700,6 +716,11 @@ end
 isa_tfunc(@nospecialize(v), @nospecialize(t)) = isa_tfunc(fallback_lattice, v, t)
 add_tfunc(isa, 2, 2, isa_tfunc, 1)
 
+function isa_nothrow(@specialize(𝕃::AbstractLattice), @nospecialize(obj), @nospecialize(typ))
+    ⊑ = Core.Compiler.:⊑(𝕃)
+    return typ ⊑ Type
+end
+
 function subtype_tfunc(@nospecialize(a), @nospecialize(b))
     a, isexact_a = instanceof_tfunc(a)
     b, isexact_b = instanceof_tfunc(b)
@@ -717,6 +738,11 @@ function subtype_tfunc(@nospecialize(a), @nospecialize(b))
     return Bool
 end
 add_tfunc(<:, 2, 2, subtype_tfunc, 10)
+
+function subtype_nothrow(@specialize(𝕃::AbstractLattice), @nospecialize(lty), @nospecialize(rty))
+    ⊑ = Core.Compiler.:⊑(𝕃)
+    return lty ⊑ Type && rty ⊑ Type
+end
 
 function fieldcount_noerror(@nospecialize t)
     if t isa UnionAll || t isa Union
@@ -1144,22 +1170,19 @@ function _mutability_errorcheck(@nospecialize objt0)
     return true
 end
 
-function setfield!_nothrow(argtypes::Vector{Any})
-    if length(argtypes) == 4
-        order = argtypes[4]
-        order === Const(:not_atomic) || return false # currently setfield!_nothrow is assuming not atomic
-    else
-        length(argtypes) == 3 || return false
-    end
-    return setfield!_nothrow(argtypes[1], argtypes[2], argtypes[3])
+function setfield!_nothrow(@specialize(𝕃::AbstractLattice), s00, name, v, order)
+    @nospecialize s00 name v order
+    order === Const(:not_atomic) || return false # currently setfield!_nothrow is assuming not atomic
+    return setfield!_nothrow(𝕃, s00, name, v)
 end
-function setfield!_nothrow(s00, name, v)
-    @nospecialize
+function setfield!_nothrow(@specialize(𝕃::AbstractLattice), s00, name, v)
+    @nospecialize s00 name v
+    ⊑ = Core.Compiler.:⊑(𝕃)
     s0 = widenconst(s00)
     s = unwrap_unionall(s0)
     if isa(s, Union)
-        return setfield!_nothrow(rewrap_unionall(s.a, s00), name, v) &&
-               setfield!_nothrow(rewrap_unionall(s.b, s00), name, v)
+        return setfield!_nothrow(𝕃, rewrap_unionall(s.a, s00), name, v) &&
+               setfield!_nothrow(𝕃, rewrap_unionall(s.b, s00), name, v)
     elseif isa(s, DataType)
         # Can't say anything about abstract types
         isabstracttype(s) && return false
@@ -1429,7 +1452,7 @@ valid_tparam_type(T::DataType) = valid_typeof_tparam(T)
 valid_tparam_type(U::Union) = valid_tparam_type(U.a) && valid_tparam_type(U.b)
 valid_tparam_type(U::UnionAll) = valid_tparam_type(unwrap_unionall(U))
 
-function apply_type_nothrow(@specialize(lattice::AbstractLattice), argtypes::Array{Any, 1}, @nospecialize(rt))
+function apply_type_nothrow(@specialize(lattice::AbstractLattice), argtypes::Vector{Any}, @nospecialize(rt))
     rt === Type && return false
     length(argtypes) >= 1 || return false
     headtypetype = argtypes[1]
@@ -1485,7 +1508,6 @@ function apply_type_nothrow(@specialize(lattice::AbstractLattice), argtypes::Arr
     end
     return true
 end
-apply_type_nothrow(argtypes::Array{Any, 1}, @nospecialize(rt)) = apply_type_nothrow(fallback_lattice, argtypes, rt)
 
 const _tvarnames = Symbol[:_A, :_B, :_C, :_D, :_E, :_F, :_G, :_H, :_I, :_J, :_K, :_L, :_M,
                           :_N, :_O, :_P, :_Q, :_R, :_S, :_T, :_U, :_V, :_W, :_X, :_Y, :_Z]
@@ -1829,7 +1851,7 @@ function arrayset_typecheck(@nospecialize(arytype), @nospecialize(elmtype))
 end
 
 # Query whether the given builtin is guaranteed not to throw given the argtypes
-function _builtin_nothrow(@specialize(𝕃::AbstractLattice), @nospecialize(f), argtypes::Array{Any,1}, @nospecialize(rt))
+function _builtin_nothrow(@specialize(𝕃::AbstractLattice), @nospecialize(f), argtypes::Vector{Any}, @nospecialize(rt))
     ⊑ = Core.Compiler.:⊑(𝕃)
     if f === arrayset
         array_builtin_common_nothrow(argtypes, 4) || return false
@@ -1844,65 +1866,76 @@ function _builtin_nothrow(@specialize(𝕃::AbstractLattice), @nospecialize(f), 
 
     # These builtins are not-vararg, so if we have varars, here, we can't guarantee
     # the correct number of arguments.
-    (!isempty(argtypes) && isvarargtype(argtypes[end])) && return false
+    na = length(argtypes)
+    (na ≠ 0 && isvarargtype(argtypes[end])) && return false
     if f === arraysize
-        return arraysize_nothrow(argtypes)
+        na == 2 || return false
+        return arraysize_nothrow(argtypes[1], argtypes[2])
     elseif f === Core._typevar
-        length(argtypes) == 3 || return false
+        na == 3 || return false
         return typevar_nothrow(argtypes[1], argtypes[2], argtypes[3])
     elseif f === invoke
         return false
     elseif f === getfield
         return getfield_nothrow(argtypes)
     elseif f === setfield!
-        return setfield!_nothrow(argtypes)
+        if na == 3
+            return setfield!_nothrow(𝕃, argtypes[1], argtypes[2], argtypes[3])
+        elseif na == 4
+            return setfield!_nothrow(𝕃, argtypes[1], argtypes[2], argtypes[3], argtypes[4])
+        end
+        return false
     elseif f === fieldtype
-        length(argtypes) == 2 || return false
+        na == 2 || return false
         return fieldtype_nothrow(𝕃, argtypes[1], argtypes[2])
     elseif f === apply_type
         return apply_type_nothrow(𝕃, argtypes, rt)
     elseif f === isa
-        length(argtypes) == 2 || return false
-        return argtypes[2] ⊑ Type
+        na == 2 || return false
+        return isa_nothrow(𝕃, nothing, argtypes[2])
     elseif f === (<:)
-        length(argtypes) == 2 || return false
-        return argtypes[1] ⊑ Type && argtypes[2] ⊑ Type
+        na == 2 || return false
+        return subtype_nothrow(𝕃, argtypes[1], argtypes[2])
     elseif f === UnionAll
-        return length(argtypes) == 2 &&
-            (argtypes[1] ⊑ TypeVar && argtypes[2] ⊑ Type)
+        return na == 2 && (argtypes[1] ⊑ TypeVar && argtypes[2] ⊑ Type)
     elseif f === isdefined
-        return isdefined_nothrow(argtypes)
+        na == 2 || return false
+        return isdefined_nothrow(𝕃, argtypes[1], argtypes[2])
     elseif f === Core.sizeof
-        length(argtypes) == 1 || return false
+        na == 1 || return false
         return sizeof_nothrow(argtypes[1])
     elseif f === Core.ifelse
-        length(argtypes) == 3 || return false
-        return argtypes[1] ⊑ Bool
+        na == 3 || return false
+        return ifelse_nothrow(𝕃, argtypes[1], nothing, nothing)
     elseif f === typeassert
-        length(argtypes) == 2 || return false
-        a3 = argtypes[2]
-        if (isType(a3) && !has_free_typevars(a3) && argtypes[1] ⊑ a3.parameters[1]) ||
-            (isa(a3, Const) && isa(a3.val, Type) && argtypes[1] ⊑ a3.val)
-            return true
+        na == 2 || return false
+        return typeassert_nothrow(𝕃, argtypes[1], argtypes[2])
+    elseif f === getglobal
+        if na == 2
+            return getglobal_nothrow(argtypes[1], argtypes[2])
+        elseif na == 3
+            return getglobal_nothrow(argtypes[1], argtypes[2], argtypes[3])
         end
         return false
-    elseif f === getglobal
-        return getglobal_nothrow(argtypes)
     elseif f === setglobal!
-        return setglobal!_nothrow(argtypes)
+        if na == 3
+            return setglobal!_nothrow(argtypes[1], argtypes[2], argtypes[3])
+        elseif na == 4
+            return setglobal!_nothrow(argtypes[1], argtypes[2], argtypes[3], argtypes[4])
+        end
+        return false
     elseif f === Core.get_binding_type
-        length(argtypes) == 2 || return false
-        return argtypes[1] ⊑ Module && argtypes[2] ⊑ Symbol
+        na == 2 || return false
+        return get_binding_type_nothrow(𝕃, argtypes[1], argtypes[2])
     elseif f === donotdelete
         return true
     elseif f === Core.finalizer
-        2 <= length(argtypes) <= 4 || return false
+        2 <= na <= 4 || return false
         # Core.finalizer does no error checking - that's done in Base.finalizer
         return true
     elseif f === Core.compilerbarrier
-        length(argtypes) == 2 || return false
-        a1 = argtypes[1]
-        return isa(a1, Const) && contains_is((:type, :const, :conditional), a1.val)
+        na == 2 || return false
+        return compilerbarrier_nothrow(argtypes[1], nothing)
     end
     return false
 end
@@ -1992,12 +2025,13 @@ const _SPECIAL_BUILTINS = Any[
     Core._apply_iterate,
 ]
 
-function isdefined_effects(argtypes::Vector{Any})
+function isdefined_effects(@specialize(𝕃::AbstractLattice), argtypes::Vector{Any})
     # consistent if the first arg is immutable
-    isempty(argtypes) && return EFFECTS_THROWS
+    na = length(argtypes)
+    na == 0 && return EFFECTS_THROWS
     obj = argtypes[1]
     consistent = is_immutable_argtype(unwrapva(obj)) ? ALWAYS_TRUE : ALWAYS_FALSE
-    nothrow = !isvarargtype(argtypes[end]) && isdefined_nothrow(argtypes)
+    nothrow = !isvarargtype(argtypes[end]) && na == 2 && isdefined_nothrow(𝕃, obj, argtypes[2])
     return Effects(EFFECTS_TOTAL; consistent, nothrow)
 end
 
@@ -2043,21 +2077,24 @@ end
 function getglobal_effects(argtypes::Vector{Any}, @nospecialize(rt))
     consistent = inaccessiblememonly = ALWAYS_FALSE
     nothrow = false
-    if getglobal_nothrow(argtypes)
-        nothrow = true
-        # typeasserts below are already checked in `getglobal_nothrow`
-        M, s = (argtypes[1]::Const).val::Module, (argtypes[2]::Const).val::Symbol
-        if isconst(M, s)
-            consistent = ALWAYS_TRUE
-            if is_mutation_free_argtype(rt)
-                inaccessiblememonly = ALWAYS_TRUE
+    if length(argtypes) ≥ 2
+        M, s = argtypes[1], argtypes[2]
+        if getglobal_nothrow(M, s)
+            nothrow = true
+            # typeasserts below are already checked in `getglobal_nothrow`
+            Mval, sval = (M::Const).val::Module, (s::Const).val::Symbol
+            if isconst(Mval, sval)
+                consistent = ALWAYS_TRUE
+                if is_mutation_free_argtype(rt)
+                    inaccessiblememonly = ALWAYS_TRUE
+                end
             end
         end
     end
     return Effects(EFFECTS_TOTAL; consistent, nothrow, inaccessiblememonly)
 end
 
-function builtin_effects(@specialize(lattice::AbstractLattice), f::Builtin, argtypes::Vector{Any}, @nospecialize(rt))
+function builtin_effects(@specialize(𝕃::AbstractLattice), f::Builtin, argtypes::Vector{Any}, @nospecialize(rt))
     if isa(f, IntrinsicFunction)
         return intrinsic_effects(f, argtypes)
     end
@@ -2065,7 +2102,7 @@ function builtin_effects(@specialize(lattice::AbstractLattice), f::Builtin, argt
     @assert !contains_is(_SPECIAL_BUILTINS, f)
 
     if f === isdefined
-        return isdefined_effects(argtypes)
+        return isdefined_effects(𝕃, argtypes)
     elseif f === getfield
         return getfield_effects(argtypes, rt)
     elseif f === getglobal
@@ -2083,7 +2120,7 @@ function builtin_effects(@specialize(lattice::AbstractLattice), f::Builtin, argt
         else
             effect_free = ALWAYS_FALSE
         end
-        nothrow = (!(!isempty(argtypes) && isvarargtype(argtypes[end])) && builtin_nothrow(lattice, f, argtypes, rt))
+        nothrow = (!(!isempty(argtypes) && isvarargtype(argtypes[end])) && builtin_nothrow(𝕃, f, argtypes, rt))
         if contains_is(_INACCESSIBLEMEM_BUILTINS, f)
             inaccessiblememonly = ALWAYS_TRUE
         elseif contains_is(_ARGMEM_BUILTINS, f)
@@ -2345,12 +2382,11 @@ function global_order_nothrow(@nospecialize(o), loading::Bool, storing::Bool)
     end
     return false
 end
-function getglobal_nothrow(argtypes::Vector{Any})
-    2 ≤ length(argtypes) ≤ 3 || return false
-    if length(argtypes) == 3
-        global_order_nothrow(argtypes[3], #=loading=#true, #=storing=#false) || return false
-    end
-    M, s = argtypes
+function getglobal_nothrow(@nospecialize(M), @nospecialize(s), @nospecialize(o))
+    global_order_nothrow(o, #=loading=#true, #=storing=#false) || return false
+    return getglobal_nothrow(M, s)
+end
+function getglobal_nothrow(@nospecialize(M), @nospecialize(s))
     if M isa Const && s isa Const
         M, s = M.val, s.val
         if M isa Module && s isa Symbol
@@ -2380,12 +2416,11 @@ function setglobal!_tfunc(@nospecialize(M), @nospecialize(s), @nospecialize(v),
 end
 add_tfunc(getglobal, 2, 3, getglobal_tfunc, 1)
 add_tfunc(setglobal!, 3, 4, setglobal!_tfunc, 3)
-function setglobal!_nothrow(argtypes::Vector{Any})
-    3 ≤ length(argtypes) ≤ 4 || return false
-    if length(argtypes) == 4
-        global_order_nothrow(argtypes[4], #=loading=#false, #=storing=#true) || return false
-    end
-    M, s, newty = argtypes
+function setglobal!_nothrow(@nospecialize(M), @nospecialize(s), @nospecialize(newty), @nospecialize(o))
+    global_order_nothrow(o, #=loading=#false, #=storing=#true) || return false
+    return setglobal!_nothrow(M, s, newty)
+end
+function setglobal!_nothrow(@nospecialize(M), @nospecialize(s), @nospecialize(newty))
     if M isa Const && s isa Const
         M, s = M.val, s.val
         if isa(M, Module) && isa(s, Symbol)
@@ -2419,6 +2454,11 @@ function get_binding_type_tfunc(@nospecialize(M), @nospecialize(s))
     return Type
 end
 add_tfunc(Core.get_binding_type, 2, 2, get_binding_type_tfunc, 0)
+
+function get_binding_type_nothrow(@specialize(𝕃::AbstractLattice), @nospecialize(M), @nospecialize(s))
+    ⊑ = Core.Compiler.:⊑(𝕃)
+    return M ⊑ Module && s ⊑ Symbol
+end
 
 # foreigncall
 # ===========

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -221,11 +221,12 @@ function ⊑(lattice::InferenceLattice, @nospecialize(a), @nospecialize(b))
 end
 
 function ⊑(lattice::OptimizerLattice, @nospecialize(a), @nospecialize(b))
-    if isa(a, MaybeUndef) && !isa(b, MaybeUndef)
-        return false
+    if isa(a, MaybeUndef)
+        isa(b, MaybeUndef) || return false
+        a, b = a.typ, b.typ
+    elseif isa(b, MaybeUndef)
+        b = b.typ
     end
-    isa(a, MaybeUndef) && (a = a.typ)
-    isa(b, MaybeUndef) && (b = b.typ)
     return ⊑(widenlattice(lattice), a, b)
 end
 

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -719,7 +719,7 @@ f_infer_abstract_fieldtype() = fieldtype(HasAbstractlyTypedField, :x)
 @test Base.return_types(f_infer_abstract_fieldtype, ()) == Any[Type{Union{Int,String}}]
 let fieldtype_tfunc = Core.Compiler.fieldtype_tfunc,
     fieldtype_nothrow(@nospecialize(s0), @nospecialize(name)) = Core.Compiler.fieldtype_nothrow(
-        Core.Compiler.fallback_lattice, s0, name)
+        Core.Compiler.OptimizerLattice(), s0, name)
     @test fieldtype_tfunc(Union{}, :x) == Union{}
     @test fieldtype_tfunc(Union{Type{Int32}, Int32}, Const(:x)) == Union{}
     @test fieldtype_tfunc(Union{Type{Base.RefValue{T}}, Type{Int32}} where {T<:Array}, Const(:x)) == Type{<:Array}
@@ -747,6 +747,19 @@ let fieldtype_tfunc = Core.Compiler.fieldtype_tfunc,
     @test fieldtype_nothrow(Type{Tuple{Vararg{Int}}}, Const(42))
     @test !fieldtype_nothrow(Type{<:Tuple{Vararg{Int}}}, Const(1))
     @test TypeVar <: fieldtype_tfunc(Any, Any)
+end
+
+import Core.Compiler: MaybeUndef, builtin_nothrow
+let 𝕃ₒ = Core.Compiler.OptimizerLattice()
+    @test !builtin_nothrow(𝕃ₒ, setfield!, Any[Base.RefValue{String}, Core.Const(:x), MaybeUndef(String)], Any)
+    @test !builtin_nothrow(𝕃ₒ, setfield!, Any[Base.RefValue{String}, Core.Const(:x), MaybeUndef(String), Core.Const(:not_atomic)], Any)
+    @test !builtin_nothrow(𝕃ₒ, isdefined, Any[Any,MaybeUndef(Symbol)], Bool)
+    @test !builtin_nothrow(𝕃ₒ, fieldtype, Any[MaybeUndef(Any),Symbol], Any)
+    @test !builtin_nothrow(𝕃ₒ, isa, Any[Type,MaybeUndef(Type)], Any)
+    @test !builtin_nothrow(𝕃ₒ, <:, Any[MaybeUndef(Any),MaybeUndef(Any)], Any)
+    @test !builtin_nothrow(𝕃ₒ, Core.ifelse, Any[MaybeUndef(Bool),Any,Any], Any)
+    @test !builtin_nothrow(𝕃ₒ, typeassert, Any[MaybeUndef(Any),Type{Symbol}], Any)
+    @test !builtin_nothrow(𝕃ₒ, Core.get_binding_type, Any[Module,MaybeUndef(Symbol)], Any)
 end
 
 # issue #11480
@@ -1758,44 +1771,46 @@ end
 @test setfield!_tfunc(ABCDconst, Const(1), Any) === Union{}
 @test setfield!_tfunc(ABCDconst, Const(2), Any) === Union{}
 @test setfield!_tfunc(ABCDconst, Const(4), Any) === Union{}
-@test setfield!_nothrow(Base.RefValue{Int}, Const(:x), Int)
-@test setfield!_nothrow(Base.RefValue{Int}, Const(1), Int)
-@test setfield!_nothrow(Base.RefValue{Any}, Const(:x), Int)
-@test setfield!_nothrow(Base.RefValue{Any}, Const(1), Int)
-@test setfield!_nothrow(XY{Any,Any}, Const(:x), Int)
-@test setfield!_nothrow(XY{Any,Any}, Const(:x), Any)
-@test setfield!_nothrow(XY{Int,Float64}, Const(:x), Int)
-@test setfield!_nothrow(ABCDconst, Const(:c), Any)
-@test setfield!_nothrow(ABCDconst, Const(3), Any)
-@test !setfield!_nothrow(XY{Int,Float64}, Symbol, Any)
-@test !setfield!_nothrow(XY{Int,Float64}, Int, Any)
-@test !setfield!_nothrow(Base.RefValue{Int}, Const(:x), Any)
-@test !setfield!_nothrow(Base.RefValue{Int}, Const(1), Any)
-@test !setfield!_nothrow(Any[Base.RefValue{Any}, Const(:x), Int, Symbol])
-@test !setfield!_nothrow(Base.RefValue{Any}, Symbol, Int)
-@test !setfield!_nothrow(Base.RefValue{Any}, Int, Int)
-@test !setfield!_nothrow(XY{Int,Float64}, Const(:y), Int)
-@test !setfield!_nothrow(XY{Int,Float64}, Symbol, Int)
-@test !setfield!_nothrow(XY{Int,Float64}, Int, Int)
-@test !setfield!_nothrow(ABCDconst, Const(:a), Any)
-@test !setfield!_nothrow(ABCDconst, Const(:b), Any)
-@test !setfield!_nothrow(ABCDconst, Const(:d), Any)
-@test !setfield!_nothrow(ABCDconst, Symbol, Any)
-@test !setfield!_nothrow(ABCDconst, Const(1), Any)
-@test !setfield!_nothrow(ABCDconst, Const(2), Any)
-@test !setfield!_nothrow(ABCDconst, Const(4), Any)
-@test !setfield!_nothrow(ABCDconst, Int, Any)
-@test !setfield!_nothrow(Union{Base.RefValue{Any},Some{Any}}, Const(:x), Int)
-@test !setfield!_nothrow(Union{Base.RefValue,Some{Any}}, Const(:x), Int)
-@test !setfield!_nothrow(Union{Base.RefValue{Any},Some{Any}}, Const(1), Int)
-@test !setfield!_nothrow(Union{Base.RefValue,Some{Any}}, Const(1), Int)
-@test !setfield!_nothrow(Union{Base.RefValue{Any},Some{Any}}, Symbol, Int)
-@test !setfield!_nothrow(Union{Base.RefValue,Some{Any}}, Symbol, Int)
-@test !setfield!_nothrow(Union{Base.RefValue{Any},Some{Any}}, Int, Int)
-@test !setfield!_nothrow(Union{Base.RefValue,Some{Any}}, Int, Int)
-@test !setfield!_nothrow(Any, Symbol, Int)
-@test !setfield!_nothrow(Any, Int, Int)
-@test !setfield!_nothrow(Any, Any, Int)
+let 𝕃ₒ = Core.Compiler.OptimizerLattice()
+    @test setfield!_nothrow(𝕃ₒ, Base.RefValue{Int}, Const(:x), Int)
+    @test setfield!_nothrow(𝕃ₒ, Base.RefValue{Int}, Const(1), Int)
+    @test setfield!_nothrow(𝕃ₒ, Base.RefValue{Any}, Const(:x), Int)
+    @test setfield!_nothrow(𝕃ₒ, Base.RefValue{Any}, Const(1), Int)
+    @test setfield!_nothrow(𝕃ₒ, XY{Any,Any}, Const(:x), Int)
+    @test setfield!_nothrow(𝕃ₒ, XY{Any,Any}, Const(:x), Any)
+    @test setfield!_nothrow(𝕃ₒ, XY{Int,Float64}, Const(:x), Int)
+    @test setfield!_nothrow(𝕃ₒ, ABCDconst, Const(:c), Any)
+    @test setfield!_nothrow(𝕃ₒ, ABCDconst, Const(3), Any)
+    @test !setfield!_nothrow(𝕃ₒ, XY{Int,Float64}, Symbol, Any)
+    @test !setfield!_nothrow(𝕃ₒ, XY{Int,Float64}, Int, Any)
+    @test !setfield!_nothrow(𝕃ₒ, Base.RefValue{Int}, Const(:x), Any)
+    @test !setfield!_nothrow(𝕃ₒ, Base.RefValue{Int}, Const(1), Any)
+    @test !setfield!_nothrow(𝕃ₒ, Base.RefValue{Any}, Const(:x), Int, Symbol)
+    @test !setfield!_nothrow(𝕃ₒ, Base.RefValue{Any}, Symbol, Int)
+    @test !setfield!_nothrow(𝕃ₒ, Base.RefValue{Any}, Int, Int)
+    @test !setfield!_nothrow(𝕃ₒ, XY{Int,Float64}, Const(:y), Int)
+    @test !setfield!_nothrow(𝕃ₒ, XY{Int,Float64}, Symbol, Int)
+    @test !setfield!_nothrow(𝕃ₒ, XY{Int,Float64}, Int, Int)
+    @test !setfield!_nothrow(𝕃ₒ, ABCDconst, Const(:a), Any)
+    @test !setfield!_nothrow(𝕃ₒ, ABCDconst, Const(:b), Any)
+    @test !setfield!_nothrow(𝕃ₒ, ABCDconst, Const(:d), Any)
+    @test !setfield!_nothrow(𝕃ₒ, ABCDconst, Symbol, Any)
+    @test !setfield!_nothrow(𝕃ₒ, ABCDconst, Const(1), Any)
+    @test !setfield!_nothrow(𝕃ₒ, ABCDconst, Const(2), Any)
+    @test !setfield!_nothrow(𝕃ₒ, ABCDconst, Const(4), Any)
+    @test !setfield!_nothrow(𝕃ₒ, ABCDconst, Int, Any)
+    @test !setfield!_nothrow(𝕃ₒ, Union{Base.RefValue{Any},Some{Any}}, Const(:x), Int)
+    @test !setfield!_nothrow(𝕃ₒ, Union{Base.RefValue,Some{Any}}, Const(:x), Int)
+    @test !setfield!_nothrow(𝕃ₒ, Union{Base.RefValue{Any},Some{Any}}, Const(1), Int)
+    @test !setfield!_nothrow(𝕃ₒ, Union{Base.RefValue,Some{Any}}, Const(1), Int)
+    @test !setfield!_nothrow(𝕃ₒ, Union{Base.RefValue{Any},Some{Any}}, Symbol, Int)
+    @test !setfield!_nothrow(𝕃ₒ, Union{Base.RefValue,Some{Any}}, Symbol, Int)
+    @test !setfield!_nothrow(𝕃ₒ, Union{Base.RefValue{Any},Some{Any}}, Int, Int)
+    @test !setfield!_nothrow(𝕃ₒ, Union{Base.RefValue,Some{Any}}, Int, Int)
+    @test !setfield!_nothrow(𝕃ₒ, Any, Symbol, Int)
+    @test !setfield!_nothrow(𝕃ₒ, Any, Int, Int)
+    @test !setfield!_nothrow(𝕃ₒ, Any, Any, Int)
+end
 
 struct Foo_22708
     x::Ptr{Foo_22708}
@@ -3067,9 +3082,12 @@ const DenseIdx = Union{IntRange,Integer}
 # Non uniformity in expressions with PartialTypeVar
 @test Core.Compiler.:⊑(Core.Compiler.PartialTypeVar(TypeVar(:N), true, true), TypeVar)
 let N = TypeVar(:N)
-    @test Core.Compiler.apply_type_nothrow([Core.Compiler.Const(NTuple),
+    𝕃 = Core.Compiler.OptimizerLattice()
+    argtypes = Any[Core.Compiler.Const(NTuple),
         Core.Compiler.PartialTypeVar(N, true, true),
-        Core.Compiler.Const(Any)], Type{Tuple{Vararg{Any,N}}})
+        Core.Compiler.Const(Any)]
+    rt = Type{Tuple{Vararg{Any,N}}}
+    @test Core.Compiler.apply_type_nothrow(𝕃, argtypes, rt)
 end
 
 # issue #33768


### PR DESCRIPTION
This should improve the robustness of `builtin_nothrow` and avoid problems like the issue reported at #47249.

@nanosoldier `runbenchmarks("inference", vs=":master")`