### PR TITLE
Threads: add a one time warning to a no-arg `nthreads()`

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -333,10 +333,10 @@ end
 
 @eval Threads function nthreads()
     @warn """
-    In julia 1.9+ which supports threadpools (see [link to docs])
+    In julia 1.9+ which supports threadpools (and changing threadpool sizes during runtime),
     use of threads should be in the context of which threadpool is going to be used, so `nthreads()` should be
-    replaced with `nthreads(:default)`, or `nthreads(:interactive)` if interactive threads are requrested.""" maxlog = 1
-    threadpoolsize()
+    replaced with `nthreads(:default)`, or `task_local_storage`, as appropriate.""" maxlog = 1
+    return threadpoolsize()
 end
 
 @eval Threads begin

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -331,7 +331,13 @@ function setproperty!(ci::CodeInfo, s::Symbol, v)
     return setfield!(ci, s, convert(fieldtype(CodeInfo, s), v))
 end
 
-@eval Threads nthreads() = threadpoolsize()
+@eval Threads function nthreads()
+    @warn """
+    In julia 1.9+ which supports threadpools (see [link to docs])
+    use of threads should be in the context of which threadpool is going to be used, so `nthreads()` should be
+    replaced with `nthreads(:default)`, or `nthreads(:interactive)` if interactive threads are requrested.""" maxlog = 1
+    threadpoolsize()
+end
 
 @eval Threads begin
     """

--- a/base/task.jl
+++ b/base/task.jl
@@ -458,7 +458,7 @@ a [`CompositeException`](@ref).
 
 # Examples
 ```julia-repl
-julia> Threads.nthreads()
+julia> Threads.nthreads(:default)
 4
 
 julia> @sync begin

--- a/doc/src/manual/multi-threading.md
+++ b/doc/src/manual/multi-threading.md
@@ -9,7 +9,7 @@ By default, Julia starts up with a single thread of execution. This can be verif
 command [`Threads.nthreads()`](@ref):
 
 ```jldoctest
-julia> Threads.nthreads()
+julia> Threads.nthreads(:default)
 1
 ```
 
@@ -38,7 +38,7 @@ $ julia --threads 4
 Let's verify there are 4 threads at our disposal.
 
 ```julia-repl
-julia> Threads.nthreads()
+julia> Threads.nthreads(:default)
 4
 ```
 
@@ -104,7 +104,7 @@ the `:interactive` threadpool:
 ```julia-repl
 julia> using Base.Threads
 
-julia> nthreads()
+julia> nthreads(:default)
 4
 
 julia> nthreadpools()
@@ -267,7 +267,7 @@ avoid the race:
 ```julia-repl
 julia> using Base.Threads
 
-julia> Threads.nthreads()
+julia> Threads.nthreads(:default)
 4
 
 julia> acc = Ref(0)

--- a/stdlib/Profile/test/allocs.jl
+++ b/stdlib/Profile/test/allocs.jl
@@ -21,7 +21,7 @@ end
     # This test is only really meaningful if we're running on
     # multiple threads, but this isn't true on the windows tests,
     # causing them to fail. So, commenting this assertion out.
-    # @test Threads.nthreads() > 1
+    # @test Threads.nthreads(:default) > 1
 
     function do_work()
         ch = Channel{Vector{Float64}}(Inf)


### PR DESCRIPTION
It seems helpful to communicate the (soft) deprecation of a no-arg `nthreads()` a bit more clearly.

re. https://github.com/JuliaLang/julia/issues/48580#issuecomment-1421163616