### PR TITLE
Update man page with internet resources and licensing

### DIFF
--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -21,7 +21,7 @@
 .\" - diagnostics
 .\" - notes
 
-.TH JULIA 1 2022-02-17 JULIA
+.TH JULIA 1 2023-09-01 JULIA
 
 .\" from the front page of https://julialang.org/
 .SH NAME
@@ -277,6 +277,15 @@ See https://docs.julialang.org/en/v1/manual/environment-variables/
 Please report any bugs using the GitHub issue tracker:
 https://github.com/julialang/julia/issues?state=open
 
-
 .SH AUTHORS
 Contributors: https://github.com/JuliaLang/julia/graphs/contributors
+
+.SH INTERNET RESOURCES
+Website:  https://julialang.org/
+.br
+Documentation:  https://docs.julialang.org/
+.br
+Downloads:  https://julialang.org/downloads/
+
+.SH LICENSING
+Julia is an open-source project. It is made available under the MIT license.


### PR DESCRIPTION
Pull request proposes a minor modification to the man page. In this PR, two additional sections for the man page are added:
- Internet resources and
- licensing.