### PR TITLE
Fix typo in docstring

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2180,7 +2180,7 @@ the function `op`.
     return y => z
 
 If supported by the hardware (for example, atomic increment), this may be
-optimized to the appropriate hardware instruction, otherwise it'll use a loop.
+optimized to the appropriate hardware instruction, otherwise it'll use a lock.
 """
 modifyfield!
 
@@ -2201,7 +2201,7 @@ a given value.
     return (; old = y, success = ok)
 
 If supported by the hardware, this may be optimized to the appropriate hardware
-instruction, otherwise it'll use a loop.
+instruction, otherwise it'll use a lock.
 """
 replacefield!
 


### PR DESCRIPTION
I can't imagine implementing this behavior with a loop, so I assume it's a typo for lock. Seeking a reviewer who can confirm that they indeed fallback to using locks.

IIUC bugfixes and documentation improvements are good candidates for backporting and this is a bit of both so I tagged it accordingly.