### PR TITLE
remove precompile mutation step from staticdata

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -281,11 +281,9 @@ jl_code_info_t *jl_type_infer(jl_method_instance_t *mi, size_t world, int force)
         return NULL;
     jl_task_t *ct = jl_current_task;
     if (ct->reentrant_inference == (uint16_t)-1) {
-        // TODO: We should avoid attempting to re-inter inference here at all
-        // and turn on this warning, but that requires further refactoring
-        // of the precompile code, so for now just catch that case here.
-        //jl_printf(JL_STDERR, "ERROR: Attempted to enter inference while writing out image.");
-        return NULL;
+        // We must avoid attempting to re-enter inference here
+        assert(0 && "attempted to enter inference while writing out image");
+        abort();
     }
     if (ct->reentrant_inference > 2)
         return NULL;
@@ -487,6 +485,7 @@ int foreach_mtable_in_module(
                         // this is the original/primary binding for the type (name/wrapper)
                         jl_methtable_t *mt = tn->mt;
                         if (mt != NULL && (jl_value_t*)mt != jl_nothing && mt != jl_type_type_mt && mt != jl_nonfunction_mt) {
+                            assert(mt->module == m);
                             if (!visit(mt, env))
                                 return 0;
                         }
@@ -497,6 +496,15 @@ int foreach_mtable_in_module(
                     if (child != m && child->parent == m && child->name == name) {
                         // this is the original/primary binding for the submodule
                         if (!foreach_mtable_in_module(child, visit, env))
+                            return 0;
+                    }
+                }
+                else if (jl_is_mtable(v)) {
+                    jl_methtable_t *mt = (jl_methtable_t*)v;
+                    if (mt->module == m && mt->name == name) {
+                        // this is probably an external method table here, so let's
+                        // assume so as there is no way to precisely distinguish them
+                        if (!visit(mt, env))
                             return 0;
                     }
                 }

--- a/src/precompile_utils.c
+++ b/src/precompile_utils.c
@@ -132,6 +132,8 @@ static int compile_all_collect__(jl_typemap_entry_t *ml, void *env)
 {
     jl_array_t *allmeths = (jl_array_t*)env;
     jl_method_t *m = ml->func.method;
+    if (m->external_mt)
+        return 1;
     if (m->source) {
         // method has a non-generated definition; can be compiled generically
         jl_array_ptr_1d_push(allmeths, (jl_value_t*)m);
@@ -204,6 +206,8 @@ static int precompile_enq_specialization_(jl_method_instance_t *mi, void *closur
 static int precompile_enq_all_specializations__(jl_typemap_entry_t *def, void *closure)
 {
     jl_method_t *m = def->func.method;
+    if (m->external_mt)
+        return 1;
     if ((m->name == jl_symbol("__init__") || m->ccallable) && jl_is_dispatch_tupletype(m->sig)) {
         // ensure `__init__()` and @ccallables get strongly-hinted, specialized, and compiled
         jl_method_instance_t *mi = jl_specializations_get_linfo(m, m->sig, jl_emptysvec);


### PR DESCRIPTION
Make sure things are properly ordered here, so that when serializing, nothing is mutating the system at the same time.

Fix #48047