### PR TITLE
Add `findextrema` news for #45783

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,6 +81,7 @@ New library functions
   is efficient. ([#43334])
 * New macro `@allocations` which is similar to `@allocated` except reporting the total number of allocations
   rather than the total size of memory allocated. ([#47367])
+* `findextrema(f, itr; [dims])` which computes `findmin(f, itr; [dims]), findmax(f, itr; [dims])` in a single pass. ([#45783])
 
 Library changes
 ---------------


### PR DESCRIPTION
At the request of @KristofferC , the relevant news update. A separate PR is perhaps not ideal, but, given that NEWS.md moves at a different pace than #45783, it seemed to make sense.