### PR TITLE
Fix inexistent method `OverflowError()` in `Dates.Base.steprange_last`

### DIFF
--- a/stdlib/Dates/src/ranges.jl
+++ b/stdlib/Dates/src/ranges.jl
@@ -43,7 +43,7 @@ function Base.steprange_last(start::T, step, stop) where T<:TimeType
         else
             diff = stop - start
             if (diff > zero(diff)) != (stop > start)
-                throw(OverflowError())
+                throw(OverflowError("Difference between stop and start overflowed"))
             end
             remain = stop - (start + step * len(start, stop, step))
             last = stop - remain

--- a/stdlib/Dates/test/ranges.jl
+++ b/stdlib/Dates/test/ranges.jl
@@ -603,4 +603,12 @@ end
     @test length(r) == 366
 end
 
+# Issue #48209
+@testset "steprange_last overflow" begin
+    epoch = Date(Date(1) - Day(1))
+    dmax = epoch + Day(typemax(fieldtype(Day, :value)))
+    dmin = epoch + Day(typemin(fieldtype(Day, :value)))
+    @test_throws OverflowError StepRange(dmin, Day(1), dmax)
+end
+
 end  # RangesTest module


### PR DESCRIPTION
Fixes #48209 and adds a test for  the error path