### PR TITLE
Add GC stat: `total_time_to_safepoint`

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -20,6 +20,7 @@ struct GC_Num
     max_memory      ::Int64
     time_to_safepoint           ::Int64
     max_time_to_safepoint       ::Int64
+    total_time_to_safepoint     ::Int64
     sweep_time      ::Int64
     mark_time       ::Int64
     total_sweep_time  ::Int64

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -18,8 +18,8 @@ struct GC_Num
     full_sweep      ::Cint
     max_pause       ::Int64
     max_memory      ::Int64
-    time_to_safepoint             ::Int64
-    max_time_to_safepointp        ::Int64
+    time_to_safepoint           ::Int64
+    max_time_to_safepoint       ::Int64
     sweep_time      ::Int64
     mark_time       ::Int64
     total_sweep_time  ::Int64

--- a/src/gc.c
+++ b/src/gc.c
@@ -3132,6 +3132,7 @@ JL_DLLEXPORT void jl_gc_collect(jl_gc_collection_t collection)
     if (duration > gc_num.max_time_to_safepoint)
         gc_num.max_time_to_safepoint = duration;
     gc_num.time_to_safepoint = duration;
+    gc_num.total_time_to_safepoint += duration;
 
     gc_invoke_callbacks(jl_gc_cb_pre_gc_t,
         gc_cblist_pre_gc, (collection));

--- a/src/gc.h
+++ b/src/gc.h
@@ -76,6 +76,7 @@ typedef struct {
     uint64_t    max_memory;
     uint64_t    time_to_safepoint;
     uint64_t    max_time_to_safepoint;
+    uint64_t    total_time_to_safepoint;
     uint64_t    sweep_time;
     uint64_t    mark_time;
     uint64_t    total_sweep_time;


### PR DESCRIPTION
Adds a useful GC statistic that counts the total time spent waiting for a safepoint.

Also fixes a typo from an earlier PR that added `max_time_to_safepointp`.