### PR TITLE
Compute `ceil(Int, log2(n))` in `TwicePrecision` using `leading_zeros` instead

### DIFF
--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -254,7 +254,11 @@ nbitslen(::Type{T}, len, offset) where {T<:IEEEFloat} =
     min(cld(precision(T), 2), nbitslen(len, offset))
 # The +1 here is for safety, because the precision of the significand
 # is 1 bit higher than the number that are explicitly stored.
-nbitslen(len, offset) = len < 2 ? 0 : ceil(Int, log2(max(offset-1, len-offset))) + 1
+nbitslen(len, offset) = len < 2 ? 0 : ceil_log2(max(offset-1, len-offset)) + 1
+
+ceil_log2(n::Integer) = ceil(Int, log2(n))
+ceil_log2(n::Int64) = 64 - leading_zeros(n - Int64(1))
+ceil_log2(n::Int32) = 32 - leading_zeros(n - Int32(1))
 
 eltype(::Type{TwicePrecision{T}}) where {T} = T
 
@@ -310,7 +314,7 @@ function *(x::TwicePrecision, v::Number)
 end
 function *(x::TwicePrecision{<:IEEEFloat}, v::Integer)
     v == 0 && return TwicePrecision(x.hi*v, x.lo*v)
-    nb = ceil(Int, log2(abs(v)))
+    nb = ceil_log2(abs(v))
     u = truncbits(x.hi, nb)
     TwicePrecision(canonicalize2(u*v, ((x.hi-u) + x.lo)*v)...)
 end

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -257,8 +257,7 @@ nbitslen(::Type{T}, len, offset) where {T<:IEEEFloat} =
 nbitslen(len, offset) = len < 2 ? 0 : ceil_log2(max(offset-1, len-offset)) + 1
 
 ceil_log2(n::Integer) = ceil(Int, log2(n))
-ceil_log2(n::Int64) = 64 - leading_zeros(n - Int64(1))
-ceil_log2(n::Int32) = 32 - leading_zeros(n - Int32(1))
+ceil_log2(n::T) where {T<:BitSigned} = 8 * sizeof(T) - leading_zeros(n - T(1))
 
 eltype(::Type{TwicePrecision{T}}) where {T} = T
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1716,6 +1716,13 @@ end
     @test_throws BoundsError (false:true)[3]
 end
 
+@testset "ceil_log2" begin
+    for n in 1:100
+        @test ceil(Int, log2(n)) == Base.ceil_log2(Int32(n))
+        @test ceil(Int, log2(n)) == Base.ceil_log2(Int64(n))
+    end
+end
+
 module NonStandardIntegerRangeTest
 
 using Test

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1718,8 +1718,10 @@ end
 
 @testset "ceil_log2" begin
     for n in 1:100
-        @test ceil(Int, log2(n)) == Base.ceil_log2(Int32(n))
-        @test ceil(Int, log2(n)) == Base.ceil_log2(Int64(n))
+        x = ceil(Int, log2(n))
+        @test x == Base.ceil_log2(Int128(n))
+        @test x == Base.ceil_log2(Int32(n))
+        @test x == Base.ceil_log2(Int8(n))
     end
 end
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1722,6 +1722,7 @@ end
         @test x == Base.ceil_log2(Int128(n))
         @test x == Base.ceil_log2(Int32(n))
         @test x == Base.ceil_log2(Int8(n))
+        @test x == Base.ceil_log2(big(n))  # fallback path
     end
 end
 


### PR DESCRIPTION
This aims to speed up the following multiplication, without functional changes:
```julia
julia> @btime $(Base.TwicePrecision(1.234, 0.0456)) * $7
  17.702 ns (0 allocations: 0 bytes)  # before
  4.541 ns (0 allocations: 0 bytes)   # after
Base.TwicePrecision{Float64}(8.9572, -3.3306690738754696e-16)
```
I also changed also the other occurrence of `ceil(Int, log2(` in the same file, inside `nbitslen`. I didn't look very hard at things downstream of that.

Discovered in fiddling with  https://github.com/JuliaLang/julia/pull/39071, where this costs more time than high-precision `exp`.