### PR TITLE
Add cross-references between codeview functions/macros

### DIFF
--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -71,6 +71,8 @@ Small unions of concrete types are usually not a concern, so these are highlight
 Keyword argument `debuginfo` may be one of `:source` or `:none` (default), to specify the verbosity of code comments.
 
 See [`@code_warntype`](@ref man-code-warntype) for more information.
+
+See also: [`@code_warntype`](@ref), [`code_native`](@ref), [`code_llvm`](@ref), [`code_typed`](@ref), [`code_lowered`](@ref).
 """
 function code_warntype(io::IO, @nospecialize(f), @nospecialize(t=Base.default_tt(f));
                        debuginfo::Symbol=:default, optimize::Bool=false, kwargs...)
@@ -273,6 +275,8 @@ If the `optimize` keyword is unset, the code will be shown before LLVM optimizat
 All metadata and dbg.* calls are removed from the printed bitcode. For the full IR, set the `raw` keyword to true.
 To dump the entire module that encapsulates the function (with declarations), set the `dump_module` keyword to true.
 Keyword argument `debuginfo` may be one of source (default) or none, to specify the verbosity of code comments.
+
+See also: [`@code_llvm`](@ref), [`code_native`](@ref), [`code_typed`](@ref), [`code_lowered`](@ref), [`code_warntype`](@ref).
 """
 function code_llvm(io::IO, @nospecialize(f), @nospecialize(types=Base.default_tt(f));
                    raw::Bool=false, dump_module::Bool=false, optimize::Bool=true, debuginfo::Symbol=:default,
@@ -298,7 +302,7 @@ generic function and type signature to `io`.
 * If `dump_module` is `false`, do not print metadata such as rodata or directives.
 * If `raw` is `false`, uninteresting instructions (like the safepoint function prologue) are elided.
 
-See also: [`@code_native`](@ref), [`code_llvm`](@ref), [`code_typed`](@ref) and [`code_lowered`](@ref)
+See also: [`@code_native`](@ref), [`code_llvm`](@ref), [`code_typed`](@ref), [`code_lowered`](@ref), [`code_warntype`](@ref).
 """
 function code_native(io::IO, @nospecialize(f), @nospecialize(types=Base.default_tt(f));
                      dump_module::Bool=true, syntax::Symbol=:intel, raw::Bool=false,

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -72,7 +72,7 @@ Keyword argument `debuginfo` may be one of `:source` or `:none` (default), to sp
 
 See [`@code_warntype`](@ref man-code-warntype) for more information.
 
-See also: [`@code_warntype`](@ref), [`code_native`](@ref), [`code_llvm`](@ref), [`code_typed`](@ref), [`code_lowered`](@ref).
+See also: [`@code_warntype`](@ref), [`code_typed`](@ref), [`code_lowered`](@ref), [`code_llvm`](@ref), [`code_native`](@ref).
 """
 function code_warntype(io::IO, @nospecialize(f), @nospecialize(t=Base.default_tt(f));
                        debuginfo::Symbol=:default, optimize::Bool=false, kwargs...)
@@ -276,7 +276,7 @@ All metadata and dbg.* calls are removed from the printed bitcode. For the full 
 To dump the entire module that encapsulates the function (with declarations), set the `dump_module` keyword to true.
 Keyword argument `debuginfo` may be one of source (default) or none, to specify the verbosity of code comments.
 
-See also: [`@code_llvm`](@ref), [`code_native`](@ref), [`code_typed`](@ref), [`code_lowered`](@ref), [`code_warntype`](@ref).
+See also: [`@code_llvm`](@ref), [`code_warntype`](@ref), [`code_typed`](@ref), [`code_lowered`](@ref), [`code_native`](@ref).
 """
 function code_llvm(io::IO, @nospecialize(f), @nospecialize(types=Base.default_tt(f));
                    raw::Bool=false, dump_module::Bool=false, optimize::Bool=true, debuginfo::Symbol=:default,
@@ -302,7 +302,7 @@ generic function and type signature to `io`.
 * If `dump_module` is `false`, do not print metadata such as rodata or directives.
 * If `raw` is `false`, uninteresting instructions (like the safepoint function prologue) are elided.
 
-See also: [`@code_native`](@ref), [`code_llvm`](@ref), [`code_typed`](@ref), [`code_lowered`](@ref), [`code_warntype`](@ref).
+See also: [`@code_native`](@ref), [`code_warntype`](@ref), [`code_typed`](@ref), [`code_lowered`](@ref), [`code_llvm`](@ref).
 """
 function code_native(io::IO, @nospecialize(f), @nospecialize(types=Base.default_tt(f));
                      dump_module::Bool=true, syntax::Symbol=:intel, raw::Bool=false,

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -298,7 +298,7 @@ Evaluates the arguments to the function or macro call, determines their types, a
 
 to control whether additional optimizations, such as inlining, are also applied.
 
-See also: [`code_typed`](@ref), [`@code_native`](@ref), [`@code_llvm`](@ref), [`@code_lowered`](@ref), [`@code_warntype`](@ref).
+See also: [`code_typed`](@ref), [`@code_warntype`](@ref), [`@code_lowered`](@ref), [`@code_llvm`](@ref), [`@code_native`](@ref).
 """
 :@code_typed
 
@@ -308,7 +308,7 @@ See also: [`code_typed`](@ref), [`@code_native`](@ref), [`@code_llvm`](@ref), [`
 Evaluates the arguments to the function or macro call, determines their types, and calls
 [`code_lowered`](@ref) on the resulting expression.
 
-See also: [`code_lowered`](@ref), [`@code_native`](@ref), [`@code_llvm`](@ref), [`@code_typed`](@ref), [`@code_warntype`](@ref).
+See also: [`code_lowered`](@ref), [`@code_warntype`](@ref), [`@code_typed`](@ref), [`@code_llvm`](@ref), [`@code_native`](@ref).
 """
 :@code_lowered
 
@@ -318,7 +318,7 @@ See also: [`code_lowered`](@ref), [`@code_native`](@ref), [`@code_llvm`](@ref), 
 Evaluates the arguments to the function or macro call, determines their types, and calls
 [`code_warntype`](@ref) on the resulting expression.
 
-See also: [`code_warntype`](@ref), [`@code_native`](@ref), [`@code_llvm`](@ref), [`@code_typed`](@ref), [`@code_lowered`](@ref).
+See also: [`code_warntype`](@ref), [`@code_typed`](@ref), [`@code_lowered`](@ref), [`@code_llvm`](@ref), [`@code_native`](@ref).
 """
 :@code_warntype
 
@@ -338,7 +338,7 @@ by putting them and their value before the function call, like this:
 `debuginfo` may be one of `:source` (default) or `:none`,  to specify the verbosity of code comments.
 `dump_module` prints the entire module that encapsulates the function.
 
-See also: [`code_llvm`](@ref), [`@code_native`](@ref), [`@code_typed`](@ref), [`@code_lowered`](@ref), [`@code_warntype`](@ref).
+See also: [`code_llvm`](@ref), [`@code_warntype`](@ref), [`@code_typed`](@ref), [`@code_lowered`](@ref), [`@code_native`](@ref).
 """
 :@code_llvm
 
@@ -358,7 +358,7 @@ by putting it before the function call, like this:
 * If `binary` is `true`, also print the binary machine code for each instruction precedented by an abbreviated address.
 * If `dump_module` is `false`, do not print metadata such as rodata or directives.
 
-See also: [`code_native`](@ref), [`@code_llvm`](@ref), [`@code_typed`](@ref), [`@code_lowered`](@ref), [`@code_warntype`](@ref).
+See also: [`code_native`](@ref), [`@code_warntype`](@ref), [`@code_typed`](@ref), [`@code_lowered`](@ref), [`@code_llvm`](@ref).
 """
 :@code_native
 

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -297,6 +297,8 @@ Evaluates the arguments to the function or macro call, determines their types, a
     @code_typed optimize=true foo(x)
 
 to control whether additional optimizations, such as inlining, are also applied.
+
+See also: [`code_typed`](@ref), [`@code_native`](@ref), [`@code_llvm`](@ref), [`@code_lowered`](@ref), [`@code_warntype`](@ref).
 """
 :@code_typed
 
@@ -305,6 +307,8 @@ to control whether additional optimizations, such as inlining, are also applied.
 
 Evaluates the arguments to the function or macro call, determines their types, and calls
 [`code_lowered`](@ref) on the resulting expression.
+
+See also: [`code_lowered`](@ref), [`@code_native`](@ref), [`@code_llvm`](@ref), [`@code_typed`](@ref), [`@code_warntype`](@ref).
 """
 :@code_lowered
 
@@ -313,6 +317,8 @@ Evaluates the arguments to the function or macro call, determines their types, a
 
 Evaluates the arguments to the function or macro call, determines their types, and calls
 [`code_warntype`](@ref) on the resulting expression.
+
+See also: [`code_warntype`](@ref), [`@code_native`](@ref), [`@code_llvm`](@ref), [`@code_typed`](@ref), [`@code_lowered`](@ref).
 """
 :@code_warntype
 
@@ -331,6 +337,8 @@ by putting them and their value before the function call, like this:
 `raw` makes all metadata and dbg.* calls visible.
 `debuginfo` may be one of `:source` (default) or `:none`,  to specify the verbosity of code comments.
 `dump_module` prints the entire module that encapsulates the function.
+
+See also: [`code_llvm`](@ref), [`@code_native`](@ref), [`@code_typed`](@ref), [`@code_lowered`](@ref), [`@code_warntype`](@ref).
 """
 :@code_llvm
 
@@ -350,7 +358,7 @@ by putting it before the function call, like this:
 * If `binary` is `true`, also print the binary machine code for each instruction precedented by an abbreviated address.
 * If `dump_module` is `false`, do not print metadata such as rodata or directives.
 
-See also: [`code_native`](@ref), [`@code_llvm`](@ref), [`@code_typed`](@ref) and [`@code_lowered`](@ref)
+See also: [`code_native`](@ref), [`@code_llvm`](@ref), [`@code_typed`](@ref), [`@code_lowered`](@ref), [`@code_warntype`](@ref).
 """
 :@code_native
 


### PR DESCRIPTION
I could only remember one of these the other day and the docstring didn't help me, so I've added a "See also:" line with all(?) its exported cousins to the ones in InteractiveUtils.jl