### PR TITLE
Extend SROA comparison lifting to `Core.ifelse`

### DIFF
--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -537,7 +537,7 @@ end
 # comparison lifting
 # ==================
 
-let # lifting `===`
+let # lifting `===` through PhiNode
     src = code_typed1((Bool,Int,)) do c, x
         y = c ? x : nothing
         y === nothing # => ϕ(false, true)
@@ -557,7 +557,15 @@ let # lifting `===`
     end
 end
 
-let # lifting `isa`
+let # lifting `===` through Core.ifelse
+    src = code_typed1((Bool,Int,)) do c, x
+        y = Core.ifelse(c, x, nothing)
+        y === nothing # => Core.ifelse(c, false, true)
+    end
+    @test count(iscall((src, ===)), src.code) == 0
+end
+
+let # lifting `isa` through PhiNode
     src = code_typed1((Bool,Int,)) do c, x
         y = c ? x : nothing
         isa(y, Int) # => ϕ(true, false)
@@ -580,7 +588,16 @@ let # lifting `isa`
     end
 end
 
-let # lifting `isdefined`
+let # lifting `isa` through Core.ifelse
+    src = code_typed1((Bool,Int,)) do c, x
+        y = Core.ifelse(c, x, nothing)
+        isa(y, Int) # => Core.ifelse(c, true, false)
+    end
+    @test count(iscall((src, isa)), src.code) == 0
+end
+
+
+let # lifting `isdefined` through PhiNode
     src = code_typed1((Bool,Some{Int},)) do c, x
         y = c ? x : nothing
         isdefined(y, 1) # => ϕ(true, false)
@@ -601,6 +618,14 @@ let # lifting `isdefined`
     @test !any(src.code) do @nospecialize x
         iscall((src, isdefined), x) && argextype(x.args[2], src) isa Union
     end
+end
+
+let # lifting `isdefined` through Core.ifelse
+    src = code_typed1((Bool,Some{Int},)) do c, x
+        y = Core.ifelse(c, x, nothing)
+        isdefined(y, 1) # => Core.ifelse(c, true, false)
+    end
+    @test count(iscall((src, isdefined)), src.code) == 0
 end
 
 mutable struct Foo30594; x::Float64; end


### PR DESCRIPTION
This change extends our existing transformation for
 ```φ(a,b) === Const(c)   =>   φ(a === c, b === c)``` 
 to apply also to Core.ifelse calls, instead of just standard φ-Nodes

For a function `foo(cond) = isa(Core.ifelse(cond, 1.0, 1), Int64)` this improves the generated IR:

```julia
julia> @code_typed foo(true)
CodeInfo(
1 ─ %1 = Core.ifelse(cond, false, true)::Bool
└──      return %1
) => Bool
```

versus without this PR:
```julia
julia> @code_typed foo(true)
CodeInfo(
1 ─ %1 = Core.ifelse(cond, 1.0, 1)::Union{Float64, Int64}
│   %2 = (%1 isa Main.Int64)::Bool
└──      return %2
) => Bool
```

~~Draft to get early feedback before I give it another once-over and revise naming later. I'm not entirely happy with how a `Union{Expr,PhiNode}` traces through the code now, but it seemed preferable to duplicating the code~~
   
