### PR TITLE
flip the env to the correct side when intersect 2 typevar

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2568,6 +2568,10 @@ static jl_value_t *finish_unionall(jl_value_t *res JL_MAYBE_UNROOTED, jl_varbind
     if (jl_is_long(vb->ub) && jl_is_typevar(vb->lb)) {
         varval = vb->ub;
     }
+    else if (!jl_is_type(vb->lb) && !jl_is_typevar(vb->lb) && vb->ub == (jl_value_t *)jl_any_type) {
+        // 1<:x<:Any
+        varval = vb->lb;
+    }
     else if (obviously_egal(vb->lb, vb->ub)) {
         // given x<:T<:x, substitute x for T
         varval = vb->ub;

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2342,16 +2342,40 @@ static int subtype_in_env_existential(jl_value_t *x, jl_value_t *y, jl_stenv_t *
 }
 
 // See if var y is reachable from x via bounds; used to avoid cycles.
-static int reachable_var(jl_value_t *x, jl_tvar_t *y, jl_stenv_t *e)
+static int _reachable_var(jl_value_t *x, jl_tvar_t *y, jl_stenv_t *e)
 {
     if (in_union(x, (jl_value_t*)y))
         return 1;
     if (!jl_is_typevar(x))
         return 0;
     jl_varbinding_t *xv = lookup(e, (jl_tvar_t*)x);
-    if (xv == NULL)
+    if (xv == NULL || xv->occurs)
         return 0;
-    return reachable_var(xv->ub, y, e) || reachable_var(xv->lb, y, e);
+    xv->occurs = 1;
+    return _reachable_var(xv->ub, y, e) || _reachable_var(xv->lb, y, e);
+}
+
+static int reachable_var(jl_value_t *x, jl_tvar_t *y, jl_stenv_t *e)
+{
+    int len = current_env_length(e);
+    int8_t *rs = (int8_t*)malloc_s(len);
+    int n = 0;
+    jl_varbinding_t *v = e->vars;
+    while (n < len) {
+        assert(v != NULL);
+        rs[n++] = v->occurs;
+        v->occurs = 0;
+        v = v->prev;
+    }
+    int res = _reachable_var(x, y, e);
+    n = 0; v = e->vars;
+    while (n < len) {
+        assert(v != NULL);
+        v->occurs = rs[n++];
+        v = v->prev;
+    }
+    free(rs);
+    return res;
 }
 
 // check whether setting v == t implies v == SomeType{v}, which is unsatisfiable.

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1678,9 +1678,7 @@ CovType{T} = Union{AbstractArray{T,2},
 # issue #31703
 @testintersect(Pair{<:Any, Ref{Tuple{Ref{Ref{Tuple{Int}}},Ref{Float64}}}},
                Pair{T, S} where S<:(Ref{A} where A<:(Tuple{C,Ref{T}} where C<:(Ref{D} where D<:(Ref{E} where E<:Tuple{FF}) where FF<:B)) where B) where T,
-               Pair{T, Ref{Tuple{Ref{Ref{Tuple{Int}}},Ref{Float64}}}} where T)
-# TODO: should be able to get this result
-#              Pair{Float64, Ref{Tuple{Ref{Ref{Tuple{Int}}},Ref{Float64}}}}
+               Pair{Float64, Ref{Tuple{Ref{Ref{Tuple{Int}}},Ref{Float64}}}})
 
 module I31703
 using Test, LinearAlgebra
@@ -1732,8 +1730,7 @@ end
                Tuple{Type{SA{2, L}}, Type{SA{2, L}}} where L)
 @testintersect(Tuple{Type{SA{2, L}}, Type{SA{2, 16}}} where L,
                Tuple{Type{<:SA{N, L}}, Type{<:SA{N, L}}} where {N,L},
-               # TODO: this could be narrower
-               Tuple{Type{SA{2, L}}, Type{SA{2, 16}}} where L)
+               Tuple{Type{SA{2, 16}}, Type{SA{2, 16}}})
 
 # issue #31993
 @testintersect(Tuple{Type{<:AbstractVector{T}}, Int} where T,
@@ -1828,9 +1825,9 @@ c32703(::Type{<:Str{C}}, str::Str{C}) where {C<:CSE} = str
                Tuple{Type{<:Str{C}}, Str{C}} where {C<:CSE},
                Union{})
 @test c32703(UTF16Str, ASCIIStr()) == 42
