### PR TITLE
`release-1.8`: change the external Buildkite ref from `main` to `release-julia-1.8`

### DIFF
--- a/.buildkite-external-version
+++ b/.buildkite-external-version
@@ -1,1 +1,1 @@
-main
+release-julia-1.8


### PR DESCRIPTION
The base (target) branch of this PR is the `release-1.8` branch.

TODO:
- [x] Do not merge this PR until [JuliaCI/julia-buildkite#241](https://github.com/JuliaCI/julia-buildkite/pull/241) has been merged.