### PR TITLE
devdoc: fix markdown title link

### DIFF
--- a/doc/src/devdocs/build/build.md
+++ b/doc/src/devdocs/build/build.md
@@ -139,7 +139,7 @@ Notes for various architectures:
 
 * [ARM](https://github.com/JuliaLang/julia/blob/master/doc/src/devdocs/build/arm.md)
 
-## [Required Build Tools and External Libraries](@id build-tools)
+## Required Build Tools and External Libraries
 
 Building Julia requires that the following software be installed:
 
@@ -302,7 +302,7 @@ From this point, you should
 ```
 (Note that `sudo` isn't installed, but neither is it necessary since you are running as `root`, so you can omit `sudo` from all commands.)
 
-Then add all the [build dependencies](@ref build-tools), a console-based editor of your choice, `git`, and anything else you'll need (e.g., `gdb`, `rr`, etc). Pick a directory to work in and `git clone` Julia, check out the branch you wish to debug, and build Julia as usual.
+Then add all the [build dependencies](#required-build-tools-and-external-libraries), a console-based editor of your choice, `git`, and anything else you'll need (e.g., `gdb`, `rr`, etc). Pick a directory to work in and `git clone` Julia, check out the branch you wish to debug, and build Julia as usual.
 
 
 ## Update the version number of a dependency


### PR DESCRIPTION
Revert short title link introduced in #44300

Use the default generated long link to keep the URL on GitHub alive.
```md
V:\julia\doc\src\devdocs\build\build.md
  19,15: dependencies](#required-build-tools-and-external-libraries). If you
  305,39: Then add all the [build dependencies](#required-build-tools-and-external-libraries), a console-based editor of your choice, `git`, and anything else you'll need (e.g., `gdb`, `rr`, etc). Pick a directory to work in and `git clone` Julia, check out the branch you wish to debug, and build Julia as usual.

V:\julia\doc\src\devdocs\build\linux.md
  7,48: * See also the [external dependencies](build.md#required-build-tools-and-external-libraries).

V:\julia\README.md
  86,92: dependencies](https://github.com/JuliaLang/julia/blob/master/doc/src/devdocs/build/build.md#required-build-tools-and-external-libraries) installed.
```
