### PR TITLE
docs: Update advice on safe use of finalizers

### DIFF
--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -121,7 +121,7 @@ You can protect access to a critical region in your finalizer with one of these 
     This can be a good strategy to use for code with event loops
     and is employed by `Gtk.jl` to manage lifetime ref-counting.
 
-    If you use `Threads.@spawn` then you will not have control over with thread the spawned task will run on, so you will still need to acquire a lock in the task.
+    If you use `Threads.@spawn` then you will not have control over which thread the spawned task will run on, so you will still need to acquire a lock in the task.
     If you define your own queue then you can avoid this by only draining the queue from one thread at a time.
 
     An example using `Threads.@spawn`:

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -109,7 +109,8 @@ You can protect access to a critical region in your finalizer with one of these 
     finalizer(my_finalizer, my_object)
     ```
 
-    Locks prevent multiple finalizers entering the critical region concurrently.
+    The locks in `Base` prevent multiple finalizers entering the critical region concurrently.
+    If you want to use a lock from another package then check its documentation.
 
  2. Another strategy is to use the finalizer only to schedule the work to be done at another time.
     This means we don't have to care about finalizers interrupting each other because the actual work will be done in a non-finalizer context.

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -49,6 +49,14 @@ Register a function `f(x)` to be called when there are no program-accessible ref
 `x`, and return `x`. The type of `x` must be a `mutable struct`, otherwise the function
 will throw.
 
+!!! warning
+
+    Julia may interrupt any other code when it calls a finalizer function so you must take special care to avoid concurrency bugs when writing your finalizers.
+    Even if you use no other concurrency features in your program, one finalizer call can interrupt another and cause a concurrency bug if they interact with the same global state.
+
+    If your finalizer interacts with global state (and it probably will), then you must use a synchronisation strategy for that interaction that is safe even if your finalizer is interrupted by another finalizer.
+    Review the extended help for suggested strategies.
+
 `f` must not cause a task switch, which excludes most I/O operations such as `println`.
 Using the `@async` macro (to defer context switching to outside of the finalizer) or
 `ccall` to directly invoke IO functions in C may be helpful for debugging purposes.
@@ -63,7 +71,7 @@ finalizer(my_mutable_struct) do x
 end
 
 finalizer(my_mutable_struct) do x
-    ccall(:jl_safe_printf, Cvoid, (Cstring, Cstring), "Finalizing %s.", repr(x))
+    @ccall jl_safe_printf("Finalizing %s."::Cstring, repr(x)::Cstring)::Cvoid
 end
 ```
 
