### PR TITLE
Hook up effect modeling for `TypeVar` and `UnionAll`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1848,7 +1848,7 @@ function abstract_call_unionall(argtypes::Vector{Any})
             return CallMeta(Any, Effects(EFFECTS_TOTAL; nothrow), NoCallInfo())
         end
         if !isa(body, Type) && !isa(body, TypeVar)
-            return CallMeta(Any, Effects(EFFECTS_TOTAL; nothrow=false), NoCallInfo())
+            return CallMeta(Any, EFFECTS_THROWS, NoCallInfo())
         end
         if has_free_typevars(body)
             if isa(a2, Const)
@@ -1857,9 +1857,9 @@ function abstract_call_unionall(argtypes::Vector{Any})
                 tv = a2.tv
                 canconst = false
             else
-                return CallMeta(Any, Effects(EFFECTS_TOTAL; nothrow=false), NoCallInfo())
+                return CallMeta(Any, EFFECTS_THROWS, NoCallInfo())
             end
-            !isa(tv, TypeVar) && return CallMeta(Any, Effects(EFFECTS_TOTAL; nothrow=false), NoCallInfo())
+            !isa(tv, TypeVar) && return CallMeta(Any, EFFECTS_THROWS, NoCallInfo())
             body = UnionAll(tv, body)
         end
         ret = canconst ? Const(body) : Type{body}

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -2117,6 +2117,7 @@ const _INACCESSIBLEMEM_BUILTINS = Any[
     typeassert,
     typeof,
     compilerbarrier,
+    Core._typevar
 ]
 
 const _ARGMEM_BUILTINS = Any[


### PR DESCRIPTION
We already had effect modeling for `_typevar`, which `TypeVar` should just defer to. Add a simple model for `UnionAll` as well, though in the future we can add the Vararg case also.