### PR TITLE
Rework broadcast for `Adjoint`/`Transpose` of vectors

### DIFF
--- a/stdlib/LinearAlgebra/test/hessenberg.jl
+++ b/stdlib/LinearAlgebra/test/hessenberg.jl
@@ -178,7 +178,13 @@ let n = 10
         @test H \ B ≈ A \ B ≈ H \ complex(B)
         @test (H - I) \ B ≈ (A - I) \ B
         @test (H - (3+4im)I) \ B ≈ (A - (3+4im)I) \ B
-        @test b' / H ≈ b' / A ≈ complex.(b') / H
+        # see #50617
+        if eltya <: Complex
+            @test b' / H ≈ b' / A ≈ complex.(b') / H
+        else
+            @test b' / H ≈ b' / A #≈ complex.(b') / H
+            @test_broken b' / H ≈ b' / A ≈ complex.(b') / H
+        end
         @test B' / H ≈ B' / A ≈ complex(B') / H
         @test B' / (H - I) ≈ B' / (A - I)
         @test B' / (H - (3+4im)I) ≈ B' / (A - (3+4im)I)


### PR DESCRIPTION
Instead of specializing `broadcast`, use the `BroadcastStyle` machinery. The former approach only affected explicit calls to `broadcast`, while the new one also works for dot-calls. Furthermore, only make the output an `Adjoint` (or `Transpose`) if its element type permits it. Finally, replace `map` with a delegation to `broadcast`. Fixes JuliaLang/LinearAlgebra.jl#1015.

Comparison for a few basic cases:
```julia
julia> v = [1, 2, 3]'
1×3 adjoint(::Vector{Int64}) with eltype Int64:          # unchanged
 1  2  3

julia> (-).(v)
1×3 Matrix{Int64}:                                       # master
1×3 adjoint(::Vector{Int64}) with eltype Int64:          # PR
 -1  -2  -3

julia> broadcast(-, v)
1×3 adjoint(::Vector{Int64}) with eltype Int64:          # unchanged
 -1  -2  -3

julia> map(-, v)
1×3 adjoint(::Vector{Int64}) with eltype Int64:          # unchanged
 -1  -2  -3

julia> (string).(v)
1×3 Matrix{String}:                                      # unchanged
 "1"  "2"  "3"

julia> broadcast(string, v)
ERROR: MethodError: no method matching adjoint(::String) # master
1×3 Matrix{String}:                                      # PR
 "1"  "2"  "3"

julia> map(string, v)
ERROR: MethodError: no method matching adjoint(::String) # master
1×3 Matrix{String}:                                      # PR
 "1"  "2"  "3"

julia> v .+ 1
1×3 Matrix{Int64}:                                       # master
1×3 adjoint(::Vector{Int64}) with eltype Int64:          # PR
 2  3  4

julia> broadcast(+, v, 1)                                # unchanged
1×3 adjoint(::Vector{Int64}) with eltype Int64:
 2  3  4
```

This made one test fail due to JuliaLang/LinearAlgebra.jl#1019 which I've converted to a `@test_broken` for now and interacts badly with SparseArrays, leading to some more test failures. I think at least some of require adjustment in SparseArrays, but I'm unsure how to orchestrate that, because I suspect that the updated SparseArrays would require this PR as a prerequisite. So how would I do that?

So while this PR is not ready to be merged (causing test failures and not yet bringing in its own tests for the improvements), I'm curious how much breakage it causes in the eco-system (apart from transitive breakage due to SparseArrays). Also, I have no experience so far with the `BroadcastStyle` machinery, so careful review welcome.