### PR TITLE
Fix test for broken libjulia-codegen

### DIFF
--- a/cli/loader.h
+++ b/cli/loader.h
@@ -20,6 +20,7 @@
 #define strchr loader_strchr
 #define malloc loader_malloc
 #define realloc loader_realloc
+#define free loader_free
 #endif
 
 #ifdef _OS_WINDOWS_

--- a/cli/loader_win_utils.c
+++ b/cli/loader_win_utils.c
@@ -12,22 +12,30 @@ static FILE _stderr = { INVALID_HANDLE_VALUE };
 FILE *stdout = &_stdout;
 FILE *stderr = &_stderr;
 
-int loader_fwrite(const WCHAR *str, size_t nchars, FILE *out) {
+int loader_fwrite(const char *str, size_t nchars, FILE *out) {
     DWORD written;
     if (out->isconsole) {
-        if (WriteConsole(out->fd, str, nchars, &written, NULL))
+        // Windows consoles do not support UTF8, only UTF16.
+        size_t wbufsz = nchars * 4 + 1;
+        wchar_t* wstr = (wchar_t*)loader_malloc(wbufsz);
+        if (!utf8_to_wchar(str, wstr, wbufsz)) {
+            loader_free(wstr);
+            return -1;
+        }
+        if (WriteConsole(out->fd, str, wcslen(wstr), &written, NULL)) {
+            loader_free(wstr);
             return written;
+        }
     } else {
-        if (WriteFile(out->fd, str, sizeof(WCHAR) * nchars, &written, NULL))
+        // However, we want to print utf8 if the output is a file.
+        if (WriteFile(out->fd, str, nchars, &written, NULL))
             return written;
     }
     return -1;
 }
 
 int loader_fputs(const char *str, FILE *out) {
-    wchar_t wstr[1024];
-    utf8_to_wchar(str, wstr, 1024);
-    return fwrite(wstr, wcslen(wstr), out);
+    return loader_fwrite(str, loader_strlen(str), out);
 }
 
 void * loader_malloc(const size_t size) {
@@ -36,6 +44,10 @@ void * loader_malloc(const size_t size) {
 
 void * loader_realloc(void * mem, const size_t size) {
     return HeapReAlloc(GetProcessHeap(), HEAP_GENERATE_EXCEPTIONS, mem, size);
+}
+
+void loader_free(void* mem) {
+    HeapFree(GetProcessHeap(), 0, mem);
 }
 
 LPWSTR *CommandLineToArgv(LPWSTR lpCmdLine, int *pNumArgs) {

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -709,7 +709,7 @@ mktempdir() do pfx
     @test_throws ProcessFailedException run(pipeline(`$pfx/bin/$(Base.julia_exename()) -e 'print("This should fail!\n")'`; stderr=errfile))
     errmsg = ""
     @static if Sys.iswindows()
-        errmsg = open(errfile, "r") do f; utf16(readbytes(f)); end
+        errmsg = open(errfile, "r") do f; utf16(read(f)); end
     else
         errmsg = readline(errfile)
     end

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -716,7 +716,7 @@ mktempdir() do pfx
         return transcode(String, units)
     end
     @static if Sys.iswindows()
-        errmsg = open(errfile, "r") do f; utf16(read(f)); end
+        errmsg = utf16(read(errfile))
     else
         errmsg = readline(errfile)
     end

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -707,7 +707,6 @@ mktempdir() do pfx
     errfile = joinpath(pfx, "stderr.txt")
     @test libs_emptied > 0
     @test_throws ProcessFailedException run(pipeline(`$pfx/bin/$(Base.julia_exename()) -e 'print("This should fail!\n")'`; stderr=errfile))
-    errmsg = ""
     utf16 = bytes -> begin
         n = Int(length(bytes)//2)
         pairs = [bytes[(2i-1):(2i)] for i in 1:n]

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -711,7 +711,7 @@ mktempdir() do pfx
     utf16 = bytes -> begin
         n = Int(length(bytes)//2)
         pairs = [bytes[(2i-1):(2i)] for i in 1:n]
-        f = x -> reinterpret(UInt16, x)
+        f = pair -> reinterpret(UInt16, pair)
         units = only.(f.(pairs))
         return transcode(String, units)
     end

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -707,7 +707,13 @@ mktempdir() do pfx
     errfile = joinpath(pfx, "stderr.txt")
     @test libs_emptied > 0
     @test_throws ProcessFailedException run(pipeline(`$pfx/bin/$(Base.julia_exename()) -e 'print("This should fail!\n")'`; stderr=errfile))
-    @test contains(readline(errfile), "ERROR: Unable to load dependent library")
+    errmsg = ""
+    @static if Sys.iswindows()
+        errmsg = open(errfile, "r") do f; utf16(readbytes(f)); end
+    else
+        errmsg = readline(errfile)
+    end
+    @test contains(errmsg, "ERROR: Unable to load dependent library")
 end
 
 # issue #42645

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -708,6 +708,13 @@ mktempdir() do pfx
     @test libs_emptied > 0
     @test_throws ProcessFailedException run(pipeline(`$pfx/bin/$(Base.julia_exename()) -e 'print("This should fail!\n")'`; stderr=errfile))
     errmsg = ""
+    utf16 = bytes -> begin
+        n = Int(length(bytes)//2)
+        pairs = [bytes[(2i-1):(2i)] for i in 1:n]
+        f = x -> reinterpret(UInt16, x)
+        units = only.(f.(pairs))
+        return transcode(String, units)
+    end
     @static if Sys.iswindows()
         errmsg = open(errfile, "r") do f; utf16(read(f)); end
     else


### PR DESCRIPTION
Fails on windows due to utf-16 conversion.

Test was introduced on PR #47343, and has been talked about on #44527