### PR TITLE
[deps] Deal with `USECCACHE=1` in common CMake options

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -73,6 +73,15 @@ LLVM_CPPFLAGS :=
 LLVM_LDFLAGS :=
 LLVM_CMAKE :=
 
+ifeq ($(USECCACHE), 1)
+# When USECCACHE is set to 1 we can't use `CC` and `CXX` as compilers because they include
+# `ccache` at the beginning and CMake would think that's the actual compiler, but we can use
+# `CC_ARG`/`CXX_ARG` in their place.
+LLVM_CMAKE += -DCMAKE_C_COMPILER_LAUNCHER=ccache
+LLVM_CMAKE += -DCMAKE_C_COMPILER="$(CC_ARG)"
+LLVM_CMAKE += -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+LLVM_CMAKE += -DCMAKE_CXX_COMPILER="$(CXX_ARG)"
+endif
 LLVM_CMAKE += -DLLVM_ENABLE_PROJECTS="$(LLVM_ENABLE_PROJECTS)"
 LLVM_CMAKE += -DLLVM_EXTERNAL_PROJECTS="$(LLVM_EXTERNAL_PROJECTS)"
 LLVM_CMAKE += -DLLVM_ENABLE_RUNTIMES="$(LLVM_ENABLE_RUNTIMES)"

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -73,15 +73,6 @@ LLVM_CPPFLAGS :=
 LLVM_LDFLAGS :=
 LLVM_CMAKE :=
 
-ifeq ($(USECCACHE), 1)
-# When USECCACHE is set to 1 we can't use `CC` and `CXX` as compilers because they include
-# `ccache` at the beginning and CMake would think that's the actual compiler, but we can use
-# `CC_ARG`/`CXX_ARG` in their place.
-LLVM_CMAKE += -DCMAKE_C_COMPILER_LAUNCHER=ccache
-LLVM_CMAKE += -DCMAKE_C_COMPILER="$(CC_ARG)"
-LLVM_CMAKE += -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-LLVM_CMAKE += -DCMAKE_CXX_COMPILER="$(CXX_ARG)"
-endif
 LLVM_CMAKE += -DLLVM_ENABLE_PROJECTS="$(LLVM_ENABLE_PROJECTS)"
 LLVM_CMAKE += -DLLVM_EXTERNAL_PROJECTS="$(LLVM_EXTERNAL_PROJECTS)"
 LLVM_CMAKE += -DLLVM_ENABLE_RUNTIMES="$(LLVM_ENABLE_RUNTIMES)"

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -15,9 +15,6 @@ CONFIGURE_COMMON += LDFLAGS="$(LDFLAGS) $(RPATH_ESCAPED_ORIGIN) $(SANITIZE_LDFLA
 endif
 CONFIGURE_COMMON += F77="$(FC)" CC="$(CC) $(SANITIZE_OPTS)" CXX="$(CXX) $(SANITIZE_OPTS)" LD="$(LD)"
 
-CMAKE_CC_ARG := $(CC_ARG)
-CMAKE_CXX_ARG := $(CXX_ARG)
-
 CMAKE_COMMON := -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DCMAKE_PREFIX_PATH=$(build_prefix)
 CMAKE_COMMON += -DLIB_INSTALL_DIR=$(build_shlibdir)
 ifeq ($(OS), Darwin)
@@ -27,12 +24,27 @@ endif
 ifneq ($(VERBOSE), 0)
 CMAKE_COMMON += -DCMAKE_VERBOSE_MAKEFILE=ON
 endif
-# The call to which here is to work around https://cmake.org/Bug/view.php?id=14366
-CMAKE_COMMON += -DCMAKE_C_COMPILER="$$(which $(CC_BASE))"
+
+# The calls to `which` are to work around https://cmake.org/Bug/view.php?id=14366
+ifeq ($(USECCACHE), 1)
+# `ccache` must be used as compiler launcher, not compiler itself.
+CMAKE_COMMON += -DCMAKE_C_COMPILER_LAUNCHER=ccache
+CMAKE_COMMON += -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+CMAKE_CC := "$$(which $(shell echo $(CC_ARG) | cut -d' ' -f1))"
+CMAKE_CXX := "$$(which $(shell echo $(CXX_ARG) | cut -d' ' -f1))"
+CMAKE_CC_ARG := $(shell echo $(CC_ARG) | cut -d' ' -f2-)
+CMAKE_CXX_ARG := $(shell echo $(CXX_ARG) | cut -d' ' -f2-)
+else
+CMAKE_CC := "$$(which $(CC_BASE))"
+CMAKE_CXX := "$$(which $(CXX_BASE))"
+CMAKE_CC_ARG := $(CC_ARG)
+CMAKE_CXX_ARG := $(CXX_ARG)
+endif
+CMAKE_COMMON += -DCMAKE_C_COMPILER=$(CMAKE_CC)
 ifneq ($(strip $(CMAKE_CC_ARG)),)
 CMAKE_COMMON += -DCMAKE_C_COMPILER_ARG1="$(CMAKE_CC_ARG) $(SANITIZE_OPTS)"
 endif
-CMAKE_COMMON += -DCMAKE_CXX_COMPILER="$(CXX_BASE)"
+CMAKE_COMMON += -DCMAKE_CXX_COMPILER=$(CMAKE_CXX)
 ifneq ($(strip $(CMAKE_CXX_ARG)),)
 CMAKE_COMMON += -DCMAKE_CXX_COMPILER_ARG1="$(CMAKE_CXX_ARG) $(SANITIZE_OPTS)"
 endif


### PR DESCRIPTION
I haven't tested this thoroughly but something like this should make building an external LLVM more `USECCACHE`-friendly, saving lots of time when recompiling code.