### PR TITLE
Subtype: Add a fastpath for nested constructor with identity name.

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1472,7 +1472,9 @@ static int forall_exists_equal(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)
 
     if (jl_is_datatype(x) && jl_is_datatype(y)) {
         // Fastpath for nested constructor. Skip the unneeded `>:` check.
-        // Note: this is valid because the normal path checks `>:` locally.
+        // Note: since there is no changes to the environment or union stack implied by `x` or `y`, this will simply forward to calling
+        // `forall_exists_equal(xi, yi, e)` on each parameter `(xi, yi)` of `(x, y)`,
+        // which means this subtype call will give the same result for `subtype(x, y)` and `subtype(y, x)`.
         jl_datatype_t *xd = (jl_datatype_t*)x, *yd = (jl_datatype_t*)y;
         if (xd->name != yd->name)
             return 0;

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1470,9 +1470,20 @@ static int forall_exists_equal(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)
         (is_definite_length_tuple_type(x) && is_indefinite_length_tuple_type(y)))
         return 0;
 
+    if (jl_is_datatype(x) && jl_is_datatype(y)) {
+        // Fastpath for nested constructor. Skip the unneeded `>:` check.
+        // Note: this is valid because the normal path checks `>:` locally.
+        jl_datatype_t *xd = (jl_datatype_t*)x, *yd = (jl_datatype_t*)y;
+        if (xd->name != yd->name)
+            return 0;
+        if (xd->name != jl_tuple_typename)
+            return subtype(x, y, e, 2);
+    }
+
     if ((jl_is_uniontype(x) && jl_is_uniontype(y))) {
         // For 2 unions, first try a more efficient greedy algorithm that compares the unions
         // componentwise. If failed, `exists_subtype` would memorize that this branch should be skipped.
+        // Note: this is valid because the normal path checks `>:` locally.
         if (pick_union_decision(e, 1) == 0) {
             return forall_exists_equal(((jl_uniontype_t *)x)->a, ((jl_uniontype_t *)y)->a, e) &&
                    forall_exists_equal(((jl_uniontype_t *)x)->b, ((jl_uniontype_t *)y)->b, e);

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2415,7 +2415,7 @@ abstract type P47654{A} end
     # issue 22123
     t1 = Ref{Ref{Ref{Union{Int64, T}}} where T}
     t2 = Ref{Ref{Ref{Union{T, S}}} where T} where S
-    @test_broken t1 <: t2
+    @test t1 <: t2
 
     # issue 21153
     @test_broken (Tuple{T1,T1} where T1<:(Val{T2} where T2)) <: (Tuple{Val{S},Val{S}} where S)
@@ -2467,3 +2467,12 @@ end
 
 #issue 48961
 @test !<:(Type{Union{Missing, Int}}, Type{Union{Missing, Nothing, Int}})
+
+#issue 49127
+struct F49127{m,n} <: Function end
+let a = [TypeVar(:V, Union{}, Function) for i in 1:32]
+    b = a[1:end-1]
+    S = foldr((v, d) -> UnionAll(v, d), a; init = foldl((i, j) -> F49127{i, j}, a))
+    T = foldr((v, d) -> UnionAll(v, d), b; init = foldl((i, j) -> F49127{i, j}, b))
+    @test S <: T
+end


### PR DESCRIPTION
This mitigate the exponential complexity caused by `>:` in equality testing.
MWE:
```julia
struct F{m,n} <: Function end
S = F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{V, V1}, V2}, V3}, V4}, V5}, V6}, V7}, V8}, V9}, V10}, V11}, V12}, V13}, V14}, V15}, V16}, V17}, V18}, V19}, V20}, V21}, V22}, V23}, V24} where {V<:Function, V1<:Function, V2<:Function, V3<:Function, V4<:Function, V5<:Function, V6<:Function, V7<:Function, V8<:Function, V9<:Function, V10<:Function, V11<:Function, V12<:Function, V13<:Function, V14<:Function, V15<:Function, V16<:Function, V17<:Function, V18<:Function, V19<:Function, V20<:Function, V21<:Function, V22<:Function, V23<:Function, V24<:Function}
T = F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{F{V, V1}, V2}, V3}, V4}, V5}, V6}, V7}, V8}, V9}, V10}, V11}, V12}, V13}, V14}, V15}, V16}, V17}, V18}, V19}, V20}, V21}, V22}, V23} where {V<:Function, V1<:Function, V2<:Function, V3<:Function, V4<:Function, V5<:Function, V6<:Function, V7<:Function, V8<:Function, V9<:Function, V10<:Function, V11<:Function, V12<:Function, V13<:Function, V14<:Function, V15<:Function, V16<:Function, V17<:Function, V18<:Function, V19<:Function, V20<:Function, V21<:Function, V22<:Function, V23<:Function}

 @time S<:T  #7.764220 seconds (922 allocations: 38.156 KiB) => 0.000037 seconds
```
I can confirm this fixes the `Mux.jl`'s precompilation on master.
But I think #49127 should not be closed. The over-specialization looks quite bad.

