### PR TITLE
Replace `flatmap` with a flatten method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -70,7 +70,7 @@ Build system changes
 New library functions
 ---------------------
 
-* `Iterators.flatmap` was added ([#44792]).
+* `Iterators.flatten` now supports a function as first argument ([#44792]).
 * New helper `Splat(f)` which acts like `x -> f(x...)`, with pretty printing for
   inspecting which function `f` was originally wrapped. ([#42717])
 * New `pkgversion(m::Module)` function to get the version of the package that loaded

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -504,26 +504,26 @@ end
 # see #29112, #29464, #29548
 @test Base.return_types(Base.IteratorEltype, Tuple{Array}) == [Base.HasEltype]
 
-# flatmap
+# flatten(f::Function, iters...)
 # -------
-@test flatmap(1:3) do j flatmap(1:3) do k
+@test flatten(1:3) do j flatten(1:3) do k
     j!=k ? ((j,k),) : ()
 end end |> collect == [(j,k) for j in 1:3 for k in 1:3 if j!=k]
 # Test inspired by the monad associativity law
 fmf(x) = x<0 ? () : (x^2,)
 fmg(x) = x<1 ? () : (x/2,)
 fmdata = -2:0.75:2
-fmv1 = flatmap(tuple.(fmdata)) do h
-    flatmap(h) do x
+fmv1 = flatten(tuple.(fmdata)) do h
+    flatten(h) do x
         gx = fmg(x)
-        flatmap(gx) do x
+        flatten(gx) do x
             fmf(x)
         end
     end
 end
-fmv2 = flatmap(tuple.(fmdata)) do h
-    gh = flatmap(h) do x fmg(x) end
-    flatmap(gh) do x fmf(x) end
+fmv2 = flatten(tuple.(fmdata)) do h
+    gh = flatten(h) do x fmg(x) end
+    flatten(gh) do x fmf(x) end
 end
 @test all(fmv1 .== fmv2)
 


### PR DESCRIPTION
From @thchr and @mcabbott's post-merge comments on @nlw0's PR #44792

> I.e. this seems to just add another short verb for a nearly trivial composition of two more basic verbs?

> We have sum(f, x) as a more efficient sum(map(f, x)), but no summap symbol. Likewise all(f, x) instead of allmap, and so on...

I would also support removing the function entirely, but triage seems to oppose that

> Long story short, triage yesterday was ok with flatmap