### PR TITLE
Convert String processing to DFA for improved performace

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -259,7 +259,7 @@ const _GUTF8_DFA_TABLE, _GUTF8_DFA_REVERSE_TABLE = let
         forward_dfa_table[n] = forward_class_rows[1 + byte_class[n]]
         reverse_dfa_table[n] = reverse_class_rows[1 + byte_class[n]]
     end
-    (forward_dfa_table, reverse_dfa_table)
+    (tuple(forward_dfa_table...), tuple(reverse_dfa_table...))
 end
 ##
 @inline function _gutf8_dfa_step(state::_GUTF8State, byte::UInt8)
@@ -433,7 +433,7 @@ const _UTF8_DFA_TABLE = let # let block rather than function doesn't pollute bas
         class_row[i]=row
     end
 
-    map(c->class_row[c+1],character_classes)
+    tuple(map(c->class_row[c+1],character_classes)...)
 end
 
 

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -559,7 +559,6 @@ end
 function getindex_continued(s::String, i::Int, u::UInt32)
     @inbounds b = codeunit(s,i) #It is faster to refetch b than recalculate u
     n = ncodeunits(s)
-    (i == n) && @goto ret
     shift = 24
     state = _gutf8_dfa_step(_GUTF8_DFA_ACCEPT, b)
     if (state == _GUTF8_DFA_INVALID)

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -614,14 +614,6 @@ end
 end
 
 const _STRING_LENGTH_CHUNKING_SIZE = 256
-@inline function _isascii(code_units::AbstractVector{CU}, first, last) where {CU}
-    r = zero(CU)
-    for n in first:last
-        @inbounds r |= code_units[n]
-    end
-    return 0 ≤ r < 0x80
-end
-
 function _length_nonascii_decrement(
     cu::AbstractVector{UInt8}, first::Int, last::Int, c::Int, state=_IUTF8_DFA_ACCEPT
 )
