### PR TITLE
Backport a fix for GMP patches to `backports-release-1.10`

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1171,7 +1171,7 @@ endif
 
 # We need python for things like BB triplet recognition.  We don't really care
 # about version, generally, so just find something that works:
-PYTHON := "$(shell which python 2>/dev/null || which python3 2>/dev/null || which python2 2>/dev/null || echo not found)"
+PYTHON := $(shell which python 2>/dev/null || which python3 2>/dev/null || which python2 2>/dev/null || echo not found)
 PYTHON_SYSTEM := $(shell $(PYTHON) -c 'from __future__ import print_function; import platform; print(platform.system())')
 
 # If we're running on Cygwin, but using a native-windows Python, we need to use cygpath -w

--- a/deps/gmp.mk
+++ b/deps/gmp.mk
@@ -39,27 +39,27 @@ checksum-gmp: $(SRCCACHE)/gmp-$(GMP_VER).tar.bz2
 # Necessary for version 6.2.1, remove after next gmp release
 $(SRCCACHE)/gmp-$(GMP_VER)/gmp-HG-changeset.patch-applied: $(SRCCACHE)/gmp-$(GMP_VER)/source-extracted
 	cd $(dir $@) && \
-		patch -p1 < $(SRCDIR)/patches/gmp-HG-changeset.patch
+		patch -p1 -f < $(SRCDIR)/patches/gmp-HG-changeset.patch
 	echo 1 > $@
 
 $(SRCCACHE)/gmp-$(GMP_VER)/gmp-exception.patch-applied: $(SRCCACHE)/gmp-$(GMP_VER)/gmp-HG-changeset.patch-applied
 	cd $(dir $@) && \
-		patch -p1 < $(SRCDIR)/patches/gmp-exception.patch
+		patch -p1 -f < $(SRCDIR)/patches/gmp-exception.patch
 	echo 1 > $@
 
 $(SRCCACHE)/gmp-$(GMP_VER)/gmp_alloc_overflow_func.patch-applied: $(SRCCACHE)/gmp-$(GMP_VER)/gmp-exception.patch-applied
 	cd $(dir $@) && \
-		patch -p1 < $(SRCDIR)/patches/gmp_alloc_overflow_func.patch
+		patch -p1 -f < $(SRCDIR)/patches/gmp_alloc_overflow_func.patch
 	echo 1 > $@
 
 $(SRCCACHE)/gmp-$(GMP_VER)/gmp-CVE-2021-43618.patch-applied: $(SRCCACHE)/gmp-$(GMP_VER)/gmp_alloc_overflow_func.patch-applied
 	cd $(dir $@) && \
-		patch -p1 < $(SRCDIR)/patches/gmp-CVE-2021-43618.patch
+		patch -p1 -f < $(SRCDIR)/patches/gmp-CVE-2021-43618.patch
 	echo 1 > $@
 
 $(SRCCACHE)/gmp-$(GMP_VER)/gmp-more_alloc_overflow.patch-applied: $(SRCCACHE)/gmp-$(GMP_VER)/gmp-CVE-2021-43618.patch-applied
 	cd $(dir $@) && \
-		patch -p1 < $(SRCDIR)/patches/gmp-more_alloc_overflow.patch
+		patch -p1 -f < $(SRCDIR)/patches/gmp-more_alloc_overflow.patch
 	echo 1 > $@
 
 $(SRCCACHE)/gmp-$(GMP_VER)/source-patched: $(SRCCACHE)/gmp-$(GMP_VER)/gmp-more_alloc_overflow.patch-applied

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -214,7 +214,7 @@ LLVM_CMAKE += -DLLVM_SHLIB_SYMBOL_VERSION:STRING="JL_LLVM_$(LLVM_VER_SHORT)"
 LLVM_PATCH_PREV :=
 define LLVM_PATCH
 $$(SRCCACHE)/$$(LLVM_SRC_DIR)/$1.patch-applied: $$(SRCCACHE)/$$(LLVM_SRC_DIR)/source-extracted | $$(SRCDIR)/patches/$1.patch $$(LLVM_PATCH_PREV)
