### PR TITLE
inference: handle `Vararg` in `abstract_call_unionall` for `argtypes` computed by `abstract_apply`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1858,7 +1858,12 @@ function abstract_call_unionall(interp::AbstractInterpreter, argtypes::Vector{An
         a2 = argtypes[2]
         a3 = argtypes[3]
         ⊑ᵢ = ⊑(typeinf_lattice(interp))
-        nothrow = a2 ⊑ᵢ TypeVar && (a3 ⊑ᵢ Type || a3 ⊑ᵢ TypeVar)
+        if isvarargtype(a3)
+            a3 = unwrapva(a3)
+            nothrow = false
+        else
+            nothrow = a2 ⊑ᵢ TypeVar && (a3 ⊑ᵢ Type || a3 ⊑ᵢ TypeVar)
+        end
         if isa(a3, Const)
             body = a3.val
         elseif isType(a3)
@@ -2252,7 +2257,6 @@ function abstract_eval_value_expr(interp::AbstractInterpreter, e::Expr, vtypes::
     end
     return Any
 end
-
 
 function abstract_eval_value(interp::AbstractInterpreter, @nospecialize(e), vtypes::Union{VarTable,Nothing}, sv::AbsIntState)
     if isa(e, Expr)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5,7 +5,7 @@ import Core.Compiler: Const, Conditional, ⊑, ReturnNode, GotoIfNot
 isdispatchelem(@nospecialize x) = !isa(x, Type) || Core.Compiler.isdispatchelem(x)
 
 using Random, Core.IR
-using InteractiveUtils: code_llvm
+using InteractiveUtils
 
 include("irutils.jl")
 
@@ -5230,3 +5230,8 @@ end |> only == Val{false}
 @test Base.return_types((Bool,)) do b
     Val(Core.Intrinsics.or_int(true, b))
 end |> only == Val{true}
+
+# https://github.com/JuliaLang/julia/issues/51310
+@test code_typed() do
+    b{c} = d...
+end |> only |> first isa Core.CodeInfo


### PR DESCRIPTION
This commit adds special handling for `Vararg` types that may appear at the end of `argtypes`, as computed by `abstract_apply`. Even though PR #42583 has ensured that `Vararg` and `TypeVar` should never appear within the abstract state, they can still be part of `argtypes`. As a result, this kind of special handling is still necessary. It remains an open question whether we can refactor `abstract_apply` to prevent `Vararg`s from appearing in `argtypes` in the first place.
