### PR TITLE
effects: Improve is_mutation_free_type to also include immutable type…

### DIFF
--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -336,11 +336,13 @@ end
 is_consistent_argtype(@nospecialize ty) = is_consistent_type(widenconst(ignorelimited(ty)))
 is_consistent_type(@nospecialize ty) = _is_consistent_type(unwrap_unionall(ty))
 function _is_consistent_type(@nospecialize ty)
+    ty = unwrap_unionall(ty)
     if isa(ty, Union)
         return is_consistent_type(ty.a) && is_consistent_type(ty.b)
+    elseif isa(ty, DataType)
+        return datatype_isidentityfree(ty)
     end
-    # N.B. String and Symbol are mutable, but also egal always, and so they never be inconsistent
-    return ty === String || ty === Symbol || isbitstype(ty)
+    return false
 end
 
 is_immutable_argtype(@nospecialize ty) = is_immutable_type(widenconst(ignorelimited(ty)))

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -93,7 +93,7 @@ function datatype_min_ninitialized(t::DataType)
     return length(t.name.names) - t.name.n_uninitialized
 end
 
-has_concrete_subtype(d::DataType) = d.flags & 0x20 == 0x20 # n.b. often computed only after setting the type and layout fields
+has_concrete_subtype(d::DataType) = d.flags & 0x0020 == 0x0020 # n.b. often computed only after setting the type and layout fields
 
 # determine whether x is a valid lattice element tag
 # For example, Type{v} is not valid if v is a value
@@ -353,18 +353,6 @@ function _is_immutable_type(@nospecialize ty)
 end
 
 is_mutation_free_argtype(@nospecialize argtype) =
-    is_mutation_free_type(widenconst(ignorelimited(argtype)))
+    ismutationfree(widenconst(ignorelimited(argtype)))
 is_mutation_free_type(@nospecialize ty) =
-    _is_mutation_free_type(unwrap_unionall(ty))
-function _is_mutation_free_type(@nospecialize ty)
-    if isa(ty, Union)
-        return _is_mutation_free_type(ty.a) && _is_mutation_free_type(ty.b)
-    end
-    if isType(ty) || ty === DataType || ty === String || ty === Symbol || ty === SimpleVector
-        return true
-    end
-    # this is okay as access and modification on global state are tracked separately
-    ty === Module && return true
-    # TODO improve this analysis, e.g. allow `Some{Symbol}`
-    return isbitstype(ty)
-end
+    ismutationfree(ty)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -645,6 +645,8 @@ function ismutationfree(@nospecialize(t::Type))
     return false
 end
 
+datatype_isidentityfree(dt::DataType) = (@_total_meta; (dt.flags & 0x0200) == 0x0200)
+
 iskindtype(@nospecialize t) = (t === DataType || t === UnionAll || t === Union || t === typeof(Bottom))
 isconcretedispatch(@nospecialize t) = isconcretetype(t) && !iskindtype(t)
 has_free_typevars(@nospecialize(t)) = ccall(:jl_has_free_typevars, Cint, (Any,), t) != 0

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -104,6 +104,7 @@ jl_datatype_t *jl_new_uninitialized_datatype(void)
     t->zeroinit = 0;
     t->has_concrete_subtype = 1;
     t->cached_by_hash = 0;
+    t->ismutationfree = 0;
     t->name = NULL;
     t->super = NULL;
     t->parameters = NULL;
@@ -446,6 +447,20 @@ static void throw_ovf(int should_malloc, void *desc, jl_datatype_t* st, int offs
     jl_errorf("type %s has field offset %d that exceeds the page size", jl_symbol_name(st->name->name), offset);
 }
 
+static int is_type_mutationfree(jl_value_t *t)
+{
+    t = jl_unwrap_unionall(t);
+    if (jl_is_uniontype(t)) {
+        jl_uniontype_t *u = (jl_uniontype_t*)t;
+        return is_type_mutationfree(u->a) && is_type_mutationfree(u->b);
+    }
+    if (jl_is_datatype(t)) {
+        return ((jl_datatype_t*)t)->ismutationfree;
+    }
+    // Free tvars, etc.
+    return 0;
+}
+
 void jl_compute_field_offsets(jl_datatype_t *st)
 {
     const uint64_t max_offset = (((uint64_t)1) << 32) - 1;
@@ -461,6 +476,7 @@ void jl_compute_field_offsets(jl_datatype_t *st)
         st->has_concrete_subtype = 1;
     }
     int isbitstype = st->isconcretetype && st->name->mayinlinealloc;
