### PR TITLE
Comment out subtype test that causes hang due to StackOverflowError

### DIFF
--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2201,11 +2201,12 @@ T46784{B<:Val, M<:AbstractMatrix} = Tuple{<:Union{B, <:Val{<:B}}, M, Union{Abstr
 
 @testset "known subtype/intersect issue" begin
     #issue 45874
-    let S = Pair{Val{P}, AbstractVector{<:Union{P,<:AbstractMatrix{P}}}} where P,
-        T = Pair{Val{R}, AbstractVector{<:Union{P,<:AbstractMatrix{P}}}} where {P,R}
-        @test_broken S <: T
-        @test_broken typeintersect(S,T) === S
-    end
+    # Causes a hang due to jl_critical_error calling back into malloc...
+    # let S = Pair{Val{P}, AbstractVector{<:Union{P,<:AbstractMatrix{P}}}} where P,
+    #     T = Pair{Val{R}, AbstractVector{<:Union{P,<:AbstractMatrix{P}}}} where {P,R}
+    #     @test_broken S <: T
+    #     @test_broken typeintersect(S,T) === S
+    # end
 
     #issue 44395
     @test_broken typeintersect(


### PR DESCRIPTION
My working theory is that we hit a stack-overflow when calling `malloc`.
```
Thread 1 received signal SIGSEGV, Segmentation fault.
0x00007f237c29559e in ?? () from target:/lib/x86_64-linux-gnu/libc.so.6
(rr) bt 10
#0  0x00007f237c29559e in ?? () from target:/lib/x86_64-linux-gnu/libc.so.6
#1  0x00007f237c2975fa in malloc () from target:/lib/x86_64-linux-gnu/libc.so.6
#2  0x00007f237b641e8c in malloc_s (sz=520) at /cache/build/default-amdci5-4/julialang/julia-master/src/support/dtypes.h:339
#3  save_env (root=root@entry=0x0, se=se@entry=0x7f235d4dd460, e=<optimized out>, e=<optimized out>) at /cache/build/default-amdci5-4/julialang/julia-master/src/subtype.c:177
#4  0x00007f237b64ac64 in intersect (x=x@entry=0x7f2355d9bbf0, y=y@entry=0x7f2355d9bd90, e=e@entry=0x7f235d4e0a40, param=param@entry=0) at /cache/build/default-amdci5-4/julialang/julia-master/src/subtype.c:3164
#5  0x00007f237b64c7bc in intersect_all (x=x@entry=0x7f2355d9bbf0, y=y@entry=0x7f2355d9bd90, e=e@entry=0x7f235d4e0a40) at /cache/build/default-amdci5-4/julialang/julia-master/src/subtype.c:3281
#6  0x00007f237b64cee2 in intersect_aside (x=x@entry=0x7f2355d9bbf0, y=y@entry=0x7f2355d9bd90, e=0x7f235d4e0a40, d=<optimized out>, R=0) at /cache/build/default-amdci5-4/julialang/julia-master/src/subtype.c:2147
#7  0x00007f237b64d5e4 in intersect_var (b=b@entry=0x7f2355d9bcd0, a=a@entry=0x7f2355d9bd90, e=e@entry=0x7f235d4e0a40, R=R@entry=0 '\000', param=param@entry=0) at /cache/build/default-amdci5-4/julialang/julia-master/src/subtype.c:2402
#8  0x00007f237b64a12f in intersect (x=0x7f2355d9bcd0, y=y@entry=0x7f2355d9bd90, e=e@entry=0x7f235d4e0a40, param=param@entry=0) at /cache/build/default-amdci5-4/julialang/julia-master/src/subtype.c:3135
#9  0x00007f237b64e020 in intersect_union (x=x@entry=0x7f2355d9bd90, u=u@entry=0x7f2355d9e8f0, e=0x7f235d4e0a40, R=R@entry=0 '\000', param=param@entry=0) at /cache/build/default-amdci5-4/julialang/julia-master/src/subtype.c:2170
(More stack frames follow...)
```

And then we hang due to something like #28908
