### PR TITLE
Intersection: fix incorrect `Vararg` length.

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1069,7 +1069,9 @@ constrain_length:
         }
 
         if (ylv) {
-            if (ylv->depth0 != e->invdepth || ylv->occurs_inv)
+            if (ylv->depth0 != e->invdepth ||
+                ylv->lb != jl_bottom_type ||
+                ylv->ub != (jl_value_t *)jl_any_type)
                 return 0;
             ylv->intvalued = 1;
         }
@@ -2518,6 +2520,7 @@ static int check_unsat_bound(jl_value_t *t, jl_tvar_t *v, jl_stenv_t *e) JL_NOTS
     return 0;
 }
 
+//TODO: This doesn't work for nested `Tuple`.
 static int has_free_vararg_length(jl_value_t *a, jl_stenv_t *e) {
     if (jl_is_unionall(a))
         a = jl_unwrap_unionall(a);

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2389,8 +2389,16 @@ static jl_value_t *bound_var_below(jl_tvar_t *tv, jl_varbinding_t *bb, jl_stenv_
             return bb->lb;
         return jl_box_long(blb - offset);
     }
-    if (offset > 0)
-        return NULL;
+    if (offset > 0) {
+        if (bb->innervars == NULL)
+            bb->innervars = jl_alloc_array_1d(jl_array_any_type, 0);
+        jl_value_t *ntv = NULL;
+        JL_GC_PUSH1(&ntv);
+        ntv = (jl_value_t *)jl_new_typevar(tv->name, jl_bottom_type, (jl_value_t *)jl_any_type);
+        jl_array_ptr_1d_push(bb->innervars, ntv);
+        JL_GC_POP();
+        return ntv;
+    }
     return (jl_value_t*)tv;
 }
 
@@ -2520,26 +2528,6 @@ static int check_unsat_bound(jl_value_t *t, jl_tvar_t *v, jl_stenv_t *e) JL_NOTS
     return 0;
 }
 
-//TODO: This doesn't work for nested `Tuple`.
-static int has_free_vararg_length(jl_value_t *a, jl_stenv_t *e) {
-    if (jl_is_unionall(a))
-        a = jl_unwrap_unionall(a);
-    if (jl_is_datatype(a) && jl_is_tuple_type((jl_datatype_t *)a)) {
-        size_t lx = jl_nparams((jl_datatype_t *)a);
-        if (lx > 0) {
-            jl_value_t *la = jl_tparam((jl_datatype_t *)a, lx-1);
-            if (jl_is_vararg(la)) {
-                jl_value_t *len = jl_unwrap_vararg_num((jl_vararg_t *)la);
-                // return 1 if we meet a vararg with Null length
-                if (!len) return 1;
-                // or a typevar not in the current env.
-                if (jl_is_typevar(len))
-                    return lookup(e, (jl_tvar_t *)len) == NULL;
-            }
-        }
-    }
-    return 0;
-}
 
 static jl_value_t *intersect_var(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, int8_t R, int param)
 {
@@ -2583,11 +2571,6 @@ static jl_value_t *intersect_var(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, int
                 JL_GC_POP();
                 return jl_bottom_type;
             }
-            if (jl_is_uniontype(ub) && !jl_is_uniontype(a)) {
-                bb->ub = ub;
-                bb->lb = jl_bottom_type;
-                ub = (jl_value_t*)b;
-            }
         }
         if (ub != (jl_value_t*)b) {
             if (jl_has_free_typevars(ub)) {
@@ -2597,12 +2580,11 @@ static jl_value_t *intersect_var(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, int
                 }
             }
             bb->ub = ub;
-            // We get a imprecise Tuple here. Don't change `lb` and return the typevar directly.
-            if (has_free_vararg_length(ub, e) && !has_free_vararg_length(a, e)) {
-                JL_GC_POP();
-                return (jl_value_t*)b;
-            }
-            bb->lb = ub;
+            if ((jl_is_uniontype(ub) && !jl_is_uniontype(a)) ||
+                (jl_is_unionall(ub) && !jl_is_unionall(a)))
+                ub = (jl_value_t*)b;
+            else
+                bb->lb = ub;
         }
         JL_GC_POP();
         return ub;

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2415,7 +2415,7 @@ abstract type P47654{A} end
     # issue 22123
     t1 = Ref{Ref{Ref{Union{Int64, T}}} where T}
     t2 = Ref{Ref{Ref{Union{T, S}}} where T} where S
-    @test_broken t1 <: t2
+    @test t1 <: t2
 
     # issue 21153
     @test_broken (Tuple{T1,T1} where T1<:(Val{T2} where T2)) <: (Tuple{Val{S},Val{S}} where S)

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2218,6 +2218,12 @@ end
 # Example from pr#39098
 @testintersect(NTuple, Tuple{Any,Vararg}, Tuple{T, Vararg{T}} where {T})
 
