### PR TITLE
Add compat note for `sortperm(x; dims)`

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1167,8 +1167,8 @@ Like [`sortperm`](@ref), but accepts a preallocated index vector or array `ix` w
 (the default), `ix` is initialized to contain the values `LinearIndices(A)`.
 
 !!! compat "Julia 1.9"
-    The method accepting `dims` requires at least Julia 1.9.                                                                                               
-                                                                                                
+    The method accepting `dims` requires at least Julia 1.9.
+
 # Examples
 ```jldoctest
 julia> v = [3, 1, 2]; p = zeros(Int, 3);

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1100,6 +1100,9 @@ ascending order.
 See also [`sortperm!`](@ref), [`partialsortperm`](@ref), [`invperm`](@ref), [`indexin`](@ref).
 To sort slices of an array, refer to [`sortslices`](@ref).
 
+!!! compat "Julia 1.9"
+    The method accepting `dims` requires at least Julia 1.9.
+
 # Examples
 ```jldoctest
 julia> v = [3, 1, 2];
@@ -1163,6 +1166,9 @@ end
 Like [`sortperm`](@ref), but accepts a preallocated index vector or array `ix` with the same `axes` as `A`.  If `initialized` is `false`
 (the default), `ix` is initialized to contain the values `LinearIndices(A)`.
 
+!!! compat "Julia 1.9"
+    The method accepting `dims` requires at least Julia 1.9.                                                                                               
+                                                                                                
 # Examples
 ```jldoctest
 julia> v = [3, 1, 2]; p = zeros(Int, 3);


### PR DESCRIPTION
These methods don't exist on 1.8, so perhaps they deserve a note.

Perhaps they also deserve mention in https://github.com/JuliaLang/julia/blob/master/HISTORY.md?