### PR TITLE
LinearAlgebra traited matrix operations

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -415,6 +415,30 @@ See also: `copymutable_oftype`.
 """
 copy_similar(A::AbstractArray, ::Type{T}) where {T} = copyto!(similar(A, T, size(A)), A)
 
+"""
+    AbstractStorageTrait
+
+Supertype for all matrix traits.
+The concrete subtypes shall always contain a field named `data` keeping the
+attributed object.
+"""
+abstract type AbstractStorageTrait{T} end
+"""
+    DenseStorage
+
+Concrete type for all types of matrix related traits.
+"""
+struct DenseStorage{T} <: AbstractStorageTrait{T}
+    data::T
+    DenseStorage(x::T) where T = new{T}(x)
+end
+
+"""
+    Storage(a::T) -> AbstractStorageTrait
+
+Create a trait type object related to `a`.
+"""
+Storage(a::T) where T = storage_trait(T)(a)
 
 include("adjtrans.jl")
 include("transpose.jl")
@@ -452,6 +476,18 @@ include("ldlt.jl")
 include("schur.jl")
 include("structuredbroadcast.jl")
 include("deprecated.jl")
+
+const WrapperArrayTypes{T,MT} = Union{
+    SubArray{T,N,MT} where N,
+    Adjoint{T,MT},
+    Transpose{T,MT},
+    AbstractTriangular{T,MT},
+    UpperHessenberg{T,MT},
+    Symmetric{T,MT},
+    Hermitian{T,MT},
+}
+storage_trait(::Type{<:AbstractArray}) = DenseStorage
+storage_trait(::Type{<:WrapperArrayTypes{T,MT}}) where {T,MT} = storage_trait(MT)
 
 const ⋅ = dot
 const × = cross

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1108,6 +1108,11 @@ true
 ```
 """
 function (\)(A::AbstractMatrix, B::AbstractVecOrMat)
+    Storage(A) \ B
+end
+
+function (\)(ta::DenseStorage, B::AbstractVecOrMat)
+    A = ta.data
     require_one_based_indexing(A, B)
     m, n = size(A)
     if m == n

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -137,9 +137,17 @@ julia> [1 1; 0 1] * [1 0; 1 1]
 ```
 """
 function (*)(A::AbstractMatrix, B::AbstractMatrix)
+    (*)(Storage(A), Storage(B))
+end
+
+# implementation for the general case (getindex should be fast operation)
+function (*)(ta::DenseStorage, tb::DenseStorage)
+    A = ta.data
+    B = tb.data
     TS = promote_op(matprod, eltype(A), eltype(B))
     mul!(similar(B, TS, (size(A, 1), size(B, 2))), A, B)
 end
+
 # optimization for dispatching to BLAS, e.g. *(::Matrix{Float32}, ::Matrix{Float64})
 # but avoiding the case *(::Matrix{<:BlasComplex}, ::Matrix{<:BlasReal})
 # which is better handled by reinterpreting rather than promotion


### PR DESCRIPTION
The functions `*`, `\` for `AbstractMatrix` and `[rl]mul!` and `[rl]div!` for triangular matrices are equipped with an indirection trait, which allows to call specialized implementations, also if the type of the matrices is hidden for standard dispatch due to multiple wrappers.
This is an effort to remedy the "Abstract Array Fallback Trap".

This PR does not introduce new behavior nor should it worsen runtime for the mentioned functions. But it allows other stdlibs or packages to use own implementations for selected subclasses of `AbstractMatrix` (for example `SparseArrays`).