### PR TITLE
bail out call inference when return type is maximized

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -220,7 +220,7 @@ add_remark!(::AbstractInterpreter, sv::Union{InferenceState, IRCode}, remark) = 
 struct InferenceLoopState
     sig
     rt
-    effects::Effects
+    effects::Effects # not used by `NativeInterpreter`, but maybe by external `AbstractInterpreter`
     function InferenceLoopState(@nospecialize(sig), @nospecialize(rt), effects::Effects)
         new(sig, rt, effects)
     end
@@ -230,7 +230,7 @@ function bail_out_toplevel_call(::AbstractInterpreter, state::InferenceLoopState
     return isa(sv, InferenceState) && sv.restrict_abstract_call_sites && !isdispatchtuple(state.sig)
 end
 function bail_out_call(::AbstractInterpreter, state::InferenceLoopState, sv::Union{InferenceState, IRCode})
-    return state.rt === Any && !is_foldable(state.effects)
+    return state.rt === Any
 end
 function bail_out_apply(::AbstractInterpreter, state::InferenceLoopState, sv::Union{InferenceState, IRCode})
     return state.rt === Any

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4695,12 +4695,13 @@ Base.@constprop :aggressive type_level_recurse2(x...) = type_level_recurse1(x...
 type_level_recurse_entry() = Val{type_level_recurse1(1)}()
 @test Base.return_types(type_level_recurse_entry, ()) |> only == Val{1}
 
-# Test that inference doesn't give up if it can potentially refine effects,
-# even if the return type is Any.
-f_no_bail_effects_any(x::Any) = x
-f_no_bail_effects_any(x::NamedTuple{(:x,), Tuple{Any}}) = getfield(x, 1)
-g_no_bail_effects_any(x::Any) = f_no_bail_effects_any(x)
-@test Core.Compiler.is_foldable_nothrow(Base.infer_effects(g_no_bail_effects_any, Tuple{Any}))
+# TODO revisit this when tweaking `bail_out_call`
+# # Test that inference doesn't give up if it can potentially refine effects,
+# # even if the return type is Any.
+# f_no_bail_effects_any(x::Any) = x
+# f_no_bail_effects_any(x::NamedTuple{(:x,), Tuple{Any}}) = getfield(x, 1)
+# g_no_bail_effects_any(x::Any) = f_no_bail_effects_any(x)
+# @test Core.Compiler.is_foldable_nothrow(Base.infer_effects(g_no_bail_effects_any, Tuple{Any}))
 
 # issue #48374
 @test (() -> Union{<:Nothing})() == Nothing


### PR DESCRIPTION
We made the condition to bail out call inference a bit more strict in #48263 by looking at the inferred effects. It turns out that it slows down package loading time as reported at #48811.

This commit simply remove the condition. In particular, the loading time of `CairoMakie` is reduced to 40s from 48s (on master).

External `AbstractInterpreter` can use the current condition by overloading `bail_out_call`.