### PR TITLE
new CRC32.adjust_crc32c! function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,12 @@ Standard library changes
 #### DelimitedFiles
 
 
+#### CRC32c
+
+* New functions `adjust_crc32c` and `adjust_crc32c!` that write padding bytes into
+  a file, stream, or array in order to force the CRC32c checksum to equal an arbitrary
+  given value, mainly useful to store a file's checksum within the file itself ([#50269]).
+
 #### InteractiveUtils
 
 Deprecated or removed

--- a/stdlib/CRC32c/docs/src/index.md
+++ b/stdlib/CRC32c/docs/src/index.md
@@ -5,4 +5,6 @@ Standard library module for computing the CRC-32c checksum.
 ```@docs
 CRC32c.crc32c
 CRC32c.crc32c(::IO, ::Integer, ::UInt32)
+CRC32c.adjust_crc32c
+CRC32c.adjust_crc32c!
 ```

--- a/stdlib/CRC32c/src/CRC32c.jl
+++ b/stdlib/CRC32c/src/CRC32c.jl
@@ -121,6 +121,8 @@ julia> ltoh(reinterpret(UInt32, data[end-3:end])[1]) # crc is stored in data ðŸ˜
 0x1a5f345c
 ```
 
+Note that the `adjust_crc32c!` function is most efficient when `fixpos` is
+close to the end of the array `a`, and is slowest for `fixpos` near the beginning.
 See also [`adjust_crc32c`](@ref) to append similar padding bytes to the end of
 a file or I/O stream (which has the advantage of not requiring you to read the
 entire file into memory at once).

--- a/stdlib/CRC32c/src/CRC32c.jl
+++ b/stdlib/CRC32c/src/CRC32c.jl
@@ -9,7 +9,7 @@ module CRC32c
 
 import Base.FastContiguousSubArray
 
-export crc32c, adjust_crc32c!
+export crc32c, adjust_crc32c!, adjust_crc32c
 
 """
     crc32c(data, crc::UInt32=0x00000000)

--- a/stdlib/CRC32c/src/CRC32c.jl
+++ b/stdlib/CRC32c/src/CRC32c.jl
@@ -89,7 +89,7 @@ This is especially useful if you want to store the checksum of some data *within
 the data* itself, which is accomplished by:
 
 1. Pad the data with 8 bytes (of any values).
-2. Compute the checksum `crc` of the data.
+2. Compute the checksum `crc` of the data.  (Or pick an arbitrary `crc`, such as `rand(UInt32)`.)
 3. Store `crc` in the data using 4 bytes of the padding.
 4. Call `adjust_crc32c!` to change the other 4 bytes so that the checksum equals `crc`.
 

--- a/stdlib/CRC32c/src/CRC32c.jl
+++ b/stdlib/CRC32c/src/CRC32c.jl
@@ -9,7 +9,7 @@ module CRC32c
 
 import Base.FastContiguousSubArray
 
-export crc32c
+export crc32c, adjust_crc32c!
 
 """
     crc32c(data, crc::UInt32=0x00000000)
@@ -48,5 +48,91 @@ mixed with a starting `crc` integer.  If `nb` is not supplied, then
 crc32c(io::IO, nb::Integer, crc::UInt32=0x00000000) = Base._crc32c(io, nb, crc)
 crc32c(io::IO, crc::UInt32=0x00000000) = Base._crc32c(io, crc)
 crc32c(io::IOStream, crc::UInt32=0x00000000) = Base._crc32c(io, crc)
+
+#####################################################################
+# Code to adjust a byte array to have an arbitrary given crc, by
+# injecting 4 bytes at fixpos, following:
+#     Martin Stigge, Henryk Plötz, Wolf Müller, Jens-Peter Redlich,
+#     "Reversing CRC — Theory and Practice",
+#     HU Berlin Public Report SAR-PR-2006-05 (May 2006).
+# This is useful if you want to store the CRC of a file in the file.
+
+const POLY = 0x82f63b78 # CRC-32C (iSCSI) polynomial in reversed bit order.
+
+# reversed CRC32c table: Algorithm 5 from Stigge et al.
+const revtable = let table = Vector{UInt32}(undef, 256)
+    for index = UInt32(0):UInt32(255)
+        crc = index << 24;
+        for i = 1:8
+            crc = !iszero(crc & 0x80000000) ? ((crc ⊻ POLY) << 1) + 0x01 : crc << 1;
+        end
+        table[index+1] = crc;
+    end
+    table
+end
+
+# Table-driven "backwards" calculation of CRC: Algorithm 6 from Stigge et al.
+function bwcrc32c(a::AbstractVector{UInt8}, crc::UInt32)
+    crc = crc ⊻ 0xffffffff
+    for i = reverse(eachindex(a))
+        crc = (crc << 8) ⊻ revtable[(crc >> 24) + 1] ⊻ a[i]
+    end
+    return crc
+end
+
+"""
+    adjust_crc32c!(a::AbstractVector{UInt8}, wantcrc::UInt32, fixpos::Integer)
+
+Write 4 bytes to `a[fixpos:fixpos+3]` so that `crc32c(a)` becomes equal to `wantcrc`.
+
+This is especially useful if you want to store the checksum of some data *within
+the data* itself, which is accomplished by:
+
+1. Pad the data with 8 bytes (of any values).
+2. Compute the checksum `crc` of the data.
+3. Store `crc` in the data using 4 bytes of the padding.
+4. Call `adjust_crc32c!` to change the other 4 bytes so that the checksum equals `crc`.
+
+For example, the following code takes some arbitrary `data`, pads it with 8
+bytes at the end, stores its checksum in the last 4 bytes (in little-endian order),
+and then adjusts the preceding 4 bytes so that the original checksum is restored:
+
+```jldoctest
+julia> using CRC32c
+
+julia> data = UInt8[0xff, 0x20, 0x21, 0x09, 0x2d, 0x25, 0xa4, 0xff, 0xa3, 0xbe];
+
+julia> data = [data; 0x01:0x08]; # pad with 8 bytes
+
+julia> crc = crc32c(data)
+0x1a5f345c
+
+julia> data[end-3:end] = reinterpret(UInt8, [htol(crc)]); # write crc at end
+
+julia> crc32c(data) # crc has changed 😢
+0x01b684ee
+
+julia> adjust_crc32c!(data, crc, length(data)-7); # adjust crc via padding bytes
+
+julia> crc32c(data) # original crc is restored! 😄
+0x1a5f345c
+
+julia> ltoh(reinterpret(UInt32, data[end-3:end])[1]) # crc is stored in data 😄
+0x1a5f345c
+```
+"""
+function adjust_crc32c!(a::AbstractVector{UInt8}, wantcrc::UInt32, fixpos::Integer)
+    # store v in little-endian order at b[k:k+3]
+    function store_le!(b::AbstractVector{UInt8}, k::Integer, v::UInt32)
+        @inbounds b[k],b[k+1],b[k+2],b[k+3] =
+            v%UInt8, (v>>8)%UInt8, (v>>16)%UInt8, (v>>24)%UInt8
+    end
+
+    # Algorithm 8 from Stigge et al.
+    checkbounds(a, fixpos:fixpos+3)
+    @views store_le!(a, fixpos, crc32c(a[begin:fixpos-1]) ⊻ 0xffffffff)
+    @views store_le!(a, fixpos, bwcrc32c(a[fixpos:end], wantcrc))
+    return a
+end
 
 end

--- a/stdlib/CRC32c/src/CRC32c.jl
+++ b/stdlib/CRC32c/src/CRC32c.jl
@@ -52,8 +52,8 @@ crc32c(io::IOStream, crc::UInt32=0x00000000) = Base._crc32c(io, crc)
 #####################################################################
 # Code to adjust a byte array to have an arbitrary given crc, by
 # injecting 4 bytes at fixpos, following:
-#     Martin Stigge, Henryk Plötz, Wolf Müller, Jens-Peter Redlich,
-#     "Reversing CRC — Theory and Practice",
+#     Martin Stigge, Henryk Plötz, Wolf Müller, & Jens-Peter Redlich,
+#     "Reversing CRC — Theory and Practice,"
 #     HU Berlin Public Report SAR-PR-2006-05 (May 2006).
 # This is useful if you want to store the CRC of a file in the file.
 

--- a/stdlib/CRC32c/src/CRC32c.jl
+++ b/stdlib/CRC32c/src/CRC32c.jl
@@ -60,7 +60,7 @@ crc32c(io::IOStream, crc::UInt32=0x00000000) = Base._crc32c(io, crc)
 const POLY = 0x82f63b78 # CRC-32C (iSCSI) polynomial in reversed bit order.
 
 # reversed CRC32c table: Algorithm 5 from Stigge et al.
-const revtable = let table = Vector{UInt32}(undef, 256)
+const REVTABLE = let table = Vector{UInt32}(undef, 256)
     for index = UInt32(0):UInt32(255)
         crc = index << 24;
         for i = 1:8
@@ -75,7 +75,7 @@ end
 function bwcrc32c(a::AbstractVector{UInt8}, crc::UInt32)
     crc = crc ⊻ 0xffffffff
     for i = reverse(eachindex(a))
-        crc = (crc << 8) ⊻ revtable[(crc >> 24) + 1] ⊻ a[i]
+        crc = (crc << 8) ⊻ REVTABLE[(crc >> 24) + 1] ⊻ a[i]
     end
     return crc
 end
@@ -150,7 +150,9 @@ to cause the CRC32c checksum of the whole stream/file to equal `wantcrc`.
 (This is mainly useful if you want to store the checksum of the file *within the file*:
 simply set `wantcrc` to be an arbitrary number, such as `rand(UInt32)`, store it within
 the file as desired, and then call `adjust_crc32c` to write padding bytes that force
-the checksum to match `wantcrc`.)
+the checksum to match `wantcrc`.  Even more simply, you could force all of your files
+to have a checksum that matches a hard-coded value like `0x01020304`, in which case you
+don't need to store the checksum in the file itself.)
 
 See also [`adjust_crc32c!`](@ref) to write similar padding bytes to an arbitrary
 position within an array.

--- a/stdlib/CRC32c/src/CRC32c.jl
+++ b/stdlib/CRC32c/src/CRC32c.jl
@@ -158,7 +158,7 @@ position within an array.
 function adjust_crc32c(io::IO, wantcrc::UInt32)
     le(v::UInt32) = [v%UInt8, (v>>8)%UInt8, (v>>16)%UInt8, (v>>24)%UInt8]
     # specialized version of adjust_crc32c! for writing to end
-    write(io, le(bwcrc32c(le(crc32c(seekstart(io)) ⊻ 0xffffffff), wantcrc)))
+    write(io, htol(bwcrc32c(le(crc32c(seekstart(io)) ⊻ 0xffffffff), wantcrc)))
     return io
 end
 

--- a/stdlib/CRC32c/test/runtests.jl
+++ b/stdlib/CRC32c/test/runtests.jl
@@ -69,7 +69,7 @@ crc32c_sw(io::IO, crc::UInt32=0x00000000) = crc32c_sw(io, typemax(Int64), crc)
 test_crc32c(crc32c)
 test_crc32c(crc32c_sw)
 
-@testset "adjust_crc32c!" begin
+@testset "adjust_crc32c" begin
     wantcrc = 0x01020304
     for fixpos = 1:98
         data = adjust_crc32c!(rand(UInt8, 101), wantcrc, fixpos)
@@ -77,4 +77,14 @@ test_crc32c(crc32c_sw)
     end
     @test_throws BoundsError adjust_crc32c!(rand(UInt8, 101), wantcrc, 0)
     @test_throws BoundsError adjust_crc32c!(rand(UInt8, 101), wantcrc, 99)
+
+    let f = tempname()
+        try
+            write(f, rand(UInt8, 101))
+            adjust_crc32c(f, wantcrc)
+            @test open(crc32c, f) == wantcrc
+        finally
+            rm(f, force=true)
+        end
+    end
 end

--- a/stdlib/CRC32c/test/runtests.jl
+++ b/stdlib/CRC32c/test/runtests.jl
@@ -68,3 +68,13 @@ end
 crc32c_sw(io::IO, crc::UInt32=0x00000000) = crc32c_sw(io, typemax(Int64), crc)
 test_crc32c(crc32c)
 test_crc32c(crc32c_sw)
+
+@testset "adjust_crc32c!" begin
+    wantcrc = 0x01020304
+    for fixpos = 1:98
+        data = adjust_crc32c!(rand(UInt8, 101), wantcrc, fixpos)
+        @test crc32c(data) == wantcrc
+    end
+    @test_throws BoundsError adjust_crc32c!(rand(UInt8, 101), wantcrc, 0)
+    @test_throws BoundsError adjust_crc32c!(rand(UInt8, 101), wantcrc, 99)
+end


### PR DESCRIPTION
Adds (and exports) a function `adjust_crc32c!(a, wantcrc, fixpos)` to the CRC32c stdlib, which writes 4 bytes at `a[fixpos:fixpos+3]` to change the checksum to `wantcrc`.

This is based on the algorithm described in [Stigge et al. (2006)](https://sar.informatik.hu-berlin.de/research/publications/SAR-PR-2006-05/SAR-PR-2006-05_.pdf) as well as in [this StackOverflow answer](https://stackoverflow.com/questions/1514040/reversing-crc32).   The main application of this routine is to allow you to store the checksum of a file *within the file itself* (or simply to require a file to have a hard-coded checksum), as discussed in #50166.

It's pretty nontrivial to implement, and seems like generally useful functionality, but doesn't require too much code, so it seemed worth including.

`adjust_crc32c!` is a very general version of this functionality, which allows you to overwrite an *arbitrary* 4 bytes of a given array in order to make the checksum whatever you want. 

The PR also adds a function `adjust_crc32c([filename or io], wantcrc)` that specifically *appends* 4 "padding" bytes to the end of a file/stream in order to make its checksum an arbitrary given value.  This can be done more efficiently for large files because it doesn't require you to read the entire file into memory all at once.