### PR TITLE
Depth-limited printing of types in stacktraces

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -2606,9 +2606,13 @@ module TypeTreesIO
                 end
                 push!(curs.children, TypeTreeNode(str, curs))
             else
-                p = curs.parent
-                if p !== nothing
-                    treeio.cursor = p
+                if curs.children === nothing
+                    curs.children = TypeTreeNode[]
+                else
+                    p = curs.parent
+                    if p !== nothing
+                        treeio.cursor = p
+                    end
                 end
             end
         elseif c != ' '
@@ -2657,7 +2661,7 @@ module TypeTreesIO
         if childs !== nothing
             delimidx = node.delimidx
             iszero(delimidx) || print(io, delims[delimidx][1])
-            if thisdepth >= maxdepth
+            if thisdepth >= maxdepth && node.children !== nothing && !isempty(node.children)
                 print(io, truncchar)
             else
                 n = lastindex(childs)
@@ -2715,7 +2719,9 @@ module TypeTreesIO
             for child in childs
                 width_by_depth!(wd, wtrunc, child, depth+1)
             end
-            wd[depth+1] += length(per_param) * (length(childs) - 1)
+            if lastindex(wd) > depth
+                wd[depth+1] += length(per_param) * (length(childs) - 1)
+            end
         end
         return wd, wtrunc
     end
@@ -2736,7 +2742,7 @@ function show_tuple_as_call(out::IO, name::Symbol, @nospecialize(sig::Type);
                             qualified=false, hasfirst=true)
     # print a method signature tuple for a lambda definition
     if sig === Tuple
-        print(io, demangle ? demangle_function_name(name) : name, "(...)")
+        print(out, demangle ? demangle_function_name(name) : name, "(...)")
         return
     end
     tv = Any[]

--- a/base/show.jl
+++ b/base/show.jl
@@ -2646,9 +2646,9 @@ module TypeTreesIO
     end
 
     function _print(io::IO, node::TypeTreeNode, thisdepth, maxdepth, isbody::Bool)
-        bold = thisdepth==1 && isbody
-        light = thisdepth==2 && isbody && get(io, :backtrace, false)::Bool
-        if thisdepth == 2 && isbody
+        iscall = thisdepth==1 && isbody
+        isargs = thisdepth==2 && isbody
+        if isargs
             sname = split(node.name, "::")
             if length(sname) == 2
                 Base.print_within_stacktrace(io, sname[1]; color=:light_black)
@@ -2658,11 +2658,14 @@ module TypeTreesIO
                 print(io, node.name)
             end
         else
-            Base.print_within_stacktrace(io, node.name; bold)
+            addparens = iscall && occursin("::", node.name)
+            addparens && print(io, '(')
+            Base.print_within_stacktrace(io, node.name; bold=iscall)
+            addparens && print(io, ')')
         end
         children = node.children
         if children !== nothing
