### PR TITLE
Remove unneeded allocations in `ldiv!(::QRPivoted, ...)`

### DIFF
--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -531,45 +531,90 @@ end
 
 # Julia implementation similar to xgelsy
 function ldiv!(A::QRPivoted{T,<:StridedMatrix}, B::AbstractMatrix{T}, rcond::Real) where {T<:BlasFloat}
-    mA, nA = size(A.factors)
-    nr = min(mA,nA)
-    nrhs = size(B, 2)
-    if nr == 0
+    require_one_based_indexing(B)
+    m, n = size(A)
+
+    if m > size(B, 1) || n > size(B, 1)
+        throw(DimensionMismatch("B has leading dimension $(size(B, 1)) but needs at least $(max(m, n))"))
+    end
+
+    if length(A.factors) == 0 || length(B) == 0
         return B, 0
     end
-    ar = abs(A.factors[1])
-    if ar == 0
-        B[1:nA, :] .= 0
-        return B, 0
-    end
-    rnk = 1
-    xmin = T[1]
-    xmax = T[1]
-    tmin = tmax = ar
-    while rnk < nr
-        tmin, smin, cmin = LAPACK.laic1!(2, xmin, tmin, view(A.factors, 1:rnk, rnk + 1), A.factors[rnk + 1, rnk + 1])
-        tmax, smax, cmax = LAPACK.laic1!(1, xmax, tmax, view(A.factors, 1:rnk, rnk + 1), A.factors[rnk + 1, rnk + 1])
-        tmax*rcond > tmin && break
-        push!(xmin, cmin)
-        push!(xmax, cmax)
-        for i = 1:rnk
-            xmin[i] *= smin
-            xmax[i] *= smax
+
+    @inbounds begin
+        smin = smax = abs(A.factors[1])
+
+        if smax == 0
+            return fill!(B, 0), 0
         end
-        rnk += 1
+
+        mn = min(m, n)
+
+        # allocate temporary work space
+        tmp  = Vector{T}(undef, 2mn)
+        wmin = view(tmp, 1:mn)
+        wmax = view(tmp, mn+1:2mn)
+
+        rnk = 1
+        wmin[1] = 1
+        wmax[1] = 1
+
+        while rnk < mn
+            i = rnk + 1
+
+            smin, s1, c1 = LAPACK.laic1!(2, view(wmin, 1:rnk), smin, view(A.factors, 1:rnk, i), A.factors[i,i])
+            smax, s2, c2 = LAPACK.laic1!(1, view(wmax, 1:rnk), smax, view(A.factors, 1:rnk, i), A.factors[i,i])
+
+            if smax*rcond > smin
+                break
+            end
+
+            for j in 1:rnk
+                wmin[j] *= s1
+                wmax[j] *= s2
+            end
+            wmin[i] = c1
+            wmax[i] = c2
+
+            rnk += 1
+        end
+
+        if rnk < n
+            C, τ = LAPACK.tzrzf!(A.factors[1:rnk, :])
+            work = vec(C)
+        else
+            C, τ = A.factors, A.τ
+            work = resize!(tmp, n)
+        end
+
+        lmul!(adjoint(A.Q), view(B, 1:m, :))
+        ldiv!(UpperTriangular(view(C, 1:rnk, 1:rnk)), view(B, 1:rnk, :))
+
+        if rnk < n
+            B[rnk+1:n,:] .= zero(T)
+            LAPACK.ormrz!('L', T <: Complex ? 'C' : 'T', C, τ, view(B, 1:n, :))
+        end
+
+        for j in axes(B, 2)
+            for i in 1:n
+                work[A.p[i]] = B[i,j]
+            end
+            for i in 1:n
+                B[i,j] = work[i]
+            end
+        end
     end
