### PR TITLE
inference: refine `PartialStruct` with declared method signature

### DIFF
--- a/base/compiler/abstractlattice.jl
+++ b/base/compiler/abstractlattice.jl
@@ -249,9 +249,7 @@ end
     isa(x, Const) && return true
     return is_forwardable_argtype(widenlattice(𝕃), x)
 end
-@nospecializeinfer function is_forwardable_argtype(::JLTypeLattice, @nospecialize x)
-    return false
-end
+@nospecializeinfer is_forwardable_argtype(::JLTypeLattice, @nospecialize x) = false
 
 """
     widenreturn(𝕃ᵢ::AbstractLattice, @nospecialize(rt), info::BestguessInfo) -> new_bestguess

--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -61,6 +61,12 @@ function pick_const_args!(𝕃::AbstractLattice, cache_argtypes::Vector{Any}, ov
         cache_argtype = cache_argtypes[i]
         if !is_argtype_match(𝕃, given_argtype, cache_argtype, false)
             # prefer the argtype we were given over the one computed from `linfo`
+            if (isa(given_argtype, PartialStruct) && isa(cache_argtype, Type) &&
+                !⊏(𝕃, given_argtype, cache_argtype))
+                # if the type information of this `PartialStruct` is less strict than
+                # declared method signature, narrow it down using `tmeet`
+                given_argtype = tmeet(𝕃, given_argtype, cache_argtype)
+            end
             cache_argtypes[i] = given_argtype
             overridden_by_const[i] = true
         end


### PR DESCRIPTION
At present, in very rare cases, `PartialStruct` used for const-prop'
might have type information that's less strict than type information
that can be derived from the method's type signature, e.g.:
```julia
Base.@constprop :aggressive function refine_partial_struct((a, b)::Tuple{String,Int})
    if iszero(b)
        println("b=0") # to prevent semi-concrete eval
        return nothing
    else
        return a
    end
end
@test Base.return_types((AbstractString,)) do s
    refine_partial_struct((s, 42))
end |> only === String
```

This commit enhances the accuracy of const-prop' by propagating `tmeet`
of `PartialStruct` and the declared type in such situations.