### PR TITLE
RFC: `stack(::Slices)` is `permutedims`

### DIFF
--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -238,3 +238,31 @@ Base.@propagate_inbounds setindex!(s::Slices{P,SM,AX,S,N}, val, I::Vararg{Int,N}
     s.parent[_slice_index(s, I...)...] = val
 
 parent(s::Slices) = s.parent
+
+# Instead of stacking slices, it's faster to call permutedims
+function _stack(dims::Colon, s::Slices)
+    nodrop = ndims(s) + ndims(eltype(s)) > ndims(parent(s))
+    if nodrop
+        return _stack(dims, IteratorSize(s), s)  # can this cause type-instability?
+    end
+    NI = ndims(eltype(s))
+    tmp = accumulate(s.slicemap; init=(0, 1)) do (_, d), c
+        c isa Integer ? (c+NI, d) : (d, d+1)
+    end
+    perm = invperm(map(first, tmp))
+    return permutedims(parent(s), perm)
+end
+
+function _stack(dims::Integer, s::Slices)
+    nodrop = ndims(s) + ndims(eltype(s)) > ndims(parent(s))
+    if nodrop || ndims(s) != 1
+        return _stack(dims, IteratorSize(s), s)
+    end
+    din = findfirst(==(1), s.slicemap)::Int
+    perm = ntuple(ndims(parent(s))) do d
+        d == dims && return din::Int
+        e = d - (d>dims)
+        e + (e>=din)
+    end
+    return permutedims(parent(s), perm)
+end


### PR DESCRIPTION
Some operations on `Slices` from https://github.com/JuliaLang/julia/pull/32310 can be more efficiently done on the parent array. Should we add shortcuts, and how widely? The obvious candidate is reductions but the problem is this:

```julia
julia> x = rand(1:99, 2,3);

julia> sum(eachcol(x)) == vec(sum(x, dims=2))  # adds whole arrays, inefficient
true

julia> prod(eachcol(x))
ERROR: MethodError: no method matching *(::SubArray, ::SubArray)

julia> identity.(0 .+ prod.(eachrow(x))) == vec(prod(x, dims=2))  # should this un-fuse?
true
```
and (edit) another problem is this:
```
julia> using CUDA

julia> prod(cu(x); dims=2) isa CuArray  # whole-array operation

julia> prod.(eachcol(cu(x))) isa Array  # iterating on CPU
```

This PR tries something which seems safer, sending `stack(eachslice(x))` to `permutedims`. Not always much of a speed improvement, but sometimes it is:
```julia
julia> let n = 500
           x = randn(n,n,n)
           a = @btime stack(eachslice($x, dims=2), dims=1)
           b = @btime permutedims($x, (2,1,3))
           a == b
       end
  945.207 ms (2 allocations: 953.67 MiB)
  203.902 ms (2 allocations: 953.67 MiB)
true
```
Draft, needs tests, and possibly located in the wrong file. 

Possibly introduces type-instabilities in its present form. It would be nicer if this could dispatch on the type of `Slices` to know whether or not it can use `permutedims`, but as far as I can see it cannot. 