### PR TITLE
compiler: fix performance issue introduced in #48962

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1349,7 +1349,9 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
     elseif isa(stmt, PhiNode)
         if cfg_transforms_enabled
             # Rename phi node edges
-            map!(i -> bb_rename_pred[i], stmt.edges, stmt.edges)
+            let bb_rename_pred=bb_rename_pred
+                map!(i::Int32 -> bb_rename_pred[i], stmt.edges, stmt.edges)
+            end
 
             # Remove edges and values associated with dead blocks. Entries in
             # `values` can be undefined when the phi node refers to something


### PR DESCRIPTION
`bb_rename_pred` was captured, so this commit fixes it up. FWIW, `JET.report_opt(CC.batch_inline!,
  (CC.IRCode,Vector{Pair{Int,Any}},Bool,CC.OptimizationParams))`
successfully detected it.

@nanosoldier `runbenchmarks("inference", vs="@ad304ea490a50c7a38a36ea01db8f8b7c00aeb8d")`
