### PR TITLE
Create rand function for Base.KeySet and Base.ValueIterator{Dict}

### DIFF
--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -452,9 +452,11 @@ function rand(rng::AbstractRNG, sp::SamplerSimple{<:Dict,<:Sampler})
     end
 end
 
-rand(rng::AbstractRNG, sp::SamplerTrivial{<:Base.KeySet}) = rand(rng, sp[].dict).first
+rand(rng::AbstractRNG, sp::SamplerTrivial{<:Base.KeySet{<:T,<:Dict}} where T) = 
+    rand(rng, sp[].dict).first
 
-rand(rng::AbstractRNG, sp::SamplerTrivial{<:Base.ValueIterator{<:Dict}}) = rand(rng, sp[].dict).second
+rand(rng::AbstractRNG, sp::SamplerTrivial{<:Base.ValueIterator{<:Dict}}) = 
+    rand(rng, sp[].dict).second
 
 ## random values from Set
 

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -452,6 +452,10 @@ function rand(rng::AbstractRNG, sp::SamplerSimple{<:Dict,<:Sampler})
     end
 end
 
+rand(rng::AbstractRNG, sp::SamplerTrivial{<:Base.KeySet}) = rand(rng, sp[].dict).first
+
+rand(rng::AbstractRNG, sp::SamplerTrivial{<:Base.ValueIterator{<:Dict}}) = rand(rng, sp[].dict).second
+
 ## random values from Set
 
 Sampler(::Type{RNG}, t::Set{T}, n::Repetition) where {RNG<:AbstractRNG,T} =

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -452,7 +452,7 @@ function rand(rng::AbstractRNG, sp::SamplerSimple{<:Dict,<:Sampler})
     end
 end
 
-rand(rng::AbstractRNG, sp::SamplerTrivial{<:Base.KeySet{<:T,<:Dict}} where T) =
+rand(rng::AbstractRNG, sp::SamplerTrivial{<:Base.KeySet{<:Any,<:Dict}}) =
     rand(rng, sp[].dict).first
 
 rand(rng::AbstractRNG, sp::SamplerTrivial{<:Base.ValueIterator{<:Dict}}) =

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -452,10 +452,10 @@ function rand(rng::AbstractRNG, sp::SamplerSimple{<:Dict,<:Sampler})
     end
 end
 
-rand(rng::AbstractRNG, sp::SamplerTrivial{<:Base.KeySet{<:T,<:Dict}} where T) = 
+rand(rng::AbstractRNG, sp::SamplerTrivial{<:Base.KeySet{<:T,<:Dict}} where T) =
     rand(rng, sp[].dict).first
 
-rand(rng::AbstractRNG, sp::SamplerTrivial{<:Base.ValueIterator{<:Dict}}) = 
+rand(rng::AbstractRNG, sp::SamplerTrivial{<:Base.ValueIterator{<:Dict}}) =
     rand(rng, sp[].dict).second
 
 ## random values from Set

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -296,6 +296,8 @@ for rng in ([], [MersenneTwister(0)], [RandomDevice()], [Xoshiro()])
                    randset                          => Int,
                    GenericSet(randset)              => Int,
                    randdict                         => Pair{Int,Int},
+                   keys(randdict)                   => Int,
+                   values(randdict)                 => Int,
                    GenericDict(randdict)            => Pair{Int,Int},
                    1:100                            => Int,
                    rand(Int, 100)                   => Int,


### PR DESCRIPTION
Fixes #51605 . 

I also created a version of rand for `Base.ValueIterator{Dict}` which currently throws an error.