### PR TITLE
refactor post-opt analysis and get rid of closures

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -504,7 +504,7 @@ struct AugmentedDomtree
 end
 
 mutable struct LazyAugmentedDomtree
-    ir::IRCode
+    const ir::IRCode
     agdomtree::AugmentedDomtree
     LazyAugmentedDomtree(ir::IRCode) = new(ir)
 end
@@ -527,29 +527,46 @@ end
 
 # TODO refine `:effect_free` using EscapeAnalysis
 mutable struct PostOptAnalysisState
+    const result::InferenceResult
+    const ir::IRCode
+    const inconsistent::BitSetBoundedMinPrioritySet
+    const tpdum::TwoPhaseDefUseMap
+    const lazypostdomtree::LazyPostDomtree
+    const lazyagdomtree::LazyAugmentedDomtree
     all_retpaths_consistent::Bool
     all_effect_free::Bool
     all_nothrow::Bool
     all_noub::Bool
     any_conditional_ub::Bool
-    PostOptAnalysisState() = new(true, true, true, true, false)
+    function PostOptAnalysisState(result::InferenceResult, ir::IRCode)
+        inconsistent = BitSetBoundedMinPrioritySet(length(ir.stmts))
+        tpdum = TwoPhaseDefUseMap(length(ir.stmts))
+        lazypostdomtree = LazyPostDomtree(ir)
+        lazyagdomtree = LazyAugmentedDomtree(ir)
+        return new(result, ir, inconsistent, tpdum, lazypostdomtree, lazyagdomtree, true, true, true, true, false)
+    end
 end
+
 give_up_refinements!(sv::PostOptAnalysisState) =
     sv.all_retpaths_consistent = sv.all_effect_free = sv.all_nothrow = sv.all_noub = false
-function any_refinable(sv::PostOptAnalysisState, effects::Effects)
+
+function any_refinable(sv::PostOptAnalysisState)
+    effects = sv.result.ipo_effects
     return ((!is_consistent(effects) & sv.all_retpaths_consistent) |
             (!is_effect_free(effects) & sv.all_effect_free) |
             (!is_nothrow(effects) & sv.all_nothrow) |
             (!is_noub(effects) & sv.all_noub))
 end
 
-function refine_effects!(result::InferenceResult, sv::PostOptAnalysisState)
-    effects = result.ipo_effects
-    return result.ipo_effects = Effects(effects;
-        consistent = sv.all_retpaths_consistent ? ALWAYS_TRUE : effects.consistent,
-        effect_free = sv.all_effect_free ? ALWAYS_TRUE : effects.effect_free,
-        nothrow = sv.all_nothrow ? true : effects.nothrow,
-        noub = sv.all_noub ? (sv.any_conditional_ub ? NOUB_IF_NOINBOUNDS : ALWAYS_TRUE) : effects.noub)
+function refine_effects!(sv::PostOptAnalysisState)
+    any_refinable(sv) || return false
+        effects = sv.result.ipo_effects
+        sv.result.ipo_effects = Effects(effects;
+            consistent = sv.all_retpaths_consistent ? ALWAYS_TRUE : effects.consistent,
+            effect_free = sv.all_effect_free ? ALWAYS_TRUE : effects.effect_free,
+            nothrow = sv.all_nothrow ? true : effects.nothrow,
+            noub = sv.all_noub ? (sv.any_conditional_ub ? NOUB_IF_NOINBOUNDS : ALWAYS_TRUE) : effects.noub)
+    return true
 end
 
 function is_ipo_dataflow_analysis_profitable(effects::Effects)
@@ -557,198 +574,201 @@ function is_ipo_dataflow_analysis_profitable(effects::Effects)
              is_nothrow(effects) && is_noub(effects))
 end
 
