### PR TITLE
Specialized codegen for opaque closure calls

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2085,7 +2085,7 @@ function most_general_argtypes(closure::PartialOpaque)
     if !isa(argt, DataType) || argt.name !== typename(Tuple)
         argt = Tuple
     end
-    return most_general_argtypes(closure.source, argt, #=withfirst=#false)
+    return Any[argt.parameters...]
 end
 
 # call where the function is any lattice element

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1920,6 +1920,11 @@ void jl_init_intrinsic_functions(void) JL_GC_DISABLED
         (jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_opaque_closure_type),
         "OpaqueClosure", jl_f_opaque_closure_call);
 
+    // Save a reference to the just created OpaqueClosure method, so we can provide special
+    // codegen for it later.
+    jl_opaque_closure_method = (jl_method_t*)jl_methtable_lookup(jl_opaque_closure_typename->mt,
+        (jl_value_t*)jl_anytuple_type, 1);
+
 #define ADD_I(name, nargs) add_intrinsic(inm, #name, name);
 #define ADD_HIDDEN(name, nargs)
 #define ALIAS ADD_I

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -48,6 +48,8 @@ JL_DLLEXPORT void jl_generate_fptr_for_unspecialized_fallback(jl_code_instance_t
     jl_atomic_store_release(&unspec->invoke, &jl_fptr_interpret_call);
 }
 
