### PR TITLE
Refine eltype(::Type{<:Flatten})

### DIFF
--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -493,6 +493,8 @@ end
 @test collect(flatten(Any[flatten(Any[1:2, 6:5]), flatten(Any[6:7, 8:9])])) == Any[1,2,6,7,8,9]
 @test collect(flatten(Any[2:1])) == Any[]
 @test eltype(flatten(UnitRange{Int8}[1:2, 3:4])) == Int8
+@test eltype(flatten(((1,), [2]))) == Int
+
 @test length(flatten(zip(1:3, 4:6))) == 6
 @test length(flatten(1:6)) == 6
 @test collect(flatten(Any[])) == Any[]


### PR DESCRIPTION
The new approach uses `typejoin` over `eltype` of all the underlying iterators of the `Flatten`. This way, `eltype(flatten(((1,), [1]))) == Int`, whereas it was `Any` before, due to the heterogenous underlying iterators.

Closes #48249