### PR TITLE
testdefs: make sure that if a test set changes the active project, they change it back when they're done

### DIFF
--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -25,6 +25,7 @@ function runtests(name, path, isolate=true; seed=nothing)
             original_depot_path = copy(Base.DEPOT_PATH)
             original_load_path = copy(Base.LOAD_PATH)
             original_env = copy(ENV)
+            original_project = Base.active_project()
 
             Base.include(m, "$path.jl")
 
@@ -62,6 +63,17 @@ function runtests(name, path, isolate=true; seed=nothing)
                     )
                     error(msg)
                 end
+            end
+            if Base.active_project() != original_project
+                msg = "The `$(name)` test set changed the active project and did not restore the original value"
+                @error(
+                    msg,
+                    original_project,
+                    Base.active_project(),
+                    testset_name = name,
+                    testset_path = path,
+                )
+                error(msg)
             end
         end
         rss = Sys.maxrss()


### PR DESCRIPTION
We already check the following for mutation by a test set:
1. DEPOT_PATH
2. LOAD_PATH
3. ENV

So this PR just adds the active project to the list of things we check.

Changing the active project during a test set can definitely have negative effects on subsequent test sets that are run on the same worker, so we want to make sure if a test set changes the active project, that they change it back when they're done.