### PR TITLE
Materialize only once in `nullspace` return value

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1543,7 +1543,7 @@ function nullspace(A::AbstractVecOrMat; atol::Real = 0.0, rtol::Real = (min(size
     SVD = svd(A; full=true)
     tol = max(atol, SVD.S[1]*rtol)
     indstart = sum(s -> s .> tol, SVD.S) + 1
-    return copy(SVD.Vt[indstart:end,:]')
+    return copy((@view SVD.Vt[indstart:end,:])')
 end
 
 """


### PR DESCRIPTION
This reduces allocations, but doesn't really impact performance.
```julia
julia> A = ones(1000, 1000);

julia> @btime nullspace($A);
  375.469 ms (15 allocations: 61.14 MiB) # master
  374.243 ms (13 allocations: 53.52 MiB) # PR
```
This might help when working with large low-rank matrices.