### PR TITLE
prevent code loading from lookin in the versioned environment when building Julia

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -86,9 +86,11 @@ See also [`JULIA_DEPOT_PATH`](@ref JULIA_DEPOT_PATH), and
 """
 const DEPOT_PATH = String[]
 
-function append_default_depot_path!(DEPOT_PATH)
-    path = joinpath(homedir(), ".julia")
-    path in DEPOT_PATH || push!(DEPOT_PATH, path)
+function append_default_depot_path!(DEPOT_PATH; only_bundled::Bool=false)
+    if !only_bundled
+        path = joinpath(homedir(), ".julia")
+        path in DEPOT_PATH || push!(DEPOT_PATH, path)
+    end
     path = abspath(Sys.BINDIR, "..", "local", "share", "julia")
     path in DEPOT_PATH || push!(DEPOT_PATH, path)
     path = abspath(Sys.BINDIR, "..", "share", "julia")
@@ -96,21 +98,21 @@ function append_default_depot_path!(DEPOT_PATH)
     return DEPOT_PATH
 end
 
-function init_depot_path()
+function init_depot_path(; only_bundled::Bool=false)
     empty!(DEPOT_PATH)
     if haskey(ENV, "JULIA_DEPOT_PATH")
         str = ENV["JULIA_DEPOT_PATH"]
         isempty(str) && return
         for path in eachsplit(str, Sys.iswindows() ? ';' : ':')
             if isempty(path)
-                append_default_depot_path!(DEPOT_PATH)
+                append_default_depot_path!(DEPOT_PATH; only_bundled)
             else
                 path = expanduser(path)
                 path in DEPOT_PATH || push!(DEPOT_PATH, path)
             end
         end
     else
-        append_default_depot_path!(DEPOT_PATH)
+        append_default_depot_path!(DEPOT_PATH; only_bundled)
     end
     nothing
 end

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -12,8 +12,8 @@ import Base.MainInclude: eval, include
 pushfirst!(Base._included_files, (@__MODULE__, abspath(@__FILE__)))
 
 # set up depot & load paths to be able to find stdlib packages
-Base.init_depot_path()
-Base.init_load_path()
+Base.init_depot_path(; only_bundled=true)
+push!(empty!(LOAD_PATH), "@stdlib")
 
 if Base.is_primary_base_module
 # load some stdlib packages but don't put their names in Main


### PR DESCRIPTION
Otherwise, if your versioned environment has the wrong dependencies for an stdlib, Julia fails to build. Happens currently sometimes for LibGit2 since it recently got the LibGit2_jll dependency.