### PR TITLE
Don't warn about skipping tests that were not skipped

### DIFF
--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -159,7 +159,12 @@ function choosetests(choices = [])
         filter!(x -> (x != "Profile"), tests)
     end
 
-    net_required_for = [
+    if ccall(:jl_running_on_valgrind,Cint,()) != 0 && "rounding" in tests
+        @warn "Running under valgrind: Skipping rounding tests"
+        filter!(x -> x != "rounding", tests)
+    end
+
+    net_required_for = filter!(in(tests), [
         "Artifacts",
         "Downloads",
         "LazyArtifacts",
@@ -167,7 +172,7 @@ function choosetests(choices = [])
         "LibGit2",
         "Sockets",
         "download",
-    ]
+    ])
     net_on = true
     JULIA_TEST_NETWORKING_AVAILABLE = get(ENV, "JULIA_TEST_NETWORKING_AVAILABLE", "") |>
                                       strip |>
@@ -179,21 +184,20 @@ function choosetests(choices = [])
     # Otherwise, we set `net_on` to true if and only if networking is actually available.
     if !JULIA_TEST_NETWORKING_AVAILABLE
         try
-            ipa = getipaddr()
+            getipaddr()
         catch
             if ci_option_passed
                 @error("Networking unavailable, but `--ci` was passed")
                 rethrow()
             end
             net_on = false
-            @warn "Networking unavailable: Skipping tests [" * join(net_required_for, ", ") * "]"
-            filter!(!in(net_required_for), tests)
+            if isempty(net_required_for)
+                @warn "Networking unavailable"
+            else
+                @warn "Networking unavailable: Skipping tests [" * join(net_required_for, ", ") * "]"
+                filter!(!in(net_required_for), tests)
+            end
         end
-    end
-
-    if ccall(:jl_running_on_valgrind,Cint,()) != 0 && "rounding" in tests
-        @warn "Running under valgrind: Skipping rounding tests"
-        filter!(x -> x != "rounding", tests)
     end
 
     filter!(!in(tests), unhandled)


### PR DESCRIPTION
Before
```
x@X julia % ./julia test/runtests.jl sorting
┌ Warning: Networking unavailable: Skipping tests [Artifacts, Downloads, LazyArtifacts, LibCURL, LibGit2, Sockets, download]
└ @ Main ~/.julia/dev/julia/test/choosetests.jl:189
Running parallel tests with:
...
x@X julia % ./julia test/runtests.jl downloads
┌ Warning: Networking unavailable: Skipping tests [Artifacts, Downloads, LazyArtifacts, LibCURL, LibGit2, Sockets, download]
└ @ Main ~/.julia/dev/julia/test/choosetests.jl:189
Running parallel tests with:
...
```
After
```
x@X julia_dm % ./julia test/runtests.jl sorting
┌ Warning: Networking unavailable
└ @ Main ~/.julia/dev/julia_dm/test/choosetests.jl:195
Running parallel tests with:
...
x@X julia_dm % ./julia test/runtests.jl download 
┌ Warning: Networking unavailable: Skipping tests [download]
└ @ Main ~/.julia/dev/julia_dm/test/choosetests.jl:197
Running parallel tests with:
...
```