### PR TITLE
Explicitly note that :consistent includes no-ub

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -514,6 +514,13 @@ The `:consistent` setting asserts that for egal (`===`) inputs:
     the other was optimized).
 
 !!! note
+    The `:consistent`-cy assertion currrently includes the assertion that the function
+    will not execute any undefined behavior (for any input). Note that undefined behavior
+    may technically cause the function to violate other effect asswertions (such as
+    `:nothrow` or `:effect_free`) as well, but we do not model this, and all effects
+    except `:consistent` assume the absence of undefined behavior.
+
+!!! note
     If `:consistent` functions terminate by throwing an exception, that exception
     itself is not required to meet the egality requirement specified above.
 

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -516,7 +516,7 @@ The `:consistent` setting asserts that for egal (`===`) inputs:
 !!! note
     The `:consistent`-cy assertion currrently includes the assertion that the function
     will not execute any undefined behavior (for any input). Note that undefined behavior
-    may technically cause the function to violate other effect asswertions (such as
+    may technically cause the function to violate other effect assertions (such as
     `:nothrow` or `:effect_free`) as well, but we do not model this, and all effects
     except `:consistent` assume the absence of undefined behavior.
 


### PR DESCRIPTION
We may split these effects in the future, but currently :consistent-cy requires the absence for undefined behavior for the function. There were a few questions about this, so explicitly document this in the help text.