### PR TITLE
Specialize isinf(::IEEEFloat)

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -631,6 +631,7 @@ Test whether a number is infinite.
 See also: [`Inf`](@ref), [`iszero`](@ref), [`isfinite`](@ref), [`isnan`](@ref).
 """
 isinf(x::Real) = !isnan(x) & !isfinite(x)
+isinf(x::IEEEFloat) = abs(x) == oftype(x, Inf)
 
 const hx_NaN = hash_uint64(reinterpret(UInt64, NaN))
 let Tf = Float64, Tu = UInt64, Ti = Int64

--- a/base/float.jl
+++ b/base/float.jl
@@ -631,7 +631,7 @@ Test whether a number is infinite.
 See also: [`Inf`](@ref), [`iszero`](@ref), [`isfinite`](@ref), [`isnan`](@ref).
 """
 isinf(x::Real) = !isnan(x) & !isfinite(x)
-isinf(x::IEEEFloat) = abs(x) == oftype(x, Inf)
+isinf(x::IEEEFloat) = abs(x) === oftype(x, Inf)
 
 const hx_NaN = hash_uint64(reinterpret(UInt64, NaN))
 let Tf = Float64, Tu = UInt64, Ti = Int64


### PR DESCRIPTION
`isinf` is slower than necessary for `IEEEFloat` values.
```
using BenchmarkTools
s = randn();
t = ntuple(_->randn(), 4);
v = randn(100);
@btime isinf($s);
@btime any(isinf,$t);
@btime any(isinf,$v);

# before
  3.000 ns (0 allocations: 0 bytes)
  5.200 ns (0 allocations: 0 bytes)
  73.073 ns (0 allocations: 0 bytes)

# with ==
  2.900 ns (0 allocations: 0 bytes)
  3.300 ns (0 allocations: 0 bytes)
  46.916 ns (0 allocations: 0 bytes)

# current: with ===
  3.100 ns (0 allocations: 0 bytes)
  3.100 ns (0 allocations: 0 bytes)
  42.727 ns (0 allocations: 0 bytes)
```