### PR TITLE
Reduce size of Profile test on 32 bit to avoid OOM

### DIFF
--- a/stdlib/Profile/test/allocs.jl
+++ b/stdlib/Profile/test/allocs.jl
@@ -64,7 +64,8 @@ end
 @testset "alloc profiler start stop fetch clear" begin
     function do_work()
         # Compiling allocates a lot
-        for f in (gensym() for _ in 1:10)
+        nsyms = @static Sys.WORD_SIZE == 32 ? 1 : 10
+        for f in (gensym() for _ in 1:nsyms)
             @eval begin
                 $f() = 10
                 $f()


### PR DESCRIPTION
This reduces the allocations on that specific test to 25% of what it does on 64bits. It still allocates about 200 mb which might still be too much. 