### PR TITLE
Base.Threads: copy `__source__` LineInfo into closure for @spawn/@async

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -922,6 +922,26 @@ function remove_linenums!(src::CodeInfo)
     return src
 end
 
+replace_linenums!(ex, ln::LineNumberNode) = ex
+function replace_linenums!(ex::Expr, ln::LineNumberNode)
+    if ex.head === :block || ex.head === :quote
+        # replace line number expressions from metadata (not argument literal or inert) position
+        map!(ex.args, ex.args) do @nospecialize(x)
+            isa(x, Expr) && x.head === :line && length(x.args) == 1 && return Expr(:line, ln.line)
+            isa(x, Expr) && x.head === :line && length(x.args) == 2 && return Expr(:line, ln.line, ln.file)
+            isa(x, LineNumberNode) && return ln
+            return x
+        end
+    end
+    # preserve any linenums inside `esc(...)` guards
+    if ex.head !== :escape
+        for subex in ex.args
+            subex isa Expr && replace_linenums!(subex, ln)
+        end
+    end
+    return ex
+end
+
 macro generated()
     return Expr(:generated)
 end

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -377,7 +377,7 @@ macro spawn(args...)
 
     letargs = Base._lift_one_interp!(ex)
 
-    thunk = esc(:(()->($ex)))
+    thunk = Base.replace_linenums!(:(()->($(esc(ex)))), __source__)
     var = esc(Base.sync_varname)
     quote
         let $(letargs...)

--- a/src/task.c
+++ b/src/task.c
@@ -1068,31 +1068,6 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, jl_value_t *completion
     t->start = start;
     t->result = jl_nothing;
     t->donenotify = completion_future;
-#ifdef USE_TRACY
-    jl_value_t *start_type = jl_typeof(t->start);
-    const char *start_name = "";
-    if (jl_is_datatype(start_type))
-        start_name = jl_symbol_name(((jl_datatype_t *) start_type)->name->name);
-
-    static uint16_t task_id = 1;
-
-    // XXX: Tracy uses this as a handle internally and requires that this
-    // string live forever, so this allocation is intentionally leaked.
-    char *fiber_name;
-    if (start_name[0] == '#') {
-        jl_method_instance_t *mi = jl_method_lookup(&t->start, 1, jl_get_world_counter());
-        const char *filename = basename(jl_symbol_name(mi->def.method->file));
-        size_t fiber_name_len = strlen(filename) + 22; // 22 characters in "Task 65535 (:0000000)\0"
-        fiber_name = (char *)malloc(fiber_name_len);
-        snprintf(fiber_name, fiber_name_len,  "Task %d (%s:%d)", task_id++, filename, mi->def.method->line);
-    } else {
-        size_t fiber_name_len = strlen(start_name) + 16; // 16 characters in "Task 65535 (\"\")\0"
-        fiber_name = (char *)malloc(fiber_name_len);
-        snprintf(fiber_name, fiber_name_len,  "Task %d (\"%s\")", task_id++, start_name);
-    }
-
-    t->name = fiber_name;
-#endif
     jl_atomic_store_relaxed(&t->_isexception, 0);
     // Inherit logger state from parent task
     t->logstate = ct->logstate;
@@ -1110,6 +1085,7 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, jl_value_t *completion
     t->ptls = NULL;
     t->world_age = ct->world_age;
     t->reentrant_timing = 0;
+    jl_timing_init_task(t);
 
 #ifdef COPY_STACKS
     if (!t->copy_stack) {

--- a/src/task.c
+++ b/src/task.c
@@ -1081,9 +1081,10 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, jl_value_t *completion
     char *fiber_name;
     if (start_name[0] == '#') {
         jl_method_instance_t *mi = jl_method_lookup(&t->start, 1, jl_get_world_counter());
-        size_t fiber_name_len = strlen(jl_symbol_name(mi->def.method->file)) + 22; // 22 characters in "Task 65535 (:0000000)\0"
+        const char *filename = basename(jl_symbol_name(mi->def.method->file));
+        size_t fiber_name_len = strlen(filename) + 22; // 22 characters in "Task 65535 (:0000000)\0"
         fiber_name = (char *)malloc(fiber_name_len);
-        snprintf(fiber_name, fiber_name_len,  "Task %d (%s:%d)", task_id++, jl_symbol_name(mi->def.method->file), mi->def.method->line);
+        snprintf(fiber_name, fiber_name_len,  "Task %d (%s:%d)", task_id++, filename, mi->def.method->line);
     } else {
         size_t fiber_name_len = strlen(start_name) + 16; // 16 characters in "Task 65535 (\"\")\0"
         fiber_name = (char *)malloc(fiber_name_len);

--- a/src/timing.h
+++ b/src/timing.h
@@ -64,6 +64,7 @@ extern uint32_t jl_timing_print_limit;
 
 #define JL_TIMING(subsystem, event)
 #define JL_TIMING_SUSPEND(subsystem, ct)
+
 #define jl_timing_show(v, b)
 #define jl_timing_show_module(m, b)
 #define jl_timing_show_filename(f, b)
@@ -72,6 +73,7 @@ extern uint32_t jl_timing_print_limit;
 #define jl_timing_show_func_sig(tt, b)
 #define jl_timing_printf(b, f, ...)
 #define jl_timing_puts(b, s)
+#define jl_timing_init_task(t)
 #define jl_timing_block_enter_task(ct, ptls, blk)
 #define jl_timing_block_exit_task(ct, ptls) ((jl_timing_block_t *)NULL)
 #define jl_pop_timing_block(blk)
@@ -98,6 +100,8 @@ extern "C" {
 #endif
 void jl_print_timings(void);
 jl_timing_block_t *jl_pop_timing_block(jl_timing_block_t *cur_block);
+
+void jl_timing_init_task(jl_task_t *t);
 void jl_timing_block_enter_task(jl_task_t *ct, jl_ptls_t ptls, jl_timing_block_t *prev_blk);
 jl_timing_block_t *jl_timing_block_exit_task(jl_task_t *ct, jl_ptls_t ptls);
 


### PR DESCRIPTION
This makes it much easier to differentiate between `@spawn/@async` tasks:

![image](https://user-images.githubusercontent.com/84105208/234133354-d1449dca-9959-4a4b-9584-406d0b940d2d.png)
versus before:

![image](https://user-images.githubusercontent.com/84105208/234092716-9d630c7b-ec84-48bc-9648-7960b127e0c4.png)
