### PR TITLE
subtype: fix merge_env innervars getting copied to itself

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -3227,7 +3227,7 @@ static int merge_env(jl_stenv_t *e, jl_value_t **root, jl_savedenv_t *se, int co
         jl_svecset(*root, n+1, simple_join(b1, b2));
         b1 = jl_svecref(*root, n+2);
         b2 = (jl_value_t*)v->innervars;
-        if (b2) {
+        if (b2 && b1 != b2) {
             if (b1)
                 jl_array_ptr_1d_append((jl_array_t*)b2, (jl_array_t*)b1);
             else

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2339,3 +2339,14 @@ T46784{B<:Val, M<:AbstractMatrix} = Tuple{<:Union{B, <:Val{<:B}}, M, Union{Abstr
 end
 
 @test !(Tuple{Any, Any, Any} <: Tuple{Any, Vararg{T}} where T)
+
+abstract type MyAbstract47877{C}; end
+struct MyType47877{A,B} <: MyAbstract47877{A} end
+let A = Tuple{Type{T}, T} where T,
+    B = Tuple{Type{MyType47877{W, V} where V<:Union{Base.BitInteger, MyAbstract47877{W}}}, MyAbstract47877{<:Base.BitInteger}} where W
+    C = Tuple{Type{MyType47877{W, V} where V<:Union{MyAbstract47877{W1}, Base.BitInteger}}, MyType47877{W, V} where V<:Union{MyAbstract47877{W1}, Base.BitInteger}} where {W<:Base.BitInteger, W1<:Base.BitInteger}
+    # ensure that merge_env for innervars does not blow up (the large Unions ensure this will take excessive memory if it does)
+    @test typeintersect(A, B) == C # suboptimal, but acceptable
+    C = Tuple{Type{MyType47877{W, V} where V<:Union{MyAbstract47877{W}, Base.BitInteger}}, MyType47877{W, V} where V<:Union{MyAbstract47877{W}, Base.BitInteger}} where W<:Base.BitInteger
+    @test typeintersect(B, A) == C
+end


### PR DESCRIPTION
Problem observed in PkgEval for https://github.com/JuliaLang/julia/pull/47877#event-8076620844