### PR TITLE
Fix type_more_complex

### DIFF
--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -261,7 +261,7 @@ function type_more_complex(@nospecialize(t), @nospecialize(c), sources::SimpleVe
         elseif isa(c, DataType) && t.name === c.name
             cP = c.parameters
             length(cP) < length(tP) && return true
-            length(cP) > length(tP) && isvarargtype(cP[end]) && return false
+            isempty(tP) && return false
             length(cP) > length(tP) && !isvarargtype(tP[end]) && depth == 1 && return false # is this line necessary?
             ntail = length(cP) - length(tP) # assume parameters were dropped from the tuple head
             # allow creating variation within a nested tuple, but only so deep

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -261,7 +261,8 @@ function type_more_complex(@nospecialize(t), @nospecialize(c), sources::SimpleVe
         elseif isa(c, DataType) && t.name === c.name
             cP = c.parameters
             length(cP) < length(tP) && return true
-            length(cP) > length(tP) && !isvarargtype(tP[end]) && depth == 1 && return false
+            length(cP) > length(tP) && isvarargtype(cP[end]) && return false
+            length(cP) > length(tP) && !isvarargtype(tP[end]) && depth == 1 && return false # is this line necessary?
             ntail = length(cP) - length(tP) # assume parameters were dropped from the tuple head
             # allow creating variation within a nested tuple, but only so deep
             if t.name === Tuple.name && tupledepth > 0

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -90,6 +90,9 @@ end
 @test  Core.Compiler.type_more_complex(Type{<:Union{Float32,Float64}}, Type{Union{Float32,Float64}}, Core.svec(Union{Float32,Float64}), 1, 1, 1)
 @test  Core.Compiler.type_more_complex(Type{<:Union{Float32,Float64}}, Any, Core.svec(Union{Float32,Float64}), 1, 1, 1)
 
+# issue #49287
+@test !Core.Compiler.type_more_complex(Tuple{Vararg{Tuple{}}}, Tuple{Vararg{Tuple}}, Core.svec(), 0, 0, 0)
+@test  Core.Compiler.type_more_complex(Tuple{Vararg{Tuple}}, Tuple{Vararg{Tuple{}}}, Core.svec(), 0, 0, 0)
 
 let # 40336
     t = Type{Type{Int}}


### PR DESCRIPTION
Fixes #49287.
My understanding is that `type_more_complex` is a function to check that `t`(which is a Type given first arg) is more complex than `c`(which is a Type given second arg).
In my chaning,  when `t` and `c` are `DataType` and they have same name but `c`'s parameters length is longer than `t`'s it , I don't know its details and think there are some situations on it.
Also in this situation, if `c`'s end paramer is a varargtype, `c` is more complex than `t`. 

I guess this thinkig from this simple Result 
```
julia> Core.Compiler.type_more_complex(Tuple{}, Tuple, Core.svec(), 0, 0, 0)
false
```
It works on stable version julia.

I don't understand the meaning of the original code happened error.
Thus I didn't change it.