### PR TITLE
Deprecate AMD's LWP extension

### DIFF
--- a/src/features_x86.h
+++ b/src/features_x86.h
@@ -89,7 +89,7 @@ JL_FEATURE_DEF(lzcnt, 32 * 5 + 5, 0)
 JL_FEATURE_DEF(sse4a, 32 * 5 + 6, 0)
 JL_FEATURE_DEF(prfchw, 32 * 5 + 8, 0)
 JL_FEATURE_DEF(xop, 32 * 5 + 11, 0)
-JL_FEATURE_DEF(lwp, 32 * 5 + 15, 0)
+// JL_FEATURE_DEF(lwp, 32 * 5 + 15, 0) Deprecated
 JL_FEATURE_DEF(fma4, 32 * 5 + 16, 0)
 JL_FEATURE_DEF(tbm, 32 * 5 + 21, 0)
 JL_FEATURE_DEF(mwaitx, 32 * 5 + 29, 0)

--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -219,7 +219,7 @@ constexpr auto btver2 = btver1 | get_feature_masks(sse41, sse42, avx, aes, pclmu
                                                    movbe, xsave, xsaveopt);
 
 constexpr auto bdver1 = amdfam10 | get_feature_masks(xop, fma4, avx, ssse3, sse41, sse42, aes,
-                                                     prfchw, pclmul, xsave, lwp);
+                                                     prfchw, pclmul, xsave);
 constexpr auto bdver2 = bdver1 | get_feature_masks(f16c, bmi, tbm, fma);
 constexpr auto bdver3 = bdver2 | get_feature_masks(xsaveopt, fsgsbase);
 constexpr auto bdver4 = bdver3 | get_feature_masks(avx2, bmi2, mwaitx, movbe, rdrnd);


### PR DESCRIPTION
Should fix #48111

AMD has deprecated that instruction set in Fam15,
and Linux removed support for it as well as part
of a microcode update.

