### PR TITLE
shorten stale_age for cachefile lock

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2968,11 +2968,13 @@ global parse_pidfile_hook
 compilecache_pidfile_path(pkg::PkgId) = compilecache_path(pkg, UInt64(0); project="") * ".pidfile"
 
 # Allows processes to wait if another process is precompiling a given source already.
-# The lock file is deleted and precompilation will proceed after `stale_age` seconds if
+# The lock file mtime will be updated when held every `stale_age/2` seconds.
+# After `stale_age` seconds beyond the mtime of the lock file, the lock file is deleted and
+# precompilation will proceed if
 #  - the locking process no longer exists
 #  - the lock is held by another host, since processes cannot be checked remotely
 # or after `stale_age * 25` seconds if the process does still exist.
-function maybe_cachefile_lock(f, pkg::PkgId, srcpath::String; stale_age=300)
+function maybe_cachefile_lock(f, pkg::PkgId, srcpath::String; stale_age=10)
     if @isdefined(mkpidlock_hook) && @isdefined(trymkpidlock_hook) && @isdefined(parse_pidfile_hook)
         pidfile = compilecache_pidfile_path(pkg)
         cachefile = invokelatest(trymkpidlock_hook, f, pidfile; stale_age)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/50746

`mkpidlock` has a `refresh` mode which touches the lockfile while locked every `stale_age/2` seconds by default to keep its mtime updated.

This wasn't appreciated by me when stale_age was set originally in https://github.com/JuliaLang/julia/pull/50214 https://github.com/JuliaLang/julia/pull/50254

This seems to make setting a much shorter `stale_age` make sense. 