### PR TITLE
add back wordaround for `Slot objects should not occur in an AST` in Ipython mode

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1404,9 +1404,9 @@ end
 
 function out_transform(@nospecialize(x), n::Ref{Int})
     return quote
-        let x = $x
-            $capture_result($n, x)
-            x
+        let __temp_val_a72df459 = $x
+            $capture_result($n, __temp_val_a72df459)
+            __temp_val_a72df459
         end
     end
 end

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1641,6 +1641,10 @@ fake_repl() do stdin_write, stdout_read, repl
     s = sendrepl2("REPL\n", "In [10]")
     @test contains(s, "Out[9]: REPL")
 
+    # Test for https://github.com/JuliaLang/julia/issues/46451
+    s = sendrepl2("x = range(-1; stop = 1)\n", "-1:1")
+    @test contains(s, "Out[11]: -1:1")
+
     write(stdin_write, '\x04')
     Base.wait(repltask)
 end

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1642,7 +1642,7 @@ fake_repl() do stdin_write, stdout_read, repl
     @test contains(s, "Out[9]: REPL")
 
     # Test for https://github.com/JuliaLang/julia/issues/46451
-    s = sendrepl2("x = range(-1; stop = 1)\n", "-1:1")
+    s = sendrepl2("x_47878 = range(-1; stop = 1)\n", "-1:1")
     @test contains(s, "Out[11]: -1:1")
 
     write(stdin_write, '\x04')


### PR DESCRIPTION
This workaround was removed in https://github.com/JuliaLang/julia/pull/47178 (cc @vtjnash).

Ref https://github.com/JuliaLang/julia/issues/46451

On master:

```julia
julia> using REPL

julia> REPL.ipython_mode!()

In [4]: x = range(-1; stop = 1)
ERROR: syntax: Slot objects should not occur in an AST
Stacktrace:
 [1] top-level scope
   @ REPL[4]:1
 [2] top-level scope
   @ ~/julia/usr/share/julia/stdlib/v1.10/REPL/src/REPL.jl:1407
```