### PR TITLE
add `get_bool_env` for parsing bool-like env vars

### DIFF
--- a/base/env.jl
+++ b/base/env.jl
@@ -98,10 +98,10 @@ See also: [`withenv`](@ref), [`addenv`](@ref).
 const ENV = EnvDict()
 
 """
-    Base.get_bool_env(name::String, default::Bool = false)::Bool
+    Base.get_bool_env(name::String, default::Bool = false)::Union{Bool,Nothing}
 
-Evaluate whether the value of environnment variable `name` is truthy or falsy,
-and error if none are recognized. If the variable is not set, or is set to "",
+Evaluate whether the value of environnment variable `name` is a truthy or falsy string,
+and return `nothing` if it is not recognized as either. If the variable is not set, or is set to "",
 return `default`.
 
 Recognized values are:
@@ -120,12 +120,7 @@ function get_bool_env(name::String, default::Bool = false)
     elseif val in falsy
         return false
     else
-        error("""
-        Failed to parse the value `$val` of environment variable `$name` as Boolean.
-        Recognized values are:
-            truthy: $(join(repr.(truthy), ", "))
-            falsy:  $(join(repr.(falsy), ", "))
-        """)
+        return nothing
     end
 end
 

--- a/base/env.jl
+++ b/base/env.jl
@@ -97,6 +97,38 @@ See also: [`withenv`](@ref), [`addenv`](@ref).
 """
 const ENV = EnvDict()
 
+"""
+    Base.get_bool_env(name::String, default::Bool = false)::Bool
+
+Evaluate whether the value of environnment variable `name` is truthy or falsy,
+and error if none are recognized. If the variable is not set, or is set to "",
+return `default`.
+
+Recognized values are:
+    truthy: "t", "true", "y", "yes", "1"
+    falsy:  "f", "false", "n", "no", "0"
+"""
+function get_bool_env(name::String, default::Bool = false)
+    haskey(ENV, name) || return default
+    val = lowercase(get(ENV, name, ""))
+    truthy = ("t", "true", "y", "yes", "1")
+    falsy = ("f", "false", "n", "no", "0")
+    if isempty(val)
+        return default
+    elseif val in truthy
+        return true
+    elseif val in falsy
+        return false
+    else
+        error("""
+        Failed to parse the value `$val` of environment variable `$name` as Boolean.
+        Recognized values are:
+            truthy: $(join(repr.(truthy), ", "))
+            falsy:  $(join(repr.(falsy), ", "))
+        """)
+    end
+end
+
 getindex(::EnvDict, k::AbstractString) = access_env(k->throw(KeyError(k)), k)
 get(::EnvDict, k::AbstractString, def) = access_env(Returns(def), k)
 get(f::Callable, ::EnvDict, k::AbstractString) = access_env(k->f(), k)

--- a/base/env.jl
+++ b/base/env.jl
@@ -97,6 +97,19 @@ See also: [`withenv`](@ref), [`addenv`](@ref).
 """
 const ENV = EnvDict()
 
+const get_bool_env_truthy = (
+    "t", "T",
+    "true", "True", "TRUE",
+    "y", "Y",
+    "yes", "Yes", "YES",
+    "1")
+const get_bool_env_falsy = (
+    "f", "F",
+    "false", "False", "FALSE",
+    "n", "N",
+    "no", "No", "NO",
+    "0")
+
 """
     Base.get_bool_env(name::String, default::Bool = false)::Union{Bool,Nothing}
 
@@ -104,20 +117,18 @@ Evaluate whether the value of environnment variable `name` is a truthy or falsy 
 and return `nothing` if it is not recognized as either. If the variable is not set, or is set to "",
 return `default`.
 
