### PR TITLE
Relax constraints on the PHI block

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -162,7 +162,7 @@ function reprocess_instruction!(interp::AbstractInterpreter, idx::Int, bb::Union
     if rt !== nothing
         if isa(rt, Const)
             ir.stmts[idx][:type] = rt
-            if is_inlineable_constant(rt.val) && !isa(inst, PhiNode) && (ir.stmts[idx][:flag] & (IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW)) == IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW
+            if is_inlineable_constant(rt.val) && (ir.stmts[idx][:flag] & (IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW)) == IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW
                 ir.stmts[idx][:inst] = quoted(rt.val)
             end
             return true

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -20,6 +20,7 @@ if !isdefined(@__MODULE__, Symbol("@verify_error"))
     end
 end
 
+is_value_pos_expr_head(head::Symbol) = head === :boundscheck
 function check_op(ir::IRCode, domtree::DomTree, @nospecialize(op), use_bb::Int, use_idx::Int, printed_use_idx::Int, print::Bool, isforeigncall::Bool, arg_idx::Int, allow_frontend_forms::Bool)
     if isa(op, SSAValue)
         if op.id > length(ir.stmts)
@@ -60,7 +61,7 @@ function check_op(ir::IRCode, domtree::DomTree, @nospecialize(op), use_bb::Int, 
             # Allow a tuple in symbol position for foreigncall - this isn't actually
             # a real call - it's interpreted in global scope by codegen. However,
             # we do need to keep this a real use, because it could also be a pointer.
-        elseif op.head !== :boundscheck
+        elseif !is_value_pos_expr_head(op.head)
             if !allow_frontend_forms || op.head !== :opaque_closure_method
                 @verify_error "Expr not allowed in value position"
                 error("")
@@ -189,9 +190,12 @@ function verify_ir(ir::IRCode, print::Bool=true,
     end
     lastbb = 0
     is_phinode_block = false
+    firstidx = 1
+    lastphi = 1
     for (bb, idx) in bbidxiter(ir)
         if bb != lastbb
             is_phinode_block = true
+            lastphi = firstidx = idx
             lastbb = bb
         end
         # We allow invalid IR in dead code to avoid passes having to detect when
@@ -204,6 +208,7 @@ function verify_ir(ir::IRCode, print::Bool=true,
                 @verify_error "φ node $idx is not at the beginning of the basic block $bb"
                 error("")
             end
+            lastphi = idx
             @assert length(stmt.edges) == length(stmt.values)
             for i = 1:length(stmt.edges)
                 edge = stmt.edges[i]
@@ -244,12 +249,19 @@ function verify_ir(ir::IRCode, print::Bool=true,
                 check_op(ir, domtree, val, Int(edge), last(ir.cfg.blocks[stmt.edges[i]].stmts)+1, idx, print, false, i, allow_frontend_forms)
             end
             continue
-        elseif stmt === nothing
-            # Nothing to do
-            continue
         end
 
-        is_phinode_block = false
+        if is_phinode_block && isa(stmt, Union{Expr, UpsilonNode, PhiCNode, SSAValue})
+            if !isa(stmt, Expr) || !is_value_pos_expr_head(stmt.head)
+                # Go back and check that all non-PhiNodes are valid value-position
+                for validate_idx in firstidx:(lastphi-1)
+                    validate_stmt = ir.stmts[validate_idx][:inst]
+                    isa(validate_stmt, PhiNode) && continue
+                    check_op(ir, domtree, validate_stmt, bb, idx, idx, print, false, 0, allow_frontend_forms)
+                end
+                is_phinode_block = false
+            end
+        end
         if isa(stmt, PhiCNode)
             for i = 1:length(stmt.values)
                 val = stmt.values[i]


### PR DESCRIPTION
In #50158, I tought the verifier to reject code that has invalid statements in the original PHI block. In #50235, this required irinterp to stop folding PhiNodes to the respective constants. I said at the time that a subsequent compact would fix it, but it turns out that we don't actually have the logic for that. I might still add that logic, but on the other hand it just seems kinda silly that PhiNodes need to be a special case here.

This PR relaxes the semantics of the PHI block, to allow any value-position constant to appear in the PHI block and undoes the irinterp change from #50235. Only the interpreter really cares about the semantics of the phi block, so the primary change is there.

Of note, SSAValue forwards are not allowed in the phi block. This is because of the following:

```
loop:
 %1 = %(...)
 %2 = %1
 %3 = %(top => %1)
```

The two phi values %1 and %2 have different semantics: %1 gets the *current* iteration of the loop, while %3 gets the *previous* value. As a result, any pass that wants to move SSAValues out of PhiNode uses would have to be aware of these semantics anyway, and there's no simplicitly benefits to allowing SSAValues in the middle of a phi block.