### PR TITLE
forward `repeat(A, cts..)` to `repeat(A; kw..)`

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -353,7 +353,7 @@ julia> repeat([1, 2, 3], 2, 3)
 ```
 """
 function repeat(A::AbstractArray, counts...)
-    return _RepeatInnerOuter.repeat(A, outer=counts)
+    return repeat(A, outer=counts)
 end
 
 """

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -8,6 +8,9 @@ using .Main.InfiniteArrays
 isdefined(Main, :StructArrays) || @eval Main include("testhelpers/StructArrays.jl")
 using .Main.StructArrays
 
+isdefined(Main, :FillArrays) || @eval Main include("testhelpers/FillArrays.jl")
+using .Main.FillArrays
+
 A = rand(5,4,3)
 @testset "Bounds checking" begin
     @test checkbounds(Bool, A, 1, 1, 1) == true
@@ -1935,4 +1938,15 @@ f45952(x) = [x;;]
     A = zeros(2,2)
     @test_throws "invalid index: true of type Bool" isassigned(A, 1, true)
     @test_throws "invalid index: true of type Bool" isassigned(A, true)
+end
+
+@testset "repeat for FillArrays" begin
+    f = FillArrays.Fill(3, (4,))
+    @test repeat(f, 2) === FillArrays.Fill(3, (8,))
+    @test repeat(f, 2, 3) === FillArrays.Fill(3, (8, 3))
+    @test repeat(f, inner=(1,2), outer=(3,1)) === repeat(f, 3, 2) === FillArrays.Fill(3, (12,2))
+    f = FillArrays.Fill(3, (4, 2))
+    @test repeat(f, 2, 3) === FillArrays.Fill(3, (8, 6))
+    @test repeat(f, 2, 3, 4) === FillArrays.Fill(3, (8, 6, 4))
+    @test repeat(f, inner=(1,2), outer=(3,1)) === FillArrays.Fill(3, (12, 4))
 end

--- a/test/testhelpers/FillArrays.jl
+++ b/test/testhelpers/FillArrays.jl
@@ -32,4 +32,31 @@ end
 Base.show(io::IO, F::Fill) = print(io, "Fill($(F.value), $(F.size))")
 Base.show(io::IO, ::MIME"text/plain", F::Fill) = show(io, F)
 
+_first_or_one(t::Tuple) = t[1]
+_first_or_one(t::Tuple{}) = 1
+
+_match_size(sz::Tuple{}, inner::Tuple{}, outer::Tuple{}) = ()
+function _match_size(sz::Tuple, inner::Tuple, outer::Tuple)
+    t1 = (_first_or_one(sz), _first_or_one(inner), _first_or_one(outer))
+    t2 = _match_size(sz[2:end], inner[2:end], outer[2:end])
+    (t1, t2...)
+end
+
+function _repeat_size(sz::Tuple, inner::Tuple, outer::Tuple)
+    t = _match_size(sz, inner, outer)
+    map(*, getindex.(t, 1), getindex.(t, 2), getindex.(t, 3))
+end
+
+function Base.repeat(A::Fill; inner=ntuple(x->1, ndims(A)), outer=ntuple(x->1, ndims(A)))
+    Base.require_one_based_indexing(A)
+    length(inner) >= ndims(A) ||
+        throw(ArgumentError("number of inner repetitions $(length(inner)) cannot be "*
+            "less than number of dimensions of input array $(ndims(A))"))
+    length(outer) >= ndims(A) ||
+        throw(ArgumentError("number of outer repetitions $(length(outer)) cannot be "*
+            "less than number of dimensions of input array $(ndims(A))"))
+    sz = _repeat_size(size(A), Tuple(inner), Tuple(outer))
+    Fill(getindex_value(A), sz)
+end
+
 end


### PR DESCRIPTION
This would mean that custom array types that seek to extend `repeat` only need to add the method `repeat(A::CustomArray; kw...)`