### PR TITLE
Clear warning about redefinition of macro

### DIFF
--- a/src/support/MurmurHash3.c
+++ b/src/support/MurmurHash3.c
@@ -8,11 +8,10 @@
 // non-native version will be less than optimal.
 
 #include "MurmurHash3.h"
+#include "dtypes.h"
 
 //-----------------------------------------------------------------------------
 // Platform-specific functions and macros
-
-#define FORCE_INLINE inline __attribute__((always_inline))
 
 static inline uint32_t rotl32 ( uint32_t x, int8_t r )
 {


### PR DESCRIPTION
`FORCE_INLINE` is also defined in `src/support/dtypes.h`, and both `dtypes.h` and `MurmurHash3.c` are included by `src/support/hashing.c`, causing a clash:

```
In file included from /home/mose/repo/julia/src/support/hashing.c:51:
/home/mose/repo/julia/src/support/MurmurHash3.c:15: warning: "FORCE_INLINE" redefined
   15 | #define FORCE_INLINE inline __attribute__((always_inline))
      |
In file included from /home/mose/repo/julia/src/support/hashing.c:7:
/home/mose/repo/julia/src/support/dtypes.h:120: note: this is the location of the previous definition
  120 | #define FORCE_INLINE static inline __attribute__((always_inline))
      |
```

Ref: https://github.com/JuliaLang/julia/pull/47292/files#r1088465126