### PR TITLE
Export flisp profile functionality.

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -301,6 +301,9 @@
     XX(jl_is_unary_operator) \
     XX(jl_lazy_load_and_lookup) \
     XX(jl_lisp_prompt) \
+    XX(fl_profile) \
+    XX(fl_show_profile) \
+    XX(fl_clear_profile) \
     XX(jl_load) \
     XX(jl_load_) \
     XX(jl_load_and_lookup) \

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -10,6 +10,8 @@
     jl_*;
     ijl_*;
     _jl_mutex_*;
+    fl_*;
+    ifl_*;
     rec_backtrace;
     julia_*;
     libsupport_init;


### PR DESCRIPTION
These were marked JL_DLLEXPORT, but are missing from the list of exported functions.