### PR TITLE
Reduce `mul!` methods related to "banded" matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -405,18 +405,13 @@ function ==(A::Bidiagonal, B::Bidiagonal)
     end
 end
 
+const BandedMatrix = Union{Bidiagonal,Diagonal,Tridiagonal,SymTridiagonal} # or BiDiTriSym
 const BiTriSym = Union{Bidiagonal,Tridiagonal,SymTridiagonal}
 const BiTri = Union{Bidiagonal,Tridiagonal}
-@inline mul!(C::AbstractVector, A::BiTriSym, B::AbstractVector, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
-@inline mul!(C::AbstractMatrix, A::BiTriSym, B::AbstractMatrix, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
-@inline mul!(C::AbstractMatrix, A::BiTriSym, B::Transpose{<:Any,<:AbstractVecOrMat}, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
-@inline mul!(C::AbstractMatrix, A::BiTriSym, B::Adjoint{<:Any,<:AbstractVecOrMat}, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
-@inline mul!(C::AbstractMatrix, A::BiTriSym, B::Diagonal, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
-@inline mul!(C::AbstractMatrix, A::AbstractMatrix, B::BiTriSym, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
-@inline mul!(C::AbstractMatrix, A::Adjoint{<:Any,<:AbstractVecOrMat}, B::BiTriSym, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
-@inline mul!(C::AbstractMatrix, A::Transpose{<:Any,<:AbstractVecOrMat}, B::BiTriSym, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
-@inline mul!(C::AbstractMatrix, A::BiTriSym, B::BiTriSym, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
-@inline mul!(C::AbstractMatrix, A::Diagonal, B::BiTriSym, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
+@inline mul!(C::AbstractVector, A::BandedMatrix, B::AbstractVector, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
+@inline mul!(C::AbstractMatrix, A::BandedMatrix, B::AbstractMatrix, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
+@inline mul!(C::AbstractMatrix, A::AbstractMatrix, B::BandedMatrix, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
+@inline mul!(C::AbstractMatrix, A::BandedMatrix, B::BandedMatrix, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
 
 function check_A_mul_B!_sizes(C, A, B)
     mA, nA = size(A)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -295,13 +295,13 @@ function (*)(D::Diagonal, A::AdjOrTransAbsMat)
     lmul!(D, Ac)
 end
 
-@inline function __muldiag!(out, D::Diagonal, B, alpha, beta)
-    require_one_based_indexing(B)
-    require_one_based_indexing(out)
+function __muldiag!(out, D::Diagonal, B, _add::MulAddMul{ais1,bis0}) where {ais1,bis0}
+    require_one_based_indexing(out, B)
+    alpha, beta = _add.alpha, _add.beta
     if iszero(alpha)
         _rmul_or_fill!(out, beta)
     else
-        if iszero(beta)
+        if bis0
             @inbounds for j in axes(B, 2)
                 @simd for i in axes(B, 1)
                     out[i,j] = D.diag[i] * B[i,j] * alpha
@@ -317,13 +317,13 @@ end
     end
     return out
 end
-@inline function __muldiag!(out, A, D::Diagonal, alpha, beta)
-    require_one_based_indexing(A)
-    require_one_based_indexing(out)
+function __muldiag!(out, A, D::Diagonal, _add::MulAddMul{ais1,bis0}) where {ais1,bis0}
+    require_one_based_indexing(out, A)
+    alpha, beta = _add.alpha, _add.beta
     if iszero(alpha)
         _rmul_or_fill!(out, beta)
     else
-        if iszero(beta)
+        if bis0
             @inbounds for j in axes(A, 2)
                 dja = D.diag[j] * alpha
                 @simd for i in axes(A, 1)
@@ -341,13 +341,14 @@ end
     end
     return out
 end
-@inline function __muldiag!(out::Diagonal, D1::Diagonal, D2::Diagonal, alpha, beta)
+function __muldiag!(out::Diagonal, D1::Diagonal, D2::Diagonal, _add::MulAddMul{ais1,bis0}) where {ais1,bis0}
     d1 = D1.diag
     d2 = D2.diag
+    alpha, beta = _add.alpha, _add.beta
     if iszero(alpha)
         _rmul_or_fill!(out.diag, beta)
     else
-        if iszero(beta)
+        if bis0
             @inbounds @simd for i in eachindex(out.diag)
                 out.diag[i] = d1[i] * d2[i] * alpha
             end
@@ -359,8 +360,9 @@ end
     end
     return out
 end
-@inline function __muldiag!(out, D1::Diagonal, D2::Diagonal, alpha, beta)
+function __muldiag!(out, D1::Diagonal, D2::Diagonal, _add::MulAddMul{ais1,bis0}) where {ais1,bis0}
     require_one_based_indexing(out)
+    alpha, beta = _add.alpha, _add.beta
     mA = size(D1, 1)
     d1 = D1.diag
     d2 = D2.diag
@@ -373,9 +375,9 @@ end
     return out
 end
 
-@inline function _muldiag!(out, A, B, alpha, beta)
+function _mul!(out, A, B, _add)
     _muldiag_size_check(out, A, B)
-    __muldiag!(out, A, B, alpha, beta)
+    __muldiag!(out, A, B, _add)
     return out
 end
 
@@ -390,24 +392,6 @@ function (*)(Da::Diagonal, Db::Diagonal, Dc::Diagonal)
     _muldiag_size_check(Db, Dc)
     return Diagonal(Da.diag .* Db.diag .* Dc.diag)
 end
-
-# Get ambiguous method if try to unify AbstractVector/AbstractMatrix here using AbstractVecOrMat
-@inline mul!(out::AbstractVector, D::Diagonal, V::AbstractVector, alpha::Number, beta::Number) =
-    _muldiag!(out, D, V, alpha, beta)
-@inline mul!(out::AbstractMatrix, D::Diagonal, B::AbstractMatrix, alpha::Number, beta::Number) =
-    _muldiag!(out, D, B, alpha, beta)
-@inline mul!(out::AbstractMatrix, D::Diagonal, B::AdjOrTrans{<:Any,<:AbstractVecOrMat},
-             alpha::Number, beta::Number) = _muldiag!(out, D, B, alpha, beta)
-
-@inline mul!(out::AbstractMatrix, A::AbstractMatrix, D::Diagonal, alpha::Number, beta::Number) =
-    _muldiag!(out, A, D, alpha, beta)
-@inline mul!(out::AbstractMatrix, A::AdjOrTrans{<:Any,<:AbstractVecOrMat}, D::Diagonal,
-             alpha::Number, beta::Number) = _muldiag!(out, A, D, alpha, beta)
-@inline mul!(C::Diagonal, Da::Diagonal, Db::Diagonal, alpha::Number, beta::Number) =
-    _muldiag!(C, Da, Db, alpha, beta)
-
-mul!(C::AbstractMatrix, Da::Diagonal, Db::Diagonal, alpha::Number, beta::Number) =
-    _muldiag!(C, Da, Db, alpha, beta)
 
 /(A::AbstractVecOrMat, D::Diagonal) = _rdiv!(similar(A, _init_eltype(/, eltype(A), eltype(D))), A, D)
 /(A::HermOrSym, D::Diagonal) = _rdiv!(similar(A, _init_eltype(/, eltype(A), eltype(D)), size(A)), A, D)
@@ -576,19 +560,21 @@ for Tri in (:UpperTriangular, :LowerTriangular)
     # 3-arg mul!: invoke 5-arg mul! rather than lmul!
     @eval mul!(C::$Tri, A::Union{$Tri,$UTri}, D::Diagonal) = mul!(C, A, D, true, false)
     # 5-arg mul!
-    @eval @inline mul!(C::$Tri, D::Diagonal, A::$Tri, α::Number, β::Number) = $Tri(mul!(C.data, D, A.data, α, β))
-    @eval @inline function mul!(C::$Tri, D::Diagonal, A::$UTri, α::Number, β::Number)
+    @eval _mul!(C::$Tri, D::Diagonal, A::$Tri, _add) = $Tri(mul!(C.data, D, A.data, _add.alpha, _add.beta))
+    @eval function _mul!(C::$Tri, D::Diagonal, A::$UTri, _add)
+        α, β = _add.alpha, _add.beta
         iszero(α) && return _rmul_or_fill!(C, β)
         diag′ = iszero(β) ? nothing : diag(C)
         data = mul!(C.data, D, A.data, α, β)
-        $Tri(_setdiag!(data, MulAddMul(α, β), D.diag, diag′))
+        $Tri(_setdiag!(data, _add, D.diag, diag′))
     end
-    @eval @inline mul!(C::$Tri, A::$Tri, D::Diagonal, α::Number, β::Number) = $Tri(mul!(C.data, A.data, D, α, β))
-    @eval @inline function mul!(C::$Tri, A::$UTri, D::Diagonal, α::Number, β::Number)
+    @eval _mul!(C::$Tri, A::$Tri, D::Diagonal, _add) = $Tri(mul!(C.data, A.data, D, _add.alpha, _add.beta))
+    @eval function _mul!(C::$Tri, A::$UTri, D::Diagonal, _add)
+        α, β = _add.alpha, _add.beta
         iszero(α) && return _rmul_or_fill!(C, β)
         diag′ = iszero(β) ? nothing : diag(C)
         data = mul!(C.data, A.data, D, α, β)
-        $Tri(_setdiag!(data, MulAddMul(α, β), D.diag, diag′))
+        $Tri(_setdiag!(data, _add, D.diag, diag′))
     end
 end
 


### PR DESCRIPTION
I was encouraged by @blegat to further reduce the number of `mul!` methods, so here we go. I think we can do this by defining larger "groups" of types, catch any multiplication where they are involved and redirect to its own multiplication function(!), so here it's `_mul!`. This may be of interest to @dlfivefifty: I grouped together all the "banded" structured matrices (remember we discussed subtyping (some of) them to `AbstractTriangular`), and called the group `BandedMatrix`. Currently, this is a simple union, but we may want to consider actually introducing an abstract type and make these subtype it. And we may want to call the "banded matrix-related" `_mul!` `bandedmul!`. I can guess you can see where this is going. Does that sound like a good direction or should we avoid any interference with `*BandedMatrices.jl`?

In the big scheme of things, we can then resolve ambiguities with other "groups"(like wrapped (typically dense) matrices à la triangular, upper Hessenberg) at the larger scale, and ambiguity resolution within the groups happens at the `_mul!`/`bandedmul!` scale, so doesn't increase the number of `mul!` methods.

This PR reduces the number of `mul!` methods from 88 to 67, but it excludes the triangular part, which is a huge source of methods. I''ll take care of that part in my triangular overhaul #43972.