### PR TITLE
move out Downloads and LibCURL from the sysimage

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -64,12 +64,6 @@ let
         # 3-depth packages
         :REPL,
         :TOML,
-
-        # 4-depth packages
-        :LibCURL,
-
-        # 5-depth packages
-        :Downloads,
     ]
     # PackageCompiler can filter out stdlibs so it can be empty
     maxlen = maximum(textwidth.(string.(stdlibs)); init=0)

--- a/pkgimage.mk
+++ b/pkgimage.mk
@@ -108,10 +108,10 @@ $(eval $(call sysimg_builder,TOML,Dates))
 $(eval $(call pkgimg_builder,Test,Logging Random Serialization InteractiveUtils))
 
 # 4-depth packages
-$(eval $(call sysimg_builder,LibCURL,LibCURL_jll MozillaCACerts_jll))
+$(eval $(call pkgimg_builder,LibCURL,LibCURL_jll MozillaCACerts_jll))
 
 # 5-depth packages
-$(eval $(call sysimg_builder,Downloads,ArgTools FileWatching LibCURL NetworkOptions))
+$(eval $(call pkgimg_builder,Downloads,ArgTools FileWatching LibCURL NetworkOptions))
 
 # 6-depth packages
 $(eval $(call pkgimg_builder,Pkg,Dates LibGit2 Libdl Logging Printf Random SHA UUIDs)) # Markdown REPL

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -395,12 +395,11 @@ precompile_test_harness(false) do dir
                      Base.PkgId(m) => Base.module_build_id(m)
                  end for s in
                 [:ArgTools, :Artifacts, :Base64, :CompilerSupportLibraries_jll, :CRC32c, :Dates,
-                 :Downloads, :FileWatching, :Future, :InteractiveUtils, :libblastrampoline_jll,
-                 :LibCURL, :LibCURL_jll, :LibGit2, :Libdl, :LinearAlgebra,
-                 :Logging, :Markdown, :Mmap, :MozillaCACerts_jll, :NetworkOptions, :OpenBLAS_jll, :Printf,
+                 :FileWatching, :Future, :InteractiveUtils, :libblastrampoline_jll,
+                 :LibGit2, :Libdl, :LinearAlgebra,
+                 :Logging, :Markdown, :Mmap, :NetworkOptions, :OpenBLAS_jll, :Printf,
                  :REPL, :Random, :SHA, :Serialization, :Sockets,
-                 :TOML, :Tar, :Test, :UUIDs, :Unicode,
-                 :nghttp2_jll]
+                 :TOML, :Tar, :Test, :UUIDs, :Unicode]
             ),
         )
         @test discard_module.(deps) == deps1


### PR DESCRIPTION
Also means, LibCURL_jll, MozillaCACerts_jll, nghttp2_jll moves out since they are no longer loaded by something else that gets  put into the sysimage.