### PR TITLE
Remove obsolete methods/type restrictions in LinAlg

### DIFF
--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -173,19 +173,15 @@ function *(B::Bidiagonal, H::UpperHessenberg)
     return B.uplo == 'U' ? UpperHessenberg(A) : A
 end
 
-/(H::UpperHessenberg, B::Bidiagonal) = _rdiv(H, B)
-/(H::UpperHessenberg{<:Number}, B::Bidiagonal{<:Number}) = _rdiv(H, B)
-function _rdiv(H::UpperHessenberg, B::Bidiagonal)
+function /(H::UpperHessenberg, B::Bidiagonal)
     T = typeof(oneunit(eltype(H))/oneunit(eltype(B)))
-    A = _rdiv!(zeros(T, size(H)), H, B)
+    A = _rdiv!(similar(H, T, size(H)), H, B)
     return B.uplo == 'U' ? UpperHessenberg(A) : A
 end
 
-\(B::Bidiagonal{<:Number}, H::UpperHessenberg{<:Number}) = _ldiv(B, H)
-\(B::Bidiagonal, H::UpperHessenberg) = _ldiv(B, H)
-function _ldiv(B::Bidiagonal, H::UpperHessenberg)
+function \(B::Bidiagonal, H::UpperHessenberg)
     T = typeof(oneunit(eltype(B))\oneunit(eltype(H)))
-    A = ldiv!(zeros(T, size(H)), B, H)
+    A = ldiv!(similar(H, T, size(H)), B, H)
     return B.uplo == 'U' ? UpperHessenberg(A) : A
 end
 

--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -234,16 +234,16 @@ end
 for op in (:+, :-)
     @eval begin
         function ($op)(A::UniformScaling, B::Tridiagonal)
-            newd = ($op).(Ref(A), B.d)
-            Tridiagonal(typeof(newd)(B.dl), newd, typeof(newd)(B.du))
+            d = ($op).(Ref(A), B.d)
+            Tridiagonal(convert(typeof(d), $op(B.dl)), d, convert(typeof(d), $op(B.du)))
         end
         function ($op)(A::UniformScaling, B::SymTridiagonal)
-            newdv = ($op).(Ref(A), B.dv)
-            SymTridiagonal(newdv, typeof(newdv)(B.ev))
+            dv = ($op).(Ref(A), B.dv)
+            SymTridiagonal(dv, convert(typeof(dv), $op(B.ev)))
         end
         function ($op)(A::UniformScaling, B::Bidiagonal)
-            newdv = ($op).(Ref(A), B.dv)
-            Bidiagonal(newdv, typeof(newdv)(B.ev), B.uplo)
+            dv = ($op).(Ref(A), B.dv)
+            Bidiagonal(dv, convert(typeof(dv), $op(B.ev)), B.uplo)
         end
         function ($op)(A::UniformScaling, B::Diagonal)
             Diagonal(($op).(Ref(A), B.diag))

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -213,7 +213,10 @@ end
 *(B::Number, A::SymTridiagonal) = SymTridiagonal(B*A.dv, B*A.ev)
 /(A::SymTridiagonal, B::Number) = SymTridiagonal(A.dv/B, A.ev/B)
 \(B::Number, A::SymTridiagonal) = SymTridiagonal(B\A.dv, B\A.ev)
-==(A::SymTridiagonal, B::SymTridiagonal) = (A.dv==B.dv) && (_evview(A)==_evview(B))
+==(A::SymTridiagonal{<:Number}, B::SymTridiagonal{<:Number}) =
+    (A.dv == B.dv) && (_evview(A) == _evview(B))
+==(A::SymTridiagonal, B::SymTridiagonal) =
+    size(A) == size(B) && all(i -> A[i,i] == B[i,i], axes(A, 1)) && (_evview(A) == _evview(B))
 
 function dot(x::AbstractVector, S::SymTridiagonal, y::AbstractVector)
     require_one_based_indexing(x, y)

--- a/stdlib/LinearAlgebra/test/special.jl
+++ b/stdlib/LinearAlgebra/test/special.jl
@@ -191,7 +191,7 @@ end
         push!(mats, SymTridiagonal(Vector{T}(diag), Vector{T}(offdiag)))
     end
 
-    for op in (+,*) # to do: fix when operation is - and the matrix has a range as the underlying representation and we get a step size of 0.
+    for op in (+,-,*)
         for A in mats
             for B in mats
                 @test (op)(A, B) ≈ (op)(Matrix(A), Matrix(B)) ≈ Matrix((op)(A, B))

--- a/stdlib/LinearAlgebra/test/special.jl
+++ b/stdlib/LinearAlgebra/test/special.jl
@@ -208,15 +208,14 @@ end
     end
     diag = [randn(ComplexF64, 2, 2) for _ in 1:3]
     odiag = [randn(ComplexF64, 2, 2) for _ in 1:2]
-    for op in (+,-)
-        for A in (Diagonal(diag),
-                    Bidiagonal(diag, odiag, :U),
-                    Bidiagonal(diag, odiag, :L),
-                    Tridiagonal(odiag, diag, odiag),
-                    SymTridiagonal(diag, odiag)), B in uniformscalingmats
-            @test (A + B)::typeof(A) == (B + A)::typeof(A)
-            @test (A - B)::typeof(A) == -((B - A)::typeof(A))
-        end
+    for A in (Diagonal(diag),
+                Bidiagonal(diag, odiag, :U),
+                Bidiagonal(diag, odiag, :L),
+                Tridiagonal(odiag, diag, odiag),
+                SymTridiagonal(diag, odiag)), B in uniformscalingmats
+        @test (A + B)::typeof(A) == (B + A)::typeof(A)
+        @test (A - B)::typeof(A) == ((A + (-B))::typeof(A))
+        @test (B - A)::typeof(A) == ((B + (-A))::typeof(A))
     end
 end
 

--- a/stdlib/LinearAlgebra/test/special.jl
+++ b/stdlib/LinearAlgebra/test/special.jl
@@ -206,6 +206,18 @@ end
             end
         end
     end
+    diag = [randn(ComplexF64, 2, 2) for _ in 1:3]
+    odiag = [randn(ComplexF64, 2, 2) for _ in 1:2]
+    for op in (+,-)
+        for A in (Diagonal(diag),
+                    Bidiagonal(diag, odiag, :U),
+                    Bidiagonal(diag, odiag, :L),
+                    Tridiagonal(odiag, diag, odiag),
+                    SymTridiagonal(diag, odiag)), B in uniformscalingmats
+            @test (A + B)::typeof(A) == (B + A)::typeof(A)
+            @test (A - B)::typeof(A) == -((B - A)::typeof(A))
+        end
+    end
 end
 
 


### PR DESCRIPTION
This is partially a follow-up to #47683. It removes ugly `Number` restrictions on the eltype.
