### PR TITLE
irinterp: Add missing widenconst into tmeet

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -250,7 +250,7 @@ function reprocess_instruction!(interp::AbstractInterpreter,
         # Handled at the very end
         return false
     elseif isa(inst, PiNode)
-        rt = tmeet(typeinf_lattice(interp), argextype(inst.val, ir), inst.typ)
+        rt = tmeet(typeinf_lattice(interp), argextype(inst.val, ir), widenconst(inst.typ))
     else
         ccall(:jl_, Cvoid, (Any,), inst)
         error()


### PR DESCRIPTION
The `fixup_slot!` code in slot2ssa.jl indiscrimnately moves lattice elements into `PiNode` `typ` fields. As a result, we cannot assume that we have `typ::Type`, so we must widenconst in irinterp to avoid errors.