### PR TITLE
inference: mark flag for effect-free `:call`s during abstractinterpret

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -532,6 +532,8 @@ function print_callstack(sv::InferenceState)
 end
 
 get_curr_ssaflag(sv::InferenceState) = sv.src.ssaflags[sv.currpc]
+add_curr_ssaflag!(sv::InferenceState, flag::UInt8) = sv.src.ssaflags[sv.currpc] |= flag
+sub_curr_ssaflag!(sv::InferenceState, flag::UInt8) = sv.src.ssaflags[sv.currpc] &= ~flag
 
 function narguments(sv::InferenceState)
     def = sv.linfo.def


### PR DESCRIPTION
So that they can be deleted during the first `compact!`-ion. This allows us to delete an inlineable and effect-free, but unused call.

This is essentially an alternative of #47305, but doesn't introduce a problem like #47374.