### PR TITLE
(re-factor) gc: remove redundant `since_sweep` field

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -12,7 +12,6 @@ struct GC_Num
     freecall        ::Int64
     total_time      ::Int64
     total_allocd    ::Int64 # GC internal
-    since_sweep     ::Int64 # GC internal
     collect         ::Csize_t # GC internal
     pause           ::Cint
     full_sweep      ::Cint

--- a/src/gc.h
+++ b/src/gc.h
@@ -68,7 +68,6 @@ typedef struct {
     uint64_t    freecall;
     uint64_t    total_time;
     uint64_t    total_allocd;
-    uint64_t    since_sweep;
     size_t      interval;
     int         pause;
     int         full_sweep;


### PR DESCRIPTION
This field is at all times 0 or identical to allocd, so this change removes it in preference of `gc_num.allocd`.

Hopefully this makes the GC metrics a tiny bit easier to interpret for newcomers (like myself).