### PR TITLE
Model :consistent for compilerbarrier

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -2381,6 +2381,12 @@ function builtin_effects(𝕃::AbstractLattice, @nospecialize(f::Builtin), argin
         length(argtypes) == 2 || return EFFECTS_THROWS
         effect_free = get_binding_type_effect_free(argtypes[1], argtypes[2]) ? ALWAYS_TRUE : ALWAYS_FALSE
         return Effects(EFFECTS_TOTAL; effect_free)
+    elseif f === compilerbarrier
+        length(argtypes) == 2 || return Effects(EFFECTS_THROWS; consistent=ALWAYS_FALSE)
+        setting = argtypes[1]
+        return Effects(EFFECTS_TOTAL;
+            consistent = (isa(setting, Const) && setting.val === :conditional) ? ALWAYS_TRUE : ALWAYS_FALSE,
+            nothrow = compilerbarrier_nothrow(setting, nothing))
     else
         if contains_is(_CONSISTENT_BUILTINS, f)
             consistent = ALWAYS_TRUE

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -3277,11 +3277,9 @@ Base.donotdelete
 """
     Base.compilerbarrier(setting::Symbol, val)
 
-This function puts a barrier at a specified compilation phase.
-It is supposed to only influence the compilation behavior according to `setting`,
-and its runtime semantics is just to return the second argument `val` (except that
-this function will perform additional checks on `setting` in a case when `setting`
-isn't known precisely at compile-time.)
+This function acts a compiler barrier at a specified compilation phase.
+The dynamic semantics of this intrinsic are to return the `val` argument, unmodified.
+However, depending on the `setting`, the compiler is prevented from assuming this behavior.
 
 Currently either of the following `setting`s is allowed:
 - Barriers on abstract interpretation:
@@ -3294,9 +3292,9 @@ Currently either of the following `setting`s is allowed:
 - Any barriers on optimization aren't implemented yet
 
 !!! note
-    This function is supposed to be used _with `setting` known precisely at compile-time_.
-    Note that in a case when the `setting` isn't known precisely at compile-time, the compiler
-    currently will put the most strongest barrier(s) rather than emitting a compile-time warning.
+    This function is expected to be used _with `setting` known precisely at compile-time.
+    If the `setting` is not known precisely at compile-time, the compiler will emit the
+    strongest barrier(s). No compile-time warning is issued.
 
 # Examples
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -3292,7 +3292,7 @@ Currently either of the following `setting`s is allowed:
 - Any barriers on optimization aren't implemented yet
 
 !!! note
-    This function is expected to be used _with `setting` known precisely at compile-time.
+    This function is expected to be used with `setting` known precisely at compile-time.
     If the `setting` is not known precisely at compile-time, the compiler will emit the
     strongest barrier(s). No compile-time warning is issued.
 

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -1025,8 +1025,8 @@ end
 end |> Core.Compiler.is_nothrow
 
 # Effects for :compilerbarrier
-f1(b) = Base.compilerbarrier(:type, b)
-f2(b) = Base.compilerbarrier(:conditional, b)
+f1_compilerbarrier(b) = Base.compilerbarrier(:type, b)
+f2_compilerbarrier(b) = Base.compilerbarrier(:conditional, b)
 
-@test !Core.Compiler.is_consistent(Base.infer_effects(f1, (Bool,)))
-@test Core.Compiler.is_consistent(Base.infer_effects(f2, (Bool,)))
+@test !Core.Compiler.is_consistent(Base.infer_effects(f1_compilerbarrier, (Bool,)))
+@test Core.Compiler.is_consistent(Base.infer_effects(f2_compilerbarrier, (Bool,)))

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -1023,3 +1023,10 @@ end
     isinf(y) && return zero(y)
     irinterp_nothrow_override(true, y)
 end |> Core.Compiler.is_nothrow
+
+# Effects for :compilerbarrier
+f1(b) = Base.compilerbarrier(:type, b)
+f2(b) = Base.compilerbarrier(:conditional, b)
+
+@test !Core.Compiler.is_consistent(Base.infer_effects(f1, (Bool,)))
+@test Core.Compiler.is_consistent(Base.infer_effects(f2, (Bool,)))


### PR DESCRIPTION
Barriers at the `:const` and `:type` level are essentially treated as (typed and untyped respectively) loads from a heap location. As such, they need to taint consistency (as they currently do). However, `:conditional` only strips backwards information, but allows constants, so `:consistent`-cy should not be tainted. Also some tweaks to the docstring.