### PR TITLE
automatically detect and debug deadlocks in package loading

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1416,7 +1416,7 @@ end
 # to synchronize multiple tasks trying to import/using something
 const package_locks = Dict{PkgId,Pair{Task,Threads.Condition}}()
 
-debug_loading_deadlocks = true # Enable a slightly more expensive, but more complete algorithm that can handle simultaneous tasks.
+debug_loading_deadlocks::Bool = true # Enable a slightly more expensive, but more complete algorithm that can handle simultaneous tasks.
                                # This only triggers if you have multiple tasks trying to load the same package at the same time,
                                # so it is unlikely to make a difference normally.
 function start_loading(modkey::PkgId)


### PR DESCRIPTION
Since we can enumerate the wait cycle of the package condition variables, we can potentially detect if there is a deadlock (indicating a cycle in the package loading graph).