### PR TITLE
fix some issues in Artifacts code reported by JET

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -38,7 +38,7 @@ Example:
 struct Platform <: AbstractPlatform
     tags::Dict{String,String}
     # The "compare strategy" allows selective overriding on how a tag is compared
-    compare_strategies::Dict{String,Function}
+    compare_strategies::IdDict{String,Function}
 
     # Passing `tags` as a `Dict` avoids the need to infer different NamedTuple specializations
     function Platform(arch::String, os::String, _tags::Dict{String};
@@ -1016,19 +1016,19 @@ function platforms_match(a::AbstractPlatform, b::AbstractPlatform)
 
         # Throw an error if `a` and `b` have both set non-default comparison strategies for `k`
         # and they're not the same strategy.
-        if a_comp != compare_default && b_comp != compare_default && a_comp != b_comp
+        if a_comp !== compare_default && b_comp !== compare_default && a_comp !== b_comp
             throw(ArgumentError("Cannot compare Platform objects with two different non-default comparison strategies for the same key \"$(k)\""))
         end
 
         # Select the custom comparator, if we have one.
         comparator = a_comp
-        if b_comp != compare_default
+        if b_comp !== compare_default
             comparator = b_comp
         end
 
         # Call the comparator, passing in which objects requested this comparison (one, the other, or both)
         # For some comparators this doesn't matter, but for non-symmetrical comparisons, it does.
-        if !(comparator(ak, bk, a_comp == comparator, b_comp == comparator)::Bool)
+        if !(comparator(ak, bk, a_comp === comparator, b_comp === comparator)::Bool)
             return false
         end
     end
@@ -1089,7 +1089,8 @@ function select_platform(download_info::Dict, platform::AbstractPlatform = HostP
         return triplet(a) > triplet(b)
     end)
 
-    return download_info[first(ps)]
+    # @invokelatest here to not get invalidated by new defs of `==(::Function, ::Function)`
+    return @invokelatest getindex(download_info, first(ps))
 end
 
 # precompiles to reduce latency (see https://github.com/JuliaLang/julia/pull/43990#issuecomment-1025692379)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -118,7 +118,8 @@ macro deprecate(old, new, export_old=true)
     end
 end
 
-function depwarn(msg, funcsym; force::Bool=false)
+depwarn(msg, funcsym; force::Bool=false) = (@invokelatest _depwarn(msg, funcsym; force))::Nothing
+function _depwarn(msg, funcsym; force::Bool=false)
     opts = JLOptions()
     if opts.depwarn == 2
         throw(ErrorException(msg))

--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -167,3 +167,9 @@ end
     @test length(Base.manifest_names) == n
     @test length(Base.preferences_names) == n
 end
+
+@testset "Platform equatlity" begin
+    armv7l_linux_1 = Platform("armv7l", "linux")
+    armv7l_linux_2 = Platform("armv7l", "linux")
+    @test armv7l_linux_1 == armv7l_linux_2
+end


### PR DESCRIPTION
This avoids invalidating

```
  precompile(Tuple{typeof(Artifacts.artifact_slash_lookup), String, Base.Dict{String, Any}, String, Base.BinaryPlatforms.Platform})
  precompile(Tuple{typeof(Artifacts._artifact_str), Module, String, Base.SubString{String}, String, Base.Dict{String, Any}, Base.SHA1, Base.BinaryPlatforms.Platform, Any})
```

when loading a JLL that uses platform augmentation after e.g. Symbolics.jl which defines a bunch of core methods (`==`, `hash`, etc) on new types that are `<: Function`.

In general, the Artifacts and BinaryPlatform modules feels quite "under typed". I wonder if it would be worth doing the TOML parsing in one single place and produce type stable outputs from that one place instead of passing around `Dict`s to so many functions.