### PR TITLE
Defensively copy IRCode from semi-concrete eval for inlining

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1476,7 +1476,7 @@ function semiconcrete_result_item(result::SemiConcreteResult,
         return compileable_specialization(mi, result.effects, et, info;
             compilesig_invokes=OptimizationParams(state.interp).compilesig_invokes)
     else
-        return InliningTodo(mi, result.ir, result.effects)
+        return InliningTodo(mi, retrieve_ir_for_inlining(mi, result.ir), result.effects)
     end
 end
 


### PR DESCRIPTION
Currently, semi-concrete eval results are one-to-one associated with a particular callsite, so in theory we can destroy them during inlining and nothing bad will happen. However, since we propagate them using the `:info` field, this breaks the assumption that we can copy IRCode around and re-run the compiler on it without ill effect. In general, the `:info` field is assumed generally immutable and mutating the IR containted therein breaks all sorts of assumptions. Perhaps in the future, we can avoid destroying the IRCode that we're about to inline, which would make all this copying unnecessary (note that we're already copying for every case other than semi-concrete eval), but for now just fix the robustness issue here.