### PR TITLE
remove allocation in skipchars

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -1392,7 +1392,7 @@ julia> String(readavailable(buf))
 function skipchars(predicate, io::IO; linecomment=nothing)
     for c in readeach(io, Char)
         if c === linecomment
-            copyline(devnull, io, keep=true)
+            copyline(devnull, io, keep=true) # like readline(io), but doesn't allocate
         elseif !predicate(c)
             skip(io, -ncodeunits(c))
             break

--- a/base/io.jl
+++ b/base/io.jl
@@ -1392,7 +1392,7 @@ julia> String(readavailable(buf))
 function skipchars(predicate, io::IO; linecomment=nothing)
     for c in readeach(io, Char)
         if c === linecomment
-            readline(io)
+            copyline(devnull, io, keep=true)
         elseif !predicate(c)
             skip(io, -ncodeunits(c))
             break


### PR DESCRIPTION
`skipchars` was using `readline(io)` to ignore line comments, which allocates a `String` that is immediately discarded.   This PR switches it to `copyline(devnull, io, keep=true)` instead, exploiting #48273, which shouldn't allocate.  (I pass `keep=true` because it's slightly more efficient in general, since it can skip the CRLF logic.)

(The existing tests cover this change.)