### PR TITLE
check that file exist in whitespace checker before trying to read it

### DIFF
--- a/contrib/check-whitespace.jl
+++ b/contrib/check-whitespace.jl
@@ -27,6 +27,7 @@ for path in eachline(`git ls-files -- $patterns`)
     file_err(msg) = push!(errors, (path, 0, msg))
     line_err(msg) = push!(errors, (path, lineno, msg))
 
+    isfile(path) || continue
     for line in eachline(path, keep=true)
         lineno += 1
         contains(line, '\r')   && file_err("non-UNIX line endings")


### PR DESCRIPTION
`git ls-files` can apparently show files that are staged to be deleted.