### PR TITLE
Improve isascii for short strings 15-30% improvement

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -670,7 +670,7 @@ function isascii(bytes::AbstractVector{UInt8}, first, last)
 
     qwords_start = 1
     if prolog_qwords > 0
-        _isascii_qword(qwords,qwords_start,prolog_qwords) || return false
+        _isascii_qword(qwords, qwords_start, prolog_qwords) || return false
         qwords_start = prolog_qwords +1
     end
 

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -663,7 +663,7 @@ function isascii(bytes::AbstractVector{UInt8}, first, last)
     if epilog_bytes > 0
         _isascii_subqword(bytes,epilog_first,epilog_bytes) || return false
     end
-    epilog_bytes > 0 || return true
+    nqwords > 0 || return true
     nchunks, prolog_qwords = divrem(nqwords,q_chunk_size)
 
     qwords = @inline @inbounds reinterpret(UInt64,@inbounds view(bytes,first:(epilog_first - 1)))

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -622,11 +622,11 @@ isascii(c::AbstractChar) = UInt32(c) < 0x80
 end
 
 
-# Julia Strings are stored in the following way
-# |  8-Byte size   | N-Bytes of UInt8 Code units |
-#                  |<- String pointer is address of first codeunit byte
-@inline function _isascii_subword(bytes::AbstractVector{UInt8},first,n)
-    # Loading bytes before the string is safe because the bytes in front of a string are the 8 bytes the representing the size
+# Julia Strings and Arrays are stored in the following way
+# | 8-Byte Type Tag|  8-Byte size   | N-Bytes of UInt8 Code units |
+# |This data is safe to read from   |<- String pointer is address of first codeunit byte
+@inline function _isascii_subqword(bytes::AbstractVector{UInt8},first,n)
+    # Loading bytes before the string is safe because the bytes in front of a string are the sure to be owned by the string object
     # This is important because those bytes are technically owned by the same object( which if you read past the end may not be the case)
     n_trash = 8 - n
     #It would be nice to use reinterpret here but there is no good way to get at a negative index
@@ -635,18 +635,11 @@ end
     return iszero(qword & UInt64(0x8080808080808080))
 end
 
-@inline function _isascii(bytes::AbstractVector{UInt8},first,last)
-    n = last-first+1
-    n <= 7 && return _isascii_subword(bytes,first,n)
-
-    nqword, prolog_bytes = divrem(n,8)
+@inline function _isascii_qword(qwords::AbstractVector{UInt64},first,last)
+    nqwords= last-first+1
     rqword = zero(UInt64)
-    if prolog_bytes > 0
-        rqword = unsafe_load(Ptr{UInt64}(pointer(bytes,first)),1)
-    end
-    qwords = @inline reinterpret(UInt64,@inbounds view(bytes,(first+prolog_bytes):last))
-    for i=1:nqword
-        @inbounds rqword |= qwords[i]
+    for i=0:nqwords-1
+        @inbounds rqword |= qwords[first+i]
     end
     return iszero(rqword & UInt64(0x8080808080808080))
 end
@@ -660,6 +653,36 @@ end
     end
     return  _isascii(cu,last-chunk_size+1,last)
 end
