### PR TITLE
Allow specifying waitfirst when waiting on a Condition

### DIFF
--- a/base/condition.jl
+++ b/base/condition.jl
@@ -78,10 +78,14 @@ islocked(c::GenericCondition) = islocked(c.lock)
 lock(f, c::GenericCondition) = lock(f, c.lock)
 
 # have waiter wait for c
-function _wait2(c::GenericCondition, waiter::Task)
+function _wait2(c::GenericCondition, waiter::Task, waitfirst::Bool=false)
     ct = current_task()
     assert_havelock(c)
-    push!(c.waitq, waiter)
+    if waitfirst
+        pushfirst!(c.waitq, waiter)
+    else
+        push!(c.waitq, waiter)
+    end
     # since _wait2 is similar to schedule, we should observe the sticky bit now
     if waiter.sticky && Threads.threadid(waiter) == 0
         # Issue #41324
@@ -103,7 +107,9 @@ Block the current task until some event occurs, depending on the type of the arg
 
 * [`Channel`](@ref): Wait for a value to be appended to the channel.
 * [`Condition`](@ref): Wait for [`notify`](@ref) on a condition and return the `val`
-  parameter passed to `notify`.
+  parameter passed to `notify`. Waiting on a condition additionally allows passing
+  `waitfirst=true` which results in the waiter being put _first_ in line to wake up on `notify`
+  instead of the usual first-in-first-out behavior.
 * `Process`: Wait for a process or process chain to exit. The `exitcode` field of a process
   can be used to determine success or failure.
 * [`Task`](@ref): Wait for a `Task` to finish. If the task fails with an exception, a
@@ -116,9 +122,9 @@ restarted by an explicit call to [`schedule`](@ref) or [`yieldto`](@ref).
 Often `wait` is called within a `while` loop to ensure a waited-for condition is met before
 proceeding.
 """
-function wait(c::GenericCondition)
+function wait(c::GenericCondition; waitfirst::Bool=false)
     ct = current_task()
-    _wait2(c, ct)
+    _wait2(c, ct, waitfirst)
     token = unlockall(c.lock)
     try
         return wait()

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -78,10 +78,10 @@ islocked(c::GenericCondition) = islocked(c.lock)
 lock(f, c::GenericCondition) = lock(f, c.lock)
 
 # have waiter wait for c
-function _wait2(c::GenericCondition, waiter::Task, waitfirst::Bool=false)
+function _wait2(c::GenericCondition, waiter::Task, first::Bool=false)
     ct = current_task()
     assert_havelock(c)
-    if waitfirst
+    if first
         pushfirst!(c.waitq, waiter)
     else
         push!(c.waitq, waiter)
@@ -108,7 +108,7 @@ Block the current task until some event occurs, depending on the type of the arg
 * [`Channel`](@ref): Wait for a value to be appended to the channel.
 * [`Condition`](@ref): Wait for [`notify`](@ref) on a condition and return the `val`
   parameter passed to `notify`. Waiting on a condition additionally allows passing
-  `waitfirst=true` which results in the waiter being put _first_ in line to wake up on `notify`
+  `first=true` which results in the waiter being put _first_ in line to wake up on `notify`
   instead of the usual first-in-first-out behavior.
 * `Process`: Wait for a process or process chain to exit. The `exitcode` field of a process
   can be used to determine success or failure.
@@ -122,9 +122,9 @@ restarted by an explicit call to [`schedule`](@ref) or [`yieldto`](@ref).
 Often `wait` is called within a `while` loop to ensure a waited-for condition is met before
 proceeding.
 """
-function wait(c::GenericCondition; waitfirst::Bool=false)
+function wait(c::GenericCondition; first::Bool=false)
     ct = current_task()
-    _wait2(c, ct, waitfirst)
+    _wait2(c, ct, first)
     token = unlockall(c.lock)
     try
         return wait()

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -14,7 +14,7 @@ using Base: n_avail
     @test fetch(t) == "finished"
 end
 
-@testset "waitfirst behavior of wait on Condition" begin
+@testset "wait first behavior of wait on Condition" begin
     a = Condition()
     waiter1 = @async begin
         wait(a)
@@ -23,7 +23,10 @@ end
         wait(a)
     end
     waiter3 = @async begin
-        wait(a; waitfirst=true)
+        wait(a; first=true)
+    end
+    waiter4 = @async begin
+        wait(a)
     end
     t = @async begin
         Base.notify(a, "success"; all=false)

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -14,6 +14,25 @@ using Base: n_avail
     @test fetch(t) == "finished"
 end
 
+@testset "waitfirst behavior of wait on Condition" begin
+    a = Condition()
+    waiter1 = @async begin
+        wait(a)
+    end
+    waiter2 = @async begin
+        wait(a)
+    end
+    waiter3 = @async begin
+        wait(a; waitfirst=true)
+    end
+    t = @async begin
+        Base.notify(a, "success"; all=false)
+        "finished"
+    end
+    @test fetch(waiter3) == "success"
+    @test fetch(t) == "finished"
+end
+
 @testset "various constructors" begin
     c = Channel()
     @test eltype(c) == Any


### PR DESCRIPTION
I have a use-case where I use a `Condition` as a wait queue, where a singler waiter is woken up on `notify`. Once a waiter is woken up, it may need to re-wait, but we want it to get back in the wait queue _first_ instead of the FIFO behavior of regular `wait`. This allows the waiter to continue being notified until a logical condition is met and the next waiter in the queue will take the next notification.

This PR proposes adding a keyword argument `waitfirst::Bool=false` to the `wait(c::Condition)` method that allows the caller to put itself _first_ in the `Condition` wait queue instead of last.

I didn't consider whether other `wait` methods (Channel, Task, etc.) would also benefit from something like this to minimize the total changes to a specific use-case that I know is useful.