### PR TITLE
Improve effects for NamedTuple merge/diff fallback

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -267,7 +267,7 @@ end
     return Tuple{Any[ fieldtype(sym_in(names[n], bn) ? b : a, names[n]) for n in 1:length(names) ]...}
 end
 
-@assume_effects :total function merge_fallback(@nospecialize(a::NamedTuple), @nospecialize(b::NamedTuple),
+@assume_effects :foldable function merge_fallback(@nospecialize(a::NamedTuple), @nospecialize(b::NamedTuple),
         @nospecialize(an::Tuple{Vararg{Symbol}}), @nospecialize(bn::Tuple{Vararg{Symbol}}))
     names = merge_names(an, bn)
     types = merge_types(names, typeof(a), typeof(b))

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -376,11 +376,11 @@ reverse(nt::NamedTuple) = NamedTuple{reverse(keys(nt))}(reverse(values(nt)))
     (names...,)
 end
 
-@assume_effects :total function diff_types(@nospecialize(a::NamedTuple), @nospecialize(names::Tuple{Vararg{Symbol}}))
+@assume_effects :foldable function diff_types(@nospecialize(a::NamedTuple), @nospecialize(names::Tuple{Vararg{Symbol}}))
     return Tuple{Any[ fieldtype(typeof(a), names[n]) for n in 1:length(names) ]...}
 end
 
-@assume_effects :total function diff_fallback(@nospecialize(a::NamedTuple), @nospecialize(an::Tuple{Vararg{Symbol}}), @nospecialize(bn::Tuple{Vararg{Symbol}}))
+@assume_effects :foldable function diff_fallback(@nospecialize(a::NamedTuple), @nospecialize(an::Tuple{Vararg{Symbol}}), @nospecialize(bn::Tuple{Vararg{Symbol}}))
     names = diff_names(an, bn)
     isempty(names) && return (;)
     types = diff_types(a, names)

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -267,6 +267,19 @@ end
     return Tuple{Any[ fieldtype(sym_in(names[n], bn) ? b : a, names[n]) for n in 1:length(names) ]...}
 end
 
+@assume_effects :total function merge_fallback(@nospecialize(a::NamedTuple), @nospecialize(b::NamedTuple),
+        @nospecialize(an::Tuple{Vararg{Symbol}}), @nospecialize(bn::Tuple{Vararg{Symbol}}))
+    names = merge_names(an, bn)
+    types = merge_types(names, typeof(a), typeof(b))
+    n = length(names)
+    A = Vector{Any}(undef, n)
+    for i=1:n
+        n = names[i]
+        A[i] = getfield(sym_in(n, bn) ? b : a, n)
+    end
+    NamedTuple{names}((A...,))::NamedTuple{names, types}
+end
+
 """
     merge(a::NamedTuple, bs::NamedTuple...)
 
@@ -299,9 +312,7 @@ function merge(a::NamedTuple{an}, b::NamedTuple{bn}) where {an, bn}
         vals = Any[ :(getfield($(sym_in(names[n], bn) ? :b : :a), $(QuoteNode(names[n])))) for n in 1:length(names) ]
         :( NamedTuple{$names,$types}(($(vals...),)) )
     else
-        names = merge_names(an, bn)
-        types = merge_types(names, typeof(a), typeof(b))
-        NamedTuple{names,types}(map(n->getfield(sym_in(n, bn) ? b : a, n), names))
+        merge_fallback(a, b, an, bn)
     end
 end
 
@@ -365,6 +376,23 @@ reverse(nt::NamedTuple) = NamedTuple{reverse(keys(nt))}(reverse(values(nt)))
     (names...,)
 end
 
+@assume_effects :total function diff_types(@nospecialize(a::NamedTuple), @nospecialize(names::Tuple{Vararg{Symbol}}))
+    return Tuple{Any[ fieldtype(typeof(a), names[n]) for n in 1:length(names) ]...}
+end
+
+@assume_effects :total function diff_fallback(@nospecialize(a::NamedTuple), @nospecialize(an::Tuple{Vararg{Symbol}}), @nospecialize(bn::Tuple{Vararg{Symbol}}))
+    names = diff_names(an, bn)
+    isempty(names) && return (;)
+    types = diff_types(a, names)
+    n = length(names)
+    A = Vector{Any}(undef, n)
+    for i=1:n
+        n = names[i]
+        A[i] = getfield(a, n)
+    end
+    NamedTuple{names}((A...,))::NamedTuple{names, types}
+end
+
 """
     structdiff(a::NamedTuple, b::Union{NamedTuple,Type{NamedTuple}})
 
@@ -380,13 +408,7 @@ function structdiff(a::NamedTuple{an}, b::Union{NamedTuple{bn}, Type{NamedTuple{
         vals = Any[ :(getfield(a, $(idx[n]))) for n in 1:length(idx) ]
         return :( NamedTuple{$names,$types}(($(vals...),)) )
     else
-        names = diff_names(an, bn)
-        # N.B this early return is necessary to get a better type stability,
-        # and also allows us to cut off the cost from constructing
-        # potentially type unstable closure passed to the `map` below
-        isempty(names) && return (;)
-        types = Tuple{Any[ fieldtype(typeof(a), names[n]) for n in 1:length(names) ]...}
-        return NamedTuple{names,types}(map(n::Symbol->getfield(a, n), names))
+        return diff_fallback(a, an, bn)
     end
 end
 

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -353,3 +353,9 @@ end
     @test mapfoldl(abs, Pair{Any,Any}, NamedTuple(Symbol(:x,i) => i for i in 1:30)) == mapfoldl(abs, Pair{Any,Any}, [1:30;])
     @test_throws "reducing over an empty collection" mapfoldl(abs, =>, (;))
 end
+
+# Test effect/inference for merge/diff of unknown NamedTuples
+for f in (Base.merge, Base.structdiff)
+    @test Core.Compiler.is_foldable(Base.infer_effects(f, Tuple{NamedTuple, NamedTuple}))
+    @test Core.Compiler.return_type(f, Tuple{NamedTuple, NamedTuple}) == NamedTuple
+end


### PR DESCRIPTION
This fallback path is rarely used when the compiler is available. However, inference does look at it to determine effects for the entire method (side note, it's not entirely clear that this is sound for `if @generated` methods, but that's a more general problem). Previously inference was able to determine neither effects nor return type for merge/structdiff of unknown NamedTuples, which was problematic, because it prevented other methods that made use of these primitives from having sufficient effects to be eligible for concrete evaluation.