### PR TITLE
unsafe_take!(::IOBuffer) for when buffer no longer needed?

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -300,7 +300,7 @@ function transcode(::Type{UInt8}, src::Vector{<:Union{Int32,UInt32}})
     for c in src
         print(buf, Char(c))
     end
-    take!(buf)
+    unsafe_take!(buf)
 end
 transcode(::Type{String}, src::String) = src
 transcode(T, src::String) = transcode(T, codeunits(src))

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -331,7 +331,7 @@ function compute_ir_line_annotations(code::IRCode)
             last_stack = stack
             entry = linetable[line]
         end
-        push!(loc_annotations, String(take!(buf)))
+        push!(loc_annotations, String(unsafe_take!(buf)))
         push!(loc_lineno, (lineno != 0 && lineno != last_lineno) ? string(lineno) : "")
         push!(loc_methods, loc_method)
         last_line = line

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -558,7 +558,7 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
                     break
                 end
                 i += 1
-                print(io, String(take!(line[1])))
+                print(io, String(unsafe_take!(line[1])))
             end
             println(io) # extra newline for spacing to stacktrace
         end

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -866,6 +866,7 @@ export
     skip,
     skipchars,
     take!,
+    unsafe_take!,
     truncate,
     unmark,
     unsafe_read,

--- a/base/int.jl
+++ b/base/int.jl
@@ -773,7 +773,7 @@ macro big_str(s)
             is_prev_dot = (c == '.')
         end
         print(bf, s[end])
-        s = String(take!(bf))
+        s = String(unsafe_take!(bf))
     end
     n = tryparse(BigInt, s)
     n === nothing || return n

--- a/base/io.jl
+++ b/base/io.jl
@@ -819,7 +819,7 @@ function readuntil(s::IO, delim::AbstractChar; keep::Bool=false)
         end
         write(out, c)
     end
-    return String(take!(out))
+    return String(unsafe_take!(out))
 end
 
 function readuntil(s::IO, delim::T; keep::Bool=false) where T
@@ -1115,7 +1115,7 @@ function iterate(r::Iterators.Reverse{<:EachLine}, state)
         buf.size = _stripnewline(r.itr.keep, buf.size, buf.data)
         empty!(chunks) # will cause next iteration to terminate
         seekend(r.itr.stream) # reposition to end of stream for isdone
-        s = String(take!(buf))
+        s = String(unsafe_take!(buf))
     else
         # extract the string from chunks[ichunk][inewline+1] to chunks[jchunk][jnewline]
         if ichunk == jchunk # common case: current and previous newline in same chunk
@@ -1132,7 +1132,7 @@ function iterate(r::Iterators.Reverse{<:EachLine}, state)
             end
             write(buf, view(chunks[jchunk], 1:jnewline))
             buf.size = _stripnewline(r.itr.keep, buf.size, buf.data)
