### PR TITLE
Fix bug in TerminalMenus when pagesize is larger than the number of options.

### DIFF
--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -216,7 +216,7 @@ function request(term::REPL.Terminals.TTYTerminal, m::AbstractMenu; cursor::Unio
                 m.pageoffset = 0
             elseif c == Int(END_KEY)
                 cursor[] = lastoption
-                m.pageoffset = lastoption - m.pagesize
+                m.pageoffset = max(0, lastoption - m.pagesize)
             elseif c == 13 # <enter>
                 # will break if pick returns true
                 pick(m, cursor[]) && break
@@ -269,7 +269,7 @@ function move_up!(m::AbstractMenu, cursor::Int, lastoption::Int=numoptions(m))
     elseif scroll_wrap(m)
         # wrap to bottom
         cursor = lastoption
-        m.pageoffset = lastoption - m.pagesize
+        m.pageoffset = max(0, lastoption - m.pagesize)
     end
     return cursor
 end
@@ -299,7 +299,7 @@ end
 
 function page_down!(m::AbstractMenu, cursor::Int, lastoption::Int=numoptions(m))
     m.pageoffset += m.pagesize - (cursor == 1 ? 1 : 0)
-    m.pageoffset = min(m.pageoffset, lastoption - m.pagesize)
+    m.pageoffset = max(0, min(m.pageoffset, lastoption - m.pagesize))
     return min(cursor + m.pagesize, lastoption)
 end
 

--- a/stdlib/REPL/test/TerminalMenus/dynamic_menu.jl
+++ b/stdlib/REPL/test/TerminalMenus/dynamic_menu.jl
@@ -116,3 +116,36 @@ str = String(take!(io))
 nback, strs = linesplitter(str)
 @test nback == 3
 @test strs == ["^  3", "   4", "   5", " > 6*"]
+
+# Test with page size larger than number of options.
+# END_KEY, PAGE_DOWN, and ARROW_UP (from first element with scroll
+# wrap) used to be problematic. The last two are tested here, whereas
+# the first one is unreachable within the `request` function.
+menu = DynamicMenu(4, 0, -1, 2, TerminalMenus.Config(scroll_wrap = true))
+
+cursor = 1
+state = TerminalMenus.printmenu(io, menu, cursor; init=true)
+str = String(take!(io))
+@test count(isequal('\n'), str) == state
+nback, strs = linesplitter(str)
+@test nback == 0
+@test strs == [" > 1*", "   2"]
+
+cursor = TerminalMenus.page_down!(menu, cursor)
+@test cursor == menu.numopts
+@test menu.pageoffset == 0
+state = TerminalMenus.printmenu(io, menu, cursor; oldstate=state)
+str = String(take!(io))
+nback, strs = linesplitter(str)
+@test nback == 1
+@test strs == ["   1", " > 2*"]
+
+cursor = TerminalMenus.page_up!(menu, cursor)
+cursor = TerminalMenus.move_up!(menu, cursor)
+@test cursor == menu.numopts
+@test menu.pageoffset == 0
+state = TerminalMenus.printmenu(io, menu, cursor; oldstate=state)
+str = String(take!(io))
+nback, strs = linesplitter(str)
+@test nback == 1
+@test strs == ["   1", " > 2*"]


### PR DESCRIPTION
Custom terminal menus with pagesize larger than the number of options didn't work correctly when you navigate with `END_KEY`, `PAGE_DOWN`, or do `ARROW_UP` from the top option with `scroll_wrap = true`. Demonstration:
```
using REPL.TerminalMenus
mutable struct DynamicMenu <: TerminalMenus._ConfiguredMenu{TerminalMenus.Config}
    pagesize::Int
    pageoffset::Int
    selected::Int
    numopts::Int
    config::TerminalMenus.Config
end
TerminalMenus.numoptions(m::DynamicMenu) = m.numopts
function TerminalMenus.writeline(buf::IO, m::DynamicMenu, idx::Int, iscursor::Bool)
    print(buf, idx)
    iscursor && print(buf, '*')
end
menu = DynamicMenu(4, 0, -1, 2, TerminalMenus.Config(scroll_wrap = true))
state = TerminalMenus.printmenu(stdout, menu, 1; init=true);
TerminalMenus.page_down!(menu, 1)
TerminalMenus.printmenu(stdout, menu, 1; oldstate=state);
```
The last line outputs
```
   -1
   0
 > 1*
   2
```
but the first two options shouldn't be there.

Discovered in https://github.com/GunnarFarneback/PackageCompatUI.jl/issues/15 where it leads to out of bounds indexing.

This PR fixes the problem and adds tests for two of the failures.