### PR TITLE
Fix Markdown header underlines

### DIFF
--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -88,7 +88,7 @@ function _term_header(io::IO, md, char, columns)
         if line_no > 1
             line_width = max(line_width, div(columns, 3))
         end
-        char != ' ' && print(io, '\n', ' '^(margin), char^line_width)
+        char != ' ' && print(io, '\n', ' '^(margin), char^(line_width-margin))
     end
 end
 

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -376,7 +376,7 @@ table = md"""
 # mime output
 let out =
     @test sprint(show, "text/plain", book) ==
-        "  Title\n  ≡≡≡≡≡≡≡\n\n  Some discussion\n\n  │  A quote\n\n  Section important\n  ===================\n\n  Some bolded\n\n    •  list1\n\n    •  list2"
+        "  Title\n  ≡≡≡≡≡\n\n  Some discussion\n\n  │  A quote\n\n  Section important\n  =================\n\n  Some bolded\n\n    •  list1\n\n    •  list2"
     @test sprint(show, "text/markdown", book) ==
         """
         # Title


### PR DESCRIPTION
Closes #47632.

| Before | After |
|:------:|:-----:| 
| ![before](https://user-images.githubusercontent.com/20258504/204043873-deca6382-2e5e-46ba-81a6-fb4aebe29179.jpeg) | ![after](https://user-images.githubusercontent.com/20258504/204043648-da589855-74bb-4e45-822b-6a01af2333f4.jpg) |

I'm not sure how to run stdlib tests locally, but it would probably be a good idea to add one.