### PR TITLE
Mangle NaN values returned from math functions

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -37,6 +37,7 @@ mangleNaN(x::Float32) = isnan(x) ? makeNan32() : x
 mangleNaN(x::Float16) = isnan(x) ? makeNan16() : x
 mangleNaN(x::Complex{<:IEEEFloat}) = Complex(mangleNaN(real(x)), mangleNaN(imag(x)))
 mangleNaN(x) = x
+mangleNaN(x, y) = (mangleNaN(x), mangleNaN(y))
 mangleNaN(x, y...) = (mangleNaN(x), mangleNaN(y...)...)
 
 @noinline function throw_complex_domainerror(f::Symbol, x)

--- a/base/special/cbrt.jl
+++ b/base/special/cbrt.jl
@@ -73,7 +73,7 @@ These implementations assume that NaNs, infinities and zeros have already been f
         u = highword(x) & 0x7fff_ffff
         v = div(u, UInt32(3)) + floor(UInt32, adj * exp2(k))
     end
-    return copysign(fromhighword(T, v), x)
+    return Base.Math.mangleNaN(copysign(fromhighword(T, v), x))
 end
 
 @inline function _improve_cbrt(x::Float32, t::Float32)
@@ -95,7 +95,7 @@ end
     tt3 = tt^3
     tt *= (2*xx + tt3)/(x + 2*tt3)
 
-    return Float32(tt)
+    return Base.Math.mangleNaN(Float32(tt))
 end
 
 @inline function _improve_cbrt(x::Float64, t::Float64)
@@ -136,20 +136,20 @@ end
     w = t+t             # t+t is exact
     r = (r - t)/(w + r) # r-t is exact; w+r ~= 3*t
     t = muladd(t, r, t) # error <= 0.5 + 0.5/3 + epsilon
-    return t
+    return Base.Math.mangleNaN(t)
 end
 
 function cbrt(x::Union{Float32,Float64})
     if !isfinite(x) || iszero(x)
-        return x
+        return Base.Math.mangleNaN(x)
     end
     t = _approx_cbrt(x)
-    return _improve_cbrt(x, t)
+    return Base.Math.mangleNaN(_improve_cbrt(x, t))
 end
 
 function cbrt(a::Float16)
     if !isfinite(a) || iszero(a)
-        return a
+        return Base.Math.mangleNaN(a)
     end
     x = Float32(a)
 
@@ -161,5 +161,5 @@ function cbrt(a::Float16)
     # 2 newton iterations
     t = 0.33333334f0 * (2f0*t + x/(t*t))
     t = 0.33333334f0 * (2f0*t + x/(t*t))
-    return Float16(t)
+    return Base.Math.mangleNaN(Float16(t))
 end

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -71,32 +71,32 @@ LogB(::Val{10}, ::Type{Float16}) = -0.30103f0
 
 # Range reduced kernels
 function expm1b_kernel(::Val{2}, x::Float64)
-    return x * evalpoly(x, (0.6931471805599393, 0.24022650695910058,
-                            0.05550411502333161, 0.009618129548366803))
+    return Base.Math.mangleNaN(x * evalpoly(x, (0.6931471805599393, 0.24022650695910058,
+                            0.05550411502333161, 0.009618129548366803)))
 end
 function expm1b_kernel(::Val{:ℯ}, x::Float64)
-    return x * evalpoly(x, (0.9999999999999912, 0.4999999999999997,
-                            0.1666666857598779, 0.04166666857598777))
+    return Base.Math.mangleNaN(x * evalpoly(x, (0.9999999999999912, 0.4999999999999997,
+                            0.1666666857598779, 0.04166666857598777)))
 end
 function expm1b_kernel(::Val{10}, x::Float64)
-    return x * evalpoly(x, (2.3025850929940255, 2.6509490552391974,
-                            2.034678825384765, 1.1712552025835192))
+    return Base.Math.mangleNaN(x * evalpoly(x, (2.3025850929940255, 2.6509490552391974,
+                            2.034678825384765, 1.1712552025835192)))
 end
 
 function expb_kernel(::Val{2}, x::Float32)
-    return evalpoly(x, (1.0f0, 0.6931472f0, 0.2402265f0,
+    return Base.Math.mangleNaN(evalpoly(x, (1.0f0, 0.6931472f0, 0.2402265f0,
                         0.05550411f0, 0.009618025f0,
-                        0.0013333423f0, 0.00015469732f0, 1.5316464f-5))
+                        0.0013333423f0, 0.00015469732f0, 1.5316464f-5)))
 end
 function expb_kernel(::Val{:ℯ}, x::Float32)
-    return evalpoly(x, (1.0f0, 1.0f0, 0.5f0, 0.16666667f0,
+    return Base.Math.mangleNaN(evalpoly(x, (1.0f0, 1.0f0, 0.5f0, 0.16666667f0,
                         0.041666217f0, 0.008333249f0,
-                        0.001394858f0, 0.00019924171f0))
+                        0.001394858f0, 0.00019924171f0)))
 end
 function expb_kernel(::Val{10}, x::Float32)
-    return evalpoly(x, (1.0f0, 2.3025851f0, 2.650949f0,
+    return Base.Math.mangleNaN(evalpoly(x, (1.0f0, 2.3025851f0, 2.650949f0,
                         2.0346787f0, 1.1712426f0, 0.53937745f0,
-                        0.20788547f0, 0.06837386f0))
+                        0.20788547f0, 0.06837386f0)))
 end
 
 # Table stores data with 60 sig figs by using the fact that the first 12 bits of all the
@@ -180,7 +180,7 @@ Base.@assume_effects :nothrow function table_unpack(ind::Int32)
     j = getfield(J_TABLE, ind) # use getfield so the compiler can prove consistent
     jU = reinterpret(Float64, JU_CONST | (j&JU_MASK))
     jL = reinterpret(Float64, JL_CONST | (j>>8))
-    return jU, jL
+    return Base.Math.mangleNaN(jU, jL)
 end
 
 # Method for Float64
@@ -221,12 +221,12 @@ end
         if k <= -53
             # The UInt64 forces promotion. (Only matters for 32 bit systems.)
             twopk = (k + UInt64(53)) << 52
