### PR TITLE
wip: inference: implement numeric interval analysis

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -431,6 +431,7 @@ eval(Core, quote
     # NOTE the main constructor is defined within `Core.Compiler`
     _PartialStruct(@nospecialize(typ), fields::Array{Any, 1}) = $(Expr(:new, :PartialStruct, :typ, :fields))
     PartialOpaque(@nospecialize(typ), @nospecialize(env), parent::MethodInstance, source) = $(Expr(:new, :PartialOpaque, :typ, :env, :parent, :source))
+    Interval(typ::DataType, @nospecialize(min), @nospecialize(max)) = $(Expr(:new, :Interval, :typ, :min, :max))
     InterConditional(slot::Int, @nospecialize(thentype), @nospecialize(elsetype)) = $(Expr(:new, :InterConditional, :slot, :thentype, :elsetype))
     MethodMatch(@nospecialize(spec_types), sparams::SimpleVector, method::Method, fully_covers::Bool) = $(Expr(:new, :MethodMatch, :spec_types, :sparams, :method, :fully_covers))
 end)

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -964,7 +964,7 @@ function const_prop_entry_heuristic(interp::AbstractInterpreter, result::MethodC
         else
             return true
         end
-    elseif isa(rt, PartialStruct) || isa(rt, InterConditional) || isa(rt, InterMustAlias)
+    elseif isa(rt, PartialStruct) || isa(rt, Interval) || isa(rt, InterConditional) || isa(rt, InterMustAlias)
         # could be improved to `Const` or a more precise wrapper
         return true
     elseif isa(rt, LimitedAccuracy)
@@ -1076,11 +1076,14 @@ function const_prop_function_heuristic(interp::AbstractInterpreter, @nospecializ
         # it is almost useless to inline the op when all the same type,
         # but highly worthwhile to inline promote of a constant
         length(argtypes) > 2 || return false
-        t1 = widenconst(argtypes[2])
+        at₂ = argtypes[2]
+        isa(at₂, Interval) && return true
+        t₂ = widenconst(at₂)
         for i in 3:length(argtypes)
-            at = argtypes[i]
-            ty = isvarargtype(at) ? unwraptv(at) : widenconst(at)
-            if ty !== t1
+            atᵢ = argtypes[i]
+            isa(atᵢ, Interval) && return true
+            tᵢ = isvarargtype(atᵢ) ? unwraptv(atᵢ) : widenconst(atᵢ)
+            if tᵢ !== t₂
                 return true
             end
         end
@@ -1722,7 +1725,8 @@ function abstract_call_builtin(interp::AbstractInterpreter, f::Builtin, (; fargs
                 end
             end
         end
-    elseif has_conditional(𝕃ᵢ, sv) && (rt === Bool || (isa(rt, Const) && isa(rt.val, Bool))) && isa(fargs, Vector{Any})
+    end
+    if has_conditional(𝕃ᵢ, sv) && (rt === Bool || (isa(rt, Const) && isa(rt.val, Bool))) && isa(fargs, Vector{Any})
         # perform very limited back-propagation of type information for `is` and `isa`
         if f === isa
             # try splitting value argument, based on types
@@ -2744,6 +2748,17 @@ end
         end
     end
     return rt
+end
+
+@nospecializeinfer function widenreturn(𝕃ᵢ::IntervalsLattice, @nospecialize(rt), info::BestguessInfo)
+    return widenreturn_interval(𝕃ᵢ, rt, info)
+end
+@nospecializeinfer function widenreturn_noslotwrapper(𝕃ᵢ::IntervalsLattice, @nospecialize(rt), info::BestguessInfo)
+    return widenreturn_interval(𝕃ᵢ, rt, info)
+end
+@nospecializeinfer function widenreturn_interval(𝕃ᵢ::IntervalsLattice, @nospecialize(rt), info::BestguessInfo)
+    isa(rt, Interval) && return rt
+    return widenreturn(widenlattice(𝕃ᵢ), rt, info)
 end
 
 @nospecializeinfer function widenreturn(𝕃ᵢ::PartialsLattice, @nospecialize(rt), info::BestguessInfo)

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -313,6 +313,9 @@ function CodeInstance(interp::AbstractInterpreter, result::InferenceResult,
         elseif isa(result_type, PartialStruct)
             rettype_const = result_type.fields
             const_flags = 0x2
+        elseif isa(result_type, Interval)
+            rettype_const = result_type
+            const_flags = 0x2
         elseif isa(result_type, InterConditional)
             rettype_const = result_type
             const_flags = 0x2
@@ -889,6 +892,8 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
                 if isa(rettype_const, Vector{Any}) && !(Vector{Any} <: rettype)
                     rettype = PartialStruct(rettype, rettype_const)
                 elseif isa(rettype_const, PartialOpaque) && rettype <: Core.OpaqueClosure
+                    rettype = rettype_const
+                elseif isa(rettype_const, Interval) && rettype !== Interval
                     rettype = rettype_const
                 elseif isa(rettype_const, InterConditional) && rettype !== InterConditional
                     rettype = rettype_const

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -552,6 +552,23 @@ end
     return tmerge(widenlattice(𝕃), typea, typeb)
 end
 
+function tmerge(𝕃::IntervalsLattice, @nospecialize(typea), @nospecialize(typeb))
+    if isa(typea, Interval)
+        if isa(typeb, Interval)
+            if typea.typ === typeb.typ
+                min = intrinsicop(:min, typea.typ)
+                max = intrinsicop(:max, typea.typ)
+                return Interval(typea.typ, min(typea.min, typeb.min), max(typea.max, typeb.max))
+            end
+            typeb = wideninterval(typeb)
+        end
+        typea = wideninterval(typea)
+    elseif isa(typeb, Interval)
+        typeb = wideninterval(typeb)
+    end
+    return tmerge(widenlattice(𝕃), typea, typeb)
+end
+
 # N.B. This can also be called with both typea::Const and typeb::Const to
 # to recover PartialStruct from `Const`s with overlapping fields.
 @nospecializeinfer function tmerge_partial_struct(lattice::PartialsLattice, @nospecialize(typea), @nospecialize(typeb))

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2075,6 +2075,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("Const", (jl_value_t*)jl_const_type);
     add_builtin("PartialStruct", (jl_value_t*)jl_partial_struct_type);
     add_builtin("PartialOpaque", (jl_value_t*)jl_partial_opaque_type);
+    add_builtin("Interval", (jl_value_t*)jl_interval_type);
     add_builtin("InterConditional", (jl_value_t*)jl_interconditional_type);
     add_builtin("MethodMatch", (jl_value_t*)jl_method_match_type);
     add_builtin("IntrinsicFunction", (jl_value_t*)jl_intrinsic_type);

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -54,6 +54,7 @@
     XX(jl_int8_type) \
     XX(jl_interconditional_type) \
     XX(jl_interrupt_exception) \
+    XX(jl_interval_type) \
     XX(jl_intrinsic_type) \
     XX(jl_kwcall_func) \
     XX(jl_lineinfonode_type) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3162,6 +3162,11 @@ void jl_init_types(void) JL_GC_DISABLED
                                        jl_svec2(jl_any_type, jl_array_any_type),
                                        jl_emptysvec, 0, 0, 2);
 
+    jl_interval_type = jl_new_datatype(jl_symbol("Interval"), core, jl_any_type, jl_emptysvec,
+                                       jl_perm_symsvec(3, "typ", "min", "max"),
+                                       jl_svec(3, jl_datatype_type, jl_any_type, jl_any_type),
+                                       jl_emptysvec, 0, 0, 3);
+
     jl_interconditional_type = jl_new_datatype(jl_symbol("InterConditional"), core, jl_any_type, jl_emptysvec,
                                           jl_perm_symsvec(3, "slot", "thentype", "elsetype"),
                                           jl_svec(3, jl_long_type, jl_any_type, jl_any_type),

--- a/src/julia.h
+++ b/src/julia.h
@@ -776,6 +776,7 @@ extern JL_DLLIMPORT jl_datatype_t *jl_argument_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_const_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_partial_struct_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_partial_opaque_type JL_GLOBALLY_ROOTED;
+extern JL_DLLIMPORT jl_datatype_t *jl_interval_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_interconditional_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_method_match_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_simplevector_type JL_GLOBALLY_ROOTED;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -99,7 +99,7 @@ extern "C" {
 // TODO: put WeakRefs on the weak_refs list during deserialization
 // TODO: handle finalizers
 
-#define NUM_TAGS    158
+#define NUM_TAGS    159
 
 // An array of references that need to be restored from the sysimg
 // This is a manually constructed dual of the gvars array, which would be produced by codegen for Julia code, for C.
@@ -138,6 +138,7 @@ jl_value_t **const*const get_tags(void) {
         INSERT_TAG(jl_const_type);
         INSERT_TAG(jl_partial_struct_type);
         INSERT_TAG(jl_partial_opaque_type);
+        INSERT_TAG(jl_interval_type);
         INSERT_TAG(jl_interconditional_type);
         INSERT_TAG(jl_method_match_type);
         INSERT_TAG(jl_pinode_type);

--- a/test/int.jl
+++ b/test/int.jl
@@ -208,6 +208,11 @@ end
                     # #47835, TODO implement interval arithmetic analysis
                     @test_broken Core.Compiler.is_nothrow(Base.infer_effects(op, (T, T2)))
                 end
+                # TODO enable these tests once we enable interval analysis in the base compiler
+                # @test Core.Compiler.is_foldable(Base.infer_effects(op, (T, T2)))
+                # # TODO fold out `0 ≤ x::UInt` to `Const(true)`
+                # T2 === Int128 && (T === UInt64 || T === UInt128) && continue
+                # @test Core.Compiler.is_removable_if_unused(Base.infer_effects(op, (T, T2)))
             end
         end
     end


### PR DESCRIPTION
This commit is an attemp to make the inference reason about numeric intervals. One of its goals is to fold out the following kind of case:
```julia
julia> code_typed((Int32,)) do x
           # we know this condition never holds because `x::Int32`
           if x == typemax(Int)
               return nothing
           end
           return 0
       end
1-element Vector{Any}:
 CodeInfo(
1 ─     nothing::Nothing
└──     return 0
) => Int64
```

It would eventually allow us to eliminate unnecessary branches and prove the `:nothrow`-ness of `::UInt32 >> ::Int32` for example (thus fixing #47835).

There are many possible improvements, such as proving that we will never reach the `return nothing` case in the following example (i.e. by integrating with `Conditional`-lattice):
```julia
julia> code_typed((Int,)) do x
           if x < 3
               if x > 5
                   return nothing
               end
           end
           0
       end
```

This may come with some compilation performance cost. We should run the benchmark and try to minimize latency cost.

@nanosoldier `runbenchmarks("inference", vs=":master")`