+    int ismutationfree = !w->layout || !jl_is_layout_opaque(w->layout);
     // If layout doesn't depend on type parameters, it's stored in st->name->wrapper
     // and reused by all subtypes.
     if (w->layout) {
@@ -511,9 +527,10 @@ void jl_compute_field_offsets(jl_datatype_t *st)
         }
     }
 
-    for (i = 0; isbitstype && i < nfields; i++) {
+    for (i = 0; (isbitstype || ismutationfree) && i < nfields; i++) {
         jl_value_t *fld = jl_field_type(st, i);
-        isbitstype = jl_isbits(fld);
+        isbitstype &= jl_isbits(fld);
+        ismutationfree &= (!st->name->mutabl || jl_field_isconst(st, i)) && is_type_mutationfree(fld);
     }
 
     // if we didn't reuse the layout above, compute it now
@@ -645,6 +662,7 @@ void jl_compute_field_offsets(jl_datatype_t *st)
     // now finish deciding if this instantiation qualifies for special properties
     assert(!isbitstype || st->layout->npointers == 0); // the definition of isbits
     st->isbitstype = isbitstype;
+    st->ismutationfree = ismutationfree;
     jl_maybe_allocate_singleton_instance(st);
     return;
 }
@@ -791,6 +809,7 @@ JL_DLLEXPORT jl_datatype_t *jl_new_primitivetype(jl_value_t *name, jl_module_t *
     // (dta->name->names == svec() && dta->layout && dta->layout->size != 0)
     // and we easily have a free bit for it in the DataType flags
     bt->isprimitivetype = 1;
+    bt->ismutationfree = 1;
     bt->isbitstype = (parameters == jl_emptysvec);
     bt->layout = jl_get_layout(nbytes, 0, 0, alignm, 0, NULL, NULL);
     bt->instance = NULL;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1548,6 +1548,9 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
     // create and initialize new type
     ndt = jl_new_uninitialized_datatype();
     ndt->isprimitivetype = dt->isprimitivetype;
+    // Usually dt won't have ismutationfree set at this point, but it is
+    // overriden for `Type`, which we handle here.
+    ndt->ismutationfree = dt->ismutationfree;
     // associate these parameters with the new type on
     // the stack, in case one of its field types references it.
     top.tt = (jl_datatype_t*)ndt;
@@ -2072,7 +2075,7 @@ void jl_init_types(void) JL_GC_DISABLED
             jl_any_type, // instance
             jl_any_type /*jl_voidpointer_type*/,
             jl_any_type /*jl_int32_type*/,
-            jl_any_type /*jl_uint8_type*/);
+            jl_any_type /*jl_uint16_type*/);
     const static uint32_t datatype_constfields[1] = { 0x00000057 }; // (1<<0)|(1<<1)|(1<<2)|(1<<4)|(1<<6)
     const static uint32_t datatype_atomicfields[1] = { 0x00000028 }; // (1<<3)|(1<<5)
     jl_datatype_type->name->constfields = datatype_constfields;
@@ -2761,7 +2764,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_uint8pointer_type = (jl_datatype_t*)jl_apply_type1((jl_value_t*)jl_pointer_type, (jl_value_t*)jl_uint8_type);
     jl_svecset(jl_datatype_type->types, 5, jl_voidpointer_type);
     jl_svecset(jl_datatype_type->types, 6, jl_int32_type);
-    jl_svecset(jl_datatype_type->types, 7, jl_uint8_type);
+    jl_svecset(jl_datatype_type->types, 7, jl_uint16_type);
     jl_svecset(jl_typename_type->types, 1, jl_module_type);
     jl_svecset(jl_typename_type->types, 3, jl_voidpointer_type);
     jl_svecset(jl_typename_type->types, 4, jl_voidpointer_type);
@@ -2796,6 +2799,20 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_compute_field_offsets(jl_unionall_type);
     jl_compute_field_offsets(jl_simplevector_type);
     jl_compute_field_offsets(jl_symbol_type);
+
+    // override ismutationfree for builtin types that are mutable for identity
+    jl_string_type->ismutationfree = 1;
+    jl_symbol_type->ismutationfree = 1;
+    jl_simplevector_type->ismutationfree = 1;
+    jl_datatype_type->ismutationfree = 1;
+    ((jl_datatype_t*)jl_type_type->body)->ismutationfree = 1;
+
+    // Technically not ismutationfree, but there's a separate system to deal
+    // with mutations for global state.
+    jl_module_type->ismutationfree = 1;
+
+    // Array's mutable data is hidden, so we need to override it
+    ((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_array_type))->ismutationfree = 0;
 
     // override the preferred layout for a couple types
     jl_lineinfonode_type->name->mayinlinealloc = 0; // FIXME: assumed to be a pointer by codegen

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2801,9 +2801,9 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_compute_field_offsets(jl_symbol_type);
 
     // override ismutationfree for builtin types that are mutable for identity
