### PR TITLE
[MPFR] Fix printing of `BigFloat`

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -1028,7 +1028,7 @@ function _string(x::BigFloat, fmt::String)::String
     isfinite(x) || return string(Float64(x))
     _prettify_bigfloat(string_mpfr(x, fmt))
 end
-_string(x::BigFloat) = _string(x, "%.Re")
+_string(x::BigFloat) = _string(x, "%Re")
 _string(x::BigFloat, k::Integer) = _string(x, "%.$(k)Re")
 
 string(b::BigFloat) = _string(b)


### PR DESCRIPTION
Backport of a [bugfix](https://github.com/JuliaLang/julia/pull/48165/commits/1a7fa99aac7373d7f1d4355b46656cdf898a1353) in #48165, which is applicable also to previous versions of MPFR.  Ref: https://github.com/JuliaLang/julia/issues/49895#issuecomment-1556024084.  CC: @simonbyrne @fxcoudert.