### PR TITLE
fix typo in "let" docstring

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -487,7 +487,7 @@ Additionally, the syntax has a special meaning for comma-separated assignments
 and variable names that may optionally appear on the same line as the `let`:
 
 ```julia
-let var1 = value1, var2, var3 = value3
+let var1 = value1, var2 = value2, var3 = value3
     code
 end
 ```


### PR DESCRIPTION
Noted [on discourse](https://discourse.julialang.org/t/syntax-how-to-write-a-cleaner-code-for-many-composed-computations/92211/12?u=stevengj).

Seems like it dates all the way back to #13217 in 2015!