### PR TITLE
Fix wrong version in docstring of `keys(::RegexMatch)`

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -204,8 +204,8 @@ That is, `idx` will be in the return value even if `m[idx] == nothing`.
 Unnamed capture groups will have integer keys corresponding to their index.
 Named capture groups will have string keys.
 
-!!! compat "Julia 1.6"
-    This method was added in Julia 1.6
+!!! compat "Julia 1.7"
+    This method was added in Julia 1.7
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
This method was added in 1.7.0 and is not available in any 1.6 release. See https://github.com/JuliaLang/julia/pull/46116#issuecomment-1380155445

It should probably be added to https://github.com/JuliaLang/julia/pull/48075 as well.