### PR TITLE
fix `compatible_vatuple`

### DIFF
--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -139,12 +139,12 @@ valid_tparam(@nospecialize(x)) = valid_typeof_tparam(typeof(x))
 
 function compatible_vatuple(a::DataType, b::DataType)
     vaa = a.parameters[end]
-    vab = a.parameters[end]
+    vab = b.parameters[end]
     if !(isvarargtype(vaa) && isvarargtype(vab))
         return isvarargtype(vaa) == isvarargtype(vab)
     end
-    (isdefined(vaa, :N) == isdefined(vab, :N)) || return false
-    !isdefined(vaa, :N) && return true
+    isdefined(vaa, :N) || return !isdefined(vab, :N)
+    isdefined(vab, :N) || return false
     return vaa.N === vab.N
 end
 
@@ -163,8 +163,7 @@ function typesubtract(@nospecialize(a), @nospecialize(b), max_union_splitting::I
     elseif a isa DataType
         ub = unwrap_unionall(b)
         if ub isa DataType
-            if a.name === ub.name === Tuple.name &&
-                    length(a.parameters) == length(ub.parameters)
+            if a.name === ub.name === Tuple.name && length(a.parameters) == length(ub.parameters)
                 if 1 < unionsplitcost(JLTypeLattice(), a.parameters) <= max_union_splitting
                     ta = switchtupleunion(a)
                     return typesubtract(Union{ta...}, b, 0)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3499,8 +3499,15 @@ end
               Tuple{Int, Char, Int}, Tuple{Int, Int, Char}, Tuple{Int, Int, Int}}
 # Test that these don't throw
 @test Core.Compiler.typesubtract(Tuple{Vararg{Int}}, Tuple{Vararg{Char}}, 0) == Tuple{Vararg{Int}}
+@test Core.Compiler.typesubtract(Tuple{Vararg{Int}}, Tuple{Vararg{Int}}, 0) == Union{}
+@test Core.Compiler.typesubtract(Tuple{String,Int}, Tuple{String,Vararg{Int}}, 0) == Union{}
+@test Core.Compiler.typesubtract(Tuple{String,Vararg{Int}}, Tuple{String,Int}, 0) == Tuple{String,Vararg{Int}}
 @test Core.Compiler.typesubtract(NTuple{3, Real}, NTuple{3, Char}, 0) == NTuple{3, Real}
 @test Core.Compiler.typesubtract(NTuple{3, Union{Real, Char}}, NTuple{2, Char}, 0) == NTuple{3, Union{Real, Char}}
+
+@test Core.Compiler.compatible_vatuple(Tuple{String,Vararg{Int}}, Tuple{String,Vararg{Int}})
+@test !Core.Compiler.compatible_vatuple(Tuple{String,Int}, Tuple{String,Vararg{Int}})
+@test !Core.Compiler.compatible_vatuple(Tuple{String,Vararg{Int}}, Tuple{String,Int})
 
 @test Base.return_types(Issue35566.f) == [Val{:expected}]
 


### PR DESCRIPTION
Seemingly `vab` has been computed wrongly.