### PR TITLE
test: fix TypeCompareError test conflict

### DIFF
--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -989,9 +989,9 @@ bt_str = sprint(Base.show_backtrace, bt)
 @test !occursin("g_collapse_pos_kw(x::Float64)", bt_str)
 
 # Test Base.print_with_compare in convert MethodErrors
-struct TypeCompareError{A,B} end
-let e = try convert(TypeCompareError{Float64,1}, TypeCompareError{Float64,2}()); catch e e end
-    str = sprint(Base.showerror, e)
+struct TypeCompareError{A,B} <: Exception end
+let e = @test_throws MethodError convert(TypeCompareError{Float64,1}, TypeCompareError{Float64,2}())
+    str = sprint(Base.showerror, e.value)
     @test  occursin("TypeCompareError{Float64,2}", str)
     @test  occursin("TypeCompareError{Float64,1}", str)
     @test !occursin("TypeCompareError{Float64{},2}", str) # No {...} for types without params


### PR DESCRIPTION
We have a slightly over-eager test in error.jl that requires all types ending in Error to subtype Exception, so this can cause a sporadic failure without this update.