### PR TITLE
explicitly document how to work-around the unicode ∘ in composed function syntax

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -960,7 +960,7 @@ Compose functions: i.e. `(f ∘ g)(args...; kwargs...)` means `f(g(args...; kwar
 The `∘` symbol can be entered in the Julia REPL (and most editors,
 appropriately configured) by typing `\\circ<tab>`. If you need to avoid
 Unicode, use the [`ComposedFunction`](@ref) constructor instead, possibly with
-[`foldl`](@ref) to support more than 2 functions..
+[`foldl`](@ref) to support more than 2 functions.
 
 Function composition also works in prefix form: `∘(f, g)` is the same as `f ∘ g`.
 The prefix form supports composition of multiple functions: `∘(f, g, h) = f ∘ g ∘ h`

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -955,8 +955,12 @@ end
 """
     f ∘ g
 
-Compose functions: i.e. `(f ∘ g)(args...; kwargs...)` means `f(g(args...; kwargs...))`. The `∘` symbol can be
-entered in the Julia REPL (and most editors, appropriately configured) by typing `\\circ<tab>`.
+Compose functions: i.e. `(f ∘ g)(args...; kwargs...)` means `f(g(args...; kwargs...))`.
+
+The `∘` symbol can be entered in the Julia REPL (and most editors,
+appropriately configured) by typing `\\circ<tab>`. If you need to avoid
+Unicode, use the [`ComposedFunction`](@ref) constructor instead, possibly with
+[`foldl`](@ref) to support more than 2 functions..
 
 Function composition also works in prefix form: `∘(f, g)` is the same as `f ∘ g`.
 The prefix form supports composition of multiple functions: `∘(f, g, h) = f ∘ g ∘ h`


### PR DESCRIPTION
I was griping over this for like 10th time already, and finally noticed that one can use `ComposedFunction` constructor directly instead of the ∘. I guess about time to document this also for others.

Also added a notice about `foldl`, hopefully preventing folks from assuming that ∘ is right-associative as in some other languages.

If viable, we can also add direct example of the multi-function composition workaround: `foldl(ComposedFunction, (f, g, h))`.

(Credits: Slack channel #gripes, starring as the ultimate rubberduck. Apologies for noise there.)