### PR TITLE
inference: don't consider `Const(::Type)`-argument as const-profitable

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -773,7 +773,6 @@ end
 function abstract_call_method_with_const_args(interp::AbstractInterpreter,
     result::MethodCallResult, @nospecialize(f), arginfo::ArgInfo, si::StmtInfo,
     match::MethodMatch, sv::AbsIntState, invokecall::Union{Nothing,InvokeCall}=nothing)
-
     if !const_prop_enabled(interp, sv, match)
         return nothing
     end

--- a/base/compiler/abstractlattice.jl
+++ b/base/compiler/abstractlattice.jl
@@ -227,9 +227,12 @@ that should be forwarded along with constant propagation.
 end
 @nospecializeinfer function is_const_prop_profitable_arg(𝕃::ConstsLattice, @nospecialize t)
     if isa(t, Const)
-        # don't consider mutable values useful constants
         val = t.val
-        return isa(val, Symbol) || isa(val, Type) || !ismutable(val)
+        # `Const(ty::Type)` is essentially equivalent to `Type{ty}`
+        val isa Type && return false
+        # don't consider mutable values useful constants
+        val isa Symbol && return true # except for Symbols
+        return !ismutable(val)
     end
     isa(t, PartialTypeVar) && return false # this isn't forwardable
     return is_const_prop_profitable_arg(widenlattice(𝕃), t)


### PR DESCRIPTION
I've observed that we're performing essentially-duplicated inference when type-argument(s) are represented as `Const`. For instance, in the code:
```julia
descend((Int,)) do x
    Ref(x)
end
```

We first perform non-constant inference for `(::Type{Base.RefValue})(::Int)` and then constant inference for `(::Const(Base.RefValue))(::Int)`, although the latter "constant" inference is just wasteful. This happens because `Type{Base.RefValue}` propagates the essentially same information as `Const(Base.RefValue)`.

To eliminate the wasteful constant propagation, this commit adjusts `is_const_prop_profitable_arg` such that it no longer considers `Const(x::Type)` as being beneficial for constant propagation.

@nanosoldier `runbenchmarks("inference", vs=":master")`