### PR TITLE
Add examples of simple use to `Ref` docs

### DIFF
--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -42,8 +42,17 @@ A `C_NULL` instance of `Ptr` can be passed to a `ccall` `Ref` argument to initia
 # Examples
 
 ```jldoctest
-julia> Ref(5)
+julia> r = Ref(5) # Create a Ref with an initial value
 Base.RefValue{Int64}(5)
+
+julia> r[] # Getting a value from a Ref
+5
+
+julia> r[] = 7 # Storing a new value in a Ref
+7
+
+julia> r # The Ref now contains 7
+Base.RefValue{Int64}(7)
 
 julia> isa.(Ref([1,2,3]), [Array, Dict, Int]) # Treat reference values as scalar during broadcasting
 3-element BitVector:
@@ -64,9 +73,6 @@ UndefRefError()
 julia> Ref{Int64}()[]; # A reference to a bitstype refers to an undetermined value if not given
 
 julia> isassigned(Ref{Int64}()) # A reference to a bitstype is always assigned
-true
-
-julia> Ref{Int64}(0)[] == 0 # Explicitly give a value for a bitstype reference
 true
 ```
 """


### PR DESCRIPTION
The docs didn't document the simple getting and setting behaviour of `Ref`s.