### PR TITLE
doc/base: remove outdata const

### DIFF
--- a/doc/src/base/constants.md
+++ b/doc/src/base/constants.md
@@ -23,6 +23,3 @@ See also:
   * [`stderr`](@ref)
   * [`ENV`](@ref)
   * [`ENDIAN_BOM`](@ref)
-  * `Libc.MS_ASYNC`
-  * `Libc.MS_INVALIDATE`
-  * `Libc.MS_SYNC`


### PR DESCRIPTION
These constants have been moved to the Mmap stdlib and are not exported.
https://github.com/JuliaLang/julia/blob/5b49c0376522fe42f9682731eeb6a52663c859a0/stdlib/Mmap/src/Mmap.jl#L333-L336