### PR TITLE
Use named global aliases for literal pointers where the name is deducible

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -2096,7 +2096,7 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t* dump, jl_method_instance_t *mi, siz
         // Force at least medium debug info for introspection
         // No debug info = no variable names,
         // max debug info = llvm.dbg.declare/value intrinsics which clutter IR output
-        output.debug_level = std::max(1, static_cast<int>(jl_options.debug_level));
+        output.debug_level = std::max(2, static_cast<int>(jl_options.debug_level));
         auto decls = jl_emit_code(m, mi, src, jlrettype, output);
         JL_UNLOCK(&jl_codegen_lock); // Might GC
 

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -472,7 +472,7 @@ static Value *runtime_apply_type_env(jl_codectx_t &ctx, jl_value_t *ty)
     // box if concrete type was not statically known
     Value *args[] = {
         literal_pointer_val(ctx, ty),
-        literal_pointer_val(ctx, (jl_value_t*)ctx.linfo->def.method->sig),
+        literal_pointer_val(ctx, (jl_value_t*)ctx.linfo->def.method->sig, jl_symbol_name(ctx.linfo->def.method->module->name) + StringRef(".") + jl_symbol_name(ctx.linfo->def.method->name) + ".sig"),
         ctx.builder.CreateInBoundsGEP(
                 ctx.types().T_prjlvalue,
                 ctx.spvals_ptr,
@@ -706,7 +706,7 @@ static jl_cgval_t emit_cglobal(jl_codectx_t &ctx, jl_value_t **args, size_t narg
     if (sym.f_name == NULL && sym.fptr == NULL && sym.jl_ptr == NULL && sym.gcroot != NULL) {
         const char *errmsg = invalid_symbol_err_msg(/*ccall=*/false);
         jl_cgval_t arg1 = emit_expr(ctx, args[1]);
-        emit_type_error(ctx, arg1, literal_pointer_val(ctx, (jl_value_t *)jl_pointer_type), errmsg);
+        emit_type_error(ctx, arg1, literal_pointer_val(ctx, (jl_value_t *)jl_pointer_type, jl_symbol_name(jl_pointer_typename->name)), errmsg);
         JL_GC_POP();
         return jl_cgval_t();
     }
@@ -1362,7 +1362,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         if (symarg.gcroot != NULL) { // static_eval(ctx, args[1]) could not be interpreted to a function pointer
             const char *errmsg = invalid_symbol_err_msg(/*ccall=*/true);
             jl_cgval_t arg1 = emit_expr(ctx, args[1]);
-            emit_type_error(ctx, arg1, literal_pointer_val(ctx, (jl_value_t *)jl_pointer_type), errmsg);
+            emit_type_error(ctx, arg1, literal_pointer_val(ctx, (jl_value_t *)jl_pointer_type, jl_symbol_name(jl_pointer_typename->name)), errmsg);
         } else {
             emit_error(ctx, "ccall: null function pointer");
         }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -175,7 +175,7 @@ void setName(jl_codegen_params_t &params, Value *V, const Twine &Name)
     // is not checking that setName is only called for non-folded instructions (e.g. folded bitcasts
     // and 0-byte geps), which can result in information loss on the renamed instruction.
     assert((isa<Constant>(V) || isa<Instruction>(V)) && "Should only set names on instructions!");
-    if (params.debug_level && !isa<Constant>(V)) {
+    if (params.debug_level >= 2 && !isa<Constant>(V)) {
         V->setName(Name);
     }
 }
@@ -183,7 +183,7 @@ void setName(jl_codegen_params_t &params, Value *V, const Twine &Name)
 void setName(jl_codegen_params_t &params, Value *V, std::function<std::string()> GetName)
 {
     assert((isa<Constant>(V) || isa<Instruction>(V)) && "Should only set names on instructions!");
-    if (params.debug_level && !isa<Constant>(V)) {
+    if (params.debug_level >= 2 && !isa<Constant>(V)) {
         V->setName(Twine(GetName()));
     }
 }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -983,7 +983,7 @@ static Value *emit_checked_srem_int(jl_codectx_t &ctx, Value *x, Value *den)
     setName(ctx.emission_context, ndivby0, "ndivby0");
     raise_exception_unless(ctx,
             ndivby0,
-            literal_pointer_val(ctx, jl_diverror_exception));
+            literal_pointer_val(ctx, jl_diverror_exception, "::DivideError"));
     BasicBlock *m1BB = BasicBlock::Create(ctx.builder.getContext(), "minus1", ctx.f);
     BasicBlock *okBB = BasicBlock::Create(ctx.builder.getContext(), "oksrem", ctx.f);
     BasicBlock *cont = BasicBlock::Create(ctx.builder.getContext(), "after_srem", ctx.f);
@@ -1483,14 +1483,14 @@ static Value *emit_untyped_intrinsic(jl_codectx_t &ctx, intrinsic f, Value **arg
                             ctx.builder.CreateICmpNE(y, ConstantInt::get(t, -1, true)),
                             ctx.builder.CreateICmpNE(x, typemin)));
         setName(ctx.emission_context, cond, "divisor_valid");
-        raise_exception_unless(ctx, cond, literal_pointer_val(ctx, jl_diverror_exception));
+        raise_exception_unless(ctx, cond, literal_pointer_val(ctx, jl_diverror_exception, "::DivideError"));
 
         return ctx.builder.CreateSDiv(x, y);
     }
     case checked_udiv_int: {
         auto cond = ctx.builder.CreateICmpNE(y, ConstantInt::get(t, 0));
         setName(ctx.emission_context, cond, "ndivby0");
-        raise_exception_unless(ctx, cond, literal_pointer_val(ctx, jl_diverror_exception));
+        raise_exception_unless(ctx, cond, literal_pointer_val(ctx, jl_diverror_exception, "::DivideError"));
         return ctx.builder.CreateUDiv(x, y);
     }
     case checked_srem_int:
@@ -1499,7 +1499,7 @@ static Value *emit_untyped_intrinsic(jl_codectx_t &ctx, intrinsic f, Value **arg
     case checked_urem_int: {
         auto cond = ctx.builder.CreateICmpNE(y, ConstantInt::get(t, 0));
         setName(ctx.emission_context, cond, "ndivby0");
-        raise_exception_unless(ctx, cond, literal_pointer_val(ctx, jl_diverror_exception));
+        raise_exception_unless(ctx, cond, literal_pointer_val(ctx, jl_diverror_exception, "::DivideError"));
         return ctx.builder.CreateURem(x, y);
     }
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -139,7 +139,7 @@ static uint64_t getAddressForFunction(StringRef fname) JL_NOTSAFEPOINT;
 void jl_link_global(GlobalVariable *GV, void *addr) JL_NOTSAFEPOINT
 {
     ++LinkedGlobals;
-    Constant *P = literal_static_pointer_val(addr, GV->getValueType());
+    Constant *P = literal_static_pointer_val(addr, GV->getValueType(), *GV->getParent(), "");
     GV->setInitializer(P);
     if (jl_options.image_codegen) {
         // If we are forcing imaging mode codegen for debugging,

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2408,6 +2408,9 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S, bool *CFGModified) {
                     tag, EmitTagPtr(builder, tag_type, T_size, newI), M.getDataLayout().getPointerABIAlignment(0));
                 store->setOrdering(AtomicOrdering::Unordered);
                 store->setMetadata(LLVMContext::MD_tbaa, tbaa_tag);
+                if (auto GA = dyn_cast<GlobalAlias>(CI->getArgOperand(2)->stripPointerCasts())) {
+                    store->setMetadata("julia.literal_pointer", MDNode::get(builder.getContext(), {ConstantAsMetadata::get(GA)}));
+                }
 
                 // Replace uses of the call to `julia.gc_alloc_obj` with the call to
                 // `julia.gc_alloc_bytes`.

--- a/src/llvm-remove-addrspaces.cpp
+++ b/src/llvm-remove-addrspaces.cpp
@@ -336,14 +336,14 @@ bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
 
         GlobalVariable *NGV = cast<GlobalVariable>(VMap[GV]);
         if (GV->hasInitializer())
-            NGV->setInitializer(MapValue(GV->getInitializer(), VMap));
+            NGV->setInitializer(MapValue(GV->getInitializer(), VMap, RF_None, &TypeRemapper, &Materializer));
 
         SmallVector<std::pair<unsigned, MDNode *>, 1> MDs;
         GV->getAllMetadata(MDs);
         for (auto MD : MDs)
             NGV->addMetadata(
                     MD.first,
-                    *MapMetadata(MD.second, VMap));
+                    *MapMetadata(MD.second, VMap, RF_None, &TypeRemapper, &Materializer));
 
         copyComdat(NGV, GV);
 
@@ -401,7 +401,7 @@ bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
     for (GlobalAlias *GA : Aliases) {
         GlobalAlias *NGA = cast<GlobalAlias>(VMap[GA]);
         if (const Constant *C = GA->getAliasee())
-            NGA->setAliasee(MapValue(C, VMap));
+            NGA->setAliasee(MapValue(C, VMap, RF_None, &TypeRemapper, &Materializer));
 
         GA->setAliasee(nullptr);
     }
@@ -409,7 +409,7 @@ bool removeAddrspaces(Module &M, AddrspaceRemapFunction ASRemapper)
     // And named metadata
     for (auto &NMD : M.named_metadata()) {
         for (unsigned i = 0, e = NMD.getNumOperands(); i != e; ++i)
-            NMD.setOperand(i, MapMetadata(NMD.getOperand(i), VMap));
+            NMD.setOperand(i, MapMetadata(NMD.getOperand(i), VMap, RF_None, &TypeRemapper, &Materializer));
     }
 
     // Now that we've duplicated everything, remove the old references

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -22,9 +22,14 @@ function get_llvm(@nospecialize(f), @nospecialize(t), raw=true, dump_module=fals
     sprint(print, d)
 end
 
+# Some tests assume calls should be stripped out,
+# so strip out the calls to debug intrinsics that
+# are not actually materialized as call instructions.
+strip_debug_calls(ir) = replace(ir, r"call void @llvm\.dbg\.declare.*\n" => "", r"call void @llvm\.dbg\.value.*\n" => "")
+
 if !is_debug_build && opt_level > 0
     # Make sure getptls call is removed at IR level with optimization on
-    @test !occursin(" call ", get_llvm(identity, Tuple{String}))
+    @test !occursin(" call ", strip_debug_calls(get_llvm(identity, Tuple{String})))
 end
 
 jl_string_ptr(s::String) = ccall(:jl_string_ptr, Ptr{UInt8}, (Any,), s)
@@ -114,22 +119,22 @@ end
 
 if !is_debug_build && opt_level > 0
     # Make sure `jl_string_ptr` is inlined
-    @test !occursin(" call ", get_llvm(jl_string_ptr, Tuple{String}))
+    @test !occursin(" call ", strip_debug_calls(get_llvm(jl_string_ptr, Tuple{String})))
     # Make sure `Core.sizeof` call is inlined
     s = "aaa"
     @test jl_string_ptr(s) == pointer_from_objref(s) + sizeof(Int)
     # String
-    test_loads_no_call(get_llvm(core_sizeof, Tuple{String}), [Iptr])
+    test_loads_no_call(strip_debug_calls(get_llvm(core_sizeof, Tuple{String})), [Iptr])
     # String
-    test_loads_no_call(get_llvm(core_sizeof, Tuple{Core.SimpleVector}), [Iptr])
+    test_loads_no_call(strip_debug_calls(get_llvm(core_sizeof, Tuple{Core.SimpleVector})), [Iptr])
     # Array
-    test_loads_no_call(get_llvm(core_sizeof, Tuple{Vector{Int}}), [Iptr])
+    test_loads_no_call(strip_debug_calls(get_llvm(core_sizeof, Tuple{Vector{Int}})), [Iptr])
     # As long as the eltype is known we don't need to load the elsize
-    test_loads_no_call(get_llvm(core_sizeof, Tuple{Array{Any}}), [Iptr])
+    test_loads_no_call(strip_debug_calls(get_llvm(core_sizeof, Tuple{Array{Any}})), [Iptr])
     # Check that we load the elsize
-    test_loads_no_call(get_llvm(core_sizeof, Tuple{Vector}), [Iptr, "i16"])
+    test_loads_no_call(strip_debug_calls(get_llvm(core_sizeof, Tuple{Vector})), [Iptr, "i16"])
     # Primitive Type size should be folded to a constant
-    test_loads_no_call(get_llvm(core_sizeof, Tuple{Ptr}), String[])
+    test_loads_no_call(strip_debug_calls(get_llvm(core_sizeof, Tuple{Ptr})), String[])
 
     test_jl_dump_compiles()
     test_jl_dump_compiles_toplevel_thunks()
@@ -791,7 +796,7 @@ f48085(@nospecialize x...) = length(x)
 @test Core.Compiler.get_compileable_sig(which(f48085, (Vararg{Any},)), Tuple{typeof(f48085), Int, Vararg{Int}}, Core.svec()) === Tuple{typeof(f48085), Any, Vararg{Any}}
 
 # Make sure that the bounds check is elided in tuple iteration
-@test !occursin("call void @", get_llvm(iterate, Tuple{NTuple{4, Float64}, Int}))
+@test !occursin("call void @", strip_debug_calls(get_llvm(iterate, Tuple{NTuple{4, Float64}, Int})))
 
 # issue #34459
 function f34459(args...)


### PR DESCRIPTION
Literal pointers are hard to read, so rewriting them with a global alias when we're pretty-printing IR makes for more pleasant output.

<details>
<summary>Example 1</summary>

```julia
julia> f() = []
f (generic function with 1 method)

julia> @code_llvm f()
```
```llvm
;  @ REPL[1]:1 within `f`
define nonnull {}* @julia_f_130() #0 {
top:
; ┌ @ array.jl:160 within `vect`
; │┌ @ boot.jl:494 within `Array` @ boot.jl:475
    %0 = call nonnull {}* @"<libjulia-internal>.ijl_alloc_array_1d"({}* inttoptr (i64 140618099122192 to {}*), i64 0)
; └└
  ret {}* %0
}
```

</details>

<details>
<summary>Example 2</summary>

Note the `@RefValue` instead of a literal type pointer.

```julia
julia> g() = Ref(0)
g (generic function with 1 method)

julia> @code_llvm g()
```
```llvm
;  @ REPL[1]:1 within `g`
define nonnull {}* @julia_g_132() #0 {
top:
  %thread_ptr = call i8* asm "movq %fs:0, $0", "=r"() #7
  %tls_ppgcstack = getelementptr i8, i8* %thread_ptr, i64 -8
  %0 = bitcast i8* %tls_ppgcstack to {}****
  %tls_pgcstack = load {}***, {}**** %0, align 8
; ┌ @ refpointer.jl:137 within `Ref`
; │┌ @ refvalue.jl:10 within `RefValue` @ refvalue.jl:8
    %ptls_field3 = getelementptr inbounds {}**, {}*** %tls_pgcstack, i64 2
    %1 = bitcast {}*** %ptls_field3 to i8**
    %ptls_load45 = load i8*, i8** %1, align 8
    %newstruct = call noalias nonnull dereferenceable(16) {}* @ijl_gc_pool_alloc(i8* %ptls_load45, i32 1136, i32 16) #6
    %2 = bitcast {}* %newstruct to i64*
    %3 = getelementptr inbounds i64, i64* %2, i64 -1
    store atomic i64 ptrtoint ({}* @RefValue to i64), i64* %3 unordered, align 8
    store i64 0, i64* %2, align 8
; └└
  ret {}* %newstruct
}
```
</details>
