### PR TITLE
Remove union penalties for inlining cost

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1669,7 +1669,7 @@ function print_statement_costs(io::IO, @nospecialize(tt::Type);
             empty!(cst)
             resize!(cst, length(code.code))
             sptypes = Core.Compiler.VarState[Core.Compiler.VarState(sp, false) for sp in match.sparams]
-            maxcost = Core.Compiler.statement_costs!(cst, code.code, code, sptypes, false, params)
+            maxcost = Core.Compiler.statement_costs!(cst, code.code, code, sptypes, params)
             nd = ndigits(maxcost)
             irshow_config = IRShow.IRShowConfig() do io, linestart, idx
                 print(io, idx > 0 ? lpad(cst[idx], nd+1) : " "^(nd+1), " ")

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -627,15 +627,15 @@ end
     B = OffsetArray(reshape(1:24, 4, 3, 2), -5, 6, -7)
     for R in (fill(0, -4:-1), fill(0, -4:-1, 7:7), fill(0, -4:-1, 7:7, -6:-6))
         @test @inferred(maximum!(R, B)) == reshape(maximum(B, dims=(2,3)), axes(R)) == reshape(21:24, axes(R))
-        @test @allocated(maximum!(R, B)) <= 800
+        @test @allocated(maximum!(R, B)) <= 1300
         @test @inferred(minimum!(R, B)) == reshape(minimum(B, dims=(2,3)), axes(R)) == reshape(1:4, axes(R))
-        @test @allocated(minimum!(R, B)) <= 800
+        @test @allocated(minimum!(R, B)) <= 1300
     end
     for R in (fill(0, -4:-4, 7:9), fill(0, -4:-4, 7:9, -6:-6))
         @test @inferred(maximum!(R, B)) == reshape(maximum(B, dims=(1,3)), axes(R)) == reshape(16:4:24, axes(R))
-        @test @allocated(maximum!(R, B)) <= 800
+        @test @allocated(maximum!(R, B)) <= 1300
         @test @inferred(minimum!(R, B)) == reshape(minimum(B, dims=(1,3)), axes(R)) == reshape(1:4:9, axes(R))
-        @test @allocated(minimum!(R, B)) <= 800
+        @test @allocated(minimum!(R, B)) <= 1300
     end
     @test_throws DimensionMismatch maximum!(fill(0, -4:-1, 7:7, -6:-6, 1:1), B)
     @test_throws DimensionMismatch minimum!(fill(0, -4:-1, 7:7, -6:-6, 1:1), B)


### PR DESCRIPTION
I added this code back in #27057, when I first made Union-full signatures inlineable. The justification was to try to encourage the union splitting to happen on the outside. However (and I believe this changed since this code was introduced), these days inference is in complete control of union splitting and we do not take inlineability or non-inlineability of the non-unionsplit function into account when deciding how to inline. As a result, the only effect of the union split penalties was to prevent inlining of functions that are not union-split eligible (e.g.
`+(::Vararg{Union{Int, Missing}, 3})`), but are nevertheless cheap by our inlining metric. There is really no reason not to try to inline such functions, so delete this logic.