### PR TITLE
invokelatest docs should say not exported before 1.9

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -857,6 +857,9 @@ e.g. long-running event loops or callback functions that may
 call obsolete versions of a function `f`.
 (The drawback is that `invokelatest` is somewhat slower than calling
 `f` directly, and the type of the result cannot be inferred by the compiler.)
+
+!!! compat "Julia 1.9"
+    Prior to Julia 1.9, this function was not exported, and was called as `Base.invokelatest`.
 """
 function invokelatest(@nospecialize(f), @nospecialize args...; kwargs...)
     kwargs = merge(NamedTuple(), kwargs)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -2159,11 +2159,11 @@ end
 
 Provides a convenient way to call [`invokelatest`](@ref).
 `@invokelatest f(args...; kwargs...)` will simply be expanded into
-`invokelatest(f, args...; kwargs...)`.
+`Base.invokelatest(f, args...; kwargs...)`.
 
 It also supports the following syntax:
-- `@invokelatest x.f` expands to `invokelatest(getproperty, x, :f)`
-- `@invokelatest x.f = v` expands to `invokelatest(setproperty!, x, :f, v)`
+- `@invokelatest x.f` expands to `Base.invokelatest(getproperty, x, :f)`
+- `@invokelatest x.f = v` expands to `Base.invokelatest(setproperty!, x, :f, v)`
 - `@invokelatest xs[i]` expands to `invoke(getindex, xs, i)`
 - `@invokelatest xs[i] = v` expands to `invoke(setindex!, xs, v, i)`
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -2157,13 +2157,13 @@ end
 """
     @invokelatest f(args...; kwargs...)
 
-Provides a convenient way to call [`Base.invokelatest`](@ref).
+Provides a convenient way to call [`invokelatest`](@ref).
 `@invokelatest f(args...; kwargs...)` will simply be expanded into
-`Base.invokelatest(f, args...; kwargs...)`.
+`invokelatest(f, args...; kwargs...)`.
 
 It also supports the following syntax:
-- `@invokelatest x.f` expands to `Base.invokelatest(getproperty, x, :f)`
-- `@invokelatest x.f = v` expands to `Base.invokelatest(setproperty!, x, :f, v)`
+- `@invokelatest x.f` expands to `invokelatest(getproperty, x, :f)`
+- `@invokelatest x.f = v` expands to `invokelatest(setproperty!, x, :f, v)`
 - `@invokelatest xs[i]` expands to `invoke(getindex, xs, i)`
 - `@invokelatest xs[i] = v` expands to `invoke(setindex!, xs, v, i)`
 
@@ -2186,6 +2186,9 @@ julia> @macroexpand @invokelatest xs[i] = v
 
 !!! compat "Julia 1.7"
     This macro requires Julia 1.7 or later.
+
+!!! compat "Julia 1.9"
+    Prior to Julia 1.9, this macro was not exported, and was called as `Base.@invokelatest`.
 
 !!! compat "Julia 1.10"
     The additional syntax is supported as of Julia 1.10.


### PR DESCRIPTION
`invokelatest` was only exported in #45831, and it would be useful for its docstring to indicate this in a compat notice.