### PR TITLE
Excise Random from the system image

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -508,6 +508,10 @@ include("docs/basedocs.jl")
 # Documentation -- should always be included last in sysimg.
 include("docs/Docs.jl")
 using .Docs
+
+# excised stdlib stubs, needs to be after docs
+include("stubs.jl")
+
 if isdefined(Core, :Compiler) && is_primary_base_module
     Docs.loaddocs(Core.Compiler.CoreDocs.DOCS)
 end
@@ -662,7 +666,7 @@ end
 # enable threads support
 @eval PCRE PCRE_COMPILE_LOCK = Threads.SpinLock()
 
-end
+end # is_primary_base_module
 
 # Ensure this file is also tracked
 @assert !isassigned(_included_files, 1)

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -377,10 +377,6 @@ using .CoreLogging
 
 include("env.jl")
 
-# functions defined in Random
-function rand end
-function randn end
-
 # I/O
 include("libuv.jl")
 include("asyncevent.jl")

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -3,6 +3,7 @@
 # Tracking of newly-inferred CodeInstances during precompilation
 const track_newly_inferred = RefValue{Bool}(false)
 const newly_inferred = CodeInstance[]
+const newly_deleted = Method[]
 
 # build (and start inferring) the inference frame for the top-level MethodInstance
 function typeinf(interp::AbstractInterpreter, result::InferenceResult, cache_mode::Symbol)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -396,4 +396,9 @@ end
 @deprecate permute!!(a, p::AbstractVector{<:Integer}) permute!(a, p) false
 @deprecate invpermute!!(a, p::AbstractVector{<:Integer}) invpermute!(a, p) false
 
+# functions defined in Random
+function rand end
+function randn end
+export rand, randn
+
 # END 1.11 deprecations

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -995,10 +995,6 @@ export
     unsafe_store!,
     unsafe_swap!,
 
-# implemented in Random module
-    rand,
-    randn,
-
 # Macros
     # parser internal
     @__FILE__,

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2414,6 +2414,7 @@ function include_package_for_output(pkg::PkgId, input::String, depot_path::Vecto
     end
 
     ccall(:jl_set_newly_inferred, Cvoid, (Any,), Core.Compiler.newly_inferred)
+    ccall(:jl_set_newly_deleted, Cvoid, (Any,), Core.Compiler.newly_deleted)
     Core.Compiler.track_newly_inferred.x = true
     try
         Base.include(Base.__toplevel__, input)

--- a/base/stubs.jl
+++ b/base/stubs.jl
@@ -1,0 +1,44 @@
+module Stubs
+
+module Random
+    let Random_PkgID = Base.PkgId(Base.UUID(0x9a3f8284_a2c9_5f02_9a11_845980a1fd5c), "Random")
+        RANDOM_MODULE_REF = Ref{Module}()
+
+        global delay_initialize
+        function delay_initialize()
+            if !isassigned(RANDOM_MODULE_REF)
+                RANDOM_MODULE_REF[] = Base.require(Random_PkgID)
+            end
+            return ccall(:jl_module_world, Csize_t, (Any,), RANDOM_MODULE_REF[])
+        end
+    end
+
+    import Base: rand, randn
+    function rand(args...)
+        Base.invoke_in_world(delay_initialize(), rand, args...)
+    end
+
+    function randn(args...)
+        Base.invoke_in_world(delay_initialize(), randn, args...)
+    end
+end
+
+Base.Docs.getdoc(::typeof(Base.rand)) = (Random.delay_initialize(); nothing)
+Base.Docs.getdoc(::typeof(Base.randn)) = (Random.delay_initialize(); nothing)
+
+function delete_stubs(mod)
+    for name in names(mod, imported=true)
+        if name == :delay_initialize
+            continue
+        end
+        obj = getglobal(mod, name)
+        if obj isa Function
+            ms = Base.methods(obj, mod)
+            for m in ms
+                Base.delete_method(m)
+            end
+        end
+    end
+end
+
+end

--- a/base/stubs.jl
+++ b/base/stubs.jl
@@ -1,6 +1,21 @@
 module Stubs
 
+macro stub(old, mod)
+    dep_message = """: `$old` has been moved to the standard library package `$mod`.
+                        Add `using $mod` to your imports."""
+    return Expr(:toplevel,
+        quote
+            import Base: $old
+            function $(esc(old))(args...)
+                Base.depwarn($dep_message, $(QuoteNode(old)))
+                Base.invoke_in_world($(esc(:delay_initialize))(), $(esc(old)), args...)
+            end
+            Base.Docs.getdoc(::typeof($(esc(old)))) = ($(esc(:delay_initialize))(); nothing)
+        end)
+end
+
 module Random
+    import ..Stubs: @stub
     let Random_PkgID = Base.PkgId(Base.UUID(0x9a3f8284_a2c9_5f02_9a11_845980a1fd5c), "Random")
         RANDOM_MODULE_REF = Ref{Module}()
 
@@ -12,19 +27,9 @@ module Random
             return ccall(:jl_module_world, Csize_t, (Any,), RANDOM_MODULE_REF[])
         end
     end
-
-    import Base: rand, randn
-    function rand(args...)
-        Base.invoke_in_world(delay_initialize(), rand, args...)
-    end
-
-    function randn(args...)
-        Base.invoke_in_world(delay_initialize(), randn, args...)
-    end
+    @stub rand Random
+    @stub randn Random
 end
-
-Base.Docs.getdoc(::typeof(Base.rand)) = (Random.delay_initialize(); nothing)
-Base.Docs.getdoc(::typeof(Base.randn)) = (Random.delay_initialize(); nothing)
 
 function delete_stubs(mod)
     for name in names(mod, imported=true)

--- a/base/stubs.jl
+++ b/base/stubs.jl
@@ -35,7 +35,8 @@ function delete_stubs(mod)
         if obj isa Function
             ms = Base.methods(obj, mod)
             for m in ms
-                Base.delete_method(m)
+                ccall(:jl_push_newly_deleted, Cvoid, (Any,), m)
+                ccall(:jl_method_table_disable_incremental, Cvoid, (Any, Any), Base.get_methodtable(m), m)
             end
         end
     end

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -73,7 +73,6 @@ let
         :FileWatching, # used by loading.jl -- implicit assumption that init runs
         :Libdl, # Transitive through LinAlg
         :Artifacts, # Transitive through LinAlg
-        :SHA, # transitive through Random
         :Sockets, # used by stream.jl
 
         # Transitive through LingAlg
@@ -82,7 +81,6 @@ let
 
         # 1-depth packages
         :LinearAlgebra, # Commits type-piracy and GEMM
-        :Random, # Can't be removed due to rand being exported by Base
     ]
     # PackageCompiler can filter out stdlibs so it can be empty
     maxlen = maximum(textwidth.(string.(stdlibs)); init=0)

