### PR TITLE
support making an IRInterpteretationState with a mismatched MI

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -335,7 +335,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
         end
     end
 
-    if last(irsv.valid_worlds) >= get_world_counter()
+    if last(irsv.valid_worlds) >= get_world_counter() && frame_instance(irsv) !== nothing
         # if we aren't cached, we don't need this edge
         # but our caller might, so let's just make it anyways
         store_backedges(frame_instance(irsv), irsv.edges)


### PR DESCRIPTION
In "non base pipelines" we are making an OpaqueClosure with generated IR code.

The issue is that we want to optimize this IR after modifying it. So we completely change the function arguments, and then want to call `_ir_abstract_constant_propagation` to get rid of runtime dispatch. This makes "silly" assumptions like that the IR arguments match the MI arguments.

So this PR bypasses the argument processing so we can optimize the IR without having a matching MI.

I don't think this change should be merged as is, so putting it out there so someone more knowledgeable can figure out a better way to do this.