### PR TITLE
Small fix to running-external-programs.md

### DIFF
--- a/doc/src/manual/running-external-programs.md
+++ b/doc/src/manual/running-external-programs.md
@@ -41,7 +41,7 @@ hello
 ```
 
 The `hello` is the output of the `echo` command, sent to [`stdout`](@ref). If the external command fails to run
-successfully, the run method throws an [`ErrorException`](@ref).
+successfully, the run method throws an [`ProcessFailedException`](@ref).
 
 If you want to read the output of the external command, [`read`](@ref) or [`readchomp`](@ref)
 can be used instead:


### PR DESCRIPTION
The `run` method no longer throws an `ErrorException` on failure. It currently throws a `ProcessFailedException`. I _think_ this is a small oversight in the documentation. I could absolutely be wrong :)