### PR TITLE
Mention allocation of `R` factor from QR

### DIFF
--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -367,7 +367,7 @@ The individual components of the decomposition `F` can be retrieved via property
  - `F.P`: the permutation matrix of the pivot ([`QRPivoted`](@ref) only)
 
 !!! note
-    Each reference to the upper triangular factor via `F.R` necessarily allocates a new array.
+    Each reference to the upper triangular factor via `F.R` allocates a new array.
     It is therefore advisable to cache that array before subsequent repeated (elementwise)
     access, for instance.
 

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -368,8 +368,8 @@ The individual components of the decomposition `F` can be retrieved via property
 
 !!! note
     Each reference to the upper triangular factor via `F.R` allocates a new array.
-    It is therefore advisable to cache that array before subsequent repeated (elementwise)
-    access, for instance.
+    It is therefore advisable to cache that array, say, by `R = F.R` and continue working
+    with `R`.
 
 Iterating the decomposition produces the components `Q`, `R`, and if extant `p`.
 

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -366,6 +366,11 @@ The individual components of the decomposition `F` can be retrieved via property
  - `F.p`: the permutation vector of the pivot ([`QRPivoted`](@ref) only)
  - `F.P`: the permutation matrix of the pivot ([`QRPivoted`](@ref) only)
 
+!!! note
+    Each reference to the upper triangular factor via `F.R` necessarily allocates a new array.
+    It is therefore advisable to cache that array before subsequent repeated (elementwise)
+    access, for instance.
+
 Iterating the decomposition produces the components `Q`, `R`, and if extant `p`.
 
 The following functions are available for the `QR` objects: [`inv`](@ref), [`size`](@ref),


### PR DESCRIPTION
This is my (non-native speaker) take at documenting that `qr(A).R` allocates and hence should be cached before access/manipulation.

Closes JuliaLang/LinearAlgebra.jl#989.