### PR TITLE
Restore initial state of `DEPOT_PATH` after precompilation workload

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2317,12 +2317,8 @@ function include_package_for_output(pkg::PkgId, input::String, depot_path::Vecto
         Core.Compiler.track_newly_inferred.x = false
     end
 
-    # restore the globals we set before running precompilation workload in case they were altered
+    # restore to initial state to make precompilation result relocatable
     append!(empty!(Base.DEPOT_PATH), depot_path)
-    append!(empty!(Base.DL_LOAD_PATH), dl_load_path)
-    append!(empty!(Base.LOAD_PATH), load_path)
-    ENV["JULIA_LOAD_PATH"] = join(load_path, Sys.iswindows() ? ';' : ':')
-    set_active_project(nothing)
 
 end
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2312,10 +2312,18 @@ function include_package_for_output(pkg::PkgId, input::String, depot_path::Vecto
     catch ex
         precompilableerror(ex) || rethrow()
         @debug "Aborting `create_expr_cache'" exception=(ErrorException("Declaration of __precompile__(false) not allowed"), catch_backtrace())
-        exit(125) # we define status = 125 means PrecompileableError
+        exit(125) # we define status = 125 means PrecompilableError
     finally
         Core.Compiler.track_newly_inferred.x = false
     end
+
+    # restore the globals we set before running precompilation workload in case they were altered
+    append!(empty!(Base.DEPOT_PATH), depot_path)
+    append!(empty!(Base.DL_LOAD_PATH), dl_load_path)
+    append!(empty!(Base.LOAD_PATH), load_path)
+    ENV["JULIA_LOAD_PATH"] = join(load_path, Sys.iswindows() ? ';' : ':')
+    set_active_project(nothing)
+
 end
 
 const PRECOMPILE_TRACE_COMPILE = Ref{String}()


### PR DESCRIPTION
Idea came from https://github.com/JuliaLang/Pkg.jl/pull/3668#issuecomment-1766719006

At least preserving `DEPOT_PATH` through precompilation workload will be essential for #49866.

---

Julia build will now fail, because `Pkg` does not pass that check until JuliaLang/Pkg.jl#3668 is merged.

And I guess this will also need a `PkgEval`.

cc @vchuravy @DilumAluthge 