### PR TITLE
clarify documentation for randcycle

### DIFF
--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -343,7 +343,7 @@ Construct a random cyclic permutation of length `n`. The optional `rng`
 argument specifies a random number generator, see [Random Numbers](@ref).
 The element type of the result is the same as the type of `n`.
 
-(Note that a "cyclic permutation" here means that all of the elements lie within
+(Here, a "cyclic permutation" means that all of the elements lie within
 a single cycle of length `n`.  There are ``(n-1)!`` possible cyclic permutations,
 which are sampled uniformly.  If `n == 0`, `randcycle` returns an empty array.)
 

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -343,7 +343,7 @@ Construct a random cyclic permutation of length `n`. The optional `rng`
 argument specifies a random number generator, see [Random Numbers](@ref).
 The element type of the result is the same as the type of `n`.
 
-(Note that a cyclic permutation means that all of the elements consist of
+(Note that a "cyclic permutation" here means that all of the elements lie within
 a single cycle of length `n`.  There are ``(n-1)!`` possible cyclic permutations,
 which are sampled uniformly.  If `n == 0`, `randcycle` returns an empty array.)
 

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -344,7 +344,7 @@ argument specifies a random number generator, see [Random Numbers](@ref).
 The element type of the result is the same as the type of `n`.
 
 Here, a "cyclic permutation" means that all of the elements lie within
-a single cycle of length `n`.  There are ``(n-1)!`` possible cyclic permutations,
+a single cycle.  If `n > 0`, there are ``(n-1)!`` possible cyclic permutations,
 which are sampled uniformly.  If `n == 0`, `randcycle` returns an empty array.
 
 [`randcycle!`](@ref) is an in-place variant of this function.

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -343,9 +343,11 @@ Construct a random cyclic permutation of length `n`. The optional `rng`
 argument specifies a random number generator, see [Random Numbers](@ref).
 The element type of the result is the same as the type of `n`.
 
-(Here, a "cyclic permutation" means that all of the elements lie within
+Here, a "cyclic permutation" means that all of the elements lie within
 a single cycle of length `n`.  There are ``(n-1)!`` possible cyclic permutations,
-which are sampled uniformly.  If `n == 0`, `randcycle` returns an empty array.)
+which are sampled uniformly.  If `n == 0`, `randcycle` returns an empty array.
+
+[`randcycle!`](@ref) is an in-place variant of this function.
 
 !!! compat "Julia 1.1"
     In Julia 1.1 `randcycle` returns a vector `v` with `eltype(v) == typeof(n)`
@@ -369,9 +371,15 @@ randcycle(n::Integer) = randcycle(default_rng(), n)
 """
     randcycle!([rng=default_rng(),] A::Array{<:Integer})
 
-Construct in `A` a random cyclic permutation of length `length(A)`.
+Construct in `A` a random cyclic permutation of length `n = length(A)`.
 The optional `rng` argument specifies a random number generator, see
 [Random Numbers](@ref).
+
+Here, a "cyclic permutation" means that all of the elements lie within a single cycle.
+If `A` is nonempty (`n > 0`), there are ``(n-1)!`` possible cyclic permutations,
+which are sampled uniformly.  If `A` is empty, `randcycle!` leaves it unchanged.
+
+[`randcycle`](@ref) is a variant of this function that allocates a new array.
 
 # Examples
 ```jldoctest

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -343,6 +343,10 @@ Construct a random cyclic permutation of length `n`. The optional `rng`
 argument specifies a random number generator, see [Random Numbers](@ref).
 The element type of the result is the same as the type of `n`.
 
+(Note that a cyclic permutation means that all of the elements consist of
+a single cycle of length `n`.  There are ``(n-1)!`` possible cyclic permutations,
+which are sampled uniformly.  If `n == 0`, `randcycle` returns an empty array.)
+
 !!! compat "Julia 1.1"
     In Julia 1.1 `randcycle` returns a vector `v` with `eltype(v) == typeof(n)`
     while in Julia 1.0 `eltype(v) == Int`.
@@ -387,6 +391,7 @@ function randcycle!(r::AbstractRNG, a::Array{<:Integer})
     @assert n <= Int64(2)^52
     a[1] = 1
     mask = 3
+    # Sattolo's algorithm:
     @inbounds for i = 2:n
         j = 1 + rand(r, ltm52(i-1, mask))
         a[i] = a[j]

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -345,7 +345,7 @@ The element type of the result is the same as the type of `n`.
 
 Here, a "cyclic permutation" means that all of the elements lie within
 a single cycle.  If `n > 0`, there are ``(n-1)!`` possible cyclic permutations,
-which are sampled uniformly.  If `n == 0`, `randcycle` returns an empty array.
+which are sampled uniformly.  If `n == 0`, `randcycle` returns an empty vector.
 
 [`randcycle!`](@ref) is an in-place variant of this function.
 

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -379,7 +379,7 @@ Here, a "cyclic permutation" means that all of the elements lie within a single 
 If `A` is nonempty (`n > 0`), there are ``(n-1)!`` possible cyclic permutations,
 which are sampled uniformly.  If `A` is empty, `randcycle!` leaves it unchanged.
 
-[`randcycle`](@ref) is a variant of this function that allocates a new array.
+[`randcycle`](@ref) is a variant of this function that allocates a new vector.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Closes #50479 by precisely stating the definition of "cyclic permutation" that we are using (which follows Knuth 2b), and the fact that we sample them uniformly.