### PR TITLE
Add docs on task-specific buffering using multithreading

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -246,8 +246,8 @@ For example, the above conditions imply that:
 - Communicating between iterations using blocking primitives like `Channel`s is incorrect.
 - Write only to locations not shared across iterations (unless a lock or atomic operation is
   used).
-- The value of [`threadid()`](@ref Threads.threadid) may change even within a single
-  iteration. See [`Task Migration`](@ref man-task-migration)
+- Unless the `:static` schedule is used, the value of [`threadid()`](@ref Threads.threadid)
+  may change even within a single iteration. See [`Task Migration`](@ref man-task-migration).
 
 ## Schedulers
 


### PR DESCRIPTION
It's common to see people using `threadid()`-based buffers, for instance in a toy sum example
```
function sum_multi(a)
     buffers = zeros(eltype(a), Threads.nthreads())
     Threads.@threads for i in eachindex(a)
         buffers[Threads.threadid()] += a[i]
     end
     s = 0
     for b in buffers
         s += b
     end
     return s
 end
```

but after task migration https://github.com/JuliaLang/julia/pull/40715 (which is undocumented AFAICT) this practice is not race-safe.


This is an attempt to document some best practice.

I expected the `task_local_storage` api to be the right answer here, but I couldn't figure out how to reduce it after the `@threads` loop returned.

Help appreciated in making this correct
