### PR TITLE
add convenience entry for `typeinf_[code|ircode|frame]`

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1559,7 +1559,7 @@ function code_typed_by_type(@nospecialize(tt::Type);
     asts = []
     for match in matches
         match = match::Core.MethodMatch
-        (code, ty) = Core.Compiler.typeinf_code(interp, match.method, match.spec_types, match.sparams, optimize)
+        (code, ty) = Core.Compiler.typeinf_code(interp, match, optimize)
         if code === nothing
             push!(asts, match.method => Any)
         else
@@ -1655,13 +1655,7 @@ function code_ircode_by_type(
     asts = []
     for match in matches
         match = match::Core.MethodMatch
-        (code, ty) = Core.Compiler.typeinf_ircode(
-            interp,
-            match.method,
-            match.spec_types,
-            match.sparams,
-            optimize_until,
-        )
+        (code, ty) = Core.Compiler.typeinf_ircode(interp, match, optimize_until)
         if code === nothing
             push!(asts, match.method => Any)
         else
@@ -1792,8 +1786,7 @@ function infer_effects(@nospecialize(f), @nospecialize(types=default_tt(f));
     end
     for match in matches.matches
         match = match::Core.MethodMatch
-        frame = Core.Compiler.typeinf_frame(interp,
-            match.method, match.spec_types, match.sparams, #=run_optimizer=#true)
+        frame = Core.Compiler.typeinf_frame(interp, match, #=run_optimizer=#true)
         frame === nothing && return Core.Compiler.Effects()
         effects = Core.Compiler.merge_effects(effects, frame.result.ipo_effects)
     end
@@ -1822,7 +1815,7 @@ function print_statement_costs(io::IO, @nospecialize(tt::Type);
     for match in matches
         match = match::Core.MethodMatch
         println(io, match.method)
-        (code, ty) = Core.Compiler.typeinf_code(interp, match.method, match.spec_types, match.sparams, true)
+        (code, ty) = Core.Compiler.typeinf_code(interp, match, true)
         if code === nothing
             println(io, "  inference not successful")
         else

--- a/doc/src/devdocs/inference.md
+++ b/doc/src/devdocs/inference.md
@@ -36,9 +36,9 @@ m = first(mths)
 # Create variables needed to call `typeinf_code`
 interp = Core.Compiler.NativeInterpreter()
 sparams = Core.svec()      # this particular method doesn't have type-parameters
-optimize = true            # run all inference optimizations
+run_optimizer = true       # run all inference optimizations
 types = Tuple{typeof(convert), atypes.parameters...} # Tuple{typeof(convert), Type{Int}, UInt}
-Core.Compiler.typeinf_code(interp, m, types, sparams, optimize)
+Core.Compiler.typeinf_code(interp, m, types, sparams, run_optimizer)
 ```
 
 If your debugging adventures require a `MethodInstance`, you can look it up by


### PR DESCRIPTION
This change allows them to take `match::MethodMatch` and `mi::MethodInstance`, making debugging easier and reflection code a bit cleaner.