### PR TITLE
Make SymTridiagonal off-diagonals mutable

### DIFF
--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -462,7 +462,11 @@ end
     @boundscheck checkbounds(A, i, j)
     if i == j
         @inbounds A.dv[i] = x
-    else
+    elseif (i == j - 1)
+        @inbounds A.ev[i] = x
+    elseif (j == i - 1)
+        @inbounds A.ev[j] = x
+    elseif !iszero(x)
         throw(ArgumentError("cannot set off-diagonal entry ($i, $j)"))
     end
     return x


### PR DESCRIPTION
Until this change, SymTridiagonals actually cannot have the off-diagonal elements modified at all. This seems to have been an error from how they were written (as a modified version of Diagonal matrices).