--- a/doc/src/devdocs/locks.md
+++ b/doc/src/devdocs/locks.md
@@ -45,6 +45,7 @@ The following is a leaf lock (level 2), and only acquires level 1 locks (safepoi
 >   * Module->lock
 >   * JLDebuginfoPlugin::PluginMutex
 >   * newly_inferred_mutex
+>   * newly_deleted_mutex
 
 The following is a level 3 lock, which can only acquire level 1 or level 2 locks internally:
 

--- a/src/clangsa/GCChecker.cpp
+++ b/src/clangsa/GCChecker.cpp
@@ -1444,7 +1444,8 @@ bool GCChecker::evalCall(const CallEvent &Call, CheckerContext &C) const {
   } else if (name == "JL_GC_PUSH1" || name == "JL_GC_PUSH2" ||
              name == "JL_GC_PUSH3" || name == "JL_GC_PUSH4" ||
              name == "JL_GC_PUSH5" || name == "JL_GC_PUSH6" ||
-             name == "JL_GC_PUSH7" || name == "JL_GC_PUSH8") {
+             name == "JL_GC_PUSH7" || name == "JL_GC_PUSH8" ||
+             name == "JL_GC_PUSH9") {
     ProgramStateRef State = C.getState();
     // Transform slots to roots, transform values to rooted
     unsigned NumArgs = CE->getNumArgs();

--- a/src/init.c
+++ b/src/init.c
@@ -718,6 +718,7 @@ static void jl_set_io_wait(int v)
 extern jl_mutex_t jl_modules_mutex;
 extern jl_mutex_t precomp_statement_out_lock;
 extern jl_mutex_t newly_inferred_mutex;
+extern jl_mutex_t newly_deleted_mutex;
 extern jl_mutex_t global_roots_lock;
 extern jl_mutex_t profile_show_peek_cond_lock;
 
@@ -736,6 +737,7 @@ static void init_global_mutexes(void) {
     JL_MUTEX_INIT(&jl_modules_mutex, "jl_modules_mutex");
     JL_MUTEX_INIT(&precomp_statement_out_lock, "precomp_statement_out_lock");
     JL_MUTEX_INIT(&newly_inferred_mutex, "newly_inferred_mutex");
+    JL_MUTEX_INIT(&newly_deleted_mutex, "newly_deleted_mutex");
     JL_MUTEX_INIT(&global_roots_lock, "global_roots_lock");
     JL_MUTEX_INIT(&jl_codegen_lock, "jl_codegen_lock");
     JL_MUTEX_INIT(&typecache_lock, "typecache_lock");

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -346,6 +346,7 @@
     XX(jl_new_method_table) \
     XX(jl_new_method_uninit) \
     XX(jl_new_module) \
+    XX(jl_module_world) \
     XX(jl_new_primitivetype) \
     XX(jl_new_struct) \
     XX(jl_new_structt) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -317,6 +317,7 @@
     XX(jl_method_instance_add_backedge) \
     XX(jl_method_table_add_backedge) \
     XX(jl_method_table_disable) \
+    XX(jl_method_table_disable_incremental) \
     XX(jl_method_table_for) \
     XX(jl_method_table_insert) \
     XX(jl_methtable_lookup) \

--- a/src/julia.h
+++ b/src/julia.h
@@ -1890,6 +1890,7 @@ extern JL_DLLIMPORT jl_module_t *jl_base_module JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_module_t *jl_top_module JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_module_t *jl_libdl_module JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name, jl_module_t *parent);
+JL_DLLEXPORT size_t jl_module_world(jl_module_t *m);
 JL_DLLEXPORT void jl_set_module_nospecialize(jl_module_t *self, int on);
 JL_DLLEXPORT void jl_set_module_optlevel(jl_module_t *self, int lvl);
 JL_DLLEXPORT int jl_get_module_optlevel(jl_module_t *m);

--- a/src/julia.h
+++ b/src/julia.h
@@ -958,6 +958,7 @@ extern void JL_GC_PUSH5(void *, void *, void *, void *, void *)  JL_NOTSAFEPOINT
 extern void JL_GC_PUSH6(void *, void *, void *, void *, void *, void *)  JL_NOTSAFEPOINT;
 extern void JL_GC_PUSH7(void *, void *, void *, void *, void *, void *, void *)  JL_NOTSAFEPOINT;
 extern void JL_GC_PUSH8(void *, void *, void *, void *, void *, void *, void *, void *)  JL_NOTSAFEPOINT;
+extern void JL_GC_PUSH9(void *, void *, void *, void *, void *, void *, void *, void *, void *)  JL_NOTSAFEPOINT;
 extern void _JL_GC_PUSHARGS(jl_value_t **, size_t) JL_NOTSAFEPOINT;
 // This is necessary, because otherwise the analyzer considers this undefined
 // behavior and terminates the exploration
@@ -999,6 +1000,9 @@ extern void JL_GC_POP() JL_NOTSAFEPOINT;
   jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
 #define JL_GC_PUSH8(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)                                     \
   void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH(8), jl_pgcstack, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8}; \
+  jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
+#define JL_GC_PUSH9(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)                                     \
+  void *__gc_stkf[] = {(void*)JL_GC_ENCODE_PUSH(9), jl_pgcstack, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9}; \
   jl_pgcstack = (jl_gcframe_t*)__gc_stkf;
 
 
@@ -2053,6 +2057,9 @@ JL_DLLEXPORT jl_value_t *jl_restore_incremental(const char *fname, jl_array_t *d
 
 JL_DLLEXPORT void jl_set_newly_inferred(jl_value_t *newly_inferred);
 JL_DLLEXPORT void jl_push_newly_inferred(jl_value_t *ci);
+JL_DLLEXPORT void jl_method_table_disable_incremental(jl_methtable_t *mt, jl_method_t *m);
+JL_DLLEXPORT void jl_set_newly_deleted(jl_value_t *newly_deleted);
+JL_DLLEXPORT void jl_push_newly_deleted(jl_value_t *m);
 JL_DLLEXPORT void jl_write_compiler_output(void);
 
 // parsing

--- a/src/module.c
+++ b/src/module.c
@@ -63,6 +63,11 @@ uint32_t jl_module_next_counter(jl_module_t *m)
     return jl_atomic_fetch_add(&m->counter, 1);
 }
 
+JL_DLLEXPORT size_t jl_module_world(jl_module_t *m)
+{
+    return m->primary_world;
+}
+
 JL_DLLEXPORT jl_value_t *jl_f_new_module(jl_sym_t *name, uint8_t std_imports, uint8_t default_names)
 {
     // TODO: should we prohibit this during incremental compilation?

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -103,6 +103,27 @@ JL_DLLEXPORT void jl_push_newly_inferred(jl_value_t* ci)
     JL_UNLOCK(&newly_inferred_mutex);
 }
 
+static jl_array_t *newly_deleted JL_GLOBALLY_ROOTED /*FIXME*/;
+// Mutex for newly_deleted
+jl_mutex_t newly_deleted_mutex;
+
+// Register array of newly-inferred MethodInstances
+// This gets called as the first step of Base.include_package_for_output
+JL_DLLEXPORT void jl_set_newly_deleted(jl_value_t* _newly_deleted)
+{
+    assert(newly_deleted == NULL || jl_is_array(_newly_deleted));
+    newly_deleted = (jl_array_t*) _newly_deleted;
+}
+
+JL_DLLEXPORT void jl_push_newly_deleted(jl_value_t* m)
+{
+    JL_LOCK(&newly_deleted_mutex);
+    size_t end = jl_array_len(newly_deleted);
+    jl_array_grow_end(newly_deleted, 1);
+    jl_array_ptr_set(newly_deleted, end, m);
+    JL_UNLOCK(&newly_deleted_mutex);
+}
+
 
 // compute whether a type references something internal to worklist
 // and thus could not have existed before deserialize
@@ -838,6 +859,19 @@ static void jl_insert_methods(jl_array_t *list)
         jl_methtable_t *mt = jl_method_get_table(meth);
         assert((jl_value_t*)mt != jl_nothing);
         jl_method_table_insert(mt, meth, NULL);
+    }
+}
+
+static void jl_delete_methods(jl_array_t *list)
+{
+    size_t i, l = jl_array_len(list);
+    for (i = 0; i < l; i++) {
+        jl_method_t *meth = (jl_method_t*)jl_array_ptr_ref(list, i);
+        assert(jl_is_method(meth));
+        assert(!meth->is_for_opaque_closure);
+        jl_methtable_t *mt = jl_method_get_table(meth);
+        assert((jl_value_t*)mt != jl_nothing);
+        jl_method_table_disable_incremental(mt, meth);
     }
 }
 

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -31,6 +31,15 @@ export rand!, randn!,
 
 ## general definitions
 
