### PR TITLE
clean up identifiers defined in `Main`

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -261,8 +261,8 @@ function exec_options(opts)
     distributed_mode = (opts.worker == 1) || (opts.nprocs > 0) || (opts.machine_file != C_NULL)
     if distributed_mode
         let Distributed = require(PkgId(UUID((0x8ba89e20_285c_5b6f, 0x9357_94700520ee1b)), "Distributed"))
-            Core.eval(Main, :(const Distributed = $Distributed))
-            Core.eval(Main, :(using .Distributed))
+            Core.eval(MainInclude, :(const Distributed = $Distributed))
+            Core.eval(Main, :(using Base.MainInclude.Distributed))
         end
 
         invokelatest(Main.Distributed.process_opts, opts)
@@ -380,19 +380,18 @@ _atreplinit(repl) = invokelatest(__atreplinit, repl)
 
 function load_InteractiveUtils(mod::Module=Main)
     # load interactive-only libraries
-    if !isdefined(mod, :InteractiveUtils)
+    if !isdefined(MainInclude, :InteractiveUtils)
         try
             let InteractiveUtils = require(PkgId(UUID(0xb77e0a4c_d291_57a0_90e8_8db25a27a240), "InteractiveUtils"))
-                Core.eval(mod, :(const InteractiveUtils = $InteractiveUtils))
-                Core.eval(mod, :(using .InteractiveUtils))
-                return InteractiveUtils
+                Core.eval(MainInclude, :(const InteractiveUtils = $InteractiveUtils))
             end
         catch ex
             @warn "Failed to import InteractiveUtils into module $mod" exception=(ex, catch_backtrace())
+            return nothing
         end
-        return nothing
     end
-    return getfield(mod, :InteractiveUtils)
+    Core.eval(mod, :(using Base.MainInclude.InteractiveUtils))
+    return MainInclude.InteractiveUtils
 end
 
 function load_REPL()
@@ -511,10 +510,6 @@ A variable referring to the last thrown errors, automatically imported to the in
 The thrown errors are collected in a stack of exceptions.
 """
 global err = nothing
-
-# weakly exposes ans and err variables to Main
-export ans, err
-
 end
 
 """

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -4,10 +4,6 @@ Core.include(Main, "Base.jl")
 
 using .Base
 
-# Set up Main module
-using Base.MainInclude # ans, err, and sometimes Out
-import Base.MainInclude: eval, include
-
 # Ensure this file is also tracked
 pushfirst!(Base._included_files, (@__MODULE__, abspath(@__FILE__)))
 
@@ -78,7 +74,10 @@ let
     empty!(LOAD_PATH)
     Base.init_load_path() # want to be able to find external packages in userimg.jl
 
+    # Set up Main module
     ccall(:jl_clear_implicit_imports, Cvoid, (Any,), Main)
+    eval(Main, :(using Base.MainInclude: eval, include, ans, err))
+
     tot_time_userimg = @elapsed (isfile("userimg.jl") && Base.include(Main, "userimg.jl"))
 
     tot_time_base = (Base.end_base_include - Base.start_base_include) * 10.0^(-9)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1490,8 +1490,8 @@ function capture_result(n::Ref{Int}, @nospecialize(x))
     mod = Base.MainInclude
     if !isdefined(mod, :Out)
         @eval mod global Out
-        @eval mod export Out
         setglobal!(mod, :Out, Dict{Int, Any}())
+        @eval Main using Base.MainInclude: Out
     end
     if x !== getglobal(mod, :Out) && x !== nothing # remove this?
         getglobal(mod, :Out)[n] = x


### PR DESCRIPTION
Loaded packages do not need explicit bindings, and the name `MainInclude` does not need to be visible.

I noticed that `Main` tab completes to `MainInclude`, which is not great since it's an implementation detail. It's also a bit messy that `InteractiveUtils` appears in `varinfo()`. This is not necessary to access its functionality.

The only behavior change from this is that adding a method to `include` or `eval` in Main used to work since these were explicitly imported. This now gives the "must be explicitly imported to be extended" error, which I consider a big improvement. Nobody should be doing that anyway.