### PR TITLE
re-allow non-string values in ENV `get!`

### DIFF
--- a/base/env.jl
+++ b/base/env.jl
@@ -138,6 +138,10 @@ end
 getindex(::EnvDict, k::AbstractString) = access_env(k->throw(KeyError(k)), k)
 get(::EnvDict, k::AbstractString, def) = access_env(Returns(def), k)
 get(f::Callable, ::EnvDict, k::AbstractString) = access_env(k->f(), k)
+function get!(default::Callable, ::EnvDict, k::AbstractString)
+    haskey(ENV, k) && return ENV[k]
+    ENV[k] = default()
+end
 in(k::AbstractString, ::KeySet{String, EnvDict}) = _hasenv(k)
 pop!(::EnvDict, k::AbstractString) = (v = ENV[k]; _unsetenv(k); v)
 pop!(::EnvDict, k::AbstractString, def) = haskey(ENV,k) ? pop!(ENV,k) : def

--- a/test/env.jl
+++ b/test/env.jl
@@ -52,6 +52,11 @@ end
     @test get!(ENV, key, "default") == "default"
     @test haskey(ENV, key)
     @test ENV[key] == "default"
+
+    key = randstring(25)
+    @test !haskey(ENV, key)
+    @test get!(ENV, key, 0) == 0
+    @test ENV[key] == "0"
 end
 @testset "#17956" begin
     @test length(ENV) > 1
@@ -168,7 +173,7 @@ end
 end
 
 # Restore the original environment
-for k in keys(ENV)
+for k in collect(keys(ENV))
     if !haskey(original_env, k)
         delete!(ENV, k)
     end


### PR DESCRIPTION
fixes #50472

I have half a mind to revert the change to AbstractDict `get!` that caused this, but it may very well be that `ENV` is a special case and the only dict that allows arbitrary values and converts them with something other than `convert`.