### PR TITLE
Fix `Vararg` methods widening with unused type variable.

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -642,8 +642,7 @@ static jl_value_t *inst_varargp_in_env(jl_value_t *decl, jl_svec_t *sparams)
                 int T_has_tv = T && jl_has_typevar(T, v);
                 int N_has_tv = N && jl_has_typevar(N, v); // n.b. JL_VARARG_UNBOUND check means this should be false
                 assert(!N_has_tv || N == (jl_value_t*)v);
-                if (T_has_tv)
-                    vm = jl_type_unionall(v, T);
+                vm = T_has_tv ? jl_type_unionall(v, T) : T;
                 if (N_has_tv)
                     N = NULL;
                 vm = (jl_value_t*)jl_wrap_vararg(vm, N); // this cannot throw for these inputs

--- a/test/core.jl
+++ b/test/core.jl
@@ -7973,3 +7973,6 @@ let spec = only(methods(g47476)).specializations
     @test any(mi -> mi !== nothing && Base.isvatuple(mi.specTypes), spec)
     @test all(mi -> mi === nothing || !Base.has_free_typevars(mi.specTypes), spec)
 end
+
+f48950(::Union{c,Nothing}...) where {c,d} = 1
+@test f48950(1, 1) == 1

--- a/test/core.jl
+++ b/test/core.jl
@@ -7974,5 +7974,5 @@ let spec = only(methods(g47476)).specializations
     @test all(mi -> mi === nothing || !Base.has_free_typevars(mi.specTypes), spec)
 end
 
-f48950(::Union{c,Nothing}...) where {c,d} = 1
-@test f48950(1, 1) == 1
+f48950(::Union{Int,d}, ::Union{c,Nothing}...) where {c,d} = 1
+@test f48950(1, 1, 1) == 1


### PR DESCRIPTION
close #48950.