### PR TITLE
Remove unnecessary allocation in `BitSet()`

### DIFF
--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -15,7 +15,7 @@ mutable struct BitSet <: AbstractSet{Int}
     # 1st stored Int equals 64*offset
     offset::Int
 
-    BitSet() = new(sizehint!(zeros(UInt64, 0), 4), NO_OFFSET)
+    BitSet() = new(resize!(Vector{UInt64}(undef, 4), 0), NO_OFFSET)
 end
 
 """


### PR DESCRIPTION
Instead of allocating a vector of size 0 and then reallocating of size 4, skip straight to the larger allocation.

```julia
julia> @btime sizehint!(zeros(UInt64, 0), 4)
  30.276 ns (2 allocations: 144 bytes)
UInt64[]

julia> @btime resize!(Vector{UInt64}(undef, 4), 0)
  18.537 ns (1 allocation: 96 bytes)
UInt64[]

julia> @btime begin x = sizehint!(zeros(UInt64, 0), 4); push!(x, 1); push!(x, 5); push!(x, 3); push!(x, 6) end
  46.680 ns (2 allocations: 144 bytes)
4-element Vector{UInt64}:
 0x0000000000000001
 0x0000000000000005
 0x0000000000000003
 0x0000000000000006

julia> @btime begin x = resize!(Vector{UInt64}(undef, 4), 0); push!(x, 1); push!(x, 5); push!(x, 3); push!(x, 6) end
  34.954 ns (1 allocation: 96 bytes)
4-element Vector{UInt64}:
 0x0000000000000001
 0x0000000000000005
 0x0000000000000003
 0x0000000000000006
```