### PR TITLE
Subtype: fix `obviously_disjoint` for Union Types

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -393,6 +393,12 @@ static int obviously_disjoint(jl_value_t *a, jl_value_t *b, int specificity)
         return 1;
     if (jl_is_unionall(a)) a = jl_unwrap_unionall(a);
     if (jl_is_unionall(b)) b = jl_unwrap_unionall(b);
+    if (jl_is_uniontype(a))
+        return obviously_disjoint(((jl_uniontype_t *)a)->a, b, specificity) &&
+               obviously_disjoint(((jl_uniontype_t *)a)->b, b, specificity);
+    if (jl_is_uniontype(b))
+        return obviously_disjoint(a, ((jl_uniontype_t *)b)->a, specificity) &&
+               obviously_disjoint(a, ((jl_uniontype_t *)b)->b, specificity);
     if (jl_is_datatype(a) && jl_is_datatype(b)) {
         jl_datatype_t *ad = (jl_datatype_t*)a, *bd = (jl_datatype_t*)b;
         if (ad->name != bd->name) {

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2474,3 +2474,7 @@ let a = [TypeVar(:V, Union{}, Function) for i in 1:32]
     T = foldr((v, d) -> UnionAll(v, d), b; init = foldl((i, j) -> F49127{i, j}, b))
     @test S <: T
 end
+
+# requires assertions enabled (to test union-split in `obviously_disjoint`)
+@test !<:(Tuple{Type{Int}, Int}, Tuple{Type{Union{Int, T}}, T} where T<:Union{Int8,Int16})
+@test <:(Tuple{Type{Int}, Int}, Tuple{Type{Union{Int, T}}, T} where T<:Union{Int8,Int})


### PR DESCRIPTION
Found in https://github.com/JuliaLang/julia/pull/48935#issuecomment-1485814887.

It looks hard to reproduce this error under normal build as `obviously_subtype` handle `Union`s correctly.
