### PR TITLE
inference: use `jl_method_get_table` for `get_nospecializeinfer_sig`

### DIFF
--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -164,7 +164,7 @@ end
 
 function get_nospecializeinfer_sig(method::Method, @nospecialize(atype), sparams::SimpleVector)
     isa(atype, DataType) || return method.sig
-    mt = ccall(:jl_method_table_for, Any, (Any,), atype)
+    mt = ccall(:jl_method_get_table, Any, (Any,), method)
     mt === nothing && return method.sig
     return ccall(:jl_normalize_to_compilable_sig, Any, (Any, Any, Any, Any, Cint),
         mt, atype, sparams, method, #=int return_if_compileable=#0)


### PR DESCRIPTION
This allows `@nospecializeinfer` to be functional for `@overlay`ed methods, making it more aligned with `get_compileable_sig` too.