### PR TITLE
correct 0x literal info

### DIFF
--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -185,7 +185,8 @@ determining storage size of a literal. So `0x01` is a `UInt8` while `0x0001` is 
 
 That allows the user to control the size.
 
-Values which cannot be stored in `UInt128` cannot be written as such literals.
+Unsigned literals (starting with `0x`) which are too big to fit in a `UInt128` object are
+interpreted as `BigInt`.
 
 Binary, octal, and hexadecimal literals may be signed by a `-` immediately preceding the
 unsigned literal. They produce an unsigned integer of the same size as the unsigned literal

--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -185,8 +185,9 @@ determining storage size of a literal. So `0x01` is a `UInt8` while `0x0001` is 
 
 That allows the user to control the size.
 
-Unsigned literals (starting with `0x`) which are too big to fit in a `UInt128` object are
-interpreted as `BigInt`.
+Unsigned literals (starting with `0x`) that encode integers too large to be represented as
+`UInt128` values will construct `BigInt` values instead. This is not an unsigned type but
+it is the only built-in type big enough to represent such large integer values.
 
 Binary, octal, and hexadecimal literals may be signed by a `-` immediately preceding the
 unsigned literal. They produce an unsigned integer of the same size as the unsigned literal


### PR DESCRIPTION
From the release notes on [v1.6](https://docs.julialang.org/en/v1.6/NEWS/), https://github.com/JuliaLang/julia/issues/23546 has addressed this and now `0x` literals too big for `UInt128` produce a `BigInt`:
```julia
julia> typemax(UInt128)
0xffffffffffffffffffffffffffffffff

julia> 0xffffffffffffffffffffffffffffffff1
5444517870735015415413993718908291383281
```