### PR TITLE
Remove mention of TwicePrecision from the docs

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -478,8 +478,6 @@ value `r[1]`, but alternatively you can supply it as the value of
 `r[offset]` for some other index `1 <= offset <= len`. The syntax `a:b`
 or `a:b:c`, where any of `a`, `b`, or `c` are floating-point numbers, creates a
 `StepRangeLen`.
-In conjunction with `TwicePrecision` this can be used to implement ranges that
-are free of roundoff error.
 
 !!! compat "Julia 1.7"
     The 4th type parameter `L` requires at least Julia 1.7.


### PR DESCRIPTION
This type is internal and should not be mentioned in the manual, since we currently have the policy of "if it's in the manual, it's API". This is not API under semver, as its own docstring says:

```
help?> Base.TwicePrecision
  TwicePrecision{T}(hi::T, lo::T)
  TwicePrecision{T}((num, denom))

  A number with twice the precision of T, e.g., quad-precision if T = Float64.

  │ Warning
  │
  │  TwicePrecision is an internal type used to increase the precision of floating-point ranges, and not
  │  intended for external use. If you encounter them in real code, the most likely explanation is that you
  │  are directly accessing the fields of a range. Use the function interface instead, step(r) rather than
  │  r.step
```

[skip ci]