### PR TITLE
Fix getfield codegen for tuple inputs and unknown symbol fields.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3877,7 +3877,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         }
         else if (fld.typ == (jl_value_t*)jl_symbol_type) { // Known type but unknown symbol
             if (jl_is_datatype(utt) && (utt != jl_module_type) && jl_struct_try_layout(utt)) {
-                if ((jl_datatype_nfields(utt) == 1 && !jl_is_namedtuple_type(utt))) {
+                if ((jl_datatype_nfields(utt) == 1 && !jl_is_namedtuple_type(utt) && !jl_is_tuple_type(utt))) {
                     jl_svec_t *fn = jl_field_names(utt);
                     assert(jl_svec_len(fn) == 1);
                     Value *typ_sym = literal_pointer_val(ctx, jl_svecref(fn, 0));

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -863,3 +863,7 @@ end
 @noinline bar50964(x::DataType) = Base.inferencebarrier(2)
 foo50964(x) = bar50964(Base.inferencebarrier(Core.Const(x)))
 foo50964(1) # Shouldn't assert!
+
+# https://github.com/JuliaLang/julia/issues/51233
+obj51233 = (1,)
+@test_throws ErrorException obj51233.x


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/51233