### PR TITLE
remove special case for homogeneous tuples in `all` and `any`

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -1222,11 +1222,8 @@ function _any(f, itr, ::Colon)
     return anymissing ? missing : false
 end
 
-# Specialized versions of any(f, ::Tuple), avoiding type instabilities for small tuples
-# containing mixed types.
-# We fall back to the for loop implementation all elements have the same type or
-# if the tuple is too large.
-any(f, itr::NTuple) = _any(f, itr, :)  # case of homogeneous tuple
+# Specialized versions of any(f, ::Tuple)
+# We fall back to the for loop implementation if the tuple is too large.
 function any(f, itr::Tuple)            # case of tuple with mixed types
     length(itr) > 32 && return _any(f, itr, :)
     _any_tuple(f, false, itr...)
@@ -1293,9 +1290,8 @@ function _all(f, itr, ::Colon)
     return anymissing ? missing : true
 end
 
-# Specialized versions of all(f, ::Tuple), avoiding type instabilities for small tuples
-# containing mixed types. This is similar to any(f, ::Tuple) defined above.
-all(f, itr::NTuple) = _all(f, itr, :)
+# Specialized versions of all(f, ::Tuple),
+# This is similar to any(f, ::Tuple) defined above.
 function all(f, itr::Tuple)
     length(itr) > 32 && return _all(f, itr, :)
     _all_tuple(f, false, itr...)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -1223,9 +1223,12 @@ function _any(f, itr, ::Colon)
 end
 
 # Specialized versions of any(f, ::Tuple)
-# We fall back to the for loop implementation if the tuple is too large.
-function any(f, itr::Tuple)            # case of tuple with mixed types
-    length(itr) > 32 && return _any(f, itr, :)
+# We fall back to the for loop implementation all elements have the same type or
+# if the tuple is too large.
+function any(f, itr::Tuple)
+    if itr isa NTuple || length(itr) > 32
+        return _any(f, itr, :)
+    end
     _any_tuple(f, false, itr...)
 end
 
@@ -1293,7 +1296,9 @@ end
 # Specialized versions of all(f, ::Tuple),
 # This is similar to any(f, ::Tuple) defined above.
 function all(f, itr::Tuple)
-    length(itr) > 32 && return _all(f, itr, :)
+    if itr isa NTuple || length(itr) > 32
+        return _all(f, itr, :)
+    end
     _all_tuple(f, false, itr...)
 end
 


### PR DESCRIPTION
These were added in https://github.com/JuliaLang/julia/pull/44063 but seem to cause some ambiguities, for example in Nullables.jl:

```
  MethodError: all(::typeof(Nullables.hasvalue), ::Tuple{Nullable{Int64}, Nullable{Int64}}) is ambiguous.
  
  Candidates:
    all(f, itr::Tuple{Vararg{T, N}} where {N, T})
      @ Base reduce.jl:1298
    all(f::typeof(Nullables.hasvalue), t::Tuple)
      @ Nullables ~/.julia/packages/Nullables/RNaHb/src/nullable.jl:371
  
  Possible fix, define
    all(::typeof(Nullables.hasvalue), ::Tuple{Vararg{T, N}} where {N, T})
```

This is a pretty weird overload from Nullables but It's unclear to me if there is any benefit of having homogenous tuples fall back to the loop version.

cc @jipolanco 

