### PR TITLE
Turn off debug build for TSAN, fixes #48031

### DIFF
--- a/contrib/tsan/Make.user.tsan
+++ b/contrib/tsan/Make.user.tsan
@@ -11,6 +11,3 @@ USE_BINARYBUILDER_LLVM=1
 
 override SANITIZE=1
 override SANITIZE_THREAD=1
-
-# default to a debug build for better line number reporting
-override JULIA_BUILD_MODE=debug


### PR DESCRIPTION
I can now build TSAN-enabled Julia on 1.9.0-beta2. Before, with debug build mode on, I hit some assertions. Fixes #48031.

cc @vtjnash @gbaraldi.