### PR TITLE
Display small NTuples as NTuples as well

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1084,7 +1084,7 @@ function show_datatype(io::IO, x::DataType, wheres::Vector{TypeVar}=TypeVar[])
 
     # Print tuple types with homogeneous tails longer than max_n compactly using `NTuple` or `Vararg`
     if istuple
-        max_n = 3
+        max_n = 1
         taillen = 1
         for i in (n-1):-1:1
             if parameters[i] === parameters[n]

--- a/base/show.jl
+++ b/base/show.jl
@@ -1084,7 +1084,7 @@ function show_datatype(io::IO, x::DataType, wheres::Vector{TypeVar}=TypeVar[])
 
     # Print tuple types with homogeneous tails longer than max_n compactly using `NTuple` or `Vararg`
     if istuple
-        max_n = 1
+        max_n = 2
         taillen = 1
         for i in (n-1):-1:1
             if parameters[i] === parameters[n]


### PR DESCRIPTION
The motivation for this is presented in [a discourse post](https://discourse.julialang.org/t/display-ntuples-with-more-than-one-element-as-ntuples-rather-than-tuples/104143).
Currently,
```julia
julia> Tuple{Int, Int, Int}
Tuple{Int64, Int64, Int64}

julia> Tuple{Int, Int, Int, Int}
NTuple{4, Int64}
```
The latter form is much easier to read if the type parameters are long. For example, compare
```julia
julia> T = typeof(Base.IdentityUnitRange(3:4));

julia> Tuple{T,T,T}
Tuple{Base.IdentityUnitRange{UnitRange{Int64}}, Base.IdentityUnitRange{UnitRange{Int64}}, Base.IdentityUnitRange{UnitRange{Int64}}}

julia> Tuple{T,T,T,T}
NTuple{4, Base.IdentityUnitRange{UnitRange{Int64}}}
```

This PR changes the behavior to use the latter form for all `NTuple`s, so after this PR we will have
```julia
julia> Tuple{Int, Int}
NTuple{2, Int64}

julia> T = typeof(Base.IdentityUnitRange(3:4));

julia> Tuple{T,T,T}
NTuple{3, Base.IdentityUnitRange{UnitRange{Int64}}}
```
This feels a bit clunky at first glance for `Tuple{Int, Int}` --- and might take a little getting-used-to --- but an `NTuple` assures homogeneity of parameters which one needs to manually assert otherwise, and secondly, the number of elements and the type parameter are easy to read without having to scan a long list of parameters manually.

The cutoff is also used for the `Vararg` form for tuples with homogeneous tails, which I have less of an opinion about, but perhaps the same applies there as well.