+let S = Val{T} where T<:Tuple{Tuple{Any, Vararg{Any}}}
+    T = Val{Tuple{Tuple{Vararg{Any, N}}}} where {N}
+    @testintersect(S, T, !Union{})
+    @test_broken typeintersect(S, T) != Val{Tuple{Tuple{Any, Vararg{Any}}}}
+end
+
 let A = Pair{NTuple{N, Int}, Val{N}} where N,
     Bs = (Pair{<:Tuple{Int, Vararg{Int}}, <:Val},
           Pair{Tuple{Int, Vararg{Int,N1}}, Val{N2}} where {N1,N2})

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1043,11 +1043,7 @@ function test_intersection()
                    Type{Tuple{Int,T}} where T<:Integer)
     @testintersect(Type{<:Tuple{Any,Vararg{Any}}},
                    Type{Tuple{Vararg{Int,N}}} where N,
-                   !Union{})
-
-    @test typeintersect(Type{<:Tuple{Any,Vararg{Any}}}, Type{Tuple{Vararg{Int,N}}} where N) != Type{Tuple{Int,Vararg{Int}}}
-    @test_broken typeintersect(Type{<:Tuple{Any,Vararg{Any}}}, Type{Tuple{Vararg{Int,N}}} where N) == Type{Tuple{Int,Vararg{Int,N}}} where N
-    @test_broken typeintersect(Type{<:Tuple{Any,Vararg{Any}}}, Type{Tuple{Vararg{Int,N}}} where N) != Type{<:Tuple{Int,Vararg{Int}}}
+                   Type{Tuple{Int,Vararg{Int,N}}} where N)
 
     @testintersect(Type{<:Array},
                    Type{AbstractArray{T}} where T,
@@ -2206,23 +2202,19 @@ let A = Pair{NTuple{N, Int}, NTuple{N, Int}} where N,
     Bs = (Pair{<:Tuple{Int, Vararg{Int}}, <:Tuple{Int, Int, Vararg{Int}}},
           Pair{Tuple{Int, Vararg{Int,N1}}, Tuple{Int, Int, Vararg{Int,N2}}} where {N1,N2},
           Pair{<:Tuple{Int, Vararg{Int,N}} where {N}, <:Tuple{Int, Int, Vararg{Int,N}} where {N}})
-    Cerr = Pair{Tuple{Int, Vararg{Int, N}}, Tuple{Int, Int, Vararg{Int, N}}} where {N}
-    for B in Bs
-        C = typeintersect(A, B)
-        @test C == typeintersect(B, A) != Union{}
-        @test C != Cerr
-        @test_broken C != B
+    Cs = (Bs[2], Bs[2], Bs[3])
+    for (B, C) in zip(Bs, Cs)
+        # TODO: The ideal result is Pair{Tuple{Int, Int, Vararg{Int, N}}, Tuple{Int, Int, Vararg{Int, N}}} where {N}
+        @testintersect(A, B, C)
     end
 end
 
 # Example from pr#39098
 @testintersect(NTuple, Tuple{Any,Vararg}, Tuple{T, Vararg{T}} where {T})
 
-let S = Val{T} where T<:Tuple{Tuple{Any, Vararg{Any}}}
-    T = Val{Tuple{Tuple{Vararg{Any, N}}}} where {N}
-    @testintersect(S, T, !Union{})
-    @test_broken typeintersect(S, T) != Val{Tuple{Tuple{Any, Vararg{Any}}}}
-end
+@testintersect(Val{T} where T<:Tuple{Tuple{Any, Vararg{Any}}},
+               Val{Tuple{Tuple{Vararg{Any, N}}}} where {N},
+               Val{Tuple{Tuple{Any, Vararg{Any, N}}}} where {N})
 
 let A = Pair{NTuple{N, Int}, Val{N}} where N,
     Bs = (Pair{<:Tuple{Int, Vararg{Int}}, <:Val},


### PR DESCRIPTION
This PR fixes the [bug](https://s3.amazonaws.com/julialang-reports/nanosoldier/pkgeval/by_hash/be94b87_vs_ceffaee/GaussianMixtureAlignment.primary.log) in `GaussianMixtureAlignment`.

The bug was caused by the code clean of `intvalued`.
After https://github.com/JuliaLang/julia/commit/e528b304f02cc1411fab3085b95b95f132605e86, intersection would increase `N`‘s `occurs_inv` when compare `Vararg{Any}` and `Vararg{Any,N}` (for reintersection).
Thus we'd better check if `N` is unbounded instead (see 48756fd45008ec8f30750a1b08b16d522c37e7c7)

075f88db27352c37f7aec290c0cb7fb7339bd0de was added to fix the incorrect intersection result by inserting `innervar` rather than return `NULL`.

The 1st commit is sperated from #48555. It makes our subtyping offset compatable thus we can put more skipped check back.
Since the previous PkgEval is quite clean, I think it's ok to put it here.

