### PR TITLE
Product Array

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1128,6 +1128,7 @@ end
 reverse(p::ProductIterator) = ProductIterator(Base.map(reverse, p.iterators))
 last(p::ProductIterator) = Base.map(last, p.iterators)
 intersect(a::ProductIterator, b::ProductIterator) = ProductIterator(intersect.(a.iterators, b.iterators))
+getindex(p::ProductIterator, inds...) = map(getindex, p.iterators, inds)
 
 # flatten an iterator of iterators
 


### PR DESCRIPTION
Spin-off from #49965. The goal is to enable users to do

```julia
julia> vec(PermutedDimsArray(Iterators.product(rand(3), 1:4), (2,1)))
12-element reshape(PermutedDimsArray(::Matrix{Tuple{Float64, Int64}}, (2, 1)), 12) with eltype Tuple{Float64, Int64}:
 (0.39059299961662275, 1)
 (0.39059299961662275, 2)
 (0.39059299961662275, 3)
 (0.39059299961662275, 4)
 (0.1864604429198029, 1)
 (0.1864604429198029, 2)
 (0.1864604429198029, 3)
 (0.1864604429198029, 4)
 (0.3248860864098778, 1)
 (0.3248860864098778, 2)
 (0.3248860864098778, 3)
 (0.3248860864098778, 4)
````

for this `ProductIterator` would need to be a subtype of `AbstractArray`, which it can not be in general. This Pull request introduces the `ProductArray` as a complement to the `ProductIterator`  and uses traits to decide which to use when `product` is called. This decision might be possible to generalize further. Using a type union the existing implementations for `ProductIterator` are then all reused for `ProductArray` (only that it also inherits functionality from `AbstractArray`.

I am not very familiar with the internals of juila, so my usage of Unions might not be performance optimal.

The same idea could in principle also be applied to `Flatten` with the same goal.