### PR TITLE
Add a fast-path for #49857

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1510,6 +1510,9 @@ static int local_forall_exists_subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t 
 {
     int16_t oldRmore = e->Runions.more;
     int sub;
+    // fast-path for #49857
+    if (obviously_in_union(y, x))
+        return 1;
     int kindx = !jl_has_free_typevars(x);
     int kindy = !jl_has_free_typevars(y);
     if (kindx && kindy)

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2547,3 +2547,6 @@ let T = Tuple{Union{Type{T}, Type{S}}, Union{Val{T}, Val{S}}, Union{Val{T}, S}} 
     @test typeintersect(T, S) == Tuple{Type{A}, Union{Val{A}, Val{S} where S<:Union{Val, A}, Val{x} where x<:Val, Val{x} where x<:Union{Val, A}}, Val{A}} where A<:(Val{S} where S<:Val)
     @test typeintersect(S, T) == Tuple{Type{T}, Union{Val{T}, Val{S}}, Val{T}} where {T<:Val, S<:(Union{Val{A}, Val} where A)}
 end
+
+#issue #49857
+@test !<:(Type{Vector{Union{Base.BitInteger, Base.IEEEFloat, StridedArray, Missing, Nothing, Val{T}}}} where {T}, Type{Array{T}} where {T})


### PR DESCRIPTION
The union explosion is caused by `Type{Vector{Union{....}} <: Type{Array{T}} where {T}`

280f9993608956f76eac30fc85e1c6ebbca4f5e6 only fixes for `Union{......}` without free `Typevar`.

This PR makes sure the remaining get fixed.