### PR TITLE
Subtype: Improve `simple_meet` resolution for `Union` inputs

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -485,19 +485,19 @@ static int union_sort_cmp(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT
     }
 }
 
-static int count_union_components(jl_value_t **types, size_t n)
+static int count_union_components(jl_value_t **types, size_t n, int widen)
 {
     size_t i, c = 0;
     for (i = 0; i < n; i++) {
         jl_value_t *e = types[i];
         while (jl_is_uniontype(e)) {
             jl_uniontype_t *u = (jl_uniontype_t*)e;
-            c += count_union_components(&u->a, 1);
+            c += count_union_components(&u->a, 1, widen);
             e = u->b;
         }
-        if (jl_is_unionall(e) && jl_is_uniontype(jl_unwrap_unionall(e))) {
+        if (widen && jl_is_unionall(e) && jl_is_uniontype(jl_unwrap_unionall(e))) {
             jl_uniontype_t *u = (jl_uniontype_t*)jl_unwrap_unionall(e);
-            c += count_union_components(&u->a, 2);
+            c += count_union_components(&u->a, 2, widen);
         }
         else {
             c++;
@@ -506,21 +506,21 @@ static int count_union_components(jl_value_t **types, size_t n)
     return c;
 }
 
-static void flatten_type_union(jl_value_t **types, size_t n, jl_value_t **out, size_t *idx)
+static void flatten_type_union(jl_value_t **types, size_t n, jl_value_t **out, size_t *idx, int widen)
 {
     size_t i;
     for (i = 0; i < n; i++) {
         jl_value_t *e = types[i];
         while (jl_is_uniontype(e)) {
             jl_uniontype_t *u = (jl_uniontype_t*)e;
-            flatten_type_union(&u->a, 1, out, idx);
+            flatten_type_union(&u->a, 1, out, idx, widen);
             e = u->b;
         }
-        if (jl_is_unionall(e) && jl_is_uniontype(jl_unwrap_unionall(e))) {
+        if (widen && jl_is_unionall(e) && jl_is_uniontype(jl_unwrap_unionall(e))) {
             // flatten this UnionAll into place by switching the union and unionall
             jl_uniontype_t *u = (jl_uniontype_t*)jl_unwrap_unionall(e);
             size_t old_idx = 0;
-            flatten_type_union(&u->a, 2, out, idx);
+            flatten_type_union(&u->a, 2, out, idx, widen);
             for (; old_idx < *idx; old_idx++)
                 out[old_idx] = jl_rewrap_unionall(out[old_idx], e);
         }
@@ -560,11 +560,11 @@ JL_DLLEXPORT jl_value_t *jl_type_union(jl_value_t **ts, size_t n)
     if (n == 1)
         return ts[0];
 
-    size_t nt = count_union_components(ts, n);
+    size_t nt = count_union_components(ts, n, 1);
     jl_value_t **temp;
     JL_GC_PUSHARGS(temp, nt+1);
     size_t count = 0;
-    flatten_type_union(ts, n, temp, &count);
+    flatten_type_union(ts, n, temp, &count, 1);
     assert(count == nt);
     size_t j;
     for (i = 0; i < nt; i++) {
@@ -641,14 +641,14 @@ static int simple_subtype2(jl_value_t *a, jl_value_t *b, int hasfree)
 
 jl_value_t *simple_union(jl_value_t *a, jl_value_t *b)
 {
-    size_t nta = count_union_components(&a, 1);
-    size_t ntb = count_union_components(&b, 1);
+    size_t nta = count_union_components(&a, 1, 1);
+    size_t ntb = count_union_components(&b, 1, 1);
     size_t nt = nta + ntb;
     jl_value_t **temp;
     JL_GC_PUSHARGS(temp, nt+1);
     size_t count = 0;
-    flatten_type_union(&a, 1, temp, &count);
-    flatten_type_union(&b, 1, temp, &count);
+    flatten_type_union(&a, 1, temp, &count, 1);
+    flatten_type_union(&b, 1, temp, &count, 1);
     assert(count == nt);
     size_t i, j;
     size_t ra = nta, rb = ntb;
@@ -717,6 +717,84 @@ jl_value_t *simple_union(jl_value_t *a, jl_value_t *b)
     return tu;
 }
 
+int obviously_disjoint(jl_value_t *a, jl_value_t *b, int specificity);
+jl_value_t *simple_intersect(jl_value_t *a, jl_value_t *b, int overesi)
+{
+    // Unlike `Union`, we don't unwrap `UnionAll` here to avoid possible widening.
+    size_t nta = count_union_components(&a, 1, 0);
+    size_t ntb = count_union_components(&b, 1, 0);
+    size_t nt = nta + ntb;
+    jl_value_t **temp;
+    JL_GC_PUSHARGS(temp, nt+1);
+    size_t count = 0;
+    flatten_type_union(&a, 1, temp, &count, 0);
+    flatten_type_union(&b, 1, temp, &count, 0);
+    assert(count == nt);
+    size_t i, j;
+    // first remove disjoint elements.
+    for (i = 0; i < nt; i++) {
+        if (obviously_disjoint(temp[i], (i < nta ? b : a), 0))
+            temp[i] = NULL;
+    }
+    // then check subtyping.
+    int8_t *stemp = (int8_t *)alloca(count);
+    memset(stemp, 0, count);
+    for (i = 0; i < nta; i++) {
+        if (temp[i] == NULL) continue;
+        int hasfree = jl_has_free_typevars(temp[i]);
+        for (j = nta; j < nt; j++) {
+            if (temp[j] == NULL) continue;
+            int subs = simple_subtype2(temp[i], temp[j], hasfree || jl_has_free_typevars(temp[j]));
+            int subab = subs & 1, subba = subs >> 1;
+            if (subba && !subab) {
+                stemp[i] = -1;
+            }
+            if (subab && !subba) {
+                stemp[j] = -1;
+                temp[j] = temp[i];
+            }
+            if (stemp[i] == 0 && subab) stemp[i] = 1;
+            if (stemp[j] == 0 && subba) stemp[j] = 1;
+        }
+    }
+    int subs[2] = {1, 1}, rs[2] = {1, 1};
+    for (i = 0; i < nt; i++) {
+        subs[i >= nta] &= (temp[i] == NULL || stemp[i] == 1);
+        rs[i >= nta] &= (temp[i] != NULL && stemp[i] == 1);
+    }
+    // return a(b) if a(b) <: b(a)
+    if (rs[0]) {
+        JL_GC_POP();
+        return a;
+    }
+    if (rs[1]) {
+        JL_GC_POP();
+        return b;
+    }
+    // return `Union{}` for `merge_env` if we can't prove `<:` or `>:`
+    if (!overesi && !subs[0] && !subs[1]) {
+        JL_GC_POP();
+        return jl_bottom_type;
+    }
+    nt = subs[0] ? nta : nt;
+    count = subs[0] ? nta : ntb;
+    i = subs[0] ? 0 : nta;
+    isort_union(&temp[i], count);
+    temp[nt] = jl_bottom_type;
+    size_t k;
+    for (k = nt; k-- > i; ) {
+        if (temp[k] != NULL) {
+            if (temp[nt] == jl_bottom_type)
+                temp[nt] = temp[k];
+            else
+                temp[nt] = jl_new_struct(jl_uniontype_type, temp[k], temp[nt]);
+        }
+    }
+    assert(temp[nt] != NULL);
+    jl_value_t *tu = temp[nt];
+    JL_GC_POP();
+    return tu;
+}
 
 // unionall types -------------------------------------------------------------
 

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2491,6 +2491,14 @@ end
 @test !<:(Tuple{Type{Int}, Int}, Tuple{Type{Union{Int, T}}, T} where T<:Union{Int8,Int16})
 @test <:(Tuple{Type{Int}, Int}, Tuple{Type{Union{Int, T}}, T} where T<:Union{Int8,Int})
 
+#issue #49354 (requires assertions enabled)
+@test !<:(Tuple{Type{Union{Int, Val{1}}}, Int}, Tuple{Type{Union{Int, T1}}, T1} where T1<:Val)
+@test !<:(Tuple{Type{Union{Int, Val{1}}}, Int}, Tuple{Type{Union{Int, T1}}, T1} where T1<:Union{Val,Pair})
+@test <:(Tuple{Type{Union{Int, Val{1}}}, Int}, Tuple{Type{Union{Int, T1}}, T1} where T1<:Union{Integer,Val})
+@test <:(Tuple{Type{Union{Int, Int8}}, Int}, Tuple{Type{Union{Int, T1}}, T1} where T1<:Integer)
+@test_broken !<:(Tuple{Type{Union{Pair{Int, Any}, Pair{Int, Int}}}, Pair{Int, Any}},
+                 Tuple{Type{Union{Pair{Int, Any}, T1}}, T1} where T1<:(Pair{T,T} where {T}))
+
 let A = Tuple{Type{T}, T, Val{T}} where T,
     B = Tuple{Type{S}, Val{S}, Val{S}} where S
     @test_broken typeintersect(A, B) != Union{}

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2496,8 +2496,8 @@ end
 @test !<:(Tuple{Type{Union{Int, Val{1}}}, Int}, Tuple{Type{Union{Int, T1}}, T1} where T1<:Union{Val,Pair})
 @test <:(Tuple{Type{Union{Int, Val{1}}}, Int}, Tuple{Type{Union{Int, T1}}, T1} where T1<:Union{Integer,Val})
 @test <:(Tuple{Type{Union{Int, Int8}}, Int}, Tuple{Type{Union{Int, T1}}, T1} where T1<:Integer)
-@test_broken !<:(Tuple{Type{Union{Pair{Int, Any}, Pair{Int, Int}}}, Pair{Int, Any}},
-                 Tuple{Type{Union{Pair{Int, Any}, T1}}, T1} where T1<:(Pair{T,T} where {T}))
+@test !<:(Tuple{Type{Union{Pair{Int, Any}, Pair{Int, Int}}}, Pair{Int, Any}},
+          Tuple{Type{Union{Pair{Int, Any}, T1}}, T1} where T1<:(Pair{T,T} where {T}))
 
 let A = Tuple{Type{T}, T, Val{T}} where T,
     B = Tuple{Type{S}, Val{S}, Val{S}} where S


### PR DESCRIPTION
close #49354. (The fix is somehow limited as `obviously_disjoint` is simple to deceive.)
