### PR TITLE
Some simple intersection/subtyping performance tuning.

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -694,6 +694,7 @@ JL_DLLEXPORT int jl_type_morespecific_no_subtype(jl_value_t *a, jl_value_t *b);
 jl_value_t *jl_instantiate_type_with(jl_value_t *t, jl_value_t **env, size_t n);
 JL_DLLEXPORT jl_value_t *jl_instantiate_type_in_env(jl_value_t *ty, jl_unionall_t *env, jl_value_t **vals);
 jl_value_t *jl_substitute_var(jl_value_t *t, jl_tvar_t *var, jl_value_t *val);
+jl_unionall_t *jl_rename_unionall(jl_unionall_t *u);
 JL_DLLEXPORT jl_value_t *jl_unwrap_unionall(jl_value_t *v JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_rewrap_unionall(jl_value_t *t, jl_value_t *u);
 JL_DLLEXPORT jl_value_t *jl_rewrap_unionall_(jl_value_t *t, jl_value_t *u);

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -630,17 +630,6 @@ static jl_value_t *simple_meet(jl_value_t *a, jl_value_t *b, int overesi)
     return overesi ? b : jl_bottom_type;
 }
 
-static jl_unionall_t *rename_unionall(jl_unionall_t *u)
-{
-    jl_tvar_t *v = jl_new_typevar(u->var->name, u->var->lb, u->var->ub);
-    jl_value_t *t = NULL;
-    JL_GC_PUSH2(&v, &t);
-    t = jl_instantiate_unionall(u, (jl_value_t*)v);
-    t = jl_new_struct(jl_unionall_type, v, t);
-    JL_GC_POP();
-    return (jl_unionall_t*)t;
-}
-
 // main subtyping algorithm
 
 static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param);
@@ -935,7 +924,7 @@ static jl_unionall_t *unalias_unionall(jl_unionall_t *u, jl_stenv_t *e)
             // outer var can only refer to inner var if bounds changed
             (btemp->lb != btemp->var->lb && jl_has_typevar(btemp->lb, u->var)) ||
             (btemp->ub != btemp->var->ub && jl_has_typevar(btemp->ub, u->var))) {
-            u = rename_unionall(u);
+            u = jl_rename_unionall(u);
             break;
         }
         btemp = btemp->prev;
@@ -2945,7 +2934,7 @@ static jl_value_t *intersect_unionall_(jl_value_t *t, jl_unionall_t *u, jl_stenv
         }
         if (btemp->var == u->var || btemp->lb == (jl_value_t*)u->var ||
             btemp->ub == (jl_value_t*)u->var) {
-            u = rename_unionall(u);
+            u = jl_rename_unionall(u);
             break;
         }
         btemp = btemp->prev;


### PR DESCRIPTION
This PR includes some pieces of performance tuning:
1. The first commit enables separatable subtyping for local for-all check, which would avoid unneeded `save_env`.
Since #49215 has been landed, the improvement might not be large. (But still good to have.)

2. The second commit implements the idea from [here](https://github.com/JuliaLang/julia/pull/49215#issuecomment-1496038171).
It skips the unneeded subtyping/normalization during `rename_unionall`, make internal type copy slightly faster.

3. The last commit slightly tunes our re-intersection logic, which mtigates #48821.

Some benchmark
```julia
julia> @time using OmniPackage # remove Flux/MLJFlux
 20.477278 seconds (30.84 M allocations: 1.678 GiB, 11.54% gc time, 14.75% compilation time: 74% of which was recompilation) # master
 17.522497 seconds (24.48 M allocations: 1.388 GiB, 9.45% gc time, 15.61% compilation time: 73% of which was recompilation) # this PR
```