### PR TITLE
Parameterize OptimizerLattice like InferenceLattice

### DIFF
--- a/base/compiler/abstractlattice.jl
+++ b/base/compiler/abstractlattice.jl
@@ -76,8 +76,11 @@ is_valid_lattice(lattice::InferenceLattice, @nospecialize(elem)) =
 The lattice used by the optimizer. Extends
 `BaseInferenceLattice` with `MaybeUndef`.
 """
-struct OptimizerLattice <: AbstractLattice; end
-widenlattice(L::OptimizerLattice) = BaseInferenceLattice.instance
+struct OptimizerLattice{L} <: AbstractLattice
+    parent::L
+end
+OptimizerLattice() = OptimizerLattice(BaseInferenceLattice.instance)
+widenlattice(L::OptimizerLattice) = L.parent
 is_valid_lattice(lattice::OptimizerLattice, @nospecialize(elem)) =
     is_valid_lattice(widenlattice(lattice), elem) || isa(elem, MaybeUndef)
 

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -292,7 +292,7 @@ infer_compilation_signature(::NativeInterpreter) = true
 
 typeinf_lattice(::AbstractInterpreter) = InferenceLattice(BaseInferenceLattice.instance)
 ipo_lattice(::AbstractInterpreter) = InferenceLattice(IPOResultLattice.instance)
-optimizer_lattice(::AbstractInterpreter) = OptimizerLattice()
+optimizer_lattice(::AbstractInterpreter) = OptimizerLattice(BaseInferenceLattice.instance)
 
 abstract type CallInfo end
 


### PR DESCRIPTION
External AbstractInterpreters that do optimization while retaining lattice elements in their custom lattice will need to have this for the same reason that InferenceLattice is needed, so there isn't really a good reason to not parameterize this.