### PR TITLE
ensure C++ does not free the DebugRegistry while we are using it

### DIFF
--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -41,10 +41,10 @@ using namespace llvm;
 #include "julia_assert.h"
 #include "debug-registry.h"
 
-static JITDebugInfoRegistry DebugRegistry;
+static JITDebugInfoRegistry *DebugRegistry = new JITDebugInfoRegistry;
 
 static JITDebugInfoRegistry &getJITDebugRegistry() JL_NOTSAFEPOINT {
-    return DebugRegistry;
+    return *DebugRegistry;
 }
 
 struct debug_link_info {


### PR DESCRIPTION
The C++ destructor design tend to cause lifetime problems at exit, so we use `new` to implicitly leak the object. Seen to possibly cause problems with printing a backtrace after the worker was killed in https://buildkite.com/julialang/julia-master/builds/22082#018701b4-6c16-4559-afdd-e33ece5a6a00. Addresses a regressions caused by 428d242f9b8, noted by @pchintalapudi.