### PR TITLE
post-opt-analysis: use EA to refine `:effect_free`

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -480,12 +480,12 @@ end)
 function CodeInstance(
     mi::MethodInstance, @nospecialize(rettype), @nospecialize(inferred_const),
     @nospecialize(inferred), const_flags::Int32, min_world::UInt, max_world::UInt,
-    ipo_effects::UInt32, effects::UInt32, @nospecialize(argescapes#=::Union{Nothing,Vector{ArgEscapeInfo}}=#),
+    ipo_effects::UInt32, effects::UInt32, @nospecialize(analysis_results),
     relocatability::UInt8)
     return ccall(:jl_new_codeinst, Ref{CodeInstance},
         (Any, Any, Any, Any, Int32, UInt, UInt, UInt32, UInt32, Any, UInt8),
         mi, rettype, inferred_const, inferred, const_flags, min_world, max_world,
-        ipo_effects, effects, argescapes,
+        ipo_effects, effects, analysis_results,
         relocatability)
 end
 GlobalRef(m::Module, s::Symbol) = ccall(:jl_module_globalref, Ref{GlobalRef}, (Any, Any), m, s)

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -24,9 +24,7 @@ const IR_FLAG_INLINE      = UInt32(1) << 1
 # This statement is marked as @noinline by user
 const IR_FLAG_NOINLINE    = UInt32(1) << 2
 const IR_FLAG_THROW_BLOCK = UInt32(1) << 3
-# This statement may be removed if its result is unused. In particular,
-# it must be both :effect_free and :nothrow.
-# TODO: Separate these out.
+# This statement was proven :effect_free
 const IR_FLAG_EFFECT_FREE = UInt32(1) << 4
 # This statement was proven not to throw
 const IR_FLAG_NOTHROW     = UInt32(1) << 5
@@ -38,6 +36,12 @@ const IR_FLAG_CONSISTENT  = UInt32(1) << 6
 const IR_FLAG_REFINED     = UInt32(1) << 7
 # This is :noub == ALWAYS_TRUE
 const IR_FLAG_NOUB        = UInt32(1) << 8
+
+# TODO: Both of these should eventually go away once
+# This is :effect_free == EFFECT_FREE_IF_INACCESSIBLEMEMONLY
+const IR_FLAG_EFIIMO      = UInt32(1) << 9
+# This is :inaccessiblememonly == INACCESSIBLEMEM_OR_ARGMEMONLY
+const IR_FLAG_INACCESSIBLE_OR_ARGMEM = UInt32(1) << 10
 
 const IR_FLAGS_EFFECTS = IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW | IR_FLAG_CONSISTENT | IR_FLAG_NOUB
 
@@ -514,7 +518,6 @@ function get!(lazyagdomtree::LazyAugmentedDomtree)
     return lazyagdomtree.agdomtree = AugmentedDomtree(cfg, domtree)
 end
 
-# TODO refine `:effect_free` using EscapeAnalysis
 mutable struct PostOptAnalysisState
     const result::InferenceResult
     const ir::IRCode
@@ -522,8 +525,10 @@ mutable struct PostOptAnalysisState
     const tpdum::TwoPhaseDefUseMap
     const lazypostdomtree::LazyPostDomtree
     const lazyagdomtree::LazyAugmentedDomtree
+    const ea_analysis_pending::Vector{Int}
     all_retpaths_consistent::Bool
     all_effect_free::Bool
+    effect_free_if_argmem_only::Union{Nothing,Bool}
     all_nothrow::Bool
     all_noub::Bool
     any_conditional_ub::Bool
@@ -532,12 +537,14 @@ mutable struct PostOptAnalysisState
         tpdum = TwoPhaseDefUseMap(length(ir.stmts))
         lazypostdomtree = LazyPostDomtree(ir)
         lazyagdomtree = LazyAugmentedDomtree(ir)
-        return new(result, ir, inconsistent, tpdum, lazypostdomtree, lazyagdomtree, true, true, true, true, false)
+        return new(result, ir, inconsistent, tpdum, lazypostdomtree, lazyagdomtree, Int[],
+                   true, true, nothing, true, true, false)
     end
 end
 
 give_up_refinements!(sv::PostOptAnalysisState) =
-    sv.all_retpaths_consistent = sv.all_effect_free = sv.all_nothrow = sv.all_noub = false
+    sv.all_retpaths_consistent = sv.all_effect_free = sv.effect_free_if_argmem_only =
+    sv.all_nothrow = sv.all_noub = false
 
 function any_refinable(sv::PostOptAnalysisState)
     effects = sv.result.ipo_effects
@@ -547,12 +554,47 @@ function any_refinable(sv::PostOptAnalysisState)
             (!is_noub(effects) & sv.all_noub))
 end
 
