### PR TITLE
Vectorized isascii using simple loop 25+bytes/cycle for large strings

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -624,9 +624,13 @@ function isascii(s::AbstractString)
     chunk_size = 1024
     bytes = codeunits(s)
     l = ncodeunits(s)
-    l < chunk_size && return _isascii(bytes, 1, l)
-    for n = 1:chunk_size:l
-        _isascii(bytes, n, min(l,n + chunk_size - 1)) || return false
+    start = 1
+    chunk_end = ifelse(l < chunk_size, l, start + chunk_size - 1)
+    fastmin(a,b) = ifelse(a < b, a, b)
+    while start <= l
+        @inline _isascii(bytes, start, chunk_end) || return false
+        start += chunk_size
+        chunk_end = fastmin(l,chunk_end + chunk_size)
     end
     return true
 end

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -622,7 +622,7 @@ isascii(c::AbstractChar) = UInt32(c) < 0x80
 end
 
 #The chunking algorithm makes the last two chunks overlap inorder to keep the size fixed
-@inline function  _isascii_chunks(chunk_size,cu::AbstractVector{CU}, first,last) where {N}
+@inline function  _isascii_chunks(chunk_size,cu::AbstractVector{CU}, first,last) where {CU}
     n=first
     while n <= last - chunk_size
         _isascii(cu,n,n+chunk_size-1) || return false

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -633,8 +633,8 @@ end
 """
     isascii(cu::AbstractVector{CU}) where {CU <: Integer} -> Bool
 
-Test whether all values in the vector belongs to the ASCII character set.
-This function is intended to be used by other sting implimentations that need a fast ASCII check.
+Test whether all values in the vector belong to the ASCII character set (0x00 to 0x7f).
+This function is intended to be used by other string implementations that need a fast ASCII check.
 """
 function isascii(cu::AbstractVector{CU}) where {CU <: Integer}
     chunk_size = 1024

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -630,13 +630,19 @@ end
     end
     return  _isascii(cu,last-chunk_size+1,last)
 end
+"""
+    isascii(cu::AbstractVector{CU}) where {CU <: Integer} -> Bool
 
+Test whether all values in the vector belongs to the ASCII character set.
+This function is intended to be used by other sting implimentations that need a fast ASCII check.
+"""
 function isascii(cu::AbstractVector{CU}) where {CU <: Integer}
     chunk_size = 1024
     chunk_threshold =  chunk_size + (chunk_size ÷ 2)
-    l = length(cu)
-    l < chunk_threshold && return _isascii(cu,1,l)
-    return _isascii_chunks(chunk_size,cu,1,l)
+    first = firstindex(cu);   last = lastindex(cu)
+    l = last - first + 1
+    l < chunk_threshold && return _isascii(cu,first,last)
+    return _isascii_chunks(chunk_size,cu,first,last)
 end
 
 ## string map, filter ##

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -627,7 +627,7 @@ function isascii(s::AbstractString)
     start = 1
     fastmin(a,b) = ifelse(a < b, a, b)
     while start <= l
-        @inline _isascii(bytes, start, fastmin(l, start + chunk_size)) || return false
+        @inline _isascii(bytes, start, fastmin(l, start+chunk_size-1)) || return false
         start += chunk_size
     end
     return true

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -622,7 +622,7 @@ isascii(c::AbstractChar) = UInt32(c) < 0x80
 end
 
 #The chunking algorithm makes the last two chunks overlap inorder to keep the size fixed
-@inline function  _isascii_chunks(chunk_size,cu::AbstractVector{CU}, first,last) where {N,CU}
+@inline function  _isascii_chunks(chunk_size,cu::AbstractVector{CU}, first,last) where {N}
     n=first
     while n <= last - chunk_size
         _isascii(cu,n,n+chunk_size-1) || return false

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -636,7 +636,6 @@ function isascii(cu::AbstractVector{CU}) where {CU <: Integer}
     chunk_threshold =  chunk_size + (chunk_size ÷ 2)
     l = length(cu)
     l < chunk_threshold && return _isascii(cu,1,l)
