### PR TITLE
irinterp: Allow for non-Const first argument

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -843,8 +843,8 @@ function concrete_eval_eligible(interp::AbstractInterpreter,
         return nothing
     end
     isoverlayed(method_table(interp)) && !is_nonoverlayed(result.effects) && return nothing
-    if f !== nothing && result.edge !== nothing && is_foldable(result.effects)
-        if is_all_const_arg(arginfo, #=start=#2)
+    if result.edge !== nothing && is_foldable(result.effects)
+        if f !== nothing && is_all_const_arg(arginfo, #=start=#2)
             return true
         else
             return false


### PR DESCRIPTION
The first argument isn't special here in any way. The original code here just wanted to avoid calling is_all_const_arg with the first argument included, because that condition was already computed when determining `f`. This code pre-dated semi-concrete eval and is now in the wrong place.