### PR TITLE
shield `Base.require` from invalidations when loading Symbolics.jl

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -747,10 +747,10 @@ function explicit_project_deps_get(project_file::String, name::String)::Union{No
     return nothing
 end
 
-function is_v1_format_manifest(raw_manifest::Dict)
+function is_v1_format_manifest(raw_manifest::Dict{String})
     if haskey(raw_manifest, "manifest_format")
         mf = raw_manifest["manifest_format"]
-        if mf isa Dict && haskey(mf, "uuid")
+        if mf isa Dict{String} && haskey(mf, "uuid")
             # the off-chance where an old format manifest has a dep called "manifest_format"
             return true
         end


### PR DESCRIPTION
Otherwise:

```
inserting isequal(x, ::SymbolicUtils.Symbolic) @ SymbolicUtils ~/.julia/packages/SymbolicUtils/H684H/src/types.jl:189 invalidated:
   backedges: 1: superseding isequal(x, y) @ Base operators.jl:133 with MethodInstance for isequal(::String, ::Any) (22 children)
```

invalidates this.