### PR TITLE
Prevent OOMs during heap snapshot: Change to streaming out the snapshot data.

### DIFF
--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -55,6 +55,7 @@ void print_str_escape_json(ios_t *stream, StringRef s)
 struct Edge {
     size_t type; // These *must* match the Enums on the JS side; control interpretation of name_or_index.
     size_t name_or_index; // name of the field (for objects/modules) or index of array
+    size_t from_node;
     size_t to_node;
 };
 
@@ -73,7 +74,6 @@ struct Node {
     // whether the from_node is attached or dettached from the main application state
     // https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/include/v8-profiler.h#L739-L745
     int detachedness;  // 0 - unknown, 1 - attached, 2 - detached
-    vector<Edge> edges;
 
     ~Node() JL_NOTSAFEPOINT = default;
 };
@@ -106,15 +106,22 @@ struct StringTable {
 };
 
 struct HeapSnapshot {
-    vector<Node> nodes;
-    // edges are stored on each from_node
-
     StringTable names;
     StringTable node_types;
     StringTable edge_types;
     DenseMap<void *, size_t> node_ptr_to_index_map;
 
-    size_t num_edges = 0; // For metadata, updated as you add each edge. Needed because edges owned by nodes.
+    size_t num_nodes = 0; // Since we stream out to files,
+    size_t num_edges = 0; // we need to track the counts here.
+
+    Node internal_root;
+
+    // Used for streaming
+    ios_t *nodes;
+    ios_t *edges;
+    ios_t *strings;
+    ios_t *json;
+
 };
 
 // global heap snapshot, mutated by garbage collector
@@ -123,23 +130,30 @@ int gc_heap_snapshot_enabled = 0;
 HeapSnapshot *g_snapshot = nullptr;
 extern jl_mutex_t heapsnapshot_lock;
 
+void final_serialize_heap_snapshot(ios_t *json, ios_t *strings, HeapSnapshot &snapshot, char all_one);
 void serialize_heap_snapshot(ios_t *stream, HeapSnapshot &snapshot, char all_one);
 static inline void _record_gc_edge(const char *edge_type,
                                    jl_value_t *a, jl_value_t *b, size_t name_or_index) JL_NOTSAFEPOINT;
-void _record_gc_just_edge(const char *edge_type, Node &from_node, size_t to_idx, size_t name_or_idx) JL_NOTSAFEPOINT;
+void _record_gc_just_edge(const char *edge_type, size_t from_idx, size_t to_idx, size_t name_or_idx) JL_NOTSAFEPOINT;
 void _add_internal_root(HeapSnapshot *snapshot);
 
 
