### PR TITLE
Faster compilation of `collect()` for NTuples

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -758,6 +758,28 @@ collect(itr) = _collect(1:1 #= Array =#, itr, IteratorEltype(itr), IteratorSize(
 
 collect(A::AbstractArray) = _collect_indices(axes(A), A)
 
+# fast collection of NTuples
+function Base._collect(::Type{T}, @nospecialize(t::Tuple)) where T
+    res = Vector{T}(undef, length(t))
+    i = 1
+    for x in t
+        res[i] = x
+        i += 1
+    end
+    res
+end
+
+function Base.collect(@nospecialize t::Tuple)
+    if isempty(t)
+        []
+    elseif t isa NTuple
+        T = typeof(t)
+        Base._collect(T.parameters[1], t)
+    else
+        Base._collect(1:1 #= Array =#, t, Base.HasEltype(), Base.HasLength())
+    end
+end
+
 collect_similar(cont, itr) = _collect(cont, itr, IteratorEltype(itr), IteratorSize(itr))
 
 _collect(cont, itr, ::HasEltype, isz::Union{HasLength,HasShape}) =


### PR DESCRIPTION
First of all, this is my first PR to julia, so please be patient with my if I should have missed something.

This PR addresses a topic that came up in #49671.

Currently, dynamic conversion of NTuples to Vectors by `collect()` triggers a new compilation
This PR offers a julia solution to this problem.

There might be other solutions to this issue, most probably compiler-related, but that's certainly out of reach for me.

Before the patch `collect(t::Tuple)` is recompiled for each number of tuple elements
```julia
julia> n = 0;

julia> n += 1; @time collect(tuple(string.(1:n)...),);
  0.110986 seconds (79.05 k allocations: 5.343 MiB, 99.61% compilation time)

julia> n += 1; @time collect(tuple(string.(1:n)...),);
  0.012787 seconds (241 allocations: 11.375 KiB, 99.69% compilation time)
```
after the patch, compilation happens only once:
```julia    
julia> n += 1; @time collect(tuple(string.(1:n)...),);
  0.029778 seconds (18.11 k allocations: 1.207 MiB, 99.68% compilation time)

julia> n += 1; @time collect(tuple(string.(1:n)...),);
  0.000037 seconds (15 allocations: 688 bytes)
```
