### PR TITLE
Speed up `logdet` for diagonal and triangular matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1676,8 +1676,12 @@ julia> logabsdet(B)
 (0.6931471805599453, 1.0)
 ```
 """
-logabsdet(A::AbstractMatrix) = logabsdet(lu(A, check=false))
-
+function logabsdet(A::AbstractMatrix)
+    if istriu(A) || istril(A)
+        return logabsdet(UpperTriangular(A))
+    end
+    logabsdet(lu(A, check=false))
+end
 logabsdet(a::Number) = log(abs(a)), sign(a)
 
 """

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1680,7 +1680,7 @@ function logabsdet(A::AbstractMatrix)
     if istriu(A) || istril(A)
         return logabsdet(UpperTriangular(A))
     end
-    logabsdet(lu(A, check=false))
+    return logabsdet(lu(A, check=false))
 end
 logabsdet(a::Number) = log(abs(a)), sign(a)
 

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -77,6 +77,17 @@ n = 5 # should be odd
         X = fill(x, 1, 1)
         @test logabsdet(x)[1] ≈ logabsdet(X)[1]
         @test logabsdet(x)[2] ≈ logabsdet(X)[2]
+        # Diagonal, upper, and lower triangular matrices
+        chksign(s1, s2) = if elty <: Real s1 == s2 else s1 ≈ s2 end
+        D = Matrix(Diagonal(A))
+        v, s = logabsdet(D)
+        @test v ≈ log(abs(det(D))) && chksign(s, sign(det(D)))
+        R = triu(A)
+        v, s = logabsdet(R)
+        @test v ≈ log(abs(det(R))) && chksign(s, sign(det(R)))
+        L = tril(A)
+        v, s = logabsdet(L)
+        @test v ≈ log(abs(det(L))) && chksign(s, sign(det(L)))
     end
 
     @testset "det with nonstandard Number type" begin


### PR DESCRIPTION
## Introduction
This PR is a straightforward fix for JuliaLang/LinearAlgebra.jl#1017. Please see the issue for more details.
Baseline: 30a73de68108b9629c4c99a1751d579ef5893bda

## Changes
- The function `logabsdet` in `generic.jl` now includes a triangular matrix detection (akin to `det`) to speed up processing for diagonal and triangular matrices.

## Tasks
- [X] Update function `logabsdet` in `generic.jl`
- [X] Update test suite ~~if necessary~~
- [X] ~~Update documentation, if necessary~~
- [X] ~~Rebase to current `master`~~