### PR TITLE
opaque_closure: Properly set world for OC from inferred CodeInfo

### DIFF
--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -64,7 +64,7 @@ static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t 
     JL_GC_PROMISE_ROOTED(oc_type);
 
     jl_method_instance_t *mi = jl_specializations_get_linfo(source, sigtype, jl_emptysvec);
-    size_t world = jl_atomic_load_acquire(&jl_world_counter);
+    size_t world = jl_current_task->world_age;
     jl_code_instance_t *ci = NULL;
     if (do_compile)
         ci = jl_compile_method_internal(mi, world);
@@ -127,12 +127,14 @@ JL_DLLEXPORT jl_opaque_closure_t *jl_new_opaque_closure_from_code_info(jl_tuplet
     JL_GC_PUSH3(&root, &sigtype, &inst);
     root = jl_box_long(lineno);
     root = jl_new_struct(jl_linenumbernode_type, root, file);
-    root = (jl_value_t*)jl_make_opaque_closure_method(mod, jl_nothing, nargs, root, ci, isva);
+    jl_method_t *meth = jl_make_opaque_closure_method(mod, jl_nothing, nargs, root, ci, isva);
+    root = (jl_value_t*)meth;
+    meth->primary_world = jl_current_task->world_age;
 
     sigtype = prepend_type(jl_typeof(env), argt);
     jl_method_instance_t *mi = jl_specializations_get_linfo((jl_method_t*)root, sigtype, jl_emptysvec);
     inst = jl_new_codeinst(mi, rt_ub, NULL, (jl_value_t*)ci,
-        0, ((jl_method_t*)root)->primary_world, -1, 0, 0, jl_nothing, 0);
+        0, meth->primary_world, -1, 0, 0, jl_nothing, 0);
     jl_mi_cache_insert(mi, inst);
 
     jl_opaque_closure_t *oc = new_opaque_closure(argt, rt_lb, rt_ub, root, env, do_compile);


### PR DESCRIPTION
For OpaqueClosures constructed from inferred code, there is only one valid age. We were incorrectly setting the primary world age of the method to `1`, rather than the construction world age of the opaque closure, causing codegen to fail to emit direct calls for :invoke'd statements.