### PR TITLE
Always use `-Wl,--warn-unresolved-symbols` in MSAN builds

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -673,7 +673,7 @@ SANITIZE_OPTS :=
 SANITIZE_LDFLAGS :=
 ifeq ($(SANITIZE_MEMORY),1)
 SANITIZE_OPTS += -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer
-SANITIZE_LDFLAGS += $(SANITIZE_OPTS)
+SANITIZE_LDFLAGS += $(SANITIZE_OPTS) -Wl,--warn-unresolved-symbols
 endif
 ifeq ($(SANITIZE_ADDRESS),1)
 SANITIZE_OPTS += -fsanitize=address

--- a/Make.inc
+++ b/Make.inc
@@ -673,8 +673,11 @@ SANITIZE_OPTS :=
 SANITIZE_LDFLAGS :=
 ifeq ($(SANITIZE_MEMORY),1)
 SANITIZE_OPTS += -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer
-SANITIZE_LDFLAGS += $(SANITIZE_OPTS) -Wl,--warn-unresolved-symbols
-endif
+SANITIZE_LDFLAGS += $(SANITIZE_OPTS)
+ifneq ($(findstring $(OS),Linux FreeBSD),)
+SANITIZE_LDFLAGS += -Wl,--warn-unresolved-symbols
+endif # OS Linux or FreeBSD
+endif # SANITIZE_MEMORY=1
 ifeq ($(SANITIZE_ADDRESS),1)
 SANITIZE_OPTS += -fsanitize=address
 SANITIZE_LDFLAGS += -fsanitize=address

--- a/deps/libsuitesparse.mk
+++ b/deps/libsuitesparse.mk
@@ -26,7 +26,7 @@ LIBSUITESPARSE_MFLAGS := CC="$(CC) $(SANITIZE_OPTS)" CXX="$(CXX) $(SANITIZE_OPTS
 	  AR="$(AR)" RANLIB="$(RANLIB)" \
 	  BLAS="-L$(build_shlibdir) -lblastrampoline" \
 	  LAPACK="-L$(build_shlibdir) -lblastrampoline" \
-	  LDFLAGS="$(SUITESPARSE_LIB) $(SANITIZE_LDFLAGS) -Wl,--warn-unresolved-symbols" CFOPENMP="" CUDA=no CUDA_PATH="" \
+	  LDFLAGS="$(SUITESPARSE_LIB) $(SANITIZE_LDFLAGS)" CFOPENMP="" CUDA=no CUDA_PATH="" \
 	  UMFPACK_CONFIG="$(UMFPACK_CONFIG)" \
 	  CHOLMOD_CONFIG="$(CHOLMOD_CONFIG)" \
 	  SPQR_CONFIG="$(SPQR_CONFIG)"


### PR DESCRIPTION
One of the two ways I could think of to fix #48732.  The other one is to use `-Wl,--warn-unresolved-symbols` in suitesparse only when doing the MSAN build, but I figured that this flag might be useful for other packages as well.

CC: @fxcoudert.