### PR TITLE
get_bool_env: remove default for `default` arg

### DIFF
--- a/base/env.jl
+++ b/base/env.jl
@@ -111,7 +111,7 @@ const get_bool_env_falsy = (
     "0")
 
 """
-    Base.get_bool_env(name::String, default::Bool = false)::Union{Bool,Nothing}
+    Base.get_bool_env(name::String, default::Bool)::Union{Bool,Nothing}
 
 Evaluate whether the value of environnment variable `name` is a truthy or falsy string,
 and return `nothing` if it is not recognized as either. If the variable is not set, or is set to "",
@@ -121,7 +121,7 @@ Recognized values are the following, and their Capitalized and UPPERCASE forms:
     truthy: "t", "true", "y", "yes", "1"
     falsy:  "f", "false", "n", "no", "0"
 """
-function get_bool_env(name::String, default::Bool = false)
+function get_bool_env(name::String, default::Bool)
     haskey(ENV, name) || return default
     val = ENV[name]
     if isempty(val)

--- a/test/env.jl
+++ b/test/env.jl
@@ -127,7 +127,6 @@ end
         for v in ("t", "true", "y", "yes", "1")
             for _v in (v, uppercasefirst(v), uppercase(v))
                 ENV["testing_gbe"] = _v
-                @test Base.get_bool_env("testing_gbe") == true
                 @test Base.get_bool_env("testing_gbe", false) == true
                 @test Base.get_bool_env("testing_gbe", true) == true
             end
@@ -137,7 +136,6 @@ end
         for v in ("f", "false", "n", "no", "0")
             for _v in (v, uppercasefirst(v), uppercase(v))
                 ENV["testing_gbe"] = _v
-                @test Base.get_bool_env("testing_gbe") == false
                 @test Base.get_bool_env("testing_gbe", true) == false
                 @test Base.get_bool_env("testing_gbe", false) == false
             end
@@ -145,25 +143,26 @@ end
     end
     @testset "empty" begin
         ENV["testing_gbe"] = ""
-        @test Base.get_bool_env("testing_gbe") == false
         @test Base.get_bool_env("testing_gbe", true) == true
         @test Base.get_bool_env("testing_gbe", false) == false
     end
     @testset "undefined" begin
         delete!(ENV, "testing_gbe")
         @test !haskey(ENV, "testing_gbe")
-        @test Base.get_bool_env("testing_gbe") == false
         @test Base.get_bool_env("testing_gbe", true) == true
         @test Base.get_bool_env("testing_gbe", false) == false
     end
     @testset "unrecognized" begin
         for v in ("truw", "falls")
             ENV["testing_gbe"] = v
-            @test Base.get_bool_env("testing_gbe") === nothing
             @test Base.get_bool_env("testing_gbe", true) === nothing
             @test Base.get_bool_env("testing_gbe", false) === nothing
         end
     end
+
+    # the "default" arg shouldn't have a default val, for clarity.
+    @test_throws MethodError Base.get_bool_env("testing_gbe")
+
     delete!(ENV, "testing_gbe")
     @test !haskey(ENV, "testing_gbe")
 end


### PR DESCRIPTION
The initial version of https://github.com/JuliaLang/julia/pull/48202 highlighted that having a default for the default arg in `Base.get_bool_env` makes the behavior of the function easy to confuse at the call site. So this removes the default.