### PR TITLE
Simplify `mul!` dispatch

### DIFF
--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -97,6 +97,7 @@ inplace_adj_or_trans(::Type{<:Transpose}) = transpose!
 adj_or_trans_char(::T) where {T<:AbstractArray} = adj_or_trans_char(T)
 adj_or_trans_char(::Type{<:AbstractArray}) = 'N'
 adj_or_trans_char(::Type{<:Adjoint}) = 'C'
+adj_or_trans_char(::Type{<:Adjoint{<:Real}}) = 'T'
 adj_or_trans_char(::Type{<:Transpose}) = 'T'
 
 Base.dataids(A::Union{Adjoint, Transpose}) = Base.dataids(A.parent)


### PR DESCRIPTION
Guys, I saw the light, while I was struck by a thunder. Look what we can do! Let a generic `mul!` strip off potential `AdjOrTrans` wrappers, and peel off the actually data-storing array. With this design, it is crystal-clear what SparseArrays.jl, GPUArrays.jl and its surounding ecosystem need to overload. Not tons of `mul!`, but `generic_matmatmul!` with all three matrix arguments of their own(ed) kind: SparseMatrixCSC, CuArray, MtlArray etc. In this PR, we have 4(!) methods as follows:

```julia
julia> methods(LinearAlgebra.generic_matmatmul!, (Any, Any, Any, Any, Any, Any))
# 4 methods for generic function "generic_matmatmul!" from LinearAlgebra:
 [1] generic_matmatmul!(C::StridedMatrix{T}, tA, tB, A::StridedVecOrMat{T}, B::StridedVecOrMat{T}, _add::LinearAlgebra.MulAddMul) where T<:Union{Float32, Float64, ComplexF64, ComplexF32}
     @ ~/Documents/julia/usr/share/julia/stdlib/v1.10/LinearAlgebra/src/matmul.jl:349
 [2] generic_matmatmul!(C::StridedVecOrMat{Complex{T}}, tA, tB, A::StridedVecOrMat{Complex{T}}, B::StridedVecOrMat{T}, _add::MulAddMul=MulAddMul()) where {T<:BlasReal}
     @ ~/Documents/julia/usr/share/julia/stdlib/v1.10/LinearAlgebra/src/matmul.jl:411
 [3] generic_matmatmul!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix, _add::LinearAlgebra.MulAddMul)
     @ ~/Documents/julia/usr/share/julia/stdlib/v1.10/LinearAlgebra/src/matmul.jl:780
 [4] generic_matmatmul!(C::AbstractVecOrMat, tA, tB, A::AbstractVecOrMat, B::AbstractVecOrMat, _add::LinearAlgebra.MulAddMul)
     @ ~/Documents/julia/usr/share/julia/stdlib/v1.10/LinearAlgebra/src/matmul.jl:798
```

That should be really helpful in terms of package load times.