### PR TITLE
Add shortcuts to `axp[b]y`

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1444,10 +1444,11 @@ function axpy!(α, x::AbstractArray, y::AbstractArray)
     if n != length(y)
         throw(DimensionMismatch("x has length $n, but y has length $(length(y))"))
     end
+    iszero(α) && return y
     for (IY, IX) in zip(eachindex(y), eachindex(x))
         @inbounds y[IY] += x[IX]*α
     end
-    y
+    return y
 end
 
 function axpy!(α, x::AbstractArray, rx::AbstractArray{<:Integer}, y::AbstractArray, ry::AbstractArray{<:Integer})
@@ -1458,10 +1459,11 @@ function axpy!(α, x::AbstractArray, rx::AbstractArray{<:Integer}, y::AbstractAr
     elseif !checkindex(Bool, eachindex(IndexLinear(), y), ry)
         throw(BoundsError(y, ry))
     end
+    iszero(α) && return y
     for (IY, IX) in zip(eachindex(ry), eachindex(rx))
         @inbounds y[ry[IY]] += x[rx[IX]]*α
     end
-    y
+    return y
 end
 
 """
@@ -1487,6 +1489,7 @@ function axpby!(α, x::AbstractArray, β, y::AbstractArray)
     if length(x) != length(y)
         throw(DimensionMismatch("x has length $(length(x)), but y has length $(length(y))"))
     end
+    iszero(α) && isone(β) && return y
     for (IX, IY) in zip(eachindex(x), eachindex(y))
         @inbounds y[IY] = x[IX]*α + y[IY]*β
     end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1444,7 +1444,7 @@ function axpy!(α, x::AbstractArray, y::AbstractArray)
     if n != length(y)
         throw(DimensionMismatch("x has length $n, but y has length $(length(y))"))
     end
-    iszero(α) && return y
+    isa(α, Number) && iszero(α) && return y
     for (IY, IX) in zip(eachindex(y), eachindex(x))
         @inbounds y[IY] += x[IX]*α
     end
@@ -1459,7 +1459,7 @@ function axpy!(α, x::AbstractArray, rx::AbstractArray{<:Integer}, y::AbstractAr
     elseif !checkindex(Bool, eachindex(IndexLinear(), y), ry)
         throw(BoundsError(y, ry))
     end
-    iszero(α) && return y
+    isa(α, Number) && iszero(α) && return y
     for (IY, IX) in zip(eachindex(ry), eachindex(rx))
         @inbounds y[ry[IY]] += x[rx[IX]]*α
     end
@@ -1489,7 +1489,7 @@ function axpby!(α, x::AbstractArray, β, y::AbstractArray)
     if length(x) != length(y)
         throw(DimensionMismatch("x has length $(length(x)), but y has length $(length(y))"))
     end
-    iszero(α) && isone(β) && return y
+    isa(α, Number) && iszero(α) && isa(β, Number) && isone(β) && return y
     for (IX, IY) in zip(eachindex(x), eachindex(y))
         @inbounds y[IY] = x[IX]*α + y[IY]*β
     end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1444,7 +1444,7 @@ function axpy!(α, x::AbstractArray, y::AbstractArray)
     if n != length(y)
         throw(DimensionMismatch("x has length $n, but y has length $(length(y))"))
     end
-    isa(α, Number) && iszero(α) && return y
+    iszero(α) && return y
     for (IY, IX) in zip(eachindex(y), eachindex(x))
         @inbounds y[IY] += x[IX]*α
     end
@@ -1459,7 +1459,7 @@ function axpy!(α, x::AbstractArray, rx::AbstractArray{<:Integer}, y::AbstractAr
     elseif !checkindex(Bool, eachindex(IndexLinear(), y), ry)
         throw(BoundsError(y, ry))
     end
-    isa(α, Number) && iszero(α) && return y
+    iszero(α) && return y
     for (IY, IX) in zip(eachindex(ry), eachindex(rx))
         @inbounds y[ry[IY]] += x[rx[IX]]*α
     end
@@ -1489,7 +1489,7 @@ function axpby!(α, x::AbstractArray, β, y::AbstractArray)
     if length(x) != length(y)
         throw(DimensionMismatch("x has length $(length(x)), but y has length $(length(y))"))
     end
-    isa(α, Number) && iszero(α) && isa(β, Number) && isone(β) && return y
+    iszero(α) && isone(β) && return y
     for (IX, IY) in zip(eachindex(x), eachindex(y))
         @inbounds y[IY] = x[IX]*α + y[IY]*β
     end

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -117,12 +117,13 @@ end
     x = ['a','b','c','d','e']
     y = ['a','b','c','d','e']
     α, β = 'f', 'g'
-    @test_throws DimensionMismatch LinearAlgebra.axpy!(α,x,['g'])
-    @test_throws DimensionMismatch LinearAlgebra.axpby!(α,x,β,['g'])
-    @test_throws BoundsError LinearAlgebra.axpy!(α,x,Vector(-1:5),y,Vector(1:7))
-    @test_throws BoundsError LinearAlgebra.axpy!(α,x,Vector(1:7),y,Vector(-1:5))
-    @test_throws BoundsError LinearAlgebra.axpy!(α,x,Vector(1:7),y,Vector(1:7))
-    @test_throws DimensionMismatch LinearAlgebra.axpy!(α,x,Vector(1:3),y,Vector(1:5))
+    @test axpy!(α, x, y)
+    @test_throws DimensionMismatch axpy!(α, x, ['g'])
+    @test_throws DimensionMismatch axpby!(α, x, β, ['g'])
+    @test_throws BoundsError axpy!(α, x, Vector(-1:5), y, Vector(1:7))
+    @test_throws BoundsError axpy!(α, x, Vector(1:7), y, Vector(-1:5))
+    @test_throws BoundsError axpy!(α, x, Vector(1:7), y, Vector(1:7))
+    @test_throws DimensionMismatch axpy!(α, x, Vector(1:3), y, Vector(1:5))
 end
 
 @test !issymmetric(fill(1,5,3))
@@ -302,44 +303,50 @@ end
     end
 end
 
-@testset "LinearAlgebra.axp(b)y! for element type without commutative multiplication" begin
+@testset "axp(b)y! for element type without commutative multiplication" begin
     α = [1 2; 3 4]
     β = [5 6; 7 8]
     x = fill([ 9 10; 11 12], 3)
     y = fill([13 14; 15 16], 3)
-    axpy = LinearAlgebra.axpy!(α, x, deepcopy(y))
-    axpby = LinearAlgebra.axpby!(α, x, β, deepcopy(y))
+    axpy = axpy!(α, x, deepcopy(y))
+    axpby = axpby!(α, x, β, deepcopy(y))
     @test axpy == x .* [α] .+ y
     @test axpy != [α] .* x .+ y
     @test axpby == x .* [α] .+ y .* [β]
     @test axpby != [α] .* x .+ [β] .* y
+    axpy = axpy!(zero(α), x, deepcopy(y))
+    axpby = axpby!(zero(α), x, one(β), deepcopy(y))
+    @test axpy == y
+    @test axpy == y
+    @test axpby == y
+    @test axpby == y
 end
 
-@testset "LinearAlgebra.axpy! for x and y of different dimensions" begin
+@testset "axpy! for x and y of different dimensions" begin
     α = 5
     x = 2:5
     y = fill(1, 2, 4)
     rx = [1 4]
     ry = [2 8]
-    @test LinearAlgebra.axpy!(α, x, rx, y, ry) == [1 1 1 1; 11 1 1 26]
+    @test axpy!(α, x, rx, y, ry) == [1 1 1 1; 11 1 1 26]
 end
 
-@testset "LinearAlgebra.axp(b)y! for non strides input" begin
+@testset "axp(b)y! for non strides input" begin
     a = rand(5, 5)
-    @test LinearAlgebra.axpby!(1, Hermitian(a), 1, zeros(size(a))) == Hermitian(a)
-    @test LinearAlgebra.axpby!(1, 1.:5, 1, zeros(5)) == 1.:5
-    @test LinearAlgebra.axpy!(1, Hermitian(a), zeros(size(a))) == Hermitian(a)
-    @test LinearAlgebra.axpy!(1, 1.:5, zeros(5)) == 1.:5
+    @test axpby!(1, Hermitian(a), 1, zeros(size(a))) == Hermitian(a)
+    @test axpby!(1, 1.:5, 1, zeros(5)) == 1.:5
+    @test axpy!(1, Hermitian(a), zeros(size(a))) == Hermitian(a)
+    @test axpy!(1, 1.:5, zeros(5)) == 1.:5
 end
 
 @testset "LinearAlgebra.axp(b)y! for stride-vector like input" begin
     for T in (Float32, Float64, ComplexF32, ComplexF64)
         a = rand(T, 5, 5)
-        @test LinearAlgebra.axpby!(1, view(a, :, 1:5), 1, zeros(T, size(a))) == a
-        @test LinearAlgebra.axpy!(1, view(a, :, 1:5), zeros(T, size(a))) == a
+        @test axpby!(1, view(a, :, 1:5), 1, zeros(T, size(a))) == a
+        @test axpy!(1, view(a, :, 1:5), zeros(T, size(a))) == a
         b = view(a, 25:-2:1)
-        @test LinearAlgebra.axpby!(1, b, 1, zeros(T, size(b))) == b
-        @test LinearAlgebra.axpy!(1, b, zeros(T, size(b))) == b
+        @test axpby!(1, b, 1, zeros(T, size(b))) == b
+        @test axpy!(1, b, zeros(T, size(b))) == b
     end
 end
 

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -117,7 +117,6 @@ end
     x = ['a','b','c','d','e']
     y = ['a','b','c','d','e']
     α, β = 'f', 'g'
-    @test axpy!(α, x, y)
     @test_throws DimensionMismatch axpy!(α, x, ['g'])
     @test_throws DimensionMismatch axpby!(α, x, β, ['g'])
     @test_throws BoundsError axpy!(α, x, Vector(-1:5), y, Vector(1:7))


### PR DESCRIPTION
These methods are fairly generic, so I'm not sure if we should restrict the shortcuts to more specific situations, like `Number`s.

Closes JuliaLang/LinearAlgebra.jl#967.