### PR TITLE
make `IRShow.method_name` inferrable

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -303,10 +303,17 @@ function finish_cfg_inline!(state::CFGInliningState)
 end
 
 # duplicated from IRShow
-normalize_method_name(m::Method) = m.name
-normalize_method_name(m::MethodInstance) = (m.def::Method).name
-normalize_method_name(m::Symbol) = m
-normalize_method_name(m) = Symbol("")
+function normalize_method_name(m)
+    if m isa Method
+        return m.name
+    elseif m isa MethodInstance
+        return (m.def::Method).name
+    elseif m isa Symbol
+        return m
+    else
+        return Symbol("")
+    end
+end
 @noinline method_name(m::LineInfoNode) = normalize_method_name(m.method)
 
 inline_node_is_duplicate(topline::LineInfoNode, line::LineInfoNode) =

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -171,10 +171,17 @@ function default_expr_type_printer(io::IO; @nospecialize(type), used::Bool, show
     return nothing
 end
 
-normalize_method_name(m::Method) = m.name
-normalize_method_name(m::MethodInstance) = (m.def::Method).name
-normalize_method_name(m::Symbol) = m
-normalize_method_name(m) = Symbol("")
+function normalize_method_name(m)
+    if m isa Method
+        return m.name
+    elseif m isa MethodInstance
+        return (m.def::Method).name
+    elseif m isa Symbol
+        return m
+    else
+        return Symbol("")
+    end
+end
 @noinline method_name(m::LineInfoNode) = normalize_method_name(m.method)
 
 # converts the linetable for line numbers

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -134,7 +134,7 @@ function lookup_inline_frame_info(func::Symbol, file::Symbol, linenum::Int, inli
             # backtrack to find the matching MethodInstance, if possible
             for j in (i - 1):-1:1
                 nextline = inlinetable[j]
-                nextline.inlined_at == line.inlined_at && Base.IRShow.method_name(line) === Base.IRShow.method_name(nextline) && line.file == nextline.file || break
+                nextline.inlined_at == line.inlined_at && Base.IRShow.method_name(line) === Base.IRShow.method_name(nextline) && line.file === nextline.file || break
                 if nextline.method isa MethodInstance
                     linfo = nextline.method
                     break

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -125,7 +125,7 @@ function lookup_inline_frame_info(func::Symbol, file::Symbol, linenum::Int, inli
     or Symbol match is found? Or can a limit on the subsequent backtracks be placed?
     =#
     for (i, line) in enumerate(inlinetable)
-        Base.IRShow.method_name(line) == func && line.file ∈ (file, filestripped) && line.line == linenum || continue
+        Base.IRShow.method_name(line) === func && line.file ∈ (file, filestripped) && line.line == linenum || continue
         if line.method isa MethodInstance
             linfo = line.method
             break
@@ -134,7 +134,7 @@ function lookup_inline_frame_info(func::Symbol, file::Symbol, linenum::Int, inli
             # backtrack to find the matching MethodInstance, if possible
             for j in (i - 1):-1:1
                 nextline = inlinetable[j]
-                nextline.inlined_at == line.inlined_at && Base.IRShow.method_name(line) == Base.IRShow.method_name(nextline) && line.file == nextline.file || break
+                nextline.inlined_at == line.inlined_at && Base.IRShow.method_name(line) === Base.IRShow.method_name(nextline) && line.file == nextline.file || break
                 if nextline.method isa MethodInstance
                     linfo = nextline.method
                     break


### PR DESCRIPTION
4 methods pushes it over the limit. 

Seems to have the same effect as https://github.com/JuliaLang/julia/pull/49605.

Now:

```
julia> code_warntype(Base.IRShow.method_name, Tuple{Core.LineInfoNode})

MethodInstance for Base.IRShow.method_name(::Core.LineInfoNode)
  from method_name(m::Core.LineInfoNode) @ Base.IRShow compiler/ssair/show.jl:185
Arguments
  #self#::Core.Const(Base.IRShow.method_name)
  m::Core.LineInfoNode
Body::Symbol
1 ─      nothing
│   %2 = Base.getproperty(m, :method)::Any
│   %3 = Base.IRShow.normalize_method_name(%2)::Symbol
└──      return %3
```