### PR TITLE
build: don't default to m(arch|cpu|tune)=native when cross-compiling

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -898,8 +898,8 @@ ISX86:=0
 endif
 
 
-#If nothing is set default to native
-ifeq ($(MARCH)$(MCPU)$(MTUNE)$(JULIA_CPU_TARGET),)
+#If nothing is set default to native unless we are cross-compiling
+ifeq ($(MARCH)$(MCPU)$(MTUNE)$(JULIA_CPU_TARGET)$(XC_HOST),)
 ifeq ($(ARCH),aarch64) #ARM recommends only setting MCPU for AArch64
 MCPU=native
 else


### PR DESCRIPTION
When trying to cross-compile the latest master for `libjulia_jll` I got errors like this for several platforms:
```
[11:19:27] cc1: error: unrecognized argument in option '-mtune=native'
```
This seems to be caused by the new defaults from #50031.
