### PR TITLE
implement `Base.hastypemax` with `hasmethod` instead of `applicable`

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -937,7 +937,7 @@ Return `true` if and only if the extrema `typemax(T)` and `typemin(T)` are defin
 """
 hastypemax(::Base.BitIntegerType) = true
 hastypemax(::Type{Bool}) = true
-hastypemax(::Type{T}) where {T} = applicable(typemax, T) && applicable(typemin, T)
+hastypemax(::Type{T}) where {T} = hasmethod_one_type(typemax, T) && hasmethod_one_type(typemin, T)
 
 """
     digits!(array, n::Integer; base::Integer = 10)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1859,6 +1859,8 @@ function hasmethod(f, t, kwnames::Tuple{Vararg{Symbol}}; world::UInt=get_world_c
     return issubset(kwnames, kws)
 end
 
+hasmethod_one_type(f::F, ::Type{T}) where {F<:Function,T} = hasmethod(f, Tuple{Type{T}})
+
 """
     fbody = bodyfunction(basemethod::Method)
 


### PR DESCRIPTION
Unlike `applicable`, `hasmethod` gets constant-folded.

Just the fallback method is modified.

Codegen examples, taking `BigFloat` as an example:

On master (3eddd1783f29eaf60ab817301bc8c3d084e417a4):
```julia-repl
julia> Base.print_statement_costs(stdout, Base.hastypemax, Tuple{Type{BigFloat}})
hastypemax(::Type{T}) where T @ Base intfuncs.jl:940
 40 1 ─ %1 = Base.applicable(Base.typemin, BigFloat)::Bool
  0 └──      return %1
```

With this commit:
```julia-repl
julia> Base.print_statement_costs(stdout, Base.hastypemax, Tuple{Type{BigFloat}})
hastypemax(::Type{T}) where T @ Base intfuncs.jl:940
 0 1 ─     return true
```