### PR TITLE
Fix emitting `undef` when coercing an `Int` to the pointersize of a target

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -334,7 +334,7 @@ static Value *emit_unboxed_coercion(jl_codectx_t &ctx, Type *to, Value *unboxed)
         // bools may be stored internally as int8
         unboxed = ctx.builder.CreateTrunc(unboxed, to);
     }
-    else if (ty->isVoidTy() || DL.getTypeSizeInBits(ty) != DL.getTypeSizeInBits(to)) {
+    else if (ty->isVoidTy() || (DL.getTypeSizeInBits(ty) != DL.getTypeSizeInBits(to) && !(to->isIntOrPtrTy() && ty->isIntOrPtrTy()))) {
         // this can happen in dead code
         //emit_unreachable(ctx);
         return UndefValue::get(to);


### PR DESCRIPTION
Previously, we always emitted `undef` in our IR when the bitsize of an unboxed value and the pointersize we want to coerce it to were mismatched. This is an issue when the pointersize is smaller than a supported integer size of a platform. This commit fixes this, by only emitting the `undef` when both arguments `to` and `ty` are not integers and not pointers, which we should be fine with converting between.

Testing this is a bit tricky - you can only reproduce this when codegen emits a pointercoercion of a global constant via e.g. a `Expr(:call, Base.pointerref, SSAValue(27), 1, 1)`. The reproducer this was found with was compiling [AVRDevices.jl/examples/motd_example](https://github.com/Seelengrab/AVRDevices.jl/blob/poison_ir/examples/motd_example/src/motd_example.jl), which uses GPUCompiler to target AVR (which has a pointersize of 16 bits). The example is more or less referencing a global `String`, the `pointerref` is from referencing that variable via `pointer` in `codeunits`. It's unclear how this would be tested here, since it more or less only happens in cross compilation, i.e. compile modes where the host-pointersize and target-pointersize differ (since we mostly assume `sizeof(Ptr{Any}) === sizeof(Int)` in codegen & the compiler, as far as I know). I guess we could have a small reproducer targeting AVR directly as a testcase, now that the backend is available in Base and check whether the unoptimized IR has a `poison`? I'd be happy to add that, provided I can get some pointers where to do so.

If this doesn't break any existing code, I'll be very happy and consider this PR two weeks well spent for a single changed LOC :joy: 