### PR TITLE
Don't show redundant typeinfo when printing LinRange

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -585,12 +585,13 @@ function show(io::IO, r::LinRange{T}) where {T}
     print(io, "LinRange{")
     show(io, T)
     print(io, "}(")
-    show(io, first(r))
-    print(io, ", ")
-    show(io, last(r))
-    print(io, ", ")
-    show(io, length(r))
-    print(io, ')')
+    ioc = IOContext(io, :typeinfo=>T)
+    show(ioc, first(r))
+    print(ioc, ", ")
+    show(ioc, last(r))
+    print(ioc, ", ")
+    show(ioc, length(r))
+    print(ioc, ')')
 end
 
 """

--- a/base/range.jl
+++ b/base/range.jl
@@ -587,11 +587,11 @@ function show(io::IO, r::LinRange{T}) where {T}
     print(io, "}(")
     ioc = IOContext(io, :typeinfo=>T)
     show(ioc, first(r))
-    print(ioc, ", ")
+    print(io, ", ")
     show(ioc, last(r))
-    print(ioc, ", ")
-    show(ioc, length(r))
-    print(ioc, ')')
+    print(io, ", ")
+    show(io, length(r))
+    print(io, ')')
 end
 
 """


### PR DESCRIPTION
```julia
julia> print(LinRange(0f0, 10f0, 4)) # before
LinRange{Float32}(0.0f0, 10.0f0, 4)

julia> print(LinRange(0f0, 10f0, 4)) # after
LinRange{Float32}(0.0, 10.0, 4)
```