### PR TITLE
inference: prioritize `SlotNumber`-constraint over `MustAlias`-constraint

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2403,6 +2403,20 @@ from_interconditional_check22(::Union{Int,String}, y) = isa(y, Int)
     return 0
 end |> only === Int
 
+# prioritize constraints on slot objects
+# https://github.com/aviatesk/JET.jl/issues/509
+struct JET509
+    list::Union{Tuple{},Vector{Int}}
+end
+jet509_hasitems(list) = length(list) >= 1
+@test Base.return_types((JET509,); interp=MustAliasInterpreter()) do ilist::JET509
+    list = ilist.list
+    if jet509_hasitems(list)
+        return list
+    end
+    error("list is empty")
+end |> only == Vector{Int}
+
 # === constraint
 # --------------
 


### PR DESCRIPTION
Currently external `AbstractInterpreter` that uses `MustAliasesLattice` can fail to propagate type constraint on `SlotNumber` in the call-site refinement, e.g. fail to infer the return type of `firstitem(::ItrList)` in the following code:
```julia
struct ItrList
    list::Union{Tuple{},Vector{Int}}
end

hasitems(list) = length(list) >= 1

function firstitem(ilist::ItrList)
    list = ilist.list
    if hasitems(list)
        return list
    end
    error("list is empty")
end
```

(xref: <https://github.com/aviatesk/JET.jl/issues/509#issuecomment-1546658476>)

This commit fixes it up as well as fixes the implementation of `from_interprocedural!` so that it uses the correct lattice.