### PR TITLE
Add Contributor Metrics Widget to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Notes for Julia Contributors
 
+<a href="https://github.com/monoclehq">
+    <img src="https://open-source-assets.middlewarehq.com/svgs/JuliaLang-julia-contributor-metrics-dark-widget.svg"></img>
+</a>
+
 Hi! If you are new to the Julia community: welcome, and thanks for trying Julia. Please be sure to respect our [community standards](https://julialang.org/community/standards) in all interactions.
 
 If you are already familiar with Julia itself, this blog post by Katharine Hyatt on [Making your first Julia pull request](https://kshyatt.github.io/post/firstjuliapr/) is a great way to get started.


### PR DESCRIPTION
## Why Do why need this ?

- Contributor recognition can help develop an active opensource community around projects.
- A widget showcasing recent contributions can be motivating for new contributors.
- This widget is already present in some selected opensource repositories- [RocketChat/Apps.GitHub22](https://github.com/RocketChat/Apps.Github22), [RocketChat/EmbeddedChat](https://github.com/RocketChat/EmbeddedChat), [RocketChat/RC4Community](https://github.com/RocketChat/RC4Community) etc. and has helped in community building around those projects. 
- A number of  students had mentioned their rank on this widget in their GSoC 2023 proposal for RocketChat. Hence, this can be great motivator for student contributors. 

## Proposed Changes

- Add a contributor widget hosted by [Middleware](https://www.middlewarehq.com/) that updates the contributor statistics regularly and renders updated widget.
- The Widget is served via a CDN and is updated regularly based on contributor statistics over the last 2 months.

![image](https://github.com/JuliaLang/julia/assets/70485812/d8bbbdd1-bf97-4b16-b8ea-84eeb2b00de8)