### PR TITLE
compact: Try to preserve IR_FLAG_REFINED

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1417,6 +1417,13 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
         ssa_rename[idx] = stmt
     elseif isa(stmt, NewSSAValue)
         ssa_rename[idx] = SSAValue(stmt.id)
+    elseif (inst[:flag] & IR_FLAG_REFINED) != 0
+        # Do not compact constants that are the result of refinement until
+        # inference had a chance to propagate any type changes.
+        # TODO: We could mark this specifically in the ssa_rename, rather tha
+        # keeping the extra statement, but keep it simple for now.
+        result[result_idx][:inst] = stmt
+        result_idx += 1
     else
         # Constant assign, replace uses of this ssa value with its result
         ssa_rename[idx] = stmt

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -122,7 +122,7 @@ function reprocess_instruction!(interp::AbstractInterpreter, idx::Int, bb::Union
     rt = nothing
     if isa(inst, Expr)
         head = inst.head
-        if head === :call || head === :foreigncall || head === :new || head === :splatnew
+        if head === :call || head === :foreigncall || head === :new || head === :splatnew || head === :static_parameter || head === :isdefined
             (; rt, effects) = abstract_eval_statement_expr(interp, inst, nothing, irsv)
             ir.stmts[idx][:flag] |= flags_for_effects(effects)
         elseif head === :invoke
@@ -149,7 +149,7 @@ function reprocess_instruction!(interp::AbstractInterpreter, idx::Int, bb::Union
     elseif isa(inst, GlobalRef)
         # GlobalRef is not refinable
     else
-        error("reprocess_instruction!: unhandled instruction found")
+        rt = argextype(inst, irsv.ir)
     end
     if rt !== nothing
         if isa(rt, Const)


### PR DESCRIPTION
In #49340, I added an ir flag (currently only set by sroa) to allow sparse-reinference of ir after optimization passes that may improve type information. However, as currently implemented, this flag gets dropped when the IR is compacted, defeating the purpose of the flag, because it can no longer be reliably used for sparse re-inference. This commit changes compact prevent compaction if IR_FLAG_REFINED is set on a statement. This is the minimal change to fix this issue, but it is probably suboptimal for the base pipeline, because we (currently) do not do any re-inference (other than during semi-concrete eval), so the flag never gets cleared. I think the viable alternatives are:

1. Be more selective about setting IR_FLAG_REFINED only in situations where there is an actual improvement in the detected type.
2. Have compact look at whether the original IR statement was refined and if so, propagate the flag.
3. Both.

However, these are somewhat separate optimizations from fixing the underlying bug (and indepedent from each other), so let's experiment with those in separate commits.