### PR TITLE
add handling of `sqrt()` function for empty matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -875,7 +875,7 @@ julia> sqrt(A)
 sqrt(::AbstractMatrix)
 
 function sqrt(A::AbstractMatrix{T}) where {T<:Union{Real,Complex}}
-    if isempty(A)
+    if checksquare(A) == 0
         return copy(A)
     elseif ishermitian(A)
         sqrtHermA = sqrt(Hermitian(A))

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -875,7 +875,9 @@ julia> sqrt(A)
 sqrt(::AbstractMatrix)
 
 function sqrt(A::AbstractMatrix{T}) where {T<:Union{Real,Complex}}
-    if ishermitian(A)
+    if isempty(A)
+        return copy(A)
+    elseif ishermitian(A)
         sqrtHermA = sqrt(Hermitian(A))
         return ishermitian(sqrtHermA) ? copytri!(parent(sqrtHermA), 'U', true) : parent(sqrtHermA)
     elseif istriu(A)

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -1213,6 +1213,10 @@ end
     @test exp(log(A2)) ≈ A2
 end
 
+@testset "sqrt of empty Matrix of type $T" for T in [Int,Float32,Float64,ComplexF32,ComplexF64]
+    @test sqrt(Matrix{T}(undef, 0, 0)) == Matrix{T}(undef, 0, 0)
+end
+
 struct TypeWithoutZero end
 Base.zero(::Type{TypeWithoutZero}) = TypeWithZero()
 struct TypeWithZero end

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -1215,6 +1215,7 @@ end
 
 @testset "sqrt of empty Matrix of type $T" for T in [Int,Float32,Float64,ComplexF32,ComplexF64]
     @test sqrt(Matrix{T}(undef, 0, 0)) == Matrix{T}(undef, 0, 0)
+    @test_throws DimensionMismatch sqrt(Matrix{T}(undef, 2, 3))
 end
 
 struct TypeWithoutZero end

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -1215,7 +1215,7 @@ end
 
 @testset "sqrt of empty Matrix of type $T" for T in [Int,Float32,Float64,ComplexF32,ComplexF64]
     @test sqrt(Matrix{T}(undef, 0, 0)) == Matrix{T}(undef, 0, 0)
-    @test_throws DimensionMismatch sqrt(Matrix{T}(undef, 2, 3))
+    @test_throws DimensionMismatch sqrt(Matrix{T}(undef, 0, 3))
 end
 
 struct TypeWithoutZero end


### PR DESCRIPTION
Fixes: JuliaLang/LinearAlgebra.jl#1008 

This PR tries to fix the error highlighted in the above-mentioned issue. I feel this is the best way of handling the function since an empty matrix is an edge case, so explicit handling seems logical. Let me know if you agree/disagree with this approach.

Now the results are:
```julia
julia> R = ones(0, 0)
0×0 Matrix{Float64}

julia> sqrt(R)
0×0 Matrix{Float64}

julia> C = ones(ComplexF64, 0, 0)
0×0 Matrix{ComplexF64}

julia> sqrt(C)
0×0 Matrix{ComplexF64}
```