### PR TITLE
Forward `axes` to the parent for a `Diagonal`

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -150,6 +150,11 @@ end
     r
 end
 
+function axes(D::Diagonal)
+    ax = axes(D.diag,1)
+    (ax, ax)
+end
+
 @inline function Base.isstored(D::Diagonal, i::Int, j::Int)
     @boundscheck checkbounds(D, i, j)
     if i == j

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -151,7 +151,7 @@ end
 end
 
 function axes(D::Diagonal)
-    ax = axes(D.diag,1)
+    ax = axes(D.diag, 1)
     (ax, ax)
 end
 

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -150,10 +150,7 @@ end
     r
 end
 
-function axes(D::Diagonal)
-    ax = axes(D.diag, 1)
-    (ax, ax)
-end
+axes(D::Diagonal) = (ax = axes(D.diag, 1); (ax, ax))
 
 @inline function Base.isstored(D::Diagonal, i::Int, j::Int)
     @boundscheck checkbounds(D, i, j)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -460,6 +460,12 @@ Random.seed!(1)
     end
 end
 
+@testset "axes" begin
+    v = OffsetArray(1:3)
+    D = Diagonal(v)
+    @test axes(D) isa NTuple{2,typeof(axes(v,1))}
+end
+
 @testset "rdiv! (#40887)" begin
     @test rdiv!(Matrix(Diagonal([2.0, 3.0])), Diagonal(2:3)) == Diagonal([1.0, 1.0])
     @test rdiv!(fill(3.0, 3, 3), 3.0I(3)) == ones(3,3)


### PR DESCRIPTION
Given that [quite a few](https://juliahub.com/ui/Search?q=axes%5Ba-zA-Z%5C%28%5C%29%3A%5D%2BDiagonal&type=code&r=true) packages define `axes(d::Diagonal{T, CustomVector{T}})` as `ax = parent(d); (ax,ax)`, perhaps it makes sense to have this defined in `LinearAlgebra`.

After this,
```julia
julia> using StaticArrays, StructArrays, LinearAlgebra

julia> D = Diagonal(StructArray{Complex{Int}}((SA[1,2], SA[1,2])))
2×2 Diagonal{Complex{Int64}, StructVector{Complex{Int64}, @NamedTuple{re::SVector{2, Int64}, im::SVector{2, Int64}}, Int64}} with indices SOneTo(2)×SOneTo(2):
 1+1im    ⋅  
   ⋅    2+2im

julia> axes(D)
(SOneTo(2), SOneTo(2))
```
The static sizes are preserved.

~This is potentially breaking, as `similar` may be undefined/ambiguous for custom axis types (see https://github.com/JuliaArrays/StructArrays.jl/issues/279), but this may be something to explore in the future.~ Packages should perhaps figure this out, as the specific method is broken anyway. 