### PR TITLE
ensure bindings handle write barriers for ty and globalref

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1252,6 +1252,7 @@ JL_CALLABLE(jl_f_set_binding_type)
         jl_errorf("cannot set type for global %s. It already has a value or is already set to a different type.",
                   jl_symbol_name(b->name));
     }
+    jl_gc_wb_binding(b, ty);
     return jl_nothing;
 }
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -3203,8 +3203,17 @@ static void jl_gc_queue_remset(jl_gc_mark_cache_t *gc_cache, jl_gc_mark_sp_t *sp
         jl_binding_t *ptr = (jl_binding_t*)items[i];
         // A null pointer can happen here when the binding is cleaned up
         // as an exception is thrown after it was already queued (#10221)
+        int bnd_refyoung = 0;
         jl_value_t *v = jl_atomic_load_relaxed(&ptr->value);
-        if (v != NULL && gc_mark_queue_obj(gc_cache, sp, v)) {
+        if (v != NULL && gc_mark_queue_obj(gc_cache, sp, v))
+            bnd_refyoung = 1;
+        jl_value_t *ty = jl_atomic_load_relaxed(&ptr->ty);
+        if (ty != NULL && gc_mark_queue_obj(gc_cache, sp, ty))
+            bnd_refyoung = 1;
+        jl_value_t *globalref = jl_atomic_load_relaxed(&ptr->globalref);
+        if (globalref != NULL && gc_mark_queue_obj(gc_cache, sp, globalref))
+            bnd_refyoung = 1;
+        if (bnd_refyoung) {
             items[n_bnd_refyoung] = ptr;
             n_bnd_refyoung++;
         }

--- a/src/module.c
+++ b/src/module.c
@@ -449,7 +449,7 @@ JL_DLLEXPORT jl_value_t *jl_module_globalref(jl_module_t *m, jl_sym_t *var)
         if (jl_atomic_cmpswap_relaxed(&b->globalref, &globalref, newref)) {
             JL_GC_PROMISE_ROOTED(newref);
             globalref = newref;
-            jl_gc_wb(m, globalref);
+            jl_gc_wb_binding(b, globalref);
         }
     }
     JL_UNLOCK(&m->lock); // may GC


### PR DESCRIPTION
This has probably been wrong for a long time (since being introduced in 79082468986). Just noticed it during routine code reading, so I have no examples of misbehavior from it.