### PR TITLE
Remove 1.9 package extension news item from NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,10 +61,6 @@ Standard library changes
 
 #### Package Manager
 
-* "Package Extensions": support for loading a piece of code based on other
-  packages being loaded in the Julia session.
-  This has similar applications as the Requires.jl package but also
-  supports precompilation and setting compatibility.
 * `Pkg.precompile` now accepts `timing` as a keyword argument which displays per package timing information for precompilation (e.g. `Pkg.precompile(timing=true)`)
 
 #### LinearAlgebra


### PR DESCRIPTION
This feature was already shipped with 1.9 so it probably shouldn't be mentioned a second time in the 1.10 NEWS.md.