### PR TITLE
Add warn about usage of applicable and hasmethod

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1882,6 +1882,14 @@ Determine whether the given generic function has a method applicable to the give
 
 See also [`hasmethod`](@ref).
 
+!!! warning
+    It is not guaranteed that the function `f` will provide the expected return
+    or will not throw exceptions if `applicable` returns `true`. For example,
+    one function can define a general method like `f(x::Any) = error("Type not
+    supported")` to catch unsupported types. In this case, `applicable` can
+    return `true`, but an error will be thrown when calling `f` with the
+    selected arguments.
+
 # Examples
 ```jldoctest
 julia> function f(x, y)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1902,6 +1902,14 @@ the provided names must be a subset of the method's keyword arguments.
 
 See also [`applicable`](@ref).
 
+!!! warning
+    It is not guaranteed that the function `f` will provide the expected return
+    or will not throw exceptions if `hasmethod` returns `true`. For example,
+    one function can define a general method like `f(x::Any) = error("Type not
+    supported")` to catch unsupported types. In this case, `hasmethod` can
+    return `true`, but an error will be thrown when calling `f` with the
+    selected arguments.
+
 !!! compat "Julia 1.2"
     Providing keyword argument names requires Julia 1.2 or later.
 


### PR DESCRIPTION
This commit adds a warning about the functions `applicable` and `hasmethod`. A user reading the current documentation can think that if those functions return `true`, we can call the method without errors. However, it is not always the case and should be clearly stated.

Closes #51258