### PR TITLE
Wait for git credential helper task

### DIFF
--- a/stdlib/LibGit2/src/gitcredential.jl
+++ b/stdlib/LibGit2/src/gitcredential.jl
@@ -183,16 +183,16 @@ end
 
 function run!(helper::GitCredentialHelper, operation::AbstractString, cred::GitCredential)
     cmd = `$(helper.cmd) $operation`
-    p = open(cmd, "r+")
+    open(cmd, "r+") do p
+        # Provide the helper with the credential information we know
+        write(p, cred)
+        write(p, "\n")
+        t = @async close(p.in)
 
-    # Provide the helper with the credential information we know
-    write(p, cred)
-    write(p, "\n")
-    t = @async close(p.in)
-
-    # Process the response from the helper
-    Base.read!(p, cred)
-    wait(p)
+        # Process the response from the helper
+        Base.read!(p, cred)
+        wait(t)
+    end
 
     return cred
 end


### PR DESCRIPTION
This is just something I noticed when reading the code (doesn't fix any user-facing bug that I'm aware of). It seems that [1] changed wait(t) to wait(p), which might be a typo? Without wait(t), any error thrown by t will be ignored.

I've folded wait(p) into the do expression, although the helper should already be dead by the time read! returns (unless it closes stdout early for some reason).

[1] https://github.com/JuliaLang/julia/commit/7577ec2f4b1674878263039982d63f854627b383