### PR TITLE
Fix RefArray(::AbstractArray{T}, i::Integer)

### DIFF
--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -113,7 +113,7 @@ end
 RefArray(x::AbstractArray{T}, i::Int, roots::Any) where {T} = RefArray{T,typeof(x),Any}(x, i, roots)
 RefArray(x::AbstractArray{T}, i::Int=1, roots::Nothing=nothing) where {T} = RefArray{T,typeof(x),Nothing}(x, i, nothing)
 RefArray(x::AbstractArray{T}, i::Integer, roots::Any) where {T} = RefArray{T,typeof(x),Any}(x, Int(i), roots)
-RefArray(x::AbstractArray{T}, i::Integer=1, roots::Nothing=nothing) where {T} = RefArray{T,typeof(x),Nothing}(x, Int(i), nothing)
+RefArray(x::AbstractArray{T}, i::Integer, roots::Nothing=nothing) where {T} = RefArray{T,typeof(x),Nothing}(x, Int(i), nothing)
 convert(::Type{Ref{T}}, x::AbstractArray{T}) where {T} = RefArray(x, 1)
 
 function unsafe_convert(P::Union{Type{Ptr{T}},Type{Ptr{Cvoid}}}, b::RefArray{T})::P where T


### PR DESCRIPTION
This removes the default argument in `RefArray(x::AbstractArray{T}, i::Integer=1)` such that it does not override `RefArray(x::AbstractArray{T}, i::Int=1)`

xref: https://github.com/JuliaLang/julia/pull/43262#discussion_r1006209709
cc: @vtjnash