### PR TITLE
build: add libjulia-internal symlink as dependency for libjulia-codegen

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -382,6 +382,8 @@ $(build_shlibdir)/libjulia-internal.$(JL_MAJOR_SHLIB_EXT) $(build_shlibdir)/libj
 $(build_shlibdir)/libjulia-internal.$(SHLIB_EXT) $(build_shlibdir)/libjulia-internal-debug.$(SHLIB_EXT): $(build_shlibdir)/libjulia-internal%.$(SHLIB_EXT): \
 		$(build_shlibdir)/libjulia-internal%.$(JL_MAJOR_MINOR_SHLIB_EXT)
 	@$(call PRINT_LINK, ln -sf $(notdir $<) $@)
+$(build_shlibdir)/libjulia-codegen.$(JL_MAJOR_MINOR_SHLIB_EXT): $(build_shlibdir)/libjulia-internal.$(SHLIB_EXT)
+$(build_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_MINOR_SHLIB_EXT): $(build_shlibdir)/libjulia-internal-debug.$(SHLIB_EXT)
 libjulia-internal-release: $(build_shlibdir)/libjulia-internal.$(JL_MAJOR_SHLIB_EXT) $(build_shlibdir)/libjulia-internal.$(SHLIB_EXT)
 libjulia-internal-debug: $(build_shlibdir)/libjulia-internal-debug.$(JL_MAJOR_SHLIB_EXT) $(build_shlibdir)/libjulia-internal-debug.$(SHLIB_EXT)
 endif


### PR DESCRIPTION
The `libjulia-internal.$(SHLIB_EXT)` symlink is required by ld (on UNIX) to build `libjulia-codegen.$(JL_MAJOR_MINOR_SHLIB_EXT)`, but it is not a dependency for the codegen library directly, only for the `libjulia-internal-release` target.

This might fix race conditions during make, e.g. this one mentioned by @giordano on slack: https://buildkite.com/julialang/julia-master/builds/20784#0186285e-604e-41dd-8965-53a78b40d0f2/445-1120

Currently the error can be triggered manually like this:

    $ rm <somepath>/usr/lib/libjulia-*
    $ make -C src <somepath>/usr/lib/libjulia-internal.so.1.10
    make: Entering directory '<somepath>/src'
        LINK usr/lib/libjulia-internal.so.1.10
    true -ignore <somepath>/usr/lib/libjulia-internal.so.1.10
    make: Leaving directory '<somepath>/src'
    $ make -C src <somepath>/usr/lib/libjulia-codegen.so.1.10
    make: Entering directory '<somepath>/src'
        LINK usr/lib/libjulia-codegen.so.1.10
    ld: cannot find -ljulia-internal: No such file or directory
    collect2: error: ld returned 1 exit status
    make: *** [Makefile:393: <somepath>/usr/lib/libjulia-codegen.so.1.10] Error 1
    make: Leaving directory '<somepath>/src'

I considered changing the input for rule below but that would probably break the windows build.
