### PR TITLE
remove `REPL.__init__`

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -517,11 +517,12 @@ function docm(source::LineNumberNode, mod::Module, ex)
     @nospecialize ex
     if isexpr(ex, :->) && length(ex.args) > 1
         return docm(source, mod, ex.args...)
-    else
+    elseif isassigned(Base.REPL_MODULE_REF)
         # TODO: this is a shim to continue to allow `@doc` for looking up docstrings
         REPL = Base.REPL_MODULE_REF[]
         return REPL.lookup_doc(ex)
     end
+    return nothing
 end
 # Drop incorrect line numbers produced by nested macro calls.
 docm(source::LineNumberNode, mod::Module, _, _, x...) = docm(source, mod, x...)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1637,6 +1637,8 @@ end
 
 require(uuidkey::PkgId) = @lock require_lock _require_prelocked(uuidkey)
 
+const REPL_PKGID = PkgId(UUID("3fa0cd96-eef1-5676-8a61-b3b8758bbffb"), "REPL")
+
 function _require_prelocked(uuidkey::PkgId, env=nothing)
     assert_havelock(require_lock)
     if !root_module_exists(uuidkey)
@@ -1648,6 +1650,9 @@ function _require_prelocked(uuidkey::PkgId, env=nothing)
         insert_extension_triggers(uuidkey)
         # After successfully loading, notify downstream consumers
         run_package_callbacks(uuidkey)
+        if uuidkey == REPL_PKGID
+            REPL_MODULE_REF[] = newm
+        end
     else
         newm = root_module(uuidkey)
     end

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -71,10 +71,6 @@ include("docview.jl")
 
 @nospecialize # use only declared type signatures
 
-function __init__()
-    Base.REPL_MODULE_REF[] = REPL
-end
-
 answer_color(::AbstractREPL) = ""
 
 const JULIA_PROMPT = "julia> "


### PR DESCRIPTION
Some packages depend on `REPL_MODULE_REF` being set, which does not work in a compilation process where `__init__` methods don't run. It would have been better to use a function like `get_repl_if_available()`, but here we are.

A related problem is that `@doc` is exported by Base, but all the code for it is actually in the REPL. I found this interesting use case in RuntimeGeneratedFunctions:
```
# Duplicate RuntimeGeneratedFunction docs onto @RuntimeGeneratedFunction
@eval @doc $(@doc RuntimeGeneratedFunction) var"@RuntimeGeneratedFunction"
```
In hindsight, we should have a simple function to get or duplicate a doc string without requiring a lot of REPL code.