### PR TITLE
make `MultiplicativeInverse<:Number`

### DIFF
--- a/base/multinverses.jl
+++ b/base/multinverses.jl
@@ -14,7 +14,7 @@ unsigned(::Type{Int64}) = UInt64
 unsigned(::Type{Int128}) = UInt128
 unsigned(::Type{T}) where {T<:Unsigned} = T
 
-abstract type  MultiplicativeInverse{T} end
+abstract type  MultiplicativeInverse{T} <: Number end
 
 # Computes integer division by a constant using multiply, add, and bitshift.
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2493,6 +2493,8 @@ Base.abs(x::TestNumber) = TestNumber(abs(x.inner))
     @test_throws ArgumentError Base.multiplicativeinverse(0)
     testmi(map(UInt32, 0:1000), map(UInt32, 1:100))
     testmi(typemax(UInt32)-UInt32(1000):typemax(UInt32), map(UInt32, 1:100))
+    # test broadcasting works.
+    @test div.(3, Base.multiplicativeinverse(3)) == 1 
 end
 @testset "ndims/indices/size/length" begin
     @test ndims(1) == 0

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2494,7 +2494,7 @@ Base.abs(x::TestNumber) = TestNumber(abs(x.inner))
     testmi(map(UInt32, 0:1000), map(UInt32, 1:100))
     testmi(typemax(UInt32)-UInt32(1000):typemax(UInt32), map(UInt32, 1:100))
     # test broadcasting works.
-    @test div.(3, Base.multiplicativeinverse(3)) == 1 
+    @test div.(3, Base.multiplicativeinverse(3)) == 1
 end
 @testset "ndims/indices/size/length" begin
     @test ndims(1) == 0


### PR DESCRIPTION
This makes operations like `divrem.(Int128(3), Base.MultiplicativeInverses.SignedMultiplicativeInverse(Int128(3)))` work.