### PR TITLE
add PersistentDict based on a HAMT

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -869,3 +869,145 @@ empty(::ImmutableDict, ::Type{K}, ::Type{V}) where {K, V} = ImmutableDict{K,V}()
 _similar_for(c::AbstractDict, ::Type{Pair{K,V}}, itr, isz, len) where {K, V} = empty(c, K, V)
 _similar_for(c::AbstractDict, ::Type{T}, itr, isz, len) where {T} =
     throw(ArgumentError("for AbstractDicts, similar requires an element type of Pair;\n  if calling map, consider a comprehension instead"))
+
+
+include("hamt.jl")
+using .HashArrayMappedTries
+const HAMT = HashArrayMappedTries
+
+struct PersistentDict{K,V} <: AbstractDict{K,V}
+    trie::HAMT.HAMT{K,V}
+end
+
+"""
+    PersistentDict
+
+`PersistentDict` is a dictionary implemented as an hash array mapped trie,
+which is optimal for situations where you need persistence, each operation
+returns a new dictonary separate from the previous one, but the underlying
+implementation is space-efficient and may share storage across multiple
+separate dictionaries.
+
+    PersistentDict(KV::Pair)
+
+# Examples
+
+```jldoctest
+julia> dict = Base.PersistentDict(:a=>1)
+Base.PersistentDict{Symbol, Int64} with 1 entry:
+  :a => 1
+
+julia> dict2 = Base.delete(dict, :a)
+  Base.PersistentDict{Symbol, Int64}()
+
+julia> dict3 = Base.PersistentDict(dict, :a=>2)
+Base.PersistentDict{Symbol, Int64} with 1 entry:
+  :a => 2
+```
+"""
+PersistentDict
+
+PersistentDict{K,V}() where {K,V} = PersistentDict(HAMT.HAMT{K,V}())
+PersistentDict(KV::Pair{K,V}) where {K,V} = PersistentDict(HAMT.HAMT(KV...))
+PersistentDict(dict::PersistentDict, pair::Pair) = PersistentDict(dict, pair...)
+function PersistentDict(dict::PersistentDict{K,V}, key::K, val::V) where {K,V}
+    trie = dict.trie
+    h = hash(key)
+    found, present, trie, i, bi, top, hs = HAMT.path(trie, key, h, #=persistent=# true)
+    HAMT.insert!(found, present, trie, i, bi, hs, val)
+    return PersistentDict(top)
+end
+
+function PersistentDict(kv::Pair, rest::Pair...)
+    dict = PersistentDict(kv)
+    for kv in rest
+        key, value = kv
+        dict = PersistentDict(dict, key, value)
+    end
+    return dict
+end
+
+eltype(::PersistentDict{K,V}) where {K,V} = Pair{K,V}
+
+function in(key_val::Pair{K,V}, dict::PersistentDict{K,V}, valcmp=(==)) where {K,V}
+    trie = dict.trie
+    if HAMT.islevel_empty(trie)
+        return false
+    end
+
+    key, val = key_val
+
+    h = hash(key)
+    found, present, trie, i, _, _, _ = HAMT.path(trie, key, h)
+    if found && present
+        leaf = @inbounds trie.data[i]::HAMT.Leaf{K,V}
+        return valcmp(val, leaf.val) && return true
+    end
+    return false
+end
+
+function haskey(dict::PersistentDict{K}, key::K) where K
+    trie = dict.trie
+    h = hash(key)
+    found, present, _, _, _, _, _ = HAMT.path(trie, key, h)
+    return found && present
+end
+
+function getindex(dict::PersistentDict{K,V}, key::K) where {K,V}
+    trie = dict.trie
+    if HAMT.islevel_empty(trie)
+        throw(KeyError(key))
+    end
+    h = hash(key)
+    found, present, trie, i, _, _, _ = HAMT.path(trie, key, h)
+    if found && present
+        leaf = @inbounds trie.data[i]::HAMT.Leaf{K,V}
+        return leaf.val
+    end
+    throw(KeyError(key))
+end
+
+function get(dict::PersistentDict{K,V}, key::K, default::V) where {K,V}
+    trie = dict.trie
+    if HAMT.islevel_empty(trie)
+        return default
+    end
+    h = hash(key)
+    found, present, trie, i, _, _, _ = HAMT.path(trie, key, h)
+    if found && present
+        leaf = @inbounds trie.data[i]::HAMT.Leaf{K,V}
+        return leaf.val
+    end
+    return default
+end
+
+function get(default::Callable, dict::PersistentDict{K,V}, key::K) where {K,V}
+    trie = dict.trie
+    if HAMT.islevel_empty(trie)
+        return default
+    end
+    h = hash(key)
+    found, present, trie, i, _, _, _ = HAMT.path(trie, key, h)
+    if found && present
+        leaf = @inbounds trie.data[i]::HAMT.Leaf{K,V}
+        return leaf.val
+    end
+    return default()
+end
+
+iterate(dict::PersistentDict, state=nothing) = HAMT.iterate(dict.trie, state)
+
+function delete(dict::PersistentDict{K}, key::K) where K
+    trie = dict.trie
+    h = hash(key)
+    found, present, trie, i, bi, top, _ = HAMT.path(trie, key, h, #=persistent=# true)
+    if found && present
+        deleteat!(trie.data, i)
+        HAMT.unset!(trie, bi)
+    end
+    return PersistentDict(top)
+end
+
+length(dict::PersistentDict) = HAMT.length(dict.trie)
+isempty(dict::PersistentDict) = HAMT.isempty(dict.trie)
+empty(::PersistentDict, ::Type{K}, ::Type{V}) where {K, V} = PersistentDict{K, V}()

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -898,7 +898,7 @@ Base.PersistentDict{Symbol, Int64} with 1 entry:
   :a => 1
 
 julia> dict2 = Base.delete(dict, :a)
-  Base.PersistentDict{Symbol, Int64}()
+Base.PersistentDict{Symbol, Int64}()
 
 julia> dict3 = Base.PersistentDict(dict, :a=>2)
 Base.PersistentDict{Symbol, Int64} with 1 entry:

--- a/base/hamt.jl
+++ b/base/hamt.jl
@@ -1,0 +1,261 @@
+module HashArrayMappedTries
+
+export HAMT, insert, delete
+
+##
+# Implements "Ideal Hash Trees" Phil Bagwell 2000
+#
+# Notable divergence is that we forgo a resizable root table.
+# Root tables improve lookup performance for large sizes, but
+# limit space efficiency if the HAMT is used for a persistent
+# dictionary, since each persistent operation would duplicate
+# the root table.
+#
+# We do not handle perfect hash-collision. We would need to
+# add an additional node type for Collisions. Perfect hash
+# collisions should not occur in practice since we perform
+# rehashing after using 55 bits (MAX_SHIFT) of the original hash.
+#
+# Use https://github.com/vchuravy/HashArrayMappedTries.jl if
+# you want to use this implementation in a package.
+#
+# A HAMT is formed by tree of levels, where at each level
+# we use a portion of the bits of the hash for indexing
+#
+# We use a branching width (ENTRY_COUNT) of 32, giving us
+# 5bits of indexing per level
+# 0000_00000_00000_00000_00000_00000_00000_00000_00000_00000_00000_00000
+# L11  L10   L9    L8    L7    L6    L5    L4    L3    L2    L1    L0
+#
+# At each level we use a 32bit bitmap to store which elements are occupied.
+# Since our storage is "sparse" we need to map from index in [0,31] to
+# the actual storage index. We mask the bitmap wiht (1 << i) - 1 and count
+# the ones in the result. The number of set ones (+1) gives us the index
+# into the storage array.
+#
+# HAMT can be both persitent and non-persistent.
+# The `path` function searches for a matching entries, and for persistency
+# optionally copies the path so that it can be safely mutated.
+
+# TODO:
+# When `trie.data` becomes empty we could remove it from it's parent,
+# but we only know so fairly late. Maybe have a compact function?
+
+const ENTRY_COUNT = UInt(32)
+const BITMAP = UInt32
+const NBITS = sizeof(UInt) * 8
+# @assert ispow2(ENTRY_COUNT)
+const BITS_PER_LEVEL = trailing_zeros(ENTRY_COUNT)
+const LEVEL_MASK = (UInt(1) << BITS_PER_LEVEL) - 1
+const MAX_SHIFT = (NBITS ÷ BITS_PER_LEVEL - 1) *  BITS_PER_LEVEL
+
+mutable struct Leaf{K, V}
+    const key::K
+    const val::V
+end
+
+"""
+    HAMT{K,V}
+
+A HashArrayMappedTrie that optionally supports persistence.
+"""
+mutable struct HAMT{K, V}
+    const data::Vector{Union{Leaf{K, V}, HAMT{K, V}}}
+    bitmap::BITMAP
+end
+HAMT{K, V}() where {K, V} = HAMT(Vector{Union{Leaf{K, V}, HAMT{K, V}}}(undef, 0), zero(BITMAP))
+function HAMT(k::K, v::V) where {K, V}
+    # For a single element we can't have a hash-collision
+    trie = HAMT(Vector{Union{Leaf{K, V}, HAMT{K, V}}}(undef, 1), zero(BITMAP))
+    trie.data[1] = Leaf{K,V}(k,v)
+    bi = BitmapIndex(HashState(k))
+    set!(trie, bi)
+    return trie
+end
+
+struct HashState{K}
+    key::K
+    hash::UInt
+    depth::Int
+    shift::Int
+end
+HashState(key)= HashState(key, hash(key), 0, 0)
+# Reconstruct
+HashState(key, depth, shift) = HashState(key, hash(key, UInt(depth ÷ BITS_PER_LEVEL)), depth, shift)
+
+function next(h::HashState)
+    depth = h.depth + 1
+    shift = h.shift + BITS_PER_LEVEL
+    if shift > MAX_SHIFT
+        # Note we use `UInt(depth ÷ BITS_PER_LEVEL)` to seed the hash function
+        # the hash docs, do we need to hash `UInt(depth ÷ BITS_PER_LEVEL)` first?
+        h_hash = hash(h.key, UInt(depth ÷ BITS_PER_LEVEL))
+    else
+        h_hash = h.hash
+    end
+    return HashState(h.key, h_hash, depth, shift)
+end
+
+struct BitmapIndex
+    x::UInt8
+    function BitmapIndex(x)
+        @assert 0 <= x < 32
+        new(x)
+    end
+end
+BitmapIndex(h::HashState) = BitmapIndex((h.hash >> h.shift) & LEVEL_MASK)
+
+Base.:(<<)(v, bi::BitmapIndex) = v << bi.x
+Base.:(>>)(v, bi::BitmapIndex) = v >> bi.x
+
+isset(trie::HAMT, bi::BitmapIndex) = isodd(trie.bitmap >> bi)
+function set!(trie::HAMT, bi::BitmapIndex)
+    trie.bitmap |= (UInt32(1) << bi)
+    @assert count_ones(trie.bitmap) == Base.length(trie.data)
+end
+
+function unset!(trie::HAMT, bi::BitmapIndex)
+    trie.bitmap &= ~(UInt32(1) << bi)
+    @assert count_ones(trie.bitmap) == Base.length(trie.data)
+end
+
+function entry_index(trie::HAMT, bi::BitmapIndex)
+    mask = (UInt32(1) << bi.x) - UInt32(1)
+    count_ones(trie.bitmap & mask) + 1
+end
+
+islevel_empty(trie::HAMT) = trie.bitmap == 0
+islevel_empty(::Leaf) = false
+
+"""
+    path(trie, h, copyf)::(found, present, trie, i, top, level)
+
+Internal function that walks a HAMT and finds the slot for hash.
+Returns if a value is `present` and a value is `found`.
+
+It returns the `trie` and the index `i` into `trie.data`, as well
+as the current `level`.
+
+If a copy function is provided `copyf` use the return `top` for the
+new persistent tree.
+"""
+@inline function path(trie::HAMT{K,V}, key, _h, copy=false) where {K, V}
+    h = HashState(key, _h, 0, 0)
+    if copy
+        trie = top = HAMT{K,V}(Base.copy(trie.data), trie.bitmap)
+    else
+        trie = top = trie
+    end
+    while true
+        bi = BitmapIndex(h)
+        i = entry_index(trie, bi)
+        if isset(trie, bi)
+            next = @inbounds trie.data[i]
+            if next isa Leaf{K,V}
+                # Check if key match if not we will need to grow.
+                found = (next.key === h.key || isequal(next.key, h.key))
+                return found, true, trie, i, bi, top, h
+            end
+            if copy
+                next = HAMT{K,V}(Base.copy(next.data), next.bitmap)
+                @inbounds trie.data[i] = next
+            end
+            trie = next::HAMT{K,V}
+        else
+            # found empty slot
+            return true, false, trie, i, bi, top, h
+        end
+        h = HashArrayMappedTries.next(h)
+    end
+end
+
+"""
+Internal function that given an obtained path, either set the value
+or grows the HAMT by inserting a new trie instead.
+"""
+@inline function insert!(found, present, trie::HAMT{K,V}, i, bi, h, val) where {K,V}
+    if found # we found a slot, just set it to the new leaf
+        # replace or insert
+        if present # replace
+            @inbounds trie.data[i] = Leaf{K, V}(h.key, val)
+        else
+            Base.insert!(trie.data, i, Leaf{K, V}(h.key, val))
+        end
+        set!(trie, bi)
+    else
+        @assert present
+        # collision -> grow
+        leaf = @inbounds trie.data[i]::Leaf{K,V}
+        leaf_h = HashState(leaf.key, h.depth, h.shift)
+        if leaf_h.hash == h.hash
+            error("Perfect hash collision")
+        end
+        while true
+            new_trie = HAMT{K, V}()
+            if present
+                @inbounds trie.data[i] = new_trie
+            else
+                i = entry_index(trie, bi)
+                Base.insert!(trie.data, i, new_trie)
+            end
+            set!(trie, bi)
+
+            h = next(h)
+            leaf_h = next(leaf_h)
+            bi_new = BitmapIndex(h)
+            bi_old = BitmapIndex(leaf_h)
+            if bi_new == bi_old # collision in new trie -> retry
+                trie = new_trie
+                bi = bi_new
+                present = false
+                continue
+            end
+            i_new = entry_index(new_trie, bi_new)
+            Base.insert!(new_trie.data, i_new, Leaf{K, V}(h.key, val))
+            set!(new_trie, bi_new)
+
+            i_old = entry_index(new_trie, bi_old)
+            Base.insert!(new_trie.data, i_old, leaf)
+            set!(new_trie, bi_old)
+
+            break
+        end
+    end
+end
+
+length(::Leaf) = 1
+length(trie::HAMT) = sum((length(trie.data[i]) for i in eachindex(trie.data)), init=0)
+
+isempty(::Leaf) = false
+function isempty(trie::HAMT)
+    if islevel_empty(trie)
+        return true
+    end
+    return all(isempty(trie.data[i]) for i in eachindex(trie.data))
+end
+
+# DFS
+function iterate(trie::HAMT, state=nothing)
+    if state === nothing
+        state = (;parent=nothing, trie, i=1)
+    end
+    while state !== nothing
+        i = state.i
+        if i > Base.length(state.trie.data)
+            state = state.parent
+            continue
+        end
+        trie = state.trie.data[i]
+        state = (;parent=state.parent, trie=state.trie, i=i+1)
+        if trie isa Leaf
+            return (trie.key => trie.val, state)
+        else
+            # we found a new level
+            state = (;parent=state, trie, i=1)
+            continue
+        end
+    end
+    return nothing
+end
+
+end # module HashArrayMapTries

--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -204,6 +204,7 @@ Base.Dict
 Base.IdDict
 Base.WeakKeyDict
 Base.ImmutableDict
+Base.PersistentDict
 Base.haskey
 Base.get
 Base.get!
@@ -236,6 +237,7 @@ Partially implemented by:
   * [`Array`](@ref)
   * [`BitArray`](@ref)
   * [`ImmutableDict`](@ref Base.ImmutableDict)
+  * [`PersistentDict`](@ref Base.PersistentDict)
   * [`Iterators.Pairs`](@ref)
 
 ## Set-Like Collections

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1084,6 +1084,132 @@ Dict(1 => rand(2,3), 'c' => "asdf") # just make sure this does not trigger a dep
     GC.@preserve A B C D nothing
 end
 
+mutable struct CollidingHash
+end
+Base.hash(::CollidingHash, h::UInt) = hash(UInt(0), h)
+
+struct PredictableHash
+    x::UInt
+end
+Base.hash(x::PredictableHash, h::UInt) = x.x
+
+import Base.PersistentDict
+@testset "PersistentDict" begin
+    @testset "basics" begin
+        dict = PersistentDict{Int, Int}()
+        @test_throws KeyError dict[1]
+        @test length(dict) == 0
+        @test isempty(dict)
+
+        dict = PersistentDict(1=>2)
+        @test dict[1] == 2
+
+        dict = PersistentDict(dict, 1=>3)
+        @test dict[1] == 3
+
+        dict = PersistentDict(dict, 1, 1)
+        @test dict[1] == 1
+        @test get(dict, 2, 1) == 1
+        @test get(()->1, dict, 2) == 1
+
+        @test (1 => 1) ∈ dict
+        @test (1 => 2) ∉ dict
+        @test (2 => 1) ∉ dict
+
+        @test haskey(dict, 1)
+        @test !haskey(dict, 2)
+
+        dict2 = PersistentDict(dict, 1, 2)
+        @test dict[1] == 1
+        @test dict2[1] == 2
+
+        dict3 = Base.delete(dict2, 1)
+        @test_throws KeyError dict3[1]
+        @test dict3 == Base.delete(dict3, 1)
+        @test dict3.trie != Base.delete(dict3, 1).trie
+
+        dict = PersistentDict(dict, 1, 3)
+        @test dict[1] == 3
+        @test dict2[1] == 2
+
+        @test length(dict) == 1
+        @test length(dict2) == 1
+
+        dict = PersistentDict(1=>2, 2=>3, 4=>1)
+        @test eltype(dict) == Pair{Int, Int}
+        @test dict[1] == 2
+        @test dict[2] == 3
+        @test dict[4] == 1
+    end
+
+    @testset "stress" begin
+        N = 2^14
+        dict = PersistentDict{Int, Int}()
+        for i in 1:N
+            dict = PersistentDict(dict, i, i)
+        end
+        @test length(dict) == N
+        length(collect(dict)) == N
+        values = sort!(collect(dict))
+        @test values[1] == (1=>1)
+        @test values[end] == (N=>N)
+
+        dict = Base.delete(dict, 16384)
+        @test !haskey(dict, 16384)
+        for i in 1:N
+            dict = Base.delete(dict, i)
+        end
+        @test isempty(dict)
+    end
+
+    @testset "CollidingHash" begin
+        dict = PersistentDict{CollidingHash, Nothing}()
+        dict = PersistentDict(dict, CollidingHash(), nothing)
+        @test_throws ErrorException PersistentDict(dict, CollidingHash(), nothing)
+    end
+
+    # Test the internal implementation
+    @testset "PredictableHash" begin
+        dict = PersistentDict{PredictableHash, Nothing}()
+        for i in 1:Base.HashArrayMappedTries.ENTRY_COUNT
+            key = PredictableHash(UInt(i-1)) # Level 0
+            dict = PersistentDict(dict, key, nothing)
+        end
+        @test length(dict.trie.data) == Base.HashArrayMappedTries.ENTRY_COUNT
+        @test dict.trie.bitmap == typemax(Base.HashArrayMappedTries.BITMAP)
+        for entry in dict.trie.data
+            @test entry isa Base.HashArrayMappedTries.Leaf
+        end
+
+        dict = PersistentDict{PredictableHash, Nothing}()
+        for i in 1:Base.HashArrayMappedTries.ENTRY_COUNT
+            key = PredictableHash(UInt(i-1) << Base.HashArrayMappedTries.BITS_PER_LEVEL) # Level 1
+            dict = PersistentDict(dict, key, nothing)
+        end
+        @test length(dict.trie.data) == 1
+        @test length(dict.trie.data[1].data) == 32
+
+        max_level = (Base.HashArrayMappedTries.NBITS ÷ Base.HashArrayMappedTries.BITS_PER_LEVEL)
+        dict = PersistentDict{PredictableHash, Nothing}()
+        for i in 1:Base.Base.HashArrayMappedTries.ENTRY_COUNT
+            key = PredictableHash(UInt(i-1) << (max_level * Base.HashArrayMappedTries.BITS_PER_LEVEL)) # Level 12
+            dict = PersistentDict(dict, key, nothing)
+        end
+        data = dict.trie.data
+        for level in 1:max_level
+            @test length(data) == 1
+            data = only(data).data
+        end
+        last_level_nbits = Base.HashArrayMappedTries.NBITS - (max_level * Base.HashArrayMappedTries.BITS_PER_LEVEL)
+        if Base.HashArrayMappedTries.NBITS == 64
+            @test last_level_nbits == 4
+        elseif Base.HashArrayMappedTries.NBITS == 32
+            @test last_level_nbits == 2
+        end
+        @test length(data) == 2^last_level_nbits
+    end
+end
+
 @testset "issue #19995, hash of dicts" begin
     @test hash(Dict(Dict(1=>2) => 3, Dict(4=>5) => 6)) != hash(Dict(Dict(4=>5) => 3, Dict(1=>2) => 6))
     a = Dict(Dict(3 => 4, 2 => 3) => 2, Dict(1 => 2, 5 => 6) => 1)


### PR DESCRIPTION
Split out from #51066 for independent review and merge.

Prototyped in https://github.com/vchuravy/HashArrayMappedTries.jl for #50958.

The implementation is based on a [Hash Array Mapped Trie (HAMT)](https://en.wikipedia.org/wiki/Hash_array_mapped_trie)
following [Bagwell (2000)](http://infoscience.epfl.ch/record/64398/files/idealhashtrees.pdf).

A HAMT uses a fixed branching factor (commonly 32) together with each node being sparse.
In order to search for an entry we take the hash of the key and chunk it up into blocks,
with a branching factor of 32 each block is 5 bits. We use those 5 bits to calculate the
index inside the node and use a bitmap within the node to keep track if an element is
already set. This makes search a `log(32, n)` operation.

Persistency is implemented by path-copying. When we insert/delete a value into the HAMT
we copy each node along the path into a new HAMT, all other nodes are shared with
the previous HAMT.

A noteable implementation choice is that I didn't add a (resizeable) root table.
Normally this root table is dense and uses the first `t` bits to calculate an index
within. This makes large HAMT a bit cheaper since the root-table effectivly folds
multiple lookup steps into one. It does hurt persistent use-cases since path-copying
means that we also copy the root node/table.

Importantly the HAMT itself is not immutable/persistent, the use of it as part of the
`PersistentDict` is. Direct mutation of the underlying data breaks the persistentcy
invariants. One could use the HAMT to implement a non-persistent dictionary (or
other datastructures). 

As an interesting side-note we could use a related data-structure [Ctrie](http://lamp.epfl.ch/~prokopec/ctries-snapshot.pdf)
to implement a concurrent lock-free dictionary. Ctrie also support `O(1)` snapshotting 
so we could replace the HAMT used here with a Ctrie.

