### PR TITLE
Add section headings to the Doc's home page & links

### DIFF
--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -60,7 +60,7 @@ R, you may find that Julia's performance is unintuitive at first. If you find th
 slow, we highly recommend reading through the [Performance Tips](@ref man-performance-tips) section before trying anything
 else. Once you understand how Julia works, it's easy to write code that's nearly as fast as C.
 
-### [Julia compared to other languages](@id man-julia-vs-other-languages)
+### [Julia compared to other languages](@id man-julia-compared-other-languages)
 
 Julia features optional typing, multiple dispatch, and good performance, achieved using type inference
 and [just-in-time (JIT) compilation](https://en.wikipedia.org/wiki/Just-in-time_compilation) (and

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -38,7 +38,7 @@ Below is a non-exhasutive list of links that will be useful as you learn and use
 
 - [Julia Homepage](https://julialang.org)
 - [Download Julia](https://julialang.org/downloads/)
-- [Q/A Support](https://discourse.julialang.org)
+- [Discussion forum](https://discourse.julialang.org)
 - [Julia YouTube](https://www.youtube.com/user/JuliaLanguage)
 - [Find Julia Packages](https://julialang.org/packages/)
 - [Learning Resources](https://julialang.org/learning/)

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -32,6 +32,18 @@ Markdown.parse("""
 """)
 ```
 
+### [Important Links](@id man-important-links)
+
+Below is a non-exhasutive list of links that will be useful as you learn and use the Julia programming language.
+
+- [Julia Homepage](https://julialang.org)
+- [Download Julia](https://julialang.org/downloads/)
+- [Q/A Support](https://discourse.julialang.org)
+- [Julia YouTube](https://www.youtube.com/user/JuliaLanguage)
+- [Find Julia Packages](https://julialang.org/packages/)
+- [Learning Resources](https://julialang.org/learning/)
+- [Read and write blogs on Julia](https://forem.julialang.org)
+
 ### [Introduction](@id man-introduction)
 
 Scientific computing has traditionally required the highest performance, yet domain experts have
@@ -47,6 +59,8 @@ Because Julia's compiler is different from the interpreters used for languages l
 R, you may find that Julia's performance is unintuitive at first. If you find that something is
 slow, we highly recommend reading through the [Performance Tips](@ref man-performance-tips) section before trying anything
 else. Once you understand how Julia works, it's easy to write code that's nearly as fast as C.
+
+### [Julia Versus Other Languages](@id man-julia-vs-other-languages)
 
 Julia features optional typing, multiple dispatch, and good performance, achieved using type inference
 and [just-in-time (JIT) compilation](https://en.wikipedia.org/wiki/Just-in-time_compilation) (and
@@ -78,6 +92,8 @@ hand, while one can -- and usually must -- annotate types for the compiler, type
 compile time and cannot be manipulated or expressed at run time. In Julia, types are themselves
 run-time objects, and can also be used to convey information to the compiler.
 
+### [What Makes Julia, Julia?](@id man-what-makes-julia)
+
 While the casual programmer need not explicitly use types or multiple dispatch, they are the core
 unifying features of Julia: functions are defined on different combinations of argument types,
 and applied by dispatching to the most specific matching definition. This model is a good fit
@@ -92,6 +108,8 @@ efficiency exceeds that of other dynamic languages, and even rivals that of stat
 languages. For large scale numerical problems, speed always has been, continues to be, and probably
 always will be crucial: the amount of data being processed has easily kept pace with Moore's Law
 over the past decades.
+
+### [Advantages of Julia](@id man-advantages-of-julia)
 
 Julia aims to create an unprecedented combination of ease-of-use, power, and efficiency in a single
 language. In addition to the above, some advantages of Julia over comparable systems include:

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -58,7 +58,7 @@ with performance comparable to traditional statically-typed languages.
 Because Julia's compiler is different from the interpreters used for languages like Python or
 R, you may find that Julia's performance is unintuitive at first. If you find that something is
 slow, we highly recommend reading through the [Performance Tips](@ref man-performance-tips) section before trying anything
-else. Once you understand how Julia works, it's easy to write code that's nearly as fast as C.
+else. Once you understand how Julia works, it is easy to write code that is nearly as fast as C.
 
 ### [Julia compared to other languages](@id man-julia-compared-other-languages)
 

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -60,7 +60,7 @@ R, you may find that Julia's performance is unintuitive at first. If you find th
 slow, we highly recommend reading through the [Performance Tips](@ref man-performance-tips) section before trying anything
 else. Once you understand how Julia works, it's easy to write code that's nearly as fast as C.
 
-### [Julia Versus Other Languages](@id man-julia-vs-other-languages)
+### [Julia compared to other languages](@id man-julia-vs-other-languages)
 
 Julia features optional typing, multiple dispatch, and good performance, achieved using type inference
 and [just-in-time (JIT) compilation](https://en.wikipedia.org/wiki/Just-in-time_compilation) (and

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -32,7 +32,7 @@ Markdown.parse("""
 """)
 ```
 
-### [Important Links](@id man-important-links)
+## [Important Links](@id man-important-links)
 
 Below is a non-exhasutive list of links that will be useful as you learn and use the Julia programming language.
 
@@ -44,7 +44,7 @@ Below is a non-exhasutive list of links that will be useful as you learn and use
 - [Learning Resources](https://julialang.org/learning/)
 - [Read and write blogs on Julia](https://forem.julialang.org)
 
-### [Introduction](@id man-introduction)
+## [Introduction](@id man-introduction)
 
 Scientific computing has traditionally required the highest performance, yet domain experts have
 largely moved to slower dynamic languages for daily work. We believe there are many good reasons
@@ -60,7 +60,7 @@ R, you may find that Julia's performance is unintuitive at first. If you find th
 slow, we highly recommend reading through the [Performance Tips](@ref man-performance-tips) section before trying anything
 else. Once you understand how Julia works, it is easy to write code that is nearly as fast as C.
 
-### [Julia compared to other languages](@id man-julia-compared-other-languages)
+## [Julia Compared to Other Languages](@id man-julia-compared-other-languages)
 
 Julia features optional typing, multiple dispatch, and good performance, achieved using type inference
 and [just-in-time (JIT) compilation](https://en.wikipedia.org/wiki/Just-in-time_compilation) (and
@@ -84,8 +84,8 @@ The most significant departures of Julia from typical dynamic languages are:
   * Automatic generation of efficient, specialized code for different argument types
   * Good performance, approaching that of statically-compiled languages like C
 
-Although one sometimes speaks of dynamic languages as being "typeless", they are definitely not:
-every object, whether primitive or user-defined, has a type. The lack of type declarations in
+Although one sometimes speaks of dynamic languages as being "typeless", they are definitely not.
+Every object, whether primitive or user-defined, has a type. The lack of type declarations in
 most dynamic languages, however, means that one cannot instruct the compiler about the types of
 values, and often cannot explicitly talk about types at all. In static languages, on the other
 hand, while one can -- and usually must -- annotate types for the compiler, types exist only at


### PR DESCRIPTION
Two things: right now, the main docs homepage reads as just a big wall of text which is not a great experience. I have a hard time looking at it without anything breaking the content up (and some of the info may not be directly relevant for every user jumping in for the first time). 

Also, right now, there is no clear pathway from the docs back to all of our other resources in the ecosystem so I added an important links section at the top of the page which should hopefully make the connection from the docs back to the rest of the ecosystem. 

Open to feedback on the wording of the section heads, this was just a first pass at that. 