### PR TITLE
Highlight extra required methods for iterators

### DIFF
--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -7,29 +7,44 @@ to generically build upon those behaviors.
 
 ## [Iteration](@id man-interface-iteration)
 
-| Required methods               |                        | Brief description                                                                     |
-|:------------------------------ |:---------------------- |:------------------------------------------------------------------------------------- |
-| `iterate(iter)`                |                        | Returns either a tuple of the first item and initial state or [`nothing`](@ref) if empty        |
-| `iterate(iter, state)`         |                        | Returns either a tuple of the next item and next state or `nothing` if no items remain  |
-| **Important optional methods** | **Default definition** | **Brief description**                                                                 |
-| `Base.IteratorSize(IterType)`  | `Base.HasLength()`     | One of `Base.HasLength()`, `Base.HasShape{N}()`, `Base.IsInfinite()`, or `Base.SizeUnknown()` as appropriate |
-| `Base.IteratorEltype(IterType)`| `Base.HasEltype()`     | Either `Base.EltypeUnknown()` or `Base.HasEltype()` as appropriate                    |
-| `eltype(IterType)`             | `Any`                  | The type of the first entry of the tuple returned by `iterate()`                      |
-| `length(iter)`                 | (*undefined*)          | The number of items, if known                                                         |
-| `size(iter, [dim])`            | (*undefined*)          | The number of items in each dimension, if known                                       |
-| `Base.isdone(iter[, state])`   | `missing`              | Fast-path hint for iterator completion. Should be defined for stateful iterators, or else `isempty(iter)` may call `iterate(iter[, state])` and mutate the iterator. |
+### Required methods
 
-| Value returned by `IteratorSize(IterType)` | Required Methods                           |
-|:------------------------------------------ |:------------------------------------------ |
-| `Base.HasLength()`                         | [`length(iter)`](@ref)                     |
-| `Base.HasShape{N}()`                       | `length(iter)`  and `size(iter, [dim])`    |
-| `Base.IsInfinite()`                        | (*none*)                                   |
-| `Base.SizeUnknown()`                       | (*none*)                                   |
+| Method                 | Brief description                                                                        |
+|:---------------------- |:---------------------------------------------------------------------------------------- |
+| `iterate(iter)`        | Returns either a tuple of the first item and initial state or [`nothing`](@ref) if empty |
+| `iterate(iter, state)` | Returns either a tuple of the next item and next state or `nothing` if no items remain   |
 
