### PR TITLE
Implement specialized `_findin` when second arg is `AbstractSet`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -2809,14 +2809,14 @@ function indexin(a, b::AbstractArray)
     ]
 end
 
-function _findin(a::Union{AbstractArray, Tuple}, b)
+function _findin(a::Union{AbstractArray, Tuple}, b::AbstractSet)
     ind  = Vector{eltype(keys(a))}()
-    bset = Set(b)
     @inbounds for (i,ai) in pairs(a)
-        ai in bset && push!(ind, i)
+        ai in b && push!(ind, i)
     end
     ind
 end
+_findin(a::Union{AbstractArray, Tuple}, b) = _findin(a, Set(b))
 
 # If two collections are already sorted, _findin can be computed with
 # a single traversal of the two collections. This is much faster than


### PR DESCRIPTION
Prior to this PR, `_findin` converts its second argument to a `Set` before using it.  However, this overhead is unnecessary if the argument is already an `AbstractSet`.  `_findin` is in turn called by `findall`, so this change provides a fast path for `findall(in(s), ...)`, where `s` is an `AbstractSet`:

```julia
julia> s = Set([1,2,3,4])
Set{Int64} with 4 elements:
  4
  2
  3
  1

julia> findall(in(s), [1,3,5,7,5,3,1])
4-element Vector{Int64}:
 1
 2
 6
 7
```