### PR TITLE
Reuse `du2` of `Tridiagonal` matrix for pivoting in `lu!` if extant

### DIFF
--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -534,7 +534,6 @@ function lu!(A::Tridiagonal{T,V}, pivot::Union{RowMaximum,NoPivot} = RowMaximum(
     else
         du2 = fill!(similar(d, max(0, n-2)), 0)::V
     end
-                
 
     @inbounds begin
         for i = 1:n

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -527,7 +527,14 @@ function lu!(A::Tridiagonal{T,V}, pivot::Union{RowMaximum,NoPivot} = RowMaximum(
     if dl === du
         throw(ArgumentError("off-diagonals of `A` must not alias"))
     end
-    du2 = fill!(similar(d, max(0, n-2)), 0)::V
+    # Check if Tridiagonal matrix already has du2 for pivoting
+    has_du2_defined = isdefined(A, :du2) && isa(A.du2, V) && length(A.du2) == max(0, n-2)
+    if has_du2_defined
+        du2 = A.du2::V
+    else
+        du2 = fill!(similar(d, max(0, n-2)), 0)::V
+    end
+                
 
     @inbounds begin
         for i = 1:n
@@ -582,7 +589,7 @@ function lu!(A::Tridiagonal{T,V}, pivot::Union{RowMaximum,NoPivot} = RowMaximum(
             end
         end
     end
-    B = Tridiagonal{T,V}(dl, d, du, du2)
+    B = has_du2_defined ? A : Tridiagonal{T,V}(dl, d, du, du2)
     check && checknonsingular(info, pivot)
     return LU{T,Tridiagonal{T,V},typeof(ipiv)}(B, ipiv, convert(BlasInt, info))
 end

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -528,7 +528,7 @@ function lu!(A::Tridiagonal{T,V}, pivot::Union{RowMaximum,NoPivot} = RowMaximum(
         throw(ArgumentError("off-diagonals of `A` must not alias"))
     end
     # Check if Tridiagonal matrix already has du2 for pivoting
-    has_du2_defined = isdefined(A, :du2) && isa(A.du2, V) && length(A.du2) == max(0, n-2)
+    has_du2_defined = isdefined(A, :du2) && length(A.du2) == max(0, n-2)
     if has_du2_defined
         du2 = A.du2::V
     else

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -532,8 +532,9 @@ function lu!(A::Tridiagonal{T,V}, pivot::Union{RowMaximum,NoPivot} = RowMaximum(
     if has_du2_defined
         du2 = A.du2::V
     else
-        du2 = fill!(similar(d, max(0, n-2)), 0)::V
+        du2 = similar(d, max(0, n-2))::V
     end
+    fill!(du2, 0)
 
     @inbounds begin
         for i = 1:n


### PR DESCRIPTION
The `LinearAlgebra.Tridiagonal` type contains an optional upper second diagonal for pivoting
```
julia> using LinearAlgebra

julia> a = Tridiagonal(ones(9), ones(10), ones(9));

julia> isdefined(a, :du2)
false

julia> b = Tridiagonal(ones(9), ones(10), ones(9), ones(8));

julia> isdefined(b, :du2)
true
```
However `lu!` currently does not use this, and instead just allocates a new one even if it already exists.

This PR has `lu!(A::Tridiagonal, ...)` check if the second upper diagonal is already defined and of the proper size and type, and uses it if so.

This can be a nontrivial speedup and reduction in allocations if `lu!` is used in a hot loop.