-| Value returned by `IteratorEltype(IterType)` | Required Methods   |
-|:-------------------------------------------- |:------------------ |
-| `Base.HasEltype()`                           | `eltype(IterType)` |
-| `Base.EltypeUnknown()`                       | (*none*)           |
+Depending on the definition of `Base.IteratorSize(IterType)`, you may need to define additional methods:
+
+| Value returned by `Base.IteratorSize(IterType)` | Required Methods                               |
+|:----------------------------------------------- |:---------------------------------------------- |
+| `Base.HasLength()`                              | [`length(iter)`](@ref)                         |
+| `Base.HasShape{N}()`                            | `length(iter)` and [`size(iter, [dim])`](@ref) |
+| `Base.IsInfinite()`                             | (*none*)                                       |
+| `Base.SizeUnknown()`                            | (*none*)                                       |
+
+Because the default definition of `Base.IteratorSize(IterType)` is `Base.HasLength()`, you will need to define at least one of `Base.IteratorSize(IterType)` and `length(iter)`.
+
+| Method                       | Default definition | Brief description                                                                                            |
+|:---------------------------- |:------------------ |:------------------------------------------------------------------------------------------------------------ |
+| `Base.IteratorSize(IterType)`| `Base.HasLength()` | One of `Base.HasLength()`, `Base.HasShape{N}()`, `Base.IsInfinite()`, or `Base.SizeUnknown()` as appropriate |
+| `length(iter)`               | (*undefined*)      | The number of items, if known                                                                                |
+| `size(iter, [dim])`          | (*undefined*)      | The number of items in each dimension, if known                                                              |
+
+### Optional methods
+
+| Method                          | Default definition | Brief description                                                                                                                                                    |
+|:------------------------------- |:------------------ |:-------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Base.IteratorEltype(IterType)` | `Base.HasEltype()` | Either `Base.EltypeUnknown()` or `Base.HasEltype()` as appropriate                                                                                                   |
+| `eltype(IterType)`              | `Any`              | The type of the first entry of the tuple returned by `iterate()`                                                                                                     |
+| `Base.isdone(iter[, state])`    | `missing`          | Fast-path hint for iterator completion. Should be defined for stateful iterators, or else `isempty(iter)` may call `iterate(iter[, state])` and mutate the iterator. |
+
+| Value returned by `Base.IteratorEltype(IterType)` | Required Methods   |
+|:------------------------------------------------- |:------------------ |
+| `Base.HasEltype()`                                | `eltype(IterType)` |
+| `Base.EltypeUnknown()`                            | (*none*)           |
+
+### Description
 
 Sequential iteration is implemented by the [`iterate`](@ref) function. Instead
 of mutating objects as they are iterated over, Julia iterators may keep track


### PR DESCRIPTION
A student on exercism read this section and did not realise that they had to define at least one of `Base.IteratorSize` and `length`.

I'm not totally happy with this revision, but it does seem a bit clearer to me. Some particular bits that I think could be better:

- `eltype` is called a required method, but that's only sorta true because the default definition is probably fine.
- it's a bit long?
  - Maybe one big table with columns "Must be defined if", "Method", "Default definition", "Brief description" would be better, but it would be quite wide.

Because the visual appearance of the docs isn't totally clear from the markdown, here are before and after images.

Before:

![image](https://github.com/JuliaLang/julia/assets/6000761/861818b6-38bf-4816-825a-867c78115e5c)

After:

![image](https://github.com/JuliaLang/julia/assets/6000761/65a0e54e-0dcd-4c79-88e2-087166766eb7)

Another variant option (one big table for all conditionally-required methods):

![image](https://github.com/JuliaLang/julia/assets/6000761/db02e1ea-7989-4e6a-a6c4-f6a1c82b044d)

<details>
<summary>Source for the variant option</summary>

```markdown
There are two methods that are always required:

| Required method        | Brief description                                                                        |
|:---------------------- |:---------------------------------------------------------------------------------------- |
| `iterate(iter)`        | Returns either a tuple of the first item and initial state or [`nothing`](@ref) if empty |
| `iterate(iter, state)` | Returns either a tuple of the next item and next state or `nothing` if no items remain   |

There are several more methods that should be defined in some circumstances. Note that 
because the default definition of `Base.IteratorSize(IterType)` is `Base.HasLength()`, you should define at least one of `Base.IteratorSize(IterType)` and `length(iter)`.

| When should this method be defined?                                            | Method                          | Default definition | Brief description |
|:--- |:--- |:--- |:--- |
| If default is not appropriate                                                  | `Base.IteratorSize(IterType)`   | `Base.HasLength()` | One of `Base.HasLength()`, `Base.HasShape{N}()`, `Base.IsInfinite()`, or `Base.SizeUnknown()` as appropriate                                                                     |
| If `IteratorSize(IterType)` returns `Base.HasLength()` or `Base.HasShape{N}()` | `length(iter)`                  | (*undefined*)      | The number of items, if known                                                                                                                                                    |
| If `IteratorSize(IterType)` returns `Base.HasShape{N}()`                       | `size(iter, [dim])`             | (*undefined*)      | The number of items in each dimension, if known                                                                                                                                  |
| If default is not appropriate                                                  | `Base.IteratorEltype(IterType)` | `Base.HasEltype()` | Either `Base.EltypeUnknown()` or `Base.HasEltype()` as appropriate                                                                                                               |
| If default is not appropriate                                                  | `eltype(IterType)`              | `Any`              | The type of the first entry of the tuple returned by `iterate()`                                                                                                                 |
| If iterator is stateful                                                        | `Base.isdone(iter[, state])`    | `missing`          | Fast-path hint for iterator completion. Should be defined for stateful iterators, or else `isempty(iter)` may call `iterate(iter[, state])` and mutate the iterator. |
```
