### PR TITLE
inference: restrict type of type parameter from `Vararg`

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -539,6 +539,13 @@ function sptypes_from_meth_instance(linfo::MethodInstance)
                     # then `arg` is more precise than `Type{T} where lb<:T<:ub`
                     ty = fieldtype(linfo.specTypes, j)
                     @goto ty_computed
+                elseif (va = va_from_vatuple(sⱼ)) !== nothing
+                    # if this parameter came from `::Tuple{.., Vararg{T,vᵢ}}`,
+                    # then `vᵢ` is known to be `Int`
+                    if isdefined(va, :N) && va.N === vᵢ
+                        ty = Int
+                        @goto ty_computed
+                    end
                 end
             end
             ub = unwraptv_ub(v)
@@ -568,6 +575,8 @@ function sptypes_from_meth_instance(linfo::MethodInstance)
                 constrains_param(v, sig, #=covariant=#true)
             end)
         elseif isvarargtype(v)
+            # if this parameter came from `func(..., ::Vararg{T,v})`,
+            # so the type is known to be `Int`
             ty = Int
             undef = false
         else
@@ -577,6 +586,21 @@ function sptypes_from_meth_instance(linfo::MethodInstance)
         sptypes[i] = VarState(ty, undef)
     end
     return sptypes
+end
+
+function va_from_vatuple(@nospecialize(t))
+    @_foldable_meta
+    t = unwrap_unionall(t)
+    if isa(t, DataType)
+        n = length(t.parameters)
+        if n > 0
+            va = t.parameters[n]
+            if isvarargtype(va)
+               return va
+            end
+        end
+    end
+    return nothing
 end
 
 _topmod(sv::InferenceState) = _topmod(frame_module(sv))

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5246,3 +5246,13 @@ let TV = TypeVar(:T)
     some = Some{Any}((TV, t))
     @test abstract_call_unionall_vararg(some) isa UnionAll
 end
+
+# use `Vararg` type constraints
+use_vararg_constrant1(args::Vararg{T,N}) where {T,N} = Val(T), Val(N)
+@test only(Base.return_types(use_vararg_constrant1, Tuple{Int,Int})) == Tuple{Val{Int},Val{2}}
+use_vararg_constrant2(args::Vararg{T,N}) where {T,N} = Val(T), N
+@test only(Base.return_types(use_vararg_constrant2, Tuple{Vararg{Int}})) == Tuple{Val{Int},Int}
+use_vararg_constrant3(args::NTuple{N,T}) where {T,N} = Val(T), Val(N)
+@test only(Base.return_types(use_vararg_constrant3, Tuple{Tuple{Int,Int}})) == Tuple{Val{Int},Val{2}}
+use_vararg_constrant4(args::NTuple{N,T}) where {T,N} = Val(T), N
+@test only(Base.return_types(use_vararg_constrant4, Tuple{NTuple{N,Int}} where N)) == Tuple{Val{Int},Int}

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1106,7 +1106,7 @@ function sub2ind_gen_fallback(dims::NTuple{N,Int}, I) where N
     for i = (N - 1):-1:1
         ind = I[i] - 1 + dims[i]*ind
     end
-    return (ind + 1)::Int
+    return ind + 1
 end;
 function sub2ind_gen(dims::NTuple{N,Int}, I::Integer...) where N
     length(I) == N || error("partial indexing is unsupported")


### PR DESCRIPTION
Inference has been able to restrict type of `Vararg` type parameter `N` to `Int` for cases like `func(..., ::Vararg{T,N}) where {T,N}`, but this refinement was not available for signatures like `func(::Tuple{Vararg{T,N}}) where {T,N}`.

This commit allows the later case to be inferred as well. Now the following kind of case will be inferred, e.g.:
```julia
julia> function sub2ind_gen_fallback(dims::NTuple{N,Int}, I) where N # N is knonw to be ::Int
           ind = I[N] - 1
           for i = (N - 1):-1:1
               ind = I[i] - 1 + dims[i]*ind
           end
           return ind + 1
       end;

julia> only(Base.return_types(sub2ind_gen_fallback, (NTuple,Tuple{Vararg{Int}})))
Int64
```