### PR TITLE
mention .= in assignment-vs-mutation docs

### DIFF
--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -211,7 +211,9 @@ in memory, accessible via either `a` or `b`.  Subsequently setting `a = 3.14159`
 does not change this array, it simply binds `a` to a different object; the array is still
 accessible via `b`. Another common syntax to mutate an existing object is
 `a.field = value` (an alias for [`setproperty!`](@ref)), which can be used to change
-a [`mutable struct`](@ref).  There is also mutation via dot assignment, for example `b .= 5:7` (which mutates our array `b` in-place to contain `[5,6,7]`), as part of Julia's [vectorized "dot" syntax](@ref man-dot-operators).
+a [`mutable struct`](@ref).  There is also mutation via dot assignment, for example
+`b .= 5:7` (which mutates our array `b` in-place to contain `[5,6,7]`), as part of Julia's
+[vectorized "dot" syntax](@ref man-dot-operators).
 
 When you call a [function](@ref man-functions) in Julia, it behaves as if you *assigned*
 the argument values to new variable names corresponding to the function arguments, as discussed

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -209,9 +209,9 @@ julia> b   # b refers to the original array object, which has been mutated
 That is, `a[i] = value` (an alias for [`setindex!`](@ref)) *mutates* an existing array object
 in memory, accessible via either `a` or `b`.  Subsequently setting `a = 3.14159`
 does not change this array, it simply binds `a` to a different object; the array is still
-accessible via `b`. The other common syntax to mutate an existing object is
+accessible via `b`. Another common syntax to mutate an existing object is
 `a.field = value` (an alias for [`setproperty!`](@ref)), which can be used to change
-a [`mutable struct`](@ref).
+a [`mutable struct`](@ref).  There is also mutation via dot assignment, for example `b .= 5:7` (which mutates our array `b` in-place to contain `[5,6,7]`), as part of Julia's [vectorized "dot" syntax](@ref man-dot-operators).
 
 When you call a [function](@ref man-functions) in Julia, it behaves as if you *assigned*
 the argument values to new variable names corresponding to the function arguments, as discussed


### PR DESCRIPTION
This seemed like an omission from that section, in the paragraph listing syntaxes that mutate an object.