### PR TITLE
Add paragraph on abstract `Function` fields to performance tips

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -368,22 +368,13 @@ end
 ```
 
 But since `Function` is an abstract type, every call to `wrapper.f` will require dynamic dispatch, due to the type instability of accessing the field `f`.
-Instead, you should write:
-
+Instead, you should write something like:
 ```julia
-struct MyCallableWrapper{F<:Function}
+struct MyCallableWrapper{F}
     f::F
 end
 ```
-
 which has nearly identical behavior but will be much faster (because the type instability is eliminated).
-Note that the constraint `F<:Function` is not necessary, and even counterproductive: indeed, it prevents the user from providing a callable object that does not subtype `Function`.
-Therefore, the following pattern is probably the best:
-
-```julia
-struct MyCallableWrapper{F}
-    f::F  # document somewhere that this needs to be callable
-end
 ```
 
 ### Avoid fields with abstract containers

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -367,7 +367,7 @@ struct MyCallableWrapper
 end
 ```
 
-But since `Function` is an abstract type, every call to `wrapper.f` will be very inefficient.
+But since `Function` is an abstract type, every call to `wrapper.f` will require dynamic dispatch, due to the type instability of accessing the field `f`.
 Instead, you should write:
 
 ```julia
@@ -376,8 +376,8 @@ struct MyCallableWrapper{F<:Function}
 end
 ```
 
-which has nearly identical behavior but will be much faster.
-Note that the constraint `F<:Function` is not necessary, and prevents the user from providing a callable object that does not subtype `Function`.
+which has nearly identical behavior but will be much faster (because the type instability is eliminated).
+Note that the constraint `F<:Function` is not necessary, and even counterproductive: indeed, it prevents the user from providing a callable object that does not subtype `Function`.
 Therefore, the following pattern is probably the best:
 
 ```julia

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -369,13 +369,15 @@ end
 
 But since `Function` is an abstract type, every call to `wrapper.f` will require dynamic dispatch, due to the type instability of accessing the field `f`.
 Instead, you should write something like:
+
 ```julia
 struct MyCallableWrapper{F}
     f::F
 end
 ```
+
 which has nearly identical behavior but will be much faster (because the type instability is eliminated).
-```
+Note that we do not impose `F<:Function`: this means callable objects which do not subtype `Function` are also allowed for the field `f`.
 
 ### Avoid fields with abstract containers
 

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -358,6 +358,34 @@ julia> !isconcretetype(Array), !isabstracttype(Array), isstructtype(Array), !isc
 ```
 In this case, it would be better to avoid declaring `MyType` with a field `a::Array` and instead declare the field as `a::Array{T,N}` or as `a::A`, where `{T,N}` or `A` are parameters of `MyType`.
 
+The previous advice is especially useful when the fields of a struct are meant to be functions, or more generally callable objects.
+It is very tempting to define a struct as follows:
+
+```julia
+struct MyCallableWrapper
+    f::Function
+end
+```
+
+But since `Function` is an abstract type, every call to `wrapper.f` will be very inefficient.
+Instead, you should write:
+
+```julia
+struct MyCallableWrapper{F<:Function}
+    f::F
+end
+```
+
+which has nearly identical behavior but will be much faster.
+Note that the constraint `F<:Function` is not necessary, and prevents the user from providing a callable object that does not subtype `Function`.
+Therefore, the following pattern is probably the best:
+
+```julia
+struct MyCallableWrapper{F}
+    f::F  # document somewhere that this needs to be callable
+end
+```
+
 ### Avoid fields with abstract containers
 
 The same best practices also work for container types:


### PR DESCRIPTION
The following pattern is very common among beginners:

```julia
struct MyStruct
    f::Function
end
```

This PR advises against it

https://discourse.julialang.org/t/how-to-enforce-function-signature-type-on-a-struct/101211/2