### PR TITLE
Dict: decrement `h.ndel` when overwriting deleted entry

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -339,12 +339,12 @@ end
 ht_keyindex2!(h::Dict, key) = ht_keyindex2_shorthash!(h, key)[1]
 
 @propagate_inbounds function _setindex!(h::Dict, v, key, index, sh = _shorthash7(hash(key)))
+    h.ndel -= isslotmissing(h, index)
     h.slots[index] = sh
     h.keys[index] = key
     h.vals[index] = v
     h.count += 1
     h.age += 1
-    h.ndel -= isslotmissing(h, index)
     if index < h.idxfloor
         h.idxfloor = index
     end

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -344,7 +344,7 @@ ht_keyindex2!(h::Dict, key) = ht_keyindex2_shorthash!(h, key)[1]
     h.vals[index] = v
     h.count += 1
     h.age += 1
-    h.ndel = ifelse(@inbounds(isslotmissing(h, index)), h.ndel - 1, h.ndel)
+    h.ndel = ifelse(isslotmissing(h, index), h.ndel - 1, h.ndel)
     if index < h.idxfloor
         h.idxfloor = index
     end

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -344,7 +344,7 @@ ht_keyindex2!(h::Dict, key) = ht_keyindex2_shorthash!(h, key)[1]
     h.vals[index] = v
     h.count += 1
     h.age += 1
-    h.ndel = ifelse(isslotmissing(h, index), h.ndel - 1, h.ndel)
+    h.ndel -= isslotmissing(h, index)
     if index < h.idxfloor
         h.idxfloor = index
     end

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -344,6 +344,7 @@ ht_keyindex2!(h::Dict, key) = ht_keyindex2_shorthash!(h, key)[1]
     h.vals[index] = v
     h.count += 1
     h.age += 1
+    isslotmissing(h, index) && h.ndel -= 1
     if index < h.idxfloor
         h.idxfloor = index
     end

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -344,7 +344,7 @@ ht_keyindex2!(h::Dict, key) = ht_keyindex2_shorthash!(h, key)[1]
     h.vals[index] = v
     h.count += 1
     h.age += 1
-    isslotmissing(h, index) && h.ndel -= 1
+    h.ndel = ifelse(@inbounds(isslotmissing(h, index)), h.ndel - 1, h.ndel)
     if index < h.idxfloor
         h.idxfloor = index
     end

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -652,6 +652,7 @@ function _delete!(h::Dict{K,V}, index) where {K,V}
     h.age += 1
     return h
     end
+end
 
 """
     delete!(collection, key)


### PR DESCRIPTION
fixes https://github.com/JuliaLang/julia/issues/47823. Previously we never lowered this leading us to rehash unnecessarily. I'm not sure if this counts as a bugfix.