### PR TITLE
UniformScaling: `copyto!` banded matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -381,19 +381,20 @@ function copyto!(A::AbstractMatrix, J::UniformScaling)
     return A
 end
 
-_copyto_diagonal!(A::Diagonal, λ) = A.diag .= λ
-function _copyto_diagonal!(A::Union{Bidiagonal, SymTridiagonal}, λ)
-    A.ev .= 0
-    A.dv .= λ
+function copyto!(A::Diagonal, J::UniformScaling)
+    A.diag .= J.λ
+    return A
 end
-function _copyto_diagonal!(A::Tridiagonal, λ)
+function copyto!(A::Union{Bidiagonal, SymTridiagonal}, J::UniformScaling)
+    A.ev .= 0
+    A.dv .= J.λ
+    return A
+end
+function copyto!(A::Tridiagonal, J::UniformScaling)
     A.dl .= 0
     A.du .= 0
-    A.d .= λ
-end
-function copyto!(A::Union{Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal}, J::UniformScaling)
-    _copyto_diagonal!(A, J.λ)
-    A
+    A.d .= J.λ
+    return A
 end
 
 function cond(J::UniformScaling{T}) where T

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -381,6 +381,21 @@ function copyto!(A::AbstractMatrix, J::UniformScaling)
     return A
 end
 
+_copyto_diagonal!(A::Diagonal, λ) = A.diag .= λ
+function _copyto_diagonal!(A::Union{Bidiagonal, SymTridiagonal}, λ)
+    A.ev .= 0
+    A.dv .= λ
+end
+function _copyto_diagonal!(A::Tridiagonal, λ)
+    A.dl .= 0
+    A.du .= 0
+    A.d .= λ
+end
+function copyto!(A::Union{Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal}, J::UniformScaling)
+    _copyto_diagonal!(A, J.λ)
+    A
+end
+
 function cond(J::UniformScaling{T}) where T
     onereal = inv(one(real(J.λ)))
     return J.λ ≠ zero(T) ? onereal : oftype(onereal, Inf)

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -13,6 +13,12 @@ using .Main.Furlongs
 isdefined(Main, :Quaternions) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "Quaternions.jl"))
 using .Main.Quaternions
 
+isdefined(Main, :InfiniteArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "InfiniteArrays.jl"))
+using .Main.InfiniteArrays
+
+isdefined(Main, :FillArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "FillArrays.jl"))
+using .Main.FillArrays
+
 include("testutils.jl") # test_approx_eq_modphase
 
 n = 10 #Size of test matrix
@@ -792,6 +798,17 @@ end
             @test iszero(BL[i,j])
         end
     end
+end
+
+@testset "copyto! with UniformScaling" begin
+    rd = FillArrays.Fill(1, InfiniteArrays.Infinity())
+    rud = FillArrays.Fill(0, InfiniteArrays.Infinity())
+    B = Bidiagonal(rd, rud, :U)
+    @test copyto!(B, I) === B
+    B = Bidiagonal(fill(2, 4), fill(3, 3), :U)
+    copyto!(B, I)
+    @test all(isone, diag(B))
+    @test all(iszero, diag(B, 1))
 end
 
 end # module TestBidiagonal

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -801,10 +801,14 @@ end
 end
 
 @testset "copyto! with UniformScaling" begin
-    rd = FillArrays.Fill(1, InfiniteArrays.Infinity())
-    rud = FillArrays.Fill(0, InfiniteArrays.Infinity())
-    B = Bidiagonal(rd, rud, :U)
-    @test copyto!(B, I) === B
+    @testset "Fill" begin
+        for len in (4, InfiniteArrays.Infinity())
+            d = FillArrays.Fill(1, len)
+            ud = FillArrays.Fill(0, len-1)
+            B = Bidiagonal(d, ud, :U)
+            @test copyto!(B, I) === B
+        end
+    end
     B = Bidiagonal(fill(2, 4), fill(3, 3), :U)
     copyto!(B, I)
     @test all(isone, diag(B))

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -12,6 +12,12 @@ using .Main.Furlongs
 isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "OffsetArrays.jl"))
 using .Main.OffsetArrays
 
