### PR TITLE
const type alias

### DIFF
--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1100,7 +1100,7 @@ There is a convenient syntax for naming such types, similar to the short form of
 definition syntax:
 
 ```julia
-Vector{T} = Array{T, 1}
+const Vector{T} = Array{T, 1}
 ```
 
 This is equivalent to `const Vector = Array{T,1} where T`.


### PR DESCRIPTION
In all the other type alias examples, `const` is used. To be consistent and since this is the better practice (right?) better to use `const` here too.