### PR TITLE
copyuntil(out::IO, in::IO, delim)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ Build system changes
 
 New library functions
 ---------------------
+* `copyuntil(out, io, delim)` copies data into an `out` stream` until `delim` ([#48273]).
 
 New library features
 --------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,7 @@ Build system changes
 
 New library functions
 ---------------------
-* `copyuntil(out, io, delim)` copies data into an `out` stream` until `delim` ([#48273]).
+* `copyuntil(out, io, delim)` and `copyline(out, io)` copy data into an `out::IO` stream ([#48273]).
 
 New library features
 --------------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -857,7 +857,6 @@ export
     readline,
     readlines,
     readuntil,
-    readuntil!,
     redirect_stdio,
     redirect_stderr,
     redirect_stdin,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -857,6 +857,8 @@ export
     readline,
     readlines,
     readuntil,
+    copyuntil,
+    copyline,
     redirect_stdio,
     redirect_stderr,
     redirect_stdin,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -857,6 +857,7 @@ export
     readline,
     readlines,
     readuntil,
+    readuntil!,
     redirect_stdio,
     redirect_stderr,
     redirect_stdin,

--- a/base/io.jl
+++ b/base/io.jl
@@ -523,7 +523,7 @@ julia> readuntil("my_file.txt", '.', keep = true)
 julia> rm("my_file.txt")
 ```
 """
-readuntil(stream::IO, delim; kw...) = take!(readuntil(IOBuffer(), stream, delim; kw...))
+readuntil(stream::IO, delim; kw...) = take!(readuntil(IOBuffer(sizehint=70), stream, delim; kw...))
 readuntil(stream::IO, delim::Union{AbstractChar, AbstractString}; kw...) = String(take!(readuntil(IOBuffer(StringVector(70),write=true), stream, delim; kw...)))
 readuntil(out::IO, filename::AbstractString, delim; kw...) = open(io->readuntil(out, io, delim; kw...), convert(String, filename)::String)
 readuntil(filename::AbstractString, delim; kw...) = open(io->readuntil(io, delim; kw...), convert(String, filename)::String)
@@ -846,17 +846,17 @@ function _readuntil(out, s::IO, delim::T, keep::Bool) where T
     output! = isa(out, IO) ? write : push!
     for c in readeach(s, T)
         if c == delim
-            keep && output(out, c)
+            keep && output!(out, c)
             break
         end
-        output(out, c)
+        output!(out, c)
     end
     return out
 end
 readuntil(s::IO, delim::T; keep::Bool=false) where T =
     _readuntil(Vector{T}(), s, delim, keep)
 readuntil(s::IO, delim::UInt8; keep::Bool=false) =
-    _readuntil(StringVector(0), s, delim, keep)
+    _readuntil(resize!(StringVector(70), 0), s, delim, keep)
 readuntil(out::IO, s::IO, delim::T; keep::Bool=false) where T =
     _readuntil(out, s, delim, keep)
 
@@ -963,7 +963,7 @@ function readuntil(out::IO, io::IO, target::AbstractString; keep::Bool=false)
 end
 
 function readuntil(io::IO, target::AbstractVector{T}; keep::Bool=false) where T
-    out = (T === UInt8 ? StringVector(0) : Vector{T}())
+    out = (T === UInt8 ? resize!(StringVector(70), 0) : Vector{T}())
     readuntil_vector!(io, target, keep, out)
     return out
 end

--- a/base/io.jl
+++ b/base/io.jl
@@ -889,7 +889,7 @@ function readuntil!(s::IO, buffer::AbstractVector{UInt8}, delim::UInt8)
     @inbounds while true
         n += _readuntil!(s, view(buffer, firstindex(buffer)+n:lastindex(buffer)), delim)
         (buffer[n] == delim || eof(s)) && return n
-        resize!(buffer, 2*length(buffer)+1)
+        resize!(buffer, 2*length(buffer)+128)
     end
 end
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -835,8 +835,8 @@ function readuntil(s::IO, delim::AbstractChar; keep::Bool=false)
     return String(take!(out))
 end
 
-# read at most length(buffer) bytes; there is also an optimize method
-# for IOStream.
+# read at most length(buffer) bytes; there is also an optimized method
+# for IOStreams in iostream.jl
 function _readuntil!(s::IO, buffer::AbstractVector{UInt8}, delim::UInt8)
     buflen = length(buffer)
     iszero(buflen) && return 0
@@ -855,7 +855,8 @@ end
     readuntil!(s::IO, buffer::AbstractVector{UInt8}, delim::UInt8)
 
 Read bytes from `s` and write them into `buffer` until a byte `== delim`
-is written.  Returns the number of bytes written into `buffer`.
+is written or [`eof(s)`](@ref) is reached.  Returns the number of bytes
+written into `buffer`.
 
 The size of `buffer` will be increased (via `resize!`) if needed, but it will
 never be decreased.

--- a/base/io.jl
+++ b/base/io.jl
@@ -865,7 +865,7 @@ function readuntil!(s::IO, buffer::AbstractVector{UInt8}, delim::UInt8)
     n = 0
     @inbounds while true
         n += _readuntil!(s, view(buffer, firstindex(buffer)+n:lastindex(buffer)), delim)
-        (buffer[end] == delim || eof(s)) && return n
+        (buffer[n] == delim || eof(s)) && return n
         resize!(buffer, 2*length(buffer)+1)
     end
 end

--- a/base/io.jl
+++ b/base/io.jl
@@ -864,7 +864,7 @@ never be decreased.
 function readuntil!(s::IO, buffer::AbstractVector{UInt8}, delim::UInt8)
     n = 0
     @inbounds while true
-        n += _readuntil!(s, @view(buffer[begin+n:end]), delim)
+        n += _readuntil!(s, view(buffer, firstindex(buffer)+n:lastindex(buffer)), delim)
         (buffer[end] == delim || eof(s)) && return n
         resize!(buffer, 2*length(buffer)+1)
     end

--- a/base/io.jl
+++ b/base/io.jl
@@ -504,8 +504,8 @@ The delimiter can be a `UInt8`, `AbstractChar`, string, or vector.
 Keyword argument `keep` controls whether the delimiter is included in the result.
 The text is assumed to be encoded in UTF-8.
 
-Returns a `String` if `delim` is an `AbstractChar` or a string
-or otherwise returns a `Vector{typeof(delim)}`.   See also [`copyuntil`](@ref)
+Return a `String` if `delim` is an `AbstractChar` or a string
+or otherwise return a `Vector{typeof(delim)}`.   See also [`copyuntil`](@ref)
 to instead write in-place to another stream (which can be a preallocated [`IOBuffer`](@ref)).
 
 # Examples

--- a/base/io.jl
+++ b/base/io.jl
@@ -566,7 +566,7 @@ false (as it is by default), these trailing newline characters are removed from 
 line before it is returned. When `keep` is true, they are returned as part of the
 line.
 
-Returns a `String`.   See also [`copyline`](@ref) to instead write in-place
+Return a `String`.   See also [`copyline`](@ref) to instead write in-place
 to another stream (which can be a preallocated [`IOBuffer`](@ref)).
 
 See also [`readuntil`](@ref) for reading until more general delimiters.

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -531,7 +531,7 @@ function readuntil(io::GenericIOBuffer, delim::UInt8; keep::Bool=false)
     lb = 70
     A = StringVector(lb)
     nout = readuntil!(io, A, delim)
-    @inbounds nout -= !keep & (A[nout] == delim)
+    @inbounds nout -= !keep & (nout > 0 && A[nout] == delim)
     if length(A) != nout
         resize!(A, nout)
     end

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -516,7 +516,7 @@ function occursin(delim::UInt8, buf::GenericIOBuffer)
     return false
 end
 
-function readuntil(out::IO, io::GenericIOBuffer, delim::UInt8; keep::Bool=false)
+function copyuntil(out::IO, io::GenericIOBuffer, delim::UInt8; keep::Bool=false)
     data = view(io.data, io.ptr:io.size)
     # note: findfirst + copyto! is much faster than a single loop
     #       except for nout ≲ 20.  A single loop is 2x faster for nout=5.
@@ -529,8 +529,8 @@ function readuntil(out::IO, io::GenericIOBuffer, delim::UInt8; keep::Bool=false)
     return out
 end
 
-function readline(out::GenericIOBuffer, s::IO; keep::Bool=false)
-    readuntil(out, s, 0x0a, keep=true)
+function copyline(out::GenericIOBuffer, s::IO; keep::Bool=false)
+    copyuntil(out, s, 0x0a, keep=true)
     line = out.data
     i = out.size
     if keep || i == 0 || line[i] != 0x0a
@@ -547,7 +547,7 @@ function readline(out::GenericIOBuffer, s::IO; keep::Bool=false)
     return out
 end
 
-function _readline(out::IO, io::GenericIOBuffer; keep::Bool=false)
+function _copyline(out::IO, io::GenericIOBuffer; keep::Bool=false)
     data = view(io.data, io.ptr:io.size)
     # note: findfirst + copyto! is much faster than a single loop
     #       except for nout ≲ 20.  A single loop is 2x faster for nout=5.
@@ -560,8 +560,8 @@ function _readline(out::IO, io::GenericIOBuffer; keep::Bool=false)
     io.ptr += nread
     return out
 end
-readline(out::IO, io::GenericIOBuffer; keep::Bool=false) = _readline(out, io; keep)
-readline(out::GenericIOBuffer, io::GenericIOBuffer; keep::Bool=false) = _readline(out, io; keep)
+copyline(out::IO, io::GenericIOBuffer; keep::Bool=false) = _copyline(out, io; keep)
+copyline(out::GenericIOBuffer, io::GenericIOBuffer; keep::Bool=false) = _copyline(out, io; keep)
 
 
 # copy-free crc32c of IOBuffer:

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -448,8 +448,9 @@ function readline(s::IOStream; keep::Bool=false)
     @_lock_ios s ccall(:jl_readuntil, Ref{String}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, '\n', 1, keep ? 0 : 2)
 end
 
-function _readuntil!(buffer::Union{Vector{UInt8},FastContiguousSubArray{UInt8,1,<:Vector{UInt8}}},
-                    s::IOStream, delim::UInt8)
+function _readuntil!(s::IOStream,
+                     buffer::Union{Vector{UInt8},FastContiguousSubArray{UInt8,1,<:Vector{UInt8}}},
+                     delim::UInt8)
     @_lock_ios s return Int(ccall(:jl_readuntil_buf, Csize_t, (Ptr{Cvoid}, UInt8, Ptr{UInt8}, Csize_t),
                                   s.ios, delim, buf, length(buf) % Csize_t))
 end

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -445,13 +445,13 @@ function readuntil_string(s::IOStream, delim::UInt8, keep::Bool)
 end
 readuntil(s::IOStream, delim::AbstractChar; keep::Bool=false) =
     delim ≤ '\x7f' ? readuntil_string(s, delim % UInt8, keep) :
-    String(take!(readuntil(IOBuffer(StringVector(70),write=true), s, delim; keep)))
+    String(take!(copyuntil(IOBuffer(StringVector(70),write=true), s, delim; keep)))
 
 function readline(s::IOStream; keep::Bool=false)
     @_lock_ios s ccall(:jl_readuntil, Ref{String}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, '\n', 1, keep ? 0 : 2)
 end
 
-function readuntil(out::IOBuffer, s::IOStream, delim::UInt8; keep::Bool=false)
+function copyuntil(out::IOBuffer, s::IOStream, delim::UInt8; keep::Bool=false)
     d = out.data
     ptr = (out.append ? out.size+1 : out.ptr)
     isempty(d) && resize!(d, min(70, out.maxsize))
@@ -477,7 +477,7 @@ function readuntil(out::IOBuffer, s::IOStream, delim::UInt8; keep::Bool=false)
     return out
 end
 
-function readuntil(out::IOStream, s::IOStream, delim::UInt8; keep::Bool=false)
+function copyuntil(out::IOStream, s::IOStream, delim::UInt8; keep::Bool=false)
     @_lock_ios out @_lock_ios s ccall(:ios_copyuntil, Csize_t,
         (Ptr{Cvoid}, Ptr{Cvoid}, UInt8, Cint), out.ios, s.ios, delim, keep)
     return out

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -448,6 +448,12 @@ function readline(s::IOStream; keep::Bool=false)
     @_lock_ios s ccall(:jl_readuntil, Ref{String}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, '\n', 1, keep ? 0 : 2)
 end
 
+function _readuntil!(buffer::Union{Vector{UInt8},FastContiguousSubArray{UInt8,1,<:Vector{UInt8}}},
+                    s::IOStream, delim::UInt8)
+    @_lock_ios s return Int(ccall(:jl_readuntil_buf, Csize_t, (Ptr{Cvoid}, UInt8, Ptr{UInt8}, Csize_t),
+                                  s.ios, delim, buf, length(buf) % Csize_t))
+end
+
 function readbytes_all!(s::IOStream,
                         b::Union{Array{UInt8}, FastContiguousSubArray{UInt8,<:Any,<:Array{UInt8}}},
                         nb::Integer)

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -464,7 +464,7 @@ function readuntil(out::IOBuffer, s::IOStream, delim::UInt8; keep::Bool=false)
         ptr += n
         if d[ptr-1] == delim
             keep || (ptr -= 1)
-            break;
+            break
         end
         (eof(s) || len == out.maxsize) && break
         len = min(2len + 64, out.maxsize)

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -452,7 +452,7 @@ function _readuntil!(s::IOStream,
                      buffer::Union{Vector{UInt8},FastContiguousSubArray{UInt8,1,<:Vector{UInt8}}},
                      delim::UInt8)
     @_lock_ios s return Int(ccall(:jl_readuntil_buf, Csize_t, (Ptr{Cvoid}, UInt8, Ptr{UInt8}, Csize_t),
-                                  s.ios, delim, buf, length(buf) % Csize_t))
+                                  s.ios, delim, buffer, length(buffer) % Csize_t))
 end
 
 function readbytes_all!(s::IOStream,

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -69,7 +69,6 @@ Base.dump
 Meta.@dump
 Base.readline
 Base.readuntil
-Base.readuntil!
 Base.readlines
 Base.eachline
 Base.displaysize

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -71,6 +71,8 @@ Base.readline
 Base.readuntil
 Base.readlines
 Base.eachline
+Base.copyline
+Base.copyuntil
 Base.displaysize
 ```
 

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -69,6 +69,7 @@ Base.dump
 Meta.@dump
 Base.readline
 Base.readuntil
+Base.readuntil!
 Base.readlines
 Base.eachline
 Base.displaysize

--- a/src/flisp/iostream.c
+++ b/src/flisp/iostream.c
@@ -354,7 +354,7 @@ value_t fl_ioreaduntil(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     ios_setbuf(&dest, data, 80, 0);
     char delim = get_delim_arg(fl_ctx, args[1], "io.readuntil");
     ios_t *src = toiostream(fl_ctx, args[0], "io.readuntil");
-    size_t n = ios_copyuntil(&dest, src, delim);
+    size_t n = ios_copyuntil(&dest, src, delim, 1);
     cv->len = n;
     if (dest.buf != data) {
         // outgrew initial space
@@ -376,7 +376,7 @@ value_t fl_iocopyuntil(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     ios_t *dest = toiostream(fl_ctx, args[0], "io.copyuntil");
     ios_t *src = toiostream(fl_ctx, args[1], "io.copyuntil");
     char delim = get_delim_arg(fl_ctx, args[2], "io.copyuntil");
-    return size_wrap(fl_ctx, ios_copyuntil(dest, src, delim));
+    return size_wrap(fl_ctx, ios_copyuntil(dest, src, delim, 1));
 }
 
 value_t fl_iocopy(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -832,7 +832,7 @@ size_t ios_copyall(ios_t *to, ios_t *from)
 
 #define LINE_CHUNK_SIZE 160
 
-size_t ios_copyuntil(ios_t *to, ios_t *from, char delim)
+size_t ios_copyuntil(ios_t *to, ios_t *from, char delim, int keep)
 {
     size_t total = 0, avail = (size_t)(from->size - from->bpos);
     while (!ios_eof(from)) {
@@ -850,9 +850,9 @@ size_t ios_copyuntil(ios_t *to, ios_t *from, char delim)
             avail = 0;
         }
         else {
-            size_t ntowrite = pd - (from->buf+from->bpos) + 1;
+            size_t ntowrite = pd - (from->buf+from->bpos) + (keep != 0);
             written = ios_write(to, from->buf+from->bpos, ntowrite);
-            from->bpos += ntowrite;
+            from->bpos += ntowrite + (keep == 0);
             total += written;
             return total;
         }
@@ -1217,7 +1217,7 @@ char *ios_readline(ios_t *s)
 {
     ios_t dest;
     ios_mem(&dest, 0);
-    ios_copyuntil(&dest, s, '\n');
+    ios_copyuntil(&dest, s, '\n', 1);
     size_t n;
     return ios_take_buffer(&dest, &n);
 }

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -108,7 +108,7 @@ JL_DLLEXPORT int ios_get_writable(ios_t *s);
 JL_DLLEXPORT void ios_set_readonly(ios_t *s);
 JL_DLLEXPORT size_t ios_copy(ios_t *to, ios_t *from, size_t nbytes);
 JL_DLLEXPORT size_t ios_copyall(ios_t *to, ios_t *from);
-JL_DLLEXPORT size_t ios_copyuntil(ios_t *to, ios_t *from, char delim) JL_NOTSAFEPOINT;
+JL_DLLEXPORT size_t ios_copyuntil(ios_t *to, ios_t *from, char delim, int keep) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t ios_nchomp(ios_t *from, size_t ntowrite);
 // ensure at least n bytes are buffered if possible. returns # available.
 JL_DLLEXPORT size_t ios_readprep(ios_t *from, size_t n);

--- a/src/sys.c
+++ b/src/sys.c
@@ -288,7 +288,7 @@ JL_DLLEXPORT jl_value_t *jl_readuntil(ios_t *s, uint8_t delim, uint8_t str, uint
         ios_t dest;
         ios_mem(&dest, 0);
         ios_setbuf(&dest, (char*)a->data, 80, 0);
-        size_t n = ios_copyuntil(&dest, s, delim);
+        size_t n = ios_copyuntil(&dest, s, delim, 1);
         if (chomp && n > 0 && dest.buf[n - 1] == delim) {
             n--;
             if (chomp == 2 && n > 0 && dest.buf[n - 1] == '\r') {

--- a/test/read.jl
+++ b/test/read.jl
@@ -308,6 +308,8 @@ for (name, f) in l
             @test String(take!(copyline(IOBuffer(), file))) == "foo bar"
             @test String(take!(copyline(IOBuffer(), file, keep=true))) == kept
 
+            cleanup()
+
             buf = IOBuffer()
             @test buf === copyline(buf, io(t))
             @test String(take!(buf)) == "foo bar"
@@ -319,6 +321,8 @@ for (name, f) in l
                 @test read(file, String) == (keep ? kept : "foo bar")
             end
 
+            cleanup()
+
             write(file, lineending)
             @test readline(IOBuffer(lineending)) == ""
             @test readline(IOBuffer(lineending), keep=true) == lineending
@@ -328,6 +332,8 @@ for (name, f) in l
             @test readline(file, keep=true) == lineending
             @test String(take!(copyline(IOBuffer(), file))) == ""
             @test String(take!(copyline(IOBuffer(), file, keep=true))) == lineending
+
+            cleanup()
         end
         rm(file)
 

--- a/test/read.jl
+++ b/test/read.jl
@@ -145,6 +145,7 @@ for (name, f) in l
 
     verbose && println("$name readuntil...")
     for (t, s, m, kept) in [
+            ("a", "", "", ""),
             ("a", "ab", "a", "a"),
             ("b", "ab", "b", "b"),
             ("α", "αγ", "α", "α"),
@@ -152,16 +153,19 @@ for (name, f) in l
             ("bc", "abc", "bc", "bc"),
             ("αβ", "αβγ", "αβ", "αβ"),
             ("aaabc", "ab", "aa", "aaab"),
+            ("aaabc", "b", "aaa", "aaab"),
             ("aaabc", "ac", "aaabc", "aaabc"),
             ("aaabc", "aab", "a", "aaab"),
             ("aaabc", "aac", "aaabc", "aaabc"),
             ("αααβγ", "αβ", "αα", "αααβ"),
+            ("αααβγ", "β", "ααα", "αααβ"),
             ("αααβγ", "ααβ", "α", "αααβ"),
             ("αααβγ", "αγ", "αααβγ", "αααβγ"),
             ("barbarbarians", "barbarian", "bar", "barbarbarian"),
             ("abcaabcaabcxl", "abcaabcx", "abca", "abcaabcaabcx"),
             ("abbaabbaabbabbaax", "abbaabbabbaax", "abba", "abbaabbaabbabbaax"),
             ("abbaabbabbaabbaabbabbaax", "abbaabbabbaax", "abbaabbabba", "abbaabbabbaabbaabbabbaax"),
+            ('a'^500 * 'x' * "bbbb", "x", 'a'^500, 'a'^500 * 'x'),
            ]
         local t, s, m, kept
         @test readuntil(io(t), s) == m
@@ -174,6 +178,12 @@ for (name, f) in l
         @test readuntil(io(t), unsafe_wrap(Vector{UInt8},s), keep=true) == unsafe_wrap(Vector{UInt8},kept)
         @test readuntil(io(t), collect(s)::Vector{Char}) == Vector{Char}(m)
         @test readuntil(io(t), collect(s)::Vector{Char}, keep=true) == Vector{Char}(kept)
+
+        for blen in (0,1,100)
+            b = Vector{UInt8}(undef, blen)
+            n = readuntil!(io(t), b, s)
+            @test b[1:n] == codeunits(kept)
+        end
     end
     cleanup()
 

--- a/test/read.jl
+++ b/test/read.jl
@@ -179,11 +179,17 @@ for (name, f) in l
         @test readuntil(io(t), collect(s)::Vector{Char}) == Vector{Char}(m)
         @test readuntil(io(t), collect(s)::Vector{Char}, keep=true) == Vector{Char}(kept)
 
-        for blen in (0,1,100)
-            b = Vector{UInt8}(undef, blen)
-            n = readuntil!(io(t), b, s)
-            @test b[1:n] == codeunits(kept)
+        buf = IOBuffer()
+        @test String(take!(readuntil(buf, io(t), s))) == m
+        @test String(take!(readuntil(buf, io(t), s, keep=true))) == kept
+        file = tempname()
+        for (k,m) in ((false, m), (true, kept))
+            open(file, "w") do f
+                @test f == readuntil(f, io(t), s, keep=k)
+            end
+            @test read(file, String) == m
         end
+        rm(file)
     end
     cleanup()
 


### PR DESCRIPTION
This PR defines and exports  ~~a new function `readuntil!(s::IO, buffer::AbstractVector{UInt8}, delim)`~~ new functions:
```jl
copyuntil(out::IO, s::IO, delim; keep=false)
copyline(out::IO, s::IO; keep=false)
```
that read data from `s` into ~~`buffer` in-place (resized if needed)~~ the `out` stream until `delim` is read/written or the end of the stream is reached.

The PR was inspired by [this post](https://discourse.julialang.org/t/is-julia-well-suited-for-string-manipulation/92943/8?u=stevengj) from @jakobnissen: the goal is to make it easier implement an allocation-free `eachline` iterator.   This can be done in a package, given `readuntil` with an `IOBuffer`, using the [`StringViews.jl` package](https://github.com/JuliaStrings/StringViews.jl) to return a string view of the in-place `buffer` on each iteration.

The reason it seemed like this needed a `Base` function, instead of living completely in a package, is that `readuntil` relies on a [low-level `jl_readuntil` C function](https://github.com/JuliaLang/julia/blob/428d242f9b8808e48905c7e82dede0e605f163cb/src/sys.c#L261-L317) that would be difficult to replicate in a package.  To obtain comparable performance, it seems like we need an analogous `jl_readuntil_buf` method (implemented in this PR) and a corresponding Julia API.

Moreover, relatively little new code was required because many of the existing `readuntil` methods used an `IOBuffer` internally, so it was merely a matter of refactoring and exporting this functionality.   Also, we already had an optimized [ios_copyuntil function](https://github.com/JuliaLang/julia/blob/8a9589d5a5d9f6bbc3dd8cbcdfb93fa03527c796/src/support/ios.c#L832-L859) for copying between IOStreams, which can now be exported in the new API.

To do:
- [x] Fix bootstrapping failures
- [x] Benchmarks.  (Maybe it is faster just to read the file in 4k blocks into a buffer with `readbytes!` and then return StringViews on top of that?   This could happen completely in a package.  It's a *lot* easier to use something like `readuntil!`, however.)
- [x] Tests
- [x] More docs
- [x] NEWS
- [x] Fixes and tests for new `out::IO` variant
- [x] add `readline(out::IO, in::IO)` too?
- [x] more tests for `readline(out::IO, in::IO)` methods
- [x] more benchmarks and optimization

Before I do much more work on this, what do people think?