### PR TITLE
add a hash value to Typeofwrapper objects

### DIFF
--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -302,3 +302,11 @@ let t1 = Tuple{AbstractVector,AbstractVector{<:Integer},UnitRange{<:Integer}},
     @test hash(t1) == hash(t2)
     @test length(Set{Type}([t1, t2])) == 1
 end
+
+struct AUnionParam{T<:Union{Nothing,Float32,Float64}} end
+@test AUnionParam.body.hash == 0
+@test Type{AUnionParam}.hash != 0
+@test Type{AUnionParam{<:Union{Float32,Float64}}}.hash == 0
+@test Type{AUnionParam{<:Union{Nothing,Float32,Float64}}} === Type{AUnionParam}
+@test Type{AUnionParam.body}.hash == 0
+@test Type{Base.Broadcast.Broadcasted}.hash != 0


### PR DESCRIPTION
We probably should not do this, in full correctness, but the performance gain is too great to ignore. This is a very rare API mistake, but it occurred on a very popular constructor, making this very costly to construct a `Broadcasted`.

```
$ git grep 'struct.*<:Union{' base
base/broadcast.jl:struct Broadcasted{Style<:Union{Nothing,BroadcastStyle}, Axes, F, Args<:Tuple} <: Base.AbstractBroadcasted
base/compiler/ssair/ir.jl:struct InsertBefore{T<:Union{IRCode, IncrementalCompact}} <: Inserter
base/sort.jl:struct ScratchQuickSort{L<:Union{Integer,Missing}, H<:Union{Integer,Missing}, T<:Algorithm} <: Algorithm
```