### PR TITLE
Don't use exchange in the hot path of the GC

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -805,7 +805,6 @@ FORCE_INLINE int gc_try_setmark_tag(jl_taggedvalue_t *o, uint8_t mark_mode) JL_N
 {
     assert(gc_marked(mark_mode));
     uintptr_t tag = jl_atomic_load_relaxed((_Atomic(uintptr_t)*)&o->header);
-    uintptr_t curr = tag;
     if (gc_marked(tag))
         return 0;
     if (mark_reset_age) {
@@ -821,7 +820,7 @@ FORCE_INLINE int gc_try_setmark_tag(jl_taggedvalue_t *o, uint8_t mark_mode) JL_N
     }
     jl_atomic_store_relaxed((_Atomic(uintptr_t)*)&o->header, tag); //xchg here was slower than
     verify_val(jl_valueof(o));                                     //potentially redoing work because of a stale tag.
-    return !gc_marked(curr);
+    return 1;
 }
 
 // This function should be called exactly once during marking for each big

--- a/src/gc.c
+++ b/src/gc.c
@@ -804,7 +804,8 @@ STATIC_INLINE void gc_queue_big_marked(jl_ptls_t ptls, bigval_t *hdr,
 FORCE_INLINE int gc_try_setmark_tag(jl_taggedvalue_t *o, uint8_t mark_mode) JL_NOTSAFEPOINT
 {
     assert(gc_marked(mark_mode));
-    uintptr_t tag = o->header;
+    uintptr_t tag = jl_atomic_load_relaxed((_Atomic(uintptr_t)*)&o->header);
+    uintptr_t curr = tag;
     if (gc_marked(tag))
         return 0;
     if (mark_reset_age) {
@@ -818,9 +819,8 @@ FORCE_INLINE int gc_try_setmark_tag(jl_taggedvalue_t *o, uint8_t mark_mode) JL_N
         tag = tag | mark_mode;
         assert((tag & 0x3) == mark_mode);
     }
-    uintptr_t curr = jl_atomic_load_relaxed((_Atomic(uintptr_t)*)&o->header);
-    jl_atomic_store_relaxed((_Atomic(uintptr_t)*)&o->header, tag);
-    verify_val(jl_valueof(o));
+    jl_atomic_store_relaxed((_Atomic(uintptr_t)*)&o->header, tag); //xchg here was slower than
+    verify_val(jl_valueof(o));                                     //potentially redoing work because of a stale tag.
     return !gc_marked(curr);
 }
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -818,9 +818,10 @@ FORCE_INLINE int gc_try_setmark_tag(jl_taggedvalue_t *o, uint8_t mark_mode) JL_N
         tag = tag | mark_mode;
         assert((tag & 0x3) == mark_mode);
     }
-    tag = jl_atomic_exchange_relaxed((_Atomic(uintptr_t)*)&o->header, tag);
+    uintptr_t curr = jl_atomic_load_relaxed((_Atomic(uintptr_t)*)&o->header);
+    jl_atomic_store_relaxed((_Atomic(uintptr_t)*)&o->header, tag);
     verify_val(jl_valueof(o));
-    return !gc_marked(tag);
+    return !gc_marked(curr);
 }
 
 // This function should be called exactly once during marking for each big


### PR DESCRIPTION
`xchg` is a very expensive instruction when working with memory, on x86 (intel 11th gen) it has an implied lock and a latency of 19. A false positive here just means a slight amount of extra work so don't do that.