### PR TITLE
prevent invalidations in `depwarn` from invalidating callers

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -118,7 +118,9 @@ macro deprecate(old, new, export_old=true)
     end
 end
 
-function depwarn(msg, funcsym; force::Bool=false)
+depwarn(msg, funcsym; force::Bool=false) = (@invokelatest _depwarn(msg, funcsym; force))::Nothing
+
+function _depwarn(msg, funcsym; force::Bool=false)
     opts = JLOptions()
     if opts.depwarn == 2
         throw(ErrorException(msg))


### PR DESCRIPTION
Extracted from https://github.com/JuliaLang/julia/pull/49596.

Otherwise:

```
inserting ==(q::MultivariatePolynomials.RationalPoly, α) @ MultivariatePolynomials ~/.julia/packages/MultivariatePolynomials/sWAOE/src/comparison.jl:112 invalidated:
   backedges: 1: superseding ==(x, y) @ Base Base.jl:159 with MethodInstance for ==(::Any, ::Symbol) (9 children)


julia> ascend(b.backedges[1])
Choose a call for analysis (q to quit):
     ==(::Any, ::Symbol)
       isequal(::Any, ::Symbol)
         ==(::WeakRef, ::Symbol)
           lookup_inline_frame_info(::Symbol, ::Symbol, ::Int64, ::Vector{Core.LineInfoNode})
             lookup(::Ptr{Nothing})
               firstcaller(::Vector{Union{Ptr{Nothing}, Base.InterpreterIP}}, ::Tuple{Symbol})
                 firstcaller(::Vector{Union{Ptr{Nothing}, Base.InterpreterIP}}, ::Symbol)
 >                 #depwarn#1027(::Bool, ::typeof(Base.depwarn), ::String, ::Symbol)
```

ends up invalidating everything calling `depwarn` (which Artifacts do).