### PR TITLE
Fix extended help hint to give full line to enter

### DIFF
--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -23,6 +23,8 @@ using Unicode: normalize
 helpmode(io::IO, line::AbstractString, mod::Module=Main) = :($REPL.insert_hlines($io, $(REPL._helpmode(io, line, mod))))
 helpmode(line::AbstractString, mod::Module=Main) = helpmode(stdout, line, mod)
 
+# A hack to make the line entered at the REPL available at trimdocs without
+# passing the string through the entire mechanism.
 const extended_help_on = Ref{Any}(nothing)
 
 function _helpmode(io::IO, line::AbstractString, mod::Module=Main)
@@ -30,10 +32,10 @@ function _helpmode(io::IO, line::AbstractString, mod::Module=Main)
     ternary_operator_help = (line == "?" || line == "?:")
     if startswith(line, '?') && !ternary_operator_help
         line = line[2:end]
-        extended_help_on[] = line
+        extended_help_on[] = nothing
         brief = false
     else
-        extended_help_on[] = nothing
+        extended_help_on[] = line
         brief = true
     end
     # interpret anything starting with # or #= as asking for help on comments


### PR DESCRIPTION
Before this commit, the REPL would say:

    Extended help is available with `??`

Now it will give the full line required to display extended help:

    Extended help is available with `??LazyString`

I believe that this was the intended function of the code that's already here, because currently the `extended_help_on` constant is never used.

I've resisted the urge to pass the `line` through to `trimdocs` without a global because I don't know why @timholy did it that way to start with and because the smaller change makes this PR easier to review.