### PR TITLE
Silence missing gfortran errors in `Make.inc`

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1125,7 +1125,7 @@ USE_BINARYBUILDER ?= 0
 endif
 
 # Auto-detect triplet once, create different versions that we use as defaults below for each BB install target
-FC_VERSION := $(shell $(FC) -dM -E - < /dev/null | grep __GNUC__ | cut -d' ' -f3)
+FC_VERSION := $(shell $(FC) -dM -E - < /dev/null 2>/dev/null | grep __GNUC__ | cut -d' ' -f3)
 ifeq ($(USEGCC)$(FC_VERSION),1)
 FC_OR_CC_VERSION := $(shell $(CC) -dumpfullversion -dumpversion 2>/dev/null | cut -d'.' -f1)
 # n.b. clang's __GNUC__ macro pretends to be gcc 4.2.1, so leave it as the empty string here if the compiler is not certain to be GCC


### PR DESCRIPTION
When we attempt to invoke `gfortran` to determine the local `libgfortran` ABI version that we should attempt to mimic, if `gfortran` is not installed we get a harmless error printed out to `stderr`:

```
/bin/sh: line 1: gfortran: command not found
```

This should silence these errors, as they're not useful to us.