### PR TITLE
Add precompile statement for Base.Ryu.writefixed from Float64 to Int64

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -59,6 +59,7 @@ precompile(Base.CoreLogging.current_logger_for_env, (Base.CoreLogging.LogLevel, 
 precompile(Base.CoreLogging.env_override_minlevel, (Symbol, Module))
 precompile(Base.StackTraces.lookup, (Ptr{Nothing},))
 precompile(Tuple{typeof(Base.run_module_init), Module, Int})
+precompile(Tuple{typeof(Base.Ryu.writefixed), Float64, Int64})
 """
 
 for T in (Float16, Float32, Float64), IO in (IOBuffer, IOContext{IOBuffer}, Base.TTY, IOContext{Base.TTY})


### PR DESCRIPTION
`@time Pkg.activate` seems to use `Base.Ryu.writefixed` on Julia master.

```
$ ./julia -e 'using Pkg; for i in 1:5; @time Pkg.activate("~/.julia/dev/ScriptUtils"); end' --trace-compile=stderr;
  Activating project at `~/.julia/dev/ScriptUtils`
precompile(Tuple{typeof(Base.Ryu.writefixed), Float64, Int64})
  0.003745 seconds (5.75 k allocations: 541.180 KiB)
  Activating project at `~/.julia/dev/ScriptUtils`
  0.002678 seconds (5.06 k allocations: 492.125 KiB)
  Activating project at `~/.julia/dev/ScriptUtils`
  0.002498 seconds (5.06 k allocations: 492.125 KiB)
  Activating project at `~/.julia/dev/ScriptUtils`
  0.002476 seconds (5.06 k allocations: 492.094 KiB)
  Activating project at `~/.julia/dev/ScriptUtils`
  0.002553 seconds (5.06 k allocations: 492.391 KiB)
```

Since environment activation is a common operation, we should precompile this statement.

```
precompile(Tuple{typeof(Base.Ryu.writefixed), Float64, Int64})
```

I had added this by hard coding it in contrib/generate_precompile.jl.

Edit: Revised to more clearly indicate that `@time Pkg.activate()` triggers the compilation, but either alone.


