### PR TITLE
Prevent registering static FASTTLS with multiple libjulias

### DIFF
--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -527,7 +527,7 @@ __attribute__((constructor)) void jl_load_libjulia_internal(void) {
     }
     void *fptr = lookup_symbol(RTLD_DEFAULT, "jl_get_pgcstack_static");
     void *(*key)(void) = lookup_symbol(RTLD_DEFAULT, "jl_pgcstack_addr_static");
-    _Atomic char *semaphore = lookup_symbol(RTLD_DEFAULT, "jl_pgcstack_static_semaphore");
+    _Atomic(char) *semaphore = lookup_symbol(RTLD_DEFAULT, "jl_pgcstack_static_semaphore");
     if (fptr != NULL && key != NULL && semaphore != NULL) {
         char already_used = 0;
         atomic_compare_exchange_strong(semaphore, &already_used, 1);

--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -527,8 +527,13 @@ __attribute__((constructor)) void jl_load_libjulia_internal(void) {
     }
     void *fptr = lookup_symbol(RTLD_DEFAULT, "jl_get_pgcstack_static");
     void *(*key)(void) = lookup_symbol(RTLD_DEFAULT, "jl_pgcstack_addr_static");
-    if (fptr != NULL && key != NULL)
-        jl_pgcstack_setkey(fptr, key);
+    _Atomic char *semaphore = lookup_symbol(RTLD_DEFAULT, "jl_pgcstack_static_semaphore");
+    if (fptr != NULL && key != NULL && semaphore != NULL) {
+        char already_used = 0;
+        atomic_compare_exchange_strong(semaphore, &already_used, 1);
+        if (already_used == 0) // RMW succeeded - we have exclusive access
+            jl_pgcstack_setkey(fptr, key);
+    }
 #endif
 
     // jl_options must be initialized very early, in case an embedder sets some

--- a/src/julia_fasttls.h
+++ b/src/julia_fasttls.h
@@ -3,6 +3,13 @@
 #ifndef JL_FASTTLS_H
 #define JL_FASTTLS_H
 
+#ifdef __cplusplus
+#include <atomic>
+#define _Atomic(T) std::atomic<T>
+#else
+#include <stdatomic.h>
+#endif
+
 // Thread-local storage access
 
 #ifdef __cplusplus
@@ -25,6 +32,7 @@ typedef jl_gcframe_t **(jl_get_pgcstack_func)(void);
 #if !defined(_OS_DARWIN_) && !defined(_OS_WINDOWS_)
 #define JULIA_DEFINE_FAST_TLS                                                                   \
 static __attribute__((tls_model("local-exec"))) __thread jl_gcframe_t **jl_pgcstack_localexec;  \
+JL_DLLEXPORT _Atomic(char) jl_pgcstack_static_semaphore;                                        \
 JL_DLLEXPORT jl_gcframe_t **jl_get_pgcstack_static(void)                                        \
 {                                                                                               \
     return jl_pgcstack_localexec;                                                               \


### PR DESCRIPTION
When there are multiple copies of libjulia present in the application, they can both end up trying to use the same static fast tls storage.

The alternative change here would be to add `jl_options.use_static_fasttls` and modify PackageCompiler.jl to set the flag to `false`.

However, that requires injecting a `#define` in PackageCompiler depending on the presence of the new flag, or starting to assign version numbers to `jl_options_t`