### PR TITLE
ASAN fixes.

### DIFF
--- a/src/dlload.c
+++ b/src/dlload.c
@@ -188,7 +188,7 @@ JL_DLLEXPORT JL_NO_SANITIZE void *jl_dlopen(const char *filename, unsigned flags
         dlopen = (dlopen_prototype*)dlsym(RTLD_NEXT, "dlopen");
         if (!dlopen)
             return NULL;
-        void *libdl_handle = dlopen("libdl.so", RTLD_NOW | RTLD_NOLOAD);
+        void *libdl_handle = dlopen("libdl.so.2", RTLD_NOW | RTLD_NOLOAD);
         assert(libdl_handle);
         dlopen = (dlopen_prototype*)dlsym(libdl_handle, "dlopen");
         dlclose(libdl_handle);

--- a/src/julia.h
+++ b/src/julia.h
@@ -2287,8 +2287,13 @@ void (ijl_longjmp)(jmp_buf _Buf, int _Value);
 #define jl_setjmp(a,b) sigsetjmp(a,b)
 #if defined(_COMPILER_ASAN_ENABLED_) && __GLIBC__
 // Bypass the ASAN longjmp wrapper - we're unpoisoning the stack ourselves.
+#if !__GLIBC_PREREQ(2, 34)
 JL_DLLIMPORT int __attribute__ ((nothrow)) (__libc_siglongjmp)(jl_jmp_buf buf, int val);
 #define jl_longjmp(a,b) __libc_siglongjmp(a,b)
+#else
+// This broke with glibc 2.34, where the __libc_siglongjmp symbol was removed
+#define jl_longjmp(a,b) siglongjmp(a,b)
+#endif
 #else
 #define jl_longjmp(a,b) siglongjmp(a,b)
 #endif

--- a/src/julia.h
+++ b/src/julia.h
@@ -2285,15 +2285,9 @@ void (ijl_longjmp)(jmp_buf _Buf, int _Value);
 #define jl_setjmp_name "sigsetjmp"
 #endif
 #define jl_setjmp(a,b) sigsetjmp(a,b)
-#if defined(_COMPILER_ASAN_ENABLED_) && __GLIBC__
-// Bypass the ASAN longjmp wrapper - we're unpoisoning the stack ourselves.
-#if !__GLIBC_PREREQ(2, 34)
-JL_DLLIMPORT int __attribute__ ((nothrow)) (__libc_siglongjmp)(jl_jmp_buf buf, int val);
-#define jl_longjmp(a,b) __libc_siglongjmp(a,b)
-#else
-// This broke with glibc 2.34, where the __libc_siglongjmp symbol was removed
-#define jl_longjmp(a,b) siglongjmp(a,b)
-#endif
+#if defined(_COMPILER_ASAN_ENABLED_) && defined(__GLIBC__)
+extern void (*real_siglongjmp)(jmp_buf _Buf, int _Value);
+#define jl_longjmp(a,b) real_siglongjmp(a,b)
 #else
 #define jl_longjmp(a,b) siglongjmp(a,b)
 #endif


### PR DESCRIPTION
Taking @topolarity's fixes from https://github.com/JuliaLang/julia/issues/50170. Resolves https://github.com/JuliaLang/julia/issues/47698

For the `sigsetjmp` bypass; looks like glibc removed the `__libc_siglongjmp` symbol in glibc 2.34, so I guess that's the cutoff:

```
❯ objdump --disassemble --show-all-symbols 2.33/lib/x86_64-linux-gnu/libc.so.6 | grep siglongjmp
000000000003c510 <__libc_siglongjmp@@GLIBC_PRIVATE>:
000000000003c510 <siglongjmp@@GLIBC_2.2.5>:
   3c528:	75 14                	jne    3c53e <__libc_siglongjmp@@GLIBC_PRIVATE+0x2e>
   3c54f:	eb d9                	jmp    3c52a <__libc_siglongjmp@@GLIBC_PRIVATE+0x1a>

❯ objdump --disassemble --show-all-symbols 2.34/lib/x86_64-linux-gnu/libc.so.6 | grep siglongjmp
000000000003d820 <siglongjmp@@GLIBC_2.2.5>:
```

@Keno What kind of code required bypassing the ASAN siglongjmp interceptor? Stuff seems to work fine without it.