### PR TITLE
add docs on task migration

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -22,6 +22,11 @@ julia> Threads.@threads for i in 1:4
 5
 4
 ```
+
+!!! note
+    The thread that a task runs on may change if the task yields, which is known as [`Task Migration`](@ref).
+    For this reason in most cases it is not safe to use `threadid()` to index into, say, a vector of buffer or stateful objects.
+
 """
 threadid() = Int(ccall(:jl_threadid, Int16, ())+1)
 
@@ -229,7 +234,7 @@ For example, the above conditions imply that:
 - Write only to locations not shared across iterations (unless a lock or atomic operation is
   used).
 - The value of [`threadid()`](@ref Threads.threadid) may change even within a single
-  iteration.
+  iteration. See [`Task Migration`](@ref)
 
 ## Schedulers
 
@@ -355,8 +360,9 @@ the _value_ of a variable, isolating the asynchronous code from changes to
 the variable's value in the current task.
 
 !!! note
-    See the manual chapter on [multi-threading](@ref man-multithreading)
-    for important caveats. See also the chapter on [threadpools](@ref man-threadpools).
+    The thread that the task runs on may change if the task yields, therefore `threadid()` should not
+    be treated as constant for a task. See [`Task Migration`](@ref), part of the [multi-threading](@ref man-multithreading)
+    manual for further important caveats. See also the chapter on [threadpools](@ref man-threadpools).
 
 !!! compat "Julia 1.3"
     This macro is available as of Julia 1.3.

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -361,8 +361,9 @@ the variable's value in the current task.
 
 !!! note
     The thread that the task runs on may change if the task yields, therefore `threadid()` should not
-    be treated as constant for a task. See [`Task Migration`](@ref man-task-migration), part of the [multi-threading](@ref man-multithreading)
-    manual for further important caveats. See also the chapter on [threadpools](@ref man-threadpools).
+    be treated as constant for a task. See [`Task Migration`](@ref man-task-migration), and the broader
+    [multi-threading](@ref man-multithreading) manual for further important caveats.
+    See also the chapter on [threadpools](@ref man-threadpools).
 
 !!! compat "Julia 1.3"
     This macro is available as of Julia 1.3.

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -24,7 +24,7 @@ julia> Threads.@threads for i in 1:4
 ```
 
 !!! note
-    The thread that a task runs on may change if the task yields, which is known as [`Task Migration`](@ref).
+    The thread that a task runs on may change if the task yields, which is known as [`Task Migration`](@ref man-task-migration).
     For this reason in most cases it is not safe to use `threadid()` to index into, say, a vector of buffer or stateful objects.
 
 """
@@ -234,7 +234,7 @@ For example, the above conditions imply that:
 - Write only to locations not shared across iterations (unless a lock or atomic operation is
   used).
 - The value of [`threadid()`](@ref Threads.threadid) may change even within a single
-  iteration. See [`Task Migration`](@ref)
+  iteration. See [`Task Migration`](@ref man-task-migration)
 
 ## Schedulers
 
@@ -361,7 +361,7 @@ the variable's value in the current task.
 
 !!! note
     The thread that the task runs on may change if the task yields, therefore `threadid()` should not
-    be treated as constant for a task. See [`Task Migration`](@ref), part of the [multi-threading](@ref man-multithreading)
+    be treated as constant for a task. See [`Task Migration`](@ref man-task-migration), part of the [multi-threading](@ref man-multithreading)
     manual for further important caveats. See also the chapter on [threadpools](@ref man-threadpools).
 
 !!! compat "Julia 1.3"

--- a/doc/src/manual/multi-threading.md
+++ b/doc/src/manual/multi-threading.md
@@ -388,10 +388,10 @@ threads in Julia:
     This may require some transitional work across the ecosystem before threading
     can be widely adopted with confidence. See the next section for further details.
 
-## Task Migration
+## [Task Migration](@id man-task-migration)
 
-After a task starts running on a certain thread (e.g. via [`@spawn`](@ref) or [`@threads`](@ref)), it
-may move to a different thread if the task yields.
+After a task starts running on a certain thread (e.g. via [`@spawn`](@ref Threads.@spawn) or
+[`@threads`](@ref Threads.@threads)), it may move to a different thread if the task yields.
 
 This means that [`threadid()`](@ref Threads.threadid) should not be treated as constant within a task, and therefore
 should not be used to index into a vector of buffers or stateful objects.

--- a/doc/src/manual/multi-threading.md
+++ b/doc/src/manual/multi-threading.md
@@ -388,6 +388,14 @@ threads in Julia:
     This may require some transitional work across the ecosystem before threading
     can be widely adopted with confidence. See the next section for further details.
 
+## Task Migration
+
+After a task starts running on a certain thread (e.g. via [`@spawn`](@ref) or [`@threads`](@ref)), it
+may move to a different thread if the task yields.
+
+This means that [`threadid()`](@ref Threads.threadid) should not be treated as constant within a task, and therefore
+should not be used to index into a vector of buffers or stateful objects.
+
 ## Safe use of Finalizers
 
 Because finalizers can interrupt any code, they must be very careful in how

--- a/doc/src/manual/multi-threading.md
+++ b/doc/src/manual/multi-threading.md
@@ -396,6 +396,10 @@ After a task starts running on a certain thread (e.g. via [`@spawn`](@ref Thread
 This means that [`threadid()`](@ref Threads.threadid) should not be treated as constant within a task, and therefore
 should not be used to index into a vector of buffers or stateful objects.
 
+!!! compat "Julia 1.7"
+    Task migration was introduced in Julia 1.7. Before this tasks always remained on the same thread that they were
+    started on.
+
 ## Safe use of Finalizers
 
 Because finalizers can interrupt any code, they must be very careful in how


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/40715 introduced task migration (in 1.7)
https://github.com/JuliaLang/julia/pull/43496 removed pre-1.7 docs that said task migration didn't happen

It seems important-enough and surprising-enough to explicitly document.