### PR TITLE
hide internally created methods in stacktraces that occur as a result of argument forwarding

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -863,6 +863,14 @@ function _collapse_repeated_frames(trace)
                 frame.linfo.def isa Method && last_frame.linfo.def isa Method
                 m, last_m = frame.linfo.def::Method, last_frame.linfo.def::Method
                 params, last_params = Base.unwrap_unionall(m.sig).parameters, Base.unwrap_unionall(last_m.sig).parameters
+
+                if last_m.nkw != 0
+                    pos_sig_params = Base.rewrap_unionall(Tuple{last_params[(last_m.nkw+2):end]...}, last_m.sig).parameters
+                    issame = true
+                    if pos_sig_params == params
+                        kept_frames[i] = false
+                    end
+                end
                 if length(last_params) > length(params)
                     issame = true
                     for i = 1:length(params)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -829,29 +829,52 @@ function _collapse_repeated_frames(trace)
     last_frame = nothing
     for i in 1:length(trace)
         frame::StackFrame, _ = trace[i]
-        if last_frame !== nothing
-            if frame.file == last_frame.file && frame.line == last_frame.line
-                #=
-                Handles this case:
+        if last_frame !== nothing && frame.file == last_frame.file && frame.line == last_frame.line
+            #=
+            Handles this case:
 
-                f(g, a; kw...) = error();
-                @inline f(a; kw...) = f(identity, a; kw...);
-                f(1)
+            f(g, a; kw...) = error();
+            @inline f(a; kw...) = f(identity, a; kw...);
+            f(1)
 
-                which otherwise ends up as:
+            which otherwise ends up as:
 
-                [4] #f#4 <-- useless
-                @ ./REPL[2]:1 [inlined]
-                [5] f(a::Int64)
-                @ Main ./REPL[2]:1
-                =#
-                if startswith(sprint(show, last_frame), "#")
-                   kept_frames[i-1] = false
-                end
-
-                # TODO: Detect more cases that can be collapsed
+            [4] #f#4 <-- useless
+            @ ./REPL[2]:1 [inlined]
+            [5] f(a::Int64)
+            @ Main ./REPL[2]:1
+            =#
+            if startswith(sprint(show, last_frame), "#")
+                kept_frames[i-1] = false
             end
-            last_frame = frame
+
+            #= Handles this case
+            g(x, y=1, z=2) = error();
+            g(1)
+
+            which otherwise ends up as:
+
+            [2] g(x::Int64, y::Int64, z::Int64)
+            @ Main ./REPL[1]:1
+            [3] g(x::Int64) <-- useless
+            @ Main ./REPL[1]:1
+            =#
+            if frame.linfo isa MethodInstance && last_frame.linfo isa MethodInstance &&
+                frame.linfo.def isa Method && last_frame.linfo.def isa Method
+                m, last_m = frame.linfo.def::Method, last_frame.linfo.def::Method
+                params, last_params = Base.unwrap_unionall(m.sig).parameters, Base.unwrap_unionall(last_m.sig).parameters
+                if length(last_params) > length(params)
+                    issame = true
+                    for i = 1:length(params)
+                        issame &= params[i] == last_params[i]
+                    end
+                    if issame
+                        kept_frames[i] = false
+                    end
+                end
+            end
+
+            # TODO: Detect more cases that can be collapsed
         end
         last_frame = frame
     end

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -958,3 +958,15 @@ end
     end
     @test !occursin("#f#", sprint(Base.show_backtrace, bt))
 end
+
+g_collapse_pos(x, y=1.0, z=2.0) = error()
+bt = try
+    g_collapse_pos(1.0)
+catch
+    catch_backtrace()
+end
+bt_str = sprint(Base.show_backtrace, bt)
+@test occursin("g_collapse_pos(x::Float64, y::Float64, z::Float64)", bt_str)
+@test !occursin("g_collapse_pos(x::Float64)", bt_str)
+
+end

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -947,3 +947,14 @@ let buf = IOBuffer()
     Base.show_method_candidates(buf, Base.MethodError(isa, ()), pairs((a = 5,)))
     @test isempty(take!(buf))
 end
+
+@testset "stacktrace filter case 1" begin
+    f(g, a; kw...) = error();
+    @inline f(a; kw...) = f(identity, a; kw...);
+    bt = try
+        f(1)
+    catch
+        catch_backtrace()
+    end
+    @test !occursin("#f#", sprint(Base.show_backtrace, bt))
+end

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -948,16 +948,14 @@ let buf = IOBuffer()
     @test isempty(take!(buf))
 end
 
