### PR TITLE
3% faster radix sort

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1139,7 +1139,7 @@ function radix_sort_pass!(t, lo, hi, offset, counts, v, shift, chunk_size)
             counts[i] += 1            # increment that bucket's count
         end
 
-        counts[1] = lo                # set target index for the first bucket
+        counts[1] = lo + offset       # set target index for the first bucket
         cumsum!(counts, counts)       # set target indices for subsequent buckets
         # counts[1:mask+1] now stores indices where the first member of each bucket
         # belongs, not the number of elements in each bucket. We will put the first element
@@ -1150,7 +1150,7 @@ function radix_sort_pass!(t, lo, hi, offset, counts, v, shift, chunk_size)
             x = v[k]                  # lookup the element
             i = (x >> shift)&mask + 1 # compute its bucket's index for this pass
             j = counts[i]             # lookup the target index
-            t[j + offset] = x         # put the element where it belongs
+            t[j] = x                  # put the element where it belongs
             counts[i] = j + 1         # increment the target index for the next
         end                           #  ↳ element in this bucket
     end


### PR DESCRIPTION
In radix_sort_pass! the offset for indexing into the target array is calculated repeatedly for each element. This PR moves the offset calculation out of the hot loop.

When not memory-bound (i.e. for small arrays), this leads to a performance gain of about 3% in my tests. For larger arrays, the performance gain tends to zero.

[Here is a test script](https://github.com/LSchwerdt/MiscJulia/blob/15494d622c9f677ffa3577dec3cf14a3836d175e/radix_pass_optim/radixpassoptim.jl), and here are the results on different hardware:

```
1_000_000 radix sort passes with 1_000 elements:
base: 2.034 seconds
PR:   1.946 seconds
speedup factor: 1.045

100 radix sort passes with 10_000_000 elements:
base: 4.199 seconds
PR:   4.156 seconds
speedup factor: 1.010

Julia Version 1.9.0-beta3
Commit 24204a7344 (2023-01-18 07:20 UTC)
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
  CPU: 16 × Intel(R) Core(TM) i7-7820X CPU @ 3.60GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.6 (ORCJIT, skylake-avx512)
  Threads: 1 on 16 virtual cores
Test Passed
```

```
1_000_000 radix sort passes with 1_000 elements:
base: 2.353 seconds
PR:   2.267 seconds
speedup factor: 1.038

100 radix sort passes with 10_000_000 elements:
base: 6.370 seconds
PR:   6.336 seconds
speedup factor: 1.005

Julia Version 1.9.0-beta3
Commit 24204a7344 (2023-01-18 07:20 UTC)
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
  CPU: 8 × Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.6 (ORCJIT, skylake)
  Threads: 1 on 8 virtual cores
Test Passed
```

```
1_000_000 radix sort passes with 1_000 elements:
base: 1.764 seconds
PR:   1.712 seconds
speedup factor: 1.030

100 radix sort passes with 10_000_000 elements:
base: 2.562 seconds
PR:   2.801 seconds
speedup factor: 0.915

Julia Version 1.9.0-beta3
Commit 24204a7344 (2023-01-18 07:20 UTC)
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
  CPU: 24 × AMD Ryzen 9 3900X 12-Core Processor
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.6 (ORCJIT, znver2)
  Threads: 24 on 24 virtual cores
Environment:
  JULIA_EDITOR = code
Test Passed
```
[The performance regression on the 3900X seems to be a strange outlier and not representative of normal hardware.](https://github.com/JuliaLang/julia/pull/48459)

Disclaimer: I did not fully build Julia including this PR, but I did test the modified function using the linked test script, and a modified test script with offset != 0.