### PR TITLE
Improve handling of LLVM function attributes

### DIFF
--- a/src/llvm-remove-addrspaces.cpp
+++ b/src/llvm-remove-addrspaces.cpp
@@ -323,7 +323,7 @@ bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
 
         Function *NF = Function::Create(
                 NFTy, F->getLinkage(), F->getAddressSpace(), Name, &M);
-        NF->copyAttributesFrom(F);
+        // no need to copy attributes here, that's done by CloneFunctionInto
         VMap[F] = NF;
     }
 
@@ -356,11 +356,9 @@ bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
 
     // Similarly, copy over and rewrite function bodies
     for (Function *F : Functions) {
-        if (F->isDeclaration())
-            continue;
-
         Function *NF = cast<Function>(VMap[F]);
         LLVM_DEBUG(dbgs() << "Processing function " << NF->getName() << "\n");
+        // we also need this to run for declarations, or attributes won't be copied
 
         Function::arg_iterator DestI = NF->arg_begin();
         for (Function::const_arg_iterator I = F->arg_begin(); I != F->arg_end();

--- a/src/llvm-remove-addrspaces.cpp
+++ b/src/llvm-remove-addrspaces.cpp
@@ -408,9 +408,6 @@ bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
         }
         NF->setAttributes(Attrs);
 
-        if (F->hasPersonalityFn())
-            NF->setPersonalityFn(MapValue(F->getPersonalityFn(), VMap));
-
         copyComdat(NF, F);
 
         RemoveNoopAddrSpaceCasts(NF);

--- a/test/llvmpasses/remove-addrspaces.ll
+++ b/test/llvmpasses/remove-addrspaces.ll
@@ -111,7 +111,7 @@ define void @byval_type([1 x {} addrspace(10)*] addrspace(11)* byval([1 x {} add
 }
 
 
-; COM: check that other function attributes are preserved
+; COM: check that function attributes are preserved on declarations too
 declare void @convergent_function() #0
 attributes #0 = { convergent }
 ; CHECK: attributes #0 = { convergent }


### PR DESCRIPTION
Improves https://github.com/JuliaLang/julia/pull/49551: Instead of copying attributes manually, just ensure we always call `CloneFunctionInto`, as it does useful work for declarations too (bailing out early, https://github.com/llvm/llvm-project/blob/33017e5a3fa2c3194522565cd0e106a931b072b3/llvm/lib/Transforms/Utils/CloneFunction.cpp#L144-L147). This includes mapping of the personality function, https://github.com/llvm/llvm-project/blob/33017e5a3fa2c3194522565cd0e106a931b072b3/llvm/lib/Transforms/Utils/CloneFunction.cpp#L111-L115, so we can get rid of that too.

x-ref https://github.com/JuliaLang/julia/pull/49551#discussion_r1180804288