### PR TITLE
Add compile_commands.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 .vscode/*
 *.heapsnapshot
 .cache
+compile_commands.json 
 # Buildkite: Ignore the entire .buildkite directory
 /.buildkite
 


### PR DESCRIPTION
using `bear` https://github.com/rizsotto/Bear we can get a `compile_commands.json` on julia and that makes development a bit nicer, so add it to gitignore