### PR TITLE
RFC: curried `reshape`?

### DIFF
--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -154,6 +154,7 @@ end
 
 """
     reshape(size...) -> Function
+    reshape(dims::Tuple) -> Function
 
 Create a function that reshapes its argument using the given size,
 equivalent to `x -> reshape(x, size...)`. At most one argument may
@@ -172,11 +173,33 @@ julia> stack(reshape(2,3), eachrow(rand(7,6))) |> size
 (2, 3, 7)
 ```
 
-!!! compat "Julia 1.10"
-    This functionality requires at least Julia 1.10.
+Also accepts a tuple: `reshape((2,3)) == reshape(2,3)`.
+This method allows the use of `axes` instead of `size`,
+especially for OffsetArrays.
+
+```
+julia> reshape(7:9, Base.OneTo(1), Base.OneTo(3))  # reshapes the first argument
+1×3 reshape(::UnitRange{Int64}, 1, 3) with eltype Int64:
+ 7  8  9
+
+julia> reshape((7:9, Base.OneTo(1), Base.OneTo(3)))  # 3 axes of an OffsetArray
+(::Base.Fix2{typeof(reshape), Tuple{UnitRange{Int64}, Base.OneTo{Int64}, Base.OneTo{Int64}}}) (generic function with 1 method)
+```
+
+!!! compat "Julia 1.11"
+    This functionality requires at least Julia 1.11.
 """
 reshape(size::Integer...) = Base.Fix2(reshape, size)
+reshape(size::Tuple{Vararg{Integer}}) = Base.Fix2(reshape, size)
+reshape(size::Tuple{Vararg{AbstractUnitRange{<:Integer}}}) = Base.Fix2(reshape, size)
+
 function reshape(dims::Union{Integer,Colon}...)
+    count(s -> s isa Colon, dims) > 1 && throw(DimensionMismatch(string("new dimensions ",
+        dims, " may have at most one omitted dimension specified by `Colon()`")))
+    Base.Fix2(reshape, dims)
+end
+reshape(dims::Tuple{Vararg{Union{Integer,Colon}}}) = reshape(dims...)
+function reshape(dims::Tuple{Vararg{Union{AbstractUnitRange{<:Integer},Colon}}})
     count(s -> s isa Colon, dims) > 1 && throw(DimensionMismatch(string("new dimensions ",
         dims, " may have at most one omitted dimension specified by `Colon()`")))
     Base.Fix2(reshape, dims)

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -152,6 +152,36 @@ function reshape(parent::AbstractArray, ndims::Val{N}) where N
     reshape(parent, rdims(Val(N), axes(parent)))
 end
 
+"""
+    reshape(size...) -> Function
+
+Create a function that reshapes its argument using the given size,
+equivalent to `x -> reshape(x, size...)`. At most one argument may
+be a colon, and `reshape(:)` is equivalent to [`vec`](@ref).
+The returned function is of type `Base.Fix2{typeof(reshape)}`.
+
+# Examples
+
+```jldoctest
+julia> 'a':'z' |> reshape(2, :)
+2×13 reshape(::StepRange{Char, Int64}, 2, 13) with eltype Char:
+ 'a'  'c'  'e'  'g'  'i'  'k'  'm'  'o'  'q'  's'  'u'  'w'  'y'
+ 'b'  'd'  'f'  'h'  'j'  'l'  'n'  'p'  'r'  't'  'v'  'x'  'z'
+
+julia> stack(reshape(2,3), eachrow(rand(7,6))) |> size
+(2, 3, 7)
+```
+
+!!! compat "Julia 1.10"
+    This functionality requires at least Julia 1.10.
+"""
+reshape(size::Integer...) = Base.Fix2(reshape, size)
+function reshape(dims::Union{Integer,Colon}...)
+    count(s -> s isa Colon, dims) > 1 && throw(DimensionMismatch(string("new dimensions ",
+        dims, " may have at most one omitted dimension specified by `Colon()`")))
+    Base.Fix2(reshape, dims)
+end
+
 # Move elements from inds to out until out reaches the desired
 # dimensionality N, either filling with OneTo(1) or collapsing the
 # product of trailing dims into the last element


### PR DESCRIPTION
Sometimes you want to pipe something to a reshape which isn't `vec`. This makes a `Fix2` which allows:

```julia
julia> 'a':'z' |> reshape(2, :)
2×13 reshape(::StepRange{Char, Int64}, 2, 13) with eltype Char:
 'a'  'c'  'e'  'g'  'i'  'k'  'm'  'o'  'q'  's'  'u'  'w'  'y'
 'b'  'd'  'f'  'h'  'j'  'l'  'n'  'p'  'r'  't'  'v'  'x'  'z'

julia> stack(reshape(2,3), eachrow(rand(7,6))) |> size
(2, 3, 7)
```

I think this should be safe since there are no methods to reshape a number. 

(What it cannot do is change what `reshape(Base.OneTo(4), Base.OneTo(2), Base.OneTo(2))` means, so it can't easily extend to OffsetArrays.)

This is quite different from the many curried predicate functions like `isequal(2)`, but is more like `filter(iseven)` (from #41173) or `getproperty(:x)` (#46855) perhaps. Not too sure what the policy is. 