### PR TITLE
Make `min/max` use `isless` even for `Real`

### DIFF
--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -532,8 +532,8 @@ min(x::Real) = x
 max(x::Real) = x
 minmax(x::Real) = (x, x)
 
-max(x::T, y::T) where {T<:Real} = ifelse(y < x, x, y)
-min(x::T, y::T) where {T<:Real} = ifelse(y < x, y, x)
-minmax(x::T, y::T) where {T<:Real} = y < x ? (y, x) : (x, y)
+max(x::T, y::T) where {T<:Real} = ifelse(isless(y, x), x, y)
+min(x::T, y::T) where {T<:Real} = ifelse(isless(y, x), y, x)
+minmax(x::T, y::T) where {T<:Real} = isless(y, x) ? (y, x) : (x, y)
 
 flipsign(x::T, y::T) where {T<:Signed} = no_op_err("flipsign", T)


### PR DESCRIPTION
In #23155, we made the generic `min/max` use `isless` rather than `<`. This is motivated by the observation that the implementation

    min(a, b) = cmp(a, b) ? a : b

implies that `cmp` satisfies the same properties as `isless` (either `cmp(a, b)` in which case we return `a`, otherwise either `cmp(b, a)` or they are equal, in which case returning `b` is correct).

However, this is not true for `Real` types, including AbstractFloat (due to `NaN`). Yet currently the default for `Real` uses `<`.

Part of the motivation here is that many packages seem to subtype `Real` when, theoretically, perhaps they shouldn't. Prominent examples include `IntervalArithmetic.Interval` and `ForwardDiff.Dual`. An example using intervals that would fail is the following: `min(1..3, 2..4)`: the two intervals have non-empty intersection, so it's not/shouldn't be true that `1..3 < 2..4`, in which case `2..4` would be returned (which is wrong by any measure). 

To be honest, I don't expect this to be mergeable, as I bet it is breaking. But I think it's worth seeing if it passes tests (I haven't tried locally) and perhaps a PkgEval run.