### PR TITLE
remove `string("a", 'b')` regression. This shouldn't work

### DIFF
--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -226,7 +226,7 @@ end
 
 string(a::Union{Char, String, SubString{String}, Symbol}...) = _string(a...)
 
-function _string(a::Union{Char, String, SubString{String}, Symbol}...)
+function _string(a...)
     n = 0
     for v in a
         # 4 types is too many for automatic Union-splitting, so we split manually


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/50458, https://github.com/JuliaLang/julia/issues/49249 but I have no idea why.
Before:
```
@btime string("a", 'b')
  246.945 ns (6 allocations: 184 bytes)
```
After:
```
@btime string("a", 'b')
18.195 ns (1 allocation: 24 bytes)
```
Can anyone explain this? It feels like a compiler bug to me.