### PR TITLE
Use `cld` instead of float division in `range.jl` `_findin`

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -1243,19 +1243,17 @@ end
 
 # _findin (the index of intersection)
 function _findin(r::AbstractRange{<:Integer}, span::AbstractUnitRange{<:Integer})
-    local ifirst
-    local ilast
     fspan = first(span)
     lspan = last(span)
     fr = first(r)
     lr = last(r)
     sr = step(r)
     if sr > 0
-        ifirst = fr >= fspan ? 1 : ceil(Integer,(fspan-fr)/sr)+1
-        ilast = lr <= lspan ? length(r) : length(r) - ceil(Integer,(lr-lspan)/sr)
+        ifirst = fr >= fspan ? 1 : cld(fspan-fr, sr)+1
+        ilast = lr <= lspan ? length(r) : length(r) - cld(lr-lspan, sr)
     elseif sr < 0
-        ifirst = fr <= lspan ? 1 : ceil(Integer,(lspan-fr)/sr)+1
-        ilast = lr >= fspan ? length(r) : length(r) - ceil(Integer,(lr-fspan)/sr)
+        ifirst = fr <= lspan ? 1 : cld(lspan-fr, sr)+1
+        ilast = lr >= fspan ? length(r) : length(r) - cld(lr-fspan, sr)
     else
         ifirst = fr >= fspan ? 1 : length(r)+1
         ilast = fr <= lspan ? length(r) : 0


### PR DESCRIPTION
In this PR, I've replaced `ceil(Integer, a / b)` with `cld(a, b)` in `_findin(r::AbstractRange{<:Integer}, span::AbstractUnitRange{<:Integer})`.  The resulting code is simpler under `@code_llvm`.

I also removed the `local` keyword on two lines of this method.  These lines have not been touched since they were first added in 499b7c55e15 (over a decade ago!).  I can only suppose that the rules for implicit local variables must have been different back then, as they seem pretty clearly unnecessary today.

One comment: coverage misses the `else` branch (which was added in 82b64197903), and I believe there is no way to reach it, as the `step` can no longer be zero:
```julia
julia> StepRange(1,0,2)
ERROR: ArgumentError: step cannot be zero
```