### PR TITLE
read(io, Char): fix read with too many leading ones

### DIFF
--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -200,11 +200,10 @@ end
 
 function read(f::File, ::Type{Char})
     b0 = read(f, UInt8)
-    l::UInt8 = leading_ones(b0)
+    l = 0x08 * (0x04 - UInt8(leading_ones(b0)))
     c = UInt32(b0) << 24
-    if 2 ≤ l ≤ 4
+    if l ≤ 0x10
         s = 16
-        l = 8(4-l)
         while s ≥ l && !eof(f)
             # this works around lack of peek(::File)
             p = position(f)

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -200,11 +200,13 @@ end
 
 function read(f::File, ::Type{Char})
     b0 = read(f, UInt8)
-    l = 8 * (4 - leading_ones(b0))
+    l::UInt8 = leading_ones(b0)
     c = UInt32(b0) << 24
-    if l < 24
+    if 2 ≤ l ≤ 4
         s = 16
+        l = 8(4-l)
         while s ≥ l && !eof(f)
+            # this works around lack of peek(::File)
             p = position(f)
             b = read(f, UInt8)
             if b & 0xc0 != 0x80

--- a/base/io.jl
+++ b/base/io.jl
@@ -884,11 +884,10 @@ end
 
 function read(io::IO, ::Type{Char})
     b0 = read(io, UInt8)::UInt8
-    l::UInt8 = leading_ones(b0)
+    l = 0x08 * (0x04 - UInt8(leading_ones(b0)))
     c = UInt32(b0) << 24
-    if 2 ≤ l ≤ 4
+    if l ≤ 0x10
         s = 16
-        l = 8(4-l)
         while s ≥ l && !eof(io)::Bool
             peek(io) & 0xc0 == 0x80 || break
             b = read(io, UInt8)::UInt8

--- a/base/io.jl
+++ b/base/io.jl
@@ -884,10 +884,11 @@ end
 
 function read(io::IO, ::Type{Char})
     b0 = read(io, UInt8)::UInt8
-    l = 8(4-leading_ones(b0))
+    l::UInt8 = leading_ones(b0)
     c = UInt32(b0) << 24
-    if l < 24
+    if 2 ≤ l ≤ 4
         s = 16
+        l = 8(4-l)
         while s ≥ l && !eof(io)::Bool
             peek(io) & 0xc0 == 0x80 || break
             b = read(io, UInt8)::UInt8

--- a/test/char.jl
+++ b/test/char.jl
@@ -221,17 +221,25 @@ end
         0xc0, 0xc8, 0xd3, 0xe3, 0xea, 0xeb, 0xf0, 0xf2,
         0xf4, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff,
     ]
+    f = tempname()
     for b1 in B, b2 in B, t = 0:3
         bytes = [b1, b2]
         append!(bytes, rand(B, t))
         s = String(bytes)
-        io = IOBuffer(s)
-        chars = Char[]
-        while !eof(io)
-            push!(chars, read(io, Char))
+        write(f, s)
+        @test s == read(f, String)
+        chars = collect(s)
+        ios = [IOBuffer(s), open(f), Base.Filesystem.open(f, 0)]
+        for io in ios
+            chars′ = Char[]
+            while !eof(io)
+                push!(chars′, read(io, Char))
+            end
+            @test chars == chars′
+            close(io)
         end
-        @test collect(s) == chars
     end
+    rm(f)
 end
 
 @testset "overlong codes" begin


### PR DESCRIPTION
Fixes #50532. The `read(io, Char)` method didn't correctly handle the case where the lead byte starts with too many leading ones; this fix makes it handle that case correctly, which makes `read(io, Char)` match `collect(s)` in its interpretation of what a character is in all invalid cases.
