### PR TITLE
add `--trace-compile-locations` option to see causes of precompile statements

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -57,6 +57,7 @@ struct JLOptions
     strip_ir::Int8
     permalloc_pkgimg::Int8
     heap_size_hint::UInt64
+    trace_compile_locations::Int8
 end
 
 # This runs early in the sysimage != is not defined yet

--- a/src/gf.c
+++ b/src/gf.c
@@ -2329,6 +2329,19 @@ jl_code_instance_t *jl_method_compiled(jl_method_instance_t *mi, size_t world)
 
 jl_mutex_t precomp_statement_out_lock;
 
+static void jl_print_codeloc(JL_STREAM* io, const char* func_name, const char* file_name,
+                                  int line, int inlined) JL_NOTSAFEPOINT
+{
+    const char *inlined_str = inlined ? " [inlined]" : "";
+    if (line != -1) {
+        jl_printf(io, "%s at %s:%d%s\n", func_name, file_name, line, inlined_str);
+    }
+    else {
+        jl_printf(io, "%s at %s (unknown line)%s\n", func_name, file_name, inlined_str);
+    }
+}
+
+
 static void record_precompile_statement(jl_method_instance_t *mi)
 {
     static ios_t f_precompile;
@@ -2354,7 +2367,42 @@ static void record_precompile_statement(jl_method_instance_t *mi)
     if (!jl_has_free_typevars(mi->specTypes)) {
         jl_printf(s_precompile, "precompile(");
         jl_static_show(s_precompile, mi->specTypes);
-        jl_printf(s_precompile, ")\n");
+        jl_printf(s_precompile, ") # ");
+
+        jl_bt_element_t *bt = (jl_bt_element_t*)malloc(JL_MAX_BT_SIZE*sizeof(jl_bt_element_t));
+        size_t frame_ct = rec_backtrace(bt, JL_MAX_BT_SIZE, 0);
+        int found_call_site = 0;
+        for (int i = 0; i < frame_ct; i++){
+            jl_frame_t *frames = NULL;
+            int n = jl_getFunctionInfo(&frames, bt[i].uintptr, 0, 0);
+            int j;
+
+            for (j = 0; j < n; j++) {
+                jl_frame_t frame = frames[j];
+                if (jl_bt_is_native(&bt[i]) && frame.fromC == 0) {
+                    if (!frame.func_name) {
+                        jl_printf(s_precompile, "unknown function (ip: %p)\n", (void*)bt);
+                    }
+                    else {
+                        jl_print_codeloc(s_precompile, frame.func_name, frame.file_name, frame.line, frame.inlined);
+                        free(frame.func_name);
+                        free(frame.file_name);
+                    }
+                    found_call_site = 1;
+                    break;
+                } else if (jl_bt_entry_tag(bt) == JL_BT_INTERP_FRAME_TAG) {
+                    jl_print_codeloc(s_precompile, frame.func_name, frame.file_name, frame.line, frame.inlined);
+                    free(frame.func_name);
+                    free(frame.file_name);
+                    found_call_site = 1;
+                    break;
+                }
+            }
+            if (found_call_site == 1)
+                break;
+            free(frames);
+        }
+        free(bt);
         if (s_precompile != JL_STDERR)
             ios_flush(&f_precompile);
     }

--- a/src/gf.c
+++ b/src/gf.c
@@ -2329,15 +2329,15 @@ jl_code_instance_t *jl_method_compiled(jl_method_instance_t *mi, size_t world)
 
 jl_mutex_t precomp_statement_out_lock;
 
-static void jl_print_codeloc(JL_STREAM* io, const char* func_name, const char* file_name,
-                                  int line, int inlined) JL_NOTSAFEPOINT
+static void print_codeloc(JL_STREAM* io, const char* func_name, const char* file_name,
+                          int line, int inlined)
 {
     const char *inlined_str = inlined ? " [inlined]" : "";
     if (line != -1) {
-        jl_printf(io, "%s at %s:%d%s\n", func_name, file_name, line, inlined_str);
+        jl_printf(io, "%s at %s:%d%s", func_name, file_name, line, inlined_str);
     }
     else {
-        jl_printf(io, "%s at %s (unknown line)%s\n", func_name, file_name, inlined_str);
+        jl_printf(io, "%s at %s (unknown line)%s", func_name, file_name, inlined_str);
     }
 }
 
@@ -2367,42 +2367,27 @@ static void record_precompile_statement(jl_method_instance_t *mi)
     if (!jl_has_free_typevars(mi->specTypes)) {
         jl_printf(s_precompile, "precompile(");
         jl_static_show(s_precompile, mi->specTypes);
-        jl_printf(s_precompile, ") # ");
-
-        jl_bt_element_t *bt = (jl_bt_element_t*)malloc(JL_MAX_BT_SIZE*sizeof(jl_bt_element_t));
-        size_t frame_ct = rec_backtrace(bt, JL_MAX_BT_SIZE, 0);
-        int found_call_site = 0;
-        for (int i = 0; i < frame_ct; i++){
-            jl_frame_t *frames = NULL;
-            int n = jl_getFunctionInfo(&frames, bt[i].uintptr, 0, 0);
-            int j;
-
-            for (j = 0; j < n; j++) {
-                jl_frame_t frame = frames[j];
-                if (jl_bt_is_native(&bt[i]) && frame.fromC == 0) {
-                    if (!frame.func_name) {
-                        jl_printf(s_precompile, "unknown function (ip: %p)\n", (void*)bt);
+        jl_printf(s_precompile, ")");
+        if (jl_options.trace_compile_locations) {
+            jl_bt_element_t *bt = (jl_bt_element_t*)malloc((JL_BT_MAX_ENTRY_SIZE+1)*sizeof(jl_bt_element_t));
+            if (jl_get_current_julia_loc(bt)) {
+                char *func, *file;
+                int line, inlined;
+                if (jl_get_bt_entry_codeloc(bt, &func, &file, &line, &inlined)) {
+                    jl_printf(s_precompile, " # ");
+                    if (func == NULL) {
+                        jl_printf(s_precompile, "unknown function (ip: %p)", (void*)bt[0].uintptr);
                     }
                     else {
-                        jl_print_codeloc(s_precompile, frame.func_name, frame.file_name, frame.line, frame.inlined);
-                        free(frame.func_name);
-                        free(frame.file_name);
+                        print_codeloc(s_precompile, func, file, line, inlined);
                     }
-                    found_call_site = 1;
-                    break;
-                } else if (jl_bt_entry_tag(bt) == JL_BT_INTERP_FRAME_TAG) {
-                    jl_print_codeloc(s_precompile, frame.func_name, frame.file_name, frame.line, frame.inlined);
-                    free(frame.func_name);
-                    free(frame.file_name);
-                    found_call_site = 1;
-                    break;
+                    free(func);
+                    free(file);
                 }
             }
-            if (found_call_site == 1)
-                break;
-            free(frames);
+            free(bt);
         }
-        free(bt);
+        jl_printf(s_precompile, "\n");
         if (s_precompile != JL_STDERR)
             ios_flush(&f_precompile);
     }

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -214,7 +214,7 @@ static const char opts_hidden[]  =
     " --trace-compile={stderr,name}\n"
     "                          Print precompile statements for methods compiled during execution or save to a path\n"
     " --trace-compile-locations\n"
-    "                          Show source locations of callers triggering precompile statements\n"
+    "                          Show source locations of callers triggering compilation\n"
     " --image-codegen          Force generate code in imaging mode\n"
     " --permalloc-pkgimg={yes|no*} Copy the data section of package images into memory\n"
 ;

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -90,6 +90,7 @@ JL_DLLEXPORT void jl_init_options(void)
                         0, // strip-ir
                         0, // permalloc_pkgimg
                         0, // heap-size-hint
+                        0, // trace-compile-locations
     };
     jl_options_initialized = 1;
 }
@@ -212,6 +213,8 @@ static const char opts_hidden[]  =
     "                          Generate an incremental output file (rather than complete)\n"
     " --trace-compile={stderr,name}\n"
     "                          Print precompile statements for methods compiled during execution or save to a path\n"
+    " --trace-compile-locations\n"
+    "                          Show source locations of callers triggering precompile statements\n"
     " --image-codegen          Force generate code in imaging mode\n"
     " --permalloc-pkgimg={yes|no*} Copy the data section of package images into memory\n"
 ;
@@ -234,6 +237,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_inline,
            opt_polly,
            opt_trace_compile,
+           opt_trace_compile_locations,
            opt_math_mode,
            opt_worker,
            opt_bind_to,
@@ -321,6 +325,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "strip-ir",        no_argument,       0, opt_strip_ir },
         { "permalloc-pkgimg",required_argument, 0, opt_permalloc_pkgimg },
         { "heap-size-hint",  required_argument, 0, opt_heap_size_hint },
+        { "trace-compile-locations", no_argument, 0, opt_trace_compile_locations },
         { 0, 0, 0, 0 }
     };
 
@@ -753,6 +758,9 @@ restart_switch:
             jl_options.trace_compile = strdup(optarg);
             if (!jl_options.trace_compile)
                 jl_errorf("fatal error: failed to allocate memory: %s", strerror(errno));
+            break;
+        case opt_trace_compile_locations:
+            jl_options.trace_compile_locations = 1;
             break;
         case opt_math_mode:
             if (!strcmp(optarg,"ieee"))

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -61,6 +61,7 @@ typedef struct {
     int8_t strip_ir;
     int8_t permalloc_pkgimg;
     uint64_t heap_size_hint;
+    int8_t trace_compile_locations;
 } jl_options_t;
 
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1099,6 +1099,10 @@ STATIC_INLINE size_t jl_bt_entry_size(jl_bt_element_t *bt_entry) JL_NOTSAFEPOINT
         1 : 2 + jl_bt_num_jlvals(bt_entry) + jl_bt_num_uintvals(bt_entry);
 }
 
+int jl_get_current_julia_loc(jl_bt_element_t *bt_entry);
+int jl_get_bt_entry_codeloc(jl_bt_element_t *bt_entry, char **func_name, char **file_name,
+                            int *line, int *inlined);
+
 //------------------------------
 // Stack walking and debug info lookup
 


### PR DESCRIPTION
Replaces #49952
