### PR TITLE
Further tweaks to LimitedAccuracy lattice operations

### DIFF
--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -417,7 +417,7 @@ function ⊑(lattice::InferenceLattice, @nospecialize(a), @nospecialize(b))
 
     # a and b's unlimited types are equal.
     isa(a, LimitedAccuracy) || return false # b is limited, so ε smaller
-    return a.causes ⊆ b.causes
+    return b.causes ⊆ a.causes
 end
 
 function ⊑(lattice::OptimizerLattice, @nospecialize(a), @nospecialize(b))

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -422,8 +422,7 @@ end
 
         # Approximated types are lattice equal. Merge causes.
         if suba && subb
-            causes = merge_causes(causesa, causesb)
-            issimplertype(lattice, typeb, typea) && return LimitedAccuracy(typeb, causesb)
+            return LimitedAccuracy(typeb, merge_causes(causesa, causesb))
         elseif suba
             issimplertype(lattice, typeb, typea) && return LimitedAccuracy(typeb, causesb)
             causes = causesb
@@ -453,6 +452,7 @@ end
         subb = ⊑(lattice, typeb, typea)
     end
 
+    suba && subb && return LimitedAccuracy(typea, causes)
     subb && issimplertype(lattice, typea, typeb) && return LimitedAccuracy(typea, causes)
     return LimitedAccuracy(tmerge(widenlattice(lattice), typea, typeb), causes)
 end


### PR DESCRIPTION
As discussed in #48045:
1. Switch the order of `causes` inclusion to make wider elements have fewer causes.
2. Fix two typos
3. Restore property that equal ulimited types will be preserved (though with potentially updated `causes` lists).