### PR TITLE
Faster radix sort

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -5,7 +5,7 @@ module Sort
 using Base.Order
 
 using Base: copymutable, midpoint, require_one_based_indexing, uinttype,
-    sub_with_overflow, add_with_overflow, OneTo, BitSigned, BitIntegerType, top_set_bit
+    sub_with_overflow, add_with_overflow, OneTo, BitSigned, BitIntegerType, top_set_bit, Cartesian
 
 import Base:
     sort,
@@ -1112,13 +1112,6 @@ function radix_sort!(v::AbstractVector{U}, lo::Integer, hi::Integer, bits::Unsig
         shift < bits || return true
     end
 end
-
-macro repeat4x(a)
-    quote
-        $a; $a; $a; $a
-    end |> esc
-end
-
 function radix_sort_pass!(t, lo, hi, offset, counts, v, shift, chunk_size)
     mask = UInt(1) << chunk_size - 1  # mask is defined in pass so that the compiler
     @inbounds begin                   #  ↳ knows it's shape
@@ -1141,7 +1134,7 @@ function radix_sort_pass!(t, lo, hi, offset, counts, v, shift, chunk_size)
 		#loop unrolled 4x
         k = lo
         while k <= hi - 4
-            @repeat4x begin
+            Cartesian.@nexprs 4 _ -> begin
                 x = v[k]                  # lookup the element
                 i = (x >> shift)&mask + 1 # compute its bucket's index for this pass
                 j = counts[i]             # lookup the target index

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1137,7 +1137,7 @@ function radix_sort_pass!(t, lo, hi, offset, counts, v, shift, chunk_size)
         # belongs, not the number of elements in each bucket. We will put the first element
         # of bucket 0x00 in t[counts[1]], the next element of bucket 0x00 in t[counts[1]+1],
         # and the last element of bucket 0x00 in t[counts[2]-1].
-		
+
 		#loop unrolled 4x
         k = lo
         while k <= hi - 4
@@ -1149,7 +1149,7 @@ function radix_sort_pass!(t, lo, hi, offset, counts, v, shift, chunk_size)
                 counts[i] = j + 1         # increment the target index for the next
                 k += 1                    #  ↳ element in this bucket
             end
-        end                           
+        end
         while k <= hi
             x = v[k]                  # lookup the element
             i = (x >> shift)&mask + 1 # compute its bucket's index for this pass


### PR DESCRIPTION
Unrolling the loop in Base.Sort.radix_sort_pass! increases performance by about 50%.
(on my Ryzen 3900x)

This makes the code somewhat less clean, but in my opinion the performance benefit is worth it.

Disclaimer: I did not fully build Julia including this PR (yet). The change is very small and I did test the modified function, but I do not want to setup everything to build Julia if the PR might be rejected based on a choice of code clarity vs. performance.

[Here is a simple test script](https://github.com/LSchwerdt/MiscJulia/blob/4c2c9c3abe04bcb5dd9cdcadb841ed64442958fd/radix_pass_unroll/radixpassunroll.jl) to try out the changed function in isolation.
This is the output:
```
2000/20000
...
20000/20000

base:     5.063 seconds
unrolled: 3.052 seconds
speedup factor: 1.66
Test Passed
```
