### PR TITLE
Zero for ranges may return ranges

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -1386,12 +1386,10 @@ end
 _reverse(r::LinRange{T}, ::Colon) where {T} = typeof(r)(r.stop, r.start, length(r))
 
 function zero(r::StepRangeLen{T,R,S}) where {T,R,S}
-    StepRangeLen{T}(zero(r.ref), zero(step(r)), length(r), r.offset)
+    StepRangeLen{T}(zero(r.ref), zero(r.step), length(r), r.offset)
 end
 zero(r::LinRange) = LinRange{eltype(r)}(zero(first(r)), zero(last(r)), length(r))
-# These are only defined for Integer currently to work around
-# TwicePrecision not having a zero defined
-zero(r::Union{UnitRange{<:Integer}, StepRange{<:Integer}}) = zero(StepRangeLen(r))
+zero(r::Union{UnitRange, StepRange}) = zero(StepRangeLen(r))
 
 ## sorting ##
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -1385,6 +1385,14 @@ function _reverse(r::StepRangeLen, ::Colon)
 end
 _reverse(r::LinRange{T}, ::Colon) where {T} = typeof(r)(r.stop, r.start, length(r))
 
+function zero(r::StepRangeLen{T,R,S}) where {T,R,S}
+    StepRangeLen{T}(zero(r.ref), zero(step(r)), length(r), r.offset)
+end
+zero(r::LinRange) = LinRange{eltype(r)}(zero(first(r)), zero(last(r)), length(r))
+# These are only defined for Integer currently to work around
+# TwicePrecision not having a zero defined
+zero(r::Union{UnitRange{<:Integer}, StepRange{<:Integer}}) = zero(StepRangeLen(r))
+
 ## sorting ##
 
 issorted(r::AbstractUnitRange) = true

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -276,6 +276,9 @@ float(x::TwicePrecision) = TwicePrecision(float(x.hi), float(x.lo))
 
 big(x::TwicePrecision) = big(x.hi) + big(x.lo)
 
+zero(r::TwicePrecision) = zero(typeof(r))
+zero(::Type{TwicePrecision{T}}) where {T} = TwicePrecision{T}(zero(T))
+
 -(x::TwicePrecision) = TwicePrecision(-x.hi, -x.lo)
 
 function zero(::Type{TwicePrecision{T}}) where {T}

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -276,11 +276,9 @@ float(x::TwicePrecision) = TwicePrecision(float(x.hi), float(x.lo))
 
 big(x::TwicePrecision) = big(x.hi) + big(x.lo)
 
-zero(r::TwicePrecision) = zero(typeof(r))
-zero(::Type{TwicePrecision{T}}) where {T} = TwicePrecision{T}(zero(T))
-
 -(x::TwicePrecision) = TwicePrecision(-x.hi, -x.lo)
 
+zero(r::TwicePrecision) = zero(typeof(r))
 function zero(::Type{TwicePrecision{T}}) where {T}
     z = zero(T)
     TwicePrecision{T}(z, z)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2539,7 +2539,8 @@ end
 @testset "zero" begin
     @testset "StepRangeLen" begin
         for r in (StepRangeLen(im, 2im, 10),
-                    StepRangeLen{Bool}(false, true, 2))
+                    StepRangeLen{Bool}(false, true, 2),
+                    1.0:2.0:5.0)
             z = zero(r)
             @test r + z == r
             @test typeof(z) == typeof(r)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2535,3 +2535,30 @@ end
     a = StepRangeLen(1,2,3,2)
     @test a[UInt(1)] == -1
 end
+
+@testset "zero" begin
+    @testset "StepRangeLen" begin
+        for r in (StepRangeLen(im, 2im, 10),
+                    StepRangeLen{Bool}(false, true, 2))
+            z = zero(r)
+            @test r + z == r
+            @test typeof(z) == typeof(r)
+        end
+    end
+    @testset "LinRange" begin
+        for r in (LinRange{Int}(2, 3, 2),
+                    LinRange(2, 3, 4),
+                    LinRange{Bool}(false, true, 2))
+            z = zero(r)
+            @test r + z == r
+            @test typeof(z) == typeof(r)
+        end
+    end
+    @testset "UnitRange/StepRange" begin
+        for r in (1:4, UnitRange(1.0, 2.0),
+                    1:1:4, false:true:true)
+            z = zero(r)
+            @test r + z == r
+        end
+    end
+end


### PR DESCRIPTION
This PR specializes `zero` for known range types to avoid allocation.
```julia
julia> zero(1:5)
StepRangeLen(0, 0, 5)

julia> zero(1:2:5)
StepRangeLen(0, 0, 3)

julia> zero(1.0:2.0:5.0)
StepRangeLen(0.0, 0.0, 3)

julia> zero(LinRange(1, 2, 3))
3-element LinRange{Float64, Int64}:
 0.0, 0.0, 0.0
```
To get this working, I've also added `zero` for `TwicePrecision`.