### PR TITLE
irinterp: fix semi-concrete evaluation of overlay methods

### DIFF
--- a/base/compiler/methodtable.jl
+++ b/base/compiler/methodtable.jl
@@ -167,7 +167,9 @@ end
 # This query is not cached
 findsup(@nospecialize(sig::Type), table::CachedMethodTable) = findsup(sig, table.table)
 
-isoverlayed(::MethodTableView)     = error("unsatisfied MethodTableView interface")
+isoverlayed(::MethodTableView) = error("unsatisfied MethodTableView interface")
 isoverlayed(::InternalMethodTable) = false
-isoverlayed(::OverlayMethodTable)  = true
+isoverlayed(::OverlayMethodTable) = true
 isoverlayed(mt::CachedMethodTable) = isoverlayed(mt.table)
+isoverlayed(m::Method) = isdefined(m, :external_mt)
+is_nonoverlayed(m::Method) = !isoverlayed(m)

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -14,7 +14,8 @@ function concrete_eval_invoke(interp::AbstractInterpreter,
     argtypes = collect_argtypes(interp, inst.args[2:end], nothing, irsv)
     argtypes === nothing && return Pair{Any,Bool}(Bottom, false)
     effects = decode_effects(code.ipo_purity_bits)
-    if is_foldable(effects) && is_all_const_arg(argtypes, #=start=#1)
+    if (is_foldable(effects) && is_all_const_arg(argtypes, #=start=#1) &&
+        is_nonoverlayed(effects) && is_nonoverlayed(mi.def::Method))
         args = collect_const_args(argtypes, #=start=#1)
         value = let world = get_world_counter(interp)
             try

--- a/test/compiler/AbstractInterpreter.jl
+++ b/test/compiler/AbstractInterpreter.jl
@@ -9,10 +9,10 @@ include("newinterp.jl")
 # OverlayMethodTable
 # ==================
 
-import Base.Experimental: @MethodTable, @overlay
+using Base.Experimental: @MethodTable, @overlay
 
 @newinterp MTOverlayInterp
-@MethodTable(OverlayedMT)
+@MethodTable OverlayedMT
 CC.method_table(interp::MTOverlayInterp) = CC.OverlayMethodTable(CC.get_world_counter(interp), OverlayedMT)
 
 function CC.add_remark!(interp::MTOverlayInterp, ::CC.InferenceState, remark)
@@ -113,10 +113,48 @@ end |> only === Nothing
 @MethodTable Issue48097MT
 CC.method_table(interp::Issue48097Interp) = CC.OverlayMethodTable(CC.get_world_counter(interp), Issue48097MT)
 CC.InferenceParams(::Issue48097Interp) = CC.InferenceParams(; unoptimize_throw_blocks=false)
+function CC.concrete_eval_eligible(interp::Issue48097Interp,
+    @nospecialize(f), result::CC.MethodCallResult, arginfo::CC.ArgInfo, sv::CC.AbsIntState)
+    ret = @invoke CC.concrete_eval_eligible(interp::CC.AbstractInterpreter,
+        f::Any, result::CC.MethodCallResult, arginfo::CC.ArgInfo, sv::CC.AbsIntState)
+    if ret === :semi_concrete_eval
+        # disable semi-concrete interpretation
+        return :none
+    end
+    return ret
+end
 @overlay Issue48097MT @noinline Core.throw_inexacterror(f::Symbol, ::Type{T}, val) where {T} = return
 issue48097(; kwargs...) = return 42
 @test fully_eliminated(; interp=Issue48097Interp(), retval=42) do
     issue48097(; a=1f0, b=1.0)
+end
+
+# Should not concrete-eval overlayed methods in semi-concrete interpretation
+@newinterp OverlaySinInterp
+@MethodTable OverlaySinMT
+CC.method_table(interp::OverlaySinInterp) = CC.OverlayMethodTable(CC.get_world_counter(interp), OverlaySinMT)
+overlay_sin1(x) = error("Not supposed to be called.")
+@overlay OverlaySinMT overlay_sin1(x) = cos(x)
+@overlay OverlaySinMT Base.sin(x::Union{Float32,Float64}) = overlay_sin1(x)
+let oc = Base.code_ircode(; interp=OverlaySinInterp()) do
+        sin(0.)
+    end |> only |> first |> Core.OpaqueClosure
+    @test oc() == cos(0.)
+end
+@overlay OverlaySinMT Base.sin(x::Union{Float32,Float64}) = @noinline overlay_sin1(x)
+let oc = Base.code_ircode(; interp=OverlaySinInterp()) do
+        sin(0.)
+    end |> only |> first |> Core.OpaqueClosure
+    @test oc() == cos(0.)
+end
+_overlay_sin2(x) = error("Not supposed to be called.")
+@overlay OverlaySinMT _overlay_sin2(x) = cos(x)
+overlay_sin2(x) = _overlay_sin2(x)
+@overlay OverlaySinMT Base.sin(x::Union{Float32,Float64}) = @noinline overlay_sin2(x)
+let oc = Base.code_ircode(; interp=OverlaySinInterp()) do
+        sin(0.)
+    end |> only |> first |> Core.OpaqueClosure
+    @test oc() == cos(0.)
 end
 
 # AbstractLattice


### PR DESCRIPTION
This commit introduces several fixes related to the overlay method and its semi-concrete evaluation. When `f` is being overlayed, semi-concrete interpretation is performed on `f`. While this isn't problematic in itself, the issue arises since there is no overlay check within concrete evaluation in the semi-concrete interpretation (`concrete_eval_invoke`), potentially leading to mis-compilation. This commit makes adjustments to allow semi-concrete interpretation for overlay methods, while preventing the concretization of overlay methods within `concrete_eval_invoke`.

Note: Confirmed GPUCompiler test suite passes with this patch after https://github.com/JuliaGPU/GPUCompiler.jl/pull/488.