### PR TITLE
Fix various oracle check failures

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1526,7 +1526,7 @@ function kill_phi!(compact::IncrementalCompact, phi_uses::Vector{Int},
             if !delete_inst
                 # Deleting the inst will update compact's use count, so
                 # don't do it here.
-                kill_current_use(compact, val)
+                kill_current_use!(compact, val)
             end
             if isa(val, SSAValue)
                 phi_uses[val.id] -= 1

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -337,6 +337,16 @@ function foreachssa(@specialize(f), @nospecialize(stmt))
     end
 end
 
+function foreach_anyssa(@specialize(f), @nospecialize(stmt))
+    urs = userefs(stmt)
+    for op in urs
+        val = op[]
+        if isa(val, AnySSAValue)
+            f(val)
+        end
+    end
+end
+
 function find_ssavalue_uses(body::Vector{Any}, nvals::Int)
     uses = BitSet[ BitSet() for i = 1:nvals ]
     for line in 1:length(body)
@@ -441,38 +451,6 @@ end
 # using a function to ensure we can infer this
 @inline slot_id(s) = isa(s, SlotNumber) ? (s::SlotNumber).id :
     isa(s, Argument) ? (s::Argument).n : (s::TypedSlot).id
-
-######################
-# IncrementalCompact #
-######################
-
-# specifically meant to be used with body1 = compact.result and body2 = compact.new_new_nodes, with nvals == length(compact.used_ssas)
-function find_ssavalue_uses1(compact)
-    body1, body2 = compact.result.inst, compact.new_new_nodes.stmts.inst
-    nvals = length(compact.used_ssas)
-    nbody1 = length(body1)
-    nbody2 = length(body2)
-
-    uses = zeros(Int, nvals)
-    function increment_uses(ssa::SSAValue)
-        uses[ssa.id] += 1
-    end
-
-    for line in 1:(nbody1 + nbody2)
-        # index into the right body
-        if line <= nbody1
-            isassigned(body1, line) || continue
-            e = body1[line]
-        else
-            line -= nbody1
-            isassigned(body2, line) || continue
-            e = body2[line]
-        end
-
-        foreachssa(increment_uses, e)
-    end
-    return uses
-end
 
 ###########
 # options #


### PR DESCRIPTION
Found while debugging other miscompiles. These are both overcounts, so shouldn't have caused any bugs (just sub-optimalities), but it's generally good to fix these anyway so that the oracle check becomes more useful for finding actual issues.