### PR TITLE
Fix REPL keybinding CTRL-Q for stdlib methods

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1248,7 +1248,7 @@ function setup_interface(
                 @goto writeback
             end
             try
-                InteractiveUtils.edit(linfos[n][1], linfos[n][2])
+                InteractiveUtils.edit(Base.fixup_stdlib_path(linfos[n][1]), linfos[n][2])
             catch ex
                 ex isa ProcessFailedException || ex isa Base.IOError || ex isa SystemError || rethrow()
                 @info "edit failed" _exception=ex


### PR DESCRIPTION
Currently, when editing methods in stdlibs with CTRL-Q from stack traces leads to #26314. For example, for v1.8.3 the following code:
```julia
julia> using Printf

julia> @sprintf "%f" "A string"
ERROR: MethodError: no method matching Float64(::String)
Closest candidates are:
  (::Type{T})(::AbstractChar) where T<:Union{AbstractChar, Number} at char.jl:50
  (::Type{T})(::Base.TwicePrecision) where T<:Number at twiceprecision.jl:266
  (::Type{T})(::Complex) where T<:Real at complex.jl:44
  ...
Stacktrace:
 [1] tofloat(x::String)
   @ Printf ~/.asdf/installs/julia/1.8.3/share/julia/stdlib/v1.8/Printf/src/Printf.jl:389
 [2] fmt
   @ ~/.asdf/installs/julia/1.8.3/share/julia/stdlib/v1.8/Printf/src/Printf.jl:402 [inlined]
 [3] format
   @ ~/.asdf/installs/julia/1.8.3/share/julia/stdlib/v1.8/Printf/src/Printf.jl:734 [inlined]
 [4] format(f::Printf.Format{Base.CodeUnits{UInt8, String}, Tuple{Printf.Spec{Val{'f'}}}}, args::String)
   @ Printf ~/.asdf/installs/julia/1.8.3/share/julia/stdlib/v1.8/Printf/src/Printf.jl:831
 [5] top-level scope
   @ REPL[2]:1
```
and typing "3[CTRL-Q]" opens the file: "/cache/build/default-amdci5-6/julialang/julia-release-1-dot-8/usr/share/julia/stdlib/v1.8/Printf/src/Printf.jl"

This change fixes it. I tested it by adding a custom keybinding with this fix.