### PR TITLE
[MSYS2] Fix installation of LIBSSH2 and ZLIB

### DIFF
--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -67,7 +67,7 @@ define LIBSSH2_INSTALL
 ifeq ($$(BUILD_OS),WINNT)
 	mkdir -p $2/$$(build_shlibdir) $2/$$(build_libdir)
 	cp $1/src/libssh2.$$(SHLIB_EXT) $2/$$(build_shlibdir)/libssh2.$$(SHLIB_EXT)
-	cp $1/src/liblibssh2.dll.a $2/$$(build_libdir)/
+	cp $1/src/libssh2.dll.a $2/$$(build_libdir)/
 else
 	$(call MAKE_INSTALL,$1,$2,$3)
 endif

--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -62,9 +62,19 @@ ifeq ($(OS),$(BUILD_OS))
 endif
 	echo 1 > $@
 
+define LIBSSH2_INSTALL
+
+ifeq ($$(BUILD_OS),WINNT)
+	mkdir -p $2/$$(build_shlibdir) $2/$$(build_libdir)
+	cp $1/src/libssh2.$$(SHLIB_EXT) $2/$$(build_shlibdir)/libssh2.$$(SHLIB_EXT)
+	cp $1/src/liblibssh2.dll.a $2/$$(build_libdir)/
+else
+	$(call MAKE_INSTALL,$1,$2,$3)
+endif
+endef
 $(eval $(call staged-install, \
 	libssh2,$(LIBSSH2_SRC_DIR), \
-	MAKE_INSTALL,,, \
+	LIBSSH2_INSTALL,,, \
 	$$(INSTALL_NAME_CMD)libssh2.$$(SHLIB_EXT) $$(build_shlibdir)/libssh2.$$(SHLIB_EXT)))
 
 clean-libssh2:

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -27,8 +27,12 @@ endif
 ifneq ($(VERBOSE), 0)
 CMAKE_COMMON += -DCMAKE_VERBOSE_MAKEFILE=ON
 endif
+ifeq ($(BUILD_OS),WINNT)
+CMAKE_COMMON += -DCMAKE_C_COMPILER="$$(cygpath -m $$(which $(CC_BASE)))"
+else
 # The call to which here is to work around https://cmake.org/Bug/view.php?id=14366
 CMAKE_COMMON += -DCMAKE_C_COMPILER="$$(which $(CC_BASE))"
+endif
 ifneq ($(strip $(CMAKE_CC_ARG)),)
 CMAKE_COMMON += -DCMAKE_C_COMPILER_ARG1="$(CMAKE_CC_ARG) $(SANITIZE_OPTS)"
 endif


### PR DESCRIPTION
Fix installation of LIBSSH2 and ZLIB from source. Under MSYS2 MINGW64 the DLLs were not being copied to ./usr/bin folder. 