### PR TITLE
ml-matches: skip intersection by world-bounds

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1465,6 +1465,8 @@ struct typemap_intersection_env {
     jl_value_t *const va; // the tparam0 for the vararg in type, if applicable (or NULL)
     size_t search_slurp;
     // output values
+    size_t min_valid;
+    size_t max_valid;
     jl_value_t *ti; // intersection type
     jl_svec_t *env; // intersection env (initialize to null to perform intersection without an environment)
     int issubty;    // if `a <: b` is true in `intersect(a,b)`


### PR DESCRIPTION
Should help speed up package loading some, by avoid complicated self-intersections, which would then be filtered out anyways from the returned results. It is not a frequent pattern, but it was observed in occasional cases, and is such an easy, obvious improvement.