### PR TITLE
Change confusing (likely wrong) docs

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -6,14 +6,14 @@
 # strict IEEE semantics.
 
 # This allows the following transformations. For more information see
-# http://llvm.org/docs/LangRef.html#fast-math-flags:
+# http://llvm.org/docs/LangRef.html#fast-math-flags :
 # nnan: No NaNs - Allow optimizations to assume the arguments and
 #       result are not NaN. Such optimizations are required to retain
 #       defined behavior over NaNs, but the value of the result is
 #       undefined.
 # ninf: No Infs - Allow optimizations to assume the arguments and
 #       result are not +/-Inf. Such optimizations are required to
-#       retain defined behavior over +/-Inf, but the value of the
+#       return some value over +/-Inf, but the value of the
 #       result is undefined.
 # nsz:  No Signed Zeros - Allow optimizations to treat the sign of a
 #       zero argument or result as insignificant.


### PR DESCRIPTION
At LLVM: "No Infs - Allow optimizations to assume the arguments and result are not +/-Inf. If an argument is +/-Inf, or the result would be +/-Inf, it produces a poison value instead."

I believe a Float64 can't return a posion value (e.g. it wouldn't mean NaN), so doesn't apply for Julia.

[skip ci]