### PR TITLE
base.combinatorics: rm dead code: `permute!!` and `permute!!`

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -115,7 +115,7 @@ function swaprows!(a::AbstractMatrix, i, j)
     end
 end
 
-# like permute!! applied to each row of a, in-place in a (overwriting p).
+# like permute! applied to each row of a, in-place in a (overwriting p).
 function permutecols!!(a::AbstractMatrix, p::AbstractVector{<:Integer})
     require_one_based_indexing(a, p)
     count = 0
@@ -131,28 +131,6 @@ function permutecols!!(a::AbstractMatrix, p::AbstractVector{<:Integer})
             next = p[next]
             count += 1
         end
-        p[ptr] = 0
-    end
-    a
-end
-
-function permute!!(a, p::AbstractVector{<:Integer})
-    require_one_based_indexing(a, p)
-    count = 0
-    start = 0
-    while count < length(a)
-        ptr = start = findnext(!iszero, p, start+1)::Int
-        temp = a[start]
-        next = p[start]
-        count += 1
-        while next != start
-            a[ptr] = a[next]
-            p[ptr] = 0
-            ptr = next
-            next = p[next]
-            count += 1
-        end
-        a[ptr] = temp
         p[ptr] = 0
     end
     a
@@ -188,30 +166,6 @@ julia> A
 ```
 """
 permute!(v, p::AbstractVector) = (v .= v[p])
-
-function invpermute!!(a, p::AbstractVector{<:Integer})
-    require_one_based_indexing(a, p)
-    count = 0
-    start = 0
-    while count < length(a)
-        start = findnext(!iszero, p, start+1)::Int
-        temp = a[start]
-        next = p[start]
-        count += 1
-        while next != start
-            temp_next = a[next]
-            a[next] = temp
-            temp = temp_next
-            ptr = p[next]
-            p[next] = 0
-            next = ptr
-            count += 1
-        end
-        a[next] = temp
-        p[next] = 0
-    end
-    a
-end
 
 """
     invpermute!(v, p)


### PR DESCRIPTION
rm `permute!!` and `permute!!`

- No documentation
- No export
- No usage case, and no tests

note:
- introduced in "Added permute!, ipermute!" 0bd7137e87d4b9961ba4b891108907df2ed85f86 to define other functions (`permute!` and `permute!`)
- reanme: "deprecate ipermute! in favor of invpermute!" 5f14f11beb4c8acc15e6c4ec429f168bbf902a75
- Stop using in "Stop using permute!! and invpermute!!" c7e7a5d63d3876381ee09727806b8a30cb7809e0

