### PR TITLE
smarter path completions in REPL shell mode

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -562,11 +562,11 @@ function complete_line(c::REPLCompletionProvider, s::PromptState, mod::Module)
     return unique!(map(completion_text, ret)), partial[range], should_complete
 end
 
-function complete_line(c::ShellCompletionProvider, s::PromptState)
+function complete_line(c::ShellCompletionProvider, s::PromptState, mod::Module=nothing)
     # First parse everything up to the current position
     partial = beforecursor(s.input_buffer)
     full = LineEdit.input_string(s)
-    ret, range, should_complete = shell_completions(full, lastindex(partial))
+    ret, range, should_complete = shell_completions(full, lastindex(partial), mod)
     return unique!(map(completion_text, ret)), partial[range], should_complete
 end
 

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -1246,8 +1246,8 @@ function shell_completions(string, pos, mod)
     ex = args.args[end]::Expr
     # Now look at the last thing we parsed
     isempty(ex.args) && return Completion[], 0:-1, false
-    arg = ex.args[end]
-    if isexpr(arg, :incomplete) || isexpr(arg, :error)
+    last_arg = ex.args[end]
+    if isexpr(last_arg, :incomplete) || isexpr(last_arg, :error)
         partial = scs[last_parse]
         ret, range = completions(partial, lastindex(partial))
         range = range .+ (first(last_parse) - 1)
@@ -1293,8 +1293,8 @@ function shell_completions(string, pos, mod)
 
     # Only replace literal user input - not interpolations - with the available completion
     should_complete = false
-    if arg isa AbstractString
-        head, tail = splitdir(arg)
+    if last_arg isa AbstractString
+        head, tail = splitdir(String(last_arg)::String)
         if !isempty(head)
             last_parse = nextind(string, last(last_parse))-ncodeunits(tail):last(last_parse)
             should_complete = true

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -155,7 +155,7 @@ function map_completion_text(completions)
 end
 
 test_complete(s) = map_completion_text(@inferred(completions(s, lastindex(s))))
-test_scomplete(s) =  map_completion_text(@inferred(shell_completions(s, lastindex(s))))
+test_scomplete(s, m=@__MODULE__) =  map_completion_text(@inferred(shell_completions(s, lastindex(s), m)))
 test_bslashcomplete(s) =  map_completion_text(@inferred(bslash_completions(s, lastindex(s)))[2])
 test_complete_context(s, m=@__MODULE__) =  map_completion_text(@inferred(completions(s,lastindex(s), m)))
 test_complete_foo(s) = test_complete_context(s, Main.CompletionFoo)

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -661,7 +661,12 @@ let p = run(`$sleepcmd 100`, wait=false)
 end
 
 # Second argument of shell_parse
-let s = "   \$abc   "
+let
+    s = "   \$abc   "
+    @test s[Base.shell_parse(s)[2]] == ""
+    @test first(Base.shell_parse(s)[2]) == nextind(s, lastindex(s))
+
+    s = "   \$abc"
     @test s[Base.shell_parse(s)[2]] == "abc"
 end
 


### PR DESCRIPTION
Uses the fancy new inference-based completion infrastructure to complete
expressions like `ls $(DEPOT_PATH[1])/<tab>` in the REPL shell. Currently
doesn't extend to path completions for cmd and string literals in the
normal REPL mode, but that shouldn't be too hard to add.

Still needs tests
