### PR TITLE
Expose the newpm pipeline to a C api

### DIFF
--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -109,6 +109,9 @@ JL_DLLEXPORT uint64_t jl_getUnwindInfo_fallback(uint64_t dwAddr)
 
 JL_DLLEXPORT void jl_add_optimization_passes_fallback(void *PM, int opt_level, int lower_intrinsics) UNAVAILABLE
 
+JL_DLLEXPORT void jl_build_newpm_pipeline_fallback(void *MPM, void *PB, int Speedup, int Size,
+    int lower_intrinsics, int dump_native, int external_use, int llvm_only) UNAVAILABLE
+
 JL_DLLEXPORT void LLVMExtraAddLowerSimdLoopPass_fallback(void *PM) UNAVAILABLE
 
 JL_DLLEXPORT void LLVMExtraAddFinalLowerGCPass_fallback(void *PM) UNAVAILABLE

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -558,6 +558,7 @@
     YY(jl_getUnwindInfo) \
     YY(jl_get_libllvm) \
     YY(jl_add_optimization_passes) \
+    YY(jl_build_newpm_pipeline) \
     YY(LLVMExtraAddLowerSimdLoopPass) \
     YY(LLVMExtraAddFinalLowerGCPass) \
     YY(LLVMExtraAddPropagateJuliaAddrspaces) \

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -571,6 +571,37 @@ static void buildPipeline(ModulePassManager &MPM, PassBuilder *PB, OptimizationL
     MPM.addPass(AfterOptimizationMarkerPass());
 }
 
+JL_DLLEXPORT_CODEGEN void jl_build_newpm_pipeline_impl(void *MPM, void *PB, int Speedup, int Size,
+    int lower_intrinsics, int dump_native, int external_use, int llvm_only) JL_NOTSAFEPOINT
+{
+    OptimizationLevel O;
+    switch (Size) {
+        case 1:
+            O = OptimizationLevel::Os;
+            break;
+        default:
+            O = OptimizationLevel::Oz;
+            break;
+        case 0:
+            switch (Speedup) {
+                case 0:
+                    O = OptimizationLevel::O0;
+                    break;
+                case 1:
+                    O = OptimizationLevel::O1;
+                    break;
+                case 2:
+                    O = OptimizationLevel::O2;
+                    break;
+                default:
+                    O = OptimizationLevel::O3;
+                    break;
+            }
+    }
+    buildPipeline(*reinterpret_cast<ModulePassManager*>(MPM), reinterpret_cast<PassBuilder*>(PB), O,
+                    OptimizationOptions{!!lower_intrinsics, !!dump_native, !!external_use, !!llvm_only});
+}
+
 #undef JULIA_PASS
 
 namespace {

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -571,7 +571,7 @@ static void buildPipeline(ModulePassManager &MPM, PassBuilder *PB, OptimizationL
     MPM.addPass(AfterOptimizationMarkerPass());
 }
 
-JL_DLLEXPORT_CODEGEN void jl_build_newpm_pipeline_impl(void *MPM, void *PB, int Speedup, int Size,
+extern "C" JL_DLLEXPORT_CODEGEN void jl_build_newpm_pipeline_impl(void *MPM, void *PB, int Speedup, int Size,
     int lower_intrinsics, int dump_native, int external_use, int llvm_only) JL_NOTSAFEPOINT
 {
     OptimizationLevel O;


### PR DESCRIPTION
GPUCompiler will need this to run the native pipeline on 1.10 and later. If building with Julia's patched LLVM or >= LLVM17, GPUCompiler should be able to register additional passes at the standard PassBuilder extension points. 