### PR TITLE
delay loading of extensions as much as possible

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1205,8 +1205,9 @@ end
 
 function run_extension_callbacks()
     assert_havelock(require_lock)
-    for pkgid in copy(keys(EXT_DORMITORY))
-        haskey(Base.loaded_modules, pkgid) || continue
+    loaded_triggers = collect(intersect(keys(Base.loaded_modules), keys(Base.EXT_DORMITORY)))
+    sort!(loaded_triggers; by=x->x.uuid)
+    for pkgid in loaded_triggers
         # take ownership of extids that depend on this pkgid
         extids = pop!(EXT_DORMITORY, pkgid, nothing)
         extids === nothing && continue

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1080,7 +1080,6 @@ function register_restored_modules(sv::SimpleVector, pkg::PkgId, path::String)
 end
 
 function run_package_callbacks(modkey::PkgId)
-    run_extension_callbacks(modkey)
     assert_havelock(require_lock)
     unlock(require_lock)
     try
@@ -1204,53 +1203,56 @@ function run_extension_callbacks(extid::ExtensionId)
     return succeeded
 end
 
-function run_extension_callbacks(pkgid::PkgId)
+function run_extension_callbacks()
     assert_havelock(require_lock)
-    # take ownership of extids that depend on this pkgid
-    extids = pop!(EXT_DORMITORY, pkgid, nothing)
-    extids === nothing && return
-    for extid in extids
-        if extid.ntriggers > 0
-            # It is possible that pkgid was loaded in an environment
-            # below the one of the parent. This will cause a load failure when the
-            # pkg ext tries to load the triggers. Therefore, check this first
-            # before loading the pkg ext.
-            pkgenv = Base.identify_package_env(extid.id, pkgid.name)
-            ext_not_allowed_load = false
-            if pkgenv === nothing
-                ext_not_allowed_load = true
-            else
-                pkg, env = pkgenv
-                path = Base.locate_package(pkg, env)
-                if path === nothing
+    for pkgid in copy(keys(EXT_DORMITORY))
+        haskey(Base.loaded_modules, pkgid) || continue
+        # take ownership of extids that depend on this pkgid
+        extids = pop!(EXT_DORMITORY, pkgid, nothing)
+        extids === nothing && continue
+        for extid in extids
+            if extid.ntriggers > 0
+                # It is possible that pkgid was loaded in an environment
+                # below the one of the parent. This will cause a load failure when the
+                # pkg ext tries to load the triggers. Therefore, check this first
+                # before loading the pkg ext.
+                pkgenv = Base.identify_package_env(extid.id, pkgid.name)
+                ext_not_allowed_load = false
+                if pkgenv === nothing
                     ext_not_allowed_load = true
+                else
+                    pkg, env = pkgenv
+                    path = Base.locate_package(pkg, env)
+                    if path === nothing
+                        ext_not_allowed_load = true
+                    end
+                end
+                if ext_not_allowed_load
+                    @debug "Extension $(extid.id.name) of $(extid.parentid.name) will not be loaded \
+                            since $(pkgid.name) loaded in environment lower in load path"
+                    # indicate extid is expected to fail
+                    extid.ntriggers *= -1
+                else
+                    # indicate pkgid is loaded
+                    extid.ntriggers -= 1
                 end
             end
-            if ext_not_allowed_load
-                @debug "Extension $(extid.id.name) of $(extid.parentid.name) will not be loaded \
-                        since $(pkgid.name) loaded in environment lower in load path"
-                # indicate extid is expected to fail
-                extid.ntriggers *= -1
-            else
+            if extid.ntriggers < 0
                 # indicate pkgid is loaded
-                extid.ntriggers -= 1
+                extid.ntriggers += 1
+                succeeded = false
+            else
+                succeeded = true
+            end
+            if extid.ntriggers == 0
+                # actually load extid, now that all dependencies are met,
+                # and record the result
+                succeeded = succeeded && run_extension_callbacks(extid)
+                succeeded || push!(EXT_DORMITORY_FAILED, extid)
             end
         end
-        if extid.ntriggers < 0
-            # indicate pkgid is loaded
-            extid.ntriggers += 1
-            succeeded = false
-        else
-            succeeded = true
-        end
-        if extid.ntriggers == 0
-            # actually load extid, now that all dependencies are met,
-            # and record the result
-            succeeded = succeeded && run_extension_callbacks(extid)
-            succeeded || push!(EXT_DORMITORY_FAILED, extid)
-        end
     end
-    nothing
+    return
 end
 
 """
@@ -1637,7 +1639,9 @@ function require(into::Module, mod::Symbol)
         if _track_dependencies[]
             push!(_require_dependencies, (into, binpack(uuidkey), 0.0))
         end
-        return _require_prelocked(uuidkey, env)
+        mod = _require_prelocked(uuidkey, env)
+        into === Main && run_extension_callbacks()
+        return mod
     finally
         LOADING_CACHE[] = nothing
     end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1639,9 +1639,7 @@ function require(into::Module, mod::Symbol)
         if _track_dependencies[]
             push!(_require_dependencies, (into, binpack(uuidkey), 0.0))
         end
-        mod = _require_prelocked(uuidkey, env)
-        into === Main && run_extension_callbacks()
-        return mod
+        return _require_prelocked(uuidkey, env)
     finally
         LOADING_CACHE[] = nothing
     end
@@ -1668,6 +1666,10 @@ function _require_prelocked(uuidkey::PkgId, env=nothing)
         end
     else
         newm = root_module(uuidkey)
+    end
+    # Load extensions when not precompiling and not in a nested package load
+    if JLOptions().incremental == 0 && isempty(package_locks)
+        run_extension_callbacks()
     end
     return newm
 end


### PR DESCRIPTION
(Diff best viewed with whitespace ignored).

To reduce the likelihood of cycles, we delay loading extensions until all packages have finished loading during a `require` call and we are ready to return to Main.

Fixes https://github.com/JuliaLang/julia/issues/48533