### PR TITLE
Constprop split_rest on tuple and namedtuple

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -423,7 +423,7 @@ macro NamedTuple(ex)
     return :(NamedTuple{($(vars...),), Tuple{$(types...)}})
 end
 
-function split_rest(t::NamedTuple{names}, n::Int, st...) where {names}
+@constprop :aggressive function split_rest(t::NamedTuple{names}, n::Int, st...) where {names}
     _check_length_split_rest(length(t), n)
     names_front, names_last_n = split_rest(names, n, st...)
     return NamedTuple{names_front}(t), NamedTuple{names_last_n}(t)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -186,7 +186,7 @@ function _split_rest(a::Union{AbstractArray, Core.SimpleVector}, n::Int)
     return a[begin:end-n], a[end-n+1:end]
 end
 
-split_rest(t::Tuple, n::Int, i=1) = t[i:end-n], t[end-n+1:end]
+@constprop :aggressive split_rest(t::Tuple, n::Int, i=1) = t[i:end-n], t[end-n+1:end]
 
 # Use dispatch to avoid a branch in first
 first(::Tuple{}) = throw(ArgumentError("tuple must be non-empty"))

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -769,4 +769,3 @@ namedtup = (;a=1, b=2, c=3)
         NamedTuple{(:a, :b), Tuple{Int, Int}},
         NamedTuple{(:c,), Tuple{Int}},
     }
-

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -757,3 +757,16 @@ g42457(a, b) = Base.isequal(a, b) ? 1 : 2.0
 
 # issue #46049: setindex(::Tuple) regression
 @inferred Base.setindex((1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16), 42, 1)
+
+# Issue 47326: Type stability of constant-folded split_rest on tuples
+f47326(x::Union{Tuple, NamedTuple}) = Base.split_rest(x, 1)
+tup = (1, 2, 3)
+namedtup = (;a=1, b=2, c=3)
+
+@test only(Base.return_types(f47326, (typeof(tup),))) == Tuple{Tuple{Int, Int}, Tuple{Int}}
+@test only(Base.return_types(f47326, (typeof(namedtup),))) ==
+    Tuple{
+        NamedTuple{(:a, :b), Tuple{Int, Int}},
+        NamedTuple{(:c,), Tuple{Int}},
+    }
+


### PR DESCRIPTION
Julia 1.9 adds Base.split_rest, which can be used to slurp in non-final positions. However, unlike slurping in the final position, split_rest does not constant propagate, causing type instability in a pattern like `head..., tail = args::Tuple`.

This PR adds `@constprop :aggressive` to split_rest for tuples and named tuples, and tests that it constant folds as expected.

Issue discovered by @sgaure and fix proposed by @simeonschaub.
Closes #47326 