### PR TITLE
inference: make `throw` block deoptimization concrete-eval friendly

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -457,7 +457,8 @@ struct REPLInterpreter <: CC.AbstractInterpreter
     code_cache::REPLInterpreterCache
     function REPLInterpreter(repl_frame::CC.InferenceResult;
                              world::UInt = Base.get_world_counter(),
-                             inf_params::CC.InferenceParams = CC.InferenceParams(),
+                             inf_params::CC.InferenceParams = CC.InferenceParams(;
+                                unoptimize_throw_blocks=false),
                              opt_params::CC.OptimizationParams = CC.OptimizationParams(),
                              inf_cache::Vector{CC.InferenceResult} = CC.InferenceResult[],
                              code_cache::REPLInterpreterCache = get_code_cache())

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1842,6 +1842,24 @@ let s = "Ref(Issue36437(42))[]."
     @test "v" ∉ c
 end
 
+# concrete evaluation throught `getindex`ing dictionary
+global_dict = Dict{Symbol, Any}(:a => r"foo")
+let s = "global_dict[:a]."
+    c, r, res = test_complete_context(s, @__MODULE__)
+    @test res
+    for fname in fieldnames(Regex)
+        @test String(fname) in c
+    end
+end
+global_dict_nested = Dict{Symbol, Any}(:a => global_dict)
+let s = "global_dict_nested[:a][:a]."
+    c, r, res = test_complete_context(s, @__MODULE__)
+    @test res
+    for fname in fieldnames(Regex)
+        @test String(fname) in c
+    end
+end
+
 const global_xs = [Some(42)]
 let s = "pop!(global_xs)."
     c, r, res = test_complete_context(s, @__MODULE__)

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1495,8 +1495,10 @@ end
 
 # getindex is :effect_free and :terminates but not :consistent
 for T in (Int, Float64, String, Symbol)
-    @test !Core.Compiler.is_consistent(Base.infer_effects(getindex, (Dict{T,Any}, T)))
-    @test Core.Compiler.is_effect_free(Base.infer_effects(getindex, (Dict{T,Any}, T)))
-    @test !Core.Compiler.is_nothrow(Base.infer_effects(getindex, (Dict{T,Any}, T)))
-    @test Core.Compiler.is_terminates(Base.infer_effects(getindex, (Dict{T,Any}, T)))
+    @testset let T=T
+        @test !Core.Compiler.is_consistent(Base.infer_effects(getindex, (Dict{T,Any}, T)))
+        @test_broken Core.Compiler.is_effect_free(Base.infer_effects(getindex, (Dict{T,Any}, T)))
+        @test !Core.Compiler.is_nothrow(Base.infer_effects(getindex, (Dict{T,Any}, T)))
+        @test_broken Core.Compiler.is_terminates(Base.infer_effects(getindex, (Dict{T,Any}, T)))
+    end
 end


### PR DESCRIPTION
The deoptimization can sometimes destroy the effects analysis and disable [semi-]concrete evaluation that is otherwise possible. This is because the deoptimization was designed with the type domain profitability in mind (#35982), and hasn't been adequately considering the effects domain.

This commit makes the deoptimization aware of the effects domain more and enables the `throw` block deoptimization only when the effects already known to be ineligible for concrete-evaluation.

In our current effect system, `ALWAYS_FALSE`/`false` means that the effect can not be refined to `ALWAYS_TRUE`/`true` anymore (unless given user annotation later). Therefore we can enable the `throw` block deoptimization without hindering the chance of concrete-evaluation when any of the following conditions are met:
- `effects.consistent === ALWAYS_FALSE`
- `effects.effect_free === ALWAYS_FALSE`
- `effects.terminates === false`
- `effects.nonoverlayed === false`

Here are some numbers:

| Metric                  | master    | this commit | #35982 reverted (set `unoptimize_throw_blocks=false`) |
|-------------------------|-----------|-------------|--------------------------------------------|
| Base (seconds)          | 15.579300 | 15.206645   | 15.296319                                  |
| Stdlibs (seconds)       | 17.919013 | 17.667094   | 17.738128                                  |
| Total (seconds)         | 33.499279 | 32.874737   | 33.035448                                  |
| Precompilation (seconds) | 49.967516 | 49.421121  | 49.999998                                  |
| First time `plot(rand(10,3))` [^1] | `2.476678 seconds (11.74 M allocations)` | `2.430355 seconds (11.77 M allocations)` | `2.514874 seconds (11.64 M allocations)` |
| First time `solve(prob, QNDF())(5.0)` [^2] | `4.469492 seconds (15.32 M allocations)` | `4.499217 seconds (15.41 M allocations)` | `4.470772 seconds (15.38 M allocations)` |

[^1]: With disabling precompilation of Plots.jl.
[^2]: With disabling precompilation of OrdinaryDiffEq.

These numbers made me question if we are getting any actual benefit from
the `throw` block deoptimization anymore. Since it is sometimes harmful
for the effects analysis, we probably want to either merge this commit
or remove the `throw` block deoptimization completely.