### PR TITLE
Flush SimpleLogger stream after each write

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -690,6 +690,7 @@ function handle_message(logger::SimpleLogger, level::LogLevel, message, _module,
     end
     println(iob, "└ @ ", _module, " ", filepath, ":", line)
     write(stream, take!(buf))
+    flush(stream)
     nothing
 end
 


### PR DESCRIPTION
Otherwise log messages are buffered and show up in the log file only after the process exits.