### PR TITLE
small update to the docs about ENV

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -18,7 +18,7 @@ the functions [`trues`](@ref) and [`falses`](@ref).
 
 !!! note
     Due to its packed storage format, concurrent access to the elements of a `BitArray`
-    where at least one of them is a write is not thread safe.
+    where at least one of them is a write is not thread-safe.
 
 """
 mutable struct BitArray{N} <: AbstractArray{Bool, N}

--- a/base/env.jl
+++ b/base/env.jl
@@ -74,11 +74,18 @@ all keys to uppercase for display, iteration, and copying. Portable code should 
 ability to distinguish variables by case, and should beware that setting an ostensibly lowercase
 variable may result in an uppercase `ENV` key.)
 
-If you want to create your own `ENV` variable, you can do so by specifying its name in quotation marks as
-is shown below:
+    !!! warning
+    Mutating the environment is not thread-safe.
 
 # Examples
-```jldoctest ENV
+```julia-repl
+julia> ENV
+Base.EnvDict with "50" entries:
+  "SECURITYSESSIONID"            => "123"
+  "USER"                         => "username"
+  "MallocNanoZone"               => "0"
+  ⋮                              => ⋮
+
 julia> ENV["JULIA_EDITOR"] = "vim"
 "vim"
 
@@ -86,15 +93,7 @@ julia> ENV["JULIA_EDITOR"]
 "vim"
 ```
 
-To see all of your active `ENV` variables in your current environment, you can simply do the following:
-```julia
-julia> ENV
-Base.EnvDict with "N" entries:
-  "SECURITYSESSIONID"            => "123"
-  "USER"                         => "username"
-  "MallocNanoZone"               => "0"
-  ⋮                              => ⋮
-```
+See also: [`withenv`](@ref), [`addenv`](@ref).
 """
 const ENV = EnvDict()
 
@@ -184,6 +183,10 @@ by zero or more `"var"=>val` arguments `kv`. `withenv` is generally used via the
 `withenv(kv...) do ... end` syntax. A value of `nothing` can be used to temporarily unset an
 environment variable (if it is set). When `withenv` returns, the original environment has
 been restored.
+
+    !!! warning
+    Changing the environment is not thread-safe. For running external commands with a different
+    environment than the parent process, prefer using [`addenv`](@ref) over `withenv`.
 """
 function withenv(f, keyvals::Pair{T}...) where T<:AbstractString
     old = Dict{T,Any}()

--- a/base/env.jl
+++ b/base/env.jl
@@ -186,7 +186,7 @@ been restored.
 
     !!! warning
     Changing the environment is not thread-safe. For running external commands with a different
-    environment than the parent process, prefer using [`addenv`](@ref) over `withenv`.
+    environment from the parent process, prefer using [`addenv`](@ref) over `withenv`.
 """
 function withenv(f, keyvals::Pair{T}...) where T<:AbstractString
     old = Dict{T,Any}()

--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -300,7 +300,7 @@ ssize_t pwrite_addr(int fd, const void *buf, size_t nbyte, uintptr_t addr)
         // However, it seems possible to change this at kernel compile time.
 
         // pwrite doesn't support offset with sign bit set but lseek does.
-        // This is obviously not thread safe but none of the mem manager does anyway...
+        // This is obviously not thread-safe but none of the mem manager does anyway...
         // From the kernel code, `lseek` with `SEEK_SET` can't fail.
         // However, this can possibly confuse the glibc wrapper to think that
         // we have invalid input value. Use syscall directly to be sure.

--- a/src/threading.c
+++ b/src/threading.c
@@ -254,7 +254,7 @@ static jl_gcframe_t **jl_get_pgcstack_init(void)
     // are used. Since the address of TLS variables should be constant,
     // changing the getter address can result in weird crashes.
 
-    // This is clearly not thread safe but should be fine since we
+    // This is clearly not thread-safe but should be fine since we
     // make sure the tls states callback is finalized before adding
     // multiple threads
 #  if JL_USE_IFUNC


### PR DESCRIPTION
The new docs added in https://github.com/JuliaLang/julia/pull/47384 are a bit too explicit imo ("you can do so by specifying its name in quotation marks as...") and I think we can just do a "show, don't tell" here. Also add a note about thread safety issues with modifying the environment.