### PR TITLE
[REPLCompletions] fix #51548, set up a mode to limit the scope of the aggressive inference

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1761,13 +1761,13 @@ This function will return an `Effects` object with information about the computa
 - [`Base.@assume_effects`](@ref): A macro for making assumptions about the effects of a method.
 """
 function infer_effects(@nospecialize(f), @nospecialize(types=default_tt(f));
-                       world = get_world_counter(),
-                       interp = Core.Compiler.NativeInterpreter(world))
+                       world::UInt=get_world_counter(),
+                       interp::Core.Compiler.AbstractInterpreter=Core.Compiler.NativeInterpreter(world))
     (ccall(:jl_is_in_pure_context, Bool, ()) || world == typemax(UInt)) &&
         error("code reflection cannot be used from generated functions")
     if isa(f, Core.Builtin)
         types = to_tuple_type(types)
-        argtypes = Any[Core.Compiler.Const(f), types.parameters...]
+        argtypes = Any[Core.Const(f), types.parameters...]
         rt = Core.Compiler.builtin_tfunction(interp, f, argtypes[2:end], nothing)
         return Core.Compiler.builtin_effects(Core.Compiler.typeinf_lattice(interp), f,
             Core.Compiler.ArgInfo(nothing, argtypes), rt)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1761,13 +1761,13 @@ This function will return an `Effects` object with information about the computa
 - [`Base.@assume_effects`](@ref): A macro for making assumptions about the effects of a method.
 """
 function infer_effects(@nospecialize(f), @nospecialize(types=default_tt(f));
-                       world::UInt=get_world_counter(),
-                       interp::Core.Compiler.AbstractInterpreter=Core.Compiler.NativeInterpreter(world))
+                       world = get_world_counter(),
+                       interp = Core.Compiler.NativeInterpreter(world))
     (ccall(:jl_is_in_pure_context, Bool, ()) || world == typemax(UInt)) &&
         error("code reflection cannot be used from generated functions")
     if isa(f, Core.Builtin)
         types = to_tuple_type(types)
-        argtypes = Any[Core.Const(f), types.parameters...]
+        argtypes = Any[Core.Compiler.Const(f), types.parameters...]
         rt = Core.Compiler.builtin_tfunction(interp, f, argtypes[2:end], nothing)
         return Core.Compiler.builtin_effects(Core.Compiler.typeinf_lattice(interp), f,
             Core.Compiler.ArgInfo(nothing, argtypes), rt)

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -453,19 +453,21 @@ function get_code_cache()
 end
 
 struct REPLInterpreter <: CC.AbstractInterpreter
+    limit_aggressive_inference::Bool
     world::UInt
     inf_params::CC.InferenceParams
     opt_params::CC.OptimizationParams
     inf_cache::Vector{CC.InferenceResult}
     code_cache::REPLInterpreterCache
-    function REPLInterpreter(;
+    function REPLInterpreter(limit_aggressive_inference::Bool=false;
                              world::UInt = Base.get_world_counter(),
                              inf_params::CC.InferenceParams = CC.InferenceParams(;
-                                unoptimize_throw_blocks=false),
+                                 aggressive_constant_propagation=true,
+                                 unoptimize_throw_blocks=false),
                              opt_params::CC.OptimizationParams = CC.OptimizationParams(),
                              inf_cache::Vector{CC.InferenceResult} = CC.InferenceResult[],
                              code_cache::REPLInterpreterCache = get_code_cache())
-        return new(world, inf_params, opt_params, inf_cache, code_cache)
+        return new(limit_aggressive_inference, world, inf_params, opt_params, inf_cache, code_cache)
     end
 end
 CC.InferenceParams(interp::REPLInterpreter) = interp.inf_params
