### PR TITLE
Docs: file: list `read` and `write` again

### DIFF
--- a/doc/src/base/file.md
+++ b/doc/src/base/file.md
@@ -1,6 +1,8 @@
 # Filesystem
 
 ```@docs
+Base.read(::String)
+Base.write(::String, ::Any)
 Base.Filesystem.pwd
 Base.Filesystem.cd(::AbstractString)
 Base.Filesystem.cd(::Function)


### PR DESCRIPTION
Point 5 of https://github.com/JuliaLang/julia/issues/43428

Motivation: I feel like the most fundamental *file* operations in Julia are `read(filename::String)` and `write(filename::String, content)`, so it makes sense to repeat their documentation in the **Filesystem** documentation. I also see 
these methods as fundamental to teach beginners.


Like https://github.com/JuliaLang/julia/pull/49837, the goal is to only show short docstrings for these methods, not the whole `IOStream` functionality. So it depends on https://github.com/JuliaLang/julia/pull/49835 and https://github.com/JuliaLang/julia/pull/49836 to be useful :)