### PR TITLE
make `get!` type-stable for `AbstractDict`

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -551,10 +551,12 @@ setindex!(t::AbstractDict, v, k1, k2, ks...) = setindex!(t, v, tuple(k1,k2,ks...
 
 get!(t::AbstractDict, key, default) = get!(() -> default, t, key)
 function get!(default::Callable, t::AbstractDict{K,V}, key) where K where V
-    haskey(t, key) && return t[key]
-    val = default()
-    t[key] = val
-    return val
+    key = convert(K, key)
+    if haskey(t, key)
+        return t[key]
+    else
+        return t[key] = convert(V, default())
+    end
 end
 
 push!(t::AbstractDict, p::Pair) = setindex!(t, p.second, p.first)


### PR DESCRIPTION
At present, `get!` for `AbstractDict` (not for `Dict`) is not type-stable because the default value is not converted to the value type of the `AbstractDict`. It seems that in Base it's only used for `EnvDict`:
```
julia> @code_warntype get!(ENV, "PATH", 0)
MethodInstance for get!(::Base.EnvDict, ::String, ::Int64)
  from get!(t::AbstractDict, key, default) in Base at abstractdict.jl:546

Body::Union{Int64, String}
```
The patch makes this conversion. The key is also first converted to the key type to avoid repeated conversion thaty are likely to occur in the subsequent lines.