### PR TITLE
Add Base prefix to list_deletefirst!

### DIFF
--- a/stdlib/Sockets/src/Sockets.jl
+++ b/stdlib/Sockets/src/Sockets.jl
@@ -450,7 +450,7 @@ function send(sock::UDPSocket, ipaddr::IPAddr, port::Integer, msg)
     finally
         Base.sigatomic_end()
         iolock_begin()
-        ct.queue === nothing || list_deletefirst!(ct.queue, ct)
+        ct.queue === nothing || Base.list_deletefirst!(ct.queue, ct)
         if uv_req_data(uvw) != C_NULL
             # uvw is still alive,
             # so make sure we won't get spurious notifications later

--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -90,7 +90,7 @@ function getalladdrinfo(host::String)
     finally
         Base.sigatomic_end()
         iolock_begin()
-        ct.queue === nothing || list_deletefirst!(ct.queue, ct)
+        ct.queue === nothing || Base.list_deletefirst!(ct.queue, ct)
         if uv_req_data(req) != C_NULL
             # req is still alive,
             # so make sure we don't get spurious notifications later
@@ -205,7 +205,7 @@ function getnameinfo(address::Union{IPv4, IPv6})
     finally
         Base.sigatomic_end()
         iolock_begin()
-        ct.queue === nothing || list_deletefirst!(ct.queue, ct)
+        ct.queue === nothing || Base.list_deletefirst!(ct.queue, ct)
         if uv_req_data(req) != C_NULL
             # req is still alive,
             # so make sure we don't get spurious notifications later


### PR DESCRIPTION
I noticed this when debugging a bizarre issue, probably caused by some earlier undefined behaviour, and I haven't been able to come up with simple reproduction steps. It seems like `current_task().queue` is basically never set after `wait()`. Based on https://github.com/JuliaLang/julia/issues/32903 it seems like raising SIGINT at the right time might trigger this.

In any case, if you manage to trigger it, `list_deletefirst!` will fail because it is out of scope. I double-checked this using `@eval Sockets list_deletefirst!` with Julia 1.9.2 (and there's only been one change to `Sockets` since then).