### PR TITLE
Put back getfield :boundscheck hack

### DIFF
--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -739,14 +739,18 @@ end |> Core.Compiler.is_foldable_nothrow
 
 # Test that dead `@inbounds` does not taint consistency
 # https://github.com/JuliaLang/julia/issues/48243
-@test Base.infer_effects() do
-    false && @inbounds (1,2,3)[1]
+@test Base.infer_effects(Tuple{Int64}) do i
+    false && @inbounds (1,2,3)[i]
     return 1
 end |> Core.Compiler.is_foldable_nothrow
 
 @test Base.infer_effects(Tuple{Int64}) do i
     @inbounds (1,2,3)[i]
 end |> !Core.Compiler.is_consistent
+
+@test Base.infer_effects(Tuple{Tuple{Int64}}) do x
+    @inbounds x[1]
+end |> Core.Compiler.is_foldable_nothrow
 
 # Test that :new of non-concrete, but otherwise known type
 # does not taint consistency.


### PR DESCRIPTION
We used to have this hack before #48246, but I removed it because I had hoped we don't need. Unfortunately, we weren't able to infer consistency of
```
@inbounds (1,2)[1]
```
With this hack, constprop is able to independently prove inbounded-ness, overriding the usual consistency taintaing that happens for inbounds.