### PR TITLE
Install `libTracyClient` when `WITH_TRACY` is enabled.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,9 @@ JL_PRIVATE_LIBS-$(USE_SYSTEM_CSL) += libwinpthread
 else
 JL_PRIVATE_LIBS-$(USE_SYSTEM_CSL) += libpthread
 endif
+ifeq ($(WITH_TRACY),1)
+JL_PRIVATE_LIBS-0 += libTracyClient
+endif
 
 
 ifeq ($(OS),Darwin)


### PR DESCRIPTION
Without this, `make install` does not bundle `libTracyClient`, which is important when trying to redistribute a build of Julia that is built with Tracy support.