### PR TITLE
allow concrete-eval for `Union`-type arguments

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -211,7 +211,7 @@ julia> Base.isbitsunion(Union{Float64, String})
 false
 ```
 """
-isbitsunion(u::Type) = u isa Union && allocatedinline(u)
+isbitsunion(@nospecialize u::Type) = u isa Union && allocatedinline(u)
 
 function _unsetindex!(A::Array, i::Int)
     @inline

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -17,14 +17,16 @@ function hasuniquerep(@nospecialize t)
     isa(t, TypeVar) && return false # TypeVars are identified by address, not equality
     iskindtype(typeof(t)) || return true # non-types are always compared by egal in the type system
     isconcretetype(t) && return true # these are also interned and pointer comparable
-    if isa(t, DataType) && t.name !== Tuple.name && !isvarargtype(t) # invariant DataTypes
-        return _all(hasuniquerep, t.parameters)
+    if isa(t, Union)
+        return hasuniquerep(t.a) && hasuniquerep(t.b)
+    elseif isa(t, DataType) && t.name !== Tuple.name && !isvarargtype(t) # invariant DataTypes
+        return all(hasuniquerep, t.parameters)
     end
     return false
 end
 
 """
-    isTypeDataType(@nospecialize t) -> Bool
+    isTypeDataType(t) -> Bool
 
 For a type `t` test whether ∀S s.t. `isa(S, rewrap_unionall(Type{t}, ...))`,
 we have `isa(S, DataType)`. In particular, if a statement is typed as `Type{t}`

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -506,6 +506,7 @@
     XX(jl_uncompress_argname_n) \
     XX(jl_uncompress_ir) \
     XX(jl_undefined_var_error) \
+    XX(jl_union_sort_cmp) \
     XX(jl_unwrap_unionall) \
     XX(jl_has_no_field_error) \
     XX(jl_value_ptr) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -458,7 +458,7 @@ static int datatype_name_cmp(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT
 
 // sort singletons first, then DataTypes, then UnionAlls,
 // ties broken alphabetically including module name & type parameters
-static int union_sort_cmp(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT
+JL_DLLEXPORT int jl_union_sort_cmp(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT
 {
     if (a == NULL)
         return b == NULL ? 0 : 1;
@@ -548,7 +548,7 @@ static void isort_union(jl_value_t **a, size_t len) JL_NOTSAFEPOINT
         jl_value_t *x = a[i];
         for (j = i; j > 0; j--) {
             jl_value_t *y = a[j - 1];
-            if (!(union_sort_cmp(x, y) < 0))
+            if (!(jl_union_sort_cmp(x, y) < 0))
                 break;
             a[j] = y;
         }

--- a/src/julia.h
+++ b/src/julia.h
@@ -1702,6 +1702,7 @@ JL_DLLEXPORT jl_value_t *jl_type_unionall(jl_tvar_t *v, jl_value_t *body);
 JL_DLLEXPORT const char *jl_typename_str(jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT const char *jl_typeof_str(jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_type_morespecific(jl_value_t *a, jl_value_t *b);
+JL_DLLEXPORT int jl_union_sort_cmp(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT;
 
 STATIC_INLINE int jl_is_dispatch_tupletype(jl_value_t *v) JL_NOTSAFEPOINT
 {

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5608,6 +5608,11 @@ end |> only === Float64
     Val(countvars50037(1, var))
 end == Val{1}
 
+# `isconstType` for `Union`-types
+@test Base.infer_return_type((Type{Union{Int,UInt}},)) do T
+    Base.allocatedinline(T) ? nothing : missing
+end === Nothing
+
 # Issue #52168
 f52168(x, t::Type) = x::NTuple{2, Base.inferencebarrier(t)::Type}
 @test f52168((1, 2.), Any) === (1, 2.)


### PR DESCRIPTION
By allowing `hasuniquerep` to analyze `Union`-types. Motivated by <https://github.com/aviatesk/JET.jl/issues/444>.

@vtjnash do you think this extension on `hasuniquerep` is valid?