-            s = String(take!(buf))
+            s = String(unsafe_take!(buf))
 
             # overwrite obsolete chunks (ichunk+1:jchunk)
             i = jchunk

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -688,7 +688,7 @@ function handle_message(logger::SimpleLogger, level::LogLevel, message, _module,
         println(iob, "│   ", key, " = ", val)
     end
     println(iob, "└ @ ", _module, " ", filepath, ":", line)
-    write(stream, take!(buf))
+    write(stream, unsafe_take!(buf))
     nothing
 end
 

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -172,7 +172,7 @@ function __binrepr(m::MIME, x, context)
     else
         show(IOContext(s, context), m, x)
     end
-    take!(s)
+    unsafe_take!(s)
 end
 _binrepr(m::MIME, x, context) = __binrepr(m, x, context)
 _binrepr(m::MIME, x::Vector{UInt8}, context) = x

--- a/base/pkgid.jl
+++ b/base/pkgid.jl
@@ -32,7 +32,7 @@ function binpack(pkg::PkgId)
     uuid = pkg.uuid
     write(io, uuid === nothing ? UInt128(0) : UInt128(uuid))
     write(io, pkg.name)
-    return String(take!(io))
+    return String(unsafe_take!(io))
 end
 
 function binunpack(s::String)

--- a/base/show.jl
+++ b/base/show.jl
@@ -2897,7 +2897,7 @@ summary(io::IO, x) = print(io, typeof(x))
 function summary(x)
     io = IOBuffer()
     summary(io, x)
-    String(take!(io))
+    String(unsafe_take!(io))
 end
 
 ## `summary` for AbstractArrays

--- a/base/stat.jl
+++ b/base/stat.jl
@@ -269,7 +269,7 @@ function filemode_string(mode)
         end
         complete && write(str, "-")
     end
-    return String(take!(str))
+    return String(unsafe_take!(str))
 end
 
 """

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -636,7 +636,7 @@ function filter(f, s::AbstractString)
     for c in s
         f(c) && write(out, c)
     end
-    String(take!(out))
+    String(unsafe_take!(out))
 end
 
 ## string first and last ##

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -113,7 +113,7 @@ function sprint(f::Function, args...; context=nothing, sizehint::Integer=0)
     else
         f(s, args...)
     end
-    String(resize!(s.data, s.size))
+    String(unsafe_take!(s))
 end
 
 function _str_sizehint(x)
@@ -143,7 +143,7 @@ function print_to_string(xs...)
     for x in xs
         print(s, x)
     end
-    String(resize!(s.data, s.size))
+    String(unsafe_take!(s))
 end
 
 function string_with_env(env, xs...)
@@ -160,7 +160,7 @@ function string_with_env(env, xs...)
     for x in xs
         print(env_io, x)
     end
-    String(resize!(s.data, s.size))
+    String(unsafe_take!(s))
 end
 
 """
@@ -737,7 +737,7 @@ function unindent(str::AbstractString, indent::Int; tabwidth=8)
             print(buf, ' ')
         end
     end
-    String(take!(buf))
+    String(unsafe_take!(buf))
 end
 
 function String(a::AbstractVector{Char})

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -665,7 +665,7 @@ function titlecase(s::AbstractString; wordsep::Function = !isletter, strict::Boo
         end
         c0 = c
     end
-    return String(take!(b))
+    return String(unsafe_take!(b))
 end
 
 """

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -737,7 +737,7 @@ function replace(str::String, pat_repl::Vararg{Pair,N}; count::Integer=typemax(I
     end
     foreach(_free_pat_replacer, patterns)
     write(out, SubString(str, i))
-    return String(take!(out))
+    return String(unsafe_take!(out))
 end
 
 
@@ -958,5 +958,5 @@ function Base.rest(s::AbstractString, st...)
     for c in Iterators.rest(s, st...)
         print(io, c)
     end
-    return String(take!(io))
+    return String(unsafe_take!(io))
 end

--- a/base/task.jl
+++ b/base/task.jl
@@ -96,7 +96,7 @@ function show_task_exception(io::IO, t::Task; indent = true)
     else
         show_exception_stack(IOContext(b, io), stack)
     end
-    str = String(take!(b))
+    str = String(unsafe_take!(b))
     if indent
         str = replace(str, "\n" => "\n    ")
     end

--- a/base/toml_parser.jl
+++ b/base/toml_parser.jl
@@ -315,7 +315,7 @@ function point_to_line(str::AbstractString, a::Int, b::Int, context)
         c == '\n' && break
         print(io1, c)
     end
-    return String(take!(io1.io)), String(take!(io2.io))
+    return String(unsafe_take!(io1.io)), String(unsafe_take!(io2.io))
 end
 
 function Base.showerror(io::IO, err::ParserError)

--- a/base/util.jl
+++ b/base/util.jl
@@ -75,10 +75,10 @@ function with_output_color(@nospecialize(f::Function), color::Union{Int, Symbol}
     iscolor = get(io, :color, false)::Bool
     try f(IOContext(buf, io), args...)
     finally
-        str = String(take!(buf))
         if !iscolor
-            print(io, str)
+            print(io, String(unsafe_take!(buf)))
         else
+            str = String(take!(buf))
             bold && color === :bold && (color = :nothing)
             underline && color === :underline && (color = :nothing)
             blink && color === :blink && (color = :nothing)
@@ -104,7 +104,7 @@ function with_output_color(@nospecialize(f::Function), color::Union{Int, Symbol}
                 isempty(line) && continue
                 print(buf, enable_ansi, line, disable_ansi)
             end
-            print(io, String(take!(buf)))
+            print(io, String(unsafe_take!(buf)))
         end
     end
 end

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -88,7 +88,7 @@ function cflags(doframework)
     if Sys.isunix()
         print(flags, " -fPIC")
     end
-    return String(take!(flags))
+    return String(unsafe_take!(flags))
 end
 
 function allflags(doframework)

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -10,6 +10,7 @@ Base.open
 Base.IOStream
 Base.IOBuffer
 Base.take!(::Base.GenericIOBuffer)
+Base.unsafe_take!
 Base.fdio
 Base.flush
 Base.close

--- a/stdlib/Base64/src/encode.jl
+++ b/stdlib/Base64/src/encode.jl
@@ -211,6 +211,6 @@ function base64encode(f::Function, args...; context=nothing)
         f(IOContext(b, context), args...)
     end
     close(b)
-    return String(take!(s))
+    return String(unsafe_take!(s))
 end
 base64encode(args...; context=nothing) = base64encode(write, args...; context=context)

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -122,7 +122,7 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
     if verbose
         cpuio = IOBuffer() # print cpu_summary with correct alignment
         Sys.cpu_summary(cpuio)
-        for (i, line) in enumerate(split(chomp(String(take!(cpuio))), "\n"))
+        for (i, line) in enumerate(split(chomp(String(unsafe_take!(cpuio))), "\n"))
             prefix = i == 1 ? "  CPU: " : "       "
             println(io, prefix, line)
         end

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -132,7 +132,7 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
         for (key, val) in kwargs
             key === :maxlog && continue
             showvalue(valio, val)
-            vallines = split(String(take!(valbuf)), '\n')
+            vallines = split(String(unsafe_take!(valbuf)), '\n')
             if length(vallines) == 1
                 push!(msglines, (indent=2, msg=SubString("$key = $(vallines[1])")))
             else
@@ -175,6 +175,6 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
         println(iob)
     end
 
-    write(stream, take!(buf))
+    write(stream, unsafe_take!(buf))
     nothing
 end

--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -114,7 +114,7 @@ function indentcode(stream::IO, block::MD)
                 break
             end
         end
-        code = String(take!(buffer))
+        code = String(unsafe_take!(buffer))
         !isempty(code) && (push!(block, Code(rstrip(code))); return true)
         return false
     end
@@ -178,7 +178,7 @@ function blockquote(stream::IO, block::MD)
         end
         empty && return false
 
-        md = String(take!(buffer))
+        md = String(unsafe_take!(buffer))
         push!(block, BlockQuote(parse(md, flavor = config(block)).content))
         return true
     end
@@ -236,7 +236,7 @@ function admonition(stream::IO, block::MD)
             end
         end
         # Parse the nested block as markdown and create a new Admonition block.
-        nested = parse(String(take!(buffer)), flavor = config(block))
+        nested = parse(String(unsafe_take!(buffer)), flavor = config(block))
         push!(block, Admonition(category, title, nested.content))
         return true
     end

--- a/stdlib/Markdown/src/parse/parse.jl
+++ b/stdlib/Markdown/src/parse/parse.jl
@@ -64,7 +64,7 @@ function parseinline(stream::IO, md::MD, config::Config)
             write(buffer, read(stream, Char))
         end
     end
-    c = String(take!(buffer))
+    c = String(unsafe_take!(buffer))
     !isempty(c) && push!(content, c)
     return content
 end

--- a/stdlib/Markdown/src/parse/util.jl
+++ b/stdlib/Markdown/src/parse/util.jl
@@ -141,7 +141,7 @@ function readuntil(stream::IO, delimiter; newlines = false, match = nothing)
         while !eof(stream)
             if startswith(stream, delimiter)
                 if count == 0
-                    return String(take!(buffer))
+                    return String(unsafe_take!(buffer))
                 else
                     count -= 1
                     write(buffer, delimiter)
@@ -187,7 +187,7 @@ function parse_inline_wrapper(stream::IO, delimiter::AbstractString; rep = false
             if !(char in whitespace || char == '\n' || char in delimiter) && startswith(stream, delimiter^n)
                 trailing = 0
                 while startswith(stream, delimiter); trailing += 1; end
-                trailing == 0 && return String(take!(buffer))
+                trailing == 0 && return String(unsafe_take!(buffer))
                 write(buffer, delimiter ^ (n + trailing))
             end
         end

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -56,7 +56,7 @@ function _peek_report()
     iob = IOBuffer()
     ioc = IOContext(IOContext(iob, stderr), :displaysize=>displaysize(stderr))
     print(ioc, groupby = [:thread, :task])
-    Base.print(stderr, String(take!(iob)))
+    Base.print(stderr, String(unsafe_take!(iob)))
 end
 # This is a ref so that it can be overridden by other profile info consumers.
 const peek_report = Ref{Function}(_peek_report)

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -552,7 +552,7 @@ function refresh_multi_line(terminal::UnixTerminal, args...; kwargs...)
     termbuf = TerminalBuffer(outbuf)
     ret = refresh_multi_line(termbuf, terminal, args...;kwargs...)
     # Output the entire refresh at once
-    write(terminal, take!(outbuf))
+    write(terminal, unsafe_take!(outbuf))
     flush(terminal)
     return ret
 end
@@ -1550,7 +1550,7 @@ function normalize_key(key::Union{String,SubString{String}})
             write(buf, c)
         end
     end
-    return String(take!(buf))
+    return String(unsafe_take!(buf))
 end
 
 function normalize_keys(keymap::Union{Dict{Char,Any},AnyDict})

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1354,7 +1354,7 @@ let matchend = Dict("\"" => r"\"", "\"\"\"" => r"\"\"\"", "'" => r"'",
             pos = nextind(code, last(j))
         end
         print(buf, SubString(code, pos, lastindex(code)))
-        return String(take!(buf))
+        return String(unsafe_take!(buf))
     end
 end
 

--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -380,7 +380,7 @@ function printmenu(out::IO, m::AbstractMenu, cursoridx::Int; oldstate=nothing, i
         print(buf, "\x1b[$(ncleared-newstate)A")
     end
 
-    print(out, String(take!(buf)))
+    print(out, String(unsafe_take!(buf)))
 
     return newstate
 end

--- a/stdlib/REPL/src/TerminalMenus/Pager.jl
+++ b/stdlib/REPL/src/TerminalMenus/Pager.jl
@@ -36,7 +36,7 @@ function pager(terminal, object)
     buffer = IOBuffer()
     ctx = IOContext(buffer, :color => REPL.Terminals.hascolor(terminal), :displaysize => (lines, columns))
     show(ctx, "text/plain", object)
-    pager = Pager(String(take!(buffer)); pagesize = div(lines, 2))
+    pager = Pager(String(unsafe_take!(buffer)); pagesize = div(lines, 2))
     return request(terminal, pager)
 end
 pager(object) = pager(terminal, object)

--- a/stdlib/REPL/test/docview.jl
+++ b/stdlib/REPL/test/docview.jl
@@ -7,17 +7,17 @@ import Markdown
 @testset "symbol completion" begin
     @test startswith(let buf = IOBuffer()
             Core.eval(Main, REPL.helpmode(buf, "α"))
-            String(take!(buf))
+            String(unsafe_take!(buf))
         end, "\"α\" can be typed by \\alpha<tab>\n")
 
     @test startswith(let buf = IOBuffer()
             Core.eval(Main, REPL.helpmode(buf, "🐨"))
-            String(take!(buf))
+            String(unsafe_take!(buf))
         end, "\"🐨\" can be typed by \\:koala:<tab>\n")
 
     @test startswith(let buf = IOBuffer()
             Core.eval(Main, REPL.helpmode(buf, "ᵞ₁₂₃¹²³α"))
-            String(take!(buf))
+            String(unsafe_take!(buf))
         end, "\"ᵞ₁₂₃¹²³α\" can be typed by \\^gamma<tab>\\_123<tab>\\^123<tab>\\alpha<tab>\n")
 
     # Check that all symbols with several completions have a canonical mapping (#39148)
@@ -29,7 +29,7 @@ end
 @testset "quoting in doc search" begin
     str = let buf = IOBuffer()
         Core.eval(Main, REPL.helpmode(buf, "mutable s"))
-        String(take!(buf))
+        String(unsafe_take!(buf))
     end
     @test occursin("'mutable struct'", str)
     @test occursin("Couldn't find 'mutable s'", str)


### PR DESCRIPTION
A common pattern in string code is to create a `buf = IOBuffer()`, write to the buffer, and do `String(take!(buf))` and discard the buffer.  But this is a bit wasteful if `buf` is no longer used because [`take!` allocates a new buffer](https://github.com/JuliaLang/julia/blob/d8c225007498a68d1a1c9f3229d0dbc11b98f0cf/base/iobuffer.jl#L396) to replace the old one.  Apparently to avoid this allocation, some of the `Base` string routines break the `IOBuffer` abstraction to [directly resize and extract the buffer](https://github.com/JuliaLang/julia/blob/d8c225007498a68d1a1c9f3229d0dbc11b98f0cf/base/strings/io.jl#L116) rather than calling `take!`.   It seems cleaner to define a new function:
```jl
unsafe_take!(buf::IOBuffer)
```
that acts like `take!` but leaves `buf` in an undefined state, to be used in cases where `buf` is not subsequently needed.

This PR is an experiment, implementing `unsafe_take!` and using it where appropriate — it seems that the **vast majority** of usages of `IOBuffer()` can use `unsafe_take!`, because they no longer use the buffer after `take!`.

I can't seem to find any practical case where this makes a significant performance difference (though it does reduce the number of allocations by 1), so I'm not sure it's worth it?

In an ideal world, the compiler would do this automatically — in any case where `buf` is no longer used after `take!`, it would eliminate the dead code from the allocation etc.   @vtjnash, is there any way to make this happen, e.g. by forcing `take!` to be inlined?