### PR TITLE
Fix big(1)^big(-1) 

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -628,11 +628,11 @@ isqrt(x::BigInt) = MPZ.sqrt(x)
 ^(x::BigInt, y::Culong) = MPZ.pow_ui(x, y)
 
 function bigint_pow(x::BigInt, y::Integer)
+    if x== 1; return x; end
+    if x==-1; return isodd(y) ? x : -x; end
     if y<0; throw(DomainError(y, "`y` cannot be negative.")); end
     @noinline throw1(y) =
         throw(OverflowError("exponent $y is too large and computation will overflow"))
-    if x== 1; return x; end
-    if x==-1; return isodd(y) ? x : -x; end
     if y>typemax(Culong)
        x==0 && return x
 

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -628,8 +628,8 @@ isqrt(x::BigInt) = MPZ.sqrt(x)
 ^(x::BigInt, y::Culong) = MPZ.pow_ui(x, y)
 
 function bigint_pow(x::BigInt, y::Integer)
-    if x== 1; return x; end
-    if x==-1; return isodd(y) ? x : -x; end
+    x == 1 && return x
+    x == -1 && return isodd(y) ? x : -x
     if y<0; throw(DomainError(y, "`y` cannot be negative.")); end
     @noinline throw1(y) =
         throw(OverflowError("exponent $y is too large and computation will overflow"))

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -445,31 +445,18 @@ end
 @testset "Exponentiation operator" begin
     @test big(5)^true == big(5)
     @test big(5)^false == one(BigInt)
-    # Test BigInt and Int8 exponentiation are consistent.
-    for i = typemin(Int8):typemax(Int8), j = typemin(Int8):typemax(Int8)
+    testvals = Int8[-128:-126; -3:3; 125:127]
+    @testset "BigInt and Int8 are consistent: $i^$j" for i in testvals, j in testvals
         int8_res = try
             i^j
         catch e
             e
         end
-        big_res = try
-            big(i)^big(j)
-        catch e
-            e
-        end
-        if int8_res isa Exception && big_res isa Exception
-            # Both have exception
-            if typeof(int8_res) != typeof(big_res)
-                throw(big_res)
-            end
-        elseif big_res isa Exception
-            @error "$i^$j failed on BigInt but not Int8"
-            throw(big_res)
-        elseif int8_res isa Exception
-            @error "$i^$j failed on Int8 but not BigInt"
-            throw(int8_res)
+        if int8_res isa Int8
+            @test (big(i)^big(j)) % Int8 === int8_res
         else
-            @test big_res%Int8 === int8_res
+            # Test both have exception of the same type
+            @test_throws typeof(int8_res) big(i)^big(j)
         end
     end
 end

--- a/test/gmp.jl
+++ b/test/gmp.jl
@@ -441,8 +441,38 @@ end
 @test isqrt(big(4)) == 2
 @test isqrt(big(5)) == 2
 
-@test big(5)^true == big(5)
-@test big(5)^false == one(BigInt)
+
+@testset "Exponentiation operator" begin
+    @test big(5)^true == big(5)
+    @test big(5)^false == one(BigInt)
+    # Test BigInt and Int8 exponentiation are consistent.
+    for i = typemin(Int8):typemax(Int8), j = typemin(Int8):typemax(Int8)
+        int8_res = try
+            i^j
+        catch e
+            e
+        end
+        big_res = try
+            big(i)^big(j)
+        catch e
+            e
+        end
+        if int8_res isa Exception && big_res isa Exception
+            # Both have exception
+            if typeof(int8_res) != typeof(big_res)
+                throw(big_res)
+            end
+        elseif big_res isa Exception
+            @error "$i^$j failed on BigInt but not Int8"
+            throw(big_res)
+        elseif int8_res isa Exception
+            @error "$i^$j failed on Int8 but not BigInt"
+            throw(int8_res)
+        else
+            @test big_res%Int8 === int8_res
+        end
+    end
+end
 
 @testset "math ops returning BigFloat" begin
     # operations that when applied to Int64 give Float64, should give BigFloat


### PR DESCRIPTION
This PR gives BigInt exponentiation the same edge-case behavior as other integer exponentiation.

The normal integer exponentiation checks if `x` is `1` or `-1` before erroring if the power is negative. 
https://github.com/JuliaLang/julia/blob/9f9e989f241fad1ae03c3920c20a93d8017a5b8f/base/intfuncs.jl#L283-L287

With this PR `big(1)^big(-1) == 1`,  `big(-1)^big(-1) == -1` and  `big(-1)^big(-2) == 1` 