### PR TITLE
minor follow up on #48996

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -331,9 +331,8 @@ isvalid(s::String, i::Int) = checkbounds(Bool, s, i) && thisind(s, i) == i
 isascii(s::String) = isascii(codeunits(s))
 
 # don't assume effects for general integers since we cannot know their implementation
-@assume_effects :foldable function repeat(c::Char, r::BitInteger)
-    @invoke repeat(c, r::Integer)
-end
+@assume_effects :foldable repeat(c::Char, r::BitInteger) = @invoke repeat(c, r::Integer)
+
 """
     repeat(c::AbstractChar, r::Integer) -> String
 
@@ -347,7 +346,7 @@ julia> repeat('A', 3)
 ```
 """
 function repeat(c::AbstractChar, r::Integer)
-    c = Char(c)
+    c = Char(c)::Char
     r == 0 && return ""
     r < 0 && throw(ArgumentError("can't repeat a character $r times"))
     u = bswap(reinterpret(UInt32, c))

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -331,7 +331,7 @@ isvalid(s::String, i::Int) = checkbounds(Bool, s, i) && thisind(s, i) == i
 isascii(s::String) = isascii(codeunits(s))
 
 # don't assume effects for general integers since we cannot know their implementation
-@assume_effects :foldable repeat(c::Char, r::BitInteger) = @invoke repeat(c, r::Integer)
+@assume_effects :foldable repeat(c::Char, r::BitInteger) = @invoke repeat(c::Char, r::Integer)
 
 """
     repeat(c::AbstractChar, r::Integer) -> String

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -260,7 +260,7 @@ end
 
 # don't assume effects for general integers since we cannot know their implementation
 # not nothrow because r<0 throws
-@assume_effects :foldable repeat(s::String, r::BitInteger) = @invoke repeat(s, r::Integer)
+@assume_effects :foldable repeat(s::String, r::BitInteger) = @invoke repeat(s::String, r::Integer)
 
 function repeat(s::Union{String, SubString{String}}, r::Integer)
     r < 0 && throw(ArgumentError("can't repeat a string $r times"))

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -227,7 +227,7 @@ end
 # nothrow needed here because for v in a can't prove the indexing is inbounds.
 @assume_effects :foldable :nothrow string(a::Union{Char, String, Symbol}...) = _string(a...)
 
-string(a::SubString{String}...) = _string(a...)
+string(a::Union{Char, String, SubString{String}, Symbol}...) = _string(a...)
 
 function _string(a::Union{Char, String, SubString{String}, Symbol}...)
     n = 0

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -225,13 +225,9 @@ end
 end
 
 # nothrow needed here because for v in a can't prove the indexing is inbounds.
-@assume_effects :foldable :nothrow function string(a::Union{Char, String, Symbol}...)
-    _string(a...)
-end
+@assume_effects :foldable :nothrow string(a::Union{Char, String, Symbol}...) = _string(a...)
 
-function string(a::Union{Char, String, SubString{String}, Symbol}...)
-    _string(a...)
-end
+string(a::SubString{String}...) = _string(a...)
 
 function _string(a::Union{Char, String, SubString{String}, Symbol}...)
     n = 0
@@ -264,9 +260,7 @@ end
 
 # don't assume effects for general integers since we cannot know their implementation
 # not nothrow because r<0 throws
-@assume_effects :foldable function repeat(s::String, r::BitInteger)
-    @invoke repeat(s, r::Integer)
-end
+@assume_effects :foldable repeat(s::String, r::BitInteger) = @invoke repeat(s, r::Integer)
 
 function repeat(s::Union{String, SubString{String}}, r::Integer)
     r < 0 && throw(ArgumentError("can't repeat a string $r times"))


### PR DESCRIPTION
- removed unnecessary `Union`-signature
- use one-liner definition when applicable
- add type assertion to make it more robust against invalidation