### PR TITLE
put back legacybindings for `libblas` and `liblapack`

### DIFF
--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -86,6 +86,13 @@ using ..LinearAlgebra: libblastrampoline, BlasReal, BlasComplex, BlasFloat, Blas
 
 include("lbt.jl")
 
+# Legacy bindings that some packages (such as NNlib.jl) use.
+# We maintain these for backwards-compatibility but new packages
+# should not look at these, instead preferring to parse the output
+# of BLAS.get_config()
+const libblas = libblastrampoline
+const liblapack = libblastrampoline
+
 vendor() = :lbt
 
 """

--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -12,6 +12,12 @@ using ..LinearAlgebra: libblastrampoline, BlasFloat, BlasInt, LAPACKException, D
 
 using Base: iszero, require_one_based_indexing
 
+
+# Legacy binding maintained for backwards-compatibility but new packages
+# should not look at this, instead preferring to parse the output
+# of BLAS.get_config()
+const liblapack = libblastrampoline
+
 #Generic LAPACK error handlers
 """
 Handle only negative LAPACK error codes


### PR DESCRIPTION
Removed in https://github.com/JuliaLang/julia/pull/44360/, causing quite a few packages to stop working

@ViralBShah, if there is an explicit comment saying that some piece of code is there for backwards compat, it is probably a good idea to run PkgEval before removing it, just to be sure.
