### PR TITLE
return used tls from `@threads` for easier use of `task_local_storage()`

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -95,6 +95,7 @@ function threading_run(fun, static)
     if !isempty(failed_tasks)
         throw(CompositeException(map(TaskFailedException, failed_tasks)))
     end
+    return map(Base.get_task_tls, tasks)
 end
 
 function _threadsfor(iter, lbody, schedule)
@@ -141,13 +142,13 @@ function _threadsfor(iter, lbody, schedule)
         end
         end
         if $(schedule === :dynamic || schedule === :default)
-            threading_run(threadsfor_fun, false)
+            tlss = threading_run(threadsfor_fun, false)
         elseif ccall(:jl_in_threaded_region, Cint, ()) != 0 # :static
             error("`@threads :static` cannot be used concurrently or nested")
         else # :static
-            threading_run(threadsfor_fun, true)
+            tlss = threading_run(threadsfor_fun, true)
         end
-        nothing
+        tlss
     end
 end
 


### PR DESCRIPTION
In thinking about https://github.com/JuliaLang/julia/pull/48542 I wondered maybe `@threads` could return the tls of all the used tasks, which would make `task_local_storage()` easier to use with `@threads`.

Something like
```
julia> function sum_multi(a::Vector{T}) where T
           tlss = Threads.@threads for i in eachindex(a)
               buf = get(task_local_storage(), :buf, zero(T))::T
               task_local_storage()[:buf] = buf + a[i]
           end
           return sum(tls -> tls[:buf]::T, tlss)
       end
sum_multi (generic function with 1 method)

julia> sum_multi(1:1_000_000)
500000500000
```

(Maybe this toy example could be reduced further with smarter `get` usage?)