### PR TITLE
Correct docs on `nthreads`

### DIFF
--- a/doc/src/manual/multi-threading.md
+++ b/doc/src/manual/multi-threading.md
@@ -104,18 +104,25 @@ the `:interactive` threadpool:
 ```julia-repl
 julia> using Base.Threads
 
-julia> nthreads()
-4
-
 julia> nthreadpools()
 2
 
 julia> threadpool()
 :default
 
+julia> nthreads(:default)
+3
+
 julia> nthreads(:interactive)
 1
+
+julia> nthreads()
+3
 ```
+
+!!! note
+    The zero-argument version of `nthreads` returns the number of threads
+    in the default pool.
 
 Either or both numbers can be replaced with the word `auto`, which causes
 Julia to choose a reasonable default.


### PR DESCRIPTION
The manual was saying that invoking `Threads.nthreads()` in a Julia session started with `-t 3,1` should return 4. It does not, and probably should not. It seems to give the number of threads in the default thread pool, which in the example is 3.
I corrected this mistake and added a note.