### PR TITLE
Fix list syntax typo in documentation.md

### DIFF
--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -17,7 +17,7 @@ environments provide a way to access documentation directly:
   You can also use the Julia panel in the sidebar to search for documentation.
 - In [Pluto](https://github.com/fonsp/Pluto.jl), open the "Live Docs" panel on the bottom right.
 - In [Juno](https://junolab.org) using `Ctrl-J, Ctrl-D` will show the documentation for the object
-under the cursor.
+  under the cursor.
 
 ## Writing Documentation
 


### PR DESCRIPTION
The end of the list item on "how to show object documentation in Juno" was broken in a separate paragraph.

I noticed the problem in https://docs.julialang.org/en/v1/manual/documentation/:

![screenshot of Julia manual §documentation](https://user-images.githubusercontent.com/1010404/198599947-3720bf19-25ff-4ee5-8099-3b8677265b7c.png)

To make things a bit more obfuscated, the problem doesn't show up when looking that Github rendered version at https://github.com/JuliaLang/julia/blob/master/doc/src/manual/documentation.md!