### PR TITLE
Inline `_log` to avoid passing symbol argument.

### DIFF
--- a/base/special/log.jl
+++ b/base/special/log.jl
@@ -267,7 +267,7 @@ log2(x::Float64)  = _log(x, Val(2),  :log2)
 log(x::Float64)   = _log(x, Val(:ℯ), :log)
 log10(x::Float64) = _log(x, Val(10), :log10)
 
-function _log(x::Float64, base, func)
+@inline function _log(x::Float64, base, func)
     if x > 0.0
         x == Inf && return x
 
@@ -302,7 +302,7 @@ function _log(x::Float64, base, func)
     end
 end
 
-function _log(x::Float32, base, func)
+@inline function _log(x::Float32, base, func)
     if x > 0f0
         x == Inf32 && return x
 

--- a/base/special/log.jl
+++ b/base/special/log.jl
@@ -260,12 +260,12 @@ end
     Float32(logb(Float32, base)*(u64 + q))
 end
 
-log2(x::Float32)  = _log(x, Val(2),  :log2)
-log(x::Float32)   = _log(x, Val(:ℯ), :log)
-log10(x::Float32) = _log(x, Val(10), :log10)
-log2(x::Float64)  = _log(x, Val(2),  :log2)
-log(x::Float64)   = _log(x, Val(:ℯ), :log)
-log10(x::Float64) = _log(x, Val(10), :log10)
+@noinline log2(x::Float32)  = _log(x, Val(2),  :log2)
+@noinline log(x::Float32)   = _log(x, Val(:ℯ), :log)
+@noinline log10(x::Float32) = _log(x, Val(10), :log10)
+@noinline log2(x::Float64)  = _log(x, Val(2),  :log2)
+@noinline log(x::Float64)   = _log(x, Val(:ℯ), :log)
+@noinline log10(x::Float64) = _log(x, Val(10), :log10)
 
 @inline function _log(x::Float64, base, func)
     if x > 0.0


### PR DESCRIPTION
This reduces callsite code from
```julia
julia> foo(x) = log(x)
foo (generic function with 1 method)

julia> @code_native syntax=:intel debuginfo=:none foo(2.3)
        .text
        .file   "foo"
        .globl  julia_foo_2627                  # -- Begin function julia_foo_2627
        .p2align        4, 0x90
        .type   julia_foo_2627,@function
julia_foo_2627:                         # @julia_foo_2627
; Function Signature: foo(Float64)
        #DEBUG_VALUE: foo:x <- $xmm0
        push    rbp
        mov     rbp, rsp
        movabs  rdi, offset ".Ljl_sym#log#2632.jit"
        movabs  rax, offset j__log_2631
        call    rax
        pop     rbp
        ret
```
to
```julia
julia> @code_native syntax=:intel debuginfo=:none foo(2.3)
        .text
        .file   "foo"
        .globl  julia_foo_10446                 # -- Begin function julia_foo_10446
        .p2align        4, 0x90
        .type   julia_foo_10446,@function
julia_foo_10446:                        # @julia_foo_10446
; Function Signature: foo(Float64)
        #DEBUG_VALUE: foo:x <- $xmm0
        push    rbp
        mov     rbp, rsp
        movabs  rax, offset j_log_10450
        call    rax
        pop     rbp
        ret
```
Note that we no longer have
```asm
movabs  rdi, offset ".Ljl_sym#log#2632.jit"`
```
saving an instruction at every call site.