### PR TITLE
Extend ifelse lifting to regular SROA

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -879,6 +879,9 @@ function insert_node!(compact::IncrementalCompact, @nospecialize(before), newins
             return os
         end
     elseif isa(before, NewSSAValue)
+        # As above, new_new_nodes must get counted. We don't visit them during our compact,
+        # so they're immediately considered reified.
+        count_added_node!(compact, newinst.stmt)
         # TODO: This is incorrect and does not maintain ordering among the new nodes
         before_entry = compact.new_new_nodes.info[-before.id]
         newline = something(newinst.line, compact.new_new_nodes.stmts[-before.id][:line])


### PR DESCRIPTION
It was only active for comparison lifting, but it is sensible for regular SROA also. While I was doing this I also found another oracle undercount bug (fixed here) as well as an overcount bug (https://github.com/JuliaLang/julia/pull/50312#discussion_r1251286003).