### PR TITLE
[docs] add performance tip concerning overly-fused broadcast loops

### DIFF
--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -1159,6 +1159,47 @@ julia> 1:5 .|> [x->x^2, inv, x->2*x, -, isodd]
  true
 ```
 
+!!! warning
+    Broadcast loop fusion is a relatively unique language feature that can enable concise and idiomatic code to express highly performant operations. However, there are some potentially surprising behaviors that one should be prepared for; these may arise when broadcasting complex expressions, broadcasting over multiple axes simultaneously, or broadcasting in-place assignment.
+
+For example, given some matrix `x = rand(100, 100, 100)` with three axes, say a normalization is desired where each 2-d slice along the third axis has unit sum. We can compute these sums in a few ways. Here are two: the first is more idiomatic, but in isolation it is equivalent to the second
+```
+julia> @btime sum(x; dims=(1,2));
+  163.708 μs (6 allocations: 1.03 KiB)
+
+julia> @btime sum.(eachslice(x; dims=3, drop=false));
+  164.250 μs (1 allocation: 896 bytes)
+```
+These expressions are nearly identically performant and it stands to verify that they return the same value. However, when we use these values to normalize the slices, there is a performance difference of several orders of magnitude.
+```
+julia> @btime x ./ sum(x; dims=(1,2));
+  340.958 μs (8 allocations: 7.63 MiB)
+
+julia> @btime x ./ sum.(eachslice(x; dims=3, drop=false));
+  1.661 s (2 allocations: 7.63 MiB)
+```
+This happens because the fusion in the second expression causes the sum to be recomputed for each element in the slice leading to an asymptotic (and empirical) slowdown. To avoid this, the expression can be forcibly "unfused" by wrapping components in an `identity` call or by using temporary variables like so
+```
+julia> @btime x ./ identity(sum.(eachslice(x; dims=3, drop=false)));
+  359.459 μs (3 allocations: 7.63 MiB)
+
+julia> @btime let denom = identity(sum.(eachslice(x; dims=3, drop=false)))
+            x ./ denom
+        end
+  394.791 μs (3 allocations: 7.63 MiB)
+```
+
+Another pertinent example comes from broadcasted assignment when transforming a mutable object. Using the example from above, say we want to do the slice normalization in-place and write something like the following
+```
+julia> x .= x ./ sum.(eachslice(x; dims=3, drop=false));
+
+julia> any(sum.(eachslice(x; dims=3, drop=false)) .== 1)
+false
+```
+Unfortunately, not a single slice got correctly normalized. What happened? The `.=` broadcasted assignment was fused with the sum expression, which, as aforementioned will be recomputed on each iteration over elements of the slice; since the values in the slice will be mutating during the broadcast, each recomputation of the sum will return a new value.
+
+As a rule of thumb, when the number of dimensions is two or fewer and mutable objects do not appear on both sides of a broadcasted assignment expression, these gotchas are unlikely to arise, and developers can write concise and efficient code with confidence. But it is always important to understand the mechanisms behind the magic of features like loop fusion so that surprising behaviors can be identified and avoided.
+
 ## Further Reading
 
 We should mention here that this is far from a complete picture of defining functions. Julia has

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -1160,7 +1160,7 @@ julia> 1:5 .|> [x->x^2, inv, x->2*x, -, isodd]
 ```
 
 !!! warning
-    It is always important to understand the mechanisms behind the magic of unique language features like fused broadcast loops. There are some occasional pitfalls which are important to avoid. For an example on when *not* to fuse broadcasted operations, see the note in [Performance Tips](@ref man-performance-unfuse). For a discussion on mutating broadcasts and anti-aliasing see [Views, Slices, and Aliasing](@ref yet-to-be-written).
+    It is always important to understand the mechanisms behind the magic of unique language features like fused broadcast loops. There are some occasional pitfalls which are important to avoid. For an example on when *not* to fuse broadcasted operations, see the note in [Performance Tips](@ref man-performance-unfuse). Users should also remember that due to the in-place mutation behavior of the `.=` operator, extra care should be taken to ensure correct and intended semantics when an object appears in both arguments of the operator like `x .= foo.(x)` or similar expressions.
 
 ## Further Reading
 

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -1161,30 +1161,6 @@ julia> 1:5 .|> [x->x^2, inv, x->2*x, -, isodd]
 
 All functions in the fused broadcast are always called for every element of the result. Thus `X .+ σ .* randn.()` will add a mask of independent and identically sampled random values to each element of the array `X`, but `X .+ σ .* randn()` will add the *same* random sample to each element. In cases where the fused computation is constant along one or more axes of the broadcast iteration, it may be possible to leverage a space-time tradeoff and allocate intermediate values to reduce the number of computations. See more at [performance tips](@ref man-performance-unfuse).
 
