### PR TITLE
Add test for #48961

### DIFF
--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2458,3 +2458,6 @@ let S = Tuple{Type{S48695{T, 2, T48695{B, 2, C}}} where {T<:(Union{Missing, A} w
     @test allunique(vars_in_unionall(V))
     @test typeintersect(V, T) != Union{}
 end
+
+#issue 48961
+@test !<:(Type{Union{Missing, Int}}, Type{Union{Missing, Nothing, Int}})


### PR DESCRIPTION
This was caused by the shared `Lunion` between fast path and normal path.
#48441 has fixed it by making sure `forall_exists_equal` never changes global `Lunion`.
close #48961.