+
+function isascii(bytes::AbstractVector{UInt8}, first, last)
+    q_chunk_size = 128
+
+    n = last - first + 1
+    nqwords, epilog_bytes = (n >> 3, n & 0x07) # divrem(n,8)
+    epilog_first = last - epilog_bytes + 1
+    if epilog_bytes > 0
+        _isascii_subqword(bytes,epilog_first,epilog_bytes) || return false
+    end
+    epilog_bytes > 0 || return true
+    nchunks, prolog_qwords = divrem(nqwords,q_chunk_size)
+
+    qwords = @inline @inbounds reinterpret(UInt64,@inbounds view(bytes,first:(epilog_first - 1)))
+
+    qwords_start = 1
+    if prolog_qwords > 0
+        _isascii_qword(qwords,qwords_start,prolog_qwords) || return false
+        qwords_start = prolog_qwords +1
+    end
+
+    while nchunks > 0
+        _isascii_qword(qwords,qwords_start,qwords_start+q_chunk_size-1) || return false
+        qwords_start += q_chunk_size
+        nchunks -= 1
+    end
+    return true
+end
+isascii(bytes::AbstractVector{UInt8}) = @inline isascii(bytes, firstindex(bytes),lastindex(bytes))
+
 """
     isascii(cu::AbstractVector{CU}) where {CU <: Integer} -> Bool
 

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -626,7 +626,6 @@ end
     nqword, epilog_bytes = divrem(n,8)
     qwords = @inline reinterpret(UInt64,@inbounds view(bytes,first:(last-epilog_bytes)))
     rqword = zero(UInt64)
-    i = 1
     for i=1:nqword
         @inbounds rqword |= qwords[i]
     end

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -666,7 +666,7 @@ function isascii(bytes::AbstractVector{UInt8}, first, last)
     nqwords > 0 || return true
     nchunks, prolog_qwords = divrem(nqwords,q_chunk_size)
 
-    qwords = @inline @inbounds reinterpret(UInt64,@inbounds view(bytes,first:(epilog_first - 1)))
+    qwords = @inline reinterpret(UInt64, @inbounds view(bytes, first:(epilog_first - 1)))
 
     qwords_start = 1
     if prolog_qwords > 0

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -329,7 +329,7 @@ end
 
 isvalid(s::String, i::Int) = checkbounds(Bool, s, i) && thisind(s, i) == i
 
-isascii(s::String) = isascii(codeunits(s))
+isascii(s::String) = @inline isascii(codeunits(s))
 
 # don't assume effects for general integers since we cannot know their implementation
 @assume_effects :foldable repeat(c::Char, r::BitInteger) = @invoke repeat(c::Char, r::Integer)


### PR DESCRIPTION
This is a tweak that ends up improving `isascii`, particularly for shorted strings.
In #48568 we had made the decision to not use the trick of treating the `codeunits` as `UInt64` this changes that and shows some improvement across the board.

Using the isascii benchmarks in [ndinsmore/StringBenchmarks](https://github.com/ndinsmore/StringBenchmarks) the results are shown below.

There is a version that is another 15-20% faster for short strings, which replaces the 7 byte  epilog `for` loop with the code below, but I could not convince myself that the unsafe load wouldn't cause problems.

```julia
rqword = Base.unsafe_load(pointer(qwords),nqword+1)
rqword >>= (8-epilog_bytes) * 8
return iszero(rqword & UInt64(0x8080808080808080))
```

Before pr:
```julia
julia> results = run(StringBenchmarks.SUITE["isascii"])
4-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "single nonASCII" => 4-element BenchmarkTools.BenchmarkGroup:
	  tags: []
	  "length 2:64" => Trial(808.355 μs)
	  "length 512:4096" => Trial(43.703 μs)
	  "length 64:512" => Trial(145.182 μs)
	  "length 4096:32768" => Trial(18.661 μs)
  "julia 1.9 source" => 4-element BenchmarkTools.BenchmarkGroup:
	  tags: []
	  "files" => Trial(207.956 μs)
	  "lines" => Trial(4.876 ms)
	  "files SubString" => Trial(58.269 μs)
	  "lines SubString" => Trial(4.889 ms)
  "Unicode" => 4-element BenchmarkTools.BenchmarkGroup:
	  tags: []
	  "length 2:64" => Trial(704.782 μs)
	  "length 512:4096" => Trial(39.246 μs)
	  "length 64:512" => Trial(168.937 μs)
	  "length 4096:32768" => Trial(1.587 μs)
  "ASCII" => 4-element BenchmarkTools.BenchmarkGroup:
	  tags: []
	  "length 2:64" => Trial(716.833 μs)
	  "length 512:4096" => Trial(38.866 μs)
	  "length 64:512" => Trial(131.775 μs)
	  "length 4096:32768" => Trial(30.260 μs)
```

With PR:  Updated to reflect latest code
```julia
julia> results = run(StringBenchmarks.SUITE["isascii"])
4-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "single nonASCII" => 4-element BenchmarkTools.BenchmarkGroup:
	  tags: []
	  "length 2:64" => Trial(577.109 μs)
	  "length 512:4096" => Trial(56.193 μs)
	  "length 64:512" => Trial(122.251 μs)
	  "length 4096:32768" => Trial(18.266 μs)
  "julia 1.9 source" => 4-element BenchmarkTools.BenchmarkGroup:
	  tags: []
	  "files" => Trial(163.237 μs)
	  "lines" => Trial(3.883 ms)
	  "files SubString" => Trial(56.971 μs)
	  "lines SubString" => Trial(3.948 ms)
  "Unicode" => 4-element BenchmarkTools.BenchmarkGroup:
	  tags: []
	  "length 2:64" => Trial(327.546 μs)
	  "length 512:4096" => Trial(12.357 μs)
	  "length 64:512" => Trial(57.958 μs)
	  "length 4096:32768" => Trial(423.300 ns)
  "ASCII" => 4-element BenchmarkTools.BenchmarkGroup:
	  tags: []
	  "length 2:64" => Trial(435.367 μs)
	  "length 512:4096" => Trial(43.038 μs)
	  "length 64:512" => Trial(107.349 μs)
	  "length 4096:32768" => Trial(27.601 μs)