### PR TITLE
REPL: remove 'oops.' for non Markdown help strings

### DIFF
--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -193,7 +193,6 @@ function insert_internal_warning(md::Markdown.MD, internal_access::Set{Pair{Modu
     md
 end
 function insert_internal_warning(other, internal_access::Set{Pair{Module,Symbol}})
-    println("oops.")
     other
 end
 


### PR DESCRIPTION
We are pulling in non-Markdown help-strings from an external library but they are prefixed by a single `oops.` now:
```
help?> Polymake.polytope.dodecahedron
oops.
dodecahedron() -> Polytope

 Create exact regular dodecahedron in Q(sqrt{5}).  A Platonic solid.

Arguments:

Returns Polytope 
```

This was added probably by accident in https://github.com/JuliaLang/julia/pull/50105/files#diff-625b68d89f9d5b3eaa175971271a3cce315a0d1e0597d03c9ab0bd7a0b020648R196 ?
cc: @LilithHafner 
