### PR TITLE
deps/blastrampoline: [CYGWIN] Add and apply patch file to fix source build

### DIFF
--- a/deps/blastrampoline.mk
+++ b/deps/blastrampoline.mk
@@ -9,23 +9,33 @@ $(eval $(call git-external,blastrampoline,BLASTRAMPOLINE,,,$(BUILDDIR)))
 BLASTRAMPOLINE_BUILD_OPTS := $(MAKE_COMMON) CC="$(CC) $(SANITIZE_OPTS)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)"
 BLASTRAMPOLINE_BUILD_OPTS += ARCH="$(ARCH)" OS="$(OS)"
 
-$(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/build-configured: $(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/source-extracted
+BLASTRAMPOLINE_BUILDDIR := $(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)
+
+$(BLASTRAMPOLINE_BUILDDIR)/blastrampoline-cygwin_build_fix.patch-applied: $(BLASTRAMPOLINE_BUILDDIR)/source-extracted
+	cd $(BLASTRAMPOLINE_BUILDDIR) && \
+		patch -p1 -f < $(SRCDIR)/patches/blastrampoline-cygwin_build_fix.patch
+	echo 1 > $@
+
+$(BLASTRAMPOLINE_BUILDDIR)/source-patched: $(BLASTRAMPOLINE_BUILDDIR)/blastrampoline-cygwin_build_fix.patch-applied
+	echo 1 > $@
+
+$(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/build-configured: $(BLASTRAMPOLINE_BUILDDIR)/source-patched
 	mkdir -p $(dir $@)
 	echo 1 > $@
 
 BLASTRAMPOLINE_BUILD_ROOT := $(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/src
 $(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/build-compiled: $(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/build-configured
 	cd $(dir $@)/src && $(MAKE) $(BLASTRAMPOLINE_BUILD_OPTS)
-ifeq ($(OS), WINNT)
-	# Windows doesn't like soft link, use hard link
-	cd $(BLASTRAMPOLINE_BUILD_ROOT)/build/ && \
-		cp -f --dereference --link libblastrampoline.dll libblastrampoline.dll
-endif
 	echo 1 > $@
 
 define BLASTRAMPOLINE_INSTALL
 	$(MAKE) -C $(BLASTRAMPOLINE_BUILD_ROOT) install $(BLASTRAMPOLINE_BUILD_OPTS) DESTDIR="$2"
 endef
+ifeq ($(OS), WINNT)
+# Windows doesn't like soft link, use hard link to copy file without version suffix
+BLASTRAMPOLINE_INSTALL += && cd $2$$(build_prefix)/bin && \
+$$(WIN_MAKE_HARD_LINK) libblastrampoline-*.dll libblastrampoline.dll
+endif
 $(eval $(call staged-install, \
 	blastrampoline,$(BLASTRAMPOLINE_SRC_DIR), \
 	BLASTRAMPOLINE_INSTALL,, \
@@ -38,7 +48,7 @@ clean-blastrampoline:
 		$(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/build-configured
 
 get-blastrampoline: $(BLASTRAMPOLINE_SRC_FILE)
-extract-blastrampoline: $(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/source-extracted
+extract-blastrampoline: $(BLASTRAMPOLINE_BUILDDIR)/source-extracted
 configure-blastrampoline: extract-blastrampoline
 compile-blastrampoline: $(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/build-compiled
 fastcheck-blastrampoline: check-blastrampoline

--- a/deps/patches/blastrampoline-cygwin_build_fix.patch
+++ b/deps/patches/blastrampoline-cygwin_build_fix.patch
@@ -1,0 +1,39 @@
+From 4e78372de1cda6f5dfaaa25b6cea0abf73b57eb1 Mon Sep 17 00:00:00 2001
+From: stahta01 <stahta01@users.noreply.github.com>
+Date: Tue, 28 Feb 2023 16:06:29 -0500
+Subject: Cygwin build fix (#108)
+
+* Cygwin build fix
+
+Use hard links on windows
+
+* Add use of maintarget=$(word 1,$(TARGET_LIBRARIES))
+---
+ src/Makefile | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/src/Makefile b/src/Makefile
+index 9e702df..ea3e0d3 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -1,8 +1,18 @@
+ LBT_ROOT := $(dir $(abspath $(dir $(lastword $(MAKEFILE_LIST)))))
+ include $(LBT_ROOT)/src/Make.inc
+ 
++ifeq ($(OS),WINNT)
++# On Windows only build the library with the major soversion, all other copies
++# are useless and error prone.
++TARGET_LIBRARIES = $(builddir)/$(LIB_MAJOR_VERSION)
++else
++TARGET_LIBRARIES = $(builddir)/$(LIB_MAJOR_VERSION) $(builddir)/$(LIB_FULL_VERSION) $(builddir)/libblastrampoline.$(SHLIB_EXT)
++endif
++
++maintarget=$(word 1,$(TARGET_LIBRARIES))
++
+ # Default target
+-all: $(builddir)/libblastrampoline.$(SHLIB_EXT)
++all: $(maintarget)
+ 
+ # Objects we'll build
+ MAIN_OBJS := libblastrampoline.o dl_utils.o config.o \
+-- 


### PR DESCRIPTION
Add and apply blastrampoline-cygwin_build_fix.patch
Edit BLASTRAMPOLINE_INSTALL to copy DLL without version number.

Error without patch is
```
make[2]: *** No rule to make target 'build/libblastrampoline.dll', needed by 'all'.  Stop.
make[1]: *** [/home/USERNAME/devel/julia/deps/blastrampoline.mk:18: scratch/blastrampoline-d00e6ca235bb747faae4c9f3a297016cae6959ed/build-compiled] Error 2
```

build command
```
cd ~/devel/julia && \
[[ -d "./usr-staging" ]] && rm -rf "./usr-staging" ; \
[[ -d "./usr" ]] && rm -rf "./usr" ; \
[[ -d "./deps/scratch/blastrampoline" ]] && rm -rf "./deps/scratch/blastrampoline" ; \
cd ~/devel/julia && \
echo 'XC_HOST = x86_64-w64-mingw32'  > Make.user && \
echo 'USE_BINARYBUILDER_BLASTRAMPOLINE = 0' >> Make.user && \
echo 'USE_BINARYBUILDER_LIBSUITESPARSE = 0' >> Make.user && \
make -C deps VERBOSE=1 install-csl && \
cp /usr/x86_64-w64-mingw32/sys-root/mingw/lib/libmsvcrt.a ./usr/lib/libmsvcrt.a && \
make all --jobs=1 2>&1 | tee ../julia-cygwin-master-all-build.log  && echo -ne '\007'
```