### PR TITLE
only sizehint! on union! and merge! when doing so will increase the size.

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -98,9 +98,6 @@ end
 max_values(::Type{Bool}) = 2
 max_values(::Type{Nothing}) = 1
 
-function _maybe_sizehint!(s::Set, size::Int)
-    size*3 > length(s.dict.keys) * 2 && sizehint!(s, size)
-end
 _maybe_sizehint!(s::AbstractSet, size::Int) = sizehint!(s, size)
 function union!(s::AbstractSet{T}, itr) where T
     haslength(itr) && _maybe_sizehint!(s, length(s) + Int(length(itr))::Int)

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -98,8 +98,12 @@ end
 max_values(::Type{Bool}) = 2
 max_values(::Type{Nothing}) = 1
 
+function _maybe_sizehint!(s::Set, size::Int)
+    size*3 > length(s.dict.keys) * 2 && sizehint!(s, size)
+end
+_maybe_sizehint!(s::AbstractSet, size::Int) = sizehint!(s, size)
 function union!(s::AbstractSet{T}, itr) where T
-    haslength(itr) && sizehint!(s, length(s) + Int(length(itr))::Int)
+    haslength(itr) && _maybe_sizehint!(s, length(s) + Int(length(itr))::Int)
     for x in itr
         push!(s, x)
         length(s) == max_values(T) && break

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -771,7 +771,11 @@ function map!(f, iter::ValueIterator{<:Dict})
 end
 
 function mergewith!(combine, d1::Dict{K, V}, d2::AbstractDict) where {K, V}
-    haslength(d2) && sizehint!(d1, length(d1) + length(d2))
+    if haslength(d2)
+        newlen = length(d1) + length(d2)
+        # if we will need to rehash, do it early
+        newlen * 3 > length(d1.slots) * 2 && sizehint!(d1, newlen)
+    end
     for (k, v) in d2
         i, sh = ht_keyindex2_shorthash!(d1, k)
         if i > 0

--- a/base/set.jl
+++ b/base/set.jl
@@ -117,6 +117,9 @@ copymutable(s::Set{T}) where {T} = Set{T}(s)
 # Set is the default mutable fall-back
 copymutable(s::AbstractSet{T}) where {T} = Set{T}(s)
 
+function _maybe_sizehint!(s::Set, size::Int)
+    size*3 > length(s.dict.keys) * 2 && sizehint!(s, size)
+end
 sizehint!(s::Set, newsz) = (sizehint!(s.dict, newsz); s)
 empty!(s::Set) = (empty!(s.dict); s)
 rehash!(s::Set) = (rehash!(s.dict); s)


### PR DESCRIPTION
Prior to this, we would have sub-optimal performance when a user gave us a specific `sizehint!` before doing a sequence of `union!`s since on seeing the first `union!` we would `sizehint!`the set with a smaller size, which would undo the `sizehint!` the user gave us. For example:

```
function f(n)
    s = Set()
    sizehint!(s, n)
    for i in 1:n
        union!(s, n)
    end
   s
end
```