### PR TITLE
doc: correct unicode-input table generation

### DIFF
--- a/doc/src/manual/unicode-input.md
+++ b/doc/src/manual/unicode-input.md
@@ -52,11 +52,12 @@ function fix_combining_chars(char)
     return cat == 6 || cat == 8 ? "$NBSP$char$NBSP" : "$char"
 end
 
-
 function table_entries(completions, unicode_dict)
-    entries = [[
-        "Code point(s)", "Character(s)",
-        "Tab completion sequence(s)", "Unicode name(s)"
+    entries = Any[Any[
+        ["Code point(s)"],
+        ["Character(s)"],
+        ["Tab completion sequence(s)"],
+        ["Unicode name(s)"],
     ]]
     for (chars, inputs) in sort!(collect(completions), by = first)
         code_points, unicode_names, characters = String[], String[], String[]
@@ -65,12 +66,21 @@ function table_entries(completions, unicode_dict)
             push!(unicode_names, get(unicode_dict, UInt32(char), "(No Unicode name)"))
             push!(characters, isempty(characters) ? fix_combining_chars(char) : "$char")
         end
+        inputs_md = []
+        for (i, input) in enumerate(inputs)
+            i > 1 && push!(inputs_md, ", ")
+            push!(inputs_md, Markdown.Code("", input))
+        end
         push!(entries, [
-            join(code_points, " + "), join(characters),
-            join(inputs, ", "), join(unicode_names, " + ")
+            [join(code_points, " + ")],
+            [join(characters)],
+            inputs_md,
+            [join(unicode_names, " + ")],
         ])
     end
-    return Markdown.Table(entries, [:l, :l, :l, :l])
+    table = Markdown.Table(entries, [:l, :c, :l, :l])
+    # We also need to wrap the Table in a Markdown.MD "document"
+    return Markdown.MD([table])
 end
 
 table_entries(


### PR DESCRIPTION
A couple small fixes and cosmetic improvements to the Unicode table in the docs:

* Most importantly, makes sure that the resulting object from the at-eval block is `Markdown.MD`, which which will be necessary for Documenter 1.0 (#47105). It also fixes the `Markdown.Table` structure -- each of the cells should be an array, not just a string, so it adds one more layer of nesting.
* Cosmetically, center-aligns the characters, and wraps the latex commands in `<code>`

![image](https://github.com/JuliaLang/julia/assets/147757/029ecdc2-aae1-4bf0-b44c-5b6de9ddeef8)
