### PR TITLE
Remove xsaves from Zen cpuspec

### DIFF
--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -227,8 +227,11 @@ constexpr auto bdver2 = bdver1 | get_feature_masks(f16c, bmi, tbm, fma);
 constexpr auto bdver3 = bdver2 | get_feature_masks(xsaveopt, fsgsbase);
 constexpr auto bdver4 = bdver3 | get_feature_masks(avx2, bmi2, mwaitx, movbe, rdrnd);
 
+// technically xsaves is part of znver1, znver2, and znver3
+// Disabled due to Erratum 1386
+// See: https://github.com/JuliaLang/julia/issues/50102
 constexpr auto znver1 = haswell | get_feature_masks(adx, aes, clflushopt, clzero, mwaitx, prfchw,
-                                                    rdseed, sha, sse4a, xsavec, xsaves);
+                                                    rdseed, sha, sse4a, xsavec);
 constexpr auto znver2 = znver1 | get_feature_masks(clwb, rdpid, wbnoinvd);
 constexpr auto znver3 = znver2 | get_feature_masks(shstk, pku, vaes, vpclmulqdq);
 


### PR DESCRIPTION
Fixes #50102

As far as I understand it `xsaves` is broken on `zenver1` and `zenver2`, and the Linux kernel disables that.
Weirdly enough in #50102 we are running on `AMD EPYC 7B13` which is `zenver3` and the it reports not having `xsaves`.

I don't think we are using it (maybe we should look into xsavec for task-switching xD )
so it should be safe to remove it from the set of required extensions.
