### PR TITLE
fix some SCC cycle mistakes

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -3737,7 +3737,7 @@ static jl_value_t *ml_matches(jl_methtable_t *mt,
                                 // now look for a third method m3 outside of this ambiguity group that fully resolves this intersection
                                 size_t k;
                                 for (k = agid; k > 0; k--) {
-                                    jl_method_match_t *matc3 = (jl_method_match_t*)jl_array_ptr_ref(env.t, k);
+                                    jl_method_match_t *matc3 = (jl_method_match_t*)jl_array_ptr_ref(env.t, k - 1);
                                     jl_method_t *m3 = matc3->method;
                                     if ((jl_subtype(ti, m3->sig) || (isect2 && jl_subtype(isect2, m3->sig)))
                                             && jl_type_morespecific((jl_value_t*)m3->sig, (jl_value_t*)m->sig)

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -178,7 +178,7 @@ static int has_backedge_to_worklist(jl_method_instance_t *mi, htable_t *visited,
     int depth = stack->len;
     *bp = (void*)((char*)HT_NOTFOUND + 4 + depth); // preliminarily mark as in-progress
     size_t i = 0, n = jl_array_len(mi->backedges);
-    int cycle = 0;
+    int cycle = depth;
     while (i < n) {
         jl_method_instance_t *be;
         i = get_next_edge(mi->backedges, i, NULL, &be);
@@ -194,7 +194,7 @@ static int has_backedge_to_worklist(jl_method_instance_t *mi, htable_t *visited,
             assert(cycle);
         }
     }
-    if (!found && cycle && cycle != depth)
+    if (!found && cycle != depth)
         return cycle + 3;
     // If we are the top of the current cycle, now mark all other parts of
     // our cycle with what we found.
@@ -1002,6 +1002,7 @@ static int jl_verify_graph_edge(size_t *maxvalids2_data, jl_array_t *edges, size
     assert(jl_typeis((jl_value_t*)callee_ids, jl_array_int32_type));
     int32_t *idxs = (int32_t*)jl_array_data(callee_ids);
     size_t i, n = jl_array_len(callee_ids);
+    cycle = depth;
     for (i = idxs[0] + 1; i < n; i++) {
         int32_t childidx = idxs[i];
         int child_cycle = jl_verify_graph_edge(maxvalids2_data, edges, childidx, visited, stack);
@@ -1020,7 +1021,7 @@ static int jl_verify_graph_edge(size_t *maxvalids2_data, jl_array_t *edges, size
         }
     }
     size_t max_valid = maxvalids2_data[idx];
-    if (max_valid != 0 && cycle && cycle != depth)
+    if (max_valid != 0 && cycle != depth)
         return cycle;
     // If we are the top of the current cycle, now mark all other parts of
     // our cycle with what we found.


### PR DESCRIPTION
I noticed cycle was not initialized, which would cause it to disregard methods that only linked back to the current image via a cycle or fail to verify those correctly. And would consider the wrong list of methods when determining if an ambiguity was already covered (making the compiler sometimes do a bit of extra work, or be very slightly too ambitious in very rare hypothetical cases).