### PR TITLE
Set -march/mcpu to native when building the runtime if no targets are set

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -874,10 +874,11 @@ endif
 
 #If nothing is set default to native
 ifeq ($(MARCH)$(MCPU)$(MTUNE)$(JULIA_CPU_TARGET),)
+ifeq ($(ARCH),aarch64) #ARM recommends only setting MCPU for AArch64
+MCPU=native
+else
 MARCH=native
 MTUNE=native
-ifeq ($(USEGCC),0) # GCC deprecated mcpu
-MCPU=native
 endif
 endif
 

--- a/Make.inc
+++ b/Make.inc
@@ -871,6 +871,16 @@ else
 ISX86:=0
 endif
 
+
+#If nothing is set default to native
+ifeq ($(MARCH)$(MCPU)$(MTUNE)$(JULIA_CPU_TARGET),)
+MARCH=native
+MTUNE=native
+ifeq ($(USEGCC),0) # GCC deprecated mcpu
+MCPU=native
+endif
+endif
+
 # If we are running on powerpc64le or ppc64le, set certain options automatically
 ifneq (,$(filter $(ARCH), powerpc64le ppc64le))
 JCFLAGS += -fsigned-char
@@ -945,6 +955,14 @@ CC += -mcpu=$(MCPU)
 CXX += -mcpu=$(MCPU)
 FC += -mcpu=$(MCPU)
 JULIA_CPU_TARGET ?= $(MCPU)
+endif
+
+# Set MTUNE-specific flags
+ifneq ($(MTUNE),)
+CC += -mtune=$(MTUNE)
+CXX += -mtune=$(MTUNE)
+FC += -mtune=$(MTUNE)
+JULIA_CPU_TARGET ?= $(MTUNE)
 endif
 
 ifneq ($(MARCH)$(MCPU),)


### PR DESCRIPTION
@vchuravy noted that we don't set these flags even when building locally, even though we set the sysimg to `native`. This probably doesn't make too much of a difference but it might save a couple % on from source builds.

Also add the option to set `mtune` which is what GCC wants