### PR TITLE
add overflow checking for `abs(::Rational)`

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -272,7 +272,7 @@ signbit(x::Rational) = signbit(x.num)
 copysign(x::Rational, y::Real) = unsafe_rational(copysign(x.num, y), x.den)
 copysign(x::Rational, y::Rational) = unsafe_rational(copysign(x.num, y.num), x.den)
 
-abs(x::Rational) = Rational(abs(x.num), x.den)
+abs(x::Rational) = unsafe_rational(checked_abs(x.num), x.den)
 
 typemin(::Type{Rational{T}}) where {T<:Signed} = unsafe_rational(T, -one(T), zero(T))
 typemin(::Type{Rational{T}}) where {T<:Integer} = unsafe_rational(T, zero(T), one(T))
@@ -540,7 +540,7 @@ function hash(x::Rational{<:BitInteger64}, h::UInt)
         pow = trailing_zeros(den)
         den >>= pow
         pow = -pow
-        if den == 1 && abs(num) < 9007199254740992
+        if den == 1 && uabs(num) < UInt64(maxintfloat(Float64))
             return hash(ldexp(Float64(num),pow),h)
         end
     end

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -60,6 +60,9 @@ end
 @test hash(nextfloat(2.0^63)) == hash(UInt64(nextfloat(2.0^63)))
 @test hash(prevfloat(2.0^64)) == hash(UInt64(prevfloat(2.0^64)))
 
+# issue #48744
+@test hash(typemin(Int)//1) === hash(big(typemin(Int)//1))
+
 # issue #9264
 @test hash(1//6,zero(UInt)) == invoke(hash, Tuple{Real, UInt}, 1//6, zero(UInt))
 @test hash(1//6) == hash(big(1)//big(6))

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -265,6 +265,9 @@ end
         @test read(io2, typeof(rational2)) == rational2
     end
 end
+@testset "abs overflow for Rational" begin
+    @test_throws OverflowError abs(typemin(Int) // 1)
+end
 @testset "parse" begin
     # Non-negative Int in which parsing is expected to work
     @test parse(Rational{Int}, string(10)) == 10 // 1


### PR DESCRIPTION
Closes: #48744 

Thanks to @mikmoore for pointing out the solution clearly. I have also added a test for the new functionality and a test for the `hash` function (which has been changed) as well.

I had made the PR earlier, but had to close and delete it because of some mistakes I made on the git side of things.