### PR TITLE
Export num_stack_mappings to track the number of in-flight stack mappings and tasks in application

### DIFF
--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -73,6 +73,9 @@ static void free_stack(void *stkbuf, size_t bufsz)
 }
 #endif
 
+JL_DLLEXPORT uint32_t jl_get_num_stack_mappings() {
+    return jl_atomic_load_relaxed(&num_stack_mappings);
+}
 
 const unsigned pool_sizes[] = {
     128 * 1024,

--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -73,7 +73,7 @@ static void free_stack(void *stkbuf, size_t bufsz)
 }
 #endif
 
-JL_DLLEXPORT uint32_t jl_get_num_stack_mappings()
+JL_DLLEXPORT uint32_t jl_get_num_stack_mappings(void)
 {
     return jl_atomic_load_relaxed(&num_stack_mappings);
 }

--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -73,7 +73,8 @@ static void free_stack(void *stkbuf, size_t bufsz)
 }
 #endif
 
-JL_DLLEXPORT uint32_t jl_get_num_stack_mappings() {
+JL_DLLEXPORT uint32_t jl_get_num_stack_mappings()
+{
     return jl_atomic_load_relaxed(&num_stack_mappings);
 }
 

--- a/src/gc.h
+++ b/src/gc.h
@@ -654,7 +654,7 @@ void gc_count_pool(void);
 size_t jl_array_nbytes(jl_array_t *a) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT void jl_enable_gc_logging(int enable);
-JL_DLLEXPORT uint32_t jl_get_num_stack_mappings();
+JL_DLLEXPORT uint32_t jl_get_num_stack_mappings(void);
 void _report_gc_finished(uint64_t pause, uint64_t freed, int full, int recollect, int64_t live_bytes) JL_NOTSAFEPOINT;
 
 #ifdef __cplusplus

--- a/src/gc.h
+++ b/src/gc.h
@@ -654,6 +654,7 @@ void gc_count_pool(void);
 size_t jl_array_nbytes(jl_array_t *a) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT void jl_enable_gc_logging(int enable);
+JL_DLLEXPORT uint32_t jl_get_num_stack_mappings();
 void _report_gc_finished(uint64_t pause, uint64_t freed, int full, int recollect, int64_t live_bytes) JL_NOTSAFEPOINT;
 
 #ifdef __cplusplus

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -246,7 +246,6 @@
     XX(jl_get_UNAME) \
     XX(jl_get_world_counter) \
     XX(jl_get_zero_subnormals) \
-    XX(jl_get_num_stack_mappings) \
     XX(jl_gf_invoke_lookup) \
     XX(jl_gf_invoke_lookup_worlds) \
     XX(jl_git_branch) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -246,6 +246,7 @@
     XX(jl_get_UNAME) \
     XX(jl_get_world_counter) \
     XX(jl_get_zero_subnormals) \
+    XX(jl_get_num_stack_mappings) \
     XX(jl_gf_invoke_lookup) \
     XX(jl_gf_invoke_lookup_worlds) \
     XX(jl_git_branch) \

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -331,3 +331,9 @@ end
 @testset "rand_ptls underflow" begin
     @test Base.Partr.cong(UInt32(0)) == 0
 end
+
+@testset "num_stack_mappings metric" begin
+    @test @ccall(jl_get_num_stack_mappings()::Cint) >= 1
+    # There must be at least two: one for the root test task and one for the async task:
+    @test fetch(@async(@ccall(jl_get_num_stack_mappings()::Cint))) >= 2
+end


### PR DESCRIPTION
Julia already tracks the number of mapped stacks for Julia tasks in a local atomic.
Exporting this atomic will allow applications to estimate the memory consumption by the stacks and also the number of in-flight tasks.