### PR TITLE
Delete `trust_inference` option

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -236,7 +236,7 @@ function cfg_inline_unionsplit!(ir::IRCode, idx::Int,
         push!(from_bbs, length(state.new_cfg_blocks))
         # TODO: Right now we unconditionally generate a fallback block
         # in case of subtyping errors - This is probably unnecessary.
-        if i != length(cases) || (!fully_covered || (!params.trust_inference))
+        if i != length(cases) || (!fully_covered)
             # This block will have the next condition or the final else case
             push!(state.new_cfg_blocks, BasicBlock(StmtRange(idx, idx)))
             push!(state.new_cfg_blocks[cond_bb].succs, length(state.new_cfg_blocks))
@@ -575,7 +575,7 @@ function ir_inline_unionsplit!(compact::IncrementalCompact, idx::Int,
         cond = true
         nparams = fieldcount(atype)
         @assert nparams == fieldcount(mtype)
-        if i != ncases || !fully_covered || !params.trust_inference
+        if i != ncases || !fully_covered
             for i = 1:nparams
                 a, m = fieldtype(atype, i), fieldtype(mtype, i)
                 # If this is always true, we don't need to check for it
@@ -630,14 +630,7 @@ function ir_inline_unionsplit!(compact::IncrementalCompact, idx::Int,
     end
     bb += 1
     # We're now in the fall through block, decide what to do
-    if fully_covered
-        if !params.trust_inference
-            e = Expr(:call, GlobalRef(Core, :throw), FATAL_TYPE_BOUND_ERROR)
-            insert_node_here!(compact, NewInstruction(e, Union{}, line))
-            insert_node_here!(compact, NewInstruction(ReturnNode(), Union{}, line))
-            finish_current_bb!(compact, 0)
-        end
-    else
+    if !fully_covered
         ssa = insert_node_here!(compact, NewInstruction(stmt, typ, line))
         push!(pn.edges, bb)
         push!(pn.values, ssa)

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -247,10 +247,6 @@ Parameters that control optimizer operation.
   generating `:invoke` expression based on the [`@nospecialize`](@ref) annotation,
   in order to avoid over-specialization.
 ---
-- `opt_params.trust_inference::Bool = false`\\
-  If `false`, the inliner will unconditionally generate a fallback block when union-splitting
-  a callsite, in case of existing subtyping bugs. This option may be removed in the future.
----
 - `opt_params.assume_fatal_throw::Bool = false`\\
   If `true`, gives the optimizer license to assume that any `throw` is fatal and thus the
   state after a `throw` is not externally observable. In particular, this gives the
@@ -266,7 +262,6 @@ struct OptimizationParams
     inline_error_path_cost::Int
     max_tuple_splat::Int
     compilesig_invokes::Bool
-    trust_inference::Bool
     assume_fatal_throw::Bool
 
     function OptimizationParams(
@@ -277,7 +272,6 @@ struct OptimizationParams
         inline_error_path_cost::Int,
         max_tuple_splat::Int,
         compilesig_invokes::Bool,
-        trust_inference::Bool,
         assume_fatal_throw::Bool)
         return new(
             inlining,
@@ -287,7 +281,6 @@ struct OptimizationParams
             inline_error_path_cost,
             max_tuple_splat,
             compilesig_invokes,
-            trust_inference,
             assume_fatal_throw)
     end
 end
@@ -300,7 +293,6 @@ function OptimizationParams(
         #=inline_error_path_cost::Int=# 20,
         #=max_tuple_splat::Int=# 32,
         #=compilesig_invokes::Bool=# true,
-        #=trust_inference::Bool=# true,
         #=assume_fatal_throw::Bool=# false);
     inlining::Bool = params.inlining,
     inline_cost_threshold::Int = params.inline_cost_threshold,
@@ -309,7 +301,6 @@ function OptimizationParams(
     inline_error_path_cost::Int = params.inline_error_path_cost,
     max_tuple_splat::Int = params.max_tuple_splat,
     compilesig_invokes::Bool = params.compilesig_invokes,
-    trust_inference::Bool = params.trust_inference,
     assume_fatal_throw::Bool = params.assume_fatal_throw)
     return OptimizationParams(
         inlining,
@@ -319,7 +310,6 @@ function OptimizationParams(
         inline_error_path_cost,
         max_tuple_splat,
         compilesig_invokes,
-        trust_inference,
         assume_fatal_throw)
 end
 

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -300,7 +300,7 @@ function OptimizationParams(
         #=inline_error_path_cost::Int=# 20,
         #=max_tuple_splat::Int=# 32,
         #=compilesig_invokes::Bool=# true,
-        #=trust_inference::Bool=# false,
+        #=trust_inference::Bool=# true,
         #=assume_fatal_throw::Bool=# false);
     inlining::Bool = params.inlining,
     inline_cost_threshold::Int = params.inline_cost_threshold,


### PR DESCRIPTION
I think the time has come to flip this. This was added when the type system was much less reliable at producing intersections. It is true that we still have the occasional type sytem bug, but we're already trusting inference in a bunch of other places. At the same time, the cost of this has grown in terms of bloated IR needing to be visited in places like irinterp, so let's flip the bit and we'll deal with type system bugs the way we usually due.