### PR TITLE
Add conditional timing events

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -784,7 +784,7 @@ JL_DLLEXPORT jl_value_t *jl_fl_parse(const char *text, size_t text_len,
                                      size_t offset, jl_value_t *options)
 {
     JL_TIMING(PARSING, PARSING);
-    jl_timing_show_filename(jl_string_data(filename), JL_TIMING_CURRENT_BLOCK);
+    jl_timing_show_filename(jl_string_data(filename), JL_TIMING_BLOCK(PARSING, PARSING));
     if (offset > text_len) {
         jl_value_t *textstr = jl_pchar_to_string(text, text_len);
         JL_GC_PUSH1(&textstr);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -8436,7 +8436,7 @@ jl_llvm_functions_t jl_emit_code(
         jl_codegen_params_t &params)
 {
     JL_TIMING(CODEGEN, CODEGEN_LLVM);
-    jl_timing_show_func_sig((jl_value_t *)li->specTypes, JL_TIMING_CURRENT_BLOCK);
+    jl_timing_show_func_sig((jl_value_t *)li->specTypes, JL_TIMING_BLOCK(CODEGEN, CODEGEN_LLVM));
     // caller must hold codegen_lock
     jl_llvm_functions_t decls = {};
     assert((params.params == &jl_default_cgparams /* fast path */ || !params.cache ||
@@ -8479,7 +8479,7 @@ jl_llvm_functions_t jl_emit_codeinst(
         jl_codegen_params_t &params)
 {
     JL_TIMING(CODEGEN, CODEGEN_Codeinst);
-    jl_timing_show_method_instance(codeinst->def, JL_TIMING_CURRENT_BLOCK);
+    jl_timing_show_method_instance(codeinst->def, JL_TIMING_BLOCK(CODEGEN, CODEGEN_Codeinst));
     JL_GC_PUSH1(&src);
     if (!src) {
         src = (jl_code_info_t*)jl_atomic_load_relaxed(&codeinst->inferred);

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -279,7 +279,7 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
     is_atpath = 0;
 
     JL_TIMING(DL_OPEN, DL_OPEN);
-    jl_timing_printf(JL_TIMING_CURRENT_BLOCK, gnu_basename(modname));
+    jl_timing_printf(JL_TIMING_BLOCK(DL_OPEN, DL_OPEN), gnu_basename(modname));
 
     // Detect if our `modname` is something like `@rpath/libfoo.dylib`
 #ifdef _OS_DARWIN_

--- a/src/gc.c
+++ b/src/gc.c
@@ -313,7 +313,7 @@ void jl_gc_wait_for_the_world(jl_ptls_t* gc_all_tls_states, int gc_n_threads)
 {
     JL_TIMING(GC, GC_Stop);
 #ifdef USE_TRACY
-    TracyCZoneCtx ctx = *(JL_TIMING_CURRENT_BLOCK->tracy_ctx);
+    TracyCZoneCtx ctx = *(JL_TIMING_BLOCK(GC, GC_Stop)->tracy_ctx);
     TracyCZoneColor(ctx, 0x696969);
 #endif
     assert(gc_n_threads);
@@ -3205,14 +3205,14 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
     JL_PROBE_GC_SWEEP_BEGIN(sweep_full);
     {
         JL_TIMING(GC, GC_Sweep);
+        JL_COND_TIMING(sweep_full, GC, GC_FullSweep);
+        JL_COND_TIMING(!sweep_full, GC, GC_IncrementalSweep);
 #ifdef USE_TRACY
         if (sweep_full) {
-            TracyCZoneCtx ctx = *(JL_TIMING_CURRENT_BLOCK->tracy_ctx);
+            TracyCZoneCtx ctx = *(JL_TIMING_BLOCK(GC, GC_Sweep)->tracy_ctx);
             TracyCZoneColor(ctx, 0xFFA500);
         }
 #endif
-        JL_COND_TIMING(sweep_full, GC, GC_FullSweep);
-        JL_COND_TIMING(!sweep_full, GC, GC_IncrementalSweep);
         sweep_weak_refs();
         sweep_stack_pools();
         gc_sweep_foreign_objs();

--- a/src/gc.c
+++ b/src/gc.c
@@ -3211,6 +3211,8 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
             TracyCZoneColor(ctx, 0xFFA500);
         }
 #endif
+        JL_COND_TIMING(sweep_full, GC, GC_FullSweep);
+        JL_COND_TIMING(!sweep_full, GC, GC_IncrementalSweep);
         sweep_weak_refs();
         sweep_stack_pools();
         gc_sweep_foreign_objs();

--- a/src/gf.c
+++ b/src/gf.c
@@ -368,7 +368,7 @@ jl_code_info_t *jl_type_infer(jl_method_instance_t *mi, size_t world, int force)
     fargs[1] = (jl_value_t*)mi;
     fargs[2] = jl_box_ulong(world);
 
-    jl_timing_show_method_instance(mi, JL_TIMING_CURRENT_BLOCK);
+    jl_timing_show_method_instance(mi, JL_TIMING_BLOCK(INFERENCE, INFERENCE));
 #ifdef TRACE_INFERENCE
     if (mi->specTypes != (jl_value_t*)jl_emptytuple_type) {
         jl_printf(JL_STDERR,"inference on ");
@@ -1986,7 +1986,7 @@ JL_DLLEXPORT void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method
     JL_TIMING(ADD_METHOD, ADD_METHOD);
     assert(jl_is_method(method));
     assert(jl_is_mtable(mt));
-    jl_timing_show_method(method, JL_TIMING_CURRENT_BLOCK);
+    jl_timing_show_method(method, JL_TIMING_BLOCK(ADD_METHOD, ADD_METHOD));
     jl_value_t *type = method->sig;
     jl_value_t *oldvalue = NULL;
     jl_array_t *oldmi = NULL;

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -252,7 +252,7 @@ static jl_callptr_t _jl_compile_codeinst(
     for (auto &def : emitted) {
         jl_code_instance_t *this_code = def.first;
         if (i < jl_timing_print_limit)
-            jl_timing_show_func_sig(this_code->def->specTypes, JL_TIMING_CURRENT_BLOCK);
+            jl_timing_show_func_sig(this_code->def->specTypes, JL_TIMING_BLOCK(CODEINST_COMPILE, CODEINST_COMPILE));
 
         jl_llvm_functions_t decls = std::get<1>(def.second);
         jl_callptr_t addr;
@@ -298,7 +298,7 @@ static jl_callptr_t _jl_compile_codeinst(
         i++;
     }
     if (i > jl_timing_print_limit)
-        jl_timing_printf(JL_TIMING_CURRENT_BLOCK, "... <%d methods truncated>", i - 10);
+        jl_timing_printf(JL_TIMING_BLOCK(CODEINST_COMPILE, CODEINST_COMPILE), "... <%d methods truncated>", i - 10);
 
     uint64_t end_time = 0;
     if (timed)

--- a/src/method.c
+++ b/src/method.c
@@ -568,7 +568,7 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo, siz
     JL_TIMING(STAGED_FUNCTION, STAGED_FUNCTION);
     jl_value_t *tt = linfo->specTypes;
     jl_method_t *def = linfo->def.method;
-    jl_timing_show_method_instance(linfo, JL_TIMING_CURRENT_BLOCK);
+    jl_timing_show_method_instance(linfo, JL_TIMING_BLOCK(STAGED_FUNCTION, STAGED_FUNCTION));
     jl_value_t *generator = def->generator;
     assert(generator != NULL);
     assert(jl_is_method(def));

--- a/src/timing.h
+++ b/src/timing.h
@@ -312,6 +312,7 @@ STATIC_INLINE void _jl_timing_block_ctor(jl_timing_block_t *block, int enabled, 
     if (jl_timing_enabled(owner)) {
         _ITTAPI_CTOR(block, event);
         _ITTAPI_START(block);
+        block->enabled |= 0b10;
     }
     uint64_t t = cycleclock(); (void)t;
     _COUNTS_CTOR(&block->counts_ctx);
@@ -330,7 +331,7 @@ STATIC_INLINE void _jl_timing_block_destroy(jl_timing_block_t *block) JL_NOTSAFE
     _TRACY_DESTROY(block->tracy_ctx);
     if (!block->enabled) return;
     uint64_t t = cycleclock(); (void)t;
-    if (jl_timing_enabled(block->owner)) {
+    if (block->enabled & 0b10) {
         _ITTAPI_STOP(block);
     }
     _COUNTS_STOP(&block->counts_ctx, t);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -65,7 +65,7 @@ static jl_function_t *jl_module_get_initializer(jl_module_t *m JL_PROPAGATES_ROO
 void jl_module_run_initializer(jl_module_t *m)
 {
     JL_TIMING(INIT_MODULE, INIT_MODULE);
-    jl_timing_show_module(m, JL_TIMING_CURRENT_BLOCK);
+    jl_timing_show_module(m, JL_TIMING_BLOCK(INIT_MODULE, INIT_MODULE));
     jl_function_t *f = jl_module_get_initializer(m);
     if (f == NULL)
         return;


### PR DESCRIPTION
This allows us to mark certain events as happening based on a runtime condition, without needing to split off code into a separate scope. Proof of concept is done by marking GC incremental and full sweeps as separate events.

![image](https://user-images.githubusercontent.com/34727397/234786220-c0b11751-2da0-4e3d-889a-be2a765be1d5.png)
![image](https://user-images.githubusercontent.com/34727397/234786296-a883a778-d335-48d8-be89-83be300b9c99.png)
