### PR TITLE
permute! and invpermute! - explain fully in-place alternatives

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -220,7 +220,7 @@ Like [`permute!`](@ref), but the inverse of the given permutation is applied.
 
 Note that if you have a pre-allocated output array (e.g. `u = similar(v)`),
 it is quicker to instead employ `u[p] = v`.  (`invpermute!` internally
-requires some data allocation.)
+allocates a copy of the data.)
 
 # Examples
 ```jldoctest

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -164,7 +164,10 @@ end
 Permute vector `v` in-place, according to permutation `p`. No checking is done
 to verify that `p` is a permutation.
 
-To return a new permutation, use `v[p]`. Note that this is faster than `permute!(v, p)`.
+To return a new permutation, use `v[p]`. This is generally faster than `permute!(v, p)`;
+it is even faster to write into a pre-allocated output array with `u .= @view v[p]`.
+(Even though `permute!` overwrites `v` in-place, it internally requires some allocation
+to keep track of which elements have been moved.)
 
 See also [`invpermute!`](@ref).
 
@@ -214,6 +217,10 @@ end
     invpermute!(v, p)
 
 Like [`permute!`](@ref), but the inverse of the given permutation is applied.
+
+Note that if you have a pre-allocated output array (e.g. `u = similar(v)`),
+it is quicker to instead employ `u[p] = v`.  (`invpermute!` internally
+requires some data allocation.)
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Document the fully in-place alternatives `u = @view v[p]` and `u[p] = v` to `permute!` and `invpermute!`, respectively, using a pre-allocated output array.  Also document the fact that the "in-place" functions `permute!` and `invpermute!` in fact require some memory allocation.

See [the discourse discussion](https://discourse.julialang.org/t/in-place-inverse-permutation/94368).