### PR TITLE
single uv_cond to coordinate wakeup of GC threads

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -2775,7 +2775,7 @@ void gc_mark_loop_parallel(jl_ptls_t ptls, int master)
         // Wake threads up and try to do some work
         uv_mutex_lock(&gc_threads_lock);
         jl_atomic_fetch_add(&gc_n_threads_marking, 1);
-        uv_cond_signal(&gc_threads_cond);
+        uv_cond_broadcast(&gc_threads_cond);
         uv_mutex_unlock(&gc_threads_lock);
         gc_mark_and_steal(ptls);
         jl_atomic_fetch_add(&gc_n_threads_marking, -1);

--- a/src/gc.h
+++ b/src/gc.h
@@ -429,6 +429,8 @@ STATIC_INLINE void gc_big_object_link(bigval_t *hdr, bigval_t **list) JL_NOTSAFE
     *list = hdr;
 }
 
+extern uv_mutex_t gc_threads_lock;
+extern uv_cond_t gc_threads_cond;
 extern uv_sem_t gc_sweep_assists_needed;
 extern _Atomic(int) gc_n_threads_marking;
 void gc_mark_queue_all_roots(jl_ptls_t ptls, jl_gc_markqueue_t *mq);

--- a/src/partr.c
+++ b/src/partr.c
@@ -130,11 +130,11 @@ void jl_gc_mark_threadfun(void *arg)
     free(targ);
 
     while (1) {
-        uv_mutex_lock(&ptls->sleep_lock);
+        uv_mutex_lock(&gc_threads_lock);
         while (!may_mark()) {
-            uv_cond_wait(&ptls->wake_signal, &ptls->sleep_lock);
+            uv_cond_wait(&gc_threads_cond, &gc_threads_lock);
         }
-        uv_mutex_unlock(&ptls->sleep_lock);
+        uv_mutex_unlock(&gc_threads_lock);
         gc_mark_loop_parallel(ptls, 0);
     }
 }


### PR DESCRIPTION
Should avoid going to the kernel multiple times to wake GC threads up.