### PR TITLE
binomial(x,k) for non-integer x

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,8 +30,9 @@ New library functions
 
 New library features
 --------------------
-The `initialized=true` keyword assignment for `sortperm!` and `partialsortperm!`
-is now a no-op ([#47979]). It previously exposed unsafe behavior ([#47977]).
+* The `initialized=true` keyword assignment for `sortperm!` and `partialsortperm!`
+  is now a no-op ([#47979]). It previously exposed unsafe behavior ([#47977]).
+* `binomial(x, k)` now supports non-integer `x` ([#?????]).
 
 Standard library changes
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -32,7 +32,7 @@ New library features
 --------------------
 * The `initialized=true` keyword assignment for `sortperm!` and `partialsortperm!`
   is now a no-op ([#47979]). It previously exposed unsafe behavior ([#47977]).
-* `binomial(x, k)` now supports non-integer `x` ([#?????]).
+* `binomial(x, k)` now supports non-integer `x` ([#48124]).
 
 Standard library changes
 ------------------------

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -1097,6 +1097,8 @@ the polynomial
 ```math
 \\frac{1}{k!} \\prod_{j=0}^{k-1} (x - j)
 ```
+When `k < 0` it returns zero.
+
 For the case of integer `x`, this is equivalent to the ordinary
 integer binomial coefficient
 ```math
@@ -1107,7 +1109,7 @@ integer binomial coefficient
 * [Binomial coefficient](https://en.wikipedia.org/wiki/Binomial_coefficient) on Wikipedia.
 """
 function binomial(x::Number, k::Integer)
-    k < 0 && throw(DomainError("k=$k must be non-negative"))
+    k < 0 && return zero(x)/one(k)
     # we don't use prod(i -> (x-i+1), 1:k) / factorial(k),
     # and instead divide each term by i, to avoid spurious overflow.
     return prod(i -> (x-(i-1))/i, OneTo(k), init=oneunit(x)/one(k))

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -1088,3 +1088,27 @@ Base.@assume_effects :terminates_locally function binomial(n::T, k::T) where T<:
     end
     copysign(x, sgn)
 end
+
+"""
+    binomial(x::Number, k::Integer)
+
+The generalized binomial coefficient, defined for `k ≥ 0` by
+the polynomial
+```math
+\\frac{1}{k!} \\prod_{j=0}^{k-1} (x - j)
+```
+For the case of integer `x`, this is equivalent to the ordinary
+integer binomial coefficient
+```math
+\\binom{n}{k} = \\frac{n!}{k! (n-k)!}
+```
+
+# External links
+* [Binomial coefficient](https://en.wikipedia.org/wiki/Binomial_coefficient) on Wikipedia.
+"""
+function binomial(x::Number, k::Integer)
+    k < 0 && throw(DomainError("k=$k must be non-negative"))
+    # we don't use prod(i -> (x-i+1), 1:k) / factorial(k),
+    # and instead divide each term by i, to avoid spurious overflow.
+    return prod(i -> (x-(i-1))/i, OneTo(k), init=oneunit(x)/one(k))
+end

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -1105,6 +1105,11 @@ integer binomial coefficient
 \\binom{n}{k} = \\frac{n!}{k! (n-k)!}
 ```
 
+Further generalizations to non-integer `k` are mathematically possible, but
+involve the Gamma function and/or the beta function, which are
+not provided by the Julia standard library but are available
+in external packages such as [SpecialFunctions.jl](https://github.com/JuliaMath/SpecialFunctions.jl).
+
 # External links
 * [Binomial coefficient](https://en.wikipedia.org/wiki/Binomial_coefficient) on Wikipedia.
 """

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -525,7 +525,7 @@ end
     @test binomial(2.5,3) ≈ 5//16 === binomial(5//2,3)
     @test binomial(2.5,0) == 1.0
     @test binomial(35.0, 30) ≈ binomial(35, 30) # naive method overflows
-    @test_throws DomainError binomial(2.5,-1)
+    @test binomial(2.5,-1) == 0.0
 end
 
 # concrete-foldability

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -518,6 +518,14 @@ end
     for x in ((false,false), (false,true), (true,false), (true,true))
         @test binomial(x...) == (x != (false,true))
     end
+
+    # binomial(x,k) for non-integer x
+    @test @inferred(binomial(10.0,3)) === 120.0
+    @test @inferred(binomial(10//1,3)) === 120//1
+    @test binomial(2.5,3) ≈ 5//16 === binomial(5//2,3)
+    @test binomial(2.5,0) == 1.0
+    @test binomial(35.0, 30) ≈ binomial(35, 30) # naive method overflows
+    @test_throws DomainError binomial(2.5,-1)
 end
 
 # concrete-foldability


### PR DESCRIPTION
It was [pointed out on discourse](https://discourse.julialang.org/t/symbolics-get-the-coefficients-of-the-polynomial-binomial-x-c/92511) that `binomial(x, k)` has a [perfectly sensible and standard meaning](https://en.wikipedia.org/wiki/Binomial_coefficient#Generalization_and_connection_to_the_binomial_series) for non-integer `x` and integer `k`, where it is simply a polynomial in `x`.

Since it can be implemented in only a few lines, a naive implementation overflows, and this can *only* be done in Base to avoid type piracy, it seems worthwhile adding.

(For non-integer `k`, a generalization requires the Gamma function and/or the [beta function](https://en.wikipedia.org/wiki/Beta_function), which is out of scope for Base.  See also https://github.com/JuliaLang/julia/pull/14165 and https://github.com/JuliaMath/SpecialFunctions.jl/issues/282)