### PR TITLE
Docs: Warn that thrown exceptions cannot be relied on

### DIFF
--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -802,7 +802,14 @@ Stacktrace:
 [...]
 ```
 
-Note that the symbol following `catch` will always be interpreted as a name for the exception,
+Note that the specific type of exception thrown of Julia code in Base and the
+standard libraries, (in this case, a `DomainError` or a `BoundsError`)
+is considered an internal implementation detail and may change across minor
+versions of Julia.
+Therefore, users are adviced not to write code like the code above which relies
+on specific exception types, unless they are explicitly documented.
+
+In `catch` statements, the symbol following `catch` will always be interpreted as a name for the exception,
 so care is needed when writing `try/catch` expressions on a single line. The following code will
 *not* work to return the value of `x` in case of an error:
 

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -737,6 +737,12 @@ Note that `@test_throws` does not support a trailing keyword form.
 !!! compat "Julia 1.8"
     The ability to specify anything other than a type or a value as `exception` requires Julia v1.8 or later.
 
+!!! note
+    The type and text of thrown exceptions is considered an implementation detail,
+    and may change in minor versions of Julia.
+    The generic `@test_throws Exception expr` may be used to test for exceptions
+    generally.
+
 # Examples
 ```jldoctest
 julia> @test_throws BoundsError [1, 2, 3][4]


### PR DESCRIPTION
The specific exception type thrown by Base and the standard libraries is an internal implementation detail, and should not be relied on by users. Document this in the docstring of `Test.@test_throws`, and mention it in the manual section on try/catch.