### PR TITLE
Clean closure and task-local-state in jl_finish_task

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -308,6 +308,11 @@ void JL_NORETURN jl_finish_task(jl_task_t *t)
     ct->ptls->in_pure_callback = 0;
     ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
     // let the runtime know this task is dead and find a new task to run
+
+    // Empty out the closure and the task local state so that GC can free those values.
+    ct->start = jl_nothing;
+    ct->tls = jl_nothing;
+
     jl_function_t *done = jl_atomic_load_relaxed(&task_done_hook_func);
     if (done == NULL) {
         done = (jl_function_t*)jl_get_global(jl_base_module, jl_symbol("task_done_hook"));

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -358,7 +358,7 @@ create_serialization_stream() do s # user-defined type array
     serialize(s, t)
     seek(s, 0)
     r = deserialize(s)
-    @test r.storage[:v] == 2
+    @test r.storage == nothing
     @test r.state === :done
     @test r.exception === nothing
 end


### PR DESCRIPTION
Implements the second part of @vtjnash idea in https://github.com/JuliaLang/julia/pull/47405#issuecomment-1298665060

Particularly motivated by @quinnj observation that it is easy to add a `return nothing` to a task, but the arguments
to the task need to be handled differently.  (x-ref https://github.com/JuliaLang/julia/issues/40626#issuecomment-1340376861)
