### PR TITLE
Remove duplicate header in parallel.md

### DIFF
--- a/doc/src/base/parallel.md
+++ b/doc/src/base/parallel.md
@@ -26,8 +26,6 @@ Base.schedule
 
 ## [Synchronization](@id lib-task-sync)
 
-## Synchronization
-
 ```@docs
 Base.errormonitor
 Base.@sync


### PR DESCRIPTION
Removes the duplicate header `Synchronization`