### PR TITLE
Set default TextTerminal, add `csave` and `crestore`

### DIFF
--- a/stdlib/REPL/src/Terminals.jl
+++ b/stdlib/REPL/src/Terminals.jl
@@ -54,22 +54,22 @@ pos(t::TextTerminal=Base.active_repl.t) = (getX(t), getY(t))
 
 # Absolute fallbacks are provided for relative movements
 cmove_up(t::TextTerminal, n=1) = cmove(getX(t), max(1, getY(t)-n))
-cmove_up(n=1) cmove_up(Base.current_repl.t, n)
+cmove_up(n=1) = cmove_up(Base.current_repl.t, n)
 
 cmove_down(t::TextTerminal, n=1) = cmove(getX(t), max(height(t), getY(t)+n))
-cmove_down(n=1) cmove_down(Base.current_repl.t, n)
+cmove_down(n=1) = cmove_down(Base.current_repl.t, n)
 
 cmove_left(t::TextTerminal, n=1) = cmove(max(1, getX(t)-n), getY(t))
-cmove_left(n=1) cmove_left(Base.current_repl.t, n)
+cmove_left(n=1) = cmove_left(Base.current_repl.t, n)
 
 cmove_right(t::TextTerminal, n=1) = cmove(max(width(t), getX(t)+n), getY(t))
-cmove_right(n=1) cmove_right(Base.current_repl.t, n)
+cmove_right(n=1) = cmove_right(Base.current_repl.t, n)
 
 cmove_line_up(t::TextTerminal, n=1) = cmove(1, max(1, getY(t)-n))
-cmove_line_up(n=1) cmove_line_up(Base.current_repl.t, n)
+cmove_line_up(n=1) = cmove_line_up(Base.current_repl.t, n)
 
 cmove_line_down(t::TextTerminal, n=1) = cmove(1, max(height(t), getY(t)+n))
-cmove_line_down(n=1) cmove_line_down(Base.current_repl.t, n)
+cmove_line_down(n=1) = cmove_line_down(Base.current_repl.t, n)
 
 cmove_col(t::TextTerminal, c) = cmove(c, getY(t))
 cmove_col(c) = cmove_col(Base.current_repl.t, n)

--- a/stdlib/REPL/src/Terminals.jl
+++ b/stdlib/REPL/src/Terminals.jl
@@ -46,11 +46,11 @@ abstract type AbstractTerminal <: Base.AbstractPipe end
 abstract type TextTerminal <: AbstractTerminal end
 
 # Terminal interface:
-pipe_reader(::TextTerminal=Base.active_repl.t) = error("Unimplemented")
-pipe_writer(::TextTerminal=Base.active_repl.t) = error("Unimplemented")
-displaysize(::TextTerminal=Base.active_repl.t) = error("Unimplemented")
+pipe_reader(::TextTerminal=active_repl.t) = error("Unimplemented")
+pipe_writer(::TextTerminal=active_repl.t) = error("Unimplemented")
+displaysize(::TextTerminal=active_repl.t) = error("Unimplemented")
 cmove(t::TextTerminal, x, y) = error("Unimplemented")
-cmove(x, y) = cmove(Base.active_repl.t, x, y)
+cmove(x, y) = cmove(active_repl.t, x, y)
 """
     csave()
     csave(t)
@@ -62,7 +62,7 @@ Note that if this is run in the REPL, the cursor moves as it is run,
 and the final position is the one saved. This means that
 the saved position is just after "julia>" on the next line.
 """
-csave(t::TextTerminal=Base.active_repl.t) = error("Unimplemented")
+csave(t::TextTerminal=active_repl.t) = error("Unimplemented")
 """
     crestore()
     crestore(t)
@@ -74,10 +74,10 @@ to `Base.active_repl.t`.
 Note that after the cursor position is restores, anything
 to the right it on the same line is cleared.
 """
