### PR TITLE
add a root profile zone for julia initialization

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -833,6 +833,7 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
 
 static NOINLINE void _finish_julia_init(JL_IMAGE_SEARCH rel, jl_ptls_t ptls, jl_task_t *ct)
 {
+    JL_TIMING(JULIA_INIT, JULIA_INIT);
     jl_resolve_sysimg_location(rel);
     // loads sysimg if available, and conditionally sets jl_options.cpu_target
     if (jl_options.image_file)

--- a/src/timing.h
+++ b/src/timing.h
@@ -144,6 +144,7 @@ void jl_timing_printf(jl_timing_block_t *cur_block, const char *format, ...);
         X(LOCK_SPIN)             \
         X(STACKWALK)             \
         X(DL_OPEN)               \
+        X(JULIA_INIT)            \
 
 
 #define JL_TIMING_EVENTS \


### PR DESCRIPTION
It's nice to be able to see when the sysimage stuff is done and where package loading stars.