### PR TITLE
Aggressive constprop in LinearAlgebra.wrap

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -465,7 +465,7 @@ wrapper_char(A::Hermitian) = A.uplo == 'U' ? 'H' : 'h'
 wrapper_char(A::Hermitian{<:Real}) = A.uplo == 'U' ? 'S' : 's'
 wrapper_char(A::Symmetric) = A.uplo == 'U' ? 'S' : 's'
 
-function wrap(A::AbstractVecOrMat, tA::AbstractChar)
+Base.@constprop :aggressive function wrap(A::AbstractVecOrMat, tA::AbstractChar)
     if tA == 'N'
         return A
     elseif tA == 'T'

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -17,6 +17,14 @@ mul_wrappers = [
     m -> adjoint(m),
     m -> transpose(m)]
 
+@testset "wrap" begin
+    f(A) = LinearAlgebra.wrap(A, 'N')
+    A = ones(1,1)
+    @test @inferred(f(A)) === A
+    g(A) = LinearAlgebra.wrap(A, 'T')
+    @test @inferred(g(A)) === transpose(A)
+end
+
 @testset "matrices with zero dimensions" begin
     for (dimsA, dimsB, dimsC) in (
         ((0, 5), (5, 3), (0, 3)),


### PR DESCRIPTION
This helps with type-stability, as the flag `tA` is usually known from the type of the matrix.
On master,
```julia
julia> f(A) = LinearAlgebra.wrap(A, 'N')
f (generic function with 1 method)

julia> @code_typed f([1;;])
CodeInfo(
1 ─ %1 = invoke LinearAlgebra.wrap(A::Matrix{Int64}, 'N'::Char)::Union{Adjoint{Int64, Matrix{Int64}}, Hermitian{Int64, Matrix{Int64}}, Symmetric{Int64, Matrix{Int64}}, Transpose{Int64, Matrix{Int64}}, Matrix{Int64}}
└──      return %1
) => Union{Adjoint{Int64, Matrix{Int64}}, Hermitian{Int64, Matrix{Int64}}, Symmetric{Int64, Matrix{Int64}}, Transpose{Int64, Matrix{Int64}}, Matrix{Int64}}
```
This PR
```julia
julia> @code_typed f([1;;])
CodeInfo(
1 ─     return A
) => Matrix{Int64}
```