-function ipo_dataflow_analysis!(interp::AbstractInterpreter, ir::IRCode, result::InferenceResult)
-    if !is_ipo_dataflow_analysis_profitable(result.ipo_effects)
-        return result.ipo_effects
+function is_getfield_with_boundscheck_arg(@nospecialize(stmt), sv::PostOptAnalysisState)
+    is_known_call(stmt, getfield, sv.ir) || return false
+    length(stmt.args) < 4 && return false
+    boundscheck = stmt.args[end]
+    argextype(boundscheck, sv.ir) === Bool || return false
+    isa(boundscheck, SSAValue) || return false
+    return true
+end
+
+function is_conditional_noub(inst::Instruction, sv::PostOptAnalysisState)
+    # Special case: `:boundscheck` into `getfield`
+    stmt = inst[:stmt]
+    is_getfield_with_boundscheck_arg(stmt, sv) || return false
+    barg = stmt.args[end]
+    bstmt = sv.ir[barg][:stmt]
+    isexpr(bstmt, :boundscheck) || return false
+    # If IR_FLAG_INBOUNDS is already set, no more conditional ub
+    (!isempty(bstmt.args) && bstmt.args[1] === false) && return false
+    sv.any_conditional_ub = true
+    return true
+end
+
+function scan_non_dataflow_flags!(inst::Instruction, sv::PostOptAnalysisState)
+    flag = inst[:flag]
+    stmt = inst[:stmt]
+    if !isterminator(stmt) && stmt !== nothing
+        # ignore control flow node – they are not removable on their own and thus not
+        # have `IR_FLAG_EFFECT_FREE` but still do not taint `:effect_free`-ness of
+        # the whole method invocation
+        sv.all_effect_free &= !iszero(flag & IR_FLAG_EFFECT_FREE)
     end
-
-    inconsistent = BitSetBoundedMinPrioritySet(length(ir.stmts))
-    tpdum = TwoPhaseDefUseMap(length(ir.stmts))
-    lazypostdomtree = LazyPostDomtree(ir)
-    lazyagdomtree = LazyAugmentedDomtree(ir)
-
-    sv = PostOptAnalysisState()
-
-    scanner = BBScanner(ir)
-
-    function is_getfield_with_boundscheck_arg(@nospecialize stmt)
-        is_known_call(stmt, getfield, ir) || return false
-        length(stmt.args) < 4 && return false
-        boundscheck = stmt.args[end]
-        argextype(boundscheck, ir) === Bool || return false
-        isa(boundscheck, SSAValue) || return false
-        return true
-    end
-
-    function is_conditional_noub(inst::Instruction)
-        # Special case: `:boundscheck` into `getfield`
-        stmt = inst[:stmt]
-        is_getfield_with_boundscheck_arg(stmt) || return false
-        barg = stmt.args[end]
-        bstmt = ir[barg][:stmt]
-        isexpr(bstmt, :boundscheck) || return false
-        # If IR_FLAG_INBOUNDS is already set, no more conditional ub
-        (!isempty(bstmt.args) && bstmt.args[1] === false) && return false
-        sv.any_conditional_ub = true
-        return true
-    end
-
-    function scan_non_dataflow_flags!(inst::Instruction)
-        flag = inst[:flag]
-        istmt = inst[:stmt]
-        if !isterminator(istmt) && istmt !== nothing
-            # ignore control flow node – they are not removable on their own and thus not
-            # have `IR_FLAG_EFFECT_FREE` but still do not taint `:effect_free`-ness of
-            # the whole method invocation
-            sv.all_effect_free &= !iszero(flag & IR_FLAG_EFFECT_FREE)
+    sv.all_nothrow &= !iszero(flag & IR_FLAG_NOTHROW)
+    if iszero(flag & IR_FLAG_NOUB)
+        if !is_conditional_noub(inst, sv)
+            sv.all_noub = false
         end
-        sv.all_nothrow &= !iszero(flag & IR_FLAG_NOTHROW)
-        if iszero(flag & IR_FLAG_NOUB)
-            if !is_conditional_noub(inst)
-                sv.all_noub = false
+    end
+end
+
+function scan_inconsistency!(inst::Instruction, idx::Int, sv::PostOptAnalysisState)
+    flag = inst[:flag]
+    stmt_inconsistent = iszero(flag & IR_FLAG_CONSISTENT)
+    stmt = inst[:stmt]
+    # Special case: For getfield, we allow inconsistency of the :boundscheck argument
+    (; inconsistent, tpdum) = sv
+    if is_getfield_with_boundscheck_arg(stmt, sv)
+        for i = 1:(length(stmt.args)-1)
+            val = stmt.args[i]
+            if isa(val, SSAValue)
+                stmt_inconsistent |= val.id in inconsistent
+                count!(tpdum, val)
+            end
+        end
+    else
+        for ur in userefs(stmt)
+            val = ur[]
+            if isa(val, SSAValue)
+                stmt_inconsistent |= val.id in inconsistent
+                count!(tpdum, val)
             end
         end
     end
