### PR TITLE
add a type assert to logging to prevent Base.require invalidation

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -445,7 +445,7 @@ function default_group_code(file)
         QuoteNode(default_group(file))  # precompute if we can
     else
         ref = Ref{Symbol}()  # memoized run-time execution
-        :(isassigned($ref) ? $ref[] : $ref[] = default_group(something($file, "")))
+        :(isassigned($ref) ? $ref[] : $ref[] = default_group(something($file, ""))::Symbol)
     end
 end
 


### PR DESCRIPTION
Before:

```julia
In [2]: using ModelBaseEcon

In [3]: @time using Random # invalidations
# precompile(Tuple{typeof(Base.something), String, String, Vararg{String}})
# precompile(Tuple{typeof(Base.require), Module, Symbol})
# precompile(Tuple{typeof(Base._require_prelocked), Base.PkgId, String})
  0.475471 seconds (599.54 k allocations: 40.704 MiB, 8.27% gc time, 99.10% compilation time: 100% of which was recompilation)
```

After:

```julia
In [2]: using ModelBaseEcon

In [3]: @time using Random
  0.004375 seconds (5.75 k allocations: 372.331 KiB)
```