-crestore(t::TextTerminal=Base.active_repl.t) = error("Unimplemented")
-getX(t::TextTerminal=Base.active_repl.t) = error("Unimplemented")
-getY(t::TextTerminal=Base.active_repl.t) = error("Unimplemented")
-pos(t::TextTerminal=Base.active_repl.t) = (getX(t), getY(t))
+crestore(t::TextTerminal=active_repl.t) = error("Unimplemented")
+getX(t::TextTerminal=active_repl.t) = error("Unimplemented")
+getY(t::TextTerminal=active_repl.t) = error("Unimplemented")
+pos(t::TextTerminal=active_repl.t) = (getX(t), getY(t))
 
 # Absolute fallbacks are provided for relative movements
 cmove_up(t::TextTerminal, n=1) = cmove(getX(t), max(1, getY(t) - n))
@@ -102,33 +102,33 @@ cmove_col(t::TextTerminal, c) = cmove(c, getY(t))
 cmove_col(c) = cmove_col(Base.current_repl.t, n)
 
 # Defaults
-hascolor(::TextTerminal=Base.active_repl.t) = false
+hascolor(::TextTerminal=active_repl.t) = false
 
 # Utility Functions
-width(t::TextTerminal=Base.active_repl.t) = (displaysize(t)::Tuple{Int,Int})[2]
-height(t::TextTerminal=Base.active_repl.t) = (displaysize(t)::Tuple{Int,Int})[1]
+width(t::TextTerminal=active_repl.t) = (displaysize(t)::Tuple{Int,Int})[2]
+height(t::TextTerminal=active_repl.t) = (displaysize(t)::Tuple{Int,Int})[1]
 
 # For terminals with buffers
-flush(t::TextTerminal=Base.active_repl.t) = nothing
+flush(t::TextTerminal=active_repl.t) = nothing
 
-clear(t::TextTerminal=Base.active_repl.t) = error("Unimplemented")
+clear(t::TextTerminal=active_repl.t) = error("Unimplemented")
 clear_line(t::TextTerminal, row) = error("Unimplemented")
-clear_line(row) = clear_line(Base.active_repl.t, row)
-clear_line(t::TextTerminal=Base.active_repl.t) = error("Unimplemented")
+clear_line(row) = clear_line(active_repl.t, row)
+clear_line(t::TextTerminal=active_repl.t) = error("Unimplemented")
 
 raw!(t::TextTerminal, raw::Bool) = error("Unimplemented")
-raw!(raw::Bool) = raw!(Base.active_repl.t, raw)
+raw!(raw::Bool) = raw!(active_repl.t, raw)
 
-beep(t::TextTerminal=Base.active_repl.t) = nothing
-enable_bracketed_paste(t::TextTerminal=Base.active_repl.t) = nothing
-disable_bracketed_paste(t::TextTerminal=Base.active_repl.t) = nothing
+beep(t::TextTerminal=active_repl.t) = nothing
+enable_bracketed_paste(t::TextTerminal=active_repl.t) = nothing
+disable_bracketed_paste(t::TextTerminal=active_repl.t) = nothing
 
 ## UnixTerminal ##
 
 abstract type UnixTerminal <: TextTerminal end
 
-pipe_reader(t::UnixTerminal=Base.active_repl.t) = t.in_stream::IO
-pipe_writer(t::UnixTerminal=Base.active_repl.t) = t.out_stream::IO
+pipe_reader(t::UnixTerminal=active_repl.t) = t.in_stream::IO
+pipe_writer(t::UnixTerminal=active_repl.t) = t.out_stream::IO
 
 mutable struct TerminalBuffer <: UnixTerminal
     out_stream::IO

--- a/stdlib/REPL/src/Terminals.jl
+++ b/stdlib/REPL/src/Terminals.jl
@@ -43,61 +43,65 @@ abstract type AbstractTerminal <: Base.AbstractPipe end
 abstract type TextTerminal <: AbstractTerminal end
 
 # Terminal interface:
-pipe_reader(::TextTerminal) = error("Unimplemented")
-pipe_writer(::TextTerminal) = error("Unimplemented")
-displaysize(::TextTerminal) = error("Unimplemented")
+pipe_reader(::TextTerminal=Base.active_repl.t) = error("Unimplemented")
+pipe_writer(::TextTerminal=Base.active_repl.t) = error("Unimplemented")
+displaysize(::TextTerminal=Base.active_repl.t) = error("Unimplemented")
 cmove(t::TextTerminal, x, y) = error("Unimplemented")
