### PR TITLE
Improve dostring for error(msg...)

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -37,7 +37,7 @@ error(s::AbstractString) = throw(ErrorException(s))
 """
     error(msg...)
 
-Raise an `ErrorException` with the given message.
+Raise an `ErrorException` with a message constructed by `string(msg...)`.
 """
 function error(s::Vararg{Any,N}) where {N}
     @noinline


### PR DESCRIPTION
This PR slightly modifies the docstring for the second method defined for `error`, as the docstring for this method a) seems quite imprecise, and b) is identical to that of `error(::AbstractString)`.