### PR TITLE
clear info on docs of vectorised operation

### DIFF
--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -1014,7 +1014,7 @@ Also, *every* binary operator supports a [dot version](@ref man-dot-operators)
 that can be applied to arrays (and combinations of arrays and scalars) in such
 [fused broadcasting operations](@ref man-vectorized), e.g. `z .== sin.(x .* y)`.
 
-Note that comparison operations such as `==`, `<`, etc., operate on whole arrays *lexicographically*,
+Note that comparison operations such as `==`, `<`, etc. operate on whole arrays *lexicographically*,
 giving a single boolean answer:
 
 ```jldoctest

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -1025,7 +1025,7 @@ julia> [1, 2] == [2, 1]
 false
 ```
 
-Use dot operators like `.==`, `.<`, etc., for elementwise comparisons.
+Use dot operators like `.==`, `.<`, etc. for elementwise comparisons.
 
 Also notice the difference between `max.(a,b)`, which [`broadcast`](@ref)s [`max`](@ref)
 elementwise over `a` and `b`, and [`maximum(a)`](@ref), which finds the largest value within

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -1109,6 +1109,42 @@ julia> ([1, 2, 3], [4, 5, 6]) .+ tuple([1, 2, 3])
 ([2, 4, 6], [5, 7, 9])
 ```
 
+
+In all these that have been said, do note that not all operations requires you vectorizing or broadcasting for
+elementwise operations. For some binary operators (e.g `*`, `+`), when used with an array and a scalar, or
+between two arrays, an elementwise operation is *normally* performed. This is important to note because whichever
+style you may choose to use, though the end results will be the same, their execution speeds and allocations may be
+different (depending on the sizes of the arrays).
+
+For example, the `+` operator when used on two arrays of same sizes and dimensions performs elementwise addition,
+just as `.+` would have done:
+
+```jldoctest
+julia> [1, 2] .+ [3, 4]
+2-element Vector{Int64}:
+ 4
+ 6
+
+julia> [1, 2] + [3, 4]
+2-element Vector{Int64}:
+ 4
+ 6
+```
+
+However, calling `@time` on these two operations (performed on a small dataset), we see the difference:
+
+```julia-repl
+julia> a = rand(Float64, 100); b = rand(Float64, 100);
+
+julia> @time a + b;
+  0.000007 seconds (1 allocation: 896 bytes)
+
+julia> @time a .+ b;
+  0.000026 seconds (3 allocations: 960 bytes)
+```
+
+On a large dataset, the time difference may be very small, but the allocations will most likely be different.
+
 ## Implementation
 
 The base array type in Julia is the abstract type [`AbstractArray{T,N}`](@ref). It is parameterized by

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -1014,9 +1014,8 @@ Also, *every* binary operator supports a [dot version](@ref man-dot-operators)
 that can be applied to arrays (and combinations of arrays and scalars) in such
 [fused broadcasting operations](@ref man-vectorized), e.g. `z .== sin.(x .* y)`.
 
-Note that comparisons such as `==` operate on whole arrays, giving a single boolean
-answer. Use dot operators like `.==` for elementwise comparisons. (For comparison
-operations like `<`, *only* the elementwise `.<` version is applicable to arrays.)
+Note that comparison operations such as `==`, `<`, etc., operate on whole arrays, giving a
+single boolean answer. Use dot operators like `.==`, `.<`, etc., for elementwise comparisons.
 
 Also notice the difference between `max.(a,b)`, which [`broadcast`](@ref)s [`max`](@ref)
 elementwise over `a` and `b`, and [`maximum(a)`](@ref), which finds the largest value within

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -1014,8 +1014,18 @@ Also, *every* binary operator supports a [dot version](@ref man-dot-operators)
 that can be applied to arrays (and combinations of arrays and scalars) in such
 [fused broadcasting operations](@ref man-vectorized), e.g. `z .== sin.(x .* y)`.
 
-Note that comparison operations such as `==`, `<`, etc., operate on whole arrays, giving a
-single boolean answer. Use dot operators like `.==`, `.<`, etc., for elementwise comparisons.
+Note that comparison operations such as `==`, `<`, etc., operate on whole arrays *lexicographically*,
+giving a single boolean answer:
+
+```jldoctest
+julia> [1, 2] > [2]
+false
+
+julia> [1, 2] == [2, 1]
+false
+```
+
+Use dot operators like `.==`, `.<`, etc., for elementwise comparisons.
 
 Also notice the difference between `max.(a,b)`, which [`broadcast`](@ref)s [`max`](@ref)
 elementwise over `a` and `b`, and [`maximum(a)`](@ref), which finds the largest value within

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -1109,38 +1109,41 @@ julia> ([1, 2, 3], [4, 5, 6]) .+ tuple([1, 2, 3])
 ([2, 4, 6], [5, 7, 9])
 ```
 
