### PR TITLE
Base: TwicePrecision: disallow some constructors

### DIFF
--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -196,7 +196,20 @@ ranges, you can set `nb = ceil(Int, log2(len-1))`.
 struct TwicePrecision{T}
     hi::T    # most significant bits
     lo::T    # least significant bits
+
+    function TwicePrecision{T}(hi::T, lo::T) where {T}
+        isconcretetype(T) || error("$T isn't a concrete type")
+        (T <: Integer) &&
+            error("TwicePrecision{<:Integer} is nonsensical")
+        (T <: TwicePrecision) &&
+            error("TwicePrecision{<:TwicePrecision} is nonsensical")
+        (T <: Tuple) &&
+            error("TwicePrecision{<:Tuple} is nonsensical")
+        new{T}(hi, lo)
+    end
 end
+
+TwicePrecision(hi::T, lo::T) where {T} = TwicePrecision{T}(hi, lo)
 
 TwicePrecision{T}(x::T) where {T} = TwicePrecision{T}(x, zero(T))
 


### PR DESCRIPTION
Disables some constructors to help in catching errors earlier.

Disables converting constructors like, for example, `TwicePrecision{Float64}(::BigFloat, ::BigFloat)`. This constructor was actually used in some cases before commit "Base: TwicePrecision: improve constructors (#49616)" (ce2c3ae73a45124c8534), so disabling the constructor would have brought the possible accuracy losses and construction of unnormalized double-word numbers to attention sooner.

Also effectively *blacklists* some types, to prevent them from being the type of a word in a `TwicePrecision` type. For example, `TwicePrecision{<:Integer}` objects are now disallowed, which is good as such a type would be nonsensical. Blacklisting is required, as opposed to whitelisting via type constraints, because of the need to support various floating-point-like types that are not `<:AbstractFloat`, and, more generally, various number-like types that are not `<:Number` (such as types representing physical units).

In the same way it is now forbidden to construct `TwicePrecision{T}` objects where `T` is not a concrete type. This should prevent the construction of `TwicePrecision` objects with the high and low words of differing types.

Updates #49589