### PR TITLE
restrict codeunit effects slightly

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -113,7 +113,8 @@ pointer(s::String, i::Integer) = pointer(s) + Int(i)::Int - 1
 ncodeunits(s::String) = Core.sizeof(s)
 codeunit(s::String) = UInt8
 
-@assume_effects :foldable @inline function codeunit(s::String, i::Integer)
+function codeunit(s::String, i::Integer) = codeunit(s, Int(i)
+@assume_effects :foldable @inline function codeunit(s::String, i::Int)
     @boundscheck checkbounds(s, i)
     b = GC.@preserve s unsafe_load(pointer(s, i))
     return b

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -113,7 +113,7 @@ pointer(s::String, i::Integer) = pointer(s) + Int(i)::Int - 1
 ncodeunits(s::String) = Core.sizeof(s)
 codeunit(s::String) = UInt8
 
-function codeunit(s::String, i::Integer) = codeunit(s, Int(i)
+codeunit(s::String, i::Integer) = codeunit(s, Int(i))
 @assume_effects :foldable @inline function codeunit(s::String, i::Int)
     @boundscheck checkbounds(s, i)
     b = GC.@preserve s unsafe_load(pointer(s, i))


### PR DESCRIPTION
restrict the effect of codeunit to `Int` rather than `Integer`. Found by https://github.com/JuliaLang/julia/pull/48996#discussion_r1146978460_