### PR TITLE
Make `append!`/`prepend!` recover gracefully from errors

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1115,7 +1115,7 @@ See [`sizehint!`](@ref) for notes about the performance model.
 See also [`vcat`](@ref) for vectors, [`union!`](@ref) for sets,
 and [`prepend!`](@ref) and [`pushfirst!`](@ref) for the opposite order.
 """
-append!(a::Vector{T}, items::AbstractVector{U}) where {U <: T} = unsafe_append!(a, items)
+append!(a::Vector{T}, items::AbstractVector{U}) where {T, U <: T} = unsafe_append!(a, items)
 append!(a::Vector, items::AbstractVector) = try_append!(a, items)
 
 function try_append!(a::Vector, items::AbstractVector)
@@ -1214,7 +1214,7 @@ julia> prepend!([6], [1, 2], [3, 4, 5])
 """
 function prepend! end
 
-prepend!(a::Vector{T}, items::AbstractVector{U}) where {U <: T} = unsafe_prepend!(a, items)
+prepend!(a::Vector{T}, items::AbstractVector{U}) where {T, U <: T} = unsafe_prepend!(a, items)
 prepend!(a::Vector, items::AbstractVector) = try_prepend!(a, items)
 
 function try_prepend!(a::Vector, items::AbstractVector)

--- a/base/array.jl
+++ b/base/array.jl
@@ -1220,7 +1220,7 @@ prepend!(a::Vector, items::AbstractVector) = try_prepend!(a, items)
 prepend!(a::Vector{T}, items::AbstractVector{U}) where {T, U <: T} = unsafe_prepend!(a, items)
 
 function try_prepend!(a::Vector, items::AbstractVector)
-    n = length(itemindices)
+    n = length(items)
     try
         unsafe_prepend!(a, items)
     catch e

--- a/base/array.jl
+++ b/base/array.jl
@@ -1271,17 +1271,17 @@ function _unsafe_prepend!(a, ::Union{HasLength,HasShape}, iter)
     a
 end
 
-function _try_prepend!(a::Vector, sz::IteratorSize, iter)
+function _try_prepend!(a, sz::IteratorSize, iter)
     n = length(a)
     try
-        unsafe_prepend!(a, sz, iter)
+        _unsafe_prepend!(a, sz, iter)
     catch e
         _deletebeg!(a, length(a) - n)
         rethrow(e)
     end
     a
 end
-function _unsafe_prepend!(a::Vector, ::IteratorSize, iter)
+function _unsafe_prepend!(a, ::IteratorSize, iter)
     n = 0
     for item in iter
         n += 1

--- a/base/array.jl
+++ b/base/array.jl
@@ -1137,7 +1137,7 @@ function unsafe_append!(a::Vector, items::AbstractVector)
 end
 
 function append!(a::AbstractVector, iter)
-    if  IteratorEltype(iter) == HasEltype() && eltype(iter) <: eltype(a)
+    if  IteratorEltype(iter) === HasEltype() && eltype(iter) <: eltype(a)
         _unsafe_append!(a, IteratorSize(iter), iter)
     else
         _try_append!(a, IteratorSize(iter), iter)
@@ -1240,7 +1240,7 @@ function unsafe_prepend!(a::Vector, items::AbstractVector)
 end
 
 function prepend!(a::AbstractVector, iter)
-    if IteratorEltype(iter) == HasEltype() && eltype(iter) <: eltype(a)
+    if IteratorEltype(iter) === HasEltype() && eltype(iter) <: eltype(a)
         _unsafe_prepend!(a, IteratorSize(iter), iter)
     else
         _try_prepend!(a, IteratorSize(iter), iter)

--- a/base/array.jl
+++ b/base/array.jl
@@ -1133,7 +1133,7 @@ function try_append!(a::Vector, items::AbstractVector)
         unsafe_append!(a, items)
     catch e
         resize!(a, n)
-        rethrow(e)
+        rethrow()
     end
     return a
 end
@@ -1164,7 +1164,7 @@ function _try_append!(a, sz::Union{HasLength,HasShape}, iter)
         _unsafe_append!(a, sz, iter)
     catch e
         resize!(a, n)
-        rethrow(e)
+        rethrow()
     end
 end
 
@@ -1180,7 +1180,7 @@ function _try_append!(a, sz::IteratorSize, iter)
         _unsafe_append!(a, sz, iter)
     catch e
         resize!(a, n)
-        rethrow(e)
+        rethrow()
     end
     a
 end
@@ -1225,7 +1225,7 @@ function try_prepend!(a::Vector, items::AbstractVector)
         unsafe_prepend!(a, items)
     catch e
         _deletebeg!(a, n)
-        rethrow(e)
+        rethrow()
     end
     return a
 end
@@ -1258,7 +1258,7 @@ function _try_prepend!(a, sz::Union{HasLength,HasShape}, iter)
         _unsafe_prepend!(a, sz, iter)
     catch e
         _deletebeg!(a, n)
-        rethrow(e)
+        rethrow()
     end
     a
 end
@@ -1279,7 +1279,7 @@ function _try_prepend!(a, sz::IteratorSize, iter)
         _unsafe_prepend!(a, sz, iter)
     catch e
         _deletebeg!(a, length(a) - n)
-        rethrow(e)
+        rethrow()
     end
     a
 end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1740,6 +1740,32 @@ end
     # offset array
     @test append!([1,2], OffsetArray([9,8], (-3,))) == [1,2,9,8]
     @test prepend!([1,2], OffsetArray([9,8], (-3,))) == [9,8,1,2]
+
+    # Error recovery
+    A = [1, 2]
+    try append!(A, [1, 2, "hi"]) catch e; end
+    @test A == [1, 2]
+
+    oA = OffsetVector(A, 0:1)
+    try append!(oA, [1, 2, 3.01]) catch e; end
+    @test oA == OffsetVector([1, 2], 0:1)
+
+    try append!(A, (x for x in [1, 2, 3.1])) catch e; end
+    @test A == [1, 2]
+
+    try append!(A, (x for x in [1, 2, 3.1] if isfinite(x))) catch e; end
+    @test A == [1, 2]
+
+    try prepend!(A, [1, 2, "hi"]) catch e; end
+    @test A == [1, 2]
+
+    A = [1, 2]
+    try prepend!(A, (x for x in [1, 2, 3.1])) catch e; end
+    @test A == [1, 2]
+
+    A = [1, 2]
+    try prepend!(A, (x for x in [1, 2, 3.1] if isfinite(x))) catch e; end
+    @test A == [1, 2]
 end
 
 let A = [1,2]


### PR DESCRIPTION
This should fix https://github.com/JuliaLang/julia/issues/15868 in the manner described here: https://github.com/JuliaLang/julia/issues/15868#issuecomment-1262583777.

_____

Currently, if you do `a = [1, 2]; append!(a, [3, 4.5])` an error will be thrown, and after the error, `a` will now be of length `4`, with one garbage value in the 4th position which is perhaps surprising and undesirable. 

Previous discussions decided that there was no way to fix this and avoid introducing a `try/catch` block, so this PR does introduce a `try/catch`, but only hits that if `eltype(items) <: eltype(a)` in `append!(a, items)`. This means that if someone writes
```julia
append!([1, 2], [3.0, 4.0])
```
that will become slower after this PR, but the performance of
```julia
append!([1, 2], [3, 4])
```
should be completely unaffected, which I think is a good compromise. 