### PR TITLE
Improve deepcopy documentation to clarify reference behavior

### DIFF
--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -9,8 +9,11 @@
     deepcopy(x)
 
 Create a deep copy of `x`: everything is copied recursively, resulting in a fully
-independent object. For example, deep-copying an array produces a new array whose elements
-are deep copies of the original elements. Calling `deepcopy` on an object should generally
+independent object. For example, deep-copying an array creates deep copies of all
+the objects it contains and produces a new array with the consistent relationship
+structure (e.g., if the first two elements are the same object in the original array,
+the first two elements of the new array will also be the same `deepcopy`ed object).
+Calling `deepcopy` on an object should generally
 have the same effect as serializing and then deserializing it.
 
 While it isn't normally necessary, user-defined types can override the default `deepcopy`


### PR DESCRIPTION
The original text here:

> For example, deep-copying an array produces a new array whose elements are deep copies of the original elements

reads to me that its implementation would do something like `deepcopy(array) = [deepcopy(element) for element in array]`.  That's the wrong mental model — we preserve relationships.  This is tricky to talk about, but I think this gets at the crux of it.