### PR TITLE
move out SharedArrays from the sysimage

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -64,7 +64,6 @@ let
 
         # 3-depth packages
         :REPL,
-        :SharedArrays,
         :TOML,
         :Test,
 

--- a/pkgimage.mk
+++ b/pkgimage.mk
@@ -103,7 +103,7 @@ $(eval $(call sysimg_builder,UUIDs,Random SHA))
  # LibGit2_jll
 $(eval $(call pkgimg_builder,LibCURL_jll,LibSSH2_jll nghttp2_jll MbedTLS_jll Zlib_jll Artifacts Libdl))
 $(eval $(call sysimg_builder,REPL,InteractiveUtils Markdown Sockets Unicode))
-$(eval $(call sysimg_builder,SharedArrays,Distributed Mmap Random Serialization))
+$(eval $(call pkgimg_builder,SharedArrays,Distributed Mmap Random Serialization))
 $(eval $(call sysimg_builder,TOML,Dates))
 $(eval $(call sysimg_builder,Test,Logging Random Serialization InteractiveUtils))
 

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -398,7 +398,7 @@ precompile_test_harness(false) do dir
                  :Distributed, :Downloads, :FileWatching, :Future, :InteractiveUtils, :libblastrampoline_jll,
                  :LazyArtifacts, :LibCURL, :LibCURL_jll, :LibGit2, :Libdl, :LinearAlgebra,
                  :Logging, :Markdown, :Mmap, :MozillaCACerts_jll, :NetworkOptions, :OpenBLAS_jll, :Pkg, :Printf,
-                 :p7zip_jll, :REPL, :Random, :SHA, :Serialization, :SharedArrays, :Sockets,
+                 :p7zip_jll, :REPL, :Random, :SHA, :Serialization, :Sockets,
                  :TOML, :Tar, :Test, :UUIDs, :Unicode,
                  :nghttp2_jll]
             ),


### PR DESCRIPTION
Loads fast anyway:

```julia
julia> @time using SharedArrays
  0.008422 seconds (14.19 k allocations: 978.284 KiB)
```