### PR TITLE
subtyping: Relax conditions for separable tuple fast-path

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1073,7 +1073,7 @@ static int subtype_tuple_tail(jl_datatype_t *xd, jl_datatype_t *yd, int8_t R, jl
              (yi == lastx && !vx && vy && jl_is_concrete_type(xi)))) {
             // fast path for repeated elements
         }
-        else if (e->Runions.depth == 0 && e->Lunions.depth == 0 && !jl_has_free_typevars(xi) && !jl_has_free_typevars(yi)) {
+        else if (e->Runions.depth == 0 && !jl_has_free_typevars(xi) && !jl_has_free_typevars(yi)) {
             // fast path for separable sub-formulas
             if (!jl_subtype(xi, yi))
                 return 0;


### PR DESCRIPTION
Let's see if PkgEval/CI agree with me that this check is unnecessary 🤞 

I'm also working on a more substantial change that should allow us to exploit separability even when the LHS check currently fails, but I wanted to kick things off with this simple change.