### PR TITLE
Fix doc. about linear from/to Cartesian indices

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -30,7 +30,7 @@ to implement indexing (and indexed assignment) with a single `Int` index;
 all other indexing expressions — including multidimensional accesses — will
 be recomputed to the linear index.  For example, if `A` were a `2×3` custom
 matrix with linear indexing, and we referenced `A[1, 3]`, this would be
-recomputed to the equivalent linear index and call `A[5]` since `2*1 + 3 = 5`.
+recomputed to the equivalent linear index and call `A[5]` since `1 + 2*(3 - 1) = 5`.
 
 See also [`IndexCartesian`](@ref).
 """
@@ -53,7 +53,7 @@ to implement indexing (and indexed assignment) with exactly `N` `Int` indices;
 all other indexing expressions — including linear indexing — will
 be recomputed to the equivalent Cartesian location.  For example, if `A` were a `2×3` custom
 matrix with cartesian indexing, and we referenced `A[5]`, this would be
-recomputed to the equivalent Cartesian index and call `A[1, 3]` since `5 = 2*1 + 3`.
+recomputed to the equivalent Cartesian index and call `A[1, 3]` since `5 = 1 + 2*(3 - 1)`.
 
 It is significantly more expensive to compute Cartesian indices from a linear index than it is
 to go the other way.  The former operation requires division — a very costly operation — whereas


### PR DESCRIPTION
Since Julia (ordinary) arrays have 1-based indices and are in column-major order, the linear index `k` and the Cartesian index `(i,j)` of an element in a `m×n` Julia array are related by: `k = i + m*(j - 1)`. The examples of conversion between linear and Cartesian indices in the doc. use incorrect formulae although the results were correct in the specific element at `(1,3)`. This can be easily checked for other indices than `(1,3)` with a simple `2×3` array (as in the examples) built by `A = reshape(collect(1:6),2,3)`.