### PR TITLE
Avoid allocations in reduction over adjoints

### DIFF
--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -406,6 +406,7 @@ Base.mapreducedim!(f::typeof(identity), op::Union{typeof(*),typeof(Base.mul_prod
     (Base.mapreducedim!(f∘adjoint, op, switch_dim12(B), parent(A)); B)
 
 switch_dim12(B::AbstractVector) = permutedims(B)
+switch_dim12(B::AbstractVector{<:Number}) = transpose(B) # avoid allocs due to permutedims
 switch_dim12(B::AbstractArray{<:Any,0}) = B
 switch_dim12(B::AbstractArray) = PermutedDimsArray(B, (2, 1, ntuple(Base.Fix1(+,2), ndims(B) - 2)...))
 


### PR DESCRIPTION
Fixes the allocation part of JuliaLang/LinearAlgebra.jl#971 as advised by @N5N3. Yields a major speedup, but doesn't quite reach the pre-46605 times for that specific size, though @N5N3 mentions that for other sizes the "new" approach is faster. So we may consider to close the issue with this fix?

Fixes JuliaLang/LinearAlgebra.jl#971.