### PR TITLE
Allow conversion of `AbstractQ` to `AbstractArray`

### DIFF
--- a/stdlib/LinearAlgebra/src/abstractq.jl
+++ b/stdlib/LinearAlgebra/src/abstractq.jl
@@ -40,7 +40,7 @@ Matrix{T}(adjQ::AdjointQ{S}) where {T,S} = convert(Matrix{T}, lmul!(adjQ, Matrix
 Matrix(Q::AbstractQ{T}) where {T} = Matrix{T}(Q)
 Array{T}(Q::AbstractQ) where {T} = Matrix{T}(Q)
 Array(Q::AbstractQ) = Matrix(Q)
-convert(::Type{T}, Q::AbstractQ) where {T<:Array} = T(Q)
+convert(::Type{T}, Q::AbstractQ) where {T<:AbstractArray} = T(Q)
 # legacy
 @deprecate(convert(::Type{AbstractMatrix{T}}, Q::AbstractQ) where {T},
     convert(LinearAlgebra.AbstractQ{T}, Q))


### PR DESCRIPTION
This small change should allow to convert a `AbstractQ` object into, say, a `CuArray`. The difference to the deprecated method right below is that the latter was used to convert the `eltype` (i.e., convert the backing matrices), but otherwise kept the outer type.

x-ref: https://github.com/JuliaGPU/CUDA.jl/pull/1872