### PR TITLE
print the skipping bytes notification when skipping printing parts of a string in color

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -237,7 +237,7 @@ function show(
     if 4t ≤ n || t ≤ n && t ≤ length(str, head, tail-1)
         skip = skip_text(n)
         show(io, SubString(str, 1:prevind(str, head)))
-        print(io, skip) # TODO: bold styled
+        printstyled(io, skip; color=:light_yellow, bold=true)
         show(io, SubString(str, tail))
     else
         show(io, str)


### PR DESCRIPTION
This makes it easier to spot:

![image](https://github.com/JuliaLang/julia/assets/1282691/28892197-832c-4827-ba44-bc32493b8646)

The risk is otherwise that you miss that the string is truncated and copy it somewhere.

cc @rfourquet 