### PR TITLE
Fix last startup & shutdown precompiles

### DIFF
--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -45,6 +45,11 @@ precompile(isequal, (String, String))
 precompile(Base.check_open, (Base.TTY,))
 precompile(Base.getproperty, (Base.TTY, Symbol))
 precompile(write, (Base.TTY, String))
+precompile(Tuple{typeof(Base.get), Base.TTY, Symbol, Bool})
+precompile(Tuple{typeof(Base.hashindex), String, Int64})
+precompile(Tuple{typeof(Base.write), Base.GenericIOBuffer{Array{UInt8, 1}}, String})
+precompile(Tuple{typeof(Base.indexed_iterate), Tuple{Nothing, Int64}, Int64})
+precompile(Tuple{typeof(Base.indexed_iterate), Tuple{Nothing, Int64}, Int64, Int64})
 
 # used by Revise.jl
 precompile(Tuple{typeof(Base.parse_cache_header), String})
@@ -57,6 +62,7 @@ precompile(Tuple{typeof(delete!), Dict{Base.PkgId,Vector{Function}}, Base.PkgId}
 precompile(Tuple{typeof(push!), Vector{Function}, Function})
 
 # miscellaneous
+precompile(Tuple{typeof(Base.exit)})
 precompile(Tuple{typeof(Base.require), Base.PkgId})
 precompile(Tuple{typeof(Base.recursive_prefs_merge), Base.Dict{String, Any}})
 precompile(Tuple{typeof(Base.recursive_prefs_merge), Base.Dict{String, Any}, Base.Dict{String, Any}, Vararg{Base.Dict{String, Any}}})

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -25,6 +25,7 @@ const PARALLEL_PRECOMPILATION = true
 const debug_output = devnull # or stdout
 
 CTRL_C = '\x03'
+CTRL_D = '\x04'
 CTRL_R = '\x12'
 UP_ARROW = "\e[A"
 DOWN_ARROW = "\e[B"
@@ -130,7 +131,7 @@ generate_precompile_statements() = try
                     sleep(0.1)
                 end
             end
-            write(ptm, "exit()\n")
+            write(ptm, "$CTRL_D")
             wait(tee)
             success(p) || Base.pipeline_error(p)
             close(ptm)


### PR DESCRIPTION
## Before
```
% ./julia  --startup-file=no --trace-compile=stderr
precompile(Tuple{typeof(Base.print), Base.GenericIOBuffer{Array{UInt8, 1}}, UInt16})
precompile(Tuple{typeof(Base.get), Base.TTY, Symbol, Bool})
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.11.0-DEV.590 (2023-10-02)
 _/ |\__'_|_|_|\__'_|  |  Commit ac8246fa60b (0 days old master)
|__/                   |

precompile(Tuple{typeof(Base.hashindex), String, Int64})
precompile(Tuple{typeof(Base.write), Base.GenericIOBuffer{Array{UInt8, 1}}, String})
julia> ^D
precompile(Tuple{REPL.LineEdit.var"#27#28"{REPL.LineEdit.var"#119#175", String}, Any, Any})
precompile(Tuple{REPL.LineEdit.var"#119#175", REPL.LineEdit.MIState, Any, Vararg{Any}})
precompile(Tuple{REPL.LineEdit.var"##edit_abort#113", Any, typeof(REPL.LineEdit.edit_abort), REPL.LineEdit.MIState, Bool})

precompile(Tuple{typeof(Base.indexed_iterate), Tuple{Nothing, Int64}, Int64})
precompile(Tuple{typeof(Base.indexed_iterate), Tuple{Nothing, Int64}, Int64, Int64})
precompile(Tuple{REPL.var"#62#68"{REPL.REPLBackendRef}})
% 
```

## This PR
```
% ./julia --startup-file=no --trace-compile=stderr
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.11.0-DEV.591 (2023-10-03)
 _/ |\__'_|_|_|\__'_|  |  Commit 6a1af7632b* (0 days old master)
|__/                   |

julia> ^D
%
```

on
```
julia> versioninfo()
Julia Version 1.11.0-DEV.591
Commit 6a1af7632b* (2023-10-03 00:30 UTC)
Platform Info:
  OS: macOS (arm64-apple-darwin23.0.0)
  CPU: 10 × Apple M2 Pro
  WORD_SIZE: 64
  LLVM: libLLVM-15.0.7 (ORCJIT, apple-m1)
  Threads: 1 on 6 virtual cores
```