### PR TITLE
avoid copy in getindex(::RegexMatch,::String)

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -243,19 +243,17 @@ end
 
 # Capture group extraction
 getindex(m::RegexMatch, idx::Integer) = m.captures[idx]
-function getindex(m::RegexMatch, name::Symbol)
+function getindex(m::RegexMatch, name::Union{AbstractString,Symbol})
     idx = PCRE.substring_number_from_name(m.regex.regex, name)
     idx <= 0 && error("no capture group named $name found in regex")
     m[idx]
 end
-getindex(m::RegexMatch, name::AbstractString) = m[Symbol(name)]
 
 haskey(m::RegexMatch, idx::Integer) = idx in eachindex(m.captures)
-function haskey(m::RegexMatch, name::Symbol)
+function haskey(m::RegexMatch, name::Union{AbstractString,Symbol})
     idx = PCRE.substring_number_from_name(m.regex.regex, name)
     return idx > 0
 end
-haskey(m::RegexMatch, name::AbstractString) = haskey(m, Symbol(name))
 
 iterate(m::RegexMatch, args...) = iterate(m.captures, args...)
 length(m::RegexMatch) = length(m.captures)


### PR DESCRIPTION
I noticed that this method was calling `Symbol(name)`, which makes a copy unnecessarily — the `name` argument just needs to be passed to `PCRE.substring_number_from_name`, but [that function](https://github.com/JuliaLang/julia/blob/b0ac45f3fbc8501c8b3909e838103c88114b29b6/base/pcre.jl#L231-L235) accepts *any* type that can be `cconvert`-ed to a `Cstring` — i.e. any `AbstractString` in addition to `Symbol`.  So we might as well avoid the copy.

There is [already a test](https://github.com/JuliaLang/julia/blob/b0ac45f3fbc8501c8b3909e838103c88114b29b6/test/regex.jl#L102-L110).