### PR TITLE
Quieter tests

### DIFF
--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -46,8 +46,8 @@ let err = try
     @test occursin("Possible fix, define\n  ambig(::Integer, ::Integer)", errstr)
 end
 
-ambig_with_bounds(x, ::Int, ::T) where {T<:Integer,S} = 0
-ambig_with_bounds(::Int, x, ::T) where {T<:Integer,S} = 1
+@test_warn "declares type variable S but does not use it" @eval ambig_with_bounds(x, ::Int, ::T) where {T<:Integer,S} = 0
+@test_warn "declares type variable S but does not use it" @eval ambig_with_bounds(::Int, x, ::T) where {T<:Integer,S} = 1
 let err = try
               ambig_with_bounds(1, 2, 3)
           catch _e_
@@ -385,7 +385,7 @@ f11407(::Dict{K,V}, ::Dict{Any,V}) where {K,V} = 1
 f11407(::Dict{K,V}, ::Dict{K,Any}) where {K,V} = 2
 @test_throws MethodError f11407(Dict{Any,Any}(), Dict{Any,Any}()) # ambiguous
 @test f11407(Dict{Any,Int}(), Dict{Any,Int}()) == 1
-f11407(::Dict{Any,Any}, ::Dict{Any,Any}) where {K,V} = 3
+@test_warn "declares type variable V but does not use it" @eval f11407(::Dict{Any,Any}, ::Dict{Any,Any}) where {K,V} = 3
 @test f11407(Dict{Any,Any}(), Dict{Any,Any}()) == 3
 
 # issue #12814
@@ -399,8 +399,9 @@ end
 
 # issue #43040
 module M43040
+   using Test
    struct C end
-   stripType(::Type{C}) where {T} = C # where {T} is intentionally incorrect
+   @test_warn "declares type variable T but does not use it" @eval M43040 stripType(::Type{C}) where {T} = C # where {T} is intentionally incorrect
 end
 
 @test isempty(detect_ambiguities(M43040; recursive=true))

--- a/test/core.jl
+++ b/test/core.jl
@@ -5267,10 +5267,10 @@ end
 GC.enable(true)
 
 # issue #18710
-bad_tvars() where {T} = 1
+@test_warn "declares type variable T but does not use it" @eval bad_tvars() where {T} = 1
 @test isa(which(bad_tvars, ()), Method)
 @test bad_tvars() === 1
-bad_tvars2() where {T} = T
+@test_warn "declares type variable T but does not use it" @eval bad_tvars2() where {T} = T
 @test_throws UndefVarError(:T) bad_tvars2()
 missing_tvar(::T...) where {T} = T
 @test_throws UndefVarError(:T) missing_tvar()

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -116,8 +116,8 @@ begin # @deprecate
 
     # test that positional and keyword arguments are forwarded when
     # there is no explicit type annotation
-    @test DeprecationTests.old_return_args(1, 2, 3) == ((1, 2, 3),(;))
-    @test DeprecationTests.old_return_args(1, 2, 3; a = 4, b = 5) == ((1, 2, 3), (a = 4, b = 5))
+    @test_logs (:warn,) @test DeprecationTests.old_return_args(1, 2, 3) == ((1, 2, 3),(;))
+    @test_logs (:warn,) @test DeprecationTests.old_return_args(1, 2, 3; a = 4, b = 5) == ((1, 2, 3), (a = 4, b = 5))
 end
 
 f24658() = depwarn24658()

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2007,7 +2007,7 @@ end
 @test Meta.parse("import Base.Foo.:(==).bar") == :(import Base.Foo.==.bar)
 
 # issue #33135
-function f33135(x::T) where {C1, T}
+@test_warn "declares type variable C1 but does not use it" @eval function f33135(x::T) where {C1, T}
     let C1 = 1, C2 = 2
         C1
     end

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -27,6 +27,8 @@ end
 # (expected test duration is about 18-180 seconds)
 Timer(t -> killjob("KILLING BY THREAD TEST WATCHDOG\n"), 1200)
 
+@testset """threads_exec.jl with JULIA_NUM_THREADS == $(ENV["JULIA_NUM_THREADS"])""" begin
+
 @test Threads.threadid() == 1
 @test 1 <= threadpoolsize() <= Threads.maxthreadid()
 
@@ -232,7 +234,7 @@ end
 # Make sure that eval'ing in a different module doesn't mess up other threads
 orig_curmodule14726 = @__MODULE__
 main_var14726 = 1
-module M14726
+@eval Main module M14726
 module_var14726 = 1
 end
 
@@ -252,7 +254,7 @@ end
     @test @__MODULE__() == orig_curmodule14726
 end
 
-module M14726_2
+@eval Main module M14726_2
 using Test
 using Base.Threads
 @threads for i in 1:100
@@ -1067,3 +1069,5 @@ end
         popfirst!(LOAD_PATH)
     end
 end
+
+end # main testset


### PR DESCRIPTION
 - Quiets intentional depwarns by catching and testing for them
```
From worker 5:	┌ Warning: `old_return_args` is deprecated, use `new_return_args` instead.
From worker 5:	│   caller = macro expansion at Test.jl:478 [inlined]
From worker 5:	└ @ Core /cache/build/default-amdci5-0/julialang/julia-master/julia-4d8c22f7f6/share/julia/stdlib/v1.10/Test/src/Test.jl:478
From worker 5:	┌ Warning: `old_return_args` is deprecated, use `new_return_args` instead.
From worker 5:	│   caller = macro expansion at Test.jl:478 [inlined]
From worker 5:	└ @ Core /cache/build/default-amdci5-0/julialang/julia-master/julia-4d8c22f7f6/share/julia/stdlib/v1.10/Test/src/Test.jl:478
```

- Groups the threaded tests into a single report per nthreads tested

- Catches what seem to be intentional unused type variable warnings
```
From worker 11:	WARNING: method definition for ambig_with_bounds at /cache/build/default-amdci5-0/julialang/julia-master/julia-4d8c22f7f6/share/julia/test/ambiguous.jl:49 declares type variable S but does not use it.
From worker 11:	WARNING: method definition for ambig_with_bounds at /cache/build/default-amdci5-0/julialang/julia-master/julia-4d8c22f7f6/share/julia/test/ambiguous.jl:50 declares type variable S but does not use it.
From worker 11:	WARNING: method definition for f11407 at /cache/build/default-amdci5-0/julialang/julia-master/julia-4d8c22f7f6/share/julia/test/ambiguous.jl:388 declares type variable V but does not use it.
From worker 11:	WARNING: method definition for f11407 at /cache/build/default-amdci5-0/julialang/julia-master/julia-4d8c22f7f6/share/julia/test/ambiguous.jl:388 declares type variable K but does not use it.
From worker 11:	WARNING: method definition for stripType at /cache/build/default-amdci5-0/julialang/julia-master/julia-4d8c22f7f6/share/julia/test/ambiguous.jl:403 declares type variable T but does not use it.
From worker 13:	WARNING: method definition for bad_tvars at /cache/build/default-amdci5-0/julialang/julia-master/julia-4d8c22f7f6/share/julia/test/core.jl:5270 declares type variable T but does not use it.
From worker 13:	WARNING: method definition for bad_tvars2 at /cache/build/default-amdci5-0/julialang/julia-master/julia-4d8c22f7f6/share/julia/test/core.jl:5273 declares type variable T but does not use it.
```