### PR TITLE
Fix sorting bugs (esp `MissingOptimization`) that come up when using SortingAlgorithms.TimSort

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -524,13 +524,13 @@ struct WithoutMissingVector{T, U} <: AbstractVector{T}
         new{nonmissingtype(eltype(data)), typeof(data)}(data)
     end
 end
-Base.@propagate_inbounds function Base.getindex(v::WithoutMissingVector, i)
-    out = v.data[i]
+Base.@propagate_inbounds function Base.getindex(v::WithoutMissingVector, i::Integer)
+    out = v.data[i::Integer]
     @assert !(out isa Missing)
     out::eltype(v)
 end
-Base.@propagate_inbounds function Base.setindex!(v::WithoutMissingVector, x, i)
-    v.data[i] = x
+Base.@propagate_inbounds function Base.setindex!(v::WithoutMissingVector, x, i::Integer)
+    v.data[i::Integer] = x
     v
 end
 Base.size(v::WithoutMissingVector) = size(v.data)
@@ -590,8 +590,9 @@ function _sort!(v::AbstractVector, a::MissingOptimization, o::Ordering, kw)
         # we can assume v is equal to eachindex(o.data) which allows a copying partition
         # without allocations.
         lo_i, hi_i = lo, hi
-        for i in eachindex(o.data) # equal to copy(v)
-            x = o.data[i]
+        cv = eachindex(o.data) # equal to copy(v)
+        for i in lo:hi
+            x = o.data[cv[i]]
             if ismissing(x) == (o.order == Reverse) # should x go at the beginning/end?
                 v[lo_i] = i
                 lo_i += 1

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -2168,7 +2168,7 @@ function _sort!(v::AbstractVector, a::Algorithm, o::Ordering, kw)
         scratch
     else
         # This error prevents infinite recursion for unknown algorithms
-        throw(ArgumentError("Base.Sort._sort!(::$(typeof(v)), ::$(typeof(a)), ::$(typeof(o))) is not defined"))
+        throw(ArgumentError("Base.Sort._sort!(::$(typeof(v)), ::$(typeof(a)), ::$(typeof(o)), ::Any) is not defined"))
     end
 end
 

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -44,6 +44,7 @@ export # not exported by Base
     SMALL_ALGORITHM,
     SMALL_THRESHOLD
 
+abstract type Algorithm end
 
 ## functions requiring only ordering ##
 
@@ -498,8 +499,6 @@ may be be a `Vector{T}` due to `MissingOptimization` changing the eltype of `v` 
 internal or recursive calls.
 """
 function _sort! end
-
-abstract type Algorithm end
 
 
 """

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -525,12 +525,12 @@ struct WithoutMissingVector{T, U} <: AbstractVector{T}
     end
 end
 Base.@propagate_inbounds function Base.getindex(v::WithoutMissingVector, i::Integer)
-    out = v.data[i::Integer]
+    out = v.data[i]
     @assert !(out isa Missing)
     out::eltype(v)
 end
 Base.@propagate_inbounds function Base.setindex!(v::WithoutMissingVector, x, i::Integer)
-    v.data[i::Integer] = x
+    v.data[i] = x
     v
 end
 Base.size(v::WithoutMissingVector) = size(v.data)

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -1025,6 +1025,38 @@ Base.similar(A::MyArray49392, ::Type{T}, dims::Dims{N}) where {T, N} = MyArray49
     @test all(sort!(y, dims=2) .== sort!(x,dims=2))
 end
 
