### PR TITLE
Extend `parent` for `IdentityUnitRange`

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -405,6 +405,8 @@ end
 IdentityUnitRange(S::IdentityUnitRange) = S
 IdentityUnitRange{T}(S::IdentityUnitRange) where {T<:AbstractUnitRange} = IdentityUnitRange{T}(T(S.indices))
 
+parent(S::IdentityUnitRange) = S.indices
+
 # IdentityUnitRanges are offset and thus have offset axes, so they are their own axes
 axes(S::IdentityUnitRange) = (S,)
 axes1(S::IdentityUnitRange) = S

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2329,8 +2329,8 @@ end
 end
 
 @testset "IdentityUnitRange" begin
-    @test parent(IdentityUnitRange(2:3)) === 2:3
-    @test parent(IdentityUnitRange(Base.OneTo(3))) === Base.OneTo(3)
+    @test parent(Base.IdentityUnitRange(2:3)) === 2:3
+    @test parent(Base.IdentityUnitRange(Base.OneTo(3))) === Base.OneTo(3)
 end
 
 @testset "Indexing OneTo with IdentityUnitRange" begin

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2328,6 +2328,11 @@ end
     @test 0.2 * (-2:2:2) == [-0.4, 0, 0.4]
 end
 
+@testset "IdentityUnitRange" begin
+    @test parent(IdentityUnitRange(2:3)) === 2:3
+    @test parent(IdentityUnitRange(Base.OneTo(3))) === Base.OneTo(3)
+end
+
 @testset "Indexing OneTo with IdentityUnitRange" begin
     for endpt in Any[10, big(10), UInt(10)]
         r = Base.OneTo(endpt)


### PR DESCRIPTION
On master
```julia
julia> Base.IdentityUnitRange(3:4) |> parent
Base.IdentityUnitRange(3:4)

julia> Base.IdentityUnitRange(3:4) |> parent |> axes
(Base.IdentityUnitRange(3:4),)
```
After this PR
```julia
julia> Base.IdentityUnitRange(3:4) |> parent
3:4

julia> Base.IdentityUnitRange(3:4) |> parent |> axes
(Base.OneTo(2),)
```
This fits the definition of `parent`, which is meant to remove wrappers, although this changes the axes of the parent. I'd be surprised if anyone depends on this, though, since the previous behavior was `axes(parent(r)) == axes(r)`, and there was no reason to use the former.