### PR TITLE
Fix zero-length Markdown headers

### DIFF
--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -88,7 +88,8 @@ function _term_header(io::IO, md, char, columns)
         if line_no > 1
             line_width = max(line_width, div(columns, 3))
         end
-        char != ' ' && print(io, '\n', ' '^(margin), char^(line_width-margin))
+        header_width = max(0, line_width-margin)
+        char != ' ' && header_width > 0 && print(io, '\n', ' '^(margin), char^header_width)
     end
 end
 

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -377,6 +377,7 @@ table = md"""
 let out =
     @test sprint(show, "text/plain", book) ==
         "  Title\n  ≡≡≡≡≡\n\n  Some discussion\n\n  │  A quote\n\n  Section important\n  =================\n\n  Some bolded\n\n    •  list1\n\n    •  list2"
+    @test sprint(show, "text/plain", md"#") == "  " # edge case of empty header
     @test sprint(show, "text/markdown", book) ==
         """
         # Title


### PR DESCRIPTION
PR #47708 introduced a bug in the edge case of zero-length Markdown headers. 
Since the exponent of `char^(line_width-margin)` becomes negative, Julia errors:
```Julia
julia> md"# "
  Error showing value of type Markdown.MD:
ERROR: ArgumentError: can't repeat a character -1 times
```

Comparing this PR to the last release (#47632):
| Release | PR    |
|:-------:|:-----:| 
| ![release](https://user-images.githubusercontent.com/20258504/204249379-cce7342c-6cc2-4b8b-9552-c79940a97a79.png) | ![pr](https://user-images.githubusercontent.com/20258504/204249389-ac4dab15-5bc6-4c8c-b360-6eda4055a5df.png) |

If the single `≡` is desired, we can set the minimum `header_width` to one.
I can also add back the extra newline created by zero-length-underlines.