### PR TITLE
Fix heapsize hint and use a line for max memory

### DIFF
--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -289,6 +289,13 @@ function total_memory()
 end
 
 """
+    Sys.heap_size()
+
+Get the maximum size of the heap in bytes.
+"""
+heap_size() = ccall(:jl_gc_get_max_memory, UInt64, ())
+
+"""
     Sys.get_process_title()
 
 Get the process title. On some systems, will always return an empty string.

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -289,13 +289,6 @@ function total_memory()
 end
 
 """
-    Sys.heap_size()
-
-Get the maximum size of the heap in bytes.
-"""
-heap_size() = ccall(:jl_gc_get_max_memory, UInt64, ())
-
-"""
     Sys.get_process_title()
 
 Get the process title. On some systems, will always return an empty string.

--- a/src/gc.c
+++ b/src/gc.c
@@ -3251,15 +3251,12 @@ void jl_gc_init(void)
     uint64_t constrained_mem = uv_get_constrained_memory();
     if (constrained_mem > 0 && constrained_mem < total_mem)
         total_mem = constrained_mem;
-    uint64_t ngigs = total_mem / 10e9;
-    if (ngigs < 128)
-    {
-        double percent = ngigs * 0.00234375 + 0.6; // 60% at 0 gigs and 90% at 128 to
-                                                   //not overcommit too much on memory contrained devices
-        max_total_memory = total_mem * percent;
-    }
-    else
-        max_total_memory = total_mem / 10 * 9;
+    double percent;
+    if (total_mem < 128e9)
+        percent = total_mem * 2.34375e-12 + 0.6; // 60% at 0 gigs and 90% at 128 to not
+    else                                         // overcommit too much on memory contrained devices
+        percent = 0.9;
+    max_total_memory = total_mem * percent;
 #endif
     if (jl_options.heap_size_hint)
         jl_gc_set_max_memory(jl_options.heap_size_hint);

--- a/src/gc.c
+++ b/src/gc.c
@@ -3254,7 +3254,7 @@ void jl_gc_init(void)
     uint64_t ngigs = total_mem / 10e9;
     if (ngigs < 128)
     {
-        double percent = ngigs * 0.00703125 + 0.6; // 60% at 0 gigs and 90% at 128 to
+        double percent = ngigs * 0.00234375 + 0.6; // 60% at 0 gigs and 90% at 128 to
                                                    //not overcommit too much on memory contrained devices
         max_total_memory = total_mem * percent;
     }

--- a/src/gc.c
+++ b/src/gc.c
@@ -3275,6 +3275,11 @@ JL_DLLEXPORT void jl_gc_set_max_memory(uint64_t max_mem)
     }
 }
 
+JL_DLLEXPORT uint64_t jl_gc_get_max_memory()
+{
+    return max_total_memory;
+}
+
 // callback for passing OOM errors from gmp
 JL_DLLEXPORT void jl_throw_out_of_memory_error(void)
 {

--- a/src/gc.c
+++ b/src/gc.c
@@ -3275,7 +3275,7 @@ JL_DLLEXPORT void jl_gc_set_max_memory(uint64_t max_mem)
     }
 }
 
-JL_DLLEXPORT uint64_t jl_gc_get_max_memory()
+JL_DLLEXPORT uint64_t jl_gc_get_max_memory(void)
 {
     return max_total_memory;
 }

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -172,6 +172,7 @@
     XX(jl_gc_external_obj_hdr_size) \
     XX(jl_gc_find_taggedvalue_pool) \
     XX(jl_gc_get_total_bytes) \
+    XX(jl_gc_get_max_memory) \
     XX(jl_gc_internal_obj_base_ptr) \
     XX(jl_gc_is_enabled) \
     XX(jl_gc_live_bytes) \

--- a/src/julia.h
+++ b/src/julia.h
@@ -919,6 +919,7 @@ JL_DLLEXPORT void jl_free_stack(void *stkbuf, size_t bufsz);
 JL_DLLEXPORT void jl_gc_use(jl_value_t *a);
 // Set GC memory trigger in bytes for greedy memory collecting
 JL_DLLEXPORT void jl_gc_set_max_memory(uint64_t max_mem);
+JL_DLLEXPORT uint64_t jl_gc_get_max_memory(void);
 
 JL_DLLEXPORT void jl_clear_malloc_data(void);
 

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -901,4 +901,6 @@ end
         @test lines[3] == "foo"
         @test lines[4] == "bar"
     end
+#heap-size-hint
+@test readchomp(`$exename --heap-size-hint=500M -e "println(Sys.heap_size())"`) == "524288000"
 end

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -902,5 +902,5 @@ end
         @test lines[4] == "bar"
     end
 #heap-size-hint
-@test readchomp(`$exename --heap-size-hint=500M -e "println(Sys.heap_size())"`) == "524288000"
+@test readchomp(`$(Base.julia_cmd()) --startup-file=no --heap-size-hint=500M -e "println(Sys.heap_size())"`) == "524288000"
 end

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -902,5 +902,5 @@ end
         @test lines[4] == "bar"
     end
 #heap-size-hint
-@test readchomp(`$(Base.julia_cmd()) --startup-file=no --heap-size-hint=500M -e "println(Sys.heap_size())"`) == "524288000"
+@test readchomp(`$(Base.julia_cmd()) --startup-file=no --heap-size-hint=500M -e "println(@ccall jl_gc_get_max_memory()::UInt64)"`) == "524288000"
 end


### PR DESCRIPTION
The idea here is that there is a kinda fixed amount of background memory for OSs and other things, so on small machines we are more conservative, but if the user has a lot of ram we should try and use most of it.
Also fix heap-sizehint since it got broken on the last change.