### PR TITLE
Rewrap in Hermitian(::Hermitian) and Symmetric(::Symmetric)

### DIFF
--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -187,7 +187,7 @@ hermitian_type(::Type{T}) where {T<:Number} = T
 
 for (S, H) in ((:Symmetric, :Hermitian), (:Hermitian, :Symmetric))
     @eval begin
-        $S(A::$S) = A
+        $S(A::$S) = $S(parent(A), sym_uplo(A.uplo)) # technically a no-op, but rewrapping the parent might narrow types
         function $S(A::$S, uplo::Symbol)
             if A.uplo == char_uplo(uplo)
                 return A

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -459,6 +459,17 @@ end
     end
 end
 
+@testset "issue #49230" begin
+    struct model
+        B::Hermitian{Float64, AbstractMatrix{Float64}}
+    end
+
+    H = Hermitian(rand(10,10))
+    M = model(H)
+    M2 = Hermitian(M.B)
+    @test typeof(M2) == typeof(H)
+end
+
 #Issue #7647: test xsyevr, xheevr, xstevr drivers.
 @testset "Eigenvalues in interval for $(typeof(Mi7647))" for Mi7647 in
         (Symmetric(diagm(0 => 1.0:3.0)),


### PR DESCRIPTION
Fix https://github.com/JuliaLang/LinearAlgebra.jl/issues/996

After this,
```julia
julia> struct model
           B::Hermitian{Float64, AbstractMatrix{Float64}}
       end

julia> M = model(Hermitian(rand(4, 4)))
model([0.5643158933611603 0.0906086672741725 0.7460634180822564 0.41187474876562746; 0.0906086672741725 0.40472038505340413 0.008039981910233696 0.5224357036155776; 0.7460634180822564 0.008039981910233696 0.7597195918953756 0.729550085230974; 0.41187474876562746 0.5224357036155776 0.729550085230974 0.38453321982131894])

julia> Hermitian(M.B) # the type of the parent is concrete after this
4×4 Hermitian{Float64, Matrix{Float64}}:
 0.564316   0.0906087   0.746063    0.411875
 0.0906087  0.40472     0.00803998  0.522436
 0.746063   0.00803998  0.75972     0.72955
 0.411875   0.522436    0.72955     0.384533
```

The re-wrapping is relatively inexpensive, so this seems harmless:
```julia
julia> H = Hermitian(rand(1000,1000));

julia> @btime Hermitian($H);
  5.461 ns (0 allocations: 0 bytes)
```