### PR TITLE
Fix method show with kwarg and optional arguments

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -194,10 +194,11 @@ function functionloc(@nospecialize(f))
 end
 
 function sym_to_string(sym)
-    s = String(sym)
-    if s === :var"..."
+    if sym === :var"..."
         return "..."
-    elseif endswith(s, "...")
+    end
+    s = String(sym)
+    if endswith(s, "...")
         return string(sprint(show_sym, Symbol(s[1:end-3])), "...")
     else
         return sprint(show_sym, sym)

--- a/test/show.jl
+++ b/test/show.jl
@@ -791,6 +791,14 @@ let ms = methods(S45879)
     @test sprint(show, Base.MethodList(Method[], typeof(S45879).name.mt)) isa String
 end
 
+function f49475(a=12.0; b) end
+let ms = methods(f49475)
+    @test length(ms) == 2
+    repr1 = sprint(show, "text/plain", ms[1])
+    repr2 = sprint(show, "text/plain", ms[2])
+    @test occursin("f49475(; ...)", repr1) || occursin("f49475(; ...)", repr2)
+end
+
 if isempty(Base.GIT_VERSION_INFO.commit)
     @test occursin("https://github.com/JuliaLang/julia/tree/v$VERSION/base/special/trig.jl#L", Base.url(which(sin, (Float64,))))
 else


### PR DESCRIPTION
@vtjnash I believe this is what you actually indended in the base/methodshow.jl edit of https://github.com/JuliaLang/julia/pull/48639?
Otherwise, currently there is the odd `var""...` that appears when showing methods (and thus in REPL completion):
```julia
julia> function foo(a=12.0; b) end;

julia> foo(#TAB, on master
foo(a; b) @ Main REPL[1]:1        foo(; var""...) @ Main REPL[1]:1

julia> foo(#TAB, this PR
foo(a; b) @ Main REPL[1]:1   foo(; ...) @ Main REPL[1]:1
```