### PR TITLE
Enable the AVR backend of LLVM

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -64,7 +64,7 @@ endif
 LLVM_LIB_FILE := libLLVMCodeGen.a
 
 # Figure out which targets to build
-LLVM_TARGETS := host;NVPTX;AMDGPU;WebAssembly;BPF
+LLVM_TARGETS := host;NVPTX;AMDGPU;WebAssembly;BPF;AVR
 LLVM_EXPERIMENTAL_TARGETS :=
 
 LLVM_CFLAGS :=


### PR DESCRIPTION
This PR enables the AVR backend of LLVM. @vchuravy mentioned on Slack I should open this, to make it easier for others debugging AVRCompiler/GPUCompiler related issues so they don't have to build LLVM locally. The backend itself is not that large (1.5MB), a bit smaller than BPF (1.8MB):

```
[sukera@tower lib]$ du -shc libLLVMBPF*
60K	libLLVMBPFAsmParser.a
1.6M	libLLVMBPFCodeGen.a
156K	libLLVMBPFDesc.a
20K	libLLVMBPFDisassembler.a
12K	libLLVMBPFInfo.a
1.8M	total
[sukera@tower lib]$ du -shc libLLVMAVR*
76K	libLLVMAVRAsmParser.a
1.1M	libLLVMAVRCodeGen.a
316K	libLLVMAVRDesc.a
20K	libLLVMAVRDisassembler.a
8.0K	libLLVMAVRInfo.a
1.5M	total
```

This does NOT mean that julia itself builds with AVR or is supported to run in any support tier other than "there is no support".