### PR TITLE
faster iteration over subarrays (views)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -767,6 +767,8 @@ false
 checkindex(::Type{Bool}, inds::AbstractUnitRange, i) =
     throw(ArgumentError("unable to check bounds for indices of type $(typeof(i))"))
 checkindex(::Type{Bool}, inds::AbstractUnitRange, i::Real) = (first(inds) <= i) & (i <= last(inds))
+checkindex(::Type{Bool}, inds::IdentityUnitRange, i::Real) = checkindex(Bool, inds.indices, i)
+checkindex(::Type{Bool}, inds::OneTo{T}, i::T) where {T<:BitInteger} = unsigned(i - one(i)) < unsigned(last(inds))
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Colon) = true
 checkindex(::Type{Bool}, inds::AbstractUnitRange, ::Slice) = true
 function checkindex(::Type{Bool}, inds::AbstractUnitRange, r::AbstractRange)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -433,6 +433,12 @@ find_extended_inds(::ScalarIndex, I...) = (@inline; find_extended_inds(I...))
 find_extended_inds(i1, I...) = (@inline; (i1, find_extended_inds(I...)...))
 find_extended_inds() = ()
 
+function iterate(V::FastContiguousSubArray,
+        state = (V.offset1+firstindex(V), V.offset1+lastindex(V)))
+    i, l = state
+    @inbounds i-1 < l ? (V.parent[i], (i+1, l)) : nothing
+end
+
 function unsafe_convert(::Type{Ptr{T}}, V::SubArray{T,N,P,<:Tuple{Vararg{RangeIndex}}}) where {T,N,P}
     return unsafe_convert(Ptr{T}, V.parent) + _memory_offset(V.parent, map(first, V.indices)...)
 end

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -433,34 +433,6 @@ find_extended_inds(::ScalarIndex, I...) = (@inline; find_extended_inds(I...))
 find_extended_inds(i1, I...) = (@inline; (i1, find_extended_inds(I...)...))
 find_extended_inds() = ()
 
-function is_valid_ind(p, i, l, stride1)
-    fi = firstindex(p)
-    li = lastindex(p)
-    if stride1 < 0
-        fi <= l <= i <= li
-    elseif fi != 1
-        fi <= i <= l <= li
-    else
-        (i-1) % UInt < l % UInt <= li % UInt
-    end
-end
-
-function iterate(v::FastContiguousSubArray,
-        state = v.offset1 .+ (firstindex(v), lastindex(v)))
-    p = parent(v)
-    i, l = state
-    is_valid_ind(p, i, l, 1) ? (@inbounds p[i], (i+1, l)) : nothing
-end
-
-stride1(v::SubArray{T,N,P}) where {T,N,P} = P <: StridedArray ? stride(v, 1) : v.stride1
-
-function iterate(v::FastSubArray,
-        state = v.offset1 .+ stride1(v) .* (firstindex(v), lastindex(v)))
-    p = parent(v)
-    i, l = state
-    is_valid_ind(p, i, l, stride1(v)) ? (@inbounds p[i], (i+stride1(v), l)) : nothing
-end
-
 function unsafe_convert(::Type{Ptr{T}}, V::SubArray{T,N,P,<:Tuple{Vararg{RangeIndex}}}) where {T,N,P}
     return unsafe_convert(Ptr{T}, V.parent) + _memory_offset(V.parent, map(first, V.indices)...)
 end


### PR DESCRIPTION
Iterating over a `SubArray` (`view`) of an ~~integer-valued~~ array is often much slower than iterating over the array itself:
```
f(v) = foldl(+, v; init = zero(eltype(v)))

a = rand(Int8, 2^16);
v = view(a, :);

julia> @btime f($a)
  570.860 ns (0 allocations: 0 bytes)
julia> @btime f($v)
  34.613 μs (0 allocations: 0 bytes)

a = rand(Int, 2^16);
v = view(a, :);

julia> @btime f($a)
  7.957 μs (0 allocations: 0 bytes)
julia> @btime f($v)
  34.741 μs (0 allocations: 0 bytes)
```
My understanding is that the index transformation necessary for accessing the view prevents the compiler from optimizing the code via SIMD instructions. This PR addresses this by a dedicated `iterate` method for `FastContiguousSubArray`. This is the (already existing) subtype of `SubArray` for which the indices in the parent array are known to be contiguous and increasing; see subarrays.jl for details. For example, `view(a, :,:,2:3,4)` is of this type, but `view(a, 1,:,2:3,4)` and `view(a, 3:-1:2,1,1,1)` are not (although they are of type `FastSubArray`, meaning that they allow fast linear indexing into the parent array). It's hard to imagine SIMD speed-ups for other subarrays.

In the following benchmarks (made with `@btime f($v)` etc.), the function `f` from above is applied to the arrays
```
v = rand(Int8, 2^16);
u = codeunits(String(rand('a':'z', 2^16)));
a = rand(Int8, 32,32,32,32)
```
and views into them.

| function call | master | this PR |
|---|---|---|
|`f(v)`| 567.227 ns | |
|`f(view(v,:))`| 34.615 μs | 563.778 ns |
|`f(u)`| 576.681 ns | |
|`f(view(u,:))`| 34.613 μs | 581.473 ns |
|`f(a)`| 15.847 μs | |
|`f(view(a, 2:3,1,1,1))`| 3.545 ns | 4.084 ns |
|`f(view(a, :,2:3,1,1))`| 36.684 ns | 10.300 ns |
|`f(view(a, :,:,2:3,1))`| 1.091 μs | 25.071 ns |
|`f(view(a, :,:,:,2:3))`| 34.610 μs | 572.445 ns |

One can see that with the new method, iterating over a view is as fast as iterating over the parent array.

EDIT: Using `@fastmath` one can obtain analogous speed-ups for floating-point arrays:
```
g(v) = @fastmath foldl(+, v; init = zero(eltype(v)))

a = rand(Float64, 2^16);
v = view(a, :);

julia> @btime g($a)
  7.963 μs (0 allocations: 0 bytes)

julia> @btime g($v)
  69.192 μs (0 allocations: 0 bytes)   # Julia 1.9.0-beta2
  7.967 μs (0 allocations: 0 bytes)    # this PR
```

```
Julia Version 1.10.0-DEV.635
Commit 12d329b6e3 (2023-02-17 20:01 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 4 × Intel(R) Core(TM) i3-10110U CPU @ 2.10GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.6 (ORCJIT, skylake)
  Threads: 1 on 4 virtual cores
```