### PR TITLE
Export jl_method_set_source.

### DIFF
--- a/src/method.c
+++ b/src/method.c
@@ -665,7 +665,7 @@ jl_method_instance_t *jl_get_specialized(jl_method_t *m, jl_value_t *types, jl_s
     return new_linfo;
 }
 
-static void jl_method_set_source(jl_method_t *m, jl_code_info_t *src)
+JL_DLLEXPORT void jl_method_set_source(jl_method_t *m, jl_code_info_t *src)
 {
     uint8_t j;
     uint8_t called = 0;


### PR DESCRIPTION
I need this to re-implement `jl_make_opaque_closure_method` for GPU-compatible opaque closures. Alternatively, exporting `jl_make_opaque_closure_method` would work too since it doesn't actually do anything GPU-incompatible, but I figured it is cleaner to reimplement that method since nothing about OpaqueClosures is supposed to be GPU-compatible.