### PR TITLE
add base64url in module Base64

### DIFF
--- a/stdlib/Base64/docs/src/index.md
+++ b/stdlib/Base64/docs/src/index.md
@@ -2,11 +2,10 @@
 
 ```@docs
 Base64.Base64
+Base64.Base64Format
 Base64.Base64EncodePipe
 Base64.base64encode
-Base64.base64urlencode
 Base64.Base64DecodePipe
 Base64.base64decode
-Base64.base64urldecode
 Base64.stringmime
 ```

--- a/stdlib/Base64/docs/src/index.md
+++ b/stdlib/Base64/docs/src/index.md
@@ -4,7 +4,9 @@
 Base64.Base64
 Base64.Base64EncodePipe
 Base64.base64encode
+Base64.base64urlencode
 Base64.Base64DecodePipe
 Base64.base64decode
+Base64.base64urldecode
 Base64.stringmime
 ```

--- a/stdlib/Base64/src/Base64.jl
+++ b/stdlib/Base64/src/Base64.jl
@@ -17,6 +17,9 @@ export
     Base64DecodePipe,
     base64decode,
     base64urldecode,
+    Base64Format,
+    BASE64,
+    BASE64URL,
     stringmime
 
 # Base64EncodePipe is a pipe-like IO object, which converts into base64 data

--- a/stdlib/Base64/src/Base64.jl
+++ b/stdlib/Base64/src/Base64.jl
@@ -13,8 +13,10 @@ using Base: require_one_based_indexing
 export
     Base64EncodePipe,
     base64encode,
+    base64urlencode,
     Base64DecodePipe,
     base64decode,
+    base64urldecode,
     stringmime
 
 # Base64EncodePipe is a pipe-like IO object, which converts into base64 data

--- a/stdlib/Base64/src/decode.jl
+++ b/stdlib/Base64/src/decode.jl
@@ -16,14 +16,13 @@ end
 const PADIND_DECODE = Int(ENCODEPADDING)+1
 BASE64_DECODE[PADIND_DECODE] = BASE64_CODE_PAD
 BASE64URL_DECODE[PADIND_DECODE] = BASE64_CODE_PAD
+const TABLE_DECODE = hcat(BASE64_DECODE, BASE64URL_DECODE)
 
-const TABLE_DECODE = vcat(BASE64_DECODE, BASE64URL_DECODE)
-
-decodeonechar(x::UInt8, decode::Base64Format) = @inbounds return TABLE_DECODE[(x | (UInt16(decode) << 8)) + 1]
-decodeonechar(x::UInt8, decode::UInt8) = @inbounds return TABLE_DECODE[(x | (UInt16(decode) << 8)) + 1]
+decodeonechar(x::UInt8, decode::Base64Format) = @inbounds return TABLE_DECODE[x + 1, UInt8(decode)]
+decodeonechar(x::UInt8, decode::UInt8) = @inbounds return TABLE_DECODE[x + 1, decode]
 
 """
-    Base64DecodePipe(istream; decode=BASE64)
+    Base64DecodePipe(istream; decode::Base64Format=BASE64)
 
 Return a new read-only I/O stream, which decodes base64-encoded data read from
 `istream`.
@@ -54,7 +53,7 @@ struct Base64DecodePipe <: IO
     decode::Base64Format
     rest::Vector{UInt8}
 
-    function Base64DecodePipe(io::IO; decode=BASE64)
+    function Base64DecodePipe(io::IO; decode::Base64Format=BASE64)
         buffer = Buffer(512)
         return new(io, buffer, decode, UInt8[])
     end

--- a/stdlib/Base64/src/encode.jl
+++ b/stdlib/Base64/src/encode.jl
@@ -3,7 +3,7 @@
 # Generate encode table.
 const BASE64_ENCODE = [UInt8(x) for x in append!(['A':'Z'; 'a':'z'; '0':'9'], ['+', '/'])]
 const BASE64URL_ENCODE = [UInt8(x) for x in append!(['A':'Z'; 'a':'z'; '0':'9'], ['-', '_'])]
-const TABLE_ENCODE = vcat(BASE64_ENCODE, BASE64URL_ENCODE)
+const TABLE_ENCODE = hcat(BASE64_ENCODE, BASE64URL_ENCODE)
 
 const ENCODEPADDING  = UInt8('=')
 
@@ -15,12 +15,12 @@ Enum to declare encoding and decoding format.
 + `BASE64`: Stands for Base64 format.
 + `BASE64URL`: Stands for Base64URL format.
 """
-@enum Base64Format::UInt8 BASE64=0 BASE64URL=1
+@enum Base64Format::UInt8 BASE64=1 BASE64URL=2
 
-encodeonechar(x::UInt8, encode::Base64Format) = @inbounds return TABLE_ENCODE[((x & 0x3f) | (UInt8(encode) << 6)) + 1]
+encodeonechar(x::UInt8, encode::Base64Format) = @inbounds return TABLE_ENCODE[(x & 0x3f) + 1, UInt8(encode)]
 
 """
-    Base64EncodePipe(ostream; encode=BASE64, padding::Bool=true)
+    Base64EncodePipe(ostream; encode::Base64Format=BASE64, padding::Bool=true)
 
 Return a new write-only I/O stream, which converts any bytes written to it into
 base64-encoded ASCII bytes written to `ostream`.  Calling [`close`](@ref) on the
@@ -56,7 +56,7 @@ struct Base64EncodePipe <: IO
     encode::Base64Format
     padding::Bool
 
-    function Base64EncodePipe(io::IO; encode=BASE64, padding::Bool=true)
+    function Base64EncodePipe(io::IO; encode::Base64Format=BASE64, padding::Bool=true)
         # The buffer size must be at least 3.
         buffer = Buffer(512)
         return new(io, buffer, encode, padding)

--- a/stdlib/Base64/test/runtests.jl
+++ b/stdlib/Base64/test/runtests.jl
@@ -2,12 +2,12 @@
 
 using Test, Random
 import Base64:
+    BASE64,
+    BASE64URL,
     Base64EncodePipe,
     base64encode,
-    base64urlencode,
     Base64DecodePipe,
     base64decode,
-    base64urldecode,
     stringmime
 
 const inputText = "Man is distinguished, not only by his reason, but by this singular passion from other animals, which is a lust of the mind, that by a perseverance of delight in the continued and indefatigable generation of knowledge, exceeds the short vehemence of any carnal pleasure."
@@ -107,7 +107,7 @@ const longDecodedText = "name = \"Genie\"\nuuid = \"c43c736e-a2d1-11e8-161f-af95
 
     # no padding
     @test base64encode("abcd", padding=false) == "YWJjZA"
-    @test base64urlencode("abcde", padding=false) == "YWJjZGU"
+    @test base64encode("abcde", encode=BASE64URL, padding=false) == "YWJjZGU"
 end
 
 @testset "Random data" begin
@@ -119,14 +119,14 @@ end
         @test hash(base64decode(enc64)) == hashv
 
         # base64url
-        enc64url = base64urlencode(data)
+        enc64url = base64encode(data, encode=BASE64URL)
         @test enc64url == replace(enc64, '+' => '-', '/' => '_')
-        @test hash(base64urldecode(enc64url)) == hashv
+        @test hash(base64decode(enc64url, decode=BASE64URL)) == hashv
 
         # padding character should not appear
         enc64nopad = base64encode(data, padding=false)
         @test length(data) == 0 || !('=' in enc64nopad[end-1:end])
-        @test length(data) == 0 || !('=' in base64urlencode(data, padding=false)[end-1:end])
+        @test length(data) == 0 || !('=' in base64encode(data, encode=BASE64URL, padding=false)[end-1:end])
 
         # encoded string without padding can be decoded
         @test hashv == hash(base64decode(enc64nopad))


### PR DESCRIPTION
This PR introduces base64url and base64/base64url encoding with no padding to Base64 module.

Implementing base64url in stdlib has been discussed in Julia Discourse,
https://discourse.julialang.org/t/support-for-urlsafe-alphabets-in-base64/4065
and more recently, in #49060.
A PR that implements base64url, #29318, was once made, but was closed before being merged (this was done before Issue #49060 was made, and I am afraid I do not know well the background and reasons why the PR was not merged). Therefore, I still think it is good to have base64url in stdlib/Base64.

This PR adds base64url and an option to enable/disable padding, which can be used along with base64url, as mentioned in RFC4648.

Implementation style is not so different from that of #29318, and thus I would similarly show the result of some benchmarks to show that severe performance regressions were not found so far.

In the code block below original Base64 module is referred to as `Base64` and the one with this PR as `Base64url`.

```julia
julia> @benchmark Base64.base64decode(dectest)

