### PR TITLE
make `Core.OpaqueClosure(ir::IRCode)` non-destructive

### DIFF
--- a/base/opaque_closure.jl
+++ b/base/opaque_closure.jl
@@ -63,6 +63,7 @@ function Core.OpaqueClosure(ir::IRCode, env...;
     if (isva && nargs > length(ir.argtypes)) || (!isva && nargs != length(ir.argtypes)-1)
         throw(ArgumentError("invalid argument count"))
     end
+    ir = Core.Compiler.copy(ir)
     src = ccall(:jl_new_code_info_uninit, Ref{CodeInfo}, ())
     src.slotflags = UInt8[]
     src.slotnames = fill(:none, nargs+1)

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -256,8 +256,7 @@ let src = first(only(code_typed(+, (Int, Int))))
     @test oc(40, 2) == 42
     @test isa(oc, OpaqueClosure{Tuple{Int,Int}, Int})
     @test_throws TypeError oc("40", 2)
-    ir = Core.Compiler.inflate_ir(src)
-    @test OpaqueClosure(ir)(40, 2) == 42
+    @test OpaqueClosure(ir)(40, 2) == 42 # OpaqueClosure constructor should be non-destructive
 end
 
 # variadic arguments


### PR DESCRIPTION
Currently the constructor is destructive because it calls `replace_code_newstyle!(src, ir, ...)` etc.
This commit made it non-destructive by calling `Core.Compiler.copy(ir)` beforehand. We can define a destructive version of this `Core.OpaqueClosure!` later if we really want it.