### PR TITLE
[cli] Ensure that probed `libstdc++` path is NULL-terminated

### DIFF
--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -345,6 +345,8 @@ static char *libstdcxxprobe(void)
             free(path);
             return NULL;
         }
+        // Ensure that `path` is zero-terminated.
+        path[pathlen] = '\0';
         return path;
     }
 }


### PR DESCRIPTION
It appears that we were assuming our path was initialized with zeros, but that is not a safe assumption.