### PR TITLE
add a type assert to `read` on a `Cmd`

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -447,7 +447,7 @@ function read(cmd::AbstractCmd)
     procs = open(cmd, "r", devnull)
     bytes = read(procs.out)
     success(procs) || pipeline_error(procs)
-    return bytes
+    return bytes::Vector{UInt8}
 end
 
 """


### PR DESCRIPTION
```julia
julia> @code_warntype read(`foo`)
MethodInstance for read(::Cmd)
  from read(cmd::Base.AbstractCmd) @ Base process.jl:446
Arguments
  #self#::Core.Const(read)
  cmd::Cmd
Locals
  bytes::Any
  procs::Base.Process
Body::Any
1 ─      (procs = Base.open(cmd, "r", Base.devnull))
│   %2 = Base.getproperty(procs, :out)::IO
│        (bytes = Base.read(%2))
│   %4 = Base.success(procs)::Bool
└──      goto #3 if not %4
2 ─      goto #4
3 ─      Base.pipeline_error(procs)
4 ┄      return bytes
```