### PR TITLE
Restore link to list of packages in Base docs

### DIFF
--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -4,7 +4,8 @@
 
 Julia Base contains a range of functions and macros appropriate for performing
 scientific and numerical computing, but is also as broad as those of many general purpose programming
-languages.  Additional functionality is available from a growing collection of available packages.
+languages.  Additional functionality is available from a growing collection of
+[available packages](https://julialang.org/packages/).
 Functions are grouped by topic below.
 
 Some general notes:


### PR DESCRIPTION
This link used to exist in the docs [up to v0.2](https://web.archive.org/web/20151229003216/http://docs.julialang.org/en/release-0.2/stdlib/base/), but it was removed in e91294f47516787ac8648f59e6c6f1abb9e47557 as it was pointing to a doc page that was removed in ef0c44d0fa865a38aefc26b138367ba6c0b4cda5 (PR #7204).

This change restores the link in the original place, pointing to the up-to-date location: https://julialang.org/packages/.