### PR TITLE
Random: allow negative seeds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,8 @@ Standard library changes
 
 #### Random
 
+* When seeding RNGs provided by `Random`, negative integer seeds can now be used ([#51416]).
+
 #### REPL
 
 * Tab complete hints now show in lighter text while typing in the repl. To disable

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -303,15 +303,12 @@ This is an internal function, subject to change.
 """
 function make_seed(n::Integer)
     neg = signbit(n)
-    n = abs(n) # n can still be negative, e.g. n == typemin(Int)
-    if n < 0
-        # we assume that `unsigned` can be called on integers `n` for which `abs(n)` is
-        # negative; `unsigned` is necessary for `n & 0xffffffff` below, which would
-        # otherwise propagate the sign bit of `n` for types smaller than UInt32
-        n = unsigned(n)
+    if neg
+        n = ~n
     end
+    @assert n >= 0
     seed = UInt32[]
-    # we directly encode the bit pattern of `abs(n)` into the resulting vector `seed`;
+    # we directly encode the bit pattern of `n` into the resulting vector `seed`;
     # to greatly limit breaking the streams of random numbers, we encode the sign bit
     # as the upper bit of `seed[end]` (i.e. for most positive seeds, `make_seed` returns
     # the same vector as when we didn't encode the sign bit)
@@ -333,7 +330,7 @@ function from_seed(a::Vector{UInt32})::BigInt
     neg = !iszero(a[end] & 0x80000000)
     seed = sum((i == length(a) ? a[i] & 0x7fffffff : a[i]) * big(2)^(32*(i-1))
                for i in 1:length(a))
-    neg ? -seed : seed
+    neg ? ~seed : seed
 end
 
 

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -394,6 +394,8 @@ sequence of numbers if and only if a `seed` is provided. Some RNGs
 don't accept a seed, like `RandomDevice`.
 After the call to `seed!`, `rng` is equivalent to a newly created
 object initialized with the same seed.
+The types of accepted seeds depend on the type of `rng`, but in general,
+integer seeds should work.
 
 If `rng` is not specified, it defaults to seeding the state of the
 shared task-local generator.

--- a/stdlib/Random/src/Xoshiro.jl
+++ b/stdlib/Random/src/Xoshiro.jl
@@ -21,6 +21,13 @@ multiple interleaved xoshiro instances).
 The virtual PRNGs are discarded once the bulk request has been serviced (and should cause
 no heap allocations).
 
+The `seed` may be an integer or a vector of `UInt32` integers.
+If no seed is provided, a randomly generated one is created (using entropy from the system).
+See the [`seed!`](@ref) function for reseeding an already existing `Xoshiro` object.
+
+!!! compat "Julia 1.11"
+    Passing a negative integer seed requires at least Julia 1.11.
+
 # Examples
 ```jldoctest
 julia> using Random
@@ -191,6 +198,12 @@ endianness and possibly word size.
 
 Using or seeding the RNG of any other task than the one returned by `current_task()`
 is undefined behavior: it will work most of the time, and may sometimes fail silently.
+
+When seeding `TaskLocalRNG()` with [`seed!`](@ref), the passed seed, if any,
+may be an integer or a vector of `UInt32` integers.
+
+!!! compat "Julia 1.11"
+    Seeding `TaskLocalRNG()` with a negative integer seed requires at least Julia 1.11.
 """
 struct TaskLocalRNG <: AbstractRNG end
 TaskLocalRNG(::Nothing) = TaskLocalRNG()

--- a/stdlib/Random/src/Xoshiro.jl
+++ b/stdlib/Random/src/Xoshiro.jl
@@ -4,7 +4,7 @@
 # Lots of implementation is shared with TaskLocalRNG
 
 """
-    Xoshiro(seed)
+    Xoshiro(seed::Integer)
     Xoshiro()
 
 Xoshiro256++ is a fast pseudorandom number generator described by David Blackman and
@@ -21,7 +21,6 @@ multiple interleaved xoshiro instances).
 The virtual PRNGs are discarded once the bulk request has been serviced (and should cause
 no heap allocations).
 
-The `seed` may be an integer or a vector of `UInt32` integers.
 If no seed is provided, a randomly generated one is created (using entropy from the system).
 See the [`seed!`](@ref) function for reseeding an already existing `Xoshiro` object.
 
@@ -200,7 +199,7 @@ Using or seeding the RNG of any other task than the one returned by `current_tas
 is undefined behavior: it will work most of the time, and may sometimes fail silently.
 
 When seeding `TaskLocalRNG()` with [`seed!`](@ref), the passed seed, if any,
-may be an integer or a vector of `UInt32` integers.
+may be any integer.
 
 !!! compat "Julia 1.11"
     Seeding `TaskLocalRNG()` with a negative integer seed requires at least Julia 1.11.


### PR DESCRIPTION
Alternative to #46190, see that PR for background. There isn't a strong use-case for accepting negative seeds, but probably many people tried something like `seed = rand(Int); seed!(rng, seed)` and saw it failing. As it's easy to support, let's do it.

This might "break" some random streams, those for which the upper bit of `make_seed(seed)[end]` was set, so it's rare.