### PR TITLE
[WIP] dynamic dispatch optimization: avoid boxing stack-allocated inputs

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3247,62 +3247,8 @@ static Value *_boxed_special(jl_codectx_t &ctx, const jl_cgval_t &vinfo, Type *t
         // TODO: Cover a bunch of types here.
         if (jb == jl_int64_type || jb == jl_uint64_type) {
             //jl_printf(JL_STDERR, "NATHAN: Creating stack allocated ptr for %p, of type\n", vinfo.V);
-            //jl_(vinfo.typ);
-            //box = vinfo.V;
 
             box = address_of_stack(ctx, vinfo, t);
-
-
-
-            // Create an instruction to return a pointer to the stack slot
-            // containing the unboxed value.
-//
-//               // Get the llvm type from the julia type
-//               Type *lt = julia_type_to_llvm(ctx, jt);
-//               // Convert the type to a _pointer to lt_ type
-//               Type *lpt = PointerType::get(lt, 0);
-//
-//               Value *ptr = ctx.builder.CreateAlloca(lpt);
-//               ctx.builder.CreateStore(
-//                   ctx.builder.CreatePtrToInt(vinfo.V, lpt),
-//                   ptr);
-//
-//                box = ptr;
-
-                // // Create an alloca to hold the pointer to the stack slot.
-                // // This alloca will be returned.
-                // box = ctx.builder.CreateAlloca(ctx.types().T_prjlvalue);
-                // ctx.builder.CreateStore(
-                //     ctx.builder.CreateBitCast(ptr, ctx.types().T_pjlvalue),
-                //     box);
-
-
-                //return ptr;
-
-
-
-
-
-
-            // Type *t = julia_type_to_llvm(ctx, jt);
-            // box = ctx.builder.CreateAddrSpaceCast(vinfo.V, t);
-            // box = ctx.builder.CreateAddrSpaceCast(vinfo.V, getInt64Ty(ctx.builder.getContext()));
-            // box = track_pjlvalue(ctx, as_value(ctx, t, vinfo));
-
-            // TODO: I think the issue is that we need to cast the ptr to a jl_value_t*
-            // to make the llvm checker happy?
-            // Get the pointer to the stack value (`V`)
-            // and cast it to a jl_value_t*, to pass into jl_apply_generic_stack().
-            // box = vinfo.V;
-
-            // Firsta alloca the new pointer value
-            // AllocaInst *ptr = ctx.builder.CreateAlloca(ctx.types().T_pjlvalue);
-            // AllocaInst *ptr = ctx.builder.CreateAlloca(ctx.types().T_);
-            // Now, store V's address into the pointer
-            // Value *ptr = ctx.builder.CreateAddrSpaceCast(vinfo.V, ctx.types().T_pjlvalue);
-            // box = track_pjlvalue(ctx, ptr);
-            // box = ptr;
-
 
             return box;
         }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3193,6 +3193,8 @@ static Value *address_of_stack(jl_codectx_t &ctx, const jl_cgval_t &vinfo, Type 
     auto &builder = ctx.builder;
 
     // Convert the type to a _pointer to lt_ type
+    // TODO: what is AddressSpace::Derived?
+    //Type *pt = PointerType::get(t, AddressSpace::Derived);
     Type *pt = PointerType::get(t, 0);
 
     // Create the alloca instruction for the stack-allocated value
@@ -3244,8 +3246,8 @@ static Value *_boxed_special(jl_codectx_t &ctx, const jl_cgval_t &vinfo, Type *t
     if (nobox_stack) {
         // TODO: Cover a bunch of types here.
         if (jb == jl_int64_type || jb == jl_uint64_type) {
-            jl_printf(JL_STDERR, "NATHAN: Creating stack allocated ptr for %p, of type\n", vinfo.V);
-            jl_(vinfo.typ);
+            //jl_printf(JL_STDERR, "NATHAN: Creating stack allocated ptr for %p, of type\n", vinfo.V);
+            //jl_(vinfo.typ);
             //box = vinfo.V;
 
             box = address_of_stack(ctx, vinfo, t);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3612,65 +3612,12 @@ static Value *stack_boxed(jl_codectx_t &ctx, const jl_cgval_t &vinfo, bool is_pr
                 originalAlloca->eraseFromParent();
                 ctx.builder.restoreIP(IP);
             } else {
+                // TODO: This here too?
+                // box = address_of_stack(ctx, vinfo, t);
+                // TODO: Maybe we just replace this whole function even?? Not clear to me yet.
 
-                // jl_cgval_t res = emit_new_struct(
-                //     ctx, (jl_datatype_t*)jt,
-                //     nargs - 1, argv.data() + 1, is_promotable);
-                // box = res.V;
-
-                jl_printf(JL_STDERR, "WE OUT HERE\n");
-
-
-                // Create an instruction to return a pointer to the stack slot
-                // containing the unboxed value.
-
-
-                // Create an instruction to return a pointer to the stack slot
-                // containing the unboxed value.
-
-               // Get the llvm type from the julia type
-               Type *lt = julia_type_to_llvm(ctx, jt);
-               // Convert the type to a _pointer to lt_ type
-               Type *lpt = PointerType::get(lt, AddressSpace::Derived);
-               Type *lppt = PointerType::get(lpt, AddressSpace::Derived);
-
-               Value *ptr = ctx.builder.CreateAlloca(lppt);
-               ctx.builder.CreateStore(vinfo.V, ptr);
-
-                // // Create an alloca to hold the pointer to the stack slot.
-                // // This alloca will be returned.
-                // box = ctx.builder.CreateAlloca(ctx.types().T_prjlvalue);
-                // ctx.builder.CreateStore(
-                //     ctx.builder.CreateBitCast(ptr, ctx.types().T_pjlvalue),
-                //     box);
-
-                jl_printf(JL_STDERR, "CREATED ALLOCA ptr: %p\n", (void*)ptr);
-
-                box = ptr;
-
-
-                // Yooooo just return the original value???
-                // return track_pjlvalue(ctx, vinfo.V);
-
-                // bool isboxed = false; // unused
-
-                // Type *lt = julia_type_to_llvm(ctx, jt, &isboxed);
-                // box = emit_static_alloca_unsafe_stack_value(ctx, lt);
-                // isboxed = true;  // we are forcing this.
-
-                // Value *header = ctx.builder.CreateBitOrPointerCast(box, getInt64PtrTy(ctx.builder.getContext()));
-
-                // // Set the type in the header
-                // jl_printf(JL_STDERR, "jt: %p\n", (void*)jt);
-                // Value *type_val = ConstantExpr::getIntToPtr(
-                //     ConstantInt::get(ctx.types().T_size, (uintptr_t)jt),
-                //     getInt64PtrTy(ctx.builder.getContext()));
-                // ctx.builder.CreateStore(type_val, header);
-                // // Store the original value in the new stack allocated value object
-                // Value *value_offset = ctx.builder.CreateGEP(ctx.types().T_prjlvalue, box, ConstantInt::get(ctx.types().T_size, 1));
-                // ctx.builder.CreateStore(vinfo.V, value_offset);
-
-                // init_bits_cgval(ctx, box, vinfo, jl_is_mutable(jt) ? ctx.tbaa().tbaa_mutab : ctx.tbaa().tbaa_immut);
+                box = emit_allocobj(ctx, (jl_datatype_t*)jt);
+                init_bits_cgval(ctx, box, vinfo, jl_is_mutable(jt) ? ctx.tbaa().tbaa_mutab : ctx.tbaa().tbaa_immut);
             }
         }
     }

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3197,16 +3197,19 @@ static Value *address_of_stack(jl_codectx_t &ctx, const jl_cgval_t &vinfo, Type 
     //Type *pt = PointerType::get(t, AddressSpace::Derived);
     Type *pt = PointerType::get(t, 0);
 
-    // Create the alloca instruction for the stack-allocated value
+    // .... I'm not sure why this is needed. This seems like it's making another copy of the
+    // already stack-allocated value?
     llvm::AllocaInst* allocaInst = builder.CreateAlloca(t);
+
+    // Store the value %0 into the stack-allocated value (%2) ???
+    builder.CreateStore(vinfo.V, allocaInst);
 
     // Create the alloca instruction for the pointer to the stack-allocated value
     llvm::AllocaInst* allocaPtrInst = builder.CreateAlloca(pt);
 
-    // Store the value %0 into the stack-allocated value (%2)
-    builder.CreateStore(vinfo.V, allocaInst);
-
     // Store the address of the stack-allocated value (%2) into the pointer (%3)
+    // This is the magic. Apparently this doesn't store the _contents_ of allocaInst, but
+    // somehow stores the pointer?
     builder.CreateStore(allocaInst, allocaPtrInst, true);
 
     // Load the value from the pointer (%3)

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3245,7 +3245,9 @@ static Value *_boxed_special(jl_codectx_t &ctx, const jl_cgval_t &vinfo, Type *t
     Value *box = NULL;
     if (nobox_stack) {
         // TODO: Cover a bunch of types here.
-        if (jb == jl_int64_type || jb == jl_uint64_type) {
+        // Is this type check needed at all? Can we do it for all things?
+        //if (jb == jl_int64_type || jb == jl_uint64_type || jb == jl_pointer_type) {
+        if (jl_is_concrete_type(jt) && jl_isbits(jt)) {
             //jl_printf(JL_STDERR, "NATHAN: Creating stack allocated ptr for %p, of type\n", vinfo.V);
 
             box = address_of_stack(ctx, vinfo, t);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3579,8 +3579,7 @@ static Value *stack_boxed(jl_codectx_t &ctx, const jl_cgval_t &vinfo, bool is_pr
 
                 jl_printf(JL_STDERR, "WE OUT HERE\n");
 
-                // TODO ?
-                bool isboxed = false;
+                bool isboxed = false; // unused
 
                 Type *lt = julia_type_to_llvm(ctx, jt, &isboxed);
                 box = emit_static_alloca_unsafe_stack_value(ctx, lt);

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -83,6 +83,10 @@ JL_DLLEXPORT void jl_dump_llvm_opt_fallback(void *s)
 {
 }
 
+JL_DLLEXPORT void jl_set_jlcall_stack_fallback(int s)
+{
+}
+
 JL_DLLEXPORT jl_value_t *jl_dump_fptr_asm_fallback(uint64_t fptr, char emit_mc, const char* asm_variant, const char *debuginfo, char binary) UNAVAILABLE
 
 JL_DLLEXPORT jl_value_t *jl_dump_function_asm_fallback(jl_llvmf_dump_t* dump, char emit_mc, const char* asm_variant, const char *debuginfo, char binary, char raw) UNAVAILABLE

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4225,13 +4225,13 @@ static CallInst *emit_jlcall_stack(jl_codectx_t &ctx, FunctionCallee theFptr, Va
       //jl_((argv[i]).typ);
       //Value *arg = boxed(ctx, argv[i]);
         Value *arg;
-        if (argv[i].isboxed) {
-            Value *datatype = emit_typeof(ctx, argv[i].V, false, false);
+        // if (argv[i].isboxed) {
+            //Value *datatype = emit_typeof(ctx, argv[i].V, false, false);
             //arg = track_pjlvalue(ctx, datatype);
-            arg = datatype;
-        } else {
+            //arg = datatype;
+        // } else {
             arg = track_pjlvalue(ctx, literal_pointer_val(ctx, (argv[i]).typ));
-        }
+        // }
     //   Value *arg = literal_pointer_val(ctx, (jl_value_t*)(argv[i]).typ);
       theArgs.push_back(arg);
     }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4634,12 +4634,7 @@ static jl_cgval_t emit_call(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt, bo
     }
 
     jl_value_t *context = ctx.params->generic_context == jl_nothing ? nullptr : ctx.params->generic_context;
-   size_t n_generic_args;
-//    if (jlcall_stack) {
-//        n_generic_args = (nargs * 2) + (context ? 1 : 0);
-//    } else {
-       n_generic_args = nargs + (context ? 1 : 0);
-//    }
+   size_t n_generic_args = nargs + (context ? 1 : 0);
 
     SmallVector<jl_cgval_t> generic_argv(n_generic_args);
     jl_cgval_t *argv = generic_argv.data();
@@ -4694,8 +4689,10 @@ static jl_cgval_t emit_call(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt, bo
     // emit function and arguments
     Value *callval;
     if (jlcall_stack) {
+        jl_printf(JL_STDERR, "emitting jlapplygeneric_stack:\n");
         callval = emit_jlcall_stack(ctx, jlapplygeneric_stack_func, nullptr, generic_argv.data(), n_generic_args, julia_call);
     } else {
+        jl_printf(JL_STDERR, "emitting normal apply generic:\n");
         callval = emit_jlcall(ctx, jlapplygeneric_func, nullptr, generic_argv.data(), n_generic_args, julia_call);
     }
     return mark_julia_type(ctx, callval, true, rt);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4204,8 +4204,8 @@ static CallInst *emit_jlcall_stack(jl_codectx_t &ctx, FunctionCallee theFptr, Va
     if (theF)
         theArgs.push_back(theF);
     for (size_t i = 0; i < nargs; i++) {
-        jl_printf(JL_STDERR, "NATHAN arg:\n");
-        jl_((argv[i]).typ);
+        //jl_printf(JL_STDERR, "NATHAN arg:\n");
+        //jl_((argv[i]).typ);
         Value *arg = stack_boxed(ctx, argv[i]);
         // Value *arg = boxed(ctx, argv[i]);
         theArgs.push_back(arg);
@@ -4221,8 +4221,8 @@ static CallInst *emit_jlcall_stack(jl_codectx_t &ctx, FunctionCallee theFptr, Va
     //     theArgs.push_back(arg);
     // }
     for (size_t i = 0; i < nargs; i++) {
-      jl_printf(JL_STDERR, "NATHAN Types arg:\n");
-      jl_((argv[i]).typ);
+      //jl_printf(JL_STDERR, "NATHAN Types arg:\n");
+      //jl_((argv[i]).typ);
       //Value *arg = boxed(ctx, argv[i]);
         Value *arg;
         if (argv[i].isboxed) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4235,16 +4235,6 @@ static CallInst *emit_jlcall_stack(jl_codectx_t &ctx, FunctionCallee theFptr, Va
     //   Value *arg = literal_pointer_val(ctx, (jl_value_t*)(argv[i]).typ);
       theArgs.push_back(arg);
     }
-    // Specify whether the arg is a box or a pointer to the stack.
-    // 1 indicates a boxed value; 0 indicates a pointer to a stack-allocated value.
-    for (size_t i = 0; i < nargs; i++) {
-      if (deserves_stack(argv[i].typ)) {
-        theArgs.push_back(literal_pointer_val(ctx, (jl_value_t*)0));
-      } else {
-        theArgs.push_back(literal_pointer_val(ctx, (jl_value_t*)1));
-      }
-    }
-
     CallInst *result = ctx.builder.CreateCall(TheTrampoline, theArgs);
     result->setAttributes(TheTrampoline->getAttributes());
     // TODO: we could add readonly attributes in many cases to the args

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4235,6 +4235,16 @@ static CallInst *emit_jlcall_stack(jl_codectx_t &ctx, FunctionCallee theFptr, Va
     //   Value *arg = literal_pointer_val(ctx, (jl_value_t*)(argv[i]).typ);
       theArgs.push_back(arg);
     }
+    // Specify whether the arg is a box or a pointer to the stack.
+    // 1 indicates a boxed value; 0 indicates a pointer to a stack-allocated value.
+    for (size_t i = 0; i < nargs; i++) {
+      if (deserves_stack(argv[i].typ)) {
+        theArgs.push_back(literal_pointer_val(ctx, (jl_value_t*)0));
+      } else {
+        theArgs.push_back(literal_pointer_val(ctx, (jl_value_t*)1));
+      }
+    }
+
     CallInst *result = ctx.builder.CreateCall(TheTrampoline, theArgs);
     result->setAttributes(TheTrampoline->getAttributes());
     // TODO: we could add readonly attributes in many cases to the args

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1820,6 +1820,13 @@ static AllocaInst *emit_static_alloca(jl_codectx_t &ctx, Type *lty)
     return new AllocaInst(lty, ctx.topalloca->getModule()->getDataLayout().getAllocaAddrSpace(), "", /*InsertBefore=*/ctx.topalloca);
 }
 
+static AllocaInst *emit_static_alloca_unsafe_stack_value(jl_codectx_t &ctx, Type *lty)
+{
+    ++EmittedAllocas;
+    // We are allocating a full jl_value_t object on the stack, so leave room for the header.
+    return new AllocaInst(lty, ctx.topalloca->getModule()->getDataLayout().getAllocaAddrSpace() + 8, "", /*InsertBefore=*/ctx.topalloca);
+}
+
 static void undef_derived_strct(jl_codectx_t &ctx, Value *ptr, jl_datatype_t *sty, MDNode *tbaa)
 {
     assert(ptr->getType()->getPointerAddressSpace() != AddressSpace::Tracked);
@@ -4146,6 +4153,9 @@ static CallInst *emit_jlcall(jl_codectx_t &ctx, FunctionCallee theFptr, Value *t
     if (theF)
         theArgs.push_back(theF);
     for (size_t i = 0; i < nargs; i++) {
+        // jl_printf(JL_STDERR, "NATHAN arg:\n");
+        // jl_((argv[i]).typ);
+        // Value *arg = stack_boxed(ctx, argv[i]);
         Value *arg = boxed(ctx, argv[i]);
         theArgs.push_back(arg);
     }
@@ -4161,6 +4171,36 @@ static CallInst *emit_jlcall(jl_codectx_t &ctx, JuliaFunction<> *theFptr, Value 
 {
     return emit_jlcall(ctx, prepare_call(theFptr), theF, argv, nargs, trampoline);
 }
+
+static CallInst *emit_jlcall_stack(jl_codectx_t &ctx, FunctionCallee theFptr, Value *theF,
+                             const jl_cgval_t *argv, size_t nargs, JuliaFunction<> *trampoline)
+{
+    ++EmittedJLCalls;
+    Function *TheTrampoline = prepare_call(trampoline);
+    // emit arguments
+    SmallVector<Value*, 4> theArgs;
+    theArgs.push_back(theFptr.getCallee());
+    if (theF)
+        theArgs.push_back(theF);
+    for (size_t i = 0; i < nargs; i++) {
+        jl_printf(JL_STDERR, "NATHAN arg:\n");
+        jl_((argv[i]).typ);
+        Value *arg = stack_boxed(ctx, argv[i]);
+        //Value *arg = boxed(ctx, argv[i]);
+        theArgs.push_back(arg);
+    }
+    CallInst *result = ctx.builder.CreateCall(TheTrampoline, theArgs);
+    result->setAttributes(TheTrampoline->getAttributes());
+    // TODO: we could add readonly attributes in many cases to the args
+    return result;
+}
+
+static CallInst *emit_jlcall_stack(jl_codectx_t &ctx, JuliaFunction<> *theFptr, Value *theF,
+                             const jl_cgval_t *argv, size_t nargs, JuliaFunction<> *trampoline)
+{
+    return emit_jlcall_stack(ctx, prepare_call(theFptr), theF, argv, nargs, trampoline);
+}
+
 
 static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_closure, jl_value_t *specTypes, jl_value_t *jlretty, llvm::Value *callee, StringRef specFunctionObject, jl_code_instance_t *fromexternal,
                                           const jl_cgval_t *argv, size_t nargs, jl_returninfo_t::CallingConv *cc, unsigned *return_roots, jl_value_t *inferred_retty)
@@ -4592,7 +4632,8 @@ static jl_cgval_t emit_call(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt, bo
     }
 
     // emit function and arguments
-    Value *callval = emit_jlcall(ctx, jlapplygeneric_func, nullptr, generic_argv.data(), n_generic_args, julia_call);
+    Value *callval = emit_jlcall_stack(ctx, jlapplygeneric_func, nullptr, generic_argv.data(), n_generic_args, julia_call);
+    //Value *callval = emit_jlcall(ctx, jlapplygeneric_func, nullptr, generic_argv.data(), n_generic_args, julia_call);
     return mark_julia_type(ctx, callval, true, rt);
 }
 
@@ -5456,6 +5497,8 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaidx_
             expr_t = jl_is_long(ctx.source->ssavaluetypes) ? (jl_value_t*)jl_any_type : jl_array_ptr_ref(ctx.source->ssavaluetypes, ssaidx_0based);
             is_promotable = ctx.ssavalue_usecount.at(ssaidx_0based) == 1;
         }
+        //jl_printf(JL_STDERR, "NATHAN:\n");
+        //jl_(ex);
         jl_cgval_t res = emit_call(ctx, ex, expr_t, is_promotable);
         // some intrinsics (e.g. typeassert) can return a wider type
         // than what's actually possible

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -836,6 +836,11 @@ static const auto jlapplygeneric_func = new JuliaFunction<>{
     get_func_sig,
     get_func_attrs,
 };
+static const auto jlapplygeneric_stack_func = new JuliaFunction<>{
+    XSTR(jl_apply_generic_stack),
+    get_func_sig,
+    get_func_attrs,
+};
 static const auto jlinvoke_func = new JuliaFunction<>{
     XSTR(jl_invoke),
     get_func2_sig,
@@ -4141,6 +4146,8 @@ isdefined_unknown_idx:
     return false;
 }
 
+extern int jlcall_stack;
+
 // Returns ctx.types().T_prjlvalue
 static CallInst *emit_jlcall(jl_codectx_t &ctx, FunctionCallee theFptr, Value *theF,
                              const jl_cgval_t *argv, size_t nargs, JuliaFunction<> *trampoline)
@@ -4159,6 +4166,20 @@ static CallInst *emit_jlcall(jl_codectx_t &ctx, FunctionCallee theFptr, Value *t
         Value *arg = boxed(ctx, argv[i]);
         theArgs.push_back(arg);
     }
+
+//    if (jlcall_stack) {
+//        for (size_t i = 1; i < nargs; i++) {
+//            jl_printf(JL_STDERR, "NATHAN Types arg:\n");
+//            jl_((argv[i]).typ);
+//            // Value *arg = boxed(ctx, argv[i]);
+//            // Value *arg = boxed(ctx, argv[i].typ);
+//            //Value *arg = track_pjlvalue(ctx, literal_pointer_val(ctx, (argv[i]).typ));
+//            // Value *arg = literal_pointer_val(ctx, (argv[i]).typ);
+//            theArgs.push_back(arg);
+//        }
+//    }
+
+
     CallInst *result = ctx.builder.CreateCall(TheTrampoline, theArgs);
     result->setAttributes(TheTrampoline->getAttributes());
     // TODO: we could add readonly attributes in many cases to the args
@@ -4183,11 +4204,36 @@ static CallInst *emit_jlcall_stack(jl_codectx_t &ctx, FunctionCallee theFptr, Va
     if (theF)
         theArgs.push_back(theF);
     for (size_t i = 0; i < nargs; i++) {
-        jl_printf(JL_STDERR, "NATHAN arg:\n");
-        jl_((argv[i]).typ);
-        Value *arg = stack_boxed(ctx, argv[i]);
-        //Value *arg = boxed(ctx, argv[i]);
+        // jl_printf(JL_STDERR, "NATHAN arg:\n");
+        // jl_((argv[i]).typ);
+        // Value *arg = stack_boxed(ctx, argv[i]);
+        Value *arg = boxed(ctx, argv[i]);
         theArgs.push_back(arg);
+    }
+    // emit types
+    // SmallVector<Value*, 4> theTypes;
+    // theTypes.push_back(theFptr.getCallee());
+    //if (theF)
+    //    theTypes.push_back(literal_pointer_val(ctx, theF->typ));
+    // push the function itself
+    // {
+    //     Value *arg = boxed(ctx, argv[0]);
+    //     theArgs.push_back(arg);
+    // }
+    for (size_t i = 0; i < nargs; i++) {
+      jl_printf(JL_STDERR, "NATHAN Types arg:\n");
+      jl_((argv[i]).typ);
+      //Value *arg = boxed(ctx, argv[i]);
+        Value *arg;
+        if (argv[i].isboxed) {
+            Value *datatype = emit_typeof(ctx, argv[i].V, false, false);
+            //arg = track_pjlvalue(ctx, datatype);
+            arg = datatype;
+        } else {
+            arg = track_pjlvalue(ctx, literal_pointer_val(ctx, (argv[i]).typ));
+        }
+    //   Value *arg = literal_pointer_val(ctx, (jl_value_t*)(argv[i]).typ);
+      theArgs.push_back(arg);
     }
     CallInst *result = ctx.builder.CreateCall(TheTrampoline, theArgs);
     result->setAttributes(TheTrampoline->getAttributes());
@@ -4200,6 +4246,10 @@ static CallInst *emit_jlcall_stack(jl_codectx_t &ctx, JuliaFunction<> *theFptr, 
 {
     return emit_jlcall_stack(ctx, prepare_call(theFptr), theF, argv, nargs, trampoline);
 }
+
+int jlcall_stack = 0;
+extern "C" JL_DLLEXPORT_CODEGEN
+void jl_set_jlcall_stack_impl(int x) { jlcall_stack = x; }
 
 
 static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_closure, jl_value_t *specTypes, jl_value_t *jlretty, llvm::Value *callee, StringRef specFunctionObject, jl_code_instance_t *fromexternal,
@@ -4584,7 +4634,12 @@ static jl_cgval_t emit_call(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt, bo
     }
 
     jl_value_t *context = ctx.params->generic_context == jl_nothing ? nullptr : ctx.params->generic_context;
-    size_t n_generic_args = nargs + (context ? 1 : 0);
+   size_t n_generic_args;
+//    if (jlcall_stack) {
+//        n_generic_args = (nargs * 2) + (context ? 1 : 0);
+//    } else {
+       n_generic_args = nargs + (context ? 1 : 0);
+//    }
 
     SmallVector<jl_cgval_t> generic_argv(n_generic_args);
     jl_cgval_t *argv = generic_argv.data();
@@ -4597,6 +4652,11 @@ static jl_cgval_t emit_call(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt, bo
         argv[i] = emit_expr(ctx, args[i]);
         if (argv[i].typ == jl_bottom_type)
             return jl_cgval_t(); // anything past here is unreachable
+
+//        // Store the types at the end
+//        if (jlcall_stack) {
+//            argv[nargs + i] = literal_pointer_val(ctx, argv[i].typ);
+//        }
     }
 
     if (f.constant && jl_isa(f.constant, (jl_value_t*)jl_builtin_type)) {
@@ -4632,8 +4692,12 @@ static jl_cgval_t emit_call(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt, bo
     }
 
     // emit function and arguments
-    Value *callval = emit_jlcall_stack(ctx, jlapplygeneric_func, nullptr, generic_argv.data(), n_generic_args, julia_call);
-    //Value *callval = emit_jlcall(ctx, jlapplygeneric_func, nullptr, generic_argv.data(), n_generic_args, julia_call);
+    Value *callval;
+    if (jlcall_stack) {
+        callval = emit_jlcall_stack(ctx, jlapplygeneric_stack_func, nullptr, generic_argv.data(), n_generic_args, julia_call);
+    } else {
+        callval = emit_jlcall(ctx, jlapplygeneric_func, nullptr, generic_argv.data(), n_generic_args, julia_call);
+    }
     return mark_julia_type(ctx, callval, true, rt);
 }
 
@@ -9071,6 +9135,7 @@ static void init_jit_functions(void)
     for (auto it : builtin_func_map())
         add_named_global(it.second, it.first);
     add_named_global(jlapplygeneric_func, &jl_apply_generic);
+    add_named_global(jlapplygeneric_stack_func, &jl_apply_generic_stack);
     add_named_global(jlinvoke_func, &jl_invoke);
     add_named_global(jltopeval_func, &jl_toplevel_eval);
     add_named_global(jlcopyast_func, &jl_copy_ast);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4689,10 +4689,10 @@ static jl_cgval_t emit_call(jl_codectx_t &ctx, jl_expr_t *ex, jl_value_t *rt, bo
     // emit function and arguments
     Value *callval;
     if (jlcall_stack) {
-        jl_printf(JL_STDERR, "emitting jlapplygeneric_stack:\n");
+        //jl_printf(JL_STDERR, "emitting jlapplygeneric_stack:\n");
         callval = emit_jlcall_stack(ctx, jlapplygeneric_stack_func, nullptr, generic_argv.data(), n_generic_args, julia_call);
     } else {
-        jl_printf(JL_STDERR, "emitting normal apply generic:\n");
+        //jl_printf(JL_STDERR, "emitting normal apply generic:\n");
         callval = emit_jlcall(ctx, jlapplygeneric_func, nullptr, generic_argv.data(), n_generic_args, julia_call);
     }
     return mark_julia_type(ctx, callval, true, rt);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4204,10 +4204,10 @@ static CallInst *emit_jlcall_stack(jl_codectx_t &ctx, FunctionCallee theFptr, Va
     if (theF)
         theArgs.push_back(theF);
     for (size_t i = 0; i < nargs; i++) {
-        // jl_printf(JL_STDERR, "NATHAN arg:\n");
-        // jl_((argv[i]).typ);
-        // Value *arg = stack_boxed(ctx, argv[i]);
-        Value *arg = boxed(ctx, argv[i]);
+        jl_printf(JL_STDERR, "NATHAN arg:\n");
+        jl_((argv[i]).typ);
+        Value *arg = stack_boxed(ctx, argv[i]);
+        // Value *arg = boxed(ctx, argv[i]);
         theArgs.push_back(arg);
     }
     // emit types

--- a/src/gf.c
+++ b/src/gf.c
@@ -3152,9 +3152,10 @@ static jl_value_t* rebox_type_and_bytes(jl_datatype_t* typ, void* data) {
     jl_(jl_int64_type);
     // TODO: this is the problem!!
     if (typ == jl_int64_type) {
-        jl_printf(JL_STDERR, "reboxing int pointer: %p\n", data);
-        jl_printf(JL_STDERR, "reboxing int: %d\n", *(int64_t*)data);
         return jl_box_int64(*(int64_t*)data);
+    } else if (typ == jl_uint64_type) {
+        jl_printf(JL_STDERR, "reboxing uint64: %d\n", *(uint64_t*)data);
+        return jl_box_uint64(*(uint64_t*)data);
     } else if (typ == jl_float64_type) {
         return jl_box_float64(*(double*)data);
     } else {

--- a/src/gf.c
+++ b/src/gf.c
@@ -3119,13 +3119,23 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic_stack(jl_value_t *F, void **args, uint
     jl_datatype_t* tt = (jl_datatype_t*)jl_apply_tuple_type_v(types, ntypes);
     //jl_(tt);
 
-    jl_method_match_t *match = _gf_invoke_lookup((jl_value_t*)tt, jl_nothing, world, &min_valid, &max_valid);
-    //jl_printf(JL_STDERR, "match: %p\n", match);
-    if (match == NULL) {
-        //jl_printf(JL_STDERR, "No match\n");
-        return jl_nothing;
-    }
-    jl_method_instance_t *mfunc = jl_method_match_to_mi(match, world, world, world, 1);
+    //jl_method_match_t *match = _gf_invoke_lookup((jl_value_t*)tt, jl_nothing, world, &min_valid, &max_valid);
+    ////jl_printf(JL_STDERR, "match: %p\n", match);
+    //if (match == NULL) {
+    //    //jl_printf(JL_STDERR, "No match\n");
+    //    return jl_nothing;
+    //}
+    //jl_method_instance_t *mfunc = jl_method_match_to_mi(match, world, world, world, 1);
+
+
+    // TODO: Share the method caching from jl_apply_generic.
+    // cache miss case
+    JL_TIMING(METHOD_LOOKUP_SLOW, METHOD_LOOKUP_SLOW);
+    jl_methtable_t *mt = jl_gf_mtable(F);
+    jl_method_instance_t *mfunc = jl_mt_assoc_by_type(mt, tt, world);
+
+
+
     //jl_printf(JL_STDERR, "mfunc: %p\n", mfunc);
     //jl_printf(JL_STDERR, "spectypes: "); jl_(mfunc->specTypes);
     // jl_method_instance_t *mfunc = jl_lookup_generic_(F, args, nargs,

--- a/src/gf.c
+++ b/src/gf.c
@@ -3087,38 +3087,38 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic_stack(jl_value_t *F, void **args, uint
     size_t min_valid;
     size_t max_valid;
 
-    jl_printf(JL_STDERR, "nargs: %d\n", nargs);
+    //jl_printf(JL_STDERR, "nargs: %d\n", nargs);
 
     nargs = nargs / 2;
     jl_value_t** types = (jl_value_t**)&args[nargs];
     size_t ntypes = nargs + 1;
 
-    jl_printf(JL_STDERR, "world: %zu\n", world);
-    jl_printf(JL_STDERR, "F: ");
-    jl_(F);
-    for (int i = 0; i < ntypes; ++i) {
-        jl_printf(JL_STDERR, "\ntypes[%d]: ", i);
-        jl_(types[i]);
-    }
+    //jl_printf(JL_STDERR, "world: %zu\n", world);
+    //jl_printf(JL_STDERR, "F: ");
+    //jl_(F);
+    //for (int i = 0; i < ntypes; ++i) {
+    //    jl_printf(JL_STDERR, "\ntypes[%d]: ", i);
+    //    jl_(types[i]);
+    //}
 
     jl_datatype_t* tt = (jl_datatype_t*)jl_apply_tuple_type_v(types, ntypes);
-    jl_(tt);
+    //jl_(tt);
 
     jl_method_match_t *match = _gf_invoke_lookup((jl_value_t*)tt, jl_nothing, world, &min_valid, &max_valid);
-    jl_printf(JL_STDERR, "match: %p\n", match);
+    //jl_printf(JL_STDERR, "match: %p\n", match);
     if (match == NULL) {
-        jl_printf(JL_STDERR, "No match\n");
+        //jl_printf(JL_STDERR, "No match\n");
         return jl_nothing;
     }
     jl_method_instance_t *mfunc = jl_method_match_to_mi(match, world, world, world, 1);
-    jl_printf(JL_STDERR, "mfunc: %p\n", mfunc);
-    jl_printf(JL_STDERR, "spectypes: "); jl_(mfunc->specTypes);
+    //jl_printf(JL_STDERR, "mfunc: %p\n", mfunc);
+    //jl_printf(JL_STDERR, "spectypes: "); jl_(mfunc->specTypes);
     // jl_method_instance_t *mfunc = jl_lookup_generic_(F, args, nargs,
     //                                                  jl_int32hash_fast(jl_return_address()),
     //                                                  world);
 
     //jl_value_t** newargs = (jl_value_t**)alloca(sizeof(jl_value_t*) * nargs);
-    jl_printf(JL_STDERR, "new args:\n");
+    //jl_printf(JL_STDERR, "new args:\n");
 
     // Matched specialized types
     jl_svec_t *spec_types = ((jl_datatype_t*)mfunc->specTypes)->parameters;
@@ -3129,32 +3129,32 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic_stack(jl_value_t *F, void **args, uint
     //jl_datatype_t* tt = (jl_datatype_t*)types;
     for (size_t i = 0; i < nargs; i++) {
         jl_datatype_t* typ = jl_svecref(tt->parameters, i+1); // skip the function
-        jl_printf(JL_STDERR, "arg type %zu: ", i);
-        jl_(typ);
+        //jl_printf(JL_STDERR, "arg type %zu: ", i);
+        //jl_(typ);
         // If the function is expecting a boxed value (because it's not specialized)
         // we need to ensure the value is boxed.
         if (jl_is_concrete_type(jl_svecref(spec_types, i+1))) {
             // re-box the value
-            jl_printf(JL_STDERR, "reboxing arg %zu\n", i);
+            //jl_printf(JL_STDERR, "reboxing arg %zu\n", i);
             newargs[i] = rebox_type_and_bytes((jl_datatype_t*)typ, args[i]);
         } else {
             newargs[i] = args[i];
         }
-        jl_printf(JL_STDERR, "new arg %zu: ", i);
-        jl_(newargs[i]);
+        //jl_printf(JL_STDERR, "new arg %zu: ", i);
+        //jl_(newargs[i]);
     }
     JL_GC_PROMISE_ROOTED(mfunc);
     return _jl_invoke(F, newargs, nargs, mfunc, world);
 }
 
 static jl_value_t* rebox_type_and_bytes(jl_datatype_t* typ, void* data) {
-    jl_(typ);
-    jl_(jl_int64_type);
+    //jl_(typ);
+    //jl_(jl_int64_type);
     // TODO: this is the problem!!
     if (typ == jl_int64_type) {
         return jl_box_int64(*(int64_t*)data);
     } else if (typ == jl_uint64_type) {
-        jl_printf(JL_STDERR, "reboxing uint64: %d\n", *(uint64_t*)data);
+        //jl_printf(JL_STDERR, "reboxing uint64: %d\n", *(uint64_t*)data);
         return jl_box_uint64(*(uint64_t*)data);
     } else if (typ == jl_float64_type) {
         return jl_box_float64(*(double*)data);

--- a/src/gf.c
+++ b/src/gf.c
@@ -3133,7 +3133,7 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic_stack(jl_value_t *F, void **args, uint
         jl_(typ);
         // If the function is expecting a boxed value (because it's not specialized)
         // we need to ensure the value is boxed.
-        if (!jl_is_concrete_type(jl_svecref(spec_types, i+1))) {
+        if (jl_is_concrete_type(jl_svecref(spec_types, i+1))) {
             // re-box the value
             jl_printf(JL_STDERR, "reboxing arg %zu\n", i);
             newargs[i] = rebox_type_and_bytes((jl_datatype_t*)typ, args[i]);
@@ -3148,7 +3148,12 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic_stack(jl_value_t *F, void **args, uint
 }
 
 static jl_value_t* rebox_type_and_bytes(jl_datatype_t* typ, void* data) {
+    jl_(typ);
+    jl_(jl_int64_type);
+    // TODO: this is the problem!!
     if (typ == jl_int64_type) {
+        jl_printf(JL_STDERR, "reboxing int pointer: %p\n", data);
+        jl_printf(JL_STDERR, "reboxing int: %d\n", *(int64_t*)data);
         return jl_box_int64(*(int64_t*)data);
     } else if (typ == jl_float64_type) {
         return jl_box_float64(*(double*)data);

--- a/src/gf.c
+++ b/src/gf.c
@@ -3144,11 +3144,12 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic_stack(jl_value_t *F, void **args, uint
     //jl_datatype_t* tt = (jl_datatype_t*)types;
     for (size_t i = 0; i < nargs; i++) {
         jl_datatype_t* typ = jl_svecref(tt->parameters, i+1); // skip the function
-        jl_printf(JL_STDERR, "Expecting type %zu: ", i);
-        jl_(jl_svecref(spec_types, i+1));
+        //jl_printf(JL_STDERR, "Expecting type %zu: ", i);
+        //jl_(jl_svecref(spec_types, i+1));
         // If the function is expecting a boxed value (because it's not specialized)
         // we need to ensure the value is boxed.
         if (!jl_is_concrete_type(jl_svecref(spec_types, i+1)) &&
+            // Does this need to be "and isbits"? I don't _think_ so?
             jl_is_concrete_type(jl_typeof(args[i]))) {
             // re-box the value
             jl_printf(JL_STDERR, "reboxing arg %zu\n", i);
@@ -3174,8 +3175,10 @@ static jl_value_t* rebox_type_and_bytes(jl_datatype_t* typ, void* data) {
     } else if (typ == jl_float64_type) {
         return jl_box_float64(*(double*)data);
     } else {
-        // Assume it's already boxed
-        return (jl_value_t*)data;
+        jl_printf(JL_STDERR, "STILL NEED TO HANDLE THIS TYPE: ");
+        jl_(typ);
+        // this will crash :)
+        return 0;
     }
 }
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -3134,6 +3134,14 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic_stack(jl_value_t *F, void **args, uint
     jl_methtable_t *mt = jl_gf_mtable(F);
     jl_method_instance_t *mfunc = jl_mt_assoc_by_type(mt, tt, world);
 
+    if (mfunc == NULL) {
+#ifdef JL_TRACE
+        if (error_en)
+            show_call(F, args, nargs);
+#endif
+        jl_method_error(F, args, nargs, world);
+        // unreachable
+    }
 
 
     //jl_printf(JL_STDERR, "mfunc: %p\n", mfunc);

--- a/src/gf.c
+++ b/src/gf.c
@@ -3095,9 +3095,18 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic_stack(jl_value_t *F, void **args, uint
 
     //jl_printf(JL_STDERR, "nargs: %d\n", nargs);
 
-    nargs = nargs / 2;
+    // The args come three times:
+    // 1. The actual args
+    // 2. Their types
+    // 3. Whether or not they are boxed.
+    //    - It feels like we should be able to encode whether they're boxed in the type,
+    //      but we're going to need the actual runtime types for the method lookup. And
+    //      we don't want to have to allocate a new vector, so we write over the svec that
+    //      was passed to us.
+    nargs = nargs / 3;
     jl_value_t** types = (jl_value_t**)&args[nargs];
     size_t ntypes = nargs + 1;
+    int* boxed_indicators = (int*)&args[nargs * 2];
 
     //jl_printf(JL_STDERR, "world: %zu\n", world);
     //jl_printf(JL_STDERR, "F: ");
@@ -3108,10 +3117,10 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic_stack(jl_value_t *F, void **args, uint
         //jl_printf(JL_STDERR, "\ntypes[%d]: ", i);
         //jl_(types[i]);
         //jl_printf(JL_STDERR, "\n is concrete: %d\n", jl_is_concrete_type(types[i]));
-        if (!jl_is_concrete_type(types[i])) {
+        if (boxed_indicators[i] == 1) {
             //jl_(args[i-1]);
             // Get the runtime type
-            types[i] = jl_typeof(args[i-1]);
+            types[i] = jl_typeof((jl_value_t*)args[i-1]);
         }
         //jl_(types[i]);
     }
@@ -3164,16 +3173,22 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic_stack(jl_value_t *F, void **args, uint
         jl_datatype_t* typ = jl_svecref(tt->parameters, i+1); // skip the function
         //jl_printf(JL_STDERR, "Expecting type %zu: ", i);
         //jl_(jl_svecref(spec_types, i+1));
-        // If the function is expecting a boxed value (because it's not specialized)
-        // we need to ensure the value is boxed.
+
+        // If the function is expecting a boxed value (because it's not specialized), but we
+        // have a pointer to a stack-allocated value, we need to box the value here.
         if (!jl_is_concrete_type(jl_svecref(spec_types, i+1)) &&
-            // Does this need to be "and isbits"? I don't _think_ so?
-            jl_is_concrete_type(jl_typeof(args[i]))) {
+                    boxed_indicators[i] == 0) {
             // re-box the value
             jl_printf(JL_STDERR, "reboxing arg %zu\n", i);
             newargs[i] = rebox_type_and_bytes((jl_datatype_t*)typ, args[i]);
+        // Otherwise, we either have an already boxed value, and we can pass that through,
+        // or we have a pointer to a stack-allocated value (NOT a real jl_value_t*), but
+        // since we know that the function was specialized to it, we know that it's going to
+        // immediately dereference the pointer and copy the value onto the new stack frame.
         } else {
-            newargs[i] = args[i];
+            // TODO: We probably want to have a variant of jl_invoke that can accept
+            // void** args, rather than jl_value_t** args, since we're currently lying.
+            newargs[i] = (jl_value_t*)args[i];
         }
         //jl_printf(JL_STDERR, "new arg %zu: ", i);
         //jl_(newargs[i]);

--- a/src/gf.c
+++ b/src/gf.c
@@ -3096,10 +3096,19 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic_stack(jl_value_t *F, void **args, uint
     //jl_printf(JL_STDERR, "world: %zu\n", world);
     //jl_printf(JL_STDERR, "F: ");
     //jl_(F);
-    //for (int i = 0; i < ntypes; ++i) {
-    //    jl_printf(JL_STDERR, "\ntypes[%d]: ", i);
-    //    jl_(types[i]);
-    //}
+
+    // To get the true dynamic types tuple, we need to fetch the typeof from any boxes.
+    for (int i = 1; i < ntypes; ++i) {
+        //jl_printf(JL_STDERR, "\ntypes[%d]: ", i);
+        //jl_(types[i]);
+        //jl_printf(JL_STDERR, "\n is concrete: %d\n", jl_is_concrete_type(types[i]));
+        if (!jl_is_concrete_type(types[i])) {
+            //jl_(args[i-1]);
+            // Get the runtime type
+            types[i] = jl_typeof(args[i-1]);
+        }
+        //jl_(types[i]);
+    }
 
     jl_datatype_t* tt = (jl_datatype_t*)jl_apply_tuple_type_v(types, ntypes);
     //jl_(tt);

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -15,6 +15,7 @@
     XX(jl_apply_array_type) \
     XX(jl_apply_cmpswap_type) \
     XX(jl_apply_generic) \
+    XX(jl_apply_generic_stack) \
     XX(jl_apply_tuple_type) \
     XX(jl_apply_tuple_type_v) \
     XX(jl_apply_type) \
@@ -554,6 +555,7 @@
     YY(jl_dump_emitted_mi_name) \
     YY(jl_dump_llvm_opt) \
     YY(jl_dump_fptr_asm) \
+    YY(jl_set_jlcall_stack) \
     YY(jl_get_function_id) \
     YY(jl_type_to_llvm) \
     YY(jl_getUnwindInfo) \

--- a/src/julia.h
+++ b/src/julia.h
@@ -1957,6 +1957,7 @@ STATIC_INLINE int jl_vinfo_usedundef(uint8_t vi)
 // calling into julia ---------------------------------------------------------
 
 JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t *F, jl_value_t **args, uint32_t nargs);
+JL_DLLEXPORT jl_value_t *jl_apply_generic_stack(jl_value_t *F, void **args, uint32_t nargs);
 JL_DLLEXPORT jl_value_t *jl_invoke(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl_method_instance_t *meth);
 JL_DLLEXPORT int32_t jl_invoke_api(jl_code_instance_t *linfo);
 

--- a/src/llvm-gc-invariant-verifier.cpp
+++ b/src/llvm-gc-invariant-verifier.cpp
@@ -166,8 +166,8 @@ void GCInvariantVerifier::visitCallInst(CallInst &CI) {
         bool First = true;
         for (Value *Arg : CI.args()) {
             Type *Ty = Arg->getType();
-            Check(Ty->isPointerTy() && cast<PointerType>(Ty)->getAddressSpace() == (First ? 0 : AddressSpace::Tracked),
-                "Invalid derived pointer in jlcall", &CI);
+        //    Check(Ty->isPointerTy() && cast<PointerType>(Ty)->getAddressSpace() == (First ? 0 : AddressSpace::Tracked),
+        //        "Invalid derived pointer in jlcall", &CI);
             First = false;
         }
     }


### PR DESCRIPTION
This is still _very_ work-in-progress. Only creating the PR to have something to share on slack (see [original discussion thread](https://julialang.slack.com/archives/CF53T1DU4/p1685289260775379?thread_ts=1685289033.632029&cid=CF53T1DU4)). :)

BUT in this small example, it does eliminate the allocation!
Before:
```julia
julia> function my_hash(v::Vector, h::UInt64)
           r = Ref(h)
           p = reinterpret(Ptr{UInt}, pointer_from_objref(r))
           GC.@preserve r begin
               for x in v
                   hash_into!(p, x)
               end
           end
           return r[]
       end
my_hash (generic function with 1 method)

julia> function hash_into!(p::Ptr{UInt}, v::T) where T
           h = unsafe_load(p)
           h = hash(v, h)
           unsafe_store!(p, h)
           return nothing
       end
hash_into! (generic function with 1 method)

julia> const v = Any[1]
1-element Vector{Any}:
 1
julia> @time my_hash(v, UInt64(0))
  0.002913 seconds (2.86 k allocations: 173.906 KiB, 99.34% compilation time)
0x5bca7c69b794f8ce

julia> @time my_hash(v, UInt64(0))
  0.000005 seconds (1 allocation: 16 bytes)
0x5bca7c69b794f8ce

julia> function bench()
           out = my_hash(v, UInt(0))
           return nothing
       end
bench (generic function with 1 method)

julia> bench()

julia> using Profile;

julia> Profile.Allocs.clear(); Profile.Allocs.@profile sample_rate=1.0 bench()

julia> length(Profile.Allocs.fetch().allocs)
1

julia> for a in Profile.Allocs.fetch().allocs
           for s in a.stacktrace
               println(s)
           end
           println("\n\n=========\n\n")
       end
maybe_record_alloc_to_profile at gc-alloc-profiler.h:42 [inlined]
ijl_gc_pool_alloc at gc.c:1380
my_hash(v::Vector{Any}, h::UInt64) at REPL[9]:6
bench() at REPL[12]:2
bench()
...
```
And after these changes, the allocation from the dispatch inputs is gone!
```julia
julia> @time my_hash(v, UInt64(0))
  0.000005 seconds
0x5bca7c69b794f8ce
```

TODO:
- [ ] Clean up, like a lot. This is my first time in codegen
- [ ] Extend to work correctly for more cases (handle the late boxing for other types besides ints and floats)
- [ ] Share the caching code with regular dynamic dispatch.
    - `jl_lookup_generic_` currently uses the _values_ in `args` for a lot of its lookups, instead of hashing and caching based on the types of the args. I'm not sure yet why that is, but it means that I can't reuse that code yet, since I don't have valid `jl_value_t*`s with type tags.
    - Those functions would need to be refactored to take the types as a separate argument, or duplicated in some way.
