### PR TITLE
inference: Enable type-based alias analysis (`MustAlias`) for `NativeInterpreter`

### DIFF
--- a/Compiler/src/abstractlattice.jl
+++ b/Compiler/src/abstractlattice.jl
@@ -80,8 +80,8 @@ const AnyConditionalsLattice{𝕃<:AbstractLattice} = Union{ConditionalsLattice{
 const AnyMustAliasesLattice{𝕃<:AbstractLattice} = Union{MustAliasesLattice{𝕃}, InterMustAliasesLattice{𝕃}}
 
 const SimpleInferenceLattice = typeof(PartialsLattice(ConstsLattice()))
-const BaseInferenceLattice = typeof(ConditionalsLattice(SimpleInferenceLattice.instance))
-const IPOResultLattice = typeof(InterConditionalsLattice(SimpleInferenceLattice.instance))
+const BaseInferenceLattice = typeof(MustAliasesLattice(ConditionalsLattice(SimpleInferenceLattice.instance)))
+const IPOResultLattice = typeof(InterMustAliasesLattice(InterConditionalsLattice(SimpleInferenceLattice.instance)))
 
 """
     struct InferenceLattice{𝕃<:AbstractLattice} <: AbstractLattice

--- a/Compiler/src/typelattice.jl
+++ b/Compiler/src/typelattice.jl
@@ -372,9 +372,15 @@ end
                 elsefields === nothing || push!(elsefields, t)
             end
         end
-        return Conditional(slot, ssadef,
-            thenfields === nothing ? Bottom : PartialStruct(fallback_lattice, vartyp_widened, thenfields),
-            elsefields === nothing ? Bottom : PartialStruct(fallback_lattice, vartyp_widened, elsefields))
+        thentype_r = thenfields === nothing ? Bottom : begin
+            undefs = partialstruct_init_undefs(vartyp_widened, thenfields)
+            undefs === nothing ? Bottom : PartialStruct(fallback_lattice, vartyp_widened, undefs, thenfields)
+        end
+        elsetype_r = elsefields === nothing ? Bottom : begin
+            undefs = partialstruct_init_undefs(vartyp_widened, elsefields)
+            undefs === nothing ? Bottom : PartialStruct(fallback_lattice, vartyp_widened, undefs, elsefields)
+        end
+        return Conditional(slot, ssadef, thentype_r, elsetype_r)
     end
 end
 

--- a/Compiler/test/inference.jl
+++ b/Compiler/test/inference.jl
@@ -2597,6 +2597,16 @@ getsomethingx(b::GetSomethingB) = b.x
     getsomethingx(x)
 end == Int
 
+# https://github.com/JuliaLang/julia/issues/59975
+struct Issue59975; a; end
+function issue59975(x::Issue59975)
+   if x.a isa Int
+        return x.a
+    end
+    return 0
+end
+@test Base.infer_return_type(issue59975, (Issue59975,)) == Int
+
 @testset "issue #56913: `BoundsError` in type inference" begin
     R = UnitRange{Int}
     @test Type{AbstractVector} == Base.infer_return_type(Base.promote_typeof, Tuple{R, R, Vector{Any}, Vararg{R}})


### PR DESCRIPTION
#41199 implements the base logic for new lattice element `MustAlias`, but doesn't enable it for `NativeInterpreter`.
This PR enables it for our native code execution pipeline, checking its performance impact.

---

Closes #59975.