### PR TITLE
Reduce allocations in `Base.merge!(d::AbstractDict, others...)`

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -216,10 +216,17 @@ Dict{Int64, Int64} with 3 entries:
 ```
 """
 function merge!(d::AbstractDict, others::AbstractDict...)
-    for other in others
-        if haslength(d) && haslength(other)
-            sizehint!(d, length(d) + length(other))
+    if haslength(d)
+        sz = length(d)
+        for other in others
+            if haslength(other)
+                sz += length(other)
+            end
         end
+        sizehint!(d, sz)
+    end
+
+    for other in others
         for (k,v) in other
             d[k] = v
         end


### PR DESCRIPTION
Previously, it was worried [0] that attempting to preallocate space beforehand would over-allocate and that it was better to incrementally allocate space as we merge multiple dictionaries together.  However, when benchmarked, it appears that this is not the case, due to the multiple `sizehint!()` calls causing repeated re-allocations.  In short, it's generally better to allocate once even if we overshoot the mark than to allocate N times, overshooting the mark by a small amount each time.

Benchmarking code follows:

```
using BenchmarkTools, Random

function dict_test(fs; share_factor = 0.1, num_keys = 1000, num_dicts = 1000, str_len = 20)
    shared_keys = [randstring(str_len) for _ in 1:num_keys]

    # Generate dict keys with the given share factor
    function gen_dict_keys()
        shared_idxs = randperm(num_keys)[1:floor(Int, share_factor*num_keys)]
        return vcat(
            shared_keys[shared_idxs],
            [randstring(str_len) for _ in 1:(num_keys - length(shared_idxs))]
        )
    end

    # Generate a bunch of dictionaries that share a certain proportion of their keys with eachother.
    dicts = [Dict(k => k for k in gen_dict_keys()) for _ in 1:num_dicts]

    benchmarks = []
    result = Base.merge(copy(dicts)...)
    for f in fs
        ds = copy(dicts)
        if f(ds...) != result
            @warn("Skipping $(f) as it is unfaithful!")
        end
        push!(benchmarks, @benchmark $(f)(dicts...) setup=(dicts = copy($(dicts))))
    end
    return benchmarks
end
```

[0] https://github.com/JuliaLang/julia/pull/44659#discussion_r829490902