-            return reinterpret(T, twopk + reinterpret(UInt64, small_part))*0x1p-53
+            return Base.Math.mangleNaN(reinterpret(T, twopk + reinterpret(UInt64, small_part))*0x1p-53)
         end
         #k == 1024 && return (small_part * 2.0) * 2.0^1023
     end
     twopk = Int64(k) << 52
-    return reinterpret(T, twopk + reinterpret(Int64, small_part))
+    return Base.Math.mangleNaN(reinterpret(T, twopk + reinterpret(Int64, small_part)))
 end
 # Computes base^(x+xlo). Used for pow.
 @inline function exp_impl(x::Float64, xlo::Float64, base)
@@ -248,12 +248,12 @@ end
         if k <= -53
             # The UInt64 forces promotion. (Only matters for 32 bit systems.)
             twopk = (k + UInt64(53)) << 52
-            return reinterpret(T, twopk + reinterpret(UInt64, small_part))*0x1p-53
+            return Base.Math.mangleNaN(reinterpret(T, twopk + reinterpret(UInt64, small_part))*0x1p-53)
         end
         #k == 1024 && return (small_part * 2.0) * 2.0^1023
     end
     twopk = Int64(k) << 52
-    return reinterpret(T, twopk + reinterpret(Int64, small_part))
+    return Base.Math.mangleNaN(reinterpret(T, twopk + reinterpret(Int64, small_part)))
 end
 @inline function exp_impl_fast(x::Float64, base)
     T = Float64
@@ -268,7 +268,7 @@ end
     jU = reinterpret(Float64, JU_CONST | (@inbounds J_TABLE[N&255 + 1] & JU_MASK))
     small_part =  muladd(jU, expm1b_kernel(base, r), jU)
     twopk = Int64(k) << 52
-    return reinterpret(T, twopk + reinterpret(Int64, small_part))
+    return Base.Math.mangleNaN(reinterpret(T, twopk + reinterpret(Int64, small_part)))
 end
 
 @inline function exp_impl(x::Float32, base)
@@ -289,7 +289,7 @@ end
         power -= Int32(1)
         small_part *= 2f0
     end
-    return small_part * reinterpret(T, power << Int32(23))
+    return Base.Math.mangleNaN(small_part * reinterpret(T, power << Int32(23)))
 end
 
 @inline function exp_impl_fast(x::Float32, base)
@@ -302,7 +302,7 @@ end
     r = muladd(N_float, LogBL(base, T), r)
     small_part = expb_kernel(base, r)
     twopk = reinterpret(T, (N+Int32(127)) << Int32(23))
-    return twopk*small_part
+    return Base.Math.mangleNaN(twopk*small_part)
 end
 
 @inline function exp_impl(a::Float16, base)
@@ -317,7 +317,7 @@ end
         x < 25 && return zero(Float16)
     end
     twopk = reinterpret(T, (N+Int32(127)) << Int32(23))
-    return Float16(twopk*small_part)
+    return Base.Math.mangleNaN(Float16(twopk*small_part))
 end
 
 for (func, fast_func, base) in ((:exp2,  :exp2_fast,  Val(2)),
@@ -417,19 +417,19 @@ Ln2(::Type{Float32}) = -0.6931472f0
                      0.001388888889068783, 0.00019841269447671544, 2.480157691845342e-5,
                      2.7558212415361945e-6, 2.758218402815439e-7, 2.4360682937111612e-8))
     p2 = exthorner(x, (1.0, .5, p))
-    return fma(x, p2[1], x*p2[2])
+    return Base.Math.mangleNaN(fma(x, p2[1], x*p2[2]))
 end
 @inline function expm1_small(x::Float32)
     p = evalpoly(x, (0.16666666f0, 0.041666627f0, 0.008333682f0,
                      0.0013908712f0, 0.0001933096f0))
     p2 = exthorner(x, (1f0, .5f0, p))
-    return fma(x, p2[1], x*p2[2])
+    return Base.Math.mangleNaN(fma(x, p2[1], x*p2[2]))
 end
 
 function expm1(x::Float64)
     T = Float64
     if -0.2876820724517809 <= x <= 0.22314355131420976
-        return expm1_small(x)
+        return Base.Math.mangleNaN(expm1_small(x))
     elseif !(abs(x)<=MIN_EXP(Float64))
         isnan(x) && return x
         x > MAX_EXP(Float64) && return Inf
@@ -449,14 +449,14 @@ function expm1(x::Float64)
     k>=106 && return reinterpret(Float64, (1022+k) << 52)*(jU + muladd(jU, p, jL))*2
     k>=53 && return twopk*(jU + muladd(jU, p, (jL-twopnk)))
     k<=-2 && return twopk*(jU + muladd(jU, p, jL))-1
-    return twopk*((jU-twopnk) + fma(jU, p, jL))
+    return Base.Math.mangleNaN(twopk*((jU-twopnk) + fma(jU, p, jL)))
 end
 
 function expm1(x::Float32)
     x > MAX_EXP(Float32) && return Inf32
     x < MIN_EXP(Float32) && return -1f0
     if -0.2876821f0 <=x <= 0.22314355f0
-        return expm1_small(x)
+        return Base.Math.mangleNaN(expm1_small(x))
     end
     x = Float64(x)
     N_float = round(x*Ln2INV(Float64))
@@ -466,7 +466,7 @@ function expm1(x::Float32)
                       0.008332997481506921, 0.0013966479175977883, 0.0002004037059220124))
     small_part = r*hi
     twopk = reinterpret(Float64, (N+1023) << 52)
-    return Float32(muladd(twopk, small_part, twopk-1.0))
+    return Base.Math.mangleNaN(Float32(muladd(twopk, small_part, twopk-1.0)))
 end
 
 function expm1(x::Float16)
@@ -474,7 +474,7 @@ function expm1(x::Float16)
     x < MIN_EXP(Float16) && return Float16(-1.0)
     x = Float32(x)
     if -0.2876821f0 <=x <= 0.22314355f0
-        return Float16(x*evalpoly(x, (1f0, .5f0, 0.16666628f0, 0.04166785f0, 0.008351848f0, 0.0013675707f0)))
+        return Base.Math.mangleNaN(Float16(x*evalpoly(x, (1f0, .5f0, 0.16666628f0, 0.04166785f0, 0.008351848f0, 0.0013675707f0))))
     end
     N_float = round(x*Ln2INV(Float32))
     N = unsafe_trunc(UInt32, N_float)
