### PR TITLE
NFC: minor followups for #48220

### DIFF
--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -333,17 +333,9 @@ end
 
 # this query is specially written for `adjust_effects` and returns true if a value of this type
 # never involves inconsistency of mutable objects that are allocated somewhere within a call graph
-is_consistent_argtype(@nospecialize ty) = is_consistent_type(widenconst(ignorelimited(ty)))
-is_consistent_type(@nospecialize ty) = _is_consistent_type(unwrap_unionall(ty))
-function _is_consistent_type(@nospecialize ty)
-    ty = unwrap_unionall(ty)
-    if isa(ty, Union)
-        return is_consistent_type(ty.a) && is_consistent_type(ty.b)
-    elseif isa(ty, DataType)
-        return datatype_isidentityfree(ty)
-    end
-    return false
-end
+is_consistent_argtype(@nospecialize ty) =
+    is_consistent_type(widenconst(ignorelimited(ty)))
+is_consistent_type(@nospecialize ty) = isidentityfree(ty)
 
 is_immutable_argtype(@nospecialize ty) = is_immutable_type(widenconst(ignorelimited(ty)))
 is_immutable_type(@nospecialize ty) = _is_immutable_type(unwrap_unionall(ty))
@@ -355,6 +347,5 @@ function _is_immutable_type(@nospecialize ty)
 end
 
 is_mutation_free_argtype(@nospecialize argtype) =
-    ismutationfree(widenconst(ignorelimited(argtype)))
-is_mutation_free_type(@nospecialize ty) =
-    ismutationfree(ty)
+    is_mutation_free_type(widenconst(ignorelimited(argtype)))
+is_mutation_free_type(@nospecialize ty) = ismutationfree(ty)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -624,7 +624,6 @@ and has no subtypes (or supertypes) which could appear in a call.
 """
 isdispatchtuple(@nospecialize(t)) = (@_total_meta; isa(t, DataType) && (t.flags & 0x0004) == 0x0004)
 
-
 datatype_ismutationfree(dt::DataType) = (@_total_meta; (dt.flags & 0x0100) == 0x0100)
 
 """
@@ -646,6 +645,21 @@ function ismutationfree(@nospecialize(t::Type))
 end
 
 datatype_isidentityfree(dt::DataType) = (@_total_meta; (dt.flags & 0x0200) == 0x0200)
+
+"""
+    isidentityfree(T)
+
+Determine whether type `T` is identity free in the sense that this type or any
+reachable through its fields has non-content-based identity.
+"""
+function isidentityfree(@nospecialize(t::Type))
+    t = unwrap_unionall(t)
+    if isa(t, DataType)
+        return datatype_isidentityfree(t)
+    elseif isa(t, Union)
+        return isidentityfree(t.a) && isidentityfree(t.b)
+    end
+end
 
 iskindtype(@nospecialize t) = (t === DataType || t === UnionAll || t === Union || t === typeof(Bottom))
 isconcretedispatch(@nospecialize t) = isconcretetype(t) && !iskindtype(t)

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -476,7 +476,6 @@ static int is_type_identityfree(jl_value_t *t)
     return 0;
 }
 
-
 void jl_compute_field_offsets(jl_datatype_t *st)
 {
     const uint64_t max_offset = (((uint64_t)1) << 32) - 1;
@@ -886,7 +885,6 @@ JL_DLLEXPORT int jl_is_foreign_type(jl_datatype_t *dt)
     return jl_is_datatype(dt) && dt->layout && dt->layout->fielddesc_type == 3;
 }
 
-
 // bits constructors ----------------------------------------------------------
 
 #if MAX_ATOMIC_SIZE > MAX_POINTERATOMIC_SIZE
@@ -1223,8 +1221,6 @@ JL_DLLEXPORT jl_value_t *jl_atomic_cmpswap_bits(jl_datatype_t *dt, jl_datatype_t
     *((uint8_t*)y + nb) = success ? 1 : 0;
     return y;
 }
-
-
 
 // used by boot.jl
 JL_DLLEXPORT jl_value_t *jl_typemax_uint(jl_value_t *bt)
@@ -1944,7 +1940,6 @@ JL_DLLEXPORT int jl_field_isdefined_checked(jl_value_t *v, size_t i)
         return 0;
     return !!jl_field_isdefined(v, i);
 }
-
 
 JL_DLLEXPORT size_t jl_get_field_offset(jl_datatype_t *ty, int field)
 {


### PR DESCRIPTION
- set up the `isidentityfree` query as `ismutationfree` and refactor `is_consistent_type` a bit using it
- move the special handling of `Module`-type's `mutationfree` bit to `Core.Compiler` since it is entangled with the implementation detail within `Core.Compiler`