### PR TITLE
compiler: add `show` methods for `InferenceState` and `CachedMethodTable`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -2824,10 +2824,14 @@ function show(io::IO, inferred::Core.Compiler.InferenceResult)
     end
 end
 
-function show(io::IO, ::Core.Compiler.NativeInterpreter)
-    print(io, "Core.Compiler.NativeInterpreter(...)")
-end
+show(io::IO, sv::Core.Compiler.InferenceState) =
+    (print(io, "InferenceState for "); show(io, sv.linfo))
 
+show(io::IO, ::Core.Compiler.NativeInterpreter) =
+    print(io, "Core.Compiler.NativeInterpreter(...)")
+
+show(io::IO, cache::Core.Compiler.CachedMethodTable) =
+    print(io, typeof(cache), "(", Core.Compiler.length(cache.cache), " entries)")
 
 function dump(io::IOContext, x::SimpleVector, n::Int, indent)
     if isempty(x)


### PR DESCRIPTION
Both `InferenceState` and `CachedMethodTable` contain caches to store inference results, making their default `show` methods excessively verbose. This commit introduces specialized `show` methods designed to display only the most essential information.