### PR TITLE
Don't perform extra inference during incremental image creation

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -447,6 +447,10 @@ for m in methods(include)
     delete_method(m)
 end
 
+# This method is here only to be overwritten during the test suite to test
+# various sysimg related invalidation scenarios.
+a_method_to_overwrite_in_test() = inferencebarrier(1)
+
 # These functions are duplicated in client.jl/include(::String) for
 # nicer stacktraces. Modifications here have to be backported there
 include(mod::Module, _path::AbstractString) = _include(identity, mod, _path)

--- a/src/gf.c
+++ b/src/gf.c
@@ -280,6 +280,13 @@ jl_code_info_t *jl_type_infer(jl_method_instance_t *mi, size_t world, int force)
     if (jl_typeinf_func == NULL)
         return NULL;
     jl_task_t *ct = jl_current_task;
+    if (ct->reentrant_inference == (uint16_t)-1) {
+        // TODO: We should avoid attempting to re-inter inference here at all
+        // and turn on this warning, but that requires further refactoring
+        // of the precompile code, so for now just catch that case here.
+        //jl_printf(JL_STDERR, "ERROR: Attempted to enter inference while writing out image.");
+        return NULL;
+    }
     if (ct->reentrant_inference > 2)
         return NULL;
 

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1691,6 +1691,23 @@ precompile_test_harness("DynamicExpressions") do load_path
     end
 end
 
+precompile_test_harness("BadInvalidations") do load_path
+    write(joinpath(load_path, "BadInvalidations.jl"),
+    """
+    module BadInvalidations
+        Base.Experimental.@compiler_options compile=min optimize=1
+        getval() = Base.a_method_to_overwrite_in_test()
+        getval()
+    end # module BadInvalidations
+    """)
+    Base.compilecache(Base.PkgId("BadInvalidations"))
+    (@eval Base a_method_to_overwrite_in_test() = inferencebarrier(2))
+    (@eval (using BadInvalidations))
+    Base.invokelatest() do
+        @test BadInvalidations.getval() === 2
+    end
+end
+
 empty!(Base.DEPOT_PATH)
 append!(Base.DEPOT_PATH, original_depot_path)
 empty!(Base.LOAD_PATH)


### PR DESCRIPTION
As noted in #48047, we're currently attempting to infer extra methods during incremental image saving, which causes us to miss edges in the image. In particular, in the case of #48047, Cthulhu had the `compile=min` option set, which caused the code instance for `do_typeinf!` to not be infered. However, later it was nevertheless queued for precompilation, causing inference to occur at an inopportune time.

This PR simply prevents code instances that don't explicitly have the `->precompile` flag set (e.g. the guard instance created for the interpreter) from being enqueued for precompilation. It is not clear that this is necessarily the correct behavior - we may in fact want to infer these method instances, just before we set up the serializer state, but for now this fixes #48047 for me.

I also included an appropriate test and a warning message if we attempt to enter inference when this is not legal, so any revisit of what should be happening here can hopefully make use of those.