### PR TITLE
optimizer: determine inlineability at callsite of `is_inlineable`

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -439,12 +439,12 @@ function CodeInstance(
     mi::MethodInstance, @nospecialize(rettype), @nospecialize(inferred_const),
     @nospecialize(inferred), const_flags::Int32, min_world::UInt, max_world::UInt,
     ipo_effects::UInt32, effects::UInt32, @nospecialize(argescapes#=::Union{Nothing,Vector{ArgEscapeInfo}}=#),
-    relocatability::UInt8)
+    relocatability::UInt8, precompile::Bool)
     return ccall(:jl_new_codeinst, Ref{CodeInstance},
-        (Any, Any, Any, Any, Int32, UInt, UInt, UInt32, UInt32, Any, UInt8),
+        (Any, Any, Any, Any, Int32, UInt, UInt, UInt32, UInt32, Any, UInt8, Bool),
         mi, rettype, inferred_const, inferred, const_flags, min_world, max_world,
         ipo_effects, effects, argescapes,
-        relocatability)
+        relocatability, precompile)
 end
 GlobalRef(m::Module, s::Symbol) = ccall(:jl_module_globalref, Ref{GlobalRef}, (Any, Any), m, s)
 Module(name::Symbol=:anonymous, std_imports::Bool=true, default_names::Bool=true) = ccall(:jl_f_new_module, Ref{Module}, (Any, Bool, Bool), name, std_imports, default_names)

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -993,7 +993,7 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter,
                     # state = InliningState(interp)
                     # ir = ssa_inlining_pass!(irsv.ir, state, propagate_inbounds(irsv))
                     new_effects = Effects(result.effects; nothrow)
-                    return ConstCallResults(rt, SemiConcreteResult(mi, ir, new_effects), new_effects, mi)
+                    return ConstCallResults(rt, SemiConcreteResult(mi, ir, rt, new_effects), new_effects, mi)
                 end
             end
         end
