### PR TITLE
Document the behavior of zip()

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -338,6 +338,10 @@ the `zip` iterator is a tuple of values of its subiterators.
     `zip` orders the calls to its subiterators in such a way that stateful iterators will
     not advance when another iterator finishes in the current iteration.
 
+!!! note
+
+    `zip()` with no arguments yields an infinite iterator of empty tuples.
+
 See also: [`enumerate`](@ref), [`Splat`](@ref Base.Splat).
 
 # Examples


### PR DESCRIPTION
`zip(xss...)` terminates when its shortest argument does -- the initial case is infinite. https://github.com/JuliaLang/julia/issues/43821#issuecomment-1013816939

Closes https://github.com/JuliaLang/julia/issues/43821