### PR TITLE
optimizer: Do not run if we know the function is ConstABI eligible

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -320,7 +320,7 @@ function CodeInstance(interp::AbstractInterpreter, result::InferenceResult,
         end
     end
     relocatability = 0x0
-    if const_flags == 0x3
+    if const_flags == 0x3 && may_discard_trees(interp)
         inferred_result = nothing
         relocatability = 0x1
     else

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -924,7 +924,7 @@ function typeinf_code(interp::AbstractInterpreter, method::Method, @nospecialize
     frame === nothing && return nothing, Any
     is_inferred(frame) || return nothing, Any
     if result_is_constabi(interp, run_optimizer, frame.result)
-        rt = ignorelimited(frame.result.result)
+        rt = frame.result.result::Const
         return codeinfo_for_const(interp, frame.linfo, frame.result.valid_worlds, rt.val), widenconst(rt)
     end
     code = frame.src

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -282,19 +282,19 @@ function _typeinf(interp::AbstractInterpreter, frame::InferenceState)
     return true
 end
 
+function is_result_constabi_eligible(result::InferenceResult)
+    result_type = result.result
+    return isa(result_type, Const) && is_foldable_nothrow(result.ipo_effects) && is_inlineable_constant(result_type.val)
+end
 function CodeInstance(interp::AbstractInterpreter, result::InferenceResult,
-                      @nospecialize(inferred_result), valid_worlds::WorldRange)
+                      valid_worlds::WorldRange)
     local const_flags::Int32
     result_type = result.result
     @assert !(result_type === nothing || result_type isa LimitedAccuracy)
-
-    if isa(result_type, Const) && is_foldable_nothrow(result.ipo_effects) && is_inlineable_constant(result_type.val)
+    if is_result_constabi_eligible(result)
         # use constant calling convention
         rettype_const = result_type.val
         const_flags = 0x3
-        if may_discard_trees(interp)
-            inferred_result = nothing
-        end
     else
         if isa(result_type, Const)
             rettype_const = result_type.val
@@ -320,12 +320,18 @@ function CodeInstance(interp::AbstractInterpreter, result::InferenceResult,
         end
     end
     relocatability = 0x0
-    if isa(inferred_result, String)
-        t = @_gc_preserve_begin inferred_result
-        relocatability = unsafe_load(unsafe_convert(Ptr{UInt8}, inferred_result), Core.sizeof(inferred_result))
-        @_gc_preserve_end t
-    elseif inferred_result === nothing
+    if const_flags == 0x3
+        inferred_result = nothing
         relocatability = 0x1
+    else
+        inferred_result = transform_result_for_cache(interp, result.linfo, valid_worlds, result)
+        if isa(inferred_result, String)
+            t = @_gc_preserve_begin inferred_result
+            relocatability = unsafe_load(unsafe_convert(Ptr{UInt8}, inferred_result), Core.sizeof(inferred_result))
+            @_gc_preserve_end t
+        elseif inferred_result === nothing
+            relocatability = 0x1
+        end
     end
     # relocatability = isa(inferred_result, String) ? inferred_result[end] : UInt8(0)
     return CodeInstance(result.linfo,
@@ -397,8 +403,7 @@ function cache_result!(interp::AbstractInterpreter, result::InferenceResult)
 
     # TODO: also don't store inferred code if we've previously decided to interpret this function
     if !already_inferred
-        inferred_result = transform_result_for_cache(interp, linfo, valid_worlds, result)
-        code_cache(interp)[linfo] = ci = CodeInstance(interp, result, inferred_result, valid_worlds)
+        code_cache(interp)[linfo] = ci = CodeInstance(interp, result, valid_worlds)
         if track_newly_inferred[]
             m = linfo.def
             if isa(m, Method) && m.module != Core
@@ -538,6 +543,11 @@ function finish(me::InferenceState, interp::AbstractInterpreter)
             end
         end
     end
+    me.result.valid_worlds = me.valid_worlds
+    me.result.result = bestguess
+    me.ipo_effects = me.result.ipo_effects = adjust_effects(me)
+
+
     if limited_ret
         # a parent may be cached still, but not this intermediate work:
         # we can throw everything else away now
@@ -555,15 +565,17 @@ function finish(me::InferenceState, interp::AbstractInterpreter)
         # either because we are the outermost code, or we might use this later
         type_annotate!(interp, me)
         doopt = (me.cached || me.parent !== nothing)
+        # Disable the optimizer if we've already determined that there's nothing for
+        # it to do.
+        if may_discard_trees(interp) && is_result_constabi_eligible(me.result)
+            doopt = false
+        end
         if doopt && may_optimize(interp)
             me.result.src = OptimizationState(me, interp)
         else
             me.result.src = me.src::CodeInfo # stash a convenience copy of the code (e.g. for reflection)
         end
     end
-    me.result.valid_worlds = me.valid_worlds
-    me.result.result = bestguess
-    me.ipo_effects = me.result.ipo_effects = adjust_effects(me)
     validate_code_in_debug_mode(me.linfo, me.src, "inferred")
     nothing
 end
@@ -883,11 +895,38 @@ end
 
 #### entry points for inferring a MethodInstance given a type signature ####
 
+function codeinfo_for_const(interp::AbstractInterpreter, mi::MethodInstance, worlds::WorldRange, @nospecialize(val))
+    method = mi.def::Method
+    tree = ccall(:jl_new_code_info_uninit, Ref{CodeInfo}, ())
+    tree.code = Any[ ReturnNode(quoted(val)) ]
+    nargs = Int(method.nargs)
+    tree.slotnames = ccall(:jl_uncompress_argnames, Vector{Symbol}, (Any,), method.slot_syms)
+    tree.slotflags = fill(0x00, nargs)
+    tree.ssavaluetypes = 1
+    tree.codelocs = Int32[1]
+    tree.linetable = LineInfoNode[LineInfoNode(method.module, method.name, method.file, method.line, Int32(0))]
+    tree.ssaflags = UInt32[0]
+    set_inlineable!(tree, true)
+    tree.parent = mi
+    tree.rettype = Core.Typeof(val)
+    tree.min_world = worlds.min_world
+    tree.max_world = worlds.max_world
+    tree.inferred = true
+    return tree
+end
+
+result_is_constabi(interp::AbstractInterpreter, run_optimizer::Bool, result::InferenceResult) =
+    run_optimizer && may_discard_trees(interp) && is_result_constabi_eligible(result)
+
 # compute an inferred AST and return type
 function typeinf_code(interp::AbstractInterpreter, method::Method, @nospecialize(atype), sparams::SimpleVector, run_optimizer::Bool)
     frame = typeinf_frame(interp, method, atype, sparams, run_optimizer)
     frame === nothing && return nothing, Any
     is_inferred(frame) || return nothing, Any
+    if result_is_constabi(interp, run_optimizer, frame.result)
+        rt = ignorelimited(frame.result.result)
+        return codeinfo_for_const(interp, frame.linfo, frame.result.valid_worlds, rt.val), widenconst(rt)
+    end
     code = frame.src
     rt = widenconst(ignorelimited(frame.result.result))
     return code, rt
@@ -947,23 +986,7 @@ function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance)
         inf = @atomic :monotonic code.inferred
         if use_const_api(code)
             ccall(:jl_typeinf_timing_end, Cvoid, (UInt64,), start_time)
-            tree = ccall(:jl_new_code_info_uninit, Ref{CodeInfo}, ())
-            rettype_const = code.rettype_const
-            tree.code = Any[ ReturnNode(quoted(rettype_const)) ]
-            nargs = Int(method.nargs)
-            tree.slotnames = ccall(:jl_uncompress_argnames, Vector{Symbol}, (Any,), method.slot_syms)
-            tree.slotflags = fill(0x00, nargs)
-            tree.ssavaluetypes = 1
-            tree.codelocs = Int32[1]
-            tree.linetable = LineInfoNode[LineInfoNode(method.module, method.name, method.file, method.line, Int32(0))]
-            tree.ssaflags = UInt32[0]
-            set_inlineable!(tree, true)
-            tree.parent = mi
-            tree.rettype = Core.Typeof(rettype_const)
-            tree.min_world = code.min_world
-            tree.max_world = code.max_world
-            tree.inferred = true
-            return tree
+            return codeinfo_for_const(interp, mi, WorldRange(code.min_world, code.max_world), code.rettype_const)
         elseif isa(inf, CodeInfo)
             ccall(:jl_typeinf_timing_end, Cvoid, (UInt64,), start_time)
             if !(inf.min_world == code.min_world &&
@@ -990,6 +1013,9 @@ function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance)
     frame === nothing && return nothing
     typeinf(interp, frame)
     ccall(:jl_typeinf_timing_end, Cvoid, (UInt64,), start_time)
+    if result_is_constabi(interp, true, frame.result)
+        return codeinfo_for_const(interp, frame.linfo, frame.result.valid_worlds, frame.result.result.val)
+    end
     frame.src.inferred || return nothing
     return frame.src
 end

--- a/test/compiler/AbstractInterpreter.jl
+++ b/test/compiler/AbstractInterpreter.jl
@@ -441,7 +441,7 @@ function custom_lookup(mi::MethodInstance, min_world::UInt, max_world::UInt)
     for inf_result in CONST_INVOKE_INTERP.inf_cache
         if inf_result.linfo === mi
             if CC.any(inf_result.overridden_by_const)
-                return CodeInstance(CONST_INVOKE_INTERP, inf_result, inf_result.src, inf_result.valid_worlds)
+                return CodeInstance(CONST_INVOKE_INTERP, inf_result, inf_result.valid_worlds)
             elseif matched_mi === nothing
                 matched_mi = inf_result.linfo
             end

--- a/test/compiler/EscapeAnalysis/local.jl
+++ b/test/compiler/EscapeAnalysis/local.jl
@@ -7,6 +7,7 @@ include(normpath(@__DIR__, "setup.jl"))
 @testset "basics" begin
     let # arg return
         result = code_escapes((Any,)) do a # return to caller
+            Base.donotdelete(1) # TODO #51143
             return nothing
         end
         @test has_arg_escape(result.state[Argument(2)])
@@ -46,6 +47,7 @@ include(normpath(@__DIR__, "setup.jl"))
     end
     let # :gc_preserve_begin / :gc_preserve_end
         result = code_escapes((String,)) do s
+            Base.donotdelete(1) # TODO #51143
             m = SafeRef(s)
             GC.@preserve m begin
                 return nothing

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -569,6 +569,7 @@ end
     function f1(cond)
         val = [1]
         GC.@preserve val begin end
+        return cond
     end
     @test occursin("llvm.julia.gc_preserve_begin", get_llvm(f1, Tuple{Bool}, true, false, false))
 
@@ -576,6 +577,7 @@ end
     function f3(cond)
         val = ([1],)
         GC.@preserve val begin end
+        return cond
     end
     @test occursin("llvm.julia.gc_preserve_begin", get_llvm(f3, Tuple{Bool}, true, false, false))
 
@@ -583,12 +585,14 @@ end
     function f2(cond)
         val = cond ? 1 : 1f0
         GC.@preserve val begin end
+        return cond
     end
     @test !occursin("llvm.julia.gc_preserve_begin", get_llvm(f2, Tuple{Bool}, true, false, false))
     # make sure the fix for the above doesn't regress #34241
     function f4(cond)
         val = cond ? ([1],) : ([1f0],)
         GC.@preserve val begin end
+        return cond
     end
     @test occursin("llvm.julia.gc_preserve_begin", get_llvm(f4, Tuple{Bool}, true, false, false))
 end

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1224,7 +1224,7 @@ function foo_cfg_empty(b)
         @goto x
     end
     @label x
-    return 1
+    return b
 end
 let ci = code_typed(foo_cfg_empty, Tuple{Bool}, optimize=true)[1][1]
     ir = Core.Compiler.inflate_ir(ci)


### PR DESCRIPTION
If we can determine that a function is sufficiently pure and returns a constant, we have special ABI that lets us throw away the code for it and just return the constant. However, we were still going through all the steps of actually computing the code, including running the optimizer on it, compressing it in preparation for caching, etc. We can just stop doing that and bypass the optimizer entirely.

The actual change to do this is pretty tiny, but there's some unexpected fallout which this needs to cleanup:
1. Various tests expect code_* queries of things inferred to ConstABI to still return reasonable code. Fix this by manually emitting a ReturnNode at the end of inference if the caller is a reflection function.
2. This kinda wreaks havoc on the EscapeAnalysis tests, which work by using a side-effect of the optimizer, but a lot of the functions are ConstABI eligible, so the optimizer doesn't run any more. Fortunately, I'm in the middle of looking at overhauling EscapeAnalysis, so I'll have some chance to figure out how to change the test system to actually do this properly, rather than exfiltrating side effects. That said, since EscapeAnalysis is not in the default pipeline, I don't think we should hold the perf improvement until that is done.

Benchmarked to be about 10% faster locally, but we'll see what nanosoldier thinks.