### PR TITLE
Fix infinite loop on macOS with TIMING enabled

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -283,7 +283,8 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
     is_atpath = 0;
 
     JL_TIMING(DL_OPEN, DL_OPEN);
-    jl_timing_puts(JL_TIMING_CURRENT_BLOCK, modname);
+    if (!(flags & JL_RTLD_NOLOAD))
+        jl_timing_puts(JL_TIMING_CURRENT_BLOCK, modname);
 
     // Detect if our `modname` is something like `@rpath/libfoo.dylib`
 #ifdef _OS_DARWIN_
@@ -340,10 +341,10 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
                     if (i == 0) { // LoadLibrary already tested the extensions, we just need to check the `stat` result
 #endif
                         handle = jl_dlopen(path, flags);
-                        if (handle) {
+                        if (handle && !(flags & JL_RTLD_NOLOAD))
                             jl_timing_puts(JL_TIMING_CURRENT_BLOCK, jl_pathname_for_handle(handle));
+                        if (handle)
                             return handle;
-                        }
 #ifdef _OS_WINDOWS_
                         err = GetLastError();
                     }
@@ -362,10 +363,10 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
         path[0] = '\0';
         snprintf(path, PATHBUF, "%s%s", modname, ext);
         handle = jl_dlopen(path, flags);
-        if (handle) {
+        if (handle && !(flags & JL_RTLD_NOLOAD))
             jl_timing_puts(JL_TIMING_CURRENT_BLOCK, jl_pathname_for_handle(handle));
+        if (handle)
             return handle;
-        }
 #ifdef _OS_WINDOWS_
         err = GetLastError();
         break; // LoadLibrary already tested the rest


### PR DESCRIPTION
`jl_pathname_for_handle` calls `jl_load_dynamic_library` internally on macOS, so naively calling it for our TIMING instrumentation causes an infinite loop.

This is a simple fix that disables instrumentation when we are RTLD_NOLOAD'ing the library, which probably makes the trace information more meaningful as a set of _opened_ libraries anyway.