-getX(t::TextTerminal) = error("Unimplemented")
-getY(t::TextTerminal) = error("Unimplemented")
-pos(t::TextTerminal) = (getX(t), getY(t))
+cmove(x, y) = cmove(Base.active_repl.t, x, y)
+getX(t::TextTerminal=Base.active_repl.t) = error("Unimplemented")
+getY(t::TextTerminal=Base.active_repl.t) = error("Unimplemented")
+pos(t::TextTerminal=Base.active_repl.t) = (getX(t), getY(t))
 
-# Relative moves (Absolute position fallbacks)
-cmove_up(t::TextTerminal, n) = cmove(getX(t), max(1, getY(t)-n))
-cmove_up(t) = cmove_up(t, 1)
+# Absolute fallbacks are provided for relative movements
+cmove_up(t::TextTerminal, n=1) = cmove(getX(t), max(1, getY(t)-n))
+cmove_up(n=1) cmove_up(Base.current_repl.t, n)
 
-cmove_down(t::TextTerminal, n) = cmove(getX(t), max(height(t), getY(t)+n))
-cmove_down(t) = cmove_down(t, 1)
+cmove_down(t::TextTerminal, n=1) = cmove(getX(t), max(height(t), getY(t)+n))
+cmove_down(n=1) cmove_down(Base.current_repl.t, n)
 
-cmove_left(t::TextTerminal, n) = cmove(max(1, getX(t)-n), getY(t))
-cmove_left(t) = cmove_left(t, 1)
+cmove_left(t::TextTerminal, n=1) = cmove(max(1, getX(t)-n), getY(t))
+cmove_left(n=1) cmove_left(Base.current_repl.t, n)
 
-cmove_right(t::TextTerminal, n) = cmove(max(width(t), getX(t)+n), getY(t))
-cmove_right(t) = cmove_right(t, 1)
+cmove_right(t::TextTerminal, n=1) = cmove(max(width(t), getX(t)+n), getY(t))
+cmove_right(n=1) cmove_right(Base.current_repl.t, n)
 
-cmove_line_up(t::TextTerminal, n) = cmove(1, max(1, getY(t)-n))
-cmove_line_up(t) = cmove_line_up(t, 1)
+cmove_line_up(t::TextTerminal, n=1) = cmove(1, max(1, getY(t)-n))
+cmove_line_up(n=1) cmove_line_up(Base.current_repl.t, n)
 
-cmove_line_down(t::TextTerminal, n) = cmove(1, max(height(t), getY(t)+n))
-cmove_line_down(t) = cmove_line_down(t, 1)
+cmove_line_down(t::TextTerminal, n=1) = cmove(1, max(height(t), getY(t)+n))
+cmove_line_down(n=1) cmove_line_down(Base.current_repl.t, n)
 
 cmove_col(t::TextTerminal, c) = cmove(c, getY(t))
+cmove_col(c) = cmove_col(Base.current_repl.t, n)
 
 # Defaults
-hascolor(::TextTerminal) = false
+hascolor(::TextTerminal=Base.active_repl.t) = false
 
 # Utility Functions
-width(t::TextTerminal) = (displaysize(t)::Tuple{Int,Int})[2]
-height(t::TextTerminal) = (displaysize(t)::Tuple{Int,Int})[1]
+width(t::TextTerminal=Base.active_repl.t) = (displaysize(t)::Tuple{Int,Int})[2]
+height(t::TextTerminal=Base.active_repl.t) = (displaysize(t)::Tuple{Int,Int})[1]
 
 # For terminals with buffers
-flush(t::TextTerminal) = nothing
+flush(t::TextTerminal=Base.active_repl.t) = nothing
 
-clear(t::TextTerminal) = error("Unimplemented")
+clear(t::TextTerminal=Base.active_repl.t) = error("Unimplemented")
 clear_line(t::TextTerminal, row) = error("Unimplemented")
