### PR TITLE
faster isascii(::Char)

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -808,7 +808,7 @@ end
 readuntil_string(s::IO, delim::UInt8, keep::Bool) = String(readuntil(s, delim, keep=keep))::String
 
 function readuntil(s::IO, delim::AbstractChar; keep::Bool=false)
-    if delim ≤ '\x7f'
+    if isascii(delim)
         return readuntil_string(s, delim % UInt8, keep)
     end
     out = IOBuffer()
@@ -925,7 +925,7 @@ function readuntil(io::IO, target::AbstractString; keep::Bool=false)
     x = Iterators.peel(target)
     isnothing(x) && return ""
     c, rest = x
-    if isempty(rest) && c <= '\x7f'
+    if isempty(rest) && isascii(c)
         return readuntil_string(io, c % UInt8, keep)
     end
     # convert String to a utf8-byte-iterator

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -609,7 +609,7 @@ julia> replace("abcdeγfgh", !isascii=>' ') # replace non-ASCII chars with space
 "abcde fgh"
 ```
 """
-isascii(c::Char) = bswap(reinterpret(UInt32, c)) < 0x80
+isascii(c::Char) = c <= '\x7f'
 isascii(s::AbstractString) = all(isascii, s)
 isascii(c::AbstractChar) = UInt32(c) < 0x80
 


### PR DESCRIPTION
The previous implementation of `isascii(c::Char)`, by @StefanKarpinski in #24999, was `bswap(reinterpret(UInt32, c)) < 0x80`.   However, I noticed that [base/io.jl](https://github.com/JuliaLang/julia/blob/0371bf44bf6bfd6ee9fbfc32d478c2ff4c97b08b/base/io.jl#L811) is using a nicer trick: `c ≤ '\x7f'`, which oddly enough is *also* by @StefanKarpinski in #24999.   The latter seems to compile to one fewer instruction because it omits the `bswap`.

@StefanKarpinski, any comment here?

The PR also cleans up `io.jl` to use `isascii(c)` rather than `c ≤ '\x7f'`, since they should now be equivalent.