### PR TITLE
Don't double-count inference time

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -1938,7 +1938,7 @@ typedef struct _jl_task_t {
     size_t bufsz; // actual sizeof stkbuf
     uint64_t inference_start_time; // time when inference started
     uint16_t reentrant_inference; // How many times we've reentered inference
-    uint16_t reentrant_codegen; // How many times we've reentered codegen
+    uint16_t reentrant_timing; // How many times we've reentered timing
     unsigned int copy_stack:31; // sizeof stack for copybuf
     unsigned int started:1;
 } jl_task_t;

--- a/src/task.c
+++ b/src/task.c
@@ -938,7 +938,7 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, jl_value_t *completion
     t->threadpoolid = ct->threadpoolid;
     t->ptls = NULL;
     t->world_age = ct->world_age;
-    t->reentrant_codegen = 0;
+    t->reentrant_timing = 0;
     t->reentrant_inference = 0;
     t->inference_start_time = 0;
 
@@ -1526,7 +1526,7 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     ct->sticky = 1;
     ct->ptls = ptls;
     ct->world_age = 1; // OK to run Julia code on this task
-    ct->reentrant_codegen = 0;
+    ct->reentrant_timing = 0;
     ct->reentrant_inference = 0;
     ct->inference_start_time = 0;
     ptls->root_task = ct;

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -353,12 +353,48 @@ end
 
 after_comp, after_recomp = Base.cumulative_compile_time_ns() # no need to turn timing off, @time will do that
 @test after_comp >= before_comp;
+@test after_recomp >= before_recomp;
+@test after_recomp - before_recomp <= after_comp - before_comp;
 
 # should be approximately 60,000,000 ns, we definitely shouldn't exceed 100x that value
 # failing this probably means an uninitialized variable somewhere
 @test after_comp - before_comp < 6_000_000_000;
 
 end # redirect_stdout
+
+# issue #48024, avoid overcounting timers
+begin
+    double(x::Real) = 2x;
+    calldouble(container) = double(container[1]);
+    calldouble2(container) = calldouble(container);
+
+    Base.Experimental.@force_compile;
+    local elapsed = Base.time_ns();
+    Base.cumulative_compile_timing(true);
+    local compiles = Base.cumulative_compile_time_ns();
+    @eval calldouble([1.0]);
+    Base.cumulative_compile_timing(false);
+    compiles = Base.cumulative_compile_time_ns() .- compiles;
+    elapsed = Base.time_ns() - elapsed;
+
+    # compile time should be at most total time
+    @test compiles[1] <= elapsed
+    # recompile time should be at most compile time
+    @test compiles[2] <= compiles[1]
+
+    elapsed = Base.time_ns();
+    Base.cumulative_compile_timing(true);
+    compiles = Base.cumulative_compile_time_ns();
+    @eval calldouble(1.0);
+    Base.cumulative_compile_timing(false);
+    compiles = Base.cumulative_compile_time_ns() .- compiles;
+    elapsed = Base.time_ns() - elapsed;
+
+    # compile time should be at most total time
+    @test compiles[1] <= elapsed
+    # recompile time should be at most compile time
+    @test compiles[2] <= compiles[1]
+end
 
 macro capture_stdout(ex)
     quote


### PR DESCRIPTION
Fixes #48024

During #46825, the timing code was updated to use task-local state instead of unsynchronized globals. Unfortunately, one of the pieces of timing code ended up using a different state tracker than the other timers, which led to the overcounting in #48024. That is fixed here + a test.