### PR TITLE
redirect line info of `@kwdef` constructor to the definition site

### DIFF
--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1204,6 +1204,25 @@ end
     end
 end
 
+@kwdef struct Test_kwdef_lineinfo
+    a::String
+end
+@testset "@kwdef constructor line info" begin
+    for method in methods(Test_kwdef_lineinfo)
+        @test method.file === Symbol(@__FILE__)
+        @test ((@__LINE__)-6) ≤ method.line ≤ ((@__LINE__)-5)
+    end
+end
+@kwdef struct Test_kwdef_lineinfo_sparam{S<:AbstractString}
+    a::S
+end
+@testset "@kwdef constructor line info with static parameter" begin
+    for method in methods(Test_kwdef_lineinfo_sparam)
+        @test method.file === Symbol(@__FILE__)
+        @test ((@__LINE__)-6) ≤ method.line ≤ ((@__LINE__)-5)
+    end
+end
+
 @testset "exports of modules" begin
     for (_, mod) in Base.loaded_modules
         mod === Main && continue # Main exports everything


### PR DESCRIPTION
This should improve the debuggability of constructors defined by `@kwdef`.

```julia
julia> @kwdef struct Test_kwdef_lineinfo
           a::String
       end

julia> Test_kwdef_lineinfo(; a=42)
[...]
```

Before:
```
Stacktrace:
 [1] Test_kwdef_lineinfo(a::Int64)
   @ Main ./none:2
 [2] Test_kwdef_lineinfo(; a::Int64)
   @ Main ~/julia/julia/base/util.jl:549
 [3] kwcall(::NamedTuple{(:a,), Tuple{Int64}}, ::Type{Test_kwdef_lineinfo})
   @ Main ~/julia/julia/base/util.jl:549
 [4] top-level scope
   @ none:1
```

After:
```
Stacktrace:
 [1] Test_kwdef_lineinfo(a::Int64)
   @ Main ./none:2
 [2] Test_kwdef_lineinfo(; a::Int64)
   @ Main ./none:1
 [3] kwcall(::NamedTuple{(:a,), Tuple{Int64}}, ::Type{Test_kwdef_lineinfo})
   @ Main ./none:1
 [4] top-level scope
   @ none:1
```