### PR TITLE
fix regression in methods lookup

### DIFF
--- a/src/typemap.c
+++ b/src/typemap.c
@@ -425,7 +425,7 @@ static int jl_typemap_intersection_array_visitor(jl_array_t *a, jl_value_t *ty, 
             if (tydt == jl_any_type || // easy case: Any always matches
                 tname_intersection(tydt, (jl_typename_t*)t, height)) {
                 if (jl_is_array(ml)) {
-                    if (!jl_typemap_intersection_array_visitor((jl_array_t*)ml, ty, 1, offs, closure))
+                    if (!jl_typemap_intersection_array_visitor((jl_array_t*)ml, ty, tparam & ~2, offs, closure))
                         goto exit;
                 }
                 else {

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1038,6 +1038,10 @@ ambig_effects_test(a, b) = 1
 end
 
 @test Base._methods_by_ftype(Tuple{}, -1, Base.get_world_counter()) == Any[]
+@test length(methods(Base.Broadcast.broadcasted, Tuple{Any, Any, Vararg})) >
+      length(methods(Base.Broadcast.broadcasted, Tuple{Base.Broadcast.BroadcastStyle, Any, Vararg})) >=
+      length(methods(Base.Broadcast.broadcasted, Tuple{Base.Broadcast.DefaultArrayStyle{1}, Any, Vararg})) >=
+      10
 
 @testset "specializations" begin
     f(x) = 1


### PR DESCRIPTION
Certain queries were searching for Type{T} instead of T due to a mistaken tparam setting, resulting in missing methods in lookup.

Fix #49408
Ref #48925