### PR TITLE
Limit type-printing in MethodError

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -103,8 +103,8 @@ scrub_repl_backtrace(stack::ExceptionStack) =
     ExceptionStack(Any[(;x.exception, backtrace = scrub_repl_backtrace(x.backtrace)) for x in stack])
 
 istrivialerror(stack::ExceptionStack) =
-    length(stack) == 1 && length(stack[1].backtrace) ≤ 1
-    # frame 1 = top level; assumes already went through scrub_repl_backtrace
+    length(stack) == 1 && length(stack[1].backtrace) ≤ 1 && !isa(stack[1].exception, MethodError)
+    # frame 1 = top level; assumes already went through scrub_repl_backtrace; MethodError see #50803
 
 function display_error(io::IO, stack::ExceptionStack)
     printstyled(io, "ERROR: "; bold=true, color=Base.error_color())

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -284,7 +284,7 @@ function showerror(io::IO, ex::MethodError)
         end
         print(iob, ")")
         str = String(take!(unwrapcontext(iob)[1]))
-        ioc = !haskey(ioc, :displaysize) ? IOContext(io, :displaysize => displaysize(io)) : io
+        ioc = !haskey(io, :displaysize) ? IOContext(io, :displaysize => displaysize(io)) : io
         str = type_limited_string_from_context(ioc, str)
         print(io, str)
     end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -284,8 +284,7 @@ function showerror(io::IO, ex::MethodError)
         end
         print(iob, ")")
         str = String(take!(unwrapcontext(iob)[1]))
-        ioc = !haskey(io, :displaysize) ? IOContext(io, :displaysize => displaysize(io)) : io
-        str = type_limited_string_from_context(ioc, str)
+        str = type_limited_string_from_context(io, str)
         print(io, str)
     end
     # catch the two common cases of element-wise addition and subtraction

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -268,20 +268,28 @@ function showerror(io::IO, ex::MethodError)
             f_is_function = true
         end
         print(io, "no method matching ")
-        show_signature_function(io, isa(f, Type) ? Type{f} : typeof(f))
-        print(io, "(")
+        iob = IOContext(IOBuffer(), io)     # for type abbreviation as in #49795; some, like `convert(T, x)`, should not abbreviate
+        show_signature_function(iob, isa(f, Type) ? Type{f} : typeof(f))
+        print(iob, "(")
         for (i, typ) in enumerate(arg_types_param)
-            print(io, "::", typ)
-            i == length(arg_types_param) || print(io, ", ")
+            print(iob, "::", typ)
+            i == length(arg_types_param) || print(iob, ", ")
         end
         if !isempty(kwargs)
-            print(io, "; ")
+            print(iob, "; ")
             for (i, (k, v)) in enumerate(kwargs)
-                print(io, k, "::", typeof(v))
-                i == length(kwargs)::Int || print(io, ", ")
+                print(iob, k, "::", typeof(v))
+                i == length(kwargs)::Int || print(iob, ", ")
             end
         end
-        print(io, ")")
+        print(iob, ")")
+        str = String(take!(unwrapcontext(iob)[1]))
+        ioc = IOContext(io)
+        if !haskey(ioc, :displaysize)
+            ioc = IOContext(ioc, :displaysize => displaysize(io))
+        end
+        str = type_limited_string_from_context(ioc, str)
+        print(io, str)
     end
     # catch the two common cases of element-wise addition and subtraction
     if (f === Base.:+ || f === Base.:-) && length(arg_types_param) == 2

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -284,10 +284,7 @@ function showerror(io::IO, ex::MethodError)
         end
         print(iob, ")")
         str = String(take!(unwrapcontext(iob)[1]))
-        ioc = IOContext(io)
-        if !haskey(ioc, :displaysize)
-            ioc = IOContext(ioc, :displaysize => displaysize(io))
-        end
+        ioc = !haskey(ioc, :displaysize) ? IOContext(io, :displaysize => displaysize(io)) : io
         str = type_limited_string_from_context(ioc, str)
         print(io, str)
     end

--- a/base/show.jl
+++ b/base/show.jl
@@ -2567,7 +2567,7 @@ end
 function type_limited_string_from_context(out::IO, str::String)
     typelimitflag = get(out, :stacktrace_types_limited, nothing)
     if typelimitflag isa RefValue{Bool}
-        sz = get(out, :displaysize, (typemax(Int), typemax(Int)))::Tuple{Int, Int}
+        sz = get(out, :displaysize, displaysize(out))::Tuple{Int, Int}
         str_lim = type_depth_limit(str, max(sz[2], 120))
         if sizeof(str_lim) < sizeof(str)
             typelimitflag[] = true

--- a/base/show.jl
+++ b/base/show.jl
@@ -2559,6 +2559,12 @@ function show_tuple_as_call(out::IO, name::Symbol, sig::Type;
     print_within_stacktrace(io, ")", bold=true)
     show_method_params(io, tv)
     str = String(take!(unwrapcontext(io)[1]))
+    str = type_limited_string_from_context(out, str)
+    print(out, str)
+    nothing
+end
+
+function type_limited_string_from_context(out::IO, str::String)
     typelimitflag = get(out, :stacktrace_types_limited, nothing)
     if typelimitflag isa RefValue{Bool}
         sz = get(out, :displaysize, (typemax(Int), typemax(Int)))::Tuple{Int, Int}
@@ -2568,8 +2574,7 @@ function show_tuple_as_call(out::IO, name::Symbol, sig::Type;
         end
         str = str_lim
     end
-    print(out, str)
-    nothing
+    return str
 end
 
 # limit nesting depth of `{ }` until string textwidth is less than `n`


### PR DESCRIPTION
Demo:

```julia
julia> a = view(reinterpret(reshape, UInt8, PermutedDimsArray(rand(5, 7), (2, 1))), 2:3, 2:4, 1:4); # a mildly-complex type

julia> function f50803 end
f50803 (generic function with 0 methods)

julia> f50803(a, a, a, a, a, a)
ERROR: MethodError: no method matching f50803(::SubArray{…}, ::SubArray{…}, ::SubArray{…}, ::SubArray{…}, ::SubArray{…}, ::SubArray{…})
Stacktrace:
 [1] top-level scope
   @ REPL[3]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

Fixes #50803