### PR TITLE
Fix indexing error in TwoPhaseDefUseMap

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -148,8 +148,9 @@ function kill_def_use!(tpdum::TwoPhaseDefUseMap, def::Int, use::Int)
             ndata = tpdum.data[idx+1]
             ndata == 0 && break
             tpdum.data[idx] = ndata
+            idx += 1
         end
-        tpdum.data[idx + 1] = 0
+        tpdum.data[idx] = 0
     end
 end
 kill_def_use!(tpdum::TwoPhaseDefUseMap, def::SSAValue, use::Int) =


### PR DESCRIPTION
There was an off-by-one in the indexing for TwoPhaseDefUseMap, causing def-use chains to not be properly visited. We don't use this functionality much in base, because it's only active for irinterp on functions with loops that were shown to terminate, which the compiler currently does not generally have the power to do, but I saw it in some downstream experiments.