### PR TITLE
Fix thread safety in `atexit(f)`: Lock access to atexit_hooks

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -353,6 +353,7 @@ end
 const atexit_hooks = Callable[
     () -> Filesystem.temp_cleanup_purge(force=true)
 ]
+const _atexit_hooks_lock = ReentrantLock()
 
 """
     atexit(f)
@@ -374,7 +375,7 @@ calls `exit(n)`, then Julia will exit with the exit code corresponding to the
 last called exit hook that calls `exit(n)`. (Because exit hooks are called in
 LIFO order, "last called" is equivalent to "first registered".)
 """
-atexit(f::Function) = (pushfirst!(atexit_hooks, f); nothing)
+atexit(f::Function) = Base.@lock _atexit_hooks_lock (pushfirst!(atexit_hooks, f); nothing)
 
 function _atexit(exitcode::Cint)
     while !isempty(atexit_hooks)


### PR DESCRIPTION
- atexit(f) mutates global shared state.
- atexit(f) can be called anytime by any thread.
- Accesses & mutations to global shared state must be locked if they can be accessed from multiple threads.

Fixes #49746 