### PR TITLE
style guide on @, as it can get ambiguous a lot

### DIFF
--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -328,7 +328,7 @@ Instead write:
 @evalpoly(1, 2, 3 ^ cbrt(27))
 ```
 
-The function-like form should be use for macros appearing within another expression, to make
+The function-like form should be used for macros appearing within another expression, to make
 the end of the macro construct clear.
 
 The statement-like form should be used to annotate blocks:

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -307,6 +307,39 @@ Calling [`eval`](@ref) inside a macro is a particularly dangerous warning sign; 
 macro will only work when called at the top level. If such a macro is written as a function instead,
 it will naturally have access to the run-time values it needs.
 
+## Write macro expressions where `@` is unambiguous
+Though the function-like syntax, `@mymacro(arg1, arg2, arg3)`, and statement-like syntax,
+`@mymacro arg1 arg2 arg3`, for macros, are interchangeable, they can be ambiguous in some cases.
+
+For example:
+
+```julia
+@evalpoly 1 2 3 ^ cbrt(27)
+```
+
+is ambiguous, as its unclear on what we want `@evalpoly` for. Do we want it to operate on
+`(1, 2, 3)` and then raise the result to power of `cbrt(27)`? Or we actually want it on
+`(1, 2, 3 ^ cbrt(27))`?
+
+Instead write:
+```julia
+@evalpoly(1, 2, 3) ^ cbrt(27)
+
+@evalpoly(1, 2, 3 ^ cbrt(27))
+```
+
+The function-like form should be use for macros appearing within another expression, to make
+the end of the macro construct clear.
+
+The statement-like form should be used to annotate blocks:
+```julia
+@views for i in 1:n; #= body =#; end
+
+@inline function longdef(x)
+      ...
+end
+```
+
 ## Don't expose unsafe operations at the interface level
 
 If you have a type that uses a native pointer:

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -317,7 +317,7 @@ For example:
 @evalpoly 1 2 3 ^ cbrt(27)
 ```
 
-is ambiguous, as its unclear on what we want `@evalpoly` for. Do we want it to operate on
+is ambiguous, as it's unclear on what we want `@evalpoly` for. Do we want it to operate on
 `(1, 2, 3)` and then raise the result to power of `cbrt(27)`? Or we actually want it on
 `(1, 2, 3 ^ cbrt(27))`?
 

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -309,7 +309,7 @@ it will naturally have access to the run-time values it needs.
 
 ## Write macro expressions where `@` is unambiguous
 Though the function-like syntax, `@mymacro(arg1, arg2, arg3)`, and statement-like syntax,
-`@mymacro arg1 arg2 arg3`, for macros, are interchangeable, they can be ambiguous in some cases.
+`@mymacro arg1 arg2 arg3`, for macros, are interchangeable, the latter can be ambiguous in some cases.
 
 For example:
 


### PR DESCRIPTION
Motivation is from this section of the docs: [Noteworthy differences from C/C++](https://docs.julialang.org/en/v1/manual/noteworthy-differences/#Noteworthy-differences-from-C/C)

> Julia macros operate on parsed expressions, rather than the text of the program, which allows them to perform sophisticated transformations of Julia code. Macro names start with the @ character, and have both a function-like syntax, @mymacro(arg1, arg2, arg3), and a statement-like syntax, @mymacro arg1 arg2 arg3. The forms are interchangeable; the function-like form is particularly useful if the macro appears within another expression, and is often clearest. The statement-like form is often used to annotate blocks, as in the distributed for construct: @distributed for i in 1:n; #= body =#; end. Where the end of the macro construct may be unclear, use the function-like form.

As the last part of the statement states:
**"Where the end of the macro construct may be unclear, use the function-like form."**

That means, it's a style guide recommendation, and I found practical cases where this is very useful.

For a glorified example:
```julia
julia> @fastmath sin(3) + @something 1.5 nothing 3.5
1.6411200080598671
```
is ambiguous and confusing on what is **intended** here, making macros seem like a "tipoff" to average users.

A better way would be to write:
```julia
julia> @fastmath(sin(3) + @something(1.5, nothing, 3.5))
1.6411200080598671
```

Don't know if its a big deal, but IMHO since its recommended on that section and it gets weird on some cases, then maybe it would be nice to add it up there.
