### PR TITLE
add docs for big_str instance sharing

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -74,8 +74,8 @@ Create an arbitrary precision integer. `x` may be an `Int` (or anything that can
 converted to an `Int`). The usual mathematical operators are defined for this type, and
 results are promoted to a [`BigInt`](@ref).
 
-Instances can be constructed from strings via [`parse`](@ref), or using the `big`
-string literal.
+Instances can be constructed from strings via [`parse`](@ref) or at macro expansion time
+via the `big` string literal.
 
 # Examples
 ```jldoctest

--- a/base/int.jl
+++ b/base/int.jl
@@ -742,6 +742,10 @@ Parse a string into a [`BigInt`](@ref) or [`BigFloat`](@ref),
 and throw an `ArgumentError` if the string is not a valid number.
 For integers `_` is allowed in the string as a separator.
 
+Each invocation of `@big_str` constructs a unique instance at
+macro expansion time, and this instance is shared by all subsequent
+variable assignments.
+
 # Examples
 ```jldoctest
 julia> big"123_456"
@@ -753,6 +757,12 @@ julia> big"7891.5"
 julia> big"_"
 ERROR: ArgumentError: invalid number format _ for BigInt or BigFloat
 [...]
+
+julia> foo() = big"1"
+foo (generic function with 1 method)
+
+julia> x, y = foo(), foo() # `x` and `y` point to the same BigInt instance
+(1, 1)
 ```
 """
 macro big_str(s)

--- a/base/int.jl
+++ b/base/int.jl
@@ -761,8 +761,11 @@ ERROR: ArgumentError: invalid number format _ for BigInt or BigFloat
 julia> foo() = big"1"
 foo (generic function with 1 method)
 
-julia> x, y = foo(), foo() # `x` and `y` point to the same BigInt instance
-(1, 1)
+# `x` and `y` point to the same BigInt instance
+julia> let x = foo(), y = foo()
+           x === y
+       end
+true
 ```
 """
 macro big_str(s)


### PR DESCRIPTION
I learned recently from user DNF on Discourse that the `@big_str` macro is not equivalent to `BigInt` constructor
https://discourse.julialang.org/t/performance-memory-differences-between-constructors-of-bigints/102863/6?u=adienes

this should be documented 