### PR TITLE
slot2ssa: Fix spurious φᶜ edges

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -357,16 +357,12 @@ function compute_trycatch(code::Vector{Any}, ip::BitSet)
     end
 
     # now forward those marks to all :leave statements
-    pc´´ = 0
     while true
         # make progress on the active ip set
-        pc = _bits_findnext(ip.bits, pc´´)::Int
+        pc = _bits_findnext(ip.bits, 0)::Int
         pc > n && break
         while true # inner loop optimizes the common case where it can run straight from pc to pc + 1
             pc´ = pc + 1 # next program-counter (after executing instruction)
-            if pc == pc´´
-                pc´´ = pc´
-            end
             delete!(ip, pc)
             cur_hand = handler_at[pc]
             @assert cur_hand != 0 "unbalanced try/catch"
@@ -378,9 +374,6 @@ function compute_trycatch(code::Vector{Any}, ip::BitSet)
                 if handler_at[l] != cur_hand
                     @assert handler_at[l] == 0 "unbalanced try/catch"
                     handler_at[l] = cur_hand
-                    if l < pc´´
-                        pc´´ = l
-                    end
                     push!(ip, l)
                 end
             elseif isa(stmt, ReturnNode)

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -2,9 +2,7 @@
 
 using Test
 using Base.Meta
-import Core:
-    CodeInfo, Argument, SSAValue, GotoNode, GotoIfNot, PiNode, PhiNode,
-    PhiCNode, QuoteNode, ReturnNode
+using Core.IR
 
 include("irutils.jl")
 
@@ -1519,3 +1517,5 @@ let ir = first(only(Base.code_ircode(f_with_early_try_catch_exit, (); optimize_u
         end
     end
 end
+
+@test isnothing(f_with_early_try_catch_exit())


### PR DESCRIPTION
The unreachable here seems to be caused by the fact that (as of #50943) we re-use a more narrow type from Inference that correctly ignores these edges, but when inserting the `φᶜ` node in `slot2reg` we were including extra edges that never get exercised at runtime.

I'm not sure _why_ this causes us to hit an unreachable, since the narrow type from inference is technically still valid (the catch block will never observe these spurious assignments at runtime), but this seems to fix the issue and anyway improves the quality of the IRCode generated by `slot2ssa`.

Resolves #51159