-function refine_effects!(sv::PostOptAnalysisState)
+struct GetNativeEscapeCache{CodeCache}
+    code_cache::CodeCache
+    GetNativeEscapeCache(code_cache::CodeCache) where CodeCache = new{CodeCache}(code_cache)
+end
+GetNativeEscapeCache(interp::AbstractInterpreter) = GetNativeEscapeCache(code_cache(interp))
+function ((; code_cache)::GetNativeEscapeCache)(mi::MethodInstance)
+    codeinst = get(code_cache, mi, nothing)
+    codeinst isa CodeInstance || return false
+    argescapes = traverse_analysis_results(codeinst) do @nospecialize result
+        return result isa EscapeAnalysis.ArgEscapeCache ? result : nothing
+    end
+    if argescapes !== nothing
+        return argescapes
+    end
+    effects = decode_effects(codeinst.ipo_purity_bits)
+    if is_effect_free(effects) && is_inaccessiblememonly(effects)
+        # We might not have run EA on simple frames without any escapes (e.g. when optimization
+        # is skipped when result is constant-folded by abstract interpretation). If those
+        # frames aren't inlined, the accuracy of EA for caller context takes a big hit.
+        # This is a HACK to avoid that, but obviously, a more comprehensive fix would be ideal.
+        return true
+    end
+    return false
+end
+
+function refine_effects!(interp::AbstractInterpreter, sv::PostOptAnalysisState)
+    if !is_effect_free(sv.result.ipo_effects) && sv.all_effect_free && !isempty(sv.ea_analysis_pending)
+        ir = sv.ir
+        nargs = length(ir.argtypes)
+        estate = EscapeAnalysis.analyze_escapes(ir, nargs, GetNativeEscapeCache(interp))
+        argescapes = EscapeAnalysis.ArgEscapeCache(estate)
+        stack_analysis_result!(sv.result, argescapes)
+        validate_mutable_arg_escapes!(estate, sv)
+    end
+
     any_refinable(sv) || return false
     effects = sv.result.ipo_effects
     sv.result.ipo_effects = Effects(effects;
         consistent = sv.all_retpaths_consistent ? ALWAYS_TRUE : effects.consistent,
-        effect_free = sv.all_effect_free ? ALWAYS_TRUE : effects.effect_free,
+        effect_free = sv.all_effect_free ? ALWAYS_TRUE :
+                      sv.effect_free_if_argmem_only === true ? EFFECT_FREE_IF_INACCESSIBLEMEMONLY : effects.effect_free,
         nothrow = sv.all_nothrow ? true : effects.nothrow,
         noub = sv.all_noub ? (sv.any_conditional_ub ? NOUB_IF_NOINBOUNDS : ALWAYS_TRUE) : effects.noub)
     return true
