### PR TITLE
Allow more Unicode characters from `Ps` and `Pe` categories for identifiers

### DIFF
--- a/src/flisp/julia_extensions.c
+++ b/src/flisp/julia_extensions.c
@@ -121,7 +121,11 @@ static int is_wc_cat_id_start(uint32_t wc, utf8proc_category_t cat)
             (wc >= 0x309B && wc <= 0x309C) || // katakana-hiragana sound marks
 
             // bold-digits and double-struck digits
-            (wc >= 0x1D7CE && wc <= 0x1D7E1)); // 𝟎 through 𝟗 (inclusive), 𝟘 through 𝟡 (inclusive)
+            (wc >= 0x1D7CE && wc <= 0x1D7E1) || // 𝟎 through 𝟗 (inclusive), 𝟘 through 𝟡 (inclusive)
+
+            // mathematical brackets
+            (wc >= 0x27e6 && wc <= 0x27ef) || // ⟦, ⟧, ⟨, ⟩, ⟪, ⟫, ⟬, ⟭, ⟮, ⟯
+            (wc >= 0x2983 && wc <= 0x298a)); // ⦃, ⦄, ⦅, ⦆, ⦇, ⦈, ⦉, ⦊
 }
 
 JL_DLLEXPORT int jl_id_start_char(uint32_t wc)
@@ -188,8 +192,6 @@ static int never_id_char(uint32_t wc)
 
           wc == '`' ||
 
-          // mathematical brackets
-          (wc >= 0x27e6 && wc <= 0x27ef) ||
           // angle, corner, and lenticular brackets
           (wc >= 0x3008 && wc <= 0x3011) ||
           // tortoise shell, square, and more lenticular brackets

--- a/test/show.jl
+++ b/test/show.jl
@@ -494,15 +494,18 @@ end
 @test sprint(show, Symbol("'")) == "Symbol(\"'\")"
 @test_repr "var\"'\" = 5"
 
-# isidentifier
-@test Meta.isidentifier("x")
-@test Meta.isidentifier("x1")
-@test !Meta.isidentifier("x.1")
-@test !Meta.isidentifier("1x")
-@test Meta.isidentifier(Symbol("x"))
-@test Meta.isidentifier(Symbol("x1"))
-@test !Meta.isidentifier(Symbol("x.1"))
-@test !Meta.isidentifier(Symbol("1x"))
+@testset "isidentifier" begin
+    @test Meta.isidentifier("x")
+    @test Meta.isidentifier("x1")
+    @test !Meta.isidentifier("x.1")
+    @test !Meta.isidentifier("1x")
+    @test Meta.isidentifier(Symbol("x"))
+    @test Meta.isidentifier(Symbol("x1"))
+    @test !Meta.isidentifier(Symbol("x.1"))
+    @test !Meta.isidentifier(Symbol("1x"))
+    @test Meta.isidentifier("⟦x⟧")
+    @test Meta.isidentifier("⦃x⦄")
+end
 
 # issue #32408: Printing of names which are invalid identifiers
 # Invalid identifiers which need `var` quoting:


### PR DESCRIPTION
Proposed implementation to fix #48885.