### PR TITLE
irinterp: Add handling for :throw_undef_if_not

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -130,8 +130,16 @@ function reprocess_instruction!(interp::AbstractInterpreter, idx::Int, bb::Union
             if nothrow
                 ir.stmts[idx][:flag] |= IR_FLAG_NOTHROW
             end
-        elseif head === :throw_undef_if_not || # TODO: Terminate interpretation early if known false?
-               head === :gc_preserve_begin ||
+        elseif head === :throw_undef_if_not
+            condval = maybe_extract_const_bool(argextype(inst.args[2], ir))
+            condval isa Bool || return false
+            if condval
+                ir.stmts[idx][:inst] = nothing
+                # We simplified the IR, but we did not update the type
+                return false
+            end
+            rt = Union{}
+        elseif head === :gc_preserve_begin ||
                head === :gc_preserve_end
             return false
         else


### PR DESCRIPTION
This addresses an existing TODO to terminate irinterp on discovering a :throw_undef_if_not that is dead. The underlying infrastructure to do this was added in #49692, so this just needed to be wired up properly.