### PR TITLE
reflection: define `Base.generating_output` utility function

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -805,8 +805,6 @@ function resolve_call_cycle!(interp::AbstractInterpreter, mi::MethodInstance, pa
     return false
 end
 
-generating_sysimg() = ccall(:jl_generating_output, Cint, ()) != 0 && JLOptions().incremental == 0
-
 ipo_effects(code::CodeInstance) = decode_effects(code.ipo_purity_bits)
 
 struct EdgeCallResult
@@ -840,7 +838,7 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
     else
         cache = :global # cache edge targets by default
     end
-    if ccall(:jl_get_module_infer, Cint, (Any,), method.module) == 0 && !generating_sysimg()
+    if ccall(:jl_get_module_infer, Cint, (Any,), method.module) == 0 && !generating_system_image()
         add_remark!(interp, caller, "Inference is disabled for the target module")
         return EdgeCallResult(Any, nothing, Effects())
     end
@@ -1011,7 +1009,7 @@ function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance)
             return inf
         end
     end
-    if ccall(:jl_get_module_infer, Cint, (Any,), method.module) == 0 && !generating_sysimg()
+    if ccall(:jl_get_module_infer, Cint, (Any,), method.module) == 0 && !generating_system_image()
         return retrieve_code_info(mi, get_world_counter(interp))
     end
     lock_mi_inference(interp, mi)

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -838,7 +838,7 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
     else
         cache = :global # cache edge targets by default
     end
-    if ccall(:jl_get_module_infer, Cint, (Any,), method.module) == 0 && !generating_system_image()
+    if ccall(:jl_get_module_infer, Cint, (Any,), method.module) == 0 && !generating_output(#=incremental=#false)
         add_remark!(interp, caller, "Inference is disabled for the target module")
         return EdgeCallResult(Any, nothing, Effects())
     end
@@ -1009,7 +1009,7 @@ function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance)
             return inf
         end
     end
