### PR TITLE
Remove unnecessary methods for `CartesianIndices`

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -3,7 +3,7 @@
 ### Multidimensional iterators
 module IteratorsMD
     import .Base: eltype, length, size, first, last, in, getindex, setindex!,
-                  min, max, zero, oneunit, isless, eachindex,  IteratorSize,
+                  min, max, zero, oneunit, isless, eachindex,
                   convert, show, iterate, promote_rule
 
     import .Base: +, -, *, (:)
@@ -396,8 +396,6 @@ module IteratorsMD
         Base._all_match_first(axes, axsA, B...) || Base.throw_eachindex_mismatch_indices(IndexCartesian(), axes(A), axes.(B)...)
         CartesianIndices(axsA)
     end
-
-    IteratorSize(::Type{<:CartesianIndices{N}}) where {N} = Base.HasShape{N}()
 
     @inline function iterate(iter::CartesianIndices)
         iterfirst = first(iter)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -2,8 +2,8 @@
 
 ### Multidimensional iterators
 module IteratorsMD
-    import .Base: eltype, length, size, first, last, in, getindex, setindex!, IndexStyle,
-                  min, max, zero, oneunit, isless, eachindex, ndims, IteratorSize,
+    import .Base: eltype, length, size, first, last, in, getindex, setindex!,
+                  min, max, zero, oneunit, isless, eachindex,  IteratorSize,
                   convert, show, iterate, promote_rule
 
     import .Base: +, -, *, (:)
@@ -342,7 +342,6 @@ module IteratorsMD
 
     # AbstractArray implementation
     Base.axes(iter::CartesianIndices{N,R}) where {N,R} = map(Base.axes1, iter.indices)
-    Base.IndexStyle(::Type{CartesianIndices{N,R}}) where {N,R} = IndexCartesian()
     Base.has_offset_axes(iter::CartesianIndices) = Base.has_offset_axes(iter.indices...)
     @propagate_inbounds function isassigned(iter::CartesianIndices{N,R}, I::Vararg{Int, N}) where {N,R}
         for i in 1:N
@@ -390,10 +389,6 @@ module IteratorsMD
         getindex(c, C)
     end
 
-    ndims(R::CartesianIndices) = ndims(typeof(R))
-    ndims(::Type{CartesianIndices{N}}) where {N} = N
-    ndims(::Type{CartesianIndices{N,TT}}) where {N,TT} = N
-
     eachindex(::IndexCartesian, A::AbstractArray) = CartesianIndices(axes(A))
 
     @inline function eachindex(::IndexCartesian, A::AbstractArray, B::AbstractArray...)
@@ -402,8 +397,6 @@ module IteratorsMD
         CartesianIndices(axsA)
     end
 
-    eltype(::Type{CartesianIndices{N}}) where {N} = CartesianIndex{N}
-    eltype(::Type{CartesianIndices{N,TT}}) where {N,TT} = CartesianIndex{N}
     IteratorSize(::Type{<:CartesianIndices{N}}) where {N} = Base.HasShape{N}()
 
     @inline function iterate(iter::CartesianIndices)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -236,6 +236,19 @@ end
     end
 end
 
+@testset "AbstractArray fallbacks for CartesianIndices" begin
+    @test ndims(CartesianIndices{3}) == 3
+    @test eltype(CartesianIndices{3}) == CartesianIndex{3}
+    for t in ((1:2, 1:2), (3:4,), ())
+        C2 = CartesianIndices(t)
+        @test ndims(C2) == length(t)
+        @test ndims(typeof(C2)) == length(t)
+        @test IndexStyle(C2) == IndexCartesian()
+        @test eltype(C2) == CartesianIndex{length(t)}
+        @test Base.IteratorSize(C2) isa Base.HasShape{length(t)}
+    end
+end
+
 @testset "LinearIndices" begin
     @testset "constructors" begin
         for oinds in [


### PR DESCRIPTION
These methods should correctly fall back to the `AbstractArray` ones, so defining them for `CartesianIndices` seems unnecessary. Even without these methods, the following seem to work:
```julia
julia> C = CartesianIndices((1:2, 1:2))
CartesianIndices((1:2, 1:2))

julia> ndims(C)
2

julia> ndims(typeof(C))
2

julia> eltype(C)
CartesianIndex{2}

julia> eltype(typeof(C))
CartesianIndex{2}

julia> Base.IteratorSize(C)
Base.HasShape{2}()
```
These may have been added with a specific reason in mind, in which case perhaps adding some comments might be more appropriate.