### PR TITLE
Handle incorrect call type in abstract_invoke

### DIFF
--- a/test/compiler/AbstractInterpreter.jl
+++ b/test/compiler/AbstractInterpreter.jl
@@ -351,3 +351,7 @@ let NoinlineModule = Module()
         @test count(iscall((src, inlined_usually)), src.code) == 0
     end
 end
+
+# Issue #46839
+@test code_typed(()->invoke(BitSet, Any, x), ())[1][2] === Union{}
+@test code_typed(()->invoke(BitSet, Union{Tuple{Int32},Tuple{Int64}}, 1), ())[1][2] === Union{}


### PR DESCRIPTION
Abstract interpreter was returning Any where calling the method would result in a MethodError, implying that the result should have been that the code was unreachable.

Fixes #46839