### PR TITLE
Lock around JIT operations

### DIFF
--- a/doc/src/devdocs/locks.md
+++ b/doc/src/devdocs/locks.md
@@ -33,6 +33,7 @@ The following are definitely leaf locks (level 1), and must not try to acquire a
 >   * jl_locked_stream::mutex
 >   * debuginfo_asyncsafe
 >   * inference_timing_mutex
+>   * ExecutionEngine::SessionLock
 >
 >     > flisp itself is already threadsafe, this lock only protects the `jl_ast_context_list_t` pool
 >     > likewise, the ResourcePool<?>::mutexes just protect the associated resource pool
@@ -61,6 +62,10 @@ hierarchy. Acquiring a TSCtx should only be done from the JIT's pool of TSCtx's,
 that TSCtx should be released prior to returning it to the pool. If multiple TSCtx locks must be
 acquired at the same time (due to recursive compilation), then locks should be acquired in the order
 that the TSCtxs were borrowed from the pool.
+
+The following is a level 5 lock
+
+>   * JuliaOJIT::EmissionMutex
 
 The following are a level 6 lock, which can only recurse to acquire locks at lower levels:
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1218,11 +1218,12 @@ JuliaOJIT::JuliaOJIT()
             }
         ),
 #endif
+    LockLayer(ObjectLayer),
     Pipelines{
-        std::make_unique<PipelineT>(ObjectLayer, *TM, 0),
-        std::make_unique<PipelineT>(ObjectLayer, *TM, 1),
-        std::make_unique<PipelineT>(ObjectLayer, *TM, 2),
-        std::make_unique<PipelineT>(ObjectLayer, *TM, 3),
+        std::make_unique<PipelineT>(LockLayer, *TM, 0),
+        std::make_unique<PipelineT>(LockLayer, *TM, 1),
+        std::make_unique<PipelineT>(LockLayer, *TM, 2),
+        std::make_unique<PipelineT>(LockLayer, *TM, 3),
     },
     OptSelLayer(Pipelines)
 {
@@ -1363,10 +1364,6 @@ void JuliaOJIT::addModule(orc::ThreadSafeModule TSM)
         }
 #endif
     });
-
-#ifndef JL_USE_JITLINK
-    std::lock_guard<std::mutex> EmissionLock(EmissionMutex);
-#endif
 
     // TODO: what is the performance characteristics of this?
     cantFail(OptSelLayer.add(JD, std::move(TSM)));

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1374,6 +1374,7 @@ void JuliaOJIT::addModule(orc::ThreadSafeModule TSM)
     // (can't handle compilation recursion)
     for (auto &sym : cantFail(ES.lookup({{&JD, orc::JITDylibLookupFlags::MatchExportedSymbolsOnly}}, NewExports))) {
         assert(sym.second);
+        (void) sym;
     }
 }
 

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -268,6 +268,21 @@ public:
 #else
     typedef orc::RTDyldObjectLinkingLayer ObjLayerT;
 #endif
+    struct LockLayerT : public orc::ObjectLayer {
+
+        LockLayerT(orc::ObjectLayer &BaseLayer) : orc::ObjectLayer(BaseLayer.getExecutionSession()), BaseLayer(BaseLayer) {}
+
+        void emit(std::unique_ptr<orc::MaterializationResponsibility> R,
+                            std::unique_ptr<MemoryBuffer> O) override {
+#ifndef JL_USE_JITLINK
+            std::lock_guard<std::mutex> lock(EmissionMutex);
+#endif
+            BaseLayer.emit(std::move(R), std::move(O));
+        }
+    private:
+        orc::ObjectLayer &BaseLayer;
+        std::mutex EmissionMutex;
+    };
     typedef orc::IRCompileLayer CompileLayerT;
     typedef orc::IRTransformLayer OptimizeLayerT;
     typedef object::OwningBinary<object::ObjectFile> OwningObj;
@@ -478,8 +493,6 @@ private:
     int RLST_inc = 0;
     DenseMap<void*, std::string> ReverseLocalSymbolTable;
 
-    std::mutex EmissionMutex;
-
     //Compilation streams
     jl_locked_stream dump_emitted_mi_name_stream;
     jl_locked_stream dump_compiles_stream;
@@ -494,6 +507,7 @@ private:
     const std::unique_ptr<jitlink::JITLinkMemoryManager> MemMgr;
 #endif
     ObjLayerT ObjectLayer;
+    LockLayerT LockLayer;
     const std::array<std::unique_ptr<PipelineT>, 4> Pipelines;
     OptSelLayerT OptSelLayer;
 };

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -478,6 +478,8 @@ private:
     int RLST_inc = 0;
     DenseMap<void*, std::string> ReverseLocalSymbolTable;
 
+    std::mutex EmissionMutex;
+
     //Compilation streams
     jl_locked_stream dump_emitted_mi_name_stream;
     jl_locked_stream dump_compiles_stream;


### PR DESCRIPTION
This should protect against any memory manager shenanigans when the codegen lock is removed. Also, make only one lookup request instead of once per symbol.