### PR TITLE
Fix imaging value for generating sysimages for multiple targets

### DIFF
--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -73,7 +73,7 @@ GlobalVariable *jl_emit_RTLD_DEFAULT_var(Module *M) JL_NOTSAFEPOINT;
 DataLayout jl_create_datalayout(TargetMachine &TM) JL_NOTSAFEPOINT;
 
 static inline bool imaging_default() JL_NOTSAFEPOINT {
-    return jl_options.image_codegen || jl_generating_output() || jl_options.use_pkgimages;
+    return jl_options.image_codegen || (jl_generating_output() && (!jl_options.incremental || jl_options.use_pkgimages));
 }
 
 struct OptimizationOptions {

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -73,7 +73,7 @@ GlobalVariable *jl_emit_RTLD_DEFAULT_var(Module *M) JL_NOTSAFEPOINT;
 DataLayout jl_create_datalayout(TargetMachine &TM) JL_NOTSAFEPOINT;
 
 static inline bool imaging_default() JL_NOTSAFEPOINT {
-    return jl_options.image_codegen || (jl_generating_output() && jl_options.use_pkgimages);
+    return jl_options.image_codegen || jl_generating_output() || jl_options.use_pkgimages;
 }
 
 struct OptimizationOptions {

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -726,6 +726,42 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     end
 end
 
+let exename = `$(Base.julia_cmd(; cpu_target="native;native")) --startup-file=no --color=no`
+    # --pkgimages with multiple cpu targets
+    @testset let v = readchomperrors(`$exename --pkgimages=no`)
+        @test !v[1]
+        @test isempty(v[2])
+        @test v[3] == "ERROR: More than one command line CPU targets specified without a `--output-` flag specified"
+    end
+
+    @test readchomp(`$exename --pkgimages=yes -e '
+        println("cpu_target = $(unsafe_string(Base.JLOptions().cpu_target)) and use_pkgimages = $(Base.JLOptions().use_pkgimages)")'`) ==
+        "cpu_target = native;native and use_pkgimages = 1"
+end
+
+# Object file with multiple cpu targets
+@testset "Object file for multiple microarchitectures" begin
+    julia_path = joinpath(Sys.BINDIR, Base.julia_exename())
+    outputo_file = tempname()
+    write(outputo_file, "1")
+    object_file = tempname() * ".o"
+
+    # This is to test that even with `pkgimages=no`, we can create object file
+    # with multiple cpu-targets
+    # The cmd is checked for `--object-o` as soon as it is run. So, to avoid long
+    # testing times, intentionally don't pass `--sysimage`; when we reach the
+    # corresponding error, we know that `check_cmdline` has already passed
+    let v = readchomperrors(`$julia_path
+        --cpu-target='native;native'
+        --output-o=$object_file $outputo_file
+        --pkgimages=no`)
+
+        @test v[1] == false
+        @test v[2] == ""
+        @test !contains(v[3], "More than one command line CPU targets specified")
+        @test v[3] == "ERROR: File \"boot.jl\" not found"
+    end
+end
 
 # Find the path of libjulia (or libjulia-debug, as the case may be)
 # to use as a dummy shlib to open


### PR DESCRIPTION

Fixes `imaging_default` function, so that sysimages for multiple architectures can be built without setting `pkgimages=yes`

### Current issue:
For versions >1.9-dev,
For a use-case like:
```julia
julia> sysimage= unsafe_string(Base.JLOptions().image_file)

julia>  run(`./julia
               --sysimage=$sysimage
               --cpu-target='generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)'
               --output-o=mock.o mock.jl
               --pkgimages=no`)

fatal: error thrown and no exception handler available.
ErrorException("More than one command line CPU targets specified without a `--output-` flag specified")

[30365] signal (11.1): Segmentation fault
in expression starting at none:0
```

This is because, with `pkgimages=no`, even if output-o is passed, the `imaging_default` returns false. This in-turn causes issues while generating sysimages for multiple cpu-targets

### After this PR, these work:
1. Sysimages with multiple targets and no pkgimages
```
julia> run(`julia --sysimage=$sysimage --cpu-target='generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)' --output-o=mock.o mock.jl --pkgimages=no`)
```
2. Pkgimages=yes and multiple targets.
   From the [docs](https://docs.julialang.org/en/v1.9-dev/devdocs/pkgimg/#Package-images-optimized-for-multiple-microarchitectures), there should be a unified cache. It's unclear to me if the current change results an issue in that regard. An alternative would be changing to `return jl_options.image_codegen || jl_generating_output()`.
```
julia> run(`julia --cpu-target='generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)' --pkgimages=yes`)
```

