### PR TITLE
Fill diagonals for structured block matrices using `diagzero`

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -118,8 +118,8 @@ Bidiagonal(A::Bidiagonal) = A
 Bidiagonal{T}(A::Bidiagonal{T}) where {T} = A
 Bidiagonal{T}(A::Bidiagonal) where {T} = Bidiagonal{T}(A.dv, A.ev, A.uplo)
 
-bidiagzero(::Bidiagonal{T}, i, j) where {T} = zero(T)
-function bidiagzero(A::Bidiagonal{<:AbstractMatrix}, i, j)
+diagzero(::Bidiagonal{T}, i, j) where {T} = zero(T)
+function diagzero(A::Bidiagonal{<:AbstractMatrix}, i, j)
     Tel = eltype(eltype(A.dv))
     if i < j && A.uplo == 'U' #= top right zeros =#
         return zeros(Tel, size(A.ev[i], 1), size(A.ev[j-1], 2))
@@ -152,7 +152,7 @@ end
     elseif A.uplo == 'L' && (i == j + 1)
         return @inbounds A.ev[j]
     else
-        return bidiagzero(A, i, j)
+        return diagzero(A, i, j)
     end
 end
 

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -372,7 +372,7 @@ function triu!(M::Bidiagonal{T}, k::Integer=0) where T
     return M
 end
 
-function diag(M::Bidiagonal{T}, n::Integer=0) where T
+function diag(M::Bidiagonal, n::Integer=0)
     # every branch call similar(..., ::Int) to make sure the
     # same vector type is returned independent of n
     if n == 0
@@ -380,7 +380,8 @@ function diag(M::Bidiagonal{T}, n::Integer=0) where T
     elseif (n == 1 && M.uplo == 'U') ||  (n == -1 && M.uplo == 'L')
         return copyto!(similar(M.ev, length(M.ev)), M.ev)
     elseif -size(M,1) <= n <= size(M,1)
-        return fill!(similar(M.dv, size(M,1)-abs(n)), zero(T))
+        v = similar(M.dv, size(M,1)-abs(n))
+        return filldiagzero!(v, M, n)
     else
         throw(ArgumentError(string("requested diagonal, $n, must be at least $(-size(M, 1)) ",
             "and at most $(size(M, 2)) for an $(size(M, 1))-by-$(size(M, 2)) matrix")))

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -110,12 +110,12 @@ AbstractMatrix{T}(D::Diagonal) where {T} = Diagonal{T}(D)
 Matrix(D::Diagonal{T}) where {T} = Matrix{promote_type(T, typeof(zero(T)))}(D)
 Array(D::Diagonal{T}) where {T} = Matrix(D)
 
-function fillzero!(B, D)
+function fillzero!(B, D::AbstractMatrix{<:AbstractMatrix})
     B .= zero.(D)
     return B
 end
-function fillzero!(B, D::AbstractMatrix{<:Number})
-    B .= zero(eltype(D))
+function fillzero!(B, D)
+    fill!(B, zero(eltype(B)))
     return B
 end
 
@@ -696,9 +696,9 @@ adjoint(D::Diagonal) = Diagonal(adjoint.(D.diag))
 permutedims(D::Diagonal) = D
 permutedims(D::Diagonal, perm) = (Base.checkdims_perm(D, D, perm); D)
 
-filldiagzero!(v, D::AbstractMatrix{<:Number}, k) = fill!(v, zero(eltype(D)))
+filldiagzero!(v, D::AbstractMatrix, k) = fill!(v, zero(eltype(D)))
 
-function filldiagzero!(v, D::AbstractMatrix, k)
+function filldiagzero!(v, D::AbstractMatrix{<:AbstractMatrix}, k)
     dinds = diagind(D,k)
     length(v) == length(dinds) ||
         throw(ArgumentError("length of the destination is incompatible with the diagonal"))

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -685,13 +685,23 @@ adjoint(D::Diagonal) = Diagonal(adjoint.(D.diag))
 permutedims(D::Diagonal) = D
 permutedims(D::Diagonal, perm) = (Base.checkdims_perm(D, D, perm); D)
 
+filldiagzero!(v, D::Diagonal{<:Number}, k) = fill!(v, zero(T))
+
+function filldiagzero!(v, D::Diagonal, k)
+    for (i,di) in zip(eachindex(v), diagind(D,k))
+        v[i] = D[di]
+    end
+    v
+end
+
 function diag(D::Diagonal{T}, k::Integer=0) where T
     # every branch call similar(..., ::Int) to make sure the
     # same vector type is returned independent of k
     if k == 0
         return copyto!(similar(D.diag, length(D.diag)), D.diag)
     elseif -size(D,1) <= k <= size(D,1)
-        return fill!(similar(D.diag, size(D,1)-abs(k)), zero(T))
+        v = similar(D.diag, size(D,1)-abs(k))
+        return filldiagzero!(v, D, k)
     else
         throw(ArgumentError(string("requested diagonal, $k, must be at least $(-size(D, 1)) ",
             "and at most $(size(D, 2)) for an $(size(D, 1))-by-$(size(D, 2)) matrix")))

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -685,9 +685,9 @@ adjoint(D::Diagonal) = Diagonal(adjoint.(D.diag))
 permutedims(D::Diagonal) = D
 permutedims(D::Diagonal, perm) = (Base.checkdims_perm(D, D, perm); D)
 
