### PR TITLE
Experiment with compressing sysimgs with zstd

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -156,7 +156,7 @@ LIBJULIA_PATH_REL := libjulia
 endif
 
 COMMON_LIBPATHS := -L$(build_libdir) -L$(build_shlibdir)
-RT_LIBS := $(WHOLE_ARCHIVE) $(LIBUV) $(WHOLE_ARCHIVE) $(LIBUTF8PROC) $(NO_WHOLE_ARCHIVE) $(LIBUNWIND) $(RT_LLVMLINK) $(OSLIBS)
+RT_LIBS := $(WHOLE_ARCHIVE) $(LIBUV) $(WHOLE_ARCHIVE) $(LIBUTF8PROC) $(NO_WHOLE_ARCHIVE) $(LIBUNWIND) $(RT_LLVMLINK) $(OSLIBS) -lzstd
 CG_LIBS := $(LIBUNWIND) $(CG_LLVMLINK) $(OSLIBS)
 RT_DEBUG_LIBS := $(COMMON_LIBPATHS) $(WHOLE_ARCHIVE) $(BUILDDIR)/flisp/libflisp-debug.a $(WHOLE_ARCHIVE) $(BUILDDIR)/support/libsupport-debug.a -ljulia-debug $(RT_LIBS)
 CG_DEBUG_LIBS := $(COMMON_LIBPATHS) $(CG_LIBS) -ljulia-debug -ljulia-internal-debug

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -69,7 +69,6 @@ External links:
 - loc/0 in relocs_list
 
 */
-#include <asm-generic/errno.h>
 #include <stddef.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -88,8 +87,6 @@ External links:
 #include "builtin_proto.h"
 #include "processor.h"
 #include "serialize.h"
-#include "support/dtypes.h"
-#include "support/ios.h"
 
 #ifndef _OS_WINDOWS_
 #include <dlfcn.h>

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -3244,15 +3244,14 @@ static jl_value_t *jl_restore_package_image_from_stream(ios_t *f, jl_image_t *im
         ios_bufmode(f, bm_none);
         JL_SIGATOMIC_BEGIN();
         size_t len = dataendpos - datastartpos;
-        char *sysimg = (char*)jl_gc_perm_alloc(len, 0, 64, 0);
+        // char *sysimg = (char*)jl_gc_perm_alloc(len, 0, 64, 0);
         ios_seek(f, datastartpos);
-        if (ios_readall(f, sysimg, len) != len || jl_crc32c(0, sysimg, len) != (uint32_t)checksum) {
+        if (jl_crc32c(0, &f->buf[f->bpos], len) != (uint32_t)checksum) {
             restored = jl_get_exceptionf(jl_errorexception_type, "Error reading system image file.");
             JL_SIGATOMIC_END();
         }
         else {
-            ios_close(f);
-            ios_static_buffer(f, sysimg, len);
+            ios_static_buffer(f, &f->buf[f->bpos], len);
             htable_new(&new_code_instance_validate, 0);
             pkgcachesizes cachesizes;
             jl_restore_system_image_from_stream_(f, image, depmods, checksum, (jl_array_t**)&restored, &init_order, &extext_methods, &new_specializations, &method_roots_list, &ext_targets, &edges, &base, &ccallable_list, &cachesizes);


### PR DESCRIPTION
While studying why the sysimgs are so large, I decided to experiment with running zstd over the .data section, which made them a quarter the size they currently are which is cool.

Since I had to put the whole sysimg in memory to decompress it, it meant that we got a 70MB increase in memory usage on a clean session. To combat that, as a further experiment. I added caching for the decompressed files in `/tmp`(`/tmp` is probably a bad place to put them :/), with caching the memory usage was about the same and so were the load/startup times.

One interesting side effect of this, is that for a session with some code ran, the memory usage was significantly lower.

I ran the readme of OrdinaryDiffEq in both master(julia-2) and this pr(julia) and for some reason we use a lot less memory.

![image](https://user-images.githubusercontent.com/28694980/211939120-3dc5bbed-1686-4022-b952-bb93502d9039.png)

The implementation is linux only currently, though it might work on macos without too many changes, for Windows I would need a bit of help. 