### PR TITLE
Implement jl_cpu_pause on PPC64

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1534,6 +1534,12 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
             ctx.builder.CreateCall(pauseinst);
             JL_GC_POP();
             return ghostValue(ctx, jl_nothing_type);
+        } else if (ctx.emission_context.TargetTriple.isPPC64()) {
+            auto hintinst = InlineAsm::get(FunctionType::get(getVoidTy(ctx.builder.getContext()), false), "or 27,27,27",
+                                                "~{memory}", true);
+            ctx.builder.CreateCall(hintinst);
+            JL_GC_POP();
+            return ghostValue(ctx, jl_nothing_type);
         } else if (ctx.emission_context.TargetTriple.isAArch64()
                     || (ctx.emission_context.TargetTriple.isARM()
                         && ctx.emission_context.TargetTriple.getSubArch() != Triple::SubArchType::NoSubArch

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -300,6 +300,10 @@ JL_DLLEXPORT void *jl_get_ptls_states(void);
 #  define jl_cpu_pause() __asm__ volatile ("wfe" ::: "memory")
 #  define jl_cpu_wake() __asm__ volatile ("sev" ::: "memory")
 #  define JL_CPU_WAKE_NOOP 0
+#elif defined(_CPU_PPC64_)
+#  define jl_cpu_pause() __asm__ volatile ("or 27,27,27" ::: "memory")
+#  define jl_cpu_wake() ((void)0)
+#  define JL_CPU_WAKE_NOOP 1
 #else
 #  define jl_cpu_pause() ((void)0)
 #  define jl_cpu_wake() ((void)0)


### PR DESCRIPTION
I took `or 27,27,27` from https://stackoverflow.com/questions/5425506/equivalent-of-x86-pause-instruction-for-ppc/7588941#7588941

The linux kernel has a more complicated sequence https://lwn.net/Articles/722786/