### PR TITLE
Fix infinite loop when inputs are `Inf`

### DIFF
--- a/stdlib/LinearAlgebra/src/givens.jl
+++ b/stdlib/LinearAlgebra/src/givens.jl
@@ -76,7 +76,6 @@ floatmin2(::Type{T}) where {T} = (twopar = 2one(T); twopar^trunc(Integer,log(flo
 # NAG Ltd.
 function givensAlgorithm(f::T, g::T) where T<:AbstractFloat
     onepar = one(T)
-    twopar = 2one(T)
     T0 = typeof(onepar) # dimensionless
     zeropar = T0(zero(T)) # must be dimensionless
 
@@ -105,7 +104,7 @@ function givensAlgorithm(f::T, g::T) where T<:AbstractFloat
                 f1 *= safmn2
                 g1 *= safmn2
                 scalepar = max(abs(f1), abs(g1))
-                if scalepar < safmx2u break end
+                if scalepar < safmx2u || count >= 20 break end
             end
             r = sqrt(f1*f1 + g1*g1)
             cs = f1/r
@@ -149,7 +148,7 @@ end
 # Univ. of Colorado Denver
 # NAG Ltd.
 function givensAlgorithm(f::Complex{T}, g::Complex{T}) where T<:AbstractFloat
-    twopar, onepar = 2one(T), one(T)
+    onepar = one(T)
     T0 = typeof(onepar) # dimensionless
     zeropar = T0(zero(T)) # must be dimensionless
     czero = complex(zeropar)
@@ -170,7 +169,7 @@ function givensAlgorithm(f::Complex{T}, g::Complex{T}) where T<:AbstractFloat
             fs *= safmn2
             gs *= safmn2
             scalepar *= safmn2
-            if scalepar < safmx2u break end
+            if scalepar < safmx2u || count >= 20 break end
         end
     elseif scalepar <= safmn2u
         if g == 0
@@ -193,13 +192,13 @@ function givensAlgorithm(f::Complex{T}, g::Complex{T}) where T<:AbstractFloat
         # This is a rare case: F is very small.
         if f == 0
             cs = zero(T)
-            r = complex(hypot(real(g), imag(g)))
+            r = complex(abs(g))
             # do complex/real division explicitly with two real divisions
-            d = hypot(real(gs), imag(gs))
+            d = abs(gs)
             sn = complex(real(gs)/d, -imag(gs)/d)
             return cs, sn, r
         end
-        f2s = hypot(real(fs), imag(fs))
+        f2s = abs(fs)
         # g2 and g2s are accurate
         # g2 is at least safmin, and g2s is at least safmn2
         g2s = sqrt(g2)
@@ -214,7 +213,7 @@ function givensAlgorithm(f::Complex{T}, g::Complex{T}) where T<:AbstractFloat
         # make sure abs(ff) = 1
         # do complex/real division explicitly with 2 real divisions
         if abs1(f) > 1
-            d = hypot(real(f), imag(f))
+            d = abs(f)
             ff = complex(real(f)/d, imag(f)/d)
         else
             dr = safmx2*real(f)

--- a/stdlib/LinearAlgebra/test/givens.jl
+++ b/stdlib/LinearAlgebra/test/givens.jl
@@ -3,7 +3,7 @@
 module TestGivens
 
 using Test, LinearAlgebra, Random
-using LinearAlgebra: Givens, Rotation
+using LinearAlgebra: Givens, Rotation, givensAlgorithm
 
 # Test givens rotations
 @testset "Test Givens for $elty" for elty in (Float32, Float64, ComplexF32, ComplexF64)
@@ -110,6 +110,15 @@ oneunit(::Type{<:MockUnitful{T}}) where T = MockUnitful(one(T))
     @test g.c ≈ 3/5
     @test g.s ≈ 4/5
     @test r.data ≈ 5.0
+end
+
+# 51554
+# avoid infinite loop on Inf inputs
+@testset "givensAlgorithm - Inf inputs" for T in (Float64, ComplexF64)
+    cs, sn, r = givensAlgorithm(T(Inf), T(1.0))
+    @test !isfinite(r)
+    cs, sn, r = givensAlgorithm(T(1.0), T(Inf))
+    @test !isfinite(r)
 end
 
 end # module TestGivens


### PR DESCRIPTION
This adds a limit of 20 iterations to avoid an infinite loop when either `f` or `g` are +/- Inf. The 20 is taken from LAPACK's `dlartgp`.

Also, currently `givensAlgorithm` for real floats does not follow the sign convention of either LAPACK function `dlartg` or `dlartgp (r >= 0)`. When `|f| < |g|`, the result matches `dlartg`, but when `|f| > |g|`, the result matches `dlartgp`. I don't know if that's on purpose. The complex version matches LAPACK.