### PR TITLE
duck-type some string internals to make StringViews easier

### DIFF
--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -196,10 +196,12 @@ function err_message(errno::Integer)
     return GC.@preserve buffer unsafe_string(pointer(buffer))
 end
 
-function exec(re, subject, offset, options, match_data)
-    if !(subject isa Union{String,SubString{String}})
-        subject = String(subject)
-    end
+exec(re, subject::Union{String,SubString{String}, offset, options, match_data) =
+    _exec(re, subject, offset, options, match_data)
+exec(re, subject, offset, options, match_data) =
+    _exec(re, String(subject), offset, options, match_data)
+
+function _exec(re, subject, offset, options, match_data)
     rc = ccall((:pcre2_match_8, PCRE_LIB), Cint,
                (Ptr{Cvoid}, Ptr{UInt8}, Csize_t, Csize_t, UInt32, Ptr{Cvoid}, Ptr{Cvoid}),
                re, subject, ncodeunits(subject), offset, options, match_data, get_local_match_context())

--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -196,7 +196,7 @@ function err_message(errno::Integer)
     return GC.@preserve buffer unsafe_string(pointer(buffer))
 end
 
-exec(re, subject::Union{String,SubString{String}, offset, options, match_data) =
+exec(re, subject::Union{String,SubString{String}}, offset, options, match_data) =
     _exec(re, subject, offset, options, match_data)
 exec(re, subject, offset, options, match_data) =
     _exec(re, String(subject), offset, options, match_data)

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -431,7 +431,8 @@ match(r::Regex, s::AbstractString, i::Integer) = throw(ArgumentError(
 findnext(re::Regex, str::Union{String,SubString}, idx::Integer) = _findnext_re(re, str, idx, C_NULL)
 
 # TODO: return only start index and update deprecation
-function _findnext_re(re::Regex, str::Union{String,SubString}, idx::Integer, match_data::Ptr{Cvoid})
+# duck-type str so that external UTF-8 string packages like StringViews can hook in
+function _findnext_re(re::Regex, str, idx::Integer, match_data::Ptr{Cvoid})
     if idx > nextind(str,lastindex(str))
         throw(BoundsError())
     end

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -404,7 +404,8 @@ is_valid_continuation(c) = c & 0xc0 == 0x80
     return iterate_continued(s, i, u)
 end
 
-function iterate_continued(s::String, i::Int, u::UInt32)
+# duck-type s so that external UTF-8 string packages like StringViews can hook in
+function iterate_continued(s, i::Int, u::UInt32)
     u < 0xc0000000 && (i += 1; @goto ret)
     n = ncodeunits(s)
     # first continuation byte
@@ -433,7 +434,8 @@ end
     return getindex_continued(s, i, u)
 end
 
-function getindex_continued(s::String, i::Int, u::UInt32)
+# duck-type s so that external UTF-8 string packages like StringViews can hook in
+function getindex_continued(s, i::Int, u::UInt32)
     if u < 0xc0000000
         # called from `getindex` which checks bounds
         @inbounds isvalid(s, i) && @goto ret
@@ -491,7 +493,8 @@ end
     @inbounds length_continued(s, i, j, c)
 end
 
-@assume_effects :terminates_locally @inline @propagate_inbounds function length_continued(s::String, i::Int, n::Int, c::Int)
+# duck-type s so that external UTF-8 string packages like StringViews can hook in
+@assume_effects :terminates_locally @inline @propagate_inbounds function length_continued(s, i::Int, n::Int, c::Int)
     i < n || return c
     b = codeunit(s, i)
     while true

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -493,8 +493,7 @@ end
     @inbounds length_continued(s, i, j, c)
 end
 
-# duck-type s so that external UTF-8 string packages like StringViews can hook in
-@assume_effects :terminates_locally @inline @propagate_inbounds function length_continued(s, i::Int, n::Int, c::Int)
+@assume_effects :terminates_locally @inline @propagate_inbounds function length_continued(s::String, i::Int, n::Int, c::Int)
     i < n || return c
     b = codeunit(s, i)
     while true


### PR DESCRIPTION
This PR just removes the type qualifiers from some undocumented internal functions to make it a bit easier to hook in with StringViews.  (Currently, I'm copy-pasting those functions in their entirety into StringViews, which is a big ugly.)