### PR TITLE
Set various array and Random effects

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -362,7 +362,10 @@ See also [`copy!`](@ref Base.copy!), [`copyto!`](@ref), [`deepcopy`](@ref).
 """
 copy
 
-copy(a::T) where {T<:Array} = ccall(:jl_array_copy, Ref{T}, (Any,), a)
+function copy(a::T) where {T<:Array}
+    @assume_effects :nothrow :effect_free :terminates_globally
+    ccall(:jl_array_copy, Ref{T}, (Any,), a)
+end
 
 ## Constructors ##
 
@@ -422,6 +425,7 @@ end
 getindex(::Type{Any}) = Vector{Any}()
 
 function fill!(a::Union{Array{UInt8}, Array{Int8}}, x::Integer)
+    @assume_effects :consistent :nothrow :terminates_globally
     ccall(:memset, Ptr{Cvoid}, (Ptr{Cvoid}, Cint, Csize_t), a, convert(eltype(a), x), length(a))
     return a
 end
@@ -1009,21 +1013,33 @@ end
 
 # efficiently grow an array
 
-_growbeg!(a::Vector, delta::Integer) =
+function _growbeg!(a::Vector, delta::Integer)
+    @assume_effects :terminates_globally
     ccall(:jl_array_grow_beg, Cvoid, (Any, UInt), a, delta)
-_growend!(a::Vector, delta::Integer) =
+end
+function _growend!(a::Vector, delta::Integer)
+    @assume_effects :terminates_globally
     ccall(:jl_array_grow_end, Cvoid, (Any, UInt), a, delta)
-_growat!(a::Vector, i::Integer, delta::Integer) =
+end
+function _growat!(a::Vector, i::Integer, delta::Integer)
+    @assume_effects :terminates_globally
     ccall(:jl_array_grow_at, Cvoid, (Any, Int, UInt), a, i - 1, delta)
+end
 
 # efficiently delete part of an array
 
-_deletebeg!(a::Vector, delta::Integer) =
+function _deletebeg!(a::Vector, delta::Integer)
+    @assume_effects :terminates_globally
     ccall(:jl_array_del_beg, Cvoid, (Any, UInt), a, delta)
-_deleteend!(a::Vector, delta::Integer) =
+end
+function _deleteend!(a::Vector, delta::Integer)
+    @assume_effects :terminates_globally
     ccall(:jl_array_del_end, Cvoid, (Any, UInt), a, delta)
-_deleteat!(a::Vector, i::Integer, delta::Integer) =
+end
+function _deleteat!(a::Vector, i::Integer, delta::Integer)
+    @assume_effects :terminates_globally
     ccall(:jl_array_del_at, Cvoid, (Any, Int, UInt), a, i - 1, delta)
+end
 
 ## Dequeue functionality ##
 

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -702,7 +702,8 @@ macro assume_effects(args...)
     end
     (consistent, effect_free, nothrow, terminates_globally, terminates_locally, notaskstate, inaccessiblememonly) =
         (false, false, false, false, false, false, false, false)
-    for org_setting in args[1:idx]
+    for arg_idx in 1:idx
+        org_setting = args[arg_idx]
         (setting, val) = compute_assumed_setting(org_setting)
         if setting === :consistent
             consistent = val

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -62,7 +62,10 @@ unsafe_convert(::Type{Ptr{Int8}}, s::String) = ccall(:jl_string_ptr, Ptr{Int8}, 
 cconvert(::Type{Ptr{UInt8}}, s::AbstractString) = String(s)
 cconvert(::Type{Ptr{Int8}}, s::AbstractString) = String(s)
 
-unsafe_convert(::Type{Ptr{T}}, a::Array{T}) where {T} = ccall(:jl_array_ptr, Ptr{T}, (Any,), a)
+function unsafe_convert(::Type{Ptr{T}}, a::Array{T}) where {T}
+    @assume_effects :consistent :nothrow :effect_free :terminates_globally
+    ccall(:jl_array_ptr, Ptr{T}, (Any,), a)
+end
 unsafe_convert(::Type{Ptr{S}}, a::AbstractArray{T}) where {S,T} = convert(Ptr{S}, unsafe_convert(Ptr{T}, a))
 unsafe_convert(::Type{Ptr{T}}, a::AbstractArray{T}) where {T} = error("conversion to pointer not defined for $(typeof(a))")
 

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -290,11 +290,13 @@ function make_seed()
     end
 end
 
-function make_seed(n::Integer)
+@Base.assume_effects :nothrow _push_nothrow!(a, i) = push!(a, i)
+
+@Base.assume_effects :effect_free function make_seed(n::Integer)
     n < 0 && throw(DomainError(n, "`n` must be non-negative."))
     seed = UInt32[]
     while true
-        push!(seed, n & 0xffffffff)
+        _push_nothrow!(seed, n & 0xffffffff)
         n >>= 32
         if n == 0
             return seed

--- a/stdlib/Random/src/Xoshiro.jl
+++ b/stdlib/Random/src/Xoshiro.jl
@@ -50,7 +50,9 @@ mutable struct Xoshiro <: AbstractRNG
     s3::UInt64
 
     Xoshiro(s0::Integer, s1::Integer, s2::Integer, s3::Integer) = new(s0, s1, s2, s3)
-    Xoshiro(seed=nothing) = seed!(new(), seed)
+    # TODO: It would be nice to only have to assert :effect_free here,
+    # but we're not quite there yet.
+    @Base.assume_effects :removable Xoshiro(seed=nothing) = seed!(new(), seed)
 end
 
 function setstate!(x::Xoshiro, s0::UInt64, s1::UInt64, s2::UInt64, s3::UInt64)

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -1018,3 +1018,8 @@ guardseed() do
         @test f42752(true) === val
     end
 end
+
+f_xoshiro_nouse() = (Xoshiro(UInt64(0)); nothing)
+let src = @code_typed f_xoshiro_nouse()
+    @test length(src.code) == 1
+end


### PR DESCRIPTION
My primary motivation here was to get the Xoshiro constructor to be removed if the RNG is unused (I have a struct that always has an RNG in it, which may or may not be used). I first tried to do that in a more fine-grained way, but #47595 currently makes that infeasible. Nevertheless, I figured it was worth leaving those improvements in so we can switch over once #47595 is resolved. In the meantime, annotate the top-level Xoshiro constructor as `:removable`.