### PR TITLE
Add pattern matching for `typeof` into field type tparam

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -235,12 +235,12 @@ function new_expr_effect_flags(𝕃ₒ::AbstractLattice, args::Vector{Any}, src:
     fcount = datatype_fieldcount(typ)
     fcount === nothing && return (false, false, false)
     fcount >= length(args) - 1 || return (false, false, false)
-    for fld_idx in 1:(length(args) - 1)
-        farg = args[fld_idx + 1]
+    for fidx in 1:(length(args) - 1)
+        farg = args[fidx + 1]
         eT = argextype(farg, src)
-        fT = fieldtype(typ, fld_idx)
+        fT = fieldtype(typ, fidx)
         if !isexact && has_free_typevars(fT)
-            if pattern_match !== nothing && pattern_match(src, typ, fld_idx, Targ, farg)
+            if pattern_match !== nothing && pattern_match(src, typ, fidx, Targ, farg)
                 continue
             end
             return (false, false, false)

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -215,6 +215,41 @@ is_stmt_inline(stmt_flag::UInt8)      = stmt_flag & IR_FLAG_INLINE      ≠ 0
 is_stmt_noinline(stmt_flag::UInt8)    = stmt_flag & IR_FLAG_NOINLINE    ≠ 0
 is_stmt_throw_block(stmt_flag::UInt8) = stmt_flag & IR_FLAG_THROW_BLOCK ≠ 0
 
+function new_expr_effect_flags(𝕃ₒ::AbstractLattice, args::Vector{Any}, src::Union{IRCode,IncrementalCompact}, pattern_match=nothing)
+    Targ = args[1]
+    atyp = argextype(Targ, src)
+    # `Expr(:new)` of unknown type could raise arbitrary TypeError.
+    typ, isexact = instanceof_tfunc(atyp)
+    if !isexact
+        atyp = unwrap_unionall(widenconst(atyp))
+        if isType(atyp) && isTypeDataType(atyp.parameters[1])
+            typ = atyp.parameters[1]
+        else
+            return (false, false, false)
+        end
+        isabstracttype(typ) && return (false, false, false)
+    else
+        isconcretedispatch(typ) || return (false, false, false)
+    end
+    typ = typ::DataType
+    fcount = datatype_fieldcount(typ)
+    fcount === nothing && return (false, false, false)
+    fcount >= length(args) - 1 || return (false, false, false)
+    for fld_idx in 1:(length(args) - 1)
+        farg = args[fld_idx + 1]
+        eT = argextype(farg, src)
+        fT = fieldtype(typ, fld_idx)
+        if !isexact && has_free_typevars(fT)
+            if pattern_match !== nothing && pattern_match(src, typ, fld_idx, Targ, farg)
+                continue
+            end
+            return (false, false, false)
+        end
+        ⊑(𝕃ₒ, eT, fT) || return (false, false, false)
+    end
+    return (false, true, true)
+end
+
 """
     stmt_effect_flags(stmt, rt, src::Union{IRCode,IncrementalCompact}) ->
         (consistent::Bool, effect_free_and_nothrow::Bool, nothrow::Bool)
@@ -264,36 +299,7 @@ function stmt_effect_flags(𝕃ₒ::AbstractLattice, @nospecialize(stmt), @nospe
             nothrow = is_nothrow(effects)
             return (consistent, effect_free & nothrow, nothrow)
         elseif head === :new
-            atyp = argextype(args[1], src)
-            # `Expr(:new)` of unknown type could raise arbitrary TypeError.
-            typ, isexact = instanceof_tfunc(atyp)
-            if !isexact
-                atyp = unwrap_unionall(widenconst(atyp))
-                if isType(atyp) && isTypeDataType(atyp.parameters[1])
-                    typ = atyp.parameters[1]
-                else
-                    return (false, false, false)
-                end
-                isabstracttype(typ) && return (false, false, false)
-            else
-                isconcretedispatch(typ) || return (false, false, false)
-            end
-            typ = typ::DataType
-            fcount = datatype_fieldcount(typ)
-            fcount === nothing && return (false, false, false)
-            fcount >= length(args) - 1 || return (false, false, false)
-            for fld_idx in 1:(length(args) - 1)
-                eT = argextype(args[fld_idx + 1], src)
-                fT = fieldtype(typ, fld_idx)
-                # Currently, we cannot represent any type equality constraints
-                # in the lattice, so if we see any type of type parameter,
-                # there is very little we can say about it
-                if !isexact && has_free_typevars(fT)
-                    return (false, false, false)
-                end
-                ⊑(𝕃ₒ, eT, fT) || return (false, false, false)
-            end
-            return (false, true, true)
+            return new_expr_effect_flags(𝕃ₒ, args, src)
         elseif head === :foreigncall
             effects = foreigncall_effects(stmt) do @nospecialize x
                 argextype(x, src)

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -908,6 +908,59 @@ end
     return nothing
 end
 
+struct IsEgal <: Function
+    x::Any
+    IsEgal(@nospecialize(x)) = new(x)
+end
+(x::IsEgal)(@nospecialize(y)) = x.x === y
+
+# This tries to match patterns of the form
+#  %ft = typeof(x)
+#  %T = apply_type(Foo, ft)
+#  %x = new(%T, %x)
+#
+# and if possible refines the nothrowness of the new expr based on it.
+function pattern_match_typeof(compact, typ, fidx, Targ, farg)
+    isa(Targ, SSAValue) || return false
+
+    Tdef = compact[Targ][:inst]
+    is_known_call(Tdef, Core.apply_type, compact) || return false
+
+    applyT = argextype(Tdef.args[2], compact)
+    isa(applyT, Const) || return false
+
+    applyT = applyT.val
+    tvars = Any[]
+    while isa(applyT, UnionAll)
+        applyTvar = applyT.var
+        applyT = applyT.body
+        push!(tvars, applyTvar)
+    end
+
+    @assert applyT.name === typ.name
+    fT = fieldtype(applyT, fidx)
+    idx = findfirst(IsEgal(fT), tvars)
+    idx === nothing && return false
+    valarg = Tdef.args[2+idx]
+    isa(valarg, SSAValue) || return false
+    valdef = compact[valarg][:inst]
+    is_known_call(valdef, typeof, compact) || return false
+
+    return valdef.args[2] === farg
+end
+
+function nothrow_new_pattern_match!(𝕃ₒ::AbstractLattice, compact::IncrementalCompact, idx::Int, stmt::Expr)
+    (consistent, effect_free_and_nothrow, nothrow) = new_expr_effect_flags(𝕃ₒ, stmt.args, compact, pattern_match_typeof)
+    if consistent
+        compact[SSAValue(idx)][:flag] |= IR_FLAG_CONSISTENT
+    end
+    if effect_free_and_nothrow
+        compact[SSAValue(idx)][:flag] |= IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW
+    elseif nothrow
+        compact[SSAValue(idx)][:flag] |= IR_FLAG_NOTHROW
+    end
+end
+
 # NOTE we use `IdSet{Int}` instead of `BitSet` for in these passes since they work on IR after inlining,
 # which can be very large sometimes, and program counters in question are often very sparse
 const SPCSet = IdSet{Int}
@@ -1037,6 +1090,8 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
                 lift_comparison!(===, compact, idx, stmt, lifting_cache, 𝕃ₒ)
             elseif is_known_call(stmt, isa, compact)
                 lift_comparison!(isa, compact, idx, stmt, lifting_cache, 𝕃ₒ)
+            elseif isexpr(stmt, :new) && (compact[SSAValue(idx)][:flag] & IR_FLAG_NOTHROW) == 0x00
+                nothrow_new_pattern_match!(𝕃ₒ, compact, idx, stmt)
             end
             continue
         end

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1355,3 +1355,14 @@ let src = code_typed1(mut50285, Tuple{Bool, Int, Float64})
     @test count(isnew, src.code) == 0
     @test count(iscall((src, typeassert)), src.code) == 0
 end
+
+# Test that we can eliminate new{typeof(x)}(x)
+struct TParamTypeofTest{T}
+    x::T
+    @eval TParamTypeofTest(x) = $(Expr(:new, :(TParamTypeofTest{typeof(x)}), :x))
+end
+function tparam_typeof_test_elim(x)
+    TParamTypeofTest(x).x
+end
+
+@test fully_eliminated(tparam_typeof_test_elim, Tuple{Any})

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1357,12 +1357,17 @@ let src = code_typed1(mut50285, Tuple{Bool, Int, Float64})
 end
 
 # Test that we can eliminate new{typeof(x)}(x)
-struct TParamTypeofTest{T}
+struct TParamTypeofTest1{T}
     x::T
-    @eval TParamTypeofTest(x) = $(Expr(:new, :(TParamTypeofTest{typeof(x)}), :x))
+    @eval TParamTypeofTest1(x) = $(Expr(:new, :(TParamTypeofTest1{typeof(x)}), :x))
 end
-function tparam_typeof_test_elim(x)
-    TParamTypeofTest(x).x
-end
+tparam_typeof_test_elim1(x) = TParamTypeofTest1(x).x
+@test fully_eliminated(tparam_typeof_test_elim1, Tuple{Any})
 
-@test fully_eliminated(tparam_typeof_test_elim, Tuple{Any})
+struct TParamTypeofTest2{S,T}
+    x::S
+    y::T
+    @eval TParamTypeofTest2(x, y) = $(Expr(:new, :(TParamTypeofTest2{typeof(x),typeof(y)}), :x, :y))
+end
+tparam_typeof_test_elim2(x, y) = TParamTypeofTest2(x, y).x
+@test fully_eliminated(tparam_typeof_test_elim2, Tuple{Any,Any})


### PR DESCRIPTION
This PR allows full elimination of the following, even in ill-typed code.
```
struct TParamTypeofTest{T}
    x::T
    @eval TParamTypeofTest(x) = $(Expr(:new, :(TParamTypeofTest{typeof(x)}), :x))
end
function tparam_typeof_test_elim(x)
    TParamTypeofTest(x).x
end
```

Before this PR, we would get:
```
julia> code_typed(tparam_typeof_test_elim, Tuple{Any})
1-element Vector{Any}:
 CodeInfo(
1 ─ %1 = Main.typeof(x)::DataType
│   %2 = Core.apply_type(Main.TParamTypeofTest, %1)::Type{TParamTypeofTest{_A}} where _A
│        %new(%2, x)::TParamTypeofTest
└──      return x
```

Where the `new` is non-eliminable, because the compiler did not know that `x::_A`. Fix this by pattern matching this particular pattern (where the condition is guaranteed, because we computed `_A` by `typeof`). This is not particularly general, but this pattern comes up a lot, so it's surprisingly effective.