### PR TITLE
faster `BigFloat(::Float64)`

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -210,6 +210,13 @@ end
 
 function BigFloat(x::Float64, r::MPFRRoundingMode=ROUNDING_MODE[]; precision::Integer=DEFAULT_PRECISION[])
     z = BigFloat(;precision)
+    if precision < 53
+        ccall((:mpfr_set_d, :libmpfr), Int32, (Ref{BigFloat}, Float64, MPFRRoundingMode), z, x, r)
+        if isnan(x) && signbit(x) != signbit(z)
+            z.sign = -z.sign
+        end
+        return z
+    end
     z.sign = 1-2*signbit(x)
     if iszero(x) || !isfinite(x)
         if isinf(x)


### PR DESCRIPTION
This technically has different behavior than the current behavior but I'm pretty sure that no one was using `BigFloat` with precision<53 because the current behavior is to give you all 53 bits for precision>=40 and only the leading 8 bits for precision<40. This is roughly 2x faster for precision<10000. It's a little slower for precisions >10^6 (about 20%) but IMO this doesn't really matter since for high precision things like multiplication will be way slower than construction.