### PR TITLE
Fixed small typo in `map`'s docstring

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3269,7 +3269,7 @@ mapany(f, itr) = Any[f(x) for x in itr]
     map(f, c...) -> collection
 
 Transform collection `c` by applying `f` to each element. For multiple collection arguments,
-apply `f` elementwise, and stop when when any of them is exhausted.
+apply `f` elementwise, and stop when any of them is exhausted.
 
 See also [`map!`](@ref), [`foreach`](@ref), [`mapreduce`](@ref), [`mapslices`](@ref), [`zip`](@ref), [`Iterators.map`](@ref).
 


### PR DESCRIPTION
Very small typo in the docstring for the `map` function.