### PR TITLE
Remove redundant definitions of `push(::AbstractDict, elements...)`

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -560,8 +560,6 @@ function get!(default::Callable, t::AbstractDict{K,V}, key) where K where V
 end
 
 push!(t::AbstractDict, p::Pair) = setindex!(t, p.second, p.first)
-push!(t::AbstractDict, p::Pair, q::Pair) = push!(push!(t, p), q)
-push!(t::AbstractDict, p::Pair, q::Pair, r::Pair...) = push!(push!(push!(t, p), q), r...)
 
 # AbstractDicts are convertible
 convert(::Type{T}, x::T) where {T<:AbstractDict} = x


### PR DESCRIPTION
We already have

https://github.com/JuliaLang/julia/blob/4044096c15f03a9f6bf4b777d93048a299f29334/base/abstractarray.jl#L3390-L3391