### PR TITLE
Add check call to getrf!

### DIFF
--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -554,9 +554,9 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         # *     .. Array Arguments ..
         #       INTEGER            IPIV( * )
         #       DOUBLE PRECISION   A( LDA, * )
-        function getrf!(A::AbstractMatrix{$elty})
+        function getrf!(A::AbstractMatrix{$elty}; check = true)
             require_one_based_indexing(A)
-            chkfinite(A)
+            check && chkfinite(A)
             chkstride1(A)
             m, n = size(A)
             lda  = max(1,stride(A, 2))

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -79,7 +79,7 @@ transpose(F::LU{<:Real}) = TransposeFactorization(F)
 # the following method is meant to catch calls to lu!(A::LAPACKArray) without a pivoting stategy
 lu!(A::StridedMatrix{<:BlasFloat}; check::Bool = true) = lu!(A, RowMaximum(); check=check)
 function lu!(A::StridedMatrix{T}, ::RowMaximum; check::Bool = true) where {T<:BlasFloat}
-    lpt = LAPACK.getrf!(A)
+    lpt = LAPACK.getrf!(A; check)
     check && checknonsingular(lpt[3])
     return LU{T,typeof(lpt[1]),typeof(lpt[2])}(lpt[1], lpt[2], lpt[3])
 end


### PR DESCRIPTION
`lu!(A; check=false)` is supposed to disable the checking and leave it to the user:

> When check = true, an error is thrown if the decomposition fails. When check = false, responsibility for checking the decomposition's validity (via issuccess) lies with the user.

However, this is not quite true since `lu!` calls `getrf!` which internally does a check for `chkfinite` which does throw an error. This updates the `getrf!` function to have a `check` argument which is then used by `lu!` to fully disable the error throwing checks.