### PR TITLE
compiler: Use correct method to construct empty NamedTuple

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2447,7 +2447,7 @@ function refine_partial_type(@nospecialize t)
         # if the first/second parameter of `NamedTuple` is known to be empty,
         # the second/first argument should also be empty tuple type,
         # so refine it here
-        return Const(NamedTuple(()))
+        return Const(NamedTuple())
     end
     return t
 end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4675,13 +4675,17 @@ bar47688() = foo47688()
 @test it_count47688 == 14
 
 # refine instantiation of partially-known NamedTuple that is known to be empty
-@test Base.return_types((Any,)) do Tpl
+function empty_nt_values(Tpl)
     T = NamedTuple{(),Tpl}
     nt = T(())
     values(nt)
-end |> only === Tuple{}
-@test Base.return_types((Any,)) do tpl
-    T = NamedTuple{tpl,Tuple{}}
+end
+function empty_nt_keys(Tpl)
+    T = NamedTuple{(),Tpl}
     nt = T(())
     keys(nt)
-end |> only === Tuple{}
+end
+@test Base.return_types(empty_nt_values, (Any,)) |> only === Tuple{}
+@test Base.return_types(empty_nt_keys, (Any,)) |> only === Tuple{}
+g() = empty_nt_values(Base.inferencebarrier(Tuple{}))
+@test g() == () # Make sure to actually run this to test this in the inference world age


### PR DESCRIPTION
The `NamedTuple(())` method is not available in the inference world age. Empty named tuples needs to be constructed with `NamedTuple()`. This was causing the Diffractor tests to error.