### PR TITLE
Define a method for `hash(::Type, ::UInt)`

### DIFF
--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -29,6 +29,7 @@ See also: [`objectid`](@ref), [`Dict`](@ref), [`Set`](@ref).
 """
 hash(x::Any) = hash(x, zero(UInt))
 hash(w::WeakRef, h::UInt) = hash(w.value, h)
+hash(T::Type, h::UInt) = hash_uint(3h - ccall(:jl_type_hash, UInt, (Any,), T))
 
 ## hashing general objects ##
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1575,6 +1575,14 @@ static unsigned type_hash(jl_value_t *kj, int *failed) JL_NOTSAFEPOINT
     }
 }
 
+JL_DLLEXPORT uintptr_t jl_type_hash(jl_value_t *v) JL_NOTSAFEPOINT
+{
+    // NOTE: The value of `failed` is purposefully ignored here. The parameter is relevant
+    // for other parts of the internal algorithm but not for exposing to the Julia side.
+    int failed = 0;
+    return type_hash(v, &failed);
+}
+
 static unsigned typekey_hash(jl_typename_t *tn, jl_value_t **key, size_t n, int nofail) JL_NOTSAFEPOINT
 {
     if (tn == jl_type_typename && key[0] == jl_bottom_type)

--- a/src/julia.h
+++ b/src/julia.h
@@ -1403,6 +1403,7 @@ JL_DLLEXPORT int jl_egal__bits(const jl_value_t *a JL_MAYBE_UNROOTED, const jl_v
 JL_DLLEXPORT int jl_egal__special(const jl_value_t *a JL_MAYBE_UNROOTED, const jl_value_t *b JL_MAYBE_UNROOTED, jl_datatype_t *dt) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_egal__unboxed(const jl_value_t *a JL_MAYBE_UNROOTED, const jl_value_t *b JL_MAYBE_UNROOTED, jl_datatype_t *dt) JL_NOTSAFEPOINT;
 JL_DLLEXPORT uintptr_t jl_object_id(jl_value_t *v) JL_NOTSAFEPOINT;
+JL_DLLEXPORT uintptr_t jl_type_hash(jl_value_t *v) JL_NOTSAFEPOINT;
 
 STATIC_INLINE int jl_egal__unboxed_(const jl_value_t *a JL_MAYBE_UNROOTED, const jl_value_t *b JL_MAYBE_UNROOTED, jl_datatype_t *dt) JL_NOTSAFEPOINT
 {

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -295,3 +295,10 @@ if Sys.WORD_SIZE >= 64
         objectid(s)
     end
 end
+
+# Issue #49620
+let t1 = Tuple{AbstractVector,AbstractVector{<:Integer},UnitRange{<:Integer}},
+    t2 = Tuple{AbstractVector,AbstractVector{<:Integer},UnitRange{<:Integer}}
+    @test hash(t1) == hash(t2)
+    @test length(Set{Type}([t1, t2])) == 1
+end


### PR DESCRIPTION
Currently, `hash(::Type, ::UInt)` uses `objectid`, which can have some odd behavior for types: in particular, subsequent identical type-valued variable definitions can have `objectid`s which differ from the first such definition. This has some bizarre downstream effects when e.g. using types as the values of a `Set` or the keys of a `Dict`. See #49620 for examples.

There is an internal `type_hash` C function used for caching types but isn't exposed to Julia, as Jameson pointed out in the linked issue. This commit exposes it as `jl_type_hash` which is then used via `ccall` to define a method `hash(::Type, ::UInt)`. This method then fixes #49620. Note, however, that this does not affect the differing `objectid`s for otherwise identical types.

I've marked this as a bugfix and notably the linked issue is present at least as far back as Julia 1.6, so it could be worth backporting to `release-1.6`, `release-1.9`, and perhaps `release-1.8` if we're going to do any more of those. I'm not sure whether that's allowed though for changes that add to the C API.