### PR TITLE
add CTRL_R to repl precompile

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -27,6 +27,7 @@ const fancyprint = (stdout isa Base.TTY) && Base.get_bool_env("CI", false) !== t
 ##
 
 CTRL_C = '\x03'
+CTRL_R = '\x12'
 UP_ARROW = "\e[A"
 DOWN_ARROW = "\e[B"
 
@@ -69,6 +70,7 @@ display([1 2; 3 4])
 @time 1+1
 ; pwd
 $CTRL_C
+$CTRL_R$CTRL_C
 ? reinterpret
 using Ra\t$CTRL_C
 \\alpha\t$CTRL_C


### PR DESCRIPTION
This should speed up `reverse-i-search` on the first run of a julia session.  On my system, it normally takes ~650 ms otherwise, which is just enough to be annoying.