### PR TITLE
allow passing `--project=temp` to create a temporary environment

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -235,6 +235,13 @@ function init_active_project()
     project = (JLOptions().project != C_NULL ?
         unsafe_string(Base.JLOptions().project) :
         get(ENV, "JULIA_PROJECT", nothing))
+    if project == "temp"
+        if isdir("temp")
+            @warn "Using a temporary directory for initial project environment, use an absolute path or \
+                   `./temp` to use the `temp` directory in the current directory"
+        end
+        project = mktempdir()
+    end
     set_active_project(
         project === nothing ? nothing :
         project == "" ? nothing :

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -222,6 +222,10 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
         @test expanded == readchomp(addenv(`$exename -e 'println(Base.active_project())'`, "JULIA_PROJECT" => "@foo", "HOME" => homedir()))
     end
 
+    tmp = readchomp(`$exename --project='temp' -e '@assert isdir(dirname(Base.active_project())); println(Base.active_project());'`)
+    # Temp project should be deleted
+    @test !isdir(tmp)
+
     # --quiet, --banner
     let t(q,b) = "Base.JLOptions().quiet == $q && Base.JLOptions().banner == $b"
         @test success(`$exename                 -e $(t(0, -1))`)


### PR DESCRIPTION
cc @aviks