### PR TITLE
Unify flags_for_effects handling

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2481,6 +2481,8 @@ function abstract_eval_statement_expr(interp::AbstractInterpreter, e::Expr, vtyp
                     t = Const(false)
                 end
             end
+        else
+            effects = EFFECTS_UNKNOWN
         end
     elseif ehead === :throw_undef_if_not
         condt = argextype(stmt.args[2], ir)

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2498,7 +2498,7 @@ function abstract_eval_statement_expr(interp::AbstractInterpreter, e::Expr, vtyp
         end
     elseif ehead === :boundscheck
         t = Bool
-        effects = Effects(EFFECTS_TOTAL; consistent = ALWAYS_FALSE)
+        effects = Effects(EFFECTS_TOTAL; consistent=ALWAYS_FALSE)
     elseif ehead === :the_exception
         t = Any
         effects = Effects(EFFECTS_TOTAL; consistent=ALWAYS_FALSE)

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2197,32 +2197,6 @@ function abstract_eval_cfunction(interp::AbstractInterpreter, e::Expr, vtypes::U
     nothing
 end
 
-function abstract_eval_value_expr(interp::AbstractInterpreter, e::Expr, vtypes::Union{VarTable,Nothing}, sv::AbsIntState)
-    head = e.head
-    if head === :static_parameter
-        n = e.args[1]::Int
-        nothrow = false
-        if 1 <= n <= length(sv.sptypes)
-            sp = sv.sptypes[n]
-            rt = sp.typ
-            nothrow = !sp.undef
-        else
-            rt = Any
-        end
-        merge_effects!(interp, sv, Effects(EFFECTS_TOTAL; nothrow))
-        return rt
-    elseif head === :boundscheck
-        merge_effects!(interp, sv, Effects(EFFECTS_TOTAL; consistent = ALWAYS_FALSE))
-        return Bool
-    elseif head === :inbounds
-        @assert false "Expected `:inbounds` expression to have been moved into SSA flags"
-    elseif head === :the_exception
-        merge_effects!(interp, sv, Effects(EFFECTS_TOTAL; consistent=ALWAYS_FALSE))
-        return Any
-    end
-    return Any
-end
-
 function abstract_eval_special_value(interp::AbstractInterpreter, @nospecialize(e), vtypes::Union{VarTable,Nothing}, sv::AbsIntState)
     if isa(e, QuoteNode)
         return Const(e.value)
@@ -2252,6 +2226,34 @@ function abstract_eval_special_value(interp::AbstractInterpreter, @nospecialize(
     return Const(e)
 end
 
+function abstract_eval_value_expr(interp::AbstractInterpreter, e::Expr, vtypes::Union{VarTable,Nothing}, sv::AbsIntState)
+    head = e.head
+    if head === :static_parameter
+        n = e.args[1]::Int
+        nothrow = false
+        if 1 <= n <= length(sv.sptypes)
+            sp = sv.sptypes[n]
+            rt = sp.typ
+            nothrow = !sp.undef
+        else
+            rt = Any
+        end
+        merge_effects!(interp, sv, Effects(EFFECTS_TOTAL; nothrow))
+        return rt
+    elseif head === :call
+        # TODO: We still have non-linearized cglobal
+        @assert e.args[1] === Core.tuple ||
+                e.args[1] === GlobalRef(Core, :tuple)
+    else
+        # Some of our tests expect us to handle invalid IR here and error later
+        # - permit that for now.
+        # @assert false "Unexpected EXPR head in value position"
+        merge_effects!(interp, sv, EFFECTS_UNKNOWN)
+    end
+    return Any
+end
+
+
 function abstract_eval_value(interp::AbstractInterpreter, @nospecialize(e), vtypes::Union{VarTable,Nothing}, sv::AbsIntState)
     if isa(e, Expr)
         return abstract_eval_value_expr(interp, e, vtypes, sv)
@@ -2280,38 +2282,12 @@ struct RTEffects
     RTEffects(@nospecialize(rt), effects::Effects) = new(rt, effects)
 end
 
-function mark_curr_effect_flags!(sv::AbsIntState, effects::Effects)
-    if isa(sv, InferenceState)
-        if is_effect_free(effects)
-            add_curr_ssaflag!(sv, IR_FLAG_EFFECT_FREE)
-        else
-            sub_curr_ssaflag!(sv, IR_FLAG_EFFECT_FREE)
-        end
-        if is_nothrow(effects)
-            add_curr_ssaflag!(sv, IR_FLAG_NOTHROW)
-        else
-            sub_curr_ssaflag!(sv, IR_FLAG_NOTHROW)
-        end
-        if is_consistent(effects)
-            add_curr_ssaflag!(sv, IR_FLAG_CONSISTENT)
-        else
-            sub_curr_ssaflag!(sv, IR_FLAG_CONSISTENT)
-        end
-        if is_noub(effects, false)
-            add_curr_ssaflag!(sv, IR_FLAG_NOUB)
-        else
-            sub_curr_ssaflag!(sv, IR_FLAG_NOUB)
-        end
-    end
-end
-
 function abstract_call(interp::AbstractInterpreter, arginfo::ArgInfo, sv::InferenceState)
     si = StmtInfo(!call_result_unused(sv, sv.currpc))
     (; rt, effects, info) = abstract_call(interp, arginfo, si, sv)
     sv.stmt_info[sv.currpc] = info
     # mark this call statement as DCE-elgible
     # TODO better to do this in a single pass based on the `info` object at the end of abstractinterpret?
-    mark_curr_effect_flags!(sv, effects)
     return RTEffects(rt, effects)
 end
 
@@ -2451,7 +2427,6 @@ function abstract_eval_statement_expr(interp::AbstractInterpreter, e::Expr, vtyp
     elseif ehead === :foreigncall
         (; rt, effects) = abstract_eval_foreigncall(interp, e, vtypes, sv)
         t = rt
-        mark_curr_effect_flags!(sv, effects)
     elseif ehead === :cfunction
         effects = EFFECTS_UNKNOWN
         t = e.args[1]
@@ -2485,12 +2460,16 @@ function abstract_eval_statement_expr(interp::AbstractInterpreter, e::Expr, vtyp
                 t = Const(true)
             elseif InferenceParams(interp).assume_bindings_static
                 t = Const(false)
+            else
+                effects = Effects(EFFECTS_TOTAL; consistent=ALWAYS_FALSE)
             end
         elseif isa(sym, GlobalRef)
             if isdefined(sym.mod, sym.name)
                 t = Const(true)
             elseif InferenceParams(interp).assume_bindings_static
                 t = Const(false)
+            else
+                effects = Effects(EFFECTS_TOTAL; consistent=ALWAYS_FALSE)
             end
         elseif isexpr(sym, :static_parameter)
             n = sym.args[1]::Int
@@ -2517,12 +2496,44 @@ function abstract_eval_statement_expr(interp::AbstractInterpreter, e::Expr, vtyp
         elseif !hasintersect(windenconst(condt), Bool)
             t = Union{}
         end
+    elseif ehead === :boundscheck
+        t = Bool
+        effects = Effects(EFFECTS_TOTAL; consistent = ALWAYS_FALSE)
+    elseif ehead === :the_exception
+        t = Any
+        effects = Effects(EFFECTS_TOTAL; consistent=ALWAYS_FALSE)
+    elseif ehead === :static_parameter
+        n = e.args[1]::Int
+        nothrow = false
+        if 1 <= n <= length(sv.sptypes)
+            sp = sv.sptypes[n]
+            t = sp.typ
+            nothrow = !sp.undef
+        else
+            t = Any
+        end
+        effects = Effects(EFFECTS_TOTAL; nothrow)
+    elseif ehead === :gc_preserve_begin || ehead === :aliasscope
+        t = Any
+        effects = Effects(EFFECTS_TOTAL; consistent=ALWAYS_FALSE, effect_free=EFFECT_FREE_GLOBALLY)
+    elseif ehead === :gc_preserve_end || ehead === :leave || ehead === :pop_exception || ehead === :global || ehead === :popaliasscope
+        t = Nothing
+        effects = Effects(EFFECTS_TOTAL; effect_free=EFFECT_FREE_GLOBALLY)
+    elseif ehead === :method
+        t = Method
+        effects = Effects(EFFECTS_TOTAL; effect_free=EFFECT_FREE_GLOBALLY)
+    elseif ehead === :thunk
+        t = Any
+        effects = EFFECTS_UNKNOWN
     elseif false
         @label always_throw
         t = Bottom
         effects = EFFECTS_THROWS
     else
         t = abstract_eval_value_expr(interp, e, vtypes, sv)
+        # N.B.: abstract_eval_value_expr can modify the global effects, but
+        # we move out any arguments with effects during SSA construction later
+        # and recompute the effects.
         effects = EFFECTS_TOTAL
     end
     return RTEffects(t, effects)
@@ -2542,7 +2553,6 @@ function refine_partial_type(@nospecialize t)
 end
 
 function abstract_eval_foreigncall(interp::AbstractInterpreter, e::Expr, vtypes::Union{VarTable,Nothing}, sv::AbsIntState)
-    abstract_eval_value(interp, e.args[1], vtypes, sv)
     mi = frame_instance(sv)
     t = sp_type_rewrap(e.args[2], mi, true)
     for i = 3:length(e.args)
@@ -2601,6 +2611,10 @@ function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), 
             effects = Effects(effects; noub=ALWAYS_TRUE)
         end
     end
+    # N.B.: This only applies to the effects of the statement itself.
+    # It is possible for arguments (GlobalRef/:static_parameter) to throw,
+    # but these will be recomputed during SSA construction later.
+    set_curr_ssaflag!(sv, flags_for_effects(effects), IR_FLAGS_EFFECTS)
     merge_effects!(interp, sv, effects)
     e = e::Expr
     @assert !isa(rt, TypeVar) "unhandled TypeVar"

--- a/base/compiler/effects.jl
+++ b/base/compiler/effects.jl
@@ -134,11 +134,11 @@ const CONSISTENT_IF_INACCESSIBLEMEMONLY = 0x01 << 2
 const EFFECT_FREE_IF_INACCESSIBLEMEMONLY = 0x02
 
 """
-EFFECT_FREE_GLOBALLY means that the statement is effect-free does not have a
-caller-visible effect, but may not be removed from the function itself. This
-may e.g. be used for effects that last only for the scope of the current function.
+`EFFECT_FREE_GLOBALLY` means that the statement is `:effect-free` and does not have a
+caller-visible effect, but may not be removed from the function itself. This may e.g.
+be used for effects that last only for the scope of the current function.
 """
-const EFFECT_FREE_GLOBALLY               = 0x03
+const EFFECT_FREE_GLOBALLY = 0x03
 
 # :inaccessiblememonly bits
 const INACCESSIBLEMEM_OR_ARGMEMONLY = 0x01 << 1

--- a/base/compiler/effects.jl
+++ b/base/compiler/effects.jl
@@ -131,7 +131,14 @@ const CONSISTENT_IF_NOTRETURNED         = 0x01 << 1
 const CONSISTENT_IF_INACCESSIBLEMEMONLY = 0x01 << 2
 
 # :effect_free-ness bits
-const EFFECT_FREE_IF_INACCESSIBLEMEMONLY = 0x01 << 1
+const EFFECT_FREE_IF_INACCESSIBLEMEMONLY = 0x02
+
+"""
+EFFECT_FREE_GLOBALLY means that the statement is effect-free does not have a
+caller-visible effect, but may not be removed from the function itself. This
+may e.g. be used for effects that last only for the scope of the current function.
+"""
+const EFFECT_FREE_GLOBALLY               = 0x03
 
 # :inaccessiblememonly bits
 const INACCESSIBLEMEM_OR_ARGMEMONLY = 0x01 << 1

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -817,14 +817,28 @@ end
 get_curr_ssaflag(sv::InferenceState) = sv.src.ssaflags[sv.currpc]
 get_curr_ssaflag(sv::IRInterpretationState) = sv.ir.stmts[sv.curridx][:flag]
 
+function set_curr_ssaflag!(sv::InferenceState, flag::UInt32, mask::UInt32=typemax(UInt32))
+    curr_flag = sv.src.ssaflags[sv.currpc]
+    sv.src.ssaflags[sv.currpc] = (curr_flag & ~mask) | flag
+end
+function set_curr_ssaflag!(sv::IRInterpretationState, flag::UInt32, mask::UInt32=typemax(UInt32))
+    curr_flag = sv.ir.stmts[sv.curridx][:flag]
+    sv.ir.stmts[sv.curridx][:flag] = (curr_flag & ~mask) | flag
+end
+
 add_curr_ssaflag!(sv::InferenceState, flag::UInt32) = sv.src.ssaflags[sv.currpc] |= flag
 add_curr_ssaflag!(sv::IRInterpretationState, flag::UInt32) = sv.ir.stmts[sv.curridx][:flag] |= flag
 
 sub_curr_ssaflag!(sv::InferenceState, flag::UInt32) = sv.src.ssaflags[sv.currpc] &= ~flag
 sub_curr_ssaflag!(sv::IRInterpretationState, flag::UInt32) = sv.ir.stmts[sv.curridx][:flag] &= ~flag
 
-merge_effects!(::AbstractInterpreter, caller::InferenceState, effects::Effects) =
+function merge_effects!(::AbstractInterpreter, caller::InferenceState, effects::Effects)
+    if effects.effect_free == EFFECT_FREE_GLOBALLY
+        # This tracks the global effects
+        effects = Effects(effects; effect_free = ALWAYS_TRUE)
+    end
     caller.ipo_effects = merge_effects(caller.ipo_effects, effects)
+end
 merge_effects!(::AbstractInterpreter, ::IRInterpretationState, ::Effects) = return
 
 struct InferenceLoopState

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -833,9 +833,9 @@ sub_curr_ssaflag!(sv::InferenceState, flag::UInt32) = sv.src.ssaflags[sv.currpc]
 sub_curr_ssaflag!(sv::IRInterpretationState, flag::UInt32) = sv.ir.stmts[sv.curridx][:flag] &= ~flag
 
 function merge_effects!(::AbstractInterpreter, caller::InferenceState, effects::Effects)
-    if effects.effect_free == EFFECT_FREE_GLOBALLY
+    if effects.effect_free === EFFECT_FREE_GLOBALLY
         # This tracks the global effects
-        effects = Effects(effects; effect_free = ALWAYS_TRUE)
+        effects = Effects(effects; effect_free=ALWAYS_TRUE)
     end
     caller.ipo_effects = merge_effects(caller.ipo_effects, effects)
 end

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -335,9 +335,9 @@ function stmt_effect_flags(𝕃ₒ::AbstractLattice, @nospecialize(stmt), @nospe
                 return (false, false, false)
             end
             return (false, true, true)
-        elseif head === :isdefined || head === :the_exception || head === :copyast || head === :inbounds
+        elseif head === :inbounds
             return (true, true, true)
-        elseif head === :boundscheck
+        elseif head === :boundscheck || head === :isdefined || head === :the_exception || head === :copyast
             return (false, true, true)
         else
             # e.g. :loopinfo

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -39,6 +39,8 @@ const IR_FLAG_REFINED     = UInt32(1) << 7
 # This is :noub == ALWAYS_TRUE
 const IR_FLAG_NOUB        = UInt32(1) << 8
 
+const IR_FLAGS_EFFECTS = IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW | IR_FLAG_CONSISTENT | IR_FLAG_NOUB
+
 const TOP_TUPLE = GlobalRef(Core, :tuple)
 
 # This corresponds to the type of `CodeInfo`'s `inlining_cost` field

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -953,7 +953,7 @@ end
 
 function refine_new_effects!(𝕃ₒ::AbstractLattice, compact::IncrementalCompact, idx::Int, stmt::Expr)
     inst = compact[SSAValue(idx)]
-    if !(iszero(inst[:flag] & IR_FLAG_NOTHROW) && iszero(inst[:flag] & IR_FLAG_EFFECT_FREE))
+    if (inst[:flag] & (IR_FLAG_NOTHROW | IR_FLAG_EFFECT_FREE)) == (IR_FLAG_NOTHROW | IR_FLAG_EFFECT_FREE)
         return # already accurate
     end
     (consistent, effect_free_and_nothrow, nothrow) = new_expr_effect_flags(𝕃ₒ, stmt.args, compact, pattern_match_typeof)

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -20,6 +20,7 @@ if !isdefined(@__MODULE__, Symbol("@verify_error"))
     end
 end
 
+is_toplevel_expr_head(head::Symbol) = head === :global || head === :method || head === :thunk
 is_value_pos_expr_head(head::Symbol) = head === :static_parameter
 function check_op(ir::IRCode, domtree::DomTree, @nospecialize(op), use_bb::Int, use_idx::Int, printed_use_idx::Int, print::Bool, isforeigncall::Bool, arg_idx::Int, allow_frontend_forms::Bool)
     if isa(op, SSAValue)

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -1001,6 +1001,11 @@ isassigned_effects(s) = isassigned(Ref(s))
     isassigned_effects(:foo)
 end
 
+# :isdefined effects
+@test @eval Base.infer_effects() do
+    @isdefined($(gensym("some_undef_symbol")))
+end |> !Core.Compiler.is_consistent
+
 # Effects of Base.hasfield (#50198)
 hf50198(s) = hasfield(typeof((;x=1, y=2)), s)
 f50198() = (hf50198(Ref(:x)[]); nothing)


### PR DESCRIPTION
There was two places where we were turning Effects into flags, one in the optimizer, one in inference. Unify these two both use the same function, but we need to refactor a bit to make sure all the effects get passed to the correct place.