### PR TITLE
Make precompile files relocatable

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -115,8 +115,8 @@ function init_depot_path()
     nothing
 end
 
-# replace leading dirname with `@depot, @stdlib` if `path` is located withiin any of
-# DEPOT_PATH/compiled or Sys.STDLIB
+# replace leading dirname with `@depot, @stdlib` if `path` is located within any of
+# DEPOT_PATH or Sys.STDLIB
 # return normalized path otherwise
 function replace_depot_path(_path::AbstractString)
     path = normpath(_path)
@@ -125,8 +125,13 @@ function replace_depot_path(_path::AbstractString)
         return joinpath("@stdlib", path[2+length(Sys.STDLIB):end])
     end
     for depot in DEPOT_PATH
-        if startswith(path, joinpath(depot, "compiled"))
-            return joinpath("@depot", path[2+length(depot):end])
+        if startswith(path, depot) # joinpath(depot, "compiled"))
+            subpath = path[1+length(depot):end]
+            if startswith(subpath, "/")
+                subpath = subpath[2:end]
+            end
+            return joinpath("@depot", subpath)
+            # return joinpath("@depot", path[1+length(depot):end])
         end
     end
     return path
@@ -142,12 +147,13 @@ function resolve_depot_path(_path::AbstractString)
         fullpath = joinpath(Sys.STDLIB, path[2+length("@stdlib"):end])
         ispath(fullpath) && return fullpath
         throw(ErrorException("Failed to resolve `$path` to a stdlib path in `$(Sys.STDLIB)`."))
-    elseif startswith(path, joinpath("@depot", "compiled"))
+    elseif startswith(path, joinpath("@depot")) #, "compiled"))
         dir = path[2+length("@depot"):end]
         for depot in DEPOT_PATH
             fullpath = joinpath(depot, dir)
             ispath(fullpath) && return fullpath
         end
+        # TODO Why IOBuffer here?
         io = IOBuffer()
         print(io, "Failed to resolve `$path` to a valid path for any depot in `DEPOT_PATH = ",
               DEPOT_PATH, "`.")

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -116,9 +116,7 @@ function init_depot_path()
 end
 
 # replace leading dirname with `@depot, @stdlib` if `path` is located within any of DEPOT_PATH or Sys.STDLIB
-# return normalized path otherwise
-function replace_depot_path(_path::AbstractString)
-    path = normpath(_path)
+function replace_depot_path(path::AbstractString)
     if startswith(path, Sys.STDLIB)
         subpath = path[nextind(path,length(Sys.STDLIB)):end]
         if isabspath(subpath)
@@ -138,22 +136,20 @@ function replace_depot_path(_path::AbstractString)
     return path
 end
 
-# resolve leading `@depot, @stdlib` alias from `_path` to point to a valid path in any
+# resolve leading `@depot, @stdlib` alias from `path` to point to a valid path in any
 # of DEPOT_PATH/compiled or Sys.STDLIb
-# if `_path` has no leading alias, we return a normalized path
-function resolve_depot_path(_path::AbstractString)
-    path = normpath(_path)
+function resolve_depot_path(path::AbstractString)
     if startswith(path, "@stdlib")
         fullpath = joinpath(Sys.STDLIB, path[nextind(path,length("@stdlib")+1):end])
         ispath(fullpath) && return fullpath
-        throw(ErrorException("Failed to resolve `$path` ($fullpath) to a stdlib path in `$(Sys.STDLIB)`."))
+        error("Failed to resolve `$path` ($fullpath) to a stdlib path in `$(Sys.STDLIB)`")
     elseif startswith(path, joinpath("@depot"))
         dir = path[nextind(path,length("@depot")+1):end]
         for depot in DEPOT_PATH
             fullpath = joinpath(depot, dir)
             ispath(fullpath) && return fullpath
         end
-        throw(ErrorException("Failed to resolve `$path` to a valid path for any depot in `DEPOT_PATH`"))
+        error("Failed to resolve `$path` to a valid path for any depot in `DEPOT_PATH`")
     end
     return path
 end

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -115,7 +115,6 @@ function init_depot_path()
     nothing
 end
 
-
 ## LOAD_PATH & ACTIVE_PROJECT ##
 
 # JULIA_LOAD_PATH: split on `:` (or `;` on Windows)

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -115,40 +115,6 @@ function init_depot_path()
     nothing
 end
 
-# replace leading dirname of `path` with `@depot` if `path` and `cachefile` are located
-# on the same depot path; otherwise just return `path`
-function replace_depot_path(path::AbstractString, cachefile::AbstractString)
-    for depot in DEPOT_PATH
-        if startswith(path, depot) && startswith(cachefile, depot)
-            depot_w_sep = joinpath(depot, "") # append the path separator
-            alias = joinpath("@depot", path[1+length(depot_w_sep):end])
-            return alias
-        end
-    end
-    # TODO Emit debug message when cachefile is not in a depot; can this even happen?
-    # TODO Emit debug message when path is not in the same depot as cachefile the cache file.
-    return path
-end
-
-# resolve a leading `@depot` tag from `depotalias` to point to a valid path located
-# in the same depot as the `cachefile` it was loaded from
-# TODO IDK if returning an unresolved @depot on failure is ok? atm it is need to not break precompile tests
-function resolve_depot_path(depotalias::AbstractString, cachefile::AbstractString)
-    !startswith(depotalias, "@depot") && return depotalias
-    for depot in DEPOT_PATH
-        if startswith(cachefile, depot)
-            tag = joinpath("@depot", "") # append the path separator
-            path = joinpath(depot, depotalias[1+length(tag):end])
-            # if !ispath(path)
-            #     error("Failed to resolve `$depotalias` to a valid path located in the same depot (`$depot`) as the cachefile `$cachefile`")
-            # end
-            return path
-        end
-    end
-    return depotalias
-    # error("Failed to resolve `$depotalias` to a valid path, because the cachefile `$cachefile` is not on located on any `DEPOT_PATH`")
-end
-
 
 ## LOAD_PATH & ACTIVE_PROJECT ##
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1671,7 +1671,8 @@ function _include_dependency(mod::Module, _path::AbstractString)
     end
     if _track_dependencies[]
         @lock require_lock begin
-        push!(_require_dependencies, (mod, path, mtime(path)))
+        push!(_require_dependencies, (mod, path, mtime(path),
+                                      path[1] == '\0' ? path : replace_depot_path(path)))
         end
     end
     return path, prev
@@ -1787,7 +1788,9 @@ function __require(into::Module, mod::Symbol)
         end
         uuidkey, env = uuidkey_env
         if _track_dependencies[]
-            push!(_require_dependencies, (into, binpack(uuidkey), 0.0))
+            path = binpack(uuidkey)
+            push!(_require_dependencies, (into, path, 0.0,
+                                          path[1] == '\0' ? path : replace_depot_path(path)))
         end
         return _require_prelocked(uuidkey, env)
     finally
@@ -2632,6 +2635,8 @@ function parse_cache_header(f::IO)
         end
         if depname[1] == '\0'
             push!(requires, modkey => binunpack(depname))
+        elseif depname[1] == '@'
+            push!(includes, CacheHeaderIncludes(modkey, resolve_depot_path(depname), mtime, modpath))
         else
             push!(includes, CacheHeaderIncludes(modkey, depname, mtime, modpath))
         end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3239,17 +3239,17 @@ end
                     @debug "Rejecting stale cache file $cachefile (hash $hash_req) because file $f (hash $hash) has changed"
                     return true
                 end