@@ -482,7 +482,7 @@ function expm1(x::Float16)
     hi = evalpoly(r, (1f0, .5f0, 0.16666667f0, 0.041665863f0, 0.008333111f0, 0.0013981499f0, 0.00019983904f0))
     small_part = r*hi
     twopk = reinterpret(Float32, (N+Int32(127)) << Int32(23))
-    return Float16(muladd(twopk, small_part, twopk-1f0))
+    return Base.Math.mangleNaN(Float16(muladd(twopk, small_part, twopk-1f0)))
 end
 
 """

--- a/base/special/hyperbolic.jl
+++ b/base/special/hyperbolic.jl
@@ -38,7 +38,7 @@ function sinh_kernel(x::Float64)
                              1.6059550718903307e-10, 7.634842144412119e-13,
                              2.9696954760355812e-15))
     hi,lo = exthorner(x2, (1.0, 0.16666666666666635, hi_order))
-    return muladd(x, hi, muladd(x, lo, x*x2lo*0.16666666666666635))
+    return Base.Math.mangleNaN(muladd(x, hi, muladd(x, lo, x*x2lo*0.16666666666666635)))
 end
 # For Float32, using Float64 is simpler, faster, and doesn't require FMA
 function sinh_kernel(x::Float32)
@@ -46,13 +46,13 @@ function sinh_kernel(x::Float32)
     res = evalpoly(x*x, (1.0, 0.1666666779967941, 0.008333336726447933,
                          0.00019841001151414065, 2.7555538207080807e-6,
                          2.5143389765825282e-8, 1.6260094552031644e-10))
-    return Float32(res*x)
+    return Base.Math.mangleNaN(Float32(res*x))
 end
 
 @inline function sinh16_kernel(x::Float32)
     res = evalpoly(x*x, (1.0f0, 0.16666667f0, 0.008333337f0, 0.00019841001f0,
                          2.7555539f-6, 2.514339f-8, 1.6260095f-10))
-    return Float16(res*x)
+    return Base.Math.mangleNaN(Float16(res*x))
 end
 
 function sinh(x::T) where T<:Union{Float32,Float64}
@@ -70,13 +70,13 @@ function sinh(x::T) where T<:Union{Float32,Float64}
 
     absx = abs(x)
     if absx <= SINH_SMALL_X(T)
-        return sinh_kernel(x)
+        return Base.Math.mangleNaN(sinh_kernel(x))
     elseif absx >= H_LARGE_X(T)
         E = exp(T(.5)*absx)
-        return copysign(T(.5)*E*E, x)
+        return Base.Math.mangleNaN(copysign(T(.5)*E*E, x))
     end
     E = exp(absx)
-    return copysign(T(.5)*(E - 1/E),x)
+    return Base.Math.mangleNaN(copysign(T(.5)*(E - 1/E),x))
 end
 
 function Base.sinh(a::Float16)
@@ -84,20 +84,20 @@ function Base.sinh(a::Float16)
     absx = abs(x)
     absx <= SINH_SMALL_X(Float32) && return sinh16_kernel(x)
     E = exp(absx)
-    return Float16(copysign(.5f0*(E - 1/E),x))
+    return Base.Math.mangleNaN(Float16(copysign(.5f0*(E - 1/E),x)))
 end
 
 COSH_SMALL_X(::Type{T}) where T= one(T)
 
 function cosh_kernel(x2::Float32)
-    return evalpoly(x2, (1.0f0, 0.49999997f0, 0.041666888f0, 0.0013882756f0, 2.549933f-5))
+    return Base.Math.mangleNaN(evalpoly(x2, (1.0f0, 0.49999997f0, 0.041666888f0, 0.0013882756f0, 2.549933f-5)))
 end
 
 function cosh_kernel(x2::Float64)
-    return evalpoly(x2, (1.0, 0.5000000000000002, 0.04166666666666269,
+    return Base.Math.mangleNaN(evalpoly(x2, (1.0, 0.5000000000000002, 0.04166666666666269,
                          1.3888888889206764e-3, 2.4801587176784207e-5,
                          2.7557345825742837e-7, 2.0873617441235094e-9,
-                         1.1663435515945578e-11))
+                         1.1663435515945578e-11)))
 end
 
 function cosh(x::T) where T<:Union{Float32,Float64}
@@ -115,13 +115,13 @@ function cosh(x::T) where T<:Union{Float32,Float64}
 
     absx = abs(x)
     if absx <= COSH_SMALL_X(T)
-        return cosh_kernel(x*x)
+        return Base.Math.mangleNaN(cosh_kernel(x*x))
     elseif absx >= H_LARGE_X(T)
         E = exp(T(.5)*absx)
-        return T(.5)*E*E
+        return Base.Math.mangleNaN(T(.5)*E*E)
     end
     E = exp(absx)
-    return T(.5)*(E + 1/E)
+    return Base.Math.mangleNaN(T(.5)*(E + 1/E))
 end
 
 # tanh methods
@@ -130,15 +130,15 @@ TANH_LARGE_X(::Type{Float32}) = 18.0f0
 TANH_SMALL_X(::Type{Float64}) = 1.0
 TANH_SMALL_X(::Type{Float32}) = 1.3862944f0       #2*log(2)
 @inline function tanh_kernel(x::Float64)
-    return evalpoly(x, (1.0, -0.33333333333332904, 0.13333333333267555,
+    return Base.Math.mangleNaN(evalpoly(x, (1.0, -0.33333333333332904, 0.13333333333267555,
                         -0.05396825393066753, 0.02186948742242217,
                         -0.008863215974794633, 0.003591910693118715,
                         -0.0014542587440487815, 0.0005825521659411748,
-                        -0.00021647574085351332, 5.5752458452673005e-5))
+                        -0.00021647574085351332, 5.5752458452673005e-5)))
 end
 @inline function tanh_kernel(x::Float32)
-    return evalpoly(x, (1.0f0, -0.3333312f0, 0.13328037f0,
-                        -0.05350336f0, 0.019975215f0, -0.0050525228f0))
+    return Base.Math.mangleNaN(evalpoly(x, (1.0f0, -0.3333312f0, 0.13328037f0,
+                        -0.05350336f0, 0.019975215f0, -0.0050525228f0)))
 end
 function tanh(x::T) where T<:Union{Float32, Float64}
     # Method
@@ -155,7 +155,7 @@ function tanh(x::T) where T<:Union{Float32, Float64}
     abs2x >= TANH_LARGE_X(T) && return copysign(one(T), x)
     abs2x <= TANH_SMALL_X(T) && return x*tanh_kernel(x*x)
     k = exp(abs2x)
-    return copysign(1 - 2/(k+1), x)
+    return Base.Math.mangleNaN(copysign(1 - 2/(k+1), x))
 end
 
 # Inverse hyperbolic functions
@@ -176,13 +176,13 @@ function asinh(x::T) where T <: Union{Float32, Float64}
     #    d) |x| >= 2^28
     #        return sign(x)*(log(x)+ln2))
     if isnan(x) || isinf(x)
-        return x
+        return Base.Math.mangleNaN(x)
     end
     absx = abs(x)
     if absx < T(2)
         # in a)
         if absx < T(2)^-28
-            return x
+            return Base.Math.mangleNaN(x)
         end
         # in b)
         t = x*x
@@ -195,7 +195,7 @@ function asinh(x::T) where T <: Union{Float32, Float64}
         # in d)
         w = log(absx) + AH_LN2(T)
     end
-    return copysign(w, x)
+    return Base.Math.mangleNaN(copysign(w, x))
 end
 
 # acosh methods
@@ -218,21 +218,21 @@ function acosh(x::T) where T <: Union{Float32, Float64}
     isnan(x) && return x
 
     if x < T(1)
-        return acosh_domain_error(x)
+        return Base.Math.mangleNaN(acosh_domain_error(x))
     elseif x == T(1)
         # in a)
-        return T(0)
+        return Base.Math.mangleNaN(T(0))
     elseif x < T(2)
         # in b)
         t = x - T(1)
-        return log1p(t + sqrt(T(2)*t + t*t))
+        return Base.Math.mangleNaN(log1p(t + sqrt(T(2)*t + t*t)))
     elseif x < T(2)^28
         # in c)
         t = x*x
-        return log(T(2)*x - T(1)/(x+sqrt(t - T(1))))
+        return Base.Math.mangleNaN(log(T(2)*x - T(1)/(x+sqrt(t - T(1)))))
     else
         # in d)
-        return log(x) + AH_LN2(T)
+        return Base.Math.mangleNaN(log(x) + AH_LN2(T))
     end
 end
 
@@ -262,5 +262,5 @@ function atanh(x::T) where T <: Union{Float32, Float64}
         # in b)
         t = log((T(1)+absx)/(T(1)-absx))
     end
-    return T(0.5)*copysign(t, x)
+    return Base.Math.mangleNaN(T(0.5)*copysign(t, x))
 end

--- a/base/special/log.jl
+++ b/base/special/log.jl
@@ -186,7 +186,7 @@ Base.@assume_effects :consistent @inline function log_proc1(y::Float64,mf::Float
     ## Step 4
     m_hi = logbU(Float64, base)
     m_lo = logbL(Float64, base)
-    return fma(m_hi, l_hi, fma(m_hi, (u + (q + l_lo)), m_lo*l_hi))
+    return Base.Math.mangleNaN(fma(m_hi, l_hi, fma(m_hi, (u + (q + l_lo)), m_lo*l_hi)))
 end
 
 # Procedure 2
@@ -212,7 +212,7 @@ end
 
     m_hi = logbU(Float64, base)
     m_lo = logbL(Float64, base)
-    return fma(m_hi, u, fma(m_lo, u, m_hi*fma(fma(-u,f,2(f-u)), g, q)))
+    return Base.Math.mangleNaN(fma(m_hi, u, fma(m_lo, u, m_hi*fma(fma(-u,f,2(f-u)), g, q))))
 end
 
 # Procedure 1
@@ -274,7 +274,7 @@ function _log(x::Float64, base, func)
         # Step 2
         if 0.9394130628134757 < x < 1.0644944589178595
             f = x-1.0
-            return log_proc2(f, base)
+            return Base.Math.mangleNaN(log_proc2(f, base))
         end
 
         # Step 3
@@ -292,7 +292,7 @@ function _log(x::Float64, base, func)
         F = (y + 3.5184372088832e13) - 3.5184372088832e13 # 0x1p-7*round(0x1p7*y)
         f = y-F
 
-        return log_proc1(y,mf,F,f,base)
+        return Base.Math.mangleNaN(log_proc1(y,mf,F,f,base))
     elseif x == 0.0
         -Inf
     elseif isnan(x)
@@ -309,7 +309,7 @@ function _log(x::Float32, base, func)
         # Step 2
         if 0.939413f0 < x < 1.0644945f0
             f = x-1f0
-            return log_proc2(f, base)
+            return Base.Math.mangleNaN(log_proc2(f, base))
         end
 
         # Step 3
@@ -342,11 +342,11 @@ function log1p(x::Float64)
     if x > -1.0
         x == Inf && return x
         if -1.1102230246251565e-16 < x < 1.1102230246251565e-16
-            return x # Inexact
+            return Base.Math.mangleNaN(x) # Inexact
 
         # Step 2
         elseif -0.06058693718652422 < x < 0.06449445891785943
-            return log_proc2(x)
+            return Base.Math.mangleNaN(log_proc2(x))
         end
 
         # Step 3
@@ -375,10 +375,10 @@ function log1p(x::Float32)
     if x > -1f0
         x == Inf32 && return x
         if -5.9604645f-8 < x < 5.9604645f-8
-            return x # Inexact
+            return Base.Math.mangleNaN(x) # Inexact
         # Step 2
         elseif -0.06058694f0 < x < 0.06449446f0
-            return log_proc2(x)
+            return Base.Math.mangleNaN(log_proc2(x))
         end
 
         # Step 3
@@ -552,7 +552,7 @@ const t_log_table_compact = (
  @inline function log_tab_unpack(t::UInt64)
     invc = UInt64(t&UInt64(0xff)|0x1ff00)<<45
     logc = t&(~UInt64(0xff))
-    return (reinterpret(Float64, invc), reinterpret(Float64, logc))
+    return Base.Math.mangleNaN((reinterpret(Float64, invc), reinterpret(Float64, logc)))
 end
 
 # Log implementation that returns 2 numbers which sum to give true value with about 68 bits of precision
@@ -589,5 +589,5 @@ function _log_ext(xu)
     lo4 = t2 - hi + ar2
     p = evalpoly(r, (-0x1.555555555556p-1, 0x1.0000000000006p-1, -0x1.999999959554ep-2, 0x1.555555529a47ap-2, -0x1.2495b9b4845e9p-2, 0x1.0002b8b263fc3p-2))
     lo = lo1 + lo2 + lo3 + muladd(r*ar2, p, lo4)
-    return hi, lo
+    return Base.Math.mangleNaN(hi, lo)
 end

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -30,24 +30,24 @@ function sin(x::T) where T<:Union{Float32, Float64}
     absx = abs(x)
     if absx < T(pi)/4 #|x| ~<= pi/4, no need for reduction
         if absx < sqrt(eps(T))
-            return x
+            return Base.Math.mangleNaN(x)
         end
-        return sin_kernel(x)
+        return Base.Math.mangleNaN(sin_kernel(x))
     elseif isnan(x)
-        return T(NaN)
+        return Base.Math.mangleNaN(T(NaN))
     elseif isinf(x)
         sin_domain_error(x)
     end
     n, y = rem_pio2_kernel(x)
     n = n&3
     if n == 0
-        return sin_kernel(y)
+        return Base.Math.mangleNaN(sin_kernel(y))
     elseif n == 1
-        return cos_kernel(y)
+        return Base.Math.mangleNaN(cos_kernel(y))
     elseif n == 2
-        return -sin_kernel(y)
+        return Base.Math.mangleNaN(-sin_kernel(y))
     else
-        return -cos_kernel(y)
+        return Base.Math.mangleNaN(-cos_kernel(y))
     end
 end
 
@@ -99,24 +99,24 @@ function cos(x::T) where T<:Union{Float32, Float64}
     absx = abs(x)
     if absx < T(pi)/4
         if absx < sqrt(eps(T)/T(2.0))
-            return T(1.0)
+            return Base.Math.mangleNaN(T(1.0))
         end
-        return cos_kernel(x)
+        return Base.Math.mangleNaN(cos_kernel(x))
     elseif isnan(x)
-        return T(NaN)
+        return Base.Math.mangleNaN(T(NaN))
     elseif isinf(x)
         cos_domain_error(x)
     else
         n, y = rem_pio2_kernel(x)
         n = n&3
         if n == 0
-            return cos_kernel(y)
+            return Base.Math.mangleNaN(cos_kernel(y))
         elseif n == 1
-            return -sin_kernel(y)
+            return Base.Math.mangleNaN(-sin_kernel(y))
         elseif n == 2
-            return -cos_kernel(y)
+            return Base.Math.mangleNaN(-cos_kernel(y))
         else
-            return sin_kernel(y)
+            return Base.Math.mangleNaN(sin_kernel(y))
         end
     end
 end
@@ -175,11 +175,11 @@ See also [`cis`](@ref), [`sincospi`](@ref), [`sincosd`](@ref).
 function sincos(x::T) where T<:Union{Float32, Float64}
     if abs(x) < T(pi)/4
         if x == zero(T)
-            return x, one(T)
+            return Base.Math.mangleNaN(x, one(T))
         end
-        return sincos_kernel(x)
+        return Base.Math.mangleNaN(sincos_kernel(x))
     elseif isnan(x)
-        return T(NaN), T(NaN)
+        return Base.Math.mangleNaN(T(NaN), T(NaN))
     elseif isinf(x)
         sincos_domain_error(x)
     end
@@ -190,13 +190,13 @@ function sincos(x::T) where T<:Union{Float32, Float64}
     # ... and use the same selection scheme as above: (sin, cos, -sin, -cos) for
     # for sin and (cos, -sin, -cos, sin) for cos
     if n == 0
-        return si, co
+        return Base.Math.mangleNaN(si, co)
     elseif n == 1
-        return co, -si
+        return Base.Math.mangleNaN(co, -si)
     elseif n == 2
-        return -si, -co
+        return Base.Math.mangleNaN(-si, -co)
     else
-        return -co, si
+        return Base.Math.mangleNaN(-co, si)
     end
 end
 
@@ -217,19 +217,19 @@ function tan(x::T) where T<:Union{Float32, Float64}
     absx = abs(x)
     if absx < T(pi)/4
         if absx < sqrt(eps(T))/2 # first order dominates, but also allows tan(-0)=-0
-            return x
+            return Base.Math.mangleNaN(x)
         end
-        return tan_kernel(x)
+        return Base.Math.mangleNaN(tan_kernel(x))
     elseif isnan(x)
-        return T(NaN)
+        return Base.Math.mangleNaN(T(NaN))
     elseif isinf(x)
         tan_domain_error(x)
     end
     n, y = rem_pio2_kernel(x)
     if iseven(n)
-        return tan_kernel(y,1)
+        return Base.Math.mangleNaN(tan_kernel(y,1))
     else
-        return tan_kernel(y,-1)
+        return Base.Math.mangleNaN(tan_kernel(y,-1))
     end
 end
 
@@ -313,12 +313,12 @@ end
         #     tan(y) = 1 - 2*(tan(y) - (tan(y)^2)/(1+tan(y)))
         #            ≈ 1 - 2*(P(z) - (P(z)^2)/(1+P(z)))
         # where z = y-π/4.
-        return (signbit(y.hi) ? -1.0 : 1.0)*(k - 2*(yhi-(Px^2/(k+Px)-r)))
+        return Base.Math.mangleNaN((signbit(y.hi) ? -1.0 : 1.0)*(k - 2*(yhi-(Px^2/(k+Px)-r))))
     end
     if k == 1
         # Else, we simply return w = P(y) if k == 1 (integer multiple from argument
         # reduction was even)...
-        return Px
+        return Base.Math.mangleNaN(Px)
     else
         # ...or tan(y) ≈ -1.0/(y+r) if !(k == 1) (integer multiple from argument
         # reduction was odd). If 2ulp error is allowed, simply return the frac-
@@ -331,7 +331,7 @@ end
         # zero out low word of t
         t = reinterpret(Float64, (reinterpret(UInt64, t) >> 32) << 32)
         s = 1.0 + t * Px0
-        return t + a * (s + t * v)
+        return Base.Math.mangleNaN(t + a * (s + t * v))
     end
 end
 
@@ -346,10 +346,10 @@ end
     u  = @horner(y², 0.333331395030791399758, 0.133392002712976742718)
     Py  = (y.hi+y³*u)+(y³*y⁴)*(t+y⁴*r)
     if k == 1
-        return Float32(Py)
+        return Base.Math.mangleNaN(Float32(Py))
     end
 
-    return Float32(-1.0/Py)
+    return Base.Math.mangleNaN(Float32(-1.0/Py))
 end
 
 # fallback methods
@@ -409,13 +409,13 @@ arc_q(t::Float32) = @horner(t, 1.0f0, -7.0662963390f-01)
     s = sqrt_llvm(t)
     tRt = arc_tRt(t)
     if abs(x) >= 0.975 # |x| > 0.975
-        return flipsign(pi/2 - (2.0*(s + s*tRt) - pio2_lo), x)
+        return Base.Math.mangleNaN(flipsign(pi/2 - (2.0*(s + s*tRt) - pio2_lo), x))
     else
         s0 = reinterpret(Float64, (reinterpret(UInt64, s) >> 32) << 32)
         c = (t - s0*s0)/(s + s0)
         p = 2.0*s*tRt - (pio2_lo - 2.0*c)
         q = pi/4 - 2.0*s0
-        return flipsign(pi/4 - (p-q), x)
+        return Base.Math.mangleNaN(flipsign(pi/4 - (p-q), x))
     end
 end
 @inline function asin_kernel(t::Float32, x::Float32)
@@ -436,19 +436,19 @@ function asin(x::T) where T<:Union{Float32, Float64}
     absx = abs(x)
     if absx >= T(1.0) # |x|>= 1
         if absx == T(1.0)
-            return flipsign(T(pi)/2, x)
+            return Base.Math.mangleNaN(flipsign(T(pi)/2, x))
         end
         asin_domain_error(x)
     elseif absx < T(1.0)/2
         # if |x| sufficiently small, |x| is a good approximation
         if absx < ASIN_X_MIN_THRESHOLD(T)
-            return x
+            return Base.Math.mangleNaN(x)
         end
-        return muladd(x, arc_tRt(x*x), x)
+        return Base.Math.mangleNaN(muladd(x, arc_tRt(x*x), x))
     end
     # else 1/2 <= |x| < 1
     t = (T(1.0) - absx)/2
-    return asin_kernel(t, x)
+    return Base.Math.mangleNaN(asin_kernel(t, x))
 end
 
 # atan methods
@@ -517,15 +517,15 @@ function atan(x::T) where T<:Union{Float32, Float64}
 
     absx = abs(x)
     if absx >= ATAN_LARGE_X(T)
-        return copysign(T(1.5707963267948966), x)
+        return Base.Math.mangleNaN(copysign(T(1.5707963267948966), x))
     end
     if absx < T(7/16)
         # no reduction needed
         if absx < ATAN_SMALL_X(T)
-            return x
+            return Base.Math.mangleNaN(x)
         end
         p, q = atan_pq(x)
-        return x - x*(p + q)
+        return Base.Math.mangleNaN(x - x*(p + q))
     end
     xsign = sign(x)
     if absx < T(19/16) # 7/16 <= |x| < 19/16
@@ -583,47 +583,47 @@ function atan(y::T, x::T) where T<:Union{Float32, Float64}
     #    S9) ATAN2(+-INF,-INF ) is +-3pi/4;
     #    S10) ATAN2(+-INF, (anything but,0,NaN, and INF)) is +-pi/2;
     if isnan(x) || isnan(y) # S1 or S2
-        return T(NaN)
+        return Base.Math.mangleNaN(T(NaN))
     end
 
     if x == T(1.0) # then y/x = y and x > 0, see M2
-        return atan(y)
+        return Base.Math.mangleNaN(atan(y))
     end
     # generate an m ∈ {0, 1, 2, 3} to branch off of
     m = 2*signbit(x) + 1*signbit(y)
 
     if iszero(y)
         if m == 0 || m == 1
-            return y # atan(+-0, +anything) = +-0
+            return Base.Math.mangleNaN(y) # atan(+-0, +anything) = +-0
         elseif m == 2
-            return T(pi) # atan(+0, -anything) = pi
+            return Base.Math.mangleNaN(T(pi)) # atan(+0, -anything) = pi
         elseif m == 3
-            return -T(pi) # atan(-0, -anything) =-pi
+            return Base.Math.mangleNaN(-T(pi)) # atan(-0, -anything) =-pi
         end
     elseif iszero(x)
-        return flipsign(T(pi)/2, y)
+        return Base.Math.mangleNaN(flipsign(T(pi)/2, y))
     end
 
     if isinf(x)
         if isinf(y)
             if m == 0
-                return T(pi)/4  # atan(+Inf), +Inf))
+                return Base.Math.mangleNaN(T(pi)/4)  # atan(+Inf), +Inf))
             elseif m == 1
-                return -T(pi)/4 # atan(-Inf), +Inf))
+                return Base.Math.mangleNaN(-T(pi)/4) # atan(-Inf), +Inf))
             elseif m == 2
-                return 3*T(pi)/4 # atan(+Inf, -Inf)
+                return Base.Math.mangleNaN(3*T(pi)/4) # atan(+Inf, -Inf)
             elseif m == 3
-                return -3*T(pi)/4 # atan(-Inf,-Inf)
+                return Base.Math.mangleNaN(-3*T(pi)/4) # atan(-Inf,-Inf)
             end
         else
             if m == 0
-                return zero(T)  # atan(+...,+Inf) */
+                return Base.Math.mangleNaN(zero(T) ) # atan(+...,+Inf) */
             elseif m == 1
-                return -zero(T) # atan(-...,+Inf) */
+                return Base.Math.mangleNaN(-zero(T)) # atan(-...,+Inf) */
             elseif m == 2
-                return T(pi)    # atan(+...,-Inf) */
+                return Base.Math.mangleNaN(T(pi)   ) # atan(+...,-Inf) */
             elseif m == 3
-                return -T(pi)   # atan(-...,-Inf) */
+                return Base.Math.mangleNaN(-T(pi)  ) # atan(-...,-Inf) */
             end
         end
     end
@@ -646,13 +646,13 @@ function atan(y::T, x::T) where T<:Union{Float32, Float64}
     end
 
     if m == 0
-        return z # atan(+,+)
+        return Base.Math.mangleNaN(z) # atan(+,+)
     elseif m == 1
-        return -z # atan(-,+)
+        return Base.Math.mangleNaN(-z) # atan(-,+)
     elseif m == 2
-        return T(pi)-(z-ATAN2_PI_LO(T)) # atan(+,-)
+        return Base.Math.mangleNaN(T(pi)-(z-ATAN2_PI_LO(T))) # atan(+,-)
     else # default case m == 3
-        return (z-ATAN2_PI_LO(T))-T(pi) # atan(-,-)
+        return Base.Math.mangleNaN((z-ATAN2_PI_LO(T))-T(pi)) # atan(-,-)
     end
 end
 # acos methods
@@ -702,13 +702,13 @@ function acos(x::T) where T <: Union{Float32, Float64}
         # if |x| sufficiently small, acos(x) ≈ pi/2
         absx < ACOS_X_MIN_THRESHOLD(T) && return T(pi)/2
         # if |x| < 0.5 we have acos(x) = pi/2 - (x + x*x^2*R(x^2))
-        return PIO2_HI(T) - (x - (PIO2_LO(T) - x*arc_tRt(x*x)))
+        return Base.Math.mangleNaN(PIO2_HI(T) - (x - (PIO2_LO(T) - x*arc_tRt(x*x))))
     end
     z = (T(1.0) - absx)*T(0.5)
     zRz = arc_tRt(z)
     s = sqrt_llvm(z)
     if x < T(0.0) # see 2) above
-        return ACOS_PI(T) - T(2.0)*(s + (zRz*s - PIO2_LO(T)))
+        return Base.Math.mangleNaN(ACOS_PI(T) - T(2.0)*(s + (zRz*s - PIO2_LO(T))))
     else # see 3) above
         # if x > 0.5 we have
         # acos(x) = pi/2 - (pi/2 - 2asin(sqrt((1-x)/2)))
@@ -719,7 +719,7 @@ function acos(x::T) where T <: Union{Float32, Float64}
         # for f so that f+c ~ sqrt(z).
         df = ACOS_CORRECT_LOWWORD(T, s)
         c  = (z - df*df)/(s + df)
-        return T(2.0)*(df + (zRz*s + c))
+        return Base.Math.mangleNaN(T(2.0)*(df + (zRz*s + c)))
     end
 end
 
@@ -732,16 +732,16 @@ end
     x⁴ = x²*x²
     r  = evalpoly(x², (2.5501640398773415, -0.5992645293202981, 0.08214588658006512,
                        -7.370429884921779e-3, 4.662827319453555e-4, -2.1717412523382308e-5))
-    return muladd(3.141592653589793, x, x*muladd(-5.16771278004997,
-                  x², muladd(x⁴, r,  1.2245907532225998e-16)))
+    return Base.Math.mangleNaN(muladd(3.141592653589793, x, x*muladd(-5.16771278004997,
+                  x², muladd(x⁴, r,  1.2245907532225998e-16))))
 end
 @inline function sinpi_kernel(x::Float32)
     Float32(sinpi_kernel_wide(x))
 end
 @inline function sinpi_kernel_wide(x::Float32)
     x = Float64(x)
-    return x*evalpoly(x*x, (3.1415926535762266, -5.167712769188119,
-                            2.5501626483206374, -0.5992021090314925, 0.08100185277841528))
+    return Base.Math.mangleNaN(x*evalpoly(x*x, (3.1415926535762266, -5.167712769188119,
+                            2.5501626483206374, -0.5992021090314925, 0.08100185277841528)))
 end
 
 @inline function sinpi_kernel(x::Float16)
@@ -749,7 +749,7 @@ end
 end
 @inline function sinpi_kernel_wide(x::Float16)
     x = Float32(x)
-    return x*evalpoly(x*x, (3.1415927f0, -5.1677127f0, 2.5501626f0, -0.5992021f0, 0.081001855f0))
+    return Base.Math.mangleNaN(x*evalpoly(x*x, (3.1415927f0, -5.1677127f0, 2.5501626f0, -0.5992021f0, 0.081001855f0)))
 end
 
 # Uses minimax polynomial of cos(π * x) for π * x in [0, .25]
@@ -764,22 +764,22 @@ end
     a_x²lo = muladd(3.109686485461973e-16, x², muladd(4.934802200544679, x², -a_x²))
 
     w  = 1.0-a_x²
-    return w + muladd(x², r, ((1.0-w)-a_x²) - a_x²lo)
+    return Base.Math.mangleNaN(w + muladd(x², r, ((1.0-w)-a_x²) - a_x²lo))
 end
 @inline function cospi_kernel(x::Float32)
     Float32(cospi_kernel_wide(x))
 end
 @inline function cospi_kernel_wide(x::Float32)
     x = Float64(x)
-    return evalpoly(x*x, (1.0, -4.934802200541122, 4.058712123568637,
-                          -1.3352624040152927, 0.23531426791507182, -0.02550710082498761))
+    return Base.Math.mangleNaN(evalpoly(x*x, (1.0, -4.934802200541122, 4.058712123568637,
+                          -1.3352624040152927, 0.23531426791507182, -0.02550710082498761)))
 end
 @inline function cospi_kernel(x::Float16)
     Float16(cospi_kernel_wide(x))
 end
 @inline function cospi_kernel_wide(x::Float16)
     x = Float32(x)
-    return evalpoly(x*x, (1.0f0, -4.934802f0, 4.058712f0, -1.3352624f0, 0.23531426f0, -0.0255071f0))
+    return Base.Math.mangleNaN(evalpoly(x*x, (1.0f0, -4.934802f0, 4.058712f0, -1.3352624f0, 0.23531426f0, -0.0255071f0)))
 end
 
 """
