### PR TITLE
Improve handling of aliasing of AbstractSlices

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ New language features
 
 Language changes
 ----------------
-
+* `AbstractSlice` exposes `dataids` of its parent array to properly identify aliasing in broadcasting ([#49182]).
 
 Compiler/Runtime improvements
 -----------------------------

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1516,6 +1516,9 @@ By default, this simply checks if either of the arrays reference the same memory
 regions, as identified by their [`Base.dataids`](@ref).
 """
 mightalias(A::AbstractArray, B::AbstractArray) = !isbits(A) && !isbits(B) && !_isdisjoint(dataids(A), dataids(B))
+mightalias(A::AbstractArray, B::AbstractSlices) = mightalias(A, parent(B))
+mightalias(A::AbstractSlices, B::AbstractArray) = mightalias(parent(A), parent(B))
+mightalias(A::AbstractSlices, B::AbstractSlices) = mightalias(parent(A), parent(B))
 mightalias(x, y) = false
 
 _isdisjoint(as::Tuple{}, bs::Tuple{}) = true

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1516,9 +1516,6 @@ By default, this simply checks if either of the arrays reference the same memory
 regions, as identified by their [`Base.dataids`](@ref).
 """
 mightalias(A::AbstractArray, B::AbstractArray) = !isbits(A) && !isbits(B) && !_isdisjoint(dataids(A), dataids(B))
-mightalias(A::AbstractArray, B::AbstractSlices) = mightalias(A, parent(B))
-mightalias(A::AbstractSlices, B::AbstractArray) = mightalias(parent(A), B)
-mightalias(A::AbstractSlices, B::AbstractSlices) = mightalias(parent(A), parent(B))
 mightalias(x, y) = false
 
 _isdisjoint(as::Tuple{}, bs::Tuple{}) = true

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1517,7 +1517,7 @@ regions, as identified by their [`Base.dataids`](@ref).
 """
 mightalias(A::AbstractArray, B::AbstractArray) = !isbits(A) && !isbits(B) && !_isdisjoint(dataids(A), dataids(B))
 mightalias(A::AbstractArray, B::AbstractSlices) = mightalias(A, parent(B))
-mightalias(A::AbstractSlices, B::AbstractArray) = mightalias(parent(A), parent(B))
+mightalias(A::AbstractSlices, B::AbstractArray) = mightalias(parent(A), B)
 mightalias(A::AbstractSlices, B::AbstractSlices) = mightalias(parent(A), parent(B))
 mightalias(x, y) = false
 

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -44,6 +44,9 @@ function Slices(A::P, slicemap::SM, ax::AX) where {P,SM,AX}
     Slices{P,SM,AX,S,N}(A, slicemap, ax)
 end
 
+unaliascopy(A::Slices{P,SM,AX,S,N}) where {P,SM,AX,S,N} =
+    Slices{P,SM,AX,S,N}(unaliascopy(A.parent), A.slicemap, A.axes)
+
 _slice_check_dims(N) = nothing
 function _slice_check_dims(N, dim, dims...)
     1 <= dim <= N || throw(DimensionMismatch("Invalid dimension $dim"))

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -44,6 +44,7 @@ function Slices(A::P, slicemap::SM, ax::AX) where {P,SM,AX}
     Slices{P,SM,AX,S,N}(A, slicemap, ax)
 end
 
+dataids(C::AbstractSlices) = dataids(parent(C))
 unaliascopy(A::Slices{P,SM,AX,S,N}) where {P,SM,AX,S,N} =
     Slices{P,SM,AX,S,N}(unaliascopy(A.parent), A.slicemap, A.axes)
 

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -442,6 +442,8 @@ V = view(A, [1,2,4], :)   # is not strided, as the spacing between rows is not f
 | `Base.BroadcastStyle(::Style1, ::Style2) = Style12()` | Precedence rules for mixing styles |
 | `Base.axes(x)` | Declaration of the indices of `x`, as per [`axes(x)`](@ref). |
 | `Base.broadcastable(x)` | Convert `x` to an object that has `axes` and supports indexing |
+| `Base.dataids(x::AbstractArray)` | Return a tuple of `UInt`s that represent the mutable data segments of an array `x`. |
+| `Base.unaliascopy(x::AbstractArray)` | Make a preventative copy of an array `x` in an operation where `x` `Base.mightalias` against another array. |
 | **Bypassing default machinery** | |
 | `Base.copy(bc::Broadcasted{DestStyle})` | Custom implementation of `broadcast` |
 | `Base.copyto!(dest, bc::Broadcasted{DestStyle})` | Custom implementation of `broadcast!`, specializing on `DestStyle` |

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1823,6 +1823,13 @@ end
     @test_broken IRUtils.fully_eliminated(_has_offset_axes, Base.typesof(a, a, b, b))
 end
 
+@testset "aliasing of slices" begin
+    x = [1 2; 3 4]
+    @test Base.mightalias(x, eachrow(x))
+    @test Base.mightalias(eachrow(x), x)
+    @test Base.mightalias(eachcol(x), eachrow(x))
+end
+                                                                                                                
 # type stable [x;;] (https://github.com/JuliaLang/julia/issues/45952)
 f45952(x) = [x;;]
 @inferred f45952(1.0)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1828,6 +1828,8 @@ end
     @test Base.mightalias(x, eachrow(x))
     @test Base.mightalias(eachrow(x), x)
     @test Base.mightalias(eachcol(x), eachrow(x))
+    x .+= sum.(eachrow(x))
+    @test x == [4 5; 10 11]
 end
                                                                                                                 
 # type stable [x;;] (https://github.com/JuliaLang/julia/issues/45952)


### PR DESCRIPTION
Currently broadcasting does not detect that slices might alias with parent:
```
julia> x = rand(2, 2)
2×2 Matrix{Float64}:
 0.63266   0.51432
 0.787383  0.21117

julia> Base.mightalias(x, eachrow(x))
false
```

See https://discourse.julialang.org/t/unexpected-broadcasting-behavior-involving-eachrow/96781 for an example when this creates a problem.