### PR TITLE
deps/libsuitesparse: fix empty var in manifest

### DIFF
--- a/deps/libsuitesparse.mk
+++ b/deps/libsuitesparse.mk
@@ -60,7 +60,7 @@ $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-checked: $(BUILDDIR)/SuiteSp
 	done
 	echo 1 > $@
 
-UNINSTALL_suitesparse := $(LIBSUITESPARSE_VER) manual_suitesparse $(LIBSUITESPARSE_LIBS)
+UNINSTALL_libsuitesparse := $(LIBSUITESPARSE_VER) manual_suitesparse $(LIBSUITESPARSE_LIBS)
 
 $(build_prefix)/manifest/libsuitesparse: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled | $(build_prefix)/manifest $(build_shlibdir)
 	echo $(UNINSTALL_libsuitesparse) > $@

--- a/deps/libsuitesparse.mk
+++ b/deps/libsuitesparse.mk
@@ -60,7 +60,7 @@ $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-checked: $(BUILDDIR)/SuiteSp
 	done
 	echo 1 > $@
 
-UNINSTALL_libsuitesparse := $(LIBSUITESPARSE_VER) manual_suitesparse $(LIBSUITESPARSE_LIBS)
+UNINSTALL_libsuitesparse := $(LIBSUITESPARSE_VER) manual_libsuitesparse $(LIBSUITESPARSE_LIBS)
 
 $(build_prefix)/manifest/libsuitesparse: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled | $(build_prefix)/manifest $(build_shlibdir)
 	echo $(UNINSTALL_libsuitesparse) > $@


### PR DESCRIPTION
`UNINSTALL_libsuitesparse` is an empty variable (used in https://github.com/JuliaLang/julia/blob/74ce6cf070a2a04e836c3e5a2211228a3ac978ef/deps/libsuitesparse.mk#L66): this leads to an empty `usr/manifest/libsuitesparse` file.

Maybe `Makefile`s should check for empty manifests and error properly, making the build system more robust ?