### PR TITLE
Disallow `ceil`/`trunc`/`floor` on complex arguments

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1084,9 +1084,10 @@ breaking ties using the specified [`RoundingMode`](@ref)s. The first
 second is used for rounding the imaginary components.
 
 
-`RoundingModeReal` and `RoundingModeImaginary` default to [`RoundNearest`](@ref),
+`RoundingModeReal` defaults to [`RoundNearest`](@ref),
 which rounds to the nearest integer, with ties (fractional values of 0.5)
-being rounded to the nearest even integer.
+being rounded to the nearest even integer. `RoundingModeImaginary` defaults to
+the mode `RoundingModeReal` is set to.
 
 # Example
 ```jldoctest
@@ -1108,6 +1109,20 @@ function round(z::Complex, rr::RoundingMode=RoundNearest, ri::RoundingMode=rr; k
             round(imag(z), ri; kwargs...))
 end
 
+trunc(x::Complex; kws...) = throw_complex_round(trunc, (typeof(x),))
+floor(x::Complex; kws...) = throw_complex_round(floor, (typeof(x),))
+ ceil(x::Complex; kws...) = throw_complex_round( ceil, (typeof(x),))
+
+trunc(::Type{T}, x::Complex) where T = throw_complex_round(trunc, (T, typeof(x)))
+floor(::Type{T}, x::Complex) where T = throw_complex_round(floor, (T, typeof(x)))
+ ceil(::Type{T}, x::Complex) where T = throw_complex_round( ceil, (T, typeof(x)))
+round(::Type{T}, x::Complex) where T = throw_complex_round(round, (T, typeof(x)))
+
+@noinline function throw_complex_round(f, args)
+    argstr = join(args, ", ::")
+    str = "`$f(::$argstr)` is not defined - use `round` and specify rounding modes for the real & complex parts instead."
+    throw(DomainError(str))
+end
 
 float(z::Complex{<:AbstractFloat}) = z
 float(z::Complex) = Complex(float(real(z)), float(imag(z)))

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -149,6 +149,7 @@ round(::Type{T}, x::Any, r::RoundingMode=RoundNearest) where {T>:Missing} = roun
 round(::Type{T}, x::Real, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype_checked(T), x, r)
 round(::Type{T}, x::Rational{Tr}, r::RoundingMode=RoundNearest) where {T>:Missing,Tr} = round(nonmissingtype_checked(T), x, r)
 round(::Type{T}, x::Rational{Bool}, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype_checked(T), x, r)
+round(::Type{T}, x::Complex, rr::RoundingMode=RoundNearest, ri::RoundingMode=rr) where {T>:Missing} = round(nonmissingtype_checked(T), x, rr, ri)
 
 # to avoid ambiguity warnings
 (^)(::Missing, ::Integer) = missing

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -361,18 +361,18 @@ end
 
 @testset "rounding complex numbers (#42060, #47128)" begin
     # 42060
-    @test ceil(Complex(4.6, 2.2)) === Complex(5.0, 3.0)
-    @test floor(Complex(4.6, 2.2)) === Complex(4.0, 2.0)
-    @test trunc(Complex(4.6, 2.2)) === Complex(4.0, 2.0)
+    @test_throws DomainError ceil(Complex(4.6, 2.2))
+    @test_throws DomainError floor(Complex(4.6, 2.2))
+    @test_throws DomainError trunc(Complex(4.6, 2.2))
+    @test_throws DomainError ceil(Complex(-4.6, -2.2))
+    @test_throws DomainError floor(Complex(-4.6, -2.2))
+    @test_throws DomainError trunc(Complex(-4.6, -2.2))
     @test round(Complex(4.6, 2.2)) === Complex(5.0, 2.0)
-    @test ceil(Complex(-4.6, -2.2)) === Complex(-4.0, -2.0)
-    @test floor(Complex(-4.6, -2.2)) === Complex(-5.0, -3.0)
-    @test trunc(Complex(-4.6, -2.2)) === Complex(-4.0, -2.0)
     @test round(Complex(-4.6, -2.2)) === Complex(-5.0, -2.0)
 
     # 47128
-    @test round(Complex{Int}, Complex(4.6, 2.2)) === Complex(5, 2)
-    @test ceil(Complex{Int}, Complex(4.6, 2.2)) === Complex(5, 3)
+    @test_throws DomainError round(Complex{Int}, Complex(4.6, 2.2)) === Complex(5, 2)
+    @test_throws DomainError ceil(Complex{Int}, Complex(4.6, 2.2)) === Complex(5, 3)
 end
 
 @testset "rounding to custom integers" begin


### PR DESCRIPTION
See #42060 for why this is not easy to define, and hence is (for now) better left to error, instead of working through a fallback.

This also rewords the docstring of the existing `round` function with two rounding modes, to make it clear that the imaginary rounding mode defaults to the same as the one that's set for the real part.
