### PR TITLE
cross-reference pathof and pkgdir in docstrings

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -475,6 +475,8 @@ or `nothing` if `m` was not imported from a package.
 
 Use [`dirname`](@ref) to get the directory part and [`basename`](@ref)
 to get the file name part of the path.
+
+See also [`pkgdir`](@ref).
 """
 function pathof(m::Module)
     @lock require_lock begin
@@ -506,6 +508,8 @@ julia> pkgdir(Foo)
 julia> pkgdir(Foo, "src", "file.jl")
 "/path/to/Foo.jl/src/file.jl"
 ```
+
+See also [`pathof`](@ref).
 
 !!! compat "Julia 1.7"
     The optional argument `paths` requires at least Julia 1.7.


### PR DESCRIPTION
I added cross-references in the docstrings of the related functions `pathof` and `pkgdir`. In my case, I remembered `pathof` but wanted to use `pkgdir`, which I couldn't find easily from the REPL help mode.