+    stmt_inconsistent && push!(inconsistent, idx)
+    return stmt_inconsistent
+end
 
-    function scan_inconsistency!(inst::Instruction, idx::Int)
-        flag = inst[:flag]
-        stmt_inconsistent = iszero(flag & IR_FLAG_CONSISTENT)
-        stmt = inst[:stmt]
-        # Special case: For getfield, we allow inconsistency of the :boundscheck argument
-        if is_getfield_with_boundscheck_arg(stmt)
-            for i = 1:(length(stmt.args)-1)
-                val = stmt.args[i]
-                if isa(val, SSAValue)
-                    stmt_inconsistent |= val.id in inconsistent
-                    count!(tpdum, val)
-                end
-            end
-        else
-            for ur in userefs(stmt)
-                val = ur[]
-                if isa(val, SSAValue)
-                    stmt_inconsistent |= val.id in inconsistent
-                    count!(tpdum, val)
-                end
-            end
-        end
-        stmt_inconsistent && push!(inconsistent, idx)
-        return stmt_inconsistent
+struct ScanStmt
+    sv::PostOptAnalysisState
+end
+
+function ((; sv)::ScanStmt)(inst::Instruction, idx::Int, lstmt::Int, bb::Int)
+    stmt = inst[:inst]
+    flag = inst[:flag]
+
+    if isexpr(stmt, :enter)
+        # try/catch not yet modeled
+        give_up_refinements!(sv)
+        return nothing
     end
 
-    function scan_stmt!(inst::Instruction, idx::Int, lstmt::Int, bb::Int)
-        stmt = inst[:inst]
-        flag = inst[:flag]
+    scan_non_dataflow_flags!(inst, sv)
 
-        if isexpr(stmt, :enter)
-            # try/catch not yet modeled
-            give_up_refinements!(sv)
-            return nothing
-        end
+    stmt_inconsistent = scan_inconsistency!(inst, idx, sv)
 
-        scan_non_dataflow_flags!(inst)
-
-        stmt_inconsistent = scan_inconsistency!(inst, idx)
-
-        if stmt_inconsistent && idx == lstmt
-            if isa(stmt, ReturnNode) && isdefined(stmt, :val)
+    if stmt_inconsistent && idx == lstmt
+        if isa(stmt, ReturnNode) && isdefined(stmt, :val)
+            sv.all_retpaths_consistent = false
+        elseif isa(stmt, GotoIfNot)
+            # Conditional Branch with inconsistent condition.
+            # If we do not know this function terminates, taint consistency, now,
+            # :consistent requires consistent termination. TODO: Just look at the
+            # inconsistent region.
+            if !sv.result.ipo_effects.terminates
                 sv.all_retpaths_consistent = false
-            elseif isa(stmt, GotoIfNot)
-                # Conditional Branch with inconsistent condition.
-                # If we do not know this function terminates, taint consistency, now,
-                # :consistent requires consistent termination. TODO: Just look at the
-                # inconsistent region.
-                if !result.ipo_effects.terminates
-                    sv.all_retpaths_consistent = false
-                elseif conditional_successors_may_throw(lazypostdomtree, ir, bb)
-                    # Check if there are potential throws that require
-                    sv.all_retpaths_consistent = false
-                else
-                    (; cfg, domtree) = get!(lazyagdomtree)
-                    for succ in iterated_dominance_frontier(cfg, BlockLiveness(ir.cfg.blocks[bb].succs, nothing), domtree)
-                        if succ == length(cfg.blocks)
-                            # Phi node in the virtual exit -> We have a conditional
-                            # return. TODO: Check if all the retvals are egal.
-                            sv.all_retpaths_consistent = false
-                        else
-                            visit_bb_phis!(ir, succ) do phiidx::Int
-                                push!(inconsistent, phiidx)
-                            end
+            elseif conditional_successors_may_throw(sv.lazypostdomtree, sv.ir, bb)
+                # Check if there are potential throws that require
+                sv.all_retpaths_consistent = false
+            else
+                (; cfg, domtree) = get!(sv.lazyagdomtree)
+                for succ in iterated_dominance_frontier(cfg, BlockLiveness(sv.ir.cfg.blocks[bb].succs, nothing), domtree)
+                    if succ == length(cfg.blocks)
+                        # Phi node in the virtual exit -> We have a conditional
+                        # return. TODO: Check if all the retvals are egal.
+                        sv.all_retpaths_consistent = false
+                    else
+                        visit_bb_phis!(sv.ir, succ) do phiidx::Int
+                            push!(sv.inconsistent, phiidx)
                         end
                     end
                 end
             end
         end
