### PR TITLE
Update env.jl to add example usage for the ENV functionality

### DIFF
--- a/base/env.jl
+++ b/base/env.jl
@@ -73,6 +73,28 @@ variables.
 all keys to uppercase for display, iteration, and copying. Portable code should not rely on the
 ability to distinguish variables by case, and should beware that setting an ostensibly lowercase
 variable may result in an uppercase `ENV` key.)
+
+If you want to create your own `ENV` variable, you can do so by specifying its name in quotation marks as
+is shown below: 
+
+# Examples
+```jldoctest ENV
+julia> ENV["JULIA_EDITOR"] = "vim"
+"vim"
+
+julia> ENV["JULIA_EDITOR"]
+"vim"
+```
+
+To see all of your active `ENV` variables in your current environment, you can simply do the following:
+```julia
+julia> ENV
+Base.EnvDict with "N" entries:
+  "SECURITYSESSIONID"            => "123"
+  "USER"                         => "username"
+  "MallocNanoZone"               => "0"
+  ⋮                              => ⋮
+```
 """
 const ENV = EnvDict()
 

--- a/base/env.jl
+++ b/base/env.jl
@@ -75,7 +75,7 @@ ability to distinguish variables by case, and should beware that setting an oste
 variable may result in an uppercase `ENV` key.)
 
 If you want to create your own `ENV` variable, you can do so by specifying its name in quotation marks as
-is shown below: 
+is shown below:
 
 # Examples
 ```jldoctest ENV


### PR DESCRIPTION
Right now, we do not give usage guidelines on how to use ENV, I was working through https://github.com/logankilpatrick/GitHub.jl#authentication and was truthfully unclear on how to set one. My first place to look was the help mode but it did not have an example. 

Eventually, I made it to the docs here: https://docs.julialang.org/en/v1/manual/environment-variables/#Environment-Variables but it would have been nice to see how to do this without leaving the REPL. 