-@test_broken typeintersect(Tuple{Vector{Vector{Float32}},Matrix,Matrix},
-                           Tuple{Vector{V},Matrix{Int},Matrix{S}} where {S, V<:AbstractVector{S}}) ==
-             Tuple{Array{Array{Float32,1},1},Array{Int,2},Array{Float32,2}}
+@testintersect(Tuple{Vector{Vector{Float32}},Matrix,Matrix},
+               Tuple{Vector{V},Matrix{Int},Matrix{S}} where {S, V<:AbstractVector{S}},
+               Tuple{Array{Array{Float32,1},1},Array{Int,2},Array{Float32,2}})
 
 @testintersect(Tuple{Pair{Int, DataType}, Any},
                Tuple{Pair{A, B} where B<:Type, Int} where A,

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2339,6 +2339,12 @@ let S = Tuple{Val{Tuple{2, 1}}, Any},
     (intersection_env(S, T)[2]...,) == (1, 2, Tuple{1, 2})
 end
 
+#https://github.com/JuliaLang/julia/pull/31167#issuecomment-1358381818
+let S = Tuple{Type{T2}, T2, Val{T2}} where {T2<:Val{S2} where {S2<:Val}},
+    T = Tuple{Union{Type{T}, Type{S}}, Union{Val{T}, Val{S}}, Union{Val{T}, S}} where T<:Val{A} where A where S<:Val
+    @test typeintersect(S, T, !Union{})
+end
+
 @testset "known subtype/intersect issue" begin
     #issue 45874
     # Causes a hang due to jl_critical_error calling back into malloc...

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2314,6 +2314,14 @@ let S1 = Tuple{Int, Any, Union{Val{C1}, C1}} where {R1<:Real, C1<:Union{Complex{
     end
 end
 
+#issue 41561
+@testintersect(Tuple{Val{VT}, Val{VT}} where {N1, VT<:AbstractVector{N1}},
+            Tuple{Val{VN} where {N, VN<:AbstractVector{N}}, Val{Vector{Float64}}},
+            Tuple{Val{Vector{Float64}}, Val{Vector{Float64}}})
+@testintersect(Tuple{Val{VT}, Val{VT}} where {N1, VT<:AbstractVector{N1}},
+            Tuple{Val{Vector{Float64}}, Val{VN} where {N, VN<:AbstractVector{N}}},
+            Tuple{Val{Vector{Float64}}, Val{Vector{Float64}}})
+
 @testset "known subtype/intersect issue" begin
     #issue 45874
     # Causes a hang due to jl_critical_error calling back into malloc...
@@ -2329,9 +2337,6 @@ end
         Tuple{Type{Vector{Union{T, R}}}, Matrix{Union{T, R}}} where {R<:Real, T<:Real},
     ) === Union{}
 
-    #issue 41561
-    @test_broken typeintersect(Tuple{Vector{VT}, Vector{VT}} where {N1, VT<:AbstractVector{N1}},
-                Tuple{Vector{VN} where {N, VN<:AbstractVector{N}}, Vector{Vector{Float64}}}) !== Union{}
     #issue 40865
     @test_broken Tuple{Set{Ref{Int}}, Set{Ref{Int}}} <: Tuple{Set{KV}, Set{K}} where {K,KV<:Union{K,Ref{K}}}
     @test_broken Tuple{Set{Val{Int}}, Set{Val{Int}}} <: Tuple{Set{KV}, Set{K}} where {K,KV<:Union{K,Val{K}}}

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2319,6 +2319,12 @@ end
             Tuple{Val{Vector{Float64}}, Val{VN} where {N, VN<:AbstractVector{N}}},
             Tuple{Val{Vector{Float64}}, Val{Vector{Float64}}})
 
+#pr 48006
+struct T48006{A1,A2,A3} end
+@testintersect(Tuple{T48006{Float64, Int, S1}, Int} where {F1<:Real, S1<:Union{Int8, Val{F1}}},
+               Tuple{T48006{F2, I, S2}, I} where {F2<:Real, I<:Int, S2<:Union{Int8, Val{F2}}},
+               Tuple{T48006{Float64, Int, S1}, Int} where S1<:Union{Val{Float64}, Int8})
+
 @testset "known subtype/intersect issue" begin
     #issue 45874
     # Causes a hang due to jl_critical_error calling back into malloc...

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2328,6 +2328,11 @@ struct T48006{A1,A2,A3} end
                Tuple{T48006{F2, I, S2}, I} where {F2<:Real, I<:Int, S2<:Union{Int8, Val{F2}}},
                Tuple{T48006{Float64, Int, S1}, Int} where S1<:Union{Val{Float64}, Int8})
 
+let S = Tuple{T2, V2} where {T2, N2, V2<:(Array{S2, N2} where {S2 <: T2})},
+    T = Tuple{V1, T1} where {T1, N1, V1<:(Array{S1, N1} where {S1 <: T1})}
+    @testintersect(S, T, !Union{})
+end
+
 @testset "known subtype/intersect issue" begin
     #issue 45874
     # Causes a hang due to jl_critical_error calling back into malloc...

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2333,6 +2333,12 @@ let S = Tuple{T2, V2} where {T2, N2, V2<:(Array{S2, N2} where {S2 <: T2})},
     @testintersect(S, T, !Union{})
 end
 
+let S = Tuple{Val{Tuple{2, 1}}, Any},
+    T = T = Tuple{Val{S}, Real} where {Y, X, S<:Tuple{Y, X}}
+    @testintersect(S, T, Tuple{Val{Tuple{2, 1}}, Real})
+    (intersection_env(S, T)[2]...,) == (1, 2, Tuple{1, 2})
+end
+
 @testset "known subtype/intersect issue" begin
     #issue 45874
     # Causes a hang due to jl_critical_error calling back into malloc...


### PR DESCRIPTION
The intersection result should be order-independent. But our subtype algorithm is sensitive to which side the typevar comes from.
This PR tries to update the `right`s in env based on the following subtype check to avoid some false `Union{}`.

fix #41561.
