### PR TITLE
Backports for Julia 1.8.5

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -218,6 +218,8 @@ else
 $(eval $(call symlink_system_library,CSL,libgcc_s,1))
 endif
 endif
+else
+$(eval $(call symlink_system_library,CSL,libgcc_s,1))
 endif
 ifneq (,$(LIBGFORTRAN_VERSION))
 $(eval $(call symlink_system_library,CSL,libgfortran,$(LIBGFORTRAN_VERSION)))

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -442,7 +442,7 @@ static void injectCRTAlias(Module &M, StringRef name, StringRef alias, FunctionT
     if (!target) {
         target = Function::Create(FT, Function::ExternalLinkage, alias, M);
     }
-    Function *interposer = Function::Create(FT, Function::WeakAnyLinkage, name, M);
+    Function *interposer = Function::Create(FT, Function::InternalLinkage, name, M);
     appendToCompilerUsed(M, {interposer});
 
     llvm::IRBuilder<> builder(BasicBlock::Create(M.getContext(), "top", interposer));

--- a/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
+++ b/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
@@ -43,11 +43,15 @@ elseif Sys.isapple()
     const libgfortran = string("@rpath/", "libgfortran.", libgfortran_version(HostPlatform()).major, ".dylib")
     const libstdcxx = "@rpath/libstdc++.6.dylib"
     const libgomp = "@rpath/libgomp.1.dylib"
+    const libssp = "@rpath/libssp.0.dylib"
 else
     const libgcc_s = "libgcc_s.so.1"
     const libgfortran = string("libgfortran.so.", libgfortran_version(HostPlatform()).major)
     const libstdcxx = "libstdc++.so.6"
     const libgomp = "libgomp.so.1"
+    if libc(HostPlatform()) != "musl"
+        const libssp = "libssp.so.0"
+    end
 end
 
 function __init__()
@@ -59,7 +63,7 @@ function __init__()
     global libstdcxx_path = dlpath(libstdcxx_handle)
     global libgomp_handle = dlopen(libgomp)
     global libgomp_path = dlpath(libgomp_handle)
-    if Sys.iswindows()
+    @static if libc(HostPlatform()) != "musl"
         global libssp_handle = dlopen(libssp)
         global libssp_path = dlpath(libssp_handle)
     end

--- a/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
+++ b/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
@@ -21,6 +21,8 @@ libstdcxx_handle = C_NULL
 libstdcxx_path = ""
 libgomp_handle = C_NULL
 libgomp_path = ""
+libssp_handle = C_NULL
+libssp_path = ""
 
 if Sys.iswindows()
     if arch(HostPlatform()) == "x86_64"
@@ -31,6 +33,7 @@ if Sys.iswindows()
     const libgfortran = string("libgfortran-", libgfortran_version(HostPlatform()).major, ".dll")
     const libstdcxx = "libstdc++-6.dll"
     const libgomp = "libgomp-1.dll"
+    const libssp = "libssp-0.dll"
 elseif Sys.isapple()
     if arch(HostPlatform()) == "aarch64" || libgfortran_version(HostPlatform()) == v"5"
         const libgcc_s = "@rpath/libgcc_s.1.1.dylib"
@@ -56,6 +59,10 @@ function __init__()
     global libstdcxx_path = dlpath(libstdcxx_handle)
     global libgomp_handle = dlopen(libgomp)
     global libgomp_path = dlpath(libgomp_handle)
+    if Sys.iswindows()
+        global libssp_handle = dlopen(libssp)
+        global libssp_path = dlpath(libssp_handle)
+    end
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libgcc_s_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/CompilerSupportLibraries_jll/test/runtests.jl
+++ b/stdlib/CompilerSupportLibraries_jll/test/runtests.jl
@@ -1,13 +1,13 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Test, CompilerSupportLibraries_jll
+using Test, CompilerSupportLibraries_jll, Base.BinaryPlatforms
 
 @testset "CompilerSupportLibraries_jll" begin
     @test isfile(CompilerSupportLibraries_jll.libgcc_s_path)
     @test isfile(CompilerSupportLibraries_jll.libgfortran_path)
     @test isfile(CompilerSupportLibraries_jll.libstdcxx_path)
     @test isfile(CompilerSupportLibraries_jll.libgomp_path)
-    if Sys.iswindows()
+    if libc(HostPlatform()) != "musl"
         @test isfile(CompilerSupportLibraries_jll.libssp_path)
     end
 end

--- a/stdlib/CompilerSupportLibraries_jll/test/runtests.jl
+++ b/stdlib/CompilerSupportLibraries_jll/test/runtests.jl
@@ -7,4 +7,7 @@ using Test, CompilerSupportLibraries_jll
     @test isfile(CompilerSupportLibraries_jll.libgfortran_path)
     @test isfile(CompilerSupportLibraries_jll.libstdcxx_path)
     @test isfile(CompilerSupportLibraries_jll.libgomp_path)
+    if Sys.iswindows()
+        @test isfile(CompilerSupportLibraries_jll.libssp_path)
+    end
 end

--- a/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
+++ b/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
@@ -47,7 +47,7 @@ function __init__()
        !haskey(ENV, "OMP_NUM_THREADS")
         # We set this to `1` here, and then LinearAlgebra will update
         # to the true value in its `__init__()` function.
-        ENV["OPENBLAS_NUM_THREADS"] = "1"
+        ENV["OPENBLAS_DEFAULT_NUM_THREADS"] = "1"
     end
 
     global libopenblas_handle = dlopen(libopenblas)


### PR DESCRIPTION
Backported PRs:
- [x] #47986 <!-- Restore libgcc_s symlinking in !macOS -->
- [x] #48010 <!-- [Backport] Fix half precision in system image -->
- [x] #48012 
- [x] #48027 
- [x] #47986 <!-- Restore libgcc_s symlinking in !macOS -->
- [x] #48064 <!-- use the correct env variable name to set default openblas num threads -->

Need manual backport:
- [ ] #47865 <!-- Fix missing GC root in Symbol construction -->

Contains multiple commits, manual intervention needed:
- [ ] #46819 <!-- Fix SROA miscompile in large functions -->

Non-merged PRs with backport label:
- [ ] #47636 <!-- Reland: Improve performance of global code by emitting fewer atomic barriers. -->
- [ ] #46801 <!-- improve inferrability of `create_expr_cache` -->