### PR TITLE
Fix type comparison printing in `MethodError`s from convert.

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -181,6 +181,7 @@ function print_with_compare(io::IO, @nospecialize(a::DataType), @nospecialize(b:
     if a.name === b.name
         Base.show_type_name(io, a.name)
         n = length(a.parameters)
+        n > 0 || return
         print(io, '{')
         for i = 1:n
             if i > length(b.parameters)

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -987,3 +987,12 @@ bt_str = sprint(Base.show_backtrace, bt)
 @test occursin("g_collapse_pos_kw(x::Float64, y::Float64; z::Float64)", bt_str)
 @test !occursin("g_collapse_pos_kw(x::Float64, y::Float64)", bt_str)
 @test !occursin("g_collapse_pos_kw(x::Float64)", bt_str)
+
+# Test Base.print_with_compare in convert MethodErrors
+struct TypeCompareError{A,B} end
+let e = try convert(TypeCompareError{Float64,1}, TypeCompareError{Float64,2}()); catch e e end
+    str = sprint(Base.showerror, e)
+    @test  occursin("TypeCompareError{Float64,2}", str)
+    @test  occursin("TypeCompareError{Float64,1}", str)
+    @test !occursin("TypeCompareError{Float64{},2}", str) # No {...} for types without params
+end


### PR DESCRIPTION
This patch removes the erroneous `{}` for types without parameters when printing `MethodError`s from convert. Fixes e.g. the following (note `Float64{}`):

```julia
julia> struct A{B, C} end

julia> convert(A{Float64,1}, A{Float64,2}())
ERROR: MethodError: Cannot `convert` an object of type
  A{Float64{},2} to an object of type
  A{Float64{},1}
```