### PR TITLE
array: make `DimensionMismatch` lazy-string friendly

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -9,7 +9,7 @@ The objects called do not have matching dimensionality. Optional argument `msg` 
 descriptive error string.
 """
 struct DimensionMismatch <: Exception
-    msg::String
+    msg::AbstractString
 end
 DimensionMismatch() = DimensionMismatch("")
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2477,3 +2477,13 @@ end
     @test !occursin("_colon", ir)
     @test !occursin("StepRange", ir)
 end
+
+# DimensionMismatch and LazyString
+function check_ranges(rx, ry)
+    if length(rx) != length(ry)
+        throw(DimensionMismatch(lazy"length of rx, $(length(rx)), does not equal length of ry, $(length(ry))"))
+    end
+    rx, ry
+end
+@test Core.Compiler.is_foldable(Base.infer_effects(check_ranges, (UnitRange{Int},UnitRange{Int})))
+# TODO JET.@test_opt check_ranges(1:2, 3:4)


### PR DESCRIPTION
At the moment, the `msg` field of `DimensionMismatch` is typed as `String`. This means lazy strings passed to `DimensionMismatch` are instantly instantiated, defeating the whole purpose of using `LazyString`.

This commit tweaks the field type to `AbstractString`. This way, lazy strings get instantiated during the exception handling later on.