@@ -572,6 +614,58 @@ function is_getfield_with_boundscheck_arg(@nospecialize(stmt), sv::PostOptAnalys
     return true
 end
 
+function check_all_args_noescape!(sv::PostOptAnalysisState, ir::IRCode, @nospecialize(stmt),
+                                  estate::EscapeAnalysis.EscapeState)
+    stmt isa Expr || return false
+    if isexpr(stmt, :invoke)
+        startidx = 2
+    elseif isexpr(stmt, :new)
+        startidx = 1
+    else
+        return false
+    end
+    for i = startidx:length(stmt.args)
+        arg = stmt.args[i]
+        argt = argextype(arg, ir)
+        if is_mutation_free_argtype(argt)
+            continue
+        end
+        # See if we can find the allocation
+        if isa(arg, Argument)
+            if EscapeAnalysis.has_no_escape(EscapeAnalysis.ignore_argescape(estate[arg]))
+                # Even if we prove everything else effect_free, the best we can
+                # say is :effect_free_if_argmem_only
+                if sv.effect_free_if_argmem_only === nothing
+                    sv.effect_free_if_argmem_only = true
+                end
+            else
+                sv.effect_free_if_argmem_only = false
+            end
+            return false
+        elseif isa(arg, SSAValue)
+            EscapeAnalysis.has_no_escape(estate[arg]) || return false
+            check_all_args_noescape!(sv, ir, ir[arg][:stmt], estate) || return false
+        else
+            return false
+        end
+    end
+    return true
+end
+
+function validate_mutable_arg_escapes!(estate::EscapeAnalysis.EscapeState, sv::PostOptAnalysisState)
+    ir = sv.ir
+    for idx in sv.ea_analysis_pending
+        # See if any mutable memory was allocated in this function and determined
+        # not to escape.
+        inst = ir[SSAValue(idx)]
+        stmt = inst[:stmt]
+        if !check_all_args_noescape!(sv, ir, stmt, estate)
+            return sv.all_effect_free = false
+        end
+    end
+    return true
+end
+
 function is_conditional_noub(inst::Instruction, sv::PostOptAnalysisState)
     # Special case: `:boundscheck` into `getfield`
     stmt = inst[:stmt]
@@ -585,14 +679,30 @@ function is_conditional_noub(inst::Instruction, sv::PostOptAnalysisState)
     return true
 end
 
+const IR_FLAGS_NEEDS_EA = IR_FLAG_EFIIMO | IR_FLAG_INACCESSIBLE_OR_ARGMEM
+
 function scan_non_dataflow_flags!(inst::Instruction, sv::PostOptAnalysisState)
     flag = inst[:flag]
+    # If we can prove that the argmem does not escape the current function, we can
+    # refine this to :effect_free.
+    needs_ea_validation = (flag & IR_FLAGS_NEEDS_EA) == IR_FLAGS_NEEDS_EA
     stmt = inst[:stmt]
-    if !isterminator(stmt) && stmt !== nothing
-        # ignore control flow node – they are not removable on their own and thus not
-        # have `IR_FLAG_EFFECT_FREE` but still do not taint `:effect_free`-ness of
-        # the whole method invocation
-        sv.all_effect_free &= !iszero(flag & IR_FLAG_EFFECT_FREE)
+    if !needs_ea_validation
+        if !isterminator(stmt) && stmt !== nothing
+            # ignore control flow node – they are not removable on their own and thus not
+            # have `IR_FLAG_EFFECT_FREE` but still do not taint `:effect_free`-ness of
+            # the whole method invocation
+            sv.all_effect_free &= !iszero(flag & IR_FLAG_EFFECT_FREE)
+        end
+    elseif sv.all_effect_free
+        if (isexpr(stmt, :invoke) || isexpr(stmt, :new) ||
+            # HACK for performance: limit the scope of EA to code with object field access only,
+            # since its abilities to reason about e.g. arrays are currently very limited anyways.
+            is_known_call(stmt, setfield!, sv.ir))
+            push!(sv.ea_analysis_pending, inst.idx)
+        else
+            sv.all_effect_free = false
+        end
     end
     sv.all_nothrow &= !iszero(flag & IR_FLAG_NOTHROW)
     if iszero(flag & IR_FLAG_NOUB)
@@ -734,7 +844,9 @@ function check_inconsistentcy!(sv::PostOptAnalysisState, scanner::BBScanner)
 end
 
 function ipo_dataflow_analysis!(interp::AbstractInterpreter, ir::IRCode, result::InferenceResult)
-    is_ipo_dataflow_analysis_profitable(result.ipo_effects) || return false
+    if !is_ipo_dataflow_analysis_profitable(result.ipo_effects)
+        return false
+    end
 
     sv = PostOptAnalysisState(result, ir)
     scanner = BBScanner(ir)
@@ -757,7 +869,7 @@ function ipo_dataflow_analysis!(interp::AbstractInterpreter, ir::IRCode, result:
         end
     end
 
-    return refine_effects!(sv)
+    return refine_effects!(interp, sv)
 end
 
 # run the optimization work

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1003,6 +1003,11 @@ function flags_for_effects(effects::Effects)
     end
     if is_effect_free(effects)
         flags |= IR_FLAG_EFFECT_FREE
+    elseif is_effect_free_if_inaccessiblememonly(effects)
+        flags |= IR_FLAG_EFIIMO
+    end
+    if is_inaccessiblemem_or_argmemonly(effects)
+        flags |= IR_FLAG_INACCESSIBLE_OR_ARGMEM
     end
     if is_nothrow(effects)
         flags |= IR_FLAG_NOTHROW

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -331,7 +331,7 @@ function CodeInstance(interp::AbstractInterpreter, result::InferenceResult,
         widenconst(result_type), rettype_const, inferred_result,
         const_flags, first(valid_worlds), last(valid_worlds),
         # TODO: Actually do something with non-IPO effects
-        encode_effects(result.ipo_effects), encode_effects(result.ipo_effects), result.argescapes,
+        encode_effects(result.ipo_effects), encode_effects(result.ipo_effects), result.analysis_results,
         relocatability)
 end
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -288,7 +288,7 @@ JL_DLLEXPORT jl_code_instance_t* jl_new_codeinst(
         jl_method_instance_t *mi, jl_value_t *rettype,
         jl_value_t *inferred_const, jl_value_t *inferred,
         int32_t const_flags, size_t min_world, size_t max_world,
-        uint32_t ipo_effects, uint32_t effects, jl_value_t *argescapes,
+        uint32_t ipo_effects, uint32_t effects, jl_value_t *analysis_results,
         uint8_t relocatability);
 
 jl_datatype_t *jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_args_t fptr) JL_GC_DISABLED
@@ -486,7 +486,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
         jl_method_instance_t *mi, jl_value_t *rettype,
         jl_value_t *inferred_const, jl_value_t *inferred,
         int32_t const_flags, size_t min_world, size_t max_world,
-        uint32_t ipo_effects, uint32_t effects, jl_value_t *argescapes,
+        uint32_t ipo_effects, uint32_t effects, jl_value_t *analysis_results,
         uint8_t relocatability
         /*, jl_array_t *edges, int absolute_max*/)
 {
@@ -514,7 +514,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
     jl_atomic_store_relaxed(&codeinst->next, NULL);
     codeinst->ipo_purity_bits = ipo_effects;
     jl_atomic_store_relaxed(&codeinst->purity_bits, effects);
-    codeinst->argescapes = argescapes;
+    codeinst->analysis_results = analysis_results;
     codeinst->relocatability = relocatability;
     return codeinst;
 }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3255,7 +3255,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             //"edges",
                             //"absolute_max",
                             "ipo_purity_bits", "purity_bits",
