### PR TITLE
threads: during abrupt thread-exit, cleanup anyways

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -286,11 +286,11 @@ $(BUILDDIR)/julia_flisp.boot: $(addprefix $(SRCDIR)/,jlfrontend.scm flisp/aliase
 
 # additional dependency links
 $(BUILDDIR)/codegen-stubs.o $(BUILDDIR)/codegen-stubs.dbg.obj: $(SRCDIR)/intrinsics.h
-$(BUILDDIR)/aotcompile.o $(BUILDDIR)/aotcompile.dbg.obj: $(SRCDIR)/jitlayers.h $(SRCDIR)/llvm-codegen-shared.h $(SRCDIR)/debug-registry.h
+$(BUILDDIR)/aotcompile.o $(BUILDDIR)/aotcompile.dbg.obj: $(SRCDIR)/jitlayers.h $(SRCDIR)/llvm-codegen-shared.h
 $(BUILDDIR)/ast.o $(BUILDDIR)/ast.dbg.obj: $(BUILDDIR)/julia_flisp.boot.inc $(SRCDIR)/flisp/*.h
 $(BUILDDIR)/builtins.o $(BUILDDIR)/builtins.dbg.obj: $(SRCDIR)/iddict.c $(SRCDIR)/builtin_proto.h
 $(BUILDDIR)/codegen.o $(BUILDDIR)/codegen.dbg.obj: $(addprefix $(SRCDIR)/,\
-	intrinsics.cpp jitlayers.h debug-registry.h intrinsics.h llvm-codegen-shared.h cgutils.cpp ccall.cpp abi_*.cpp processor.h builtin_proto.h)
+	intrinsics.cpp jitlayers.h intrinsics.h llvm-codegen-shared.h cgutils.cpp ccall.cpp abi_*.cpp processor.h builtin_proto.h)
 $(BUILDDIR)/datatype.o $(BUILDDIR)/datatype.dbg.obj: $(SRCDIR)/support/htable.h $(SRCDIR)/support/htable.inc
 $(BUILDDIR)/debuginfo.o $(BUILDDIR)/debuginfo.dbg.obj: $(addprefix $(SRCDIR)/,debuginfo.h processor.h jitlayers.h debug-registry.h)
 $(BUILDDIR)/disasm.o $(BUILDDIR)/disasm.dbg.obj: $(SRCDIR)/debuginfo.h $(SRCDIR)/processor.h
@@ -301,13 +301,13 @@ $(BUILDDIR)/gc-heap-snapshot.o $(BUILDDIR)/gc-heap-snapshot.dbg.obj: $(SRCDIR)/g
 $(BUILDDIR)/gc-alloc-profiler.o $(BUILDDIR)/gc-alloc-profiler.dbg.obj: $(SRCDIR)/gc.h $(SRCDIR)/gc-alloc-profiler.h
 $(BUILDDIR)/init.o $(BUILDDIR)/init.dbg.obj: $(SRCDIR)/builtin_proto.h
 $(BUILDDIR)/interpreter.o $(BUILDDIR)/interpreter.dbg.obj: $(SRCDIR)/builtin_proto.h
-$(BUILDDIR)/jitlayers.o $(BUILDDIR)/jitlayers.dbg.obj: $(SRCDIR)/jitlayers.h $(SRCDIR)/llvm-codegen-shared.h $(SRCDIR)/debug-registry.h
+$(BUILDDIR)/jitlayers.o $(BUILDDIR)/jitlayers.dbg.obj: $(SRCDIR)/jitlayers.h $(SRCDIR)/llvm-codegen-shared.h
 $(BUILDDIR)/jltypes.o $(BUILDDIR)/jltypes.dbg.obj: $(SRCDIR)/builtin_proto.h
 $(build_shlibdir)/libllvmcalltest.$(SHLIB_EXT): $(SRCDIR)/llvm-codegen-shared.h $(BUILDDIR)/julia_version.h
 $(BUILDDIR)/llvm-alloc-helpers.o $(BUILDDIR)/llvm-alloc-helpers.dbg.obj: $(SRCDIR)/llvm-codegen-shared.h $(SRCDIR)/llvm-pass-helpers.h $(SRCDIR)/llvm-alloc-helpers.h
 $(BUILDDIR)/llvm-alloc-opt.o $(BUILDDIR)/llvm-alloc-opt.dbg.obj: $(SRCDIR)/llvm-codegen-shared.h $(SRCDIR)/llvm-pass-helpers.h $(SRCDIR)/llvm-alloc-helpers.h
-$(BUILDDIR)/llvm-cpufeatures.o $(BUILDDIR)/llvm-cpufeatures.dbg.obj: $(SRCDIR)/jitlayers.h $(SRCDIR)/debug-registry.h
-$(BUILDDIR)/llvm-demote-float16.o $(BUILDDIR)/llvm-demote-float16.dbg.obj: $(SRCDIR)/jitlayers.h $(SRCDIR)/debug-registry.h
+$(BUILDDIR)/llvm-cpufeatures.o $(BUILDDIR)/llvm-cpufeatures.dbg.obj: $(SRCDIR)/jitlayers.h
+$(BUILDDIR)/llvm-demote-float16.o $(BUILDDIR)/llvm-demote-float16.dbg.obj: $(SRCDIR)/jitlayers.h
 $(BUILDDIR)/llvm-final-gc-lowering.o $(BUILDDIR)/llvm-final-gc-lowering.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h $(SRCDIR)/llvm-codegen-shared.h
 $(BUILDDIR)/llvm-gc-invariant-verifier.o $(BUILDDIR)/llvm-gc-invariant-verifier.dbg.obj: $(SRCDIR)/llvm-codegen-shared.h
 $(BUILDDIR)/llvm-julia-licm.o $(BUILDDIR)/llvm-julia-licm.dbg.obj: $(SRCDIR)/llvm-codegen-shared.h $(SRCDIR)/llvm-alloc-helpers.h $(SRCDIR)/llvm-pass-helpers.h
@@ -323,7 +323,7 @@ $(BUILDDIR)/signal-handling.o $(BUILDDIR)/signal-handling.dbg.obj: $(addprefix $
 $(BUILDDIR)/staticdata.o $(BUILDDIR)/staticdata.dbg.obj: $(SRCDIR)/staticdata_utils.c $(SRCDIR)/precompile_utils.c $(SRCDIR)/processor.h $(SRCDIR)/builtin_proto.h
 $(BUILDDIR)/toplevel.o $(BUILDDIR)/toplevel.dbg.obj: $(SRCDIR)/builtin_proto.h
 $(BUILDDIR)/ircode.o $(BUILDDIR)/ircode.dbg.obj: $(SRCDIR)/serialize.h
-$(BUILDDIR)/pipeline.o $(BUILDDIR)/pipeline.dbg.obj: $(SRCDIR)/passes.h $(SRCDIR)/jitlayers.h $(SRCDIR)/debug-registry.h
+$(BUILDDIR)/pipeline.o $(BUILDDIR)/pipeline.dbg.obj: $(SRCDIR)/passes.h $(SRCDIR)/jitlayers.h
 
 $(addprefix $(BUILDDIR)/,threading.o threading.dbg.obj gc.o gc.dbg.obj init.c init.dbg.obj task.o task.dbg.obj): $(addprefix $(SRCDIR)/,threading.h)
 $(addprefix $(BUILDDIR)/,APInt-C.o APInt-C.dbg.obj runtime_intrinsics.o runtime_intrinsics.dbg.obj): $(SRCDIR)/APInt-C.h
@@ -437,8 +437,14 @@ $(build_shlibdir)/lib%Plugin.$(SHLIB_EXT): $(SRCDIR)/clangsa/%.cpp $(LLVM_CONFIG
 # before attempting this static analysis, so that all necessary headers
 # and dependencies are properly installed:
 #   make -C src install-analysis-deps
+ANALYSIS_DEPS := llvm clang llvm-tools libuv utf8proc
+ifeq ($(OS),Darwin)
+ANALYSIS_DEPS += llvmunwind
+else ifneq ($(OS),WINNT)
+ANALYSIS_DEPS += unwind
+endif
 install-analysis-deps:
-	$(MAKE) -C $(JULIAHOME)/deps install-llvm install-clang install-llvm-tools install-libuv install-utf8proc install-unwind
+	$(MAKE) -C $(JULIAHOME)/deps $(addprefix install-,$(ANALYSIS_DEPS))
 
 analyzegc-deps-check: $(BUILDDIR)/julia_version.h $(BUILDDIR)/julia_flisp.boot.inc $(BUILDDIR)/jl_internal_funcs.inc
 ifeq ($(USE_BINARYBUILDER_LLVM),0)

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -58,7 +58,7 @@ JL_DLLEXPORT int jl_compile_extern_c_fallback(LLVMOrcThreadSafeModuleRef llvmmod
     return 0;
 }
 
-JL_DLLEXPORT void jl_teardown_codegen_fallback(void)
+JL_DLLEXPORT void jl_teardown_codegen_fallback(void) JL_NOTSAFEPOINT
 {
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8662,7 +8662,7 @@ extern "C" JL_DLLEXPORT void jl_init_codegen_impl(void)
     init_jit_functions();
 }
 
-extern "C" JL_DLLEXPORT void jl_teardown_codegen_impl()
+extern "C" JL_DLLEXPORT void jl_teardown_codegen_impl() JL_NOTSAFEPOINT
 {
     // output LLVM timings and statistics
     reportAndResetTimings();

--- a/src/debug-registry.h
+++ b/src/debug-registry.h
@@ -3,8 +3,6 @@
 #include <llvm/IR/DataLayout.h>
 
 #include "julia.h"
-#include "julia_internal.h"
-#include "processor.h"
 
 #include <map>
 #include <mutex>

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -39,10 +39,12 @@ using namespace llvm;
 #include <set>
 #include <mutex>
 #include "julia_assert.h"
+#include "debug-registry.h"
 
+static JITDebugInfoRegistry DebugRegistry;
 
 static JITDebugInfoRegistry &getJITDebugRegistry() JL_NOTSAFEPOINT {
-    return jl_ExecutionEngine->getDebugInfoRegistry();
+    return DebugRegistry;
 }
 
 struct debug_link_info {

--- a/src/gc.c
+++ b/src/gc.c
@@ -145,7 +145,7 @@ static _Atomic(int) support_conservative_marking = 0;
  * threads that enters `jl_gc_collect()` at the same time (or later calling
  * from unmanaged code) will wait in `jl_gc_collect()` until the GC is finished.
  *
- * Before starting the mark phase the GC thread calls `jl_safepoint_gc_start()`
+ * Before starting the mark phase the GC thread calls `jl_safepoint_start_gc()`
  * and `jl_gc_wait_for_the_world()`
  * to make sure all the thread are in a safe state for the GC. The function
  * activates the safepoint and wait for all the threads to get ready for the

--- a/src/gf.c
+++ b/src/gf.c
@@ -2320,10 +2320,11 @@ jl_value_t *jl_fptr_const_return(jl_value_t *f, jl_value_t **args, uint32_t narg
 
 jl_value_t *jl_fptr_args(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_code_instance_t *m)
 {
+    jl_fptr_args_t invoke = jl_atomic_load_relaxed(&m->specptr.fptr1);
     while (1) {
-        jl_fptr_args_t invoke = jl_atomic_load_relaxed(&m->specptr.fptr1);
         if (invoke)
             return invoke(f, args, nargs);
+        invoke = jl_atomic_load_acquire(&m->specptr.fptr1); // require forward progress with acquire annotation
     }
 }
 
@@ -2331,10 +2332,11 @@ jl_value_t *jl_fptr_sparam(jl_value_t *f, jl_value_t **args, uint32_t nargs, jl_
 {
     jl_svec_t *sparams = m->def->sparam_vals;
     assert(sparams != jl_emptysvec);
+    jl_fptr_sparam_t invoke = jl_atomic_load_relaxed(&m->specptr.fptr3);
     while (1) {
-        jl_fptr_sparam_t invoke = jl_atomic_load_relaxed(&m->specptr.fptr3);
         if (invoke)
             return invoke(f, args, nargs, sparams);
+        invoke = jl_atomic_load_acquire(&m->specptr.fptr3); // require forward progress with acquire annotation
     }
 }
 

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -19,7 +19,8 @@
 
 #include <llvm/Target/TargetMachine.h>
 #include "julia_assert.h"
-#include "debug-registry.h"
+#include "julia.h"
+#include "julia_internal.h"
 #include "platform.h"
 
 #include <stack>
@@ -487,10 +488,6 @@ public:
 
     size_t getTotalBytes() const JL_NOTSAFEPOINT;
 
-    JITDebugInfoRegistry &getDebugInfoRegistry() JL_NOTSAFEPOINT {
-        return DebugRegistry;
-    }
-
     jl_locked_stream &get_dump_emitted_mi_name_stream() JL_NOTSAFEPOINT {
         return dump_emitted_mi_name_stream;
     }
@@ -511,8 +508,6 @@ private:
     orc::ExecutionSession ES;
     orc::JITDylib &GlobalJD;
     orc::JITDylib &JD;
-
-    JITDebugInfoRegistry DebugRegistry;
 
     //Map and inc are guarded by RLST_mutex
     std::mutex RLST_mutex{};

--- a/src/julia.h
+++ b/src/julia.h
@@ -2065,7 +2065,7 @@ typedef int jl_uv_os_fd_t;
 
 JL_DLLEXPORT int jl_process_events(void);
 
-JL_DLLEXPORT struct uv_loop_s *jl_global_event_loop(void);
+JL_DLLEXPORT struct uv_loop_s *jl_global_event_loop(void) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT void jl_close_uv(struct uv_handle_s *handle);
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -868,7 +868,7 @@ void jl_init_thread_heap(jl_ptls_t ptls) JL_NOTSAFEPOINT;
 void jl_init_int32_int64_cache(void);
 JL_DLLEXPORT void jl_init_options(void);
 
-void jl_teardown_codegen(void);
+void jl_teardown_codegen(void) JL_NOTSAFEPOINT;
 
 void jl_set_base_ctx(char *__stk);
 
@@ -920,7 +920,7 @@ void jl_safepoint_defer_sigint(void);
 // Return `1` if the sigint should be delivered and `0` if there's no sigint
 // to be delivered.
 int jl_safepoint_consume_sigint(void);
-void jl_wake_libuv(void);
+void jl_wake_libuv(void) JL_NOTSAFEPOINT;
 
 void jl_set_pgcstack(jl_gcframe_t **) JL_NOTSAFEPOINT;
 #if defined(_OS_DARWIN_)

--- a/src/partr.c
+++ b/src/partr.c
@@ -183,7 +183,7 @@ static int sleep_check_after_threshold(uint64_t *start_cycles)
 }
 
 
-static int wake_thread(int16_t tid)
+static int wake_thread(int16_t tid) JL_NOTSAFEPOINT
 {
     jl_ptls_t other = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
     int8_t state = sleeping;
@@ -201,7 +201,7 @@ static int wake_thread(int16_t tid)
 }
 
 
-static void wake_libuv(void)
+static void wake_libuv(void) JL_NOTSAFEPOINT
 {
     JULIA_DEBUG_SLEEPWAKE( io_wakeup_enter = cycleclock() );
     jl_wake_libuv();
@@ -209,7 +209,7 @@ static void wake_libuv(void)
 }
 
 /* ensure thread tid is awake if necessary */
-JL_DLLEXPORT void jl_wakeup_thread(int16_t tid)
+JL_DLLEXPORT void jl_wakeup_thread(int16_t tid) JL_NOTSAFEPOINT
 {
     jl_task_t *ct = jl_current_task;
     int16_t self = jl_atomic_load_relaxed(&ct->tid);

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -419,17 +419,18 @@ void jl_show_sigill(void *_ctx)
 // this is generally quite an foolish operation, but does free you up to do
 // arbitrary things on this stack now without worrying about corrupt state that
 // existed already on it
-void jl_task_frame_noreturn(jl_task_t *ct)
+void jl_task_frame_noreturn(jl_task_t *ct) JL_NOTSAFEPOINT
 {
     jl_set_safe_restore(NULL);
     if (ct) {
         ct->gcstack = NULL;
         ct->eh = NULL;
-        ct->excstack = NULL;
+        ct->world_age = 1;
         ct->ptls->locks.len = 0;
         ct->ptls->in_pure_callback = 0;
         ct->ptls->in_finalizer = 0;
-        ct->world_age = 1;
+        ct->ptls->defer_signal = 0;
+        jl_atomic_store_release(&ct->ptls->gc_state, 0); // forceably exit GC (if we were in it) or safe into unsafe, without the mandatory safepoint
     }
 }
 

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -214,10 +214,10 @@ NOINLINE size_t rec_backtrace(jl_bt_element_t *bt_data, size_t maxsize, int skip
     int r = jl_unw_get(&context);
     if (r < 0)
         return 0;
-    jl_gcframe_t *pgcstack = jl_pgcstack;
     bt_cursor_t cursor;
-    if (!jl_unw_init(&cursor, &context))
+    if (!jl_unw_init(&cursor, &context) || maxsize == 0)
         return 0;
+    jl_gcframe_t *pgcstack = jl_pgcstack;
     size_t bt_size = 0;
     jl_unw_stepn(&cursor, bt_data, &bt_size, NULL, maxsize, skip + 1, &pgcstack, 0);
     return bt_size;

--- a/src/task.c
+++ b/src/task.c
@@ -474,6 +474,7 @@ JL_NO_ASAN static void ctx_switch(jl_task_t *lastt)
     if (killed) {
         *pt = NULL; // can't fail after here: clear the gc-root for the target task now
         lastt->gcstack = NULL;
+        lastt->eh = NULL;
         if (!lastt->copy_stack && lastt->stkbuf) {
             // early free of stkbuf back to the pool
             jl_release_task_stack(ptls, lastt);

--- a/src/timing.h
+++ b/src/timing.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 void jl_init_timing(void);
-void jl_destroy_timing(void);
+void jl_destroy_timing(void) JL_NOTSAFEPOINT;
 #ifdef __cplusplus
 }
 #endif
@@ -87,7 +87,7 @@ struct _jl_timing_block_t { // typedef in julia.h
 #endif
 };
 
-STATIC_INLINE void _jl_timing_block_stop(jl_timing_block_t *block, uint64_t t) {
+STATIC_INLINE void _jl_timing_block_stop(jl_timing_block_t *block, uint64_t t) JL_NOTSAFEPOINT {
 #ifdef JL_DEBUG_BUILD
     assert(block->running);
     block->running = 0;
@@ -95,7 +95,7 @@ STATIC_INLINE void _jl_timing_block_stop(jl_timing_block_t *block, uint64_t t) {
     block->total += t - block->t0;
 }
 
-STATIC_INLINE void _jl_timing_block_start(jl_timing_block_t *block, uint64_t t) {
+STATIC_INLINE void _jl_timing_block_start(jl_timing_block_t *block, uint64_t t) JL_NOTSAFEPOINT {
 #ifdef JL_DEBUG_BUILD
     assert(!block->running);
     block->running = 1;
@@ -103,7 +103,7 @@ STATIC_INLINE void _jl_timing_block_start(jl_timing_block_t *block, uint64_t t) 
     block->t0 = t;
 }
 
-STATIC_INLINE uint64_t _jl_timing_block_init(jl_timing_block_t *block, int owner) {
+STATIC_INLINE uint64_t _jl_timing_block_init(jl_timing_block_t *block, int owner) JL_NOTSAFEPOINT {
     uint64_t t = cycleclock();
     block->owner = owner;
     block->total = 0;
@@ -114,7 +114,7 @@ STATIC_INLINE uint64_t _jl_timing_block_init(jl_timing_block_t *block, int owner
     return t;
 }
 
-STATIC_INLINE void _jl_timing_block_ctor(jl_timing_block_t *block, int owner) {
+STATIC_INLINE void _jl_timing_block_ctor(jl_timing_block_t *block, int owner) JL_NOTSAFEPOINT {
     uint64_t t = _jl_timing_block_init(block, owner);
     jl_task_t *ct = jl_current_task;
     jl_timing_block_t **prevp = &ct->ptls->timing_stack;
@@ -124,7 +124,7 @@ STATIC_INLINE void _jl_timing_block_ctor(jl_timing_block_t *block, int owner) {
     *prevp = block;
 }
 
-STATIC_INLINE void _jl_timing_block_destroy(jl_timing_block_t *block) {
+STATIC_INLINE void _jl_timing_block_destroy(jl_timing_block_t *block) JL_NOTSAFEPOINT {
     uint64_t t = cycleclock();
     jl_task_t *ct = jl_current_task;
     _jl_timing_block_stop(block, t);
@@ -139,10 +139,10 @@ STATIC_INLINE void _jl_timing_block_destroy(jl_timing_block_t *block) {
 #ifdef __cplusplus
 struct jl_timing_block_cpp_t {
     jl_timing_block_t block;
-    jl_timing_block_cpp_t(int owner) {
+    jl_timing_block_cpp_t(int owner) JL_NOTSAFEPOINT {
         _jl_timing_block_ctor(&block, owner);
     }
-    ~jl_timing_block_cpp_t() {
+    ~jl_timing_block_cpp_t() JL_NOTSAFEPOINT {
         _jl_timing_block_destroy(&block);
     }
     jl_timing_block_cpp_t(const jl_timing_block_cpp_t&) = delete;


### PR DESCRIPTION
Closes #47590 (pthread_cancel still forbidden though, since async mode will corrupt the process, and synchronously tested is just a slow implementation of a boolean)

Refs #47201 (only deals with thread exit, not other case where this is an issue, like cfunction exit and gc-safe-leave)

May help #46537, by blocking jl_wake_libuv before uv_library_shutdown, and other tweaks to GC mode. For example:

[4011824] signal (6.-6): Aborted
gsignal at /lib/x86_64-linux-gnu/libc.so.6 (unknown line) abort at /lib/x86_64-linux-gnu/libc.so.6 (unknown line) uv__async_send at /workspace/srcdir/libuv/src/unix/async.c:198 uv_async_send at /workspace/srcdir/libuv/src/unix/async.c:73 jl_wake_libuv at /data/vtjnash/julia1/src/jl_uv.c:44 [inlined] JL_UV_LOCK at /data/vtjnash/julia1/src/jl_uv.c:64 [inlined] ijl_iolock_begin at /data/vtjnash/julia1/src/jl_uv.c:72 iolock_begin at ./libuv.jl:48 [inlined]
_trywait at ./asyncevent.jl:140
wait at ./asyncevent.jl:155 [inlined]
profile_printing_listener at /data/vtjnash/julia1/usr/share/julia/stdlib/v1.10/Profile/src/Profile.jl:39 jfptr_YY.3_58617 at /data/vtjnash/julia1/usr/lib/julia/sys.so (unknown line) _jl_invoke at /data/vtjnash/julia1/src/gf.c:2665 [inlined] ijl_apply_generic at /data/vtjnash/julia1/src/gf.c:2866 jl_apply at /data/vtjnash/julia1/src/julia.h:1870 [inlined] start_task at /data/vtjnash/julia1/src/task.c:1093 Aborted

Fixes #37400