### PR TITLE
make "dec" and ryu functions faster and simpler

### DIFF
--- a/base/ryu/exp.jl
+++ b/base/ryu/exp.jl
@@ -8,33 +8,33 @@ function writeexp(buf, pos, v::T,
 
     # special cases
     if x == 0
-        buf[pos] = UInt8('0')
+        @inbounds buf[pos] = UInt8('0')
         pos += 1
         if precision > 0 && !trimtrailingzeros
-            buf[pos] = decchar
+            @inbounds buf[pos] = decchar
             pos += 1
             for _ = 1:precision
-                buf[pos] = UInt8('0')
+                @inbounds buf[pos] = UInt8('0')
                 pos += 1
             end
         elseif hash
-            buf[pos] = decchar
+            @inbounds buf[pos] = decchar
             pos += 1
         end
-        buf[pos] = expchar
-        buf[pos + 1] = UInt8('+')
-        buf[pos + 2] = UInt8('0')
-        buf[pos + 3] = UInt8('0')
+        @inbounds buf[pos] = expchar
+        @inbounds buf[pos + 1] = UInt8('+')
+        @inbounds buf[pos + 2] = UInt8('0')
+        @inbounds buf[pos + 3] = UInt8('0')
         return pos + 4
     elseif isnan(x)
-        buf[pos] = UInt8('N')
-        buf[pos + 1] = UInt8('a')
-        buf[pos + 2] = UInt8('N')
+        @inbounds buf[pos] = UInt8('N')
+        @inbounds buf[pos + 1] = UInt8('a')
+        @inbounds buf[pos + 2] = UInt8('N')
         return pos + 3
     elseif !isfinite(x)
-        buf[pos] = UInt8('I')
-        buf[pos + 1] = UInt8('n')
-        buf[pos + 2] = UInt8('f')
+        @inbounds buf[pos] = UInt8('I')
+        @inbounds buf[pos + 1] = UInt8('n')
+        @inbounds buf[pos + 2] = UInt8('f')
         return pos + 3
     end
 
@@ -80,10 +80,10 @@ function writeexp(buf, pos, v::T,
                 if precision > 1
                     pos = append_d_digits(availableDigits, digits, buf, pos, decchar)
                 else
-                    buf[pos] = UInt8('0') + digits
+                    @inbounds buf[pos] = UInt8('0') + digits
                     pos += 1
                     if hash
-                        buf[pos] = decchar
+                        @inbounds buf[pos] = decchar
                         pos += 1
                     end
                 end
@@ -121,10 +121,10 @@ function writeexp(buf, pos, v::T,
                 if precision > 1
                     pos = append_d_digits(availableDigits, digits, buf, pos, decchar)
                 else
-                    buf[pos] = UInt8('0') + digits
+                    @inbounds buf[pos] = UInt8('0') + digits
                     pos += 1
                     if hash
-                        buf[pos] = decchar
+                        @inbounds buf[pos] = decchar
                         pos += 1
                     end
                 end
@@ -162,7 +162,7 @@ function writeexp(buf, pos, v::T,
     if printedDigits != 0
         if digits == 0
             for _ = 1:maximum
-                buf[pos] = UInt8('0')
+                @inbounds buf[pos] = UInt8('0')
                 pos += 1
             end
         else
@@ -172,10 +172,10 @@ function writeexp(buf, pos, v::T,
         if precision > 1
             pos = append_d_digits(maximum, digits, buf, pos, decchar)
         else
-            buf[pos] = UInt8('0') + digits
+            @inbounds buf[pos] = UInt8('0') + digits
             pos += 1
             if hash
-                buf[pos] = decchar
+                @inbounds buf[pos] = decchar
                 pos += 1
             end
         end
@@ -184,52 +184,56 @@ function writeexp(buf, pos, v::T,
         roundPos = pos
         while true
             roundPos -= 1
-            if roundPos == (startpos - 1) || buf[roundPos] == UInt8('-') || (plus && buf[roundPos] == UInt8('+')) || (space && buf[roundPos] == UInt8(' '))
-                buf[roundPos + 1] = UInt8('1')
+            if roundPos == (startpos - 1) || (@inbounds buf[roundPos]) == UInt8('-') || (plus && (@inbounds buf[roundPos]) == UInt8('+')) || (space && (@inbounds buf[roundPos]) == UInt8(' '))
+                @inbounds buf[roundPos + 1] = UInt8('1')
                 e += 1
                 break
             end
-            c = roundPos > 0 ? buf[roundPos] : 0x00
+            c = roundPos > 0 ? (@inbounds buf[roundPos]) : 0x00
             if c == decchar
                 continue
             elseif c == UInt8('9')
-                buf[roundPos] = UInt8('0')
+                @inbounds buf[roundPos] = UInt8('0')
                 roundUp = 1
                 continue
             else
                 if roundUp == 2 && UInt8(c) % 2 == 0
                     break
                 end
-                buf[roundPos] = c + 1
+                @inbounds buf[roundPos] = c + 1
                 break
             end
         end
     end
     if trimtrailingzeros
-        while buf[pos - 1] == UInt8('0')
+        while @inbounds buf[pos - 1] == UInt8('0')
             pos -= 1
         end
-        if buf[pos - 1] == decchar && !hash
+        if @inbounds buf[pos - 1] == decchar && !hash
             pos -= 1
         end
     end
     buf[pos] = expchar
     pos += 1
     if e < 0
-        buf[pos] = UInt8('-')
+        @inbounds buf[pos] = UInt8('-')
         pos += 1
         e = -e
     else
-        buf[pos] = UInt8('+')
+        @inbounds buf[pos] = UInt8('+')
         pos += 1
     end
     if e >= 100
         c = e % 10
-        unsafe_copyto!(buf, pos, DIGIT_TABLE, 2 * div(e, 10) + 1, 2)
-        buf[pos + 2] = UInt8('0') + c
+        @inbounds d100 = DIGIT_TABLE16[div(e, 10) + 1]
+        @inbounds buf[pos] = d100 % UInt8
+        @inbounds buf[pos + 1] = (d100 >> 0x8) % UInt8
+        @inbounds buf[pos + 2] = UInt8('0') + c
         pos += 3
     else
-        unsafe_copyto!(buf, pos, DIGIT_TABLE, 2 * e + 1, 2)
+        @inbounds d100 = DIGIT_TABLE16[e + 1]
+        @inbounds buf[pos] = d100 % UInt8
+        @inbounds buf[pos + 1] = (d100 >> 0x8) % UInt8
         pos += 2
     end
     return pos

--- a/base/ryu/fixed.jl
+++ b/base/ryu/fixed.jl
@@ -59,7 +59,7 @@ function writefixed(buf, pos, v::T,
                 pos = append_nine_digits(digits, buf, pos)
             elseif digits != 0
                 olength = decimallength(digits)
-                pos = append_n_digits(olength, digits, buf, pos)
+                pos = append_c_digits(olength, digits, buf, pos)
                 nonzero = true
             end
             i -= 1

--- a/base/ryu/shortest.jl
+++ b/base/ryu/shortest.jl
@@ -232,79 +232,79 @@ function writeshortest(buf::Vector{UInt8}, pos, x::T,
     # special cases
     if x == 0
         if typed && x isa Float16
-            buf[pos] = UInt8('F')
-            buf[pos + 1] = UInt8('l')
-            buf[pos + 2] = UInt8('o')
-            buf[pos + 3] = UInt8('a')
-            buf[pos + 4] = UInt8('t')
-            buf[pos + 5] = UInt8('1')
-            buf[pos + 6] = UInt8('6')
-            buf[pos + 7] = UInt8('(')
+            @inbounds buf[pos] = UInt8('F')
+            @inbounds buf[pos + 1] = UInt8('l')
+            @inbounds buf[pos + 2] = UInt8('o')
+            @inbounds buf[pos + 3] = UInt8('a')
+            @inbounds buf[pos + 4] = UInt8('t')
+            @inbounds buf[pos + 5] = UInt8('1')
+            @inbounds buf[pos + 6] = UInt8('6')
+            @inbounds buf[pos + 7] = UInt8('(')
             pos += 8
         end
         pos = append_sign(x, plus, space, buf, pos)
-        buf[pos] = UInt8('0')
+        @inbounds buf[pos] = UInt8('0')
         pos += 1
         if hash
-            buf[pos] = decchar
+            @inbounds buf[pos] = decchar
             pos += 1
         end
         if precision == -1
-            buf[pos] = UInt8('0')
+            @inbounds buf[pos] = UInt8('0')
             pos += 1
             if typed && x isa Float32
-                buf[pos] = UInt8('f')
-                buf[pos + 1] = UInt8('0')
+                @inbounds buf[pos] = UInt8('f')
+                @inbounds buf[pos + 1] = UInt8('0')
                 pos += 2
             end
             if typed && x isa Float16
-                buf[pos] = UInt8(')')
+                @inbounds buf[pos] = UInt8(')')
                 pos += 1
             end
             return pos
         end
         while hash && precision > 1
-            buf[pos] = UInt8('0')
+            @inbounds buf[pos] = UInt8('0')
             pos += 1
             precision -= 1
         end
         if typed && x isa Float32
-            buf[pos] = UInt8('f')
-            buf[pos + 1] = UInt8('0')
+            @inbounds buf[pos] = UInt8('f')
+            @inbounds buf[pos + 1] = UInt8('0')
             pos += 2
         end
         if typed && x isa Float16
-            buf[pos] = UInt8(')')
+            @inbounds buf[pos] = UInt8(')')
             pos += 1
         end
         return pos
     elseif isnan(x)
         pos = append_sign(x, plus, space, buf, pos)
-        buf[pos] = UInt8('N')
-        buf[pos + 1] = UInt8('a')
-        buf[pos + 2] = UInt8('N')
+        @inbounds buf[pos] = UInt8('N')
+        @inbounds buf[pos + 1] = UInt8('a')
+        @inbounds buf[pos + 2] = UInt8('N')
         if typed
             if x isa Float32
-                buf[pos + 3] = UInt8('3')
-                buf[pos + 4] = UInt8('2')
+                @inbounds buf[pos + 3] = UInt8('3')
+                @inbounds buf[pos + 4] = UInt8('2')
             elseif x isa Float16
-                buf[pos + 3] = UInt8('1')
-                buf[pos + 4] = UInt8('6')
+                @inbounds buf[pos + 3] = UInt8('1')
+                @inbounds buf[pos + 4] = UInt8('6')
             end
         end
         return pos + 3 + (typed && x isa Union{Float32, Float16} ? 2 : 0)
     elseif !isfinite(x)
         pos = append_sign(x, plus, space, buf, pos)
-        buf[pos] = UInt8('I')
-        buf[pos + 1] = UInt8('n')
-        buf[pos + 2] = UInt8('f')
+        @inbounds buf[pos] = UInt8('I')
+        @inbounds buf[pos + 1] = UInt8('n')
+        @inbounds buf[pos + 2] = UInt8('f')
         if typed
             if x isa Float32
-                buf[pos + 3] = UInt8('3')
-                buf[pos + 4] = UInt8('2')
+                @inbounds buf[pos + 3] = UInt8('3')
+                @inbounds buf[pos + 4] = UInt8('2')
             elseif x isa Float16
-                buf[pos + 3] = UInt8('1')
-                buf[pos + 4] = UInt8('6')
+                @inbounds buf[pos + 3] = UInt8('1')
+                @inbounds buf[pos + 4] = UInt8('6')
             end
         end
         return pos + 3 + (typed && x isa Union{Float32, Float16} ? 2 : 0)
@@ -313,14 +313,14 @@ function writeshortest(buf::Vector{UInt8}, pos, x::T,
     output, nexp = reduce_shortest(x, compact ? 999_999 : nothing)
 
     if typed && x isa Float16
-        buf[pos] = UInt8('F')
-        buf[pos + 1] = UInt8('l')
-        buf[pos + 2] = UInt8('o')
-        buf[pos + 3] = UInt8('a')
-        buf[pos + 4] = UInt8('t')
-        buf[pos + 5] = UInt8('1')
-        buf[pos + 6] = UInt8('6')
-        buf[pos + 7] = UInt8('(')
+        @inbounds buf[pos] = UInt8('F')
+        @inbounds buf[pos + 1] = UInt8('l')
+        @inbounds buf[pos + 2] = UInt8('o')
+        @inbounds buf[pos + 3] = UInt8('a')
+        @inbounds buf[pos + 4] = UInt8('t')
+        @inbounds buf[pos + 5] = UInt8('1')
+        @inbounds buf[pos + 6] = UInt8('6')
+        @inbounds buf[pos + 7] = UInt8('(')
         pos += 8
     end
     pos = append_sign(x, plus, space, buf, pos)
@@ -332,161 +332,122 @@ function writeshortest(buf::Vector{UInt8}, pos, x::T,
         !(pt >= olength && abs(mod(x + 0.05, 10^(pt - olength)) - 0.05) > 0.05)
         exp_form = false
         if pt <= 0
-            buf[pos] = UInt8('0')
+            @inbounds buf[pos] = UInt8('0')
             pos += 1
-            buf[pos] = decchar
+            @inbounds buf[pos] = decchar
             pos += 1
             for _ = 1:abs(pt)
-                buf[pos] = UInt8('0')
+                @inbounds buf[pos] = UInt8('0')
                 pos += 1
             end
-            # elseif pt >= olength
+        # elseif pt >= olength
             # nothing to do at this point
-            # else
+        # else
             # nothing to do at this point
         end
     else
+        # make space for decchar
         pos += 1
     end
-    i = 0
-    ptr = pointer(buf)
-    ptr2 = pointer(DIGIT_TABLE)
-    if (output >> 32) != 0
-        q = output ÷ 100000000
-        output2 = (output % UInt32) - UInt32(100000000) * (q % UInt32)
-        output = q
 
-        c = output2 % UInt32(10000)
-        output2 = div(output2, UInt32(10000))
-        d = output2 % UInt32(10000)
-        c0 = (c % 100) << 1
-        c1 = (c ÷ 100) << 1
-        d0 = (d % 100) << 1
-        d1 = (d ÷ 100) << 1
-        memcpy(ptr + pos + olength - 3, ptr2 + c0, 2)
-        memcpy(ptr + pos + olength - 5, ptr2 + c1, 2)
-        memcpy(ptr + pos + olength - 7, ptr2 + d0, 2)
-        memcpy(ptr + pos + olength - 9, ptr2 + d1, 2)
-        i += 8
-    end
-    output2 = output % UInt32
-    while output2 >= 10000
-        c = output2 % UInt32(10000)
-        output2 = div(output2, UInt32(10000))
-        c0 = (c % 100) << 1
-        c1 = (c ÷ 100) << 1
-        memcpy(ptr + pos + olength - i - 3, ptr2 + c0, 2)
-        memcpy(ptr + pos + olength - i - 5, ptr2 + c1, 2)
-        i += 4
-    end
-    if output2 >= 100
-        c = (output2 % UInt32(100)) << 1
-        output2 = div(output2, UInt32(100))
-        memcpy(ptr + pos + olength - i - 3, ptr2 + c, 2)
-        i += 2
-    end
-    if output2 >= 10
-        c = output2 << 1
-        buf[pos + 1] = DIGIT_TABLE[c + 2]
-        buf[pos - exp_form] = DIGIT_TABLE[c + 1]
-    else
-        buf[pos - exp_form] = UInt8('0') + (output2 % UInt8)
-    end
+    append_c_digits(olength, output, buf, pos)
 
     if !exp_form
         if pt <= 0
             pos += olength
             precision -= olength
-            while hash && precision > 0
-                buf[pos] = UInt8('0')
-                pos += 1
-                precision -= 1
-            end
         elseif pt >= olength
             pos += olength
             precision -= olength
             for _ = 1:nexp
-                buf[pos] = UInt8('0')
+                @inbounds buf[pos] = UInt8('0')
                 pos += 1
                 precision -= 1
             end
             if hash
-                buf[pos] = decchar
+                @inbounds buf[pos] = decchar
                 pos += 1
                 if precision < 0
-                    buf[pos] = UInt8('0')
+                    @inbounds buf[pos] = UInt8('0')
                     pos += 1
-                end
-                while precision > 0
-                    buf[pos] = UInt8('0')
-                    pos += 1
-                    precision -= 1
                 end
             end
         else
             pointoff = olength - abs(nexp)
+            # shift bytes after pointoff to make room for decchar
+            ptr = pointer(buf)
             memmove(ptr + pos + pointoff, ptr + pos + pointoff - 1, olength - pointoff + 1)
-            buf[pos + pointoff] = decchar
+            @inbounds buf[pos + pointoff] = decchar
             pos += olength + 1
             precision -= olength
-            while hash && precision > 0
-                buf[pos] = UInt8('0')
+        end
+        if hash
+            while precision > 0
+                @inbounds buf[pos] = UInt8('0')
                 pos += 1
                 precision -= 1
             end
         end
         if typed && x isa Float32
-            buf[pos] = UInt8('f')
-            buf[pos + 1] = UInt8('0')
+            @inbounds buf[pos] = UInt8('f')
+            @inbounds buf[pos + 1] = UInt8('0')
             pos += 2
         end
     else
+        # move leading digit into place
+        @inbounds buf[pos - 1] = buf[pos]
         if olength > 1 || hash
-            buf[pos] = decchar
+            @inbounds buf[pos] = decchar
             pos += olength
             precision -= olength
         end
-        if hash && olength == 1
-            buf[pos] = UInt8('0')
-            pos += 1
-        end
-        while hash && precision > 0
-            buf[pos] = UInt8('0')
-            pos += 1
-            precision -= 1
+        if hash
+            if olength == 1
+                @inbounds buf[pos] = UInt8('0')
+                pos += 1
+            end
+            while precision > 0
+                @inbounds buf[pos] = UInt8('0')
+                pos += 1
+                precision -= 1
+            end
         end
 
-        buf[pos] = expchar
+        @inbounds buf[pos] = expchar
         pos += 1
         exp2 = nexp + olength - 1
         if exp2 < 0
-            buf[pos] = UInt8('-')
+            @inbounds buf[pos] = UInt8('-')
             pos += 1
             exp2 = -exp2
         elseif padexp
-            buf[pos] = UInt8('+')
+            @inbounds buf[pos] = UInt8('+')
             pos += 1
         end
 
         if exp2 >= 100
             c = exp2 % 10
-            memcpy(ptr + pos - 1, ptr2 + 2 * div(exp2, 10), 2)
-            buf[pos + 2] = UInt8('0') + (c % UInt8)
+            @inbounds d100 = DIGIT_TABLE16[(div(exp2, 10) % Int) + 1]
+            @inbounds buf[pos] = d100 % UInt8
+            @inbounds buf[pos + 1] = (d100 >> 0x8) % UInt8
+            @inbounds buf[pos + 2] = UInt8('0') + (c % UInt8)
             pos += 3
         elseif exp2 >= 10
-            memcpy(ptr + pos - 1, ptr2 + 2 * exp2, 2)
+            @inbounds d100 = DIGIT_TABLE16[(exp2 % Int) + 1]
+            @inbounds buf[pos] = d100 % UInt8
+            @inbounds buf[pos + 1] = (d100 >> 0x8) % UInt8
             pos += 2
         else
             if padexp
-                buf[pos] = UInt8('0')
+                @inbounds buf[pos] = UInt8('0')
                 pos += 1
             end
-            buf[pos] = UInt8('0') + (exp2 % UInt8)
+            @inbounds buf[pos] = UInt8('0') + (exp2 % UInt8)
             pos += 1
         end
     end
     if typed && x isa Float16
-        buf[pos] = UInt8(')')
+        @inbounds buf[pos] = UInt8(')')
         pos += 1
     end
 


### PR DESCRIPTION
We had some common code in `Ryu.append_c_digits` that can be combined with Base logic for the same thing. But it turns out all of this duplicated code in Ryu seems to just make it run slightly slower in most cases. The old version had many more branches to check, even though often numbers are small, so only the last check is meaningful. But the assumption that it would be faster even if all of them were used also seems to not hold up in practice. Particularly for a function like `append_nine_digits` which unrolls completely, but the complicated version has slightly more data dependencies because of they way it is written.

Similarly, we replace `unsafe_copy` with `@inbounds[]`, since this is better for the optimizer, which doesn't need to treat this operation as an unknown reference escape.

Lastly, we use the append_nine_digits trick from Ryu to make printing of arbitrary big numbers much faster.

```
julia> @btime string(typemax(Int128))
  402.345 ns (2 allocations: 120 bytes) # before
  151.139 ns (2 allocations: 120 bytes) # after
```

@nanosoldier `runbenchmarks("io" || "misc" || "problem" || "micro" || "shootout", vs=":master")`