### PR TITLE
Make cache mismatch log more informative

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2514,11 +2514,10 @@ struct CacheFlags
 
     CacheFlags(f::Int) = CacheFlags(UInt8(f))
     function CacheFlags(f::UInt8)
-        s = bitstring(f)
-        use_pkgimages = parse(Bool, s[end])
-        debug_level = parse(Int, s[end-2:end-1], base=2)
-        check_bounds = parse(Bool, s[end-3])
-        opt_level = parse(Int, s[end-5:end-4], base=2)
+        use_pkgimages = Bool(f & 1)
+        debug_level = Int((f >> 1) & 3)
+        check_bounds = Bool((f >> 2) & 1)
+        opt_level = Int((f >> 4) & 3)
         new(use_pkgimages, debug_level, check_bounds, opt_level)
     end
 end

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -621,6 +621,7 @@ JL_DLLEXPORT uint8_t jl_cache_flags(void)
     flags |= (jl_options.opt_level & 3) << 4;
     // NOTES:
     // In contrast to check-bounds, inline has no "observable effect"
+    // CacheFlags in loading.jl should be kept in-sync with this
     return flags;
 }
 


### PR DESCRIPTION
Master
```
┌ Debug: Rejecting cache file /tmp/jl_aCrjdm/compiled/v1.9/LibSSH2_jll/K6mup_TmZuG.ji for LibSSH2_jll [29816b5a-b9ab-546f-933c-edad1886dfa8] since the flags are mismatched
│   cachefile_flags = 35
│   current_flags = 51
└ @ Base loading.jl:2526
```

This PR
```
% ./julia -O2
julia> using Revise
[ Info: Precompiling Revise [295af30f-e4ad-537b-8983-00126c2a3abe]

% JULIA_DEBUG=loading ./julia -O3
julia> using Revise
┌ Debug: Rejecting cache file /Users/ian/.julia/compiled/v1.10/Revise/M1Qoh_7IH4d.ji for Revise [295af30f-e4ad-537b-8983-00126c2a3abe] since the flags are mismatched
│   current session: use_pkgimages = true, debug_level = 1, check_bounds = false, opt_level = 3
│   cache file:      use_pkgimages = true, debug_level = 1, check_bounds = false, opt_level = 2
└ @ Base loading.jl:2550