### PR TITLE
Add debug_info_level to cgparams

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1381,8 +1381,8 @@ struct CodegenParams
 
     function CodegenParams(; track_allocations::Bool=true, code_coverage::Bool=true,
                    prefer_specsig::Bool=false,
-                   gnu_pubnames=true, debug_info_kind::Cint = default_debug_info_kind(),
-                   debug_info_level::Cint = JLOptions().debug_level, safepoint_on_entry::Bool=true,
+                   gnu_pubnames::Bool=true, debug_info_kind::Cint = default_debug_info_kind(),
+                   debug_info_level::Cint = Cint(JLOptions().debug_level), safepoint_on_entry::Bool=true,
                    gcstack_arg::Bool=true, use_jlplt::Bool=true,
                    lookup::Ptr{Cvoid}=unsafe_load(cglobal(:jl_rettype_inferred_addr, Ptr{Cvoid})))
         return new(

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1336,6 +1336,11 @@ struct CodegenParams
     debug_info_kind::Cint
 
     """
+    Controls the debug_info_level parameter, equivalent to the -g command line option.
+    """
+    debug_info_level::Cint
+
+    """
     If enabled, generate a GC safepoint at the entry to every function. Emitting
     these extra safepoints can reduce the amount of time that other threads are
     waiting for the currently running thread to reach a safepoint. The cost for
@@ -1377,14 +1382,14 @@ struct CodegenParams
     function CodegenParams(; track_allocations::Bool=true, code_coverage::Bool=true,
                    prefer_specsig::Bool=false,
                    gnu_pubnames=true, debug_info_kind::Cint = default_debug_info_kind(),
-                   safepoint_on_entry::Bool=true,
+                   debug_info_level::Cint = JLOptions().debug_level, safepoint_on_entry::Bool=true,
                    gcstack_arg::Bool=true, use_jlplt::Bool=true,
                    lookup::Ptr{Cvoid}=unsafe_load(cglobal(:jl_rettype_inferred_addr, Ptr{Cvoid})))
         return new(
             Cint(track_allocations), Cint(code_coverage),
             Cint(prefer_specsig),
             Cint(gnu_pubnames), debug_info_kind,
-            Cint(safepoint_on_entry),
+            debug_info_level, Cint(safepoint_on_entry),
             Cint(gcstack_arg), Cint(use_jlplt),
             lookup)
     end

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -304,7 +304,7 @@ void *jl_create_native_impl(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvm
     jl_codegen_params_t params(ctxt, std::move(target_info.first), std::move(target_info.second));
     params.params = cgparams;
     params.imaging_mode = imaging;
-    params.debug_level = jl_options.debug_level;
+    params.debug_level = cgparams->debug_info_level;
     params.external_linkage = _external_linkage;
     size_t compile_for[] = { jl_typeinf_world, _world };
     for (int worlds = 0; worlds < 2; worlds++) {
@@ -1854,7 +1854,7 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t* dump, jl_method_instance_t *mi, siz
         // Force at least medium debug info for introspection
         // No debug info = no variable names,
         // max debug info = llvm.dbg.declare/value intrinsics which clutter IR output
-        output.debug_level = std::max(2, static_cast<int>(jl_options.debug_level));
+        output.debug_level = params.debug_info_level;
         auto decls = jl_emit_code(m, mi, src, jlrettype, output);
         JL_UNLOCK(&jl_codegen_lock); // Might GC
 

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -1851,9 +1851,7 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t* dump, jl_method_instance_t *mi, siz
         // // Force imaging mode for names of pointers
         // output.imaging = true;
         // This would also be nice, but it seems to cause OOMs on the windows32 builder
-        // Force at least medium debug info for introspection
-        // No debug info = no variable names,
-        // max debug info = llvm.dbg.declare/value intrinsics which clutter IR output
+        // To get correct names in the IR this needs to be at least 2
         output.debug_level = params.debug_info_level;
         auto decls = jl_emit_code(m, mi, src, jlrettype, output);
         JL_UNLOCK(&jl_codegen_lock); // Might GC

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1363,6 +1363,7 @@ extern "C" {
         /* gnu_pubnames */ 1,
 #endif
         /* debug_info_kind */ (int) DICompileUnit::DebugEmissionKind::FullDebug,
+        /* debug_line_info */ 1,
         /* safepoint_on_entry */ 1,
         /* gcstack_arg */ 1,
         /* use_jlplt*/ 1,

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9300,7 +9300,7 @@ extern "C" void jl_init_llvm(void)
 {
     jl_page_size = jl_getpagesize();
     jl_default_debug_info_kind = (int) DICompileUnit::DebugEmissionKind::FullDebug;
-
+    jl_default_cgparams.debug_info_level = (int) jl_options.debug_level;
     InitializeNativeTarget();
     InitializeNativeTargetAsmPrinter();
     InitializeNativeTargetAsmParser();

--- a/src/julia.h
+++ b/src/julia.h
@@ -2379,12 +2379,11 @@ typedef struct {
     int gnu_pubnames;       // can we emit the gnu pubnames debuginfo
     int debug_info_kind;    // Enum for line-table-only, line-directives-only,
                             // limited, standalone
-
+    int debug_info_level;   // equivalent to the -g level from the cli
     int safepoint_on_entry; // Emit a safepoint on entry to each function
     int gcstack_arg; // Pass the ptls value as an argument with swiftself
 
     int use_jlplt; // Whether to use the Julia PLT mechanism or emit symbols directly
-
     // Cache access. Default: jl_rettype_inferred.
     jl_codeinstance_lookup_t lookup;
 } jl_cgparams_t;

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -172,7 +172,7 @@ const OC_MISMATCH_WARNING =
 function _dump_function(@nospecialize(f), @nospecialize(t), native::Bool, wrapper::Bool,
                         raw::Bool, dump_module::Bool, syntax::Symbol,
                         optimize::Bool, debuginfo::Symbol, binary::Bool,
-                        params::CodegenParams=CodegenParams(debug_info_kind=Cint(0), safepoint_on_entry=raw, gcstack_arg=raw))
+                        params::CodegenParams=CodegenParams(debug_info_kind=Cint(0), debug_info_level=Cint(2), safepoint_on_entry=raw, gcstack_arg=raw))
     ccall(:jl_is_in_pure_context, Bool, ()) && error("code reflection cannot be used from generated functions")
     if isa(f, Core.Builtin)
         throw(ArgumentError("argument is not a generic function"))
@@ -280,7 +280,7 @@ See also: [`@code_llvm`](@ref), [`code_warntype`](@ref), [`code_typed`](@ref), [
 """
 function code_llvm(io::IO, @nospecialize(f), @nospecialize(types=Base.default_tt(f));
                    raw::Bool=false, dump_module::Bool=false, optimize::Bool=true, debuginfo::Symbol=:default,
-                   params::CodegenParams=CodegenParams(debug_info_kind=Cint(0), safepoint_on_entry=raw, gcstack_arg=raw))
+                   params::CodegenParams=CodegenParams(debug_info_kind=Cint(0), debug_info_level=Cint(2), safepoint_on_entry=raw, gcstack_arg=raw))
     d = _dump_function(f, types, false, false, raw, dump_module, :intel, optimize, debuginfo, false, params)
     if highlighting[:llvm] && get(io, :color, false)::Bool
         print_llvm(io, d)
