### PR TITLE
Remove fallback that assigns a module to inlined frames.

### DIFF
--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -206,7 +206,6 @@ Base.@constprop :none function lookup(pointer::Ptr{Cvoid})
             elseif miroots !== nothing
                 linfo = lookup_inline_frame_info(func, file, miroots)
             end
-            linfo = linfo === nothing ? parentmodule(res[i + 1]) : linfo # e.g. `macro expansion`
         end
         res[i] = StackFrame(func, file, linenum, linfo, info[5]::Bool, info[6]::Bool, pointer)
     end


### PR DESCRIPTION
The work I did in #41099 introduced code which, if method information could not be found for an inlined frame, would fall back to use the module of the next-higher stack frame. This often worked there because the only frames that would not be assigned a module at this point would be e.g., `macro expansion` frames.

However, due to the performance impact of the way method roots are currently encoded, the extra method roots were removed in #50546.

The result is that inlined frames in 1.10 and beyond are being assigned a potentially incorrect module, rather than being left blank.

This PR removes the fallback and fixes the issue.

Please mark for 1.10 backport?


Example:
```
@btime plot([1 2 3], seriestype = :blah)

...
 [13] #invokelatest#2
    @ BenchmarkTools ./essentials.jl:901 [inlined]
 [14] invokelatest
    @ BenchmarkTools ./essentials.jl:896 [inlined]
...

```