### PR TITLE
Add versions to all stdlibs

### DIFF
--- a/stdlib/Artifacts/Project.toml
+++ b/stdlib/Artifacts/Project.toml
@@ -1,5 +1,6 @@
 name = "Artifacts"
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Base64/Project.toml
+++ b/stdlib/Base64/Project.toml
@@ -1,5 +1,6 @@
 name = "Base64"
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/CRC32c/Project.toml
+++ b/stdlib/CRC32c/Project.toml
@@ -1,5 +1,6 @@
 name = "CRC32c"
 uuid = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
+version = "1.11.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Dates/Project.toml
+++ b/stdlib/Dates/Project.toml
@@ -1,5 +1,6 @@
 name = "Dates"
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/stdlib/FileWatching/Project.toml
+++ b/stdlib/FileWatching/Project.toml
@@ -1,5 +1,6 @@
 name = "FileWatching"
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Future/Project.toml
+++ b/stdlib/Future/Project.toml
@@ -1,5 +1,6 @@
 name = "Future"
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+version = "1.11.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/stdlib/InteractiveUtils/Project.toml
+++ b/stdlib/InteractiveUtils/Project.toml
@@ -1,5 +1,6 @@
 name = "InteractiveUtils"
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
 
 [deps]
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/stdlib/LibGit2/Project.toml
+++ b/stdlib/LibGit2/Project.toml
@@ -1,5 +1,6 @@
 name = "LibGit2"
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/stdlib/Libdl/Project.toml
+++ b/stdlib/Libdl/Project.toml
@@ -1,5 +1,6 @@
 name = "Libdl"
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/LinearAlgebra/Project.toml
+++ b/stdlib/LinearAlgebra/Project.toml
@@ -1,5 +1,6 @@
 name = "LinearAlgebra"
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.11.0"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/stdlib/Logging/Project.toml
+++ b/stdlib/Logging/Project.toml
@@ -1,5 +1,6 @@
 name = "Logging"
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Markdown/Project.toml
+++ b/stdlib/Markdown/Project.toml
@@ -1,5 +1,6 @@
 name = "Markdown"
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/stdlib/Mmap/Project.toml
+++ b/stdlib/Mmap/Project.toml
@@ -1,5 +1,6 @@
 name = "Mmap"
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Printf/Project.toml
+++ b/stdlib/Printf/Project.toml
@@ -1,5 +1,6 @@
 name = "Printf"
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
 
 [deps]
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/stdlib/Profile/Project.toml
+++ b/stdlib/Profile/Project.toml
@@ -1,5 +1,6 @@
 name = "Profile"
 uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+version = "1.11.0"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/stdlib/REPL/Project.toml
+++ b/stdlib/REPL/Project.toml
@@ -1,5 +1,6 @@
 name = "REPL"
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/stdlib/Random/Project.toml
+++ b/stdlib/Random/Project.toml
@@ -1,5 +1,6 @@
 name = "Random"
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
 
 [deps]
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"

--- a/stdlib/Serialization/Project.toml
+++ b/stdlib/Serialization/Project.toml
@@ -1,5 +1,6 @@
 name = "Serialization"
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/SharedArrays/Project.toml
+++ b/stdlib/SharedArrays/Project.toml
@@ -1,5 +1,6 @@
 name = "SharedArrays"
 uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+version = "1.11.0"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/stdlib/Sockets/Project.toml
+++ b/stdlib/Sockets/Project.toml
@@ -1,5 +1,6 @@
 name = "Sockets"
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Test/Project.toml
+++ b/stdlib/Test/Project.toml
@@ -1,5 +1,6 @@
 name = "Test"
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/stdlib/UUIDs/Project.toml
+++ b/stdlib/UUIDs/Project.toml
@@ -1,5 +1,6 @@
 name = "UUIDs"
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/stdlib/Unicode/Project.toml
+++ b/stdlib/Unicode/Project.toml
@@ -1,6 +1,6 @@
 name = "Unicode"
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
-
+version = "1.11.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
For upgradeable stdlibs we need versions numbers,
let's add them now instead of after excision.
