### PR TITLE
Revert "faster `hypot(::IEEEFloat...)`"

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -841,17 +841,6 @@ function _hypot(x::NTuple{N,<:Number}) where {N}
     end
 end
 
-function _hypot(x::NTuple{N,T}) where {N,T<:IEEEFloat}
-    infT = convert(T, Inf)
-    x = abs.(x) # doesn't change result but enables computational shortcuts
-    any(==(infT), x) && return infT # return Inf even if an argument is NaN
-    maxabs = reinterpret(T, maximum(z -> reinterpret(Signed, z), x)) # for abs(::IEEEFloat) values, a ::BitInteger cast does not change the result
-    iszero(maxabs) && return maxabs
-    y = abs2.(x ./ maxabs)
-    a2 = @fastmath reduce(+, y) # allow sum to be reordered
-    return sqrt(a2) * maxabs
-end
-
 atan(y::Real, x::Real) = atan(promote(float(y),float(x))...)
 atan(y::T, x::T) where {T<:AbstractFloat} = Base.no_op_err("atan", T)
 


### PR DESCRIPTION
Reverts JuliaLang/julia#48130

Seems to have broken build
```
math.jl
error during bootstrap:
LoadError("sysimg.jl", 3, LoadError("Base.jl", 328, LoadError("math.jl", 844, LoadError("math.jl", 851, UndefVarError(Symbol("@fastmath"))))))
ijl_undefined_var_error at /home/ian/Documents/GitHub/julia/src/rtutils.c:132
```