### PR TITLE
isassigned for ranges with BigInt indices

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -905,7 +905,7 @@ end
 
 ## indexing
 
-isassigned(r::AbstractRange, i::Int) = firstindex(r) <= i <= lastindex(r)
+isassigned(r::AbstractRange, i::Integer) = firstindex(r) <= i <= lastindex(r)
 
 _in_unit_range(v::UnitRange, val, i::Integer) = i > 0 && val <= v.stop && val >= v.start
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -905,7 +905,10 @@ end
 
 ## indexing
 
-isassigned(r::AbstractRange, i::Integer) = firstindex(r) <= i <= lastindex(r)
+function isassigned(r::AbstractRange, i::Integer)
+    i isa Bool && throw(ArgumentError("invalid index: $i of type Bool"))
+    firstindex(r) <= i <= lastindex(r)
+end
 
 _in_unit_range(v::UnitRange, val, i::Integer) = i > 0 && val <= v.stop && val >= v.start
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2498,3 +2498,11 @@ end
     # a case that using mul_with_overflow & add_with_overflow might get wrong:
     @test (-10:2:typemax(Int))[typemax(Int)÷2+2] == typemax(Int)-9
 end
+
+@testset "isassigned" begin
+    for (r, val) in ((1:3, 3), (1:big(2)^65, big(2)^65))
+        @test isassigned(r, lastindex(r))
+        # test that the indexing actually succeeds
+        @test r[end] == val
+    end
+end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2504,5 +2504,6 @@ end
         @test isassigned(r, lastindex(r))
         # test that the indexing actually succeeds
         @test r[end] == val
+        @test_throws ArgumentError isassigned(r, true)
     end
 end


### PR DESCRIPTION
This fixes certain possible regressions in `isassigned` for ranges to restore the 1.9-like behavior.
On v1.9
```julia
julia> r = 1:big(2)^65
1:36893488147419103232

julia> isassigned(r, lastindex(r))
true

julia> isassigned(r, true)
ERROR: ArgumentError: invalid index: true of type Bool
```
On v1.10.0-alpha1
```julia
julia> isassigned(r, lastindex(r))
ERROR: InexactError: Int64(36893488147419103232)

julia> isassigned(r, true) # Bool is converted to Int
true

julia> r[true] # but indexing with Bool doesn't work
ERROR: ArgumentError: invalid index: true of type Bool
```
This PR
```julia
julia> isassigned(r, lastindex(r))
true

julia> isassigned(r, true)
ERROR: ArgumentError: invalid index: true of type Bool
```
This still leaves
```julia
julia> isassigned(collect(1:3), true)
true
```
so that should perhaps be changed as well.