### PR TITLE
Add `instancemethods` to retrieve the methods of non-instantiated callable objects

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -790,6 +790,7 @@ export
     isinteractive,
     hasmethod,
     methods,
+    instancemethods,
     nameof,
     parentmodule,
     pathof,

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -974,6 +974,12 @@ function signature_type(@nospecialize(f), @nospecialize(argtypes))
     return rewrap_unionall(Tuple{ft, u.parameters...}, argtypes)
 end
 
+function instance_signature_type(t::Type, @nospecialize(argtypes))
+    argtypes = to_tuple_type(argtypes)
+    u = unwrap_unionall(argtypes)::DataType
+    return rewrap_unionall(Tuple{t,u.parameters...}, argtypes)
+end
+
 """
     code_lowered(f, types; generated=true, debuginfo=:default)
 
@@ -1065,7 +1071,7 @@ end
 """
     methods(f, [types], [module])
 
-Return the method table for `f`.
+Return the method list for `f`.
 
 If `types` is specified, return an array of methods whose types match.
 If `module` is specified, return an array of methods defined in that module.
@@ -1104,6 +1110,69 @@ function methods(@nospecialize(f),
                  mod::Union{Module,AbstractArray{Module},Nothing}=nothing)
     # return all matches
     return methods(f, Tuple{Vararg{Any}}, mod)
+end
+
+function _instancemethods(t::Type, @nospecialize(mt), lim::Int, world::UInt)
+    tt = instance_signature_type(t, mt)
+    return _methods_by_ftype(tt, lim, world)
+end
+
+"""
+    instancemethods(t::Type, [types], [module])
+
+Return the method list for instances of type `t`.
+
+If `types` is specified, return the methods whose types match.
+If `module` is specified, return the methods defined in that module.
+Multiple modules can also be specified as an array.
+
+# Example
+
+The `instancemethods` function enables the return of methods defined for a callable
+object of a given type, eliminating the need to instantiate the object first.
+
+```julia
+julia> struct A{T}
+    x::T
+end
+
+# making the object callable
+julia> (a::A{Float64})(x::Float64) = a.x + x
+julia> (a::A{String})(x::String) = a.x * x
+
+julia> a = A(1.0)
+A{Float64}(1.0)
+
+julia> methods(a) == instancemethods(A{Float64})
+true
+
+julia> length(instancemethods(A{<:Any})) == 2
+true
+```
+
+!!! compat "Julia 1.4"
+    At least Julia 1.4 is required for specifying a module.
+
+See also: [`methods`](@ref).
+"""
+function instancemethods(t::Type,
+    @nospecialize(tmatch),
+    mod::Union{Tuple{Module},AbstractArray{Module},Nothing}=nothing)
+    world = get_world_counter()
+    ms = Method[]
+    for m in _instancemethods(t, tmatch, -1, world)::Vector
+        m = m::Core.MethodMatch
+        (mod === nothing || parentmodule(m.method) ∈ mod) && push!(ms, m.method)
+    end
+    t === Function && return MethodList(ms, typeof(t).name.mt)
+    mt = t isa UnionAll ? unwrap_unionall(t).name.mt : t.name.mt
+    return MethodList(ms, mt)
+end
+instancemethods(t::Type, @nospecialize(tmatch), mod::Module) = instancemethods(t, tmatch, (mod,))
+
+function instancemethods(t::Type,
+    mod::Union{Module,AbstractArray{Module},Nothing}=nothing)
+    return instancemethods(t, Tuple{Vararg{Any}}, mod)
 end
 
 function visit(f, mt::Core.MethodTable)

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -36,6 +36,7 @@ Base.include_dependency
 __init__
 Base.which(::Any, ::Any)
 Base.methods
+Base.instancemethods
 Base.@show
 ans
 err

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -948,6 +948,41 @@ end
     @test length(methods(g, ())) == 1
 end
 
