### PR TITLE
precise and correct documentation on generators

### DIFF
--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -410,22 +410,36 @@ julia> sum(1/n^2 for n=1:1000)
 1.6439345666815615
 ```
 
-When writing a generator expression with multiple dimensions inside an argument list, parentheses
-are needed to separate the generator from subsequent arguments:
-
-```julia-repl
-julia> map(tuple, 1/(i+j) for i=1:2, j=1:2, [1:4;])
-ERROR: syntax: invalid iteration specification
-```
-
-All comma-separated expressions after `for` are interpreted as ranges. Adding parentheses lets
-us add a third argument to [`map`](@ref):
+When writing a generator expression in an argument list, parentheses can be omitted, provided the
+generator is the last argument:
 
 ```jldoctest
-julia> map(tuple, (1/(i+j) for i=1:2, j=1:2), [1 3; 2 4])
-2×2 Matrix{Tuple{Float64, Int64}}:
- (0.5, 1)       (0.333333, 3)
- (0.333333, 2)  (0.25, 4)
+julia> map(Tuple, i for i=1:2)
+4-element Vector{Tuple{Int64}}:
+ (1,)
+ (2,)
+
+julia> map(Tuple, (i,j) for i=1:2 for j=3:4) # result is always a 1D array with multiple `for` keywords
+4-element Vector{Tuple{Int64, Int64}}:
+ (1, 3)
+ (1, 4)
+ (2, 3)
+ (2, 4)
+
+julia> map(Tuple, (i,j) for i=1:2, j=3:4)
+2×2 Matrix{Tuple{Int64, Int64}}:
+ (1, 3)  (1, 4)
+ (2, 3)  (2, 4)
+```
+
+If the generator is not the last in the argument list, then parentheses must be used to seperate it from
+subsequent arguments:
+
+```jldoctest
+julia> map(tuple, (i for i=1:2), 3:4)
+2-element Vector{Tuple{Int64, Int64}}:
+ (1, 3)
+ (2, 4)
 ```
 
 Generators are implemented via inner functions. Just like

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -414,28 +414,39 @@ When writing a generator expression in an argument list, parentheses can be omit
 generator is the last argument:
 
 ```jldoctest
-julia> map(join, (i,j) for i=1:2, j=3:4)
-2×2 Matrix{String}:
- "13"  "14"
- "23"  "24"
+julia> map(Tuple, i for i=1:4)
+4-element Vector{Tuple{Int64}}:
+ (1,)
+ (2,)
+ (3,)
+ (4,)
 
-julia> map(+, 1:2, i for i=3:4)
-2-element Vector{Int64}:
- 4
- 6
+julia> map(Tuple, (i,j) for i=1:2, j=3:4)
+2×2 Matrix{Tuple{Int64, Int64}}:
+ (1, 3)  (1, 4)
+ (2, 3)  (2, 4)
+
+julia> map(tuple, 1:4, i for i=5:8)
+4-element Vector{Tuple{Int64, Int64}}:
+ (1, 5)
+ (2, 6)
+ (3, 7)
+ (4, 8)
 ```
 
 If the generator is not the last in the argument list, then parentheses must be used to seperate it from
 subsequent arguments:
 
 ```jldoctest
-julia> map(+, i for i=3:4, 1:2)
+julia> map(tuple, i for i=1:4, 5:8)
 ERROR: syntax: invalid iteration specification
 
-julia> map(+, (i for i=3:4), 1:2)
-2-element Vector{Int64}:
- 4
- 6
+julia> map(tuple, (i for i=1:4), 5:8)
+4-element Vector{Tuple{Int64, Int64}}:
+ (1, 5)
+ (2, 6)
+ (3, 7)
+ (4, 8)
 ```
 
 Generators are implemented via inner functions. Just like

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -414,32 +414,28 @@ When writing a generator expression in an argument list, parentheses can be omit
 generator is the last argument:
 
 ```jldoctest
-julia> map(Tuple, i for i=1:2)
-4-element Vector{Tuple{Int64}}:
- (1,)
- (2,)
+julia> map(join, (i,j) for i=1:2, j=3:4)
+2×2 Matrix{String}:
+ "13"  "14"
+ "23"  "24"
 
-julia> map(Tuple, (i,j) for i=1:2 for j=3:4) # result is always a 1D array with multiple `for` keywords
-4-element Vector{Tuple{Int64, Int64}}:
- (1, 3)
- (1, 4)
- (2, 3)
- (2, 4)
-
-julia> map(Tuple, (i,j) for i=1:2, j=3:4)
-2×2 Matrix{Tuple{Int64, Int64}}:
- (1, 3)  (1, 4)
- (2, 3)  (2, 4)
+julia> map(+, 1:2, i for i=3:4)
+2-element Vector{Int64}:
+ 4
+ 6
 ```
 
 If the generator is not the last in the argument list, then parentheses must be used to seperate it from
 subsequent arguments:
 
 ```jldoctest
-julia> map(tuple, (i for i=1:2), 3:4)
-2-element Vector{Tuple{Int64, Int64}}:
- (1, 3)
- (2, 4)
+julia> map(+, i for i=3:4, 1:2)
+ERROR: syntax: invalid iteration specification
+
+julia> map(+, (i for i=3:4), 1:2)
+2-element Vector{Int64}:
+ 4
+ 6
 ```
 
 Generators are implemented via inner functions. Just like


### PR DESCRIPTION
This part of the docs: [Generator Expressions](https://docs.julialang.org/en/v1/manual/arrays/#Generator-Expressions) is not precise and confusing for some number of reasons.

This is the part I'm talking about:
> When writing a generator expression with multiple dimensions inside an argument list, parentheses are needed to separate the generator from subsequent arguments:
```julia
julia> map(tuple, 1/(i+j) for i=1:2, j=1:2, [1:4;])
ERROR: syntax: invalid iteration specification
```

> All comma-separated expressions after for are interpreted as ranges. Adding parentheses lets us add a third argument to [map](https://docs.julialang.org/en/v1/base/collections/#Base.map):
```julia
julia> map(tuple, (1/(i+j) for i=1:2, j=1:2), [1 3; 2 4])
2×2 Matrix{Tuple{Float64, Int64}}:
 (0.5, 1)       (0.333333, 3)
 (0.333333, 2)  (0.25, 4)
```

The word **"multiple dimensions"** is misleading. We're under a section of the docs where **"dimension"** is strongly thought of as "dimension in an array", saying multiple dimension for a generator is **VERY** confusing and provides no benefit, but instead confusion.

Now let's assume we're experienced Julia users and know it means **"multiple `for` loops"**, so is:
```Julia
((i, j) for i=1:10, j=11:20)
```
also a **"multiple dimension"** of a generator? If it will be subjective, why then introduce a word/term that has no value for a subject, and to worsen the case it brings confusion?

>  When writing a generator expression with multiple dimensions inside an argument list, parentheses are needed to separate the generator from subsequent arguments

This again is misleading, because it only talks about the so-called **"multiple dimensions"** when it is used with other arguments. So, IMO, the docs is not general on that, which it should be. That is, I can use generators with multiple loops without a parentheses provided its not the last argument as I pointed in the change I made.

I don't know if I've stated my argument very well (English is not my first language), but my point is the whole concept should be generalised instead of treating corner cases only. So as I made in the change:
- generators can be without parentheses provided they're the last argument. This is regardless of the fact that they may be the so-called **"multiple dimensions"**.
- a generator must be enclosed in parentheses if its not the last argument.

Moreover, the current examples is a bit too dirty to the eyes. If we're talking about generators, then provide a simple `map` expression with generators.

