### PR TITLE
avoid potential type-instability in _replace_(str, ...)

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -778,11 +778,11 @@ end
 
 # note: leave str untyped here to make it easier for packages like StringViews to hook in
 function _replace_(str, pat_repl::NTuple{N, Pair}, count::Int) where N
-    count == 0 && return str
+    count == 0 && return String(str)
     e1, patterns, replaces, rs, notfound = _replace_init(str, pat_repl, count)
     if notfound
         foreach(_free_pat_replacer, patterns)
-        return str
+        return String(str)
     end
     out = IOBuffer(sizehint=floor(Int, 1.2sizeof(str)))
     return String(take!(_replace_finish(out, str, count, e1, patterns, replaces, rs)))


### PR DESCRIPTION
Slight improvement to #48625.

Does not affect `Base`, but affects downstream code that might want to override the low-level `Base._replace_` to support another string type.  This function should always return a `String`.

(Added a backport label since #48625 is also currently marked for backport.)