### PR TITLE
Reactivate automatic nospecialize for unused arguments

### DIFF
--- a/src/method.c
+++ b/src/method.c
@@ -859,10 +859,8 @@ JL_DLLEXPORT void jl_method_set_source(jl_method_t *m, jl_code_info_t *src)
     for (j = 1; j < m->nargs && j <= sizeof(m->nospecialize) * 8; j++) {
         jl_value_t *ai = jl_array_ptr_ref(src->slotnames, j);
         if (ai == (jl_value_t*)jl_unused_sym) {
-            // TODO: enable this. currently it triggers a bug on arguments like
-            // ::Type{>:Missing}
-            //int sn = j-1;
-            //m->nospecialize |= (1 << sn);
+            int sn = j-1;
+            m->nospecialize |= (1 << sn);
             continue;
         }
         if (j <= 8) {


### PR DESCRIPTION
Reactivate automatic nospecialize for unused arguments, to avoid unnecessary code generation in use cases like

```
foo(A::Array, B::Array) = length(A) * length(B)
foo(A::Array, ::Number) = length(A)
```

(let's see if the bug mentioned in the code is gone by now).

Maybe even use the new `@nospecializeinfer`?  (I don't know how to do this in C though :-) ).

CC @JeffBezanson , @LilithHafner (our discussion at JuliaCon).