### PR TITLE
Use `fld` in `_colon` method in `range.jl`, rather than floating point division

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -24,9 +24,9 @@
 _colon(::Ordered, ::Any, start::T, step, stop::T) where {T} = StepRange(start, step, stop)
 # for T<:Union{Float16,Float32,Float64} see twiceprecision.jl
 _colon(::Ordered, ::ArithmeticRounds, start::T, step, stop::T) where {T} =
-    StepRangeLen(start, step, floor(Integer, (stop-start)/step)+1)
+    StepRangeLen(start, step, convert(Integer, fld(stop - start, step)) + 1)
 _colon(::Any, ::Any, start::T, step, stop::T) where {T} =
-    StepRangeLen(start, step, floor(Integer, (stop-start)/step)+1)
+    StepRangeLen(start, step, convert(Integer, fld(stop - start, step)) + 1)
 
 """
     (:)(start, [step], stop)


### PR DESCRIPTION
This replaces calls to `floor(Integer, a / b)` with `fld(a, b)` in `_colon()`, resulting in simpler and more efficient generated code.

The `convert(Integer, ...)` is necessary, otherwise the following test fails:

https://github.com/JuliaLang/julia/blob/d8c225007498a68d1a1c9f3229d0dbc11b98f0cf/test/ranges.jl#L1524-L1527

with

```
  LoadError: MethodError: no method matching StepRangeLen(::BigFloat, ::BigFloat, ::BigFloat)
  
  Closest candidates are:
    StepRangeLen(::R, ::S, ::Integer) where {R, S}
     @ Base range.jl:507
    StepRangeLen(::R, ::S, ::Integer, ::Integer) where {R, S}
     @ Base range.jl:507
```

I was surprised at first that `cld(::BigFloat, ::BigFloat)` returns a `BigFloat` rather than a `BigInt`, but ~on second thought, I believe the current behavior is indeed appropriate, as there is nothing to say that `BigInt` and `BigFloat` are set to the same precision~ this is consistent with `cld(::Float64, ::Float64)` returning a `Float64` (see the `cld` docstring).  Hence the `convert` call in this PR to ensure the returned value is still an `Integer`.