### PR TITLE
move out Test from the sysimage

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -65,7 +65,6 @@ let
         # 3-depth packages
         :REPL,
         :TOML,
-        :Test,
 
         # 4-depth packages
         :LibCURL,

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -199,39 +199,6 @@ if Libdl !== nothing
     """
 end
 
-Test = get(Base.loaded_modules,
-          Base.PkgId(Base.UUID("8dfed614-e22c-5e08-85e1-65c5234f0b40"), "Test"),
-          nothing)
-if Test !== nothing
-    hardcoded_precompile_statements *= """
-    precompile(Tuple{typeof(Test.do_test), Test.ExecutionResult, Any})
-    precompile(Tuple{typeof(Test.testset_beginend_call), Tuple{String, Expr}, Expr, LineNumberNode})
-    precompile(Tuple{Type{Test.DefaultTestSet}, String})
-    precompile(Tuple{Type{Test.DefaultTestSet}, AbstractString})
-    precompile(Tuple{Core.kwftype(Type{Test.DefaultTestSet}), Any, Type{Test.DefaultTestSet}, AbstractString})
-    precompile(Tuple{typeof(Test.finish), Test.DefaultTestSet})
-    precompile(Tuple{typeof(Test.eval_test), Expr, Expr, LineNumberNode, Bool})
-    precompile(Tuple{typeof(Test._inferred), Expr, Module})
-    precompile(Tuple{typeof(Test.push_testset), Test.DefaultTestSet})
-    precompile(Tuple{typeof(Test.get_alignment), Test.DefaultTestSet, Int})
-    precompile(Tuple{typeof(Test.get_test_result), Any, Any})
-    precompile(Tuple{typeof(Test.do_test_throws), Test.ExecutionResult, Any, Any})
-    precompile(Tuple{typeof(Test.print_counts), Test.DefaultTestSet, Int, Int, Int, Int, Int, Int, Int})
-    precompile(Tuple{typeof(Test._check_testset), Type, Expr})
-    precompile(Tuple{typeof(Test.test_expr!), Any, Any})
-    precompile(Tuple{typeof(Test.test_expr!), Any, Any, Vararg{Any, 100}})
-    precompile(Tuple{typeof(Test.pop_testset)})
-    precompile(Tuple{typeof(Test.match_logs), Function, Tuple{Symbol, Regex}})
-    precompile(Tuple{typeof(Test.match_logs), Function, Tuple{String, Regex}})
-    precompile(Tuple{typeof(Base.CoreLogging.shouldlog), Test.TestLogger, Base.CoreLogging.LogLevel, Module, Symbol, Symbol})
-    precompile(Tuple{typeof(Base.CoreLogging.handle_message), Test.TestLogger, Base.CoreLogging.LogLevel, String, Module, Symbol, Symbol, String, Int})
-    precompile(Tuple{typeof(Test.detect_ambiguities), Any})
-    precompile(Tuple{typeof(Test.collect_test_logs), Function})
-    precompile(Tuple{typeof(Test.do_broken_test), Test.ExecutionResult, Any})
-    precompile(Tuple{typeof(Test.record), Test.DefaultTestSet, Union{Test.Error, Test.Fail}})
-    precompile(Tuple{typeof(Test.filter_errors), Test.DefaultTestSet})
-    """
-end
 
 const JULIA_PROMPT = "julia> "
 const PKG_PROMPT = "pkg> "

--- a/pkgimage.mk
+++ b/pkgimage.mk
@@ -105,7 +105,7 @@ $(eval $(call pkgimg_builder,LibCURL_jll,LibSSH2_jll nghttp2_jll MbedTLS_jll Zli
 $(eval $(call sysimg_builder,REPL,InteractiveUtils Markdown Sockets Unicode))
 $(eval $(call pkgimg_builder,SharedArrays,Distributed Mmap Random Serialization))
 $(eval $(call sysimg_builder,TOML,Dates))
-$(eval $(call sysimg_builder,Test,Logging Random Serialization InteractiveUtils))
+$(eval $(call pkgimg_builder,Test,Logging Random Serialization InteractiveUtils))
 
 # 4-depth packages
 $(eval $(call sysimg_builder,LibCURL,LibCURL_jll MozillaCACerts_jll))

--- a/stdlib/Distributed/test/splitrange.jl
+++ b/stdlib/Distributed/test/splitrange.jl
@@ -28,6 +28,8 @@ isdefined(Main, :OffsetArrays) || @eval Main @everywhere include(joinpath($(BASE
 using .Main.OffsetArrays
 
 oa = OffsetArray([123, -345], (-2,))
+
+@everywhere using Test
 @sync @distributed for i in eachindex(oa)
     @test i ∈ (-1, 0)
 end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -2096,5 +2096,6 @@ function _check_bitarray_consistency(B::BitArray{N}) where N
 end
 
 include("logging.jl")
+include("precompile.jl")
 
 end # module

--- a/stdlib/Test/src/precompile.jl
+++ b/stdlib/Test/src/precompile.jl
@@ -1,0 +1,9 @@
+redirect_stdout(devnull) do
+    @testset "example" begin
+        @test 1 == 1
+        @test_throws ErrorException error()
+        @test_logs (:info, "Doing foo with n=2") @info "Doing foo with n=2"
+        @test_broken 1 == 2
+        @test 1 ≈ 1.0000000000000001
+    end
+end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1089,15 +1089,14 @@ end
     for (P, D, C, I, O) in Iterators.product(0:1, 0:2, 0:2, 0:1, 0:3)
         julia = joinpath(Sys.BINDIR, Base.julia_exename())
         script = """
-        using Test
         let
             cf = Base.CacheFlags()
             opts = Base.JLOptions()
-            @test cf.use_pkgimages == opts.use_pkgimages == $P
-            @test cf.debug_level == opts.debug_level == $D
-            @test cf.check_bounds == opts.check_bounds == $C
-            @test cf.inline == opts.can_inline == $I
-            @test cf.opt_level == opts.opt_level == $O
+            cf.use_pkgimages == opts.use_pkgimages == $P || error("use_pkgimages")
+            cf.debug_level == opts.debug_level == $D || error("debug_level")
+            cf.check_bounds == opts.check_bounds == $C || error("check_bounds")
+            cf.inline == opts.can_inline == $I || error("inline")
+            cf.opt_level == opts.opt_level == $O || error("opt_level")
         end
         """
         cmd = `$julia $(pkgimage(P)) $(opt_level(O)) $(debug_level(D)) $(check_bounds(C)) $(inline(I)) -e $script`


### PR DESCRIPTION
There doesn't seem to be any noticeable latency from this. Using a test file:

```julia
using Test
@testset "test" begin
    @test 1==1
end
```

With this PR I get:

```
❯ time ./julia --startup-file=no time_test.jl  
Test Summary: | Pass  Total  Time
test          |    1      1  0.0s
./julia --startup-file=no time_test.jl  0.42s user 0.77s system 447% cpu 0.266 total
```

and on 1.9:

```
❯ time julia --startup-file=no time_test.jl 
Test Summary: | Pass  Total  Time
test          |    1      1  0.0s
julia --startup-file=no time_test.jl  0.40s user 0.75s system 511% cpu 0.225 total
```

