### PR TITLE
Fix starting range in REPLCompletions

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -1021,7 +1021,7 @@ function completions(string::String, pos::Int, context_module::Module=Main, shif
         ok, ret = bslash_completions(string, pos)
         ok && return ret
         startpos = first(varrange) + 4
-        dotpos = something(findprev(isequal('.'), string, startpos), 0)
+        dotpos = something(findprev(isequal('.'), string, first(varrange)-1), 0)
         return complete_identifiers!(Completion[], ffunc, context_module, string,
             string[startpos:pos], pos, dotpos, startpos)
     # otherwise...

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1819,7 +1819,7 @@ let s = "var\"complicated "
     @test c == Any["var\"complicated symbol with spaces\""]
 end
 
-let s = "WeirdNames().var\"oh "
+for s in ("WeirdNames().var\"oh ", "WeirdNames().var\"")
     c, r = test_complete_foo(s)
     @test c == Any["var\"oh no!\"", "var\"oh yes!\""]
 end


### PR DESCRIPTION
The new completion for `var"` fields (#49294) failed when the `var"` was at the end of the completion query, e.g. in `WeirdNames().var"`. This is because we have the following behavior:

```
julia> findprev(==('x'), "x", 1)
1

julia> findprev(==('x'), "x", 2)
```

REPLCompletions attempt to find `.` starting after the `var"`, which in this case is at the end of the string. Of course, the index was probably off by one anyway, because
we didn't want to match `var".`, but nevertheless, I find this behavior surprising (ref also [1]).
For now, fix this by starting the search before the `var"`, but we may want to revisit the `findprev` behavior also.

[1] https://github.com/JuliaLang/julia/pull/35742/files#r420945975