### PR TITLE
fix malloc-stack CI failure

### DIFF
--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -165,9 +165,11 @@ JL_DLLEXPORT void *jl_malloc_stack(size_t *bufsz, jl_task_t *owner) JL_NOTSAFEPO
         ssize = LLT_ALIGN(ssize, jl_page_size);
     }
     if (stk == NULL) {
-        if (jl_atomic_load_relaxed(&num_stack_mappings) >= MAX_STACK_MAPPINGS)
+        if (jl_atomic_load_relaxed(&num_stack_mappings) >= MAX_STACK_MAPPINGS) {
             // we accept that this can go over by as much as nthreads since it's not a CAS
+            errno = ENOMEM;
             return NULL;
+        }
         // TODO: allocate blocks of stacks? but need to mprotect individually anyways
         stk = malloc_stack(ssize);
         if (stk == MAP_FAILED)

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -621,7 +621,7 @@ static void allocate_segv_handler(void)
 static void *alloc_sigstack(size_t *ssize)
 {
     void *stk = jl_malloc_stack(ssize, NULL);
-    if (stk == MAP_FAILED)
+    if (stk == NULL)
         jl_errorf("fatal error allocating signal stack: mmap: %s", strerror(errno));
     return stk;
 }

--- a/src/task.c
+++ b/src/task.c
@@ -1552,12 +1552,15 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
 #endif
         if (jl_setjmp(ptls->copy_stack_ctx.uc_mcontext, 0))
             start_task(); // sanitizer_finish_switch_fiber is part of start_task
-        return ct;
     }
-    ssize = JL_STACK_SIZE;
-    char *stkbuf = jl_alloc_fiber(&ptls->base_ctx, &ssize, NULL);
-    ptls->stackbase = stkbuf + ssize;
-    ptls->stacksize = ssize;
+    else {
+        ssize = JL_STACK_SIZE;
+        char *stkbuf = jl_alloc_fiber(&ptls->base_ctx, &ssize, NULL);
+        if (stkbuf != NULL) {
+            ptls->stackbase = stkbuf + ssize;
+            ptls->stacksize = ssize;
+        }
+    }
 #endif
 
     if (jl_options.handle_signals == JL_OPTIONS_HANDLE_SIGNALS_ON)


### PR DESCRIPTION
We see Windows CI fail often here, and we don't actually need this memory--only the first thread should initialize it. (indeed, we were temporarily corrupting these data-structures in the process by reinitializing them, though that was not typically detectable.)

    From worker 7:  Exception: EXCEPTION_ACCESS_VIOLATION at 0x7ffa26726e87 -- jl_makecontext at C:/workdir/src\win32_ucontext.c:67
    From worker 7:  in expression starting at C:\buildkite-agent\builds\win2k22-amdci6-6\julialang\julia-master\julia-ceffaee345\share\julia\test\ccall.jl:1066
    From worker 7:  jl_makecontext at C:/workdir/src\win32_ucontext.c:67
    From worker 7:  jl_install_thread_signal_handler at C:/workdir/src\signals-win.c:490
    From worker 7:  jl_init_root_task at C:/workdir/src\task.c:1568
    From worker 7:  ijl_adopt_thread at C:/workdir/src\threading.c:414
    From worker 7:  unknown function (ip: 000001d791a58969)
    From worker 7:  uv__queue_work at /workspace/srcdir/libuv\src\threadpool.c:305
    From worker 7:  worker at /workspace/srcdir/libuv\src\threadpool.c:122
    From worker 7:  uv__thread_start at /workspace/srcdir/libuv\src/win\thread.c:111
    From worker 7:  beginthreadex at C:\Windows\System32\msvcrt.dll (unknown line)
    From worker 7:  endthreadex at C:\Windows\System32\msvcrt.dll (unknown line)
    From worker 7:  BaseThreadInitThunk at C:\Windows\System32\KERNEL32.DLL (unknown line)
    From worker 7:  RtlUserThreadStart at C:\Windows\SYSTEM32\ntdll.dll (unknown line)
    From worker 7:  Allocations: 352796158 (Pool: 352389694; Big: 406464); GC: 722