### PR TITLE
Restore libgcc_s symlinking in !macOS

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -227,6 +227,8 @@ else
 $(eval $(call symlink_system_library,CSL,libgcc_s,1))
 endif
 endif
+else
+$(eval $(call symlink_system_library,CSL,libgcc_s,1))
 endif
 ifneq (,$(LIBGFORTRAN_VERSION))
 $(eval $(call symlink_system_library,CSL,libgfortran,$(LIBGFORTRAN_VERSION)))


### PR DESCRIPTION
Commit c8b72e2bf49046e8daca64214765694377277947 completely removed libgcc_s symlinking (I assume unintentionally) in !macOS.