### PR TITLE
missing: improve effects for some missing operations

### DIFF
--- a/test/missing.jl
+++ b/test/missing.jl
@@ -643,4 +643,11 @@ end
     @test isequal(sort(X, alg=MergeSort, rev=true), XRP)
 end
 
-sortperm(reverse([NaN, missing, NaN, missing]))
+@test (sortperm(reverse([NaN, missing, NaN, missing])); true)
+
+# use LazyString for MissingException to get the better effects
+for func in (round, ceil, floor, trunc)
+    @testset let func = func
+        @test Core.Compiler.is_foldable(Base.infer_effects(func, (Type{Int},Union{Int,Missing})))
+    end
+end


### PR DESCRIPTION
With the same motivation as JuliaLang/julia#50079, this commit is defining the `msg` field of `MissingException` as `AbstractString` type. By utilizing `LazyString`, it aims to improve the effects of various operations associated with `missing`.