### PR TITLE
move out LazyArtifacts from the sysimage

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -76,9 +76,6 @@ let
 
         # 6-depth packages
         :Pkg,
-
-        # 7-depth packages
-        :LazyArtifacts,
     ]
     # PackageCompiler can filter out stdlibs so it can be empty
     maxlen = maximum(textwidth.(string.(stdlibs)); init=0)

--- a/pkgimage.mk
+++ b/pkgimage.mk
@@ -117,7 +117,7 @@ $(eval $(call sysimg_builder,Downloads,ArgTools FileWatching LibCURL NetworkOpti
 $(eval $(call sysimg_builder,Pkg,Dates LibGit2 Libdl Logging Printf Random SHA UUIDs)) # Markdown REPL
 
 # 7-depth packages
-$(eval $(call sysimg_builder,LazyArtifacts,Artifacts Pkg))
+$(eval $(call pkgimg_builder,LazyArtifacts,Artifacts Pkg))
 
 $(eval $(call pkgimg_builder,SparseArrays,Libdl LinearAlgebra Random Serialization))
 # SuiteSparse_jll

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -396,7 +396,7 @@ precompile_test_harness(false) do dir
                  end for s in
                 [:ArgTools, :Artifacts, :Base64, :CompilerSupportLibraries_jll, :CRC32c, :Dates,
                  :Distributed, :Downloads, :FileWatching, :Future, :InteractiveUtils, :libblastrampoline_jll,
-                 :LazyArtifacts, :LibCURL, :LibCURL_jll, :LibGit2, :Libdl, :LinearAlgebra,
+                 :LibCURL, :LibCURL_jll, :LibGit2, :Libdl, :LinearAlgebra,
                  :Logging, :Markdown, :Mmap, :MozillaCACerts_jll, :NetworkOptions, :OpenBLAS_jll, :Pkg, :Printf,
                  :p7zip_jll, :REPL, :Random, :SHA, :Serialization, :SharedArrays, :Sockets,
                  :TOML, :Tar, :Test, :UUIDs, :Unicode,


### PR DESCRIPTION
Doesn't seem to be a need to have this in the sysimage, it loads pretty much instantly and it blocks Pkg (which it depends on) from potentially being moved out in the future. 