### PR TITLE
`LinearAlgebra.norm(x::Union{Transpose, Adjoint})` should default to `norm(parent(x))`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,8 @@ Standard library changes
   `Factorization` ([#46874]).
 * New functions `hermitianpart` and `hermitianpart!` for extracting the Hermitian
   (real symmetric) part of a matrix ([#31836]).
+* The `norm` of the adjoint or transpose of an `AbstractMatrix` now returns the norm of the
+  parent matrix by default, matching the current behaviour for `AbstractVector`s ([#49020]).
 
 #### Printf
 * Format specifiers now support dynamic width and precision, e.g. `%*s` and `%*.*g` ([#40105]).

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -805,7 +805,7 @@ opnorm(v::AdjointAbsVec, q::Real) = q == Inf ? norm(conj(v.parent), 1) : norm(co
 opnorm(v::AdjointAbsVec) = norm(conj(v.parent))
 opnorm(v::TransposeAbsVec) = norm(v.parent)
 
-norm(v::Union{AdjOrTransAbsVec,AdjOrTransAbsMat}, p::Real) = norm(v.parent, p)
+norm(v::AdjOrTrans, p::Real) = norm(v.parent, p)
 
 """
     dot(x, y)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -805,7 +805,7 @@ opnorm(v::AdjointAbsVec, q::Real) = q == Inf ? norm(conj(v.parent), 1) : norm(co
 opnorm(v::AdjointAbsVec) = norm(conj(v.parent))
 opnorm(v::TransposeAbsVec) = norm(v.parent)
 
-norm(v::Union{TransposeAbsVec,AdjointAbsVec}, p::Real) = norm(v.parent, p)
+norm(v::Union{AdjOrTransAbsVec,AdjOrTransAbsMat}, p::Real) = norm(v.parent, p)
 
 """
     dot(x, y)

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -275,14 +275,14 @@ end
         for sz in ((2,), (2, 3))
             A = rand(elt, sz...)
             Aᵀ = t(A)
-            @test norm(Aᵀ) == norm(Matrix(Aᵀ))
+            @test norm(Aᵀ) ≈ norm(Matrix(Aᵀ))
         end
 
         # Vector/matrix of vectors/matrices
         for sz_outer in ((2,), (2, 3)), sz_inner in ((3,), (1, 2))
             A = [rand(elt, sz_inner...) for _ in CartesianIndices(sz_outer)]
             Aᵀ = t(A)
-            @test norm(Aᵀ) == norm(Matrix(Matrix.(Aᵀ)))
+            @test norm(Aᵀ) ≈ norm(Matrix(Matrix.(Aᵀ)))
         end
     end
 end

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -269,6 +269,22 @@ end
     @test norm(x, 3) ≈ cbrt(5^3  +sqrt(5)^3)
 end
 
+@testset "norm of transpose/adjoint equals norm of parent #32739" begin
+    for t in (transpose, adjoint), elt in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFloat})
+        # Vector/matrix of scalars
+        for sz in ((2,), (2, 3))
+            A = rand(elt, sz...)
+            @test norm(t(A)) ≈ norm(A) # `isapprox` because summation order can cause floating point differences
+        end
+
+        # Vector/matrix of vectors/matrices
+        for sz_outer in ((2,), (2, 3)), sz_inner in ((3,), (1, 2))
+            A = [rand(elt, sz_inner...) for _ in CartesianIndices(sz_outer)]
+            @test norm(t(A)) ≈ norm(A)
+        end
+    end
+end
+
 @testset "rotate! and reflect!" begin
     x = rand(ComplexF64, 10)
     y = rand(ComplexF64, 10)

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -274,13 +274,15 @@ end
         # Vector/matrix of scalars
         for sz in ((2,), (2, 3))
             A = rand(elt, sz...)
-            @test norm(t(A)) ≈ norm(A) # `isapprox` because summation order can cause floating point differences
+            Aᵀ = t(A)
+            @test norm(Aᵀ) == norm(Matrix(Aᵀ))
         end
 
         # Vector/matrix of vectors/matrices
         for sz_outer in ((2,), (2, 3)), sz_inner in ((3,), (1, 2))
             A = [rand(elt, sz_inner...) for _ in CartesianIndices(sz_outer)]
-            @test norm(t(A)) ≈ norm(A)
+            Aᵀ = t(A)
+            @test norm(Aᵀ) == norm(Matrix(Matrix.(Aᵀ)))
         end
     end
 end


### PR DESCRIPTION
Currently, if `x` is the `adjoint` or `transpose` of an `AbstractVector`, then `norm(x)` will default to `norm(parent(x))`.  This PR extends this behaviour to include `AbstractMatrix`s, as well.

I don't think this should be consider breaking. It is true by the definition of `norm` - which is invariant to permutation and/or conjugation of the underlying array elements - that `norm(x) == norm(parent(x))` should hold.

For reference, I ran into this issue in the wild. When `x` is an `adjoint` of a `CuMatrix`, [`norm(x)` falls back to the generic implementation and throws an error](https://github.com/JuliaGPU/CUDA.jl/issues/1782). While this could easily be patched in `CUDA.jl`, I think it is more correct and convenient to have this fallback in `Base`. Currently, it is not possible to fix this in one's own code without type piracy.