-
-In all these that have been said, do note that not all operations requires you vectorizing or broadcasting for
-elementwise operations. For some binary operators (e.g `*`, `+`), when used with an array and a scalar, or
-between two arrays, an elementwise operation is *normally* performed. This is important to note because whichever
-style you may choose to use, though the end results will be the same, their execution speeds and allocations may be
-different (depending on the sizes of the arrays).
-
-For example, the `+` operator when used on two arrays of same sizes and dimensions performs elementwise addition,
-just as `.+` would have done:
-
-```jldoctest
-julia> [1, 2] .+ [3, 4]
-2-element Vector{Int64}:
- 4
- 6
-
-julia> [1, 2] + [3, 4]
-2-element Vector{Int64}:
- 4
- 6
-```
-
-However, calling `@time` on these two operations (performed on a small dataset), we see the difference:
+It is important to note that not all operations requires you vectorizing or broadcasting for
+elementwise operations; for some binary operators (e.g `*`, `+`), when used with a 1D-array and a scalar,
+or between two 1D-arrays, an elementwise operation is *normally* performed. Though the returned value will
+be the same, their execution speeds and allocations may be different (depending on the sizes of the arrays).
+For example, the `+` operator when used on two 1D arrays of same sizes performs elementwise addition,
+just as `.+` would have done too:
 
 ```julia-repl
-julia> a = rand(Float64, 100); b = rand(Float64, 100);
+julia> a = rand(Int8, 5); b = rand(Int8, 5);
 
+julia> a + b
+5-element Vector{Int8}:
+ -83
+ -72
+ -84
+ -77
+ 121
+
+julia> a .+ b
+5-element Vector{Int8}:
+ -83
+ -72
+ -84
+ -77
+ 121
+```
+
+Using `@time`, we see the difference in the execution time and number of allocations:
+
+```julia-repl
 julia> @time a + b;
-  0.000007 seconds (1 allocation: 896 bytes)
+  0.000005 seconds (1 allocation: 64 bytes)
 
 julia> @time a .+ b;
-  0.000026 seconds (3 allocations: 960 bytes)
+  0.000031 seconds (3 allocations: 128 bytes)
 ```
 
 On a large dataset, the time difference may be very small, but the allocations will most likely be different.


### PR DESCRIPTION
This is very confusing:
> (For comparison operations like `<`, *only* the elementwise `.<` version is applicable to arrays.)

What does **applicable** means here, because the former statement which states that:
> Note that comparisons such as `==` operate on whole arrays, giving a single boolean answer

already clears the ground on this:
```julia
julia> [1, 2] < [2]
true
```

The operator is *applicable* in my view, since it can be called on arrays, however it performs comparison lexicographically, but still it is *applicable*.

Except **applicable** means something different here, I'd think that info is misleading and should be changed.

If anything should be added, maybe it should say: "comparison operators perform comparison lexicograhically on arrays." and then provide an example on it:
```julia
julia> [1, 2] == [2, 1]
false
```

Any which way, IMHO, the current info isn't clear and should be changed.