-JL_DLLEXPORT void jl_gc_take_heap_snapshot(ios_t *stream, char all_one)
+JL_DLLEXPORT void jl_gc_take_heap_snapshot(ios_t *nodes, ios_t *edges,
+    ios_t *strings, ios_t *json, char all_one)
 {
     HeapSnapshot snapshot;
-    _add_internal_root(&snapshot);
+    snapshot.nodes = nodes;
+    snapshot.edges = edges;
+    snapshot.strings = strings;
+    snapshot.json = json;
 
     jl_mutex_lock(&heapsnapshot_lock);
 
     // Enable snapshotting
     g_snapshot = &snapshot;
     gc_heap_snapshot_enabled = true;
+
+    _add_internal_root(&snapshot);
 
     // Do a full GC mark (and incremental sweep), which will invoke our callbacks on `g_snapshot`
     jl_gc_collect(JL_GC_FULL);
@@ -152,30 +166,55 @@ JL_DLLEXPORT void jl_gc_take_heap_snapshot(ios_t *stream, char all_one)
 
     // When we return, the snapshot is full
     // Dump the snapshot
-    serialize_heap_snapshot((ios_t*)stream, snapshot, all_one);
+    final_serialize_heap_snapshot((ios_t*)json, (ios_t*)strings, snapshot, all_one);
+}
+
+void serialize_node(HeapSnapshot *snapshot, const Node &node)
+{
+    // ["type","name","id","self_size","edge_count","trace_node_id","detachedness"]
+    ios_printf(snapshot->nodes, "%zu,%zu,%zu,%zu,%zu,%zu,%d\n",
+                            node.type,
+                            node.name,
+                            node.id,
+                            node.self_size,
+                            0,  // fake edge count for now
+                            node.trace_node_id,
+                            node.detachedness);
+
+    g_snapshot->num_nodes += 1;
+}
+void serialize_edge(HeapSnapshot *snapshot, const Edge &edge)
+{
+    // ["type","name_or_index","to_node"]
+    ios_printf(snapshot->edges, "%zu,%zu,%zu,%zu\n",
+                            edge.type,
+                            edge.name_or_index,
+                            edge.from_node, // NOTE: Row number (not adjusted for k_node_number_of_fields)
+                            edge.to_node); // NOTE: Row number (not adjusted for k_node_number_of_fields)
+    g_snapshot->num_edges += 1;
 }
 
 // adds a node at id 0 which is the "uber root":
 // a synthetic node which points to all the GC roots.
 void _add_internal_root(HeapSnapshot *snapshot)
 {
-    Node internal_root{
+    snapshot->internal_root = Node{
         snapshot->node_types.find_or_create_string_id("synthetic"),
         snapshot->names.find_or_create_string_id(""), // name
         0, // id
         0, // size
         0, // size_t trace_node_id (unused)
-        0, // int detachedness;  // 0 - unknown,  1 - attached;  2 - detached
-        vector<Edge>() // outgoing edges
+        0 // int detachedness;  // 0 - unknown,  1 - attached;  2 - detached
     };
-    snapshot->nodes.push_back(internal_root);
+
+    serialize_node(snapshot, snapshot->internal_root);
 }
 
 // mimicking https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/src/profiler/heap-snapshot-generator.cc#L597-L597
 // returns the index of the new node
 size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
 {
-    auto val = g_snapshot->node_ptr_to_index_map.insert(make_pair(a, g_snapshot->nodes.size()));
+    auto val = g_snapshot->node_ptr_to_index_map.insert(make_pair(a, g_snapshot->num_nodes));
     if (!val.second) {
         return val.first->second;
     }
@@ -245,7 +284,7 @@ size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
         name = StringRef((const char*)str_.buf, str_.size);
     }
 
-    g_snapshot->nodes.push_back(Node{
+    auto node = Node{
         g_snapshot->node_types.find_or_create_string_id(node_type), // size_t type;
         g_snapshot->names.find_or_create_string_id(name), // size_t name;
         (size_t)a,     // size_t id;
@@ -254,8 +293,8 @@ size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
         sizeof(void*) + self_size, // size_t self_size;
         0,             // size_t trace_node_id (unused)
         0,             // int detachedness;  // 0 - unknown,  1 - attached;  2 - detached
-        vector<Edge>() // outgoing edges
-    });
+    };
+    serialize_node(g_snapshot, node);
 
     if (ios_need_close)
         ios_close(&str_);
@@ -265,20 +304,20 @@ size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT
 
 static size_t record_pointer_to_gc_snapshot(void *a, size_t bytes, StringRef name) JL_NOTSAFEPOINT
 {
-    auto val = g_snapshot->node_ptr_to_index_map.insert(make_pair(a, g_snapshot->nodes.size()));
+    auto val = g_snapshot->node_ptr_to_index_map.insert(make_pair(a, g_snapshot->num_nodes));
     if (!val.second) {
         return val.first->second;
     }
 
-    g_snapshot->nodes.push_back(Node{
+    auto node = Node{
         g_snapshot->node_types.find_or_create_string_id( "object"), // size_t type;
         g_snapshot->names.find_or_create_string_id(name), // size_t name;
         (size_t)a,     // size_t id;
         bytes,         // size_t self_size;
         0,             // size_t trace_node_id (unused)
         0,             // int detachedness;  // 0 - unknown,  1 - attached;  2 - detached
-        vector<Edge>() // outgoing edges
-    });
+    };
+    serialize_node(g_snapshot, node);
 
     return val.first->second;
 }
@@ -317,13 +356,11 @@ static string _fieldpath_for_slot(void *obj, void *slot) JL_NOTSAFEPOINT
 
 void _gc_heap_snapshot_record_root(jl_value_t *root, char *name) JL_NOTSAFEPOINT
 {
-    record_node_to_gc_snapshot(root);
-
-    auto &internal_root = g_snapshot->nodes.front();
-    auto to_node_idx = g_snapshot->node_ptr_to_index_map[root];
+    size_t to_node_idx = record_node_to_gc_snapshot(root);
+    size_t internal_root_idx = 0;
     auto edge_label = g_snapshot->names.find_or_create_string_id(name);
 
-    _record_gc_just_edge("internal", internal_root, to_node_idx, edge_label);
+    _record_gc_just_edge("internal", internal_root_idx, to_node_idx, edge_label);
 }
 
 // Add a node to the heap snapshot representing a Julia stack frame.
@@ -332,20 +369,20 @@ void _gc_heap_snapshot_record_root(jl_value_t *root, char *name) JL_NOTSAFEPOINT
 // Stack frame nodes point at the objects they have as local variables.
 size_t _record_stack_frame_node(HeapSnapshot *snapshot, void *frame) JL_NOTSAFEPOINT
 {
-    auto val = g_snapshot->node_ptr_to_index_map.insert(make_pair(frame, g_snapshot->nodes.size()));
+    auto val = g_snapshot->node_ptr_to_index_map.insert(make_pair(frame, g_snapshot->num_nodes));
     if (!val.second) {
         return val.first->second;
     }
 
-    snapshot->nodes.push_back(Node{
+    auto node = Node{
         snapshot->node_types.find_or_create_string_id("synthetic"),
         snapshot->names.find_or_create_string_id("(stack frame)"), // name
         (size_t)frame, // id
         1, // size
         0, // size_t trace_node_id (unused)
         0, // int detachedness;  // 0 - unknown,  1 - attached;  2 - detached
-        vector<Edge>() // outgoing edges
-    });
+    };
+    serialize_node(snapshot, node);
 
     return val.first->second;
 }
@@ -354,30 +391,27 @@ void _gc_heap_snapshot_record_frame_to_object_edge(void *from, jl_value_t *to) J
 {
     auto from_node_idx = _record_stack_frame_node(g_snapshot, (jl_gcframe_t*)from);
     auto to_idx = record_node_to_gc_snapshot(to);
-    Node &from_node = g_snapshot->nodes[from_node_idx];
 
     auto name_idx = g_snapshot->names.find_or_create_string_id("local var");
-    _record_gc_just_edge("internal", from_node, to_idx, name_idx);
+    _record_gc_just_edge("internal", from_node_idx, to_idx, name_idx);
 }
 
 void _gc_heap_snapshot_record_task_to_frame_edge(jl_task_t *from, void *to) JL_NOTSAFEPOINT
 {
     auto from_node_idx = record_node_to_gc_snapshot((jl_value_t*)from);
     auto to_node_idx = _record_stack_frame_node(g_snapshot, to);
-    Node &from_node = g_snapshot->nodes[from_node_idx];
 
     auto name_idx = g_snapshot->names.find_or_create_string_id("stack");
-    _record_gc_just_edge("internal", from_node, to_node_idx, name_idx);
+    _record_gc_just_edge("internal", from_node_idx, to_node_idx, name_idx);
 }
 
 void _gc_heap_snapshot_record_frame_to_frame_edge(jl_gcframe_t *from, jl_gcframe_t *to) JL_NOTSAFEPOINT
 {
     auto from_node_idx = _record_stack_frame_node(g_snapshot, from);
     auto to_node_idx = _record_stack_frame_node(g_snapshot, to);
-    Node &from_node = g_snapshot->nodes[from_node_idx];
 
     auto name_idx = g_snapshot->names.find_or_create_string_id("next frame");
-    _record_gc_just_edge("internal", from_node, to_node_idx, name_idx);
+    _record_gc_just_edge("internal", from_node_idx, to_node_idx, name_idx);
 }
 
 void _gc_heap_snapshot_record_array_edge(jl_value_t *from, jl_value_t *to, size_t index) JL_NOTSAFEPOINT
@@ -405,13 +439,10 @@ void _gc_heap_snapshot_record_module_to_binding(jl_module_t *module, jl_binding_
     auto ty_idx = ty ? record_node_to_gc_snapshot(ty) : 0;
     auto globalref_idx = record_node_to_gc_snapshot((jl_value_t*)globalref);
 
-    auto &from_node = g_snapshot->nodes[from_node_idx];
-    auto &to_node = g_snapshot->nodes[to_node_idx];
-
-    _record_gc_just_edge("property", from_node, to_node_idx, g_snapshot->names.find_or_create_string_id("<native>"));
-    if (value_idx)     _record_gc_just_edge("internal", to_node, value_idx, g_snapshot->names.find_or_create_string_id("value"));
-    if (ty_idx)        _record_gc_just_edge("internal", to_node, ty_idx, g_snapshot->names.find_or_create_string_id("ty"));
-    if (globalref_idx) _record_gc_just_edge("internal", to_node, globalref_idx, g_snapshot->names.find_or_create_string_id("globalref"));
+    _record_gc_just_edge("property", from_node_idx, to_node_idx, g_snapshot->names.find_or_create_string_id("<native>"));
+    if (value_idx)     _record_gc_just_edge("internal", to_node_idx, value_idx, g_snapshot->names.find_or_create_string_id("value"));
+    if (ty_idx)        _record_gc_just_edge("internal", to_node_idx, ty_idx, g_snapshot->names.find_or_create_string_id("ty"));
+    if (globalref_idx) _record_gc_just_edge("internal", to_node_idx, globalref_idx, g_snapshot->names.find_or_create_string_id("globalref"));
 }
 
 void _gc_heap_snapshot_record_internal_array_edge(jl_value_t *from, jl_value_t *to) JL_NOTSAFEPOINT
@@ -442,9 +473,8 @@ void _gc_heap_snapshot_record_hidden_edge(jl_value_t *from, void* to, size_t byt
         break;
     }
     auto to_node_idx = record_pointer_to_gc_snapshot(to, bytes, alloc_kind);
-    auto &from_node = g_snapshot->nodes[from_node_idx];
 
-    _record_gc_just_edge("hidden", from_node, to_node_idx, name_or_idx);
+    _record_gc_just_edge("hidden", from_node_idx, to_node_idx, name_or_idx);
 }
 
 static inline void _record_gc_edge(const char *edge_type, jl_value_t *a,
@@ -453,84 +483,46 @@ static inline void _record_gc_edge(const char *edge_type, jl_value_t *a,
     auto from_node_idx = record_node_to_gc_snapshot(a);
     auto to_node_idx = record_node_to_gc_snapshot(b);
 
-    auto &from_node = g_snapshot->nodes[from_node_idx];
-
-    _record_gc_just_edge(edge_type, from_node, to_node_idx, name_or_idx);
+    _record_gc_just_edge(edge_type, from_node_idx, to_node_idx, name_or_idx);
 }
 
-void _record_gc_just_edge(const char *edge_type, Node &from_node, size_t to_idx, size_t name_or_idx) JL_NOTSAFEPOINT
+void _record_gc_just_edge(const char *edge_type, size_t from_idx, size_t to_idx, size_t name_or_idx) JL_NOTSAFEPOINT
 {
-    from_node.edges.push_back(Edge{
+    auto edge = Edge{
         g_snapshot->edge_types.find_or_create_string_id(edge_type),
         name_or_idx, // edge label
+        from_idx, // from
         to_idx // to
-    });
+    };
 
-    g_snapshot->num_edges += 1;
+    serialize_edge(g_snapshot, edge);
 }
 
-void serialize_heap_snapshot(ios_t *stream, HeapSnapshot &snapshot, char all_one)
+void final_serialize_heap_snapshot(ios_t *json, ios_t *strings, HeapSnapshot &snapshot, char all_one)
 {
     // mimicking https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/src/profiler/heap-snapshot-generator.cc#L2567-L2567
-    ios_printf(stream, "{\"snapshot\":{");
-    ios_printf(stream, "\"meta\":{");
-    ios_printf(stream, "\"node_fields\":[\"type\",\"name\",\"id\",\"self_size\",\"edge_count\",\"trace_node_id\",\"detachedness\"],");
-    ios_printf(stream, "\"node_types\":[");
-    snapshot.node_types.print_json_array(stream, false);
-    ios_printf(stream, ",");
-    ios_printf(stream, "\"string\", \"number\", \"number\", \"number\", \"number\", \"number\"],");
-    ios_printf(stream, "\"edge_fields\":[\"type\",\"name_or_index\",\"to_node\"],");
-    ios_printf(stream, "\"edge_types\":[");
-    snapshot.edge_types.print_json_array(stream, false);
-    ios_printf(stream, ",");
-    ios_printf(stream, "\"string_or_number\",\"from_node\"]");
-    ios_printf(stream, "},\n"); // end "meta"
-    ios_printf(stream, "\"node_count\":%zu,", snapshot.nodes.size());
-    ios_printf(stream, "\"edge_count\":%zu", snapshot.num_edges);
-    ios_printf(stream, "},\n"); // end "snapshot"
+    ios_printf(json, "{\"snapshot\":{");
+    ios_printf(json, "\"meta\":{");
+    ios_printf(json, "\"node_fields\":[\"type\",\"name\",\"id\",\"self_size\",\"edge_count\",\"trace_node_id\",\"detachedness\"],");
+    ios_printf(json, "\"node_types\":[");
+    snapshot.node_types.print_json_array(json, false);
+    ios_printf(json, ",");
+    ios_printf(json, "\"string\", \"number\", \"number\", \"number\", \"number\", \"number\"],");
+    ios_printf(json, "\"edge_fields\":[\"type\",\"name_or_index\",\"to_node\"],");
+    ios_printf(json, "\"edge_types\":[");
+    snapshot.edge_types.print_json_array(json, false);
+    ios_printf(json, ",");
+    ios_printf(json, "\"string_or_number\",\"from_node\"]");
+    ios_printf(json, "},\n"); // end "meta"
+    ios_printf(json, "\"node_count\":%zu,", snapshot.num_nodes);
+    ios_printf(json, "\"edge_count\":%zu", snapshot.num_edges);
+    ios_printf(json, "}\n"); // end "snapshot"
+    ios_printf(json, "}");
 
-    ios_printf(stream, "\"nodes\":[");
-    bool first_node = true;
-    for (const auto &from_node : snapshot.nodes) {
-        if (first_node) {
-            first_node = false;
-        }
-        else {
-            ios_printf(stream, ",");
-        }
-        // ["type","name","id","self_size","edge_count","trace_node_id","detachedness"]
-        ios_printf(stream, "%zu,%zu,%zu,%zu,%zu,%zu,%d\n",
-                            from_node.type,
-                            from_node.name,
-                            from_node.id,
-                            all_one ? (size_t)1 : from_node.self_size,
-                            from_node.edges.size(),
-                            from_node.trace_node_id,
-                            from_node.detachedness);
-    }
-    ios_printf(stream, "],\n");
+    ios_printf(strings, "{\n");
+    ios_printf(strings, "\"strings\":");
 
-    ios_printf(stream, "\"edges\":[");
-    bool first_edge = true;
-    for (const auto &from_node : snapshot.nodes) {
-        for (const auto &edge : from_node.edges) {
-            if (first_edge) {
-                first_edge = false;
-            }
-            else {
-                ios_printf(stream, ",");
-            }
-            ios_printf(stream, "%zu,%zu,%zu\n",
-                                edge.type,
-                                edge.name_or_index,
-                                edge.to_node * k_node_number_of_fields);
-        }
-    }
-    ios_printf(stream, "],\n"); // end "edges"
+    snapshot.names.print_json_array(strings, true);
+    ios_printf(strings, "}");
 
-    ios_printf(stream, "\"strings\":");
-
-    snapshot.names.print_json_array(stream, true);
-
-    ios_printf(stream, "}");
 }

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -55,7 +55,7 @@ void print_str_escape_json(ios_t *stream, StringRef s)
 struct Edge {
     size_t type; // These *must* match the Enums on the JS side; control interpretation of name_or_index.
     size_t name_or_index; // name of the field (for objects/modules) or index of array
-    size_t from_node;
+    size_t from_node;  // This is a deviation from the .heapsnapshot format to support streaming.
     size_t to_node;
 };
 

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -97,7 +97,8 @@ static inline void gc_heap_snapshot_record_hidden_edge(jl_value_t *from, void* t
 // ---------------------------------------------------------------------
 // Functions to call from Julia to take heap snapshot
 // ---------------------------------------------------------------------
-JL_DLLEXPORT void jl_gc_take_heap_snapshot(ios_t *stream, char all_one);
+JL_DLLEXPORT void jl_gc_take_heap_snapshot(ios_t *nodes, ios_t *edges,
+    ios_t *strings, ios_t *json, char all_one);
 
 
 #ifdef __cplusplus

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1263,10 +1263,12 @@ function take_heap_snapshot(io::IO, all_one::Bool=false)
     Profile.HeapSnapshot.assemble_snapshot(prefix, io)
 end
 function _stream_heap_snapshot(prefix::AbstractString, all_one::Bool)
+    # Nodes and edges are binary files
     open("$prefix.nodes", "w") do nodes
         open("$prefix.edges", "w") do edges
-            open("$prefix.strings", "w") do strings
-                open("$prefix.json", "w") do json
+            # The other two files are json data
+            open("$prefix.strings.json", "w") do strings
+                open("$prefix.metadata.json", "w") do json
                     Base.@_lock_ios(nodes,
                     Base.@_lock_ios(edges,
                     Base.@_lock_ios(strings,

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1228,7 +1228,7 @@ counted. Otherwise, report the actual size.
 If `streaming` is true, we will stream the snapshot data out into four files, using filepath
 as the prefix, to avoid having to hold the entire snapshot in memory. This option should be
 used for any setting where your memory is constrained. These files can then be reassembled
-by calling [`Profile.HeapSnapshot.assemble_snapshot(filepath; out_file)`](@ref), which can
+by calling [`Profile.HeapSnapshot.assemble_snapshot(filepath)`](@ref), which can
 be done offline.
 
 NOTE: We strongly recommend setting streaming=true for performance reasons. Reconstructing

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -25,6 +25,12 @@ struct Nodes
     self_size::Vector{Int}     # size of the object itself, not including the size of its fields
     edge_count::Vector{UInt32} # number of outgoing edges
     edges::Edges               # outgoing edges
+    # This is the main complexity of the .heapsnapshot format, and it's the reason we need
+    # to read in all the data before writing it out. The edges vector contains all edges,
+    # but organized by which node they came from. First, it contains all the edges coming
+    # out of node 0, then all edges leaving node 1, etc. So we need to have visited all
+    # edges, and assigned them to their corresponding nodes, before we can emit the file.
+    edge_idxs::Vector{Vector{UInt}} # indexes into edges, keeping per-node outgoing edge ids
 end
 function init_nodes(n::Int, e::Int)
     Nodes(
@@ -34,6 +40,7 @@ function init_nodes(n::Int, e::Int)
         Vector{Int}(undef, n),
         Vector{UInt32}(undef, n),
         init_edges(e),
+        [Vector{UInt}() for _ in 1:n],  # Take care to construct n separate empty vectors
     )
 end
 Base.length(n::Nodes) = length(n.type)
@@ -81,9 +88,19 @@ function assemble_snapshot(in_prefix, io::IO)
 
     nodes = init_nodes(node_count, edge_count)
 
+    shouldlog(i) = false
+    # N = 100000
+    # shouldlog(i) = i % N == 0
+    #     N *= 10
+    #     return true
+    # else
+    #     return false
+    # end
+
     # Parse nodes with empty edge counts that we need to fill later
     # TODO: preallocate line buffer
     for (i, line) in enumerate(eachline(string(in_prefix, ".nodes")))
+        shouldlog(i) && println("Parsing node $i")
         iter = eachsplit(line, ',')
         x, s = iterate(iter)
         node_type = parse(Int8, x)
@@ -106,6 +123,15 @@ function assemble_snapshot(in_prefix, io::IO)
         nodes.id[i] = id
         nodes.self_size[i] = self_size
         nodes.edge_count[i] = edge_count
+
+        shouldlog(i) && begin
+            println("Parsed node $i")
+            @show node_type
+            @show node_name_idx
+            @show id
+            @show self_size
+            @show edge_count
+        end
     end
 
     # Parse the edges to fill in the edge counts for nodes and correct the to_node offsets
@@ -125,6 +151,7 @@ function assemble_snapshot(in_prefix, io::IO)
         nodes.edges.name_or_index[i] = edge_name_or_index
         nodes.edges.to_pos[i] = to_node * 7 # 7 fields per node, the streaming format doesn't multiply the offset by 7
         nodes.edge_count[from_node + 1] += UInt32(1)  # C and JSON use 0-based indexing
+        push!(nodes.edge_idxs[from_node + 1], i) # Index into nodes.edges
     end
 
     _digits_buf = zeros(UInt8, ndigits(typemax(UInt)))
@@ -143,18 +170,29 @@ function assemble_snapshot(in_prefix, io::IO)
         _write_decimal_number(io, nodes.edge_count[i], _digits_buf)
         print(io, ",0,0")
     end
-    println(io, "],\"edges\":[")
-    for i in 1:length(nodes.edges)
-        i > 1 && println(io, ",")
-        _write_decimal_number(io, nodes.edges.type[i], _digits_buf)
-        print(io, ",")
-        _write_decimal_number(io, nodes.edges.name_or_index[i], _digits_buf)
-        print(io, ",")
-        _write_decimal_number(io, nodes.edges.to_pos[i], _digits_buf)
+    print(io, "],\"edges\":[")
+    e = 1
+    for n in 1:length(nodes)
+        count = nodes.edge_count[n]
+        len_edges = length(nodes.edge_idxs[n])
+        @assert count == len_edges "For node $n: $count != $len_edges"
+        for i in nodes.edge_idxs[n]
+            e > 1 && print(io, ",")
+            println(io)
+            _write_decimal_number(io, nodes.edges.type[i], _digits_buf)
+            print(io, ",")
+            _write_decimal_number(io, nodes.edges.name_or_index[i], _digits_buf)
+            print(io, ",")
+            _write_decimal_number(io, nodes.edges.to_pos[i], _digits_buf)
+            if !(nodes.edges.to_pos[i] % 7 == 0)
+                @warn "Bug in to_pos for edge $i from node $n: $(nodes.edges.to_pos[i])"
+            end
+            e += 1
+        end
     end
+    println(io, "],")
     open(string(in_prefix, ".strings"), "r") do strings_io
         skip(strings_io, 2) # skip "{\n"
-        println(io, "],")
         write(io, strings_io) # strings contain the trailing "}" so we close out what we opened in preamble
     end
     return nothing

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -90,7 +90,7 @@ function assemble_snapshot(in_prefix, io::IO)
 
     shouldlog(i) = false
     # N = 100000
-    # shouldlog(i) = i % N == 0
+    # shouldlog(i) = i % 10000 == 0
     #     N *= 10
     #     return true
     # else
@@ -171,6 +171,7 @@ function assemble_snapshot(in_prefix, io::IO)
         print(io, ",0,0")
     end
     print(io, "],\"edges\":[")
+    shouldloge(i) = i % 10000 == 0
     e = 1
     for n in 1:length(nodes)
         count = nodes.edge_count[n]
@@ -186,6 +187,10 @@ function assemble_snapshot(in_prefix, io::IO)
             _write_decimal_number(io, nodes.edges.to_pos[i], _digits_buf)
             if !(nodes.edges.to_pos[i] % 7 == 0)
                 @warn "Bug in to_pos for edge $i from node $n: $(nodes.edges.to_pos[i])"
+            end
+            shouldloge(i) && println("Edge $i: type $(nodes.edges.type[i])")
+            if nodes.edges.type[i] == 2 # "element" (array index)
+                println("Array Edge $i: index $(nodes.edges.name_or_index[i])")
             end
             e += 1
         end

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -1,0 +1,161 @@
+# TODO(PR): This code hasn't been reviewed yet.
+
+module HeapSnapshot
+
+# SoA layout to reduce padding
+struct Edges
+    type::Vector{Int8}       # index into `snapshot.meta.edge_types`
+    name_index::Vector{UInt} # index into `snapshot.strings`
+    to_pos::Vector{UInt32}   # index into `snapshot.nodes`
+end
+function init_edges(n::Int)
+    Edges(
+        Vector{Int8}(undef, n),
+        Vector{UInt}(undef, n),
+        Vector{UInt32}(undef, n),
+    )
+end
+Base.length(n::Edges) = length(n.type)
+
+# trace_node_id and detachedness are always 0 in the snapshots Julia produces so we don't store them
+struct Nodes
+    type::Vector{Int8}         # index in index into `snapshot.meta.node_types`
+    name_index::Vector{UInt32} # index in `snapshot.strings`
+    id::Vector{UInt}           # unique id, in julia it is the address of the object
+    self_size::Vector{Int}     # size of the object itself, not including the size of its fields
+    edge_count::Vector{UInt32} # number of outgoing edges
+    edges::Edges               # outgoing edges
+end
+function init_nodes(n::Int, e::Int)
+    Nodes(
+        Vector{Int8}(undef, n),
+        Vector{UInt32}(undef, n),
+        Vector{UInt}(undef, n),
+        Vector{Int}(undef, n),
+        Vector{UInt32}(undef, n),
+        init_edges(e),
+    )
+end
+Base.length(n::Nodes) = length(n.type)
+
+# Like Base.dec, but doesn't allocate a string and writes directly to the io object
+# We know all of the numbers we're about to write fit into a UInt and are non-negative
+let _digits_buf = zeros(UInt8, ndigits(typemax(UInt))),
+    _dec_d100 = UInt16[(0x30 + i % 10) << 0x8 + (0x30 + i ÷ 10) for i = 0:99]
+    global _write_decimal_number
+    _write_decimal_number(io, x::Integer, a=_digits_buf) = _write_decimal_number(io, unsigned(x), a)
+    function _write_decimal_number(io, x::Unsigned, a=_digits_buf)
+        n = ndigits(x)
+        i = n
+        @inbounds while i >= 2
+            d, r = divrem(x, 0x64)
+            d100 = _dec_d100[(r % Int)::Int + 1]
+            a[i-1] = d100 % UInt8
+            a[i] = (d100 >> 0x8) % UInt8
+            x = oftype(x, d)
+            i -= 2
+        end
+        if i > 0
+            @inbounds a[i] = 0x30 + (rem(x, 0xa) % UInt8)::UInt8
+        end
+        write(io, @view a[max(i, 1):n])
+    end
+end
+
+function assemble_snapshot(in_prefix, out_file::AbstractString)
+    open(out_file, "w") do io
+        assemble_snapshot(in_prefix, io)
+    end
+end
+function assemble_snapshot(in_prefix, io::IO)
+    preamble = read(string(in_prefix, ".json"), String)
+    pos = last(findfirst("node_count\":", preamble)) + 1
+    endpos = findnext(==(','), preamble, pos) - 1
+    node_count = parse(Int, String(@view preamble[pos:endpos]))
+
+    pos = last(findnext("edge_count\":", preamble, endpos)) + 1
+    endpos = findnext(==('}'), preamble, pos) - 1
+    edge_count = parse(Int, String(@view preamble[pos:endpos]))
+
+    nodes = init_nodes(node_count, edge_count)
+
+    # Parse nodes with empty edge counts that we need to fill later
+    # TODO: preallocate line buffer
+    for (i, line) in enumerate(eachline(string(in_prefix, ".nodes")))
+        iter = eachsplit(line, ',')
+        x, s = iterate(iter)
+        node_type = parse(Int8, x)
+        x, s = iterate(iter, s)
+        node_name_index = parse(UInt32, x)
+        x, s = iterate(iter, s)
+        id = parse(UInt, x)
+        x, s = iterate(iter, s)
+        self_size = parse(Int,  x)
+        x, s = iterate(iter, s)
+        edge_count = parse(UInt, x)
+        @assert edge_count == 0
+        x, s = iterate(iter, s)
+        @assert parse(Int8, x) == 0 # trace_node_id
+        x, s = iterate(iter, s)
+        @assert parse(Int8, x) == 0 # detachedness
+
+        nodes.type[i] = node_type
+        nodes.name_index[i] = node_name_index
+        nodes.id[i] = id
+        nodes.self_size[i] = self_size
+        nodes.edge_count[i] = edge_count
+    end
+
+    # Parse the edges to fill in the edge counts for nodes and correct the to_node offsets
+    # TODO: preallocate line buffer
+    for (i, line) in enumerate(eachline(string(in_prefix, ".edges")))
+        iter = eachsplit(line, ',')
+        x, s = iterate(iter)
+        edge_type = parse(Int8, x)
+        x, s = iterate(iter, s)
+        edge_name_index = parse(UInt, x)
+        x, s = iterate(iter, s)
+        to_node = parse(UInt32, x)
+        x, s = iterate(iter, s)
+        from_node = parse(Int,  x)
+
+        nodes.edges.type[i] = edge_type
+        nodes.edges.name_index[i] = edge_name_index
+        nodes.edges.to_pos[i] = to_node * 7 # 7 fields per node, the streaming format doesn't multiply the offset by 7
+        nodes.edge_count[from_node] += UInt32(1)
+    end
+
+    _digits_buf = zeros(UInt8, ndigits(typemax(UInt)))
+    println(io, @view(preamble[1:end-2]), ",") # remove trailing "}\n", we don't end the snapshot here
+    println(io, "\"nodes\":[")
+    for i in 1:length(nodes)
+        i > 1 && println(io, ",")
+        _write_decimal_number(io, nodes.type[i], _digits_buf)
+        print(io, ",")
+        _write_decimal_number(io, nodes.name_index[i], _digits_buf)
+        print(io, ",")
+        _write_decimal_number(io, nodes.id[i], _digits_buf)
+        print(io, ",")
+        _write_decimal_number(io, nodes.self_size[i], _digits_buf)
+        print(io, ",")
+        _write_decimal_number(io, nodes.edge_count[i], _digits_buf)
+        print(io, ",0,0")
+    end
+    println(io, "],\"edges\":[")
+    for i in 1:length(nodes.edges)
+        i > 1 && println(io, ",")
+        _write_decimal_number(io, nodes.edges.type[i], _digits_buf)
+        print(io, ",")
+        _write_decimal_number(io, nodes.edges.name_index[i], _digits_buf)
+        print(io, ",")
+        _write_decimal_number(io, nodes.edges.to_pos[i], _digits_buf)
+    end
+    open(string(in_prefix, ".strings"), "r") do strings_io
+        skip(strings_io, 2) # skip "{\n"
+        println(io, "],")
+        write(io, strings_io) # strings contain the trailing "}" so we close out what we opened in preamble
+    end
+    return nothing
+end
+
+end

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -19,8 +19,8 @@ Base.length(n::Edges) = length(n.type)
 
 # trace_node_id and detachedness are always 0 in the snapshots Julia produces so we don't store them
 struct Nodes
-    type::Vector{Int8}         # index in index into `snapshot.meta.node_types`
-    name_index::Vector{UInt32} # index in `snapshot.strings`
+    type::Vector{Int8}         # index into `snapshot.meta.node_types`
+    name_index::Vector{UInt32} # index into `snapshot.strings`
     id::Vector{UInt}           # unique id, in julia it is the address of the object
     self_size::Vector{Int}     # size of the object itself, not including the size of its fields
     edge_count::Vector{UInt32} # number of outgoing edges

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -1,4 +1,4 @@
-# TODO(PR): This code hasn't been reviewed yet.
+# This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module HeapSnapshot
 
@@ -88,19 +88,9 @@ function assemble_snapshot(in_prefix, io::IO)
 
     nodes = init_nodes(node_count, edge_count)
 
-    shouldlog(i) = false
-    # N = 100000
-    # shouldlog(i) = i % 10000 == 0
-    #     N *= 10
-    #     return true
-    # else
-    #     return false
-    # end
-
     # Parse nodes with empty edge counts that we need to fill later
     nodes_file = open(string(in_prefix, ".nodes"), "r")
     for i in 1:length(nodes)
-        shouldlog(i) && println("Parsing node $i")
         node_type = read(nodes_file, Int8)
         node_name_idx = read(nodes_file, UInt)
         id = read(nodes_file, UInt)
@@ -113,15 +103,6 @@ function assemble_snapshot(in_prefix, io::IO)
         nodes.id[i] = id
         nodes.self_size[i] = self_size
         nodes.edge_count[i] = 0 # edge_count
-
-        shouldlog(i) && begin
-            println("Parsed node $i")
-            @show node_type
-            @show node_name_idx
-            @show id
-            @show self_size
-            @show edge_count
-        end
     end
 
     # Parse the edges to fill in the edge counts for nodes and correct the to_node offsets
@@ -156,7 +137,6 @@ function assemble_snapshot(in_prefix, io::IO)
         print(io, ",0,0")
     end
     print(io, "],\"edges\":[")
-    shouldloge(i) = i % 10000 == 0
     e = 1
     for n in 1:length(nodes)
         count = nodes.edge_count[n]
@@ -173,10 +153,6 @@ function assemble_snapshot(in_prefix, io::IO)
             if !(nodes.edges.to_pos[i] % 7 == 0)
                 @warn "Bug in to_pos for edge $i from node $n: $(nodes.edges.to_pos[i])"
             end
-            # shouldloge(i) && println("Edge $i: type $(nodes.edges.type[i])")
-            # if nodes.edges.type[i] == 2 # "element" (array index)
-            #     println("Array Edge $i: index $(nodes.edges.name_or_index[i])")
-            # end
             e += 1
         end
     end

--- a/stdlib/Profile/src/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/src/heapsnapshot_reassemble.jl
@@ -188,10 +188,10 @@ function assemble_snapshot(in_prefix, io::IO)
             if !(nodes.edges.to_pos[i] % 7 == 0)
                 @warn "Bug in to_pos for edge $i from node $n: $(nodes.edges.to_pos[i])"
             end
-            shouldloge(i) && println("Edge $i: type $(nodes.edges.type[i])")
-            if nodes.edges.type[i] == 2 # "element" (array index)
-                println("Array Edge $i: index $(nodes.edges.name_or_index[i])")
-            end
+            # shouldloge(i) && println("Edge $i: type $(nodes.edges.type[i])")
+            # if nodes.edges.type[i] == 2 # "element" (array index)
+            #     println("Array Edge $i: index $(nodes.edges.name_or_index[i])")
+            # end
             e += 1
         end
     end

--- a/stdlib/Profile/test/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/test/heapsnapshot_reassemble.jl
@@ -12,7 +12,19 @@ using Test
     end
     @test test_write(0) == "0"
     @test test_write(99) == "99"
+
+    @test test_write(UInt8(0)) == "0"
+    @test test_write(UInt32(0)) == "0"
+    @test test_write(Int32(0)) == "0"
+
+    @test test_write(UInt8(99)) == "99"
+    @test test_write(UInt32(99)) == "99"
+    @test test_write(Int32(99)) == "99"
+
     # Sample among possible UInts we might print
+    for x in typemin(UInt8):typemax(UInt8)
+        @test test_write(x) == string(x)
+    end
     for x in typemin(UInt):typemax(UInt)÷10001:typemax(UInt)
         @test test_write(x) == string(x)
     end

--- a/stdlib/Profile/test/heapsnapshot_reassemble.jl
+++ b/stdlib/Profile/test/heapsnapshot_reassemble.jl
@@ -1,0 +1,19 @@
+using Test
+
+@testset "_write_decimal_number" begin
+    _digits_buf = zeros(UInt8, ndigits(typemax(UInt)))
+    io = IOBuffer()
+
+    test_write(d) = begin
+        Profile.HeapSnapshot._write_decimal_number(io, d, _digits_buf)
+        s = String(take!(io))
+        seekstart(io)
+        return s
+    end
+    @test test_write(0) == "0"
+    @test test_write(99) == "99"
+    # Sample among possible UInts we might print
+    for x in typemin(UInt):typemax(UInt)÷10001:typemax(UInt)
+        @test test_write(x) == string(x)
+    end
+end

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -295,3 +295,4 @@ end
 end
 
 include("allocs.jl")
+include("heapsnapshot_reassemble.jl")


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/51381.

The solution we came up with here is **stream out the heap snapshot,** to avoid OOMing while recording it, and then **do the downsampling via post-processing,** to satisfy the Chrome devtools.

This allows you to record a heap snapshot from a running julia process, even (or especially) when it's current memory usage is close to the limit, without the snapshotter pushing it over the edge.

Unfortunately, **this currently represents a change in the API**: we now need to write out four files instead of one, and we can no longer support the function that takes an IOBuffer.

Linked here is the current version of our reassembly code, which could probably stand to be cleaned up a bit (thanks @drvi):
- https://gist.github.com/Drvi/37726df2a00d385717e79181539e33bc

-------------------------

I'd like to solicit opinions on whether this kind of breaking change is okay or not for a debugging tool like this.

If we don't want to break this API, I think we can add an _option_, like `streaming=false`. Then, to support the legacy non-streaming mode, I think we have two options:
1. We could include the reassembly code in the `Profiler` stdlib, which maybe we'd want to do _anyway,_ so that people don't have to install another package like HeapSnapshotTools.jl just to use the heap snapshot. Then for the legacy mode, we simply reconstruct the file and write it to the destination.
2. We could keep both the new and the old C++ code, and toggle between them. This seems annoyingly wasteful and messy though.

This PR currently takes approach 1.


Co-Authored-By: @drvi