### PR TITLE
Do not create `sigwait()` thread when `JL_OPTIONS_HANDLE_SIGNALS_OFF` is configured

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -754,7 +754,9 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
     jl_init_uv();
     init_stdio();
     restore_fp_env();
-    restore_signals();
+    if (jl_options.handle_signals == JL_OPTIONS_HANDLE_SIGNALS_ON)
+        restore_signals();
+
     jl_init_intrinsic_properties();
 
     jl_prep_sanitizers();


### PR DESCRIPTION
We already disable part of the signal-handling machinery, but it seems that this piece was missed for an unknown reason.

This is important to disable so that, e.g. `sigwait()` can be received reliably by the main application (which may even be another copy of Julia). This issue has apparently also come up for users in the wild: https://discourse.julialang.org/t/signal-handlers-with-embedded-julia/41701

Noticed this on #48781 