### PR TITLE
Forward transpose(realQ) to Q' on 1.9

### DIFF
--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -519,6 +519,7 @@ adjoint(F::Union{QR,QRPivoted,QRCompactWY}) = Adjoint(F)
 abstract type AbstractQ{T} <: AbstractMatrix{T} end
 
 inv(Q::AbstractQ) = Q'
+transpose(Q::AbstractQ{<:Real}) = adjoint(Q)
 
 """
     QRPackedQ <: AbstractMatrix

--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -345,11 +345,6 @@ end
 *(Q::AbstractQ, B::Adjoint{<:Any,<:AbstractQ}) = Q * (B * I)
 *(Q::Adjoint{<:Any,<:AbstractQ}, B::Adjoint{<:Any,<:AbstractQ}) = Q * (B * I)
 
-*(Q::Transpose{<:AbstractFloat, <:AbstractQ}, B::AbstractQ) = parent(Q)' * B
-*(Q::AbstractQ, B::Transpose{<:AbstractFloat,<:AbstractQ}) = Q * parent(B)'
-*(Q::Transpose{<:AbstractFloat,<:AbstractQ}, B::Transpose{<:AbstractFloat,<:AbstractQ}) = parent(Q)' * parent(B)'
-
-
 # fill[stored]! methods
 fillstored!(A::Diagonal, x) = (fill!(A.diag, x); A)
 fillstored!(A::Bidiagonal, x) = (fill!(A.dv, x); fill!(A.ev, x); A)

--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -345,6 +345,11 @@ end
 *(Q::AbstractQ, B::Adjoint{<:Any,<:AbstractQ}) = Q * (B * I)
 *(Q::Adjoint{<:Any,<:AbstractQ}, B::Adjoint{<:Any,<:AbstractQ}) = Q * (B * I)
 
+*(Q::Transpose{<:AbstractFloat, <:AbstractQ}, B::AbstractQ) = parent(Q)' * B
+*(Q::AbstractQ, B::Transpose{<:AbstractFloat,<:AbstractQ}) = Q * parent(B)'
+*(Q::Transpose{<:AbstractFloat,<:AbstractQ}, B::Transpose{<:AbstractFloat,<:AbstractQ}) = parent(Q)' * parent(B)'
+
+
 # fill[stored]! methods
 fillstored!(A::Diagonal, x) = (fill!(A.diag, x); A)
 fillstored!(A::Bidiagonal, x) = (fill!(A.dv, x); fill!(A.ev, x); A)

--- a/stdlib/LinearAlgebra/test/special.jl
+++ b/stdlib/LinearAlgebra/test/special.jl
@@ -238,6 +238,9 @@ end
         @test size(Q*Q') == (m, m)
         @test Q'Q' ≈ (Q'*I) * (Q'*I) ≈ mul!(C, Q', Q')
         @test size(Q'Q') == (m, m)
+        @test transpose(Q) * Q ≈ Q'Q
+        @test Q*transpose(Q) ≈ Q*Q'
+        @test transpose(Q) * transpose(Q) ≈ Q'Q'
     end
 end
 


### PR DESCRIPTION
`transpose(Q) * Q` hangs on 1.9, while on main it forwards correctly for `Real` types (`transpose(Q)` returns an adjoint technically).

I didn't do `transpose(Q) = Q'` in case that was more problematic, this is handled more elegantly on main anyway. I can switch to that method if desired though.

@dkarrasch.