### PR TITLE
Implement pop! for AbstractSet and remove some implementations of pop! for concrete sets

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -289,6 +289,11 @@ function symdiff!(s::AbstractSet, itr::AbstractSet)
     return s
 end
 
+## pop!
+
+pop!(s::AbstractSet, x)          = x in s ? (delete!(s, x); x) : throw(KeyError(x))
+pop!(s::AbstractSet, x, default) = x in s ? (delete!(s, x); x) : default
+
 ## non-strict subset comparison
 
 const ⊆ = issubset

--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -253,24 +253,6 @@ push!(s::BitSet, ns::Integer...) = (for n in ns; push!(s, n); end; s)
 
 @inline pop!(s::BitSet) = pop!(s, last(s))
 
-@inline function pop!(s::BitSet, n::Integer)
-    if n in s
-        delete!(s, n)
-        n
-    else
-        throw(KeyError(n))
-    end
-end
-
-@inline function pop!(s::BitSet, n::Integer, default)
-    if n in s
-        delete!(s, n)
-        n
-    else
-        default
-    end
-end
-
 @inline _is_convertible_Int(n) = typemin(Int) <= n <= typemax(Int)
 @inline delete!(s::BitSet, n::Int) = _setint!(s, n, false)
 @inline delete!(s::BitSet, n::Integer) = _is_convertible_Int(n) ? delete!(s, Int(n)) : s

--- a/base/idset.jl
+++ b/base/idset.jl
@@ -19,8 +19,7 @@ isempty(s::IdSet) = isempty(s.dict)
 length(s::IdSet)  = length(s.dict)
 in(@nospecialize(x), s::IdSet) = haskey(s.dict, x)
 push!(s::IdSet, @nospecialize(x)) = (s.dict[x] = nothing; s)
-pop!(s::IdSet, @nospecialize(x)) = (pop!(s.dict, x); x)
-pop!(s::IdSet, @nospecialize(x), @nospecialize(default)) = (x in s ? pop!(s, x) : default)
+pop!(s::IdSet, @nospecialize(x)) = (pop!(s.dict, x); x) # Faster than the AbstractSet fallback
 delete!(s::IdSet, @nospecialize(x)) = (delete!(s.dict, x); s)
 
 sizehint!(s::IdSet, newsz) = (sizehint!(s.dict, newsz); s)

--- a/base/set.jl
+++ b/base/set.jl
@@ -101,8 +101,7 @@ function in!(x, s::Set)
 end
 
 push!(s::Set, x) = (s.dict[x] = nothing; s)
-pop!(s::Set, x) = (pop!(s.dict, x); x)
-pop!(s::Set, x, default) = (x in s ? pop!(s, x) : default)
+pop!(s::Set, x) = (pop!(s.dict, x); x) # Faster than the AbstractSet fallback
 
 function pop!(s::Set)
     isempty(s) && throw(ArgumentError("set must be non-empty"))


### PR DESCRIPTION
This is mostly a refactoring, but it also means that anyone who defines an `AbstractSet` in a package with `delete!` gets some `pop!` functions for free.

(The `AbstractSet` interface remains [undocumented](https://docs.julialang.org/en/v1.10-dev/manual/interfaces/))

This PR would be bad if we want `pop!` to be what new types define and `delete!` to be defined in terms of `pop!` in general, but I prefer the other way around (and the other way around is how BitSet is already implemented)