### PR TITLE
Reuse incremental JIT compilation for --image-codegen

### DIFF
--- a/test/llvmpasses/image-codegen.jl
+++ b/test/llvmpasses/image-codegen.jl
@@ -13,7 +13,8 @@
 # CHECK-NOT: internal global
 # CHECK-NOT: private global
 # CHECK: jl_global
-# CHECK-SAME: = global
+# COM: we emit both declarations and definitions, so we may see either style in the IR
+# CHECK-SAME: = {{(external )?}}global
 # CHECK: julia_f_
 # CHECK-NOT: internal global
 # CHECK-NOT: private global


### PR DESCRIPTION
We don't need to merge all of the workqueue modules when performing compilation with `--image-codegen` set, we just need the global variable initializers to be defined before they're used in one of the modules. Therefore we can do this by compiling all of the global variable initializers upfront, so that later references will link them properly.