### PR TITLE
use `Base.return_types` instead of `Core.Compiler.return_type`

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1398,7 +1398,7 @@ function return_types(@nospecialize(f), @nospecialize(types=default_tt(f));
     if isa(f, Core.Builtin)
         argtypes = Any[to_tuple_type(types).parameters...]
         rt = Core.Compiler.builtin_tfunction(interp, f, argtypes, nothing)
-        return Any[rt]
+        return Any[Core.Compiler.widenconst(rt)]
     end
     rts = []
     for match in _methods(f, types, -1, world)::Vector


### PR DESCRIPTION
in the "inference" test suite, since the behavior of the latter is
pretty much undefined and usually we want to use the former for testing
the precision of type inference.

Also fixes up the implementation of `Base.return_types` so that it
doesn't miss to call `widenconst` when inferring a builtin call.