### PR TITLE
Add NDArray and NDAbstractArray aliases with N as first parameter

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -31,6 +31,17 @@ elements of type `T`. Alias for [`AbstractArray{T,2}`](@ref).
 const AbstractMatrix{T} = AbstractArray{T,2}
 
 """
+    NDAbstractArray{N,T}
+
+Supertype for N-dimensional arrays (or array-like types) with
+elements of type `T`. Alias for [`AbstractArray{T,N}`](@ref).
+
+`NDAbstractArray{1}` can also be written as [`AbstractVector`](@ref)
+`NDAbstractArray{2}` can also be written as [`AbstractMatrix`](@ref)
+"""
+const NDAbstractArray{N,T} = AbstractArray{T,N}
+
+"""
     AbstractVecOrMat{T}
 
 Union type of [`AbstractVector{T}`](@ref) and [`AbstractMatrix{T}`](@ref).
@@ -69,6 +80,16 @@ See also [`fill`](@ref), [`zeros`](@ref), [`undef`](@ref) and [`similar`](@ref)
 for creating matrices.
 """
 const Matrix{T} = Array{T,2}
+
+"""
+    NDArray{N,T} <: NDAbstractArray{N,T}
+
+N-dimensional dense array with elements of type `T`. Alias for [`Array{T,N}`](@ref).
+
+`NDArray{1}` can be written as [`Vector`](@ref)
+`NDArray{2}` can be written as [`Matrix`](@ref)
+"""
+const NDArray{N,T} = Array{T,N}
 
 """
     VecOrMat{T}

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -63,6 +63,8 @@ export
     Matrix,
     MergeSort,
     Missing,
+    NDArray,
+    NDAbstractArray,
     NTuple,
     IdDict,
     OrdinalRange,


### PR DESCRIPTION
Currently we have the following aliases, demonstrating a desire to think of the dimension of the array before the type.
* `const AbstractVector{T} = AbstractArray{T,1}`
* `const AbstractMatrix{T} = AbstractArray{T,2}`
* `const Vector{T} = Array{T,1}`
* `const Matrix{T} = Array{T,2}`

This pull request creates and exports the following aliases:
* `const NDAbstractArray{N,T} = AbstractArray{T,N}`
* `const NDArray{N,T} = Array{T,N}`

This allows for the following sequence:
```julia
julia> NDArray{0}
Array{T, 0} where T

julia> NDArray{1}
Vector (alias for Array{T, 1} where T)

julia> NDArray{2}
Matrix (alias for Array{T, 2} where T)

julia> NDArray{3}
Array{T, 3} where T

julia> NDArray{4}
Array{T, 4} where T
```

This is improved over the current status quo:
```julia
julia> Array{T,0} where T
Array{T, 0} where T

julia> Array{T,1} where T
Vector (alias for Array{T, 1} where T)

julia> Array{T,2} where T
Matrix (alias for Array{T, 2} where T)

julia> Array{T,3} where T
Array{T, 3} where T

julia> Array{T,4} where T
Array{T, 4} where T
```

This makes function definitions that focus on the dimensionality of the array compact, easier to read, and less confusing since the free type parameter does not need to be written.
```
julia> f(a::NDArray{N}, b::NDArray{M}) where {N, M} = N == M - 1
f (generic function with 1 method)

julia> g(a::Array{T, N} where T, b::Array{T, M} where T) where {N, M} = N == M - 1
g (generic function with 1 method)

julia> f(Array{Int,0}(undef), Float64[1,2,3])
true

julia> g(Array{Int,0}(undef), Float64[1,2,3])
true
```