### PR TITLE
faster folding operations for "reversed" views

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -204,6 +204,21 @@ function mapfoldr_impl(f, op, nt, itr)
     return foldl_impl(op′, nt, _reverse_iter(itr′))
 end
 
+function mapfoldr_impl(f, op, s, a::AbstractArray{T}) where T
+# to avoid ambiguity with other methods we use a single method
+# both for given initial value s and for s == _InitialValue()
+    li = lastindex(a)
+    if s isa _InitialValue
+        isempty(a) && return mapreduce_empty(f, op, T)
+        s = f(a[li])
+        li -= 1
+    end
+    for i in li:-1:firstindex(a)
+        s = op(f(a[i]), s)
+    end
+    return s
+end
+
 _reverse_iter(itr) = Iterators.reverse(itr)
 _reverse_iter(itr::Union{Tuple,NamedTuple}) = length(itr) <= 32 ? reverse(itr) : Iterators.reverse(itr) #33235
 

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -204,21 +204,6 @@ function mapfoldr_impl(f, op, nt, itr)
     return foldl_impl(op′, nt, _reverse_iter(itr′))
 end
 
-function mapfoldr_impl(f, op, s, a::AbstractArray{T}) where T
-# to avoid ambiguity with other methods we use a single method
-# both for given initial value s and for s == _InitialValue()
-    li = lastindex(a)
-    if s isa _InitialValue
-        isempty(a) && return mapreduce_empty(f, op, T)
-        s = f(a[li])
-        li -= 1
-    end
-    for i in li:-1:firstindex(a)
-        s = op(f(a[i]), s)
-    end
-    return s
-end
-
 _reverse_iter(itr) = Iterators.reverse(itr)
 _reverse_iter(itr::Union{Tuple,NamedTuple}) = length(itr) <= 32 ? reverse(itr) : Iterators.reverse(itr) #33235
 

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -375,16 +375,6 @@ function _mapreduce_dim(f, op, nt, A::AbstractArrayOrBroadcasted, dims)
     end
 end
 
-function _mapreduce_dim(f::F, op::OP, nt::NT, a::FastSubArray, dims::Colon) where {F,OP,NT}
-    if a.stride1 == -1
-        fi, li = a.offset1 .- (firstindex(a), lastindex(a))
-        b = view(parent(a), li:fi)
-        @invoke _mapreduce_dim(f::F, FlipArgs(op)::FlipArgs{OP}, nt::NT, b::AbstractArray, dims::Colon)
-    else
-        @invoke _mapreduce_dim(f::F, op::OP, nt::NT, a::AbstractArray, dims::Colon)
-    end
-end
-
 """
     reduce(f, A::AbstractArray; dims=:, [init])
 

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -461,3 +461,14 @@ function _indices_sub(i1::AbstractArray, I...)
 end
 
 has_offset_axes(S::SubArray) = has_offset_axes(S.indices...)
+
+# faster implementation of mapreduce for "reversed" FastSubArray with stride1 == -1
+function mapreduce(f, op, a::FastSubArray; dims::T=:, init=_InitialValue()) where T
+    if T == Colon && a.stride1 == -1
+        fi, li = a.offset1 .- (firstindex(a), lastindex(a))
+        b = view(parent(a), li:fi)
+        invoke(mapreduce, Tuple{Any,Any,AbstractArray}, f, op, b; dims, init)
+    else
+        invoke(mapreduce, Tuple{Any,Any,AbstractArray}, f, op, a; dims, init)
+    end
+end

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -772,3 +772,22 @@ end
     @test view(m, 1:2, 3, 1, 1) == m[1:2, 3]
     @test parent(view(m, 1:2, 3, 1, 1)) === m
 end
+
+@testset "mapfoldl, mapfoldr and mapreduce for FastSubArray" begin
+    v = rand(Int, 10)
+    i = rand(Int)
+    @test mapfoldl(abs, -, @view(v[:])) == mapfoldl(abs, -, v)
+    @test mapfoldr(abs, -, @view(v[:])) == mapfoldr(abs, -, v)
+    @test mapfoldl(abs, -, @view(v[end:-1:begin])) == mapfoldl(abs, -, reverse(v))
+    @test mapfoldr(abs, -, @view(v[end:-1:begin])) == mapfoldr(abs, -, reverse(v))
+    @test mapfoldl(abs, -, @view(v[:]); init = i) == mapfoldl(abs, -, v; init = i)
+    @test mapfoldr(abs, -, @view(v[:]); init = i) == mapfoldr(abs, -, v; init = i)
+    @test mapfoldl(abs, -, @view(v[end:-1:begin]); init = i) == mapfoldl(abs, -, reverse(v); init = i)
+    @test mapfoldr(abs, -, @view(v[end:-1:begin]); init = i) == mapfoldr(abs, -, reverse(v); init = i)
+
+    v = rand('a':'z', 10)
+    @test mapreduce(uppercase, *, @view(v[:])) == mapreduce(uppercase, *, v)
+    @test mapreduce(uppercase, *, @view(v[end:-1:begin])) == mapreduce(uppercase, *, reverse(v))
+    @test mapreduce(uppercase, *, @view(v[:]); init = "") == mapreduce(uppercase, *, v; init = "")
+    @test mapreduce(uppercase, *, @view(v[end:-1:begin]); init = "") == mapreduce(uppercase, *, reverse(v); init = "")
+end


### PR DESCRIPTION
Since we now have fast iteration over `FastContiguousSubArray` (#48720), it could make sense to implement a special method for `mapreduce` for "reversed" `FastSubArray`, that is, for those step with value -1 (`w2` below). Since for `mapreduce` we are allowed to process the array elements in any order, we can reverse the view to get something that has a much better chance of SIMD compiler optimization. Here are some benchmarks:
```
g(a) = reduce(+, a; init = zero(eltype(a)))
v = rand(Int8, 2^16);
w1 = @view v[begin:end];
w2 = @view v[end:-1:begin];

julia> @btime g($v); @btime g($w1); @btime g($w2)

# master
  574.189 ns (0 allocations: 0 bytes)
  641.550 ns (0 allocations: 0 bytes)
  834.255 μs (0 allocations: 0 bytes)
# this PR
  572.086 ns (0 allocations: 0 bytes)   # not affected by the PR
  675.769 ns (1 allocation: 48 bytes)   # around 30ns slower
  696.621 ns (1 allocation: 48 bytes)   # over 1000 times faster
```
The not implemented part of #48720 gave a speed-up factor of around 17 for `FastSubArray{Int8}`. Even if that is implemented later, this special method would still be around 70 times faster than that. Maybe this justifies to have a special method for this case. Maybe it doesn't.

**Note:** There is currently one issue with the PR. The new method allocates 48 bytes, which seems to take around 30ns (the time difference for `w1` above). I don't know how to get rid of this, but I'm hoping that somebody else has an idea. I have the feeling that it is somehow related to the treatment of keyword arguments.

Also note that I'm using `invoke` to avoid any interference with the implementation of `mapreduce` for `AbstractArray`.