### PR TITLE
Add missing compat in docstring in `Artifacts.jl`

### DIFF
--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -653,6 +653,9 @@ access a single file/directory within an artifact.  Example:
 
 !!! compat "Julia 1.6"
     Slash-indexing requires at least Julia 1.6.
+
+!!! compat "Julia 1.9"
+    The argument `artifacts_toml_path` requires at least Julia 1.9.
 """
 macro artifact_str(name, platform=nothing, artifacts_toml_path=nothing)
     # Find Artifacts.toml file we're going to load from


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/46755 added a new argument to `@artifact_str`. The docstring however does not mention the julia version it has been introduced in.