### PR TITLE
`@inbounds` in `copyto!` for structured broadcasting

### DIFF
--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -156,7 +156,7 @@ function copyto!(dest::Diagonal, bc::Broadcasted{<:StructuredMatrixStyle})
     !isstructurepreserving(bc) && !fzeropreserving(bc) && return copyto!(dest, convert(Broadcasted{Nothing}, bc))
     axs = axes(dest)
     axes(bc) == axs || Broadcast.throwdm(axes(bc), axs)
-    for i in axs[1]
+    @inbounds for i in axs[1]
         dest.diag[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, i))
     end
     return dest

--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -190,7 +190,7 @@ function copyto!(dest::SymTridiagonal, bc::Broadcasted{<:StructuredMatrixStyle})
     end
     for i = 1:size(dest, 1)-1
         v = @inbounds Broadcast._broadcast_getindex(bc, CartesianIndex(i, i+1))
-        v == @inbounds Broadcast._broadcast_getindex(bc, CartesianIndex(i+1, i)) || throw(ArgumentError("broadcasted assignment breaks symmetry between locations ($i, $(i+1)) and ($(i+1), $i)"))
+        v == (@inbounds Broadcast._broadcast_getindex(bc, CartesianIndex(i+1, i))) || throw(ArgumentError("broadcasted assignment breaks symmetry between locations ($i, $(i+1)) and ($(i+1), $i)"))
         dest.ev[i] = v
     end
     return dest

--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -166,15 +166,15 @@ function copyto!(dest::Bidiagonal, bc::Broadcasted{<:StructuredMatrixStyle})
     !isstructurepreserving(bc) && !fzeropreserving(bc) && return copyto!(dest, convert(Broadcasted{Nothing}, bc))
     axs = axes(dest)
     axes(bc) == axs || Broadcast.throwdm(axes(bc), axs)
-    for i in axs[1]
+    @inbounds for i in axs[1]
         dest.dv[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, i))
     end
     if dest.uplo == 'U'
-        for i = 1:size(dest, 1)-1
+        @inbounds for i = 1:size(dest, 1)-1
             dest.ev[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, i+1))
         end
     else
-        for i = 1:size(dest, 1)-1
+        @inbounds for i = 1:size(dest, 1)-1
             dest.ev[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i+1, i))
         end
     end
@@ -185,10 +185,10 @@ function copyto!(dest::SymTridiagonal, bc::Broadcasted{<:StructuredMatrixStyle})
     !isstructurepreserving(bc) && !fzeropreserving(bc) && return copyto!(dest, convert(Broadcasted{Nothing}, bc))
     axs = axes(dest)
     axes(bc) == axs || Broadcast.throwdm(axes(bc), axs)
-    for i in axs[1]
+    @inbounds for i in axs[1]
         dest.dv[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, i))
     end
-    for i = 1:size(dest, 1)-1
+    @inbounds for i = 1:size(dest, 1)-1
         v = Broadcast._broadcast_getindex(bc, CartesianIndex(i, i+1))
         v == Broadcast._broadcast_getindex(bc, CartesianIndex(i+1, i)) || throw(ArgumentError("broadcasted assignment breaks symmetry between locations ($i, $(i+1)) and ($(i+1), $i)"))
         dest.ev[i] = v
@@ -200,10 +200,10 @@ function copyto!(dest::Tridiagonal, bc::Broadcasted{<:StructuredMatrixStyle})
     !isstructurepreserving(bc) && !fzeropreserving(bc) && return copyto!(dest, convert(Broadcasted{Nothing}, bc))
     axs = axes(dest)
     axes(bc) == axs || Broadcast.throwdm(axes(bc), axs)
-    for i in axs[1]
+    @inbounds for i in axs[1]
         dest.d[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, i))
     end
-    for i = 1:size(dest, 1)-1
+    @inbounds for i = 1:size(dest, 1)-1
         dest.du[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, i+1))
         dest.dl[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i+1, i))
     end
