### PR TITLE
Use an intrinsic to determine fmin/fmax availability.

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -33,6 +33,7 @@ STATISTIC(Emitted_fptrunc, "Number of fptrunc calls emitted");
 STATISTIC(Emitted_fpext, "Number of fpext calls emitted");
 STATISTIC(Emitted_not_int, "Number of not_int calls emitted");
 STATISTIC(Emitted_have_fma, "Number of have_fma calls emitted");
+STATISTIC(Emitted_have_fminmax, "Number of have_fminmax calls emitted");
 STATISTIC(EmittedUntypedIntrinsics, "Number of untyped intrinsics emitted");
 
 using namespace JL_I;
@@ -1251,6 +1252,28 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
 
         // select the appropriated overloaded intrinsic
         std::string intr_name = "julia.cpu.have_fma.";
+        if (dt == jl_float32_type)
+            intr_name += "f32";
+        else if (dt == jl_float64_type)
+            intr_name += "f64";
+        else
+            return emit_runtime_call(ctx, f, argv.data(), nargs);
+
+        FunctionCallee intr = jl_Module->getOrInsertFunction(intr_name, getInt1Ty(ctx.builder.getContext()));
+        auto ret = ctx.builder.CreateCall(intr);
+        return mark_julia_type(ctx, ret, false, jl_bool_type);
+    }
+
+    case have_fminmax: {
+        ++Emitted_have_fminmax;
+        assert(nargs == 1);
+        const jl_cgval_t &x = argv[0];
+        if (!x.constant || !jl_is_datatype(x.constant))
+            return emit_runtime_call(ctx, f, argv.data(), nargs);
+        jl_datatype_t *dt = (jl_datatype_t*) x.constant;
+
+        // select the appropriated overloaded intrinsic
+        std::string intr_name = "julia.cpu.have_fminmax.";
         if (dt == jl_float32_type)
             intr_name += "f32";
         else if (dt == jl_float64_type)

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -103,6 +103,7 @@
     ADD_I(arraylen, 1) \
     /*  cpu feature tests */ \
     ADD_I(have_fma, 1) \
+    ADD_I(have_fminmax, 1) \
     /*  hidden intrinsics */ \
     ADD_HIDDEN(cglobal_auto, 1)
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1361,6 +1361,7 @@ JL_DLLEXPORT jl_value_t *jl_flipsign_int(jl_value_t *a, jl_value_t *b);
 
 JL_DLLEXPORT jl_value_t *jl_arraylen(jl_value_t *a);
 JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_have_fminmax(jl_value_t *a);
 JL_DLLEXPORT int jl_stored_inline(jl_value_t *el_type);
 JL_DLLEXPORT jl_value_t *(jl_array_data_owner)(jl_array_t *a);
 JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i);

--- a/src/llvm-multiversioning.cpp
+++ b/src/llvm-multiversioning.cpp
@@ -49,6 +49,7 @@
 using namespace llvm;
 
 extern Optional<bool> always_have_fma(Function&, const Triple &TT);
+extern Optional<bool> always_have_fminmax(Function&, const Triple &TT);
 
 namespace {
 constexpr uint32_t clone_mask =
@@ -106,6 +107,11 @@ static uint32_t collect_func_info(Function &F, const Triple &TT, bool &has_vecca
                             // for some platforms we know they always do (or don't) support
                             // FMA. in those cases we don't need to clone the function.
                             if (!always_have_fma(*callee, TT).hasValue())
+                                flag |= JL_TARGET_CLONE_CPU;
+                        } else if (name.startswith("julia.cpu.have_fminmax.")) {
+                            // for some platforms we know they always do (or don't) support
+                            // FMIN/FMAX. in those cases we don't need to clone the function.
+                            if (!always_have_fminmax(*callee, TT).hasValue())
                                 flag |= JL_TARGET_CLONE_CPU;
                         } else {
                             flag |= JL_TARGET_CLONE_CPU;

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1467,3 +1467,10 @@ JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *typ)
     // TODO: run-time feature check?
     return jl_false;
 }
+
+JL_DLLEXPORT jl_value_t *jl_have_fminmax(jl_value_t *typ)
+{
+    JL_TYPECHK(have_fminmax, datatype, typ);
+    // TODO: run-time feature check?
+    return jl_false;
+}


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/47814 introduced the use of `llvm.minimum` and `llvm.maximum` in order to use hardware-accelerated `fmin`/`fmax`, but doing so by checking `Sys.ARCH` isn't ideal. Instead, switch it to an instrinsic like `have_fma`, which may make it possible to extend this to more platforms.

I ran into this because our Metal back-end didn't support `llvm.minimum`. It's something I have fixed since, so we don't strictly need this kind of optimization.