### PR TITLE
inference: use `VarState` to represent static parameter

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2191,12 +2191,9 @@ function abstract_eval_value_expr(interp::AbstractInterpreter, e::Expr, vtypes::
         n = e.args[1]::Int
         nothrow = false
         if 1 <= n <= length(sv.sptypes)
-            rt = sv.sptypes[n]
-            if is_maybeundefsp(rt)
-                rt = unwrap_maybeundefsp(rt)
-            else
-                nothrow = true
-            end
+            sp = sv.sptypes[n]
+            rt = sp.typ
+            nothrow = !sp.undef
         end
         merge_effects!(interp, sv, Effects(EFFECTS_TOTAL; nothrow))
         return rt
@@ -2460,8 +2457,11 @@ function abstract_eval_statement_expr(interp::AbstractInterpreter, e::Expr, vtyp
         elseif isexpr(sym, :static_parameter)
             n = sym.args[1]::Int
             if 1 <= n <= length(sv.sptypes)
-                if !is_maybeundefsp(sv.sptypes, n)
+                sp = sv.sptypes[n]
+                if !sp.undef
                     t = Const(true)
+                elseif sp.typ === Bottom
+                    t = Const(false)
                 end
             end
         end

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -1,13 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-# The type of a variable load is either a value or an UndefVarError
-# (only used in abstractinterpret, doesn't appear in optimize)
-struct VarState
-    typ
-    undef::Bool
-    VarState(@nospecialize(typ), undef::Bool) = new(typ, undef)
-end
-
 """
     const VarTable = Vector{VarState}
 
@@ -91,7 +83,7 @@ mutable struct InferenceState
     linfo::MethodInstance
     world::UInt
     mod::Module
-    sptypes::Vector{Any}
+    sptypes::Vector{VarState}
     slottypes::Vector{Any}
     src::CodeInfo
     cfg::CFG
@@ -437,25 +429,7 @@ function constrains_param(var::TypeVar, @nospecialize(typ), covariant::Bool, typ
     return false
 end
 
-"""
-    MaybeUndefSP(typ)
-    is_maybeundefsp(typ) -> Bool
-    unwrap_maybeundefsp(typ) -> Any
-
-A special wrapper that represents a static parameter that could be undefined at runtime.
-This does not participate in the native type system nor the inference lattice,
-and it thus should be always unwrapped when performing any type or lattice operations on it.
-"""
-struct MaybeUndefSP
-    typ
-    MaybeUndefSP(@nospecialize typ) = new(typ)
-end
-is_maybeundefsp(@nospecialize typ) = isa(typ, MaybeUndefSP)
-unwrap_maybeundefsp(@nospecialize typ) = isa(typ, MaybeUndefSP) ? typ.typ : typ
-is_maybeundefsp(sptypes::Vector{Any}, idx::Int) = is_maybeundefsp(sptypes[idx])
-unwrap_maybeundefsp(sptypes::Vector{Any}, idx::Int) = unwrap_maybeundefsp(sptypes[idx])
-
-const EMPTY_SPTYPES = Any[]
+const EMPTY_SPTYPES = VarState[]
 
 function sptypes_from_meth_instance(linfo::MethodInstance)
     def = linfo.def
@@ -464,28 +438,26 @@ function sptypes_from_meth_instance(linfo::MethodInstance)
     if isempty(linfo.sparam_vals)
         isa(sig, UnionAll) || return EMPTY_SPTYPES
         # linfo is unspecialized
-        sp = Any[]
+        spvals = Any[]
         sig′ = sig
         while isa(sig′, UnionAll)
-            push!(sp, sig′.var)
+            push!(spvals, sig′.var)
             sig′ = sig′.body
         end
     else
-        sp = collect(Any, linfo.sparam_vals)
+        spvals = linfo.sparam_vals
     end
-    for i = 1:length(sp)
-        v = sp[i]
+    nvals = length(spvals)
+    sptypes = Vector{VarState}(undef, nvals)
+    for i = 1:nvals
+        v = spvals[i]
         if v isa TypeVar
-            maybe_undef = !constrains_param(v, linfo.specTypes, #=covariant=#true)
             temp = sig
             for j = 1:i-1
                 temp = temp.body
             end
             vᵢ = (temp::UnionAll).var
-            while temp isa UnionAll
-                temp = temp.body
-            end
-            sigtypes = (temp::DataType).parameters
+            sigtypes = (unwrap_unionall(temp)::DataType).parameters
             for j = 1:length(sigtypes)
                 sⱼ = sigtypes[j]
                 if isType(sⱼ) && sⱼ.parameters[1] === vᵢ
@@ -495,36 +467,32 @@ function sptypes_from_meth_instance(linfo::MethodInstance)
                     @goto ty_computed
                 end
             end
-            ub = v.ub
-            while ub isa TypeVar
-                ub = ub.ub
-            end
+            ub = unwraptv_ub(v)
             if has_free_typevars(ub)
                 ub = Any
             end
-            lb = v.lb
-            while lb isa TypeVar
-                lb = lb.lb
-            end
+            lb = unwraptv_lb(v)
             if has_free_typevars(lb)
                 lb = Bottom
             end
-            if Any <: ub && lb <: Bottom
+            if Any === ub && lb === Bottom
                 ty = Any
             else
                 tv = TypeVar(v.name, lb, ub)
                 ty = UnionAll(tv, Type{tv})
             end
             @label ty_computed
-            maybe_undef && (ty = MaybeUndefSP(ty))
+            undef = !constrains_param(v, linfo.specTypes, #=covariant=#true)
         elseif isvarargtype(v)
             ty = Int
+            undef = false
         else
             ty = Const(v)
+            undef = false
         end
-        sp[i] = ty
+        sptypes[i] = VarState(ty, undef)
     end
-    return sp
+    return sptypes
 end
 
 _topmod(sv::InferenceState) = _topmod(sv.mod)

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -145,7 +145,7 @@ mutable struct OptimizationState{Interp<:AbstractInterpreter}
     ir::Union{Nothing, IRCode}
     stmt_info::Vector{CallInfo}
     mod::Module
-    sptypes::Vector{Any}
+    sptypes::Vector{VarState}
     slottypes::Vector{Any}
     inlining::InliningState{Interp}
     cfg::Union{Nothing,CFG}
@@ -253,7 +253,7 @@ function stmt_effect_flags(𝕃ₒ::AbstractLattice, @nospecialize(stmt), @nospe
         if head === :static_parameter
             # if we aren't certain enough about the type, it might be an UndefVarError at runtime
             sptypes = isa(src, IRCode) ? src.sptypes : src.ir.sptypes
-            nothrow = !is_maybeundefsp(sptypes, args[1]::Int)
+            nothrow = !sptypes[args[1]::Int].undef
             return (true, nothrow, nothrow)
         end
         if head === :call
@@ -343,25 +343,25 @@ end
 
 """
     argextype(x, src::Union{IRCode,IncrementalCompact}) -> t
-    argextype(x, src::CodeInfo, sptypes::Vector{Any}) -> t
+    argextype(x, src::CodeInfo, sptypes::Vector{VarState}) -> t
 
 Return the type of value `x` in the context of inferred source `src`.
 Note that `t` might be an extended lattice element.
 Use `widenconst(t)` to get the native Julia type of `x`.
 """
-argextype(@nospecialize(x), ir::IRCode, sptypes::Vector{Any} = ir.sptypes) =
+argextype(@nospecialize(x), ir::IRCode, sptypes::Vector{VarState} = ir.sptypes) =
     argextype(x, ir, sptypes, ir.argtypes)
-function argextype(@nospecialize(x), compact::IncrementalCompact, sptypes::Vector{Any} = compact.ir.sptypes)
+function argextype(@nospecialize(x), compact::IncrementalCompact, sptypes::Vector{VarState} = compact.ir.sptypes)
     isa(x, AnySSAValue) && return types(compact)[x]
     return argextype(x, compact, sptypes, compact.ir.argtypes)
 end
-argextype(@nospecialize(x), src::CodeInfo, sptypes::Vector{Any}) = argextype(x, src, sptypes, src.slottypes::Vector{Any})
+argextype(@nospecialize(x), src::CodeInfo, sptypes::Vector{VarState}) = argextype(x, src, sptypes, src.slottypes::Vector{Any})
 function argextype(
     @nospecialize(x), src::Union{IRCode,IncrementalCompact,CodeInfo},
-    sptypes::Vector{Any}, slottypes::Vector{Any})
+    sptypes::Vector{VarState}, slottypes::Vector{Any})
     if isa(x, Expr)
         if x.head === :static_parameter
-            return unwrap_maybeundefsp(sptypes, x.args[1]::Int)
+            return sptypes[x.args[1]::Int].typ
         elseif x.head === :boundscheck
             return Bool
         elseif x.head === :copyast
@@ -646,7 +646,7 @@ plus_saturate(x::Int, y::Int) = max(x, y, x+y)
 # known return type
 isknowntype(@nospecialize T) = (T === Union{}) || isa(T, Const) || isconcretetype(widenconst(T))
 
-function statement_cost(ex::Expr, line::Int, src::Union{CodeInfo, IRCode}, sptypes::Vector{Any},
+function statement_cost(ex::Expr, line::Int, src::Union{CodeInfo, IRCode}, sptypes::Vector{VarState},
                         union_penalties::Bool, params::OptimizationParams, error_path::Bool = false)
     head = ex.head
     if is_meta_expr_head(head)
@@ -737,7 +737,7 @@ function statement_cost(ex::Expr, line::Int, src::Union{CodeInfo, IRCode}, sptyp
     return 0
 end
 
-function statement_or_branch_cost(@nospecialize(stmt), line::Int, src::Union{CodeInfo, IRCode}, sptypes::Vector{Any},
+function statement_or_branch_cost(@nospecialize(stmt), line::Int, src::Union{CodeInfo, IRCode}, sptypes::Vector{VarState},
                                   union_penalties::Bool, params::OptimizationParams)
     thiscost = 0
     dst(tgt) = isa(src, IRCode) ? first(src.cfg.blocks[tgt].stmts) : tgt
@@ -767,7 +767,7 @@ function inline_cost(ir::IRCode, params::OptimizationParams, union_penalties::Bo
     return inline_cost_clamp(bodycost)
 end
 
-function statement_costs!(cost::Vector{Int}, body::Vector{Any}, src::Union{CodeInfo, IRCode}, sptypes::Vector{Any}, unionpenalties::Bool, params::OptimizationParams)
+function statement_costs!(cost::Vector{Int}, body::Vector{Any}, src::Union{CodeInfo, IRCode}, sptypes::Vector{VarState}, unionpenalties::Bool, params::OptimizationParams)
     maxcost = 0
     for line = 1:length(body)
         stmt = body[line]

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -334,13 +334,13 @@ end
 struct IRCode
     stmts::InstructionStream
     argtypes::Vector{Any}
-    sptypes::Vector{Any}
+    sptypes::Vector{VarState}
     linetable::Vector{LineInfoNode}
     cfg::CFG
     new_nodes::NewNodeStream
     meta::Vector{Expr}
 
-    function IRCode(stmts::InstructionStream, cfg::CFG, linetable::Vector{LineInfoNode}, argtypes::Vector{Any}, meta::Vector{Expr}, sptypes::Vector{Any})
+    function IRCode(stmts::InstructionStream, cfg::CFG, linetable::Vector{LineInfoNode}, argtypes::Vector{Any}, meta::Vector{Expr}, sptypes::Vector{VarState})
         return new(stmts, argtypes, sptypes, linetable, cfg, NewNodeStream(), meta)
     end
     function IRCode(ir::IRCode, stmts::InstructionStream, cfg::CFG, new_nodes::NewNodeStream)
@@ -358,7 +358,7 @@ for debugging and unit testing of IRCode APIs. The compiler itself should genera
 from the frontend or one of the caches.
 """
 function IRCode()
-    ir = IRCode(InstructionStream(1), CFG([BasicBlock(1:1, Int[], Int[])], Int[1]), LineInfoNode[], Any[], Expr[], Any[])
+    ir = IRCode(InstructionStream(1), CFG([BasicBlock(1:1, Int[], Int[])], Int[1]), LineInfoNode[], Any[], Expr[], VarState[])
     ir[SSAValue(1)][:inst] = ReturnNode(nothing)
     ir[SSAValue(1)][:type] = Nothing
     ir[SSAValue(1)][:flag] = 0x00

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -463,7 +463,7 @@ end
 
 function ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IRInterpretationState)
     if __measure_typeinf__[]
-        inf_frame = Timings.InferenceFrameInfo(irsv.mi, irsv.world, Any[], Any[], length(irsv.ir.argtypes))
+        inf_frame = Timings.InferenceFrameInfo(irsv.mi, irsv.world, VarState[], Any[], length(irsv.ir.argtypes))
         Timings.enter_new_timer(inf_frame)
         v = _ir_abstract_constant_propagation(interp, irsv)
         append!(inf_frame.slottypes, irsv.ir.argtypes)

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -213,10 +213,10 @@ struct DelayedTyp
 end
 
 # maybe use expr_type?
-function typ_for_val(@nospecialize(x), ci::CodeInfo, sptypes::Vector{Any}, idx::Int, slottypes::Vector{Any})
+function typ_for_val(@nospecialize(x), ci::CodeInfo, sptypes::Vector{VarState}, idx::Int, slottypes::Vector{Any})
     if isa(x, Expr)
         if x.head === :static_parameter
-            return unwrap_maybeundefsp(sptypes, x.args[1]::Int)
+            return sptypes[x.args[1]::Int].typ
         elseif x.head === :boundscheck
             return Bool
         elseif x.head === :copyast
@@ -567,7 +567,7 @@ function compute_live_ins(cfg::CFG, defs::Vector{Int}, uses::Vector{Int})
 end
 
 function recompute_type(node::Union{PhiNode, PhiCNode}, ci::CodeInfo, ir::IRCode,
-    sptypes::Vector{Any}, slottypes::Vector{Any}, nstmts::Int, 𝕃ₒ::AbstractLattice)
+    sptypes::Vector{VarState}, slottypes::Vector{Any}, nstmts::Int, 𝕃ₒ::AbstractLattice)
     new_typ = Union{}
     for i = 1:length(node.values)
         if isa(node, PhiNode) && !isassigned(node.values, i)

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -29,7 +29,7 @@ using Core.Compiler: -, +, :, Vector, length, first, empty!, push!, pop!, @inlin
 struct InferenceFrameInfo
     mi::Core.MethodInstance
     world::UInt64