-filldiagzero!(v, D::Diagonal{<:Number}, k) = fill!(v, zero(eltype(D)))
+filldiagzero!(v, D::AbstractMatrix{<:Number}, k) = fill!(v, zero(eltype(D)))
 
-function filldiagzero!(v, D::Diagonal, k)
+function filldiagzero!(v, D::AbstractMatrix, k)
     dinds = diagind(D,k)
     for i in eachindex(v)
         v[i] = D[dinds[i]]

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -689,8 +689,14 @@ filldiagzero!(v, D::AbstractMatrix{<:Number}, k) = fill!(v, zero(eltype(D)))
 
 function filldiagzero!(v, D::AbstractMatrix, k)
     dinds = diagind(D,k)
+    length(v) == length(dinds) ||
+        throw(ArgumentError("length of the destination is incompatible with the diagonal"))
+    isempty(dinds) && return v
+    CIstart = CartesianIndices(D)[first(dinds)]
+    Cstep = CartesianIndex(1,1)
     for i in eachindex(v)
-        v[i] = D[dinds[i]]
+        CI = CIstart + (i-firstindex(v)) * Cstep
+        v[i] = diagzero(D, Tuple(CI)...)
     end
     v
 end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -685,16 +685,17 @@ adjoint(D::Diagonal) = Diagonal(adjoint.(D.diag))
 permutedims(D::Diagonal) = D
 permutedims(D::Diagonal, perm) = (Base.checkdims_perm(D, D, perm); D)
 
-filldiagzero!(v, D::Diagonal{<:Number}, k) = fill!(v, zero(T))
+filldiagzero!(v, D::Diagonal{<:Number}, k) = fill!(v, zero(eltype(D)))
 
 function filldiagzero!(v, D::Diagonal, k)
-    for (i,di) in zip(eachindex(v), diagind(D,k))
-        v[i] = D[di]
+    dinds = diagind(D,k)
+    for i in eachindex(v)
+        v[i] = D[dinds[i]]
     end
     v
 end
 
-function diag(D::Diagonal{T}, k::Integer=0) where T
+function diag(D::Diagonal, k::Integer=0)
     # every branch call similar(..., ::Int) to make sure the
     # same vector type is returned independent of k
     if k == 0

--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -15,9 +15,7 @@ Diagonal(A::Bidiagonal) = Diagonal(A.dv)
 SymTridiagonal(A::Bidiagonal) =
     iszero(A.ev) ? SymTridiagonal(A.dv, A.ev) :
         throw(ArgumentError("matrix cannot be represented as SymTridiagonal"))
-Tridiagonal(A::Bidiagonal) =
-    Tridiagonal(A.uplo == 'U' ? fill!(similar(A.ev), 0) : A.ev, A.dv,
-                A.uplo == 'U' ? A.ev : fill!(similar(A.ev), 0))
+Tridiagonal(A::Bidiagonal) = Tridiagonal{eltype(A)}(A)
 
 # conversions from SymTridiagonal to other special matrix types
 Diagonal(A::SymTridiagonal) = Diagonal(A.dv)

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -776,9 +776,9 @@ using .Main.ImmutableArrays
 end
 
 @testset "block-bidiagonal matrix indexing" begin
-    dv = [ones(4,3), ones(2,2).*2, ones(2,3).*3, ones(4,4).*4]
-    evu = [ones(4,2), ones(2,3).*2, ones(2,4).*3]
-    evl = [ones(2,3), ones(2,2).*2, ones(4,3).*3]
+    dv = [ones(4,3), fill(2.0,2,2), fill(3.0,2,3), fill(4.0,4,4)]
+    evu = [ones(4,2), fill(2.0,2,3), fill(3.0,2,4)]
+    evl = [ones(2,3), fill(3.0,2,2), fill(3.0,4,3)]
     BU = Bidiagonal(dv, evu, :U)
     BL = Bidiagonal(dv, evl, :L)
     # check that all the matrices along a column have the same number of columns,
@@ -797,6 +797,12 @@ end
             @test iszero(BL[i,j])
         end
     end
+
+    @test diag(BU, -3) == [zeros(4,3)]
+    @test diag(BU, -2) == [zeros(2,3), zeros(4,2)]
+    @test diag(BU, -1) == [zeros(2,3), zeros(2,2), zeros(4,3)]
+    @test diag(BU, 2) == [zeros(4,3), zeros(2,4)]
+    @test diag(BU, 3) == [zeros(4,4)]
 
     M = ones(2,2)
     for n in 0:1

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -775,7 +775,7 @@ using .Main.ImmutableArrays
     @test convert(AbstractMatrix{Float64}, Bl)::Bidiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Bl
 end
 
