### PR TITLE
macroexpand: stop pre-running the hygiene pass

### DIFF
--- a/doc/src/base/reflection.md
+++ b/doc/src/base/reflection.md
@@ -87,7 +87,7 @@ be passed instead!). For example:
 
 ```jldoctest; setup = :(using InteractiveUtils)
 julia> InteractiveUtils.macroexpand(@__MODULE__, :(@edit println("")) )
-:(InteractiveUtils.edit(println, (Base.typesof)("")))
+:($(Expr(Symbol("hygienic-scope"), :(edit($(Expr(:escape, :println)), (Base.typesof)($(Expr(:escape, ""))))), InteractiveUtils)))
 ```
 
 The functions `Base.Meta.show_sexpr` and [`dump`](@ref) are used to display S-expr style views

--- a/src/ast.c
+++ b/src/ast.c
@@ -1255,7 +1255,6 @@ JL_DLLEXPORT jl_value_t *jl_macroexpand(jl_value_t *expr, jl_module_t *inmodule)
     JL_GC_PUSH1(&expr);
     expr = jl_copy_ast(expr);
     expr = jl_expand_macros(expr, inmodule, NULL, 0, jl_atomic_load_acquire(&jl_world_counter), 0);
-    expr = jl_call_scm_on_ast("jl-expand-macroscope", expr, inmodule);
     JL_GC_POP();
     return expr;
 }
@@ -1266,7 +1265,6 @@ JL_DLLEXPORT jl_value_t *jl_macroexpand1(jl_value_t *expr, jl_module_t *inmodule
     JL_GC_PUSH1(&expr);
     expr = jl_copy_ast(expr);
     expr = jl_expand_macros(expr, inmodule, NULL, 1, jl_atomic_load_acquire(&jl_world_counter), 0);
-    expr = jl_call_scm_on_ast("jl-expand-macroscope", expr, inmodule);
     JL_GC_POP();
     return expr;
 }

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -194,10 +194,6 @@
 (define (jl-expand-to-thunk-stmt expr file line)
   (expand-to-thunk-stmt- expr file line))
 
-(define (jl-expand-macroscope expr)
-  (error-wrap (lambda ()
-                (julia-expand-macroscope expr))))
-
 ;; construct default definitions of `eval` for non-bare modules
 ;; called by jl_eval_module_expr
 (define (module-default-defs name file line)


### PR DESCRIPTION
This prepares us to delete the separate hygiene pass, and make it part of lowering resolve-scopes. This affects a few macros which expect to run macroexpand then mangle the result more, and the result of those macros is not already wrapped in `esc()`. The damage seems relatively minor however, and generally a good improvement.