### PR TITLE
Fix `rationalize(::Complex)` test on 32 bit systems

### DIFF
--- a/test/rational.jl
+++ b/test/rational.jl
@@ -736,6 +736,6 @@ end
     # test: rationalize(x::Complex; kvs...)
     precise_next = 7205759403792795//72057594037927936
     @assert Float64(precise_next) == nextfloat(0.1)
-    @test rationalize(nextfloat(0.1) * im; tol=0) == precise_next * im
-    @test rationalize(Int64, 0.1im; tol=eps(0.1)) == rationalize(0.1im)
+    @test rationalize(Int64, nextfloat(0.1) * im; tol=0) == precise_next * im
+    @test rationalize(0.1im; tol=eps(0.1)) == rationalize(0.1im)
 end

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -737,5 +737,5 @@ end
     precise_next = 7205759403792795//72057594037927936
     @assert Float64(precise_next) == nextfloat(0.1)
     @test rationalize(nextfloat(0.1) * im; tol=0) == precise_next * im
-    @test rationalize(0.1im; tol=eps(0.1)) == rationalize(0.1im)
+    @test rationalize(Int64, 0.1im; tol=eps(0.1)) == rationalize(0.1im)
 end


### PR DESCRIPTION
the test was relying on `Int===Int64`.