### PR TITLE
fix `Base.identify_package` docstring typo

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -375,7 +375,7 @@ There `where` argument provides the context from where to search for the
 package: in this case it first checks if the name matches the context itself,
 otherwise it searches all recursive dependencies (from the resolved manifest of
 each environment) until it locates the context `where`, and from there
-identifies the dependency with with the corresponding name.
+identifies the dependency with the corresponding name.
 
 ```julia-repl
 julia> Base.identify_package("Pkg") # Pkg is a dependency of the default environment


### PR DESCRIPTION
I guess the title says it all.