### PR TITLE
Fix incorrect inlining location for early finalization

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1152,12 +1152,10 @@ function try_resolve_finalizer!(ir::IRCode, idx::Int, finalizer_idx::Int, defuse
     function note_block_use!(usebb::Int, useidx::Int)
         new_bb_insert_block = nearest_common_dominator(get!(lazypostdomtree),
             bb_insert_block, usebb)
-        if new_bb_insert_block == bb_insert_block == usebb
-            if bb_insert_idx !== nothing
-                bb_insert_idx = max(bb_insert_idx::Int, useidx)
-            else
-                bb_insert_idx = useidx
-            end
+        if new_bb_insert_block == bb_insert_block && bb_insert_idx !== nothing
+            bb_insert_idx = max(bb_insert_idx::Int, useidx)
+        elseif new_bb_insert_block == usebb
+            bb_insert_idx = useidx
         else
             bb_insert_idx = nothing
         end


### PR DESCRIPTION
The early inlining of finalizer inside sroa_pass! had incorrect logic that would sometimes cause it to accidentally inline the finalizer at the beginning of the basic block of the last use, rather than after the final use. This generally happened when the final use is not in basic block that is the postdominator of all previous uses. Because this optimization is relatively conservative with respect to what may happen between the various uses, all our test cases had this property, so we didn't see it. This changed in b33a7635915f838c7e038a815a0de7a7749da616, which introduced an extra basic block in `setproperty!` causing downstream breakage.

Fix the logic and add a regression test with this pattern.