### PR TITLE
Throw precompilation error if dependency load failure during incremental precompilation

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1919,7 +1919,7 @@ function _require(pkg::PkgId, env=nothing)
                     else
                         @warn "The call to compilecache failed to create a usable precompiled cache file for $pkg" exception=m
                     end
-                    # fall-through to loading the file locally
+                    # fall-through to loading the file locally if not incremental
                 else
                     cachefile, ocachefile = cachefile::Tuple{String, Union{Nothing, String}}
                     m = _tryrequire_from_serialized(pkg, cachefile, ocachefile)
@@ -1928,6 +1928,10 @@ function _require(pkg::PkgId, env=nothing)
                     else
                         return m
                     end
+                end
+                if JLOptions().incremental != 0
+                    # during incremental precompilation, this should be fail-fast
+                    throw(PrecompilableError())
                 end
             end
         end


### PR DESCRIPTION
In rare cases, if we fail to load a dependency during precompilation, we can fall-through to the "load locally" fallthrough in `_require()`.  However, if this happens during incremental precompilation, this ends up emitting `.ji` files that have multiple modules embedded within, which can cause massive precompilation issues further down the chain, as dependencies which try to load our `.ji` file themselves get corrupted.

This catches the error at the source, refusing to generate such a `.ji` file in the first place.