### PR TITLE
Expand kwcall lowering positional default check to vararg

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -555,7 +555,7 @@
           name positional-sparams
           `((|::|
              ;; if there are optional positional args, we need to be able to reference the function name
-             ,(if (any kwarg? pargl) (gensy) UNUSED)
+             ,(if (any kwarg? `(,@pargl ,@vararg)) (gensy) UNUSED)
              (call (core kwftype) ,ftype)) ,kwdecl ,@pargl ,@vararg)
           `(block
             ;; propagate method metadata to keyword sorter

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -394,3 +394,9 @@ let m = first(methods(Core.kwcall, (NamedTuple,typeof(kwf1),Vararg)))
     @test Core.kwcall(1) == "hi 1"
     @test which(Core.kwcall, (Int,)).name === :kwcall
 end
+
+# issue #50518
+function f50518(xs...=["a", "b", "c"]...; debug=false)
+    return xs[1]
+end
+@test f50518() == f50518(;debug=false) == "a"


### PR DESCRIPTION
Fixes the case from #50518, but we actually have two test cases in the tests that also hit this (e.g. this one:
```
f40964(xs::Int...=1; k = 2) = (xs, k)
```
), but just happened not to hit the bad codegen path. #50556, once merged would have complained on those definitions as well, without this fix.