### PR TITLE
Add GC metric `last_incremental_sweep`

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -25,6 +25,7 @@ struct GC_Num
     total_sweep_time  ::Int64
     total_mark_time   ::Int64
     last_full_sweep ::Int64
+    last_incremental_sweep ::Int64
 end
 
 gc_num() = ccall(:jl_gc_num, GC_Num, ())

--- a/src/gc.c
+++ b/src/gc.c
@@ -3248,7 +3248,7 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
     gc_num.sweep_time = sweep_time;
     if (sweep_full) {
         gc_num.last_full_sweep = gc_end_time;
-    } 
+    }
     else {
         gc_num.last_incremental_sweep = gc_end_time;
     }

--- a/src/gc.c
+++ b/src/gc.c
@@ -3248,6 +3248,8 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
     gc_num.sweep_time = sweep_time;
     if (sweep_full) {
         gc_num.last_full_sweep = gc_end_time;
+    } else {
+        gc_num.last_incremental_sweep = gc_end_time;
     }
 
     // sweeping is over

--- a/src/gc.c
+++ b/src/gc.c
@@ -3248,7 +3248,8 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
     gc_num.sweep_time = sweep_time;
     if (sweep_full) {
         gc_num.last_full_sweep = gc_end_time;
-    } else {
+    } 
+    else {
         gc_num.last_incremental_sweep = gc_end_time;
     }
 

--- a/src/gc.h
+++ b/src/gc.h
@@ -82,6 +82,7 @@ typedef struct {
     uint64_t    total_sweep_time;
     uint64_t    total_mark_time;
     uint64_t    last_full_sweep;
+    uint64_t    last_incremental_sweep;
 } jl_gc_num_t;
 
 // Array chunks (work items representing suffixes of


### PR DESCRIPTION
Records the time that the last incremental sweep ran.

This allows an application that explicitly runs GC when idle or at convenient points to be more intelligent about it.

Related: https://github.com/JuliaLang/julia/pull/50018