### PR TITLE
Fix the `stage` and `version-check` targets for `make -C deps`

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -168,6 +168,8 @@ DEP_LIBS += libwhich
 endif
 endif
 
+DEP_LIBS_STAGED := $(DEP_LIBS)
+
 # list all targets
 DEP_LIBS_STAGED_ALL := llvm llvm-tools clang llvmunwind unwind libuv pcre \
 	openlibm dsfmt blastrampoline openblas lapack gmp mpfr patchelf utf8proc \


### PR DESCRIPTION
The variable `DEP_LIBS_STAGED` was removed in #40998 but it's still being referenced in other places. Notably, its removal renders `make -C deps stage` and `make -C deps version-check` as no-ops. For reference, the definition of the variable prior to #40998 was
```make
DEP_LIBS_STAGED := $(filter-out libsuitesparse-wrapper,$(DEP_LIBS))
```
Since that PR removed `libsuitesparse-wrapper` entirely, we can simply initialize `DEP_LIBS_STAGED` to `DEP_LIBS`.