### PR TITLE
Metric for number of live bytes in the pool allocator

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -753,6 +753,7 @@ int prev_sweep_full = 1;
 int under_pressure = 0;
 
 // Full collection heuristics
+static int64_t pool_live_bytes = 0;
 static int64_t live_bytes = 0;
 static int64_t promoted_bytes = 0;
 static int64_t last_live_bytes = 0; // live_bytes at last collection
@@ -1530,6 +1531,7 @@ done:
     }
     gc_time_count_page(freedall, pg_skpd);
     gc_num.freed += (nfree - old_nfree) * osize;
+    pool_live_bytes += GC_PAGE_SZ - GC_PAGE_OFFSET - nfree * osize;
     return pfl;
 }
 
@@ -3108,6 +3110,11 @@ JL_DLLEXPORT int64_t jl_gc_sync_total_bytes(int64_t offset) JL_NOTSAFEPOINT
     return newtb - oldtb;
 }
 
+JL_DLLEXPORT int64_t jl_gc_pool_live_bytes(void)
+{
+    return pool_live_bytes;
+}
+
 JL_DLLEXPORT int64_t jl_gc_live_bytes(void)
 {
     return live_bytes;
@@ -3269,6 +3276,7 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
         promoted_bytes = 0;
     }
     scanned_bytes = 0;
+    pool_live_bytes = 0;
     // 6. start sweeping
     uint64_t start_sweep_time = jl_hrtime();
     JL_PROBE_GC_SWEEP_BEGIN(sweep_full);

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -176,6 +176,7 @@
     XX(jl_gc_internal_obj_base_ptr) \
     XX(jl_gc_is_enabled) \
     XX(jl_gc_is_in_finalizer) \
+    XX(jl_gc_pool_live_bytes) \
     XX(jl_gc_live_bytes) \
     XX(jl_gc_managed_malloc) \
     XX(jl_gc_managed_realloc) \


### PR DESCRIPTION
We want to study what is the degree of fragmentation we have in the pool allocator specifically.

`pool_live_bytes` / `(live pages * GC_PAGE_SZ)` should provide an estimate of that.