### PR TITLE
More scalable pool allocator

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -27,19 +27,16 @@ jl_gc_pagemeta_t *jl_gc_page_metadata(void *data)
 // the end of the page.
 JL_DLLEXPORT jl_taggedvalue_t *jl_gc_find_taggedvalue_pool(char *p, size_t *osize_p)
 {
-    if (!page_metadata(p))
+    if (!gc_alloc_map_is_set(p))
         // Not in the pool
         return NULL;
-    struct jl_gc_metadata_ext info = page_metadata_ext(p);
+    jl_gc_pagemeta_t *meta = page_metadata(p);
     char *page_begin = gc_page_data(p) + GC_PAGE_OFFSET;
     // In the page header
     if (p < page_begin)
         return NULL;
     size_t ofs = p - page_begin;
-    // Check if this is a free page
-    if (!(info.pagetable0->allocmap[info.pagetable0_i32] & (uint32_t)(1 << info.pagetable0_i)))
-        return NULL;
-    int osize = info.meta->osize;
+    int osize = meta->osize;
     // Shouldn't be needed, just in case
     if (osize == 0)
         return NULL;
@@ -111,44 +108,14 @@ static void gc_clear_mark_page(jl_gc_pagemeta_t *pg, int bits)
     }
 }
 
-static void gc_clear_mark_pagetable0(pagetable0_t *pagetable0, int bits)
+static void gc_clear_mark_outer(int bits)
 {
-    for (int pg_i = 0; pg_i < REGION0_PG_COUNT / 32; pg_i++) {
-        uint32_t line = pagetable0->allocmap[pg_i];
-        if (line) {
-            for (int j = 0; j < 32; j++) {
-                if ((line >> j) & 1) {
-                    gc_clear_mark_page(pagetable0->meta[pg_i * 32 + j], bits);
-                }
-            }
-        }
-    }
-}
-
-static void gc_clear_mark_pagetable1(pagetable1_t *pagetable1, int bits)
-{
-    for (int pg_i = 0; pg_i < REGION1_PG_COUNT / 32; pg_i++) {
-        uint32_t line = pagetable1->allocmap0[pg_i];
-        if (line) {
-            for (int j = 0; j < 32; j++) {
-                if ((line >> j) & 1) {
-                    gc_clear_mark_pagetable0(pagetable1->meta0[pg_i * 32 + j], bits);
-                }
-            }
-        }
-    }
-}
-
-static void gc_clear_mark_pagetable(int bits)
-{
-    for (int pg_i = 0; pg_i < (REGION2_PG_COUNT + 31) / 32; pg_i++) {
-        uint32_t line = memory_map.allocmap1[pg_i];
-        if (line) {
-            for (int j = 0; j < 32; j++) {
-                if ((line >> j) & 1) {
-                    gc_clear_mark_pagetable1(memory_map.meta1[pg_i * 32 + j], bits);
-                }
-            }
+    for (int i = 0; i < gc_n_threads; i++) {
+        jl_ptls_t ptls2 = gc_all_tls_states[i];
+        jl_gc_pagemeta_t *pg = ptls2->page_metadata_allocd;
+        while (pg != NULL) {
+            gc_clear_mark_page(pg, bits);
+            pg = pg->next;
         }
     }
 }
@@ -184,7 +151,7 @@ static void clear_mark(int bits)
         v = v->next;
     }
 
-    gc_clear_mark_pagetable(bits);
+    gc_clear_mark_outer(bits);
 }
 
 static void restore(void)
