### PR TITLE
add `@inline` annotation to `Core.Compiler.specialize_method`

### DIFF
--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -211,7 +211,7 @@ function normalize_typevars(method::Method, @nospecialize(atype), sparams::Simpl
 end
 
 # get a handle to the unique specialization object representing a particular instantiation of a call
-function specialize_method(method::Method, @nospecialize(atype), sparams::SimpleVector; preexisting::Bool=false)
+@inline function specialize_method(method::Method, @nospecialize(atype), sparams::SimpleVector; preexisting::Bool=false)
     if isa(atype, UnionAll)
         atype, sparams = normalize_typevars(method, atype, sparams)
     end


### PR DESCRIPTION
Since the return type of `Core.Compiler.specialize_method` relies on the boolean keyword argument `preexisting`, it is profitable to constant propagate it to get better inferrability.

@nanosoldier `runbenchmarks("inference", vs=":master")`