### PR TITLE
loader: Avoid compiler-generated memset

### DIFF
--- a/cli/loader.h
+++ b/cli/loader.h
@@ -14,7 +14,7 @@
 #define exit loader_exit
 #define strlen loader_strlen
 #define wcslen loader_wcslen
-#define strncat loader_strncat
+#define strlcat loader_strncat
 #define memcpy loader_memcpy
 #define dirname loader_dirname
 #define strchr loader_strchr

--- a/cli/loader_lib.c
+++ b/cli/loader_lib.c
@@ -60,10 +60,11 @@ static void * load_library(const char * rel_path, const char * src_dir, int err)
         return handle;
 #endif
 
-    char path[2*JL_PATH_MAX + 1] = {0};
-    strncat(path, src_dir, sizeof(path) - 1);
-    strncat(path, PATHSEPSTRING, sizeof(path) - 1);
-    strncat(path, rel_path, sizeof(path) - 1);
+    char path[2*JL_PATH_MAX + 1];
+    path[0] = '\0';
+    strlcat(path, src_dir, sizeof(path));
+    strlcat(path, PATHSEPSTRING, sizeof(path));
+    strlcat(path, rel_path, sizeof(path));
 
 #if defined(_OS_WINDOWS_)
 #define PATH_EXISTS() win_file_exists(wpath)

--- a/cli/loader_win_utils.c
+++ b/cli/loader_win_utils.c
@@ -162,7 +162,7 @@ size_t loader_wcslen(const wchar_t * x) {
     return idx;
 }
 
-char * loader_strncat(char * base, const char * tail, size_t maxlen) {
+char * loader_strlcat(char * base, const char * tail, size_t maxlen) {
     int base_len = strlen(base);
     int tail_len = strlen(tail);
     for (int idx=base_len; idx<min(maxlen, base_len + tail_len); ++idx) {


### PR DESCRIPTION
This file is built standalone, so no memset definition is available. The only thing we need is that the path is originally zero-terminated. While we're at it, also rename the function to `strlcat`, since that's the semantics our version implements (`strncat` takes the source size, not the dest size). Fixes #51126.