+module Stubs
+    function __init__()
+        # Remove the shim methods
+        if !Base.generating_output()
+            Base.Stubs.delete_stubs(Base.Stubs.Random)
+        end
+    end
+end
+
 """
     AbstractRNG
 

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -31,14 +31,8 @@ export rand!, randn!,
 
 ## general definitions
 
-module Stubs
-    function __init__()
-        # Remove the shim methods
-        if !Base.generating_output()
-            Base.Stubs.delete_stubs(Base.Stubs.Random)
-        end
-    end
-end
+# Remove the shim methods
+Base.Stubs.delete_stubs(Base.Stubs.Random)
 
 """
     AbstractRNG

--- a/stdlib/stdlib.mk
+++ b/stdlib/stdlib.mk
@@ -1,11 +1,11 @@
 STDLIBS_WITHIN_SYSIMG := \
-	Artifacts FileWatching Libdl SHA libblastrampoline_jll OpenBLAS_jll Random \
+	Artifacts FileWatching Libdl libblastrampoline_jll OpenBLAS_jll \
 	LinearAlgebra Sockets
 
 INDEPENDENT_STDLIBS := \
 	ArgTools Base64 CRC32c Dates DelimitedFiles Distributed Downloads Future \
 	InteractiveUtils LazyArtifacts LibGit2 LibCURL Logging Markdown Mmap \
