### PR TITLE
Add a `wait(::[Abstract]WorkerPool)`

### DIFF
--- a/stdlib/Distributed/src/workerpool.jl
+++ b/stdlib/Distributed/src/workerpool.jl
@@ -120,6 +120,11 @@ function wp_local_take!(pool::AbstractWorkerPool)
     return worker
 end
 
+function wp_local_wait(pool::AbstractWorkerPool)
+    wait(pool.channel)
+    return nothing
+end
+
 function remotecall_pool(rc_f, f, pool::AbstractWorkerPool, args...; kwargs...)
     worker = take!(pool)
     try
@@ -133,7 +138,7 @@ end
 # NOTE: remotecall_fetch does it automatically, but this will be more efficient as
 # it avoids the overhead associated with a local remotecall.
 
-for (func, rt) = ((:length, Int), (:isready, Bool), (:workers, Vector{Int}), (:nworkers, Int), (:take!, Int))
+for (func, rt) = ((:length, Int), (:isready, Bool), (:workers, Vector{Int}), (:nworkers, Int), (:take!, Int), (:wait, Nothing))
     func_local = Symbol(string("wp_local_", func))
     @eval begin
         function ($func)(pool::WorkerPool)

--- a/stdlib/Distributed/src/workerpool.jl
+++ b/stdlib/Distributed/src/workerpool.jl
@@ -8,6 +8,7 @@ An `AbstractWorkerPool` should implement:
   - [`push!`](@ref) - add a new worker to the overall pool (available + busy)
   - [`put!`](@ref) - put back a worker to the available pool
   - [`take!`](@ref) - take a worker from the available pool (to be used for remote function execution)
+  - [`wait`](@ref) - block until a worker is available
   - [`length`](@ref) - number of workers available in the overall pool
   - [`isready`](@ref) - return false if a `take!` on the pool would block, else true
 

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -677,19 +677,17 @@ w = take!(wp)
 t = @async wait(wp)
 @test !istaskdone(t)
 put!(wp, w)
-# avoid race condition
-sleep(0.1)
-@test istaskdone(t)
+status = timedwait(() -> istaskdone(t), 10)
+@test status == :ok
 
 # remote call to _wait
 take!(wp)
 @test !isready(wp)
 f = @spawnat w wait(wp)
 @test !isready(f)
-# avoid race condition
-sleep(0.1)
 put!(wp, w)
-@test isready(f)
+status = timedwait(() -> isready(f), 10)
+@test status == :ok
 
 # CachingPool tests
 wp = CachingPool(workers())


### PR DESCRIPTION
I was surprised to find that there was no method for `Base.wait` on a `WorkerPool` which blocks until a worker is ready and then returns `nothing`.  This adds a straightforward method based on the `wp_local_$f` pattern, that just calls `wait(pool.channel)`.  I've added tests (for both local and remote invocations) and will update docs as well.