### PR TITLE
Fix log1p(z) for extremely small |z|.

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -750,7 +750,7 @@ function log1p(z::Complex{T}) where T
         # allegedly due to Kahan, only modified to handle real(u) <= 0
         # differently to avoid inaccuracy near z==-2 and for correct branch cut
         u = one(float(T)) + z
-        u == 1 ? convert(typeof(u), z) : real(u) <= 0 ? log(u) : log(u)*z/(u-1)
+        u == 1 ? convert(typeof(u), z) : real(u) <= 0 ? log(u) : log(u)*(z/(u-1))
     elseif isnan(zr)
         Complex(zr, zr)
     elseif isfinite(zi)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -383,6 +383,7 @@ import Base.Math.@horner
     @test isequal(log1p(complex(-2, 1e-10)), log(1 + complex(-2, 1e-10)))
     @test isequal(log1p(complex(1, Inf)), complex(Inf, pi/2))
     @test isequal(log1p(complex(1, -Inf)), complex(Inf, -pi/2))
+    @test isequal(log1p(complex(1e-200, 5e-175)), complex(1e-200, 5e-175))
 
     for z in (1e-10+1e-9im, 1e-10-1e-9im, -1e-10+1e-9im, -1e-10-1e-9im)
         @test log1p(z) ≈ @horner(z, 0, 1, -0.5, 1/3, -0.25, 0.2)


### PR DESCRIPTION
If |z| is extremely small (e.g. `1e-200+5e-175im`), the expression `log(u)*z/(u-1)` (where `u` is `1 + z`) evaluates to 0, because the product `log(u)*z` is approximately `z.im*z` when |z| is very small, and that product underflows to 0.  By adding parentheses so that the expression is `log(u)*(z/(u-1))`, `z/(u - 1)` is evaluated first and the underflow is avoided.