### PR TITLE
Disable frame-pointer-optimization on Linux

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6,7 +6,7 @@
 #if defined(_CPU_X86_)
 #define JL_NEED_FLOATTEMP_VAR 1
 #endif
-#if defined(_OS_WINDOWS_) || defined(_OS_FREEBSD_) || defined(_COMPILER_MSAN_ENABLED_)
+#if defined(_OS_LINUX_) || defined(_OS_WINDOWS_) || defined(_OS_FREEBSD_) || defined(_COMPILER_MSAN_ENABLED_)
 #define JL_DISABLE_FPO
 #endif
 


### PR DESCRIPTION
There recently has been some debate in the Linux community around FPO,
and as an example Fedora has decided to turn disable FPO system wide.

Waiting on a resolution to #40655, I am proposing disabling FPO on Linux
as well. My concrete motivation is that I am interested in enabling better
experience for external profilers such as Linux's perf, parca and ddprof,
by default.