-    jl_string_type->ismutationfree = 1;
-    jl_symbol_type->ismutationfree = 1;
-    jl_simplevector_type->ismutationfree = 1;
+    jl_string_type->ismutationfree = jl_string_type->isidentityfree = 1;
+    jl_symbol_type->ismutationfree = jl_symbol_type->isidentityfree = 1;
+    jl_simplevector_type->ismutationfree = jl_simplevector_type->isidentityfree = 1;
     jl_datatype_type->ismutationfree = 1;
     ((jl_datatype_t*)jl_type_type->body)->ismutationfree = 1;
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -548,6 +548,7 @@ typedef struct _jl_datatype_t {
     uint16_t cached_by_hash:1; // stored in hash-based set cache (instead of linear cache)
     uint16_t isprimitivetype:1; // whether this is declared with 'primitive type' keyword (sized, no fields, and immutable)
     uint16_t ismutationfree:1; // whether any mutable memory is reachable through this type (in the type or via fields)
+    uint16_t isidentityfree:1; // whether this type or any object reachable through its fields has non-content-based identity
 } jl_datatype_t;
 
 typedef struct _jl_vararg_t {

--- a/src/julia.h
+++ b/src/julia.h
@@ -539,14 +539,15 @@ typedef struct _jl_datatype_t {
     const jl_datatype_layout_t *layout;
     // memoized properties (set on construction)
     uint32_t hash;
-    uint8_t hasfreetypevars:1; // majority part of isconcrete computation
-    uint8_t isconcretetype:1; // whether this type can have instances
-    uint8_t isdispatchtuple:1; // aka isleaftupletype
-    uint8_t isbitstype:1; // relevant query for C-api and type-parameters
-    uint8_t zeroinit:1; // if one or more fields requires zero-initialization
-    uint8_t has_concrete_subtype:1; // If clear, no value will have this datatype
-    uint8_t cached_by_hash:1; // stored in hash-based set cache (instead of linear cache)
-    uint8_t isprimitivetype:1; // whether this is declared with 'primitive type' keyword (sized, no fields, and immutable)
+    uint16_t hasfreetypevars:1; // majority part of isconcrete computation
+    uint16_t isconcretetype:1; // whether this type can have instances
+    uint16_t isdispatchtuple:1; // aka isleaftupletype
+    uint16_t isbitstype:1; // relevant query for C-api and type-parameters
+    uint16_t zeroinit:1; // if one or more fields requires zero-initialization
+    uint16_t has_concrete_subtype:1; // If clear, no value will have this datatype
+    uint16_t cached_by_hash:1; // stored in hash-based set cache (instead of linear cache)
+    uint16_t isprimitivetype:1; // whether this is declared with 'primitive type' keyword (sized, no fields, and immutable)
+    uint16_t ismutationfree:1; // whether any mutable memory is reachable through this type (in the type or via fields)
 } jl_datatype_t;
 
 typedef struct _jl_vararg_t {

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -487,7 +487,7 @@ end |> Core.Compiler.is_inaccessiblememonly
 @test Base.infer_effects() do
     ConstantType{Any}()
 end |> Core.Compiler.is_inaccessiblememonly
-@test_broken Base.infer_effects() do
+@test Base.infer_effects() do
     constant_global_nonisbits
 end |> Core.Compiler.is_inaccessiblememonly
 @test Base.infer_effects() do
@@ -708,6 +708,13 @@ end
 @test Base.infer_effects(Tuple{Nothing}) do x
     WrapperOneField{typeof(x)}.instance
 end |> Core.Compiler.is_total
+@test Base.infer_effects(Tuple{WrapperOneField{Float64}, Symbol}) do w, s
+    getfield(w, s)
+end |> Core.Compiler.is_foldable
+@test Core.Compiler.getfield_notundefined(WrapperOneField{Float64}, Symbol)
+@test Base.infer_effects(Tuple{WrapperOneField{Symbol}, Symbol}) do w, s
+    getfield(w, s)
+end |> Core.Compiler.is_foldable
 
 # Flow-sensitive consistenct for _typevar
 @test Base.infer_effects() do


### PR DESCRIPTION
…s thereof

Addresses an outstanding todo. The property is memoized in the datatype like `isbitstype`. It is possible for types to refer to themselves via fields, so some form of memoization is required to avoid an infinite recursion.