### PR TITLE
Try LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32 | LOAD_LIBRARY_SEARCH_USER_DIRS for DLL loading on Windows

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -165,13 +165,10 @@ JL_DLLEXPORT void *jl_dlopen(const char *filename, unsigned flags) JL_NOTSAFEPOI
     {
         /* If loading with LOAD_WITH_ALTERED_SEARCH_PATH fails,
            search user directories added with `AddDllDirectory`.
-           
            In Julia on Windows, user directories can be added to the DLL search path as follows.
            `library::String = pwd()`
            `@ccall "kernel32".AddDllDirectory(library::Cwstring)::Ptr{Nothing}`
-           
            https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-adddlldirectory
-           
            Consider `LOAD_LIBRARY_SEARCH_DEFAULT_DIRS` or
           `LOAD_LIBRARY_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR` for use below. */
         lib = LoadLibraryExW(wfilename, NULL, LOAD_LIBRARY_SEARCH_USER_DIRS);

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -161,6 +161,21 @@ JL_DLLEXPORT void *jl_dlopen(const char *filename, unsigned flags) JL_NOTSAFEPOI
     WCHAR *wfilename = (WCHAR*)alloca(len * sizeof(WCHAR));
     if (!MultiByteToWideChar(CP_UTF8, 0, filename, -1, wfilename, len)) return NULL;
     HANDLE lib = LoadLibraryExW(wfilename, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
+    if (!lib)
+    {
+        /* If loading with LOAD_WITH_ALTERED_SEARCH_PATH fails,
+           search user directories added with `AddDllDirectory`.
+           
+           In Julia on Windows, user directories can be added to the DLL search path as follows.
+           `library::String = pwd()`
+           `@ccall "kernel32".AddDllDirectory(library::Cwstring)::Ptr{Nothing}`
+           
+           https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-adddlldirectory
+           
+           Consider `LOAD_LIBRARY_SEARCH_DEFAULT_DIRS` or
+          `LOAD_LIBRARY_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR` for use below. */
+        lib = LoadLibraryExW(wfilename, NULL, LOAD_LIBRARY_SEARCH_USER_DIRS);
+    }
     if (lib)
         needsSymRefreshModuleList = 1;
     return lib;

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -160,18 +160,19 @@ JL_DLLEXPORT void *jl_dlopen(const char *filename, unsigned flags) JL_NOTSAFEPOI
     if (!len) return NULL;
     WCHAR *wfilename = (WCHAR*)alloca(len * sizeof(WCHAR));
     if (!MultiByteToWideChar(CP_UTF8, 0, filename, -1, wfilename, len)) return NULL;
-    HANDLE lib = LoadLibraryExW(wfilename, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
-    if (!lib)
-    {
-        /* If loading with LOAD_WITH_ALTERED_SEARCH_PATH fails,
-           search user directories added with `AddDllDirectory`.
-           In Julia on Windows, user directories can be added to the DLL search path as follows.
-           `library::String = pwd()`
-           `@ccall "kernel32".AddDllDirectory(library::Cwstring)::Ptr{Nothing}`
-           https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-adddlldirectory
-           Consider `LOAD_LIBRARY_SEARCH_DEFAULT_DIRS` or
-          `LOAD_LIBRARY_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR` for use below. */
-        lib = LoadLibraryExW(wfilename, NULL, LOAD_LIBRARY_SEARCH_USER_DIRS);
+    /* Treat `AddDllDirectory` like `(DY)LD_LIBRARY_PATH` on other platforms.
+        In Julia on Windows, user directories can be added to the DLL search path as follows.
+        `library::String = pwd()`
+        `@ccall "kernel32".AddDllDirectory(library::Cwstring)::Ptr{Nothing}`
+        https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-adddlldirectory
+        Consider `LOAD_LIBRARY_SEARCH_DEFAULT_DIRS` or
+      `LOAD_LIBRARY_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR` for use below. */
+    lib = LoadLibraryExW(wfilename, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32 | LOAD_LIBRARY_SEARCH_USER_DIRS); // this is LOAD_LIBRARY_SEARCH_DEFAULT_DIRS with ALTERED_SEARCH_PATH
+    if (!lib) {
+        lib = LoadLibraryExW(".\\" wfilename, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32 | LOAD_LIBRARY_SEARCH_USER_DIRS);
+        if (!lib) {
+            lib = LoadLibraryExW(wfilename, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
+        }
     }
     if (lib)
         needsSymRefreshModuleList = 1;


### PR DESCRIPTION
Currently, we use `LOAD_WITH_ALTERED_SEARCH_PATH` to load DLL libraries on Windows. With this pull request, if loading with the above fails, we use `LOAD_LIBRARY_SEARCH_USER_DIRS`.

This is a minimalist version of the idea proposed on [Discourse](https://discourse.julialang.org/t/use-modern-secure-windows-api-for-dlopen/90171/5). Rather than replacing `LOAD_WITH_ALTERED_SEARCH_PATH` with `LOAD_LIBRARY_SEARCH_DEFAULT_DIRS`, we only use `LOAD_LIBRARY_SEARCH_USER_DIRS` if loading with ``LOAD_WITH_ALTERED_SEARCH_PATH` fails.

This allows the user to manually build a search list of directories via `AddDllDirectory`.
```julia
@ccall "kernel32".AddDllDirectory(library::Cwstring)::Ptr{Nothing}
```

https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw