### PR TITLE
add note to CONTRIBUTING.md about making issues and PR names self explanatory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,14 @@ At the moment, this should always be done with the following `compat` admonition
 
 *By contributing code to Julia, you are agreeing to release it under the [MIT License](https://github.com/JuliaLang/julia/tree/master/LICENSE.md).*
 
-The Julia community uses [GitHub issues](https://github.com/JuliaLang/julia/issues) to track and discuss problems, feature requests, and pull requests (PR). You can make pull requests for incomplete features to get code review. The convention is to prefix the pull request title with "WIP:" for Work In Progress, or "RFC:" for Request for Comments when work is completed and ready for merging. This will prevent accidental merging of work that is in progress.
+The Julia community uses [GitHub issues](https://github.com/JuliaLang/julia/issues) to track and discuss problems, feature requests, and pull requests (PR).
+
+Issues and pull requests should have self explanatory titles such that they can be understood from the list of PRs and Issues.
+i.e. `Add feature x`, `Fix feature x`, `Add feature x (#12345) - fixup` are good, `Fixup #12345` is bad.
+
+You can make pull requests for incomplete features to get code review. The convention is to open these a draft PRs and prefix
+the pull request title with "WIP:" for Work In Progress, or "RFC:" for Request for Comments when work is completed and ready
+for merging. This will prevent accidental merging of work that is in progress.
 
 Note: These instructions are for adding to or improving functionality in the base library. Before getting started, it can be helpful to discuss the proposed changes or additions on the [Julia Discourse forum](https://discourse.julialang.org) or in a GitHub issue---it's possible your proposed change belongs in a package rather than the core language. Also, keep in mind that changing stuff in the base can potentially break a lot of things. Finally, because of the time required to build Julia, note that it's usually faster to develop your code in stand-alone files, get it working, and then migrate it into the base libraries.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,7 @@ At the moment, this should always be done with the following `compat` admonition
 The Julia community uses [GitHub issues](https://github.com/JuliaLang/julia/issues) to track and discuss problems, feature requests, and pull requests (PR).
 
 Issues and pull requests should have self explanatory titles such that they can be understood from the list of PRs and Issues.
-i.e. `Add feature x`, `Fix feature x`, `Add feature x (#12345) - fixup` are good, `Fixup #12345` is bad.
+i.e. `Add feature x` and `Fix issue x` are good, `Fix #12345. Corrects the bug.` is bad.
 
 You can make pull requests for incomplete features to get code review. The convention is to open these a draft PRs and prefix
 the pull request title with "WIP:" for Work In Progress, or "RFC:" for Request for Comments when work is completed and ready

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,7 @@ At the moment, this should always be done with the following `compat` admonition
 The Julia community uses [GitHub issues](https://github.com/JuliaLang/julia/issues) to track and discuss problems, feature requests, and pull requests (PR).
 
 Issues and pull requests should have self explanatory titles such that they can be understood from the list of PRs and Issues.
-i.e. `Add feature x` and `Fix issue x` are good, `Fix #12345. Corrects the bug.` is bad.
+i.e. `Add {feature}` and `Fix {bug}` are good, `Fix #12345. Corrects the bug.` is bad.
 
 You can make pull requests for incomplete features to get code review. The convention is to open these a draft PRs and prefix
 the pull request title with "WIP:" for Work In Progress, or "RFC:" for Request for Comments when work is completed and ready


### PR DESCRIPTION
I think this would be a good thing to require