### PR TITLE
Fixed the order of arguments in Dates (ceil, round, floor)  with documentation & test

### DIFF
--- a/stdlib/Dates/docs/src/index.md
+++ b/stdlib/Dates/docs/src/index.md
@@ -603,13 +603,13 @@ julia> canonicalize(t2-t1) # creates a CompoundPeriod
 month or 15 minutes) with [`floor`](@ref), [`ceil`](@ref), or [`round`](@ref):
 
 ```jldoctest
-julia> floor(Date(1985, 8, 16), Dates.Month)
+julia> floor(Dates.Month, Date(1985, 8, 16))
 1985-08-01
 
-julia> ceil(DateTime(2013, 2, 13, 0, 31, 20), Dates.Minute(15))
+julia> ceil(Dates.Minute(15), DateTime(2013, 2, 13, 0, 31, 20))
 2013-02-13T00:45:00
 
-julia> round(DateTime(2016, 8, 6, 20, 15), Dates.Day)
+julia> round(Dates.Day, DateTime(2016, 8, 6, 20, 15))
 2016-08-07T00:00:00
 ```
 
@@ -629,7 +629,7 @@ in which this is not true may lead to confusion. What is the expected result of 
 to the nearest 10 hours?
 
 ```jldoctest
-julia> round(DateTime(2016, 7, 17, 11, 55), Dates.Hour(10))
+julia> round(Dates.Hour(10), DateTime(2016, 7, 17, 11, 55))
 2016-07-17T12:00:00
 ```
 
@@ -654,10 +654,10 @@ when we round to the nearest `P(2)`, where `P` is a [`Period`](@ref) type? In so
 when `P <: Dates.TimePeriod`) the answer is clear:
 
 ```jldoctest
-julia> round(DateTime(2016, 7, 17, 8, 55, 30), Dates.Hour(2))
+julia> round(Dates.Hour(2), DateTime(2016, 7, 17, 8, 55, 30))
 2016-07-17T08:00:00
 
-julia> round(DateTime(2016, 7, 17, 8, 55, 30), Dates.Minute(2))
+julia> round(Dates.Minute(2), DateTime(2016, 7, 17, 8, 55, 30))
 2016-07-17T08:56:00
 ```
 
