### PR TITLE
Avoid some stackoverflow during typeintersect.

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2150,6 +2150,9 @@ static jl_value_t *intersect_aside(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, 
         return y;
     if (y == (jl_value_t*)jl_any_type && !jl_is_typevar(x))
         return x;
+    // band-aid for #46736
+    if (jl_egal(x, y))
+        return x;
 
     jl_saved_unionstate_t oldRunions; push_unionstate(&oldRunions, &e->Runions);
     int savedepth = e->invdepth, Rsavedepth = e->Rinvdepth;

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2286,6 +2286,16 @@ T46784{B<:Val, M<:AbstractMatrix} = Tuple{<:Union{B, <:Val{<:B}}, M, Union{Abstr
 @testintersect(T46784{T,S} where {T,S}, T46784, !Union{})
 @test_broken T46784 <: T46784{T,S} where {T,S}
 
+#issue 36185
+let S = Tuple{Type{T},Array{Union{T,Missing},N}} where {T,N},
+    T = Tuple{Type{T},Array{Union{T,Nothing},N}} where {T,N}
+    @testintersect(S, T, !Union{})
+    I = typeintersect(S, T)
+    @test (Tuple{Type{Any},Array{Any,N}} where {N}) <: I
+    @test_broken I <: S
+    @test_broken I <: T
+end
+
 @testset "known subtype/intersect issue" begin
     #issue 45874
     # Causes a hang due to jl_critical_error calling back into malloc...
@@ -2312,10 +2322,6 @@ T46784{B<:Val, M<:AbstractMatrix} = Tuple{<:Union{B, <:Val{<:B}}, M, Union{Abstr
     A = Tuple{Tuple{Int, Int, Vararg{Int, N}}, Tuple{Int, Vararg{Int, N}}, Tuple{Vararg{Int, N}}} where N
     B = Tuple{NTuple{N, Int}, NTuple{N, Int}, NTuple{N, Int}} where N
     @test_broken !(A <: B)
-
-    #issue 36185
-    @test_broken typeintersect((Tuple{Type{T},Array{Union{T,Missing},N}} where {T,N}),
-                               (Tuple{Type{T},Array{Union{T,Nothing},N}} where {T,N})) <: Any
 
     #issue 35698
     @test_broken typeintersect(Type{Tuple{Array{T,1} where T}}, UnionAll) != Union{}

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2304,6 +2304,16 @@ let S = Tuple{Val{T}, T} where {S1,T<:Val{Union{Nothing,S1}}},
     @test_broken testintersect(S, T) == Tuple{Val{Val{Union{Nothing, S1}}}, Val{Union{Nothing, S1}}} where S1<:(Union{Nothing, S2} where S2)
 end
 
+#issue #47874:case1
+let S1 = Tuple{Int, Any, Union{Val{C1}, C1}} where {R1<:Real, C1<:Union{Complex{R1}, R1}},
+    S2 = Tuple{Int, Any, Union{Val{C1}, C1} where {R1<:Real, C1<:Union{Complex{R1}, R1}}},
+    T1 = Tuple{Any, Int, Union{Val{C2}, C2}} where {R2<:Real, C2<:Union{Complex{R2}, R2}},
+    T2 = Tuple{Any, Int, V} where {R2<:Real, C2<:Union{Complex{R2}, R2}, V<:Union{Val{C2}, C2}}
+    for S in (S1, S2), T in (T1, T2)
+        @testintersect(S, T, !Union{})
+    end
+end
+
 @testset "known subtype/intersect issue" begin
     #issue 45874
     # Causes a hang due to jl_critical_error calling back into malloc...

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2296,6 +2296,14 @@ let S = Tuple{Type{T},Array{Union{T,Missing},N}} where {T,N},
     @test_broken I <: T
 end
 
+#issue 46736
+let S = Tuple{Val{T}, T} where {S1,T<:Val{Union{Nothing,S1}}},
+    T = Tuple{Val{Val{Union{Nothing, S2}}}, Any} where S2
+    @testintersect(S, T, !Union{})
+    # not ideal (`S1` should be unbounded)
+    @test_broken testintersect(S, T) == Tuple{Val{Val{Union{Nothing, S1}}}, Val{Union{Nothing, S1}}} where S1<:(Union{Nothing, S2} where S2)
+end
+
 @testset "known subtype/intersect issue" begin
     #issue 45874
     # Causes a hang due to jl_critical_error calling back into malloc...


### PR DESCRIPTION
When I dig in #46736, I found that `subtype_in_env_existential` is somehow dangous as we flip all typevar to the right side.
I tried to follow #48006 style but it caused many test failure. So this PR just makes the following change to avoid some known stackoverflow:
1. Make sure `env` is restored between 2 adjacent `subtype_in_env_existential`. Thus the second subtype check wont be influenced by the first one. (close #36185)
2. Add a fast path to skip the repeated `intersect_aside` (close #46736.)
