### PR TITLE
Improve error when indexing is interpreted as a typed comprehension

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1636,8 +1636,8 @@ typed_hcat(::Type{T}, A::AbstractVecOrMat...) where {T} = _typed_hcat(T, A)
 # interpreted as a typed concatenation. (issue #49676)
 typed_hcat(::AbstractArray, other...) = throw(ArgumentError("It is unclear whether you \
     intend to perform an indexing operation or typed concatenation. If you intend to \
-    perform indexing (v[1 + 2]) insert missing operator or adjust spacing to clarify. \
-    If you intend to perform typed concatenation (T[1 2]) ensure that T is a type."))
+    perform indexing (v[1 + 2]), adjust spacing or insert missing operator to clarify. \
+    If you intend to perform typed concatenation (T[1 2]), ensure that T is a type."))
 
 
 hcat(A::AbstractVecOrMat...) = typed_hcat(promote_eltype(A...), A...)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1633,7 +1633,10 @@ end
 typed_hcat(::Type{T}, A::AbstractVecOrMat...) where {T} = _typed_hcat(T, A)
 
 # Catch indexing errors like v[i +1] (instead of v[i+1] or v[i + 1]), where indexing is interpreted as typed a comprehension. (issue #49676)
-typed_hcat(::AbstractArray, other...) = throw(ArgumentError("It is unclear whether you intend to perform an indexing operation or typed list comprehension. If you intend to perform indexing (v[1 + 2]) insert missing operator or adjust spacing to clarify. If you intend to perform typed list comprehension, (T[1 2]) ensure that T is a type."))
+typed_hcat(::AbstractArray, other...) = throw(ArgumentError("It is unclear whether you \
+    intend to perform an indexing operation or typed concatenation. If you intend to \
+    perform indexing (v[1 + 2]) insert missing operator or adjust spacing to clarify. \
+    If you intend to perform typed concatenation (T[1 2]) ensure that T is a type."))
 
 
 hcat(A::AbstractVecOrMat...) = typed_hcat(promote_eltype(A...), A...)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1632,6 +1632,10 @@ end
 
 typed_hcat(::Type{T}, A::AbstractVecOrMat...) where {T} = _typed_hcat(T, A)
 
+# Catch indexing errors like vec[i +1], where indexing is interpreted as typed a comprehension. (issue #49676)
+typed_hcat(::AbstractArray, other...) = throw(ArgumentError("First argument must be a type. Hint: if indexing, missing or misplaced operators can cause this (e.g. vec[i +1] instead of vec[i+1])."))
+
+
 hcat(A::AbstractVecOrMat...) = typed_hcat(promote_eltype(A...), A...)
 hcat(A::AbstractVecOrMat{T}...) where {T} = typed_hcat(T, A...)
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1633,7 +1633,7 @@ end
 typed_hcat(::Type{T}, A::AbstractVecOrMat...) where {T} = _typed_hcat(T, A)
 
 # Catch indexing errors like v[i +1] (instead of v[i+1] or v[i + 1]), where indexing is
-# interpreted as typed a concatenation. (issue #49676)
+# interpreted as a typed concatenation. (issue #49676)
 typed_hcat(::AbstractArray, other...) = throw(ArgumentError("It is unclear whether you \
     intend to perform an indexing operation or typed concatenation. If you intend to \
     perform indexing (v[1 + 2]) insert missing operator or adjust spacing to clarify. \

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1632,8 +1632,8 @@ end
 
 typed_hcat(::Type{T}, A::AbstractVecOrMat...) where {T} = _typed_hcat(T, A)
 
-# Catch indexing errors like vec[i +1], where indexing is interpreted as typed a comprehension. (issue #49676)
-typed_hcat(::AbstractArray, other...) = throw(ArgumentError("First argument must be a type. Hint: if indexing, missing or misplaced operators can cause this (e.g. vec[i +1] instead of vec[i+1])."))
+# Catch indexing errors like v[i +1] (instead of v[i+1] or v[i + 1]), where indexing is interpreted as typed a comprehension. (issue #49676)
+typed_hcat(::AbstractArray, other...) = throw(ArgumentError("It is unclear whether you intend to perform an indexing operation or typed list comprehension. If you intend to perform indexing (v[1 + 2]) insert missing operator or adjust spacing to clarify. If you intend to perform typed list comprehension, (T[1 2]) ensure that T is a type."))
 
 
 hcat(A::AbstractVecOrMat...) = typed_hcat(promote_eltype(A...), A...)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1632,7 +1632,8 @@ end
 
 typed_hcat(::Type{T}, A::AbstractVecOrMat...) where {T} = _typed_hcat(T, A)
 
-# Catch indexing errors like v[i +1] (instead of v[i+1] or v[i + 1]), where indexing is interpreted as typed a comprehension. (issue #49676)
+# Catch indexing errors like v[i +1] (instead of v[i+1] or v[i + 1]), where indexing is
+# interpreted as typed a concatenation. (issue #49676)
 typed_hcat(::AbstractArray, other...) = throw(ArgumentError("It is unclear whether you \
     intend to perform an indexing operation or typed concatenation. If you intend to \
     perform indexing (v[1 + 2]) insert missing operator or adjust spacing to clarify. \

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -682,8 +682,13 @@ function test_cat(::Type{TestAbstractArray})
     @test Base.typed_hcat(Float64, B, B) == TSlow(b2hcat)
     @test Base.typed_hcat(Float64, B, B, B) == TSlow(b3hcat)
 
-    # issue #49676
-    @test_throws ArgumentError Base.typed_hcat([1 2 3], 1, +1)
+    @testset "issue #49676, bad error message on v[1 +1]" begin
+        # This is here because all these expressions are handled by Base.typed_hcat
+        v = [1 2 3]
+        @test_throws ArgumentError v[1 +1]
+        @test_throws ArgumentError v[1 1]
+        @test_throws ArgumentError v[[1 2] [2 3]]
+    end
 
     @test vcat(B1, B2) == TSlow(vcat([1:24...], [1:25...]))
     @test hcat(C1, C2) == TSlow([1 2 1 2 3; 3 4 4 5 6])

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -682,6 +682,9 @@ function test_cat(::Type{TestAbstractArray})
     @test Base.typed_hcat(Float64, B, B) == TSlow(b2hcat)
     @test Base.typed_hcat(Float64, B, B, B) == TSlow(b3hcat)
 
+    # issue #49676
+    @test_throws ArgumentError Base.typed_hcat([1 2 3], 1, +1)
+
     @test vcat(B1, B2) == TSlow(vcat([1:24...], [1:25...]))
     @test hcat(C1, C2) == TSlow([1 2 1 2 3; 3 4 4 5 6])
     @test hcat(C1, C2, C1) == TSlow([1 2 1 2 3 1 2; 3 4 4 5 6 3 4])


### PR DESCRIPTION
When indexing into an array, writing `vec[i +1]` is interpreted as a typed comprehension `vec[i 1]`. Because `vec` is not a type, it causes a unhelpful error.

This adds a new error message for this case. Example:
```
julia> vec = [1 2 3]; vec[1 +1]
ERROR: ArgumentError: First argument must be a type. Hint: if indexing, missing or misplaced operators can cause this (e.g. vec[i +1] instead of vec[i+1]).
```
This is my first PR here, please let me know if I can make any improvements.

See #49676 