### PR TITLE
Dict: rehesh when there are too many tombstones

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -351,8 +351,8 @@ ht_keyindex2!(h::Dict, key) = ht_keyindex2_shorthash!(h, key)[1]
 
     sz = length(h.keys)
     # Rehash now if necessary
-    if h.ndel >= ((3*sz)>>2) || h.count*3 > sz*2
-        # > 3/4 deleted or > 2/3 full
+    if (h.count*3 + h.ndel) > sz*2
+        # > 2/3 full (including tombstones)
         rehash!(h, h.count > 64000 ? h.count*2 : h.count*4)
     end
     nothing

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -351,7 +351,7 @@ ht_keyindex2!(h::Dict, key) = ht_keyindex2_shorthash!(h, key)[1]
 
     sz = length(h.keys)
     # Rehash now if necessary
-    if (h.count*3 + h.ndel) > sz*2
+    if (h.count + h.ndel)*3 > sz*2
         # > 2/3 full (including tombstones)
         rehash!(h, h.count > 64000 ? h.count*2 : h.count*4)
     end


### PR DESCRIPTION
This idea comes from #47841. Originally, rehashing is triggered when 66% is full or/and 75% is deleted. In the worst case, it's well over 100%.
https://github.com/JuliaLang/julia/blob/c8662b593a245e3d1efa5b0d2b60175cfc23ebc7/base/dict.jl#L353-L356

This PR rehash more often when there are too many deleted slots (tombstone) that cannot be removed by #47825.

**This PR**
```
n=1000  17.266 μs (9 allocations: 7.64 KiB)
n=2000  35.728 μs (12 allocations: 16.45 KiB)
n=5000  130.017 μs (18 allocations: 68.20 KiB)
n=10000  297.715 μs (23 allocations: 136.48 KiB)
n=20000  653.945 μs (28 allocations: 272.77 KiB)
n=50000  1.617 ms (34 allocations: 544.97 KiB)
n=100000  3.301 ms (40 allocations: 1.06 MiB)
```

**Master**
```
n=1000  17.794 μs (6 allocations: 5.83 KiB)
n=2000  53.774 μs (9 allocations: 23.14 KiB)
n=5000  162.630 μs (9 allocations: 23.14 KiB)
n=10000  335.564 μs (14 allocations: 91.42 KiB)
n=20000  740.026 μs (14 allocations: 91.42 KiB)
n=50000  2.129 ms (20 allocations: 363.62 KiB)
n=100000  5.016 ms (20 allocations: 363.62 KiB)
```

**Testing code**
```julia
using BenchmarkTools

function foo(d, reps)
    for i in 1:reps
        d[i] = i
        mod(i,11) != 0 && delete!(d, i)
    end
end

for n = [1, 2, 5, 10, 20, 50, 100] .* 1000
    print("n=", n)
    @btime foo(d, $n) setup=(d=Dict{Int,Int}())
end
```