### PR TITLE
use power iteration for opnorm2

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -679,8 +679,8 @@ function opnorm2(A::AbstractMatrix{T}) where T
     if m == 0 || n == 0 return zero(Tnorm) end
     if m == 1 || n == 1 return norm2(A) end
     # to minimize the chance of x being orthogonal to the largest eigenvector
-    x = rand(Tnorm, m)
-    tmp = similar(x)
+    x = randn(Tnorm, n)
+    tmp = zeros(Tnorm, m)
     At = A'
     v = one(Tnorm)
     # this will converge quickly as long as the top two eigenvalues are distinct

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -689,7 +689,7 @@ function opnorm2(A::AbstractMatrix{T}) where T
         newv = norm(x)
         # the numerics got very wonky
         !isfinite(newv) && return first(svdvals(A))
-        isapprox(v, newv; rtol=10*eps(T)) && return sqrt(newv)
+        isapprox(v, newv; rtol=10*eps(Tnorm)) && return sqrt(newv)
         v = newv
         x .*= inv(newv)
     end


### PR DESCRIPTION
This is much faster and allocates `O(m)` instead of `O(m*n)`
```
A  = rand(1024,1024);
# before
@time opnorm(A)
  0.148451 seconds (10 allocations: 8.210 MiB)
512.4395710760909

# after
@time opnorm(A)
  0.001369 seconds (3 allocations: 16.266 KiB)
512.439571076091
```