### PR TITLE
make `getfield_notundefined` more robust

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1227,12 +1227,14 @@ end
 
 @nospecs function getfield_notundefined(typ0, name)
     if isa(typ0, Const) && isa(name, Const)
+        typv = typ0.val
         namev = name.val
+        isa(typv, Module) && return true
         if isa(namev, Symbol) || isa(namev, Int)
             # Fields are not allowed to transition from defined to undefined, so
             # even if the field is not const, all we need to check here is that
             # it is defined here.
-            return isdefined(typ0.val, namev)
+            return isdefined(typv, namev)
         end
     end
     typ0 = widenconst(typ0)

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -271,6 +271,8 @@ for TupleType = Any[Tuple{Int,Int,Int}, Tuple{Int,Vararg{Int}}, Tuple{Any}, Tupl
 end
 # skip analysis on fields that are known to be defined syntactically
 @test Core.Compiler.getfield_notundefined(SyntacticallyDefined{Float64}, Symbol)
+@test Core.Compiler.getfield_notundefined(Const(Main), Const(:var))
+@test Core.Compiler.getfield_notundefined(Const(Main), Const(42))
 # high-level tests for `getfield_notundefined`
 @test Base.infer_effects() do
     Maybe{Int}()


### PR DESCRIPTION
Follow up #48203.
See the added test cases for the purpose of this commit.