### PR TITLE
Change `reinterpret` docstring

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -542,11 +542,11 @@ unsafe_convert(::Type{T}, x::T) where {T<:Ptr} = x  # to resolve ambiguity with 
 unsafe_convert(::Type{P}, x::Ptr) where {P<:Ptr} = convert(P, x)
 
 """
-    reinterpret(type, A)
+    reinterpret(type, x)
 
-Change the type-interpretation of the binary data in the primitive type `A`
+Change the type-interpretation of the binary data in the primitive type `x`
 to that of the primitive type `type`.
-The size of `type` has to be the same as that of the type of `A`.
+The size of `type` has to be the same as that of the type of `x`.
 For example, `reinterpret(Float32, UInt32(7))` interprets the 4 bytes corresponding to `UInt32(7)` as a
 [`Float32`](@ref).
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -544,7 +544,7 @@ unsafe_convert(::Type{P}, x::Ptr) where {P<:Ptr} = convert(P, x)
 """
     reinterpret(type, x)
 
-Change the type-interpretation of the binary data in the primitive type `x`
+Change the type-interpretation of the binary data in the primitive value `x`
 to that of the primitive type `type`.
 The size of `type` has to be the same as that of the type of `x`.
 For example, `reinterpret(Float32, UInt32(7))` interprets the 4 bytes corresponding to `UInt32(7)` as a

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -38,13 +38,13 @@ struct ReinterpretArray{T,N,S,A<:AbstractArray{S},IsReshaped} <: AbstractArray{T
     ```jldoctest
     julia> reinterpret(Float32, UInt32[1 2 3 4 5])
     1×5 reinterpret(Float32, ::Matrix{UInt32}):
-    1.0f-45  3.0f-45  4.0f-45  6.0f-45  7.0f-45
+     1.0f-45  3.0f-45  4.0f-45  6.0f-45  7.0f-45
 
     julia> reinterpret(Complex{Int}, 1:6)
     3-element reinterpret(Complex{$Int}, ::UnitRange{$Int}):
-    1 + 2im
-    3 + 4im
-    5 + 6im
+     1 + 2im
+     3 + 4im
+     5 + 6im
     ```
     """
     function reinterpret(::Type{T}, a::A) where {T,N,S,A<:AbstractArray{S, N}}

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -26,7 +26,7 @@ struct ReinterpretArray{T,N,S,A<:AbstractArray{S},IsReshaped} <: AbstractArray{T
 
     global reinterpret
 
-    """
+    @doc """
         reinterpret(T::DataType, A::AbstractArray)
 
     Construct a view of the array with the same binary data as the given


### PR DESCRIPTION
`A` is a variable name that makes me think of an array, but this docstring entry is talking about scalars. `x` also matches the variable name used in the implementation.

`x` s a value, not a type, so I also changed the word "type" to "value"