### PR TITLE
simplify default outer constructor for struct

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -788,7 +788,7 @@
                  (map (lambda (b) (cons 'var-bounds b)) bounds))
                (block
                 ,@locs
-                (call (curly ,name ,@params) ,@field-names)))))
+                (new (curly ,name ,@params) ,@field-names)))))
 
 (define (num-non-varargs args)
   (count (lambda (a) (not (vararg? a))) args))


### PR DESCRIPTION
Removes the `convert` calls in new for default outer constructor. I don't expect this will have a visible difference in behavior, but may help avoid some edges and specializations improving latency.