### PR TITLE
Preserve LLVM function attributes during address space removal pass.

### DIFF
--- a/src/llvm-remove-addrspaces.cpp
+++ b/src/llvm-remove-addrspaces.cpp
@@ -323,7 +323,7 @@ bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
 
         Function *NF = Function::Create(
                 NFTy, F->getLinkage(), F->getAddressSpace(), Name, &M);
-        // no need to copy attributes here, that's done by CloneFunctionInto
+        NF->copyAttributesFrom(F);
         VMap[F] = NF;
     }
 
@@ -385,8 +385,7 @@ bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
                 &TypeRemapper,
                 &Materializer);
 
-        // CloneFunctionInto unconditionally copies the attributes from F to NF,
-        // without considering e.g. the byval attribute type.
+        // Update function attributes that contain types
         AttributeList Attrs = F->getAttributes();
         LLVMContext &C = F->getContext();
         for (unsigned i = 0; i < Attrs.getNumAttrSets(); ++i) {

--- a/test/llvmpasses/remove-addrspaces.ll
+++ b/test/llvmpasses/remove-addrspaces.ll
@@ -47,7 +47,7 @@ top:
 %list = type { i64, %list* }
 
 ; COM: There's nothing to remove in this function; but remove-addrspaces shouldn't crash.
-define i64 @sum.linked.list() #0 {
+define i64 @sum.linked.list() {
 ; CHECK-LABEL: @sum.linked.list
 top:
   %a = alloca %list
@@ -109,3 +109,9 @@ define void @byval_type([1 x {} addrspace(10)*] addrspace(11)* byval([1 x {} add
 ; CHECK: define void @byval_type([1 x {}*]* byval([1 x {}*]) %0)
   ret void
 }
+
+
+; COM: check that other function attributes are preserved
+declare void @convergent_function() #0
+attributes #0 = { convergent }
+; CHECK: attributes #0 = { convergent }


### PR DESCRIPTION
Bug introduced in https://github.com/JuliaLang/julia/pull/42395; or maybe `CloneFunctionInto` has change behavior since? In any case, this addresses https://github.com/JuliaGPU/GPUCompiler.jl/issues/437. 