### PR TITLE
Allow `...` outside call

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2769,7 +2769,7 @@
    '|...|
    (lambda (e)
 	 (expand-tuple (cadr e)))
-   
+
    '$
    (lambda (e) (error "\"$\" expression outside quote"))
 

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -3464,7 +3464,6 @@ end
 end
 
 
-
 # Issue #48738
 macro splatter()
     :((1,2)...)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -342,9 +342,6 @@ end
 @test_parseerror("if\nfalse\nend", "missing condition in \"if\" at none:1")
 @test_parseerror("if false\nelseif\nend", "missing condition in \"elseif\" at none:2")
 
-# issue #15828
-@test Meta.lower(Main, Meta.parse("x...")) == Expr(:error, "\"...\" expression outside call")
-
 # issue #15830
 @test Meta.lower(Main, Meta.parse("foo(y = (global x)) = y")) == Expr(:error, "misplaced \"global\" declaration")
 
@@ -3464,4 +3461,17 @@ end
     @test @_macroexpand(global (; x, $(esc(:y))) = a) == :(global (; x, y) = $(GlobalRef(m, :a)))
     @test @_macroexpand(global (; x::S, $(esc(:y))::$(esc(:T))) = a) ==
         :(global (; x::$(GlobalRef(m, :S)), y::T) = $(GlobalRef(m, :a)))
+end
+
+
+
+# Issue #48738
+macro splatter()
+    :((1,2)...)
+end
+@testset "splatting outside call" begin
+    @test @eval((1, 2)...) == (1, 2)
+    tup = @splatter()
+    @test tup == (1, 2)
+    @test +(@splatter) == 3
 end


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/48738

# What

- Before:

```julia
julia> +((1, 2)...)
3

julia> 0, (1, 2)... # if this works...
(0, 1, 2)

julia>  (1, 2)... # Then I think this should also work
ERROR: syntax: "..." expression outside call around REPL[3]:1
```

- After:

```julia

julia> +((1, 2)...)
3

julia> 0, (1, 2)...
(0, 1, 2)

julia> (1, 2)... # <------ The new behaviour.
(1, 2)
```

# Why?

I want this because [SimpleUnderscores.jl](https://github.com/MasonProtter/SimpleUnderscores.jl) provides a macro `@->` which is meant to act like an anonymous function, but macros have different precedence than `->` so we get this:
```julia
julia> dump(:(x -> x, 1))
Expr
  head: Symbol tuple
  args: Array{Any}((2,))
    1: Expr
      head: Symbol ->
      args: Array{Any}((2,))
        1: Symbol x
        2: Expr
          head: Symbol block
          args: Array{Any}((2,))
            1: LineNumberNode
              line: Int64 1
              file: Symbol REPL[6]
            2: Symbol x
    2: Int64 1

julia> dump(:(@-> x, 1))
Expr
  head: Symbol macrocall
  args: Array{Any}((3,))
    1: Symbol @->
    2: LineNumberNode
      line: Int64 1
      file: Symbol REPL[7]
    3: Expr
      head: Symbol tuple
      args: Array{Any}((2,))
        1: Symbol x
        2: Int64 1
```
This means that if `@->` wants to mimic the behaviour of `->`, it needs to splat out multiple arguments but that currently causes an error if done outside of a `:call` expression.

- Before this PR:

```julia
julia> using SimpleUnderscores

julia> map(@-> _, [1,])
1-element Vector{Int64}:
 1

julia> (@-> _, [1,])
ERROR: syntax: "..." expression outside call around REPL[6]:1
Stacktrace:
 [1] top-level scope
   @ REPL[6]:1
```

- After this PR:

```julia
julia> using SimpleUnderscores

julia> map(@-> _, [1,])
1-element Vector{Int64}:
 1

julia> (@-> _, [1,])
(var"#9#10"(), [1])
```
 