### PR TITLE
Add ability to set keepalive on TCP sockets via keyword arg to connect

### DIFF
--- a/stdlib/Sockets/src/Sockets.jl
+++ b/stdlib/Sockets/src/Sockets.jl
@@ -511,7 +511,7 @@ end
 
 connect!(sock::TCPSocket, addr::InetAddr) = connect!(sock, addr.host, addr.port)
 
-function wait_connected(x::LibuvStream)
+function wait_connected(x::LibuvStream, keepalive_delay::Int=0)
     iolock_begin()
     check_open(x)
     isopen(x) || x.readerror === nothing || throw(x.readerror)
@@ -526,6 +526,12 @@ function wait_connected(x::LibuvStream)
             lock(x.cond)
         end
         isopen(x) || x.readerror === nothing || throw(x.readerror)
+        if keepalive_delay > 0
+            err = ccall(:uv_tcp_keepalive, Cint,
+                (Ptr{Nothing}, Cint, Cuint),
+                x.handle, 1, 1)
+            Base.uv_error("failed to set keepalive on tcp socket", err)
+        end
     finally
         unlock(x.cond)
         unpreserve_handle(x)
@@ -541,13 +547,13 @@ end
 
 Connect to the host `host` on port `port`.
 """
-connect(sock::TCPSocket, port::Integer) = connect(sock, localhost, port)
-connect(port::Integer) = connect(localhost, port)
+connect(sock::TCPSocket, port::Integer; kw...) = connect(sock, localhost, port; kw...)
+connect(port::Integer; kw...) = connect(localhost, port; kw...)
 
 # Valid connect signatures for TCP
-connect(host::AbstractString, port::Integer) = connect(TCPSocket(), host, port)
-connect(addr::IPAddr, port::Integer) = connect(TCPSocket(), addr, port)
-connect(addr::InetAddr) = connect(TCPSocket(), addr)
+connect(host::AbstractString, port::Integer; kw...) = connect(TCPSocket(), host, port; kw...)
+connect(addr::IPAddr, port::Integer; kw...) = connect(TCPSocket(), addr, port; kw...)
+connect(addr::InetAddr; kw...) = connect(TCPSocket(), addr; kw...)
 
 function connect!(sock::TCPSocket, host::AbstractString, port::Integer)
     if sock.status != StatusInit
@@ -558,9 +564,9 @@ function connect!(sock::TCPSocket, host::AbstractString, port::Integer)
     return sock
 end
 
-function connect(sock::LibuvStream, args...)
+function connect(sock::LibuvStream, args...; keepalive_delay::Int=0)
     connect!(sock, args...)
-    wait_connected(sock)
+    wait_connected(sock, keepalive_delay)
     return sock
 end
 

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -588,6 +588,16 @@ end
         end
         close(srv)
     end
+    # test passing keepalive_delay keyword argument
+    let addr = Sockets.InetAddr(ip"127.0.0.1", 4445)
+        srv = listen(addr)
+        let s = Sockets.connect(addr; keepalive_delay=1)
+            @test iswritable(s)
+            closewrite(s)
+            @test !iswritable(s)
+            close(s)
+        end
+    end
 end
 
 @testset "TCPSocket RawFD constructor" begin


### PR DESCRIPTION
This functionality has [lived in HTTP.jl](https://github.com/JuliaWeb/HTTP.jl/blob/040df996e608572fee760fc9816376a2d8fe3299/src/ConnectionPool.jl#L392) for far too long, and I always kept forgetting to upstream it. Made worse by the fact that we recently realized we weren't even holding the global IO lock when making the `ccall` (though to be fair, this ccall predates the global IO lock even).

I added this as a keyword arg to `connect` because it would be ideal to avoid needing to get the global IO lock _yet again_ after the socket is connected just to set the keepalive.

cc: @vtjnash 