### PR TITLE
keep undefinedness of static parameters as a separate field

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2192,11 +2192,7 @@ function abstract_eval_value_expr(interp::AbstractInterpreter, e::Expr, vtypes::
         nothrow = false
         if 1 <= n <= length(sv.sptypes)
             rt = sv.sptypes[n]
-            if is_maybeundefsp(rt)
-                rt = unwrap_maybeundefsp(rt)
-            else
-                nothrow = true
-            end
+            nothrow = !sv.spundefs[n]
         end
         merge_effects!(interp, sv, Effects(EFFECTS_TOTAL; nothrow))
         return rt
@@ -2460,7 +2456,7 @@ function abstract_eval_statement_expr(interp::AbstractInterpreter, e::Expr, vtyp
         elseif isexpr(sym, :static_parameter)
             n = sym.args[1]::Int
             if 1 <= n <= length(sv.sptypes)
-                if !is_maybeundefsp(sv.sptypes, n)
+                if !sv.spundefs[n]
                     t = Const(true)
                 end
             end

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -335,18 +335,20 @@ struct IRCode
     stmts::InstructionStream
     argtypes::Vector{Any}
     sptypes::Vector{Any}
+    spundefs::BitVector
     linetable::Vector{LineInfoNode}
     cfg::CFG
     new_nodes::NewNodeStream
     meta::Vector{Expr}
 
-    function IRCode(stmts::InstructionStream, cfg::CFG, linetable::Vector{LineInfoNode}, argtypes::Vector{Any}, meta::Vector{Expr}, sptypes::Vector{Any})
-        return new(stmts, argtypes, sptypes, linetable, cfg, NewNodeStream(), meta)
+    function IRCode(stmts::InstructionStream, cfg::CFG, linetable::Vector{LineInfoNode},
+                    argtypes::Vector{Any}, meta::Vector{Expr}, sptypes::Vector{Any}, spundefs::BitVector)
+        return new(stmts, argtypes, sptypes, spundefs, linetable, cfg, NewNodeStream(), meta)
     end
     function IRCode(ir::IRCode, stmts::InstructionStream, cfg::CFG, new_nodes::NewNodeStream)
-        return new(stmts, ir.argtypes, ir.sptypes, ir.linetable, cfg, new_nodes, ir.meta)
+        return new(stmts, ir.argtypes, ir.sptypes, ir.spundefs, ir.linetable, cfg, new_nodes, ir.meta)
     end
-    global copy(ir::IRCode) = new(copy(ir.stmts), copy(ir.argtypes), copy(ir.sptypes),
+    global copy(ir::IRCode) = new(copy(ir.stmts), copy(ir.argtypes), copy(ir.sptypes), copy(ir.spundefs),
         copy(ir.linetable), copy(ir.cfg), copy(ir.new_nodes), copy(ir.meta))
 end
 
@@ -358,7 +360,7 @@ for debugging and unit testing of IRCode APIs. The compiler itself should genera
 from the frontend or one of the caches.
 """
 function IRCode()
-    ir = IRCode(InstructionStream(1), CFG([BasicBlock(1:1, Int[], Int[])], Int[1]), LineInfoNode[], Any[], Expr[], Any[])
+    ir = IRCode(InstructionStream(1), CFG([BasicBlock(1:1, Int[], Int[])], Int[1]), LineInfoNode[], Any[], Expr[], Any[], falses(0))
     ir[SSAValue(1)][:inst] = ReturnNode(nothing)
     ir[SSAValue(1)][:type] = Nothing
     ir[SSAValue(1)][:flag] = 0x00

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -216,7 +216,7 @@ end
 function typ_for_val(@nospecialize(x), ci::CodeInfo, sptypes::Vector{Any}, idx::Int, slottypes::Vector{Any})
     if isa(x, Expr)
         if x.head === :static_parameter
-            return unwrap_maybeundefsp(sptypes, x.args[1]::Int)
+            return sptypes[x.args[1]::Int]
         elseif x.head === :boundscheck
             return Bool
         elseif x.head === :copyast

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -699,7 +699,7 @@ end
 
 @testset "code_llvm on opaque_closure" begin
     let ci = code_typed(+, (Int, Int))[1][1]
-        ir = Core.Compiler.inflate_ir(ci, Any[], Any[Tuple{}, Int, Int])
+        ir = Core.Compiler.inflate_ir(ci, Any[], Core.Compiler.falses(0), Any[Tuple{}, Int, Int])
         oc = Core.OpaqueClosure(ir)
         @test (code_llvm(devnull, oc, Tuple{Int, Int}); true)
         let io = IOBuffer()

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -710,7 +710,7 @@ let m = Meta.@lower 1 + 1
     nstmts = length(src.code)
     src.codelocs = fill(Int32(1), nstmts)
     src.ssaflags = fill(Int32(0), nstmts)
-    ir = Core.Compiler.inflate_ir(src, Any[], Any[Any, Any])
+    ir = Core.Compiler.inflate_ir(src, Any[], Core.Compiler.falses(0), Any[Any, Any])
     @test Core.Compiler.verify_ir(ir) === nothing
     ir = @test_nowarn Core.Compiler.sroa_pass!(ir)
     @test Core.Compiler.verify_ir(ir) === nothing

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -117,7 +117,7 @@ let cfg = CFG(BasicBlock[
     make_bb([2, 3]    , []    ),
 ], Int[])
     insts = Compiler.InstructionStream([], [], Any[], Int32[], UInt8[])
-    code = Compiler.IRCode(insts, cfg, LineInfoNode[], [], Expr[], [])
+    code = Compiler.IRCode(insts, cfg, LineInfoNode[], [], Expr[], [], Core.Compiler.falses(0))
     compact = Compiler.IncrementalCompact(code, true)
     @test length(compact.result_bbs) == 4 && 0 in compact.result_bbs[3].preds
 end

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -247,7 +247,7 @@ let ci = code_typed(+, (Int, Int))[1][1]
     @test OpaqueClosure(ir; nargs=2, isva=false)(40, 2) == 42
     @test OpaqueClosure(ci)(40, 2) == 42
 
-    ir = Core.Compiler.inflate_ir(ci, Any[], Any[Tuple{}, Int, Int])
+    ir = Core.Compiler.inflate_ir(ci, Any[], Core.Compiler.falses(0), Any[Tuple{}, Int, Int])
     @test OpaqueClosure(ir; nargs=2, isva=false)(40, 2) == 42
     @test isa(OpaqueClosure(ir; nargs=2, isva=false), Core.OpaqueClosure{Tuple{Int, Int}, Int})
     @test_throws TypeError OpaqueClosure(ir; nargs=2, isva=false)(40.0, 2)
@@ -264,7 +264,7 @@ let ci = code_typed((x, y...)->(x, y), (Int, Int))[1][1]
         @test_throws MethodError oc(1,2,3)
     end
 
-    ir = Core.Compiler.inflate_ir(ci, Any[], Any[Tuple{}, Int, Tuple{Int}])
+    ir = Core.Compiler.inflate_ir(ci, Any[], Core.Compiler.falses(0), Any[Tuple{}, Int, Tuple{Int}])
     let oc = OpaqueClosure(ir; nargs=2, isva=true)
         @test oc(40, 2) === (40, (2,))
         @test_throws MethodError oc(1,2,3)


### PR DESCRIPTION
This is an alternative to #46791.
Will be filed as a PR to check the performance difference.

@nanosoldier `runbenchmarks("inference", vs=":master")`