### PR TITLE
mktempdir docstring: clarify when `X` characters may be replaced

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -675,8 +675,9 @@ mktemp(parent)
     mktempdir(parent=tempdir(); prefix=$(repr(temp_prefix)), cleanup=true) -> path
 
 Create a temporary directory in the `parent` directory with a name
-constructed from the given prefix and a random suffix, and return its path.
-Additionally, any trailing `X` characters may be replaced with random characters.
+constructed from the given `prefix` and a random suffix, and return its path.
+Additionally, on some platforms, any trailing `'X'` characters in `prefix` may be replaced
+with random characters.
 If `parent` does not exist, throw an error. The `cleanup` option controls whether
 the temporary directory is automatically deleted when the process exits.
 


### PR DESCRIPTION
The current formulation,

> Additionally, any trailing `X` characters may be replaced with random characters.

left me wondering  when this could happen, and exactly what could happen; thanks @vtjnash who clarified on slack.