### PR TITLE
Add missing root for method instances used in opaque closure

### DIFF
--- a/src/debug-registry.h
+++ b/src/debug-registry.h
@@ -137,7 +137,7 @@ public:
     jl_method_instance_t *lookupLinfo(size_t pointer) JL_NOTSAFEPOINT;
     void registerJITObject(const llvm::object::ObjectFile &Object,
                         std::function<uint64_t(const llvm::StringRef &)> getLoadAddress,
-                        std::function<void*(void*)> lookupWriteAddress) JL_NOTSAFEPOINT;
+                        std::function<void*(void*)> lookupWriteAddress);
     objectmap_t& getObjectMap() JL_NOTSAFEPOINT;
     void add_image_info(image_info_t info) JL_NOTSAFEPOINT;
     bool get_image_info(uint64_t base, image_info_t *info) const JL_NOTSAFEPOINT;

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -690,7 +690,7 @@ void JuliaOJIT::OptSelLayerT::emit(std::unique_ptr<orc::MaterializationResponsib
 
 void jl_register_jit_object(const object::ObjectFile &debugObj,
                             std::function<uint64_t(const StringRef &)> getLoadAddress,
-                            std::function<void *(void *)> lookupWriteAddress) JL_NOTSAFEPOINT;
+                            std::function<void *(void *)> lookupWriteAddress);
 
 namespace {
 


### PR DESCRIPTION
Usually the rooting path for method instances is something like this:

Module -> DataType -> TypeName -> MethodTable -> Method -> MethodInstance

so these MethodInstances are effectively globally rooted. However, the Method(instances) inside opaque closures do not have this rooting path and can be deleted. Unfortunately, if we codegen'ed these opaque closures, we do have a reference to the method instance in our global debuginfo tables. This was causing crashes in cases where the oc was gc'ed before a stack trace could be printed. Fix that by adding any method instance that needs to be rooted to the global roots table.

Reported by @staticfloat 