### PR TITLE
make abi_aarch64 return structs

### DIFF
--- a/src/abi_aarch64.cpp
+++ b/src/abi_aarch64.cpp
@@ -376,7 +376,7 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret, LLVMContext &ctx) const
     bool onstack = false;
     size_t rewrite_len = 0;
     if (Type *rewrite_ty = classify_arg(dt, &fpreg, &onstack, &rewrite_len, ctx))
-        return ArrayType::get(rewrite_ty, rewrite_len);
+        return StructType::get(ctx, ArrayRef<Type*>(std::vector<Type*>(rewrite_len, rewrite_ty)));
     return NULL;
 }
 

--- a/src/abi_aarch64.cpp
+++ b/src/abi_aarch64.cpp
@@ -376,7 +376,7 @@ Type *preferred_llvm_type(jl_datatype_t *dt, bool isret, LLVMContext &ctx) const
     bool onstack = false;
     size_t rewrite_len = 0;
     if (Type *rewrite_ty = classify_arg(dt, &fpreg, &onstack, &rewrite_len, ctx))
-        return StructType::get(ctx, ArrayRef<Type*>(std::vector<Type*>(rewrite_len, rewrite_ty)));
+        return StructType::get(ctx, ArrayRef<Type*>(std::vector<Type*>(rewrite_len, rewrite_ty)), true);
     return NULL;
 }
 


### PR DESCRIPTION
Native codegen is unchanged, preserving the abi but makes ComplexFP64 look the same as x86_64 in IR.