### PR TITLE
Implement cong in Julia

### DIFF
--- a/base/partr.jl
+++ b/base/partr.jl
@@ -22,10 +22,11 @@ const heaps_lock = [SpinLock(), SpinLock()]
 cong(max::UInt32) = iszero(max) ? UInt32(0) : jl_rand_ptls(max) + UInt32(1)
 
 function jl_rand_ptls(max::UInt32)
-    rngseed = Base.unsafe_load(Base.unsafe_convert(Ptr{UInt64}, Core.getptls()), 2) # TODO, less horrid
+    ptls = Base.unsafe_convert(Ptr{UInt64}, Core.getptls())
+    rngseed = Base.unsafe_load(ptls, 2)
     # one-extend unbias back to 64-bits
     val, seed = _cong(UInt64(max), rngseed)
-    Base.unsafe_store!(Base.unsafe_convert(Ptr{UInt64}, Core.getptls()), seed, 2)
+    Base.unsafe_store!(ptls, seed, 2)
     return val % UInt32
 end
 

--- a/base/partr.jl
+++ b/base/partr.jl
@@ -34,7 +34,6 @@ function _cong(max::UInt64, seed::UInt64)
         return UInt64(0), seed
     end
     mask = typemax(UInt64)
-
     max -= 1
     mask >>= leading_zeros(max | 1)
 
@@ -42,7 +41,7 @@ function _cong(max::UInt64, seed::UInt64)
     while true
         seed = UInt64(69069) * seed + UInt64(362437)
         x = seed & mask
-        x > mask || break
+        x > max || break
     end
     return x, seed
 end

--- a/base/partr.jl
+++ b/base/partr.jl
@@ -19,33 +19,32 @@ const heap_d = UInt32(8)
 const heaps = [Vector{taskheap}(undef, 0), Vector{taskheap}(undef, 0)]
 const heaps_lock = [SpinLock(), SpinLock()]
 
-# cong(max::UInt32, unbias::UInt32) =
-#     ccall(:jl_rand_ptls, UInt32, (UInt32, UInt32), max, unbias) + UInt32(1)
+cong(max::UInt32) = iszero(max) ? UInt32(0) : jl_rand_ptls(max) + UInt32(1)
 
-cong(max::UInt32, unbias::UInt32) = jl_rand_ptls(max, unbias) + UInt32(1)
-
-function unbias_cong(max::UInt32)
-    return typemax(UInt32) - ((typemax(UInt32) % max) + UInt32(1))
-end
-
-function unbias_cong(max::UInt64)
-    return typemax(UInt64) - ((typemax(UInt64) % max) + UInt64(1))
-end
-
-function jl_rand_ptls(max::UInt32, unbias::UInt32)
+function jl_rand_ptls(max::UInt32)
     rngseed = Base.unsafe_load(Base.unsafe_convert(Ptr{UInt64}, Core.getptls()), 2) # TODO, less horrid
     # one-extend unbias back to 64-bits
-    val, seed = _cong(UInt64(max), -UInt64(-unbias), rngseed)
+    val, seed = _cong(UInt64(max), rngseed)
     Base.unsafe_store!(Base.unsafe_convert(Ptr{UInt64}, Core.getptls()), seed, 2)
     return val % UInt32
 end
 
-function _cong(max::UInt64, unbias::UInt64, seed::UInt64)
-    seed = UInt64(69069) * seed + UInt64(362437)
-    while seed > unbias
-        seed = UInt64(69069) * seed + UInt64(362437)
+function _cong(max::UInt64, seed::UInt64)
+    if max == 0
+        return UInt64(0), seed
     end
-    return seed % max, seed
+    mask = typemax(UInt64)
+
+    max -= 1
+    mask >>= leading_zeros(max | 1)
+
+    local x::UInt64
+    while true
+        seed = UInt64(69069) * seed + UInt64(362437)
+        x = seed & mask
+        x > mask || break
+    end
+    return x, seed
 end
 
 function multiq_sift_up(heap::taskheap, idx::Int32)

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -88,6 +88,7 @@ extern int jl_gc_mark_queue_obj_explicit(jl_gc_mark_cache_t *gc_cache,
 // parallel task runtime
 // ---
 
+// TODO: Delete
 JL_DLLEXPORT uint32_t jl_rand_ptls(uint32_t max)
 {
     jl_ptls_t ptls = jl_current_task->ptls;


### PR DESCRIPTION
Moving cong to Julia safes a tiny bit in overhead,
but accessing the PTLS rngseed for the scheduler is a bit... ugly.
