### PR TITLE
remove extra zero byte store in `jl_readuntil`

### DIFF
--- a/src/sys.c
+++ b/src/sys.c
@@ -304,7 +304,6 @@ JL_DLLEXPORT jl_value_t *jl_readuntil(ios_t *s, uint8_t delim, uint8_t str, uint
         else {
             a->length = n;
             a->nrows = n;
-            ((char*)a->data)[n] = '\0';
         }
         if (str) {
             JL_GC_PUSH1(&a);


### PR DESCRIPTION
Since 3b1bbe30e53c487929c47d2a1facbc6173848e6c we no longer do this for arrays, only strings.

Fixes a crash when using `readline`.