### PR TITLE
Optimize top_set_bit(::BigInt) and hash(::Real)

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -674,34 +674,28 @@ function hash(x::Real, h::UInt)
         num = -num
         den = -den
     end
-    z = trailing_zeros(num)
-    if z != 0
-        num >>= z
-        pow += z
-    end
-    z = trailing_zeros(den)
-    if z != 0
-        den >>= z
-        pow -= z
-    end
+    num_z = trailing_zeros(num)
+    den_z = trailing_zeros(den)
+    den >>= den_z
+    pow += num_z - den_z
 
     # handle values representable as Int64, UInt64, Float64
     if den == 1
-        left = top_set_bit(abs(num)) + pow
-        right = trailing_zeros(num) + pow
+        left = top_set_bit(abs(num)) - den_z
+        right = pow
         if -1074 <= right
-            if 0 <= right && left <= 64
-                left <= 63                     && return hash(Int64(num) << Int(pow), h)
-                signbit(num) == signbit(den)   && return hash(UInt64(num) << Int(pow), h)
+            if 0 <= right
+                left <= 63 && return hash(Int64(num) >> Int(den_z), h)
+                left <= 64 && !signbit(num) && return hash(UInt64(num) >> Int(den_z), h)
             end # typemin(Int64) handled by Float64 case
-            left <= 1024 && left - right <= 53 && return hash(ldexp(Float64(num),pow), h)
+            left <= 1024 && left - right <= 53 && return hash(ldexp(Float64(num), -den_z), h)
         end
     end
 
     # handle generic rational values
     h = hash_integer(den, h)
     h = hash_integer(pow, h)
-    h = hash_integer(num, h)
+    h = hash_integer(num >> num_z, h)
     return h
 end
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -685,10 +685,10 @@ function hash(x::Real, h::UInt)
         right = pow
         if -1074 <= right
             if 0 <= right
-                left <= 63 && return hash(Int64(num) >> Int(den_z), h)
-                left <= 64 && !signbit(num) && return hash(UInt64(num) >> Int(den_z), h)
+                left <= 63 && return hash(Int64(num) << Int(pow-num_z), h)
+                left <= 64 && !signbit(num) && return hash(UInt64(num) << Int(pow-num_z), h)
             end # typemin(Int64) handled by Float64 case
-            left <= 1024 && left - right <= 53 && return hash(ldexp(Float64(num), -den_z), h)
+            left <= 1024 && left - right <= 53 && return hash(ldexp(Float64(num), pow-num_z), h)
         end
     end
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -687,7 +687,7 @@ function hash(x::Real, h::UInt)
 
     # handle values representable as Int64, UInt64, Float64
     if den == 1
-        left = ndigits0z(num,2) + pow
+        left = top_set_bit(abs(num)) + pow
         right = trailing_zeros(num) + pow
         if -1074 <= right
             if 0 <= right && left <= 64

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -606,8 +606,8 @@ Number of ones in the binary representation of abs(x).
 count_ones_abs(x::BigInt) = iszero(x) ? 0 : MPZ.mpn_popcount(x)
 
 function top_set_bit(x::BigInt)
-    x < 0 && throw(DomainError(x, "top_set_bit only supports negative arguments when they have type BitSigned."))
-    x == 0 && return 0
+    isneg(x) && throw(DomainError(x, "top_set_bit only supports negative arguments when they have type BitSigned."))
+    iszero(x) && return 0
     Int(ccall((:__gmpz_sizeinbase, :libgmp), Csize_t, (Base.GMP.MPZ.mpz_t, Cint), x, 2))
 end
 

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -608,7 +608,7 @@ count_ones_abs(x::BigInt) = iszero(x) ? 0 : MPZ.mpn_popcount(x)
 function top_set_bit(x::BigInt)
     isneg(x) && throw(DomainError(x, "top_set_bit only supports negative arguments when they have type BitSigned."))
     iszero(x) && return 0
-    Int(ccall((:__gmpz_sizeinbase, :libgmp), Csize_t, (Base.GMP.MPZ.mpz_t, Cint), x, 2))
+    x.size * sizeof(Limb) << 3 - leading_zeros(GC.@preserve x unsafe_load(x.d, x.size))
 end
 
 divrem(x::BigInt, y::BigInt) = MPZ.tdiv_qr(x, y)


### PR DESCRIPTION
EDIT: this PR now does a fair bit more than #49986 did, see later comments.

Re-lands #49986, but computes `abs` first. This should be safe now because `ndigits0z(x, 2)` and `top_set_bit(abs(x))` are semantically equivalent whereas before I was falsely assuming `x > 0`.

The performance gain is now only 1.4x instead of 1.5x, which could be noise or the cost of `abs` (probably noise)