### PR TITLE
Debub doc html preview artifact upload

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -391,6 +391,7 @@ function Documenter.Writers.HTMLWriter.expand_versions(dir::String, v::Versions)
 end
 
 if "deploy" in ARGS
+    @info "deploydocs" pwd() get(ENV, "DOCUMENTER_ARCHIVE", nothing)
     deploydocs(
         repo = "github.com/JuliaLang/docs.julialang.org.git",
         deploy_config = BuildBotConfig(),


### PR DESCRIPTION
HTML docs preview tarballs should be uploaded
https://github.com/IanButterworth/julia-buildkite/blob/4b6932992f7985af71fc3f73af77abf4d25bd146/pipelines/main/misc/doctest.yml#L43

but it's broken
https://buildkite.com/julialang/julia-master/builds/27817#018aa4fc-216f-4a69-aa9a-00b364da7b78/787-788