-!!! warning 
-    At this time Julia provides no anti-aliasing guarantees for broadcasted mutating functions.
-
-As a consequence of the fact that the fused expression is computed for every element of the result, when the expression contains mutating functions or functions with other side effects, users should be very careful to understand the order of iterations over the broadcast to ensure correct and intended semantics. This can be used powerfully: say we want to compute the number of North-East lattice paths from the point `(1, 1)` to each point in the square up to `(n, n)`. We can define the recursion as a dynamic program very concisely and with nearly optimal performance.
-```
-function num_paths!(M, I)
-    if any(Tuple(I) .== 1)
-        M[I] = 1
-    else
-        M[I] = M[I - CartesianIndex(0, 1)] + M[I - CartesianIndex(1, 0)]
-    end
-end
-
-M = zeros(Int, n, n)
-num_paths!.(Ref(M), CartesianIndices(M))
-# M is now filled with the correct number of paths to each point
-```
-
-However by the same token, expressions like the following
-```
-normalize_rows!(X) = (X ./= sum.(eachrow(X))) # do not do this!
-```
-
-Will not in fact normalize rows to have unit sum as might be expected upon first reading the code due to the sum being recomputed (after mutation) for each row entry.
 ## Further Reading
 
 We should mention here that this is far from a complete picture of defining functions. Julia has

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1092,7 +1092,7 @@ julia> d = sum(abs2, x; dims=2);
 julia> @time x ./= sqrt.(d);
   0.002049 seconds (4 allocations: 96 bytes)
 ```
-This will work. However, this expression will actually recompute `sqrt(d[i])` for *every* element in the row `x[i, :]`, meaning that many more square roots are computed than necessary. To see precisely over which indices the broadcast will iterate, we can call `Broadcast.combine_axes` on the arguments of the fused expression. This will return a tuple of ranges whose entries correspond to the axes of iteration; the sum of lengths of these ranges will be the total number of calls to the fused operation.
+This will work. However, this expression will actually recompute `sqrt(d[i])` for *every* element in the row `x[i, :]`, meaning that many more square roots are computed than necessary. To see precisely over which indices the broadcast will iterate, we can call `Broadcast.combine_axes` on the arguments of the fused expression. This will return a tuple of ranges whose entries correspond to the axes of iteration; the product of lengths of these ranges will be the total number of calls to the fused operation.
 
 It follows that when some components of the broadcast expression are constant along an axis—like the `sqrt` along the second dimension in the preceding example—there is potential for a performance improvement by forcibly "unfusing" those components, i.e. allocating the result of the broadcasted operation in advance and reusing the cached value along its constant axis. Some such potential approaches are to use temporary variables, wrap components of a dot expression in `identity`, or use an equivalent intrinsically vectorized (but non-fused) function.
 ```

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1081,6 +1081,31 @@ a new temporary array and executes in a separate loop. In this example
 convenient to sprinkle some dots in your expressions than to
 define a separate function for each vectorized operation.
 
