### PR TITLE
atinit function

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -123,6 +123,9 @@ function __init__()
     nothing
 end
 ```
+
+# See also
+- [`@atinit`](@ref) and [`Base.atinit`](@ref) for defining multiple initializers.
 """
 kw"__init__"
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -812,6 +812,7 @@ export
     precompile,
 
 # misc
+    @atinit,
     atexit,
     atreplinit,
     exit,

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -378,6 +378,26 @@ function _atexit()
     end
 end
 
+function atinit(m::Module, f::Function)
+    # could be moved to module-default-defs?
+    if !isdefined(m, :__init_hooks__)
+        if isdefined(m, :__init__)
+            error("atinit cannot be used with __init__")
+        end
+        eval(m, :(const __init_hooks__ = $Callable[]))
+        eval(m, :(__init__() = $_atinit($m)))
+    end
+    (push!(m.__init_hooks__, f); nothing)
+end
+function _atinit(m::Module)
+    if isdefined(m, :__init_hooks__)
+        for f in m.__init_hooks__
+            f()
+        end
+    end
+end
+
+
 ## postoutput: register post output hooks ##
 ## like atexit but runs after any requested output.
 ## any hooks saved in the sysimage are cleared in Base._start

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -33,6 +33,8 @@ Base.MainInclude.include
 Base.include_string
 Base.include_dependency
 __init__
+Base.atinit
+Base.@atinit
 Base.which(::Any, ::Any)
 Base.methods
 Base.@show

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -201,7 +201,11 @@
        (= (call include (:: ,mex (top Function)) ,x)
           (block
            ,@loc
-           (call (core _call_latest) (top include) ,mex ,name ,x)))))
+           (call (core _call_latest) (top include) ,mex ,name ,x)))
+       (= (call atinit (:: ,x (top Function)))
+          (block
+           ,@loc
+           (call (core _call_latest) (top atinit) ,name ,x)))))
    'none 0))
 
 ; run whole frontend on a string. useful for testing.

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -201,11 +201,7 @@
        (= (call include (:: ,mex (top Function)) ,x)
           (block
            ,@loc
-           (call (core _call_latest) (top include) ,mex ,name ,x)))
-       (= (call atinit (:: ,x (top Function)))
-          (block
-           ,@loc
-           (call (core _call_latest) (top atinit) ,name ,x)))))
+           (call (core _call_latest) (top include) ,mex ,name ,x)))))
    'none 0))
 
 ; run whole frontend on a string. useful for testing.

--- a/test/core.jl
+++ b/test/core.jl
@@ -1111,7 +1111,9 @@ let didthrow =
             @__MODULE__,
             """
             module TestInitError
-                __init__() = error()
+                atinit() do
+                    error()
+                end
             end
             """)
         false

--- a/test/core.jl
+++ b/test/core.jl
@@ -1104,6 +1104,22 @@ end
 @test Module(:anonymous, false, true).Core == Core
 @test_throws UndefVarError Module(:anonymous, false, false).Core
 
+# atinit FIFO
+include_string(
+    @__MODULE__,
+    """
+    module TestInitFIFO
+        str = ""
+        atinit() do
+            global str = str*"a"
+        end
+        atinit() do
+            global str = str*"b"
+        end
+    end
+    """)
+@test TestInitFIFO.str == "ab"
+
 # exception from __init__()
 let didthrow =
     try

--- a/test/core.jl
+++ b/test/core.jl
@@ -1138,7 +1138,8 @@ let didthrow =
             """)
         false
     catch ex
-        @test isa(ex, ErrorException)
+        @test isa(ex, LoadError)
+        @test isa(ex.error, ErrorException)
         true
     end
     @test didthrow
@@ -1157,7 +1158,8 @@ let didthrow =
             """)
         false
     catch ex
-        @test isa(ex, ErrorException)
+        @test isa(ex, LoadError)
+        @test isa(ex.error, ErrorException)
         true
     end
     @test didthrow

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1329,7 +1329,9 @@ precompile_test_harness("Issues #19030 and #25279") do load_path
     write(joinpath(load_path, "$ModuleA.jl"),
         """
         module $ModuleA
-            __init__() = push!(Base.package_callbacks, sym->nothing)
+            atinit() do
+                push!(Base.package_callbacks, sym->nothing)
+            end
         end
         """)
     l0 = length(Base.package_callbacks)
@@ -1367,7 +1369,7 @@ precompile_test_harness("Issue #26028") do load_path
         module Bar26028
             x = 0
         end
-        function __init__()
+        atinit() do
             include(joinpath(@__DIR__, "Baz26028.jl"))
         end
         end
@@ -1503,11 +1505,13 @@ end
 
 # Test that the cachepath is available in pkgorigins during the
 # __init__ callback
-precompile_test_harness("__init__ cachepath") do load_path
+precompile_test_harness("atinit cachepath") do load_path
     write(joinpath(load_path, "InitCachePath.jl"),
           """
           module InitCachePath
-            __init__() = Base.pkgorigins[Base.PkgId(InitCachePath)]
+            atinit() do
+                Base.pkgorigins[Base.PkgId(InitCachePath)]
+            end
           end
           """)
     @test isa((@eval (using InitCachePath; InitCachePath)), Module)
@@ -1546,7 +1550,9 @@ precompile_test_harness("issue #46296") do load_path
         ci = Core.CodeInstance(mi, Any, nothing, nothing, zero(Int32), typemin(UInt),
                                typemax(UInt), zero(UInt32), zero(UInt32), nothing, 0x00)
 
-        __init__() = @assert ci isa Core.CodeInstance
+        atinit() do
+            @assert ci isa Core.CodeInstance
+        end
 
         end
         """)

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1329,7 +1329,7 @@ precompile_test_harness("Issues #19030 and #25279") do load_path
     write(joinpath(load_path, "$ModuleA.jl"),
         """
         module $ModuleA
-            atinit() do
+            @atinit() do
                 push!(Base.package_callbacks, sym->nothing)
             end
         end
@@ -1369,7 +1369,7 @@ precompile_test_harness("Issue #26028") do load_path
         module Bar26028
             x = 0
         end
-        atinit() do
+        @atinit() do
             include(joinpath(@__DIR__, "Baz26028.jl"))
         end
         end
@@ -1509,7 +1509,7 @@ precompile_test_harness("atinit cachepath") do load_path
     write(joinpath(load_path, "InitCachePath.jl"),
           """
           module InitCachePath
-            atinit() do
+            @atinit() do
                 Base.pkgorigins[Base.PkgId(InitCachePath)]
             end
           end
@@ -1550,7 +1550,7 @@ precompile_test_harness("issue #46296") do load_path
         ci = Core.CodeInstance(mi, Any, nothing, nothing, zero(Int32), typemin(UInt),
                                typemax(UInt), zero(UInt32), zero(UInt32), nothing, 0x00)
 
-        atinit() do
+        @atinit() do
             @assert ci isa Core.CodeInstance
         end
 

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -149,7 +149,7 @@ module TestGeneratedThrow
 
     foo() = (bar(rand() > 0.5 ? 1 : 1.0); error("foo"))
     inited = false
-    function __init__()
+    atinit() do
         code_typed(foo, (); optimize = false)
         @cfunction(foo, Cvoid, ())
         global inited = true

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -149,7 +149,7 @@ module TestGeneratedThrow
 
     foo() = (bar(rand() > 0.5 ? 1 : 1.0); error("foo"))
     inited = false
-    atinit() do
+    @atinit() do
         code_typed(foo, (); optimize = false)
         @cfunction(foo, Cvoid, ())
         global inited = true


### PR DESCRIPTION
Fixes #11098.

This adds a more flexible method for module initialization: instead of 
```julia
module XX
function __init__()
   ...
end
end
```
you can now use
```julia
module XX
atinit() do
   ...
end
end
```

The key advantage is that it can be called multiple times, similar to `atexit` except that the functions are called in FIFO order.

This seemed like the easiest way to implement it, but I'm open to suggestions for better ways to do it.
