### PR TITLE
Make `Some` example in `something` docstring more informative

### DIFF
--- a/base/some.jl
+++ b/base/some.jl
@@ -82,6 +82,9 @@ See also [`coalesce`](@ref), [`skipmissing`](@ref), [`@something`](@ref).
 julia> something(nothing, 1)
 1
 
+julia>something(Some(1), nothing)
+1
+
 julia> something(Some(nothing), 2) === nothing
 true
 

--- a/base/some.jl
+++ b/base/some.jl
@@ -82,7 +82,7 @@ See also [`coalesce`](@ref), [`skipmissing`](@ref), [`@something`](@ref).
 julia> something(nothing, 1)
 1
 
-julia>something(Some(1), nothing)
+julia> something(Some(1), nothing)
 1
 
 julia> something(Some(nothing), 2) === nothing

--- a/base/some.jl
+++ b/base/some.jl
@@ -82,8 +82,8 @@ See also [`coalesce`](@ref), [`skipmissing`](@ref), [`@something`](@ref).
 julia> something(nothing, 1)
 1
 
-julia> something(Some(1), nothing)
-1
+julia> typeof(something(nothing, Some(nothing)))
+Nothing
 
 julia> something(missing, nothing)
 missing

--- a/base/some.jl
+++ b/base/some.jl
@@ -82,8 +82,8 @@ See also [`coalesce`](@ref), [`skipmissing`](@ref), [`@something`](@ref).
 julia> something(nothing, 1)
 1
 
-julia> typeof(something(nothing, Some(nothing)))
-Nothing
+julia> something(Some(nothing), 2) === nothing
+true
 
 julia> something(missing, nothing)
 missing


### PR DESCRIPTION
Previous example:
```julia
julia> something(Some(1), nothing)
1
```

PR example:
```julia
julia> typeof(something(nothing, Some(nothing)))
Nothing
```

The previous example this PR replaces was a potentially confusing and nonsensical use of `Some` with `something`.

(AFAIU from the docs), The sole purpose of `Some` is to distinguish a non-value `nothing` from a value `nothing` (presumably with the use of `something`). Therefore, a literal `Some(1)` is not an informative example, since an unwrapped `1` would also be returned by `something` (i.e. the `Some` wrapper in that example does not change the result).

The new example is a clearer way of showing how `something` and `Some` interact.