### PR TITLE
turn tabs to spaces

### DIFF
--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2442,16 +2442,16 @@ end
 end
 
 @testset "PR 49516" begin
-	struct PR49516 <: Signed
-		n::Int
-	end
-	PR49516(f::PR49516) = f
-	Base.:*(x::Integer, f::PR49516) = PR49516(*(x, f.n))
-	Base.:+(f1::PR49516, f2::PR49516) = PR49516(+(f1.n, f2.n))
-	Base.show(io::IO, f::PR49516) = print(io, "PR49516(", f.n, ")")
+    struct PR49516 <: Signed
+        n::Int
+    end
+    PR49516(f::PR49516) = f
+    Base.:*(x::Integer, f::PR49516) = PR49516(*(x, f.n))
+    Base.:+(f1::PR49516, f2::PR49516) = PR49516(+(f1.n, f2.n))
+    Base.show(io::IO, f::PR49516) = print(io, "PR49516(", f.n, ")")
 
-	srl = StepRangeLen(PR49516(1), PR49516(2), 10)
-	@test sprint(show, srl) == "PR49516(1):PR49516(2):PR49516(19)"
+    srl = StepRangeLen(PR49516(1), PR49516(2), 10)
+    @test sprint(show, srl) == "PR49516(1):PR49516(2):PR49516(19)"
 end
 
 @testset "Inline StepRange Construction #49270" begin


### PR DESCRIPTION
#49516 used tabs in the changes to the test file. That was not detected by the online whitespace check step, but I obtained complaints locally.

[skip-ci] [ci-skip]