### PR TITLE
replace mfence with lock'ed inst on x86

### DIFF
--- a/src/julia_atomics.h
+++ b/src/julia_atomics.h
@@ -73,7 +73,11 @@ enum jl_memory_order {
  * are). We also need to access these atomic variables from the LLVM JIT code
  * which is very hard unless the layout of the object is fully specified.
  */
-#define jl_fence() atomic_thread_fence(memory_order_seq_cst)
+#if defined(_CPU_X86_64_)
+    #define jl_fence() __asm__ volatile("lock orq $0 , (%rsp)")
+#else
+    #define jl_fence() atomic_thread_fence(memory_order_seq_cst)
+#endif
 #define jl_fence_release() atomic_thread_fence(memory_order_release)
 #define jl_signal_fence() atomic_signal_fence(memory_order_seq_cst)
 

--- a/src/julia_atomics.h
+++ b/src/julia_atomics.h
@@ -73,7 +73,14 @@ enum jl_memory_order {
  * are). We also need to access these atomic variables from the LLVM JIT code
  * which is very hard unless the layout of the object is fully specified.
  */
-#if defined(_CPU_X86_64_)
+
+/**
+ * On modern Intel and AMD platforms `lock orq` on the SP is faster than
+ * `mfence`. GCC 11 did switch to this representation. See #48123
+ */
+#if defined(_CPU_X86_64_) && \
+	((defined(__GNUC__) && __GNUC__ < 11) || \
+	 (defined(__clang__)))
     #define jl_fence() __asm__ volatile("lock orq $0 , (%rsp)")
 #else
     #define jl_fence() atomic_thread_fence(memory_order_seq_cst)


### PR DESCRIPTION
A dummy instruction with `lock` prefix should provide the same sequential consistency guarantees as an `mfence` on `x86`.

This had a large performance impact when benchmarking work-stealing queues for parallel marking and it would be interesting to see how/if it affects performance in general.

CC: @vchuravy 