### PR TITLE
allow `code_[llvm|native]` to take custom `params::CodegenParams`

### DIFF
--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -154,10 +154,9 @@ function code_warntype(io::IO, @nospecialize(f), @nospecialize(t=Base.default_tt
     end
     nothing
 end
-code_warntype(@nospecialize(f), @nospecialize(t=Base.default_tt(f)); kwargs...) =
-    code_warntype(stdout, f, t; kwargs...)
+code_warntype(args...; kwargs...) = (@nospecialize; code_warntype(stdout, args...; kwargs...))
 
-import Base.CodegenParams
+using Base: CodegenParams
 
 const GENERIC_SIG_WARNING = "; WARNING: This code may not match what actually runs.\n"
 const OC_MISMATCH_WARNING =
@@ -170,15 +169,8 @@ const OC_MISMATCH_WARNING =
 
 function _dump_function(@nospecialize(f), @nospecialize(t), native::Bool, wrapper::Bool,
                         raw::Bool, dump_module::Bool, syntax::Symbol,
-                        optimize::Bool, debuginfo::Symbol, binary::Bool)
-        params = CodegenParams(debug_info_kind=Cint(0),
-                               safepoint_on_entry=raw, gcstack_arg=raw)
-        _dump_function(f, t, native, wrapper, raw, dump_module, syntax,
-                       optimize, debuginfo, binary, params)
-end
-function _dump_function(@nospecialize(f), @nospecialize(t), native::Bool, wrapper::Bool,
-                        raw::Bool, dump_module::Bool, syntax::Symbol,
-                        optimize::Bool, debuginfo::Symbol, binary::Bool, params::CodegenParams)
+                        optimize::Bool, debuginfo::Symbol, binary::Bool,
+                        params::CodegenParams=CodegenParams(debug_info_kind=Cint(0), safepoint_on_entry=raw, gcstack_arg=raw))
     ccall(:jl_is_in_pure_context, Bool, ()) && error("code reflection cannot be used from generated functions")
     if isa(f, Core.Builtin)
         throw(ArgumentError("argument is not a generic function"))
@@ -281,19 +273,17 @@ All metadata and dbg.* calls are removed from the printed bitcode. For the full 
 To dump the entire module that encapsulates the function (with declarations), set the `dump_module` keyword to true.
 Keyword argument `debuginfo` may be one of source (default) or none, to specify the verbosity of code comments.
 """
-function code_llvm(io::IO, @nospecialize(f), @nospecialize(types), raw::Bool,
-                   dump_module::Bool=false, optimize::Bool=true, debuginfo::Symbol=:default)
-    d = _dump_function(f, types, false, false, raw, dump_module, :intel, optimize, debuginfo, false)
+function code_llvm(io::IO, @nospecialize(f), @nospecialize(types=Base.default_tt(f));
+                   raw::Bool=false, dump_module::Bool=false, optimize::Bool=true, debuginfo::Symbol=:default,
+                   params::CodegenParams=CodegenParams(debug_info_kind=Cint(0), safepoint_on_entry=raw, gcstack_arg=raw))
+    d = _dump_function(f, types, false, false, raw, dump_module, :intel, optimize, debuginfo, false, params)
     if highlighting[:llvm] && get(io, :color, false)::Bool
         print_llvm(io, d)
     else
         print(io, d)
     end
 end
-code_llvm(io::IO, @nospecialize(f), @nospecialize(types=Base.default_tt(f)); raw::Bool=false, dump_module::Bool=false, optimize::Bool=true, debuginfo::Symbol=:default) =
-    code_llvm(io, f, types, raw, dump_module, optimize, debuginfo)
-code_llvm(@nospecialize(f), @nospecialize(types=Base.default_tt(f)); raw=false, dump_module=false, optimize=true, debuginfo::Symbol=:default) =
-    code_llvm(stdout, f, types; raw, dump_module, optimize, debuginfo)
+code_llvm(args...; kwargs...) = (@nospecialize; code_llvm(stdout, args...; kwargs...))
 
 """
     code_native([io=stdout,], f, types; syntax=:intel, debuginfo=:default, binary=false, dump_module=true)
@@ -311,17 +301,16 @@ See also: [`@code_native`](@ref), [`code_llvm`](@ref), [`code_typed`](@ref) and 
 """
 function code_native(io::IO, @nospecialize(f), @nospecialize(types=Base.default_tt(f));
                      dump_module::Bool=true, syntax::Symbol=:intel, raw::Bool=false,
-                     debuginfo::Symbol=:default, binary::Bool=false)
-    d = _dump_function(f, types, true, false, raw, dump_module, syntax, true, debuginfo, binary)
+                     debuginfo::Symbol=:default, binary::Bool=false,
+                     params::CodegenParams=CodegenParams(debug_info_kind=Cint(0), safepoint_on_entry=raw, gcstack_arg=raw))
+    d = _dump_function(f, types, true, false, raw, dump_module, syntax, true, debuginfo, binary, params)
     if highlighting[:native] && get(io, :color, false)::Bool
         print_native(io, d)
     else
         print(io, d)
     end
 end
-code_native(@nospecialize(f), @nospecialize(types=Base.default_tt(f)); dump_module::Bool=true, syntax::Symbol=:intel, raw::Bool=false, debuginfo::Symbol=:default, binary::Bool=false) =
-    code_native(stdout, f, types; dump_module, syntax, raw, debuginfo, binary)
-code_native(::IO, ::Any, ::Symbol) = error("invalid code_native call") # resolve ambiguous call
+code_native(args...; kwargs...) = (@nospecialize; code_native(stdout, args...; kwargs...))
 
 ## colorized IR and assembly printing
 


### PR DESCRIPTION
Also cleans up the implementations a bit.