### PR TITLE
Fix various refcount violations

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1122,10 +1122,10 @@ end
 function renumber_ssa2(val::SSAValue, ssanums::Vector{Any}, used_ssas::Vector{Int},
         new_new_used_ssas::Vector{Int}, do_rename_ssa::Bool)
     id = val.id
-    if id > length(ssanums)
-        return val
-    end
     if do_rename_ssa
+        if id > length(ssanums)
+            return val
+        end
         val = ssanums[id]
     end
     if isa(val, SSAValue)


### PR DESCRIPTION
Fixes two refcount violations, one that's in pending_nodes (which is a little used feature, so unsurprising that nobody found it) and one in the new sroa ifelse lifting. Found by turning on oracle check on a downstream package that stresses the compiler.