+isdefined(Main, :InfiniteArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "InfiniteArrays.jl"))
+using .Main.InfiniteArrays
+
+isdefined(Main, :FillArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "FillArrays.jl"))
+using .Main.FillArrays
+
 const n=12 # Size of matrix problem to test
 Random.seed!(1)
 
@@ -1131,6 +1137,14 @@ Base.size(::SMatrix1) = (1, 1)
     C = map(a -> SMatrix1(string(a)), A)
     @test C == fill(SMatrix1(string(1)), 1, 1)
     @test C isa Matrix{SMatrix1{String}}
+end
+
+@testset "copyto! with UniformScaling" begin
+    D = Diagonal(FillArrays.Fill(1, InfiniteArrays.Infinity()))
+    @test copyto!(D, I) === D
+    D = Diagonal(fill(2, 2))
+    copyto!(D, I)
+    @test all(isone, diag(D))
 end
 
 end # module TestDiagonal

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -1140,8 +1140,13 @@ Base.size(::SMatrix1) = (1, 1)
 end
 
 @testset "copyto! with UniformScaling" begin
-    D = Diagonal(FillArrays.Fill(1, InfiniteArrays.Infinity()))
-    @test copyto!(D, I) === D
+    @testset "Fill" begin
+        for len in (4, InfiniteArrays.Infinity())
+            d = FillArrays.Fill(1, len)
+            D = Diagonal(d)
+            @test copyto!(D, I) === D
+        end
+    end
     D = Diagonal(fill(2, 2))
     copyto!(D, I)
     @test all(isone, diag(D))

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -9,6 +9,12 @@ const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
 isdefined(Main, :Quaternions) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "Quaternions.jl"))
 using .Main.Quaternions
 
+isdefined(Main, :InfiniteArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "InfiniteArrays.jl"))
+using .Main.InfiniteArrays
+
+isdefined(Main, :FillArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "FillArrays.jl"))
+using .Main.FillArrays
+
 include("testutils.jl") # test_approx_eq_modphase
 
 #Test equivalence of eigenvectors/singular vectors taking into account possible phase (sign) differences
@@ -738,4 +744,28 @@ using .Main.SizedArrays
         @test S !== Tridiagonal(diag(Sdense, 1), diag(Sdense),  diag(Sdense, 1)) !== S
     end
 end
+
+@testset "copyto! with UniformScaling" begin
+    rd = FillArrays.Fill(1, InfiniteArrays.Infinity())
+    rud = FillArrays.Fill(0, InfiniteArrays.Infinity())
+    @testset "Tridiagonal" begin
+        T = Tridiagonal(rud, rd, rud)
+        @test copyto!(T, I) === T
+        T = Tridiagonal(fill(3, 3), fill(2, 4), fill(3, 3))
+        copyto!(T, I)
+        @test all(isone, diag(T))
+        @test all(iszero, diag(T, 1))
+        @test all(iszero, diag(T, -1))
+    end
+    @testset "SymTridiagonal" begin
+        ST = SymTridiagonal(rd, rud)
+        @test copyto!(ST, I) === ST
+        ST = SymTridiagonal(fill(2, 4), fill(3, 3))
+        copyto!(ST, I)
+        @test all(isone, diag(ST))
+        @test all(iszero, diag(ST, 1))
+        @test all(iszero, diag(ST, -1))
+    end
+end
+
 end # module TestTridiagonal

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -746,11 +746,15 @@ using .Main.SizedArrays
 end
 
 @testset "copyto! with UniformScaling" begin
-    rd = FillArrays.Fill(1, InfiniteArrays.Infinity())
-    rud = FillArrays.Fill(0, InfiniteArrays.Infinity())
     @testset "Tridiagonal" begin
-        T = Tridiagonal(rud, rd, rud)
-        @test copyto!(T, I) === T
+        @testset "Fill" begin
+            for len in (4, InfiniteArrays.Infinity())
+                d = FillArrays.Fill(1, len)
+                ud = FillArrays.Fill(0, len-1)
+                T = Tridiagonal(ud, d, ud)
+                @test copyto!(T, I) === T
+            end
+        end
         T = Tridiagonal(fill(3, 3), fill(2, 4), fill(3, 3))
         copyto!(T, I)
         @test all(isone, diag(T))
