### PR TITLE
Lower typeassert `a::Int` as `a=a::Int`

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -4181,7 +4181,8 @@ f(x) = yt(x)
                 (block ,@body))))
           ;; remaining `::` expressions are type assertions
           ((|::|)
-           (cl-convert `(call (core typeassert) ,@(cdr e)) fname lam namemap defined toplevel interp opaq globals))
+           (cl-convert `(= ,(cadr e) (call (core typeassert) ,@(cdr e)))
+                       fname lam namemap defined toplevel interp opaq globals))
           ;; remaining `decl` expressions are only type assertions if the
           ;; argument is global or a non-symbol.
           ((decl)


### PR DESCRIPTION
Fixes #38274

In particular:

```julia-repl
julia> function f(obj)
         obj::String
         length(obj)
       end
f (generic function with 1 method)

julia> code_typed(f, (Any,), optimize=false)
1-element Vector{Any}:
 CodeInfo(
1 ─      (obj = Core.typeassert(obj, Main.String))::String
│   %2 = Main.length(obj::String)::Int64
└──      return %2
) => Int64
```

before

```julia-repl
julia> code_typed(f, (Any,), optimize=false)
1-element Vector{Any}:
 CodeInfo(
1 ─      Core.typeassert(obj, Main.String)::String
│   %2 = Main.length(obj)::Any
└──      return %2
) => Any
```
