### PR TITLE
tasks: Don't set parent's sticky bit when in a finalizer

### DIFF
--- a/base/condition.jl
+++ b/base/condition.jl
@@ -87,7 +87,7 @@ function _wait2(c::GenericCondition, waiter::Task, first::Bool=false)
         push!(c.waitq, waiter)
     end
     # since _wait2 is similar to schedule, we should observe the sticky bit now
-    if waiter.sticky && Threads.threadid(waiter) == 0
+    if waiter.sticky && Threads.threadid(waiter) == 0 && !GC.in_finalizer()
         # Issue #41324
         # t.sticky && tid == 0 is a task that needs to be co-scheduled with
         # the parent task. If the parent (current_task) is not sticky we must

--- a/base/task.jl
+++ b/base/task.jl
@@ -323,7 +323,7 @@ function _wait2(t::Task, waiter::Task)
             unlock(t.donenotify)
             # since _wait2 is similar to schedule, we should observe the sticky
             # bit, even if we aren't calling `schedule` due to this early-return
-            if waiter.sticky && Threads.threadid(waiter) == 0
+            if waiter.sticky && Threads.threadid(waiter) == 0 && !GC.in_finalizer()
                 # Issue #41324
                 # t.sticky && tid == 0 is a task that needs to be co-scheduled with
                 # the parent task. If the parent (current_task) is not sticky we must
@@ -771,7 +771,7 @@ function enq_work(t::Task)
     # Sticky tasks go into their thread's work queue.
     if t.sticky
         tid = Threads.threadid(t)
-        if tid == 0
+        if tid == 0 && !GC.in_finalizer()
             # The task is not yet stuck to a thread. Stick it to the current
             # thread and do the same to the parent task (the current task) so
             # that the tasks are correctly co-scheduled (issue #41324).


### PR DESCRIPTION
When spawning a child task via `@async`, we "poison" the parent by setting their `sticky` flag to `true` to ensure that parent and child are co-scheduled on the same thread. This is obviously unideal, and also is potentially incorrect when this happens within a GC finalizer (which co-opts an unsuspecting task to run itself). This PR uses the `GC.in_finalizer` query added in #48857 to ensure that this does not happen when the parent is running within a GC finalizer.