### PR TITLE
Adjoint for diagonal should be lazy

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -675,7 +675,7 @@ end
 conj(D::Diagonal) = Diagonal(conj(D.diag))
 transpose(D::Diagonal{<:Number}) = D
 transpose(D::Diagonal) = Diagonal(transpose.(D.diag))
-adjoint(D::Diagonal{<:Number}) = conj(D)
+adjoint(D::Diagonal{<:Number}) = Diagonal(vec(adjoint(D.diag)))
 adjoint(D::Diagonal) = Diagonal(adjoint.(D.diag))
 permutedims(D::Diagonal) = D
 permutedims(D::Diagonal, perm) = (Base.checkdims_perm(D, D, perm); D)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -676,6 +676,7 @@ conj(D::Diagonal) = Diagonal(conj(D.diag))
 transpose(D::Diagonal{<:Number}) = D
 transpose(D::Diagonal) = Diagonal(transpose.(D.diag))
 adjoint(D::Diagonal{<:Number}) = Diagonal(vec(adjoint(D.diag)))
+adjoint(D::Diagonal{<:Number,<:Base.ReshapedArray{<:Number,1,<:Adjoint}}) = Diagonal(adjoint(parent(D.diag)))
 adjoint(D::Diagonal) = Diagonal(adjoint.(D.diag))
 permutedims(D::Diagonal) = D
 permutedims(D::Diagonal, perm) = (Base.checkdims_perm(D, D, perm); D)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -381,13 +381,17 @@ Random.seed!(1)
 
     @testset "conj and transpose" begin
         @test transpose(D) == D
-        if elty <: BlasComplex
+        if elty <: Real
+            @test transpose(D) === D
+            @test adjoint(D) === D
+        elseif elty <: BlasComplex
             @test Array(conj(D)) ≈ conj(DM)
             @test adjoint(D) == conj(D)
             local D2 = copy(D)
             local D2adj = adjoint(D2)
             D2adj[1,1] = rand(eltype(D2adj))
             @test D2[1,1] == adjoint(D2adj[1,1])
+            @test D2adj' === D2
         end
         # Translates to Ac/t_mul_B, which is specialized after issue 21286
         @test(D' * vv == conj(D) * vv)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -384,6 +384,10 @@ Random.seed!(1)
         if elty <: BlasComplex
             @test Array(conj(D)) ≈ conj(DM)
             @test adjoint(D) == conj(D)
+            local D2 = copy(D)
+            local D2adj = adjoint(D2)
+            D2adj[1,1] = rand(eltype(D2adj))
+            @test D2[1,1] == adjoint(D2adj[1,1])
         end
         # Translates to Ac/t_mul_B, which is specialized after issue 21286
         @test(D' * vv == conj(D) * vv)


### PR DESCRIPTION
Currently, `adjoint` for a `Diagonal` materializes the diagonal vector. This goes against the documentation of `adjoint` as a lazy wrapper.

This PR makes the result share memory with the original `Diagonal`.
```julia
julia> D = Diagonal(fill(2im, 2))
2×2 Diagonal{Complex{Int64}, Vector{Complex{Int64}}}:
 0+2im    ⋅  
   ⋅    0+2im

julia> D'
2×2 Diagonal{Complex{Int64}, Base.ReshapedArray{Complex{Int64}, 1, Adjoint{Complex{Int64}, Vector{Complex{Int64}}}, Tuple{}}}:
 0-2im    ⋅  
   ⋅    0-2im
```

 The implementation isn't perfect, as 
```julia
julia> D = Diagonal(fill(2im, 2))
2×2 Diagonal{Complex{Int64}, Vector{Complex{Int64}}}:
 0+2im    ⋅  
   ⋅    0+2im

julia> D'
2×2 Diagonal{Complex{Int64}, Base.ReshapedArray{Complex{Int64}, 1, Adjoint{Complex{Int64}, Vector{Complex{Int64}}}, Tuple{}}}:
 0-2im    ⋅  
   ⋅    0-2im

julia> (D')'
2×2 Diagonal{Complex{Int64}, Base.ReshapedArray{Complex{Int64}, 1, Adjoint{Complex{Int64}, Base.ReshapedArray{Complex{Int64}, 1, Adjoint{Complex{Int64}, Vector{Complex{Int64}}}, Tuple{}}}, Tuple{}}}:
 0+2im    ⋅  
   ⋅    0+2im
```
and, ideally, `(D')'` would just return `D`. However, at least this makes the `adjoint` operation lazy and allocation-free.