### PR TITLE
REPLCompletions: get completions for `:toplevel`/`:tuple` expressions

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -569,6 +569,10 @@ end
 
 # lower `ex` and run type inference on the resulting top-level expression
 function repl_eval_ex(@nospecialize(ex), context_module::Module)
+    if isexpr(ex, :toplevel) || isexpr(ex, :tuple)
+        # get the inference result for the last expression
+        ex = ex.args[end]
+    end
     lwr = try
         Meta.lower(context_module, ex)
     catch # macro expansion failed, etc.

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1832,6 +1832,32 @@ let s = "Some(Issue36437(42)).value."
     end
 end
 
+some_issue36437 = Some(Issue36437(42))
+
+let s = "some_issue36437.value."
+    c, r, res = test_complete_context(s, @__MODULE__)
+    @test res
+    for n in ("a", "b", "c")
+        @test n in c
+    end
+end
+
+# get completions for :toplevel/:tuple expressions
+let s = "some_issue36437.value.a, some_issue36437.value."
+    c, r, res = test_complete_context(s, @__MODULE__)
+    @test res
+    for n in ("a", "b", "c")
+        @test n in c
+    end
+end
+let s = "@show some_issue36437.value.a; some_issue36437.value."
+    c, r, res = test_complete_context(s, @__MODULE__)
+    @test res
+    for n in ("a", "b", "c")
+        @test n in c
+    end
+end
+
 # aggressive concrete evaluation on mutable allocation in `repl_frame`
 let s = "Ref(Issue36437(42))[]."
     c, r, res = test_complete_context(s, @__MODULE__)


### PR DESCRIPTION
This allows us to get completions for the following kind of cases:
```julia
julia> some_issue36437 = Some(Issue36437(42));

julia> some_issue36437.value.a, some_issue36437.value.

a
b
c
julia> some_issue36437.value.a; some_issue36437.value.

a
b
c
```