### PR TITLE
docs: Fix a `!!! note` which was miscapitalized

### DIFF
--- a/doc/src/manual/multi-threading.md
+++ b/doc/src/manual/multi-threading.md
@@ -292,7 +292,7 @@ sum_multi_good (generic function with 1 method)
 julia> sum_multi_good(1:1_000_000)
 500000500000
 ```
-!!! Note
+!!! note
     Buffers should not be managed based on `threadid()` i.e. `buffers = zeros(Threads.nthreads())` because concurrent tasks
     can yield, meaning multiple concurrent tasks may use the same buffer on a given thread, introducing risk of data races.
     Further, when more than one thread is available tasks may change thread at yield points, which is known as


### PR DESCRIPTION
The multi-threading manual page has a paragraph which is supposed to appear in a `Note` environment. However, on the live version of the docs, it appears as a regular paragraph with a literal `!!! Note` at the front of it. It is two paragraphs above the [Atomic Operations](https://docs.julialang.org/en/v1/manual/multi-threading/#Atomic-Operations) section, at the end of [the section about using `@threads`](https://docs.julialang.org/en/v1/manual/multi-threading/#Using-@threads-without-data-races).