### PR TITLE
force singlethreading during precompilation

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2068,10 +2068,10 @@ function create_expr_cache(pkg::PkgId, input::String, output::String, output_o::
     io = open(pipeline(addenv(`$(julia_cmd(;cpu_target)::Cmd) $(opts)
                               --startup-file=no --history-file=no --warn-overwrite=yes
                               --color=$(have_color === nothing ? "auto" : have_color ? "yes" : "no")
-                              -t1
                               $trace
                               -`,
-                              "OPENBLAS_NUM_THREADS" => 1),
+                              "OPENBLAS_NUM_THREADS" => 1,
+                              "JULIA_NUM_THREADS" => 1),
                        stderr = internal_stderr, stdout = internal_stdout),
               "w", stdout)
     # write data over stdin to avoid the (unlikely) case of exceeding max command line size

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2068,6 +2068,7 @@ function create_expr_cache(pkg::PkgId, input::String, output::String, output_o::
     io = open(pipeline(addenv(`$(julia_cmd(;cpu_target)::Cmd) $(opts)
                               --startup-file=no --history-file=no --warn-overwrite=yes
                               --color=$(have_color === nothing ? "auto" : have_color ? "yes" : "no")
+                              -t1
                               $trace
                               -`,
                               "OPENBLAS_NUM_THREADS" => 1),


### PR DESCRIPTION
Only allowing 1 julia thread during precompiling packages makes sense in the context that
- `Pkg.precompile` manages multi-processing, and any multithreading during precompilation risks overloading the system
- The upcoming LLVM image parallel PR https://github.com/JuliaLang/julia/pull/47797 has it's own `JULIA_IMAGE_THREADS` env var for controlling that multithreading, which `Pkg.precompile` will be taught to manage

And a niche issue:
- Allowing multiple threads (as julia currently does) causes all threads to light up in modes where no sysimage is present: https://github.com/JuliaLang/PackageCompiler.jl/issues/778 

A pkgeval run would probably be a good idea for this