### PR TITLE
RFC: Introduce abstract type `AbstractBandedMatrix`

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -182,6 +182,8 @@ struct RowNonZero <: PivotingStrategy end
 struct RowMaximum <: PivotingStrategy end
 struct ColumnNorm <: PivotingStrategy end
 
+abstract type AbstractBandedMatrix{T} <: AbstractMatrix{T} end
+
 # Check that stride of matrix/vector is 1
 # Writing like this to avoid splatting penalty when called with multiple arguments,
 # see PR 16416

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Bidiagonal matrices
-struct Bidiagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
+struct Bidiagonal{T,V<:AbstractVector{T}} <: AbstractBandedMatrix{T}
     dv::V      # diagonal
     ev::V      # sub/super diagonal
     uplo::Char # upper bidiagonal ('U') or lower ('L')
@@ -421,11 +421,11 @@ end
 const BandedMatrix = Union{Bidiagonal,Diagonal,Tridiagonal,SymTridiagonal} # or BiDiTriSym
 const BiTriSym = Union{Bidiagonal,Tridiagonal,SymTridiagonal}
 const BiTri = Union{Bidiagonal,Tridiagonal}
-@inline mul!(C::AbstractVector, A::BandedMatrix, B::AbstractVector, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
-@inline mul!(C::AbstractMatrix, A::BandedMatrix, B::AbstractVector, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
-@inline mul!(C::AbstractMatrix, A::BandedMatrix, B::AbstractMatrix, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
-@inline mul!(C::AbstractMatrix, A::AbstractMatrix, B::BandedMatrix, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
-@inline mul!(C::AbstractMatrix, A::BandedMatrix, B::BandedMatrix, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
+@inline mul!(C::AbstractVector, A::AbstractBandedMatrix, B::AbstractVector, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
+@inline mul!(C::AbstractMatrix, A::AbstractBandedMatrix, B::AbstractVector, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
+@inline mul!(C::AbstractMatrix, A::AbstractBandedMatrix, B::AbstractMatrix, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
+@inline mul!(C::AbstractMatrix, A::AbstractMatrix, B::AbstractBandedMatrix, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
+@inline mul!(C::AbstractMatrix, A::AbstractBandedMatrix, B::AbstractBandedMatrix, alpha::Number, beta::Number) = _mul!(C, A, B, MulAddMul(alpha, beta))
 
 function check_A_mul_B!_sizes(C, A, B)
     mA, nA = size(A)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -2,7 +2,7 @@
 
 ## Diagonal matrices
 
-struct Diagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
+struct Diagonal{T,V<:AbstractVector{T}} <: AbstractBandedMatrix{T}
     diag::V
 
     function Diagonal{T,V}(diag) where {T,V<:AbstractVector{T}}

--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -138,6 +138,9 @@ function \(B::AbstractBandedMatrix, H::UpperHessenberg)
     return istriu(B) ? UpperHessenberg(A) : A
 end
 
+(\)(B::Bidiagonal, U::UpperHessenberg) = @invoke \(B::AbstractBandedMatrix, U::UpperHessenberg)
+(/)(U::UpperHessenberg, B::Bidiagonal) = @invoke /(U::UpperHessenberg, B::AbstractBandedMatrix)
+
 # specialized +/- for structured matrices. If these are removed, it falls
 # back to broadcasting which has ~2-10x speed regressions.
 # For the other structure matrix pairs, broadcasting works well.

--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -108,34 +108,34 @@ for op in (:+, :-)
 end
 
 # disambiguation between triangular and banded matrices, banded ones "dominate"
-mul!(C::AbstractMatrix, A::AbstractTriangular, B::BandedMatrix) = _mul!(C, A, B, MulAddMul())
-mul!(C::AbstractMatrix, A::BandedMatrix, B::AbstractTriangular) = _mul!(C, A, B, MulAddMul())
-mul!(C::AbstractMatrix, A::AbstractTriangular, B::BandedMatrix, alpha::Number, beta::Number) =
+mul!(C::AbstractMatrix, A::AbstractTriangular, B::AbstractBandedMatrix) = _mul!(C, A, B, MulAddMul())
+mul!(C::AbstractMatrix, A::AbstractBandedMatrix, B::AbstractTriangular) = _mul!(C, A, B, MulAddMul())
+mul!(C::AbstractMatrix, A::AbstractTriangular, B::AbstractBandedMatrix, alpha::Number, beta::Number) =
     _mul!(C, A, B, MulAddMul(alpha, beta))
-mul!(C::AbstractMatrix, A::BandedMatrix, B::AbstractTriangular, alpha::Number, beta::Number) =
+mul!(C::AbstractMatrix, A::AbstractBandedMatrix, B::AbstractTriangular, alpha::Number, beta::Number) =
     _mul!(C, A, B, MulAddMul(alpha, beta))
 
-function *(H::UpperHessenberg, B::Bidiagonal)
+function *(H::UpperHessenberg, B::AbstractBandedMatrix)
     T = promote_op(matprod, eltype(H), eltype(B))
     A = mul!(similar(H, T, size(H)), H, B)
-    return B.uplo == 'U' ? UpperHessenberg(A) : A
+    return istriu(B) ? UpperHessenberg(A) : A
 end
-function *(B::Bidiagonal, H::UpperHessenberg)
+function *(B::AbstractBandedMatrix, H::UpperHessenberg)
     T = promote_op(matprod, eltype(B), eltype(H))
     A = mul!(similar(H, T, size(H)), B, H)
-    return B.uplo == 'U' ? UpperHessenberg(A) : A
+    return istriu(B) ? UpperHessenberg(A) : A
 end
 
-function /(H::UpperHessenberg, B::Bidiagonal)
+function /(H::UpperHessenberg, B::AbstractBandedMatrix)
     T = typeof(oneunit(eltype(H))/oneunit(eltype(B)))
     A = _rdiv!(similar(H, T, size(H)), H, B)
-    return B.uplo == 'U' ? UpperHessenberg(A) : A
+    return istriu(B) ? UpperHessenberg(A) : A
 end
 
-function \(B::Bidiagonal, H::UpperHessenberg)
+function \(B::AbstractBandedMatrix, H::UpperHessenberg)
     T = typeof(oneunit(eltype(B))\oneunit(eltype(H)))
     A = ldiv!(similar(H, T, size(H)), B, H)
-    return B.uplo == 'U' ? UpperHessenberg(A) : A
+    return istriu(B) ? UpperHessenberg(A) : A
 end
 
 # specialized +/- for structured matrices. If these are removed, it falls

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -3,7 +3,7 @@
 #### Specialized matrix types ####
 
 ## (complex) symmetric tridiagonal matrices
-struct SymTridiagonal{T, V<:AbstractVector{T}} <: AbstractMatrix{T}
+struct SymTridiagonal{T, V<:AbstractVector{T}} <: AbstractBandedMatrix{T}
     dv::V                        # diagonal
     ev::V                        # superdiagonal
     function SymTridiagonal{T, V}(dv, ev) where {T, V<:AbstractVector{T}}
@@ -450,7 +450,7 @@ end
 end
 
 ## Tridiagonal matrices ##
-struct Tridiagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
+struct Tridiagonal{T,V<:AbstractVector{T}} <: AbstractBandedMatrix{T}
     dl::V    # sub-diagonal
     d::V     # diagonal
     du::V    # sup-diagonal


### PR DESCRIPTION
This is a little experiment, inspired by some comment by @dlfivefifty. It helps avoid union types in multiplication and division methods.