### PR TITLE
Ensure accurate invalidation logging data

### DIFF
--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -871,7 +871,8 @@ static jl_array_t *jl_verify_edges(jl_array_t *targets, size_t minworld)
             // TODO: possibly need to included ambiguities too (for the optimizer correctness)?
             // len + 1 is to allow us to log causes of invalidation (SnoopCompile's @snoopr)
             matches = jl_matching_methods((jl_tupletype_t*)sig, jl_nothing,
-                    INT32_MAX, 0, minworld, &min_valid, &max_valid, &ambig);
+                    _jl_debug_method_invalidation ? INT32_MAX : jl_array_len(expected),
+                    0, minworld, &min_valid, &max_valid, &ambig);
             if (matches == jl_nothing) {
                 max_valid = 0;
             }

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -869,8 +869,9 @@ static jl_array_t *jl_verify_edges(jl_array_t *targets, size_t minworld)
             assert(jl_is_array(expected));
             int ambig = 0;
             // TODO: possibly need to included ambiguities too (for the optimizer correctness)?
+            // len + 1 is to allow us to log causes of invalidation (SnoopCompile's @snoopr)
             matches = jl_matching_methods((jl_tupletype_t*)sig, jl_nothing,
-                    jl_array_len(expected), 0, minworld, &min_valid, &max_valid, &ambig);
+                    jl_array_len(expected) + 1, 0, minworld, &min_valid, &max_valid, &ambig);
             if (matches == jl_nothing) {
                 max_valid = 0;
             }

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -871,7 +871,7 @@ static jl_array_t *jl_verify_edges(jl_array_t *targets, size_t minworld)
             // TODO: possibly need to included ambiguities too (for the optimizer correctness)?
             // len + 1 is to allow us to log causes of invalidation (SnoopCompile's @snoopr)
             matches = jl_matching_methods((jl_tupletype_t*)sig, jl_nothing,
-                    jl_array_len(expected) + 1, 0, minworld, &min_valid, &max_valid, &ambig);
+                    INT32_MAX, 0, minworld, &min_valid, &max_valid, &ambig);
             if (matches == jl_nothing) {
                 max_valid = 0;
             }

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -915,7 +915,7 @@ precompile_test_harness("code caching") do dir
     mi = m.specializations[1]
     @test hasvalid(mi, world)       # was compiled with the new method
 
-    # Reporting test
+    # Reporting test (ensure SnoopCompile works)
     @test all(i -> isassigned(invalidations, i), eachindex(invalidations))
     m = only(methods(MB.call_nbits))
     for mi in m.specializations
@@ -936,7 +936,7 @@ precompile_test_harness("code caching") do dir
     j = findfirst(==(tagbad), invalidations)
     @test invalidations[j-1] == "insert_backedges_callee"
     @test isa(invalidations[j-2], Type)
-    @test invalidations[j+1] === nothing || isa(invalidations[j+1], Vector{Any}) # [nbits(::UInt8)]
+    @test isa(invalidations[j+1], Vector{Any}) # [nbits(::UInt8)]
 
     m = only(methods(MB.map_nbits))
     @test !hasvalid(m.specializations[1], world+1) # insert_backedges invalidations also trigger their backedges


### PR DESCRIPTION
This modifies #48841 to restore the required logging data.  When logging is on, it recalculates the method-match as needed, casting a wider net to ensure that we identify the trigger of the invalidation.

Closes #48980
Fixes #48967