### PR TITLE
Always rewrite GotoIfNot with unreachable branches

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -669,16 +669,17 @@ function type_annotate!(interp::AbstractInterpreter, sv::InferenceState)
     # and mark any unreachable statements by wrapping them in Const(...), to distinguish them from
     # must-throw statements which also have type Bottom
     for i = 1:nstmt
+        expr = stmts[i]
         if was_reached(sv, i)
             ssavaluetypes[i] = widenslotwrapper(ssavaluetypes[i]) # 3
         else # i.e. any runtime execution will never reach this statement
             push!(sv.unreachable, i)
-            if is_meta_expr(stmts[i]) # keep any lexically scoped expressions
+            if is_meta_expr(expr) # keep any lexically scoped expressions
                 ssavaluetypes[i] = Any # 3
             else
                 ssavaluetypes[i] = Bottom # 3
                 # annotate that this statement actually is dead
-                stmts[i] = Const(stmts[i])
+                stmts[i] = Const(expr)
             end
         end
     end


### PR DESCRIPTION
This resolves a regression introduced in https://github.com/JuliaLang/julia/pull/50943#issuecomment-1694198019

That PR requires the Goto/GotoIfNot statements of the IR to correspond 1-1 (in terms of reachability) to the information we get from inference. To make that happen, we have to unconditionally re-write control flow to match the branches that inference ended up actually exploring.

The problem is that we were choosing not to do this if the GotoIfNot condition seemed to be maybe-non-Boolean.

Thankfully, it turns out that check is unnecessary because Inference when following conditionals does not consider "true or non-Bool" etc. If it did, we'd instead have to re-write these branches as a `typeassert; goto` to encode the reachability