### PR TITLE
RFC: move ans and err variables to MainInclude module

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -425,16 +425,14 @@ include("loading.jl")
 # misc useful functions & macros
 include("timing.jl")
 include("util.jl")
-
+include("client.jl")
 include("asyncmap.jl")
 
 # deprecated functions
 include("deprecated.jl")
-
-# Some basic documentation
+#
+# Some additional basic documentation
 include("docs/basedocs.jl")
-
-include("client.jl")
 
 # Documentation -- should always be included last in sysimg.
 include("docs/Docs.jl")

--- a/base/client.jl
+++ b/base/client.jl
@@ -132,14 +132,14 @@ function eval_user_input(errio, @nospecialize(ast), show_value::Bool)
             end
             if lasterr !== nothing
                 lasterr = scrub_repl_backtrace(lasterr)
-                istrivialerror(lasterr) || setglobal!(Main, :err, lasterr)
+                istrivialerror(lasterr) || setglobal!(Base.MainInclude, :err, lasterr)
                 invokelatest(display_error, errio, lasterr)
                 errcount = 0
                 lasterr = nothing
             else
                 ast = Meta.lower(Main, ast)
                 value = Core.eval(Main, ast)
-                setglobal!(Main, :ans, value)
+                setglobal!(Base.MainInclude, :ans, value)
                 if !(value === nothing) && show_value
                     if have_color
                         print(answer_color())
@@ -159,7 +159,7 @@ function eval_user_input(errio, @nospecialize(ast), show_value::Bool)
             end
             errcount += 1
             lasterr = scrub_repl_backtrace(current_exceptions())
-            setglobal!(Main, :err, lasterr)
+            setglobal!(Base.MainInclude, :err, lasterr)
             if errcount > 2
                 @error "It is likely that something important is broken, and Julia will not be able to continue normally" errcount
                 break
@@ -478,6 +478,25 @@ function include(fname::AbstractString)
     Base._include(identity, Main, fname)
 end
 eval(x) = Core.eval(Main, x)
+
+"""
+    ans
+
+A variable referring to the last computed value, automatically imported to the interactive prompt.
+"""
+global ans = nothing
+
+"""
+    err
+
+A variable referring to the last thrown errors, automatically imported to the interactive prompt.
+The thrown errors are collected in a stack of exceptions.
+"""
+global err = nothing
+
+# weakly exposes ans and err variables to Main
+export ans, err
+
 end
 
 """

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1471,21 +1471,6 @@ parser rather than being implemented as a normal string macro `@var_str`.
 kw"var\"name\"", kw"@var_str"
 
 """
-    ans
-
-A variable referring to the last computed value, automatically set at the interactive prompt.
-"""
-kw"ans"
-
-"""
-    err
-
-A variable referring to the last thrown errors, automatically set at the interactive prompt.
-The thrown errors are collected in a stack of exceptions.
-"""
-kw"err"
-
-"""
     devnull
 
 Used in a stream redirect to discard all data written to it. Essentially equivalent to

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -5,6 +5,7 @@ Core.include(Main, "Base.jl")
 using .Base
 
 # Set up Main module
+using Base.MainInclude # ans, err, and sometimes Out
 import Base.MainInclude: eval, include
 
 # Ensure this file is also tracked

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -148,7 +148,7 @@ function eval_user_input(@nospecialize(ast), backend::REPLBackend, mod::Module)
                 end
                 value = Core.eval(mod, ast)
                 backend.in_eval = false
-                setglobal!(mod, :ans, value)
+                setglobal!(Base.MainInclude, :ans, value)
                 put!(backend.response_channel, Pair{Any, Bool}(value, false))
             end
             break
@@ -290,7 +290,7 @@ function print_response(errio::IO, response, show_value::Bool, have_color::Bool,
             Base.sigatomic_end()
             if iserr
                 val = Base.scrub_repl_backtrace(val)
-                Base.istrivialerror(val) || setglobal!(Main, :err, val)
+                Base.istrivialerror(val) || setglobal!(Base.MainInclude, :err, val)
                 Base.invokelatest(Base.display_error, errio, val)
             else
                 if val !== nothing && show_value
@@ -313,7 +313,7 @@ function print_response(errio::IO, response, show_value::Bool, have_color::Bool,
                 println(errio, "SYSTEM (REPL): showing an error caused an error")
                 try
                     excs = Base.scrub_repl_backtrace(current_exceptions())
-                    setglobal!(Main, :err, excs)
+                    setglobal!(Base.MainInclude, :err, excs)
                     Base.invokelatest(Base.display_error, errio, excs)
                 catch e
                     # at this point, only print the name of the type as a Symbol to
@@ -1416,8 +1416,10 @@ end
 
 function capture_result(n::Ref{Int}, @nospecialize(x))
     n = n[]
-    mod = REPL.active_module()
+    mod = Base.MainInclude
     if !isdefined(mod, :Out)
+        @eval mod global Out
+        @eval mod export Out
         setglobal!(mod, :Out, Dict{Int, Any}())
     end
     if x !== getglobal(mod, :Out) && x !== nothing # remove this?
@@ -1460,6 +1462,17 @@ function ipython_mode!(repl::LineEditREPL=Base.active_repl, backend=nothing)
     push!(__current_ast_transforms(backend), @nospecialize(ast) -> out_transform(ast, n))
     return
 end
+
+"""
+    Out[n]
+
+A variable referring to all previously computed values, automatically imported to the interactive prompt.
+Only defined and exists while using [IPython mode](@ref IPython-mode).
+
+See also [`ans`](@ref).
+"""
+Base.MainInclude.Out
+
 end
 
 import .IPython.ipython_mode!

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1164,7 +1164,7 @@ fake_repl() do stdin_write, stdout_read, repl
     Base.wait(repltask)
 end
 
-help_result(line, mod::Module=Base) = mod.eval(REPL._helpmode(IOBuffer(), line))
+help_result(line, mod::Module=Base) = Core.eval(mod, REPL._helpmode(IOBuffer(), line))
 
 # Docs.helpmode tests: we test whether the correct expressions are being generated here,
 # rather than complete integration with Julia's REPL mode system.
@@ -1203,7 +1203,9 @@ end
 @test occursin("broadcast", sprint(show, help_result(".<=")))
 
 # Issue 39427
-@test occursin("does not exist", sprint(show, help_result(":=")))
+@test occursin("does not exist.", sprint(show, help_result(":=")))
+global some_undef_global
+@test occursin("exists,", sprint(show, help_result("some_undef_global", @__MODULE__)))
 
 # Issue #40563
 @test occursin("does not exist", sprint(show, help_result("..")))
@@ -1481,7 +1483,7 @@ fake_repl() do stdin_write, stdout_read, repl
     end
     # initialize `err` to `nothing`
     t = @async (readline(stdout_read); readuntil(stdout_read, "\e[0m\n"))
-    write(stdin_write, "global err = nothing\n")
+    write(stdin_write, "setglobal!(Base.MainInclude, :err, nothing)\n")
     wait(t)
     readuntil(stdout_read, "julia> ", keep=true)
     # generate top-level error


### PR DESCRIPTION
This hides them from `names()` unfortunately, but means we will not accidentally discard a variable from the user in Main, either because the import will fail or the assignment will fail. If we later have world-versioned bindings, this would also mean you could toggle (between worlds) between being module-local and a special import value.

Fix #43172
Fix #48299