### PR TITLE
Add note about references in `Out`

### DIFF
--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -646,6 +646,13 @@ Out[3]: Dict{Int64, Any} with 2 entries:
   1 => 8
 ```
 
+!!! note
+    Since all outputs from previous REPL evaluations are saved in the `Out` variable, one should be careful if they are returning many
+    large in-memory objects like arrays, since they will be protected from garbage collection so long as a reference to them remains in
+    `Out`. If you need to remove references to objects in `Out`, you can clear the entire history it stores with `empty!(Out)`, or clear
+    an individual entry with `Out[n] = nothing`.
+
+
 ## TerminalMenus
 
 TerminalMenus is a submodule of the Julia REPL and enables small, low-profile interactive menus in the terminal.


### PR DESCRIPTION
This is a common footgun with the whole `Out` thing, so it's good to warn people about it. E.g.
```julia
julia> using REPL

julia> REPL.numbered_prompt!()

In [3]: rand(1000, 1000);

In [4]: Base.summarysize(Out)
8000496

In [5]: rand(1000, 1000);

In [6]: Base.summarysize(Out)
16000544

In [7]: rand(1000, 1000);

In [8]: Base.summarysize(Out)
24000592

In [9]: rand(1000, 1000);

In [10]: Base.summarysize(Out)
32000640

In [11]: rand(1000, 1000);

In [12]: Base.summarysize(Out)
40000688
```
This is an easy way to run out of memory.

Prior art in https://julialang.github.io/IJulia.jl/dev/manual/usage/#Input-and-output-history