### PR TITLE
Fixes for the `1.9.1-full` tarball

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -230,6 +230,8 @@ $$(LLVM_BUILDDIR_withtype)/build-compiled: $$(SRCCACHE)/$$(LLVM_SRC_DIR)/$1.patc
 LLVM_PATCH_PREV := $$(SRCCACHE)/$$(LLVM_SRC_DIR)/$1.patch-applied
 endef
 
+$(eval $(call LLVM_PATCH,llvm-ittapi-cmake))
+
 ifeq ($(USE_SYSTEM_ZLIB), 0)
 $(LLVM_BUILDDIR_withtype)/build-configured: | $(build_prefix)/manifest/zlib
 endif
@@ -288,7 +290,7 @@ fastcheck-llvm: #none
 check-llvm: $(LLVM_BUILDDIR_withtype)/build-checked
 
 ifeq ($(USE_INTEL_JITEVENTS),1)
-extract-llvm: $(SRCCACHE)/$(ITTAPI_SRC_DIR)/source-extracted
+$(SRCCACHE)/$(LLVM_SRC_DIR)/source-extracted: $(SRCCACHE)/$(ITTAPI_SRC_DIR)/source-extracted
 endif
 
 #todo: LLVM make check target is broken on julia.mit.edu (and really slow elsewhere)

--- a/deps/patches/llvm-ittapi-cmake.patch
+++ b/deps/patches/llvm-ittapi-cmake.patch
@@ -1,0 +1,47 @@
+diff --git a/lib/ExecutionEngine/IntelJITEvents/CMakeLists.txt b/lib/ExecutionEngine/IntelJITEvents/CMakeLists.txt
+index 0c5017c359d6..92777133e9de 100644
+--- a/lib/ExecutionEngine/IntelJITEvents/CMakeLists.txt
++++ b/lib/ExecutionEngine/IntelJITEvents/CMakeLists.txt
+@@ -12,23 +12,23 @@ if(NOT DEFINED ITTAPI_SOURCE_DIR)
+     set(ITTAPI_SOURCE_DIR ${PROJECT_BINARY_DIR})
+ endif()
+
+-if(NOT EXISTS ${ITTAPI_SOURCE_DIR}/ittapi)
+-    execute_process(COMMAND ${GIT_EXECUTABLE} clone ${ITTAPI_GIT_REPOSITORY}
+-                    WORKING_DIRECTORY ${ITTAPI_SOURCE_DIR}
++if(NOT EXISTS ${ITTAPI_SOURCE_DIR})
++    execute_process(COMMAND ${GIT_EXECUTABLE} clone ${ITTAPI_GIT_REPOSITORY} ${ITTAPI_SOURCE_DIR}
++                    WORKING_DIRECTORY ${ITTAPI_SOURCE_DIR}/..
+                     RESULT_VARIABLE GIT_CLONE_RESULT)
+     if(NOT GIT_CLONE_RESULT EQUAL "0")
+         message(FATAL_ERROR "git clone ${ITTAPI_GIT_REPOSITORY} failed with ${GIT_CLONE_RESULT}, please clone ${ITTAPI_GIT_REPOSITORY}")
+     endif()
+-endif()
+
+-execute_process(COMMAND ${GIT_EXECUTABLE} checkout ${ITTAPI_GIT_TAG}
+-                WORKING_DIRECTORY ${ITTAPI_SOURCE_DIR}/ittapi
+-                RESULT_VARIABLE GIT_CHECKOUT_RESULT)
+-if(NOT GIT_CHECKOUT_RESULT EQUAL "0")
+-    message(FATAL_ERROR "git checkout ${ITTAPI_GIT_TAG} failed with ${GIT_CHECKOUT_RESULT}, please checkout ${ITTAPI_GIT_TAG} at ${ITTAPI_SOURCE_DIR}/ittapi")
++    execute_process(COMMAND ${GIT_EXECUTABLE} checkout ${ITTAPI_GIT_TAG}
++                    WORKING_DIRECTORY ${ITTAPI_SOURCE_DIR}
++                    RESULT_VARIABLE GIT_CHECKOUT_RESULT)
++    if(NOT GIT_CHECKOUT_RESULT EQUAL "0")
++        message(FATAL_ERROR "git checkout ${ITTAPI_GIT_TAG} failed with ${GIT_CHECKOUT_RESULT}, please checkout ${ITTAPI_GIT_TAG} at ${ITTAPI_SOURCE_DIR}")
++    endif()
+ endif()
+
+-include_directories( ${ITTAPI_SOURCE_DIR}/ittapi/include/ )
++include_directories( ${ITTAPI_SOURCE_DIR}/include/ )
+
+ if( HAVE_LIBDL )
+     set(LLVM_INTEL_JIT_LIBS ${CMAKE_DL_LIBS})
+@@ -40,7 +40,7 @@ set(LLVM_INTEL_JIT_LIBS ${LLVM_PTHREAD_LIB} ${LLVM_INTEL_JIT_LIBS})
+ add_llvm_component_library(LLVMIntelJITEvents
+   IntelJITEventListener.cpp
+   jitprofiling.c
+-  ${ITTAPI_SOURCE_DIR}/ittapi/src/ittnotify/ittnotify_static.c
++  ${ITTAPI_SOURCE_DIR}/src/ittnotify/ittnotify_static.c
+
+   LINK_LIBS ${LLVM_INTEL_JIT_LIBS}
+

--- a/deps/tools/common.mk
+++ b/deps/tools/common.mk
@@ -20,6 +20,10 @@ CMAKE_CXX_ARG := $(CXX_ARG)
 
 CMAKE_COMMON := -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix) -DCMAKE_PREFIX_PATH=$(build_prefix)
 CMAKE_COMMON += -DLIB_INSTALL_DIR=$(build_shlibdir)
+ifneq ($(OS),WINNT)
+CMAKE_COMMON += -DCMAKE_INSTALL_LIBDIR=$(build_libdir)
+endif
+
 ifeq ($(OS), Darwin)
 CMAKE_COMMON += -DCMAKE_MACOSX_RPATH=1
 endif


### PR DESCRIPTION
See commits.

~~Fixes for `aarch64-darwin` still to come.~~ It is actually `x86_64-darwin` that is still failing and needs a fix.

Closes https://github.com/JuliaLang/julia/issues/46530. Please confirm @benlorenz? Partially reverts https://github.com/JuliaLang/julia/pull/46061. Cc: @maleadt 
Closes https://github.com/JuliaLang/julia/issues/50127.

Related: https://github.com/JuliaLang/llvm-project/pull/18
