### PR TITLE
Revert "pkgimage: use faster flags to jl_matching_methods (#48841)"

### DIFF
--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -520,7 +520,7 @@ static void jl_collect_edges(jl_array_t *edges, jl_array_t *ext_targets, jl_arra
                         sig = callee;
                     int ambig = 0;
                     matches = jl_matching_methods((jl_tupletype_t*)sig, jl_nothing,
-                            INT32_MAX, 0, world, &min_valid, &max_valid, &ambig);
+                            -1, 0, world, &min_valid, &max_valid, &ambig);
                     if (matches == jl_nothing) {
                         callee_ids = NULL; // invalid
                         break;
@@ -870,7 +870,7 @@ static jl_array_t *jl_verify_edges(jl_array_t *targets, size_t minworld)
             int ambig = 0;
             // TODO: possibly need to included ambiguities too (for the optimizer correctness)?
             matches = jl_matching_methods((jl_tupletype_t*)sig, jl_nothing,
-                    jl_array_len(expected), 0, minworld, &min_valid, &max_valid, &ambig);
+                    -1, 0, minworld, &min_valid, &max_valid, &ambig);
             if (matches == jl_nothing) {
                 max_valid = 0;
             }

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -936,7 +936,7 @@ precompile_test_harness("code caching") do dir
     j = findfirst(==(tagbad), invalidations)
     @test invalidations[j-1] == "insert_backedges_callee"
     @test isa(invalidations[j-2], Type)
-    @test invalidations[j+1] === nothing || isa(invalidations[j+1], Vector{Any}) # [nbits(::UInt8)]
+    @test isa(invalidations[j+1], Vector{Any}) # [nbits(::UInt8)]
 
     m = only(methods(MB.map_nbits))
     @test !hasvalid(m.specializations[1], world+1) # insert_backedges invalidations also trigger their backedges


### PR DESCRIPTION
This reverts commit eb36cb9e7d01e230dfe0371a77476d4867c0e615.