### PR TITLE
Add getfield/setfield names, propagate names through more places

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2538,11 +2538,11 @@ static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &st
     bool isatomic = jl_field_isatomic(jt, idx);
     bool needlock = isatomic && !jl_field_isptr(jt, idx) && jl_datatype_size(jfty) > MAX_ATOMIC_SIZE;
     if (!isatomic && order != jl_memory_order_notatomic && order != jl_memory_order_unspecified) {
-        emit_atomic_error(ctx, ("getfield: non-atomic field " + StringRef(jl_symbol_name(jt->name->name)) + "." + get_fieldname(jt, idx) + " cannot be accessed atomically").str());
+        emit_atomic_error(ctx, "getfield: non-atomic field cannot be accessed atomically");
         return jl_cgval_t(); // unreachable
     }
     if (isatomic && order == jl_memory_order_notatomic) {
-        emit_atomic_error(ctx, ("getfield: atomic field " + StringRef(jl_symbol_name(jt->name->name)) + "." + get_fieldname(jt, idx) + " cannot be accessed non-atomically").str());
+        emit_atomic_error(ctx, "getfield: atomic field cannot be accessed non-atomically");
         return jl_cgval_t(); // unreachable
     }
     if (order == jl_memory_order_unspecified) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -177,6 +177,14 @@ void setName(jl_codegen_params_t &params, Value *V, const Twine &Name)
     }
 }
 
+void setName(jl_codegen_params_t &params, Value *V, std::function<std::string()> GetName)
+{
+    assert((isa<Constant>(V) || isa<Instruction>(V)) && "Should only set names on instructions!");
+    if (params.debug_level && !isa<Constant>(V)) {
+        V->setName(Twine(GetName()));
+    }
+}
+
 STATISTIC(EmittedAllocas, "Number of allocas emitted");
 STATISTIC(EmittedIntToPtrs, "Number of inttoptrs emitted");
 STATISTIC(ModulesCreated, "Number of LLVM Modules created");

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -171,6 +171,9 @@ void setName(jl_codegen_params_t &params, Value *V, const Twine &Name)
 {
     // we do the constant check again later, duplicating it here just makes sure the assertion
     // fires on debug builds even if debug info is not enabled
+    // note that if this assertion fires then the implication is that the caller of setName
+    // is not checking that setName is only called for non-folded instructions (e.g. folded bitcasts
+    // and 0-byte geps), which can result in information loss on the renamed instruction.
     assert((isa<Constant>(V) || isa<Instruction>(V)) && "Should only set names on instructions!");
     if (params.debug_level && !isa<Constant>(V)) {
         V->setName(Name);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -397,7 +397,7 @@ static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x, jl_va
     if (jt == (jl_value_t*)jl_bool_type || to->isIntegerTy(1)) {
         jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, x.tbaa);
         Instruction *unbox_load = ai.decorateInst(ctx.builder.CreateLoad(getInt8Ty(ctx.builder.getContext()), maybe_bitcast(ctx, p, getInt8PtrTy(ctx.builder.getContext()))));
-        setName(ctx.emission_context, unbox_load, "unbox");
+        setName(ctx.emission_context, unbox_load, p->getName() + ".unbox");
         if (jt == (jl_value_t*)jl_bool_type)
             unbox_load->setMetadata(LLVMContext::MD_range, MDNode::get(ctx.builder.getContext(), {
                 ConstantAsMetadata::get(ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0)),
@@ -425,14 +425,14 @@ static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x, jl_va
                 (to->isFloatingPointTy() || to->isIntegerTy() || to->isPointerTy()) &&
                 DL.getTypeSizeInBits(AllocType) == DL.getTypeSizeInBits(to)) {
             Instruction *load = ctx.builder.CreateAlignedLoad(AllocType, p, Align(alignment));
-            setName(ctx.emission_context, load, "unbox");
+            setName(ctx.emission_context, load, p->getName() + ".unbox");
             jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, x.tbaa);
             return emit_unboxed_coercion(ctx, to, ai.decorateInst(load));
         }
     }
     p = maybe_bitcast(ctx, p, ptype);
     Instruction *load = ctx.builder.CreateAlignedLoad(to, p, Align(alignment));
-    setName(ctx.emission_context, load, "unbox");
+    setName(ctx.emission_context, load, p->getName() + ".unbox");
     jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, x.tbaa);
     return ai.decorateInst(load);
 }


### PR DESCRIPTION
This makes field names show up when we lower setfield/getfield, and tries to ensure that names are propagated through operations.

<details>
<summary>Struct Example</summary>

```julia
julia> struct A
           a::Int
           b::Float64
           c::UInt
       end

julia> a = A(1, 1.0, 0x01)
A(1, 1.0, 0x0000000000000001)

julia> function f(a)
           a.b
       end
f (generic function with 1 method)

julia> @code_llvm f(a)
```

```llvm
;  @ REPL[5]:1 within `f`
define double @julia_f_164({ i64, double, i64 }* nocapture noundef nonnull readonly align 8 dereferenceable(24) %"a::A") #0 {
top:
;  @ REPL[5]:2 within `f`
; ┌ @ Base.jl:37 within `getproperty`
   %"a::A.b_ptr" = getelementptr inbounds { i64, double, i64 }, { i64, double, i64 }* %"a::A", i64 0, i32 1
; └
  %"a::A.b_ptr.unbox" = load double, double* %"a::A.b_ptr", align 8
  ret double %"a::A.b_ptr.unbox"
}
```

</details>

<details>
<summary>kwarg Example</summary>

```julia
function g(a, b, c, d; kwarg=0, kwarg2=1)
                 a + b + c + d + kwarg + kwarg2
             end
g (generic function with 1 method)

julia> @code_llvm g(0,0,0,0,kwarg=0,kwarg2=1)
```

