### PR TITLE
Add escape hatch to avoid demoting float16 operations for unknown arc…

### DIFF
--- a/src/llvm-demote-float16.cpp
+++ b/src/llvm-demote-float16.cpp
@@ -66,6 +66,9 @@ static bool have_fp16(Function &caller, const Triple &TT) {
             return true;
         }
     }
+    if (caller.hasFnAttribute("julia.hasfp16")) {
+        return true;
+    }
     return false;
 }
 


### PR DESCRIPTION
…hitectures.

The old pipeline separated the DemoteFloat16 pass as a machine pass, and therefore GPUCompiler would never run it. Rather than have this split pipeline for the new pass manager, I think it's better to just turn the pass into a no-op when specifically requested, so that we have the same pipeline regardless of architecture. 