### PR TITLE
Add a gc-safe sleeping mutex

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -3966,12 +3966,12 @@ JL_DLLEXPORT void jl_typeinf_timing_end(uint64_t start)
 
 JL_DLLEXPORT void jl_typeinf_lock_begin(void)
 {
-    JL_SPIN_LOCK(&jl_codegen_lock);
+    JL_SLEEP_LOCK(&jl_codegen_lock);
 }
 
 JL_DLLEXPORT void jl_typeinf_lock_end(void)
 {
-    JL_SPIN_UNLOCK(&jl_codegen_lock);
+    JL_SLEEP_UNLOCK(&jl_codegen_lock);
 }
 
 #ifdef __cplusplus

--- a/src/init.c
+++ b/src/init.c
@@ -726,7 +726,7 @@ static void init_global_mutexes(void) {
     JL_SPIN_MUTEX_INIT(&precomp_statement_out_lock, "precomp_statement_out_lock");
     JL_SPIN_MUTEX_INIT(&newly_inferred_mutex, "newly_inferred_mutex");
     JL_SPIN_MUTEX_INIT(&global_roots_lock, "global_roots_lock");
-    JL_SPIN_MUTEX_INIT(&jl_codegen_lock, "jl_codegen_lock");
+    JL_SLEEP_MUTEX_INIT(&jl_codegen_lock, "jl_codegen_lock");
     JL_SPIN_MUTEX_INIT(&typecache_lock, "typecache_lock");
 }
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1378,7 +1378,7 @@ JL_DLLEXPORT void jl_set_next_task(jl_task_t *task) JL_NOTSAFEPOINT;
 // -- synchronization utilities -- //
 
 extern jl_spin_mutex_t typecache_lock;
-extern JL_DLLEXPORT jl_spin_mutex_t jl_codegen_lock;
+extern JL_DLLEXPORT jl_sleep_mutex_t jl_codegen_lock;
 
 #if defined(__APPLE__)
 void jl_mach_gc_end(void);

--- a/src/threading.c
+++ b/src/threading.c
@@ -493,7 +493,7 @@ static void jl_delete_thread(void *value) JL_NOTSAFEPOINT_ENTER
 //// the other threads time to fail and emit their failure message
 //__attribute__((destructor)) static void _waitthreaddeath(void) { sleep(1); }
 
-JL_DLLEXPORT jl_spin_mutex_t jl_codegen_lock;
+JL_DLLEXPORT jl_sleep_mutex_t jl_codegen_lock;
 jl_spin_mutex_t typecache_lock;
 
 JL_DLLEXPORT ssize_t jl_tls_offset = -1;


### PR DESCRIPTION
Threads that wait for the codegen lock should really sleep when it isn't available, since codegen often takes a nontrivial amount of time to complete. Therefore we introduce a sleeping mutex that cooperates with the GC to replace the spin mutex. 

Sleeping lock implementation mostly stolen from here: https://www.realworldtech.com/forum/?threadid=189711&curpostid=189755

If we run on an example that forces 5 threads to attempt to acquire the codegen lock at the same time:

Before:

![image](https://user-images.githubusercontent.com/34727397/233758189-32cbf37d-a62b-46de-9d73-cd8123d8dc2a.png)

After:

![image](https://user-images.githubusercontent.com/34727397/233757938-86298ae7-ec60-4645-83c2-3e7a77dc508f.png)
