### PR TITLE
tweak test cases added in #47379

### DIFF
--- a/test/compiler/AbstractInterpreter.jl
+++ b/test/compiler/AbstractInterpreter.jl
@@ -351,7 +351,3 @@ let NoinlineModule = Module()
         @test count(iscall((src, inlined_usually)), src.code) == 0
     end
 end
-
-# Issue #46839
-@test code_typed(()->invoke(BitSet, Any, x), ())[1][2] === Union{}
-@test code_typed(()->invoke(BitSet, Union{Tuple{Int32},Tuple{Int64}}, 1), ())[1][2] === Union{}

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4285,3 +4285,7 @@ end
         ccall(0, Cvoid, (Nothing,), b)
     end)[2] === Nothing
 end
+
+# Issue #46839: `abstract_invoke` should handle incorrect call type
+@test only(Base.return_types(()->invoke(BitSet, Any, x), ())) === Union{}
+@test only(Base.return_types(()->invoke(BitSet, Union{Tuple{Int32},Tuple{Int64}}, 1), ())) === Union{}


### PR DESCRIPTION
- general inference test should go in `compiler/inference`, while `compiler/AbstractInterpreter` should keep cases that test `AbstractInterpreter` inference specifically
- `only(Base.return_types(...))` is simpler than `code_typed()[1][1]` to implement a return type based test case.

/cc @apaz-cli 