### PR TITLE
FAQ: Clarify use of PROGRAM_FILE for importable scripts

### DIFF
--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -94,6 +94,9 @@ When a file is run as the main script using `julia file.jl` one might want to ac
 functionality like command line argument handling. A way to determine that a file is run in
 this fashion is to check if `abspath(PROGRAM_FILE) == @__FILE__` is `true`.
 
+However, it is recommended to not write files that double as a script and as an importable library.
+If one needs functionality both available as a library and a script, it is better to write is as a library, then import the functionality into a distinct script.
+
 ### [How do I catch CTRL-C in a script?](@id catch-ctrl-c)
 
 Running a Julia script using `julia file.jl` does not throw


### PR DESCRIPTION
In issue #45852, the proposed `@is_script` macro as a shorthand for `abspath(PROGRAM_FILE) == @__FILE__` was rejected, because it was agreed that the pattern of using the same file as a script and an importable library is questionable, so there is no reason to make it too idiomatic.

For this reason, mention in the FAQ that while checking `PROGRAM_FILE` can be used to check if a file is run as a script, it is not recommended to have files double as both scripts and importable libraries.