### PR TITLE
Close code block for `div12` docstring

### DIFF
--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -141,6 +141,7 @@ julia> hi, lo = Base.div12(x, y)
 
 julia> Float64(hi) + Float64(lo)
 1.0134170444063066
+```
 """
 function div12(x::T, y::T) where {T<:AbstractFloat}
     # We lose precision if any intermediate calculation results in a subnormal.


### PR DESCRIPTION
Completes the code block for `div12` which is currently:

```
"""
```julia-repl
julia> x, y = Float32(π), 3.1f0
(3.1415927f0, 3.1f0)

julia> x / y
1.013417f0

julia> Float64(x) / Float64(y)
1.0134170444063078

julia> hi, lo = Base.div12(x, y)
(1.013417f0, 3.8867366f-8)

julia> Float64(hi) + Float64(lo)
1.0134170444063066
"""
```

Adds `"```"` at the end before `"""` to complete it.