### PR TITLE
Introduces get-lld to fix `make full-source-dist USE_BINARYBUILDER=0`

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -314,4 +314,5 @@ $(eval $(call bb-install,llvm-tools,LLVM_TOOLS,false,true))
 
 endif # USE_BINARYBUILDER_LLVM
 
+get-lld: get-llvm
 install-lld install-clang install-llvm-tools: install-llvm


### PR DESCRIPTION
This aims to fix #47584. There are no extra sources for `lld` because it's compiled as part of llvm. In the original PR, I've tested only `make USE_BINARYBUILDER=0`.