### PR TITLE
Revert "Use `top_set_bit` to optimize `hash(Real)` (#49986)"

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -687,7 +687,7 @@ function hash(x::Real, h::UInt)
 
     # handle values representable as Int64, UInt64, Float64
     if den == 1
-        left = top_set_bit(num) + pow
+        left = ndigits0z(num,2) + pow
         right = trailing_zeros(num) + pow
         if -1074 <= right
             if 0 <= right && left <= 64


### PR DESCRIPTION
This reverts commit 18d02c249a90a7c2d25ac5a99a14cf7a414a3295.