### PR TITLE
Properly isolate `sysimg` bootstrap environment

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -77,6 +77,7 @@ let
 
     tot_time_stdlib = 0.0
     # use a temp module to avoid leaving the type of this closure in Main
+    push!(empty!(LOAD_PATH), "@stdlib")
     m = Module()
     GC.@preserve m begin
         print_time = @eval m (mod, t) -> (print(rpad(string(mod) * "  ", $maxlen + 3, "─"));


### PR DESCRIPTION
The stdlib environment should be isolated from the global environment while it is bootstrapping; it should only load from the stdlib directory.