### PR TITLE
Forward `copyto!` for `Adjoint` to `adjoint!`

### DIFF
--- a/stdlib/LinearAlgebra/src/transpose.jl
+++ b/stdlib/LinearAlgebra/src/transpose.jl
@@ -212,12 +212,6 @@ function copy_similar(A::TransposeAbsMat, ::Type{T}) where {T}
 end
 
 function Base.copyto_unaliased!(deststyle::IndexStyle, dest::AbstractMatrix, srcstyle::IndexCartesian, src::AdjOrTransAbsMat)
-    isempty(src) && return dest
-    destinds, srcinds = LinearIndices(dest), LinearIndices(src)
-    idf, isf = first(destinds), first(srcinds)
-    Δi = idf - isf
-    (checkbounds(Bool, destinds, isf+Δi) & checkbounds(Bool, destinds, last(srcinds)+Δi)) ||
-        throw(BoundsError(dest, srcinds))
     if axes(dest) == axes(src)
         f! = inplace_adj_or_trans(src)
         f!(dest, parent(src))

--- a/stdlib/LinearAlgebra/src/transpose.jl
+++ b/stdlib/LinearAlgebra/src/transpose.jl
@@ -210,3 +210,8 @@ function copy_similar(A::TransposeAbsMat, ::Type{T}) where {T}
     C = similar(A, T, size(A))
     transpose!(C, parent(A))
 end
+
+function Base.copyto_unaliased!(deststyle::IndexStyle, dest::AbstractMatrix, srcstyle::IndexCartesian, src::AdjOrTransAbsMat)
+    f! = inplace_adj_or_trans(src)
+    f!(dest, parent(src))
+end

--- a/stdlib/LinearAlgebra/src/transpose.jl
+++ b/stdlib/LinearAlgebra/src/transpose.jl
@@ -216,8 +216,7 @@ function Base.copyto_unaliased!(deststyle::IndexStyle, dest::AbstractMatrix, src
         f! = inplace_adj_or_trans(src)
         f!(dest, parent(src))
     else
-        invoke(Base.copyto_unaliased!, Tuple{IndexStyle, AbstractArray, IndexStyle, AbstractArray},
-            deststyle, dest, srcstyle, src)
+        @invoke Base.copyto_unaliased!(deststyle::IndexStyle, dest::AbstractArray, srcstyle::IndexStyle, src::AbstractArray)
     end
     return dest
 end

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -476,6 +476,16 @@ end
     @test adjoint!(b, a) === b
 end
 
+@testset "copyto! uses adjoint!/transpose!" begin
+    for T in (Float64, ComplexF64), f in (transpose, adjoint), sz in ((5,4), (5,))
+        S = rand(T, sz)
+        adjS = f(S)
+        A = similar(S')
+        copyto!(A, adjS)
+        @test A == adjS
+    end
+end
+
 @testset "aliasing with adjoint and transpose" begin
     A = collect(reshape(1:25, 5, 5)) .+ rand.().*im
     B = copy(A)


### PR DESCRIPTION
`adjoint!`/`transpose!` operate blockwise, and are usually faster than a linear `copyto!`. We may therefore forward `copyto!` to these when copying from an `Adjoint`/`Transpose`. This is already being done for an out-of-place `copy`, and this PR does the same for the in-place `copyto!`.

The difference in performance:
```julia
julia> @btime copyto!($(zeros(ComplexF64, 1000, 1000)), $(rand(ComplexF64, 1000, 1000)'));
  3.540 ms (0 allocations: 0 bytes) # master
  2.693 ms (0 allocations: 0 bytes) # PR
```