### PR TITLE
Profile: print profile peek to stderr

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -39,9 +39,9 @@ function profile_printing_listener()
             wait(PROFILE_PRINT_COND[])
             peek_report[]()
             if get(ENV, "JULIA_PROFILE_PEEK_HEAP_SNAPSHOT", nothing) === "1"
-                println("Saving heap snapshot...")
+                println(stderr, "Saving heap snapshot...")
                 fname = take_heap_snapshot()
-                println("Heap snapshot saved to `$(fname)`")
+                println(stderr, "Heap snapshot saved to `$(fname)`")
             end
         end
     catch ex
@@ -54,9 +54,9 @@ end
 # An internal function called to show the report after an information request (SIGINFO or SIGUSR1).
 function _peek_report()
     iob = IOBuffer()
-    ioc = IOContext(IOContext(iob, stdout), :displaysize=>displaysize(stdout))
+    ioc = IOContext(IOContext(iob, stderr), :displaysize=>displaysize(stderr))
     print(ioc, groupby = [:thread, :task])
-    Base.print(stdout, String(take!(iob)))
+    Base.print(stderr, String(take!(iob)))
 end
 # This is a ref so that it can be overridden by other profile info consumers.
 const peek_report = Ref{Function}(_peek_report)

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -206,7 +206,7 @@ if Sys.isbsd() || Sys.islinux()
                 end
                 """
             iob = Base.BufferStream()
-            p = run(pipeline(`$cmd -e $script`, stderr = devnull, stdout = iob), wait = false)
+            p = run(pipeline(`$cmd -e $script`, stderr = iob, stdout = devnull), wait = false)
             t = Timer(120) do t
                 # should be under 10 seconds, so give it 2 minutes then report failure
                 println("KILLING BY PROFILE TEST WATCHDOG\n")

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -199,7 +199,7 @@ if Sys.isbsd() || Sys.islinux()
         let cmd = Base.julia_cmd()
             script = """
                 x = rand(1000, 1000)
-                println("started")
+                println(stderr, "started")
                 while true
                     x * x
                     yield()


### PR DESCRIPTION
The first part of the report prints to stderr, so the peek report and optional heap snapshot notices should too.