### PR TITLE
Wipe ptls->system_id when a thread exits.

### DIFF
--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -259,7 +259,7 @@ typedef struct _jl_tls_states_t {
 #else
     void *signal_stack;
 #endif
-    jl_thread_t system_id;
+    _Atomic(jl_thread_t) system_id;
     arraylist_t finalizers;
     struct _jl_gc_pagemeta_t *page_metadata_allocd;
     struct _jl_gc_pagemeta_t *page_metadata_lazily_freed;

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -385,11 +385,10 @@ static int jl_thread_suspend_and_get_state2(int tid, host_thread_state_t *ctx)
     jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
     if (ptls2 == NULL) // this thread is not alive
         return 0;
+    mach_port_t thread = pthread_mach_thread_np(jl_atomic_load_acquire(&ptls2->system_id));
     jl_task_t *ct2 = ptls2 ? jl_atomic_load_relaxed(&ptls2->current_task) : NULL;
     if (ct2 == NULL) // this thread is already dead
         return 0;
-
-    mach_port_t thread = pthread_mach_thread_np(jl_atomic_load_relaxed(&ptls2->system_id));
 
     kern_return_t ret = thread_suspend(thread);
     HANDLE_MACH_ERROR("thread_suspend", ret);

--- a/src/threading.c
+++ b/src/threading.c
@@ -475,7 +475,7 @@ static void jl_delete_thread(void *value) JL_NOTSAFEPOINT_ENTER
     }
     // mark this thread as dead
     jl_atomic_store_relaxed(&ptls->current_task, NULL);
-    jl_atomic_store_relaxed(&ptls->system_id, 0);
+    jl_atomic_store_release(&ptls->system_id, 0);
     // finally, release all of the locks we had grabbed
 #ifdef _OS_WINDOWS_
     jl_unlock_profile_wr();

--- a/src/threading.c
+++ b/src/threading.c
@@ -474,6 +474,7 @@ static void jl_delete_thread(void *value) JL_NOTSAFEPOINT_ENTER
         abort();
     }
     jl_atomic_store_relaxed(&ptls->current_task, NULL); // dead
+    ptls->system_id = 0;
     // finally, release all of the locks we had grabbed
 #ifdef _OS_WINDOWS_
     jl_unlock_profile_wr();


### PR DESCRIPTION
On macOS, we use the system thread ID to match against the list of known thread local states during signal handling. To prevent picking up the wrong entry, i.e. from when a thread was previously executing a different task, make sure to wipe the system ID when a thread exits.

This manifested as the signal handler actually reporting a bus error when a thread touched safepoint memory during GC, because the matched thread local state had no current task attached to it.

Fixes JuliaGPU/Metal.jl#225