### PR TITLE
Backport to 1.9: Improve performance of global code by emitting fewer atomic barriers.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7739,8 +7739,15 @@ static jl_llvm_functions_t
 
     Instruction &prologue_end = ctx.builder.GetInsertBlock()->back();
 
+    // step 11a. For top-level code, load the world age
+    if (toplevel && !ctx.is_opaque_closure) {
+        LoadInst *load_world = ctx.builder.CreateAlignedLoad(getSizeTy(ctx.builder.getContext()),
+            prepare_global_in(jl_Module, jlgetworld_global), Align(sizeof(size_t)));
+        load_world->setOrdering(AtomicOrdering::Monotonic);
+        ctx.builder.CreateAlignedStore(load_world, world_age_field, Align(sizeof(size_t)));
+    }
 
-    // step 11. Do codegen in control flow order
+    // step 11b. Do codegen in control flow order
     std::vector<int> workstack;
     std::map<int, BasicBlock*> BB;
     std::map<size_t, BasicBlock*> come_from_bb;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5917,7 +5917,7 @@ static Function* gen_cfun_wrapper(
 
     Value *world_v = ctx.builder.CreateAlignedLoad(getSizeTy(ctx.builder.getContext()),
         prepare_global_in(jl_Module, jlgetworld_global), Align(sizeof(size_t)));
-    cast<LoadInst>(world_v)->setOrdering(AtomicOrdering::Acquire);
+    cast<LoadInst>(world_v)->setOrdering(AtomicOrdering::Monotonic);
 
     Value *age_ok = NULL;
     if (calltype) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5917,7 +5917,7 @@ static Function* gen_cfun_wrapper(
 
     Value *world_v = ctx.builder.CreateAlignedLoad(getSizeTy(ctx.builder.getContext()),
         prepare_global_in(jl_Module, jlgetworld_global), Align(sizeof(size_t)));
-    cast<LoadInst>(world_v)->setOrdering(AtomicOrdering::Monotonic);
+    cast<LoadInst>(world_v)->setOrdering(AtomicOrdering::Acquire);
 
     Value *age_ok = NULL;
     if (calltype) {
@@ -7743,7 +7743,7 @@ static jl_llvm_functions_t
     if (toplevel && !ctx.is_opaque_closure) {
         LoadInst *load_world = ctx.builder.CreateAlignedLoad(getSizeTy(ctx.builder.getContext()),
             prepare_global_in(jl_Module, jlgetworld_global), Align(sizeof(size_t)));
-        load_world->setOrdering(AtomicOrdering::Monotonic);
+        load_world->setOrdering(AtomicOrdering::Acquire);
         ctx.builder.CreateAlignedStore(load_world, world_age_field, Align(sizeof(size_t)));
     }
 
@@ -8315,7 +8315,7 @@ static jl_llvm_functions_t
                     LoadInst *load_world = new LoadInst(getSizeTy(ctx.builder.getContext()),
                         prepare_global_in(jl_Module, jlgetworld_global), Twine(),
                         /*isVolatile*/false, Align(sizeof(size_t)), /*insertBefore*/&I);
-                    load_world->setOrdering(AtomicOrdering::Monotonic);
+                    load_world->setOrdering(AtomicOrdering::Acquire);
                     StoreInst *store_world = new StoreInst(load_world, world_age_field,
                         /*isVolatile*/false, Align(sizeof(size_t)), /*insertBefore*/&I);
                     (void)store_world;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8063,13 +8063,6 @@ static jl_llvm_functions_t
             ctx.builder.SetInsertPoint(tryblk);
         }
         else {
-            if (!jl_is_method(ctx.linfo->def.method) && !ctx.is_opaque_closure) {
-                // TODO: inference is invalid if this has any effect (which it often does)
-                LoadInst *world = ctx.builder.CreateAlignedLoad(getSizeTy(ctx.builder.getContext()),
-                    prepare_global_in(jl_Module, jlgetworld_global), Align(sizeof(size_t)));
-                world->setOrdering(AtomicOrdering::Acquire);
-                ctx.builder.CreateAlignedStore(world, world_age_field, Align(sizeof(size_t)));
-            }
             emit_stmtpos(ctx, stmt, cursor);
             mallocVisitStmt(debuginfoloc, nullptr);
         }
@@ -8295,12 +8288,12 @@ static jl_llvm_functions_t
     }
 
     // step 12. Perform any delayed instantiations
-    if (ctx.debug_enabled) {
-        bool in_prologue = true;
-        for (auto &BB : *ctx.f) {
-            for (auto &I : BB) {
-                CallBase *call = dyn_cast<CallBase>(&I);
-                if (call && !I.getDebugLoc()) {
+    bool in_prologue = true;
+    for (auto &BB : *ctx.f) {
+        for (auto &I : BB) {
+            CallBase *call = dyn_cast<CallBase>(&I);
+            if (call) {
+                if (ctx.debug_enabled && !I.getDebugLoc()) {
                     // LLVM Verifier: inlinable function call in a function with debug info must have a !dbg location
                     // make sure that anything we attempt to call has some inlining info, just in case optimization messed up
                     // (except if we know that it is an intrinsic used in our prologue, which should never have its own debug subprogram)
@@ -8309,12 +8302,24 @@ static jl_llvm_functions_t
                         I.setDebugLoc(topdebugloc);
                     }
                 }
-                if (&I == &prologue_end)
-                    in_prologue = false;
+                if (toplevel && !ctx.is_opaque_closure && !in_prologue) {
+                    // we're at toplevel; insert an atomic barrier between every instruction
+                    // TODO: inference is invalid if this has any effect (which it often does)
+                    LoadInst *load_world = new LoadInst(getSizeTy(ctx.builder.getContext()),
+                        prepare_global_in(jl_Module, jlgetworld_global), Twine(),
+                        /*isVolatile*/false, Align(sizeof(size_t)), /*insertBefore*/&I);
+                    load_world->setOrdering(AtomicOrdering::Monotonic);
+                    StoreInst *store_world = new StoreInst(load_world, world_age_field,
+                        /*isVolatile*/false, Align(sizeof(size_t)), /*insertBefore*/&I);
+                    (void)store_world;
+                }
             }
+            if (&I == &prologue_end)
+                in_prologue = false;
         }
-        dbuilder.finalize();
     }
+    if (ctx.debug_enabled)
+        dbuilder.finalize();
 
     if (ctx.vaSlot > 0) {
         // remove VA allocation if we never referenced it

--- a/src/llvm-julia-licm.cpp
+++ b/src/llvm-julia-licm.cpp
@@ -127,7 +127,6 @@ struct JuliaLICMPassLegacy : public LoopPass {
             getLoopAnalysisUsage(AU);
         }
 };
-
 struct JuliaLICM : public JuliaPassContext {
     function_ref<DominatorTree &()> GetDT;
     function_ref<LoopInfo &()> GetLI;
@@ -276,6 +275,19 @@ struct JuliaLICM : public JuliaPassContext {
                     if (valid) {
                         ++HoistedAllocation;
                         moveInstructionBefore(*call, *preheader->getTerminator(), MSSAU, SE);
+                        IRBuilder<> builder(preheader->getTerminator());
+                        builder.SetCurrentDebugLocation(call->getDebugLoc());
+                        auto obj_i8 = builder.CreateBitCast(call, Type::getInt8PtrTy(call->getContext(), call->getType()->getPointerAddressSpace()));
+                        // Note that this alignment is assuming the GC allocates at least pointer-aligned memory
+                        auto align = Align(DL.getPointerSize(0));
+                        auto clear_obj = builder.CreateMemSet(obj_i8, ConstantInt::get(Type::getInt8Ty(call->getContext()), 0), call->getArgOperand(1), align);
+                        if (MSSAU.getMemorySSA()) {
+                            auto alloc_mdef = MSSAU.getMemorySSA()->getMemoryAccess(call);
+                            assert(isa<MemoryDef>(alloc_mdef) && "Expected alloc to be associated with a memory def!");
+                            auto clear_mdef = MSSAU.createMemoryAccessAfter(clear_obj, nullptr, alloc_mdef);
+                            assert(isa<MemoryDef>(clear_mdef) && "Expected memset to be associated with a memory def!");
+                            (void) clear_mdef;
+                        }
                         changed = true;
                     }
                 }
@@ -331,6 +343,10 @@ PreservedAnalyses JuliaLICMPass::run(Loop &L, LoopAnalysisManager &AM,
     };
     auto juliaLICM = JuliaLICM(GetDT, GetLI, GetMSSA, GetSE);
     if (juliaLICM.runOnLoop(&L)) {
+#ifdef JL_DEBUG_BUILD
+        if (AR.MSSA)
+            AR.MSSA->verifyMemorySSA();
+#endif
         auto preserved = getLoopPassPreservedAnalyses();
         preserved.preserveSet<CFGAnalyses>();
         preserved.preserve<MemorySSAAnalysis>();

--- a/test/llvmpasses/julia-licm.ll
+++ b/test/llvmpasses/julia-licm.ll
@@ -25,13 +25,15 @@ L4:                                               ; preds = %top
   %current_task112 = getelementptr inbounds {}**, {}*** %1, i64 -12
   %current_task1 = bitcast {}*** %current_task112 to {}**
   ; CHECK: %3 = call noalias nonnull {} addrspace(10)* @julia.gc_alloc_obj({}** nonnull %current_task1, i64 8, {} addrspace(10)* @tag)
+  ; CHECK-NEXT: %4 = bitcast {} addrspace(10)* %3 to i8 addrspace(10)*
+  ; CHECK-NEXT: call void @llvm.memset.p10i8.i64(i8 addrspace(10)* align {{[0-9]+}} %4, i8 0, i64 8, i1 false)
   ; CHECK-NEXT: br label %L22
   br label %L22
 
 L22:                                              ; preds = %L4, %L22
   %value_phi5 = phi i64 [ 1, %L4 ], [ %5, %L22 ]
-  ; CHECK: %value_phi5 = phi i64 [ 1, %L4 ], [ %5, %L22 ]
-  ; CHECK-NEXT %4 = bitcast {} addrspace(10)* %3 to i64 addrspace(10)*
+  ; CHECK: %value_phi5 = phi i64 [ 1, %L4 ], [ %6, %L22 ]
+  ; CHECK-NEXT %5 = bitcast {} addrspace(10)* %3 to i64 addrspace(10)*
   %3 = call noalias nonnull {} addrspace(10)* @julia.gc_alloc_obj({}** nonnull %current_task1, i64 8, {} addrspace(10)* @tag) #1
   %4 = bitcast {} addrspace(10)* %3 to i64 addrspace(10)*
   store i64 %value_phi5, i64 addrspace(10)* %4, align 8, !tbaa !2


### PR DESCRIPTION
Manual backport of #47636. We should be careful with this change, as in https://github.com/JuliaLang/julia/pull/47636 there used to be a mysterious failure with the i686 tester during LinearAlgebra/special (a segfault) that just disappeared at some point.