### PR TITLE
Fix visibility of assert on GCC12/13

### DIFF
--- a/src/julia_assert.h
+++ b/src/julia_assert.h
@@ -10,6 +10,7 @@
 // Files that need `assert` should include this file after all other includes.
 // All files should also check `JL_NDEBUG` instead of `NDEBUG`.
 
+#pragma GCC visibility push(default)
 #ifdef NDEBUG
 #  ifndef JL_NDEBUG
 #    undef NDEBUG
@@ -28,3 +29,4 @@
 #    include <assert.h>
 #  endif
 #endif
+#pragma GCC visibility pop


### PR DESCRIPTION
Since updating my local development machine to GCC12/13 I have been running into
"undefined symbol __assert_fail". 

I am unsure if this is the correct fix, but at least it allows me to build debug builds again.
