### PR TITLE
Throw on non-promotion in fallback `UnitRange` constructor

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -404,7 +404,11 @@ struct UnitRange{T<:Real} <: AbstractUnitRange{T}
 end
 UnitRange{T}(start, stop) where {T<:Real} = UnitRange{T}(convert(T, start), convert(T, stop))
 UnitRange(start::T, stop::T) where {T<:Real} = UnitRange{T}(start, stop)
-UnitRange(start, stop) = UnitRange(promote(start, stop)...)
+function UnitRange(start, stop)
+    a, b = promote(start, stop)
+    not_sametype((start, stop), (a, b))
+    UnitRange(a, b)
+end
 
 # if stop and start are integral, we know that their difference is a multiple of 1
 unitrange_last(start::Integer, stop::Integer) =

--- a/base/range.jl
+++ b/base/range.jl
@@ -405,9 +405,9 @@ end
 UnitRange{T}(start, stop) where {T<:Real} = UnitRange{T}(convert(T, start), convert(T, stop))
 UnitRange(start::T, stop::T) where {T<:Real} = UnitRange{T}(start, stop)
 function UnitRange(start, stop)
-    a, b = promote(start, stop)
-    not_sametype((start, stop), (a, b))
-    UnitRange(a, b)
+    startstop_promoted = promote(start, stop)
+    not_sametype((start, stop), startstop_promoted)
+    UnitRange(startstop_promoted...)
 end
 
 # if stop and start are integral, we know that their difference is a multiple of 1

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -59,6 +59,9 @@ using InteractiveUtils: code_llvm
     @test last(10:0.2:3) === 9.8
     @test step(10:0.2:3) === 0.2
     @test isempty(10:0.2:3)
+
+    unitrangeerrstr = "promotion of types Char and Char failed to change any arguments"
+    @test_throws unitrangeerrstr UnitRange('a', 'b')
 end
 
 using Dates, Random


### PR DESCRIPTION
This avoids a `StackOverflowError` in the fallback `UnitRange` constructor, and throws an error if the promotion does not change the types of the arguments.

On master
```julia
julia> UnitRange('a', 'b')
ERROR: StackOverflowError:
Stacktrace:
 [1] UnitRange(start::Char, stop::Char) (repeats 79984 times)
   @ Base ./range.jl:401
```

After this
```julia
julia> UnitRange('a', 'b')
ERROR: promotion of types Char and Char failed to change any arguments
Stacktrace:
 [1] error(::String, ::String, ::String)
   @ Base ./error.jl:44
 [2] sametype_error(input::Tuple{Char, Char})
   @ Base ./promotion.jl:417
 [3] not_sametype(x::Tuple{Char, Char}, y::Tuple{Char, Char})
   @ Base ./promotion.jl:411
 [4] UnitRange(start::Char, stop::Char)
   @ Base ~/julia/base/range.jl:409
 [5] top-level scope
   @ REPL[9]:1
```