### PR TITLE
Add docstring for `err` in the REPL

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1457,6 +1457,14 @@ A variable referring to the last computed value, automatically set at the intera
 kw"ans"
 
 """
+    err
+
+A variable referring to the last thrown errors, automatically set at the interactive prompt.
+The thrown errors are collected in a stack of exceptions.
+"""
+kw"err"
+
+"""
     devnull
 
 Used in a stream redirect to discard all data written to it. Essentially equivalent to

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -37,6 +37,7 @@ Base.which(::Any, ::Any)
 Base.methods
 Base.@show
 ans
+err
 Base.active_project
 Base.set_active_project
 ```


### PR DESCRIPTION
Unlike `ans`, this previously wasn't documented:

```
help?> ans
search: ans transpose transcode contains expanduser instances MathConstants readlines LinearIndices leading_ones

  ans

  A variable referring to the last computed value, automatically set at the interactive prompt.

help?> err
search: error errormonitor ErrorException @error stderr InterruptException showerror LoadError InitError

Couldn't find err
Perhaps you meant error, zero, repr, eof, eps, esc, exp, end, nor, rm, xor, Ptr, for, try, @error, stderr or merge
  No documentation found.

  Binding err does not exist.
```

Found while looking at #48299