-
-        # bail out early if there are no possibilities to refine the effects
-        if !any_refinable(sv, result.ipo_effects)
-            return nothing
-        end
-
-        return true
     end
 
-    completed_scan = scan!(scan_stmt!, scanner, true)
+    # bail out early if there are no possibilities to refine the effects
+    if !any_refinable(sv)
+        return nothing
+    end
+
+    return true
+end
+
+function check_inconsistentcy!(sv::PostOptAnalysisState, scanner::BBScanner)
+    scan!(ScanStmt(sv), scanner, true)
+    complete!(sv.tpdum); push!(scanner.bb_ip, 1)
+    populate_def_use_map!(sv.tpdum, scanner)
+    (; ir, inconsistent, tpdum) = sv
+    stmt_ip = BitSetBoundedMinPrioritySet(length(ir.stmts))
+    for def in sv.inconsistent
+        for use in tpdum[def]
+            if !(use in inconsistent)
+                push!(inconsistent, use)
+                append!(stmt_ip, tpdum[use])
+            end
+        end
+    end
+    while !isempty(stmt_ip)
+        idx = popfirst!(stmt_ip)
+        inst = ir[SSAValue(idx)]
+        stmt = inst[:inst]
+        if is_getfield_with_boundscheck_arg(stmt, sv)
+            any_non_boundscheck_inconsistent = false
+            for i = 1:(length(stmt.args)-1)
+                val = stmt.args[i]
+                if isa(val, SSAValue)
+                    any_non_boundscheck_inconsistent |= val.id in inconsistent
+                    any_non_boundscheck_inconsistent && break
+                end
+            end
+            any_non_boundscheck_inconsistent || continue
+        elseif isa(stmt, ReturnNode)
+            sv.all_retpaths_consistent = false
+        else isa(stmt, GotoIfNot)
+            bb = block_for_inst(ir, idx)
+            cfg = ir.cfg
+            blockliveness = BlockLiveness(cfg.blocks[bb].succs, nothing)
+            domtree = construct_domtree(cfg.blocks)
+            for succ in iterated_dominance_frontier(cfg, blockliveness, domtree)
+                visit_bb_phis!(ir, succ) do phiidx::Int
+                    push!(inconsistent, phiidx)
+                    push!(stmt_ip, phiidx)
+                end
+            end
+        end
+        sv.all_retpaths_consistent || break
+        append!(inconsistent, tpdum[idx])
+        append!(stmt_ip, tpdum[idx])
+    end
+end
+
+function ipo_dataflow_analysis!(interp::AbstractInterpreter, ir::IRCode, result::InferenceResult)
+    is_ipo_dataflow_analysis_profitable(result.ipo_effects) || return false
+
+    sv = PostOptAnalysisState(result, ir)
+    scanner = BBScanner(ir)
+
+    completed_scan = scan!(ScanStmt(sv), scanner, true)
 
     if !completed_scan
-        if !sv.all_retpaths_consistent
+        if sv.all_retpaths_consistent
+            check_inconsistentcy!(sv, scanner)
+        else
             # No longer any dataflow concerns, just scan the flags
             scan!(scanner, false) do inst::Instruction, idx::Int, lstmt::Int, bb::Int
-                scan_non_dataflow_flags!(inst)
+                scan_non_dataflow_flags!(inst, sv)
                 # bail out early if there are no possibilities to refine the effects
-                if !any_refinable(sv, result.ipo_effects)
+                if !any_refinable(sv)
                     return nothing
                 end
                 return true
             end
