### PR TITLE
make `splice!` work when `replacement` is a length-1 generator

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1757,7 +1757,7 @@ function splice!(a::Vector, i::Integer, ins=_default_splice)
     if m == 0
         _deleteat!(a, i, 1)
     elseif m == 1
-        a[i] = ins[1]
+        a[i] = only(ins)
     else
         _growat!(a, i, m-1)
         k = 1


### PR DESCRIPTION
the contract for `splice!` asks for an "ordered collection." Looking at the implementation, empirically that seems to require `length` and iteration, and in the case of a length-1 replacement, also `getindex`. This PR removes that last restriction and concretely, allows `replacement` to be a length-1 generator.

before PR:
```
julia> arr = Any[1,2,3,4]
4-element Vector{Any}:
 1
 2
 3
 4

julia> splice!(arr, 2, (i for i in 'a'))
ERROR: MethodError: no method matching getindex(::Base.Generator{Char, typeof(identity)}, ::Int64)
```


after PR:
```
julia> arr = Any[1,2,3,4]
4-element Vector{Any}:
 1
 2
 3
 4

julia> splice!(arr, 2, (i for i in 'a'))
2
```