### PR TITLE
Change heap-size-hint in test processes to total memory

### DIFF
--- a/test/testenv.jl
+++ b/test/testenv.jl
@@ -38,7 +38,7 @@ if !@isdefined(testenv_defined)
     function addprocs_with_testenv(X; rr_allowed=true, kwargs...)
         exename = rr_allowed ? `$rr_exename $test_exename` : test_exename
         if X isa Integer
-            heap_size=round(Int,(Sys.free_memory()/(1024^2)/(X+1)))
+            heap_size=round(Int,(Sys.total_memory()/(1024^2)/(X+1)))
             push!(test_exeflags.exec, "--heap-size-hint=$(heap_size)M")
         end
         addprocs(X; exename=exename, exeflags=test_exeflags, kwargs...)


### PR DESCRIPTION
It seems this is causing macos to hang because the shown free memory is generally very small.

This is a version of https://github.com/JuliaLang/julia/issues/50673 