@@ -638,7 +630,6 @@ function _length_nonascii_decrement(
         if state <= _IUTF8_DFA_INVALID
             #Loop through all the one byte characters
             while true
-                #b = codeunit(s, i)
                 b = cu[i]
                 ((i += 1) <= last) || break
                 0xc0 ≤ b ≤ 0xf7 && break
@@ -649,7 +640,6 @@ function _length_nonascii_decrement(
 
         #This should get unrolled
         for n in 1:3
-            #b = codeunit(s, i)
             b = cu[i]
             state = _iutf8_dfa_step(state, b)
             c -= 1

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -680,7 +680,7 @@ function _length_continued_nonascii(
     return c
 end
 
-@inline function length_continued(s::String, first::Int, last::Int, c::Int)
+@assume_effects :terminates_locally @inline @propagate_inbounds @inline function length_continued(s::String, first::Int, last::Int, c::Int)
     cu = codeunits(s)
     chunk_size = _STRING_LENGTH_CHUNKING_SIZE
     first < last || return c

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -565,7 +565,7 @@ function getindex_continued(s::String, i::Int, u::UInt32)
         #Checks whether i is not at the beginning of a character which is an error
         # or a single invalid byte which returns
         @inbounds isvalid(s, i) && @goto ret
-        Base.string_index_err(s, i)
+        string_index_err(s, i)
     end
     for j in 1:3
         k = i + j

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -680,7 +680,7 @@ function _length_continued_nonascii(
     return c
 end
 
-@assume_effects :terminates_locally @inline @propagate_inbounds  function length_continued(s::String, first::Int, last::Int, c::Int)
+@assume_effects :foldable @inline @propagate_inbounds  function length_continued(s::String, first::Int, last::Int, c::Int)
     cu = codeunits(s)
     chunk_size = _STRING_LENGTH_CHUNKING_SIZE
     first < last || return c

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -680,7 +680,7 @@ function _length_continued_nonascii(
     return c
 end
 
-@assume_effects :terminates_locally @inline @propagate_inbounds @inline function length_continued(s::String, first::Int, last::Int, c::Int)
+@assume_effects :terminates_locally @inline @propagate_inbounds  function length_continued(s::String, first::Int, last::Int, c::Int)
     cu = codeunits(s)
     chunk_size = _STRING_LENGTH_CHUNKING_SIZE
     first < last || return c

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -551,13 +551,13 @@ end
 @propagate_inbounds function getindex(s::String, i::Int)
     b = codeunit(s, i)
     u = UInt32(b) << 24
-    #Check for ascii or end of string
-    (b >= 0x80) || return reinterpret(Char, u) #return here is faster than @got ret
-    return getindex_continued(s, i, b)
+    #Check u rather than b here because it force compiler to calculate u now
+    (u >= 0x80000000) || return reinterpret(Char, u)
+    return getindex_continued(s, i, u)
 end
 
-function getindex_continued(s::String, i::Int, b::UInt8)
-    u = UInt32(b) << 24 #Recaculating u is faster than passing is as a argument
+function getindex_continued(s::String, i::Int, u::UInt32)
+    @inbounds b = codeunit(s,i) #It is faster to refetch b than recalculate u
     n = ncodeunits(s)
     (i == n) && @goto ret
     shift = 24

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -1445,3 +1445,5 @@ if Sys.iswindows()
         @test Base.cwstring(str_3) == UInt16[0x0061, 0x0723, 0xd808, 0xdc00, 0x0000]
     end
 end
+
+@test_throws StringIndexError "α"[2]


### PR DESCRIPTION
This PR changes most of the processing of the base string case over to using a DFA State Machine that can run both forward and reverse.   This is similar to the DFA used #47880.

Also introduce the idea that Julia's base Strings use a format we call inclusive/invalid UTF-8 or IUTF-8.   IUTF-8 Is a superset of UTF-8 and encodes how Julia will split up the code units of a string.

This PR would be simplified by merging #48568 first as it borrows methods that were used in that.  Furthermore with that PR merged, there will be speedups seen in most of the important methods for string.

Performance benchmarks using [ndinsmore/StringBenchmarks](https://github.com/ndinsmore/StringBenchmarks) show performance benefits of around 20% nearly across the board with `length` showing a benefit of 20x for long ascii strings.

Update to include benchmarks
```julia
julia> judge(iutf_m,master_m)
6-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "length" => 3-element BenchmarkTools.BenchmarkGroup:
	  tags: []
	  "single nonASCII" => 4-element BenchmarkTools.BenchmarkGroup:
		  tags: []
		  "length 2:64" => TrialJudgement(+35.28% => regression)
		  "length 512:4096" => TrialJudgement(-83.65% => improvement)
		  "length 64:512" => TrialJudgement(-36.18% => improvement)
		  "length 4096:32768" => TrialJudgement(-93.53% => improvement)
	  "julia 1.9 source" => 4-element BenchmarkTools.BenchmarkGroup:
		  tags: []
		  "files" => TrialJudgement(-86.02% => improvement)
		  "lines" => TrialJudgement(-33.53% => improvement)
		  "files SubString" => TrialJudgement(-87.81% => improvement)
		  "lines SubString" => TrialJudgement(-30.25% => improvement)
	  "ASCII" => 4-element BenchmarkTools.BenchmarkGroup:
		  tags: []
		  "length 2:64" => TrialJudgement(-28.44% => improvement)
		  "length 512:4096" => TrialJudgement(-93.43% => improvement)
		  "length 64:512" => TrialJudgement(-81.89% => improvement)
		  "length 4096:32768" => TrialJudgement(-95.20% => improvement)
  "thisind" => 3-element BenchmarkTools.BenchmarkGroup:
	  tags: []
	  "ascii" => TrialJudgement(-15.60% => improvement)
	  "malformed" => TrialJudgement(-22.11% => improvement)
	  "unicode" => TrialJudgement(-18.80% => improvement)
  "iterate" => 3-element BenchmarkTools.BenchmarkGroup:
	  tags: []
	  "ascii" => TrialJudgement(+10.01% => invariant)
	  "malformed" => TrialJudgement(-1.08% => invariant)
	  "unicode" => TrialJudgement(-28.38% => improvement)
  "isascii" => 3-element BenchmarkTools.BenchmarkGroup:
	  tags: []
	  "single nonASCII" => 4-element BenchmarkTools.BenchmarkGroup:
		  tags: []
		  "length 2:64" => TrialJudgement(-12.35% => invariant)
		  "length 512:4096" => TrialJudgement(-7.44% => invariant)
		  "length 64:512" => TrialJudgement(-8.75% => invariant)
		  "length 4096:32768" => TrialJudgement(-3.00% => invariant)
	  "julia 1.9 source" => 4-element BenchmarkTools.BenchmarkGroup:
		  tags: []
		  "files" => TrialJudgement(-14.12% => invariant)
		  "lines" => TrialJudgement(-19.24% => improvement)
		  "files SubString" => TrialJudgement(-17.87% => improvement)
		  "lines SubString" => TrialJudgement(-11.89% => invariant)
	  "ASCII" => 4-element BenchmarkTools.BenchmarkGroup:
		  tags: []
		  "length 2:64" => TrialJudgement(-8.00% => invariant)
		  "length 512:4096" => TrialJudgement(-4.36% => invariant)
		  "length 64:512" => TrialJudgement(-3.78% => invariant)
		  "length 4096:32768" => TrialJudgement(-4.05% => invariant)
  "nextind" => 3-element BenchmarkTools.BenchmarkGroup:
	  tags: []
	  "ascii" => TrialJudgement(-73.16% => improvement)
	  "malformed" => TrialJudgement(-64.81% => improvement)
	  "unicode" => TrialJudgement(-14.73% => invariant)
  "getindex" => 4-element BenchmarkTools.BenchmarkGroup:
	  tags: []
	  "1-byte" => TrialJudgement(+0.37% => invariant)
	  "3-byte" => TrialJudgement(+5.05% => invariant)
	  "2-byte" => TrialJudgement(+2.89% => invariant)
	  "4-byte" => TrialJudgement(-0.21% => invariant)

```
