### PR TITLE
signals: when exiting because of a signal, call `raise` instead of `exit`

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -197,10 +197,50 @@ static void jl_close_item_atexit(uv_handle_t *handle)
     }
 }
 
+// This prevents `ct` from returning via error handlers or other unintentional
+// means by destroying some old state before we start destroying that state in atexit hooks.
 void jl_task_frame_noreturn(jl_task_t *ct);
+
+// cause this process to exit with WEXITSTATUS(signo), after waiting to finish all julia, C, and C++ cleanup
+JL_DLLEXPORT void jl_exit(int exitcode)
+{
+    jl_atexit_hook(exitcode);
+    exit(exitcode);
+}
+
+// cause this process to exit with WTERMSIG(signo),
+// fairly aggressively (flushing stderr a bit, and doing a little bit of other
+// external cleanup, but no internal cleanup)
+JL_DLLEXPORT void jl_raise(int signo)
+{
+    uv_tty_reset_mode();
+    fflush(NULL);
+#ifdef _OS_WINDOWS_
+    if (signo == SIGABRT) {
+        signal(signo, SIG_DFL);
+        abort();
+    }
+    // the exit status could also potentially be set to an NTSTATUS value
+    // corresponding to a signal number, but this seems somewhat is uncommon on Windows
+    TerminateProcess(GetCurrentProcess(), 3); // aka _exit
+    abort(); // prior call does not return, because we passed GetCurrentProcess()
+#else
+    signal(signo, SIG_DFL);
+    sigset_t sset;
+    sigemptyset(&sset);
+    sigaddset(&sset, signo);
+    pthread_sigmask(SIG_UNBLOCK, &sset, NULL);
+    raise(signo); // aka pthread_kill(pthread_self(), signo);
+    if (signo == SIGABRT)
+        abort();
+    _exit(128 + signo);
+#endif
+}
 
 JL_DLLEXPORT void jl_atexit_hook(int exitcode)
 {
+    uv_tty_reset_mode();
+
     if (jl_atomic_load_relaxed(&jl_all_tls_states) == NULL)
         return;
 

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -634,13 +634,6 @@ JL_DLLEXPORT void jl_safe_printf(const char *fmt, ...)
     errno = last_errno;
 }
 
-JL_DLLEXPORT void jl_exit(int exitcode)
-{
-    uv_tty_reset_mode();
-    jl_atexit_hook(exitcode);
-    exit(exitcode);
-}
-
 typedef union {
     struct sockaddr in;
     struct sockaddr_in v4;

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -574,7 +574,7 @@ static NOINLINE int true_main(int argc, char *argv[])
             ct->world_age = last_age;
         }
         JL_CATCH {
-            jl_no_exc_handler(jl_current_exception());
+            jl_no_exc_handler(jl_current_exception(), ct);
         }
         return 0;
     }

--- a/src/julia.h
+++ b/src/julia.h
@@ -1753,6 +1753,7 @@ JL_DLLEXPORT int jl_is_initialized(void);
 JL_DLLEXPORT void jl_atexit_hook(int status);
 JL_DLLEXPORT void jl_postoutput_hook(void);
 JL_DLLEXPORT void JL_NORETURN jl_exit(int status);
+JL_DLLEXPORT void JL_NORETURN jl_raise(int signo);
 JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle);
 JL_DLLEXPORT jl_gcframe_t **jl_adopt_thread(void);
 
@@ -1950,7 +1951,7 @@ JL_DLLEXPORT void JL_NORETURN jl_throw(jl_value_t *e JL_MAYBE_UNROOTED);
 JL_DLLEXPORT void JL_NORETURN jl_rethrow(void);
 JL_DLLEXPORT void JL_NORETURN jl_sig_throw(void);
 JL_DLLEXPORT void JL_NORETURN jl_rethrow_other(jl_value_t *e JL_MAYBE_UNROOTED);
-JL_DLLEXPORT void JL_NORETURN jl_no_exc_handler(jl_value_t *e);
+JL_DLLEXPORT void JL_NORETURN jl_no_exc_handler(jl_value_t *e, jl_task_t *ct);
 JL_DLLEXPORT JL_CONST_FUNC jl_gcframe_t **(jl_get_pgcstack)(void) JL_GLOBALLY_ROOTED JL_NOTSAFEPOINT;
 #define jl_current_task (container_of(jl_get_pgcstack(), jl_task_t, gcstack))
 

--- a/src/task.c
+++ b/src/task.c
@@ -320,7 +320,7 @@ void JL_NORETURN jl_finish_task(jl_task_t *t)
             jl_apply(args, 2);
         }
         JL_CATCH {
-            jl_no_exc_handler(jl_current_exception());
+            jl_no_exc_handler(jl_current_exception(), ct);
         }
     }
     jl_gc_debug_critical_error();
@@ -696,7 +696,7 @@ JL_DLLEXPORT void jl_switchto(jl_task_t **pt)
     jl_switch();
 }
 
