### PR TITLE
Remove `[l/r]mul!` of `AbstractQ` with `*Triangular`

### DIFF
--- a/stdlib/LinearAlgebra/src/abstractq.jl
+++ b/stdlib/LinearAlgebra/src/abstractq.jl
@@ -144,8 +144,8 @@ end
 (*)(u::AdjointAbsVec, Q::AbstractQ) = (Q'u')'
 
 # AbstractQ * Triangular
-lmul!(Q::AbstractQ, B::AbstractTriangular) = lmul!(Q, full!(B))
-rmul!(A::AbstractTriangular, Q::AbstractQ) = rmul!(full!(A), Q)
+# @deprecate lmul!(Q::AbstractQ, B::AbstractTriangular) lmul!(Q, full!(B)) false
+# @deprecate rmul!(A::AbstractTriangular, Q::AbstractQ) rmul!(full!(A), Q) false
 
 ### Q*Q (including adjoints)
 *(Q::AbstractQ, P::AbstractQ) = Q * (P*I)
@@ -279,7 +279,7 @@ function lmul!(A::QRPackedQ, B::AbstractVecOrMat)
     end
     B
 end
-lmul!(Q::QRPackedQ, B::AbstractTriangular) = lmul!(Q, full!(B)) # disambiguation
+# lmul!(Q::QRPackedQ, B::AbstractTriangular) = lmul!(Q, full!(B)) # disambiguation
 
 ### QcB
 lmul!(adjQ::AdjointQ{<:Any,<:QRCompactWYQ{T,<:StridedMatrix}}, B::StridedVecOrMat{T}) where {T<:BlasReal} =
@@ -316,7 +316,7 @@ function lmul!(adjA::AdjointQ{<:Any,<:QRPackedQ}, B::AbstractVecOrMat)
     end
     B
 end
-lmul!(Q::AdjointQ{<:Any,<:QRPackedQ}, B::AbstractTriangular) = lmul!(Q, full!(B)) # disambiguation
+# lmul!(Q::AdjointQ{<:Any,<:QRPackedQ}, B::AbstractTriangular) = lmul!(Q, full!(B)) # disambiguation
 
 ### AQ
 rmul!(A::StridedVecOrMat{T}, B::QRCompactWYQ{T,<:StridedMatrix}) where {T<:BlasFloat} =
@@ -348,7 +348,7 @@ function rmul!(A::AbstractMatrix, Q::QRPackedQ)
     end
     A
 end
-rmul!(A::AbstractTriangular, Q::QRPackedQ) = rmul!(full!(A), Q) # disambiguation
+# rmul!(A::AbstractTriangular, Q::QRPackedQ) = rmul!(full!(A), Q) # disambiguation
 
 ### AQc
 rmul!(A::StridedVecOrMat{T}, adjQ::AdjointQ{<:Any,<:QRCompactWYQ{T}}) where {T<:BlasReal} =
@@ -385,7 +385,7 @@ function rmul!(A::AbstractMatrix, adjQ::AdjointQ{<:Any,<:QRPackedQ})
     end
     A
 end
-rmul!(A::AbstractTriangular, Q::AdjointQ{<:Any,<:QRPackedQ}) = rmul!(full!(A), Q) # disambiguation
+# rmul!(A::AbstractTriangular, Q::AdjointQ{<:Any,<:QRPackedQ}) = rmul!(full!(A), Q) # disambiguation
 
 det(Q::QRPackedQ) = _det_tau(Q.τ)
 det(Q::QRCompactWYQ) =

--- a/stdlib/LinearAlgebra/src/abstractq.jl
+++ b/stdlib/LinearAlgebra/src/abstractq.jl
@@ -143,10 +143,6 @@ function (*)(A::AbstractMatrix, Q::AbstractQ)
 end
 (*)(u::AdjointAbsVec, Q::AbstractQ) = (Q'u')'
 
-# AbstractQ * Triangular
-# @deprecate lmul!(Q::AbstractQ, B::AbstractTriangular) lmul!(Q, full!(B)) false
-# @deprecate rmul!(A::AbstractTriangular, Q::AbstractQ) rmul!(full!(A), Q) false
-
 ### Q*Q (including adjoints)
 *(Q::AbstractQ, P::AbstractQ) = Q * (P*I)
 
@@ -279,7 +275,6 @@ function lmul!(A::QRPackedQ, B::AbstractVecOrMat)
     end
     B
 end
