### PR TITLE
Don't inline into toplevel code.

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -576,7 +576,10 @@ function run_passes(
     @pass "slot2reg"  ir = slot2reg(ir, ci, sv)
     # TODO: Domsorting can produce an updated domtree - no need to recompute here
     @pass "compact 1" ir = compact!(ir)
-    @pass "Inlining"  ir = ssa_inlining_pass!(ir, sv.inlining, ci.propagate_inbounds)
+    # don't inline into toplevel code (which is much slower)
+    if isa(sv.linfo.def, Method)
+        @pass "Inlining"  ir = ssa_inlining_pass!(ir, sv.inlining, ci.propagate_inbounds)
+    end
     # @timeit "verify 2" verify_ir(ir)
     @pass "compact 2" ir = compact!(ir)
     @pass "SROA"      ir = sroa_pass!(ir, sv.inlining)

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -90,30 +90,40 @@ struct OptimizationParams
     assume_fatal_throw::Bool
 
     MAX_TUPLE_SPLAT::Int
-
-    function OptimizationParams(;
-            inlining::Bool = inlining_enabled(),
-            inline_cost_threshold::Int = 100,
-            inline_nonleaf_penalty::Int = 1000,
-            inline_tupleret_bonus::Int = 250,
-            inline_error_path_cost::Int = 20,
-            tuple_splat::Int = 32,
-            compilesig_invokes::Bool = true,
-            trust_inference::Bool = false,
-            assume_fatal_throw::Bool = false
-        )
-        return new(
-            inlining,
-            inline_cost_threshold,
-            inline_nonleaf_penalty,
-            inline_tupleret_bonus,
-            inline_error_path_cost,
-            compilesig_invokes,
-            trust_inference,
-            assume_fatal_throw,
-            tuple_splat,
-        )
-    end
+end
+function OptimizationParams(
+    params::OptimizationParams = OptimizationParams(
+        #=inlining=# inlining_enabled(),
+        #=inline_cost_threshold=# 100,
+        #=inline_nonleaf_penalty::Int=# 1000,
+        #=inline_tupleret_bonus::Int=# 250,
+        #=inline_error_path_cost::Int=# 20,
+        #=compilesig_invokes::Bool=# true,
+        #=trust_inference::Bool=# false,
+        #=assume_fatal_throw::Bool=# false,
+        #=MAX_TUPLE_SPLAT::Int=# 32
+        );
+    inlining::Bool = params.inlining,
+    inline_cost_threshold::Int = params.inline_cost_threshold,
+    inline_nonleaf_penalty::Int = params.inline_nonleaf_penalty,
+    inline_tupleret_bonus::Int = params.inline_tupleret_bonus,
+    inline_error_path_cost::Int = params.inline_error_path_cost,
+    compilesig_invokes::Bool = params.compilesig_invokes,
+    trust_inference::Bool = params.trust_inference,
+    assume_fatal_throw::Bool = params.assume_fatal_throw,
+    tuple_splat::Int = params.MAX_TUPLE_SPLAT,
+    )
+    return OptimizationParams(
+        inlining,
+        inline_cost_threshold,
+        inline_nonleaf_penalty,
+        inline_tupleret_bonus,
+        inline_error_path_cost,
+        compilesig_invokes,
+        trust_inference,
+        assume_fatal_throw,
+        tuple_splat,
+    )
 end
 
 """
@@ -146,28 +156,38 @@ struct InferenceParams
     # when attempting to inline _apply_iterate, abort the optimization if the
     # tuple contains more than this many elements
     MAX_TUPLE_SPLAT::Int
+end
 
-    function InferenceParams(;
-            ipo_constant_propagation::Bool = true,
-            aggressive_constant_propagation::Bool = false,
-            unoptimize_throw_blocks::Bool = true,
-            max_methods::Int = 3,
-            union_splitting::Int = 4,
-            apply_union_enum::Int = 8,
-            tupletype_depth::Int = 3,
-            tuple_splat::Int = 32,
-        )
-        return new(
-            ipo_constant_propagation,
-            aggressive_constant_propagation,
-            unoptimize_throw_blocks,
-            max_methods,
-            union_splitting,
-            apply_union_enum,
-            tupletype_depth,
-            tuple_splat,
-        )
-    end
+function InferenceParams(
+    params::InferenceParams = InferenceParams(
+        #=ipo_constant_propagation::Bool=# true,
+        #=aggressive_constant_propagation::Bool=# false,
+        #=unoptimize_throw_blocks::Bool=# true,
+        #=max_methods::Int=# 3,
+        #=union_splitting::Int=# 4,
+        #=apply_union_enum::Int=# 8,
+        #=tupletype_depth::Int=# 3,
+        #=tuple_splat::Int=# 32,
+        );
+    ipo_constant_propagation::Bool = params.ipo_constant_propagation,
+    aggressive_constant_propagation::Bool = params.aggressive_constant_propagation,
+    unoptimize_throw_blocks::Bool = params.unoptimize_throw_blocks,
+    max_methods::Int = params.MAX_METHODS,
+    union_splitting::Int = params.MAX_UNION_SPLITTING,
+    apply_union_enum::Int = params.MAX_APPLY_UNION_ENUM,
+    tupletype_depth::Int = params.TUPLE_COMPLEXITY_LIMIT_DEPTH,
+    tuple_splat::Int = params.MAX_TUPLE_SPLAT,
+    )
+    return InferenceParams(
+        ipo_constant_propagation,
+        aggressive_constant_propagation,
+        unoptimize_throw_blocks,
+        max_methods,
+        union_splitting,
+        apply_union_enum,
+        tupletype_depth,
+        tuple_splat,
+    )
 end
 
 """


### PR DESCRIPTION
After #42556 and #45550, code executed at top level is much slower because of atomic barriers being emitted between every instruction.

Fixes https://github.com/JuliaLang/julia/issues/47561, where this manifested because of the `@force_compile` (where previously we'd just have interpreted the `@time` harness).

I wanted to add a test, but wasn't sure how to get the IR that's emitted for toplevel code. Any ideas?