@@ -1244,8 +1244,10 @@ function const_prop_methodinstance_heuristic(interp::AbstractInterpreter,
         code = get(code_cache(interp), mi, nothing)
         if isa(code, CodeInstance)
             inferred = @atomic :monotonic code.inferred
+            rt = code.rettype
             # TODO propagate a specific `CallInfo` that conveys information about this call
-            if inlining_policy(interp, inferred, NoCallInfo(), IR_FLAG_NULL, mi, arginfo.argtypes) !== nothing
+            iinfo = InliningInfo(rt, mi, arginfo.argtypes, NoCallInfo(), IR_FLAG_NULL)
+            if inlining_policy(interp, inferred, iinfo) !== nothing
                 return true
             end
         end

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -849,8 +849,9 @@ end
 
 struct CachedResult
     src::Any
+    rt::Any
     effects::Effects
-    CachedResult(@nospecialize(src), effects::Effects) = new(src, effects)
+    CachedResult(@nospecialize(src), @nospecialize(rt), effects::Effects) = new(src, rt, effects)
 end
 @inline function get_cached_result(state::InliningState, mi::MethodInstance)
     code = get(code_cache(state), mi, nothing)
@@ -861,10 +862,11 @@ end
         else
             src = @atomic :monotonic code.inferred
         end
+        rt = code.rettype
         effects = decode_effects(code.ipo_purity_bits)
-        return CachedResult(src, effects)
+        return CachedResult(src, rt, effects)
     end
-    return CachedResult(nothing, Effects())
+    return CachedResult(nothing, Any, Effects())
 end
 
 # the general resolver for usual and const-prop'ed calls
@@ -876,6 +878,7 @@ function resolve_todo(mi::MethodInstance, result::Union{MethodMatch,InferenceRes
     #XXX: update_valid_age!(min_valid[1], max_valid[1], sv)
     if isa(result, InferenceResult)
         src = result.src
+        rt = result.result
         effects = result.ipo_effects
         if is_foldable_nothrow(effects)
             res = result.result
@@ -891,7 +894,7 @@ function resolve_todo(mi::MethodInstance, result::Union{MethodMatch,InferenceRes
             add_inlining_backedge!(et, mi)
             return cached_result
         end
-        (; src, effects) = cached_result
+        (; src, effects, rt) = cached_result
     end
 
     # the duplicated check might have been done already within `analyze_method!`, but still
@@ -901,7 +904,9 @@ function resolve_todo(mi::MethodInstance, result::Union{MethodMatch,InferenceRes
             compilesig_invokes=OptimizationParams(state.interp).compilesig_invokes)
     end
 
-    src = inlining_policy(state.interp, src, info, flag, mi, argtypes)
+    iinfo = InliningInfo(rt, mi, argtypes, info, flag)
+    src = inlining_policy(state.interp, src, iinfo)
+
     src === nothing && return compileable_specialization(mi, effects, et, info;
         compilesig_invokes=OptimizationParams(state.interp).compilesig_invokes)
 
@@ -923,9 +928,10 @@ function resolve_todo(mi::MethodInstance, argtypes::Vector{Any},
         add_inlining_backedge!(et, mi)
         return cached_result
     end
-    (; src, effects) = cached_result
+    (; src, rt, effects) = cached_result
 
-    src = inlining_policy(state.interp, src, info, flag, mi, argtypes)
+    iinfo = InliningInfo(rt, mi, argtypes, info, flag)
+    src = inlining_policy(state.interp, src, iinfo)
 
     src === nothing && return nothing
 
@@ -1315,9 +1321,9 @@ function handle_any_const_result!(cases::Vector{InliningCase},
     allow_abstract::Bool, allow_typevars::Bool)
     if isa(result, ConcreteResult)
         return handle_concrete_result!(cases, result, info, state)
-    end
-    if isa(result, SemiConcreteResult)
-        result = inlining_policy(state.interp, result, info, flag, result.mi, argtypes)
+    elseif isa(result, SemiConcreteResult)
+        iinfo = InliningInfo(result.rt, result.mi, argtypes, info, flag)
+        result = inlining_policy(state.interp, result, iinfo)
         if isa(result, SemiConcreteResult)
             return handle_semi_concrete_result!(cases, result, info, flag, state; allow_abstract)
         end
@@ -1564,7 +1570,8 @@ function handle_opaque_closure_call!(todo::Vector{Pair{Int,Any}},
         item = concrete_result_item(result, info, state)
     else
         if isa(result, SemiConcreteResult)
-            result = inlining_policy(state.interp, result, info, flag, result.mi, sig.argtypes)
+            iinfo = InliningInfo(result.rt, result.mi, sig.argtypes, info, flag)
+            result = inlining_policy(state.interp, result, iinfo)
         end
         if isa(result, SemiConcreteResult)
             item = semiconcrete_result_item(result, info, flag, state)

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1072,7 +1072,8 @@ function try_inline_finalizer!(ir::IRCode, argexprs::Vector{Any}, idx::Int,
         src = nothing
     end
 
-    src = inlining_policy(inlining.interp, src, info, IR_FLAG_NULL, mi, Any[])
+    iinfo = InliningInfo(Any, mi, Any[], info, IR_FLAG_NULL)
+    src = inlining_policy(inlining.interp, src, iinfo)
     src === nothing && return false
     src = retrieve_ir_for_inlining(mi, src)
 

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -73,7 +73,11 @@ end
 struct SemiConcreteResult <: ConstResult
     mi::MethodInstance
     ir::IRCode
+    rt
     effects::Effects
+    function SemiConcreteResult(mi::MethodInstance, ir::IRCode, @nospecialize(rt), effects::Effects)
+        return new(mi, ir, rt, effects)
+    end
 end
 
 """

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -226,7 +226,7 @@ function finish!(interp::AbstractInterpreter, caller::InferenceResult)
         if opt.ir !== nothing
             if caller.must_be_codeinf
                 caller.src = ir_to_codeinf!(opt)
-            elseif is_inlineable(opt.src)
+            elseif is_inlineable(interp, opt.src, InlineabilityInfo(caller.result, caller.linfo))
                 # TODO: If the CFG is too big, inlining becomes more expensive and if we're going to
                 # use this IR over and over, it's worth simplifying it. Round trips through
                 # CodeInstance do this implicitly, since they recompute the CFG, so try to
@@ -325,6 +325,11 @@ function CodeInstance(interp::AbstractInterpreter, result::InferenceResult,
             const_flags = 0x00
         end
     end
+    mi = result.linfo
+    rettype = widenconst(result_type)
+    min_world, max_world = first(valid_worlds), last(valid_worlds)
+    # TODO: Actually do something with non-IPO effects
+    ipo_effects = effects = encode_effects(result.ipo_effects)
     relocatability = 0x0
     if isa(inferred_result, String)
         t = @_gc_preserve_begin inferred_result
@@ -334,22 +339,28 @@ function CodeInstance(interp::AbstractInterpreter, result::InferenceResult,
         relocatability = 0x1
     end
     # relocatability = isa(inferred_result, String) ? inferred_result[end] : UInt8(0)
-    return CodeInstance(result.linfo,
-        widenconst(result_type), rettype_const, inferred_result,
-        const_flags, first(valid_worlds), last(valid_worlds),
-        # TODO: Actually do something with non-IPO effects
-        encode_effects(result.ipo_effects), encode_effects(result.ipo_effects), result.argescapes,
-        relocatability)
+    precompile = false
+    if isa(interp, NativeInterpreter)
+        if inferred_result !== nothing
+            src = inferred_result::MaybeCompressed
+            if !is_inlineable(interp, src, InlineabilityInfo(result_type, mi))
+                precompile = true
+            end
+        end
+    end
+    return CodeInstance(mi, rettype, rettype_const,
+                        inferred_result, const_flags, min_world, max_world,
+                        ipo_effects, effects, result.argescapes,
+                        relocatability, precompile)
 end
 
-function maybe_compress_codeinfo(interp::AbstractInterpreter, linfo::MethodInstance, ci::CodeInfo)
-    def = linfo.def
-    toplevel = !isa(def, Method)
-    if toplevel
-        return ci
-    end
+function maybe_compress_codeinfo(interp::AbstractInterpreter, mi::MethodInstance, ci::CodeInfo)
+    def = mi.def
+    isa(def, Method) || return ci
     if may_discard_trees(interp)
-        cache_the_tree = ci.inferred && (is_inlineable(ci) || isa_compileable_sig(linfo.specTypes, linfo.sparam_vals, def))
+        cache_the_tree = ci.inferred && (
+            is_inlineable(interp, ci, InlineabilityInfo(ci.rettype, mi)) ||
+            isa_compileable_sig(mi))
     else
         cache_the_tree = true
     end
@@ -547,13 +558,13 @@ function finish(me::InferenceState, interp::AbstractInterpreter)
         # we can throw everything else away now
         me.result.src = nothing
         me.cached = false
-        set_inlineable!(me.src, false)
+        me.src.inlining_cost = DECLARED_NOINLINE_COST
         unlock_mi_inference(interp, me.linfo)
     elseif limited_src
         # a type result will be cached still, but not this intermediate work:
         # we can throw everything else away now
         me.result.src = nothing
-        set_inlineable!(me.src, false)
+        me.src.inlining_cost = DECLARED_NOINLINE_COST
     else
         # annotate fulltree with type information,
         # either because we are the outermost code, or we might use this later
@@ -1019,7 +1030,7 @@ function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance)
             tree.codelocs = Int32[1]
             tree.linetable = LineInfoNode[LineInfoNode(method.module, mi, method.file, method.line, Int32(0))]
             tree.ssaflags = UInt8[0]
-            set_inlineable!(tree, true)
+            tree.inlining_cost = DEFAULT_INLINEABLE_COST
             tree.parent = mi
             tree.rettype = Core.Typeof(rettype_const)
             tree.min_world = code.min_world

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -158,6 +158,9 @@ function get_compileable_sig(method::Method, @nospecialize(atype), sparams::Simp
         mt, atype, sparams, method)
 end
 
+function isa_compileable_sig(mi::MethodInstance)
+    return isa_compileable_sig(mi.specTypes, mi.sparam_vals, mi.def::Method)
+end
 isa_compileable_sig(@nospecialize(atype), sparams::SimpleVector, method::Method) =
     !iszero(ccall(:jl_isa_compileable_sig, Int32, (Any, Any, Any), atype, sparams, method))
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -322,12 +322,17 @@ const var"@_noinline_meta" = var"@noinline"
 # Core.Compiler.is_inlineable and Core.Compiler.set_inlineable! move towards this direction,
 # but we need to keep these around for compat
 function getproperty(ci::CodeInfo, s::Symbol)
-    s === :inlineable && return Core.Compiler.is_inlineable(ci)
+    if s === :inlineable
+        return ci.inlining_cost ≤ Core.Compiler.OptimizationParams().inline_cost_threshold
+    end
     return getfield(ci, s)
 end
 
 function setproperty!(ci::CodeInfo, s::Symbol, v)
-    s === :inlineable && return Core.Compiler.set_inlineable!(ci, v)
+    if s === :inlineable
+        ci.inlining_cost = v ? Core.Compiler.DEFAULT_INLINEABLE_COST : Core.Compiler.MAX_INLINING_COST
+        return v
+    end
     return setfield!(ci, s, convert(fieldtype(CodeInfo, s), v))
 end
 

--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -134,7 +134,7 @@ jl_opaque_closure_t *jl_new_opaque_closure(jl_tupletype_t *argt, jl_value_t *rt_
 jl_method_t *jl_make_opaque_closure_method(jl_module_t *module, jl_value_t *name,
     int nargs, jl_value_t *functionloc, jl_code_info_t *ci, int isva);
 
-JL_DLLEXPORT jl_code_instance_t* jl_new_codeinst(
+jl_code_instance_t* jl_new_codeinst(
         jl_method_instance_t *mi, jl_value_t *rettype,
         jl_value_t *inferred_const, jl_value_t *inferred,
         int32_t const_flags, size_t min_world, size_t max_world,

--- a/src/precompile_utils.c
+++ b/src/precompile_utils.c
@@ -186,8 +186,8 @@ static int precompile_enq_specialization_(jl_method_instance_t *mi, void *closur
             jl_value_t *inferred = jl_atomic_load_relaxed(&codeinst->inferred);
             if (inferred &&
                 inferred != jl_nothing &&
-                jl_ir_flag_inferred(inferred) &&
-                (jl_ir_inlining_cost(inferred) == UINT16_MAX)) {
+                jl_ir_flag_inferred((jl_array_t*)inferred) &&
+                jl_atomic_load_relaxed(&codeinst->precompile)) {
                 do_compile = 1;
             }
             else if (jl_atomic_load_relaxed(&codeinst->invoke) != NULL || jl_atomic_load_relaxed(&codeinst->precompile)) {

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1183,7 +1183,7 @@ function deserialize(s::AbstractSerializer, ::Type{CodeInfo})
     if format_version(s) < 22
         inlining_cost = deserialize(s)
         if isa(inlining_cost, Bool)
-            Core.Compiler.set_inlineable!(ci, inlining_cost)
+            ci.inlining_cost = inlining_cost ? Core.Compiler.DEFAULT_INLINEABLE_COST : Core.Compiler.MAX_INLINING_COST
         else
             ci.inlining_cost = inlining_cost
         end

--- a/test/compiler/AbstractInterpreter.jl
+++ b/test/compiler/AbstractInterpreter.jl
@@ -287,15 +287,11 @@ function CC.abstract_call(interp::NoinlineInterpreter,
     end
     return ret
 end
-function CC.inlining_policy(interp::NoinlineInterpreter,
-    @nospecialize(src), @nospecialize(info::CallInfo), stmt_flag::UInt8, mi::MethodInstance,
-    argtypes::Vector{Any})
-    if isa(info, NoinlineCallInfo)
+function CC.inlining_policy(interp::NoinlineInterpreter, @nospecialize(src), iinfo::CC.InliningInfo)
+    if isa(iinfo.info, NoinlineCallInfo)
         return nothing
     end
-    return @invoke CC.inlining_policy(interp::CC.AbstractInterpreter,
-        src::Any, info::CallInfo, stmt_flag::UInt8, mi::MethodInstance,
-        argtypes::Vector{Any})
+    return @invoke CC.inlining_policy(interp::CC.AbstractInterpreter, src::Any, iinfo::CC.InliningInfo)
 end
 
 @inline function inlined_usually(x, y, z)

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -295,19 +295,6 @@ using Core.Compiler: is_declared_inline, is_declared_noinline
     @test !is_declared_noinline(only(methods() do x x end))
 end
 
-using Core.Compiler: is_inlineable, set_inlineable!
-
-@testset "basic set_inlineable! functionality" begin
-    ci = code_typed1() do
-        x -> x
-    end
-    set_inlineable!(ci, true)
-    @test is_inlineable(ci)
-    set_inlineable!(ci, false)
-    @test !is_inlineable(ci)
-    @test_throws MethodError set_inlineable!(ci, 5)
-end
-
 const _a_global_array = [1]
 f_inline_global_getindex() = _a_global_array[1]
 let ci = code_typed(f_inline_global_getindex, Tuple{})[1].first

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1587,7 +1587,7 @@ precompile_test_harness("issue #46296") do load_path
 
         mi = first(Base.specializations(first(methods(identity))))
         ci = Core.CodeInstance(mi, Any, nothing, nothing, zero(Int32), typemin(UInt),
-                               typemax(UInt), zero(UInt32), zero(UInt32), nothing, 0x00)
+                               typemax(UInt), zero(UInt32), zero(UInt32), nothing, 0x00, false)
 
         __init__() = @assert ci isa Core.CodeInstance
 


### PR DESCRIPTION
Now `src::CodeInfo` stores an inlining cost that is computed by `inlining_cost` function no matter if it is lower than or higher than the default `inline_cost_threshold`. This allows `AbstractInterpreter`s to determine the inlineability of `src` on the fly.

This PR completes #45378.

@nanosoldier `runbenchmarks("inference", vs=":master")`