### PR TITLE
correct comment about type of `method` in a `LineInfoNode`

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -109,7 +109,7 @@
 
 #struct LineInfoNode
 #    module::Module
-#    method::Symbol
+#    method::Any (Union{Symbol, Method, MethodInstance})
 #    file::Symbol
 #    line::Int32
 #    inlined_at::Int32


### PR DESCRIPTION
The type is set here:

https://github.com/JuliaLang/julia/blob/5304baa45a9a686f122525f0cdea7c604a39aa76/src/jltypes.c#L2802-L2805

so it is `::Any`.

And 

https://github.com/JuliaLang/julia/blob/5304baa45a9a686f122525f0cdea7c604a39aa76/base/stacktraces.jl#L132

+

https://github.com/JuliaLang/julia/blob/5304baa45a9a686f122525f0cdea7c604a39aa76/base/stacktraces.jl#L129

shows it can at least be a `Method` and a `MethodInstance`.

