### PR TITLE
call Pkg precompile hook in latest world

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1961,7 +1961,7 @@ function _require(pkg::PkgId, env=nothing)
                     pkg_precompile_attempted = true
                     unlock(require_lock)
                     try
-                        PKG_PRECOMPILE_HOOK[](pkg.name, _from_loading = true)
+                        @invokelatest PKG_PRECOMPILE_HOOK[](pkg.name, _from_loading = true)
                     finally
                         lock(require_lock)
                     end


### PR DESCRIPTION
Should fix https://github.com/JuliaLang/julia/issues/51280.

@svilupp, could you check this?