### PR TITLE
Optimizer: Re-use CFG from type inference

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -551,9 +551,9 @@ function finish(me::InferenceState, interp::AbstractInterpreter)
         # annotate fulltree with type information,
         # either because we are the outermost code, or we might use this later
         doopt = (me.cached || me.parent !== nothing)
-        recompute_cfg = type_annotate!(interp, me, doopt)
+        type_annotate!(interp, me, doopt)
         if doopt && may_optimize(interp)
-            me.result.src = OptimizationState(me, interp, recompute_cfg)
+            me.result.src = OptimizationState(me, interp)
         else
             me.result.src = me.src::CodeInfo # stash a convenience copy of the code (e.g. for reflection)
         end
@@ -713,20 +713,31 @@ function type_annotate!(interp::AbstractInterpreter, sv::InferenceState, run_opt
     # 3. mark unreached statements for a bulk code deletion (see issue #7836)
     # 4. widen slot wrappers (`Conditional` and `MustAlias`) and remove `NOT_FOUND` from `ssavaluetypes`
     #    NOTE because of this, `was_reached` will no longer be available after this point
-    # 5. eliminate GotoIfNot if either branch target is unreachable
+    # 5. eliminate GotoIfNot if either or both branches are statically unreachable
     changemap = nothing # initialized if there is any dead region
     for i = 1:nstmt
         expr = stmts[i]
         if was_reached(sv, i)
             if run_optimizer
-                if isa(expr, GotoIfNot) && widenconst(argextype(expr.cond, src, sv.sptypes)) === Bool
+                if isa(expr, GotoIfNot)
                     # 5: replace this live GotoIfNot with:
-                    # - GotoNode if the fallthrough target is unreachable
-                    # - no-op if the branch target is unreachable
-                    if !was_reached(sv, i+1)
-                        expr = GotoNode(expr.dest)
-                    elseif !was_reached(sv, expr.dest)
-                        expr = nothing
+                    # - no-op if :nothrow and the branch target is unreachable
+                    # - cond if :nothrow and both targets are unreachable
+                    # - typeassert if must-throw
+                    if widenconst(argextype(expr.cond, src, sv.sptypes)) === Bool
+                        block = block_for_inst(sv.cfg, i)
+                        if !was_reached(sv, i+1)
+                            cfg_delete_edge!(sv.cfg, block, block + 1)
+                            expr = GotoNode(expr.dest)
+                        elseif !was_reached(sv, expr.dest)
+                            cfg_delete_edge!(sv.cfg, block, block_for_inst(sv.cfg, expr.dest))
+                            expr = nothing
+                        end
+                    elseif ssavaluetypes[i] === Bottom
+                        block = block_for_inst(sv.cfg, i)
+                        cfg_delete_edge!(sv.cfg, block, block + 1)
+                        cfg_delete_edge!(sv.cfg, block, block_for_inst(sv.cfg, expr.dest))
+                        expr = Expr(:call, Core.typeassert, expr.cond, Bool)
                     end
                 end
             end

--- a/test/compiler/interpreter_exec.jl
+++ b/test/compiler/interpreter_exec.jl
@@ -21,6 +21,7 @@ let m = Meta.@lower 1 + 1
     ]
     nstmts = length(src.code)
     src.ssavaluetypes = Any[ Any for _ = 1:nstmts ]
+    src.ssaflags = fill(UInt8(0x00), nstmts)
     src.codelocs = fill(Int32(1), nstmts)
     src.inferred = true
     Core.Compiler.verify_ir(Core.Compiler.inflate_ir(src))
@@ -61,6 +62,7 @@ let m = Meta.@lower 1 + 1
     ]
     nstmts = length(src.code)
     src.ssavaluetypes = Any[ Any for _ = 1:nstmts ]
+    src.ssaflags = fill(UInt8(0x00), nstmts)
     src.codelocs = fill(Int32(1), nstmts)
     src.inferred = true
     Core.Compiler.verify_ir(Core.Compiler.inflate_ir(src))
@@ -98,6 +100,7 @@ let m = Meta.@lower 1 + 1
     ]
     nstmts = length(src.code)
     src.ssavaluetypes = Any[ Any for _ = 1:nstmts ]
+    src.ssaflags = fill(UInt8(0x00), nstmts)
     src.codelocs = fill(Int32(1), nstmts)
     src.inferred = true
     Core.Compiler.verify_ir(Core.Compiler.inflate_ir(src))

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -849,6 +849,7 @@ function each_stmt_a_bb(stmts, preds, succs)
     empty!(ir.stmts.line); append!(ir.stmts.line, [Int32(0) for _ = 1:length(stmts)])
     empty!(ir.stmts.info); append!(ir.stmts.info, [NoCallInfo() for _ = 1:length(stmts)])
     empty!(ir.cfg.blocks); append!(ir.cfg.blocks, [BasicBlock(StmtRange(i, i), preds[i], succs[i]) for i = 1:length(stmts)])
+    empty!(ir.cfg.index);  append!(ir.cfg.index,  [i for i = 2:length(stmts)])
     Core.Compiler.verify_ir(ir)
     return ir
 end

--- a/test/compiler/irutils.jl
+++ b/test/compiler/irutils.jl
@@ -43,16 +43,22 @@ fully_eliminated(src::CodeInfo; retval=(@__FILE__)) = fully_eliminated(src.code;
 fully_eliminated(ir::IRCode; retval=(@__FILE__)) = fully_eliminated(ir.stmts.stmt; retval)
 function fully_eliminated(code::Vector{Any}; retval=(@__FILE__), kwargs...)
     if retval !== (@__FILE__)
-        length(code) == 1 || return false
-        code1 = code[1]
-        isreturn(code1) || return false
-        val = code1.val
+        (length(code) <= 2) || return false
+        for i = 1:(length(code) - 1)
+            code[i] === nothing || return false
+        end
+        isreturn(code[end]) || return false
+        val = code[end].val
         if val isa QuoteNode
             val = val.value
         end
         return val == retval
     else
-        return length(code) == 1 && isreturn(code[1])
+        (length(code) <= 2) || return false
+        for i = 1:(length(code) - 1)
+            code[i] === nothing || return false
+        end
+        return isreturn(code[end])
     end
 end
 macro fully_eliminated(ex0...)


### PR DESCRIPTION
This change will allow us to re-use Inference-collected information at the basic block level, such as the `bb_vartables`.

There were a couple of spots where the `unreachable` insertion pass at IRCode conversion (i.e. optimizer entry) was ignoring statically divergent code that inference had discovered:
  - `%x = SlotNumber(3)` can throw and cause the following statements to be statically unreachable
  - `goto #b if not %cond` can be statically throwing if %cond is known to never be Bool (or to always throw during its own evaluation)

CFG re-computation was hiding these bugs by flowing through the "Core.Const(...)"-wrapped statements that would follow, inserting unnecessary but harmless extra branches in the CFG.