-@testset "block-bidiagonal matrix indexing" begin
+@testset "block-bidiagonal matrix" begin
     dv = [ones(4,3), fill(2.0,2,2), fill(3.0,2,3), fill(4.0,4,4)]
     evu = [ones(4,2), fill(2.0,2,3), fill(3.0,2,4)]
     evl = [ones(2,3), fill(3.0,2,2), fill(3.0,4,3)]
@@ -805,11 +805,58 @@ end
     @test diag(BU, 3) == [zeros(4,4)]
 
     M = ones(2,2)
-    for n in 0:1
-        dv = fill(M, n)
-        ev = fill(M, 0)
+    for n in 0:3
+        local dv = fill(M, n)
+        local ev = fill(M, max(0,n-1))
         B = Bidiagonal(dv, ev, :U)
         @test B == Matrix{eltype(B)}(B)
+    end
+
+    @testset "triu!/tril!" begin
+        @testset "L" begin
+            BL2 = Bidiagonal(copy(dv), copy(evl), :L)
+            tril!(BL2, 0)
+            @test BL2 == BL
+            triu!(BL2, -1)
+            @test BL2 == BL
+
+            tril!(BL2, -1)
+            @test all(iszero, diag(BL2))
+            tril!(BL2, -2)
+            @test all(iszero, BL2)
+
+            BL2 = Bidiagonal(copy(dv), copy(evl), :L)
+            triu!(BL2, 0)
+            @test all(iszero, diag(BL2,-1))
+            triu!(BL2, 2)
+            @test all(iszero, BL2)
+        end
+        @testset "U" begin
+            BU2 = Bidiagonal(copy(dv), copy(evu), :U)
+            tril!(BU2, 1)
+            @test BU2 == BU
+            triu!(BU2, 0)
+            @test BU2 == BU
+
+            tril!(BU2, 0)
+            @test all(iszero, diag(BU2,1))
+            tril!(BU2, -1)
+            @test all(iszero, BU2)
+
+            BU2 = Bidiagonal(copy(dv), copy(evu), :U)
+            triu!(BU2, 1)
+            @test all(iszero, diag(BU2,0))
+            triu!(BU2, 2)
+            @test all(iszero, BU2)
+        end
+    end
+
+    @testset "conversion to Tridiagonal" begin
+        TL = Tridiagonal(BL);
+        @test TL isa Tridiagonal{eltype(BL)}
+        @test diag(TL) == diag(BL)
+        @test diag(TL,-1) == diag(BL,-1)
+        @test diag(TL,1) == zero.(diag(BL,1))
     end
 end
 

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -769,6 +769,14 @@ end
     @test (@inferred diag(D,1)) == [zeros(Int,2,2)]
     @test (@inferred diag(D,-1)) == [zeros(Int,2,3)]
     @test (@inferred diag(D,2)) == Vector{Matrix{Int}}[]
+
+    @test tril!(D,0) == tril!(D,1) == D
+    @test triu!(D,0) == triu!(D,-1) == D
+    tril!(D,-1)
+    @test all(iszero, D)
+    D = Diagonal([[1 2 3; 4 5 6], [1 2; 4 5]])
+    triu!(D,1)
+    @test all(iszero, D)
 end
 
 @testset "linear solve for block diagonal matrices" begin

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -727,6 +727,9 @@ end
 
 @testset "block diagonal matrices" begin
     D = Diagonal([[1 2; 3 4], [1 2; 3 4]])
+    @test diag(D,1) == [zeros(Int,2,2)]
+    @test diag(D) == [[1 2; 3 4], [1 2; 3 4]]
+    @test diag(D,-1) == [zeros(Int,2,2)]
     Dherm = Diagonal([[1 1+im; 1-im 1], [1 1+im; 1-im 1]])
     Dsym = Diagonal([[1 1+im; 1+im 1], [1 1+im; 1+im 1]])
     @test adjoint(D) == Diagonal([[1 3; 2 4], [1 3; 2 4]])
@@ -761,6 +764,11 @@ end
         D = Diagonal(fill(M, n))
         @test D == Matrix{eltype(D)}(D)
     end
+
+    D = Diagonal([[1 2 3; 4 5 6], [1 2; 4 5]])
+    @test (@inferred diag(D,1)) == [zeros(Int,2,2)]
+    @test (@inferred diag(D,-1)) == [zeros(Int,2,3)]
+    @test (@inferred diag(D,2)) == Vector{Matrix{Int}}[]
 end
 
 @testset "linear solve for block diagonal matrices" begin


### PR DESCRIPTION
After this, `diag` works for `Diagonal` even if the `eltype` isn't a `Number` (i.e. `zero(T)` isn't defined). That's because we can always use `diagzero`.
```julia
julia> D = Diagonal([[1 2 3; 4 5 6], [1 2; 4 5]])
2×2 Diagonal{Matrix{Int64}, Vector{Matrix{Int64}}}:
 [1 2 3; 4 5 6]      ⋅     
       ⋅         [1 2; 4 5]

julia> diag(D,1)
1-element Vector{Matrix{Int64}}:
 [0 0; 0 0]

julia> diag(D,-1)
1-element Vector{Matrix{Int64}}:
 [0 0 0; 0 0 0]

```