### PR TITLE
Precompile cache: always add worklist CIs

### DIFF
--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -167,7 +167,7 @@ static int has_backedge_to_worklist(jl_method_instance_t *mi, htable_t *visited,
     if (jl_is_method(mod))
         mod = ((jl_method_t*)mod)->module;
     assert(jl_is_module(mod));
-    if (mi->precompiled || !jl_object_in_image((jl_value_t*)mod)) {
+    if (mi->precompiled || !jl_object_in_image((jl_value_t*)mod) || type_in_worklist(mi->specTypes)) {
         return 1;
     }
     if (!mi->backedges) {
@@ -241,7 +241,7 @@ static jl_array_t *queue_external_cis(jl_array_t *list)
         if (jl_is_method(m)) {
             if (jl_object_in_image((jl_value_t*)m->module)) {
                 if (ptrhash_get(&external_mis, mi) == HT_NOTFOUND) {
-                    int found = type_in_worklist(mi->specTypes) | has_backedge_to_worklist(mi, &visited, &stack);
+                    int found = has_backedge_to_worklist(mi, &visited, &stack);
                     assert(found == 0 || found == 1);
                     assert(stack.len == 0);
                     if (found == 1) {

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -241,7 +241,7 @@ static jl_array_t *queue_external_cis(jl_array_t *list)
         if (jl_is_method(m)) {
             if (jl_object_in_image((jl_value_t*)m->module)) {
                 if (ptrhash_get(&external_mis, mi) == HT_NOTFOUND) {
-                    int found = has_backedge_to_worklist(mi, &visited, &stack);
+                    int found = type_in_worklist(mi->specTypes) | has_backedge_to_worklist(mi, &visited, &stack);
                     assert(found == 0 || found == 1);
                     assert(stack.len == 0);
                     if (found == 1) {


### PR DESCRIPTION
We cache only those external CodeInstances that link back to the package being precompiled. Formerly we required a backedge; this PRs adds any whose `specTypes` could only link back to the package. This scoops up a few runtime-dispatched CodeInstances.

In local tests, this shaves off ~20% of CSV's TTFX.