### PR TITLE
replace broken link in manual

### DIFF
--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -137,7 +137,7 @@ ERROR: syntax: unexpected "="
 
 Some Unicode characters are considered to be equivalent in identifiers.
 Different ways of entering Unicode combining characters (e.g., accents)
-are treated as equivalent (specifically, Julia identifiers are [NFC](https://www.macchiato.com/unicode-intl-sw/nfc-faq)-normalized).
+are treated as equivalent (specifically, Julia identifiers are [NFC](https://en.wikipedia.org/wiki/Unicode_equivalence).
 Julia also includes a few non-standard equivalences for characters that are
 visually similar and are easily entered by some input methods. The Unicode
 characters `ɛ` (U+025B: Latin small letter open e) and `µ` (U+00B5: micro sign)


### PR DESCRIPTION
The old link to a page explaining NFC normalization is broken, so I replaced it with https://en.wikipedia.org/wiki/Unicode_equivalence
