### PR TITLE
Show typeinfo for arrays with >2 dimensions

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -462,8 +462,10 @@ function _show_nonempty(io::IO, @nospecialize(X::AbstractMatrix), prefix::String
 end
 
 
-_show_nonempty(io::IO, X::AbstractArray, prefix::String) =
+function _show_nonempty(io::IO, X::AbstractArray, prefix::String)
+    print(io, prefix)
     show_nd(io, X, (io, slice) -> _show_nonempty(io, inferencebarrier(slice), prefix, true, axes(slice)), false)
+end
 
 # a specific call path is used to show vectors (show_vector)
 _show_nonempty(::IO, ::AbstractVector, ::String) =

--- a/test/show.jl
+++ b/test/show.jl
@@ -1867,6 +1867,10 @@ end
     @test replstr((; var"#var#"=1)) == """(var"#var#" = 1,)"""
     @test replstr((; var"a"=1, b=2)) == "(a = 1, b = 2)"
     @test replstr((; a=1, b=2)) == "(a = 1, b = 2)"
+
+    # issue 48828, typeinfo missing for arrays with >2 dimensions
+    @test showstr(Float16[1.0 3.0; 2.0 4.0;;; 5.0 7.0; 6.0 8.0]) ==
+                 "Float16[1.0 3.0; 2.0 4.0;;; 5.0 7.0; 6.0 8.0]"
 end
 
 @testset "#14684: `display` should print associative types in full" begin


### PR DESCRIPTION
Fixes #48828

```julia
julia> x = Float16.(reshape(1:8, 2, 2, 2));

julia> show(x) # before
[1.0 3.0; 2.0 4.0;;; 5.0 7.0; 6.0 8.0]
julia> show(x) # after
Float16[1.0 3.0; 2.0 4.0;;; 5.0 7.0; 6.0 8.0]
```