### PR TITLE
CircleCI caching: allow ftime to be ceil(ftime_req) in Base.stale_cachefile

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2260,9 +2260,11 @@ end
                 ftime = mtime(f)
                 is_stale = ( ftime != ftime_req ) &&
                            ( ftime != floor(ftime_req) ) &&           # Issue #13606, PR #13613: compensate for Docker images rounding mtimes
+                           ( ftime != ceil(ftime_req) ) &&            # Compensate for CirceCI's truncating of timestamps in its caching https://circleci.com/docs/caching/
                            ( ftime != trunc(ftime_req, digits=6) ) && # Issue #20837, PR #20840: compensate for GlusterFS truncating mtimes to microseconds
                            ( ftime != 1.0 )  &&                       # PR #43090: provide compatibility with Nix mtime.
                            !( 0 < (ftime_req - ftime) < 1e-6 )        # PR #45552: Compensate for Windows tar giving mtimes that may be incorrect by up to one microsecond
+
                 if is_stale
                     @debug "Rejecting stale cache file $cachefile (mtime $ftime_req) because file $f (mtime $ftime) has changed"
                     return true

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2260,11 +2260,10 @@ end
                 ftime = mtime(f)
                 is_stale = ( ftime != ftime_req ) &&
                            ( ftime != floor(ftime_req) ) &&           # Issue #13606, PR #13613: compensate for Docker images rounding mtimes
-                           ( ftime != ceil(ftime_req) ) &&            # Compensate for CirceCI's truncating of timestamps in its caching https://circleci.com/docs/caching/
+                           ( ftime != ceil(ftime_req) ) &&            # PR: #47433 Compensate for CirceCI's truncating of timestamps in its caching
                            ( ftime != trunc(ftime_req, digits=6) ) && # Issue #20837, PR #20840: compensate for GlusterFS truncating mtimes to microseconds
                            ( ftime != 1.0 )  &&                       # PR #43090: provide compatibility with Nix mtime.
                            !( 0 < (ftime_req - ftime) < 1e-6 )        # PR #45552: Compensate for Windows tar giving mtimes that may be incorrect by up to one microsecond
-
                 if is_stale
                     @debug "Rejecting stale cache file $cachefile (mtime $ftime_req) because file $f (mtime $ftime) has changed"
                     return true


### PR DESCRIPTION
It appears that [caching functionalities](https://circleci.com/docs/caching/) provided by CircleCi (a leading CI/CD provider) can truncate timestamps to full seconds, resulting in re-compilations as below:
```
┌ Debug: Rejecting stale cache file /root/.julia/compiled/v1.8/ComponentArrays/cYHSD_3rQji.ji (mtime 1.6673960929277816e9) because file /root/.julia/packages/ComponentArrays/YyD7i/src/ComponentArrays.jl (mtime 1.667396093e9) has changed
└ @ Base loading.jl:2152
```

This PR relaxes the `is_stale` check to be robust against truncating-to-seconds timestamp mutations.

I can provide a minimal CircleCI configuration file to reproduce if this is helpful.