### PR TITLE
RFC: Add a simple feature checking mechanism.

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -439,6 +439,7 @@ include("timing.jl")
 include("util.jl")
 include("client.jl")
 include("asyncmap.jl")
+include("features.jl")
 
 # deprecated functions
 include("deprecated.jl")

--- a/base/features.jl
+++ b/base/features.jl
@@ -1,0 +1,10 @@
+const features = Set{String}([
+    "features",
+])
+
+"""
+    has_feature(feature::String)
+
+Checks if this version of Julia has the given feature.
+"""
+@assume_effects :foldable has_feature(feature::String) = feature in features

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1386,3 +1386,15 @@ end
     @test (@allocations "a") == 0
     @test (@allocations "a" * "b") == 1
 end
+
+@testset "features" begin
+    @test Base.has_feature("features")
+    f() = Base.has_feature("features")
+    code = sprint(code_warntype, f, Tuple{})
+    @test occursin("(\"features\")::Core.Const(true)", code)
+
+    @test !Base.has_feature("nonexisting_feature")
+    g() = Base.has_feature("nonexisting_feature")
+    code = sprint(code_warntype, g, Tuple{})
+    @test occursin("(\"nonexisting_feature\")::Core.Const(false)", code)
+end


### PR DESCRIPTION
This PR adds a simple mechanism to check if a build of Julia has certain features:

```julia
julia> Base.has_feature("features")
true

julia> Base.has_feature("whatever")
false
```

The purpose of this function is to use this to drive conditional code in packages. Currently, we use:

- `VERSION` checks, e.g. `if VERSION >= v"1.10.0-DEV.649"`, which doesn't tell me much if I read this code
- checking for specific functionality, e.g., `if isdefined(Base, :get_extension)`

The other problem with version checks is that they need the Julia PR to be merged before we can adapt packages. For example, in https://github.com/JuliaLang/julia/pull/48611 PkgEval revealed quite some breakage. I'd like to fix packages without having to merge the (re-landed version of) that PR, but there isn't any easy way to check for the changed behavior without looking deeply into compiler internals, which is ugly. In fact, I think the `isdefined(Base, :get_extension)` is ugly too, and a call to `Base.has_feature("extensions")` would be much easier on the eyes.

Currently, the set of `features` is hard-coded, just as a starting point for this PR. I considered automating its generation during build, e.g. making it possible to check for PR numbers, but AFAIK that would require use of the GitHub API during build which isn't great.