### PR TITLE
typeintersect: fix `constraintkind` for non-covariant var

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -3023,13 +3023,12 @@ static int always_occurs_cov(jl_value_t *v, jl_tvar_t *var, int param) JL_NOTSAF
         return param == 1;
     }
     else if (jl_is_uniontype(v)) {
-        return always_occurs_cov(((jl_uniontype_t*)v)->a, var, param) ||
+        return always_occurs_cov(((jl_uniontype_t*)v)->a, var, param) &&
                always_occurs_cov(((jl_uniontype_t*)v)->b, var, param);
     }
     else if (jl_is_unionall(v)) {
         jl_unionall_t *ua = (jl_unionall_t*)v;
         return ua->var != var && (
-            always_occurs_cov(ua->var->lb, var, 0) ||
             always_occurs_cov(ua->var->ub, var, 0) ||
             always_occurs_cov(ua->body, var, param));
     }

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -2550,3 +2550,10 @@ end
 
 #issue #49857
 @test !<:(Type{Vector{Union{Base.BitInteger, Base.IEEEFloat, StridedArray, Missing, Nothing, Val{T}}}} where {T}, Type{Array{T}} where {T})
+
+#issue 50195
+T50195{S} = Pair{S,Set{S}}
+let a = Tuple{Type{X} where X<:Union{Nothing, Val{X1} where {X4, X1<:(Pair{X2, Val{X2}} where X2<:Val{X4})}}},
+    b = Tuple{Type{Y} where Y<:(Val{Y1} where {Y4<:Src, Y1<:(Pair{Y2, Val{Y2}} where Y2<:Union{Val{Y4}, Y4})})} where Src
+    @test typeintersect(a, b) <: Any
+end


### PR DESCRIPTION
The pre-check for `constraintkind` failed to predict `occurs_cov` (`!var_occurs_invariant` doesn't means `occurs_cov > 0`). And false `constraintkind` might cause circular constraints during the env contraction.

This PR fixes it by adding missing check back.
MWE added.
close #50195.