### PR TITLE
loader: Provide memset, and use weak linkage instead of symbol renaming.

### DIFF
--- a/cli/loader.h
+++ b/cli/loader.h
@@ -6,24 +6,6 @@
 #include "../src/julia_fasttls.h"
 
 #ifdef _OS_WINDOWS_
-/* We need to reimplement a bunch of standard library stuff on windows,
- * but we want to make sure that it doesn't conflict with the actual implementations
- * once those get linked into this process. */
-#define fwrite loader_fwrite
-#define fputs loader_fputs
-#define exit loader_exit
-#define strlen loader_strlen
-#define wcslen loader_wcslen
-#define strncat loader_strncat
-#define memcpy loader_memcpy
-#define dirname loader_dirname
-#define strchr loader_strchr
-#define malloc loader_malloc
-#define realloc loader_realloc
-#define free loader_free
-#endif
-
-#ifdef _OS_WINDOWS_
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>

--- a/cli/loader_win_utils.c
+++ b/cli/loader_win_utils.c
@@ -12,7 +12,7 @@ static FILE _stderr = { INVALID_HANDLE_VALUE };
 FILE *stdout = &_stdout;
 FILE *stderr = &_stderr;
 
-int __attribute__((weak)) fwrite(const char *str, size_t nchars, FILE *out) {
+int JL_HIDDEN fwrite(const char *str, size_t nchars, FILE *out) {
     DWORD written;
     if (out->isconsole) {
         // Windows consoles do not support UTF-8 (for reading input, though new Windows Terminal does for writing), only UTF-16.
@@ -32,19 +32,19 @@ int __attribute__((weak)) fwrite(const char *str, size_t nchars, FILE *out) {
     return -1;
 }
 
-int __attribute__((weak)) fputs(const char *str, FILE *out) {
+int JL_HIDDEN fputs(const char *str, FILE *out) {
     return fwrite(str, strlen(str), out);
 }
 
-void __attribute__((weak)) *malloc(const size_t size) {
+void JL_HIDDEN *malloc(const size_t size) {
     return HeapAlloc(GetProcessHeap(), HEAP_GENERATE_EXCEPTIONS, size);
 }
 
-void __attribute__((weak)) *realloc(void * mem, const size_t size) {
+void JL_HIDDEN *realloc(void * mem, const size_t size) {
     return HeapReAlloc(GetProcessHeap(), HEAP_GENERATE_EXCEPTIONS, mem, size);
 }
 
-void __attribute__((weak)) free(void* mem) {
+void JL_HIDDEN free(void* mem) {
     HeapFree(GetProcessHeap(), 0, mem);
 }
 
@@ -110,7 +110,7 @@ void setup_stdio() {
     _stderr.isconsole = GetConsoleMode(_stderr.fd, &mode);
 }
 
-void __attribute__((weak)) exit(int code) {
+void JL_HIDDEN exit(int code) {
     ExitProcess(code);
 }
 
@@ -148,21 +148,21 @@ wchar_t *utf8_to_wchar(const char * str) {
     return wstr;
 }
 
-size_t __attribute__((weak)) strlen(const char * x) {
+size_t JL_HIDDEN strlen(const char * x) {
     int idx = 0;
     while (x[idx] != 0)
         idx++;
     return idx;
 }
 
-size_t __attribute__((weak)) wcslen(const wchar_t * x) {
+size_t JL_HIDDEN wcslen(const wchar_t * x) {
     int idx = 0;
     while (x[idx] != 0)
         idx++;
     return idx;
 }
 
-char __attribute__((weak)) *strncat(char * base, const char * tail, size_t maxlen) {
+char JL_HIDDEN *strncat(char * base, const char * tail, size_t maxlen) {
     int base_len = strlen(base);
     int tail_len = strlen(tail);
     for (int idx=base_len; idx<min(maxlen, base_len + tail_len); ++idx) {
@@ -171,21 +171,21 @@ char __attribute__((weak)) *strncat(char * base, const char * tail, size_t maxle
     return base;
 }
 
-void __attribute__((weak)) *memcpy(void * dest, const void * src, size_t len) {
+void JL_HIDDEN *memcpy(void * dest, const void * src, size_t len) {
     for (int idx=0; idx<len; ++idx) {
         ((char *)dest)[idx] = ((const char *)src)[idx];
     }
     return dest;
 }
 
-void __attribute__((weak)) *memset(void *s, int c, size_t n) {
+void JL_HIDDEN *memset(void *s, int c, size_t n) {
   unsigned char* p = s;
   while(n--)
     *p++ = (unsigned char)c;
   return s;
 }
 
-char __attribute__((weak)) *dirname(char * x) {
+char JL_HIDDEN *dirname(char * x) {
     int idx = strlen(x);
     while (idx > 0 && x[idx] != PATHSEPSTRING[0]) {
         idx -= 1;
@@ -205,7 +205,7 @@ char __attribute__((weak)) *dirname(char * x) {
     return x;
 }
 
-char __attribute__((weak)) *strchr(const char * haystack, int needle) {
+char JL_HIDDEN *strchr(const char * haystack, int needle) {
     int idx=0;
     while (haystack[idx] != needle) {
         if (haystack[idx] == 0) {


### PR DESCRIPTION
This ensures that the compiler may generate calls to these functions. Fixes https://github.com/JuliaLang/julia/issues/51680

Also, since we're using `-ffreestanding` for non-Windows platforms too, shouldn't the definitions of `memset` etc be put in `loader_lib.c`?

https://github.com/JuliaLang/julia/blob/e949236f29347f3e57a1a3a7d5ec656872ad8347/cli/Makefile#L10-L11

> GCC requires the freestanding environment provide memcpy, memmove, memset and memcmp

cc @gbaraldi 