### PR TITLE
Add option to `jl_print_task_backtraces(bool)` to control whether or not to print DONE tasks

### DIFF
--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -1123,10 +1123,7 @@ JL_DLLEXPORT void jl_print_backtrace(void) JL_NOTSAFEPOINT
     jlbacktrace();
 }
 
-// Print backtraces for all live tasks, for all threads.
-// WARNING: this is dangerous and can crash if used outside of gdb, if
-// all of Julia's threads are not stopped!
-JL_DLLEXPORT void jl_print_task_backtraces(void) JL_NOTSAFEPOINT
+void _jl_print_task_backtraces(int skip_done) JL_NOTSAFEPOINT
 {
     size_t nthreads = jl_atomic_load_acquire(&jl_n_threads);
     jl_ptls_t *allstates = jl_atomic_load_relaxed(&jl_all_tls_states);
@@ -1146,9 +1143,13 @@ JL_DLLEXPORT void jl_print_task_backtraces(void) JL_NOTSAFEPOINT
         void **lst = live_tasks->items;
         for (size_t j = 0; j < live_tasks->len; j++) {
             jl_task_t *t = (jl_task_t *)lst[j];
+            int t_state = jl_atomic_load_relaxed(&t->_state);
+            if (skip_done && t_state == JL_TASK_STATE_DONE) {
+                continue;
+            }
             jl_safe_printf("     ---- Task %zu (%p)\n", j + 1, t);
             jl_safe_printf("          (sticky: %d, started: %d, state: %d, tid: %d)\n",
-                    t->sticky, t->started, jl_atomic_load_relaxed(&t->_state),
+                    t->sticky, t->started, t_state,
                     jl_atomic_load_relaxed(&t->tid) + 1);
             if (t->stkbuf != NULL)
                 jlbacktracet(t);
@@ -1159,6 +1160,17 @@ JL_DLLEXPORT void jl_print_task_backtraces(void) JL_NOTSAFEPOINT
         jl_safe_printf("==== End thread %d\n", ptls2->tid + 1);
     }
     jl_safe_printf("==== Done\n");
+}
+// Print backtraces for all live tasks, for all threads.
+// WARNING: this is dangerous and can crash if used outside of gdb, if
+// all of Julia's threads are not stopped!
+JL_DLLEXPORT void jl_print_task_backtraces(void) JL_NOTSAFEPOINT
+{
+    _jl_print_task_backtraces(0);
+}
+JL_DLLEXPORT void jl_print_task_backtraces_skip_done(void) JL_NOTSAFEPOINT
+{
+    _jl_print_task_backtraces(1);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
This lets you print all live tasks, with less noise in the logs, in case it's been a while since the last GC.

In some cases, we are seeing many thousands of DONE Tasks, which greatly increase the noise in the logs, and can overwhelm the DataDog logging.


This addresses part of the logging issues identified in https://github.com/JuliaLang/julia/issues/47932.

@vilterp and @msagarpatel for review.