### PR TITLE
Add documentation about failure cases of trig functions & return types

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -497,7 +497,7 @@ asinh(x::Number)
 
 # functions that return NaN on non-NaN argument for domain error
 """
-    sin(x::T) where T <: Number -> float(T)
+    sin(x::T) where {T <: Number} -> float(T)
 
 Compute sine of `x`, where `x` is in radians.
 
@@ -530,7 +530,7 @@ julia> round(exp(im*pi/6), digits=3)
 sin(x::Number)
 
 """
-    cos(x::T) where T <: Number -> float(T)
+    cos(x::T) where {T <: Number} -> float(T)
 
 Compute cosine of `x`, where `x` is in radians.
 
@@ -541,7 +541,7 @@ See also [`cosd`](@ref), [`cospi`](@ref), [`sincos`](@ref), [`cis`](@ref).
 cos(x::Number)
 
 """
-    tan(x::T) where T <: Number -> float(T)
+    tan(x::T) where {T <: Number} -> float(T)
 
 Compute tangent of `x`, where `x` is in radians.
 
@@ -552,7 +552,7 @@ See also [`tanh`](@ref).
 tan(x::Number)
 
 """
-    asin(x::T) where T <: Number -> float(T)
+    asin(x::T) where {T <: Number} -> float(T)
 
 Compute the inverse sine of `x`, where the output is in radians.
 
@@ -572,7 +572,7 @@ julia> asind.((0, 1/2, 1))
 asin(x::Number)
 
 """
-    acos(x::T) where T <: Number -> float(T)
+    acos(x::T) where {T <: Number} -> float(T)
 
 Compute the inverse cosine of `x`, where the output is in radians
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -604,7 +604,7 @@ Use [`Complex`](@ref) arguments to obtain [`Complex`](@ref) results.
 
 !!! note "Branch cut"
     `log` has a branch cut along the negative real axis; `-0.0im` is taken
-    to be below the axis. 
+    to be below the axis.
 
 See also [`ℯ`](@ref), [`log1p`](@ref), [`log2`](@ref), [`log10`](@ref).
 
@@ -732,7 +732,7 @@ The prefix operator `√` is equivalent to `sqrt`.
 
 !!! note "Branch cut"
     `sqrt` has a branch cut along the negative real axis; `-0.0im` is taken
-    to be below the axis. 
+    to be below the axis.
 
 See also: [`hypot`](@ref).
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -359,7 +359,7 @@ log(b::T, x::T) where {T<:Number} = log(x)/log(b)
 """
     log(b,x)
 
-Compute the base `b` logarithm of `x`. Throws [`DomainError`](@ref) for negative
+Compute the base `b` logarithm of `x`. Throw a [`DomainError`](@ref) for negative
 [`Real`](@ref) arguments.
 
 # Examples
@@ -501,7 +501,7 @@ asinh(x::Number)
 
 Compute sine of `x`, where `x` is in radians.
 
-Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
+Throw a [`DomainError`](@ref) if `isinf(x)`, return a `T(NaN)` if `isnan(x)`.
 
 See also [`sind`](@ref), [`sinpi`](@ref), [`sincos`](@ref), [`cis`](@ref), [`asin`](@ref).
 
@@ -534,7 +534,7 @@ sin(x::Number)
 
 Compute cosine of `x`, where `x` is in radians.
 
-Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
+Throw a [`DomainError`](@ref) if `isinf(x)`, return a `T(NaN)` if `isnan(x)`.
 
 See also [`cosd`](@ref), [`cospi`](@ref), [`sincos`](@ref), [`cis`](@ref).
 """
@@ -545,7 +545,7 @@ cos(x::Number)
 
 Compute tangent of `x`, where `x` is in radians.
 
-Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
+Throw a [`DomainError`](@ref) if `isinf(x)`, return a `T(NaN)` if `isnan(x)`.
 
 See also [`tanh`](@ref).
 """
@@ -556,7 +556,7 @@ tan(x::Number)
 
 Compute the inverse sine of `x`, where the output is in radians.
 
-Returns a `T(NaN)` if `isnan(x)`.
+Return a `T(NaN)` if `isnan(x)`.
 
 See also [`asind`](@ref) for output in degrees.
 
