### PR TITLE
add mechanism for using task-local vars with `Threads.@threads`

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -135,8 +135,12 @@ function threading_run(fun, static)
             schedule(t)
         end
         for i = 1:n
-            ret = fetch(tasks[i])
-            isnothing(ret) || push!(task_locals, ret)
+            t = tasks[i]
+            Base._wait(t)
+            if !istaskfailed(t)
+                ret = Base.task_result(t)
+                isnothing(ret) || push!(task_locals, ret)
+            end
         end
     finally
         ccall(:jl_exit_threaded_region, Cvoid, ())

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -132,17 +132,25 @@ function threading_run(fun, static)
         tasks[i] = t
         schedule(t)
     end
+    task_locals = Any[]
     for i = 1:n
-        Base._wait(tasks[i])
+        ret = fetch(tasks[i])
+        isnothing(ret) || push!(task_locals, ret)
     end
     ccall(:jl_exit_threaded_region, Cvoid, ())
     failed_tasks = filter(istaskfailed, tasks)
     if !isempty(failed_tasks)
         throw(CompositeException(map(TaskFailedException, failed_tasks)))
     end
+    if isempty(task_locals) || isnothing(task_locals[1])
+        return nothing
+    else
+        return Tuple(collect(zip(task_locals...)))
+    end
 end
 
-function _threadsfor(iter, lbody, schedule)
+function _threadsfor(iter, task_locals, lbody, schedule)
+    # @show task_locals, isempty(task_locals)
     lidx = iter.args[1]         # index
     range = iter.args[2]
     quote
@@ -178,11 +186,17 @@ function _threadsfor(iter, lbody, schedule)
                     l = l + rem
                 end
             end
+            $((esc(e) for e in task_locals)...)
             # run this thread's iterations
             for i = f:l
                 local $(esc(lidx)) = @inbounds r[i]
                 $(esc(lbody))
             end
+            $(if isempty(task_locals)
+                :nothing
+            else
+                Expr(:tuple, (esc(e.args[1]) for e in task_locals)...) # returns
+            end)
         end
         end
         if $(schedule === :dynamic || schedule === :default)
@@ -192,12 +206,11 @@ function _threadsfor(iter, lbody, schedule)
         else # :static
             threading_run(threadsfor_fun, true)
         end
-        nothing
     end
 end
 
 """
-    Threads.@threads [schedule] for ... end
+    Threads.@threads [schedule] [task local vars] for ... end
 
 A macro to execute a `for` loop in parallel. The iteration space is distributed to
 coarse-grained tasks. This policy can be specified by the `schedule` argument. The
@@ -305,17 +318,23 @@ to run two of the 1-second iterations to complete the for loop.
 """
 macro threads(args...)
     na = length(args)
-    if na == 2
-        sched, ex = args
-        if sched isa QuoteNode
-            sched = sched.value
-        elseif sched isa Symbol
-            # for now only allow quoted symbols
-            sched = nothing
+    task_locals = Expr[]
+    if na > 1
+        sched = :default
+        if args[1] isa QuoteNode
+            sched = args[1].value
+            if !in(sched, (:static, :dynamic))
+                throw(ArgumentError("unsupported schedule argument `$(sched)` in @threads"))
+            end
         end
-        if sched !== :static && sched !== :dynamic
-            throw(ArgumentError("unsupported schedule argument in @threads"))
+        m = sched == :default ? 1 : 2
+        for i = m:na-1
+            if !isa(args[i], Expr) || args[i].head !== :(=)
+                throw(ArgumentError("Bad local variable arguments. Local variable declarations must have initializers"))
+            end
+            push!(task_locals, args[i])
         end
+        ex = args[end]
     elseif na == 1
         sched = :default
         ex = args[1]
@@ -325,10 +344,12 @@ macro threads(args...)
     if !(isa(ex, Expr) && ex.head === :for)
         throw(ArgumentError("@threads requires a `for` loop expression"))
     end
-    if !(ex.args[1] isa Expr && ex.args[1].head === :(=))
+    iter = ex.args[1]
+    lbody = ex.args[2]
+    if !(iter isa Expr && iter.head === :(=))
         throw(ArgumentError("nested outer loops are not currently supported by @threads"))
     end
-    return _threadsfor(ex.args[1], ex.args[2], sched)
+    return _threadsfor(iter, task_locals, lbody, sched)
 end
 
 function _spawn_set_thrpool(t::Task, tp::Symbol)


### PR DESCRIPTION
Alternative to https://github.com/JuliaLang/julia/pull/48543

This adds a form of `Threads.@threads` that allows storing of variables at the task level for use in the partitioned iterations.

It means the user can use `@threads` with task local buffering/storage/states without having to read into the `task_local_storage()` dict every iteration.
```julia
xs, ys = Threads.@threads x = some_init() y = another_init() for i in eachindex(a)
 	# do something with a[i] using x, y as buffers or states etc.
end

# optionally do something with xs & ys which are both of length threadpoolsize()
```

For instance
```julia
julia> Threads.threadpoolsize()
6

julia> xs, ys = Threads.@threads x = 1 y = 1 for i in 1:100
       x = i
       y = i+10
       end
((17, 34, 51, 68, 84, 100), (27, 44, 61, 78, 94, 110))
```

Or a toy sum
```julia
julia> function multi_sum(a)
           buffers, = Threads.@threads buffer = 0 for i in eachindex(a)
               buffer += a[i]
           end
           return sum(buffers)
       end
multi_sum (generic function with 1 method)

julia> multi_sum(1:1_000_000)
500000500000

julia> multi_sum(1:1_000_000) == sum(1:1_000_000)
true
```