### PR TITLE
Add documentation for some documentation forms.

### DIFF
--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -429,10 +429,13 @@ Adds docstring `"..."` to the `@m(::Any)` macro definition.
 
 ```julia
 "..."
-:(@m)
+:(@m1)
+
+"..."
+macro m2 end
 ```
 
-Adds docstring `"..."` to the macro named `@m`.
+Adds docstring `"..."` to the macros named `@m1` and `@m2`.
 
 ### Types
 
@@ -452,6 +455,20 @@ end
 ```
 
 Adds the docstring `"..."` to types `T1`, `T2`, and `T3`.
+
+```
+"..."
+T1
+
+"..."
+T2
+
+"..."
+T3
+```
+
+Adds the docstring `"..."` to types `T1`, `T2`, and `T3`.
+The previous version is the preferred syntax, however both are equivalent.
 
 ```julia
 "..."


### PR DESCRIPTION
There are a couple of documentation forms that are used in the wild but not covered by the documentation.  Here I describe them.