### PR TITLE
Markdown Docs: specify necessary indent

### DIFF
--- a/stdlib/Markdown/docs/src/index.md
+++ b/stdlib/Markdown/docs/src/index.md
@@ -153,8 +153,8 @@ A header line can contain any inline syntax in the same way as a paragraph can.
 
 ### Code blocks
 
-Source code can be displayed as a literal block using an indent of four spaces as shown in the
-following example.
+Source code can be displayed as a literal block using an indent of four spaces or one tab as shown
+in the following example.
 
 ```
 This is a paragraph.
@@ -298,7 +298,8 @@ aside from the `:` character that is appended to the footnote label.
 
 [^note]:
 
-    Named footnote text containing several toplevel elements.
+    Named footnote text containing several toplevel elements
+    indented by 4 spaces or one tab.
 
       * item one
       * item two
@@ -357,6 +358,7 @@ They can be defined using the following `!!!` syntax:
 !!! note
 
     This is the content of the note.
+    It is indented by 4 spaces. A tab would work as well.
 
 !!! warning "Beware!"
 


### PR DESCRIPTION
Rationale: currently, the Markdown documentation specifies the necessary indent for code blocks and lists only. As there are people out there, who indent their lines by only two spaces (or whatever amount) documenting the indent could help in finding the reason for malformed Markdown. See #45622. For an example where this problem occurred see https://github.com/oscar-system/Oscar.jl/pull/1369#discussion_r893488230.