### PR TITLE
Check Windows CI on buildkite on `release-1.8`

### DIFF
--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -48,8 +48,6 @@ jobs:
       - run: |
           declare -a CONTEXT_LIST=(
                 "buildbot/tester_freebsd64"
-                "buildbot/tester_win32"
-                "buildbot/tester_win64"
                 )
           for CONTEXT in "${CONTEXT_LIST[@]}"
           do


### PR DESCRIPTION
To see if the Windows red in https://github.com/JuliaLang/julia/pull/46984 is due to the stuff in there or due to moving Windows CI to buildkite.