### PR TITLE
allow loading extensions when a trigger is loaded from below the parent's load path

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -635,10 +635,10 @@ function manifest_deps_get(env::String, where::PkgId, name::String)::Union{Nothi
                     if wuuid !== nothing
                         return PkgId(UUID(wuuid), name)
                     end
-                    # ... and they can load same deps as the project itself
-                    mby_uuid = explicit_project_deps_get(project_file, name)
-                    mby_uuid === nothing || return PkgId(mby_uuid, name)
                 end
+                # ... and they can load same deps as the project itself
+                mby_uuid = explicit_project_deps_get(project_file, name)
+                mby_uuid === nothing || return PkgId(mby_uuid, name)
             end
         end
         # look for manifest file and `where` stanza

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1056,8 +1056,6 @@ end
         envs = [joinpath(@__DIR__, "project", "Extensions", "EnvWithHasExtensionsv2"), joinpath(@__DIR__, "project", "Extensions", "EnvWithHasExtensions")]
         cmd = addenv(```$(Base.julia_cmd()) --startup-file=no -e '
         begin
-
-
             push!(empty!(DEPOT_PATH), '$(repr(depot_path))')
             using HasExtensions
             using ExtDep
@@ -1067,6 +1065,22 @@ end
         '
         ```, "JULIA_LOAD_PATH" => join(envs, sep))
         @test success(cmd)
+
+        test_ext_proj = """
+        begin
+            using HasExtensions
+            using ExtDep
+            Base.get_extension(HasExtensions, :Extension) isa Module || error("expected extension to load")
+            using ExtDep2
+            Base.get_extension(HasExtensions, :ExtensionFolder) isa Module || error("expected extension to load")
+        end
+        """
+        for compile in (`--compiled-modules=no`, ``)
+            cmd_proj_ext = `$(Base.julia_cmd()) $compile --startup-file=no -e $test_ext_proj`
+            proj = joinpath(@__DIR__, "project", "Extensions")
+            cmd_proj_ext = addenv(cmd_proj_ext, "JULIA_LOAD_PATH" => join([joinpath(proj, "HasExtensions.jl"), joinpath(proj, "EnvWithDeps")], sep))
+            run(cmd_proj_ext)
+        end
     finally
         try
             rm(depot_path, force=true, recursive=true)

--- a/test/project/Extensions/EnvWithDeps/Manifest.toml
+++ b/test/project/Extensions/EnvWithDeps/Manifest.toml
@@ -1,0 +1,21 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.9.0-rc3"
+manifest_format = "2.0"
+project_hash = "ec25ff8df3a5e2212a173c3de2c7d716cc47cd36"
+
+[[deps.ExtDep]]
+deps = ["SomePackage"]
+path = "../ExtDep.jl"
+uuid = "fa069be4-f60b-4d4c-8b95-f8008775090c"
+version = "0.1.0"
+
+[[deps.ExtDep2]]
+path = "../ExtDep2"
+uuid = "55982ee5-2ad5-4c40-8cfe-5e9e1b01500d"
+version = "0.1.0"
+
+[[deps.SomePackage]]
+path = "../SomePackage"
+uuid = "678608ae-7bb3-42c7-98b1-82102067a3d8"
+version = "0.1.0"

--- a/test/project/Extensions/EnvWithDeps/Project.toml
+++ b/test/project/Extensions/EnvWithDeps/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+ExtDep = "fa069be4-f60b-4d4c-8b95-f8008775090c"
+ExtDep2 = "55982ee5-2ad5-4c40-8cfe-5e9e1b01500d"
+SomePackage = "678608ae-7bb3-42c7-98b1-82102067a3d8"


### PR DESCRIPTION
@topolarity has convinced me that this makes sense.

As it is right now, an extension gets loaded only if the trigger is above (or at the same place) as the parent in the load path. 
This is kind of a symmetry break because, from the extension's point of view, there isn't really any difference between the parent and one of the triggers. Both of these are just dependencies.
The extension could be shifted from the parent to the trigger without any change of functionality.
So then why does code loading differ between these two cases?

With this PR, the extension will load no matter the relationship of load paths between the parent and triggers.

This also avoids the complication in https://github.com/JuliaLang/julia/pull/49681.

cc @vtjnash, @topolarity 

~Also, a TODO is that extensions should probably be loadable if the parent is the active project (which would need to add some code to look up extensions in Project.toml files, right now it only looks in `Manifest.toml`). Fortunately, I envisioned maybe having to do this so I saved some code I ripped out earlier that implements this: https://gist.github.com/KristofferC/e5c9e80db0f056ab1f72714c46477a02.~

^Done

Fixes https://github.com/JuliaLang/julia/issues/49656