### PR TITLE
lattice: Don't short-circuit layers between PartialStruct and Type

### DIFF
--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -487,69 +487,79 @@ function tmerge(𝕃::AnyMustAliasesLattice, @nospecialize(typea), @nospecialize
     return tmerge(widenlattice(𝕃), typea, typeb)
 end
 
-function tmerge(lattice::PartialsLattice, @nospecialize(typea), @nospecialize(typeb))
-    # type-lattice for Const and PartialStruct wrappers
-    acp = isa(typea, Const) || isa(typea, PartialStruct)
-    bcp = isa(typeb, Const) || isa(typeb, PartialStruct)
-    if acp && bcp
-        aty = widenconst(typea)
-        bty = widenconst(typeb)
-        if aty === bty
-            # must have egal here, since we do not create PartialStruct for non-concrete types
-            typea_nfields = nfields_tfunc(lattice, typea)
-            typeb_nfields = nfields_tfunc(lattice, typeb)
-            isa(typea_nfields, Const) || return aty
-            isa(typeb_nfields, Const) || return aty
-            type_nfields = typea_nfields.val::Int
-            type_nfields === typeb_nfields.val::Int || return aty
-            type_nfields == 0 && return aty
-            fields = Vector{Any}(undef, type_nfields)
-            anyrefine = false
-            for i = 1:type_nfields
-                ai = getfield_tfunc(lattice, typea, Const(i))
-                bi = getfield_tfunc(lattice, typeb, Const(i))
-                ft = fieldtype(aty, i)
-                if is_lattice_equal(lattice, ai, bi) || is_lattice_equal(lattice, ai, ft)
-                    # Since ai===bi, the given type has no restrictions on complexity.
-                    # and can be used to refine ft
-                    tyi = ai
-                elseif is_lattice_equal(lattice, bi, ft)
-                    tyi = bi
-                elseif (tyi′ = tmerge_field(lattice, ai, bi); tyi′ !== nothing)
-                    # allow external lattice implementation to provide a custom field-merge strategy
-                    tyi = tyi′
+# N.B. This can also be called with both typea::Const and typeb::Const to
+# to recover PartialStruct from `Const`s with overlapping fields.
+function tmerge_partial_struct(lattice::PartialsLattice, @nospecialize(typea), @nospecialize(typeb))
+    aty = widenconst(typea)
+    bty = widenconst(typeb)
+    if aty === bty
+        # must have egal here, since we do not create PartialStruct for non-concrete types
+        typea_nfields = nfields_tfunc(lattice, typea)
+        typeb_nfields = nfields_tfunc(lattice, typeb)
+        isa(typea_nfields, Const) || return nothing
+        isa(typeb_nfields, Const) || return nothing
+        type_nfields = typea_nfields.val::Int
+        type_nfields === typeb_nfields.val::Int || return nothing
+        type_nfields == 0 && return nothing
+        fields = Vector{Any}(undef, type_nfields)
+        anyrefine = false
+        for i = 1:type_nfields
+            ai = getfield_tfunc(lattice, typea, Const(i))
+            bi = getfield_tfunc(lattice, typeb, Const(i))
+            ft = fieldtype(aty, i)
+            if is_lattice_equal(lattice, ai, bi) || is_lattice_equal(lattice, ai, ft)
+                # Since ai===bi, the given type has no restrictions on complexity.
+                # and can be used to refine ft
+                tyi = ai
+            elseif is_lattice_equal(lattice, bi, ft)
+                tyi = bi
+            elseif (tyi′ = tmerge_field(lattice, ai, bi); tyi′ !== nothing)
+                # allow external lattice implementation to provide a custom field-merge strategy
+                tyi = tyi′
+            else
+                # Otherwise use the default aggressive field-merge implementation, and
+                # choose between using the fieldtype or some other simple merged type.
+                # The wrapper type never has restrictions on complexity,
+                # so try to use that to refine the estimated type too.
+                tni = _typename(widenconst(ai))
+                if tni isa Const && tni === _typename(widenconst(bi))
+                    # A tmeet call may cause tyi to become complex, but since the inputs were
+                    # strictly limited to being egal, this has no restrictions on complexity.
+                    # (Otherwise, we would need to use <: and take the narrower one without
+                    # intersection. See the similar comment in abstract_call_method.)
+                    tyi = typeintersect(ft, (tni.val::Core.TypeName).wrapper)
                 else
-                    # Otherwise use the default aggressive field-merge implementation, and
-                    # choose between using the fieldtype or some other simple merged type.
-                    # The wrapper type never has restrictions on complexity,
-                    # so try to use that to refine the estimated type too.
-                    tni = _typename(widenconst(ai))
-                    if tni isa Const && tni === _typename(widenconst(bi))
-                        # A tmeet call may cause tyi to become complex, but since the inputs were
-                        # strictly limited to being egal, this has no restrictions on complexity.
-                        # (Otherwise, we would need to use <: and take the narrower one without
-                        # intersection. See the similar comment in abstract_call_method.)
-                        tyi = typeintersect(ft, (tni.val::Core.TypeName).wrapper)
-                    else
-                        # Since aty===bty, the fieldtype has no restrictions on complexity.
-                        tyi = ft
-                    end
-                end
-                fields[i] = tyi
-                if !anyrefine
-                    anyrefine = has_nontrivial_extended_info(lattice, tyi) || # extended information
-                                ⋤(lattice, tyi, ft) # just a type-level information, but more precise than the declared type
+                    # Since aty===bty, the fieldtype has no restrictions on complexity.
+                    tyi = ft
                 end
             end
-            return anyrefine ? PartialStruct(aty, fields) : aty
+            fields[i] = tyi
+            if !anyrefine
+                anyrefine = has_nontrivial_extended_info(lattice, tyi) || # extended information
+                            ⋤(lattice, tyi, ft) # just a type-level information, but more precise than the declared type
+            end
         end
+        anyrefine && return PartialStruct(aty, fields)
+    end
+    return nothing
+end
+
+function tmerge(lattice::PartialsLattice, @nospecialize(typea), @nospecialize(typeb))
+    # type-lattice for Const and PartialStruct wrappers
+    aps = isa(typea, PartialStruct)
+    bps = isa(typeb, PartialStruct)
+    acp = aps || isa(typea, Const)
+    bcp = bps || isa(typeb, Const)
+    if acp && bcp
+        psrt = tmerge_partial_struct(lattice, typea, typeb)
+        psrt !== nothing && return psrt
     end
 
     # Don't widen const here - external AbstractInterpreter might insert lattice
     # layers between us and `ConstsLattice`.
     wl = widenlattice(lattice)
-    isa(typea, PartialStruct) && (typea = widenlattice(wl, typea))
-    isa(typeb, PartialStruct) && (typeb = widenlattice(wl, typeb))
+    aps && (typea = widenlattice(wl, typea))
+    bps && (typeb = widenlattice(wl, typeb))
 
     # type-lattice for PartialOpaque wrapper
     apo = isa(typea, PartialOpaque)


### PR DESCRIPTION
This catches a corner case I missed in #46881. In particular, when both arguments are `Const`, it is legal for intermediate lattice layers between the PartialsLattice and the ConstLattice to do something other than give the merged type. The current code in the PartialsLattice was short-circuiting this, leading to inference imprecision. I think technically, we'd be ok to do the short-circuiting when both are known to be PartialStruct (since we know that they widenlattice to a type), but it doesn't seem worth the extra effort to check.