### PR TITLE
another fix to `--compile=all` on 1.8

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -287,8 +287,6 @@ jl_code_info_t *jl_type_infer(jl_method_instance_t *mi, size_t world, int force)
 #ifdef ENABLE_INFERENCE
     if (mi->inInference && !force)
         return NULL;
-    if (jl_is_method(mi->def.method) && mi->def.method->unspecialized == mi)
-        return NULL; // be careful never to infer the unspecialized method, this would not be valid
 
     jl_value_t **fargs;
     JL_GC_PUSHARGS(fargs, 3);


### PR DESCRIPTION
Would be good to get this in if there is going to be a 1.8.5.