### PR TITLE
Apply `InitialOptimizations` more consistently in sorting

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -566,8 +566,8 @@ function _sort!(v::AbstractVector, a::MissingOptimization, o::Ordering, kw)
     if nonmissingtype(eltype(v)) != eltype(v) && o isa DirectOrdering
         lo, hi = send_to_end!(ismissing, v, o; lo, hi)
         _sort!(WithoutMissingVector(v, unsafe=true), a.next, o, (;kw..., lo, hi))
-    elseif eltype(v) <: Integer && o isa Perm{DirectOrdering} && nonmissingtype(eltype(o.data)) != eltype(o.data)
-        lo, hi = send_to_end!(i -> ismissing(@inbounds o.data[i]), v, o)
+    elseif eltype(v) <: Integer && o isa Perm && o.order isa DirectOrdering && nonmissingtype(eltype(o.data)) != eltype(o.data)
+        lo, hi = send_to_end!(i -> ismissing(@inbounds o.data[i]), v, o.order; lo, hi)
         _sort!(v, a.next, Perm(o.order, WithoutMissingVector(o.data, unsafe=true)), (;kw..., lo, hi))
     else
         _sort!(v, a.next, o, kw)


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/47383 revised how initial optimizations (special cases for `eltype`s that are unions with missing and/or a concrete `IEEEFloat` or `Bool` and very small input) are implemented and dispatched to. I accidentally dropped the initial optimizations in that PR for cases where the user specifies `alg=QuickSort`, `alg=MergeSort`, or `alg=InsertionSort`. I also dropped those optimizations for `partialsort` and `paritalsort!`. Thanks @vtjnash for catching these regressions [here](https://github.com/JuliaLang/julia/pull/47383#issuecomment-1349666916)

This PR applies `InitialOptimizations` to achieve better performance and avoid regressions.
```julia
julia> @btime sort(rand(50_000); alg=QuickSort);
  2.705 ms (2 allocations: 390.67 KiB) => 3.733 ms (4 allocations: 781.34 KiB) => 2.652 ms (4 allocations: 781.34 KiB)

julia> @btime sortperm(vcat([missing], rand(50_000)));
  6.221 ms (8 allocations: 1.19 MiB) => 6.785 ms (12 allocations: 1.57 MiB) => 3.525 ms (12 allocations: 1.57 MiB)

julia> VERSION
v"1.8.3" => v"1.10.0-DEV.164" => PR
```

Also fixes a dispatch bug in `::MissingOptimization` and debugs code that was previously unreachable due to that dispatch bug.