### PR TITLE
Fix subtyping freeze in 1.9.0

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1386,7 +1386,8 @@ static int local_forall_exists_subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t 
         // Once limit_slow == 1, also skip it if
         // 1) `forall_exists_subtype` return false
         // 2) the left `Union` looks big
-        if (noRmore || (limit_slow && (count > 3  || !sub)))
+        // NOTE: altered to fix issue 49857
+        if (noRmore || limit_slow)
             e->Runions.more = oldRmore;
     }
     else {

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2272,8 +2272,9 @@ abstract type P47654{A} end
     @test_broken typeintersect(Tuple{Vector{VT}, Vector{VT}} where {N1, VT<:AbstractVector{N1}},
                 Tuple{Vector{VN} where {N, VN<:AbstractVector{N}}, Vector{Vector{Float64}}}) !== Union{}
     #issue 40865
-    @test Tuple{Set{Ref{Int}}, Set{Ref{Int}}} <: Tuple{Set{KV}, Set{K}} where {K,KV<:Union{K,Ref{K}}}
-    @test Tuple{Set{Val{Int}}, Set{Val{Int}}} <: Tuple{Set{KV}, Set{K}} where {K,KV<:Union{K,Val{K}}}
+    #broken due to 49857 and 49875
+    @test_broken Tuple{Set{Ref{Int}}, Set{Ref{Int}}} <: Tuple{Set{KV}, Set{K}} where {K,KV<:Union{K,Ref{K}}}
+    @test_broken Tuple{Set{Val{Int}}, Set{Val{Int}}} <: Tuple{Set{KV}, Set{K}} where {K,KV<:Union{K,Val{K}}}
 
     #issue 39099
     A = Tuple{Tuple{Int, Int, Vararg{Int, N}}, Tuple{Int, Vararg{Int, N}}, Tuple{Vararg{Int, N}}} where N
@@ -2310,7 +2311,8 @@ end
 
 # try to fool a greedy algorithm that picks X=Int, Y=String here
 @test Tuple{Ref{Union{Int,String}}, Ref{Union{Int,String}}} <: Tuple{Ref{Union{X,Y}}, Ref{X}} where {X,Y}
-@test Tuple{Ref{Union{Int,String,Missing}}, Ref{Union{Int,String}}} <: Tuple{Ref{Union{X,Y}}, Ref{X}} where {X,Y}
+# broken due to 49857 and 49875
+@test_broken Tuple{Ref{Union{Int,String,Missing}}, Ref{Union{Int,String}}} <: Tuple{Ref{Union{X,Y}}, Ref{X}} where {X,Y}
 
 @test !(Tuple{Any, Any, Any} <: Tuple{Any, Vararg{T}} where T)
 


### PR DESCRIPTION
Closes #49857.

As [suggested](https://github.com/JuliaLang/julia/pull/49859#issuecomment-1552341649) by @N5N3, this disables the slow path in `local_forall_exists_subtype` as an alternative to [backing out](https://github.com/JuliaLang/julia/pull/49859) #48441.

Confirmed that it fixes #49857. Also confirmed that the test added in #49014 passes. However, as with #49859, this fix will reopen #40865.

Cc: @quinnj and @NHDaly 