@@ -666,7 +666,7 @@ order period. But in the case of two months (which still divides evenly into one
 may be surprising:
 
 ```jldoctest
-julia> round(DateTime(2016, 7, 17, 8, 55, 30), Dates.Month(2))
+julia> round(Dates.Month(2), DateTime(2016, 7, 17, 8, 55, 30))
 2016-07-01T00:00:00
 ```
 
@@ -814,15 +814,15 @@ Dates.periods
 with `floor`, `ceil`, or `round`.
 
 ```@docs
-Base.floor(::Dates.TimeType, ::Dates.Period)
-Base.ceil(::Dates.TimeType, ::Dates.Period)
-Base.round(::Dates.TimeType, ::Dates.Period, ::RoundingMode{:NearestTiesUp})
+Base.floor(::Dates.Period, ::Dates.TimeType)
+Base.ceil(::Dates.Period, ::Dates.TimeType)
+Base.round(::Dates.Period, ::Dates.TimeType, ::RoundingMode{:NearestTiesUp})
 ```
 
 Most `Period` values can also be rounded to a specified resolution:
 
 ```@docs
-Base.floor(::Dates.ConvertiblePeriod, ::T) where T <: Dates.ConvertiblePeriod
+Base.floor(::T, ::Dates.ConvertiblePeriod) where T <: Dates.ConvertiblePeriod
 Base.ceil(::Dates.ConvertiblePeriod, ::Dates.ConvertiblePeriod)
 Base.round(::Dates.ConvertiblePeriod, ::Dates.ConvertiblePeriod, ::RoundingMode{:NearestTiesUp})
 ```

--- a/stdlib/Dates/src/deprecated.jl
+++ b/stdlib/Dates/src/deprecated.jl
@@ -115,4 +115,3 @@ end
 
 @simple_deprecate(Base.round(x::TimeTypeOrPeriod, ::Type{P}, r::RoundingMode=RoundNearestTiesUp) where P <: Period, Base.round(oneunit(P), x, r))
 @simple_deprecate(Base.round(::Type{Date}, x::TimeTypeOrPeriod, ::Type{P}, r::RoundingMode=RoundNearestTiesUp) where P <: Period, Base.round(oneunit(P), Date(x), r))
-

--- a/stdlib/Dates/src/deprecated.jl
+++ b/stdlib/Dates/src/deprecated.jl
@@ -98,7 +98,7 @@ end
 @simple_deprecate(Base.ceil(x::ConvertiblePeriod, precision::ConvertiblePeriod), Base.ceil(precision, x))
 
 @simple_deprecate(Base.round(dt::TimeType,  p::Period, r::RoundingMode{:NearestTiesUp}), Base.round(p, dt, r))
-# The definitions were excluded due to ambiguities, and it didn't effeect test results
+# The definitions were excluded due to ambiguities, and it didn't effect test results
 # @simple_deprecate(Base.round(x::ConvertiblePeriod, precision::ConvertiblePeriod, r::RoundingMode{:NearestTiesUp}), Base.round(precision, x, r))
 # @simple_deprecate(Base.round(x::TimeTypeOrPeriod, p::Period, r::RoundingMode{:Down}), Base.round(p,x,r))
 # @simple_deprecate(Base.round(x::TimeTypeOrPeriod, p::Period, r::RoundingMode{:Up}), Base.round(p,x,r))

--- a/stdlib/Dates/src/deprecated.jl
+++ b/stdlib/Dates/src/deprecated.jl
@@ -98,13 +98,13 @@ end
 @simple_deprecate(Base.ceil(x::ConvertiblePeriod, precision::ConvertiblePeriod), Base.ceil(precision, x))
 
 @simple_deprecate(Base.round(dt::TimeType,  p::Period, r::RoundingMode{:NearestTiesUp}), Base.round(p, dt, r))
-# The definitions were excluded due to ambiguities, and it didn't effect test results
+# These definitions were excluded due to ambiguities, and it didn't effect test results
 # @simple_deprecate(Base.round(x::ConvertiblePeriod, precision::ConvertiblePeriod, r::RoundingMode{:NearestTiesUp}), Base.round(precision, x, r))
 # @simple_deprecate(Base.round(x::TimeTypeOrPeriod, p::Period, r::RoundingMode{:Down}), Base.round(p,x,r))
 # @simple_deprecate(Base.round(x::TimeTypeOrPeriod, p::Period, r::RoundingMode{:Up}), Base.round(p,x,r))
 
 # This had to be replace with line below to limit ambiguities
-# @simple_deprecate(# Base.round(x::TimeTypeOrPeriod, p::Period), Base.round(p, x, RoundNearestTiesUp))
+# @simple_deprecate(Base.round(x::TimeTypeOrPeriod, p::Period), Base.round(p, x, RoundNearestTiesUp))
 @simple_deprecate(Base.round(x::TimeType, p::Period), Base.round(p, x))
 
 @simple_deprecate(Base.floor(x::TimeTypeOrPeriod, p::Type{P}) where P <: Period, Base.floor(p, x))

--- a/stdlib/Dates/src/deprecated.jl
+++ b/stdlib/Dates/src/deprecated.jl
@@ -84,20 +84,20 @@ macro simple_deprecate(old, new)
 end
 
 @simple_deprecate(Base.floor(dt::Date, p::Year) , Base.floor(p, dt)) #@depreciate
-
-
 @simple_deprecate(Base.floor(dt::Date, p::Month), Base.floor(p, dt))
 @simple_deprecate(Base.floor(dt::Date, p::Quarter), Base.floor(p, dt))
 @simple_deprecate(Base.floor(dt::Date, p::Week), Base.floor(p, dt))
 @simple_deprecate(Base.floor(dt::Date, p::Day), Base.floor(p, dt))
+
 @simple_deprecate(Base.floor(dt::DateTime, p::DatePeriod), Base.floor(p, dt))
 @simple_deprecate(Base.floor(dt::DateTime, p::TimePeriod), Base.floor(p, dt))
+
 @simple_deprecate(Base.floor(x::ConvertiblePeriod, precision::T)  where T <: ConvertiblePeriod, Base.floor(precision, x))
+
 @simple_deprecate(Base.ceil(dt::TimeType, p::Period), Base.ceil(p, dt))
 @simple_deprecate(Base.ceil(x::ConvertiblePeriod, precision::ConvertiblePeriod), Base.ceil(precision, x))
 
 @simple_deprecate(Base.round(dt::TimeType,  p::Period, r::RoundingMode{:NearestTiesUp}), Base.round(p, dt, r))
-
 # The definitions were excluded due to ambiguities, and it didn't effeect test results
 # @simple_deprecate(Base.round(x::ConvertiblePeriod, precision::ConvertiblePeriod, r::RoundingMode{:NearestTiesUp}), Base.round(precision, x, r))
 # @simple_deprecate(Base.round(x::TimeTypeOrPeriod, p::Period, r::RoundingMode{:Down}), Base.round(p,x,r))

--- a/stdlib/Dates/src/rounding.jl
+++ b/stdlib/Dates/src/rounding.jl
@@ -279,7 +279,6 @@ Base.round(p::Period, ::TimeTypeOrPeriod, ::RoundingMode) = throw(DomainError(p)
 
 # Default to RoundNearestTiesUp.
 Base.round(p::Period, x::TimeTypeOrPeriod) = Base.round(p, x, RoundNearestTiesUp)
-# This is a reduced scope to cover the ambigous commened out deprecated method above 
 
 # Make rounding functions callable using Period types in addition to values.
 Base.floor(::Type{P}, x::TimeTypeOrPeriod) where P <: Period = Base.floor(oneunit(P), x)

--- a/stdlib/Dates/src/rounding.jl
+++ b/stdlib/Dates/src/rounding.jl
@@ -42,14 +42,12 @@ Take the given `DateTime` and return the number of milliseconds since the roundi
 """
 datetime2epochms(dt::DateTime) = value(dt) - DATETIMEEPOCH
 
-@depreciate Base.floor(dt::Date, p::Year) = Base.floor(p, dt)
 function Base.floor(p::Year, dt::Date)
     value(p) < 1 && throw(DomainError(p))
     years = year(dt)
     return Date(years - mod(years, value(p)))
 end
 
-@deprecate Base.floor(dt::Date, p::Month) = Base.floor(p, dt)
 function Base.floor(p::Month, dt::Date)
     value(p) < 1 && throw(DomainError(p))
     y, m = yearmonth(dt)
@@ -60,12 +58,10 @@ function Base.floor(p::Month, dt::Date)
     return Date(target_year, target_month)
 end
 
-@deprecate Base.floor(dt::Date, p::Quarter) = Base.floor(p, dt)
 function Base.floor(p::Quarter, dt::Date)
     return floor(dt, Month(p))
 end
 
-@deprecate Base.floor(dt::Date, p::Week) = Base.floor(p, dt)
 function Base.floor(p::Week, dt::Date)
     value(p) < 1 && throw(DomainError(p))
     days = value(dt) - WEEKEPOCH
@@ -73,17 +69,14 @@ function Base.floor(p::Week, dt::Date)
     return Date(UTD(WEEKEPOCH + Int64(days)))
 end
 
-@deprecate Base.floor(dt::Date, p::Day) = Base.floor(p, dt)
 function Base.floor(p::Day, dt::Date)
     value(p) < 1 && throw(DomainError(p))
     days = date2epochdays(dt)
     return epochdays2date(days - mod(days, value(p)))
 end
 
-@deprecate Base.floor(dt::DateTime, p::DatePeriod) = Base.floor(p, dt)
 Base.floor(p::DatePeriod, dt::DateTime) = DateTime(Base.floor(p, Date(dt)))
 
-@deprecate Base.floor(dt::DateTime, p::TimePeriod) = Base.floor(p, dt)
 function Base.floor(p::TimePeriod, dt::DateTime)
     value(p) < 1 && throw(DomainError(p))
     milliseconds = datetime2epochms(dt)
@@ -118,7 +111,6 @@ function Base.floor(precision::T, x::ConvertiblePeriod) where T <: ConvertiblePe
     _x, _precision = promote(x, precision)
     return T(_x - mod(_x, _precision))
 end
-@deprecate Base.floor(x::ConvertiblePeriod, precision::T) = Base.floor(precision, x)
 
 """
     floor(p::Period, dt::TimeType) -> TimeType
@@ -164,7 +156,6 @@ function Base.ceil(p::Period, dt::TimeType)
     f = floor(p, dt)
     return (dt == f) ? f : f + p
 end
-@deprecate Base.ceil(dt::TimeType, p::Period) = Base.ceil(p, dt)
 
 """
     ceil(precision::T, x::Period) where T <: Union{TimePeriod, Week, Day} -> T
@@ -193,7 +184,6 @@ function Base.ceil(precision::ConvertiblePeriod, x::ConvertiblePeriod)
     f = floor(precision, x)
     return (x == f) ? f : f + precision
 end
-@deprecate Base.ceil(x::ConvertiblePeriod, precision::ConvertiblePeriod) = Base.ceil(precision, x)
 
 """
     floorceil(p::Period, dt::TimeType) -> (TimeType, TimeType)
@@ -201,11 +191,10 @@ end
 Simultaneously return the `floor` and `ceil` of a `Date` or `DateTime` at resolution `p`.
 More efficient than calling both `floor` and `ceil` individually.
 """
-function floorceil(dt::TimeType, p::Period)
+function floorceil(p::Period, dt::TimeType)
     f = floor(p, dt)
     return f, (dt == f) ? f : f + p
 end
-@deprecate floorceil(dt::TimeType, p::Period) = floorceil(x, precision)
 
 """
     floorceil(precision::T, x::Period) where T <: Union{TimePeriod, Week, Day} -> (T, T)
@@ -213,11 +202,10 @@ end
 Simultaneously return the `floor` and `ceil` of `Period` at resolution `p`.  More efficient
 than calling both `floor` and `ceil` individually.
 """
-function floorceil(x::ConvertiblePeriod, precision::ConvertiblePeriod)
+function floorceil(precision::ConvertiblePeriod, x::ConvertiblePeriod)
     f = floor(precision, x)
     return f, (x == f) ? f : f + precision
 end
-@deprecate floorceil(x::ConvertiblePeriod, precision::ConvertiblePeriod) = floorceil(x, precision)
 
 """
     round(p::Period, dt::TimeType, [r::RoundingMode]) -> TimeType
@@ -246,7 +234,6 @@ function Base.round(p::Period, dt::TimeType, r::RoundingMode{:NearestTiesUp})
     f, c = floorceil(p, dt)
     return (dt - f) < (c - dt) ? f : c
 end
-@depreciate Base.round(dt::TimeType,  p::Period, r::RoundingMode{:NearestTiesUp}) = Base.round(p, dt, r)
 
 """
     round(precision::T, , x::Period, [r::RoundingMode]) where T <: Union{TimePeriod, Week, Day} -> T
@@ -281,43 +268,29 @@ function Base.round(precision::ConvertiblePeriod, x::ConvertiblePeriod, r::Round
     _x, _f, _c = promote(x, f, c)
     return (_x - _f) < (_c - _x) ? f : c
 end
-@depreciate Base.round(x::ConvertiblePeriod, precision::ConvertiblePeriod, r::RoundingMode{:NearestTiesUp}) = Base.round(precision, x, r)
 
-
-@depreciate Base.round(x::TimeTypeOrPeriod, p::Period, r::RoundingMode{:Down}) = Base.floor(p, x)
 Base.round(p::Period, x::TimeTypeOrPeriod, r::RoundingMode{:Down}) = Base.floor(p, x)
-@depreciate Base.round(x::TimeTypeOrPeriod, p::Period, r::RoundingMode{:Up}) = Base.ceil(p, x)
 Base.round(p::Period, x::TimeTypeOrPeriod, r::RoundingMode{:Up}) = Base.ceil(p, x)
 
 # No implementation of other `RoundingMode`s: rounding to nearest "even" is skipped because
 # "even" is not defined for Period; rounding toward/away from zero is skipped because ISO
 # 8601's year 0000 is not really "zero".
-@depreciate Base.round(::TimeTypeOrPeriod, p::Period, ::RoundingMode) = throw(DomainError(p))
 Base.round(p::Period, ::TimeTypeOrPeriod, ::RoundingMode) = throw(DomainError(p))
 
 # Default to RoundNearestTiesUp.
-@depreciate Base.round(x::TimeTypeOrPeriod, p::Period) = Base.round(p, x, RoundNearestTiesUp)
 Base.round(p::Period, x::TimeTypeOrPeriod) = Base.round(p, x, RoundNearestTiesUp)
+# This is a reduced scope to cover the ambigous commened out deprecated method above 
 
 # Make rounding functions callable using Period types in addition to values.
-@depreciate Base.floor(x::TimeTypeOrPeriod, ::Type{P}) where P <: Period = Base.floor(oneunit(P), x)
 Base.floor(::Type{P}, x::TimeTypeOrPeriod) where P <: Period = Base.floor(oneunit(P), x)
-
-@depreciate Base.ceil(x::TimeTypeOrPeriod, ::Type{P}) where P <: Period = Base.ceil(oneunit(P), x)
 Base.ceil(::Type{P}, x::TimeTypeOrPeriod)  where P <: Period = Base.ceil(oneunit(P), x)
-
-@depreciate Base.floor(::Type{Date}, x::TimeTypeOrPeriod, ::Type{P}) where P <: Period = Base.floor(oneunit(P), Date(x))
 Base.floor(x::TimeTypeOrPeriod, ::Type{Date}, ::Type{P}) where P <: Period = Base.floor(oneunit(P), Date(x))
-
-@depreciate Base.ceil(::Type{Date}, x::TimeTypeOrPeriod, ::Type{P}) where P <: Period = Base.ceil(oneunit(P), Date(x))
 Base.ceil(x::TimeTypeOrPeriod, ::Type{Date}, ::Type{P}) where P <: Period = Base.ceil(oneunit(P), Date(x))
 
-@depreciate Base.round(x::TimeTypeOrPeriod, ::Type{P}, r::RoundingMode=RoundNearestTiesUp) where P <: Period = Base.round(oneunit(P), x, r)
 function Base.round(::Type{P}, x::TimeTypeOrPeriod, r::RoundingMode=RoundNearestTiesUp) where P <: Period
     return Base.round(oneunit(P), x, r)
 end
 
-@deprecate Base.round(::Type{Date}, x::TimeTypeOrPeriod, ::Type{P}, r::RoundingMode=RoundNearestTiesUp) where P <: Period = Base.round(oneunit(P), Date(x), r)
 function Base.round(x::TimeTypeOrPeriod, ::Type{Date}, ::Type{P}, r::RoundingMode=RoundNearestTiesUp) where P <: Period
     return Base.round(Date(x), oneunit(P), r)
 end

--- a/stdlib/Dates/src/rounding.jl
+++ b/stdlib/Dates/src/rounding.jl
@@ -113,12 +113,12 @@ julia> floor(Day, Hour(36))
 Rounding to a `precision` of `Month`s or `Year`s is not supported, as these `Period`s are of
 inconsistent length.
 """
-@deprecate Base.floor(x::ConvertiblePeriod, precision::T) = Base.floor(precision, x)
 function Base.floor(precision::T, x::ConvertiblePeriod) where T <: ConvertiblePeriod
     value(precision) < 1 && throw(DomainError(precision))
     _x, _precision = promote(x, precision)
     return T(_x - mod(_x, _precision))
 end
+@deprecate Base.floor(x::ConvertiblePeriod, precision::T) = Base.floor(precision, x)
 
 """
     floor(p::Period, dt::TimeType) -> TimeType
@@ -142,126 +142,131 @@ julia> floor(Day, DateTime(2016, 8, 6, 12, 0, 0))
 Base.floor(::Dates.Period, ::Dates.TimeType)
 
 """
-    ceil(dt::TimeType, p::Period) -> TimeType
+    ceil(p::Period, dt::TimeType) -> TimeType
 
 Return the nearest `Date` or `DateTime` greater than or equal to `dt` at resolution `p`.
 
-For convenience, `p` may be a type instead of a value: `ceil(dt, Dates.Hour)` is a shortcut
-for `ceil(dt, Dates.Hour(1))`.
+For convenience, `p` may be a type instead of a value: `ceil(Dates.Hour, dt)` is a shortcut
+for `ceil(Dates.Hour(1), dt)`.
 
 ```jldoctest
-julia> ceil(Date(1985, 8, 16), Month)
+julia> ceil(Month, Date(1985, 8, 16))
 1985-09-01
 
-julia> ceil(DateTime(2013, 2, 13, 0, 31, 20), Minute(15))
+julia> ceil(Minute(15), DateTime(2013, 2, 13, 0, 31, 20))
 2013-02-13T00:45:00
 
-julia> ceil(DateTime(2016, 8, 6, 12, 0, 0), Day)
+julia> ceil(Day, DateTime(2016, 8, 6, 12, 0, 0))
 2016-08-07T00:00:00
 ```
 """
-function Base.ceil(dt::TimeType, p::Period)
-    f = floor(dt, p)
+function Base.ceil(p::Period, dt::TimeType)
+    f = floor(p, dt)
     return (dt == f) ? f : f + p
 end
+@deprecate Base.ceil(dt::TimeType, p::Period) = Base.ceil(p, dt)
 
 """
-    ceil(x::Period, precision::T) where T <: Union{TimePeriod, Week, Day} -> T
+    ceil(precision::T, x::Period) where T <: Union{TimePeriod, Week, Day} -> T
 
 Round `x` up to the nearest multiple of `precision`. If `x` and `precision` are different
 subtypes of `Period`, the return value will have the same type as `precision`.
 
-For convenience, `precision` may be a type instead of a value: `ceil(x, Dates.Hour)` is a
-shortcut for `ceil(x, Dates.Hour(1))`.
+For convenience, `precision` may be a type instead of a value: `ceil(Dates.Hour, x)` is a
+shortcut for `ceil(Dates.Hour(1), x)`.
 
 ```jldoctest
-julia> ceil(Day(16), Week)
+julia> ceil(Week, Day(16))
 3 weeks
 
-julia> ceil(Minute(44), Minute(15))
+julia> ceil(Minute(15), Minute(44))
 45 minutes
 
-julia> ceil(Hour(36), Day)
+julia> ceil(Day, Hour(36))
 2 days
 ```
 
 Rounding to a `precision` of `Month`s or `Year`s is not supported, as these `Period`s are of
 inconsistent length.
 """
-function Base.ceil(x::ConvertiblePeriod, precision::ConvertiblePeriod)
-    f = floor(x, precision)
+function Base.ceil(precision::ConvertiblePeriod, x::ConvertiblePeriod)
+    f = floor(precision, x)
     return (x == f) ? f : f + precision
 end
+@deprecate Base.ceil(x::ConvertiblePeriod, precision::ConvertiblePeriod) = Base.ceil(precision, x)
 
 """
-    floorceil(dt::TimeType, p::Period) -> (TimeType, TimeType)
+    floorceil(p::Period, dt::TimeType) -> (TimeType, TimeType)
 
 Simultaneously return the `floor` and `ceil` of a `Date` or `DateTime` at resolution `p`.
 More efficient than calling both `floor` and `ceil` individually.
 """
 function floorceil(dt::TimeType, p::Period)
-    f = floor(dt, p)
+    f = floor(p, dt)
     return f, (dt == f) ? f : f + p
 end
+@deprecate floorceil(dt::TimeType, p::Period) = floorceil(x, precision)
 
 """
-    floorceil(x::Period, precision::T) where T <: Union{TimePeriod, Week, Day} -> (T, T)
+    floorceil(precision::T, x::Period) where T <: Union{TimePeriod, Week, Day} -> (T, T)
 
 Simultaneously return the `floor` and `ceil` of `Period` at resolution `p`.  More efficient
 than calling both `floor` and `ceil` individually.
 """
 function floorceil(x::ConvertiblePeriod, precision::ConvertiblePeriod)
-    f = floor(x, precision)
+    f = floor(precision, x)
     return f, (x == f) ? f : f + precision
 end
+@deprecate floorceil(x::ConvertiblePeriod, precision::ConvertiblePeriod) = floorceil(x, precision)
 
 """
-    round(dt::TimeType, p::Period, [r::RoundingMode]) -> TimeType
+    round(p::Period, dt::TimeType, [r::RoundingMode]) -> TimeType
 
 Return the `Date` or `DateTime` nearest to `dt` at resolution `p`. By default
 (`RoundNearestTiesUp`), ties (e.g., rounding 9:30 to the nearest hour) will be rounded up.
 
-For convenience, `p` may be a type instead of a value: `round(dt, Dates.Hour)` is a shortcut
-for `round(dt, Dates.Hour(1))`.
+For convenience, `p` may be a type instead of a value: `round(Dates.Hour, dt)` is a shortcut
+for `round(Dates.Hour(1), dt)`.
 
 ```jldoctest
-julia> round(Date(1985, 8, 16), Month)
+julia> round(Month, Date(1985, 8, 16))
 1985-08-01
 
-julia> round(DateTime(2013, 2, 13, 0, 31, 20), Minute(15))
+julia> round(Minute(15), DateTime(2013, 2, 13, 0, 31, 20))
 2013-02-13T00:30:00
 
-julia> round(DateTime(2016, 8, 6, 12, 0, 0), Day)
+julia> round(Day, DateTime(2016, 8, 6, 12, 0, 0))
 2016-08-07T00:00:00
 ```
 
-Valid rounding modes for `round(::TimeType, ::Period, ::RoundingMode)` are
+Valid rounding modes for `round(::Period, ::TimeType, ::RoundingMode)` are
 `RoundNearestTiesUp` (default), `RoundDown` (`floor`), and `RoundUp` (`ceil`).
 """
-function Base.round(dt::TimeType, p::Period, r::RoundingMode{:NearestTiesUp})
-    f, c = floorceil(dt, p)
+function Base.round(p::Period, dt::TimeType, r::RoundingMode{:NearestTiesUp})
+    f, c = floorceil(p, dt)
     return (dt - f) < (c - dt) ? f : c
 end
+@depreciate Base.round(dt::TimeType,  p::Period, r::RoundingMode{:NearestTiesUp}) = Base.round(p, dt, r)
 
 """
-    round(x::Period, precision::T, [r::RoundingMode]) where T <: Union{TimePeriod, Week, Day} -> T
+    round(precision::T, , x::Period, [r::RoundingMode]) where T <: Union{TimePeriod, Week, Day} -> T
 
 Round `x` to the nearest multiple of `precision`. If `x` and `precision` are different
 subtypes of `Period`, the return value will have the same type as `precision`. By default
 (`RoundNearestTiesUp`), ties (e.g., rounding 90 minutes to the nearest hour) will be rounded
 up.
 
-For convenience, `precision` may be a type instead of a value: `round(x, Dates.Hour)` is a
-shortcut for `round(x, Dates.Hour(1))`.
+For convenience, `precision` may be a type instead of a value: `round(Dates.Hour, x)` is a
+shortcut for `round(Dates.Hour(1), x)`.
 
 ```jldoctest
-julia> round(Day(16), Week)
+julia> round(Week, Day(16))
 2 weeks
 
-julia> round(Minute(44), Minute(15))
+julia> round(Minute(15), Minute(44))
 45 minutes
 
-julia> round(Hour(36), Day)
+julia> round(Day, Hour(36))
 2 days
 ```
 
@@ -271,33 +276,48 @@ Valid rounding modes for `round(::Period, ::T, ::RoundingMode)` are `RoundNeares
 Rounding to a `precision` of `Month`s or `Year`s is not supported, as these `Period`s are of
 inconsistent length.
 """
-function Base.round(x::ConvertiblePeriod, precision::ConvertiblePeriod, r::RoundingMode{:NearestTiesUp})
-    f, c = floorceil(x, precision)
+function Base.round(precision::ConvertiblePeriod, x::ConvertiblePeriod, r::RoundingMode{:NearestTiesUp})
+    f, c = floorceil(precision, x)
     _x, _f, _c = promote(x, f, c)
     return (_x - _f) < (_c - _x) ? f : c
 end
+@depreciate Base.round(x::ConvertiblePeriod, precision::ConvertiblePeriod, r::RoundingMode{:NearestTiesUp}) = Base.round(precision, x, r)
 
-Base.round(x::TimeTypeOrPeriod, p::Period, r::RoundingMode{:Down}) = Base.floor(x, p)
-Base.round(x::TimeTypeOrPeriod, p::Period, r::RoundingMode{:Up}) = Base.ceil(x, p)
+
+@depreciate Base.round(x::TimeTypeOrPeriod, p::Period, r::RoundingMode{:Down}) = Base.floor(p, x)
+Base.round(p::Period, x::TimeTypeOrPeriod, r::RoundingMode{:Down}) = Base.floor(p, x)
+@depreciate Base.round(x::TimeTypeOrPeriod, p::Period, r::RoundingMode{:Up}) = Base.ceil(p, x)
+Base.round(p::Period, x::TimeTypeOrPeriod, r::RoundingMode{:Up}) = Base.ceil(p, x)
 
 # No implementation of other `RoundingMode`s: rounding to nearest "even" is skipped because
 # "even" is not defined for Period; rounding toward/away from zero is skipped because ISO
 # 8601's year 0000 is not really "zero".
-Base.round(::TimeTypeOrPeriod, p::Period, ::RoundingMode) = throw(DomainError(p))
+@depreciate Base.round(::TimeTypeOrPeriod, p::Period, ::RoundingMode) = throw(DomainError(p))
+Base.round(p::Period, ::TimeTypeOrPeriod, ::RoundingMode) = throw(DomainError(p))
 
 # Default to RoundNearestTiesUp.
-Base.round(x::TimeTypeOrPeriod, p::Period) = Base.round(x, p, RoundNearestTiesUp)
+@depreciate Base.round(x::TimeTypeOrPeriod, p::Period) = Base.round(p, x, RoundNearestTiesUp)
+Base.round(p::Period, x::TimeTypeOrPeriod) = Base.round(p, x, RoundNearestTiesUp)
 
 # Make rounding functions callable using Period types in addition to values.
-Base.floor(x::TimeTypeOrPeriod, ::Type{P}) where P <: Period = Base.floor(x, oneunit(P))
-Base.ceil(x::TimeTypeOrPeriod, ::Type{P}) where P <: Period = Base.ceil(x, oneunit(P))
-Base.floor(::Type{Date}, x::TimeTypeOrPeriod, ::Type{P}) where P <: Period = Base.floor(Date(x), oneunit(P))
-Base.ceil(::Type{Date}, x::TimeTypeOrPeriod, ::Type{P}) where P <: Period = Base.ceil(Date(x), oneunit(P))
+@depreciate Base.floor(x::TimeTypeOrPeriod, ::Type{P}) where P <: Period = Base.floor(oneunit(P), x)
+Base.floor(::Type{P}, x::TimeTypeOrPeriod) where P <: Period = Base.floor(oneunit(P), x)
 
-function Base.round(x::TimeTypeOrPeriod, ::Type{P}, r::RoundingMode=RoundNearestTiesUp) where P <: Period
-    return Base.round(x, oneunit(P), r)
+@depreciate Base.ceil(x::TimeTypeOrPeriod, ::Type{P}) where P <: Period = Base.ceil(oneunit(P), x)
+Base.ceil(::Type{P}, x::TimeTypeOrPeriod)  where P <: Period = Base.ceil(oneunit(P), x)
+
+@depreciate Base.floor(::Type{Date}, x::TimeTypeOrPeriod, ::Type{P}) where P <: Period = Base.floor(oneunit(P), Date(x))
+Base.floor(x::TimeTypeOrPeriod, ::Type{Date}, ::Type{P}) where P <: Period = Base.floor(oneunit(P), Date(x))
+
+@depreciate Base.ceil(::Type{Date}, x::TimeTypeOrPeriod, ::Type{P}) where P <: Period = Base.ceil(oneunit(P), Date(x))
+Base.ceil(x::TimeTypeOrPeriod, ::Type{Date}, ::Type{P}) where P <: Period = Base.ceil(oneunit(P), Date(x))
+
+@depreciate Base.round(x::TimeTypeOrPeriod, ::Type{P}, r::RoundingMode=RoundNearestTiesUp) where P <: Period = Base.round(oneunit(P), x, r)
+function Base.round(::Type{P}, x::TimeTypeOrPeriod, r::RoundingMode=RoundNearestTiesUp) where P <: Period
+    return Base.round(oneunit(P), x, r)
 end
 
-function Base.round(::Type{Date}, x::TimeTypeOrPeriod, ::Type{P}, r::RoundingMode=RoundNearestTiesUp) where P <: Period
+@deprecate Base.round(::Type{Date}, x::TimeTypeOrPeriod, ::Type{P}, r::RoundingMode=RoundNearestTiesUp) where P <: Period = Base.round(oneunit(P), Date(x), r)
+function Base.round(x::TimeTypeOrPeriod, ::Type{Date}, ::Type{P}, r::RoundingMode=RoundNearestTiesUp) where P <: Period
     return Base.round(Date(x), oneunit(P), r)
 end

--- a/stdlib/Dates/test/rounding.jl
+++ b/stdlib/Dates/test/rounding.jl
@@ -23,170 +23,170 @@ using Dates
 end
 @testset "Basic rounding" begin
     dt = Dates.Date(2016, 2, 28)    # Sunday
-    @test floor(dt, Dates.Year) == Dates.Date(2016)
-    @test floor(dt, Dates.Year(5)) == Dates.Date(2015)
-    @test floor(dt, Dates.Year(10)) == Dates.Date(2010)
-    @test floor(dt, Dates.Quarter) == Dates.Date(2016, 1)
-    @test floor(dt, Dates.Quarter(6)) == Dates.Date(2016, 1)
-    @test floor(dt, Dates.Month) == Dates.Date(2016, 2)
-    @test floor(dt, Dates.Month(6)) == Dates.Date(2016, 1)
-    @test floor(dt, Dates.Week) == Dates.toprev(dt, Dates.Monday)
-    @test ceil(dt, Dates.Year) == Dates.Date(2017)
-    @test ceil(dt, Dates.Year(5)) == Dates.Date(2020)
-    @test ceil(dt, Dates.Quarter) == Dates.Date(2016, 4)
-    @test ceil(dt, Dates.Quarter(6)) == Dates.Date(2017, 7)
-    @test ceil(dt, Dates.Month) == Dates.Date(2016, 3)
-    @test ceil(dt, Dates.Month(6)) == Dates.Date(2016, 7)
-    @test ceil(dt, Dates.Week) == Dates.tonext(dt, Dates.Monday)
-    @test round(dt, Dates.Year) == Dates.Date(2016)
-    @test round(dt, Dates.Month) == Dates.Date(2016, 3)
-    @test round(dt, Dates.Week) == Dates.Date(2016, 2, 29)
+    @test floor(Dates.Year, dt) == Dates.Date(2016)
+    @test floor(Dates.Year(5), dt) == Dates.Date(2015)
+    @test floor(Dates.Year(10), dt) == Dates.Date(2010)
+    @test floor(Dates.Quarter, dt) == Dates.Date(2016, 1)
+    @test floor(Dates.Quarter(6), dt) == Dates.Date(2016, 1)
+    @test floor(Dates.Month, dt) == Dates.Date(2016, 2)
+    @test floor(Dates.Month(6), dt) == Dates.Date(2016, 1)
+    @test floor(Dates.Week, dt) == Dates.toprev(dt, Dates.Monday)
+    @test ceil(Dates.Year, dt) == Dates.Date(2017)
+    @test ceil(Dates.Year(5), dt) == Dates.Date(2020)
+    @test ceil(Dates.Quarter, dt) == Dates.Date(2016, 4)
+    @test ceil(Dates.Quarter(6), dt) == Dates.Date(2017, 7)
+    @test ceil(Dates.Month, dt) == Dates.Date(2016, 3)
+    @test ceil(Dates.Month(6), dt) == Dates.Date(2016, 7)
+    @test ceil(Dates.Week, dt) == Dates.tonext(dt, Dates.Monday)
+    @test round(Dates.Year, dt) == Dates.Date(2016)
+    @test round(Dates.Month, dt) == Dates.Date(2016, 3)
+    @test round(Dates.Week, dt) == Dates.Date(2016, 2, 29)
 
     dt = Dates.DateTime(2016, 2, 28, 15, 10, 50, 500)
-    @test floor(dt, Dates.Day) == Dates.DateTime(2016, 2, 28)
-    @test floor(dt, Dates.Hour) == Dates.DateTime(2016, 2, 28, 15)
-    @test floor(dt, Dates.Hour(2)) == Dates.DateTime(2016, 2, 28, 14)
-    @test floor(dt, Dates.Hour(12)) == Dates.DateTime(2016, 2, 28, 12)
-    @test floor(dt, Dates.Minute) == Dates.DateTime(2016, 2, 28, 15, 10)
-    @test floor(dt, Dates.Minute(15)) == Dates.DateTime(2016, 2, 28, 15, 0)
-    @test floor(dt, Dates.Second) == Dates.DateTime(2016, 2, 28, 15, 10, 50)
-    @test floor(dt, Dates.Second(30)) == Dates.DateTime(2016, 2, 28, 15, 10, 30)
-    @test ceil(dt, Dates.Day) == Dates.DateTime(2016, 2, 29)
-    @test ceil(dt, Dates.Hour) == Dates.DateTime(2016, 2, 28, 16)
-    @test ceil(dt, Dates.Hour(2)) == Dates.DateTime(2016, 2, 28, 16)
-    @test ceil(dt, Dates.Hour(12)) == Dates.DateTime(2016, 2, 29, 0)
-    @test ceil(dt, Dates.Minute) == Dates.DateTime(2016, 2, 28, 15, 11)
-    @test ceil(dt, Dates.Minute(15)) == Dates.DateTime(2016, 2, 28, 15, 15)
-    @test ceil(dt, Dates.Second) == Dates.DateTime(2016, 2, 28, 15, 10, 51)
-    @test ceil(dt, Dates.Second(30)) == Dates.DateTime(2016, 2, 28, 15, 11, 0)
-    @test round(dt, Dates.Day) == Dates.DateTime(2016, 2, 29)
-    @test round(dt, Dates.Hour) == Dates.DateTime(2016, 2, 28, 15)
-    @test round(dt, Dates.Hour(2)) == Dates.DateTime(2016, 2, 28, 16)
-    @test round(dt, Dates.Hour(12)) == Dates.DateTime(2016, 2, 28, 12)
-    @test round(dt, Dates.Minute) == Dates.DateTime(2016, 2, 28, 15, 11)
-    @test round(dt, Dates.Minute(15)) == Dates.DateTime(2016, 2, 28, 15, 15)
-    @test round(dt, Dates.Second) == Dates.DateTime(2016, 2, 28, 15, 10, 51)
-    @test round(dt, Dates.Second(30)) == Dates.DateTime(2016, 2, 28, 15, 11, 0)
+    @test floor(Dates.Day, dt) == Dates.DateTime(2016, 2, 28)
+    @test floor(Dates.Hour, dt) == Dates.DateTime(2016, 2, 28, 15)
+    @test floor(Dates.Hour(2), dt) == Dates.DateTime(2016, 2, 28, 14)
+    @test floor(Dates.Hour(12), dt) == Dates.DateTime(2016, 2, 28, 12)
+    @test floor(Dates.Minute, dt) == Dates.DateTime(2016, 2, 28, 15, 10)
+    @test floor(Dates.Minute(15), dt) == Dates.DateTime(2016, 2, 28, 15, 0)
+    @test floor(Dates.Second, dt) == Dates.DateTime(2016, 2, 28, 15, 10, 50)
+    @test floor(Dates.Second(30), dt) == Dates.DateTime(2016, 2, 28, 15, 10, 30)
+    @test ceil(Dates.Day, dt) == Dates.DateTime(2016, 2, 29)
+    @test ceil(Dates.Hour, dt) == Dates.DateTime(2016, 2, 28, 16)
+    @test ceil(Dates.Hour(2), dt) == Dates.DateTime(2016, 2, 28, 16)
+    @test ceil(Dates.Hour(12), dt) == Dates.DateTime(2016, 2, 29, 0)
+    @test ceil(Dates.Minute, dt) == Dates.DateTime(2016, 2, 28, 15, 11)
+    @test ceil(Dates.Minute(15), dt) == Dates.DateTime(2016, 2, 28, 15, 15)
+    @test ceil(Dates.Second, dt) == Dates.DateTime(2016, 2, 28, 15, 10, 51)
+    @test ceil(Dates.Second(30), dt) == Dates.DateTime(2016, 2, 28, 15, 11, 0)
+    @test round(Dates.Day, dt) == Dates.DateTime(2016, 2, 29)
+    @test round(Dates.Hour, dt) == Dates.DateTime(2016, 2, 28, 15)
+    @test round(Dates.Hour(2), dt) == Dates.DateTime(2016, 2, 28, 16)
+    @test round(Dates.Hour(12), dt) == Dates.DateTime(2016, 2, 28, 12)
+    @test round(Dates.Minute, dt) == Dates.DateTime(2016, 2, 28, 15, 11)
+    @test round(Dates.Minute(15), dt) == Dates.DateTime(2016, 2, 28, 15, 15)
+    @test round(Dates.Second, dt) == Dates.DateTime(2016, 2, 28, 15, 10, 51)
+    @test round(Dates.Second(30), dt) == Dates.DateTime(2016, 2, 28, 15, 11, 0)
 end
 @testset "Rounding for dates at the rounding epoch (year 0000)" begin
     dt = Dates.DateTime(0)
-    @test floor(dt, Dates.Year) == dt
-    @test floor(dt, Dates.Month) == dt
-    @test floor(dt, Dates.Week) == Dates.Date(-1, 12, 27)   # Monday prior to 0000-01-01
+    @test floor(Dates.Year, dt) == dt
+    @test floor(Dates.Month, dt) == dt
+    @test floor(Dates.Week, dt) == Dates.Date(-1, 12, 27)   # Monday prior to 0000-01-01
     @test floor(Dates.Date(-1, 12, 27), Dates.Week) == Dates.Date(-1, 12, 27)
-    @test floor(dt, Dates.Day) == dt
-    @test floor(dt, Dates.Hour) == dt
-    @test floor(dt, Dates.Minute) == dt
-    @test floor(dt, Dates.Second) == dt
-    @test ceil(dt, Dates.Year) == dt
-    @test ceil(dt, Dates.Month) == dt
-    @test ceil(dt, Dates.Week) == Dates.Date(0, 1, 3)       # Monday following 0000-01-01
+    @test floor(Dates.Day, dt) == dt
+    @test floor(Dates.Hour, dt) == dt
+    @test floor(Dates.Minute, dt) == dt
+    @test floor(Dates.Second, dt) == dt
+    @test ceil(Dates.Year, dt) == dt
+    @test ceil(Dates.Month, dt) == dt
+    @test ceil(Dates.Week, dt) == Dates.Date(0, 1, 3)       # Monday following 0000-01-01
     @test ceil(Dates.Date(0, 1, 3), Dates.Week) == Dates.Date(0, 1, 3)
-    @test ceil(dt, Dates.Day) == dt
-    @test ceil(dt, Dates.Hour) == dt
-    @test ceil(dt, Dates.Minute) == dt
-    @test ceil(dt, Dates.Second) == dt
+    @test ceil(Dates.Day, dt) == dt
+    @test ceil(Dates.Hour, dt) == dt
+    @test ceil(Dates.Minute, dt) == dt
+    @test ceil(Dates.Second, dt) == dt
 end
 @testset "Rounding for multiples of a period" begin
     # easiest to test close to rounding epoch
     dt = Dates.DateTime(0, 1, 19, 19, 19, 19, 19)
-    @test floor(dt, Dates.Year(2)) == DateTime(0)
-    @test floor(dt, Dates.Month(2)) == DateTime(0, 1)       # Odd number; months are 1-indexed
-    @test floor(dt, Dates.Week(2)) == DateTime(0, 1, 17)    # Third Monday of 0000
-    @test floor(dt, Dates.Day(2)) == DateTime(0, 1, 19)     # Odd number; days are 1-indexed
-    @test floor(dt, Dates.Hour(2)) == DateTime(0, 1, 19, 18)
-    @test floor(dt, Dates.Minute(2)) == DateTime(0, 1, 19, 19, 18)
-    @test floor(dt, Dates.Second(2)) == DateTime(0, 1, 19, 19, 19, 18)
-    @test ceil(dt, Dates.Year(2)) == DateTime(2)
-    @test ceil(dt, Dates.Month(2)) == DateTime(0, 3)        # Odd number; months are 1-indexed
-    @test ceil(dt, Dates.Week(2)) == DateTime(0, 1, 31)     # Fifth Monday of 0000
-    @test ceil(dt, Dates.Day(2)) == DateTime(0, 1, 21)      # Odd number; days are 1-indexed
-    @test ceil(dt, Dates.Hour(2)) == DateTime(0, 1, 19, 20)
-    @test ceil(dt, Dates.Minute(2)) == DateTime(0, 1, 19, 19, 20)
-    @test ceil(dt, Dates.Second(2)) == DateTime(0, 1, 19, 19, 19, 20)
+    @test floor(Dates.Year(2), dt) == DateTime(0)
+    @test floor(Dates.Month(2), dt) == DateTime(0, 1)       # Odd number; months are 1-indexed
+    @test floor(Dates.Week(2), dt) == DateTime(0, 1, 17)    # Third Monday of 0000
+    @test floor(Dates.Day(2), dt) == DateTime(0, 1, 19)     # Odd number; days are 1-indexed
+    @test floor(Dates.Hour(2), dt) == DateTime(0, 1, 19, 18)
+    @test floor(Dates.Minute(2), dt) == DateTime(0, 1, 19, 19, 18)
+    @test floor(Dates.Second(2), dt) == DateTime(0, 1, 19, 19, 19, 18)
+    @test ceil(Dates.Year(2), dt) == DateTime(2)
+    @test ceil(Dates.Month(2), dt) == DateTime(0, 3)        # Odd number; months are 1-indexed
+    @test ceil(Dates.Week(2), dt) == DateTime(0, 1, 31)     # Fifth Monday of 0000
+    @test ceil(Dates.Day(2), dt) == DateTime(0, 1, 21)      # Odd number; days are 1-indexed
+    @test ceil(Dates.Hour(2), dt) == DateTime(0, 1, 19, 20)
+    @test ceil(Dates.Minute(2), dt) == DateTime(0, 1, 19, 19, 20)
+    @test ceil(Dates.Second(2), dt) == DateTime(0, 1, 19, 19, 19, 20)
 end
 @testset "Rounding for dates with negative years" begin
     dt = Dates.DateTime(-1, 12, 29, 19, 19, 19, 19)
-    @test floor(dt, Dates.Year(2)) == DateTime(-2)
-    @test floor(dt, Dates.Month(2)) == DateTime(-1, 11)     # Odd number; months are 1-indexed
-    @test floor(dt, Dates.Week(2)) == DateTime(-1, 12, 20)  # 2 weeks prior to 0000-01-03
-    @test floor(dt, Dates.Day(2)) == DateTime(-1, 12, 28)   # Even; 4 days prior to 0000-01-01
-    @test floor(dt, Dates.Hour(2)) == DateTime(-1, 12, 29, 18)
-    @test floor(dt, Dates.Minute(2)) == DateTime(-1, 12, 29, 19, 18)
-    @test floor(dt, Dates.Second(2)) == DateTime(-1, 12, 29, 19, 19, 18)
-    @test ceil(dt, Dates.Year(2)) == DateTime(0)
-    @test ceil(dt, Dates.Month(2)) == DateTime(0, 1)        # Odd number; months are 1-indexed
-    @test ceil(dt, Dates.Week(2)) == DateTime(0, 1, 3)      # First Monday of 0000
-    @test ceil(dt, Dates.Day(2)) == DateTime(-1, 12, 30)    # Even; 2 days prior to 0000-01-01
-    @test ceil(dt, Dates.Hour(2)) == DateTime(-1, 12, 29, 20)
-    @test ceil(dt, Dates.Minute(2)) == DateTime(-1, 12, 29, 19, 20)
-    @test ceil(dt, Dates.Second(2)) == DateTime(-1, 12, 29, 19, 19, 20)
+    @test floor(Dates.Year(2), dt) == DateTime(-2)
+    @test floor(Dates.Month(2), dt) == DateTime(-1, 11)     # Odd number; months are 1-indexed
+    @test floor(Dates.Week(2), dt) == DateTime(-1, 12, 20)  # 2 weeks prior to 0000-01-03
+    @test floor(Dates.Day(2), dt) == DateTime(-1, 12, 28)   # Even; 4 days prior to 0000-01-01
+    @test floor(Dates.Hour(2), dt) == DateTime(-1, 12, 29, 18)
+    @test floor(Dates.Minute(2), dt) == DateTime(-1, 12, 29, 19, 18)
+    @test floor(Dates.Second(2), dt) == DateTime(-1, 12, 29, 19, 19, 18)
+    @test ceil(Dates.Year(2), dt) == DateTime(0)
+    @test ceil(Dates.Month(2), dt) == DateTime(0, 1)        # Odd number; months are 1-indexed
+    @test ceil(Dates.Week(2), dt) == DateTime(0, 1, 3)      # First Monday of 0000
+    @test ceil(Dates.Day(2), dt) == DateTime(-1, 12, 30)    # Even; 2 days prior to 0000-01-01
+    @test ceil(Dates.Hour(2), dt) == DateTime(-1, 12, 29, 20)
+    @test ceil(Dates.Minute(2), dt) == DateTime(-1, 12, 29, 19, 20)
+    @test ceil(Dates.Second(2), dt) == DateTime(-1, 12, 29, 19, 19, 20)
 end
 @testset "Rounding for dates that should not need rounding" begin
     for dt in [Dates.DateTime(2016, 1, 1), Dates.DateTime(-2016, 1, 1)]
         local dt
         for p in [Dates.Year, Dates.Month, Dates.Day, Dates.Hour, Dates.Minute, Dates.Second]
             local p
-            @test floor(dt, p) == dt
-            @test ceil(dt, p) == dt
+            @test floor(p, dt) == dt
+            @test ceil(p, dt) == dt
         end
     end
 end
 @testset "Various available RoundingModes" begin
     dt = Dates.DateTime(2016, 2, 28, 12)
-    @test round(dt, Dates.Day, RoundNearestTiesUp) == Dates.DateTime(2016, 2, 29)
-    @test round(dt, Dates.Day, RoundUp) == Dates.DateTime(2016, 2, 29)
-    @test round(dt, Dates.Day, RoundDown) == Dates.DateTime(2016, 2, 28)
-    @test_throws DomainError round(dt, Dates.Day, RoundNearest)
-    @test_throws DomainError round(dt, Dates.Day, RoundNearestTiesAway)
-    @test_throws DomainError round(dt, Dates.Day, RoundToZero)
-    @test round(dt, Dates.Day) == round(dt, Dates.Day, RoundNearestTiesUp)
+    @test round(Dates.Day, dt, RoundNearestTiesUp) == Dates.DateTime(2016, 2, 29)
+    @test round(Dates.Day, dt, RoundUp) == Dates.DateTime(2016, 2, 29)
+    @test round(Dates.Day, dt, RoundDown) == Dates.DateTime(2016, 2, 28)
+    @test_throws DomainError round(Dates.Day, dt, RoundNearest)
+    @test_throws DomainError round(Dates.Day, dt, RoundNearestTiesAway)
+    @test_throws DomainError round(Dates.Day, dt, RoundToZero)
+    @test round(dt, Dates.Day) == round(Dates.Day, dt, RoundNearestTiesUp)
 end
 @testset "Rounding datetimes to invalid resolutions" begin
     dt = Dates.DateTime(2016, 2, 28, 12, 15)
     for p in [Dates.Year, Dates.Month, Dates.Week, Dates.Day, Dates.Hour]
         local p
         for v in [-1, 0]
-            @test_throws DomainError floor(dt, p(v))
-            @test_throws DomainError ceil(dt, p(v))
-            @test_throws DomainError round(dt, p(v))
+            @test_throws DomainError floor(p(v), dt)
+            @test_throws DomainError ceil(p(v), dt)
+            @test_throws DomainError round(p(v), dt)
         end
     end
 end
 @testset "Rounding for periods" begin
     x = Dates.Second(172799)
-    @test floor(x, Dates.Week) == Dates.Week(0)
-    @test floor(x, Dates.Day) == Dates.Day(1)
-    @test floor(x, Dates.Hour) == Dates.Hour(47)
-    @test floor(x, Dates.Minute) == Dates.Minute(2879)
-    @test floor(x, Dates.Second) == Dates.Second(172799)
-    @test floor(x, Dates.Millisecond) == Dates.Millisecond(172799000)
-    @test ceil(x, Dates.Week) == Dates.Week(1)
-    @test ceil(x, Dates.Day) == Dates.Day(2)
-    @test ceil(x, Dates.Hour) == Dates.Hour(48)
-    @test ceil(x, Dates.Minute) == Dates.Minute(2880)
-    @test ceil(x, Dates.Second) == Dates.Second(172799)
-    @test ceil(x, Dates.Millisecond) == Dates.Millisecond(172799000)
-    @test round(x, Dates.Week) == Dates.Week(0)
-    @test round(x, Dates.Day) == Dates.Day(2)
-    @test round(x, Dates.Hour) == Dates.Hour(48)
-    @test round(x, Dates.Minute) == Dates.Minute(2880)
-    @test round(x, Dates.Second) == Dates.Second(172799)
-    @test round(x, Dates.Millisecond) == Dates.Millisecond(172799000)
+    @test floor(Dates.Week, x) == Dates.Week(0)
+    @test floor(Dates.Day, x) == Dates.Day(1)
+    @test floor(Dates.Hour, x) == Dates.Hour(47)
+    @test floor(Dates.Minute, x) == Dates.Minute(2879)
+    @test floor(Dates.Second, x) == Dates.Second(172799)
+    @test floor(Dates.Millisecond, x) == Dates.Millisecond(172799000)
+    @test ceil(Dates.Week, x) == Dates.Week(1)
+    @test ceil(Dates.Day, x) == Dates.Day(2)
+    @test ceil(Dates.Hour, x) == Dates.Hour(48)
+    @test ceil(Dates.Minute, x) == Dates.Minute(2880)
+    @test ceil(Dates.Second, x) == Dates.Second(172799)
+    @test ceil(Dates.Millisecond, x) == Dates.Millisecond(172799000)
+    @test round(Dates.Week, x) == Dates.Week(0)
+    @test round(Dates.Day, x) == Dates.Day(2)
+    @test round(Dates.Hour, x) == Dates.Hour(48)
+    @test round(Dates.Minute, x) == Dates.Minute(2880)
+    @test round(Dates.Second, x) == Dates.Second(172799)
+    @test round(Dates.Millisecond, x) == Dates.Millisecond(172799000)
 
     x = Dates.Nanosecond(2000999999)
-    @test floor(x, Dates.Second) == Dates.Second(2)
-    @test floor(x, Dates.Millisecond) == Dates.Millisecond(2000)
-    @test floor(x, Dates.Microsecond) == Dates.Microsecond(2000999)
-    @test floor(x, Dates.Nanosecond) == x
-    @test ceil(x, Dates.Second) == Dates.Second(3)
-    @test ceil(x, Dates.Millisecond) == Dates.Millisecond(2001)
-    @test ceil(x, Dates.Microsecond) == Dates.Microsecond(2001000)
-    @test ceil(x, Dates.Nanosecond) == x
-    @test round(x, Dates.Second) == Dates.Second(2)
-    @test round(x, Dates.Millisecond) == Dates.Millisecond(2001)
-    @test round(x, Dates.Microsecond) == Dates.Microsecond(2001000)
-    @test round(x, Dates.Nanosecond) == x
+    @test floor(Dates.Second, x) == Dates.Second(2)
+    @test floor(Dates.Millisecond, x) == Dates.Millisecond(2000)
+    @test floor(Dates.Microsecond, x) == Dates.Microsecond(2000999)
+    @test floor(Dates.Nanosecond, x) == x
+    @test ceil(Dates.Second, x) == Dates.Second(3)
+    @test ceil(Dates.Millisecond, x) == Dates.Millisecond(2001)
+    @test ceil(Dates.Microsecond, x) == Dates.Microsecond(2001000)
+    @test ceil(Dates.Nanosecond, x) == x
+    @test round(Dates.Second, x) == Dates.Second(2)
+    @test round(Dates.Millisecond, x) == Dates.Millisecond(2001)
+    @test round(Dates.Microsecond, x) == Dates.Microsecond(2001000)
+    @test round(Dates.Nanosecond, x) == x
 end
 
 @testset "Rounding DateTime to Date" begin
@@ -205,37 +205,37 @@ end
         local x
         for p in [Dates.Week, Dates.Day, Dates.Hour, Dates.Second, Dates.Millisecond, Dates.Microsecond, Dates.Nanosecond]
             local p
-            @test floor(x, p) == p(x)
-            @test ceil(x, p) == p(x)
+            @test floor(p, x) == p(x)
+            @test ceil(p, x) == p(x)
         end
     end
 end
 @testset "Various available RoundingModes for periods" begin
     x = Dates.Hour(36)
-    @test round(x, Dates.Day, RoundNearestTiesUp) == Dates.Day(2)
-    @test round(x, Dates.Day, RoundUp) == Dates.Day(2)
-    @test round(x, Dates.Day, RoundDown) == Dates.Day(1)
-    @test_throws DomainError round(x, Dates.Day, RoundNearest)
-    @test_throws DomainError round(x, Dates.Day, RoundNearestTiesAway)
-    @test_throws DomainError round(x, Dates.Day, RoundToZero)
-    @test round(x, Dates.Day) == round(x, Dates.Day, RoundNearestTiesUp)
+    @test round(Dates.Day, x, RoundNearestTiesUp) == Dates.Day(2)
+    @test round(Dates.Day, x, RoundUp) == Dates.Day(2)
+    @test round(Dates.Day, x, RoundDown) == Dates.Day(1)
+    @test_throws DomainError round(Dates.Day, x, RoundNearest)
+    @test_throws DomainError round(Dates.Day, x, RoundNearestTiesAway)
+    @test_throws DomainError round(Dates.Day, x, RoundToZero)
+    @test round(Dates.Day, x) == round(Dates.Day, x, RoundNearestTiesUp)
 end
 @testset "Rounding periods to invalid resolutions" begin
     x = Dates.Hour(86399)
     for p in [Dates.Week, Dates.Day, Dates.Hour, Dates.Second, Dates.Millisecond, Dates.Microsecond, Dates.Nanosecond]
         local p
         for v in [-1, 0]
-            @test_throws DomainError floor(x, p(v))
-            @test_throws DomainError ceil(x, p(v))
-            @test_throws DomainError round(x, p(v))
+            @test_throws DomainError floor(p(v), x)
+            @test_throws DomainError ceil(p(v), x)
+            @test_throws DomainError round(p(v), x)
         end
     end
     for p in [Dates.Year, Dates.Month]
         local p
         for v in [-1, 0, 1]
-            @test_throws MethodError floor(x, p(v))
-            @test_throws MethodError ceil(x, p(v))
-            @test_throws DomainError round(x, p(v))
+            @test_throws MethodError floor(p(v), x)
+            @test_throws MethodError ceil(p(v), x)
+            @test_throws DomainError round(p(v), x)
         end
     end
 end

--- a/stdlib/Dates/test/rounding_deprecate.jl
+++ b/stdlib/Dates/test/rounding_deprecate.jl
@@ -1,0 +1,228 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module RoundingTestsDeprecated
+
+using Test
+using Dates
+
+
+@testset "Basic rounding" begin
+    dt = Dates.Date(2016, 2, 28)    # Sunday
+    @test floor(dt, Dates.Year) == Dates.Date(2016)
+    @test floor(dt, Dates.Year(5)) == Dates.Date(2015)
+    @test floor(dt, Dates.Year(10)) == Dates.Date(2010)
+    @test floor(dt, Dates.Quarter) == Dates.Date(2016, 1)
+    @test floor(dt, Dates.Quarter(6)) == Dates.Date(2016, 1)
+    @test floor(dt, Dates.Month) == Dates.Date(2016, 2)
+    @test floor(dt, Dates.Month(6)) == Dates.Date(2016, 1)
+    @test floor(dt, Dates.Week) == Dates.toprev(dt, Dates.Monday)
+    @test ceil(dt, Dates.Year) == Dates.Date(2017)
+    @test ceil(dt, Dates.Year(5)) == Dates.Date(2020)
+    @test ceil(dt, Dates.Quarter) == Dates.Date(2016, 4)
+    @test ceil(dt, Dates.Quarter(6)) == Dates.Date(2017, 7)
+    @test ceil(dt, Dates.Month) == Dates.Date(2016, 3)
+    @test ceil(dt, Dates.Month(6)) == Dates.Date(2016, 7)
+    @test ceil(dt, Dates.Week) == Dates.tonext(dt, Dates.Monday)
+    @test round(dt, Dates.Year) == Dates.Date(2016)
+    @test round(dt, Dates.Month) == Dates.Date(2016, 3)
+    @test round(dt, Dates.Week) == Dates.Date(2016, 2, 29)
+
+    dt = Dates.DateTime(2016, 2, 28, 15, 10, 50, 500)
+    @test floor(dt, Dates.Day) == Dates.DateTime(2016, 2, 28)
+    @test floor(dt, Dates.Hour) == Dates.DateTime(2016, 2, 28, 15)
+    @test floor(dt, Dates.Hour(2)) == Dates.DateTime(2016, 2, 28, 14)
+    @test floor(dt, Dates.Hour(12)) == Dates.DateTime(2016, 2, 28, 12)
+    @test floor(dt, Dates.Minute) == Dates.DateTime(2016, 2, 28, 15, 10)
+    @test floor(dt, Dates.Minute(15)) == Dates.DateTime(2016, 2, 28, 15, 0)
+    @test floor(dt, Dates.Second) == Dates.DateTime(2016, 2, 28, 15, 10, 50)
+    @test floor(dt, Dates.Second(30)) == Dates.DateTime(2016, 2, 28, 15, 10, 30)
+    @test ceil(dt, Dates.Day) == Dates.DateTime(2016, 2, 29)
+    @test ceil(dt, Dates.Hour) == Dates.DateTime(2016, 2, 28, 16)
+    @test ceil(dt, Dates.Hour(2)) == Dates.DateTime(2016, 2, 28, 16)
+    @test ceil(dt, Dates.Hour(12)) == Dates.DateTime(2016, 2, 29, 0)
+    @test ceil(dt, Dates.Minute) == Dates.DateTime(2016, 2, 28, 15, 11)
+    @test ceil(dt, Dates.Minute(15)) == Dates.DateTime(2016, 2, 28, 15, 15)
+    @test ceil(dt, Dates.Second) == Dates.DateTime(2016, 2, 28, 15, 10, 51)
+    @test ceil(dt, Dates.Second(30)) == Dates.DateTime(2016, 2, 28, 15, 11, 0)
+    @test round(dt, Dates.Day) == Dates.DateTime(2016, 2, 29)
+    @test round(dt, Dates.Hour) == Dates.DateTime(2016, 2, 28, 15)
+    @test round(dt, Dates.Hour(2)) == Dates.DateTime(2016, 2, 28, 16)
+    @test round(dt, Dates.Hour(12)) == Dates.DateTime(2016, 2, 28, 12)
+    @test round(dt, Dates.Minute) == Dates.DateTime(2016, 2, 28, 15, 11)
+    @test round(dt, Dates.Minute(15)) == Dates.DateTime(2016, 2, 28, 15, 15)
+    @test round(dt, Dates.Second) == Dates.DateTime(2016, 2, 28, 15, 10, 51)
+    @test round(dt, Dates.Second(30)) == Dates.DateTime(2016, 2, 28, 15, 11, 0)
+end
+@testset "Rounding for dates at the rounding epoch (year 0000)" begin
+    dt = Dates.DateTime(0)
+    @test floor(dt, Dates.Year) == dt
+    @test floor(dt, Dates.Month) == dt
+    @test floor(dt, Dates.Week) == Dates.Date(-1, 12, 27)   # Monday prior to 0000-01-01
+    @test floor(Dates.Date(-1, 12, 27), Dates.Week) == Dates.Date(-1, 12, 27)
+    @test floor(dt, Dates.Day) == dt
+    @test floor(dt, Dates.Hour) == dt
+    @test floor(dt, Dates.Minute) == dt
+    @test floor(dt, Dates.Second) == dt
+    @test ceil(dt, Dates.Year) == dt
+    @test ceil(dt, Dates.Month) == dt
+    @test ceil(dt, Dates.Week) == Dates.Date(0, 1, 3)       # Monday following 0000-01-01
+    @test ceil(Dates.Date(0, 1, 3), Dates.Week) == Dates.Date(0, 1, 3)
+    @test ceil(dt, Dates.Day) == dt
+    @test ceil(dt, Dates.Hour) == dt
+    @test ceil(dt, Dates.Minute) == dt
+    @test ceil(dt, Dates.Second) == dt
+end
+@testset "Rounding for multiples of a period" begin
+    # easiest to test close to rounding epoch
+    dt = Dates.DateTime(0, 1, 19, 19, 19, 19, 19)
+    @test floor(dt, Dates.Year(2)) == DateTime(0)
+    @test floor(dt, Dates.Month(2)) == DateTime(0, 1)       # Odd number; months are 1-indexed
+    @test floor(dt, Dates.Week(2)) == DateTime(0, 1, 17)    # Third Monday of 0000
+    @test floor(dt, Dates.Day(2)) == DateTime(0, 1, 19)     # Odd number; days are 1-indexed
+    @test floor(dt, Dates.Hour(2)) == DateTime(0, 1, 19, 18)
+    @test floor(dt, Dates.Minute(2)) == DateTime(0, 1, 19, 19, 18)
+    @test floor(dt, Dates.Second(2)) == DateTime(0, 1, 19, 19, 19, 18)
+    @test ceil(dt, Dates.Year(2)) == DateTime(2)
+    @test ceil(dt, Dates.Month(2)) == DateTime(0, 3)        # Odd number; months are 1-indexed
+    @test ceil(dt, Dates.Week(2)) == DateTime(0, 1, 31)     # Fifth Monday of 0000
+    @test ceil(dt, Dates.Day(2)) == DateTime(0, 1, 21)      # Odd number; days are 1-indexed
+    @test ceil(dt, Dates.Hour(2)) == DateTime(0, 1, 19, 20)
+    @test ceil(dt, Dates.Minute(2)) == DateTime(0, 1, 19, 19, 20)
+    @test ceil(dt, Dates.Second(2)) == DateTime(0, 1, 19, 19, 19, 20)
+end
+@testset "Rounding for dates with negative years" begin
+    dt = Dates.DateTime(-1, 12, 29, 19, 19, 19, 19)
+    @test floor(dt, Dates.Year(2)) == DateTime(-2)
+    @test floor(dt, Dates.Month(2)) == DateTime(-1, 11)     # Odd number; months are 1-indexed
+    @test floor(dt, Dates.Week(2)) == DateTime(-1, 12, 20)  # 2 weeks prior to 0000-01-03
+    @test floor(dt, Dates.Day(2)) == DateTime(-1, 12, 28)   # Even; 4 days prior to 0000-01-01
+    @test floor(dt, Dates.Hour(2)) == DateTime(-1, 12, 29, 18)
+    @test floor(dt, Dates.Minute(2)) == DateTime(-1, 12, 29, 19, 18)
+    @test floor(dt, Dates.Second(2)) == DateTime(-1, 12, 29, 19, 19, 18)
+    @test ceil(dt, Dates.Year(2)) == DateTime(0)
+    @test ceil(dt, Dates.Month(2)) == DateTime(0, 1)        # Odd number; months are 1-indexed
+    @test ceil(dt, Dates.Week(2)) == DateTime(0, 1, 3)      # First Monday of 0000
+    @test ceil(dt, Dates.Day(2)) == DateTime(-1, 12, 30)    # Even; 2 days prior to 0000-01-01
+    @test ceil(dt, Dates.Hour(2)) == DateTime(-1, 12, 29, 20)
+    @test ceil(dt, Dates.Minute(2)) == DateTime(-1, 12, 29, 19, 20)
+    @test ceil(dt, Dates.Second(2)) == DateTime(-1, 12, 29, 19, 19, 20)
+end
+@testset "Rounding for dates that should not need rounding" begin
+    for dt in [Dates.DateTime(2016, 1, 1), Dates.DateTime(-2016, 1, 1)]
+        local dt
+        for p in [Dates.Year, Dates.Month, Dates.Day, Dates.Hour, Dates.Minute, Dates.Second]
+            local p
+            @test floor(dt, p) == dt
+            @test ceil(dt, p) == dt
+        end
+    end
+end
+@testset "Various available RoundingModes" begin
+    dt = Dates.DateTime(2016, 2, 28, 12)
+    @test round(dt, Dates.Day, RoundNearestTiesUp) == Dates.DateTime(2016, 2, 29)
+    @test round(dt, Dates.Day, RoundUp) == Dates.DateTime(2016, 2, 29)
+    @test round(dt, Dates.Day, RoundDown) == Dates.DateTime(2016, 2, 28)
+    @test_throws DomainError round(dt, Dates.Day, RoundNearest)
+    @test_throws DomainError round(dt, Dates.Day, RoundNearestTiesAway)
+    @test_throws DomainError round(dt, Dates.Day, RoundToZero)
+    @test round(dt, Dates.Day) == round(dt, Dates.Day, RoundNearestTiesUp)
+end
+@testset "Rounding datetimes to invalid resolutions" begin
+    dt = Dates.DateTime(2016, 2, 28, 12, 15)
+    for p in [Dates.Year, Dates.Month, Dates.Week, Dates.Day, Dates.Hour]
+        local p
+        for v in [-1, 0]
+            @test_throws DomainError floor(dt, p(v))
+            @test_throws DomainError ceil(dt, p(v))
+            @test_throws DomainError round(dt, p(v))
+        end
+    end
+end
+@testset "Rounding for periods" begin
+    x = Dates.Second(172799)
+    @test floor(x, Dates.Week) == Dates.Week(0)
+    @test floor(x, Dates.Day) == Dates.Day(1)
+    @test floor(x, Dates.Hour) == Dates.Hour(47)
+    @test floor(x, Dates.Minute) == Dates.Minute(2879)
+    @test floor(x, Dates.Second) == Dates.Second(172799)
+    @test floor(x, Dates.Millisecond) == Dates.Millisecond(172799000)
+    @test ceil(x, Dates.Week) == Dates.Week(1)
+    @test ceil(x, Dates.Day) == Dates.Day(2)
+    @test ceil(x, Dates.Hour) == Dates.Hour(48)
+    @test ceil(x, Dates.Minute) == Dates.Minute(2880)
+    @test ceil(x, Dates.Second) == Dates.Second(172799)
+    @test ceil(x, Dates.Millisecond) == Dates.Millisecond(172799000)
+    @test round(x, Dates.Week) == Dates.Week(0)
+    @test round(x, Dates.Day) == Dates.Day(2)
+    @test round(x, Dates.Hour) == Dates.Hour(48)
+    @test round(x, Dates.Minute) == Dates.Minute(2880)
+    @test round(x, Dates.Second) == Dates.Second(172799)
+    @test round(x, Dates.Millisecond) == Dates.Millisecond(172799000)
+
+    x = Dates.Nanosecond(2000999999)
+    @test floor(x, Dates.Second) == Dates.Second(2)
+    @test floor(x, Dates.Millisecond) == Dates.Millisecond(2000)
+    @test floor(x, Dates.Microsecond) == Dates.Microsecond(2000999)
+    @test floor(x, Dates.Nanosecond) == x
+    @test ceil(x, Dates.Second) == Dates.Second(3)
+    @test ceil(x, Dates.Millisecond) == Dates.Millisecond(2001)
+    @test ceil(x, Dates.Microsecond) == Dates.Microsecond(2001000)
+    @test ceil(x, Dates.Nanosecond) == x
+    @test round(x, Dates.Second) == Dates.Second(2)
+    @test round(x, Dates.Millisecond) == Dates.Millisecond(2001)
+    @test round(x, Dates.Microsecond) == Dates.Microsecond(2001000)
+    @test round(x, Dates.Nanosecond) == x
+end
+
+@testset "Rounding DateTime to Date" begin
+    now_ = DateTime(2020, 9, 1, 13)
+    for p in (Year, Month, Day)
+        for r in (RoundUp, RoundDown)
+            @test round(Date, now_, p, r) == round(Date(now_), p, r)
+        end
+        @test round(Date, now_, p) == round(Date, now_, p, RoundNearestTiesUp)
+        @test floor(Date, now_, p) == round(Date, now_, p, RoundDown)
+        @test ceil(Date, now_, p)  == round(Date, now_, p, RoundUp)
+    end
+end
+@testset "Rounding for periods that should not need rounding" begin
+    for x in [Dates.Week(3), Dates.Day(14), Dates.Second(604800)]
+        local x
+        for p in [Dates.Week, Dates.Day, Dates.Hour, Dates.Second, Dates.Millisecond, Dates.Microsecond, Dates.Nanosecond]
+            local p
+            @test floor(x, p) == p(x)
+            @test ceil(x, p) == p(x)
+        end
+    end
+end
+@testset "Various available RoundingModes for periods" begin
+    x = Dates.Hour(36)
+    @test round(x, Dates.Day, RoundNearestTiesUp) == Dates.Day(2)
+    @test round(x, Dates.Day, RoundUp) == Dates.Day(2)
+    @test round(x, Dates.Day, RoundDown) == Dates.Day(1)
+    @test_throws DomainError round(x, Dates.Day, RoundNearest)
+    @test_throws DomainError round(x, Dates.Day, RoundNearestTiesAway)
+    @test_throws DomainError round(x, Dates.Day, RoundToZero)
+    @test round(x, Dates.Day) == round(x, Dates.Day, RoundNearestTiesUp)
+end
+@testset "Rounding periods to invalid resolutions" begin
+    x = Dates.Hour(86399)
+    for p in [Dates.Week, Dates.Day, Dates.Hour, Dates.Second, Dates.Millisecond, Dates.Microsecond, Dates.Nanosecond]
+        local p
+        for v in [-1, 0]
+            # @test_throws DomainError floor(x, p(v))
+            # @test_throws DomainError ceil(x, p(v))
+            # @test_throws DomainError round(x, p(v))
+        end
+    end
+    for p in [Dates.Year, Dates.Month]
+        local p
+        for v in [-1, 0, 1]
+            # @test_throws MethodError floor(x, p(v))
+            # @test_throws MethodError ceil(x, p(v))
+            # @test_throws DomainError round(x, p(v))
+        end
+    end
+end
+
+end

--- a/stdlib/Dates/test/testgroups
+++ b/stdlib/Dates/test/testgroups
@@ -4,6 +4,7 @@ query
 periods
 ranges
 rounding
+rounding_deprecate
 types
 io
 arithmetic


### PR DESCRIPTION
This resolves #47843

First, I must apologize for stepping on #47843. This was started before I saw their work, but covers more.


This updates the code & documentation to change the order of arguments for ceil, floor, & round.  Tests were modified to cover the new method as well as the old "deprecated" versions.   

As you can see in the tests/rounding_deprecated.jl the only test that couldn't be passed are commented out on line 213:215 & 221:224. These should be inconsequential.

One open question is whether the old ordering should be addressed in the documentation as a note.

I would ask @keno and @x0samnan to look at this as they had  been involved in the other PR.
