### PR TITLE
Document the fields of `VersionNumber`

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -16,6 +16,13 @@ alphanumeric annotations.
 `VersionNumber` objects can be compared with all of the standard comparison
 operators (`==`, `<`, `<=`, etc.), with the result following semver rules.
 
+`VersionNumber` has the the following public fields:
+- `v.major::Integer`
+- `v.minor::Integer`
+- `v.patch::Integer`
+- `v.prerelease::Tuple{Vararg{Union{Integer, AbstractString}}}`
+- `v.build::Tuple{Vararg{Union{Integer, AbstractString}}}`
+
 See also [`@v_str`](@ref) to efficiently construct `VersionNumber` objects
 from semver-format literal strings, [`VERSION`](@ref) for the `VersionNumber`
 of Julia itself, and [Version Number Literals](@ref man-version-number-literals)

--- a/test/version.jl
+++ b/test/version.jl
@@ -219,6 +219,15 @@ for major=0:3, minor=0:3, patch=0:3
     end
 end
 
+# VersionNumber has the promised fields
+let v = v"4.2.1-1.x+a.9"
+    @test v.major isa Integer
+    @test v.minor isa Integer
+    @test v.micro isa Integer
+    @test v.prerelease isa Tuple{Vararg{Union{Integer, AbstractString}}}
+    @test v.build isa Tuple{Vararg{Union{Integer, AbstractString}}}
+end
+
 # julia_version.h version test
 @test VERSION.major == ccall(:jl_ver_major, Cint, ())
 @test VERSION.minor == ccall(:jl_ver_minor, Cint, ())

--- a/test/version.jl
+++ b/test/version.jl
@@ -223,7 +223,7 @@ end
 let v = v"4.2.1-1.x+a.9"
     @test v.major isa Integer
     @test v.minor isa Integer
-    @test v.micro isa Integer
+    @test v.patch isa Integer
     @test v.prerelease isa Tuple{Vararg{Union{Integer, AbstractString}}}
     @test v.build isa Tuple{Vararg{Union{Integer, AbstractString}}}
 end


### PR DESCRIPTION
`VersionNumber`'s fields are currently not documented, and therefore, private by default.
However, if people want to use `VersionNumber` for anything other than the documented comparison operations, users will have to access the fields.

#### Questions for reviewers
Do we want this? Normally, fields are not documented for a reason. But I feel like it's hard to use `VersionNumber` for much in practice without access to its fields, unless we add several more methods such as `major(::VersionNumber)` etc.

Should we change the field type of `.prerelease` and `.build` from `Tuple{Vararg{T}}` to `Vector{T}`? It seems like it was changed from `Vector` to `Tuple` in ef69a19c to make VersionNumber immutable. I'm not sure why that's a good thing, since it currently means accessing `.prerelease` is type unstable but there might be a good reason.