### PR TITLE
ir: Respect GlobalRef lattice elements

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1244,7 +1244,6 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
             ssa_rename[idx] = stmt
         else
             result[result_idx][:inst] = stmt
-            result[result_idx][:type] = argextype(stmt, compact)
             result[result_idx][:flag] = flag
             result_idx += 1
         end

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -253,6 +253,8 @@ function reprocess_instruction!(interp::AbstractInterpreter,
         rt = tmeet(typeinf_lattice(interp), argextype(inst.val, ir), widenconst(inst.typ))
     elseif inst === nothing
         return false
+    elseif isa(inst, GlobalRef)
+        # GlobalRef is not refinable
     else
         ccall(:jl_, Cvoid, (Any,), inst)
         error()


### PR DESCRIPTION
Currently IncrementalCompact recomputes the type of globals on every iteration. There is not much reason to do this - the type of a global cannot change. In addition, external abstract interpreters may want to inject custom, more precise lattice elements for globals, which should be respected. Overall, this should be both faster and better for external absint, though of course GlobalRefs now need to be inserted into the IR with the correct type. If there's any callsites that don't do that, those would have to be updated.