### PR TITLE
Call all-underscore identifiers write-only

### DIFF
--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -111,18 +111,17 @@ variable name. For example, if `+ᵃ` is an operator, then `+ᵃx` must be writt
 it from `+ ᵃx` where `ᵃx` is the variable name.
 
 
-A particular class of variable names is one that contains only underscores. These identifiers can only be assigned values, which are immediately discarded, and cannot therefore be used to assign values to other variables (i.e., they cannot be used as [`rvalues`](https://en.wikipedia.org/wiki/Value_(computer_science)#Assignment:_l-values_and_r-values)) or use the last value
-assigned to them in any way.
+A particular class of variable names is one that contains only underscores. These identifiers are write-only. I.e. they can only be assigned values, which are immediately discarded, and their values cannot be used in any way.
 
 ```julia-repl
 julia> x, ___ = size([2 2; 1 1])
 (2, 2)
 
 julia> y = ___
-ERROR: syntax: all-underscore identifier used as rvalue
+ERROR: syntax: all-underscore identifiers are write-only and their values cannot be used in expressions
 
 julia> println(___)
-ERROR: syntax: all-underscore identifier used as rvalue
+ERROR: syntax: all-underscore identifiers are write-only and their values cannot be used in expressions
 ```
 
 The only explicitly disallowed names for variables are the names of the built-in [Keywords](@ref Keywords):

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -149,7 +149,7 @@
 (define (expand-toplevel-expr e file line)
   (cond ((or (atom? e) (toplevel-only-expr? e))
          (if (underscore-symbol? e)
-             (error "all-underscore identifier used as rvalue"))
+             (error "all-underscore identifiers are write-only and their values cannot be used in expressions"))
          e)
         (else
          (let ((last *in-expand*))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -4490,7 +4490,7 @@ f(x) = yt(x)
                                (and (pair? e) (or (eq? (car e) 'outerref)
                                                   (eq? (car e) 'globalref))
                                     (underscore-symbol? (cadr e)))))
-                (error (string "all-underscore identifier used as rvalue" (format-loc current-loc))))
+                (error (string "all-underscore identifiers are write-only and their values cannot be used in expressions" (format-loc current-loc))))
             (cond (tail  (emit-return e1))
                   (value e1)
                   ((symbol? e1) (emit e1) #f)  ;; keep symbols for undefined-var checking

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -698,7 +698,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_module_t *JL_NONNULL m, jl_value_t *e, int 
             char *n = jl_symbol_name((jl_sym_t*)e), *n0 = n;
             while (*n == '_') ++n;
             if (*n == 0 && n > n0)
-                jl_eval_errorf(m, "all-underscore identifier used as rvalue");
+                jl_eval_errorf(m, "all-underscore identifiers are write-only and their values cannot be used in expressions");
         }
         return jl_interpret_toplevel_expr_in(m, e, NULL, NULL);
     }


### PR DESCRIPTION
Followup to #45964, #46506, and https://discourse.julialang.org/t/class-of-variables/83892.

The error
```
julia> println(_)
ERROR: syntax: all-underscore identifier used as rvalue
```
is hard to interpret if you are not familiar with the term `rvalue`, which is not used in any other context in Julia, and as discussed previously the use here is not clearly matching the wikipedia page referred to in the documentation either.

This PR does away with the term `rvalue` by changing the error to
```
ERROR: syntax: all-underscore identifiers are write-only and their values cannot be used in expressions
```
and updates the documentation accordingly.