### PR TITLE
Allow effect inference of `eltype(::Tuple)`

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -234,6 +234,21 @@ function _compute_eltype(@nospecialize t)
     end
 end
 
+# We'd like to be able to infer eltype(::Tuple), which needs to be able to
+# look at these four methods:
+#
+# julia> methods(Base.eltype, Tuple{Type{<:Tuple}})
+# 4 methods for generic function "eltype" from Base:
+# [1] eltype(::Type{Union{}})
+#  @ abstractarray.jl:234
+# [2] eltype(::Type{Tuple{}})
+#  @ tuple.jl:199
+# [3] eltype(t::Type{<:Tuple{Vararg{E}}}) where E
+#  @ tuple.jl:200
+# [4] eltype(t::Type{<:Tuple})
+#  @ tuple.jl:209
+typeof(function eltype end).name.max_methods = UInt8(4)
+
 # version of tail that doesn't throw on empty tuples (used in array indexing)
 safe_tail(t::Tuple) = tail(t)
 safe_tail(t::Tuple{}) = ()

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -782,3 +782,4 @@ namedtup = (;a=1, b=2, c=3)
 
 # Make sure that tuple iteration is foldable
 @test Core.Compiler.is_foldable(Base.infer_effects(iterate, Tuple{NTuple{4, Float64}, Int}))
+@test Core.Compiler.is_foldable(Base.infer_effects(eltype, Tuple{Tuple}))


### PR DESCRIPTION
By bumping max_methods for `eltype` slightly to cover all four Tuple methods.