### PR TITLE
Add `@eval using REPL` to the `atreplinit` do block in REPL documentation.

### DIFF
--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -623,7 +623,7 @@ It is possible to get an interface which is similar to the IPython REPL and the 
 
 ```julia
 atreplinit() do repl
-    @eval using REPL
+    @eval import REPL
     if !isdefined(repl, :interface)
         repl.interface = REPL.setup_interface(repl)
     end

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -623,6 +623,7 @@ It is possible to get an interface which is similar to the IPython REPL and the 
 
 ```julia
 atreplinit() do repl
+    @eval using REPL
     if !isdefined(repl, :interface)
         repl.interface = REPL.setup_interface(repl)
     end


### PR DESCRIPTION
This commit adds `@eval import REPL` to the `atreplinit` do block. This way, users that are linked to that particular section of the documentation, can copy paste the code into their `startup.jl` and it will work.

Without this, I was getting ``UndefVarError: `REPL` not defined`` when opening the Julia prompt.