### PR TITLE
Prevent update_julia_type from creating a broken cgval_t.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1967,6 +1967,11 @@ static inline jl_cgval_t update_julia_type(jl_codectx_t &ctx, const jl_cgval_t &
     Type *T = julia_type_to_llvm(ctx, typ);
     if (type_is_ghost(T))
         return ghostValue(ctx, typ);
+    else if (v.TIndex && v.V == NULL) {
+        // type mismatch (there weren't any non-ghost values in the union)
+        CreateTrap(ctx.builder);
+        return jl_cgval_t();
+    }
     return jl_cgval_t(v, typ, NULL);
 }
 

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -804,3 +804,20 @@ function f34459(args...)
     return
 end
 @test !occursin("jl_f_tuple", get_llvm(f34459, Tuple{Ptr{Int}, Type{Int}}, true, false, false))
+
+# issue #48394: incorrectly-inferred getproperty shouldn't introduce invalid cgval_t
+#               when dealing with unions of ghost values
+struct X48394
+    x::Nothing
+    y::Bool
+end
+struct Y48394
+    x::Nothing
+    z::Missing
+end
+function F48394(a, b, i)
+    c = i ? a : b
+    c.y
+end
+@test F48394(X48394(nothing,true), Y48394(nothing, missing), true)
+@test occursin("llvm.trap", get_llvm(F48394, Tuple{X48394, Y48394, Bool}))


### PR DESCRIPTION
When then incoming value is a union without any non-ghost component, we cannot update it with a non-ghost type.

Closes https://github.com/JuliaLang/julia/issues/48394 (confirmed that it works with the OrdinaryDiffEx MWE), fix by @vtjnash 