### PR TITLE
Export offsets necessary for external codegen

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -759,6 +759,10 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
 
     jl_init_intrinsic_properties();
 
+    // Important offset for external codegen.
+    jl_task_gcstack_offset = offsetof(jl_task_t, gcstack);
+    jl_task_ptls_offset = offsetof(jl_task_t, ptls);
+
     jl_prep_sanitizers();
     void *stack_lo, *stack_hi;
     jl_init_stack_limits(1, &stack_lo, &stack_hi);

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -132,5 +132,7 @@
     XX(jl_n_threadpools, int) \
     XX(jl_n_threads, _Atomic(int)) \
     XX(jl_options, jl_options_t) \
+    XX(jl_task_gcstack_offset, int) \
+    XX(jl_task_ptls_offset, int) \
 
 // end of file

--- a/src/julia.h
+++ b/src/julia.h
@@ -1984,6 +1984,9 @@ JL_DLLEXPORT void JL_NORETURN jl_no_exc_handler(jl_value_t *e, jl_task_t *ct);
 JL_DLLEXPORT JL_CONST_FUNC jl_gcframe_t **(jl_get_pgcstack)(void) JL_GLOBALLY_ROOTED JL_NOTSAFEPOINT;
 #define jl_current_task (container_of(jl_get_pgcstack(), jl_task_t, gcstack))
 
+extern JL_DLLIMPORT int jl_task_gcstack_offset;
+extern JL_DLLIMPORT int jl_task_ptls_offset;
+
 #include "julia_locks.h"   // requires jl_task_t definition
 
 JL_DLLEXPORT void jl_enter_handler(jl_handler_t *eh);


### PR DESCRIPTION
Enzyme performs external codegen that needs to access current_task and
the ptls. We have three options:

1. Hard-code it per Julia version/architecture
2. "Introspect" it by doing a `code_llvm` to get the offset
3. Expose a variable that Enzyme can read to get a stable answer.

We used to do `1.` in the past which lead to fun crashes everytime it changed on the
Julia side.

We currently do `2.`, which leads to bad initialization times.

This is option `3.`
