### PR TITLE
Cleanup: Use `issingletontype` consistently

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1671,7 +1671,7 @@ end
 @inline function egal_condition(c::Const, @nospecialize(xt), max_union_splitting::Int)
     thentype = c
     elsetype = widenslotwrapper(xt)
-    if elsetype isa Type && isdefined(typeof(c.val), :instance) # can only widen a if it is a singleton
+    if elsetype isa Type && issingletontype(typeof(c.val)) # can only widen a if it is a singleton
         elsetype = typesubtract(elsetype, typeof(c.val), max_union_splitting)
     end
     return ConditionalTypes(thentype, elsetype)

--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -151,7 +151,7 @@ function most_general_argtypes(method::Union{Method, Nothing}, @nospecialize(spe
                 end
                 for i in 1:length(vargtype_elements)
                     atyp = vargtype_elements[i]
-                    if isa(atyp, DataType) && isdefined(atyp, :instance)
+                    if issingletontype(atyp)
                         # replace singleton types with their equivalent Const object
                         vargtype_elements[i] = Const(atyp.instance)
                     elseif isconstType(atyp)
@@ -180,7 +180,7 @@ function most_general_argtypes(method::Union{Method, Nothing}, @nospecialize(spe
                 tail_index -= 1
             end
             atyp = unwraptv(atyp)
-            if isa(atyp, DataType) && isdefined(atyp, :instance)
+            if issingletontype(atyp)
                 # replace singleton types with their equivalent Const object
                 atyp = Const(atyp.instance)
             elseif isconstType(atyp)

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -253,8 +253,8 @@ function egal_tfunc(::ConstsLattice, @nospecialize(x), @nospecialize(y))
         return Const(x.val === y.val)
     elseif !hasintersect(widenconst(x), widenconst(y))
         return Const(false)
-    elseif (isa(x, Const) && y === typeof(x.val) && isdefined(y, :instance)) ||
-           (isa(y, Const) && x === typeof(y.val) && isdefined(x, :instance))
+    elseif (isa(x, Const) && y === typeof(x.val) && issingletontype(x)) ||
+           (isa(y, Const) && x === typeof(y.val) && issingletontype(y))
         return Const(true)
     end
     return Bool
@@ -1753,7 +1753,7 @@ function tuple_tfunc(@specialize(lattice::AbstractLattice), argtypes::Vector{Any
     end
     typ = Tuple{params...}
     # replace a singleton type with its equivalent Const object
-    isdefined(typ, :instance) && return Const(typ.instance)
+    issingletontype(typ) && return Const(typ.instance)
     return anyinfo ? PartialStruct(typ, argtypes) : typ
 end
 tuple_tfunc(argtypes::Vector{Any}) = tuple_tfunc(fallback_lattice, argtypes)

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -493,7 +493,7 @@ function ⊑(lattice::ConstsLattice, @nospecialize(a), @nospecialize(b))
         # most conservative option.
         return isa(b, Type) && isa(a.val, b)
     elseif isa(b, Const)
-        if isa(a, DataType) && isdefined(a, :instance)
+        if issingletontype(a)
             return a.instance === b.val
         end
         return false

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -55,7 +55,7 @@ function has_nontrivial_const_info(lattice::ConstsLattice, @nospecialize t)
     isa(t, PartialTypeVar) && return true
     if isa(t, Const)
         val = t.val
-        return !isdefined(typeof(val), :instance) && !(isa(val, Type) && hasuniquerep(val))
+        return !issingletontype(typeof(val)) && !(isa(val, Type) && hasuniquerep(val))
     end
     return has_nontrivial_const_info(widenlattice(lattice), t)
 end

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -296,7 +296,7 @@ function singleton_type(@nospecialize(ft))
         return ft.val
     elseif isconstType(ft)
         return ft.parameters[1]
-    elseif ft isa DataType && isdefined(ft, :instance)
+    elseif issingletontype(ft)
         return ft.instance
     end
     return nothing
@@ -304,7 +304,7 @@ end
 
 function maybe_singleton_const(@nospecialize(t))
     if isa(t, DataType)
-        if isdefined(t, :instance)
+        if issingletontype(t)
             return Const(t.instance)
         elseif isconstType(t)
             return Const(t.parameters[1])

--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -77,7 +77,7 @@ end
 (ss::SummarySize)(@nospecialize obj) = _summarysize(ss, obj)
 # define the general case separately to make sure it is not specialized for every type
 @noinline function _summarysize(ss::SummarySize, @nospecialize obj)
-    isdefined(typeof(obj), :instance) && return 0
+    issingletontype(typeof(obj)) && return 0
     # NOTE: this attempts to discover multiple copies of the same immutable value,
     # and so is somewhat approximate.
     key = ccall(:jl_value_ptr, Ptr{Cvoid}, (Any,), obj)

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1323,7 +1323,7 @@ function deserialize_typename(s::AbstractSerializer, number)
         tn.max_methods = maxm
         if has_instance
             ty = ty::DataType
-            if !isdefined(ty, :instance)
+            if !Base.issingletontype(ty)
                 singleton = ccall(:jl_new_struct, Any, (Any, Any...), ty)
                 # use setfield! directly to avoid `fieldtype` lowering expecting to see a Singleton object already on ty
                 ccall(:jl_set_nth_field, Cvoid, (Any, Csize_t, Any), ty, Base.fieldindex(DataType, :instance)-1, singleton)

--- a/test/compiler/contextual.jl
+++ b/test/compiler/contextual.jl
@@ -70,7 +70,7 @@ module MiniCassette
     end
 
     function overdub_generator(self, c, f, args)
-        if !isdefined(f, :instance)
+        if !Base.issingletontype(f)
             return :(return f(args...))
         end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -4870,8 +4870,8 @@ end
 let a = Val{Val{TypeVar(:_, Int)}},
     b = Val{Val{x} where x<:Int}
 
-    @test !isdefined(a, :instance)
-    @test  isdefined(b, :instance)
+    @test !Base.issingletontype(a)
+    @test  Base.issingletontype(b)
     @test Base.isconcretetype(b)
 end
 


### PR DESCRIPTION
Rather than reaching for `isdefined(x, :instance)`. They are currently equivalent, but I was playing with an extension that would have made them not be. I don't currently have plans to finish that particular PR, but this cleanup seems good regardless to specify exactly what is meant rather than reaching for the implementation.