### PR TITLE
Make the `getproperty` example type stable

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2871,9 +2871,9 @@ julia> obj.x
 1
 ```
 
-One should overload `getproperty` only when necessary, as it can be confusing if 
+One should overload `getproperty` only when necessary, as it can be confusing if
 the behavior of the syntax `obj.f` is unusual.
-Also note that using methods is often preferable. See also this style guide documentation 
+Also note that using methods is often preferable. See also this style guide documentation
 for more information: [Prefer exported methods over direct field access](@ref).
 
 See also [`getfield`](@ref Core.getfield),

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2850,8 +2850,8 @@ the syntax `@atomic a.b` calls `getproperty(a, :b, :sequentially_consistent)`.
 
 # Examples
 ```jldoctest
-julia> struct MyType
-           x
+julia> struct MyType{T <: Number}
+           x::T
        end
 
 julia> function Base.getproperty(obj::MyType, sym::Symbol)

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2871,10 +2871,10 @@ julia> obj.x
 1
 ```
 
-One should overload `getproperty` only when necessary,
-as it can be confusing if the behavior of `obj.f` changes.
-Using methods is often preferable; see
-https://docs.julialang.org/en/v1/manual/style-guide/#Prefer-exported-methods-over-direct-field-access
+One should overload `getproperty` only when necessary, as it can be confusing if 
+the behavior of the syntax `obj.f` is unusual.
+Also note that using methods is often preferable. See also this style guide documentation 
+for more information: [Prefer exported methods over direct field access](@ref).
 
 See also [`getfield`](@ref Core.getfield),
 [`propertynames`](@ref Base.propertynames) and

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2871,6 +2871,11 @@ julia> obj.x
 1
 ```
 
+One should overload `getproperty` only when necessary,
+as it can be confusing if the behavior of `obj.f` changes.
+Using methods is often preferable; see
+https://docs.julialang.org/en/v1/manual/style-guide/#Prefer-exported-methods-over-direct-field-access
+
 See also [`getfield`](@ref Core.getfield),
 [`propertynames`](@ref Base.propertynames) and
 [`setproperty!`](@ref Base.setproperty!).


### PR DESCRIPTION
The example as written is not type stable, as one can verify with`@code_warntype`. It seems worth this small change to illustrate the preferable approach.

On a more general note, I just recently figured out that `getproperty` is not type stable in general. (Simply replace the `obj.x + 1` with something like `obj.x / 2`.) Probably whoever reviews this PR will know that already, but I wish that I had been warned long ago about that. I recommend that a warning be put right here in these docs for it. I could draft the warning if there is openness to including it, but I figured that might be more debatable than the type annotation so I thought I'd wait for feedback first.