### PR TITLE
use the correct env variable name to set default openblas num threads

### DIFF
--- a/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
+++ b/stdlib/OpenBLAS_jll/src/OpenBLAS_jll.jl
@@ -47,7 +47,7 @@ function __init__()
        !haskey(ENV, "OMP_NUM_THREADS")
         # We set this to `1` here, and then LinearAlgebra will update
         # to the true value in its `__init__()` function.
-        ENV["OPENBLAS_NUM_THREADS"] = "1"
+        ENV["OPENBLAS_DEFAULT_NUM_THREADS"] = "1"
     end
 
     global libopenblas_handle = dlopen(libopenblas)


### PR DESCRIPTION
It looks to me like this is a typo and causes OpenBLAS to be limited to a single thread if OpenBLAS_jll is in the sysimage (which it is on 1.9 (but not 1.8)).

Fixes JuliaLang/LinearAlgebra.jl#976 