### PR TITLE
[DONOTMERGE] See if compilesig ever changes sparams

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -823,10 +823,9 @@ function compileable_specialization(mi::MethodInstance, effects::Effects,
         new_atype === nothing && return nothing
         if atype !== new_atype
             sp_ = ccall(:jl_type_intersection_with_env, Any, (Any, Any), new_atype, method.sig)::SimpleVector
-            if sparams === sp_[2]::SimpleVector
-                mi_invoke = specialize_method(method, new_atype, sparams)
-                mi_invoke === nothing && return nothing
-            end
+            @assert sparams === sp_[2]::SimpleVector
+            mi_invoke = specialize_method(method, new_atype, sparams)
+            mi_invoke === nothing && return nothing
         end
     else
         # If this caller does not want us to optimize calls to use their


### PR DESCRIPTION
We have a check in here that checks whether changing to compilesig changes the sparams and we refuse to use the compilesig in that case (although the exact behavior changed recently). I'm not sure the code path where we do change sparams is actually correct, but I also couldn't come up with a test that actually goes down this path. Putting in this assert shows that we don't hit it anywhere in our existing testsuite either, so I'm putting this up as a PR to pkgeval it and see if I'm missing anything. If not, we could possibly remove typeintersect (or only do it with an assert in debug mode).