### PR TITLE
Shift DCE pass to optimize imaging mode code better

### DIFF
--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -342,9 +342,12 @@ static void buildEarlySimplificationPipeline(ModulePassManager &MPM, PassBuilder
         if (O.getSpeedupLevel() >= 2) {
             JULIA_PASS(FPM.addPass(PropagateJuliaAddrspacesPass()));
         }
+        // DCE must come before simplifycfg
+        // codegen can generate unused statements when generating builtin calls,
+        // and those dead statements can alter how simplifycfg optimizes the CFG
+        FPM.addPass(DCEPass());
         FPM.addPass(SimplifyCFGPass(basicSimplifyCFGOptions()));
         if (O.getSpeedupLevel() >= 1) {
-            FPM.addPass(DCEPass());
             FPM.addPass(SROAPass());
         }
         MPM.addPass(createModuleToFunctionPassAdaptor(std::move(FPM)));


### PR DESCRIPTION
While stripping out literal pointer values and replacing them with imaging mode's loads from global variables, it turns out that codegen emits LLVM IR instructions to load builtin intrinsics that are later removed when codegen lowers builtin calls (e.g. Core.arrayset, Core.not_int, etc). DCE is able to remove this dead code, but we weren't running it before the initial simplifycfg pass, which caused simplifycfg to become more conservative about moving operations around the loads from global variables.

I personally think we should backport this to 1.10 as it probably improves the native code's quality by a decent fraction. 

Diff: https://www.diffchecker.com/iwo6mJUs/