@@ -813,7 +813,7 @@ function sinpi(_x::T) where T<:Union{IEEEFloat, Rational}
     else
         res = zero(T)-cospi_kernel(rx)
     end
-    return ifelse(signbit(_x), -res, res)
+    return Base.Math.mangleNaN(ifelse(signbit(_x), -res, res))
 end
 """
     cospi(x)
@@ -836,13 +836,13 @@ function cospi(x::T) where T<:Union{IEEEFloat, Rational}
     rx = float(muladd(T(-.5), n, x))
     n = Int64(n) & 3
     if n==0
-        return cospi_kernel(rx)
+        return Base.Math.mangleNaN(cospi_kernel(rx))
     elseif n==1
-        return zero(T)-sinpi_kernel(rx)
+        return Base.Math.mangleNaN(zero(T)-sinpi_kernel(rx))
     elseif n==2
-        return zero(T)-cospi_kernel(rx)
+        return Base.Math.mangleNaN(zero(T)-cospi_kernel(rx))
     else
-        return sinpi_kernel(rx)
+        return Base.Math.mangleNaN(sinpi_kernel(rx))
     end
 end
 """
@@ -882,7 +882,7 @@ function sincospi(_x::T) where T<:Union{IEEEFloat, Rational}
         si, co  = zero(T)-co, si
     end
     si = ifelse(signbit(_x), -si, si)
