### PR TITLE
Fix TODO in IncrementalCompact's `already_inserted`

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -326,7 +326,7 @@ function already_inserted(compact::IncrementalCompact, old::OldSSAValue)
     end
     id -= length(compact.ir.stmts)
     if id < length(compact.ir.new_nodes)
-        error("")
+        return already_inserted(compact, OldSSAValue(compact.ir.new_nodes.info[id].pos))
     end
     id -= length(compact.ir.new_nodes)
     @assert id <= length(compact.pending_nodes)


### PR DESCRIPTION
The `already_inserted` query on `IncrementalCompact` had a missing case for being called on incremental compact whose underlying IR had new nodes to be inserted. This does not happen in the base pipeline, because `already_inserted` is only used in the sroa passes, but can happen in some non-Base pipelines that run multiple rounds of sroa.