### PR TITLE
ssair: `compact!` constant `PiNode`

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1362,8 +1362,9 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
                 return result_idx
             end
         elseif !isa(pi_val, AnySSAValue) && !isa(pi_val, GlobalRef)
-            valtyp = isa(pi_val, QuoteNode) ? typeof(pi_val.value) : typeof(pi_val)
-            if valtyp === stmt.typ
+            pi_val′ = isa(pi_val, QuoteNode) ? pi_val.value : pi_val
+            stmttyp = stmt.typ
+            if isa(stmttyp, Const) ? pi_val′ === stmttyp.val : typeof(pi_val′) === stmttyp
                 ssa_rename[idx] = pi_val
                 return result_idx
             end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1130,7 +1130,7 @@ function f44200()
     x44200
 end
 let src = code_typed1(f44200)
-    @test_broken count(x -> isa(x, Core.PiNode), src.code) == 0
+    @test count(x -> isa(x, Core.PiNode), src.code) == 0
 end
 
 # Test that peeling off one case from (::Any) doesn't introduce

--- a/test/compiler/irutils.jl
+++ b/test/compiler/irutils.jl
@@ -37,8 +37,11 @@ isinvoke(y) = @nospecialize(x) -> isinvoke(y, x)
 isinvoke(sym::Symbol, @nospecialize(x)) = isinvoke(mi->mi.def.name===sym, x)
 isinvoke(pred::Function, @nospecialize(x)) = isexpr(x, :invoke) && pred(x.args[1]::MethodInstance)
 
-function fully_eliminated(@nospecialize args...; retval=(@__FILE__), kwargs...)
-    code = code_typed1(args...; kwargs...).code
+fully_eliminated(@nospecialize args...; retval=(@__FILE__), kwargs...) =
+    fully_eliminated(code_typed1(args...; kwargs...); retval)
+fully_eliminated(src::CodeInfo; retval=(@__FILE__)) = fully_eliminated(src.code; retval)
+fully_eliminated(ir::IRCode; retval=(@__FILE__)) = fully_eliminated(ir.stmts.inst; retval)
+function fully_eliminated(code::Vector{Any}; retval=(@__FILE__), kwargs...)
     if retval !== (@__FILE__)
         length(code) == 1 || return false
         code1 = code[1]

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -5,7 +5,7 @@ using Core.IR
 const Compiler = Core.Compiler
 using .Compiler: CFG, BasicBlock, NewSSAValue
 
-include(normpath(@__DIR__, "irutils.jl"))
+include("irutils.jl")
 
 make_bb(preds, succs) = BasicBlock(Compiler.StmtRange(0, 0), preds, succs)
 
@@ -591,6 +591,16 @@ let ci = make_ci([
     ir = Core.Compiler.complete(compact)
 
     @test Core.Compiler.verify_ir(ir) === nothing
+end
+
+# compact constant PiNode
+let ci = make_ci(Any[
+        PiNode(0.0, Const(0.0))
+        ReturnNode(SSAValue(1))
+    ])
+    ir = Core.Compiler.inflate_ir(ci)
+    ir = Core.Compiler.compact!(ir)
+    @test fully_eliminated(ir)
 end
 
 # insert_node! with new instruction with flag computed


### PR DESCRIPTION
Currently the `compact!`-ion pass fails to fold constant `PiNode` like `PiNode(0.0, Float64)`. This commit fixes it up.