### PR TITLE
Fix regression in generic_bitcast with Union{} arguments.

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -509,6 +509,9 @@ static jl_cgval_t generic_bitcast(jl_codectx_t &ctx, const jl_cgval_t *argv)
     bool isboxed;
     Type *vxt = julia_type_to_llvm(ctx, v.typ, &isboxed);
 
+    if (v.typ == jl_bottom_type)
+        return jl_cgval_t();
+
     if (!jl_is_primitivetype(v.typ) || jl_datatype_size(v.typ) != nb) {
         Value *typ = emit_typeof_boxed(ctx, v);
         if (!jl_is_primitivetype(v.typ)) {

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -785,3 +785,8 @@ f_isa_type(@nospecialize(x)) = isa(x, Type)
 # Issue #47247
 f47247(a::Ref{Int}, b::Nothing) = setfield!(a, :x, b)
 @test_throws TypeError f47247(Ref(5), nothing)
+
+@testset "regression in generic_bitcast: should support Union{} values" begin
+    f(x) = Core.bitcast(UInt64, x)
+    @test occursin("llvm.trap", get_llvm(f, Tuple{Union{}}))
+end


### PR DESCRIPTION
#47170 introduced a regression with bitcasts of error values (i.e. `::Union{}`), resulting in a failed assertion/segfault:

```julia
julia> f(x) = Core.bitcast(UInt64, x)
f (generic function with 1 method)

julia> code_llvm(f, Type{Union{}})
julia-debug: /home/tim/Julia/src/julia/src/intrinsics.cpp:536: jl_cgval_t generic_bitcast(jl_codectx_t&, const jl_cgval_t*): Assertion `!v.isghost' failed.

[730343] signal (6): Aborted
in expression starting at REPL[2]:1
unknown function (ip: 0x7fb345c8c64c)
gsignal at /usr/lib/libc.so.6 (unknown line)
abort at /usr/lib/libc.so.6 (unknown line)
unknown function (ip: 0x7fb345c2645b)
__assert_fail at /usr/lib/libc.so.6 (unknown line)
generic_bitcast at /home/tim/Julia/src/julia/src/intrinsics.cpp:536
```

This manifested on PkgEval in the testing of ANOVAapprox.jl (as well as Gtk.jl, and probably others), https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_date/2022-11/15/ANOVAapprox.primary.log, which contains code like:

```julia
struct Foo
    bar::Int32
end

function Base.getproperty(obj::Foo, field::Symbol)
    if field == :whatever
        unsafe_wrap(Vector{Float64}, ptr, obj.bar)
    elseif field == :return
        ccall(:jl_breakpoint, Int64, ())
    else
        getfield(obj, field)
    end
end
```

Compiling this results in essentially:

```
%4 = Main.getfield(_2, :bar)::Int32
%32 = π (%4, Int64)
%40 = bitcast(UInt64, %32)
```

... where inference thinks that %32 produces a Int64, but during codegen it turns out that `π (%4::Int32, Int64)` produces `Union{}` (as determined by `convert_julia_type`) which then crashes `bitcast` as seen above.