### PR TITLE
Handle `ProcessChain` in `open(f, cmd, ..)`

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -413,7 +413,7 @@ process failed, or if the process attempts to print anything to stdout.
 """
 function open(f::Function, cmds::AbstractCmd, args...; kwargs...)
     P = open(cmds, args...; kwargs...)
-    function waitkill(P::Process)
+    function waitkill(P::Union{Process,ProcessChain})
         close(P)
         # 0.1 seconds after we hope it dies (from closing stdio),
         # we kill the process with SIGTERM (15)


### PR DESCRIPTION
Hey all,

On current master, `open(f, cmds::pipeline)` does not forward an exception in`f` but throws a MethodError since `waitkill` is only defined for `Process`. This PR extends it to ProcessChain. Maybe the type specification could be dropped entirely...

```julia
cmd = pipeline(`sleep 100`, `echo "foo"`)
open(cmd) do out
    error("my error")
end
# throws MethodError

cmd = `sleep 100`
open(cmd) do out
    error("my error")
end
# throws "my error" as expected
```