### PR TITLE
Prioritize build_dir for generated headers

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -4,7 +4,9 @@
 #define JULIA_H
 
 #ifdef LIBRARY_EXPORTS
-#include "jl_internal_funcs.inc"
+// Generated file, needs to be searched in include paths so that the builddir
+// retains priority
+#include <jl_internal_funcs.inc>
 #undef jl_setjmp
 #undef jl_longjmp
 #undef jl_egal

--- a/src/julia.h
+++ b/src/julia.h
@@ -2191,7 +2191,7 @@ JL_DLLEXPORT int jl_generating_output(void) JL_NOTSAFEPOINT;
 #define JL_OPTIONS_USE_COMPILED_MODULES_NO 0
 
 // Version information
-#include "julia_version.h"
+#include <julia_version.h> // Generated file
 
 JL_DLLEXPORT extern int jl_ver_major(void);
 JL_DLLEXPORT extern int jl_ver_minor(void);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1684,7 +1684,9 @@ JL_DLLEXPORT uint32_t jl_crc32c(uint32_t crc, const char *buf, size_t len);
 #endif
 
 #ifdef USE_DTRACE
-#include "uprobes.h.gen"
+// Generated file, needs to be searched in include paths so that the builddir
+// retains priority
+#include <uprobes.h.gen>
 
 // uprobes.h.gen on systems with DTrace, is auto-generated to include
 // `JL_PROBE_{PROBE}` and `JL_PROBE_{PROBE}_ENABLED()` macros for every probe


### PR DESCRIPTION
Alternative to #47755

Builds are compiled with:

```sh
clang ... -I. -I/home/vchuravy/julia/src
```

For out-of-tree builds this should mean that we prioritize the build dir.

Using `-H` we observe that if a generated header is present in the src dir:

```
. /home/vchuravy/julia/src/julia.h
.. /home/vchuravy/julia/src/jl_internal_funcs.inc
```

This is due to the semantics of `#include "file"` vs `#include <file>` in the C pre-processor.
The former is relative to the current header/source file, while the later uses the include directories.

After this change we observe:

```
. /home/vchuravy/julia/src/julia.h
.. ./jl_internal_funcs.inc
```

