### PR TITLE
REPLCompletions: unswitch `Union` of same `UnionAll` results

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -580,6 +580,11 @@ function repl_eval_ex(@nospecialize(ex), context_module::Module)
 
     result = frame.result.result
     result === Union{} && return nothing # for whatever reason, callers expect this as the Bottom and/or Top type instead
+    if isa(result, Union)
+        # unswitch `Union` of same `UnionAll` instances to `UnionAll` of `Union`s
+        # so that we can use the field information of the `UnionAll`
+        return CC.unswitchtypeunion(result)
+    end
     return result
 end
 

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1873,3 +1873,13 @@ let s = "`abc`.e"
     # (completions for the fields of `Cmd`)
     @test c == Any["env", "exec"]
 end
+
+# Test completion for a case when type inference returned `Union` of the same types
+function union_somes()
+    return rand() < 0.5 ? Some(1) : Some(2.)
+end
+let s = "union_somes()."
+    c, r, res = test_complete_context(s, @__MODULE__)
+    @test res
+    @test "value" in c
+end


### PR DESCRIPTION
With this commit the inference-based REPL completion algorithm converts `Union` result of same `UnionAll` instances to `UnionAll` of `Union`s so that it can use the field information of the `UnionAll`.

This allows us to get completions for cases like:
```julia
julia> union_somes() = rand() < 0.5 ? Some(1) : Some(2.);

julia> union_somes().| # completes to `value`
```