### PR TITLE
instrument `jl_load_dynamic_library` to the profiler

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -272,11 +272,14 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
         }
         handle = dlopen(info.dli_fname, RTLD_NOW);
 #endif
-        goto done;
+        return handle;
     }
 
     abspath = jl_isabspath(modname);
     is_atpath = 0;
+
+    JL_TIMING(DL_OPEN, DL_OPEN);
+    jl_timing_printf(JL_TIMING_CURRENT_BLOCK, gnu_basename(modname));
 
     // Detect if our `modname` is something like `@rpath/libfoo.dylib`
 #ifdef _OS_DARWIN_
@@ -334,7 +337,7 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
 #endif
                         handle = jl_dlopen(path, flags);
                         if (handle)
-                            goto done;
+                            return handle;
 #ifdef _OS_WINDOWS_
                         err = GetLastError();
                     }
@@ -354,7 +357,7 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
         snprintf(path, PATHBUF, "%s%s", modname, ext);
         handle = jl_dlopen(path, flags);
         if (handle)
-            goto done;
+            return handle;
 #ifdef _OS_WINDOWS_
         err = GetLastError();
         break; // LoadLibrary already tested the rest
@@ -377,7 +380,6 @@ notfound:
     }
     handle = NULL;
 
-done:
     return handle;
 }
 

--- a/src/timing.c
+++ b/src/timing.c
@@ -141,12 +141,6 @@ jl_timing_block_t *jl_timing_block_exit_task(jl_task_t *ct, jl_ptls_t ptls)
     return blk;
 }
 
-static inline const char *gnu_basename(const char *path)
-{
-    char *base = strrchr(path, '/');
-    return base ? base+1 : path;
-}
-
 JL_DLLEXPORT void jl_timing_show(jl_value_t *v, jl_timing_block_t *cur_block)
 {
 #ifdef USE_TRACY

--- a/src/timing.h
+++ b/src/timing.h
@@ -5,6 +5,12 @@
 
 #include "julia.h"
 
+static inline const char *gnu_basename(const char *path)
+{
+    const char *base = strrchr(path, '/');
+    return base ? base+1 : path;
+}
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -135,6 +141,8 @@ void jl_timing_printf(jl_timing_block_t *cur_block, const char *format, ...);
         X(SAVE_MODULE)           \
         X(INIT_MODULE)           \
         X(LOCK_SPIN)             \
+        X(DL_OPEN)                \
+
 
 
 #define JL_TIMING_EVENTS \


### PR DESCRIPTION
I wanted to see how much of the jll initialization time was due to opening dynamic libraries:

<img width="313" alt="image" src="https://user-images.githubusercontent.com/1282691/234258224-9fb2e26f-ae6a-46c8-837b-fad2391d57c9.png">

I had to change some of the `goto`s to `return` due to the cleanup attribute not working very well with `goto`. I don't really see why `goto` was used in the first place but maybe I miss something.