### PR TITLE
improve effects of  `objectid` and `getindex(::Dict)`

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -263,7 +263,7 @@ end
     sz = length(h.keys)
     iter = 0
     maxprobe = h.maxprobe
-    maxprobe < sz || error() # This error will never trigger, but is needed for terminates_locally to be valid
+    maxprobe < sz || throw(AssertionError()) # This error will never trigger, but is needed for terminates_locally to be valid
     index, sh = hashindex(key, sz)
     keys = h.keys
 

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -263,7 +263,7 @@ end
     sz = length(h.keys)
     iter = 0
     maxprobe = h.maxprobe
-    @assert maxprobe <= sz # needed for terminates_locally to be valid
+    maxprobe < sz || error() # This error will never trigger, but is needed for terminates_locally to be valid
     index, sh = hashindex(key, sz)
     keys = h.keys
 

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -258,11 +258,12 @@ function empty!(h::Dict{K,V}) where V where K
 end
 
 # get the index where a key is stored, or -1 if not present
-function ht_keyindex(h::Dict{K,V}, key) where V where K
+@assume_effects :terminates_locally function ht_keyindex(h::Dict{K,V}, key) where V where K
     isempty(h) && return -1
     sz = length(h.keys)
     iter = 0
     maxprobe = h.maxprobe
+    @assert maxprobe <= sz # needed for terminates_locally to be valid
     index, sh = hashindex(key, sz)
     keys = h.keys
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -600,7 +600,8 @@ See also [`hash`](@ref), [`IdDict`](@ref).
 """
 function objectid(x)
     # objectid is foldable iff it isn't a pointer.
-    if !ismutable(x) || x isa String || x isa Symbol
+    # Sring, Symbol, Module, and DataType are safe because jl_objectid for them works by value.
+    if !ismutable(x) || x isa String || x isa Symbol || x isa Module
         return _foldable_objectid(x)
     end
     return _objectid(x)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -334,28 +334,6 @@ macro locals()
     return Expr(:locals)
 end
 
-"""
-    objectid(x) -> UInt
-
-Get a hash value for `x` based on object identity.
-
-If `x === y` then `objectid(x) == objectid(y)`, and usually when `x !== y`, `objectid(x) != objectid(y)`.
-
-See also [`hash`](@ref), [`IdDict`](@ref).
-"""
-function objectid(x)
-    # objectid is foldable iff it isn't a pointer.
-    if isimmutable(x) || x isa String || x isa Symbol
-        return _foldable_objectid(x)
-    end
-    return _objectid(x)
-end
-function _foldable_objectid(@nospecialize(x))
-    @_foldable_meta
-    _objectid(x)
-end
-_objectid(@nospecialize(x)) = ccall(:jl_object_id, UInt, (Any,), x)
-
 # concrete datatype predicates
 
 datatype_fieldtypes(x::DataType) = ccall(:jl_get_fieldtypes, Core.SimpleVector, (Any,), x)
@@ -610,6 +588,28 @@ isbitstype(@nospecialize t) = (@_total_meta; isa(t, DataType) && (t.flags & 0x00
 Return `true` if `x` is an instance of an [`isbitstype`](@ref) type.
 """
 isbits(@nospecialize x) = isbitstype(typeof(x))
+
+"""
+    objectid(x) -> UInt
+
+Get a hash value for `x` based on object identity.
+
+If `x === y` then `objectid(x) == objectid(y)`, and usually when `x !== y`, `objectid(x) != objectid(y)`.
+
+See also [`hash`](@ref), [`IdDict`](@ref).
+"""
+function objectid(x)
+    # objectid is foldable iff it isn't a pointer.
+    if !ismutable(x) || x isa String || x isa Symbol
+        return _foldable_objectid(x)
+    end
+    return _objectid(x)
+end
+function _foldable_objectid(@nospecialize(x))
+    @_foldable_meta
+    _objectid(x)
+end
+_objectid(@nospecialize(x)) = ccall(:jl_object_id, UInt, (Any,), x)
 
 """
     isdispatchtuple(T)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -343,10 +343,18 @@ If `x === y` then `objectid(x) == objectid(y)`, and usually when `x !== y`, `obj
 
 See also [`hash`](@ref), [`IdDict`](@ref).
 """
-function objectid(@nospecialize(x))
-    @_foldable_meta
-    ccall(:jl_object_id, UInt, (Any,), x)
+function objectid(x)
+    # objectid is foldable iff it isn't a pointer.
+    if isimmutable(x) || x isa String || x isa Symbol
+        return _foldable_objectid(x)
+    end
+    return _objectid(x)
 end
