### PR TITLE
Base: TwicePrecision: improve constructors

### DIFF
--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -200,14 +200,12 @@ end
 
 TwicePrecision{T}(x::T) where {T} = TwicePrecision{T}(x, zero(T))
 
+TwicePrecision{T}(x::TwicePrecision{T}) where {T} = x
+
 function TwicePrecision{T}(x) where {T}
-    xT = convert(T, x)
+    xT = T(x)
     Δx = x - xT
     TwicePrecision{T}(xT, T(Δx))
-end
-
-function TwicePrecision{T}(x::TwicePrecision) where {T}
-    TwicePrecision{T}(x.hi, x.lo)
 end
 
 TwicePrecision{T}(i::Integer) where {T<:AbstractFloat} =
@@ -264,8 +262,7 @@ promote_rule(::Type{TwicePrecision{R}}, ::Type{TwicePrecision{S}}) where {R,S} =
 promote_rule(::Type{TwicePrecision{R}}, ::Type{S}) where {R,S<:Number} =
     TwicePrecision{promote_type(R,S)}
 
-(::Type{T})(x::TwicePrecision) where {T<:Number} = T(x.hi + x.lo)::T
-TwicePrecision{T}(x::Number) where {T} = TwicePrecision{T}(T(x), zero(T))
+(::Type{T})(x::TwicePrecision) where {T<:Number} = (T(x.hi) + T(x.lo))::T
 
 convert(::Type{TwicePrecision{T}}, x::TwicePrecision{T}) where {T} = x
 convert(::Type{TwicePrecision{T}}, x::TwicePrecision) where {T} =

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -254,6 +254,45 @@ end
     @test x.hi/2 === PhysQuantity{1}(2.0)
     @test_throws ErrorException("Int is incommensurate with PhysQuantity") x/2
     @test zero(typeof(x)) === Base.TwicePrecision(PhysQuantity{1}(0.0))
+
+    function twiceprecision_roundtrip_is_not_lossy(
+        ::Type{S},
+        x::T,
+    ) where {S<:Number, T<:Union{Number,Base.TwicePrecision}}
+        tw = Base.TwicePrecision{S}(x)
+        @test x == T(tw)
+    end
+
+    function twiceprecision_is_normalized(tw::Tw) where {Tw<:Base.TwicePrecision}
+        (hi, lo) = (tw.hi, tw.lo)
+        normalized = Tw(Base.canonicalize2(hi, lo)...)
+        @test (abs(lo) ≤ abs(hi)) & (tw == normalized)
+    end
+
+    rand_twiceprecision(::Type{T}) where {T<:Number} = Base.TwicePrecision{T}(rand(widen(T)))
+
+    rand_twiceprecision_is_ok(::Type{T}) where {T<:Number} = @test !iszero(rand_twiceprecision(T).lo)
+
+    # For this test the `BigFloat` mantissa needs to be just a bit
+    # larger than the `Float64` mantissa
+    setprecision(BigFloat, 70) do
+        n = 10
+        @testset "rand twiceprecision is ok" for T ∈ (Float32, Float64), i ∈ 1:n
+            rand_twiceprecision_is_ok(T)
+        end
+        @testset "twiceprecision roundtrip is not lossy 1" for i ∈ 1:n
+            twiceprecision_roundtrip_is_not_lossy(Float64, rand(BigFloat))
+        end
+        @testset "twiceprecision roundtrip is not lossy 2" for i ∈ 1:n
+            twiceprecision_roundtrip_is_not_lossy(Float64, rand_twiceprecision(Float32))
+        end
+        @testset "twiceprecision normalization 1: Float64 to Float32" for i ∈ 1:n
+            twiceprecision_is_normalized(Base.TwicePrecision{Float32}(rand_twiceprecision(Float64)))
+        end
+        @testset "twiceprecision normalization 2: Float32 to Float64" for i ∈ 1:n
+            twiceprecision_is_normalized(Base.TwicePrecision{Float64}(rand_twiceprecision(Float32)))
+        end
+    end
 end
 @testset "ranges" begin
     @test size(10:1:0) == (0,)


### PR DESCRIPTION
EDIT: when someone gets around to reviewing this, it'd probably be best to skip all the comments, seeing as none are relevant any more after I reduced the PR, leaving the tricky concerns for future PRs

Correctness is improved for constructing `TwicePrecision{T}` from `TwicePrecision{S}`. Previously a call like
`TwicePrecision{Float64}(::TwicePrecision{Float32})` would leave `hi` and `lo` unnormalized; while a call like
`TwicePrecision{Float32}(::TwicePrecision{Float64})` would additionally introduce unnecessary truncation.

Accuracy is improved for constructing `TwicePrecision` from types like `BigFloat` or `Rational`. Previously a call like
`TwicePrecision{Float64}(::BigFloat)` would unconditionally leave `lo` as zero.

Example code that tests the improvements (all Boolean values should evaluate to `true`):
```julia
const TwicePrecision = Base.TwicePrecision
const canonicalize2 = Base.canonicalize2

function twiceprecision_roundtrip_is_not_lossy(
    ::Type{S},
    x::T,
) where {S<:Number, T<:Union{Number,TwicePrecision}}
    tw = TwicePrecision{S}(x)
    x == T(tw)
end

function twiceprecision_is_normalized(tw::Tw) where {Tw<:TwicePrecision}
    (hi, lo) = (tw.hi, tw.lo)
    normalized = Tw(canonicalize2(hi, lo)...)
    (abs(lo) ≤ abs(hi)) & (tw == normalized)
end

rand_twiceprecision(::Type{T}) where {T<:Number} = TwicePrecision{T}(rand(widen(T)))

rand_twiceprecision_is_ok(::Type{T}) where {T<:Number} = !iszero(rand_twiceprecision(T).lo)

setprecision(BigFloat, 70)  # The mantissa needs to be just a bit larger than for `Float64`

rand_twiceprecision_is_ok(Float32)
rand_twiceprecision_is_ok(Float32)
rand_twiceprecision_is_ok(Float32)

rand_twiceprecision_is_ok(Float64)
rand_twiceprecision_is_ok(Float64)
rand_twiceprecision_is_ok(Float64)

twiceprecision_roundtrip_is_not_lossy(Float64, rand(BigFloat))
twiceprecision_roundtrip_is_not_lossy(Float64, rand(BigFloat))
twiceprecision_roundtrip_is_not_lossy(Float64, rand(BigFloat))

twiceprecision_roundtrip_is_not_lossy(Float64, rand_twiceprecision(Float32))
twiceprecision_roundtrip_is_not_lossy(Float64, rand_twiceprecision(Float32))
twiceprecision_roundtrip_is_not_lossy(Float64, rand_twiceprecision(Float32))

twiceprecision_is_normalized(TwicePrecision{Float32}(rand_twiceprecision(Float64)))
twiceprecision_is_normalized(TwicePrecision{Float32}(rand_twiceprecision(Float64)))
twiceprecision_is_normalized(TwicePrecision{Float32}(rand_twiceprecision(Float64)))

twiceprecision_is_normalized(TwicePrecision{Float64}(rand_twiceprecision(Float32)))
twiceprecision_is_normalized(TwicePrecision{Float64}(rand_twiceprecision(Float32)))
twiceprecision_is_normalized(TwicePrecision{Float64}(rand_twiceprecision(Float32)))
```

Updates #49589