### PR TITLE
fix #51586, annotate method from `@ccallable` with `@__doc__`

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -540,7 +540,7 @@ function expand_ccallable(rt, def)
                 end
             end
             return quote
-                $(esc(def))
+                @__doc__ $(esc(def))
                 _ccallable($(esc(rt)), $(Expr(:curly, :Tuple, esc(f), map(esc, at)...)))
             end
         end

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1517,3 +1517,11 @@ struct S41727
 end
 @test S41727(1) isa S41727
 @test string(@repl S41727.x) == "x is 4\n"
+
+"ensure we can document ccallable functions"
+Base.@ccallable c51586_short()::Int = 2
+"ensure we can document ccallable functions"
+Base.@ccallable c51586_long()::Int = 3
+
+@test docstrings_equal(@doc(c51586_short()), doc"ensure we can document ccallable functions")
+@test docstrings_equal(@doc(c51586_long()), doc"ensure we can document ccallable functions")

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -147,6 +147,10 @@ module ObjLoadTest
     using Base: llvmcall, @ccallable
     using Test
     didcall = false
+    """    jl_the_callback()
+
+    Sets the global didcall when it did the call
+    """
     @ccallable Cvoid function jl_the_callback()
         global didcall
         didcall = true


### PR DESCRIPTION
Fixes issue #51586; this allows you to attach a docstring to a `@ccallable` method definition.