-    C, τ = LAPACK.tzrzf!(A.factors[1:rnk, :])
-    lmul!(A.Q', view(B, 1:mA, :))
-    ldiv!(UpperTriangular(view(C, :, 1:rnk)), view(B, 1:rnk, :))
-    B[rnk+1:end,:] .= zero(T)
-    LAPACK.ormrz!('L', eltype(B)<:Complex ? 'C' : 'T', C, τ, view(B, 1:nA, :))
-    B[A.p,:] = B[1:nA,:]
+
     return B, rnk
 end
+
 ldiv!(A::QRPivoted{T,<:StridedMatrix}, B::AbstractVector{T}) where {T<:BlasFloat} =
     vec(ldiv!(A, reshape(B, length(B), 1)))
 ldiv!(A::QRPivoted{T,<:StridedMatrix}, B::AbstractMatrix{T}) where {T<:BlasFloat} =
-    ldiv!(A, B, min(size(A)...)*eps(real(float(one(eltype(B))))))[1]
+    ldiv!(A, B, min(size(A)...)*eps(real(T)))[1]
+
+
 function _wide_qr_ldiv!(A::QR{T}, B::AbstractMatrix{T}) where T
     m, n = size(A)
     minmn = min(m,n)


### PR DESCRIPTION
This PR aims to improve the performance of `ldiv!(A::QRPivoted, ...)` by
1. eliminating redundant calls to LAPACK for matrices with a rank of `size(A, 2)`
2. pre-allocating/reusing temporary arrays for inverse permutation of the solution

Additionally, this PR introduces one (breaking?) change in the case where the right hand side array is larger than than the solution array. The previous implementation zeroed out the solution array, whereas this PR follows the `LAPACK.xgelsy` implementation and the array is no longer zeroed out.

If we allow A to be modified in-place, we could further reduce allocations.

Some benchmarks: 
```julia
julia> versioninfo()
Julia Version 1.9.0-rc2
Commit 72aec423c2a (2023-04-01 10:41 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 36 × Intel(R) Xeon(R) W-2195 CPU @ 2.30GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-14.0.6 (ORCJIT, skylake-avx512)
  Threads: 36 on 36 virtual cores
 ```
 
 ```julia 
Random.seed!(1234)

for nrhs in (1, 100_000), n in (5, 100), m in (5, 100)
    @info "m = $m, n = $n, nrhs = $nrhs"
    local A = qr(randn(m, n), ColumnNorm())
    local B = randn(max(m, n), nrhs)

    @assert ldiv!(A, copy(B))[1:n,:] ≈ proposed_ldiv!(A, copy(B))[1:n,:]

    @btime ldiv!(a, b) setup=(a=deepcopy($A); b = copy($B))
    @btime proposed_ldiv!(a, b) setup=(a=deepcopy($A); b = copy($B))
    println()
end

[ Info: m = 5, n = 5, nrhs = 1
  2.241 μs (36 allocations: 68.03 KiB)
  1.668 μs (27 allocations: 34.52 KiB)
  
[ Info: m = 100, n = 5, nrhs = 1
  2.784 μs (36 allocations: 68.03 KiB)
  2.069 μs (27 allocations: 34.52 KiB)
  
[ Info: m = 5, n = 100, nrhs = 1
  7.454 μs (37 allocations: 73.95 KiB)
  7.210 μs (35 allocations: 73.02 KiB)
  
[ Info: m = 100, n = 100, nrhs = 1
  130.408 μs (611 allocations: 186.70 KiB)
  113.923 μs (597 allocations: 71.77 KiB)
  
[ Info: m = 5, n = 5, nrhs = 100000
  2.511 ms (37 allocations: 52.71 MiB)
  1.805 ms (27 allocations: 24.45 MiB)
  
[ Info: m = 100, n = 5, nrhs = 100000
  25.738 ms (37 allocations: 52.71 MiB)
  17.931 ms (27 allocations: 24.45 MiB)
  
[ Info: m = 5, n = 100, nrhs = 100000
  78.122 ms (38 allocations: 125.19 MiB)
  34.130 ms (35 allocations: 48.90 MiB)
  
[ Info: m = 100, n = 100, nrhs = 100000
  282.322 ms (612 allocations: 125.30 MiB)
  146.832 ms (597 allocations: 24.48 MiB)
  
...
  
  [ Info: m = 100, n = 95, nrhs = 1
  126.734 μs (582 allocations: 177.14 KiB)
  111.139 μs (567 allocations: 69.72 KiB)
  
[ Info: m = 95, n = 100, nrhs = 1
  223.025 μs (583 allocations: 204.72 KiB)
  220.735 μs (576 allocations: 201.64 KiB)
  
[ Info: m = 100, n = 95, nrhs = 100000
  273.032 ms (583 allocations: 121.48 MiB)
  143.162 ms (567 allocations: 24.48 MiB)
  
[ Info: m = 95, n = 100, nrhs = 100000
  280.939 ms (584 allocations: 125.32 MiB)
  236.457 ms (576 allocations: 49.02 MiB)

  ```