### PR TITLE
gc-debug: fix time unit in `jl_print_gc_stats`

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -784,11 +784,12 @@ void jl_print_gc_stats(JL_STREAM *s)
     malloc_stats();
 #endif
     double ptime = jl_hrtime() - process_t0;
-    jl_safe_printf("exec time\t%.5f sec\n", ptime);
+    double exec_time = jl_ns2s(ptime);
+    jl_safe_printf("exec time\t%.5f sec\n", exec_time);
     if (gc_num.pause > 0) {
         jl_safe_printf("gc time  \t%.5f sec (%2.1f%%) in %d (%d full) collections\n",
                        jl_ns2s(gc_num.total_time),
-                       jl_ns2s(gc_num.total_time) / ptime * 100,
+                       jl_ns2s(gc_num.total_time) / exec_time * 100,
                        gc_num.pause, gc_num.full_sweep);
         jl_safe_printf("gc pause \t%.2f ms avg\n\t\t%2.0f ms max\n",
                        jl_ns2ms(gc_num.total_time) / gc_num.pause,


### PR DESCRIPTION

`jl_hrtime()` return nanosec. Then `ptime` is also in nanosec.
Need to convert unit to seconds with the `jl_ns2s` function.
https://github.com/JuliaLang/julia/blob/7fc8646ad47857796078f96e3d061622df52023a/src/sys.c#L461-L462
https://github.com/JuliaLang/julia/blob/7fc8646ad47857796078f96e3d061622df52023a/src/gc-debug.c#L1007


NOTE: those codes need flag: `CFLAGS = -DGC_FINAL_STATS`


