### PR TITLE
Add environment variable to force the use of the fallback repl

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -411,7 +411,9 @@ global active_repl
 function run_main_repl(interactive::Bool, quiet::Bool, banner::Symbol, history_file::Bool, color_set::Bool)
     load_InteractiveUtils()
 
-    if interactive && isassigned(REPL_MODULE_REF)
+    fallback_repl = get_bool_env("JULIA_FALLBACK_REPL", false)
+
+    if !fallback_repl && interactive && isassigned(REPL_MODULE_REF)
         invokelatest(REPL_MODULE_REF[]) do REPL
             term_env = get(ENV, "TERM", @static Sys.iswindows() ? "" : "dumb")
             global current_terminfo = load_terminfo(term_env)

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -503,3 +503,7 @@ On debug builds of Julia this is always enabled. Recommended to use with `-g 2`.
 ### `JULIA_LLVM_ARGS`
 
 Arguments to be passed to the LLVM backend.
+
+### `JULIA_FALLBACK_REPL`
+
+Forces the fallback repl instead of REPL.jl.


### PR DESCRIPTION
While working on moving REPL.jl out of base I noticed that the fallback repl
hangs. In order to debug that and to test this code we should allow
`JULIA_FALLBACK_REPL=1 julia` to load the fallback repl even if REPL.jl is
available.
