### PR TITLE
Micro-optimization in WeakKeyDict constructor

### DIFF
--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -23,7 +23,7 @@ mutable struct WeakKeyDict{K,V} <: AbstractDict{K,V}
 
     # Constructors mirror Dict's
     function WeakKeyDict{K,V}() where V where K
-        t = new(Dict{Any,V}(), ReentrantLock(), identity, 0)
+        t = new(Dict{WeakRef,V}(), ReentrantLock(), identity, 0)
         t.finalizer = k -> t.dirty = true
         return t
     end


### PR DESCRIPTION
The `Dict{Any, Any}()` is getting allocated and discarded. This should save about 70ns.
```julia
julia> @btime convert(Dict{WeakRef,Int}, Dict{Any,Int}())
  133.890 ns (8 allocations: 1.03 KiB)
Dict{WeakRef, Int64}()

julia> @btime convert(Dict{WeakRef,Int}, Dict{WeakRef,Int}())
  61.184 ns (4 allocations: 528 bytes)
Dict{WeakRef, Int64}()
```