### PR TITLE
allow `Base._which` to take `method_table::CC.MethodTableView`

### DIFF
--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -31,6 +31,9 @@ macro noinline() Expr(:meta, :noinline) end
 convert(::Type{Any}, Core.@nospecialize x) = x
 convert(::Type{T}, x::T) where {T} = x
 
+# mostly used by compiler/methodtable.jl, but also by reflection.jl
+abstract type MethodTableView end
+
 # essential files and libraries
 include("essentials.jl")
 include("ctypes.jl")

--- a/base/compiler/methodtable.jl
+++ b/base/compiler/methodtable.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-abstract type MethodTableView; end
-
 struct MethodLookupResult
     # Really Vector{Core.MethodMatch}, but it's easier to represent this as
     # and work with Vector{Any} on the C side.

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1498,13 +1498,15 @@ end
 print_statement_costs(args...; kwargs...) = print_statement_costs(stdout, args...; kwargs...)
 
 function _which(@nospecialize(tt::Type);
-    method_table::Union{Nothing,Core.MethodTable}=nothing,
+    method_table::Union{Nothing,Core.MethodTable,Core.Compiler.MethodTableView}=nothing,
     world::UInt=get_world_counter(),
     raise::Bool=true)
     if method_table === nothing
         table = Core.Compiler.InternalMethodTable(world)
-    else
+    elseif method_table isa Core.MethodTable
         table = Core.Compiler.OverlayMethodTable(world, method_table)
+    else
+        table = method_table
     end
     match, = Core.Compiler.findsup(tt, table)
     if match === nothing


### PR DESCRIPTION
Might be useful for some external `AbstractInterpreter` implementation.