### PR TITLE
clean up test/opaque_closure

### DIFF
--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -1,6 +1,7 @@
 using Test
 using InteractiveUtils
 using Core: OpaqueClosure
+using Base.Experimental: @opaque
 
 const_int() = 1
 
@@ -12,7 +13,7 @@ let ci = @code_lowered const_int()
             Expr(:opaque_closure_method, nothing, 0, false, lno, ci)))
     end
 end
-@test isa(oc_trivial(), Core.OpaqueClosure{Tuple{}, Any})
+@test isa(oc_trivial(), OpaqueClosure{Tuple{}, Any})
 @test oc_trivial()() == 1
 
 let ci = @code_lowered const_int()
@@ -21,7 +22,7 @@ let ci = @code_lowered const_int()
             Expr(:opaque_closure_method, nothing, 0, false, lno, ci)))
     end
 end
-@test isa(oc_simple_inf(), Core.OpaqueClosure{Tuple{}, Int})
+@test isa(oc_simple_inf(), OpaqueClosure{Tuple{}, Int})
 @test oc_simple_inf()() == 1
 
 struct OcClos2Int
@@ -72,8 +73,8 @@ let ci = @code_lowered OcClos1Any(1)()
             :x))
     end
 end
-@test isa(oc_infer_pass_clos(1), Core.OpaqueClosure{Tuple{}, typeof(1)})
-@test isa(oc_infer_pass_clos("a"), Core.OpaqueClosure{Tuple{}, typeof("a")})
+@test isa(oc_infer_pass_clos(1), OpaqueClosure{Tuple{}, typeof(1)})
+@test isa(oc_infer_pass_clos("a"), OpaqueClosure{Tuple{}, typeof("a")})
 @test oc_infer_pass_clos(1)() == 1
 @test oc_infer_pass_clos("a")() == "a"
 
@@ -115,8 +116,6 @@ let A = [1 2]
     end
 end
 
-using Base.Experimental: @opaque
-
 @test @opaque(x->2x)(8) == 16
 let f = @opaque (x::Int, y::Float64)->(2x, 3y)
     @test_throws TypeError f(1, 1)
@@ -128,18 +127,26 @@ end
 @test uses_frontend_opaque(10)(8) == 18
 
 # World age mechanism
+module test_world_age
+
+using Test
+using Core: OpaqueClosure
+using Base.Experimental: @opaque
+
 function test_oc_world_age end
 mk_oc_world_age() = @opaque ()->test_oc_world_age()
 g_world_age = @opaque ()->test_oc_world_age()
 h_world_age = mk_oc_world_age()
-@test isa(h_world_age, Core.OpaqueClosure{Tuple{}, Union{}})
+@test isa(h_world_age, OpaqueClosure{Tuple{}, Union{}})
 test_oc_world_age() = 1
 @test_throws MethodError g_world_age()
 @test_throws MethodError h_world_age()
 @test mk_oc_world_age()() == 1
 g_world_age = @opaque ()->test_oc_world_age()
 @test g_world_age() == 1
-@test isa(mk_oc_world_age(), Core.OpaqueClosure{Tuple{}, Int})
+@test isa(mk_oc_world_age(), OpaqueClosure{Tuple{}, Int})
+
+end # module test_world_age
 
 function maybe_vararg(isva::Bool)
     T = isva ? Vararg{Int} : Int
@@ -196,7 +203,7 @@ end
                 QuoteNode(Symbol(@__FILE__)),
                 true)))
 end
-@test isa(oc_trivial_generated(), Core.OpaqueClosure{Tuple{}, Any})
+@test isa(oc_trivial_generated(), OpaqueClosure{Tuple{}, Any})
 @test oc_trivial_generated()() == 1
 
 # Constprop through varargs OpaqueClosure
@@ -242,31 +249,28 @@ let oc = @opaque a->sin(a)
 end
 
 # constructing an opaque closure from IRCode
-let ci = code_typed(+, (Int, Int))[1][1]
-    ir = Core.Compiler.inflate_ir(ci)
-    @test OpaqueClosure(ir; nargs=2, isva=false)(40, 2) == 42
-    @test OpaqueClosure(ci)(40, 2) == 42
-
-    ir = Core.Compiler.inflate_ir(ci)
-    @test OpaqueClosure(ir; nargs=2, isva=false)(40, 2) == 42
-    @test isa(OpaqueClosure(ir; nargs=2, isva=false), Core.OpaqueClosure{Tuple{Int, Int}, Int})
-    @test_throws TypeError OpaqueClosure(ir; nargs=2, isva=false)(40.0, 2)
+let src = first(only(code_typed(+, (Int, Int))))
+    ir = Core.Compiler.inflate_ir(src)
+    @test OpaqueClosure(src)(40, 2) == 42
+    oc = OpaqueClosure(ir)
+    @test oc(40, 2) == 42
+    @test isa(oc, OpaqueClosure{Tuple{Int,Int}, Int})
+    @test_throws TypeError oc("40", 2)
+    ir = Core.Compiler.inflate_ir(src)
+    @test OpaqueClosure(ir)(40, 2) == 42
 end
 
-let ci = code_typed((x, y...)->(x, y), (Int, Int))[1][1]
-    ir = Core.Compiler.inflate_ir(ci)
-    let oc = OpaqueClosure(ir; nargs=2, isva=true)
-        @test oc(40, 2) === (40, (2,))
+# variadic arguments
+let src = code_typed((Int,Int)) do x, y...
+        return (x, y)
+    end |> only |> first
+    let oc = OpaqueClosure(src)
+        @test oc(1,2) === (1,(2,))
         @test_throws MethodError oc(1,2,3)
     end
-    let oc = OpaqueClosure(ci)
-        @test oc(40, 2) === (40, (2,))
-        @test_throws MethodError oc(1,2,3)
-    end
-
-    ir = Core.Compiler.inflate_ir(ci)
-    let oc = OpaqueClosure(ir; nargs=2, isva=true)
-        @test oc(40, 2) === (40, (2,))
+    ir = Core.Compiler.inflate_ir(src)
+    let oc = OpaqueClosure(ir; isva=true)
+        @test oc(1,2) === (1,(2,))
         @test_throws MethodError oc(1,2,3)
     end
 end


### PR DESCRIPTION
- removed unnecessary `Core.` accessor
- use the default `nargs`/`isva` values of `OpaqueClosure` constructor where possible
- wrap the world age test in a separate module so that `include("test/opaque_closure")` works multiple times in the same session