### PR TITLE
small typo in code example in the llvm.md documentation

### DIFF
--- a/doc/src/devdocs/llvm.md
+++ b/doc/src/devdocs/llvm.md
@@ -117,7 +117,7 @@ using:
 fun, T = +, Tuple{Int,Int} # Substitute your function of interest here
 optimize = false
 open("plus.ll", "w") do file
-    println(file, InteractiveUtils._dump_function(fun, T, false, false, false, true, :att, optimize, :default))
+    println(file, InteractiveUtils._dump_function(fun, T, false, false, false, true, :att, optimize, :default, false))
 end
 ```
 These files can be processed the same way as the unoptimized sysimg IR shown


### PR DESCRIPTION
The code in the documentation returns an error:
```
ERROR: MethodError: no method matching _dump_function(::typeof(+), ::Type{Tuple{Int64, Int64}}, ::Bool, ::Bool, ::Bool, ::Bool, ::Symbol, ::Bool, ::Symbol)
```
apparently, one boolean variable was missing from the call to `InteractiveUtils._dump_function`. Adding one `false` at the end of the call should fix that.