### PR TITLE
Update return type in `collect(::Dict)` docs

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -723,7 +723,7 @@ _array_for(::Type{T}, itr, isz) where {T} = _array_for(T, isz, _similar_shape(it
     collect(collection)
 
 Return an `Array` of all items in a collection or iterator. For dictionaries, returns
-`Pair{KeyType, ValType}`. If the argument is array-like or is an iterator with the
+`Vector{Pair{KeyType, ValType}}`. If the argument is array-like or is an iterator with the
 [`HasShape`](@ref IteratorSize) trait, the result will have the same shape
 and number of dimensions as the argument.
 


### PR DESCRIPTION
```julia
julia> collect(Dict(1=>3, 2=>5))
2-element Vector{Pair{Int64, Int64}}:
 2 => 5
 1 => 3
```
The current docstring states the element type rather than the collection type