### PR TITLE
improve error message when an extension fails to load

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1184,8 +1184,7 @@ function run_extension_callbacks(extid::ExtensionId)
         true
     catch
         # Try to continue loading if loading an extension errors
-        errs = current_exceptions()
-        @error "Error during loading of extension" exception=errs
+        @error "Error during loading of extension $(extid.id.name) of $(extid.parentid.name)"
         false
     end
     return succeeded


### PR DESCRIPTION
The exception stack here is completely useless since it just points into this function. The stacktrace for the error during precompiling is already shown.

Made on top of https://github.com/JuliaLang/julia/pull/48513