-@testset "stacktrace filter case 1" begin
-    f(g, a; kw...) = error();
-    @inline f(a; kw...) = f(identity, a; kw...);
-    bt = try
-        f(1)
-    catch
-        catch_backtrace()
-    end
-    @test !occursin("#f#", sprint(Base.show_backtrace, bt))
+f_internal_wrap(g, a; kw...) = error();
+@inline f_internal_wrap(a; kw...) = f_internal_wrap(identity, a; kw...);
+bt = try
+    f_internal_wrap(1)
+catch
+    catch_backtrace()
 end
+@test !occursin("#f_internal_wrap#", sprint(Base.show_backtrace, bt))
 
 g_collapse_pos(x, y=1.0, z=2.0) = error()
 bt = try

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -969,4 +969,23 @@ bt_str = sprint(Base.show_backtrace, bt)
 @test occursin("g_collapse_pos(x::Float64, y::Float64, z::Float64)", bt_str)
 @test !occursin("g_collapse_pos(x::Float64)", bt_str)
 
+g_collapse_kw(x; y=2.0) = error()
+bt = try
+    g_collapse_kw(1.0)
+catch
+    catch_backtrace()
 end
+bt_str = sprint(Base.show_backtrace, bt)
+@test occursin("g_collapse_kw(x::Float64; y::Float64)", bt_str)
+@test !occursin("g_collapse_kw(x::Float64)", bt_str)
+
+g_collapse_pos_kw(x, y=1.0; z=2.0) = error()
+bt = try
+    g_collapse_pos_kw(1.0)
+catch
+    catch_backtrace()
+end
+bt_str = sprint(Base.show_backtrace, bt)
+@test occursin("g_collapse_pos_kw(x::Float64, y::Float64; z::Float64)", bt_str)
+@test !occursin("g_collapse_pos_kw(x::Float64, y::Float64)", bt_str)
+@test !occursin("g_collapse_pos_kw(x::Float64)", bt_str)


### PR DESCRIPTION
Inspired by https://github.com/JuliaLang/julia/discussions/49044, I tried to make a small incremental improvement. This hides some frames that are automatically generated in `kw...` forwarding.

Running

```
julia> sum([])
```

and looking at the stacktrace we have before:

```
[12] #_sum#810
@ ./reducedim.jl:999 [inlined]
[13] _sum
@ ./reducedim.jl:999 [inlined]
[14] #_sum#809
@ ./reducedim.jl:998 [inlined]
[15] _sum
@ ./reducedim.jl:998 [inlined]
[16] #sum#807
@ ./reducedim.jl:994 [inlined]
[17] sum(a::Vector{Any})
@ Base ./reducedim.jl:994
[18] top-level scope
@ REPL[1]:1
```

and after:
```
 [11] _sum
    @ ./reducedim.jl:999 [inlined]
 [12] _sum
    @ ./reducedim.jl:998 [inlined]
 [13] sum(a::Vector{Any})
    @ Base ./reducedim.jl:994
 [14] top-level scope
    @ REPL[5]:1
```

The "MWE" for this is 

```
f(g, a; kw...) = error();
@inline f(a; kw...) = f(identity, a; kw...);
f(1)
``` 

which before shows as

```
julia> f(1)
ERROR: 
Stacktrace:
 [1] error()
   @ Base ./error.jl:44
 [2] f(g::Function, a::Int64; kw::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Main ./REPL[1]:1
 [3] f(g::Function, a::Int64)
   @ Main ./REPL[1]:1
 [4] #f#4
   @ ./REPL[2]:1 [inlined]
 [5] f(a::Int64)
   @ Main ./REPL[2]:1
 [6] top-level scope
   @ REPL[3]:1
```

and after (frame 4 above removed).

```
julia> f(1)
ERROR: 
Stacktrace:
 [1] error()
   @ Base ./error.jl:44
 [2] f(g::Function, a::Int64; kw::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Main ./REPL[7]:1
 [3] f(g::Function, a::Int64)
   @ Main ./REPL[7]:1
 [4] f(a::Int64)
   @ Main ./REPL[6]:1
 [5] top-level scope
   @ REPL[8]:1
```

-------------------------

There are more cases to detect, for example:

```
julia> g(x, y=1, z=2) = error()
g (generic function with 3 methods)

julia> g(1)
ERROR: 
Stacktrace:
 [1] error()
   @ Base ./error.jl:44
 [2] g(x::Int64, y::Int64, z::Int64)
   @ Main ./REPL[5]:1
 [3] g(x::Int64)
   @ Main ./REPL[5]:1
 [4] top-level scope
   @ REPL[6]:1
```

could maybe hide [3] (or [2]??) but it is also a bit hard to not also filter out "real" calls.