### PR TITLE
only check that values are finite in `generic_lufact`  when `check=true`

### DIFF
--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -133,7 +133,7 @@ lu!(A::AbstractMatrix, pivot::Union{RowMaximum,NoPivot,RowNonZero} = lupivottype
     generic_lufact!(A, pivot; check = check)
 function generic_lufact!(A::AbstractMatrix{T}, pivot::Union{RowMaximum,NoPivot,RowNonZero} = lupivottype(T);
                          check::Bool = true) where {T}
-    LAPACK.chkfinite(A)
+    check && LAPACK.chkfinite(A)
     # Extract values
     m, n = size(A)
     minmn = min(m,n)

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -464,4 +464,11 @@ end
     @test Matrix(F1) ≈ Matrix(F2) ≈ C
 end
 
+@testset "matrix with Nonfinite"
+    lu(fill(NaN, 2, 2), check=false)
+    lu(fill(Inf, 2, 2), check=false)
+    LinearAlgebra.generic_lufact!(fill(NaN, 2, 2), check=false)
+    LinearAlgebra.generic_lufact!(fill(Inf, 2, 2), check=false)
+end
+
 end # module TestLU

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -464,7 +464,7 @@ end
     @test Matrix(F1) ≈ Matrix(F2) ≈ C
 end
 
-@testset "matrix with Nonfinite"
+@testset "matrix with Nonfinite" begin
     lu(fill(NaN, 2, 2), check=false)
     lu(fill(Inf, 2, 2), check=false)
     LinearAlgebra.generic_lufact!(fill(NaN, 2, 2), check=false)


### PR DESCRIPTION
followup to https://github.com/JuliaLang/julia/pull/50134/files. This fixes a bunch of SciML CI errors. We would really like this to make it into 1.9.3