### PR TITLE
raise default sample rate for `Profile.Allocs.@profile`

### DIFF
--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -30,7 +30,7 @@ struct RawResults
 end
 
 """
-    Profile.Allocs.@profile [sample_rate=0.0001] expr
+    Profile.Allocs.@profile [sample_rate=0.1] expr
 
 Profile allocations that happen during `expr`, returning
 both the result and and AllocResults struct.
@@ -67,7 +67,7 @@ macro profile(opts, ex)
     _prof_expr(ex, opts)
 end
 macro profile(ex)
-    _prof_expr(ex, :(sample_rate=0.0001))
+    _prof_expr(ex, :(sample_rate=0.1))
 end
 
 function _prof_expr(expr, opts)


### PR DESCRIPTION
For most applications the sample rate of 1/1000 is way too low. This will require manually setting a rate for production use, but IMO it's a lot better to make the default be taylored towards interactive/beginner use rather than deployment. 
I'm not sure whether this is considered a breaking change. Thoughts?
@kpamnany tagging you on this since RAI presumably will have thoughts about this.