### PR TITLE
Fix for #49489: Ensure length(ipiv)==n before calling LAPACK.getrs! to avoid segfaults

### DIFF
--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -1010,6 +1010,9 @@ for (gels, gesv, getrs, getri, elty) in
             if n != size(B, 1)
                 throw(DimensionMismatch("B has leading dimension $(size(B,1)), but needs $n"))
             end
+            if n != length(ipiv)
+                throw(DimensionMismatch("ipiv has length $(length(ipiv)), but needs to be $n"))
+            end
             nrhs = size(B, 2)
             info = Ref{BlasInt}()
             ccall((@blasfunc($getrs), libblastrampoline), Cvoid,

--- a/stdlib/LinearAlgebra/test/lapack.jl
+++ b/stdlib/LinearAlgebra/test/lapack.jl
@@ -720,4 +720,13 @@ a = zeros(2,0), zeros(0)
 @test LinearAlgebra.LAPACK.geqrf!(a...) === a
 @test LinearAlgebra.LAPACK.gerqf!(a...) === a
 
+# Issue #49489: https://github.com/JuliaLang/julia/issues/49489
+# Dimension mismatch between A and ipiv causes segfaults
+@testset "issue #49489" begin
+    A = randn(23,23)
+    b = randn(23)
+    ipiv = collect(1:20)
+    @test_throws DimensionMismatch LinearAlgebra.LAPACK.getrs!('N', A, ipiv, b)
+end
+
 end # module TestLAPACK


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#1001, where the tests for MultiScaleArrays.jl causes a segfault.

1. The primary cause is that `getrs!` does not ensure `length(ipiv) == n` before LAPACK call, leading to a segfault.
2. The secondary cause is that MultiScaleArrays.jl (or one of its dependents) is utilizing `LU(factor, ipiv, info)` with incompatible sizes for `factor` and `ipiv`, which, together with 1. above, causes a segfault.

Fix: 
1. Implement a check in `getrs!` and raise `DimensionMismatch` if `length(ipiv) != n`. 
2. Note: A fix in the wrapper `LU(factor, ipiv, info)` does not seem feasible as it handles square, thin, and thick matrices with varying `ipiv` lengths.

Unit test: Test case added to LinearAlgebra/test/lapack.jl to require `DimensionMismatch` if `length(ipiv) != n`.