### PR TITLE
add a suffix to a new cache files in case of failure of renaming it to an exisiting cache file already in use

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2112,7 +2112,7 @@ function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, in
                     e isa IOError || rethrow()
                     # Windows prevents renaming a file that is in use so if there is a Julia session started
                     # with a package image loaded, we cannot rename that file.
-                    # The code belows append a `_i` to the name of the cache file where `i` is the smallest number such that 
+                    # The code belows append a `_i` to the name of the cache file where `i` is the smallest number such that
                     # that cache file does not exist.
                     ocachename, ocacheext = splitext(ocachefile)
                     old_cachefiles = filter(x->startswith(x, basename(ocachename)) && endswith(x, ocacheext), readdir(cachepath))

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1708,6 +1708,35 @@ precompile_test_harness("BadInvalidations") do load_path
     end
 end
 
+# https://github.com/JuliaLang/julia/issues/48074
+precompile_test_harness("WindowsCacheOverwrite") do load_path
+    # https://github.com/JuliaLang/julia/pull/47184#issuecomment-1364716312
+    write(joinpath(load_path, "WindowsCacheOverwrite.jl"),
+    """
+    module WindowsCacheOverwrite
+
+    end # module
+    """)
+    ji, ofile = Base.compilecache(Base.PkgId("WindowsCacheOverwrite"))
+    (@eval (using WindowsCacheOverwrite))
+
+    write(joinpath(load_path, "WindowsCacheOverwrite.jl"),
+    """
+    module WindowsCacheOverwrite
+
+    f() = "something new"
+
+    end # module
+    """)
+
+    ji_2, ofile_2 = Base.compilecache(Base.PkgId("WindowsCacheOverwrite"))
+    if Sys.iswindows()
+        @test ji != ji_2
+        @test ofile != ofile_2
+        @test ofile_2 == Base.ocachefile_from_cachefile(ji_2)
+    end
+end
+
 empty!(Base.DEPOT_PATH)
 append!(Base.DEPOT_PATH, original_depot_path)
 empty!(Base.LOAD_PATH)

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1730,11 +1730,7 @@ precompile_test_harness("WindowsCacheOverwrite") do load_path
     """)
 
     ji_2, ofile_2 = Base.compilecache(Base.PkgId("WindowsCacheOverwrite"))
-    if Sys.iswindows()
-        @test ji != ji_2
-        @test ofile != ofile_2
-        @test ofile_2 == Base.ocachefile_from_cachefile(ji_2)
-    end
+    @test ofile_2 == Base.ocachefile_from_cachefile(ji_2)
 end
 
 empty!(Base.DEPOT_PATH)


### PR DESCRIPTION
In cases where we try to compile a cache file for a package that is already in use in another Julia session, Windows gives us an error because we are trying to rename a file to another file that is already in use (https://github.com/JuliaLang/julia/issues/48074).

This PR detects when the rename fails and adds a suffix `_i` to the cache file name where `i` is the smallest integer such that that file does not exist.

Starting a few julia sessions and loading `Example` while editing it between every load gives a list of files like:

```
PS C:\Users\Kristoffer\.julia\compiled\v1.10\Example> dir

    Directory: C:\Users\Kristoffer\.julia\compiled\v1.10\Example
Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---          2023-01-05    14:11          20480 lLvWP_7lexV_1.dll
-a---          2023-01-05    14:11           2732 lLvWP_7lexV_1.ji
-a---          2023-01-05    14:12          20480 lLvWP_7lexV_2.dll
-a---          2023-01-05    14:12           2738 lLvWP_7lexV_2.ji
-a---          2023-01-05    14:11          20480 lLvWP_7lexV.dll
-a---          2023-01-05    14:11           2728 lLvWP_7lexV.ji
````

Fixes #48074