### PR TITLE
JuliennedArrays.jl Compatibility

### DIFF
--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -72,9 +72,11 @@ end
 @inline function _eachslice(A::AbstractArray, dim::Integer, drop::Bool)
     _eachslice(A, (dim,), drop)
 end
+Slices(A::AbstractArray, args...) = _eachslice(A, args, true)
 
 """
     eachslice(A::AbstractArray; dims, drop=true)
+    eachslice(A::AbstractArray, dims; drop=true)
 
 Create a [`Slices`](@ref) object that is an array of slices over dimensions `dims` of `A`, returning
 views that select all the data from the other dimensions in `A`. `dims` can either by an
@@ -85,7 +87,7 @@ the ordering of the dimensions will match those in `dims`. If `drop = false`, th
 `Slices` will have the same dimensionality as the underlying array, with inner
 dimensions having size 1.
 
-See [`stack`](@ref)`(slices; dims)` for the inverse of `eachcol(A; dims::Integer, drop=true)`.
+See [`stack`](@ref)`(slices; dims)` for the inverse of `eachslice(A; dims::Integer)`.
 
 See also [`eachrow`](@ref), [`eachcol`](@ref), [`mapslices`](@ref) and [`selectdim`](@ref).
 
@@ -126,6 +128,7 @@ julia> eachslice(m, dims=1, drop=false)
 @inline function eachslice(A; dims, drop=true)
     _eachslice(A, dims, drop)
 end
+@inline eachslice(A, dims; drop=true) = _eachslice(A, dims, drop)
 
 """
     eachrow(A::AbstractVecOrMat) <: AbstractVector

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -72,8 +72,8 @@ end
 @inline function _eachslice(A::AbstractArray, dim::Integer, drop::Bool)
     _eachslice(A, (dim,), drop)
 end
-Slices(A::AbstractArray, args...) = _eachslice(A, args, true)
-Slices(A::AbstractArray, args) = _eachslice(A, args, true)
+Slices(A::AbstractArray, dims...) = eachslice(A; dims)
+Slices(A::AbstractArray, dims) = eachslice(A; dims)
 
 """
     eachslice(A::AbstractArray; dims, drop=true)
@@ -96,7 +96,8 @@ See also [`eachrow`](@ref), [`eachcol`](@ref), [`mapslices`](@ref) and [`selectd
      This function requires at least Julia 1.1.
 
 !!! compat "Julia 1.9"
-     Prior to Julia 1.9, this returned an iterator, and only a single dimension `dims` was supported.
+    Prior to Julia 1.9, this returned an iterator, and only a single dimension `dims` was supported.
+    Prior to Julia 1.9, this function did not accept `dims` as a positional argument.
 
 # Example
 
@@ -129,8 +130,8 @@ julia> eachslice(m, dims=1, drop=false)
 @inline function eachslice(A; dims, drop=true)
     _eachslice(A, dims, drop)
 end
-@inline eachslice(A, dims; drop=true) = _eachslice(A, dims, drop)
-@inline eachslice(A, dims...; drop=true) = _eachslice(A, dims, drop)
+@inline eachslice(A, dims; drop=true) = eachslice(A; dims, drop)
+@inline eachslice(A, dims...; drop=true) = eachslice(A; dims, drop)
 
 """
     eachrow(A::AbstractVecOrMat) <: AbstractVector

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -73,10 +73,11 @@ end
     _eachslice(A, (dim,), drop)
 end
 Slices(A::AbstractArray, args...) = _eachslice(A, args, true)
+Slices(A::AbstractArray, args) = _eachslice(A, args, true)
 
 """
     eachslice(A::AbstractArray; dims, drop=true)
-    eachslice(A::AbstractArray, dims; drop=true)
+    eachslice(A::AbstractArray, dims...; drop=true)
 
 Create a [`Slices`](@ref) object that is an array of slices over dimensions `dims` of `A`, returning
 views that select all the data from the other dimensions in `A`. `dims` can either by an
@@ -129,6 +130,7 @@ julia> eachslice(m, dims=1, drop=false)
     _eachslice(A, dims, drop)
 end
 @inline eachslice(A, dims; drop=true) = _eachslice(A, dims, drop)
+@inline eachslice(A, dims...; drop=true) = _eachslice(A, dims, drop)
 
 """
     eachrow(A::AbstractVecOrMat) <: AbstractVector

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2293,6 +2293,8 @@ end
         f2(a) = eachslice(a, dims=2)
         @test (@inferred f2(a)) == eachcol(a)
     end
+    @test eachslice(M, (3, 2)) == eachslice(M; dims=(3, 2))
+    @test eachslice(M, (2, 3)) == Slices(M, (2, 3))
 end
 
 ###


### PR DESCRIPTION
Prior to 1.9, JuliennedArrays.jl provided `Slices` functionality; this adds an extra constructor for `Slices` so that old code written using that library will work after 1.9.