### PR TITLE
macOS: Don't inspect dead threadtls during exception handling.

### DIFF
--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -279,12 +279,16 @@ kern_return_t catch_mach_exception_raise(
     int nthreads = jl_atomic_load_acquire(&jl_n_threads);
     for (tid = 0; tid < nthreads; tid++) {
         jl_ptls_t _ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
+        if (_ptls2->current_task == NULL) {
+            // this thread is dead
+            continue;
+        }
         if (pthread_mach_thread_np(_ptls2->system_id) == thread) {
             ptls2 = _ptls2;
             break;
         }
     }
-    if (!ptls2 || ptls2->current_task == NULL) {
+    if (!ptls2) {
         // We don't know about this thread, let the kernel try another handler
         // instead. This shouldn't actually happen since we only register the
         // handler for the threads we know about.

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -279,7 +279,7 @@ kern_return_t catch_mach_exception_raise(
     int nthreads = jl_atomic_load_acquire(&jl_n_threads);
     for (tid = 0; tid < nthreads; tid++) {
         jl_ptls_t _ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[tid];
-        if (_ptls2->current_task == NULL) {
+        if (jl_atomic_load_relaxed(&_ptls2->current_task) == NULL) {
             // this thread is dead
             continue;
         }


### PR DESCRIPTION
Otherwise we may end up with the state of a dead thread, as the system IDs can alias. This can lead to an early return from the exception handler, resulting in e.g. safepoint exceptions being actually delivered to user code.

Alternative to https://github.com/JuliaLang/julia/pull/50747, closes https://github.com/JuliaGPU/Metal.jl/issues/225.