### PR TITLE
Use `oneto` in CartesianIndices given sizes

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -267,7 +267,7 @@ module IteratorsMD
     CartesianIndices(A::AbstractArray) = CartesianIndices(axes(A))
 
     _convert2ind(sz::Bool) = Base.OneTo(Int8(sz))
-    _convert2ind(sz::Integer) = Base.OneTo(sz)
+    _convert2ind(sz::Integer) = Base.oneto(sz)
     _convert2ind(sz::AbstractUnitRange) = first(sz):last(sz)
     _convert2ind(sz::OrdinalRange) = first(sz):step(sz):last(sz)
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2,6 +2,9 @@
 
 using Random, LinearAlgebra
 
+isdefined(Main, :InfiniteArrays) || @eval Main include("testhelpers/InfiniteArrays.jl")
+using .Main.InfiniteArrays
+
 A = rand(5,4,3)
 @testset "Bounds checking" begin
     @test checkbounds(Bool, A, 1, 1, 1) == true
@@ -54,6 +57,13 @@ end
     @test checkbounds(Bool, A, 6, CartesianIndex((4, 3)))  == false
     @test checkbounds(Bool, A, 5, CartesianIndex((5,)), 3) == false
     @test checkbounds(Bool, A, CartesianIndex((5,)), CartesianIndex((4,)), CartesianIndex((4,)))  == false
+end
+
+@testset "Infinite CartesianIndices" begin
+    r = OneToInf()
+    C = CartesianIndices(size(r))
+    ax = to_indices(r, (C,))[1]
+    @test ax === r
 end
 
 @testset "vector indices" begin


### PR DESCRIPTION
This PR changes the way a `CartesianIndices` maps sizes to axes from `OneTo` to `oneto`. Packages that specialize `oneto` for special integer types may avail these when constructing a `CartesianIndices` from sizes. For example, this would permit
```julia
julia> r = InfiniteArrays.OneToInf()
OneToInf()

julia> r[CartesianIndices(size(r))]
1:∞
```