### PR TITLE
Restrict `path` to be an `AbstractString` in `lbt_forward()`

### DIFF
--- a/stdlib/LinearAlgebra/src/lbt.jl
+++ b/stdlib/LinearAlgebra/src/lbt.jl
@@ -207,9 +207,10 @@ function lbt_set_num_threads(nthreads)
     return ccall((:lbt_set_num_threads, libblastrampoline), Cvoid, (Int32,), nthreads)
 end
 
-function lbt_forward(path; clear::Bool = false, verbose::Bool = false, suffix_hint::Union{String,Nothing} = nothing)
+function lbt_forward(path::AbstractString; clear::Bool = false, verbose::Bool = false, suffix_hint::Union{String,Nothing} = nothing)
     _clear_config_with() do
-        return ccall((:lbt_forward, libblastrampoline), Int32, (Cstring, Int32, Int32, Cstring), path, clear ? 1 : 0, verbose ? 1 : 0, something(suffix_hint, C_NULL))
+        return ccall((:lbt_forward, libblastrampoline), Int32, (Cstring, Int32, Int32, Cstring),
+                     path, clear ? 1 : 0, verbose ? 1 : 0, something(suffix_hint, C_NULL))
     end
 end
 


### PR DESCRIPTION
Some users tried to pass a `dlopen()` handle into `lbt_forward()` which sadly works just fine, despite `ccall()` declaring its first argument as being a `Cstring`.  I guess it's trivial to convert a `Ptr{Cvoid}` into a `Cstring`, so this just goes through.

To protect against this, restrict `path` to be an `AbstractString`.

X-ref: https://github.com/JuliaLinearAlgebra/libblastrampoline/issues/102