### PR TITLE
Reduce unnecessary task stickiness

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -253,6 +253,7 @@ Stacktrace:
 """
 function bind(c::Channel, task::Task)
     T = Task(() -> close_chnl_on_taskdone(task, c))
+    T.sticky = false
     _wait2(task, T)
     return c
 end

--- a/base/task.jl
+++ b/base/task.jl
@@ -317,22 +317,22 @@ end
 # have `waiter` wait for `t`
 function _wait2(t::Task, waiter::Task)
     if !istaskdone(t)
+        # since _wait2 is similar to schedule, we should observe the sticky
+        # bit, even if we don't call `schedule` with early-return below
+        if waiter.sticky && Threads.threadid(waiter) == 0 && !GC.in_finalizer()
+            # Issue #41324
+            # t.sticky && tid == 0 is a task that needs to be co-scheduled with
+            # the parent task. If the parent (current_task) is not sticky we must
+            # set it to be sticky.
+            # XXX: Ideally we would be able to unset this
+            current_task().sticky = true
+            tid = Threads.threadid()
+            ccall(:jl_set_task_tid, Cint, (Any, Cint), waiter, tid-1)
+        end
         lock(t.donenotify)
         if !istaskdone(t)
             push!(t.donenotify.waitq, waiter)
             unlock(t.donenotify)
-            # since _wait2 is similar to schedule, we should observe the sticky
-            # bit, even if we aren't calling `schedule` due to this early-return
-            if waiter.sticky && Threads.threadid(waiter) == 0 && !GC.in_finalizer()
-                # Issue #41324
-                # t.sticky && tid == 0 is a task that needs to be co-scheduled with
-                # the parent task. If the parent (current_task) is not sticky we must
-                # set it to be sticky.
-                # XXX: Ideally we would be able to unset this
-                current_task().sticky = true
-                tid = Threads.threadid()
-                ccall(:jl_set_task_tid, Cint, (Any, Cint), waiter, tid-1)
-            end
             return nothing
         else
             unlock(t.donenotify)


### PR DESCRIPTION
Tasks are created sticky [by default](https://github.com/JuliaLang/julia/blob/master/src/task.c#L1102). Task stickiness [also](https://github.com/JuliaLang/julia/blob/master/base/task.jl#L781) [spreads](https://github.com/JuliaLang/julia/blob/master/base/condition.jl#L96), and tasks do not get "unstickied". Until that can be fixed, we need to avoid introducing any unnecessary stickiness.

This PR removes one case: `bind`ing a task to a `Channel` creates a task to close the channel which does not need to be sticky. It also fixes a potential race.
