### PR TITLE
Take "needs" labels seriously, block merge if labels are assigned

### DIFF
--- a/.github/workflows/LabelCheck.yml
+++ b/.github/workflows/LabelCheck.yml
@@ -1,0 +1,15 @@
+name: Check Labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: yogevbd/enforce-label-action@2.2.2
+      with:
+        # REQUIRED_LABELS_ANY: "bug,enhancement,skip-changelog"
+        # REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['bug','enhancement','skip-changelog']"
+        BANNED_LABELS: "needs docs,needs compat annotation,needs more info,needs nanosoldier run,needs news,needs pkgeval,needs tests,DO NOT MERGE"
+        BANNED_LABELS_DESCRIPTION: "PRs with the ${bannedLabel.name} label should not be merged"

--- a/.github/workflows/LabelCheck.yml
+++ b/.github/workflows/LabelCheck.yml
@@ -1,11 +1,15 @@
-name: Check Labels
+name: LabelCheck
 
+permissions:
+  contents: read
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, edited, synchronize]
+    types: [labeled, unlabeled, opened, reopened, edited]
 jobs:
   enforce-label:
+    name: Check for blocking labels
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
     - uses: yogevbd/enforce-label-action@2.2.2
       with:

--- a/.github/workflows/LabelCheck.yml
+++ b/.github/workflows/LabelCheck.yml
@@ -4,7 +4,7 @@ permissions:
   contents: read
 on:
   pull_request:
-    types: [labeled, unlabeled, opened, reopened, edited]
+    types: [labeled, unlabeled, opened, reopened, edited, synchronize]
 jobs:
   enforce-label:
     name: Check for blocking labels

--- a/.github/workflows/LabelCheck.yml
+++ b/.github/workflows/LabelCheck.yml
@@ -1,4 +1,4 @@
-name: LabelCheck
+name: Labels
 
 permissions:
   contents: read
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [labeled, unlabeled, opened, reopened, edited, synchronize]
 jobs:
-  enforce-label:
+  enforce-labels:
     name: Check for blocking labels
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -16,4 +16,4 @@ jobs:
         # REQUIRED_LABELS_ANY: "bug,enhancement,skip-changelog"
         # REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['bug','enhancement','skip-changelog']"
         BANNED_LABELS: "needs docs,needs compat annotation,needs more info,needs nanosoldier run,needs news,needs pkgeval,needs tests,DO NOT MERGE"
-        BANNED_LABELS_DESCRIPTION: "PRs with the ${bannedLabel.name} label should not be merged"
+        BANNED_LABELS_DESCRIPTION: "A PR should not be merged with `needs *` or `DO NOT MERGE` labels"


### PR DESCRIPTION
This is a proposal to ensure that `needs docs` or `needs tests` etc. labels are effective before PRs with them are merged and go out of sight into the merged PRs list.

Also does the same for the `DO NOT MERGE` label.

The idea being that this check would be a "required" check.