### PR TITLE
Fix rewrap-where for anonymous function parse

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1352,7 +1352,7 @@
 
 (define (rewrap-where x w)
   (if (and (pair? w) (eq? (car w) 'where))
-      (list 'where (rewrap-where x (cadr w)) (caddr w))
+      (list* 'where (rewrap-where x (cadr w)) (cddr w))
       x))
 
 (define (parse-struct-field s)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -878,6 +878,12 @@ let f = function (x::T, y::S) where T<:S where S
     @test f(0,1) === (Int,Int)
 end
 
+# issue #45506
+@test :( function (a) where {B, C} end).args[1] == Expr(:where, Expr(:tuple, :a), :B, :C)
+@test (function(::Type{Tuple{A45506, B45506}}) where {A45506 <: Any, B45506 <: Any}
+    B45506
+end)(Tuple{Int8, Int16}) == Int16
+
 # issue #20541
 @test Meta.parse("[a .!b]") == Expr(:hcat, :a, Expr(:call, :.!, :b))
 


### PR DESCRIPTION
Was throwing away the tail of the list, dropping the result of where clauses.

Fixes #45506