### PR TITLE
Make `cache_file_entry` more type stable

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1007,7 +1007,6 @@ function cache_file_entry(pkg::PkgId)
         "v$(VERSION.major).$(VERSION.minor)",
         uuid === nothing ? ""       : pkg.name),
         uuid === nothing ? pkg.name : package_slug(uuid)
-    )
 end
 
 function find_all_in_cache_path(pkg::PkgId)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1000,7 +1000,7 @@ function find_source_file(path::AbstractString)
     return isfile(base_path) ? normpath(base_path) : nothing
 end
 
-function cache_file_entry(pkg::PkgId) 
+function cache_file_entry(pkg::PkgId)
     uuid = pkg.uuid
     return joinpath(
         "compiled",

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1000,11 +1000,15 @@ function find_source_file(path::AbstractString)
     return isfile(base_path) ? normpath(base_path) : nothing
 end
 
-cache_file_entry(pkg::PkgId) = joinpath(
-    "compiled",
-    "v$(VERSION.major).$(VERSION.minor)",
-    pkg.uuid === nothing ? ""       : pkg.name),
-    pkg.uuid === nothing ? pkg.name : package_slug(pkg.uuid)
+function cache_file_entry(pkg::PkgId) 
+    uuid = pkg.uuid
+    return joinpath(
+        "compiled",
+        "v$(VERSION.major).$(VERSION.minor)",
+        uuid === nothing ? ""       : pkg.name),
+        uuid === nothing ? pkg.name : package_slug(uuid)
+    )
+end
 
 function find_all_in_cache_path(pkg::PkgId)
     paths = String[]


### PR DESCRIPTION
According to JET.jl, the type inference was not able to tell the type of `pkg.uuid` in the `pkg.uuid !== nothing` branch. Moving this to a local variable first should resolve that problem. 