### PR TITLE
gc: remove over-eager assertion

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1483,7 +1483,7 @@ static int get_intersect_visitor(jl_typemap_entry_t *oldentry, struct typemap_in
     struct matches_env *closure = container_of(closure0, struct matches_env, match);
     assert(oldentry != closure->newentry && "entry already added");
     assert(oldentry->min_world <= closure->newentry->min_world && "old method cannot be newer than new method");
-    assert(oldentry->max_world == ~(size_t)0 && "method cannot be added at the same time as method deleted");
+    assert(oldentry->max_world != closure->newentry->min_world && "method cannot be added at the same time as method deleted");
     // don't need to consider other similar methods if this oldentry will always fully intersect with them and dominates all of them
     typemap_slurp_search(oldentry, &closure->match);
     jl_method_t *oldmethod = oldentry->func.method;


### PR DESCRIPTION
Fixes #50451. Fortunately, this wasn't anything more than an unnecessary assertion.