### PR TITLE
Inference: more thorough `UnionAll` renaming in `apply_type_tfunc`

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2743,6 +2743,7 @@ let 𝕃 = Core.Compiler.fallback_lattice
     @test apply_type_tfunc(𝕃, Const(Issue47089), A, A) <: (Type{Issue47089{A,B}} where {A<:Integer, B<:Integer})
 end
 @test only(Base.return_types(keys, (Dict{String},))) == Base.KeySet{String, T} where T<:(Dict{String})
+@test only(Base.return_types((r)->similar(Array{typeof(r[])}, 1), (Base.RefValue{Array{Int}},))) == Vector{T} where T<:(Array{Int})
 
 # PR 27351, make sure optimized type intersection for method invalidation handles typevars
 


### PR DESCRIPTION
Should fix the "An unreachable instruction was executed" error in recent PkgEval.
MWE has been added to test.