-            if light
+            if isargs && get(io, :backtrace, false)::Bool
                 Base.with_output_color(:light_black, io) do io
                     _print_children(io, children, node.delimidx, thisdepth, maxdepth, isbody)
                 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -2462,6 +2462,267 @@ function show_signature_function(io::IO, @nospecialize(ft), demangle=false, farg
     nothing
 end
 
+"""
+    TypeTreesIO
+
+A module defining an IO subtype that constructs trees that mirror printing of a parametric types.
+"""
+module TypeTreesIO
+
+    export TypeTreeIO, TypeTreeNode
+
+    const delims = (('(', ')'), ('{', '}'))
+
+    mutable struct TypeTreeNode
+        name::String
+        parent::Union{Nothing,TypeTreeNode}
+        delimidx::Int8          # 1 or 2 for delims[delimidx], 0 for not assigned
+        children::Union{Nothing,Vector{TypeTreeNode}}
+    end
+    TypeTreeNode(name::AbstractString="", parent=nothing) = TypeTreeNode(name, parent, 0, nothing)
+
+    mutable struct TypeTreeBundle
+        body::TypeTreeNode                  # DataType
+        vars::Union{Nothing,TypeTreeNode}   # TypeVars
+    end
+    TypeTreeBundle(node::TypeTreeNode) = TypeTreeBundle(node, nothing)
+
+    """
+        TypeTreeIO() → io
+
+    Create an IO object to which you can print type objects or natural signatures.
+    Afterwards, `io.tree` will contain a tree representation of the printed type.
+
+    # Examples
+
+    ```jldoctest
+    julia> io = TypeTreeIO();
+
+    julia> print(io, Tuple{Int,Float64});
+
+    julia> io.tree.body.name
+    "Tuple"
+
+    julia> io.tree.body.children[1].name
+    "$Int"
+
+    julia> String(take!(io))
+    "Tuple{$Int, Float64}"
+    ```
+
+    # Extended help
+
+    In addition to printing a type directly to an `io::TypeTreeIO`, you can also
+    assemble it manually if you follow a few precautions:
+
+        - any `where` statement must be printed as `print(io, " where ")` or
+          `print(io, " where {")`. The `where` string argument may not have any
+          additional characters. Note the bracketing spaces.
+
+    """
+    mutable struct TypeTreeIO <: IO    # TODO?: abstract type TextIO <: IO end for text-only printing
+        io::Union{IOBuffer,IOContext{IOBuffer}}
+        tree::TypeTreeBundle
+        cursor::TypeTreeNode   # current position in the tree
+    end
+    function TypeTreeIO(io=IOBuffer())
+        root = TypeTreeNode()
+        return TypeTreeIO(io, TypeTreeBundle(root), root)
+    end
+
+    getttio(io::TypeTreeIO) = io
+    getttio(ioctx::IOContext{TypeTreeIO}) = ioctx.io
+    getio(io::TypeTreeIO) = io.io
+    getio(ioctx::IOContext{TypeTreeIO}) = getio(getttio(ioctx))
+
+    ## IO interface
+
+    function Base.flush(io::TypeTreeIO)
+        str = String(take!(io.io))
+        if !isempty(str)
+            curs = io.cursor
+            if curs.children === nothing
+                curs.children = TypeTreeNode[]
+            end
+            push!(curs.children, TypeTreeNode(str, curs))
+        end
+        return
+    end
+    Base.iswritable(::TypeTreeIO) = true
+
+    function Base.unsafe_write(io::TypeTreeIO, p::Ptr{UInt8}, nb::UInt)
+        str = String(unsafe_wrap(Array, p, (Int(nb),)))
+        if startswith(str, " where ")
+            @assert io.tree.vars === nothing
+            io.cursor = io.tree.vars = TypeTreeNode(" where ")
+            endswith(str, '{') && (io.cursor.delimidx = 2)
+            io.cursor.children = TypeTreeNode[]
+            return nb
+        end
+        for c in str
+            write(io, c)
+        end
+        return nb
+    end
+    Base.unsafe_write(ioctx::IOContext{TypeTreeIO}, p::Ptr{UInt8}, nb::UInt) = unsafe_write(getttio(ioctx), p, nb)
+
+    Base.get(treeio::TypeTreeIO, key, default) = get(treeio.io, key, default)
+
+    function Base.write(treeio::TypeTreeIO, c::Char)
+        curs = treeio.cursor
+        if c ∈ ('{', '(')
+            str = String(take!(getio(treeio)))
+            if c == '(' && str == "typeof"
+                # oops, we shouldn't have grabbed this, put it back
+                print(getio(treeio), str, '(')
+                return textwidth(c)
+            end
+            if isempty(curs.name)
+                if curs.children === nothing
+                    curs.children = TypeTreeNode[]
+                end
+                curs.name = str
+                curs.delimidx = c == '(' ? 1 : 2
+            else
+                # We're dropping in depth
+                newcurs = TypeTreeNode(str, curs)
+                newcurs.delimidx = c == '(' ? 1 : 2
+                if curs.children === nothing
+                    curs.children = TypeTreeNode[]
+                end
+                push!(curs.children, newcurs)
+                treeio.cursor = newcurs
+            end
+        elseif c ∈ (',', '}', ')')
+            str = String(take!(getio(treeio)))
+            if !isempty(str)
+                if c == ')' && startswith(str, "typeof(")
+                    # put it back
+                    print(getio(treeio), str, c)
+                    return textwidth(c)
+                end
+                if curs.children === nothing
+                    curs.children = TypeTreeNode[]
+                end
+                push!(curs.children, TypeTreeNode(str, curs))
+            else
+                p = curs.parent
+                if p !== nothing
+                    treeio.cursor = p
+                end
+            end
+        elseif c != ' '
+            print(treeio.io, c)
+        end
+        return textwidth(c)
+    end
+    Base.write(treeioctx::IOContext{TypeTreeIO}, c::Char) = write(getttio(treeioctx), c)
+
+
+    ## Printing the tree with constraints on width and/or depth
+
+    const truncchar = "…"
+    const per_param = ", "
+
+    function Base.take!(io::TypeTreeIO)
+        flush(io)
+        str = sprint(show, io.tree)
+        io.tree = TypeTreeBundle(TypeTreeNode())
+        io.cursor = io.tree.body
+        return codeunits(str)
+    end
+
+    function Base.show(io::IO, bundle::TypeTreeBundle)
+        depth = get(io, :type_depth, nothing)::Union{Int,Nothing}
+        if depth === nothing
+            maxdepth = get(io, :type_maxdepth, typemax(Int))::Int
+            maxwidth = get(io, :type_maxwidth, typemax(Int))::Int
+            depth = choose_depth(bundle, maxdepth, maxwidth)
+        end
+        _print(io, bundle.body, 1, depth)
+        vars = bundle.vars
+        if vars !== nothing
+            children = vars.children
+            if children !== nothing && length(children) == 1
+                vars = children[1]
+                print(io, " where ")
+            end
+            _print(io, vars, 1, depth)
+        end
+    end
+
+    function _print(io::IO, node::TypeTreeNode, thisdepth, maxdepth)
+        print(io, node.name)
+        childs = node.children
+        if childs !== nothing
+            delimidx = node.delimidx
+            iszero(delimidx) || print(io, delims[delimidx][1])
+            if thisdepth >= maxdepth
+                print(io, truncchar)
+            else
+                n = lastindex(childs)
+                for (i, child) in pairs(childs)
+                    _print(io, child, thisdepth+1, maxdepth)
+                    i < n && print(io, per_param)
+                end
+            end
+            iszero(delimidx) || print(io, delims[delimidx][end])
+        end
+    end
+
+    function choose_depth(wd::Vector{Int}, wtrunc::Vector{Int}, maxdepth::Int, maxwidth::Int)
+        wsum, depth = 0, 1
+        while depth <= maxdepth && depth <= length(wd)
+            wsum += wd[depth]
+            if wsum + wtrunc[depth] > maxwidth
+                return depth - 1
+            end
+            depth += 1
+        end
+        return depth - 1
+    end
+    choose_depth(bundle::TypeTreeBundle, maxdepth::Int, maxwidth::Int) =
+        choose_depth(width_by_depth(bundle)..., maxdepth, maxwidth)
+
+    """
+        width_by_depth(node) → wd, wtrunc
+
+    Compute the number of characters `wd[depth]` needed to print at each `depth` within the tree.
+    Also compute the number of additional characters `wtrunc[depth]` needed if one truncates the tree at `depth`.
+    """
+    function width_by_depth(bundle::TypeTreeBundle)
+        wd, wtrunc = Int[], Int[]
+        width_by_depth!(wd, wtrunc, bundle.body, 1)
+        if bundle.vars !== nothing
+            width_by_depth!(wd, wtrunc, bundle.vars, 1)
+        end
+        return wd, wtrunc
+    end
+
+    function width_by_depth!(wd, wtrunc, node::TypeTreeNode, depth)
+        if depth > length(wd)
+            push!(wd, 0)
+            push!(wtrunc, 0)
+        end
+        wd[depth] += length(node.name)
+        childs = node.children
+        if childs !== nothing
+            delimidx = node.delimidx
+            if !iszero(delimidx)
+                wd[depth] += length(delims[node.delimidx])
+            end
+            wtrunc[depth] += length(truncchar)
+            for child in childs
+                width_by_depth!(wd, wtrunc, child, depth+1)
+            end
+            wd[depth+1] += length(per_param) * (length(childs) - 1)
+        end
+        return wd, wtrunc
+    end
+
+end
+using .TypeTreesIO
+
 function print_within_stacktrace(io, s...; color=:normal, bold=false)
     if get(io, :backtrace, false)::Bool
         printstyled(io, s...; color, bold)
@@ -2470,7 +2731,7 @@ function print_within_stacktrace(io, s...; color=:normal, bold=false)
     end
 end
 
-function show_tuple_as_call(io::IO, name::Symbol, sig::Type;
+function show_tuple_as_call(out::IO, name::Symbol, @nospecialize(sig::Type);
                             demangle=false, kwargs=nothing, argnames=nothing,
                             qualified=false, hasfirst=true)
     # print a method signature tuple for a lambda definition
@@ -2479,6 +2740,14 @@ function show_tuple_as_call(io::IO, name::Symbol, sig::Type;
         return
     end
     tv = Any[]
+    if get(out, :limit, false)::Bool
+        io = TypeTreeIO()
+        if isa(out, IOContext)
+            io = IOContext(io, out)
+        end
+    else
+        io = out
+    end
     env_io = io
     while isa(sig, UnionAll)
         push!(tv, sig.var)
@@ -2516,6 +2785,10 @@ function show_tuple_as_call(io::IO, name::Symbol, sig::Type;
     end
     print_within_stacktrace(io, ")", bold=true)
     show_method_params(io, tv)
+    if get(out, :limit, false)::Bool
+        sz = get(out, :displaysize, (typemax(Int), typemax(Int)))::Tuple{Int, Int}
+        show(IOContext(out, :type_maxwidth => sz[2]), TypeTreesIO.getttio(io).tree)
+    end
     nothing
 end
 

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -222,6 +222,11 @@ function show_spec_linfo(io::IO, frame::StackFrame)
     elseif linfo isa MethodInstance
         def = linfo.def
         if isa(def, Method)
+            if get(io, :limit, false)::Bool
+                if !haskey(io, :displaysize)
+                    io = IOContext(io, :displaysize => displaysize(io))
+                end
+            end
             sig = linfo.specTypes
             argnames = Base.method_argnames(def)
             argnames = replace(argnames, :var"#unused#" => :var"")

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -191,3 +191,88 @@ let bt
     end
     @test any(s->startswith(string(s), "f33065(x::Float32, y::Float32; b::Float64, a::String, c::"), bt)
 end
+
+@testset "TypeTreeIO" begin
+    ttio = Base.TypeTreesIO.TypeTreeIO()
+    obj = view([1, 2, 3], 1:2)
+    print(ttio, typeof(obj))
+    @test sprint(print, ttio.tree) == sprint(print, typeof(obj))
+    @test sprint((io, node) -> print(IOContext(io, :type_maxdepth=>1), node), ttio.tree) == "SubArray{…}"
+    @test sprint((io, node) -> print(IOContext(io, :type_maxdepth=>2), node), ttio.tree) == "SubArray{$Int, 1, Vector{…}, Tuple{…}, true}"
+    @test sprint((io, node) -> print(IOContext(io, :type_maxdepth=>3), node), ttio.tree) == "SubArray{$Int, 1, Vector{$Int}, Tuple{UnitRange{…}}, true}"
+    @test sprint((io, node) -> print(IOContext(io, :type_maxdepth=>4), node), ttio.tree) == "SubArray{$Int, 1, Vector{$Int}, Tuple{UnitRange{$Int}}, true}"
+    @test sprint((io, node) -> print(IOContext(io, :type_maxwidth=>3), node), ttio.tree) == "SubArray{…}"
+    @test sprint((io, node) -> print(IOContext(io, :type_maxwidth=>44), node), ttio.tree) == "SubArray{…}"
+    @test sprint((io, node) -> print(IOContext(io, :type_maxwidth=>45), node), ttio.tree) == "SubArray{$Int, 1, Vector{…}, Tuple{…}, true}"
+    @test sprint((io, node) -> print(IOContext(io, :type_maxwidth=>59), node), ttio.tree) == "SubArray{$Int, 1, Vector{…}, Tuple{…}, true}"
+    @test sprint((io, node) -> print(IOContext(io, :type_maxwidth=>60), node), ttio.tree) == "SubArray{Int64, 1, Vector{Int64}, Tuple{UnitRange{…}}, true}"
+    @test sprint((io, node) -> print(IOContext(io, :type_maxwidth=>100), node), ttio.tree) == "SubArray{$Int, 1, Vector{$Int}, Tuple{UnitRange{$Int}}, true}"
+    @test String(take!(ttio)) == sprint(print, typeof(obj))
+
+    # ttio can be reused (after `take!`)
+    typ = Vector{V} where V<:AbstractVector{T} where T<:Real
+    print(ttio, typ)
+    @test sprint(print, ttio.tree) == sprint(print, typ)
+    @test sprint((io, node) -> print(IOContext(io, :type_maxdepth=>1), node), ttio.tree) == "Vector{…} where {…}"
+    @test sprint((io, node) -> print(IOContext(io, :type_maxdepth=>2), node), ttio.tree) == "Vector{V} where {T<:Real, V<:AbstractVector{…}}"
+    @test sprint((io, node) -> print(IOContext(io, :type_maxdepth=>3), node), ttio.tree) == "Vector{V} where {T<:Real, V<:AbstractVector{T}}"
+    @test sprint((io, node) -> print(IOContext(io, :type_maxwidth=>20), node), ttio.tree) == "Vector{…} where {…}"
+    @test sprint((io, node) -> print(IOContext(io, :type_maxwidth=>46), node), ttio.tree) == "Vector{…} where {…}"
+    @test sprint((io, node) -> print(IOContext(io, :type_maxwidth=>47), node), ttio.tree) == "Vector{V} where {T<:Real, V<:AbstractVector{T}}"
+    @test String(take!(ttio)) == sprint(print, typ)
+
+    typ = Vector{T} where T<:Real
+    print(ttio, typ)
+    @test String(take!(ttio)) == sprint(print, typ)
+    # IOContext
+    print(IOContext(ttio, :color=>true), typ)
+    @test String(take!(ttio)) == sprint(print, typ)
+
+    typ = Union{Int32, T} where T
+    print(ttio, typ)
+    @test String(take!(ttio)) == sprint(print, typ)
+
+    print(ttio, Tuple{})
+    @test String(take!(ttio)) == sprint(print, Tuple{})
+
+    # Stacktrace
+    a = UInt8(81):UInt8(160)
+    b = view(a, 1:64)
+    c = reshape(b, (8, 8))
+    d = reinterpret(reshape, Float64, c)
+    sqrteach(a) = [sqrt(x) for x in a]
+    st = try
+        sqrteach(d)
+    catch e
+        stacktrace(catch_backtrace())
+    end
+    nmi = 0
+    for sf in st
+        mi = sf.linfo
+        if mi !== nothing
+            if isa(mi, Core.MethodInstance)
+                nmi += 1
+                print(ttio, mi.specTypes)
+                @test String(take!(ttio)) == sprint(print, mi.specTypes)
+            end
+        end
+        iobuf = IOBuffer()
+        ioctx = IOContext(iobuf, :limit=>true,  :color=>true, :displaysize=>(50,1000), :backtrace=>true)
+        Base.StackTraces.show_spec_linfo(ioctx, sf)
+        str = String(take!(iobuf))
+        ioctx = IOContext(iobuf, :limit=>false, :color=>true, :displaysize=>(50,1000), :backtrace=>true)
+        Base.StackTraces.show_spec_linfo(ioctx, sf)
+        @test str == String(take!(iobuf))
+    end
+    @test nmi > 0
+
+    # Whole signatures
+    m = which(show, (IO, String))
+    print(ttio, m.sig)
+    @test String(take!(ttio)) == sprint(print, m.sig)
+    print(ttio, "show(io::IO, x::String)")
+    @test String(take!(ttio)) == "show(io::IO, x::String)"
+    T = TypeVar(:T)
+    print(ttio, "show(io::IO, x::", T, ')', " where ", T)
+    @test String(take!(ttio)) == "show(io::IO, x::T) where T"
+end


### PR DESCRIPTION
Print parametric types in stacktraces up to a depth limited by screen size, printing deeper type-parameters as `...`. Complete info can be printed with a manual `show(err[1].backtrace[idx])`.

I'm posting this for feedback about the general approach, before investing more time in correctness, testing, etc. There are two ways you could go about this:
- build the tree structure from the type itself
- parse the printed output about the type to construct the tree

Perhaps surprisingly, this takes the latter approach. We do a lot of customization when we print types, like using aliases and interacting with the `IOContext` to signal whether we're deferring printing `TypeVar` constraints. Given these customizations, it seemed to make sense to use the text output to ensure uniformity. That said, I can be persuaded to go the other way.

If we like this proposal, then [FoldingTrees.jl](https://github.com/JuliaCollections/FoldingTrees.jl) can be extended with specializations to allow interactive unfolding (but this plan would require an external package).

CC @ChrisRackauckas, @storopoli 

Closes #48444

Demo (exhibiting some currently-buggy missing arguments):
```julia
julia> a = rand(UInt8, 80);

julia> b = view(a, 1:64);

julia> c = reshape(b, (8, 8));

julia> d = reinterpret(reshape, Float64, c)
8-element reinterpret(reshape, Float64, reshape(view(::Vector{UInt8}, 1:64), 8, 8)) with eltype Float64:
  1.80852721337015e220
  8.960367199887082e169
  2.2887057012581985e-127
 -5.017255012702684e-121
  8.891015307157821e288
  2.3276748109198913e-288
  8.683913364354522e-132
 -4.126925591937627e-189

julia> sqrteach(a) = [sqrt(x) for x in a]
sqrteach (generic function with 1 method)

julia> sqrteach(d)     # old stacktraces
ERROR: DomainError with -5.017255012702684e-121:
sqrt was called with a negative real argument but will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
Stacktrace:
 [1] throw_complex_domainerror(f::Symbol, x::Float64)
   @ Base.Math ./math.jl:33
 [2] sqrt
   @ ./math.jl:681 [inlined]
 [3] #3
   @ ./none:0 [inlined]
 [4] iterate
   @ ./generator.jl:47 [inlined]
 [5] collect_to!(dest::Vector{Float64}, itr::Base.Generator{Base.ReinterpretArray{Float64, 1, UInt8, Base.ReshapedArray{UInt8, 2, SubArray{UInt8, 1, Vector{UInt8}, Tuple{UnitRange{Int64}}, true}, Tuple{}}, true}, var"#3#4"}, offs::Int64, st::Tuple{Base.OneTo{Int64}, Int64})
   @ Base ./array.jl:893
 [6] collect_to_with_first!
   @ ./array.jl:871 [inlined]
 [7] collect(itr::Base.Generator{Base.ReinterpretArray{Float64, 1, UInt8, Base.ReshapedArray{UInt8, 2, SubArray{UInt8, 1, Vector{UInt8}, Tuple{UnitRange{Int64}}, true}, Tuple{}}, true}, var"#3#4"})
   @ Base ./array.jl:845
 [8] sqrteach(a::Base.ReinterpretArray{Float64, 1, UInt8, Base.ReshapedArray{UInt8, 2, SubArray{UInt8, 1, Vector{UInt8}, Tuple{UnitRange{Int64}}, true}, Tuple{}}, true})
   @ Main ./REPL[5]:1
 [9] top-level scope
   @ REPL[6]:1

julia> Revise.track(Base)      # trigger new stacktraces

julia> sqrteach(d)
ERROR: DomainError with -5.017255012702684e-121:
sqrt was called with a negative real argument but will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
Stacktrace:
 [1] throw_complex_domainerror(f::Symbol, x::Float64)
   @ Base.Math ./math.jl:33
 [2] sqrt
   @ ./math.jl:681 [inlined]
 [3] #3
   @ ./none:0 [inlined]
 [4] iterate
   @ ./generator.jl:47 [inlined]
 [5] collect_to!(dest::Vector{…})
   @ Base ./array.jl:893
 [6] collect_to_with_first!
   @ ./array.jl:871 [inlined]
 [7] collect(itr::Base.Generator{Base.ReinterpretArray{Float64, 1, UInt8, Base.ReshapedArray{…}}, true}, var"#3#4", )
   @ Base ./array.jl:845
 [8] sqrteach(a::Base.ReinterpretArray{Float64, 1, UInt8, Base.ReshapedArray{UInt8, 2, SubArray{…}, Tuple}}, true, )
   @ Main ./REPL[5]:1
 [9] top-level scope
   @ REPL[8]:1

julia> show(err[1].backtrace[5])    # we can still see all the info if we want
collect_to!(dest::Vector{Float64}, itr::Base.Generator{Base.ReinterpretArray{Float64, 1, UInt8, Base.ReshapedArray{UInt8, 2, SubArray{UInt8, 1, Vector{UInt8}, Tuple{UnitRange{Int64}}, true}, Tuple{}}, true}, var"#3#4"}, offs::Int64, st::Tuple{Base.OneTo{Int64}, Int64}) at array.jl:893
```
