### PR TITLE
Reland: Improve performance of global code by emitting fewer atomic barriers.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7760,7 +7760,7 @@ static jl_llvm_functions_t
 
     Instruction &prologue_end = ctx.builder.GetInsertBlock()->back();
 
-    // step 11b. For top-level code, load the world age
+    // step 11a. For top-level code, load the world age
     if (toplevel && !ctx.is_opaque_closure) {
         LoadInst *world = ctx.builder.CreateAlignedLoad(ctx.types().T_size,
             prepare_global_in(jl_Module, jlgetworld_global), ctx.types().alignof_ptr);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5959,7 +5959,7 @@ static Function* gen_cfun_wrapper(
 
     Value *world_v = ctx.builder.CreateAlignedLoad(ctx.types().T_size,
         prepare_global_in(jl_Module, jlgetworld_global), ctx.types().alignof_ptr);
-    cast<LoadInst>(world_v)->setOrdering(AtomicOrdering::Monotonic);
+    cast<LoadInst>(world_v)->setOrdering(AtomicOrdering::Acquire);
 
     Value *age_ok = NULL;
     if (calltype) {
@@ -7764,7 +7764,7 @@ static jl_llvm_functions_t
     if (toplevel && !ctx.is_opaque_closure) {
         LoadInst *world = ctx.builder.CreateAlignedLoad(ctx.types().T_size,
             prepare_global_in(jl_Module, jlgetworld_global), ctx.types().alignof_ptr);
-        world->setOrdering(AtomicOrdering::Monotonic);
+        world->setOrdering(AtomicOrdering::Acquire);
         ctx.builder.CreateAlignedStore(world, world_age_field, ctx.types().alignof_ptr);
     }
 
@@ -8340,7 +8340,7 @@ static jl_llvm_functions_t
                     LoadInst *world = new LoadInst(ctx.types().T_size,
                         prepare_global_in(jl_Module, jlgetworld_global), Twine(),
                         /*isVolatile*/false, ctx.types().alignof_ptr, /*insertBefore*/&I);
-                    world->setOrdering(AtomicOrdering::Monotonic);
+                    world->setOrdering(AtomicOrdering::Acquire);
                     StoreInst *store_world = new StoreInst(world, world_age_field,
                         /*isVolatile*/false, ctx.types().alignof_ptr, /*insertBefore*/&I);
                     (void)store_world;


### PR DESCRIPTION
Re-land https://github.com/JuliaLang/julia/pull/47578 which got reverted because of a GC issue on win32. I haven't debugged this, but want to have an open PR so that I don't lose track of this.

Fixes https://github.com/JuliaLang/julia/issues/47561