### PR TITLE
Add lock around uv_unref during init

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -600,7 +600,9 @@ function __init__()
     @static if !Sys.iswindows()
         # triggering a profile via signals is not implemented on windows
         cond = Base.AsyncCondition()
+        Base.iolock_begin() # uv_unref needs lock
         Base.uv_unref(cond.handle)
+        Base.iolock_end()
         PROFILE_PRINT_COND[] = cond
         ccall(:jl_set_peek_cond, Cvoid, (Ptr{Cvoid},), PROFILE_PRINT_COND[].handle)
         errormonitor(Threads.@spawn(profile_printing_listener()))

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -600,9 +600,7 @@ function __init__()
     @static if !Sys.iswindows()
         # triggering a profile via signals is not implemented on windows
         cond = Base.AsyncCondition()
-        Base.iolock_begin() # uv_unref needs lock
         Base.uv_unref(cond.handle)
-        Base.iolock_end()
         PROFILE_PRINT_COND[] = cond
         ccall(:jl_set_peek_cond, Cvoid, (Ptr{Cvoid},), PROFILE_PRINT_COND[].handle)
         errormonitor(Threads.@spawn(profile_printing_listener()))

--- a/base/libuv.jl
+++ b/base/libuv.jl
@@ -103,8 +103,17 @@ uv_error(prefix::AbstractString, c::Integer) = c < 0 ? throw(_UVError(prefix, c)
 
 eventloop() = ccall(:jl_global_event_loop, Ptr{Cvoid}, ())
 
-uv_unref(h::Ptr{Cvoid}) = ccall(:uv_unref, Cvoid, (Ptr{Cvoid},), h)
-uv_ref(h::Ptr{Cvoid}) = ccall(:uv_ref, Cvoid, (Ptr{Cvoid},), h)
+function uv_unref(h::Ptr{Cvoid})
+    iolock_begin()
+    ccall(:uv_unref, Cvoid, (Ptr{Cvoid},), h)
+    iolock_end()
+end
+
+function uv_ref(h::Ptr{Cvoid})
+    iolock_begin()
+    ccall(:uv_ref, Cvoid, (Ptr{Cvoid},), h)
+    iolock_end()
+end
 
 function process_events()
     return ccall(:jl_process_events, Int32, ())


### PR DESCRIPTION
This is not a legal operation outside the lock because it's not atomic 