-    return si, co
+    return Base.Math.mangleNaN(si, co)
 end
 
 """
@@ -922,7 +922,7 @@ function tanpi(_x::T) where T<:Union{IEEEFloat, Rational}
         si, co  = zero(T)-co, si
     end
     si = ifelse(signbit(_x), -si, si)
-    return float(T)(si / co)
+    return Base.Math.mangleNaN(float(T)(si / co))
 end
 
 sinpi(x::Integer) = x >= 0 ? zero(float(x)) : -zero(float(x))
@@ -1109,9 +1109,9 @@ function _cosc(x::Number)
             s += (δs = term/(1+2n))
             fastabs(δs) ≤ ε && break
         end
-        return π*s
+        return Base.Math.mangleNaN(π*s)
     else
-        return isinf_real(x) ? zero(x) : ((pi*x)*cospi(x)-sinpi(x))/((pi*x)*x)
+        return Base.Math.mangleNaN(isinf_real(x) ? zero(x) : ((pi*x)*cospi(x)-sinpi(x))/((pi*x)*x))
     end
 end
 # hard-code Float64/Float32 Taylor series, with coefficients
@@ -1186,58 +1186,58 @@ deg2rad_ext(x::Real) = deg2rad(x) # Fallback
 
 function sind(x::Real)
     if isinf(x)
-        return throw(DomainError(x, "`x` cannot be infinite."))
+        return Base.Math.mangleNaN(throw(DomainError(x, "`x` cannot be infinite.")))
     elseif isnan(x)
-        return oftype(x,NaN)
+        return Base.Math.mangleNaN(oftype(x,NaN))
     end
 
     rx = copysign(float(rem(x,360)),x)
     arx = abs(rx)
 
     if rx == zero(rx)
-        return rx
+        return Base.Math.mangleNaN(rx)
     elseif arx < oftype(rx,45)
-        return sin_kernel(deg2rad_ext(rx))
+        return Base.Math.mangleNaN(sin_kernel(deg2rad_ext(rx)))
     elseif arx <= oftype(rx,135)
         y = deg2rad_ext(oftype(rx,90) - arx)
-        return copysign(cos_kernel(y),rx)
+        return Base.Math.mangleNaN(copysign(cos_kernel(y),rx))
     elseif arx == oftype(rx,180)
-        return copysign(zero(rx),rx)
+        return Base.Math.mangleNaN(copysign(zero(rx),rx))
     elseif arx < oftype(rx,225)
         y = deg2rad_ext((oftype(rx,180) - arx)*sign(rx))
-        return sin_kernel(y)
+        return Base.Math.mangleNaN(sin_kernel(y))
     elseif arx <= oftype(rx,315)
         y = deg2rad_ext(oftype(rx,270) - arx)
-        return -copysign(cos_kernel(y),rx)
+        return Base.Math.mangleNaN(-copysign(cos_kernel(y),rx))
     else
         y = deg2rad_ext(rx - copysign(oftype(rx,360),rx))
-        return sin_kernel(y)
+        return Base.Math.mangleNaN(sin_kernel(y))
     end
 end
 
 function cosd(x::Real)
     if isinf(x)
-        return throw(DomainError(x, "`x` cannot be infinite."))
+        return Base.Math.mangleNaN(throw(DomainError(x, "`x` cannot be infinite.")))
     elseif isnan(x)
-        return oftype(x,NaN)
+        return Base.Math.mangleNaN(oftype(x,NaN))
     end
 
     rx = abs(float(rem(x,360)))
 
     if rx <= oftype(rx,45)
-        return cos_kernel(deg2rad_ext(rx))
+        return Base.Math.mangleNaN(cos_kernel(deg2rad_ext(rx)))
     elseif rx < oftype(rx,135)
         y = deg2rad_ext(oftype(rx,90) - rx)
-        return sin_kernel(y)
+        return Base.Math.mangleNaN(sin_kernel(y))
     elseif rx <= oftype(rx,225)
         y = deg2rad_ext(oftype(rx,180) - rx)
-        return -cos_kernel(y)
+        return Base.Math.mangleNaN(-cos_kernel(y))
     elseif rx < oftype(rx,315)
         y = deg2rad_ext(rx - oftype(rx,270))
-        return sin_kernel(y)
+        return Base.Math.mangleNaN(sin_kernel(y))
     else
         y = deg2rad_ext(oftype(rx,360) - rx)
-        return cos_kernel(y)
+        return Base.Math.mangleNaN(cos_kernel(y))
     end
 end
 


### PR DESCRIPTION
To test dependance on NaN payloads with pkgeval. Supports discussion at #48523.

This is never intended to merge. It would be a terrible semantic and also bad for performance. It's only to inform discussion by seeing what it would hypothetically break.