-                ftime = mtime(f)
-                is_stale = ( ftime != ftime_req ) &&
-                           ( ftime != floor(ftime_req) ) &&           # Issue #13606, PR #13613: compensate for Docker images rounding mtimes
-                           ( ftime != ceil(ftime_req) ) &&            # PR: #47433 Compensate for CirceCI's truncating of timestamps in its caching
-                           ( ftime != trunc(ftime_req, digits=6) ) && # Issue #20837, PR #20840: compensate for GlusterFS truncating mtimes to microseconds
-                           ( ftime != 1.0 )  &&                       # PR #43090: provide compatibility with Nix mtime.
-                           !( 0 < (ftime_req - ftime) < 1e-6 )        # PR #45552: Compensate for Windows tar giving mtimes that may be incorrect by up to one microsecond
-                if is_stale
-                    @debug "Rejecting stale cache file $cachefile (mtime $ftime_req) because file $f (mtime $ftime) has changed"
-                    return true
-                end
+                # ftime = mtime(f)
+                # is_stale = ( ftime != ftime_req ) &&
+                #            ( ftime != floor(ftime_req) ) &&           # Issue #13606, PR #13613: compensate for Docker images rounding mtimes
+                #            ( ftime != ceil(ftime_req) ) &&            # PR: #47433 Compensate for CirceCI's truncating of timestamps in its caching
+                #            ( ftime != trunc(ftime_req, digits=6) ) && # Issue #20837, PR #20840: compensate for GlusterFS truncating mtimes to microseconds
+                #            ( ftime != 1.0 )  &&                       # PR #43090: provide compatibility with Nix mtime.
+                #            !( 0 < (ftime_req - ftime) < 1e-6 )        # PR #45552: Compensate for Windows tar giving mtimes that may be incorrect by up to one microsecond
+                # if is_stale
+                #     @debug "Rejecting stale cache file $cachefile (mtime $ftime_req) because file $f (mtime $ftime) has changed"
+                #     return true
+                # end
             end
         end
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2608,7 +2608,7 @@ function resolve_depot(includes)
     if any(includes) do inc
             !startswith(inc, "@depot")
         end
-        return :missing_tag
+        return :missing_depot_tag
     end
     for depot in DEPOT_PATH
         if all(includes) do inc
@@ -2617,7 +2617,7 @@ function resolve_depot(includes)
             return depot
         end
     end
-    return :no_depot
+    return :no_depot_found
 end
 
 
@@ -2708,9 +2708,11 @@ function parse_cache_header(f::IO, cachefile::AbstractString)
     for (i, chi) in enumerate(includes)
         chi.filename ∈ srcfiles && push!(keepidx, i)
     end
-    if depot === :no_depot
-        @debug "Failed to determine depot from srctext files in cache file $cachefile."
-    elseif depot === :missing_tag
+    if depot === :no_depot_found
+        throw(ArgumentError("""
+              Failed to determine depot from srctext files in cache file $cachefile.
+              - Make sure you have adjusted DEPOT_PATH in case you relocated depots."""))
+    elseif depot === :missing_depot_tag
         @debug "Missing @depot tag for include dependencies in cache file $cachefile."
     else
         for inc in includes

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1671,11 +1671,8 @@ function _include_dependency(mod::Module, _path::AbstractString)
     end
     if _track_dependencies[]
         @lock require_lock begin
-            fsize, hash = if isfile(path)
-                UInt64(filesize(path)), open(_crc32c, path, "r")
-            else
-                UInt64(0), UInt32(0)
-            end
+            fsize = filesize(path)
+            hash = isfile(path) ? open(_crc32c, path, "r") : UInt32(0)
             push!(_require_dependencies, (mod, path, fsize, hash))
         end
     end
@@ -1687,7 +1684,7 @@ end
 
 In a module, declare that the file, directory, or symbolic link specified by `path`
 (relative or absolute) is a dependency for precompilation; that is, the module will need
-to be recompiled if its file contents change.
+to be recompiled if the file's size changes.
 
 This is only needed if your module depends on a path that is not used via [`include`](@ref). It has
 no effect outside of compilation.

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1687,8 +1687,7 @@ end
 
 In a module, declare that the file, directory, or symbolic link specified by `path`
 (relative or absolute) is a dependency for precompilation; that is, the module will need
-to be recompiled if the modification time of `path` changes.
-TODO: Update docs because we now use file size and content hash
+to be recompiled if its file contents change.
 
 This is only needed if your module depends on a path that is not used via [`include`](@ref). It has
 no effect outside of compilation.
@@ -2588,15 +2587,14 @@ function isvalid_pkgimage_crc(f::IOStream, ocachefile::String)
 end
 
 mutable struct CacheHeaderIncludes
-    id::PkgId
+    const id::PkgId
     filename::String
-    fsize::UInt64
-    hash::UInt32
-    modpath::Vector{String}   # seemingly not needed in Base, but used by Revise
+    const fsize::UInt64
+    const hash::UInt32
+    const modpath::Vector{String}   # seemingly not needed in Base, but used by Revise
 end
 
-# replace leading dirname of `path` with `@depot` if `path` and `cachefile` are located
-# on the same depot path; otherwise just return `path`
+# replace leading dirname of `path` with a `@depot` tag if the file is located inside of a DEPOT_PATH
 function replace_depot_path(path::AbstractString, cachefile::AbstractString)
     for depot in DEPOT_PATH
         if startswith(path, depot) && startswith(cachefile, depot)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2608,7 +2608,7 @@ function resolve_depot(includes)
     if any(includes) do inc
             !startswith(inc, "@depot")
         end
-        return nothing
+        return :missing_tag
     end
     for depot in DEPOT_PATH
         if all(includes) do inc
@@ -2617,7 +2617,7 @@ function resolve_depot(includes)
             return depot
         end
     end
-    return nothing
+    return :no_depot
 end
 
 
@@ -2708,8 +2708,10 @@ function parse_cache_header(f::IO, cachefile::AbstractString)
     for (i, chi) in enumerate(includes)
         chi.filename ∈ srcfiles && push!(keepidx, i)
     end
-    if isnothing(depot)
+    if depot === :no_depot
         @debug "Failed to determine depot from srctext files in cache file $cachefile."
+    elseif depot === :missing_tag
+        @debug "Missing @depot tag for include dependencies in cache file $cachefile."
     else
         for inc in includes
             inc.filename = replace(inc.filename, r"^@depot" => depot)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3273,13 +3273,14 @@ end
                     return true
                 end
                 fsize = filesize(f)
-                if fsize != chi.fsize
-                    @debug "Rejecting stale cache file $cachefile (file size $fsize_req) because file $f (file size $fsize) has changed"
+                @debug (f,fsize)
+                if fsize != fsize_req
+                    @debug "Rejecting stale cache file $cachefile because file size of $f has changed (file size $fsize, before $fsize_req)"
                     return true
                 end
                 hash = open(_crc32c, f, "r")
-                if hash != chi.hash
-                    @debug "Rejecting stale cache file $cachefile (hash $hash_req) because file $f (hash $hash) has changed"
+                if hash != hash_req
+                    @debug "Rejecting stale cache file $cachefile because file size of $f has changed (hash $hash, before $hash_req)"
                     return true
                 end
             end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1660,7 +1660,7 @@ const include_callbacks = Any[]
 
 # used to optionally track dependencies when requiring a module:
 const _concrete_dependencies = Pair{PkgId,UInt128}[] # these dependency versions are "set in stone", and the process should try to avoid invalidating them
-const _require_dependencies = Any[] # a list of (mod, path, fsize, hash, depot_alias) tuples that are the file dependencies of the module currently being precompiled
+const _require_dependencies = Any[] # a list of (mod, depot_alias, fsize, hash) tuples that are the file dependencies of the module currently being precompiled
 const _track_dependencies = Ref(false) # set this to true to track the list of file dependencies
 function _include_dependency(mod::Module, _path::AbstractString)
     prev = source_path(nothing)
@@ -1676,7 +1676,7 @@ function _include_dependency(mod::Module, _path::AbstractString)
             else
                 UInt64(0), UInt32(0)
             end
-            push!(_require_dependencies, (mod, path, fsize, hash, replace_depot_path(path)))
+            push!(_require_dependencies, (mod, replace_depot_path(path), fsize, hash))
         end
     end
     return path, prev
@@ -1793,7 +1793,7 @@ function __require(into::Module, mod::Symbol)
         uuidkey, env = uuidkey_env
         if _track_dependencies[]
             path = binpack(uuidkey)
