### PR TITLE
Highlight manifests from other versions when failing to find packages

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1826,35 +1826,19 @@ end
 
 function collect_manifest_warnings()
     unsuitable_manifests, dev_manifests = find_unsuitable_manifests_versions()
-    msg = if isempty(unsuitable_manifests)
-        ""
-    elseif length(unsuitable_manifests) == 1
-        """
-        - Note that a manifest in the load path was resolved with a different
-          julia version, which may be the cause of the error:
-            $(only(unsuitable_manifests))
-
-        """
-    else
-        """
-        - Note that manifests in the load path were resolved with a different
+    msg = ""
+    if !isempty(unsuitable_manifests)
+        msg *= """
+        - Note that the following manifests in the load path were resolved with a different
           julia version, which may be the cause of the error:
             $(join(unsuitable_manifests, "\n    "))
 
         """
     end
-    if length(dev_manifests) == 1
+    if !isempty(dev_manifests)
         msg *= """
-        - Note that a manifest in the load path was resolved a potentially
+        - Note that the following manifests in the load path were resolved a potentially
           different DEV version of the current version, which may be the cause
-          of the error:
-            $(only(dev_manifests))
-
-        """
-    else
-        msg *= """
-        - Note that manifests in the load path were resolved with potentially
-          different DEV versions of the current version, which may be the cause
           of the error:
             $(join(dev_manifests, "\n    "))
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1774,9 +1774,10 @@ function __require(into::Module, mod::Symbol)
                     Package $mod not found in current path$hint_message.
                     - $start_sentence `import Pkg; Pkg.add($(repr(String(mod))))` to install the $mod package."""))
             else
+                manifest_warnings = collect_manifest_warnings()
                 throw(ArgumentError("""
                 Package $(where.name) does not have $mod in its dependencies:
-                - You may have a partially installed environment. Try `Pkg.instantiate()`
+                $manifest_warnings- You may have a partially installed environment. Try `Pkg.instantiate()`
                   to ensure all packages in the environment are installed.
                 - Or, if you have $(where.name) checked out for development and have
                   added $mod as a dependency but haven't updated your primary
@@ -1793,6 +1794,73 @@ function __require(into::Module, mod::Symbol)
         LOADING_CACHE[] = nothing
     end
     end
+end
+
+function find_unsuitable_manifests_versions()
+    unsuitable_manifests = String[]
+    dev_manifests = String[]
+    for env in load_path()
+        project_file = env_project_file(env)
+        project_file || continue # no project file
+        manifest_file = project_file_manifest_path(project_file)
+        manifest_file isa String || continue # no manifest file
+        m = parsed_toml(manifest_file)
+        man_julia_version = get(m, "julia_version", nothing)
+        man_julia_version isa String || @goto mark
+        man_julia_version = VersionNumber(man_julia_version)
+        thispatch(man_julia_version) != thispatch(VERSION) && @goto mark
+        isempty(man_julia_version.prerelease) != isempty(VERSION.prerelease) && @goto mark
+        isempty(man_julia_version.prerelease) && continue
+        man_julia_version.prerelease[1] != VERSION.prerelease[1] && @goto mark
+        if VERSION.prerelease[1] == "DEV"
+            # manifests don't store the 2nd part of prerelease, so cannot check further
+            # so treat them specially in the warning
+            push!(dev_manifests, manifest_file)
+        end
+        continue
+        @label mark
+        push!(unsuitable_manifests, string(manifest_file, " (v", man_julia_version, ")"))
+    end
+    return unsuitable_manifests, dev_manifests
+end
+
+function collect_manifest_warnings()
+    unsuitable_manifests, dev_manifests = find_unsuitable_manifests_versions()
+    msg = if isempty(unsuitable_manifests)
+        ""
+    elseif length(unsuitable_manifests) == 1
+        """
+        - Note that a manifest in the load path was resolved with a different
+          julia version, which may be the cause of the error:
+            $(only(unsuitable_manifests))
+
+        """
+    else
+        """
+        - Note that manifests in the load path were resolved with a different
+          julia version, which may be the cause of the error:
+            $(join(unsuitable_manifests, "\n    "))
+
+        """
+    end
+    if length(dev_manifests) == 1
+        msg *= """
+        - Note that a manifest in the load path was resolved a potentially
+          different DEV version of the current version, which may be the cause
+          of the error:
+            $(only(dev_manifests))
+
+        """
+    else
+        msg *= """
+        - Note that manifests in the load path were resolved with potentially
+          different DEV versions of the current version, which may be the cause
+          of the error:
+            $(join(dev_manifests, "\n    "))
+
+        """
+    end
+    return msg
 end
 
 require(uuidkey::PkgId) = @lock require_lock _require_prelocked(uuidkey)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1801,7 +1801,7 @@ function find_unsuitable_manifests_versions()
     dev_manifests = String[]
     for env in load_path()
         project_file = env_project_file(env)
-        project_file || continue # no project file
+        project_file isa String || continue # no project file
         manifest_file = project_file_manifest_path(project_file)
         manifest_file isa String || continue # no manifest file
         m = parsed_toml(manifest_file)
@@ -1832,7 +1832,6 @@ function collect_manifest_warnings()
         - Note that the following manifests in the load path were resolved with a different
           julia version, which may be the cause of the error:
             $(join(unsuitable_manifests, "\n    "))
-
         """
     end
     if !isempty(dev_manifests)
@@ -1841,7 +1840,6 @@ function collect_manifest_warnings()
           different DEV version of the current version, which may be the cause
           of the error:
             $(join(dev_manifests, "\n    "))
-
         """
     end
     return msg


### PR DESCRIPTION
There's ideas on how to avoid this error entirely, but in cases where manifest from other versions can't be hotpatched, it seems helpful to highlight the problematic manifest(s) in the load path.

So this type of error would become
```
% ./julia
┌ Info: Precompiling Revise [295af30f-e4ad-537b-8983-00126c2a3abe]
└ @ Base loading.jl:2401
ERROR: LoadError: ArgumentError: Package LibGit2 does not have LibGit2_jll in its dependencies:
- Note that the following manifests in the load path were resolved with a different
  julia version, which may be the cause of the error:
    /Users/ian/.julia/environments/v1.11/Manifest.toml (v1.10.0-beta1)
- You may have a partially installed environment. Try `Pkg.instantiate()`
  to ensure all packages in the environment are installed.
- Or, if you have LibGit2 checked out for development and have
  added LibGit2_jll as a dependency but haven't updated your primary
  environment's manifest file, try `Pkg.resolve()`.
- Otherwise you may need to report an issue with LibGit2
```
or
```
% ./julia 
┌ Info: Precompiling Revise [295af30f-e4ad-537b-8983-00126c2a3abe]
└ @ Base loading.jl:2401
ERROR: LoadError: ArgumentError: Package LibGit2 does not have LibGit2_jll in its dependencies:
- Note that the following manifests in the load path were resolved a potentially
  different DEV version of the current version, which may be the cause
  of the error:
    /Users/ian/.julia/environments/v1.11/Manifest.toml
- You may have a partially installed environment. Try `Pkg.instantiate()`
  to ensure all packages in the environment are installed.
- Or, if you have LibGit2 checked out for development and have
  added LibGit2_jll as a dependency but haven't updated your primary
  environment's manifest file, try `Pkg.resolve()`.
- Otherwise you may need to report an issue with LibGit2
```
