### PR TITLE
Tracy: add source-code information to lowering and macro zones.

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -1017,6 +1017,7 @@ static jl_value_t *jl_invoke_julia_macro(jl_array_t *args, jl_module_t *inmodule
     margs[2] = (jl_value_t*)inmodule;
     for (i = 3; i < nargs; i++)
         margs[i] = jl_array_ptr_ref(args, i - 1);
+    jl_timing_show_macro(margs[0], margs[1], inmodule, JL_TIMING_DEFAULT_BLOCK);
 
     size_t last_age = ct->world_age;
     ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
@@ -1178,6 +1179,7 @@ JL_DLLEXPORT jl_value_t *jl_expand_in_world(jl_value_t *expr, jl_module_t *inmod
                                             const char *file, int line, size_t world)
 {
     JL_TIMING(LOWERING, LOWERING);
+    jl_timing_show_location(file, line, inmodule, JL_TIMING_DEFAULT_BLOCK);
     JL_GC_PUSH1(&expr);
     expr = jl_copy_ast(expr);
     expr = jl_expand_macros(expr, inmodule, NULL, 0, world, 1);
@@ -1191,6 +1193,7 @@ JL_DLLEXPORT jl_value_t *jl_expand_with_loc_warn(jl_value_t *expr, jl_module_t *
                                                  const char *file, int line)
 {
     JL_TIMING(LOWERING, LOWERING);
+    jl_timing_show_location(file, line, inmodule, JL_TIMING_DEFAULT_BLOCK);
     jl_array_t *kwargs = NULL;
     JL_GC_PUSH2(&expr, &kwargs);
     expr = jl_copy_ast(expr);

--- a/src/ast.c
+++ b/src/ast.c
@@ -1017,7 +1017,6 @@ static jl_value_t *jl_invoke_julia_macro(jl_array_t *args, jl_module_t *inmodule
     margs[2] = (jl_value_t*)inmodule;
     for (i = 3; i < nargs; i++)
         margs[i] = jl_array_ptr_ref(args, i - 1);
-    jl_timing_show_macro(margs[0], margs[1], inmodule, JL_TIMING_DEFAULT_BLOCK);
 
     size_t last_age = ct->world_age;
     ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
@@ -1032,6 +1031,7 @@ static jl_value_t *jl_invoke_julia_macro(jl_array_t *args, jl_module_t *inmodule
             jl_method_error(margs[0], &margs[1], nargs, ct->world_age);
             // unreachable
         }
+        jl_timing_show_macro(mfunc, margs[1], inmodule, JL_TIMING_DEFAULT_BLOCK);
         *ctx = mfunc->def.method->module;
         result = jl_invoke(margs[0], &margs[1], nargs - 1, mfunc);
     }

--- a/src/timing.c
+++ b/src/timing.c
@@ -256,13 +256,11 @@ JL_DLLEXPORT void jl_timing_show_func_sig(jl_value_t *v, jl_timing_block_t *cur_
 
 JL_DLLEXPORT void jl_timing_show_macro(jl_method_instance_t *macro, jl_value_t* lno, jl_module_t* mod, jl_timing_block_t *cur_block)
 {
-#ifdef USE_TRACY
     jl_timing_printf(cur_block, "%s", jl_symbol_name(macro->def.method->name));
     assert(jl_typetagis(lno, jl_linenumbernode_type));
     jl_timing_show_location(jl_symbol_name((jl_sym_t*)jl_fieldref(lno, 1)),
                             jl_unbox_int64(jl_fieldref(lno, 0)),
                             mod, cur_block);
-#endif
 }
 
 JL_DLLEXPORT void jl_timing_printf(jl_timing_block_t *cur_block, const char *format, ...)

--- a/src/timing.c
+++ b/src/timing.c
@@ -205,23 +205,37 @@ JL_DLLEXPORT void jl_timing_show_filename(const char *path, jl_timing_block_t *c
 #endif
 }
 
+JL_DLLEXPORT void jl_timing_show_location(const char *file, int line, jl_module_t* mod, jl_timing_block_t *cur_block)
+{
+#ifdef USE_TRACY
+    jl_module_t *root = jl_module_root(mod);
+    if (root == mod || root == jl_main_module) {
+        jl_timing_printf(cur_block, "%s:%d in %s",
+                         gnu_basename(file),
+                         line,
+                         jl_symbol_name(mod->name));
+    } else {
+        // TODO: generalize to print the entire module hierarchy
+        jl_timing_printf(cur_block, "%s:%d in %s.%s",
+                         gnu_basename(file),
+                         line,
+                         jl_symbol_name(root->name),
+                         jl_symbol_name(mod->name));
+    }
+#endif
+}
+
 JL_DLLEXPORT void jl_timing_show_method_instance(jl_method_instance_t *mi, jl_timing_block_t *cur_block)
 {
     jl_timing_show_func_sig(mi->specTypes, cur_block);
     jl_method_t *def = mi->def.method;
-    jl_timing_printf(cur_block, "%s:%d in %s",
-                     gnu_basename(jl_symbol_name(def->file)),
-                     def->line,
-                     jl_symbol_name(def->module->name));
+    jl_timing_show_location(jl_symbol_name(def->file), def->line, def->module, cur_block);
 }
 
 JL_DLLEXPORT void jl_timing_show_method(jl_method_t *method, jl_timing_block_t *cur_block)
 {
     jl_timing_show((jl_value_t *)method, cur_block);
-    jl_timing_printf(cur_block, "%s:%d in %s",
-                    gnu_basename(jl_symbol_name(method->file)),
-                    method->line,
-                    jl_symbol_name(method->module->name));
+    jl_timing_show_location(jl_symbol_name(method->file), method->line, method->module, cur_block);
 }
 
 JL_DLLEXPORT void jl_timing_show_func_sig(jl_value_t *v, jl_timing_block_t *cur_block)
@@ -237,6 +251,22 @@ JL_DLLEXPORT void jl_timing_show_func_sig(jl_value_t *v, jl_timing_block_t *cur_
         memset(&buf.buf[IOS_INLSIZE - 3], '.', 3);
 
     TracyCZoneText(cur_block->tracy_ctx, buf.buf, buf.size);
+#endif
+}
+
+JL_DLLEXPORT void jl_timing_show_macro(jl_value_t *macro, jl_value_t* lno, jl_module_t* mod, jl_timing_block_t *cur_block)
+{
+#ifdef USE_TRACY
+    if (jl_is_symbol(macro)) {
+        jl_timing_printf(cur_block, "%s", jl_symbol_name((jl_sym_t*)macro));
+    } else {
+        // TODO: render e.g. `Expr(:(:), :Mod, :(Symbol("@Macro")))` as `Mod.@Macro
+        jl_timing_show(macro, cur_block);
+    }
+    assert(jl_typetagis(lno, jl_linenumbernode_type));
+    jl_timing_show_location(jl_symbol_name((jl_sym_t*)jl_fieldref(lno, 1)),
+                            jl_unbox_int64(jl_fieldref(lno, 0)),
+                            mod, cur_block);
 #endif
 }
 

--- a/src/timing.c
+++ b/src/timing.c
@@ -254,15 +254,10 @@ JL_DLLEXPORT void jl_timing_show_func_sig(jl_value_t *v, jl_timing_block_t *cur_
 #endif
 }
 
-JL_DLLEXPORT void jl_timing_show_macro(jl_value_t *macro, jl_value_t* lno, jl_module_t* mod, jl_timing_block_t *cur_block)
+JL_DLLEXPORT void jl_timing_show_macro(jl_method_instance_t *macro, jl_value_t* lno, jl_module_t* mod, jl_timing_block_t *cur_block)
 {
 #ifdef USE_TRACY
-    if (jl_is_symbol(macro)) {
-        jl_timing_printf(cur_block, "%s", jl_symbol_name((jl_sym_t*)macro));
-    } else {
-        // TODO: render e.g. `Expr(:(:), :Mod, :(Symbol("@Macro")))` as `Mod.@Macro
-        jl_timing_show(macro, cur_block);
-    }
+    jl_timing_printf(cur_block, "%s", jl_symbol_name(macro->def.method->name));
     assert(jl_typetagis(lno, jl_linenumbernode_type));
     jl_timing_show_location(jl_symbol_name((jl_sym_t*)jl_fieldref(lno, 1)),
                             jl_unbox_int64(jl_fieldref(lno, 0)),

--- a/src/timing.h
+++ b/src/timing.h
@@ -129,7 +129,7 @@ JL_DLLEXPORT void jl_timing_show_method_instance(jl_method_instance_t *mi, jl_ti
 JL_DLLEXPORT void jl_timing_show_method(jl_method_t *method, jl_timing_block_t *cur_block);
 JL_DLLEXPORT void jl_timing_show_func_sig(jl_value_t *v, jl_timing_block_t *cur_block);
 JL_DLLEXPORT void jl_timing_show_location(const char *file, int line, jl_module_t* mod, jl_timing_block_t *cur_block);
-JL_DLLEXPORT void jl_timing_show_macro(jl_value_t *macro, jl_value_t* lno, jl_module_t* mod, jl_timing_block_t *cur_block);
+JL_DLLEXPORT void jl_timing_show_macro(jl_method_instance_t *macro, jl_value_t* lno, jl_module_t* mod, jl_timing_block_t *cur_block);
 JL_DLLEXPORT void jl_timing_printf(jl_timing_block_t *cur_block, const char *format, ...);
 JL_DLLEXPORT void jl_timing_puts(jl_timing_block_t *cur_block, const char *str);
 

--- a/src/timing.h
+++ b/src/timing.h
@@ -78,6 +78,8 @@ extern JL_DLLEXPORT uint32_t jl_timing_print_limit;
 #define jl_timing_show_method_instance(mi, b)
 #define jl_timing_show_method(mi, b)
 #define jl_timing_show_func_sig(tt, b)
+#define jl_timing_show_location(file, line, mod, b)
+#define jl_timing_show_macro(macro, lno, mod, b)
 #define jl_timing_printf(b, f, ...)
 #define jl_timing_puts(b, s)
 #define jl_timing_init_task(t)
@@ -126,6 +128,8 @@ JL_DLLEXPORT void jl_timing_show_filename(const char *path, jl_timing_block_t *c
 JL_DLLEXPORT void jl_timing_show_method_instance(jl_method_instance_t *mi, jl_timing_block_t *cur_block);
 JL_DLLEXPORT void jl_timing_show_method(jl_method_t *method, jl_timing_block_t *cur_block);
 JL_DLLEXPORT void jl_timing_show_func_sig(jl_value_t *v, jl_timing_block_t *cur_block);
+JL_DLLEXPORT void jl_timing_show_location(const char *file, int line, jl_module_t* mod, jl_timing_block_t *cur_block);
+JL_DLLEXPORT void jl_timing_show_macro(jl_value_t *macro, jl_value_t* lno, jl_module_t* mod, jl_timing_block_t *cur_block);
 JL_DLLEXPORT void jl_timing_printf(jl_timing_block_t *cur_block, const char *format, ...);
 JL_DLLEXPORT void jl_timing_puts(jl_timing_block_t *cur_block, const char *str);
 


### PR DESCRIPTION
Trying to figure out why CUDA precompilation times are so slow. Most time seems to be spend parsing our library wrappers full of `@ccall`s.

<img width="661" alt="image" src="https://github.com/JuliaLang/julia/assets/383068/0738f1c4-1006-40b7-b954-32bc1596fab5">

<img width="664" alt="image" src="https://github.com/JuliaLang/julia/assets/383068/1fc40fd5-db7e-4f55-b5c8-fc576a269467">

It's very surprising to me that a relatively simple definition like https://github.com/JuliaGPU/CUDA.jl/blob/ad4e9b5c73b8471c4698a739dcbedb73b682c152/lib/cublas/libcublas.jl#L2382-L2389 takes 6ms in the parser. @JeffBezanson Is there anything obviously wrong with it? Any tips and tricks on how to profile or optimize?

x-ref https://github.com/JuliaGPU/CUDA.jl/issues/1684
