### PR TITLE
Emphasize the default base of multiversioning in the documentation, a…

### DIFF
--- a/doc/src/devdocs/sysimg.md
+++ b/doc/src/devdocs/sysimg.md
@@ -42,6 +42,9 @@ All features supported by LLVM are supported and a feature can be disabled with 
 (`+` prefix is also allowed and ignored to be consistent with LLVM syntax).
 Additionally, a few special features are supported to control the function cloning behavior.
 
+!!! note
+    It is good practice to specify either `clone_all` or `base(<n>)` for every target apart from the first one. This makes it explicit which targets have all functions cloned, and which targets are based on other targets. If this is not done, the default behavior is to not clone every function, and to use the first target's function definition as the fallback when not cloning a function.
+
 1. `clone_all`
 
     By default, only functions that are the most likely to benefit from


### PR DESCRIPTION
…nd discourage the implicit default base.

Setting `JULIA_CPU_TARGET=skylake;broadwell` as done in #50148 is inadvisable, as this results in an image where the uncloned functions use skylake features but cloned functions use broadwell features. The more likely intended meaning here is to have set `clone_all` for broadwell, so we should make this default more obvious while also encouraging explicitly specifying clone_all/base target index when necessary.