### PR TITLE
Clean up various naming aspects of codegen

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -245,7 +245,7 @@ static GlobalVariable *emit_plt_thunk(
     std::string fname;
     raw_string_ostream(fname) << "jlplt_" << f_name << "_" << jl_atomic_fetch_add(&globalUniqueGeneratedNames, 1);
     Function *plt = Function::Create(functype,
-                                     GlobalVariable::ExternalLinkage,
+                                     GlobalVariable::PrivateLinkage,
                                      fname, M);
     plt->setAttributes(attrs);
     if (cc != CallingConv::C)

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -119,7 +119,7 @@ static Value *stringConstPtr(
     // null-terminate the string
     ctxt.push_back(0);
     Constant *Data = ConstantDataArray::get(irbuilder.getContext(), ctxt);
-    GlobalVariable *gv = get_pointer_to_constant(emission_context, Data, "_j_str_", *M);
+    GlobalVariable *gv = get_pointer_to_constant(emission_context, Data, "_j_str_" + StringRef(ctxt.data(), ctxt.size() - 1), *M);
     Value *zero = ConstantInt::get(Type::getInt32Ty(irbuilder.getContext()), 0);
     Value *Args[] = { zero, zero };
     auto gep = irbuilder.CreateInBoundsGEP(gv->getValueType(),
@@ -1100,7 +1100,7 @@ static Value *emit_typeof(jl_codectx_t &ctx, const jl_cgval_t &p, bool maybenull
                 if (justtag && jt->smalltag) {
                     ptr = ConstantInt::get(expr_type, jt->smalltag << 4);
                     if (ctx.emission_context.imaging)
-                        ptr = get_pointer_to_constant(ctx.emission_context, ptr, "_j_tag", *jl_Module);
+                        ptr = get_pointer_to_constant(ctx.emission_context, ptr, StringRef("_j_smalltag_") + jl_symbol_name(jt->name->name), *jl_Module);
                 }
                 else if (ctx.emission_context.imaging)
                     ptr = ConstantExpr::getBitCast(literal_pointer_val_slot(ctx, (jl_value_t*)jt), datatype_or_p->getType());

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -119,7 +119,13 @@ static Value *stringConstPtr(
     // null-terminate the string
     ctxt.push_back(0);
     Constant *Data = ConstantDataArray::get(irbuilder.getContext(), ctxt);
-    GlobalVariable *gv = get_pointer_to_constant(emission_context, Data, "_j_str_" + StringRef(ctxt.data(), ctxt.size() - 1), *M);
+    ctxt.pop_back();
+    // We use this for the name of the gv, so cap its size to avoid memory blowout
+    if (ctxt.size() > 25) {
+        ctxt.resize(25 + 3);
+        ctxt[25] = ctxt[26] = ctxt[27] = '.';
+    }
+    GlobalVariable *gv = get_pointer_to_constant(emission_context, Data, "_j_str_" + StringRef(ctxt.data(), ctxt.size()), *M);
     Value *zero = ConstantInt::get(Type::getInt32Ty(irbuilder.getContext()), 0);
     Value *Args[] = { zero, zero };
     auto gep = irbuilder.CreateInBoundsGEP(gv->getValueType(),

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -121,8 +121,8 @@ static Value *stringConstPtr(
     Constant *Data = ConstantDataArray::get(irbuilder.getContext(), ctxt);
     ctxt.pop_back();
     // We use this for the name of the gv, so cap its size to avoid memory blowout
-    if (ctxt.size() > 25) {
-        ctxt.resize(25 + 3);
+    if (ctxt.size() > 28) {
+        ctxt.resize(28);
         ctxt[25] = ctxt[26] = ctxt[27] = '.';
     }
     GlobalVariable *gv = get_pointer_to_constant(emission_context, Data, "_j_str_" + StringRef(ctxt.data(), ctxt.size()), *M);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1827,7 +1827,8 @@ static GlobalVariable *get_pointer_to_constant(jl_codegen_params_t &emission_con
     };
     if (gv == nullptr) {
         gv = get_gv(name + "#" + Twine(emission_context.mergedConstants.size()));
-    } else if (gv->getParent() != &M) {
+    }
+    else if (gv->getParent() != &M) {
         StringRef gvname = gv->getName();
         gv = M.getNamedGlobal(gvname);
         if (!gv) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1761,7 +1761,7 @@ static Value *global_binding_pointer(jl_codectx_t &ctx, jl_module_t *m, jl_sym_t
                                      jl_binding_t **pbnd, bool assign);
 static jl_cgval_t emit_checked_var(jl_codectx_t &ctx, Value *bp, jl_sym_t *name, bool isvol, MDNode *tbaa);
 static jl_cgval_t emit_sparam(jl_codectx_t &ctx, size_t i);
-static Value *emit_condition(jl_codectx_t &ctx, const jl_cgval_t &condV, const std::string &msg);
+static Value *emit_condition(jl_codectx_t &ctx, const jl_cgval_t &condV, const Twine &msg);
 static Value *get_current_task(jl_codectx_t &ctx);
 static Value *get_current_ptls(jl_codectx_t &ctx);
 static Value *get_last_age_field(jl_codectx_t &ctx);
@@ -3393,7 +3393,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         const jl_cgval_t &ty = argv[2];
         if (jl_is_type_type(ty.typ) && !jl_has_free_typevars(ty.typ)) {
             jl_value_t *tp0 = jl_tparam0(ty.typ);
-            Value *isa_result = emit_isa(ctx, arg, tp0, NULL).first;
+            Value *isa_result = emit_isa(ctx, arg, tp0, Twine()).first;
             if (isa_result->getType() == getInt1Ty(ctx.builder.getContext()))
                 isa_result = ctx.builder.CreateZExt(isa_result, getInt8Ty(ctx.builder.getContext()));
             *ret = mark_julia_type(ctx, isa_result, false, jl_bool_type);
@@ -5278,7 +5278,7 @@ static void emit_upsilonnode(jl_codectx_t &ctx, ssize_t phic, jl_value_t *val)
 
 static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, const jl_cgval_t &fexpr, jl_value_t *rt, jl_svec_t *argt);
 
-static Value *emit_condition(jl_codectx_t &ctx, const jl_cgval_t &condV, const std::string &msg)
+static Value *emit_condition(jl_codectx_t &ctx, const jl_cgval_t &condV, const Twine &msg)
 {
     bool isbool = (condV.typ == (jl_value_t*)jl_bool_type);
     if (!isbool) {
@@ -5301,7 +5301,7 @@ static Value *emit_condition(jl_codectx_t &ctx, const jl_cgval_t &condV, const s
     return ConstantInt::get(getInt1Ty(ctx.builder.getContext()), 0); // TODO: replace with Undef
 }
 
-static Value *emit_condition(jl_codectx_t &ctx, jl_value_t *cond, const std::string &msg)
+static Value *emit_condition(jl_codectx_t &ctx, jl_value_t *cond, const Twine &msg)
 {
     return emit_condition(ctx, emit_expr(ctx, cond), msg);
 }


### PR DESCRIPTION
Most of the changes are changing from `const std::string &` to `const Twine &`, which lets us be lazier about computing string values efficiently. We also make the plt function private linkage since it's only referred to by the plt global. 

Depends on #50632 (potentially, I haven't checked if there are actual conflicts)