### PR TITLE
Remove `new BitCastInst` unless it's in a typed pointer context

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7271,6 +7271,7 @@ static jl_llvm_functions_t
     // allocate Function declarations and wrapper objects
     //Safe because params holds ctx lock
     Module *M = TSM.getModuleUnlocked();
+    M->addModuleFlag(Module::Warning, "julia.debug_level", ctx.emission_context.debug_level);
     jl_debugcache_t debuginfo;
     debuginfo.initialize(M);
     jl_returninfo_t returninfo = {};

--- a/src/llvm-alloc-opt.cpp
+++ b/src/llvm-alloc-opt.cpp
@@ -732,6 +732,8 @@ void Optimizer::moveToStack(CallInst *orig_inst, size_t sz, bool has_ref)
             auto replace_i = new_i;
             Type *new_t = new_i->getType();
             if (cast_t != new_t) {
+                // Shouldn't get here when using opaque pointers, so the new BitCastInst is fine
+                assert(cast_t->getContext().supportsTypedPointers());
                 replace_i = new BitCastInst(replace_i, cast_t, "", user);
                 replace_i->setDebugLoc(user->getDebugLoc());
                 replace_i->takeName(user);

--- a/src/llvm-propagate-addrspaces.cpp
+++ b/src/llvm-propagate-addrspaces.cpp
@@ -187,6 +187,8 @@ Value *PropagateJuliaAddrspacesVisitor::LiftPointer(Module *M, Value *V, Instruc
         if (LiftingMap.count(CurrentV))
             CurrentV = LiftingMap[CurrentV];
         if (CurrentV->getType() != TargetType) {
+            // Shouldn't get here when using opaque pointers, so the new BitCastInst is fine
+            assert(CurrentV->getContext().supportsTypedPointers());
             auto *BCI = new BitCastInst(CurrentV, TargetType);
             ToInsert.push_back(std::make_pair(BCI, InsertPt));
             CurrentV = BCI;

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -70,6 +70,7 @@ void LowerPTLS::set_pgcstack_attrs(CallInst *pgcstack) const
 
 Instruction *LowerPTLS::emit_pgcstack_tp(Value *offset, Instruction *insertBefore) const
 {
+    IRBuilder<> builder(insertBefore);
     Value *tls;
     if (TargetTriple.isX86() && insertBefore->getFunction()->callsFunctionThatReturnsTwice()) {
         // Workaround LLVM bug by hiding the offset computation
@@ -87,15 +88,15 @@ Instruction *LowerPTLS::emit_pgcstack_tp(Value *offset, Instruction *insertBefor
         if (offset) {
             std::vector<Type*> args(0);
             args.push_back(offset->getType());
-            auto tp = InlineAsm::get(FunctionType::get(Type::getInt8PtrTy(insertBefore->getContext()), args, false),
+            auto tp = InlineAsm::get(FunctionType::get(Type::getInt8PtrTy(builder.getContext()), args, false),
                                      dyn_asm_str, "=&r,r,~{dirflag},~{fpsr},~{flags}", false);
-            tls = CallInst::Create(tp, offset, "pgcstack_i8", insertBefore);
+            tls = builder.CreateCall(tp, {offset}, "pgcstack");
         }
         else {
             auto tp = InlineAsm::get(FunctionType::get(Type::getInt8PtrTy(insertBefore->getContext()), false),
                                      const_asm_str.c_str(), "=r,~{dirflag},~{fpsr},~{flags}",
                                      false);
-            tls = CallInst::Create(tp, "pgcstack_i8", insertBefore);
+            tls = builder.CreateCall(tp, {offset}, "tls_pgcstack");
         }
     } else {
         // AArch64/ARM doesn't seem to have this issue.
@@ -118,12 +119,12 @@ Instruction *LowerPTLS::emit_pgcstack_tp(Value *offset, Instruction *insertBefor
         }
         if (!offset)
             offset = ConstantInt::getSigned(T_size, jl_tls_offset);
-        auto tp = InlineAsm::get(FunctionType::get(Type::getInt8PtrTy(insertBefore->getContext()), false), asm_str, "=r", false);
-        tls = CallInst::Create(tp, "thread_ptr", insertBefore);
-        tls = GetElementPtrInst::Create(Type::getInt8Ty(insertBefore->getContext()), tls, {offset}, "ppgcstack_i8", insertBefore);
+        auto tp = InlineAsm::get(FunctionType::get(Type::getInt8PtrTy(builder.getContext()), false), asm_str, "=r", false);
+        tls = builder.CreateCall(tp, {}, "thread_ptr");
+        tls = builder.CreateGEP(Type::getInt8Ty(builder.getContext()), tls, {offset}, "tls_ppgcstack");
     }
-    tls = new BitCastInst(tls, T_pppjlvalue->getPointerTo(), "ppgcstack", insertBefore);
-    return new LoadInst(T_pppjlvalue, tls, "pgcstack", false, insertBefore);
+    tls = builder.CreateBitCast(tls, T_pppjlvalue->getPointerTo());
+    return builder.CreateLoad(T_pppjlvalue, tls, "tls_pgcstack");
 }
 
 GlobalVariable *LowerPTLS::create_hidden_global(Type *T, StringRef name) const
@@ -153,15 +154,16 @@ void LowerPTLS::fix_pgcstack_use(CallInst *pgcstack, Function *pgcstack_getter, 
         // if (!retboxed)
         //     foreach(retinst)
         //         emit_gc_unsafe_leave(ctx, last_gc_state);
-        auto phi = PHINode::Create(pgcstack->getType(), 2, "");
-        phi->insertAfter(pgcstack);
+        IRBuilder<> builder(pgcstack->getNextNode());
+        auto phi = builder.CreatePHI(pgcstack->getType(), 2, "pgcstack");
         pgcstack->replaceAllUsesWith(phi);
         MDBuilder MDB(pgcstack->getContext());
         SmallVector<uint32_t, 2> Weights{9, 1};
         TerminatorInst *fastTerm;
         TerminatorInst *slowTerm;
         assert(pgcstack->getType()); // Static analyzer
-        auto cmp = new ICmpInst(phi, CmpInst::ICMP_NE, pgcstack, Constant::getNullValue(pgcstack->getType()));
+        builder.SetInsertPoint(phi);
+        auto cmp = builder.CreateICmpNE(pgcstack, Constant::getNullValue(pgcstack->getType()));
         SplitBlockAndInsertIfThenElse(cmp, phi, &fastTerm, &slowTerm,
                                       MDB.createBranchWeights(Weights));
         if (CFGModified)
@@ -180,7 +182,7 @@ void LowerPTLS::fix_pgcstack_use(CallInst *pgcstack, Function *pgcstack_getter, 
         adopt->insertBefore(slowTerm);
         phi->addIncoming(adopt, slowTerm->getParent());
         // emit fast branch code
-        IRBuilder<> builder(fastTerm->getParent());
+        builder.SetInsertPoint(fastTerm->getParent());
         fastTerm->removeFromParent();
         MDNode *tbaa = tbaa_gcframe;
         Value *prior = emit_gc_unsafe_enter(builder, T_size, get_current_ptls_from_task(builder, T_size, get_current_task_from_pgcstack(builder, T_size, pgcstack), tbaa), true);
@@ -194,7 +196,7 @@ void LowerPTLS::fix_pgcstack_use(CallInst *pgcstack, Function *pgcstack_getter, 
             last_gc_state->addIncoming(prior, fastTerm->getParent());
             for (auto &BB : *pgcstack->getParent()->getParent()) {
                 if (isa<ReturnInst>(BB.getTerminator())) {
-                    IRBuilder<> builder(BB.getTerminator());
+                    builder.SetInsertPoint(BB.getTerminator());
                     emit_gc_unsafe_leave(builder, T_size, get_current_ptls_from_task(builder, T_size, get_current_task_from_pgcstack(builder, T_size, phi), tbaa), last_gc_state, true);
                 }
             }
@@ -202,16 +204,16 @@ void LowerPTLS::fix_pgcstack_use(CallInst *pgcstack, Function *pgcstack_getter, 
     }
 
     if (imaging_mode) {
+        IRBuilder<> builder(pgcstack);
         if (jl_tls_elf_support) {
             // if (offset != 0)
             //     pgcstack = tp + offset; // fast
             // else
             //     pgcstack = getter();    // slow
-            auto offset = new LoadInst(T_size, pgcstack_offset, "", false, pgcstack);
+            auto offset = builder.CreateLoad(T_size, pgcstack_offset);
             offset->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_const);
             offset->setMetadata(llvm::LLVMContext::MD_invariant_load, MDNode::get(pgcstack->getContext(), None));
-            auto cmp = new ICmpInst(pgcstack, CmpInst::ICMP_NE, offset,
-                                    Constant::getNullValue(offset->getType()));
+            auto cmp = builder.CreateICmpNE(offset, Constant::getNullValue(offset->getType()));
             MDBuilder MDB(pgcstack->getContext());
             SmallVector<uint32_t, 2> Weights{9, 1};
             TerminatorInst *fastTerm;
@@ -222,10 +224,10 @@ void LowerPTLS::fix_pgcstack_use(CallInst *pgcstack, Function *pgcstack_getter, 
                 *CFGModified = true;
 
             auto fastTLS = emit_pgcstack_tp(offset, fastTerm);
-            auto phi = PHINode::Create(T_pppjlvalue, 2, "", pgcstack);
+            auto phi = builder.CreatePHI(T_pppjlvalue, 2, "pgcstack");
             pgcstack->replaceAllUsesWith(phi);
             pgcstack->moveBefore(slowTerm);
-            auto getter = new LoadInst(T_pgcstack_getter, pgcstack_func_slot, "", false, pgcstack);
+            auto getter = builder.CreateLoad(T_pgcstack_getter, pgcstack_func_slot);
             getter->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_const);
             getter->setMetadata(llvm::LLVMContext::MD_invariant_load, MDNode::get(pgcstack->getContext(), None));
             pgcstack->setCalledFunction(pgcstack->getFunctionType(), getter);
@@ -240,14 +242,14 @@ void LowerPTLS::fix_pgcstack_use(CallInst *pgcstack, Function *pgcstack_getter, 
         // variable to be filled (in `staticdata.c`) at initialization time of the sysimg.
         // This way we can bypass the extra indirection in `jl_get_pgcstack`
         // since we may not know which getter function to use ahead of time.
-        auto getter = new LoadInst(T_pgcstack_getter, pgcstack_func_slot, "", false, pgcstack);
+        auto getter = builder.CreateLoad(T_pgcstack_getter, pgcstack_func_slot);
         getter->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_const);
         getter->setMetadata(llvm::LLVMContext::MD_invariant_load, MDNode::get(pgcstack->getContext(), None));
         if (TargetTriple.isOSDarwin()) {
-            auto key = new LoadInst(T_size, pgcstack_key_slot, "", false, pgcstack);
+            auto key = builder.CreateLoad(T_size, pgcstack_key_slot);
             key->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_const);
             key->setMetadata(llvm::LLVMContext::MD_invariant_load, MDNode::get(pgcstack->getContext(), None));
-            auto new_pgcstack = CallInst::Create(FT_pgcstack_getter, getter, {key}, "", pgcstack);
+            auto new_pgcstack = builder.CreateCall(FT_pgcstack_getter, getter, {key});
             new_pgcstack->takeName(pgcstack);
             pgcstack->replaceAllUsesWith(new_pgcstack);
             pgcstack->eraseFromParent();


### PR DESCRIPTION
We shouldn't be creating random bitcasts in opaque pointer mode since it's inefficient, so this either requires that typed pointers be present to use `new BitCastInst` or farms off that responsibility to an IRBuilder.