### PR TITLE
Allow unquoted symbols for threadpool in `Threads.@spawn`

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -59,11 +59,23 @@ function _nthreads_in_pool(tpid::Int8)
 end
 
 function _tpid_to_sym(tpid::Int8)
-    return tpid == 0 ? :interactive : :default
+    if tpid == 0
+        return :interactive
+    elseif tpid === 1
+        return :default
+    else
+        throw(ArgumentError("Unrecognized threadpool id $tpid"))
+    end
 end
 
 function _sym_to_tpid(tp::Symbol)
-    return tp === :interactive ? Int8(0) : Int8(1)
+    if tp === :interactive
+        return Int8(0)
+    elseif tp === :default
+        return Int8(1)
+    else
+        throw(ArgumentError("Unrecognized threadpool name `$(repr(tp))`"))
+    end
 end
 
 """

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -61,7 +61,7 @@ end
 function _tpid_to_sym(tpid::Int8)
     if tpid == 0
         return :interactive
-    elseif tpid === 1
+    elseif tpid == 1
         return :default
     else
         throw(ArgumentError("Unrecognized threadpool id $tpid"))

--- a/test/threadpool_use.jl
+++ b/test/threadpool_use.jl
@@ -13,5 +13,7 @@ tp = :default
 @test fetch(Threads.@spawn tp Threads.threadpool()) === :default
 tp = :interactive
 @test fetch(Threads.@spawn tp Threads.threadpool()) === :interactive
+tp = :foo
+@test_throws ArgumentError Threads.@spawn tp Threads.threadpool()
 @test Threads.threadpooltids(:interactive) == [1]
 @test Threads.threadpooltids(:default) == [2]

--- a/test/threadpool_use.jl
+++ b/test/threadpool_use.jl
@@ -9,5 +9,9 @@ using Base.Threads
 @test fetch(Threads.@spawn Threads.threadpool()) === :default
 @test fetch(Threads.@spawn :default Threads.threadpool()) === :default
 @test fetch(Threads.@spawn :interactive Threads.threadpool()) === :interactive
+tp = :default
+@test fetch(Threads.@spawn tp Threads.threadpool()) === :default
+tp = :interactive
+@test fetch(Threads.@spawn tp Threads.threadpool()) === :interactive
 @test Threads.threadpooltids(:interactive) == [1]
 @test Threads.threadpooltids(:default) == [2]


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/50165

```
julia> fetch(Threads.@spawn :interactive Threads.threadpool())
:interactive

julia> tp = :interactive
:interactive

julia> fetch(Threads.@spawn tp Threads.threadpool())
:interactive
```

Co-authored with @jpsamaroo 