### PR TITLE
Add *(::Diagonal, ::Diagonal, ::Diagonal) (#49005)

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -385,6 +385,12 @@ function (*)(Da::Diagonal, A::AbstractMatrix, Db::Diagonal)
     return broadcast(*, Da.diag, A, permutedims(Db.diag))
 end
 
+function (*)(Da::Diagonal, Db::Diagonal, Dc::Diagonal)
+    _muldiag_size_check(Da, Db)
+    _muldiag_size_check(Db, Dc)
+    return Diagonal(Da.diag .* Db.diag .* Dc.diag)
+end
+
 # Get ambiguous method if try to unify AbstractVector/AbstractMatrix here using AbstractVecOrMat
 @inline mul!(out::AbstractVector, D::Diagonal, V::AbstractVector, alpha::Number, beta::Number) =
     _muldiag!(out, D, V, alpha, beta)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -1158,9 +1158,9 @@ end
 @testset "diagonal triple multiplication (#49005)" begin
     n = 10
     @test *(Diagonal(ones(n)), Diagonal(1:n), Diagonal(ones(n))) isa Diagonal
-    @test_throws DimensionMismatch *(Diagonal(ones(n)), Diagonal(1:n), Diagonal(ones(n+1)))
-    @test_throws DimensionMismatch *(Diagonal(ones(n)), Diagonal(1:n+1), Diagonal(ones(n+1)))
-    @test_throws DimensionMismatch *(Diagonal(ones(n+1)), Diagonal(1:n), Diagonal(ones(n)))
+    @test_throws DimensionMismatch (*(Diagonal(ones(n)), Diagonal(1:n), Diagonal(ones(n+1))))
+    @test_throws DimensionMismatch (*(Diagonal(ones(n)), Diagonal(1:n+1), Diagonal(ones(n+1))))
+    @test_throws DimensionMismatch (*(Diagonal(ones(n+1)), Diagonal(1:n), Diagonal(ones(n))))
 
     # currently falls back to two-term *
     @test *(Diagonal(ones(n)), Diagonal(1:n), Diagonal(ones(n)), Diagonal(1:n)) isa Diagonal

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -1156,7 +1156,7 @@ end
 end
                                                         
 @testset "diagonal triple multiplication (#49005)" begin
-    n = 10;
+    n = 10
     @test *(Diagonal(ones(n)), Diagonal(1:n), Diagonal(ones(n))) isa Diagonal
     @test_throws DimensionMismatch *(Diagonal(ones(n)), Diagonal(1:n), Diagonal(ones(n+1)))
     @test_throws DimensionMismatch *(Diagonal(ones(n)), Diagonal(1:n+1), Diagonal(ones(n+1)))

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -1154,7 +1154,7 @@ end
     copyto!(D, I)
     @test all(isone, diag(D))
 end
-                                                        
+
 @testset "diagonal triple multiplication (#49005)" begin
     n = 10
     @test *(Diagonal(ones(n)), Diagonal(1:n), Diagonal(ones(n))) isa Diagonal

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -1154,5 +1154,13 @@ end
     copyto!(D, I)
     @test all(isone, diag(D))
 end
+                                                        
+@testset "diagonal triple multiplication (#49005)" begin
+    n = 10;
+    @test *(Diagonal(ones(n)), Diagonal(1:n), Diagonal(ones(n))) isa Diagonal
+    @test_throws DimensionMismatch *(Diagonal(ones(n)), Diagonal(1:n), Diagonal(ones(n+1)))
+    @test_throws DimensionMismatch *(Diagonal(ones(n)), Diagonal(1:n+1), Diagonal(ones(n+1)))
+    @test_throws DimensionMismatch *(Diagonal(ones(n+1)), Diagonal(1:n), Diagonal(ones(n)))
+end
 
 end # module TestDiagonal

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -1161,6 +1161,9 @@ end
     @test_throws DimensionMismatch *(Diagonal(ones(n)), Diagonal(1:n), Diagonal(ones(n+1)))
     @test_throws DimensionMismatch *(Diagonal(ones(n)), Diagonal(1:n+1), Diagonal(ones(n+1)))
     @test_throws DimensionMismatch *(Diagonal(ones(n+1)), Diagonal(1:n), Diagonal(ones(n)))
+
+    # currently falls back to two-term *
+    @test *(Diagonal(ones(n)), Diagonal(1:n), Diagonal(ones(n)), Diagonal(1:n)) isa Diagonal
 end
 
 end # module TestDiagonal


### PR DESCRIPTION
This adds a special case for triple multiplication of diagonals to ensure that the result is a `Diagonal`, see https://github.com/JuliaLang/LinearAlgebra.jl/issues/992.