### PR TITLE
TOML: print: handle mixed vector of dicts and non-dicts

### DIFF
--- a/stdlib/TOML/src/print.jl
+++ b/stdlib/TOML/src/print.jl
@@ -122,7 +122,10 @@ end
 
 is_table(value)           = isa(value, AbstractDict)
 is_array_of_tables(value) = isa(value, AbstractArray) &&
-                            length(value) > 0 && isa(value[1], AbstractDict)
+                            length(value) > 0 && (
+                                isa(value, AbstractArray{<:AbstractDict}) ||
+                                all(v -> isa(v, AbstractDict), value)
+                            )
 is_tabular(value)         = is_table(value) || is_array_of_tables(value)
 
 function print_table(f::MbyFunc, io::IO, a::AbstractDict,

--- a/stdlib/TOML/test/print.jl
+++ b/stdlib/TOML/test/print.jl
@@ -80,21 +80,21 @@ loaders = ["gzip", { driver = "csv", args = {delim = "\t"}}]
 @test roundtrip(str)
 
 
-# Array of dictionaries and non-dictionaries
-# https://github.com/JuliaLang/julia/issues/45340
-d =  Dict("b" => Any[111, Dict("a" =>  222, "d" => 333)])
-@test toml_str(d) == "b = [111, {a = 222, d = 333}]\n"
+@testset "vec with dicts and non-dicts" begin
+    # https://github.com/JuliaLang/julia/issues/45340
+    d =  Dict("b" => Any[111, Dict("a" =>  222, "d" => 333)])
+    @test toml_str(d) == "b = [111, {a = 222, d = 333}]\n"
 
-d =  Dict("b" => Any[Dict("a" =>  222, "d" => 333), 111])
-@test toml_str(d) == "b = [{a = 222, d = 333}, 111]\n"
+    d =  Dict("b" => Any[Dict("a" =>  222, "d" => 333), 111])
+    @test toml_str(d) == "b = [{a = 222, d = 333}, 111]\n"
 
-d =  Dict("b" => Any[Dict("a" =>  222, "d" => 333)])
-@test toml_str(d) == """
-[[b]]
-a = 222
-d = 333
-"""
-
+    d =  Dict("b" => Any[Dict("a" =>  222, "d" => 333)])
+    @test toml_str(d) == """
+    [[b]]
+    a = 222
+    d = 333
+    """
+end
 
 struct Foo
     a::Int64

--- a/stdlib/TOML/test/print.jl
+++ b/stdlib/TOML/test/print.jl
@@ -80,6 +80,12 @@ loaders = ["gzip", { driver = "csv", args = {delim = "\t"}}]
 @test roundtrip(str)
 
 
+# Array of dictionaries and non-dictionaries
+# https://github.com/JuliaLang/julia/issues/45340
+d =  Dict("b" => Any[111, Dict("a" =>  222, "d" => 333)])
+@test_throws ErrorException TOML.print(devnull, d)
+
+
 struct Foo
     a::Int64
     b::Float64

--- a/stdlib/TOML/test/print.jl
+++ b/stdlib/TOML/test/print.jl
@@ -83,7 +83,17 @@ loaders = ["gzip", { driver = "csv", args = {delim = "\t"}}]
 # Array of dictionaries and non-dictionaries
 # https://github.com/JuliaLang/julia/issues/45340
 d =  Dict("b" => Any[111, Dict("a" =>  222, "d" => 333)])
-@test_throws ErrorException TOML.print(devnull, d)
+@test toml_str(d) == "b = [111, {a = 222, d = 333}]\n"
+
+d =  Dict("b" => Any[Dict("a" =>  222, "d" => 333), 111])
+@test toml_str(d) == "b = [{a = 222, d = 333}, 111]\n"
+
+d =  Dict("b" => Any[Dict("a" =>  222, "d" => 333)])
+@test toml_str(d) == """
+[[b]]
+a = 222
+d = 333
+"""
 
 
 struct Foo


### PR DESCRIPTION
Fix #45340

