### PR TITLE
Document stability for rev=true in sort!

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1342,7 +1342,8 @@ specific algorithm to use via the `alg` keyword (see [Sorting Algorithms](@ref) 
 available algorithms). The `by` keyword lets you provide a function that will be applied to
 each element before comparison; the `lt` keyword allows providing a custom "less than"
 function (note that for every `x` and `y`, only one of `lt(x,y)` and `lt(y,x)` can return
-`true`); use `rev=true` to reverse the sorting order. These options are independent and can
+`true`); use `rev=true` to reverse the sorting order. `rev=true` preserves forward stability:
+Elements that compare equal are not reversed. These options are independent and can
 be used together in all possible combinations: if both `by` and `lt` are specified, the `lt`
 function is applied to the result of the `by` function; `rev=true` reverses whatever
 ordering specified via the `by` and `lt` keywords.


### PR DESCRIPTION
Document the fact that `sort!` with `rev=true` maintains forward stability.

I think this:

```Julia
julia> reverse(sort(1:3,by=Returns(0))) == sort(1:3,by=Returns(0),rev=true)
false
```
is non-obvious behaviour, which should be documented somewhere. Python does [here](https://docs.python.org/3/howto/sorting.html#odds-and-ends).