@@ -214,7 +214,7 @@ function copyto!(dest::LowerTriangular, bc::Broadcasted{<:StructuredMatrixStyle}
     !isstructurepreserving(bc) && !fzeropreserving(bc) && return copyto!(dest, convert(Broadcasted{Nothing}, bc))
     axs = axes(dest)
     axes(bc) == axs || Broadcast.throwdm(axes(bc), axs)
-    for j in axs[2]
+    @inbounds for j in axs[2]
         for i in j:axs[1][end]
             dest.data[i,j] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, j))
         end
@@ -226,7 +226,7 @@ function copyto!(dest::UpperTriangular, bc::Broadcasted{<:StructuredMatrixStyle}
     !isstructurepreserving(bc) && !fzeropreserving(bc) && return copyto!(dest, convert(Broadcasted{Nothing}, bc))
     axs = axes(dest)
     axes(bc) == axs || Broadcast.throwdm(axes(bc), axs)
-    for j in axs[2]
+    @inbounds for j in axs[2]
         for i in 1:j
             dest.data[i,j] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, j))
         end

--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -156,8 +156,8 @@ function copyto!(dest::Diagonal, bc::Broadcasted{<:StructuredMatrixStyle})
     !isstructurepreserving(bc) && !fzeropreserving(bc) && return copyto!(dest, convert(Broadcasted{Nothing}, bc))
     axs = axes(dest)
     axes(bc) == axs || Broadcast.throwdm(axes(bc), axs)
-    @inbounds for i in axs[1]
-        dest.diag[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, i))
+    for i in axs[1]
+        dest.diag[i] = @inbounds Broadcast._broadcast_getindex(bc, CartesianIndex(i, i))
     end
     return dest
 end
@@ -166,16 +166,16 @@ function copyto!(dest::Bidiagonal, bc::Broadcasted{<:StructuredMatrixStyle})
     !isstructurepreserving(bc) && !fzeropreserving(bc) && return copyto!(dest, convert(Broadcasted{Nothing}, bc))
     axs = axes(dest)
     axes(bc) == axs || Broadcast.throwdm(axes(bc), axs)
-    @inbounds for i in axs[1]
-        dest.dv[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, i))
+    for i in axs[1]
+        dest.dv[i] = @inbounds Broadcast._broadcast_getindex(bc, CartesianIndex(i, i))
     end
     if dest.uplo == 'U'
-        @inbounds for i = 1:size(dest, 1)-1
-            dest.ev[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, i+1))
+        for i = 1:size(dest, 1)-1
+            dest.ev[i] = @inbounds Broadcast._broadcast_getindex(bc, CartesianIndex(i, i+1))
         end
     else
-        @inbounds for i = 1:size(dest, 1)-1
-            dest.ev[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i+1, i))
+        for i = 1:size(dest, 1)-1
+            dest.ev[i] = @inbounds Broadcast._broadcast_getindex(bc, CartesianIndex(i+1, i))
         end
     end
     return dest
@@ -185,12 +185,12 @@ function copyto!(dest::SymTridiagonal, bc::Broadcasted{<:StructuredMatrixStyle})
     !isstructurepreserving(bc) && !fzeropreserving(bc) && return copyto!(dest, convert(Broadcasted{Nothing}, bc))
     axs = axes(dest)
     axes(bc) == axs || Broadcast.throwdm(axes(bc), axs)
-    @inbounds for i in axs[1]
-        dest.dv[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, i))
+    for i in axs[1]
+        dest.dv[i] = @inbounds Broadcast._broadcast_getindex(bc, CartesianIndex(i, i))
     end
-    @inbounds for i = 1:size(dest, 1)-1
-        v = Broadcast._broadcast_getindex(bc, CartesianIndex(i, i+1))
-        v == Broadcast._broadcast_getindex(bc, CartesianIndex(i+1, i)) || throw(ArgumentError("broadcasted assignment breaks symmetry between locations ($i, $(i+1)) and ($(i+1), $i)"))
+    for i = 1:size(dest, 1)-1
+        v = @inbounds Broadcast._broadcast_getindex(bc, CartesianIndex(i, i+1))
+        v == @inbounds Broadcast._broadcast_getindex(bc, CartesianIndex(i+1, i)) || throw(ArgumentError("broadcasted assignment breaks symmetry between locations ($i, $(i+1)) and ($(i+1), $i)"))
         dest.ev[i] = v
     end
     return dest
