### PR TITLE
Remove unnecessary definition of `eltype(::Type{BitSet})`

### DIFF
--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -38,8 +38,6 @@ end
 
 @inline intoffset(s::BitSet) = s.offset << 6
 
-eltype(::Type{BitSet}) = Int
-
 empty(s::BitSet, ::Type{Int}=Int) = BitSet()
 emptymutable(s::BitSet, ::Type{Int}=Int) = BitSet()
 


### PR DESCRIPTION
We already have

https://github.com/JuliaLang/julia/blob/357bcdd302e10c2f0e827a8dad625e42719e106c/base/abstractset.jl#L3

and

https://github.com/JuliaLang/julia/blob/357bcdd302e10c2f0e827a8dad625e42719e106c/base/bitset.jl#L13