### PR TITLE
[Filesystem]: `rm(; recursive=true)` should ignore `UV_EACCES`

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -294,7 +294,7 @@ function rm(path::AbstractString; force::Bool=false, recursive::Bool=false)
                     rm(joinpath(path, p), force=force, recursive=true)
                 end
             catch err
-                if !(force && isa(err, IOError) && err.code==Base.UV_EACCES)
+                if !(isa(err, IOError) && err.code==Base.UV_EACCES)
                     rethrow(err)
                 end
             end

--- a/test/file.jl
+++ b/test/file.jl
@@ -1520,11 +1520,11 @@ if !Sys.iswindows()
             chmod(joinpath(d, "empty_outer", "empty_inner"), 0o333)
 
             # Test that an empty directory, even when we can't read its contents, is deletable
-            rm(joinpath(d, "empty_outer"); recursive=true, force=true)
+            rm(joinpath(d, "empty_outer"); recursive=true)
             @test !isdir(joinpath(d, "empty_outer"))
 
             # But a non-empty directory is not
-            @test_throws Base.IOError rm(joinpath(d, "nonempty"); recursive=true, force=true)
+            @test_throws Base.IOError rm(joinpath(d, "nonempty"); recursive=true)
             chmod(joinpath(d, "nonempty"), 0o777)
             rm(joinpath(d, "nonempty"); recursive=true, force=true)
             @test !isdir(joinpath(d, "nonempty"))


### PR DESCRIPTION
The command-line program `rm` has no problem deleting an empty directory that we do not have listing permissions on, so we should follow suit.

Example:

```
mktempdir() do dir
    mkpath("$(dir)/foo")
    chmod("$(dir)/foo", 0o200)
    rm(dir; recursive=true)
end
```