### PR TITLE
Excise support for LLVM 13

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -9,11 +9,7 @@
 #include <llvm/Analysis/TargetLibraryInfo.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/IR/DataLayout.h>
-#if JL_LLVM_VERSION >= 140000
 #include <llvm/MC/TargetRegistry.h>
-#else
-#include <llvm/Support/TargetRegistry.h>
-#endif
 #include <llvm/Target/TargetMachine.h>
 
 // analysis passes

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -958,10 +958,8 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
     // copy module properties that should always match
     Mod->setTargetTriple(jl_Module->getTargetTriple());
     Mod->setDataLayout(jl_Module->getDataLayout());
-#if JL_LLVM_VERSION >= 130000
     Mod->setStackProtectorGuard(jl_Module->getStackProtectorGuard());
     Mod->setOverrideStackAlignment(jl_Module->getOverrideStackAlignment());
-#endif
 
     // verify the definition
     Function *def = Mod->getFunction(ir_name);
@@ -1097,11 +1095,7 @@ std::string generate_func_sig(const char *fname)
             abi->use_sret(jl_voidpointer_type, LLVMCtx);
         }
         else if (abi->use_sret((jl_datatype_t*)rt, LLVMCtx)) {
-#if JL_LLVM_VERSION >= 140000
             AttrBuilder retattrs(LLVMCtx);
-#else
-            AttrBuilder retattrs;
-#endif
             if (!ctx->TargetTriple.isOSWindows()) {
                 // llvm used to use the old mingw ABI, skipping this marking works around that difference
                 retattrs.addStructRetAttr(lrt);
@@ -1120,11 +1114,7 @@ std::string generate_func_sig(const char *fname)
     }
 
     for (size_t i = 0; i < nccallargs; ++i) {
-#if JL_LLVM_VERSION >= 140000
         AttrBuilder ab(LLVMCtx);
-#else
-        AttrBuilder ab;
-#endif
         jl_value_t *tti = jl_svecref(at, i);
         Type *t = NULL;
         bool isboxed;

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -92,11 +92,7 @@
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/NativeFormatting.h>
 #include <llvm/Support/SourceMgr.h>
-#if JL_LLVM_VERSION >= 140000
 #include <llvm/MC/TargetRegistry.h>
-#else
-#include <llvm/Support/TargetRegistry.h>
-#endif
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/raw_ostream.h>
 
@@ -883,16 +879,10 @@ static void jl_dump_asm_internal(
       TheTarget->createMCSubtargetInfo(TheTriple.str(), cpu, features));
     assert(STI && "Unable to create subtarget info!");
 
-#if JL_LLVM_VERSION >= 130000
     MCContext Ctx(TheTriple, MAI.get(), MRI.get(), STI.get(), &SrcMgr);
     std::unique_ptr<MCObjectFileInfo> MOFI(
       TheTarget->createMCObjectFileInfo(Ctx, /*PIC=*/false, /*LargeCodeModel=*/ false));
     Ctx.setObjectFileInfo(MOFI.get());
-#else
-    std::unique_ptr<MCObjectFileInfo> MOFI(new MCObjectFileInfo());
-    MCContext Ctx(MAI.get(), MRI.get(), MOFI.get(), &SrcMgr);
-    MOFI->InitMCObjectFileInfo(TheTriple, /* PIC */ false, Ctx);
-#endif
 
     std::unique_ptr<MCDisassembler> DisAsm(TheTarget->createMCDisassembler(*STI, Ctx));
     if (!DisAsm) {

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -12,9 +12,7 @@
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/ExecutionEngine/Orc/CompileUtils.h>
 #include <llvm/ExecutionEngine/Orc/ExecutionUtils.h>
-#if JL_LLVM_VERSION >= 130000
 #include <llvm/ExecutionEngine/Orc/ExecutorProcessControl.h>
-#endif
 #include <llvm/IR/Verifier.h>
 #include <llvm/Support/DynamicLibrary.h>
 #include <llvm/Support/FormattedStream.h>
@@ -26,11 +24,7 @@
 
 // target machine computation
 #include <llvm/CodeGen/TargetSubtargetInfo.h>
-#if JL_LLVM_VERSION >= 140000
 #include <llvm/MC/TargetRegistry.h>
-#else
-#include <llvm/Support/TargetRegistry.h>
-#endif
 #include <llvm/Target/TargetOptions.h>
 #include <llvm/Support/Host.h>
 #include <llvm/Support/TargetSelect.h>
@@ -44,9 +38,7 @@ using namespace llvm;
 #include "processor.h"
 
 #ifdef JL_USE_JITLINK
-# if JL_LLVM_VERSION >= 140000
-#  include <llvm/ExecutionEngine/Orc/DebuggerSupportPlugin.h>
-# endif
+# include <llvm/ExecutionEngine/Orc/DebuggerSupportPlugin.h>
 # include <llvm/ExecutionEngine/JITLink/EHFrameSupport.h>
 # include <llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h>
 # if JL_LLVM_VERSION >= 150000
@@ -817,11 +809,7 @@ public:
                 auto SecName = Sec.getName();
 #endif
                 // https://github.com/llvm/llvm-project/commit/118e953b18ff07d00b8f822dfbf2991e41d6d791
-#if JL_LLVM_VERSION >= 140000
                Info.SectionLoadAddresses[SecName] = jitlink::SectionRange(Sec).getStart().getValue();
-#else
-               Info.SectionLoadAddresses[SecName] = jitlink::SectionRange(Sec).getStart();
-#endif
             }
             return Error::success();
         });
