### PR TITLE
mark return type of failed concrete eval of intrinsics as `Bottom`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -2453,11 +2453,12 @@ function builtin_tfunction(interp::AbstractInterpreter, @nospecialize(f), argtyp
             try
                 return Const(f(argvals...))
             catch
+                return Bottom
             end
         end
         iidx = Int(reinterpret(Int32, f::IntrinsicFunction)) + 1
         if iidx < 0 || iidx > length(T_IFUNC)
-            # invalid intrinsic
+            # unknown intrinsic
             return Any
         end
         tf = T_IFUNC[iidx]

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5185,3 +5185,8 @@ end
 end
 foo51090(b) = return bar51090(b)
 @test !fully_eliminated(foo51090, (Int,))
+
+# exploit throwness from concrete eval for intrinsics
+@test Base.return_types() do
+    Base.or_int(true, 1)
+end |> only === Union{}


### PR DESCRIPTION
Because of the consistency assumed by `is_pure_intrinsic_infer`, we can aggressively mark the return type as `Bottom` in a case when the concrete evaluation of an intrinsic fails.