### PR TITLE
mention `Cmd(::Vector{String})` in `Cmd` docstring

### DIFF
--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -75,7 +75,7 @@ For any keywords that are not specified, the current settings from `cmd` are use
 
 Note that the `Cmd` constructor does not create a copy of `exec`. Any subsequent changes to `exec` will be reflected in the `Cmd` object.
 
-The most common way to construct a `Cmd` object is with command literals, e.g.
+The most common way to construct a `Cmd` object is with command literals (backticks), e.g.
 
     `ls -l`
 

--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -41,6 +41,7 @@ has_nondefault_cmd_flags(c::Cmd) =
 
 """
     Cmd(cmd::Cmd; ignorestatus, detach, windows_verbatim, windows_hide, env, dir)
+    Cmd(exec::Vector{String})
 
 Construct a new `Cmd` object, representing an external program and arguments, from `cmd`,
 while changing the settings of the optional keyword arguments:
@@ -70,8 +71,15 @@ while changing the settings of the optional keyword arguments:
 * `dir::AbstractString`: Specify a working directory for the command (instead
   of the current directory).
 
-For any keywords that are not specified, the current settings from `cmd` are used. Normally,
-to create a `Cmd` object in the first place, one uses backticks, e.g.
+For any keywords that are not specified, the current settings from `cmd` are used.
+
+Note that the `Cmd` constructor does not create a copy of `exec`. Any subsequent changes to `exec` will be reflected in the `Cmd` object.
+
+The most common way to construct a `Cmd` object is with command literals, e.g.
+
+    `ls -l`
+
+This can then be passed to the `Cmd` constructor to modify its settings, e.g.
 
     Cmd(`echo "Hello world"`, ignorestatus=true, detach=false)
 """

--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -73,7 +73,7 @@ while changing the settings of the optional keyword arguments:
 
 For any keywords that are not specified, the current settings from `cmd` are used.
 
-Note that the `Cmd` constructor does not create a copy of `exec`. Any subsequent changes to `exec` will be reflected in the `Cmd` object.
+Note that the `Cmd(exec)` constructor does not create a copy of `exec`. Any subsequent changes to `exec` will be reflected in the `Cmd` object.
 
 The most common way to construct a `Cmd` object is with command literals (backticks), e.g.
 


### PR DESCRIPTION
This seems like a cyclical definition without it, and
naively `Cmd` and `String` seem on the surface to be
similar so it can be surprising that `Cmd("a string")`
does not work. Adding this signature in the docstring
should obviate the issues for first time users that read
the docstring without having reviewed the manual.
