### PR TITLE
fix #50709, type bound error due to free typevar in sparam env

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2186,6 +2186,12 @@ function sp_type_rewrap(@nospecialize(T), linfo::MethodInstance, isreturn::Bool)
                         T = UnionAll(v, T)
                     end
                 end
+                if has_free_typevars(T)
+                    fv = ccall(:jl_find_free_typevars, Vector{Any}, (Any,), T)
+                    for v in fv
+                        T = UnionAll(v, T)
+                    end
+                end
             else
                 T = rewrap_unionall(T, spsig)
             end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5142,6 +5142,9 @@ h45759(x::Tuple{Any,Vararg}; kwargs...) = x[1] + h45759(x[2:end]; kwargs...)
 h45759(x::Tuple{}; kwargs...) = 0
 @test only(Base.return_types(h45759, Tuple{Tuple{Int,Int,Int,Int,Int,Int,Int}})) == Int
 
+# issue #50709
+@test Base.code_typed_by_type(Tuple{Type{Vector{S}} where {T, S<:AbstractVector{T}}, UndefInitializer, Int})[1][2] == Vector{<:AbstractVector{T}} where T
+
 @test only(Base.return_types((typeof([[[1]]]),)) do x
     sum(x) do v
         sum(length, v)


### PR DESCRIPTION
fix #50709

This issue *appears* fixed on master due to #50432, which simply removed the error. This fixes the underlying cause, which is that we sometimes return typevars in the environment from intersection that have free vars in their bounds. I think it's reasonable to just widen these aggressively, since we usually cannot do much with these kinds of unknown static parameters anyway.
