### PR TITLE
Fix segfault if root task is NULL

### DIFF
--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -1158,23 +1158,30 @@ JL_DLLEXPORT void jl_print_task_backtraces(int show_done) JL_NOTSAFEPOINT
             continue;
         }
         jl_ptls_t ptls2 = allstates[i];
-        if (ptls2 == NULL)
+        if (ptls2 == NULL) {
             continue;
+        }
         small_arraylist_t *live_tasks = &ptls2->heap.live_tasks;
         size_t n = mtarraylist_length(live_tasks);
+        int t_state = JL_TASK_STATE_DONE;
         jl_task_t *t = ptls2->root_task;
-        int t_state = jl_atomic_load_relaxed(&t->_state);
+        if (t != NULL)
+            t_state = jl_atomic_load_relaxed(&t->_state);
         jl_safe_printf("==== Thread %d created %zu live tasks\n",
                 ptls2->tid + 1, n + (t_state != JL_TASK_STATE_DONE));
         if (show_done || t_state != JL_TASK_STATE_DONE) {
             jl_safe_printf("     ---- Root task (%p)\n", ptls2->root_task);
-            jl_safe_printf("          (sticky: %d, started: %d, state: %d, tid: %d)\n",
-                    t->sticky, t->started, t_state,
-                    jl_atomic_load_relaxed(&t->tid) + 1);
-            if (t->stkbuf != NULL)
-                jlbacktracet(t);
-            else
-                jl_safe_printf("      no stack\n");
+            if (t != NULL) {
+                jl_safe_printf("          (sticky: %d, started: %d, state: %d, tid: %d)\n",
+                        t->sticky, t->started, t_state,
+                        jl_atomic_load_relaxed(&t->tid) + 1);
+                if (t->stkbuf != NULL) {
+                    jlbacktracet(t);
+                }
+                else {
+                    jl_safe_printf("      no stack\n");
+                }
+            }
             jl_safe_printf("     ---- End root task\n");
         }
 


### PR DESCRIPTION
In `jl_print_task_backtraces()`. Follow-on to https://github.com/JuliaLang/julia/pull/51430.