### PR TITLE
Fixup `hash(::Real)` broken by #49996

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -675,27 +675,28 @@ function hash(x::Real, h::UInt)
         den = -den
     end
     num_z = trailing_zeros(num)
+    num >>= num_z
     den_z = trailing_zeros(den)
     den >>= den_z
     pow += num_z - den_z
 
     # handle values representable as Int64, UInt64, Float64
     if den == 1
-        left = top_set_bit(abs(num)) - den_z
-        right = pow
+        left = top_set_bit(abs(num)) + pow
+        right = pow + den_z
         if -1074 <= right
             if 0 <= right
-                left <= 63 && return hash(Int64(num) << Int(pow-num_z), h)
-                left <= 64 && !signbit(num) && return hash(UInt64(num) << Int(pow-num_z), h)
+                left <= 63 && return hash(Int64(num) << Int(pow), h)
+                left <= 64 && !signbit(num) && return hash(UInt64(num) << Int(pow), h)
             end # typemin(Int64) handled by Float64 case
-            left <= 1024 && left - right <= 53 && return hash(ldexp(Float64(num), pow-num_z), h)
+            left <= 1024 && left - right <= 53 && return hash(ldexp(Float64(num), pow), h)
         end
     end
 
     # handle generic rational values
     h = hash_integer(den, h)
     h = hash_integer(pow, h)
-    h = hash_integer(num >> num_z, h)
+    h = hash_integer(num, h)
     return h
 end
 

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -310,3 +310,6 @@ struct AUnionParam{T<:Union{Nothing,Float32,Float64}} end
 @test Type{AUnionParam{<:Union{Nothing,Float32,Float64}}} === Type{AUnionParam}
 @test Type{AUnionParam.body}.hash == 0
 @test Type{Base.Broadcast.Broadcasted}.hash != 0
+
+# Issue #50065
+@test hash(1.0) == hash(BigFloat(1.0))

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -8,7 +8,8 @@ types = Any[
     Bool,
     Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Float32, Float64,
     Rational{Int8}, Rational{UInt8}, Rational{Int16}, Rational{UInt16},
-    Rational{Int32}, Rational{UInt32}, Rational{Int64}, Rational{UInt64}
+    Rational{Int32}, Rational{UInt32}, Rational{Int64}, Rational{UInt64},
+    BigInt, BigFloat,
 ]
 vals = vcat(
     typemin(Int64),
@@ -51,8 +52,7 @@ let collides = 0
             collides += eq
         end
     end
-    # each pair of types has one collision for these values
-    @test collides <= (length(types) - 1)^2
+    @test collides <= 452
 end
 @test hash(0.0) != hash(-0.0)
 
@@ -310,6 +310,3 @@ struct AUnionParam{T<:Union{Nothing,Float32,Float64}} end
 @test Type{AUnionParam{<:Union{Nothing,Float32,Float64}}} === Type{AUnionParam}
 @test Type{AUnionParam.body}.hash == 0
 @test Type{Base.Broadcast.Broadcasted}.hash != 0
-
-# Issue #50065
-@test hash(1.0) == hash(BigFloat(1.0))

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -9,8 +9,13 @@ types = Any[
     Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Float32, Float64,
     Rational{Int8}, Rational{UInt8}, Rational{Int16}, Rational{UInt16},
     Rational{Int32}, Rational{UInt32}, Rational{Int64}, Rational{UInt64},
-    BigInt, BigFloat,
+    BigFloat, #BigInt, # TODO: BigInt hashing is broken on 32-bit systems
 ]
+if Int === Int64
+    push!(types, BigInt)
+else
+    @test_broken hash(12345678901234) == hash(big(12345678901234))
+end
 vals = vcat(
     typemin(Int64),
     -Int64(maxintfloat(Float64)) .+ Int64[-4:1;],
@@ -35,7 +40,6 @@ end
 
 for T = types[2:end], x = vals
     a = coerce(T, x)
-    hash(a, zero(UInt)) == invoke(hash, Tuple{Real, UInt}, a, zero(UInt)) || println(Int, " ", T, " ", a)
     @test hash(a, zero(UInt)) == invoke(hash, Tuple{Real, UInt}, a, zero(UInt))
     @test hash(a, one(UInt)) == invoke(hash, Tuple{Real, UInt}, a, one(UInt))
 end

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -35,6 +35,7 @@ end
 
 for T = types[2:end], x = vals
     a = coerce(T, x)
+    hash(a, zero(UInt)) == invoke(hash, Tuple{Real, UInt}, a, zero(UInt)) || println(Int, " ", T, " ", a)
     @test hash(a, zero(UInt)) == invoke(hash, Tuple{Real, UInt}, a, zero(UInt))
     @test hash(a, one(UInt)) == invoke(hash, Tuple{Real, UInt}, a, one(UInt))
 end


### PR DESCRIPTION
I mishandled nonzero `pow` returned by `decompose(::BigFloat)`.

Fixes #50065 and adds a test