### PR TITLE
color compilation with red in tracy during recompilation

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -197,7 +197,7 @@ static jl_callptr_t _jl_compile_codeinst(
 #ifdef USE_TRACY
     if (is_recompile) {
         TracyCZoneCtx ctx = *(JL_TIMING_CURRENT_BLOCK->tracy_ctx);
-        TracyCZoneColor(ctx, 0xFF0000);
+        TracyCZoneColor(ctx, 0xFFA500);
     }
 #endif
     jl_callptr_t fptr = NULL;


### PR DESCRIPTION
This makes them kind of obvious and then you can click on them and see what methods ended up getting recompiled. In the screenshot below, we can see that code loading got recompiled.

<img width="813" alt="image" src="https://user-images.githubusercontent.com/1282691/234695250-e4052655-7491-455f-937f-f36d02b038d6.png">

The red bar to the right is code loading getting recompiled... Again! (this is all during loading of a single package)