### PR TITLE
Set `OPENBLAS_NUM_THREADS=1` on local Distributed workers

### DIFF
--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -487,6 +487,13 @@ function launch(manager::LocalManager, params::Dict, launched::Array, c::Conditi
     if get(env, "JULIA_DEPOT_PATH", nothing) === nothing
         env["JULIA_DEPOT_PATH"] = join(DEPOT_PATH, pathsep)
     end
+
+    # If we haven't explicitly asked for threaded BLAS, prevent OpenBLAS from starting
+    # up with multiple threads, thereby sucking up a bunch of wasted memory on Windows.
+    if !params[:enable_threaded_blas] &&
+       get(env, "OPENBLAS_NUM_THREADS", nothing) === nothing
+        env["OPENBLAS_NUM_THREADS"] = "1"
+    end
     # Set the active project on workers using JULIA_PROJECT.
     # Users can opt-out of this by (i) passing `env = ...` or (ii) passing
     # `--project=...` as `exeflags` to addprocs(...).


### PR DESCRIPTION
This should prevent LinearAlgebra from trying to increase our OpenBLAS thread count in its `__init__()` method when we're not trying to enable threaded BLAS.