### PR TITLE
Base: twiceprecision: optimize mul12

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -46,6 +46,11 @@ end
 
 # non-type specific math functions
 
+function two_mul(x::T, y::T) where {T<:Number}
+    xy = x*y
+    xy, fma(x, y, -xy)
+end
+
 @assume_effects :consistent @inline function two_mul(x::Float64, y::Float64)
     if Core.Intrinsics.have_fma(Float64)
         xy = x*y

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -112,8 +112,8 @@ julia> Float64(hi) + Float64(lo)
 ```
 """
 function mul12(x::T, y::T) where {T<:AbstractFloat}
-    h = x * y
-    ifelse(iszero(h) | !isfinite(h), (h, h), canonicalize2(h, fma(x, y, -h)))
+    (h, l) = Base.Math.two_mul(x, y)
+    ifelse(!isfinite(h), (h, h), (h, l))
 end
 mul12(x::T, y::T) where {T} = (p = x * y; (p, zero(p)))
 mul12(x, y) = mul12(promote(x, y)...)


### PR DESCRIPTION
It is well known and obvious that the algorithm behind `Base.mul12` (sometimes known as "Fast2Mult") doesn't require a "Fast2Sum" (known in the Julia codebase as `Base.canonicalize2`) call at the end, so remove it. This follows from the fact that IEEE-754 floating-point multiplication is required to be well-rounded, so Fast2Sum can't change the result.

Reference, for example, the beginning of https://doi.org/10.1145/3121432 by Joldes, Muller, Popescu.

Furthermore, `Base.Math.two_mul` already exists, so use it as a kernel function. This required adding a general fallback method for `Base.Math.two_mul`, required, for example, for `BigFloat`.

Also removed the `iszero` check that is now obviously not necessary.