-JL_DLLEXPORT JL_NORETURN void jl_no_exc_handler(jl_value_t *e)
+JL_DLLEXPORT JL_NORETURN void jl_no_exc_handler(jl_value_t *e, jl_task_t *ct)
 {
     // NULL exception objects are used when rethrowing. we don't have a handler to process
     // the exception stack, so at least report the exception at the top of the stack.
@@ -707,6 +707,8 @@ JL_DLLEXPORT JL_NORETURN void jl_no_exc_handler(jl_value_t *e)
     jl_static_show((JL_STREAM*)STDERR_FILENO, e);
     jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
     jlbacktrace(); // written to STDERR_FILENO
+    if (ct == NULL)
+        jl_raise(6);
     jl_exit(1);
 }
 
@@ -745,7 +747,7 @@ JL_DLLEXPORT JL_NORETURN void jl_no_exc_handler(jl_value_t *e)
         jl_longjmp(eh->eh_ctx, 1);                                             \
     }                                                                          \
     else {                                                                     \
-        jl_no_exc_handler(exception);                                          \
+        jl_no_exc_handler(exception, ct);                                      \
     }                                                                          \
     assert(0);
 
@@ -780,8 +782,8 @@ JL_DLLEXPORT void jl_throw(jl_value_t *e JL_MAYBE_UNROOTED)
         asan_unpoison_task_stack(ct, safe_restore);
         jl_longjmp(*safe_restore, 1);
     }
-    if (ct == NULL) // During startup
-        jl_no_exc_handler(e);
+    if (ct == NULL) // During startup, or on other threads
+        jl_no_exc_handler(e, ct);
     record_backtrace(ct->ptls, 1);
     throw_internal(ct, e);
 }
@@ -1381,9 +1383,9 @@ static char *jl_alloc_fiber(_jl_ucontext_t *t, size_t *ssize, jl_task_t *owner)
     _jl_ucontext_t base_ctx;
     memcpy(&base_ctx, &ptls->base_ctx, sizeof(base_ctx));
     sigfillset(&set);
-    if (sigprocmask(SIG_BLOCK, &set, &oset) != 0) {
+    if (pthread_sigmask(SIG_BLOCK, &set, &oset) != 0) {
        jl_free_stack(stk, *ssize);
-       jl_error("sigprocmask failed");
+       jl_error("pthread_sigmask failed");
     }
     uc_stack.ss_sp = stk;
     uc_stack.ss_size = *ssize;
@@ -1415,9 +1417,9 @@ static char *jl_alloc_fiber(_jl_ucontext_t *t, size_t *ssize, jl_task_t *owner)
        jl_free_stack(stk, *ssize);
        jl_error("sigaltstack failed");
     }
-    if (sigprocmask(SIG_SETMASK, &oset, NULL) != 0) {
+    if (pthread_sigmask(SIG_SETMASK, &oset, NULL) != 0) {
        jl_free_stack(stk, *ssize);
-       jl_error("sigprocmask failed");
+       jl_error("pthread_sigmask failed");
     }
     if (&ptls->base_ctx != t) {
         memcpy(&t, &ptls->base_ctx, sizeof(base_ctx));


### PR DESCRIPTION
* Be careful now to avoid `jl_exit` on foreign threads, which would try to adopt them now
* Call `raise` (with enhancements as `jl_raise`) to exit due to handling a signal, which sets WTERMSIG instead of emulating it with WEXITSTATUS, and triggers the SIG_DFL behaviors (which may include a coredump, for SIGQUIT / `Ctrl-\`).
* Use pthread_sigmask in preference to sigprocmask, since it is better specified, though probably usually identical.

This mainly affects the fatal signals (SIGQUIT and SIGTERM), which will now exit with those signals and run the default kernel handlers for those:
```
julia> run(`./old/julia -e 'ccall(:kill, Cint, (Clong, Cint,), getpid(), 3)' `)
ERROR: failed process: Process(`../julia/julia -e 'ccall(:kill, Cint, (Clong, Cint,), getpid(), 3)'`, ProcessExited(131)) [131]

julia> run(`./new/julia -e 'ccall(:kill, Cint, (Clong, Cint,), getpid(), 3)' `)
ERROR: failed process: Process(`./julia -e 'ccall(:kill, Cint, (Clong, Cint,), getpid(), 3)'`, ProcessSignaled(3)) [0]

$ lldb -c /cores/core.5503
(lldb) bt
* thread #1
  * frame #0: 0x00007ff80161d00e libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x00007ff8016531ff libsystem_pthread.dylib`pthread_kill + 263
    frame #2: 0x00007ff8015612d8 libsystem_c.dylib`raise + 26
    frame #3: 0x0000000104661b00 libjulia-internal.1.9.dylib`jl_raise(signo=3) at init.c:223:5 [opt]
    frame #4: 0x00000001046b235d libjulia-internal.1.9.dylib`jl_exit_thread0_cb(signo=3) at signals-mach.c:458:5 [opt]
```