### PR TITLE
faster `hypot(::IEEEFloat...)`

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -832,7 +832,7 @@ _hypot(x::ComplexF16, y::ComplexF16) = Float16(_hypot(ComplexF32(x), ComplexF32(
 
 function _hypot(x::NTuple{N,<:Number}) where {N}
     maxabs = maximum(abs, x)
-    if any(isinf, x)
+    if isnan(maxabs) && any(isinf, x)
         return typeof(maxabs)(Inf)
     elseif (iszero(maxabs) || isinf(maxabs))
         return maxabs

--- a/base/math.jl
+++ b/base/math.jl
@@ -832,7 +832,7 @@ _hypot(x::ComplexF16, y::ComplexF16) = Float16(_hypot(ComplexF32(x), ComplexF32(
 
 function _hypot(x::NTuple{N,<:Number}) where {N}
     maxabs = maximum(abs, x)
-    if isnan(maxabs) && any(isinf, x)
+    if any(isinf, x)
         return typeof(maxabs)(Inf)
     elseif (iszero(maxabs) || isinf(maxabs))
         return maxabs

--- a/base/math.jl
+++ b/base/math.jl
@@ -841,6 +841,17 @@ function _hypot(x::NTuple{N,<:Number}) where {N}
     end
 end
 
+function _hypot(x::NTuple{N,T}) where {N,T<:IEEEFloat}
+	infT = convert(T, Inf)
+	x = abs.(x) # doesn't change result but enables computational shortcuts
+	any(==(infT), x) && return infT # return Inf even if an argument is NaN
+	maxabs = reinterpret(T, maximum(z -> reinterpret(Signed, z), x)) # for abs(::IEEEFloat) values, a ::BitInteger cast does not change the result
+    iszero(maxabs) && return maxabs
+	y = abs2.(x ./ maxabs)
+	a2 = @fastmath reduce(+, y) # allow sum to be reordered
+	return sqrt(a2) * maxabs
+end
+
 atan(y::Real, x::Real) = atan(promote(float(y),float(x))...)
 atan(y::T, x::T) where {T<:AbstractFloat} = Base.no_op_err("atan", T)
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -842,14 +842,14 @@ function _hypot(x::NTuple{N,<:Number}) where {N}
 end
 
 function _hypot(x::NTuple{N,T}) where {N,T<:IEEEFloat}
-	infT = convert(T, Inf)
-	x = abs.(x) # doesn't change result but enables computational shortcuts
-	any(==(infT), x) && return infT # return Inf even if an argument is NaN
-	maxabs = reinterpret(T, maximum(z -> reinterpret(Signed, z), x)) # for abs(::IEEEFloat) values, a ::BitInteger cast does not change the result
+    infT = convert(T, Inf)
+    x = abs.(x) # doesn't change result but enables computational shortcuts
+    any(==(infT), x) && return infT # return Inf even if an argument is NaN
+    maxabs = reinterpret(T, maximum(z -> reinterpret(Signed, z), x)) # for abs(::IEEEFloat) values, a ::BitInteger cast does not change the result
     iszero(maxabs) && return maxabs
-	y = abs2.(x ./ maxabs)
-	a2 = @fastmath reduce(+, y) # allow sum to be reordered
-	return sqrt(a2) * maxabs
+    y = abs2.(x ./ maxabs)
+    a2 = @fastmath reduce(+, y) # allow sum to be reordered
+    return sqrt(a2) * maxabs
 end
 
 atan(y::Real, x::Real) = atan(promote(float(y),float(x))...)


### PR DESCRIPTION
`hypot(::IEEEFloat...)` can be made faster for 3+ arguments.

```julia
using BenchmarkTools

t3 = ntuple(_->randn(), 3)
t4 = ntuple(_->randn(), 4)
t8 = ntuple(_->randn(), 8)
t16 = ntuple(_->randn(), 16)

@btime hypot($t3...)
@btime hypot($t4...)
@btime hypot($t8...)
@btime hypot($t16...)

# master
  9.810 ns (0 allocations: 0 bytes)
  10.110 ns (0 allocations: 0 bytes)
  19.759 ns (0 allocations: 0 bytes)
  50.203 ns (0 allocations: 0 bytes)

# SHA 1a0340c
  7.808 ns (0 allocations: 0 bytes)
  8.008 ns (0 allocations: 0 bytes)
  10.010 ns (0 allocations: 0 bytes)
  14.529 ns (0 allocations: 0 bytes)
```

The notable savings here come from casting to integers before computing `maximum(abs,...)` (same result but faster comparisons) and re-associating the final sum (see #48129).