### PR TITLE
Add options to jl_dump_native

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1241,6 +1241,15 @@ struct CodegenParams
     end
 end
 
+# this type mirrors jl_emission_params_t (documented in julia.h)
+struct EmissionParams
+    emit_metadata::Cint
+
+    function EmissionParams(; emit_metadata::Bool=true)
+        return new(Cint(emit_metadata))
+    end
+end
+
 const SLOT_USED = 0x8
 ast_slotflag(@nospecialize(code), i) = ccall(:jl_ir_slotflag, UInt8, (Any, Csize_t), code, i - 1)
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -2363,6 +2363,10 @@ typedef struct {
 } jl_cgparams_t;
 extern JL_DLLEXPORT int jl_default_debug_info_kind;
 
+typedef struct {
+    int emit_metadata;
+} jl_emission_params_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1682,7 +1682,7 @@ JL_DLLIMPORT jl_value_t *jl_dump_function_asm(jl_llvmf_dump_t *dump, char emit_m
 JL_DLLIMPORT void *jl_create_native(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvmmod, const jl_cgparams_t *cgparams, int policy, int imaging_mode, int cache, size_t world);
 JL_DLLIMPORT void jl_dump_native(void *native_code,
         const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *asm_fname,
-        ios_t *z, ios_t *s);
+        ios_t *z, ios_t *s, jl_emission_params_t *params);
 JL_DLLIMPORT void jl_get_llvm_gvs(void *native_code, arraylist_t *gvs);
 JL_DLLIMPORT void jl_get_llvm_external_fns(void *native_code, arraylist_t *gvs);
 JL_DLLIMPORT void jl_get_function_id(void *native_code, jl_code_instance_t *ncode,

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -147,7 +147,7 @@ JL_DLLEXPORT void jl_write_compiler_output(void)
                         jl_options.outputunoptbc,
                         jl_options.outputo,
                         jl_options.outputasm,
-                        z, targets);
+                        z, targets, NULL);
         jl_postoutput_hook();
     }
 


### PR DESCRIPTION
I am attempting to more or less unify the codepaths between sysimage-like binary emissions and StaticCompiler-like binary emissions (the latter currently uses a GPUCompiler-derived pipeline), with a view towards enabling things that are somewhat in the middle (may have parts, but not all of the runtime, etc.). To that end, add a parameters struct to jl_dump_native that will likely grow over time, but for now, the primary thing it controls is whether or not to emit the sysimage "metadata" section.