-clear_line(t::TextTerminal) = error("Unimplemented")
+clear_line(row) = clear_line(Base.active_repl.t, row)
+clear_line(t::TextTerminal=Base.active_repl.t) = error("Unimplemented")
 
 raw!(t::TextTerminal, raw::Bool) = error("Unimplemented")
+raw!(raw::Bool) = raw!(Base.active_repl.t, raw)
 
-beep(t::TextTerminal) = nothing
-enable_bracketed_paste(t::TextTerminal) = nothing
-disable_bracketed_paste(t::TextTerminal) = nothing
+beep(t::TextTerminal=Base.active_repl.t) = nothing
+enable_bracketed_paste(t::TextTerminal=Base.active_repl.t) = nothing
+disable_bracketed_paste(t::TextTerminal=Base.active_repl.t) = nothing
 
 ## UnixTerminal ##
 
 abstract type UnixTerminal <: TextTerminal end
 
-pipe_reader(t::UnixTerminal) = t.in_stream::IO
-pipe_writer(t::UnixTerminal) = t.out_stream::IO
+pipe_reader(t::UnixTerminal=Base.active_repl.t) = t.in_stream::IO
+pipe_writer(t::UnixTerminal=Base.active_repl.t) = t.out_stream::IO
 
 mutable struct TerminalBuffer <: UnixTerminal
     out_stream::IO

--- a/stdlib/REPL/src/Terminals.jl
+++ b/stdlib/REPL/src/Terminals.jl
@@ -55,11 +55,11 @@ cmove(x, y) = cmove(Base.active_repl.t, x, y)
     csave()
     csave(t)
 
-Save the cursor position in TextTerminal `t`. If 
+Save the cursor position in TextTerminal `t`. If
 `t` is not provided, it defaults to `Base.active_repl.t`.
 
-Note that if this is run in the REPL, the cursor moves as it is run, 
-and the final position is the one saved. This means that 
+Note that if this is run in the REPL, the cursor moves as it is run,
+and the final position is the one saved. This means that
 the saved position is just after "julia>" on the next line.
 """
 csave(t::TextTerminal=Base.active_repl.t) = error("Unimplemented")
@@ -67,11 +67,11 @@ csave(t::TextTerminal=Base.active_repl.t) = error("Unimplemented")
     crestore()
     crestore(t)
 
-Restore the the cursor position in TextTerminal `t`to the 
-position set by `csave`. If `t` is not provided, it defaults 
+Restore the the cursor position in TextTerminal `t`to the
+position set by `csave`. If `t` is not provided, it defaults
 to `Base.active_repl.t`.
 
-Note that after the cursor position is restores, anything 
+Note that after the cursor position is restores, anything
 to the right it on the same line is cleared.
 """
 crestore(t::TextTerminal=Base.active_repl.t) = error("Unimplemented")


### PR DESCRIPTION
This PR adds defaults to the functions defined in `REPL.Terminals`. Specifically, it makes `Base.active_repl.t` the default terminal for all relevant functions (someone please verify that I did not overlook one). In my view, adding defaults _greatly_ enhances usability, as users can not be expected to dig into this undocumented module, sorting out how to construct a handle to a terminal (related: https://discourse.julialang.org/t/how-to-get-a-handle-to-the-terminal/99592/3).

The defaults are added in the generic fallbacks. This is maybe unclear, as the defaults are defined in methods in which they are not generally used (most of the fallbacks are `error("Unimplemented")`). But it reduces the number of code lines, and I feel it is mentally neat to define fallback and default in the same location, even if they apply to different situations.

~~The branch name is related to the original thought behind this PR, but I could not get consistent results in testing for that. The idea was to use "\x1b[s" and "\x1b[u" to save and return to cursor positions. This worked initially, but then not, for reasons I could not understand. Help with implementing that would also be appreciated.~~

EDIT.
The branch name is now valid, as explained in commit number 4. This means that this PR now adds the two functions `csave` and `crestore`, which are immensely useful for creating updating displays of e.g. a terminal plot. The functions have docstrings (as the only functions in this module), and are exported. I am sure a lot of terminal wizardry like the one used in `TerminalMenus.jl` and `Term.jl` use something like this, or would benefit from it.