### PR TITLE
allow specializing `Base.hash` for enum types without overwriting method

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -21,6 +21,14 @@ Base.cconvert(::Type{T}, x::Enum{T2}) where {T<:Integer,T2<:Integer} = T(x)::T
 Base.write(io::IO, x::Enum{T}) where {T<:Integer} = write(io, T(x))
 Base.read(io::IO, ::Type{T}) where {T<:Enum} = T(read(io, basetype(T)))
 
+"""
+    _enum_hash(x::Enum, h::UInt)
+
+Compute hash for an enum value `x`. This internal method will be specialized
+for every enum type created through [`@enum`](@ref).
+"""
+_enum_hash(x::Enum, h::UInt) = hash(x, h)
+Base.hash(x::Enum, h::UInt) = _enum_hash(x, h)
 Base.isless(x::T, y::T) where {T<:Enum} = isless(basetype(T)(x), basetype(T)(y))
 
 Base.Symbol(x::Enum) = namemap(typeof(x))[Integer(x)]::Symbol
@@ -206,8 +214,12 @@ macro enum(T::Union{Symbol,Expr}, syms...)
         Enums.namemap(::Type{$(esc(typename))}) = $(esc(namemap))
         Base.typemin(x::Type{$(esc(typename))}) = $(esc(typename))($lo)
         Base.typemax(x::Type{$(esc(typename))}) = $(esc(typename))($hi)
-        let enum_hash = hash($(esc(typename)))
-            Base.hash(x::$(esc(typename)), h::UInt) = hash(enum_hash, hash(Integer(x), h))
+        let type_hash = hash($(esc(typename)))
+            # Use internal `_enum_hash` to allow users to specialize
+            # `Base.hash` for their own enum types without overwriting the
+            # method we would define here. This avoids a warning for
+            # precompilation.
+            Enums._enum_hash(x::$(esc(typename)), h::UInt) = hash(type_hash, hash(Integer(x), h))
         end
         let insts = (Any[ $(esc(typename))(v) for v in $values ]...,)
             Base.instances(::Type{$(esc(typename))}) = insts

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -179,6 +179,11 @@ end
 @enum HashEnum2 Enum2_a=1
 @test hash(Enum1_a) != hash(Enum2_a)
 
+# PR #49777: Check that `Base.hash` can be specialized by the user without
+# overwriting a method definition.
+@enum HashEnum3 Enum3_a=1
+@test which(hash, (HashEnum3, UInt)).sig != Tuple{typeof(hash), HashEnum3, UInt64}
+
 @test (Vector{Fruit}(undef, 3) .= apple) == [apple, apple, apple]
 
 # long, discongruous


### PR DESCRIPTION
Previously `@enum` defined `Base.hash(::MyEnumType, ::UInt)` on the user-defined enum type `MyEnumType`.
When the user wants to specialize the hash function for his own enum type he will define exactly that method signature again which overwrites it and leads to the warning

    WARNING: Method definition hash(TestPackage.MyEnumType, UInt64) in module TestPackage at Enums.jl:210 overwritten at [...]
      ** incremental compilation may be fatally broken for this module **

This commit changes `@enum` so that an internal method is used instead which is called through a fallback `Base.hash(::Enum, ::UInt)`.