### PR TITLE
Optimize indexing `Diagonal` with `Colon`s

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -121,6 +121,10 @@ end
 diagzero(::Diagonal{T}, i, j) where {T} = zero(T)
 diagzero(D::Diagonal{<:AbstractMatrix{T}}, i, j) where {T} = zeros(T, size(D.diag[i], 1), size(D.diag[j], 2))
 
+# Optimize some indexing methods to take advantage of the structure of the matrix
+getindex(D::Diagonal, ::Colon, ::Colon) = Diagonal(copy(D.diag))
+getindex(D::Diagonal, ::Colon, indsrest::Colon...) = reshape(D[:, :], Val(length(indsrest) + 1))
+
 function setindex!(D::Diagonal, v, i::Int, j::Int)
     @boundscheck checkbounds(D, i, j)
     if i == j

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -542,6 +542,9 @@ end
     for i in 1:n, j in 1:n
         @test D[i, j] == (i == j ? d[i] : 0)
     end
+    @test D[:] == vec(D)
+    @test D[:,:] == Matrix(D)
+    @test D[:,:,:] == Matrix(D)[:,:,:]
 end
 
 @testset "setindex!" begin


### PR DESCRIPTION
This PR tries to optimize indexing operations such as `D[:]` and `D[:,:]` for a diagonal `D`, making use of the structure of `D`. The idea parallels the optimized `Matrix(D)` method. Such an approach has certain advantages, such as preserving sparsity or static size information.

On master:
```julia
julia> D = Diagonal([1,2,3,4])
4×4 Diagonal{Int64, Vector{Int64}}:
 1  ⋅  ⋅  ⋅
 ⋅  2  ⋅  ⋅
 ⋅  ⋅  3  ⋅
 ⋅  ⋅  ⋅  4

julia> D[:,:]
4×4 Matrix{Int64}:
 1  0  0  0
 0  2  0  0
 0  0  3  0
 0  0  0  4

julia> using StaticArrays

julia> D = Diagonal(SVector{2}(1:2))
2×2 Diagonal{Int64, SVector{2, Int64}} with indices SOneTo(2)×SOneTo(2):
 1  ⋅
 ⋅  2

julia> D[:]
4-element Vector{Int64}:
 1
 0
 0
 2

julia> using SparseArrays

julia> D = Diagonal(spzeros(2))
2×2 Diagonal{Float64, SparseVector{Float64, Int64}}:
 0.0   ⋅ 
  ⋅   0.0

julia> D[:,:,:]
2×2×1 Array{Float64, 3}:
[:, :, 1] =
 0.0  0.0
 0.0  0.0
```
This PR
```julia
julia> D = Diagonal([1,2,3,4])
4×4 Diagonal{Int64, Vector{Int64}}:
 1  ⋅  ⋅  ⋅
 ⋅  2  ⋅  ⋅
 ⋅  ⋅  3  ⋅
 ⋅  ⋅  ⋅  4

julia> D[:,:]
4×4 Diagonal{Int64, Vector{Int64}}:
 1  ⋅  ⋅  ⋅
 ⋅  2  ⋅  ⋅
 ⋅  ⋅  3  ⋅
 ⋅  ⋅  ⋅  4

julia> D = Diagonal(SVector{2}(1:2))
2×2 Diagonal{Int64, SVector{2, Int64}} with indices SOneTo(2)×SOneTo(2):
 1  ⋅
 ⋅  2

julia> D[:]
4-element SizedVector{4, Int64, Base.ReshapedArray{Int64, 1, Diagonal{Int64, SVector{2, Int64}}, Tuple{Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64}}}} with indices SOneTo(4):
 1
 0
 0
 2

julia> D = Diagonal(spzeros(2))
2×2 Diagonal{Float64, SparseVector{Float64, Int64}}:
 0.0   ⋅ 
  ⋅   0.0

julia> D[:,:,:]
2×2×1 reshape(::Diagonal{Float64, SparseVector{Float64, Int64}}, 2, 2, 1) with eltype Float64:
[:, :, 1] =
 0.0  0.0
 0.0  0.0
```

The returned type is somewhat unusual for `getindex` operations (as it's a reshaped array), and I'm uncertain if this is a good idea from an invalidation point of view. The new methods introduced in this PR might also lead to method ambiguities, in case packages have defined `getindex(::Diagonal{T, MyVector{T}}, ::Vararg{Colon})`, so I'm not fully convinced that this is the best way to proceed, and would like to hear of other ways to achieve the goals.