### PR TITLE
Fix and correct sentence in `Base.ccall_macro_parse`

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -565,9 +565,9 @@ end
 """
     ccall_macro_parse(expression)
 
-`ccall_macro_parse` is an implementation detail of `@ccall
+`ccall_macro_parse` is an implementation detail of `@ccall`.
 
-it takes an expression like `:(printf("%d"::Cstring, value::Cuint)::Cvoid)`
+It takes an expression like `:(printf("%d"::Cstring, value::Cuint)::Cvoid)`
 returns: a tuple of `(function_name, return_type, arg_types, args)`
 
 The above input outputs this:


### PR DESCRIPTION
The current doc for `Base.ccall_macro_parse` says:

```julia
"""
    ccall_macro_parse(expression)

`ccall_macro_parse` is an implementation detail of `@ccall

it takes an expression like `:(printf("%d"::Cstring, value::Cuint)::Cvoid)`
returns: a tuple of `(function_name, return_type, arg_types, args)`

The above input outputs this:

    (:printf, :Cvoid, [:Cstring, :Cuint], ["%d", :value])
"""
```

This PR complete the code block of `` `@ccall `` to `` `@ccall` ``, adds a period (`.`) to it to close that sentence. And then starts the next sentence with a capital letter.