### PR TITLE
Revert "Store heapsnapshot files in tempdir() instead of current directory"

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1234,7 +1234,7 @@ function take_heap_snapshot(filepath::String, all_one::Bool=false)
     return filepath
 end
 function take_heap_snapshot(all_one::Bool=false)
-    f = joinpath(tempdir(), "$(getpid())_$(time_ns()).heapsnapshot")
+    f = abspath("$(getpid())_$(time_ns()).heapsnapshot")
     return take_heap_snapshot(f, all_one)
 end
 


### PR DESCRIPTION
Reverts JuliaLang/julia#50026. At the very least, this introduced a documentation error, since the documentation explicitly says this method signature uses `pwd`