### PR TITLE
Restore `modname == NULL` behavior for `jl_load_dynamic_library`

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -275,6 +275,10 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
     int n_extensions = endswith_extension(modname) ? 1 : N_EXTENSIONS;
     int ret;
 
+    // modname == NULL is a sentinel value requesting the handle of libjulia-internal
+    if (modname == NULL)
+        return jl_find_dynamic_library_by_addr(&jl_load_dynamic_library);
+
     abspath = jl_isabspath(modname);
     is_atpath = 0;
 


### PR DESCRIPTION
Within the Julia runtime, this usage has been superseded by the new `jl_find_library_by_addr`, but this is still used downstream.

In particular, CBinding.jl ends up using this branch to get a handle to libjulia-internal (perhaps a bit accidentally, since the [comments in CBinding.jl](https://github.com/analytech-solutions/CBinding.jl/blob/38e76e51d31e22beaa125f7fb9928d0cd1057e15/src/context.jl#L242-L244) suggest it intends to get a handle to the exe)

This restores the behavior to avoid downstream breakage.