@@ -561,7 +528,6 @@ void gc_scrub_record_task(jl_task_t *t)
 
 JL_NO_ASAN static void gc_scrub_range(char *low, char *high)
 {
-    jl_ptls_t ptls = jl_current_task->ptls;
     jl_jmp_buf *old_buf = jl_get_safe_restore();
     jl_jmp_buf buf;
     if (jl_setjmp(buf, 0)) {
@@ -1168,7 +1134,7 @@ void gc_stats_big_obj(void)
 static int64_t poolobj_sizes[4];
 static int64_t empty_pages;
 
-static void gc_count_pool_page(jl_gc_pagemeta_t *pg)
+static void gc_count_pool_page(jl_gc_pagemeta_t *pg) JL_NOTSAFEPOINT
 {
     int osize = pg->osize;
     char *data = pg->data;
@@ -1187,44 +1153,16 @@ static void gc_count_pool_page(jl_gc_pagemeta_t *pg)
     }
 }
 
-static void gc_count_pool_pagetable0(pagetable0_t *pagetable0)
-{
-    for (int pg_i = 0; pg_i < REGION0_PG_COUNT / 32; pg_i++) {
-        uint32_t line = pagetable0->allocmap[pg_i];
-        if (line) {
-            for (int j = 0; j < 32; j++) {
-                if ((line >> j) & 1) {
-                    gc_count_pool_page(pagetable0->meta[pg_i * 32 + j]);
-                }
-            }
-        }
-    }
-}
-
-static void gc_count_pool_pagetable1(pagetable1_t *pagetable1)
-{
-    for (int pg_i = 0; pg_i < REGION1_PG_COUNT / 32; pg_i++) {
-        uint32_t line = pagetable1->allocmap0[pg_i];
-        if (line) {
-            for (int j = 0; j < 32; j++) {
-                if ((line >> j) & 1) {
-                    gc_count_pool_pagetable0(pagetable1->meta0[pg_i * 32 + j]);
-                }
-            }
-        }
-    }
-}
-
 static void gc_count_pool_pagetable(void)
 {
-    for (int pg_i = 0; pg_i < (REGION2_PG_COUNT + 31) / 32; pg_i++) {
-        uint32_t line = memory_map.allocmap1[pg_i];
-        if (line) {
-            for (int j = 0; j < 32; j++) {
-                if ((line >> j) & 1) {
-                    gc_count_pool_pagetable1(memory_map.meta1[pg_i * 32 + j]);
-                }
+    for (int i = 0; i < gc_n_threads; i++) {
+        jl_ptls_t ptls2 = gc_all_tls_states[i];
+        jl_gc_pagemeta_t *pg = ptls2->page_metadata_allocd;
+        while (pg != NULL) {
+            if (gc_alloc_map_is_set(pg->data)) {
+                gc_count_pool_page(pg);
             }
+            pg = pg->next;
         }
     }
 }

--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -19,7 +19,6 @@ extern "C" {
 #define MIN_BLOCK_PG_ALLOC (1) // 16 KB
 
 static int block_pg_cnt = DEFAULT_BLOCK_PG_ALLOC;
-static size_t current_pg_count = 0;
 
 void jl_gc_init_page(void)
 {
@@ -33,7 +32,7 @@ void jl_gc_init_page(void)
 
 // Try to allocate a memory block for multiple pages
 // Return `NULL` if allocation failed. Result is aligned to `GC_PAGE_SZ`.
-static char *jl_gc_try_alloc_pages(int pg_cnt) JL_NOTSAFEPOINT
+char *jl_gc_try_alloc_pages_(int pg_cnt) JL_NOTSAFEPOINT
 {
     size_t pages_sz = GC_PAGE_SZ * pg_cnt;
 #ifdef _OS_WINDOWS_
@@ -63,13 +62,12 @@ static char *jl_gc_try_alloc_pages(int pg_cnt) JL_NOTSAFEPOINT
 // smaller `MIN_BLOCK_PG_ALLOC` a `jl_memory_exception` is thrown.
 // Assumes `gc_perm_lock` is acquired, the lock is released before the
 // exception is thrown.
-static jl_gc_pagemeta_t *jl_gc_alloc_new_page(void) JL_NOTSAFEPOINT
+char *jl_gc_try_alloc_pages(void) JL_NOTSAFEPOINT
 {
-    // try to allocate a large block of memory (or a small one)
-    unsigned pg, pg_cnt = block_pg_cnt;
+    unsigned pg_cnt = block_pg_cnt;
     char *mem = NULL;
     while (1) {
-        if (__likely((mem = jl_gc_try_alloc_pages(pg_cnt))))
+        if (__likely((mem = jl_gc_try_alloc_pages_(pg_cnt))))
             break;
         size_t min_block_pg_alloc = MIN_BLOCK_PG_ALLOC;
         if (GC_PAGE_SZ * min_block_pg_alloc < jl_page_size)
@@ -86,201 +84,70 @@ static jl_gc_pagemeta_t *jl_gc_alloc_new_page(void) JL_NOTSAFEPOINT
             jl_throw(jl_memory_exception);
         }
     }
-
-    // now need to insert these pages into the pagetable metadata
-    // if any allocation fails, this just stops recording more pages from that point
-    // and will free (munmap) the remainder
-    jl_gc_pagemeta_t *page_meta =
-        (jl_gc_pagemeta_t*)jl_gc_perm_alloc_nolock(pg_cnt * sizeof(jl_gc_pagemeta_t), 1,
-                                                   sizeof(void*), 0);
-    pg = 0;
-    if (page_meta) {
-        for (; pg < pg_cnt; pg++) {
-            struct jl_gc_metadata_ext info;
-            uint32_t msk;
-            unsigned i;
-            pagetable1_t **ppagetable1;
-            pagetable0_t **ppagetable0;
-            jl_gc_pagemeta_t **pmeta;
-
-            char *ptr = mem + (GC_PAGE_SZ * pg);
-            page_meta[pg].data = ptr;
-
-            // create & store the level 2 / outermost info
-            i = REGION_INDEX(ptr);
-            info.pagetable_i = i % 32;
-            info.pagetable_i32 = i / 32;
-            msk = (1u << info.pagetable_i);
-            if ((memory_map.freemap1[info.pagetable_i32] & msk) == 0)
-                memory_map.freemap1[info.pagetable_i32] |= msk; // has free
-            info.pagetable1 = *(ppagetable1 = &memory_map.meta1[i]);
-            if (!info.pagetable1) {
-                info.pagetable1 = (pagetable1_t*)jl_gc_perm_alloc_nolock(sizeof(pagetable1_t), 1,
-                                                                         sizeof(void*), 0);
-                *ppagetable1 = info.pagetable1;
-                if (!info.pagetable1)
-                    break;
-            }
-
-            // create & store the level 1 info
-            i = REGION1_INDEX(ptr);
-            info.pagetable1_i = i % 32;
-            info.pagetable1_i32 = i / 32;
-            msk = (1u << info.pagetable1_i);
-            if ((info.pagetable1->freemap0[info.pagetable1_i32] & msk) == 0)
-                info.pagetable1->freemap0[info.pagetable1_i32] |= msk; // has free
-            info.pagetable0 = *(ppagetable0 = &info.pagetable1->meta0[i]);
-            if (!info.pagetable0) {
-                info.pagetable0 = (pagetable0_t*)jl_gc_perm_alloc_nolock(sizeof(pagetable0_t), 1,
-                                                                         sizeof(void*), 0);
-                *ppagetable0 = info.pagetable0;
-                if (!info.pagetable0)
-                    break;
-            }
-
-            // create & store the level 0 / page info
-            i = REGION0_INDEX(ptr);
-            info.pagetable0_i = i % 32;
-            info.pagetable0_i32 = i / 32;
-            msk = (1u << info.pagetable0_i);
-            info.pagetable0->freemap[info.pagetable0_i32] |= msk; // is free
-            pmeta = &info.pagetable0->meta[i];
-            info.meta = (*pmeta = &page_meta[pg]);
-        }
-    }
-
-    if (pg < pg_cnt) {
-#ifndef _OS_WINDOWS_
-        // Trim the allocation to only cover the region
-        // that we successfully created the metadata for.
-        // This is not supported by the Windows kernel,
-        // so we have to just skip it there and just lose these virtual addresses.
-        munmap(mem + LLT_ALIGN(GC_PAGE_SZ * pg, jl_page_size),
-               GC_PAGE_SZ * pg_cnt - LLT_ALIGN(GC_PAGE_SZ * pg, jl_page_size));
-#endif
-        if (pg == 0) {
-            uv_mutex_unlock(&gc_perm_lock);
-            jl_throw(jl_memory_exception);
-        }
-    }
-    return page_meta;
+    return mem;
 }
 
 // get a new page, either from the freemap
 // or from the kernel if none are available
 NOINLINE jl_gc_pagemeta_t *jl_gc_alloc_page(void) JL_NOTSAFEPOINT
 {
-    struct jl_gc_metadata_ext info;
-    uv_mutex_lock(&gc_perm_lock);
-
     int last_errno = errno;
 #ifdef _OS_WINDOWS_
     DWORD last_error = GetLastError();
 #endif
-    // scan over memory_map page-table for existing allocated but unused pages
-    for (info.pagetable_i32 = memory_map.lb; info.pagetable_i32 < (REGION2_PG_COUNT + 31) / 32; info.pagetable_i32++) {
-        uint32_t freemap1 = memory_map.freemap1[info.pagetable_i32];
-        for (info.pagetable_i = 0; freemap1; info.pagetable_i++, freemap1 >>= 1) {
-            unsigned next = ffs_u32(freemap1);
-            info.pagetable_i += next;
-            freemap1 >>= next;
-            info.pagetable1 = memory_map.meta1[info.pagetable_i + info.pagetable_i32 * 32];
-            // repeat over page-table level 1
-            for (info.pagetable1_i32 = info.pagetable1->lb; info.pagetable1_i32 < REGION1_PG_COUNT / 32; info.pagetable1_i32++) {
-                uint32_t freemap0 = info.pagetable1->freemap0[info.pagetable1_i32];
-                for (info.pagetable1_i = 0; freemap0; info.pagetable1_i++, freemap0 >>= 1) {
-                    unsigned next = ffs_u32(freemap0);
-                    info.pagetable1_i += next;
-                    freemap0 >>= next;
-                    info.pagetable0 = info.pagetable1->meta0[info.pagetable1_i + info.pagetable1_i32 * 32];
-                    // repeat over page-table level 0
-                    for (info.pagetable0_i32 = info.pagetable0->lb; info.pagetable0_i32 < REGION0_PG_COUNT / 32; info.pagetable0_i32++) {
-                        uint32_t freemap = info.pagetable0->freemap[info.pagetable0_i32];
-                        if (freemap) {
-                            info.pagetable0_i = ffs_u32(freemap);
-                            info.meta = info.pagetable0->meta[info.pagetable0_i + info.pagetable0_i32 * 32];
-                            assert(info.meta->data);
-                            // new pages available starting at min of lb and pagetable_i32
-                            if (memory_map.lb < info.pagetable_i32)
-                                memory_map.lb = info.pagetable_i32;
-                            if (info.pagetable1->lb < info.pagetable1_i32)
-                                info.pagetable1->lb = info.pagetable1_i32;
-                            if (info.pagetable0->lb < info.pagetable0_i32)
-                                info.pagetable0->lb = info.pagetable0_i32;
-                            goto have_free_page; // break out of all of these loops
-                        }
-                    }
-                    info.pagetable1->freemap0[info.pagetable1_i32] &= ~(uint32_t)(1u << info.pagetable1_i); // record that this was full
-                }
-            }
-            memory_map.freemap1[info.pagetable_i32] &= ~(uint32_t)(1u << info.pagetable_i); // record that this was full
+    jl_gc_pagemeta_t *meta = NULL;
+
+    // try to get page from `pool_clean`
+    meta = pop_lf_page_metadata_back(&global_page_pool_clean);
+    if (meta != NULL) {
+        gc_alloc_map_set(meta->data, 1);
+        goto exit;
+    }
+
+    // try to get page from `pool_freed`
+    meta = pop_lf_page_metadata_back(&global_page_pool_freed);
+    if (meta != NULL) {
+        gc_alloc_map_set(meta->data, 1);
+        goto exit;
+    }
+
+    uv_mutex_lock(&gc_perm_lock);
+    // another thread may have allocated a large block while we're waiting...
+    meta = pop_lf_page_metadata_back(&global_page_pool_clean);
+    if (meta != NULL) {
+        uv_mutex_unlock(&gc_perm_lock);
+        gc_alloc_map_set(meta->data, 1);
+        goto exit;
+    }
+    // must map a new set of pages
+    char *data = jl_gc_try_alloc_pages();
+    meta = (jl_gc_pagemeta_t*)malloc_s(block_pg_cnt * sizeof(jl_gc_pagemeta_t));
+    for (int i = 0; i < block_pg_cnt; i++) {
+        jl_gc_pagemeta_t *pg = &meta[i];
+        pg->data = data + GC_PAGE_SZ * i;
+        gc_alloc_map_maybe_create(pg->data);
+        if (i == 0) {
+            gc_alloc_map_set(pg->data, 1);
+        }
+        else {
+            push_lf_page_metadata_back(&global_page_pool_clean, pg);
         }
     }
-
-    // no existing pages found, allocate a new one
-    {
-        jl_gc_pagemeta_t *meta = jl_gc_alloc_new_page();
-        info = page_metadata_ext(meta->data);
-        assert(meta == info.meta);
-        // new pages are now available starting at max of lb and pagetable_i32
-        if (memory_map.lb > info.pagetable_i32)
-            memory_map.lb = info.pagetable_i32;
-        if (info.pagetable1->lb > info.pagetable1_i32)
-            info.pagetable1->lb = info.pagetable1_i32;
-        if (info.pagetable0->lb > info.pagetable0_i32)
-            info.pagetable0->lb = info.pagetable0_i32;
-    }
-
-have_free_page:
-    // in-use pages are now ending at min of ub and pagetable_i32
-    if (memory_map.ub < info.pagetable_i32)
-        memory_map.ub = info.pagetable_i32;
-    if (info.pagetable1->ub < info.pagetable1_i32)
-        info.pagetable1->ub = info.pagetable1_i32;
-    if (info.pagetable0->ub < info.pagetable0_i32)
-        info.pagetable0->ub = info.pagetable0_i32;
-
-    // mark this entry as in-use and not free
-    info.pagetable0->freemap[info.pagetable0_i32] &= ~(uint32_t)(1u << info.pagetable0_i);
-    info.pagetable0->allocmap[info.pagetable0_i32] |= (uint32_t)(1u << info.pagetable0_i);
-    info.pagetable1->allocmap0[info.pagetable1_i32] |= (uint32_t)(1u << info.pagetable1_i);
-    memory_map.allocmap1[info.pagetable_i32] |= (uint32_t)(1u << info.pagetable_i);
-
+    uv_mutex_unlock(&gc_perm_lock);
+exit:
 #ifdef _OS_WINDOWS_
-    VirtualAlloc(info.meta->data, GC_PAGE_SZ, MEM_COMMIT, PAGE_READWRITE);
-#endif
-#ifdef _OS_WINDOWS_
+    VirtualAlloc(meta->data, GC_PAGE_SZ, MEM_COMMIT, PAGE_READWRITE);
     SetLastError(last_error);
 #endif
     errno = last_errno;
-    current_pg_count++;
-    gc_final_count_page(current_pg_count);
-    uv_mutex_unlock(&gc_perm_lock);
-    return info.meta;
+    return meta;
 }
 
 // return a page to the freemap allocator
-void jl_gc_free_page(void *p) JL_NOTSAFEPOINT
+void jl_gc_free_page(jl_gc_pagemeta_t *pg) JL_NOTSAFEPOINT
 {
-    // update the allocmap and freemap to indicate this contains a free entry
-    struct jl_gc_metadata_ext info = page_metadata_ext(p);
-    uint32_t msk;
-    msk = (uint32_t)(1u << info.pagetable0_i);
-    assert(!(info.pagetable0->freemap[info.pagetable0_i32] & msk));
-    assert(info.pagetable0->allocmap[info.pagetable0_i32] & msk);
-    info.pagetable0->allocmap[info.pagetable0_i32] &= ~msk;
-    info.pagetable0->freemap[info.pagetable0_i32] |= msk;
-
-    msk = (uint32_t)(1u << info.pagetable1_i);
-    assert(info.pagetable1->allocmap0[info.pagetable1_i32] & msk);
-    if ((info.pagetable1->freemap0[info.pagetable1_i32] & msk) == 0)
-        info.pagetable1->freemap0[info.pagetable1_i32] |= msk;
-
-    msk = (uint32_t)(1u << info.pagetable_i);
-    assert(memory_map.allocmap1[info.pagetable_i32] & msk);
-    if ((memory_map.freemap1[info.pagetable_i32] & msk) == 0)
-        memory_map.freemap1[info.pagetable_i32] |= msk;
-
+    void *p = pg->data;
+    gc_alloc_map_set((char*)p, 0);
     // tell the OS we don't need these pages right now
     size_t decommit_size = GC_PAGE_SZ;
     if (GC_PAGE_SZ < jl_page_size) {
@@ -290,10 +157,9 @@ void jl_gc_free_page(void *p) JL_NOTSAFEPOINT
         void *otherp = (void*)((uintptr_t)p & ~(jl_page_size - 1)); // round down to the nearest physical page
         p = otherp;
         while (n_pages--) {
-            struct jl_gc_metadata_ext info = page_metadata_ext(otherp);
-            msk = (uint32_t)(1u << info.pagetable0_i);
-            if (info.pagetable0->allocmap[info.pagetable0_i32] & msk)
-                goto no_decommit;
+            if (gc_alloc_map_is_set((char*)otherp)) {
+                return;
+            }
             otherp = (void*)((char*)otherp + GC_PAGE_SZ);
         }
     }
@@ -313,20 +179,7 @@ void jl_gc_free_page(void *p) JL_NOTSAFEPOINT
 #else
     madvise(p, decommit_size, MADV_DONTNEED);
 #endif
-    /* TODO: Should we leave this poisoned and rather allow the GC to read poisoned pointers from
-     *       the page when it sweeps pools?
-     */
     msan_unpoison(p, decommit_size);
-
-no_decommit:
-    // new pages are now available starting at max of lb and pagetable_i32
-    if (memory_map.lb > info.pagetable_i32)
-        memory_map.lb = info.pagetable_i32;
-    if (info.pagetable1->lb > info.pagetable1_i32)
-        info.pagetable1->lb = info.pagetable1_i32;
-    if (info.pagetable0->lb > info.pagetable0_i32)
-        info.pagetable0->lb = info.pagetable0_i32;
-    current_pg_count--;
 }
 
 #ifdef __cplusplus

--- a/src/gc.c
+++ b/src/gc.c
@@ -17,9 +17,6 @@ _Atomic(int) gc_n_threads_marking;
 _Atomic(int) gc_master_tid;
 // `tid` of first GC thread
 int gc_first_tid;
-// Mutex/cond used to synchronize sleep/wakeup of GC threads
-uv_mutex_t gc_threads_lock;
-uv_cond_t gc_threads_cond;
 
 // Linked list of callback functions
 
@@ -177,8 +174,6 @@ JL_DLLEXPORT uintptr_t jl_get_buff_tag(void)
 {
     return jl_buff_tag;
 }
-
-pagetable_t memory_map;
 
 // List of marked big objects.  Not per-thread.  Accessed only by master thread.
 bigval_t *big_objects_marked = NULL;
@@ -819,7 +814,7 @@ FORCE_INLINE int gc_try_setmark_tag(jl_taggedvalue_t *o, uint8_t mark_mode) JL_N
 STATIC_INLINE void gc_setmark_big(jl_ptls_t ptls, jl_taggedvalue_t *o,
                                   uint8_t mark_mode) JL_NOTSAFEPOINT
 {
-    assert(!page_metadata(o));
+    assert(!gc_alloc_map_is_set((char*)o));
     bigval_t *hdr = bigval_header(o);
     if (mark_mode == GC_OLD_MARKED) {
         ptls->gc_cache.perm_scanned_bytes += hdr->sz & ~3;
@@ -842,13 +837,11 @@ STATIC_INLINE void gc_setmark_big(jl_ptls_t ptls, jl_taggedvalue_t *o,
 // This function should be called exactly once during marking for each pool
 // object being marked to update the page metadata.
 STATIC_INLINE void gc_setmark_pool_(jl_ptls_t ptls, jl_taggedvalue_t *o,
-                                    uint8_t mark_mode,
-                                    jl_gc_pagemeta_t *page) JL_NOTSAFEPOINT
+                                    uint8_t mark_mode, jl_gc_pagemeta_t *page) JL_NOTSAFEPOINT
 {
 #ifdef MEMDEBUG
     gc_setmark_big(ptls, o, mark_mode);
 #else
-    jl_assume(page);
     if (mark_mode == GC_OLD_MARKED) {
         ptls->gc_cache.perm_scanned_bytes += page->osize;
         static_assert(sizeof(_Atomic(uint16_t)) == sizeof(page->nold), "");
@@ -869,7 +862,7 @@ STATIC_INLINE void gc_setmark_pool_(jl_ptls_t ptls, jl_taggedvalue_t *o,
 STATIC_INLINE void gc_setmark_pool(jl_ptls_t ptls, jl_taggedvalue_t *o,
                                    uint8_t mark_mode) JL_NOTSAFEPOINT
 {
-    gc_setmark_pool_(ptls, o, mark_mode, page_metadata(o));
+    gc_setmark_pool_(ptls, o, mark_mode, page_metadata((char*)o));
 }
 
 STATIC_INLINE void gc_setmark(jl_ptls_t ptls, jl_taggedvalue_t *o,
@@ -893,9 +886,9 @@ STATIC_INLINE void gc_setmark_buf_(jl_ptls_t ptls, void *o, uint8_t mark_mode, s
     // sure.
     if (__likely(gc_try_setmark_tag(buf, mark_mode)) && !gc_verifying) {
         if (minsz <= GC_MAX_SZCLASS) {
-            jl_gc_pagemeta_t *page = page_metadata(buf);
-            if (page != NULL) {
-                gc_setmark_pool_(ptls, buf, bits, page);
+            jl_gc_pagemeta_t *meta = page_metadata(buf);
+            if (meta != NULL) {
+                gc_setmark_pool_(ptls, buf, bits, meta);
                 return;
             }
         }
@@ -1213,35 +1206,23 @@ static void sweep_malloced_arrays(void) JL_NOTSAFEPOINT
 }
 
 // pool allocation
-STATIC_INLINE jl_taggedvalue_t *gc_reset_page(jl_ptls_t ptls2, const jl_gc_pool_t *p, jl_gc_pagemeta_t *pg, jl_taggedvalue_t *fl) JL_NOTSAFEPOINT
+STATIC_INLINE jl_taggedvalue_t *gc_reset_page(jl_ptls_t ptls2, const jl_gc_pool_t *p, jl_gc_pagemeta_t *pg) JL_NOTSAFEPOINT
 {
     assert(GC_PAGE_OFFSET >= sizeof(void*));
     pg->nfree = (GC_PAGE_SZ - GC_PAGE_OFFSET) / p->osize;
     pg->pool_n = p - ptls2->heap.norm_pools;
     jl_taggedvalue_t *beg = (jl_taggedvalue_t*)(pg->data + GC_PAGE_OFFSET);
-    jl_taggedvalue_t *next = (jl_taggedvalue_t*)pg->data;
-    if (fl == NULL) {
-        next->next = NULL;
-    }
-    else {
-        // Insert free page after first page.
-        // This prevents unnecessary fragmentation from multiple pages
-        // being allocated from at the same time. Instead, objects will
-        // only ever be allocated from the first object in the list.
-        // This is specifically being relied on by the implementation
-        // of jl_gc_internal_obj_base_ptr() so that the function does
-        // not have to traverse the entire list.
-        jl_taggedvalue_t *flpage = (jl_taggedvalue_t *)gc_page_data(fl);
-        next->next = flpage->next;
-        flpage->next = beg;
-        beg = fl;
-    }
     pg->has_young = 0;
     pg->has_marked = 0;
     pg->fl_begin_offset = UINT16_MAX;
     pg->fl_end_offset = UINT16_MAX;
     return beg;
 }
+
+jl_gc_global_page_pool_t global_page_pool_lazily_freed;
+jl_gc_global_page_pool_t global_page_pool_clean;
+jl_gc_global_page_pool_t global_page_pool_freed;
+pagetable_t alloc_map;
 
 // Add a new page to the pool. Discards any pages in `p->newpages` before.
 static NOINLINE jl_taggedvalue_t *gc_add_page(jl_gc_pool_t *p) JL_NOTSAFEPOINT
@@ -1252,7 +1233,9 @@ static NOINLINE jl_taggedvalue_t *gc_add_page(jl_gc_pool_t *p) JL_NOTSAFEPOINT
     jl_gc_pagemeta_t *pg = jl_gc_alloc_page();
     pg->osize = p->osize;
     pg->thread_n = ptls->tid;
-    jl_taggedvalue_t *fl = gc_reset_page(ptls, p, pg, NULL);
+    set_page_metadata(pg);
+    push_page_metadata_back(&ptls->page_metadata_allocd, pg);
+    jl_taggedvalue_t *fl = gc_reset_page(ptls, p, pg);
     p->newpages = fl;
     return fl;
 }
@@ -1282,7 +1265,7 @@ STATIC_INLINE jl_value_t *jl_gc_pool_alloc_inner(jl_ptls_t ptls, int pool_offset
         if (__unlikely(gc_page_data(v) != gc_page_data(next))) {
             // we only update pg's fields when the freelist changes page
             // since pg's metadata is likely not in cache
-            jl_gc_pagemeta_t *pg = jl_assume(page_metadata(v));
+            jl_gc_pagemeta_t *pg = jl_assume(page_metadata_unsafe(v));
             assert(pg->osize == p->osize);
             pg->nfree = 0;
             pg->has_young = 1;
@@ -1300,11 +1283,19 @@ STATIC_INLINE jl_value_t *jl_gc_pool_alloc_inner(jl_ptls_t ptls, int pool_offset
         if (v != NULL) {
             // like the freelist case,
             // but only update the page metadata when it is full
-            jl_gc_pagemeta_t *pg = jl_assume(page_metadata((char*)v - 1));
+            jl_gc_pagemeta_t *pg = jl_assume(page_metadata_unsafe((char*)v - 1));
             assert(pg->osize == p->osize);
             pg->nfree = 0;
             pg->has_young = 1;
-            v = *(jl_taggedvalue_t**)cur_page;
+            pg = pop_page_metadata_back(&ptls->page_metadata_lazily_freed);
+            if (pg != NULL) {
+                v = gc_reset_page(ptls, p, pg);
+                pg->osize = p->osize;
+                push_page_metadata_back(&ptls->page_metadata_allocd, pg);
+            }
+            else {
+                v = NULL;
+            }
         }
         // Not an else!!
         if (v == NULL) {
@@ -1348,7 +1339,8 @@ int jl_gc_classify_pools(size_t sz, int *osize)
 int64_t lazy_freed_pages = 0;
 
 // Returns pointer to terminal pointer of list rooted at *pfl.
-static jl_taggedvalue_t **sweep_page(jl_gc_pool_t *p, jl_gc_pagemeta_t *pg, jl_taggedvalue_t **pfl, int sweep_full, int osize) JL_NOTSAFEPOINT
+static jl_taggedvalue_t **gc_sweep_page(jl_gc_pool_t *p, jl_gc_pagemeta_t **allocd,
+                                        jl_gc_pagemeta_t **lazily_freed, jl_gc_pagemeta_t *pg, jl_taggedvalue_t **pfl, int sweep_full, int osize) JL_NOTSAFEPOINT
 {
     char *data = pg->data;
     jl_taggedvalue_t *v = (jl_taggedvalue_t*)(data + GC_PAGE_OFFSET);
@@ -1356,24 +1348,23 @@ static jl_taggedvalue_t **sweep_page(jl_gc_pool_t *p, jl_gc_pagemeta_t *pg, jl_t
     size_t old_nfree = pg->nfree;
     size_t nfree;
 
+    int reuse_page = 1;
+    int freed_lazily = 0;
     int freedall = 1;
     int pg_skpd = 1;
     if (!pg->has_marked) {
+        reuse_page = 0;
+    #ifdef _P64
         // lazy version: (empty) if the whole page was already unused, free it (return it to the pool)
         // eager version: (freedall) free page as soon as possible
         // the eager one uses less memory.
         // FIXME - need to do accounting on a per-thread basis
         // on quick sweeps, keep a few pages empty but allocated for performance
         if (!sweep_full && lazy_freed_pages <= default_collect_interval / GC_PAGE_SZ) {
-            jl_ptls_t ptls2 = gc_all_tls_states[pg->thread_n];
-            jl_taggedvalue_t *begin = gc_reset_page(ptls2, p, pg, p->newpages);
-            p->newpages = begin;
-            begin->next = NULL;
             lazy_freed_pages++;
+            freed_lazily = 1;
         }
-        else {
-            jl_gc_free_page(data);
-        }
+    #endif
         nfree = (GC_PAGE_SZ - GC_PAGE_OFFSET) / osize;
         goto done;
     }
@@ -1440,97 +1431,31 @@ static jl_taggedvalue_t **sweep_page(jl_gc_pool_t *p, jl_gc_pagemeta_t *pg, jl_t
     nfree = pg->nfree;
 
 done:
+    if (reuse_page) {
+        push_page_metadata_back(allocd, pg);
+    }
+    else if (freed_lazily) {
+        push_page_metadata_back(lazily_freed, pg);
+    }
+    else {
+        jl_gc_free_page(pg);
+        push_lf_page_metadata_back(&global_page_pool_freed, pg);
+    }
     gc_time_count_page(freedall, pg_skpd);
     gc_num.freed += (nfree - old_nfree) * osize;
     return pfl;
 }
 
 // the actual sweeping over all allocated pages in a memory pool
-STATIC_INLINE void sweep_pool_page(jl_taggedvalue_t ***pfl, jl_gc_pagemeta_t *pg, int sweep_full) JL_NOTSAFEPOINT
+STATIC_INLINE void gc_sweep_pool_page(jl_taggedvalue_t ***pfl, jl_gc_pagemeta_t **allocd,
+                                      jl_gc_pagemeta_t **lazily_freed, jl_gc_pagemeta_t *pg, int sweep_full) JL_NOTSAFEPOINT
 {
     int p_n = pg->pool_n;
     int t_n = pg->thread_n;
     jl_ptls_t ptls2 = gc_all_tls_states[t_n];
     jl_gc_pool_t *p = &ptls2->heap.norm_pools[p_n];
     int osize = pg->osize;
-    pfl[t_n * JL_GC_N_POOLS + p_n] = sweep_page(p, pg, pfl[t_n * JL_GC_N_POOLS + p_n], sweep_full, osize);
-}
-
-// sweep over a pagetable0 for all allocated pages
-STATIC_INLINE int sweep_pool_pagetable0(jl_taggedvalue_t ***pfl, pagetable0_t *pagetable0, int sweep_full) JL_NOTSAFEPOINT
-{
-    unsigned ub = 0;
-    unsigned alloc = 0;
-    for (unsigned pg_i = 0; pg_i <= pagetable0->ub; pg_i++) {
-        uint32_t line = pagetable0->allocmap[pg_i];
-        unsigned j;
-        if (!line)
-            continue;
-        ub = pg_i;
-        alloc = 1;
-        for (j = 0; line; j++, line >>= 1) {
-            unsigned next = ffs_u32(line);
-            j += next;
-            line >>= next;
-            jl_gc_pagemeta_t *pg = pagetable0->meta[pg_i * 32 + j];
-            sweep_pool_page(pfl, pg, sweep_full);
-        }
-    }
-    pagetable0->ub = ub;
-    return alloc;
-}
-
-// sweep over pagetable1 for all pagetable0 that may contain allocated pages
-STATIC_INLINE int sweep_pool_pagetable1(jl_taggedvalue_t ***pfl, pagetable1_t *pagetable1, int sweep_full) JL_NOTSAFEPOINT
-{
-    unsigned ub = 0;
-    unsigned alloc = 0;
-    for (unsigned pg_i = 0; pg_i <= pagetable1->ub; pg_i++) {
-        uint32_t line = pagetable1->allocmap0[pg_i];
-        unsigned j;
-        for (j = 0; line; j++, line >>= 1) {
-            unsigned next = ffs_u32(line);
-            j += next;
-            line >>= next;
-            pagetable0_t *pagetable0 = pagetable1->meta0[pg_i * 32 + j];
-            if (pagetable0 && !sweep_pool_pagetable0(pfl, pagetable0, sweep_full))
-                pagetable1->allocmap0[pg_i] &= ~(1 << j); // no allocations found, remember that for next time
-        }
-        if (pagetable1->allocmap0[pg_i]) {
-            ub = pg_i;
-            alloc = 1;
-        }
-    }
-    pagetable1->ub = ub;
-    return alloc;
-}
-
-// sweep over all memory for all pagetable1 that may contain allocated pages
-static void sweep_pool_pagetable(jl_taggedvalue_t ***pfl, int sweep_full) JL_NOTSAFEPOINT
-{
-    if (REGION2_PG_COUNT == 1) { // compile-time optimization
-        pagetable1_t *pagetable1 = memory_map.meta1[0];
-        if (pagetable1 != NULL)
-            sweep_pool_pagetable1(pfl, pagetable1, sweep_full);
-        return;
-    }
-    unsigned ub = 0;
-    for (unsigned pg_i = 0; pg_i <= memory_map.ub; pg_i++) {
-        uint32_t line = memory_map.allocmap1[pg_i];
-        unsigned j;
-        for (j = 0; line; j++, line >>= 1) {
-            unsigned next = ffs_u32(line);
-            j += next;
-            line >>= next;
-            pagetable1_t *pagetable1 = memory_map.meta1[pg_i * 32 + j];
-            if (pagetable1 && !sweep_pool_pagetable1(pfl, pagetable1, sweep_full))
-                memory_map.allocmap1[pg_i] &= ~(1 << j); // no allocations found, remember that for next time
-        }
-        if (memory_map.allocmap1[pg_i]) {
-            ub = pg_i;
-        }
-    }
-    memory_map.ub = ub;
+    pfl[t_n * JL_GC_N_POOLS + p_n] = gc_sweep_page(p, allocd, lazily_freed, pg, pfl[t_n * JL_GC_N_POOLS + p_n], sweep_full, osize);
 }
 
 // sweep over all memory that is being used and not in a pool
@@ -1584,7 +1509,7 @@ static void gc_sweep_pool(int sweep_full)
             jl_gc_pool_t *p = &ptls2->heap.norm_pools[i];
             jl_taggedvalue_t *last = p->freelist;
             if (last != NULL) {
-                jl_gc_pagemeta_t *pg = jl_assume(page_metadata(last));
+                jl_gc_pagemeta_t *pg = jl_assume(page_metadata_unsafe(last));
                 gc_pool_sync_nfree(pg, last);
                 pg->has_young = 1;
             }
@@ -1594,17 +1519,35 @@ static void gc_sweep_pool(int sweep_full)
             last = p->newpages;
             if (last != NULL) {
                 char *last_p = (char*)last;
-                jl_gc_pagemeta_t *pg = jl_assume(page_metadata(last_p - 1));
+                jl_gc_pagemeta_t *pg = jl_assume(page_metadata_unsafe(last_p - 1));
                 assert(last_p - gc_page_data(last_p - 1) >= GC_PAGE_OFFSET);
                 pg->nfree = (GC_PAGE_SZ - (last_p - gc_page_data(last_p - 1))) / p->osize;
                 pg->has_young = 1;
             }
             p->newpages = NULL;
         }
+        jl_gc_pagemeta_t *pg = ptls2->page_metadata_lazily_freed;
+        while (pg != NULL) {
+            jl_gc_pagemeta_t *pg2 = pg->next;
+            lazy_freed_pages++;
+            pg = pg2;
+        }
     }
 
     // the actual sweeping
-    sweep_pool_pagetable(pfl, sweep_full);
+    for (int t_i = 0; t_i < n_threads; t_i++) {
+        jl_ptls_t ptls2 = gc_all_tls_states[t_i];
+        if (ptls2 != NULL) {
+            jl_gc_pagemeta_t *allocd = NULL;
+            jl_gc_pagemeta_t *pg = ptls2->page_metadata_allocd;
+            while (pg != NULL) {
+                jl_gc_pagemeta_t *pg2 = pg->next;
+                gc_sweep_pool_page(pfl, &allocd, &ptls2->page_metadata_lazily_freed, pg, sweep_full);
+                pg = pg2;
+            }
+            ptls2->page_metadata_allocd = allocd;
+        }
+    }
 
     // null out terminal pointers of free lists
     for (int t_i = 0; t_i < n_threads; t_i++) {
@@ -2796,29 +2739,19 @@ void gc_mark_and_steal(jl_ptls_t ptls)
     }
 }
 
-#define GC_BACKOFF_MIN 4
-#define GC_BACKOFF_MAX 12
-
-void gc_mark_backoff(int *i)
-{
-    if (*i < GC_BACKOFF_MAX) {
-        (*i)++;
-    }
-    for (int j = 0; j < (1 << *i); j++) {
-        jl_cpu_pause();
-    }
-}
-
 void gc_mark_loop_parallel(jl_ptls_t ptls, int master)
 {
     int backoff = GC_BACKOFF_MIN;
     if (master) {
         jl_atomic_store(&gc_master_tid, ptls->tid);
         // Wake threads up and try to do some work
-        uv_mutex_lock(&gc_threads_lock);
         jl_atomic_fetch_add(&gc_n_threads_marking, 1);
-        uv_cond_broadcast(&gc_threads_cond);
-        uv_mutex_unlock(&gc_threads_lock);
+        for (int i = gc_first_tid; i < gc_first_tid + jl_n_gcthreads; i++) {
+            jl_ptls_t ptls2 = gc_all_tls_states[i];
+            uv_mutex_lock(&ptls2->sleep_lock);
+            uv_cond_signal(&ptls2->wake_signal);
+            uv_mutex_unlock(&ptls2->sleep_lock);
+        }
         gc_mark_and_steal(ptls);
         jl_atomic_fetch_add(&gc_n_threads_marking, -1);
     }
@@ -2830,7 +2763,7 @@ void gc_mark_loop_parallel(jl_ptls_t ptls, int master)
         }
         jl_atomic_fetch_add(&gc_n_threads_marking, -1);
         // Failed to steal
-        gc_mark_backoff(&backoff);
+        gc_backoff(&backoff);
     }
 }
 
@@ -3574,13 +3507,10 @@ void jl_init_thread_heap(jl_ptls_t ptls)
 // System-wide initializations
 void jl_gc_init(void)
 {
-
     JL_MUTEX_INIT(&heapsnapshot_lock, "heapsnapshot_lock");
     JL_MUTEX_INIT(&finalizers_lock, "finalizers_lock");
     uv_mutex_init(&gc_cache_lock);
     uv_mutex_init(&gc_perm_lock);
-    uv_mutex_init(&gc_threads_lock);
-    uv_cond_init(&gc_threads_cond);
 
     jl_gc_init_page();
     jl_gc_debug_init();
@@ -4031,7 +3961,7 @@ JL_DLLEXPORT jl_value_t *jl_gc_internal_obj_base_ptr(void *p)
 {
     p = (char *) p - 1;
     jl_gc_pagemeta_t *meta = page_metadata(p);
-    if (meta) {
+    if (meta != NULL) {
         char *page = gc_page_data(p);
         // offset within page.
         size_t off = (char *)p - page;

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -198,6 +198,7 @@ typedef struct {
 } jl_gc_mark_cache_t;
 
 struct _jl_bt_element_t;
+struct _jl_gc_pagemeta_t;
 
 // This includes all the thread local states we care about for a thread.
 // Changes to TLS field types must be reflected in codegen.
@@ -260,6 +261,8 @@ typedef struct _jl_tls_states_t {
 #endif
     jl_thread_t system_id;
     arraylist_t finalizers;
+    struct _jl_gc_pagemeta_t *page_metadata_allocd;
+    struct _jl_gc_pagemeta_t *page_metadata_lazily_freed;
     jl_gc_markqueue_t mark_queue;
     jl_gc_mark_cache_t gc_cache;
     arraylist_t sweep_objs;

--- a/src/support/dtypes.h
+++ b/src/support/dtypes.h
@@ -340,6 +340,23 @@ STATIC_INLINE void jl_store_unaligned_i16(void *ptr, uint16_t val) JL_NOTSAFEPOI
     memcpy(ptr, &val, 2);
 }
 
+STATIC_INLINE void *calloc_s(size_t sz) JL_NOTSAFEPOINT {
+    int last_errno = errno;
+#ifdef _OS_WINDOWS_
+    DWORD last_error = GetLastError();
+#endif
+    void *p = calloc(sz == 0 ? 1 : sz, 1);
+    if (p == NULL) {
+        perror("(julia) calloc");
+        abort();
+    }
+#ifdef _OS_WINDOWS_
+    SetLastError(last_error);
+#endif
+    errno = last_errno;
+    return p;
+}
+
 STATIC_INLINE void *malloc_s(size_t sz) JL_NOTSAFEPOINT {
     int last_errno = errno;
 #ifdef _OS_WINDOWS_


### PR DESCRIPTION
Still very experimental and depends on #49644. Mostly for later comparisons with #48969 (e.g. if concurrent sweeping would perform better on a potentially less contended pool allocator).

Seems to perform better than master on some multithreaded allocation benchmarks (e.g. `tree_mutable.jl`), but a lot more benchmarking is needed:

- master:
```
../julia-master/julia run_benchmarks.jl multithreaded binary_tree tree_mutable -n5 -t16 --gcthreads=1
bench = "tree_mutable.jl"
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       7058 │    4033 │      2414 │       1619 │          350 │              1518 │     1631 │         57 │
│  median │       7535 │    4302 │      2484 │       1772 │          384 │              1820 │     1642 │         58 │
│ maximum │       7805 │    4848 │      2710 │       2369 │          415 │              1868 │     1667 │         62 │
│   stdev │        298 │     324 │       121 │        300 │           24 │               161 │       15 │          2 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
```

- PR:
```
../julia-allocator/julia run_benchmarks.jl multithreaded binary_tree tree_mutable -n5 -t16 --gcthreads=1
bench = "tree_mutable.jl"
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       6344 │    3894 │      1967 │       1922 │          356 │              1487 │     1950 │         59 │
│  median │       6486 │    4021 │      2058 │       2029 │          359 │              1645 │     1971 │         62 │
│ maximum │       7225 │    4321 │      2230 │       2232 │          413 │              1854 │     1982 │         63 │
│   stdev │        368 │     189 │       107 │        120 │           24 │               146 │       13 │          1 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
```