### PR TITLE
pidlock cache file precompilation

### DIFF
--- a/stdlib/FileWatching/docs/src/index.md
+++ b/stdlib/FileWatching/docs/src/index.md
@@ -20,6 +20,7 @@ A simple utility tool for creating advisory pidfiles (lock files).
 
 ```@docs
 mkpidlock
+trymkpidlock
 close(lock::LockMonitor)
 ```
 

--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -18,7 +18,8 @@ export
     PollingFileWatcher,
     FDWatcher,
     # pidfile:
-    mkpidlock
+    mkpidlock,
+    trymkpidlock
 
 import Base: @handle_as, wait, close, eventloop, notify_error, IOError,
     _sizeof_uv_poll, _sizeof_uv_fs_poll, _sizeof_uv_fs_event, _uv_hook_close, uv_error, _UVError,
@@ -462,6 +463,11 @@ function __init__()
     global uv_jl_fspollcb = @cfunction(uv_fspollcb, Cvoid, (Ptr{Cvoid}, Cint, Ptr{Cvoid}, Ptr{Cvoid}))
     global uv_jl_fseventscb_file = @cfunction(uv_fseventscb_file, Cvoid, (Ptr{Cvoid}, Ptr{Int8}, Int32, Int32))
     global uv_jl_fseventscb_folder = @cfunction(uv_fseventscb_folder, Cvoid, (Ptr{Cvoid}, Ptr{Int8}, Int32, Int32))
+
+    Base.mkpidlock_hook = mkpidlock
+    Base.trymkpidlock_hook = trymkpidlock
+    Base.parse_pidfile_hook = Pidfile.parse_pidfile
+
     nothing
 end
 
@@ -885,6 +891,6 @@ function poll_file(s::AbstractString, interval_seconds::Real=5.007, timeout_s::R
 end
 
 include("pidfile.jl")
-import .Pidfile: mkpidlock
+import .Pidfile: mkpidlock, trymkpidlock
 
 end

--- a/stdlib/FileWatching/src/pidfile.jl
+++ b/stdlib/FileWatching/src/pidfile.jl
@@ -1,7 +1,7 @@
 module Pidfile
 
 
-export mkpidlock
+export mkpidlock, trymkpidlock
 
 using Base:
     IOError, UV_EEXIST, UV_ESRCH,
@@ -41,6 +41,16 @@ Optional keyword arguments:
 """
 function mkpidlock end
 
+"""
+    trymkpidlock([f::Function], at::String, [pid::Cint, proc::Process]; kwopts...)
+
+Like `mkpidlock` except returns `false` instead of waiting if the file is already locked.
+
+!!! compat "Julia 1.10"
+    This function requires at least Julia 1.10.
+
+"""
+function trymkpidlock end
 
 # mutable only because we want to add a finalizer
 mutable struct LockMonitor
@@ -93,6 +103,18 @@ function mkpidlock(at::String, proc::Process; kwopts...)
     end
     isdefined(Base, :errormonitor) && Base.errormonitor(closer)
     return lock
+end
+
+function trymkpidlock(args...; kwargs...)
+    try
+        mkpidlock(args...; kwargs..., wait=false)
+    catch ex
+        if ex isa PidlockedError
+            return false
+        else
+            rethrow()
+        end
+    end
 end
 
 """
@@ -192,8 +214,12 @@ function tryopen_exclusive(path::String, mode::Integer = 0o444)
     return nothing
 end
 
+struct PidlockedError <: Exception
+    msg::AbstractString
+end
+
 """
-    open_exclusive(path::String; mode, poll_interval, stale_age) :: File
+    open_exclusive(path::String; mode, poll_interval, wait, stale_age) :: File
 
 Create a new a file for read-write advisory-exclusive access.
 If `wait` is `false` then error out if the lock files exist
@@ -218,7 +244,7 @@ function open_exclusive(path::String;
             file = tryopen_exclusive(path, mode)
         end
         if file === nothing
-            error("Failed to get pidfile lock for $(repr(path)).")
+            throw(PidlockedError("Failed to get pidfile lock for $(repr(path))."))
         else
             return file
         end

--- a/stdlib/FileWatching/test/pidfile.jl
+++ b/stdlib/FileWatching/test/pidfile.jl
@@ -180,14 +180,14 @@ end
         Base.errormonitor(rmtask)
 
         t1 = time()
-        @test_throws ErrorException open_exclusive("pidfile", wait=false)
+        @test_throws Pidfile.PidlockedError open_exclusive("pidfile", wait=false)
         @test time()-t1 ≈ 0 atol=1
 
         sleep(1)
         @test !deleted
 
         t1 = time()
-        @test_throws ErrorException open_exclusive("pidfile", wait=false)
+        @test_throws Pidfile.PidlockedError open_exclusive("pidfile", wait=false)
         @test time()-t1 ≈ 0 atol=1
 
         wait(rmtask)
@@ -246,7 +246,7 @@ end
     Base.errormonitor(waittask)
 
     # mkpidlock with no waiting
-    t = @elapsed @test_throws ErrorException mkpidlock("pidfile", wait=false)
+    t = @elapsed @test_throws Pidfile.PidlockedError mkpidlock("pidfile", wait=false)
     @test t ≈ 0 atol=1
 
     t = @elapsed lockf1 = mkpidlock(joinpath(dir, "pidfile"))
@@ -354,7 +354,7 @@ end
     @test lockf.update === nothing
 
     sleep(1)
-    t = @elapsed @test_throws ErrorException mkpidlock("pidfile-2", wait=false, stale_age=1, poll_interval=1, refresh=0)
+    t = @elapsed @test_throws Pidfile.PidlockedError mkpidlock("pidfile-2", wait=false, stale_age=1, poll_interval=1, refresh=0)
     @test t ≈ 0 atol=1
 
     sleep(5)


### PR DESCRIPTION
This avoids multiple processes entering precompile cache file generation for the same package at the same time, allowing the first to enter and the others will wait to use the cache file that the first generated.

Terminal 1
```
julia> @time using Revise
[ Info: Precompiling Revise [295af30f-e4ad-537b-8983-00126c2a3abe]
 18.165747 seconds (321.97 k allocations: 19.684 MiB)
```
Terminal 2 (started just after above)
```
julia> @time using Revise
[ Info: Waiting for another process to precompile Revise [295af30f-e4ad-537b-8983-00126c2a3abe]
 17.033804 seconds (325.99 k allocations: 19.775 MiB, 0.07% compilation time: 100% of which was recompilation)

julia> 
```

~Perhaps the 2nd process should inform the user that it's waiting for another process to finish.~ Implemented

Making this specific to the package source was relatively straightforward. Making it specific to the resulting cache file path seems basically impossible because of the way the cache file name is generated.