### PR TITLE
Expose PassBuilder callback registration via C api

### DIFF
--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -112,6 +112,8 @@ JL_DLLEXPORT void jl_add_optimization_passes_fallback(void *PM, int opt_level, i
 JL_DLLEXPORT void jl_build_newpm_pipeline_fallback(void *MPM, void *PB, int Speedup, int Size,
     int lower_intrinsics, int dump_native, int external_use, int llvm_only) UNAVAILABLE
 
+JL_DLLEXPORT void jl_register_passbuilder_callbacks_fallback(void *PB) { }
+
 JL_DLLEXPORT void LLVMExtraAddLowerSimdLoopPass_fallback(void *PM) UNAVAILABLE
 
 JL_DLLEXPORT void LLVMExtraAddFinalLowerGCPass_fallback(void *PM) UNAVAILABLE

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -559,6 +559,7 @@
     YY(jl_get_libllvm) \
     YY(jl_add_optimization_passes) \
     YY(jl_build_newpm_pipeline) \
+    YY(jl_register_passbuilder_callbacks) \
     YY(LLVMExtraAddLowerSimdLoopPass) \
     YY(LLVMExtraAddFinalLowerGCPass) \
     YY(LLVMExtraAddPropagateJuliaAddrspaces) \

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -691,7 +691,7 @@ PIC.addClassToPassName(decltype(CREATE_PASS)::name(), NAME);
                 AA.registerFunctionAnalysis<ScopedNoAliasAA>();
                 AA.registerFunctionAnalysis<TypeBasedAA>();
             }
-            // TM->registerDefaultAliasAnalyses(AA);
+            TM->registerDefaultAliasAnalyses(AA);
             return AA;
         });
         // Register our TargetLibraryInfoImpl.

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -819,7 +819,7 @@ static llvm::Optional<std::pair<OptimizationLevel, OptimizationOptions>> parseJu
 // NOTE: Instead of exporting all the constructors in passes.h we could
 // forward the callbacks to the respective passes. LLVM seems to prefer this,
 // and when we add the full pass builder having them directly will be helpful.
-void registerCallbacks(PassBuilder &PB) JL_NOTSAFEPOINT {
+static void registerCallbacks(PassBuilder &PB) JL_NOTSAFEPOINT {
     auto PIC = PB.getPassInstrumentationCallbacks();
     if (PIC) {
         adjustPIC(*PIC);
@@ -897,6 +897,11 @@ void registerCallbacks(PassBuilder &PB) JL_NOTSAFEPOINT {
 #undef LOOP_PASS
             return false;
         });
+}
+
+extern "C" JL_DLLEXPORT_CODEGEN
+void jl_register_passbuilder_callbacks_impl(void *PB) JL_NOTSAFEPOINT {
+    registerCallbacks(*static_cast<PassBuilder*>(PB));
 }
 
 extern "C" JL_DLLEXPORT_CODEGEN


### PR DESCRIPTION
Opt has an interface to do this to, except it accepts a C++ function that takes a reference. Thus we need a different API entrypoint for actual C API users who want to register our PassBuilder parsing callbacks.