### PR TITLE
fix multiq_check_empty to only look at the caller's pool

### DIFF
--- a/base/partr.jl
+++ b/base/partr.jl
@@ -179,13 +179,12 @@ function multiq_deletemin()
     return task
 end
 
-
 function multiq_check_empty()
-    for j = UInt32(1):length(heaps)
-        for i = UInt32(1):length(heaps[j])
-            if heaps[j][i].ntasks != 0
-                return false
-            end
+    tid = Threads.threadid()
+    tp = ccall(:jl_threadpoolid, Int8, (Int16,), tid-1) + 1
+    for i = UInt32(1):length(heaps[tp])
+        if heaps[tp][i].ntasks != 0
+            return false
         end
     end
     return true


### PR DESCRIPTION
The scheduler running on the current thread will only pull tasks from its own pool, so it should only check that pool in check_empty, instead of checking all pools. This is tricky to test since I think it basically just affects idle CPU use, but the change should be pretty clearly correct.