### PR TITLE
remove lgamma(Float16) definition

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -1489,7 +1489,7 @@ include("special/log.jl")
 # Float16 definitions
 
 for func in (:sin,:cos,:tan,:asin,:acos,:atan,:cosh,:tanh,:asinh,:acosh,
-             :atanh,:log,:log2,:log10,:sqrt,:lgamma,:log1p)
+             :atanh,:log,:log2,:log10,:sqrt,:log1p)
     @eval begin
         $func(a::Float16) = Float16($func(Float32(a)))
         $func(a::ComplexF16) = ComplexF16($func(ComplexF32(a)))


### PR DESCRIPTION
`lgamma` was removed in 0.7 or so.