### PR TITLE
remove SIGABRT from sigwait list

### DIFF
--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -645,7 +645,7 @@ void jl_install_thread_signal_handler(jl_ptls_t ptls)
 }
 
 const static int sigwait_sigs[] = {
-    SIGINT, SIGTERM, SIGABRT, SIGQUIT,
+    SIGINT, SIGTERM, SIGQUIT,
 #ifdef SIGINFO
     SIGINFO,
 #else


### PR DESCRIPTION
This already is added to the sigdie list, so on mach it was attempting to handle it in both places simultaneously.