### PR TITLE
Inline StepRange construction

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -526,7 +526,7 @@ module IteratorsMD
         dimrev = ntuple(i -> sum(==(i), dims; init = 0) == 1, Val(length(indices)))
         length(dims) == sum(dimrev) || throw(ArgumentError(Base.LazyString("invalid dimensions ", dims, " in reverse")))
         length(dims) == length(indices) && return Base._reverse(iter, :)
-        indices′ = map((i, f) -> f ? reverse(i) : i, indices, dimrev)
+        indices′ = map((i, f) -> f ? (@noinline reverse(i)) : i, indices, dimrev)
         return CartesianIndices(indices′)
     end
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -20,8 +20,8 @@
 (:)(start::T, step::T, stop::T) where {T<:AbstractFloat} =
     _colon(OrderStyle(T), ArithmeticStyle(T), start, step, stop)
 (:)(start::T, step::T, stop::T) where {T<:Real} =
-    (@inline; _colon(OrderStyle(T), ArithmeticStyle(T), start, step, stop))
-_colon(::Ordered, ::Any, start::T, step, stop::T) where {T} = (@inline; StepRange(start, step, stop))
+    _colon(OrderStyle(T), ArithmeticStyle(T), start, step, stop)
+_colon(::Ordered, ::Any, start::T, step, stop::T) where {T} = StepRange(start, step, stop)
 # for T<:Union{Float16,Float32,Float64} see twiceprecision.jl
 _colon(::Ordered, ::ArithmeticRounds, start::T, step, stop::T) where {T} =
     StepRangeLen(start, step, convert(Integer, fld(stop - start, step)) + 1)
@@ -319,7 +319,6 @@ struct StepRange{T,S} <: OrdinalRange{T,S}
     stop::T
 
     function StepRange{T,S}(start, step, stop) where {T,S}
-        @inline
         start = convert(T, start)
         step = convert(S, step)
         stop = convert(T, stop)
@@ -329,7 +328,6 @@ end
 
 # to make StepRange constructor inlineable, so optimizer can see `step` value
 function steprange_last(start, step, stop)::typeof(stop)
-    @inline
     if isa(start, AbstractFloat) || isa(step, AbstractFloat)
         throw(ArgumentError("StepRange should not be used with floating point"))
     end
@@ -352,7 +350,8 @@ function steprange_last(start, step, stop)::typeof(stop)
             # Compute remainder as a nonnegative number:
             if absdiff isa Signed && absdiff < zero(absdiff)
                 # unlikely, but handle the signed overflow case with unsigned rem
-                remain = convert(typeof(absdiff), unsigned(absdiff) % absstep)
+                overflow_case(absdiff, absstep) = (@noinline; convert(typeof(absdiff), unsigned(absdiff) % absstep))
+                remain = overflow_case(absdiff, absstep)
             else
                 remain = convert(typeof(absdiff), absdiff % absstep)
             end
@@ -376,8 +375,8 @@ end
 # For types where x+oneunit(x) may not be well-defined use the user-given value for stop
 steprange_last_empty(start, step, stop) = stop
 
