### PR TITLE
Do not reallocate on sizehint to same size

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -1161,7 +1161,7 @@ JL_DLLEXPORT void jl_array_sizehint(jl_array_t *a, size_t sz)
     if (sz <= a->maxsize) {
         size_t dec = a->maxsize - sz;
         //if we don't save at least an eighth of maxsize then its not worth it to shrink
-        if (dec < a->maxsize / 8) return;
+        if (dec <= a->maxsize / 8) return;
         jl_array_shrink(a, dec);
     }
     else {


### PR DESCRIPTION
The sizehint! code currently do not reallocate when sizehinting to a smaller size if 1/8th or fewer elements will be freed. However, the check rounds down, so an array of size e.g. 3 resized to size 3 will "free" 1/8th of the elements, namely zero elements, needlessly resizing.
This commit changes the check to only reallocate if MORE than 1/8th of elements will be freed.

Close #49695