### PR TITLE
reflection: fix up handling of `Core.Compile.findall`

### DIFF
--- a/base/compiler/methodtable.jl
+++ b/base/compiler/methodtable.jl
@@ -122,7 +122,7 @@ end
 
 """
     findsup(sig::Type, view::MethodTableView) ->
-        (match::MethodMatch, valid_worlds::WorldRange, overlayed::Bool) or nothing
+        (match::Union{MethodMatch,Nothing}, valid_worlds::WorldRange, overlayed::Bool)
 
 Find the (unique) method such that `sig <: match.method.sig`, while being more
 specific than any other method with the same property. In other words, find the method

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1634,8 +1634,9 @@ function infer_effects(@nospecialize(f), @nospecialize(types=default_tt(f));
     end
     tt = signature_type(f, types)
     result = Core.Compiler.findall(tt, Core.Compiler.method_table(interp))
-    if result === missing
-        # unanalyzable call, return the unknown effects
+    if result === nothing
+        # unanalyzable call, i.e. the interpreter world might be newer than the world where
+        # the `f` is defined, return the unknown effects
         return Core.Compiler.Effects()
     end
     (; matches) = result


### PR DESCRIPTION
`Core.Compiler.findall(sig, ::MethodTableView)` may return `nothing`
but never returns `missing`.

Also fixes up the docstring of `Core.Compiler.findsup`.