### PR TITLE
Prefer blocked LAPACK routines for generalized eigenvalue problems

### DIFF
--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -797,6 +797,7 @@ LinearAlgebra.LAPACK.ggsvd!
 LinearAlgebra.LAPACK.ggsvd3!
 LinearAlgebra.LAPACK.geevx!
 LinearAlgebra.LAPACK.ggev!
+LinearAlgebra.LAPACK.ggev3!
 LinearAlgebra.LAPACK.gtsv!
 LinearAlgebra.LAPACK.gttrf!
 LinearAlgebra.LAPACK.gttrs!
@@ -845,6 +846,7 @@ LinearAlgebra.LAPACK.gehrd!
 LinearAlgebra.LAPACK.orghr!
 LinearAlgebra.LAPACK.gees!
 LinearAlgebra.LAPACK.gges!
+LinearAlgebra.LAPACK.gges3!
 LinearAlgebra.LAPACK.trexc!
 LinearAlgebra.LAPACK.trsen!
 LinearAlgebra.LAPACK.tgsen!

--- a/stdlib/LinearAlgebra/src/schur.jl
+++ b/stdlib/LinearAlgebra/src/schur.jl
@@ -345,8 +345,13 @@ Base.iterate(S::GeneralizedSchur, ::Val{:done}) = nothing
 
 Same as [`schur`](@ref) but uses the input matrices `A` and `B` as workspace.
 """
-schur!(A::StridedMatrix{T}, B::StridedMatrix{T}) where {T<:BlasFloat} =
-    GeneralizedSchur(LinearAlgebra.LAPACK.gges!('V', 'V', A, B)...)
+function schur!(A::StridedMatrix{T}, B::StridedMatrix{T}) where {T<:BlasFloat}
+    if LAPACK.version() < v"3.6.0"
+        GeneralizedSchur(LinearAlgebra.LAPACK.gges!('V', 'V', A, B)...)
+    else
+        GeneralizedSchur(LinearAlgebra.LAPACK.gges3!('V', 'V', A, B)...)
+    end
+end
 
 """
     schur(A, B) -> F::GeneralizedSchur

--- a/stdlib/LinearAlgebra/test/lapack.jl
+++ b/stdlib/LinearAlgebra/test/lapack.jl
@@ -180,7 +180,7 @@ end
     end
 end
 
-@testset "geevx, ggev errors" begin
+@testset "geevx, ggev, ggev3 errors" begin
     @testset for elty in (Float32, Float64, ComplexF32, ComplexF64)
         A = rand(elty,10,10)
         B = rand(elty,10,10)
@@ -191,6 +191,9 @@ end
         @test_throws ArgumentError LAPACK.ggev!('N','B',A,B)
         @test_throws ArgumentError LAPACK.ggev!('B','N',A,B)
         @test_throws DimensionMismatch LAPACK.ggev!('N','N',A,zeros(elty,12,12))
+        @test_throws ArgumentError LAPACK.ggev3!('N','B',A,B)
+        @test_throws ArgumentError LAPACK.ggev3!('B','N',A,B)
+        @test_throws DimensionMismatch LAPACK.ggev3!('N','N',A,zeros(elty,12,12))
     end
 end
 
@@ -590,11 +593,12 @@ end
     end
 end
 
-@testset "gees, gges error throwing" begin
+@testset "gees, gges, gges3 error throwing" begin
     @testset for elty in (Float32, Float64, ComplexF32, ComplexF64)
         A = rand(elty,10,10)
         B = rand(elty,11,11)
         @test_throws DimensionMismatch LAPACK.gges!('V','V',A,B)
+        @test_throws DimensionMismatch LAPACK.gges3!('V','V',A,B)
     end
 end
 


### PR DESCRIPTION
`xGGEV` and `xGGES` have variants `xGGEV3` and `xGGES3` using blocked algorithms, which are generally much faster and more accurate. Especially in more recent releases of LAPACK these routines have received quite a bit of love (see e.g. Reference-LAPACK/lapack/pull/421).

This pull request adds bindings to these subroutines and updates the `schur!`, `eigen!` and `eigvals!` functions to prefer these blocked versions.