+function _foldable_objectid(@nospecialize(x))
+    @_foldable_meta
+    _objectid(x)
+end
+_objectid(@nospecialize(x)) = ccall(:jl_object_id, UInt, (Any,), x)
 
 # concrete datatype predicates
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -600,8 +600,7 @@ See also [`hash`](@ref), [`IdDict`](@ref).
 """
 function objectid(x)
     # objectid is foldable iff it isn't a pointer.
-    # Sring, Symbol, Module, and DataType are safe because jl_objectid for them works by value.
-    if x isa String || Core.Compiler.valid_tparam(x)
+    if isidentityfree(typeof(x))
         return _foldable_objectid(x)
     end
     return _objectid(x)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -343,7 +343,10 @@ If `x === y` then `objectid(x) == objectid(y)`, and usually when `x !== y`, `obj
 
 See also [`hash`](@ref), [`IdDict`](@ref).
 """
-objectid(@nospecialize(x)) = ccall(:jl_object_id, UInt, (Any,), x)
+function objectid(@nospecialize(x))
+    @_foldable_meta
+    ccall(:jl_object_id, UInt, (Any,), x)
+end
 
 # concrete datatype predicates
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -601,7 +601,7 @@ See also [`hash`](@ref), [`IdDict`](@ref).
 function objectid(x)
     # objectid is foldable iff it isn't a pointer.
     # Sring, Symbol, Module, and DataType are safe because jl_objectid for them works by value.
-    if !ismutable(x) || x isa String || x isa Symbol || x isa Module
+    if x isa String || Core.Compiler.valid_tparam(x)
         return _foldable_objectid(x)
     end
     return _objectid(x)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3137,6 +3137,8 @@ void jl_init_types(void) JL_GC_DISABLED
     // Technically not ismutationfree, but there's a separate system to deal
     // with mutations for global state.
     jl_module_type->ismutationfree = 1;
+    // Module object identity is determined by its name and parent name.
+    jl_module_type->isidentityfree = 1;
 
     // Array's mutable data is hidden, so we need to override it
     ((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_array_type))->ismutationfree = 0;

--- a/test/core.jl
+++ b/test/core.jl
@@ -7985,3 +7985,22 @@ f48950(::Union{Int,d}, ::Union{c,Nothing}...) where {c,d} = 1
 # Module as tparam in unionall
 struct ModTParamUnionAll{A, B}; end
 @test isa(objectid(ModTParamUnionAll{Base}), UInt)
+
+# effects for objectid
+for T in (Int, String, Symbol)
+    @test Core.Compiler.is_foldable(Base.infer_effects(objectid, (T,)))
+    @test Core.Compiler.is_foldable(Base.infer_effects(hash, (T,)))
+    @test Core.Compiler.is_foldable(Base.infer_effects(objectid, (Some{T},)))
+    @test Core.Compiler.is_foldable(Base.infer_effects(hash, (Some{T},)))
+    @test Core.Compiler.is_foldable(Base.infer_effects(objectid, (Some{Some{T}},)))
+    @test Core.Compiler.is_foldable(Base.infer_effects(hash, (Some{Some{T}},)))
+    @test Core.Compiler.is_foldable(Base.infer_effects(objectid, (Tuple{T},)))
+    @test Core.Compiler.is_foldable(Base.infer_effects(hash, (Tuple{T},)))
+    @test Core.Compiler.is_foldable(Base.infer_effects(objectid, (Tuple{T,T},)))
+    @test Core.Compiler.is_foldable(Base.infer_effects(hash, (Tuple{T,T},)))
+end
+@test !Core.Compiler.is_consistent(Base.infer_effects(objectid, (Ref{Int},)))
+@test !Core.Compiler.is_consistent(Base.infer_effects(objectid, (Tuple{Ref{Int}},)))
+# objectid for datatypes is inconsistant for types that have unbound type parameters.
+@test !Core.Compiler.is_consistent(Base.infer_effects(objectid, (DataType,)))
+@test !Core.Compiler.is_consistent(Base.infer_effects(objectid, (Tuple{Vector{Int}},)))

--- a/test/core.jl
+++ b/test/core.jl
@@ -7987,7 +7987,7 @@ struct ModTParamUnionAll{A, B}; end
 @test isa(objectid(ModTParamUnionAll{Base}), UInt)
 
 # effects for objectid
-for T in (Int, String, Symbol)
+for T in (Int, String, Symbol, Module)
     @test Core.Compiler.is_foldable(Base.infer_effects(objectid, (T,)))
     @test Core.Compiler.is_foldable(Base.infer_effects(hash, (T,)))
     @test Core.Compiler.is_foldable(Base.infer_effects(objectid, (Some{T},)))

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1363,3 +1363,9 @@ end
     sizehint!(d, 10)
     @test length(d.slots) < 100
 end
+
+# getindex is effect free and nothrow but not consistent
+for T in (String, Module, Symbol, Int, Float64)
+    @test Core.Compiler.is_effect_free(Base.infer_effects(getindex, (Dict{T, BigInt},T)))
+    @test Core.Compiler.is_terminates(Base.infer_effects(getindex, (Dict{T, BigInt},T)))
+end

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1364,8 +1364,10 @@ end
     @test length(d.slots) < 100
 end
 
