### PR TITLE
Try to reduce memory usage during sysimg build

### DIFF
--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -12,7 +12,7 @@
 
 JL_DLLEXPORT void jl_dump_native_fallback(void *native_code,
         const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *asm_fname,
-        const char *sysimg_data, size_t sysimg_len, ios_t *s) UNAVAILABLE
+        ios_t *z, ios_t *s) UNAVAILABLE
 JL_DLLEXPORT void jl_get_llvm_gvs_fallback(void *native_code, arraylist_t *gvs) UNAVAILABLE
 JL_DLLEXPORT void jl_get_llvm_external_fns_fallback(void *native_code, arraylist_t *gvs) UNAVAILABLE
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1667,7 +1667,7 @@ JL_DLLIMPORT jl_value_t *jl_dump_function_asm(jl_llvmf_dump_t *dump, char emit_m
 JL_DLLIMPORT void *jl_create_native(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int policy, int imaging_mode, int cache, size_t world);
 JL_DLLIMPORT void jl_dump_native(void *native_code,
         const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *asm_fname,
-        const char *sysimg_data, size_t sysimg_len, ios_t *s);
+        ios_t *z, ios_t *s);
 JL_DLLIMPORT void jl_get_llvm_gvs(void *native_code, arraylist_t *gvs);
 JL_DLLIMPORT void jl_get_llvm_external_fns(void *native_code, arraylist_t *gvs);
 JL_DLLIMPORT void jl_get_function_id(void *native_code, jl_code_instance_t *ncode,

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -111,7 +111,9 @@ JL_DLLEXPORT void jl_write_compiler_output(void)
 
     bool_t emit_native = jl_options.outputo || jl_options.outputbc || jl_options.outputunoptbc || jl_options.outputasm;
 
-    bool_t emit_split = jl_options.outputji && emit_native;
+    const char *outputji = jl_options.outputji;
+
+    bool_t emit_split = outputji && emit_native;
 
     ios_t *s = NULL;
     ios_t *z = NULL;
@@ -125,9 +127,9 @@ JL_DLLEXPORT void jl_write_compiler_output(void)
 
     ios_t f;
 
-    if (jl_options.outputji) {
-        if (ios_file(&f, jl_options.outputji, 1, 1, 1, 1) == NULL)
-            jl_errorf("cannot open system image file \"%s\" for writing", jl_options.outputji);
+    if (outputji) {
+        if (ios_file(&f, outputji, 1, 1, 1, 1) == NULL)
+            jl_errorf("cannot open system image file \"%s\" for writing", outputji);
         ios_write(&f, (const char *)s->buf, (size_t)s->size);
         ios_close(s);
         free(s);
@@ -136,7 +138,7 @@ JL_DLLEXPORT void jl_write_compiler_output(void)
     // jl_dump_native writes the clone_targets into `s`
     // We need to postpone the srctext writing after that.
     if (native_code) {
-        ios_t *targets = jl_options.outputji ? &f : NULL;
+        ios_t *targets = outputji ? &f : NULL;
         // jl_dump_native will close and free z when appropriate
         // this is a horrible abstraction, but
         // this helps reduce live memory significantly
@@ -149,7 +151,7 @@ JL_DLLEXPORT void jl_write_compiler_output(void)
         jl_postoutput_hook();
     }
 
-    if (jl_options.outputji) {
+    if (outputji) {
         if (jl_options.incremental) {
             write_srctext(&f, udeps, srctextpos);
         }

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -137,14 +137,15 @@ JL_DLLEXPORT void jl_write_compiler_output(void)
     // We need to postpone the srctext writing after that.
     if (native_code) {
         ios_t *targets = jl_options.outputji ? &f : NULL;
+        // jl_dump_native will close and free z when appropriate
+        // this is a horrible abstraction, but
+        // this helps reduce live memory significantly
         jl_dump_native(native_code,
                         jl_options.outputbc,
                         jl_options.outputunoptbc,
                         jl_options.outputo,
                         jl_options.outputasm,
-                        (const char*)z->buf, (size_t)z->size, targets);
-        ios_close(z);
-        free(z);
+                        z, targets);
         jl_postoutput_hook();
     }
 


### PR DESCRIPTION
At least in the past, the most memory hungry step was emitting the system image to the object file. This is likely due to there being 3 or more copies of the sysimage live at that time, specifically:
1. Inside the ios_t providing the system image buffer
2. Inside the LLVMContext for the module
3. Inside the object file being emitted

This PR tries to reduce the number of live copies to 2, by incrementally copying to the next stage of code generation and then explicitly freeing the previous stage's resources. 