-	cd $$(SRCCACHE)/$$(LLVM_SRC_DIR)/llvm && patch -p1 < $$(SRCDIR)/patches/$1.patch
+	cd $$(SRCCACHE)/$$(LLVM_SRC_DIR)/llvm && patch -p1 -f < $$(SRCDIR)/patches/$1.patch
 	echo 1 > $$@
 # declare that applying any patch must re-run the compile step
 $$(LLVM_BUILDDIR_withtype)/build-compiled: $$(SRCCACHE)/$$(LLVM_SRC_DIR)/$1.patch-applied
@@ -223,7 +223,7 @@ endef
 
 define LLVM_PROJ_PATCH
 $$(SRCCACHE)/$$(LLVM_SRC_DIR)/$1.patch-applied: $$(SRCCACHE)/$$(LLVM_SRC_DIR)/source-extracted | $$(SRCDIR)/patches/$1.patch $$(LLVM_PATCH_PREV)
-	cd $$(SRCCACHE)/$$(LLVM_SRC_DIR) && patch -p1 < $$(SRCDIR)/patches/$1.patch
+	cd $$(SRCCACHE)/$$(LLVM_SRC_DIR) && patch -p1 -f < $$(SRCDIR)/patches/$1.patch
 	echo 1 > $$@
 # declare that applying any patch must re-run the compile step
 $$(LLVM_BUILDDIR_withtype)/build-compiled: $$(SRCCACHE)/$$(LLVM_SRC_DIR)/$1.patch-applied
@@ -249,7 +249,7 @@ $(BUILDDIR)/julia-patches.patch:
 
 # Apply the patch.
 $(SRCCACHE)/$(LLVM_SRC_DIR)/julia-patches.patch-applied: $(BUILDDIR)/julia-patches.patch $(SRCCACHE)/$(LLVM_SRC_DIR)/source-extracted
-	cd $(SRCCACHE)/$(LLVM_SRC_DIR) && patch -p1 < $(realpath $<)
+	cd $(SRCCACHE)/$(LLVM_SRC_DIR) && patch -p1 -f < $(realpath $<)
 	echo 1 > $@
 
 # Require application of Julia's patchset before configuring LLVM.

--- a/deps/patches/gmp-more_alloc_overflow.patch
+++ b/deps/patches/gmp-more_alloc_overflow.patch
@@ -1,6 +1,6 @@
-diff -ur gmp-6.2.1.orig/mpz/n_pow_ui.c gmp-6.2.1/mpz/n_pow_ui.c
---- gmp-6.2.1.orig/mpz/n_pow_ui.c	2023-09-08 11:41:16.620551175 +0200
-+++ gmp-6.2.1/mpz/n_pow_ui.c	2023-09-08 12:49:29.650492180 +0200
+diff -ur a/mpz/n_pow_ui.c b/mpz/n_pow_ui.c
+--- a/mpz/n_pow_ui.c
++++ b/mpz/n_pow_ui.c
 @@ -220,8 +220,7 @@
    umul_ppmm (ovfl, rtwos_bits, e, btwos);
    if (ovfl)
@@ -21,10 +21,10 @@ diff -ur gmp-6.2.1.orig/mpz/n_pow_ui.c gmp-6.2.1/mpz/n_pow_ui.c
      }
    ralloc = ralloc / GMP_NUMB_BITS + 5;
 
-diff -ur gmp-6.2.1.orig/tal-reent.c gmp-6.2.1/tal-reent.c
---- gmp-6.2.1.orig/tal-reent.c	2020-11-14 19:45:09.000000000 +0100
-+++ gmp-6.2.1/tal-reent.c	2023-09-08 12:10:34.061357613 +0200
-@@ -61,6 +61,11 @@
+diff -ur a/tal-reent.c b/tal-reent.c
+--- a/tal-reent.c
++++ b/tal-reent.c
+@@ -61,6 +61,10 @@
 
    total_size = size + HSIZ;
    p = __GMP_ALLOCATE_FUNC_TYPE (total_size, char);


### PR DESCRIPTION
This backports `Fixes and improvements for source builds (#51422)` PR to the `backports-release-1.10` branch to make it buildable without binary builder (we are monitoring that branch in our CI to make sure we are up to date with the upcoming 1.10 release).

Merging this PR should be followed by removing the `backport 1.10` label from #51422

I hope this PR makes the backporting process easier for you, please let me know if that is not the case.
