### PR TITLE
remove special case for the no-op first statement in `fully_eliminated`

### DIFF
--- a/test/compiler/irutils.jl
+++ b/test/compiler/irutils.jl
@@ -42,24 +42,15 @@ fully_eliminated(@nospecialize args...; retval=(@__FILE__), kwargs...) =
 fully_eliminated(src::CodeInfo; retval=(@__FILE__)) = fully_eliminated(src.code; retval)
 fully_eliminated(ir::IRCode; retval=(@__FILE__)) = fully_eliminated(ir.stmts.stmt; retval)
 function fully_eliminated(code::Vector{Any}; retval=(@__FILE__), kwargs...)
-    if retval !== (@__FILE__)
-        (length(code) <= 2) || return false
-        for i = 1:(length(code) - 1)
-            code[i] === nothing || return false
-        end
-        isreturn(code[end]) || return false
-        val = code[end].val
-        if val isa QuoteNode
-            val = val.value
-        end
-        return val == retval
-    else
-        (length(code) <= 2) || return false
-        for i = 1:(length(code) - 1)
-            code[i] === nothing || return false
-        end
-        return isreturn(code[end])
+    length(code) == 1 || return false
+    retstmt = only(code)
+    isreturn(retstmt) || return false
+    retval === (@__FILE__) && return true
+    retval′ = retstmt.val
+    if retval′ isa QuoteNode
+        val = retval′.value
     end
+    return val == retval
 end
 macro fully_eliminated(ex0...)
     return gen_call_with_extracted_types_and_kwargs(__module__, :fully_eliminated, ex0)

--- a/test/compiler/irutils.jl
+++ b/test/compiler/irutils.jl
@@ -48,9 +48,9 @@ function fully_eliminated(code::Vector{Any}; retval=(@__FILE__), kwargs...)
     retval === (@__FILE__) && return true
     retval′ = retstmt.val
     if retval′ isa QuoteNode
-        val = retval′.value
+        retval′ = retval′.value
     end
-    return val == retval
+    return retval′ == retval
 end
 macro fully_eliminated(ex0...)
     return gen_call_with_extracted_types_and_kwargs(__module__, :fully_eliminated, ex0)


### PR DESCRIPTION
It looks like the special case is no longer needed. If this gets broken by future changes, I would like fix it or mark the test cases as `broken`.