### PR TITLE
optimizer: exclude `ConditionalsLattice` from the optimizer lattice

### DIFF
--- a/base/compiler/abstractlattice.jl
+++ b/base/compiler/abstractlattice.jl
@@ -50,8 +50,10 @@ widenlattice(L::InterConditionalsLattice) = L.parent
 is_valid_lattice_norec(lattice::InterConditionalsLattice, @nospecialize(elem)) = isa(elem, InterConditional)
 
 const AnyConditionalsLattice{L} = Union{ConditionalsLattice{L}, InterConditionalsLattice{L}}
-const BaseInferenceLattice = typeof(ConditionalsLattice(PartialsLattice(ConstsLattice())))
-const IPOResultLattice = typeof(InterConditionalsLattice(PartialsLattice(ConstsLattice())))
+
+const SimpleInferenceLattice = typeof(PartialsLattice(ConstsLattice()))
+const BaseInferenceLattice = typeof(ConditionalsLattice(SimpleInferenceLattice.instance))
+const IPOResultLattice = typeof(InterConditionalsLattice(SimpleInferenceLattice.instance))
 
 """
     struct InferenceLattice{L}
@@ -74,7 +76,7 @@ The lattice used by the optimizer. Extends
 struct OptimizerLattice{L} <: AbstractLattice
     parent::L
 end
-OptimizerLattice() = OptimizerLattice(BaseInferenceLattice.instance)
+OptimizerLattice() = OptimizerLattice(SimpleInferenceLattice.instance)
 widenlattice(L::OptimizerLattice) = L.parent
 is_valid_lattice_norec(lattice::OptimizerLattice, @nospecialize(elem)) = isa(elem, MaybeUndef)
 

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -687,8 +687,14 @@ function find_dominating_assignment(id::Int, idx::Int, sv::InferenceState)
     return nothing
 end
 
-# annotate types of all symbols in AST
+# annotate types of all symbols in AST, preparing for optimization
 function type_annotate!(interp::AbstractInterpreter, sv::InferenceState, run_optimizer::Bool)
+    # widen `Conditional`s from `slottypes`
+    slottypes = sv.slottypes
+    for i = 1:length(slottypes)
+        slottypes[i] = widenconditional(slottypes[i])
+    end
+
     # compute the required type for each slot
     # to hold all of the items assigned into it
     record_slot_assign!(sv)

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -299,7 +299,7 @@ infer_compilation_signature(::NativeInterpreter) = true
 
 typeinf_lattice(::AbstractInterpreter) = InferenceLattice(BaseInferenceLattice.instance)
 ipo_lattice(::AbstractInterpreter) = InferenceLattice(IPOResultLattice.instance)
-optimizer_lattice(::AbstractInterpreter) = OptimizerLattice(BaseInferenceLattice.instance)
+optimizer_lattice(::AbstractInterpreter) = OptimizerLattice(SimpleInferenceLattice.instance)
 
 abstract type CallInfo end
 


### PR DESCRIPTION
Since `Conditional`s never appear within the optimization.

Also added a missing widening of `Conditional`s in `slottypes` (a.k.a.
`argtypes` in optimization) so that they never appear in the optimization.

@nanosoldier `runbenchmarks("inference", vs=":master")`