### PR TITLE
(re-)allow include_dependency(directory)

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1543,11 +1543,11 @@ end
 """
     include_dependency(path::AbstractString)
 
-In a module, declare that the file specified by `path` (relative or absolute) is a
-dependency for precompilation; that is, the module will need to be recompiled if this file
-changes.
+In a module, declare that the file, directory, or symbolic link specified by `path`
+(relative or absolute) is a dependency for precompilation; that is, the module will need
+to be recompiled if the modification time of `path` changes.
 
-This is only needed if your module depends on a file that is not used via [`include`](@ref). It has
+This is only needed if your module depends on a path that is not used via [`include`](@ref). It has
 no effect outside of compilation.
 """
 function include_dependency(path::AbstractString)
@@ -2822,7 +2822,7 @@ end
             end
             for chi in includes
                 f, ftime_req = chi.filename, chi.mtime
-                if !isfile(f)
+                if !ispath(f)
                     _f = fixup_stdlib_path(f)
                     if isfile(_f) && startswith(_f, Sys.STDLIB)
                         # mtime is changed by extraction


### PR DESCRIPTION
This would allow using a directory for `include_dependency(path)` to track whether any file or subdirectory is added.

This was working fine (for Oscar.jl) in Julia 1.6 and 1.8 but since #47184 (in master and 1.9) the cache file is rejected with the following error and a fresh precompilation is triggered every time Oscar is loaded:
```
┌ Debug: Rejecting stale cache file <...>/aJ3Pg_wOMvI.ji because file <...>/Oscar.jl/experimental does not exist
```
Here `experimental` is a subfolder where developers can add extra code that will then be picked up without adding all files explicitly to some list in the main Oscar sources.

I am aware that the docs for `include_dependency` only mention `file`, I understood `file` here in a more file-system oriented way and not strictly as `regular file`, similar to how it is used in the docs for `stat`.

I adjusted the docs for `include_dependency` accordingly and clarified that this uses the mtime of `path`.

cc: @lkastner
x-ref: https://github.com/oscar-system/Oscar.jl/issues/2203