### PR TITLE
Add iterator for method specializations

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1119,10 +1119,10 @@ specializations(m::Method) = MethodSpecializations(isdefined(m, :specializations
 function iterate(specs::MethodSpecializations)
     s = specs.specializations
     s === nothing && return nothing
-    isa(s, Core.MethodInstance) && return (s, false)
+    isa(s, Core.MethodInstance) && return (s, nothing)
     return iterate(specs, 0)
 end
-iterate(specs::MethodSpecializations, ::Bool) = nothing
+iterate(specs::MethodSpecializations, ::Nothing) = nothing
 function iterate(specs::MethodSpecializations, i::Int)
     s = specs.specializations
     n = length(s)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1107,6 +1107,33 @@ function visit(f, d::Core.TypeMapEntry)
     end
     nothing
 end
+struct MethodSpecializations
+    specializations::Union{Nothing, Core.MethodInstance, Core.SimpleVector}
+end
+"""
+    specializations(m::Method) → itr
+
+Return an iterator `itr` of all compiler-generated specializations of `m`.
+"""
+specializations(m::Method) = MethodSpecializations(isdefined(m, :specializations) ? m.specializations : nothing)
+function iterate(specs::MethodSpecializations)
+    s = specs.specializations
+    s === nothing && return nothing
+    isa(s, Core.MethodInstance) && return (s, false)
+    return iterate(specs, 0)
+end
+iterate(specs::MethodSpecializations, ::Bool) = nothing
+function iterate(specs::MethodSpecializations, i::Int)
+    s = specs.specializations
+    n = length(s)
+    i >= n && return nothing
+    item = nothing
+    while i < n && item === nothing
+        item = s[i+=1]
+    end
+    item === nothing && return nothing
+    return (item, i)
+end
 
 function length(mt::Core.MethodTable)
     n = 0

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1124,7 +1124,7 @@ function iterate(specs::MethodSpecializations)
 end
 iterate(specs::MethodSpecializations, ::Nothing) = nothing
 function iterate(specs::MethodSpecializations, i::Int)
-    s = specs.specializations
+    s = specs.specializations::Core.SimpleVector
     n = length(s)
     i >= n && return nothing
     item = nothing

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1134,6 +1134,7 @@ function iterate(specs::MethodSpecializations, i::Int)
     item === nothing && return nothing
     return (item, i)
 end
+length(specs::MethodSpecializations) = count(Returns(true), specs)
 
 function length(mt::Core.MethodTable)
     n = 0

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -584,7 +584,7 @@ h_vararg(x::Vararg{Any, N}) where {N} = tuple(x...)
 Note that [`@code_typed`](@ref) and friends will always show you specialized code, even if Julia
 would not normally specialize that method call. You need to check the
 [method internals](@ref ast-lowered-method) if you want to see whether specializations are generated
-when argument types are changed, i.e., if `(@which f(...)).specializations` contains specializations
+when argument types are changed, i.e., if `Base.specializations(@which f(...))` contains specializations
 for the argument in question.
 
 ## Break functions into multiple definitions

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1039,3 +1039,10 @@ ambig_effects_test(a, b) = 1
 end
 
 @test Base._methods_by_ftype(Tuple{}, -1, Base.get_world_counter()) == Any[]
+
+@testset "specializations" begin
+    f(x) = 1
+    f(1)
+    f("hello")
+    @test length(Base.specializations(only(methods(f)))) == 2
+end

--- a/test/worlds.jl
+++ b/test/worlds.jl
@@ -233,21 +233,10 @@ function method_instance(f, types=Base.default_tt(f))
     m = which(f, types)
     inst = nothing
     tt = Base.signature_type(f, types)
-    specs = m.specializations
-    if isa(specs, Core.SimpleVector)
-        for i = 1:length(specs)
-            mi = specs[i]
-            if mi isa Core.MethodInstance
-                if mi.specTypes <: tt && tt <: mi.specTypes
-                    inst = mi
-                    break
-                end
-            end
-        end
-    else
-        mi = specs::Core.MethodInstance
-        if mi.specTypes === tt
+    for mi in Base.specializations(m)
+        if mi.specTypes <: tt && tt <: mi.specTypes
             inst = mi
+            break
         end
     end
     return inst


### PR DESCRIPTION
There have been longstanding reasons to want an API for extracting all extant specializations of a method, but this is even more true after #49071.