### PR TITLE
[WIP] Specialize `chklapackerror` to improve error messages

### DIFF
--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -31,18 +31,18 @@ function chkargsok(ret::BlasInt)
 end
 
 "Handle all nonzero info codes"
-function chklapackerror(ret::BlasInt, f = nothing)
+function chklapackerror(ret::BlasInt, f...)
     if ret == 0
         return
     elseif ret < 0
         throw(ArgumentError("invalid argument #$(-ret) to LAPACK call"))
     else # ret > 0
-        chklapackerror_positive(ret, f)
+        chklapackerror_positive(ret, f...)
     end
 end
 
-chklapackerror_positive(ret, ::Nothing) = throw(LAPACKException(ret))
-chklapackerror_positive(ret, ::Val{:trtrs!}) = chknonsingular(ret)
+chklapackerror_positive(ret, f...) = throw(LAPACKException(ret))
+chklapackerror_positive(ret, ::typeof(trtrs!)) = chknonsingular(ret)
 
 function chknonsingular(ret::BlasInt)
     if ret > 0
@@ -3572,7 +3572,7 @@ for (trtri, trtrs, elty) in
                   uplo, trans, diag, n, size(B,2), A, max(1,stride(A,2)),
                   B, max(1,stride(B,2)), info,
                   1, 1, 1)
-            chklapackerror(info[], Val(:trtrs!))
+            chklapackerror(info[], trtrs!)
             B
         end
     end

--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -42,7 +42,6 @@ function chklapackerror(ret::BlasInt, f...)
 end
 
 chklapackerror_positive(ret, f...) = throw(LAPACKException(ret))
-chklapackerror_positive(ret, ::typeof(trtrs!)) = chknonsingular(ret)
 
 function chknonsingular(ret::BlasInt)
     if ret > 0
@@ -3577,6 +3576,7 @@ for (trtri, trtrs, elty) in
         end
     end
 end
+chklapackerror_positive(ret, ::typeof(trtrs!)) = chknonsingular(ret)
 
 """
     trtri!(uplo, diag, A)

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -492,11 +492,7 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
             @test_throws DimensionMismatch Ann'\bm
             @test_throws DimensionMismatch transpose(Ann)\bm
             if t1 == UpperTriangular || t1 == LowerTriangular
-                if elty1 === eltyB <: BlasFloat
-                    @test_throws LAPACKException ldiv!(t1(zeros(elty1, n, n)), fill(eltyB(1), n))
-                else
-                    @test_throws SingularException ldiv!(t1(zeros(elty1, n, n)), fill(eltyB(1), n))
-                end
+                @test_throws SingularException ldiv!(t1(zeros(elty1, n, n)), fill(eltyB(1), n))
             end
             @test B/A1 ≈ B/Matrix(A1)
             @test B/transpose(A1) ≈ B/transpose(Matrix(A1))


### PR DESCRIPTION
This is an attempt at resolving https://github.com/JuliaLang/LinearAlgebra.jl/issues/948. Since each LAPACK function generally has a specific meaning attached to a positive error code, this PR tries to specialize `chklapackerror` for the caller to throw a more informative error instead of a `LAPACKException`. For example:
```julia
julia> U = UpperTriangular([1 2; 0 0])
2×2 UpperTriangular{Int64, Matrix{Int64}}:
 1  2
 ⋅  0

julia> inv(U)
ERROR: SingularException(2)
[...]
```
Currently, I've only specialized it for `trtrs!`, but if this seems reasonable, I'll add others.

Functions to be implemented:

- [ ] `gbtrf`
- [ ] `gbtrs`
- [ ] `gebal!`
- [ ] `gebak!`
- [ ] `gebrd!`
- [ ] `gelqf!`
- [ ] `geqlf!`
- [ ] `geqp3!`
- [ ] `geqrt!`
- [ ] `geqrt3!`
- [ ] `geqrf!`
- [ ] `gerqf!`
- [ ] `getrf!`
- [ ] `tzrzf!`
- [ ] `ormrz!`
- [ ] `gels!`
- [ ] `gesv!`
- [ ] `getrs!`
- [ ] `getri!`
- [ ] `gesvx!`
- [ ] `gelsd!`
- [ ] `gelsy!`
- [ ] `gglse!`
- [ ] `geev!`
- [ ] `gesdd!`
- [ ] `gesvd!`
- [ ] `ggsvd!`
- [ ] `ggsvd3!`
- [ ] `geevx!`
- [ ] `ggev!`
- [ ] `ggev3!`
- [ ] `gtsv!`
- [ ] `gttrf!`
- [ ] `gttrs!`
- [ ] `orglq!`
- [ ] `orgqr!`
- [ ] `orgql!`
- [ ] `orgrq!`
- [ ] `ormlq!`
- [ ] `ormqr!`
- [ ] `ormql!`
- [ ] `ormrq!`
- [ ] `gemqrt!`
- [ ] `potrs!`
- [ ] `ptsv!`
- [ ] `pttrf!`
- [ ] `pttrs!`
- [ ] `trtri!`
- [x] `trtrs!`
- [ ] `trcon!`
- [ ] `trevc!`
- [ ] `trrfs!`
- [ ] `stev!`
- [ ] `stebz!`
- [ ] `stegr!`
- [ ] `stein!`
- [ ] `syconv!`
- [ ] `sytrs!`
- [ ] `sytrs_rook!`
- [ ] `syconvf_rook!`
- [ ] `hesv!`
- [ ] `hetri!`
- [ ] `hetrs!`
- [ ] `hesv_rook!`
- [ ] `hetri_rook!`
- [ ] `hetrs_rook!`
- [ ] `sytri!`
- [ ] `sytri_rook!`
- [ ] `syconvf_rook!`
- [ ] `syev!`
- [ ] `syevr!`
- [ ] `syevd!`
- [ ] `bdsqr!`
- [ ] `bdsdc!`
- [ ] `gecon!`
- [ ] `gehrd!`
- [ ] `orghr!`
- [ ] `ormhr!`
- [ ] `hseqr!`
- [ ] `hetrd!`
- [ ] `ormtr!`
- [ ] `gees!`
- [ ] `gges!`
- [ ] `gges3!`
- [ ] `trexc!`
- [ ] `trsen!`
- [ ] `tgsen!`
- [ ] `trsyl!`