### PR TITLE
better example construct on RegexMatch

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -182,7 +182,7 @@ julia> m.captures[2]    # same as m[2]
 julia> m["minute"]
 "30"
 
-julia> hr, min, ampm = m;
+julia> hr, min, ampm = m; # destructure capture groups by iteration
 
 julia> hr
 "11"

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -164,7 +164,7 @@ See [`keys`](@ref keys(::RegexMatch)) for more information.
 
 # Examples
 ```jldoctest
-julia> m = match(r"(?<hour>\d+):(?<minute>\d+)(am|pm)?", "The time is 11:30")
+julia> m = match(r"(?<hour>\\d+):(?<minute>\\d+)(am|pm)?", "The time is 11:30")
 RegexMatch("11:30", hour="11", minute="30", 3=nothing)
 
 julia> m.match

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -164,19 +164,28 @@ See [`keys`](@ref keys(::RegexMatch)) for more information.
 
 # Examples
 ```jldoctest
-julia> m = match(r"(?<hour>\\d+):(?<minute>\\d+)(am|pm)?", "11:30 in the morning")
+julia> m = match(r"(?<hour>\d+):(?<minute>\d+)(am|pm)?", "The time is 11:30")
 RegexMatch("11:30", hour="11", minute="30", 3=nothing)
+
+julia> m.match
+"11:30"
+
+julia> m.captures
+3-element Vector{Union{Nothing, SubString{String}}}:
+ "11"
+ "30"
+ nothing
+
+julia> m.captures[2]    # same as m[2]
+"30"
+
+julia> m["minute"]
+"30"
 
 julia> hr, min, ampm = m;
 
 julia> hr
 "11"
-
-julia> m["minute"]
-"30"
-
-julia> m.match
-"11:30"
 ```
 """
 struct RegexMatch <: AbstractMatch

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -164,7 +164,7 @@ See [`keys`](@ref keys(::RegexMatch)) for more information.
 
 # Examples
 ```jldoctest
-julia> m = match(r"(?<hour>\\d+):(?<minute>\\d+)(am|pm)?", "The time is 11:30")
+julia> m = match(r"(?<hour>\\d+):(?<minute>\\d+)(am|pm)?", "11:30 in the morning")
 RegexMatch("11:30", hour="11", minute="30", 3=nothing)
 
 julia> m.match
@@ -176,8 +176,6 @@ julia> m.captures
  "30"
  nothing
 
-julia> m.captures[2]    # same as m[2]
-"30"
 
 julia> m["minute"]
 "30"


### PR DESCRIPTION
The current example section of `RegexMatch` IMHO does not clarify the docstring of `RegexMatch` in a simple view.

The docstring talks about:
> The captures field stores the substrings for each capture group, indexed by number. To index by capture group name, the entire match object should be indexed instead, as shown in the examples.

But no example is provided to show the similarities (or difference in syntax) between what this section is actually trying to point out. This PR provides this example and easily makes clear what that statement means.

A shorter string was used over the former long one, so it does not overlap multiple lines in the REPL (which makes it kinda dirty to the eyes).