### PR TITLE
fix rawbigints

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -436,7 +436,7 @@ function to_ieee754(::Type{T}, x::BigFloat, rm) where {T<:AbstractFloat}
     ret_u = if is_regular & !rounds_to_inf & !rounds_to_zero
         if !exp_is_huge_p
             # significand
-            v = RawBigInt(x.d, significand_limb_count(x))
+            v = RawBigInt{Limb}(x._d, significand_limb_count(x))
             len = max(ieee_precision + min(exp_diff, 0), 0)::Int
             signif = truncated(U, v, len) & significand_mask(T)
 

--- a/base/rawbigints.jl
+++ b/base/rawbigints.jl
@@ -5,15 +5,14 @@ Segment of raw words of bits interpreted as a big integer. Less
 significant words come first. Each word is in machine-native bit-order.
 """
 struct RawBigInt{T<:Unsigned}
-    d::Ptr{T}
+    d::String
     word_count::Int
 
-    function RawBigInt{T}(d::Ptr{T}, word_count::Int) where {T<:Unsigned}
+    function RawBigInt{T}(d::String, word_count::Int) where {T<:Unsigned}
         new{T}(d, word_count)
     end
 end
 
-RawBigInt(d::Ptr{T}, word_count::Int) where {T<:Unsigned} = RawBigInt{T}(d, word_count)
 elem_count(x::RawBigInt, ::Val{:words}) = x.word_count
 elem_count(x::Unsigned, ::Val{:bits}) = sizeof(x) * 8
 word_length(::RawBigInt{T}) where {T} = elem_count(zero(T), Val(:bits))
@@ -26,8 +25,10 @@ split_bit_index(x::RawBigInt, i::Int) = divrem(i, word_length(x), RoundToZero)
 `i` is the zero-based index of the wanted word in `x`, starting from
 the less significant words.
 """
-function get_elem(x::RawBigInt, i::Int, ::Val{:words}, ::Val{:ascending})
-    unsafe_load(x.d, i + 1)
+function get_elem(x::RawBigInt{T}, i::Int, ::Val{:words}, ::Val{:ascending}) where {T}
+    # `i` must be nonnegative and less than `x.word_count`
+    d = x.d
+    (GC.@preserve d unsafe_load(Ptr{T}(pointer(d)), i + 1))::T
 end
 
 function get_elem(x, i::Int, v::Val, ::Val{:descending})

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -244,6 +244,9 @@ precompile_test_harness(false) do dir
               const abigint_f() = big"123"
               const abigint_x = big"124"
 
+              # issue #51111
+              abigfloat_to_f32() = Float32(big"1.5")
+
               # issue #31488
               _v31488 = Base.StringVector(2)
               resize!(_v31488, 0)
@@ -298,6 +301,9 @@ precompile_test_harness(false) do dir
         @test (Foo.abigfloat_x::BigFloat + 21) == big"64.21"
         @test Foo.abigint_f()::BigInt == big"123"
         @test Foo.abigint_x::BigInt + 1 == big"125"
+
+        # Issue #51111
+        @test Foo.abigfloat_to_f32() == 1.5f0
 
         @test Foo.x28297.result === missing
 


### PR DESCRIPTION
Using `Ptr` like that was incorrect. Among other issues, a `Ptr` doesn't own the data it points to, so hold a `String` instead.

Fixes #51111