### PR TITLE
Add GC.in_finalizer query

### DIFF
--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -163,6 +163,23 @@ function disable_finalizers() @inline
 end
 
 """
+    GC.in_finalizer()::Bool
+
+Returns `true` if the current task is running a finalizer, returns `false`
+otherwise. Will also return `false` within a finalizer which was inlined by the
+compiler's eager finalization optimization, or if `finalize` is called on the
+finalizer directly.
+
+The result of this function may be useful, for example, when a finalizer must
+wait on a resource to become available; instead of polling the resource in a
+`yield` loop (which is not legal to execute within a task running finalizers),
+busy polling or an `@async` continuation could be used instead.
+"""
+function in_finalizer() @inline
+    ccall(:jl_gc_is_in_finalizer, Int8, ()) > 0
+end
+
+"""
     GC.@preserve x1 x2 ... xn expr
 
 Mark the objects `x1, x2, ...` as being *in use* during the evaluation of the

--- a/src/gc.c
+++ b/src/gc.c
@@ -488,6 +488,11 @@ JL_DLLEXPORT void jl_gc_enable_finalizers(jl_task_t *ct, int on)
     }
 }
 
+JL_DLLEXPORT int8_t jl_gc_is_in_finalizer(void)
+{
+    return jl_current_task->ptls->in_finalizer;
+}
+
 static void schedule_all_finalizers(arraylist_t *flist) JL_NOTSAFEPOINT
 {
     void **items = flist->items;

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -175,6 +175,7 @@
     XX(jl_gc_get_max_memory) \
     XX(jl_gc_internal_obj_base_ptr) \
     XX(jl_gc_is_enabled) \
+    XX(jl_gc_is_in_finalizer) \
     XX(jl_gc_live_bytes) \
     XX(jl_gc_managed_malloc) \
     XX(jl_gc_managed_realloc) \

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -365,6 +365,7 @@ JL_DLLEXPORT void jl_gc_disable_finalizers_internal(void);
 JL_DLLEXPORT void jl_gc_enable_finalizers_internal(void);
 JL_DLLEXPORT void jl_gc_run_pending_finalizers(struct _jl_task_t *ct);
 extern JL_DLLEXPORT _Atomic(int) jl_gc_have_pending_finalizers;
+JL_DLLEXPORT int8_t jl_gc_is_in_finalizer(void);
 
 JL_DLLEXPORT void jl_wakeup_thread(int16_t tid);
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1386,3 +1386,18 @@ end
     @test (@allocations "a") == 0
     @test (@allocations "a" * "b") == 1
 end
+
+@testset "in_finalizer" begin
+    @test !GC.in_finalizer()
+
+    in_fin = Ref{Any}()
+    wait(@async begin
+        r = Ref(1)
+        finalizer(r) do _
+            in_fin[] = GC.in_finalizer()
+        end
+        nothing
+    end)
+    GC.gc(true); yield()
+    @test in_fin[]
+end


### PR DESCRIPTION
This will allow us to skip setting the sticky bit of a parent task that calls `@async` in a finalizer, along with also allowing resource cleanup finalizers to use a finalizer-compatible implementation only when necessary.