### PR TITLE
Various precompile fixes

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -71,7 +71,8 @@ print("")
 printstyled("a", "b")
 display([1])
 display([1 2; 3 4])
-@time 1+1
+foo(x) = 1
+@time foo(1)
 ; pwd
 $CTRL_C
 $CTRL_R$CTRL_C

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -72,7 +72,7 @@ printstyled("a", "b")
 display([1])
 display([1 2; 3 4])
 foo(x) = 1
-@time foo(1)
+@time @eval foo(1)
 ; pwd
 $CTRL_C
 $CTRL_R$CTRL_C

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -438,7 +438,7 @@ generate_precompile_statements() = try # Make sure `ansi_enablecursor` is printe
             if precompile(ps...)
                 n_succeeded += 1
             else
-                @debug "precompile failed for $(ps)"
+                @warn "Failed to precompile expression" form=statement _module=nothing _file=nothing _line=0
             end
             failed = length(statements) - n_succeeded
             yield() # Make clock spinning

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -45,6 +45,7 @@ precompile(Tuple{typeof(push!), Vector{Function}, Function})
 # miscellaneous
 precompile(Tuple{typeof(Base.require), Base.PkgId})
 precompile(Tuple{typeof(Base.recursive_prefs_merge), Base.Dict{String, Any}})
+precompile(Tuple{typeof(Base.recursive_prefs_merge), Base.Dict{String, Any}, Base.Dict{String, Any}, Vararg{Base.Dict{String, Any}}})
 precompile(Tuple{typeof(Base.hashindex), Tuple{Base.PkgId, Nothing}, Int64})
 precompile(Tuple{typeof(Base.hashindex), Tuple{Base.PkgId, String}, Int64})
 precompile(Tuple{typeof(isassigned), Core.SimpleVector, Int})

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -182,6 +182,14 @@ if Libdl !== nothing
     """
 end
 
+InteractiveUtils = get(Base.loaded_modules,
+          Base.PkgId(Base.UUID("b77e0a4c-d291-57a0-90e8-8db25a27a240"), "InteractiveUtils"),
+          nothing)
+if InteractiveUtils !== nothing
+    repl_script *= """
+    @time_imports using Random
+    """
+end
 
 const JULIA_PROMPT = "julia> "
 const PKG_PROMPT = "pkg> "

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -426,8 +426,11 @@ generate_precompile_statements() = try # Make sure `ansi_enablecursor` is printe
             ps.head = :tuple
             # println(ps)
             ps = Core.eval(PrecompileStagingArea, ps)
-            precompile(ps...)
-            n_succeeded += 1
+            if precompile(ps...)
+                n_succeeded += 1
+            else
+                @debug "precompile failed for $(ps)"
+            end
             failed = length(statements) - n_succeeded
             yield() # Make clock spinning
             print_state("step3" => string("R$n_succeeded", failed > 0 ? " ($failed failed)" : ""))


### PR DESCRIPTION
- Precompile `@time` with a compiling workload, which without it seemed to cause `@time` to miss compilation in some cases the first time it's used (hard to repro)
- Fix reporting of broken precompile directives in generate_precompile
- Add the varargs version of `Base.recursive_prefs_merge` given it's on the list but the varargs version will be hit if you have local preferences
- Precompile `@time_imports` just in case
