### PR TITLE
Don't use '#' when naming global variables.

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -371,12 +371,12 @@ static Constant *julia_pgv(jl_codectx_t &ctx, const char *cname, void *addr)
 static Constant *julia_pgv(jl_codectx_t &ctx, const char *prefix, jl_sym_t *name, jl_module_t *mod, void *addr)
 {
     // emit a GlobalVariable for a jl_value_t, using the prefix, name, and module to
-    // to create a readable name of the form prefixModA.ModB.name#
+    // to create a readable name of the form prefixModA.ModB.name.
     // reverse-of-reverse algorithm
     std::string finalname;
     StringRef name_str(jl_symbol_name(name));
     finalname.resize(name_str.size() + 1);
-    finalname[0] = '#';
+    finalname[0] = '.';
     std::reverse_copy(name_str.begin(), name_str.end(), finalname.begin() + 1);
     jl_module_t *parent = mod, *prev = NULL;
     while (parent && parent != prev) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1854,7 +1854,7 @@ static GlobalVariable *get_pointer_to_constant(jl_codegen_params_t &emission_con
         return gv;
     };
     if (gv == nullptr) {
-        gv = get_gv(name + "#" + Twine(emission_context.mergedConstants.size()));
+        gv = get_gv(name + "." + Twine(emission_context.mergedConstants.size()));
     }
     else if (gv->getParent() != &M) {
         StringRef gvname = gv->getName();


### PR DESCRIPTION
On 1.11, I'm seeing GVs with definitions like:

```llvm
@"_j_const#3" = private unnamed_addr addrspace(1) constant [2 x double] [double 0x7FF8000000000000, double 0x7FF8000000000000], align 8
```

LLVM doesn't like these, https://github.com/llvm/llvm-project/blob/6982f1fc2e750cfbb4b0098a6294d341238656ca/llvm/lib/MC/MCAsmInfo.cpp#L104-L109, resulting in issues compiling GPU code. I'm not sure why the Base JIT doesn't run into this...

