### PR TITLE
Specialize `setindex`  for isbits `Tuple`s and `_totuple` for isbits `NTuple`s

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -432,7 +432,10 @@ function _totuple(::Type{NTuple{N, T}}, itr) where {N, T}
     end
 end
 
-_totuple(::Type{T}, itr, s::Vararg{Any,N}) where {T, N} = _totuple_recursive(T, itr, s...)
+function _totuple(::Type{T}, itr, s::Vararg{Any,N}) where {T, N}
+    @inline
+    _totuple_recursive(T, itr, s...)
+end
 
 function _totuple_recursive(::Type{T}, itr, s::Vararg{Any,N}) where {T,N}
     @inline

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -56,10 +56,13 @@ true
 function setindex(x::T, v::V, i::Integer) where {T<:Tuple, V}
     @boundscheck 1 <= i <= length(x) || throw(BoundsError(x, i))
     @inline
-    if @inbounds fieldtype(T, Int(i)) == V && isbitstype(V)
+    T1 = @inbounds fieldtype(T, Int(i))
+    if V <: T1 && allocatedinline(T1)
         new_tuple = Ref(x)
         t = @_gc_preserve_begin new_tuple
-        unsafe_store!(Ptr{V}(Base.pointer_from_objref(new_tuple)), v, i)
+        new_tuple_ptr = unsafe_convert(Ptr{T}, new_tuple)
+        ith_index_ptr = Ptr{T1}(new_tuple_ptr + fieldoffset(T, i))
+        unsafe_store!(ith_index_ptr, v, 1)
         @_gc_preserve_end t
         new_tuple[]
     else
@@ -395,11 +398,11 @@ function _totuple_err(@nospecialize T)
     throw(ArgumentError("too few elements for tuple type $T"))
 end
 
-function _tontuple_isbits(::Type{NTuple{N, T}}, itr) where {N, T}
+function _tontuple_inline(::Type{NTuple{N, T}}, itr) where {N, T}
     @inline
-    isbitstype(T) || throw(ArgumentError("tuple type $T is not isbits"))
+    allocatedinline(T) || throw(ArgumentError("tuple type $T is not allocated inline"))
     tuple = Ref{NTuple{N, T}}()
-    tuple_ptr = Ptr{T}(Base.pointer_from_objref(tuple))
+    tuple_ptr = Ptr{T}(unsafe_convert(Ptr{NTuple{N, T}}, tuple))
 
     iterations = 0
     for (i, v) in zip(1:N, itr)
@@ -416,8 +419,8 @@ end
 
 function _totuple(::Type{NTuple{N, T}}, itr) where {N, T}
     @inline
-    if isbitstype(T)
-        _tontuple_isbits(NTuple{N, T}, itr)
+    if allocatedinline(T)
+        _tontuple_inline(NTuple{N, T}, itr)
     elseif N >= 32
         # use iterative algorithm for long tuples
         elts = collect(E, Iterators.take(itr,N))

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -652,6 +652,9 @@ end
     y = Base.setindex(x, Ref(3), 1)
     @test y[1][] === 3
     @test y[2][] === 2
+
+    z = (1, Int32(2), Int128(3), Int8(1))
+    @test Base.setindex(z, Int8(5), 4) === (1, Int32(2), Int128(3), Int8(5))
 end
 
 @testset "inferable range indexing with constant values" begin

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -647,6 +647,11 @@ end
 
     f() = Base.setindex((1:1, 2:2, 3:3), 9, 1)
     @test @inferred(f()) == (9, 2:2, 3:3)
+
+    x = (Ref(1), Ref(2))
+    y = Base.setindex(x, Ref(3), 1)
+    @test y[1][] === 3
+    @test y[2][] === 2
 end
 
 @testset "inferable range indexing with constant values" begin

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -125,6 +125,8 @@ end
         z = Array{Float64,0}(undef); z[] = 3.0
         @test (3.0,) === @inferred Tuple(z)
     end
+
+    @test Tuple{Union{Int, Float64}}(1) === Tuple{Int}(1)
 end
 
 @testset "size" begin
@@ -655,6 +657,9 @@ end
 
     z = (1, Int32(2), Int128(3), Int8(1))
     @test Base.setindex(z, Int8(5), 4) === (1, Int32(2), Int128(3), Int8(5))
+
+    a = (1, Int32(2), Int32(3), Int8(4))
+    @test Base.setindex(z, Int8(5), 4) === (1, Int32(2), Int32(3), Int8(5))
 end
 
 @testset "inferable range indexing with constant values" begin

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -659,7 +659,7 @@ end
     @test Base.setindex(z, Int8(5), 4) === (1, Int32(2), Int128(3), Int8(5))
 
     a = (1, Int32(2), Int32(3), Int8(4))
-    @test Base.setindex(z, Int8(5), 4) === (1, Int32(2), Int32(3), Int8(5))
+    @test Base.setindex(a, Int8(5), 4) === (1, Int32(2), Int32(3), Int8(5))
 end
 
 @testset "inferable range indexing with constant values" begin


### PR DESCRIPTION
This pr instead of using a recursive solution like the existing method, creates a `Ref` to a tuple and mutates that iteratively. Escape Analysis seems to work well enough that this is always stack allocated.

master
```julia
julia>  @btime Base.setindex($(Ref{NTuple{100, Int}}()[];), 0, 5);  
  1.520 μs (98 allocations: 3.09 KiB)

julia>  @btime Base.setindex($(Ref{NTuple{5, Int}}()[];), 0, 5);  
  2.100 ns (0 allocations: 0 bytes)

julia> @btime NTuple{100, Int}($(i for i in 1:100));
  2.067 μs (2 allocations: 1.67 KiB)

julia> @btime NTuple{5, Int}($(i for i in 1:5));
  2.300 ns (0 allocations: 0 bytes)

julia> @btime NTuple{28, Int}($(i for i in 1:28));
  13.614 ns (0 allocations: 0 bytes)

julia> @btime NTuple{28, Float64}((rand()*i for i in 1:28));
  74.409 ns (0 allocations: 0 bytes)
```
pr
```julia
julia> @btime Base.setindex($(Ref{NTuple{100, Int}}()[];), 0, 5);
  13.313 ns (0 allocations: 0 bytes)

julia> @btime Base.setindex($(Ref{NTuple{5, Int}}()[];), 0, 5);
  2.000 ns (0 allocations: 0 bytes)

julia> @btime NTuple{100, Int}($(i for i in 1:100));
  24.574 ns (0 allocations: 0 bytes)

julia> @btime NTuple{5, Int}($(i for i in 1:5));
  2.500 ns (0 allocations: 0 bytes)

julia> @btime NTuple{28, Int}($(i for i in 1:28));
  8.709 ns (0 allocations: 0 bytes)

julia> @btime NTuple{28, Float64}((rand()*i for i in 1:28));
  45.510 ns (0 allocations: 0 bytes)
```

The new code seems to be about 100x faster for sizes >= 32 and it also SIMDs better. We could also specialize `_totuple` for isbits `Tuple`s but that requires unrolling to prevent type instabilities and runtime dispatch.