### PR TITLE
Continue working to make GlobalRef more first-class

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2521,14 +2521,12 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
 end
 
 function isdefined_globalref(g::GlobalRef)
-    g.binding != C_NULL && return ccall(:jl_binding_boundp, Cint, (Ptr{Cvoid},), g.binding) != 0
-    return isdefined(g.mod, g.name)
+    return ccall(:jl_globalref_boundp, Cint, (Any,), g) != 0
 end
 
 function abstract_eval_globalref(g::GlobalRef)
     if isdefined_globalref(g) && isconst(g)
-        g.binding != C_NULL && return Const(ccall(:jl_binding_value, Any, (Ptr{Cvoid},), g.binding))
-        return Const(getglobal(g.mod, g.name))
+        return Const(ccall(:jl_get_globalref_value, Any, (Any,), g))
     end
     ty = ccall(:jl_get_binding_type, Any, (Any, Any), g.mod, g.name)
     ty === nothing && return Any

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -114,13 +114,6 @@ function binding_module(m::Module, s::Symbol)
     return unsafe_pointer_to_objref(p)::Module
 end
 
-function resolve(g::GlobalRef; force::Bool=false)
-    if force || isbindingresolved(g.mod, g.name)
-        return GlobalRef(binding_module(g.mod, g.name), g.name)
-    end
-    return g
-end
-
 const _NAMEDTUPLE_NAME = NamedTuple.body.body.name
 
 function _fieldnames(@nospecialize t)
@@ -268,8 +261,7 @@ isconst(m::Module, s::Symbol) =
     ccall(:jl_is_const, Cint, (Any, Any), m, s) != 0
 
 function isconst(g::GlobalRef)
