### PR TITLE
`@fastmath maximum`

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -370,10 +370,15 @@ for f in (:^, :atan, :hypot, :log)
 end
 
 # Reductions
+
 maximum_fast(a; kw...) = Base.reduce(max_fast, a; kw...)
 minimum_fast(a; kw...) = Base.reduce(min_fast, a; kw...)
 
 maximum_fast(f, a; kw...) = Base.mapreduce(f, max_fast, a; kw...)
 minimum_fast(f, a; kw...) = Base.mapreduce(f, min_fast, a; kw...)
 
+Base.reducedim_init(f, ::typeof(max_fast), A::AbstractArray, region) =
+    Base.reducedim_init(f, max, A::AbstractArray, region)
+Base.reducedim_init(f, ::typeof(min_fast), A::AbstractArray, region) =
+    Base.reducedim_init(f, min, A::AbstractArray, region)
 end

--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -87,7 +87,9 @@ const fast_op =
          :tanh => :tanh_fast,
          # reductions
          :maximum => :maximum_fast,
-         :minimum => :minimum_fast)
+         :minimum => :minimum_fast,
+         :maximum! => :maximum!_fast,
+         :minimum! => :minimum!_fast)
 
 const rewrite_op =
     Dict(:+= => :+,
@@ -381,4 +383,15 @@ Base.reducedim_init(f, ::typeof(max_fast), A::AbstractArray, region) =
     Base.reducedim_init(f, max, A::AbstractArray, region)
 Base.reducedim_init(f, ::typeof(min_fast), A::AbstractArray, region) =
     Base.reducedim_init(f, min, A::AbstractArray, region)
+
+maximum!_fast(r::AbstractArray, A::AbstractArray; kw...) =
+    maximum!_fast(identity, r, A; kw...)
+minimum!_fast(r::AbstractArray, A::AbstractArray; kw...) =
+    minimum!_fast(identity, r, A; kw...)
+
+maximum!_fast(f::Function, r::AbstractArray, A::AbstractArray; init::Bool=true) =
+    Base.mapreducedim!(f, max_fast, Base.initarray!(r, f, max, init, A), A)
+minimum!_fast(f::Function, r::AbstractArray, A::AbstractArray; init::Bool=true) =
+    Base.mapreducedim!(f, min_fast, Base.initarray!(r, f, min, init, A), A)
+
 end

--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -84,7 +84,10 @@ const fast_op =
          :sinh => :sinh_fast,
          :sqrt => :sqrt_fast,
          :tan => :tan_fast,
-         :tanh => :tanh_fast)
+         :tanh => :tanh_fast,
+         # reductions
+         :maximum => :maximum_fast,
+         :minimum => :minimum_fast)
 
 const rewrite_op =
     Dict(:+= => :+,
@@ -365,5 +368,12 @@ for f in (:^, :atan, :hypot, :log)
         $f_fast(x::T, y::T) where {T<:Number} = $f(x, y)
     end
 end
+
+# Reductions
+maximum_fast(a; kw...) = Base.reduce(max_fast, a; kw...)
+minimum_fast(a; kw...) = Base.reduce(min_fast, a; kw...)
+
+maximum_fast(f, a; kw...) = Base.mapreduce(f, max_fast, a; kw...)
+minimum_fast(f, a; kw...) = Base.mapreduce(f, min_fast, a; kw...)
 
 end

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -124,7 +124,9 @@ function _reducedim_init(f, op, fv, fop, A, region)
 end
 
 # initialization when computing minima and maxima requires a little care
-for (f1, f2, initval, typeextreme) in ((:min, :max, :Inf, :typemax), (:max, :min, :(-Inf), :typemin))
+for (f1, f2, initval, typeextreme) in ((:min, :max, :Inf, :typemax), (:max, :min, :(-Inf), :typemin),
+                                       (:(FastMath.min_fast), :(FastMath.max_fast), :Inf, :typemax),
+                                       (:(FastMath.max_fast), :(FastMath.min_fast), :(-Inf), :typemin))
     @eval function reducedim_init(f, op::typeof($f1), A::AbstractArray, region)
         # First compute the reduce indices. This will throw an ArgumentError
         # if any region is invalid

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -124,9 +124,7 @@ function _reducedim_init(f, op, fv, fop, A, region)
 end
 
 # initialization when computing minima and maxima requires a little care
-for (f1, f2, initval, typeextreme) in ((:min, :max, :Inf, :typemax), (:max, :min, :(-Inf), :typemin),
-                                       (:(FastMath.min_fast), :(FastMath.max_fast), :Inf, :typemax),
-                                       (:(FastMath.max_fast), :(FastMath.min_fast), :(-Inf), :typemin))
+for (f1, f2, initval, typeextreme) in ((:min, :max, :Inf, :typemax), (:max, :min, :(-Inf), :typemin))
     @eval function reducedim_init(f, op::typeof($f1), A::AbstractArray, region)
         # First compute the reduce indices. This will throw an ArgumentError
         # if any region is invalid

--- a/test/fastmath.jl
+++ b/test/fastmath.jl
@@ -220,6 +220,16 @@ end
     @test @fastmath(minimum(Float32[4 5 6; 7 8 9]; dims=2)) == Float32[4.0; 7.0;;]
     @test @fastmath(maximum(abs, [4+im -5 6-im; -7 8 -9]; dims=1)) == [7.0 8.0 9.0]
     @test @fastmath(minimum(cbrt, [4 -5 6; -7 8 -9]; dims=2)) == cbrt.([-5; -9;;])
+
+    x = randn(3,4,5)
+    x1 = sum(x; dims=1)
+    x23 = sum(x; dims=(2,3))
+    @test @fastmath(maximum!(x1, x)) ≈ maximum(x; dims=1)
+    @test x1 ≈ maximum(x; dims=1)
+    @test @fastmath(minimum!(x23, x)) ≈ minimum(x; dims=(2,3))
+    @test x23 ≈ minimum(x; dims=(2,3))
+    @test @fastmath(maximum!(abs, x23, x .+ im)) ≈ maximum(abs, x .+ im; dims=(2,3))
+    @test @fastmath(minimum!(abs2, x1, x .+ im)) ≈ minimum(abs2, x .+ im; dims=1)
 end
 
 @testset "issue #10544" begin

--- a/test/fastmath.jl
+++ b/test/fastmath.jl
@@ -207,6 +207,21 @@ end
         @test @fastmath(cis(third)) ≈ cis(third)
     end
 end
+
+@testset "reductions" begin
+    @test @fastmath(maximum([1,2,3])) == 3
+    @test @fastmath(minimum([1,2,3])) == 1
+    @test @fastmath(maximum(abs2, [1,2,3+0im])) == 9
+    @test @fastmath(minimum(sqrt, [1,2,3])) == 1
+    @test @fastmath(maximum(Float32[4 5 6; 7 8 9])) == 9.0f0
+    @test @fastmath(minimum(Float32[4 5 6; 7 8 9])) == 4.0f0
+
+    @test @fastmath(maximum(Float32[4 5 6; 7 8 9]; dims=1)) == Float32[7.0 8.0 9.0]
+    @test @fastmath(minimum(Float32[4 5 6; 7 8 9]; dims=2)) == Float32[4.0; 7.0;;]
+    @test @fastmath(maximum(abs, [4+im -5 6-im; -7 8 -9]; dims=1)) == [7.0 8.0 9.0]
+    @test @fastmath(minimum(cbrt, [4 -5 6; -7 8 -9]; dims=2)) == cbrt.([-5; -9;;])
+end
+
 @testset "issue #10544" begin
     a = fill(1.,2,2)
     b = fill(1.,2,2)


### PR DESCRIPTION
This implements #48082. 



```julia
julia> fast_maximum(x::AbstractArray{T}; dims=:) where T = @fastmath reduce(max, x; dims, init=typemin(T));

julia> let x = randn(Float32, 100, 1000)
           @btime maximum($x; dims=1)
           @btime fast_maximum($x; dims=1)
           @btime @fastmath maximum($x; dims=1)  # this PR
       end;
  min 708.375 μs, mean 713.129 μs (4 allocations, 4.17 KiB)
  min 12.375 μs, mean 13.942 μs (1 allocation, 4.06 KiB)
  min 14.791 μs, mean 15.820 μs (3 allocations, 4.12 KiB)

julia> let x = randn(Float32, 100, 1000)
           @btime maximum($x)
           @btime fast_maximum($x)
           @btime @fastmath maximum($x)  # this PR
       end;
  min 104.250 μs, mean 105.658 μs (0 allocations)
  min 12.708 μs, mean 13.205 μs (0 allocations)
  min 9.791 μs, mean 10.284 μs (0 allocations)
```

The need for this would be reduced if https://github.com/JuliaLang/julia/pull/45581 happened soon. 

Currently fails because of an order of imports problem I think. 