### PR TITLE
Simplify array creation in `sortslices` docstring

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1843,7 +1843,7 @@ but the result order will be row-major instead.
 
 # Higher dimensional examples
 ```
-julia> A = permutedims(reshape([4 3; 2 1; 'A' 'B'; 'C' 'D'], (2, 2, 2)), (1, 3, 2))
+julia> A = [4 3; 2 1 ;;; 'A' 'B'; 'C' 'D']
 2×2×2 Array{Any, 3}:
 [:, :, 1] =
  4  3


### PR DESCRIPTION
Using concatenation instead of `permutedims(reshape(...))` makes the construction easier to read and understand.