@@ -574,9 +574,9 @@ asin(x::Number)
 """
     acos(x::T) where T <: Number -> float(T)
 
-Returns a `T(NaN)` if `isnan(x)`.
-
 Compute the inverse cosine of `x`, where the output is in radians
+
+Return a `T(NaN)` if `isnan(x)`.
 """
 acos(x::Number)
 
@@ -599,9 +599,12 @@ atanh(x::Number)
 
 Compute the natural logarithm of `x`.
 
-Throws [`DomainError`](@ref) for negative [`Real`](@ref) arguments.
-Use complex arguments to obtain complex results.
-Has a branch cut along the negative real axis, for which `-0.0im` is taken to be below the axis.
+Throw a [`DomainError`](@ref) for negative [`Real`](@ref) arguments.
+Use [`Complex`](@ref) arguments to obtain [`Complex`](@ref) results.
+
+!!! note "Branch cut"
+    `log` has a branch cut along the negative real axis; `-0.0im` is taken
+    to be below the axis. 
 
 See also [`ℯ`](@ref), [`log1p`](@ref), [`log2`](@ref), [`log10`](@ref).
 
@@ -635,7 +638,7 @@ log(x::Number)
 """
     log2(x)
 
-Compute the logarithm of `x` to base 2. Throws [`DomainError`](@ref) for negative
+Compute the logarithm of `x` to base 2. Throw a [`DomainError`](@ref) for negative
 [`Real`](@ref) arguments.
 
 See also: [`exp2`](@ref), [`ldexp`](@ref), [`ispow2`](@ref).
@@ -668,7 +671,7 @@ log2(x)
     log10(x)
 
 Compute the logarithm of `x` to base 10.
-Throws [`DomainError`](@ref) for negative [`Real`](@ref) arguments.
+Throw a [`DomainError`](@ref) for negative [`Real`](@ref) arguments.
 
 # Examples
 ```jldoctest; filter = r"Stacktrace:(\\n \\[[0-9]+\\].*)*"
@@ -691,7 +694,7 @@ log10(x)
 """
     log1p(x)
 
-Accurate natural logarithm of `1+x`. Throws [`DomainError`](@ref) for [`Real`](@ref)
+Accurate natural logarithm of `1+x`. Throw a [`DomainError`](@ref) for [`Real`](@ref)
 arguments less than -1.
 
 # Examples
@@ -722,11 +725,14 @@ end
 
 Return ``\\sqrt{x}``.
 
-Throws [`DomainError`](@ref) for negative [`Real`](@ref) arguments.
-Use complex negative arguments instead. Note that `sqrt` has a branch cut
-along the negative real axis.
+Throw a [`DomainError`](@ref) for negative [`Real`](@ref) arguments.
+Use [`Complex`](@ref) negative arguments instead to obtain a [`Complex`](@ref) result.
 
 The prefix operator `√` is equivalent to `sqrt`.
+
+!!! note "Branch cut"
+    `sqrt` has a branch cut along the negative real axis; `-0.0im` is taken
+    to be below the axis. 
 
 See also: [`hypot`](@ref).
 
@@ -1021,7 +1027,8 @@ ldexp(x::Float16, q::Integer) = Float16(ldexp(Float32(x), q))
 """
     exponent(x::Real) -> Int
 
-Returns the largest integer `y` such that `2^y ≤ abs(x)`.
+Return the largest integer `y` such that `2^y ≤ abs(x)`.
+For a normalized floating-point number `x`, this corresponds to the exponent of `x`.
 
 Throws a `DomainError` when `x` is zero, infinite, or [`NaN`](@ref).
 For any other non-subnormal floating-point number `x`, this corresponds to the exponent bits of `x`.
@@ -1346,8 +1353,8 @@ end
 
 function add22condh(xh::Float64, xl::Float64, yh::Float64, yl::Float64)
     # This algorithm, due to Dekker, computes the sum of two
-    # double-double numbers and returns the high double. References:
-    # [1] https://www.digizeitschriften.de/en/dms/img/?PID=GDZPPN001170007
+    # double-double numbers and return the high double. References:
+    # [1] http://www.digizeitschriften.de/en/dms/img/?PID=GDZPPN001170007
     # [2] https://doi.org/10.1007/BF01397083
     r = xh+yh
     s = (abs(xh) > abs(yh)) ? (xh-r+yh+yl+xl) : (yh-r+xh+xl+yl)

--- a/base/math.jl
+++ b/base/math.jl
@@ -408,6 +408,8 @@ const libm = Base.libm_name
     sinh(x)
 
 Compute hyperbolic sine of `x`.
+
+See also [`sin`](@ref).
 """
 sinh(x::Number)
 
