### PR TITLE
Structured display for adjoint/transpose

### DIFF
--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -505,3 +505,8 @@ pinv(v::TransposeAbsVec, tol::Real = 0) = pinv(conj(v.parent)).parent
 ## complex conjugate
 conj(A::Transpose) = adjoint(A.parent)
 conj(A::Adjoint) = transpose(A.parent)
+
+## structured matrix methods ##
+function Base.replace_in_print_matrix(A::AdjOrTrans,i::Integer,j::Integer,s::AbstractString)
+    Base.replace_in_print_matrix(parent(A), j, i, s)
+end

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -856,3 +856,10 @@ function _hermitianpart!(A::AbstractMatrix)
     end
     return A
 end
+
+## structured matrix printing ##
+function Base.replace_in_print_matrix(A::HermOrSym,i::Integer,j::Integer,s::AbstractString)
+    ijminmax = minmax(i, j)
+    inds = A.uplo == 'U' ? ijminmax : reverse(ijminmax)
+    Base.replace_in_print_matrix(parent(A), inds..., s)
+end

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -643,4 +643,32 @@ end
     end
 end
 
+@testset "structured printing" begin
+    D = Diagonal(1:3)
+    @test sprint(Base.print_matrix, Adjoint(D)) == sprint(Base.print_matrix, D)
+    @test sprint(Base.print_matrix, Transpose(D)) == sprint(Base.print_matrix, D)
+    D = Diagonal((1:3)*im)
+    D2 = Diagonal((1:3)*(-im))
+    @test sprint(Base.print_matrix, Transpose(D)) == sprint(Base.print_matrix, D)
+    @test sprint(Base.print_matrix, Adjoint(D)) == sprint(Base.print_matrix, D2)
+
+    struct OneHotVecOrMat{N} <: AbstractArray{Bool,N}
+        inds::NTuple{N,Int}
+        sz::NTuple{N,Int}
+    end
+    Base.size(x::OneHotVecOrMat) = x.sz
+    function Base.getindex(x::OneHotVecOrMat{N}, inds::Vararg{Int,N}) where {N}
+        checkbounds(x, inds...)
+        inds == x.inds
+    end
+    Base.replace_in_print_matrix(o::OneHotVecOrMat{1}, i::Integer, j::Integer, s::AbstractString) =
+        o.inds == (i,) ? s : Base.replace_with_centered_mark(s)
+    Base.replace_in_print_matrix(o::OneHotVecOrMat{2}, i::Integer, j::Integer, s::AbstractString) =
+        o.inds == (i,j) ? s : Base.replace_with_centered_mark(s)
+
+    o = OneHotVecOrMat((2,), (4,))
+    @test sprint(Base.print_matrix, Transpose(o)) == sprint(Base.print_matrix, OneHotVecOrMat((1,2), (1,4)))
+    @test sprint(Base.print_matrix, Adjoint(o)) == sprint(Base.print_matrix, OneHotVecOrMat((1,2), (1,4)))
+end
+
 end # module TestAdjointTranspose

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -824,4 +824,58 @@ end
     end
 end
 
+@testset "Structured display" begin
+    @testset "Diagonal" begin
+        d = 10:13
+        D = Diagonal(d)
+        for uplo in (:L, :U), SymHerm in (Symmetric, Hermitian)
+            S = SymHerm(D, uplo)
+            @test sprint(Base.print_matrix, S) == sprint(Base.print_matrix, D)
+        end
+
+        d = (10:13) .+ 2im
+        D = Diagonal(d)
+        DR = Diagonal(complex.(real.(d)))
+        for uplo in (:L, :U)
+            H = Hermitian(D, uplo)
+            @test sprint(Base.print_matrix, H) == sprint(Base.print_matrix, DR)
+
+            S = Symmetric(D, uplo)
+            @test sprint(Base.print_matrix, S) == sprint(Base.print_matrix, D)
+        end
+    end
+    @testset "Bidiagonal" begin
+        dv, ev = 1:4, 1:3
+        ST = SymTridiagonal(dv, ev)
+        D = Diagonal(dv)
+        for B_uplo in (:L, :U)
+            B = Bidiagonal(dv, ev, B_uplo)
+            for Sym_uplo in (:L, :U), SymHerm in (Symmetric, Hermitian)
+                SB = SymHerm(B, Sym_uplo)
+                teststr = sprint(Base.print_matrix, Sym_uplo == B_uplo ? ST : D)
+                @test sprint(Base.print_matrix, SB) == teststr
+            end
+        end
+    end
+    @testset "Tridiagonal" begin
+        superd, d, subd = 3:5, 10:13, 1:3
+        for uplo in (:U, :L), SymHerm in (Symmetric, Hermitian)
+            S = SymHerm(Tridiagonal(subd, d, superd), uplo)
+            ST = SymTridiagonal(d, uplo == :U ? superd : subd)
+            @test sprint(Base.print_matrix, S) == sprint(Base.print_matrix, ST)
+        end
+
+        superd, d, subd = collect((3:5)*im), collect(Complex{Int}, 10:13), collect((1:3)*im)
+        for uplo in (:U, :L)
+            S = Symmetric(Tridiagonal(subd, d, superd), uplo)
+            ST = SymTridiagonal(d, uplo == :U ? superd : subd)
+            @test sprint(Base.print_matrix, S) == sprint(Base.print_matrix, ST)
+
+            H = Hermitian(Tridiagonal(subd, d, superd), uplo)
+            T = Tridiagonal(uplo == :L ? subd : conj(superd), d, uplo == :U ? superd : conj(subd))
+            @test sprint(Base.print_matrix, H) == sprint(Base.print_matrix, T)
+        end
+    end
+end
+
 end # module TestSymmetric

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -854,6 +854,9 @@ end
                 SB = SymHerm(B, Sym_uplo)
                 teststr = sprint(Base.print_matrix, Sym_uplo == B_uplo ? ST : D)
                 @test sprint(Base.print_matrix, SB) == teststr
+                SB = SymHerm(Transpose(B), Sym_uplo)
+                teststr = sprint(Base.print_matrix, Sym_uplo == B_uplo ? D : ST)
+                @test sprint(Base.print_matrix, SB) == teststr
             end
         end
     end


### PR DESCRIPTION
On master
```julia
julia> D = Diagonal(1:3)
3×3 Diagonal{Int64, UnitRange{Int64}}:
 1  ⋅  ⋅
 ⋅  2  ⋅
 ⋅  ⋅  3

julia> Adjoint(D)
3×3 adjoint(::Diagonal{Int64, UnitRange{Int64}}) with eltype Int64:
 1  0  0
 0  2  0
 0  0  3
```
After this PR
```julia
julia> Adjoint(D)
3×3 adjoint(::Diagonal{Int64, UnitRange{Int64}}) with eltype Int64:
 1  ⋅  ⋅
 ⋅  2  ⋅
 ⋅  ⋅  3
```

This example is somewhat artificial, but the structured printing makes it easier to work with various sparse/banded array types.