### PR TITLE
Copy slottypes before ir conversion

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -623,7 +623,7 @@ function convert_to_ircode(ci::CodeInfo, sv::OptimizationState)
     # NOTE this `argtypes` contains types of slots yet: it will be modified to contain the
     # types of call arguments only once `slot2reg` converts this `IRCode` to the SSA form
     # and eliminates slots (see below)
-    argtypes = sv.slottypes
+    argtypes = copy(sv.slottypes)
     return IRCode(stmts, cfg, linetable, argtypes, meta, sv.sptypes)
 end
 


### PR DESCRIPTION
This was changed in https://github.com/JuliaLang/julia/pull/49113 and is usually not a problem, but Cthulhu captures the post-inference but unoptimized CodeInfo, which was invalidated by the later modification of the slottypes array. Fix this by copying the slottypes for IRCode construction instead.