### PR TITLE
fix `_tryonce_download_from_cache` (busybox.exe download error)

### DIFF
--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -22,7 +22,7 @@ lscmd = `ls`
 havebb = false
 
 function _tryonce_download_from_cache(desired_url::AbstractString)
-    cache_url = "https://cache.julialang.org/foo/$(desired_url)"
+    cache_url = "https://cache.julialang.org/$(desired_url)"
     cache_output_filename = joinpath(mktempdir(), "myfile")
     cache_response = Downloads.request(
         cache_url;


### PR DESCRIPTION
Removes what seems to be an intentional breakage that wasn't reverted before merge from https://github.com/JuliaLang/julia/pull/47015 which meant we've since never succeeded to use the cache.

Fixes
```
Got exception outside of a @test
--
  | LoadError: RequestError: HTTP/1.1 403 Forbidden while requesting https://frippery.org/files/busybox/busybox.exe
  | Stacktrace:
  | [1] #3
  | @ C:\buildkite-agent\builds\win2k22-amdci6-7\julialang\julia-master\julia-b90a992f06\share\julia\stdlib\v1.11\Downloads\src\Downloads.jl:270 [inlined]

```

This works
```
https://cache.julialang.org/https://frippery.org/files/busybox/busybox.exe
```

This does not
```
https://cache.julialang.org/foo/https://frippery.org/files/busybox/busybox.exe
```