### PR TITLE
Fix debug assert when using module as tparam

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -347,6 +347,8 @@ static uintptr_t type_object_id_(jl_value_t *v, jl_varidx_t *env) JL_NOTSAFEPOIN
     }
     if (tv == jl_symbol_type)
         return ((jl_sym_t*)v)->hash;
+    if (tv == jl_module_type)
+        return ((jl_module_t*)v)->hash;
     assert(!tv->name->mutabl);
     return immut_id_(tv, v, tv->hash);
 }

--- a/test/core.jl
+++ b/test/core.jl
@@ -7977,3 +7977,7 @@ end
 
 f48950(::Union{Int,d}, ::Union{c,Nothing}...) where {c,d} = 1
 @test f48950(1, 1, 1) == 1
+
+# Module as tparam in unionall
+struct ModTParamUnionAll{A, B}; end
+@test isa(objectid(ModTParamUnionAll{Base}), UInt)


### PR DESCRIPTION
This was an oversight in the implementation of #47749 and caused spurious asserts in debug mode:

```
julia> struct Foo{A, B}; end

julia> Foo{Base}
julia-debug: /home/keno/julia/src/builtins.c:350: type_object_id_: Assertion `!tv->name->mutabl' failed.
```