### PR TITLE
lowering: apply let hygiene in let environment

### DIFF
--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -447,7 +447,7 @@
                                                               newenv m parent-scope inarg))
                                ;; expand initial values in old env
                                (resolve-expansion-vars- (caddr bind) env m parent-scope inarg))
-                              (resolve-expansion-vars- bind env m parent-scope inarg)))
+                              (resolve-expansion-vars- bind newenv m parent-scope inarg)))
                         binds))
                  ,body)))
            ((hygienic-scope) ; TODO: move this lowering to resolve-scopes, instead of reimplementing it here badly

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -3479,3 +3479,7 @@ end
     @test @_macroexpand(global (; x::S, $(esc(:y))::$(esc(:T))) = a) ==
         :(global (; x::$(GlobalRef(m, :S)), y::T) = $(GlobalRef(m, :a)))
 end
+
+# issue #49984
+macro z49984(s); :(let a; $(esc(s)); end); end
+@test let a = 1; @z49984(a) === 1; end


### PR DESCRIPTION
Not just a regression, since this test also fails on old versions, but
 #49897 applied the wrong environment to make this hygiene correct which
broke it worse.

Fix #49984