### PR TITLE
docs: fix link in `AbstractString` docstring

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -16,9 +16,7 @@ about strings:
   * Each `AbstractChar` in a string is encoded by one or more code units
   * Only the index of the first code unit of an `AbstractChar` is a valid index
   * The encoding of an `AbstractChar` is independent of what precedes or follows it
-  * String encodings are [self-synchronizing] – i.e. `isvalid(s, i)` is O(1)
-
-[self-synchronizing]: https://en.wikipedia.org/wiki/Self-synchronizing_code
+  * String encodings are [self-synchronizing](https://en.wikipedia.org/wiki/Self-synchronizing_code) – i.e. `isvalid(s, i)` is O(1)
 
 Some string functions that extract code units, characters or substrings from
 strings error if you pass them out-of-bounds or invalid string indices. This


### PR DESCRIPTION
Alas, link definitions are not a thing for us. Should fix this:

![image](https://github.com/JuliaLang/julia/assets/147757/4ee623b2-3754-4bc4-8506-df91069403fb)
