### PR TITLE
Bugfix: Convert numbers to Int in extendedterminfo

### DIFF
--- a/base/terminfo.jl
+++ b/base/terminfo.jl
@@ -137,7 +137,7 @@ function extendedterminfo(data::IO; NumInt::Union{Type{UInt16}, Type{UInt32}})
         0x00 == read(data, UInt8) ||
             throw(ArgumentError("Terminfo did not contain a null byte after the extended flag section, expected to position the start of the numbers section on an even byte"))
     end
-    numbers = reinterpret(NumInt, read(data, numbers_count * sizeof(NumInt))) .|> ltoh
+    numbers = map(n -> Int(ltoh(n)), reinterpret(NumInt, read(data, numbers_count * sizeof(NumInt))))
     table_indices = reinterpret(UInt16, read(data, table_count * sizeof(UInt16))) .|> ltoh
     table_strings = [String(readuntil(data, 0x00)) for _ in 1:length(table_indices)]
     strings = table_strings[1:string_count]


### PR DESCRIPTION
Before, in the extendedterminfo function in terminfo.jl, if the numbers array was nonempty, the function would fail as a `UInt32` cannot be implicitly converted to the output `Int` type. Do this conversion explicitly.

Closes #51190

@tecosaur it seems that this function was not tested. Looking at code coverage, `base/terminfo.jl` only has 18% coverage. Would it be possible to test this functionality more thoroughly?