### PR TITLE
Add missing ssavalue check for hoisting loads

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5284,7 +5284,7 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaidx_
         jl_cgval_t res = emit_call(ctx, ex, expr_t, is_promotable);
         // some intrinsics (e.g. typeassert) can return a wider type
         // than what's actually possible
-        if (is_promotable && res.promotion_point) {
+        if (is_promotable && res.promotion_point && res.promotion_ssa == -1) {
             res.promotion_ssa = ssaidx_0based;
         }
         res = update_julia_type(ctx, res, expr_t);

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -821,3 +821,7 @@ function F48394(a, b, i)
 end
 @test F48394(X48394(nothing,true), Y48394(nothing, missing), true)
 @test occursin("llvm.trap", get_llvm(F48394, Tuple{X48394, Y48394, Bool}))
+
+# issue 48917, hoisting load to above the parent
+f48917(x, w) = (y = (a=1, b=x); z = (; a=(a=(1, w), b=(3, y))))
+@test f48917(1,2) == (a = (a = (1, 2), b = (3, (a = 1, b = 1))),)


### PR DESCRIPTION
Should fix https://github.com/JuliaLang/julia/issues/48917 
We might want to do a PkgEval with Julia and LLVM assertions