### PR TITLE
optimizer: inline effect-free `:static_parameter`

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -401,7 +401,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
         end
     end
 
-    return ultimate_rt
+    return maybe_singleton_const(ultimate_rt)
 end
 
 function ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IRInterpretationState)

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1816,3 +1816,30 @@ let ir = Base.code_ircode(big_tuple_test1, Tuple{})[1][1]
     ir = Core.Compiler.compact!(ir, true)
     @test length(ir.stmts) == 1
 end
+
+# compiler should recognize effectful :static_parameter
+# https://github.com/JuliaLang/julia/issues/45490
+issue45490_1(x::Union{T, Nothing}, y::Union{T, Nothing}) where {T} = T
+issue45490_2(x::Union{T, Nothing}, y::Union{T, Nothing}) where {T} = (typeof(T); nothing)
+for f = (issue45490_1, issue45490_2)
+    src = code_typed1(f, (Any,Any))
+    @test any(src.code) do @nospecialize x
+        isexpr(x, :static_parameter)
+    end
+    @test_throws UndefVarError f(nothing, nothing)
+end
+
+# inline effect-free :static_parameter, required for semi-concrete interpretation accuracy
+# https://github.com/JuliaLang/julia/issues/47349
+function make_issue47349(::Val{N}) where {N}
+    pickargs(::Val{N}) where {N} = (@nospecialize(x::Tuple)) -> x[N]
+    return pickargs(Val{N-1}())
+end
+let src = code_typed1(make_issue47349(Val{4}()), (Any,))
+    @test !any(src.code) do @nospecialize x
+        isexpr(x, :static_parameter)
+    end
+    @test Base.return_types((Int,)) do x
+        make_issue47349(Val(4))((x,nothing,Int))
+    end |> only === Type{Int}
+end


### PR DESCRIPTION
JuliaLang/julia#45459 moved `:static_parameter` always to statement position as our optimizer assumes `:static_parameter` in value position effect-free.
But it turns out that it can cause precision issue for semi-concrete interpretation as discovered at #47349, since the type of `:static_parameter` in statement position is widened when converted to compressed IR for cache.

This commit follows up JuliaLang/julia#45459 so that we inline effect-free `:static_parameter` during IR conversion and get a more reasonable semi-concrete interpretation.

Fixes https://github.com/JuliaLang/julia/issues/47349