### PR TITLE
Add default method for setmodifiers!

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -517,6 +517,8 @@ active_module((; mistate)::LineEditREPL) = mistate === nothing ? Main : mistate.
 active_module(::AbstractREPL) = Main
 active_module(d::REPLDisplay) = active_module(d.repl)
 
+setmodifiers!(c::CompletionProvider, m::LineEdit.Modifiers) = nothing
+
 setmodifiers!(c::REPLCompletionProvider, m::LineEdit.Modifiers) = c.modifiers = m
 
 """


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/50690
This does 
```julia
activate     add          build        compat       develop
free         gc           generate     help         instantiate
package      pin          precompile   redo         registry
remove       resolve      status       test         undo
```
for the pkg repl and prints nothing for the shell one.

I would love some assistance into how the REPL tests work however