### PR TITLE
fix `isinteractive()` from sysimage `__init__`s

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -220,7 +220,7 @@ function exec_options(opts)
     history_file          = (opts.historyfile != 0)
     color_set             = (opts.color != 0) # --color!=auto
     global have_color     = color_set ? (opts.color == 1) : nothing # --color=on
-    global is_interactive = (opts.isinteractive != 0)
+    is_interactive        = (opts.isinteractive != 0)
 
     # pre-process command line argument list
     arg_is_program = !isempty(ARGS)
@@ -261,8 +261,8 @@ function exec_options(opts)
         invokelatest(Main.Distributed.process_opts, opts)
     end
 
-    interactiveinput = (repl || is_interactive::Bool) && isa(stdin, TTY)
-    is_interactive::Bool |= interactiveinput
+    interactiveinput = (repl || is_interactive) && isa(stdin, TTY)
+    is_interactive |= interactiveinput
 
     # load ~/.julia/config/startup.jl file
     if startup
@@ -270,7 +270,7 @@ function exec_options(opts)
             load_julia_startup()
         catch
             invokelatest(display_error, scrub_repl_backtrace(current_exceptions()))
-            !(repl || is_interactive::Bool) && exit(1)
+            !(repl || is_interactive) && exit(1)
         end
     end
 
@@ -543,7 +543,7 @@ function _start()
         invokelatest(display_error, scrub_repl_backtrace(current_exceptions()))
         exit(1)
     end
-    if is_interactive && get(stdout, :color, false)
+    if isinteractive() && get(stdout, :color, false)
         print(color_normal)
     end
 end

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -30,14 +30,12 @@ exit() = exit(0)
 
 const roottask = current_task()
 
-is_interactive = false
-
 """
     isinteractive() -> Bool
 
 Determine whether Julia is running an interactive session.
 """
-isinteractive() = (is_interactive::Bool)
+isinteractive() = JLOptions().isinteractive != 0
 
 ## package depots (registries, packages, environments) ##
 


### PR DESCRIPTION
I'm wondering if this would be a reasonable fix for https://github.com/JuliaLang/julia/issues/42425 to make `isinteractive()` return true from an `__init__()` in a sysimage used in an interactive session.

The key change just being to make
```
isinteractive() = JLOptions().isinteractive != 0
```
The rest is removing the global. 