### PR TITLE
all(Array{Int}) consistent with all(Array{Int};dims=N)

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -1220,7 +1220,7 @@ function _any(f, itr, ::Colon)
         v = f(x)
         if ismissing(v)
             anymissing = true
-        elseif v
+        elseif v == true
             return true
         end
     end
@@ -1241,7 +1241,7 @@ end
     v = f(x)
     if ismissing(v)
         anymissing = true
-    elseif v
+    elseif v == true
         return true
     end
     return _any_tuple(f, anymissing, rest...)
@@ -1288,8 +1288,7 @@ function _all(f, itr, ::Colon)
         v = f(x)
         if ismissing(v)
             anymissing = true
-        # this syntax allows throwing a TypeError for non-Bool, for consistency with any
-        elseif v
+        elseif v == true
             continue
         else
             return false
@@ -1311,8 +1310,7 @@ end
     v = f(x)
     if ismissing(v)
         anymissing = true
-    # this syntax allows throwing a TypeError for non-Bool, for consistency with any
-    elseif v
+    elseif v == true
         nothing
     else
         return false


### PR DESCRIPTION
Currently we have this behavior, which seems inconsistent:

```julia
julia> all([1,0];dims=1)
1-element Vector{Bool}:
 0

julia> all([1,0])
ERROR: TypeError: non-boolean (Int64) used in boolean context
```
This occurs because of the `elseif v` clauses, which fail for `v === 1`. If we instead check for `v == true`,  than it will pass, and the behavior becomes consistent among these two calls. 

I don't know if this is considered breaking (probably it is), though.

The implementation for tuples specifically had chosen the `elseif v` syntax to be consistent with `any`, such that probably this is a desired behavior. Probably this PR won't be merged, then, although the inconsistency with `any([1, 0])` will remain.