-            push!(_require_dependencies, (into, path, UInt64(0), UInt32(0), replace_depot_path(path)))
+            push!(_require_dependencies, (into, replace_depot_path(path), UInt64(0), UInt32(0)))
         end
         return _require_prelocked(uuidkey, env)
     finally

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -59,8 +59,10 @@ let
             print_time(stdlib, tt)
         end
         for dep in Base._require_dependencies
-            dep[3] == 0.0 && continue
-            push!(Base._included_files, dep[1:2])
+            mod, depotpath, fsize = dep[1], dep[2], dep[3]
+            fsize == 0 && continue
+            path = Base.resolve_depot_path(depotpath)
+            push!(Base._included_files, (mod, path))
         end
         empty!(Base._require_dependencies)
         Base._track_dependencies[] = false

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -59,9 +59,8 @@ let
             print_time(stdlib, tt)
         end
         for dep in Base._require_dependencies
-            mod, depotpath, fsize = dep[1], dep[2], dep[3]
+            mod, path, fsize = dep[1], dep[2], dep[3]
             fsize == 0 && continue
-            path = Base.resolve_depot_path(depotpath)
             push!(Base._included_files, (mod, path))
         end
         empty!(Base._require_dependencies)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -59,8 +59,8 @@ let
             print_time(stdlib, tt)
         end
         for dep in Base._require_dependencies
-            mod, path, fsize = dep[1], dep[2], dep[3]
-            fsize == 0 && continue
+            mod, path, fsize, mtime = dep[1], dep[2], dep[3], dep[5]
+            (fsize == 0 || mtime == 0.0) && continue
             push!(Base._included_files, (mod, path))
         end
         empty!(Base._require_dependencies)

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -447,10 +447,12 @@ recompiled upon `using` or `import`. Dependencies are modules it
 imports, the Julia build, files it includes, or explicit dependencies declared by [`include_dependency(path)`](@ref)
 in the module file(s).
 
-For file dependencies, a change is determined by examining whether the modification time (`mtime`)
-of each file loaded by `include` or added explicitly by `include_dependency` is unchanged, or equal
-to the modification time truncated to the nearest second (to accommodate systems that can't copy
-mtime with sub-second accuracy). It also takes into account whether the path to the file chosen
+For file dependencies loaded by `include`, a change is determined by examining whether the
+file size (`fsize`) or content (condensed into a hash) is unchanged.
+For file dependencies loaded by `include_dependency` a change is determined by examining whether the modification time (`mtime`)
+is unchanged, or equal to the modification time truncated to the nearest second
+(to accommodate systems that can't copy mtime with sub-second accuracy).
+It also takes into account whether the path to the file chosen
 by the search logic in `require` matches the path that had created the precompile file. It also takes
 into account the set of dependencies already loaded into the current process and won't recompile those
 modules, even if their files change or disappear, in order to avoid creating incompatibilities between

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -30,8 +30,8 @@ void write_srctext(ios_t *f, jl_array_t *udeps, int64_t srctextpos) {
         write_uint64(f, posfile);
         ios_seek_end(f);
         // Each source-text file is written as
-        //   int32: length of abspath
-        //   char*: abspath
+        //   int32: length of depot alias
+        //   char*: depot alias
         //   uint64: length of src text
         //   char*: src text
         // At the end we write int32(0) as a terminal sentinel.
@@ -50,12 +50,13 @@ void write_srctext(ios_t *f, jl_array_t *udeps, int64_t srctextpos) {
                 ios_t *srctp = ios_file(&srctext, depstr, 1, 0, 0, 0);
                 if (!srctp) {
                     jl_printf(JL_STDERR, "WARNING: could not cache source text for \"%s\".\n",
-                            jl_string_data(dep));
+                              depstr);
                     continue;
                 }
-                size_t slen = jl_string_len(dep);
+                jl_value_t *depalias = jl_fieldref(deptuple, 3);  // file @depot alias
+                size_t slen = jl_string_len(depalias);
                 write_int32(f, slen);
-                ios_write(f, depstr, slen);
+                ios_write(f, jl_string_data(depalias), slen);
                 posfile = ios_pos(f);
                 write_uint64(f, 0);   // placeholder for length of this file in bytes
                 uint64_t filelen = (uint64_t) ios_copyall(f, &srctext);

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -53,7 +53,7 @@ void write_srctext(ios_t *f, jl_array_t *udeps, int64_t srctextpos) {
                               depstr);
                     continue;
                 }
-                jl_value_t *depalias = jl_fieldref(deptuple, 3);  // file @depot alias
+                jl_value_t *depalias = jl_fieldref(deptuple, 5);  // file @depot alias
                 size_t slen = jl_string_len(depalias);
                 write_int32(f, slen);
                 ios_write(f, jl_string_data(depalias), slen);

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -53,7 +53,7 @@ void write_srctext(ios_t *f, jl_array_t *udeps, int64_t srctextpos) {
                               depstr);
                     continue;
                 }
-                jl_value_t *depalias = jl_fieldref(deptuple, 5);  // file @depot alias
+                jl_value_t *depalias = jl_fieldref(deptuple, 4);  // file @depot alias
                 size_t slen = jl_string_len(depalias);
                 write_int32(f, slen);
                 ios_write(f, jl_string_data(depalias), slen);

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -60,14 +60,13 @@ void write_srctext(ios_t *f, jl_array_t *udeps, int64_t srctextpos) {
                 }
 
                 jl_value_t **replace_depot_args;
-                JL_GC_PUSHARGS(replace_depot_args, 3);
+                JL_GC_PUSHARGS(replace_depot_args, 2);
                 replace_depot_args[0] = replace_depot_func;
                 replace_depot_args[1] = abspath;
-                replace_depot_args[2] = jl_cstr_to_string(jl_options.outputji);
                 jl_task_t *ct = jl_current_task;
                 size_t last_age = ct->world_age;
                 ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
