### PR TITLE
update loading test to best-practices

### DIFF
--- a/test/loading.jl
+++ b/test/loading.jl
@@ -673,10 +673,10 @@ end
         cd("foo")
         @test Base.active_project() == old
         """
-        @test success(`$(Base.julia_cmd()) --startup-file=no --project=foo -e $(script)`)
-        withenv("JULIA_PROJECT" => "foo") do
-            @test success(`$(Base.julia_cmd()) --startup-file=no -e $(script)`)
-        end
+        cmd = `$(Base.julia_cmd()) --startup-file=no -e $(script)`
+        cmd = addenv(cmd, "JULIA_PROJECT" => "foo")
+        cmd = pipeline(cmd; stdout, stderr)
+        @test success(cmd)
     end; end
 end
 
@@ -689,15 +689,16 @@ mktempdir() do dir
     vdir = vdir[2:end] # remove @
     vpath = joinpath(dir, "environments", vdir)
     mkpath(vpath)
-    withenv("JULIA_DEPOT_PATH" => dir) do
-        script = "@assert startswith(Base.active_project(), $(repr(vpath)))"
-        @test success(`$(Base.julia_cmd()) --startup-file=no -e $(script)`)
-    end
+    script = "@assert startswith(Base.active_project(), $(repr(vpath)))"
+    cmd = `$(Base.julia_cmd()) --startup-file=no -e $(script)`
+    cmd = addenv(cmd, "JULIA_DEPOT_PATH" => dir)
+    cmd = pipeline(cmd; stdout, stderr)
+    @test success(cmd)
 end
 
 @testset "expansion of JULIA_LOAD_PATH" begin
     s = Sys.iswindows() ? ';' : ':'
-    tmp = "/foo/bar"
+    tmp = "/this/does/not/exist"
     cases = Dict{Any,Vector{String}}(
         nothing => Base.DEFAULT_LOAD_PATH,
         "" => [],
@@ -706,16 +707,17 @@ end
         "$s$tmp" => [Base.DEFAULT_LOAD_PATH; tmp],
         )
     for (env, result) in pairs(cases)
-        withenv("JULIA_LOAD_PATH" => env) do
-            script = "LOAD_PATH == $(repr(result)) || error()"
-            @test success(`$(Base.julia_cmd()) --startup-file=no -e $script`)
-        end
+        script = "LOAD_PATH == $(repr(result)) || error()"
+        cmd = `$(Base.julia_cmd()) --startup-file=no -e $script`
+        cmd = addenv(cmd, "JULIA_LOAD_PATH" => env)
+        cmd = pipeline(cmd; stdout, stderr)
+        @test success(cmd)
     end
 end
 
 @testset "expansion of JULIA_DEPOT_PATH" begin
     s = Sys.iswindows() ? ';' : ':'
-    tmp = "/foo/bar"
+    tmp = "/this/does/not/exist"
     DEFAULT = Base.append_default_depot_path!(String[])
     cases = Dict{Any,Vector{String}}(
         nothing => DEFAULT,
@@ -725,10 +727,11 @@ end
         "$s$tmp" => [DEFAULT; tmp],
         )
     for (env, result) in pairs(cases)
-        withenv("JULIA_DEPOT_PATH" => env) do
-            script = "DEPOT_PATH == $(repr(result)) || error()"
-            @test success(`$(Base.julia_cmd()) --startup-file=no -e $script`)
-        end
+        script = "DEPOT_PATH == $(repr(result)) || error()"
+        cmd = `$(Base.julia_cmd()) --startup-file=no -e $script`
+        cmd = addenv(cmd, "JULIA_DEPOT_PATH" => env)
+        cmd = pipeline(cmd; stdout, stderr)
+        @test success(cmd)
     end
 end
 
@@ -996,15 +999,14 @@ end
 end
 
 @testset "Extensions" begin
-    old_depot_path = copy(DEPOT_PATH)
+    depot_path = mktempdir()
     try
-        tmp = mktempdir()
-        push!(empty!(DEPOT_PATH), joinpath(tmp, "depot"))
         proj = joinpath(@__DIR__, "project", "Extensions", "HasDepWithExtensions.jl")
 
         function gen_extension_cmd(compile)
             ```$(Base.julia_cmd()) $compile --startup-file=no -e '
                 begin
+                    push!(empty!(DEPOT_PATH), '$(repr(depot_path))')
                     using HasExtensions
                     # Base.get_extension(HasExtensions, :Extension) === nothing || error("unexpectedly got an extension")
                     HasExtensions.ext_loaded && error("ext_loaded set")
@@ -1020,21 +1022,25 @@ end
             ```
         end
 
-        for compile in (`--compiled-modules=no`, ``, ``) # Once when requiring precomilation, once where it is already precompiled
+        for compile in (`--compiled-modules=no`, ``, ``) # Once when requiring precompilation, once where it is already precompiled
             cmd = gen_extension_cmd(compile)
-            withenv("JULIA_LOAD_PATH" => proj) do
-                @test success(cmd)
-            end
+            cmd = addenv(cmd, "JULIA_LOAD_PATH" => proj)
+            cmd = pipeline(cmd; stdout, stderr)
+            @test success(cmd)
         end
 
         # 48351
         sep = Sys.iswindows() ? ';' : ':'
-        withenv("JULIA_LOAD_PATH" => join([mktempdir(), proj], sep)) do
-            cmd = gen_extension_cmd(``)
-            @test success(cmd)
-        end
+        cmd = gen_extension_cmd(``)
+        cmd = addenv(cmd, "JULIA_LOAD_PATH" => join([mktempdir(), proj], sep))
+        cmd = pipeline(cmd; stdout, stderr)
+        @test success(cmd)
     finally
-        copy!(DEPOT_PATH, old_depot_path)
+        try
+            rm(depot_path, force=true, recursive=true)
+        catch err
+            @show err
+        end
     end
 end
 
@@ -1075,7 +1081,7 @@ end
         end
         """
         cmd = `$julia $(pkgimage(P)) $(opt_level(O)) $(debug_level(D)) $(check_bounds(C)) $(inline(I)) -e $script`
-        @test success(pipeline(cmd; stderr))
+        @test success(pipeline(cmd; stdout, stderr))
     end
 end
 


### PR DESCRIPTION
Many of these test were hiding output or using semi-deprecated functions or failing to cleanup output or setting the wrong variables.