### PR TITLE
Remove last references to gc_num.since_sweep

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -996,7 +996,7 @@ void gc_time_sweep_pause(uint64_t gc_end_t, int64_t actual_allocd,
                    "(%.2f ms in post_mark) %s | next in %" PRId64 " kB\n",
                    jl_ns2ms(sweep_pause), live_bytes / 1024,
                    gc_num.freed / 1024, estimate_freed / 1024,
-                   gc_num.freed - estimate_freed, pct, gc_num.since_sweep / 1024,
+                   gc_num.freed - estimate_freed, pct, gc_num.allocd / 1024,
                    jl_ns2ms(gc_postmark_end - gc_premark_end),
                    sweep_full ? "full" : "quick", -gc_num.allocd / 1024);
 }

--- a/src/gc.c
+++ b/src/gc.c
@@ -3347,7 +3347,7 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
     if (collection == JL_GC_AUTO) {
         //If we aren't freeing enough or are seeing lots and lots of pointers let it increase faster
         if (!not_freed_enough || large_frontier) {
-            int64_t tot = 2 * (live_bytes + gc_num.since_sweep) / 3;
+            int64_t tot = 2 * (live_bytes + gc_num.allocd) / 3;
             if (gc_num.interval > tot) {
                 gc_num.interval = tot;
                 last_long_collect_interval = tot;


### PR DESCRIPTION
Commit ebc6776 removed the since_sweep field, but left two references to it, which makes Julia fail to build. This commit removes those references.

Note: I don't know anything about this C code here - I simply replaced both uses with `allocd` because #49195 claims that the two fields are always equal. Before merging this, it would be nice if anyone who knows the code could give it a thumbs up.

Closes #49627 