### PR TITLE
More robust check in `test/math.jl`

### DIFF
--- a/test/math.jl
+++ b/test/math.jl
@@ -1365,13 +1365,16 @@ end
             # note x won't be subnormal here
             x=rand(T)*100; y=rand(T)*200-100
             got, expected = x^y, widen(x)^y
+            # Narrow `expected` back to `T` before doing the difference, because
+            # we compare with `eps` of `T(expected)`.
+            diff = abs(T(expected) - T(got))
             if isfinite(eps(T(expected)))
                 if y == T(-2) # unfortunately x^-2 is less accurate for performance reasons.
-                    @test abs(expected-got) <= POW_TOLS[T][3]*eps(T(expected)) || (x,y)
+                    @test diff <= POW_TOLS[T][3]*eps(T(expected)) || (x,y)
                 elseif y == T(3) # unfortunately x^3 is less accurate for performance reasons.
-                    @test abs(expected-got) <= POW_TOLS[T][4]*eps(T(expected)) || (x,y)
+                    @test diff <= POW_TOLS[T][4]*eps(T(expected)) || (x,y)
                 else
-                    @test abs(expected-got) <= POW_TOLS[T][1]*eps(T(expected)) || (x,y)
+                    @test diff <= POW_TOLS[T][1]*eps(T(expected)) || (x,y)
                 end
             end
         end
@@ -1380,7 +1383,7 @@ end
             x=rand(T)*floatmin(T); y=rand(T)*3-T(1.2)
             got, expected = x^y, widen(x)^y
             if isfinite(eps(T(expected)))
-                @test abs(expected-got) <= POW_TOLS[T][2]*eps(T(expected)) || (x,y)
+                @test abs(T(expected) - T(got)) <= POW_TOLS[T][2]*eps(T(expected)) || (x,y)
             end
         end
         # test (-x)^y for y larger than typemax(Int)


### PR DESCRIPTION
For reference, today [a test failed](https://buildkite.com/julialang/julia-master/builds/19992#01859a44-bbad-4cd2-960b-f464ee5c26a4/720-1537) with
```
Error in testset math:
Error During Test at /cache/build/default-amdci5-6/julialang/julia-master/julia-e163c84c9d/share/julia/test/math.jl:1374
  Expression evaluated to non-Boolean
  Expression: abs(expected - got) <= (POW_TOLS[T])[1] * eps(T(expected)) || (x, y)
       Value: (0.0013653274095082324, -97.60372292227069)
```
This can be reproduced with
```
julia> x, y = (0.0013653274095082324, -97.60372292227069)
(0.0013653274095082324, -97.60372292227069)

julia> got, expected = x^y, widen(x)^y
(4.0883939487500343e279, 4.088393948750034788744191479961798830319233864898102306395137698121077029309752e+279)

julia> abs(expected-got) <= eps(Float64(expected))
false
```
`got` isn't too much off of `expected`, but in the test we do `expected-got` mixing up `expected::widen(T)` with `got::T`, and then compare the difference with `esp` of the narrowed `T(expected)`.

With the proposed change, we narrow `expected` back to `T` _before_ taking the difference with `got`.  Does this make sense? :slightly_smiling_face: 