### PR TITLE
fix atomic intrinsics implementation issues

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -926,7 +926,11 @@ static jl_cgval_t emit_atomic_pointerop(jl_codectx_t &ctx, intrinsic f, const jl
         bool isboxed;
         Type *ptrty = julia_type_to_llvm(ctx, ety, &isboxed);
         assert(!isboxed);
-        Value *thePtr = emit_unbox(ctx, ptrty->getPointerTo(), e, e.typ);
+        Value *thePtr;
+        if (!type_is_ghost(ptrty))
+            thePtr = emit_unbox(ctx, ptrty->getPointerTo(), e, e.typ);
+        else
+            thePtr = nullptr; // could use any value here, since typed_store will not use it
         jl_cgval_t ret = typed_store(ctx, thePtr, nullptr, x, y, ety, ctx.tbaa().tbaa_data, nullptr, nullptr, isboxed,
                     llvm_order, llvm_failorder, nb, false, issetfield, isreplacefield, isswapfield, ismodifyfield, false, modifyop, "atomic_pointermodify");
         if (issetfield)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1411,7 +1411,7 @@ jl_datatype_t *jl_apply_modify_type(jl_value_t *dt)
     return rettyp;
 }
 
-jl_datatype_t *jl_apply_cmpswap_type(jl_value_t *dt)
+jl_datatype_t *jl_apply_cmpswap_type(jl_value_t *ty)
 {
     jl_value_t *params[2];
     jl_value_t *names = jl_atomic_load_relaxed(&cmpswap_names);
@@ -1422,12 +1422,12 @@ jl_datatype_t *jl_apply_cmpswap_type(jl_value_t *dt)
         if (jl_atomic_cmpswap(&cmpswap_names, &names, lnames))
             names = jl_atomic_load_relaxed(&cmpswap_names); // == lnames
     }
-    params[0] = dt;
+    params[0] = ty;
     params[1] = (jl_value_t*)jl_bool_type;
-    jl_datatype_t *tuptyp = (jl_datatype_t*)jl_apply_tuple_type_v(params, 2);
-    JL_GC_PROMISE_ROOTED(tuptyp); // (JL_ALWAYS_LEAFTYPE)
-    jl_datatype_t *rettyp = (jl_datatype_t*)jl_apply_type2((jl_value_t*)jl_namedtuple_type, names, (jl_value_t*)tuptyp);
-    JL_GC_PROMISE_ROOTED(rettyp); // (JL_ALWAYS_LEAFTYPE)
+    jl_value_t *tuptyp = jl_apply_tuple_type_v(params, 2);
+    JL_GC_PUSH1(&tuptyp);
+    jl_datatype_t *rettyp = (jl_datatype_t*)jl_apply_type2((jl_value_t*)jl_namedtuple_type, names, tuptyp);
+    JL_GC_POP();
     return rettyp;
 }
 

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -429,6 +429,8 @@ JL_DLLEXPORT jl_value_t *jl_atomic_pointerreplace(jl_value_t *p, jl_value_t *exp
         jl_atomic_error("atomic_pointerreplace: invalid atomic ordering");
     // TODO: filter other invalid orderings
     jl_value_t *ety = jl_tparam0(jl_typeof(p));
+    if (!is_valid_intrinsic_elptr(ety))
+        jl_error("atomic_pointerreplace: invalid pointer");
     char *pp = (char*)jl_unbox_long(p);
     jl_datatype_t *rettyp = jl_apply_cmpswap_type(ety);
     JL_GC_PROMISE_ROOTED(rettyp); // (JL_ALWAYS_LEAFTYPE)
@@ -447,8 +449,6 @@ JL_DLLEXPORT jl_value_t *jl_atomic_pointerreplace(jl_value_t *p, jl_value_t *exp
         return result;
     }
     else {
-        if (!is_valid_intrinsic_elptr(ety))
-            jl_error("atomic_pointerreplace: invalid pointer");
         if (jl_typeof(x) != ety)
             jl_type_error("atomic_pointerreplace", ety, x);
         size_t nb = jl_datatype_size(ety);


### PR DESCRIPTION
* jltypes: add missing GC root for cmpswap_type Tuple This is called with a fieldtype, which might not even be a DataType.

* support Ptr{Union{}} and Ptr{Cvoid} better

As seen on CI run here: https://buildkite.com/julialang/julia-master/builds/24304#018858f7-adce-4928-8aad-51ad6584b439