### PR TITLE
Changed Caption of last -Next button in Windows InstallationWizard to -Install button

### DIFF
--- a/contrib/windows/build-installer.iss
+++ b/contrib/windows/build-installer.iss
@@ -147,7 +147,7 @@ end;
 
 procedure CurPageChanged(CurPageID: Integer);
 begin
-  ;  Fixing bug in git Issue #48521
+  ;  change button text from "next" to "install" when ReadyPage is disabled.
   if CurPageID = wpSelectProgramGroup then
     WizardForm.NextButton.Caption := SetupMessage(msgButtonInstall)
   else

--- a/contrib/windows/build-installer.iss
+++ b/contrib/windows/build-installer.iss
@@ -151,8 +151,8 @@ begin
   case CurPageID of
     wpWelcome: WizardForm.Color := WizardForm.WelcomePage.Color;
     wpFinished: WizardForm.Color := WizardForm.FinishedPage.Color;
-    
-    ; change button text from "next" to "install" when ReadyPage is disabled.
+
+    ;change button text from "next" to "install" when ReadyPage is disabled.
     wpSelectTasks: WizardForm.NextButton.Caption := SetupMessage(msgButtonInstall);
   else
     WizardForm.Color := WizardForm.InnerPage.Color;

--- a/contrib/windows/build-installer.iss
+++ b/contrib/windows/build-installer.iss
@@ -147,6 +147,12 @@ end;
 
 procedure CurPageChanged(CurPageID: Integer);
 begin
+  ;  Fixing bug in git Issue #48521
+  if CurPageID = wpSelectProgramGroup then
+    WizardForm.NextButton.Caption := SetupMessage(msgButtonInstall)
+  else
+    WizardForm.NextButton.Caption := SetupMessage(msgButtonNext);
+
   case CurPageID of
     wpWelcome: WizardForm.Color := WizardForm.WelcomePage.Color;
     wpFinished: WizardForm.Color := WizardForm.FinishedPage.Color;

--- a/contrib/windows/build-installer.iss
+++ b/contrib/windows/build-installer.iss
@@ -145,17 +145,15 @@ begin
   end;
 end;
 
+
 procedure CurPageChanged(CurPageID: Integer);
 begin
-  ;  change button text from "next" to "install" when ReadyPage is disabled.
-  if CurPageID = wpSelectProgramGroup then
-    WizardForm.NextButton.Caption := SetupMessage(msgButtonInstall)
-  else
-    WizardForm.NextButton.Caption := SetupMessage(msgButtonNext);
-
   case CurPageID of
     wpWelcome: WizardForm.Color := WizardForm.WelcomePage.Color;
     wpFinished: WizardForm.Color := WizardForm.FinishedPage.Color;
+    
+    ; change button text from "next" to "install" when ReadyPage is disabled.
+    wpSelectTasks: WizardForm.NextButton.Caption := SetupMessage(msgButtonInstall);
   else
     WizardForm.Color := WizardForm.InnerPage.Color;
   end;

--- a/contrib/windows/build-installer.iss
+++ b/contrib/windows/build-installer.iss
@@ -156,6 +156,8 @@ begin
   case CurPageID of
     wpWelcome: WizardForm.Color := WizardForm.WelcomePage.Color;
     wpFinished: WizardForm.Color := WizardForm.FinishedPage.Color;
+    // change button text from "next" to "install" when ReadyPage is disabled.
+    wpSelectTasks: WizardForm.NextButton.Caption := SetupMessage(msgButtonInstall);
   else
     WizardForm.Color := WizardForm.InnerPage.Color;
   end;

--- a/contrib/windows/build-installer.iss
+++ b/contrib/windows/build-installer.iss
@@ -145,14 +145,13 @@ begin
   end;
 end;
 
-
 procedure CurPageChanged(CurPageID: Integer);
 begin
   case CurPageID of
     wpWelcome: WizardForm.Color := WizardForm.WelcomePage.Color;
     wpFinished: WizardForm.Color := WizardForm.FinishedPage.Color;
 
-    ;change button text from "next" to "install" when ReadyPage is disabled.
+    //change button text from "next" to "install" when ReadyPage is disabled.
     wpSelectTasks: WizardForm.NextButton.Caption := SetupMessage(msgButtonInstall);
   else
     WizardForm.Color := WizardForm.InnerPage.Color;


### PR DESCRIPTION
closes #48521 
Bug Description-
![PR-Bug-Report](https://user-images.githubusercontent.com/74596419/216816180-be97a85c-63aa-4ab9-b981-705004ffa4d4.jpg)

Here the **Next** button should be replaced with **Install**

the Windows-Installer-Wizard shows the Install button on the ReadyPage of other software
as provided attachments in #48521

Bug Fix-

-now to solve this bug

in builder.iss inno-Setup-Script file the `disablereadypage=yes`  is not making Installation-Wizard reach its readypage .

![PR-Builder](https://user-images.githubusercontent.com/74596419/216816701-b7ae536e-0282-4fa5-bc5e-3a58cdf8aa30.jpg)


so to fix this I gone through Setup guide of Inno-Setup-Script and found the solution
link-[](https://jrsoftware.org/ishelp/index.php?topic=runsection) 

like show here in attachment below

![PR-Inno](https://user-images.githubusercontent.com/74596419/216816867-b8f31d82-af16-49a5-9e08-6e231df9df20.jpg)

