### PR TITLE
ml_matches: Discard matches whose isect is covered by more specific mthd

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -7938,3 +7938,10 @@ let spec = only(methods(g47476)).specializations
     @test any(mi -> mi !== nothing && Base.isvatuple(mi.specTypes), spec)
     @test all(mi -> mi === nothing || !Base.has_free_typevars(mi.specTypes), spec)
 end
+
+# Method matches should discard methods fully covered by more specific match
+f_more_specific(::Type{Union{}}) = 1
+f_more_specific(::Type{<:Base.RefValue}) = 2
+f_more_specific(::Type{<:Base.Tuple}) = 3
+f_more_specific(::Type{Tuple{}}) = 4
+@test length(methods(f_more_specific, Tuple{Type{<:Tuple}})) == 3


### PR DESCRIPTION
Before:
```
julia> methods(Base.eltype, Tuple{Type{<:Tuple}})
  [1] eltype(::Type{Union{}})
     @ abstractarray.jl:222
  [2] eltype(::Type{<:AbstractArray{E}}) where E
     @ abstractarray.jl:224
  [3] eltype(::Type{<:Base.Iterators.Stateful{T}}) where T
     @ Base.Iterators iterators.jl:1464
  [4] eltype(::Type{<:Base.CyclePadding})
     @ reinterpretarray.jl:664
  [5] eltype(::Type{T}) where T<:CartesianIndex
     @ Base.IteratorsMD multidimensional.jl:92
  [6] eltype(::Type{T}) where T<:NamedTuple
     @ namedtuple.jl:193
  [7] eltype(::Type{<:AbstractDict{K, V}}) where {K, V}
     @ abstractdict.jl:482
  [8] eltype(::Type{T}) where T<:AbstractChar
     @ char.jl:207
  [9] eltype(::Type{<:AbstractSet{T}}) where T
     @ abstractset.jl:3
 [10] eltype(::Type{<:Base.EachLine})
     @ io.jl:1064
 [11] eltype(::Type{<:Base.Iterators.Rest{I}}) where I
     @ Base.Iterators iterators.jl:653
 [12] eltype(::Type{<:AbstractString})
     @ strings/basic.jl:162
 [13] eltype(x::Type{<:Ref{T}}) where T
     @ refpointer.jl:88
 [14] eltype(::Type{<:Base.EachStringIndex})
     @ strings/basic.jl:577
 [15] eltype(::Type{<:Base.IntrusiveLinkedList{Base.LinkedListItem{T}}}) where T
     @ linked_list.jl:135
 [16] eltype(::Type{<:Base.IntrusiveLinkedList{T}}) where T
     @ linked_list.jl:13
 [17] eltype(::Type{<:Base.ReshapedArrayIterator{I}}) where I
     @ reshapedarray.jl:36
 [18] eltype(::Type{<:Base.SplitIterator{<:SubString{T}}}) where T
     @ strings/util.jl:521
 [19] eltype(::Type{<:Base.SplitIterator{T}}) where T
     @ strings/util.jl:520
 [20] eltype(::Type{<:LinearAlgebra.Factorization{T}}) where T
     @ LinearAlgebra ~/julia/usr/share/julia/stdlib/v1.9/LinearAlgebra/src/factorization.jl:14
 [21] eltype(::Type{T}) where T<:Number
     @ number.jl:84
 [22] eltype(::Type{<:Base.Iterators.Count{T}}) where T
     @ Base.Iterators iterators.jl:688
 [23] eltype(::Type{Tuple{}})
     @ tuple.jl:197
 [24] eltype(t::Type{<:Tuple{Vararg{E}}}) where E
     @ tuple.jl:198
 [25] eltype(t::Type{<:Tuple})
     @ tuple.jl:207
```

After:
```
julia> methods(Base.eltype, Tuple{Type{<:Tuple}})
 [1] eltype(::Type{Union{}})
     @ abstractarray.jl:234
 [2] eltype(::Type{T}) where T<:CartesianIndex
     @ Base.IteratorsMD multidimensional.jl:92
 [3] eltype(t::Type{<:Tuple{Vararg{E}}}) where E
     @ tuple.jl:200
 [4] eltype(t::Type{<:Tuple})
     @ tuple.jl:209
```

Note that all the extra methods in the `Before` list are not actually callable, because the only possible intersection between them and the requested signature are covered by the more specific method `eltype(::Type{Union{}})`.