@@ -415,6 +417,8 @@ sinh(x::Number)
     cosh(x)
 
 Compute hyperbolic cosine of `x`.
+
+See also [`cos`](@ref).
 """
 cosh(x::Number)
 
@@ -493,9 +497,11 @@ asinh(x::Number)
 
 # functions that return NaN on non-NaN argument for domain error
 """
-    sin(x)
+    sin(x::T) where T <: Number -> float(T)
 
 Compute sine of `x`, where `x` is in radians.
+
+Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
 
 See also [`sind`](@ref), [`sinpi`](@ref), [`sincos`](@ref), [`cis`](@ref), [`asin`](@ref).
 
@@ -524,25 +530,33 @@ julia> round(exp(im*pi/6), digits=3)
 sin(x::Number)
 
 """
-    cos(x)
+    cos(x::T) where T <: Number -> float(T)
 
 Compute cosine of `x`, where `x` is in radians.
+
+Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
 
 See also [`cosd`](@ref), [`cospi`](@ref), [`sincos`](@ref), [`cis`](@ref).
 """
 cos(x::Number)
 
 """
-    tan(x)
+    tan(x::T) where T <: Number -> float(T)
 
 Compute tangent of `x`, where `x` is in radians.
+
+Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
+
+See also [`tanh`](@ref).
 """
 tan(x::Number)
 
 """
-    asin(x)
+    asin(x::T) where T <: Number -> float(T)
 
 Compute the inverse sine of `x`, where the output is in radians.
+
+Returns a `T(NaN)` if `isnan(x)`.
 
 See also [`asind`](@ref) for output in degrees.
 
@@ -558,7 +572,9 @@ julia> asind.((0, 1/2, 1))
 asin(x::Number)
 
 """
-    acos(x)
+    acos(x::T) where T <: Number -> float(T)
+
+Returns a `T(NaN)` if `isnan(x)`.
 
 Compute the inverse cosine of `x`, where the output is in radians
 """

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1075,7 +1075,7 @@ isinf_real(x::Complex) = isinf(real(x)) && isfinite(imag(x))
 isinf_real(x::Number) = false
 
 """
-    sinc(x::T) where T <: Number -> float(T)
+    sinc(x::T) where {T <: Number} -> float(T)
 
 Compute normalized sinc function ``\\operatorname{sinc}(x) = \\sin(\\pi x) / (\\pi x)`` if ``x \\neq 0``, and ``1`` if ``x = 0``.
 
@@ -1094,7 +1094,7 @@ _sinc(x::Float16) = Float16(_sinc(Float32(x)))
 _sinc(x::ComplexF16) = ComplexF16(_sinc(ComplexF32(x)))
 
 """
-    cosc(x::T) where T <: Number -> float(T)
+    cosc(x::T) where {T <: Number} -> float(T)
 
 Compute ``\\cos(\\pi x) / x - \\sin(\\pi x) / (\\pi x^2)`` if ``x \\neq 0``, and ``0`` if
 ``x = 0``. This is the derivative of `sinc(x)`.
@@ -1145,21 +1145,21 @@ for (finv, f, finvh, fh, finvd, fd, fn) in ((:sec, :cos, :sech, :cosh, :secd, :c
     dname = string(finvd)
     @eval begin
         @doc """
-            $($name)(x::T) where T <: Number -> float(T)
+            $($name)(x::T) where {T <: Number} -> float(T)
 
         Compute the $($fn) of `x`, where `x` is in radians.
 
         Throw a [`DomainError`](@ref) if `isinf(x)`, return a `T(NaN)` if `isnan(x)`.
         """ ($finv)(z::Number) = inv(($f)(z))
         @doc """
-            $($hname)(x::T) where T <: Number -> float(T)
+            $($hname)(x::T) where {T <: Number} -> float(T)
 
         Compute the hyperbolic $($fn) of `x`.
 
         Return a `T(NaN)` if `isnan(x)`.
         """ ($finvh)(z::Number) = inv(($fh)(z))
         @doc """
