### PR TITLE
Improve allunique performance for strings, avoid computing length several times for iterators

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -478,7 +478,7 @@ allunique(::Union{AbstractSet,AbstractDict}) = true
 
 allunique(r::AbstractRange) = !iszero(step(r)) || length(r) <= 1
 
-function allunique(S::String)
+function allunique(S::AbstractString)
     nunits = ncodeunits(S) # computing `length` for a string might be expensive
     nunits < 32 ? _indexed_allunique(S, nunits) : _hashed_allunique(S, nunits)
 end

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -560,7 +560,9 @@ end
     @test !allunique(x for x in [NaN, NaN] if true)
     # strings
     @test !allunique("aaaa")
+    @test !allunique(@views("aaaa"[1:3])) # sub-string / abstractstring
     @test allunique("abcd")
+    @test allunique(@views("abcd"[1:3])) # sub-string / abstractstring
     @test !allunique("a" ^ 100) # longer than 32 but less than 1000
     @test !allunique("a" ^ 10_000) # longer than 1000
     # ranges

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -558,6 +558,11 @@ end
     @test allunique(x for x in [0.0, -0.0] if true)
     @test !allunique([NaN, NaN])
     @test !allunique(x for x in [NaN, NaN] if true)
+    # strings
+    @test !allunique("aaaa")
+    @test allunique("abcd")
+    @test !allunique("a" ^ 100) # longer than 32 but less than 1000
+    @test !allunique("a" ^ 10_000) # longer than 1000
     # ranges
     @test allunique(4:7)
     @test allunique(1:1)


### PR DESCRIPTION
This PR fixes #50360 .

master: 
```julia
julia> VERSION
v"1.11.0-DEV.142"

julia> using Random

julia> using BenchmarkTools

julia> s=randstring(100000);

julia> @btime allunique($s)
  171.250 μs (4 allocations: 336 bytes)
false

julia> @btime allunique($s[1:100]) && allunique($s)
  258.552 ns (5 allocations: 456 bytes)
false
```

This PR:
```julia
julia> VERSION
v"1.11.0-DEV.142"

julia> using Random

julia> using BenchmarkTools

julia> s=randstring(100000);

julia> @btime allunique($s)
  72.362 ns (4 allocations: 336 bytes)
false

julia> @btime allunique($s[1:100]) && allunique($s)
  91.118 ns (5 allocations: 456 bytes)
false
```