### PR TITLE
optimizer: code quality and performance improvements to post-opt analysis

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -514,7 +514,6 @@ function ipo_dataflow_analysis!(interp::AbstractInterpreter, ir::IRCode, result:
     end
 
     inconsistent = BitSetBoundedMinPrioritySet(length(ir.stmts))
-    inconsistent_bbs = BitSet()
     tpdum = TwoPhaseDefUseMap(length(ir.stmts))
     lazypostdomtree = LazyPostDomtree(ir)
 

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -483,13 +483,12 @@ end
 function conditional_successors_may_throw(lazypostdomtree::LazyPostDomtree, ir::IRCode, bb::Int)
     visited = BitSet((bb,))
     worklist = Int[bb]
-    postdomtree = get!(lazypostdomtree)
     while !isempty(worklist)
         thisbb = pop!(worklist)
         for succ in ir.cfg.blocks[thisbb].succs
             succ in visited && continue
             push!(visited, succ)
-            postdominates(postdomtree, succ, thisbb) && continue
+            postdominates(get!(lazypostdomtree), succ, thisbb) && continue
             any_stmt_may_throw(ir, succ) && return true
             push!(worklist, succ)
         end

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -618,7 +618,7 @@ function ipo_dataflow_analysis!(interp::AbstractInterpreter, ir::IRCode, result:
         if isexpr(stmt, :enter)
             # try/catch not yet modeled
             had_trycatch = true
-            return false
+            return nothing
         end
 
         scan_non_dataflow_flags!(inst)

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -217,7 +217,7 @@ function BBScanner(ir::IRCode)
     return BBScanner(ir, bb_ip)
 end
 
-function scan!(callback, scanner::BBScanner, forwards_only::Bool)
+function scan!(@specialize(callback), scanner::BBScanner, forwards_only::Bool)
     (; bb_ip, ir) = scanner
     bbs = ir.cfg.blocks
     while !isempty(bb_ip)
@@ -235,7 +235,7 @@ function scan!(callback, scanner::BBScanner, forwards_only::Bool)
 end
 
 function populate_def_use_map!(tpdum::TwoPhaseDefUseMap, scanner::BBScanner)
-    scan!(scanner, false) do inst, idx, lstmt, bb
+    scan!(scanner, false) do inst::Instruction, idx::Int, lstmt::Int, bb::Int
         for ur in userefs(inst)
             val = ur[]
             if isa(val, SSAValue)
@@ -262,7 +262,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
     # Fast path: Scan both use counts and refinement in one single pass of
     #            of the instructions. In the absence of backedges, this will
     #            converge.
-    completed_scan = scan!(scanner, true) do inst, idx, lstmt, bb
+    completed_scan = scan!(scanner, true) do inst::Instruction, idx::Int, lstmt::Int, bb::Int
         irsv.curridx = idx
         stmt = ir.stmts[idx][:inst]
         typ = ir.stmts[idx][:type]
@@ -315,7 +315,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
         stmt_ip = BitSetBoundedMinPrioritySet(length(ir.stmts))
 
         # Slow Path Phase 1.A: Complete use scanning
-        scan!(scanner, false) do inst, idx, lstmt, bb
+        scan!(scanner, false) do inst::Instruction, idx::Int, lstmt::Int, bb::Int
             irsv.curridx = idx
             stmt = inst[:inst]
             flag = inst[:flag]

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -227,7 +227,8 @@ function scan!(@specialize(callback), scanner::BBScanner, forwards_only::Bool)
         for idx = stmts
             inst = ir[SSAValue(idx)]
             ret = callback(inst, idx, lstmt, bb)
-            ret === false && break
+            ret === nothing && return true
+            ret::Bool || break
             idx == lstmt && process_terminator!(inst[:inst], bb, bb_ip) && forwards_only && return false
         end
     end

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -217,7 +217,7 @@ function BBScanner(ir::IRCode)
     return BBScanner(ir, bb_ip)
 end
 
-function scan!(@specialize(callback), scanner::BBScanner, forwards_only::Bool)
+function scan!(callback, scanner::BBScanner, forwards_only::Bool)
     (; bb_ip, ir) = scanner
     bbs = ir.cfg.blocks
     while !isempty(bb_ip)

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -464,7 +464,6 @@ function adjust_effects(ipo_effects::Effects, def::Method)
     return ipo_effects
 end
 
-
 function adjust_effects(sv::InferenceState)
     ipo_effects = sv.ipo_effects
 
@@ -553,7 +552,6 @@ function finish(me::InferenceState, interp::AbstractInterpreter)
     me.result.valid_worlds = me.valid_worlds
     me.result.result = bestguess
     me.ipo_effects = me.result.ipo_effects = adjust_effects(me)
-
 
     if limited_ret
         # a parent may be cached still, but not this intermediate work:


### PR DESCRIPTION
This PR is composed of a set of fixes and improvements to `ipo_dataflow_analysis!`.
I will rebase this once we merge #51185 and #51188, so still WIP, but let's see benchmark.

@nanosoldier `runbenchmarks("inference", vs=":master")`