### PR TITLE
fix error messages in relpath to reflect non-empty instead of specified

### DIFF
--- a/base/path.jl
+++ b/base/path.jl
@@ -552,8 +552,8 @@ On Windows, case sensitivity is applied to every part of the path except drive l
 `path` and `startpath` refer to different drives, the absolute path of `path` is returned.
 """
 function relpath(path::String, startpath::String = ".")
-    isempty(path) && throw(ArgumentError("`path` must be specified"))
-    isempty(startpath) && throw(ArgumentError("`startpath` must be specified"))
+    isempty(path) && throw(ArgumentError("`path` must be non-empty"))
+    isempty(startpath) && throw(ArgumentError("`startpath` must be non-empty"))
     curdir = "."
     pardir = ".."
     path == startpath && return curdir


### PR DESCRIPTION
An attempt to improve the error messages for relpath function as a part of an attempt to resolve #47443.

The error messages have been changed from `path must be specified` to `path must be non-empty`