### PR TITLE
update newpages pointer after actually sweeping pages

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1541,7 +1541,6 @@ static void gc_sweep_pool(int sweep_full)
                 pg->nfree = (GC_PAGE_SZ - (last_p - gc_page_data(last_p - 1))) / p->osize;
                 pg->has_young = 1;
             }
-            p->newpages = NULL;
         }
         jl_gc_pagemeta_t *pg = ptls2->page_metadata_lazily_freed;
         while (pg != NULL) {
@@ -1563,6 +1562,10 @@ static void gc_sweep_pool(int sweep_full)
                 pg = pg2;
             }
             ptls2->page_metadata_allocd = allocd;
+            for (int i = 0; i < JL_GC_N_POOLS; i++) {
+                jl_gc_pool_t *p = &ptls2->heap.norm_pools[i];
+                p->newpages = NULL;
+            }
         }
     }
 


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/50357 modified the sweeping code so that all objects past the `p->newpages` pointer were inserted into the freelist.

I believe this means that we should reset `p->newpages` **after** sweeping, otherwise the code introduced in https://github.com/JuliaLang/julia/pull/50357 becomes a no-op since `gc_sweep_pool_page` will always observe `p->newpages == NULL`.