### PR TITLE
print feature flags used for matching pkgimage

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2843,9 +2843,9 @@ get_compiletime_preferences(::Nothing) = String[]
 function check_clone_targets(clone_targets)
     try
         ccall(:jl_check_pkgimage_clones, Cvoid, (Ptr{Cchar},), clone_targets)
-        return true
-    catch
-        return false
+        nothing
+    catch err
+        return sprint(showerror, err)
     end
 end
 
@@ -3025,10 +3025,9 @@ end
                 @debug "Rejecting cache file $cachefile for $modkey since it would require usage of pkgimage"
                 return true
             end
-            if !check_clone_targets(clone_targets)
-                image_targets = parse_image_targets(clone_targets)
-                curr_targets = current_image_targets()
-                @debug "Rejecting cache file $cachefile for $modkey since pkgimage can't be loaded on this target" image_targets curr_targets
+            rejection_reasons = check_clone_targets(clone_targets)
+            if !isnothing(rejection_reasons)
+                @debug "Rejecting cache file $cachefile for $modkey\n" * rejection_reasons
                 return true
             end
             if !isfile(ocachefile)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2841,11 +2841,9 @@ get_compiletime_preferences(m::Module) = get_compiletime_preferences(PkgId(m).uu
 get_compiletime_preferences(::Nothing) = String[]
 
 function check_clone_targets(clone_targets)
-    try
-        ccall(:jl_check_pkgimage_clones, Cvoid, (Ptr{Cchar},), clone_targets)
-        nothing
-    catch err
-        return sprint(showerror, err)
+    rejection_reason = ccall(:jl_check_pkgimage_clones, Any, (Ptr{Cchar},), clone_targets)
+    if rejection_reason !== nothing
+        return rejection_reason
     end
 end
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2942,7 +2942,7 @@ function show(io::IO, it::ImageTarget)
     first = true
     for feat in feature_names()
         if test_feature(it.features_en, feat)
-            name =  Base.unsafe_string(feat.name)
+            name = Base.unsafe_string(feat.name)
             if first
                 first = false
                 print(io, name)
@@ -3027,7 +3027,10 @@ end
             end
             rejection_reasons = check_clone_targets(clone_targets)
             if !isnothing(rejection_reasons)
-                @debug "Rejecting cache file $cachefile for $modkey\n" * rejection_reasons
+                @debug("Rejecting cache file $cachefile for $modkey:",
+                    Reasons=rejection_reasons,
+                    var"Image Targets"=parse_image_targets(clone_targets),
+                    var"Current Targets"=current_image_targets())
                 return true
             end
             if !isfile(ocachefile)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2920,6 +2920,10 @@ function feature_names()
     fnames = Ref{Ptr{FeatureName}}()
     nf = Ref{Csize_t}()
     @ccall jl_reflect_feature_names(fnames::Ptr{Ptr{FeatureName}}, nf::Ptr{Csize_t})::Cvoid
+    if fnames[] == C_NULL
+        @assert nf[] == 0
+        return Vector{FeatureName}(undef, 0)
+    end
     Base.unsafe_wrap(Array, fnames[], nf[], own=false)
 end
 

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -630,11 +630,12 @@ static inline jl_image_t parse_sysimg(void *hdl, F &&callback)
     jl_dlsym(hdl, "jl_image_pointers", (void**)&pointers, 1);
 
     const void *ids = pointers->target_data;
-    jl_value_t* rejection_reason = C_NULL;
+    jl_value_t* rejection_reason = nullptr;
     JL_GC_PUSH1(&rejection_reason);
     uint32_t target_idx = callback(ids, &rejection_reason);
-    if target_idx == -1;
-        jl_error(rejection_reason);
+    if (target_idx == (uint32_t)-1) {
+        jl_throw(jl_new_struct(jl_errorexception_type, rejection_reason));
+    }
     JL_GC_POP();
 
     if (pointers->header->version != 1) {
@@ -984,7 +985,7 @@ extern "C" JL_DLLEXPORT jl_value_t* jl_reflect_clone_targets() {
         data.insert(data.end(), specdata.begin(), specdata.end());
     }
 
-    arr = (jl_value_t*)jl_alloc_array_1d(jl_array_uint8_type, data.size());
+    jl_value_t *arr = (jl_value_t*)jl_alloc_array_1d(jl_array_uint8_type, data.size());
     uint8_t *out = (uint8_t*)jl_array_data(arr);
     memcpy(out, data.data(), data.size());
     return arr;

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -978,12 +978,9 @@ extern "C" JL_DLLEXPORT jl_value_t* jl_reflect_clone_targets() {
         data.insert(data.end(), specdata.begin(), specdata.end());
     }
 
-    jl_value_t *arr = nullptr;
-    JL_GC_PUSH1(&arr);
     arr = (jl_value_t*)jl_alloc_array_1d(jl_array_uint8_type, data.size());
     uint8_t *out = (uint8_t*)jl_array_data(arr);
     memcpy(out, data.data(), data.size());
-    JL_GC_POP();
     return arr;
 }
 

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -107,13 +107,13 @@ static inline bool test_nbit(const T1 &bits, T2 _bitidx)
 }
 
 template<typename T>
