### PR TITLE
support `public` in fallback/legacy parser

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1069,83 +1069,82 @@ export
     @views,
     @static
 
-# TODO: use normal syntax once JuliaSyntax.jl becomes available at this point in bootstrapping
-eval(Expr(:public,
+public
 # Modules
-    :Checked,
-    :Filesystem,
-    :Order,
-    :Sort,
+    Checked,
+    Filesystem,
+    Order,
+    Sort,
 
 # Types
-    :AbstractLock,
-    :AsyncCondition,
-    :CodeUnits,
-    :Event,
-    :Fix1,
-    :Fix2,
-    :Generator,
-    :ImmutableDict,
-    :OneTo,
-    :UUID,
+    AbstractLock,
+    AsyncCondition,
+    CodeUnits,
+    Event,
+    Fix1,
+    Fix2,
+    Generator,
+    ImmutableDict,
+    OneTo,
+    UUID,
 
 # Semaphores
-    :Semaphore,
-    :acquire,
-    :release,
+    Semaphore,
+    acquire,
+    release,
 
 # collections
-    :IteratorEltype,
-    :IteratorSize,
-    :to_index,
-    :vect,
-    :isdone,
-    :front,
-    :rest,
-    :split_rest,
-    :tail,
-    :checked_length,
+    IteratorEltype,
+    IteratorSize,
+    to_index,
+    vect,
+    isdone,
+    front,
+    rest,
+    split_rest,
+    tail,
+    checked_length,
 
 # Loading
-    :DL_LOAD_PATH,
-    :load_path,
-    :active_project,
+    DL_LOAD_PATH,
+    load_path,
+    active_project,
 
 # Reflection and introspection
-    :isambiguous,
-    :isexpr,
-    :isidentifier,
-    :issingletontype,
-    :identify_package,
-    :locate_package,
-    :moduleroot,
-    :jit_total_bytes,
-    :summarysize,
-    :isexported,
-    :ispublic,
+    isambiguous,
+    isexpr,
+    isidentifier,
+    issingletontype,
+    identify_package,
+    locate_package,
+    moduleroot,
+    jit_total_bytes,
+    summarysize,
+    isexported,
+    ispublic,
 
 # Opperators
-    :operator_associativity,
-    :operator_precedence,
-    :isbinaryoperator,
-    :isoperator,
-    :isunaryoperator,
+    operator_associativity,
+    operator_precedence,
+    isbinaryoperator,
+    isoperator,
+    isunaryoperator,
 
 # C interface
-    :cconvert,
-    :unsafe_convert,
+    cconvert,
+    unsafe_convert,
 
 # Error handling
-    :exit_on_sigint,
-    :windowserror,
+    exit_on_sigint,
+    windowserror,
 
 # Macros
-    Symbol("@assume_effects"),
-    Symbol("@constprop"),
-    Symbol("@locals"),
-    Symbol("@propagate_inbounds"),
+    @assume_effects,
+    @constprop,
+    @locals,
+    @propagate_inbounds,
 
 # misc
-    :notnothing,
-    :runtests,
-    :text_colors))
+    notnothing,
+    runtests,
+    text_colors

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -249,7 +249,7 @@
            ;; misc syntax forms
            ((import using)
             (string (car e) " " (string.join (map deparse-import-path (cdr e)) ", ")))
-           ((global local export) (string (car e) " " (string.join (map deparse (cdr e)) ", ")))
+           ((global local export public) (string (car e) " " (string.join (map deparse (cdr e)) ", ")))
            ((const)        (string "const " (deparse (cadr e))))
            ((top)          (deparse (cadr e)))
            ((core)         (string "Core." (deparse (cadr e))))

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -140,7 +140,7 @@
 
 (define (toplevel-only-expr? e)
   (and (pair? e)
-       (or (memq (car e) '(toplevel line module import using export
+       (or (memq (car e) '(toplevel line module import using export public
                                     error incomplete))
            (and (memq (car e) '(global const)) (every symbol? (cdr e))))))
 


### PR DESCRIPTION
This should do it!

@c42f or @LilithHafner I'd ilke to share JuliaSyntax's tests for this; I know it has a mechanism for comparing the two parsers' outputs, can we run the tests for `public` through those?