### PR TITLE
Add `@allocations` macro for getting number of allocations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -78,6 +78,8 @@ New library functions
 * New function `stack(x)` which generalises `reduce(hcat, x::Vector{<:Vector})` to any dimensionality,
   and allows any iterators of iterators. Method `stack(f, x)` generalises `mapreduce(f, hcat, x)` and
   is efficient. ([#43334])
+* New macro `@allocations` which is similar to `@allocated` except reporting the total number of allocations
+  rather than the total size of memory allocated. ([#47367])
 
 Library changes
 ---------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1018,6 +1018,7 @@ export
     @timev,
     @elapsed,
     @allocated,
+    @allocs,
 
     # tasks
     @sync,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1018,7 +1018,7 @@ export
     @timev,
     @elapsed,
     @allocated,
-    @allocs,
+    @allocations,
 
     # tasks
     @sync,

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -219,7 +219,7 @@ called code before execution of the top-level expression begins. When that happe
 compilation time will not be counted. To include this time you can run `@time @eval ...`.
 
 See also [`@showtime`](@ref), [`@timev`](@ref), [`@timed`](@ref), [`@elapsed`](@ref),
-[`@allocated`](@ref), and [`@allocs`](@ref).
+[`@allocated`](@ref), and [`@allocations`](@ref).
 
 !!! note
     For more serious benchmarking, consider the `@btime` macro from the BenchmarkTools.jl
@@ -319,7 +319,7 @@ Optionally provide a description string to print before the time report.
     The option to add a description was introduced in Julia 1.8.
 
 See also [`@time`](@ref), [`@timed`](@ref), [`@elapsed`](@ref),
-[`@allocated`](@ref), and [`@allocs`](@ref).
+[`@allocated`](@ref), and [`@allocations`](@ref).
 
 ```julia-repl
 julia> x = rand(10,10);
@@ -379,7 +379,7 @@ called code before execution of the top-level expression begins. When that happe
 compilation time will not be counted. To include this time you can run `@elapsed @eval ...`.
 
 See also [`@time`](@ref), [`@timev`](@ref), [`@timed`](@ref),
-[`@allocated`](@ref), and [`@allocs`](@ref).
+[`@allocated`](@ref), and [`@allocations`](@ref).
 
 ```julia-repl
 julia> @elapsed sleep(0.3)
@@ -410,7 +410,7 @@ end
 A macro to evaluate an expression, discarding the resulting value, instead returning the
 total number of bytes allocated during evaluation of the expression.
 
-See also [`@allocs`](@ref), [`@time`](@ref), [`@timev`](@ref), [`@timed`](@ref),
+See also [`@allocations`](@ref), [`@time`](@ref), [`@timev`](@ref), [`@timed`](@ref),
 and [`@elapsed`](@ref).
 
 ```julia-repl
@@ -431,7 +431,7 @@ macro allocated(ex)
 end
 
 """
-    @allocs
+    @allocations
 
 A macro to evaluate an expression, discard the resulting value, and instead return the
 total number of allocations during evaluation of the expression.
@@ -440,14 +440,14 @@ See also [`@allocated`](@ref), [`@time`](@ref), [`@timev`](@ref), [`@timed`](@re
 and [`@elapsed`](@ref).
 
 ```julia-repl
-julia> @allocs rand(10^6)
+julia> @allocations rand(10^6)
 2
 ```
 
 !!! compat "Julia 1.9"
     This macro was added in Julia 1.9.
 """
-macro allocs(ex)
+macro allocations(ex)
     quote
         Experimental.@force_compile
         local stats = Base.gc_num()
@@ -469,7 +469,7 @@ called code before execution of the top-level expression begins. When that happe
 compilation time will not be counted. To include this time you can run `@timed @eval ...`.
 
 See also [`@time`](@ref), [`@timev`](@ref), [`@elapsed`](@ref),
-[`@allocated`](@ref), and [`@allocs`](@ref).
+[`@allocated`](@ref), and [`@allocations`](@ref).
 
 ```julia-repl
 julia> stats = @timed rand(10^6);

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -218,8 +218,8 @@ In some cases the system will look inside the `@time` expression and compile som
 called code before execution of the top-level expression begins. When that happens, some
 compilation time will not be counted. To include this time you can run `@time @eval ...`.
 
-See also [`@showtime`](@ref), [`@timev`](@ref), [`@timed`](@ref), [`@elapsed`](@ref), and
-[`@allocated`](@ref).
+See also [`@showtime`](@ref), [`@timev`](@ref), [`@timed`](@ref), [`@elapsed`](@ref),
+[`@allocated`](@ref), and [`@allocs`](@ref).
 
 !!! note
     For more serious benchmarking, consider the `@btime` macro from the BenchmarkTools.jl
@@ -318,8 +318,8 @@ Optionally provide a description string to print before the time report.
 !!! compat "Julia 1.8"
     The option to add a description was introduced in Julia 1.8.
 
-See also [`@time`](@ref), [`@timed`](@ref), [`@elapsed`](@ref), and
-[`@allocated`](@ref).
+See also [`@time`](@ref), [`@timed`](@ref), [`@elapsed`](@ref),
+[`@allocated`](@ref), and [`@allocs`](@ref).
 
 ```julia-repl
 julia> x = rand(10,10);
@@ -379,7 +379,7 @@ called code before execution of the top-level expression begins. When that happe
 compilation time will not be counted. To include this time you can run `@elapsed @eval ...`.
 
 See also [`@time`](@ref), [`@timev`](@ref), [`@timed`](@ref),
-and [`@allocated`](@ref).
+[`@allocated`](@ref), and [`@allocs`](@ref).
 
 ```julia-repl
 julia> @elapsed sleep(0.3)
@@ -410,7 +410,7 @@ end
 A macro to evaluate an expression, discarding the resulting value, instead returning the
 total number of bytes allocated during evaluation of the expression.
 
-See also [`@time`](@ref), [`@timev`](@ref), [`@timed`](@ref),
+See also [`@allocs`](@ref), [`@time`](@ref), [`@timev`](@ref), [`@timed`](@ref),
 and [`@elapsed`](@ref).
 
 ```julia-repl
@@ -431,6 +431,33 @@ macro allocated(ex)
 end
 
 """
+    @allocs
+
+A macro to evaluate an expression, discard the resulting value, and instead return the
+total number of allocations during evaluation of the expression.
+
+See also [`@allocated`](@ref), [`@time`](@ref), [`@timev`](@ref), [`@timed`](@ref),
+and [`@elapsed`](@ref).
+
+```julia-repl
+julia> @allocs rand(10^6)
+2
+```
+
+!!! compat "Julia 1.9"
+    This macro was added in Julia 1.9.
+"""
+macro allocs(ex)
+    quote
+        Experimental.@force_compile
+        local stats = Base.gc_num()
+        $(esc(ex))
+        local diff = Base.GC_Diff(Base.gc_num(), stats)
+        Base.gc_alloc_count(diff)
+    end
+end
+
+"""
     @timed
 
 A macro to execute an expression, and return the value of the expression, elapsed time,
@@ -441,8 +468,8 @@ In some cases the system will look inside the `@timed` expression and compile so
 called code before execution of the top-level expression begins. When that happens, some
 compilation time will not be counted. To include this time you can run `@timed @eval ...`.
 
-See also [`@time`](@ref), [`@timev`](@ref), [`@elapsed`](@ref), and
-[`@allocated`](@ref).
+See also [`@time`](@ref), [`@timev`](@ref), [`@elapsed`](@ref),
+[`@allocated`](@ref), and [`@allocs`](@ref).
 
 ```julia-repl
 julia> stats = @timed rand(10^6);

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -332,6 +332,7 @@ Base.@timev
 Base.@timed
 Base.@elapsed
 Base.@allocated
+Base.@allocations
 Base.EnvDict
 Base.ENV
 Base.Sys.STDLIB

--- a/doc/src/manual/profile.md
+++ b/doc/src/manual/profile.md
@@ -303,8 +303,8 @@ provides several tools measure this:
 
 ### `@time`
 
-The total amount of allocation can be measured with [`@time`](@ref) and [`@allocated`](@ref), and
-specific lines triggering allocation can often be inferred from profiling via the cost of garbage
+The total amount of allocation can be measured with [`@time`](@ref), [`@allocated`](@ref) and [`@allocations`](@ref),
+and specific lines triggering allocation can often be inferred from profiling via the cost of garbage
 collection that these lines incur. However, sometimes it is more efficient to directly measure
 the amount of memory allocated by each line of code.
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1235,7 +1235,7 @@ end
 @testset "Base/timing.jl" begin
     @test Base.jit_total_bytes() >= 0
 
-    # sanity check `@allocs` returns what we expect in some very simple cases
-    @test (@alloc "a") == 0
-    @test (@alloc "a" * "b") == 1
+    # sanity check `@allocations` returns what we expect in some very simple cases
+    @test (@allocations "a") == 0
+    @test (@allocations "a" * "b") == 1
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1234,4 +1234,8 @@ end
 
 @testset "Base/timing.jl" begin
     @test Base.jit_total_bytes() >= 0
+
+    # sanity check `@allocs` returns what we expect in some very simple cases
+    @test (@alloc "a") == 0
+    @test (@alloc "a" * "b") == 1
 end


### PR DESCRIPTION
Adds an ~`@allocs`~ `@allocations` macro (name TBD) which behaves similarly to `@allocated` except for returning a count of the allocations during evaluation of the expression rather than the total size in bytes of the memory allocated.

This uses `Base.gc_alloc_count` so returns a single number combining all types of allocations (malloc, realloc, poolalloc, bigalloc), like what is printed via `@time`. The more granular break down is still available from `@timed` (or printed via `@timev`). i think the single number is useful for some cases (when you're happy to treat all allocations as equal).

The motivation is to make it just as easy to get number of allocations as it is to get number of bytes allocated. For example, at RAI we have some people investigating sources of allocations and are often more concerned about the number of allocations than the size of memory allocated, yet i still see people reach for `@allocated` to get a single-number sumarry, because it's just a much easier and more discoverable interface than something like `Base.gc_alloc_count((@timed foo()).gcstats)`.

Opened this as a PR as it wasn't too much harder than opening an issue - discussion welcome! Would appreciate pointers on implementation and testing too, if we're happy with this in prospect. Thanks!
