### PR TITLE
tweak the error printed for `PrecompileError` to indicate that it doesn't have to be due to `__precompile__(false)`

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1692,7 +1692,7 @@ end
 # we throw PrecompilableError when a module doesn't want to be precompiled
 struct PrecompilableError <: Exception end
 function show(io::IO, ex::PrecompilableError)
-    print(io, "Declaring __precompile__(false) is not allowed in files that are being precompiled.")
+    print(io, "Error when precompiling module, potentially caused by a __precompile__(false) declaration in the module.")
 end
 precompilableerror(ex::PrecompilableError) = true
 precompilableerror(ex::WrappedException) = precompilableerror(ex.error)


### PR DESCRIPTION
This error pops up here and there but the root cause is never due to  `__precompile__(false)`