### PR TITLE
namedtuple: Use correct return type in merge/diff

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -129,6 +129,12 @@ function NamedTuple{names, T}(nt::NamedTuple) where {names, T <: Tuple}
     end
 end
 
+# Like NamedTuple{names, T} as a constructor, but omits the additional
+# `convert` call, when the types are known to match the fields
+@eval function _new_NamedTuple(T::Type{NamedTuple{NTN, NTT}} where {NTN, NTT}, args::Tuple)
+    $(Expr(:splatnew, :T, :args))
+end
+
 function NamedTuple{names}(nt::NamedTuple) where {names}
     if @generated
         idx = Int[ fieldindex(nt, names[n]) for n in 1:length(names) ]
@@ -137,7 +143,7 @@ function NamedTuple{names}(nt::NamedTuple) where {names}
     else
         length_names = length(names::Tuple)
         types = Tuple{(fieldtype(typeof(nt), names[n]) for n in 1:length_names)...}
-        NamedTuple{names, types}(map(Fix1(getfield, nt), names))
+        _new_NamedTuple(NamedTuple{names, types}, map(Fix1(getfield, nt), names))
     end
 end
 
@@ -277,7 +283,7 @@ end
         n = names[i]
         A[i] = getfield(sym_in(n, bn) ? b : a, n)
     end
-    NamedTuple{names}((A...,))::NamedTuple{names, types}
+    _new_NamedTuple(NamedTuple{names, types}, (A...,))
 end
 
 """
@@ -310,7 +316,7 @@ function merge(a::NamedTuple{an}, b::NamedTuple{bn}) where {an, bn}
         names = merge_names(an, bn)
         types = merge_types(names, a, b)
         vals = Any[ :(getfield($(sym_in(names[n], bn) ? :b : :a), $(QuoteNode(names[n])))) for n in 1:length(names) ]
-        :( NamedTuple{$names,$types}(($(vals...),)) )
+        :( _new_NamedTuple(NamedTuple{$names,$types}, ($(vals...),)) )
     else
         merge_fallback(a, b, an, bn)
     end
@@ -390,7 +396,7 @@ end
         n = names[i]
         A[i] = getfield(a, n)
     end
-    NamedTuple{names}((A...,))::NamedTuple{names, types}
+    _new_NamedTuple(NamedTuple{names, types}, (A...,))
 end
 
 """
@@ -406,7 +412,7 @@ function structdiff(a::NamedTuple{an}, b::Union{NamedTuple{bn}, Type{NamedTuple{
         idx = Int[ fieldindex(a, names[n]) for n in 1:length(names) ]
         types = Tuple{Any[ fieldtype(a, idx[n]) for n in 1:length(idx) ]...}
         vals = Any[ :(getfield(a, $(idx[n]))) for n in 1:length(idx) ]
-        return :( NamedTuple{$names,$types}(($(vals...),)) )
+        return :( _new_NamedTuple(NamedTuple{$names,$types}, ($(vals...),)) )
     else
         return diff_fallback(a, an, bn)
     end

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -356,6 +356,14 @@ end
 
 # Test effect/inference for merge/diff of unknown NamedTuples
 for f in (Base.merge, Base.structdiff)
-    @test Core.Compiler.is_foldable(Base.infer_effects(f, Tuple{NamedTuple, NamedTuple}))
+    let eff = Base.infer_effects(f, Tuple{NamedTuple, NamedTuple})
+        @test Core.Compiler.is_foldable(eff) && eff.nonoverlayed
+    end
     @test Core.Compiler.return_type(f, Tuple{NamedTuple, NamedTuple}) == NamedTuple
+end
+
+# Test that merge/diff preserves nt field types
+let a = Base.NamedTuple{(:a, :b), Tuple{Any, Any}}((1, 2)), b = Base.NamedTuple{(:b,), Tuple{Float64}}(3)
+    @test typeof(Base.merge(a, b)) == Base.NamedTuple{(:a, :b), Tuple{Any, Float64}}
+    @test typeof(Base.structdiff(a, b)) == Base.NamedTuple{(:a,), Tuple{Any}}
 end


### PR DESCRIPTION
In a lapse of memory, I had assumed that NamedTuple was covariant like Tuple, but since this is not the case, we do actually need to pass the types into the constructor. However, the main constructor for NamedTuple has an extra `convert` call to the declared tuple type. This call is problematic for effects, because the type is unknown. For the merge/diff case, we are guaranteed that the convert is a no-op, but the compiler's analysis is not strong enough to prove this. Work around that by introducing an `_NamedTuple` constructor that bypasses the unnecessary convert to make sure that the compiler can prove sufficiently strong effects.