### PR TITLE
timing: Check `jl_current_task` is ready before emitting timing events

### DIFF
--- a/src/timing.c
+++ b/src/timing.c
@@ -342,6 +342,7 @@ JL_DLLEXPORT void _jl_timing_block_init(char *buf, size_t size, jl_timing_event_
 JL_DLLEXPORT void _jl_timing_block_start(jl_timing_block_t *block) {
     assert(!block->is_running);
     if (!_jl_timing_enabled(block->event->subsystem)) return;
+    if (jl_get_pgcstack() == NULL) return; // not setup on this thread
 
     uint64_t t = cycleclock(); (void)t;
     _COUNTS_START(&block->counts_ctx, t);


### PR DESCRIPTION
We sometimes spawn imaging-dedicated threads for running LLVM that do not have `jl_current_task` setup.

Since we rely on the thread-local storage stack for our built-in profiling, we will segfault if we try to emit any events on these threads. A better long-term fix is probably to setup `jl_current_task` et al on these threads so that we can track them as usual, but this avoids crashes for now.