### PR TITLE
Display zero `Complex{Bool}` as `false*im`

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -214,7 +214,7 @@ function show(io::IO, z::Complex)
     print(io, "im")
 end
 show(io::IO, z::Complex{Bool}) =
-    print(io, z == im ? "im" : "Complex($(z.re),$(z.im))")
+    print(io, z == im ? "im" : iszero(z) ? "$(z.im)*im" : "Complex($(z.re),$(z.im))")
 
 function show_unquoted(io::IO, z::Complex, ::Int, prec::Int)
     if operator_precedence(:+) <= prec

--- a/test/show.jl
+++ b/test/show.jl
@@ -1550,6 +1550,7 @@ end
 @testset "alignment for complex arrays" begin # (#34763)
     @test replstr([ 1e-7 + 2.0e-11im, 2.0e-5 + 4e0im]) == "2-element Vector{ComplexF64}:\n 1.0e-7 + 2.0e-11im\n 2.0e-5 + 4.0im"
     @test replstr([ 1f-7 + 2.0f-11im, 2.0f-5 + 4f0im]) == "2-element Vector{ComplexF32}:\n 1.0f-7 + 2.0f-11im\n 2.0f-5 + 4.0f0im"
+    @test replstr([im false*im; false*im im]) == "2×2 Matrix{Complex{Bool}}:\n       im  false*im\n false*im        im"
 end
 
 @testset "display arrays non-compactly when size(⋅, 2) == 1" begin


### PR DESCRIPTION
Since
```julia
julia> Complex(false,false) === false*im
true
```
we may use the latter form, which is more concise. This makes the display of structured matrices easier to read.
On master:
```julia
julia> Diagonal(fill(im, 2))
2×2 Diagonal{Complex{Bool}, Vector{Complex{Bool}}}:
                   im           ⋅          
          ⋅                              im
```
This PR
```julia
julia> Diagonal(fill(im, 2))
2×2 Diagonal{Complex{Bool}, Vector{Complex{Bool}}}:
       im     ⋅    
    ⋅            im
```