### PR TITLE
rename `jl_tls_offset` in sysimage to avoid naming clash with `libjulia-internal`

### DIFF
--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -329,7 +329,7 @@ bool LowerPTLS::run(bool *CFGModified)
             if (imaging_mode) {
                 pgcstack_func_slot = create_aliased_global(T_pgcstack_getter, "jl_pgcstack_func_slot");
                 pgcstack_key_slot = create_aliased_global(getSizeTy(M->getContext()), "jl_pgcstack_key_slot"); // >= sizeof(jl_pgcstack_key_t)
-                pgcstack_offset = create_aliased_global(getSizeTy(M->getContext()), "jl_tls_offset");
+                pgcstack_offset = create_aliased_global(getSizeTy(M->getContext()), "jl_tls_offset_image");
             }
             need_init = false;
         }

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -481,7 +481,7 @@ static void jl_load_sysimg_so(void)
         jl_pgcstack_getkey((jl_get_pgcstack_func**)pgcstack_func_slot, (jl_pgcstack_key_t*)pgcstack_key_slot);
 
         size_t *tls_offset_idx;
-        jl_dlsym(jl_sysimg_handle, "jl_tls_offset", (void **)&tls_offset_idx, 1);
+        jl_dlsym(jl_sysimg_handle, "jl_tls_offset_image", (void **)&tls_offset_idx, 1);
         *tls_offset_idx = (uintptr_t)(jl_tls_offset == -1 ? 0 : jl_tls_offset);
 
 #ifdef _OS_WINDOWS_
@@ -3475,7 +3475,7 @@ JL_DLLEXPORT jl_value_t *jl_restore_package_image_from_file(const char *fname, j
         jl_pgcstack_getkey((jl_get_pgcstack_func**)pgcstack_func_slot, (jl_pgcstack_key_t*)pgcstack_key_slot);
 
         size_t *tls_offset_idx;
-        jl_dlsym(pkgimg_handle, "jl_tls_offset", (void **)&tls_offset_idx, 1);
+        jl_dlsym(pkgimg_handle, "jl_tls_offset_image", (void **)&tls_offset_idx, 1);
         *tls_offset_idx = (uintptr_t)(jl_tls_offset == -1 ? 0 : jl_tls_offset);
     }
 


### PR DESCRIPTION
We have seen some issues with PackageCompiler that likely comes from an ODR violation with this symbol. Testing this PR here to see if that produces binaries that are better.