### PR TITLE
Negative-length arrays are empty

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1220,7 +1220,7 @@ function iterate(A::AbstractArray, state=(eachindex(A),))
     A[y[1]], (state[1], tail(y)...)
 end
 
-isempty(a::AbstractArray) = (length(a) == 0)
+isempty(a::AbstractArray) = (length(a) <= 0)
 
 
 ## range conversions ##


### PR DESCRIPTION
This addresses a somewhat unusual case, but it's useful for this to work correctly. Currently,
```julia
julia> using BlockArrays

julia> M = [Block(2), Block(-1)];

julia> b = reinterpret(BlockRange{1, Tuple{UnitRange{Int64}}}, M)[1]
0-element BlockRange{1, Tuple{UnitRange{Int64}}}:

julia> length(b)
-2

julia> isempty(b)
false
```
Ideally the `length` should be fixed, but if the length is negative, the array should be empty. This is the case for ranges, for example:
```julia
julia> r = reinterpret(UnitRange{Int}, [2,-1])[1]
2:-1

julia> length(r)
-2

julia> isempty(r)
true
```
After this PR, `isempty(b) == true` 