### PR TITLE
gf: remove unnecessary assert cycle==depth

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -3426,7 +3426,9 @@ static int sort_mlmatches(jl_array_t *t, size_t idx, arraylist_t *visited, array
                 }
             }
             if ((size_t)visited->items[idx] == 1) {
-                assert(cycle == depth);
+                // n.b. cycle might be < depth, if we had a cycle with a child
+                // idx, but since we are on the top of the stack, nobody
+                // observed that and so we are content to ignore this
                 size_t childidx = (size_t)arraylist_pop(stack);
                 assert(childidx == idx); (void)childidx;
                 assert(!subt || *found_minmax == 2);


### PR DESCRIPTION
We do not care about this condition (the point of this fast path is to skip checking it).

Fix #50450