### PR TITLE
remove uses of `@Module.macro`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -936,7 +936,7 @@ end
 
 ## from general iterable to any array
 
-# This is `@Experimental.max_methods 1 function copyto! end`, which is not
+# This is `Experimental.@max_methods 1 function copyto! end`, which is not
 # defined at this point in bootstrap.
 typeof(function copyto! end).name.max_methods = UInt8(1)
 

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -50,7 +50,7 @@ ntuple(f, n) = (Any[f(i) for i = 1:n]...,)
 
 # core operations & types
 function return_type end # promotion.jl expects this to exist
-is_return_type(@Core.nospecialize(f)) = f === return_type
+is_return_type(Core.@nospecialize(f)) = f === return_type
 include("promotion.jl")
 include("tuple.jl")
 include("pair.jl")

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -111,9 +111,9 @@ function verify_ir(ir::IRCode, print::Bool=true,
                 error("")
             end
             if !(idx in ir.cfg.blocks[s].preds)
-                #@Base.show ir.cfg
-                #@Base.show ir
-                #@Base.show ir.argtypes
+                #Base.@show ir.cfg
+                #Base.@show ir
+                #Base.@show ir.argtypes
                 @verify_error "Successor $s of block $idx not in predecessor list"
                 error("")
             end
@@ -192,8 +192,8 @@ function verify_ir(ir::IRCode, print::Bool=true,
                     end
                 end
                 if !(edge == 0 && bb == 1) && !(edge in ir.cfg.blocks[bb].preds)
-                    #@Base.show ir.argtypes
-                    #@Base.show ir
+                    #Base.@show ir.argtypes
+                    #Base.@show ir
                     @verify_error "Edge $edge of φ node $idx not in predecessor list"
                     error("")
                 end

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -39,7 +39,7 @@ You can document an object after its definition by
     @doc "foo" function_to_doc
     @doc "bar" TypeToDoc
 
-For macros, the syntax is `@doc "macro doc" :(@Module.macro)` or `@doc "macro doc"
+For macros, the syntax is `@doc "macro doc" :(Module.@macro)` or `@doc "macro doc"
 :(string_macro"")` for string macros. Without the quote `:()` the expansion of the macro
 will be documented.
 

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -302,7 +302,7 @@ end
 
 # Tests for issue #23109 - should not hang.
 f = @spawnat :any rand(1, 1)
-@Base.Experimental.sync begin
+Base.Experimental.@sync begin
     for _ in 1:10
         @async fetch(f)
     end
@@ -310,7 +310,7 @@ end
 
 wid1, wid2 = workers()[1:2]
 f = @spawnat wid1 rand(1,1)
-@Base.Experimental.sync begin
+Base.Experimental.@sync begin
     @async fetch(f)
     @async remotecall_fetch(()->fetch(f), wid2)
 end

--- a/stdlib/FileWatching/test/runtests.jl
+++ b/stdlib/FileWatching/test/runtests.jl
@@ -74,7 +74,7 @@ end
 
 # Odd numbers trigger reads, even numbers timeout
 for (i, intvl) in enumerate(intvls)
-    @Experimental.sync begin
+    Experimental.@sync begin
         global ready = 0
         global ready_c = Condition()
         for idx in 1:n

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -331,7 +331,7 @@ end
 
 # manually generate a broken function, which will break codegen
 # and make sure Julia doesn't crash
-@eval @noinline @Base.constprop :none f_broken_code() = 0
+@eval @noinline Base.@constprop :none f_broken_code() = 0
 let m = which(f_broken_code, ())
    let src = Base.uncompressed_ast(m)
        src.code = Any[

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1250,7 +1250,7 @@ every object as one so they can be easily counted. Otherwise, report the
 actual size.
 """
 function take_heap_snapshot(io::IOStream, all_one::Bool=false)
-    @Base._lock_ios(io, ccall(:jl_gc_take_heap_snapshot, Cvoid, (Ptr{Cvoid}, Cchar), io.handle, Cchar(all_one)))
+    Base.@_lock_ios(io, ccall(:jl_gc_take_heap_snapshot, Cvoid, (Ptr{Cvoid}, Cchar), io.handle, Cchar(all_one)))
 end
 function take_heap_snapshot(filepath::String, all_one::Bool=false)
     open(filepath, "w") do io

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -136,7 +136,7 @@ defaultport = rand(2000:4000)
                 write(sock, "Hello World\n")
 
                 # test "locked" println to a socket
-                @Experimental.sync begin
+                Experimental.@sync begin
                     for i in 1:100
                         @async println(sock, "a", 1)
                     end
@@ -307,7 +307,7 @@ end
         bind(a, ip"127.0.0.1", randport)
         bind(b, ip"127.0.0.1", randport + 1)
 
-        @Experimental.sync begin
+        Experimental.@sync begin
             let i = 0
                 for _ = 1:30
                     @async let msg = String(recv(a))
@@ -387,7 +387,7 @@ end
         # connect to it
         client_sock = connect(addr, port)
         test_done = false
-        @Experimental.sync begin
+        Experimental.@sync begin
             @async begin
                 Base.wait_readnb(client_sock, 1)
                 test_done || error("Client disconnected prematurely.")

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1921,7 +1921,7 @@ end
 end
 
 @testset "ccall_effects" begin
-    ctest_total(x) = @Base.assume_effects :total @ccall libccalltest.ctest(x::Complex{Int})::Complex{Int}
+    ctest_total(x) = Base.@assume_effects :total @ccall libccalltest.ctest(x::Complex{Int})::Complex{Int}
     ctest_total_const() = Val{ctest_total(1 + 2im)}()
     Core.Compiler.return_type(ctest_total_const, Tuple{}) == Val{2 + 0im}
 end

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -310,7 +310,7 @@ end
 end
 
 @testset "timedwait on multiple channels" begin
-    @Experimental.sync begin
+    Experimental.@sync begin
         rr1 = Channel(1)
         rr2 = Channel(1)
         rr3 = Channel(1)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3282,8 +3282,8 @@ f_with_Type_arg(::Type{T}) where {T} = T
     (N >= 0) || throw(ArgumentError(string("tuple length should be ≥0, got ", N)))
     if @generated
         quote
-            @Base.nexprs $N i -> t_i = f(i)
-            @Base.ncall $N tuple t
+            Base.@nexprs $N i -> t_i = f(i)
+            Base.@ncall $N tuple t
         end
     else
         Tuple(f(i) for i = 1:N)
@@ -4468,7 +4468,7 @@ end
 end
 
 # Test that max_methods works as expected
-@Base.Experimental.max_methods 1 function f_max_methods end
+Base.Experimental.@max_methods 1 function f_max_methods end
 f_max_methods(x::Int) = 1
 f_max_methods(x::Float64) = 2
 g_max_methods(x) = f_max_methods(x)
@@ -4502,7 +4502,7 @@ end
 struct Issue45780
     oc::Core.OpaqueClosure{Tuple{}}
 end
-f45780() = Val{Issue45780(@Base.Experimental.opaque ()->1).oc()}()
+f45780() = Val{Issue45780(Base.Experimental.@opaque ()->1).oc()}()
 @test (@inferred f45780()) == Val{1}()
 
 # issue #45600
@@ -4582,7 +4582,7 @@ end
 @test Const((1,2)) ⊑ PartialStruct(Tuple{Vararg{Int}}, [Const(1), Vararg{Int}])
 
 # Test that semi-concrete interpretation doesn't break on functions with while loops in them.
-@Base.assume_effects :consistent :effect_free :terminates_globally function pure_annotated_loop(x::Int, y::Int)
+Base.@assume_effects :consistent :effect_free :terminates_globally function pure_annotated_loop(x::Int, y::Int)
     for i = 1:2
         x += y
     end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -364,7 +364,7 @@ struct RealConstrained{T <: Real}; end
 struct Big
     x::NTuple{1024, Int}
 end
-@Base.pure Big() = Big(ntuple(identity, 1024))
+Base.@pure Big() = Big(ntuple(identity, 1024))
 function pure_elim_full()
     Big()
     nothing

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -181,7 +181,7 @@ end
     @test test4538_2(x=2) == 2
 
     # that, but in a module
-    @Foo4538.TEST()
+    Foo4538.@TEST()
     @test test4538_foo_2() == 1
     @test test4538_foo_2(x=2) == 2
 

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -144,8 +144,8 @@ baremodule B
     x = 1
     module M; x = 2; end
     import Base
-    @Base.eval x = 3
-    @Base.eval M x = 4
+    Base.@eval x = 3
+    Base.@eval M x = 4
 end
 @test B.x == 3
 @test B.M.x == 4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -243,7 +243,7 @@ cd(@__DIR__) do
                 end
             end
         end
-        o_ts_duration = @elapsed @Experimental.sync begin
+        o_ts_duration = @elapsed Experimental.@sync begin
             for p in workers()
                 @async begin
                     push!(all_tasks, current_task())

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -154,7 +154,7 @@ end
 
 # issue #34769
 function idle_callback(handle)
-    idle = @Base.handle_as handle UvTestIdle
+    idle = Base.@handle_as handle UvTestIdle
     if idle.active
         idle.count += 1
         if idle.count == 1


### PR DESCRIPTION
This syntax makes it hard to grep for a certain macro use.

cc @Keno since git blame points most of these to you :P.