### PR TITLE
[CompilerSupportLibraries_jll] Add `libssp` as product on Windows

### DIFF
--- a/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
+++ b/stdlib/CompilerSupportLibraries_jll/src/CompilerSupportLibraries_jll.jl
@@ -21,6 +21,8 @@ libstdcxx_handle = C_NULL
 libstdcxx_path = ""
 libgomp_handle = C_NULL
 libgomp_path = ""
+libssp_handle = C_NULL
+libssp_path = ""
 
 if Sys.iswindows()
     if arch(HostPlatform()) == "x86_64"
@@ -31,6 +33,7 @@ if Sys.iswindows()
     const libgfortran = string("libgfortran-", libgfortran_version(HostPlatform()).major, ".dll")
     const libstdcxx = "libstdc++-6.dll"
     const libgomp = "libgomp-1.dll"
+    const libssp = "libssp-0.dll"
 elseif Sys.isapple()
     if arch(HostPlatform()) == "aarch64" || libgfortran_version(HostPlatform()) == v"5"
         const libgcc_s = "@rpath/libgcc_s.1.1.dylib"
@@ -56,6 +59,10 @@ function __init__()
     global libstdcxx_path = dlpath(libstdcxx_handle)
     global libgomp_handle = dlopen(libgomp)
     global libgomp_path = dlpath(libgomp_handle)
+    if Sys.iswindows()
+        global libssp_handle = dlopen(libssp)
+        global libssp_path = dlpath(libssp_handle)
+    end
     global artifact_dir = dirname(Sys.BINDIR)
     LIBPATH[] = dirname(libgcc_s_path)
     push!(LIBPATH_list, LIBPATH[])

--- a/stdlib/CompilerSupportLibraries_jll/test/runtests.jl
+++ b/stdlib/CompilerSupportLibraries_jll/test/runtests.jl
@@ -7,4 +7,7 @@ using Test, CompilerSupportLibraries_jll
     @test isfile(CompilerSupportLibraries_jll.libgfortran_path)
     @test isfile(CompilerSupportLibraries_jll.libstdcxx_path)
     @test isfile(CompilerSupportLibraries_jll.libgomp_path)
+    if Sys.iswindows()
+        @test isfile(CompilerSupportLibraries_jll.libssp_path)
+    end
 end


### PR DESCRIPTION
Background is https://discourse.julialang.org/t/glmakie-and-plots-fail-to-precompile-under-julia-1-8-4/92087.  To summarise:

* libcairo [requires libssp](https://github.com/JuliaPackaging/Yggdrasil/blob/7eddf232436b72bd2c979ce59b62267436428e2b/C/Cairo/build_tarballs.jl#L19-L29) on Windows
* somehow, `libssp-0.dll` [was loaded automatically](https://discourse.julialang.org/t/glmakie-and-plots-fail-to-precompile-under-julia-1-8-4/92087/29) when loading libllvm until julia v1.8.3, only on Windows; on macOS and Linux I don’t see libssp loaded at any point
* this doesn’t happen anymore with julia v1.8.4+, which means that libcairo can’t find libssp any longer on Windows, unless the directory where libssp is located is in `PATH`

This PR explicitly adds `libssp` to the products of `CompilerSupportLibraries_jll` on Windows so that we can ensure this library is loaded when `CompilerSupportLibraries_jll` is used.