### PR TITLE
[Foreign threads] Install signal-handlers early

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -829,7 +829,7 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
 #pragma GCC diagnostic ignored "-Wdangling-pointer"
 #endif
     // warning: this changes `jl_current_task`, so be careful not to call that from this function
-    jl_task_t *ct = jl_init_root_task(ptls, stack_lo, stack_hi);
+    jl_task_t *ct = jl_init_root_task(ptls, stack_lo, stack_hi, 1);
 #pragma GCC diagnostic pop
     JL_GC_PROMISE_ROOTED(ct);
     _finish_julia_init(rel, ptls, ct);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -860,7 +860,7 @@ void jl_init_intrinsic_functions(void);
 void jl_init_intrinsic_properties(void);
 void jl_init_tasks(void) JL_GC_DISABLED;
 void jl_init_stack_limits(int ismaster, void **stack_hi, void **stack_lo) JL_NOTSAFEPOINT;
-jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi);
+jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi, int8_t initialize_signals);
 void jl_init_serializer(void);
 void jl_gc_init(void);
 void jl_init_uv(void);

--- a/src/partr.c
+++ b/src/partr.c
@@ -143,7 +143,7 @@ void jl_threadfun(void *arg)
     void *stack_lo, *stack_hi;
     jl_init_stack_limits(0, &stack_lo, &stack_hi);
     // warning: this changes `jl_current_task`, so be careful not to call that from this function
-    jl_task_t *ct = jl_init_root_task(ptls, stack_lo, stack_hi);
+    jl_task_t *ct = jl_init_root_task(ptls, stack_lo, stack_hi, 1);
     JL_GC_PROMISE_ROOTED(ct);
 
     // wait for all threads

--- a/src/task.c
+++ b/src/task.c
@@ -1618,7 +1618,7 @@ static char *jl_alloc_fiber(_jl_ucontext_t *t, size_t *ssize, jl_task_t *owner) 
 #endif
 
 // Initialize a root task using the given stack.
-jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
+jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi, int8_t initialize_signals)
 {
     assert(ptls->root_task == NULL);
     // We need `gcstack` in `Task` to allocate Julia objects; *including* the `Task` type.
@@ -1626,6 +1626,7 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     // we need the `Task` type itself. We use stack-allocated "raw" `jl_task_t` struct to
     // workaround this chicken-and-egg problem. Note that this relies on GC to be turned
     // off as GC fails because we don't/can't allocate the type tag.
+    // TODO: This is being executed from foreign-threads with GC running.
     struct {
         jl_value_t *type;
         jl_task_t value;
@@ -1719,7 +1720,7 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     }
 #endif
 
-    if (jl_options.handle_signals == JL_OPTIONS_HANDLE_SIGNALS_ON)
+    if (initialize_signals && jl_options.handle_signals == JL_OPTIONS_HANDLE_SIGNALS_ON)
         jl_install_thread_signal_handler(ptls);
 
     return ct;


### PR DESCRIPTION
In #49928 we identified a couple of problems:

1. `jl_init_threadtls` sets the `gc_state` to 0, effectivly bypassing the `gc_unsafe_enter` transition
2. `jl_init_root_tasks` assumes that GC is turned off and installs the signal-handler very late

This moves the signal handler installation before the the `gc_unsafe` transition.
