### PR TITLE
Show `Inf16` (instead of just `Inf`) in `InexactError`

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -176,7 +176,7 @@ function showerror(io::IO, ex::InexactError)
     T = first(ex.args)
     nameof(T) === ex.func || print(io, T, ", ")
     join(io, ex.args[2:end], ", ")
-    print(io, ")")
+    print(io, repr(ex.val), ')')
     Experimental.show_error_hints(io, ex)
 end
 

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -176,7 +176,8 @@ function showerror(io::IO, ex::InexactError)
     T = first(ex.args)
     nameof(T) === ex.func || print(io, T, ", ")
     join(io, ex.args[2:end], ", ")
-    print(io, repr(ex.val), ')')
+    show(io, ex.val)
+    print(io, ')')
     Experimental.show_error_hints(io, ex)
 end
 


### PR DESCRIPTION
InexactError shows Inf16 as Inf #51087

I am not sure if it would pass checks further , I will need to review my code again
