### PR TITLE
effects: allow override of `:nonoverlayed` effect bit (and rename it to `:native_executable`)

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -465,7 +465,7 @@ macro _foldable_meta()
         #=:notaskstate=#false,
         #=:inaccessiblememonly=#false,
         #=:noub=#true,
-        #=:nonoverlayed=#false))
+        #=:native_executable=#false))
 end
 
 const NTuple{N,T} = Tuple{Vararg{T,N}}

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -464,7 +464,8 @@ macro _foldable_meta()
         #=:terminates_locally=#false,
         #=:notaskstate=#false,
         #=:inaccessiblememonly=#false,
-        #=:noub=#true))
+        #=:noub=#true,
+        #=:nonoverlayed=#false))
 end
 
 const NTuple{N,T} = Tuple{Vararg{T,N}}

--- a/base/c.jl
+++ b/base/c.jl
@@ -715,6 +715,6 @@ macro ccall(expr)
     return ccall_macro_lower(:ccall, ccall_macro_parse(expr)...)
 end
 
-macro ccall_effects(effects::UInt8, expr)
+macro ccall_effects(effects::UInt32, expr)
     return ccall_macro_lower((:ccall, effects), ccall_macro_parse(expr)...)
 end

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -451,10 +451,10 @@ function add_call_backedges!(interp::AbstractInterpreter, @nospecialize(rettype)
     # don't bother to add backedges when both type and effects information are already
     # maximized to the top since a new method couldn't refine or widen them anyway
     if rettype === Any
-        # ignore the `:nonoverlayed` property if `interp` doesn't use overlayed method table
+        # ignore the `:native_executable` property if `interp` doesn't use overlayed method table
         # since it will never be tainted anyway
         if !isoverlayed(method_table(interp))
-            all_effects = Effects(all_effects; nonoverlayed=false)
+            all_effects = Effects(all_effects; native_executable=false)
         end
         if (# ignore the `:noinbounds` property if `:consistent`-cy is tainted already
             (sv isa InferenceState && sv.ipo_effects.consistent === ALWAYS_FALSE) ||
@@ -854,7 +854,7 @@ function concrete_eval_eligible(interp::AbstractInterpreter,
     mi = result.edge
     if mi !== nothing && is_foldable(effects)
         if f !== nothing && is_all_const_arg(arginfo, #=start=#2)
-            if is_nonoverlayed(interp) || is_nonoverlayed(effects)
+            if is_native_executable(interp) || is_native_executable(effects)
                 return :concrete_eval
             end
             # disable concrete-evaluation if this function call is tainted by some overlayed

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2557,7 +2557,7 @@ function abstract_eval_foreigncall(interp::AbstractInterpreter, e::Expr, vtypes:
         abstract_eval_value(interp, x, vtypes, sv)
     end
     cconv = e.args[5]
-    if isa(cconv, QuoteNode) && (v = cconv.value; isa(v, Tuple{Symbol, UInt8}))
+    if isa(cconv, QuoteNode) && (v = cconv.value; isa(v, Tuple{Symbol, UInt32}))
         override = decode_effects_override(v[2])
         effects = Effects(effects;
             consistent          = override.consistent ? ALWAYS_TRUE : effects.consistent,

--- a/base/compiler/effects.jl
+++ b/base/compiler/effects.jl
@@ -258,29 +258,32 @@ struct EffectsOverride
     notaskstate::Bool
     inaccessiblememonly::Bool
     noub::Bool
+    nonoverlayed::Bool
 end
 
 function encode_effects_override(eo::EffectsOverride)
-    e = 0x00
-    eo.consistent          && (e |= (0x01 << 0))
-    eo.effect_free         && (e |= (0x01 << 1))
-    eo.nothrow             && (e |= (0x01 << 2))
-    eo.terminates_globally && (e |= (0x01 << 3))
-    eo.terminates_locally  && (e |= (0x01 << 4))
-    eo.notaskstate         && (e |= (0x01 << 5))
-    eo.inaccessiblememonly && (e |= (0x01 << 6))
-    eo.noub                && (e |= (0x01 << 7))
+    e = zero(UInt32)
+    eo.consistent          && (e |= (1 << 0) % UInt32)
+    eo.effect_free         && (e |= (1 << 1) % UInt32)
+    eo.nothrow             && (e |= (1 << 2) % UInt32)
+    eo.terminates_globally && (e |= (1 << 3) % UInt32)
+    eo.terminates_locally  && (e |= (1 << 4) % UInt32)
+    eo.notaskstate         && (e |= (1 << 5) % UInt32)
+    eo.inaccessiblememonly && (e |= (1 << 6) % UInt32)
+    eo.noub                && (e |= (1 << 7) % UInt32)
+    eo.nonoverlayed        && (e |= (1 << 8) % UInt32)
     return e
 end
 
-function decode_effects_override(e::UInt8)
+function decode_effects_override(e::UInt32)
     return EffectsOverride(
-        (e & (0x01 << 0)) != 0x00,
-        (e & (0x01 << 1)) != 0x00,
-        (e & (0x01 << 2)) != 0x00,
-        (e & (0x01 << 3)) != 0x00,
-        (e & (0x01 << 4)) != 0x00,
-        (e & (0x01 << 5)) != 0x00,
-        (e & (0x01 << 6)) != 0x00,
-        (e & (0x01 << 7)) != 0x00)
+        !iszero(e & (1 << 0)),
+        !iszero(e & (1 << 1)),
+        !iszero(e & (1 << 2)),
+        !iszero(e & (1 << 3)),
+        !iszero(e & (1 << 4)),
+        !iszero(e & (1 << 5)),
+        !iszero(e & (1 << 6)),
+        !iszero(e & (1 << 7)),
+        !iszero(e & (1 << 8)))
 end

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -297,7 +297,7 @@ mutable struct InferenceState
         end
 
         if def isa Method
-            ipo_effects = Effects(ipo_effects; nonoverlayed=is_nonoverlayed(def))
+            ipo_effects = Effects(ipo_effects; native_executable=is_native_executable(def))
         end
 
         restrict_abstract_call_sites = isa(def, Module)
@@ -318,8 +318,9 @@ mutable struct InferenceState
     end
 end
 
-is_nonoverlayed(m::Method) = !isdefined(m, :external_mt)
-is_nonoverlayed(interp::AbstractInterpreter) = !isoverlayed(method_table(interp))
+is_native_executable(m::Method) = !isdefined(m, :external_mt)
+is_native_executable(interp::AbstractInterpreter) = !isoverlayed(method_table(interp))
+
 isoverlayed(::MethodTableView) = error("unsatisfied MethodTableView interface")
 isoverlayed(::InternalMethodTable) = false
 isoverlayed(::OverlayMethodTable) = true

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -15,7 +15,7 @@ function concrete_eval_invoke(interp::AbstractInterpreter,
     argtypes === nothing && return Pair{Any,Bool}(Bottom, false)
     effects = decode_effects(code.ipo_purity_bits)
     if (is_foldable(effects) && is_all_const_arg(argtypes, #=start=#1) &&
-        (is_nonoverlayed(interp) || is_nonoverlayed(effects)))
+        (is_native_executable(interp) || is_native_executable(effects)))
         args = collect_const_args(argtypes, #=start=#1)
         value = let world = get_world_counter(interp)
             try

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -1020,7 +1020,7 @@ function Base.show(io::IO, e::Effects)
     print(io, ',')
     printstyled(io, effectbits_letter(e, :noinbounds, 'i'); color=effectbits_color(e, :noinbounds))
     print(io, ')')
-    e.nonoverlayed || printstyled(io, '′'; color=:red)
+    e.native_executable || printstyled(io, '′'; color=:red)
 end
 
 @specialize

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -500,6 +500,9 @@ function adjust_effects(sv::InferenceState)
         if is_effect_overridden(override, :noub)
             ipo_effects = Effects(ipo_effects; noub=true)
         end
+        if is_effect_overridden(override, :nonoverlayed)
+            ipo_effects = Effects(ipo_effects; nonoverlayed=true)
+        end
     end
 
     return ipo_effects

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -500,8 +500,8 @@ function adjust_effects(sv::InferenceState)
         if is_effect_overridden(override, :noub)
             ipo_effects = Effects(ipo_effects; noub=true)
         end
-        if is_effect_overridden(override, :nonoverlayed)
-            ipo_effects = Effects(ipo_effects; nonoverlayed=true)
+        if is_effect_overridden(override, :native_executable)
+            ipo_effects = Effects(ipo_effects; native_executable=true)
         end
     end
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -209,7 +209,8 @@ macro _total_meta()
         #=:terminates_locally=#false,
         #=:notaskstate=#true,
         #=:inaccessiblememonly=#true,
-        #=:noub=#true))
+        #=:noub=#true,
+        #=:nonoverlayed=#false))
 end
 # can be used in place of `@assume_effects :foldable` (supposed to be used for bootstrapping)
 macro _foldable_meta()
@@ -221,7 +222,8 @@ macro _foldable_meta()
         #=:terminates_locally=#false,
         #=:notaskstate=#false,
         #=:inaccessiblememonly=#true,
-        #=:noub=#true))
+        #=:noub=#true,
+        #=:nonoverlayed=#false))
 end
 # can be used in place of `@assume_effects :nothrow` (supposed to be used for bootstrapping)
 macro _nothrow_meta()
@@ -233,7 +235,8 @@ macro _nothrow_meta()
         #=:terminates_locally=#false,
         #=:notaskstate=#false,
         #=:inaccessiblememonly=#false,
-        #=:noub=#false))
+        #=:noub=#false,
+        #=:nonoverlayed=#false))
 end
 # can be used in place of `@assume_effects :terminates_locally` (supposed to be used for bootstrapping)
 macro _terminates_locally_meta()
@@ -245,7 +248,8 @@ macro _terminates_locally_meta()
         #=:terminates_locally=#true,
         #=:notaskstate=#false,
         #=:inaccessiblememonly=#false,
-        #=:noub=#false))
+        #=:noub=#false,
+        #=:nonoverlayed=#false))
 end
 # can be used in place of `@assume_effects :effect_free :terminates_locally` (supposed to be used for bootstrapping)
 macro _effect_free_terminates_locally_meta()
@@ -257,7 +261,8 @@ macro _effect_free_terminates_locally_meta()
         #=:terminates_locally=#true,
         #=:notaskstate=#false,
         #=:inaccessiblememonly=#false,
-        #=:noub=#false))
+        #=:noub=#false,
+        #=:nonoverlayed=#false))
 end
 
 # another version of inlining that propagates an inbounds context

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -210,7 +210,7 @@ macro _total_meta()
         #=:notaskstate=#true,
         #=:inaccessiblememonly=#true,
         #=:noub=#true,
-        #=:nonoverlayed=#false))
+        #=:native_executable=#false))
 end
 # can be used in place of `@assume_effects :foldable` (supposed to be used for bootstrapping)
 macro _foldable_meta()
@@ -223,7 +223,7 @@ macro _foldable_meta()
         #=:notaskstate=#false,
         #=:inaccessiblememonly=#true,
         #=:noub=#true,
-        #=:nonoverlayed=#false))
+        #=:native_executable=#false))
 end
 # can be used in place of `@assume_effects :nothrow` (supposed to be used for bootstrapping)
 macro _nothrow_meta()
@@ -236,7 +236,7 @@ macro _nothrow_meta()
         #=:notaskstate=#false,
         #=:inaccessiblememonly=#false,
         #=:noub=#false,
-        #=:nonoverlayed=#false))
+        #=:native_executable=#false))
 end
 # can be used in place of `@assume_effects :terminates_locally` (supposed to be used for bootstrapping)
 macro _terminates_locally_meta()
@@ -249,7 +249,7 @@ macro _terminates_locally_meta()
         #=:notaskstate=#false,
         #=:inaccessiblememonly=#false,
         #=:noub=#false,
-        #=:nonoverlayed=#false))
+        #=:native_executable=#false))
 end
 # can be used in place of `@assume_effects :effect_free :terminates_locally` (supposed to be used for bootstrapping)
 macro _effect_free_terminates_locally_meta()
@@ -262,7 +262,7 @@ macro _effect_free_terminates_locally_meta()
         #=:notaskstate=#false,
         #=:inaccessiblememonly=#false,
         #=:noub=#false,
-        #=:nonoverlayed=#false))
+        #=:native_executable=#false))
 end
 
 # another version of inlining that propagates an inbounds context

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -87,7 +87,11 @@ end
 
 # This is @assume_effects :effect_free :nothrow :terminates_globally @ccall jl_alloc_string(n::Csize_t)::Ref{String},
 # but the macro is not available at this time in bootstrap, so we write it manually.
-@eval _string_n(n::Integer) = $(Expr(:foreigncall, QuoteNode(:jl_alloc_string), Ref{String}, Expr(:call, Expr(:core, :svec), :Csize_t), 1, QuoteNode((:ccall,0xe)), :(convert(Csize_t, n))))
+@eval function _string_n(n::Integer)
+    return $(Expr(:foreigncall, QuoteNode(:jl_alloc_string), Ref{String},
+        Expr(:call, Expr(:core, :svec), :Csize_t), 1, QuoteNode((:ccall, 0x0000000e)),
+        :(convert(Csize_t, n))))
+end
 
 """
     String(s::AbstractString)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3005,7 +3005,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             jl_bool_type,
                             jl_uint8_type,
                             jl_uint8_type,
-                            jl_uint8_type,
+                            jl_uint32_type,
                             jl_uint16_type),
                         jl_emptysvec,
                         0, 1, 22);
@@ -3074,7 +3074,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             jl_bool_type,
                             jl_uint8_type,
                             jl_uint8_type,
-                            jl_uint8_type),
+                            jl_uint32_type),
                         jl_emptysvec,
                         0, 1, 10);
     //const static uint32_t method_constfields[1] = { 0x03fc065f }; // (1<<0)|(1<<1)|(1<<2)|(1<<3)|(1<<4)|(1<<6)|(1<<9)|(1<<10)|(1<<18)|(1<<19)|(1<<20)|(1<<21)|(1<<22)|(1<<23)|(1<<24)|(1<<25);

--- a/src/julia.h
+++ b/src/julia.h
@@ -269,8 +269,9 @@ typedef union __jl_purity_overrides_t {
         uint8_t ipo_notaskstate         : 1;
         uint8_t ipo_inaccessiblememonly : 1;
         uint8_t ipo_noub                : 1;
+        uint8_t ipo_nonoverlayed        : 1;
     } overrides;
-    uint8_t bits;
+    uint32_t bits;
 } _jl_purity_overrides_t;
 
 // This type describes a single function body
@@ -428,22 +429,24 @@ typedef struct _jl_code_instance_t {
     // see also encode_effects() and decode_effects() in `base/compiler/effects.jl`,
     uint32_t ipo_purity_bits;
     // ipo_purity_flags:
-    //     uint8_t ipo_consistent          : 2;
+    //     uint8_t ipo_consistent          : 3;
     //     uint8_t ipo_effect_free         : 2;
-    //     uint8_t ipo_nothrow             : 2;
-    //     uint8_t ipo_terminates          : 2;
-    //     uint8_t ipo_nonoverlayed        : 1;
+    //     uint8_t ipo_nothrow             : 1;
+    //     uint8_t ipo_terminates          : 1;
     //     uint8_t ipo_notaskstate         : 2;
     //     uint8_t ipo_inaccessiblememonly : 2;
+    //     uint8_t ipo_nonoverlayed        : 1;
+    //     uint8_t ipo_noinbounds          : 1;
     _Atomic(uint32_t) purity_bits;
     // purity_flags:
-    //     uint8_t consistent          : 2;
-    //     uint8_t effect_free         : 2;
-    //     uint8_t nothrow             : 2;
-    //     uint8_t terminates          : 2;
-    //     uint8_t nonoverlayed        : 1;
-    //     uint8_t notaskstate         : 2;
-    //     uint8_t inaccessiblememonly : 2;
+    //     uint8_t ipo_consistent          : 3;
+    //     uint8_t ipo_effect_free         : 2;
+    //     uint8_t ipo_nothrow             : 1;
+    //     uint8_t ipo_terminates          : 1;
+    //     uint8_t ipo_notaskstate         : 2;
+    //     uint8_t ipo_inaccessiblememonly : 2;
+    //     uint8_t ipo_nonoverlayed        : 1;
+    //     uint8_t ipo_noinbounds          : 1;
     jl_value_t *argescapes; // escape information of call arguments
 
     // compilation state cache

--- a/src/julia.h
+++ b/src/julia.h
@@ -269,7 +269,7 @@ typedef union __jl_purity_overrides_t {
         uint8_t ipo_notaskstate         : 1;
         uint8_t ipo_inaccessiblememonly : 1;
         uint8_t ipo_noub                : 1;
-        uint8_t ipo_nonoverlayed        : 1;
+        uint8_t ipo_native_executable   : 1;
     } overrides;
     uint32_t bits;
 } _jl_purity_overrides_t;
@@ -435,7 +435,7 @@ typedef struct _jl_code_instance_t {
     //     uint8_t ipo_terminates          : 1;
     //     uint8_t ipo_notaskstate         : 2;
     //     uint8_t ipo_inaccessiblememonly : 2;
-    //     uint8_t ipo_nonoverlayed        : 1;
+    //     uint8_t ipo_native_executable   : 1;
     //     uint8_t ipo_noinbounds          : 1;
     _Atomic(uint32_t) purity_bits;
     // purity_flags:
@@ -445,7 +445,7 @@ typedef struct _jl_code_instance_t {
     //     uint8_t ipo_terminates          : 1;
     //     uint8_t ipo_notaskstate         : 2;
     //     uint8_t ipo_inaccessiblememonly : 2;
-    //     uint8_t ipo_nonoverlayed        : 1;
+    //     uint8_t ipo_native_executable   : 1;
     //     uint8_t ipo_noinbounds          : 1;
     jl_value_t *argescapes; // escape information of call arguments
 

--- a/src/method.c
+++ b/src/method.c
@@ -192,7 +192,7 @@ static jl_value_t *resolve_globals(jl_value_t *expr, jl_module_t *module, jl_sve
                         jl_error("In ccall calling convention, expected two argument tuple or symbol.");
                     }
                     JL_TYPECHK(ccall method definition, symbol, jl_get_nth_field(cc, 0));
-                    JL_TYPECHK(ccall method definition, uint8, jl_get_nth_field(cc, 1));
+                    JL_TYPECHK(ccall method definition, uint32, jl_get_nth_field(cc, 1));
                 }
                 jl_exprargset(e, 0, resolve_globals(jl_exprarg(e, 0), module, sparam_vals, binding_effects, 1));
                 i++;
@@ -328,7 +328,7 @@ static void jl_code_info_set_ir(jl_code_info_t *li, jl_expr_t *ir)
                 else if (ma == (jl_value_t*)jl_no_constprop_sym)
                     li->constprop = 2;
                 else if (jl_is_expr(ma) && ((jl_expr_t*)ma)->head == jl_purity_sym) {
-                    if (jl_expr_nargs(ma) == 8) {
+                    if (jl_expr_nargs(ma) == 9) {
                         li->purity.overrides.ipo_consistent = jl_unbox_bool(jl_exprarg(ma, 0));
                         li->purity.overrides.ipo_effect_free = jl_unbox_bool(jl_exprarg(ma, 1));
                         li->purity.overrides.ipo_nothrow = jl_unbox_bool(jl_exprarg(ma, 2));
@@ -337,6 +337,7 @@ static void jl_code_info_set_ir(jl_code_info_t *li, jl_expr_t *ir)
                         li->purity.overrides.ipo_notaskstate = jl_unbox_bool(jl_exprarg(ma, 5));
                         li->purity.overrides.ipo_inaccessiblememonly = jl_unbox_bool(jl_exprarg(ma, 6));
                         li->purity.overrides.ipo_noub = jl_unbox_bool(jl_exprarg(ma, 7));
+                        li->purity.overrides.ipo_nonoverlayed = jl_unbox_bool(jl_exprarg(ma, 8));
                     }
                 }
                 else

--- a/src/method.c
+++ b/src/method.c
@@ -337,7 +337,7 @@ static void jl_code_info_set_ir(jl_code_info_t *li, jl_expr_t *ir)
                         li->purity.overrides.ipo_notaskstate = jl_unbox_bool(jl_exprarg(ma, 5));
                         li->purity.overrides.ipo_inaccessiblememonly = jl_unbox_bool(jl_exprarg(ma, 6));
                         li->purity.overrides.ipo_noub = jl_unbox_bool(jl_exprarg(ma, 7));
-                        li->purity.overrides.ipo_nonoverlayed = jl_unbox_bool(jl_exprarg(ma, 8));
+                        li->purity.overrides.ipo_native_executable = jl_unbox_bool(jl_exprarg(ma, 8));
                     }
                 }
                 else

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -383,7 +383,7 @@ end
 # Test effect/inference for merge/diff of unknown NamedTuples
 for f in (Base.merge, Base.structdiff)
     let eff = Base.infer_effects(f, Tuple{NamedTuple, NamedTuple})
-        @test Core.Compiler.is_foldable(eff) && eff.nonoverlayed
+        @test Core.Compiler.is_foldable(eff) && eff.native_executable
     end
     @test Core.Compiler.return_type(f, Tuple{NamedTuple, NamedTuple}) == NamedTuple
 end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1021,7 +1021,7 @@ ambig_effects_test(a, b) = 1
         @test !Core.Compiler.is_effect_free(effects)
         @test !Core.Compiler.is_nothrow(effects)
         @test !Core.Compiler.is_terminates(effects)
-        @test !Core.Compiler.is_nonoverlayed(effects)
+        @test !Core.Compiler.is_native_executable(effects)
     end
     # should account for MethodError
     @test Base.infer_effects(issue41694, (Float64,)) |> !Core.Compiler.is_nothrow # definitive dispatch error


### PR DESCRIPTION
Certain external `AbstractInterpreters`, such as GPUCompiler.jl, have
long sought the ability to allow concrete evaluation for specific
overlay-ed methods to achieve optimal inference accuracy. This is
currently not permitted, although it should be safe when an overlay-ed
method has the same semantics as the original method, and its result can
be safely replaced with the result of the original method. Refer to
JuliaGPU/GPUCompiler.jl#384 for more examples.

To address this issue, this commit introduces the capability to override
the `:nonoverlayed` effect bit using `@assume_effects`. With the
enhancements in PR #51078, this override behaves similarly to other
effect bits. 

However, it now seems awkward to annotate a method with `Base.@assume_effects :nonoverlayed`
when it is actually marked with `@overlay`. Thus the second commit
replaces `:nonoverlayed` with (hopefully) more appropriate terminology,
`:native_executable`. This terminology is intended to indicate that the
method is concrete-evaluable. More specifically, it means that 
(quoting from the new `Base.@assume_effects` docstring):
> The `:native_executable` setting asserts that this method can be executed using Julia's
> native compiler and runtime. Currently this particularly implies that any methods defined
> in an [`OverlayMethodTable`](@ref Core.Compiler.OverlayMethodTable) (including this method in
> question) are never be called during executing the method. However, it is worth noting that
> it is safe to annotate [`@overlay`](@ref Base.Experimental.@overlay) method as
> `:native_executable` when the overlay-ed method has the same semantics as the original
> method and its result can safely be replaced with the result of the original method.

Consequently, external `AbstractInterpreters` can utilize
this feature to permit concrete evaluation for annotated overlay-ed
methods, e.g.
```julia
Base.@assume_effects :foldable function fact(x::Int)
    1 < x < 20 || error("x is too big")
    return factorial(x)
end

@overlay GPU_MT_TABLE Base.@assume_effects :foldable :native_executable function fact(x::Int)
    1 < x < 20 || raise_on_gpu("x is too big")
    return factorial(x)
end
raise_on_gpu(x) = #=do something with GPU=# error(x)
```