+module TestInstanceMethods
+struct A{T}
+    x::T
+end
+(a::A)(y) = a.x + y
+(a::A)(x::String) = "$x: $a.x"
+(a::A{Float64})(x::Float64) = a.x + x
+
+struct B
+    x::Int
+end
+
+(b::B)(y) = b.x + y
+(b::B)(x::String) = string(b.x) * x
+(b::B)(y::Float64) = b.x + y
+end
+
+@testset "instancemethods" begin
+    using .TestInstanceMethods: A, B
+
+    @test methods(A(1)) == instancemethods(A{Int})
+    @test methods(B(1)) == instancemethods(B)
+
+    @test length(methods(A{<:Any})) == 1
+    @test length(instancemethods(A{<:Any})) == 3
+
+    @test methods(A("s")) == instancemethods(A{String})
+
+    @test length(methods(A{String})) == 1
+    @test length(instancemethods(A{String})) == 2
+
+    @test length(methods(B)) == 2
+    @test length(instancemethods(B)) == 3
+end
+
 module BodyFunctionLookup
 f1(x, y; a=1) = error("oops")
 f2(f::Function, args...; kwargs...) = f1(args...; kwargs...)


### PR DESCRIPTION
The current PR is a follow-up to the previous (now closed) [PR discussion](https://github.com/JuliaLang/julia/pull/50898).

Besides the context provided above, I still want this to be standalone, so I'll add the relevant information below (naturally, there will be an overlap with the previous PR).

# Rationale

The inception of this PR started [here](https://discourse.julialang.org/t/how-to-determine-the-methods-for-a-callable-object-without-instantiating-it/102618?u=algunion) by observing that there is no easy way to determine the methods for a callable object without instantiating it.

For the following scenario, there is no way to use `methods` and retrieve the `method` list of the callable object without actually instantiating it first:
```julia
struct A{T} x::T end
(a::A)(y) = a.x+y
```
Calling `methods(A}` will return the constructor methods. Callable object methods are only retrievable (before this PR) by performing the `methods(A(1))` call.

This is not practical at all (especially if the object construction is expensive). But even more, since the instances are of concrete types, extending the callable object methods in the following way will imply multiple instances construction and multiple `methods` calls in order to get the complete method collection defined for different `A{T}` types. 
```julia
(a::A{Float64})(x::Float64) = a.x + x
(a::A{String})(x::String) = a.x * x

# A{Float64}(1.0) instance and A{String}("s") needed
afloat = A(1.0)
astring = A("s")

methods(afloat)
methods(astring) 
```

# Enter `instancemethods`

The current PR introduces the `instancemethods` function. Instead of constructing an instance, the methods defined for a callable object can now be retrieved by calling `instancemethods` with the type of the object.

```julia
julia> struct A{T}
    x::T
end

# making the object callable
julia> (a::A{Float64})(x::Float64) = a.x + x
julia> (a::A{String})(x::String) = a.x * x

julia> a = A(1.0)
A{Float64}(1.0)

julia> methods(a) == instancemethods(A{Float64})
true

julia> length(instancemethods(A{<:Any})) == 2
true
```

Additionally, getting the complete collection of methods defined for the callable object types derived from A{T} is possible by the usage of `instancemethods(A{<:Any})`.

# Potential discussion: `instancemethods(Function)`

Calling `instancemethods(Function)` will actually return all the methods defined for all the instances of `Function` from all modules.  This returns a method list of length equal to 28184 (in my branch of 1.11.0-DEV.355). And one can also retrieve all methods relative to module/modules (e.g., `instancemethods(Function, Base)`. 

This `Function` related functionality is more like a side-effect (but it is understandable since the actual functions are instances of `Function`). 

At this point, I don't see a good reason to restrict the `instancemethods(Function)` usage - however, I want to point out that I observed the behavior, and I am open to changing this behavior if somebody provides reasons that I might miss.

## Small wording change in `methods` doc

This PR also slightly changed the wording in `methods` docs (*method table* ---> *method list*). The reason is obvious: `methods` does not return a `Core.MethodTable`; it actually returns `Base.MethodList`).