### PR TITLE
[Experiment]: set `max_methods = 1`

### DIFF
--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -153,7 +153,7 @@ struct InferenceParams
 end
 function InferenceParams(
     params::InferenceParams = InferenceParams( # default constructor
-        #=max_methods::Int=# 3,
+        #=max_methods::Int=# 1,
         #=max_union_splitting::Int=# 4,
         #=max_apply_union_enum::Int=# 8,
         #=max_tuple_splat::Int=# 32,


### PR DESCRIPTION
This is just to see the effect of this change on Base tests, PkgEval, benchmarks etc.

Advantages of lowering this:

- Lower inference time
- Less invalidations

Disadvantages:

- Less precise inference results in presence of non-concrete types