### PR TITLE
isassigned: @_propagate_inbounds_meta instead of @inline

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -214,7 +214,7 @@ elsize(@nospecialize _::Type{A}) where {T,A<:Array{T}} = aligned_sizeof(T)
 sizeof(a::Array) = Core.sizeof(a)
 
 function isassigned(a::Array, i::Int...)
-    @inline
+    @_propagate_inbounds_meta
     @boundscheck checkbounds(Bool, a, i...) || return false
     ii = (_sub2ind(size(a), i...) % UInt) - 1
     ccall(:jl_array_isassigned, Cint, (Any, UInt), a, ii) == 1


### PR DESCRIPTION
Tiny follow-up from discussion on #48003

There was talk about trying to test this as well, but I couldn't come up with a case that caused `@_propagate_inbounds_meta` and `@inline` to generate different inlined code for `isassigned`. Both propagated inbounds. But maybe there are cases where it does matter. If nothing else I guess this is for correctness.