### PR TITLE
Mention "make debug"

### DIFF
--- a/doc/src/devdocs/build/windows.md
+++ b/doc/src/devdocs/build/windows.md
@@ -90,7 +90,8 @@ MinGW-w64 compilers available through Cygwin's package manager.
 
     3. Start the build
        ```sh
-       make -j 4   # Adjust the number of threads (4) to match your build environment.
+       make -j 4       # Adjust the number of threads (4) to match your build environment.
+       make -j 4 debug # This builds julia-debug.exe
        ```
 
 


### PR DESCRIPTION
The build instructions for Windows mention that `julia-debug.exe` should have been created by `make -j 4`, but this happens only if you run `make debug`.