### PR TITLE
add specialized `reverse` implementation for `NTuple`

### DIFF
--- a/base/ntuple.jl
+++ b/base/ntuple.jl
@@ -88,3 +88,11 @@ end
         (t..., fill(val, N-M)...)
     end
 end
+
+
+# Specialized extensions for NTuple
+function reverse(t::NTuple{N}) where N
+    ntuple(Val{N}()) do i
+        t[end+1-i]
+    end
+end


### PR DESCRIPTION
This adds a specialized version of `reverse` for NTuple
using a simple constructor.

1.9:
```
julia> a = tuple(rand(Int, 256)...);

julia> @benchmark reverse($a)
BenchmarkTools.Trial: 7099 samples with 1 evaluation.
 Range (min … max):  611.280 μs …   5.698 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     670.392 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   700.950 μs ± 144.952 μs  ┊ GC (mean ± σ):  1.37% ± 5.70%

   ▃▄██▇▆▆▆▆▄▂                                                  ▂
  ▇███████████▇▇▆▄▇█▅▅▅▃▄▁▁▁▁▃▄▄▁▁▁▃▁▃▁▁▄▃▄▅▆▅▆▆▅▅▆▇▆▆▇▇▇█▇▆▇▇▆ █
  611 μs        Histogram: log(frequency) by time       1.33 ms <

 Memory estimate: 794.42 KiB, allocs estimate: 33663.
```

This commit:
```
julia> @benchmark reverse($a)
BenchmarkTools.Trial: 10000 samples with 995 evaluations.
 Range (min … max):  26.252 ns … 52.545 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     26.285 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   26.578 ns ±  0.940 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▆▂                                                      ▁  ▁
  ████▆▅▆▅▄▄▄▂▃▄███▇▆▆▆▅▆▄▅▅▆█▇▆▄▅▆▆▅▆██▅▅▅▄▅▅▄▅▄▅▅▅▄▅▃▅▂▄▄██ █
  26.3 ns      Histogram: log(frequency) by time      30.2 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
