### PR TITLE
show the root module in tracing for __init__ as well

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -927,6 +927,15 @@ JL_DLLEXPORT jl_value_t *jl_module_names(jl_module_t *m, int all, int imported)
 
 JL_DLLEXPORT jl_sym_t *jl_module_name(jl_module_t *m) { return m->name; }
 JL_DLLEXPORT jl_module_t *jl_module_parent(jl_module_t *m) { return m->parent; }
+jl_module_t *jl_module_root(jl_module_t *m)
+{
+    while (1) {
+        if (m->parent == NULL || m->parent == m)
+            return m;
+        m = m->parent;
+    }
+}
+
 JL_DLLEXPORT jl_uuid_t jl_module_build_id(jl_module_t *m) { return m->build_id; }
 JL_DLLEXPORT jl_uuid_t jl_module_uuid(jl_module_t* m) { return m->uuid; }
 

--- a/src/timing.c
+++ b/src/timing.c
@@ -168,7 +168,7 @@ JL_DLLEXPORT void jl_timing_show_module(jl_module_t *m, jl_timing_block_t *cur_b
 {
 #ifdef USE_TRACY
     jl_module_t *root = jl_module_root(m);
-    if (root == m) {
+    if (root == m || root == jl_main_module) {
         const char *module_name = jl_symbol_name(m->name);
         TracyCZoneText(*(cur_block->tracy_ctx), module_name, strlen(module_name));
     } else {

--- a/src/timing.c
+++ b/src/timing.c
@@ -6,6 +6,8 @@
 #include "options.h"
 #include "stdio.h"
 
+jl_module_t *jl_module_root(jl_module_t *m);
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -165,8 +167,14 @@ JL_DLLEXPORT void jl_timing_show(jl_value_t *v, jl_timing_block_t *cur_block)
 JL_DLLEXPORT void jl_timing_show_module(jl_module_t *m, jl_timing_block_t *cur_block)
 {
 #ifdef USE_TRACY
-    const char *module_name = jl_symbol_name(m->name);
-    TracyCZoneText(*(cur_block->tracy_ctx), module_name, strlen(module_name));
+    jl_module_t *root = jl_module_root(m);
+    if (root == m) {
+        const char *module_name = jl_symbol_name(m->name);
+        TracyCZoneText(*(cur_block->tracy_ctx), module_name, strlen(module_name));
+    } else {
+
+        jl_timing_printf(cur_block, "%s->%s", jl_symbol_name(root->name), jl_symbol_name(m->name));
+    }
 #endif
 }
 

--- a/src/timing.c
+++ b/src/timing.c
@@ -173,7 +173,7 @@ JL_DLLEXPORT void jl_timing_show_module(jl_module_t *m, jl_timing_block_t *cur_b
         TracyCZoneText(*(cur_block->tracy_ctx), module_name, strlen(module_name));
     } else {
 
-        jl_timing_printf(cur_block, "%s->%s", jl_symbol_name(root->name), jl_symbol_name(m->name));
+        jl_timing_printf(cur_block, "%s.%s", jl_symbol_name(root->name), jl_symbol_name(m->name));
     }
 #endif
 }


### PR DESCRIPTION
When a submodule is running `__init__` it can sometimes be non trivial to find out what package that module actually lives in.