### PR TITLE
cglobal: Add an option to bypass jlplt mechanism

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -278,7 +278,10 @@ add_tfunc(Core.Intrinsics.llvmcall, 3, INT_INF, llvmcall_tfunc, 10)
     isa(t, Const) && return isa(t.val, Type) ? Ptr{t.val} : Ptr
     return isType(t) ? Ptr{t.parameters[1]} : Ptr
 end
-add_tfunc(Core.Intrinsics.cglobal, 1, 2, cglobal_tfunc, 5)
+@nospecs function cglobal_tfunc(𝕃::AbstractLattice, fptr, t, useplt)
+    return cglobal_tfunc(𝕃, fptr, t)
+end
+add_tfunc(Core.Intrinsics.cglobal, 1, 3, cglobal_tfunc, 5)
 
 add_tfunc(Core.Intrinsics.have_fma, 1, 1, @nospecs((𝕃::AbstractLattice, x)->Bool), 1)
 add_tfunc(Core.Intrinsics.arraylen, 1, 1, @nospecs((𝕃::AbstractLattice, x)->Int), 4)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1873,8 +1873,12 @@ JL_CALLABLE(jl_f_intrinsic_call)
 {
     JL_TYPECHK(intrinsic_call, intrinsic, F);
     enum intrinsic f = (enum intrinsic)*(uint32_t*)jl_data_ptr(F);
-    if (f == cglobal && nargs == 1)
-        f = cglobal_auto;
+    if (f == cglobal) {
+        if (nargs == 1)
+            f = cglobal_auto;
+        else if (nargs == 3)
+            f = cglobal_pltarg;
+    }
     unsigned fargs = intrinsic_nargs[f];
     if (!fargs)
         jl_errorf("`%s` must be compiled to be called", jl_intrinsic_name(f));

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1181,8 +1181,13 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
 {
     auto &DL = ctx.emission_context.DL;
     assert(f < num_intrinsics);
-    if (f == cglobal && nargs == 1)
-        f = cglobal_auto;
+    if (f == cglobal) {
+        if (nargs == 1)
+            f = cglobal_auto;
+        else if (nargs == 3)
+            f = cglobal_pltarg;
+    }
+
     unsigned expected_nargs = jl_intrinsic_nargs((int)f);
     if (expected_nargs && expected_nargs != nargs) {
         jl_errorf("intrinsic #%d %s: wrong number of arguments", f, jl_intrinsic_name((int)f));
@@ -1190,7 +1195,7 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
 
     if (f == llvmcall)
         return emit_llvmcall(ctx, args, nargs);
-    if (f == cglobal_auto || f == cglobal)
+    if (f == cglobal_auto || f == cglobal || f == cglobal_pltarg)
         return emit_cglobal(ctx, args, nargs);
 
     SmallVector<jl_cgval_t> argv(nargs);

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -104,7 +104,8 @@
     /*  cpu feature tests */ \
     ADD_I(have_fma, 1) \
     /*  hidden intrinsics */ \
-    ADD_HIDDEN(cglobal_auto, 1)
+    ADD_HIDDEN(cglobal_auto, 1) \
+    ADD_HIDDEN(cglobal_pltarg, 3)
 
 enum intrinsic {
 #define ADD_I(func, nargs) func,

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -91,6 +91,7 @@
     XX(jl_ceil_llvm_withtype) \
     XX(jl_cglobal) \
     XX(jl_cglobal_auto) \
+    XX(jl_cglobal_pltarg) \
     XX(jl_checked_assignment) \
     XX(jl_clear_implicit_imports) \
     XX(jl_close_uv) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1298,6 +1298,7 @@ JL_DLLEXPORT jl_value_t *jl_atomic_pointermodify(jl_value_t *p, jl_value_t *f, j
 JL_DLLEXPORT jl_value_t *jl_atomic_pointerreplace(jl_value_t *p, jl_value_t *x, jl_value_t *expected, jl_value_t *success_order, jl_value_t *failure_order);
 JL_DLLEXPORT jl_value_t *jl_cglobal(jl_value_t *v, jl_value_t *ty);
 JL_DLLEXPORT jl_value_t *jl_cglobal_auto(jl_value_t *v);
+JL_DLLEXPORT jl_value_t *jl_cglobal_pltarg(jl_value_t *v, jl_value_t *ty, jl_value_t *usejlplt);
 
 JL_DLLEXPORT jl_value_t *jl_neg_int(jl_value_t *a);
 JL_DLLEXPORT jl_value_t *jl_add_int(jl_value_t *a, jl_value_t *b);

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -524,6 +524,10 @@ JL_DLLEXPORT jl_value_t *jl_cglobal_auto(jl_value_t *v) {
     return jl_cglobal(v, (jl_value_t*)jl_nothing_type);
 }
 
+JL_DLLEXPORT jl_value_t *jl_cglobal_pltarg(jl_value_t *v, jl_value_t *ty, jl_value_t *useplt) {
+    return jl_cglobal(v, ty);
+}
+
 static inline char signbitbyte(void *a, unsigned bytes) JL_NOTSAFEPOINT
 {
     // sign bit of an signed number of n bytes, as a byte


### PR DESCRIPTION
This adds an extra argument to `cglobal` to opt out of the jlplt runtime symbol resolution mechanism. This is necessary for StaticCompiler-like code that needs to function in environments that do not provide the julia runtime symbol resolution support code. Symbol resolution is deferred to the host linker (static or dynamic, where the latter may of course use its own PLT).