### PR TITLE
Random: allow string seeds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,9 +53,10 @@ Standard library changes
 
 #### Random
 * `rand` now supports sampling over `Tuple` types ([#35856], [#50251]).
-* When seeding RNGs provided by `Random`, negative integer seeds can now be used ([#51416]).
-
 * `rand` now supports sampling over `Pair` types ([#28705]).
+* When seeding RNGs provided by `Random`, negative integer seeds can now be used ([#51416]).
+* Seedable random number generators from `Random` can now be seeded by a string, e.g.
+  `seed!(rng, "a random seed")` ([#51527]).
 
 #### REPL
 

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -83,7 +83,7 @@ MersenneTwister(seed, state::DSFMT_state) =
 Create a `MersenneTwister` RNG object. Different RNG objects can have
 their own seeds, which may be useful for generating different streams
 of random numbers.
-The `seed` may be an integer or a vector of `UInt32` integers.
+The `seed` may be an integer, a string, or a vector of `UInt32` integers.
 If no seed is provided, a randomly generated one is created (using entropy from the system).
 See the [`seed!`](@ref) function for reseeding an already existing `MersenneTwister` object.
 
@@ -316,12 +316,22 @@ function hash_seed(seed::Union{AbstractArray{UInt32}, AbstractArray{UInt64}})
     SHA.digest!(ctx)
 end
 
+function hash_seed(str::AbstractString)
+    ctx = SHA.SHA2_256_CTX()
+    for chr in str
+        SHA.update!(ctx, reinterpret(NTuple{4, UInt8}, UInt32(chr)))
+    end
+    SHA.update!(ctx, (0x05,))
+    SHA.digest!(ctx)
+end
+
 
 """
     hash_seed(seed) -> AbstractVector{UInt8}
 
 Return a cryptographic hash of `seed` of size 256 bits (32 bytes).
-`seed` can currently be of type `Union{Integer, DenseArray{UInt32}, DenseArray{UInt64}}`,
+`seed` can currently be of type
+`Union{Integer, AbstractString, AbstractArray{UInt32}, AbstractArray{UInt64}}`,
 but modules can extend this function for types they own.
 
 `hash_seed` is "injective" : if `n != m`, then `hash_seed(n) != `hash_seed(m)`.
@@ -750,13 +760,13 @@ jump!(r::MersenneTwister, steps::Integer) = copy!(r, jump(r, steps))
 # 3, 4: .adv_vals, .idxF (counters to reconstruct the float cache, optional if 5-6 not shown))
 # 5, 6: .adv_ints, .idxI (counters to reconstruct the integer cache, optional)
 
-Random.MersenneTwister(seed::Union{Integer,Vector{UInt32}}, advance::NTuple{6,Integer}) =
+Random.MersenneTwister(seed, advance::NTuple{6,Integer}) =
     advance!(MersenneTwister(seed), advance...)
 
-Random.MersenneTwister(seed::Union{Integer,Vector{UInt32}}, advance::NTuple{4,Integer}) =
+Random.MersenneTwister(seed, advance::NTuple{4,Integer}) =
     MersenneTwister(seed, (advance..., 0, 0))
 
-Random.MersenneTwister(seed::Union{Integer,Vector{UInt32}}, advance::NTuple{2,Integer}) =
+Random.MersenneTwister(seed, advance::NTuple{2,Integer}) =
     MersenneTwister(seed, (advance..., 0, 0, 0, 0))
 
 # advances raw state (per fill_array!) of r by n steps (Float64 values)

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -325,7 +325,8 @@ function hash_seed(str::AbstractString)
     # signature for strings: so far, all hash_seed functions end-up hashing a multiple
     # of 4 bytes of data, and add the signature (1 byte) at the end; so hash as many
     # 0x05 bytes as necessary to have a total number of hashed bytes equal to 1 mod 4
-    SHA.update!(ctx, ntuple(Returns(0x05), 5 - mod1(ncodeunits(str), 4)))
+    a = 4 - mod(ncodeunits(str), 4)
+    SHA.update!(ctx, (0x05, ntuple(Returns(UInt8(a)),  a)...))
     SHA.digest!(ctx)
 end
 

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -324,10 +324,14 @@ function hash_seed(str::AbstractString)
     SHA.update!(ctx, codeunits(str))
     # signature for strings: so far, all hash_seed functions end-up hashing a multiple
     # of 4 bytes of data, and add the signature (1 byte) at the end; so hash as many
-    # 0x05 bytes as necessary to have a total number of hashed bytes equal to 1 mod 4
-    a = 4 - mod(ncodeunits(str), 4)
-    SHA.update!(ctx, (0x05, ntuple(Returns(UInt8(a)),  a)...))
-    SHA.digest!(ctx)
+    # bytes as necessary to have a total number of hashed bytes equal to 0 mod 4 (padding),
+    # and then hash the signature 0x05; in order for strings of different lengths to have
+    # different hashes, padding bytes are set equal to the number of padding bytes
+    pad = 4 - mod(ncodeunits(str), 4)
+    for _=1:pad
+        SHA.update!(ctx, (pad % UInt8,))
+    end
+    SHA.update!(ctx, (0x05,))
 end
 
 

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -332,6 +332,7 @@ function hash_seed(str::AbstractString)
         SHA.update!(ctx, (pad % UInt8,))
     end
     SHA.update!(ctx, (0x05,))
+    SHA.digest!(ctx)
 end
 
 

--- a/stdlib/Random/src/Xoshiro.jl
+++ b/stdlib/Random/src/Xoshiro.jl
@@ -4,7 +4,7 @@
 # Lots of implementation is shared with TaskLocalRNG
 
 """
-    Xoshiro(seed::Integer)
+    Xoshiro(seed::Union{Integer, AbstractString})
     Xoshiro()
 
 Xoshiro256++ is a fast pseudorandom number generator described by David Blackman and


### PR DESCRIPTION
We used to be able to seed RNGs with a string, but that string was interpreted as the filename containing the actual seed. This was deprecated in #21359, in order to later allow using a string seed directly, which this patch does.