### PR TITLE
faster `isfinite` for floats

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -619,7 +619,7 @@ See also: [`iszero`](@ref), [`isone`](@ref), [`isinf`](@ref), [`ismissing`](@ref
 isnan(x::AbstractFloat) = (x != x)::Bool
 isnan(x::Number) = false
 
-isfinite(x::AbstractFloat) = x - x == 0
+isfinite(x::AbstractFloat) = !isnan(x - x)
 isfinite(x::Real) = decompose(x)[3] != 0
 isfinite(x::Integer) = true
 


### PR DESCRIPTION
Improvement can be seen in shortened `code_native(isfinite,Tuple{Float64})`. Checking for `NaN` is easier than checking for zero and those are the only two possibilities for `x - x`.
```julia-repl
julia> using BenchmarkTools

julia> x = rand(100);

julia> @btime all(isfinite,$x); # before
  58.350 ns (0 allocations: 0 bytes)

julia> @btime all(isfinite,$x); # after
  47.166 ns (0 allocations: 0 bytes)
```

Benchmarks show small improvement on x86. It'd be nice if someone could benchmark or `code_native` this change on an ARM.

Up for discussion: Should this change apply to all `AbstractFloat` or only to `IEEEFloat`? They're both the same here (among `Base` types) since `BigFloat` has its own method.