### PR TITLE
Allow Semaphores to have initial value zero.

### DIFF
--- a/base/lock.jl
+++ b/base/lock.jl
@@ -340,7 +340,7 @@ mutable struct Semaphore
     sem_size::Int
     curr_cnt::Int
     cond_wait::Threads.Condition
-    Semaphore(sem_size) = sem_size > 0 ? new(sem_size, 0, Threads.Condition()) : throw(ArgumentError("Semaphore size must be > 0"))
+    Semaphore(sem_size) = sem_size >= 0 ? new(sem_size, 0, Threads.Condition()) : throw(ArgumentError("Semaphore size must be >= 0"))
 end
 
 """


### PR DESCRIPTION
`Semaphore(0)` currently throws an error. Initializing semaphores with value zero is useful and was part of the original concept (see excerpt from Dijkstra below).

![Screenshot 2023-09-14 at 10 30 30 AM](https://github.com/JuliaLang/julia/assets/38042357/c1ea168a-52f0-411a-b7e3-ca7148b50be2)

- Edsger W. Dijkstra. 1967. The structure of the “THE”-multiprogramming system. In Proceedings of the first ACM symposium on Operating System Principles (SOSP '67). Association for Computing Machinery, New York, NY, USA, 10.1–10.6. https://doi.org/10.1145/800001.811672

