### PR TITLE
show mark-queue on GC critical error

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1886,8 +1886,8 @@ JL_NORETURN NOINLINE void gc_dump_queue_and_abort(jl_ptls_t ptls, jl_datatype_t 
         jl_safe_printf("~~~~~~~~~~ ptr queue top ~~~~~~~~~~\n");
         while ((new_obj = gc_ptr_queue_steal_from(mq)) != NULL) {
             jl_(new_obj);
+            jl_safe_printf("==========\n");
         }
-        jl_safe_printf("==========\n");
         jl_safe_printf("~~~~~~~~~~ ptr queue bottom ~~~~~~~~~~\n");
     }
     abort();

--- a/src/gc.c
+++ b/src/gc.c
@@ -1871,6 +1871,28 @@ STATIC_INLINE jl_gc_chunk_t gc_chunkqueue_pop(jl_gc_markqueue_t *mq) JL_NOTSAFEP
     return c;
 }
 
+// Dump mark queue on critical error
+JL_NORETURN NOINLINE void gc_dump_queue_and_abort(jl_ptls_t ptls, jl_datatype_t *vt) JL_NOTSAFEPOINT
+{
+    jl_safe_printf("GC error (probable corruption)\n");
+    jl_gc_debug_print_status();
+    jl_(vt);
+    jl_gc_debug_critical_error();
+    if (jl_n_gcthreads == 0) {
+        jl_safe_printf("\n");
+        jl_value_t *new_obj;
+        jl_gc_markqueue_t *mq = &ptls->mark_queue;
+        jl_safe_printf("thread %d ptr queue:\n", ptls->tid);
+        jl_safe_printf("~~~~~~~~~~ ptr queue top ~~~~~~~~~~\n");
+        while ((new_obj = gc_ptr_queue_steal_from(mq)) != NULL) {
+            jl_(new_obj);
+        }
+        jl_safe_printf("==========\n");
+        jl_safe_printf("~~~~~~~~~~ ptr queue bottom ~~~~~~~~~~\n");
+    }
+    abort();
+}
+
 // Steal chunk from `mq2`
 STATIC_INLINE jl_gc_chunk_t gc_chunkqueue_steal_from(jl_gc_markqueue_t *mq2) JL_NOTSAFEPOINT
 {
@@ -2567,6 +2589,11 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
                     objprofile_count(vt, bits == GC_OLD_MARKED, dtsz);
             }
             return;
+        }
+        else {
+            jl_datatype_t *vt = (jl_datatype_t *)vtag;
+            if (__unlikely(!jl_is_datatype(vt) || vt->smalltag))
+                gc_dump_queue_and_abort(ptls, vt);
         }
         jl_datatype_t *vt = (jl_datatype_t *)vtag;
         if (vt->name == jl_array_typename) {


### PR DESCRIPTION
Re-adds the capability of showing the mark-queue on a GC critical error.

Example:

```julia
a = Ref(1)
ptr = pointer_from_objref(a) - 8
unsafe_store!(Ptr{Int}(ptr), ptr)
GC.gc()
```

produces:

```
GC error (probable corruption)
Allocations: 15137 (Pool: 15119; Big: 18); GC: 0
Core.ReturnNode(val=SSAValue(1))

thread 0 ptr queue:
~~~~~~~~~~ ptr queue top ~~~~~~~~~~
...
Core.Binding(value=#<null>, globalref=Main.:(+), owner=#<null>, ty=#<null>, flags=0x00)
==========
Core.Binding(value=#<null>, globalref=Main.println, owner=Core.Binding(value=Base.println, globalref=Base.println, owner=<circular reference @-1>, ty=#<null>, flags=0x03), ty=#<null>, flags=0x00)
==========
Core.Binding(value=#<null>, globalref=Main.print, owner=#<null>, ty=#<null>, flags=0x00)
==========
Core.Binding(value=#<null>, globalref=Main.stdout, owner=#<null>, ty=#<null>, flags=0x00)
==========
Core.Binding(value=#<null>, globalref=Main.:(=>), owner=#<null>, ty=#<null>, flags=0x00)
==========
Core.Binding(value=#<null>, globalref=Main.IOContext, owner=Core.Binding(value=Base.IOContext{IO_t} where IO_t<:IO, globalref=Base.IOContext, owner=<circular reference @-1>, ty=Any, flags=0x03), ty=#<null>, flags=0x00)
==========
Core.Binding(value=#<null>, globalref=Main.:(/), owner=#<null>, ty=#<null>, flags=0x00)
==========
Core.Binding(value=#<null>, globalref=Main.show, owner=#<null>, ty=#<null>, flags=0x00)
==========
Core.Binding(value=#<null>, globalref=Main.DEPOT_PATH, owner=#<null>, ty=#<null>, flags=0x00)
==========
Core.Binding(value=#<null>, globalref=Main.Sys, owner=Core.Binding(value=Base.Sys, globalref=Base.Sys, owner=<circular reference @-1>, ty=#<null>, flags=0x03), ty=#<null>, flags=0x00)
==========
Core.Binding(value=#<null>, globalref=Main.Int64, owner=#<null>, ty=#<null>, flags=0x00)
==========
Core.Binding(value=#<null>, globalref=Main.:(@warn), owner=Core.Binding(value=Base.CoreLogging.var"@warn", globalref=Base.CoreLogging.:(@warn), owner=<circular reference @-1>, ty=#<null>, flags=0x03), ty=#<null>, flags=0x00)
==========
Core.Binding(value=#<null>, globalref=Main.Threads, owner=Core.Binding(value=Base.Threads, globalref=Base.Threads, owner=<circular reference @-1>, ty=#<null>, flags=0x03), ty=#<null>, flags=0x00)
==========
Core.Binding(value=#<null>, globalref=Main.:(!=), owner=Core.Binding(value=Base.:(!=), globalref=Base.:(!=), owner=<circular reference @-1>, ty=#<null>, flags=0x03), ty=#<null>, flags=0x00)
==========
Core.Binding(value=#<null>, globalref=Main.:(!==), owner=Core.Binding(value=Base.:(!==), globalref=Base.:(!==), owner=<circular reference @-1>, ty=#<null>, flags=0x03), ty=#<null>, flags=0x00)
==========
Core.Binding(value=#<null>, globalref=Main.IOBuffer, owner=Core.Binding(value=Base.GenericIOBuffer{Array{UInt8, 1}}, globalref=Base.IOBuffer, owner=<circular reference @-1>, ty=Any, flags=0x03), ty=#<null>, flags=0x00)
==========
Core.Binding(value=#<null>, globalref=Main.time_ns, owner=Core.Binding(value=Base.time_ns, globalref=Base.time_ns, owner=<circular reference @-1>, ty=#<null>, flags=0x03), ty=#<null>, flags=0x00)
==========
Core.Binding(value=Main.var"#1#2"{pre_output_time} where pre_output_time, globalref=Main.:(#1#2), owner=<circular reference @-1>, ty=Any, flags=0x01)
==========
Core.Binding(value=#<null>, globalref=Main.Ref, owner=Core.Binding(value=Ref{T} where T, globalref=Core.Ref, owner=<circular reference @-1>, ty=Any, flags=0x03), ty=#<null>, flags=0x00)
==========
~~~~~~~~~~ ptr queue bottom ~~~~~~~~~~
```