### PR TITLE
[test] Automatically install `llvm-tools` when runnning `llvmpasses`

### DIFF
--- a/test/llvmpasses/Makefile
+++ b/test/llvmpasses/Makefile
@@ -9,6 +9,7 @@ TESTS_jl := $(patsubst $(SRCDIR)/%,%,$(wildcard $(SRCDIR)/*.jl))
 TESTS := $(TESTS_ll) $(TESTS_jl)
 
 . $(TESTS):
+	$(MAKE) -C $(JULIAHOME)/deps install-llvm-tools
 	PATH=$(build_bindir):$(build_depsbindir):$$PATH \
 	LD_LIBRARY_PATH=${build_libdir}:$$LD_LIBRARY_PATH \
 	$(build_depsbindir)/lit/lit.py -v "$(addprefix $(SRCDIR)/,$@)"


### PR DESCRIPTION
It's quite frustrating to go figure out every time what's the spell to make `$(build_depsbindir)/lit/lit.py` appear.  There's a precedent for running `$(MAKE) -C $(JULIAHOME)/deps install-something`: https://github.com/JuliaLang/julia/blob/1cc10a604045b3d665b496e761de7966aa49f435/src/Makefile#L456