@@ -81,6 +89,92 @@ mutable struct MyMutableStruct
     end
 end
 ```
+
+# Extended help
+
+You can protect access to a critical region in your finalizer with one of these techniques:
+
+ 1. If your Julia process is single-threaded or the state that you are modifying is only accessible from your current thread then all you need to do is prevent other finalizers from running during your critical region:
+
+    ```julia
+    function my_finalizer(x)
+        GC.disable_finalizers()
+        # Your critical section here
+        GC.enable_finalizers()
+    end
+    ```
+
+    If your global state is accessible from more than one thread then you must use a lock or some other synchronisation control as well:
+
+    ```julia
+    function my_finalizer(x)
+        GC.disable_finalizers()
+        lock(my_lock)
+        try
+            # Your critical section here
+        finally
+            unlock(my_lock)
+        end
+        GC.enable_finalizers()
+    end
+    ```
+
+    Julia uses this strategy in its locks and to prevent recursion when doing certain operations (incremental package loading, codegen, etc.).
+
+ 2. A second strategy, employed by Base in a couple places, is to explicitly
+    delay a finalizer until it may be able to acquire its lock non-recursively.
+    The following example demonstrates how this strategy could be applied to
+    `Distributed.finalize_ref`:
+
+    ```julia
+    function finalize_ref(r::AbstractRemoteRef)
+        if r.where > 0 # Check if the finalizer is already run
+            if islocked(client_refs) || !trylock(client_refs)
+                # delay finalizer for later if we aren't free to acquire the lock
+                finalizer(finalize_ref, r)
+                return nothing
+            end
+            try # `lock` should always be followed by `try`
+                if r.where > 0 # Must check again here
+                    # Do actual cleanup here
+                    r.where = 0
+                end
+            finally
+                unlock(client_refs)
+            end
+        end
+        nothing
+    end
+    ```
+
+ 3. A third strategy is to use the finalizer only to schedule the work to be done at another time.
+    This means we don't have to care about finalizers interrupting each other because the actual work will be done in a non-finalizer context.
+
+    Do this by pushing the work into a concurrent queue such as `Base.IntrusiveLinkedListSynchronized{T}`
+    or by using `Threads.@spawn` to add a task to the Julia task scheduler's queue.
+
+    This can frequently be a good strategy to use for code with event loops
+    and is employed by `Gtk.jl` to manage lifetime ref-counting.
+
+    If you use `Threads.@spawn` then you will not have control over with thread the spawned task will run on, so you will still need to acquire a lock in the task.
+    If you define your own queue then you can avoid this by only draining the queue from one thread at a time.
+
+    An example using `Threads.@spawn`:
+
+    ```
+    function my_finalizer(x)
+        Threads.@spawn begin
+            lock(my_lock)
+            try
+                # Your critical area here
+            finally
+                unlock(my_lock)
+            end
+        end
+    end
+
+    finalizer(my_finalizer, my_object)
+    ```
 """
 function finalizer(@nospecialize(f), @nospecialize(o))
     _check_mutable(o)

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -10,8 +10,12 @@ Creates a re-entrant lock for synchronizing [`Task`](@ref)s. The same task can
 acquire the lock as many times as required (this is what the "Reentrant" part
 of the name means). Each [`lock`](@ref) must be matched with an [`unlock`](@ref).
 
-Calling `lock` will also inhibit running of finalizers on that thread until the
-corresponding `unlock`. Use of the standard lock pattern illustrated below
+Acquiring a `ReentrantLock` with `lock` or `trylock` prevents:
+
+- any other task from acquiring the lock until `unlock`
+- finalizers from interrupting your task until `unlock`.
+
+Use of the standard lock pattern illustrated below
 should naturally be supported, but beware of inverting the try/lock order or
 missing the try block entirely (e.g. attempting to return with the lock still
 held):

--- a/base/locks-mt.jl
+++ b/base/locks-mt.jl
@@ -20,6 +20,11 @@ This kind of lock should only be used around code that takes little time
 to execute and does not block (e.g. perform I/O).
 In general, [`ReentrantLock`](@ref) should be used instead.
 
+Acquiring a `SpinLock` with `lock` or `trylock` prevents:
+
+- anything (including this task) from acquiring the lock until `unlock`
+- finalizers from interrupting your task until `unlock`.
+
 Each [`lock`](@ref) must be matched with an [`unlock`](@ref).
 If [`!islocked(lck::SpinLock)`](@ref islocked) holds, [`trylock(lck)`](@ref trylock)
 succeeds unless there are other tasks attempting to hold the lock "at the same time."
@@ -27,6 +32,7 @@ succeeds unless there are other tasks attempting to hold the lock "at the same t
 Test-and-test-and-set spin locks are quickest up to about 30ish
 contending threads. If you have more contention than that, different
 synchronization approaches should be considered.
+
 """
 mutable struct SpinLock <: AbstractLock
     # we make this much larger than necessary to minimize false-sharing

--- a/doc/src/manual/multi-threading.md
+++ b/doc/src/manual/multi-threading.md
@@ -464,56 +464,10 @@ and therefore should not be used to index into a vector of buffers or stateful o
     Task migration was introduced in Julia 1.7. Before this tasks always remained on the same thread that they were
     started on.
 
-## Safe use of Finalizers
+## Safe use of finalizers
 
-Because finalizers can interrupt any code, they must be very careful in how
-they interact with any global state. Unfortunately, the main reason that
-finalizers are used is to update global state (a pure function is generally
-rather pointless as a finalizer). This leads us to a bit of a conundrum.
-There are a few approaches to dealing with this problem:
+A [`finalizer`](@ref) function can be registered for any value of any `mutable struct`.
+Finalizer functions will be called when there are no program-accessible references to the value they were registered for and can *interrupt any code*.
 
-1. When single-threaded, code could call the internal `jl_gc_enable_finalizers`
-   C function to prevent finalizers from being scheduled
-   inside a critical region. Internally, this is used inside some functions (such
-   as our C locks) to prevent recursion when doing certain operations (incremental
-   package loading, codegen, etc.). The combination of a lock and this flag
-   can be used to make finalizers safe.
-
-2. A second strategy, employed by Base in a couple places, is to explicitly
-   delay a finalizer until it may be able to acquire its lock non-recursively.
-   The following example demonstrates how this strategy could be applied to
-   `Distributed.finalize_ref`:
-
-   ```julia
-   function finalize_ref(r::AbstractRemoteRef)
-       if r.where > 0 # Check if the finalizer is already run
-           if islocked(client_refs) || !trylock(client_refs)
-               # delay finalizer for later if we aren't free to acquire the lock
-               finalizer(finalize_ref, r)
-               return nothing
-           end
-           try # `lock` should always be followed by `try`
-               if r.where > 0 # Must check again here
-                   # Do actual cleanup here
-                   r.where = 0
-               end
-           finally
-               unlock(client_refs)
-           end
-       end
-       nothing
-   end
-   ```
-
-3. A related third strategy is to use a yield-free queue. We don't currently
-   have a lock-free queue implemented in Base, but
-   `Base.IntrusiveLinkedListSynchronized{T}` is suitable. This can frequently be a
-   good strategy to use for code with event loops. For example, this strategy is
-   employed by `Gtk.jl` to manage lifetime ref-counting. In this approach, we
-   don't do any explicit work inside the `finalizer`, and instead add it to a queue
-   to run at a safer time. In fact, Julia's task scheduler already uses this, so
-   defining the finalizer as `x -> @spawn do_cleanup(x)` is one example of this
-   approach. Note however that this doesn't control which thread `do_cleanup`
-   runs on, so `do_cleanup` would still need to acquire a lock. That
-   doesn't need to be true if you implement your own queue, as you can explicitly
-   only drain that queue from your thread.
+Because they can interrupt any code and usually interact with global state, they must be written carefully to avoid concurrency issues.
+Read the [extended help for `finalizer`](@ref finalizer) for more details and for strategies for dealing with this issue.

--- a/doc/src/manual/multi-threading.md
+++ b/doc/src/manual/multi-threading.md
@@ -470,4 +470,4 @@ A [`finalizer`](@ref) function can be registered for any value of any `mutable s
 Finalizer functions will be called when there are no program-accessible references to the value they were registered for and can *interrupt any code*.
 
 Because they can interrupt any code and usually interact with global state, they must be written carefully to avoid concurrency issues.
-Read the [extended help for `finalizer`](@ref finalizer) for more details and for strategies for dealing with this issue.
+Read the extended help for `finalizer` for more details and for strategies for dealing with this issue.


### PR DESCRIPTION
This commit concentrates the advice in the place that users of `finalizer` are most likely to see it and provides examples.

It's unclear to me if any of this is required if you use the `ReentrantLock`, because `_trylock` will disable finalizers anyway, but I couldn't work it out and I figured this PR might summon someone who knows definitively.