### PR TITLE
Add link to alloc profiler issue in Profile docs

### DIFF
--- a/doc/src/manual/profile.md
+++ b/doc/src/manual/profile.md
@@ -362,7 +362,7 @@ Passing `sample_rate=1.0` will make it record everything (which is slow);
     `Profile.Allocs.UnknownType`.
 
     You can read more about the missing types and the plan to improve this, here:
-    <https://github.com/JuliaLang/julia/issues/43688>.
+    [issue #43688](https://github.com/JuliaLang/julia/issues/43688).
 
 ## External Profiling
 


### PR DESCRIPTION
The URL is provided as text in the note, and it'll be good to include a link