-# getindex is effect free and nothrow but not consistent
-for T in (String, Module, Symbol, Int, Float64)
-    @test Core.Compiler.is_effect_free(Base.infer_effects(getindex, (Dict{T, BigInt},T)))
-    @test Core.Compiler.is_terminates(Base.infer_effects(getindex, (Dict{T, BigInt},T)))
+# getindex is :effect_free and :terminates but not :consistent
+for T in (Int, Float64, String, Symbol)
+    @test !Core.Compiler.is_consistent(Base.infer_effects(getindex, (Dict{T,Any}, T)))
+    @test Core.Compiler.is_effect_free(Base.infer_effects(getindex, (Dict{T,Any}, T)))
+    @test !Core.Compiler.is_nothrow(Base.infer_effects(getindex, (Dict{T,Any}, T)))
+    @test Core.Compiler.is_terminates(Base.infer_effects(getindex, (Dict{T,Any}, T)))
 end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1035,12 +1035,6 @@ ambig_effects_test(a, b) = 1
     @test Base.infer_effects(===, (Any,Any)) |> Core.Compiler.is_foldable_nothrow
     @test (Base.infer_effects(setfield!, ()); true) # `builtin_effects` shouldn't throw on empty `argtypes`
     @test (Base.infer_effects(Core.Intrinsics.arraylen, ()); true) # `intrinsic_effects` shouldn't throw on empty `argtypes`
-    for T in (Int, String, Symbol, Some{Int}, Some{String}, Some{Symbol}, Some{Some{Int}}, Some{Some{String}}, Some{Some{Symbol}})
-         @test Core.Compiler.is_foldable(Base.infer_effects(hash, (T,)))
-    end
-    # objectid for datatypes is inconsistant for types that have unbound type parameters.
-    @test !Core.Compiler.is_consistent(Base.infer_effects(hash, (DataType,)))
-    @test !Core.Compiler.is_consistent(Base.infer_effects(hash, (Tuple{Vector{Int}},)))
 end
 
 @test Base._methods_by_ftype(Tuple{}, -1, Base.get_world_counter()) == Any[]

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1038,8 +1038,9 @@ ambig_effects_test(a, b) = 1
     for T in (String, Module, Symbol)
          @test Core.Compiler.is_foldable(Base.infer_effects(hash, (T,)))
     end
-    # darn unbound typevars
+    # darn unbound
     @test !Core.Compiler.is_consistent(Base.infer_effects(hash, (DataType,)))
+    @test !Core.Compiler.is_consistent(Base.infer_effects(hash, (Tuple{Vector{Int}},)))
 end
 
 @test Base._methods_by_ftype(Tuple{}, -1, Base.get_world_counter()) == Any[]

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1035,7 +1035,7 @@ ambig_effects_test(a, b) = 1
     @test Base.infer_effects(===, (Any,Any)) |> Core.Compiler.is_foldable_nothrow
     @test (Base.infer_effects(setfield!, ()); true) # `builtin_effects` shouldn't throw on empty `argtypes`
     @test (Base.infer_effects(Core.Intrinsics.arraylen, ()); true) # `intrinsic_effects` shouldn't throw on empty `argtypes`
-    for T in (String, Module, Symbol)
+    for T in (Int, String, Symbol, Some{Int}, Some{String}, Some{Symbol}, Some{Some{Int}}, Some{Some{String}}, Some{Some{Symbol}})
          @test Core.Compiler.is_foldable(Base.infer_effects(hash, (T,)))
     end
     # objectid for datatypes is inconsistant for types that have unbound type parameters.

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1038,7 +1038,7 @@ ambig_effects_test(a, b) = 1
     for T in (String, Module, Symbol)
          @test Core.Compiler.is_foldable(Base.infer_effects(hash, (T,)))
     end
-    # darn unbound
+    # objectid for datatypes is inconsistant for types that have unbound type parameters.
     @test !Core.Compiler.is_consistent(Base.infer_effects(hash, (DataType,)))
     @test !Core.Compiler.is_consistent(Base.infer_effects(hash, (Tuple{Vector{Int}},)))
 end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1035,6 +1035,11 @@ ambig_effects_test(a, b) = 1
     @test Base.infer_effects(===, (Any,Any)) |> Core.Compiler.is_foldable_nothrow
     @test (Base.infer_effects(setfield!, ()); true) # `builtin_effects` shouldn't throw on empty `argtypes`
     @test (Base.infer_effects(Core.Intrinsics.arraylen, ()); true) # `intrinsic_effects` shouldn't throw on empty `argtypes`
+    for T in (String, Module, Symbol)
+         @test Core.Compiler.is_foldable(Base.infer_effects(hash, (T,)))
+    end
+    # darn unbound typevars
+    @test !Core.Compiler.is_consistent(Base.infer_effects(hash, (DataType,)))
 end
 
 @test Base._methods_by_ftype(Tuple{}, -1, Base.get_world_counter()) == Any[]


### PR DESCRIPTION
~~With these changes (and https://github.com/JuliaLang/julia/pull/49260) we can now tab complete through dictionaries.~~ EDIT: It's not necessary.

The `objectid` improvement is needed for `Dict{Symbol, T}` since `hash(Symbol)` calls `objectid`.