### PR TITLE
improve performance of `isapprox(::AbstractArray, ::AbstractArray)` when `rtol = 0`

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1767,7 +1767,7 @@ promote_leaf_eltypes(x::Union{AbstractArray,Tuple}) = mapreduce(promote_leaf_elt
 # Supports nested arrays; e.g., for `a = [[1,2, [3,4]], 5.0, [6im, [7.0, 8.0]]]`
 # `a ≈ a` is `true`.
 function isapprox(x::AbstractArray, y::AbstractArray;
-    atol::Real=zero(promote_type(real(promote_leaf_eltypes(x)),real(promote_leaf_eltypes(y)))),
+    atol::Real=0,
     rtol::Real=Base.rtoldefault(promote_leaf_eltypes(x),promote_leaf_eltypes(y),atol),
     nans::Bool=false, norm::Function=norm)
     d = norm(x - y)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1767,12 +1767,13 @@ promote_leaf_eltypes(x::Union{AbstractArray,Tuple}) = mapreduce(promote_leaf_elt
 # Supports nested arrays; e.g., for `a = [[1,2, [3,4]], 5.0, [6im, [7.0, 8.0]]]`
 # `a ≈ a` is `true`.
 function isapprox(x::AbstractArray, y::AbstractArray;
-    atol::Real=0,
+    atol::Real=zero(promote_type(real(promote_leaf_eltypes(x)),real(promote_leaf_eltypes(y)))),
     rtol::Real=Base.rtoldefault(promote_leaf_eltypes(x),promote_leaf_eltypes(y),atol),
     nans::Bool=false, norm::Function=norm)
     d = norm(x - y)
     if isfinite(d)
-        return d <= max(atol, rtol*max(norm(x), norm(y)))
+        tol = iszero(rtol) ? atol : max(atol, rtol*max(norm(x), norm(y)))
+        return d <= tol
     else
         # Fall back to a component-wise approximate comparison
         # (mapreduce instead of all for greater generality [#44893])

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1772,11 +1772,7 @@ function isapprox(x::AbstractArray, y::AbstractArray;
     nans::Bool=false, norm::Function=norm)
     d = norm(x - y)
     if isfinite(d)
-        T = promote_type(typeof(atol), typeof(rtol*d))
-        rtol = convert(T, rtol)
-        atol = convert(T, atol)
-        tol = iszero(rtol) ? atol : max(atol, rtol*max(norm(x), norm(y)))
-        return d <= tol
+        iszero(rtol) ? d <= atol : d <= max(atol, rtol*max(norm(x), norm(y)))
     else
         # Fall back to a component-wise approximate comparison
         # (mapreduce instead of all for greater generality [#44893])

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1772,6 +1772,9 @@ function isapprox(x::AbstractArray, y::AbstractArray;
     nans::Bool=false, norm::Function=norm)
     d = norm(x - y)
     if isfinite(d)
+        T = promote_type(typeof(atol), typeof(rtol*d))
+        rtol = convert(T, rtol)
+        atol = convert(T, atol)
         tol = iszero(rtol) ? atol : max(atol, rtol*max(norm(x), norm(y)))
         return d <= tol
     else

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1772,7 +1772,7 @@ function isapprox(x::AbstractArray, y::AbstractArray;
     nans::Bool=false, norm::Function=norm)
     d = norm(x - y)
     if isfinite(d)
-        iszero(rtol) ? d <= atol : d <= max(atol, rtol*max(norm(x), norm(y)))
+        return iszero(rtol) ? d <= atol : d <= max(atol, rtol*max(norm(x), norm(y)))
     else
         # Fall back to a component-wise approximate comparison
         # (mapreduce instead of all for greater generality [#44893])


### PR DESCRIPTION
The default value of `rtol` for `isapprox` depends on whether `atol` is zero or not; if `atol` is nonzero, `rtol` is zero (#22742).

The "normal-path" `isapprox(x, y; atol, rtol` check is just `norm(x-y) <= max(atol, rtol*max(norm(x), norm(y)))`. If `rtol = 0`, however, we are then redundantly computing the norm of both `x` and `y`, which can be expensive for arrays (unlike numbers).

This change simply puts a branch in to check `iszero(rtol)`: if so, it avoids computing the norms redundantly. This speeds up `isapprox(X, Y; atol ≠ 0)` considerably:

```jl
julia> A = rand(3, 3)
julia> @btime isapprox($A, $A; atol=1e-11);
  124.592 ns (1 allocation: 128 bytes) # master
julia> @btime isapprox($A, $A; atol=1e-11);
  68.821 ns (1 allocation: 128 bytes) # PR

julia> B = @SMatrix rand(3, 3)
julia> @btime isapprox($B, $B; atol=1e-11);
  14.544 ns (0 allocations: 0 bytes) # master
julia> @btime isapprox($B, $B; atol=1e-11);
  6.900 ns (0 allocations: 0 bytes) # PR
```

The cost of the extra branch is not nothing, of course, but should be negligible in the context of other costs for most array sizes.

---
There's also a small change to the `atol` default value: I noticed that care was being taken to initialize `rtol` to a type consistent with `x` and `y`; I figured the same might as well be done for `atol`.