### PR TITLE
use in-place operations where appropriate

### DIFF
--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -186,7 +186,7 @@ end
 function Base.show(io::IO, p::Platform)
     str = string(platform_name(p), " ", arch(p))
     # Add on all the other tags not covered by os/arch:
-    other_tags = sort!(collect(filter(kv -> kv[1] ∉ ("os", "arch"), tags(p))))
+    other_tags = sort(filter(kv -> kv[1] ∉ ("os", "arch"), tags(p))))
     if !isempty(other_tags)
         str = string(str, " {", join([string(k, "=", v) for (k, v) in other_tags], ", "), "}")
     end

--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -186,7 +186,7 @@ end
 function Base.show(io::IO, p::Platform)
     str = string(platform_name(p), " ", arch(p))
     # Add on all the other tags not covered by os/arch:
-    other_tags = sort(filter(kv -> kv[1] ∉ ("os", "arch"), tags(p))))
+    other_tags = sort(filter(kv -> kv[1] ∉ ("os", "arch"), tags(p)))
     if !isempty(other_tags)
         str = string(str, " {", join([string(k, "=", v) for (k, v) in other_tags], ", "), "}")
     end

--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -186,7 +186,7 @@ end
 function Base.show(io::IO, p::Platform)
     str = string(platform_name(p), " ", arch(p))
     # Add on all the other tags not covered by os/arch:
-    other_tags = sort(collect(filter(kv -> kv[1] ∉ ("os", "arch"), tags(p))))
+    other_tags = sort!(collect(filter(kv -> kv[1] ∉ ("os", "arch"), tags(p))))
     if !isempty(other_tags)
         str = string(str, " {", join([string(k, "=", v) for (k, v) in other_tags], ", "), "}")
     end
@@ -835,7 +835,7 @@ Inspects the current Julia process to determine the libgfortran version this Jul
 linked against (if any).
 """
 function detect_libgfortran_version()
-    libgfortran_paths = filter(x -> occursin("libgfortran", x), Libdl.dllist())
+    libgfortran_paths = filter!(x -> occursin("libgfortran", x), Libdl.dllist())
     if isempty(libgfortran_paths)
         # One day, I hope to not be linking against libgfortran in base Julia
         return nothing
@@ -865,7 +865,7 @@ it is linked against (if any).  `max_minor_version` is the latest version in the
 3.4 series of GLIBCXX where the search is performed.
 """
 function detect_libstdcxx_version(max_minor_version::Int=30)
-    libstdcxx_paths = filter(x -> occursin("libstdc++", x), Libdl.dllist())
+    libstdcxx_paths = filter!(x -> occursin("libstdc++", x), Libdl.dllist())
     if isempty(libstdcxx_paths)
         # This can happen if we were built by clang, so we don't link against
         # libstdc++ at all.
@@ -897,7 +897,7 @@ between Julia and LLVM; they must match.
 """
 function detect_cxxstring_abi()
     # First, if we're not linked against libstdc++, then early-exit because this doesn't matter.
-    libstdcxx_paths = filter(x -> occursin("libstdc++", x), Libdl.dllist())
+    libstdcxx_paths = filter!(x -> occursin("libstdc++", x), Libdl.dllist())
     if isempty(libstdcxx_paths)
         # We were probably built by `clang`; we don't link against `libstdc++`` at all.
         return nothing
@@ -1080,7 +1080,7 @@ function select_platform(download_info::Dict, platform::AbstractPlatform = HostP
     # We prefer these better matches, and secondarily reverse-sort by triplet so
     # as to generally choose the latest release (e.g. a `libgfortran5` tarball
     # over a `libgfortran3` tarball).
-    ps = sort(ps, lt = (a, b) -> begin
+    sort!(ps, lt = (a, b) -> begin
         loss_a = match_loss(a, platform)
         loss_b = match_loss(b, platform)
         if loss_a != loss_b

--- a/base/binaryplatforms.jl
+++ b/base/binaryplatforms.jl
@@ -186,7 +186,7 @@ end
 function Base.show(io::IO, p::Platform)
     str = string(platform_name(p), " ", arch(p))
     # Add on all the other tags not covered by os/arch:
-    other_tags = sort(filter(kv -> kv[1] ∉ ("os", "arch"), tags(p)))
+    other_tags = sort!(filter!(kv -> kv[1] ∉ ("os", "arch"), collect(tags(p))))
     if !isempty(other_tags)
         str = string(str, " {", join([string(k, "=", v) for (k, v) in other_tags], ", "), "}")
     end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2700,7 +2700,7 @@ end
 
 function get_preferences(uuid::Union{UUID,Nothing} = nothing)
     merged_prefs = Dict{String,Any}()
-    for env in reverse(load_path())
+    for env in reverse!(load_path())
         project_toml = env_project_file(env)
         if !isa(project_toml, String)
             continue

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -141,7 +141,7 @@ function threading_run(fun, static)
         Base._wait(tasks[i])
     end
     ccall(:jl_exit_threaded_region, Cvoid, ())
-    failed_tasks = filter(istaskfailed, tasks)
+    failed_tasks = filter!(istaskfailed, tasks)
     if !isempty(failed_tasks)
         throw(CompositeException(map(TaskFailedException, failed_tasks)))
     end

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -743,7 +743,7 @@ function doc_completions(name, mod::Module=Main)
     idxs = findall(!isnothing, ms)
 
     # avoid messing up the order while inserting
-    for i in reverse(idxs)
+    for i in reverse!(idxs)
         c = only((ms[i]::AbstractMatch).captures)
         insert!(res, i, "$(c)\"\"")
     end


### PR DESCRIPTION
This changes some uses of reverse/sort/filter
to the in-place versions where appropriate.
Should provide some minor memory savings.
