### PR TITLE
[LibCURL_jll] Add major extension to SONAME

### DIFF
--- a/stdlib/LibCURL_jll/src/LibCURL_jll.jl
+++ b/stdlib/LibCURL_jll/src/LibCURL_jll.jl
@@ -23,7 +23,7 @@ if Sys.iswindows()
 elseif Sys.isapple()
     const libcurl = "@rpath/libcurl.4.dylib"
 else
-    const libcurl = "libcurl.so"
+    const libcurl = "libcurl.so.4"
 end
 
 function __init__()


### PR DESCRIPTION
We should be consistent in the SONAMEs we use when loading, so that we are properly declaring the ABI we support when loading `libcurl`.