### PR TITLE
memoize the freevars list, so less recursion is needed in subtyping

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -109,6 +109,7 @@ jl_datatype_t *jl_new_uninitialized_datatype(void)
     t->name = NULL;
     t->super = NULL;
     t->parameters = NULL;
+    t->freevars = NULL;
     t->layout = NULL;
     t->types = NULL;
     t->instance = NULL;
@@ -715,7 +716,8 @@ JL_DLLEXPORT jl_datatype_t *jl_new_datatype(
     t->super = super;
     if (super != NULL) jl_gc_wb(t, t->super);
     t->parameters = parameters;
-    jl_gc_wb(t, t->parameters);
+    t->freevars = parameters;
+    jl_gc_wb(t, parameters);
     t->types = ftypes;
     if (ftypes != NULL) jl_gc_wb(t, t->types);
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -538,6 +538,7 @@ typedef struct _jl_datatype_t {
     jl_typename_t *name;
     struct _jl_datatype_t *super;
     jl_svec_t *parameters;
+    jl_svec_t *freevars;
     jl_svec_t *types;
     jl_value_t *instance;  // for singletons
     const jl_datatype_layout_t *layout;

--- a/test/core.jl
+++ b/test/core.jl
@@ -21,7 +21,7 @@ for (T, c) in (
         (Core.TypeMapEntry, [:sig, :simplesig, :guardsigs, :min_world, :max_world, :func, :isleafsig, :issimplesig, :va]),
         (Core.TypeMapLevel, []),
         (Core.TypeName, [:name, :module, :names, :atomicfields, :constfields, :wrapper, :mt, :hash, :n_uninitialized, :flags]),
-        (DataType, [:name, :super, :parameters, :instance, :hash]),
+        (DataType, [:name, :super, :parameters, :freevars, :instance, :hash]),
         (TypeVar, [:name, :ub, :lb]),
     )
     @test Set((fieldname(T, i) for i in 1:fieldcount(T) if isconst(T, i))) == Set(c)
@@ -5877,11 +5877,11 @@ function f_unused_undefined_sp(::T...) where T
 end
 @test_throws UndefVarError(:T) f_unused_undefined_sp()
 
-# note: the constant `5` here should be > DataType.ninitialized.
+# note: the constant `6` here should be > DataType.ninitialized.
 # This tests that there's no crash due to accessing Type.body.layout.
-let f(n) = isdefined(typeof(n), 5)
+let f(n) = isdefined(typeof(n), 6)
     @test f(0) === false
-    @test isdefined(Int, 5) === false
+    @test isdefined(Int, 6) === false
 end
 
 # @isdefined in a loop


### PR DESCRIPTION
This is an experiment to see if this particularly operation of subtyping can be made less costly. Profile measurements on master indicate this can take over 10% of the cost of subtyping (perhaps as much as 30%), and since it enables an important fast-path, it is worthwhile to check this that frequently, plus, it is necessary to call whenever we try to allocate a new UnionAll wrapper. This costs a few percent extra memory, but appears to be nearly free to compute in my measurements. Marking as draft currently since it doesn't seem to be very much faster yet either (unwrapping the unionall is still a bit significantly costly perhaps and resulting in deep recursion).