### PR TITLE
make ConsoleLogger respect active repl iocontext

### DIFF
--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -119,8 +119,12 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
     msglines = [(indent=0, msg=l) for l in split(chomp(convert(String, string(message))::String), '\n')]
     stream::IO = logger.stream
     if !(isopen(stream)::Bool)
-        repl_ioc = Base.active_repl.options.iocontext
-        stream = IOContext(stderr, repl_ioc...)
+        if isdefined(Base, :active_repl)
+            repl_ioc = Base.active_repl.options.iocontext
+            stream = IOContext(stderr, repl_ioc...)
+        else
+            stream = stderr
+        end
     end
     dsize = displaysize(stream)::Tuple{Int,Int}
     nkwargs = length(kwargs)::Int

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -119,7 +119,8 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
     msglines = [(indent=0, msg=l) for l in split(chomp(convert(String, string(message))::String), '\n')]
     stream::IO = logger.stream
     if !(isopen(stream)::Bool)
-        stream = stderr
+        repl_ioc = Base.active_repl.options.iocontext
+        stream = IOContext(stderr, repl_ioc...)
     end
     dsize = displaysize(stream)::Tuple{Int,Int}
     nkwargs = length(kwargs)::Int


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/50966

```
julia> @info "msg" rand(100)
┌ Info: msg
│   rand(100) =
│    100-element Vector{Float64}:
│     0.31865680660524676
│     0.16988153794366578
│     0.3297352714106879
│     0.730095231666752
│     ⋮
│     0.34785788866017486
│     0.8090313673812081
│     0.6264631844074221
└     0.21672825693197895

julia> Base.active_repl.options.iocontext[:displaysize] = (1000, displaysize(stdout)[2])
(1000, 148)

julia> @info "msg" rand(100)
┌ Info: msg
│   rand(100) =
│    100-element Vector{Float64}:
│     0.41144853917376256
│     0.15830792044161057
│     0.021068774824703373
│     0.5992327965202229
│     0.4589906336017341
│     0.9034830653478718
│     0.4327793117273919
│     0.8618775649384036
│     0.8863892401850897
│     0.7298358588615682
│     0.22763664024065244
... (manual truncated.. shows all)
```