### PR TITLE
[REPLCompletions] this code uses `nothing` as the failure token type

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -567,7 +567,9 @@ function repl_eval_ex(@nospecialize(ex), context_module::Module)
 
     CC.typeinf(interp, frame)
 
-    return frame.result.result
+    result = frame.result.result
+    result === Union{} && return nothing # for whatever reason, callers expect this as the Bottom and/or Top type instead
+    return result
 end
 
 # Method completion on function call expression that look like :(max(1))


### PR DESCRIPTION
Need to convert the failure type from inference (Union{}) to the failure type for the new completions logic (nothing).

Simultaneously update these tests to be more robust. There is no sort guaranteed order for `methods`, so the lookup needs to be the same as the completions is expected to do.

Changed by 98988d8bfbc769c3d20736e0c2e20717b11cd4c9, which ended up conflicting with 35e4a1f9689f4b98f301884e0683e4f07db7514b.