### PR TITLE
Fix weird dispatch of * with zero arguments

### DIFF
--- a/stdlib/LinearAlgebra/src/givens.jl
+++ b/stdlib/LinearAlgebra/src/givens.jl
@@ -417,7 +417,7 @@ function *(G1::Givens{S}, G2::Givens{T}) where {S,T}
     TS = promote_type(T, S)
     Rotation{TS}([convert(AbstractRotation{TS}, G2), convert(AbstractRotation{TS}, G1)])
 end
-function *(G::Givens, Gs::Givens...)
+function *(G::Givens{T}, Gs::Givens{T}...) where {T}
     return Rotation([reverse(Gs)..., G])
 end
 function *(G::Givens{S}, R::Rotation{T}) where {S,T}

--- a/stdlib/LinearAlgebra/src/givens.jl
+++ b/stdlib/LinearAlgebra/src/givens.jl
@@ -417,7 +417,9 @@ function *(G1::Givens{S}, G2::Givens{T}) where {S,T}
     TS = promote_type(T, S)
     Rotation{TS}([convert(AbstractRotation{TS}, G2), convert(AbstractRotation{TS}, G1)])
 end
-*(G::Givens{T}...) where {T} = Rotation([reverse(G)...])
+function *(G::Givens, Gs::Givens...)
+    return Rotation([reverse(Gs)..., G])
+end
 function *(G::Givens{S}, R::Rotation{T}) where {S,T}
     TS = promote_type(T, S)
     Rotation(vcat(convert(AbstractRotation{TS}, R).rotations, convert(AbstractRotation{TS}, G)))

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -154,6 +154,13 @@ Base.convert(::Type{T19714}, ::Int) = T19714()
 Base.promote_rule(::Type{T19714}, ::Type{Int}) = T19714
 @test T19714()/1 === 1/T19714() === T19714()
 
+@testset "operators with zero argument" begin
+    @test_throws(MethodError, +())
+    @test_throws(MethodError, *())
+    @test isempty(methods(+, ()))
+    @test isempty(methods(*, ()))
+end
+
 # pr #17155 and #33568
 @testset "function composition" begin
     @test (uppercase∘(x->string(x,base=16)))(239487) == "3A77F"


### PR DESCRIPTION
As pointed out on Slack, this error message is not very nice:
```julia
julia> *()
ERROR: MethodError: no method matching LinearAlgebra.Rotation(::Vector{Any})

Closest candidates are:
  LinearAlgebra.Rotation(::Array{LinearAlgebra.Givens{T}, 1}) where T
   @ LinearAlgebra ~/.julia/juliaup/julia-1.9.1+0.x64.linux.gnu/share/julia/stdlib/v1.9/LinearAlgebra/src/givens.jl:44

Stacktrace:
 [1] *()
   @ LinearAlgebra ~/.julia/juliaup/julia-1.9.1+0.x64.linux.gnu/share/julia/stdlib/v1.9/LinearAlgebra/src/givens.jl:420
 [2] top-level scope
   @ REPL[1]:1
```
I hope my PR fixes it, but I don't know what new error might pop up.