### PR TITLE
Assert tid>0 in workqueue_for

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -755,6 +755,7 @@ function workqueue_for(tid::Int)
         return @inbounds qs[tid]
     end
     # slow path to allocate it
+    @assert tid > 0
     l = Workqueues_lock
     @lock l begin
         qs = Workqueues


### PR DESCRIPTION
Otherwise the inbounds annotations are not sound. As requested in https://github.com/JuliaLang/julia/pull/50597#pullrequestreview-1537852869.