### PR TITLE
complete `ismutationfree` fixup

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2892,6 +2892,10 @@ void jl_init_types(void) JL_GC_DISABLED
     // Array's mutable data is hidden, so we need to override it
     ((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_array_type))->ismutationfree = 0;
     ((jl_datatype_t*)jl_array_any_type)->ismutationfree = 0;
+    ((jl_datatype_t*)jl_array_symbol_type)->ismutationfree = 0;
+    ((jl_datatype_t*)jl_array_uint8_type)->ismutationfree = 0;
+    ((jl_datatype_t*)jl_array_int32_type)->ismutationfree = 0;
+    ((jl_datatype_t*)jl_array_uint64_type)->ismutationfree = 0;
 
     // override the preferred layout for a couple types
     jl_lineinfonode_type->name->mayinlinealloc = 0; // FIXME: assumed to be a pointer by codegen

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -775,7 +775,6 @@ end |> Core.Compiler.is_foldable_nothrow
 end
 @test Core.Compiler.is_foldable(Base.infer_effects(ImmutRef, Tuple{Any}))
 
-@test Base.ismutationfree(Type{Union{}})
 @test Core.Compiler.is_foldable_nothrow(Base.infer_effects(typejoin, ()))
 
 # nothrow-ness of subtyping operations
@@ -815,6 +814,3 @@ actually_recursive1(x) = actually_recursive2(x)
 actually_recursive2(x) = (x <= 0) ? 1 : actually_recursive1(x - 1)
 actually_recursive3(x) = actually_recursive2(x)
 @test !Core.Compiler.is_terminates(Base.infer_effects(actually_recursive3, (Int,)))
-
-# https://github.com/JuliaLang/julia/issues/48856
-@test Base.ismutationfree(Vector{Any}) == false

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1048,10 +1048,10 @@ end
 end
 
 # https://github.com/JuliaLang/julia/issues/48856
-@test Base.ismutationfree(Vector{Any}) == false
-@test Base.ismutationfree(Vector{Symbol}) == false
-@test Base.ismutationfree(Vector{UInt8}) == false
-@test Base.ismutationfree(Vector{Int32}) == false
-@test Base.ismutationfree(Vector{UInt64}) == false
+@test !Base.ismutationfree(Vector{Any})
+@test !Base.ismutationfree(Vector{Symbol})
+@test !Base.ismutationfree(Vector{UInt8})
+@test !Base.ismutationfree(Vector{Int32})
+@test !Base.ismutationfree(Vector{UInt64})
 
 @test Base.ismutationfree(Type{Union{}})

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1046,3 +1046,12 @@ end
     f("hello")
     @test length(Base.specializations(only(methods(f)))) == 2
 end
+
+# https://github.com/JuliaLang/julia/issues/48856
+@test Base.ismutationfree(Vector{Any}) == false
+@test Base.ismutationfree(Vector{Symbol}) == false
+@test Base.ismutationfree(Vector{UInt8}) == false
+@test Base.ismutationfree(Vector{Int32}) == false
+@test Base.ismutationfree(Vector{UInt64}) == false
+
+@test Base.ismutationfree(Type{Union{}})


### PR DESCRIPTION
`ismutationfree(Vector{Any})` is fixed in #48868, but there are other array types that are instantiated within jltypes.c and thus annotated as `ismutationfree` wrongly.
This commit fixes it up by covering all the builtin array types.