### PR TITLE
Allocation Profiler: Types for all allocations

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1316,7 +1316,7 @@ STATIC_INLINE jl_value_t *jl_gc_pool_alloc_inner(jl_ptls_t ptls, int pool_offset
 }
 
 // Record an allocation, called into by LLVM-generated code.
-JL_DLLEXPORT jl_value_t *jl_maybe_record_alloc_to_profile(jl_value_t* val, int osize,
+JL_DLLEXPORT void jl_maybe_record_alloc_to_profile(jl_value_t* val, int osize,
                                         jl_value_t* type)
 {
     maybe_record_alloc_to_profile(val, osize, (jl_datatype_t*)type);

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -185,6 +185,7 @@
     XX(jl_gc_new_weakref_th) \
     XX(jl_gc_num) \
     XX(jl_gc_pool_alloc) \
+    XX(jl_maybe_record_alloc_to_profile) \
     XX(jl_gc_queue_multiroot) \
     XX(jl_gc_queue_root) \
     XX(jl_gc_safepoint) \

--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -48,6 +48,7 @@ private:
     Function *queueRootFunc;
     Function *poolAllocFunc;
     Function *bigAllocFunc;
+    Function *recordAllocFunc;
     Function *allocTypedFunc;
     Instruction *pgcstack;
     Type *T_size;
@@ -253,10 +254,11 @@ bool FinalLowerGC::doInitialization(Module &M) {
     queueRootFunc = getOrDeclare(jl_well_known::GCQueueRoot);
     poolAllocFunc = getOrDeclare(jl_well_known::GCPoolAlloc);
     bigAllocFunc = getOrDeclare(jl_well_known::GCBigAlloc);
+    recordAllocFunc = getOrDeclare(jl_well_known::GCRecordAllocToProfile);
     allocTypedFunc = getOrDeclare(jl_well_known::GCAllocTyped);
     T_size = M.getDataLayout().getIntPtrType(M.getContext());
 
-    GlobalValue *functionList[] = {queueRootFunc, poolAllocFunc, bigAllocFunc, allocTypedFunc};
+    GlobalValue *functionList[] = {queueRootFunc, poolAllocFunc, bigAllocFunc, recordAllocFunc, allocTypedFunc};
     unsigned j = 0;
     for (unsigned i = 0; i < sizeof(functionList) / sizeof(void*); i++) {
         if (!functionList[i])
@@ -272,8 +274,8 @@ bool FinalLowerGC::doInitialization(Module &M) {
 
 bool FinalLowerGC::doFinalization(Module &M)
 {
-    GlobalValue *functionList[] = {queueRootFunc, poolAllocFunc, bigAllocFunc, allocTypedFunc};
-    queueRootFunc = poolAllocFunc = bigAllocFunc = allocTypedFunc = nullptr;
+    GlobalValue *functionList[] = {queueRootFunc, poolAllocFunc, bigAllocFunc, recordAllocFunc, allocTypedFunc};
+    queueRootFunc = poolAllocFunc = bigAllocFunc = recordAllocFunc = allocTypedFunc = nullptr;
     auto used = M.getGlobalVariable("llvm.compiler.used");
     if (!used)
         return false;

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2404,6 +2404,24 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S, bool *CFGModified) {
                 store->setOrdering(AtomicOrdering::Unordered);
                 store->setMetadata(LLVMContext::MD_tbaa, tbaa_tag);
 
+                auto recordAllocIntrinsic = getOrDeclare(jl_well_known::GCRecordAllocToProfile);
+                auto value = newI;
+                //auto record_alloc =
+                builder.CreateCall(
+                    recordAllocIntrinsic,
+                    {
+                        value,
+                        builder.CreateIntCast(
+                            CI->getArgOperand(1),
+                            allocBytesIntrinsic->getFunctionType()->getParamType(1),
+                            false),
+                        tag
+                    });
+                // TODO: is this needed? What is it?
+                //record_alloc->setOrdering(AtomicOrdering::Unordered);
+                //record_alloc->setMetadata(LLVMContext::MD_tbaa, tbaa_tag);
+
+
                 // Replace uses of the call to `julia.gc_alloc_obj` with the call to
                 // `julia.gc_alloc_bytes`.
                 CI->replaceAllUsesWith(newI);

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2413,7 +2413,7 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S, bool *CFGModified) {
                         value,
                         builder.CreateIntCast(
                             CI->getArgOperand(1),
-                            allocBytesIntrinsic->getFunctionType()->getParamType(1),
+                            recordAllocIntrinsic->getFunctionType()->getParamType(1),
                             false),
                         tag
                     });

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2415,7 +2415,7 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S, bool *CFGModified) {
                             CI->getArgOperand(1),
                             recordAllocIntrinsic->getFunctionType()->getParamType(1),
                             false),
-                        tag
+                        builder.CreatePtrToInt(tag, T_size),
                     });
                 // TODO: is this needed? What is it?
                 //record_alloc->setOrdering(AtomicOrdering::Unordered);

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -238,6 +238,7 @@ namespace jl_intrinsics {
 namespace jl_well_known {
     static const char *GC_BIG_ALLOC_NAME = XSTR(jl_gc_big_alloc);
     static const char *GC_POOL_ALLOC_NAME = XSTR(jl_gc_pool_alloc);
+    static const char *GC_RECORD_ALLOC_TO_PROFILE_NAME = XSTR(jl_maybe_record_alloc_to_profile);
     static const char *GC_QUEUE_ROOT_NAME = XSTR(jl_gc_queue_root);
     static const char *GC_ALLOC_TYPED_NAME = XSTR(jl_gc_alloc_typed);
 
@@ -273,6 +274,26 @@ namespace jl_well_known {
                 GC_POOL_ALLOC_NAME);
             poolAllocFunc->addFnAttr(Attribute::getWithAllocSizeArgs(ctx, 2, None));
             return addGCAllocAttributes(poolAllocFunc);
+        });
+
+    const WellKnownFunctionDescription GCRecordAllocToProfile(
+        GC_RECORD_ALLOC_TO_PROFILE_NAME,
+        [](Type *T_size) {
+            auto &ctx = T_size->getContext();
+            auto T_prjlvalue = JuliaType::get_prjlvalue_ty(ctx);
+            auto recordAllocFunc = Function::Create(
+                FunctionType::get(
+                    T_prjlvalue,
+                    {
+                        T_size,
+                        Type::getInt32Ty(ctx),
+                        T_size,
+                    },
+                    false),
+                Function::ExternalLinkage,
+                GC_RECORD_ALLOC_TO_PROFILE_NAME);
+            recordAllocFunc->addFnAttr(Attribute::getWithAllocSizeArgs(ctx, 2, None));
+            return addGCAllocAttributes(recordAllocFunc);
         });
 
     const WellKnownFunctionDescription GCQueueRoot(

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -281,10 +281,12 @@ namespace jl_well_known {
         [](Type *T_size) {
             auto &ctx = T_size->getContext();
             auto T_prjlvalue = JuliaType::get_prjlvalue_ty(ctx);
+            auto T_void = Type::getVoidTy(ctx);
             auto recordAllocFunc = Function::Create(
                 FunctionType::get(
-                    T_prjlvalue,
+                    T_void,
                     {
+                        //T_prjlvalue,
                         T_size,
                         Type::getInt32Ty(ctx),
                         T_size,
@@ -292,8 +294,9 @@ namespace jl_well_known {
                     false),
                 Function::ExternalLinkage,
                 GC_RECORD_ALLOC_TO_PROFILE_NAME);
-            recordAllocFunc->addFnAttr(Attribute::getWithAllocSizeArgs(ctx, 2, None));
-            return addGCAllocAttributes(recordAllocFunc);
+            // TODO: what is this?
+            //recordAllocFunc->addFnAttr(Attribute::getWithAllocSizeArgs(ctx, 2, None));
+            return recordAllocFunc;
         });
 
     const WellKnownFunctionDescription GCQueueRoot(

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -147,6 +147,9 @@ namespace jl_well_known {
     // `jl_gc_pool_alloc`: allocates bytes.
     extern const WellKnownFunctionDescription GCPoolAlloc;
 
+    // `jl_maybe_record_alloc_to_profile`: records an allocation to the alloc profile.
+    extern const WellKnownFunctionDescription GCRecordAllocToProfile;
+
     // `jl_gc_queue_root`: queues a GC root.
     extern const WellKnownFunctionDescription GCQueueRoot;
 

--- a/stdlib/Profile/test/allocs.jl
+++ b/stdlib/Profile/test/allocs.jl
@@ -141,3 +141,15 @@ end
     @test length(prof.allocs) >= 1
     @test length([a for a in prof.allocs if a.type == MyType]) >= 1
 end
+
+@testset "alloc profiler catches allocs from buffer resize" begin
+    a = Int[]
+    Allocs.@profile sample_rate=1 for _ in 1:100; push!(a, 1); end
+
+    prof = Allocs.fetch()
+    Allocs.clear()
+
+    @test length(prof.allocs) >= 1
+    @test length([a for a in prof.allocs if a.type == Profile.Allocs.BufferType]) >= 1
+end
+

--- a/stdlib/Profile/test/allocs.jl
+++ b/stdlib/Profile/test/allocs.jl
@@ -121,3 +121,23 @@ end
     @test length(prof.allocs) >= 1
     @test length([a for a in prof.allocs if a.type == String]) >= 1
 end
+
+@testset "alloc profiler catches allocs from codegen" begin
+    @eval begin
+        struct MyType x::Int; y::Int end
+        Base.:(+)(n::Number, x::MyType) = n + x.x + x.y
+        foo(a, x) = a[1] + x
+        wrapper(a) = foo(a, MyType(0,1))
+    end
+    a = Any[1,2,3]
+    # warmup
+    wrapper(a)
+
+    @eval Allocs.@profile sample_rate=1 wrapper(a)
+
+    prof = Allocs.fetch()
+    Allocs.clear()
+
+    @test length(prof.allocs) >= 1
+    @test length([a for a in prof.allocs if a.type == MyType]) >= 1
+end

--- a/stdlib/Profile/test/allocs.jl
+++ b/stdlib/Profile/test/allocs.jl
@@ -133,7 +133,7 @@ end
     # warmup
     wrapper(a)
 
-    @eval Allocs.@profile sample_rate=1 wrapper(a)
+    @eval Allocs.@profile sample_rate=1 wrapper($a)
 
     prof = Allocs.fetch()
     Allocs.clear()


### PR DESCRIPTION
Before this PR, we were missing the types for allocations in two cases:
1. allocations from codegen
2. allocations in `gc_managed_realloc_`

The second one is easy: those are always used for `buffer`s, right?

For the first one: this PR adds a new exported julia function, which codegen will call after every allocation, to record the allocation and set its type.

Based on the approach from https://github.com/JuliaLang/julia/pull/33467.

-----

An example of the generated code:
```llvm
  %ptls_field6 = getelementptr inbounds {}**, {}*** %4, i64 2
  %13 = bitcast {}*** %ptls_field6 to i8**
  %ptls_load78 = load i8*, i8** %13, align 8
  %box = call noalias nonnull dereferenceable(32) {}* @ijl_gc_pool_alloc(i8* %ptls_load78, i32 1184, i32 32) #7
  %14 = bitcast {}* %box to i64*
  %15 = getelementptr inbounds i64, i64* %14, i64 -1
  store atomic i64 4335994192, i64* %15 unordered, align 8
  call void @ijl_maybe_record_alloc_to_profile({}* nonnull %box, i32 16, i64 4335994192)
```
(Note that now we are reporting the _true size_ of the allocated object, rather than its pool osize, when recording an allocation. Maybe that's not actually desirable? We could move this to the pool vs big alloc case to get that more precise.)