-# lmul!(Q::QRPackedQ, B::AbstractTriangular) = lmul!(Q, full!(B)) # disambiguation
 
 ### QcB
 lmul!(adjQ::AdjointQ{<:Any,<:QRCompactWYQ{T,<:StridedMatrix}}, B::StridedVecOrMat{T}) where {T<:BlasReal} =
@@ -316,7 +311,6 @@ function lmul!(adjA::AdjointQ{<:Any,<:QRPackedQ}, B::AbstractVecOrMat)
     end
     B
 end
-# lmul!(Q::AdjointQ{<:Any,<:QRPackedQ}, B::AbstractTriangular) = lmul!(Q, full!(B)) # disambiguation
 
 ### AQ
 rmul!(A::StridedVecOrMat{T}, B::QRCompactWYQ{T,<:StridedMatrix}) where {T<:BlasFloat} =
@@ -348,7 +342,6 @@ function rmul!(A::AbstractMatrix, Q::QRPackedQ)
     end
     A
 end
-# rmul!(A::AbstractTriangular, Q::QRPackedQ) = rmul!(full!(A), Q) # disambiguation
 
 ### AQc
 rmul!(A::StridedVecOrMat{T}, adjQ::AdjointQ{<:Any,<:QRCompactWYQ{T}}) where {T<:BlasReal} =
@@ -385,7 +378,6 @@ function rmul!(A::AbstractMatrix, adjQ::AdjointQ{<:Any,<:QRPackedQ})
     end
     A
 end
-# rmul!(A::AbstractTriangular, Q::AdjointQ{<:Any,<:QRPackedQ}) = rmul!(full!(A), Q) # disambiguation
 
 det(Q::QRPackedQ) = _det_tau(Q.τ)
 det(Q::QRCompactWYQ) =

--- a/stdlib/LinearAlgebra/test/special.jl
+++ b/stdlib/LinearAlgebra/test/special.jl
@@ -228,10 +228,10 @@ end
         b = rand(n,n)
         for pivot in (ColumnNorm(), NoPivot())
             qrb = qr(b, pivot)
-            @test atri * qrb.Q ≈ matri * qrb.Q ≈ rmul!(copy(atri), qrb.Q)
-            @test atri * qrb.Q' ≈ matri * qrb.Q' ≈ rmul!(copy(atri), qrb.Q')
-            @test qrb.Q * atri ≈ qrb.Q * matri ≈ lmul!(qrb.Q, copy(atri))
-            @test qrb.Q' * atri ≈ qrb.Q' * matri ≈ lmul!(qrb.Q', copy(atri))
+            @test atri * qrb.Q ≈ matri * qrb.Q# ≈ rmul!(copy(atri), qrb.Q)
+            @test atri * qrb.Q' ≈ matri * qrb.Q'# ≈ rmul!(copy(atri), qrb.Q')
+            @test qrb.Q * atri ≈ qrb.Q * matri# ≈ lmul!(qrb.Q, copy(atri))
+            @test qrb.Q' * atri ≈ qrb.Q' * matri# ≈ lmul!(qrb.Q', copy(atri))
         end
     end
 end

--- a/stdlib/LinearAlgebra/test/special.jl
+++ b/stdlib/LinearAlgebra/test/special.jl
@@ -228,10 +228,10 @@ end
         b = rand(n,n)
         for pivot in (ColumnNorm(), NoPivot())
             qrb = qr(b, pivot)
-            @test atri * qrb.Q ≈ matri * qrb.Q# ≈ rmul!(copy(atri), qrb.Q)
-            @test atri * qrb.Q' ≈ matri * qrb.Q'# ≈ rmul!(copy(atri), qrb.Q')
-            @test qrb.Q * atri ≈ qrb.Q * matri# ≈ lmul!(qrb.Q, copy(atri))
-            @test qrb.Q' * atri ≈ qrb.Q' * matri# ≈ lmul!(qrb.Q', copy(atri))
+            @test atri * qrb.Q ≈ matri * qrb.Q
+            @test atri * qrb.Q' ≈ matri * qrb.Q'
+            @test qrb.Q * atri ≈ qrb.Q * matri
+            @test qrb.Q' * atri ≈ qrb.Q' * matri
         end
     end
 end


### PR DESCRIPTION
These two methods are nowhere internally used, but they provoke ambiguities for every `AbstractQ` subtype out there. The method is strange anyway in that it modifies the argument, but doesn't return it. Whoever wants to use it needs to remember to assign the result to a new variable, in contrast to all other `*mul!`s that I'm aware of. If we need this method, then it should be provided for each concrete `AbstratQ` subtype, even in the presence of a generic fallback (due to ambiguity).