### PR TITLE
fix a case of potentially use of undefined variable when handling error in distributed message processing

### DIFF
--- a/stdlib/Distributed/src/process_messages.jl
+++ b/stdlib/Distributed/src/process_messages.jl
@@ -210,6 +210,9 @@ function message_handler_loop(r_stream::IO, w_stream::IO, incoming::Bool)
             handle_msg(msg, header, r_stream, w_stream, version)
         end
     catch e
+        werr = worker_from_id(iderr)
+        oldstate = werr.state
+
         # Check again as it may have been set in a message handler but not propagated to the calling block above
         if wpid < 1
             wpid = worker_id_from_socket(r_stream)
@@ -219,8 +222,6 @@ function message_handler_loop(r_stream::IO, w_stream::IO, incoming::Bool)
             println(stderr, e, CapturedException(e, catch_backtrace()))
             println(stderr, "Process($(myid())) - Unknown remote, closing connection.")
         elseif !(wpid in map_del_wrkr)
-            werr = worker_from_id(wpid)
-            oldstate = werr.state
             set_worker_state(werr, W_TERMINATED)
 
             # If unhandleable error occurred talking to pid 1, exit

--- a/stdlib/Distributed/src/process_messages.jl
+++ b/stdlib/Distributed/src/process_messages.jl
@@ -210,7 +210,7 @@ function message_handler_loop(r_stream::IO, w_stream::IO, incoming::Bool)
             handle_msg(msg, header, r_stream, w_stream, version)
         end
     catch e
-        werr = worker_from_id(iderr)
+        werr = worker_from_id(wpid)
         oldstate = werr.state
 
         # Check again as it may have been set in a message handler but not propagated to the calling block above


### PR DESCRIPTION
There is a use of `oldstate` on line 244 which has the possibility of being undefined. This bug seems to have been introduced in https://github.com/JuliaLang/julia/commit/40c622b7e66a88c05d8892222126f1d13851bc62#diff-39fa44ff86c5b38bd6b9e7f60733b25724a9efd9221ca38f776ed3f3ab01dec2. I don't have a repro for this but this PR reverts back to the situation where `oldstate` is defined at the topmost level of the catch block as it was before the offending commit.