### PR TITLE
support random sampling of tuple types: add tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,8 +52,7 @@ Standard library changes
 #### Profile
 
 #### Random
-* `rand` now supports sampling over `Tuple` types ([#50251]).
-
+* `rand` now supports sampling over `Tuple` types ([#35856], [#50251]).
 * When seeding RNGs provided by `Random`, negative integer seeds can now be used ([#51416]).
 
 #### REPL

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -175,7 +175,11 @@ function Sampler(::Type{RNG}, ::Type{T}, n::Repetition) where {T<:Tuple, RNG<:Ab
 end
 
 function Sampler(::Type{RNG}, ::Type{Tuple{Vararg{T, N}}}, n::Repetition) where {T, N, RNG<:AbstractRNG}
-    SamplerTag{Tuple{Vararg{T, N}}}((Sampler(RNG, T, n),))
+    if N > 0
+        SamplerTag{Tuple{Vararg{T, N}}}((Sampler(RNG, T, n),))
+    else
+        SamplerTag{Tuple{}}(())
+    end
 end
 
 function rand(rng::AbstractRNG, sp::SamplerTag{T}) where T<:Tuple

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -790,6 +790,14 @@ end
     end
 end
 
+@testset "rand(::Type{<:Tuple})" begin
+    @test_throws ArgumentError rand(Tuple)
+    @test rand(Tuple{}) == ()
+    @inferred rand(Tuple{Int32,Int64,Float64})
+    @inferred rand(NTuple{20,Int})
+    @test_throws TypeError rand(Tuple{1:2,3:4})
+end
+
 @testset "GLOBAL_RNG" begin
     @test VERSION < v"2" # deprecate this in v2 (GLOBAL_RNG must go)
     local GLOBAL_RNG = Random.GLOBAL_RNG


### PR DESCRIPTION
This is a rebase of #35856, where we keep only the tests, as the functionality was added in #50251. This also adds the possibility to call `rand` on an empty tuple type: `rand(Tuple{})`. 