### PR TITLE
RFC: Remove `--track-allocation`

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -138,7 +138,7 @@ See also [`print`](@ref), [`println`](@ref), [`show`](@ref).
 Return a julia command similar to the one of the running process.
 Propagates any of the `--cpu-target`, `--sysimage`, `--compile`, `--sysimage-native-code`,
 `--compiled-modules`, `--inline`, `--check-bounds`, `--optimize`, `-g`,
-`--code-coverage`, `--track-allocation`, `--color`, `--startup-file`, and `--depwarn`
+`--code-coverage`, `--color`, `--startup-file`, and `--depwarn`
 command line arguments that are not at their default values.
 
 Among others, `--math-mode`, `--warn-overwrite`, and `--trace-compile` are notably not propagated currently.
@@ -207,13 +207,6 @@ function julia_cmd(julia=joinpath(Sys.BINDIR, julia_exename()); cpu_target::Unio
             isempty(coverage_file) || push!(addflags, "--code-coverage=$coverage_file")
         end
     end
-    if opts.malloc_log == 1
-        push!(addflags, "--track-allocation=user")
-    elseif opts.malloc_log == 2
-        push!(addflags, "--track-allocation=all")
-    elseif opts.malloc_log == 3
-        push!(addflags, "--track-allocation=@$(unsafe_string(opts.tracked_path))")
-    end
     if opts.color == 1
         push!(addflags, "--color=yes")
     elseif opts.color == 2
@@ -228,8 +221,8 @@ function julia_cmd(julia=joinpath(Sys.BINDIR, julia_exename()); cpu_target::Unio
     if opts.use_pkgimages == 0
         push!(addflags, "--pkgimages=no")
     else
-        # If pkgimage is set, malloc_log and code_coverage should not
-        @assert opts.malloc_log == 0 && opts.code_coverage == 0
+        # If pkgimage is set code_coverage should not
+        @assert opts.code_coverage == 0
     end
     return `$julia -C$cpu_target -J$image_file $addflags`
 end

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -201,15 +201,6 @@ be placed before the path to indicate this option. A `@` with no path will track
  Append coverage information to the LCOV tracefile (filename supports format tokens)
 
 .TP
---track-allocation[={none*|user|all}]
-Count bytes allocated by each source line (omitting setting is equivalent to `user`)
-
-.TP
---track-allocation=@<path>
-Count bytes allocated by each source line in a file or files under a given directory. A `@`
-must be placed before the path to indicate this option. A `@` with no path will track the current directory.
-
-.TP
 --bug-report=KIND
 Launch a bug report session. It can be used to start a REPL, run a script, or evaluate
 expressions. It first tries to use BugReporting.jl installed in current environment and

--- a/doc/src/manual/command-line-interface.md
+++ b/doc/src/manual/command-line-interface.md
@@ -126,7 +126,6 @@ The following is a complete list of command-line switches available when launchi
 |`--math-mode={ieee,fast}`              |Disallow or enable unsafe floating point optimizations (overrides `@fastmath` declaration)|
 |`--code-coverage[={none*\|user\|all}]` |Count executions of source lines (omitting setting is equivalent to `user`)|
 |`--code-coverage=tracefile.info`       |Append coverage information to the LCOV tracefile (filename supports format tokens).|
-|`--track-allocation[={none*\|user\|all}]` |Count bytes allocated by each source line (omitting setting is equivalent to "user")|
 |`--bug-report=KIND`                    |Launch a bug report session. It can be used to start a REPL, run a script, or evaluate expressions. It first tries to use BugReporting.jl installed in current environment and falls back to the latest compatible BugReporting.jl if not. For more information, see `--bug-report=help`.|
 |`--compile={yes*\|no\|all\|min}`       |Enable or disable JIT compiler, or request exhaustive or minimal compilation|
 |`--output-o <name>`                    |Generate an object file (including system image data)|

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -161,8 +161,7 @@ the performance of your code:
   * Unexpectedly-large memory allocations--as reported by [`@time`](@ref), [`@allocated`](@ref), or
     the profiler (through calls to the garbage-collection routines)--hint that there might be issues
     with your code. If you don't see another reason for the allocations, suspect a type problem.
-     You can also start Julia with the `--track-allocation=user` option and examine the resulting
-    `*.mem` files to see information about where those allocations occur. See [Memory allocation analysis](@ref).
+     You can also start use the heap-profiler to find out where allocation stem from. See [Memory allocation analysis](@ref).
   * `@code_warntype` generates a representation of your code that can be helpful in finding expressions
     that result in type uncertainty. See [`@code_warntype`](@ref) below.
 

--- a/doc/src/manual/profile.md
+++ b/doc/src/manual/profile.md
@@ -305,28 +305,7 @@ provides several tools measure this:
 
 The total amount of allocation can be measured with [`@time`](@ref), [`@allocated`](@ref) and [`@allocations`](@ref),
 and specific lines triggering allocation can often be inferred from profiling via the cost of garbage
-collection that these lines incur. However, sometimes it is more efficient to directly measure
-the amount of memory allocated by each line of code.
-
-### Line-by-Line Allocation Tracking
-
-To measure allocation line-by-line, start Julia with the `--track-allocation=<setting>` command-line
-option, for which you can choose `none` (the default, do not measure allocation), `user` (measure
-memory allocation everywhere except Julia's core code), or `all` (measure memory allocation at
-each line of Julia code). Allocation gets measured for each line of compiled code. When you quit
-Julia, the cumulative results are written to text files with `.mem` appended after the file name,
-residing in the same directory as the source file. Each line lists the total number of bytes
-allocated. The [`Coverage` package](https://github.com/JuliaCI/Coverage.jl) contains some elementary
-analysis tools, for example to sort the lines in order of number of bytes allocated.
-
-In interpreting the results, there are a few important details. Under the `user` setting, the
-first line of any function directly called from the REPL will exhibit allocation due to events
-that happen in the REPL code itself. More significantly, JIT-compilation also adds to allocation
-counts, because much of Julia's compiler is written in Julia (and compilation usually requires
-memory allocation). The recommended procedure is to force compilation by executing all the commands
-you want to analyze, then call [`Profile.clear_malloc_data()`](@ref) to reset all allocation counters.
- Finally, execute the desired commands and quit Julia to trigger the generation of the `.mem`
-files.
+collection that these lines incur.
 
 ### GC Logging
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -2638,7 +2638,6 @@ STATIC_INLINE jl_value_t *_jl_invoke(jl_value_t *F, jl_value_t **args, uint32_t 
         }
         codeinst = jl_atomic_load_relaxed(&codeinst->next);
     }
-    int64_t last_alloc = jl_options.malloc_log ? jl_gc_diff_total_bytes() : 0;
     int last_errno = errno;
 #ifdef _OS_WINDOWS_
     DWORD last_error = GetLastError();
@@ -2648,8 +2647,6 @@ STATIC_INLINE jl_value_t *_jl_invoke(jl_value_t *F, jl_value_t **args, uint32_t 
     SetLastError(last_error);
 #endif
     errno = last_errno;
-    if (jl_options.malloc_log)
-        jl_gc_sync_total_bytes(last_alloc); // discard allocation count from compilation
     jl_callptr_t invoke = jl_atomic_load_relaxed(&codeinst->invoke);
     jl_value_t *res = invoke(F, args, nargs, codeinst);
     return verify_type(res);
@@ -2775,7 +2772,6 @@ STATIC_INLINE jl_method_instance_t *jl_lookup_generic_(jl_value_t *F, jl_value_t
             jl_typemap_t *cache = jl_atomic_load_relaxed(&mt->cache); // XXX: gc root required?
             entry = jl_typemap_assoc_exact(cache, F, args, nargs, jl_cachearg_offset(mt), world);
             if (entry == NULL) {
-                last_alloc = jl_options.malloc_log ? jl_gc_diff_total_bytes() : 0;
                 if (tt == NULL) {
                     tt = arg_type_tuple(F, args, nargs);
                     entry = lookup_leafcache(leafcache, (jl_value_t*)tt, world);
@@ -2807,8 +2803,6 @@ have_entry:
         mfunc = jl_mt_assoc_by_type(mt, tt, world);
         JL_UNLOCK(&mt->writelock);
         JL_GC_POP();
-        if (jl_options.malloc_log)
-            jl_gc_sync_total_bytes(last_alloc); // discard allocation count from compilation
         if (mfunc == NULL) {
 #ifdef JL_TRACE
             if (error_en)
@@ -2912,7 +2906,6 @@ jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value
         mfunc = tm->func.linfo;
     }
     else {
-        int64_t last_alloc = jl_options.malloc_log ? jl_gc_diff_total_bytes() : 0;
         jl_svec_t *tpenv = jl_emptysvec;
         jl_tupletype_t *tt = NULL;
         JL_GC_PUSH2(&tpenv, &tt);
@@ -2933,8 +2926,6 @@ jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value
         }
         JL_UNLOCK(&method->writelock);
         JL_GC_POP();
-        if (jl_options.malloc_log)
-            jl_gc_sync_total_bytes(last_alloc); // discard allocation count from compilation
     }
     JL_GC_PROMISE_ROOTED(mfunc);
     size_t world = jl_current_task->world_age;

--- a/src/init.c
+++ b/src/init.c
@@ -259,8 +259,6 @@ JL_DLLEXPORT void jl_atexit_hook(int exitcode) JL_NOTSAFEPOINT_ENTER
     jl_print_gc_stats(JL_STDERR);
     if (jl_options.code_coverage)
         jl_write_coverage_data(jl_options.output_code_coverage);
-    if (jl_options.malloc_log)
-        jl_write_malloc_log();
 
     int8_t old_state;
     if (ct)
@@ -769,8 +767,8 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
 #endif
 
     if ((jl_options.outputo || jl_options.outputbc || jl_options.outputasm) &&
-        (jl_options.code_coverage || jl_options.malloc_log)) {
-        jl_error("cannot generate code-coverage or track allocation information while generating a .o, .bc, or .s output file");
+        jl_options.code_coverage) {
+        jl_error("cannot generate code-coverage information while generating a .o, .bc, or .s output file");
     }
 
     jl_init_rand();

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -25,7 +25,6 @@ typedef struct {
     int8_t startupfile;
     int8_t compile_enabled;
     int8_t code_coverage;
-    int8_t malloc_log;
     const char *tracked_path;
     int8_t opt_level;
     int8_t opt_level_min;

--- a/src/julia.h
+++ b/src/julia.h
@@ -2122,7 +2122,7 @@ JL_DLLEXPORT void jl_set_ARGS(int argc, char **argv);
 
 JL_DLLEXPORT int jl_generating_output(void) JL_NOTSAFEPOINT;
 
-// Settings for code_coverage and malloc_log
+// Settings for code_coverage
 // NOTE: if these numbers change, test/cmdlineargs.jl will have to be updated
 #define JL_LOG_NONE 0
 #define JL_LOG_USER 1

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1625,7 +1625,6 @@ struct _jl_image_fptrs_t;
 void jl_register_fptrs(uint64_t image_base, const struct _jl_image_fptrs_t *fptrs,
                        jl_method_instance_t **linfos, size_t n);
 void jl_write_coverage_data(const char*);
-void jl_write_malloc_log(void);
 
 #if jl_has_builtin(__builtin_unreachable) || defined(_COMPILER_GCC_) || defined(_COMPILER_INTEL_)
 #  define jl_unreachable() __builtin_unreachable()

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -564,22 +564,6 @@ callers(func::Function, bt::Vector, lidict::LineInfoFlatDict; kwargs...) =
     callers(string(func), bt, lidict; kwargs...)
 callers(func::Function; kwargs...) = callers(string(func), retrieve()...; kwargs...)
 
-##
-## For --track-allocation
-##
-# Reset the malloc log. Used to avoid counting memory allocated during
-# compilation.
-
-"""
-    clear_malloc_data()
-
-Clears any stored memory allocation data when running julia with `--track-allocation`.
-Execute the command(s) you want to test (to force JIT-compilation), then call
-[`clear_malloc_data`](@ref). Then execute your command(s) again, quit
-Julia, and examine the resulting `*.mem` files.
-"""
-clear_malloc_data() = ccall(:jl_clear_malloc_data, Cvoid, ())
-
 # C wrappers
 function start_timer()
     check_init() # if the profile buffer hasn't been initialized, initialize with default size

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -7,7 +7,7 @@ using InteractiveUtils
 using Libdl
 
 const opt_level = Base.JLOptions().opt_level
-const coverage = (Base.JLOptions().code_coverage > 0) || (Base.JLOptions().malloc_log > 0)
+const coverage = Base.JLOptions().code_coverage > 0
 const Iptr = sizeof(Int) == 8 ? "i64" : "i32"
 
 const is_debug_build = Base.isdebugbuild()


### PR DESCRIPTION
Prior to Julia 1.9 `--track-allocation` was one of the only ways to track where allocations where coming from in Julia.
The way it functions is to change the emitted LLVM IR to insert code that tracks allocations occuring.
This often leads to false-positives since these statements interfere with optimization (in particular escape analysis)
and @simonbyrne and I once spend a particular fun couple of days hunting down ghosts.

Since it changes the emitted code it also does not particular play well with package images.

I believe there is no remaining use-case for `--track-allocation` that would not be better served by using the allocation profiler,
and I am proposing to remove of the `--track-allocation` feature in 1.10. 

Are there users  of `--track-allocation` that would object? Are there use-cases where you have fund it particular useful that are not covered by the allocation profiler?