### PR TITLE
fix new scope assignment warning in Distributed

### DIFF
--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -704,7 +704,7 @@ clear!(wp)
 # default_worker_pool! tests
 wp_default = Distributed.default_worker_pool()
 try
-    wp = CachingPool(workers())
+    local wp = CachingPool(workers())
     Distributed.default_worker_pool!(wp)
     @test [1:100...] == pmap(x->x, wp, 1:100)
     @test !isempty(wp.map_obj2ref)


### PR DESCRIPTION
Disambiguate scope of the `wp` variable inside `try`-`catch` in distributed tests by qualifying it and suppress the warning reported in the tests.

fixes #49289