### PR TITLE
add a timing zone for `call_require`

### DIFF
--- a/src/timing.h
+++ b/src/timing.h
@@ -182,6 +182,7 @@ JL_DLLEXPORT void jl_timing_puts(jl_timing_block_t *cur_block, const char *str);
         X(CODEGEN_LLVM) \
         X(CODEGEN_Codeinst) \
         X(CODEGEN_Workqueue) \
+        X(LOAD_Require)               \
         X(LOAD_Sysimg) \
         X(LOAD_Pkgimg) \
         X(LOAD_Processor) \

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -461,6 +461,9 @@ static void body_attributes(jl_array_t *body, int *has_ccall, int *has_defs, int
 
 static jl_module_t *call_require(jl_module_t *mod, jl_sym_t *var) JL_GLOBALLY_ROOTED
 {
+    JL_TIMING(LOAD_IMAGE, LOAD_Require);
+    jl_timing_printf(JL_TIMING_DEFAULT_BLOCK, "%s", jl_symbol_name(var));
+
     static jl_value_t *require_func = NULL;
     int build_mode = jl_generating_output();
     jl_module_t *m = NULL;


### PR DESCRIPTION
This adds a zone that "grounds" all the `LOAD_Pkgimg`  Maybe it should be `LOAD_Require`?

![gnome-shell-screenshot-c7enl](https://github.com/JuliaLang/julia/assets/1282691/0518993a-ef44-4e52-bb3a-cc2fb53c094b)
