### PR TITLE
Fix fallback fro znver3 to be generic

### DIFF
--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -291,7 +291,7 @@ static constexpr CPUSpec<CPU, feature_sz> cpus[] = {
 
     {"znver1", CPU::amd_znver1, CPU::generic, 0, Feature::znver1},
     {"znver2", CPU::amd_znver2, CPU::generic, 0, Feature::znver2},
-    {"znver3", CPU::amd_znver3, CPU::amd_znver2, 120000, Feature::znver3},
+    {"znver3", CPU::amd_znver3, CPU::generic, 120000, Feature::znver3},
 };
 static constexpr size_t ncpu_names = sizeof(cpus) / sizeof(cpus[0]);
 


### PR DESCRIPTION
Noticed while looking at #50102
Introduced by #45663

I don't fully understand the fallback definition, but every-other CPU uses generic there. 
