### PR TITLE
Fix REPL.fuzzyscore() function using Levenshtein distance and converting to a range from 0 to 1

### DIFF
--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -629,13 +629,7 @@ avgdistance(xs) =
     (xs[end] - xs[1] - length(xs)+1)/length(xs)
 
 function fuzzyscore(needle, haystack)
-    score = 0.
-    is, acro = bestmatch(needle, haystack)
-    score += (acro ? 2 : 1)*length(is) # Matched characters
-    score -= 2(length(needle)-length(is)) # Missing characters
-    !acro && (score -= avgdistance(is)/10) # Contiguous
-    !isempty(is) && (score -= sum(is)/length(is)/100) # Closer to beginning
-    return score
+    return 1 - levenshtein(needle, haystack) / max(length(needle), length(haystack))
 end
 
 function fuzzysort(search::String, candidates::Vector{String})

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -624,10 +624,6 @@ bestmatch(needle, haystack) =
     longer(matchinds(needle, haystack, acronym = true),
            matchinds(needle, haystack))
 
-avgdistance(xs) =
-    isempty(xs) ? 0 :
-    (xs[end] - xs[1] - length(xs)+1)/length(xs)
-
 function fuzzyscore(needle, haystack)
     return 1 - levenshtein(needle, haystack) / max(length(needle), length(haystack))
 end

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -684,7 +684,7 @@ function printmatches(io::IO, word, matches; cols::Int = _displaysize(io)[2])
     total = 0
     for match in matches
         total + length(match) + 1 > cols && break
-        fuzzyscore(word, match) < 0 && break
+        fuzzyscore(word, match) < 0.6 && break
         print(io, " ")
         printmatch(io, word, match)
         total += length(match) + 1

--- a/stdlib/REPL/test/docview.jl
+++ b/stdlib/REPL/test/docview.jl
@@ -54,7 +54,7 @@ end
     # https://github.com/JunoLab/FuzzyCompletions.jl/issues/7
     # shouldn't throw when there is a space in a middle of query
     @test (REPL.matchinds("a ", "a file.txt"); true)
-    
+
     @test REPL.fuzzyscore("abc", "xyz") == 0
     @test REPL.fuzzyscore("abc", "abc") == 1
     @test REPL.fuzzyscore("abc", "dcab") == 0.25

--- a/stdlib/REPL/test/docview.jl
+++ b/stdlib/REPL/test/docview.jl
@@ -46,7 +46,7 @@ end
     checks = ["var", "raw", "r"]
     symbols = "@" .* checks .* "_str"
     results = checks .* "\"\""
-    for (i,r) in zip(symbols,results)
+    for (i, r) in zip(symbols, results)
         @test r ∈ REPL.doc_completions(i)
     end
 end
@@ -54,6 +54,11 @@ end
     # https://github.com/JunoLab/FuzzyCompletions.jl/issues/7
     # shouldn't throw when there is a space in a middle of query
     @test (REPL.matchinds("a ", "a file.txt"); true)
+    
+    @test REPL.fuzzyscore("abc", "xyz") == 0
+    @test REPL.fuzzyscore("abc", "abc") == 1
+    @test REPL.fuzzyscore("abc", "dcab") == 0.25
+    @test REPL.fuzzyscore("abc", "dab") ≈ 1 / 3
 end
 
 @testset "Unicode doc lookup (#41589)" begin


### PR DESCRIPTION
Closes #49466

 - Implements `fuzzyscore()` using `levenshtein()`, and calculates the score by limiting it to a range from 0 to 1.
 - Works similar to `stringsimilarity()` as described [here](https://github.com/JuliaLang/julia/issues/49466#issuecomment-1525785061).
 
Here's a few examples:

    julia> REPL.fuzzyscore("abc", "xyz")
    0.0

    julia> REPL.fuzzyscore("abc", "abc")
    1.0

    julia> REPL.fuzzyscore("bupercalifragilisticexpialidocious", "supercalifragilisticexpialidocious")
    0.9705882352941176

    julia> REPL.fuzzyscore("IJilia", "MotionCaptureJointCalibration")
    0.1724137931034483