-    # return _isascii_chunks(chunk_size,cu,1,l)
     return _isascii_chunks(Val(chunk_size),cu,1,l)
 end
 

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -610,8 +610,16 @@ julia> replace("abcdeγfgh", !isascii=>' ') # replace non-ASCII chars with space
 ```
 """
 isascii(c::Char) = bswap(reinterpret(UInt32, c)) < 0x80
-isascii(s::AbstractString) = all(isascii, s)
 isascii(c::AbstractChar) = UInt32(c) < 0x80
+function isascii(s::AbstractString)
+    bytes = codeunits(s)
+    l = ncodeunits(s)
+    ret = true
+    for n = 1:l
+        @inbounds ret &= bytes[n] < UInt8(0x80)
+    end
+    return ret
+end
 
 ## string map, filter ##
 

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -626,7 +626,7 @@ function isascii(s::AbstractString)
     l = ncodeunits(s)
     l < chunk_size && return _isascii(bytes, 1, l)
     for n = 1:chunk_size:l
-        _isascii(bytes, n, n + chunk_size - 1) || return false
+        _isascii(bytes, n, min(l,n + chunk_size - 1)) || return false
     end
     return true
 end

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -610,6 +610,7 @@ julia> replace("abcdeγfgh", !isascii=>' ') # replace non-ASCII chars with space
 ```
 """
 isascii(c::Char) = bswap(reinterpret(UInt32, c)) < 0x80
+isascii(s::AbstractString) = all(isascii, s)
 isascii(c::AbstractChar) = UInt32(c) < 0x80
 
 function _isascii(code_units::AbstractVector{CU}, first, last) where {CU}
@@ -620,11 +621,9 @@ function _isascii(code_units::AbstractVector{CU}, first, last) where {CU}
     return r < 0x80
 end
 
-
-function isascii(s::AbstractString)
+function isascii(code_units::AbstractVector{CU}) where {CU <: Integer}
     chunk_size = 1024
-    code_units = codeunits(s)
-    l = ncodeunits(s)
+    l = length(code_units)
     start = 1
     fastmin(a,b) = ifelse(a < b, a, b)
     while start <= l
@@ -633,7 +632,6 @@ function isascii(s::AbstractString)
     end
     return true
 end
-
 
 ## string map, filter ##
 

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -612,23 +612,23 @@ julia> replace("abcdeγfgh", !isascii=>' ') # replace non-ASCII chars with space
 isascii(c::Char) = bswap(reinterpret(UInt32, c)) < 0x80
 isascii(c::AbstractChar) = UInt32(c) < 0x80
 
-function _isascii(bytes::AbstractVector{UInt8}, first, last)
-    r = UInt8(0)
+function _isascii(code_units::AbstractVector{CU}, first, last) where {CU}
+    r = zero(CU)
     for n = first:last
-        @inbounds r |= bytes[n]
+        @inbounds r |= code_units[n]
     end
     return r < 0x80
 end
-_isascii(notbytes, first, last) = false #If the CodeUnits are not UInt8 it can not be ascii
+
 
 function isascii(s::AbstractString)
     chunk_size = 1024
-    bytes = codeunits(s)
+    code_units = codeunits(s)
     l = ncodeunits(s)
     start = 1
     fastmin(a,b) = ifelse(a < b, a, b)
     while start <= l
-        @inline _isascii(bytes, start, fastmin(l, start+chunk_size-1)) || return false
+        @inline _isascii(code_units, start, fastmin(l, start+chunk_size-1)) || return false
         start += chunk_size
     end
     return true

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -612,13 +612,14 @@ julia> replace("abcdeγfgh", !isascii=>' ') # replace non-ASCII chars with space
 isascii(c::Char) = bswap(reinterpret(UInt32, c)) < 0x80
 isascii(c::AbstractChar) = UInt32(c) < 0x80
 
-function _isascii(bytes, first, last)
+function _isascii(bytes::AbstractVector{UInt8}, first, last)
     r = UInt8(0)
     for n = first:last
         @inbounds r |= bytes[n]
     end
     return r < 0x80
 end
+_isascii(notbytes, first, last) = false #If the CodeUnits are not UInt8 it can not be ascii
 
 function isascii(s::AbstractString)
     chunk_size = 1024
@@ -627,7 +628,7 @@ function isascii(s::AbstractString)
     start = 1
     fastmin(a,b) = ifelse(a < b, a, b)
     while start <= l
-        @inline _isascii(bytes, start, fastmin(l, start + chunk_size)) || return false
+        @inline _isascii(bytes, start, fastmin(l, start+chunk_size-1)) || return false
         start += chunk_size
     end
     return true

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -326,13 +326,6 @@ end
 
 isvalid(s::String, i::Int) = checkbounds(Bool, s, i) && thisind(s, i) == i
 
-function isascii(s::String)
-    @inbounds for i = 1:ncodeunits(s)
-        codeunit(s, i) >= 0x80 && return false
-    end
-    return true
-end
-
 """
     repeat(c::AbstractChar, r::Integer) -> String
 

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -326,6 +326,8 @@ end
 
 isvalid(s::String, i::Int) = checkbounds(Bool, s, i) && thisind(s, i) == i
 
