### PR TITLE
only load extensions once dependencies have finished loading

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1102,7 +1102,7 @@ function run_extension_callbacks(; force::Bool=false)
         for extid in EXT_DORMITORY
             extid.succeeded && continue
             !force && extid.triggered && continue
-            if all(x -> haskey(Base.loaded_modules, x), extid.triggers)
+            if all(x -> haskey(Base.loaded_modules, x) && !haskey(package_locks, x), extid.triggers)
                 ext_not_allowed_load = nothing
                 extid.triggered = true
                 # It is possible that some of the triggers were loaded in an environment

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -998,8 +998,8 @@ end
         push!(empty!(DEPOT_PATH), joinpath(tmp, "depot"))
 
         proj = joinpath(@__DIR__, "project", "Extensions", "HasDepWithExtensions.jl")
-        for i in 1:2 # Once when requiring precomilation, once where it is already precompiled
-            cmd = `$(Base.julia_cmd()) --project=$proj --startup-file=no -e '
+        for compile in (`--compiled-modules=no`, ``, ``) # Once when requiring precomilation, once where it is already precompiled
+            cmd = `$(Base.julia_cmd()) $compile --project=$proj --startup-file=no -e '
                 begin
                 using HasExtensions
                 # Base.get_extension(HasExtensions, :Extension) === nothing || error("unexpectedly got an extension")

--- a/test/project/Extensions/ExtDep.jl/Project.toml
+++ b/test/project/Extensions/ExtDep.jl/Project.toml
@@ -1,3 +1,6 @@
 name = "ExtDep"
 uuid = "fa069be4-f60b-4d4c-8b95-f8008775090c"
 version = "0.1.0"
+
+[deps]
+SomePackage = "678608ae-7bb3-42c7-98b1-82102067a3d8"

--- a/test/project/Extensions/ExtDep.jl/src/ExtDep.jl
+++ b/test/project/Extensions/ExtDep.jl/src/ExtDep.jl
@@ -1,5 +1,9 @@
 module ExtDep
 
+# loading this package makes the check for loading extensions trigger
+# which tests #47921
+using SomePackage
+
 struct ExtDepStruct end
 
 end # module ExtDep

--- a/test/project/Extensions/HasDepWithExtensions.jl/Manifest.toml
+++ b/test/project/Extensions/HasDepWithExtensions.jl/Manifest.toml
@@ -2,9 +2,10 @@
 
 julia_version = "1.10.0-DEV"
 manifest_format = "2.0"
-project_hash = "7cbe1857ecc6692a8cc8be428a5ad5073531ff98"
+project_hash = "d523b3401f72a1ed34b7b43749fd2655c6b78542"
 
 [[deps.ExtDep]]
+deps = ["SomePackage"]
 path = "../ExtDep.jl"
 uuid = "fa069be4-f60b-4d4c-8b95-f8008775090c"
 version = "0.1.0"
@@ -15,11 +16,16 @@ uuid = "55982ee5-2ad5-4c40-8cfe-5e9e1b01500d"
 version = "0.1.0"
 
 [[deps.HasExtensions]]
-weakdeps = ["ExtDep", "ExtDep2"]
 path = "../HasExtensions.jl"
 uuid = "4d3288b3-3afc-4bb6-85f3-489fffe514c8"
 version = "0.1.0"
+weakdeps = ["ExtDep", "ExtDep2"]
 
     [deps.HasExtensions.extensions]
     Extension = "ExtDep"
     ExtensionFolder = ["ExtDep", "ExtDep2"]
+
+[[deps.SomePackage]]
+path = "../SomePackage"
+uuid = "678608ae-7bb3-42c7-98b1-82102067a3d8"
+version = "0.1.0"

--- a/test/project/Extensions/SomePackage/Project.toml
+++ b/test/project/Extensions/SomePackage/Project.toml
@@ -1,0 +1,4 @@
+name = "SomePackage"
+uuid = "678608ae-7bb3-42c7-98b1-82102067a3d8"
+authors = ["Kristoffer <kcarlsson89@gmail.com>"]
+version = "0.1.0"

--- a/test/project/Extensions/SomePackage/src/SomePackage.jl
+++ b/test/project/Extensions/SomePackage/src/SomePackage.jl
@@ -1,0 +1,5 @@
+module SomePackage
+
+greet() = print("Hello World!")
+
+end # module SomePackage


### PR DESCRIPTION
Thanks to @vchuravy for suggesting looking at `package_locks`.

Fixes https://github.com/JuliaLang/julia/issues/47921.