### PR TITLE
remove unnecessary inline annotations in ryu

### DIFF
--- a/base/ryu/utils.jl
+++ b/base/ryu/utils.jl
@@ -49,7 +49,7 @@ pow5bits(e) = ((e * 1217359) >> 19) + 1
 
 Compute `(m * mul) >> j`, where `j >= 8*sizeof(U)`. The type of the results is the larger of `U` or `UInt32`.
 """
-@inline function mulshift(m::U, mul, j) where {U<:Unsigned}
+function mulshift(m::U, mul, j) where {U<:Unsigned}
     W = widen(U)
     nbits = 8*sizeof(U)
     return ((((W(m) * (mul % U)) >> nbits) + W(m) * (mul >> nbits)) >> (j - nbits)) % promote_type(U,UInt32)
@@ -64,7 +64,7 @@ lengthforindex(idx) = div(((Int64(16 * idx) * 1292913986) >> 32) + 1 + 16 + 8, 9
 
 Return `true` if `5^p` is a divisor of `x`.
 """
-@inline function pow5(x, p)
+function pow5(x, p)
     x % (5^p) == 0
 end
 
@@ -80,7 +80,7 @@ pow2(x, p) = (x & ((Int64(1) << p) - 1)) == 0
 
 The number of decimal digits of the integer `v`.
 """
-@inline function decimallength(v)
+function decimallength(v)
     v >= 10000000000000000 && return 17
     v >= 1000000000000000 && return 16
     v >= 100000000000000 && return 15
@@ -99,7 +99,7 @@ The number of decimal digits of the integer `v`.
     v >= 10 && return 2
     return 1
 end
-@inline function decimallength(v::UInt32)
+function decimallength(v::UInt32)
     v >= 100000000 && return 9
     v >= 10000000 && return 8
     v >= 1000000 && return 7
@@ -110,7 +110,7 @@ end
     v >= 10 && return 2
     return 1
 end
-@inline function decimallength(v::UInt16)
+function decimallength(v::UInt16)
     v >= 10000 && return 5
     v >= 1000 && return 4
     v >= 100 && return 3
@@ -118,7 +118,7 @@ end
     return 1
 end
 
-@inline function mulshiftinvsplit(::Type{T}, mv, mp, mm, i, j) where {T}
+function mulshiftinvsplit(::Type{T}, mv, mp, mm, i, j) where {T}
     mul = pow5invsplit_lookup(T, i)
     vr = mulshift(mv, mul, j)
     vp = mulshift(mp, mul, j)
@@ -126,7 +126,7 @@ end
     return vr, vp, vm
 end
 
-@inline function mulshiftsplit(::Type{T}, mv, mp, mm, i, j) where {T}
+function mulshiftsplit(::Type{T}, mv, mp, mm, i, j) where {T}
     mul = pow5split_lookup(T, i)
     vr = mulshift(mv, mul, j)
     vp = mulshift(mp, mul, j)
@@ -139,7 +139,7 @@ end
 
 Compute `p = a*b` where `b = bLo + bHi<<64`, returning the result as `pLo, pHi` where `p = pLo + pHi<<128`.
 """
-@inline function umul256(a, bHi, bLo)
+function umul256(a, bHi, bLo)
     aLo = a % UInt64
     aHi = (a >> 64) % UInt64
 
