### PR TITLE
Fix warning admonition error

### DIFF
--- a/base/env.jl
+++ b/base/env.jl
@@ -74,7 +74,7 @@ all keys to uppercase for display, iteration, and copying. Portable code should 
 ability to distinguish variables by case, and should beware that setting an ostensibly lowercase
 variable may result in an uppercase `ENV` key.)
 
-    !!! warning
+!!! warning
     Mutating the environment is not thread-safe.
 
 # Examples

--- a/base/env.jl
+++ b/base/env.jl
@@ -222,7 +222,7 @@ by zero or more `"var"=>val` arguments `kv`. `withenv` is generally used via the
 environment variable (if it is set). When `withenv` returns, the original environment has
 been restored.
 
-    !!! warning
+!!! warning
     Changing the environment is not thread-safe. For running external commands with a different
     environment from the parent process, prefer using [`addenv`](@ref) over `withenv`.
 """


### PR DESCRIPTION
The current docstring for `withenv` does not print the warning-admonition as desired:

```julia
help?> withenv
search: withenv

  withenv(f, kv::Pair...)

  Execute f in an environment that is temporarily modified (not replaced as
  in setenv) by zero or more "var"=>val arguments kv. withenv is generally
  used via the withenv(kv...) do ... end syntax. A value of nothing can be
  used to temporarily unset an environment variable (if it is set). When
  withenv returns, the original environment has been restored.

  !!! warning
  Changing the environment is not thread-safe. For running external commands with a different
  environment from the parent process, prefer using [`addenv`](@ref) over `withenv`.
```

The waring-admonition should be formatted this way for it to be printed as desired:

```julia
  !!! warning
      Changing the environment is not thread-safe. For running external commands with a different
      environment from the parent process, prefer using [`addenv`](@ref) over `withenv`.
```