### PR TITLE
Fix generator-invocation legality check for varargs generators

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1165,10 +1165,22 @@ function may_invoke_generator(method::Method, @nospecialize(atype), sparams::Sim
             end
         end
     end
-    for i = 1:length(at.parameters)
+    non_va_args = method.isva ? method.nargs - 1 : method.nargs
+    for i = 1:non_va_args
         if !isdispatchelem(at.parameters[i])
             if (ast_slotflag(code, 1 + i + nsparams) & SLOT_USED) != 0
                 return false
+            end
+        end
+    end
+    if method.isva
+        # If the va argument is used, we need to ensure that all arguments that
+        # contribute to the va tuple are dispatchelemes
+        if (ast_slotflag(code, 1 + method.nargs + nsparams) & SLOT_USED) != 0
+            for i = (non_va_args+1):length(at.parameters)
+                if !isdispatchelem(at.parameters[i])
+                    return false
+                end
             end
         end
     end


### PR DESCRIPTION
This code was introduced by me back in #31025 to speed up evaluation of generated functions that didn't make use of all of their arguments to make generation decisions. However, it neglected to take into account the possibility that the generator could be varargs. As a result, an unfortunate coincidence of an unused slot in the correct position could have allowed expansion of generators that were not supposed to be expandable. This can cause incorrect inference with all the usual consequences. However, fortunately this coincidence appears to be pretty rare.

Fixes https://github.com/JuliaDebug/CassetteOverlay.jl/issues/12