### PR TITLE
Make `jit_total_bytes()` return a `UInt` instead of an `Int`

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -103,7 +103,7 @@ Return the total amount (in bytes) allocated by the just-in-time compiler
 for e.g. native code and data.
 """
 function jit_total_bytes()
-    return Int(ccall(:jl_jit_total_bytes, Csize_t, ()))
+    return ccall(:jl_jit_total_bytes, Csize_t, ())
 end
 
 # print elapsed time, return expression value


### PR DESCRIPTION
There is not a good reason why we should return an `Int` here instead of a `UInt`, especially since the C API returns a `size_t`.