### PR TITLE
move regex anchor tests to test/; make more precise

### DIFF
--- a/stdlib/PCRE2_jll/test/runtests.jl
+++ b/stdlib/PCRE2_jll/test/runtests.jl
@@ -8,14 +8,3 @@ using Test, Libdl, PCRE2_jll
     vn = VersionNumber(split(unsafe_string(pointer(vstr)), " ")[1])
     @test vn == v"10.42.0"
 end
-
-@testset "#47936" begin
-    tests = (r"a+[bc]+c",
-             r"a+[bc]{1,2}c",
-             r"(a)+[bc]+c",
-             r"a{1,2}[bc]+c",
-             r"(a+)[bc]+c")
-    for re in tests
-        @test !isnothing(match(re, "ababc"))
-    end
-end

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -224,3 +224,14 @@
     # hash
     @test hash(r"123"i, zero(UInt)) == hash(Regex("123", "i"), zero(UInt))
 end
+
+@testset "#47936" begin
+    tests = (r"a+[bc]+c",
+             r"a+[bc]{1,2}c",
+             r"(a)+[bc]+c",
+             r"a{1,2}[bc]+c",
+             r"(a+)[bc]+c")
+    for re in tests
+        @test match(re, "ababc").match === SubString("ababc", 3:5)
+    end
+end


### PR DESCRIPTION
These tests aren't specific to PCRE; no matter how Regex matching is implemented, these tests should pass, so I'm moving them into test/regex.jl. I'm also making them more precise and testing that the match is not only something, but also that it is the exact substring that should match. Might catch some future PCRE regression.
