### PR TITLE
change default threading scheduler to :static

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -260,7 +260,7 @@ microseconds).
 
 !!! warning
     If your code rely on indexing buffer with [`Threads.threadid()`](@ref), you should
-    use `:static` shcedule. For example, the now-discouraged pattern from 
+    use `:static` shcedule. For example, the now-discouraged pattern from
     [1.3 release blog post](https://julialang.org/blog/2019/07/multithreading/#thread-local_state)
     Specifically, the use of `temps[Threads.threadid()]` is incorrect when using dynamic scheduler.
 

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -566,8 +566,8 @@ test_load_and_lookup_18020(10000)
 # This may not be efficient/fully supported but should work without crashing.....
 function test_nested_loops()
     a = zeros(Int, 100, 100)
-    @threads for i in 1:100
-        @threads for j in 1:100
+    @threads :dynamic for i in 1:100
+        @threads :dynamic for j in 1:100
             a[j, i] = i + j
         end
     end


### PR DESCRIPTION
This is a quick-aid measure to prevent users from silently getting incorrect results across the entire Julia ecosystem because of the many packages (with 1000+ of dependencies) that rely on indexable-buffer containers. (which is a pattern we once highlighted in a [blog post](https://julialang.org/blog/2019/07/multithreading/#thread-local_state) ages ago and probably stuck in people's minds and code)

See: https://github.com/JuliaLang/julia/pull/48542#issuecomment-1569101718
