### PR TITLE
Consistently report sysimg size limits

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2533,8 +2533,8 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
     if (sysimg.size > ((uintptr_t)1 << RELOC_TAG_OFFSET)) {
         jl_printf(
             JL_STDERR,
-            "ERROR: system image too large: sysimg.size is %jd but the limit is %" PRIxPTR "\n",
-            (intmax_t)sysimg.size,
+            "ERROR: system image too large: sysimg.size is 0x%" PRIxPTR " but the limit is 0x%" PRIxPTR "\n",
+            (uintptr_t)sysimg.size,
             ((uintptr_t)1 << RELOC_TAG_OFFSET)
         );
         jl_exit(1);
@@ -2542,8 +2542,8 @@ static void jl_save_system_image_to_stream(ios_t *f, jl_array_t *mod_array,
     if (const_data.size / sizeof(void*) > ((uintptr_t)1 << RELOC_TAG_OFFSET)) {
         jl_printf(
             JL_STDERR,
-            "ERROR: system image too large: const_data.size is %jd but the limit is %" PRIxPTR "\n",
-            (intmax_t)const_data.size,
+            "ERROR: system image too large: const_data.size is 0x%" PRIxPTR " but the limit is 0x%" PRIxPTR "\n",
+            (uintptr_t)const_data.size,
             ((uintptr_t)1 << RELOC_TAG_OFFSET)*sizeof(void*)
         );
         jl_exit(1);


### PR DESCRIPTION
We used to be reporting the maximum system image size in hexadecimal, while reporting the image that was just built in decimal.  This is a recipe for confusion when the size limit contains no blatantly hexadecimal characters.

This PR addresses the issue by consistently printing out both values in hexadecimal (making this more obvious by prefixing the numbers with `0x`).  In order to use `PRIxPTR` in both format strings, I have cast the current image size to `uintptr_t` from `intmax_t`, which should be safe in all situations.