-Recognized values are:
+Recognized values are the following, and their Capitalized and UPPERCASE forms:
     truthy: "t", "true", "y", "yes", "1"
     falsy:  "f", "false", "n", "no", "0"
 """
 function get_bool_env(name::String, default::Bool = false)
     haskey(ENV, name) || return default
-    val = lowercase(get(ENV, name, ""))
-    truthy = ("t", "true", "y", "yes", "1")
-    falsy = ("f", "false", "n", "no", "0")
+    val = ENV[name]
     if isempty(val)
         return default
-    elseif val in truthy
+    elseif val in get_bool_env_truthy
         return true
-    elseif val in falsy
+    elseif val in get_bool_env_falsy
         return false
     else
         return nothing

--- a/test/env.jl
+++ b/test/env.jl
@@ -125,7 +125,7 @@ end
 @testset "get_bool_env" begin
     @testset "truthy" begin
         for v in ("t", "true", "y", "yes", "1")
-            for _v in (v, uppercase(v))
+            for _v in (v, uppercasefirst(v), uppercase(v))
                 ENV["testing_gbe"] = _v
                 @test Base.get_bool_env("testing_gbe") == true
                 @test Base.get_bool_env("testing_gbe", false) == true
@@ -135,7 +135,7 @@ end
     end
     @testset "falsy" begin
         for v in ("f", "false", "n", "no", "0")
-            for _v in (v, uppercase(v))
+            for _v in (v, uppercasefirst(v), uppercase(v))
                 ENV["testing_gbe"] = _v
                 @test Base.get_bool_env("testing_gbe") == false
                 @test Base.get_bool_env("testing_gbe", true) == false
@@ -159,9 +159,9 @@ end
     @testset "unrecognized" begin
         for v in ("truw", "falls")
             ENV["testing_gbe"] = v
-            @test_throws ErrorException Base.get_bool_env("testing_gbe")
-            @test_throws ErrorException Base.get_bool_env("testing_gbe", true)
-            @test_throws ErrorException Base.get_bool_env("testing_gbe", false)
+            @test Base.get_bool_env("testing_gbe") === nothing
+            @test Base.get_bool_env("testing_gbe", true) === nothing
+            @test Base.get_bool_env("testing_gbe", false) === nothing
         end
     end
     delete!(ENV, "testing_gbe")

--- a/test/env.jl
+++ b/test/env.jl
@@ -122,6 +122,52 @@ if Sys.iswindows()
     end
 end
 
+@testset "get_bool_env" begin
+    @testset "truthy" begin
+        for v in ("t", "true", "y", "yes", "1")
+            for _v in (v, uppercase(v))
+                ENV["testing_gbe"] = _v
+                @test Base.get_bool_env("testing_gbe") == true
+                @test Base.get_bool_env("testing_gbe", false) == true
+                @test Base.get_bool_env("testing_gbe", true) == true
+            end
+        end
+    end
+    @testset "falsy" begin
+        for v in ("f", "false", "n", "no", "0")
+            for _v in (v, uppercase(v))
+                ENV["testing_gbe"] = _v
+                @test Base.get_bool_env("testing_gbe") == false
+                @test Base.get_bool_env("testing_gbe", true) == false
+                @test Base.get_bool_env("testing_gbe", false) == false
+            end
+        end
+    end
+    @testset "empty" begin
+        ENV["testing_gbe"] = ""
+        @test Base.get_bool_env("testing_gbe") == false
+        @test Base.get_bool_env("testing_gbe", true) == true
+        @test Base.get_bool_env("testing_gbe", false) == false
+    end
+    @testset "undefined" begin
+        delete!(ENV, "testing_gbe")
+        @test !haskey(ENV, "testing_gbe")
+        @test Base.get_bool_env("testing_gbe") == false
+        @test Base.get_bool_env("testing_gbe", true) == true
+        @test Base.get_bool_env("testing_gbe", false) == false
+    end
+    @testset "unrecognized" begin
+        for v in ("truw", "falls")
+            ENV["testing_gbe"] = v
+            @test_throws ErrorException Base.get_bool_env("testing_gbe")
+            @test_throws ErrorException Base.get_bool_env("testing_gbe", true)
+            @test_throws ErrorException Base.get_bool_env("testing_gbe", false)
+        end
+    end
+    delete!(ENV, "testing_gbe")
+    @test !haskey(ENV, "testing_gbe")
+end
+
 # Restore the original environment
 for k in keys(ENV)
     if !haskey(original_env, k)


### PR DESCRIPTION
Expands and brings @giordano's `get_bool_env` over from [Pkg](https://github.com/JuliaLang/Pkg.jl/pull/2858).

For another PR: Use where appropriate in Base & stdlibs