### PR TITLE
Doc: improve @(s)printf docstrings

### DIFF
--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -911,6 +911,10 @@ Use shorter of decimal or scientific 1.23 1.23e+07
 For a systematic specification of the format, see [here](https://www.cplusplus.com/reference/cstdio/printf/).
 See also [`@sprintf`](@ref) to get the result as a `String` instead of it being printed.
 
+If you need to use a programmatically generated format string, use
+`print(Printf.format(Printf.Format(format_string), args...))` instead.
+See [`Printf.format`](@ref) for more details.
+
 # Caveats
 `Inf` and `NaN` are printed consistently as `Inf` and `NaN` for flags `%a`, `%A`,
 `%e`, `%E`, `%f`, `%F`, `%g`, and `%G`. Furthermore, if a floating point number is
@@ -950,6 +954,10 @@ end
     @sprintf("%Fmt", args...)
 
 Return [`@printf`](@ref) formatted output as string.
+
+If you need to use a programmatically generated format string, use
+`Printf.format(Printf.Format(format_string), args...)` instead.
+See [`Printf.format`](@ref) for more details.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
I just ran into `@(s)printf` only accepting string literals as first argument again, and it took me finding https://discourse.julialang.org/t/is-this-sprintf-annoying-behaviour-intended/68483/7 to figure out how to get what I want to work. I would have found it helpful if the `@sprintf` docstring already pointed to the solution, which is what this PR intends to add.