### PR TITLE
define `Random.GLOBAL_RNG = TaskLocalRNG()`

### DIFF
--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -136,11 +136,9 @@ the amount of precomputation, if applicable.
 *types* and *values*, respectively. [`Random.SamplerSimple`](@ref) can be used to store
 pre-computed values without defining extra types for only this purpose.
 """
-Sampler(rng::AbstractRNG, x, r::Repetition=Val(Inf)) = Sampler(typeof_rng(rng), x, r)
+Sampler(rng::AbstractRNG, x, r::Repetition=Val(Inf)) = Sampler(typeof(rng), x, r)
 Sampler(rng::AbstractRNG, ::Type{X}, r::Repetition=Val(Inf)) where {X} =
-    Sampler(typeof_rng(rng), X, r)
-
-typeof_rng(rng::AbstractRNG) = typeof(rng)
+    Sampler(typeof(rng), X, r)
 
 # this method is necessary to prevent rand(rng::AbstractRNG, X) from
 # recursively constructing nested Sampler types.

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -743,31 +743,13 @@ end
         Random.seed!(seed)
         @test Random.GLOBAL_SEED === seed
     end
-    # two separate loops as otherwise we are no sure that the second call (with GLOBAL_RNG)
-    # actually sets GLOBAL_SEED
-    for seed=seeds
-        Random.seed!(Random.GLOBAL_RNG, seed)
-        @test Random.GLOBAL_SEED === seed
+
+    for ii = 1:8
+        iseven(ii) ? Random.seed!(nothing) : Random.seed!()
+        push!(seeds, Random.GLOBAL_SEED)
+        @test Random.GLOBAL_SEED isa UInt128 # could change, but must not be nothing
     end
-
-    Random.seed!(nothing)
-    seed1 = Random.GLOBAL_SEED
-    @test seed1 isa Vector{UInt64} # could change, but must not be nothing
-
-    Random.seed!(Random.GLOBAL_RNG, nothing)
-    seed2 = Random.GLOBAL_SEED
-    @test seed2 isa Vector{UInt64}
-    @test seed2 != seed1
-
-    Random.seed!()
-    seed3 = Random.GLOBAL_SEED
-    @test seed3 isa Vector{UInt64}
-    @test seed3 != seed2
-
-    Random.seed!(Random.GLOBAL_RNG)
-    seed4 = Random.GLOBAL_SEED
-    @test seed4 isa Vector{UInt64}
-    @test seed4 != seed3
+    @test allunique(seeds)
 end
 
 struct RandomStruct23964 end
@@ -821,9 +803,9 @@ end
 end
 
 @testset "GLOBAL_RNG" begin
+    @test VERSION < v"2" # deprecate this in v2 (GLOBAL_RNG must go)
     local GLOBAL_RNG = Random.GLOBAL_RNG
     local LOCAL_RNG = Random.default_rng()
-    @test VERSION < v"2" # deprecate this in v2
 
     @test Random.seed!(GLOBAL_RNG, nothing) === LOCAL_RNG
     @test Random.seed!(GLOBAL_RNG, UInt32[0]) === LOCAL_RNG

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1589,11 +1589,10 @@ function testset_beginend_call(args, tests, source)
         # we reproduce the logic of guardseed, but this function
         # cannot be used as it changes slightly the semantic of @testset,
         # by wrapping the body in a function
-        local RNG = default_rng()
-        local oldrng = copy(RNG)
+        local oldrng = copy(default_rng())
         local oldseed = Random.GLOBAL_SEED
         try
-            # RNG is re-seeded with its own seed to ease reproduce a failed test
+            # default RNG is re-seeded with its own seed to ease reproduce a failed test
             Random.seed!(Random.GLOBAL_SEED)
             let
                 $(esc(tests))
@@ -1609,7 +1608,7 @@ function testset_beginend_call(args, tests, source)
                 record(ts, Error(:nontest_error, Expr(:tuple), err, Base.current_exceptions(), $(QuoteNode(source))))
             end
         finally
-            copy!(RNG, oldrng)
+            copy!(default_rng(), oldrng)
             Random.set_global_seed!(oldseed)
             pop_testset()
             ret = finish(ts)
@@ -1677,7 +1676,7 @@ function testset_forloop(args, testloop, source)
             finish_errored = false
 
             # it's 1000 times faster to copy from tmprng rather than calling Random.seed!
-            copy!(RNG, tmprng)
+            copy!(default_rng(), tmprng)
 
         end
         ts = if ($testsettype === $DefaultTestSet) && $(isa(source, LineNumberNode))
@@ -1704,11 +1703,10 @@ function testset_forloop(args, testloop, source)
         local first_iteration = true
         local ts
         local finish_errored = false
-        local RNG = default_rng()
-        local oldrng = copy(RNG)
+        local oldrng = copy(default_rng())
         local oldseed = Random.GLOBAL_SEED
         Random.seed!(Random.GLOBAL_SEED)
-        local tmprng = copy(RNG)
+        local tmprng = copy(default_rng())
         try
             let
                 $(Expr(:for, Expr(:block, [esc(v) for v in loopvars]...), blk))
@@ -1719,7 +1717,7 @@ function testset_forloop(args, testloop, source)
                 pop_testset()
                 push!(arr, finish(ts))
             end
-            copy!(RNG, oldrng)
+            copy!(default_rng(), oldrng)
             Random.set_global_seed!(oldseed)
         end
         arr

--- a/stdlib/UUIDs/src/UUIDs.jl
+++ b/stdlib/UUIDs/src/UUIDs.jl
@@ -42,14 +42,14 @@ Generates a version 1 (time-based) universally unique identifier (UUID), as spec
 by RFC 4122. Note that the Node ID is randomly generated (does not identify the host)
 according to section 4.5 of the RFC.
 
-The default rng used by `uuid1` is not `GLOBAL_RNG` and every invocation of `uuid1()` without
+The default rng used by `uuid1` is not `Random.default_rng()` and every invocation of `uuid1()` without
 an argument should be expected to return a unique identifier. Importantly, the outputs of
 `uuid1` do not repeat even when `Random.seed!(seed)` is called. Currently (as of Julia 1.6),
 `uuid1` uses `Random.RandomDevice` as the default rng. However, this is an implementation
 detail that may change in the future.
 
 !!! compat "Julia 1.6"
-    The output of `uuid1` does not depend on `GLOBAL_RNG` as of Julia 1.6.
+    The output of `uuid1` does not depend on `Random.default_rng()` as of Julia 1.6.
 
 # Examples
 ```jldoctest; filter = r"[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}"
@@ -90,14 +90,14 @@ end
 Generates a version 4 (random or pseudo-random) universally unique identifier (UUID),
 as specified by RFC 4122.
 
-The default rng used by `uuid4` is not `GLOBAL_RNG` and every invocation of `uuid4()` without
+The default rng used by `uuid4` is not `Random.default_rng()` and every invocation of `uuid4()` without
 an argument should be expected to return a unique identifier. Importantly, the outputs of
 `uuid4` do not repeat even when `Random.seed!(seed)` is called. Currently (as of Julia 1.6),
 `uuid4` uses `Random.RandomDevice` as the default rng. However, this is an implementation
 detail that may change in the future.
 
 !!! compat "Julia 1.6"
-    The output of `uuid4` does not depend on `GLOBAL_RNG` as of Julia 1.6.
+    The output of `uuid4` does not depend on `Random.default_rng()` as of Julia 1.6.
 
 # Examples
 ```jldoctest

--- a/stdlib/UUIDs/test/runtests.jl
+++ b/stdlib/UUIDs/test/runtests.jl
@@ -56,10 +56,10 @@ for (init_uuid, next_uuid) in standard_namespace_uuids
 end
 
 # Issue 35860
-Random.seed!(Random.GLOBAL_RNG, 10)
+Random.seed!(Random.default_rng(), 10)
 u1 = uuid1()
 u4 = uuid4()
-Random.seed!(Random.GLOBAL_RNG, 10)
+Random.seed!(Random.default_rng(), 10)
 @test u1 != uuid1()
 @test u4 != uuid4()
 


### PR DESCRIPTION
`GLOBAL_RNG` is a relic from pre-v1.3 when our global RNG was not thread-safe:
```
const GLOBAL_RNG = MersenneTwister()
```

`GLOBAL_RNG` was never really specified, but was referred to in docstrings (of `rand` etc.), and people had to use it in packages in order to provide a default RNG to their functions. So we have to keep defining `Random.GLOBAL_RNG` for the time being.

In v1.3, we didn't have anymore a unique global RNG, but instead one per thread; in order to keep code using `GLOBAL_RNG` working, we got this new definition as a clever hack:
```
struct _GLOBAL_RNG <: AbstractRNG end
const GLOBAL_RNG = _GLOBAL_RNG()
```
I.e. `GLOBAL_RNG` is just a handle, which refers to the actual threaded-RNG when passed to `rand` functions. This entails defining most function taking a `default_rng()` to also accept `_GLOBAL_RNG`. See #41123, and #41235 which is not even merged.

But since v1.7, we have `Random.default_rng()` (our now official way to refer to the default RNG) returning `TaskLocalRNG()`, which is itself a "handle" (singleton). So we can as well redefine `GLOBAL_RNG` to be `TaskLocalRNG()` instead of `_GLOBAL_RNG()`, with the advantage that all the relevant methods are already defined for `TaskLocalRNG`.

The only expected difference in behavior is `seed!(GLOBAL_RNG, seed)`, which previously would update `Random.GLOBAL_SEED` (a hack used by `@testset`), but now is equivalent to `seed!(TaskLocalRNG(), seed)`, which doesn't update this global seed. This precise behavior was never documented (`GLOBAL_SEED` is purely internal), so this should be fine.