### PR TITLE
Add missing latex symbols `\Mu` and `\Nu`

### DIFF
--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -2673,4 +2673,6 @@ const symbols_latex_canonical = Dict(
     "⊼" => "\\nand",
     "⊽" => "\\nor",
     "≠" => "\\ne",
+    "Μ" => "\\Mu",
+    "Ν" => "\\Nu",
 )

--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -119,6 +119,10 @@ const latex_symbols = Dict(
     "\\euler" => "ℯ",
     "\\ohm" => "Ω",
 
+    # Greek letters
+    "\\Mu" => "Μ",
+    "\\Nu" => "Ν",
+
     # Superscripts
     "\\^0" => "⁰",
     "\\^1" => "¹",

--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -122,6 +122,7 @@ const latex_symbols = Dict(
     # Greek letters
     "\\Mu" => "Μ",
     "\\Nu" => "Ν",
+    "\\Omicron" => "Ο",
 
     # Superscripts
     "\\^0" => "⁰",
@@ -2675,4 +2676,5 @@ const symbols_latex_canonical = Dict(
     "≠" => "\\ne",
     "Μ" => "\\Mu",
     "Ν" => "\\Nu",
+    "Ο" => "\\Omicron",
 )


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/50911.