-    g.binding != C_NULL && return ccall(:jl_binding_is_const, Cint, (Ptr{Cvoid},), g.binding) != 0
-    return isconst(g.mod, g.name)
+    return ccall(:jl_globalref_is_const, Cint, (Any,), g) != 0
 end
 
 """

--- a/base/show.jl
+++ b/base/show.jl
@@ -1004,9 +1004,9 @@ end
 # If an object with this name exists in 'from', we need to check that it's the same binding
 # and that it's not deprecated.
 function isvisible(sym::Symbol, parent::Module, from::Module)
-    owner = ccall(:jl_binding_owner, Any, (Any, Any), parent, sym)
-    from_owner = ccall(:jl_binding_owner, Any, (Any, Any), from, sym)
-    return owner !== nothing && from_owner === owner &&
+    owner = ccall(:jl_binding_owner, Ptr{Cvoid}, (Any, Any), parent, sym)
+    from_owner = ccall(:jl_binding_owner, Ptr{Cvoid}, (Any, Any), from, sym)
+    return owner !== C_NULL && from_owner === owner &&
         !isdeprecated(parent, sym) &&
         isdefined(from, sym) # if we're going to return true, force binding resolution
 end
@@ -1842,10 +1842,10 @@ function allow_macroname(ex)
     end
 end
 
-function is_core_macro(arg::GlobalRef, macro_name::AbstractString)
-    arg == GlobalRef(Core, Symbol(macro_name))
-end
+is_core_macro(arg::GlobalRef, macro_name::AbstractString) = is_core_macro(arg, Symbol(macro_name))
+is_core_macro(arg::GlobalRef, macro_name::Symbol) = arg == GlobalRef(Core, macro_name)
 is_core_macro(@nospecialize(arg), macro_name::AbstractString) = false
+is_core_macro(@nospecialize(arg), macro_name::Symbol) = false
 
 # symbol for IOContext flag signaling whether "begin" is treated
 # as an ordinary symbol, which is true in indexing expressions.
@@ -2173,12 +2173,12 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
     elseif head === :macrocall && nargs >= 2
         # handle some special syntaxes
         # `a b c`
-        if is_core_macro(args[1], "@cmd")
+        if is_core_macro(args[1], :var"@cmd")
             print(io, "`", args[3], "`")
         # 11111111111111111111, 0xfffffffffffffffff, 1111...many digits...
-        elseif is_core_macro(args[1], "@int128_str") ||
-               is_core_macro(args[1], "@uint128_str") ||
-               is_core_macro(args[1], "@big_str")
+        elseif is_core_macro(args[1], :var"@int128_str") ||
+               is_core_macro(args[1], :var"@uint128_str") ||
+               is_core_macro(args[1], :var"@big_str")
             print(io, args[3])
         # x"y" and x"y"z
         elseif isa(args[1], Symbol) && nargs >= 3 && isa(args[3], String) &&

--- a/doc/src/manual/embedding.md
+++ b/doc/src/manual/embedding.md
@@ -406,8 +406,10 @@ As an alternative for very simple cases, it is possible to just create a global 
 per pointer using
 
 ```c
-jl_binding_t *bp = jl_get_binding_wr(jl_main_module, jl_symbol("var"), 1);
-jl_checked_assignment(bp, val);
+jl_module_t *mod = jl_main_module;
+jl_sym_t *var = jl_symbol("var");
+jl_binding_t *bp = jl_get_binding_wr(mod, var, 1);
+jl_checked_assignment(bp, mod, var, val);
 ```
 
 ### Updating fields of GC-managed objects

--- a/doc/src/manual/embedding.md
+++ b/doc/src/manual/embedding.md
@@ -408,7 +408,7 @@ per pointer using
 ```c
 jl_module_t *mod = jl_main_module;
 jl_sym_t *var = jl_symbol("var");
-jl_binding_t *bp = jl_get_binding_wr(mod, var, 1);
+jl_binding_t *bp = jl_get_binding_wr(mod, var);
 jl_checked_assignment(bp, mod, var, val);
 ```
 

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -171,7 +171,7 @@ julia> using .NiceStuff: nice
 julia> struct Cat end
 
 julia> nice(::Cat) = "nice 😸"
-ERROR: error in method definition: function NiceStuff.nice must be explicitly imported to be extended
+ERROR: invalid method definition in Main: function NiceStuff.nice must be explicitly imported to be extended
 Stacktrace:
  [1] top-level scope
    @ none:0

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -81,7 +81,7 @@ julia> pi
 π = 3.1415926535897...
 
 julia> pi = 3
-ERROR: cannot assign a value to imported variable MathConstants.pi from module Main
+ERROR: cannot assign a value to imported variable Base.pi from module Main
 
 julia> sqrt(100)
 10.0

--- a/src/ast.c
+++ b/src/ast.c
@@ -157,7 +157,7 @@ static value_t fl_defined_julia_global(fl_context_t *fl_ctx, value_t *args, uint
     jl_ast_context_t *ctx = jl_ast_ctx(fl_ctx);
     jl_sym_t *var = jl_symbol(symbol_name(fl_ctx, args[0]));
     jl_binding_t *b = jl_get_module_binding(ctx->module, var);
-    return (b != NULL && b->owner == ctx->module) ? fl_ctx->T : fl_ctx->F;
+    return (b != NULL && jl_atomic_load_relaxed(&b->owner) == b) ? fl_ctx->T : fl_ctx->F;
 }
 
 static value_t fl_current_module_counter(fl_context_t *fl_ctx, value_t *args, uint32_t nargs) JL_NOTSAFEPOINT

--- a/src/ast.c
+++ b/src/ast.c
@@ -156,7 +156,7 @@ static value_t fl_defined_julia_global(fl_context_t *fl_ctx, value_t *args, uint
     (void)tosymbol(fl_ctx, args[0], "defined-julia-global");
     jl_ast_context_t *ctx = jl_ast_ctx(fl_ctx);
     jl_sym_t *var = jl_symbol(symbol_name(fl_ctx, args[0]));
-    jl_binding_t *b = jl_get_module_binding(ctx->module, var);
+    jl_binding_t *b = jl_get_module_binding(ctx->module, var, 0);
     return (b != NULL && jl_atomic_load_relaxed(&b->owner) == b) ? fl_ctx->T : fl_ctx->F;
 }
 

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1220,7 +1220,7 @@ JL_CALLABLE(jl_f_setglobal)
     if (order == jl_memory_order_notatomic)
         jl_atomic_error("setglobal!: module binding cannot be written non-atomically");
     // is seq_cst already, no fence needed
-    jl_binding_t *b = jl_get_binding_wr_or_error(mod, var);
+    jl_binding_t *b = jl_get_binding_wr(mod, var);
     jl_checked_assignment(b, mod, var, args[2]);
     return args[2];
 }
@@ -1234,7 +1234,7 @@ JL_CALLABLE(jl_f_get_binding_type)
     JL_TYPECHK(get_binding_type, symbol, (jl_value_t*)var);
     jl_value_t *ty = jl_get_binding_type(mod, var);
     if (ty == (jl_value_t*)jl_nothing) {
-        jl_binding_t *b = jl_get_binding_wr(mod, var, 0);
+        jl_binding_t *b = jl_get_module_binding(mod, var, 0);
         if (b == NULL)
             return (jl_value_t*)jl_any_type;
         jl_binding_t *b2 = jl_atomic_load_relaxed(&b->owner);
@@ -1256,7 +1256,7 @@ JL_CALLABLE(jl_f_set_binding_type)
     JL_TYPECHK(set_binding_type!, symbol, (jl_value_t*)s);
     jl_value_t *ty = nargs == 2 ? (jl_value_t*)jl_any_type : args[2];
     JL_TYPECHK(set_binding_type!, type, ty);
-    jl_binding_t *b = jl_get_binding_wr(m, s, 1);
+    jl_binding_t *b = jl_get_binding_wr(m, s);
     jl_value_t *old_ty = NULL;
     if (!jl_atomic_cmpswap_relaxed(&b->ty, &old_ty, ty) && ty != old_ty) {
         if (nargs == 2)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1194,11 +1194,13 @@ JL_CALLABLE(jl_f_getglobal)
         JL_TYPECHK(getglobal, symbol, args[2]);
         order = jl_get_atomic_order_checked((jl_sym_t*)args[2], 1, 0);
     }
-    JL_TYPECHK(getglobal, module, args[0]);
-    JL_TYPECHK(getglobal, symbol, args[1]);
+    jl_module_t *mod = (jl_module_t*)args[0];
+    jl_sym_t *sym = (jl_sym_t*)args[1];
+    JL_TYPECHK(getglobal, module, (jl_value_t*)mod);
+    JL_TYPECHK(getglobal, symbol, (jl_value_t*)sym);
     if (order == jl_memory_order_notatomic)
         jl_atomic_error("getglobal: module binding cannot be read non-atomically");
-    jl_value_t *v = jl_eval_global_var((jl_module_t*)args[0], (jl_sym_t*)args[1]);
+    jl_value_t *v = jl_eval_global_var(mod, sym);
     // is seq_cst already, no fence needed
     return v;
 }
@@ -1211,32 +1213,36 @@ JL_CALLABLE(jl_f_setglobal)
         JL_TYPECHK(setglobal!, symbol, args[3]);
         order = jl_get_atomic_order_checked((jl_sym_t*)args[3], 0, 1);
     }
-    JL_TYPECHK(setglobal!, module, args[0]);
-    JL_TYPECHK(setglobal!, symbol, args[1]);
+    jl_module_t *mod = (jl_module_t*)args[0];
+    jl_sym_t *var = (jl_sym_t*)args[1];
+    JL_TYPECHK(setglobal!, module, (jl_value_t*)mod);
+    JL_TYPECHK(setglobal!, symbol, (jl_value_t*)var);
     if (order == jl_memory_order_notatomic)
         jl_atomic_error("setglobal!: module binding cannot be written non-atomically");
     // is seq_cst already, no fence needed
-    jl_binding_t *b = jl_get_binding_wr_or_error((jl_module_t*)args[0], (jl_sym_t*)args[1]);
-    jl_checked_assignment(b, args[2]);
+    jl_binding_t *b = jl_get_binding_wr_or_error(mod, var);
+    jl_checked_assignment(b, mod, var, args[2]);
     return args[2];
 }
 
 JL_CALLABLE(jl_f_get_binding_type)
 {
     JL_NARGS(get_binding_type, 2, 2);
-    JL_TYPECHK(get_binding_type, module, args[0]);
-    JL_TYPECHK(get_binding_type, symbol, args[1]);
     jl_module_t *mod = (jl_module_t*)args[0];
-    jl_sym_t *sym = (jl_sym_t*)args[1];
-    jl_value_t *ty = jl_get_binding_type(mod, sym);
+    jl_sym_t *var = (jl_sym_t*)args[1];
+    JL_TYPECHK(get_binding_type, module, (jl_value_t*)mod);
+    JL_TYPECHK(get_binding_type, symbol, (jl_value_t*)var);
+    jl_value_t *ty = jl_get_binding_type(mod, var);
     if (ty == (jl_value_t*)jl_nothing) {
-        jl_binding_t *b = jl_get_binding_wr(mod, sym, 0);
-        if (b && b->owner == mod) {
-            jl_value_t *old_ty = NULL;
-            jl_atomic_cmpswap_relaxed(&b->ty, &old_ty, (jl_value_t*)jl_any_type);
-            return jl_atomic_load_relaxed(&b->ty);
-        }
-        return (jl_value_t*)jl_any_type;
+        jl_binding_t *b = jl_get_binding_wr(mod, var, 0);
+        if (b == NULL)
+            return (jl_value_t*)jl_any_type;
+        jl_binding_t *b2 = jl_atomic_load_relaxed(&b->owner);
+        if (b2 != b)
+            return (jl_value_t*)jl_any_type;
+        jl_value_t *old_ty = NULL;
+        jl_atomic_cmpswap_relaxed(&b->ty, &old_ty, (jl_value_t*)jl_any_type);
+        return jl_atomic_load_relaxed(&b->ty);
     }
     return ty;
 }
@@ -1244,17 +1250,19 @@ JL_CALLABLE(jl_f_get_binding_type)
 JL_CALLABLE(jl_f_set_binding_type)
 {
     JL_NARGS(set_binding_type!, 2, 3);
-    JL_TYPECHK(set_binding_type!, module, args[0]);
-    JL_TYPECHK(set_binding_type!, symbol, args[1]);
+    jl_module_t *m = (jl_module_t*)args[0];
+    jl_sym_t *s = (jl_sym_t*)args[1];
+    JL_TYPECHK(set_binding_type!, module, (jl_value_t*)m);
+    JL_TYPECHK(set_binding_type!, symbol, (jl_value_t*)s);
     jl_value_t *ty = nargs == 2 ? (jl_value_t*)jl_any_type : args[2];
     JL_TYPECHK(set_binding_type!, type, ty);
-    jl_binding_t *b = jl_get_binding_wr((jl_module_t*)args[0], (jl_sym_t*)args[1], 1);
+    jl_binding_t *b = jl_get_binding_wr(m, s, 1);
     jl_value_t *old_ty = NULL;
     if (!jl_atomic_cmpswap_relaxed(&b->ty, &old_ty, ty) && ty != old_ty) {
         if (nargs == 2)
             return jl_nothing;
-        jl_errorf("cannot set type for global %s. It already has a value or is already set to a different type.",
-                  jl_symbol_name(b->name));
+        jl_errorf("cannot set type for global %s.%s. It already has a value or is already set to a different type.",
+                  jl_symbol_name(m->name), jl_symbol_name(s));
     }
     jl_gc_wb_binding(b, ty);
     return jl_nothing;

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -293,7 +293,7 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
       such as Windows, so we emulate them here.
     */
     if (!abspath && !is_atpath && jl_base_module != NULL) {
-        jl_binding_t *b = jl_get_module_binding(jl_base_module, jl_symbol("DL_LOAD_PATH"));
+        jl_binding_t *b = jl_get_module_binding(jl_base_module, jl_symbol("DL_LOAD_PATH"), 0);
         jl_array_t *DL_LOAD_PATH = (jl_array_t*)(b ? jl_atomic_load_relaxed(&b->value) : NULL);
         if (DL_LOAD_PATH != NULL) {
             size_t j;

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -392,16 +392,16 @@ void _gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t *to, void
                     g_snapshot->names.find_or_create_string_id(path));
 }
 
-void _gc_heap_snapshot_record_module_to_binding(jl_module_t* module, jl_binding_t* binding) JL_NOTSAFEPOINT
+void _gc_heap_snapshot_record_module_to_binding(jl_module_t *module, jl_sym_t *name, jl_binding_t *binding) JL_NOTSAFEPOINT
 {
     auto from_node_idx = record_node_to_gc_snapshot((jl_value_t*)module);
-    auto to_node_idx = record_pointer_to_gc_snapshot(binding, sizeof(jl_binding_t), jl_symbol_name(binding->name));
+    auto to_node_idx = record_pointer_to_gc_snapshot(binding, sizeof(jl_binding_t), jl_symbol_name(name));
 
     jl_value_t *value = jl_atomic_load_relaxed(&binding->value);
     auto value_idx = value ? record_node_to_gc_snapshot(value) : 0;
     jl_value_t *ty = jl_atomic_load_relaxed(&binding->ty);
     auto ty_idx = ty ? record_node_to_gc_snapshot(ty) : 0;
-    jl_value_t *globalref = jl_atomic_load_relaxed(&binding->globalref);
+    jl_value_t *globalref = (jl_value_t*)binding->globalref;
     auto globalref_idx = globalref ? record_node_to_gc_snapshot(globalref) : 0;
 
     auto &from_node = g_snapshot->nodes[from_node_idx];

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -20,7 +20,7 @@ void _gc_heap_snapshot_record_task_to_frame_edge(jl_task_t *from, void *to) JL_N
 void _gc_heap_snapshot_record_frame_to_frame_edge(jl_gcframe_t *from, jl_gcframe_t *to) JL_NOTSAFEPOINT;
 void _gc_heap_snapshot_record_array_edge(jl_value_t *from, jl_value_t *to, size_t index) JL_NOTSAFEPOINT;
 void _gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_value_t *to, void* slot) JL_NOTSAFEPOINT;
-void _gc_heap_snapshot_record_module_to_binding(jl_module_t* module, jl_binding_t* binding) JL_NOTSAFEPOINT;
+void _gc_heap_snapshot_record_module_to_binding(jl_module_t* module, jl_sym_t *name, jl_binding_t* binding) JL_NOTSAFEPOINT;
 // Used for objects managed by GC, but which aren't exposed in the julia object, so have no
 // field or index.  i.e. they're not reachable from julia code, but we _will_ hit them in
 // the GC mark phase (so we can check their type tag to get the size).
@@ -73,10 +73,10 @@ static inline void gc_heap_snapshot_record_object_edge(jl_value_t *from, jl_valu
     }
 }
 
-static inline void gc_heap_snapshot_record_module_to_binding(jl_module_t* module, jl_binding_t* binding) JL_NOTSAFEPOINT
+static inline void gc_heap_snapshot_record_module_to_binding(jl_module_t* module, jl_sym_t *name, jl_binding_t* binding) JL_NOTSAFEPOINT
 {
     if (__unlikely(gc_heap_snapshot_enabled && prev_sweep_full)) {
-        _gc_heap_snapshot_record_module_to_binding(module, binding);
+        _gc_heap_snapshot_record_module_to_binding(module, name, binding);
     }
 }
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -2543,7 +2543,7 @@ module_binding: {
                 continue;
             verify_parent1("module", binding->parent, begin, "binding_buff");
             // Record the size used for the box for non-const bindings
-            gc_heap_snapshot_record_module_to_binding(binding->parent, b);
+            gc_heap_snapshot_record_module_to_binding(binding->parent, (jl_sym_t*)begin[-1], b);
             if (gc_try_setmark((jl_value_t*)b, &binding->nptr, &tag, &bits)) {
                 begin += 2;
                 binding->begin = begin;

--- a/src/gf.c
+++ b/src/gf.c
@@ -473,17 +473,18 @@ int foreach_mtable_in_module(
 {
     size_t i;
     void **table = m->bindings.table;
-    for (i = 1; i < m->bindings.size; i += 2) {
-        if (table[i] != HT_NOTFOUND) {
-            jl_binding_t *b = (jl_binding_t*)table[i];
+    for (i = 0; i < m->bindings.size; i += 2) {
+        if (table[i+1] != HT_NOTFOUND) {
+            jl_sym_t *name = (jl_sym_t*)table[i];
+            jl_binding_t *b = (jl_binding_t*)table[i+1];
             JL_GC_PROMISE_ROOTED(b);
-            if (b->owner == m && b->constp) {
+            if (jl_atomic_load_relaxed(&b->owner) == b && b->constp) {
                 jl_value_t *v = jl_atomic_load_relaxed(&b->value);
                 if (v) {
                     jl_value_t *uw = jl_unwrap_unionall(v);
                     if (jl_is_datatype(uw)) {
                         jl_typename_t *tn = ((jl_datatype_t*)uw)->name;
-                        if (tn->module == m && tn->name == b->name && tn->wrapper == v) {
+                        if (tn->module == m && tn->name == name && tn->wrapper == v) {
                             // this is the original/primary binding for the type (name/wrapper)
                             jl_methtable_t *mt = tn->mt;
                             if (mt != NULL && (jl_value_t*)mt != jl_nothing && mt != jl_type_type_mt && mt != jl_nonfunction_mt) {
@@ -494,7 +495,7 @@ int foreach_mtable_in_module(
                     }
                     else if (jl_is_module(v)) {
                         jl_module_t *child = (jl_module_t*)v;
-                        if (child != m && child->parent == m && child->name == b->name) {
+                        if (child != m && child->parent == m && child->name == name) {
                             // this is the original/primary binding for the submodule
                             if (!foreach_mtable_in_module(child, visit, env))
                                 return 0;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -91,10 +91,9 @@ static jl_value_t *eval_methoddef(jl_expr_t *ex, interpreter_state *s)
         if (!jl_is_symbol(fname)) {
             jl_error("method: invalid declaration");
         }
-        jl_value_t *bp_owner = (jl_value_t*)modu;
         jl_binding_t *b = jl_get_binding_for_method_def(modu, fname);
         _Atomic(jl_value_t*) *bp = &b->value;
-        jl_value_t *gf = jl_generic_function_def(b->name, b->owner, bp, bp_owner, b);
+        jl_value_t *gf = jl_generic_function_def(fname, modu, bp, b);
         return gf;
     }
 
@@ -153,13 +152,10 @@ jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e)
 
 jl_value_t *jl_eval_globalref(jl_globalref_t *g)
 {
-    if (g->bnd_cache) {
-        jl_value_t *v = jl_atomic_load_relaxed(&g->bnd_cache->value);
-        if (v == NULL)
-            jl_undefined_var_error(g->name);
-        return v;
-    }
-    return jl_eval_global_var(g->mod, g->name);
+    jl_value_t *v = jl_get_globalref_value(g);
+    if (v == NULL)
+        jl_undefined_var_error(g->name);
+    return v;
 }
 
 static int jl_source_nslots(jl_code_info_t *src) JL_NOTSAFEPOINT
@@ -497,7 +493,7 @@ static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, size_t ip,
                     }
                     JL_GC_PUSH1(&rhs);
                     jl_binding_t *b = jl_get_binding_wr_or_error(modu, sym);
-                    jl_checked_assignment(b, rhs);
+                    jl_checked_assignment(b, modu, sym, rhs);
                     JL_GC_POP();
                 }
             }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -492,7 +492,7 @@ static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, size_t ip,
                         sym = (jl_sym_t*)lhs;
                     }
                     JL_GC_PUSH1(&rhs);
-                    jl_binding_t *b = jl_get_binding_wr_or_error(modu, sym);
+                    jl_binding_t *b = jl_get_binding_wr(modu, sym);
                     jl_checked_assignment(b, modu, sym, rhs);
                     JL_GC_POP();
                 }

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -55,7 +55,6 @@
     XX(jl_atomic_swap_bits) \
     XX(jl_backtrace_from_here) \
     XX(jl_base_relative_to) \
-    XX(jl_binding_owner) \
     XX(jl_binding_resolved_p) \
     XX(jl_bitcast) \
     XX(jl_boundp) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -209,7 +209,6 @@
     XX(jl_get_binding) \
     XX(jl_get_binding_for_method_def) \
     XX(jl_get_binding_or_error) \
-    XX(jl_get_binding_wr_or_error) \
     XX(jl_get_binding_wr) \
     XX(jl_get_cpu_name) \
     XX(jl_get_current_task) \
@@ -223,7 +222,6 @@
     XX(jl_get_julia_bin) \
     XX(jl_get_julia_bindir) \
     XX(jl_get_method_inferred) \
-    XX(jl_get_module_binding) \
     XX(jl_get_module_compile) \
     XX(jl_get_module_infer) \
     XX(jl_get_module_of_binding) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2751,18 +2751,18 @@ void jl_init_types(void) JL_GC_DISABLED
 
     jl_binding_type =
         jl_new_datatype(jl_symbol("Binding"), core, jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(6, "name", "value", "globalref", "owner", "ty", "flags"),
-                        jl_svec(6, jl_symbol_type, jl_any_type, jl_any_type/*jl_globalref_type*/, jl_module_type, jl_any_type, jl_uint8_type),
-                        jl_emptysvec, 0, 1, 1);
-    const static uint32_t binding_constfields[1]  = { 0x0001 }; // Set fields 1 as const
-    const static uint32_t binding_atomicfields[1] = { 0x0016 }; // Set fields 2, 3, 5 as atomic
-    jl_binding_type->name->constfields = binding_constfields;
+                        jl_perm_symsvec(5, "value", "globalref", "owner", "ty", "flags"),
+                        jl_svec(5, jl_any_type, jl_any_type/*jl_globalref_type*/, jl_any_type/*jl_binding_type*/, jl_type_type, jl_uint8_type),
+                        jl_emptysvec, 0, 1, 0);
+    const static uint32_t binding_atomicfields[] = { 0x0015 }; // Set fields 1, 3, 4 as atomic
     jl_binding_type->name->atomicfields = binding_atomicfields;
+    const static uint32_t binding_constfields[] = { 0x0002 }; // Set fields 2 as constant
+    jl_binding_type->name->constfields = binding_constfields;
 
     jl_globalref_type =
         jl_new_datatype(jl_symbol("GlobalRef"), core, jl_any_type, jl_emptysvec,
                         jl_perm_symsvec(3, "mod", "name", "binding"),
-                        jl_svec(3, jl_module_type, jl_symbol_type, pointer_void),
+                        jl_svec(3, jl_module_type, jl_symbol_type, jl_binding_type),
                         jl_emptysvec, 0, 0, 3);
 
     tv = jl_svec2(tvar("A"), tvar("R"));
@@ -2804,7 +2804,8 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_method_instance_type->types, 6, jl_code_instance_type);
     jl_svecset(jl_code_instance_type->types, 13, jl_voidpointer_type);
     jl_svecset(jl_code_instance_type->types, 14, jl_voidpointer_type);
-    jl_svecset(jl_binding_type->types, 2, jl_globalref_type);
+    jl_svecset(jl_binding_type->types, 1, jl_globalref_type);
+    jl_svecset(jl_binding_type->types, 2, jl_binding_type);
 
     jl_compute_field_offsets(jl_datatype_type);
     jl_compute_field_offsets(jl_typename_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1627,8 +1627,7 @@ JL_DLLEXPORT jl_binding_t *jl_get_binding_if_bound(jl_module_t *m, jl_sym_t *var
 JL_DLLEXPORT jl_value_t *jl_module_globalref(jl_module_t *m, jl_sym_t *var);
 JL_DLLEXPORT jl_value_t *jl_get_binding_type(jl_module_t *m, jl_sym_t *var);
 // get binding for assignment
-JL_DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var, int alloc);
-JL_DLLEXPORT jl_binding_t *jl_get_binding_wr_or_error(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var);
+JL_DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var);
 JL_DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var);
 JL_DLLEXPORT int jl_boundp(jl_module_t *m, jl_sym_t *var);
 JL_DLLEXPORT int jl_defines_or_exports_p(jl_module_t *m, jl_sym_t *var);

--- a/src/julia.h
+++ b/src/julia.h
@@ -196,6 +196,9 @@ STATIC_INLINE int jl_array_ndimwords(uint32_t ndims) JL_NOTSAFEPOINT
 
 typedef struct _jl_datatype_t jl_tupletype_t;
 struct _jl_code_instance_t;
+typedef struct _jl_method_instance_t jl_method_instance_t;
+typedef struct _jl_globalref_t jl_globalref_t;
+
 
 // TypeMap is an implicitly defined type
 // that can consist of any of the following nodes:
@@ -225,8 +228,6 @@ typedef jl_value_t *(*jl_fptr_sparam_t)(jl_value_t*, jl_value_t**, uint32_t, jl_
 
 extern jl_call_t jl_fptr_interpret_call;
 JL_DLLEXPORT extern jl_callptr_t jl_fptr_interpret_call_addr;
-
-typedef struct _jl_method_instance_t jl_method_instance_t;
 
 typedef struct _jl_line_info_node_t {
     struct _jl_module_t *module;
@@ -312,7 +313,7 @@ typedef struct _jl_method_t {
     jl_value_t *slot_syms; // compacted list of slot names (String)
     jl_value_t *external_mt; // reference to the method table this method is part of, null if part of the internal table
     jl_value_t *source;  // original code template (jl_code_info_t, but may be compressed), null for builtins
-    _Atomic(struct _jl_method_instance_t*) unspecialized;  // unspecialized executable method instance, or null
+    _Atomic(jl_method_instance_t*) unspecialized;  // unspecialized executable method instance, or null
     jl_value_t *generator;  // executable code-generating function if available
     jl_array_t *roots;  // pointers in generated code (shared to reduce memory), or null
     // Identify roots by module-of-origin. We only track the module for roots added during incremental compilation.
@@ -373,7 +374,7 @@ struct _jl_method_instance_t {
 };
 
 // OpaqueClosure
-typedef struct jl_opaque_closure_t {
+typedef struct _jl_opaque_closure_t {
     JL_DATA_TYPE
     jl_value_t *captures;
     size_t world;
@@ -554,21 +555,21 @@ typedef struct _jl_vararg_t {
     jl_value_t *N;
 } jl_vararg_t;
 
-typedef struct {
+typedef struct _jl_weakref_t {
     JL_DATA_TYPE
     jl_value_t *value;
 } jl_weakref_t;
 
-typedef struct {
+typedef struct _jl_binding_t {
     JL_DATA_TYPE
-    jl_sym_t *name;
     _Atomic(jl_value_t*) value;
-    _Atomic(jl_value_t*) globalref;  // cached GlobalRef for this binding
-    struct _jl_module_t* owner;  // for individual imported bindings -- TODO: make _Atomic
+    jl_globalref_t *globalref;  // cached GlobalRef for this binding
+    _Atomic(struct _jl_binding_t*) owner;  // for individual imported bindings (NULL until 'resolved')
     _Atomic(jl_value_t*) ty;  // binding type
     uint8_t constp:1;
     uint8_t exportp:1;
     uint8_t imported:1;
+    uint8_t usingfailed:1;
     uint8_t deprecated:2; // 0=not deprecated, 1=renamed, 2=moved to another package
 } jl_binding_t;
 
@@ -598,11 +599,10 @@ typedef struct _jl_module_t {
     intptr_t hash;
 } jl_module_t;
 
-typedef struct {
+typedef struct _jl_globalref_t {
     jl_module_t *mod;
     jl_sym_t *name;
-    // Not serialized. Caches the value of jl_get_binding(mod, name).
-    jl_binding_t *bnd_cache;
+    jl_binding_t *binding;
 } jl_globalref_t;
 
 // one Type-to-Value entry
@@ -1490,7 +1490,7 @@ JL_DLLEXPORT jl_sym_t *jl_tagged_gensym(const char *str, size_t len);
 JL_DLLEXPORT jl_sym_t *jl_get_root_symbol(void);
 JL_DLLEXPORT jl_value_t *jl_generic_function_def(jl_sym_t *name,
                                                  jl_module_t *module,
-                                                 _Atomic(jl_value_t*) *bp, jl_value_t *bp_owner,
+                                                 _Atomic(jl_value_t*) *bp,
                                                  jl_binding_t *bnd);
 JL_DLLEXPORT jl_method_t *jl_method_def(jl_svec_t *argdata, jl_methtable_t *mt, jl_code_info_t *f, jl_module_t *module);
 JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo);
@@ -1634,13 +1634,14 @@ JL_DLLEXPORT int jl_boundp(jl_module_t *m, jl_sym_t *var);
 JL_DLLEXPORT int jl_defines_or_exports_p(jl_module_t *m, jl_sym_t *var);
 JL_DLLEXPORT int jl_binding_resolved_p(jl_module_t *m, jl_sym_t *var);
 JL_DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var);
-JL_DLLEXPORT int jl_binding_is_const(jl_binding_t *b);
-JL_DLLEXPORT int jl_binding_boundp(jl_binding_t *b);
+JL_DLLEXPORT int jl_globalref_is_const(jl_globalref_t *gr);
+JL_DLLEXPORT int jl_globalref_boundp(jl_globalref_t *gr);
+JL_DLLEXPORT jl_value_t *jl_get_globalref_value(jl_globalref_t *gr);
 JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var);
 JL_DLLEXPORT void jl_set_global(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT);
 JL_DLLEXPORT void jl_set_const(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT);
-JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs JL_MAYBE_UNROOTED);
-JL_DLLEXPORT void jl_declare_constant(jl_binding_t *b);
+JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_module_t *mod, jl_sym_t *var, jl_value_t *rhs JL_MAYBE_UNROOTED);
+JL_DLLEXPORT void jl_declare_constant(jl_binding_t *b, jl_module_t *mod, jl_sym_t *var);
 JL_DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from);
 JL_DLLEXPORT void jl_module_use(jl_module_t *to, jl_module_t *from, jl_sym_t *s);
 JL_DLLEXPORT void jl_module_use_as(jl_module_t *to, jl_module_t *from, jl_sym_t *s, jl_sym_t *asname);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -763,7 +763,7 @@ jl_array_t *jl_new_array_for_deserialization(jl_value_t *atype, uint32_t ndims, 
                                              int isunboxed, int hasptr, int isunion, int elsz);
 void jl_module_run_initializer(jl_module_t *m);
 jl_binding_t *jl_get_module_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var);
-JL_DLLEXPORT void jl_binding_deprecation_warning(jl_module_t *m, jl_binding_t *b);
+JL_DLLEXPORT void jl_binding_deprecation_warning(jl_module_t *m, jl_sym_t *sym, jl_binding_t *b);
 extern jl_array_t *jl_module_init_order JL_GLOBALLY_ROOTED;
 extern htable_t jl_current_modules JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_module_t *jl_precompile_toplevel_module JL_GLOBALLY_ROOTED;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -762,7 +762,7 @@ void jl_compute_field_offsets(jl_datatype_t *st);
 jl_array_t *jl_new_array_for_deserialization(jl_value_t *atype, uint32_t ndims, size_t *dims,
                                              int isunboxed, int hasptr, int isunion, int elsz);
 void jl_module_run_initializer(jl_module_t *m);
-jl_binding_t *jl_get_module_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var);
+jl_binding_t *jl_get_module_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var, int alloc);
 JL_DLLEXPORT void jl_binding_deprecation_warning(jl_module_t *m, jl_sym_t *sym, jl_binding_t *b);
 extern jl_array_t *jl_module_init_order JL_GLOBALLY_ROOTED;
 extern htable_t jl_current_modules JL_GLOBALLY_ROOTED;

--- a/src/method.c
+++ b/src/method.c
@@ -892,25 +892,24 @@ jl_method_t *jl_make_opaque_closure_method(jl_module_t *module, jl_value_t *name
 JL_DLLEXPORT jl_value_t *jl_generic_function_def(jl_sym_t *name,
                                                  jl_module_t *module,
                                                  _Atomic(jl_value_t*) *bp,
-                                                 jl_value_t *bp_owner,
                                                  jl_binding_t *bnd)
 {
     jl_value_t *gf = NULL;
 
     assert(name && bp);
     if (bnd && jl_atomic_load_relaxed(&bnd->value) != NULL && !bnd->constp)
-        jl_errorf("cannot define function %s; it already has a value", jl_symbol_name(bnd->name));
+        jl_errorf("cannot define function %s; it already has a value", jl_symbol_name(name));
     gf = jl_atomic_load_relaxed(bp);
     if (gf != NULL) {
         if (!jl_is_datatype_singleton((jl_datatype_t*)jl_typeof(gf)) && !jl_is_type(gf))
             jl_errorf("cannot define function %s; it already has a value", jl_symbol_name(name));
     }
     if (bnd)
-        bnd->constp = 1;
+        bnd->constp = 1; // XXX: use jl_declare_constant and jl_checked_assignment
     if (gf == NULL) {
         gf = (jl_value_t*)jl_new_generic_function(name, module);
         jl_atomic_store(bp, gf); // TODO: fix constp assignment data race
-        if (bp_owner) jl_gc_wb(bp_owner, gf);
+        if (bnd) jl_gc_wb(bnd, gf);
     }
     return gf;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -156,22 +156,38 @@ JL_DLLEXPORT uint8_t jl_istopmod(jl_module_t *mod)
     return mod->istopmod;
 }
 
-static jl_binding_t *new_binding(jl_sym_t *name)
+static jl_globalref_t *jl_new_globalref(jl_module_t *mod, jl_sym_t *name, jl_binding_t *b)
 {
     jl_task_t *ct = jl_current_task;
-    assert(jl_is_symbol(name));
+    jl_globalref_t *g = (jl_globalref_t*)jl_gc_alloc(ct->ptls, sizeof(jl_globalref_t), jl_globalref_type);
+    g->mod = mod;
+    jl_gc_wb(g, g->mod);
+    g->name = name;
+    g->binding = b;
+    return g;
+}
+
+static jl_binding_t *new_binding(jl_module_t *mod, jl_sym_t *name)
+{
+    jl_task_t *ct = jl_current_task;
+    assert(jl_is_module(mod) && jl_is_symbol(name));
     jl_binding_t *b = (jl_binding_t*)jl_gc_alloc(ct->ptls, sizeof(jl_binding_t), jl_binding_type);
-    b->name = name;
     jl_atomic_store_relaxed(&b->value, NULL);
-    b->owner = NULL;
+    jl_atomic_store_relaxed(&b->owner, NULL);
     jl_atomic_store_relaxed(&b->ty, NULL);
-    jl_atomic_store_relaxed(&b->globalref, NULL);
+    b->globalref = NULL;
     b->constp = 0;
     b->exportp = 0;
     b->imported = 0;
     b->deprecated = 0;
+    b->usingfailed = 0;
+    JL_GC_PUSH1(&b);
+    b->globalref = jl_new_globalref(mod, name, b);
+    JL_GC_POP();
     return b;
 }
+
+static jl_module_t *jl_binding_dbgmodule(jl_binding_t *b, jl_module_t *m, jl_sym_t *var) JL_GLOBALLY_ROOTED;
 
 // get binding for assignment
 JL_DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var, int alloc)
@@ -181,20 +197,27 @@ JL_DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m JL_PROPAGATES_ROOT, 
     jl_binding_t *b = *bp;
 
     if (b != HT_NOTFOUND) {
-        if (b->owner != m) {
-            if (b->owner == NULL) {
-                b->owner = m;
+        JL_GC_PROMISE_ROOTED(b);
+        jl_binding_t *b2 = jl_atomic_load_relaxed(&b->owner);
+        if (b2 != b) {
+            if (b2 == NULL) {
+                jl_atomic_store_release(&b->owner, b);
             }
             else if (alloc) {
+                jl_module_t *from = jl_binding_dbgmodule(b, m, var);
                 JL_UNLOCK(&m->lock);
-                jl_errorf("cannot assign a value to imported variable %s.%s from module %s",
-                          jl_symbol_name(b->owner->name), jl_symbol_name(var), jl_symbol_name(m->name));
+                if (from == m)
+                    jl_errorf("cannot assign a value to imported variable %s.%s",
+                              jl_symbol_name(from->name), jl_symbol_name(var));
+                else
+                    jl_errorf("cannot assign a value to imported variable %s.%s from module %s",
+                              jl_symbol_name(from->name), jl_symbol_name(var), jl_symbol_name(m->name));
             }
         }
     }
     else if (alloc) {
-        b = new_binding(var);
-        b->owner = m;
+        b = new_binding(m, var);
+        jl_atomic_store_release(&b->owner, b);
         *bp = b;
         JL_GC_PROMISE_ROOTED(b);
         jl_gc_wb(m, b);
@@ -219,14 +242,13 @@ static inline jl_binding_t *_jl_get_module_binding(jl_module_t *m JL_PROPAGATES_
 }
 #endif
 
-
 // return module of binding
 JL_DLLEXPORT jl_module_t *jl_get_module_of_binding(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t *b = jl_get_binding(m, var);
     if (b == NULL)
         return NULL;
-    return b->owner;
+    return b->globalref->mod; // TODO: deprecate this?
 }
 
 // get binding for adding a method
@@ -236,42 +258,47 @@ JL_DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m, jl_sym_
     JL_LOCK(&m->lock);
     jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&m->bindings, var);
     jl_binding_t *b = *bp;
-    JL_GC_PROMISE_ROOTED(b);
 
     if (b != HT_NOTFOUND) {
-        if (b->owner != m) {
-            if (b->owner == NULL) {
-                b->owner = m;
+        JL_GC_PROMISE_ROOTED(b);
+        jl_binding_t *b2 = jl_atomic_load_relaxed(&b->owner);
+        if (b2 != b) {
+            // TODO: make this cmpswap atomic
+            if (b2 == NULL) {
+                jl_atomic_store_release(&b->owner, b);
             }
             else {
+                jl_value_t *f = jl_atomic_load_relaxed(&b2->value);
+                jl_module_t *from = jl_binding_dbgmodule(b, m, var);
                 JL_UNLOCK(&m->lock);
-                jl_binding_t *b2 = jl_get_binding(b->owner, b->name);
-                if (b2 == NULL || jl_atomic_load_relaxed(&b2->value) == NULL)
-                    jl_errorf("invalid method definition: imported function %s.%s does not exist",
-                              jl_symbol_name(b->owner->name), jl_symbol_name(b->name));
+                if (f == NULL) {
+                    // we must have implicitly imported this with using, so call jl_binding_dbgmodule to try to get the name of the module we got this from
+                    jl_errorf("invalid method definition in %s: exported function %s.%s does not exist",
+                              jl_symbol_name(m->name), jl_symbol_name(from->name), jl_symbol_name(var));
+                }
                 // TODO: we might want to require explicitly importing types to add constructors
-                if (!b->imported && (!b2->constp || !jl_is_type(jl_atomic_load_relaxed(&b2->value)))) {
-                    jl_errorf("error in method definition: function %s.%s must be explicitly imported to be extended",
-                              jl_symbol_name(b->owner->name), jl_symbol_name(b->name));
+                //       or we might want to drop this error entirely
+                if (!b->imported && (!b2->constp || !jl_is_type(f))) {
+                    jl_errorf("invalid method definition in %s: function %s.%s must be explicitly imported to be extended",
+                              jl_symbol_name(m->name), jl_symbol_name(from->name), jl_symbol_name(var));
                 }
                 return b2;
             }
         }
     }
     else {
-        b = new_binding(var);
-        b->owner = m;
+        b = new_binding(m, var);
+        jl_atomic_store_relaxed(&b->owner, b);
         *bp = b;
         JL_GC_PROMISE_ROOTED(b);
         jl_gc_wb(m, b);
     }
 
-    JL_UNLOCK(&m->lock);
+    JL_UNLOCK(&m->lock); // may gc
     return b;
 }
 
-static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s, jl_sym_t *asname,
-                           int explici);
+static void module_import_(jl_module_t *to, jl_module_t *from, jl_binding_t *b, jl_sym_t *asname, jl_sym_t *s, int explici);
 
 typedef struct _modstack_t {
     jl_module_t *m;
@@ -279,7 +306,7 @@ typedef struct _modstack_t {
     struct _modstack_t *prev;
 } modstack_t;
 
-static jl_binding_t *jl_get_binding_(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var, modstack_t *st);
+static jl_binding_t *jl_resolve_owner(jl_binding_t *b/*optional*/, jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var, modstack_t *st);
 
 static inline jl_module_t *module_usings_getidx(jl_module_t *m JL_PROPAGATES_ROOT, size_t i) JL_NOTSAFEPOINT;
 
@@ -291,29 +318,44 @@ static inline jl_module_t *module_usings_getidx(jl_module_t *m JL_PROPAGATES_ROO
 }
 #endif
 
+static int eq_bindings(jl_binding_t *a, jl_binding_t *b)
+{
+    if (a == b)
+        return 1;
+    if (jl_atomic_load_relaxed(&a->owner) == jl_atomic_load_relaxed(&b->owner))
+        return 1;
+    if (a->constp && b->constp && jl_atomic_load_relaxed(&a->value) && jl_atomic_load_relaxed(&b->value) == jl_atomic_load_relaxed(&a->value))
+        return 1;
+    return 0;
+}
+
 // find a binding from a module's `usings` list
 // called while holding m->lock
-static jl_binding_t *using_resolve_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var, modstack_t *st, int warn)
+static jl_binding_t *using_resolve_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var, jl_module_t **from, modstack_t *st, int warn)
 {
     jl_binding_t *b = NULL;
     jl_module_t *owner = NULL;
-    for(int i=(int)m->usings.len-1; i >= 0; --i) {
+    for (int i = (int)m->usings.len - 1; i >= 0; --i) {
         jl_module_t *imp = module_usings_getidx(m, i);
         // TODO: make sure this can't deadlock
-        JL_LOCK(&imp->lock);
-        jl_binding_t *tempb = _jl_get_module_binding(imp, var);
-        JL_UNLOCK(&imp->lock);
-        if (tempb != HT_NOTFOUND && tempb->exportp) {
-            tempb = jl_get_binding_(imp, var, st);
-            if (tempb == NULL || tempb->owner == NULL)
+        jl_binding_t *tempb = jl_get_module_binding(imp, var);
+        if (tempb != NULL && tempb->exportp) {
+            tempb = jl_resolve_owner(NULL, imp, var, st); // find the owner for tempb
+            if (tempb == NULL)
                 // couldn't resolve; try next using (see issue #6105)
                 continue;
-            if (owner != NULL && tempb->owner != b->owner &&
-                !tempb->deprecated && !b->deprecated &&
-                !(tempb->constp && b->constp && jl_atomic_load_relaxed(&tempb->value) && b->constp && jl_atomic_load_relaxed(&b->value) == jl_atomic_load_relaxed(&tempb->value))) {
+            assert(jl_atomic_load_relaxed(&tempb->owner) == tempb);
+            if (b != NULL && !tempb->deprecated && !b->deprecated && !eq_bindings(tempb, b)) {
                 if (warn) {
-                    // mark this binding resolved (by creating it or setting the owner), to avoid repeating the warning
-                    (void)jl_get_binding_wr(m, var, 1);
+                    // set usingfailed=1 to avoid repeating this warning
+                    // the owner will still be NULL, so it can be later imported or defined
+                    tempb = _jl_get_module_binding(m, var);
+                    if (tempb == HT_NOTFOUND) {
+                        tempb = new_binding(m, var);
+                        ptrhash_put(&m->bindings, (void*)var, (void*)tempb);
+                        jl_gc_wb(m, tempb);
+                    }
+                    tempb->usingfailed = 1;
                     JL_UNLOCK(&m->lock);
                     jl_printf(JL_STDERR,
                               "WARNING: both %s and %s export \"%s\"; uses of it in module %s must be qualified\n",
@@ -330,77 +372,97 @@ static jl_binding_t *using_resolve_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl
             }
         }
     }
+    *from = owner;
     return b;
 }
 
-// get binding for reading. might return NULL for unbound.
-static jl_binding_t *jl_get_binding_(jl_module_t *m, jl_sym_t *var, modstack_t *st)
+// for error message printing: look up the module that exported a binding to m as var
+// this might not be the same as the owner of the binding, since the binding itself may itself have been imported from elsewhere
+// must be holding m->lock before calling this
+static jl_module_t *jl_binding_dbgmodule(jl_binding_t *b, jl_module_t *m, jl_sym_t *var)
 {
-    modstack_t top = { m, var, st };
-    modstack_t *tmp = st;
-    while (tmp != NULL) {
-        if (tmp->m == m && tmp->var == var) {
-            // import cycle without finding actual location
-            return NULL;
+    jl_binding_t *b2 = jl_atomic_load_relaxed(&b->owner);
+    if (b2 != b && !b->imported) {
+        // for implicitly imported globals, try to re-resolve it to find the module we got it from most directly
+        jl_module_t *from = NULL;
+        b = using_resolve_binding(m, var, &from, NULL, 0);
+        if (b) {
+            if (b2 == NULL || jl_atomic_load_relaxed(&b->owner) == jl_atomic_load_relaxed(&b2->owner))
+                return from;
+            // if we did not find it (or accidentally found a different one), ignore this
         }
-        tmp = tmp->prev;
     }
-    JL_LOCK(&m->lock);
-    jl_binding_t *b = _jl_get_module_binding(m, var);
-    if (b == HT_NOTFOUND || b->owner == NULL) {
-        b = using_resolve_binding(m, var, &top, 1);
+    return m;
+}
+
+// get binding for reading. might return NULL for unbound.
+static jl_binding_t *jl_resolve_owner(jl_binding_t *b/*optional*/, jl_module_t *m, jl_sym_t *var, modstack_t *st)
+{
+    if (b == NULL)
+        b = jl_get_module_binding(m, var);
+    if (b != NULL) {
+        if (jl_atomic_load_relaxed(&b->owner) == NULL && b->usingfailed)
+            return NULL;
+        b = jl_atomic_load_relaxed(&b->owner);
+    }
+    if (b == NULL) {
+        modstack_t top = { m, var, st };
+        modstack_t *tmp = st;
+        for (; tmp != NULL; tmp = tmp->prev) {
+            if (tmp->m == m && tmp->var == var) {
+                // import cycle without finding actual location
+                return NULL;
+            }
+        }
+        jl_module_t *from = NULL; // for error message printing
+        JL_LOCK(&m->lock);
+        b = using_resolve_binding(m, var, &from, &top, 1);
         JL_UNLOCK(&m->lock);
         if (b != NULL) {
             // do a full import to prevent the result of this lookup
             // from changing, for example if this var is assigned to
             // later.
-            module_import_(m, b->owner, b->name, var, 0);
+            // TODO: make this more thread-safe
+            assert(jl_atomic_load_relaxed(&b->owner) == b && from);
+            module_import_(m, from, b, var, var, 0);
             return b;
         }
         return NULL;
     }
-    JL_UNLOCK(&m->lock);
-    if (b->owner != m || b->name != var)
-        return jl_get_binding_(b->owner, b->name, &top);
+    assert(jl_atomic_load_relaxed(&b->owner) == b);
     return b;
 }
 
 JL_DLLEXPORT jl_binding_t *jl_get_binding_if_bound(jl_module_t *m, jl_sym_t *var)
 {
-    JL_LOCK(&m->lock);
-    jl_binding_t *b = _jl_get_module_binding(m, var);
-    JL_UNLOCK(&m->lock);
-    if (b == HT_NOTFOUND || b->owner == NULL) {
-        return NULL;
-    }
-    if (b->owner != m || b->name != var)
-        return jl_get_binding_if_bound(b->owner, b->name);
-    return b;
+    jl_binding_t *b = jl_get_module_binding(m, var);
+    return b == NULL ? NULL : jl_atomic_load_relaxed(&b->owner);
 }
 
 
-// get owner of binding when accessing m.var, without resolving the binding
-JL_DLLEXPORT jl_value_t *jl_binding_owner(jl_module_t *m, jl_sym_t *var)
+// get the current likely owner of binding when accessing m.var, without resolving the binding (it may change later)
+JL_DLLEXPORT jl_binding_t *jl_binding_owner(jl_module_t *m, jl_sym_t *var)
 {
     JL_LOCK(&m->lock);
     jl_binding_t *b = (jl_binding_t*)ptrhash_get(&m->bindings, var);
-    if (b == HT_NOTFOUND || b->owner == NULL)
-        b = using_resolve_binding(m, var, NULL, 0);
+    jl_module_t *from = m;
+    if (b == HT_NOTFOUND || (!b->usingfailed && jl_atomic_load_relaxed(&b->owner) == NULL))
+        b = using_resolve_binding(m, var, &from, NULL, 0);
+    else
+        b = jl_atomic_load_relaxed(&b->owner);
     JL_UNLOCK(&m->lock);
-    if (b == NULL || b->owner == NULL)
-        return jl_nothing;
-    return (jl_value_t*)b->owner;
+    return b;
 }
 
 // get type of binding m.var, without resolving the binding
 JL_DLLEXPORT jl_value_t *jl_get_binding_type(jl_module_t *m, jl_sym_t *var)
 {
-    JL_LOCK(&m->lock);
-    jl_binding_t *b = _jl_get_module_binding(m, var);
-    JL_UNLOCK(&m->lock);
-    if (b == HT_NOTFOUND || b->owner == NULL)
+    jl_binding_t *b = jl_get_module_binding(m, var);
+    if (b == NULL)
         return jl_nothing;
-    b = jl_get_binding(m, var);
+    b = jl_atomic_load_relaxed(&b->owner);
+    if (b == NULL)
+        return jl_nothing;
     jl_value_t *ty = jl_atomic_load_relaxed(&b->ty);
     return ty ? ty : jl_nothing;
 }
@@ -412,7 +474,7 @@ JL_DLLEXPORT jl_binding_t *jl_get_binding_wr_or_error(jl_module_t *m, jl_sym_t *
 
 JL_DLLEXPORT jl_binding_t *jl_get_binding(jl_module_t *m, jl_sym_t *var)
 {
-    return jl_get_binding_(m, var, NULL);
+    return jl_resolve_owner(NULL, m, var, NULL);
 }
 
 JL_DLLEXPORT jl_binding_t *jl_get_binding_or_error(jl_module_t *m, jl_sym_t *var)
@@ -420,20 +482,10 @@ JL_DLLEXPORT jl_binding_t *jl_get_binding_or_error(jl_module_t *m, jl_sym_t *var
     jl_binding_t *b = jl_get_binding(m, var);
     if (b == NULL)
         jl_undefined_var_error(var);
+    // XXX: this only considers if the original is deprecated, not the binding in m
     if (b->deprecated)
-        jl_binding_deprecation_warning(m, b);
+        jl_binding_deprecation_warning(m, var, b);
     return b;
-}
-
-JL_DLLEXPORT jl_globalref_t *jl_new_globalref(jl_module_t *mod, jl_sym_t *name, jl_binding_t *b)
-{
-    jl_task_t *ct = jl_current_task;
-    jl_globalref_t *g = (jl_globalref_t *)jl_gc_alloc(ct->ptls, sizeof(jl_globalref_t), jl_globalref_type);
-    g->mod = mod;
-    jl_gc_wb(g, g->mod);
-    g->name = name;
-    g->bnd_cache = b;
-    return g;
 }
 
 JL_DLLEXPORT jl_value_t *jl_module_globalref(jl_module_t *m, jl_sym_t *var)
@@ -441,32 +493,15 @@ JL_DLLEXPORT jl_value_t *jl_module_globalref(jl_module_t *m, jl_sym_t *var)
     JL_LOCK(&m->lock);
     jl_binding_t *b = _jl_get_module_binding(m, var);
     if (b == HT_NOTFOUND) {
-        JL_UNLOCK(&m->lock);
-        return (jl_value_t *)jl_new_globalref(m, var, NULL);
-    }
-    jl_value_t *globalref = jl_atomic_load_relaxed(&b->globalref);
-    if (globalref == NULL) {
-        jl_value_t *newref = (jl_value_t *)jl_new_globalref(m, var,
-            !b->owner ? NULL : b->owner == m ? b : _jl_get_module_binding(b->owner, b->name));
-        if (jl_atomic_cmpswap_relaxed(&b->globalref, &globalref, newref)) {
-            JL_GC_PROMISE_ROOTED(newref);
-            globalref = newref;
-            jl_gc_wb_binding(b, globalref);
-        }
+        b = new_binding(m, var);
+        ptrhash_put(&m->bindings, (void*)var, (void*)b);
+        jl_gc_wb(m, b);
+        JL_GC_PROMISE_ROOTED(b);
     }
     JL_UNLOCK(&m->lock); // may GC
-    return globalref;
-}
-
-static int eq_bindings(jl_binding_t *a, jl_binding_t *b)
-{
-    if (a == b)
-        return 1;
-    if (a->name == b->name && a->owner == b->owner)
-        return 1;
-    if (a->constp && b->constp && jl_atomic_load_relaxed(&a->value) && jl_atomic_load_relaxed(&b->value) == jl_atomic_load_relaxed(&a->value))
-        return 1;
-    return 0;
+    jl_globalref_t *globalref = b->globalref;
+    assert(globalref != NULL);
+    return (jl_value_t*)globalref;
 }
 
 // does module m explicitly import s?
@@ -478,10 +513,62 @@ JL_DLLEXPORT int jl_is_imported(jl_module_t *m, jl_sym_t *s)
     return (b != HT_NOTFOUND && b->imported);
 }
 
-// NOTE: we use explici since explicit is a C++ keyword
-static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s, jl_sym_t *asname, int explici)
+extern const char *jl_filename;
+extern int jl_lineno;
+
+static char const dep_message_prefix[] = "_dep_message_";
+
+static void jl_binding_dep_message(jl_module_t *m, jl_sym_t *name, jl_binding_t *b)
 {
-    jl_binding_t *b = jl_get_binding(from, s);
+    size_t prefix_len = strlen(dep_message_prefix);
+    size_t name_len = strlen(jl_symbol_name(name));
+    char *dep_binding_name = (char*)alloca(prefix_len+name_len+1);
+    memcpy(dep_binding_name, dep_message_prefix, prefix_len);
+    memcpy(dep_binding_name + prefix_len, jl_symbol_name(name), name_len);
+    dep_binding_name[prefix_len+name_len] = '\0';
+    jl_binding_t *dep_message_binding = jl_get_binding(m, jl_symbol(dep_binding_name));
+    jl_value_t *dep_message = NULL;
+    if (dep_message_binding != NULL)
+        dep_message = jl_atomic_load_relaxed(&dep_message_binding->value);
+    JL_GC_PUSH1(&dep_message);
+    if (dep_message != NULL) {
+        if (jl_is_string(dep_message)) {
+            jl_uv_puts(JL_STDERR, jl_string_data(dep_message), jl_string_len(dep_message));
+        }
+        else {
+            jl_static_show(JL_STDERR, dep_message);
+        }
+    }
+    else {
+        jl_value_t *v = jl_atomic_load_relaxed(&b->value);
+        dep_message = v; // use as gc-root
+        if (v) {
+            if (jl_is_type(v) || jl_is_module(v)) {
+                jl_printf(JL_STDERR, ", use ");
+                jl_static_show(JL_STDERR, v);
+                jl_printf(JL_STDERR, " instead.");
+            }
+            else {
+                jl_methtable_t *mt = jl_gf_mtable(v);
+                if (mt != NULL) {
+                    jl_printf(JL_STDERR, ", use ");
+                    if (mt->module != jl_core_module) {
+                        jl_static_show(JL_STDERR, (jl_value_t*)mt->module);
+                        jl_printf(JL_STDERR, ".");
+                    }
+                    jl_printf(JL_STDERR, "%s", jl_symbol_name(mt->name));
+                    jl_printf(JL_STDERR, " instead.");
+                }
+            }
+        }
+    }
+    jl_printf(JL_STDERR, "\n");
+    JL_GC_POP();
+}
+
+// NOTE: we use explici since explicit is a C++ keyword
+static void module_import_(jl_module_t *to, jl_module_t *from, jl_binding_t *b, jl_sym_t *asname, jl_sym_t *s, int explici)
+{
     if (b == NULL) {
         jl_printf(JL_STDERR,
                   "WARNING: could not import %s.%s into %s\n",
@@ -489,8 +576,10 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s, jl_s
                   jl_symbol_name(to->name));
     }
     else {
+        assert(jl_atomic_load_relaxed(&b->owner) == b);
         if (b->deprecated) {
             if (jl_atomic_load_relaxed(&b->value) == jl_nothing) {
+                // silently skip importing deprecated values assigned to nothing (to allow later mutation)
                 return;
             }
             else if (to != jl_main_module && to != jl_base_module &&
@@ -499,9 +588,12 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s, jl_s
                    deprecated Base bindings should simply export the new
                    binding */
                 jl_printf(JL_STDERR,
-                          "WARNING: importing deprecated binding %s.%s into %s.\n",
+                          "WARNING: importing deprecated binding %s.%s into %s%s%s.\n",
                           jl_symbol_name(from->name), jl_symbol_name(s),
-                          jl_symbol_name(to->name));
+                          jl_symbol_name(to->name),
+                          asname == s ? "" : " as ",
+                          asname == s ? "" : jl_symbol_name(asname));
+                jl_binding_dep_message(from, s, b);
             }
         }
 
@@ -509,10 +601,17 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s, jl_s
         jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&to->bindings, asname);
         jl_binding_t *bto = *bp;
         if (bto != HT_NOTFOUND) {
+            JL_GC_PROMISE_ROOTED(bto);
+            jl_binding_t *ownerto = jl_atomic_load_relaxed(&bto->owner);
             if (bto == b) {
                 // importing a binding on top of itself. harmless.
             }
-            else if (bto->name != s) {
+            else if (eq_bindings(bto, b)) {
+                // already imported
+                bto->imported = (explici != 0);
+            }
+            else if (ownerto != b && ownerto != NULL) {
+                // already imported from somewhere else
                 JL_UNLOCK(&to->lock);
                 jl_printf(JL_STDERR,
                           "WARNING: ignoring conflicting import of %s.%s into %s\n",
@@ -520,53 +619,26 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s, jl_s
                           jl_symbol_name(to->name));
                 return;
             }
-            else if (bto->owner == b->owner) {
-                // already imported
-                bto->imported = (explici!=0);
-            }
-            else if (bto->owner != to && bto->owner != NULL) {
-                // already imported from somewhere else
-                jl_binding_t *bval = jl_get_binding(to, asname);
-                if (bval->constp && b->constp && jl_atomic_load_relaxed(&bval->value) && jl_atomic_load_relaxed(&b->value) == jl_atomic_load_relaxed(&bval->value)) {
-                    // equivalent binding
-                    bto->imported = (explici!=0);
-                    JL_UNLOCK(&to->lock);
-                }
-                else {
-                    JL_UNLOCK(&to->lock);
-                    jl_printf(JL_STDERR,
-                              "WARNING: ignoring conflicting import of %s.%s into %s\n",
-                              jl_symbol_name(from->name), jl_symbol_name(s),
-                              jl_symbol_name(to->name));
-                }
-                return;
-            }
             else if (bto->constp || jl_atomic_load_relaxed(&bto->value)) {
                 // conflict with name owned by destination module
-                assert(bto->owner == to);
-                if (bto->constp && b->constp && jl_atomic_load_relaxed(&bto->value) && jl_atomic_load_relaxed(&b->value) == jl_atomic_load_relaxed(&bto->value)) {
-                    // equivalent binding
-                    JL_UNLOCK(&to->lock);
-                }
-                else {
-                    JL_UNLOCK(&to->lock);
-                    jl_printf(JL_STDERR,
-                              "WARNING: import of %s.%s into %s conflicts with an existing identifier; ignored.\n",
-                              jl_symbol_name(from->name), jl_symbol_name(s),
-                              jl_symbol_name(to->name));
-                }
+                assert(ownerto == bto);
+                JL_UNLOCK(&to->lock);
+                jl_printf(JL_STDERR,
+                          "WARNING: import of %s.%s into %s conflicts with an existing identifier; ignored.\n",
+                          jl_symbol_name(from->name), jl_symbol_name(s),
+                          jl_symbol_name(to->name));
                 return;
             }
             else {
-                bto->owner = b->owner;
-                bto->imported = (explici!=0);
+                jl_atomic_store_release(&bto->owner, b);
+                bto->imported = (explici != 0);
             }
         }
         else {
-            jl_binding_t *nb = new_binding(b->name);
-            nb->owner = b->owner;
-            nb->imported = (explici!=0);
-            nb->deprecated = b->deprecated;
+            jl_binding_t *nb = new_binding(to, asname);
+            jl_atomic_store_relaxed(&nb->owner, b);
+            nb->imported = (explici != 0);
+            nb->deprecated = b->deprecated; // we already warned about this above, but we might want to warn at the use sites too
             *bp = nb;
             jl_gc_wb(to, nb);
         }
@@ -576,22 +648,26 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s, jl_s
 
 JL_DLLEXPORT void jl_module_import(jl_module_t *to, jl_module_t *from, jl_sym_t *s)
 {
-    module_import_(to, from, s, s, 1);
+    jl_binding_t *b = jl_get_binding(from, s);
+    module_import_(to, from, b, s, s, 1);
 }
 
 JL_DLLEXPORT void jl_module_import_as(jl_module_t *to, jl_module_t *from, jl_sym_t *s, jl_sym_t *asname)
 {
-    module_import_(to, from, s, asname, 1);
+    jl_binding_t *b = jl_get_binding(from, s);
+    module_import_(to, from, b, asname, s, 1);
 }
 
 JL_DLLEXPORT void jl_module_use(jl_module_t *to, jl_module_t *from, jl_sym_t *s)
 {
-    module_import_(to, from, s, s, 0);
+    jl_binding_t *b = jl_get_binding(from, s);
+    module_import_(to, from, b, s, s, 0);
 }
 
 JL_DLLEXPORT void jl_module_use_as(jl_module_t *to, jl_module_t *from, jl_sym_t *s, jl_sym_t *asname)
 {
-    module_import_(to, from, s, asname, 0);
+    jl_binding_t *b = jl_get_binding(from, s);
+    module_import_(to, from, b, asname, s, 0);
 }
 
 JL_DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from)
@@ -599,7 +675,7 @@ JL_DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from)
     if (to == from)
         return;
     JL_LOCK(&to->lock);
-    for(size_t i=0; i < to->usings.len; i++) {
+    for (size_t i = 0; i < to->usings.len; i++) {
         if (from == to->usings.items[i]) {
             JL_UNLOCK(&to->lock);
             return;
@@ -611,17 +687,17 @@ JL_DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from)
     // an existing identifier. note that an identifier added later may still
     // silently override a "using" name. see issue #2054.
     void **table = from->bindings.table;
-    for(size_t i=1; i < from->bindings.size; i+=2) {
-        if (table[i] != HT_NOTFOUND) {
-            jl_binding_t *b = (jl_binding_t*)table[i];
-            if (b->exportp && (b->owner==from || b->imported)) {
+    for (size_t i = 1; i < from->bindings.size; i += 2) {
+        jl_binding_t *b = (jl_binding_t*)table[i];
+        if (b != HT_NOTFOUND) {
+            if (b->exportp && (jl_atomic_load_relaxed(&b->owner) == b || b->imported)) {
                 jl_sym_t *var = (jl_sym_t*)table[i-1];
                 jl_binding_t **tobp = (jl_binding_t**)ptrhash_bp(&to->bindings, var);
-                if (*tobp != HT_NOTFOUND && (*tobp)->owner != NULL &&
+                if (*tobp != HT_NOTFOUND && jl_atomic_load_relaxed(&(*tobp)->owner) != NULL &&
                     // don't warn for conflicts with the module name itself.
                     // see issue #4715
                     var != to->name &&
-                    !eq_bindings(jl_get_binding(to,var), b)) {
+                    !eq_bindings(jl_get_binding(to, var), b)) {
                     // TODO: not ideal to print this while holding module locks
                     jl_printf(JL_STDERR,
                               "WARNING: using %s.%s in module %s conflicts with an existing identifier.\n",
@@ -643,9 +719,8 @@ JL_DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s)
     JL_LOCK(&from->lock);
     jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&from->bindings, s);
     if (*bp == HT_NOTFOUND) {
-        jl_binding_t *b = new_binding(s);
-        // don't yet know who the owner is
-        b->owner = NULL;
+        jl_binding_t *b = new_binding(from, s);
+        // don't yet know who the owner will be
         *bp = b;
         jl_gc_wb(from, b);
     }
@@ -665,23 +740,19 @@ JL_DLLEXPORT int jl_defines_or_exports_p(jl_module_t *m, jl_sym_t *var)
     JL_LOCK(&m->lock);
     jl_binding_t *b = (jl_binding_t*)ptrhash_get(&m->bindings, var);
     JL_UNLOCK(&m->lock);
-    return b != HT_NOTFOUND && (b->exportp || b->owner == m);
+    return b != HT_NOTFOUND && (b->exportp || jl_atomic_load_relaxed(&b->owner) == b);
 }
 
 JL_DLLEXPORT int jl_module_exports_p(jl_module_t *m, jl_sym_t *var)
 {
-    JL_LOCK(&m->lock);
-    jl_binding_t *b = _jl_get_module_binding(m, var);
-    JL_UNLOCK(&m->lock);
-    return b != HT_NOTFOUND && b->exportp;
+    jl_binding_t *b = jl_get_module_binding(m, var);
+    return b && b->exportp;
 }
 
 JL_DLLEXPORT int jl_binding_resolved_p(jl_module_t *m, jl_sym_t *var)
 {
-    JL_LOCK(&m->lock);
-    jl_binding_t *b = _jl_get_module_binding(m, var);
-    JL_UNLOCK(&m->lock);
-    return b != HT_NOTFOUND && b->owner != NULL;
+    jl_binding_t *b = jl_get_module_binding(m, var);
+    return b && jl_atomic_load_relaxed(&b->owner) != NULL;
 }
 
 JL_DLLEXPORT jl_binding_t *jl_get_module_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var)
@@ -693,23 +764,29 @@ JL_DLLEXPORT jl_binding_t *jl_get_module_binding(jl_module_t *m JL_PROPAGATES_RO
 }
 
 
-JL_DLLEXPORT jl_value_t *jl_binding_value(jl_binding_t *b JL_PROPAGATES_ROOT)
+JL_DLLEXPORT jl_value_t *jl_get_globalref_value(jl_globalref_t *gr)
 {
-    return jl_atomic_load_relaxed(&b->value);
+    jl_binding_t *b = gr->binding;
+    b = jl_resolve_owner(b, gr->mod, gr->name, NULL);
+    // ignores b->deprecated
+    return b == NULL ? NULL : jl_atomic_load_relaxed(&b->value);
 }
 
 JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t *b = jl_get_binding(m, var);
-    if (b == NULL) return NULL;
-    if (b->deprecated) jl_binding_deprecation_warning(m, b);
-    return jl_binding_value(b);
+    if (b == NULL)
+        return NULL;
+    // XXX: this only considers if the original is deprecated, not the binding in m
+    if (b->deprecated)
+        jl_binding_deprecation_warning(m, var, b);
+    return jl_atomic_load_relaxed(&b->value);
 }
 
 JL_DLLEXPORT void jl_set_global(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT)
 {
     jl_binding_t *bp = jl_get_binding_wr(m, var, 1);
-    jl_checked_assignment(bp, val);
+    jl_checked_assignment(bp, m, var, val);
 }
 
 JL_DLLEXPORT void jl_set_const(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT)
@@ -729,32 +806,34 @@ JL_DLLEXPORT void jl_set_const(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var
             }
         }
     }
-    jl_errorf("invalid redefinition of constant %s",
-              jl_symbol_name(bp->name));
+    jl_errorf("invalid redefinition of constant %s", jl_symbol_name(var));
 }
 
-JL_DLLEXPORT int jl_binding_is_const(jl_binding_t *b)
+JL_DLLEXPORT int jl_globalref_is_const(jl_globalref_t *gr)
 {
-    assert(b);
-    return b->constp;
+    jl_binding_t *b = gr->binding;
+    b = jl_resolve_owner(b, gr->mod, gr->name, NULL);
+    return b && b->constp;
 }
 
-JL_DLLEXPORT int jl_binding_boundp(jl_binding_t *b)
+JL_DLLEXPORT int jl_globalref_boundp(jl_globalref_t *gr)
 {
-    assert(b);
-    return jl_atomic_load_relaxed(&b->value) != NULL;
+    jl_binding_t *b = gr->binding;
+    b = jl_resolve_owner(b, gr->mod, gr->name, NULL);
+    return b && (jl_atomic_load_relaxed(&b->value) != NULL);
 }
 
 JL_DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var)
 {
     jl_binding_t *b = jl_get_binding(m, var);
-    return b && jl_binding_is_const(b);
+    return b && b->constp;
 }
 
 // set the deprecated flag for a binding:
 //   0=not deprecated, 1=renamed, 2=moved to another package
 JL_DLLEXPORT void jl_deprecate_binding(jl_module_t *m, jl_sym_t *var, int flag)
 {
+    // XXX: this deprecates the original value, which might be imported from elsewhere
     jl_binding_t *b = jl_get_binding(m, var);
     if (b) b->deprecated = flag;
 }
@@ -762,29 +841,14 @@ JL_DLLEXPORT void jl_deprecate_binding(jl_module_t *m, jl_sym_t *var, int flag)
 JL_DLLEXPORT int jl_is_binding_deprecated(jl_module_t *m, jl_sym_t *var)
 {
     if (jl_binding_resolved_p(m, var)) {
+        // XXX: this only considers if the original is deprecated, not this precise binding
         jl_binding_t *b = jl_get_binding(m, var);
         return b && b->deprecated;
     }
     return 0;
 }
 
-extern const char *jl_filename;
-extern int jl_lineno;
-
-static char const dep_message_prefix[] = "_dep_message_";
-
-static jl_binding_t *jl_get_dep_message_binding(jl_module_t *m, jl_binding_t *deprecated_binding)
-{
-    size_t prefix_len = strlen(dep_message_prefix);
-    size_t name_len = strlen(jl_symbol_name(deprecated_binding->name));
-    char *dep_binding_name = (char*)alloca(prefix_len+name_len+1);
-    memcpy(dep_binding_name, dep_message_prefix, prefix_len);
-    memcpy(dep_binding_name + prefix_len, jl_symbol_name(deprecated_binding->name), name_len);
-    dep_binding_name[prefix_len+name_len] = '\0';
-    return jl_get_binding(m, jl_symbol(dep_binding_name));
-}
-
-void jl_binding_deprecation_warning(jl_module_t *m, jl_binding_t *b)
+void jl_binding_deprecation_warning(jl_module_t *m, jl_sym_t *s, jl_binding_t *b)
 {
     // Only print a warning for deprecated == 1 (renamed).
     // For deprecated == 2 (moved to a package) the binding is to a function
@@ -792,82 +856,34 @@ void jl_binding_deprecation_warning(jl_module_t *m, jl_binding_t *b)
     if (b->deprecated == 1 && jl_options.depwarn) {
         if (jl_options.depwarn != JL_OPTIONS_DEPWARN_ERROR)
             jl_printf(JL_STDERR, "WARNING: ");
-        jl_value_t *dep_message = NULL;
-        if (b->owner) {
-            jl_printf(JL_STDERR, "%s.%s is deprecated",
-                      jl_symbol_name(b->owner->name), jl_symbol_name(b->name));
-            jl_binding_t *dep_message_binding = jl_get_dep_message_binding(b->owner, b);
-            if (dep_message_binding != NULL)
-                dep_message = jl_atomic_load_relaxed(&dep_message_binding->value);
-        }
-        else {
-            jl_printf(JL_STDERR, "%s is deprecated", jl_symbol_name(b->name));
-        }
-
-        JL_GC_PUSH1(&dep_message);
-        if (dep_message != NULL) {
-            if (jl_is_string(dep_message)) {
-                jl_uv_puts(JL_STDERR, jl_string_data(dep_message), jl_string_len(dep_message));
-            }
-            else {
-                jl_static_show(JL_STDERR, dep_message);
-            }
-        }
-        else {
-            jl_value_t *v = jl_atomic_load_relaxed(&b->value);
-            dep_message = v;
-            if (v) {
-                if (jl_is_type(v) || jl_is_module(v)) {
-                    jl_printf(JL_STDERR, ", use ");
-                    jl_static_show(JL_STDERR, v);
-                    jl_printf(JL_STDERR, " instead.");
-                }
-                else {
-                    jl_methtable_t *mt = jl_gf_mtable(v);
-                    if (mt != NULL) {
-                        jl_printf(JL_STDERR, ", use ");
-                        if (mt->module != jl_core_module) {
-                            jl_static_show(JL_STDERR, (jl_value_t*)mt->module);
-                            jl_printf(JL_STDERR, ".");
-                        }
-                        jl_printf(JL_STDERR, "%s", jl_symbol_name(mt->name));
-                        jl_printf(JL_STDERR, " instead.");
-                    }
-                }
-            }
-        }
-        jl_printf(JL_STDERR, "\n");
-        JL_GC_POP();
+        assert(jl_atomic_load_relaxed(&b->owner) == b);
+        jl_printf(JL_STDERR, "%s.%s is deprecated",
+                  jl_symbol_name(m->name), jl_symbol_name(s));
+        jl_binding_dep_message(m, s, b);
 
         if (jl_options.depwarn != JL_OPTIONS_DEPWARN_ERROR) {
-            if (jl_lineno == 0) {
-                jl_printf(JL_STDERR, " in module %s\n", jl_symbol_name(m->name));
-            }
-            else {
+            if (jl_lineno != 0) {
                 jl_printf(JL_STDERR, "  likely near %s:%d\n", jl_filename, jl_lineno);
             }
         }
 
         if (jl_options.depwarn == JL_OPTIONS_DEPWARN_ERROR) {
-            if (b->owner)
-                jl_errorf("deprecated binding: %s.%s",
-                          jl_symbol_name(b->owner->name),
-                          jl_symbol_name(b->name));
-            else
-                jl_errorf("deprecated binding: %s", jl_symbol_name(b->name));
+            jl_errorf("use of deprecated variable: %s.%s",
+                      jl_symbol_name(m->name),
+                      jl_symbol_name(s));
         }
     }
 }
 
-JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs)
+JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_module_t *mod, jl_sym_t *var, jl_value_t *rhs)
 {
     jl_value_t *old_ty = NULL;
     if (!jl_atomic_cmpswap_relaxed(&b->ty, &old_ty, (jl_value_t*)jl_any_type)) {
         if (old_ty != (jl_value_t*)jl_any_type && jl_typeof(rhs) != old_ty) {
-            JL_GC_PUSH1(&rhs);
+            JL_GC_PUSH1(&rhs); // callee-rooted
             if (!jl_isa(rhs, old_ty))
-                jl_errorf("cannot assign an incompatible value to the global %s.",
-                          jl_symbol_name(b->name));
+                jl_errorf("cannot assign an incompatible value to the global %s.%s.",
+                          jl_symbol_name(mod->name), jl_symbol_name(var));
             JL_GC_POP();
         }
     }
@@ -880,36 +896,39 @@ JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs)
         if (jl_egal(rhs, old))
             return;
         if (jl_typeof(rhs) != jl_typeof(old) || jl_is_type(rhs) || jl_is_module(rhs)) {
-            jl_errorf("invalid redefinition of constant %s",
-                      jl_symbol_name(b->name));
+            jl_errorf("invalid redefinition of constant %s.%s",
+                      jl_symbol_name(mod->name), jl_symbol_name(var));
+
         }
-        jl_safe_printf("WARNING: redefinition of constant %s. This may fail, cause incorrect answers, or produce other errors.\n",
-                       jl_symbol_name(b->name));
+        jl_safe_printf("WARNING: redefinition of constant %s.%s. This may fail, cause incorrect answers, or produce other errors.\n",
+                       jl_symbol_name(mod->name), jl_symbol_name(var));
     }
     jl_atomic_store_release(&b->value, rhs);
     jl_gc_wb_binding(b, rhs);
 }
 
-JL_DLLEXPORT void jl_declare_constant(jl_binding_t *b)
+JL_DLLEXPORT void jl_declare_constant(jl_binding_t *b, jl_module_t *mod, jl_sym_t *var)
 {
-    if (jl_atomic_load_relaxed(&b->value) != NULL && !b->constp) {
-        jl_errorf("cannot declare %s constant; it already has a value",
-                  jl_symbol_name(b->name));
+    // n.b. jl_get_binding_wr should have ensured b->owner == b as mod.var
+    if (jl_atomic_load_relaxed(&b->owner) != b || (jl_atomic_load_relaxed(&b->value) != NULL && !b->constp)) {
+        jl_errorf("cannot declare %s.%s constant; it already has a value",
+                  jl_symbol_name(mod->name), jl_symbol_name(var));
     }
     b->constp = 1;
 }
 
 JL_DLLEXPORT jl_value_t *jl_module_usings(jl_module_t *m)
 {
-    jl_array_t *a = jl_alloc_array_1d(jl_array_any_type, 0);
-    JL_GC_PUSH1(&a);
     JL_LOCK(&m->lock);
-    for(int i=(int)m->usings.len-1; i >= 0; --i) {
-        jl_array_grow_end(a, 1);
+    int j = m->usings.len;
+    jl_array_t *a = jl_alloc_array_1d(jl_array_any_type, j);
+    JL_GC_PUSH1(&a);
+    for (int i = 0; j > 0; i++) {
+        j--;
         jl_module_t *imp = (jl_module_t*)m->usings.items[i];
-        jl_array_ptr_set(a,jl_array_dim0(a)-1, (jl_value_t*)imp);
+        jl_array_ptr_set(a, j, (jl_value_t*)imp);
     }
-    JL_UNLOCK(&m->lock);
+    JL_UNLOCK(&m->lock); // may gc
     JL_GC_POP();
     return (jl_value_t*)a;
 }
@@ -921,18 +940,18 @@ JL_DLLEXPORT jl_value_t *jl_module_names(jl_module_t *m, int all, int imported)
     size_t i;
     JL_LOCK(&m->lock);
     void **table = m->bindings.table;
-    for (i = 1; i < m->bindings.size; i+=2) {
-        if (table[i] != HT_NOTFOUND) {
-            jl_binding_t *b = (jl_binding_t*)table[i];
-            int hidden = jl_symbol_name(b->name)[0]=='#';
+    for (i = 0; i < m->bindings.size; i+=2) {
+        jl_binding_t *b = (jl_binding_t*)table[i+1];
+        if (b != HT_NOTFOUND) {
+            jl_sym_t *asname = (jl_sym_t*)table[i];
+            int hidden = jl_symbol_name(asname)[0]=='#';
             if ((b->exportp ||
                  (imported && b->imported) ||
-                 (b->owner == m && !b->imported && (all || m == jl_main_module))) &&
+                 (jl_atomic_load_relaxed(&b->owner) == b && !b->imported && (all || m == jl_main_module))) &&
                 (all || (!b->deprecated && !hidden))) {
-                jl_sym_t *in_module_name = (jl_sym_t*)table[i-1]; // the name in the module may not be b->name, use the httable key instead
                 jl_array_grow_end(a, 1);
-                //XXX: change to jl_arrayset if array storage allocation for Array{Symbols,1} changes:
-                jl_array_ptr_set(a, jl_array_dim0(a)-1, (jl_value_t*)in_module_name);
+                // n.b. change to jl_arrayset if array storage allocation for Array{Symbols,1} changes:
+                jl_array_ptr_set(a, jl_array_dim0(a)-1, (jl_value_t*)asname);
             }
         }
     }
@@ -969,11 +988,11 @@ JL_DLLEXPORT void jl_clear_implicit_imports(jl_module_t *m)
     size_t i;
     JL_LOCK(&m->lock);
     void **table = m->bindings.table;
-    for (i = 1; i < m->bindings.size; i+=2) {
+    for (i = 1; i < m->bindings.size; i += 2) {
         if (table[i] != HT_NOTFOUND) {
             jl_binding_t *b = (jl_binding_t*)table[i];
-            if (b->owner != m && !b->imported)
-                table[i] = HT_NOTFOUND;
+            if (jl_atomic_load_relaxed(&b->owner) && jl_atomic_load_relaxed(&b->owner) != b && !b->imported)
+                jl_atomic_store_relaxed(&b->owner, NULL);
         }
     }
     JL_UNLOCK(&m->lock);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -295,7 +295,6 @@ static htable_t external_objects;
 static htable_t serialization_order; // to break cycles, mark all objects that are serialized
 static htable_t unique_ready; // as we serialize types, we need to know if all reachable objects are also already serialized. This tracks whether `immediate` has been set for all of them.
 static htable_t nullptrs;
-static htable_t bindings; // because they are not first-class objects
 // FIFO queue for objects to be serialized. Anything requiring fixup upon deserialization
 // must be "toplevel" in this queue. For types, parameters and field types must appear
 // before the "wrapper" type so they can be properly recached against the running system.
@@ -606,19 +605,12 @@ static void jl_queue_module_for_serialization(jl_serializer_state *s, jl_module_
     void **table = m->bindings.table;
     for (i = 0; i < m->bindings.size; i += 2) {
         if (table[i+1] != HT_NOTFOUND) {
-            jl_queue_for_serialization(s, (jl_value_t*)table[i]);
+            jl_sym_t *name = (jl_sym_t*)table[i];
+            jl_queue_for_serialization(s, (jl_value_t*)name);
             jl_binding_t *b = (jl_binding_t*)table[i+1];
-            ptrhash_put(&bindings, b, (void*)(uintptr_t)-1);
-            jl_queue_for_serialization(s, b->name);
-            jl_value_t *value;
-            if (jl_docmeta_sym && b->name == jl_docmeta_sym && jl_options.strip_metadata)
-                value = jl_nothing;
-            else
-                value = get_replaceable_field((jl_value_t**)&b->value, !b->constp);
-            jl_queue_for_serialization(s, value);
-            jl_queue_for_serialization(s, jl_atomic_load_relaxed(&b->globalref));
-            jl_queue_for_serialization(s, b->owner);
-            jl_queue_for_serialization(s, jl_atomic_load_relaxed(&b->ty));
+            if (name == jl_docmeta_sym && jl_atomic_load_relaxed(&b->value) && jl_options.strip_metadata)
+                record_field_change((jl_value_t**)&b->value, jl_nothing);
+            jl_queue_for_serialization(s, jl_module_globalref(m, name));
         }
     }
 
@@ -659,9 +651,9 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
         immediate = 0; // do not handle remaining fields immediately (just field types remains)
     }
     if (s->incremental && jl_is_method_instance(v)) {
+        jl_method_instance_t *mi = (jl_method_instance_t*)v;
         if (needs_uniquing(v)) {
             // we only need 3 specific fields of this (the rest are not used)
-            jl_method_instance_t *mi = (jl_method_instance_t*)v;
             jl_queue_for_serialization(s, mi->def.value);
             jl_queue_for_serialization(s, mi->specTypes);
             jl_queue_for_serialization(s, (jl_value_t*)mi->sparam_vals);
@@ -670,11 +662,16 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
         }
         else if (needs_recaching(v)) {
             // we only need 3 specific fields of this (the rest are restored afterward, if valid)
-            jl_method_instance_t *mi = (jl_method_instance_t*)v;
             record_field_change((jl_value_t**)&mi->uninferred, NULL);
             record_field_change((jl_value_t**)&mi->backedges, NULL);
             record_field_change((jl_value_t**)&mi->callbacks, NULL);
             record_field_change((jl_value_t**)&mi->cache, NULL);
+        }
+    }
+    if (s->incremental && jl_is_globalref(v)) {
+        jl_globalref_t *gr = (jl_globalref_t*)v;
+        if (jl_object_in_image((jl_value_t*)gr->mod)) {
+            record_field_change((jl_value_t**)&gr->binding, NULL);
         }
     }
     if (jl_is_typename(v)) {
@@ -735,7 +732,10 @@ static void jl_insert_into_serialization_queue(jl_serializer_state *s, jl_value_
         size_t i, np = layout->npointers;
         for (i = 0; i < np; i++) {
             uint32_t ptr = jl_ptr_offset(t, i);
-            jl_value_t *fld = get_replaceable_field(&((jl_value_t**)data)[ptr], t->name->mutabl);
+            int mutabl = t->name->mutabl;
+            if (jl_is_binding(v) && ((jl_binding_t*)v)->constp && i == 0) // value field depends on constp field
+                mutabl = 0;
+            jl_value_t *fld = get_replaceable_field(&((jl_value_t**)data)[ptr], mutabl);
             jl_queue_for_serialization_(s, fld, 1, immediate);
         }
     }
@@ -1001,26 +1001,10 @@ static void jl_write_module(jl_serializer_state *s, uintptr_t item, jl_module_t 
     void **table = m->bindings.table;
     for (i = 0; i < m->bindings.size; i += 2) {
         if (table[i+1] != HT_NOTFOUND) {
-            jl_binding_t *b = (jl_binding_t*)table[i+1];
-            write_pointerfield(s, (jl_value_t*)table[i]);
+            jl_globalref_t *gr = ((jl_binding_t*)table[i+1])->globalref;
+            assert(gr && gr->mod == m && gr->name == (jl_sym_t*)table[i]);
+            write_pointerfield(s, (jl_value_t*)gr);
             tot += sizeof(void*);
-            write_gctaggedfield(s, jl_binding_type);
-            tot += sizeof(void*);
-            size_t binding_reloc_offset = ios_pos(s->s);
-            ptrhash_put(&bindings, b, (void*)(((uintptr_t)DataRef << RELOC_TAG_OFFSET) + binding_reloc_offset));
-            write_pointerfield(s, (jl_value_t*)b->name);
-            jl_value_t *value;
-            if (jl_docmeta_sym && b->name == jl_docmeta_sym && jl_options.strip_metadata)
-                value = jl_nothing;
-            else
-                value = get_replaceable_field((jl_value_t**)&b->value, !b->constp);
-            write_pointerfield(s, value);
-            write_pointerfield(s, jl_atomic_load_relaxed(&b->globalref));
-            write_pointerfield(s, (jl_value_t*)b->owner);
-            write_pointerfield(s, jl_atomic_load_relaxed(&b->ty));
-            size_t flag_offset = offsetof(jl_binding_t, ty) + sizeof(b->ty);
-            ios_write(s->s, (char*)b + flag_offset, sizeof(*b) - flag_offset);
-            tot += sizeof(jl_binding_t);
             count += 1;
         }
     }
@@ -1060,21 +1044,8 @@ static void jl_write_module(jl_serializer_state *s, uintptr_t item, jl_module_t 
 
 static void record_gvars(jl_serializer_state *s, arraylist_t *globals) JL_NOTSAFEPOINT
 {
-    for (size_t i = 0; i < globals->len; i++) {
-        void *g = globals->items[i];
-        if (jl_is_binding((uintptr_t)g)) {
-            if (!ptrhash_has(&bindings, g)) {
-                // need to deal with foreign bindings here too
-                assert(s->incremental);
-                jl_binding_t *b = (jl_binding_t*)g;
-                jl_value_t *gr = jl_module_globalref(b->owner, b->name);
-                jl_queue_for_serialization(s, gr);
-            }
-            continue;
-        }
-        assert(!ptrhash_has(&bindings, g));
-        jl_queue_for_serialization(s, g);
-    }
+    for (size_t i = 0; i < globals->len; i++)
+        jl_queue_for_serialization(s, globals->items[i]);
 }
 
 static void record_external_fns(jl_serializer_state *s, arraylist_t *external_fns) JL_NOTSAFEPOINT
@@ -1140,6 +1111,11 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
         }
         else if (s->incremental && needs_recaching(v)) {
             arraylist_push(jl_is_datatype(v) ? &s->fixup_types : &s->fixup_objs, (void*)reloc_offset);
+        }
+        else if (s->incremental && jl_typeis(v, jl_binding_type)) {
+            jl_binding_t *b = (jl_binding_t*)v;
+            if (b->globalref == NULL || jl_object_in_image((jl_value_t*)b->globalref->mod))
+                jl_error("Binding cannot be serialized"); // no way (currently) to recover its identity
         }
 
         // write data
@@ -1251,9 +1227,6 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
         else if (jl_typeis(v, jl_task_type)) {
             jl_error("Task cannot be serialized");
         }
-        else if (jl_typeis(v, jl_binding_type)) {
-            jl_error("Binding cannot be serialized"); // no way (currently) to recover its identity
-        }
         else if (jl_is_svec(v)) {
             ios_write(s->s, (char*)v, sizeof(void*));
             size_t ii, l = jl_svec_len(v);
@@ -1318,7 +1291,10 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
             size_t np = t->layout->npointers;
             for (i = 0; i < np; i++) {
                 size_t offset = jl_ptr_offset(t, i) * sizeof(jl_value_t*);
-                jl_value_t *fld = get_replaceable_field((jl_value_t**)&data[offset], t->name->mutabl);
+                int mutabl = t->name->mutabl;
+                if (jl_is_binding(v) && ((jl_binding_t*)v)->constp && i == 0) // value field depends on constp field
+                    mutabl = 0;
+                jl_value_t *fld = get_replaceable_field((jl_value_t**)&data[offset], mutabl);
                 size_t fld_pos = offset + reloc_offset;
                 if (fld != NULL) {
                     arraylist_push(&s->relocs_list, (void*)(uintptr_t)(fld_pos)); // relocation location
@@ -1443,15 +1419,6 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
                     arraylist_push(&s->relocs_list, (void*)(((uintptr_t)BuiltinFunctionRef << RELOC_TAG_OFFSET) + builtin_id - 2)); // relocation target
                 }
             }
-            else if (jl_is_globalref(v)) {
-                jl_globalref_t *newg = (jl_globalref_t*)&s->s->buf[reloc_offset];
-                // Don't save the cached binding reference in staticdata
-                // (it does not happen automatically since we declare the struct immutable)
-                // TODO: this should be a relocation pointing to the binding in the new image
-                newg->bnd_cache = NULL;
-                if (s->incremental)
-                    arraylist_push(&s->fixup_objs, (void*)reloc_offset);
-            }
             else if (jl_is_datatype(v)) {
                 jl_datatype_t *dt = (jl_datatype_t*)v;
                 jl_datatype_t *newdt = (jl_datatype_t*)&s->s->buf[reloc_offset];
@@ -1508,6 +1475,13 @@ static void jl_write_values(jl_serializer_state *s) JL_GC_DISABLED
                     ios_write(s->const_data, (char*)tn->constfields, nb);
                 }
             }
+            else if (jl_is_globalref(v)) {
+                jl_globalref_t *gr = (jl_globalref_t*)v;
+                if (s->incremental && jl_object_in_image((jl_value_t*)gr->mod)) {
+                    // will need to populate the binding field later
+                    arraylist_push(&s->fixup_objs, (void*)reloc_offset);
+                }
+            }
             else if (((jl_datatype_t*)(jl_typeof(v)))->name == jl_idtable_typename) {
                 // will need to rehash this, later (after types are fully constructed)
                 arraylist_push(&s->fixup_objs, (void*)reloc_offset);
@@ -1550,7 +1524,7 @@ static uintptr_t get_reloc_for_item(uintptr_t reloc_item, size_t reloc_offset)
         uintptr_t reloc_base = (uintptr_t)layout_table.items[reloc_item];
         assert(reloc_base != 0 && "layout offset missing for relocation item");
         // write reloc_offset into s->s at pos
-        return reloc_base + reloc_offset;
+        return ((uintptr_t)tag << RELOC_TAG_OFFSET) + reloc_base + reloc_offset;
     }
     else {
         // just write the item reloc_id directly
@@ -1574,7 +1548,6 @@ static uintptr_t get_reloc_for_item(uintptr_t reloc_item, size_t reloc_offset)
             break;
         case ExternalLinkage:
             break;
-        case DataRef:
         default:
             assert(0 && "corrupt relocation item id");
             abort();
@@ -1904,19 +1877,6 @@ static uint32_t write_gvars(jl_serializer_state *s, arraylist_t *globals, arrayl
     ios_ensureroom(s->gvar_record, len * sizeof(reloc_t));
     for (size_t i = 0; i < globals->len; i++) {
         void *g = globals->items[i];
-        if (jl_is_binding((uintptr_t)g)) {
-            jl_binding_t *b = (jl_binding_t*)g;
-            void *reloc = ptrhash_get(&bindings, g);
-            if (reloc != HT_NOTFOUND) {
-                assert(reloc != (void*)(uintptr_t)-1);
-                write_reloc_t(s->gvar_record, (uintptr_t)reloc);
-                continue;
-            }
-            // need to deal with foreign bindings here too
-            assert(s->incremental);
-            arraylist_push(&s->uniquing_objs, (void*)((i << 2) | 2)); // mark as gvar && !tag
-            g = (void*)jl_module_globalref(b->owner, b->name);
-        }
         uintptr_t item = backref_id(s, g, s->link_ids_gvars);
         uintptr_t reloc = get_reloc_for_item(item, 0);
         write_reloc_t(s->gvar_record, reloc);
@@ -2297,7 +2257,6 @@ static void jl_save_system_image_to_stream(ios_t *f,
     htable_new(&serialization_order, 25000);
     htable_new(&unique_ready, 0);
     htable_new(&nullptrs, 0);
-    htable_new(&bindings, 0);
     arraylist_new(&object_worklist, 0);
     arraylist_new(&serialization_queue, 0);
     ios_t sysimg, const_data, symbols, relocs, gvar_record, fptr_record;
@@ -2401,7 +2360,7 @@ static void jl_save_system_image_to_stream(ios_t *f,
             jl_queue_for_serialization(&s, edges);
         }
         jl_serialize_reachable(&s);
-        // step 1.2: now that we have marked all bindings (badly), ensure all gvars are part of the sysimage
+        // step 1.2: ensure all gvars are part of the sysimage too
         record_gvars(&s, &gvars);
         record_external_fns(&s, &external_fns);
         jl_serialize_reachable(&s);
@@ -2548,7 +2507,6 @@ static void jl_save_system_image_to_stream(ios_t *f,
     htable_free(&serialization_order);
     htable_free(&unique_ready);
     htable_free(&nullptrs);
-    htable_free(&bindings);
     htable_free(&symbol_table);
     htable_free(&fptr_to_id);
     nsym_tag = 0;
@@ -3065,13 +3023,6 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image, jl
                 obj[0] = newobj;
             }
         }
-        else if (otyp == (jl_value_t*)jl_globalref_type) {
-            // this actually needs a binding_t object at that gvar slot if we encountered it in the uniquing_objs
-            jl_globalref_t *g = (jl_globalref_t*)obj;
-            jl_binding_t *b = jl_get_binding_if_bound(g->mod, g->name);
-            assert(b); // XXX: actually this is probably quite buggy, since julia's handling of global resolution is rather bad
-            newobj = (jl_value_t*)b;
-        }
         else {
             abort(); // should be unreachable
         }
@@ -3128,24 +3079,22 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image, jl
         }
         else if (jl_is_module(obj)) {
             // rebuild the binding table for module v
-            // TODO: maybe want to delay this more, but that only strongly matters for async / thread safety
+            // TODO: maybe want to hold the lock on `v`, but that only strongly matters for async / thread safety
             // and we are already bad at that
             jl_module_t *mod = (jl_module_t*)obj;
             mod->build_id.hi = checksum;
             size_t nbindings = mod->bindings.size;
             htable_new(&mod->bindings, nbindings);
-            struct binding {
-                jl_sym_t *asname;
-                uintptr_t tag;
-                jl_binding_t b;
-            } *b;
-            b = (struct binding*)&mod[1];
-            while (nbindings > 0) {
-                ptrhash_put(&mod->bindings, b->asname, &b->b);
-                b += 1;
-                nbindings -= 1;
+            jl_globalref_t **pgr = (jl_globalref_t**)&mod[1];
+            for (size_t i = 0; i < nbindings; i++) {
+                jl_globalref_t *gr = pgr[i];
+                jl_binding_t *b = gr->binding;
+                assert(gr->mod == mod);
+                assert(b && (!b->globalref || b->globalref->mod == mod));
+                ptrhash_put(&mod->bindings, gr->name, b);
             }
             if (mod->usings.items != &mod->usings._space[0]) {
+                // arraylist_t assumes we called malloc to get this memory, so make that true now
                 void **newitems = (void**)malloc_s(mod->usings.max * sizeof(void*));
                 memcpy(newitems, mod->usings.items, mod->usings.len * sizeof(void*));
                 mod->usings.items = newitems;
@@ -3160,14 +3109,17 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image, jl
             jl_gc_wb(obj, *a);
         }
     }
-    // Now pick up the globalref binding pointer field, when we can
+    // Now pick up the globalref binding pointer field
     for (size_t i = 0; i < s.fixup_objs.len; i++) {
         uintptr_t item = (uintptr_t)s.fixup_objs.items[i];
         jl_value_t *obj = (jl_value_t*)(image_base + item);
         if (jl_is_globalref(obj)) {
             jl_globalref_t *r = (jl_globalref_t*)obj;
-            jl_binding_t *b = jl_get_binding_if_bound(r->mod, r->name);
-            r->bnd_cache = b && b->value ? b : NULL;
+            if (r->binding == NULL) {
+                jl_globalref_t *gr = (jl_globalref_t*)jl_module_globalref(r->mod, r->name);
+                r->binding = gr->binding;
+                jl_gc_wb(r, gr->binding);
+            }
         }
     }
     arraylist_free(&s.fixup_types);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -154,7 +154,7 @@ static jl_value_t *jl_eval_module_expr(jl_module_t *parent_module, jl_expr_t *ex
         }
     }
     else {
-        jl_binding_t *b = jl_get_binding_wr(parent_module, name, 1);
+        jl_binding_t *b = jl_get_binding_wr(parent_module, name);
         jl_declare_constant(b, parent_module, name);
         jl_value_t *old = NULL;
         if (!jl_atomic_cmpswap(&b->value, &old, (jl_value_t*)newm)) {
@@ -314,7 +314,7 @@ void jl_eval_global_expr(jl_module_t *m, jl_expr_t *ex, int set_type) {
             gs = (jl_sym_t*)arg;
         }
         if (!jl_binding_resolved_p(gm, gs)) {
-            jl_binding_t *b = jl_get_binding_wr(gm, gs, 1);
+            jl_binding_t *b = jl_get_binding_wr(gm, gs);
             if (set_type) {
                 jl_value_t *old_ty = NULL;
                 // maybe set the type too, perhaps
@@ -590,7 +590,7 @@ static void import_module(jl_module_t *JL_NONNULL m, jl_module_t *import, jl_sym
     assert(m);
     jl_sym_t *name = asname ? asname : import->name;
     // TODO: this is a bit race-y with what error message we might print
-    jl_binding_t *b = jl_get_module_binding(m, name);
+    jl_binding_t *b = jl_get_module_binding(m, name, 0);
     jl_binding_t *b2;
     if (b != NULL && (b2 = jl_atomic_load_relaxed(&b->owner)) != NULL) {
         if (b2->constp && jl_atomic_load_relaxed(&b2->value) == (jl_value_t*)import)
@@ -600,7 +600,7 @@ static void import_module(jl_module_t *JL_NONNULL m, jl_module_t *import, jl_sym
                       jl_symbol_name(name), jl_symbol_name(m->name));
     }
     else {
-        b = jl_get_binding_wr(m, name, 1);
+        b = jl_get_binding_wr(m, name);
     }
     jl_declare_constant(b, m, name);
     jl_checked_assignment(b, m, name, (jl_value_t*)import);
@@ -841,7 +841,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_module_t *JL_NONNULL m, jl_value_t *e, int 
             gm = m;
             gs = (jl_sym_t*)arg;
         }
-        jl_binding_t *b = jl_get_binding_wr(gm, gs, 1);
+        jl_binding_t *b = jl_get_binding_wr(gm, gs);
         jl_declare_constant(b, gm, gs);
         JL_GC_POP();
         return jl_nothing;

--- a/test/atomics.jl
+++ b/test/atomics.jl
@@ -22,19 +22,20 @@ mutable struct Refxy{T}
     Refxy{T}() where {T} = new() # unused, but sets ninitialized to 0
 end
 
-@test_throws ErrorException("invalid redefinition of constant ARefxy") @eval mutable struct ARefxy{T}
+modname = String(nameof(@__MODULE__))
+@test_throws ErrorException("invalid redefinition of constant $modname.ARefxy") @eval mutable struct ARefxy{T}
     @atomic x::T
     @atomic y::T
 end
-@test_throws ErrorException("invalid redefinition of constant ARefxy") @eval mutable struct ARefxy{T}
+@test_throws ErrorException("invalid redefinition of constant $modname.ARefxy") @eval mutable struct ARefxy{T}
     x::T
     y::T
 end
-@test_throws ErrorException("invalid redefinition of constant ARefxy") @eval mutable struct ARefxy{T}
+@test_throws ErrorException("invalid redefinition of constant $modname.ARefxy") @eval mutable struct ARefxy{T}
     x::T
     @atomic y::T
 end
-@test_throws ErrorException("invalid redefinition of constant Refxy") @eval mutable struct Refxy{T}
+@test_throws ErrorException("invalid redefinition of constant $modname.Refxy") @eval mutable struct Refxy{T}
     x::T
     @atomic y::T
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -57,14 +57,14 @@ mutable struct ABCDconst
     c
     const d::Union{Int,Nothing}
 end
-@test_throws(ErrorException("invalid redefinition of constant ABCDconst"),
+@test_throws(ErrorException("invalid redefinition of constant $(nameof(curmod)).ABCDconst"),
     mutable struct ABCDconst
         const a
         const b::Int
         c
         d::Union{Int,Nothing}
     end)
-@test_throws(ErrorException("invalid redefinition of constant ABCDconst"),
+@test_throws(ErrorException("invalid redefinition of constant $(nameof(curmod)).ABCDconst"),
     mutable struct ABCDconst
         a
         b::Int
@@ -5963,7 +5963,7 @@ module GlobalDef18933
         global sincos
         nothing
     end
-    @test which(Main, :sincos) === Base.Math
+    @test which(@__MODULE__, :sincos) === Base.Math
     @test @isdefined sincos
     @test sincos === Base.sincos
 end
@@ -7535,7 +7535,7 @@ end
 struct X36104; x::Int; end
 @test fieldtypes(X36104) == (Int,)
 primitive type P36104 8 end
-@test_throws ErrorException("invalid redefinition of constant P36104") @eval(primitive type P36104 16 end)
+@test_throws ErrorException("invalid redefinition of constant $(nameof(curmod)).P36104") @eval(primitive type P36104 16 end)
 
 # Malformed invoke
 f_bad_invoke(x::Int) = invoke(x, (Any,), x)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2537,7 +2537,8 @@ using Test
 
 module Mod
 const x = 1
-global maybe_undef
+global maybe_undef, always_undef
+export always_undef
 def() = (global maybe_undef = 0)
 func(x) = 2x + 1
 
@@ -2575,10 +2576,18 @@ import .Mod.maybe_undef as mu
 Mod.def()
 @test mu === 0
 
-using .Mod: func as f
-@test f(10) == 21
-@test !@isdefined(func)
-@test_throws ErrorException("error in method definition: function Mod.func must be explicitly imported to be extended") eval(:(f(x::Int) = x))
+module Mod3
+using ..Mod: func as f
+using ..Mod
+end
+@test Mod3.f(10) == 21
+@test !isdefined(Mod3, :func)
+@test_throws ErrorException("invalid method definition in Mod3: function Mod3.f must be explicitly imported to be extended") Core.eval(Mod3, :(f(x::Int) = x))
+@test !isdefined(Mod3, :always_undef) # resolve this binding now in Mod3
+@test_throws ErrorException("invalid method definition in Mod3: exported function Mod.always_undef does not exist") Core.eval(Mod3, :(always_undef(x::Int) = x))
+@test_throws ErrorException("cannot assign a value to imported variable Mod.always_undef from module Mod3") Core.eval(Mod3, :(const always_undef = 3))
+@test_throws ErrorException("cannot assign a value to imported variable Mod3.f") Core.eval(Mod3, :(const f = 3))
+@test_throws ErrorException("cannot declare Mod.maybe_undef constant; it already has a value") Core.eval(Mod, :(const maybe_undef = 3))
 
 z = 42
 import .z as also_z


### PR DESCRIPTION
The `owner` field now points directly at the target binding (which may be itself), rather than indirecting through a module+name re-lookup. This makes `module X; import .x as y; end` behavior more precise.

The `globalref` field is currently now mandatory, since otherwise incremental compilation will be impossible right now. Maybe world-age splitting will help improve that later?

Fix up a lot of locations that previously used the `name` field badly. There are some valid uses of this, but mostly it was wrong, since it would may fail to reflect what content actually appeared in the user's code. Directly forwarding the actual lookup result is cleaner and clearer for the user in most cases.

Also remove `resolve` for GlobalRef:
This has been wrong since `import as` was added, and appears unused and untested.

@Keno you probably should review this, since you were the most interested in seeing Binding become more first-class