### PR TITLE
Make `apply_type_nothrow` robust against `TypeVar`s in upper bounds

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1665,7 +1665,7 @@ function apply_type_nothrow(𝕃::AbstractLattice, argtypes::Vector{Any}, @nospe
                 end
             else
                 istype || return false
-                if !(T <: u.var.ub)
+                if isa(u.var.ub, TypeVar) || !(T <: u.var.ub)
                     return false
                 end
                 if exact ? !(u.var.lb <: T) : !(u.var.lb === Bottom)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -4904,3 +4904,17 @@ let src = code_typed1((Bool,Base.RefValue{String}, Base.RefValue{Any},Int,)) do 
     end
     @test count(@nospecialize(x)->isa(x, Core.PhiNode), src.code) == 0
 end
+
+struct Issue49785{S, T<:S} end
+let 𝕃 = Core.Compiler.OptimizerLattice()
+    argtypes = Any[Core.Compiler.Const(Issue49785),
+        Union{Type{String},Type{Int}},
+        Union{Type{String},Type{Int}}]
+    rt = Type{Issue49785{<:Any, Int}}
+    # the following should not throw
+    @test !Core.Compiler.apply_type_nothrow(𝕃, argtypes, rt)
+    @test code_typed() do
+        S = Union{Type{String},Type{Int}}[Int][1]
+        map(T -> Issue49785{S,T}, (a = S,))
+    end isa Vector
+end


### PR DESCRIPTION
For types like `Foo{S, T<:S}`, `apply_type_nothrow` could in some situations check whether the argument is a subtype of the upper bound of `T`, i.e. `S`, but subtyping agaist a plain `TypeVar` would fail. Instead return `false` in this case.

Fixes #49785.