### PR TITLE
Add note to load_path docstring stating that it is not safe to mutate its return value

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -336,6 +336,10 @@ end
 
 Return the fully expanded value of [`LOAD_PATH`](@ref) that is searched for projects and
 packages.
+
+!!! note
+    `load_path` may return a reference to a cached value so it is not safe to modify the
+    returned vector.
 """
 function load_path()
     cache = LOADING_CACHE[]


### PR DESCRIPTION
Motivated by the mistake made in #50119 (which slipped past three approving reviews) and fixed in #50230.