### PR TITLE
Rearrange TaskFailedException’s showerror printing

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -78,13 +78,14 @@ struct TaskFailedException <: Exception
 end
 
 function showerror(io::IO, ex::TaskFailedException, bt = nothing; backtrace=true)
-    print(io, "TaskFailedException")
+    println(io, "TaskFailedException")
+    println(io, "Nested Task Exception:")
+    show_task_exception(io, ex.task)
     if bt !== nothing && backtrace
+        println(io, "\n\nAbove TaskFailedException was triggered at:")
         show_backtrace(io, bt)
     end
     println(io)
-    printstyled(io, "\n    nested task error: ", color=error_color())
-    show_task_exception(io, ex.task)
 end
 
 function show_task_exception(io::IO, t::Task; indent = true)


### PR DESCRIPTION
[From this discourse thread](https://discourse.julialang.org/t/confused-about-the-order-of-taskfailedexceptions-showerror/94679?u=nrontsis)


### Description
In Julia's stacktraces, I typically expect that scrolling all the way up will get me to the “deepest” level of the call stack.

However, when having code in `@threads`, the resulting exceptions are `TaskFailedException` that print first their backtrace and then the nested task’s error, which I find contrary to typical practice.

This PR changes that.

### Example
`master`:
```julia
julia> foo() = throw(ArgumentError("a"))
julia> Threads.@threads for i in 1:4
          foo()
          end
ERROR: TaskFailedException
Stacktrace:
 [1] wait
   @ ./task.jl:345 [inlined]
 [2] threading_run(fun::var"#39#threadsfor_fun#9"{var"#39#threadsfor_fun#8#10"{UnitRange{Int64}}}, static::Bool)
   @ Base.Threads ./threadingconstructs.jl:38
 [3] top-level scope
   @ ./threadingconstructs.jl:89

    nested task error: ArgumentError: a
    Stacktrace:
     [1] foo()
       @ Main ./REPL[1]:1
     [2] macro expansion
       @ ./REPL[6]:2 [inlined]
     [3] #39#threadsfor_fun#8
       @ ./threadingconstructs.jl:84 [inlined]
     [4] #39#threadsfor_fun
       @ ./threadingconstructs.jl:51 [inlined]
     [5] (::Base.Threads.var"#1#2"{var"#39#threadsfor_fun#9"{var"#39#threadsfor_fun#8#10"{UnitRange{Int64}}}, Int64})()
       @ Base.Threads ./threadingconstructs.jl:30
```
This PR:
```julia
ERROR: TaskFailedException
Nested Task Exception:
ArgumentError: a
    Stacktrace:
     [1] foo()
       @ Main ./REPL[1]:1
     [2] macro expansion
       @ ./REPL[7]:2 [inlined]
     [3] #54#threadsfor_fun#11
       @ ./threadingconstructs.jl:84 [inlined]
     [4] #54#threadsfor_fun
       @ ./threadingconstructs.jl:51 [inlined]
     [5] (::Base.Threads.var"#1#2"{var"#54#threadsfor_fun#12"{var"#54#threadsfor_fun#11#13"{UnitRange{Int64}}}, Int64})()
       @ Base.Threads ./threadingconstructs.jl:30

Above TaskFailedException was triggered at:

Stacktrace:
 [1] wait
   @ ./task.jl:345 [inlined]
 [2] threading_run(fun::var"#54#threadsfor_fun#12"{var"#54#threadsfor_fun#11#13"{UnitRange{Int64}}}, static::Bool)
   @ Base.Threads ./threadingconstructs.jl:38
 [3] macro expansion
   @ ./threadingconstructs.jl:89 [inlined]
 [4] top-level scope
   @ ./REPL[7]:1
```