+isascii(s::String) = isascii(codeunits(s))
+
 """
     repeat(c::AbstractChar, r::Integer) -> String
 

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -92,6 +92,8 @@ function getindex(s::SubString, i::Integer)
     @inbounds return getindex(s.string, s.offset + i)
 end
 
+isascii(ss::SubString{String}) = isascii(codeunits(ss))
+
 function isvalid(s::SubString, i::Integer)
     ib = true
     @boundscheck ib = checkbounds(Bool, s, i)

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -1119,6 +1119,32 @@ end
     @test sprint(summary, "") == "empty String"
 end
 
+@testset "isascii" begin
+    N=1
+    @test isascii("S"^N) = true
+    @test isascii("S"^(N - 1)) = true
+    @test isascii("S"^(N + 1)) = true
+
+    @test isascii("λ"*("S"^(N))) = false
+    @test isascii(("S"^(N))*"λ") = false
+
+    for p = 1:16
+        N = 2^p
+        @test isascii("S"^N) = true
+        @test isascii("S"^(N - 1)) = true
+        @test isascii("S"^(N + 1)) = true
+
+        @test isascii("λ" * ("S"^(N))) = false
+        @test isascii(("S"^(N)) * "λ") = false
+        @test isascii("λ"*("S"^(N - 1))) = false
+        @test isascii(("S"^(N - 1)) * "λ") = false
+        if N > 4
+            @test isascii("λ" * ("S"^(N - 3))) = false
+            @test isascii(("S"^(N - 3)) * "λ") = false
+        end
+    end
+end
+
 @testset "Plug holes in test coverage" begin
     @test_throws MethodError checkbounds(Bool, "abc", [1.0, 2.0])
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -1120,27 +1120,27 @@ end
 end
 
 @testset "isascii" begin
-    N=1
-    @test isascii("S"^N) = true
-    @test isascii("S"^(N - 1)) = true
-    @test isascii("S"^(N + 1)) = true
+    N = 1
+    @test isascii("S"^N) == true
+    @test isascii("S"^(N - 1)) == true
+    @test isascii("S"^(N + 1)) == true
 
-    @test isascii("λ"*("S"^(N))) = false
-    @test isascii(("S"^(N))*"λ") = false
+    @test isascii("λ" * ("S"^(N))) == false
+    @test isascii(("S"^(N)) * "λ") == false
 
     for p = 1:16
         N = 2^p
-        @test isascii("S"^N) = true
-        @test isascii("S"^(N - 1)) = true
-        @test isascii("S"^(N + 1)) = true
+        @test isascii("S"^N) == true
+        @test isascii("S"^(N - 1)) == true
+        @test isascii("S"^(N + 1)) == true
 
-        @test isascii("λ" * ("S"^(N))) = false
-        @test isascii(("S"^(N)) * "λ") = false
-        @test isascii("λ"*("S"^(N - 1))) = false
-        @test isascii(("S"^(N - 1)) * "λ") = false
+        @test isascii("λ" * ("S"^(N))) == false
+        @test isascii(("S"^(N)) * "λ") == false
+        @test isascii("λ"*("S"^(N - 1))) == false
+        @test isascii(("S"^(N - 1)) * "λ") == false
         if N > 4
-            @test isascii("λ" * ("S"^(N - 3))) = false
-            @test isascii(("S"^(N - 3)) * "λ") = false
+            @test isascii("λ" * ("S"^(N - 3))) == false
+            @test isascii(("S"^(N - 3)) * "λ") == false
         end
     end
 end


### PR DESCRIPTION
This changes `isascii` to a simple loop that checks the whole string.   LLVM is doing a disturbingly good job vectorizing this function which slightly hurts it with small strings because the overhead of loading the function is higher.  The benchmarking below shows that the loop-based method is 50x faster than the current method.

The funny thing is that I had a fancy `isascii` built to use the `UInt64` trick, and was just doing some final benchmarking when I realized the simple loop gave the best results.    This does make me a little worried that the result here is very sensitive to the optimizations that it gets.

Another note is that any attempts at checking early if the string has encountered a non ASCII character just dramatically slows down the overall function.


**UPDATE***
*as per @oscardssmith  `isascii`  now looks at chunks.  I did a little optimization and 1024 seemed to be the right size. 

`isascii`  is the version now in this PR and was refined by @matthias314  

The benchmark should be an average of the two extremes 1. All ascii 2.) non asci first character

benchmark code
```julia
using BenchmarkTools
function benchmark_isascii(fun)
    for p=1:14
        n = (2 * 2^(p-1))-1
        s='S'^n
        s2 = 'λ' * 'S'^(n-1)
        b = @benchmark $fun($s)&$fun($s2) seconds=1
        cpu_info = Sys.cpu_info()
        cpu_ghz= mean(i.speed for i in Sys.cpu_info()) /1_000
        parse_time_ns = time(median(b))
        GB_per_second= 2*n / parse_time_ns
        bytes_per_cycle = GB_per_second / cpu_ghz
        print("$fun -> $n bytes $GB_per_second GB/second @ $cpu_ghz GHz -> $bytes_per_cycle bytes/cycle\n")
    end
end
##
function isascii_nochunks(s::AbstractString)
    bytes = codeunits(s)
    l = ncodeunits(s)
    r = UInt8(0)
    for n = 1:l
        @inbounds r |= bytes[n]
    end
    return r < 0x80
end

function _isascii(bytes, first, last)
    r = UInt8(0)
    for n = first:last
        @inbounds r |= bytes[n]
    end
    return r < 0x80
end

function isascii(s::AbstractString)
    chunk_size = 1024
    bytes = codeunits(s)
    l = ncodeunits(s)
    start = 1
    fastmin(a,b) = ifelse(a < b, a, b)
    while start <= l
        @inline _isascii(bytes, start, fastmin(l, start + chunk_size)) || return false
        start += chunk_size
    end
    return true
end

isascii_all(c::Char) = bswap(reinterpret(UInt32, c)) < 0x80
isascii_all(s::AbstractString) = all(isascii_all, s)
isascii_all(c::AbstractChar) = UInt32(c) < 0x80

##
 benchmark_isascii(isascii_all)
##
 benchmark_isascii(isascii_nochunks)
##
 benchmark_isascii(isascii)
##
```
results
```
isascii_all -> 1 bytes 0.06623796354912871 GB/second @ 2.7 GHz -> 0.024532579092269892 bytes/cycle
isascii_all -> 3 bytes 0.21423568080176733 GB/second @ 2.7 GHz -> 0.079346548445099 bytes/cycle
isascii_all -> 7 bytes 0.3949880668257757 GB/second @ 2.7 GHz -> 0.14629187660213913 bytes/cycle
isascii_all -> 15 bytes 0.7953936797000536 GB/second @ 2.7 GHz -> 0.2945902517407606 bytes/cycle
isascii_all -> 31 bytes 1.3267578400808178 GB/second @ 2.7 GHz -> 0.4913917926225251 bytes/cycle
isascii_all -> 63 bytes 1.792814953381155 GB/second @ 2.7 GHz -> 0.6640055382893166 bytes/cycle
isascii_all -> 127 bytes 2.0539571873077573 GB/second @ 2.7 GHz -> 0.7607248841880582 bytes/cycle
isascii_all -> 255 bytes 2.442238909701151 GB/second @ 2.7 GHz -> 0.9045329295189447 bytes/cycle
isascii_all -> 511 bytes 2.66197056596995 GB/second @ 2.7 GHz -> 0.9859150244333148 bytes/cycle
isascii_all -> 1023 bytes 2.7845331630383012 GB/second @ 2.7 GHz -> 1.0313085789030745 bytes/cycle
isascii_all -> 2047 bytes 2.8371448371448373 GB/second @ 2.7 GHz -> 1.0507943841277174 bytes/cycle
isascii_all -> 4095 bytes 2.8627466210967842 GB/second @ 2.7 GHz -> 1.0602765263321423 bytes/cycle
isascii_all -> 8191 bytes 2.893238748417861 GB/second @ 2.7 GHz -> 1.07156990682143 bytes/cycle
isascii_all -> 16383 bytes 2.8853469531525184 GB/second @ 2.7 GHz -> 1.068647019686118 bytes/cycle

isascii_nochunks -> 1 bytes 0.16941096588015617 GB/second @ 2.7 GHz -> 0.06274480217783561 bytes/cycle
isascii_nochunks -> 3 bytes 0.44490675384501077 GB/second @ 2.7 GHz -> 0.16478027920185584 bytes/cycle
isascii_nochunks -> 7 bytes 0.8653977307954616 GB/second @ 2.7 GHz -> 0.3205176780723932 bytes/cycle
isascii_nochunks -> 15 bytes 1.569987389659521 GB/second @ 2.7 GHz -> 0.5814768109850077 bytes/cycle
isascii_nochunks -> 31 bytes 2.8405009669398655 GB/second @ 2.7 GHz -> 1.0520373951629132 bytes/cycle
isascii_nochunks -> 63 bytes 5.303299492385786 GB/second @ 2.7 GHz -> 1.9641849971799208 bytes/cycle
isascii_nochunks -> 127 bytes 10.465010351966875 GB/second @ 2.7 GHz -> 3.875929759987731 bytes/cycle
isascii_nochunks -> 255 bytes 18.675950486295314 GB/second @ 2.7 GHz -> 6.917018698627894 bytes/cycle
isascii_nochunks -> 511 bytes 34.2668152350081 GB/second @ 2.7 GHz -> 12.691413050003 bytes/cycle
isascii_nochunks -> 1023 bytes 58.472315145922245 GB/second @ 2.7 GHz -> 21.656413017008237 bytes/cycle
isascii_nochunks -> 2047 bytes 76.48904580152671 GB/second @ 2.7 GHz -> 28.32927622278767 bytes/cycle
isascii_nochunks -> 4095 bytes 97.76940343334071 GB/second @ 2.7 GHz -> 36.21089016049656 bytes/cycle
isascii_nochunks -> 8191 bytes 99.35550547582335 GB/second @ 2.7 GHz -> 36.79833536141605 bytes/cycle
isascii_nochunks -> 16383 bytes 98.05788949825984 GB/second @ 2.7 GHz -> 36.31773685120734 bytes/cycle

isascii -> 1 bytes 0.12132643748098569 GB/second @ 2.7 GHz -> 0.044935717585550254 bytes/cycle
isascii -> 3 bytes 0.31225833420420107 GB/second @ 2.7 GHz -> 0.11565123489044483 bytes/cycle
isascii -> 7 bytes 0.6210432456531431 GB/second @ 2.7 GHz -> 0.23001601690857149 bytes/cycle
isascii -> 15 bytes 1.2457223937901678 GB/second @ 2.7 GHz -> 0.4613786643667288 bytes/cycle
isascii -> 31 bytes 2.430222011908987 GB/second @ 2.7 GHz -> 0.900082226632958 bytes/cycle
isascii -> 63 bytes 4.547217078749592 GB/second @ 2.7 GHz -> 1.6841544736109597 bytes/cycle
isascii -> 127 bytes 8.880743635787473 GB/second @ 2.7 GHz -> 3.289164309550916 bytes/cycle
isascii -> 255 bytes 15.564374711582834 GB/second @ 2.7 GHz -> 5.76458322651216 bytes/cycle
isascii -> 511 bytes 30.51297732921594 GB/second @ 2.7 GHz -> 11.301102714524422 bytes/cycle
isascii -> 1023 bytes 42.45936692642148 GB/second @ 2.7 GHz -> 15.725691454230176 bytes/cycle
isascii -> 2047 bytes 79.80871569659996 GB/second @ 2.7 GHz -> 29.558783591333317 bytes/cycle
isascii -> 4095 bytes 113.6582026746599 GB/second @ 2.7 GHz -> 42.09563062024441 bytes/cycle
isascii -> 8191 bytes 136.41434343065026 GB/second @ 2.7 GHz -> 50.52383090024083 bytes/cycle
isascii -> 16383 bytes 156.27125780921037 GB/second @ 2.7 GHz -> 57.878243633040874 bytes/cycle
```