-static inline void unset_bits(T &bits)
+static inline void unset_bits(T &bits) JL_NOTSAFEPOINT
 {
     (void)bits;
 }
 
 template<typename T, typename T1, typename... Rest>
-static inline void unset_bits(T &bits, T1 _bitidx, Rest... rest)
+static inline void unset_bits(T &bits, T1 _bitidx, Rest... rest) JL_NOTSAFEPOINT
 {
     auto bitidx = static_cast<uint32_t>(_bitidx);
     auto u32idx = bitidx / 32;
@@ -142,7 +142,7 @@ static inline void set_bit(T &bits, T1 _bitidx, bool val)
 template<size_t n>
 struct FeatureList {
     uint32_t eles[n];
-    uint32_t &operator[](size_t pos)
+    uint32_t &operator[](size_t pos) JL_NOTSAFEPOINT
     {
         return eles[pos];
     }

--- a/src/processor.h
+++ b/src/processor.h
@@ -274,6 +274,15 @@ struct jl_target_spec_t {
 extern "C" JL_DLLEXPORT std::vector<jl_target_spec_t> jl_get_llvm_clone_targets(void) JL_NOTSAFEPOINT;
 std::string jl_get_cpu_name_llvm(void) JL_NOTSAFEPOINT;
 std::string jl_get_cpu_features_llvm(void) JL_NOTSAFEPOINT;
+
+struct FeatureName {
+    const char *name;
+    uint32_t bit; // bit index into a `uint32_t` array;
+    uint32_t llvmver; // 0 if it is available on the oldest LLVM version we support
+};
+
+extern "C" JL_DLLEXPORT jl_value_t* jl_reflect_clone_targets();
+extern "C" JL_DLLEXPORT void jl_reflect_feature_names(const FeatureName **feature_names, size_t *nfeatures);
 #endif
 
 #endif

--- a/src/processor.h
+++ b/src/processor.h
@@ -226,7 +226,7 @@ JL_DLLEXPORT jl_value_t *jl_get_cpu_features(void);
 // Dump the name and feature set of the host CPU
 // For debugging only
 JL_DLLEXPORT void jl_dump_host_cpu(void);
-JL_DLLEXPORT void jl_check_pkgimage_clones(char* data);
+JL_DLLEXPORT jl_value_t* jl_check_pkgimage_clones(char* data);
 
 JL_DLLEXPORT int32_t jl_set_zero_subnormals(int8_t isZero);
 JL_DLLEXPORT int32_t jl_get_zero_subnormals(void);

--- a/src/processor_arm.cpp
+++ b/src/processor_arm.cpp
@@ -1830,7 +1830,7 @@ JL_DLLEXPORT jl_value_t* jl_check_pkgimage_clones(char *data)
     JL_GC_PUSH1(&rejection_reason);
     uint32_t match_idx = pkgimg_init_cb(data, &rejection_reason);
     JL_GC_POP();
-    if (match_idx == -1)
+    if (match_idx == (uint32_t)-1)
         return rejection_reason;
     return jl_nothing;
 }

--- a/src/processor_arm.cpp
+++ b/src/processor_arm.cpp
@@ -1574,7 +1574,7 @@ static uint32_t sysimg_init_cb(const void *id, jl_value_t **rejection_reason)
         }
     }
     auto match = match_sysimg_targets(sysimg, target, max_vector_size, rejection_reason);
