### PR TITLE
inlining: allow non-compileable result when handling `ConcreteResult`

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1494,6 +1494,7 @@ end
 
 function handle_concrete_result!(cases::Vector{InliningCase}, result::ConcreteResult, @nospecialize(info::CallInfo), state::InliningState)
     case = concrete_result_item(result, info, state)
+    case === nothing && return false
     push!(cases, InliningCase(result.mi.specTypes, case))
     return true
 end
@@ -1505,10 +1506,8 @@ function concrete_result_item(result::ConcreteResult, @nospecialize(info::CallIn
     invokesig::Union{Nothing,Vector{Any}}=nothing)
     if !may_inline_concrete_result(result)
         et = InliningEdgeTracker(state.et, invokesig)
-        case = compileable_specialization(result.mi, result.effects, et, info;
+        return compileable_specialization(result.mi, result.effects, et, info;
             compilesig_invokes=OptimizationParams(state.interp).compilesig_invokes)
-        @assert case !== nothing "concrete evaluation should never happen for uncompileable callsite"
-        return case
     end
     @assert result.effects === EFFECTS_TOTAL
     return ConstantCase(quoted(result.result))

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1936,4 +1936,7 @@ let src = code_typed1() do
     end
     @test any(isinvoke(:issue49074), src.code)
 end
-@test_throws MethodError issue49074(Issue49050Concrete)
+let result = @test_throws MethodError issue49074(Issue49050Concrete)
+    @test result.value.f === issue49074
+    @test result.value.args === (Any,)
+end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1921,3 +1921,19 @@ let res = @test_throws MethodError let
     err = res.value
     @test err.f === convert && err.args === (Union{Bool,Tuple{String,String}}, g48397)
 end
+
+# https://github.com/JuliaLang/julia/issues/49050
+abstract type Issue49050AbsTop{T,N} end
+abstract type Issue49050Abs1{T, N} <: Issue49050AbsTop{T,N} end
+abstract type Issue49050Abs2{T} <: Issue49050Abs1{T,3} end
+struct Issue49050Concrete{T} <: Issue49050Abs2{T}
+    x::T
+end
+issue49074(::Type{Issue49050AbsTop{T,N}}) where {T,N} = Issue49050AbsTop{T,N}
+Base.@assume_effects :foldable issue49074(::Type{C}) where {C<:Issue49050AbsTop} = issue49074(supertype(C))
+let src = code_typed1() do
+        issue49074(Issue49050Concrete)
+    end
+    @test any(isinvoke(:issue49074), src.code)
+end
+@test_throws MethodError issue49074(Issue49050Concrete)


### PR DESCRIPTION
In rare cases, the system might decide to widen the signature of a call that is determined to throw by concrete-evaluation. We should remove this unnecessary assertion here.

closes #49050