### PR TITLE
Fix comment in `load_path_expand()`

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -247,8 +247,8 @@ end
 function load_path_expand(env::AbstractString)::Union{String, Nothing}
     # named environment?
     if startswith(env, '@')
-        # `@` in JULIA_LOAD_PATH is expanded early (at startup time)
-        # if you put a `@` in LOAD_PATH manually, it's expanded late
+        # `@.` in JULIA_LOAD_PATH is expanded early (at startup time)
+        # if you put a `@.` in LOAD_PATH manually, it's expanded late
         env == "@" && return active_project(false)
         env == "@." && return current_project()
         env == "@stdlib" && return Sys.STDLIB


### PR DESCRIPTION
When the meaning of `"@"` in `LOAD_PATH` was changed and `"@."` introduced as the new name for the previous meaning of `"@"` in 9a4ecaa4e4, a comment in `load_path_expand()` wasn’t updated to reflect this change. This left the comment being incorrect, leading to potential confusion.

I hope I’m not creating more hassle than it’s worth with this super-tiny PR, but since it’s caused some confusion (e. g. https://github.com/JuliaLang/Pkg.jl/pull/3547#issuecomment-16795025350), I thought it might be worthwhile to fix it.