### PR TITLE
Add note about keywords in tab completion to NEWS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -141,6 +141,7 @@ Standard library changes
   the keybinding Alt-m ([#33872]).
 * An "IPython mode" which mimics the behaviour of the prompts and storing the evaluated result in `Out` can be
   activated with `REPL.ipython_mode!()`. See the manual for how to enable this at startup ([#46474]).
+* Tab completion displays available keyword arguments ([#43536])
 
 #### SuiteSparse
 


### PR DESCRIPTION
Tiny change to add note on keywords in REPL tab completion. (see #43536).