### PR TITLE
optimizer: fix the `all_rettypes_consistent` case of post-opt analysis

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -65,6 +65,8 @@ function in(idx::Int, bsbmp::BitSetBoundedMinPrioritySet)
     return idx in bsbmp.elems
 end
 
+iterate(bsbmp::BitSetBoundedMinPrioritySet, s...) = iterate(bsbmp.elems, s...)
+
 function append!(bsbmp::BitSetBoundedMinPrioritySet, itr)
     for val in itr
         push!(bsbmp, val)

--- a/test/compiler/datastructures.jl
+++ b/test/compiler/datastructures.jl
@@ -16,6 +16,19 @@ end
     bsbmp = Core.Compiler.BitSetBoundedMinPrioritySet(5)
     Core.Compiler.push!(bsbmp, 2)
     Core.Compiler.push!(bsbmp, 2)
+    iterateok = true
+    cnt = 0
+    @eval Core.Compiler for v in $bsbmp
+        if cnt == 0
+            iterateok &= v == 2
+        elseif cnt == 1
+            iterateok &= v == 5
+        else
+            iterateok = false
+        end
+        cnt += 1
+    end
+    @test iterateok
     @test Core.Compiler.popfirst!(bsbmp) == 2
     Core.Compiler.push!(bsbmp, 1)
     @test Core.Compiler.popfirst!(bsbmp) == 1


### PR DESCRIPTION
The case does not seem to be functional, although it looks like we never hit it currently.
We should have added test cases for this, so WIP until we come up with some.