### PR TITLE
Add option to add backtrace to log messages

### DIFF
--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -104,7 +104,7 @@ function termlength(str)
 end
 
 function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module, group, id,
-                        filepath, line; kwargs...)
+                        filepath, line; trace=nothing, kwargs...)
     @nospecialize
     hasmaxlog = haskey(kwargs, :maxlog) ? 1 : 0
     maxlog = get(kwargs, :maxlog, nothing)
@@ -152,6 +152,13 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
                   msglines[end].indent + termlength(msglines[end].msg) +
                   (isempty(suffix) ? 0 : length(suffix)+minsuffixpad)
     justify_width = min(logger.right_justify, dsize[2])
+    if !isnothing(trace)
+        push!(msglines, (indent=0, msg="Stacktrace:"))
+        for line in trace[4:end] # skip the first two which will fall in logger code
+            line.file == Symbol("./boot.jl") && line.func == :eval && break
+            push!(msglines, (indent=2, msg=SubString(sprint(show,line))))
+        end
+    end
     if nonpadwidth > justify_width && !isempty(suffix)
         push!(msglines, (indent=0, msg=SubString("")))
         minsuffixpad = 0

--- a/stdlib/Test/src/logging.jl
+++ b/stdlib/Test/src/logging.jl
@@ -26,6 +26,7 @@ struct LogRecord
     id
     file
     line
+    trace
     kwargs
 end
 LogRecord(args...; kwargs...) = LogRecord(args..., kwargs)
@@ -93,7 +94,7 @@ function Logging.shouldlog(logger::TestLogger, level, _module, group, id)
 end
 
 function Logging.handle_message(logger::TestLogger, level, msg, _module,
-                                group, id, file, line; kwargs...)
+                                group, id, file, line; trace=nothing, kwargs...)
     @nospecialize
     if logger.respect_maxlog
         maxlog = get(kwargs, :maxlog, nothing)
@@ -103,7 +104,7 @@ function Logging.handle_message(logger::TestLogger, level, msg, _module,
             remaining > 0 || return
         end
     end
-    push!(logger.logs, LogRecord(level, msg, _module, group, id, file, line, kwargs))
+    push!(logger.logs, LogRecord(level, msg, _module, group, id, file, line, trace, kwargs))
 end
 
 # Catch exceptions for the test logger only if specified


### PR DESCRIPTION
Tracking down why a log message is happening can be hard from just the call site info.

The idea here is to expose a way to inject stack traces into the log message without having to edit the code site to manually add an error. For instance in CI where adding an env var is easier than editing code in a dependency that logs.

`test.jl` including
```
foo() = bar()
bar() = @error "hello"
```
This PR:
```
julia> include("test.jl")

julia> foo()
┌ Error: hello
└ @ Main ~/test.jl:2

julia> ENV["JULIA_LOG_TRACE"]=1
1

julia> foo()
┌ Error: hello
│ Stacktrace:
│   bar() at test.jl:2
│   foo() at test.jl:1
│   top-level scope at REPL[25]:1
└ @ Main ~/test.jl:2

julia> ENV["JULIA_DEBUG"]="loading"
"loading"

julia> using CSV
┌ Debug: Loading object cache file /Users/ian/.julia/compiled/v1.10/Preferences/pWSk8_wG2DL.dylib for Preferences [21216c6a-2e73-6563-6e65-726566657250]
│ Stacktrace:
│   _include_from_serialized(pkg::Base.PkgId, path::String, ocachepath::String, depmods::Vector{Any}) at loading.jl:1000
│   _tryrequire_from_serialized(modkey::Base.PkgId, path::String, ocachepath::String, sourcepath::String, depmods::Vector{Any}) at loading.jl:1298
│   _require_search_from_serialized(pkg::Base.PkgId, sourcepath::String, build_id::UInt128) at loading.jl:1401
│   _require(pkg::Base.PkgId, env::String) at loading.jl:1690
│   _require_prelocked(uuidkey::Base.PkgId, env::String) at loading.jl:1567
│   macro expansion at loading.jl:1555 [inlined]
│   macro expansion at lock.jl:267 [inlined]
│   require(into::Module, mod::Symbol) at loading.jl:1518
└ @ Base loading.jl:1000
...
```

Ignoring the stackframes from inside the logging code gen might be too crude.

Also, ignoring past an eval as a way to ignore the repl internals might be too, as `Base.scrub_repl_backtrace` didn't work for some reason.