### PR TITLE
Partial fixes for building under MSys2 MINGW64

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -362,6 +362,18 @@ export PKG_CONFIG_LIBDIR = $(JULIAHOME)/usr/lib/pkgconfig
 # Figure out OS and architecture
 BUILD_OS := $(shell uname)
 
+# Set ISMSYS_MINGW64 to 0 or 1
+OSNAME := $(shell uname -o | tr '[:lower:]' '[:upper:]')
+ISMSYS_MINGW64 := 0
+ifneq (,$(findstring MSYS,$(OSNAME)))
+TRIPLET := $(shell $(CC) -dumpmachine)
+ifneq (,$(findstring w64,$(TRIPLET)))
+ifneq (,$(findstring mingw,$(TRIPLET)))
+override ISMSYS_MINGW64 := 1
+endif
+endif
+endif
+
 ifneq (,$(findstring CYGWIN,$(BUILD_OS)))
 XC_HOST ?= $(shell uname -m)-w64-mingw32
 endif
@@ -621,7 +633,11 @@ endif
 ifeq ($(OS), FreeBSD)
 LOCALBASE ?= /usr/local
 else
+ifeq (1,$(ISMSYS_MINGW64))
+LOCALBASE ?= $(MINGW_PREFIX)
+else
 LOCALBASE ?= /usr
+endif
 endif
 
 ifeq (exists, $(shell [ -e $(JULIAHOME)/$(MAKE_USER_FNAME) ] && echo exists ))

--- a/Make.inc
+++ b/Make.inc
@@ -362,18 +362,6 @@ export PKG_CONFIG_LIBDIR = $(JULIAHOME)/usr/lib/pkgconfig
 # Figure out OS and architecture
 BUILD_OS := $(shell uname)
 
-# Set ISMSYS_MINGW64 to 0 or 1
-OSNAME := $(shell uname -o | tr '[:lower:]' '[:upper:]')
-ISMSYS_MINGW64 := 0
-ifneq (,$(findstring MSYS,$(OSNAME)))
-TRIPLET := $(shell $(CC) -dumpmachine)
-ifneq (,$(findstring w64,$(TRIPLET)))
-ifneq (,$(findstring mingw,$(TRIPLET)))
-override ISMSYS_MINGW64 := 1
-endif
-endif
-endif
-
 ifneq (,$(findstring CYGWIN,$(BUILD_OS)))
 XC_HOST ?= $(shell uname -m)-w64-mingw32
 endif
@@ -627,6 +615,18 @@ JL_MAJOR_SHLIB_EXT := $(SOMAJOR).$(SHLIB_EXT)
 else
 JL_MAJOR_MINOR_SHLIB_EXT := $(SHLIB_EXT).$(SOMAJOR).$(SOMINOR)
 JL_MAJOR_SHLIB_EXT := $(SHLIB_EXT).$(SOMAJOR)
+endif
+endif
+
+# Set ISMSYS_MINGW64 to 0 or 1
+OSNAME := $(shell uname -o | tr '[:lower:]' '[:upper:]')
+ISMSYS_MINGW64 := 0
+ifneq (,$(findstring MSYS,$(OSNAME)))
+TRIPLET := $(shell $(CC) -dumpmachine)
+ifneq (,$(findstring w64,$(TRIPLET)))
+ifneq (,$(findstring mingw,$(TRIPLET)))
+ISMSYS_MINGW64 := 1
+endif
 endif
 endif
 

--- a/deps/csl.mk
+++ b/deps/csl.mk
@@ -4,6 +4,9 @@ STD_LIB_PATH += :$(shell LANG=C $(FC) -print-search-dirs 2>/dev/null | grep '^li
 ifneq (,$(findstring CYGWIN,$(BUILD_OS))) # the cygwin-mingw32 compiler lies about it search directory paths
 STD_LIB_PATH := $(shell echo '$(STD_LIB_PATH)' | sed -e "s!/lib/!/bin/!g")
 endif
+ifeq (1,$(ISMSYS_MINGW64))
+STD_LIB_PATH := $(LOCALBASE)/bin
+endif
 
 # Given a colon-separated list of paths in $(2), find the location of the library given in $(1)
 define pathsearch


### PR DESCRIPTION
Tested with Make.user containing
```
DEPS_GIT = 1
USE_BINARYBUILDER_CSL = 0
USE_BINARYBUILDER_LLVM = 0
USE_BINARYBUILDER_GMP = 0
USE_BINARYBUILDER_MPFR = 0
```

It failed about the same place as an Cygwin build did that had the same settings plus 'XC_HOST = x86_64-w64-mingw32'
Edit: Recent changes to master now breaks Cygwin a little sooner.

Tim S.