### PR TITLE
Simple heuristic to dynamically adjust number of GC threads

### DIFF
--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -216,6 +216,8 @@ typedef struct _jl_tls_states_t {
 #define JL_GC_STATE_SAFE 2
     // gc_state = 2 means the thread is running unmanaged code that can be
     //              execute at the same time with the GC.
+#define JL_GC_STATE_PARALLEL 3
+    // gc_state = 2 means the thread is running parallel GC code.
     _Atomic(int8_t) gc_state; // read from foreign threads
     // execution of certain certain impure
     // statements is prohibited from certain


### PR DESCRIPTION
Basically, every GC thread will first look at other workers' queues and count the amount of available work in order to decide whether it's worth it to start marking.

Seems to fix, on my machine, a negative scaling I was seeing on a GCBenchmark which exposes very little parallelism (e.g. `list.jl`).

- master:
```
../julia-master/julia run_benchmarks.jl serial linked list -n5 --gcthreads=1         
bench = "list.jl"
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       6099 │    5233 │      4921 │        291 │         1523 │                82 │     3321 │         86 │
│  median │       6149 │    5275 │      4983 │        297 │         1563 │                85 │     3321 │         86 │
│ maximum │       6740 │    5867 │      5566 │        314 │         2313 │               103 │     3321 │         87 │
│   stdev │        271 │     271 │       270 │          9 │          345 │                10 │        0 │          1 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
../julia-master/julia run_benchmarks.jl serial linked list -n5 --gcthreads=8
bench = "list.jl"
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       7911 │    7022 │      6688 │        304 │         2162 │               106 │     3321 │         89 │
│  median │       8467 │    7582 │      7221 │        333 │         2738 │               174 │     3321 │         89 │
│ maximum │       8553 │    7656 │      7324 │        366 │         2906 │              1143 │     3321 │         90 │
│   stdev │        316 │     315 │       298 │         25 │          323 │               448 │        0 │          0 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
```

- PR:
```
../julia-adjust-n-threads/julia run_benchmarks.jl serial linked list -n5 --gcthreads=1
bench = "list.jl"
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       5874 │    5112 │      4786 │        296 │         1455 │                78 │     3321 │         87 │
│  median │       5900 │    5138 │      4827 │        311 │         1461 │                86 │     3321 │         87 │
│ maximum │       6585 │    5809 │      5384 │        425 │         2278 │                90 │     3321 │         88 │
│   stdev │        337 │     324 │       285 │         52 │          423 │                 4 │        0 │          1 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
../julia-adjust-n-threads/julia run_benchmarks.jl serial linked list -n5 --gcthreads=8
bench = "list.jl"
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       5838 │    5035 │      4720 │        300 │         1513 │                95 │     3321 │         86 │
│  median │       5916 │    5117 │      4806 │        336 │         1679 │               118 │     3321 │         86 │
│ maximum │       6311 │    5521 │      5184 │        392 │         2169 │               489 │     3321 │         87 │
│   stdev │        186 │     193 │       188 │         35 │          257 │               206 │        0 │          1 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
```

Also, doesn't seem to sacrifice scaling on a few GCBenchmarks which expose a lot of parallelism (e.g. `binary_tree` ones):

- master:
```
../julia-master/julia run_benchmarks.jl multithreaded binary_tree tree_mutable -n5 -t8 --gcthreads=8
bench = "tree_mutable.jl"
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       4200 │    1975 │       520 │       1450 │           84 │              1952 │      980 │         47 │
│  median │       4321 │    2032 │       542 │       1485 │           86 │              2225 │      988 │         47 │
│ maximum │       4413 │    2093 │       561 │       1532 │           97 │              2329 │     1025 │         47 │
│   stdev │         89 │      49 │        16 │         33 │            5 │               149 │       18 │          0 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
```

- PR:
```
../julia-adjust-n-threads/julia run_benchmarks.jl multithreaded binary_tree tree_mutable -n5 -t8 --gcthreads=8 
bench = "tree_mutable.jl"
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       3967 │    1877 │       474 │       1400 │           79 │              2026 │      987 │         47 │
│  median │       4062 │    1939 │       495 │       1441 │           84 │              2174 │     1003 │         47 │
│ maximum │       4222 │    1997 │       522 │       1502 │           91 │              2488 │     1028 │         48 │
│   stdev │        101 │      54 │        19 │         41 │            5 │               171 │       16 │          0 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
```