### PR TITLE
Tweaks to repl tab complete hints

### DIFF
--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -334,8 +334,8 @@ julia> mapfold[TAB]
 mapfoldl mapfoldr
 ```
 
-When a single complete tab-complete result is available at the end of an input line a hint of
-the completion will show in a lighter color.
+When a single complete tab-complete result is available at the end of an input line and 2 or more characters
+have been typed, a hint of the completion will show in a lighter color.
 This can be disabled via `Base.active_repl.options.hint_tab_completes = false`.
 
 !!! compat "Julia 1.11"

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -334,7 +334,8 @@ julia> mapfold[TAB]
 mapfoldl mapfoldr
 ```
 
-When a single complete tab-complete result is available a hint of the completion will show in a lighter color.
+When a single complete tab-complete result is available at the end of an input line a hint of
+the completion will show in a lighter color.
 This can be disabled via `Base.active_repl.options.hint_tab_completes = false`.
 
 !!! compat "Julia 1.11"

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -376,6 +376,11 @@ end
 function check_for_hint(s::MIState)
     st = state(s)
     options(st).hint_tab_completes || return false
+    if !eof(buffer(st)) # only generate hints if at the end of the line
+        # TODO: maybe show hints for insertions at other positions
+        # Requires making space for them earlier in refresh_multi_line
+        return false
+    end
     completions, partial, should_complete = complete_line(st.p.complete, st, s.active_module)::Tuple{Vector{String},String,Bool}
     if should_complete
         if length(completions) == 1

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -382,6 +382,7 @@ function check_for_hint(s::MIState)
         return false
     end
     completions, partial, should_complete = complete_line(st.p.complete, st, s.active_module)::Tuple{Vector{String},String,Bool}
+    length(partial) < 2 && return false # Don't complete for single chars, given e.g. `x` completes to `xor`
     if should_complete
         if length(completions) == 1
             hint = only(completions)[sizeof(partial)+1:end]

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1700,6 +1700,13 @@ fake_repl() do stdin_write, stdout_read, repl
     write(stdin_write, "\t")
     s4 = readuntil(stdout_read, "readavailable") # full completion is reprinted
 
+    write(stdin_write, "\x15")
+    write(stdin_write, "x") # single chars shouldn't hint e.g. `x` shouldn't hint at `xor`
+    while LineEdit.state(repl.mistate).hint !== nothing
+        sleep(0.1)
+    end
+    @test LineEdit.state(repl.mistate).hint === nothing
+
     write(stdin_write, "\x15\x04")
     Base.wait(repltask)
 end


### PR DESCRIPTION
Follow-on from https://github.com/JuliaLang/julia/pull/51229

- Fix https://github.com/JuliaLang/julia/issues/51320 by only generating hints at the end of the line. Inserting hints earlier requires further work to avoid overprinting 
- Don't hint on single letters, require at least 2, given it's a bit awkward that just typing `x` hints `xor`