@@ -863,9 +851,7 @@ public:
 // TODO: Port our memory management optimisations to JITLink instead of using the
 // default InProcessMemoryManager.
 std::unique_ptr<jitlink::JITLinkMemoryManager> createJITLinkMemoryManager() {
-#if JL_LLVM_VERSION < 140000
-    return std::make_unique<jitlink::InProcessMemoryManager>();
-#elif JL_LLVM_VERSION < 150000
+#if JL_LLVM_VERSION < 150000
     return cantFail(jitlink::InProcessMemoryManager::Create());
 #else
     return cantFail(orc::MapperJITLinkMemoryManager::CreateWithMapper<orc::InProcessMemoryMapper>());
@@ -875,17 +861,11 @@ std::unique_ptr<jitlink::JITLinkMemoryManager> createJITLinkMemoryManager() {
 
 # ifdef LLVM_SHLIB
 
-#  if JL_LLVM_VERSION >= 140000
-#   define EHFRAME_RANGE(name) orc::ExecutorAddrRange name
-#   define UNPACK_EHFRAME_RANGE(name) \
+# define EHFRAME_RANGE(name) orc::ExecutorAddrRange name
+# define UNPACK_EHFRAME_RANGE(name) \
         name.Start.toPtr<uint8_t *>(), \
         static_cast<size_t>(name.size())
-#  else
-#   define EHFRAME_RANGE(name) JITTargetAddress name##Addr, size_t name##Size
-#   define UNPACK_EHFRAME_RANGE(name) \
-        jitTargetAddressToPointer<uint8_t *>(name##Addr), \
-        name##Size
-#  endif
+
 
 class JLEHFrameRegistrar final : public jitlink::EHFrameRegistrar {
 public:
@@ -1019,19 +999,6 @@ namespace {
             TheTriple.setObjectFormat(Triple::ELF);
         }
         //options.PrintMachineCode = true; //Print machine code produced during JIT compiling
-#if JL_LLVM_VERSION < 130000
-        if (TheTriple.isOSWindows() && TheTriple.getArch() == Triple::x86) {
-            // tell Win32 to assume the stack is always 16-byte aligned,
-            // and to ensure that it is 16-byte aligned for out-going calls,
-            // to ensure compatibility with GCC codes
-            // In LLVM 13 and onwards this has turned into a module option
-            options.StackAlignmentOverride = 16;
-        }
-#endif
-#if defined(JL_DEBUG_BUILD) && JL_LLVM_VERSION < 130000
-        // LLVM defaults to tls stack guard, which causes issues with Julia's tls implementation
-        options.StackProtectorGuard = StackProtectorGuards::Global;
-#endif
 #if defined(MSAN_EMUTLS_WORKAROUND)
         options.EmulatedTLS = true;
         options.ExplicitEmulatedTLS = true;
@@ -1297,11 +1264,7 @@ int64_t ___asan_globals_registered;
 JuliaOJIT::JuliaOJIT()
   : TM(createTargetMachine()),
     DL(jl_create_datalayout(*TM)),
-#if JL_LLVM_VERSION >= 130000
     ES(cantFail(orc::SelfExecutorProcessControl::Create())),
-#else
-    ES(),
-#endif
     GlobalJD(ES.createBareJITDylib("JuliaGlobals")),
     JD(ES.createBareJITDylib("JuliaOJIT")),
     ContextPool([](){
@@ -1565,10 +1528,6 @@ StringRef JuliaOJIT::getFunctionAtAddress(uint64_t Addr, jl_code_instance_t *cod
 
 
 #ifdef JL_USE_JITLINK
-# if JL_LLVM_VERSION < 140000
-#  pragma message("JIT debugging (GDB integration) not available on LLVM < 14.0 (for JITLink)")
-void JuliaOJIT::enableJITDebuggingSupport() {}
-# else
 extern "C" orc::shared::CWrapperFunctionResult
 llvm_orc_registerJITLoaderGDBAllocAction(const char *Data, size_t Size);
 
@@ -1582,7 +1541,6 @@ void JuliaOJIT::enableJITDebuggingSupport()
     const auto Addr = ExecutorAddr::fromPtr(&llvm_orc_registerJITLoaderGDBAllocAction);
     ObjectLayer.addPlugin(std::make_unique<orc::GDBJITDebugInfoRegistrationPlugin>(Addr));
 }
-# endif
 #else
 void JuliaOJIT::enableJITDebuggingSupport()
 {

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -50,9 +50,6 @@
 // The sanitizers don't play well with our memory manager
 
 #if defined(_OS_DARWIN_) && defined(_CPU_AARCH64_) || defined(JL_FORCE_JITLINK) || JL_LLVM_VERSION >= 150000 && defined(HAS_SANITIZER)
-# if JL_LLVM_VERSION < 130000
-#  pragma message("On aarch64-darwin, LLVM version >= 13 is required for JITLink; fallback suffers from occasional segfaults")
-# endif
 # define JL_USE_JITLINK
 #endif
 

--- a/src/llvm-codegen-shared.h
+++ b/src/llvm-codegen-shared.h
@@ -316,125 +316,73 @@ using namespace llvm;
 
 inline void addFnAttr(CallInst *Target, Attribute::AttrKind Attr)
 {
-#if JL_LLVM_VERSION >= 140000
     Target->addFnAttr(Attr);
-#else
-    Target->addAttribute(AttributeList::FunctionIndex, Attr);
-#endif
 }
 
 template<class T, class A>
 inline void addRetAttr(T *Target, A Attr)
 {
-#if JL_LLVM_VERSION >= 140000
     Target->addRetAttr(Attr);
-#else
-    Target->addAttribute(AttributeList::ReturnIndex, Attr);
-#endif
 }
 
 inline void addAttributeAtIndex(Function *F, unsigned Index, Attribute Attr)
 {
-#if JL_LLVM_VERSION >= 140000
     F->addAttributeAtIndex(Index, Attr);
-#else
-    F->addAttribute(Index, Attr);
-#endif
 }
 
 inline AttributeSet getFnAttrs(const AttributeList &Attrs)
 {
-#if JL_LLVM_VERSION >= 140000
     return Attrs.getFnAttrs();
-#else
-    return Attrs.getFnAttributes();
-#endif
 }
 
 inline AttributeSet getRetAttrs(const AttributeList &Attrs)
 {
-#if JL_LLVM_VERSION >= 140000
     return Attrs.getRetAttrs();
-#else
-    return Attrs.getRetAttributes();
-#endif
 }
 
 inline bool hasFnAttr(const AttributeList &L, Attribute::AttrKind Kind)
 {
-#if JL_LLVM_VERSION >= 140000
     return L.hasFnAttr(Kind);
-#else
-    return L.hasAttribute(AttributeList::FunctionIndex, Kind);
-#endif
 }
 
 inline AttributeList addAttributeAtIndex(const AttributeList &L, LLVMContext &C,
                                          unsigned Index, Attribute::AttrKind Kind)
 {
-#if JL_LLVM_VERSION >= 140000
     return L.addAttributeAtIndex(C, Index, Kind);
-#else
-    return L.addAttribute(C, Index, Kind);
-#endif
 }
 
 inline AttributeList addAttributeAtIndex(const AttributeList &L, LLVMContext &C,
                                          unsigned Index, Attribute Attr)
 {
-#if JL_LLVM_VERSION >= 140000
     return L.addAttributeAtIndex(C, Index, Attr);
-#else
-    return L.addAttribute(C, Index, Attr);
-#endif
 }
 
 inline AttributeList addAttributesAtIndex(const AttributeList &L, LLVMContext &C,
                                           unsigned Index, const AttrBuilder &Builder)
 {
-#if JL_LLVM_VERSION >= 140000
     return L.addAttributesAtIndex(C, Index, Builder);
-#else
-    return L.addAttributes(C, Index, Builder);
-#endif
 }
 
 inline AttributeList addFnAttribute(const AttributeList &L, LLVMContext &C,
                                     Attribute::AttrKind Kind)
 {
-#if JL_LLVM_VERSION >= 140000
     return L.addFnAttribute(C, Kind);
-#else
-    return L.addAttribute(C, AttributeList::FunctionIndex, Kind);
-#endif
 }
 
 inline AttributeList addRetAttribute(const AttributeList &L, LLVMContext &C,
                                      Attribute::AttrKind Kind)
 {
-#if JL_LLVM_VERSION >= 140000
     return L.addRetAttribute(C, Kind);
-#else
-    return L.addAttribute(C, AttributeList::ReturnIndex, Kind);
-#endif
 }
 
 inline bool hasAttributesAtIndex(const AttributeList &L, unsigned Index)
 {
-#if JL_LLVM_VERSION >= 140000
     return L.hasAttributesAtIndex(Index);
-#else
-    return L.hasAttributes(Index);
-#endif
 }
 
 inline Attribute getAttributeAtIndex(const AttributeList &L, unsigned Index, Attribute::AttrKind Kind)
 {
-#if JL_LLVM_VERSION >= 140000
     return L.getAttributeAtIndex(Index, Kind);
-#else
-    return L.getAttribute(Index, Kind);
-#endif
 }
 
 // Iterate through uses of a particular type.

--- a/src/llvm-multiversioning.cpp
+++ b/src/llvm-multiversioning.cpp
@@ -543,12 +543,8 @@ static void clone_function(Function *F, Function *new_f, ValueToValueMapTy &vmap
         vmap[&*J] = &*DestI++;
     }
     SmallVector<ReturnInst*,8> Returns;
-#if JL_LLVM_VERSION >= 130000
     // We are cloning into the same module
     CloneFunctionInto(new_f, F, vmap, CloneFunctionChangeType::GlobalChanges, Returns);
-#else
-    CloneFunctionInto(new_f, F, vmap, true, Returns);
-#endif
 }
 
 static void add_features(Function *F, TargetSpec &spec)

--- a/src/llvm-remove-addrspaces.cpp
+++ b/src/llvm-remove-addrspaces.cpp
@@ -343,11 +343,7 @@ bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
         for (auto MD : MDs)
             NGV->addMetadata(
                     MD.first,
-#if JL_LLVM_VERSION >= 130000
                     *MapMetadata(MD.second, VMap));
-#else
-                    *MapMetadata(MD.second, VMap, RF_MoveDistinctMDs));
-#endif
 
         copyComdat(NGV, GV);
 
@@ -372,11 +368,7 @@ bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
                 NF,
                 F,
                 VMap,
-#if JL_LLVM_VERSION >= 130000
                 CloneFunctionChangeType::GlobalChanges,
-#else
-                /*ModuleLevelChanges=*/true,
-#endif
                 Returns,
                 "",
                 nullptr,
@@ -389,19 +381,10 @@ bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
         for (unsigned i = 0; i < Attrs.getNumAttrSets(); ++i) {
             for (Attribute::AttrKind TypedAttr :
                  {Attribute::ByVal, Attribute::StructRet, Attribute::ByRef}) {
-#if JL_LLVM_VERSION >= 140000
                 auto Attr = Attrs.getAttributeAtIndex(i, TypedAttr);
-#else
-                auto Attr = Attrs.getAttribute(i, TypedAttr);
-#endif
                 if (Type *Ty = Attr.getValueAsType()) {
-#if JL_LLVM_VERSION >= 140000
                     Attrs = Attrs.replaceAttributeTypeAtIndex(
                         C, i, TypedAttr, TypeRemapper.remapType(Ty));
-#else
-                    Attrs = Attrs.replaceAttributeType(
-                        C, i, TypedAttr, TypeRemapper.remapType(Ty));
-#endif
                     break;
                 }
             }

--- a/src/llvm-version.h
+++ b/src/llvm-version.h
@@ -10,8 +10,8 @@
 #define JL_LLVM_VERSION (LLVM_VERSION_MAJOR * 10000 + LLVM_VERSION_MINOR * 100 \
                         + LLVM_VERSION_PATCH)
 
-#if JL_LLVM_VERSION < 120000
-    #error Only LLVM versions >= 12.0.0 are supported by Julia
+#if JL_LLVM_VERSION < 140000
+    #error Only LLVM versions >= 14.0.0 are supported by Julia
 #endif
 
 #if JL_LLVM_VERSION >= 160000


### PR DESCRIPTION
As usual with the release for Julia 1.9 we will drop the code-paths for
the LLVM version used by the previous release (1.8) e.g. LLVM 13.