### PR TITLE
ensure extension triggers are only run by the package that satified them

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1184,8 +1184,7 @@ function run_extension_callbacks(extid::ExtensionId)
         true
     catch
         # Try to continue loading if loading an extension errors
-        errs = current_exceptions()
-        @error "Error during loading of extension" exception=errs
+        @error "Error during loading of extension $(extid.id.name) of $(extid.parentid.name)"
         false
     end
     return succeeded


### PR DESCRIPTION
Oscar had noticed a problem where loading an extension might trigger loading another package, which might re-trigger attempting to load the same extension. And then that causes a deadlock from waiting for the extension to finish loading (it appears to be a recursive import triggered from multiple places). Instead alter the representation, to be similar to a semaphore, so that it will be loaded only exactly by the final package that satisfied all dependencies for it.

This approach could still encounter an issue if the user imports a package (C) which it does not explicitly list as a dependency for extension. But it is unclear to me that we actually want to solve that, since it weakens and delays the premise that Bext is available shortly after A and B are both loaded.

\# module C; using A, B; end;; module A; end;; module B; end;; module Bext; using C; end
\# using C, Bext / A / B
starts C -> requires A, B to load
loads A -> defines Bext (extends B, but tries to also require C) loads B -> loads Bext (which waits for C -> deadlock!)
finish C -> now safe to load Bext

While using this order would have been fine.
\# using A, B, Bext / C
loads A -> defines Bext (extends B, but tries to also require C) loads B -> starts Bext
loads C
finish Bext