### PR TITLE
doc: Positional arguments cannot be given by name.

### DIFF
--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -374,6 +374,36 @@ julia> twothreearr()
  3
 ```
 
+### [Can I pass positional arguments by name?](@id faq-positional-args-by-name)
+
+No; if you have e.g. a function with signature `lognormal(median, g)`,
+then calling it as `lognormal(median = 4, g = 1)` will not work.
+
+Instead, you can explain argument names in other ways:
+```julia
+lognormal(
+    4,  # Median
+    1,  # Geometric standard deviation, g
+)
+```
+or, using inline comments:
+```julia
+lognormal(#=median=# 4, #=g=# 1)
+```
+or, simply:
+```julia
+median = 4
+g      = 1  # Geometric standard deviation
+lognormal(median, g)
+```
+
+You can also define a wrapper method that takes keyword arguments:
+```julia
+lognormal(; median, g) = lognormal(median, g)
+```
+which can then be called as `lognormal(median = 4, g = 1)`.
+
+
 ## Types, type declarations, and constructors
 
 ### [What does "type-stable" mean?](@id man-type-stability)

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -159,11 +159,11 @@ For users coming to Julia from R, these are some noteworthy differences:
     will be visible in the caller. This is very different from R and allows new functions to operate
     on large data structures much more efficiently.
   * In Julia, a function argument is either positional, or a keyword
-    argument. Unlike in R -- where any argument can be passed either
-    positionally or by name -- in Julia, positional arguments cannot be
+    argument. Unlike in R---where any argument can be passed either 
+    positionally or by name---positional arguments cannot be
     passed by name, and keyword arguments cannot be passed positionally.
     E.g. a function with signature `work(x; T)` must be called
-    as `work(4, T = 5)`, and not `work(4, 5)` or `work(x = 4, T = 5)`.
+    as `work(4; T = 5)`, and not `work(4, 5)` or `work(x = 4, T = 5)`.
     (See also [this FAQ entry](faq-positional-args-by-name)).
   * In Julia, vectors and matrices are concatenated using [`hcat`](@ref), [`vcat`](@ref) and
     [`hvcat`](@ref), not `c`, `rbind` and `cbind` like in R.

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -237,8 +237,9 @@ For users coming to Julia from R, these are some noteworthy differences:
   * In Julia, keyword arguments must be passed using keywords, unlike Python in which it is usually possible
     to pass them positionally. Attempting to pass a keyword argument positionally alters the method
     signature leading to a `MethodError` or calling of the wrong method.
-  * Positional arguments cannot be given by name in Julia.
-    E.g. calling `lognormal(median = 4, g = 1)` will not work for a function defined as `lognormal(median, g)`.
+  * Conversely, positional arguments cannot be given by name in Julia.
+    If a function's signature is e.g. `lognormal(median, g)`,
+    then calling it as `lognormal(median = 4, g = 1)` will not work.
     Instead, you can explain arguments by name on separate lines:
     ```
     median = 4

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -237,6 +237,15 @@ For users coming to Julia from R, these are some noteworthy differences:
   * In Julia, keyword arguments must be passed using keywords, unlike Python in which it is usually possible
     to pass them positionally. Attempting to pass a keyword argument positionally alters the method
     signature leading to a `MethodError` or calling of the wrong method.
+  * Positional arguments cannot be given by name in Julia.
+    E.g. calling `lognormal(median = 4, g = 1)` will not work for a function defined as `lognormal(median, g)`.
+    Instead, you can explain arguments by name on separate lines:
+    ```
+    median = 4
+    g      = 1  # Geometric standard deviation
+    lognormal(median, g)
+    ```
+    ..or use inline comments: `lognormal( #=median=# 4, #=g=# 1)`.
   * In Julia `%` is the remainder operator, whereas in Python it is the modulus.
   * In Julia, the commonly used `Int` type corresponds to the machine integer type (`Int32` or `Int64`), unlike in Python, where `int` is an arbitrary length integer.
     This means in Julia the `Int` type will overflow, such that `2^64 == 0`. If you need larger values use another appropriate type,

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -164,7 +164,7 @@ For users coming to Julia from R, these are some noteworthy differences:
     passed by name, and keyword arguments cannot be passed positionally.
     E.g. a function with signature `work(x; T)` must be called
     as `work(4; T = 5)`, and not `work(4, 5)` or `work(x = 4, T = 5)`.
-    (See also [this FAQ entry](faq-positional-args-by-name)).
+    (See also [this FAQ entry](@ref faq-positional-args-by-name)).
   * In Julia, vectors and matrices are concatenated using [`hcat`](@ref), [`vcat`](@ref) and
     [`hvcat`](@ref), not `c`, `rbind` and `cbind` like in R.
   * In Julia, a range like `a:b` is not shorthand for a vector like in R, but is a specialized `AbstractRange`

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -158,6 +158,13 @@ For users coming to Julia from R, these are some noteworthy differences:
   * In Julia, values are not copied when assigned or passed to a function. If a function modifies an array, the changes
     will be visible in the caller. This is very different from R and allows new functions to operate
     on large data structures much more efficiently.
+  * In Julia, a function argument is either positional, or a keyword
+    argument. Unlike in R -- where any argument can be passed either
+    positionally or by name -- in Julia, positional arguments cannot be
+    passed by name, and keyword arguments cannot be passed positionally.
+    E.g. a function with signature `work(x; T)` must be called
+    as `work(4, T = 5)`, and not `work(4, 5)` or `work(x = 4, T = 5)`.
+    (See also [this FAQ entry](faq-positional-args-by-name)).
   * In Julia, vectors and matrices are concatenated using [`hcat`](@ref), [`vcat`](@ref) and
     [`hvcat`](@ref), not `c`, `rbind` and `cbind` like in R.
   * In Julia, a range like `a:b` is not shorthand for a vector like in R, but is a specialized `AbstractRange`
@@ -237,16 +244,7 @@ For users coming to Julia from R, these are some noteworthy differences:
   * In Julia, keyword arguments must be passed using keywords, unlike Python in which it is usually possible
     to pass them positionally. Attempting to pass a keyword argument positionally alters the method
     signature leading to a `MethodError` or calling of the wrong method.
-  * Conversely, positional arguments cannot be given by name in Julia.
-    If a function's signature is e.g. `lognormal(median, g)`,
-    then calling it as `lognormal(median = 4, g = 1)` will not work.
-    Instead, you can explain arguments by name on separate lines:
-    ```
-    median = 4
-    g      = 1  # Geometric standard deviation
-    lognormal(median, g)
-    ```
-    ..or use inline comments: `lognormal( #=median=# 4, #=g=# 1)`.
+  * Conversely, positional arguments cannot be given by name in Julia. If a function's signature is e.g. `lognormal(median, g)`, then calling it as `lognormal(median = 4, g = 1)` will not work. Instead, positional arguments can be documented [in other ways](@ref faq-positional-args-by-name).
   * In Julia `%` is the remainder operator, whereas in Python it is the modulus.
   * In Julia, the commonly used `Int` type corresponds to the machine integer type (`Int32` or `Int64`), unlike in Python, where `int` is an arbitrary length integer.
     This means in Julia the `Int` type will overflow, such that `2^64 == 0`. If you need larger values use another appropriate type,


### PR DESCRIPTION
Many new (and old) Julians have been missing this feature over the years.[^1],[^2] But it's not gonna come anytime soon, or ever.[^3]
So, here we add best practices to the docs on how you can still document the names/meaning of positional arguments at the call site.

I added it to the 'Python' section in `noteworthy-differences.md`.
Disadvantage of this location, as [noted][4] by @digital-carver:
- it could also go in the R section.
- individual points on this page (like this one) are not linkable!
- the page in its entirety is already quite long.

The new bullet point _does_ fit in well with the existing, preceding one, however.

[^1]: https://discourse.julialang.org/t/allow-use-of-named-argument-syntax-for-positional-arguments/5287
[^2]: https://discourse.julialang.org/t/naming-positional-arguments-at-call-site/103526
[^3]: https://discourse.julialang.org/t/naming-positional-arguments-at-call-site/103526/97

[4]: https://discourse.julialang.org/t/naming-positional-arguments-at-call-site/103526/112?u=tfiers