### PR TITLE
Don't depend on `CompilerSupportLibraries_jll` from `OpenBLAS_jll`

### DIFF
--- a/stdlib/OpenBLAS_jll/Project.toml
+++ b/stdlib/OpenBLAS_jll/Project.toml
@@ -3,6 +3,7 @@ uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
 version = "0.3.23+0"
 
 [deps]
+# See note in `src/OpenBLAS_jll.jl` about this dependency.
 CompilerSupportLibraries_jll = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -394,7 +394,7 @@ precompile_test_harness(false) do dir
             Dict(let m = Base.root_module(Base, s)
                      Base.PkgId(m) => Base.module_build_id(m)
                  end for s in
-                [:ArgTools, :Artifacts, :Base64, :CompilerSupportLibraries_jll, :CRC32c, :Dates,
+                [:ArgTools, :Artifacts, :Base64, :CRC32c, :Dates,
                  :Downloads, :FileWatching, :Future, :InteractiveUtils, :libblastrampoline_jll,
                  :LibCURL, :LibCURL_jll, :LibGit2, :Libdl, :LinearAlgebra,
                  :Logging, :Markdown, :Mmap, :MozillaCACerts_jll, :NetworkOptions, :OpenBLAS_jll, :Pkg, :Printf,


### PR DESCRIPTION
This is important because CSL_jll loads in many other libraries that we may or may not care that much about, such as `libstdc++` and `libgomp`.

We load `libstdc++` eagerly on Linux, so that will already be loaded in all cases that we care about, however on macOS we don't generally want that loaded, and this suppresses that.

`libgomp` is needed by BB-provided software that uses OpenMP during compilation, however it can conflict with software compiled by the Intel compilers, such as `MKL`.  It's best to allow MKL to load its OpenMP libraries first, so delaying loading `libgomp` until someone actually calls `using CompilerSupportLibraries_jll` is the right thing to do.

In the future, we want to rework JLLs such that libraries aren't eagerly loaded at JLL `__init__()` time, but rather they should be JIT loaded upon first usage of the library handle itself.  This would allow BB to emit much more fine-grained dependency structures, so that the distribution of a set of libraries can happen together, but the loading of said libraries would be independent.