### PR TITLE
Provide timing infrastructure through a dynamic library

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1577,6 +1577,12 @@ LIBJULIACODEGEN_INSTALL_DEPLIB := $(call dep_lib_path,$(libdir),$(private_shlibd
 LIBJULIACODEGEN_DEBUG_BUILD_DEPLIB := $(call dep_lib_path,$(build_libdir),$(build_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_SHLIB_EXT))
 LIBJULIACODEGEN_DEBUG_INSTALL_DEPLIB := $(call dep_lib_path,$(libdir),$(private_shlibdir)/libjulia-codegen-debug.$(JL_MAJOR_SHLIB_EXT))
 
+LIBJULIATIMING_BUILD_DEPLIB := $(call dep_lib_path,$(build_libdir),$(build_shlibdir)/libjulia-timing.$(JL_MAJOR_SHLIB_EXT))
+LIBJULIATIMING_INSTALL_DEPLIB := $(call dep_lib_path,$(libdir),$(private_shlibdir)/libjulia-timing.$(JL_MAJOR_SHLIB_EXT))
+
+LIBJULIATIMING_DEBUG_BUILD_DEPLIB := $(call dep_lib_path,$(build_libdir),$(build_shlibdir)/libjulia-timing-debug.$(JL_MAJOR_SHLIB_EXT))
+LIBJULIATIMING_DEBUG_INSTALL_DEPLIB := $(call dep_lib_path,$(libdir),$(private_shlibdir)/libjulia-timing-debug.$(JL_MAJOR_SHLIB_EXT))
+
 ifeq ($(OS),WINNT)
 ifeq ($(BINARY),32)
 LIBGCC_NAME := libgcc_s_sjlj-1.$(SHLIB_EXT)
@@ -1637,8 +1643,9 @@ LIBM_INSTALL_DEPLIB := $(call dep_lib_path,$(libdir),$(private_shlibdir)/$(LIBMN
 #  * libopenlibm, because Windows has an untrustworthy libm, and we want to use ours more than theirs
 #  * libstdc++, because while performing `libstdc++` probing we need to
 #    know the path to the bundled `libstdc++` library.
-#  * libjulia-internal, which must always come second-to-last.
-#  * libjulia-codegen, which must always come last
+#  * libjulia-internal, which must always come third-to-last.
+#  * libjulia-codegen, which must always come second-to-last.
+#  * libjulia-timing, which must always come last.
 #
 # We need these four separate variables because:
 #  * debug builds must link against libjuliadebug, not libjulia
@@ -1660,6 +1667,7 @@ LOADER_BUILD_DEP_LIBS = $(call build_deplibs, \
     @$(LIBSTDCXX_BUILD_DEPLIB) \
     @$(LIBJULIAINTERNAL_BUILD_DEPLIB) \
     @$(LIBJULIACODEGEN_BUILD_DEPLIB) \
+    @$(LIBJULIATIMING_BUILD_DEPLIB) \
 )
 
 LOADER_DEBUG_BUILD_DEP_LIBS = $(call build_deplibs, \
@@ -1668,6 +1676,7 @@ LOADER_DEBUG_BUILD_DEP_LIBS = $(call build_deplibs, \
    @$(LIBSTDCXX_BUILD_DEPLIB) \
    @$(LIBJULIAINTERNAL_DEBUG_BUILD_DEPLIB) \
    @$(LIBJULIACODEGEN_DEBUG_BUILD_DEPLIB) \
+   @$(LIBJULIATIMING_DEBUG_BUILD_DEPLIB) \
 )
 
 LOADER_INSTALL_DEP_LIBS = $(call build_deplibs, \

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ all: debug release
 # sort is used to remove potential duplicates
 DIRS := $(sort $(build_bindir) $(build_depsbindir) $(build_libdir) $(build_private_libdir) $(build_libexecdir) $(build_includedir) $(build_includedir)/julia $(build_sysconfdir)/julia $(build_datarootdir)/julia $(build_datarootdir)/julia/stdlib $(build_man1dir))
 ifneq ($(BUILDROOT),$(JULIAHOME))
-BUILDDIRS := $(BUILDROOT) $(addprefix $(BUILDROOT)/,base src src/flisp src/support src/clangsa cli doc deps stdlib test test/clangsa test/embedding test/gcext test/llvmpasses)
+BUILDDIRS := $(BUILDROOT) $(addprefix $(BUILDROOT)/,base src src/flisp src/support src/clangsa cli doc deps stdlib test test/clangsa test/embedding test/gcext test/llvmpasses plugins/timing-julia)
 BUILDDIRMAKE := $(addsuffix /Makefile,$(BUILDDIRS)) $(BUILDROOT)/sysimage.mk $(BUILDROOT)/pkgimage.mk
 DIRS += $(BUILDDIRS)
 $(BUILDDIRMAKE): | $(BUILDDIRS)

--- a/cli/jl_exports.h
+++ b/cli/jl_exports.h
@@ -28,6 +28,7 @@ JL_RUNTIME_EXPORTED_FUNCS(XX)
 JL_RUNTIME_EXPORTED_FUNCS_WIN(XX)
 #endif
 JL_CODEGEN_EXPORTED_FUNCS(XX)
+JL_INSTRUMENTATION_EXPORTED_FUNCS(XX)
 #undef XX
 
 // Define holder locations for function addresses as `const void * $(name)_addr = NULL;
@@ -37,6 +38,7 @@ JL_RUNTIME_EXPORTED_FUNCS(XX)
 JL_RUNTIME_EXPORTED_FUNCS_WIN(XX)
 #endif
 JL_CODEGEN_EXPORTED_FUNCS(XX)
+JL_INSTRUMENTATION_EXPORTED_FUNCS(XX)
 #undef XX
 
 // Generate lists of function names and addresses
@@ -64,6 +66,20 @@ static const char *const jl_codegen_fallback_func_names[] = {
 };
 #undef XX
 
+#define XX(name)    #name"_impl",
+static const char *const jl_timing_exported_func_names[] = {
+    JL_INSTRUMENTATION_EXPORTED_FUNCS(XX)
+    NULL
+};
+#undef XX
+
+#define XX(name)    #name"_fallback",
+static const char *const jl_timing_fallback_func_names[] = {
+    JL_INSTRUMENTATION_EXPORTED_FUNCS(XX)
+    NULL
+};
+#undef XX
+
 #define XX(name)    &name##_addr,
 static anonfunc **const jl_runtime_exported_func_addrs[] = {
     JL_RUNTIME_EXPORTED_FUNCS(XX)
@@ -74,6 +90,10 @@ static anonfunc **const jl_runtime_exported_func_addrs[] = {
 };
 static anonfunc **const jl_codegen_exported_func_addrs[] = {
     JL_CODEGEN_EXPORTED_FUNCS(XX)
+    NULL
+};
+static anonfunc **const jl_timing_exported_func_addrs[] = {
+    JL_INSTRUMENTATION_EXPORTED_FUNCS(XX)
     NULL
 };
 #undef XX

--- a/plugins/timing-julia/Makefile
+++ b/plugins/timing-julia/Makefile
@@ -10,8 +10,7 @@ include $(JULIAHOME)/deps/llvm-ver.make
 HEADERS := $(addprefix $(JULIAHOME)/src/,julia.h julia_fasttls.h support/platform.h support/dirpath.h)
 
 PLUGIN_CFLAGS = $(JCFLAGS) -I$(BUILDROOT)/src -I$(JULIAHOME)/src -I$(JULIAHOME)/src/support -I$(build_includedir)
-PLUGIN_LDFLAGS = $(JLDFLAGS) -L$(build_shlibdir) -L$(build_libdir)
-
+PLUGIN_LDFLAGS = $(JLDFLAGS) -L$(build_shlibdir) -L$(build_libdir) -ljulia-internal -ljulia
 LIB_OBJS := $(BUILDDIR)/timing-julia.o
 LIB_DOBJS := $(BUILDDIR)/timing-julia.dbg.obj
 

--- a/plugins/timing-julia/Makefile
+++ b/plugins/timing-julia/Makefile
@@ -1,0 +1,56 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+SRCDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+JULIAHOME := $(abspath $(SRCDIR)/../..)
+BUILDDIR ?= .
+
+include $(JULIAHOME)/Make.inc
+include $(JULIAHOME)/deps/llvm-ver.make
+
+HEADERS := $(addprefix $(JULIAHOME)/src/,julia.h julia_fasttls.h support/platform.h support/dirpath.h)
+
+PLUGIN_CFLAGS = $(JCFLAGS) -I$(BUILDROOT)/src -I$(JULIAHOME)/src -I$(JULIAHOME)/src/support -I$(build_includedir)
+PLUGIN_LDFLAGS = $(JLDFLAGS) -L$(build_shlibdir) -L$(build_libdir)
+
+LIB_OBJS := $(BUILDDIR)/timing-julia.o
+LIB_DOBJS := $(BUILDDIR)/timing-julia.dbg.obj
+
+$(BUILDDIR)/timing-julia.o : $(SRCDIR)/timing-julia.c $(HEADERS)
+	@$(call PRINT_CC, $(CC) $(SHIPFLAGS) $(PLUGIN_CFLAGS) -c $< -o $@)
+$(BUILDDIR)/timing-julia.dbg.obj : $(SRCDIR)/timing-julia.c $(HEADERS)
+	@$(call PRINT_CC, $(CC) $(DEBUGFLAGS) $(PLUGIN_CFLAGS) -c $< -o $@)
+
+libtiming-julia-release: $(build_shlibdir)/libtiming-julia.$(SHLIB_EXT)
+libtiming-julia-debug: $(build_shlibdir)/libtiming-julia-debug.$(SHLIB_EXT)
+
+$(build_shlibdir)/libtiming-julia.$(JL_MAJOR_MINOR_SHLIB_EXT): $(LIB_OBJS) | $(build_shlibdir) $(build_libdir)
+	@$(call PRINT_LINK, $(CC) $(call IMPLIB_FLAGS,$@.tmp) $(PLUGIN_CFLAGS) -shared $(SHIPFLAGS) $(LIB_OBJS) $(RPATH_LIB) -o $@ \
+		$(JLIBLDFLAGS) $(PLUGIN_LDFLAGS) $(call SONAME_FLAGS,libtiming-julia.$(JL_MAJOR_SHLIB_EXT)))
+	@$(INSTALL_NAME_CMD)libtiming-julia.$(JL_MAJOR_SHLIB_EXT) $@
+	@$(DSYMUTIL) $@
+
+$(build_shlibdir)/libtiming-julia-debug.$(JL_MAJOR_MINOR_SHLIB_EXT): $(LIB_DOBJS) | $(build_shlibdir) $(build_libdir)
+	@$(call PRINT_LINK, $(CC) $(call IMPLIB_FLAGS,$@.tmp) $(PLUGIN_CFLAGS) -shared $(DEBUGFLAGS) $(LIB_DOBJS) $(RPATH_LIB) -o $@ \
+		$(JLIBLDFLAGS) $(PLUGIN_LDFLAGS) $(call SONAME_FLAGS,libtiming-julia-debug.$(JL_MAJOR_SHLIB_EXT)))
+	@$(INSTALL_NAME_CMD)libtiming-julia-debug.$(JL_MAJOR_SHLIB_EXT) $@
+	@$(DSYMUTIL) $@
+
+ifneq ($(OS), WINNT)
+$(build_shlibdir)/libtiming-julia.$(JL_MAJOR_SHLIB_EXT) $(build_shlibdir)/libtiming-julia-debug.$(JL_MAJOR_SHLIB_EXT): $(build_shlibdir)/libtiming-julia%.$(JL_MAJOR_SHLIB_EXT): \
+		$(build_shlibdir)/libtiming-julia%.$(JL_MAJOR_MINOR_SHLIB_EXT)
+	@$(call PRINT_LINK, ln -sf $(notdir $<) $@)
+$(build_shlibdir)/libtiming-julia.$(SHLIB_EXT) $(build_shlibdir)/libtiming-julia-debug.$(SHLIB_EXT): $(build_shlibdir)/libtiming-julia%.$(SHLIB_EXT): \
+		$(build_shlibdir)/libtiming-julia%.$(JL_MAJOR_MINOR_SHLIB_EXT) $(build_shlibdir)/libtiming-julia%.$(JL_MAJOR_SHLIB_EXT)
+	@$(call PRINT_LINK, ln -sf $(notdir $<) $@)
+endif
+
+#=============================================================================
+
+release: libtiming-julia-release
+debug:   libtiming-julia-debug
+
+clean:
+	-rm -fr $(build_shlibdir)/libtiming-julia*
+	-rm -f $(LIB_OBJS) $(LIB_DOBJS)
+
+.PHONY: release debug clean

--- a/plugins/timing-julia/timing-julia.c
+++ b/plugins/timing-julia/timing-julia.c
@@ -1,0 +1,8 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#include <inttypes.h>
+#include "julia.h"
+
+JL_DLLEXPORT int jl_timing_available_impl(void) {
+    return 1;
+}

--- a/plugins/timing-julia/timing-julia.c
+++ b/plugins/timing-julia/timing-julia.c
@@ -2,7 +2,111 @@
 
 #include <inttypes.h>
 #include "julia.h"
+#include "julia_internal.h"
+#include "timing.h"
+
+typedef struct jl_timing_counts_event_t {
+    const char *name;
+    _Atomic(uint64_t) self;
+    _Atomic(uint64_t) total;
+} jl_timing_counts_event_t;
+
+typedef struct _jl_timing_counts_t {
+    uint64_t total;
+    uint64_t start;
+    uint64_t t0;
+#ifdef JL_DEBUG_BUILD
+    uint8_t running;
+#endif
+} jl_timing_counts_t;
+
+typedef struct {
+    _Atomic(uint64_t) basic_counter;
+} jl_timing_counter_t;
+
+JL_DLLEXPORT jl_timing_counter_t jl_timing_counters[JL_TIMING_COUNTER_LAST];
+
+static arraylist_t jl_timing_counts_events;
+static jl_mutex_t jl_timing_counts_events_lock;
+static uint64_t t0;
+
+static int cmp_counts_events(const void *a, const void *b) {
+    jl_timing_counts_event_t *event_a = *(jl_timing_counts_event_t **)a;
+    jl_timing_counts_event_t *event_b = *(jl_timing_counts_event_t **)b;
+    return strcmp(event_a->name, event_b->name);
+}
 
 JL_DLLEXPORT int jl_timing_available_impl(void) {
     return 1;
+}
+
+JL_DLLEXPORT void jl_timing_counter_inc_impl(int counter, uint64_t val) JL_NOTSAFEPOINT {
+    jl_atomic_fetch_add_relaxed(&jl_timing_counters[counter].basic_counter, val);
+}
+
+JL_DLLEXPORT void jl_timing_counter_dec_impl(int counter, uint64_t val) JL_NOTSAFEPOINT {
+    jl_atomic_fetch_add_relaxed(&jl_timing_counters[counter].basic_counter, -(int64_t)val);
+}
+
+JL_DLLEXPORT void jl_timing_init_impl(void) {
+    t0 = cycleclock();
+
+    _Static_assert(JL_TIMING_SUBSYSTEM_LAST < sizeof(uint64_t) * CHAR_BIT, "Too many timing subsystems!");
+
+    JL_MUTEX_INIT(&jl_timing_counts_events_lock, "jl_timing_counts_events_lock");
+
+    // Create events list for counts backend
+    arraylist_new(&jl_timing_counts_events, 1);
+
+    jl_timing_counts_event_t *root_event = (jl_timing_counts_event_t *)malloc(sizeof(jl_timing_counts_event_t));
+    arraylist_push(&jl_timing_counts_events, (void *)root_event);
+
+    root_event->name = "ROOT";
+    jl_atomic_store_relaxed(&root_event->self, 0);
+    jl_atomic_store_relaxed(&root_event->total, 0);
+}
+
+JL_DLLEXPORT void jl_timing_print_impl(void) {
+    qsort(jl_timing_counts_events.items, jl_timing_counts_events.len,
+          sizeof(jl_timing_counts_event_t *), cmp_counts_events);
+
+    JL_LOCK_NOGC(&jl_timing_counts_events_lock);
+    uint64_t total_time = cycleclock() - t0;
+    uint64_t root_time = total_time;
+    jl_timing_counts_event_t *root_event;
+    for (int i = 0; i < jl_timing_counts_events.len; i++) {
+        jl_timing_counts_event_t *other_event = (jl_timing_counts_event_t *)jl_timing_counts_events.items[i];
+        if (strcmp(other_event->name, "ROOT") == 0) {
+            root_event = other_event;
+        } else {
+            root_time -= jl_atomic_load_relaxed(&other_event->self);
+        }
+    }
+    jl_atomic_store_relaxed(&root_event->self, root_time);
+    jl_atomic_store_relaxed(&root_event->total, total_time);
+
+    fprintf(stderr, "\nJULIA TIMINGS\n");
+    fprintf(stderr, "%-25s, %-30s, %-30s\n", "Event", "Self Cycles (% of Total)", "Total Cycles (% of Total)");
+    for (int i = 0; i < jl_timing_counts_events.len; i++) {
+        jl_timing_counts_event_t *event = (jl_timing_counts_event_t *)jl_timing_counts_events.items[i];
+        uint64_t self = jl_atomic_load_relaxed(&event->self);
+        uint64_t total = jl_atomic_load_relaxed(&event->total);
+        if (total != 0)
+            fprintf(stderr, "%-25s, %20" PRIu64 " (%5.2f %%), %20" PRIu64 " (%5.2f %%)\n",
+                    event->name,
+                    self, 100 * (((double)self) / total_time),
+                    total, 100 * (((double)total) / total_time));
+    }
+    JL_UNLOCK_NOGC(&jl_timing_counts_events_lock);
+
+    fprintf(stderr, "\nJULIA COUNTERS\n");
+    fprintf(stderr, "%-25s, %-20s\n", "Counter", "Value");
+#define X(name) do { \
+        int64_t val = (int64_t) jl_atomic_load_relaxed(&jl_timing_counters[(int)JL_TIMING_COUNTER_##name].basic_counter); \
+        if (val != 0) \
+            fprintf(stderr, "%-25s, %20" PRIi64 "\n", #name, val); \
+    } while (0);
+
+    JL_TIMING_COUNTERS
+#undef X
 }

--- a/src/init.c
+++ b/src/init.c
@@ -735,7 +735,8 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
     // initialize many things, in no particular order
     // but generally running from simple platform things to optional
     // configuration features
-    jl_init_timing();
+    if(jl_timing_available())
+        jl_timing_init();
     // Make sure we finalize the tls callback before starting any threads.
     (void)jl_get_pgcstack();
 

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -608,5 +608,7 @@
     YY(JLJITGetDataLayoutString) \
     YY(JLJITGetIRCompileLayer) \
 
+#define JL_INSTRUMENTATION_EXPORTED_FUNCS(YY) \
+    YY(jl_timing_enabled) \
 
 // end of file

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -610,5 +610,9 @@
 
 #define JL_INSTRUMENTATION_EXPORTED_FUNCS(YY) \
     YY(jl_timing_available) \
+    YY(jl_timing_counter_inc) \
+    YY(jl_timing_counter_dec) \
+    YY(jl_timing_init) \
+    YY(jl_timing_print) \
 
 // end of file

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -609,6 +609,6 @@
     YY(JLJITGetIRCompileLayer) \
 
 #define JL_INSTRUMENTATION_EXPORTED_FUNCS(YY) \
-    YY(jl_timing_enabled) \
+    YY(jl_timing_available) \
 
 // end of file

--- a/src/julia.h
+++ b/src/julia.h
@@ -2363,6 +2363,9 @@ typedef struct {
 } jl_cgparams_t;
 extern JL_DLLEXPORT int jl_default_debug_info_kind;
 
+// Timing libjulia definitions
+JL_DLLEXPORT int jl_timing_available(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/julia.h
+++ b/src/julia.h
@@ -2365,6 +2365,10 @@ extern JL_DLLEXPORT int jl_default_debug_info_kind;
 
 // Timing libjulia definitions
 JL_DLLEXPORT int jl_timing_available(void);
+JL_DLLEXPORT void jl_timing_counter_inc(int counter, uint64_t val);
+JL_DLLEXPORT void jl_timing_counter_dec(int counter, uint64_t val);
+JL_DLLEXPORT void jl_timing_init(void);
+JL_DLLEXPORT void jl_timing_print(void);
 
 #ifdef __cplusplus
 }

--- a/src/timing.c
+++ b/src/timing.c
@@ -677,6 +677,10 @@ JL_DLLEXPORT uint32_t jl_timing_print_limit = 0;
 
 #endif
 
+#define UNAVAILABLE { return; }
+
+JL_DLLEXPORT void jl_timing_enabled_fallback(void) UNAVAILABLE
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/timing.c
+++ b/src/timing.c
@@ -679,7 +679,10 @@ JL_DLLEXPORT uint32_t jl_timing_print_limit = 0;
 
 #define UNAVAILABLE { return; }
 
-JL_DLLEXPORT void jl_timing_enabled_fallback(void) UNAVAILABLE
+
+JL_DLLEXPORT int jl_timing_available_fallback(void) {
+    return 0;
+}
 
 #ifdef __cplusplus
 }

--- a/src/timing.h
+++ b/src/timing.h
@@ -4,6 +4,7 @@
 #define JL_TIMING_H
 
 #include "julia.h"
+#include <limits.h>
 
 static inline const char *gnu_basename(const char *path)
 {
@@ -213,21 +214,6 @@ enum jl_timing_counter_types {
  * Timing Backend: Aggregated timing counts (implemented in timing.c)
  **/
 
-typedef struct jl_timing_counts_event_t {
-    const char *name;
-    _Atomic(uint64_t) self;
-    _Atomic(uint64_t) total;
-} jl_timing_counts_event_t;
-
-typedef struct _jl_timing_counts_t {
-    uint64_t total;
-    uint64_t start;
-    uint64_t t0;
-#ifdef JL_DEBUG_BUILD
-    uint8_t running;
-#endif
-} jl_timing_counts_t;
-
 #ifdef USE_TIMING_COUNTS
 #define _COUNTS_EVENT_MEMBER             jl_timing_counts_event_t *counts_event;
 #define _COUNTS_BLOCK_MEMBER             jl_timing_counts_t counts_ctx;
@@ -354,61 +340,6 @@ STATIC_INLINE void _jl_timing_suspend_destroy(jl_timing_suspend_t *suspend) JL_N
     __attribute__((cleanup(_jl_timing_suspend_destroy))) \
     jl_timing_suspend_t __timing_suspend; \
     _jl_timing_suspend_ctor(&__timing_suspend, #subsystem, ct)
-
-// Counting
-#ifdef USE_ITTAPI
-#define _ITTAPI_COUNTER_MEMBER __itt_counter ittapi_counter;
-#else
-#define _ITTAPI_COUNTER_MEMBER
-#endif
-
-#ifdef USE_TRACY
-# define _TRACY_COUNTER_MEMBER jl_tracy_counter_t tracy_counter;
-# else
-# define _TRACY_COUNTER_MEMBER
-#endif
-
-#ifdef USE_TIMING_COUNTS
-#define _COUNTS_MEMBER _Atomic(uint64_t) basic_counter;
-#else
-#define _COUNTS_MEMBER
-#endif
-
-typedef struct {
-    _ITTAPI_COUNTER_MEMBER
-    _TRACY_COUNTER_MEMBER
-    _COUNTS_MEMBER
-} jl_timing_counter_t;
-
-JL_DLLEXPORT extern jl_timing_counter_t jl_timing_counters[JL_TIMING_COUNTER_LAST];
-
-static inline void jl_timing_counter_inc(int counter, uint64_t val) JL_NOTSAFEPOINT {
-#ifdef USE_ITTAPI
-    __itt_counter_inc_delta(jl_timing_counters[counter].ittapi_counter, val);
-#endif
-#ifdef USE_TRACY
-    jl_tracy_counter_t *tracy_counter = &jl_timing_counters[counter].tracy_counter;
-    uint64_t oldval = jl_atomic_fetch_add_relaxed(&tracy_counter->val, val);
-    TracyCPlotI(tracy_counter->name, oldval + val);
-#endif
-#ifdef USE_TIMING_COUNTS
-    jl_atomic_fetch_add_relaxed(&jl_timing_counters[counter].basic_counter, val);
-#endif
-}
-
-static inline void jl_timing_counter_dec(int counter, uint64_t val) JL_NOTSAFEPOINT {
-#ifdef USE_ITTAPI
-    __itt_counter_dec_delta(jl_timing_counters[counter].ittapi_counter, val);
-#endif
-#ifdef USE_TRACY
-    jl_tracy_counter_t *tracy_counter = &jl_timing_counters[counter].tracy_counter;
-    uint64_t oldval = jl_atomic_fetch_add_relaxed(&tracy_counter->val, -val);
-    TracyCPlotI(tracy_counter->name, oldval - val);
-#endif
-#ifdef USE_TIMING_COUNTS
-    jl_atomic_fetch_add_relaxed(&jl_timing_counters[counter].basic_counter, -(int64_t)val);
-#endif
-}
 
 // Locking profiling
 static inline void jl_profile_lock_init(jl_mutex_t *lock, const char *name) {


### PR DESCRIPTION
Very early stages, but my goal is to enable the building/loading of an external library
that provides the integration with an external timing consumer.

Currently we have three timing consumers:

1. "Timing Counts"
2. Tracy
3. ITTAPI

I have been talking to @simonbyrne and we would like to add NVTX support. @kpamnany & @nhdahly might want to implement datadog/perfetto.
Having all these implementations in-tree will not be scalable and so we should provide an interface that tools can implement
to receive runtime events/metrics.

My design criteria are:
1. Early availibity (before sysimage loading/first task creation)
2. Always on. Julia should come with timing always turned on, but reporting only happens when the user provides an actual implementation.

Right now I am reusing the `libjulia-codegen` infrastructure, but I would like to support something like

```
julia --timing-agent=libjulia-timing-tracy.so
```

or 

```
JULIA_TIMING_AGENT=libjulia-timing-tracy.so julia
```

Maybe we could support a "late initialization" for users that don't care about early startup, but might want to turn timing reporting
on and off on-demand.

cc: @topolarity & @pchintalapudi

