### PR TITLE
reset `maxprobe` on `empty!`

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -672,6 +672,7 @@ function _delete!(h::Dict{K,V}, index) where {K,V}
     h.ndel += ndel
     h.count -= 1
     h.age += 1
+    h.maxprobe = max(h.maxprobe, h.size-1)
     return h
     end
 end

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -184,6 +184,7 @@ end
         resize!(h.keys, newsz)
         resize!(h.vals, newsz)
         h.ndel = 0
+        h.maxprobe = 0
         return h
     end
 
@@ -672,7 +673,6 @@ function _delete!(h::Dict{K,V}, index) where {K,V}
     h.ndel += ndel
     h.count -= 1
     h.age += 1
-    h.maxprobe = max(h.maxprobe, h.size-1)
     return h
     end
 end

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -259,6 +259,7 @@ function empty!(h::Dict{K,V}) where V where K
     resize!(h.vals, sz)
     h.ndel = 0
     h.count = 0
+    h.maxprobe = 0
     h.age += 1
     h.idxfloor = sz
     return h

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1502,3 +1502,24 @@ for T in (Int, Float64, String, Symbol)
         @test_broken Core.Compiler.is_terminates(Base.infer_effects(getindex, (Dict{T,Any}, T)))
     end
 end
+
+struct BadHash
+    i::Int
+end
+Base.hash(::BadHash, UInt)=UInt(1)
+@testset "maxprobe reset #51595" begin
+    d = Dict(BadHash(i)=>nothing for i in 1:20)
+    empty!(d)
+    sizehint!(d, 0)
+    @test d.maxprobe < length(d.keys)
+    d[BadHash(1)]=nothing
+    @test !(BadHash(2) in keys(d))
+    d = Dict(BadHash(i)=>nothing for i in 1:20)
+    for _ in 1:20
+        pop!(d)
+    end
+    sizehint!(d, 0)
+    @test d.maxprobe < length(d.keys)
+    d[BadHash(1)]=nothing
+    @test !(BadHash(2) in keys(d))
+end

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1506,7 +1506,7 @@ end
 struct BadHash
     i::Int
 end
-Base.hash(::BadHash, UInt)=UInt(1)
+Base.hash(::BadHash, ::UInt)=UInt(1)
 @testset "maxprobe reset #51595" begin
     d = Dict(BadHash(i)=>nothing for i in 1:20)
     empty!(d)


### PR DESCRIPTION
As pointed out in https://github.com/JuliaLang/julia/issues/51594#issuecomment-1747781744, this is necessary for the assertion added in https://github.com/JuliaLang/julia/pull/49447 to be valid.

Fix #51594