### PR TITLE
Rename LLVM passes to be suffixed with `Pass`

### DIFF
--- a/src/llvm-cpufeatures.cpp
+++ b/src/llvm-cpufeatures.cpp
@@ -118,7 +118,7 @@ bool lowerCPUFeatures(Module &M) JL_NOTSAFEPOINT
     }
 }
 
-PreservedAnalyses CPUFeatures::run(Module &M, ModuleAnalysisManager &AM)
+PreservedAnalyses CPUFeaturesPass::run(Module &M, ModuleAnalysisManager &AM)
 {
     if (lowerCPUFeatures(M)) {
         return PreservedAnalyses::allInSet<CFGAnalyses>();

--- a/src/llvm-demote-float16.cpp
+++ b/src/llvm-demote-float16.cpp
@@ -187,7 +187,7 @@ static bool demoteFloat16(Function &F)
 
 } // end anonymous namespace
 
-PreservedAnalyses DemoteFloat16::run(Function &F, FunctionAnalysisManager &AM)
+PreservedAnalyses DemoteFloat16Pass::run(Function &F, FunctionAnalysisManager &AM)
 {
     if (demoteFloat16(F)) {
         return PreservedAnalyses::allInSet<CFGAnalyses>();

--- a/src/llvm-julia-passes.inc
+++ b/src/llvm-julia-passes.inc
@@ -1,10 +1,10 @@
 //Module passes
 #ifdef MODULE_PASS
-MODULE_PASS("CPUFeatures", CPUFeatures())
-MODULE_PASS("RemoveNI", RemoveNI())
-MODULE_PASS("LowerSIMDLoop", LowerSIMDLoop())
+MODULE_PASS("CPUFeatures", CPUFeaturesPass())
+MODULE_PASS("RemoveNI", RemoveNIPass())
+MODULE_PASS("LowerSIMDLoop", LowerSIMDLoopPass())
 MODULE_PASS("FinalLowerGC", FinalLowerGCPass())
-MODULE_PASS("JuliaMultiVersioning", MultiVersioning())
+MODULE_PASS("JuliaMultiVersioning", MultiVersioningPass())
 MODULE_PASS("RemoveJuliaAddrspaces", RemoveJuliaAddrspacesPass())
 MODULE_PASS("RemoveAddrspaces", RemoveAddrspacesPass())
 MODULE_PASS("LowerPTLSPass", LowerPTLSPass())
@@ -12,12 +12,12 @@ MODULE_PASS("LowerPTLSPass", LowerPTLSPass())
 
 //Function passes
 #ifdef FUNCTION_PASS
-FUNCTION_PASS("DemoteFloat16", DemoteFloat16())
-FUNCTION_PASS("CombineMulAdd", CombineMulAdd())
-FUNCTION_PASS("LateLowerGCFrame", LateLowerGC())
+FUNCTION_PASS("DemoteFloat16", DemoteFloat16Pass())
+FUNCTION_PASS("CombineMulAdd", CombineMulAddPass())
+FUNCTION_PASS("LateLowerGCFrame", LateLowerGCPass())
 FUNCTION_PASS("AllocOpt", AllocOptPass())
 FUNCTION_PASS("PropagateJuliaAddrspaces", PropagateJuliaAddrspacesPass())
-FUNCTION_PASS("LowerExcHandlers", LowerExcHandlers())
+FUNCTION_PASS("LowerExcHandlers", LowerExcHandlersPass())
 FUNCTION_PASS("GCInvariantVerifier", GCInvariantVerifierPass())
 #endif
 

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2764,7 +2764,7 @@ bool LateLowerGCFrameLegacy::runOnFunction(Function &F) {
     return modified;
 }
 
-PreservedAnalyses LateLowerGC::run(Function &F, FunctionAnalysisManager &AM)
+PreservedAnalyses LateLowerGCPass::run(Function &F, FunctionAnalysisManager &AM)
 {
     auto GetDT = [&AM, &F]() -> DominatorTree & {
         return AM.getResult<DominatorTreeAnalysis>(F);

--- a/src/llvm-lower-handlers.cpp
+++ b/src/llvm-lower-handlers.cpp
@@ -236,7 +236,7 @@ static bool lowerExcHandlers(Function &F) {
 
 } // anonymous namespace
 
-PreservedAnalyses LowerExcHandlers::run(Function &F, FunctionAnalysisManager &AM)
+PreservedAnalyses LowerExcHandlersPass::run(Function &F, FunctionAnalysisManager &AM)
 {
     bool modified = lowerExcHandlers(F);
 #ifdef JL_VERIFY_PASSES

--- a/src/llvm-muladd.cpp
+++ b/src/llvm-muladd.cpp
@@ -109,7 +109,7 @@ static bool combineMulAdd(Function &F) JL_NOTSAFEPOINT
     return modified;
 }
 
-PreservedAnalyses CombineMulAdd::run(Function &F, FunctionAnalysisManager &AM) JL_NOTSAFEPOINT
+PreservedAnalyses CombineMulAddPass::run(Function &F, FunctionAnalysisManager &AM) JL_NOTSAFEPOINT
 {
     if (combineMulAdd(F)) {
         return PreservedAnalyses::allInSet<CFGAnalyses>();

--- a/src/llvm-multiversioning.cpp
+++ b/src/llvm-multiversioning.cpp
@@ -1140,7 +1140,7 @@ void multiversioning_preannotate(Module &M)
     M.addModuleFlag(Module::ModFlagBehavior::Error, "julia.mv.enable", 1);
 }
 
-PreservedAnalyses MultiVersioning::run(Module &M, ModuleAnalysisManager &AM)
+PreservedAnalyses MultiVersioningPass::run(Module &M, ModuleAnalysisManager &AM)
 {
     if (runMultiVersioning(M, external_use)) {
         auto preserved = PreservedAnalyses::allInSet<CFGAnalyses>();

--- a/src/llvm-remove-ni.cpp
+++ b/src/llvm-remove-ni.cpp
@@ -36,7 +36,7 @@ static bool removeNI(Module &M) JL_NOTSAFEPOINT
 }
 }
 
-PreservedAnalyses RemoveNI::run(Module &M, ModuleAnalysisManager &AM)
+PreservedAnalyses RemoveNIPass::run(Module &M, ModuleAnalysisManager &AM)
 {
     if (removeNI(M)) {
         return PreservedAnalyses::allInSet<CFGAnalyses>();

--- a/src/llvm-simdloop.cpp
+++ b/src/llvm-simdloop.cpp
@@ -282,7 +282,7 @@ static bool markLoopInfo(Module &M, Function *marker, function_ref<LoopInfo &(Fu
 /// prevent SIMDization.
 
 
-PreservedAnalyses LowerSIMDLoop::run(Module &M, ModuleAnalysisManager &AM)
+PreservedAnalyses LowerSIMDLoopPass::run(Module &M, ModuleAnalysisManager &AM)
 {
     Function *loopinfo_marker = M.getFunction("julia.loopinfo_marker");
 

--- a/src/passes.h
+++ b/src/passes.h
@@ -10,16 +10,16 @@
 using namespace llvm;
 
 // Function Passes
-struct DemoteFloat16 : PassInfoMixin<DemoteFloat16> {
+struct DemoteFloat16Pass : PassInfoMixin<DemoteFloat16Pass> {
     PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM) JL_NOTSAFEPOINT;
     static bool isRequired() { return true; }
 };
 
-struct CombineMulAdd : PassInfoMixin<CombineMulAdd> {
+struct CombineMulAddPass : PassInfoMixin<CombineMulAddPass> {
     PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM) JL_NOTSAFEPOINT;
 };
 
-struct LateLowerGC : PassInfoMixin<LateLowerGC> {
+struct LateLowerGCPass : PassInfoMixin<LateLowerGCPass> {
     PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM) JL_NOTSAFEPOINT;
     static bool isRequired() { return true; }
 };
@@ -33,7 +33,7 @@ struct PropagateJuliaAddrspacesPass : PassInfoMixin<PropagateJuliaAddrspacesPass
     static bool isRequired() { return true; }
 };
 
-struct LowerExcHandlers : PassInfoMixin<LowerExcHandlers> {
+struct LowerExcHandlersPass : PassInfoMixin<LowerExcHandlersPass> {
     PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM) JL_NOTSAFEPOINT;
     static bool isRequired() { return true; }
 };
@@ -47,17 +47,17 @@ struct GCInvariantVerifierPass : PassInfoMixin<GCInvariantVerifierPass> {
 };
 
 // Module Passes
-struct CPUFeatures : PassInfoMixin<CPUFeatures> {
+struct CPUFeaturesPass : PassInfoMixin<CPUFeaturesPass> {
     PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM) JL_NOTSAFEPOINT;
     static bool isRequired() { return true; }
 };
 
-struct RemoveNI : PassInfoMixin<RemoveNI> {
+struct RemoveNIPass : PassInfoMixin<RemoveNIPass> {
     PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM) JL_NOTSAFEPOINT;
     static bool isRequired() { return true; }
 };
 
-struct LowerSIMDLoop : PassInfoMixin<LowerSIMDLoop> {
+struct LowerSIMDLoopPass : PassInfoMixin<LowerSIMDLoopPass> {
     PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM) JL_NOTSAFEPOINT;
     static bool isRequired() { return true; }
 };
@@ -67,9 +67,9 @@ struct FinalLowerGCPass : PassInfoMixin<FinalLowerGCPass> {
     static bool isRequired() { return true; }
 };
 
-struct MultiVersioning : PassInfoMixin<MultiVersioning> {
+struct MultiVersioningPass : PassInfoMixin<MultiVersioningPass> {
     bool external_use;
-    MultiVersioning(bool external_use = false) : external_use(external_use) {}
+    MultiVersioningPass(bool external_use = false) : external_use(external_use) {}
     PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM) JL_NOTSAFEPOINT;
     static bool isRequired() { return true; }
 };


### PR DESCRIPTION
LLVM suffixes all of its passes with `Pass`, so we should do the same for consistency. 