### PR TITLE
Allow supplying custom "Expression" values to `@test`

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -485,10 +485,7 @@ Test Broken
 julia> @test 2 + 2 == 4 skip=false
 Test Passed
 
-julia> @test 2 == 4 skip=false
-Test Passed
-
-julia> 
+julia>
 ```
 
 !!! compat "Julia 1.7"


### PR DESCRIPTION
This looks extremely helpful to me when testing a lot of "generated" test cases, and does not seem to add much breakable code.

use-case:
```julia
for something in somethings
  x = tricky_f(something)
  @test looks_ok(x, something)
end
```

All reports in above code give a relatively boring outcome of "Expression `looks_ok(x, something)` is somehow broken."

With this patch, users may append the "explanation" as

```julia
  [...]
  @test looks_ok(x,something)  expr=:(looks_ok($x,$something))
  [...]
```
which gives much more desirable values, and the test report directly says e.g. "Expression `looks_ok(1,2)` is broken."

Hope this helps. :]
-mk

(cc @stelmo)