### PR TITLE
Make clang happy 

### DIFF
--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -104,7 +104,7 @@ void *mach_segv_listener(void *arg)
 }
 
 
-static void allocate_mach_handler()
+static void allocate_mach_handler(void)
 {
     // ensure KEYMGR_GCC3_DW2_OBJ_LIST is initialized, as this requires malloc
     // and thus can deadlock when used without first initializing it.


### PR DESCRIPTION
Newer clang versions now complain about this so fix it. 

They also complain about 
```
/Users/gabrielbaraldi/julia/usr/include/llvm/ADT/DenseMap.h:129:16: warning: variable 'NumEntries' set but not used [-Wunused-but-set-variable]
```
But it's on an LLVM header so not sure what to do