### PR TITLE
Enable coredumps on Windows

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1300,7 +1300,7 @@ endif
 ifeq ($(OS), WINNT)
 HAVE_SSP := 1
 OSLIBS += -Wl,--export-all-symbols -Wl,--version-script=$(JULIAHOME)/src/julia.expmap \
-	$(NO_WHOLE_ARCHIVE) -lpsapi -lkernel32 -lws2_32 -liphlpapi -lwinmm -ldbghelp -luserenv -lsecur32 -latomic -ldbghelp -lshell32 -lole32 -luuid
+	$(NO_WHOLE_ARCHIVE) -lpsapi -lkernel32 -lws2_32 -liphlpapi -lwinmm -ldbghelp -luserenv -lsecur32 -latomic -lshell32 -lole32 -luuid
 JLDFLAGS += -Wl,--stack,8388608
 ifeq ($(ARCH),i686)
 JLDFLAGS += -Wl,--large-address-aware

--- a/Make.inc
+++ b/Make.inc
@@ -1300,7 +1300,7 @@ endif
 ifeq ($(OS), WINNT)
 HAVE_SSP := 1
 OSLIBS += -Wl,--export-all-symbols -Wl,--version-script=$(JULIAHOME)/src/julia.expmap \
-	$(NO_WHOLE_ARCHIVE) -lpsapi -lkernel32 -lws2_32 -liphlpapi -lwinmm -ldbghelp -luserenv -lsecur32 -latomic
+	$(NO_WHOLE_ARCHIVE) -lpsapi -lkernel32 -lws2_32 -liphlpapi -lwinmm -ldbghelp -luserenv -lsecur32 -latomic -ldbghelp -lshell32 -lole32 -luuid
 JLDFLAGS += -Wl,--stack,8388608
 ifeq ($(ARCH),i686)
 JLDFLAGS += -Wl,--large-address-aware


### PR DESCRIPTION
This commit provides two pieces; first, it enables building libuv with `SIGQUIT` support on Windows (useful for [0]), and second it enables coredumping when exceptions are hit, after our exception handler has finished printing out a backtrace.  This is useful for using WER to create dump files when we segfault, etc...

This commit requires libuv PRs [1] and [2] to properly function.

[0] https://github.com/JuliaLang/julia/pull/45864
[1] https://github.com/JuliaLang/libuv/pull/30
[2] https://github.com/JuliaLang/libuv/pull/31