### PR TITLE
Revise `jl_timing` prints for `dlopen`

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -279,7 +279,7 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
     is_atpath = 0;
 
     JL_TIMING(DL_OPEN, DL_OPEN);
-    jl_timing_printf(JL_TIMING_CURRENT_BLOCK, gnu_basename(modname));
+    jl_timing_puts(JL_TIMING_CURRENT_BLOCK, modname);
 
     // Detect if our `modname` is something like `@rpath/libfoo.dylib`
 #ifdef _OS_DARWIN_
@@ -336,8 +336,10 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
                     if (i == 0) { // LoadLibrary already tested the extensions, we just need to check the `stat` result
 #endif
                         handle = jl_dlopen(path, flags);
-                        if (handle)
+                        if (handle) {
+                            jl_timing_puts(JL_TIMING_CURRENT_BLOCK, jl_pathname_for_handle(handle));
                             return handle;
+                        }
 #ifdef _OS_WINDOWS_
                         err = GetLastError();
                     }
@@ -356,8 +358,10 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
         path[0] = '\0';
         snprintf(path, PATHBUF, "%s%s", modname, ext);
         handle = jl_dlopen(path, flags);
-        if (handle)
+        if (handle) {
+            jl_timing_puts(JL_TIMING_CURRENT_BLOCK, jl_pathname_for_handle(handle));
             return handle;
+        }
 #ifdef _OS_WINDOWS_
         err = GetLastError();
         break; // LoadLibrary already tested the rest

--- a/src/timing.c
+++ b/src/timing.c
@@ -234,6 +234,13 @@ JL_DLLEXPORT void jl_timing_printf(jl_timing_block_t *cur_block, const char *for
     va_end(args);
 }
 
+JL_DLLEXPORT void jl_timing_puts(jl_timing_block_t *cur_block, const char *str)
+{
+#ifdef USE_TRACY
+    TracyCZoneText(*(cur_block->tracy_ctx), str, strlen(str));
+#endif
+}
+
 JL_DLLEXPORT int jl_timing_set_enable(const char *subsystem, uint8_t enabled)
 {
     for (int i = 0; i < JL_TIMING_LAST; i++) {

--- a/src/timing.h
+++ b/src/timing.h
@@ -8,6 +8,11 @@
 static inline const char *gnu_basename(const char *path)
 {
     const char *base = strrchr(path, '/');
+#ifdef _WIN32
+    const char *backslash = strrchr(path, '\\');
+    if (backslash > base)
+        base = backslash;
+#endif
     return base ? base+1 : path;
 }
 
@@ -65,7 +70,8 @@ extern uint32_t jl_timing_print_limit;
 #define jl_timing_show_method_instance(mi, b)
 #define jl_timing_show_method(mi, b)
 #define jl_timing_show_func_sig(tt, b)
-#define jl_timing_printf(s, f, ...)
+#define jl_timing_printf(b, f, ...)
+#define jl_timing_puts(b, s)
 #define jl_timing_block_enter_task(ct, ptls, blk)
 #define jl_timing_block_exit_task(ct, ptls) ((jl_timing_block_t *)NULL)
 #define jl_pop_timing_block(blk)
@@ -106,6 +112,7 @@ void jl_timing_show_method_instance(jl_method_instance_t *mi, jl_timing_block_t 
 void jl_timing_show_method(jl_method_t *method, jl_timing_block_t *cur_block);
 void jl_timing_show_func_sig(jl_value_t *v, jl_timing_block_t *cur_block);
 void jl_timing_printf(jl_timing_block_t *cur_block, const char *format, ...);
+void jl_timing_puts(jl_timing_block_t *cur_block, const char *str);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This change updates the profiling metadata for `DL_OPEN` to include both the full requested library name and the path to the resolved handle:

![image](https://user-images.githubusercontent.com/84105208/235266078-f6bbf5f3-ee72-4252-8426-e4cf720b304c.png)

Also fixes a bug in `gnu_basename` where Windows filepaths were not being scanned for `\` correctly.