### PR TITLE
Support `convert(LineNumberNode, ::LineInfoNode)`

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -33,6 +33,9 @@ macro gensym(names...)
     return blk
 end
 
+## line numbers ##
+convert(::Type{LineNumberNode}, lin::Core.LineInfoNode) = LineNumberNode(lin.line, lin.file)
+
 ## expressions ##
 
 isexpr(@nospecialize(ex), head::Symbol) = isa(ex, Expr) && ex.head === head

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -34,7 +34,7 @@ macro gensym(names...)
 end
 
 ## line numbers ##
-convert(::Type{LineNumberNode}, lin::Core.LineInfoNode) = LineNumberNode(lin.line, lin.file)
+convert(::Type{LineNumberNode}, lin::Core.LineInfoNode) = LineNumberNode(Int(lin.line), lin.file)
 
 ## expressions ##
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -8044,3 +8044,7 @@ end
 # `SimpleVector`-operations should be concrete-eval eligible
 @test Core.Compiler.is_foldable(Base.infer_effects(length, (Core.SimpleVector,)))
 @test Core.Compiler.is_foldable(Base.infer_effects(getindex, (Core.SimpleVector,Int)))
+
+let lin = Core.LineInfoNode(Base, first(methods(convert)), :foo, Int32(5), Int32(0))
+    @test convert(LineNumberNode, lin) == LineNumberNode(5, :foo)
+end


### PR DESCRIPTION
xref https://github.com/timholy/CodeTracking.jl/pull/113. From the CI it looks like that method might not even be important anymore for CodeTracking and the Revise stack, but because we have lots of packages that dive into internals, having this seems to make sense.