### PR TITLE
Remove libuv_jll contents

### DIFF
--- a/stdlib/LibUV_jll/src/LibUV_jll.jl
+++ b/stdlib/LibUV_jll/src/LibUV_jll.jl
@@ -6,41 +6,6 @@ baremodule LibUV_jll
 using Base, Libdl
 Base.Experimental.@compiler_options compile=min optimize=0 infer=false
 
-const PATH_list = String[]
-const LIBPATH_list = String[]
-
-export libuv
-
-# These get calculated in __init__()
-const PATH = Ref("")
-const LIBPATH = Ref("")
-artifact_dir::String = ""
-libuv_handle::Ptr{Cvoid} = C_NULL
-libuv_path::String = ""
-
-if Sys.iswindows()
-    const libuv = "libuv-2.dll"
-elseif Sys.isapple()
-    const libuv = "@rpath/libuv.2.dylib"
-else
-    const libuv = "libuv.so.2"
-end
-
-function __init__()
-    global libuv_handle = dlopen(libuv)
-    global libuv_path = dlpath(libuv_handle)
-    global artifact_dir = dirname(Sys.BINDIR)
-    LIBPATH[] = dirname(libuv_path)
-    push!(LIBPATH_list, LIBPATH[])
-end
-
-# JLLWrappers API compatibility shims.  Note that not all of these will really make sense.
-# For instance, `find_artifact_dir()` won't actually be the artifact directory, because
-# there isn't one.  It instead returns the overall Julia prefix.
-is_available() = true
-find_artifact_dir() = artifact_dir
-dev_jll() = error("stdlib JLLs cannot be dev'ed")
-best_wrapper = nothing
-get_libuv_path() = libuv_path
+# NOTE: This file is currently empty, as we link libuv statically for now.
 
 end  # module LibUV_jll

--- a/stdlib/LibUV_jll/test/runtests.jl
+++ b/stdlib/LibUV_jll/test/runtests.jl
@@ -1,8 +1,3 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Test, Libdl, LibUV_jll
-
-@testset "LibUV_jll" begin
-    vn = VersionNumber(unsafe_string(ccall((:uv_version_string, libuv), Cstring, ())))
-    @test vn == v"2.0.0-dev"
-end


### PR DESCRIPTION
We link libuv statically, so there's no point in trying to use a JLL. I'm not removing the JLL entirely as removing stdlibs is difficult, and we may link libuv dynamically in the future.

Fixes https://github.com/JuliaLang/julia/issues/50592