### PR TITLE
Support building dependencies with Emscripten

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -552,8 +552,6 @@ ifeq ($(OS), WINNT)
   SHLIB_EXT := dll
 else ifeq ($(OS), Darwin)
   SHLIB_EXT := dylib
-else ifeq ($(OS), Emscripten)
-  SHLIB_EXT := a
 else
   SHLIB_EXT := so
 endif

--- a/Make.inc
+++ b/Make.inc
@@ -552,6 +552,8 @@ ifeq ($(OS), WINNT)
   SHLIB_EXT := dll
 else ifeq ($(OS), Darwin)
   SHLIB_EXT := dylib
+else ifeq ($(OS), Emscripten)
+  SHLIB_EXT := a
 else
   SHLIB_EXT := so
 endif

--- a/deps/dsfmt.mk
+++ b/deps/dsfmt.mk
@@ -5,9 +5,12 @@ ifneq ($(USE_BINARYBUILDER_DSFMT),1)
 
 DSFMT_CFLAGS := $(CFLAGS) -DNDEBUG -DDSFMT_MEXP=19937 $(fPIC) -DDSFMT_DO_NOT_USE_OLD_NAMES -DDSFMT_SHLIB $(SANITIZE_OPTS)
 DSFMT_CFLAGS += -O3 -finline-functions -fomit-frame-pointer -fno-strict-aliasing \
-		--param max-inline-insns-single=1800 -Wall  -std=c99 -shared
+		-Wall  -std=c99 -shared
 ifeq ($(ARCH), x86_64)
 DSFMT_CFLAGS += -msse2 -DHAVE_SSE2
+endif
+ifneq ($(OS), emscripten)
+DSFMT_CFLAGS += --param max-inline-insns-single=1800
 endif
 
 $(SRCCACHE)/dsfmt-$(DSFMT_VER).tar.gz: | $(SRCCACHE)

--- a/deps/gmp.mk
+++ b/deps/gmp.mk
@@ -19,6 +19,9 @@ ifeq ($(BUILD_OS),WINNT)
 GMP_CONFIGURE_OPTS += --srcdir="$(subst \,/,$(call mingw_to_dos,$(SRCCACHE)/gmp-$(GMP_VER)))"
 endif
 
+ifeq ($(OS),emscripten)
+GMP_CONFIGURE_OPTS += CFLAGS="-fPIC"
+endif
 
 $(SRCCACHE)/gmp-$(GMP_VER).tar.bz2: | $(SRCCACHE)
 	$(JLDOWNLOAD) $@ https://gmplib.org/download/gmp/$(notdir $@)

--- a/deps/mpfr.mk
+++ b/deps/mpfr.mk
@@ -20,6 +20,9 @@ ifeq ($(SANITIZE),1)
 MPFR_CONFIGURE_OPTS += --host=none-unknown-linux
 endif
 
+ifeq ($(OS),emscripten)
+MPFR_CONFIGURE_OPTS += CFLAGS="-fPIC"
+endif
 
 $(SRCCACHE)/mpfr-$(MPFR_VER).tar.bz2: | $(SRCCACHE)
 	$(JLDOWNLOAD) $@ https://www.mpfr.org/mpfr-$(MPFR_VER)/$(notdir $@)

--- a/deps/pcre.mk
+++ b/deps/pcre.mk
@@ -6,6 +6,13 @@ ifneq ($(USE_BINARYBUILDER_PCRE),1)
 PCRE_CFLAGS := -O3
 PCRE_LDFLAGS := $(RPATH_ESCAPED_ORIGIN)
 
+ifeq ($(OS),emscripten)
+PCRE_CFLAGS += -fPIC
+PCRE_JIT = --disable-jit
+else
+PCRE_JIT = --enable-jit
+endif
+
 $(SRCCACHE)/pcre2-$(PCRE_VER).tar.bz2: | $(SRCCACHE)
 	$(JLDOWNLOAD) $@ https://github.com/PCRE2Project/pcre2/releases/download/pcre2-$(PCRE_VER)/pcre2-$(PCRE_VER).tar.bz2
 
@@ -20,7 +27,7 @@ checksum-pcre: $(SRCCACHE)/pcre2-$(PCRE_VER).tar.bz2
 $(BUILDDIR)/pcre2-$(PCRE_VER)/build-configured: $(SRCCACHE)/pcre2-$(PCRE_VER)/source-extracted
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
-	$(dir $<)/configure $(CONFIGURE_COMMON) --enable-jit --includedir=$(build_includedir) CFLAGS="$(CFLAGS) $(PCRE_CFLAGS) -g -O0" LDFLAGS="$(LDFLAGS) $(PCRE_LDFLAGS)"
+	$(dir $<)/configure $(CONFIGURE_COMMON) $(PCRE_JIT) --includedir=$(build_includedir) CFLAGS="$(CFLAGS) $(PCRE_CFLAGS) -g -O0" LDFLAGS="$(LDFLAGS) $(PCRE_LDFLAGS)"
 	echo 1 > $@
 
 $(BUILDDIR)/pcre2-$(PCRE_VER)/build-compiled: $(BUILDDIR)/pcre2-$(PCRE_VER)/build-configured


### PR DESCRIPTION
These dependencies can be compiled to WASM with modified build flags. Specifically, this fixes builds for:
- dsfmt
- gmp
- libuv
- mpfr
- pcre