### PR TITLE
Disable further FileWatching tests

### DIFF
--- a/stdlib/FileWatching/test/runtests.jl
+++ b/stdlib/FileWatching/test/runtests.jl
@@ -12,8 +12,6 @@ using Base: uv_error, Experimental
 # Odd numbered pipes are tested for reads
 # Even numbered pipes are tested for timeouts
 # Writable ends are always tested for write-ability before a write
-ismacos_arm = ((Sys.ARCH == :aarch64) && (Sys.isapple())) #https://github.com/JuliaLang/julia/issues/46185
-ismacos_x86 = ((Sys.ARCH == :x86_64) && (Sys.isapple()))  #Used to disable the unreliable macos tests
 
 n = 20
 intvls = [2, .2, .1, .005, .00001]
@@ -34,7 +32,7 @@ for i in 1:n
     if !fd_in_limits && Sys.islinux()
         run(`ls -la /proc/$(getpid())/fd`)
     end
-    if !ismacos_arm
+    if !Sys.isapple()
         @test fd_in_limits
     end
 end
@@ -187,7 +185,7 @@ function test_init_afile()
     @test(watch_folder(dir) == (F_PATH => FileWatching.FileEvent(FileWatching.UV_RENAME)))
     @test close(open(file, "w")) === nothing
     sleep(3)
-    if !ismacos_x86
+    if !Sys.isapple()
         let c
             c = watch_folder(dir, 0)
 
@@ -377,7 +375,7 @@ test_monitor_wait_poll()
 test_watch_file_timeout(0.2)
 test_watch_file_change(6)
 
-if !ismacos_x86
+if !Sys.isapple()
     test_dirmonitor_wait2(0.2)
     test_dirmonitor_wait2(0.2)
 


### PR DESCRIPTION
Generalizing #46497 to all macOS platforms, due to https://github.com/JuliaLang/julia/issues/46185#issuecomment-1354172320 from NixOS/nixpkgs#205584.