### PR TITLE
Update link in docs for Dates

### DIFF
--- a/stdlib/Dates/docs/src/index.md
+++ b/stdlib/Dates/docs/src/index.md
@@ -1,3 +1,7 @@
+```@meta
+EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/Dates/docs/src/index.md"
+```
+
 # Dates
 
 ```@meta


### PR DESCRIPTION
Update the 'Edit in GitHub' link in docs for Dates. Earlier pointed to a 404 error

Solves #47879 

While going through other documentation pages, I have noticed a lot of the 'Edit on GitHub' links lead to 404 errors, it is not just limited to this particular page.