### PR TITLE
Make `normalize` work for `Number`s

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1804,21 +1804,18 @@ function normalize!(a::AbstractArray, p::Real=2)
     __normalize!(a, nrm)
 end
 
-@inline function __normalize!(a::AbstractArray, nrm::Real)
+@inline function __normalize!(a::AbstractArray, nrm)
     # The largest positive floating point number whose inverse is less than infinity
     δ = inv(prevfloat(typemax(nrm)))
-
     if nrm ≥ δ # Safe to multiply with inverse
         invnrm = inv(nrm)
         rmul!(a, invnrm)
-
     else # scale elements to avoid overflow
         εδ = eps(one(nrm))/δ
         rmul!(a, εδ)
         rmul!(a, inv(nrm*εδ))
     end
-
-    a
+    return a
 end
 
 """

--- a/test/testhelpers/DualNumbers.jl
+++ b/test/testhelpers/DualNumbers.jl
@@ -14,7 +14,8 @@ end
 Base.:+(x::Dual, y::Dual) = Dual(x.val + y.val, x.eps + y.eps)
 Base.:-(x::Dual, y::Dual) = Dual(x.val - y.val, x.eps - y.eps)
 Base.:*(x::Dual, y::Dual) = Dual(x.val * y.val, x.eps * y.val + y.eps * x.val)
-Base.:*(x::Integer, y::Dual) = Dual(x*y.val, x*y.eps)
+Base.:*(x::Number, y::Dual) = Dual(x*y.val, x*y.eps)
+Base.:*(x::Dual, y::Number) = Dual(x.val*y, x.eps*y)
 Base.:/(x::Dual, y::Dual) = Dual(x.val / y.val, (x.eps*y.val - x.val*y.eps)/(y.val*y.val))
 
 Base.:(==)(x::Dual, y::Dual) = x.val == y.val && x.eps == y.eps
@@ -38,7 +39,7 @@ Base.sqrt(x::Dual) = Dual(sqrt(x.val), x.eps/(2sqrt(x.val)))
 
 Base.isless(x::Dual, y::Dual) = x.val < y.val
 Base.isless(x::Real, y::Dual) = x < y.val
-Base.isinf(x::Dual) = isinf(x.val)
+Base.isinf(x::Dual) = isinf(x.val) & isfinite(x.eps)
 Base.real(x::Dual) = x # since we curently only consider Dual{<:Real}
 
 end # module

--- a/test/testhelpers/DualNumbers.jl
+++ b/test/testhelpers/DualNumbers.jl
@@ -4,8 +4,9 @@ module DualNumbers
 
 export Dual
 
-# Dual numbers type with minimal interface, example of a (real) number type that
-# subtypes Number, but not Real. Can be used to test generic linear algebra functions.
+# Dual numbers type with minimal interface
+# example of a (real) number type that subtypes Number, but not Real.
+# Can be used to test generic linear algebra functions.
 
 struct Dual{T<:Real} <: Number
     val::T
@@ -29,7 +30,7 @@ Base.convert(::Type{Dual{T}}, x::Dual) where {T} = Dual(convert(T, x.val), conve
 Base.convert(::Type{Dual{T}}, x::Real) where {T} = Dual(convert(T, x), zero(T))
 
 Base.float(x::Dual) = Dual(float(x.val), float(x.eps))
-# the folowing two are needed for normalize
+# the following two methods are needed for normalize (to check for potential overflow)
 Base.typemax(x::Dual) = Dual(typemax(x.val), zero(x.eps))
 Base.prevfloat(x::Dual{<:AbstractFloat}) = prevfloat(x.val)
 

--- a/test/testhelpers/DualNumbers.jl
+++ b/test/testhelpers/DualNumbers.jl
@@ -1,0 +1,44 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module DualNumbers
+
+export Dual
+
+# Dual numbers type with minimal interface, example of a (real) number type that
+# subtypes Number, but not Real. Can be used to test generic linear algebra functions.
+
+struct Dual{T<:Real} <: Number
+    val::T
+    eps::T
+end
+Base.:+(x::Dual, y::Dual) = Dual(x.val + y.val, x.eps + y.eps)
+Base.:-(x::Dual, y::Dual) = Dual(x.val - y.val, x.eps - y.eps)
+Base.:*(x::Dual, y::Dual) = Dual(x.val * y.val, x.eps * y.val + y.eps * x.val)
+Base.:*(x::Integer, y::Dual) = Dual(x*y.val, x*y.eps)
+Base.:/(x::Dual, y::Dual) = Dual(x.val / y.val, (x.eps*y.val - x.val*y.eps)/(y.val*y.val))
+
+Base.:(==)(x::Dual, y::Dual) = x.val == y.val && x.eps == y.eps
+
+Base.promote_rule(::Type{Dual{T}}, ::Type{T}) where {T} = Dual{T}
+Base.promote_rule(::Type{Dual{T}}, ::Type{S}) where {T,S<:Real} = Dual{promote_type(T, S)}
+Base.promote_rule(::Type{Dual{T}}, ::Type{Dual{S}}) where {T,S} = Dual{promote_type(T, S)}
+
+Base.convert(::Type{Dual{T}}, x::Dual{T}) where {T} = x
+Base.convert(::Type{Dual{T}}, x::Dual) where {T} = Dual(convert(T, x.val), convert(T, x.eps))
+Base.convert(::Type{Dual{T}}, x::Real) where {T} = Dual(convert(T, x), zero(T))
+
+Base.float(x::Dual) = Dual(float(x.val), float(x.eps))
+# the folowing two are needed for normalize
+Base.typemax(x::Dual) = Dual(typemax(x.val), zero(x.eps))
+Base.prevfloat(x::Dual{<:AbstractFloat}) = prevfloat(x.val)
+
+Base.abs2(x::Dual) = x*x
+Base.abs(x::Dual) = sqrt(abs2(x))
+Base.sqrt(x::Dual) = Dual(sqrt(x.val), x.eps/(2sqrt(x.val)))
+
+Base.isless(x::Dual, y::Dual) = x.val < y.val
+Base.isless(x::Real, y::Dual) = x < y.val
+Base.isinf(x::Dual) = isinf(x.val)
+Base.real(x::Dual) = x # since we curently only consider Dual{<:Real}
+
+end # module


### PR DESCRIPTION
Closes  JuliaLang/LinearAlgebra.jl#994.

@jishnub To make this work with DualNumbers.jl, one would need to add `typemax` and `prevfloat` methods for `Dual` numbers.