### PR TITLE
clarify r"..."x mode

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -99,7 +99,7 @@ listed after the ending quote, to change its behaviour:
 - `m` treats the `^` and `\$` tokens as matching the start and end of individual lines, as
   opposed to the whole string.
 - `s` allows the `.` modifier to match newlines.
-- `x` enables "free-spacing mode": whitespace in the regex is ignored except when escaped with `\\`,
+- `x` enables "free-spacing mode": whitespace between regex tokens is ignored except when escaped with `\\`,
    and `#` in the regex is treated as starting a comment (which is ignored to the line ending).
 - `a` enables ASCII mode (disables `UTF` and `UCP` modes). By default `\\B`, `\\b`, `\\D`,
   `\\d`, `\\S`, `\\s`, `\\W`, `\\w`, etc. match based on Unicode character properties. With

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -99,8 +99,8 @@ listed after the ending quote, to change its behaviour:
 - `m` treats the `^` and `\$` tokens as matching the start and end of individual lines, as
   opposed to the whole string.
 - `s` allows the `.` modifier to match newlines.
-- `x` enables "comment mode": whitespace is enabled except when escaped with `\\`, and `#`
-  is treated as starting a comment.
+- `x` enables "free-spacing mode": whitespace in the regex is ignored except when escaped with `\\`,
+   and `#` in the regex is treated as starting a comment (which is ignored to the line ending).
 - `a` enables ASCII mode (disables `UTF` and `UCP` modes). By default `\\B`, `\\b`, `\\D`,
   `\\d`, `\\S`, `\\s`, `\\W`, `\\w`, etc. match based on Unicode character properties. With
   this option, these sequences only match ASCII characters. This includes `\\u` also, which


### PR DESCRIPTION
`x` seems to be more commonly referred to as ["free-spacing mode"](https://www.regular-expressions.info/freespacing.html) than "comment mode", and the description was difficult for me to comprehend so I tried to clarify it.