### PR TITLE
Prohibit tabs in whitespace check

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5564,18 +5564,18 @@ Deprecated or removed
 
   * several syntax whitespace insensitivities have been deprecated ([#11891]).
     ```julia
-     # function call
-     f (x)
+    # function call
+    f (x)
 
-     # getindex
-     x [17]
-     rand(2) [1]
+    # getindex
+    x [17]
+    rand(2) [1]
 
-     # function definition
-     f (x) = x^2
-     function foo (x)
-	x^2
-     end
+    # function definition
+    f (x) = x^2
+    function foo (x)
+        x^2
+    end
     ```
 
   * indexing with `Real`s that are not subtypes of `Integer` (`Rational`, `AbstractFloat`, etc.) has been deprecated ([#10458]).

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -202,7 +202,7 @@ function _print_matrix(io, @nospecialize(X::AbstractVecOrMat), pre, sep, post, h
     if n > maxpossiblecols
         colsA = [colsA[(0:maxpossiblecols-1) .+ firstindex(colsA)]; colsA[(end-maxpossiblecols+1):end]]
     else
-	    colsA = [colsA;]
+        colsA = [colsA;]
     end
     A = alignment(io, X, rowsA, colsA, screenwidth, screenwidth, sepsize, ncols)
     # Nine-slicing is accomplished using print_matrix_row repeatedly

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -332,7 +332,7 @@ function CodeInstance(interp::AbstractInterpreter, result::InferenceResult,
         widenconst(result_type), rettype_const, inferred_result,
         const_flags, first(valid_worlds), last(valid_worlds),
         # TODO: Actually do something with non-IPO effects
-	    encode_effects(result.ipo_effects), encode_effects(result.ipo_effects), result.argescapes,
+        encode_effects(result.ipo_effects), encode_effects(result.ipo_effects), result.argescapes,
         relocatability)
 end
 

--- a/contrib/check-whitespace.jl
+++ b/contrib/check-whitespace.jl
@@ -18,6 +18,16 @@ const patterns = split("""
     *Makefile
 """)
 
+allow_tabs(path) =
+    path == "Make.inc" ||
+    endswith(path, "Makefile") ||
+    endswith(path, ".make") ||
+    endswith(path, ".mk") ||
+    startswith(path, joinpath("src", "support")) ||
+    startswith(path, joinpath("src", "flisp")) ||
+    endswith(path, joinpath("test", "syntax.jl")) ||
+    endswith(path, joinpath("test", "triplequote.jl"))
+
 const errors = Set{Tuple{String,Int,String}}()
 
 for path in eachline(`git ls-files -- $patterns`)
@@ -32,6 +42,8 @@ for path in eachline(`git ls-files -- $patterns`)
         lineno += 1
         contains(line, '\r')   && file_err("non-UNIX line endings")
         contains(line, '\ua0') && line_err("non-breaking space")
+        allow_tabs(path) ||
+        contains(line, '\t')   && line_err("tab")
         endswith(line, '\n')   || line_err("no trailing newline")
         line = chomp(line)
         endswith(line, r"\s")  && line_err("trailing whitespace")

--- a/doc/src/devdocs/probes.md
+++ b/doc/src/devdocs/probes.md
@@ -27,28 +27,28 @@ to enable USDT probes.
 > readelf -n usr/lib/libjulia-internal.so.1
 
 Displaying notes found in: .note.gnu.build-id
-  Owner                Data size 	Description
-  GNU                  0x00000014	NT_GNU_BUILD_ID (unique build ID bitstring)
+  Owner                Data size  Description
+  GNU                  0x00000014 NT_GNU_BUILD_ID (unique build ID bitstring)
     Build ID: 57161002f35548772a87418d2385c284ceb3ead8
 
 Displaying notes found in: .note.stapsdt
-  Owner                Data size 	Description
-  stapsdt              0x00000029	NT_STAPSDT (SystemTap probe descriptors)
+  Owner                Data size  Description
+  stapsdt              0x00000029 NT_STAPSDT (SystemTap probe descriptors)
     Provider: julia
     Name: gc__begin
     Location: 0x000000000013213e, Base: 0x00000000002bb4da, Semaphore: 0x0000000000346cac
     Arguments:
-  stapsdt              0x00000032	NT_STAPSDT (SystemTap probe descriptors)
+  stapsdt              0x00000032 NT_STAPSDT (SystemTap probe descriptors)
     Provider: julia
     Name: gc__stop_the_world
     Location: 0x0000000000132144, Base: 0x00000000002bb4da, Semaphore: 0x0000000000346cae
     Arguments:
-  stapsdt              0x00000027	NT_STAPSDT (SystemTap probe descriptors)
+  stapsdt              0x00000027 NT_STAPSDT (SystemTap probe descriptors)
     Provider: julia
     Name: gc__end
     Location: 0x000000000013214a, Base: 0x00000000002bb4da, Semaphore: 0x0000000000346cb0
     Arguments:
-  stapsdt              0x0000002d	NT_STAPSDT (SystemTap probe descriptors)
+  stapsdt              0x0000002d NT_STAPSDT (SystemTap probe descriptors)
     Provider: julia
     Name: gc__finalizer
     Location: 0x0000000000132150, Base: 0x00000000002bb4da, Semaphore: 0x0000000000346cb2
@@ -308,7 +308,7 @@ An example probe in the bpftrace format looks like:
 ```
 usdt:usr/lib/libjulia-internal.so:julia:gc__begin
 {
-	@start[pid] = nsecs;
+  @start[pid] = nsecs;
 }
 ```
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -94,33 +94,33 @@ extern "C" {
 
 enum class MSanTLS
 {
-	param = 1,             // __msan_param_tls
-	param_origin,          //__msan_param_origin_tls
-	retval,                // __msan_retval_tls
-	retval_origin,         //__msan_retval_origin_tls
-	va_arg,                // __msan_va_arg_tls
-	va_arg_origin,         // __msan_va_arg_origin_tls
-	va_arg_overflow_size,  // __msan_va_arg_overflow_size_tls
-	origin,                //__msan_origin_tls
+    param = 1,             // __msan_param_tls
+    param_origin,          //__msan_param_origin_tls
+    retval,                // __msan_retval_tls
+    retval_origin,         //__msan_retval_origin_tls
+    va_arg,                // __msan_va_arg_tls
+    va_arg_origin,         // __msan_va_arg_origin_tls
+    va_arg_overflow_size,  // __msan_va_arg_overflow_size_tls
+    origin,                //__msan_origin_tls
 };
 
 static void *getTLSAddress(void *control)
 {
-	auto tlsIndex = static_cast<MSanTLS>(reinterpret_cast<uintptr_t>(control));
-	switch(tlsIndex)
-	{
-	case MSanTLS::param: return reinterpret_cast<void *>(&__msan_param_tls);
-	case MSanTLS::param_origin: return reinterpret_cast<void *>(&__msan_param_origin_tls);
-	case MSanTLS::retval: return reinterpret_cast<void *>(&__msan_retval_tls);
-	case MSanTLS::retval_origin: return reinterpret_cast<void *>(&__msan_retval_origin_tls);
-	case MSanTLS::va_arg: return reinterpret_cast<void *>(&__msan_va_arg_tls);
-	case MSanTLS::va_arg_origin: return reinterpret_cast<void *>(&__msan_va_arg_origin_tls);
-	case MSanTLS::va_arg_overflow_size: return reinterpret_cast<void *>(&__msan_va_arg_overflow_size_tls);
-	case MSanTLS::origin: return reinterpret_cast<void *>(&__msan_origin_tls);
-	default:
-		assert(false && "BAD MSAN TLS INDEX");
-		return nullptr;
-	}
+    auto tlsIndex = static_cast<MSanTLS>(reinterpret_cast<uintptr_t>(control));
+    switch(tlsIndex)
+    {
+    case MSanTLS::param: return reinterpret_cast<void *>(&__msan_param_tls);
+    case MSanTLS::param_origin: return reinterpret_cast<void *>(&__msan_param_origin_tls);
+    case MSanTLS::retval: return reinterpret_cast<void *>(&__msan_retval_tls);
+    case MSanTLS::retval_origin: return reinterpret_cast<void *>(&__msan_retval_origin_tls);
+    case MSanTLS::va_arg: return reinterpret_cast<void *>(&__msan_va_arg_tls);
+    case MSanTLS::va_arg_origin: return reinterpret_cast<void *>(&__msan_va_arg_origin_tls);
+    case MSanTLS::va_arg_overflow_size: return reinterpret_cast<void *>(&__msan_va_arg_overflow_size_tls);
+    case MSanTLS::origin: return reinterpret_cast<void *>(&__msan_origin_tls);
+    default:
+        assert(false && "BAD MSAN TLS INDEX");
+        return nullptr;
+    }
 }
 }
 #endif

--- a/src/julia_atomics.h
+++ b/src/julia_atomics.h
@@ -79,8 +79,8 @@ enum jl_memory_order {
  * `mfence`. GCC 11 did switch to this representation. See #48123
  */
 #if defined(_CPU_X86_64_) && \
-	((defined(__GNUC__) && __GNUC__ < 11) || \
-	 (defined(__clang__)))
+    ((defined(__GNUC__) && __GNUC__ < 11) || \
+     (defined(__clang__)))
     #define jl_fence() __asm__ volatile("lock orq $0 , (%rsp)")
 #else
     #define jl_fence() atomic_thread_fence(memory_order_seq_cst)

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -299,8 +299,8 @@ int is_write_fault(void *context) {
 }
 #elif defined(_OS_LINUX_) && defined(_CPU_AARCH64_)
 struct linux_aarch64_ctx_header {
-	uint32_t magic;
-	uint32_t size;
+    uint32_t magic;
+    uint32_t size;
 };
 const uint32_t linux_esr_magic = 0x45535201;
 
@@ -767,7 +767,7 @@ static void *signal_listener(void *arg)
         profile = (sig == SIGUSR1);
 #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 199309L
         if (profile && !(info.si_code == SI_TIMER &&
-	            info.si_value.sival_ptr == &timerprof))
+                info.si_value.sival_ptr == &timerprof))
             profile = 0;
 #endif
 #endif

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1149,7 +1149,7 @@ end
 # issue 20225, check this can print
 @test typeof(sprint(Markdown.term, Markdown.parse(" "))) == String
 
-# different output depending on whether color is requested:	+# issue 20225, check this can print
+# different output depending on whether color is requested: +# issue 20225, check this can print
 let buf = IOBuffer()
     @test typeof(sprint(Markdown.term, Markdown.parse(" "))) == String
     show(buf, "text/plain", md"*emph*")

--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -405,13 +405,13 @@ using Test
 
 @testset "Example tests" begin
 
-	@testset "Math tests" begin
-		include("math_tests.jl")
-	end
+    @testset "Math tests" begin
+        include("math_tests.jl")
+    end
 
-	@testset "Greeting tests" begin
-		include("greeting_tests.jl")
-	end
+    @testset "Greeting tests" begin
+        include("greeting_tests.jl")
+    end
 end
 ```
 
@@ -426,16 +426,16 @@ Using our knowledge of `Test.jl`, here are some example tests we could add to `m
 
 ```julia
 @testset "Testset 1" begin
-	@test 2 == simple_add(1, 1)
-	@test 3.5 == simple_add(1, 2.5)
+    @test 2 == simple_add(1, 1)
+    @test 3.5 == simple_add(1, 2.5)
         @test_throws MethodError simple_add(1, "A")
         @test_throws MethodError simple_add(1, 2, 3)
 end
 
 @testset "Testset 2" begin
-	@test 1.0 == type_multiply(1.0, 1.0)
+    @test 1.0 == type_multiply(1.0, 1.0)
         @test isa(type_multiply(2.0, 2.0), Float64)
-	@test_throws MethodError type_multiply(1, 2.5)
+    @test_throws MethodError type_multiply(1, 2.5)
 end
 ```
 

--- a/test/testhelpers/FillArrays.jl
+++ b/test/testhelpers/FillArrays.jl
@@ -12,8 +12,8 @@ Base.size(F::Fill) = F.size
 @inline getindex_value(F::Fill) = F.value
 
 @inline function Base.getindex(F::Fill{<:Any,N}, i::Vararg{Int,N}) where {N}
-	@boundscheck checkbounds(F, i...)
-	getindex_value(F)
+    @boundscheck checkbounds(F, i...)
+    getindex_value(F)
 end
 
 @inline function Base.setindex!(F::Fill, v, k::Integer)


### PR DESCRIPTION
In general, tabs do not appear in well-formatted Julia source code. This automates that check.
- Prohibit tabs in whitespace check
- replace tabs with spaces and fix indentation

Is a superset of and closes #48697

This should possibly also cover other languages, but I don't know what our style conventions are for those languages and they are presumably less important to cover with this check.

This _Does Not_ mean Julia code with tabs will error/warn/etc. It only effects the style enforcement of source code in this repo.