### PR TITLE
Copy slottypes in copy(::CodeInfo)

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -75,6 +75,9 @@ function copy(c::CodeInfo)
     cnew.code = copy_exprargs(cnew.code)
     cnew.slotnames = copy(cnew.slotnames)
     cnew.slotflags = copy(cnew.slotflags)
+    if cnew.slottypes !== nothing
+        cnew.slottypes = copy(cnew.slottypes)
+    end
     cnew.codelocs  = copy(cnew.codelocs)
     cnew.linetable = copy(cnew.linetable::Union{Vector{Any},Vector{Core.LineInfoNode}})
     cnew.ssaflags  = copy(cnew.ssaflags)


### PR DESCRIPTION
This started as #49369 where I noticed CodeInfos with corrupted slottypes, though Shuhei pointed out that Cthulhu was actually copying the slottypes itself (but other downstreams were not), so I opened https://github.com/JuliaDebug/Cthulhu.jl/pull/429. However, on second thought, it seemed unnecessary for Cthulhu to be doing the copy of the slottypes explicitly, since it was already explicitly copying the CodeInfo. Upon further inspection, it became apparent that we simply forgot to add the `slottypes` to the CodeInfo copy method. Whoops.