### PR TITLE
Backports release 1.9

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -1066,20 +1066,12 @@ function select_platform(download_info::Dict, platform::AbstractPlatform = HostP
         return nothing
     end
 
-    # At this point, we may have multiple possibilities.  We now engage a multi-
-    # stage selection algorithm, where we first choose simpler matches over more
-    # complex matches.  We define a simpler match as one that has fewer tags
-    # overall.  As these candidate matches have already been filtered to match
-    # the given platform, the only other tags that exist are ones that are in
-    # addition to the tags declared by the platform. Hence, selecting the
-    # minimum in number of tags is equivalent to selecting the closest match.
-    min_tag_count = minimum(length(tags(p)) for p in ps)
-    filter!(p -> length(tags(p)) == min_tag_count, ps)
-
-    # Now we _still_ may continue to have multiple matches, so we now simply sort
-    # the candidate matches by their triplets and take the last one, so as to
-    # generally choose the latest release (e.g. a `libgfortran5` tarball over a
-    # `libgfortran3` tarball).
+    # At this point, we may have multiple possibilities.  E.g. if, in the future,
+    # Julia can be built without a direct dependency on libgfortran, we may match
+    # multiple tarballs that vary only within their libgfortran ABI.  To narrow it
+    # down, we just sort by triplet, then pick the last one.  This has the effect
+    # of generally choosing the latest release (e.g. a `libgfortran5` tarball
+    # rather than a `libgfortran3` tarball)
     p = last(sort(ps, by = p -> triplet(p)))
     return download_info[p]
 end

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -293,6 +293,7 @@ end
 
 function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IRInterpretationState;
     extra_reprocess::Union{Nothing,BitSet} = nothing)
+
     (; ir, tpdum, ssa_refined) = irsv
 
     bbs = ir.cfg.blocks
@@ -416,7 +417,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
     return maybe_singleton_const(ultimate_rt)
 end
 
-function ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IRInterpretationState)
+function ir_abstract_constant_propagation(interp::NativeInterpreter, irsv::IRInterpretationState)
     if __measure_typeinf__[]
         inf_frame = Timings.InferenceFrameInfo(irsv.mi, irsv.world, Any[], Any[], length(irsv.ir.argtypes))
         Timings.enter_new_timer(inf_frame)
@@ -429,3 +430,5 @@ function ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IRI
         return T
     end
 end
+ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IRInterpretationState) =
+    _ir_abstract_constant_propagation(interp, irsv)

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -204,8 +204,9 @@ If set to `true`, record per-method-instance timings within type inference in th
 __set_measure_typeinf(onoff::Bool) = __measure_typeinf__[] = onoff
 const __measure_typeinf__ = fill(false)
 
-# Wrapper around _typeinf that optionally records the exclusive time for each invocation.
-function typeinf(interp::AbstractInterpreter, frame::InferenceState)
+# Wrapper around `_typeinf` that optionally records the exclusive time for
+# each inference performed by `NativeInterpreter`.
+function typeinf(interp::NativeInterpreter, frame::InferenceState)
     if __measure_typeinf__[]
         Timings.enter_new_timer(frame)
         v = _typeinf(interp, frame)
@@ -215,6 +216,7 @@ function typeinf(interp::AbstractInterpreter, frame::InferenceState)
         return _typeinf(interp, frame)
     end
 end
+typeinf(interp::AbstractInterpreter, frame::InferenceState) = _typeinf(interp, frame)
 
 function finish!(interp::AbstractInterpreter, caller::InferenceResult)
     # If we didn't transform the src for caching, we may have to transform

--- a/test/binaryplatforms.jl
+++ b/test/binaryplatforms.jl
@@ -315,9 +315,8 @@ end
         P("x86_64", "linux"; libgfortran_version=v"5") => "linux8",
 
         # Ambiguity test
-        P("aarch64", "linux"; libgfortran_version=v"3") => "linux3",
+        P("aarch64", "linux"; libgfortran_version=v"3") => "linux4",
         P("aarch64", "linux"; libgfortran_version=v"3", libstdcxx_version=v"3.4.18") => "linux5",
-        P("aarch64", "linux"; libgfortran_version=v"3", libstdcxx_version=v"3.4.18", foo="bar") => "linux9",
 
         # OS test
         P("x86_64", "macos"; libgfortran_version=v"3") => "mac4",
@@ -328,10 +327,8 @@ end
     @test select_platform(platforms, P("x86_64", "linux"; libgfortran_version=v"4")) == "linux7"
 
     # Ambiguity test
-    @test select_platform(platforms, P("aarch64", "linux")) == "linux3"
-    @test select_platform(platforms, P("aarch64", "linux"; libgfortran_version=v"3")) == "linux3"
-    # This one may be surprising, but we still match `linux3`, and since linux3 is shorter, we choose it.
-    @test select_platform(platforms, P("aarch64", "linux"; libgfortran_version=v"3", libstdcxx_version=v"3.4.18")) === "linux3"
+    @test select_platform(platforms, P("aarch64", "linux")) == "linux5"
+    @test select_platform(platforms, P("aarch64", "linux"; libgfortran_version=v"3")) == "linux5"
     @test select_platform(platforms, P("aarch64", "linux"; libgfortran_version=v"4")) === nothing
 
     @test select_platform(platforms, P("x86_64", "macos")) == "mac4"
@@ -342,14 +339,6 @@ end
 
     # Sorry, Alex. ;)
     @test select_platform(platforms, P("x86_64", "freebsd")) === nothing
-
-    # The new "prefer shortest matching" algorithm is meant to be used to resolve ambiguities such as the following:
-    platforms = Dict(
-        # Typical binning test
-        P("x86_64", "linux") => "good",
-        P("x86_64", "linux"; sanitize="memory") => "bad",
-    )
-    @test select_platform(platforms, P("x86_64", "linux")) == "good"
 end
 
 @testset "Custom comparators" begin


### PR DESCRIPTION
- [x] [Revert "Resolve artifact ambiguities using shortest match"](https://github.com/JuliaLang/julia/pull/49500/commits/6f2f44e602a3b9641a1538605b5e0f7432e0f4cd) 

Fixes (on release-1.9) https://github.com/JuliaLang/julia/issues/49491

cc @giordano, @staticfloat 