### PR TITLE
Make map! correctly handle differently-sized containers.

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3297,10 +3297,12 @@ map(f, ::AbstractSet) = error("map is not defined on sets")
 
 ## N argument
 
-function map_n!(f::F, dest::AbstractArray, As) where F
+@noinline throw_map_mismatch(ndest, nvals) =
+    throw(DimensionMismatch("map! over $nvals values, but destination only has length $ndest"))
+
+@inline function map_n!(f::F, dest::AbstractArray, As) where F
     Is = zip(map(eachindex, As)...)
-    @boundscheck length(Is) <= length(dest) ||
-        throw(DimensionMismatch("map! over $(length(Is)) values, but destination only has length $(length(dest))"))
+    @boundscheck length(Is) <= length(dest) || throw_map_mismatch(length(dest), length(Is))
     for (i, js...) in zip(eachindex(dest), map(eachindex, As)...)
         J = ntuple(d -> @inbounds(As[d][js[d]]), Val(length(As)))
         val = f(J...)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3339,6 +3339,7 @@ julia> map!(+, zeros(Int, 5), 100:999, 1:3)
 ```
 """
 function map!(f::F, dest::AbstractArray, As::AbstractArray...) where {F}
+    @_propagate_inbounds_meta
     isempty(As) && throw(ArgumentError(
         """map! requires at least one "source" argument"""))
     map_n!(f, dest, As)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3298,10 +3298,10 @@ map(f, ::AbstractSet) = error("map is not defined on sets")
 ## N argument
 
 function map_n!(f::F, dest::AbstractArray, As) where F
-    Is = zip(eachindex(dest), map(eachindex, As)...)
+    Is = zip(map(eachindex, As)...)
     @boundscheck length(Is) <= length(dest) ||
         throw(DimensionMismatch("map! over $(length(Is)) values, but destination only has length $(length(dest))"))
-    for (i, js...) in Is
+    for (i, js...) in zip(eachindex(dest), Is...)
         J = ntuple(d -> @inbounds(As[d][js[d]]), Val(length(As)))
         val = f(J...)
         @inbounds dest[i] = val

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3262,6 +3262,7 @@ map(f) = f()
 ## 1 argument
 
 function map!(f::F, dest::AbstractArray, A::AbstractArray) where F
+    @boundscheck checkbounds(dest, LinearIndices(A))
     for (i,j) in zip(eachindex(dest),eachindex(A))
         val = f(@inbounds A[j])
         @inbounds dest[i] = val
@@ -3305,6 +3306,7 @@ map(f, ::AbstractSet) = error("map is not defined on sets")
 
 ## 2 argument
 function map!(f::F, dest::AbstractArray, A::AbstractArray, B::AbstractArray) where F
+    @boundscheck checkbounds(dest, intersect(LinearIndices(A), LinearIndices(B)))
     for (i, j, k) in zip(eachindex(dest), eachindex(A), eachindex(B))
         @inbounds a, b = A[j], B[k]
         val = f(a, b)
@@ -3322,9 +3324,15 @@ function ith_all(i, as)
 end
 
 function map_n!(f::F, dest::AbstractArray, As) where F
-    idxs1 = LinearIndices(As[1])
-    @boundscheck LinearIndices(dest) == idxs1 && all(x -> LinearIndices(x) == idxs1, As)
-    for i = idxs1
+    # determine the smallest range of linear indices to iterate over
+    i0, i1 = firstindex(As[1]), lastindex(As[1])
+    for A in As[2:end]
+        i0 = max(firstindex(A), i0)
+        i1 = min(lastindex(A), i1)
+    end
+    @boundscheck checkbounds(dest, i0:i1)
+
+    for i = i0:i1
         @inbounds I = ith_all(i, As)
         val = f(I...)
         @inbounds dest[i] = val

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3301,7 +3301,7 @@ function map_n!(f::F, dest::AbstractArray, As) where F
     Is = zip(map(eachindex, As)...)
     @boundscheck length(Is) <= length(dest) ||
         throw(DimensionMismatch("map! over $(length(Is)) values, but destination only has length $(length(dest))"))
-    for (i, js...) in zip(eachindex(dest), Is...)
+    for (i, js...) in zip(eachindex(dest), map(eachindex, As)...)
         J = ntuple(d -> @inbounds(As[d][js[d]]), Val(length(As)))
         val = f(J...)
         @inbounds dest[i] = val

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -271,7 +271,7 @@ copyfirst!(R::AbstractArray, A::AbstractArray) = mapfirst!(identity, R, A)
 function mapfirst!(f::F, R::AbstractArray, A::AbstractArray{<:Any,N}) where {N, F}
     lsiz = check_reducedims(R, A)
     t = _firstreducedslice(axes(R), axes(A))
-    map!(f, R, view(A, t...))
+    @inbounds map!(f, R, view(A, t...))
 end
 # We know that the axes of R and A are compatible, but R might have a different number of
 # dimensions than A, which is trickier than it seems due to offset arrays and type stability

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -844,6 +844,12 @@ test_ind2sub(TestAbstractArray)
 include("generic_map_tests.jl")
 generic_map_tests(map, map!)
 @test_throws ArgumentError map!(-, [1])
+# Issue #30624
+@test map!(+, [0,0,0], [1,2], [10,20,30], [100]) == [111,0,0]
+## destination container should be large enough
+@test_throws BoundsError map!(+, [0], [1,2])
+@test_throws BoundsError map!(+, [0], [1,2], [1,2])
+@test_throws BoundsError map!(+, [0], [1,2], [1,2], [1,2])
 
 test_UInt_indexing(TestAbstractArray)
 test_13315(TestAbstractArray)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -847,9 +847,9 @@ generic_map_tests(map, map!)
 # Issue #30624
 @test map!(+, [0,0,0], [1,2], [10,20,30], [100]) == [111,0,0]
 ## destination container should be large enough
-@test_throws BoundsError map!(+, [0], [1,2])
-@test_throws BoundsError map!(+, [0], [1,2], [1,2])
-@test_throws BoundsError map!(+, [0], [1,2], [1,2], [1,2])
+@test_throws DimensionMismatch map!(+, [0], [1,2])
+@test_throws DimensionMismatch map!(+, [0], [1,2], [1,2])
+@test_throws DimensionMismatch map!(+, [0], [1,2], [1,2], [1,2])
 
 test_UInt_indexing(TestAbstractArray)
 test_13315(TestAbstractArray)


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/36235.

The `map!` docstring specifies:

> Like map, but stores the result in destination rather than a new collection. destination must be at least as large as the smallest collection.

However, we're neither boundschecking the destination container, nor using the smallest input collection:

```julia
# should throw
julia> map!(identity, [0], [1,2])
1-element Vector{Int64}:
 1

# uses undefined values
julia> map!(+, [0,0], [1,2], [3], [4])
2-element Vector{Int64}:
           8
 10187977346
```

This PR corrects that.

Will need some careful benchmarking, maybe add some `@inbounds` to `map!` calls and/or outlining the throwing.

FWIW, the performance of the example in https://github.com/JuliaLang/julia/pull/30624#issue-396345382 is identical.