### PR TITLE
add some rep invariant checks in the pool allocator

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -1228,7 +1228,7 @@ size_t gc_count_allocd_pages_in_allocd_lists(void)
 
 size_t gc_count_mapped_pages(void)
 {
-    // to keep things consistent with `gc_count_allocd_pages_in_alloc_lists`
+    // to keep things consistent with `gc_count_allocd_pages_in_allocd_lists`
     // in the case of concurrent modification of `alloc_map` by a sweeping
     // thread
     if (jl_n_sweepthreads > 0) {

--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -19,6 +19,7 @@ extern "C" {
 #define MIN_BLOCK_PG_ALLOC (1) // 16 KB
 
 static int block_pg_cnt = DEFAULT_BLOCK_PG_ALLOC;
+size_t gc_mapped_pages;
 
 void jl_gc_init_page(void)
 {
@@ -129,6 +130,7 @@ NOINLINE jl_gc_pagemeta_t *jl_gc_alloc_page(void) JL_NOTSAFEPOINT
     }
     // must map a new set of pages
     char *data = jl_gc_try_alloc_pages();
+    gc_mapped_pages += block_pg_cnt;
     meta = (jl_gc_pagemeta_t*)malloc_s(block_pg_cnt * sizeof(jl_gc_pagemeta_t));
     for (int i = 0; i < block_pg_cnt; i++) {
         jl_gc_pagemeta_t *pg = &meta[i];

--- a/src/gc.c
+++ b/src/gc.c
@@ -1508,7 +1508,7 @@ static void gc_sweep_pool(int sweep_full)
     assert(gc_count_allocd_pages_in_allocd_map() == gc_count_allocd_pages_in_allocd_lists());
     // `jl_n_sweepthreads` is 0 or 1, and gc_count_mapped_pages in `src/gc-debug.c` returns 0
     // if `jl_n_sweepthreads` is 1
-    assert(gc_count_mapped_pages() == jl_n_sweepthreads == 0 ? gc_mapped_pages : 0);
+    assert(gc_count_mapped_pages() == (jl_n_sweepthreads == 0 ? gc_mapped_pages : 0));
     gc_time_pool_start();
     lazy_freed_pages = 0;
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -1506,8 +1506,9 @@ static void gc_sweep_pool(int sweep_full)
 {
     // run a few sanity checks before actually sweeping
     assert(gc_count_allocd_pages_in_allocd_map() == gc_count_allocd_pages_in_allocd_lists());
-    assert(gc_count_mapped_pages() == gc_mapped_pages);
-
+    // `jl_n_sweepthreads` is 0 or 1, and gc_count_mapped_pages in `src/gc-debug.c` returns 0
+    // if `jl_n_sweepthreads` is 1
+    assert(gc_count_mapped_pages() == jl_n_sweepthreads == 0 ? gc_mapped_pages : 0);
     gc_time_pool_start();
     lazy_freed_pages = 0;
 
@@ -1589,10 +1590,6 @@ static void gc_sweep_pool(int sweep_full)
         uv_sem_post(&gc_sweep_assists_needed);
     }
 #endif
-
-    // run a few sanity after sweeping as well
-    assert(gc_count_allocd_pages_in_allocd_map() == gc_count_allocd_pages_in_allocd_lists());
-    assert(gc_count_mapped_pages() == gc_mapped_pages);
 
     gc_time_pool_end(sweep_full);
 }

--- a/src/gc.c
+++ b/src/gc.c
@@ -848,6 +848,7 @@ STATIC_INLINE void gc_setmark_pool_(jl_ptls_t ptls, jl_taggedvalue_t *o,
 #ifdef MEMDEBUG
     gc_setmark_big(ptls, o, mark_mode);
 #else
+    assert(page != NULL);
     if (mark_mode == GC_OLD_MARKED) {
         ptls->gc_cache.perm_scanned_bytes += page->osize;
         static_assert(sizeof(_Atomic(uint16_t)) == sizeof(page->nold), "");
@@ -1452,6 +1453,7 @@ done:
             push_lf_page_metadata_back(&global_page_pool_freed, pg);
         }
         else {
+            gc_alloc_map_set(pg->data, 0);
             push_lf_page_metadata_back(&global_page_pool_lazily_freed, pg);
         }
     #else
@@ -1502,6 +1504,7 @@ static void gc_pool_sync_nfree(jl_gc_pagemeta_t *pg, jl_taggedvalue_t *last) JL_
 // setup the data-structures for a sweep over all memory pools
 static void gc_sweep_pool(int sweep_full)
 {
+    assert(gc_count_allocd_pages_in_allocd_map() == gc_count_allocd_pages_in_allocd_lists());
     gc_time_pool_start();
     lazy_freed_pages = 0;
 

--- a/src/gc.h
+++ b/src/gc.h
@@ -625,9 +625,11 @@ void gc_stats_big_obj(void);
 #endif
 
 // For debugging
+extern size_t gc_mapped_pages;
 void gc_count_pool(void);
 size_t gc_count_allocd_pages_in_allocd_map(void);
 size_t gc_count_allocd_pages_in_allocd_lists(void);
+size_t gc_count_mapped_pages(void);
 
 size_t jl_array_nbytes(jl_array_t *a) JL_NOTSAFEPOINT;
 

--- a/src/gc.h
+++ b/src/gc.h
@@ -626,6 +626,8 @@ void gc_stats_big_obj(void);
 
 // For debugging
 void gc_count_pool(void);
+size_t gc_count_allocd_pages_in_allocd_map(void);
+size_t gc_count_allocd_pages_in_allocd_lists(void);
 
 size_t jl_array_nbytes(jl_array_t *a) JL_NOTSAFEPOINT;
 


### PR DESCRIPTION
Some rep invariant checks to ensure we're not missing pages.

Needs more testing to see if the assertion on `assert(gc_count_allocd_pages_in_allocd_map() == gc_count_allocd_pages_in_allocd_lists());` would be prohibitively expensive on `test x86_64-linux-gnu-assertrr`