### PR TITLE
test: make ComposedFunction inference test easier

### DIFF
--- a/test/operators.jl
+++ b/test/operators.jl
@@ -184,7 +184,7 @@ end
     @test (@inferred g(1)) == ntuple(Returns(1), 13)
     h = (-) ∘ (-) ∘ (-) ∘ (-) ∘ (-) ∘ (-) ∘ sum
     @test (@inferred h((1, 2, 3); init = 0.0)) == 6.0
-    issue_45877 = reduce(∘, fill(sin,500))
+    issue_45877 = reduce(∘, fill(sin, 50))
     @test Core.Compiler.is_foldable(Base.infer_effects(Base.unwrap_composed, (typeof(issue_45877),)))
     @test fully_eliminated() do
         issue_45877(1.0)


### PR DESCRIPTION
This was written to be a very difficult compiler stress test, and be nearly close to failing at runtime too. While we like tests to be comprehensive, we do not like them to be a stress test on unrelated parts of the compiler simultaneously.

From: #45925
Fix: #47179