### PR TITLE
Reduce the extra overhead caused by greedy `equal_unions`

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1258,19 +1258,6 @@ static int subtype_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_stenv_t *e, in
     return ans;
 }
 
-static int equal_unions(jl_uniontype_t *x, jl_uniontype_t *y, jl_stenv_t *e)
-{
-    jl_value_t *saved=NULL; jl_savedenv_t se;
-    JL_GC_PUSH1(&saved);
-    save_env(e, &saved, &se);
-    int eq = forall_exists_equal(x->a, y->a, e) && forall_exists_equal(x->b, y->b, e);
-    if (!eq)
-        restore_env(e, saved, &se);
-    free_env(&se);
-    JL_GC_POP();
-    return eq;
-}
-
 // `param` means we are currently looking at a parameter of a type constructor
 // (as opposed to being outside any type constructor, or comparing variable bounds).
 // this is used to record the positions where type variables occur for the
@@ -1452,17 +1439,12 @@ static int forall_exists_equal(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)
         (is_definite_length_tuple_type(x) && is_indefinite_length_tuple_type(y)))
         return 0;
 
-    if (jl_is_uniontype(x) && jl_is_uniontype(y)) {
-        // For 2 unions, try a more efficient greedy algorithm that compares the unions
-        // componentwise. If it returns `false`, we forget it and proceed with the usual
-        // algorithm. If it returns `true` we try returning `true`, but need to come back
-        // here to try the usual algorithm if subtyping later fails.
-        jl_unionstate_t *state = &e->Runions;
-        jl_saved_unionstate_t oldRunions; push_unionstate(&oldRunions, state);
+    if ((jl_is_uniontype(x) && jl_is_uniontype(y))) {
+        // For 2 unions, first try a more efficient greedy algorithm that compares the unions
+        // componentwise. If failed, `exists_subtype` would memorize that this branch should be skipped.
         if (pick_union_decision(e, 1) == 0) {
-            if (equal_unions((jl_uniontype_t*)x, (jl_uniontype_t*)y, e))
-                return 1;
-            pop_unionstate(state, &oldRunions);
+            return forall_exists_equal(((jl_uniontype_t *)x)->a, ((jl_uniontype_t *)y)->a, e) &&
+                   forall_exists_equal(((jl_uniontype_t *)x)->b, ((jl_uniontype_t *)y)->b, e);
         }
     }
 


### PR DESCRIPTION
It turns out that #48221 increases the overhead of subtyping if `equal_unions` return `false`.
The failing `equal_unions` would be re-subtyped during the next `exists_subtype`.
This PR tries to avoid that by:
1. First exhausting `equal_unions` branch and setting `state[i] = 1` if it failed.
2. Skipping the checked part when we perform the next `equal_unions`.

Some simple benchmark with `subtype` test itself as the reference
```julia
Test  (Worker) | Time (s) | GC (s) | GC % | Alloc (MB) | RSS (MB)
subtype    (1) |    12.97 |   0.49 |  3.8 |    1919.17 |   680.35  # master
subtype    (1) |    12.71 |   0.43 |  3.4 |    1843.41 |   685.72  # with 1
subtype    (1) |    12.19 |   0.47 |  3.8 |    1660.20 |   688.86  # with 1 + 2
```