### PR TITLE
don't add cross-compile prefix for CC twice

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -458,7 +458,7 @@ endif
 
 # Compiler specific stuff
 
-ifeq (,$(findstring $(CROSS_COMPILE),$(CC)))
+ifeq (default,$(origin CC))
 CC := $(CROSS_COMPILE)$(CC) # attempt to add cross-compiler prefix, if the user
                             # is not overriding the default, to form target-triple-cc (which
                             # may not exist), and use that to decide what compiler the user

--- a/Make.inc
+++ b/Make.inc
@@ -458,10 +458,12 @@ endif
 
 # Compiler specific stuff
 
+ifeq (,$(findstring $(CROSS_COMPILE),$(CC)))
 CC := $(CROSS_COMPILE)$(CC) # attempt to add cross-compiler prefix, if the user
                             # is not overriding the default, to form target-triple-cc (which
                             # may not exist), and use that to decide what compiler the user
                             # is using for the target build (or default to gcc)
+endif
 CC_VERSION_STRING = $(shell $(CC) --version 2>/dev/null)
 ifneq (,$(findstring clang,$(CC_VERSION_STRING)))
 USECLANG := 1


### PR DESCRIPTION
`make` re-exports changed environment variables to subprocesses, this causes the make subprocess for the src or deps folders to have this applied a second time.

This was observed while trying to build libjulia for Yggdrasil (https://github.com/JuliaPackaging/Yggdrasil/pull/6543) which has `CC=cc` in the environment, the main make process then changes this to `CC=aarch64-apple-darwin20-clang` (cc is clang in this case). But the subprocess `make -C src` will then try to use
```
CC=aarch64-apple-darwin20-aarch64-apple-darwin20-clang
```
which fails and then falls back to `$(CROSS_COMPILE)gcc` which is not what we want to use for this platform.

This assignment was added recently by @vtjnash in #49081
cc: @giordano @fingolfin 
