### PR TITLE
Make reinterpret specialize fully.

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -571,8 +571,8 @@ julia> reinterpret(Tuple{UInt16, UInt8}, (0x01, 0x0203))
     otherwise be prevented by the type's constructors and methods. Unexpected behavior
     may result without additional validation.
 """
-function reinterpret(Out::Type, x::In) where {In}
-    if isprimitivetype(Out) && isprimitivetype(In)
+function reinterpret(::Type{Out}, x) where {Out}
+    if isprimitivetype(Out) && isprimitivetype(typeof(x))
         return bitcast(Out, x)
     end
     # only available when Base is fully loaded.

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -2061,3 +2061,7 @@ let src = code_typed1((Union{DataType,UnionAll},); interp=NoCompileSigInvokes())
         (x.args[1]::MethodInstance).specTypes == Tuple{typeof(no_compile_sig_invokes),UnionAll}
     end == 1
 end
+
+# https://github.com/JuliaLang/julia/issues/50612
+f50612(x) = UInt32(x)
+@test all(!isinvoke(:UInt32),get_code(f50612,Tuple{Char}))


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/50612

The issue here was the reinterpret change made a bunch of operations like `Core.bitcast(UInt64,24)` not fold, even though they are fully known at compile time. That made `UInt32(Char)` not inline which then caused the regression.