### PR TITLE
make `samefile` of nonexistent files false

### DIFF
--- a/base/stat.jl
+++ b/base/stat.jl
@@ -464,22 +464,16 @@ end
 islink(path...) = islink(lstat(path...))
 
 # samefile can be used for files and directories: #11145#issuecomment-99511194
-samefile(a::StatStruct, b::StatStruct) = a.device==b.device && a.inode==b.inode
+function samefile(a::StatStruct, b::StatStruct)
+    ispath(a) && ispath(b) && a.device == b.device && a.inode == b.inode
+end
 
 """
     samefile(path_a::AbstractString, path_b::AbstractString)
 
 Check if the paths `path_a` and `path_b` refer to the same existing file or directory.
 """
-function samefile(a::AbstractString, b::AbstractString)
-    infoa = stat(a)
-    infob = stat(b)
-    if ispath(infoa) && ispath(infob)
-        samefile(infoa, infob)
-    else
-        return false
-    end
-end
+samefile(a::AbstractString, b::AbstractString) = samefile(stat(a), stat(b))
 
 """
     ismount(path) -> Bool

--- a/test/file.jl
+++ b/test/file.jl
@@ -771,13 +771,13 @@ end
 mktempdir() do tmpdir
     # rename file
     file = joinpath(tmpdir, "afile.txt")
-    files_stat = stat(file)
     close(open(file, "w")) # like touch, but lets the operating system update
+    files_stat = stat(file)
     # the timestamp for greater precision on some platforms (windows)
 
     newfile = joinpath(tmpdir, "bfile.txt")
     mv(file, newfile)
-    newfile_stat = stat(file)
+    newfile_stat = stat(newfile)
 
     @test !ispath(file)
     @test isfile(newfile)


### PR DESCRIPTION
The docstring is clear about this in the case of paths "Check if the paths `path_a` and `path_b` refer to the same existing file or directory." The (undocumented) method for `StatStruct`s should be consistent.

I think this is an internal bug fix.

Fixes #46830