### PR TITLE
subtype: fix miscount of Tuple Vararg matching

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1003,7 +1003,7 @@ static int subtype_tuple_tail(jl_datatype_t *xd, jl_datatype_t *yd, int8_t R, jl
 {
     size_t lx = jl_nparams(xd);
     size_t ly = jl_nparams(yd);
-    size_t i = 0, j = 0, vx = 0, vy = 0, x_reps = 1;
+    size_t i = 0, j = 0, vx = 0, vy = 0, x_reps = 0;
     jl_value_t *lastx = NULL, *lasty = NULL;
     jl_value_t *xi = NULL, *yi = NULL;
 

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2249,3 +2249,5 @@ T46784{B<:Val, M<:AbstractMatrix} = Tuple{<:Union{B, <:Val{<:B}}, M, Union{Abstr
     # issue 21153
     @test_broken (Tuple{T1,T1} where T1<:(Val{T2} where T2)) <: (Tuple{Val{S},Val{S}} where S)
 end
+
+@test !(Tuple{Any, Any, Any} <: Tuple{Any, Vararg{T}} where T)


### PR DESCRIPTION
Fix #47246

I feel this might get an award for easiest subtyping bug.