### PR TITLE
Fix typo in `isambiguous`

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1858,7 +1858,7 @@ function isambiguous(m1::Method, m2::Method; ambiguous_bottom::Bool=false)
                 m = match.method
                 m === minmax && continue
                 if !morespecific(minmax.sig, m.sig)
-                    if match.full_covers || !morespecific(m.sig, minmax.sig)
+                    if match.fully_covers || !morespecific(m.sig, minmax.sig)
                         return true
                     end
                 end

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -153,9 +153,17 @@ ambig(x::Int8, y) = 1
 ambig(x::Integer, y) = 2
 ambig(x, y::Int) = 3
 end
-
 ambs = detect_ambiguities(Ambig5)
 @test length(ambs) == 2
+
+module Ambig48312
+ambig(::Integer, ::Int) = 1
+ambig(::Int, ::Integer) = 2
+ambig(::Signed, ::Int) = 3
+ambig(::Int, ::Signed) = 4
+end
+ambs = detect_ambiguities(Ambig48312)
+@test length(ambs) == 4
 
 # Test that Core and Base are free of ambiguities
 # not using isempty so this prints more information when it fails


### PR DESCRIPTION
This went wrong in #48196 and is apparently untested. @vtjnash