### PR TITLE
[build] Allow automatically applying Julia's patches to LLVM source

### DIFF
--- a/deps/llvm.version
+++ b/deps/llvm.version
@@ -1,7 +1,23 @@
+# -*- makefile -*-
+
 ## jll artifact
 LLVM_JLL_NAME := libLLVM
 LLVM_ASSERT_JLL_VER := 15.0.7+5
 ## source build
+# Version number of LLVM
 LLVM_VER := 15.0.7
+# Git branch name in `LLVM_GIT_URL` repository
 LLVM_BRANCH=julia-15.0.7-5
+# Git ref in `LLVM_GIT_URL` repository
 LLVM_SHA1=julia-15.0.7-5
+
+## Following options are used to automatically fetch patchset from Julia's fork.  This is
+## useful if you want to build an external LLVM while still applying Julia's patches.
+# Set to 1 if you want to automatically apply Julia's patches to a different fork of LLVM.
+LLVM_APPLY_JULIA_PATCHES := 0
+# GitHub repository to use for fetching the Julia patches to apply to LLVM source code.
+LLVM_JULIA_DIFF_GITHUB_REPO := https://github.com/llvm/llvm-project
+# Base GitHub ref for generating the diff.
+LLVM_BASE_REF := llvm:llvmorg-15.0.7
+# Julia fork's GitHub ref for generating the diff.
+LLVM_JULIA_REF := JuliaLang:julia-15.0.7-5


### PR DESCRIPTION
This is useful when one wants to build Julia with a non-Julia fork of LLVM, but still apply Julia's patches, to be a good citizen.  I'm happy to document these new options in the devdocs if #50207 is accepted.