### PR TITLE
Correct hbar

### DIFF
--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -2644,6 +2644,7 @@ const symbols_latex_canonical = Dict(
     "ℯ" => "\\euler",
     "♀" => "\\female",
     "≥" => "\\ge",
+    "ℏ" => "\\hbar",
     "⟺" => "\\iff",
     "ℑ" => "\\Im",
     "⟸" => "\\impliedby",

--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -235,7 +235,7 @@ const latex_symbols = Dict(
 
     # Misc. Math and Physics
     "\\ldots" => "…",
-    "\\hbar" => "ħ",
+    "\\hbar" => "ℏ",
     "\\del" => "∇",
 
     "\\sout" => "̶",# ulem package, same as Elzbar


### PR DESCRIPTION
The correct unicode character is ℏ https://www.compart.com/en/unicode/U+210F "Planck Constant Over Two Pi".

However, previously the character was set to ħ https://www.compart.com/en/unicode/U+0127 "Latin Small Letter H with Stroke".
