### PR TITLE
Add complete documentation for `Base.countlines()`

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -1304,6 +1304,7 @@ end
 
 """
     countlines(io::IO; eol::AbstractChar = '\\n')
+    countlines(filename::AbstractString; eol::AbstractChar = '\\n')
 
 Read `io` until the end of the stream/file and count the number of lines. To specify a file
 pass the filename as the first argument. EOL markers other than `'\\n'` are supported by
@@ -1331,6 +1332,19 @@ julia> io = IOBuffer("JuliaLang is a GitHub organization.");
 
 julia> countlines(io, eol = '.')
 1
+```
+```jldoctest
+julia> write("my_file.txt", "JuliaLang is a GitHub organization.\\n")
+36
+
+julia> countlines("my_file.txt")
+1
+
+julia> countlines("my_file.txt", eol = '.')
+2
+
+julia> rm("my_file.txt")
+
 ```
 """
 function countlines(io::IO; eol::AbstractChar='\n')

--- a/base/io.jl
+++ b/base/io.jl
@@ -1340,8 +1340,8 @@ julia> write("my_file.txt", "JuliaLang is a GitHub organization.\\n")
 julia> countlines("my_file.txt")
 1
 
-julia> countlines("my_file.txt", eol = '.')
-2
+julia> countlines("my_file.txt", eol = 'n')
+4
 
 julia> rm("my_file.txt")
 


### PR DESCRIPTION
Fixes: #48494

I think this makes sense. It is also in line with the documentation for `Base.readlines()` and similar functions. Please let me know of possible improvements.