### PR TITLE
Try to fix the wine/mingw build

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -18,7 +18,7 @@ endif
 
 ifeq ($(OS),WINNT)
 LOADER_LDFLAGS += -municode -mconsole -nostdlib --disable-auto-import \
-                  --disable-runtime-pseudo-reloc -lntdll -lkernel32 -lpsapi
+                  --disable-runtime-pseudo-reloc -lntdll -lkernel32 -lpsapi -lmsvcrt
 else ifeq ($(OS),Linux)
 LOADER_LDFLAGS += -Wl,--no-as-needed -ldl -lpthread -rdynamic -lc -Wl,--as-needed
 else ifeq ($(OS),FreeBSD)


### PR DESCRIPTION
For some reason I'm getting
```
/home/keno/julia-win64/cli/loader_lib.c:63: undefined reference to `memset'
```
Trying to build for win64 under wine. I'm assuming the memset symbol is being inserted by the compiler for the big zero initialization of the array (perhaps it is usually a preprocessor define). Linking `msvcrt` made this work for me, but I'm not sure if this was something we had intentionally omitted.