### PR TITLE
redirect muladd for BigFloat to fma

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -8,7 +8,7 @@ export
 
 import
     .Base: *, +, -, /, <, <=, ==, >, >=, ^, ceil, cmp, convert, copysign, div,
-        inv, exp, exp2, exponent, factorial, floor, fma, hypot, isinteger,
+        inv, exp, exp2, exponent, factorial, floor, fma, muladd, hypot, isinteger,
         isfinite, isinf, isnan, ldexp, log, log2, log10, max, min, mod, modf,
         nextfloat, prevfloat, promote_rule, rem, rem2pi, round, show, float,
         sum, sqrt, string, print, trunc, precision, _precision, exp10, expm1, log1p,
@@ -535,6 +535,8 @@ function fma(x::BigFloat, y::BigFloat, z::BigFloat)
     ccall(("mpfr_fma",libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, Ref{BigFloat}, MPFRRoundingMode), r, x, y, z, ROUNDING_MODE[])
     return r
 end
+
+muladd(x::BigFloat, y::BigFloat, z::BigFloat) = fma(x, y, z)
 
 # div
 # BigFloat


### PR DESCRIPTION
A fused multiply-add is available in MPFR as `mpfr_fma` and `Base.fma` already uses it. Apart from being fused (more accurate), it's also more performant than the generic `muladd` and allocates one less temporary `BigFloat`.