### PR TITLE
prevent extensions from loading packages outside weakdeps and parent

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -821,8 +821,8 @@ function explicit_manifest_deps_get(project_file::String, where::PkgId, name::St
                                 end
                             end
                         end
-                        # `name` is not an ext, do standard lookup as if this was the parent
-                        return identify_package(PkgId(UUID(uuid), dep_name), name)
+                        # `name` is not a weak dependency of the extension, not the parent
+                        return nothing
                     end
                 end
             end

--- a/doc/src/manual/code-loading.md
+++ b/doc/src/manual/code-loading.md
@@ -391,8 +391,7 @@ end
 
 When a package with extensions is added to an environment, the `weakdeps` and `extensions` sections
 are stored in the manifest file in the section for that package. The dependency lookup rules for
-a package are the same as for its "parent" except that the listed extension dependencies are also considered as
-dependencies.
+an extension is that they can load the "parent" package and the listed extension dependencies. Other dependencies have to be loaded transitively via the parent pacakge via e.g. `import Parent.Dependency`.
 
 ### [Package/Environment Preferences](@id preferences)
 


### PR DESCRIPTION
Fixes #48533 

Needs a better error message, the current one is not very good with this:

```
ERROR: LoadError: ArgumentError: Package ColorsExt does not have ArgCheck in its dependencies:
- You may have a partially installed environment. Try `Pkg.instantiate()`
  to ensure all packages in the environment are installed.
- Or, if you have ColorsExt checked out for development and have
  added ArgCheck as a dependency but haven't updated your primary
  environment's manifest file, try `Pkg.resolve()`.
- Otherwise you may need to report an issue with ColorsExt
```

Needs update to documentation.

