### PR TITLE
Change `@test ex broken=true` to error if `ex` evaluates to non-boolean

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -674,8 +674,13 @@ function do_broken_test(result::ExecutionResult, orig_expr)
     # Assume the test is broken and only change if the result is true
     if isa(result, Returned)
         value = result.value
-        if isa(value, Bool) && value
-            testres = Error(:test_unbroken, orig_expr, value, nothing, result.source)
+        if isa(value, Bool)
+            if value
+                testres = Error(:test_unbroken, orig_expr, value, nothing, result.source)
+            end
+        else
+            # If the result is non-Boolean, this counts as an Error
+            testres = Error(:test_nonbool, orig_expr, value, nothing, result.source)
         end
     end
     record(get_testset(), testres)

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1020,7 +1020,7 @@ end
 
 else
 
-@test_broken "cfunction: no support for closures on this platform"
+@test_broken "cfunction: no support for closures on this platform" === nothing
 
 end
 

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -734,8 +734,7 @@ end
     x = @inferred replace([1, 2], 2=>missing)
     @test isequal(x, [1, missing]) && x isa Vector{Union{Int, Missing}}
 
-    @test_broken @inferred replace([1, missing], missing=>2)
-    x = replace([1, missing], missing=>2)
+    x = @inferred replace([1, missing], missing=>2)
     @test x == [1, 2] && x isa Vector{Int}
     x = @inferred replace([1, missing], missing=>2, count=1)
     @test x == [1, 2] && x isa Vector{Union{Int, Missing}}

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2230,7 +2230,7 @@ T46784{B<:Val, M<:AbstractMatrix} = Tuple{<:Union{B, <:Val{<:B}}, M, Union{Abstr
                                (Tuple{Type{T},Array{Union{T,Nothing},N}} where {T,N})) <: Any
 
     #issue 35698
-    @test_broken typeintersect(Type{Tuple{Array{T,1} where T}}, UnionAll)
+    @test_broken typeintersect(Type{Tuple{Array{T,1} where T}}, UnionAll) != Union{}
 
     #issue 33137
     @test_broken (Tuple{Q,Int} where Q<:Int) <: Tuple{T,T} where T


### PR DESCRIPTION
Just like `@test ex` errors if `ex` does not evaluable to a boolean, the `broken=true` variant should as well.  As it stands, right now the following does not result in an error:

```
@test 1 broken=true
```

While the following does result in an error:
```
@test 1
```

The intention of `broken=true` is to allow for tests to be added such that they pass although something is broken, and then fail once the missing functionality has been added, so that the developer knows to go and adjust the tests for the newly-added functionality.  It is often used in situations such as:

```
@test partially_implemented_test() broken=Sys.iswindows()
```

Sometimes, the function under test throws an error in certain situations, and this test can even be used to track a function erroring out, and notifying the developer when it no longer throws:

```
@test this_throws() broken=true
```

However, this occasionally leads to improper usage such as:
```
@test this_usually_returns_an_object_but_sometimes_throws() broken=true
```

This test, when it throws, passes (because of `broken=true`) but then when it returns a non-boolean, it _also_ passes.  This is Very Bad (TM). This PR fixes the state of affairs by making a non-boolean return an error here.