@@ -489,28 +491,36 @@ CC.bail_out_toplevel_call(::REPLInterpreter, ::CC.InferenceLoopState, ::CC.Infer
 # Aggressive binding resolution poses challenges for the inference cache validation
 # (until https://github.com/JuliaLang/julia/issues/40399 is implemented).
 # To avoid the cache validation issues, `REPLInterpreter` only allows aggressive binding
-# resolution for top-level frame representing REPL input code (`repl_frame`) and for child
-# `getproperty` frames that are constant propagated from the `repl_frame`. This works, since
-# a.) these frames are never cached, and
-# b.) their results are only observed by the non-cached `repl_frame`.
+# resolution for top-level frame representing REPL input code and for child uncached frames
+# that are constant propagated from the top-level frame ("repl-frame"s). This works, even if
+# those global bindings are not constant and may be mutated in the future, since:
+# a.) "repl-frame"s are never cached, and
+# b.) mutable values are never observed by any cached frames.
 #
 # `REPLInterpreter` also aggressively concrete evaluate `:inconsistent` calls within
-# `repl_frame` to provide reasonable completions for lines like `Ref(Some(42))[].|`.
+# "repl-frame" to provide reasonable completions for lines like `Ref(Some(42))[].|`.
 # Aggressive concrete evaluation allows us to get accurate type information about complex
 # expressions that otherwise can not be constant folded, in a safe way, i.e. it still
 # doesn't evaluate effectful expressions like `pop!(xs)`.
 # Similarly to the aggressive binding resolution, aggressive concrete evaluation doesn't
-# present any cache validation issues because `repl_frame` is never cached.
+# present any cache validation issues because "repl-frame" is never cached.
 
 # `REPLInterpreter` is specifically used by `repl_eval_ex`, where all top-level frames are
 # `repl_frame` always. However, this assumption wouldn't stand if `REPLInterpreter` were to
 # be employed, for instance, by `typeinf_ext_toplevel`.
 is_repl_frame(sv::CC.InferenceState) = sv.linfo.def isa Module && !sv.cached
 
+function is_call_graph_uncached(sv::CC.AbsIntState)
+    sv isa CC.InferenceState && sv.cached && return false
+    parent = sv.parent
+    parent === nothing && return true
+    return is_call_graph_uncached(parent)
+end
+
 # aggressive global binding resolution within `repl_frame`
 function CC.abstract_eval_globalref(interp::REPLInterpreter, g::GlobalRef,
                                     sv::CC.InferenceState)
-    if is_repl_frame(sv)
+    if (interp.limit_aggressive_inference ? is_repl_frame(sv) : is_call_graph_uncached(sv))
         if CC.isdefined_globalref(g)
             return Const(ccall(:jl_get_globalref_value, Any, (Any,), g))
         end
@@ -520,7 +530,7 @@ function CC.abstract_eval_globalref(interp::REPLInterpreter, g::GlobalRef,
                                               sv::CC.InferenceState)
 end
 
-function is_repl_frame_getproperty(interp::REPLInterpreter, sv::CC.InferenceState)
+function is_repl_frame_getproperty(sv::CC.InferenceState)
     def = sv.linfo.def
     def isa Method || return false
     def.name === :getproperty || return false
@@ -531,7 +541,7 @@ end
 # aggressive global binding resolution for `getproperty(::Module, ::Symbol)` calls within `repl_frame`
 function CC.builtin_tfunction(interp::REPLInterpreter, @nospecialize(f),
                               argtypes::Vector{Any}, sv::CC.InferenceState)
-    if f === Core.getglobal && is_repl_frame_getproperty(interp, sv)
+    if f === Core.getglobal && (interp.limit_aggressive_inference ? is_repl_frame_getproperty(sv) : is_call_graph_uncached(sv))
         if length(argtypes) == 2
             a1, a2 = argtypes
             if isa(a1, Const) && isa(a2, Const)
@@ -554,7 +564,7 @@ end
 function CC.concrete_eval_eligible(interp::REPLInterpreter, @nospecialize(f),
                                    result::CC.MethodCallResult, arginfo::CC.ArgInfo,
                                    sv::CC.InferenceState)
-    if is_repl_frame(sv)
+    if (interp.limit_aggressive_inference ? is_repl_frame(sv) : is_call_graph_uncached(sv))
         neweffects = CC.Effects(result.effects; consistent=CC.ALWAYS_TRUE)
         result = CC.MethodCallResult(result.rt, result.edgecycle, result.edgelimited,
                                      result.edge, neweffects)
@@ -562,6 +572,14 @@ function CC.concrete_eval_eligible(interp::REPLInterpreter, @nospecialize(f),
     return @invoke CC.concrete_eval_eligible(interp::CC.AbstractInterpreter, f::Any,
                                              result::CC.MethodCallResult, arginfo::CC.ArgInfo,
                                              sv::CC.InferenceState)
+end
+
+# allow constant propagation for mutable constants
+function CC.const_prop_argument_heuristic(interp::REPLInterpreter, arginfo::CC.ArgInfo, sv::CC.AbsIntState)
+    if !interp.limit_aggressive_inference
+        any(@nospecialize(a)->isa(a, Const), arginfo.argtypes) && return true # even if mutable
+    end
+    return @invoke CC.const_prop_argument_heuristic(interp::CC.AbstractInterpreter, arginfo::CC.ArgInfo, sv::CC.AbsIntState)
 end
 
 function resolve_toplevel_symbols!(src::Core.CodeInfo, mod::Module)
@@ -574,7 +592,7 @@ function resolve_toplevel_symbols!(src::Core.CodeInfo, mod::Module)
 end
 
 # lower `ex` and run type inference on the resulting top-level expression
-function repl_eval_ex(@nospecialize(ex), context_module::Module)
+function repl_eval_ex(@nospecialize(ex), context_module::Module; limit_aggressive_inference::Bool=false)
     if (isexpr(ex, :toplevel) || isexpr(ex, :tuple)) && !isempty(ex.args)
         # get the inference result for the last expression
         ex = ex.args[end]
@@ -599,7 +617,7 @@ function repl_eval_ex(@nospecialize(ex), context_module::Module)
     resolve_toplevel_symbols!(src, context_module)
     @atomic mi.uninferred = src
 
-    interp = REPLInterpreter()
+    interp = REPLInterpreter(limit_aggressive_inference)
     result = CC.InferenceResult(mi)
     frame = CC.InferenceState(result, src, #=cache=#:no, interp)
 

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -453,19 +453,20 @@ function get_code_cache()
 end
 
 struct REPLInterpreter <: CC.AbstractInterpreter
+    repl_frame::CC.InferenceResult
     world::UInt
     inf_params::CC.InferenceParams
     opt_params::CC.OptimizationParams
     inf_cache::Vector{CC.InferenceResult}
     code_cache::REPLInterpreterCache
-    function REPLInterpreter(; world::UInt = Base.get_world_counter(),
-                               inf_params::CC.InferenceParams = CC.InferenceParams(;
-                                   aggressive_constant_propagation=true,
-                                   unoptimize_throw_blocks=false),
-                               opt_params::CC.OptimizationParams = CC.OptimizationParams(),
-                               inf_cache::Vector{CC.InferenceResult} = CC.InferenceResult[],
-                               code_cache::REPLInterpreterCache = get_code_cache())
-        return new(world, inf_params, opt_params, inf_cache, code_cache)
+    function REPLInterpreter(repl_frame::CC.InferenceResult;
+                             world::UInt = Base.get_world_counter(),
+                             inf_params::CC.InferenceParams = CC.InferenceParams(;
+                                unoptimize_throw_blocks=false),
+                             opt_params::CC.OptimizationParams = CC.OptimizationParams(),
+                             inf_cache::Vector{CC.InferenceResult} = CC.InferenceResult[],
+                             code_cache::REPLInterpreterCache = get_code_cache())
+        return new(repl_frame, world, inf_params, opt_params, inf_cache, code_cache)
     end
 end
 CC.InferenceParams(interp::REPLInterpreter) = interp.inf_params
@@ -489,31 +490,25 @@ CC.bail_out_toplevel_call(::REPLInterpreter, ::CC.InferenceLoopState, ::CC.Infer
 # Aggressive binding resolution poses challenges for the inference cache validation
 # (until https://github.com/JuliaLang/julia/issues/40399 is implemented).
 # To avoid the cache validation issues, `REPLInterpreter` only allows aggressive binding
-# resolution for top-level frame representing REPL input code and for child uncached frames
-# that are constant propagated from the top-level frame ("repl-frame"s). This works, even if
-# those global bindings are not constant and may be mutated in the future, since:
-# a.) "repl-frame"s are never cached, and
-# b.) mutable values are never observed by any cached frames.
+# resolution for top-level frame representing REPL input code (`repl_frame`) and for child
+# `getproperty` frames that are constant propagated from the `repl_frame`. This works, since
+# a.) these frames are never cached, and
+# b.) their results are only observed by the non-cached `repl_frame`.
 #
 # `REPLInterpreter` also aggressively concrete evaluate `:inconsistent` calls within
-# "repl-frame" to provide reasonable completions for lines like `Ref(Some(42))[].|`.
+# `repl_frame` to provide reasonable completions for lines like `Ref(Some(42))[].|`.
 # Aggressive concrete evaluation allows us to get accurate type information about complex
 # expressions that otherwise can not be constant folded, in a safe way, i.e. it still
 # doesn't evaluate effectful expressions like `pop!(xs)`.
 # Similarly to the aggressive binding resolution, aggressive concrete evaluation doesn't
-# present any cache validation issues because "repl-frame" is never cached.
+# present any cache validation issues because `repl_frame` is never cached.
 
-function is_call_graph_uncached(sv::CC.AbsIntState)
-    sv isa CC.InferenceState && sv.cached && return false
-    parent = sv.parent
-    parent === nothing && return true
-    return is_call_graph_uncached(parent)
-end
+is_repl_frame(interp::REPLInterpreter, sv::CC.InferenceState) = interp.repl_frame === sv.result
 
 # aggressive global binding resolution within `repl_frame`
 function CC.abstract_eval_globalref(interp::REPLInterpreter, g::GlobalRef,
                                     sv::CC.InferenceState)
-    if is_call_graph_uncached(sv)
+    if is_repl_frame(interp, sv)
         if CC.isdefined_globalref(g)
             return Const(ccall(:jl_get_globalref_value, Any, (Any,), g))
         end
@@ -523,10 +518,18 @@ function CC.abstract_eval_globalref(interp::REPLInterpreter, g::GlobalRef,
                                               sv::CC.InferenceState)
 end
 
+function is_repl_frame_getproperty(interp::REPLInterpreter, sv::CC.InferenceState)
+    def = sv.linfo.def
+    def isa Method || return false
+    def.name === :getproperty || return false
+    sv.cached && return false
+    return is_repl_frame(interp, sv.parent)
+end
+
 # aggressive global binding resolution for `getproperty(::Module, ::Symbol)` calls within `repl_frame`
 function CC.builtin_tfunction(interp::REPLInterpreter, @nospecialize(f),
                               argtypes::Vector{Any}, sv::CC.InferenceState)
-    if f === Core.getglobal && is_call_graph_uncached(sv)
+    if f === Core.getglobal && is_repl_frame_getproperty(interp, sv)
         if length(argtypes) == 2
             a1, a2 = argtypes
             if isa(a1, Const) && isa(a2, Const)
@@ -549,7 +552,7 @@ end
 function CC.concrete_eval_eligible(interp::REPLInterpreter, @nospecialize(f),
                                    result::CC.MethodCallResult, arginfo::CC.ArgInfo,
                                    sv::CC.InferenceState)
-    if is_call_graph_uncached(sv)
+    if is_repl_frame(interp, sv)
         neweffects = CC.Effects(result.effects; consistent=CC.ALWAYS_TRUE)
         result = CC.MethodCallResult(result.rt, result.edgecycle, result.edgelimited,
                                      result.edge, neweffects)
@@ -557,12 +560,6 @@ function CC.concrete_eval_eligible(interp::REPLInterpreter, @nospecialize(f),
     return @invoke CC.concrete_eval_eligible(interp::CC.AbstractInterpreter, f::Any,
                                              result::CC.MethodCallResult, arginfo::CC.ArgInfo,
                                              sv::CC.InferenceState)
-end
-
-# allow constant propagation for mutable constants
-function CC.const_prop_argument_heuristic(interp::REPLInterpreter, arginfo::CC.ArgInfo, sv::CC.AbsIntState)
-    any(@nospecialize(a)->isa(a, Const), arginfo.argtypes) && return true # even if mutable
-    return @invoke CC.const_prop_argument_heuristic(interp::CC.AbstractInterpreter, arginfo::CC.ArgInfo, sv::CC.AbsIntState)
 end
 
 function resolve_toplevel_symbols!(src::Core.CodeInfo, mod::Module)
@@ -600,9 +597,9 @@ function repl_eval_ex(@nospecialize(ex), context_module::Module)
     resolve_toplevel_symbols!(src, context_module)
     @atomic mi.uninferred = src
 
-    interp = REPLInterpreter()
     result = CC.InferenceResult(mi)
-    frame = CC.InferenceState(result, src, #=cache=#:no, interp)
+    interp = REPLInterpreter(result)
+    frame = CC.InferenceState(result, src, #=cache=#:no, interp)::CC.InferenceState
 
     # NOTE Use the fixed world here to make `REPLInterpreter` robust against
     #      potential invalidations of `Core.Compiler` methods.

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -599,7 +599,7 @@ function repl_eval_ex(@nospecialize(ex), context_module::Module)
 
     result = CC.InferenceResult(mi)
     interp = REPLInterpreter(result)
-    frame = CC.InferenceState(result, src, #=cache=#:no, interp)::CC.InferenceState
+    frame = CC.InferenceState(result, src, #=cache=#:no, interp)
 
     # NOTE Use the fixed world here to make `REPLInterpreter` robust against
     #      potential invalidations of `Core.Compiler` methods.

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1978,6 +1978,23 @@ let (c, r, res) = test_complete_context("getkeyelem(mutable_const_prop).value.")
     end
 end
 
+# JuliaLang/julia/#51548
+# don't return wrong result due to mutable inconsistentcy
+function issue51548(T, a)
+    # if we fold `xs = getindex(T)` to `xs::Const(Vector{T}())`, then we may wrongly
+    # constant-fold `isempty(xs)::Const(true)` and return wrong result
+    xs = T[]
+    if a isa T
+        push!(xs, a)
+    end
+    return Val(isempty(xs))
+end;
+let inferred = REPL.REPLCompletions.repl_eval_ex(:(issue51548(Any, r"issue51548")), @__MODULE__)
+    @test !isnothing(inferred)
+    RT = Core.Compiler.widenconst(inferred)
+    @test Val{false} <: RT
+end
+
 # Test completion of var"" identifiers (#49280)
 let s = "var\"complicated "
     c, r = test_complete_foo(s)

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -502,7 +502,7 @@ end
 let s = "CompletionFoo.test3([1, 2] .+ CompletionFoo.varfloat,"
     c, r, res = test_complete(s)
     @test !res
-    @test_broken only(c) == first(test_methods_list(Main.CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64, Vararg}))
+    @test only(c) == first(test_methods_list(Main.CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64, Vararg}))
 end
 
 let s = "CompletionFoo.test3([1.,2.], 1.,"
@@ -573,7 +573,7 @@ end
 let s = "CompletionFoo.test3(@time([1, 2] .+ CompletionFoo.varfloat),"
     c, r, res = test_complete(s)
     @test !res
-    @test length(c) == 2
+    @test length(c) == 1
 end
 
 # method completions with kwargs
@@ -1953,12 +1953,12 @@ let (c, r, res) = test_complete_context("tcd1.")
 end
 let (c, r, res) = test_complete_context("tcd1.x.")
     @test res
-    @test_broken "v" in c && "w" in c
+    @test "v" in c && "w" in c
     @test isnothing(issue51499[])
 end
 let (c, r, res) = test_complete_context("tcd1.x.v.")
     @test res
-    @test_broken "a" in c && "b" in c
+    @test "a" in c && "b" in c
     @test isnothing(issue51499[])
 end
 @test tcd1.x.v.a == sin(1.0)
@@ -1969,12 +1969,12 @@ mutable_const_prop = Dict{Symbol,Any}(:key => Any[Some(r"x")])
 getkeyelem(d) = d[:key][1]
 let (c, r, res) = test_complete_context("getkeyelem(mutable_const_prop).")
     @test res
-    @test_broken "value" in c
+    @test "value" in c
 end
 let (c, r, res) = test_complete_context("getkeyelem(mutable_const_prop).value.")
     @test res
     for name in fieldnames(Regex)
-        @test_broken String(name) in c
+        @test String(name) in c
     end
 end
 
@@ -1989,7 +1989,8 @@ function issue51548(T, a)
     end
     return Val(isempty(xs))
 end;
-let inferred = REPL.REPLCompletions.repl_eval_ex(:(issue51548(Any, r"issue51548")), @__MODULE__)
+let inferred = REPL.REPLCompletions.repl_eval_ex(
+        :(issue51548(Any, r"issue51548")), @__MODULE__; limit_aggressive_inference=true)
     @test !isnothing(inferred)
     RT = Core.Compiler.widenconst(inferred)
     @test Val{false} <: RT

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -502,7 +502,7 @@ end
 let s = "CompletionFoo.test3([1, 2] .+ CompletionFoo.varfloat,"
     c, r, res = test_complete(s)
     @test !res
-    @test only(c) == first(test_methods_list(Main.CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64, Vararg}))
+    @test_broken only(c) == first(test_methods_list(Main.CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64, Vararg}))
 end
 
 let s = "CompletionFoo.test3([1.,2.], 1.,"
@@ -573,7 +573,7 @@ end
 let s = "CompletionFoo.test3(@time([1, 2] .+ CompletionFoo.varfloat),"
     c, r, res = test_complete(s)
     @test !res
-    @test length(c) == 1
+    @test length(c) == 2
 end
 
 # method completions with kwargs
@@ -1917,66 +1917,6 @@ let s = "pop!(global_xs)."
     @test "value" in c
 end
 @test length(global_xs) == 1 # the completion above shouldn't evaluate `pop!` call
-
-# https://github.com/JuliaLang/julia/issues/51499
-# allow aggressive concrete evaluation for child uncached frames
-struct Issue51499CompletionDict
-    inner::Dict{Symbol,Any}
-    leaf_func # Function that gets invoked on leaf objects before being returned.
-    function Issue51499CompletionDict(inner::Dict, leaf_func=identity)
-        inner = Dict{Symbol,Any}(Symbol(k) => v for (k, v) in inner)
-        return new(inner, leaf_func)
-    end
-end
-function Base.getproperty(tcd::Issue51499CompletionDict, name::Symbol)
-    prop = getfield(tcd, :inner)[name]
-    isa(prop, Issue51499CompletionDict) && return prop
-    return getfield(tcd, :leaf_func)(prop)
-end
-Base.propertynames(tcd::Issue51499CompletionDict) = keys(getfield(tcd, :inner))
-
-const issue51499 = Ref{Any}(nothing)
-tcd3 = Issue51499CompletionDict(
-    Dict(:a => 1.0, :b => 2.0),
-    function (x)
-        issue51499[] = x
-        return sin(x)
-    end)
-tcd2 = Issue51499CompletionDict(
-    Dict(:v => tcd3, :w => 1.0))
-tcd1 = Issue51499CompletionDict(
-    Dict(:x => tcd2, :y => 1.0))
-let (c, r, res) = test_complete_context("tcd1.")
-    @test res
-    @test "x" in c && "y" in c
-    @test isnothing(issue51499[])
-end
-let (c, r, res) = test_complete_context("tcd1.x.")
-    @test res
-    @test "v" in c && "w" in c
-    @test isnothing(issue51499[])
-end
-let (c, r, res) = test_complete_context("tcd1.x.v.")
-    @test res
-    @test "a" in c && "b" in c
-    @test isnothing(issue51499[])
-end
-@test tcd1.x.v.a == sin(1.0)
-@test issue51499[] == 1.0
-
-# aggressive constant propagation for mutable `Const`s
-mutable_const_prop = Dict{Symbol,Any}(:key => Any[Some(r"x")])
-getkeyelem(d) = d[:key][1]
-let (c, r, res) = test_complete_context("getkeyelem(mutable_const_prop).")
-    @test res
-    @test "value" in c
-end
-let (c, r, res) = test_complete_context("getkeyelem(mutable_const_prop).value.")
-    @test res
-    for name in fieldnames(Regex)
-        @test String(name) in c
-    end
-end
 
 # Test completion of var"" identifiers (#49280)
 let s = "var\"complicated "


### PR DESCRIPTION
It appears that #51503 was too aggressive, because it fails to account for inconsistencies that arise from mutable values, leading to potential inaccuracies in results (refer to #51548 for examples). 

In addressing this issue, I've came up with the following options:

1. Introduce a new lattice element, perhaps termed `ConstUntilModified`. This would represent mutable values until they're modified, at which point they could be widened to their native type and discard constant information. While it may be an option, it feels like and overkill for this particular issue although `ConstUntilModified` may not be generally useful as mutable values shouldn't be considered as `Const`-like in other inference contexts in general.
2. Simply reverts the changes in #51503. This doesn't completely resolve the problem since `REPLInterpreter` might still overlook inconsistencies with mutable values at the top-level frame. However, given that `repl_eval_ex` is mostly used for simple expressions, this hasn't posed significant issues.

I would like to go with the second option and so this commit reverts the changes from #51503 and adds new test cases also.

Fixes #51548.