### PR TITLE
Fix jl_gc_internal_obj_base_ptr

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -4040,6 +4040,8 @@ JL_DLLEXPORT jl_value_t *jl_gc_internal_obj_base_ptr(void *p)
         // offset within object
         size_t off2 = (off - GC_PAGE_OFFSET);
         size_t osize = meta->osize;
+        if (osize == 0)
+            return NULL;
         off2 %= osize;
         if (off - off2 + osize > GC_PAGE_SZ)
             return NULL;


### PR DESCRIPTION
The function `jl_gc_internal_obj_base_ptr` takes a pointer and tries to determine if it is a valid object pointer. As such it has to carefully validate all data it reads, and abort whenever there are obvious inconsistencies.

This patch adds a check which aborts when `meta->osize` is zero, just before we perform a division-with-remainder by this value, thus avoiding a potential division-by-zero exception. This fixes a crash we are seeing in our code.

The crash did not happen before PR #49644 was merged because back then there was a check for `meta->ages` not being zero, which apparently was enough to detect invalid values for `meta` (e.g. when `meta` points into a null page).


All credits for finding this should go to @benlorenz (see also the discussion at and after <https://github.com/oscar-system/GAP.jl/issues/901#issuecomment-1597832335>), all misrepresentations are my fault.

Also CC @ThomasBreuer