### PR TITLE
Test: add space after test failure for visual clarity

### DIFF
--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -55,6 +55,7 @@ julia> @test foo("f") == 20
 Test Failed at none:1
   Expression: foo("f") == 20
    Evaluated: 1 == 20
+
 ERROR: There was an error during testing
 ```
 
@@ -224,6 +225,7 @@ julia> @test 1 ≈ 0.999999
 Test Failed at none:1
   Expression: 1 ≈ 0.999999
    Evaluated: 1 ≈ 0.999999
+
 ERROR: There was an error during testing
 ```
 You can specify relative and absolute tolerances by setting the `rtol` and `atol` keyword arguments of `isapprox`, respectively,

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -165,6 +165,7 @@ function Base.show(io::IO, t::Fail)
             print(io, "\n     Context: ", t.context)
         end
     end
+    println(io) # add some visual space to separate sequential failures
 end
 
 """

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1406,6 +1406,7 @@ julia> @testset let logi = log(im)
 Test Failed at none:3
   Expression: !(iszero(real(logi)))
      Context: logi = 0.0 + 1.5707963267948966im
+
 ERROR: There was an error during testing
 ```
 """


### PR DESCRIPTION
Small change. Currently sequential failures visually clump together.

Example failures

master
```
Pkg.precompile: Test Failed at /home/runner/work/Pkg.jl/Pkg.jl/test/api.jl:173
  Expression: length(broken_packages) == 1
   Evaluated: 0 == 1
Stacktrace:
 [1] macro expansion
   @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.10/Test/src/Test.jl:477 [inlined]
 [2] (::Main.PkgTestsOuter.PkgTestsInner.APITests.var"#17#32")(tmp::String)
   @ Main.PkgTestsOuter.PkgTestsInner.APITests ~/work/Pkg.jl/Pkg.jl/test/api.jl:173
Pkg.precompile: Test Failed at /home/runner/work/Pkg.jl/Pkg.jl/test/api.jl:181
  Expression: !(occursin("Precompiling", String(take!(iob))))
   Evaluated: !(occursin("Precompiling", "    Updating registry at `/tmp/jl_GaJgXM/registries/General`\n    Updating git-repo `[https://github.com/JuliaRegistries/General.git`\n](https://github.com/JuliaRegistries/General.git%60/n)  No Changes to `/tmp/jl_hEt56v/Project.toml`\n  No Changes to `/tmp/jl_hEt56v/Manifest.toml`\nPrecompiling project...\n\e[91m  ✗ \e[39mBrokenDep\n  0 dependencies successfully precompiled in 1 seconds. 6 already precompiled.\n  \e[91m1\e[39m dependency errored. To see a full report either run `import Pkg; Pkg.precompile()` or load the package\n"))
Stacktrace:
 [1] macro expansion
   @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.10/Test/src/Test.jl:477 [inlined]
 [2] (::Main.PkgTestsOuter.PkgTestsInner.APITests.var"#17#32")(tmp::String)
   @ Main.PkgTestsOuter.PkgTestsInner.APITests ~/work/Pkg.jl/Pkg.jl/test/api.jl:181
Pkg.precompile: Test Failed at /home/runner/work/Pkg.jl/Pkg.jl/test/api.jl:182
  Expression: length(Pkg.API.pkgs_precompile_suspended) == 1
   Evaluated: 0 == 1
Stacktrace:
 [1] macro expansion
   @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.10/Test/src/Test.jl:477 [inlined]
 [2] (::Main.PkgTestsOuter.PkgTestsInner.APITests.var"#17#32")(tmp::String)
   @ Main.PkgTestsOuter.PkgTestsInner.APITests ~/work/Pkg.jl/Pkg.jl/test/api.jl:182
```
This PR
```
Pkg.precompile: Test Failed at /home/runner/work/Pkg.jl/Pkg.jl/test/api.jl:173
  Expression: length(broken_packages) == 1
   Evaluated: 0 == 1
Stacktrace:
 [1] macro expansion
   @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.10/Test/src/Test.jl:477 [inlined]
 [2] (::Main.PkgTestsOuter.PkgTestsInner.APITests.var"#17#32")(tmp::String)
   @ Main.PkgTestsOuter.PkgTestsInner.APITests ~/work/Pkg.jl/Pkg.jl/test/api.jl:173

Pkg.precompile: Test Failed at /home/runner/work/Pkg.jl/Pkg.jl/test/api.jl:181
  Expression: !(occursin("Precompiling", String(take!(iob))))
   Evaluated: !(occursin("Precompiling", "    Updating registry at `/tmp/jl_GaJgXM/registries/General`\n    Updating git-repo `[https://github.com/JuliaRegistries/General.git`\n](https://github.com/JuliaRegistries/General.git%60/n)  No Changes to `/tmp/jl_hEt56v/Project.toml`\n  No Changes to `/tmp/jl_hEt56v/Manifest.toml`\nPrecompiling project...\n\e[91m  ✗ \e[39mBrokenDep\n  0 dependencies successfully precompiled in 1 seconds. 6 already precompiled.\n  \e[91m1\e[39m dependency errored. To see a full report either run `import Pkg; Pkg.precompile()` or load the package\n"))
Stacktrace:
 [1] macro expansion
   @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.10/Test/src/Test.jl:477 [inlined]
 [2] (::Main.PkgTestsOuter.PkgTestsInner.APITests.var"#17#32")(tmp::String)
   @ Main.PkgTestsOuter.PkgTestsInner.APITests ~/work/Pkg.jl/Pkg.jl/test/api.jl:181

Pkg.precompile: Test Failed at /home/runner/work/Pkg.jl/Pkg.jl/test/api.jl:182
  Expression: length(Pkg.API.pkgs_precompile_suspended) == 1
   Evaluated: 0 == 1
Stacktrace:
 [1] macro expansion
   @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.10/Test/src/Test.jl:477 [inlined]
 [2] (::Main.PkgTestsOuter.PkgTestsInner.APITests.var"#17#32")(tmp::String)
   @ Main.PkgTestsOuter.PkgTestsInner.APITests ~/work/Pkg.jl/Pkg.jl/test/api.jl:182
```