### PR TITLE
Fix invalidations in `finish_show_ir`

### DIFF
--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -858,7 +858,7 @@ function show_ir_stmts(io::IO, ir::Union{IRCode, CodeInfo, IncrementalCompact}, 
     return bb_idx
 end
 
-function finish_show_ir(io::IO, cfg, config::IRShowConfig)
+function finish_show_ir(io::IO, cfg::CFG, config::IRShowConfig)
     max_bb_idx_size = length(string(length(cfg.blocks)))
     config.line_info_preprinter(io, " "^(max_bb_idx_size + 2), 0)
     return nothing


### PR DESCRIPTION
The whole module is under `@nospecialize`, so inference needs us to annotate the argtypes.

This should fix invalidation of ~95 MethodInstances in Revise/LoweredCodeUtils
Example trigger of invalidation: `convert(::Type{T}, i::LoopVectorization.UpperBoundedInteger) where T<:Number`