### PR TITLE
NEWS: add news for task-local RNG split change

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ New language features
 Language changes
 ----------------
 
+* When a task forks a child, the parent task's task-local RNG (random number generator) is no longer affected. The seeding of child based on the parent task also takes a more disciplined approach to collision resistance, using a design based on the SplitMix and DotMix splittable RNG schemes ([#49110]).
 
 Compiler/Runtime improvements
 -----------------------------


### PR DESCRIPTION
Adding NEWS entry for #49110.
