### PR TITLE
Use PersistentDict for efficient implementation of ScopedValue's

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -984,6 +984,21 @@ function get(dict::PersistentDict{K,V}, key::K, default::V) where {K,V}
     return default
 end
 
+# Private version for ScopedValue
+function _get(dict::PersistentDict{K,V}, key::K) where {K,V}
+    trie = dict.trie
+    if HAMT.islevel_empty(trie)
+        return false, nothing
+    end
+    h = hash(key)
+    found, present, trie, i, _, _, _ = HAMT.path(trie, key, h)
+    if found && present
+        leaf = @inbounds trie.data[i]::HAMT.Leaf{K,V}
+        return true, leaf.val
+    end
+    return false, nothing
+end
+
 function get(default::Callable, dict::PersistentDict{K,V}, key::K) where {K,V}
     trie = dict.trie
     if HAMT.islevel_empty(trie)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -908,9 +908,12 @@ Base.PersistentDict{Symbol, Int64} with 1 entry:
 PersistentDict
 
 PersistentDict{K,V}() where {K,V} = PersistentDict(HAMT.HAMT{K,V}())
-PersistentDict(KV::Pair{K,V}) where {K,V} = PersistentDict(HAMT.HAMT(KV...))
+PersistentDict{K,V}(KV::Pair) where {K,V} = PersistentDict(HAMT.HAMT{K,V}(KV...))
+PersistentDict(KV::Pair{K,V}) where {K,V} = PersistentDict(HAMT.HAMT{K,V}(KV...))
 PersistentDict(dict::PersistentDict, pair::Pair) = PersistentDict(dict, pair...)
