### PR TITLE
feat(Sockets): add keepalive method

### DIFF
--- a/stdlib/Sockets/src/Sockets.jl
+++ b/stdlib/Sockets/src/Sockets.jl
@@ -603,9 +603,9 @@ end
 """
     keepalive(sock::Union{TCPServer, TCPSocket}, enable::Bool, delay::Int)
 
-Enable / disable TCP keep-alive. `delay` is the initial delay in seconds, ignored when `enable`` is false.
+Enable / disable TCP keep-alive. `delay` is the initial delay in seconds, ignored when `enable` is false.
 After delay has been reached, 10 successive probes, each spaced 1 second from the previous one, will still happen.
-If the connection is still lost at the end of this procedure, then the handle is destroyed with a UV_ETIMEDOUT error passed to the corresponding callback.
+If the connection is still lost at the end of this procedure, then the handle is destroyed and pending operations are failed with an ETIMEDOUT error.
 
 !!! compat "Julia 1.11"
     This function requires Julia 1.11 or later.
@@ -615,7 +615,7 @@ function keepalive(sock::Union{TCPServer, TCPSocket}, enable::Bool, delay::Int)
     check_open(sock)
     err = ccall(:uv_tcp_keepalive, Cint, (Ptr{Nothing}, Cint, Cuint), sock.handle, Cint(enable), Cint(delay))
     iolock_end()
-    err == 0 || error("cannot $(enable ? "enable" : "disable") keepalive")
+    err == 0 || uv_error("uv_tcp_keepalive: failed to set keepalive on tcp socket", err)
     nothing
 end
 

--- a/stdlib/Sockets/src/Sockets.jl
+++ b/stdlib/Sockets/src/Sockets.jl
@@ -600,6 +600,24 @@ function quickack(sock::Union{TCPServer, TCPSocket}, enable::Bool)
     nothing
 end
 
+"""
+    keepalive(sock::Union{TCPServer, TCPSocket}, enable::Bool, delay::Int)
+
+Enable / disable TCP keep-alive. `delay` is the initial delay in seconds, ignored when `enable`` is false.
+After delay has been reached, 10 successive probes, each spaced 1 second from the previous one, will still happen.
+If the connection is still lost at the end of this procedure, then the handle is destroyed with a UV_ETIMEDOUT error passed to the corresponding callback.
+
+!!! compat "Julia 1.11"
+    This function requires Julia 1.11 or later.
+"""
+function keepalive(sock::Union{TCPServer, TCPSocket}, enable::Bool, delay::Int)
+    iolock_begin()
+    check_open(sock)
+    err = ccall(:uv_tcp_keepalive, Cint, (Ptr{Nothing}, Cint, Cuint), sock.handle, Cint(enable), Cint(delay))
+    iolock_end()
+    err == 0 || error("cannot $(enable ? "enable" : "disable") keepalive")
+    nothing
+end
 
 ##
 

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -555,6 +555,22 @@ end
     end
 end
 
+@testset "keepalive" begin
+    let addr = Sockets.InetAddr(ip"127.0.0.1", 4443)
+        srv = listen(addr)
+        let s = Sockets.TCPSocket()
+            Sockets.connect!(s, addr)
+            @test try
+                Sockets.keepalive(s, true, 120)
+                true
+            catch;
+                false
+            end
+            close(s)
+        end
+    end
+end
+
 @testset "iswritable" begin
     let addr = Sockets.InetAddr(ip"127.0.0.1", 4445)
         srv = listen(addr)


### PR DESCRIPTION
Literally the HTTP.jl's method, in Sockets.jl style. https://github.com/JuliaWeb/HTTP.jl/blob/040df996e608572fee760fc9816376a2d8fe3299/src/ConnectionPool.jl#L389-L397

_Not_ a replacement of https://github.com/JuliaLang/julia/pull/48406 (but they can be combined)