### PR TITLE
dont show `#unused#` for unnamed arguments in stacktraces

### DIFF
--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -224,6 +224,7 @@ function show_spec_linfo(io::IO, frame::StackFrame)
         if isa(def, Method)
             sig = linfo.specTypes
             argnames = Base.method_argnames(def)
+            argnames = replace(argnames, Symbol("#unused#") => Symbol(""))
             if def.nkw > 0
                 # rearrange call kw_impl(kw_args..., func, pos_args...) to func(pos_args...)
                 kwarg_types = Any[ fieldtype(sig, i) for i = 2:(1+def.nkw) ]

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -224,7 +224,7 @@ function show_spec_linfo(io::IO, frame::StackFrame)
         if isa(def, Method)
             sig = linfo.specTypes
             argnames = Base.method_argnames(def)
-            argnames = replace(argnames, Symbol("#unused#") => Symbol(""))
+            argnames = replace(argnames, :var"#unused#" => :var"")
             if def.nkw > 0
                 # rearrange call kw_impl(kw_args..., func, pos_args...) to func(pos_args...)
                 kwarg_types = Any[ fieldtype(sig, i) for i = 2:(1+def.nkw) ]

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -933,3 +933,9 @@ let err_str
     err_str = @except_str "a" + "b" MethodError
     @test occursin("String concatenation is performed with *", err_str)
 end
+
+@testset "unused argument names" begin
+    g(::Int) = backtrace()
+    bt = g(1)
+    @test !contains(sprint(Base.show_backtrace, bt), "#unused#")
+end


### PR DESCRIPTION
All the `#unused#` in

```
Stacktrace:
  [1] zero(#unused#::Type{Any})
    @ Base ./missing.jl:106
  [2] reduce_empty(#unused#::typeof(+), #unused#::Type{Any})
    @ Base ./reduce.jl:338
  [3] reduce_empty(#unused#::typeof(Base.add_sum), #unused#::Type{Any})
    @ Base ./reduce.jl:347
  [4] mapreduce_empty(#unused#::typeof(identity), op::Function, T::Type)
    @ Base ./reduce.jl:367
```

are pretty pointless and verbose.