### PR TITLE
add discussion of named positional arguments

### DIFF
--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -791,7 +791,7 @@ julia> date(2000)
 ```
 
 Optional arguments are actually just a convenient syntax for writing multiple method definitions
-with different numbers of arguments (see [Note on Optional and keyword Arguments](@ref)).
+with different numbers of arguments (see [Note on Optional and Keyword Arguments](@ref)).
 This can be checked for our `date` function example by calling the `methods` function:
 
 ```julia-repl

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -907,7 +907,7 @@ would be called only when the number of `indices` matches the dimensionality of 
 When only the type of supplied arguments needs to be constrained `Vararg{T}` can be equivalently
 written as `T...`. For instance `f(x::Int...) = x` is a shorthand for `f(x::Vararg{Int}) = x`.
 
-## Note on Optional and keyword Arguments
+## Note on Optional and Keyword Arguments
 
 As mentioned briefly in [Functions](@ref man-functions), optional arguments are implemented as syntax for multiple
 method definitions. For example, this definition:

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -447,3 +447,43 @@ julia> h(1)
 
 Thus, use `Int` literals when possible, with `Rational{Int}` for literal non-integer numbers,
 in order to make it easier to use your code.
+
+## Workarounds for named positional arguments
+Named positional arguments are not supported in Julia, however, some users may still wish to use a named positional arguments code-style.
+There are several workarounds that can provide an experience similar to named positionals.
+Consider the `mod` method, which a user might call with the ambiguous variables `a` and `b` in the positional arguments:
+```julia
+a = 5; b = 2
+mod( a, b )
+```
+
+One approach is to use inline comment blocks when calling the method:
+```julia
+mod( #=x=# a, #=y=# b )
+```
+
+or with end-of-line comments
+
+```julia
+mod( a, # x
+     b, # y
+    )
+```
+
+Furthermore the use of comments permit more descriptive names while not interfering with Julia's multiple dispatch on positional arguments:
+
+```julia
+mod( #=Dividend=# a, #=Divisor=# b )
+mod( a, # Dividend
+     b, # Divisor
+    )
+```
+
+A final option is to define your own wrapper for the method using keyword arguments:
+```julia
+import Base.mod
+function mod(; dividend, divisor )
+    return mod( dividend, divisor )
+end
+mod( dividend = a, divisor = b )
+```

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -471,7 +471,7 @@ mod( a, # x
     )
 ```
 
-Furthermore the use of comments permit more descriptive names while not interfering with Julia's multiple dispatch on positional arguments:
+Furthermore the use of comments permit you to insert hints describing a positional argument, while not interfering with Julia's multiple dispatch on positional arguments:
 
 ```julia
 mod( #=Dividend=# a, #=Divisor=# b )

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -450,7 +450,8 @@ in order to make it easier to use your code.
 
 ## Options for referencing positional arguments by name
 Named positional arguments are not supported in Julia, however, some users may still wish to use a named positional arguments code-style supported by some languages.
-An example of a function, in a different language, supporting named positional arguments and keyword arguments is `f(x,y;z)`, which could then be called by either `f(a,b,z=c)` or with `f(x=a,b=y,z=c)`.  There are several workarounds that can provide an experience similar to named positionals.
+An example of a function, in a different language, supporting named positional arguments and keyword arguments is `f(x,y;z)`, which could then be called by either `f(a,b,z=c)` or with `f(x=a,b=y,z=c)`.  
+There are several workarounds that can provide an experience similar to named positionals.
 Consider the `mod` method, which a user might call with the variables `a` and `b` in the positional arguments:
 
 ```julia
@@ -487,29 +488,4 @@ function mod(; dividend, divisor )
     return mod( dividend, divisor )
 end
 mod( dividend = a, divisor = b )
-```
-
-A final option is to (re-)assign variable names that are clear within the context of your code.
-For example, instead of
-
-```julia
-a, b, c = get_unit_sale_data()
-d = mod( a, c )
-```
-
-do
-
-```julia
-units_sold, price_per_unit, units_per_package = get_unit_sale_data()
-leftover_units = mod( units_sold, units_per_package )
-```
-
-or
-
-```julia
-a, b, c = get_unit_sale_data()
-units_sold = a
-price_per_unit = b
-units_per_package = c
-leftover_units = mod( units_sold, units_per_package )
 ```

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -448,10 +448,11 @@ julia> h(1)
 Thus, use `Int` literals when possible, with `Rational{Int}` for literal non-integer numbers,
 in order to make it easier to use your code.
 
-## Workarounds for named positional arguments
-Named positional arguments are not supported in Julia, however, some users may still wish to use a named positional arguments code-style.
-There are several workarounds that can provide an experience similar to named positionals.
-Consider the `mod` method, which a user might call with the ambiguous variables `a` and `b` in the positional arguments:
+## Options for referencing positional arguments by name
+Named positional arguments are not supported in Julia, however, some users may still wish to use a named positional arguments code-style supported by some languages.
+An example of a function, in a different language, supporting named positional arguments and keyword arguments is `f(x,y;z)`, which could then be called by either `f(a,b,z=c)` or with `f(x=a,b=y,z=c)`.  There are several workarounds that can provide an experience similar to named positionals.
+Consider the `mod` method, which a user might call with the variables `a` and `b` in the positional arguments:
+
 ```julia
 a = 5; b = 2
 mod( a, b )

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -480,11 +480,36 @@ mod( a, # Dividend
     )
 ```
 
-A final option is to define your own wrapper for the method using keyword arguments:
+Another option is to define your own wrapper for the method using keyword arguments:
 ```julia
 import Base.mod
 function mod(; dividend, divisor )
     return mod( dividend, divisor )
 end
 mod( dividend = a, divisor = b )
+```
+
+A final option is to (re-)assign variable names that are clear within the context of your code.
+For example, instead of
+
+```julia
+a, b, c = get_unit_sale_data()
+d = mod( a, c )
+```
+
+do
+
+```julia
+units_sold, price_per_unit, units_per_package = get_unit_sale_data()
+leftover_units = mod( units_sold, units_per_package )
+```
+
+or
+
+```julia
+a, b, c = get_unit_sale_data()
+units_sold = a
+price_per_unit = b
+units_per_package = c
+leftover_units = mod( units_sold, units_per_package )
 ```


### PR DESCRIPTION
Added a short discussion of named positional arguments to the documentation.  The discussion is the result of [this Discourse thread](https://discourse.julialang.org/t/naming-positional-arguments-at-call-site/103526).  

I've added this to the [Methods](https://docs.julialang.org/en/v1/manual/methods/) documentation section, as I think its relevant given the immediately prior subsection [Note-on-Optional-and-keyword-Arguments](https://docs.julialang.org/en/v1/manual/methods/#Note-on-Optional-and-keyword-Arguments).  But I am open to putting it in a different section (FAQ?) if preferable.