### PR TITLE
rewrite DW_TAG_compile_unit during aotcompile

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -1341,6 +1341,11 @@ static void add_output(Module &M, TargetMachine &TM, std::vector<std::string> &o
             timers[i].construct.startTimer();
             construct_vars(*M, partitions[i]);
             M->setModuleFlag(Module::Error, "julia.mv.suffix", MDString::get(M->getContext(), "_" + std::to_string(i)));
+            // The DICompileUnit file is not used for anything, but ld64 requires it be a unique string per object file
+            // or it may skip emitting debug info for that file. Here set it to ./julia#N
+            DIFile *topfile = DIFile::get(M->getContext(), "julia#" + std::to_string(i), ".");
+            for (DICompileUnit *CU : M->debug_compile_units())
+                CU->replaceOperandWith(0, topfile);
             timers[i].construct.stopTimer();
 
             timers[i].deletion.startTimer();

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1694,8 +1694,8 @@ void jl_merge_module(orc::ThreadSafeModule &destTSM, orc::ThreadSafeModule srcTS
             NamedMDNode *sNMD = src.getNamedMetadata("llvm.dbg.cu");
             if (sNMD) {
                 NamedMDNode *dNMD = dest.getOrInsertNamedMetadata("llvm.dbg.cu");
-                for (NamedMDNode::op_iterator I = sNMD->op_begin(), E = sNMD->op_end(); I != E; ++I) {
-                    dNMD->addOperand(*I);
+                for (MDNode *I : sNMD->operands()) {
+                    dNMD->addOperand(I);
                 }
             }
         });


### PR DESCRIPTION
The macOS linker requires these to be unique due to a bug, and we do not care about this value at all as it does nothing, so just make it something unique. However, keep the directory as ".", since it uses that to compose the DW_AT_decl_file values for its subprograms.

Also try to save a little memory, since we have to leak all of these objects (per LLVMContext), and we would like to avoid that.

Fix #49152
Fix #49151
Fix #49153