### PR TITLE
Move ccall tests to node 1 on 32 bit

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,9 @@ function move_to_node1(t)
 end
 
 # Base.compilecache only works from node 1, so precompile test is handled specially
+if Int == Int32
+    move_to_node1("ccall") # ccall seems to be test that most often OOMs on 32-bit
+end
 move_to_node1("precompile")
 move_to_node1("SharedArrays")
 move_to_node1("threads")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,9 +71,7 @@ function move_to_node1(t)
 end
 
 # Base.compilecache only works from node 1, so precompile test is handled specially
-if Int == Int32
-    move_to_node1("ccall") # ccall seems to be test that most often OOMs on 32-bit
-end
+move_to_node1("ccall")
 move_to_node1("precompile")
 move_to_node1("SharedArrays")
 move_to_node1("threads")


### PR DESCRIPTION
The ccall tests seems to be a very common failure point so move it to node 1 because it usually has less maxrss