-    sptypes::Vector{Any}
+    sptypes::Vector{Core.Compiler.VarState}
     slottypes::Vector{Any}
     nargs::Int
 end
@@ -89,7 +89,7 @@ function reset_timings()
     empty!(_timings)
     push!(_timings, Timing(
         # The MethodInstance for ROOT(), and default empty values for other fields.
-        InferenceFrameInfo(ROOTmi, 0x0, Any[], Any[Core.Const(ROOT)], 1),
+        InferenceFrameInfo(ROOTmi, 0x0, Core.Compiler.VarState[], Any[Core.Const(ROOT)], 1),
         _time_ns()))
     return nothing
 end

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -32,6 +32,22 @@ struct StmtInfo
     used::Bool
 end
 
+"""
+    v::VarState
+
+A special wrapper that represents a local variable of a method being analyzed.
+This does not participate in the native type system nor the inference lattice, and it thus
+should be always unwrapped to `v.typ` when performing any type or lattice operations on it.
+`v.undef` represents undefined-ness of this static parameter. If `true`, it means that the
+variable _may_ be undefined at runtime, otherwise it is guaranteed to be defined.
+If `v.typ === Bottom` it means that the variable is strictly undefined.
+"""
+struct VarState
+    typ
+    undef::Bool
+    VarState(@nospecialize(typ), undef::Bool) = new(typ, undef)
+end
+
 abstract type ForwardableArgtypes end
 
 """

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -324,12 +324,19 @@ function unswitchtupleunion(u::Union)
     Tuple{Any[ Union{Any[(t::DataType).parameters[i] for t in ts]...} for i in 1:n ]...}
 end
 
-function unwraptv(@nospecialize t)
+function unwraptv_ub(@nospecialize t)
     while isa(t, TypeVar)
         t = t.ub
     end
     return t
 end
+function unwraptv_lb(@nospecialize t)
+    while isa(t, TypeVar)
+        t = t.lb
+    end
+    return t
+end
+const unwraptv = unwraptv_ub
 
 # this query is specially written for `adjust_effects` and returns true if a value of this type
 # never involves inconsistency of mutable objects that are allocated somewhere within a call graph

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1548,7 +1548,8 @@ function print_statement_costs(io::IO, @nospecialize(tt::Type);
         else
             empty!(cst)
             resize!(cst, length(code.code))
-            maxcost = Core.Compiler.statement_costs!(cst, code.code, code, Any[match.sparams...], false, params)
+            sptypes = Core.Compiler.VarState[Core.Compiler.VarState(sp, false) for sp in match.sparams]
+            maxcost = Core.Compiler.statement_costs!(cst, code.code, code, sptypes, false, params)
             nd = ndigits(maxcost)
             irshow_config = IRShow.IRShowConfig() do io, linestart, idx
                 print(io, idx > 0 ? lpad(cst[idx], nd+1) : " "^(nd+1), " ")

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -699,7 +699,7 @@ end
 
 @testset "code_llvm on opaque_closure" begin
     let ci = code_typed(+, (Int, Int))[1][1]
-        ir = Core.Compiler.inflate_ir(ci, Any[], Any[Tuple{}, Int, Int])
+        ir = Core.Compiler.inflate_ir(ci)
         oc = Core.OpaqueClosure(ir)
         @test (code_llvm(devnull, oc, Tuple{Int, Int}); true)
         let io = IOBuffer()

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -708,9 +708,10 @@ let m = Meta.@lower 1 + 1
         Any
     ]
     nstmts = length(src.code)
-    src.codelocs = fill(Int32(1), nstmts)
-    src.ssaflags = fill(Int32(0), nstmts)
-    ir = Core.Compiler.inflate_ir(src, Any[], Any[Any, Any])
+    src.codelocs = fill(one(Int32), nstmts)
+    src.ssaflags = fill(one(Int32), nstmts)
+    src.slotflags = fill(zero(UInt8), 3)
+    ir = Core.Compiler.inflate_ir(src)
     @test Core.Compiler.verify_ir(ir) === nothing
     ir = @test_nowarn Core.Compiler.sroa_pass!(ir)
     @test Core.Compiler.verify_ir(ir) === nothing

--- a/test/compiler/irutils.jl
+++ b/test/compiler/irutils.jl
@@ -1,8 +1,8 @@
 import Core: CodeInfo, ReturnNode, MethodInstance
-import Core.Compiler: IRCode, IncrementalCompact, argextype, singleton_type
+import Core.Compiler: IRCode, IncrementalCompact, VarState, argextype, singleton_type
 import Base.Meta: isexpr
 
-argextype(@nospecialize args...) = argextype(args..., Any[])
+argextype(@nospecialize args...) = argextype(args..., VarState[])
 code_typed1(args...; kwargs...) = first(only(code_typed(args...; kwargs...)))::CodeInfo
 get_code(args...; kwargs...) = code_typed1(args...; kwargs...).code
 

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -117,8 +117,8 @@ let cfg = CFG(BasicBlock[
     make_bb([2, 3]    , []    ),
 ], Int[])
     insts = Compiler.InstructionStream([], [], Any[], Int32[], UInt8[])
-    code = Compiler.IRCode(insts, cfg, LineInfoNode[], [], Expr[], [])
-    compact = Compiler.IncrementalCompact(code, true)
+    ir = Compiler.IRCode(insts, cfg, Core.LineInfoNode[], Any[], Expr[], Compiler.VarState[])
+    compact = Compiler.IncrementalCompact(ir, true)
     @test length(compact.result_bbs) == 4 && 0 in compact.result_bbs[3].preds
 end
 

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -247,7 +247,7 @@ let ci = code_typed(+, (Int, Int))[1][1]
     @test OpaqueClosure(ir; nargs=2, isva=false)(40, 2) == 42
     @test OpaqueClosure(ci)(40, 2) == 42
 
-    ir = Core.Compiler.inflate_ir(ci, Any[], Any[Tuple{}, Int, Int])
+    ir = Core.Compiler.inflate_ir(ci)
     @test OpaqueClosure(ir; nargs=2, isva=false)(40, 2) == 42
     @test isa(OpaqueClosure(ir; nargs=2, isva=false), Core.OpaqueClosure{Tuple{Int, Int}, Int})
     @test_throws TypeError OpaqueClosure(ir; nargs=2, isva=false)(40.0, 2)
@@ -264,7 +264,7 @@ let ci = code_typed((x, y...)->(x, y), (Int, Int))[1][1]
         @test_throws MethodError oc(1,2,3)
     end
 
-    ir = Core.Compiler.inflate_ir(ci, Any[], Any[Tuple{}, Int, Tuple{Int}])
+    ir = Core.Compiler.inflate_ir(ci)
     let oc = OpaqueClosure(ir; nargs=2, isva=true)
         @test oc(40, 2) === (40, (2,))
         @test_throws MethodError oc(1,2,3)


### PR DESCRIPTION
This allows us to represent strict undefined-ness of a static parameter.

@nanosoldier `runbenchmarks("inference", vs=":master")`