### PR TITLE
Ensure Distributed workers inherit threads spec properly

### DIFF
--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -1317,6 +1317,20 @@ end
 
 write_cookie(io::IO) = print(io.in, string(cluster_cookie(), "\n"))
 
+function get_threads_spec(opts)
+    if opts.nthreads > 0
+        @assert opts.nthreadpools >= 1
+        @assert opts.nthreads_per_pool != C_NULL
+        thr = "$(unsafe_load(opts.nthreads_per_pool))"
+        if opts.nthreadpools == 2
+            thr = "$(thr),$(unsafe_load(opts.nthreads_per_pool, 2))"
+        end
+        `--threads=$(thr)`
+    else
+        ``
+    end
+end
+
 # Starts workers specified by (-n|--procs) and --machine-file command line options
 function process_opts(opts)
     # startup worker.
@@ -1331,7 +1345,7 @@ function process_opts(opts)
     end
 
     # Propagate --threads to workers
-    threads = opts.nthreads > 0 ? `--threads=$(opts.nthreads)` : ``
+    threads = get_threads_spec(opts)
     gcthreads = opts.ngcthreads > 0 ? `--gcthreads=$(opts.ngcthreads)` : ``
 
     exeflags = `$threads $gcthreads`


### PR DESCRIPTION
Now that there are threadpools, we cannot simply use `Base.JLOptions().nthreads` to get the threads spec for Distributed workers.