-    if ccall(:jl_get_module_infer, Cint, (Any,), method.module) == 0 && !generating_system_image()
+    if ccall(:jl_get_module_infer, Cint, (Any,), method.module) == 0 && !generating_output(#=incremental=#false)
         return retrieve_code_info(mi, get_world_counter(interp))
     end
     lock_mi_inference(interp, mi)

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -500,7 +500,7 @@ is_root_module(m::Module) = false
 
 inlining_enabled() = (JLOptions().can_inline == 1)
 function coverage_enabled(m::Module)
-    generating_image() && return false # don't alter caches
+    generating_output() && return false # don't alter caches
     cov = JLOptions().code_coverage
     if cov == 1 # user
         m = moduleroot(m)

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -500,7 +500,7 @@ is_root_module(m::Module) = false
 
 inlining_enabled() = (JLOptions().can_inline == 1)
 function coverage_enabled(m::Module)
-    ccall(:jl_generating_output, Cint, ()) == 0 || return false # don't alter caches
+    generating_image() && return false # don't alter caches
     cov = JLOptions().code_coverage
     if cov == 1 # user
         m = moduleroot(m)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1703,7 +1703,7 @@ If a module or file is *not* safely precompilable, it should call `__precompile_
 order to throw an error if Julia attempts to precompile it.
 """
 @noinline function __precompile__(isprecompilable::Bool=true)
-    if !isprecompilable && ccall(:jl_generating_output, Cint, ()) != 0
+    if !isprecompilable && generating_image()
         throw(PrecompilableError())
     end
     nothing
@@ -1843,7 +1843,7 @@ root_module_key(m::Module) = @lock require_lock module_keys[m]
     if haskey(loaded_modules, key)
         oldm = loaded_modules[key]
         if oldm !== m
-            if (0 != ccall(:jl_generating_output, Cint, ())) && (JLOptions().incremental != 0)
+            if generating_image() && (JLOptions().incremental != 0)
                 error("Replacing module `$(key.name)`")
             else
                 @warn "Replacing module `$(key.name)`"
@@ -1894,7 +1894,7 @@ function set_pkgorigin_version_path(pkg::PkgId, path::Union{String,Nothing})
     pkgorigin = get!(PkgOrigin, pkgorigins, pkg)
     if path !== nothing
         # Pkg needs access to the version of packages in the sysimage.
-        if Core.Compiler.generating_sysimg()
+        if generating_system_image()
             pkgorigin.version = get_pkgversion_from_path(joinpath(dirname(path), ".."))
         end
     end
@@ -1949,7 +1949,7 @@ function _require(pkg::PkgId, env=nothing)
         end
 
         if JLOptions().use_compiled_modules == 1
-            if (0 == ccall(:jl_generating_output, Cint, ())) || (JLOptions().incremental != 0)
+            if !generating_system_image()
                 if !pkg_precompile_attempted && isinteractive() && isassigned(PKG_PRECOMPILE_HOOK)
                     pkg_precompile_attempted = true
                     unlock(require_lock)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1703,7 +1703,7 @@ If a module or file is *not* safely precompilable, it should call `__precompile_
 order to throw an error if Julia attempts to precompile it.
 """
 @noinline function __precompile__(isprecompilable::Bool=true)
-    if !isprecompilable && generating_image()
+    if !isprecompilable && generating_output()
         throw(PrecompilableError())
     end
     nothing
@@ -1843,7 +1843,7 @@ root_module_key(m::Module) = @lock require_lock module_keys[m]
     if haskey(loaded_modules, key)
         oldm = loaded_modules[key]
         if oldm !== m
-            if generating_image() && (JLOptions().incremental != 0)
+            if generating_output(#=incremental=#true)
                 error("Replacing module `$(key.name)`")
             else
                 @warn "Replacing module `$(key.name)`"
@@ -1894,7 +1894,7 @@ function set_pkgorigin_version_path(pkg::PkgId, path::Union{String,Nothing})
     pkgorigin = get!(PkgOrigin, pkgorigins, pkg)
     if path !== nothing
         # Pkg needs access to the version of packages in the sysimage.
-        if generating_system_image()
+        if generating_output(#=incremental=#false)
             pkgorigin.version = get_pkgversion_from_path(joinpath(dirname(path), ".."))
         end
     end
@@ -1949,7 +1949,7 @@ function _require(pkg::PkgId, env=nothing)
         end
 
         if JLOptions().use_compiled_modules == 1
-            if !generating_system_image()
+            if !generating_output(#=incremental=#false)
                 if !pkg_precompile_attempted && isinteractive() && isassigned(PKG_PRECOMPILE_HOOK)
                     pkg_precompile_attempted = true
                     unlock(require_lock)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -2346,3 +2346,7 @@ function destructure_callex(topmod::Module, @nospecialize(ex))
     end
     return f, args, kwargs
 end
+
+generating_image() = ccall(:jl_generating_output, Cint, ()) != 0
+
+generating_system_image() = generating_image() && JLOptions().incremental == 0

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -2347,6 +2347,18 @@ function destructure_callex(topmod::Module, @nospecialize(ex))
     return f, args, kwargs
 end
 
-generating_image() = ccall(:jl_generating_output, Cint, ()) != 0
+"""
+    Base.generating_output([incremental::Bool])::Bool
 
-generating_system_image() = generating_image() && JLOptions().incremental == 0
+Return `true` if the current process is being used to pre-generate a
+code cache via any of the `--output-*` command line arguments. The
+optional argument `incremental` controls whether to only return `true`
+for that specific mode of compilation.
+"""
+function generating_output(incremental::Union{Bool,Nothing}=nothing)
+    ccall(:jl_generating_output, Cint, ()) == 0 && return false
+    if incremental !== nothing
+        JLOptions().incremental == incremental || return false
+    end
+    return true
+end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -2354,6 +2354,9 @@ Return `true` if the current process is being used to pre-generate a
 code cache via any of the `--output-*` command line arguments. The
 optional argument `incremental` controls whether to only return `true`
 for that specific mode of compilation.
+
+!!! compat "Julia 1.11"
+    This function requires at least Julia 1.11.
 """
 function generating_output(incremental::Union{Bool,Nothing}=nothing)
     ccall(:jl_generating_output, Cint, ()) == 0 && return false

--- a/stdlib/Profile/src/precompile.jl
+++ b/stdlib/Profile/src/precompile.jl
@@ -1,4 +1,4 @@
-if ccall(:jl_generating_output, Cint, ()) == 1
+if Base.generating_image()
     precompile(Tuple{typeof(Profile.tree!), Profile.StackFrameTree{UInt64}, Vector{UInt64}, Dict{UInt64, Vector{Base.StackTraces.StackFrame}}, Bool, Symbol, Int, UInt})
     precompile(Tuple{typeof(Profile.tree!), Profile.StackFrameTree{UInt64}, Vector{UInt64}, Dict{UInt64, Vector{Base.StackTraces.StackFrame}}, Bool, Symbol, Int, UnitRange{UInt}})
     precompile(Tuple{typeof(Profile.tree!), Profile.StackFrameTree{UInt64}, Vector{UInt64}, Dict{UInt64, Vector{Base.StackTraces.StackFrame}}, Bool, Symbol, UnitRange{Int}, UInt})

--- a/stdlib/Profile/src/precompile.jl
+++ b/stdlib/Profile/src/precompile.jl
@@ -1,4 +1,4 @@
-if Base.generating_image()
+if Base.generating_output()
     precompile(Tuple{typeof(Profile.tree!), Profile.StackFrameTree{UInt64}, Vector{UInt64}, Dict{UInt64, Vector{Base.StackTraces.StackFrame}}, Bool, Symbol, Int, UInt})
     precompile(Tuple{typeof(Profile.tree!), Profile.StackFrameTree{UInt64}, Vector{UInt64}, Dict{UInt64, Vector{Base.StackTraces.StackFrame}}, Bool, Symbol, Int, UnitRange{UInt}})
     precompile(Tuple{typeof(Profile.tree!), Profile.StackFrameTree{UInt64}, Vector{UInt64}, Dict{UInt64, Vector{Base.StackTraces.StackFrame}}, Bool, Symbol, UnitRange{Int}, UInt})

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -429,7 +429,7 @@ function get_code_cache()
     #     that those produced by `NativeInterpreter`, will leak into the native code cache,
     #     potentially causing runtime slowdown.
     #     (see https://github.com/JuliaLang/julia/issues/48453).
-    if (@ccall jl_generating_output()::Cint) == 1
+    if Base.generating_output()
         return REPLInterpreterCache()
     else
         return REPL_INTERPRETER_CACHE


### PR DESCRIPTION
And replaces `ccall(:jl_generating_out, ...)` with the new function.