### PR TITLE
Include JuliaSyntax.jl from the build directory.

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -495,7 +495,7 @@ include(mapexpr::Function, mod::Module, _path::AbstractString) = _include(mapexp
 
 # External libraries vendored into Base
 Core.println("JuliaSyntax/src/JuliaSyntax.jl")
-include(@__MODULE__, "JuliaSyntax/src/JuliaSyntax.jl")
+include(@__MODULE__, strcat((length(Core.ARGS)>=2 ? Core.ARGS[2] : ""), "JuliaSyntax/src/JuliaSyntax.jl")) # include($BUILDROOT/base/JuliaSyntax/JuliaSyntax.jl)
 
 end_base_include = time_ns()
 

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -495,7 +495,7 @@ include(mapexpr::Function, mod::Module, _path::AbstractString) = _include(mapexp
 
 # External libraries vendored into Base
 Core.println("JuliaSyntax/src/JuliaSyntax.jl")
-include(@__MODULE__, strcat((length(Core.ARGS)>=2 ? Core.ARGS[2] : ""), "JuliaSyntax/src/JuliaSyntax.jl")) # include($BUILDROOT/base/JuliaSyntax/JuliaSyntax.jl)
+include(@__MODULE__, string((length(Core.ARGS)>=2 ? Core.ARGS[2] : ""), "JuliaSyntax/src/JuliaSyntax.jl")) # include($BUILDROOT/base/JuliaSyntax/JuliaSyntax.jl)
 
 end_base_include = time_ns()
 

--- a/deps/JuliaSyntax.mk
+++ b/deps/JuliaSyntax.mk
@@ -4,7 +4,7 @@ $(BUILDDIR)/$(JULIASYNTAX_SRC_DIR)/build-compiled: $(BUILDDIR)/$(JULIASYNTAX_SRC
 	@# no build steps
 	echo 1 > $@
 
-$(eval $(call symlink_install,JuliaSyntax,$$(JULIASYNTAX_SRC_DIR),$$(JULIAHOME)/base))
+$(eval $(call symlink_install,JuliaSyntax,$$(JULIASYNTAX_SRC_DIR),$$(BUILDROOT)/base))
 
 clean-JuliaSyntax:
 	-rm -f $(BUILDDIR)/$(JULIASYNTAX_SRC_DIR)/build-compiled


### PR DESCRIPTION
This ensures the source isn't modified during an out-of-tree build.

Fixes https://github.com/JuliaLang/julia/issues/51230