### PR TITLE
Doc-fix: documentation in non-toplevel blocks

### DIFF
--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -310,18 +310,18 @@ end
 @doc "`subtract(a,b)` subtracts `b` from `a`" subtract
 ```
 
-Documentation written in non-toplevel blocks, such as `begin`, `if`, `for`, and `let`, is
-added to the documentation system as blocks are evaluated. For example:
+Documentation in non-toplevel blocks, such as `begin`, `if`, `for`, and `let`, should be
+added to the documentation system via `@doc` as well. For example:
 
 ```julia
 if condition()
-    "..."
+    @doc "..."
     f(x) = x
 end
 ```
 
 will add documentation to `f(x)` when `condition()` is `true`. Note that even if `f(x)` goes
-out of scope at the end of the block, its documentation will remain.
+out of scope at the end of a block, its documentation will remain.
 
 It is possible to make use of metaprogramming to assist in the creation of documentation.
 When using string-interpolation within the docstring you will need to use an extra `$` as


### PR DESCRIPTION
The previous statement and example were incorrect:

> Documentation written in non-toplevel blocks, such as begin, if, for, and let, is added to the documentation system as blocks are evaluated. For example:
> 
> ```julia
> if condition()
>     "..."
>     f(x) = x
> end
> ```
> 
> will add documentation to f(x) when condition() is true. Note that even if f(x) goes out of scope at the end of the block, its documentation will remain.

```julia
julia> if true
           "..."
           f(x) = x
       end
f (generic function with 1 method)

help?> f
search: f fd for fma fld fld1 fill fdio frexp foldr foldl flush floor float first fill! fetch fldmod filter falses finally foreach fldmod1 findmin findmax findall filter! function Float64 Float32

  No documentation found.

  f is a Function.

  # 1 method for generic function "f":
  [1] f(x) in Main at REPL[1]:3
```

The simplest fix is to just put `@doc` in front of the docstring which is what the docs are saying with this PR.

(cc @pfitzseb)