### PR TITLE
add `Printf.Format` and `Printf.format` to manual

### DIFF
--- a/stdlib/Printf/docs/src/index.md
+++ b/stdlib/Printf/docs/src/index.md
@@ -3,4 +3,6 @@
 ```@docs
 Printf.@printf
 Printf.@sprintf
+Printf.Format
+Printf.format
 ```


### PR DESCRIPTION
As @ararslan [pointed out](https://github.com/beacon-biosignals/EDF.jl/pull/70#discussion_r1358917025), these were mentioned in the [1.6 NEWS](https://github.com/JuliaLang/julia/blob/release-1.6/NEWS.md#printf), so they should already be considered part of the Printf public API. Therefore we should add them to the manual, per-<https://docs.julialang.org/en/v1/manual/faq/#How-does-Julia-define-its-public-API?>.