@@ -307,7 +307,7 @@ See also: [`@code_native`](@ref), [`code_warntype`](@ref), [`code_typed`](@ref),
 function code_native(io::IO, @nospecialize(f), @nospecialize(types=Base.default_tt(f));
                      dump_module::Bool=true, syntax::Symbol=:intel, raw::Bool=false,
                      debuginfo::Symbol=:default, binary::Bool=false,
-                     params::CodegenParams=CodegenParams(debug_info_kind=Cint(0), safepoint_on_entry=raw, gcstack_arg=raw))
+                     params::CodegenParams=CodegenParams(debug_info_kind=Cint(0), debug_info_level=Cint(2), safepoint_on_entry=raw, gcstack_arg=raw))
     d = _dump_function(f, types, true, false, raw, dump_module, syntax, true, debuginfo, binary, params)
     if highlighting[:native] && get(io, :color, false)::Bool
         print_native(io, d)

--- a/test/compiler/AbstractInterpreter.jl
+++ b/test/compiler/AbstractInterpreter.jl
@@ -464,6 +464,7 @@ let # generate cache
     lookup = @cfunction(custom_lookup, Any, (Any,Csize_t,Csize_t))
     params = CodegenParams(;
         debug_info_kind=Cint(0),
+        debug_info_level=Cint(2),
         safepoint_on_entry=raw,
         gcstack_arg=raw,
         lookup)

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -17,7 +17,7 @@ end
 
 # The tests below assume a certain format and safepoint_on_entry=true breaks that.
 function get_llvm(@nospecialize(f), @nospecialize(t), raw=true, dump_module=false, optimize=true)
-    params = Base.CodegenParams(safepoint_on_entry=false, gcstack_arg = false)
+    params = Base.CodegenParams(safepoint_on_entry=false, gcstack_arg = false, debug_info_level=Cint(2))
     d = InteractiveUtils._dump_function(f, t, false, false, raw, dump_module, :att, optimize, :none, false, params)
     sprint(print, d)
 end


### PR DESCRIPTION
This adds the option for non native code emission to override the process debug level. Note that this is diferrent from debug_kind and behaves similarly to the -g option