### PR TITLE
Fix numbered prompt with input only with comment

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1418,6 +1418,7 @@ function out_transform(@nospecialize(x), n::Ref{Int})
 end
 
 function get_usings!(usings, ex)
+    ex isa Expr || return usings
     # get all `using` and `import` statements which are at the top level
     for (i, arg) in enumerate(ex.args)
         if Base.isexpr(arg, :toplevel)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1652,6 +1652,10 @@ fake_repl() do stdin_write, stdout_read, repl
     @test !contains(s, "ERROR")
     @test contains(s, "Test Passed")
 
+    # Test for https://github.com/JuliaLang/julia/issues/49319
+    s = sendrepl2("# comment", "In [16]")
+    @test !contains(s, "ERROR")
+
     write(stdin_write, '\x04')
     Base.wait(repltask)
 end


### PR DESCRIPTION
If REPL input consists solely of a comment, the input expression of `out_transfrom` will be `nothing`, which breaks the `get_usings!`, so we need to check the type of input expression.

Fix #49319 