+@testset "MissingOptimization fastpath for Perm ordering when lo:hi ≠ eachindex(v)" begin
+    v = [rand() < .5 ? missing : rand() for _ in 1:100]
+    ix = collect(1:100)
+    sort!(ix, 1, 10, Base.Sort.DEFAULT_STABLE, Base.Order.Perm(Base.Order.Forward, v))
+    @test issorted(v[ix[1:10]])
+end
+
+struct NonScalarIndexingOfWithoutMissingVectorAlgorithm <: Base.Sort.Algorithm end
+function Base.Sort._sort!(v::AbstractVector, ::NonScalarIndexingOfWithoutMissingVectorAlgorithm, o::Base.Order.Ordering, kw)
+    Base.Sort.@getkw lo hi
+    first_half = v[lo:lo+(hi-lo)÷2]
+    second_half = v[lo+(hi-lo)÷2+1:hi]
+    whole = v[lo:hi]
+    all(vcat(first_half, second_half) .=== whole) || error()
+    out = Base.Sort._sort!(whole, Base.Sort.DEFAULT_STABLE, o, (;kw..., lo=1, hi=length(whole)))
+    v[lo:hi] .= whole
+    out
+end
+
+@testset "Non-scaler indexing of WithoutMissingVector" begin
+    @testset "Unit test" begin
+        wmv = Base.Sort.WithoutMissingVector(Union{Missing, Int}[1, 7, 2, 9])
+        @test wmv[[1, 3]] == [1, 2]
+        @test wmv[1:3] == [1, 7, 2]
+    end
+    @testset "End to end" begin
+        alg = Base.Sort.InitialOptimizations(NonScalarIndexingOfWithoutMissingVectorAlgorithm())
+        @test issorted(sort(rand(100); alg))
+        @test issorted(sort([rand() < .5 ? missing : randstring() for _ in 1:100]; alg))
+    end
+end
+
 # This testset is at the end of the file because it is slow.
 @testset "searchsorted" begin
     numTypes = [ Int8,  Int16,  Int32,  Int64,  Int128,


### PR DESCRIPTION
These bugs in Base led to [a bug](https://github.com/JuliaData/DataFrames.jl/issues/3340) in DataFrames.jl. The bugs this fixes are regressions introduced in 1.9.

The systemic issue is that Base only uses and therefore only tests a subset of its sorting internals, while SortingAlgorithms.jl uses a larger subset, and SortingAlgorithms.jl has [poor testing](https://github.com/JuliaCollections/SortingAlgorithms.jl/issues/58).

More specifically, SortingAlgorithms.TimSort is defined as `Base.Sort.InitialOptimizations(TimSortAlg())`, which results in some preprocessing taking place before the `Base.sort!(v::AbstractVector, ::TimSortAlg, ::Ordering)` method gets called. This preprocessing results in `v` sometimes being a `Base.Sort.WithoutMissingVector`. TimSort calls `v[b]` where `b` is a unit range (why? idk, it would probably be more performant not to but I haven't read the whole algorithm). This is a perfectly reasonable thing to do, but `getindex(::Base.Sort.WithoutMissingOptimization, ::UnitRange)` was buggy. This PR fixes that.

Also, there was a bug in the fastpath for filtering `missing`s to the end under a `Perm` ordering. We (I) assumed that `lo:hi == eachindex(v)`, which is not guaranteed. It's pretty hard to trigger this bug without calling a 5-arg `sort!` method, but TimSort does call such a method as its base case, so this branch is broken there too. Again, this PR removes the buggy assumption that `lo:hi == eachindex(v)`.

Finally, the mechanism to implicitly convert the old 3- 5- or 6-argument `sort!` calling convention to the new 4-argument `_sort!` and back without triggering infinite loops when neither is defined was too strict about infinite loop detection. It prohibits anything that calls into sorting using the old convention, implicitly converts to the new convention, and then at any point later implicitly converts back to the old convention. This prohibits, for example, calling `sort!(v, SortingAlgorithms.TimSort, Base.Order.Forward)` because `SortingAlgorithms.TimSort` is defined as `Base.Sort.InitialOptimizations(SortingAlgorithms.TimSortAlg())`, so that old-style `sort!` call is implicitly converted to the new style, benefits from modern intermediary layers, and then implicitly converted back to the old style for TimSortAlg. This throws because of the conversion back and forth. Technically, this bug isn't visible in the public API because `InitialOptimizations` is internal, as is `_sort!` but it feels bad enough to be worth backporting a fix. The fix is to switch from tracking "has there been a legacy dispatch into this sorting call chain" to "what was the alg that was used at that entrypoint, if any". Then, we only throw if implicitly convert to the `_sort!` system and then implicitly convert back out _without unwrapping a single layer of the algorithm_, which is a much tighter bound than we had before.

Also makes a misleading error message not misleading, which I'd also call a bugfix in this case.