### PR TITLE
provide documentation for the as keyword

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -66,7 +66,8 @@ kw"export"
 `import` or `using`, for the purpose of working around name conflicts as
 well as for shortening names.
 
-`import CSV as C` brings the imported `CSV` package into scope as `C`.
+`import BenchMarkTools as BT` brings the imported `BenchMarkTools` package
+into scope as `BT`.
 
 `import CSV: read as rd, write as wd` brings the `read` and `write` methods
 from `CSV` into scope as `rd` and `wd` respectively.

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -73,7 +73,7 @@ into scope as `BT`.
 from `CSV` into scope as `rd` and `wd` respectively.
 
 `as` works with `using` only when individual identifiers are brought into scope.
-E.g `using CSV: read as rd` or `using CSV: read as rd, write as wd` works,
+For example, `using LinearAlgebra: eigen as eig` or `using LinearAlgebra: eigen as eig, cholesky as chol` works,
 but this: `using CSV as rd`, throws an error, since it operates on all of the
 `export`ed names in `CSV`.
 """

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -67,8 +67,8 @@ kw"export"
 well as for shortening names.  (Outside of `import` or `using` statements,
 `as` is not a keyword and can be used as an ordinary identifier.)
 
-`import BenchMarkTools as BT` brings the imported `BenchMarkTools` package
-into scope as `BT`.
+`import LinearAlgebra as LA` brings the imported `LinearAlgebra` standard library
+into scope as `LA`.
 
 `import LinearAlgebra: eigen as eig, cholesky as chol` brings the `eigen` and `cholesky` methods
 from `LinearAlgebra` into scope as `eig` and `chol` respectively.

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -64,7 +64,8 @@ kw"export"
 
 `as` is used as a keyword to rename an identifier brought into scope by
 `import` or `using`, for the purpose of working around name conflicts as
-well as for shortening names.
+well as for shortening names.  (Outside of `import` or `using` statements,
+`as` is not a keyword and can be used as an ordinary identifier.)
 
 `import BenchMarkTools as BT` brings the imported `BenchMarkTools` package
 into scope as `BT`.

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -72,7 +72,7 @@ into scope as `BT`.
 `import CSV: read as rd, write as wd` brings the `read` and `write` methods
 from `CSV` into scope as `rd` and `wd` respectively.
 
-`as` works with `using` only when single identifiers are brought into scope.
+`as` works with `using` only when individual identifiers are brought into scope.
 E.g `using CSV: read as rd` or `using CSV: read as rd, write as wd` works,
 but this: `using CSV as rd`, throws an error, since it operates on all of the
 `export`ed names in `CSV`.

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -75,8 +75,8 @@ from `LinearAlgebra` into scope as `eig` and `chol` respectively.
 
 `as` works with `using` only when individual identifiers are brought into scope.
 For example, `using LinearAlgebra: eigen as eig` or `using LinearAlgebra: eigen as eig, cholesky as chol` works,
-but this: `using CSV as rd`, throws an error, since it operates on all of the
-`export`ed names in `CSV`.
+but `using LinearAlgebra as LA` is invalid syntax, since it is nonsensical to
+rename *all* exported names from `LinearAlgebra` to `LA`.
 """
 kw"as"
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -69,8 +69,8 @@ well as for shortening names.
 `import BenchMarkTools as BT` brings the imported `BenchMarkTools` package
 into scope as `BT`.
 
-`import CSV: read as rd, write as wd` brings the `read` and `write` methods
-from `CSV` into scope as `rd` and `wd` respectively.
+`import LinearAlgebra: eigen as eig, cholesky as chol` brings the `eigen` and `cholesky` methods
+from `LinearAlgebra` into scope as `eig` and `chol` respectively.
 
 `as` works with `using` only when individual identifiers are brought into scope.
 For example, `using LinearAlgebra: eigen as eig` or `using LinearAlgebra: eigen as eig, cholesky as chol` works,

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -60,6 +60,25 @@ See the [manual section about modules](@ref modules) for details.
 kw"export"
 
 """
+    as
+
+`as` is used as a keyword to rename an identifier brought into scope by
+`import` or `using`, for the purpose of working around name conflicts as
+well as for shortening names.
+
+`import CSV as C` brings the imported `CSV` package into scope as `C`.
+
+`import CSV: read as rd, write as wd` brings the `read` and `write` methods
+from `CSV` into scope as `rd` and `wd` respectively.
+
+`as` works with `using` only when single identifiers are brought into scope.
+E.g `using CSV: read as rd` or `using CSV: read as rd, write as wd` works,
+but this: `using CSV as rd`, throws an error, since it operates on all of the
+`export`ed names in `CSV`.
+"""
+kw"as"
+
+"""
     abstract type
 
 `abstract type` declares a type that cannot be instantiated, and serves only as a node in the

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -58,14 +58,16 @@ However, you can create variables with names:
 Finally:
 `where` is parsed as an infix operator for writing parametric method and type definitions;
 `in` and `isa` are parsed as infix operators;
-and `outer` is parsed as a keyword when used to modify the scope of a variable in an iteration specification of a `for` loop.
-Creation of variables named `where`, `in`, `isa` or `outer` is allowed though.
+`outer` is parsed as a keyword when used to modify the scope of a variable in an iteration specification of a `for` loop.
+and `as` is used as a keyword to rename an identifier brought into scope by `import` or `using`.
+Creation of variables named `where`, `in`, `isa`, `outer` and `as` is allowed though.
 
 ```@docs
 module
 export
 import
 using
+as
 baremodule
 function
 macro

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -58,7 +58,7 @@ However, you can create variables with names:
 Finally:
 `where` is parsed as an infix operator for writing parametric method and type definitions;
 `in` and `isa` are parsed as infix operators;
-`outer` is parsed as a keyword when used to modify the scope of a variable in an iteration specification of a `for` loop.
+`outer` is parsed as a keyword when used to modify the scope of a variable in an iteration specification of a `for` loop;
 and `as` is used as a keyword to rename an identifier brought into scope by `import` or `using`.
 Creation of variables named `where`, `in`, `isa`, `outer` and `as` is allowed though.
 

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -60,7 +60,7 @@ Finally:
 `in` and `isa` are parsed as infix operators;
 `outer` is parsed as a keyword when used to modify the scope of a variable in an iteration specification of a `for` loop;
 and `as` is used as a keyword to rename an identifier brought into scope by `import` or `using`.
-Creation of variables named `where`, `in`, `isa`, `outer` and `as` is allowed though.
+Creation of variables named `where`, `in`, `isa`, `outer` and `as` is allowed, though.
 
 ```@docs
 module


### PR DESCRIPTION
`as` is a special keyword, which acts as a reserved word in certain statements, just like `where` is. `where` is documented, but `as` isn't, which I don't see any reasons for.

Also, its surprising to see that none of the docs of `using`, `import` or `export` speaks on `as`, which is a useful special keyword, seeing that some package names are too long and would be terse to type all over in source code.

So, while I only opened a PR for `as` to be documented, it would also be worth it to see the `as` keyword added to any one of the aforementioned keywords.