### PR TITLE
Put back `@inline` on unsafe_getindex

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1288,7 +1288,7 @@ end
 # To avoid invalidations from multidimensional.jl: getindex(A::Array, i1::Union{Integer, CartesianIndex}, I::Union{Integer, CartesianIndex}...)
 @propagate_inbounds getindex(A::Array, i1::Integer, I::Integer...) = A[to_indices(A, (i1, I...))...]
 
-unsafe_getindex(A::AbstractArray, I...) = @inbounds getindex(A, I...)
+@inline unsafe_getindex(A::AbstractArray, I...) = @inbounds getindex(A, I...)
 
 struct CanonicalIndexError <: Exception
     func::String


### PR DESCRIPTION
Fixup for #50467

@nanosoldier `runbenchmarks("array", vs="@fb7613635cab77cf269790335e8121f513c9ea96")`