### PR TITLE
Add extra profiling events to JIT/AOT compilation

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1214,12 +1214,13 @@ namespace {
                     }
                 }
 
-                JL_TIMING(LLVM_OPT, LLVM_OPT);
-
-                //Run the optimization
-                assert(!verifyLLVMIR(M));
-                (***PMs).run(M);
-                assert(!verifyLLVMIR(M));
+                {
+                    JL_TIMING(LLVM_JIT, JIT_Opt);
+                    //Run the optimization
+                    assert(!verifyLLVMIR(M));
+                    (***PMs).run(M);
+                    assert(!verifyLLVMIR(M));
+                }
 
                 uint64_t end_time = 0;
                 {
@@ -1272,6 +1273,7 @@ namespace {
             : orc::IRCompileLayer::IRCompiler(MO), TMs(TMCreator(TM, optlevel)) {}
 
         Expected<std::unique_ptr<MemoryBuffer>> operator()(Module &M) override {
+            JL_TIMING(LLVM_JIT, JIT_Compile);
             return orc::SimpleCompiler(***TMs)(M);
         }
 
@@ -1459,7 +1461,7 @@ void JuliaOJIT::addGlobalMapping(StringRef Name, uint64_t Addr)
 
 void JuliaOJIT::addModule(orc::ThreadSafeModule TSM)
 {
-    JL_TIMING(LLVM_ORC, LLVM_ORC);
+    JL_TIMING(LLVM_JIT, JIT_Total);
     ++ModulesAdded;
     orc::SymbolLookupSet NewExports;
     TSM.withModuleDo([&](Module &M) JL_NOTSAFEPOINT {

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -314,6 +314,7 @@ public:
 
         void emit(std::unique_ptr<orc::MaterializationResponsibility> R,
                             std::unique_ptr<MemoryBuffer> O) override {
+            JL_TIMING(LLVM_JIT, JIT_Link);
 #ifndef JL_USE_JITLINK
             std::lock_guard<std::mutex> lock(EmissionMutex);
 #endif

--- a/src/timing.h
+++ b/src/timing.h
@@ -160,8 +160,7 @@ JL_DLLEXPORT void jl_timing_puts(jl_timing_block_t *cur_block, const char *str);
         X(METHOD_LOOKUP_SLOW)    \
         X(METHOD_LOOKUP_FAST)    \
         X(CODEINST_COMPILE)      \
-        X(LLVM_OPT)              \
-        X(LLVM_ORC)              \
+        X(LLVM_JIT)              \
         X(METHOD_MATCH)          \
         X(TYPE_CACHE_LOOKUP)     \
         X(TYPE_CACHE_INSERT)     \


### PR DESCRIPTION
This lets us profile how much time is spent in JIT and AOT machine code optimization and emission, as well as JIT linking. This complements the current LLVM_OPT measurement (now JIT_Opt).

Best viewed with whitespace off.