### PR TITLE
reflection: remove the `func_for_method_checked` check

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3290,7 +3290,10 @@ end
 call_ntuple(a, b) = my_ntuple(i->(a+b; i), Val(4))
 @test Base.return_types(call_ntuple, Tuple{Any,Any}) == [NTuple{4, Int}]
 @test length(code_typed(my_ntuple, Tuple{Any, Val{4}})) == 1
-@test_throws ErrorException code_typed(my_ntuple, Tuple{Any, Val})
+let (src, rt) = only(code_typed(my_ntuple, Tuple{Any, Val}))
+    @test src isa CodeInfo
+    @test rt == Tuple
+end
 
 @generated unionall_sig_generated(::Vector{T}, b::Vector{S}) where {T, S} = :($b)
 @test length(code_typed(unionall_sig_generated, Tuple{Any, Vector{Int}})) == 1


### PR DESCRIPTION
Introduced in 539224f, the `func_for_method_checked` check has been used for some of the reflection utilities like `code_typed`, but now it appears to be outdated. E.g. previously, when provided with abstract input types for optionally-generated functions, they would raise unnecessary errors, even though the inference would utilize the fallback code path. In such instances, the reflection utilities should present what the inference would perform, instead of raising errors.

This commit simply removes the check. This works because all the reflection utilities now internally calls the `InferenceState()` constructor, where code generation occurs, and they gracefully handle cases when code generation fails.
Now their behavior is more synced with the actual behavior of inference.