### PR TITLE
Markdown: Reset underline style when wrapping text.

### DIFF
--- a/stdlib/Markdown/src/render/terminal/formatting.jl
+++ b/stdlib/Markdown/src/render/terminal/formatting.jl
@@ -22,9 +22,12 @@ function wrapped_line(io::IO, s::AbstractString, width, i)
                 maybe_underline = findlast(Base.text_colors[:underline], last_line)
                 if !isnothing(maybe_underline)
                     # disable underline style at end of line if not already disabled.
-                    maybe_disable_underline = findlast(Base.disable_text_style[:underline], last_line)
-                    if isnothing(maybe_disable_underline) ||
-                        last(maybe_disable_underline) < last(maybe_underline)
+                    maybe_disable_underline = max(
+                        last(something(findlast(Base.disable_text_style[:underline], last_line), -1)),
+                        last(something(findlast(Base.text_colors[:normal], last_line), -1)),
+                    )
+
+                    if maybe_disable_underline < 0 || maybe_disable_underline < last(maybe_underline)
 
                         lines[end] = last_line * Base.disable_text_style[:underline]
                         word = Base.text_colors[:underline] * word

--- a/stdlib/Markdown/src/render/terminal/formatting.jl
+++ b/stdlib/Markdown/src/render/terminal/formatting.jl
@@ -17,6 +17,20 @@ function wrapped_line(io::IO, s::AbstractString, width, i)
         word_length == 0 && continue
         if isempty(lines) || i + word_length + 1 > width
             i = word_length
+            if length(lines) > 0
+                last_line = lines[end]
+                maybe_underline = findlast(Base.text_colors[:underline], last_line)
+                if !isnothing(maybe_underline)
+                    # disable underline style at end of line if not already disabled.
+                    maybe_disable_underline = findlast(Base.disable_text_style[:underline], last_line)
+                    if isnothing(maybe_disable_underline) ||
+                        last(maybe_disable_underline) < last(maybe_underline)
+
+                        lines[end] = last_line * Base.disable_text_style[:underline]
+                        word = Base.text_colors[:underline] * word
+                    end
+                end
+            end
             push!(lines, word)
         else
             i += word_length + 1

--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -81,14 +81,15 @@ end
 function _term_header(io::IO, md, char, columns)
     text = terminline_string(io, md.text)
     with_output_color(:bold, io) do io
-        print(io, ' '^margin)
+        pre = ' '^margin
+        print(io, pre)
         line_no, lastline_width = print_wrapped(io, text,
-                                                width=columns - 4margin; pre=" ")
-        line_width = min(1 + lastline_width, columns)
+                                                width=columns - 4margin; pre)
+        line_width = min(lastline_width, columns)
         if line_no > 1
-            line_width = max(line_width, div(columns, 3))
+            line_width = max(line_width, div(columns, 3)+length(pre))
         end
-        header_width = max(0, line_width-margin)
+        header_width = max(0, line_width-length(pre))
         char != ' ' && header_width > 0 && print(io, '\n', ' '^(margin), char^header_width)
     end
 end

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1160,6 +1160,25 @@ let buf = IOBuffer()
     @test String(take!(buf)) == "  \e[4memph\e[24m"
 end
 
+let word = "Markdown" # disable underline when wrapping lines
+    buf = IOBuffer()
+    ctx = IOContext(buf, :color => true, :displaysize => (displaysize(buf)[1], length(word)))
+    long_italic_text = Markdown.parse('_' * join(fill(word, 10), ' ') * '_')
+    show(ctx, MIME("text/plain"), long_italic_text)
+    lines = split(String(take!(buf)), '\n')
+    @test endswith(lines[begin], Base.disable_text_style[:underline])
+    @test startswith(lines[begin+1], ' '^Markdown.margin * Base.text_colors[:underline])
+end
+
+let word = "Markdown" # pre is of size Markdown.margin when wrapping title
+    buf = IOBuffer()
+    ctx = IOContext(buf, :color => true, :displaysize => (displaysize(buf)[1], length(word)))
+    long_title = Markdown.parse("# " * join(fill(word, 3)))
+    show(ctx, MIME("text/plain"), long_title)
+    lines = split(String(take!(buf)), '\n')
+    @test all(startswith(Base.text_colors[:bold] * ' '^Markdown.margin), lines)
+end
+
 # table rendering with term #25213
 t = """
     a   |   b

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1179,6 +1179,19 @@ let word = "Markdown" # pre is of size Markdown.margin when wrapping title
     @test all(startswith(Base.text_colors[:bold] * ' '^Markdown.margin), lines)
 end
 
+struct Struct49454 end
+Base.show(io::IO, ::Struct49454) =
+    print(io, Base.text_colors[:underline], "Struct 49454()", Base.text_colors[:normal])
+
+let buf = IOBuffer()
+    ctx = IOContext(buf, :color => true, :displaysize => (displaysize(buf)[1], 10))
+    show(stdout, MIME("text/plain"), md"""
+    text without $(Struct49454()) underline.
+    """)
+    lines = split(String(take!(buf)), '\n')
+    @test !occursin(Base.text_colors[:underline], lines[end])
+end
+
 # table rendering with term #25213
 t = """
     a   |   b


### PR DESCRIPTION
Also changes the margin for wrapped headers from one space to `' '^margin`.

Example with underlined long title and list item:

| Before | PR |
|--------|----|
|![image](https://user-images.githubusercontent.com/9824244/233721248-36beaaf1-96a1-4313-86f9-f4db3a060dbb.png)|![image](https://user-images.githubusercontent.com/9824244/233720737-f4def91d-827a-4f5a-b485-e85699cec176.png)|
