### PR TITLE
Use a single Float16 ABI.

### DIFF
--- a/base/ctypes.jl
+++ b/base/ctypes.jl
@@ -113,3 +113,7 @@ const Cfloat = Float32
 Equivalent to the native `double` c-type ([`Float64`](@ref)).
 """
 const Cdouble = Float64
+
+
+# we have no `Float16` alias, because C does not define a standard fp16 type. Julia follows
+# the _Float16 C ABI; if that becomes standard, we can add an appropriate alias here.

--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -313,10 +313,13 @@ void LLVMByteSwap(unsigned numbits, integerPart *pa, integerPart *pr) {
     ASSIGN(r, a)
 }
 
+extern "C" float julia_half_to_float(uint16_t ival) JL_NOTSAFEPOINT;
+extern "C" uint16_t julia_float_to_half(float param) JL_NOTSAFEPOINT;
+
 void LLVMFPtoInt(unsigned numbits, void *pa, unsigned onumbits, integerPart *pr, bool isSigned, bool *isExact) {
     double Val;
     if (numbits == 16)
-        Val = julia__gnu_h2f_ieee(*(uint16_t*)pa);
+        Val = julia_half_to_float(*(uint16_t*)pa);
     else if (numbits == 32)
         Val = *(float*)pa;
     else if (numbits == 64)
@@ -391,7 +394,7 @@ void LLVMSItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPar
         val = a.roundToDouble(true);
     }
     if (onumbits == 16)
-        *(uint16_t*)pr = julia__gnu_f2h_ieee(val);
+        *(uint16_t*)pr = julia_float_to_half(val);
     else if (onumbits == 32)
         *(float*)pr = val;
     else if (onumbits == 64)
@@ -408,7 +411,7 @@ void LLVMUItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPar
         val = a.roundToDouble(false);
     }
     if (onumbits == 16)
-        *(uint16_t*)pr = julia__gnu_f2h_ieee(val);
+        *(uint16_t*)pr = julia_float_to_half(val);
     else if (onumbits == 32)
         *(float*)pr = val;
     else if (onumbits == 64)

--- a/src/abi_x86_64.cpp
+++ b/src/abi_x86_64.cpp
@@ -118,7 +118,8 @@ struct Classification {
 void classifyType(Classification& accum, jl_datatype_t *dt, uint64_t offset) const
 {
     // Floating point types
-    if (dt == jl_float64_type || dt == jl_float32_type || dt == jl_bfloat16_type) {
+    if (dt == jl_float64_type || dt == jl_float32_type || dt == jl_float16_type ||
+        dt == jl_bfloat16_type) {
         accum.addField(offset, Sse);
     }
     // Misc types

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1729,13 +1729,14 @@ JuliaOJIT::JuliaOJIT()
     ExternalJD.addToLinkOrder(JD, orc::JITDylibLookupFlags::MatchExportedSymbolsOnly);
 
     orc::SymbolAliasMap jl_crt = {
-#if JULIA_FLOAT16_ABI == 1
+        // Float16 conversion routines
         { mangle("__gnu_h2f_ieee"), { mangle("julia__gnu_h2f_ieee"), JITSymbolFlags::Exported } },
         { mangle("__extendhfsf2"),  { mangle("julia__gnu_h2f_ieee"), JITSymbolFlags::Exported } },
         { mangle("__gnu_f2h_ieee"), { mangle("julia__gnu_f2h_ieee"), JITSymbolFlags::Exported } },
         { mangle("__truncsfhf2"),   { mangle("julia__gnu_f2h_ieee"), JITSymbolFlags::Exported } },
         { mangle("__truncdfhf2"),   { mangle("julia__truncdfhf2"),   JITSymbolFlags::Exported } },
-#endif
+
+        // BFloat16 conversion routines
         { mangle("__truncsfbf2"),   { mangle("julia__truncsfbf2"),   JITSymbolFlags::Exported } },
         { mangle("__truncdfbf2"),   { mangle("julia__truncdfbf2"),   JITSymbolFlags::Exported } },
     };

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1661,20 +1661,12 @@ jl_sym_t *_jl_symbol(const char *str, size_t len) JL_NOTSAFEPOINT;
 #define JL_WEAK_SYMBOL_DEFAULT(sym) NULL
 #endif
 
-JL_DLLEXPORT float julia__gnu_h2f_ieee(uint16_t param) JL_NOTSAFEPOINT;
-JL_DLLEXPORT uint16_t julia__gnu_f2h_ieee(float param) JL_NOTSAFEPOINT;
-JL_DLLEXPORT uint16_t julia__truncdfhf2(double param) JL_NOTSAFEPOINT;
-JL_DLLEXPORT float julia__truncsfbf2(float param) JL_NOTSAFEPOINT;
-JL_DLLEXPORT float julia__truncdfbf2(double param) JL_NOTSAFEPOINT;
-//JL_DLLEXPORT double julia__extendhfdf2(uint16_t n) JL_NOTSAFEPOINT;
-//JL_DLLEXPORT int32_t julia__fixhfsi(uint16_t n) JL_NOTSAFEPOINT;
-//JL_DLLEXPORT int64_t julia__fixhfdi(uint16_t n) JL_NOTSAFEPOINT;
-//JL_DLLEXPORT uint32_t julia__fixunshfsi(uint16_t n) JL_NOTSAFEPOINT;
-//JL_DLLEXPORT uint64_t julia__fixunshfdi(uint16_t n) JL_NOTSAFEPOINT;
-//JL_DLLEXPORT uint16_t julia__floatsihf(int32_t n) JL_NOTSAFEPOINT;
-//JL_DLLEXPORT uint16_t julia__floatdihf(int64_t n) JL_NOTSAFEPOINT;
-//JL_DLLEXPORT uint16_t julia__floatunsihf(uint32_t n) JL_NOTSAFEPOINT;
-//JL_DLLEXPORT uint16_t julia__floatundihf(uint64_t n) JL_NOTSAFEPOINT;
+//JL_DLLEXPORT float julia__gnu_h2f_ieee(half param) JL_NOTSAFEPOINT;
+//JL_DLLEXPORT half julia__gnu_f2h_ieee(float param) JL_NOTSAFEPOINT;
+//JL_DLLEXPORT half julia__truncdfhf2(double param) JL_NOTSAFEPOINT;
+//JL_DLLEXPORT float julia__truncsfbf2(float param) JL_NOTSAFEPOINT;
+//JL_DLLEXPORT float julia__truncdfbf2(double param) JL_NOTSAFEPOINT;
+//JL_DLLEXPORT double julia__extendhfdf2(half n) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT uint32_t jl_crc32c(uint32_t crc, const char *buf, size_t len);
 

--- a/src/llvm-version.h
+++ b/src/llvm-version.h
@@ -18,15 +18,6 @@
 #define JL_LLVM_OPAQUE_POINTERS 1
 #endif
 
-// Pre GCC 12 libgcc defined the ABI for Float16->Float32
-// to take an i16. GCC 12 silently changed the ABI to now pass
-// Float16 in Float32 registers.
-#if JL_LLVM_VERSION < 150000 || defined(_CPU_PPC64_) || defined(_CPU_PPC_)
-#define JULIA_FLOAT16_ABI 1
-#else
-#define JULIA_FLOAT16_ABI 2
-#endif
-
 #ifdef __cplusplus
 #if defined(__GNUC__) && (__GNUC__ >= 9)
 // Added in GCC 9, this warning is annoying

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -264,7 +264,7 @@ float julia_half_to_float(uint16_t param) {
 #else
     #define FLOAT16_TYPE float
     #define FLOAT16_TO_UINT16(x) ((uint16_t)*(uint32_t*)&(x))
-    #define FLOAT16_FROM_UINT16(x) (*(float*)&((uint32_t)(x)))
+    #define FLOAT16_FROM_UINT16(x) ({ uint32_t tmp = (uint32_t)(x); *(float*)&tmp; })
 #endif
 
 JL_DLLEXPORT float julia__gnu_h2f_ieee(FLOAT16_TYPE param)
@@ -338,7 +338,7 @@ static inline uint16_t double_to_bfloat(double param) JL_NOTSAFEPOINT
 #else
     #define BFLOAT16_TYPE float
     #define BFLOAT16_TO_UINT16(x) ((uint16_t)*(uint32_t*)&(x))
-    #define BFLOAT16_FROM_UINT16(x) (*(float*)&((uint32_t)(x)))
+    #define BFLOAT16_FROM_UINT16(x) ({ uint32_t tmp = (uint32_t)(x); *(float*)&tmp; })
 #endif
 
 JL_DLLEXPORT BFLOAT16_TYPE julia__truncsfbf2(float param) JL_NOTSAFEPOINT

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -248,19 +248,22 @@ float julia_half_to_float(uint16_t param) {
 }
 
 // starting with GCC 12 and Clang 15, we have _Float16 which does the right thing
-#if (defined(__GNUC__) && __GNUC__ > 11) || (defined(__clang__) && __clang_major__ > 14)
+// (but not on Windows; this may be a bug in the MSYS2 GCC compilers)
+#if ((defined(__GNUC__) && __GNUC__ > 11) || \
+     (defined(__clang__) && __clang_major__ > 14)) && \
+    !defined(_OS_WINDOWS_)
     #define FLOAT16_TYPE _Float16
     #define FLOAT16_TO_UINT16(x) (*(uint16_t*)&(x))
     #define FLOAT16_FROM_UINT16(x) (*(_Float16*)&(x))
 // on older compilers, we need to emulate the platform-specific ABI
-#elif (defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)) || defined(_CPU_PPC64_) || defined(_CPU_PPC_)
-    #define FLOAT16_TYPE uint16_t
-    #define FLOAT16_TO_UINT16(x) (x)
-    #define FLOAT16_FROM_UINT16(x) (x)
 #elif defined(_CPU_X86_) || defined(_CPU_X86_64_)
     #define FLOAT16_TYPE __m128
     #define FLOAT16_TO_UINT16(x) take_from_xmm(x)
     #define FLOAT16_FROM_UINT16(x) return_in_xmm(x)
+#elif defined(_CPU_PPC64_) || defined(_CPU_PPC_)
+    #define FLOAT16_TYPE uint16_t
+    #define FLOAT16_TO_UINT16(x) (x)
+    #define FLOAT16_FROM_UINT16(x) (x)
 #else
     #define FLOAT16_TYPE float
     #define FLOAT16_TO_UINT16(x) ((uint16_t)*(uint32_t*)&(x))
@@ -322,19 +325,22 @@ static inline uint16_t double_to_bfloat(double param) JL_NOTSAFEPOINT
 // bfloat16 conversion API
 
 // starting with GCC 13 and Clang 17, we have __bf16 which does the right thing
-#if (defined(__GNUC__) && __GNUC__ > 12) || (defined(__clang__) && __clang_major__ > 16)
+// (but not on Windows; this may be a bug in the MSYS2 GCC compilers)
+#if ((defined(__GNUC__) && __GNUC__ > 12) || \
+     (defined(__clang__) && __clang_major__ > 16)) && \
+    !defined(_OS_WINDOWS_)
     #define BFLOAT16_TYPE __bf16
     #define BFLOAT16_TO_UINT16(x) (*(uint16_t*)&(x))
     #define BFLOAT16_FROM_UINT16(x) (*(__bf16*)&(x))
 // on older compilers, we need to emulate the platform-specific ABI
-#elif (defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)) || defined(_CPU_PPC64_) || defined(_CPU_PPC_)
-    #define BFLOAT16_TYPE uint16_t
-    #define BFLOAT16_TO_UINT16(x) (x)
-    #define BFLOAT16_FROM_UINT16(x) (x)
 #elif defined(_CPU_X86_) || defined(_CPU_X86_64_)
     #define BFLOAT16_TYPE __m128
     #define BFLOAT16_TO_UINT16(x) take_from_xmm(x)
     #define BFLOAT16_FROM_UINT16(x) return_in_xmm(x)
+#elif defined(_CPU_PPC64_) || defined(_CPU_PPC_)
+    #define BFLOAT16_TYPE uint16_t
+    #define BFLOAT16_TO_UINT16(x) (x)
+    #define BFLOAT16_FROM_UINT16(x) (x)
 #else
     #define BFLOAT16_TYPE float
     #define BFLOAT16_TO_UINT16(x) ((uint16_t)*(uint32_t*)&(x))

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -224,6 +224,30 @@ float julia_half_to_float(uint16_t param) {
 // very recent compilers. to work around this, we pass float16 parameters as float, which is
 // also passed in XMM registers.
 
+// Starting with GCC 12 and Clang 15, we have the _Float16 type which does the right thing
+#if (defined(__GNUC__) && (__GNUC__ > 12 || (__GNUC__ == 12 && __GNUC_MINOR__ >= 0))) || \
+    (defined(__clang__) && (__clang_major__ > 15 || (__clang_major__ == 15 && __clang_minor__ >= 0)))
+
+JL_DLLEXPORT float julia__gnu_h2f_ieee(_Float16 param)
+{
+    uint16_t param16 = *(uint16_t*)&param;
+    return half_to_float(param16);
+}
+
+JL_DLLEXPORT _Float16 julia__gnu_f2h_ieee(float param)
+{
+    uint16_t res = float_to_half(param);
+    return *(_Float16*)&res;
+}
+
+JL_DLLEXPORT _Float16 julia__truncdfhf2(double param)
+{
+    uint16_t res = double_to_half(param);
+    return *(_Float16*)&res;
+}
+
+#else
+
 JL_DLLEXPORT float julia__gnu_h2f_ieee(float param)
 {
     uint32_t param32 = *(uint32_t*)&param;
@@ -244,6 +268,8 @@ JL_DLLEXPORT float julia__truncdfhf2(double param)
     uint32_t res32 = (uint32_t)res16;
     return *(float*)&res32;
 }
+
+#endif
 
 // bfloat16 conversion routines
 

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -213,27 +213,27 @@ static inline uint16_t double_to_half(double param) JL_NOTSAFEPOINT
 // x86-specific helpers for emulating the (B)Float16 ABI
 #if defined(_CPU_X86_) || defined(_CPU_X86_64_)
 #include <xmmintrin.h>
-static inline __m128 return_in_xmm(uint16_t val) JL_NOTSAFEPOINT {
-    __m128 xmm_result;
-    uint32_t extended_val = val;
+static inline __m128 return_in_xmm(uint16_t input) JL_NOTSAFEPOINT {
+    __m128 xmm_output;
     asm (
-        "pxor %%xmm0, %%xmm0\n\t"
-        "pinsrw $0, %1, %%xmm0\n\t"
-        "movaps %%xmm0, %0"
-        : "=x"(xmm_result)
-        : "r"(extended_val)
+        "movd %[input], %%xmm0\n\t"
+        "movss %%xmm0, %[xmm_output]\n\t"
+        : [xmm_output] "=x" (xmm_output)
+        : [input] "r" ((uint32_t)input)
         : "xmm0"
     );
-    return xmm_result;
+    return xmm_output;
 }
-static inline uint16_t take_from_xmm(__m128 xmm_val) JL_NOTSAFEPOINT {
-    uint32_t result;
+static inline uint16_t take_from_xmm(__m128 xmm_input) JL_NOTSAFEPOINT {
+    uint32_t output;
     asm (
-        "pextrw $0, %1, %0"
-        : "=r"(result)
-        : "x"(xmm_val)
+        "movss %[xmm_input], %%xmm0\n\t"
+        "movd %%xmm0, %[output]\n\t"
+        : [output] "=r" (output)
+        : [xmm_input] "x" (xmm_input)
+        : "xmm0"
     );
-    return (uint16_t) result;
+    return (uint16_t)output;
 }
 #endif
 

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -213,7 +213,7 @@ static inline uint16_t double_to_half(double param) JL_NOTSAFEPOINT
 // x86-specific helpers for emulating the (B)Float16 ABI
 #if defined(_CPU_X86_) || defined(_CPU_X86_64_)
 #include <xmmintrin.h>
-static inline __m128 return_in_xmm(uint16_t val) {
+static inline __m128 return_in_xmm(uint16_t val) JL_NOTSAFEPOINT {
     __m128 xmm_result;
     uint32_t extended_val = val;
     asm (
@@ -226,7 +226,7 @@ static inline __m128 return_in_xmm(uint16_t val) {
     );
     return xmm_result;
 }
-static inline uint16_t take_from_xmm(__m128 xmm_val) {
+static inline uint16_t take_from_xmm(__m128 xmm_val) JL_NOTSAFEPOINT {
     uint32_t result;
     asm (
         "pextrw $0, %1, %0"

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -268,10 +268,27 @@ JL_DLLEXPORT _Float16 julia__truncdfhf2(double param)
     return *(_Float16*)&res;
 }
 
-#elif defined(_CPU_X86_) || defined(_CPU_X86_64_)
+// on older compilers, we need to do something platform-specific to ensure we're
+// using the appropriate ABI. on Win64 and PPC, that means treating as int16.
+#elif (defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)) || defined(_CPU_PPC64_) || defined(_CPU_PPC_)
 
-// on older compilers, we need to do something platform-specific to ensure we're using
-// the appropriate ABI. in the case of X86, use __m128 to return in XMM registers.
+JL_DLLEXPORT float julia__gnu_h2f_ieee(uint16_t param)
+{
+    return half_to_float(param);
+}
+
+JL_DLLEXPORT uint16_t julia__gnu_f2h_ieee(float param)
+{
+    return float_to_half(param);
+}
+
+JL_DLLEXPORT uint16_t julia__truncdfhf2(double param)
+{
+    return double_to_half(param);
+}
+
+// in the case of X86, use __m128 to return in XMM registers.
+#elif defined(_CPU_X86_) || defined(_CPU_X86_64_)
 
 JL_DLLEXPORT float julia__gnu_h2f_ieee(__m128 param)
 {
@@ -291,9 +308,8 @@ JL_DLLEXPORT __m128 julia__truncdfhf2(double param)
     return return_in_xmm(res);
 }
 
-#else
-
 // on other platforms, we use the floating-point ABI and pray it's compatible
+#else
 
 JL_DLLEXPORT float julia__gnu_h2f_ieee(float param)
 {
@@ -369,10 +385,22 @@ JL_DLLEXPORT __bf16 julia__truncdfbf2(double param) JL_NOTSAFEPOINT
     return *(__bf16*)&res;
 }
 
-#elif defined(_CPU_X86_) || defined(_CPU_X86_64_)
+// on older compilers, we need to do something platform-specific to ensure we're
+// using the appropriate ABI. on Win64 and PPC, that means treating as int16.
+#elif (defined(_OS_WINDOWS_) && defined(_CPU_X86_64_)) || defined(_CPU_PPC64_) || defined(_CPU_PPC_)
 
-// on older compilers, we need to do something platform-specific to ensure we're using
-// the appropriate ABI. in the case of X86, use __m128 to return in XMM registers.
+JL_DLLEXPORT uint16_t julia__truncsfbf2(float param) JL_NOTSAFEPOINT
+{
+    return float_to_bfloat(param);
+}
+
+JL_DLLEXPORT uint16_t julia__truncdfbf2(double param) JL_NOTSAFEPOINT
+{
+    return double_to_bfloat(param);
+}
+
+// in the case of X86, use __m128 to return in XMM registers.
+#elif defined(_CPU_X86_) || defined(_CPU_X86_64_)
 
 JL_DLLEXPORT __m128 julia__truncsfbf2(float param) JL_NOTSAFEPOINT
 {

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -247,10 +247,11 @@ float julia_half_to_float(uint16_t param) {
     return half_to_float(param);
 }
 
-// starting with GCC 12 and Clang 15, we have _Float16 which does the right thing
+// starting with GCC 12 and Clang 15, we have _Float16 on most platforms
 // (but not on Windows; this may be a bug in the MSYS2 GCC compilers)
 #if ((defined(__GNUC__) && __GNUC__ > 11) || \
      (defined(__clang__) && __clang_major__ > 14)) && \
+    !defined(_CPU_PPC64_) && !defined(_CPU_PPC_) && \
     !defined(_OS_WINDOWS_)
     #define FLOAT16_TYPE _Float16
     #define FLOAT16_TO_UINT16(x) (*(uint16_t*)&(x))
@@ -329,10 +330,11 @@ static inline uint16_t double_to_bfloat(double param) JL_NOTSAFEPOINT
 
 // bfloat16 conversion API
 
-// starting with GCC 13 and Clang 17, we have __bf16 which does the right thing
+// starting with GCC 13 and Clang 17, we have __bf16 on most platforms
 // (but not on Windows; this may be a bug in the MSYS2 GCC compilers)
 #if ((defined(__GNUC__) && __GNUC__ > 12) || \
      (defined(__clang__) && __clang_major__ > 16)) && \
+    !defined(_CPU_PPC64_) && !defined(_CPU_PPC_) && \
     !defined(_OS_WINDOWS_)
     #define BFLOAT16_TYPE __bf16
     #define BFLOAT16_TO_UINT16(x) (*(uint16_t*)&(x))

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -180,23 +180,14 @@ end
     @test_intrinsic Core.Intrinsics.fptoui UInt Float16(3.3) UInt(3)
 end
 
-if Sys.ARCH == :aarch64 ||  Sys.ARCH === :powerpc64le || Sys.ARCH === :ppc64le
-    # On AArch64 we are following the `_Float16` ABI. Buthe these functions expect `Int16`.
-    # TODO: Should we have `Chalf == Int16` and `Cfloat16 == Float16`?
-    extendhfsf2(x::Float16) = ccall("extern __extendhfsf2", llvmcall, Float32, (UInt16,), reinterpret(UInt16, x))
-    gnu_h2f_ieee(x::Float16) = ccall("extern __gnu_h2f_ieee", llvmcall, Float32, (UInt16,), reinterpret(UInt16, x))
-    truncsfhf2(x::Float32) = reinterpret(Float16, ccall("extern __truncsfhf2", llvmcall, UInt16, (Float32,), x))
-    gnu_f2h_ieee(x::Float32) = reinterpret(Float16, ccall("extern __gnu_f2h_ieee", llvmcall, UInt16, (Float32,), x))
-    truncdfhf2(x::Float64) = reinterpret(Float16, ccall("extern __truncdfhf2", llvmcall, UInt16, (Float64,), x))
-else
+@testset "Float16 intrinsics (crt)" begin
+    # TODO: Should we have `Chalf == Float16`?
     extendhfsf2(x::Float16) = ccall("extern __extendhfsf2", llvmcall, Float32, (Float16,), x)
     gnu_h2f_ieee(x::Float16) = ccall("extern __gnu_h2f_ieee", llvmcall, Float32, (Float16,), x)
     truncsfhf2(x::Float32) = ccall("extern __truncsfhf2", llvmcall, Float16, (Float32,), x)
     gnu_f2h_ieee(x::Float32) = ccall("extern __gnu_f2h_ieee", llvmcall, Float16, (Float32,), x)
     truncdfhf2(x::Float64) = ccall("extern __truncdfhf2", llvmcall, Float16, (Float64,), x)
-end
 
-@testset "Float16 intrinsics (crt)" begin
     @test extendhfsf2(Float16(3.3)) == 3.3007812f0
     @test gnu_h2f_ieee(Float16(3.3)) == 3.3007812f0
     @test truncsfhf2(3.3f0) == Float16(3.3)

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -181,18 +181,11 @@ end
 end
 
 @testset "Float16 intrinsics (crt)" begin
-    # TODO: Should we have `Chalf == Float16`?
-    extendhfsf2(x::Float16) = ccall("extern __extendhfsf2", llvmcall, Float32, (Float16,), x)
-    gnu_h2f_ieee(x::Float16) = ccall("extern __gnu_h2f_ieee", llvmcall, Float32, (Float16,), x)
-    truncsfhf2(x::Float32) = ccall("extern __truncsfhf2", llvmcall, Float16, (Float32,), x)
-    gnu_f2h_ieee(x::Float32) = ccall("extern __gnu_f2h_ieee", llvmcall, Float16, (Float32,), x)
-    truncdfhf2(x::Float64) = ccall("extern __truncdfhf2", llvmcall, Float16, (Float64,), x)
+    gnu_h2f_ieee(x::Float16) = ccall("julia__gnu_h2f_ieee", Float32, (Float16,), x)
+    gnu_f2h_ieee(x::Float32) = ccall("julia__gnu_f2h_ieee", Float16, (Float32,), x)
 
-    @test extendhfsf2(Float16(3.3)) == 3.3007812f0
     @test gnu_h2f_ieee(Float16(3.3)) == 3.3007812f0
-    @test truncsfhf2(3.3f0) == Float16(3.3)
     @test gnu_f2h_ieee(3.3f0) == Float16(3.3)
-    @test truncdfhf2(3.3) == Float16(3.3)
 end
 
 using Base.Experimental: @force_compile


### PR DESCRIPTION
Currently, we are using different Float16 ABIs depending on which GCC compiler Julia is compiled with (i.e., not based on what the user's OS uses), because of how the runtime intrinsics are implemented in C. Before GCC 12, we pass Float16 as UInt16, and otherwise we use `half` which passes (on X86) in XMM registers.

This PR moves to always using the "new" ABI, regardless of the GCC compiler, by returning Float16's from C using the `float` datatype. This probably only works on X86, and may need additional code paths for other platforms.

Tested on: i686-linux, x86_64-linux, aarch64-apple

cc @gbaraldi @vchuravy