BenchmarkTools.Trial: 10000 samples with 28 evaluations.
 Range (min … max):  878.571 ns … 82.350 μs  ┊ GC (min … max): 0.00% … 98.06%
 Time  (median):     975.000 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):     1.257 μs ±  2.541 μs  ┊ GC (mean ± σ):  7.05% ±  3.65%

 Memory estimate: 2.30 KiB, allocs estimate: 31.

julia> @benchmark Base64url.base64decode(dectest)

BenchmarkTools.Trial: 10000 samples with 38 evaluations.
 Range (min … max):  902.632 ns … 75.274 μs  ┊ GC (min … max): 0.00% … 97.06%
 Time  (median):     973.684 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):     1.310 μs ±  2.539 μs  ┊ GC (mean ± σ):  8.17% ±  4.24%

 Memory estimate: 2.30 KiB, allocs estimate: 31.

julia> @benchmark Base64.base64encode(enctest)

BenchmarkTools.Trial: 10000 samples with 178 evaluations.
 Range (min … max):  584.831 ns … 636.268 μs  ┊ GC (min … max):  0.00% … 96.53%
 Time  (median):     616.854 ns               ┊ GC (median):     0.00%
 Time  (mean ± σ):     1.430 μs ±  12.126 μs  ┊ GC (mean ± σ):  42.82% ±  5.80%

 Memory estimate: 1.11 KiB, allocs estimate: 10.

julia> @benchmark Base64url.base64encode(enctest)

BenchmarkTools.Trial: 10000 samples with 183 evaluations.
 Range (min … max):  569.399 ns … 709.499 μs  ┊ GC (min … max):  0.00% … 97.79%
 Time  (median):     618.579 ns               ┊ GC (median):     0.00%
 Time  (mean ± σ):     1.445 μs ±  12.803 μs  ┊ GC (mean ± σ):  44.52% ±  5.87%

 Memory estimate: 1.11 KiB, allocs estimate: 10.

julia> @benchmark Base64url.base64encode(enctest, padding=false)

BenchmarkTools.Trial: 10000 samples with 182 evaluations.
 Range (min … max):  561.538 ns … 690.309 μs  ┊ GC (min … max):  0.00% … 97.50%
 Time  (median):     601.099 ns               ┊ GC (median):     0.00%
 Time  (mean ± σ):     1.429 μs ±  12.433 μs  ┊ GC (mean ± σ):  44.12% ±  5.87%

 Memory estimate: 1.11 KiB, allocs estimate: 10.
```

This PR also includes minor fix in function argument type (`(f::Function, ...)` to `(f::F, ...) where {F<:Function}`), which slightly improves encoding performance from above results.