### PR TITLE
add `delete` for key[s] in a NamedTuple

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@ New library functions
 ---------------------
 * `copyuntil(out, io, delim)` and `copyline(out, io)` copy data into an `out::IO` stream ([#48273]).
 * `delete(nt::NamedTuple, key::Symbol)` returns `nt` without the entry named by `key`.
+- `delete(nt::NamedTuple, keys::Tuple{Vararg{Symbol}})` returns `nt` without the entris named by `keys`.
 
 New library features
 --------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@ Build system changes
 New library functions
 ---------------------
 * `copyuntil(out, io, delim)` and `copyline(out, io)` copy data into an `out::IO` stream ([#48273]).
+* `delete(nt::NamedTuple, key::Symbol)` returns `nt` without the entry named by `key`.
 
 New library features
 --------------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 export
-# Modules
+    # Modules
     Meta,
     StackTraces,
     Sys,
@@ -12,7 +12,7 @@ export
     Broadcast,
     MathConstants,
 
-# Types
+    # Types
     AbstractChannel,
     AbstractIrrational,
     AbstractMatrix,
@@ -103,7 +103,7 @@ export
     VersionNumber,
     WeakKeyDict,
 
-# Ccall types
+    # Ccall types
     Cchar,
     Cdouble,
     Cfloat,
@@ -125,7 +125,7 @@ export
     Cstring,
     Cwstring,
 
-# Exceptions
+    # Exceptions
     CanonicalIndexError,
     CapturedException,
     CompositeException,
@@ -139,7 +139,7 @@ export
     SystemError,
     StringIndexError,
 
-# Global constants and variables
+    # Global constants and variables
     ARGS,
     C_NULL,
     DEPOT_PATH,
@@ -153,7 +153,7 @@ export
     VERSION,
     devnull,
 
-# Mathematical constants
+    # Mathematical constants
     Inf,
     Inf16,
     Inf32,
@@ -166,7 +166,7 @@ export
     π, pi,
     ℯ,
 
-# Operators
+    # Operators
     !,
     !=,
     ≠,
@@ -204,11 +204,11 @@ export
     |,
     |>,
     ~,
-    :,
+    : ,
     =>,
     ∘,
 
-# scalar math
+    # scalar math
     @evalpoly,
     evalpoly,
     abs,
@@ -369,7 +369,7 @@ export
     ≈,
     ≉,
 
-# arrays
+    # arrays
     axes,
     broadcast!,
     broadcast,
@@ -460,7 +460,7 @@ export
     view,
     zeros,
 
-# search, find, match and related functions
+    # search, find, match and related functions
     contains,
     eachmatch,
     endswith,
@@ -481,18 +481,18 @@ export
     insorted,
     startswith,
 
-# linear algebra
+    # linear algebra
     var"'", # to enable syntax a' for adjoint
     adjoint,
     transpose,
     kron,
     kron!,
 
-# bitarrays
+    # bitarrays
     falses,
     trues,
 
-# dequeues
+    # dequeues
     append!,
     insert!,
     pop!,
@@ -503,7 +503,7 @@ export
     popfirst!,
     pushfirst!,
 
-# collections
+    # collections
     all!,
     all,
     allequal,
@@ -514,6 +514,7 @@ export
     collect,
     count!,
     count,
+    delete,
     delete!,
     deleteat!,
     keepat!,
@@ -579,7 +580,7 @@ export
     ∩,
     ∪,
 
-# strings
+    # strings
     ascii,
     bitstring,
     bytes2hex,
@@ -636,7 +637,7 @@ export
     uppercase,
     uppercasefirst,
 
-# text output
+    # text output
     IOContext,
     displaysize,
     dump,
@@ -648,13 +649,13 @@ export
     sprint,
     summary,
 
-# logging
+    # logging
     @debug,
     @info,
     @warn,
     @error,
 
-# bigfloat & precision
+    # bigfloat & precision
     precision,
     rounding,
     setprecision,
@@ -662,13 +663,13 @@ export
     get_zero_subnormals,
     set_zero_subnormals,
 
-# iteration
+    # iteration
     iterate,
     enumerate,  # re-exported from Iterators
     zip,
     only,
 
-# object identity and equality
+    # object identity and equality
     copy,
     deepcopy,
     hash,
@@ -683,7 +684,7 @@ export
     objectid,
     sizeof,
 
-# tasks and conditions
+    # tasks and conditions
     Condition,
     current_task,
     islocked,
@@ -706,14 +707,14 @@ export
     asyncmap!,
     errormonitor,
 
-# channels
+    # channels
     take!,
     put!,
     isready,
     fetch,
     bind,
 
-# missing values
+    # missing values
     coalesce,
     @coalesce,
     ismissing,
@@ -724,12 +725,12 @@ export
     isnothing,
     nonmissingtype,
 
-# time
+    # time
     sleep,
     time,
     time_ns,
 
-# errors
+    # errors
     backtrace,
     catch_backtrace,
     current_exceptions,
@@ -738,10 +739,10 @@ export
     retry,
     systemerror,
 
-# stack traces
+    # stack traces
     stacktrace,
 
-# types
+    # types
     convert,
     getproperty,
     setproperty!,
@@ -772,7 +773,7 @@ export
     typejoin,
     widen,
 
-# syntax
+    # syntax
     esc,
     gensym,
     @kwdef,
@@ -781,7 +782,7 @@ export
     @macroexpand,
     parse,
 
-# help and reflection
+    # help and reflection
     code_typed,
     code_lowered,
     fullname,
@@ -802,26 +803,26 @@ export
     invokelatest,
     @invokelatest,
 
-# loading source files
+    # loading source files
     __precompile__,
     evalfile,
     include_string,
     include_dependency,
 
-# RTS internals
+    # RTS internals
     GC,
     finalizer,
     finalize,
     precompile,
 
-# misc
+    # misc
     atexit,
     atreplinit,
     exit,
     ntuple,
     splat,
 
-# I/O and events
+    # I/O and events
     close,
     closewrite,
     countlines,
@@ -876,7 +877,7 @@ export
     unsafe_write,
     write,
 
-# multimedia I/O
+    # multimedia I/O
     AbstractDisplay,
     display,
     displayable,
@@ -891,7 +892,7 @@ export
     HTML,
     Text,
 
-# paths and file names
+    # paths and file names
     abspath,
     basename,
     dirname,
@@ -909,7 +910,7 @@ export
     splitext,
     splitpath,
 
-# filesystem operations
+    # filesystem operations
     cd,
     chmod,
     chown,
@@ -955,7 +956,7 @@ export
     uperm,
     walkdir,
 
-# external processes
+    # external processes
     detach,
     getpid,
     ignorestatus,
@@ -969,7 +970,7 @@ export
     success,
     withenv,
 
-# C interface
+    # C interface
     @cfunction,
     @ccall,
     cglobal,
@@ -987,11 +988,11 @@ export
     unsafe_store!,
     unsafe_swap!,
 
-# implemented in Random module
+    # implemented in Random module
     rand,
     randn,
 
-# Macros
+    # Macros
     # parser internal
     @__FILE__,
     @__DIR__,
@@ -1050,9 +1051,7 @@ export
     @noinline,
     @nospecialize,
     @specialize,
-    @polly,
-
-    @assert,
+    @polly, @assert,
     @atomic,
     @atomicswap,
     @atomicreplace,

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -428,7 +428,7 @@ julia> delete((a=1, b=2, c=3), (:c, :b))
 (a = 1,)
 ```
 """
-function delete(a::NamedTuple{an}, @nospecialize(key::Symbol)) where {an}
+function delete(a::NamedTuple{an}, key::Symbol) where {an}
     names = diff_names(an, (key,))
     NamedTuple{names}(a)
 end

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -415,19 +415,26 @@ end
 end
 
 """
-    delete(a::NamedTuple, field::Symbol)
+    delete(a::NamedTuple, keys::Union{Symbol, Tuple{Vararg{Symbol}}})
 
-Construct a new named tuple from `a` by removing the named field.
+Construct a new named tuple from `a` by removing the named entries.
 
 ```jldoctest
 julia> delete((a=1, b=2, c=3), :a)
 (b = 2, c = 3)
 julia> delete((a=1, b=2, c=3), :b)
 (a = 1, c = 3)
+julia> delete((a=1, b=2, c=3), (:c, :b))
+(a = 1,)
 ```
 """
-function delete(a::NamedTuple{an}, field::Symbol) where {an}
-    names = diff_names(an, (field,))
+function delete(a::NamedTuple{an}, @nospecialize(key::Symbol)) where {an}
+    names = diff_names(an, (key,))
+    NamedTuple{names}(a)
+end
+
+function delete(a::NamedTuple{an}, @nospecialize(keys::Tuple{Vararg{Symbol}})) where {an}
+    names = diff_names(an, keys)
     NamedTuple{names}(a)
 end
 

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -276,6 +276,7 @@ abstr_nt_22194_3()
 @test Base.delete((a=1, b=2), :a) == (b=2,)
 @test Base.delete((a=1, b=2, c=3), :b) == (a=1, c=3)
 @test Base.delete((a=1, b=2, c=3), :z) == (a=1, b=2, c=3)
+@test Base.delete((a=1, b=2, c=3), (:b, :a)) == (c=3,)
 
 @test Base.structdiff((a=1, b=2), (b=3,)) == (a=1,)
 @test Base.structdiff((a=1, b=2, z=20), (b=3,)) == (a=1, z=20)

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -1,3 +1,4 @@
+
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 @test_throws TypeError NamedTuple{1,Tuple{}}
@@ -271,6 +272,11 @@ end
 abstr_nt_22194_3()
 @test Base.return_types(abstr_nt_22194_3, ()) == Any[Any]
 
+@test Base.delete((a=1,), :a) == NamedTuple()
+@test Base.delete((a=1, b=2), :a) == (b=2,)
+@test Base.delete((a=1, b=2, c=3), :b) == (a=1, c=3)
+@test Base.delete((a=1, b=2, c=3), :z) == (a=1, b=2, c=3)
+
 @test Base.structdiff((a=1, b=2), (b=3,)) == (a=1,)
 @test Base.structdiff((a=1, b=2, z=20), (b=3,)) == (a=1, z=20)
 @test Base.structdiff((a=1, b=2, z=20), (b=3, q=20, z=1)) == (a=1,)
@@ -378,7 +384,7 @@ end
     @test mapfoldl(abs, =>, (;), init=-10) == -10
     @test mapfoldl(abs, Pair{Any,Any}, NamedTuple(Symbol(:x,i) => i for i in 1:30)) == mapfoldl(abs, Pair{Any,Any}, [1:30;])
     @test_throws "reducing over an empty collection" mapfoldl(abs, =>, (;))
-end
+    end
 
 # Test effect/inference for merge/diff of unknown NamedTuples
 for f in (Base.merge, Base.structdiff)


### PR DESCRIPTION
Replaces #27725

This PR updates [delete for NamedTuples](https://github.com/JuliaLang/julia/pull/27725). See that (closed) PR for much discussion.  This revision supports deleting one or more keys from a NamedTuple.
