### PR TITLE
Initialize prev_nold and nold in gc_reset_page

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1214,6 +1214,8 @@ STATIC_INLINE jl_taggedvalue_t *gc_reset_page(jl_ptls_t ptls2, const jl_gc_pool_
     jl_taggedvalue_t *beg = (jl_taggedvalue_t*)(pg->data + GC_PAGE_OFFSET);
     pg->has_young = 0;
     pg->has_marked = 0;
+    pg->prev_nold = 0;
+    pg->nold = 0;
     pg->fl_begin_offset = UINT16_MAX;
     pg->fl_end_offset = UINT16_MAX;
     return beg;


### PR DESCRIPTION
These are defined as:

```
// number of old objects in this page
uint16_t nold;
// number of old objects in this page during the previous full sweep
uint16_t prev_nold;
```

so I believe they should be initialized to 0 on `gc_reset_page`.

Assertion failure spotted in https://buildkite.com/julialang/julia-master/builds/25240#0188f3c2-f975-4b3b-938d-3cc86f920c9e.