### PR TITLE
Code loading: do the "skipping mtime check for stdlib" check regardless of the value of `ispath(f)`

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3118,20 +3118,16 @@ end
             for chi in includes
                 f, ftime_req = chi.filename, chi.mtime
                 if ispath(f)
-                    # `ispath(f)` is true
-                    if isfile(f) && startswith(f, Sys.STDLIB)
-                        # mtime is changed by extraction
-                        @debug "Skipping mtime check for file $f used by $cachefile, since it is a stdlib"
-                        continue
-                    end
+                    _f = f
                 else
-                    # `ispath(f)` is false
                     _f = fixup_stdlib_path(f)
-                    if isfile(_f) && startswith(_f, Sys.STDLIB)
-                        # mtime is changed by extraction
-                        @debug "Skipping mtime check for file $f used by $cachefile, since it is a stdlib"
-                        continue
-                    end
+                end
+                if isfile(_f) && startswith(_f, Sys.STDLIB)
+                    # mtime is changed by extraction
+                    @debug "Skipping mtime check for file $f used by $cachefile, since it is a stdlib"
+                    continue
+                end
+                if !ispath(f)
                     @debug "Rejecting stale cache file $cachefile because file $f does not exist"
                     return true
                 end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3117,7 +3117,15 @@ end
             end
             for chi in includes
                 f, ftime_req = chi.filename, chi.mtime
-                if !ispath(f)
+                if ispath(f)
+                    # `ispath(f)` is true
+                    if isfile(f) && startswith(f, Sys.STDLIB)
+                        # mtime is changed by extraction
+                        @debug "Skipping mtime check for file $f used by $cachefile, since it is a stdlib"
+                        continue
+                    end
+                else
+                    # `ispath(f)` is false
                     _f = fixup_stdlib_path(f)
                     if isfile(_f) && startswith(_f, Sys.STDLIB)
                         # mtime is changed by extraction

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3117,7 +3117,8 @@ end
             end
             for chi in includes
                 f, ftime_req = chi.filename, chi.mtime
-                if ispath(f)
+                f_ispath = ispath(f)
+                if f_ispath
                     _f = f
                 else
                     _f = fixup_stdlib_path(f)
@@ -3126,10 +3127,10 @@ end
                     # mtime is changed by extraction
                     # Note: we intentionally include the value of `ispath(f)` in the following debug message,
                     # to help debug which branch we went down.
-                    @debug "Skipping mtime check for file $f used by $cachefile, since it is a stdlib" ispath(f)
+                    @debug "Skipping mtime check for file $f used by $cachefile, since it is a stdlib" f_ispath
                     continue
                 end
-                if !ispath(f)
+                if !f_ispath
                     @debug "Rejecting stale cache file $cachefile because file $f does not exist"
                     return true
                 end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3124,7 +3124,7 @@ end
                 end
                 if isfile(_f) && startswith(_f, Sys.STDLIB)
                     # mtime is changed by extraction
-                    @debug "Skipping mtime check for file $f used by $cachefile, since it is a stdlib"
+                    @debug "Skipping mtime check for file $f used by $cachefile, since it is a stdlib" ispath(f)
                     continue
                 end
                 if !ispath(f)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3124,6 +3124,8 @@ end
                 end
                 if isfile(_f) && startswith(_f, Sys.STDLIB)
                     # mtime is changed by extraction
+                    # Note: we intentionally include the value of `ispath(f)` in the following debug message,
+                    # to help debug which branch we went down.
                     @debug "Skipping mtime check for file $f used by $cachefile, since it is a stdlib" ispath(f)
                     continue
                 end


### PR DESCRIPTION
Fixes #50918