### PR TITLE
Reinstate load-time Pkg.precompile

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2007,9 +2007,9 @@ function _require(pkg::PkgId, env=nothing)
                 if !pkg_precompile_attempted && isinteractive()
                     if !isassigned(PKG_PRECOMPILE_HOOK)
                         # Note: Prevent load-time Pkg.precompile via `Base.PKG_PRECOMPILE_HOOK[]=Returns(nothing)`
-                        pkgid = Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg")
-                        if Base.locate_package(pkgid) !== nothing # Only try load Pkg if we can find it
-                            Base.require(pkgid)
+                        pkgid = PkgId(UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg")
+                        if locate_package(pkgid) !== nothing # Only try load Pkg if we can find it
+                            require(pkgid)
                         end
                     end
                     pkg_precompile_attempted = true

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2004,7 +2004,14 @@ function _require(pkg::PkgId, env=nothing)
 
         if JLOptions().use_compiled_modules == 1
             if !generating_output(#=incremental=#false)
-                if !pkg_precompile_attempted && isinteractive() && isassigned(PKG_PRECOMPILE_HOOK)
+                if !pkg_precompile_attempted && isinteractive()
+                    if !isassigned(PKG_PRECOMPILE_HOOK)
+                        # Note: Prevent load-time Pkg.precompile via `Base.PKG_PRECOMPILE_HOOK[]=Returns(nothing)`
+                        pkgid = Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg")
+                        if Base.locate_package(pkgid) !== nothing # Only try load Pkg if we can find it
+                            Base.require(pkgid)
+                        end
+                    end
                     pkg_precompile_attempted = true
                     unlock(require_lock)
                     try


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/51492

Even once the core of `Pkg.precompile` is [move to Base](https://github.com/JuliaLang/julia/issues/49433), we'll probably still want to call `Pkg.precompile` as it instantiates first, which can't move to Base.