### PR TITLE
Remove SparseArrays legacy code

### DIFF
--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -64,21 +64,6 @@ end
 Adjoint(A) = Adjoint{Base.promote_op(adjoint,eltype(A)),typeof(A)}(A)
 Transpose(A) = Transpose{Base.promote_op(transpose,eltype(A)),typeof(A)}(A)
 
-# TODO: remove, is already replaced by wrapperop
-"""
-    adj_or_trans(::AbstractArray) -> adjoint|transpose|identity
-    adj_or_trans(::Type{<:AbstractArray}) -> adjoint|transpose|identity
-Return [`adjoint`](@ref) from an `Adjoint` type or object and
-[`transpose`](@ref) from a `Transpose` type or object. Otherwise,
-return [`identity`](@ref). Note that `Adjoint` and `Transpose` have
-to be the outer-most wrapper object for a non-`identity` function to be
-returned.
-"""
-adj_or_trans(::T) where {T<:AbstractArray} = adj_or_trans(T)
-adj_or_trans(::Type{<:AbstractArray}) = identity
-adj_or_trans(::Type{<:Adjoint}) = adjoint
-adj_or_trans(::Type{<:Transpose}) = transpose
-
 """
     inplace_adj_or_trans(::AbstractArray) -> adjoint!|transpose!|copyto!
     inplace_adj_or_trans(::Type{<:AbstractArray}) -> adjoint!|transpose!|copyto!

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -679,12 +679,6 @@ fillstored!(A::UnitUpperTriangular, x) = (fillband!(A.data, x, 1, size(A,2)-1); 
 # BlasFloat routines #
 ######################
 
-# legacy stuff, to be removed
-_multrimat!(C, A, B) = _trimul!(C, A, B)
-_mulmattri!(C, A, B) = _trimul!(C, A, B)
-_uconvert_copyto!(c, b, oA) = (c .= Ref(oA) .\ b)
-_uconvert_copyto!(c::AbstractArray{T}, b::AbstractArray{T}, _) where {T} = copyto!(c, b)
-
 # which triangle to use of the underlying data
 uplo_char(::UpperOrUnitUpperTriangular) = 'U'
 uplo_char(::LowerOrUnitLowerTriangular) = 'L'


### PR DESCRIPTION
This code was introduced in the v1.10 cycle, so has not been released. It needed to stay to have the included SparseArrays.jl pass CI tests. After the latest bump, though, this is no longer required. We should backport this to make sure this doesn't get released, even as internal functions.