### PR TITLE
Temp cleanup log tweaks

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -544,7 +544,10 @@ function temp_cleanup_purge(; force::Bool=false)
             end
             !ispath(path) && delete!(TEMP_CLEANUP, path)
         catch ex
-            @warn "temp cleanup" _group=:file exception=(ex, catch_backtrace())
+            @warn """
+                Failed to clean up temporary path $(repr(path))
+                $ex
+                """ _group=:file
         end
     end
 end


### PR DESCRIPTION
Fixes #49079
```
  | From worker 11:	┌ Warning: Failed to clean up temporary path "C:\\Users\\julia\\AppData\\Local\\Temp\\jl_cVh8we"
  | From worker 11:	│ Base.IOError("rm(\"C:\\\\Users\\\\julia\\\\AppData\\\\Local\\\\Temp\\\\jl_cVh8we\\\\compiled\\\\v1.10\"): directory not empty (ENOTEMPTY)", -4051)
  | From worker 11:	└ @ Base.Filesystem file.jl:547
```