+JL_DLLEXPORT void jl_generate_fptr_for_oc_wrapper_fallback(jl_code_instance_t *unspec) UNAVAILABLE
+
 JL_DLLEXPORT uint32_t jl_get_LLVM_VERSION_fallback(void)
 {
     return 0;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8058,6 +8058,11 @@ static jl_llvm_functions_t
             // this is basically a copy of emit_assignment,
             // but where the assignment slot is the retval
             jl_cgval_t retvalinfo = emit_expr(ctx, retexpr);
+
+            if (ctx.is_opaque_closure) {
+                emit_typecheck(ctx, retvalinfo, jlrettype, "OpaqueClosure");
+            }
+
             retvalinfo = convert_julia_type(ctx, retvalinfo, jlrettype);
             if (retvalinfo.typ == jl_bottom_type) {
                 CreateTrap(ctx.builder, false);

--- a/src/gf.c
+++ b/src/gf.c
@@ -134,8 +134,8 @@ static int speccache_eq(size_t idx, const void *ty, jl_svec_t *data, uint_t hv)
 // get or create the MethodInstance for a specialization
 static jl_method_instance_t *jl_specializations_get_linfo_(jl_method_t *m JL_PROPAGATES_ROOT, jl_value_t *type, jl_svec_t *sparams, jl_method_instance_t *mi_insert)
 {
-    //if (m->sig == (jl_value_t*)jl_anytuple_type && jl_atomic_load_relaxed(&m->unspecialized) != NULL)
-    //    return jl_atomic_load_relaxed(&m->unspecialized); // handle builtin methods
+    if (m->sig == (jl_value_t*)jl_anytuple_type && jl_atomic_load_relaxed(&m->unspecialized) != NULL && m != jl_opaque_closure_method)
+        return jl_atomic_load_relaxed(&m->unspecialized); // handle builtin methods
     jl_value_t *ut = jl_is_unionall(type) ? jl_unwrap_unionall(type) : type;
     JL_TYPECHK(specializations, datatype, ut);
     uint_t hv = ((jl_datatype_t*)ut)->hash;

--- a/src/gf.c
+++ b/src/gf.c
@@ -2828,7 +2828,7 @@ jl_value_t *jl_argtype_with_function_type(jl_value_t *ft JL_MAYBE_UNROOTED, jl_v
     JL_GC_PUSH2(&tt, &ft);
     tt = (jl_value_t*)jl_alloc_svec(1+l);
     jl_svecset(tt, 0, ft);
-    for(size_t i=0; i < l; i++)
+    for (size_t i = 0; i < l; i++)
         jl_svecset(tt, i+1, jl_tparam(types,i));
     tt = (jl_value_t*)jl_apply_tuple_type((jl_svec_t*)tt);
     tt = jl_rewrap_unionall_(tt, types0);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -736,8 +736,8 @@ jl_value_t *jl_interpret_opaque_closure(jl_opaque_closure_t *oc, jl_value_t **ar
     jl_value_t *r = eval_body(code->code, s, 0, 0);
     locals[0] = r; // GC root
     JL_GC_PROMISE_ROOTED(r);
-    jl_typeassert(r, jl_tparam1(jl_typeof(oc)));
     ct->world_age = last_age;
+    jl_typeassert(r, jl_tparam1(jl_typeof(oc)));
     JL_GC_POP();
     return r;
 }

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -462,7 +462,7 @@ jl_code_instance_t *jl_generate_fptr_impl(jl_method_instance_t *mi JL_PROPAGATES
         is_recompile = jl_atomic_load_relaxed(&mi->cache) != NULL;
     }
     if (src == NULL && jl_is_method(mi->def.method) &&
-             jl_symbol_name(mi->def.method->name)[0] != '@' ) {
+             jl_symbol_name(mi->def.method->name)[0] != '@') {
         if (mi->def.method->source != jl_nothing) {
             // If the caller didn't provide the source and IR is available,
             // see if it is inferred, or try to infer it for ourself.

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -506,14 +506,14 @@ jl_code_instance_t *jl_generate_fptr_impl(jl_method_instance_t *mi JL_PROPAGATES
 }
 
 extern "C" JL_DLLEXPORT
-void jl_generate_fptr_for_oc_wrapper_impl(jl_code_instance_t *unspec)
+void jl_generate_fptr_for_oc_wrapper_impl(jl_code_instance_t *oc_wrap)
 {
-    if (jl_atomic_load_relaxed(&unspec->invoke) != NULL) {
+    if (jl_atomic_load_relaxed(&oc_wrap->invoke) != NULL) {
         return;
     }
     JL_LOCK(&jl_codegen_lock);
-    if (jl_atomic_load_relaxed(&unspec->invoke) == NULL) {
-        _jl_compile_codeinst(unspec, NULL, 1, *jl_ExecutionEngine->getContext());
+    if (jl_atomic_load_relaxed(&oc_wrap->invoke) == NULL) {
+        _jl_compile_codeinst(oc_wrap, NULL, 1, *jl_ExecutionEngine->getContext(), 0);
     }
     JL_UNLOCK(&jl_codegen_lock); // Might GC
 }

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -178,7 +178,7 @@ typedef struct _jl_llvm_functions_t {
 } jl_llvm_functions_t;
 
 struct jl_returninfo_t {
-    llvm::Function *decl;
+    llvm::Value *decl;
     enum CallingConv {
         Boxed = 0,
         Register,

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -178,7 +178,8 @@ typedef struct _jl_llvm_functions_t {
 } jl_llvm_functions_t;
 
 struct jl_returninfo_t {
-    llvm::Value *decl;
+    llvm::FunctionCallee decl;
+    llvm::AttributeList attrs;
     enum CallingConv {
         Boxed = 0,
         Register,

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -546,6 +546,7 @@
     YY(jl_register_fptrs) \
     YY(jl_generate_fptr) \
     YY(jl_generate_fptr_for_unspecialized) \
+    YY(jl_generate_fptr_for_oc_wrapper) \
     YY(jl_compile_extern_c) \
     YY(jl_teardown_codegen) \
     YY(jl_jit_total_bytes) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3182,6 +3182,8 @@ void jl_init_types(void) JL_GC_DISABLED
 
     tv = jl_svec2(tvar("A"), tvar("R"));
     jl_opaque_closure_type = (jl_unionall_t*)jl_new_datatype(jl_symbol("OpaqueClosure"), core, jl_function_type, tv,
+        // N.B.: OpaqueClosure call code relies on specptr being field 5.
+        // Update that code if you change this.
         jl_perm_symsvec(5, "captures", "world", "source", "invoke", "specptr"),
         jl_svec(5, jl_any_type, jl_long_type, jl_any_type, pointer_void, pointer_void),
         jl_emptysvec, 0, 0, 5)->name->wrapper;

--- a/src/julia.h
+++ b/src/julia.h
@@ -235,6 +235,8 @@ typedef jl_value_t *(*jl_fptr_sparam_t)(jl_value_t*, jl_value_t**, uint32_t, jl_
 extern jl_call_t jl_fptr_interpret_call;
 JL_DLLEXPORT extern jl_callptr_t jl_fptr_interpret_call_addr;
 
+JL_DLLEXPORT extern jl_callptr_t jl_f_opaque_closure_call_addr;
+
 typedef struct _jl_line_info_node_t {
     struct _jl_module_t *module;
     jl_value_t *method; // may contain a jl_symbol, jl_method_t, or jl_method_instance_t

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -307,6 +307,7 @@ static inline void memmove_refs(void **dstp, void *const *srcp, size_t n) JL_NOT
 extern jl_methtable_t *jl_type_type_mt JL_GLOBALLY_ROOTED;
 extern jl_methtable_t *jl_nonfunction_mt JL_GLOBALLY_ROOTED;
 extern jl_methtable_t *jl_kwcall_mt JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_method_t *jl_opaque_closure_method JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT _Atomic(size_t) jl_world_counter;
 
 typedef void (*tracer_cb)(jl_value_t *tracee);
@@ -1481,22 +1482,7 @@ JL_DLLEXPORT jl_value_t *jl_svec_ref(jl_svec_t *t JL_PROPAGATES_ROOT, ssize_t i)
 
 // check whether the specified number of arguments is compatible with the
 // specified number of parameters of the tuple type
-STATIC_INLINE int jl_tupletype_length_compat(jl_value_t *v, size_t nargs) JL_NOTSAFEPOINT
-{
-    v = jl_unwrap_unionall(v);
-    assert(jl_is_tuple_type(v));
-    size_t nparams = jl_nparams(v);
-    if (nparams == 0)
-        return nargs == 0;
-    jl_value_t *va = jl_tparam(v,nparams-1);
-    if (jl_is_vararg(va)) {
-        jl_value_t *len = jl_unwrap_vararg_num(va);
-        if (len &&jl_is_long(len))
-            return nargs == nparams - 1 + jl_unbox_long(len);
-        return nargs >= nparams - 1;
-    }
-    return nparams == nargs;
-}
+JL_DLLEXPORT int jl_tupletype_length_compat(jl_value_t *v, size_t nargs) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT jl_value_t *jl_argtype_with_function(jl_value_t *f, jl_value_t *types0);
 JL_DLLEXPORT jl_value_t *jl_argtype_with_function_type(jl_value_t *ft JL_MAYBE_UNROOTED, jl_value_t *types0);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -615,8 +615,10 @@ typedef union {
 
 JL_DLLEXPORT jl_code_info_t *jl_type_infer(jl_method_instance_t *li, size_t world, int force);
 JL_DLLEXPORT jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *meth JL_PROPAGATES_ROOT, size_t world);
+JL_DLLEXPORT void *jl_compile_oc_wrapper(jl_code_instance_t *ci);
 jl_code_instance_t *jl_generate_fptr(jl_method_instance_t *mi JL_PROPAGATES_ROOT, size_t world);
 void jl_generate_fptr_for_unspecialized(jl_code_instance_t *unspec);
+void jl_generate_fptr_for_oc_wrapper(jl_code_instance_t *unspec);
 JL_DLLEXPORT jl_code_instance_t *jl_get_method_inferred(
         jl_method_instance_t *mi JL_PROPAGATES_ROOT, jl_value_t *rettype,
         size_t min_world, size_t max_world);
@@ -996,7 +998,7 @@ JL_DLLEXPORT jl_method_instance_t *jl_get_specialization1(jl_tupletype_t *types,
 jl_method_instance_t *jl_get_specialized(jl_method_t *m, jl_value_t *types, jl_svec_t *sp);
 JL_DLLEXPORT jl_value_t *jl_rettype_inferred(jl_method_instance_t *li JL_PROPAGATES_ROOT, size_t min_world, size_t max_world);
 JL_DLLEXPORT jl_code_instance_t *jl_method_compiled(jl_method_instance_t *mi JL_PROPAGATES_ROOT, size_t world);
-JL_DLLEXPORT jl_value_t *jl_methtable_lookup(jl_methtable_t *mt, jl_value_t *type, size_t world);
+JL_DLLEXPORT jl_value_t *jl_methtable_lookup(jl_methtable_t *mt JL_PROPAGATES_ROOT, jl_value_t *type, size_t world);
 JL_DLLEXPORT jl_method_instance_t *jl_specializations_get_linfo(
     jl_method_t *m JL_PROPAGATES_ROOT, jl_value_t *type, jl_svec_t *sparams);
 jl_method_instance_t *jl_specializations_get_or_insert(jl_method_instance_t *mi_ins);
@@ -1477,6 +1479,27 @@ void typemap_slurp_search(jl_typemap_entry_t *ml, struct typemap_intersection_en
 JL_DLLEXPORT size_t (jl_svec_len)(jl_svec_t *t) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_svec_ref(jl_svec_t *t JL_PROPAGATES_ROOT, ssize_t i);
 
+// check whether the specified number of arguments is compatible with the
+// specified number of parameters of the tuple type
+STATIC_INLINE int jl_tupletype_length_compat(jl_value_t *v, size_t nargs) JL_NOTSAFEPOINT
+{
+    v = jl_unwrap_unionall(v);
+    assert(jl_is_tuple_type(v));
+    size_t nparams = jl_nparams(v);
+    if (nparams == 0)
+        return nargs == 0;
+    jl_value_t *va = jl_tparam(v,nparams-1);
+    if (jl_is_vararg(va)) {
+        jl_value_t *len = jl_unwrap_vararg_num(va);
+        if (len &&jl_is_long(len))
+            return nargs == nparams - 1 + jl_unbox_long(len);
+        return nargs >= nparams - 1;
+    }
+    return nparams == nargs;
+}
+
+JL_DLLEXPORT jl_value_t *jl_argtype_with_function(jl_value_t *f, jl_value_t *types0);
+JL_DLLEXPORT jl_value_t *jl_argtype_with_function_type(jl_value_t *ft JL_MAYBE_UNROOTED, jl_value_t *types0);
 
 JL_DLLEXPORT unsigned jl_special_vector_alignment(size_t nfields, jl_value_t *field_type);
 

--- a/src/method.c
+++ b/src/method.c
@@ -18,6 +18,7 @@ extern "C" {
 extern jl_value_t *jl_builtin_getfield;
 extern jl_value_t *jl_builtin_tuple;
 jl_methtable_t *jl_kwcall_mt;
+jl_method_t *jl_opaque_closure_method;
 
 jl_method_t *jl_make_opaque_closure_method(jl_module_t *module, jl_value_t *name,
     int nargs, jl_value_t *functionloc, jl_code_info_t *ci, int isva);

--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -65,12 +65,12 @@ static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t 
     JL_GC_PROMISE_ROOTED(oc_type);
 
     jl_method_instance_t *mi = jl_specializations_get_linfo(source, sigtype, jl_emptysvec);
-    size_t world = jl_current_task->world_age;
+    jl_task_t *ct = jl_current_task;
+    size_t world = ct->world_age;
     jl_code_instance_t *ci = NULL;
     if (do_compile)
         ci = jl_compile_method_internal(mi, world);
 
-    jl_task_t *ct = jl_current_task;
     jl_opaque_closure_t *oc = (jl_opaque_closure_t*)jl_gc_alloc(ct->ptls, sizeof(jl_opaque_closure_t), oc_type);
     JL_GC_POP();
     oc->source = source;

--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -60,7 +60,7 @@ static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t 
         invoke = (jl_fptr_args_t)jl_atomic_load_relaxed(&ci->invoke);
         specptr = jl_atomic_load_relaxed(&ci->specptr.fptr);
         if (invoke == (jl_fptr_args_t) jl_fptr_interpret_call) {
-            invoke =(jl_fptr_args_t) jl_interpret_opaque_closure;
+            invoke = (jl_fptr_args_t)jl_interpret_opaque_closure;
         }
         else if (invoke == (jl_fptr_args_t)jl_fptr_args) {
             invoke = (jl_fptr_args_t)specptr;
@@ -76,7 +76,8 @@ static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t 
             // wrapper, but lets leave that for later.
             specptr = NULL;
             selected_rt = jl_type_intersection(rt_lb, ci->rettype);
-        } else {
+        }
+        else {
             selected_rt = ci->rettype;
         }
     }

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -98,7 +98,7 @@ extern "C" {
 // TODO: put WeakRefs on the weak_refs list during deserialization
 // TODO: handle finalizers
 
-#define NUM_TAGS    157
+#define NUM_TAGS    158
 
 // An array of references that need to be restored from the sysimg
 // This is a manually constructed dual of the gvars array, which would be produced by codegen for Julia code, for C.
@@ -241,6 +241,7 @@ jl_value_t **const*const get_tags(void) {
         INSERT_TAG(jl_nonfunction_mt);
         INSERT_TAG(jl_kwcall_mt);
         INSERT_TAG(jl_kwcall_func);
+        INSERT_TAG(jl_opaque_closure_method);
 
         // some Core.Builtin Functions that we want to be able to reference:
         INSERT_TAG(jl_builtin_throw);

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -177,7 +177,7 @@ mk_va_opaque() = @opaque (x...)->x
 @test mk_va_opaque()(1,2) == (1,2)
 
 # OpaqueClosure show method
-@test repr(@opaque x->1) == "(::Any)::Any->◌"
+@test repr(@opaque x->Base.inferencebarrier(1)) == "(::Any)::Any->◌"
 
 # Opaque closure in CodeInfo returned from generated functions
 let ci = @code_lowered const_int()

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -4,6 +4,7 @@ using Core: OpaqueClosure
 using Base.Experimental: @opaque
 
 const_int() = 1
+const_int_barrier() = Base.inferencebarrier(1)::typeof(1)
 
 const lno = LineNumberNode(1, :none)
 
@@ -273,5 +274,26 @@ let src = code_typed((Int,Int)) do x, y...
     let oc = OpaqueClosure(ir; isva=true)
         @test oc(1,2) === (1,(2,))
         @test_throws MethodError oc(1,2,3)
+    end
+end
+
+# Check for correct handling in case of broken return type.
+eval_oc_dyn(oc) = Base.inferencebarrier(oc)()
+eval_oc_spec(oc) = oc()
+for f in (const_int, const_int_barrier)
+    ci = code_lowered(f, Tuple{})[1]
+    for compiled in (true, false)
+        oc_expr = Expr(:new_opaque_closure, Tuple{}, Union{}, Float64,
+            Expr(:opaque_closure_method, nothing, 0, false, lno, ci))
+        oc_mismatch = let ci = code_lowered(f, Tuple{})[1]
+            if compiled
+                eval(:((()->$oc_expr)()))
+            else
+                eval(oc_expr)
+            end
+        end
+        @test isa(oc_mismatch, OpaqueClosure{Tuple{}, Union{}})
+        @test_throws TypeError eval_oc_dyn(oc_mismatch)
+        @test_throws TypeError eval_oc_spec(oc_mismatch)
     end
 end


### PR DESCRIPTION
Benchmark:
```
using Base.Experimental: @opaque
f() = @opaque (x::Float64)->x+1.0
vec = [f() for i = 1:10_000];
g((x,f),) = f(Float64(x))
```

Before:
```
julia> @time mapreduce(g, +, enumerate(vec))
  0.001928 seconds (30.00 k allocations: 781.297 KiB)
5.0015e7
```

After:
```
julia> @time mapreduce(g, +, enumerate(vec))
  0.000085 seconds (3 allocations: 48 bytes)
5.0015e7
```