### PR TITLE
Add an option to not run compiler in IR2OC

### DIFF
--- a/base/opaque_closure.jl
+++ b/base/opaque_closure.jl
@@ -58,7 +58,8 @@ end
 function Core.OpaqueClosure(ir::IRCode, env...;
         nargs::Int = length(ir.argtypes)-1,
         isva::Bool = false,
-        rt = compute_ir_rettype(ir))
+        rt = compute_ir_rettype(ir),
+        do_compile::Bool = true)
     if (isva && nargs > length(ir.argtypes)) || (!isva && nargs != length(ir.argtypes)-1)
         throw(ArgumentError("invalid argument count"))
     end
@@ -71,14 +72,14 @@ function Core.OpaqueClosure(ir::IRCode, env...;
     src.inferred = true
     # NOTE: we need ir.argtypes[1] == typeof(env)
 
-    ccall(:jl_new_opaque_closure_from_code_info, Any, (Any, Any, Any, Any, Any, Cint, Any, Cint, Cint, Any),
-        compute_oc_argtypes(ir, nargs, isva), Union{}, rt, @__MODULE__, src, 0, nothing, nargs, isva, env)
+    ccall(:jl_new_opaque_closure_from_code_info, Any, (Any, Any, Any, Any, Any, Cint, Any, Cint, Cint, Any, Cint),
+        compute_oc_argtypes(ir, nargs, isva), Union{}, rt, @__MODULE__, src, 0, nothing, nargs, isva, env, do_compile)
 end
 
 function Core.OpaqueClosure(src::CodeInfo, env...)
     M = src.parent.def
     sig = Base.tuple_type_tail(src.parent.specTypes)
 
-    ccall(:jl_new_opaque_closure_from_code_info, Any, (Any, Any, Any, Any, Any, Cint, Any, Cint, Cint, Any),
-          sig, Union{}, src.rettype, @__MODULE__, src, 0, nothing, M.nargs - 1, M.isva, env)
+    ccall(:jl_new_opaque_closure_from_code_info, Any, (Any, Any, Any, Any, Any, Cint, Any, Cint, Cint, Any, Cint),
+          sig, Union{}, src.rettype, @__MODULE__, src, 0, nothing, M.nargs - 1, M.isva, env, true)
 end

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -300,7 +300,7 @@ static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
             argv[i] = eval_value(args[i], s);
         JL_NARGSV(new_opaque_closure, 4);
         jl_value_t *ret = (jl_value_t*)jl_new_opaque_closure((jl_tupletype_t*)argv[0], argv[1], argv[2],
-            argv[3], argv+4, nargs-4);
+            argv[3], argv+4, nargs-4, 1);
         JL_GC_POP();
         return ret;
     }

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -744,7 +744,7 @@ JL_DLLEXPORT jl_value_t *jl_as_global_root(jl_value_t *val JL_MAYBE_UNROOTED);
 int jl_compile_extern_c(LLVMOrcThreadSafeModuleRef llvmmod, void *params, void *sysimg, jl_value_t *declrt, jl_value_t *sigt);
 
 jl_opaque_closure_t *jl_new_opaque_closure(jl_tupletype_t *argt, jl_value_t *rt_lb, jl_value_t *rt_ub,
-    jl_value_t *source,  jl_value_t **env, size_t nenv);
+    jl_value_t *source,  jl_value_t **env, size_t nenv, int do_compile);
 JL_DLLEXPORT int jl_is_valid_oc_argtype(jl_tupletype_t *argt, jl_method_t *source);
 
 // Each tuple can exist in one of 4 Vararg states:

--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -38,7 +38,7 @@ static jl_value_t *prepend_type(jl_value_t *t0, jl_tupletype_t *t)
 }
 
 static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t *rt_lb, jl_value_t *rt_ub,