-                jl_value_t *depalias = (jl_value_t*)jl_apply(replace_depot_args, 3);
+                jl_value_t *depalias = (jl_value_t*)jl_apply(replace_depot_args, 2);
                 ct->world_age = last_age;
                 JL_GC_POP();
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2691,8 +2691,9 @@ static void jl_write_header_for_incremental(ios_t *f, jl_array_t *worklist, jl_a
     write_uint8(f, jl_cache_flags());
     // write description of contents (name, uuid, buildid)
     write_worklist_for_header(f, worklist);
-    // Determine unique (module, depotalias, hash, fsize) dependencies for the files defining modules in the worklist
-    // (see Base._require_dependencies). These get stored in `udeps` and written to the ji-file header.
+    // Determine unique (module, abspath, fsize, hash) dependencies for the files defining modules in the worklist
+    // (see Base._require_dependencies). These get stored in `udeps` and written to the ji-file header
+    // (abspath will be converted to a relocateable @depot path before writing, Base.replace_depot_path).
     // Also write Preferences.
     // last word of the dependency list is the end of the data / start of the srctextpos
     *srctextpos = write_dependency_list(f, worklist, udeps);  // srctextpos: position of srctext entry in header index (update later)

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2693,7 +2693,7 @@ static void jl_write_header_for_incremental(ios_t *f, jl_array_t *worklist, jl_a
     write_worklist_for_header(f, worklist);
     // Determine unique (module, abspath, fsize, hash) dependencies for the files defining modules in the worklist
     // (see Base._require_dependencies). These get stored in `udeps` and written to the ji-file header
-    // (abspath will be converted to a relocateable @depot path before writing, Base.replace_depot_path).
+    // (abspath will be converted to a relocateable @depot path before writing, cf. Base.replace_depot_path).
     // Also write Preferences.
     // last word of the dependency list is the end of the data / start of the srctextpos
     *srctextpos = write_dependency_list(f, worklist, udeps);  // srctextpos: position of srctext entry in header index (update later)

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2691,7 +2691,7 @@ static void jl_write_header_for_incremental(ios_t *f, jl_array_t *worklist, jl_a
     write_uint8(f, jl_cache_flags());
     // write description of contents (name, uuid, buildid)
     write_worklist_for_header(f, worklist);
-    // Determine unique (module, abspath, hash, fsize, depotalias) dependencies for the files defining modules in the worklist
+    // Determine unique (module, depotalias, hash, fsize) dependencies for the files defining modules in the worklist
     // (see Base._require_dependencies). These get stored in `udeps` and written to the ji-file header.
     // Also write Preferences.
     // last word of the dependency list is the end of the data / start of the srctextpos

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2691,7 +2691,7 @@ static void jl_write_header_for_incremental(ios_t *f, jl_array_t *worklist, jl_a
     write_uint8(f, jl_cache_flags());
     // write description of contents (name, uuid, buildid)
     write_worklist_for_header(f, worklist);
-    // Determine unique (module, abspath, mtime) dependencies for the files defining modules in the worklist
+    // Determine unique (module, abspath, mtime, hash, fsize) dependencies for the files defining modules in the worklist
     // (see Base._require_dependencies). These get stored in `udeps` and written to the ji-file header.
     // Also write Preferences.
     // last word of the dependency list is the end of the data / start of the srctextpos

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2691,7 +2691,7 @@ static void jl_write_header_for_incremental(ios_t *f, jl_array_t *worklist, jl_a
     write_uint8(f, jl_cache_flags());
     // write description of contents (name, uuid, buildid)
     write_worklist_for_header(f, worklist);
-    // Determine unique (module, abspath, mtime, hash, fsize) dependencies for the files defining modules in the worklist
+    // Determine unique (module, abspath, hash, fsize, depotalias) dependencies for the files defining modules in the worklist
     // (see Base._require_dependencies). These get stored in `udeps` and written to the ji-file header.
     // Also write Preferences.
     // last word of the dependency list is the end of the data / start of the srctextpos

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2691,7 +2691,7 @@ static void jl_write_header_for_incremental(ios_t *f, jl_array_t *worklist, jl_a
     write_uint8(f, jl_cache_flags());
     // write description of contents (name, uuid, buildid)
     write_worklist_for_header(f, worklist);
-    // Determine unique (module, abspath, fsize, hash) dependencies for the files defining modules in the worklist
+    // Determine unique (module, abspath, fsize, hash, mtime) dependencies for the files defining modules in the worklist
     // (see Base._require_dependencies). These get stored in `udeps` and written to the ji-file header
     // (abspath will be converted to a relocateable @depot path before writing, cf. Base.replace_depot_path).
     // Also write Preferences.

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -713,11 +713,13 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
     size_t i, l = udeps ? jl_array_len(udeps) : 0;
     for (i = 0; i < l; i++) {
         jl_value_t *deptuple = jl_array_ptr_ref(udeps, i);
-        jl_value_t *depalias = jl_fieldref(deptuple, 3);        // file @depot alias
+        jl_value_t *depalias = jl_fieldref(deptuple, 5);        // file @depot alias
         size_t slen = jl_string_len(depalias);
         write_int32(s, slen);
         ios_write(s, jl_string_data(depalias), slen);
         write_float64(s, jl_unbox_float64(jl_fieldref(deptuple, 2)));  // mtime
+        write_uint64(s, jl_unbox_uint64(jl_fieldref(deptuple, 3)));    // fsize
+        write_uint32(s, jl_unbox_uint32(jl_fieldref(deptuple, 4)));    // hash
         jl_module_t *depmod = (jl_module_t*)jl_fieldref(deptuple, 0);  // evaluating module
         jl_module_t *depmod_top = depmod;
         while (depmod_top->parent != jl_main_module && depmod_top->parent != depmod_top)

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -713,10 +713,10 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
     size_t i, l = udeps ? jl_array_len(udeps) : 0;
     for (i = 0; i < l; i++) {
         jl_value_t *deptuple = jl_array_ptr_ref(udeps, i);
-        jl_value_t *dep = jl_fieldref(deptuple, 1);              // file abspath
-        size_t slen = jl_string_len(dep);
+        jl_value_t *depalias = jl_fieldref(deptuple, 3);        // file @depot alias
+        size_t slen = jl_string_len(depalias);
         write_int32(s, slen);
-        ios_write(s, jl_string_data(dep), slen);
+        ios_write(s, jl_string_data(depalias), slen);
         write_float64(s, jl_unbox_float64(jl_fieldref(deptuple, 2)));  // mtime
         jl_module_t *depmod = (jl_module_t*)jl_fieldref(deptuple, 0);  // evaluating module
         jl_module_t *depmod_top = depmod;

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -1,11 +1,6 @@
 // inverse of backedges graph (caller=>callees hash)
 jl_array_t *edges_map JL_GLOBALLY_ROOTED = NULL; // rooted for the duration of our uses of this
 
-static void write_float64(ios_t *s, double x) JL_NOTSAFEPOINT
-{
-    write_uint64(s, *((uint64_t*)&x));
-}
-
 // Decide if `t` must be new, because it points to something new.
 // If it is new, the object (in particular, the super field) might not be entirely
 // valid for the cache, so we want to finish transforming it before attempting
@@ -713,13 +708,12 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
     size_t i, l = udeps ? jl_array_len(udeps) : 0;
     for (i = 0; i < l; i++) {
         jl_value_t *deptuple = jl_array_ptr_ref(udeps, i);
-        jl_value_t *depalias = jl_fieldref(deptuple, 5);        // file @depot alias
+        jl_value_t *depalias = jl_fieldref(deptuple, 4);        // file @depot alias
         size_t slen = jl_string_len(depalias);
         write_int32(s, slen);
         ios_write(s, jl_string_data(depalias), slen);
-        write_float64(s, jl_unbox_float64(jl_fieldref(deptuple, 2)));  // mtime
-        write_uint64(s, jl_unbox_uint64(jl_fieldref(deptuple, 3)));    // fsize
-        write_uint32(s, jl_unbox_uint32(jl_fieldref(deptuple, 4)));    // hash
+        write_uint64(s, jl_unbox_uint64(jl_fieldref(deptuple, 2)));    // fsize
+        write_uint32(s, jl_unbox_uint32(jl_fieldref(deptuple, 3)));    // hash
         jl_module_t *depmod = (jl_module_t*)jl_fieldref(deptuple, 0);  // evaluating module
         jl_module_t *depmod_top = depmod;
         while (depmod_top->parent != jl_main_module && depmod_top->parent != depmod_top)

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -701,6 +701,10 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
     jl_array_t *udeps = (*udepsp = deps && unique_func ? (jl_array_t*)jl_apply(uniqargs, 2) : NULL);
     ct->world_age = last_age;
 
+    static jl_value_t *replace_depot_func = NULL;
+    if (!replace_depot_func)
+        replace_depot_func = jl_get_global(jl_base_module, jl_symbol("replace_depot_path"));
+
     // write a placeholder for total size so that we can quickly seek past all of the
     // dependencies if we don't need them
     initial_pos = ios_pos(s);
@@ -708,7 +712,20 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
     size_t i, l = udeps ? jl_array_len(udeps) : 0;
     for (i = 0; i < l; i++) {
         jl_value_t *deptuple = jl_array_ptr_ref(udeps, i);
-        jl_value_t *depalias = jl_fieldref(deptuple, 1);               // file @depot alias
+        jl_value_t *abspath = jl_fieldref(deptuple, 1);
+
+        jl_value_t **replace_depot_args;
+        JL_GC_PUSHARGS(replace_depot_args, 3);
+        replace_depot_args[0] = replace_depot_func;
+        replace_depot_args[1] = abspath;
+        replace_depot_args[2] = jl_cstr_to_string(jl_options.outputji);
+        ct = jl_current_task;
+        size_t last_age = ct->world_age;
+        ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
+        jl_value_t *depalias = (jl_value_t*)jl_apply(replace_depot_args, 3);
+        ct->world_age = last_age;
+        JL_GC_POP();
+
         size_t slen = jl_string_len(depalias);
         write_int32(s, slen);
         ios_write(s, jl_string_data(depalias), slen);

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -708,7 +708,7 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
     size_t i, l = udeps ? jl_array_len(udeps) : 0;
     for (i = 0; i < l; i++) {
         jl_value_t *deptuple = jl_array_ptr_ref(udeps, i);
-        jl_value_t *depalias = jl_fieldref(deptuple, 4);        // file @depot alias
+        jl_value_t *depalias = jl_fieldref(deptuple, 1);               // file @depot alias
         size_t slen = jl_string_len(depalias);
         write_int32(s, slen);
         ios_write(s, jl_string_data(depalias), slen);

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -715,14 +715,13 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
         jl_value_t *abspath = jl_fieldref(deptuple, 1);
 
         jl_value_t **replace_depot_args;
-        JL_GC_PUSHARGS(replace_depot_args, 3);
+        JL_GC_PUSHARGS(replace_depot_args, 2);
         replace_depot_args[0] = replace_depot_func;
         replace_depot_args[1] = abspath;
-        replace_depot_args[2] = jl_cstr_to_string(jl_options.outputji);
         ct = jl_current_task;
         size_t last_age = ct->world_age;
         ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
-        jl_value_t *depalias = (jl_value_t*)jl_apply(replace_depot_args, 3);
+        jl_value_t *depalias = (jl_value_t*)jl_apply(replace_depot_args, 2);
         ct->world_age = last_age;
         JL_GC_POP();
 

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -1,6 +1,11 @@
 // inverse of backedges graph (caller=>callees hash)
 jl_array_t *edges_map JL_GLOBALLY_ROOTED = NULL; // rooted for the duration of our uses of this
 
+static void write_float64(ios_t *s, double x) JL_NOTSAFEPOINT
+{
+    write_uint64(s, *((uint64_t*)&x));
+}
+
 // Decide if `t` must be new, because it points to something new.
 // If it is new, the object (in particular, the super field) might not be entirely
 // valid for the cache, so we want to finish transforming it before attempting
@@ -730,6 +735,7 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
         ios_write(s, jl_string_data(depalias), slen);
         write_uint64(s, jl_unbox_uint64(jl_fieldref(deptuple, 2)));    // fsize
         write_uint32(s, jl_unbox_uint32(jl_fieldref(deptuple, 3)));    // hash
+        write_float64(s, jl_unbox_float64(jl_fieldref(deptuple, 4)));  // mtime
         jl_module_t *depmod = (jl_module_t*)jl_fieldref(deptuple, 0);  // evaluating module
         jl_module_t *depmod_top = depmod;
         while (depmod_top->parent != jl_main_module && depmod_top->parent != depmod_top)

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -3,4 +3,4 @@
 /ccalltest.s
 /libccalltest.*
 /relocatedepot
-/RelocationTestPkg/src/foo.txt
+/RelocationTestPkg2/src/foo.txt

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -2,3 +2,4 @@
 /ccalltest
 /ccalltest.s
 /libccalltest.*
+/relocatedepot

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -3,3 +3,4 @@
 /ccalltest.s
 /libccalltest.*
 /relocatedepot
+/RelocationTestPkg/src/foo.txt

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,7 +14,7 @@ unexport JULIA_BINDIR :=
 TESTGROUPS = unicode strings compiler
 TESTS = all default stdlib $(TESTGROUPS) \
 		$(patsubst $(STDLIBDIR)/%/,%,$(dir $(wildcard $(STDLIBDIR)/*/.))) \
-		$(filter-out runtests testdefs, \
+		$(filter-out runtests testdefs relocatedepot, \
 			$(patsubst $(SRCDIR)/%.jl,%,$(wildcard $(SRCDIR)/*.jl))) \
 		$(foreach group,$(TESTGROUPS), \
 			$(patsubst $(SRCDIR)/%.jl,%,$(wildcard $(SRCDIR)/$(group)/*.jl)))
@@ -34,6 +34,24 @@ $(addprefix revise-, $(TESTS)): revise-% :
 	@cd $(SRCDIR) && \
     $(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --revise $*)
 
+relocatedepot:
+	@rm -rf $(SRCDIR)/relocatedepot
+	@cd $(SRCDIR) && \
+	$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl $@)
+	@mkdir $(SRCDIR)/relocatedepot
+	@cp -R $(build_datarootdir)/julia $(SRCDIR)/relocatedepot
+	@cd $(SRCDIR) && \
+	$(call PRINT_JULIA, $(call spawn,RELOCATEDEPOT="" JULIA_DEPOT_PATH=$(SRCDIR)/relocatedepot/julia $(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl $@)
+
+revise-relocatedepot: revise-% :
+	@rm -rf $(SRCDIR)/relocatedepot
+	@cd $(SRCDIR) && \
+	$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --revise $*)
+	@mkdir $(SRCDIR)/relocatedepot
+	@cp -R $(build_datarootdir)/julia $(SRCDIR)/relocatedepot
+	@cd $(SRCDIR) && \
+	$(call PRINT_JULIA, $(call spawn,RELOCATEDEPOT="" JULIA_DEPOT_PATH=$(SRCDIR)/relocatedepot/julia $(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --revise $*)
+
 embedding:
 	@$(MAKE) -C $(SRCDIR)/$@ check $(EMBEDDING_ARGS)
 
@@ -47,4 +65,4 @@ clean:
 	@$(MAKE) -C embedding $@ $(EMBEDDING_ARGS)
 	@$(MAKE) -C gcext $@ $(GCEXT_ARGS)
 
-.PHONY: $(TESTS) $(addprefix revise-, $(TESTS)) embedding gcext clangsa clean
+.PHONY: $(TESTS) $(addprefix revise-, $(TESTS)) relocatedepot revise-relocatedepot embedding gcext clangsa clean

--- a/test/Makefile
+++ b/test/Makefile
@@ -40,7 +40,8 @@ relocatedepot:
 	$(call PRINT_JULIA, $(call spawn,JULIA_DEBUG=loading $(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl $@)
 	@mkdir $(SRCDIR)/relocatedepot
 	@cp -R $(build_datarootdir)/julia $(SRCDIR)/relocatedepot
-	@cp -R $(SRCDIR)/RelocationTestPkg $(SRCDIR)/relocatedepot
+	@cp -R $(SRCDIR)/RelocationTestPkg1 $(SRCDIR)/relocatedepot
+	@cp -R $(SRCDIR)/RelocationTestPkg2 $(SRCDIR)/relocatedepot
 	@cd $(SRCDIR) && \
 	$(call PRINT_JULIA, $(call spawn,JULIA_DEBUG=loading RELOCATEDEPOT="" JULIA_DEPOT_PATH=$(SRCDIR)/relocatedepot/julia $(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl $@)
 
@@ -50,7 +51,8 @@ revise-relocatedepot: revise-% :
 	$(call PRINT_JULIA, $(call spawn,JULIA_DEBUG=loading $(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --revise $*)
 	@mkdir $(SRCDIR)/relocatedepot
 	@cp -R $(build_datarootdir)/julia $(SRCDIR)/relocatedepot
-	@cp -R $(SRCDIR)/RelocationTestPkg $(SRCDIR)/relocatedepot
+	@cp -R $(SRCDIR)/RelocationTestPkg1 $(SRCDIR)/relocatedepot
+	@cp -R $(SRCDIR)/RelocationTestPkg2 $(SRCDIR)/relocatedepot
 	@cd $(SRCDIR) && \
 	$(call PRINT_JULIA, $(call spawn,JULIA_DEBUG=loading RELOCATEDEPOT="" JULIA_DEPOT_PATH=$(SRCDIR)/relocatedepot/julia $(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --revise $*)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -37,20 +37,22 @@ $(addprefix revise-, $(TESTS)): revise-% :
 relocatedepot:
 	@rm -rf $(SRCDIR)/relocatedepot
 	@cd $(SRCDIR) && \
-	$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl $@)
+	$(call PRINT_JULIA, $(call spawn,JULIA_DEBUG=loading $(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl $@)
 	@mkdir $(SRCDIR)/relocatedepot
 	@cp -R $(build_datarootdir)/julia $(SRCDIR)/relocatedepot
+	@cp -R $(SRCDIR)/RelocationTestPkg $(SRCDIR)/relocatedepot
 	@cd $(SRCDIR) && \
-	$(call PRINT_JULIA, $(call spawn,RELOCATEDEPOT="" JULIA_DEPOT_PATH=$(SRCDIR)/relocatedepot/julia $(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl $@)
+	$(call PRINT_JULIA, $(call spawn,JULIA_DEBUG=loading RELOCATEDEPOT="" JULIA_DEPOT_PATH=$(SRCDIR)/relocatedepot/julia $(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl $@)
 
 revise-relocatedepot: revise-% :
 	@rm -rf $(SRCDIR)/relocatedepot
 	@cd $(SRCDIR) && \
-	$(call PRINT_JULIA, $(call spawn,$(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --revise $*)
+	$(call PRINT_JULIA, $(call spawn,JULIA_DEBUG=loading $(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --revise $*)
 	@mkdir $(SRCDIR)/relocatedepot
 	@cp -R $(build_datarootdir)/julia $(SRCDIR)/relocatedepot
+	@cp -R $(SRCDIR)/RelocationTestPkg $(SRCDIR)/relocatedepot
 	@cd $(SRCDIR) && \
-	$(call PRINT_JULIA, $(call spawn,RELOCATEDEPOT="" JULIA_DEPOT_PATH=$(SRCDIR)/relocatedepot/julia $(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --revise $*)
+	$(call PRINT_JULIA, $(call spawn,JULIA_DEBUG=loading RELOCATEDEPOT="" JULIA_DEPOT_PATH=$(SRCDIR)/relocatedepot/julia $(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --revise $*)
 
 embedding:
 	@$(MAKE) -C $(SRCDIR)/$@ check $(EMBEDDING_ARGS)

--- a/test/RelocationTestPkg/Project.toml
+++ b/test/RelocationTestPkg/Project.toml
@@ -1,3 +1,0 @@
-name = "RelocationTestPkg"
-uuid = "84019e0e-37c6-44aa-be55-38c734c0a527"
-version = "0.1.0"

--- a/test/RelocationTestPkg/Project.toml
+++ b/test/RelocationTestPkg/Project.toml
@@ -1,0 +1,3 @@
+name = "RelocationTestPkg"
+uuid = "84019e0e-37c6-44aa-be55-38c734c0a527"
+version = "0.1.0"

--- a/test/RelocationTestPkg/src/RelocationTestPkg.jl
+++ b/test/RelocationTestPkg/src/RelocationTestPkg.jl
@@ -1,0 +1,8 @@
+module RelocationTestPkg
+
+
+include_dependency("foo.txt")
+greet() = print("Hello World!")
+
+
+end # module RelocationTestPkg

--- a/test/RelocationTestPkg1/Project.toml
+++ b/test/RelocationTestPkg1/Project.toml
@@ -1,0 +1,4 @@
+name = "RelocationTestPkg1"
+uuid = "854e1adb-5a97-46bf-a391-1cfe05ac726d"
+authors = ["flo "]
+version = "0.1.0"

--- a/test/RelocationTestPkg1/src/RelocationTestPkg1.jl
+++ b/test/RelocationTestPkg1/src/RelocationTestPkg1.jl
@@ -1,0 +1,5 @@
+module RelocationTestPkg1
+
+greet() = print("Hello World!")
+
+end # module RelocationTestPkg1

--- a/test/RelocationTestPkg2/Project.toml
+++ b/test/RelocationTestPkg2/Project.toml
@@ -1,0 +1,4 @@
+name = "RelocationTestPkg2"
+uuid = "8d933983-b090-4b0b-a37e-c34793f459d1"
+authors = ["flo "]
+version = "0.1.0"

--- a/test/RelocationTestPkg2/src/RelocationTestPkg2.jl
+++ b/test/RelocationTestPkg2/src/RelocationTestPkg2.jl
@@ -1,8 +1,6 @@
-module RelocationTestPkg
-
+module RelocationTestPkg2
 
 include_dependency("foo.txt")
 greet() = print("Hello World!")
 
-
-end # module RelocationTestPkg
+end # module RelocationTestPkg2

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -24,7 +24,7 @@ const TESTNAMES = [
         "some", "meta", "stacktraces", "docs", "gc",
         "misc", "threads", "stress", "binaryplatforms", "atexit",
         "enums", "cmdlineargs", "int", "interpreter",
-        "checked", "bitset", "floatfuncs", "precompile",
+        "checked", "bitset", "floatfuncs", "precompile", "relocatedepot",
         "boundscheck", "error", "ambiguous", "cartesian", "osutils",
         "channels", "iostream", "secretbuffer", "specificity",
         "reinterpretarray", "syntax", "corelogging", "missing", "asyncmap",

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -381,7 +381,7 @@ precompile_test_harness(false) do dir
         @test string(Base.Docs.doc(Foo.Bar.bar)) == "bar function\n"
         @test string(Base.Docs.doc(Foo.Bar)) == "Bar module\n"
 
-        modules, (deps, requires), required_modules, _... = Base.parse_cache_header(cachefile)
+        modules, (deps, _, requires), required_modules, _... = Base.parse_cache_header(cachefile)
         discard_module = mod_fl_mt -> mod_fl_mt.filename
         @test modules == [ Base.PkgId(Foo) => Base.module_build_id(Foo) % UInt64 ]
         @test map(x -> x.filename, deps) == [ Foo_file, joinpath(dir, "foo.jl"), joinpath(dir, "bar.jl") ]
@@ -422,7 +422,8 @@ precompile_test_harness(false) do dir
         @test Dict(modules) == modules_ok
 
         @test discard_module.(deps) == deps1
-        modules, (deps, requires), required_modules, _... = Base.parse_cache_header(cachefile; srcfiles_only=true)
+        # modules, (_, deps, requires), required_modules, _... = Base.parse_cache_header(cachefile; srcfiles_only=true)
+        modules, (_, deps, requires), required_modules, _... = Base.parse_cache_header(cachefile)
         @test map(x -> x.filename, deps) == [Foo_file]
 
         @test current_task()(0x01, 0x4000, 0x30031234) == 2
@@ -485,7 +486,7 @@ precompile_test_harness(false) do dir
         """)
     Nest = Base.require(Main, Nest_module)
     cachefile = joinpath(cachedir, "$Nest_module.ji")
-    modules, (deps, requires), required_modules, _... = Base.parse_cache_header(cachefile)
+    modules, (deps, _, requires), required_modules, _... = Base.parse_cache_header(cachefile)
     @test last(deps).modpath == ["NestInner"]
 
     UsesB_module = :UsesB4b3a94a1a081a8cb
@@ -507,7 +508,7 @@ precompile_test_harness(false) do dir
         """)
     UsesB = Base.require(Main, UsesB_module)
     cachefile = joinpath(cachedir, "$UsesB_module.ji")
-    modules, (deps, requires), required_modules, _... = Base.parse_cache_header(cachefile)
+    modules, (deps, _, requires), required_modules, _... = Base.parse_cache_header(cachefile)
     id1, id2 = only(requires)
     @test Base.pkgorigins[id1].cachepath == cachefile
     @test Base.pkgorigins[id2].cachepath == joinpath(cachedir, "$B_module.ji")

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1712,7 +1712,7 @@ precompile_test_harness("PkgCacheInspector") do load_path
         try
             # isvalid_cache_header returns checksum id or zero
             Base.isvalid_cache_header(io) == 0 && throw(ArgumentError("Invalid header in cache file $cachefile."))
-            depmodnames = Base.parse_cache_header(io, cachefile)[3]
+            depmodnames = Base.parse_cache_header(io)[3]
             Base.isvalid_file_crc(io) || throw(ArgumentError("Invalid checksum in cache file $cachefile."))
         finally
             close(io)

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1712,7 +1712,7 @@ precompile_test_harness("PkgCacheInspector") do load_path
         try
             # isvalid_cache_header returns checksum id or zero
             Base.isvalid_cache_header(io) == 0 && throw(ArgumentError("Invalid header in cache file $cachefile."))
-            depmodnames = Base.parse_cache_header(io)[3]
+            depmodnames = Base.parse_cache_header(io, cachefile)[3]
             Base.isvalid_file_crc(io) || throw(ArgumentError("Invalid checksum in cache file $cachefile."))
         finally
             close(io)

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -382,7 +382,7 @@ precompile_test_harness(false) do dir
         @test string(Base.Docs.doc(Foo.Bar)) == "Bar module\n"
 
         modules, (deps, requires), required_modules, _... = Base.parse_cache_header(cachefile)
-        discard_module = mod_fl_mt -> (mod_fl_mt.filename, mod_fl_mt.mtime)
+        discard_module = mod_fl_mt -> mod_fl_mt.filename
         @test modules == [ Base.PkgId(Foo) => Base.module_build_id(Foo) % UInt64 ]
         @test map(x -> x.filename, deps) == [ Foo_file, joinpath(dir, "foo.jl"), joinpath(dir, "bar.jl") ]
         @test requires == [ Base.PkgId(Foo) => Base.PkgId(string(FooBase_module)),

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -584,12 +584,12 @@ precompile_test_harness(false) do dir
     fb_uuid = Base.module_build_id(FooBar)
     sleep(2); touch(FooBar_file)
     insert!(DEPOT_PATH, 1, dir2)
-    @test Base.stale_cachefile(FooBar_file, joinpath(cachedir, "FooBar.ji")) === true
+    @test Base.stale_cachefile(FooBar_file, joinpath(cachedir, "FooBar.ji")) isa Tsc
     @eval using FooBar1
     @test !isfile(joinpath(cachedir2, "FooBar.ji"))
     @test !isfile(joinpath(cachedir, "FooBar1.ji"))
     @test isfile(joinpath(cachedir2, "FooBar1.ji"))
-    @test Base.stale_cachefile(FooBar_file, joinpath(cachedir, "FooBar.ji")) === true
+    @test Base.stale_cachefile(FooBar_file, joinpath(cachedir, "FooBar.ji")) isa Tsc
     @test Base.stale_cachefile(FooBar1_file, joinpath(cachedir2, "FooBar1.ji")) isa Tsc
     @test fb_uuid == Base.module_build_id(FooBar)
     fb_uuid1 = Base.module_build_id(FooBar1)

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -422,7 +422,6 @@ precompile_test_harness(false) do dir
         @test Dict(modules) == modules_ok
 
         @test discard_module.(deps) == deps1
-        # modules, (_, deps, requires), required_modules, _... = Base.parse_cache_header(cachefile; srcfiles_only=true)
         modules, (_, deps, requires), required_modules, _... = Base.parse_cache_header(cachefile)
         @test map(x -> x.filename, deps) == [Foo_file]
 

--- a/test/relocatedepot.jl
+++ b/test/relocatedepot.jl
@@ -1,0 +1,23 @@
+using Test
+
+
+include("testenv.jl")
+
+
+@testset "compile and load relocated pkg" begin
+    pkg = Base.identify_package("DelimitedFiles")
+    if !test_relocated_depot
+        # precompile
+        Base.require(Main, :DelimitedFiles)
+        @test Base.root_module_exists(pkg) == true
+    else
+        path = Base.locate_package(pkg)
+        iscached = @lock Base.require_lock begin
+            m = Base._require_search_from_serialized(pkg, path, UInt128(0))
+            m isa Module
+        end
+        @test iscached == true # can load from cache
+        Base.require(Main, :DelimitedFiles)
+        @test Base.root_module_exists(pkg) == true
+    end
+end

--- a/test/relocatedepot.jl
+++ b/test/relocatedepot.jl
@@ -5,68 +5,99 @@ using Logging
 include("testenv.jl")
 
 
+function test_harness(@nospecialize(fn))
+    load_path = copy(LOAD_PATH)
+    depot_path = copy(DEPOT_PATH)
+    try
+        fn()
+    finally
+        copy!(LOAD_PATH, load_path)
+        copy!(DEPOT_PATH, depot_path)
+    end
+end
+
+
 if !test_relocated_depot
 
-    @testset "precompile RelocationTestPkg" begin
-        load_path = copy(LOAD_PATH)
-        depot_path = copy(DEPOT_PATH)
-        push!(LOAD_PATH, @__DIR__)
-        push!(DEPOT_PATH, @__DIR__)
-        try
-            pkg = Base.identify_package("RelocationTestPkg")
+    @testset "precompile RelocationTestPkg1" begin
+        pkgname = "RelocationTestPkg1"
+        test_harness() do
+            push!(LOAD_PATH, @__DIR__)
+            push!(DEPOT_PATH, @__DIR__)
+            pkg = Base.identify_package(pkgname)
             cachefiles = Base.find_all_in_cache_path(pkg)
             rm.(cachefiles, force=true)
-            rm(joinpath(@__DIR__, "RelocationTestPkg", "src", "foo.txt"), force=true)
-            @test Base.isprecompiled(pkg) == false # include_dependency foo.txt is missing
+            @test Base.isprecompiled(pkg) == false
             Base.require(pkg) # precompile
-            @test Base.isprecompiled(pkg, ignore_loaded=true) == false # foo.txt still missing
-            touch(joinpath(@__DIR__, "RelocationTestPkg", "src", "foo.txt"))
             @test Base.isprecompiled(pkg, ignore_loaded=true) == true
-        finally
-            copy!(LOAD_PATH, load_path)
-            copy!(DEPOT_PATH, depot_path)
+        end
+    end
+
+    @testset "precompile RelocationTestPkg2 (contains include_dependency)" begin
+        pkgname = "RelocationTestPkg2"
+        test_harness() do
+            push!(LOAD_PATH, @__DIR__)
+            push!(DEPOT_PATH, @__DIR__)
+            pkg = Base.identify_package(pkgname)
+            cachefiles = Base.find_all_in_cache_path(pkg)
+            rm.(cachefiles, force=true)
+            @test Base.isprecompiled(pkg) == false
+            touch(joinpath(@__DIR__, pkgname, "src", "foo.txt"))
+            Base.require(pkg) # precompile
+            @info "SERS OIDA"
+            @test Base.isprecompiled(pkg, ignore_loaded=true) == true
         end
     end
 
 else
 
-    @testset "load stdlib from test/relocatedepot" begin
-        # stdlib should be already precompiled
-        pkg = Base.identify_package("DelimitedFiles")
-        @test Base.isprecompiled(pkg, ignore_loaded=true) == true
-    end
-
-    @testset "load RelocationTestPkg from test/relocatedepot" begin
-        load_path = copy(LOAD_PATH)
-        depot_path = copy(DEPOT_PATH)
-        # moved source and depot into test/relocatedepot
-        push!(LOAD_PATH, joinpath(@__DIR__, "relocatedepot"))
-        push!(DEPOT_PATH, joinpath(@__DIR__, "relocatedepot"))
-        try
-            pkg = Base.identify_package("RelocationTestPkg")
-            rm(joinpath(@__DIR__, "relocatedepot", "RelocationTestPkg", "src", "foo.txt"), force=true)
-            @test Base.isprecompiled(pkg, ignore_loaded=true) == false # foo.txt missing
-            touch(joinpath(@__DIR__, "relocatedepot", "RelocationTestPkg", "src", "foo.txt"))
-            @test Base.isprecompiled(pkg) == true
-        finally
-            copy!(LOAD_PATH, load_path)
-            copy!(DEPOT_PATH, depot_path)
+    # must come before any of the load tests, because the will recompile and generate new cache files
+    @testset "attempt loading precompiled pkgs when depot is missing" begin
+        test_harness() do
+            empty!(LOAD_PATH)
+            push!(LOAD_PATH, joinpath(@__DIR__, "relocatedepot"))
+            for pkgname in ("RelocationTestPkg1", "RelocationTestPkg2")
+                pkg = Base.identify_package(pkgname)
+                cachefile = only(Base.find_all_in_cache_path(pkg))
+                @info cachefile
+                @test_throws ArgumentError("""
+                  Failed to determine depot from srctext files in cache file $cachefile.
+                  - Make sure you have adjusted DEPOT_PATH in case you relocated depots.""") Base.isprecompiled(pkg)
+            end
         end
     end
 
+    @testset "load stdlib from test/relocatedepot" begin
+        test_harness() do
+            push!(LOAD_PATH, joinpath(@__DIR__, "relocatedepot"))
+            push!(DEPOT_PATH, joinpath(@__DIR__, "relocatedepot"))
+            # stdlib should be already precompiled
+            pkg = Base.identify_package("DelimitedFiles")
+            @test Base.isprecompiled(pkg) == true
+        end
+    end
 
-    @testset "throw when failed to find a depot for RelocationTestPkg" begin
-        load_path = copy(LOAD_PATH)
-        push!(LOAD_PATH, joinpath(@__DIR__, "relocatedepot"))
-        try
-            pkg = Base.identify_package("RelocationTestPkg")
-            touch(joinpath(@__DIR__, "relocatedepot", "RelocationTestPkg", "src", "foo.txt"))
-            cachefile = only(Base.find_all_in_cache_path(pkg))
-            @test_throws ArgumentError("""
-              Failed to determine depot from srctext files in cache file $cachefile.
-              - Make sure you have adjusted DEPOT_PATH in case you relocated depots.""") Base.isprecompiled(pkg)
-        finally
-            copy!(LOAD_PATH, load_path)
+    @testset "load RelocationTestPkg1 from test/relocatedepot" begin
+        pkgname = "RelocationTestPkg1"
+        test_harness() do
+            push!(LOAD_PATH, joinpath(@__DIR__, "relocatedepot"))
+            push!(DEPOT_PATH, joinpath(@__DIR__, "relocatedepot"))
+            pkg = Base.identify_package(pkgname)
+            @test Base.isprecompiled(pkg) == true
+            Base.require(pkg) # re-precompile
+            @test Base.isprecompiled(pkg) == true
+        end
+    end
+
+    @testset "load RelocationTestPkg2 (contains include_dependency) from test/relocatedepot" begin
+        pkgname = "RelocationTestPkg2"
+        test_harness() do
+            push!(LOAD_PATH, joinpath(@__DIR__, "relocatedepot"))
+            push!(DEPOT_PATH, joinpath(@__DIR__, "relocatedepot"))
+            pkg = Base.identify_package(pkgname)
+            @test Base.isprecompiled(pkg) == false # moving depot changes mtime of include_dependency
+            Base.require(pkg) # re-precompile
+            @test Base.isprecompiled(pkg) == true
         end
     end
 

--- a/test/relocatedepot.jl
+++ b/test/relocatedepot.jl
@@ -54,4 +54,20 @@ else
         end
     end
 
+
+    @testset "throw when failed to find a depot for RelocationTestPkg" begin
+        load_path = copy(LOAD_PATH)
+        push!(LOAD_PATH, joinpath(@__DIR__, "relocatedepot"))
+        try
+            pkg = Base.identify_package("RelocationTestPkg")
+            touch(joinpath(@__DIR__, "relocatedepot", "RelocationTestPkg", "src", "foo.txt"))
+            cachefile = only(Base.find_all_in_cache_path(pkg))
+            @test_throws ArgumentError("""
+              Failed to determine depot from srctext files in cache file $cachefile.
+              - Make sure you have adjusted DEPOT_PATH in case you relocated depots.""") Base.isprecompiled(pkg)
+        finally
+            copy!(LOAD_PATH, load_path)
+        end
+    end
+
 end

--- a/test/testenv.jl
+++ b/test/testenv.jl
@@ -35,6 +35,8 @@ if !@isdefined(testenv_defined)
         const rr_exename = ``
     end
 
+    const test_relocated_depot = haskey(ENV, "RELOCATEDEPOT")
+
     function addprocs_with_testenv(X; rr_allowed=true, kwargs...)
         exename = rr_allowed ? `$rr_exename $test_exename` : test_exename
         if X isa Integer


### PR DESCRIPTION
Fixes #45215
Fixes #47943
Fixes #45541
Fixes #50918 

---

**Updated description**

Hi.

I tried my luck with https://github.com/JuliaLang/julia/issues/47943 and I implemented what was suggested by OP.

String replacement with `@depot` when serializing out happens with any paths that are located inside a `DEPOT_PATH` (first match wins). If no match, then we emit the absolute file path as before. Right now we only emit one token `@depot`.

String replacement of `@depot` when loading happens now on a `.ji` file basis and only if all the listed include dependencies can be resolved to files located in one and the same depot on `DEPOT_PATH` (again, first match wins). If we can't resolve, then the cache is invalided with `stale_cachefile`.

This PR does not explicitly address any of #4630 or #33065 some suggested would be nice to fix in one swipe with #47943. It remains to check if this was accidentally solved.

I also did not understand what was meant in https://github.com/JuliaLang/julia/issues/47943#issuecomment-1361023611 with the `deps/build.jl` and `artifacts` issue and how that should be addressed here.

# Status of this PR

The following works for me locally,
- build julia, run it and compile a few packages
```julia
$ cd <git-root-julia>
$ export JULIA_DEPOT_PATH="$(pwd)/usr/share/julia"
$ ./julia
julia> using Pkg; Pkg.add("UnPack")
julia> using UnPack
```
- exit julia, copy the depot (`<git-root>/usr/share/julia/`) somewhere else, set `JULIA_DEPOT_PATH` accordingly, e.g.
```sh
$ cp usr/share/julia /tmp
$ export JULIA_DEPOT_PATH="/tmp/julia"
```
- restart julia and verify the package can be loaded without compilation by running
```julia
$ ./julia
pkg = Base.identify_package("UnPack")
path = Base.locate_package(pkg)
iscached = @lock Base.require_lock begin
    m = Base._require_search_from_serialized(pkg, path, UInt128(0))
    m isa Module
end
iscached == true # can load from cache
```


### Open questions

From docs:
```
The first entry is the "user depot" and should be writable by and owned by the
current user. The user depot is where: registries are cloned, new package versions
are installed, named environments are created and updated, package repos are cloned,
newly compiled package image files are saved, log files are written, development
packages are checked out by default, and global configuration data is saved. Later
entries in the depot path are treated as read-only and are appropriate for
registries, packages, etc. installed and managed by system administrators.
```
- ~~Does `... are treated as read-only ...` guarantee that Julia will never write anything to a path other than `DEPOT_PATH[1]`?~~
- ~~[Need to test this myself] If we load packages from any of the read-only paths, their precompiles also end up in `DEPOT_PATH[1]/compiled`?~~

~~If both questions can be answered with yes, then I guess its save to replace `@depot` always with `DEPOT_PATH[1]` when loading. The path for `@stdlib` is replaced with `Sys.STDLIB`, because that seems to be tied to where the julia binary sits.~~

I think I could work around all of that by following more closely what was proposed in https://github.com/JuliaLang/julia/issues/47943#issue-1505400826:

> If we have a package Foo.jl which has been precompiled, that cache should reference the source files as something like @depot/packages/Foo_jll/a2b2c3/src/Foo.jl. During cache header verification, we string-replace ^@depot to the same depot that the cache file is currently being loaded from. I do not think it's worthwhile to allow this path to resolve to other depots on the depot path; it's too easy to find the "wrong" files, and I think it's reasonable to expect an atomic move of all associated resources for a package image.

See top of this post on how it is implemented now.

### TODO

- [x] Get basic functionality working.
- [x] Write basic test.
- [x] PkgEval -- first run looked good.
- [x] Fix depot relocation logic.
- [x] Write more tests.

I would appreciate any feedback!