+## [Fewer dots: Unfuse certain intermediate broadcasts](@id man-performance-unfuse)
+
+The dot loop fusion mentioned above enables concise and idiomatic code to express highly performant operations. However, it is important to remember that the fused operation will be computed at every iteration of the broadcast. This means that in some situations, particularly in the presence of composed or multidimensional broadcasts, an expression with dot calls maybe be computing a function more times than intended. As an example, say we want to build a random matrix whose rows have unit Euclidean norm with the following:
+```
+julia> x = rand(1000, 1000);
+
+julia> d = sum(abs2, x; dims=2);
+
+julia> @time x ./= sqrt.(d);
+  0.002049 seconds (4 allocations: 96 bytes)
+```
+However, this expression will actually recompute `sqrt(d[i])` for *every* element in the row `x[i, :]`, meaning that many more square roots are computed than necessary. To improve this performance, we can forcibly "unfuse" the loop by allocating the result of the broadcasted operation in advance. Some ways to do that are to use temporary variables, wrap components of a dot expression in `identity`, or use an allocating but equivalent function
+```
+julia> @time let s = sqrt.(d); x ./= s end;
+  0.000809 seconds (5 allocations: 8.031 KiB)
+
+julia> @time x ./= identity(sqrt.(d));
+  0.000608 seconds (5 allocations: 8.031 KiB)
+
+julia> @time x ./= map(sqrt, d);
+  0.000611 seconds (4 allocations: 8.016 KiB)
+```
+
+Any of these options yields approximately a three-fold speedup at the cost of an allocation; for large broadcastables this speedup can be asymptotically very large.
+
 ## [Consider using views for slices](@id man-performance-views)
 
 In Julia, an array "slice" expression like `array[1:5, :]` creates

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1083,7 +1083,7 @@ define a separate function for each vectorized operation.
 
 ## [Fewer dots: Unfuse certain intermediate broadcasts](@id man-performance-unfuse)
 
-The dot loop fusion mentioned above enables concise and idiomatic code to express highly performant operations. However, it is important to remember that the fused operation will be computed at every iteration of the broadcast. This means that in some situations, particularly in the presence of composed or multidimensional broadcasts, an expression with dot calls maybe be computing a function more times than intended. As an example, say we want to build a random matrix whose rows have Euclidean norm one. We might write something like the following:
+The dot loop fusion mentioned above enables concise and idiomatic code to express highly performant operations. However, it is important to remember that the fused operation will be computed at every iteration of the broadcast. This means that in some situations, particularly in the presence of composed or multidimensional broadcasts, an expression with dot calls may be computing a function more times than intended. As an example, say we want to build a random matrix whose rows have Euclidean norm one. We might write something like the following:
 ```
 julia> x = rand(1000, 1000);
 
@@ -1092,7 +1092,9 @@ julia> d = sum(abs2, x; dims=2);
 julia> @time x ./= sqrt.(d);
   0.002049 seconds (4 allocations: 96 bytes)
 ```
-This will work, however this expression will actually recompute `sqrt(d[i])` for *every* element in the row `x[i, :]`, meaning that many more square roots are computed than necessary. To improve this performance we can forcibly "unfuse" the loop by allocating the result of the broadcasted operation in advance. Some potential approaches are to use temporary variables, wrap components of a dot expression in `identity`, or use an allocating but equivalent function
+This will work. However, this expression will actually recompute `sqrt(d[i])` for *every* element in the row `x[i, :]`, meaning that many more square roots are computed than necessary. To see precisely over which indices the broadcast will iterate, we can call `Broadcast.combine_axes` on the arguments of the fused expression. This will return a tuple of ranges whose entries correspond to the axes of iteration; the sum of lengths of these ranges will be the total number of calls to the fused operation.
+
+It follows that when some components of the broadcast expression are constant along an axis—like the `sqrt` along the second dimension in the preceding example—there is potential for a performance improvement by forcibly "unfusing" those components, i.e. allocating the result of the broadcasted operation in advance and reusing the cached value along its constant axis. Some such potential approaches are to use temporary variables, wrap components of a dot expression in `identity`, or use an equivalent intrinsically vectorized (but non-fused) function.
 ```
 julia> @time let s = sqrt.(d); x ./= s end;
   0.000809 seconds (5 allocations: 8.031 KiB)


### PR DESCRIPTION
cautionary / explanatory documentation following the wake of https://discourse.julialang.org/t/unexpected-broadcasting-behavior-involving-eachrow/96781/88