### PR TITLE
reland refinement on instantiation of partially-known empty `NamedTuple`

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4669,3 +4669,15 @@ bar47688() = foo47688()
 @test it_count47688 == 7
 @test isa(foo47688(), NTuple{6, Int})
 @test it_count47688 == 14
+
+# refine instantiation of partially-known NamedTuple that is known to be empty
+@test Base.return_types((Any,)) do Tpl
+    T = NamedTuple{(),Tpl}
+    nt = T(())
+    values(nt)
+end |> only === Tuple{}
+@test Base.return_types((Any,)) do tpl
+    T = NamedTuple{tpl,Tuple{}}
+    nt = T(())
+    keys(nt)
+end |> only === Tuple{}


### PR DESCRIPTION
This is a re-land of #47481.
This commit improves inference accuracy of instantiation of partially-known, empty NamedTuple. Note that we can't do the same for inference of `apply_type` call as pointed at #47481.

```julia
@test Base.return_types((Any,)) do Tpl
    T = NamedTuple{(),Tpl}
    nt = T(())
    values(nt)
end === Tuple{}
```