### PR TITLE
compiler: Rename :inst -> :stmt

### DIFF
--- a/base/compiler/ssair/EscapeAnalysis/EscapeAnalysis.jl
+++ b/base/compiler/ssair/EscapeAnalysis/EscapeAnalysis.jl
@@ -671,7 +671,7 @@ function analyze_escapes(ir::IRCode, nargs::Int, call_resolved::Bool, get_escape
         local anyupdate = false
 
         for pc in nstmts:-1:1
-            stmt = getinst(ir, pc)[:inst]
+            stmt = getinst(ir, pc)[:stmt]
 
             # collect escape information
             if isa(stmt, Expr)
@@ -784,7 +784,7 @@ function compute_frameinfo(ir::IRCode, call_resolved::Bool)
     end
     for idx in 1:nstmts+nnewnodes
         inst = getinst(ir, idx)
-        stmt = inst[:inst]
+        stmt = inst[:stmt]
         if !call_resolved
             # TODO don't call `check_effect_free!` in the inlinear
             check_effect_free!(ir, idx, stmt, inst[:type], 𝕃ₒ)

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -186,24 +186,24 @@ const AnySSAValue = Union{SSAValue, OldSSAValue, NewSSAValue}
 
 # SSA-indexed nodes
 struct InstructionStream
-    inst::Vector{Any}
+    stmt::Vector{Any}
     type::Vector{Any}
     info::Vector{CallInfo}
     line::Vector{Int32}
     flag::Vector{UInt8}
 end
 function InstructionStream(len::Int)
-    insts = Vector{Any}(undef, len)
+    stmts = Vector{Any}(undef, len)
     types = Vector{Any}(undef, len)
     info = Vector{CallInfo}(undef, len)
     fill!(info, NoCallInfo())
     lines = fill(Int32(0), len)
     flags = fill(IR_FLAG_NULL, len)
-    return InstructionStream(insts, types, info, lines, flags)
+    return InstructionStream(stmts, types, info, lines, flags)
 end
 InstructionStream() = InstructionStream(0)
-length(is::InstructionStream) = length(is.inst)
-isempty(is::InstructionStream) = isempty(is.inst)
+length(is::InstructionStream) = length(is.stmt)
+isempty(is::InstructionStream) = isempty(is.stmt)
 function add_new_idx!(is::InstructionStream)
     ninst = length(is) + 1
     resize!(is, ninst)
@@ -211,7 +211,7 @@ function add_new_idx!(is::InstructionStream)
 end
 function copy(is::InstructionStream)
     return InstructionStream(
-        copy_exprargs(is.inst),
+        copy_exprargs(is.stmt),
         copy(is.type),
         copy(is.info),
         copy(is.line),
@@ -219,7 +219,7 @@ function copy(is::InstructionStream)
 end
 function resize!(stmts::InstructionStream, len)
     old_length = length(stmts)
-    resize!(stmts.inst, len)
+    resize!(stmts.stmt, len)
     resize!(stmts.type, len)
     resize!(stmts.info, len)
     resize!(stmts.line, len)
@@ -239,17 +239,19 @@ end
 Instruction(is::InstructionStream) = Instruction(is, add_new_idx!(is))
 
 @inline function getindex(node::Instruction, fld::Symbol)
+    (fld === :inst) && (fld = :stmt) # deprecated
     isdefined(node, fld) && return getfield(node, fld)
     return getfield(getfield(node, :data), fld)[getfield(node, :idx)]
 end
 @inline function setindex!(node::Instruction, @nospecialize(val), fld::Symbol)
+    (fld === :inst) && (fld = :stmt) # deprecated
     getfield(getfield(node, :data), fld)[getfield(node, :idx)] = val
     return node
 end
 
 @inline getindex(is::InstructionStream, idx::Int) = Instruction(is, idx)
 function setindex!(is::InstructionStream, newval::Instruction, idx::Int)
-    is.inst[idx] = newval[:inst]
+    is.stmt[idx] = newval[:stmt]
     is.type[idx] = newval[:type]
     is.info[idx] = newval[:info]
     is.line[idx] = newval[:line]
@@ -257,7 +259,7 @@ function setindex!(is::InstructionStream, newval::Instruction, idx::Int)
     return is
 end
 function setindex!(is::InstructionStream, newval::Union{AnySSAValue, Nothing}, idx::Int)
-    is.inst[idx] = newval
+    is.stmt[idx] = newval
     return is
 end
 function setindex!(node::Instruction, newval::Instruction)
@@ -308,7 +310,7 @@ function NewInstruction(newinst::NewInstruction;
     return NewInstruction(stmt, type, info, line, flag)
 end
 function NewInstruction(inst::Instruction;
-    stmt::Any=inst[:inst],
+    stmt::Any=inst[:stmt],
     type::Any=inst[:type],
     info::CallInfo=inst[:info],
     line::Union{Int32,Nothing}=inst[:line],
@@ -358,7 +360,7 @@ from the frontend or one of the caches.
 """
 function IRCode()
     ir = IRCode(InstructionStream(1), CFG([BasicBlock(1:1, Int[], Int[])], Int[1]), LineInfoNode[], Any[], Expr[], VarState[])
-    ir[SSAValue(1)][:inst] = ReturnNode(nothing)
+    ir[SSAValue(1)][:stmt] = ReturnNode(nothing)
     ir[SSAValue(1)][:type] = Nothing
     ir[SSAValue(1)][:flag] = 0x00
     ir[SSAValue(1)][:line] = Int32(0)
@@ -810,7 +812,7 @@ end
 
 function inst_from_newinst!(node::Instruction, newinst::NewInstruction,
     newline::Int32=newinst.line::Int32, newflag::UInt8=newinst.flag::UInt8)
-    node[:inst] = newinst.stmt
+    node[:stmt] = newinst.stmt
     node[:type] = newinst.type
     node[:info] = newinst.info
     node[:line] = newline
@@ -952,10 +954,10 @@ end
 
 function setindex!(compact::IncrementalCompact, @nospecialize(v), idx::SSAValue)
     @assert idx.id < compact.result_idx
-    (compact.result[idx.id][:inst] === v) && return compact
+    (compact.result[idx.id][:stmt] === v) && return compact
     # Kill count for current uses
-    kill_current_uses!(compact, compact.result[idx.id][:inst])
-    compact.result[idx.id][:inst] = v
+    kill_current_uses!(compact, compact.result[idx.id][:stmt])
+    compact.result[idx.id][:stmt] = v
     # Add count for new use
     count_added_node!(compact, v) && push!(compact.late_fixup, idx.id)
     return compact
@@ -965,22 +967,22 @@ function setindex!(compact::IncrementalCompact, @nospecialize(v), idx::OldSSAVal
     id = idx.id
     if id < compact.idx
         new_idx = compact.ssa_rename[id]::Int
-        (compact.result[new_idx][:inst] === v) && return compact
-        kill_current_uses!(compact, compact.result[new_idx][:inst])
-        compact.result[new_idx][:inst] = v
+        (compact.result[new_idx][:stmt] === v) && return compact
+        kill_current_uses!(compact, compact.result[new_idx][:stmt])
+        compact.result[new_idx][:stmt] = v
         count_added_node!(compact, v) && push!(compact.late_fixup, new_idx)
         return compact
     elseif id <= length(compact.ir.stmts)  # ir.stmts, new_nodes, and pending_nodes uses aren't counted yet, so no need to adjust
-        compact.ir.stmts[id][:inst] = v
+        compact.ir.stmts[id][:stmt] = v
         return compact
     end
     id -= length(compact.ir.stmts)
     if id <= length(compact.ir.new_nodes)
-        compact.ir.new_nodes.stmts[id][:inst] = v
+        compact.ir.new_nodes.stmts[id][:stmt] = v
         return compact
     end
     id -= length(compact.ir.new_nodes)
-    compact.pending_nodes.stmts[id][:inst] = v
+    compact.pending_nodes.stmts[id][:stmt] = v
     return compact
 end
 
@@ -988,7 +990,7 @@ function setindex!(compact::IncrementalCompact, @nospecialize(v), idx::Int)
     if idx < compact.result_idx
         compact[SSAValue(idx)] = v
     else
-        compact.ir.stmts[idx][:inst] = v
+        compact.ir.stmts[idx][:stmt] = v
     end
     return compact
 end
@@ -1000,7 +1002,7 @@ should_check_ssa_counts() = __check_ssa_counts__[]
 
 # specifically meant to be used with body1 = compact.result and body2 = compact.new_new_nodes, with nvals == length(compact.used_ssas)
 function find_ssavalue_uses1(compact::IncrementalCompact)
-    body1, body2 = compact.result.inst, compact.new_new_nodes.stmts.inst
+    body1, body2 = compact.result.stmt, compact.new_new_nodes.stmts.stmt
     nvals = length(compact.used_ssas)
     nvalsnew = length(compact.new_new_used_ssas)
     nbody1 = compact.result_idx
@@ -1215,9 +1217,9 @@ function kill_edge!(compact::IncrementalCompact, active_bb::Int, from::Int, to::
             # Kill all statements in the block
             stmts = result_bbs[bb_rename_succ[to]].stmts
             for stmt in stmts
-                compact.result[stmt][:inst] = nothing
+                compact.result[stmt][:stmt] = nothing
             end
-            compact.result[last(stmts)][:inst] = ReturnNode()
+            compact.result[last(stmts)][:stmt] = ReturnNode()
         else
             # Tell compaction to not schedule this block. A value of -2 here
             # indicates that the block is not to be scheduled, but there should
@@ -1233,7 +1235,7 @@ function kill_edge!(compact::IncrementalCompact, active_bb::Int, from::Int, to::
             stmts = result_bbs[bb_rename_succ[to]].stmts
             idx = first(stmts)
             while idx <= last(stmts)
-                stmt = compact.result[idx][:inst]
+                stmt = compact.result[idx][:stmt]
                 stmt === nothing && continue
                 isa(stmt, PhiNode) || break
                 i = findfirst(x::Int32->x==bb_rename_pred[from], stmt.edges)
@@ -1265,7 +1267,7 @@ struct Refined
 end
 
 function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instruction, idx::Int, processed_idx::Int, active_bb::Int, do_rename_ssa::Bool)
-    stmt = inst[:inst]
+    stmt = inst[:stmt]
     (; result, ssa_rename, late_fixup, used_ssas, new_new_used_ssas) = compact
     (; cfg_transforms_enabled, fold_constant_branches, bb_rename_succ, bb_rename_pred, result_bbs) = compact.cfg_transform
     mark_refined! = Refiner(result.flag, result_idx)
@@ -1277,7 +1279,7 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
         label = bb_rename_succ[stmt.label]
         @assert label > 0
         ssa_rename[idx] = SSAValue(result_idx)
-        result[result_idx][:inst] = GotoNode(label)
+        result[result_idx][:stmt] = GotoNode(label)
         result_idx += 1
     elseif isa(stmt, GlobalRef)
         total_flags = IR_FLAG_CONSISTENT | IR_FLAG_EFFECT_FREE
@@ -1286,16 +1288,16 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
             ssa_rename[idx] = stmt
         else
             ssa_rename[idx] = SSAValue(result_idx)
-            result[result_idx][:inst] = stmt
+            result[result_idx][:stmt] = stmt
             result_idx += 1
         end
     elseif isa(stmt, GotoNode)
         ssa_rename[idx] = SSAValue(result_idx)
-        result[result_idx][:inst] = stmt
+        result[result_idx][:stmt] = stmt
         result_idx += 1
     elseif isa(stmt, GotoIfNot) && cfg_transforms_enabled
         stmt = renumber_ssa2!(stmt, ssa_rename, used_ssas, new_new_used_ssas, late_fixup, result_idx, do_rename_ssa, mark_refined!)::GotoIfNot
-        result[result_idx][:inst] = stmt
+        result[result_idx][:stmt] = stmt
         cond = stmt.cond
         if fold_constant_branches
             if !isa(cond, Bool)
@@ -1307,14 +1309,14 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
             end
             if cond
                 ssa_rename[idx] = nothing
-                result[result_idx][:inst] = nothing
+                result[result_idx][:stmt] = nothing
                 kill_edge!(compact, active_bb, active_bb, stmt.dest)
                 # Don't increment result_idx => Drop this statement
             else
                 label = bb_rename_succ[stmt.dest]
                 @assert label > 0
                 ssa_rename[idx] = SSAValue(result_idx)
-                result[result_idx][:inst] = GotoNode(label)
+                result[result_idx][:stmt] = GotoNode(label)
                 kill_edge!(compact, active_bb, active_bb, active_bb+1)
                 result_idx += 1
             end
@@ -1323,7 +1325,7 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
             label = bb_rename_succ[stmt.dest]
             @assert label > 0
             ssa_rename[idx] = SSAValue(result_idx)
-            result[result_idx][:inst] = GotoIfNot(cond, label)
+            result[result_idx][:stmt] = GotoIfNot(cond, label)
             result_idx += 1
         end
     elseif isa(stmt, Expr)
@@ -1347,7 +1349,7 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
         else
             ssa_rename[idx] = SSAValue(result_idx)
         end
-        result[result_idx][:inst] = stmt
+        result[result_idx][:stmt] = stmt
         result_idx += 1
     elseif isa(stmt, PiNode)
         # As an optimization, we eliminate any trivial pinodes. For performance, we use ===
@@ -1375,11 +1377,11 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
             end
         end
         ssa_rename[idx] = SSAValue(result_idx)
-        result[result_idx][:inst] = stmt
+        result[result_idx][:stmt] = stmt
         result_idx += 1
     elseif isa(stmt, ReturnNode) || isa(stmt, UpsilonNode) || isa(stmt, GotoIfNot)
         ssa_rename[idx] = SSAValue(result_idx)
-        result[result_idx][:inst] = renumber_ssa2!(stmt, ssa_rename, used_ssas, new_new_used_ssas, late_fixup, result_idx, do_rename_ssa, mark_refined!)
+        result[result_idx][:stmt] = renumber_ssa2!(stmt, ssa_rename, used_ssas, new_new_used_ssas, late_fixup, result_idx, do_rename_ssa, mark_refined!)
         result_idx += 1
     elseif isa(stmt, PhiNode)
         # N.B.: For PhiNodes, this needs to be at the top, since PhiNodes
@@ -1442,12 +1444,12 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
             end
             ssa_rename[idx] = v
         else
-            result[result_idx][:inst] = PhiNode(edges, values)
+            result[result_idx][:stmt] = PhiNode(edges, values)
             result_idx += 1
         end
     elseif isa(stmt, PhiCNode)
         ssa_rename[idx] = SSAValue(result_idx)
-        result[result_idx][:inst] = PhiCNode(process_phinode_values(stmt.values, late_fixup, processed_idx, result_idx, ssa_rename, used_ssas, new_new_used_ssas, do_rename_ssa, mark_refined!))
+        result[result_idx][:stmt] = PhiCNode(process_phinode_values(stmt.values, late_fixup, processed_idx, result_idx, ssa_rename, used_ssas, new_new_used_ssas, do_rename_ssa, mark_refined!))
         result_idx += 1
     else
         if isa(stmt, SSAValue)
@@ -1496,9 +1498,9 @@ function finish_current_bb!(compact::IncrementalCompact, active_bb::Int,
             length(compact.result) < old_result_idx && resize!(compact, old_result_idx)
             node = compact.result[old_result_idx]
             if unreachable
-                node[:inst], node[:type], node[:line] = ReturnNode(), Union{}, 0
+                node[:stmt], node[:type], node[:line] = ReturnNode(), Union{}, 0
             else
-                node[:inst], node[:type], node[:line] = nothing, Nothing, 0
+                node[:stmt], node[:type], node[:line] = nothing, Nothing, 0
             end
             compact.result_idx = old_result_idx + 1
         elseif cfg_transforms_enabled && compact.result_idx - 1 == first(bb.stmts)
@@ -1573,7 +1575,7 @@ function iterate(it::CompactPeekIterator, (idx, aidx, bidx)::NTuple{3, Int}=(it.
         for eidx in aidx:length(compact.perm)
             if entry_at_idx(new_nodes.info[compact.perm[eidx]], idx)
                 entry = new_nodes.stmts[compact.perm[eidx]]
-                return (entry[:inst], (idx, eidx+1, bidx))
+                return (entry[:stmt], (idx, eidx+1, bidx))
             end
         end
     end
@@ -1581,12 +1583,12 @@ function iterate(it::CompactPeekIterator, (idx, aidx, bidx)::NTuple{3, Int}=(it.
         for eidx in bidx:length(compact.pending_perm)
             if entry_at_idx(compact.pending_nodes.info[compact.pending_perm[eidx]], idx)
                 entry = compact.pending_nodes.stmts[compact.pending_perm[eidx]]
-                return (entry[:inst], (idx, aidx, eidx+1))
+                return (entry[:stmt], (idx, aidx, eidx+1))
             end
         end
     end
     idx > length(compact.ir.stmts) && return nothing
-    return (compact.ir.stmts[idx][:inst], (idx + 1, aidx, bidx))
+    return (compact.ir.stmts[idx][:stmt], (idx + 1, aidx, bidx))
 end
 
 # the returned Union{Nothing, Pair{Pair{Int,Int},Any}} cannot be stack allocated,
@@ -1595,7 +1597,7 @@ end
     idxs = iterate_compact(compact)
     idxs === nothing && return nothing
     old_result_idx = idxs[2]
-    return Pair{Pair{Int,Int},Any}(idxs, compact.result[old_result_idx][:inst]), nothing
+    return Pair{Pair{Int,Int},Any}(idxs, compact.result[old_result_idx][:stmt]), nothing
 end
 
 function iterate_compact(compact::IncrementalCompact)
@@ -1682,7 +1684,7 @@ function iterate_compact(compact::IncrementalCompact)
         idx += 1
         @goto restart
     end
-    @assert isassigned(compact.result.inst, old_result_idx)
+    @assert isassigned(compact.result.stmt, old_result_idx)
     return Pair{Int,Int}(compact.idx-1, old_result_idx)
 end
 
@@ -1692,7 +1694,7 @@ function maybe_erase_unused!(callback::Function, compact::IncrementalCompact, id
     in_worklist::Bool, extra_worklist::Vector{Int})
     nresult = length(compact.result)
     inst = idx ≤ nresult ? compact.result[idx] : compact.new_new_nodes.stmts[idx-nresult]
-    stmt = inst[:inst]
+    stmt = inst[:stmt]
     stmt === nothing && return false
     inst[:type] === Bottom && return false
     effect_free = (inst[:flag] & (IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW)) == IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW
@@ -1706,7 +1708,7 @@ function maybe_erase_unused!(callback::Function, compact::IncrementalCompact, id
         compact.used_ssas[val.id] -= 1
         callback(val)
     end
-    inst[:inst] = nothing
+    inst[:stmt] = nothing
     return true
 end
 
@@ -1777,9 +1779,9 @@ function just_fixup!(compact::IncrementalCompact, new_new_nodes_offset::Union{In
     set_off = off
     for i in off:length(compact.late_fixup)
         idx = compact.late_fixup[i]
-        stmt = compact.result[idx][:inst]
+        stmt = compact.result[idx][:stmt]
         (;node, needs_fixup) = fixup_node(compact, stmt, late_fixup_offset === nothing)
-        (stmt === node) || (compact.result[idx][:inst] = node)
+        (stmt === node) || (compact.result[idx][:stmt] = node)
         if needs_fixup
             compact.late_fixup[set_off] = idx
             set_off += 1
@@ -1791,10 +1793,10 @@ function just_fixup!(compact::IncrementalCompact, new_new_nodes_offset::Union{In
     off = new_new_nodes_offset === nothing ? 1 : (new_new_nodes_offset+1)
     for idx in off:length(compact.new_new_nodes)
         new_node = compact.new_new_nodes.stmts[idx]
-        stmt = new_node[:inst]
+        stmt = new_node[:stmt]
         (;node) = fixup_node(compact, stmt, late_fixup_offset === nothing)
         if node !== stmt
-            new_node[:inst] = node
+            new_node[:stmt] = node
         end
     end
 end
@@ -1842,7 +1844,7 @@ function complete(compact::IncrementalCompact)
     # trim trailing undefined statements due to copy propagation
     nundef = 0
     for i in length(compact.result):-1:1
-        if isassigned(compact.result.inst, i)
+        if isassigned(compact.result.stmt, i)
             break
         end
         nundef += 1

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -56,20 +56,21 @@ function update_phi!(irsv::IRInterpretationState, from::Int, to::Int)
     if length(ir.cfg.blocks[to].preds) == 0
         # Kill the entire block
         for bidx = ir.cfg.blocks[to].stmts
-            ir.stmts[bidx][:inst] = nothing
-            ir.stmts[bidx][:type] = Bottom
-            ir.stmts[bidx][:flag] = IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW
+            inst = ir[SSAValue(bidx)]
+            inst[:stmt] = nothing
+            inst[:type] = Bottom
+            inst[:flag] = IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW
         end
         return
     end
     for sidx = ir.cfg.blocks[to].stmts
-        sinst = ir.stmts[sidx][:inst]
-        isa(sinst, Nothing) && continue # allowed between `PhiNode`s
-        isa(sinst, PhiNode) || break
-        for (eidx, edge) in enumerate(sinst.edges)
+        stmt = ir[SSAValue(sidx)][:stmt]
+        isa(stmt, Nothing) && continue # allowed between `PhiNode`s
+        isa(stmt, PhiNode) || break
+        for (eidx, edge) in enumerate(stmt.edges)
             if edge == from
-                deleteat!(sinst.edges, eidx)
-                deleteat!(sinst.values, eidx)
+                deleteat!(stmt.edges, eidx)
+                deleteat!(stmt.values, eidx)
                 push!(irsv.ssa_refined, sidx)
                 break
             end
@@ -80,25 +81,26 @@ update_phi!(irsv::IRInterpretationState) = (from::Int, to::Int)->update_phi!(irs
 
 function kill_terminator_edges!(irsv::IRInterpretationState, term_idx::Int, bb::Int=block_for_inst(irsv.ir, term_idx))
     ir = irsv.ir
-    inst = ir[SSAValue(term_idx)][:inst]
-    if isa(inst, GotoIfNot)
-        kill_edge!(ir, bb, inst.dest, update_phi!(irsv))
+    stmt = ir[SSAValue(term_idx)][:stmt]
+    if isa(stmt, GotoIfNot)
+        kill_edge!(ir, bb, stmt.dest, update_phi!(irsv))
         kill_edge!(ir, bb, bb+1, update_phi!(irsv))
-    elseif isa(inst, GotoNode)
-        kill_edge!(ir, bb, inst.label, update_phi!(irsv))
-    elseif isa(inst, ReturnNode)
+    elseif isa(stmt, GotoNode)
+        kill_edge!(ir, bb, stmt.label, update_phi!(irsv))
+    elseif isa(stmt, ReturnNode)
         # Nothing to do
     else
-        @assert !isexpr(inst, :enter)
+        @assert !isexpr(stmt, :enter)
         kill_edge!(ir, bb, bb+1, update_phi!(irsv))
     end
 end
 
 function reprocess_instruction!(interp::AbstractInterpreter, idx::Int, bb::Union{Int,Nothing},
-    @nospecialize(inst), @nospecialize(typ), irsv::IRInterpretationState)
+    @nospecialize(stmt), @nospecialize(typ), irsv::IRInterpretationState)
     ir = irsv.ir
-    if isa(inst, GotoIfNot)
-        cond = inst.cond
+    inst = ir[SSAValue(idx)]
+    if isa(stmt, GotoIfNot)
+        cond = stmt.cond
         condval = maybe_extract_const_bool(argextype(cond, ir))
         if condval isa Bool
             if isa(cond, SSAValue)
@@ -107,13 +109,13 @@ function reprocess_instruction!(interp::AbstractInterpreter, idx::Int, bb::Union
             if bb === nothing
                 bb = block_for_inst(ir, idx)
             end
-            ir.stmts[idx][:flag] |= IR_FLAG_NOTHROW
+            inst[:flag] |= IR_FLAG_NOTHROW
             if condval
-                ir.stmts[idx][:inst] = nothing
-                ir.stmts[idx][:type] = Any
-                kill_edge!(ir, bb, inst.dest, update_phi!(irsv))
+                inst[:stmt] = nothing
+                inst[:type] = Any
+                kill_edge!(ir, bb, stmt.dest, update_phi!(irsv))
             else
-                ir.stmts[idx][:inst] = GotoNode(inst.dest)
+                inst[:stmt] = GotoNode(stmt.dest)
                 kill_edge!(ir, bb, bb+1, update_phi!(irsv))
             end
             return true
@@ -121,21 +123,21 @@ function reprocess_instruction!(interp::AbstractInterpreter, idx::Int, bb::Union
         return false
     end
     rt = nothing
-    if isa(inst, Expr)
-        head = inst.head
+    if isa(stmt, Expr)
+        head = stmt.head
         if head === :call || head === :foreigncall || head === :new || head === :splatnew || head === :static_parameter || head === :isdefined
-            (; rt, effects) = abstract_eval_statement_expr(interp, inst, nothing, irsv)
-            ir.stmts[idx][:flag] |= flags_for_effects(effects)
+            (; rt, effects) = abstract_eval_statement_expr(interp, stmt, nothing, irsv)
+            inst[:flag] |= flags_for_effects(effects)
         elseif head === :invoke
-            rt, nothrow = concrete_eval_invoke(interp, inst, inst.args[1]::MethodInstance, irsv)
+            rt, nothrow = concrete_eval_invoke(interp, stmt, stmt.args[1]::MethodInstance, irsv)
             if nothrow
-                ir.stmts[idx][:flag] |= IR_FLAG_NOTHROW
+                inst[:flag] |= IR_FLAG_NOTHROW
             end
         elseif head === :throw_undef_if_not
-            condval = maybe_extract_const_bool(argextype(inst.args[2], ir))
+            condval = maybe_extract_const_bool(argextype(stmt.args[2], ir))
             condval isa Bool || return false
             if condval
-                ir.stmts[idx][:inst] = nothing
+                inst[:stmt] = nothing
                 # We simplified the IR, but we did not update the type
                 return false
             end
@@ -146,29 +148,29 @@ function reprocess_instruction!(interp::AbstractInterpreter, idx::Int, bb::Union
         else
             error("reprocess_instruction!: unhandled expression found")
         end
-    elseif isa(inst, PhiNode)
-        rt = abstract_eval_phi_stmt(interp, inst, idx, irsv)
-    elseif isa(inst, ReturnNode)
+    elseif isa(stmt, PhiNode)
+        rt = abstract_eval_phi_stmt(interp, stmt, idx, irsv)
+    elseif isa(stmt, ReturnNode)
         # Handled at the very end
         return false
-    elseif isa(inst, PiNode)
-        rt = tmeet(typeinf_lattice(interp), argextype(inst.val, ir), widenconst(inst.typ))
-    elseif inst === nothing
+    elseif isa(stmt, PiNode)
+        rt = tmeet(typeinf_lattice(interp), argextype(stmt.val, ir), widenconst(stmt.typ))
+    elseif stmt === nothing
         return false
-    elseif isa(inst, GlobalRef)
+    elseif isa(stmt, GlobalRef)
         # GlobalRef is not refinable
     else
-        rt = argextype(inst, irsv.ir)
+        rt = argextype(stmt, irsv.ir)
     end
     if rt !== nothing
         if isa(rt, Const)
-            ir.stmts[idx][:type] = rt
-            if is_inlineable_constant(rt.val) && (ir.stmts[idx][:flag] & (IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW)) == IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW
-                ir.stmts[idx][:inst] = quoted(rt.val)
+            inst[:type] = rt
+            if is_inlineable_constant(rt.val) && (inst[:flag] & (IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW)) == IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW
+                inst[:stmt] = quoted(rt.val)
             end
             return true
         elseif !⊑(typeinf_lattice(interp), typ, rt)
-            ir.stmts[idx][:type] = rt
+            inst[:type] = rt
             return true
         end
     end
@@ -176,24 +178,24 @@ function reprocess_instruction!(interp::AbstractInterpreter, idx::Int, bb::Union
 end
 
 # Process the terminator and add the successor to `bb_ip`. Returns whether a backedge was seen.
-function process_terminator!(ir::IRCode, @nospecialize(inst), idx::Int, bb::Int,
+function process_terminator!(ir::IRCode, @nospecialize(stmt), idx::Int, bb::Int,
     all_rets::Vector{Int}, bb_ip::BitSetBoundedMinPrioritySet)
-    if isa(inst, ReturnNode)
-        if isdefined(inst, :val)
+    if isa(stmt, ReturnNode)
+        if isdefined(stmt, :val)
             push!(all_rets, idx)
         end
         return false
-    elseif isa(inst, GotoNode)
-        backedge = inst.label <= bb
-        backedge || push!(bb_ip, inst.label)
+    elseif isa(stmt, GotoNode)
+        backedge = stmt.label <= bb
+        backedge || push!(bb_ip, stmt.label)
         return backedge
-    elseif isa(inst, GotoIfNot)
-        backedge = inst.dest <= bb
-        backedge || push!(bb_ip, inst.dest)
+    elseif isa(stmt, GotoIfNot)
+        backedge = stmt.dest <= bb
+        backedge || push!(bb_ip, stmt.dest)
         push!(bb_ip, bb+1)
         return backedge
-    elseif isexpr(inst, :enter)
-        dest = inst.args[1]::Int
+    elseif isexpr(stmt, :enter)
+        dest = stmt.args[1]::Int
         @assert dest > bb
         push!(bb_ip, dest)
         push!(bb_ip, bb+1)
@@ -224,15 +226,16 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
         lstmt = last(stmts)
         for idx = stmts
             irsv.curridx = idx
-            inst = ir.stmts[idx][:inst]
-            typ = ir.stmts[idx][:type]
-            flag = ir.stmts[idx][:flag]
+            inst = ir[SSAValue(idx)]
+            stmt = inst[:stmt]
+            typ = inst[:type]
+            flag = inst[:flag]
             any_refined = false
             if (flag & IR_FLAG_REFINED) != 0
                 any_refined = true
-                ir.stmts[idx][:flag] &= ~IR_FLAG_REFINED
+                inst[:flag] &= ~IR_FLAG_REFINED
             end
-            for ur in userefs(inst)
+            for ur in userefs(stmt)
                 val = ur[]
                 if isa(val, Argument)
                     any_refined |= irsv.argtypes_refined[val.n]
@@ -241,20 +244,20 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
                     count!(tpdum, val)
                 end
             end
-            if isa(inst, PhiNode) && idx in ssa_refined
+            if isa(stmt, PhiNode) && idx in ssa_refined
                 any_refined = true
                 delete!(ssa_refined, idx)
             end
-            is_terminator_or_phi = isa(inst, PhiNode) || isa(inst, GotoNode) || isa(inst, GotoIfNot) || isa(inst, ReturnNode) || isexpr(inst, :enter)
+            is_terminator_or_phi = isa(stmt, PhiNode) || isa(stmt, GotoNode) || isa(stmt, GotoIfNot) || isa(stmt, ReturnNode) || isexpr(stmt, :enter)
             if typ === Bottom && (idx != lstmt || !is_terminator_or_phi)
                 continue
             end
             if (any_refined && reprocess_instruction!(interp,
-                    idx, bb, inst, typ, irsv)) ||
+                    idx, bb, stmt, typ, irsv)) ||
                (externally_refined !== nothing && idx in externally_refined)
                 push!(ssa_refined, idx)
-                inst = ir.stmts[idx][:inst]
-                typ = ir.stmts[idx][:type]
+                stmt = inst[:stmt]
+                typ = inst[:type]
             end
             if typ === Bottom && !is_terminator_or_phi
                 kill_terminator_edges!(irsv, lstmt, bb)
@@ -262,12 +265,12 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
                     for idx2 in (idx+1:lstmt-1)
                         ir[SSAValue(idx2)] = nothing
                     end
-                    ir[SSAValue(lstmt)][:inst] = ReturnNode()
+                    ir[SSAValue(lstmt)][:stmt] = ReturnNode()
                 end
                 break
             end
             if idx == lstmt
-                process_terminator!(ir, inst, idx, bb, all_rets, bb_ip) && @goto residual_scan
+                process_terminator!(ir, stmt, idx, bb, all_rets, bb_ip) && @goto residual_scan
             end
         end
     end
@@ -284,13 +287,14 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
             lstmt = last(stmts)
             for idx = stmts
                 irsv.curridx = idx
-                inst = ir.stmts[idx][:inst]
-                flag = ir.stmts[idx][:flag]
+                inst = ir[SSAValue(idx)]
+                stmt = inst[:stmt]
+                flag = inst[:flag]
                 if (flag & IR_FLAG_REFINED) != 0
-                    ir.stmts[idx][:flag] &= ~IR_FLAG_REFINED
+                    inst[:flag] &= ~IR_FLAG_REFINED
                     push!(stmt_ip, idx)
                 end
-                for ur in userefs(inst)
+                for ur in userefs(stmt)
                     val = ur[]
                     if isa(val, Argument)
                         if irsv.argtypes_refined[val.n]
@@ -300,7 +304,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
                         count!(tpdum, val)
                     end
                 end
-                idx == lstmt && process_terminator!(ir, inst, idx, bb, all_rets, bb_ip)
+                idx == lstmt && process_terminator!(ir, stmt, idx, bb, all_rets, bb_ip)
             end
         end
 
@@ -313,14 +317,15 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
             lstmt = last(stmts)
             for idx = stmts
                 irsv.curridx = idx
-                inst = ir.stmts[idx][:inst]
-                for ur in userefs(inst)
+                inst = ir[SSAValue(idx)]
+                stmt = inst[:stmt]
+                for ur in userefs(stmt)
                     val = ur[]
                     if isa(val, SSAValue)
                         push!(tpdum[val.id], idx)
                     end
                 end
-                idx == lstmt && process_terminator!(ir, inst, idx, bb, all_rets, bb_ip)
+                idx == lstmt && process_terminator!(ir, stmt, idx, bb, all_rets, bb_ip)
             end
         end
 
@@ -333,10 +338,11 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
         while !isempty(stmt_ip)
             idx = popfirst!(stmt_ip)
             irsv.curridx = idx
-            inst = ir.stmts[idx][:inst]
-            typ = ir.stmts[idx][:type]
+            inst = ir[SSAValue(idx)]
+            stmt = inst[:stmt]
+            typ = inst[:type]
             if reprocess_instruction!(interp,
-                idx, nothing, inst, typ, irsv)
+                idx, nothing, stmt, typ, irsv)
                 append!(stmt_ip, tpdum[idx])
             end
         end
@@ -350,7 +356,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
                 # Could have discovered this block is dead after the initial scan
                 continue
             end
-            inst = ir.stmts[idx][:inst]::ReturnNode
+            inst = ir[SSAValue(idx)][:stmt]::ReturnNode
             rt = argextype(inst.val, ir)
             ultimate_rt = tmerge(typeinf_lattice(interp), ultimate_rt, rt)
         end
@@ -358,7 +364,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
 
     nothrow = true
     for idx = 1:length(ir.stmts)
-        if (ir.stmts[idx][:flag] & IR_FLAG_NOTHROW) == 0
+        if (ir[SSAValue(idx)][:flag] & IR_FLAG_NOTHROW) == 0
             nothrow = false
             break
         end

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -72,7 +72,7 @@ function replace_code_newstyle!(ci::CodeInfo, ir::IRCode)
     resize!(ci.slotflags, nargs)
     resize!(ci.slottypes, nargs)
     stmts = ir.stmts
-    code = ci.code = stmts.inst
+    code = ci.code = stmts.stmt
     ssavaluetypes = ci.ssavaluetypes = stmts.type
     codelocs = ci.codelocs = stmts.line
     ssaflags = ci.ssaflags = stmts.flag

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -79,7 +79,7 @@ function find_curblock(domtree::DomTree, allblocks::BitSet, curblock::Int)
 end
 
 function val_for_def_expr(ir::IRCode, def::Int, fidx::Int)
-    ex = ir[SSAValue(def)][:inst]
+    ex = ir[SSAValue(def)][:stmt]
     if isexpr(ex, :new)
         return ex.args[1+fidx]
     else
@@ -199,7 +199,7 @@ function simple_walk(compact::IncrementalCompact, @nospecialize(defssa#=::AnySSA
                 return rename
             end
         end
-        def = compact[defssa][:inst]
+        def = compact[defssa][:stmt]
         if isa(def, PiNode)
             if callback(def, defssa)
                 return defssa
@@ -249,7 +249,7 @@ predecessors for a "phi-like" node (PhiNode or Core.ifelse) or `nothing` otherwi
 function walk_to_defs(compact::IncrementalCompact, @nospecialize(defssa), @nospecialize(typeconstraint), predecessors, 𝕃ₒ::AbstractLattice)
     visited_philikes = AnySSAValue[]
     isa(defssa, AnySSAValue) || return Any[defssa], visited_philikes
-    def = compact[defssa][:inst]
+    def = compact[defssa][:stmt]
     if predecessors(def, compact) === nothing
         return Any[defssa], visited_philikes
     end
@@ -263,7 +263,7 @@ function walk_to_defs(compact::IncrementalCompact, @nospecialize(defssa), @nospe
         defssa = pop!(worklist_defs)
         typeconstraint = pop!(worklist_constraints)
         visited_constraints[defssa] = typeconstraint
-        def = compact[defssa][:inst]
+        def = compact[defssa][:stmt]
         values = predecessors(def, compact)
         if values !== nothing
             push!(visited_philikes, defssa)
@@ -403,7 +403,7 @@ function lift_leaves(compact::IncrementalCompact, field::Int,
             #      `:new` expressions by the inlinear
             # elseif isexpr(def, :splatnew) && length(def.args) == 2 && isa(def.args[2], AnySSAValue)
             #     tplssa = def.args[2]::AnySSAValue
-            #     tplexpr = compact[tplssa][:inst]
+            #     tplexpr = compact[tplssa][:stmt]
             #     if is_known_call(tplexpr, tuple, compact) && 1 ≤ field < length(tplexpr.args)
             #         lift_arg!(compact, tplssa, cache_key, tplexpr, 1+field, lifted_leaves)
             #         continue
@@ -493,12 +493,12 @@ function walk_to_def(compact::IncrementalCompact, @nospecialize(leaf))
             leaf = simple_walk(compact, leaf)
         end
         if isa(leaf, AnySSAValue)
-            def = compact[leaf][:inst]
+            def = compact[leaf][:stmt]
         else
             def = leaf
         end
     elseif isa(leaf, AnySSAValue)
-        def = compact[leaf][:inst]
+        def = compact[leaf][:stmt]
     else
         def = leaf
     end
@@ -703,7 +703,7 @@ function perform_lifting!(compact::IncrementalCompact,
     for i = 1:nphilikes
         old_ssa = visited_philikes[i]
         old_inst = compact[old_ssa]
-        old_node = old_inst[:inst]::Union{PhiNode,Expr}
+        old_node = old_inst[:stmt]::Union{PhiNode,Expr}
         # FIXME this cache is broken somehow
         # ckey = Pair{AnySSAValue, Any}(old_ssa, cache_key)
         # cached = ckey in keys(lifting_cache)
@@ -745,7 +745,7 @@ function perform_lifting!(compact::IncrementalCompact,
 
         lfnode = lf.node
         if isa(lfnode, PhiNode)
-            old_node = compact[old_node_ssa][:inst]::PhiNode
+            old_node = compact[old_node_ssa][:stmt]::PhiNode
             new_node = lfnode
             for i = 1:length(old_node.values)
                 isassigned(old_node.values, i) || continue
@@ -760,7 +760,7 @@ function perform_lifting!(compact::IncrementalCompact,
                 end
             end
         elseif isa(lfnode, IfElseCall)
-            old_node = compact[old_node_ssa][:inst]::Expr
+            old_node = compact[old_node_ssa][:stmt]::Expr
             then_result, else_result = old_node.args[3], old_node.args[4]
 
             then_result = lifted_value(compact, old_node_ssa, then_result,
@@ -774,7 +774,7 @@ function perform_lifting!(compact::IncrementalCompact,
                 only_result = (then_result === SKIP_TOKEN) ? else_result : then_result
 
                 # Replace Core.ifelse(%cond, %a, %b) with %a
-                compact[lf.ssa][:inst] = only_result
+                compact[lf.ssa][:stmt] = only_result
                 should_count && _count_added_node!(compact, only_result)
 
                 # Note: Core.ifelse(%cond, %a, %b) has observable effects (!nothrow), but since
@@ -824,7 +824,7 @@ function lift_svec_ref!(compact::IncrementalCompact, idx::Int, stmt::Expr)
         valI <= length(vec) || return
         compact[idx] = quoted(vec[valI])
     elseif isa(vec, SSAValue)
-        def = compact[vec][:inst]
+        def = compact[vec][:stmt]
         if is_known_call(def, Core.svec, compact)
             valI <= length(def.args) - 1 || return
             compact[idx] = def.args[valI+1]
@@ -870,11 +870,11 @@ end
 
     rarg = def.args[2 + i]
     isa(rarg, SSAValue) || return nothing
-    argdef = compact[rarg][:inst]
+    argdef = compact[rarg][:stmt]
     if isexpr(argdef, :new)
         rarg = argdef.args[1]
         isa(rarg, SSAValue) || return nothing
-        argdef = compact[rarg][:inst]
+        argdef = compact[rarg][:stmt]
     else
         isType(arg) || return nothing
         arg = arg.parameters[1]
@@ -923,7 +923,7 @@ function pattern_match_typeof(compact::IncrementalCompact, typ::DataType, fidx::
                               @nospecialize(Targ), @nospecialize(farg))
     isa(Targ, SSAValue) || return false
 
-    Tdef = compact[Targ][:inst]
+    Tdef = compact[Targ][:stmt]
     is_known_call(Tdef, Core.apply_type, compact) || return false
     length(Tdef.args) ≥ 2 || return false
 
@@ -945,7 +945,7 @@ function pattern_match_typeof(compact::IncrementalCompact, typ::DataType, fidx::
     checkbounds(Bool, Tdef.args, 2+idx) || return false
     valarg = Tdef.args[2+idx]
     isa(valarg, SSAValue) || return false
-    valdef = compact[valarg][:inst]
+    valdef = compact[valarg][:stmt]
     is_known_call(valdef, typeof, compact) || return false
 
     return valdef.args[2] === farg
@@ -1054,7 +1054,7 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
                     def = simple_walk(compact, preserved_arg, callback)
                     isa(def, SSAValue) || continue
                     defidx = def.id
-                    def = compact[def][:inst]
+                    def = compact[def][:stmt]
                     if is_known_call(def, tuple, compact)
                         record_immutable_preserve!(new_preserves, def, compact)
                         push!(preserved, preserved_arg.id)
@@ -1254,7 +1254,7 @@ function try_inline_finalizer!(ir::IRCode, argexprs::Vector{Any}, idx::Int,
     ssa_rename = Vector{Any}(undef, length(src.stmts))
     for idx′ = 1:length(src.stmts)
         inst = src[SSAValue(idx′)]
-        stmt′ = inst[:inst]
+        stmt′ = inst[:stmt]
         isa(stmt′, ReturnNode) && continue
         stmt′ = ssamap(stmt′) do ssa::SSAValue
             ssa_rename[ssa.id]
@@ -1383,7 +1383,7 @@ function try_resolve_finalizer!(ir::IRCode, idx::Int, finalizer_idx::Int, defuse
     loc = bb_insert_idx === nothing ? first(ir.cfg.blocks[bb_insert_block].stmts) : bb_insert_idx::Int
     attach_after = bb_insert_idx !== nothing
 
-    finalizer_stmt = ir[SSAValue(finalizer_idx)][:inst]
+    finalizer_stmt = ir[SSAValue(finalizer_idx)][:stmt]
     argexprs = Any[finalizer_stmt.args[2], finalizer_stmt.args[3]]
     flags = info isa FinalizerInfo ? flags_for_effects(info.effects) : IR_FLAG_NULL
     if length(finalizer_stmt.args) >= 4
@@ -1402,7 +1402,7 @@ function try_resolve_finalizer!(ir::IRCode, idx::Int, finalizer_idx::Int, defuse
         insert_node!(ir, loc, with_flags(NewInstruction(Expr(:call, argexprs...), Nothing), flags), attach_after)
     end
     # Erase the call to `finalizer`
-    ir[SSAValue(finalizer_idx)][:inst] = nothing
+    ir[SSAValue(finalizer_idx)][:stmt] = nothing
     return nothing
 end
 
@@ -1423,7 +1423,7 @@ function sroa_mutables!(ir::IRCode, defuses::IdDict{Int, Tuple{SPCSet, SSADefUse
         nuses_total = used_ssas[idx] + nuses - length(intermediaries)
         nleaves == nuses_total || continue
         # Find the type for this allocation
-        defexpr = ir[SSAValue(idx)][:inst]
+        defexpr = ir[SSAValue(idx)][:stmt]
         isexpr(defexpr, :new) || continue
         newidx = idx
         typ = unwrap_unionall(ir.stmts[newidx][:type])
@@ -1456,7 +1456,7 @@ function sroa_mutables!(ir::IRCode, defuses::IdDict{Int, Tuple{SPCSet, SSADefUse
                 end
                 continue
             end
-            stmt = ir[SSAValue(use.idx)][:inst] # == `getfield`/`isdefined` call
+            stmt = ir[SSAValue(use.idx)][:stmt] # == `getfield`/`isdefined` call
             # We may have discovered above that this use is dead
             # after the getfield elim of immutables. In that case,
             # it would have been deleted. That's fine, just ignore
@@ -1470,7 +1470,7 @@ function sroa_mutables!(ir::IRCode, defuses::IdDict{Int, Tuple{SPCSet, SSADefUse
             push!(fielddefuse[field].uses, use)
         end
         for def in defuse.defs
-            stmt = ir[SSAValue(def)][:inst]::Expr # == `setfield!` call
+            stmt = ir[SSAValue(def)][:stmt]::Expr # == `setfield!` call
             field = try_compute_fieldidx_stmt(ir, stmt, typ)
             field === nothing && @goto skip
             isconst(typ, field) && @goto skip # we discovered an attempt to mutate a const field, which must error
@@ -1499,7 +1499,7 @@ function sroa_mutables!(ir::IRCode, defuses::IdDict{Int, Tuple{SPCSet, SSADefUse
                     use = du.uses[i]
                     if use.kind === :isdefined
                         if has_safe_def(ir, get!(lazydomtree), allblocks, du, newidx, use.idx)
-                            ir[SSAValue(use.idx)][:inst] = true
+                            ir[SSAValue(use.idx)][:stmt] = true
                         else
                             all_eliminated = false
                         end
@@ -1517,7 +1517,7 @@ function sroa_mutables!(ir::IRCode, defuses::IdDict{Int, Tuple{SPCSet, SSADefUse
                 for i = 1:length(du.uses)
                     use = du.uses[i]
                     if use.kind === :isdefined
-                        ir[SSAValue(use.idx)][:inst] = true
+                        ir[SSAValue(use.idx)][:stmt] = true
                     end
                 end
             end
@@ -1541,7 +1541,7 @@ function sroa_mutables!(ir::IRCode, defuses::IdDict{Int, Tuple{SPCSet, SSADefUse
                 # Now go through all uses and rewrite them
                 for use in du.uses
                     if use.kind === :getfield
-                        ir[SSAValue(use.idx)][:inst] = compute_value_for_use(ir, domtree, allblocks,
+                        ir[SSAValue(use.idx)][:stmt] = compute_value_for_use(ir, domtree, allblocks,
                             du, phinodes, fidx, use.idx)
                         ir[SSAValue(use.idx)][:flag] |= IR_FLAG_REFINED
                     elseif use.kind === :isdefined
@@ -1562,7 +1562,7 @@ function sroa_mutables!(ir::IRCode, defuses::IdDict{Int, Tuple{SPCSet, SSADefUse
                     end
                 end
                 for b in phiblocks
-                    n = ir[phinodes[b]][:inst]::PhiNode
+                    n = ir[phinodes[b]][:stmt]::PhiNode
                     result_t = Bottom
                     for p in ir.cfg.blocks[b].preds
                         push!(n.edges, p)
@@ -1582,7 +1582,7 @@ function sroa_mutables!(ir::IRCode, defuses::IdDict{Int, Tuple{SPCSet, SSADefUse
                 # verify this statement won't throw, otherwise it can't be eliminated safely
                 ssa = SSAValue(idx)
                 if is_nothrow(ir, ssa)
-                    ir[ssa][:inst] = nothing
+                    ir[ssa][:stmt] = nothing
                 else
                     # We can't eliminate this statement, because it might still
                     # throw an error, but we can mark it as effect-free since we
@@ -1602,7 +1602,7 @@ function sroa_mutables!(ir::IRCode, defuses::IdDict{Int, Tuple{SPCSet, SSADefUse
         end
         # Insert the new preserves
         for (useidx, new_preserves) in preserve_uses
-            ir[SSAValue(useidx)][:inst] = form_new_preserves(ir[SSAValue(useidx)][:inst]::Expr,
+            ir[SSAValue(useidx)][:stmt] = form_new_preserves(ir[SSAValue(useidx)][:stmt]::Expr,
                 intermediaries, new_preserves)
         end
 
@@ -1653,7 +1653,7 @@ end
 
 function adce_erase!(phi_uses::Vector{Int}, extra_worklist::Vector{Int}, compact::IncrementalCompact, idx::Int, in_worklist::Bool)
     # return whether this made a change
-    if isa(compact.result[idx][:inst], PhiNode)
+    if isa(compact.result[idx][:stmt], PhiNode)
         return maybe_erase_unused!(compact, idx, in_worklist, extra_worklist) do val::SSAValue
             phi_uses[val.id] -= 1
         end
@@ -1668,10 +1668,10 @@ function mark_phi_cycles!(compact::IncrementalCompact, safe_phis::SPCSet, phi::I
     while !isempty(worklist)
         phi = pop!(worklist)
         push!(safe_phis, phi)
-        for ur in userefs(compact.result[phi][:inst])
+        for ur in userefs(compact.result[phi][:stmt])
             val = ur[]
             isa(val, SSAValue) || continue
-            isa(compact[val][:inst], PhiNode) || continue
+            isa(compact[val][:stmt], PhiNode) || continue
             (val.id in safe_phis) && continue
             push!(worklist, val.id)
         end
@@ -1684,7 +1684,7 @@ end
 
 function is_union_phi(compact::IncrementalCompact, idx::Int)
     inst = compact.result[idx]
-    isa(inst[:inst], PhiNode) || return false
+    isa(inst[:stmt], PhiNode) || return false
     return is_some_union(inst[:type])
 end
 
@@ -1776,11 +1776,11 @@ function adce_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
     non_dce_finish!(compact)
     for phi in all_phis
         inst = compact.result[phi]
-        for ur in userefs(inst[:inst]::PhiNode)
+        for ur in userefs(inst[:stmt]::PhiNode)
             use = ur[]
             if isa(use, SSAValue)
                 phi_uses[use.id] += 1
-                stmt = compact.result[use.id][:inst]
+                stmt = compact.result[use.id][:stmt]
                 if isa(stmt, PhiNode)
                     r = searchsorted(unionphis, use.id; by=first)
                     if !isempty(r)
@@ -1798,7 +1798,7 @@ function adce_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
         phi = unionphi[1]
         t = unionphi[2]
         if t === Union{}
-            stmt = compact[SSAValue(phi)][:inst]::PhiNode
+            stmt = compact[SSAValue(phi)][:stmt]::PhiNode
             kill_phi!(compact, phi_uses, 1:length(stmt.values), SSAValue(phi), stmt, true)
             continue
         elseif t === Any
@@ -1807,7 +1807,7 @@ function adce_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
             continue
         end
         to_drop = Int[]
-        stmt = compact[SSAValue(phi)][:inst]
+        stmt = compact[SSAValue(phi)][:stmt]
         stmt === nothing && continue
         stmt = stmt::PhiNode
         for i = 1:length(stmt.values)
@@ -1860,7 +1860,7 @@ end
 function is_bb_empty(ir::IRCode, bb::BasicBlock)
     isempty(bb.stmts) && return true
     if length(bb.stmts) == 1
-        stmt = ir[SSAValue(first(bb.stmts))][:inst]
+        stmt = ir[SSAValue(first(bb.stmts))][:stmt]
         return stmt === nothing || isa(stmt, GotoNode)
     end
     return false
@@ -1874,7 +1874,7 @@ function is_legal_bb_drop(ir::IRCode, bbidx::Int, bb::BasicBlock)
     # the block.
     length(bb.stmts) == 0 && return true
     if length(bb.stmts) == 1
-        stmt = ir[SSAValue(first(bb.stmts))][:inst]
+        stmt = ir[SSAValue(first(bb.stmts))][:stmt]
         stmt === nothing && return true
         ((stmt::GotoNode).label == bbidx + 1) && return true
     end
@@ -1890,13 +1890,13 @@ function legalize_bb_drop_pred!(ir::IRCode, bb::BasicBlock, bbidx::Int, bbs::Vec
         dbi -= 1
     end
     last_fallthrough_term_ssa = SSAValue(last(bbs[last_fallthrough].stmts))
-    terminator = ir[last_fallthrough_term_ssa][:inst]
+    terminator = ir[last_fallthrough_term_ssa][:stmt]
     if isa(terminator, GotoIfNot)
         if terminator.dest != bbidx
             # The previous terminator's destination matches our fallthrough.
             # If we're also a fallthrough terminator, then we just have
             # to delete the GotoIfNot.
-            our_terminator = ir[SSAValue(last(bb.stmts))][:inst]
+            our_terminator = ir[SSAValue(last(bb.stmts))][:stmt]
             if terminator.dest != (isa(our_terminator, GotoNode) ? our_terminator.label : bbidx + 1)
                 return false
             end
@@ -1915,7 +1915,7 @@ function legalize_bb_drop_pred!(ir::IRCode, bb::BasicBlock, bbidx::Int, bbs::Vec
     return true
 end
 
-is_terminator(@nospecialize(inst)) = isa(inst, GotoNode) || isa(inst, GotoIfNot) || isexpr(inst, :enter)
+is_terminator(@nospecialize(stmt)) = isa(stmt, GotoNode) || isa(stmt, GotoIfNot) || isexpr(stmt, :enter)
 
 function cfg_simplify!(ir::IRCode)
     bbs = ir.cfg.blocks
@@ -1948,7 +1948,7 @@ function cfg_simplify!(ir::IRCode)
             if length(bbs[succ].preds) == 1 && succ != 1
                 # Can't merge blocks with :enter terminator even if they
                 # only have one successor.
-                if isexpr(ir[SSAValue(last(bb.stmts))][:inst], :enter)
+                if isexpr(ir[SSAValue(last(bb.stmts))][:stmt], :enter)
                     continue
                 end
                 # Prevent cycles by making sure we don't end up back at `idx`
@@ -1963,7 +1963,7 @@ function cfg_simplify!(ir::IRCode)
                 found_interference = false
                 preds = Int[ascend_eliminated_preds(pred) for pred in bb.preds]
                 for idx in bbs[succ].stmts
-                    stmt = ir[SSAValue(idx)][:inst]
+                    stmt = ir[SSAValue(idx)][:stmt]
                     stmt === nothing && continue
                     isa(stmt, PhiNode) || break
                     for edge in stmt.edges
@@ -2017,7 +2017,7 @@ function cfg_simplify!(ir::IRCode)
                     end
                     curr = merged_succ[curr]
                 end
-                terminator = ir.stmts[ir.cfg.blocks[curr].stmts[end]][:inst]
+                terminator = ir[SSAValue(ir.cfg.blocks[curr].stmts[end])][:stmt]
                 if isa(terminator, GotoNode) || isa(terminator, ReturnNode)
                     break
                 elseif isa(terminator, GotoIfNot)
@@ -2184,9 +2184,9 @@ function cfg_simplify!(ir::IRCode)
         if new_bb.succs[1] == new_bb.succs[2]
             old_bb2 = findfirst(x::Int->x==bbidx, bb_rename_pred)
             terminator = ir[SSAValue(last(bbs[old_bb2].stmts))]
-            @assert terminator[:inst] isa GotoIfNot
+            @assert terminator[:stmt] isa GotoIfNot
             # N.B.: The dest will be renamed in process_node! below
-            terminator[:inst] = GotoNode(terminator[:inst].dest)
+            terminator[:stmt] = GotoNode(terminator[:stmt].dest)
             pop!(new_bb.succs)
             new_succ = cresult_bbs[new_bb.succs[1]]
             for (i, nsp) in enumerate(new_succ.preds)
@@ -2210,11 +2210,11 @@ function cfg_simplify!(ir::IRCode)
             for i in bbs[ms].stmts
                 node = ir.stmts[i]
                 compact.result[compact.result_idx] = node
-                if isa(node[:inst], GotoNode) && merged_succ[ms] != 0
+                if isa(node[:stmt], GotoNode) && merged_succ[ms] != 0
                     # If we merged a basic block, we need remove the trailing GotoNode (if any)
-                    compact.result[compact.result_idx][:inst] = nothing
-                elseif isa(node[:inst], PhiNode)
-                    phi = node[:inst]
+                    compact.result[compact.result_idx][:stmt] = nothing
+                elseif isa(node[:stmt], PhiNode)
+                    phi = node[:stmt]
                     values = phi.values
                     (; ssa_rename, late_fixup, used_ssas, new_new_used_ssas) = compact
                     ssa_rename[i] = SSAValue(compact.result_idx)
@@ -2265,19 +2265,19 @@ function cfg_simplify!(ir::IRCode)
                         end
                     end
                     if length(edges) == 0 || (length(edges) == 1 && !isassigned(values, 1))
-                        compact.result[compact.result_idx][:inst] = nothing
+                        compact.result[compact.result_idx][:stmt] = nothing
                     elseif length(edges) == 1 && !bb_start
-                        compact.result[compact.result_idx][:inst] = values[1]
+                        compact.result[compact.result_idx][:stmt] = values[1]
                     else
                         @assert bb_start
-                        compact.result[compact.result_idx][:inst] = PhiNode(edges, values)
+                        compact.result[compact.result_idx][:stmt] = PhiNode(edges, values)
                     end
                 else
                     ri = process_node!(compact, compact.result_idx, node, i, i, ms, true)
                     if ri == compact.result_idx
                         # process_node! wanted this statement dropped. We don't do this,
                         # but we still need to erase the node
-                        compact.result[compact.result_idx][:inst] = nothing
+                        compact.result[compact.result_idx][:stmt] = nothing
                     end
                 end
                 # We always increase the result index to ensure a predicatable

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -542,11 +542,11 @@ end
 
 function _stmt(code::IRCode, idx::Int)
     stmts = code.stmts
-    return isassigned(stmts.inst, idx) ? stmts[idx][:inst] : UNDEF
+    return isassigned(stmts.stmt, idx) ? stmts[idx][:stmt] : UNDEF
 end
 function _stmt(compact::IncrementalCompact, idx::Int)
     stmts = compact.result
-    return isassigned(stmts.inst, idx) ? stmts[idx][:inst] : UNDEF
+    return isassigned(stmts.stmt, idx) ? stmts[idx][:stmt] : UNDEF
 end
 function _stmt(code::CodeInfo, idx::Int)
     code = code.code
@@ -717,7 +717,7 @@ function show_ir_stmt(io::IO, code::Union{IRCode, CodeInfo, IncrementalCompact},
 end
 
 function _new_nodes_iter(stmts, new_nodes, new_nodes_info, new_nodes_idx)
-    new_nodes_perm = filter(i -> isassigned(new_nodes.inst, i), 1:length(new_nodes))
+    new_nodes_perm = filter(i -> isassigned(new_nodes.stmt, i), 1:length(new_nodes))
     sort!(new_nodes_perm, by = x -> (x = new_nodes_info[x]; (x.pos, x.attach_after)))
 
     # separate iterators for the nodes that are inserted before resp. after each statement
@@ -745,7 +745,7 @@ function _new_nodes_iter(stmts, new_nodes, new_nodes_info, new_nodes_idx)
 
         iter[] += 1
         new_node = new_nodes[node_idx]
-        new_node_inst = isassigned(new_nodes.inst, node_idx) ? new_node[:inst] : UNDEF
+        new_node_inst = isassigned(new_nodes.stmt, node_idx) ? new_node[:stmt] : UNDEF
         new_node_type = isassigned(new_nodes.type, node_idx) ? new_node[:type] : UNDEF
         node_idx += length(stmts)
         return node_idx, new_node_inst, new_node_type
@@ -820,15 +820,15 @@ end
 statementidx_lineinfo_printer(code) = statementidx_lineinfo_printer(DILineInfoPrinter, code)
 
 function stmts_used(io::IO, code::IRCode, warn_unset_entry=true)
-    stmts = code.stmts
+    insts = code.stmts
     used = BitSet()
-    for stmt in stmts
-        scan_ssa_use!(push!, used, stmt[:inst])
+    for inst in insts
+        scan_ssa_use!(push!, used, inst[:stmt])
     end
     new_nodes = code.new_nodes.stmts
     for nn in 1:length(new_nodes)
-        if isassigned(new_nodes.inst, nn)
-            scan_ssa_use!(push!, used, new_nodes[nn][:inst])
+        if isassigned(new_nodes.stmt, nn)
+            scan_ssa_use!(push!, used, new_nodes[nn][:stmt])
         elseif warn_unset_entry
             printstyled(io, "ERROR: New node array has unset entry\n", color=:red)
             warn_unset_entry = false

--- a/base/opaque_closure.jl
+++ b/base/opaque_closure.jl
@@ -26,13 +26,13 @@ macro opaque(ty, ex)
 end
 
 # OpaqueClosure construction from pre-inferred CodeInfo/IRCode
-using Core.Compiler: IRCode
+using Core.Compiler: IRCode, SSAValue
 using Core: CodeInfo
 
 function compute_ir_rettype(ir::IRCode)
     rt = Union{}
     for i = 1:length(ir.stmts)
-        stmt = ir.stmts[i][:inst]
+        stmt = ir[SSAValue(i)][:stmt]
         if isa(stmt, Core.Compiler.ReturnNode) && isdefined(stmt, :val)
             rt = Core.Compiler.tmerge(Core.Compiler.argextype(stmt.val, ir), rt)
         end

--- a/base/show.jl
+++ b/base/show.jl
@@ -2775,6 +2775,7 @@ module IRShow
     Base.iterate(is::Compiler.InstructionStream, st::Int=1) = (st <= Compiler.length(is)) ? (is[st], st + 1) : nothing
     Base.getindex(is::Compiler.InstructionStream, idx::Int) = Compiler.getindex(is, idx)
     Base.getindex(node::Compiler.Instruction, fld::Symbol) = Compiler.getindex(node, fld)
+    Base.getindex(ir::IRCode, ssa::SSAValue) = Compiler.getindex(ir, ssa)
     include("compiler/ssair/show.jl")
 
     const __debuginfo = Dict{Symbol, Any}(

--- a/test/compiler/EscapeAnalysis/interprocedural.jl
+++ b/test/compiler/EscapeAnalysis/interprocedural.jl
@@ -36,13 +36,13 @@ end
 let result = code_escapes((SafeRef{String},); optimize=false) do x
         return identity(x)
     end
-    r = only(findall(isreturn, result.ir.stmts.inst))
+    r = only(findall(isreturn, result.ir.stmts.stmt))
     @test has_return_escape(result.state[Argument(2)], r)
 end
 let result = code_escapes((SafeRef{String},); optimize=false) do x
         return Ref(x)
     end
-    r = only(findall(isreturn, result.ir.stmts.inst))
+    r = only(findall(isreturn, result.ir.stmts.stmt))
     @test has_return_escape(result.state[Argument(2)], r)
 end
 let result = code_escapes((SafeRef{String},); optimize=false) do x
@@ -50,7 +50,7 @@ let result = code_escapes((SafeRef{String},); optimize=false) do x
         r[] = x
         return r
     end
-    r = only(findall(isreturn, result.ir.stmts.inst))
+    r = only(findall(isreturn, result.ir.stmts.stmt))
     @test has_return_escape(result.state[Argument(2)], r)
 end
 let result = code_escapes((SafeRef{String},); optimize=false) do x
@@ -104,8 +104,8 @@ end
 let result = code_escapes((Union{SafeRef{String},Vector{String}},); optimize=false) do x
         identity_if_string(x)
     end
-    i = only(findall(iscall((result.ir, identity_if_string)), result.ir.stmts.inst))
-    r = only(findall(isreturn, result.ir.stmts.inst))
+    i = only(findall(iscall((result.ir, identity_if_string)), result.ir.stmts.stmt))
+    r = only(findall(isreturn, result.ir.stmts.stmt))
     @test has_thrown_escape(result.state[Argument(2)], i)
     @test !has_return_escape(result.state[Argument(2)], r)
 end
@@ -136,8 +136,8 @@ ambig_error_test(a, b) = nothing
 let result = code_escapes((SafeRef{String},Any); optimize=false) do x, y
         ambig_error_test(x, y)
     end
-    i = only(findall(iscall((result.ir, ambig_error_test)), result.ir.stmts.inst))
-    r = only(findall(isreturn, result.ir.stmts.inst))
+    i = only(findall(iscall((result.ir, ambig_error_test)), result.ir.stmts.stmt))
+    r = only(findall(isreturn, result.ir.stmts.stmt))
     @test has_thrown_escape(result.state[Argument(2)], i)  # x
     @test has_thrown_escape(result.state[Argument(3)], i)  # y
     @test !has_return_escape(result.state[Argument(2)], r)  # x
@@ -168,7 +168,7 @@ end
 let result = code_escapes() do
         broadcast_noescape1(Ref("Hi"))
     end
-    i = only(findall(isnew, result.ir.stmts.inst))
+    i = only(findall(isnew, result.ir.stmts.stmt))
     @test_broken !has_return_escape(result.state[SSAValue(i)])
     @test_broken !has_thrown_escape(result.state[SSAValue(i)])
 end
@@ -176,7 +176,7 @@ end
 let result = code_escapes() do
         broadcast_noescape2(Ref("Hi"))
     end
-    i = only(findall(isnew, result.ir.stmts.inst))
+    i = only(findall(isnew, result.ir.stmts.stmt))
     @test_broken !has_return_escape(result.state[SSAValue(i)])
     @test_broken !has_thrown_escape(result.state[SSAValue(i)])
 end
@@ -184,7 +184,7 @@ end
 let result = code_escapes() do
         allescape_argument(Ref("Hi"))
     end
-    i = only(findall(isnew, result.ir.stmts.inst))
+    i = only(findall(isnew, result.ir.stmts.stmt))
     @test has_all_escape(result.state[SSAValue(i)])
 end
 # if we can't determine the matching method statically, we should be conservative
@@ -207,7 +207,7 @@ let result = code_escapes((Union{Int,Nothing},)) do x
         unionsplit_noescape(s[])
         return nothing
     end
-    inds = findall(isnew, result.ir.stmts.inst) # find allocation statement
+    inds = findall(isnew, result.ir.stmts.stmt) # find allocation statement
     @assert !isempty(inds)
     for i in inds
         @test has_no_escape(result.state[SSAValue(i)])
@@ -223,8 +223,8 @@ let result = code_escapes() do
         b = unused_argument(a)
         nothing
     end
-    i = only(findall(isnew, result.ir.stmts.inst))
-    r = only(findall(isreturn, result.ir.stmts.inst))
+    i = only(findall(isnew, result.ir.stmts.stmt))
+    r = only(findall(isreturn, result.ir.stmts.stmt))
     @test !has_return_escape(result.state[SSAValue(i)], r)
 
     result = code_escapes() do
@@ -232,8 +232,8 @@ let result = code_escapes() do
         b = unused_argument(a)
         return a
     end
-    i = only(findall(isnew, result.ir.stmts.inst))
-    r = only(findall(isreturn, result.ir.stmts.inst))
+    i = only(findall(isnew, result.ir.stmts.stmt))
+    r = only(findall(isreturn, result.ir.stmts.stmt))
     @test has_return_escape(result.state[SSAValue(i)], r)
 end
 
@@ -244,8 +244,8 @@ let result = code_escapes() do
         ret = returnescape_argument(obj)
         return ret                 # alias of `obj`
     end
-    i = only(findall(isnew, result.ir.stmts.inst))
-    r = only(findall(isreturn, result.ir.stmts.inst))
+    i = only(findall(isnew, result.ir.stmts.stmt))
+    r = only(findall(isreturn, result.ir.stmts.stmt))
     @test has_return_escape(result.state[SSAValue(i)], r)
 end
 @noinline noreturnescape_argument(a) = (println("prevent inlining"); identity("hi"))
@@ -254,7 +254,7 @@ let result = code_escapes() do
         ret = noreturnescape_argument(obj)
         return ret                    # must not alias to `obj`
     end
-    i = only(findall(isnew, result.ir.stmts.inst))
-    r = only(findall(isreturn, result.ir.stmts.inst))
+    i = only(findall(isnew, result.ir.stmts.stmt))
+    r = only(findall(isreturn, result.ir.stmts.stmt))
     @test !has_return_escape(result.state[SSAValue(i)], r)
 end

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -1770,15 +1770,15 @@ let interp = Core.Compiler.NativeInterpreter()
     ir, = Base.code_ircode((Int,Int); optimize_until="inlining", interp) do a, b
         @noinline a*b
     end |> only
-    i = findfirst(isinvoke(:*), ir.stmts.inst)
+    i = findfirst(isinvoke(:*), ir.stmts.stmt)
     @test i !== nothing
 
     # ok, now delete the callsite flag, and see the second inlining pass can inline the call
     @eval Core.Compiler $ir.stmts[$i][:flag] &= ~IR_FLAG_NOINLINE
     inlining = Core.Compiler.InliningState(interp)
     ir = Core.Compiler.ssa_inlining_pass!(ir, inlining, false)
-    @test count(isinvoke(:*), ir.stmts.inst) == 0
-    @test count(iscall((ir, Core.Intrinsics.mul_int)), ir.stmts.inst) == 1
+    @test count(isinvoke(:*), ir.stmts.stmt) == 0
+    @test count(iscall((ir, Core.Intrinsics.mul_int)), ir.stmts.stmt) == 1
 end
 
 # Test special purpose inliner for Core.ifelse

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -42,7 +42,7 @@ let m = Meta.@lower 1 + 1
     domtree = Core.Compiler.construct_domtree(ir.cfg.blocks)
     ir = Core.Compiler.domsort_ssa!(ir, domtree)
     Core.Compiler.verify_ir(ir)
-    phi = ir.stmts.inst[3]
+    phi = ir.stmts.stmt[3]
     @test isa(phi, Core.PhiNode) && length(phi.edges) == 1
 end
 
@@ -838,12 +838,12 @@ end
 
 # Test cfg_simplify in complicated sequences of dropped and merged bbs
 using Core.Compiler: Argument, IRCode, GotoNode, GotoIfNot, ReturnNode, NoCallInfo, BasicBlock, StmtRange, SSAValue
-bb_term(ir, bb) = Core.Compiler.getindex(ir, SSAValue(Core.Compiler.last(ir.cfg.blocks[bb].stmts)))[:inst]
+bb_term(ir, bb) = Core.Compiler.getindex(ir, SSAValue(Core.Compiler.last(ir.cfg.blocks[bb].stmts)))[:stmt]
 
 function each_stmt_a_bb(stmts, preds, succs)
     ir = IRCode()
-    empty!(ir.stmts.inst)
-    append!(ir.stmts.inst, stmts)
+    empty!(ir.stmts.stmt)
+    append!(ir.stmts.stmt, stmts)
     empty!(ir.stmts.type); append!(ir.stmts.type, [Nothing for _ = 1:length(stmts)])
     empty!(ir.stmts.flag); append!(ir.stmts.flag, [0x0 for _ = 1:length(stmts)])
     empty!(ir.stmts.line); append!(ir.stmts.line, [Int32(0) for _ = 1:length(stmts)])
@@ -949,7 +949,7 @@ let m = Meta.@lower 1 + 1
     ir = Core.Compiler.cfg_simplify!(ir)
     Core.Compiler.verify_ir(ir)
     @test length(ir.cfg.blocks) == 5
-    ret_2 = ir.stmts.inst[ir.cfg.blocks[3].stmts[end]]
+    ret_2 = ir.stmts.stmt[ir.cfg.blocks[3].stmts[end]]
     @test isa(ret_2, Core.Compiler.ReturnNode) && ret_2.val == 2
 end
 
@@ -1195,9 +1195,9 @@ let ci = code_typed1(optimize=false) do
         end
     end
     ir = Core.Compiler.inflate_ir(ci)
-    @test count(@nospecialize(stmt)->isa(stmt, Core.GotoIfNot), ir.stmts.inst) == 1
+    @test count(@nospecialize(stmt)->isa(stmt, Core.GotoIfNot), ir.stmts.stmt) == 1
     ir = Core.Compiler.compact!(ir, true)
-    @test count(@nospecialize(stmt)->isa(stmt, Core.GotoIfNot), ir.stmts.inst) == 0
+    @test count(@nospecialize(stmt)->isa(stmt, Core.GotoIfNot), ir.stmts.stmt) == 0
 end
 
 # Test that adce_pass! can drop phi node uses that can be concluded unused
@@ -1233,7 +1233,7 @@ let ci = code_typed(foo_cfg_empty, Tuple{Bool}, optimize=true)[1][1]
     ir = Core.Compiler.cfg_simplify!(ir)
     Core.Compiler.verify_ir(ir)
     @test length(ir.cfg.blocks) <= 2
-    @test isa(ir.stmts[length(ir.stmts)][:inst], ReturnNode)
+    @test isa(ir.stmts[length(ir.stmts)][:stmt], ReturnNode)
 end
 
 @test Core.Compiler.is_effect_free(Base.infer_effects(getfield, (Complex{Int}, Symbol)))

--- a/test/compiler/irutils.jl
+++ b/test/compiler/irutils.jl
@@ -40,7 +40,7 @@ isinvoke(pred::Function, @nospecialize(x)) = isexpr(x, :invoke) && pred(x.args[1
 fully_eliminated(@nospecialize args...; retval=(@__FILE__), kwargs...) =
     fully_eliminated(code_typed1(args...; kwargs...); retval)
 fully_eliminated(src::CodeInfo; retval=(@__FILE__)) = fully_eliminated(src.code; retval)
-fully_eliminated(ir::IRCode; retval=(@__FILE__)) = fully_eliminated(ir.stmts.inst; retval)
+fully_eliminated(ir::IRCode; retval=(@__FILE__)) = fully_eliminated(ir.stmts.stmt; retval)
 function fully_eliminated(code::Vector{Any}; retval=(@__FILE__), kwargs...)
     if retval !== (@__FILE__)
         length(code) == 1 || return false

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -454,7 +454,7 @@ let ir = Base.code_ircode((Bool,Any)) do c, x
     @test length(ir.cfg.blocks) == 4
     for i = 1:4
         @test any(ir.cfg.blocks[i].stmts) do j
-            inst = ir.stmts[j][:inst]
+            inst = ir.stmts[j][:stmt]
             iscall((ir, println), inst) &&
             inst.args[3] == i
         end
@@ -494,12 +494,12 @@ end
 
     # get the addition instruction
     add_stmt = ir.stmts[1]
-    @test Meta.isexpr(add_stmt[:inst], :call) && add_stmt[:inst].args[3] == 42
+    @test Meta.isexpr(add_stmt[:stmt], :call) && add_stmt[:stmt].args[3] == 42
 
     # replace the addition with a slightly different one
-    inst = Core.Compiler.NewInstruction(Expr(:call, add_stmt[:inst].args[1], add_stmt[:inst].args[2], 999), Int)
+    inst = Core.Compiler.NewInstruction(Expr(:call, add_stmt[:stmt].args[1], add_stmt[:stmt].args[2], 999), Int)
     node = Core.Compiler.insert_node!(ir, 1, inst)
-    Core.Compiler.setindex!(add_stmt, node, :inst)
+    Core.Compiler.setindex!(add_stmt, node, :stmt)
 
     # perform compaction (not by calling compact! because with DCE the bug doesn't trigger)
     compact = Core.Compiler.IncrementalCompact(ir)
@@ -550,18 +550,18 @@ let ir = Base.code_ircode((Int,Int); optimize_until="inlining") do a, b
         a^b
     end |> only |> first
     @test length(ir.stmts) == 2
-    @test Meta.isexpr(ir.stmts[1][:inst], :invoke)
+    @test Meta.isexpr(ir.stmts[1][:stmt], :invoke)
 
     newssa = insert_node!(ir, SSAValue(1), NewInstruction(Expr(:call, println, SSAValue(1)), Nothing), #=attach_after=#true)
     newssa = insert_node!(ir, newssa, NewInstruction(Expr(:call, println, newssa), Nothing), #=attach_after=#true)
 
     ir = Core.Compiler.compact!(ir)
     @test length(ir.stmts) == 4
-    @test Meta.isexpr(ir.stmts[1][:inst], :invoke)
-    call1 = ir.stmts[2][:inst]
+    @test Meta.isexpr(ir.stmts[1][:stmt], :invoke)
+    call1 = ir.stmts[2][:stmt]
     @test iscall((ir,println), call1)
     @test call1.args[2] === SSAValue(1)
-    call2 = ir.stmts[3][:inst]
+    call2 = ir.stmts[3][:stmt]
     @test iscall((ir,println), call2)
     @test call2.args[2] === SSAValue(2)
 end
@@ -607,11 +607,11 @@ end
 let ir = Base.code_ircode((Int,Int); optimize_until="inlining") do a, b
         a^b
     end |> only |> first
-    invoke_idx = findfirst(ir.stmts.inst) do @nospecialize(x)
+    invoke_idx = findfirst(ir.stmts.stmt) do @nospecialize(x)
         Meta.isexpr(x, :invoke)
     end
     @test invoke_idx !== nothing
-    invoke_expr = ir.stmts.inst[invoke_idx]
+    invoke_expr = ir.stmts.stmt[invoke_idx]
 
     # effect-ful node
     let compact = Core.Compiler.IncrementalCompact(Core.Compiler.copy(ir))
@@ -621,11 +621,11 @@ let ir = Base.code_ircode((Int,Int); optimize_until="inlining") do a, b
             state = Core.Compiler.iterate(compact, state[2])
         end
         ir = Core.Compiler.finish(compact)
-        new_invoke_idx = findfirst(ir.stmts.inst) do @nospecialize(x)
+        new_invoke_idx = findfirst(ir.stmts.stmt) do @nospecialize(x)
             x == invoke_expr
         end
         @test new_invoke_idx !== nothing
-        new_call_idx = findfirst(ir.stmts.inst) do @nospecialize(x)
+        new_call_idx = findfirst(ir.stmts.stmt) do @nospecialize(x)
             iscall((ir,println), x) && x.args[2] === SSAValue(invoke_idx)
         end
         @test new_call_idx !== nothing
@@ -642,11 +642,11 @@ let ir = Base.code_ircode((Int,Int); optimize_until="inlining") do a, b
         ir = Core.Compiler.finish(compact)
 
         ir = Core.Compiler.finish(compact)
-        new_invoke_idx = findfirst(ir.stmts.inst) do @nospecialize(x)
+        new_invoke_idx = findfirst(ir.stmts.stmt) do @nospecialize(x)
             x == invoke_expr
         end
         @test new_invoke_idx !== nothing
-        new_call_idx = findfirst(ir.stmts.inst) do @nospecialize(x)
+        new_call_idx = findfirst(ir.stmts.stmt) do @nospecialize(x)
             iscall((ir,Base.add_int), x) && x.args[2] === SSAValue(invoke_idx)
         end
         @test new_call_idx === nothing # should be deleted during the compaction

--- a/test/show.jl
+++ b/test/show.jl
@@ -2059,8 +2059,8 @@ let src = code_typed(my_fun28173, (Int,), debuginfo=:source)[1][1]
     @test all(isspace, pop!(lines1))
     Core.Compiler.insert_node!(ir, 1, Core.Compiler.NewInstruction(QuoteNode(1), Val{1}), false)
     Core.Compiler.insert_node!(ir, 1, Core.Compiler.NewInstruction(QuoteNode(2), Val{2}), true)
-    Core.Compiler.insert_node!(ir, length(ir.stmts.inst), Core.Compiler.NewInstruction(QuoteNode(3), Val{3}), false)
-    Core.Compiler.insert_node!(ir, length(ir.stmts.inst), Core.Compiler.NewInstruction(QuoteNode(4), Val{4}), true)
+    Core.Compiler.insert_node!(ir, length(ir.stmts.stmt), Core.Compiler.NewInstruction(QuoteNode(3), Val{3}), false)
+    Core.Compiler.insert_node!(ir, length(ir.stmts.stmt), Core.Compiler.NewInstruction(QuoteNode(4), Val{4}), true)
     lines2 = split(repr(ir), '\n')
     @test all(isspace, pop!(lines2))
     @test popfirst!(lines2) == "2  1 ──       $(QuoteNode(1))"
@@ -2096,7 +2096,7 @@ end
 # with as unnamed "!" BB.
 let src = code_typed(gcd, (Int, Int), debuginfo=:source)[1][1]
     ir = Core.Compiler.inflate_ir(src)
-    push!(ir.stmts.inst, Core.Compiler.ReturnNode())
+    push!(ir.stmts.stmt, Core.Compiler.ReturnNode())
     lines = split(sprint(show, ir), '\n')
     @test all(isspace, pop!(lines))
     @test pop!(lines) == "   !!! ──       unreachable::#UNDEF"
@@ -2458,9 +2458,9 @@ end
 
     # replace an instruction
     add_stmt = ir.stmts[1]
-    inst = Core.Compiler.NewInstruction(Expr(:call, add_stmt[:inst].args[1], add_stmt[:inst].args[2], 999), Int)
+    inst = Core.Compiler.NewInstruction(Expr(:call, add_stmt[:stmt].args[1], add_stmt[:stmt].args[2], 999), Int)
     node = Core.Compiler.insert_node!(ir, 1, inst)
-    Core.Compiler.setindex!(add_stmt, node, :inst)
+    Core.Compiler.setindex!(add_stmt, node, :stmt)
 
     # the new node should be colored green (as it's uncompacted IR),
     # and its uses shouldn't be colored at all (since they're just plain valid references)
@@ -2471,7 +2471,7 @@ end
     @test contains(str, "%1 = %6")
 
     # if we insert an invalid node, it should be colored appropriately
-    Core.Compiler.setindex!(add_stmt, Core.Compiler.SSAValue(node.id+1), :inst)
+    Core.Compiler.setindex!(add_stmt, Core.Compiler.SSAValue(node.id+1), :stmt)
     str = sprint(; context=:color=>true) do io
         show(io, ir)
     end


### PR DESCRIPTION
As discussed in #49057, this renames the :inst field of `Instruction` to `:stmt` (`:inst` is still allowed for the moment to ease transition for out-of-tree users). I'm hoping to get through some more compiler datastructure cleanup in the 1.11 timeframe, but this is probably one of the larger ones in terms of number of lines affected.