### PR TITLE
Docs: add examples to `istril`/`istriu` docstrings

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1281,16 +1281,32 @@ false
 julia> istriu(a, -1)
 true
 
-julia> b = [1 im; 0 -1]
-2×2 Matrix{Complex{Int64}}:
- 1+0im   0+1im
- 0+0im  -1+0im
+julia> b = [1 1 1; 0 1 1; 0 0 1]
+3×3 Matrix{Int64}:
+ 1  1  1
+ 0  1  1
+ 0  0  1
 
 julia> istriu(b)
 true
 
 julia> istriu(b, 1)
 false
+
+julia> istriu(b, -1)
+true
+
+julia> c = [1 1 1; 1 1 1; 0 1 1]
+3×3 Matrix{Int64}:
+ 1  1  1
+ 1  1  1
+ 0  1  1
+
+julia> istriu(c)
+false
+
+julia> istriu(c, -1)
+true
 ```
 """
 function istriu(A::AbstractMatrix, k::Integer = 0)
@@ -1325,16 +1341,32 @@ false
 julia> istril(a, 1)
 true
 
-julia> b = [1 0; -im -1]
-2×2 Matrix{Complex{Int64}}:
- 1+0im   0+0im
- 0-1im  -1+0im
+julia> b = [1 0 0; 1 1 0; 1 1 1]
+3×3 Matrix{Int64}:
+ 1  0  0
+ 1  1  0
+ 1  1  1
 
 julia> istril(b)
 true
 
 julia> istril(b, -1)
 false
+
+julia> istril(b, 1)
+true
+
+julia> c = [1 1 0; 1 1 1; 1 1 1]
+3×3 Matrix{Int64}:
+ 1  1  0
+ 1  1  1
+ 1  1  1
+
+julia> istril(c)
+false
+
+julia> istril(c, 1)
+true
 ```
 """
 function istril(A::AbstractMatrix, k::Integer = 0)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1270,7 +1270,7 @@ Test whether `A` is upper triangular starting from the `k`th superdiagonal.
 
 # Examples
 ```jldoctest
-julia> a = Int64[1 2; 2 -1]
+julia> a = [1 2; 2 -1]
 2×2 Matrix{Int64}:
  1   2
  2  -1
@@ -1281,7 +1281,7 @@ false
 julia> istriu(a, -1)
 true
 
-julia> b = Int64[1 1 1; 0 1 1; 0 0 1]
+julia> b = [1 1 1; 0 1 1; 0 0 1]
 3×3 Matrix{Int64}:
  1  1  1
  0  1  1
@@ -1296,7 +1296,7 @@ false
 julia> istriu(b, -1)
 true
 
-julia> c = Int64[1 1 1; 1 1 1; 0 1 1]
+julia> c = [1 1 1; 1 1 1; 0 1 1]
 3×3 Matrix{Int64}:
  1  1  1
  1  1  1
@@ -1330,7 +1330,7 @@ Test whether `A` is lower triangular starting from the `k`th superdiagonal.
 
 # Examples
 ```jldoctest
-julia> a = Int64[1 2; 2 -1]
+julia> a = [1 2; 2 -1]
 2×2 Matrix{Int64}:
  1   2
  2  -1
@@ -1341,7 +1341,7 @@ false
 julia> istril(a, 1)
 true
 
-julia> b = Int64[1 0 0; 1 1 0; 1 1 1]
+julia> b = [1 0 0; 1 1 0; 1 1 1]
 3×3 Matrix{Int64}:
  1  0  0
  1  1  0
@@ -1356,7 +1356,7 @@ false
 julia> istril(b, 1)
 true
 
-julia> c = Int64[1 1 0; 1 1 1; 1 1 1]
+julia> c = [1 1 0; 1 1 1; 1 1 1]
 3×3 Matrix{Int64}:
  1  1  0
  1  1  1

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1270,7 +1270,7 @@ Test whether `A` is upper triangular starting from the `k`th superdiagonal.
 
 # Examples
 ```jldoctest
-julia> a = [1 2; 2 -1]
+julia> a = Int64[1 2; 2 -1]
 2×2 Matrix{Int64}:
  1   2
  2  -1
@@ -1281,7 +1281,7 @@ false
 julia> istriu(a, -1)
 true
 
-julia> b = [1 1 1; 0 1 1; 0 0 1]
+julia> b = Int64[1 1 1; 0 1 1; 0 0 1]
 3×3 Matrix{Int64}:
  1  1  1
  0  1  1
@@ -1296,7 +1296,7 @@ false
 julia> istriu(b, -1)
 true
 
-julia> c = [1 1 1; 1 1 1; 0 1 1]
+julia> c = Int64[1 1 1; 1 1 1; 0 1 1]
 3×3 Matrix{Int64}:
  1  1  1
  1  1  1
@@ -1330,7 +1330,7 @@ Test whether `A` is lower triangular starting from the `k`th superdiagonal.
 
 # Examples
 ```jldoctest
-julia> a = [1 2; 2 -1]
+julia> a = Int64[1 2; 2 -1]
 2×2 Matrix{Int64}:
  1   2
  2  -1
@@ -1341,7 +1341,7 @@ false
 julia> istril(a, 1)
 true
 
-julia> b = [1 0 0; 1 1 0; 1 1 1]
+julia> b = Int64[1 0 0; 1 1 0; 1 1 1]
 3×3 Matrix{Int64}:
  1  0  0
  1  1  0
@@ -1356,7 +1356,7 @@ false
 julia> istril(b, 1)
 true
 
-julia> c = [1 1 0; 1 1 1; 1 1 1]
+julia> c = Int64[1 1 0; 1 1 1; 1 1 1]
 3×3 Matrix{Int64}:
  1  1  0
  1  1  1

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1281,21 +1281,6 @@ false
 julia> istriu(a, -1)
 true
 
-julia> b = [1 1 1; 0 1 1; 0 0 1]
-3×3 Matrix{Int64}:
- 1  1  1
- 0  1  1
- 0  0  1
-
-julia> istriu(b)
-true
-
-julia> istriu(b, 1)
-false
-
-julia> istriu(b, -1)
-true
-
 julia> c = [1 1 1; 1 1 1; 0 1 1]
 3×3 Matrix{Int64}:
  1  1  1
@@ -1339,21 +1324,6 @@ julia> istril(a)
 false
 
 julia> istril(a, 1)
-true
-
-julia> b = [1 0 0; 1 1 0; 1 1 1]
-3×3 Matrix{Int64}:
- 1  0  0
- 1  1  0
- 1  1  1
-
-julia> istril(b)
-true
-
-julia> istril(b, -1)
-false
-
-julia> istril(b, 1)
 true
 
 julia> c = [1 1 0; 1 1 1; 1 1 1]


### PR DESCRIPTION
Also, simplify some of the examples to focus on the structure of the matrices