### PR TITLE
lattice: Thread lattice through to va_process_argtypes

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -927,18 +927,18 @@ struct ConditionalArgtypes <: ForwardableArgtypes
 end
 
 """
-    matching_cache_argtypes(linfo::MethodInstance, argtypes::ConditionalArgtypes)
+    matching_cache_argtypes(𝕃::AbstractLattice, linfo::MethodInstance, argtypes::ConditionalArgtypes)
 
 The implementation is able to forward `Conditional` of `argtypes`,
 as well as the other general extended lattice inforamtion.
 """
-function matching_cache_argtypes(linfo::MethodInstance, argtypes::ConditionalArgtypes)
+function matching_cache_argtypes(𝕃::AbstractLattice, linfo::MethodInstance, argtypes::ConditionalArgtypes)
     (; arginfo, sv) = argtypes
     (; fargs, argtypes) = arginfo
     given_argtypes = Vector{Any}(undef, length(argtypes))
     def = linfo.def::Method
     nargs = Int(def.nargs)
-    cache_argtypes, overridden_by_const = matching_cache_argtypes(linfo)
+    cache_argtypes, overridden_by_const = matching_cache_argtypes(𝕃, linfo)
     local condargs = nothing
     for i in 1:length(argtypes)
         argtype = argtypes[i]