@@ -758,8 +762,14 @@ end
         @test all(iszero, diag(T, -1))
     end
     @testset "SymTridiagonal" begin
-        ST = SymTridiagonal(rd, rud)
-        @test copyto!(ST, I) === ST
+        @testset "Fill" begin
+            for len in (4, InfiniteArrays.Infinity())
+                d = FillArrays.Fill(1, len)
+                ud = FillArrays.Fill(0, len-1)
+                ST = SymTridiagonal(d, ud)
+                @test copyto!(ST, I) === ST
+            end
+        end
         ST = SymTridiagonal(fill(2, 4), fill(3, 3))
         copyto!(ST, I)
         @test all(isone, diag(ST))

--- a/test/testhelpers/FillArrays.jl
+++ b/test/testhelpers/FillArrays.jl
@@ -1,0 +1,33 @@
+module FillArrays
+
+struct Fill{T, N, S<:NTuple{N,Integer}} <: AbstractArray{T,N}
+    value::T
+    size::S
+end
+
+Fill(v, size::Vararg{Integer}) = Fill(v, size)
+
+Base.size(F::Fill) = F.size
+
+@inline getindex_value(F::Fill) = F.value
+
+@inline function Base.getindex(F::Fill{<:Any,N}, i::Vararg{Int,N}) where {N}
+	@boundscheck checkbounds(F, i...)
+	getindex_value(F)
+end
+
+@inline function Base.setindex!(F::Fill, v, k::Integer)
+    @boundscheck checkbounds(F, k)
+    v == getindex_value(F) || throw(ArgumentError("Cannot setindex! to $v for a Fill with value $(getindex_value(F))."))
+    F
+end
+
+@inline function Base.fill!(F::Fill, v)
+    v == getindex_value(F) || throw(ArgumentError("Cannot fill! with $v a Fill with value $(getindex_value(F))."))
+    F
+end
+
+Base.show(io::IO, F::Fill) = print(io, "Fill($(F.value), $(F.size))")
+Base.show(io::IO, ::MIME"text/plain", F::Fill) = show(io, F)
+
+end

--- a/test/testhelpers/InfiniteArrays.jl
+++ b/test/testhelpers/InfiniteArrays.jl
@@ -21,11 +21,14 @@ Base.:(==)(::Infinity, ::Int) = false
 Base.:(==)(::Int, ::Infinity) = false
 Base.:(<)(::Int, ::Infinity) = true
 Base.:(≤)(::Int, ::Infinity) = true
+Base.:(<)(::Infinity, ::Int) = false
 Base.:(≤)(::Infinity, ::Int) = false
 Base.:(≤)(::Infinity, ::Infinity) = true
 Base.:(-)(::Infinity, ::Int) = Infinity()
 Base.:(+)(::Infinity, ::Int) = Infinity()
 Base.:(:)(::Infinity, ::Infinity) = 1:0
+Base.max(::Infinity, ::Int) = Infinity()
+Base.max(::Int, ::Infinity) = Infinity()
 
 """
     OneToInf(n)


### PR DESCRIPTION
The fallback method `fill!`s the array with zeros before copying to the diagonal. This seems redundant for `Diagonal` and almost-diagonal banded matrices, as this involves two passes over the diagonal. This also resolves issues like https://github.com/JuliaArrays/FillArrays.jl/issues/206, where the diagonal must necessarily be non-zero, and an attempt to set it to zero will lead to an error.

Removing the redundancy cuts runtime by half, as expected:
On nightly `v"1.10.0-DEV.450"`
```julia
julia> using LinearAlgebra,BenchmarkTools

julia> D = Diagonal(rand(10000));

julia> @btime copyto!($D, I);
  3.329 μs (0 allocations: 0 bytes)
```
This PR
```julia
julia> @btime copyto!($D, I);
  1.659 μs (0 allocations: 0 bytes)
```

I've added a simplified `FillArray` test-helper module, as I imagine this might be useful elsewhere as well.

Something similar might also be necessary for `UnitLowerTriangular` and `UnitUpperTriangular`, but that can be a separate PR