### PR TITLE
Random: better handling of the "global seed" (using TLS)

### DIFF
--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -718,13 +718,13 @@ end
 
     for seed=seeds
         Random.seed!(seed)
-        @test Random.GLOBAL_SEED === seed
+        @test Random.get_tls_seed() == default_rng()
     end
 
     for ii = 1:8
         iseven(ii) ? Random.seed!(nothing) : Random.seed!()
-        push!(seeds, Random.GLOBAL_SEED)
-        @test Random.GLOBAL_SEED isa UInt128 # could change, but must not be nothing
+        push!(seeds, copy(Random.get_tls_seed()))
+        @test Random.get_tls_seed() isa Xoshiro # could change, but must not be nothing
     end
     @test allunique(seeds)
 end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1589,11 +1589,11 @@ function testset_beginend_call(args, tests, source)
         # we reproduce the logic of guardseed, but this function
         # cannot be used as it changes slightly the semantic of @testset,
         # by wrapping the body in a function
-        local oldrng = copy(default_rng())
-        local oldseed = Random.GLOBAL_SEED
+        local default_rng_orig = copy(default_rng())
+        local tls_seed_orig = copy(Random.get_tls_seed())
         try
-            # default RNG is re-seeded with its own seed to ease reproduce a failed test
-            Random.seed!(Random.GLOBAL_SEED)
+            # default RNG is reset to its state from last `seed!()` to ease reproduce a failed test
+            copy!(Random.default_rng(), tls_seed_orig)
             let
                 $(esc(tests))
             end
@@ -1608,8 +1608,8 @@ function testset_beginend_call(args, tests, source)
                 record(ts, Error(:nontest_error, Expr(:tuple), err, Base.current_exceptions(), $(QuoteNode(source))))
             end
         finally
-            copy!(default_rng(), oldrng)
-            Random.set_global_seed!(oldseed)
+            copy!(default_rng(), default_rng_orig)
+            copy!(Random.get_tls_seed(), tls_seed_orig)
             pop_testset()
             ret = finish(ts)
         end
@@ -1674,10 +1674,7 @@ function testset_forloop(args, testloop, source)
             finish_errored = true
             push!(arr, finish(ts))
             finish_errored = false
-
-            # it's 1000 times faster to copy from tmprng rather than calling Random.seed!
-            copy!(default_rng(), tmprng)
-
+            copy!(default_rng(), tls_seed_orig)
         end
         ts = if ($testsettype === $DefaultTestSet) && $(isa(source, LineNumberNode))
             $(testsettype)($desc; source=$(QuoteNode(source.file)), $options...)
@@ -1703,10 +1700,9 @@ function testset_forloop(args, testloop, source)
         local first_iteration = true
         local ts
         local finish_errored = false
-        local oldrng = copy(default_rng())
-        local oldseed = Random.GLOBAL_SEED
-        Random.seed!(Random.GLOBAL_SEED)
-        local tmprng = copy(default_rng())
+        local default_rng_orig = copy(default_rng())
+        local tls_seed_orig = copy(Random.get_tls_seed())
+        copy!(Random.default_rng(), tls_seed_orig)
         try
             let
                 $(Expr(:for, Expr(:block, [esc(v) for v in loopvars]...), blk))
@@ -1717,8 +1713,8 @@ function testset_forloop(args, testloop, source)
                 pop_testset()
                 push!(arr, finish(ts))
             end
-            copy!(default_rng(), oldrng)
-            Random.set_global_seed!(oldseed)
+            copy!(default_rng(), default_rng_orig)
+            copy!(Random.get_tls_seed(), tls_seed_orig)
         end
         arr
     end


### PR DESCRIPTION
We maintain a "global seed" for this feature of `@testset`:

> Before the execution of the body of a @testset, there is an implicit call to Random.seed!(seed)
where seed is the current seed of the global RNG. Moreover, after the execution of the body, the state of the global RNG is restored to what it was before the @testset. This is meant to ease reproducibility in case of failure, and to allow seamless re-arrangements of @testsets regardless of their side-effect on the global RNG state.

But since we don't use `MersenneTwister` as the "global RNG" anymore, we need to maintain a separate "global seed" object. So far we literally used a global object `Random.GLOBAL_SEED` storing the original seed, but it's not robust when multi-tasking is involved: e.g.
```julia
seed!(0)
x = rand()
seed!(0)
@sync begin
    @async @testset "A" begin
        seed!(1) # reset GLOBAL_SEED to V2
        sleep(2)
    end # reset GLOBAL_SEED to its original value V1
    sleep(0.5)
    @async @testset "B" begin
        # here seed!(2) above has already been called
        # so @testset B recorded value V2 as the "original" value of GLOBAL_SEED
        seed!(2)
        sleep(2)
        # here @testset A already finished
    end # reset GLOBAL_SEED to the wrong original value V2
end
@testset "main task" begin
    # async tests didn't mutate this task's global seed
    @test x == rand() # fails!
end
```

So we store here a "global seed" in `task_local_storage()`, which is set when `seed!()` is invoked without an explicit RNG, and defaults to `Random.GLOBAL_SEED`, which is set only once when `Random` is loaded. And instead of actually storing a seed, we store a copy of the RNG state.

This is still not ideal, in that at the beginning of `@testset "A"` or `@testset "B"`, we can't do `@test x == rand()`, because these are in separate tasks, so the global seed defaults to `Random.GLOBAL_SEED`, and not to the global seed of the parent's task; there might be a nice way to handle that, but at least different tasks don't corrupt each-other's seeds.