### PR TITLE
add getindex(nt::NamedTuple, ::Colon) method

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -135,6 +135,7 @@ firstindex(t::NamedTuple) = 1
 lastindex(t::NamedTuple) = nfields(t)
 getindex(t::NamedTuple, i::Int) = getfield(t, i)
 getindex(t::NamedTuple, i::Symbol) = getfield(t, i)
+getindex(t::NamedTuple, ::Colon) = t
 @inline getindex(t::NamedTuple, idxs::Tuple{Vararg{Symbol}}) = NamedTuple{idxs}(t)
 @inline getindex(t::NamedTuple, idxs::AbstractVector{Symbol}) = NamedTuple{Tuple(idxs)}(t)
 indexed_iterate(t::NamedTuple, i::Int, state=1) = (getfield(t, i), i+1)

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -26,6 +26,7 @@
 @test (x=4, y=5, z=6)[[:x, :y]] == (x=4, y=5)
 @test (x=4, y=5, z=6)[[:x]] == (x=4,)
 @test (x=4, y=5, z=6)[()] == NamedTuple()
+@test (x=4, y=5, z=6)[:] == (x=4, y=5, z=6)
 @test NamedTuple()[()] == NamedTuple()
 @test_throws ErrorException (x=4, y=5, z=6).a
 @test_throws BoundsError (a=2,)[0]


### PR DESCRIPTION
Addresses #47821 

This is arguably a bug fix, as it probably should have been included in #38878, but I don't know the implications of treating something as a new feature vs bug fix.