### PR TITLE
complete function signature for `varinfo`

### DIFF
--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -21,7 +21,7 @@ include("macros.jl")
 include("clipboard.jl")
 
 """
-    varinfo(m::Module=Main, pattern::Regex=r""; all::Bool = false, imported::Bool = false, sortby::Symbol = :name, minsize::Int = 0)
+    varinfo(m::Module=Main, pattern::Regex=r""; all::Bool = false, imported::Bool = false, recursive::Bool = false, sortby::Symbol = :name, minsize::Int = 0)
 
 Return a markdown table giving information about exported global variables in a module, optionally restricted
 to those matching `pattern`.


### PR DESCRIPTION
The `varinfo` function doc says:

```julia
  varinfo(m::Module=Main, pattern::Regex=r""; all::Bool = false, imported::Bool = false, sortby::Symbol = :name, minsize::Int = 0)

  Return a markdown table giving information about exported global variables
  in a module, optionally restricted to those matching pattern.

  The memory consumption estimate is an approximate lower bound on the size of
  the internal structure of the object.

    •  all : also list non-exported objects defined in the module,
       deprecated objects, and compiler-generated objects.

    •  imported : also list objects explicitly imported from other
       modules.

    •  recursive : recursively include objects in sub-modules, observing
       the same settings in each.

    •  sortby : the column to sort results by. Options are :name
       (default), :size, and :summary.

    •  minsize : only includes objects with size at least minsize bytes.
       Defaults to 0.
```

While the keyword `recursive` was added to the parameters explained, it was not added to the function docs. This PR corrects the mistake.