### PR TITLE
Optimize reverse(::CartesianIndices, dims=...)

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -523,7 +523,7 @@ module IteratorsMD
     Base.@constprop :aggressive function Base._reverse(iter::CartesianIndices, dims::Tuple{Vararg{Integer}})
         indices = iter.indices
         # use `sum` to force const fold
-        dimrev = ntuple(i -> sum(==(i), dims) == 1, Val(length(indices)))
+        dimrev = ntuple(i -> sum(==(i), dims; init = 0) == 1, Val(length(indices)))
         length(dims) == sum(dimrev) || throw(ArgumentError(Base.LazyString("invalid dimensions ", dims, " in reverse")))
         length(dims) == length(indices) && return Base._reverse(iter, :)
         indices′ = map((i, f) -> f ? reverse(i) : i, indices, dimrev)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -512,20 +512,27 @@ module IteratorsMD
     @inline function Base._reverse(iter::CartesianIndices, ::Colon)
         CartesianIndices(reverse.(iter.indices))
     end
+
     Base.@constprop :aggressive function Base._reverse(iter::CartesianIndices, dim::Integer)
         1 <= dim <= ndims(iter) || throw(ArgumentError(Base.LazyString("invalid dimension ", dim, " in reverse")))
+        ndims(iter) == 1 && return Base._reverse(iter, :)
         indices = iter.indices
         return CartesianIndices(Base.setindex(indices, reverse(indices[dim]), dim))
     end
+
     Base.@constprop :aggressive function Base._reverse(iter::CartesianIndices, dims::Tuple{Vararg{Integer}})
         indices = iter.indices
-        dimrev = ntuple(in(dims), Val(length(indices)))
+        # use `sum` to force const fold
+        dimrev = ntuple(i -> sum(==(i), dims) == 1, Val(length(indices)))
         length(dims) == sum(dimrev) || throw(ArgumentError(Base.LazyString("invalid dimensions ", dims, " in reverse")))
-        indices′ = foldl(dims; init = indices) do i, dim
-            Base.setindex(i, reverse(i[dim]), dim)
-        end
+        length(dims) == length(indices) && return Base._reverse(iter, :)
+        indices′ = map((i, f) -> f ? reverse(i) : i, indices, dimrev)
         return CartesianIndices(indices′)
     end
+
+    # fix ambiguity with array.jl:
+    Base._reverse(iter::CartesianIndices{1}, dims::Tuple{Integer}) =
+        Base._reverse(iter, first(dims))
 
     @inline function iterate(r::Reverse{<:CartesianIndices})
         iterfirst = last(r.itr)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1735,6 +1735,7 @@ end
     f2(x) = reverse(x; dims=(1, 3))
     @test @inferred(f1(A)) === CartesianIndices((2:-1:1, 3, 5:-1:1))
     @test @inferred(f2(A)) === CartesianIndices((2:-1:1, 3, 1:1:5))
+    @test @inferred(reverse(A; dims=())) === A
 end
 
 # issue 4228

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1714,10 +1714,10 @@ end
 
 @testset "reverse cartesian indices dim" begin
     A = CartesianIndices((2, 3, 5:-1:1))
-    @test reverse(A, dim=1) === CartesianIndices((2:-1:1, 3, 5:-1:1))
-    @test reverse(A, dim=3) === CartesianIndices((2, 3, 1:1:5))
-    @test_throws ArgumentError reverse(A, dim=0)
-    @test_throws ArgumentError reverse(A, dim=4)
+    @test reverse(A, dims=1) === CartesianIndices((2:-1:1, 3, 5:-1:1))
+    @test reverse(A, dims=3) === CartesianIndices((2, 3, 1:1:5))
+    @test_throws ArgumentError reverse(A, dims=0)
+    @test_throws ArgumentError reverse(A, dims=4)
 end
 
 @testset "reverse cartesian indices multiple dims" begin

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1705,6 +1705,38 @@ end
     @test istriu([1 2 0; 0 4 1])
 end
 
+#issue 49021
+@testset "reverse cartesian indices" begin
+    @test reverse(CartesianIndices((2, 3))) === CartesianIndices((2:-1:1, 3:-1:1))
+    @test reverse(CartesianIndices((2:5, 3:7))) === CartesianIndices((5:-1:2, 7:-1:3))
+    @test reverse(CartesianIndices((5:-1:2, 7:-1:3))) === CartesianIndices((2:1:5, 3:1:7))
+end
+
+@testset "reverse cartesian indices dim" begin
+    A = CartesianIndices((2, 3, 5:-1:1))
+    @test reverse(A, dim=1) === CartesianIndices((2:-1:1, 3, 5:-1:1))
+    @test reverse(A, dim=3) === CartesianIndices((2, 3, 1:1:5))
+    @test_throws ArgumentError reverse(A, dim=0)
+    @test_throws ArgumentError reverse(A, dim=4)
+end
+
+@testset "reverse cartesian indices multiple dims" begin
+    A = CartesianIndices((2, 3, 5:-1:1))
+    @test reverse(A, dims=(1, 3)) === CartesianIndices((2:-1:1, 3, 1:1:5))
+    @test reverse(A, dims=(3, 1)) === CartesianIndices((2:-1:1, 3, 1:1:5))
+    @test_throws ArgumentError reverse(A, dims=(1, 2, 4))
+    @test_throws ArgumentError reverse(A, dims=(0, 1, 2))
+    @test_throws ArgumentError reverse(A, dims=(1, 1))
+end
+
+@testset "stability of const propagation" begin
+    A = CartesianIndices((2, 3, 5:-1:1))
+    f1(x) = reverse(x; dims=1)
+    f2(x) = reverse(x; dims=(1, 3))
+    @test @inferred(f1(A)) === CartesianIndices((2:-1:1, 3, 5:-1:1))
+    @test @inferred(f2(A)) === CartesianIndices((2:-1:1, 3, 1:1:5))
+end
+
 # issue 4228
 let A = [[i i; i i] for i=1:2]
     @test cumsum(A) == Any[[1 1; 1 1], [3 3; 3 3]]


### PR DESCRIPTION
Multidimensional.jl didn't have support for reverse(::CartesianIndices, dims=...) therefore previously this would happen:
```
julia> I = CartesianIndices((3,4))
CartesianIndices((3, 4))

julia> reverse(I) # good!
CartesianIndices((3:-1:1, 4:-1:1))

julia> reverse(I, dims=1) # bad!
3×4 Matrix{CartesianIndex{2}}:
 CartesianIndex(3, 1)  CartesianIndex(3, 2)  …  CartesianIndex(3, 4)
 CartesianIndex(2, 1)  CartesianIndex(2, 2)     CartesianIndex(2, 4)
 CartesianIndex(1, 1)  CartesianIndex(1, 2)     CartesianIndex(1, 4)
```
And now:
```
julia> I = CartesianIndices((3,4))
CartesianIndices((3, 4))

julia> reverse(I) # good!
CartesianIndices((3:-1:1, 4:-1:1))

julia> reverse(I, dims=1) # good!
CartesianIndices((3:-1:1, 4))

julia> reverse(I, dims=(1,2)) # good!
CartesianIndices((3:-1:1, 4:-1:1))
```

Fixes: #49021 