### PR TITLE
Removed attributes from arguments to gc_preserve_begin

### DIFF
--- a/src/llvm-alloc-opt.cpp
+++ b/src/llvm-alloc-opt.cpp
@@ -58,6 +58,7 @@ static void removeGCPreserve(CallInst *call, Instruction *val)
     ++RemovedGCPreserve;
     auto replace = Constant::getNullValue(val->getType());
     call->replaceUsesOfWith(val, replace);
+    call->setAttributes(AttributeList());
     for (auto &arg: call->args()) {
         if (!isa<Constant>(arg.get())) {
             return;
@@ -1093,7 +1094,6 @@ void Optimizer::splitOnStack(CallInst *orig_inst)
                 }
                 auto new_call = builder.CreateCall(pass.gc_preserve_begin_func, operands);
                 new_call->takeName(call);
-                new_call->setAttributes(call->getAttributes());
                 call->replaceAllUsesWith(new_call);
                 call->eraseFromParent();
                 return;

--- a/test/llvmpasses/alloc-opt-pass.jl
+++ b/test/llvmpasses/alloc-opt-pass.jl
@@ -32,7 +32,7 @@ define void @preserve_branches(i8* %fptr, i1 %b, i1 %b2) {
 
 L1:
   %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, {} addrspace(10)* @tag)
-  %tok = call token (...) @llvm.julia.gc_preserve_begin({} addrspace(10)* %v)
+  %tok = call token (...) @llvm.julia.gc_preserve_begin({} addrspace(10)* nonnull %v)
   call void @external_function()
   br i1 %b2, label %L2, label %L3
 
@@ -68,7 +68,7 @@ define void @preserve_branches2(i8* %fptr, i1 %b, i1 %b2) {
 
 L1:
   %v = call noalias {} addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, {} addrspace(10)* @tag)
-  %tok = call token (...) @llvm.julia.gc_preserve_begin({} addrspace(10)* %v, {} addrspace(10)* %v2)
+  %tok = call token (...) @llvm.julia.gc_preserve_begin({} addrspace(10)* %v, {} addrspace(10)* nonnull %v2)
   call void @external_function()
   br i1 %b2, label %L2, label %L3
 


### PR DESCRIPTION
LLVM adds the nonnull attribute on its own, which makes the verifier fail.

Fixes #47245