### PR TITLE
Resolve artifact ambiguities using shortest match

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -1067,12 +1067,20 @@ function select_platform(download_info::Dict, platform::AbstractPlatform = HostP
         return nothing
     end
 
-    # At this point, we may have multiple possibilities.  E.g. if, in the future,
-    # Julia can be built without a direct dependency on libgfortran, we may match
-    # multiple tarballs that vary only within their libgfortran ABI.  To narrow it
-    # down, we just sort by triplet, then pick the last one.  This has the effect
-    # of generally choosing the latest release (e.g. a `libgfortran5` tarball
-    # rather than a `libgfortran3` tarball)
+    # At this point, we may have multiple possibilities.  We now engage a multi-
+    # stage selection algorithm, where we first choose simpler matches over more
+    # complex matches.  We define a simpler match as one that has fewer tags
+    # overall.  As these candidate matches have already been filtered to match
+    # the given platform, the only other tags that exist are ones that are in
+    # addition to the tags declared by the platform. Hence, selecting the
+    # minimum in number of tags is equivalent to selecting the closest match.
+    min_tag_count = minimum(length(tags(p)) for p in ps)
+    filter!(p -> length(tags(p)) == min_tag_count, ps)
+
+    # Now we _still_ may continue to have multiple matches, so we now simply sort
+    # the candidate matches by their triplets and take the last one, so as to
+    # generally choose the latest release (e.g. a `libgfortran5` tarball over a
+    # `libgfortran3` tarball).
     p = last(sort(ps, by = p -> triplet(p)))
     return download_info[p]
 end


### PR DESCRIPTION
This changes the behavior of `select_platform()` to resolve ambiguities using a two-step process.  Previously, we would simply sort the resultant triplets and return the last one (so as to provide asemi- arbitrary stability, and also to prefer higher version numbers over lower version numbers in tags).  However, with the proliferation of tags (and especially the new `sanitize=memory` tags) we need a way to exclude these "extra" tags when our `HostPlatform()` does not have them.

This new matching algorithm excludes candidates from matching with the platform if there are other candidates with fewer total tags.  This results in a "simplest match first" behavior, which better represents the intent of tags in the first place.