### PR TITLE
inference: enable `:call` inference in irinterp

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -1,12 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-# TODO (#48913) remove this overload to enable interprocedural call inference from irinterp
-function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
-    arginfo::ArgInfo, si::StmtInfo, @nospecialize(atype),
-    sv::IRInterpretationState, max_methods::Int)
-    return CallMeta(Any, Effects(), NoCallInfo())
-end
-
 function collect_limitations!(@nospecialize(typ), ::IRInterpretationState)
     @assert !isa(typ, LimitedAccuracy) "irinterp is unable to handle heavy recursion"
     return typ

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -140,7 +140,7 @@ function reprocess_instruction!(interp::AbstractInterpreter, idx::Int, bb::Union
         # Handled at the very end
         return false
     elseif isa(inst, PiNode)
-        rt = tmeet(optimizer_lattice(interp), argextype(inst.val, ir), widenconst(inst.typ))
+        rt = tmeet(typeinf_lattice(interp), argextype(inst.val, ir), widenconst(inst.typ))
     elseif inst === nothing
         return false
     elseif isa(inst, GlobalRef)
@@ -148,7 +148,7 @@ function reprocess_instruction!(interp::AbstractInterpreter, idx::Int, bb::Union
     else
         error("reprocess_instruction!: unhandled instruction found")
     end
-    if rt !== nothing && !⊑(optimizer_lattice(interp), typ, rt)
+    if rt !== nothing && !⊑(typeinf_lattice(interp), typ, rt)
         ir.stmts[idx][:type] = rt
         return true
     end
@@ -316,7 +316,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
             end
             inst = ir.stmts[idx][:inst]::ReturnNode
             rt = argextype(inst.val, ir)
-            ultimate_rt = tmerge(optimizer_lattice(interp), ultimate_rt, rt)
+            ultimate_rt = tmerge(typeinf_lattice(interp), ultimate_rt, rt)
         end
     end
 

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -466,8 +466,12 @@ typeinf_lattice(::AbstractInterpreter) = InferenceLattice(BaseInferenceLattice.i
 ipo_lattice(::AbstractInterpreter) = InferenceLattice(IPOResultLattice.instance)
 optimizer_lattice(::AbstractInterpreter) = OptimizerLattice(SimpleInferenceLattice.instance)
 
-typeinf_lattice(interp::NativeInterpreter) = interp.irinterp ? optimizer_lattice(interp) : InferenceLattice(BaseInferenceLattice.instance)
-ipo_lattice(interp::NativeInterpreter) = interp.irinterp ? optimizer_lattice(interp) : InferenceLattice(IPOResultLattice.instance)
+typeinf_lattice(interp::NativeInterpreter) = interp.irinterp ?
+    OptimizerLattice(InferenceLattice(SimpleInferenceLattice.instance)) :
+    InferenceLattice(BaseInferenceLattice.instance)
+ipo_lattice(interp::NativeInterpreter) = interp.irinterp ?
+    InferenceLattice(SimpleInferenceLattice.instance) :
+    InferenceLattice(IPOResultLattice.instance)
 optimizer_lattice(interp::NativeInterpreter) = OptimizerLattice(SimpleInferenceLattice.instance)
 
 """

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4784,31 +4784,30 @@ fhasmethod(::Integer, ::Int32) = 3
 @test only(Base.return_types(()) do; Val(hasmethod(sin, Tuple{Int, Vararg{Int}})); end) == Val{false}
 @test only(Base.return_types(()) do; Val(hasmethod(sin, Tuple{Int, Int, Vararg{Int}})); end) === Val{false}
 
-# TODO (#48913) enable interprocedural call inference from irinterp
-# # interprocedural call inference from irinterp
-# @noinline Base.@assume_effects :total issue48679_unknown_any(x) = Base.inferencebarrier(x)
+# interprocedural call inference from irinterp
+@noinline Base.@assume_effects :total issue48679_unknown_any(x) = Base.inferencebarrier(x)
 
-# @noinline _issue48679(y::Union{Nothing,T}) where {T} = T::Type
-# Base.@constprop :aggressive function issue48679(x, b)
-#     if b
-#         x = issue48679_unknown_any(x)
-#     end
-#     return _issue48679(x)
-# end
-# @test Base.return_types((Float64,)) do x
-#     issue48679(x, false)
-# end |> only == Type{Float64}
+@noinline _issue48679(y::Union{Nothing,T}) where {T} = T::Type
+Base.@constprop :aggressive function issue48679(x, b)
+    if b
+        x = issue48679_unknown_any(x)
+    end
+    return _issue48679(x)
+end
+@test Base.return_types((Float64,)) do x
+    issue48679(x, false)
+end |> only == Type{Float64}
 
-# Base.@constprop :aggressive @noinline _issue48679_const(b, y::Union{Nothing,T}) where {T} = b ? nothing : T::Type
-# Base.@constprop :aggressive function issue48679_const(x, b)
-#     if b
-#         x = issue48679_unknown_any(x)
-#     end
-#     return _issue48679_const(b, x)
-# end
-# @test Base.return_types((Float64,)) do x
-#     issue48679_const(x, false)
-# end |> only == Type{Float64}
+Base.@constprop :aggressive @noinline _issue48679_const(b, y::Union{Nothing,T}) where {T} = b ? nothing : T::Type
+Base.@constprop :aggressive function issue48679_const(x, b)
+    if b
+        x = issue48679_unknown_any(x)
+    end
+    return _issue48679_const(b, x)
+end
+@test Base.return_types((Float64,)) do x
+    issue48679_const(x, false)
+end |> only == Type{Float64}
 
 # `invoke` call in irinterp
 @noinline _irinterp_invoke(x::Any) = :any


### PR DESCRIPTION
Built on top of #48913, this commit enables `:call` inference in irinterp. In a case when some regression is detected, we can simply revert this commit rather than reverting the whole refactoring from #48913.

@nanosoldier `runbenchmarks("inference", vs=":master")`
@nanosoldier `runtests()`