### PR TITLE
ensure all `isequal` methods to be inferred to return `Bool`

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -245,9 +245,9 @@ bswap(z::Complex) = Complex(bswap(real(z)), bswap(imag(z)))
 ==(z::Complex, x::Real) = isreal(z) && real(z) == x
 ==(x::Real, z::Complex) = isreal(z) && real(z) == x
 
-isequal(z::Complex, w::Complex) = isequal(real(z),real(w)) & isequal(imag(z),imag(w))
-isequal(z::Complex, w::Real) = isequal(real(z),w) & isequal(imag(z),zero(w))
-isequal(z::Real, w::Complex) = isequal(z,real(w)) & isequal(zero(z),imag(w))
+isequal(z::Complex, w::Complex) = isequal(real(z),real(w))::Bool & isequal(imag(z),imag(w))::Bool
+isequal(z::Complex, w::Real) = isequal(real(z),w)::Bool & isequal(imag(z),zero(w))::Bool
+isequal(z::Real, w::Complex) = isequal(z,real(w))::Bool & isequal(zero(z),imag(w))::Bool
 
 in(x::Complex, r::AbstractRange{<:Real}) = isreal(x) && real(x) in r
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -79,7 +79,7 @@ also implement [`<`](@ref) to ensure consistency of comparisons.
 ==
 
 """
-    isequal(x, y)
+    isequal(x, y) -> Bool
 
 Similar to [`==`](@ref), except for the treatment of floating point numbers
 and of missing values. `isequal` treats all floating-point `NaN` values as equal

--- a/base/pair.jl
+++ b/base/pair.jl
@@ -44,7 +44,7 @@ indexed_iterate(p::Pair, i::Int, state=1) = (getfield(p, i), i + 1)
 hash(p::Pair, h::UInt) = hash(p.second, hash(p.first, h))
 
 ==(p::Pair, q::Pair) = (p.first==q.first) & (p.second==q.second)
-isequal(p::Pair, q::Pair) = isequal(p.first,q.first) & isequal(p.second,q.second)
+isequal(p::Pair, q::Pair) = isequal(p.first,q.first)::Bool & isequal(p.second,q.second)::Bool
 
 isless(p::Pair, q::Pair) = ifelse(!isequal(p.first,q.first), isless(p.first,q.first),
                                                              isless(p.second,q.second))

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -80,7 +80,7 @@ end
     @test isapprox(missing, 1.0, atol=1e-6) === missing
     @test isapprox(1.0, missing, rtol=1e-6) === missing
 
-    @test !any(T -> T === Union{Missing,Bool}, Base.return_types(isequal, Tuple{Any,Any}))
+    @test all(==(Bool), Base.return_types(isequal, Tuple{Any,Any}))
 end
 
 @testset "arithmetic operators" begin

--- a/test/testhelpers/Furlongs.jl
+++ b/test/testhelpers/Furlongs.jl
@@ -74,7 +74,7 @@ for op in (:+, :-)
     end
 end
 for op in (:(==), :(!=), :<, :<=, :isless, :isequal)
-    @eval $op(x::Furlong{p}, y::Furlong{p}) where {p} = $op(x.val, y.val)
+    @eval $op(x::Furlong{p}, y::Furlong{p}) where {p} = $op(x.val, y.val)::Bool
 end
 for (f,op) in ((:_plus,:+),(:_minus,:-),(:_times,:*),(:_div,://))
     @eval function $f(v::T, ::Furlong{p}, ::Union{Furlong{q},Val{q}}) where {T,p,q}


### PR DESCRIPTION
This would help inference on `Core.Compiler.return_type(isequal, tt)` when `tt` is not well inferred (e.g. `tt` is inferred to `Tuple{Any,Any}`). (although JuliaLang/julia#46810 may disable this `Core.Compiler.return_type` improvement for good reasons).

Anyway, it is explicitly stated in the documentation that the `isequal` method should always return a value of `Bool`. So, not only does this annotation assist inference, it also serves to ensure the correctness of our code base, and therefore should be beneficial. We may need to take similar measures for `isless` and `isgreater` (in separate PRs).