-                            "argescapes",
+                            "analysis_results",
                             "isspecsig", "precompile", "relocatability",
                             "invoke", "specptr"), // function object decls
                         jl_svec(15,

--- a/src/julia.h
+++ b/src/julia.h
@@ -435,7 +435,7 @@ typedef struct _jl_code_instance_t {
     //     uint8_t nonoverlayed        : 1;
     //     uint8_t notaskstate         : 2;
     //     uint8_t inaccessiblememonly : 2;
-    jl_value_t *argescapes; // escape information of call arguments
+    jl_value_t *analysis_results; // Analysis results about this code (IPO-safe)
 
     // compilation state cache
     _Atomic(uint8_t) specsigflags; // & 0b001 == specptr is a specialized function signature for specTypes->rettype

--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -138,7 +138,7 @@ JL_DLLEXPORT jl_code_instance_t* jl_new_codeinst(
         jl_method_instance_t *mi, jl_value_t *rettype,
         jl_value_t *inferred_const, jl_value_t *inferred,
         int32_t const_flags, size_t min_world, size_t max_world,
-        uint32_t ipo_effects, uint32_t effects, jl_value_t *argescapes,
+        uint32_t ipo_effects, uint32_t effects, jl_value_t *analysis_results,
         uint8_t relocatability);
 
 JL_DLLEXPORT jl_opaque_closure_t *jl_new_opaque_closure_from_code_info(jl_tupletype_t *argt, jl_value_t *rt_lb, jl_value_t *rt_ub,

--- a/test/compiler/EscapeAnalysis/EAUtils.jl
+++ b/test/compiler/EscapeAnalysis/EAUtils.jl
@@ -62,14 +62,13 @@ __clear_cache!() = empty!(GLOBAL_EA_CODE_CACHE)
 # imports
 import .CC:
     AbstractInterpreter, NativeInterpreter, WorldView, WorldRange,
-    InferenceParams, OptimizationParams, get_world_counter, get_inference_cache, code_cache
+    InferenceParams, OptimizationParams, get_world_counter, get_inference_cache, code_cache,
+    ipo_dataflow_analysis!, cache_result!
 # usings
 using Core:
     CodeInstance, MethodInstance, CodeInfo
 using .CC:
-    InferenceResult, OptimizationState, IRCode, copy as cccopy,
-    @timeit, convert_to_ircode, slot2reg, compact!, ssa_inlining_pass!, sroa_pass!,
-    adce_pass!, JLOptions, verify_ir, verify_linetable
+    InferenceResult, OptimizationState, IRCode
 using .EA: analyze_escapes, ArgEscapeCache, EscapeInfo, EscapeState
 
 struct CodeCache
@@ -144,17 +143,31 @@ function CC.setindex!(wvc::WorldView{EscapeAnalyzerCacheView}, ci::CodeInstance,
     return wvc
 end
 
-function CC.optimize(interp::EscapeAnalyzer, opt::OptimizationState, caller::InferenceResult)
-    ir = run_passes_ipo_safe_with_ea(interp, opt.src, opt, caller)
-    CC.ipo_dataflow_analysis!(interp, ir, caller)
-    return CC.finish(interp, opt, ir, caller)
+function CC.ipo_dataflow_analysis!(interp::EscapeAnalyzer, ir::IRCode, caller::InferenceResult)
+    # run EA on all frames that have been optimized
+    nargs = let def = caller.linfo.def; isa(def, Method) ? Int(def.nargs) : 0; end
+    get_escape_cache = GetEscapeCache(interp)
+    estate = try
+        analyze_escapes(ir, nargs, get_escape_cache)
+    catch err
+        @error "error happened within EA, inspect `Main.failed_escapeanalysis`"
+        Main.failed_escapeanalysis = FailedAnalysis(ir, nargs, get_escape_cache)
+        rethrow(err)
+    end
+    if caller.linfo === interp.entry_mi
+        # return back the result
+        interp.result = EscapeResultForEntry(CC.copy(ir), estate, caller.linfo)
+    end
+    record_escapes!(interp, caller, estate, ir)
+
+    @invoke CC.ipo_dataflow_analysis!(interp::AbstractInterpreter, ir::IRCode, caller::InferenceResult)
 end
 
 function record_escapes!(interp::EscapeAnalyzer,
-    caller::InferenceResult, estate::EscapeState, cacheir::IRCode)
-    cache = ArgEscapeCache(estate)
-    ecache = EscapeCacheInfo(cache, estate, cacheir)
-    return caller.argescapes = ecache
+    caller::InferenceResult, estate::EscapeState, ir::IRCode)
+    argescapes = ArgEscapeCache(estate)
+    ecacheinfo = EscapeCacheInfo(argescapes, estate, ir)
+    return CC.stack_analysis_result!(caller, ecacheinfo)
 end
 
 struct GetEscapeCache
@@ -162,8 +175,8 @@ struct GetEscapeCache
     GetEscapeCache(interp::EscapeAnalyzer) = new(interp.escape_cache)
 end
 function ((; escape_cache)::GetEscapeCache)(mi::MethodInstance)
-    cached = get(escape_cache.cache, mi, nothing)
-    return cached === nothing ? nothing : cached.argescapes
+    ecacheinfo = get(escape_cache.cache, mi, nothing)
+    return ecacheinfo === nothing ? false : ecacheinfo.argescapes
 end
 
 struct FailedAnalysis
@@ -172,45 +185,12 @@ struct FailedAnalysis
     get_escape_cache::GetEscapeCache
 end
 
-function run_passes_ipo_safe_with_ea(interp::EscapeAnalyzer,
-    ci::CodeInfo, sv::OptimizationState, caller::InferenceResult)
-    @timeit "convert"   ir = convert_to_ircode(ci, sv)
-    @timeit "slot2reg"  ir = slot2reg(ir, ci, sv)
-    # TODO: Domsorting can produce an updated domtree - no need to recompute here
-    @timeit "compact 1" ir = compact!(ir)
-    @timeit "Inlining"  ir = ssa_inlining_pass!(ir, sv.inlining, ci.propagate_inbounds)
-    # @timeit "verify 2" verify_ir(ir)
-    @timeit "compact 2" ir = compact!(ir)
-    @timeit "SROA"      ir = sroa_pass!(ir, sv.inlining)
-    @timeit "ADCE"      ir = adce_pass!(ir, sv.inlining)
-    @timeit "compact 3" ir = compact!(ir, true)
-    if JLOptions().debug_level == 2
-        @timeit "verify 3" (verify_ir(ir); verify_linetable(ir.linetable))
+function CC.cache_result!(interp::EscapeAnalyzer, inf_result::InferenceResult)
+    ecacheinfo = CC.traverse_analysis_results(inf_result) do @nospecialize result
+        return result isa EscapeCacheInfo ? result : nothing
     end
-    nargs = let def = sv.linfo.def; isa(def, Method) ? Int(def.nargs) : 0; end
-    get_escape_cache = GetEscapeCache(interp)
-    local estate::EscapeState
-    try
-        @timeit "EA" estate = analyze_escapes(ir, nargs, get_escape_cache)
-    catch err
-        @error "error happened within EA, inspect `Main.failed_escapeanalysis`"
-        Main.failed_escapeanalysis = FailedAnalysis(ir, nargs, get_escape_cache)
-        rethrow(err)
-    end
-    if caller.linfo === interp.entry_mi
-        # return back the result
-        interp.result = EscapeResultForEntry(cccopy(ir), estate, sv.linfo)
-    end
-    record_escapes!(interp, caller, estate, ir)
-    return ir
-end
-
-function CC.cache_result!(interp::EscapeAnalyzer, result::InferenceResult)
-    argescapes = result.argescapes
-    if argescapes isa EscapeCacheInfo
-        interp.escape_cache.cache[result.linfo] = argescapes
-    end
-    return @invoke CC.cache_result!(interp::AbstractInterpreter, result::InferenceResult)
+    ecacheinfo isa EscapeCacheInfo && (interp.escape_cache.cache[inf_result.linfo] = ecacheinfo)
+    return @invoke CC.cache_result!(interp::AbstractInterpreter, inf_result::InferenceResult)
 end
 
 # printing
@@ -278,7 +258,7 @@ Base.show(io::IO, result::EscapeResult) = print_with_info(io, result)
 @eval Base.iterate(res::EscapeResult, state=1) =
     return state > $(fieldcount(EscapeResult)) ? nothing : (getfield(res, state), state+1)
 
-Base.show(io::IO, cached::EscapeCacheInfo) = show(io, EscapeResult(cached.ir, cached.state))
+Base.show(io::IO, ecacheinfo::EscapeCacheInfo) = show(io, EscapeResult(ecacheinfo.ir, ecacheinfo.state))
 
 # adapted from https://github.com/JuliaDebug/LoweredCodeUtils.jl/blob/4612349432447e868cf9285f647108f43bd0a11c/src/codeedges.jl#L881-L897
 function print_with_info(io::IO, result::EscapeResult)

--- a/test/core.jl
+++ b/test/core.jl
@@ -14,7 +14,7 @@ include("testenv.jl")
 # sanity tests that our built-in types are marked correctly for const fields
 for (T, c) in (
         (Core.CodeInfo, []),
-        (Core.CodeInstance, [:def, :rettype, :rettype_const, :ipo_purity_bits, :argescapes]),
+        (Core.CodeInstance, [:def, :rettype, :rettype_const, :ipo_purity_bits, :analysis_results]),
         (Core.Method, [#=:name, :module, :file, :line, :primary_world, :sig, :slot_syms, :external_mt, :nargs, :called, :nospecialize, :nkw, :isva, :is_for_opaque_closure, :constprop=#]),
         (Core.MethodInstance, [#=:def, :specTypes, :sparam_vals=#]),
         (Core.MethodTable, [:module]),

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -1015,5 +1015,19 @@ end
     args = ["ab ^` c", " \" ", "\"", ascii95, ascii95,
             "\"\\\"\\", "", "|", "&&", ";"];
     @test Base.shell_escape_wincmd(Base.escape_microsoft_c_args(args...)) == "\"ab ^` c\" \" \\\" \" \"\\\"\" \" !\\\"#\$%^&'^(^)*+,-./0123456789:;^<=^>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^^_`abcdefghijklmnopqrstuvwxyz{^|}~\" \" ^!\\\"#\$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\" \"\\\"\\\\\\\"\\\\\" \"\" ^| ^&^& ;"
+end
 
+# effects for Cmd construction
+for f in (() -> `a b c`, () -> `a a$("bb")a $("c")`)
+    effects = Base.infer_effects(f)
+    @test Core.Compiler.is_effect_free(effects)
+    @test Core.Compiler.is_terminates(effects)
+    @test Core.Compiler.is_noub(effects)
+    @test !Core.Compiler.is_consistent(effects)
+end
+let effects = Base.infer_effects(x -> `a $x`, (Any,))
+    @test !Core.Compiler.is_effect_free(effects)
+    @test !Core.Compiler.is_terminates(effects)
+    @test !Core.Compiler.is_noub(effects)
+    @test !Core.Compiler.is_consistent(effects)
 end


### PR DESCRIPTION
This commit is aiming to integrate EA into the Base compiler pipeline by using it during the post-opt analysis to refine `:effect_free` information. In doing so, this also generalizes `argescapes` field of `Union{InferenceResult,CodeInstance}` to `analysis_results::AnalysisResults` so that it can hold results of multiple post-optimization analyses, where `AnalysisResults` is designed to be linked-list like data structure. This is because an external `AbstractInterpreter`, like `EscapeAnalyzer`, might perform several post-optimization analyses. Honestly speaking, however, I’m not completely satisfied with this solution yet. It might make more sense to require a single post-optimization analysis for every `AbstractInterpreter` always, as like what we do for the other fields like `rettype`.

So this PR is still a work in progress, but it’s already bootstrappable and the tests should be all passing.