### PR TITLE
Optimize TLS access in generated code on FreeBSD

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -13,7 +13,7 @@
 // Ref https://www.uclibc.org/docs/tls.pdf
 // For variant 1 JL_ELF_TLS_INIT_SIZE is the size of the thread control block (TCB)
 // For variant 2 JL_ELF_TLS_INIT_SIZE is 0
-#ifdef _OS_LINUX_
+#if defined(_OS_LINUX_) || defined(_OS_FREEBSD_)
 #  if defined(_CPU_X86_64_) || defined(_CPU_X86_)
 #    define JL_ELF_TLS_VARIANT 2
 #    define JL_ELF_TLS_INIT_SIZE 0

--- a/src/threading.c
+++ b/src/threading.c
@@ -30,6 +30,11 @@
 #  include <link.h>
 #endif
 
+// `ElfW` was added to FreeBSD in 12.3 but we still support 12.2
+#if defined(_OS_FREEBSD_) && !defined(ElfW)
+#  define ElfW(x) __ElfN(x)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This extends the optimization made for Linux in #17178 to FreeBSD.

In #17178, Yichao said
> FreeBSD or other platforms that uses ELF format probably works too assuming it has `dl_iterate_phdr` but I can't really test.

Here we are, 6.5 years later, and I can confirm that Yichao was right: this builds and passes all tests on FreeBSD.