### PR TITLE
Fix LazyString building with non-ASCII preceding $

### DIFF
--- a/base/strings/lazy.jl
+++ b/base/strings/lazy.jl
@@ -67,7 +67,7 @@ macro lazy_str(text)
     parts = Any[]
     lastidx = idx = 1
     while (idx = findnext('$', text, idx)) !== nothing
-        lastidx < idx && push!(parts, text[lastidx:idx-1])
+        lastidx < idx && push!(parts, text[lastidx:prevind(text, idx)])
         idx += 1
         expr, idx = Meta.parseatom(text, idx; filename=string(__source__.file))
         push!(parts, esc(expr))

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -1191,6 +1191,9 @@ end
         end
         return a
     end |> Core.Compiler.is_foldable
+    let i=49248
+        @test String(lazy"PR n°$i") == "PR n°49248"
+    end
 end
 
 @testset "String Effects" begin


### PR DESCRIPTION
Simple bugfix for building `LazyString` with an `$` sign just after a character of encoding longer than one codeunit.

master:
```julia
julia> lazy"foo n°$3"
ERROR: LoadError: StringIndexError: invalid index [7], valid nearby indices [6]=>'°', [8]=>'$'
Stacktrace:
 [1] string_index_err(s::String, i::Int64)
   @ Base ./strings/string.jl:12
 [2] getindex(s::String, r::UnitRange{Int64})
   @ Base ./strings/string.jl:279
 [3] var"@lazy_str"(__source__::LineNumberNode, __module__::Module, text::Any)
   @ Base ./strings/lazy.jl:70
in expression starting at REPL[8]:1
```

This PR:
```julia
julia> lazy"foo n°$3"
"foo n°3"
```