### PR TITLE
use concrete eltypes in `union` when `Generator` is used

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -56,6 +56,7 @@ function union end
 
 union(s, sets...) = union!(emptymutable(s, promote_eltype(s, sets...)), s, sets...)
 union(s::AbstractSet) = copy(s)
+union(s::Generator) = union!(emptymutable(s, promote_eltype(s.iter)), s)
 
 const ∪ = union
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1172,6 +1172,12 @@ end
     end
 end
 
+@testset "union with Generator" begin
+    fruits = ["apple", "banana", "grapes", "grapes"]
+    @test isequal(union(fruit for fruit in fruits), ["apple", "banana", "grapes"])
+    @test isequal(union(i for i in 1:3), [1, 2, 3])
+end
+
 @testset "mapslices" begin
     local a, b, c, m, h, s
     a = rand(5,5)


### PR DESCRIPTION
Fixes: #48448 

```
julia> x = ["apple", "banana", "grapes"]
3-element Vector{String}:
 "apple"
 "banana"
 "grapes"

julia> union(i for i in x)
3-element Vector{Any}:
 "apple"
 "banana"
 "grapes"

julia> union([i for i in x])
3-element Vector{String}:
 "apple"
 "banana"
 "grapes"
```

I think either the user can use the `union([i for i in x])` syntax or we have to change the code to give a concrete type, the latter seems the way forward imo. This PR tries to fix that.

It works fine after my changes:
```
julia> x = ["apple", "banana", "grapes"]
3-element Vector{String}:
 "apple"
 "banana"
 "grapes"

julia> union(i for i in x)
3-element Vector{String}:
 "apple"
 "banana"
 "grapes"
```
