### PR TITLE
Avoid a couple of InexactErrors in the IdDict code.

### DIFF
--- a/base/iddict.jl
+++ b/base/iddict.jl
@@ -68,7 +68,7 @@ end
 
 empty(d::IdDict, ::Type{K}, ::Type{V}) where {K, V} = IdDict{K,V}()
 
-function rehash!(d::IdDict, newsz = length(d.ht))
+function rehash!(d::IdDict, newsz = length(d.ht)%UInt)
     d.ht = ccall(:jl_idtable_rehash, Vector{Any}, (Any, Csize_t), d.ht, newsz)
     d
 end
@@ -89,7 +89,7 @@ function setindex!(d::IdDict{K,V}, @nospecialize(val), @nospecialize(key)) where
         val = convert(V, val)
     end
     if d.ndel >= ((3*length(d.ht))>>2)
-        rehash!(d, max(length(d.ht)>>1, 32))
+        rehash!(d, max((length(d.ht)%UInt)>>1, 32))
         d.ndel = 0
     end
     inserted = RefValue{Cint}(0)
@@ -143,7 +143,7 @@ end
 _oidd_nextind(a, i) = reinterpret(Int, ccall(:jl_eqtable_nextind, Csize_t, (Any, Csize_t), a, i))
 
 function iterate(d::IdDict{K,V}, idx=0) where {K, V}
-    idx = _oidd_nextind(d.ht, idx)
+    idx = _oidd_nextind(d.ht, idx%UInt)
     idx == -1 && return nothing
     return (Pair{K, V}(d.ht[idx + 1]::K, d.ht[idx + 2]::V), idx + 2)
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/48097 (working around the issue).

On 1.9, kwarg calls use `Base._tuple_unique_fieldtypes`, which relies on IdDict. Normally that doesn't matter, because the method is marked `@total_meta` so the optimizer is free to use concrete evaluation to evaluate the function at compile time. However, with our GPU back-ends, `Core.throw_inexacterror` is replaced with an overlay method that does GPU-compatible exception reporting. That currently disables concrete evaluation, resulting in run-time calls to `Base._tuple_unique_fieldtypes` (and a whole lot of dynamic code following it).

To get things working in time for 1.9, just avoid throwing InexactErrors as part of IdDict operations. That results in the optimizer being able to concrete evaluate `Base._tuple_unique_fieldtypes` even in GPU compilation mode.

For 1.10, we probably need a better way of overriding methods without disabling concrete evaluation. Some GPU overrides should not disable these optimizations, e.g., if we override `Base.sin` with a version that uses hardware intrinsics we should still get to benefit from concrete evaluation (albeit using the original method). In other cases, like the `Core.throw_inexacterror` overlay here, it's not so clear what needs to happen.