### PR TITLE
Add .clangd file for clang language server

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,2 @@
 CompileFlags:
-  Add: [-I.,-I.., -Iflisp, -Isupport, -I../usr/include, -I../../usr/include,-I.., -Wall, ]
+  Add: [-I., -I.., -Iflisp, -Isupport, -I../support, -I../usr/include, -I../../usr/include, -Wall,]

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  Add: [-I.,-I.., -Iflisp, -Isupport, -I../usr/include, -I../../usr/include,-I.., -Wall, ]

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 .idea/*
 .vscode/*
 *.heapsnapshot
+.cache
 # Buildkite: Ignore the entire .buildkite directory
 /.buildkite
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -6,7 +6,7 @@
 #ifdef LIBRARY_EXPORTS
 // Generated file, needs to be searched in include paths so that the builddir
 // retains priority
-#include <jl_internal_funcs.inc>
+#include "jl_internal_funcs.inc"
 #undef jl_setjmp
 #undef jl_longjmp
 #undef jl_egal

--- a/src/julia.h
+++ b/src/julia.h
@@ -6,7 +6,7 @@
 #ifdef LIBRARY_EXPORTS
 // Generated file, needs to be searched in include paths so that the builddir
 // retains priority
-#include "jl_internal_funcs.inc"
+#include <jl_internal_funcs.inc>
 #undef jl_setjmp
 #undef jl_longjmp
 #undef jl_egal


### PR DESCRIPTION
This adds a `.clangd` file that tells it where to find the includes and whatnot, which makes it happier. Also fix a small thing it was complaining about :).