### PR TITLE
initialize padding because we use that memory for hashing

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -816,6 +816,7 @@ JL_DLLEXPORT jl_datatype_t * jl_new_foreign_type(jl_sym_t *name,
     layout->haspadding = 1;
     layout->npointers = haspointers;
     layout->fielddesc_type = 3;
+    layout->padding = 0;
     jl_fielddescdyn_t * desc =
       (jl_fielddescdyn_t *) ((char *)layout + sizeof(*layout));
     desc->markfunc = markfunc;

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -219,6 +219,7 @@ static jl_datatype_layout_t *jl_get_layout(uint32_t sz,
     flddesc->alignment = alignment;
     flddesc->haspadding = haspadding;
     flddesc->fielddesc_type = fielddesc_type;
+    flddesc->padding = 0;
     flddesc->npointers = npointers;
     flddesc->first_ptr = (npointers > 0 ? pointers[0] : -1);
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -523,6 +523,7 @@ typedef struct {
     uint16_t alignment; // strictest alignment over all fields
     uint16_t haspadding : 1; // has internal undefined bytes
     uint16_t fielddesc_type : 2; // 0 -> 8, 1 -> 16, 2 -> 32, 3 -> foreign type
+    uint16_t padding : 13;
     // union {
     //     jl_fielddesc8_t field8[nfields];
     //     jl_fielddesc16_t field16[nfields];


### PR DESCRIPTION
Found by using MSAN, the layout uses uninitialized bits when hashing, that is probably a bad idea, also it makes MSAN unhappy. 