### PR TITLE
Mark llvm::Any::TypeId as global in julia.expmap

### DIFF
--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -35,6 +35,9 @@
     LLVMExtra*;
     llvmGetPassPluginInfo;
 
+    /* Make visible so that linker will merge duplicate definitions across DSO boundaries */
+    _ZN4llvm3Any6TypeId*;
+
     /* freebsd */
     environ;
     __progname;


### PR DESCRIPTION
The dynamic linker needs to unify `llvm::Any::TypeId` across DSOs. In our case
`libjulia-codegen` and `libLLVM`.

See https://github.com/llvm/llvm-project/blob/2bc4c3e920ee078ef2879b00c40440e0867f0b9e/llvm/include/llvm/ADT/Any.h#L30

Fixes: #49121
