### PR TITLE
Implement keys and pairs for Enumerate

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,10 +39,13 @@ Standard library changes
 
 #### Package Manager
 
-- "Package Extensions": support for loading a piece of code based on other
+* "Package Extensions": support for loading a piece of code based on other
   packages being loaded in the Julia session.
   This has similar applications as the Requires.jl package but also
   supports precompilation and setting compatibility.
+* Iterators returned by `enumerate` now implement the `keys` and `pairs`
+  functions. ([#48318])
+
 #### LinearAlgebra
 
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -225,6 +225,13 @@ end
     (i, n[1]), (i-1, ri, n[2])
 end
 
+keys(e::Enumerate) = OneTo(length(e.itr))
+
+# This will work even when keys doesn't (due to length being undefined)
+pairs(e::Enumerate) = map(e) do (i, el)
+    Pair(i, el)
+end
+
 """
     pairs(IndexLinear(), A)
     pairs(IndexCartesian(), A)

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -80,12 +80,25 @@ let b = IOBuffer("foo\n")
     @test collect(Base.EachLine(b, keep=true, ondone=()->0)) == ["foo\n"]
 end
 
-# enumerate (issue #6284)
-let b = IOBuffer("1\n2\n3\n"), a = []
-    for (i,x) in enumerate(eachline(b))
-        push!(a, (i,x))
+@testset "Iterators.enumerate" begin
+    # issue #6284
+    let b = IOBuffer("1\n2\n3\n"), a = []
+        for (i,x) in enumerate(eachline(b))
+            push!(a, (i,x))
+        end
+        @test a == [(1,"1"),(2,"2"),(3,"3")]
     end
-    @test a == [(1,"1"),(2,"2"),(3,"3")]
+
+    # keys and pairs
+    let it = enumerate(zip(1:2, 3:4))
+        @test collect(keys(it)) == [1, 2]
+        @test collect(pairs(it)) == [1=>(1,3), 2=>(2,4)]
+    end
+
+    # pairs when length (and hence keys) is undefined
+    let b = IOBuffer("1\n2\n3\n"), it=enumerate(eachline(b))
+        @test collect(pairs(it)) == [1=>"1", 2=>"2", 3=>"3"]
+    end
 end
 
 # zip eachline (issue #7369)


### PR DESCRIPTION
This implements `keys` and `pairs` for iterators returned by `enumerate`.

This addresses https://github.com/JuliaLang/julia/issues/47124, enabling e.g.

```julia
julia> findmin(enumerate(Iterators.filter(!=(1), [3,2,1])))
(2, 2)
```

The definition of `pairs` (in addition to `keys`) is required for iterators that have no length defined, as in the above example.