### PR TITLE
[release-1.9] Avoid usage of `jl_error()` in `check_cmdline()`

### DIFF
--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -739,20 +739,24 @@ static inline void check_cmdline(T &&cmdline, bool imaging)
     // sysimg means. Make it an error for now.
     if (!imaging) {
         if (cmdline.size() > 1) {
-            jl_error("More than one command line CPU targets specified "
-                     "without a `--output-` flag specified");
+            jl_safe_printf("More than one command line CPU targets specified "
+                      "without a `--output-` flag specified");
+            exit(1);
         }
         if (cmdline[0].en.flags & JL_TARGET_CLONE_ALL) {
-            jl_error("\"clone_all\" feature specified "
-                     "without a `--output-` flag specified");
+            jl_safe_printf("\"clone_all\" feature specified "
+                      "without a `--output-` flag specified");
+            exit(1);
         }
         if (cmdline[0].en.flags & JL_TARGET_OPTSIZE) {
-            jl_error("\"opt_size\" feature specified "
-                     "without a `--output-` flag specified");
+            jl_safe_printf("\"opt_size\" feature specified "
+                      "without a `--output-` flag specified");
+            exit(1);
         }
         if (cmdline[0].en.flags & JL_TARGET_MINSIZE) {
-            jl_error("\"min_size\" feature specified "
-                     "without a `--output-` flag specified");
+            jl_safe_printf("\"min_size\" feature specified "
+                      "without a `--output-` flag specified");
+            exit(1);
         }
     }
 }


### PR DESCRIPTION
This is the same as https://github.com/JuliaLang/julia/pull/45765 where we use `jl_error()` too early to get backtraces, but too late to fail the supposed guard `if` statement that should prevent us from trying to take a backtrace.  X-ref: https://github.com/JuliaLang/julia/issues/45847

(cherry picked from commit fa215891aff303e57608a6786fb152ef67565a51)