### PR TITLE
RFC: support iteration for `CartesianIndex`

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -724,7 +724,7 @@ julia> Broadcast.broadcastable("hello") # Strings break convention of matching i
 Base.RefValue{String}("hello")
 ```
 """
-broadcastable(x::Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,AbstractPattern,Pair,IO}) = Ref(x)
+broadcastable(x::Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,AbstractPattern,Pair,IO,CartesianIndex}) = Ref(x)
 broadcastable(::Type{T}) where {T} = Ref{Type{T}}(T)
 broadcastable(x::Union{AbstractArray,Number,AbstractChar,Ref,Tuple,Broadcasted}) = x
 # Default to collecting iterables — which will error for non-iterables

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -153,10 +153,17 @@ module IteratorsMD
 
     Base._ind2sub(t::Tuple, ind::CartesianIndex) = Tuple(ind)
 
-    # Iteration over the elements of CartesianIndex cannot be supported until its length can be inferred,
-    # see #23719
-    Base.iterate(::CartesianIndex) =
-        error("iteration is deliberately unsupported for CartesianIndex. Use `I` rather than `I...`, or use `Tuple(I)...`")
+    Base.iterate((; I)::CartesianIndex) = iterate(I)
+    Base.iterate((; I)::CartesianIndex, st::Int) = iterate(I, st)
+    # probably not needed, but might make inference's job a little easier
+    Base.indexed_iterate((; I)::CartesianIndex, i::Int) = Base.indexed_iterate(I, i)
+    Base.indexed_iterate((; I)::CartesianIndex, i::Int, st::Int) = Base.indexed_iterate(I, i, st)
+
+    Base.rest((; I)::CartesianIndex, st...) = CartesianIndex(Base.rest(I, st...))
+    function Base.split_rest((; I)::CartesianIndex, n::Int, st...)
+        front, tail = Base.split_rest(I, n, st...)
+        return CartesianIndex(front), tail
+    end
 
     # Iteration
     const OrdinalRangeInt = OrdinalRange{Int, Int}

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2016,7 +2016,7 @@ end
 
     @test 2*CartesianIndex{3}(1,2,3) == CartesianIndex{3}(2,4,6)
     @test CartesianIndex{3}(1,2,3)*2 == CartesianIndex{3}(2,4,6)
-    @test_throws ErrorException iterate(CartesianIndex{3}(1,2,3))
+    @test iterate(CartesianIndex{3}(1,2,3))[1] == 1
     @test CartesianIndices(CartesianIndex{3}(1,2,3)) == CartesianIndices((1, 2, 3))
     @test Tuple{}(CartesianIndices{0,Tuple{}}(())) == ()
 

--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -536,3 +536,33 @@ end
     inds2 = (1, CI(1, 2), 1, CI(1, 2), 1, CI(1, 2), 1)
     @test (@inferred CI(inds2)) == CI(1, 1, 2, 1, 1, 2, 1, 1, 2, 1)
 end
+
+@testset "CartesianIndex iteration and destructuring" begin
+    I = CartesianIndex((1, 2, 3, 4))
+
+    a, b, c, d = I
+    @test a === 1
+    @test b === 2
+    @test c === 3
+    @test d === 4
+
+    a, b... = I
+    @test a === 1
+    @test b === CartesianIndex((2, 3, 4))
+
+    a..., b = I
+    @test a === CartesianIndex((1, 2, 3))
+    @test b === 4
+
+    a, b..., c = I
+    @test a === 1
+    @test b === CartesianIndex((2, 3))
+    @test c === 4
+
+    a..., = I
+    @test a === I
+
+    a, b... = CartesianIndex((1,))
+    @test a === 1
+    @test b === CartesianIndex(())
+end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -720,9 +720,9 @@ end
 # Issue #42264 - crash on certain union splits
 let f(x) = (x...,)
     # Test splatting with a Union of non-{Tuple, SimpleVector} types that require creating new `iterate` calls
-    # in inlining. For this particular case, we're relying on `iterate(::CaretesianIndex)` throwing an error, such
+    # in inlining. For this particular case, we're relying on `iterate(::typeof(sin))` throwing an error, such
     # the the original apply call is not union-split, but the inserted `iterate` call is.
-    @test code_typed(f, Tuple{Union{Int64, CartesianIndex{1}, CartesianIndex{3}}})[1][2] == Tuple{Int64}
+    @test Base.return_types(f, Tuple{Union{Int64, typeof(sin), typeof(cos)}}) |> only == Tuple{Int64}
 end
 
 # https://github.com/JuliaLang/julia/issues/42754


### PR DESCRIPTION
I'm almost certain this came up before, but wasn't able to find the
discussion. I think now that the multidimensional indexing API has
matured a bit, the potential for confusion when allowing iteration is
excedingly low. With this change, it's possible to destructure
`CartesianIndex` objects without having to convert them to a tuple,
which I feel currently makes writing such code unnecessarily annoying.

This also makes `CartesianIndex` broadcast like a scalar which I felt
was consistent with the behavior for objects like `Pair`, but I am open
to other suggestions.