@@ -200,12 +200,12 @@ function copyto!(dest::Tridiagonal, bc::Broadcasted{<:StructuredMatrixStyle})
     !isstructurepreserving(bc) && !fzeropreserving(bc) && return copyto!(dest, convert(Broadcasted{Nothing}, bc))
     axs = axes(dest)
     axes(bc) == axs || Broadcast.throwdm(axes(bc), axs)
-    @inbounds for i in axs[1]
-        dest.d[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, i))
+    for i in axs[1]
+        dest.d[i] = @inbounds Broadcast._broadcast_getindex(bc, CartesianIndex(i, i))
     end
-    @inbounds for i = 1:size(dest, 1)-1
-        dest.du[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, i+1))
-        dest.dl[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i+1, i))
+    for i = 1:size(dest, 1)-1
+        dest.du[i] = @inbounds Broadcast._broadcast_getindex(bc, CartesianIndex(i, i+1))
+        dest.dl[i] = @inbounds Broadcast._broadcast_getindex(bc, CartesianIndex(i+1, i))
     end
     return dest
 end
@@ -214,9 +214,9 @@ function copyto!(dest::LowerTriangular, bc::Broadcasted{<:StructuredMatrixStyle}
     !isstructurepreserving(bc) && !fzeropreserving(bc) && return copyto!(dest, convert(Broadcasted{Nothing}, bc))
     axs = axes(dest)
     axes(bc) == axs || Broadcast.throwdm(axes(bc), axs)
-    @inbounds for j in axs[2]
+    for j in axs[2]
         for i in j:axs[1][end]
-            dest.data[i,j] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, j))
+            @inbounds dest.data[i,j] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, j))
         end
     end
     return dest
@@ -226,9 +226,9 @@ function copyto!(dest::UpperTriangular, bc::Broadcasted{<:StructuredMatrixStyle}
     !isstructurepreserving(bc) && !fzeropreserving(bc) && return copyto!(dest, convert(Broadcasted{Nothing}, bc))
     axs = axes(dest)
     axes(bc) == axs || Broadcast.throwdm(axes(bc), axs)
-    @inbounds for j in axs[2]
+    for j in axs[2]
         for i in 1:j
-            dest.data[i,j] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, j))
+            @inbounds dest.data[i,j] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, j))
         end
     end
     return dest


### PR DESCRIPTION
This seems to cut down the runtime of `D .* D` by half for `5000x5000` diagonal matrices. Using nightly `v"1.10.0-DEV.450"`
```julia
julia> using LinearAlgebra, BenchmarkTools

julia> D = Diagonal(rand(5000));

julia> @btime $D * $D;
  3.648 μs (2 allocations: 39.11 KiB)

julia> @btime $D .* $D; # ideally, should be identical to matrix multiplication
  8.729 μs (2 allocations: 39.11 KiB)

julia> B = Broadcast.instantiate(Broadcast.Broadcasted(*, (D, D)));

julia> @btime Base.copyto!($(copy(D)), $B); # the main method called
  8.390 μs (0 allocations: 0 bytes)

julia> function copyto2!(dest::Diagonal, bc::Broadcast.Broadcasted{<:LinearAlgebra.StructuredMatrixStyle})
           !LinearAlgebra.isstructurepreserving(bc) && !LinearAlgebra.fzeropreserving(bc) && return copyto!(dest, convert(Broadcast.Broadcasted{Nothing}, bc))
           axs = axes(dest)
           axes(bc) == axs || Broadcast.throwdm(axes(bc), axs)
           @inbounds for i in axs[1]
               dest.diag[i] = Broadcast._broadcast_getindex(bc, CartesianIndex(i, i))
           end
           return dest
       end
copyto2! (generic function with 1 method)

julia> @btime copyto2!($(copy(D)), $B);
  4.207 μs (0 allocations: 0 bytes)
```
Given that the axes are verified to be identical in the previous line, this seems safe.