### PR TITLE
Profile: Add specifying dir for `take_heap_snapshot` and handling if current dir is unwritable

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1234,7 +1234,7 @@ function take_heap_snapshot(filepath::String, all_one::Bool=false)
     return filepath
 end
 function take_heap_snapshot(all_one::Bool=false)
-    f = joinpath(tempdir(), "$(getpid())_$(time_ns()).heapsnapshot")
+    f = abspath("$(getpid())_$(time_ns()).heapsnapshot")
     return take_heap_snapshot(f, all_one)
 end
 

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1244,7 +1244,7 @@ function take_heap_snapshot(all_one::Bool=false; dir::Union{Nothing,S}=nothing) 
             touch(fpath)
             rm(fpath; force=true)
         catch
-            @warn "Cannot write to current directory `$(pwd())` so saving heap snapshot to `tempdir()`" maxlog=1 _id=Symbol(wd)
+            @warn "Cannot write to current directory `$(pwd())` so saving heap snapshot to `$(tempdir())`" maxlog=1 _id=Symbol(wd)
             fpath = joinpath(tempdir(), fname)
         end
     else

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1215,14 +1215,16 @@ end
 """
     Profile.take_heap_snapshot(io::IOStream, all_one::Bool=false)
     Profile.take_heap_snapshot(filepath::String, all_one::Bool=false)
-    Profile.take_heap_snapshot(all_one::Bool=false)
+    Profile.take_heap_snapshot(all_one::Bool=false; dir::String)
 
 Write a snapshot of the heap, in the JSON format expected by the Chrome
-Devtools Heap Snapshot viewer (.heapsnapshot extension), to a file
-(`\$pid_\$timestamp.heapsnapshot`) in the current directory, or the given
-file path, or IO stream. If `all_one` is true, then report the size of
-every object as one so they can be easily counted. Otherwise, report the
-actual size.
+Devtools Heap Snapshot viewer (.heapsnapshot extension) to a file
+(`\$pid_\$timestamp.heapsnapshot`) in the current directory by default (or tempdir if
+the current directory is unwritable), or in `dir` if given, or the given
+full file path, or IO stream.
+
+If `all_one` is true, then report the size of every object as one so they can be easily
+counted. Otherwise, report the actual size.
 """
 function take_heap_snapshot(io::IOStream, all_one::Bool=false)
     Base.@_lock_ios(io, ccall(:jl_gc_take_heap_snapshot, Cvoid, (Ptr{Cvoid}, Cchar), io.handle, Cchar(all_one)))
@@ -1233,9 +1235,22 @@ function take_heap_snapshot(filepath::String, all_one::Bool=false)
     end
     return filepath
 end
-function take_heap_snapshot(all_one::Bool=false)
-    f = abspath("$(getpid())_$(time_ns()).heapsnapshot")
-    return take_heap_snapshot(f, all_one)
+function take_heap_snapshot(all_one::Bool=false; dir::Union{Nothing,S}=nothing) where {S <: AbstractString}
+    fname = "$(getpid())_$(time_ns()).heapsnapshot"
+    if isnothing(dir)
+        wd = pwd()
+        fpath = joinpath(wd, fname)
+        try
+            touch(fpath)
+            rm(fpath; force=true)
+        catch
+            @warn "Cannot write to current directory `$(pwd())` so saving heap snapshot to `tempdir()`" maxlog=1 _id=Symbol(wd)
+            fpath = joinpath(tempdir(), fname)
+        end
+    else
+        fpath = joinpath(expanduser(dir), fname)
+    end
+    return take_heap_snapshot(fpath, all_one)
 end
 
 


### PR DESCRIPTION
Replaces #50443
Reverts https://github.com/JuliaLang/julia/pull/50026 which changed the default to always use tempdir

Implements the idea here https://github.com/JuliaLang/julia/pull/50026#issuecomment-1623892082

- If the current dir is unwritable saves to `tempdir()` with a `maxlog=1` warning
- Adds `dir` kwarg to override the directory the named file is saved to

```
shell> cd unwritable/
/Users/ian/Documents/GitHub/julia/unwritable

julia> Profile.take_heap_snapshot()
┌ Warning: Cannot write to current directory `/Users/ian/Documents/GitHub/julia/unwritable` so saving heap snapshot to `tempdir()`
└ @ Profile ~/Documents/GitHub/julia/usr/share/julia/stdlib/v1.11/Profile/src/Profile.jl:1247
"/var/folders/1z/jf841bdj73bdj3vk7kc7f_3w0000gn/T/31236_782350876174583.heapsnapshot"

shell> cd ..
/Users/ian/Documents/GitHub/julia

julia> Profile.take_heap_snapshot()
"/Users/ian/Documents/GitHub/julia/31236_782356649496041.heapsnapshot"

julia> Profile.take_heap_snapshot(dir = "~/Documents")
"/Users/ian/Documents/31236_782363162146916.heapsnapshot"

julia> Profile.take_heap_snapshot("/Users/ian/Documents/mysnap.snapshot")
"/Users/ian/Documents/mysnap.snapshot"

```

fyi @kpamnany @NHDaly @adnan-alhomssi @vchuravy 