### PR TITLE
1.10 backports: Revert #51403

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5106,11 +5106,3 @@ end
 @test code_typed() do
     b{c} = d...
 end |> only |> first isa Core.CodeInfo
-
-abstract_call_unionall_vararg(some::Some{Any}) = UnionAll(some.value...)
-@test only(Base.return_types(abstract_call_unionall_vararg)) !== Union{}
-let TV = TypeVar(:T)
-    t = Vector{TV}
-    some = Some{Any}((TV, t))
-    @test abstract_call_unionall_vararg(some) isa UnionAll
-end


### PR DESCRIPTION
Revert "inference: follow up the `Vararg` fix in `abstract_call_unionall` (#51403).

This reverts commit ae8f9ad5b8c5f5b0c217d99e83657405dbeb1913.

Fixes https://github.com/JuliaLang/julia/issues/51603.

CC: @aviatesk.
We probably also want to revert this on master, since we're experiencing the same issue on master.