### PR TITLE
[WIP] Ensure that 1-based axes are insulated from `OffsetArrays`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -833,7 +833,7 @@ similar(a::AbstractArray, ::Type{T}, dims::DimOrInd...) where {T}  = similar(a, 
 # but we don't want to require all AbstractArray subtypes to dispatch on Base.OneTo. So instead we
 # define this method to convert supported axes to Ints, with the expectation that an offset array
 # package will define a method with dims::Tuple{Union{Integer, UnitRange}, Vararg{Union{Integer, UnitRange}}}
-similar(a::AbstractArray, ::Type{T}, dims::Tuple{Union{Integer, OneTo}, Vararg{Union{Integer, OneTo}}}) where {T} = similar(a, T, to_shape(dims))
+similar(a::AbstractArray, ::Type{T}, dims::Tuple{Union{Integer, AbstractOneTo}, Vararg{Union{Integer, AbstractOneTo}}}) where {T} = similar(a, T, to_shape(dims))
 similar(a::AbstractArray, ::Type{T}, dims::Tuple{Integer, Vararg{Integer}}) where {T} = similar(a, T, to_shape(dims))
 # similar creates an Array by default
 similar(a::AbstractArray, ::Type{T}, dims::Dims{N}) where {T,N}    = Array{T,N}(undef, dims)
@@ -844,7 +844,7 @@ to_shape(dims::DimsOrInds) = map(to_shape, dims)::DimsOrInds
 # each dimension
 to_shape(i::Int) = i
 to_shape(i::Integer) = Int(i)
-to_shape(r::OneTo) = Int(last(r))
+to_shape(r::AbstractOneTo) = Int(last(r))
 to_shape(r::AbstractUnitRange) = r
 
 """
@@ -870,7 +870,7 @@ would create a 1-dimensional logical array whose indices match those
 of the columns of `A`.
 """
 similar(::Type{T}, dims::DimOrInd...) where {T<:AbstractArray} = similar(T, dims)
-similar(::Type{T}, shape::Tuple{Union{Integer, OneTo}, Vararg{Union{Integer, OneTo}}}) where {T<:AbstractArray} = similar(T, to_shape(shape))
+similar(::Type{T}, shape::Tuple{Union{Integer, AbstractOneTo}, Vararg{Union{Integer, AbstractOneTo}}}) where {T<:AbstractArray} = similar(T, to_shape(shape))
 similar(::Type{T}, dims::Dims) where {T<:AbstractArray} = T(undef, dims)
 
 """

--- a/base/range.jl
+++ b/base/range.jl
@@ -440,13 +440,21 @@ if isdefined(Main, :Base)
 end
 
 """
+    Base.AbstractOneTo{T}
+
+Abstract type for axes that begin at `1`.
+Custom axis types that seek to guarantee 1-based indexing may
+choose to be a subtype of `AbstractOneTo`.
+"""
+abstract type AbstractOneTo{T} <: AbstractUnitRange{T} end
+"""
     Base.OneTo(n)
 
 Define an `AbstractUnitRange` that behaves like `1:n`, with the added
 distinction that the lower limit is guaranteed (by the type system) to
 be 1.
 """
-struct OneTo{T<:Integer} <: AbstractUnitRange{T}
+struct OneTo{T<:Integer} <: AbstractOneTo{T}
     stop::T
     function OneTo{T}(stop) where {T<:Integer}
         throwbool(r)  = (@noinline; throw(ArgumentError("invalid index: $r of type Bool")))

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -108,7 +108,7 @@ julia> reshape(1:6, 2, 3)
 reshape
 
 reshape(parent::AbstractArray, dims::IntOrInd...) = reshape(parent, dims)
-reshape(parent::AbstractArray, shp::Tuple{Union{Integer,OneTo}, Vararg{Union{Integer,OneTo}}}) = reshape(parent, to_shape(shp))
+reshape(parent::AbstractArray, shp::Tuple{Union{Integer,AbstractOneTo}, Vararg{Union{Integer,AbstractOneTo}}}) = reshape(parent, to_shape(shp))
 reshape(parent::AbstractArray, dims::Dims)        = _reshape(parent, dims)
 
 # Allow missing dimensions with Colon():


### PR DESCRIPTION
`OffsetArrays` commits type-piracy on `similar` and `reshape`, which may impact packages in unexpected ways (e.g. https://github.com/rafaqz/DimensionalData.jl/issues/464#issuecomment-1437217274). This PR introduces an abstract type `AbstractOneTo` that custom axis types may choose to subtype, which would ensure that such axes will always use the methods from `Base`. This was the original idea behind `OneTo`, but there are other `OneTo`-like axis types proliferating in the wild, e.g. `SOneTo` from `StaticArrays` which also should not be impacted by `OffsetArrays`.

Closes https://github.com/JuliaLang/julia/issues/41946. Ideally, this insulation from `OffsetArrays` would be implemented through a trait instead of a type, but this PR may be a starting point. This doesn't solve the issue for wrapper axis types, which is where traits might be more suitable.