### PR TITLE
replace `/bin/date` with `date` in version_git.sh

### DIFF
--- a/base/version_git.sh
+++ b/base/version_git.sh
@@ -63,14 +63,14 @@ fi
 date_string=$git_time
 case $(uname) in
   Darwin | FreeBSD)
-    date_string="$(/bin/date -jr $git_time -u '+%Y-%m-%d %H:%M %Z')"
+    date_string="$(date -jr $git_time -u '+%Y-%m-%d %H:%M %Z')"
     ;;
   MINGW*)
     git_time=$(git log -1 --pretty=format:%ci)
-    date_string="$(/bin/date --date="$git_time" -u '+%Y-%m-%d %H:%M %Z')"
+    date_string="$(date --date="$git_time" -u '+%Y-%m-%d %H:%M %Z')"
     ;;
   *)
-    date_string="$(/bin/date --date="@$git_time" -u '+%Y-%m-%d %H:%M %Z')"
+    date_string="$(date --date="@$git_time" -u '+%Y-%m-%d %H:%M %Z')"
     ;;
 esac
 if [ $(git describe --tags --exact-match 2> /dev/null) ]; then


### PR DESCRIPTION
This could primarily be an error on NixOS-like systems, where `/bin/date` does not exist. This could be for various reasons, such as reproducible builds and/or symlinked FSH.
