### PR TITLE
fix incorrect inference of `NamedTuple{(), <:Any}`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1766,12 +1766,6 @@ const _tvarnames = Symbol[:_A, :_B, :_C, :_D, :_E, :_F, :_G, :_H, :_I, :_J, :_K,
     end
     if istuple
         return Type{<:appl}
-    elseif isa(appl, DataType) && appl.name === _NAMEDTUPLE_NAME && length(appl.parameters) == 2 &&
-           (appl.parameters[1] === () || appl.parameters[2] === Tuple{})
-        # if the first/second parameter of `NamedTuple` is known to be empty,
-        # the second/first argument should also be empty tuple type,
-        # so refine it here
-        return Const(NamedTuple{(),Tuple{}})
     end
     ans = Type{appl}
     for i = length(outervars):-1:1

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2728,15 +2728,6 @@ end |> only === Int
 # Equivalence of Const(T.instance) and T for singleton types
 @test Const(nothing) ⊑ Nothing && Nothing ⊑ Const(nothing)
 
-# `apply_type_tfunc` should always return accurate result for empty NamedTuple case
-import Core: Const
-let apply_type_tfunc(@nospecialize xs...) =
-        Core.Compiler.apply_type_tfunc(Core.Compiler.fallback_lattice, xs...)
-    @test apply_type_tfunc(Const(NamedTuple), Const(()), Type{T} where T<:Tuple{}) === Const(typeof((;)))
-    @test apply_type_tfunc(Const(NamedTuple), Const(()), Type{T} where T<:Tuple) === Const(typeof((;)))
-    @test apply_type_tfunc(Const(NamedTuple), Tuple{Vararg{Symbol}}, Type{Tuple{}}) === Const(typeof((;)))
-end
-
 # Don't pessimize apply_type to anything worse than Type and yield Bottom for invalid Unions
 @test only(Base.return_types(Core.apply_type, Tuple{Type{Union}})) == Type{Union{}}
 @test only(Base.return_types(Core.apply_type, Tuple{Type{Union},Any})) == Type


### PR DESCRIPTION
closes #47481

Please note that the performance regression reported in #47479 is unrelated to this fix. The regression was caused by the optimization introduced in #47059, which allows for more code to be inlined, but can be suboptimal in some cases. However, the bug that this commit fixes is not necessary for enabling the optimization, so it does not address the performance problem.