### PR TITLE
add replace(io, str, patterns...)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@ New library functions
 
 New library features
 --------------------
+* `replace(string, pattern...)` now supports an optional `IO` argument to
+  write the output to a stream rather than returning a string ([#48625]).
 
 Standard library changes
 ------------------------

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -840,12 +840,6 @@ replace(out::IO, s::AbstractString, pat_f::Pair...; count=typemax(Int)) =
 replace(s::AbstractString, pat_f::Pair...; count=typemax(Int)) =
     _replace_str(String(s), pat_f..., count=count)
 
-# no copy needed for SubString{String}
-replace(out::IO, s::SubString{String}, pat_f::Pair...; count=typemax(Int)) =
-    _replace_io(out, s, pat_f..., count=count)
-replace(s::SubString{String}, pat_f::Pair...; count=typemax(Int)) =
-    _replace_str(s, pat_f..., count=count)
-
 
 # TODO: allow transform as the first argument to replace?
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -704,10 +704,11 @@ _pat_replacer(x::Union{Tuple{Vararg{AbstractChar}},AbstractVector{<:AbstractChar
 function _replace_init(str, pat_repl::NTuple{N, Pair}, count::Int) where N
     count < 0 && throw(DomainError(count, "`count` must be non-negative."))
     e1 = nextind(str, lastindex(str)) # sizeof(str)+1
+    a = firstindex(str)
     patterns = map(p -> _pat_replacer(first(p)), pat_repl)
     replaces = map(last, pat_repl)
     rs = map(patterns) do p
-        r = findfirst(p, str)
+        r = findnext(p, str, a)
         if r === nothing || first(r) == 0
             return e1+1:0
         end
@@ -718,8 +719,7 @@ function _replace_init(str, pat_repl::NTuple{N, Pair}, count::Int) where N
 end
 
 # note: leave str untyped here to make it easier for packages like StringViews to hook in
-function _replace_finish(io::IO, str, count::Int,
-                         e1::Int, patterns::NTuple{N}, replaces::NTuple{N}, rs::NTuple{N}) where N
+function _replace_finish(io::IO, str, count::Int, e1, patterns, replaces, rs)
     n = 1
     i = a = firstindex(str)
     while true

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -703,9 +703,7 @@ _pat_replacer(x::Union{Tuple{Vararg{AbstractChar}},AbstractVector{<:AbstractChar
 # note: leave str untyped here to make it easier for packages like StringViews to hook in
 function _replace_init(str, pat_repl::NTuple{N, Pair}, count::Int) where N
     count < 0 && throw(DomainError(count, "`count` must be non-negative."))
-    n = 1
-    e1 = nextind(str, lastindex(str)) # sizeof(str)
-    i = a = firstindex(str)
+    e1 = sizeof(str)+1 # nextind(str, lastindex(str))
     patterns = map(p -> _pat_replacer(first(p)), pat_repl)
     replaces = map(last, pat_repl)
     rs = map(patterns) do p
@@ -722,6 +720,9 @@ end
 # note: leave str untyped here to make it easier for packages like StringViews to hook in
 function _replace_finish(out::IO, str, count::Int,
                          patterns::NTuple{N}, replaces::NTuple{N}, rs::NTuple{N}) where N
+    n = 1
+    e1 = sizeof(str)+1 # nextind(str, lastindex(str))
+    i = a = firstindex(str)
     while true
         p = argmin(map(first, rs)) # TODO: or argmin(rs), to pick the shortest first match ?
         r = rs[p]

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -51,7 +51,7 @@ Base.findlast(::AbstractChar, ::AbstractString)
 Base.findprev(::AbstractString, ::AbstractString, ::Integer)
 Base.occursin
 Base.reverse(::Union{String,SubString{String}})
-Base.replace(s::AbstractString, ::Pair...)
+Base.replace(::IO, s::AbstractString, ::Pair...)
 Base.eachsplit
 Base.split
 Base.rsplit

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -333,6 +333,24 @@ end
     # Issue 36953
     @test replace("abc", "" => "_", count=1) == "_abc"
 
+    # tests for io::IO API (in addition to internals exercised above):
+    let buf = IOBuffer()
+        replace(buf, "aaa", 'a' => 'z', count=0)
+        replace(buf, "aaa", 'a' => 'z', count=1)
+        replace(buf, "bbb", 'a' => 'z')
+        replace(buf, "aaa", 'a' => 'z')
+        @test String(take!(buf)) == "aaazaabbbzzz"
+    end
+    let tempfile = tempname()
+        open(tempfile, "w") do f
+            replace(f, "aaa", 'a' => 'z', count=0)
+            replace(f, "aaa", 'a' => 'z', count=1)
+            replace(f, "bbb", 'a' => 'z')
+            replace(f, "aaa", 'a' => 'z')
+            print(f, "\n")
+        end
+        @test read(tempfile, String) == "aaazaabbbzzz\n"
+    end
 end
 
 @testset "replace many" begin

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -342,14 +342,18 @@ end
         @test String(take!(buf)) == "aaazaabbbzzz"
     end
     let tempfile = tempname()
-        open(tempfile, "w") do f
-            replace(f, "aaa", 'a' => 'z', count=0)
-            replace(f, "aaa", 'a' => 'z', count=1)
-            replace(f, "bbb", 'a' => 'z')
-            replace(f, "aaa", 'a' => 'z')
-            print(f, "\n")
+        try
+            open(tempfile, "w") do f
+                replace(f, "aaa", 'a' => 'z', count=0)
+                replace(f, "aaa", 'a' => 'z', count=1)
+                replace(f, "bbb", 'a' => 'z')
+                replace(f, "aaa", 'a' => 'z')
+                print(f, "\n")
+            end
+            @test read(tempfile, String) == "aaazaabbbzzz\n"
+        finally
+            rm(tempfile, force=true)
         end
-        @test read(tempfile, String) == "aaazaabbbzzz\n"
     end
 end
 


### PR DESCRIPTION
This PR adds an optional `io::IO` argument to `replace(str, patterns...)` so that the output can be written to an `IO` stream rather than returning a `String`.    This requires almost no new code, only some refactoring, since internally `replace` was already implemented by writing to an `IOBuffer`.

As @jakobnissen has pointed out, we have a shortage of in-place operations for strings.  `replace` was an egregious example because it was virtually impossible to do in-place without copy-pasting large swathes of code from `Base`.  Now you can simply write to a pre-allocated, re-usable `IOBuffer`.

This PR was also motivated by a [discourse discussion](https://discourse.julialang.org/t/replace-lines-of-file-a-using-advanced-regex-and-write-to-file-b/94362) about performing regex substitutions on a file.   For large files that cannot simply be read into memory, I realized that this is unnecessarily difficult (especially if you want to use `SubstitutionString` since it requires a completely undocumented internal `_replace` API, or multiple replacement patterns).   With this PR, it should be possible to simply do:
```jl
using Mmap, StringViews
s = StringView(mmap("input_file"))
open(out -> replace(out, s, pat=>repl), "output_file", "w")
```
to get something very efficient (after corresponding hooks are added to StringViews.jl to prevent `s` from being copied to a `String`).