### PR TITLE
Fix `MethodError` while showing `MethodError` from `invoke` with `UnionAll`

### DIFF
--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -933,3 +933,8 @@ let err_str
     err_str = @except_str "a" + "b" MethodError
     @test occursin("String concatenation is performed with *", err_str)
 end
+
+@testset "issue #47559" begin
+    err = try; invoke(Returns, Tuple{Any,Val{N}} where N, 1, Val(1)) catch ex; ex; end
+    @test startswith(sprint(Base.showerror, err), "MethodError: no method matching Returns(::Any, ::Val{N})")
+end


### PR DESCRIPTION
The old code had a comment about this being either a `Tuple` or a type, and chose to check for the type. Unwrapping the `UnionAll` and checking for being a tuple seemed to be the easiest way to fix this, so that's what I did.

Also adds the same comment from `showerror` to `show_method_candidates`, since that assumes the same thing.

Fixes #47559