### PR TITLE
unify `shuffle` and `randperm`

### DIFF
--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -222,13 +222,13 @@ julia> shuffle!(rng, Vector(1:16))
 function shuffle!(r::AbstractRNG, a::AbstractArray)
     require_one_based_indexing(a)
     n = length(a)
-    n <= 1 && return a # nextpow below won't work with n == 0
     @assert n <= Int64(2)^52
-    mask = nextpow(2, n) - 1
-    for i = n:-1:2
-        (mask >> 1) == i && (mask >>= 1)
+    n == 0 && return a
+    mask = 3
+    @inbounds for i = 2:n
         j = 1 + rand(r, ltm52(i, mask))
         a[i], a[j] = a[j], a[i]
+        i == 1 + mask && (mask = 2 * mask + 1)
     end
     return a
 end
@@ -326,7 +326,7 @@ function randperm!(r::AbstractRNG, a::Array{<:Integer})
             a[i] = a[j]
         end
         a[j] = i
-        i == 1+mask && (mask = 2mask + 1)
+        i == 1 + mask && (mask = 2 * mask + 1)
     end
     return a
 end

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -201,22 +201,22 @@ julia> rng = MersenneTwister(1234);
 
 julia> shuffle!(rng, Vector(1:16))
 16-element Vector{Int64}:
-  2
- 15
-  5
- 14
+ 16
   1
-  9
+ 14
+ 12
+  5
  10
+  4
+ 15
+ 13
+  3
+  7
+  9
   6
  11
-  3
- 16
-  7
-  4
- 12
   8
- 13
+  2
 ```
 """
 function shuffle!(r::AbstractRNG, a::AbstractArray)
@@ -249,16 +249,16 @@ julia> rng = MersenneTwister(1234);
 
 julia> shuffle(rng, Vector(1:10))
 10-element Vector{Int64}:
-  6
-  1
- 10
   2
-  3
+  1
+  7
   9
   5
-  7
+ 10
   4
   8
+  6
+  3
 ```
 """
 shuffle(r::AbstractRNG, a::AbstractArray) = shuffle!(r, copymutable(a))

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -220,6 +220,7 @@ julia> shuffle!(rng, Vector(1:16))
 ```
 """
 function shuffle!(r::AbstractRNG, a::AbstractArray)
+    # keep it consistent with `randperm!` and `randcycle!` if possible
     require_one_based_indexing(a)
     n = length(a)
     @assert n <= Int64(2)^52
@@ -315,6 +316,7 @@ julia> randperm!(MersenneTwister(1234), Vector{Int}(undef, 4))
 ```
 """
 function randperm!(r::AbstractRNG, a::Array{<:Integer})
+    # keep it consistent with `shuffle!` and `randcycle!` if possible
     n = length(a)
     @assert n <= Int64(2)^52
     n == 0 && return a
@@ -382,16 +384,17 @@ julia> randcycle!(MersenneTwister(1234), Vector{Int}(undef, 6))
 ```
 """
 function randcycle!(r::AbstractRNG, a::Array{<:Integer})
+    # keep it consistent with `shuffle!` and `randperm!` if possible
     n = length(a)
-    n == 0 && return a
     @assert n <= Int64(2)^52
+    n == 0 && return a
     a[1] = 1
     mask = 3
     @inbounds for i = 2:n
         j = 1 + rand(r, ltm52(i-1, mask))
         a[i] = a[j]
         a[j] = i
-        i == 1+mask && (mask = 2mask + 1)
+        i == 1 + mask && (mask = 2 * mask + 1)
     end
     return a
 end


### PR DESCRIPTION
unify the algorithms of `shuffle` and `randperm` without performance loss, so that:
- `shuffle(rng, 1:n) == randperm(rng, n)`
- `shuffle(rng, eachindex(1:n)) == shuffle(rng, 1:n)`

see also:
- https://github.com/JuliaLang/julia/issues/50304
- https://github.com/JuliaLang/julia/pull/45732

correctness:
```julia
ns = [1, 10, 100, 1000, 10000]

for n in ns
    @show shuffle!(MersenneTwister(1), Vector(1:n) .* 7) ./ 7 == randperm(MersenneTwister(1), n)
end

"""
output:
shuffle!(MersenneTwister(1), Vector(1:n) .* 7) ./ 7 == randperm(MersenneTwister(1), n) = true
shuffle!(MersenneTwister(1), Vector(1:n) .* 7) ./ 7 == randperm(MersenneTwister(1), n) = true
shuffle!(MersenneTwister(1), Vector(1:n) .* 7) ./ 7 == randperm(MersenneTwister(1), n) = true
shuffle!(MersenneTwister(1), Vector(1:n) .* 7) ./ 7 == randperm(MersenneTwister(1), n) = true
shuffle!(MersenneTwister(1), Vector(1:n) .* 7) ./ 7 == randperm(MersenneTwister(1), n) = true
"""
```

performance:
```julia
ns = [1, 10, 100, 1000, 10000]

t_new = [@belapsed(shuffle!(MersenneTwister(1), Vector(1:$n))) for n in ns]
t_old = [@belapsed(Random.shuffle!(MersenneTwister(1), Vector(1:$n))) for n in ns]
println("small item:\n#item\tnew\told")
display(hcat(ns, t_new, t_old))

"""
output:
small item:
#item   new     old
5×3 Matrix{Float64}:
     1.0  9.75e-6    9.748e-6
    10.0  9.938e-6   1.02e-5
   100.0  1.0523e-5  1.0548e-5
  1000.0  1.3765e-5  1.3549e-5
 10000.0  7.2876e-5  7.1795e-5
"""

vs = [[NTuple{1000, Float64}(rand(1000)) for _ in 1:n] for n in ns]
t_new = [@belapsed(shuffle!(MersenneTwister(1), $v)) for v in copy.(vs)]
t_old = [@belapsed(Random.shuffle!(MersenneTwister(1), $v)) for v in copy.(vs)]
println("large item:\n#item\tnew\told")
display(hcat(ns, t_new, t_old))

"""
output:
large item:
#item   new     old
5×3 Matrix{Float64}:
     1.0  9.811e-6     9.733e-6
    10.0  1.2482e-5    1.2365e-5
   100.0  4.4791e-5    4.3842e-5
  1000.0  0.000401874  0.000391641
 10000.0  0.00989083   0.0101406
"""
```
