### PR TITLE
Fix typos in symmetric eigendecomposition code

### DIFF
--- a/stdlib/LinearAlgebra/src/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/src/symmetriceigen.jl
@@ -158,7 +158,7 @@ eigmin(A::RealHermSymComplexHerm{<:Real}) = eigvals(A, 1:1)[1]
 
 function eigen(A::HermOrSym{TA}, B::HermOrSym{TB}; kws...) where {TA,TB}
     S = promote_type(eigtype(TA), TB)
-    return eigen!(eigencopy_oftype{S}(A), eigencopy_oftype(B, S); kws...)
+    return eigen!(eigencopy_oftype(A, S), eigencopy_oftype(B, S); kws...)
 end
 
 function eigen!(A::HermOrSym{T,S}, B::HermOrSym{T,S}; sortby::Union{Function,Nothing}=nothing) where {T<:BlasReal,S<:StridedMatrix}
@@ -192,7 +192,7 @@ _UtiAUi!(A, U) = rdiv!(ldiv!(U', A), U)
 
 function eigvals(A::HermOrSym{TA}, B::HermOrSym{TB}; kws...) where {TA,TB}
     S = promote_type(eigtype(TA), TB)
-    return eigen!(eigencopy_oftype{S}(A), eigencopy_oftype(B, S); kws...)
+    return eigvals!(eigencopy_oftype(A, S), eigencopy_oftype(B, S); kws...)
 end
 
 function eigvals!(A::HermOrSym{T,S}, B::HermOrSym{T,S}; sortby::Union{Function,Nothing}=nothing) where {T<:BlasReal,S<:StridedMatrix}

--- a/stdlib/LinearAlgebra/test/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/test/symmetriceigen.jl
@@ -47,26 +47,32 @@ end
     e0,v0 = eigen(A, B)
     e1,v1 = eigen(A, Symmetric(B))
     e2,v2 = eigen(Symmetric(A), B)
+    e3,v3 = eigen(Symmetric(A), Symmetric(B))
     @test e0 ≈ e1 && v0 ≈ v1
     @test e0 ≈ e2 && v0 ≈ v2
+    @test e0 ≈ e3 && v0 ≈ v3
     # eigvals
     @test eigvals(A, B) ≈ eigvals(A, Symmetric(B))
     @test eigvals(A, B) ≈ eigvals(Symmetric(A), B)
+    @test eigvals(A, B) ≈ eigvals(Symmetric(A), Symmetric(B))
 
     ## Complex valued
     A =  [1.0+im 1.0+1.0im 0 0; 1.0+1.0im 2.0+3.0im 1.0+1.0im 0; 0 1.0+2.0im 3.0+4.0im 1.0+5.0im; 0 0 1.0+1.0im 4.0+4.0im]
-    AH = (A+A')/2
+    AH = A'A
     B =  [2.0+2.0im 1.0+1.0im 4.0+4.0im 3.0+3.0im; 0 3.0+2.0im 1.0+1.0im 3.0+4.0im; 3.0+3.0im 1.0+4.0im 0 0; 0 1.0+2.0im 3.0+1.0im 1.0+1.0im]
-    BH = (B+B')/2
+    BH = B'B
     # eigen
     sf = x->(real(x),imag(x))
     e1,v1 = eigen(A, Hermitian(BH))
-    e2,v2 = eigen(Hermitian(AH), B)
     @test A*v1 ≈ Hermitian(BH)*v1*Diagonal(e1)
+    e2,v2 = eigen(Hermitian(AH), B)
     @test Hermitian(AH)*v2 ≈ B*v2*Diagonal(e2)
+    e3,v3 = eigen(Hermitian(AH), Hermitian(BH))
+    @test Hermitian(AH)*v3 ≈ Hermitian(BH)*v3*Diagonal(e3)
     # eigvals
     @test eigvals(A, BH; sortby=sf) ≈ eigvals(A, Hermitian(BH); sortby=sf)
     @test eigvals(AH, B; sortby=sf) ≈ eigvals(Hermitian(AH), B; sortby=sf)
+    @test eigvals(AH, BH; sortby=sf) ≈ eigvals(Hermitian(AH), Hermitian(BH); sortby=sf)
 end
 
 end # module TestSymmetricEigen

--- a/stdlib/LinearAlgebra/test/testgroups
+++ b/stdlib/LinearAlgebra/test/testgroups
@@ -27,3 +27,4 @@ pinv
 factorization
 abstractq
 ldlt
+symmetriceigen


### PR DESCRIPTION
Those functions were uncovered and hence the typos were not revealed.