### PR TITLE
document that `get` and `replace` accept a type as first argument

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -423,7 +423,7 @@ Dict{String, Int64} with 4 entries:
 get!(collection, key, default)
 
 """
-    get!(f::Function, collection, key)
+    get!(f::Union{Function, Type}, collection, key)
 
 Return the value stored for the given key, or if no mapping for the key is present, store
 `key => f()`, and return `f()`.
@@ -449,7 +449,7 @@ Dict{Int64, Int64} with 1 entry:
   2 => 4
 ```
 """
-get!(f::Function, collection, key)
+get!(f::Callable, collection, key)
 
 function get!(default::Callable, h::Dict{K,V}, key0) where V where K
     key = convert(K, key0)
@@ -512,7 +512,7 @@ function get(h::Dict{K,V}, key, default) where V where K
 end
 
 """
-    get(f::Function, collection, key)
+    get(f::Union{Function, Type}, collection, key)
 
 Return the value stored for the given key, or if no mapping for the key is present, return
 `f()`.  Use [`get!`](@ref) to also store the default value in the dictionary.
@@ -526,7 +526,7 @@ get(dict, key) do
 end
 ```
 """
-get(::Function, collection, key)
+get(::Callable, collection, key)
 
 function get(default::Callable, h::Dict{K,V}, key) where V where K
     index = ht_keyindex(h, key)

--- a/base/set.jl
+++ b/base/set.jl
@@ -617,7 +617,7 @@ function replace_pairs!(res, A, count::Int, old_new::Tuple{Vararg{Pair}})
 end
 
 """
-    replace!(new::Function, A; [count::Integer])
+    replace!(new::Union{Function, Type}, A; [count::Integer])
 
 Replace each element `x` in collection `A` by `new(x)`.
 If `count` is specified, then replace at most `count` values in total
@@ -710,7 +710,7 @@ subtract_singletontype(::Type{T}, x::Pair{K}, y::Pair...) where {T, K} =
     subtract_singletontype(subtract_singletontype(T, y...), x)
 
 """
-    replace(new::Function, A; [count::Integer])
+    replace(new::Union{Function, Type}, A; [count::Integer])
 
 Return a copy of `A` where each value `x` in `A` is replaced by `new(x)`.
 If `count` is specified, then replace at most `count` values in total


### PR DESCRIPTION
Currently, it's unclear by just looking at the docstring whether e.g. `get(Vector, collection, key)` is valid.