### PR TITLE
allow `show_tuple_as_call` to be used for abstract call signature

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -23,8 +23,10 @@ function show(io::IO, ::MIME"text/plain", r::LinRange)
     print_range(io, r)
 end
 
-function _isself(@nospecialize(ft))
-    name = ft.name.mt.name
+function _isself(ft::DataType)
+    ftname = ft.name
+    isdefined(ftname, :mt) || return false
+    name = ftname.mt.name
     mod = parentmodule(ft)  # NOTE: not necessarily the same as ft.name.mt.module
     return isdefined(mod, name) && ft == typeof(getfield(mod, name))
 end
@@ -2128,7 +2130,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
 
     # comparison (i.e. "x < y < z")
     elseif head === :comparison && nargs >= 3 && (nargs&1==1)
-        comp_prec = minimum(operator_precedence, args[2:2:end])
+        comp_prec = minimum(operator_precedence, args[2:2:end]; init=typemax(Int))
         if comp_prec <= prec
             show_enclosed_list(io, '(', args, " ", ')', indent, comp_prec, quote_level)
         else

--- a/test/show.jl
+++ b/test/show.jl
@@ -2630,3 +2630,8 @@ end
     ir = Core.Compiler.complete(compact)
     verify_display(ir)
 end
+
+let buf = IOBuffer()
+    Base.show_tuple_as_call(buf, Symbol(""), Tuple{Function,Any})
+    @test String(take!(buf)) == "(::Function)(::Any)"
+end


### PR DESCRIPTION
Improving its robustness.