### PR TITLE
[CYGWIN] [BUILD] deps/blastrampoline: Fix build with USE_BINARYBUILDER_BLASTRAMPOLINE=0

### DIFF
--- a/deps/blastrampoline.mk
+++ b/deps/blastrampoline.mk
@@ -16,16 +16,16 @@ $(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/build-configured: $(BUILDDIR)/$(BLASTRAMPO
 BLASTRAMPOLINE_BUILD_ROOT := $(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/src
 $(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/build-compiled: $(BUILDDIR)/$(BLASTRAMPOLINE_SRC_DIR)/build-configured
 	cd $(dir $@)/src && $(MAKE) $(BLASTRAMPOLINE_BUILD_OPTS)
-ifeq ($(OS), WINNT)
-	# Windows doesn't like soft link, use hard link
-	cd $(BLASTRAMPOLINE_BUILD_ROOT)/build/ && \
-		cp -f --dereference --link libblastrampoline.dll libblastrampoline.dll
-endif
 	echo 1 > $@
 
 define BLASTRAMPOLINE_INSTALL
 	$(MAKE) -C $(BLASTRAMPOLINE_BUILD_ROOT) install $(BLASTRAMPOLINE_BUILD_OPTS) DESTDIR="$2"
 endef
+ifeq ($(OS), WINNT)
+# Windows doesn't like soft link, use hard link to copy file without version suffix
+BLASTRAMPOLINE_INSTALL += && cd $2$$(build_prefix)/bin && \
+$$(WIN_MAKE_HARD_LINK) libblastrampoline-*.dll libblastrampoline.dll
+endif
 $(eval $(call staged-install, \
 	blastrampoline,$(BLASTRAMPOLINE_SRC_DIR), \
 	BLASTRAMPOLINE_INSTALL,, \


### PR DESCRIPTION
Error:
```
cp: cannot stat 'libblastrampoline.dll': No such file or directory
```
Build commands:
```
cd ~/devel/julia && \
git clean -ffxd --exclude=srccache --exclude=scratch && \
  [[ -d "./usr-staging" ]] && rm -rf "./usr-staging" ; \
  [[ -d "./usr" ]] && rm -rf "./usr" ; \
  [[ -d "./deps/srccache/blastrampoline.git" ]] && rm -rf "./deps/srccache/blastrampoline.git" ; \
  [[ -d "./deps/scratch/blastrampoline" ]] && rm -rf "./deps/scratch/blastrampoline" ; \
  [[ -d "./deps/scratch/SuiteSparse-5.10.1" ]] && rm -rf "./deps/scratch/SuiteSparse-5.10.1" ; \
git checkout master && \
git log -1 --format=oneline && \
echo 'XC_HOST = x86_64-w64-mingw32'          > Make.user && \
echo 'DEPS_GIT = 1'                         >> Make.user && \
echo 'USE_BINARYBUILDER_BLASTRAMPOLINE = 0' >> Make.user && \
echo 'USE_BINARYBUILDER_LIBSUITESPARSE = 0' >> Make.user && \
make -C deps install-csl && \
cp /usr/x86_64-w64-mingw32/sys-root/mingw/lib/libmsvcrt.a ./usr/lib/libmsvcrt.a && \
make all --jobs=1 2>&1 | tee ../julia-master-blastrampoline-all-build.log && echo -ne '\007'
```

Tim S.
