### PR TITLE
Allow for potential customization of TLII

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -1777,7 +1777,7 @@ void jl_dump_native_impl(void *native_code,
 
 void addTargetPasses(legacy::PassManagerBase *PM, const Triple &triple, TargetIRAnalysis analysis)
 {
-    PM->add(new TargetLibraryInfoWrapperPass(triple));
+    PM->add(new TargetLibraryInfoWrapperPass(*createTLII(triple)));
     PM->add(createTargetTransformInfoWrapperPass(std::move(analysis)));
 }
 

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -586,6 +586,9 @@ static inline std::unique_ptr<llvm::TargetLibraryInfoImpl> createTLII(llvm::Trip
         {"julia.safepoint", "julia.safepoint", ElementCount::getFixed(2)},
         {"julia.safepoint", "julia.safepoint", ElementCount::getFixed(4)},
         {"julia.safepoint", "julia.safepoint", ElementCount::getFixed(8)},
+        {"julia.gcroot_flush", "julia.gcroot_flush", ElementCount::getFixed(2)},
+        {"julia.gcroot_flush", "julia.gcroot_flush", ElementCount::getFixed(4)},
+        {"julia.gcroot_flush", "julia.gcroot_flush", ElementCount::getFixed(8)},
     };
     TLII->addVectorizableFunctions(JuliaIntrinsics);
     return std::unique_ptr<llvm::TargetLibraryInfoImpl>(TLII);

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -581,5 +581,12 @@ static inline std::unique_ptr<llvm::TargetLibraryInfoImpl> createTLII(llvm::Trip
     llvm::TargetLibraryInfoImpl *TLII = new llvm::TargetLibraryInfoImpl(TargetTriple);
     // We could add VecLib here, or disable all builtins and replace them with our own.
     // TLII->disableAllFunctions();
+
+    const VecDesc JuliaIntrinsics[] = {
+        {"julia.safepoint", "julia.safepoint", ElementCount::getFixed(2)},
+        {"julia.safepoint", "julia.safepoint", ElementCount::getFixed(4)},
+        {"julia.safepoint", "julia.safepoint", ElementCount::getFixed(8)},
+    };
+    TLII->addVectorizableFunctions(JuliaIntrinsics);
     return std::unique_ptr<llvm::TargetLibraryInfoImpl>(TLII);
 }

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -1,6 +1,9 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
 #include <llvm/ADT/MapVector.h>
+#include <llvm/ADT/Triple.h>
+
+#include <llvm/Analysis/TargetLibraryInfo.h>
 
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Constants.h>
@@ -573,3 +576,10 @@ void optimizeDLSyms(Module &M);
 #include "passes.h"
 
 CodeGenOpt::Level CodeGenOptLevelFor(int optlevel) JL_NOTSAFEPOINT;
+
+static inline std::unique_ptr<llvm::TargetLibraryInfoImpl> createTLII(llvm::Triple TargetTriple) {
+    llvm::TargetLibraryInfoImpl *TLII = new llvm::TargetLibraryInfoImpl(TargetTriple);
+    // We could add VecLib here, or disable all builtins and replace them with our own.
+    // TLII->disableAllFunctions();
+    return std::unique_ptr<llvm::TargetLibraryInfoImpl>(TLII);
+}

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -710,7 +710,7 @@ PIC.addClassToPassName(decltype(CREATE_PASS)::name(), NAME);
         });
         // Register our TargetLibraryInfoImpl.
         FAM.registerPass([&] JL_NOTSAFEPOINT { return llvm::TargetIRAnalysis(TM.getTargetIRAnalysis()); });
-        FAM.registerPass([&] JL_NOTSAFEPOINT { return llvm::TargetLibraryAnalysis(llvm::TargetLibraryInfoImpl(TM.getTargetTriple())); });
+        FAM.registerPass([&] JL_NOTSAFEPOINT { return llvm::TargetLibraryAnalysis(*createTLII(TM.getTargetTriple())); });
         return FAM;
     }
 


### PR DESCRIPTION
Currently NFC.
The most interesting option is to disallow all libcalls,
or enable vectorization.

We could investigate:

```
  /// Return true if the function F has a vector equivalent with any
  /// vectorization factor.
  bool isFunctionVectorizable(StringRef F) const;
 
  /// Return the name of the equivalent of F, vectorized with factor VF. If no
  /// such mapping exists, return the empty string.
  StringRef getVectorizedFunction(StringRef F, const ElementCount &VF,
                                  bool Masked) const;
 ```