@@ -169,14 +169,14 @@ end
 
 Compute `pHi = (a*b)>>128` where `b = bLo + bHi<<64`.
 """
-@inline umul256_hi(a, bHi, bLo) = umul256(a, bHi, bLo)[2]
+umul256_hi(a, bHi, bLo) = umul256(a, bHi, bLo)[2]
 
 """
     Ryu.mulshiftmod1e9(m, mula, mulb, mulc, j)::UInt32
 
 Compute `(m * mul) >> j % 10^9` where `mul = mula + mulb<<64 + mulc<<128`, and `j >= 128`.
 """
-@inline function mulshiftmod1e9(m, mula, mulb, mulc, j)
+function mulshiftmod1e9(m, mula, mulb, mulc, j)
     b0 = UInt128(m) * mula
     b1 = UInt128(m) * mulb
     b2 = UInt128(m) * mulc
@@ -188,7 +188,7 @@ Compute `(m * mul) >> j % 10^9` where `mul = mula + mulb<<64 + mulc<<128`, and `
     return (v % UInt32) - UInt32(1000000000) * shifted
 end
 
-@inline function append_sign(x, plus, space, buf, pos)
+function append_sign(x, plus, space, buf, pos)
     if signbit(x) && !isnan(x)  # suppress minus sign for signaling NaNs
         buf[pos] = UInt8('-')
         pos += 1
@@ -202,7 +202,7 @@ end
     return pos
 end
 
-@inline function append_n_digits(olength, digits, buf, pos)
+function append_n_digits(olength, digits, buf, pos)
     i = 0
     while digits >= 10000
         c = digits % 10000
@@ -230,7 +230,7 @@ end
     return pos + i
 end
 
-@inline function append_d_digits(olength, digits, buf, pos, decchar)
+function append_d_digits(olength, digits, buf, pos, decchar)
     i = 0
     while digits >= 10000
         c = digits % 10000
@@ -261,7 +261,7 @@ end
     return pos + i
 end
 
-@inline function append_c_digits(count, digits, buf, pos)
+function append_c_digits(count, digits, buf, pos)
     i = 0
     while i < count - 1
         c = (digits % 100) << 1
@@ -276,7 +276,7 @@ end
     return pos + i
 end
 
-@inline function append_nine_digits(digits, buf, pos)
+function append_nine_digits(digits, buf, pos)
     if digits == 0
         for _ = 1:9
             buf[pos] = UInt8('0')


### PR DESCRIPTION
I used th following benchmarks to decide that these `@inline` annotations are not helpful.
```julia
for T in (Float16, Float32, Float64), x in T[0, 17.3, T(π), floatmin(T), floatmax(T), typemax(T)]
    println(x)
    @btime string($x)
end

0.0
  49.887 ns (2 allocations: 104 bytes) => 48.581 ns (2 allocations: 104 bytes)
17.3
  93.893 ns (2 allocations: 104 bytes) => 94.695 ns (2 allocations: 104 bytes)
3.14
  94.357 ns (2 allocations: 104 bytes) => 95.120 ns (2 allocations: 104 bytes)
6.104e-5
  89.451 ns (2 allocations: 104 bytes) => 89.563 ns (2 allocations: 104 bytes)
6.55e4
  91.047 ns (2 allocations: 104 bytes) => 92.273 ns (2 allocations: 104 bytes)
Inf
  50.038 ns (2 allocations: 104 bytes) => 50.441 ns (2 allocations: 104 bytes)
0.0
  48.149 ns (2 allocations: 136 bytes) => 47.519 ns (2 allocations: 136 bytes)
17.3
  100.287 ns (2 allocations: 136 bytes) => 99.606 ns (2 allocations: 136 bytes)
3.1415927
  90.511 ns (2 allocations: 136 bytes) => 88.517 ns (2 allocations: 136 bytes)
1.1754944e-38
  84.935 ns (2 allocations: 136 bytes) => 84.355 ns (2 allocations: 136 bytes)
3.4028235e38
  85.075 ns (2 allocations: 136 bytes) => 82.979 ns (2 allocations: 136 bytes)
Inf
  48.673 ns (2 allocations: 136 bytes) => 47.587 ns (2 allocations: 136 bytes)
0.0
  60.720 ns (2 allocations: 432 bytes) => 59.582 ns (2 allocations: 432 bytes)
17.3
  110.734 ns (2 allocations: 432 bytes) => 110.788 ns (2 allocations: 432 bytes)
3.141592653589793
  96.990 ns (2 allocations: 432 bytes) => 95.462 ns (2 allocations: 432 bytes)
2.2250738585072014e-308
  88.259 ns (2 allocations: 432 bytes) => 90.646 ns (2 allocations: 432 bytes)
1.7976931348623157e308
  90.150 ns (2 allocations: 432 bytes) => 90.026 ns (2 allocations: 432 bytes)
Inf
  60.327 ns (2 allocations: 432 bytes) => 60.278 ns (2 allocations: 432 bytes)
```