### PR TITLE
more clarity on [] indexing

### DIFF
--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -653,7 +653,7 @@ indices and can be converted to such by [`to_indices`](@ref):
     * [`CartesianIndex{N}`](@ref)s, which behave like an `N`-tuple of integers spanning multiple dimensions (see below for more details)
 2. An array of scalar indices. This includes:
     * Vectors and multidimensional arrays of integers
-    * Empty arrays like `[]`, which select no elements
+    * Empty arrays like `[]`, which select no elements e.g. `A[[]]` (not to be confused with `A[]`)
     * Ranges like `a:c` or `a:b:c`, which select contiguous or strided subsections from `a` to `c` (inclusive)
     * Any custom array of scalar indices that is a subtype of `AbstractArray`
     * Arrays of `CartesianIndex{N}` (see below for more details)


### PR DESCRIPTION
There is no example on this which can be confused with `A[]`:
```julia
ulia> A = [1]
1-element Vector{Int64}:
 1

julia> A[]
1

julia> A[[]]
Int64[]
```

An example would help to make clarity ASAP.