### PR TITLE
Fix an impossible-to-reach `InexactError` in `parse(Int, ::String)`

### DIFF
--- a/base/parse.jl
+++ b/base/parse.jl
@@ -92,9 +92,8 @@ end
 # '0':'9' -> 0:9
 # 'A':'Z' -> 10:26
 # 'a':'z' -> 10:26 if base <= 36, 36:62 otherwise
-# input outside of that is mapped to base as an UInt32
-# current callers only ever call this with UInt32...
-@inline function __convert_digit(_c::UInt32, base)
+# input outside of that is mapped to base
+@inline function __convert_digit(_c::UInt32, base::UInt32)
     _0 = UInt32('0')
     _9 = UInt32('9')
     _A = UInt32('A')
@@ -105,7 +104,7 @@ end
     d = _0 <= _c <= _9 ? _c-_0             :
         _A <= _c <= _Z ? _c-_A+ UInt32(10) :
         _a <= _c <= _z ? _c-_a+a           :
-        base % UInt32 # we should have errored earlier anyway, but this prevents an InexactError that can't happen in our callers
+        base
 end
 
 

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -89,6 +89,11 @@ function parseint_preamble(signed::Bool, base::Int, s::AbstractString, startpos:
     return sgn, base, j
 end
 
+# '0':'9' -> 0:9
+# 'A':'Z' -> 10:26
+# 'a':'z' -> 10:26 if base <= 36, 36:62 otherwise
+# input outside of that is mapped to base as an UInt32
+# current callers only ever call this with UInt32...
 @inline function __convert_digit(_c::UInt32, base)
     _0 = UInt32('0')
     _9 = UInt32('9')
@@ -96,10 +101,11 @@ end
     _a = UInt32('a')
     _Z = UInt32('Z')
     _z = UInt32('z')
-    a::UInt32 = base <= 36 ? 10 : 36
+    a = base <= 36 ? UInt32(10) : UInt32(36) # converting here instead of via a type assertion prevents typeassert related errors
     d = _0 <= _c <= _9 ? _c-_0             :
         _A <= _c <= _Z ? _c-_A+ UInt32(10) :
-        _a <= _c <= _z ? _c-_a+a           : UInt32(base)
+        _a <= _c <= _z ? _c-_a+a           :
+        base % UInt32 # we should have errored earlier anyway, but this prevents an InexactError that can't happen in our callers
 end
 
 
@@ -110,7 +116,7 @@ function tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::
         return nothing
     end
     if !(2 <= base <= 62)
-        raise && throw(ArgumentError("invalid base: base must be 2 ≤ base ≤ 62, got $base"))
+        raise && throw(ArgumentError(LazyString("invalid base: base must be 2 ≤ base ≤ 62, got ", base)))
         return nothing
     end
     if i == 0
@@ -132,7 +138,7 @@ function tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::
     while n <= m
         # Fast path from `UInt32(::Char)`; non-ascii will be >= 0x80
         _c = reinterpret(UInt32, c) >> 24
-        d::T = __convert_digit(_c, base)
+        d::T = __convert_digit(_c, base % UInt32) # we know 2 <= base <= 62, so prevent an incorrect InexactError here
         if d >= base
             raise && throw(ArgumentError("invalid base $base digit $(repr(c)) in $(repr(SubString(s,startpos,endpos)))"))
             return nothing
@@ -150,7 +156,7 @@ function tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::
     while !isspace(c)
         # Fast path from `UInt32(::Char)`; non-ascii will be >= 0x80
         _c = reinterpret(UInt32, c) >> 24
-        d::T = __convert_digit(_c, base)
+        d::T = __convert_digit(_c, base % UInt32) # we know 2 <= base <= 62
         if d >= base
             raise && throw(ArgumentError("invalid base $base digit $(repr(c)) in $(repr(SubString(s,startpos,endpos)))"))
             return nothing


### PR DESCRIPTION
Previously, even though everything was bounded by checks earlier, this function would have an error path about an `InexactError` that makes it through LLVM and into assembly. By converting to `UInt32` before the call, the inner conversion will always succeed. This is safe, since we know 2 <= `base` <= 62 from the checks at the start of `tryparse_internal`.

I've also added some doc-comments, to make it easier for the next one that reads/touches this.. I'm not quite sure how to test this.