### PR TITLE
fix stackoverflow in `hash` for custom enum subtypes

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -27,7 +27,7 @@ Base.read(io::IO, ::Type{T}) where {T<:Enum} = T(read(io, basetype(T)))
 Compute hash for an enum value `x`. This internal method will be specialized
 for every enum type created through [`@enum`](@ref).
 """
-_enum_hash(x::Enum, h::UInt) = hash(x, h)
+_enum_hash(x::Enum, h::UInt) = invoke(hash, Tuple{Any, UInt}, x, h)
 Base.hash(x::Enum, h::UInt) = _enum_hash(x, h)
 Base.isless(x::T, y::T) where {T<:Enum} = isless(basetype(T)(x), basetype(T)(y))
 

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -184,6 +184,10 @@ end
 @enum HashEnum3 Enum3_a=1
 @test which(hash, (HashEnum3, UInt)).sig != Tuple{typeof(hash), HashEnum3, UInt64}
 
+# Check that generic `hash` on custom enum subtypes works.
+struct HashEnum4 <: Enum{Int} end
+@test hash(HashEnum4(), zero(UInt)) == invoke(hash, Tuple{Any, UInt}, HashEnum4(), zero(UInt))
+
 @test (Vector{Fruit}(undef, 3) .= apple) == [apple, apple, apple]
 
 # long, discongruous


### PR DESCRIPTION
This fixes an stackoverflow issue introduced by #49777 when using a custom enum subtype.

See [corresponding discussion](https://github.com/JuliaLang/julia/pull/49777#discussion_r1204124479) and [bug report](https://github.com/fredrikekre/EnumX.jl/issues/5).

Backporting this requires #49777 as well.