### PR TITLE
Revert optimisations to `findall(f, ::AbstractArray{Bool})`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -2420,7 +2420,7 @@ end
 
 # Broadcasting is much faster for small testf, and computing
 # integer indices from logical index using findall has a negligible cost
-findall(testf::F, A::AbstractArray) where {F<:Function} = findall((testf.(A))::BitArray)
+findall(testf::F, A::AbstractArray) where {F<:Function} = findall(testf.(A))
 
 """
     findall(A)

--- a/base/array.jl
+++ b/base/array.jl
@@ -2482,9 +2482,7 @@ function _findall(f::Function, I::Vector, A::AbstractArray{Bool})
         cnt += f(v)
         cnt > len && return I
     end
-    # In case of impure f, this line could potentially be hit. In that case,
-    # we can't assume I is the correct length.
-    resize!(I, cnt - 1)
+    I
 end
 
 function _findall(f::Function, I::Vector, A::AbstractVector{Bool})
@@ -2493,13 +2491,13 @@ function _findall(f::Function, I::Vector, A::AbstractVector{Bool})
     len = length(I)
     while cnt ≤ len
         @inbounds I[cnt] = i
-        cnt += f(@inbounds A[i])
+        cnt += f(A[i])
         i = nextind(A, i)
     end
-    cnt - 1 == len ? I : resize!(I, cnt - 1)
+    I
 end
 
-findall(f::Function, A::AbstractArray{Bool}) = _findall(f, A)
+findall(f::Union{typeof(!), typeof(identity)}, A::AbstractArray{Bool}) = _findall(f, A)
 findall(f::Fix2{typeof(in)}, A::AbstractArray{Bool}) = _findall(f, A)
 findall(A::AbstractArray{Bool}) = _findall(identity, A)
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -2420,7 +2420,7 @@ end
 
 # Broadcasting is much faster for small testf, and computing
 # integer indices from logical index using findall has a negligible cost
-findall(testf::F, A::AbstractArray) where {F<:Function} = findall(testf.(A))
+findall(testf::F, A::AbstractArray) where {F<:Function} = findall((testf.(A))::BitArray)
 
 """
     findall(A)
@@ -2465,6 +2465,7 @@ Int64[]
 function findall(A)
     collect(first(p) for p in pairs(A) if last(p))
 end
+findall(A::AbstractArray) = findall(identity, A)
 
 findall(x::Bool) = x ? [1] : Vector{Int}()
 findall(testf::Function, x::Number) = testf(x) ? [1] : Vector{Int}()

--- a/base/array.jl
+++ b/base/array.jl
@@ -2466,41 +2466,6 @@ function findall(A)
     collect(first(p) for p in pairs(A) if last(p))
 end
 
-# Allocating result upfront is faster (possible only when collection can be iterated twice)
-function _findall(f::Function, A::AbstractArray{Bool})
-    n = count(f, A)
-    I = Vector{eltype(keys(A))}(undef, n)
-    isempty(I) && return I
-    _findall(f, I, A)
-end
-
-function _findall(f::Function, I::Vector, A::AbstractArray{Bool})
-    cnt = 1
-    len = length(I)
-    for (k, v) in pairs(A)
-        @inbounds I[cnt] = k
-        cnt += f(v)
-        cnt > len && return I
-    end
-    I
-end
-
-function _findall(f::Function, I::Vector, A::AbstractVector{Bool})
-    i = firstindex(A)
-    cnt = 1
-    len = length(I)
-    while cnt ≤ len
-        @inbounds I[cnt] = i
-        cnt += f(A[i])
-        i = nextind(A, i)
-    end
-    I
-end
-
-findall(f::Union{typeof(!), typeof(identity)}, A::AbstractArray{Bool}) = _findall(f, A)
-findall(f::Fix2{typeof(in)}, A::AbstractArray{Bool}) = _findall(f, A)
-findall(A::AbstractArray{Bool}) = _findall(identity, A)
-
 findall(x::Bool) = x ? [1] : Vector{Int}()
 findall(testf::Function, x::Number) = testf(x) ? [1] : Vector{Int}()
 findall(p::Fix2{typeof(in)}, x::Number) = x in p.x ? [1] : Vector{Int}()

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1683,7 +1683,6 @@ end
 @inline _toind(i1, irest::Tuple{}) = i1
 @inline _toind(i1, irest) = CartesianIndex(i1, irest...)
 
-
 function findall(B::BitArray)
     nnzB = count(B)
     I = Vector{eltype(keys(B))}(undef, nnzB)

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1683,6 +1683,7 @@ end
 @inline _toind(i1, irest::Tuple{}) = i1
 @inline _toind(i1, irest) = CartesianIndex(i1, irest...)
 
+
 function findall(B::BitArray)
     nnzB = count(B)
     I = Vector{eltype(keys(B))}(undef, nnzB)
@@ -1713,6 +1714,7 @@ end
 
 # For performance
 findall(::typeof(!iszero), B::BitArray) = findall(B)
+findall(::typeof(identity), B::BitArray) = findall(B)
 
 ## Reductions ##
 


### PR DESCRIPTION
In commit 4c4c94f, findall(f, A::AbstractArray{Bool}) was optimised by using a technique where A was traversed twice: Once to count the number of true elements and once to fill in the resulting vector.
However, this could cause problems for arbitrary functions f: For slow f, the approach is ~2x slower. For impure f, f being called twice could cause side effects and strange issues (see issue #46425)

With this commit, the optimised version is only dispatched to when f is ! or identity.

Note that this re-introduces the performance regression from #42187 by reverting some of the optimisation in https://github.com/JuliaLang/julia/pull/42202

Closes issue #46425