### PR TITLE
Workaround upstream FreeBSD issue #272992

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -435,6 +435,13 @@ JL_DLLEXPORT int jl_dlsym(void *handle, const char *symbol, void ** value, int t
 // Look for symbols in internal libraries
 JL_DLLEXPORT const char *jl_dlfind(const char *f_name)
 {
+#ifdef _OS_FREEBSD_
+    // This is a workaround for FreeBSD <= 13.2 which do not have
+    // https://cgit.freebsd.org/src/commit/?id=21a52f99440c9bec7679f3b0c5c9d888901c3694
+    // (See https://github.com/JuliaLang/julia/issues/50846)
+    if (strcmp(f_name, "dl_iterate_phdr") == 0)
+        return JL_EXE_LIBNAME;
+#endif
     void * dummy;
     if (jl_dlsym(jl_libjulia_internal_handle, f_name, &dummy, 0))
         return JL_LIBJULIA_INTERNAL_DL_LIBNAME;


### PR DESCRIPTION
ELF doesn't handle WEAK symbols dynamically the way it handles them statically.

Looking up overloaded WEAK symbols via a library-specific handle will often give you the empty stub (in `libc.so.7` in this case) instead of the strong implementation elsewhere (`ld-elf.so.1` here).

Even after the [upstream fix](https://cgit.freebsd.org/src/commit/?id=21a52f99440c9bec7679f3b0c5c9d888901c3694), `dlsym`, `dladdr` and a ton of other symbols still have stubs with no trampoline in FreeBSD's libc:
https://cgit.freebsd.org/src/tree/lib/libc/gen/dlfcn.c?id=21a52f99440c9bec7679f3b0c5c9d888901c3694 Thankfully `dl_iterate_phdr` appears to be the only function that we directly `ccall` from Julia's Libdl so we can leave this fix incomplete for now.

Resolves #50846.