### PR TITLE
set `max_methods = 4` for `merge`

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -285,8 +285,9 @@ end
     return Tuple{Any[ fieldtype(sym_in(names[n], bn) ? b : a, names[n]) for n in 1:length(names) ]...}
 end
 
-@assume_effects :foldable function merge_fallback(@nospecialize(a::NamedTuple), @nospecialize(b::NamedTuple),
-        @nospecialize(an::Tuple{Vararg{Symbol}}), @nospecialize(bn::Tuple{Vararg{Symbol}}))
+@assume_effects :foldable function merge_fallback(a::NamedTuple, b::NamedTuple,
+                                                  an::Tuple{Vararg{Symbol}}, bn::Tuple{Vararg{Symbol}})
+    @nospecialize
     names = merge_names(an, bn)
     types = merge_types(names, typeof(a), typeof(b))
     n = length(names)
@@ -297,6 +298,10 @@ end
     end
     _new_NamedTuple(NamedTuple{names, types}, (A...,))
 end
+
+# This is `Experimental.@max_methods 4 function merge end`, which is not
+# defined at this point in bootstrap.
+typeof(function merge end).name.max_methods = UInt8(4)
 
 """
     merge(a::NamedTuple, bs::NamedTuple...)

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -382,10 +382,22 @@ end
 
 # Test effect/inference for merge/diff of unknown NamedTuples
 for f in (Base.merge, Base.structdiff)
-    let eff = Base.infer_effects(f, Tuple{NamedTuple, NamedTuple})
-        @test Core.Compiler.is_foldable(eff) && eff.nonoverlayed
+    @testset let f = f
+        # test the effects of the fallback path
+        @testset let eff = Base.infer_effects() do a::NamedTuple, b::NamedTuple
+                @invoke f(a::NamedTuple, b::NamedTuple)
+            end
+            @test Core.Compiler.is_foldable(eff)
+            @test eff.nonoverlayed
+        end
+        # test if `max_methods = 4` setting works as expected
+        func(a, b) = f(a, b)
+        @testset let eff = Base.infer_effects(func, (NamedTuple, NamedTuple))
+            @test Core.Compiler.is_foldable(eff)
+            @test eff.nonoverlayed
+        end
+        @test Core.Compiler.return_type(func, Tuple{NamedTuple,NamedTuple}) == NamedTuple
     end
-    @test Core.Compiler.return_type(f, Tuple{NamedTuple, NamedTuple}) == NamedTuple
 end
 @test Core.Compiler.is_foldable(Base.infer_effects(pairs, Tuple{NamedTuple}))
 


### PR DESCRIPTION
This enhances type/effects inference for calls of the `merge` function, especially when input types are known only as abstract `NamedTuple`. While we improved inference for the fallback `merge` path in JuliaLang/julia#48262, the enhancements have not been available to general cases as inference gives up attempts when there are ≥4 matching methods. This commit fixes it up.