### PR TITLE
irinterp: Allow Expr(:boundscheck) in statement position

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -125,7 +125,7 @@ function reprocess_instruction!(interp::AbstractInterpreter, idx::Int, bb::Union
     rt = nothing
     if isa(stmt, Expr)
         head = stmt.head
-        if head === :call || head === :foreigncall || head === :new || head === :splatnew || head === :static_parameter || head === :isdefined
+        if head === :call || head === :foreigncall || head === :new || head === :splatnew || head === :static_parameter || head === :isdefined || head === :boundscheck
             (; rt, effects) = abstract_eval_statement_expr(interp, stmt, nothing, irsv)
             inst[:flag] |= flags_for_effects(effects)
         elseif head === :invoke


### PR DESCRIPTION
We didn't used to see these because :boundscheck in statement position would always taint consistency, but with the recent consistency refinement this is reachable, so it needs to be in the list.