### PR TITLE
Extend `startswith`, `endswith` to iterable collections

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -1374,3 +1374,50 @@ function _simple_count(::typeof(identity), x::Array{Bool}, init::T=0) where {T}
     end
     return n
 end
+
+"""
+    startswith(target, prefix)
+
+Simultaneously iterate both arguments until they disagree or one of them is exhausted;
+if they disagree or `target` is exhausted first, return `false`; if `prefix` is exhausted
+before or at the same time as `target` and they never disagree, return `true`.
+
+Results are well-defined for ordered collections only.
+
+# Examples
+```jldoctest
+julia> startswith((1,2,3), (1,2))
+true
+```
+"""
+function startswith(target, prefix)
+    length(prefix) > length(target) && return false
+    for (a, b) ∈ zip(target, prefix)
+        isequal(a, b) || return false
+    end
+    true
+end
+
+"""
+    endswith(target, suffix)
+
+Simultaneously iterate (in reverse order) both arguments until they disagree or one of
+them is exhausted; if they disagree or `target` is exhausted first, return `false`;
+if `prefix` is exhausted before or at the same time as `target` and they never disagree,
+return `true`.
+
+Results are well-defined for ordered collections only.
+
+# Examples
+```jldoctest
+julia> endswith((1,2,3), (2,3))
+true
+```
+"""
+function endswith(target, suffix)
+    length(suffix) > length(target) && return false
+    for (a, b) ∈ Iterators.reverse(zip(target, suffix))
+        isequal(a, b) || return false
+    end
+    true
+end

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -691,3 +691,60 @@ end
     @test @inferred(prod(b)) == prod(collect(b))
     @test @inferred(minimum(a)) == minimum(collect(a))
 end
+
+# startswith, endswith
+@testset "startswith, arbitrary iterables" begin
+    @test startswith(1.0, 1)
+    @test startswith([1,2,3], [1,2])
+    @test startswith(0.0:0.5:2.5, 0.0:0.5:1.5)
+
+    # various types, nothing and missing
+    @test startswith([NaN, missing, nothing], (NaN, missing))
+    @inferred startswith((NaN, missing, nothing), (NaN, missing, 1))
+    @inferred startswith((NaN, missing, nothing), [NaN, missing, nothing, 1])
+    @test startswith((nothing, missing, missing, 1), (nothing, missing))
+
+    # arrays
+    @test startswith(trues(4), [true, true])
+    @test !startswith(trues(1), [true, true])
+    @test !startswith((), ((), ()))
+
+    # etc
+    a = zip((1,2,3), (4,5,6))
+    b = ((1, 4), (2, 5))
+    @test startswith(a, b)
+    @test startswith(['w', 'o', 'r', 'l', 'd'], "wo")
+    @test !startswith(['w', 'o', 'r', 'l', 'd'], "worlds")
+    @test startswith([0x1, 0x2, 0x3], 1)
+end
+@testset "endswith, arbitrary iterables" begin
+    @test endswith(1.0, 1)
+    @test endswith([1,2,3], [2,3])
+    @test endswith(0.0:0.5:2.5, 1.5:0.5:2.5)
+
+    # un-ordered collections do not have well-defined reverse, hence, throw
+    d = Dict(i => i + 1 for i = 1:3)
+    ps = [2 => 3, 3 => 4]
+    @test_throws MethodError endswith(d, ps)
+    @test_throws MethodError endswith(d, Set(ps))
+
+    # nothing and missing
+    # various types, nothing and missing
+    @test endswith([NaN, missing, nothing, Inf], (missing, nothing, Inf))
+    @inferred endswith((NaN, missing, nothing), (NaN, missing, 1))
+    @inferred endswith((NaN, missing, nothing), [NaN, missing, nothing, 1])
+    @test endswith((nothing, missing, missing, 1), (missing, 1))
+
+    # arrays
+    @test endswith(trues(4), [true, true])
+    @test !endswith(trues(1), [true, true])
+    @test !endswith((), ((), ()))
+
+    # etc
+    a = zip((1,2,3), (4,5,6))
+    b = ((2, 5), (3, 6))
+    @test endswith(a, b)
+    @test endswith(["these", "are", "words"], ("words",))
+    @test endswith(['h', 'e', 'l', 'l', 'o'], "ello")
+    @test endswith([0x1, 0x2, 0x3], 3.0f0)
+end


### PR DESCRIPTION
The impetus for this was @StefanKarpinski 's comment on #47219, reproduced below.

> `startswith(target, prefix)` can work with arbitrary iterables: iterate
> both arguments in parallel until they disagree or one of them is done;
> if they disagree or `target` ends first, return false; if `prefix` ends
> before or at the same time as `target` and they never disagree, return true.

It achieves clarity and is precise; a minor re-phrasing serves as an excellent docstring.

We reverse the order of iteration and obtain `endswith(target, suffix)`.

- collections lacking explicit order (sets, dicts, etc.) are not handled
- arrays may benefit from specialized methods
- heterogeneous tuples are not type stable, but return type is stable
- should all arrays be treated as flat iterables?
- `dims` kwarg?

Community opinion solicited!