### PR TITLE
Use `top_set_bit` to optimize `hash(Real)`

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -687,7 +687,7 @@ function hash(x::Real, h::UInt)
 
     # handle values representable as Int64, UInt64, Float64
     if den == 1
-        left = ndigits0z(num,2) + pow
+        left = top_set_bit(num) + pow
         right = trailing_zeros(num) + pow
         if -1074 <= right
             if 0 <= right && left <= 64


### PR DESCRIPTION
This should not affect computed hash values (the num == 0 case is covered earlier), simplify generated code, and, 
on my machine, this results in a 1.5x speedup for hashing 128-bit integers according to `@btime hash(x) setup=(x=rand(Int128))`.