### PR TITLE
fix 5-arg `mul!` for vectors of vectors

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -807,7 +807,15 @@ function generic_matvecmul!(C::AbstractVector{R}, tA, A::AbstractVecOrMat, B::Ab
         end
         for k = 1:mB
             aoffs = (k-1)*Astride
-            b = _add(B[k], false)
+            bk = B[k]
+            # We use `false` for `Number`s since `Bool`s are also numbers and
+            # we assume that we can add them. This should be more efficient in
+            # general since it avoids allocating a zero number for something
+            # like `BigFloats`. However, we do not necessarily need to have
+            # vectors of numbers but can also have vectors of vectors. In this
+            # case, adding a scalar `false` to the vector-valued entries is
+            # not defined, so we need to use an appropriate zero.
+            b = _add(bk, bk isa Number ? false : zero(bk))
             for i = 1:mA
                 C[i] += A[aoffs + i] * b
             end

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -807,15 +807,7 @@ function generic_matvecmul!(C::AbstractVector{R}, tA, A::AbstractVecOrMat, B::Ab
         end
         for k = 1:mB
             aoffs = (k-1)*Astride
-            bk = B[k]
-            # We use `false` for `Number`s since `Bool`s are also numbers and
-            # we assume that we can add them. This should be more efficient in
-            # general since it avoids allocating a zero number for something
-            # like `BigFloats`. However, we do not necessarily need to have
-            # vectors of numbers but can also have vectors of vectors. In this
-            # case, adding a scalar `false` to the vector-valued entries is
-            # not defined, so we need to use an appropriate zero.
-            b = _add(bk, bk isa Number ? false : zero(bk))
+            b = _add(B[k])
             for i = 1:mA
                 C[i] += A[aoffs + i] * b
             end

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -157,15 +157,55 @@ end
 end
 
 @testset "generic_matvecmul for vectors of vectors" begin
-    u = [[1, 2], [3, 4]]
+    @testset "matrix of scalars" begin
+        u = [[1, 2], [3, 4]]
+        A = [1 2; 3 4]
+        v = [[0, 0], [0, 0]]
+        Au = [[7, 10], [15, 22]]
+        @test A * u == Au
+        mul!(v, A, u)
+        @test v == Au
+        mul!(v, A, u, 2, -1)
+        @test v == Au
+    end
+
+    @testset "matrix of matrices" begin
+        u = [[1, 2], [3, 4]]
+        A = Matrix{Matrix{Int}}(undef, 2, 2)
+        A[1, 1] = [1 2; 3 4]
+        A[1, 2] = [5 6; 7 8]
+        A[2, 1] = [9 10; 11 12]
+        A[2, 2] = [13 14; 15 16]
+        v = [[0, 0], [0, 0]]
+        Au = [[44, 64], [124, 144]]
+        @test A * u == Au
+        mul!(v, A, u)
+        @test v == Au
+        mul!(v, A, u, 2, -1)
+        @test v == Au
+    end
+end
+
+@testset "generic_matmatmul for matrices of vectors" begin
+    B = Matrix{Vector{Int}}(undef, 2, 2)
+    B[1, 1] = [1, 2]
+    B[2, 1] = [3, 4]
+    B[1, 2] = [5, 6]
+    B[2, 2] = [7, 8]
     A = [1 2; 3 4]
-    v = [[0, 0], [0, 0]]
-    Au = [[7, 10], [15, 22]]
-    @test A * u == Au
-    mul!(v, A, u)
-    @test v == Au
-    mul!(v, A, u, 2, 1)
-    @test v == [[15, 22], [33, 48]]
+    C = Matrix{Vector{Int}}(undef, 2, 2)
+    AB = Matrix{Vector{Int}}(undef, 2, 2)
+    AB[1, 1] = [7, 10]
+    AB[2, 1] = [15, 22]
+    AB[1, 2] = [19, 22]
+    AB[2, 2] = [43, 50]
+    @test A * B == AB
+    mul!(C, A, B)
+    @test C == AB
+    mul!(C, A, B, 2, -1)
+    @test C == AB
+    LinearAlgebra._generic_matmatmul!(C, 'N', 'N', A, B, LinearAlgebra.MulAddMul(2, -1))
+    @test C == AB
 end
 
 @testset "fallbacks & such for BlasFloats" begin

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -156,6 +156,18 @@ end
     end
 end
 
+@testset "generic_matvecmul for vectors of vectors" begin
+    u = [[1, 2], [3, 4]]
+    A = [1 2; 3 4]
+    v = [[0, 0], [0, 0]]
+    Au = [[7, 10], [15, 22]]
+    @test A * u == Au
+    mul!(v, A, u)
+    @test v == Au
+    mul!(v, A, u, 2, 1)
+    @test v == [[15, 22], [33, 48]]
+end
+
 @testset "fallbacks & such for BlasFloats" begin
     AA = rand(Float64, 6, 6)
     BB = rand(Float64, 6, 6)


### PR DESCRIPTION
On current `master` and release, vectors of vectors work with `*` and 3-arg `mul!` but not with 5-arg `mul!`:

```julia
julia> using LinearAlgebra

julia> u = [[1, 2], [3, 4]]
2-element Vector{Vector{Int64}}:
 [1, 2]
 [3, 4]

julia> A = [1 2; 3 4]
2×2 Matrix{Int64}:
 1  2
 3  4

julia> A * u
2-element Vector{Vector{Int64}}:
 [7, 10]
 [15, 22]

julia> v = [[0, 0], [0, 0]]
2-element Vector{Vector{Int64}}:
 [0, 0]
 [0, 0]

julia> mul!(v, A, u)
2-element Vector{Vector{Int64}}:
 [7, 10]
 [15, 22]

julia> mul!(v, A, u, 1, 1)
ERROR: MethodError: no method matching +(::Vector{Int64}, ::Int64)
For element-wise addition, use broadcasting with dot syntax: array .+ scalar

Closest candidates are:
  +(::Any, ::Any, ::Any, ::Any...)
   @ Base operators.jl:578
  +(::T, ::T) where T<:Union{Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64, UInt8}
   @ Base int.jl:87
  +(::Base.TwicePrecision, ::Number)
   @ Base twiceprecision.jl:290
  ...

Stacktrace:
 [1] MulAddMul
   @ ~/.../julia/stdlib/v1.10/LinearAlgebra/src/generic.jl:58 [inlined]
 [2] generic_matvecmul!(C::Vector{Vector{Int64}}, tA::Char, A::Matrix{Int64}, B::Vector{Vector{Int64}}, _add::LinearAlgebra.MulAddMul{true, false, Int64, Int64})
   @ LinearAlgebra ~/.../julia/stdlib/v1.10/LinearAlgebra/src/matmul.jl:810
 [3] mul!(y::Vector{Vector{Int64}}, A::Matrix{Int64}, x::Vector{Vector{Int64}}, alpha::Int64, beta::Int64)
   @ LinearAlgebra ~/.../julia/stdlib/v1.10/LinearAlgebra/src/matmul.jl:81
 [4] top-level scope
   @ REPL[7]:1
```

Since matrix vector products only need to be able to
- multiply elements of the matrix and the vector
- add elements of the vector multiplied by entries of the matrix

this is an unnecessary restriction I fixed here. In practice, this appears for us when multiplying vectors of `SVector`s from StaticArrays.jl (or `StructArray`s thereof from StructArrays.jl) by matrices, e.g., when discretizing differential equations.