### PR TITLE
add variant of regex.jl:match() that updates idx

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,9 @@ New library features
 * `replace(string, pattern...)` now supports an optional `IO` argument to
   write the output to a stream rather than returning a string ([#48625]).
 
+* `match(regex, string, idx)` now supports updating `idx::Ref{Int}` to
+  point at the first character after a successful match ([#51429])
+
 Standard library changes
 ------------------------
 

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -428,6 +428,42 @@ match(r::Regex, s::AbstractString, i::Integer) = throw(ArgumentError(
     "regex matching is only available for the String type; use String(s) to convert"
 ))
 
+"""
+    match(r::Regex, s::Union{SubString{String}, String}, idx::Ref{Int}[, addopts])
+
+If `idx` is a reference (of type `Ref{Int}`), then the dereferenced
+value `idx[]` is used as the start index for the search. If a match is
+found, then `idx[]` is updated to the index of the first character
+after that match. If the match extends to the end of `s`, then
+`idx[] == firstindex(str) + ncodeunits(str)`.
+
+# Example
+```jldoctest
+julia> s = "10+2"; i = Ref{Int}(firstindex(s));
+
+julia> match(r"\\G\\d+", s, i)
+RegexMatch("10")
+
+julia> match(r"\\G\\d+", s, i)
+
+julia> match(r"\\G\\+\\d+", s, i)
+RegexMatch("+2")
+
+julia> match(r"\\G\\+\\d+", s, i)
+
+julia> i[]
+5
+```
+"""
+function match(re::Regex, str::Union{SubString{String}, String},
+               idx::Ref{Int}, add_opts::UInt32=UInt32(0))
+    m = match(re, str, idx[], add_opts)
+    if m !== nothing
+        idx[] = m.offset + ncodeunits(m.match)
+    end
+    return m
+end
+
 findnext(re::Regex, str::Union{String,SubString}, idx::Integer) = _findnext_re(re, str, idx, C_NULL)
 
 # TODO: return only start index and update deprecation

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -35,6 +35,7 @@ Base.isvalid(::Any)
 Base.isvalid(::Any, ::Any)
 Base.isvalid(::AbstractString, ::Integer)
 Base.match
+Base.match(::Regex, ::Union{SubString{String}, String}, ::Ref{Int})
 Base.eachmatch
 Base.RegexMatch
 Base.keys(::RegexMatch)

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -213,6 +213,14 @@
         end
     end
 
+    @testset "continue index" begin
+        s = "a1a2a3"
+        idx = Ref(firstindex(s))
+        @test [match(r"\Ga\d", s, idx).match for i=1:3] == ["a1", "a2", "a3"]
+        @test match(r"\Ga\d", s, idx) === nothing &&
+            idx[] == firstindex(s) + ncodeunits(s)
+    end
+
     @testset "Destructuring dispatch" begin
         handle(::Nothing) = "not found"
         handle((capture,)::RegexMatch) = "found $capture"


### PR DESCRIPTION
Allow `idx` to be a `Ref{Int}`, so it can be updated easily to always point at the first character not yet matched. This is particularly useful e.g. when writing parsers that repeatedly call `match()` as a token scanner on the same string, allowing them to start the next match right after the previous one, usually with the regex anchored to the `idx` position with `\G`.

fixes #51429
