### PR TITLE
Some small patch for typeintersect.

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2630,8 +2630,10 @@ static jl_value_t *omit_bad_union(jl_value_t *u, jl_tvar_t *t)
         ub = omit_bad_union(ub, t);
         body = omit_bad_union(body, t);
         if (ub != NULL && body != NULL && !jl_has_typevar(var->lb, t)) {
-            if (ub != var->ub)
+            if (ub != var->ub) {
                 var = jl_new_typevar(var->name, var->lb, ub);
+                body = jl_substitute_var(body, ((jl_unionall_t *)u)->var, (jl_value_t *)var);
+            }
             res = jl_new_struct(jl_unionall_type, var, body);
         }
         JL_GC_POP();

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -3249,7 +3249,15 @@ static jl_value_t *intersect(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int pa
                     return jl_bottom_type;
                 }
                 int ccheck;
-                if (yub == xub ||
+                if (xlb == xub && ylb == yub &&
+                    jl_has_typevar(xlb, (jl_tvar_t *)y) &&
+                    jl_has_typevar(ylb, (jl_tvar_t *)x)) {
+                    // specical case for e.g.
+                    // 1) Val{Y}<:X<:Val{Y} && Val{X}<:Y<:Val{X}
+                    // 2) Y<:X<:Y && Val{X}<:Y<:Val{X} => Val{Y}<:Y<:Val{Y}
+                    ccheck = 0;
+                }
+                else if (yub == xub ||
                     (subtype_by_bounds(xlb, yub, e) && subtype_by_bounds(ylb, xub, e))) {
                     ccheck = 1;
                 }

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2357,6 +2357,11 @@ end
                Tuple{Type{Vector{Union{T, R}}}, Matrix{Union{T, R}}} where {R<:Real, T<:Real},
                Union{})
 
+#issue 26487
+@testintersect(Tuple{Type{Tuple{T,Val{T}}}, Val{T}} where T,
+               Tuple{Type{Tuple{Val{T},T}}, Val{T}} where T,
+               Union{})
+
 @testset "known subtype/intersect issue" begin
     #issue 45874
     # Causes a hang due to jl_critical_error calling back into malloc...
@@ -2383,9 +2388,6 @@ end
 
     #issue 33137
     @test_broken (Tuple{Q,Int} where Q<:Int) <: Tuple{T,T} where T
-
-    #issue 26487
-    @test_broken typeintersect(Tuple{Type{Tuple{T,Val{T}}}, Val{T}} where T, Tuple{Type{Tuple{Val{T},T}}, Val{T}} where T) <: Any
 
     # issue 24333
     @test_broken (Type{Union{Ref,Cvoid}} <: Type{Union{T,Cvoid}} where T)

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2352,6 +2352,11 @@ let S = Tuple{Type{T1}, T1, Val{T1}} where T1<:(Val{S1} where S1<:Val),
     @test_broken I2 <: T
 end
 
+#issue 44395
+@testintersect(Tuple{Type{T}, T} where {T <: Vector{Union{T, R}} where {R<:Real, T<:Real}},
+               Tuple{Type{Vector{Union{T, R}}}, Matrix{Union{T, R}}} where {R<:Real, T<:Real},
+               Union{})
+
 @testset "known subtype/intersect issue" begin
     #issue 45874
     # Causes a hang due to jl_critical_error calling back into malloc...
@@ -2360,12 +2365,6 @@ end
     #     @test_broken S <: T
     #     @test_broken typeintersect(S,T) === S
     # end
-
-    #issue 44395
-    @test_broken typeintersect(
-        Tuple{Type{T}, T} where {T <: Vector{Union{T, R}} where {R<:Real, T<:Real}},
-        Tuple{Type{Vector{Union{T, R}}}, Matrix{Union{T, R}}} where {R<:Real, T<:Real},
-    ) === Union{}
 
     #issue 41561
     @test_broken typeintersect(Tuple{Vector{VT}, Vector{VT}} where {N1, VT<:AbstractVector{N1}},


### PR DESCRIPTION
Add var substitution forgotten in 303734204dbe74f1a5d1defcb4ae3ada3e318dd4 and make the `reachable_var` test not ignore free var.
