### PR TITLE
Print LLVM module when verification fails

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -984,7 +984,7 @@ static AOTOutputs add_output_impl(Module &M, TargetMachine &SourceTM, ShardTimer
     if (!opt && !obj && !asm_) {
         return out;
     }
-    assert(!verifyModule(M, &errs()));
+    assert(!verifyLLVMIR(M));
 
     timers.optimize.startTimer();
 
@@ -1007,7 +1007,7 @@ static AOTOutputs add_output_impl(Module &M, TargetMachine &SourceTM, ShardTimer
     NewPM optimizer{std::move(PMTM), getOptLevel(jl_options.opt_level), OptimizationOptions::defaults(true, true)};
 #endif
     optimizer.run(M);
-    assert(!verifyModule(M, &errs()));
+    assert(!verifyLLVMIR(M));
     bool inject_aliases = false;
     for (auto &F : M.functions()) {
         if (!F.isDeclaration() && F.getName() != "_DllMainCRTStartup") {
@@ -1077,7 +1077,7 @@ static AOTOutputs add_output_impl(Module &M, TargetMachine &SourceTM, ShardTimer
 
 // serialize module to bitcode
 static auto serializeModule(const Module &M) {
-    assert(!verifyModule(M, &errs()) && "Serializing invalid module!");
+    assert(!verifyLLVMIR(M) && "Serializing invalid module!");
     SmallVector<char, 0> ClonedModuleBuffer;
     BitcodeWriter BCWriter(ClonedModuleBuffer);
     BCWriter.writeModule(M);
@@ -2108,7 +2108,7 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t* dump, jl_method_instance_t *mi, siz
             // and will better match what's actually in sysimg.
             for (auto &global : output.globals)
                 global.second->setLinkage(GlobalValue::ExternalLinkage);
-            assert(!verifyModule(*m.getModuleUnlocked(), &errs()));
+            assert(!verifyLLVMIR(*m.getModuleUnlocked()));
             if (optimize) {
 #ifndef JL_USE_NEW_PM
                 legacy::PassManager PM;
@@ -2120,7 +2120,7 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t* dump, jl_method_instance_t *mi, siz
 #endif
                 //Safe b/c context lock is held by output
                 PM.run(*m.getModuleUnlocked());
-                assert(!verifyModule(*m.getModuleUnlocked(), &errs()));
+                assert(!verifyLLVMIR(*m.getModuleUnlocked()));
             }
             const std::string *fname;
             if (decls.functionObject == "jl_fptr_args" || decls.functionObject == "jl_fptr_sparam")

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1217,9 +1217,9 @@ namespace {
                 JL_TIMING(LLVM_OPT, LLVM_OPT);
 
                 //Run the optimization
-                assert(!verifyModule(M, &errs()));
+                assert(!verifyLLVMIR(M));
                 (***PMs).run(M);
-                assert(!verifyModule(M, &errs()));
+                assert(!verifyLLVMIR(M));
 
                 uint64_t end_time = 0;
                 {

--- a/src/llvm-alloc-opt.cpp
+++ b/src/llvm-alloc-opt.cpp
@@ -1247,7 +1247,7 @@ bool AllocOpt::runOnFunction(Function &F, function_ref<DominatorTree&()> GetDT)
     optimizer.optimizeAll();
     bool modified = optimizer.finalize();
 #ifdef JL_VERIFY_PASSES
-    assert(!verifyFunction(F, &errs()));
+    assert(!verifyLLVMIR(F));
 #endif
     return modified;
 }

--- a/src/llvm-cpufeatures.cpp
+++ b/src/llvm-cpufeatures.cpp
@@ -110,7 +110,7 @@ bool lowerCPUFeatures(Module &M) JL_NOTSAFEPOINT
             I->eraseFromParent();
         }
 #ifdef JL_VERIFY_PASSES
-        assert(!verifyModule(M, &errs()));
+        assert(!verifyLLVMIR(M));
 #endif
         return true;
     } else {

--- a/src/llvm-demote-float16.cpp
+++ b/src/llvm-demote-float16.cpp
@@ -184,7 +184,7 @@ static bool demoteFloat16(Function &F)
         for (auto V : erase)
             V->eraseFromParent();
 #ifdef JL_VERIFY_PASSES
-        assert(!verifyFunction(F, &errs()));
+        assert(!verifyLLVMIR(F));
 #endif
         return true;
     }

--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -396,7 +396,7 @@ bool FinalLowerGCLegacy::doInitialization(Module &M) {
 bool FinalLowerGCLegacy::doFinalization(Module &M) {
     auto ret = finalLowerGC.doFinalization(M);
 #ifdef JL_VERIFY_PASSES
-    assert(!verifyModule(M, &errs()));
+    assert(!verifyLLVMIR(M));
 #endif
     return ret;
 }
@@ -414,7 +414,7 @@ PreservedAnalyses FinalLowerGCPass::run(Module &M, ModuleAnalysisManager &AM)
     }
     modified |= finalLowerGC.doFinalization(M);
 #ifdef JL_VERIFY_PASSES
-    assert(!verifyModule(M, &errs()));
+    assert(!verifyLLVMIR(M));
 #endif
     if (modified) {
         return PreservedAnalyses::allInSet<CFGAnalyses>();

--- a/src/llvm-julia-licm.cpp
+++ b/src/llvm-julia-licm.cpp
@@ -358,7 +358,7 @@ struct JuliaLICM : public JuliaPassContext {
             SE->forgetLoopDispositions(L);
         }
 #ifdef JL_VERIFY_PASSES
-        assert(!verifyFunction(*L->getHeader()->getParent(), &errs()));
+        assert(!verifyLLVMIR(*L));
 #endif
         return changed;
     }

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2772,7 +2772,7 @@ bool LateLowerGCFrameLegacy::runOnFunction(Function &F) {
     auto lateLowerGCFrame = LateLowerGCFrame(GetDT);
     bool modified = lateLowerGCFrame.runOnFunction(F);
 #ifdef JL_VERIFY_PASSES
-    assert(!verifyFunction(F, &errs()));
+    assert(!verifyLLVMIR(F));
 #endif
     return modified;
 }
@@ -2786,7 +2786,7 @@ PreservedAnalyses LateLowerGCPass::run(Function &F, FunctionAnalysisManager &AM)
     bool CFGModified = false;
     bool modified = lateLowerGCFrame.runOnFunction(F, &CFGModified);
 #ifdef JL_VERIFY_PASSES
-    assert(!verifyFunction(F, &errs()));
+    assert(!verifyLLVMIR(F));
 #endif
     if (modified) {
         if (CFGModified) {

--- a/src/llvm-lower-handlers.cpp
+++ b/src/llvm-lower-handlers.cpp
@@ -240,7 +240,7 @@ PreservedAnalyses LowerExcHandlersPass::run(Function &F, FunctionAnalysisManager
 {
     bool modified = lowerExcHandlers(F);
 #ifdef JL_VERIFY_PASSES
-    assert(!verifyFunction(F, &errs()));
+    assert(!verifyLLVMIR(F));
 #endif
     if (modified) {
         return PreservedAnalyses::allInSet<CFGAnalyses>();
@@ -256,7 +256,7 @@ struct LowerExcHandlersLegacy : public FunctionPass {
     bool runOnFunction(Function &F) {
         bool modified = lowerExcHandlers(F);
 #ifdef JL_VERIFY_PASSES
-        assert(!verifyFunction(F, &errs()));
+        assert(!verifyLLVMIR(F));
 #endif
         return modified;
     }

--- a/src/llvm-muladd.cpp
+++ b/src/llvm-muladd.cpp
@@ -104,7 +104,7 @@ static bool combineMulAdd(Function &F) JL_NOTSAFEPOINT
         }
     }
 #ifdef JL_VERIFY_PASSES
-    assert(!verifyFunction(F, &errs()));
+    assert(!verifyLLVMIR(F));
 #endif
     return modified;
 }

--- a/src/llvm-multiversioning.cpp
+++ b/src/llvm-multiversioning.cpp
@@ -1104,7 +1104,7 @@ static bool runMultiVersioning(Module &M, bool allow_bad_fvars)
     // and collected all the shared/target-specific relocations.
     clone.emit_metadata();
 #ifdef JL_VERIFY_PASSES
-    assert(!verifyModule(M, &errs()));
+    assert(!verifyLLVMIR(M));
 #endif
 
     return true;

--- a/src/llvm-propagate-addrspaces.cpp
+++ b/src/llvm-propagate-addrspaces.cpp
@@ -306,7 +306,7 @@ struct PropagateJuliaAddrspacesLegacy : FunctionPass {
     bool runOnFunction(Function &F) override {
         bool modified = propagateJuliaAddrspaces(F);
 #ifdef JL_VERIFY_PASSES
-        assert(!verifyFunction(F, &errs()));
+        assert(!verifyLLVMIR(F));
 #endif
         return modified;
     }
@@ -323,7 +323,7 @@ PreservedAnalyses PropagateJuliaAddrspacesPass::run(Function &F, FunctionAnalysi
     bool modified = propagateJuliaAddrspaces(F);
 
 #ifdef JL_VERIFY_PASSES
-    assert(!verifyFunction(F, &errs()));
+    assert(!verifyLLVMIR(F));
 #endif
     if (modified) {
         return PreservedAnalyses::allInSet<CFGAnalyses>();

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -355,7 +355,7 @@ struct LowerPTLSLegacy: public ModulePass {
         LowerPTLS lower(M, imaging_mode);
         bool modified = lower.run(nullptr);
 #ifdef JL_VERIFY_PASSES
-        assert(!verifyModule(M, &errs()));
+        assert(!verifyLLVMIR(M));
 #endif
         return modified;
     }
@@ -374,7 +374,7 @@ PreservedAnalyses LowerPTLSPass::run(Module &M, ModuleAnalysisManager &AM) {
     bool CFGModified = false;
     bool modified = lower.run(&CFGModified);
 #ifdef JL_VERIFY_PASSES
-    assert(!verifyModule(M, &errs()));
+    assert(!verifyLLVMIR(M));
 #endif
     if (modified) {
         if (CFGModified) {

--- a/src/llvm-remove-addrspaces.cpp
+++ b/src/llvm-remove-addrspaces.cpp
@@ -444,7 +444,7 @@ public:
     bool runOnModule(Module &M) override {
         bool modified = removeAddrspaces(M, ASRemapper);
 #ifdef JL_VERIFY_PASSES
-        assert(!verifyModule(M, &errs()));
+        assert(!verifyLLVMIR(M));
 #endif
         return modified;
     }
@@ -468,7 +468,7 @@ RemoveAddrspacesPass::RemoveAddrspacesPass() : RemoveAddrspacesPass(removeAllAdd
 PreservedAnalyses RemoveAddrspacesPass::run(Module &M, ModuleAnalysisManager &AM) {
     bool modified = removeAddrspaces(M, ASRemapper);
 #ifdef JL_VERIFY_PASSES
-    assert(!verifyModule(M, &errs()));
+    assert(!verifyLLVMIR(M));
 #endif
     if (modified) {
         return PreservedAnalyses::allInSet<CFGAnalyses>();

--- a/src/llvm-simdloop.cpp
+++ b/src/llvm-simdloop.cpp
@@ -270,7 +270,7 @@ static bool markLoopInfo(Module &M, Function *marker, function_ref<LoopInfo &(Fu
         I->deleteValue();
     marker->eraseFromParent();
 #ifdef JL_VERIFY_PASSES
-    assert(!verifyModule(M, &errs()));
+    assert(!verifyLLVMIR(M));
 #endif
     return Changed;
 }

--- a/src/passes.h
+++ b/src/passes.h
@@ -146,4 +146,8 @@ MODULE_MARKER_PASS(BeforeCleanup)
 MODULE_MARKER_PASS(AfterCleanup)
 MODULE_MARKER_PASS(AfterOptimization)
 
+bool verifyLLVMIR(const Module &M);
+bool verifyLLVMIR(const Function &F);
+bool verifyLLVMIR(const Loop &L);
+
 #endif

--- a/src/passes.h
+++ b/src/passes.h
@@ -146,8 +146,8 @@ MODULE_MARKER_PASS(BeforeCleanup)
 MODULE_MARKER_PASS(AfterCleanup)
 MODULE_MARKER_PASS(AfterOptimization)
 
-bool verifyLLVMIR(const Module &M);
-bool verifyLLVMIR(const Function &F);
-bool verifyLLVMIR(const Loop &L);
+bool verifyLLVMIR(const Module &M) JL_NOTSAFEPOINT;
+bool verifyLLVMIR(const Function &F) JL_NOTSAFEPOINT;
+bool verifyLLVMIR(const Loop &L) JL_NOTSAFEPOINT;
 
 #endif

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -814,6 +814,33 @@ static llvm::Optional<std::pair<OptimizationLevel, OptimizationOptions>> parseJu
     return {};
 }
 
+bool verifyLLVMIR(const Module &M) {
+    if (verifyModule(M, &errs())) {
+        errs() << "Failed to verify module '" << M.getModuleIdentifier() << "', dumping entire module!\n\n";
+        errs() << M << "\n";
+        return true;
+    }
+    return false;
+}
+
+bool verifyLLVMIR(const Function &F) {
+    if (verifyFunction(F, &errs())) {
+        errs() << "Failed to verify function '" << F.getName() << "', dumping entire module!\n\n";
+        errs() << *F.getParent() << "\n";
+        return true;
+    }
+    return false;
+}
+
+bool verifyLLVMIR(const Loop &L) {
+    if (verifyFunction(*L.getHeader()->getParent(), &errs())) {
+        errs() << "Failed to verify loop '" << L.getName() << "', dumping entire module!\n\n";
+        errs() << *L.getHeader()->getModule() << "\n";
+        return true;
+    }
+    return false;
+}
+
 // new pass manager plugin
 
 // NOTE: Instead of exporting all the constructors in passes.h we could

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -814,7 +814,7 @@ static llvm::Optional<std::pair<OptimizationLevel, OptimizationOptions>> parseJu
     return {};
 }
 
-bool verifyLLVMIR(const Module &M) {
+bool verifyLLVMIR(const Module &M) JL_NOTSAFEPOINT {
     if (verifyModule(M, &errs())) {
         errs() << "Failed to verify module '" << M.getModuleIdentifier() << "', dumping entire module!\n\n";
         errs() << M << "\n";
@@ -823,7 +823,7 @@ bool verifyLLVMIR(const Module &M) {
     return false;
 }
 
-bool verifyLLVMIR(const Function &F) {
+bool verifyLLVMIR(const Function &F) JL_NOTSAFEPOINT {
     if (verifyFunction(F, &errs())) {
         errs() << "Failed to verify function '" << F.getName() << "', dumping entire module!\n\n";
         errs() << *F.getParent() << "\n";
@@ -832,7 +832,7 @@ bool verifyLLVMIR(const Function &F) {
     return false;
 }
 
-bool verifyLLVMIR(const Loop &L) {
+bool verifyLLVMIR(const Loop &L) JL_NOTSAFEPOINT {
     if (verifyFunction(*L.getHeader()->getParent(), &errs())) {
         errs() << "Failed to verify loop '" << L.getName() << "', dumping entire module!\n\n";
         errs() << *L.getHeader()->getModule() << "\n";


### PR DESCRIPTION
This should hopefully make it easier to identify why a particular piece of LLVM IR fails the verifier, and give more contextual clues as to the nature of the verification failure. 