### PR TITLE
docs: `Base.Order.Ordering`: consistency with #48363 and #48387

### DIFF
--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -21,7 +21,8 @@ export # not exported by Base
 """
     Base.Order.Ordering
 
-Abstract type which represents a total order on some set of elements.
+Abstract type which represents a strict weak order on some set of elements. See
+[`sort!`](@ref) for more.
 
 Use [`Base.Order.lt`](@ref) to compare two elements according to the ordering.
 """


### PR DESCRIPTION
"Total order" -> "strict weak order".