### PR TITLE
[CYGWIN] [BUILD] [INSTALL] Fix make install error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,9 +350,9 @@ else ifeq ($(JULIA_BUILD_MODE),debug)
 endif
 
 	# Cache stdlibs
-	@$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --startup-file=no $(JULIAHOME)/contrib/cache_stdlibs.jl)
+	@$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --startup-file=no $(call cygpath_w,$(JULIAHOME)/contrib/cache_stdlibs.jl))
 	# CI uses `--check-bounds=yes` which impacts the cache flags
-	@$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --startup-file=no --check-bounds=yes $(JULIAHOME)/contrib/cache_stdlibs.jl)
+	@$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --startup-file=no --check-bounds=yes $(call cygpath_w,$(JULIAHOME)/contrib/cache_stdlibs.jl))
 
 	# Copy in all .jl sources as well
 	mkdir -p $(DESTDIR)$(datarootdir)/julia/base $(DESTDIR)$(datarootdir)/julia/test


### PR DESCRIPTION
See also #48658 

Version 1.10.0-DEV.805 (2023-03-14)
Commit 7ba7e32629* (0 days old master)

$ uname -srvmo
CYGWIN_NT-10.0-19045 3.4.6-1.x86_64 2023-02-14 13:23 UTC x86_64 Cygwin

cd ~/devel/julia && make install VERBOSE=1 --jobs=1

The problem without the patch; and, below this error are a couple of doc install related warnings that might be of concern.
Edit: This commit only fixes the error; the doc install warning are not fixed.
'''
\# Copy system image
/home/USERNAME/devel/julia/contrib/install.sh 755 /home/USERNAME/devel/julia/usr/lib/julia/sys.dll /home/USERNAME/devel/julia/julia-7ba7e32629/lib/julia
\# Cache stdlibs
 /home/USERNAME/devel/julia/usr/bin/julia.exe --startup-file=no /home/USERNAME/devel/julia/contrib/cache_stdlibs.jl
ERROR: SystemError: opening file "\\home\\USERNAME\\devel\\julia\\contrib\\cache_stdlibs.jl": No such file or directory
Stacktrace:
  [1] systemerror(p::String, errno::Int32; extrainfo::Nothing)
    @ Base .\error.jl:176
  [2] #systemerror#83
    @ .\error.jl:175 [inlined]
  [3] systemerror
    @ .\error.jl:175 [inlined]
  [4] open(fname::String; lock::Bool, read::Nothing, write::Nothing, create::Nothing, truncate::Nothing, append::Nothing)
    @ Base .\iostream.jl:293
  [5] open
    @ .\iostream.jl:275 [inlined]
  [6] open(f::Base.var"#419#420"{String}, args::String; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ Base .\io.jl:393
  [7] open
    @ .\io.jl:392 [inlined]
  [8] read
    @ .\io.jl:473 [inlined]
  [9] _include(mapexpr::Function, mod::Module, _path::String)
    @ Base .\loading.jl:1945
 [10] include(mod::Module, _path::String)
    @ Base .\Base.jl:468
 [11] exec_options(opts::Base.JLOptions)
    @ Base .\client.jl:307
 [12] _start()
    @ Base .\client.jl:541
make: *** [Makefile:281: install] Error 1
'''

Re-occurring HTML documentation message
'''
Building HTML documentation.
/home/USERNAME/devel/julia/usr/bin/julia.exe --startup-file=no --color=yes `cygpath -w /home/USERNAME/devel/julia/doc/make.jl` linkcheck= doctest= buildroot=`cygpath -w /home/USERNAME/devel/julia` texplatform= revise=
┌ Warning: The active manifest file has dependencies that were resolved with a different julia version (1.9.0-DEV). Unexpected behavior may occur.
└ @ H:\cygwin64\home\USERNAME\devel\julia\doc\Manifest.toml:0
'''

Another HTML documentation message during make install; many more like it on first make
'''
@ Documenter.Writers.HTMLWriter H:\cygwin64\home\USERNAME\devel\julia\doc\deps\packages\Documenter\yf96B\src\Writers\HTMLWriter.jl:2081
┌ Warning: invalid local link: unresolved path in base\numbers.md
│   link.text =
│    1-element Vector{Any}:
│     Markdown.Code("", "Inf")
│   link.url = "numbers.html#Base.Inf"
└
'''