### PR TITLE
Add time collection feature in `Base.current_exceptions()`

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -148,13 +148,13 @@ uncaught exceptions.
     1.1–1.6, and had a plain Vector-of-tuples as a return type.
 """
 function current_exceptions(task::Task=current_task(); backtrace::Bool=true, time::Bool=true)
-    raw = ccall(:jl_get_excstack, Any, (Any,Cint,Cint), task, backtrace, typemax(Cint))::Vector{Any}
+    raw = ccall(:jl_get_excstack, Any, (Any,Cint,Cint,Cint), task, backtrace, typemax(Cint), time)::Vector{Any}
     formatted = Any[]
     stride = backtrace ? 3 : 1
     for i = reverse(1:stride:length(raw))
         exc = raw[i]
+        tm = time ? exc[end] : nothing
         bt = backtrace ? Base._reformat_bt(raw[i+1],raw[i+2]) : nothing
-        tm = time ? ccall(:jl_clock_now, Any, ())::Any : nothing
         push!(formatted, (exception=exc,backtrace=bt,time=tm))
     end
     ExceptionStack(formatted)

--- a/base/error.jl
+++ b/base/error.jl
@@ -147,14 +147,15 @@ uncaught exceptions.
     This function went by the experimental name `catch_stack()` in Julia
     1.1–1.6, and had a plain Vector-of-tuples as a return type.
 """
-function current_exceptions(task::Task=current_task(); backtrace::Bool=true)
+function current_exceptions(task::Task=current_task(); backtrace::Bool=true, time::Bool=true)
     raw = ccall(:jl_get_excstack, Any, (Any,Cint,Cint), task, backtrace, typemax(Cint))::Vector{Any}
     formatted = Any[]
     stride = backtrace ? 3 : 1
     for i = reverse(1:stride:length(raw))
         exc = raw[i]
         bt = backtrace ? Base._reformat_bt(raw[i+1],raw[i+2]) : nothing
-        push!(formatted, (exception=exc,backtrace=bt))
+        tm = time ? ccall(:jl_clock_now, Any, ())::Any : nothing
+        push!(formatted, (exception=exc,backtrace=bt,time=tm))
     end
     ExceptionStack(formatted)
 end

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -340,7 +340,7 @@ JL_DLLEXPORT jl_value_t *jl_get_backtrace(void)
 // with the top of the stack and returning up to `max_entries`. If requested by
 // setting the `include_bt` flag, backtrace data in bt,bt2 format is
 // interleaved.
-JL_DLLEXPORT jl_value_t *jl_get_excstack(jl_task_t* task, int include_bt, int max_entries)
+JL_DLLEXPORT jl_value_t *jl_get_excstack(jl_task_t* task, int include_bt, int max_entries, int time)
 {
     JL_TYPECHK(current_exceptions, task, (jl_value_t*)task);
     jl_task_t *ct = jl_current_task;
@@ -364,6 +364,9 @@ JL_DLLEXPORT jl_value_t *jl_get_excstack(jl_task_t* task, int include_bt, int ma
                              &bt, &bt2);
             jl_array_ptr_1d_push(stack, (jl_value_t*)bt);
             jl_array_ptr_1d_push(stack, (jl_value_t*)bt2);
+        }
+        if (time) {
+            jl_array_ptr_1d_push(stack, (jl_value_t*)jl_hrtime());
         }
         itr = jl_excstack_next(excstack, itr);
         i++;


### PR DESCRIPTION
Closes: #48307 

I think this is the way to do it. However, I'm a little confused as to if I should call `jl_gettimeofday` or `jl_clock_now` for this.
It runs fine on current tests, but I will have to make new tests to check for with/without `time=true`.
Please let me know if more changes are to made.