### PR TITLE
effects: add `:removable` convenient setting for `Base.@assume_effects`

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -436,6 +436,7 @@ The following `setting`s are supported.
 - `:notaskstate`
 - `:inaccessiblememonly`
 - `:foldable`
+- `:removable`
 - `:total`
 
 # Extended help
@@ -596,7 +597,6 @@ global state or mutable memory pointed to by its arguments.
 This setting is a convenient shortcut for the set of effects that the compiler
 requires to be guaranteed to constant fold a call at compile time. It is
 currently equivalent to the following `setting`s:
-
 - `:consistent`
 - `:effect_free`
 - `:terminates_globally`
@@ -606,6 +606,16 @@ currently equivalent to the following `setting`s:
     attempt constant propagation and note any thrown error at compile time. Note
     however, that by the `:consistent`-cy requirements, any such annotated call
     must consistently throw given the same argument values.
+
+---
+## `:removable`
+
+This setting is a convenient shortcut for the set of effects that the compiler
+requires to be guaranteed to delete a call whose result is unused at compile time.
+It is currently equivalent to the following `setting`s:
+- `:effect_free`
+- `:nothrow`
+- `:terminates_globally`
 
 ---
 ## `:total`
@@ -666,6 +676,8 @@ macro assume_effects(args...)
             inaccessiblememonly = val
         elseif setting === :foldable
             consistent = effect_free = terminates_globally = val
+        elseif setting === :removable
+            effect_free = nothrow = terminates_globally = val
         elseif setting === :total
             consistent = effect_free = nothrow = terminates_globally = notaskstate = inaccessiblememonly = val
         else

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -67,7 +67,7 @@ end
 Base.@assume_effects :removable removable_call(
     f, args...; kwargs...) = f(args...; kwargs...)
 @test fully_eliminated() do
-    removable_call(getindex, ___CONST_DICT___, :a)
+    @noinline removable_call(getindex, ___CONST_DICT___, :a)
     nothing
 end
 

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -63,6 +63,14 @@ Base.@assume_effects :foldable concrete_eval(
     concrete_eval(getindex, ___CONST_DICT___, :a)
 end
 
+# :removable override
+Base.@assume_effects :removable removable_call(
+    f, args...; kwargs...) = f(args...; kwargs...)
+@test fully_eliminated() do
+    removable_call(getindex, ___CONST_DICT___, :a)
+    nothing
+end
+
 # terminates_globally override
 # https://github.com/JuliaLang/julia/issues/41694
 Base.@assume_effects :terminates_globally function issue41694(x)


### PR DESCRIPTION
This setting is similar to `:foldable` but for dead call elimination.