### PR TITLE
add `isunix` for BinaryPlatforms `AbstractPlatform`

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -584,6 +584,7 @@ Sys.islinux(p::AbstractPlatform) = os(p) == "linux"
 Sys.iswindows(p::AbstractPlatform) = os(p) == "windows"
 Sys.isfreebsd(p::AbstractPlatform) = os(p) == "freebsd"
 Sys.isbsd(p::AbstractPlatform) = os(p) ∈ ("freebsd", "macos")
+Sys.isunix(p::AbstractPlatform) = Sys.isbsd(p) || Sys.islinux(p)
 
 const arch_mapping = Dict(
     "x86_64" => "(x86_|amd)64",


### PR DESCRIPTION
This provides symmetry with the methods defined in `Sys`, and is convenient for use in e.g. BinaryBuilder platform filters. Note that there are other `is.*bsd` variants we omit since they are unsupported by BinaryPlatforms. The capitalization conventions are also different so we do not call the Sys methods directly.