### PR TITLE
Fix --image-codegen

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -333,7 +333,8 @@ static Constant *julia_pgv(jl_codectx_t &ctx, const char *cname, void *addr)
     StringRef localname;
     std::string gvname;
     if (!gv) {
-        raw_string_ostream(gvname) << cname << ctx.global_targets.size();
+        uint64_t id = ctx.emission_context.imaging ? jl_atomic_fetch_add(&globalUniqueGeneratedNames, 1) : ctx.global_targets.size();
+        raw_string_ostream(gvname) << cname << id;
         localname = StringRef(gvname);
     }
     else {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1284,7 +1284,7 @@ static const auto &builtin_func_map() {
 
 static const auto jl_new_opaque_closure_jlcall_func = new JuliaFunction<>{XSTR(jl_new_opaque_closure_jlcall), get_func_sig, get_func_attrs};
 
-static _Atomic(int) globalUniqueGeneratedNames{1};
+static _Atomic(uint64_t) globalUniqueGeneratedNames{1};
 
 // --- code generation ---
 extern "C" {

--- a/test/llvmpasses/image-codegen.jl
+++ b/test/llvmpasses/image-codegen.jl
@@ -1,0 +1,22 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+# RUN: export JULIA_LLVM_ARGS="--print-before=loop-vectorize --print-module-scope"
+# RUN: rm -rf %t
+# RUN: mkdir %t
+# RUN: julia --image-codegen --startup-file=no %s 2> %t/output.txt
+# RUN: FileCheck %s < %t/output.txt
+
+# COM: checks that global variables compiled in imaging codegen
+# COM: are marked as external and not internal
+# COM: Also makes sure that --imaging-codegen doesn't crash
+
+# CHECK: *** IR Dump Before
+# CHECK-NOT: internal global
+# CHECK-NOT: private global
+# CHECK: jl_global
+# CHECK-SAME: = global
+# CHECK: julia_f_
+# CHECK-NOT: internal global
+# CHECK-NOT: private global
+
+f() = "abcd"
+f()


### PR DESCRIPTION
When we run with --image-codegen, we can't use local counters when creating global variables since they will not be marked internal/private later.

Fixes #49614 