### PR TITLE
Add test for sprint (fixes: #45066)

### DIFF
--- a/test/strings/io.jl
+++ b/test/strings/io.jl
@@ -219,6 +219,10 @@ end
         """
 end
 
+@testset "sprint honoring IOcontext" begin
+    @test sprint(show, Base.Dict[], context=(:compact=>false, :module=>nothing))[1:4] === "Base"
+end
+
 @testset "#11659" begin
     # The indentation code was not correctly counting tab stops
     @test Base.indentation("      \t") == (8, true)

--- a/test/strings/io.jl
+++ b/test/strings/io.jl
@@ -219,8 +219,8 @@ end
         """
 end
 
-@testset "sprint honoring IOcontext" begin
-    @test sprint(show, Base.Dict[], context=(:compact=>false, :module=>nothing))[1:4] === "Base"
+@testset "sprint honoring IOContext" begin
+    @test startswith(sprint(show, Base.Dict[], context=(:compact=>false, :module=>nothing)), "Base.Dict")
 end
 
 @testset "#11659" begin


### PR DESCRIPTION
Added tests for sprint in `test/strings/io.jl` since the function is defined in `base/strings/io.jl`. Refer: #45277 & #45066