### PR TITLE
Use `oneto` instead of `OneTo` when constructing `LinearIndices`

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -485,7 +485,7 @@ LinearIndices(inds::NTuple{N,Union{<:Integer,AbstractUnitRange{<:Integer}}}) whe
     LinearIndices(map(_convert2ind, inds))
 LinearIndices(A::Union{AbstractArray,SimpleVector}) = LinearIndices(axes(A))
 
-_convert2ind(i::Integer) = Base.OneTo(i)
+_convert2ind(i::Integer) = oneto(i)
 _convert2ind(ind::AbstractUnitRange) = first(ind):last(ind)
 
 function indices_promote_type(::Type{Tuple{R1,Vararg{R1,N}}}, ::Type{Tuple{R2,Vararg{R2,N}}}) where {R1,R2,N}

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -59,11 +59,18 @@ end
     @test checkbounds(Bool, A, CartesianIndex((5,)), CartesianIndex((4,)), CartesianIndex((4,)))  == false
 end
 
-@testset "Infinite CartesianIndices" begin
+@testset "Infinite axes" begin
     r = OneToInf()
-    C = CartesianIndices(size(r))
-    ax = to_indices(r, (C,))[1]
-    @test ax === r
+    @testset "CartesianIndices" begin
+        C = CartesianIndices(size(r))
+        ax = to_indices(r, (C,))[1]
+        @test ax === r
+    end
+    @testset "LinearIndices" begin
+        L = LinearIndices(size(r))
+        ax = to_indices(r, (L,))[1]
+        @test ax === L
+    end
 end
 
 @testset "vector indices" begin


### PR DESCRIPTION
This permits constructing `LinearIndices` for infinite arrays, for which the axes can't be a `Base.OneTo`:
```julia
julia> using InfiniteArrays

julia> L = LinearIndices(1:∞)
ℵ₀-element LinearIndices{1, Tuple{InfiniteArrays.OneToInf{Int64}}} with indices OneToInf():
  1
  2
  3
  4
  5
  6
  7
  8
  9
 10
  ⋮
```