-    if match.best_idx == -1
+    if (match.best_idx == -1)
         return match.best_idx;
     // Now we've decided on which sysimg version to use.
     // Make sure the JIT target is compatible with it and save the JIT target.

--- a/src/processor_arm.cpp
+++ b/src/processor_arm.cpp
@@ -1588,7 +1588,7 @@ static uint32_t sysimg_init_cb(const void *id, jl_value_t **rejection_reason)
     return match.best_idx;
 }
 
-static uint32_t pkgimg_init_cb(const void *id, jl_value_t** rejection_reason)
+static uint32_t pkgimg_init_cb(const void *id, jl_value_t **rejection_reason JL_REQUIRE_ROOTED_SLOT)
 {
     TargetData<feature_sz> target = jit_targets.front();
     auto pkgimg = deserialize_target_data<feature_sz>((const uint8_t*)id);
@@ -1826,7 +1826,7 @@ jl_image_t jl_init_processor_pkgimg(void *hdl)
 
 JL_DLLEXPORT jl_value_t* jl_check_pkgimage_clones(char *data)
 {
-    jl_value_t *rejection_reason;
+    jl_value_t *rejection_reason = NULL;
     JL_GC_PUSH1(&rejection_reason);
     uint32_t match_idx = pkgimg_init_cb(data, &rejection_reason);
     JL_GC_POP();

--- a/src/processor_fallback.cpp
+++ b/src/processor_fallback.cpp
@@ -2,7 +2,7 @@
 
 // Fallback processor detection and dispatch
 
-static constexpr FeatureName feature_names[0];
+static constexpr FeatureName *feature_names = nullptr;
 static constexpr uint32_t nfeature_names = 0;
 
 namespace Fallback {

--- a/src/processor_fallback.cpp
+++ b/src/processor_fallback.cpp
@@ -2,6 +2,9 @@
 
 // Fallback processor detection and dispatch
 
+static constexpr FeatureName feature_names[] = {};
+static constexpr uint32_t nfeature_names = sizeof(feature_names) / sizeof(FeatureName);
+
 namespace Fallback {
 
 static inline const std::string &host_cpu_name()

--- a/src/processor_fallback.cpp
+++ b/src/processor_fallback.cpp
@@ -177,7 +177,7 @@ JL_DLLEXPORT void jl_dump_host_cpu(void)
 
 JL_DLLEXPORT jl_value_t* jl_check_pkgimage_clones(char *data)
 {
-    jl_value_t *rejection_reason;
+    jl_value_t *rejection_reason = NULL;
     JL_GC_PUSH1(&rejection_reason);
     uint32_t match_idx = pkgimg_init_cb(data, &rejection_reason);
     JL_GC_POP();

--- a/src/processor_fallback.cpp
+++ b/src/processor_fallback.cpp
@@ -175,9 +175,15 @@ JL_DLLEXPORT void jl_dump_host_cpu(void)
     jl_safe_printf("Features: %s\n", jl_get_cpu_features_llvm().c_str());
 }
 
-JL_DLLEXPORT void jl_check_pkgimage_clones(char *data)
+JL_DLLEXPORT jl_value_t* jl_check_pkgimage_clones(char *data)
 {
-    pkgimg_init_cb(data);
+    jl_value_t *rejection_reason;
+    JL_GC_PUSH1(&rejection_reason);
+    uint32_t match_idx = pkgimg_init_cb(data, &rejection_reason);
+    JL_GC_POP();
+    if (match_idx == -1)
+        return rejection_reason;
+    return jl_nothing;
 }
 
 extern "C" int jl_test_cpu_feature(jl_cpu_feature_t)

--- a/src/processor_fallback.cpp
+++ b/src/processor_fallback.cpp
@@ -2,8 +2,8 @@
 
 // Fallback processor detection and dispatch
 
-static constexpr FeatureName feature_names[] = {};
-static constexpr uint32_t nfeature_names = sizeof(feature_names) / sizeof(FeatureName);
+static constexpr FeatureName feature_names[0];
+static constexpr uint32_t nfeature_names = 0;
 
 namespace Fallback {
 

--- a/src/processor_fallback.cpp
+++ b/src/processor_fallback.cpp
@@ -181,7 +181,7 @@ JL_DLLEXPORT jl_value_t* jl_check_pkgimage_clones(char *data)
     JL_GC_PUSH1(&rejection_reason);
     uint32_t match_idx = pkgimg_init_cb(data, &rejection_reason);
     JL_GC_POP();
-    if (match_idx == -1)
+    if (match_idx == (uint32_t)-1)
         return rejection_reason;
     return jl_nothing;
 }

--- a/src/processor_fallback.cpp
+++ b/src/processor_fallback.cpp
@@ -33,7 +33,7 @@ static TargetData<1> arg_target_data(const TargetData<1> &arg, bool require_host
     return res;
 }
 
-static uint32_t sysimg_init_cb(const void *id)
+static uint32_t sysimg_init_cb(const void *id, jl_value_t **rejection_reason)
 {
     // First see what target is requested for the JIT.
     auto &cmdline = get_cmdline_targets();
@@ -51,7 +51,7 @@ static uint32_t sysimg_init_cb(const void *id)
     return best_idx;
 }
 
-static uint32_t pkgimg_init_cb(const void *id)
+static uint32_t pkgimg_init_cb(const void *id, jl_value_t **rejection_reason)
 {
     TargetData<1> target = jit_targets.front();
     // Find the last name match or use the default one.

--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -869,7 +869,7 @@ static uint32_t sysimg_init_cb(const void *id, jl_value_t** rejection_reason)
                  "https://docs.julialang.org/en/v1/devdocs/sysimg/ for more.");
     }
     auto match = match_sysimg_targets(sysimg, target, max_vector_size, rejection_reason);
-    if match.best_idx == -1
+    if (match.best_idx == (uint32_t)-1)
         return match.best_idx;
     // Now we've decided on which sysimg version to use.
     // Make sure the JIT target is compatible with it and save the JIT target.
@@ -1040,7 +1040,7 @@ JL_DLLEXPORT jl_value_t* jl_check_pkgimage_clones(char *data)
     JL_GC_PUSH1(&rejection_reason);
     uint32_t match_idx = pkgimg_init_cb(data, &rejection_reason);
     JL_GC_POP();
-    if (match_idx == -1)
+    if (match_idx == (uint32_t)-1)
         return rejection_reason;
     return jl_nothing;
 }

--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -1036,7 +1036,7 @@ JL_DLLEXPORT void jl_dump_host_cpu(void)
 
 JL_DLLEXPORT jl_value_t* jl_check_pkgimage_clones(char *data)
 {
-    jl_value_t *rejection_reason;
+    jl_value_t *rejection_reason = NULL;
     JL_GC_PUSH1(&rejection_reason);
     uint32_t match_idx = pkgimg_init_cb(data, &rejection_reason);
     JL_GC_POP();


### PR DESCRIPTION
To help with debugging of #50102, #50148, and #49705

```
julia> @ccall jl_dump_host_cpu()::Cvoid
CPU: znver2
Features: sse3, pclmul, ssse3, fma, cx16, sse4.1, sse4.2, movbe, popcnt, aes, xsave, avx, f16c, rdrnd, fsgsbase, bmi, avx2, bmi2, rdseed, adx, clflushopt, clwb, sha, rdpid, sahf, lzcnt, sse4a, prfchw, mwaitx, xsaveopt, xsavec, xsaves, clzero, wbnoinvd

julia> target = only(Base.current_image_targets())
znver2; flags=0; features_en=(sse3, pclmul, ssse3, fma, cx16, sse4.1, sse4.2, movbe, popcnt, aes, xsave, avx, f16c, fsgsbase, bmi, avx2, bmi2, adx, clflushopt, clwb, sha, rdpid, sahf, lzcnt, sse4a, prfchw, mwaitx, xsavec, xsaves, clzero, wbnoinvd)
```

cc: @mkitti @nrontsis @simonbyrne 
