### PR TITLE
improve inlining cost analysis for invoke

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -737,7 +737,7 @@ function statement_cost(ex::Expr, line::Int, src::Union{CodeInfo, IRCode}, sptyp
             end
             return T_IFUNC_COST[iidx]
         end
-        if isa(f, Builtin)
+        if isa(f, Builtin) && f !== invoke
             # The efficiency of operations like a[i] and s.b
             # depend strongly on whether the result can be
             # inferred, so check the type of ex


### PR DESCRIPTION
Before we just assumed that the cost of an `invoke` was 20 while it should be much lower for inferred types and much higher for uninferred types. Fixes https://discourse.julialang.org/t/extremely-slow-invoke-when-inlined/90665