### PR TITLE
Tweak `donotdelete` effects

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -2196,6 +2196,7 @@ const _CONSISTENT_BUILTINS = Any[
     typeassert,
     throw,
     setfield!,
+    donotdelete
 ]
 
 # known to be effect-free (but not necessarily nothrow)
@@ -2235,7 +2236,8 @@ const _INACCESSIBLEMEM_BUILTINS = Any[
     typeassert,
     typeof,
     compilerbarrier,
-    Core._typevar
+    Core._typevar,
+    donotdelete
 ]
 
 const _ARGMEM_BUILTINS = Any[

--- a/test/core.jl
+++ b/test/core.jl
@@ -8006,3 +8006,7 @@ end
 # objectid for datatypes is inconsistant for types that have unbound type parameters.
 @test !Core.Compiler.is_consistent(Base.infer_effects(objectid, (DataType,)))
 @test !Core.Compiler.is_consistent(Base.infer_effects(objectid, (Tuple{Vector{Int}},)))
+
+# donotdelete should not taint consistency of the containing function
+f_donotdete(x) = (Core.Compiler.donotdelete(x); 1)
+@test Core.Compiler.is_consistent(Base.infer_effects(f_donotdete, (Tuple{Float64},)))


### PR DESCRIPTION
I don't think there's any reason not to mark this intrinsic as `:consistent`. The only real property we need from it at the julia level is that the optimizer does not delete it, which `!:effect_free` will take care of.

As requested by @oscardssmith and @pepijndevos 