### PR TITLE
Docs: simple docstring for `write(filename::AbstractString, x)`

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -463,7 +463,7 @@ wait_close(io::AbstractPipe) = (wait_close(pipe_writer(io)::IO); wait_close(pipe
 
 Write the canonical binary representation of `content` to a file, which will be created if it does not exist yet or overwritten if it does exist.
 
-Return the number of bytes written into the stream.
+Return the number of bytes written into the file.
 """
 write(filename::AbstractString, a1, args...) = open(io->write(io, a1, args...), convert(String, filename)::String, "w")
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -224,7 +224,6 @@ read(stream, ::Type{Union{}}, slurp...; kwargs...) = error("cannot read a value 
 
 """
     write(io::IO, x)
-    write(filename::AbstractString, x)
 
 Write the canonical binary representation of a value to the given I/O stream or file.
 Return the number of bytes written into the stream. See also [`print`](@ref) to
@@ -458,6 +457,14 @@ wait_close(io::AbstractPipe) = (wait_close(pipe_writer(io)::IO); wait_close(pipe
 
 # Exception-safe wrappers (io = open(); try f(io) finally close(io))
 
+
+"""
+    write(filename::AbstractString, x)
+
+Write `x` to a file, which will be created if it does not exist yet.
+
+Return the number of bytes written into the stream.
+"""
 write(filename::AbstractString, a1, args...) = open(io->write(io, a1, args...), convert(String, filename)::String, "w")
 
 """

--- a/base/io.jl
+++ b/base/io.jl
@@ -461,7 +461,7 @@ wait_close(io::AbstractPipe) = (wait_close(pipe_writer(io)::IO); wait_close(pipe
 """
     write(filename::AbstractString, content)
 
-Write `content` to a file, which will be created if it does not exist yet.
+Write the canonical binary representation of `content` to a file, which will be created if it does not exist yet or overwritten if it does exist.
 
 Return the number of bytes written into the stream.
 """

--- a/base/io.jl
+++ b/base/io.jl
@@ -459,9 +459,9 @@ wait_close(io::AbstractPipe) = (wait_close(pipe_writer(io)::IO); wait_close(pipe
 
 
 """
-    write(filename::AbstractString, x)
+    write(filename::AbstractString, content)
 
-Write `x` to a file, which will be created if it does not exist yet.
+Write `content` to a file, which will be created if it does not exist yet.
 
 Return the number of bytes written into the stream.
 """


### PR DESCRIPTION
Point 2 of https://github.com/JuliaLang/julia/issues/43428.

I also changed "*the canonical binary representation of a value*" to just say "`x`". 
It felt like a very complex way of saying that it does what you think it does. 🙂 I think it's good to document it like this for the `write(io::IO, x)` method, but as I expressed in https://github.com/JuliaLang/julia/issues/43428, I think we should document the `write(filename::String, content)` method in a more beginner-friendly way.