### PR TITLE
improve type stability of `[hcat|vcat](arrays::Vector{T}...) where T`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1918,9 +1918,6 @@ end
 
 # concatenations of homogeneous combinations of vectors, horizontal and vertical
 
-vcat() = Vector{Any}()
-hcat() = Vector{Any}()
-
 function hcat(V::Vector{T}...) where T
     height = length(V[1])
     for j = 2:length(V)
@@ -1928,7 +1925,8 @@ function hcat(V::Vector{T}...) where T
             throw(DimensionMismatch("vectors must have same lengths"))
         end
     end
-    return [ V[j][i]::T for i=1:length(V[1]), j=1:length(V) ]
+    T′ = @isdefined(T) ? T : Any # edge case: empty input
+    return [ V[j][i]::T′ for i=1:length(V[1]), j=1:length(V) ]
 end
 
 function vcat(arrays::Vector{T}...) where T
@@ -1936,7 +1934,8 @@ function vcat(arrays::Vector{T}...) where T
     for a in arrays
         n += length(a)
     end
-    arr = Vector{T}(undef, n)
+    T′ = @isdefined(T) ? T : Any # edge case: empty input
+    arr = Vector{T′}(undef, n)
     nd = 1
     for a in arrays
         na = length(a)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -3075,3 +3075,11 @@ end
         @test c + zero(c) == c
     end
 end
+
+# https://github.com/aviatesk/JET.jl/issues/413
+function jet413(idx)
+    N = 4
+    indices_flat = [idx...;]
+    Int[i for i=1:N if i ∉ indices_flat]
+end
+@inferred jet413([[1,2], [3]])


### PR DESCRIPTION
We can delete the `[vcat|hcat]() = Any[]` methods and get more type stability for calls like
`Core._apply_iterate(Base.iterate, Base.vcat, ::Vector{Vector{Int}}))`. This change is backward compat since `[vcat|hcat]()` still returns `Any[]`.