### PR TITLE
Add an inference option to assume no new bindings being added

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2385,10 +2385,14 @@ function abstract_eval_statement_expr(interp::AbstractInterpreter, e::Expr, vtyp
         elseif isa(sym, Symbol)
             if isdefined(sv.mod, sym)
                 t = Const(true)
+            elseif sv.params.assume_bindings_static
+                t = Const(false)
             end
         elseif isa(sym, GlobalRef)
             if isdefined(sym.mod, sym.name)
                 t = Const(true)
+            elseif sv.params.assume_bindings_static
+                t = Const(false)
             end
         elseif isexpr(sym, :static_parameter)
             n = sym.args[1]::Int
@@ -2499,6 +2503,9 @@ function abstract_eval_globalref(interp::AbstractInterpreter, g::GlobalRef, fram
         end
     elseif isdefined_globalref(g)
         nothrow = true
+    elseif isa(frame, InferenceState) && frame.params.assume_bindings_static
+        consistent = inaccessiblememonly = ALWAYS_TRUE
+        rt = Union{}
     end
     merge_effects!(interp, frame, Effects(EFFECTS_TOTAL; consistent, nothrow, inaccessiblememonly))
     return rt

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -147,6 +147,10 @@ struct InferenceParams
     # tuple contains more than this many elements
     MAX_TUPLE_SPLAT::Int
 
+    # Assume that no new bindings will be added, i.e. a non-existing binding
+    # at inference time can be assumed to always error.
+    assume_bindings_static::Bool
+
     function InferenceParams(;
             ipo_constant_propagation::Bool = true,
             aggressive_constant_propagation::Bool = false,
@@ -156,6 +160,7 @@ struct InferenceParams
             apply_union_enum::Int = 8,
             tupletype_depth::Int = 3,
             tuple_splat::Int = 32,
+            assume_bindings_static::Bool = false,
         )
         return new(
             ipo_constant_propagation,
@@ -166,6 +171,7 @@ struct InferenceParams
             apply_union_enum,
             tupletype_depth,
             tuple_splat,
+            assume_bindings_static
         )
     end
 end


### PR DESCRIPTION
This is currently intended for use with external AbstractInterpreters that want to be able to constant fold `:isdefined` away. We always support the `true` case, since we don't support removing bindings, but the `false` case is currently not foldable. In the future, we might partition bindings by world age, in which case we would likely get this for free, but for now, just add this as a hook for external AbstractInterpreters to use.