### PR TITLE
use invokelatest to prevent invalidations in TOML

### DIFF
--- a/stdlib/TOML/src/print.jl
+++ b/stdlib/TOML/src/print.jl
@@ -126,7 +126,7 @@ is_array_of_tables(value) = isa(value, AbstractArray) &&
                                 isa(value, AbstractArray{<:AbstractDict}) ||
                                 all(v -> isa(v, AbstractDict), value)
                             )
-is_tabular(value)         = is_table(value) || is_array_of_tables(value)
+is_tabular(value)         = is_table(value) || @invokelatest(is_array_of_tables(value))
 
 function print_table(f::MbyFunc, io::IO, a::AbstractDict,
     ks::Vector{String} = String[];
@@ -176,7 +176,7 @@ function print_table(f::MbyFunc, io::IO, a::AbstractDict,
             # Use runtime dispatch here since the type of value seems not to be enforced other than as AbstractDict
             @invokelatest print_table(f, io, value, ks; indent = indent + header, first_block = header, sorted=sorted, by=by)
             pop!(ks)
-        elseif is_array_of_tables(value)
+        elseif @invokelatest(is_array_of_tables(value))
             # print array of tables
             first_block || println(io)
             first_block = false


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/47876 added some 400 invalidations to `using CSV`. This removes them. 