### PR TITLE
speed up expansion and lowering of ccall macro

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -640,13 +640,11 @@ end
 
 
 function ccall_macro_lower(convention, func, rettype, types, args, nreq)
-    lowering = []
-    realargs = []
-    gcroots = []
+    statements = []
 
-    # if interpolation was used, ensure  variable is a function pointer at runtime.
+    # if interpolation was used, ensure the value is a function pointer at runtime.
     if Meta.isexpr(func, :$)
-        push!(lowering, Expr(:(=), :func, esc(func.args[1])))
+        push!(statements, Expr(:(=), :func, esc(func.args[1])))
         name = QuoteNode(func.args[1])
         func = :func
         check = quote
@@ -655,31 +653,14 @@ function ccall_macro_lower(convention, func, rettype, types, args, nreq)
                 throw(ArgumentError("interpolated function `$name` was not a Ptr{Cvoid}, but $(typeof(func))"))
             end
         end
-        push!(lowering, check)
+        push!(statements, check)
     else
         func = esc(func)
     end
 
-    for (i, (arg, type)) in enumerate(zip(args, types))
-        sym = Symbol(string("arg", i, "root"))
-        sym2 = Symbol(string("arg", i, ))
-        earg, etype = esc(arg), esc(type)
-        push!(lowering, :(local $sym = $(GlobalRef(Base, :cconvert))($etype, $earg)))
-        push!(lowering, :(local $sym2 = $(GlobalRef(Base, :unsafe_convert))($etype, $sym)))
-        push!(realargs, sym2)
-        push!(gcroots, sym)
-    end
-    etypes = Expr(:call, Expr(:core, :svec), types...)
-    exp = Expr(:foreigncall,
-               func,
-               esc(rettype),
-               esc(etypes),
-               nreq,
-               QuoteNode(convention),
-               realargs..., gcroots...)
-    push!(lowering, exp)
-
-    return Expr(:block, lowering...)
+    return Expr(:block, statements...,
+                Expr(:call, :ccall, func, Expr(:cconv, convention, nreq), esc(rettype),
+                     Expr(:tuple, map(esc, types)...), map(esc, args)...))
 end
 
 """

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1097,7 +1097,7 @@
 
 ;; insert calls to convert() in ccall, and pull out expressions that might
 ;; need to be rooted before conversion.
-(define (lower-ccall name RT atypes args cconv)
+(define (lower-ccall name RT atypes args cconv nreq)
   (let loop ((F atypes)  ;; formals
              (A args)    ;; actuals
              (stmts '()) ;; initializers
@@ -1114,13 +1114,15 @@
       (if (null? A)
           `(block
             ,.(reverse! stmts)
-            (foreigncall ,name ,RT (call (core svec) ,@(reverse! T))
-                         ,(if isseq (- (length atypes) 1) 0) ; 0 or number of arguments before ... in definition
+            (foreigncall ,(expand-forms name) ,(expand-forms RT) (call (core svec) ,@(reverse! T))
+                         ;; 0 or number of arguments before ... in definition
+                         ,(or nreq
+                              (if isseq (- (length atypes) 1) 0))
                          ',cconv
                          ,.(reverse! C)
                          ,@GC)) ; GC root ordering is arbitrary
-          (let* ((a     (car A))
-                 (ty    (if isseq (cadar F) (car F))))
+          (let* ((a     (expand-forms (car A)))
+                 (ty    (expand-forms (if isseq (cadar F) (car F)))))
             (if (and isseq (not (null? (cdr F)))) (error "only the trailing ccall argument type should have \"...\""))
             (if (eq? ty 'Any)
                 (loop (if isseq F (cdr F)) (cdr A) stmts (list* '(core Any) T) (list* a C) GC)
@@ -2616,7 +2618,9 @@
                  ((eq? f 'ccall)
                   (if (not (length> e 4)) (error "too few arguments to ccall"))
                   (let* ((cconv (cadddr e))
-                         (have-cconv (memq cconv '(cdecl stdcall fastcall thiscall llvmcall)))
+                         (have-cconv-expr (and (pair? cconv) (eq? (car cconv) 'cconv)))
+                         (have-cconv (or have-cconv-expr
+                                         (memq cconv '(cdecl stdcall fastcall thiscall llvmcall))))
                          (after-cconv (if have-cconv (cddddr e) (cdddr e)))
                          (name (caddr e))
                          (RT   (car after-cconv))
@@ -2629,9 +2633,13 @@
                                        (eq? (car RT) 'tuple))
                                   (error "ccall argument types must be a tuple; try \"(T,)\" and check if you specified a correct return type")
                                   (error "ccall argument types must be a tuple; try \"(T,)\"")))
-                          (expand-forms
-                           (lower-ccall name RT (cdr argtypes) args
-                                        (if have-cconv cconv 'ccall))))))
+                          (lower-ccall name RT (cdr argtypes) args
+                                       (if have-cconv
+                                           (if have-cconv-expr
+                                               (cadr cconv)
+                                               cconv)
+                                           'ccall)
+                                       (and have-cconv-expr (caddr cconv))))))
                  ((any kwarg? (cddr e))       ;; f(..., a=b, ...)
                   (expand-forms (lower-kw-call f (cddr e))))
                  ((has-parameters? (cddr e))  ;; f(...; ...)

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1757,37 +1757,11 @@ end
     )::Cstring))...)
     @test call == Base.remove_linenums!(
         quote
-        local arg1root = $(GlobalRef(Base, :cconvert))($(Expr(:escape, :Cstring)), $(Expr(:escape, :str)))
-        local arg1 = $(GlobalRef(Base, :unsafe_convert))($(Expr(:escape, :Cstring)), arg1root)
-        local arg2root = $(GlobalRef(Base, :cconvert))($(Expr(:escape, :Cint)), $(Expr(:escape, :num1)))
-        local arg2 = $(GlobalRef(Base, :unsafe_convert))($(Expr(:escape, :Cint)), arg2root)
-        local arg3root = $(GlobalRef(Base, :cconvert))($(Expr(:escape, :Cint)), $(Expr(:escape, :num2)))
-        local arg3 = $(GlobalRef(Base, :unsafe_convert))($(Expr(:escape, :Cint)), arg3root)
-        $(Expr(:foreigncall,
-               :($(Expr(:escape, :((:func, libstring))))),
-               :($(Expr(:escape, :Cstring))),
-               :($(Expr(:escape, :(($(Expr(:core, :svec)))(Cstring, Cint, Cint))))),
-               0,
-               :(:ccall),
-               :arg1, :arg2, :arg3, :arg1root, :arg2root, :arg3root))
+        ccall($(Expr(:escape, :((:func, libstring)))), $(Expr(:cconv, :ccall, 0)), $(Expr(:escape, :Cstring)), ($(Expr(:escape, :Cstring)), $(Expr(:escape, :Cint)), $(Expr(:escape, :Cint))), $(Expr(:escape, :str)), $(Expr(:escape, :num1)), $(Expr(:escape, :num2)))
         end)
 
-    # pointer interpolation
-    call = ccall_macro_lower(:ccall, ccall_macro_parse(:( $(Expr(:$, :fptr))("bar"::Cstring)::Cvoid ))...)
-    @test Base.remove_linenums!(call) == Base.remove_linenums!(
-    quote
-        func = $(Expr(:escape, :fptr))
-        begin
-            if !(func isa Ptr{Cvoid})
-                name = :fptr
-                throw(ArgumentError("interpolated function `$(name)` was not a Ptr{Cvoid}, but $(typeof(func))"))
-            end
-        end
-        local arg1root = $(GlobalRef(Base, :cconvert))($(Expr(:escape, :Cstring)), $(Expr(:escape, "bar")))
-        local arg1 = $(GlobalRef(Base, :unsafe_convert))($(Expr(:escape, :Cstring)), arg1root)
-        $(Expr(:foreigncall, :func, :($(Expr(:escape, :Cvoid))), :($(Expr(:escape, :(($(Expr(:core, :svec)))(Cstring))))), 0, :(:ccall), :arg1, :arg1root))
-    end)
-
+    local fptr = :x
+    @test_throws ArgumentError("interpolated function `fptr` was not a Ptr{Cvoid}, but Symbol") @ccall $fptr()::Cvoid
 end
 
 @testset "check error paths" begin


### PR DESCRIPTION
Test case:
```
julia> ex = quote
           function cublasCher2_v2_64(handle, uplo, n, alpha, x, incx, y, incy, A, lda)
               @ccall libcublas.cublasCher2_v2_64(handle::cublasHandle_t, uplo::cublasFillMode_t,
                                               n::Int64, alpha::RefOrCuRef{cuComplex},
                                               x::CuPtr{cuComplex}, incx::Int64,
                                               y::CuPtr{cuComplex}, incy::Int64,
                                               A::CuPtr{cuComplex}, lda::Int64)::cublasStatus_t
           end
       end

julia> @btime Meta.lower(Main, ex)
```

before: 1.33ms after: 0.680ms.
I do like the idea of `@ccall` producing a `foreigncall` expression, but there are two problems leading to noticeable load time differences in some packages: (1) it does some unnecessary work forming strings to make temporary identifier names, and (2) normal variables (slots) are more expensive to analyze than ssavalues. It would probably help if macros were somehow able to generate ssavalues. In the meantime this cuts the lowering time in half by making `@ccall` produce a "classic" `ccall` call expression (plus a new `cconv` Expr head to retain the ability to express calling conventions and correct varargs).