### PR TITLE
Ignore ANSI colour codes in printing Diagonal, etc

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -40,7 +40,7 @@ centered cdot, used in printing of structural zeros of structured matrices.
 Accept keyword args `c` for alternate single character marker.
 """
 function replace_with_centered_mark(s::AbstractString;c::AbstractChar = '⋅')
-    N = length(s)
+    N = textwidth(ANSIIterator(s))
     return join(setindex!([" " for i=1:N],string(c),ceil(Int,N/2)))
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -2380,8 +2380,8 @@ Base.show(io::IO, ces::⛵) = Base.print(io, '⛵')
 @test Base.alignment(IOContext(IOBuffer(), :color=>false), ColoredLetter()) == (0, 1)
 
 # spacing around dots in Diagonal, etc:
-redmiusthree = sprint((io, x) -> printstyled(io, x, color=:red), "-3", context=stdout)
-@test Base.replace_with_centered_mark(redmiusthree) == Base.replace_with_centered_mark("-3")
+redminusthree = sprint((io, x) -> printstyled(io, x, color=:red), "-3", context=stdout)
+@test Base.replace_with_centered_mark(redminusthree) == Base.replace_with_centered_mark("-3")
 
 # `show` implementations for `Method`
 let buf = IOBuffer()

--- a/test/show.jl
+++ b/test/show.jl
@@ -2379,6 +2379,10 @@ Base.show(io::IO, ces::⛵) = Base.print(io, '⛵')
 @test Base.alignment(IOContext(IOBuffer(), :color=>true), ColoredLetter()) == (0, 1)
 @test Base.alignment(IOContext(IOBuffer(), :color=>false), ColoredLetter()) == (0, 1)
 
+# spacing around dots in Diagonal, etc:
+redmiusthree = sprint((io, x) -> printstyled(io, x, color=:red), "-3", context=stdout)
+@test Base.replace_with_centered_mark(redmiusthree) == Base.replace_with_centered_mark("-3")
+
 # `show` implementations for `Method`
 let buf = IOBuffer()
 


### PR DESCRIPTION
Follow-up to https://github.com/JuliaLang/julia/pull/45751

Uses ANSIIterator from https://github.com/JuliaLang/julia/pull/45521 so that the printing of structured matrices isn't thrown off by the presence of invisible colour codes. 