### PR TITLE
Query `Array` ownership with `isshared` and `isowner`

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -59,6 +59,16 @@ JL_DLLEXPORT char *jl_array_typetagdata(jl_array_t *a) JL_NOTSAFEPOINT
     return ((char*)jl_array_data(a)) + ((jl_array_ndims(a) == 1 ? (a->maxsize - a->offset) : jl_array_len(a)) * a->elsize) + a->offset;
 }
 
+JL_DLLEXPORT uint16_t jl_array_shared_flag(jl_array_t *a)
+{
+    return a->flags.isshared;
+}
+
+JL_DLLEXPORT uint16_t jl_array_how_flag(jl_array_t *a)
+{
+    return a->flags.how;
+}
+
 STATIC_INLINE jl_value_t *jl_array_owner(jl_array_t *a JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
     if (a->flags.how == 3) {

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -40,6 +40,8 @@
     XX(jl_array_ptr_1d_append) \
     XX(jl_array_ptr_1d_push) \
     XX(jl_array_ptr_copy) \
+    XX(jl_array_shared_flag) \
+    XX(jl_array_how_flag) \
     XX(jl_array_rank) \
     XX(jl_array_size) \
     XX(jl_array_sizehint) \

--- a/src/julia.h
+++ b/src/julia.h
@@ -1000,6 +1000,7 @@ STATIC_INLINE jl_value_t *jl_svecset(
 #define jl_array_data_owner_offset(ndims) (offsetof(jl_array_t,ncols) + sizeof(size_t)*(1+jl_array_ndimwords(ndims))) // in bytes
 #define jl_array_data_owner(a) (*((jl_value_t**)((char*)a + jl_array_data_owner_offset(jl_array_ndims(a)))))
 
+
 JL_DLLEXPORT char *jl_array_typetagdata(jl_array_t *a) JL_NOTSAFEPOINT;
 
 #ifdef __clang_gcanalyzer__
@@ -1598,6 +1599,8 @@ JL_DLLEXPORT int jl_array_validate_dims(size_t *nel, size_t *tot, uint32_t ndims
 JL_DLLEXPORT void *jl_array_ptr(jl_array_t *a);
 JL_DLLEXPORT void *jl_array_eltype(jl_value_t *a);
 JL_DLLEXPORT int jl_array_rank(jl_value_t *a);
+JL_DLLEXPORT uint16_t jl_array_shared_flag(jl_array_t *a);
+JL_DLLEXPORT uint16_t jl_array_how_flag(jl_array_t *a);
 JL_DLLEXPORT size_t jl_array_size(jl_value_t *a, int d);
 
 // strings


### PR DESCRIPTION
Resizing operations throw errors on shared arrays but there's currently no way to find this out until an error is thrown. `isshared` lets us know before execution that an array may be shared and `isowner` lets us know if the array is the original owner, potentially allowing "unsharing" data. (#47537).

This recently came up alongside discussion of other traits for characterizing this information at the type level (#46500).