### PR TITLE
Define `length(::Flatten)` for some collections of arrays

### DIFF
--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -492,12 +492,30 @@ end
 @test collect(flatten(Any[])) == Any[]
 @test collect(flatten(())) == Union{}[]
 @test_throws ArgumentError length(flatten(NTuple[(1,), ()])) # #16680
-@test_throws ArgumentError length(flatten([[1], [1]]))
+@test length(flatten([[1], [1]])) == 2
 
 @testset "IteratorSize trait for flatten" begin
     @test Base.IteratorSize(Base.Flatten((i for i=1:2) for j=1:1)) == Base.SizeUnknown()
     @test Base.IteratorSize(Base.Flatten((1,2))) == Base.HasLength()
     @test Base.IteratorSize(Base.Flatten(1:2:4)) == Base.HasLength()
+    @test Base.IteratorSize(Base.Flatten([(1,2), (3,4), (5,6)])) == Base.HasLength()
+
+    @test Base.IteratorSize(Base.Flatten((1:2, 3:4, 5:6))) == Base.HasLength()
+    @test Base.IteratorSize(Base.Flatten([1:2, 3:4, 5:6])) == Base.HasLength()
+    @test Base.IteratorSize(Base.Flatten([1:2, [3 4 5], [6.0;;;]])) == Base.HasLength()
+end
+@testset "length of nontrivial flatten" begin
+    @test length(flatten((1:2, 3:4, 5:6))) == 6
+    @test length(flatten((1:2, [3 4 5], [6;;;]))) == 6
+    @test length(flatten(Int[])) == 0
+    @test length(flatten(())) == 0
+
+    @test length(flatten([1:2, 3:4, 5:6])) == 6
+    @test length(flatten([1:2, [3 4 5], [6.0;;;]])) == 6
+    @test length(flatten(Vector[])) == 0
+
+    @test length(flatten([(1,2), (3,4), (5,6)])) == 6  # length from eltype of array
+    @test length(flatten([(1,2)] |> empty!)) == 0
 end
 
 @test Base.IteratorEltype(Base.Flatten((i for i=1:2) for j=1:1)) == Base.EltypeUnknown()


### PR DESCRIPTION

As suggested at https://github.com/JuliaLang/julia/issues/23431, this defines `length` (and `IteratorSize` trait) for a few more `Iterators.flatten` objects: those flattening an arrays of array, or a tuples of arrays.

Computing the total length involves adding the lengths of the constituent arrays. At present `length(::Flatten)` never does this. For these cases it seems to be very cheap.

Knowing the length speeds up `collect ∘ Iterators.flatten`, although there is still room for improvement:
```julia
julia> vecs = [rand(100) for _ in 1:100];

julia> @btime length(Iterators.flatten($vecs))
  min 54.133 ns, mean 54.270 ns (0 allocations)  # this PR
10000

julia> @btime collect(Iterators.flatten($vecs));
  min 68.875 μs, mean 81.634 μs (9 allocations, 326.55 KiB) # master
  min 12.167 μs, mean 17.848 μs (2 allocations, 78.17 KiB)  # this PR

julia> @btime reduce(vcat, $vecs);
  min 2.403 μs, mean 8.332 μs (3 allocations, 79.05 KiB)  # ideal?
  
julia> tvecs = Tuple(rand(1000) for _ in 1:10);

julia> @btime collect(Iterators.flatten($tvecs));
  min 69.167 μs, mean 81.648 μs (9 allocations, 326.55 KiB)  # master
  min 12.833 μs, mean 22.149 μs (2 allocations, 78.17 KiB)   # this PR

julia> @btime vcat($tvecs...);
  min 1.780 μs, mean 11.348 μs (2 allocations, 78.17 KiB)  # ideal?
```
Some other cases with already known length remain quite slow:
```julia
julia> tups = [Tuple(rand(10)) for _ in 1:1000];

julia> Base.haslength(tups)  # unchanged, uses eltype of array
true

julia> v = @btime collect(Iterators.flatten($tups));
  min 117.583 μs, mean 131.905 μs (2 allocations, 78.17 KiB)

julia> v == vec(@btime stack($tups))
  min 8.597 μs, mean 18.170 μs (2 allocations, 78.17 KiB)
true
```