### PR TITLE
optimizer: fold `ifelse` call with constant condition

### DIFF
--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1442,6 +1442,7 @@ end
 
 # ifelse folding
 @test Core.Compiler.is_removable_if_unused(Base.infer_effects(exp, (Float64,)))
+@test !Core.Compiler.is_inlineable(code_typed1(exp, (Float64,)))
 fully_eliminated(; retval=Core.Argument(2)) do x::Float64
     return Core.ifelse(true, x, exp(x))
 end


### PR DESCRIPTION
We have had the optimization to fold `Core.ifelse` with constant condition with `early_inline_special_case`, but it can be too early as the inlining pass may produce `Core.ifelse` with constant condition.

This commit adds a similar optimization within the SROA pass, which already has a bunch of other non-pure-SROA optimizations.

Now we can fully optimize this kind of case:
```julia
fully_eliminated(; retval=Core.Argument(2)) do x::Float64
    return Core.ifelse(true, x, exp(x)) # optimized already
end
fully_eliminated(; retval=Core.Argument(2)) do x::Float64
    return ifelse(true, x, exp(x)) # the optimization should be applied to post-inlining IR too
end
fully_eliminated(; retval=Core.Argument(2)) do x::Float64
    return ifelse(isa(x, Float64), x, exp(x))
end
```