### PR TITLE
Improve robustness in Dates/conversions test

### DIFF
--- a/stdlib/Dates/src/conversions.jl
+++ b/stdlib/Dates/src/conversions.jl
@@ -46,9 +46,11 @@ Take the number of seconds since unix epoch `1970-01-01T00:00:00` and convert to
 corresponding `DateTime`.
 """
 function unix2datetime(x)
-    rata = UNIXEPOCH + round(Int64, Int64(1000) * x)
+    # Rounding should match `now` below
+    rata = UNIXEPOCH + trunc(Int64, Int64(1000) * x)
     return DateTime(UTM(rata))
 end
+
 """
     datetime2unix(dt::DateTime) -> Float64
 

--- a/stdlib/Dates/test/conversions.jl
+++ b/stdlib/Dates/test/conversions.jl
@@ -60,10 +60,16 @@ end
 
     if Sys.isapple()
         withenv("TZ" => "UTC") do
-            @test abs(Dates.now() - now(Dates.UTC)) < Dates.Second(1)
+            a = Dates.now()
+            b = Dates.now(Dates.UTC)
+            c = Dates.now()
+            @test a <= b <= c
         end
     end
-    @test abs(Dates.now() - now(Dates.UTC)) < Dates.Hour(16)
+    a = Dates.now()
+    b = now(Dates.UTC)
+    c = Dates.now()
+    @test abs(a - b) < Dates.Hour(16) + abs(c - a)
 end
 @testset "Issue #9171, #9169" begin
     let t = Dates.Period[Dates.Week(2), Dates.Day(14), Dates.Hour(14 * 24), Dates.Minute(14 * 24 * 60), Dates.Second(14 * 24 * 60 * 60), Dates.Millisecond(14 * 24 * 60 * 60 * 1000)]


### PR DESCRIPTION
In [1], this test was observed to fail, with a 1 second pause between the two Dates.now calls. In general, particularly on high-load CI systems, we cannot make assumptions that calls will complete within any particular amount of time. Instead, we should be asserting properties that should be universally true. This test wants to assert that Dates.now() and Dates.now(UTC) give the same answer if the TZ environment variable is set appropriately, but of course we can't guarantee that these calls run at the same time. Rather than setting an arbitrary limit of 1 second, just run `Dates.now` again. Our semantics guarantee ordering of these calls (in the absence of leap days/seconds at least), so the test is more robust.

[1] https://buildkite.com/julialang/julia-master/builds/22064#0186ff11-f07e-4ba4-9b54-21bdf738d35e