@@ -969,7 +969,7 @@ function matching_cache_argtypes(linfo::MethodInstance, argtypes::ConditionalArg
     end
     if condargs !== nothing
         given_argtypes = let condargs=condargs
-            va_process_argtypes(given_argtypes, linfo) do isva_given_argtypes::Vector{Any}, last::Int
+            va_process_argtypes(𝕃, given_argtypes, linfo) do isva_given_argtypes::Vector{Any}, last::Int
                 # invalidate `Conditional` imposed on varargs
                 for (slotid, i) in condargs
                     if slotid ≥ last && (1 ≤ i ≤ length(isva_given_argtypes)) # `Conditional` is already widened to vararg-tuple otherwise
@@ -979,9 +979,9 @@ function matching_cache_argtypes(linfo::MethodInstance, argtypes::ConditionalArg
             end
         end
     else
-        given_argtypes = va_process_argtypes(given_argtypes, linfo)
+        given_argtypes = va_process_argtypes(𝕃, given_argtypes, linfo)
     end
-    return pick_const_args!(cache_argtypes, overridden_by_const, given_argtypes)
+    return pick_const_args!(𝕃, cache_argtypes, overridden_by_const, given_argtypes)
 end
 
 function abstract_call_method_with_const_args(interp::AbstractInterpreter,

--- a/base/compiler/abstractlattice.jl
+++ b/base/compiler/abstractlattice.jl
@@ -1,6 +1,5 @@
 # TODO add more documentations
 
-abstract type AbstractLattice end
 function widenlattice end
 function is_valid_lattice_norec end
 

--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -1,14 +1,14 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 """
-    matching_cache_argtypes(linfo::MethodInstance) ->
+    matching_cache_argtypes(𝕃::AbstractLattice, linfo::MethodInstance) ->
         (cache_argtypes::Vector{Any}, overridden_by_const::BitVector)
 
 Returns argument types `cache_argtypes::Vector{Any}` for `linfo` that are in the native
 Julia type domain. `overridden_by_const::BitVector` is all `false` meaning that
 there is no additional extended lattice information there.
 
-    matching_cache_argtypes(linfo::MethodInstance, argtypes::ForwardableArgtypes) ->
+    matching_cache_argtypes(𝕃::AbstractLattice, linfo::MethodInstance, argtypes::ForwardableArgtypes) ->
         (cache_argtypes::Vector{Any}, overridden_by_const::BitVector)
 
 Returns cache-correct extended lattice argument types `cache_argtypes::Vector{Any}`
@@ -22,7 +22,7 @@ so that we can construct cache-correct `InferenceResult`s in the first place.
 """
 function matching_cache_argtypes end
 
-function matching_cache_argtypes(linfo::MethodInstance)
+function matching_cache_argtypes(𝕃::AbstractLattice, linfo::MethodInstance)
     mthd = isa(linfo.def, Method) ? linfo.def::Method : nothing
     cache_argtypes = most_general_argtypes(mthd, linfo.specTypes)
     return cache_argtypes, falses(length(cache_argtypes))
@@ -33,33 +33,33 @@ struct SimpleArgtypes <: ForwardableArgtypes
 end
 
 """
-    matching_cache_argtypes(linfo::MethodInstance, argtypes::SimpleArgtypes)
+    matching_cache_argtypes(𝕃::AbstractLattice, linfo::MethodInstance, argtypes::SimpleArgtypes)
 
 The implementation for `argtypes` with general extended lattice information.
 This is supposed to be used for debugging and testing or external `AbstractInterpreter`
 usages and in general `matching_cache_argtypes(::MethodInstance, ::ConditionalArgtypes)`
 is more preferred it can forward `Conditional` information.
 """
-function matching_cache_argtypes(linfo::MethodInstance, simple_argtypes::SimpleArgtypes)
+function matching_cache_argtypes(𝕃::AbstractLattice, linfo::MethodInstance, simple_argtypes::SimpleArgtypes)
     (; argtypes) = simple_argtypes
     given_argtypes = Vector{Any}(undef, length(argtypes))
     for i = 1:length(argtypes)
         given_argtypes[i] = widenslotwrapper(argtypes[i])
     end
-    given_argtypes = va_process_argtypes(given_argtypes, linfo)
-    return pick_const_args(linfo, given_argtypes)
+    given_argtypes = va_process_argtypes(𝕃, given_argtypes, linfo)
+    return pick_const_args(𝕃, linfo, given_argtypes)
 end
 
-function pick_const_args(linfo::MethodInstance, given_argtypes::Vector{Any})
-    cache_argtypes, overridden_by_const = matching_cache_argtypes(linfo)
-    return pick_const_args!(cache_argtypes, overridden_by_const, given_argtypes)
+function pick_const_args(𝕃::AbstractLattice, linfo::MethodInstance, given_argtypes::Vector{Any})
+    cache_argtypes, overridden_by_const = matching_cache_argtypes(𝕃, linfo)
+    return pick_const_args!(𝕃, cache_argtypes, overridden_by_const, given_argtypes)
 end
 
-function pick_const_args!(cache_argtypes::Vector{Any}, overridden_by_const::BitVector, given_argtypes::Vector{Any})
+function pick_const_args!(𝕃::AbstractLattice, cache_argtypes::Vector{Any}, overridden_by_const::BitVector, given_argtypes::Vector{Any})
     for i = 1:length(given_argtypes)
         given_argtype = given_argtypes[i]
         cache_argtype = cache_argtypes[i]
-        if !is_argtype_match(fallback_lattice, given_argtype, cache_argtype, false)
+        if !is_argtype_match(𝕃, given_argtype, cache_argtype, false)
             # prefer the argtype we were given over the one computed from `linfo`
             cache_argtypes[i] = given_argtype
             overridden_by_const[i] = true
@@ -78,9 +78,9 @@ function is_argtype_match(𝕃::AbstractLattice,
     return !overridden_by_const
 end
 
-va_process_argtypes(given_argtypes::Vector{Any}, linfo::MethodInstance) =
-    va_process_argtypes(Returns(nothing), given_argtypes, linfo)
-function va_process_argtypes(@nospecialize(va_handler!), given_argtypes::Vector{Any}, linfo::MethodInstance)
+va_process_argtypes(𝕃::AbstractLattice, given_argtypes::Vector{Any}, linfo::MethodInstance) =
+    va_process_argtypes(Returns(nothing), 𝕃, given_argtypes, linfo)
+function va_process_argtypes(@nospecialize(va_handler!), 𝕃::AbstractLattice, given_argtypes::Vector{Any}, linfo::MethodInstance)
     def = linfo.def::Method
     isva = def.isva
     nargs = Int(def.nargs)
@@ -95,7 +95,7 @@ function va_process_argtypes(@nospecialize(va_handler!), given_argtypes::Vector{
             else
                 last = nargs
             end
-            isva_given_argtypes[nargs] = tuple_tfunc(fallback_lattice, given_argtypes[last:end])
+            isva_given_argtypes[nargs] = tuple_tfunc(𝕃, given_argtypes[last:end])
             va_handler!(isva_given_argtypes, last)
         end
         return isva_given_argtypes

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -104,7 +104,7 @@ struct IRInterpretationState
     lazydomtree::LazyDomtree
     function IRInterpretationState(interp::AbstractInterpreter,
         ir::IRCode, mi::MethodInstance, world::UInt, argtypes::Vector{Any})
-        argtypes = va_process_argtypes(argtypes, mi)
+        argtypes = va_process_argtypes(typeinf_lattice(interp), argtypes, mi)
         for i = 1:length(argtypes)
             argtypes[i] = widenslotwrapper(argtypes[i])
         end

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -11,7 +11,7 @@ the original `ci::CodeInfo` are modified.
 function inflate_ir!(ci::CodeInfo, linfo::MethodInstance)
     sptypes = sptypes_from_meth_instance(linfo)
     if ci.inferred
-        argtypes, _ = matching_cache_argtypes(linfo)
+        argtypes, _ = matching_cache_argtypes(fallback_lattice, linfo)
     else
         argtypes = Any[ Any for i = 1:length(ci.slotflags) ]
     end

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -17,6 +17,7 @@ the following methods to satisfy the `AbstractInterpreter` API requirement:
 - `code_cache(interp::NewInterpreter)` - return the global inference cache
 """
 abstract type AbstractInterpreter end
+abstract type AbstractLattice end
 
 struct ArgInfo
     fargs::Union{Nothing,Vector{Any}}
@@ -57,11 +58,11 @@ mutable struct InferenceResult
             WorldRange(), Effects(), Effects(), nothing, true)
     end
 end
-function InferenceResult(linfo::MethodInstance)
-    return InferenceResult(linfo, matching_cache_argtypes(linfo)...)
+function InferenceResult(linfo::MethodInstance; lattice::AbstractLattice=fallback_lattice)
+    return InferenceResult(linfo, matching_cache_argtypes(lattice, linfo)...)
 end
-function InferenceResult(linfo::MethodInstance, argtypes::ForwardableArgtypes)
-    return InferenceResult(linfo, matching_cache_argtypes(linfo, argtypes)...)
+function InferenceResult(linfo::MethodInstance, argtypes::ForwardableArgtypes; lattice::AbstractLattice=fallback_lattice)
+    return InferenceResult(linfo, matching_cache_argtypes(lattice, linfo, argtypes)...)
 end
 
 """


### PR DESCRIPTION
Which in particular calls `tuple_tfunc`, which needs a correct lattice
argument to retain precision.