### PR TITLE
Switch where LimitedAccuracy sits in the ⊑ lattice

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -135,6 +135,8 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
                     if const_call_result.rt ⊑ₚ rt
                         rt = const_call_result.rt
                         (; effects, const_result, edge) = const_call_result
+                    else
+                        add_remark!(interp, sv, "[constprop] Discarded because the result was wider than inference")
                     end
                 end
                 all_effects = merge_effects(all_effects, effects)
@@ -169,6 +171,8 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
                     this_conditional = this_const_conditional
                     this_rt = this_const_rt
                     (; effects, const_result, edge) = const_call_result
+                else
+                    add_remark!(interp, sv, "[constprop] Discarded because the result was wider than inference")
                 end
             end
             all_effects = merge_effects(all_effects, effects)
@@ -535,6 +539,7 @@ end
 
 const RECURSION_UNUSED_MSG = "Bounded recursion detected with unused result. Annotated return type may be wider than true result."
 const RECURSION_MSG = "Bounded recursion detected. Call was widened to force convergence."
+const RECURSION_MSG_HARDLIMIT = "Bounded recursion detected under hardlimit. Call was widened to force convergence."
 
 function abstract_call_method(interp::AbstractInterpreter, method::Method, @nospecialize(sig), sparams::SimpleVector, hardlimit::Bool, si::StmtInfo, sv::InferenceState)
     if method.name === :depwarn && isdefined(Main, :Base) && method.module === Main.Base
@@ -573,6 +578,7 @@ function abstract_call_method(interp::AbstractInterpreter, method::Method, @nosp
             end
         end
     end
+    washardlimit = hardlimit
 
     if topmost !== nothing
         sigtuple = unwrap_unionall(sig)::DataType
@@ -611,7 +617,11 @@ function abstract_call_method(interp::AbstractInterpreter, method::Method, @nosp
                 # (non-typically, this means that we lose the ability to detect a guaranteed StackOverflow in some cases)
                 return MethodCallResult(Any, true, true, nothing, Effects())
             end
-            add_remark!(interp, sv, RECURSION_MSG)
+            if washardlimit
+                add_remark!(interp, sv, RECURSION_MSG_HARDLIMIT)
+            else
+                add_remark!(interp, sv, RECURSION_MSG)
+            end
             topmost = topmost::InferenceState
             parentframe = topmost.parent
             poison_callstack(sv, parentframe === nothing ? topmost : parentframe)

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -366,16 +366,16 @@ ignorelimited(typ::LimitedAccuracy) = typ.typ
 # =============
 
 function ⊑(lattice::InferenceLattice, @nospecialize(a), @nospecialize(b))
-    if isa(b, LimitedAccuracy)
-        if !isa(a, LimitedAccuracy)
+    if isa(a, LimitedAccuracy)
+        if !isa(b, LimitedAccuracy)
             return false
         end
         if b.causes ⊈ a.causes
             return false
         end
-        b = b.typ
+        a = a.typ
     end
-    isa(a, LimitedAccuracy) && (a = a.typ)
+    isa(b, LimitedAccuracy) && (b = b.typ)
     return ⊑(widenlattice(lattice), a, b)
 end
 

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4701,3 +4701,11 @@ let # jl_widen_core_extended_info
               widened
     end
 end
+
+# This is somewhat sensitive to the exact recursion level that inference is willing to do, but the intention
+# is to test the case where inference limited a recursion, but then a forced constprop nevertheless managed
+# to terminate the call.
+@Base.constprop :aggressive type_level_recurse1(x...) = x[1] == 2 ? 1 : (length(x) > 100 ? x : type_level_recurse2(x[1] + 1, x..., x...))
+@Base.constprop :aggressive type_level_recurse2(x...) = type_level_recurse1(x...)
+type_level_recurse_entry() = Val{type_level_recurse1(1)}()
+@test Base.return_types(type_level_recurse_entry, ()) |> only == Val{1}


### PR DESCRIPTION
I was investigating some suboptimal inference in Diffractor (which due to its recursive structure over the order of the taken derivative likes to tickle recursion limiting) and noticed that inference was performing some constant propagation, but then discarding the result. Upon further investigation, it turned out that inference had determined the function to be `LimitedAccuracy(...)`, but constprop found out it actually returned `Const`. Now, ordinarily, we don't constprop functions that inference determined to be `LimitedAccuracy`, but this function happened to have `@constprop :aggressive` annotated.

Of course, if constprop determines that the function actually terminates, we do want to use that information. We could hardcode this in abstract_call_gf_by_type, but it made me take a closer look at the lattice operations for `LimitedAccuracy`, since in theory `abstract_call_gf_by_type` should prefer a more precise result.

It appears that currently `LimitedAccuracy` is considered epsilon smaller than the type it wraps, and only other `LimitedAccuracy` elements it below it (other than Union{}). However, `tmerge` unions together limit accuracy causes. This doesn't quite make sense to me. If `LimitedAccuracy` is smaller than the corresponding type, then `tmerge(LimitedAccuracy(T), T)` is supposed to return `T`.

However, our definition of it returns `LimitedAccuracy(T)` (if not going through the fastpath). This would be much more sensible if `LimitedAccuracy` were epislon larger than the type. I think this makes sense in general since larger types (in the subtype lattice) are less precise. Switching this around also fixes my inference imprecision, so unless I'm missing something here, I think ordering makes sense.