### PR TITLE
Fix union estimation on non-type parameters.

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1536,7 +1536,7 @@ static int may_contain_union_decision(jl_value_t *x, jl_stenv_t *e, jl_typeenv_t
         return 0;
     }
     if (!jl_is_typevar(x))
-        return 1;
+        return jl_is_type(x);
     jl_typeenv_t *t = log;
     while (t != NULL) {
         if (x == (jl_value_t *)t->var)

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2453,8 +2453,11 @@ let A = Tuple{Type{T}, T} where T,
     @testintersect(A, B, C)
 end
 
-let a = (isodd(i) ? Pair{Char, String} : Pair{String, String} for i in 1:2000)
+let
+    a = (isodd(i) ? Pair{Char, String} : Pair{String, String} for i in 1:2000)
     @test Tuple{Type{Pair{Union{Char, String}, String}}, a...} <: Tuple{Type{Pair{K, V}}, Vararg{Pair{A, B} where B where A}} where V where K
+    a = (isodd(i) ? Matrix{Int} : Vector{Int} for i in 1:4000)
+    @test Tuple{Type{Pair{Union{Char, String}, String}}, a...,} <: Tuple{Type{Pair{K, V}}, Vararg{Array}} where V where K
 end
 
 #issue 48582


### PR DESCRIPTION
Non-type parameters are never splitable. (Ignored in #48441)
Close #49323.

