### PR TITLE
add effects for `Cmd` constructor

### DIFF
--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -481,7 +481,9 @@ function cmd_gen(parsed)
     end
 end
 
-@assume_effects :foldable function cmd_gen(parsed::Tuple{Vararg{Tuple{Vararg{Union{String, SubString{String}}}}}})
+@assume_effects :effect_free :terminates_globally :noub function cmd_gen(
+    parsed::Tuple{Vararg{Tuple{Vararg{Union{String, SubString{String}}}}}}
+)
     return @invoke cmd_gen(parsed::Any)
 end
 

--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -481,6 +481,10 @@ function cmd_gen(parsed)
     end
 end
 
+@assume_effects :foldable function cmd_gen(parsed::Tuple{Vararg{Tuple{Vararg{Union{String, SubString{String}}}}}})
+    return @invoke cmd_gen(parsed::Any)
+end
+
 """
     @cmd str
 

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -2071,6 +2071,7 @@ end
     @test !Base.isexported(Base, :ispublic)
 end
 
+<<<<<<< HEAD
 # issue #51194
 for (s, compl) in (("2*CompletionFoo.nam", "named"),
                    (":a isa CompletionFoo.test!1", "test!12"),
@@ -2085,7 +2086,7 @@ for (s, compl) in (("2*CompletionFoo.nam", "named"),
     @test only(c) == compl
 end
 
-let t = REPLCompletions.repl_eval_ex(:(`a b`), @__MODULE__)
+let t = REPLCompletions.repl_eval_ex(:(`a b`), @__MODULE__; limit_aggressive_inference=true)
     @test t isa Core.Const
     @test t.val == `a b`
 end

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -2071,7 +2071,6 @@ end
     @test !Base.isexported(Base, :ispublic)
 end
 
-<<<<<<< HEAD
 # issue #51194
 for (s, compl) in (("2*CompletionFoo.nam", "named"),
                    (":a isa CompletionFoo.test!1", "test!12"),

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -2084,3 +2084,8 @@ for (s, compl) in (("2*CompletionFoo.nam", "named"),
     c, r = test_complete(s)
     @test only(c) == compl
 end
+
+let t = REPLCompletions.repl_eval_ex(:(`a b`), @__MODULE__)
+    @test t isa Core.Const
+    @test t.val == `a b`
+end

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -1116,7 +1116,17 @@ end
     post_opt_refine_effect_free(y, true)
 end |> Core.Compiler.is_effect_free
 
-# constant folding of Cmd construction
-@test Core.Compiler.is_foldable(Base.infer_effects(() -> `a b c`))
-@test Core.Compiler.is_foldable(Base.infer_effects(() -> `a a$("bb")a $("c")`))
-@test !Core.Compiler.is_foldable(Base.infer_effects(x -> `a $x`, (Any,)))
+# effects for Cmd construction
+for f in (() -> `a b c`, () -> `a a$("bb")a $("c")`)
+    effects = Base.infer_effects(f)
+    @test Core.Compiler.is_effect_free(effects)
+    @test Core.Compiler.is_terminates(effects)
+    @test Core.Compiler.is_noub(effects)
+    @test !Core.Compiler.is_consistent(effects)
+end
+let effects = Base.infer_effects(x -> `a $x`, (Any,))
+    @test !Core.Compiler.is_effect_free(effects)
+    @test !Core.Compiler.is_terminates(effects)
+    @test !Core.Compiler.is_noub(effects)
+    @test !Core.Compiler.is_consistent(effects)
+end

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -1115,3 +1115,8 @@ end
 @test Base.infer_effects((Base.RefValue{Any},)) do y
     post_opt_refine_effect_free(y, true)
 end |> Core.Compiler.is_effect_free
+
+# constant folding of Cmd construction
+@test Core.Compiler.is_foldable(Base.infer_effects(() -> `a b c`))
+@test Core.Compiler.is_foldable(Base.infer_effects(() -> `a a$("bb")a $("c")`))
+@test !Core.Compiler.is_foldable(Base.infer_effects(x -> `a $x`, (Any,)))


### PR DESCRIPTION
Interestingly, `repl_eval_ex` currently evaluates `` :(`a b`) `` as
```Const(``)```. Any idea what's going on with that?
