### PR TITLE
feat: support match(f, regex, s) interface

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -402,6 +402,26 @@ true
 """
 function match end
 
+"""
+    match(f, re::Regex, s::AbstractString)
+
+Search for the first match of the regular expression `re` in `s` and return the result of
+calling `f(m)`, where `m` is a [`RegexMatch`](@ref) object containing the match, or nothing if
+the match failed. The matching substring can be retrieved by accessing `m.match` and the
+captured sequences can be retrieved by accessing `m.captures`.
+
+# Examples
+```jldoctest
+julia> match(m -> m.captures[1], r"a(.)a", "cabac")
+"b"
+```
+"""
+function match(f, re::Regex, s::AbstractString)
+    m = match(re, s)
+    m === nothing && return nothing
+    return f(m)
+end
+
 function match(re::Regex, str::Union{SubString{String}, String}, idx::Integer,
                add_opts::UInt32=UInt32(0))
     compile(re)


### PR DESCRIPTION
This might be a bit simple, but I find it's quite convenient to have this and saves some ~code~ worry when one wants to use the captured string to generate something and instead of having a new variable `m` in current scope, one can just use the name `m` in a different scope, e.g

```julia
function some_other_function(s)
   match(regex, s) do m
      # do some generation
      return my_long_results
   end
end
```

instead of 

```julia
function some_other_function(s)
   # some other code that has a variable m
   m = match(regex, s)
   isnothing(m) && return
   # do some generation that
   return my_long_results
end
```

a more concrete example

```julia
function slurm_time(time::String)
    match(r"(\d+)-(\d+):(\d+):(\d+)", time) do m
        (
            days=parse(Int, m[1]),
            hours=parse(Int, m[2]),
            minutes=parse(Int, m[3]),
            seconds=parse(Int, m[4]),
        )
    end
end
```

I'll add some tests if people like this, and credit to a random copilot auto-complete suggestion that doesn't work