### PR TITLE
[WIP] use jl_strtof_c to convert strings to float

### DIFF
--- a/src/flisp/read.c
+++ b/src/flisp/read.c
@@ -47,14 +47,16 @@ int isnumtok_base(fl_context_t *fl_ctx, char *tok, value_t *pval, int base)
             return 1;
         }
 
-        // NOTE(#49689): DO NOT convert double to float directly,
-        //  indirect conversion (string->double->float) will lose precision.
-        f = jl_strtof_c(tok, &end);
         // floats can end in f or f0
         if (end > tok && end[0] == 'f' &&
             (end[1] == '\0' ||
              (end[1] == '0' && end[2] == '\0'))) {
-            if (pval) *pval = mk_float(fl_ctx, f);
+            if (pval) {
+                // NOTE(#49689): DO NOT convert double to float directly,
+                //  indirect conversion (string->double->float) will lose precision.
+                f = jl_strtof_c(tok, &end);
+                *pval = mk_float(fl_ctx, f);
+            }
             return 1;
         }
     }
@@ -67,14 +69,16 @@ int isnumtok_base(fl_context_t *fl_ctx, char *tok, value_t *pval, int base)
             return 1;
         }
 
-        // NOTE(#49689): DO NOT convert double to float directly,
-        //  indirect conversion (string->double->float) will lose precision.
-        f = jl_strtof_c(tok, &end);
         // floats can end in f or f0
         if (end > tok && end[0] == 'f' &&
             (end[1] == '\0' ||
              (end[1] == '0' && end[2] == '\0'))) {
-            if (pval) *pval = mk_float(fl_ctx, f);
+            if (pval) {
+                // NOTE(#49689): DO NOT convert double to float directly,
+                //  indirect conversion (string->double->float) will lose precision.
+                f = jl_strtof_c(tok, &end);                
+                *pval = mk_float(fl_ctx, f);
+            }
             return 1;
         }
     }

--- a/src/flisp/read.c
+++ b/src/flisp/read.c
@@ -76,7 +76,7 @@ int isnumtok_base(fl_context_t *fl_ctx, char *tok, value_t *pval, int base)
             if (pval) {
                 // NOTE(#49689): DO NOT convert double to float directly,
                 //  indirect conversion (string->double->float) will lose precision.
-                f = jl_strtof_c(tok, &end);                
+                f = jl_strtof_c(tok, &end);
                 *pval = mk_float(fl_ctx, f);
             }
             return 1;

--- a/src/flisp/read.c
+++ b/src/flisp/read.c
@@ -35,6 +35,8 @@ int isnumtok_base(fl_context_t *fl_ctx, char *tok, value_t *pval, int base)
     int64_t i64;
     uint64_t ui64;
     double d;
+    float f;
+
     if (*tok == '\0')
         return 0;
     if (!((tok[0]=='0' && tok[1]=='x') || (base >= 15)) &&
@@ -44,11 +46,15 @@ int isnumtok_base(fl_context_t *fl_ctx, char *tok, value_t *pval, int base)
             if (pval) *pval = mk_double(fl_ctx, d);
             return 1;
         }
+
+        // NOTE(#49689): DO NOT convert double to float directly,
+        //  indirect conversion (string->double->float) will lose precision.
+        f = jl_strtof_c(tok, &end);
         // floats can end in f or f0
         if (end > tok && end[0] == 'f' &&
             (end[1] == '\0' ||
              (end[1] == '0' && end[2] == '\0'))) {
-            if (pval) *pval = mk_float(fl_ctx, (float)d);
+            if (pval) *pval = mk_float(fl_ctx, f);
             return 1;
         }
     }
@@ -60,11 +66,15 @@ int isnumtok_base(fl_context_t *fl_ctx, char *tok, value_t *pval, int base)
             if (pval) *pval = mk_double(fl_ctx, d);
             return 1;
         }
+
+        // NOTE(#49689): DO NOT convert double to float directly,
+        //  indirect conversion (string->double->float) will lose precision.
+        f = jl_strtof_c(tok, &end);
         // floats can end in f or f0
         if (end > tok && end[0] == 'f' &&
             (end[1] == '\0' ||
              (end[1] == '0' && end[2] == '\0'))) {
-            if (pval) *pval = mk_float(fl_ctx, (float)d);
+            if (pval) *pval = mk_float(fl_ctx, f);
             return 1;
         }
     }

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -503,11 +503,7 @@ JL_DLLEXPORT jl_nullable_float32_t jl_try_substrtof(char *str, size_t offset, si
         bstr = newstr;
         pend = bstr+len;
     }
