### PR TITLE
fix `compilesig_invokes=false` inlining option

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -826,7 +826,7 @@ function compileable_specialization(mi::MethodInstance, effects::Effects,
         # If this caller does not want us to optimize calls to use their
         # declared compilesig, then it is also likely they would handle sparams
         # incorrectly if there were any unknown typevars, so we conservatively return nothing
-        if _any(t->isa(t, TypeVar), match.sparams)
+        if any(@nospecialize(t)->isa(t, TypeVar), mi.sparam_vals)
             return nothing
         end
     end


### PR DESCRIPTION
Follows up #49404.
Tests are added.