### PR TITLE
Docs: simple docstring for `read(filename::AbstractString)`

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -461,14 +461,18 @@ wait_close(io::AbstractPipe) = (wait_close(pipe_writer(io)::IO); wait_close(pipe
 write(filename::AbstractString, a1, args...) = open(io->write(io, a1, args...), convert(String, filename)::String, "w")
 
 """
-    read(filename::AbstractString, args...)
+    read(filename::AbstractString)
 
-Open a file and read its contents. `args` is passed to `read`: this is equivalent to
-`open(io->read(io, args...), filename)`.
+Read the entire contents of a file as a `Vector{UInt8}`.
 
     read(filename::AbstractString, String)
 
 Read the entire contents of a file as a string.
+
+    read(filename::AbstractString, args...)
+
+Open a file and read its contents. `args` is passed to `read`: this is equivalent to
+`open(io->read(io, args...), filename)`.
 """
 read(filename::AbstractString, args...) = open(io->read(io, args...), convert(String, filename)::String)
 


### PR DESCRIPTION
As I expressed in https://github.com/JuliaLang/julia/issues/43428, I felt like the current documentation is not clear enough about the method `read(filename::AbstractString)`. 

In this PR I explicitly document this method on its own, without the `args...` option. I suspect that `args...` is distracting (now users need to understand `open` and `read(io)` before reading this docstring), and it might not be obvious that you can leave `args` empty.

Feel free to edit this PR directly!