### PR TITLE
Add ORIGIN to SuiteSparse rpath on Linux/FreeBSD

### DIFF
--- a/deps/libsuitesparse.mk
+++ b/deps/libsuitesparse.mk
@@ -24,6 +24,10 @@ LIBSUITESPARSE_CMAKE_FLAGS := $(CMAKE_COMMON) \
 	  -DLAPACK_LIBRARIES="$(build_shlibdir)/libblastrampoline.$(SHLIB_EXT)" \
 	  -DLAPACK_LINKER_FLAGS="blastrampoline"
 
+ifneq (,$(findstring $(OS),Linux FreeBSD))
+LIBSUITESPARSE_CMAKE_FLAGS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
+endif
+
 $(SRCCACHE)/SuiteSparse-$(LIBSUITESPARSE_VER).tar.gz: | $(SRCCACHE)
 	$(JLDOWNLOAD) $@ https://github.com/Wimmerer/SuiteSparse/archive/v$(LIBSUITESPARSE_VER).tar.gz
 


### PR DESCRIPTION
@ararslan I believe this should work. Fastest way to test is: `USE_BINARYBUILDER_LIBSUITESPARSE=0`. Outside of Linux and BSD I'm hopeful nothing needs to be done. A very brief test on my Mac indicates that it uses the rpath correctly. 

Will need backport if this indeed does work.