### PR TITLE
LinearAlgebra: extend `eigen` with left eigenvectors and errorbounds

### DIFF
--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -70,7 +70,7 @@ end
 """
     GeneralizedEigen <: Factorization
 
-Matrix factorization type of the generalized eigenvalue/apply decomposition of
+Matrix factorization type of the generalized eigenvalue/spectral decomposition of
 `A` and `B`. This is the return type of [`eigen`](@ref), the corresponding
 matrix factorization function, when called with two matrix arguments.
 

--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -24,18 +24,7 @@ The error bounds are empty, if not opted in by `eigen( ; eerror=true, verror=tru
 
 # Examples
 ```jldoctest
-julia> F = eigen([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
-Eigen{Float64, Float64, Matrix{Float64}, Vector{Float64}}
-values:
-3-element Vector{Float64}:
-  1.0
-  3.0
- 18.0
-vectors:
-3×3 Matrix{Float64}:
- 1.0  0.0  0.0
- 0.0  1.0  0.0
- 0.0  0.0  1.0
+julia> F = eigen([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0]);
 
 julia> F.values
 3-element Vector{Float64}:
@@ -336,34 +325,38 @@ sine of the acute angles between the calculated and true vectors. For details se
 
 # Examples
 ```jldoctest
-julia> F = eigen([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
-Eigen{Float64, Float64, Matrix{Float64}, Vector{Float64}}
+julia> F = eigen([1.0 1.0+eps() 0.0; 1.0 1.0 0.0; 0.0 0.0 18.0], left=true, eerror=true, verror=true)
+Eigen{Float64, Float64, Matrix{Float64}, Vector{Float64}, Vector{Float64}}
 values:
 3-element Vector{Float64}:
-  1.0
-  3.0
+ -2.220446049250313e-16
+  2.0
  18.0
-vectors:
+right vectors:
 3×3 Matrix{Float64}:
- 1.0  0.0  0.0
- 0.0  1.0  0.0
- 0.0  0.0  1.0
-
-julia> F.values
+ -0.707107  0.707107  0.0
+  0.707107  0.707107  0.0
+  0.0       0.0       1.0
+left vectors:
+3×3 Matrix{Float64}:
+ -0.707107  0.707107  0.0
+  0.707107  0.707107  0.0
+  0.0       0.0       1.0
+value error bounds:
 3-element Vector{Float64}:
-  1.0
-  3.0
- 18.0
+ 1.998401444325282e-15
+ 1.998401444325282e-15
+ 1.9984014443252818e-15
+vector error bounds:
+3-element Vector{Float64}:
+ 9.992007221626409e-16
+ 9.992007221626409e-16
+ 1.249000902703301e-16
 
-julia> F.vectors
-3×3 Matrix{Float64}:
- 1.0  0.0  0.0
- 0.0  1.0  0.0
- 0.0  0.0  1.0
+julia> vals, vecs, vl, eerr, verr = F; # destructuring via iteration
 
-julia> vals, vecs = F; # destructuring via iteration
-
-julia> vals == F.values && vecs == F.vectors
+julia> vals == F.values && vecs === F.vectors &&
+       vl === F.vectorsl && eerr === F.eerrbd && verr === F.verrbd
 true
 ```
 """

--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -4,7 +4,7 @@
 """
     Eigen <: Factorization
 
-Matrix factorization type of the eigenvalue/apply decomposition of a square
+Matrix factorization type of the eigenvalue/spectral decomposition of a square
 matrix `A`. This is the return type of [`eigen`](@ref), the corresponding matrix
 factorization function.
 
@@ -332,7 +332,7 @@ While the right eigenvectors are normalized, we have `F.vectorsl' * F.vectors = 
 
 The returned error bounds for the eigenvectors are estimating the maximal size of the
 sine of the acute angles between the calculated and true vectors. For details see
-[LAPACK](https://netlib.org/lapack/lug/node91.html), [`sineacuteangle`](@ref).
+[LAPACK](https://netlib.org/lapack/lug/node91.html), [`sintheta`](@ref).
 
 # Examples
 ```jldoctest

--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -332,7 +332,7 @@ While the right eigenvectors are normalized, we have `F.vectorsl' * F.vectors = 
 
 The returned error bounds for the eigenvectors are estimating the maximal size of the
 sine of the acute angles between the calculated and true vectors. For details see
-[LAPACK](https://netlib.org/lapack/lug/node91.html), [`sintheta`](@ref).
+[LAPACK](https://netlib.org/lapack/lug/node91.html).
 
 # Examples
 ```jldoctest


### PR DESCRIPTION

This is a remake of #38483, this time with documentation and test cases included.
The changes (added features) are:

1. `struct Eigen` and `struct GeneralizedEigen` have new matrix field `vectorsl` to keep optional left eigenvectors.
2. `struct Eigen` has additional vector fields `eerrbd` and `verrbd` to keep optional error bounds for eigenvalues and eigenvectors.
3. Function `eigen` has new boolean keyword arguments `left`, `eerror`, `verror` to opt in the calculation of the new output fields.

The data are obtained by use of the existing `LAPACK` API. See also [user's guide](https://netlib.org/lapack/lug/node91.html)