### PR TITLE
irinterp: Remove redundant `is_inlineable_constant` check

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -156,9 +156,7 @@ function concrete_eval_invoke(interp::AbstractInterpreter,
         catch
             return Pair{Any, Bool}(Union{}, false)
         end
-        if is_inlineable_constant(value)
-            return Pair{Any, Bool}(Const(value), true)
-        end
+        return Pair{Any, Bool}(Const(value), true)
     else
         ir′ = codeinst_to_ir(interp, code)
         if ir′ !== nothing

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1896,3 +1896,17 @@ let src = code_typed1(make_issue47349(Val{4}()), (Any,))
         make_issue47349(Val(4))((x,nothing,Int))
     end |> only === Type{Int}
 end
+
+# Test that irinterp can make use of constant results even if they're big
+# Check that pure functions with non-inlineable results still get deleted
+struct BigSemi
+    x::NTuple{1024, Int}
+end
+@Base.assume_effects :total @noinline make_big_tuple(x::Int) = ntuple(x->x+1, 1024)::NTuple{1024, Int}
+BigSemi(y::Int, x::Int) = BigSemi(make_big_tuple(x))
+function elim_full_ir(y)
+    bs = BigSemi(y, 10)
+    return Val{bs.x[1]}()
+end
+
+@test fully_eliminated(elim_full_ir, Tuple{Int})


### PR DESCRIPTION
The way that `is_inlineable_constant` is supposed to work is that during type inference, we allow a large `Const` type to persist in the inference domain and then at inlining time, we decide whether or not to remove the call and replace it by the constant (thus having to serialize the constant) or just leave the call as is (with the types eventually being widened). `irinterp` was being a bit overeager here, not even permitting large constants into the inference domain, which was hurting precision. We alraedy have an appropriate `is_inlineable_constant` call guarding the inlining of constants into the IR, so the move the one that checks it when returning from concrete eval.