-    jl_value_t *source_, jl_value_t *captures)
+    jl_value_t *source_, jl_value_t *captures, int do_compile)
 {
     if (!jl_is_tuple_type((jl_value_t*)argt)) {
         jl_error("OpaqueClosure argument tuple must be a tuple type");
@@ -65,7 +65,9 @@ static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t 
 
     jl_method_instance_t *mi = jl_specializations_get_linfo(source, sigtype, jl_emptysvec);
     size_t world = jl_atomic_load_acquire(&jl_world_counter);
-    jl_code_instance_t *ci = jl_compile_method_internal(mi, world);
+    jl_code_instance_t *ci = NULL;
+    if (do_compile)
+        ci = jl_compile_method_internal(mi, world);
 
     jl_task_t *ct = jl_current_task;
     jl_opaque_closure_t *oc = (jl_opaque_closure_t*)jl_gc_alloc(ct->ptls, sizeof(jl_opaque_closure_t), oc_type);
@@ -73,7 +75,7 @@ static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t 
     oc->source = source;
     oc->captures = captures;
     oc->specptr = NULL;
-    if (jl_atomic_load_relaxed(&ci->invoke) == jl_fptr_interpret_call) {
+    if (!ci || jl_atomic_load_relaxed(&ci->invoke) == jl_fptr_interpret_call) {
         oc->invoke = (jl_fptr_args_t)jl_interpret_opaque_closure;
     }
     else if (jl_atomic_load_relaxed(&ci->invoke) == jl_fptr_args) {
@@ -91,11 +93,11 @@ static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t 
 }
 
 jl_opaque_closure_t *jl_new_opaque_closure(jl_tupletype_t *argt, jl_value_t *rt_lb, jl_value_t *rt_ub,
-    jl_value_t *source_, jl_value_t **env, size_t nenv)
+    jl_value_t *source_, jl_value_t **env, size_t nenv, int do_compile)
 {
     jl_value_t *captures = jl_f_tuple(NULL, env, nenv);
     JL_GC_PUSH1(&captures);
-    jl_opaque_closure_t *oc = new_opaque_closure(argt, rt_lb, rt_ub, source_, captures);
+    jl_opaque_closure_t *oc = new_opaque_closure(argt, rt_lb, rt_ub, source_, captures, do_compile);
     JL_GC_POP();
     return oc;
 }
@@ -111,7 +113,7 @@ JL_DLLEXPORT jl_code_instance_t* jl_new_codeinst(
         uint8_t relocatability);
 
 JL_DLLEXPORT jl_opaque_closure_t *jl_new_opaque_closure_from_code_info(jl_tupletype_t *argt, jl_value_t *rt_lb, jl_value_t *rt_ub,
-    jl_module_t *mod, jl_code_info_t *ci, int lineno, jl_value_t *file, int nargs, int isva, jl_value_t *env)
+    jl_module_t *mod, jl_code_info_t *ci, int lineno, jl_value_t *file, int nargs, int isva, jl_value_t *env, int do_compile)
 {
     if (!ci->inferred)
         jl_error("CodeInfo must already be inferred");
@@ -128,7 +130,7 @@ JL_DLLEXPORT jl_opaque_closure_t *jl_new_opaque_closure_from_code_info(jl_tuplet
         0, ((jl_method_t*)root)->primary_world, -1, 0, 0, jl_nothing, 0);
     jl_mi_cache_insert(mi, inst);
 
-    jl_opaque_closure_t *oc = new_opaque_closure(argt, rt_lb, rt_ub, root, env);
+    jl_opaque_closure_t *oc = new_opaque_closure(argt, rt_lb, rt_ub, root, env, do_compile);
     JL_GC_POP();
     return oc;
 }
@@ -138,7 +140,7 @@ JL_CALLABLE(jl_new_opaque_closure_jlcall)
     if (nargs < 4)
         jl_error("new_opaque_closure: Not enough arguments");
     return (jl_value_t*)jl_new_opaque_closure((jl_tupletype_t*)args[0],
-        args[1], args[2], args[3], &args[4], nargs-4);
+        args[1], args[2], args[3], &args[4], nargs-4, 1);
 }
 
 


### PR DESCRIPTION
I have a case where I'm generating an opaque closure that is only run once, but LLVM takes 200s to compile it. This adds an option to not run LLVM in the IR2OC path, which is useful for two things:
1. Getting a handle on the OC without waiting for LLVM to finish, so we can have it dump out the unoptimized LLVM IR for profiling purposes.
2. Just actually not running LLVM, since it's probably not worth it.