### PR TITLE
irinterp: make sure to use `optimizer_lattice` when performing irinterp

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -979,8 +979,9 @@ function abstract_call_method_with_const_args(interp::AbstractInterpreter,
         if code !== nothing
             ir = codeinst_to_ir(interp, code)
             if isa(ir, IRCode)
-                irsv = IRInterpretationState(interp, ir, mi, sv.world, arginfo.argtypes)
-                rt, nothrow = ir_abstract_constant_propagation(interp, irsv)
+                irinterp = switch_to_irinterp(interp)
+                irsv = IRInterpretationState(irinterp, ir, mi, sv.world, arginfo.argtypes)
+                rt, nothrow = ir_abstract_constant_propagation(irinterp, irsv)
                 @assert !(rt isa Conditional || rt isa MustAlias) "invalid lattice element returned from IR interpretation"
                 if !isa(rt, Type) || typeintersect(rt, Bool) === Union{}
                     new_effects = Effects(result.effects; nothrow=nothrow)


### PR DESCRIPTION
While the base abstract interpretation routine uses `typeinf_lattice`, irinterp only needs `optimizer_lattice`. Therefore, there are unnecessary computations involved in handling `Conditional` in irinterp. This commit adds `irinterp::Bool` field to `NativeInterpreter`, indicating if a native interpreter is performing irinterp. This allows it to switch its lattice to `optimizer_lattice` during irinterp.

@nanosoldier `runbenchmarks("inference", vs=":master")`