### PR TITLE
add username() function

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -904,6 +904,7 @@ export
     splitdrive,
     splitext,
     splitpath,
+    username,
 
 # filesystem operations
     cd,

--- a/base/path.jl
+++ b/base/path.jl
@@ -16,7 +16,8 @@ export
     splitdir,
     splitdrive,
     splitext,
-    splitpath
+    splitpath,
+    username
 
 if Sys.isunix()
     const path_separator    = "/"
@@ -593,4 +594,23 @@ relpath(path::AbstractString, startpath::AbstractString) =
 
 for f in (:isdirpath, :splitdir, :splitdrive, :splitext, :normpath, :abspath)
     @eval $f(path::AbstractString) = $f(String(path))
+end
+
+"""
+    username() -> String
+
+    Return the “login name” of the user.
+    This function checks the environment variables LOGNAME, USER, LNAME and USERNAME, in order, and
+    returns the value of the first one which is set to a non-empty string.
+    If none are set, the login name from the password database is returned
+"""
+
+function username()
+    for varname in ("LOGNAME", "USER", "LNAME",  "USERNAME")
+        username = get(ENV, varname, "")
+        !isempty(username) && return username
+    end
+
+    uv_passwd = Libc.getpwuid(Libc.getuid(), true)
+    return uv_passwd.username
 end

--- a/doc/src/base/file.md
+++ b/doc/src/base/file.md
@@ -64,4 +64,5 @@ Base.Filesystem.splitdir
 Base.Filesystem.splitdrive
 Base.Filesystem.splitext
 Base.Filesystem.splitpath
+Base.Filesystem.username
 ```

--- a/test/path.jl
+++ b/test/path.jl
@@ -339,3 +339,19 @@ end
     end
     @test isabspath(withenv(homedir, var => nothing))
 end
+
+@testset "username" begin
+    # Read from env variables
+    envvars = ("LOGNAME", "USER", "LNAME",  "USERNAME")
+    for varname in envvars
+        local uname = "testuser"
+        unset_envdict = Dict(k => "" for k in envvars if k != varname)
+        @test withenv(varname => uname, unset_envdict...) do
+            username()
+        end == uname
+    end
+
+    # Read using Libc
+    @test !isempty(username())
+    @test typeof(username()) == String
+end


### PR DESCRIPTION
This PR introduces a function called `username` that returns the “login name” of the user as requested in the issue https://github.com/JuliaLang/julia/issues/48302

The implementation is based on Python and Rust's implementation of similar function as mentioned in  https://github.com/JuliaLang/julia/issues/48302#issuecomment-1384113863 and https://github.com/JuliaLang/julia/issues/48302#issuecomment-1386027756