### PR TITLE
Wait for other threads to finish compiling before exiting

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9433,6 +9433,8 @@ extern "C" JL_DLLEXPORT_CODEGEN void jl_teardown_codegen_impl() JL_NOTSAFEPOINT
     if (jl_ExecutionEngine)
         jl_ExecutionEngine->printTimers();
     PrintStatistics();
+    JL_LOCK(&jl_codegen_lock); // TODO: If this lock gets removed reconsider
+                                    // LLVM global state/destructors (maybe a rwlock)
 }
 
 // the rest of this file are convenience functions


### PR DESCRIPTION
This avoids a crashes where we run the destructors because C++ is fun and runs destructors before thread exit.