### PR TITLE
Make PrecompileTools into a stdlib

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,7 @@ Standard library changes
 ------------------------
 
 * `pmap` now defaults to using a `CachingPool` ([#33892]).
+* [PrecompileTools](https://github.com/JuliaLang/PrecompileTools.jl) is now an upgradable standard library ([#50923]).
 
 #### Package Manager
 

--- a/pkgimage.mk
+++ b/pkgimage.mk
@@ -27,7 +27,7 @@ STDLIBS := ArgTools Artifacts Base64 CRC32c FileWatching Libdl NetworkOptions SH
 		   Zlib_jll dSFMT_jll libLLVM_jll libblastrampoline_jll OpenBLAS_jll Printf Random Tar \
 		   LibSSH2_jll MPFR_jll LinearAlgebra Dates Distributed Future LibGit2 Profile SparseArrays UUIDs \
 		   SharedArrays TOML Test LibCURL Downloads Pkg Dates LazyArtifacts Sockets Unicode Markdown \
-		   InteractiveUtils REPL DelimitedFiles
+		   InteractiveUtils REPL DelimitedFiles PrecompileTools
 
 all-release: $(addprefix cache-release-, $(STDLIBS))
 all-debug:   $(addprefix cache-debug-, $(STDLIBS))
@@ -97,6 +97,7 @@ $(eval $(call sysimg_builder,Printf,Unicode))
 $(eval $(call sysimg_builder,Random,SHA))
 $(eval $(call sysimg_builder,Tar,ArgTools,SHA))
 $(eval $(call pkgimg_builder,DelimitedFiles,Mmap))
+$(eval $(call pkgimg_builder,PrecompileTools,Preferences))
 
 # 2-depth packages
 $(eval $(call pkgimg_builder,LLD_jll,Zlib_jll libLLVM_jll Artifacts Libdl))

--- a/stdlib/.gitignore
+++ b/stdlib/.gitignore
@@ -1,6 +1,8 @@
 /srccache
 /DelimitedFiles-*
 /DelimitedFiles
+/PrecompileTools-*
+/PrecompileTools
 /Pkg-*
 /Pkg
 /Statistics-*

--- a/stdlib/PrecompileTools.version
+++ b/stdlib/PrecompileTools.version
@@ -1,0 +1,4 @@
+PRECOMPILETOOLS_BRANCH = main
+PRECOMPILETOOLS_SHA1 = 11410b2970041907c2396d374ad7893d6f89a118
+PRECOMPILETOOLS_GIT_URL := https://github.com/JuliaLang/PrecompileTools.jl
+PRECOMPILETOOLS_TAR_URL = https://github.com/JuliaLang/PrecompileTools.jl/tarball/$1


### PR DESCRIPTION
This makes PrecompileTools an upgradable stdlib.
While it will still live in its own repository, this allows
it to be used by other stdlibs to lower their TTFX
when they migrate out.