### PR TITLE
RFC: add default `dims` to `eachslice`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -73,6 +73,7 @@ New library features
 * `tempname` can now take a suffix string to allow the file name to include a suffix and include that suffix in
   the uniquing checking ([#53474])
 * `RegexMatch` objects can now be used to construct `NamedTuple`s and `Dict`s ([#50988])
+* `eachslice(A)` now has a default `dims=ndims(A)`, making it the inverse of `stack` ([#48108])
 
 Standard library changes
 ------------------------

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -75,11 +75,11 @@ end
 end
 
 """
-    eachslice(A::AbstractArray; dims, drop=true)
+    eachslice(A::AbstractArray; dims=ndims(A), drop=true)
 
 Create a [`Slices`](@ref) object that is an array of slices over dimensions `dims` of `A`, returning
-views that select all the data from the other dimensions in `A`. `dims` can either be an
-integer or a tuple of integers.
+views that select all the data from the other dimensions in `A`. Keyword `dims` can either be an
+integer or a tuple of integers, and defaults to `ndims(A)`.
 
 If `drop = true` (the default), the outer `Slices` will drop the inner dimensions, and
 the ordering of the dimensions will match those in `dims`. If `drop = false`, then the
@@ -95,6 +95,10 @@ See also [`eachrow`](@ref), [`eachcol`](@ref), [`mapslices`](@ref) and [`selectd
 
 !!! compat "Julia 1.9"
      Prior to Julia 1.9, this returned an iterator, and only a single dimension `dims` was supported.
+     The keyword `drop` was not supported.
+
+!!! compat "Julia 1.12"
+     Prior to Julia 1.12, they keyword `dims` had no default.
 
 # Examples
 
@@ -105,23 +109,38 @@ julia> m = [1 2 3; 4 5 6; 7 8 9]
  4  5  6
  7  8  9
 
-julia> s = eachslice(m, dims=1)
+julia> c = eachslice(m)  # dims=2, same as eachcol(m)
+3-element ColumnSlices{Matrix{Int64}, Tuple{Base.OneTo{Int64}}, SubArray{Int64, 1, Matrix{Int64}, Tuple{Base.Slice{Base.OneTo{Int64}}, Int64}, true}}:
+ [1, 4, 7]
+ [2, 5, 8]
+ [3, 6, 9]
+
+julia> c[end]
+3-element view(::Matrix{Int64}, :, 3) with eltype Int64:
+ 3
+ 6
+ 9
+
+julia> stack(c) == m
+true
+
+julia> s = eachslice(m, dims=1)  # same as eachrow(m)
 3-element RowSlices{Matrix{Int64}, Tuple{Base.OneTo{Int64}}, SubArray{Int64, 1, Matrix{Int64}, Tuple{Int64, Base.Slice{Base.OneTo{Int64}}}, true}}:
  [1, 2, 3]
  [4, 5, 6]
  [7, 8, 9]
 
-julia> s[1]
-3-element view(::Matrix{Int64}, 1, :) with eltype Int64:
- 1
- 2
- 3
+julia> stack(s; dims=1) == m
+true
 
-julia> eachslice(m, dims=1, drop=false)
+julia> s2 = eachslice(m, dims=1, drop=false)  # container is 3×1 now
 3×1 Slices{Matrix{Int64}, Tuple{Int64, Colon}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}, SubArray{Int64, 1, Matrix{Int64}, Tuple{Int64, Base.Slice{Base.OneTo{Int64}}}, true}, 2}:
  [1, 2, 3]
  [4, 5, 6]
  [7, 8, 9]
+
+julia> s2[1] == s[1]
+true
 ```
 """
 @inline function eachslice(A; dims=ndims(A), drop=true)

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -124,7 +124,7 @@ julia> eachslice(m, dims=1, drop=false)
  [7, 8, 9]
 ```
 """
-@inline function eachslice(A; dims, drop=true)
+@inline function eachslice(A; dims=ndims(A), drop=true)
     _eachslice(A, dims, drop)
 end
 
@@ -165,6 +165,7 @@ julia> s[1]
 """
 eachrow(A::AbstractMatrix) = _eachslice(A, (1,), true)
 eachrow(A::AbstractVector) = eachrow(reshape(A, size(A,1), 1))
+eachrow(A::AbstractArray) = _eachslice(A, (1, ntuple(d -> d+2, ndims(A)-2)...), true)
 
 """
     eachcol(A::AbstractVecOrMat) <: AbstractVector
@@ -203,6 +204,7 @@ julia> s[1]
 """
 eachcol(A::AbstractMatrix) = _eachslice(A, (2,), true)
 eachcol(A::AbstractVector) = eachcol(reshape(A, size(A, 1), 1))
+eachcol(A::AbstractArray) = _eachslice(A, ntuple(d -> d+1, ndims(A)-1), true)
 
 """
     RowSlices{M,AX,S}

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -184,7 +184,6 @@ julia> s[1]
 """
 eachrow(A::AbstractMatrix) = _eachslice(A, (1,), true)
 eachrow(A::AbstractVector) = eachrow(reshape(A, size(A,1), 1))
-eachrow(A::AbstractArray) = _eachslice(A, (1, ntuple(d -> d+2, ndims(A)-2)...), true)
 
 """
     eachcol(A::AbstractVecOrMat) <: AbstractVector
@@ -223,7 +222,6 @@ julia> s[1]
 """
 eachcol(A::AbstractMatrix) = _eachslice(A, (2,), true)
 eachcol(A::AbstractVector) = eachcol(reshape(A, size(A, 1), 1))
-eachcol(A::AbstractArray) = _eachslice(A, ntuple(d -> d+1, ndims(A)-1), true)
 
 """
     RowSlices{M,AX,S}

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2330,7 +2330,7 @@ end
     # Simple ones
     M = [1 2 3; 4 5 6; 7 8 9]
     @test eachrow(M) == eachslice(M, dims = 1) == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-    @test eachcol(M) == eachslice(M, dims = 2) == [[1, 4, 7], [2, 5, 8], [3, 6, 9]]
+    @test eachcol(M) == eachslice(M, dims = 2) == [[1, 4, 7], [2, 5, 8], [3, 6, 9]] == eachslice(M)
     @test_throws DimensionMismatch eachslice(M, dims = 4)
 
     SR = @inferred eachrow(M)
@@ -2344,6 +2344,8 @@ end
     SC[3] = [23,26,29]
     @test SC[3] == M[:,3] == [23,26,29]
     @test parent(SC) === M
+
+    @test SC === @inferred eachslice(M)  # default dims
 
     # Higher-dimensional cases
     M = reshape(collect(1:16), (2,2,2,2))
@@ -2379,6 +2381,11 @@ end
     @test S32K isa AbstractSlices{<:AbstractArray{Int, 2}, 4}
     @test size(S32K) == (1,2,2,1)
     @test S32K[1,2,1,1] == M[:,2,1,:]
+
+    S3 = eachslice(M)
+    @test S3 isa AbstractSlices{<:AbstractArray{Int, 3}, 1}
+    @test size(S3) == (2,)
+    @test S3[1] == M[:,:,:,1]
 
     @testset "eachslice inference (#45923)" begin
         a = [1 2; 3 4]


### PR DESCRIPTION
I wonder if `eachslice` should have a default of the last dimension. 

In python you can do `for mat in batch` to iterate a 3D array by getting its slices... the ones which make sense for row-major arrays. With this, something like `for mat in eachslice(batch)` would iterate the slices which make sense for column-major arrays.

```julia
julia> sizes(A) = (inner = size(first(A)), outer = size(A));

julia> eachslice(rand(2,3,5,7)) |> sizes  # previously no default
(inner = (2, 3, 5), outer = (7,))

julia> stack(eachslice(rand(2,3,5,7))) |> size  # matches this
(2, 3, 5, 7)
```

Edit: closes #54626

### Extend to `eachcol`? (Edit: removed for now)

Less obviously, we could also extend `eachcol` to always give a slice along the first dimension. Then `for col in eachcol(batch)` would return dense 1D views for any higher-dim Array.

```julia
julia> eachcol(rand(2,3,5)) |> sizes  # always 1st dim inner
(inner = (2,), outer = (3, 5))

julia> eachcol(rand(2,3)) |> sizes  # as before
(inner = (2,), outer = (3,))

julia> eachcol(rand(2,)) |> sizes  # as before, involves a reshape
(inner = (2,), outer = (1,))
```

For symmetry we should then extend `eachrow`; note that on vectors it currently picks the 2nd (trivial) dimension, so I think that's what it would have to do always:

```julia
julia> eachrow(rand(2,3,5)) |> sizes  # always 2st dim inner
(inner = (3,), outer = (2, 5))

julia> eachrow(rand(2,3)) |> sizes  # as before
(inner = (3,), outer = (2,))

julia> eachrow(rand(2)) |> sizes  # as before,  involves a reshape
(inner = (1,), outer = (2,))
```
