### PR TITLE
prevent heap snapshot test to write to julia dir

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1255,7 +1255,6 @@ function take_heap_snapshot(io::IOStream, all_one::Bool=false)
     Base.@_lock_ios(io, ccall(:jl_gc_take_heap_snapshot, Cvoid, (Ptr{Cvoid}, Cchar), io.handle, Cchar(all_one)))
 end
 function take_heap_snapshot(filepath::String, all_one::Bool=false)
-    mkpath(filepath)
     open(filepath, "w") do io
         take_heap_snapshot(io, all_one)
     end

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1255,6 +1255,7 @@ function take_heap_snapshot(io::IOStream, all_one::Bool=false)
     Base.@_lock_ios(io, ccall(:jl_gc_take_heap_snapshot, Cvoid, (Ptr{Cvoid}, Cchar), io.handle, Cchar(all_one)))
 end
 function take_heap_snapshot(filepath::String, all_one::Bool=false)
+    mkpath(filepath)
     open(filepath, "w") do io
         take_heap_snapshot(io, all_one)
     end

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -279,7 +279,8 @@ end
 end
 
 @testset "HeapSnapshot" begin
-    fname = read(`$(Base.julia_cmd()) --startup-file=no -e "using Profile; print(Profile.take_heap_snapshot())"`, String)
+    tmpfile = tempname()
+    fname = read(`$(Base.julia_cmd()) --startup-file=no -e "using Profile; print(Profile.take_heap_snapshot(\"$tmpfile\"))"`, String)
 
     @test isfile(fname)
 

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -279,7 +279,8 @@ end
 end
 
 @testset "HeapSnapshot" begin
-    fname = cd(mktempdir()) do
+    tmpdir = mktempdir()
+    fname = cd(tmpdir) do
         read(`$(Base.julia_cmd()) --startup-file=no -e "using Profile; print(Profile.take_heap_snapshot())"`, String)
     end
 
@@ -290,6 +291,7 @@ end
     end
 
     rm(fname)
+    rm(tmpdir, force = true, recursive = true)
 end
 
 include("allocs.jl")

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -279,8 +279,9 @@ end
 end
 
 @testset "HeapSnapshot" begin
-    tmpfile = tempname()
-    fname = read(`$(Base.julia_cmd()) --startup-file=no -e "using Profile; print(Profile.take_heap_snapshot(\"$tmpfile\"))"`, String)
+    fname = cd(mktempdir()) do
+        read(`$(Base.julia_cmd()) --startup-file=no -e "using Profile; print(Profile.take_heap_snapshot())"`, String)
+    end
 
     @test isfile(fname)
 


### PR DESCRIPTION
Otherwise errors on PkgEval (and it is a good idea nonetheless): https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/9a67956_vs_17cfb8e/Profile.primary.log

```
ERROR: SystemError: opening file "/opt/julia/share/julia/stdlib/v1.9/Profile/test/32_3557048005887140.heapsnapshot": Read-only file system
```