### PR TITLE
Correct the documentation of default constructor.

### DIFF
--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -83,6 +83,9 @@ is like an outer constructor method, except for two differences:
 2. It has access to a special locally existent function called [`new`](@ref) that creates objects of the
    block's type.
 
+The semantics of `new` include implicit `convert` operations to convert each argument to the declared type
+of the corresponding field.
+
 For example, suppose one wants to declare a type that holds a pair of real numbers, subject to
 the constraint that the first number is not greater than the second one. One could declare it
 like this:
@@ -206,8 +209,6 @@ the unspecified fields uninitialized. The inner constructor method can then use 
 object, finishing its initialization before returning it. Here, for example, is another attempt
 at defining the `SelfReferential` type, this time using a zero-argument inner constructor returning instances
 having `obj` fields pointing to themselves:
-The semantics of `new` include implicit `convert` operations to convert each argument to the declared type
-of the corresponding field.
 
 ```jldoctest selfrefer2
 julia> mutable struct SelfReferential

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -122,10 +122,10 @@ If any inner constructor method is defined, no default constructor method is pro
 that you have supplied yourself with all the inner constructors you need.
 
 The default constructor is equivalent to writing one or two of your own constructor methods that take
-all of the object's fields as parameters.  One is an inner constructor method without type constraints
-on its parameters that passes the parameters to `new`, returning the resulting object.  The other
+all of the object's fields as arguments.  One is an inner constructor method without type constraints
+on its arguments that passes the them to `new`, returning the resulting object.  The other
 default constructor method is provided if there are any type constraints on the fields. This method
-is an inner constructor method if the type is not generic and similarly passes the parameters to `new`.
+is an inner constructor method if the type is not generic and similarly passes the arguments to `new`.
 However, if the type is generic, it is an outer [Parametric Constructor](@ref) method that delegates
 to the inner constructor.
 

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -121,17 +121,16 @@ some degree of enforcement of a type's invariants.
 If any inner constructor method is defined, no default constructor method is provided: it is presumed
 that you have supplied yourself with all the inner constructors you need.
 
-For non-parametric struct declarations (that is, structs without type parameters),
-the default constructor is equivalent to writing one or two of your own inner
+The default constructor is equivalent to writing one or two of your own
 constructor methods that take all of the object's fields as arguments.
-One has no type constraints on its arguments, and passes them to `new`, returning the resulting object.
-The semantics of `new` include implicit `convert` operations to convert each argument to the declared type
-of the corresponding field.
-The other default constructor method is provided only if there are any type constraints on the fields,
-and has the methods's arguments constrained to the corresponding field types.
-This method similarly passes the arguments to `new`.
+One is an inner constructor method that has the methods's arguments constrained to the corresponding field types.
+This method simply passes the arguments to `new` and returns the result.
+The other is an outer constructor method that is provided only if there are any type constraints on fields other than `Any`.
+This methods calls `convert` to convert each argument to the type of the constraint on the corresponding field, and
+calls the inner constructor to compute the returned result.
 
-If the type is parametric, see the section [Parametric Constructors](@ref) for the set of default constructors.
+If the type is parametric, see the section [Parametric Constructors](@ref) for an additional default
+constructor provided.
 
 ```jldoctest
 julia> struct Foo
@@ -152,9 +151,10 @@ julia> struct T1
 
 julia> struct T2
            x::Int64
-           T2(x) = new(x)
            T2(x::Int64) = new(x)
        end
+
+julia> T2(x) = T(convert(Int64, x)::Int64)
 
 julia> T1(1)
 T1(1)
@@ -206,6 +206,8 @@ the unspecified fields uninitialized. The inner constructor method can then use 
 object, finishing its initialization before returning it. Here, for example, is another attempt
 at defining the `SelfReferential` type, this time using a zero-argument inner constructor returning instances
 having `obj` fields pointing to themselves:
+The semantics of `new` include implicit `convert` operations to convert each argument to the declared type
+of the corresponding field.
 
 ```jldoctest selfrefer2
 julia> mutable struct SelfReferential

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -121,7 +121,7 @@ some degree of enforcement of a type's invariants.
 If any inner constructor method is defined, no default constructor method is provided: it is presumed
 that you have supplied yourself with all the inner constructors you need. The default constructor
 is equivalent to writing your own inner constructor method that takes all of the object's fields
-as parameters (constrained to be of the correct type, if the corresponding field has a type),
+as parameters (without type constraints, even if the corresponding field has a type),
 and passes them to `new`, returning the resulting object:
 
 ```jldoctest

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -119,10 +119,15 @@ existence by a call to one of the inner constructor methods provided with the ty
 some degree of enforcement of a type's invariants.
 
 If any inner constructor method is defined, no default constructor method is provided: it is presumed
-that you have supplied yourself with all the inner constructors you need. The default constructor
-is equivalent to writing your own inner constructor method that takes all of the object's fields
-as parameters (without type constraints, even if the corresponding field has a type),
-and passes them to `new`, returning the resulting object:
+that you have supplied yourself with all the inner constructors you need.
+
+The default constructor is equivalent to writing one or two of your own constructor methods that take
+all of the object's fields as parameters.  One is an inner constructor method without type constraints
+on its parameters that passes the parameters to `new`, returning the resulting object.  The other
+default constructor method is provided if there are any type constraints on the fields. This method
+is an inner constructor method if the type is not generic and similarly passes the parameters to `new`.
+However, if the type is generic, it is an outer [Parametric Constructor](@ref) method that delegates
+to the inner constructor.
 
 ```jldoctest
 julia> struct Foo
@@ -130,12 +135,11 @@ julia> struct Foo
            baz
            Foo(bar,baz) = new(bar,baz)
        end
-
 ```
 
 This declaration has the same effect as the earlier definition of the `Foo` type without an explicit
 inner constructor method. The following two types are equivalent -- one with a default constructor,
-the other with an explicit constructor:
+the other with explicit constructors:
 
 ```jldoctest
 julia> struct T1
@@ -145,6 +149,7 @@ julia> struct T1
 julia> struct T2
            x::Int64
            T2(x) = new(x)
+           T2(x::Int64) = new(x)
        end
 
 julia> T1(1)


### PR DESCRIPTION
The examples in the documentation, and experimenting with the actual behavior, demonstrate that the documentation needs this correction.  Here is a simple demo that shows that the old documented behavior is not right.

```julia
struct S1
    x::Int
end
S1(2.0) # OK

struct S2
    x::Int
    S2(x::Int) = new(x)
end
S2(2.0) # error!
```

The behavior appears to be as if the default constructor has two methods, not one as currently documented.