### PR TITLE
Intersect: avoid re-wrapping inner-var.

### DIFF
--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2447,3 +2447,14 @@ end
 #issue 48582
 @test !<:(Tuple{Pair{<:T,<:T}, Val{S} where {S}} where {T<:Base.BitInteger},
           Tuple{Pair{<:T,<:T}, Val{Int}} where {T<:Base.BitInteger})
+
+struct T48695{T, N, H<:AbstractArray} <: AbstractArray{Union{Missing, T}, N} end
+struct S48695{T, N, H<:AbstractArray{T, N}} <: AbstractArray{T, N} end
+let S = Tuple{Type{S48695{T, 2, T48695{B, 2, C}}} where {T<:(Union{Missing, A} where A), B, C}, T48695{T, 2} where T},
+    T = Tuple{Type{S48695{T, N, H}}, H} where {T, N, H<:AbstractArray{T, N}}
+    V = typeintersect(S, T)
+    vars_in_unionall(s) = s isa UnionAll ? (s.var, vars_in_unionall(s.body)...) : ()
+    @test V != Union{}
+    @test allunique(vars_in_unionall(V))
+    @test typeintersect(V, T) != Union{}
+end


### PR DESCRIPTION
If 2 var hold the same inner-var, the result `UnionAll` might contain 2 identical var, which should be avoided in general.
#48228 has some more eager change but this part should be safe. Should fix `Zarr.jl` related error on master.
