### PR TITLE
Add `Base.get_extension` to docs/API

### DIFF
--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -465,6 +465,7 @@ Base.locate_package
 Base.require
 Base.compilecache
 Base.isprecompiled
+Base.get_extension
 ```
 
 ## Internals


### PR DESCRIPTION
I am interested in whether `Base.get_extension` can be cemented as part of the API of Julia. The documentation of `Pkg.jl` is instructing developers to rely on the existence of this function, and there doesn't seem to be any alternative which is a part of the API that developers can use instead on to guarantee forward compatibility for the same behavior.

`Base.get_extension` is [referred to explicitly](https://pkgdocs.julialang.org/v1.9/creating-packages/#Backwards-compatibility) in the `Pkg.jl` docs to conditionally use package extensions vs `Requires.jl`.

The `Pkg.jl` docs suggest
```julia
if !isdefined(Base, :get_extension)
  include("../ext/PlottingContourExt.jl")
end
```
to transition from "normal dependency to extension," which will break and automatically load the extension in future versions should `Base.get_extension` go away.

`Base.get_extension` is the only way (that I know of) to directly access the module associated with a package extension, which can be a useful utility as well.