-#if defined(_OS_WINDOWS_) && !defined(_COMPILER_GCC_)
-    float out = (float)jl_strtod_c(bstr, &p);
-#else
     float out = jl_strtof_c(bstr, &p);
-#endif
 
     if (errno==ERANGE && (out==0 || out==HUGE_VALF || out==-HUGE_VALF)) {
         hasvalue = 0;

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -265,10 +265,32 @@ end
 @test tryparse(Float32, "1.23") === 1.23f0
 @test tryparse(Float16, "1.23") === Float16(1.23)
 
-# Test floating-point rounding (#49689)
-@test tryparse(Float32, "17.328679084777833") == 17.32868f0
-@test_broken 17.328679084777833f0 == 17.32868f0
-# TODO: fix @test_broken in *nix platforms, add more test
+@testset "issue #49689" begin
+    """Test floating-point rounding
+
+        ::Float32           ::Float64
+        17.3286_78f0        17.3286_78_131103516
+        ??                  17.3286_79_084777832
+        ??                  17.3286_79_084777833
+        17.3286_80f0        17.3286_80_03845215
+    """
+    lower_bond = 17.3286_78f0
+    f64_str832 = "17.328679084777832"
+    f64_str833 = "17.328679084777833"
+    upper_bond = 17.3286_80f0
+
+    abs_diff(a, b) = abs(BigFloat(a) - BigFloat(b))
+    # f64_str832
+    @test abs_diff(lower_bond, f64_str832) < abs_diff(f64_str832, upper_bond)
+    @test tryparse(Float32, f64_str832) == lower_bond
+    @test 17.328679084777_832f0 == lower_bond
+
+    # f64_str833
+    @test abs_diff(lower_bond, f64_str833) > abs_diff(f64_str833, upper_bond)
+    @test tryparse(Float32, f64_str833) == upper_bond
+    @test_broken 17.328679084777_833f0 == upper_bond
+    # TODO: fix @test_broken in *nix platforms, add more test
+end
 
 # parsing complex numbers (#22250)
 @testset "complex parsing" begin

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -265,6 +265,11 @@ end
 @test tryparse(Float32, "1.23") === 1.23f0
 @test tryparse(Float16, "1.23") === Float16(1.23)
 
+# Test floating-point rounding (#49689)
+@test tryparse(Float32, "17.328679084777833") == 17.32868f0
+@test_broken 17.328679084777833f0 == 17.32868f0
+# TODO: fix @test_broken in *nix platforms, add more test
+
 # parsing complex numbers (#22250)
 @testset "complex parsing" begin
     for sign in ('-','+'), Im in ("i","j","im"), s1 in (""," "), s2 in (""," "), s3 in (""," "), s4 in (""," ")


### PR DESCRIPTION
ref: #49689
This pr tries to fix the precision problem when rounding doubles to floats on *nix platforms.
The rounding problem on the windows platform will be fixed in the next pr.

indirect conversion (string->double->float) will lose precision



**before pr**

Version 1.10.0-DEV.1255 (2023-05-10) Commit e204e200df8

`julia --lisp`
```
> (string->number "17.328679084777833")
17.32867908477783

> (float (string->number "17.328679084777833"))
17.328678f

> (string->number "17.328679084777833f0")
17.328678f

> (float (string->number "17.328679084777833f0"))
17.328678f
```
`julia`
```
julia> 17.328679084777833f0
17.328678f0

julia> 17.328679084777833f0 == 17.32868f0
false
```

**after pr**

`julia --lisp`
```
> (string->number "17.328679084777833")
17.32867908477783

> (float (string->number "17.328679084777833"))
17.328678f

> (string->number "17.328679084777833f0")
17.32868f

> (float (string->number "17.328679084777833f0"))
17.32868f
```
- [ ] fix `(float xxxx)`?

`julia`
```
julia> 17.328679084777833f0
17.328678f0

julia> 17.328679084777833f0 == 17.32868f0
false
```
- [ ] fix rounding for `17.328679084777833f0`

