### PR TITLE
Don't use pkgimage for package if any includes fall in tracked path for coverage or alloc tracking

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -245,7 +245,7 @@ function julia_cmd(julia=joinpath(Sys.BINDIR, julia_exename()); cpu_target::Unio
         push!(addflags, "--pkgimages=no")
     else
         # If pkgimage is set, malloc_log and code_coverage should not
-        @assert opts.malloc_log == 0 && opts.code_coverage == 0
+        @assert opts.malloc_log in (0, 3) && opts.code_coverage in (0, 3)
     end
     return `$julia -C$cpu_target -J$image_file $addflags`
 end

--- a/src/init.c
+++ b/src/init.c
@@ -804,7 +804,8 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
 #endif
 
     if ((jl_options.outputo || jl_options.outputbc || jl_options.outputasm) &&
-        (jl_options.code_coverage || jl_options.malloc_log)) {
+        (jl_options.code_coverage == 1 || jl_options.code_coverage == 2 || 
+         jl_options.malloc_log == 1 || jl_options.malloc_log == 2)) {
         jl_error("cannot generate code-coverage or track allocation information while generating a .o, .bc, or .s output file");
     }
 

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -860,10 +860,17 @@ restart_switch:
                       "This is a bug, please report it.", c);
         }
     }
-    if (codecov || malloclog) {
+    if (codecov == 1 || codecov == 2) {
         if (pkgimage_explicit && jl_options.use_pkgimages) {
             jl_errorf("julia: Can't use --pkgimages=yes together "
-                      "with --track-allocation or --code-coverage.");
+                      "with --code-coverage=user|all");
+        }
+        jl_options.use_pkgimages = 0;
+    }
+    if (malloclog == 1 || malloclog == 2) {
+        if (pkgimage_explicit && jl_options.use_pkgimages) {
+            jl_errorf("julia: Can't use --pkgimages=yes together "
+                      "with --track-allocation=user|all");
         }
         jl_options.use_pkgimages = 0;
     }

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -3494,7 +3494,7 @@ static jl_value_t *jl_validate_cache_file(ios_t *f, jl_array_t *depmods, uint64_
                 "Precompile file header verification checks failed.");
     }
     uint8_t flags = read_uint8(f);
-    if (pkgimage && !jl_match_cache_flags(flags)) {
+    if (pkgimage && !jl_match_cache_flags(flags, jl_cache_flags())) {
         return jl_get_exceptionf(jl_errorexception_type, "Pkgimage flags mismatch");
     }
     if (!pkgimage) {


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/48071

Makes disabling pkgimages specific to the package being coverage (or alloc) tracked.
i.e. should increase the testing of pkgimages in ecosystem CI

Does more than this need to be done @vchuravy ? I'm guessing so given code_coverage != 0 disables pkgimages globally, I believe?