### PR TITLE
Fix show method candidate for builtins

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -416,17 +416,17 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
             end
             sig0 = sig0::DataType
             s1 = sig0.parameters[1]
-            sig = sig0.parameters[2:end]
-            print(iob, "  ")
-            if !isa(func, rewrap_unionall(s1, method.sig))
-                # function itself doesn't match
+            if sig0 === Tuple || !isa(func, rewrap_unionall(s1, method.sig))
+                # function itself doesn't match or is a builtin
                 continue
             else
+                print(iob, "  ")
                 show_signature_function(iob, s1)
             end
             print(iob, "(")
             t_i = copy(arg_types_param)
             right_matches = 0
+            sig = sig0.parameters[2:end]
             for i = 1 : min(length(t_i), length(sig))
                 i > 1 && print(iob, ", ")
                 # If isvarargtype then it checks whether the rest of the input arguments matches

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -936,7 +936,7 @@ end
 
 # issue #49002
 let buf = IOBuffer()
-    Base.show_method_candidates(buf, Base.MethodError(typeof, (17)), pairs((foo = :bar,)))
+    Base.show_method_candidates(buf, Base.MethodError(typeof, (17,)), pairs((foo = :bar,)))
     @test isempty(take!(buf))
     Base.show_method_candidates(buf, Base.MethodError(isa, ()), pairs((a = 5,)))
     @test isempty(take!(buf))

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -933,3 +933,11 @@ let err_str
     err_str = @except_str "a" + "b" MethodError
     @test occursin("String concatenation is performed with *", err_str)
 end
+
+# issue #49002
+let buf = IOBuffer()
+    Base.show_method_candidates(buf, Base.MethodError(typeof, (17)), pairs((foo = :bar,)))
+    @test isempty(take!(buf))
+    Base.show_method_candidates(buf, Base.MethodError(isa, ()), pairs((a = 5,)))
+    @test isempty(take!(buf))
+end


### PR DESCRIPTION
Fix https://github.com/JuliaLang/julia/issues/49002

With this PR:
```julia
julia> typeof(; a=3, b=4)
ERROR: MethodError: no method matching typeof(; a::Int64, b::Int64)
Stacktrace:
 [1] top-level scope
   @ REPL[41]:1
```