### PR TITLE
Avoid `Style()` during broadcast whenever possible.

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -419,6 +419,10 @@ function combine_styles end
 
 combine_styles() = DefaultArrayStyle{0}()
 combine_styles(c) = result_style(BroadcastStyle(typeof(c)))
+function combine_styles(bc::Broadcasted)
+    bc.style isa Union{Nothing,Unknown} || return bc.style
+    throw(ArgumentError("Broadcasted{Unknown} wrappers do not have a style assigned"))
+end
 combine_styles(c1, c2) = result_style(combine_styles(c1), combine_styles(c2))
 @inline combine_styles(c1, c2, cs...) = result_style(combine_styles(c1), combine_styles(c2, cs...))
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1153,6 +1153,9 @@ Base.BroadcastStyle(a::MyBroadcastStyleWithField, b::MyBroadcastStyleWithField) 
         MyBroadcastStyleWithField(1)
     @test_throws ErrorException Broadcast.result_style(MyBroadcastStyleWithField(1),
                                                        MyBroadcastStyleWithField(2))
+    dest = [0, 0]
+    dest .= Broadcast.Broadcasted(MyBroadcastStyleWithField(1), +, (1:2, 2:3))
+    @test dest == [3, 5]
 end
 
 # test that `Broadcast` definition is defined as total and eligible for concrete evaluation


### PR DESCRIPTION
On master, `combine_styles(bc::Broadcasted)` calls `BroadcastStyle(typeof(bc))`, which seems bad after #49395 as it has a `Style()` call by default.