### PR TITLE
Subtype: Avoid split `y::Union` when comparing with a forall var. 

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1254,7 +1254,9 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param)
             // of unions and vars: if matching `typevar <: union`, first try to match the whole
             // union against the variable before trying to take it apart to see if there are any
             // variables lurking inside.
-            ui = pick_union_decision(e, 1);
+            // note: for forall var, there's no need to split y if it has no free typevars.
+            jl_varbinding_t *xx = lookup(e, (jl_tvar_t *)x);
+            ui = ((xx && xx->right) || jl_has_free_typevars(y)) && pick_union_decision(e, 1);
         }
         if (ui == 1)
             y = pick_union_element(y, e, 1);

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2443,3 +2443,7 @@ end
 let a = (isodd(i) ? Pair{Char, String} : Pair{String, String} for i in 1:2000)
     @test Tuple{Type{Pair{Union{Char, String}, String}}, a...} <: Tuple{Type{Pair{K, V}}, Vararg{Pair{A, B} where B where A}} where V where K
 end
+
+#issue 48582
+@test !<:(Tuple{Pair{<:T,<:T}, Val{S} where {S}} where {T<:Base.BitInteger},
+          Tuple{Pair{<:T,<:T}, Val{Int}} where {T<:Base.BitInteger})


### PR DESCRIPTION
Should bring the load time of `CUDA.jl` back to a similar level before the regression.
MWE:
```julia
julia> @time !<:(Tuple{Pair{<:T,<:T}, Val{S} where {S}} where {T<:Base.BitInteger},
                 Tuple{Pair{<:T,<:T}, Val{Int}} where {T<:Base.BitInteger})
  0.000016 seconds (33 allocations: 2.188 KiB) # master 86.345139 seconds (50.49 M allocations: 7.023 GiB, 0.53% gc time)
```
close #48582.