### PR TITLE
LinearAlgebra: Speed up the trace function

### DIFF
--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -414,6 +414,9 @@ switch_dim12(B::AbstractArray) = PermutedDimsArray(B, (2, 1, ntuple(Base.Fix1(+,
 (-)(A::Adjoint)   = Adjoint(  -A.parent)
 (-)(A::Transpose) = Transpose(-A.parent)
 
+tr(A::Adjoint) = adjoint(tr(parent(A)))
+tr(A::Transpose) = transpose(tr(parent(A)))
+
 ## multiplication *
 
 function _dot_nonrecursive(u, v)

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -208,6 +208,8 @@ convert(::Type{T}, m::AbstractMatrix) where {T<:Bidiagonal} = m isa T ? m : T(m)
 similar(B::Bidiagonal, ::Type{T}) where {T} = Bidiagonal(similar(B.dv, T), similar(B.ev, T), B.uplo)
 similar(B::Bidiagonal, ::Type{T}, dims::Union{Dims{1},Dims{2}}) where {T} = zeros(T, dims...)
 
+tr(B::Bidiagonal) = sum(B.dv)
+
 function kron(A::Diagonal, B::Bidiagonal)
     # `_droplast!` is only guaranteed to work with `Vector`
     kdv = _makevector(kron(diag(A), B.dv))

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -344,7 +344,7 @@ diagm(m::Integer, n::Integer, v::AbstractVector) = diagm(m, n, 0 => v)
 function tr(A::Matrix{T}) where T
     n = checksquare(A)
     t = zero(T)
-    for i=1:n
+    @inbounds @simd for i in 1:n
         t += A[i,i]
     end
     t

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -363,6 +363,7 @@ Base.copy(A::Adjoint{<:Any,<:Symmetric}) =
 Base.copy(A::Transpose{<:Any,<:Hermitian}) =
     Hermitian(copy(transpose(A.parent.data)), ifelse(A.parent.uplo == 'U', :L, :U))
 
+tr(A::Symmetric) = tr(A.data) # to avoid AbstractMatrix fallback (incl. allocations)
 tr(A::Hermitian) = real(tr(A.data))
 
 Base.conj(A::HermOrSym) = typeof(A)(conj(A.data), A.uplo)

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -428,6 +428,11 @@ function -(A::UnitUpperTriangular)
     UpperTriangular(Anew)
 end
 
+tr(A::LowerTriangular) = tr(A.data)
+tr(A::UnitLowerTriangular) = size(A, 1) * oneunit(eltype(A))
+tr(A::UpperTriangular) = tr(A.data)
+tr(A::UnitUpperTriangular) = size(A, 1) * oneunit(eltype(A))
+
 # copy and scale
 function copyto!(A::T, B::T) where T<:Union{UpperTriangular,UnitUpperTriangular}
     n = size(B,1)

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -172,6 +172,8 @@ Base.copy(S::Adjoint{<:Any,<:SymTridiagonal}) = SymTridiagonal(map(x -> copy.(ad
 ishermitian(S::SymTridiagonal) = isreal(S.dv) && isreal(_evview(S))
 issymmetric(S::SymTridiagonal) = true
 
+tr(S::SymTridiagonal) = sum(S.dv)
+
 function diag(M::SymTridiagonal{T}, n::Integer=0) where T<:Number
     # every branch call similar(..., ::Int) to make sure the
     # same vector type is returned independent of n
@@ -746,6 +748,8 @@ function triu!(M::Tridiagonal{T}, k::Integer=0) where T
     end
     return M
 end
+
+tr(M::Tridiagonal) = sum(T.d)
 
 ###################
 # Generic methods #

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -749,7 +749,7 @@ function triu!(M::Tridiagonal{T}, k::Integer=0) where T
     return M
 end
 
-tr(M::Tridiagonal) = sum(T.d)
+tr(M::Tridiagonal) = sum(M.d)
 
 ###################
 # Generic methods #

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -636,4 +636,11 @@ end
     @test mapreduce(string, *, [1 2; 3 4]') == mapreduce(string, *, copy([1 2; 3 4]')) == "1234"
 end
 
+@testset "trace" begin
+    for T in (Float64, ComplexF64), t in (adjoint, transpose)
+        A = randn(T, 10, 10)
+        @test tr(t(A)) == tr(copy(t(A))) == t(tr(A))
+    end
+end
+
 end # module TestAdjointTranspose

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -218,6 +218,13 @@ Random.seed!(1)
             end
         end
 
+        @testset "iszero and isone, trace" begin
+            for uplo in (:U, :L)
+                B = Bidiagonal(dv, ev, uplo)
+                @test tr(B) ≈ tr(Matrix(B)) rtol=2eps(eltype(B))
+            end
+        end
+
         Tfull = Array(T)
         @testset "Linear solves" begin
             if relty <: AbstractFloat

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -218,7 +218,7 @@ Random.seed!(1)
             end
         end
 
-        @testset "iszero and isone, trace" begin
+        @testset "trace" begin
             for uplo in (:U, :L)
                 B = Bidiagonal(dv, ev, uplo)
                 @test tr(B) ≈ tr(Matrix(B)) rtol=2eps(eltype(B))

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -221,7 +221,7 @@ Random.seed!(1)
         @testset "trace" begin
             for uplo in (:U, :L)
                 B = Bidiagonal(dv, ev, uplo)
-                @test tr(B) ≈ tr(Matrix(B)) rtol=2eps(eltype(B))
+                @test tr(B) ≈ tr(Matrix(B)) rtol=2eps(real(eltype(B)))
             end
         end
 

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -221,7 +221,11 @@ Random.seed!(1)
         @testset "trace" begin
             for uplo in (:U, :L)
                 B = Bidiagonal(dv, ev, uplo)
-                @test tr(B) ≈ tr(Matrix(B)) rtol=2eps(real(eltype(B)))
+                if relty <: Integer
+                    @test tr(B) == tr(Matrix(B))
+                else
+                    @test tr(B) ≈ tr(Matrix(B)) rtol=2eps(relty)
+                end
             end
         end
 

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -169,6 +169,9 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
         # diag
         @test diag(A1) == diag(Matrix(A1))
 
+        # tr
+        @test tr(A1)::elty1 == tr(parent(A1))
+
         # real
         @test real(A1) == real(Matrix(A1))
         @test imag(A1) == imag(Matrix(A1))

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -170,7 +170,7 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
         @test diag(A1) == diag(Matrix(A1))
 
         # tr
-        @test tr(A1)::elty1 == tr(parent(A1))
+        @test tr(A1)::elty1 == tr(Matrix(A1))
 
         # real
         @test real(A1) == real(Matrix(A1))

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -264,7 +264,7 @@ end
             @test (@inferred diag(GA, -1))::typeof(GenericArray(d)) == GenericArray(dl)
         end
         @testset "trace" begin
-            @test tr(A) ≈ tr(fA) rtol=2eps(eltype(A))
+            @test tr(A) ≈ tr(fA) rtol=2eps(real(eltype(A)))
         end
         @testset "Idempotent tests" begin
             for func in (conj, transpose, adjoint)

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -264,7 +264,11 @@ end
             @test (@inferred diag(GA, -1))::typeof(GenericArray(d)) == GenericArray(dl)
         end
         @testset "trace" begin
-            @test tr(A) ≈ tr(fA) rtol=2eps(real(eltype(A)))
+            if real(elty) <: Integer
+                @test tr(A) == tr(fA)
+            else
+                @test tr(A) ≈ tr(fA) rtol=2eps(real(elty))
+            end
         end
         @testset "Idempotent tests" begin
             for func in (conj, transpose, adjoint)

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -263,6 +263,9 @@ end
             @test (@inferred diag(GA))::typeof(GenericArray(d)) == GenericArray(d)
             @test (@inferred diag(GA, -1))::typeof(GenericArray(d)) == GenericArray(dl)
         end
+        @testset "trace" begin
+            @test tr(A) ≈ tr(fA) rtol=2eps(eltype(A))
+        end
         @testset "Idempotent tests" begin
             for func in (conj, transpose, adjoint)
                 @test func(func(A)) == A


### PR DESCRIPTION
The annotations should be safe. For me, this speeds up the computation by a factor of 2. It's not entirely clear why switching to `for i in diagind(A) t += A[i] end` doesn't improve the performance, but makes it a tiny bit worse.