```llvm
;  @ REPL[1]:1 within `g`
define i64 @julia_g_138([2 x i64]* nocapture noundef nonnull readonly align 8 dereferenceable(16) %"#1::NamedTuple", i64 signext %"a::Int64", i64 signext %"b::Int64", i64 signext %"c::Int64", i64 signext %"d::Int64") #0 {
top:
  %"#1::NamedTuple.kwarg_ptr" = getelementptr inbounds [2 x i64], [2 x i64]* %"#1::NamedTuple", i64 0, i64 0
  %"#1::NamedTuple.kwarg2_ptr" = getelementptr inbounds [2 x i64], [2 x i64]* %"#1::NamedTuple", i64 0, i64 1
; ┌ @ REPL[1]:2 within `#g#1`
; │┌ @ operators.jl:587 within `+` @ int.jl:87
    %0 = add i64 %"b::Int64", %"a::Int64"
    %1 = add i64 %0, %"c::Int64"
; ││ @ operators.jl:587 within `+`
; ││┌ @ operators.jl:544 within `afoldl`
; │││┌ @ int.jl:87 within `+`
      %2 = add i64 %1, %"d::Int64"
; │││└
; │││ @ operators.jl:545 within `afoldl`
; │││┌ @ int.jl:87 within `+`
      %"#1::NamedTuple.kwarg_ptr.unbox" = load i64, i64* %"#1::NamedTuple.kwarg_ptr", align 8
      %3 = add i64 %2, %"#1::NamedTuple.kwarg_ptr.unbox"
; │││└
; │││ @ operators.jl:546 within `afoldl`
; │││┌ @ int.jl:87 within `+`
      %"#1::NamedTuple.kwarg2_ptr.unbox" = load i64, i64* %"#1::NamedTuple.kwarg2_ptr", align 8
      %4 = add i64 %3, %"#1::NamedTuple.kwarg2_ptr.unbox"
; └└└└
  ret i64 %4
}
```

</details>

<details>
<summary>Array propagation example</summary>

```julia
julia> struct A
           arr::Vector{Int}
       end

julia> function sum_example(a)
           s = zero(eltype(a.arr))
           for i in eachindex(a.arr)
               s += a.arr[i]
           end
           s
       end
sum_example (generic function with 1 method)

julia> @code_llvm sum_example(A([1]))
```

```llvm
;  @ REPL[3]:1 within `sum_example`
define i64 @julia_sum_example_134(ptr nocapture noundef nonnull readonly align 8 dereferenceable(8) %"a::A") #0 {
top:
;  @ REPL[3]:3 within `sum_example`
; ┌ @ Base.jl:37 within `getproperty`
   %"a::A.arr" = load atomic ptr, ptr %"a::A" unordered, align 8
; └
; ┌ @ abstractarray.jl:318 within `eachindex`
; │┌ @ abstractarray.jl:134 within `axes1`
; ││┌ @ abstractarray.jl:98 within `axes`
; │││┌ @ array.jl:191 within `size`
      %"a::A.arr.length_ptr" = getelementptr inbounds { ptr, i64, i16, i16, i32 }, ptr %"a::A.arr", i64 0, i32 1
      %"a::A.arr.length" = load i64, ptr %"a::A.arr.length_ptr", align 8
; └└└└
; ┌ @ range.jl:897 within `iterate`
; │┌ @ range.jl:672 within `isempty`
; ││┌ @ operators.jl:378 within `>`
; │││┌ @ int.jl:83 within `<`
      %.not.not = icmp eq i64 %"a::A.arr.length", 0
; └└└└
  br i1 %.not.not, label %L31, label %L14

L14:                                              ; preds = %idxend, %top
  %value_phi3 = phi i64 [ %3, %idxend ], [ 1, %top ]
  %value_phi5 = phi i64 [ %2, %idxend ], [ 0, %top ]
;  @ REPL[3]:4 within `sum_example`
; ┌ @ essentials.jl:13 within `getindex`
   %0 = add i64 %value_phi3, -1
   %"a::A.arr8.length" = load i64, ptr %"a::A.arr.length_ptr", align 8
   %inbounds = icmp ult i64 %0, %"a::A.arr8.length"
   br i1 %inbounds, label %idxend, label %oob

L31:                                              ; preds = %idxend, %top
   %value_phi12 = phi i64 [ 0, %top ], [ %2, %idxend ]
; └
;  @ REPL[3]:6 within `sum_example`
  ret i64 %value_phi12

oob:                                              ; preds = %L14
;  @ REPL[3]:4 within `sum_example`
; ┌ @ essentials.jl:13 within `getindex`
   %errorbox = alloca i64, align 8
   store i64 %value_phi3, ptr %errorbox, align 8
   call void @ijl_bounds_error_ints(ptr %"a::A.arr", ptr nonnull %errorbox, i64 1)
   unreachable

idxend:                                           ; preds = %L14
   %"a::A.arr8.data" = load ptr, ptr %"a::A.arr", align 8
   %1 = getelementptr inbounds i64, ptr %"a::A.arr8.data", i64 %0
   %"a::A.arr8.ref" = load i64, ptr %1, align 8
; └
; ┌ @ int.jl:87 within `+`
   %2 = add i64 %value_phi5, %"a::A.arr8.ref"
; └
;  @ REPL[3]:5 within `sum_example`
; ┌ @ range.jl:901 within `iterate`
; │┌ @ promotion.jl:521 within `==`
    %.not.not14 = icmp eq i64 %value_phi3, %"a::A.arr.length"
; │└
   %3 = add i64 %value_phi3, 1
; └
  br i1 %.not.not14, label %L31, label %L14
}
```

</details>