### PR TITLE
1.8: update SuiteSparse from f63732 to e8285d

### DIFF
--- a/stdlib/SuiteSparse.version
+++ b/stdlib/SuiteSparse.version
@@ -1,4 +1,4 @@
 SUITESPARSE_BRANCH = master
-SUITESPARSE_SHA1 = f63732c1c6adecb277d8f2981cc8c1883c321bcc
+SUITESPARSE_SHA1 = e8285dd13a6d5b5cf52d8124793fc4d622d07554
 SUITESPARSE_GIT_URL := https://github.com/JuliaSparse/SuiteSparse.jl.git
 SUITESPARSE_TAR_URL = https://api.github.com/repos/JuliaSparse/SuiteSparse.jl/tarball/$1


### PR DESCRIPTION
The target branch of this PR is the `backports-release-1.8` branch.