-	NetworkOptions Profile Printf Pkg REPL Serialization SharedArrays SparseArrays \
+	NetworkOptions Profile Printf Pkg Random REPL Serialization SHA SharedArrays SparseArrays \
 	Statistics StyledStrings Tar Test TOML Unicode UUIDs \
 	dSFMT_jll GMP_jll libLLVM_jll LLD_jll LLVMLibUnwind_jll LibUnwind_jll LibUV_jll \
 	LibCURL_jll LibSSH2_jll LibGit2_jll nghttp2_jll  MozillaCACerts_jll MbedTLS_jll \

--- a/test/gc/chunks.jl
+++ b/test/gc/chunks.jl
@@ -1,4 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
+using Random
 
 # MWE from https://github.com/JuliaLang/julia/issues/49501
 N = 1_000_000  # or larger

--- a/test/testhelpers/coverage_file.jl
+++ b/test/testhelpers/coverage_file.jl
@@ -1,4 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
+using Random
 
 function code_coverage_test()
     if rand(1:2) == 3


### PR DESCRIPTION
I am not really a fan of this solution,
but it does work. Preferably this is something one could
express to the method-table so that instead of doing this at init time
in Random, we do it on at top-level and package loading does the deletion
and addition of methods at the same time.

For Random the current solution might be fine, but for LinearAlgebra we do
need a better mechanism.
