### PR TITLE
cleanups to copyuntil

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -524,7 +524,7 @@ julia> rm("my_file.txt")
 readuntil(filename::AbstractString, delim; kw...) = open(io->readuntil(io, delim; kw...), convert(String, filename)::String)
 readuntil(stream::IO, delim::UInt8; kw...) = _unsafe_take!(copyuntil(IOBuffer(sizehint=70), stream, delim; kw...))
 readuntil(stream::IO, delim::Union{AbstractChar, AbstractString}; kw...) = String(_unsafe_take!(copyuntil(IOBuffer(sizehint=70), stream, delim; kw...)))
-readuntil(stream::IO, delim::T; keep::Bool=false) where T = _copyuntil(Vector{T}(), s, delim, keep)
+readuntil(stream::IO, delim::T; keep::Bool=false) where T = _copyuntil(Vector{T}(), stream, delim, keep)
 
 
 """

--- a/base/io.jl
+++ b/base/io.jl
@@ -524,7 +524,7 @@ julia> rm("my_file.txt")
 readuntil(filename::AbstractString, delim; kw...) = open(io->readuntil(io, delim; kw...), convert(String, filename)::String)
 readuntil(stream::IO, delim::UInt8; kw...) = _unsafe_take!(copyuntil(IOBuffer(sizehint=70), stream, delim; kw...))
 readuntil(stream::IO, delim::Union{AbstractChar, AbstractString}; kw...) = String(_unsafe_take!(copyuntil(IOBuffer(sizehint=70), stream, delim; kw...)))
-readuntil(stream::IO, delim::UInt8; keep::Bool=false) = _copyuntil(Vector{T}(), s, delim, keep)
+readuntil(stream::IO, delim::T; keep::Bool=false) where {T} = _copyuntil(Vector{T}(), s, delim, keep)
 
 
 """

--- a/base/io.jl
+++ b/base/io.jl
@@ -524,6 +524,7 @@ julia> rm("my_file.txt")
 readuntil(filename::AbstractString, delim; kw...) = open(io->readuntil(io, delim; kw...), convert(String, filename)::String)
 readuntil(stream::IO, delim::UInt8; kw...) = _unsafe_take!(copyuntil(IOBuffer(sizehint=70), stream, delim; kw...))
 readuntil(stream::IO, delim::Union{AbstractChar, AbstractString}; kw...) = String(_unsafe_take!(copyuntil(IOBuffer(sizehint=70), stream, delim; kw...)))
+readuntil(stream::IO, delim::UInt8; keep::Bool=false) = _copyuntil(Vector{T}(), s, delim, keep)
 
 
 """
@@ -914,6 +915,10 @@ function copyuntil(out::IO, s::IO, delim::AbstractChar; keep::Bool=false)
 end
 
 # note: optimized methods of copyuntil for IOStreams and delim::UInt8 in iostream.jl
+#       and for IOBuffer with delim::UInt8 in iobuffer.jl
+copyuntil(out::IO, s::IO, delim; keep::Bool=false) = _copyuntil(out, s, delim, keep)
+
+# supports out::Union{IO, AbstractVector} for use with both copyuntil & readuntil
 function _copyuntil(out, s::IO, delim::T, keep::Bool) where T
     output! = isa(out, IO) ? write : push!
     for c in readeach(s, T)
@@ -925,12 +930,6 @@ function _copyuntil(out, s::IO, delim::T, keep::Bool) where T
     end
     return out
 end
-readuntil(s::IO, delim::T; keep::Bool=false) where T =
-    _copyuntil(Vector{T}(), s, delim, keep)
-readuntil(s::IO, delim::UInt8; keep::Bool=false) =
-    _copyuntil(resize!(StringVector(70), 0), s, delim, keep)
-copyuntil(out::IO, s::IO, delim::T; keep::Bool=false) where T =
-    _copyuntil(out, s, delim, keep)
 
 # requires that indices for target are the integer unit range from firstindex to lastindex
 # returns whether the delimiter was matched

--- a/base/io.jl
+++ b/base/io.jl
@@ -524,7 +524,7 @@ julia> rm("my_file.txt")
 readuntil(filename::AbstractString, delim; kw...) = open(io->readuntil(io, delim; kw...), convert(String, filename)::String)
 readuntil(stream::IO, delim::UInt8; kw...) = _unsafe_take!(copyuntil(IOBuffer(sizehint=70), stream, delim; kw...))
 readuntil(stream::IO, delim::Union{AbstractChar, AbstractString}; kw...) = String(_unsafe_take!(copyuntil(IOBuffer(sizehint=70), stream, delim; kw...)))
-readuntil(stream::IO, delim::T; keep::Bool=false) where {T} = _copyuntil(Vector{T}(), s, delim, keep)
+readuntil(stream::IO, delim::T; keep::Bool=false) where T = _copyuntil(Vector{T}(), s, delim, keep)
 
 
 """

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -452,7 +452,7 @@ function readline(s::IOStream; keep::Bool=false)
 end
 
 function copyuntil(out::IOBuffer, s::IOStream, delim::UInt8; keep::Bool=false)
-    ensureroom(out, 16)
+    ensureroom(out, 1) # make sure we can read at least 1 byte, for iszero(n) check below
     ptr = (out.append ? out.size+1 : out.ptr)
     d = out.data
     len = length(d)

--- a/test/read.jl
+++ b/test/read.jl
@@ -677,6 +677,21 @@ end
     @test  isempty(itr) # now it is empty
 end
 
+@testset "readuntil/copyuntil fallbacks" begin
+    # test fallback for generic delim::T
+    buf = IOBuffer()
+    fib = [1,1,2,3,5,8,13,21]
+    write(buf, fib)
+    @test readuntil(seekstart(buf), 21) == fib[1:end-1]
+    @test readuntil(buf, 21) == Int[]
+    @test readuntil(seekstart(buf), 21; keep=true) == fib
+    out = IOBuffer()
+    @test copyuntil(out, seekstart(buf), 21) === out
+    @test reinterpret(Int, take!(out)) == fib[1:end-1]
+    @test copyuntil(out, seekstart(buf), 21; keep=true) === out
+    @test reinterpret(Int, take!(out)) == fib
+end
+
 # more tests for reverse(eachline)
 @testset "reverse(eachline)" begin
     lines = vcat(repr.(1:4), ' '^50000 .* repr.(5:10), repr.(11:10^5))


### PR DESCRIPTION
A couple of cleanups to #48273:

- [x] Removed an overwritten method, as noted in https://github.com/JuliaLang/julia/pull/48273#discussion_r1256340158 … I also rearranged the method definitions a bit to make them more readable.
- [x] Made the `ensureroom` call in `copyuntil(::IOBuffer, ::IOStream, ::UInt8)` more conservative, as noted in https://github.com/JuliaLang/julia/pull/48273#discussion_r1254858946
- [x] added tests for generic `delim::T` fallback methods of `readuntil` and `copyuntil`