### PR TITLE
Format extensions with parent in `@time_imports` report

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -979,6 +979,12 @@ function _include_from_serialized(pkg::PkgId, path::String, depmods::Vector{Any}
                 elapsed = round((time_ns() - t_before) / 1e6, digits = 1)
                 comp_time, recomp_time = cumulative_compile_time_ns() .- t_comp_before
                 print(lpad(elapsed, 9), " ms  ")
+                for extid in EXT_DORMITORY
+                    if extid.id == pkg
+                        print(extid.parentid.name, " → ")
+                        break
+                    end
+                end
                 print(pkg.name)
                 if comp_time > 0
                     printstyled(" ", Ryu.writefixed(Float64(100 * comp_time / (elapsed * 1e6)), 2), "% compilation time", color = Base.info_color())

--- a/doc/src/manual/code-loading.md
+++ b/doc/src/manual/code-loading.md
@@ -349,7 +349,7 @@ The subscripted `rootsᵢ`, `graphᵢ` and `pathsᵢ` variables correspond to th
 
 Since the primary environment is typically the environment of a project you're working on, while environments later in the stack contain additional tools, this is the right trade-off: it's better to break your development tools but keep the project working. When such incompatibilities occur, you'll typically want to upgrade your dev tools to versions that are compatible with the main project.
 
-### Package Extensions
+### [Package Extensions](@id man-extensions)
 
 A package "extension" is a module that is automatically loaded when a specified set of other packages (its "extension dependencies") are loaded in the current Julia session. The extension dependencies of an extension are a subset of those packages listed under the `[weakdeps]` section of a Project file. Extensions are defined under the `[extensions]` section in the project file:
 

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -360,7 +360,7 @@ See also: [`code_native`](@ref), [`@code_llvm`](@ref), [`@code_typed`](@ref) and
 A macro to execute an expression and produce a report of any time spent importing packages and their
 dependencies. Any compilation time will be reported as a percentage, and how much of which was recompilation, if any.
 
-On Julia 1.9+ package extensions will show as Parent → Extension.
+On Julia 1.9+ [package extensions](@ref man-extensions) will show as Parent → Extension.
 
 !!! note
     During the load process a package sequentially imports all of its dependencies, not just its direct dependencies.

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -360,6 +360,8 @@ See also: [`code_native`](@ref), [`@code_llvm`](@ref), [`@code_typed`](@ref) and
 A macro to execute an expression and produce a report of any time spent importing packages and their
 dependencies. Any compilation time will be reported as a percentage, and how much of which was recompilation, if any.
 
+On Julia 1.9+ package extensions will show as Parent → Extension.
+
 !!! note
     During the load process a package sequentially imports all of its dependencies, not just its direct dependencies.
 


### PR DESCRIPTION
Just adds the parent of the extension for context on an extension. See the last line here
```
julia> @time_imports using Colors, PGFPlotsX
      1.4 ms  Statistics
     41.5 ms  FixedPointNumbers
      0.7 ms  Reexport
     93.5 ms  ColorTypes
    144.6 ms  Colors
      0.7 ms  ArgCheck
      0.6 ms  DefaultApplication
      1.5 ms  DocStringExtensions
      9.6 ms  MacroTools
      0.7 ms  UnPack
      0.9 ms  Parameters
      0.5 ms  Requires
      0.8 ms  DataValueInterfaces
      1.7 ms  DataAPI
      0.7 ms  IteratorInterfaceExtensions
      0.7 ms  TableTraits
     15.6 ms  Tables
     80.2 ms  PGFPlotsX
      0.8 ms  PGFPlotsX → ColorsExt
```
