### PR TITLE
Extend NamedTuple special case to PartialStruct

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1331,14 +1331,18 @@ function precise_container_type(interp::AbstractInterpreter, @nospecialize(itft)
                                 sv::AbsIntState)
     if isa(typ, PartialStruct)
         widet = typ.typ
-        if isa(widet, DataType) && widet.name === Tuple.name
-            return AbstractIterationResult(typ.fields, nothing)
+        if isa(widet, DataType)
+            if widet.name === Tuple.name
+                return AbstractIterationResult(typ.fields, nothing)
+            elseif widet.name === _NAMEDTUPLE_NAME
+                return AbstractIterationResult(typ.fields, nothing)
+            end
         end
     end
 
     if isa(typ, Const)
         val = typ.val
-        if isa(val, SimpleVector) || isa(val, Tuple)
+        if isa(val, SimpleVector) || isa(val, Tuple) || isa(val, NamedTuple)
             return AbstractIterationResult(Any[ Const(val[i]) for i in 1:length(val) ], nothing) # avoid making a tuple Generator here!
         end
     end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4859,3 +4859,16 @@ end) == Type{Nothing}
 @test Base.return_types() do
     Core.Compiler.return_type(Tuple{typeof(+), Int, Int})
 end |> only == Type{Int}
+
+# Test that NamedTuple abstract iteration works for PartialStruct/Const
+function nt_splat_const()
+    nt = (; x=1, y = 2)
+    Val{tuple(nt...)[2]}()
+end
+@test @inferred(nt_splat_const) == Val{2}()
+
+function nt_splat_partial()
+    nt = (; x=1, y = 2)
+    Val{tuple(nt...)[2]}()
+end
+@test @inferred(nt_splat_partial) == Val{2}()

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4862,13 +4862,13 @@ end |> only == Type{Int}
 
 # Test that NamedTuple abstract iteration works for PartialStruct/Const
 function nt_splat_const()
-    nt = (; x=1, y = 2)
+    nt = (; x=1, y=2)
     Val{tuple(nt...)[2]}()
 end
-@test @inferred(nt_splat_const) == Val{2}()
+@test @inferred(nt_splat_const()) == Val{2}()
 
-function nt_splat_partial()
-    nt = (; x=1, y = 2)
+function nt_splat_partial(x::Int)
+    nt = (; x, y=2)
     Val{tuple(nt...)[2]}()
 end
-@test @inferred(nt_splat_partial) == Val{2}()
+@test @inferred(nt_splat_partial(42)) == Val{2}()


### PR DESCRIPTION
A little later in the `precise_container_type` function, we have a special case for extracting the iteration type from a NamedTuple, treating it the same as Tuple. However, as a result of this special case we were accidentally discarding any constant information that may have been in a PartialStruct. If we didn't have this special case, `abstract_iteration` would have taken care of it properly. To fix this, simply add the same special case to the PartialStruct check at the top of the function.