-            $($dname)(x::T) where T <: Number -> float(T)
+            $($dname)(x::T) where {T <: Number} -> float(T)
 
         Compute the $($fn) of `x`, where `x` is in degrees.
 
@@ -1175,12 +1175,12 @@ for (tfa, tfainv, hfa, hfainv, fn) in ((:asec, :acos, :asech, :acosh, "secant"),
     hname = string(hfa)
     @eval begin
         @doc """
-            $($tname)(x::T) where T <: Number -> float(T)
+            $($tname)(x::T) where {T <: Number} -> float(T)
 
         Compute the inverse $($fn) of `x`, where the output is in radians.
         """ ($tfa)(y::Number) = ($tfainv)(inv(y))
         @doc """
-            $($hname)(x::T) where T <: Number -> float(T)
+            $($hname)(x::T) where {T <: Number} -> float(T)
 
         Compute the inverse hyperbolic $($fn) of `x`.
         """ ($hfa)(y::Number) = ($hfainv)(inv(y))

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -165,10 +165,12 @@ end
 @noinline sincos_domain_error(x) = throw(DomainError(x, "sincos(x) is only defined for finite x."))
 
 """
-    sincos(x)
+    sincos(x::T) where T -> float(T)
 
 Simultaneously compute the sine and cosine of `x`, where `x` is in radians, returning
 a tuple `(sine, cosine)`.
+
+Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `(T(NaN), T(NaN))` if `isnan(x)`.
 
 See also [`cis`](@ref), [`sincospi`](@ref), [`sincosd`](@ref).
 """
@@ -783,9 +785,11 @@ end
 end
 
 """
-    sinpi(x)
+    sinpi(x::T) where T -> float(T)
 
 Compute ``\\sin(\\pi x)`` more accurately than `sin(pi*x)`, especially for large `x`.
+
+Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
 
 See also [`sind`](@ref), [`cospi`](@ref), [`sincospi`](@ref).
 """
@@ -793,7 +797,7 @@ function sinpi(_x::T) where T<:IEEEFloat
     x = abs(_x)
     if !isfinite(x)
         isnan(x) && return x
-        throw(DomainError(x, "`x` cannot be infinite."))
+        throw(DomainError(x, "`sinpi(x)` is only defined for finite `x`."))
     end
     # For large x, answers are all 1 or zero.
     x >= maxintfloat(T) && return copysign(zero(T), _x)
@@ -814,15 +818,19 @@ function sinpi(_x::T) where T<:IEEEFloat
     return ifelse(signbit(_x), -res, res)
 end
 """
-    cospi(x)
+    cospi(x::T) where T -> float(T)
 
 Compute ``\\cos(\\pi x)`` more accurately than `cos(pi*x)`, especially for large `x`.
+
+Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
+
+See also: [`cispi`](@ref), [`sincosd`](@ref), [`cospi`](@ref).
 """
 function cospi(x::T) where T<:IEEEFloat
     x = abs(x)
     if !isfinite(x)
         isnan(x) && return x
-        throw(DomainError(x, "`x` cannot be infinite."))
+        throw(DomainError(x, "`cospi(x)` is only defined for finite `x`."))
     end
     # For large x, answers are all 1 or zero.
     x >= maxintfloat(T) && return one(T)
@@ -842,10 +850,12 @@ function cospi(x::T) where T<:IEEEFloat
     end
 end
 """
-    sincospi(x)
+    sincospi(x::T) where T -> float(T)
 
 Simultaneously compute [`sinpi(x)`](@ref) and [`cospi(x)`](@ref) (the sine and cosine of `π*x`,
 where `x` is in radians), returning a tuple `(sine, cosine)`.
+
+Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `(T(NaN), T(NaN))` tuple if `isnan(x)`.
 
 !!! compat "Julia 1.6"
     This function requires Julia 1.6 or later.
@@ -856,7 +866,7 @@ function sincospi(_x::T) where T<:IEEEFloat
     x = abs(_x)
     if !isfinite(x)
         isnan(x) && return x, x
-        throw(DomainError(x, "`x` cannot be infinite."))
+        throw(DomainError(x, "`sincospi(x)` is only defined for finite `x`."))
     end
     # For large x, answers are all 1 or zero.
     x >= maxintfloat(T) && return (copysign(zero(T), _x), one(T))
@@ -880,9 +890,11 @@ function sincospi(_x::T) where T<:IEEEFloat
 end
 
 """
-    tanpi(x)
+    tanpi(x::T) where T -> float(T)
 
 Compute ``\\tan(\\pi x)`` more accurately than `tan(pi*x)`, especially for large `x`.
+
+Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
 
 !!! compat "Julia 1.10"
     This function requires at least Julia 1.10.
@@ -895,7 +907,7 @@ function tanpi(_x::T) where T<:IEEEFloat
     x = abs(_x)
     if !isfinite(x)
         isnan(x) && return x
-        throw(DomainError(x, "`x` cannot be infinite."))
+        throw(DomainError(x, "`tanpi(x)` is only defined for finite `x`."))
     end
     # For large x, answers are all zero.
     # All integer values for floats larger than maxintfloat are even.
@@ -1063,9 +1075,11 @@ isinf_real(x::Complex) = isinf(real(x)) && isfinite(imag(x))
 isinf_real(x::Number) = false
 
 """
-    sinc(x)
+    sinc(x::T) where T <: Number -> float(T)
 
 Compute normalized sinc function ``\\operatorname{sinc}(x) = \\sin(\\pi x) / (\\pi x)`` if ``x \\neq 0``, and ``1`` if ``x = 0``.
+
+Return a `T(NaN)` if `isnan(x)`.
 
 See also [`cosc`](@ref), its derivative.
 """
@@ -1080,10 +1094,12 @@ _sinc(x::Float16) = Float16(_sinc(Float32(x)))
 _sinc(x::ComplexF16) = ComplexF16(_sinc(ComplexF32(x)))
 
 """
-    cosc(x)
+    cosc(x::T) where T <: Number -> float(T)
 
 Compute ``\\cos(\\pi x) / x - \\sin(\\pi x) / (\\pi x^2)`` if ``x \\neq 0``, and ``0`` if
 ``x = 0``. This is the derivative of `sinc(x)`.
+
+Return a `T(NaN)` if `isnan(x)`.
 
 See also [`sinc`](@ref).
 """
@@ -1129,19 +1145,25 @@ for (finv, f, finvh, fh, finvd, fd, fn) in ((:sec, :cos, :sech, :cosh, :secd, :c
     dname = string(finvd)
     @eval begin
         @doc """
-            $($name)(x)
+            $($name)(x::T) where T <: Number -> float(T)
 
         Compute the $($fn) of `x`, where `x` is in radians.
+
+        Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
         """ ($finv)(z::Number) = inv(($f)(z))
         @doc """
-            $($hname)(x)
+            $($hname)(x::T) where T <: Number -> float(T)
 
         Compute the hyperbolic $($fn) of `x`.
+
+        Returns a `T(NaN)` if `isnan(x)`.
         """ ($finvh)(z::Number) = inv(($fh)(z))
         @doc """
-            $($dname)(x)
+            $($dname)(x::T) where T <: Number -> float(T)
 
         Compute the $($fn) of `x`, where `x` is in degrees.
+
+        Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
         """ ($finvd)(z::Number) = inv(($fd)(z))
     end
 end
@@ -1153,11 +1175,15 @@ for (tfa, tfainv, hfa, hfainv, fn) in ((:asec, :acos, :asech, :acosh, "secant"),
     hname = string(hfa)
     @eval begin
         @doc """
-            $($tname)(x)
-        Compute the inverse $($fn) of `x`, where the output is in radians. """ ($tfa)(y::Number) = ($tfainv)(inv(y))
+            $($tname)(x::T) where T <: Number -> float(T)
+
+        Compute the inverse $($fn) of `x`, where the output is in radians.
+        """ ($tfa)(y::Number) = ($tfainv)(inv(y))
         @doc """
-            $($hname)(x)
-        Compute the inverse hyperbolic $($fn) of `x`. """ ($hfa)(y::Number) = ($hfainv)(inv(y))
+            $($hname)(x::T) where T <: Number -> float(T)
+
+        Compute the inverse hyperbolic $($fn) of `x`.
+        """ ($hfa)(y::Number) = ($hfainv)(inv(y))
     end
 end
 
@@ -1182,7 +1208,7 @@ deg2rad_ext(x::Real) = deg2rad(x) # Fallback
 
 function sind(x::Real)
     if isinf(x)
-        return throw(DomainError(x, "`x` cannot be infinite."))
+        return throw(DomainError(x, "`sind(x)` is only defined for finite `x`."))
     elseif isnan(x)
         return x
     end
@@ -1213,7 +1239,7 @@ end
 
 function cosd(x::Real)
     if isinf(x)
-        return throw(DomainError(x, "`x` cannot be infinite."))
+        return throw(DomainError(x, "`cosd(x)` is only defined for finite `x`."))
     elseif isnan(x)
         return x
     end
@@ -1240,9 +1266,12 @@ end
 tand(x::Real) = sind(x) / cosd(x)
 
 """
-    sincosd(x)
+    sincosd(x::T) where T -> float(T)
 
 Simultaneously compute the sine and cosine of `x`, where `x` is in degrees.
+
+Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `(T(NaN), T(NaN))` tuple if `isnan(x)`.
+Propagates `Missing`.
 
 !!! compat "Julia 1.3"
     This function requires at least Julia 1.3.
@@ -1258,10 +1287,12 @@ for (fd, f, fn) in ((:sind, :sin, "sine"), (:cosd, :cos, "cosine"), (:tand, :tan
         name = string(fd)
         @eval begin
             @doc """
-                $($name)(x)
+                $($name)(x::T) where T -> float(T)
 
             Compute $($fn) of `x`, where `x` is in $($un).
             If `x` is a matrix, `x` needs to be a square matrix.
+
+            Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
 
             !!! compat "Julia 1.7"
                 Matrix arguments require Julia 1.7 or later.
@@ -1290,10 +1321,14 @@ for (fd, f, fn) in ((:asind, :asin, "sine"), (:acosd, :acos, "cosine"),
 end
 
 """
-    atand(y)
-    atand(y,x)
+    atand(y::T) where T -> float(T)
+    atand(y::T, x::S) where {T,S} -> promote_type(T,S)
+    atand(y::AbstractMatrix{T}) where T -> AbstractMatrix{Complex{float(T)}}
 
 Compute the inverse tangent of `y` or `y/x`, respectively, where the output is in degrees.
+
+Returns a `NaN` if `isnan(y)` or `isnan(x)`. The returned `NaN` is either a `T` in the single
+argument version, or a `promote_type(T,S)` in the two argument version.
 
 !!! compat "Julia 1.7"
     The one-argument method supports square matrix arguments as of Julia 1.7.

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -170,7 +170,7 @@ end
 Simultaneously compute the sine and cosine of `x`, where `x` is in radians, returning
 a tuple `(sine, cosine)`.
 
-Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `(T(NaN), T(NaN))` if `isnan(x)`.
+Throw a [`DomainError`](@ref) if `isinf(x)`, return a `(T(NaN), T(NaN))` if `isnan(x)`.
 
 See also [`cis`](@ref), [`sincospi`](@ref), [`sincosd`](@ref).
 """
@@ -789,7 +789,7 @@ end
 
 Compute ``\\sin(\\pi x)`` more accurately than `sin(pi*x)`, especially for large `x`.
 
-Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
+Throw a [`DomainError`](@ref) if `isinf(x)`, return a `T(NaN)` if `isnan(x)`.
 
 See also [`sind`](@ref), [`cospi`](@ref), [`sincospi`](@ref).
 """
@@ -822,7 +822,7 @@ end
 
 Compute ``\\cos(\\pi x)`` more accurately than `cos(pi*x)`, especially for large `x`.
 
-Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
+Throw a [`DomainError`](@ref) if `isinf(x)`, return a `T(NaN)` if `isnan(x)`.
 
 See also: [`cispi`](@ref), [`sincosd`](@ref), [`cospi`](@ref).
 """
@@ -855,7 +855,7 @@ end
 Simultaneously compute [`sinpi(x)`](@ref) and [`cospi(x)`](@ref) (the sine and cosine of `π*x`,
 where `x` is in radians), returning a tuple `(sine, cosine)`.
 
-Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `(T(NaN), T(NaN))` tuple if `isnan(x)`.
+Throw a [`DomainError`](@ref) if `isinf(x)`, return a `(T(NaN), T(NaN))` tuple if `isnan(x)`.
 
 !!! compat "Julia 1.6"
     This function requires Julia 1.6 or later.
@@ -894,7 +894,7 @@ end
 
 Compute ``\\tan(\\pi x)`` more accurately than `tan(pi*x)`, especially for large `x`.
 
-Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
+Throw a [`DomainError`](@ref) if `isinf(x)`, return a `T(NaN)` if `isnan(x)`.
 
 !!! compat "Julia 1.10"
     This function requires at least Julia 1.10.
@@ -1149,21 +1149,21 @@ for (finv, f, finvh, fh, finvd, fd, fn) in ((:sec, :cos, :sech, :cosh, :secd, :c
 
         Compute the $($fn) of `x`, where `x` is in radians.
 
-        Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
+        Throw a [`DomainError`](@ref) if `isinf(x)`, return a `T(NaN)` if `isnan(x)`.
         """ ($finv)(z::Number) = inv(($f)(z))
         @doc """
             $($hname)(x::T) where T <: Number -> float(T)
 
         Compute the hyperbolic $($fn) of `x`.
 
-        Returns a `T(NaN)` if `isnan(x)`.
+        Return a `T(NaN)` if `isnan(x)`.
         """ ($finvh)(z::Number) = inv(($fh)(z))
         @doc """
             $($dname)(x::T) where T <: Number -> float(T)
 
         Compute the $($fn) of `x`, where `x` is in degrees.
 
-        Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
+        Throw a [`DomainError`](@ref) if `isinf(x)`, return a `T(NaN)` if `isnan(x)`.
         """ ($finvd)(z::Number) = inv(($fd)(z))
     end
 end
@@ -1270,7 +1270,7 @@ tand(x::Real) = sind(x) / cosd(x)
 
 Simultaneously compute the sine and cosine of `x`, where `x` is in degrees.
 
-Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `(T(NaN), T(NaN))` tuple if `isnan(x)`.
+Throw a [`DomainError`](@ref) if `isinf(x)`, return a `(T(NaN), T(NaN))` tuple if `isnan(x)`.
 Propagates `Missing`.
 
 !!! compat "Julia 1.3"
@@ -1292,7 +1292,7 @@ for (fd, f, fn) in ((:sind, :sin, "sine"), (:cosd, :cos, "cosine"), (:tand, :tan
             Compute $($fn) of `x`, where `x` is in $($un).
             If `x` is a matrix, `x` needs to be a square matrix.
 
-            Throws a [`DomainError`](@ref) if `isinf(x)`, returns a `T(NaN)` if `isnan(x)`.
+            Throw a [`DomainError`](@ref) if `isinf(x)`, return a `T(NaN)` if `isnan(x)`.
 
             !!! compat "Julia 1.7"
                 Matrix arguments require Julia 1.7 or later.
@@ -1327,7 +1327,7 @@ end
 
 Compute the inverse tangent of `y` or `y/x`, respectively, where the output is in degrees.
 
-Returns a `NaN` if `isnan(y)` or `isnan(x)`. The returned `NaN` is either a `T` in the single
+Return a `NaN` if `isnan(y)` or `isnan(x)`. The returned `NaN` is either a `T` in the single
 argument version, or a `promote_type(T,S)` in the two argument version.
 
 !!! compat "Julia 1.7"

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1271,7 +1271,6 @@ tand(x::Real) = sind(x) / cosd(x)
 Simultaneously compute the sine and cosine of `x`, where `x` is in degrees.
 
 Throw a [`DomainError`](@ref) if `isinf(x)`, return a `(T(NaN), T(NaN))` tuple if `isnan(x)`.
-Propagates `Missing`.
 
 !!! compat "Julia 1.3"
     This function requires at least Julia 1.3.


### PR DESCRIPTION
This documents the failure cases of various trigonometric functions provided in Base, but is not exhaustive. In particular, there are still undocumented failure cases of the versions of these functions taking matrices, but this can be added at a later date. The failure cases where found with PropCheck.jl, checking if the property `x -> f(x) isa T` for the functions `f` in question and the types `(Int8, Int16, Int32, Int64, Float16, Float32, Float64)` holds (i.e., doesn't error and returns `true`). I can give a script reproducing the failures if requested.

I'd expect CI to be happy, unless someone somewhere is checking for the exact error message when a `DomainError` is thrown - some of the functions in here had a really bare bones error message, which I've also aligned with the formulation we use in other places.

I'm not 100% sure who best to review this, but since I know @oscardssmith and @stevengj have done plenty of numeric work on these functions in the past, have a ping :)