### PR TITLE
[Backport] Fix half precision in system image

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -442,7 +442,7 @@ static void injectCRTAlias(Module &M, StringRef name, StringRef alias, FunctionT
     if (!target) {
         target = Function::Create(FT, Function::ExternalLinkage, alias, M);
     }
-    Function *interposer = Function::Create(FT, Function::WeakAnyLinkage, name, M);
+    Function *interposer = Function::Create(FT, Function::InternalLinkage, name, M);
     appendToCompilerUsed(M, {interposer});
 
     llvm::IRBuilder<> builder(BasicBlock::Create(M.getContext(), "top", interposer));


### PR DESCRIPTION
Noticed during #47184, I don't recall why I choose weak, but it causes an ABI mismatch.


