### PR TITLE
Fix typos in JuliaSyntax.mk

### DIFF
--- a/deps/JuliaSyntax.mk
+++ b/deps/JuliaSyntax.mk
@@ -12,5 +12,5 @@ get-JuliaSyntax: $(JULIASYNTAX_SRC_FILE)
 extract-JuliaSyntax: $(BUILDDIR)/$(JULIASYNTAX_SRC_DIR)/source-extracted
 configure-JuliaSyntax: extract-JuliaSyntax
 compile-JuliaSyntax: $(BUILDDIR)/$(JULIASYNTAX_SRC_DIR)/build-compiled
-fastcheck-JuliSyntax: check-JuliSyntax
-check-JuliSyntax: compile-JuliSyntax
+fastcheck-JuliaSyntax: check-JuliaSyntax
+check-JuliaSyntax: compile-JuliaSyntax


### PR DESCRIPTION
before
```
x@x julia % make -C deps fastcheck-JuliaSyntax
make: *** No rule to make target `fastcheck-JuliaSyntax'.  Stop.
x@x julia % make -C deps fastcheck-JuliSyntax 
make: *** No rule to make target `compile-JuliSyntax', needed by `check-JuliSyntax'.  Stop.
```
after
```
x@x julia % make -C deps fastcheck-JuliaSyntax
make: Nothing to be done for `fastcheck-JuliaSyntax'.
```