### PR TITLE
Base: add new help function `isdebugbuild`

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -670,7 +670,7 @@ end
 """
     isdebugbuild()
 
-Return `true` is julia is a debug version.
+Return `true` if julia is a debug version.
 """
 function isdebugbuild()
     return ccall(:jl_is_debugbuild, Cint, ()) != 0

--- a/base/util.jl
+++ b/base/util.jl
@@ -224,7 +224,7 @@ function julia_cmd(julia=joinpath(Sys.BINDIR, julia_exename()))
 end
 
 function julia_exename()
-    if ccall(:jl_is_debugbuild, Cint, ()) == 0
+    if !Base.isdebugbuild()
         return @static Sys.iswindows() ? "julia.exe" : "julia"
     else
         return @static Sys.iswindows() ? "julia-debug.exe" : "julia-debug"

--- a/base/util.jl
+++ b/base/util.jl
@@ -666,3 +666,12 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS / 2),
               "including error messages above and the output of versioninfo():\n$(read(buf, String))")
     end
 end
+
+"""
+    isdebugbuild()
+
+Return `true` is julia is a debug version.
+"""
+function isdebugbuild()
+    return ccall(:jl_is_debugbuild, Cint, ()) != 0
+end

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -152,7 +152,7 @@ if Artifacts !== nothing
     artifacts = Artifacts.load_artifacts_toml(artifacts_toml)
     platforms = [Artifacts.unpack_platform(e, "HelloWorldC", artifacts_toml) for e in artifacts["HelloWorldC"]]
     best_platform = select_platform(Dict(p => triplet(p) for p in platforms))
-    dlopen("libjulia$(ccall(:jl_is_debugbuild, Cint, ()) != 0 ? "-debug" : "")", RTLD_LAZY | RTLD_DEEPBIND)
+    dlopen("libjulia$(Base.isdebugbuild() ? "-debug" : "")", RTLD_LAZY | RTLD_DEEPBIND)
     """
 end
 

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -17,7 +17,7 @@ function shell_escape(str)
 end
 
 function libDir()
-    return if ccall(:jl_is_debugbuild, Cint, ()) != 0
+    return if Base.isdebugbuild()
         if Base.DARWIN_FRAMEWORK
             joinpath(dirname(abspath(Libdl.dlpath(Base.DARWIN_FRAMEWORK_NAME * "_debug"))),"lib")
         else
@@ -33,7 +33,7 @@ function libDir()
 end
 
 function frameworkDir()
-    libjulia = ccall(:jl_is_debugbuild, Cint, ()) != 0 ?
+    libjulia = Base.isdebugbuild() ?
         Libdl.dlpath(Base.DARWIN_FRAMEWORK_NAME * "_debug") :
         Libdl.dlpath(Base.DARWIN_FRAMEWORK_NAME)
     normpath(joinpath(dirname(abspath(libjulia)),"..","..",".."))
@@ -61,7 +61,7 @@ function ldlibs(doframework)
     # If the user wants the debug framework, DYLD_IMAGE_SUFFIX=_debug
     # should be used (refer to man 1 dyld).
     doframework && return "-framework $(Base.DARWIN_FRAMEWORK_NAME)"
-    libname = if ccall(:jl_is_debugbuild, Cint, ()) != 0
+    libname = if Base.isdebugbuild()
         "julia-debug"
     else
         "julia"

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -96,7 +96,7 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
     if !isempty(Base.GIT_VERSION_INFO.commit_short)
         println(io, "Commit $(Base.GIT_VERSION_INFO.commit_short) ($(Base.GIT_VERSION_INFO.date_string))")
     end
-    if ccall(:jl_is_debugbuild, Cint, ())!=0
+    if Base.isdebugbuild()
         println(io, "DEBUG build")
     end
     println(io, "Platform Info:")

--- a/stdlib/Libdl/test/runtests.jl
+++ b/stdlib/Libdl/test/runtests.jl
@@ -32,12 +32,12 @@ cd(@__DIR__) do
 # Find the library directory by finding the path of libjulia-internal (or libjulia-internal-debug,
 # as the case may be) to get the private library directory
 private_libdir = if Base.DARWIN_FRAMEWORK
-    if ccall(:jl_is_debugbuild, Cint, ()) != 0
+    if Base.isdebugbuild()
         dirname(abspath(Libdl.dlpath(Base.DARWIN_FRAMEWORK_NAME * "_debug")))
     else
         joinpath(dirname(abspath(Libdl.dlpath(Base.DARWIN_FRAMEWORK_NAME))),"Frameworks")
     end
-elseif ccall(:jl_is_debugbuild, Cint, ()) != 0
+elseif Base.isdebugbuild()
     dirname(abspath(Libdl.dlpath("libjulia-internal-debug")))
 else
     dirname(abspath(Libdl.dlpath("libjulia-internal")))

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -657,9 +657,9 @@ end
 # to use as a dummy shlib to open
 libjulia = if Base.DARWIN_FRAMEWORK
     abspath(Libdl.dlpath(Base.DARWIN_FRAMEWORK_NAME *
-        (ccall(:jl_is_debugbuild, Cint, ()) != 0 ? "_debug" : "")))
+        (Base.isdebugbuild() ? "_debug" : "")))
 else
-    abspath(Libdl.dlpath((ccall(:jl_is_debugbuild, Cint, ()) != 0) ? "libjulia-debug" : "libjulia"))
+    abspath(Libdl.dlpath(Base.isdebugbuild() ? "libjulia-debug" : "libjulia"))
 end
 
 

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -10,7 +10,7 @@ const opt_level = Base.JLOptions().opt_level
 const coverage = (Base.JLOptions().code_coverage > 0) || (Base.JLOptions().malloc_log > 0)
 const Iptr = sizeof(Int) == 8 ? "i64" : "i32"
 
-const is_debug_build = ccall(:jl_is_debugbuild, Cint, ()) != 0
+const is_debug_build = Base.isdebugbuild()
 function libjulia_codegen_name()
     is_debug_build ? "libjulia-codegen-debug" : "libjulia-codegen"
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -149,7 +149,7 @@ for l in (Threads.SpinLock(), ReentrantLock())
     @test get_finalizers_inhibited() == 1
     GC.enable_finalizers(true)
     @test get_finalizers_inhibited() == 0
-    if ccall(:jl_is_debugbuild, Cint, ()) != 0
+    if Base.isdebugbuild()
         # Note this warning only exists in debug builds
         @test_warn "WARNING: GC finalizers already enabled on this thread." GC.enable_finalizers(true)
     end


### PR DESCRIPTION
I put `isdebugbuild` in `base/util` and didn't export it.

Or define it as a new constant `IS_DEBUG_BUILD`.
like: 
https://github.com/JuliaLang/julia/blob/6354e2cf70c7df8e343e28da52fd30404d120fc6/base/sysinfo.jl#L76