### PR TITLE
fix: make `fieldcount` work for `Type{T}`

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -868,6 +868,7 @@ function argument_datatype(@nospecialize t)
     return ccall(:jl_argument_datatype, Any, (Any,), t)::Union{Nothing,DataType}
 end
 
+datatype_fieldcount(::Type{Type{T}}) where T = 0
 function datatype_fieldcount(t::DataType)
     if t.name === _NAMEDTUPLE_NAME
         names, types = t.parameters[1], t.parameters[2]

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -626,6 +626,8 @@ end
 @test fieldcount(Complex) == fieldcount(ComplexF32) == 2
 @test fieldcount(Union{ComplexF32,ComplexF64}) == 2
 @test fieldcount(Int) == 0
+@test fieldcount(Type{Int}) == 0
+@test fieldcount(Type{Type{DataType}}) == 0
 @test_throws(ArgumentError("type does not have a definite number of fields"),
              fieldcount(Union{Complex,Pair}))
 @test_throws ArgumentError fieldcount(Real)


### PR DESCRIPTION
```
julia> fieldcount(Type{Int})
ERROR: ArgumentError: type does not have a definite number of fields
Stacktrace:
 [1] fieldcount(t::Any)
   @ Base ./reflection.jl:893
 [2] top-level scope
   @ REPL[1]:1
```
seems like a sensible thing to ask and I'd expect it to return `0`. This PR makes it work.