### PR TITLE
Add GC metric `last_full_sweep`

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -24,6 +24,7 @@ struct GC_Num
     mark_time       ::Int64
     total_sweep_time  ::Int64
     total_mark_time   ::Int64
+    last_full_sweep ::Int64
 end
 
 gc_num() = ccall(:jl_gc_num, GC_Num, ())

--- a/src/gc.c
+++ b/src/gc.c
@@ -3392,6 +3392,9 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
     uint64_t sweep_time = gc_end_time - start_sweep_time;
     gc_num.total_sweep_time += sweep_time;
     gc_num.sweep_time = sweep_time;
+    if (sweep_full) {
+        gc_num.last_full_sweep = gc_end_time;
+    }
 
     // sweeping is over
     // 7. if it is a quick sweep, put back the remembered objects in queued state

--- a/src/gc.h
+++ b/src/gc.h
@@ -81,6 +81,7 @@ typedef struct {
     uint64_t    mark_time;
     uint64_t    total_sweep_time;
     uint64_t    total_mark_time;
+    uint64_t    last_full_sweep;
 } jl_gc_num_t;
 
 // Array chunks (work items representing suffixes of


### PR DESCRIPTION
Records the time that the last full sweep ran.

This allows an application that explicitly runs GC when idle or at convenient points to be more intelligent about it.