### PR TITLE
reduce test time for rounding and floatfuncs

### DIFF
--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -139,9 +139,10 @@ end
 end
 
 @testset "literal pow matches runtime pow matches optimized pow" begin
-    two = 2
-    @test 1.0000000105367122^2 == 1.0000000105367122^two
-    @test 1.0041504f0^2 == 1.0041504f0^two
+    let two = 2
+        @test 1.0000000105367122^2 == 1.0000000105367122^two
+        @test 1.0041504f0^2 == 1.0041504f0^two
+    end
 
     function g2(start, two, N)
         x = start
@@ -192,11 +193,13 @@ end
     finv(x) = f(x, -1)
     f2(x) = f(x, 2)
     f3(x) = f(x, 3)
-    x = 1.0000000105367122
-    @test x^2 == f(x, 2) == f2(x) == x*x == Float64(big(x)*big(x))
-    @test x^3 == f(x, 3) == f3(x) == x*x*x == Float64(big(x)*big(x)*big(x))
-    x = 1.000000007393669
-    @test x^-1 == f(x, -1) == finv(x) == 1/x == inv(x) == Float64(1/big(x)) == Float64(inv(big(x)))
+    let x = 1.0000000105367122
+        @test x^2 == f(x, 2) == f2(x) == x*x == Float64(big(x)*big(x))
+        @test x^3 == f(x, 3) == f3(x) == x*x*x == Float64(big(x)*big(x)*big(x))
+    end
+    let x = 1.000000007393669
+        @test x^-1 == f(x, -1) == finv(x) == 1/x == inv(x) == Float64(1/big(x)) == Float64(inv(big(x)))
+    end
 end
 
 @testset "curried approximation" begin

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -412,11 +412,14 @@ function float_samples(::Type{T}, exponents, n::Int) where {T<:AbstractFloat}
     ret
 end
 
+# a reasonable range of values for testing behavior between 1:200
+const fib200 = [1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 200]
+
 @testset "IEEEFloat(::BigFloat) against MPFR" begin
-    for pr ∈ 1:200
+    for pr ∈ fib200
         setprecision(BigFloat, pr) do
             exp = exponent(floatmax(Float64)) + 10
-            bf_samples = float_samples(BigFloat, (-exp):exp, 20)
+            bf_samples = float_samples(BigFloat, (-exp):exp, 20) # about 82680 random values
             for mpfr_rm ∈ mpfr_rounding_modes, bf ∈ bf_samples, F ∈ (Float32, Float64)
                 @test (
                     mpfr_to_ieee(F, bf, mpfr_rm) ===
@@ -434,10 +437,11 @@ const native_rounding_modes = (
 
 # Checks that each rounding mode is faithful.
 @testset "IEEEFloat(::BigFloat) faithful rounding" begin
-    for pr ∈ 1:200
+    for pr ∈ fib200
         setprecision(BigFloat, pr) do
             exp = 500
-            bf_samples = float_samples(BigFloat, (-exp):exp, 20)
+            bf_samples = float_samples(BigFloat, (-exp):exp, 20) # about 40040 random values
+            @show length(bf_samples)
             for rm ∈ (mpfr_rounding_modes..., Base.MPFR.MPFRRoundFaithful,
                       native_rounding_modes...),
                 bf ∈ bf_samples,


### PR DESCRIPTION
These test were taking on the order of 5 minutes and 10-100s of GB, but they really did not need to.