### PR TITLE
Remove `Base.lib{blas,lapack}_name`

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -384,11 +384,6 @@ include("sysinfo.jl")
 include("libc.jl")
 using .Libc: getpid, gethostname, time, memcpy, memset, memmove, memcmp
 
-# These used to be in build_h.jl and are retained for backwards compatibility.
-# NOTE: keep in sync with `libblastrampoline_jll.libblastrampoline`.
-const libblas_name = "libblastrampoline" * (Sys.iswindows() ? "-5" : "")
-const liblapack_name = libblas_name
-
 # Concurrency (part 2)
 # Note that `atomics.jl` here should be deprecated
 Core.eval(Threads, :(include("atomics.jl")))

--- a/stdlib/LinearAlgebra/test/blas.jl
+++ b/stdlib/LinearAlgebra/test/blas.jl
@@ -773,11 +773,4 @@ end
     end
 end
 
-# Make sure we can use `Base.libblas_name`.  Avoid causing
-# https://github.com/JuliaLang/julia/issues/48427 again.
-@testset "libblas_name" begin
-    dot_sym = dlsym(dlopen(Base.libblas_name), "cblas_ddot" * (Sys.WORD_SIZE == 64 ? "64_" : ""))
-    @test 23.0 === @ccall $(dot_sym)(2::Int, [2.0, 3.0]::Ref{Cdouble}, 1::Int, [4.0, 5.0]::Ref{Cdouble}, 1::Int)::Cdouble
-end
-
 end # module TestBLAS


### PR DESCRIPTION
These have been deprecated for a long time, users should instead use
`LinearAlgebra.BLAS.libblas` or `LinearAlgebra.BLAS.liblapack`.

This will be necessary once we have lazy JLLs, as it's not desirable to
recreate the dependency graph in `Base`, we already have it in standard
libraries, and only load libblastrampoline when `LinearAlgebra` starts
doing ccalls.