### PR TITLE
Use `sum` in `count` for constant folding of type based predicates

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -1354,15 +1354,7 @@ count(itr; init=0) = count(identity, itr; init)
 
 count(f, itr; init=0) = _simple_count(f, itr, init)
 
-_simple_count(pred, itr, init) = _simple_count_helper(Generator(pred, itr), init)
-
-function _simple_count_helper(g, init::T) where {T}
-    n::T = init
-    for x in g
-        n += x::Bool
-    end
-    return n
-end
+_simple_count(pred, itr, init) = sum(pred(i)::Bool for i in itr; init)
 
 function _simple_count(::typeof(identity), x::Array{Bool}, init::T=0) where {T}
     n::T = init

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -1354,7 +1354,7 @@ count(itr; init=0) = count(identity, itr; init)
 
 count(f, itr; init=0) = _simple_count(f, itr, init)
 
-_simple_count(pred, itr, init) = sum(pred(i)::Bool for i in itr; init)
+_simple_count(pred, itr, init) = sum(_bool(pred), itr; init)
 
 function _simple_count(::typeof(identity), x::Array{Bool}, init::T=0) where {T}
     n::T = init


### PR DESCRIPTION
Master:

```
julia> @btime count(f, tup) setup=(f=x->x isa Int; tup=(nothing, 1, 2.0, π, '4', "five", :six, 21//3, 8im))
  71.209 ns (11 allocations: 720 bytes)
1
```

PR:

```
julia> @btime count(f, tup) setup=(f=x->x isa Int; tup=(nothing, 1, 2.0, π, '4', "five", :six, 21//3, 8im))
  0.920 ns (0 allocations: 0 bytes)
1
```

The underlying issue is that the previous simple loop, even with the type assertion, was unable to constant fold due to iterating over a `Generator` wrapping such a bad tuple seemingly going out of bounds at some point (according to Cthulhu at least), leading to a throwing branch:

```
julia> a = x->x isa Int; b=(nothing, 1, 2.0, π, '4', "five", :six, 21//3, 8im)

julia> Base.infer_effects(sum, Base.typesof(a, b))
(+c,+e,+n,+t,+s,!m,+i)

julia> Base.infer_effects(count, Base.typesof(a, b))
(+c,+e,!n,!t,+s,+m,+i)
```

```
 • %17 = iterate(::Base.Generator{Tuple{Nothing, Int64, Float64, Irrational{:π}, Char, String, Symbol, Rational{Int64}, Complex{Int64}}, var"#3#4"},::Int64)::Union{Nothing, Tuple{Bool, Int64}} (+c,+e,!n,+t,+s,+m,+i)
...
 • %10 = getindex(::Tuple{Nothing, Int64, Float64, Irrational{:π}, Char, String, Symbol, Rational{Int64}, Complex{Int64}},::Int64)::Any (+c,+e,!n,+t,+s,+m,!i)
```

I suspect that there's a deeper fix for iterating in `Generator`, but this fixes the case brought up on Slack.