### PR TITLE
avoid generating native code if only output ji file

### DIFF
--- a/src/precompile.c
+++ b/src/precompile.c
@@ -116,8 +116,9 @@ JL_DLLEXPORT void jl_write_compiler_output(void)
     ios_t *s = NULL;
     ios_t *z = NULL;
     int64_t srctextpos = 0 ;
-    jl_create_system_image(&native_code, jl_options.incremental ? worklist : NULL, emit_split,
-                           &s, &z, &udeps, &srctextpos);
+    jl_create_system_image(emit_native ? &native_code : NULL,
+                           jl_options.incremental ? worklist : NULL,
+                           emit_split, &s, &z, &udeps, &srctextpos);
 
     if (!emit_split)
         z = s;


### PR DESCRIPTION
This seems to have been a minor build performance regression introduced in the incremental staticdata work.