### PR TITLE
Revert "allow artifact string macro to take an explicit path to the artifact file"

### DIFF
--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -654,18 +654,13 @@ access a single file/directory within an artifact.  Example:
 !!! compat "Julia 1.6"
     Slash-indexing requires at least Julia 1.6.
 """
-macro artifact_str(name, platform=nothing, artifacts_toml_path=nothing)
+macro artifact_str(name, platform=nothing)
     # Find Artifacts.toml file we're going to load from
     srcfile = string(__source__.file)
     if ((isinteractive() && startswith(srcfile, "REPL[")) || (!isinteractive() && srcfile == "none")) && !isfile(srcfile)
         srcfile = pwd()
     end
-    # Sometimes we know the exact path to the Artifacts.toml file, so we can save some lookups
-    local artifacts_toml = if artifacts_toml_path === nothing || artifacts_toml_path == :(nothing)
-        find_artifacts_toml(srcfile)
-    else
-        eval(artifacts_toml_path)
-    end
+    local artifacts_toml = find_artifacts_toml(srcfile)
     if artifacts_toml === nothing
         error(string(
             "Cannot locate '(Julia)Artifacts.toml' file when attempting to use artifact '",
@@ -695,7 +690,7 @@ macro artifact_str(name, platform=nothing, artifacts_toml_path=nothing)
 
     # If `name` is a constant, (and we're using the default `Platform`) we can actually load
     # and parse the `Artifacts.toml` file now, saving the work from runtime.
-    if isa(name, AbstractString) && (platform === nothing || platform == :(nothing))
+    if isa(name, AbstractString) && platform === nothing
         # To support slash-indexing, we need to split the artifact name from the path tail:
         platform = HostPlatform()
         artifact_name, artifact_path_tail, hash = artifact_slash_lookup(name, artifact_dict, artifacts_toml, platform)

--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -91,9 +91,6 @@ end
         HelloWorldC_exe_path = joinpath(HelloWorldC_dir, "bin", "hello_world$(exeext)")
         @test isfile(HelloWorldC_exe_path)
 
-        HelloWorldC_dir_explicit_artifact = eval(:(@artifact_str "HelloWorldC" nothing joinpath(@__DIR__, "Artifacts.toml")))
-        @test isdir(HelloWorldC_dir_explicit_artifact)
-
         # Simple slash-indexed lookup
         HelloWorldC_bin_path = artifact"HelloWorldC/bin"
         @test isdir(HelloWorldC_bin_path)


### PR DESCRIPTION
Reverts JuliaLang/julia#46755 as proposed by @KristofferC in https://github.com/JuliaLang/julia/pull/50009#issuecomment-1569771399.

Closes #50009. 