-function PersistentDict(dict::PersistentDict{K,V}, key::K, val::V) where {K,V}
+function PersistentDict(dict::PersistentDict{K,V}, key, val) where {K,V}
+    key = convert(K, key)
+    val = convert(V, val)
     trie = dict.trie
     h = hash(key)
     found, present, trie, i, bi, top, hs = HAMT.path(trie, key, h, #=persistent=# true)

--- a/base/hamt.jl
+++ b/base/hamt.jl
@@ -64,7 +64,8 @@ mutable struct HAMT{K, V}
     bitmap::BITMAP
 end
 HAMT{K, V}() where {K, V} = HAMT(Vector{Union{Leaf{K, V}, HAMT{K, V}}}(undef, 0), zero(BITMAP))
-function HAMT(k::K, v::V) where {K, V}
+function HAMT{K,V}(k::K, v) where {K, V}
+    v = convert(V, v)
     # For a single element we can't have a hash-collision
     trie = HAMT(Vector{Union{Leaf{K, V}, HAMT{K, V}}}(undef, 1), zero(BITMAP))
     trie.data[1] = Leaf{K,V}(k,v)
@@ -72,6 +73,7 @@ function HAMT(k::K, v::V) where {K, V}
     set!(trie, bi)
     return trie
 end
+HAMT(k::K, v::V) where {K, V} = HAMT{K,V}(K, V)
 
 struct HashState{K}
     key::K

--- a/base/scopedvalues.jl
+++ b/base/scopedvalues.jl
@@ -64,21 +64,20 @@ mutable struct Scope
     values::Base.PersistentDict{ScopedValue, Any}
 end
 function Scope(parent::Union{Nothing, Scope}, key::ScopedValue{T}, value) where T
+    val = convert(T, value)
     if parent === nothing
-        values = Base.PersistentDict{ScopedValue, Any}()
-    else
-        values = parent.values
+        return Scope(Base.PersistentDict{ScopedValue, Any}(key=>val)
     end
-    values = Base.PersistentDict(values, key=>convert(T, value))
-    return Scope(values)
+    return Scope(Base.PersistentDict(parent.values, key=>convert(T, val)))
 end
 
 function Scope(scope, pairs::Pair{<:ScopedValue}...)
     for pair in pairs
         scope = Scope(scope, pair...)
     end
-    return scope
+    return scope::Scope
 end
+Scope(::Nothing) = nothing
 
 """
     current_scope()::Union{Nothing, Scope}

--- a/base/scopedvalues.jl
+++ b/base/scopedvalues.jl
@@ -108,7 +108,8 @@ function Base.getindex(val::ScopedValue{T})::T where T
     if scope === nothing
         return val.initial_value
     end
-    @inline get(scope.values, val, val.initial_value)::T
+    # get(scope.values, val, val.initial_value) get's union-split if T is `Union{Nothing, V}`
+    @inline get(()-> val.initial_value, scope.values, val)::T
 end
 
 function Base.show(io::IO, var::ScopedValue)

--- a/base/scopedvalues.jl
+++ b/base/scopedvalues.jl
@@ -84,7 +84,7 @@ Scope(::Nothing) = nothing
 
 Return the current dynamic scope.
 """
-current_scope() = current_task().scope::Union{Nothing, Scope}
+current_scope() = current_task().scope
 
 function Base.show(io::IO, scope::Scope)
     print(io, Scope, "(")
@@ -118,7 +118,7 @@ end
     if scope === nothing
         return val.initial_value
     end
-    getindex_slow(scope, val)
+    getindex_slow(scope::Scope, val)
 end
 
 function Base.show(io::IO, var::ScopedValue)

--- a/base/scopedvalues.jl
+++ b/base/scopedvalues.jl
@@ -66,7 +66,7 @@ end
 function Scope(parent::Union{Nothing, Scope}, key::ScopedValue{T}, value) where T
     val = convert(T, value)
     if parent === nothing
-        return Scope(Base.PersistentDict{ScopedValue, Any}(key=>val)
+        return Scope(Base.PersistentDict{ScopedValue, Any}(key=>val))
     end
     return Scope(Base.PersistentDict(parent.values, key=>convert(T, val)))
 end


### PR DESCRIPTION
In #50958 I used an inlined immutable dictonary to implement `ScopedValue`.
That implementation performs very well for a small number of scoped values,
or a shallow nesting of dynamical scopes.

Crucially the lookup time for a scoped value grows `O(n)` with the number
dynamic scopes. Here I propose the usage of a PersistentDict based on
a hash array mapped trie (HAMT). HAMT has lookup `O(log(32, n))`.

A few numbers for the old implementation gather from ScopedValues.jl

| ID                              | time            |
|---------------------------------|----------------:|
| `["DEPTH", "depth=1"]`          |   2.980 ns (5%) |
| `["DEPTH", "depth=2"]`          |   3.720 ns (5%) |
| `["DEPTH", "depth=4"]`          |   3.720 ns (5%) |
| `["DEPTH", "depth=8"]`          |   5.700 ns (5%) |         
| `["DEPTH", "depth=16"]`         |  10.631 ns (5%) |
| `["DEPTH", "depth=32"]`         |  25.954 ns (5%) |
| `["DEPTH", "depth=64"]`         |  57.548 ns (5%) |
| `["DEPTH", "depth=256"]`        | 265.488 ns (5%) |
| `["DEPTH", "depth=512"]`        | 518.125 ns (5%) |
| `["DEPTH", "depth=1024"]`       |   1.034 μs (5%) |
| `["DEPTH", "depth=2048"]`       |   2.055 μs (5%) |
| `["DEPTH", "depth=4096"]`       |   4.101 μs (5%) |

With a PersistentDict:
| ID                              | time            |
|---------------------------------|----------------:|
| `["DEPTH", "depth=1"]`          |   9.660 ns (5%) |
| `["DEPTH", "depth=2"]`          |   9.660 ns (5%) |
| `["DEPTH", "depth=4"]`          |   9.660 ns (5%) |
| `["DEPTH", "depth=8"]`          |   9.660 ns (5%) |
| `["DEPTH", "depth=16"]`         |   9.620 ns (5%) |
| `["DEPTH", "depth=32"]`         |   9.659 ns (5%) |
| `["DEPTH", "depth=64"]`         |   9.624 ns (5%) |
| `["DEPTH", "depth=128"]`        |   9.663 ns (5%) |
| `["DEPTH", "depth=256"]`        |   9.721 ns (5%) |
| `["DEPTH", "depth=512"]`        |   9.792 ns (5%) |
| `["DEPTH", "depth=1024"]`       |  12.900 ns (5%) |
| `["DEPTH", "depth=2048"]`       |  13.333 ns (5%) |
| `["DEPTH", "depth=4096"]`       |  14.286 ns (5%) |


As we can see access time is now predictable (similar in cost to task local storage),
and no longer running the risk that abundant usage of scoped values in libraries,
having negative effects through spooky action at a distance.

Now the tradeoff is that dynamic scope entry becomes more expensive,
from ~80ns to ~192ns and memory usage going from 112 bytes to 368 bytes.

So why the complication of using a HAMT and not just copying a dictonary at entry.
HAMT have the benefit of being able to structurally share memory.
Using the persitent operation `insert` in https://github.com/vchuravy/HashArrayMappedTries.jl we can see
the overhead cost.

| ID                                                   | time            | GC time   | memory          | allocations |
|------------------------------------------------------|----------------:|----------:|----------------:|------------:|
| `["Base.Dict", "insert, size=0"]`                    |  96.143 ns (5%) |           |  544 bytes (1%) |           4 |
| `["Base.Dict", "insert, size=1"]`                    | 102.561 ns (5%) |           |  544 bytes (1%) |           4 |
| `["Base.Dict", "insert, size=2"]`                    | 102.608 ns (5%) |           |  544 bytes (1%) |           4 |
| `["Base.Dict", "insert, size=4"]`                    | 103.010 ns (5%) |           |  544 bytes (1%) |           4 |
| `["Base.Dict", "insert, size=8"]`                    | 103.189 ns (5%) |           |  544 bytes (1%) |           4 |
| `["Base.Dict", "insert, size=16"]`                   | 118.819 ns (5%) |           |   1.33 KiB (1%) |           4 |
| `["Base.Dict", "insert, size=32"]`                   | 117.118 ns (5%) |           |   1.33 KiB (1%) |           4 |
| `["Base.Dict", "insert, size=64"]`                   | 653.087 ns (5%) |           |   4.66 KiB (1%) |           4 |
| `["Base.Dict", "insert, size=128"]`                  | 655.882 ns (5%) |           |   4.66 KiB (1%) |           4 |
| `["Base.Dict", "insert, size=256"]`                  |   1.475 μs (5%) |           |  17.39 KiB (1%) |           4 |
| `["Base.Dict", "insert, size=512"]`                  |   1.515 μs (5%) |           |  17.39 KiB (1%) |           4 |
| `["Base.Dict", "insert, size=1024"]`                 |   4.547 μs (5%) |           |  68.36 KiB (1%) |           6 |
| `["Base.Dict", "insert, size=2048"]`                 |   4.816 μs (5%) |           |  68.36 KiB (1%) |           6 |
| `["Base.Dict", "insert, size=4096"]`                 |  16.320 μs (5%) |           | 272.28 KiB (1%) |           7 |
| `["Base.Dict", "insert, size=8192"]`                 |  18.520 μs (5%) |           | 272.28 KiB (1%) |           7 |
| `["Base.Dict", "insert, size=16384"]`                |  73.600 μs (5%) |           |   1.06 MiB (1%) |           7 |
| `["HAMT", "insert, size=0"]`                         |  65.594 ns (5%) |           |  192 bytes (1%) |           4 |
| `["HAMT", "insert, size=1"]`                         |  65.015 ns (5%) |           |  208 bytes (1%) |           4 |
| `["HAMT", "insert, size=2"]`                         |  63.245 ns (5%) |           |  208 bytes (1%) |           4 |
| `["HAMT", "insert, size=4"]`                         |  63.908 ns (5%) |           |  224 bytes (1%) |           4 |
| `["HAMT", "insert, size=8"]`                         |  69.670 ns (5%) |           |  512 bytes (1%) |           4 |
| `["HAMT", "insert, size=16"]`                        |  69.619 ns (5%) |           |  624 bytes (1%) |           4 |
| `["HAMT", "insert, size=32"]`                        | 101.133 ns (5%) |           |  464 bytes (1%) |           6 |
| `["HAMT", "insert, size=64"]`                        | 102.006 ns (5%) |           |  528 bytes (1%) |           6 |
| `["HAMT", "insert, size=128"]`                       | 108.866 ns (5%) |           |  576 bytes (1%) |           6 |
| `["HAMT", "insert, size=256"]`                       | 105.794 ns (5%) |           |  592 bytes (1%) |           6 |
| `["HAMT", "insert, size=512"]`                       | 153.153 ns (5%) |           |  672 bytes (1%) |           8 |
| `["HAMT", "insert, size=1024"]`                      | 108.324 ns (5%) |           |   1.31 KiB (1%) |           6 |
| `["HAMT", "insert, size=2048"]`                      | 197.957 ns (5%) |           |   1.45 KiB (1%) |           6 |
| `["HAMT", "insert, size=4096"]`                      | 145.598 ns (5%) |           |  912 bytes (1%) |           8 |
| `["HAMT", "insert, size=8192"]`                      | 166.904 ns (5%) |           |   1.20 KiB (1%) |           8 |
| `["HAMT", "insert, size=16384"]`                     | 158.961 ns (5%) |           |   1.22 KiB (1%) |           8 |

For `Dict` we must `copy` the dictionary to have the persitency requirement we need for scoped values.

```julia
function insert(dict::Base.Dict{K, V}, key::K, v::V) where {K,V}
    dict = copy(dict)
    dict[key] = v
    return dict
end
```

This would also be an in-tree user of #46453.

Kudos to @gbaraldi for bouncing a lot of ideas over the last two weeks.
