### PR TITLE
loader_fputs convert to utf16 only for Windows console

### DIFF
--- a/cli/loader.h
+++ b/cli/loader.h
@@ -20,6 +20,7 @@
 #define strchr loader_strchr
 #define malloc loader_malloc
 #define realloc loader_realloc
+#define free loader_free
 #endif
 
 #ifdef _OS_WINDOWS_

--- a/cli/loader_win_utils.c
+++ b/cli/loader_win_utils.c
@@ -12,22 +12,30 @@ static FILE _stderr = { INVALID_HANDLE_VALUE };
 FILE *stdout = &_stdout;
 FILE *stderr = &_stderr;
 
-int loader_fwrite(const WCHAR *str, size_t nchars, FILE *out) {
+int loader_fwrite(const char *str, size_t nchars, FILE *out) {
     DWORD written;
     if (out->isconsole) {
-        if (WriteConsole(out->fd, str, nchars, &written, NULL))
+        // Windows consoles do not support UTF8, only UTF16.
+        size_t wbufsz = nchars * 4 + 1;
+        wchar_t* wstr = (wchar_t*)loader_malloc(wbufsz);
+        if (!utf8_to_wchar(str, wstr, wbufsz)) {
+            loader_free(wstr);
+            return -1;
+        }
+        if (WriteConsole(out->fd, str, wcslen(wstr), &written, NULL)) {
+            loader_free(wstr);
             return written;
+        }
     } else {
-        if (WriteFile(out->fd, str, sizeof(WCHAR) * nchars, &written, NULL))
+        // However, we want to print utf8 if the output is a file.
+        if (WriteFile(out->fd, str, nchars, &written, NULL))
             return written;
     }
     return -1;
 }
 
 int loader_fputs(const char *str, FILE *out) {
-    wchar_t wstr[1024];
-    utf8_to_wchar(str, wstr, 1024);
-    return fwrite(wstr, wcslen(wstr), out);
+    return loader_fwrite(str, loader_strlen(str), out);
 }
 
 void * loader_malloc(const size_t size) {
@@ -36,6 +44,10 @@ void * loader_malloc(const size_t size) {
 
 void * loader_realloc(void * mem, const size_t size) {
     return HeapReAlloc(GetProcessHeap(), HEAP_GENERATE_EXCEPTIONS, mem, size);
+}
+
+void loader_free(void* mem) {
+    HeapFree(GetProcessHeap(), 0, mem);
 }
 
 LPWSTR *CommandLineToArgv(LPWSTR lpCmdLine, int *pNumArgs) {


### PR DESCRIPTION
We use `loader_fputs` to write error messages, and when
we write them to files we want those files to be utf8.

This should fix the broken test I introduced in JuliaLang/julia#47343.