### PR TITLE
faster invalid object lookup in conservative gc

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -4070,18 +4070,10 @@ JL_DLLEXPORT jl_value_t *jl_gc_internal_obj_base_ptr(void *p)
         // before the freelist pointer was either live during the last
         // sweep or has been allocated since.
         if (gc_page_data(cell) == gc_page_data(pool->freelist)
-            && (char *)cell < (char *)pool->freelist) {
+            && (char *)cell < (char *)pool->freelist)
             goto valid_object;
-        }
-        else {
-            jl_taggedvalue_t *v = pool->freelist;
-            while (v != NULL) {
-                if (v == cell) {
-                    return NULL;
-                }
-                v = v->next;
-            }
-        }
+        else
+            return NULL;
         // Not a freelist entry, therefore a valid object.
     valid_object:
         // We have to treat objects with type `jl_buff_tag` differently,

--- a/src/gc.c
+++ b/src/gc.c
@@ -4072,8 +4072,9 @@ JL_DLLEXPORT jl_value_t *jl_gc_internal_obj_base_ptr(void *p)
         if (gc_page_data(cell) == gc_page_data(pool->freelist)
             && (char *)cell < (char *)pool->freelist)
             goto valid_object;
-        else
-            return NULL;
+        // already skipped marked or old objects above, so here
+        // the age bits are 0, thus the object is on the freelist
+        return NULL;
         // Not a freelist entry, therefore a valid object.
     valid_object:
         // We have to treat objects with type `jl_buff_tag` differently,


### PR DESCRIPTION
We may possibly optimize the free-list lookup by just looking at the page metadata and GC bits.

If we're allocating from a free-list then we have three cases for a valid object:

1. Object is in a page whose free-list has been exhausted (the `meta->nfree == 0` covers this).
2. Object is in a page whose free-list has not been used since the last GC (the GC bits for the object will be set since it's not freshly allocated, and the `cell->bits.gc` check should cover this).
3. Object is in a page whose free-list is currently being used. If it's before the free-list pointer then it's a valid object. If it's after the free-list pointer then it will have its GC bits set and the `cell->bits.gc` check should cover this.

This PR basically implements case 3 so that we don't have to walk the whole free-list looking for an invalid object.

CC: @fingolfin 