### PR TITLE
Update Printf.jl reference link

### DIFF
--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -975,7 +975,7 @@ Use shorter of decimal or scientific 1.23 1.23e+07
 julia> @printf "Use dynamic width and precision  %*.*f" 10 2 0.12345
 Use dynamic width and precision        0.12
 ```
-For a systematic specification of the format, see [here](https://www.cplusplus.com/reference/cstdio/printf/).
+For a systematic specification of the format, see [here](https://en.cppreference.com/w/c/io/fprintf).
 See also [`@sprintf`](@ref) to get the result as a `String` instead of it being printed.
 
 # Caveats


### PR DESCRIPTION
The old link described %g inaccurately. The new one is better (tho it mentions %n, which we don't support).

Edit, the reference is also wrong about how Printf.jl will print Inf and NaN, but I don't know if that's a bug in Printf.jl or an intentional change (Julia prints them as Inf, -Inf and NaN, stdio.h prints them all lowercase or uppercase depending on the capitalisation of the type specifier).