-StepRange{T}(start, step::S, stop) where {T,S} = (@inline; StepRange{T,S}(start, step, stop))
-StepRange(start::T, step::S, stop::T) where {T,S} = (@inline; StepRange{T,S}(start, step, stop))
+StepRange{T}(start, step::S, stop) where {T,S} = StepRange{T,S}(start, step, stop)
+StepRange(start::T, step::S, stop::T) where {T,S} = StepRange{T,S}(start, step, stop)
 
 """
     UnitRange{T<:Real}

--- a/base/range.jl
+++ b/base/range.jl
@@ -20,8 +20,8 @@
 (:)(start::T, step::T, stop::T) where {T<:AbstractFloat} =
     _colon(OrderStyle(T), ArithmeticStyle(T), start, step, stop)
 (:)(start::T, step::T, stop::T) where {T<:Real} =
-    _colon(OrderStyle(T), ArithmeticStyle(T), start, step, stop)
-_colon(::Ordered, ::Any, start::T, step, stop::T) where {T} = StepRange(start, step, stop)
+    (@inline; _colon(OrderStyle(T), ArithmeticStyle(T), start, step, stop))
+_colon(::Ordered, ::Any, start::T, step, stop::T) where {T} = (@inline; StepRange(start, step, stop))
 # for T<:Union{Float16,Float32,Float64} see twiceprecision.jl
 _colon(::Ordered, ::ArithmeticRounds, start::T, step, stop::T) where {T} =
     StepRangeLen(start, step, convert(Integer, fld(stop - start, step)) + 1)
@@ -319,6 +319,7 @@ struct StepRange{T,S} <: OrdinalRange{T,S}
     stop::T
 
     function StepRange{T,S}(start, step, stop) where {T,S}
+        @inline
         start = convert(T, start)
         step = convert(S, step)
         stop = convert(T, stop)
@@ -328,6 +329,7 @@ end
 
 # to make StepRange constructor inlineable, so optimizer can see `step` value
 function steprange_last(start, step, stop)::typeof(stop)
+    @inline
     if isa(start, AbstractFloat) || isa(step, AbstractFloat)
         throw(ArgumentError("StepRange should not be used with floating point"))
     end
@@ -374,8 +376,8 @@ end
 # For types where x+oneunit(x) may not be well-defined use the user-given value for stop
 steprange_last_empty(start, step, stop) = stop
 
-StepRange{T}(start, step::S, stop) where {T,S} = StepRange{T,S}(start, step, stop)
-StepRange(start::T, step::S, stop::T) where {T,S} = StepRange{T,S}(start, step, stop)
+StepRange{T}(start, step::S, stop) where {T,S} = (@inline; StepRange{T,S}(start, step, stop))
+StepRange(start::T, step::S, stop::T) where {T,S} = (@inline; StepRange{T,S}(start, step, stop))
 
 """
     UnitRange{T<:Real}

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Base.Checked: checked_length
+using InteractiveUtils: code_llvm
 
 @testset "range construction" begin
     @test_throws ArgumentError range(start=1, step=1, stop=2, length=10)
@@ -2417,7 +2418,7 @@ end
         return c
     end
 
-    llvm_ir(f, args) = sprint(code_llvm, f, Base.typesof(args...), false, false, true, :none)
+    llvm_ir(f, args) = sprint((io, args...) -> code_llvm(io, args...; debuginfo=:none), f, Base.typesof(args...))
 
     ir = llvm_ir(test, (x, a))
     @test !occursin("steprange_last", ir)


### PR DESCRIPTION
This can improve performance when iterating over a range with a step as currently `steprange_last` is not inlined. 

```julia
using BenchmarkTools

x = rand(Float32, 80)
a = rand(round(Int, length(x) / 2):length(x), 10^6)

function test(x, a)
    c = zero(Float32)

    for j in a
        for i in 1:8:j
            c += x[i]
        end
    end

    return c
end
```

On 1bf65b9907 (similar results on 1.8.5), 
```julia
julia> @benchmark test($x, $a)
BenchmarkTools.Trial: 380 samples with 1 evaluation.
 Range (min … max):  12.714 ms …  20.363 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     13.091 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   13.141 ms ± 470.076 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

        ▄▄▁  ▁▂█▃▂▅▃▆▇▁▂ ▂                                      
  ▃▁▁▃▃▆████▇██████████████▇▆▄▅▄▃▃▃▃▃▁▃▃▁▁▃▁▁▁▁▁▃▁▁▁▁▁▁▁▃▁▃▃▁▃ ▄
  12.7 ms         Histogram: frequency by time         14.1 ms <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

With this change
```julia
julia> @benchmark test($x, $a)
BenchmarkTools.Trial: 669 samples with 1 evaluation.
 Range (min … max):  7.376 ms …  8.252 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     7.459 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   7.465 ms ± 57.103 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

              ▂▆▂▆▇█▆█▆█▂▇▆▄▇▄▆█▄ ▂▂▂▁▄                       
  ▃▃▂▂▄▄▁▄▆▆████████████████████████████▄▅▄▄▄▄▅▄▄▃▃▄▂▄▂▃▄▂▁▂ ▅
  7.38 ms        Histogram: frequency by time        7.58 ms <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

While this is a contrived example, if using SIMD.jl you want to loop over `1:8:length(x)` and if that's in an inner loop that can't be inlined or if the length is changing this will improve performance.

See https://discourse.julialang.org/t/iterating-over-range-is-slower-than-while-loop/96991 for investigation.