### PR TITLE
faster `hypot`

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -718,7 +718,7 @@ function normalize(x::T) where T<:IEEEFloat
     ans = (~xi-(one(UT)<<significand_bits(T))) & exponent_mask(T)
     reinterpret(T, ans)
 end
-normalze(x) = inv(x)
+normalize(x) = inv(x)
 
 """
     hypot(x, y)


### PR DESCRIPTION
unconditionally scale `hypot` rather than having separate branches for small/large/normal inputs.