### PR TITLE
minor NFC in GC codebase

### DIFF
--- a/src/gc-pages.c
+++ b/src/gc-pages.c
@@ -127,7 +127,7 @@ NOINLINE jl_gc_pagemeta_t *jl_gc_alloc_page(void) JL_NOTSAFEPOINT
     meta = pop_lf_page_metadata_back(&global_page_pool_clean);
     if (meta != NULL) {
         uv_mutex_unlock(&gc_perm_lock);
-        gc_alloc_map_set(meta->data, 1);
+        gc_alloc_map_set(meta->data, GC_PAGE_ALLOCATED);
         goto exit;
     }
     // must map a new set of pages

--- a/src/gc.c
+++ b/src/gc.c
@@ -2423,7 +2423,6 @@ FORCE_INLINE void gc_mark_outrefs(jl_ptls_t ptls, jl_gc_markqueue_t *mq, void *_
         uint8_t bits = (gc_old(o->header) && !mark_reset_age) ? GC_OLD_MARKED : GC_MARKED;
         int update_meta = __likely(!meta_updated && !gc_verifying);
         int foreign_alloc = 0;
-        // directly point at eyt_obj_in_img to encourage inlining
         if (update_meta && o->bits.in_image) {
             foreign_alloc = 1;
             update_meta = 0;

--- a/src/gc.h
+++ b/src/gc.h
@@ -146,6 +146,8 @@ typedef struct _mallocarray_t {
 
 // pool page metadata
 typedef struct _jl_gc_pagemeta_t {
+    // next metadata structre in per-thread list
+    // or in one of the `jl_gc_global_page_pool_t`
     struct _jl_gc_pagemeta_t *next;
     // index of pool that owns this page
     uint8_t pool_n;
@@ -203,6 +205,11 @@ STATIC_INLINE void gc_backoff(int *i) JL_NOTSAFEPOINT
 
 // Lock-free stack implementation taken
 // from Herlihy's "The Art of Multiprocessor Programming"
+// XXX: this is not a general-purpose lock-free stack. We can
+// get away with just using a CAS and not implementing some ABA
+// prevention mechanism since once a node is popped from the
+// `jl_gc_global_page_pool_t`, it may only be pushed back to them
+// in the sweeping phase, which is serial
 
 STATIC_INLINE void push_lf_page_metadata_back(jl_gc_global_page_pool_t *pool, jl_gc_pagemeta_t *elt) JL_NOTSAFEPOINT
 {


### PR DESCRIPTION
- Use `GC_PAGE_ALLOCATED`instead of hardcoded constant
- Remove stale eytzinger tree comment from `gc_mark_outrefs`
- Add some comments to explain why push_lf_page_metadata_back/pop_lf_page_metadata_back can only use a CAS and not be vulnerable to ABA