-        else
-            scan!(scan_stmt!, scanner, true)
-            complete!(tpdum); push!(scanner.bb_ip, 1)
-            populate_def_use_map!(tpdum, scanner)
-            stmt_ip = BitSetBoundedMinPrioritySet(length(ir.stmts))
-            for def in inconsistent
-                for use in tpdum[def]
-                    if !(use in inconsistent)
-                        push!(inconsistent, use)
-                        append!(stmt_ip, tpdum[use])
-                    end
-                end
-            end
-            while !isempty(stmt_ip)
-                idx = popfirst!(stmt_ip)
-                inst = ir[SSAValue(idx)]
-                stmt = inst[:inst]
-                if is_getfield_with_boundscheck_arg(stmt)
-                    any_non_boundscheck_inconsistent = false
-                    for i = 1:(length(stmt.args)-1)
-                        val = stmt.args[i]
-                        if isa(val, SSAValue)
-                            any_non_boundscheck_inconsistent |= val.id in inconsistent
-                            any_non_boundscheck_inconsistent && break
-                        end
-                    end
-                    any_non_boundscheck_inconsistent || continue
-                elseif isa(stmt, ReturnNode)
-                    sv.all_retpaths_consistent = false
-                else isa(stmt, GotoIfNot)
-                    bb = block_for_inst(ir, idx)
-                    blockliveness = BlockLiveness(ir.cfg.blocks[bb].succs, nothing)
-                    domtree = construct_domtree(ir.cfg.blocks)
-                    for succ in iterated_dominance_frontier(ir.cfg, blockliveness, domtree)
-                        visit_bb_phis!(ir, succ) do phiidx::Int
-                            push!(inconsistent, phiidx)
-                            push!(stmt_ip, phiidx)
-                        end
-                    end
-                end
-                sv.all_retpaths_consistent || break
-                append!(inconsistent, tpdum[idx])
-                append!(stmt_ip, tpdum[idx])
-            end
         end
     end
 
-    return refine_effects!(result, sv)
+    return refine_effects!(sv)
 end
 
 # run the optimization work

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -229,7 +229,7 @@ function scan!(callback, scanner::BBScanner, forwards_only::Bool)
             ret = callback(inst, idx, lstmt, bb)
             ret === nothing && return true
             ret::Bool || break
-            idx == lstmt && process_terminator!(inst[:inst], bb, bb_ip) && forwards_only && return false
+            idx == lstmt && process_terminator!(inst[:stmt], bb, bb_ip) && forwards_only && return false
         end
     end
     return true
@@ -265,7 +265,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
     #            converge.
     completed_scan = scan!(scanner, true) do inst::Instruction, idx::Int, lstmt::Int, bb::Int
         irsv.curridx = idx
-        stmt = ir.stmts[idx][:inst]
+        stmt = ir.stmts[idx][:stmt]
         typ = ir.stmts[idx][:type]
         flag = ir.stmts[idx][:flag]
         any_refined = false
@@ -295,7 +295,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
                 idx, bb, stmt, typ, irsv)) ||
             (externally_refined !== nothing && idx in externally_refined)
             push!(ssa_refined, idx)
-            stmt = ir.stmts[idx][:inst]
+            stmt = ir.stmts[idx][:stmt]
             typ = ir.stmts[idx][:type]
         end
         if typ === Bottom && !is_terminator_or_phi
@@ -304,7 +304,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
                 for idx2 in (idx+1:lstmt-1)
                     ir[SSAValue(idx2)] = nothing
                 end
-                ir[SSAValue(lstmt)][:inst] = ReturnNode()
+                ir[SSAValue(lstmt)][:stmt] = ReturnNode()
             end
             return false
         end
@@ -318,7 +318,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
         # Slow Path Phase 1.A: Complete use scanning
         scan!(scanner, false) do inst::Instruction, idx::Int, lstmt::Int, bb::Int
             irsv.curridx = idx
-            stmt = inst[:inst]
+            stmt = inst[:stmt]
             flag = inst[:flag]
             if (flag & IR_FLAG_REFINED) != 0
                 inst[:flag] &= ~IR_FLAG_REFINED


### PR DESCRIPTION
@nanosoldier `runbenchmarks("inference", vs=":master")`