### PR TITLE
Allow for use 60% of constrained/total system memory

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -3246,12 +3246,14 @@ void jl_gc_init(void)
     gc_num.allocd = 0;
     gc_num.max_pause = 0;
     gc_num.max_memory = 0;
+    total_mem = uv_get_total_memory();
 
 #ifdef _P64
-    total_mem = uv_get_total_memory();
     uint64_t constrained_mem = uv_get_constrained_memory();
     if (constrained_mem > 0 && constrained_mem < total_mem)
         total_mem = constrained_mem;
+#else
+    total_mem = total_mem > max_total_memory ? max_total_memory : total_mem;
 #endif
 
     total_mem = total_mem / 10 * 6; // 60% of constrained memory

--- a/src/gc.c
+++ b/src/gc.c
@@ -3254,12 +3254,7 @@ void jl_gc_init(void)
         total_mem = constrained_mem;
 #endif
 
-    // We allocate with abandon until we get close to the free memory on the machine.
-    uint64_t free_mem = uv_get_available_memory();
-    uint64_t high_water_mark = free_mem / 10 * 7;  // 70% high water mark
-
-    if (high_water_mark < max_total_memory)
-       max_total_memory = high_water_mark;
+    total_mem = total_mem / 10 * 6; // 60% of constrained memory
     t_start = jl_hrtime();
 }
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -3246,17 +3246,15 @@ void jl_gc_init(void)
     gc_num.allocd = 0;
     gc_num.max_pause = 0;
     gc_num.max_memory = 0;
-    total_mem = uv_get_total_memory();
 
 #ifdef _P64
+    total_mem = uv_get_total_memory();
     uint64_t constrained_mem = uv_get_constrained_memory();
     if (constrained_mem > 0 && constrained_mem < total_mem)
         total_mem = constrained_mem;
-#else
-    total_mem = total_mem > max_total_memory ? max_total_memory : total_mem;
+    max_total_memory = total_mem / 10 * 6;
 #endif
 
-    total_mem = total_mem / 10 * 6; // 60% of constrained memory
     t_start = jl_hrtime();
 }
 


### PR DESCRIPTION
Remove the high watermark logic because it doesn't really make sense and allow for use of 60% of system memory.
Should fix https://github.com/JuliaLang/julia/issues/48473