### PR TITLE
Improve performance of atomic load in toplevel code

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7787,10 +7787,11 @@ static jl_llvm_functions_t
         }
         else {
             if (!jl_is_method(ctx.linfo->def.method) && !ctx.is_opaque_closure) {
+                // we're at toplevel; insert an atomic barrier between every instruction
                 // TODO: inference is invalid if this has any effect (which it often does)
                 LoadInst *world = ctx.builder.CreateAlignedLoad(getSizeTy(ctx.builder.getContext()),
                     prepare_global_in(jl_Module, jlgetworld_global), Align(sizeof(size_t)));
-                world->setOrdering(AtomicOrdering::Acquire);
+                world->setOrdering(AtomicOrdering::Monotonic);
                 ctx.builder.CreateAlignedStore(world, world_age_field, Align(sizeof(size_t)));
             }
             emit_stmtpos(ctx, stmt, cursor);


### PR DESCRIPTION
As noted in https://github.com/JuliaLang/julia/issues/47561, the performance of toplevel code is pretty bad because of the atomic barrier (loading the global world age into the task-local one) that's emitted after every instruction now. @vtjnash noted that monotonic ordering is sufficient, which recovers some performance (1.5s -> 0.7s). But the biggest improvement comes from not emitting the atomic operation between every statement, but only when we perform a call.

Fixes https://github.com/JuliaLang/julia/pull/47561