### PR TITLE
Nospecialize close(c::Channel, excp::Exception) on excp.

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -183,7 +183,8 @@ Close a channel. An exception (optionally given by `excp`), is thrown by:
 * [`put!`](@ref) on a closed channel.
 * [`take!`](@ref) and [`fetch`](@ref) on an empty, closed channel.
 """
-function close(c::Channel, @nospecialize(excp::Exception=closed_exception()))
+close(c::Channel) = close(c, closed_exception()) # nospecialize on default arg seems to confuse makedocs
+function close(c::Channel, @nospecialize(excp::Exception))
     lock(c)
     try
         c.excp = excp

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -183,7 +183,7 @@ Close a channel. An exception (optionally given by `excp`), is thrown by:
 * [`put!`](@ref) on a closed channel.
 * [`take!`](@ref) and [`fetch`](@ref) on an empty, closed channel.
 """
-function close(c::Channel, excp::Exception=closed_exception())
+function close(c::Channel, @nospecialize(excp::Exception=closed_exception()))
     lock(c)
     try
         c.excp = excp


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/49507.

~Avoids dynamic dispatch when closing a Channel with an Exception, and~ should avoid a call into the runtime for julia compilation when attempting to report an exception.