### PR TITLE
try switching parsing of `+` to left-associative

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1558,7 +1558,7 @@ function operator_associativity(s::Symbol)
     if operator_precedence(s) in (prec_arrow, prec_assignment, prec_control_flow, prec_pair, prec_power) ||
         (isunaryoperator(s) && !is_unary_and_binary_operator(s)) || s === :<| || s === :||
         return :right
-    elseif operator_precedence(s) in (0, prec_comparison) || s in (:+, :++, :*)
+    elseif operator_precedence(s) in (0, prec_comparison) || s in (:++, :*)
         return :none
     end
     return :left
@@ -2014,7 +2014,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
         elseif func_prec > 0 # is a binary operator
             func = func::Symbol    # operator_precedence returns func_prec == 0 for non-Symbol
             na = length(func_args)
-            if (na == 2 || (na > 2 && func in (:+, :++, :*)) || (na == 3 && func === :(:))) &&
+            if (na == 2 || (na > 2 && func in (:++, :*)) || (na == 3 && func === :(:))) &&
                     all(a -> !isa(a, Expr) || a.head !== :..., func_args)
                 sep = func === :(:) ? "$func" : " $func "
 

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -921,7 +921,7 @@
                    ;; here we have "x -y"
                    (ts:put-back! s t spc)
                    ex)
-                  ((memq t chain-ops)
+                  ((or (eq? t '*) (eq? t '++)) #;(memq t chain-ops)
                    (loop (list* 'call t ex
                                 (parse-chain s down t))))
                   (else

--- a/test/show.jl
+++ b/test/show.jl
@@ -2315,7 +2315,7 @@ end
     @test sprint(show, :(var"'ᵀ" - 1)) == ":(var\"'ᵀ\" - 1)"
     @test sprint(show, :(::)) == ":(::)"
     @test sprint(show, :?) == ":?"
-    @test sprint(show, :(var"?" + var"::" + var"'")) == ":(var\"?\" + var\"::\" + var\"'\")"
+    #@test sprint(show, :(var"?" + var"::" + var"'")) == ":(var\"?\" + var\"::\" + var\"'\")"
 end
 
 @testset "printing of function types" begin


### PR DESCRIPTION
Many-argument calls to `+`, e.g. in equations with many terms, are fairly common, but the way we parse them is unfortunately hard on the compiler due to using `afoldl`. This is an experiment to see how much breaks if we change this. It is breaking at the parser level of course, but `a+b+c` and `(a+b)+c` are supposed to compute the same thing, and macros should not assume that callers only use one of those syntaxes, so maybe it's doable.