### PR TITLE
Dots in displaying views of sparse/structured arrays

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -495,9 +495,9 @@ end
 
 has_offset_axes(S::SubArray) = has_offset_axes(S.indices...)
 
-function Base.replace_in_print_matrix(S::SubArray{<:Any,2,<:AbstractMatrix}, i::Integer, j::Integer, s::AbstractString)
-    Base.replace_in_print_matrix(S.parent, reindex(S.indices, (i,j))..., s)
+function replace_in_print_matrix(S::SubArray{<:Any,2,<:AbstractMatrix}, i::Integer, j::Integer, s::AbstractString)
+    replace_in_print_matrix(S.parent, reindex(S.indices, (i,j))..., s)
 end
-function Base.replace_in_print_matrix(S::SubArray{<:Any,1,<:AbstractVector}, i::Integer, j::Integer, s::AbstractString)
-    Base.replace_in_print_matrix(S.parent, reindex(S.indices, (i,))..., j, s)
+function replace_in_print_matrix(S::SubArray{<:Any,1,<:AbstractVector}, i::Integer, j::Integer, s::AbstractString)
+    replace_in_print_matrix(S.parent, reindex(S.indices, (i,))..., j, s)
 end

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -494,3 +494,10 @@ function _indices_sub(i1::AbstractArray, I...)
 end
 
 has_offset_axes(S::SubArray) = has_offset_axes(S.indices...)
+
+function Base.replace_in_print_matrix(S::SubArray{<:Any,2,<:AbstractMatrix}, i::Integer, j::Integer, s::AbstractString)
+    Base.replace_in_print_matrix(S.parent, reindex(S.indices, (i,j))..., s)
+end
+function Base.replace_in_print_matrix(S::SubArray{<:Any,1,<:AbstractVector}, i::Integer, j::Integer, s::AbstractString)
+    Base.replace_in_print_matrix(S.parent, reindex(S.indices, (i,))..., j, s)
+end

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -769,3 +769,34 @@ end
     @test view(m, 1:2, 3, 1, 1) == m[1:2, 3]
     @test parent(view(m, 1:2, 3, 1, 1)) === m
 end
+
+@testset "replace_in_print_matrix" begin
+    struct MyIdentity <: AbstractMatrix{Bool}
+        n :: Int
+    end
+    Base.size(M::MyIdentity) = (M.n, M.n)
+    function Base.getindex(M::MyIdentity, i::Int, j::Int)
+        checkbounds(M, i, j)
+        i == j
+    end
+    function Base.replace_in_print_matrix(M::MyIdentity, i::Integer, j::Integer, s::AbstractString)
+        i == j ? s : Base.replace_with_centered_mark(s)
+    end
+    V = view(MyIdentity(3), 1:2, 1:3)
+    @test sprint(show, "text/plain", V) == "$(summary(V)):\n 1  ⋅  ⋅\n ⋅  1  ⋅"
+
+    struct OneElVec <: AbstractVector{Bool}
+        n :: Int
+        ind :: Int
+    end
+    Base.size(M::OneElVec) = (M.n,)
+    function Base.getindex(M::OneElVec, i::Int)
+        checkbounds(M, i)
+        i == M.ind
+    end
+    function Base.replace_in_print_matrix(M::OneElVec, i::Integer, j::Integer, s::AbstractString)
+        i == M.ind ? s : Base.replace_with_centered_mark(s)
+    end
+    V = view(OneElVec(6, 2), 1:5)
+    @test sprint(show, "text/plain", V) == "$(summary(V)):\n ⋅\n 1\n ⋅\n ⋅\n ⋅"
+end


### PR DESCRIPTION
With this, views of sparse/structured arrays are printed with dots as well: 
```julia
julia> D = Diagonal(1:4)
4×4 Diagonal{Int64, UnitRange{Int64}}:
 1  ⋅  ⋅  ⋅
 ⋅  2  ⋅  ⋅
 ⋅  ⋅  3  ⋅
 ⋅  ⋅  ⋅  4

julia> view(D, 1:3, 1:3)
3×3 view(::Diagonal{Int64, UnitRange{Int64}}, 1:3, 1:3) with eltype Int64:
 1  ⋅  ⋅
 ⋅  2  ⋅
 ⋅  ⋅  3

julia> S = sparse([1,2,2,2,3], [1,1,2,2,4], [5, -19, 73, 12, -7])
3×4 SparseMatrixCSC{Int64, Int64} with 4 stored entries:
   5   ⋅  ⋅   ⋅
 -19  85  ⋅   ⋅
   ⋅   ⋅  ⋅  -7

julia> view(S, 1:3, 1:3)
3×3 view(::SparseMatrixCSC{Int64, Int64}, 1:3, 1:3) with eltype Int64:
   5   ⋅  ⋅
 -19  85  ⋅
   ⋅   ⋅  ⋅
```