### PR TITLE
restore support for cross-compile builds

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -452,7 +452,11 @@ endif
 
 # Compiler specific stuff
 
-CC_VERSION_STRING = $(shell $(CC) --version)
+CC := $(CROSS_COMPILE)$(CC) # attempt to add cross-compiler prefix, if the user
+                            # is not overriding the default, to form target-triple-cc (which
+                            # may not exist), and use that to decide what compiler the user
+                            # is using for the target build (or default to gcc)
+CC_VERSION_STRING = $(shell $(CC) --version 2>/dev/null)
 ifneq (,$(findstring clang,$(CC_VERSION_STRING)))
 USECLANG := 1
 USEGCC := 0


### PR DESCRIPTION
Defaults to gcc after autodetection. Regression caused by ee6115bbb2c.