### PR TITLE
Docs: Bang has other meaning for IO and RNG functions

### DIFF
--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -119,6 +119,10 @@ with both copying and modifying forms (e.g., [`sort`](@ref) and [`sort!`](@ref))
 which are just modifying (e.g., [`push!`](@ref), [`pop!`](@ref), [`splice!`](@ref)).  It
 is typical for such functions to also return the modified array for convenience.
 
+Functions related to IO or making use of random number generators (RNG) are notable exceptions:
+Since these functions almost invariably must mutate the IO or RNG, respectively, functions with ending with `!` are used to signify that an argument _other_ than the IO or RNG is mutated.
+For example, `rand(x)` mutate the RNG, whereas `rand!(x)` mutate the RNG and `x`, and similarly, `read(io)` mutates `io`, whereas `read!(io, x)` mutates both arguments.
+
 ## Avoid strange type `Union`s
 
 Types such as `Union{Function,AbstractString}` are often a sign that some design could be cleaner.

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -120,7 +120,7 @@ which are just modifying (e.g., [`push!`](@ref), [`pop!`](@ref), [`splice!`](@re
 is typical for such functions to also return the modified array for convenience.
 
 Functions related to IO or making use of random number generators (RNG) are notable exceptions:
-Since these functions almost invariably must mutate the IO or RNG, respectively, functions with ending with `!` are used to signify that an argument _other_ than the IO or RNG is mutated.
+Since these functions almost invariably must mutate the IO or RNG, respectively, functions ending with `!` are used to signify that an argument _other_ than the IO or RNG is mutated.
 For example, `rand(x)` mutate the RNG, whereas `rand!(x)` mutate the RNG and `x`, and similarly, `read(io)` mutates `io`, whereas `read!(io, x)` mutates both arguments.
 
 ## Avoid strange type `Union`s

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -121,7 +121,7 @@ is typical for such functions to also return the modified array for convenience.
 
 Functions related to IO or making use of random number generators (RNG) are notable exceptions:
 Since these functions almost invariably must mutate the IO or RNG, respectively, functions ending with `!` are used to signify that an argument _other_ than the IO or RNG is mutated.
-For example, `rand(x)` mutate the RNG, whereas `rand!(x)` mutate the RNG and `x`, and similarly, `read(io)` mutates `io`, whereas `read!(io, x)` mutates both arguments.
+For example, `rand(x)` mutates the RNG, whereas `rand!(x)` mutates the RNG and `x`; similarly, `read(io)` mutates `io`, whereas `read!(io, x)` mutates both arguments.
 
 ## Avoid strange type `Union`s
 

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -120,8 +120,8 @@ which are just modifying (e.g., [`push!`](@ref), [`pop!`](@ref), [`splice!`](@re
 is typical for such functions to also return the modified array for convenience.
 
 Functions related to IO or making use of random number generators (RNG) are notable exceptions:
-Since these functions almost invariably must mutate the IO or RNG, respectively, functions ending with `!` are used to signify a mutation _other_ than mutating the IO or incrementing the RNG state.
-For example, `rand(x)` mutates the RNG, whereas `rand!(x)` mutates the RNG and `x`; similarly, `read(io)` mutates `io`, whereas `read!(io, x)` mutates both arguments.
+Since these functions almost invariably must mutate the IO or RNG, functions ending with `!` are used to signify a mutation _other_ than mutating the IO or advancing the RNG state.
+For example, `rand(x)` mutates the RNG, whereas `rand!(x)` mutates both the RNG and `x`; similarly, `read(io)` mutates `io`, whereas `read!(io, x)` mutates both arguments.
 
 ## Avoid strange type `Union`s
 

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -120,7 +120,7 @@ which are just modifying (e.g., [`push!`](@ref), [`pop!`](@ref), [`splice!`](@re
 is typical for such functions to also return the modified array for convenience.
 
 Functions related to IO or making use of random number generators (RNG) are notable exceptions:
-Since these functions almost invariably must mutate the IO or RNG, respectively, functions ending with `!` are used to signify that an argument _other_ than the IO or RNG is mutated.
+Since these functions almost invariably must mutate the IO or RNG, respectively, functions ending with `!` are used to signify a mutation _other_ than mutating the IO or incrementing the RNG state.
 For example, `rand(x)` mutates the RNG, whereas `rand!(x)` mutates the RNG and `x`; similarly, `read(io)` mutates `io`, whereas `read!(io, x)` mutates both arguments.
 
 ## Avoid strange type `Union`s


### PR DESCRIPTION
I have seen multiple people ask why functions such as `write` or `rand` does not end with a `!`, given that they mutate the input IO or RNG object. Mention in the style guide that `!` means something slightly different for functions taking IO or RNG arguments.