### PR TITLE
move out Random from sysimage to see what packages it breaks

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -30,7 +30,6 @@ let
         :FileWatching, # used by loading.jl -- implicit assumption that init runs
         :Libdl, # Transitive through LinAlg
         :Artifacts, # Transitive through LinAlg
-        :SHA, # transitive through Random
         :Sockets, # used by stream.jl
 
         # Transitive through LingAlg
@@ -39,7 +38,6 @@ let
 
         # 1-depth packages
         :LinearAlgebra, # Commits type-piracy and GEMM
-        :Random, # Can't be removed due to rand being exported by Base
     ]
     # PackageCompiler can filter out stdlibs so it can be empty
     maxlen = maximum(textwidth.(string.(stdlibs)); init=0)

--- a/stdlib/stdlib.mk
+++ b/stdlib/stdlib.mk
@@ -1,12 +1,12 @@
 STDLIBS_WITHIN_SYSIMG := \
-	Artifacts FileWatching Libdl SHA libblastrampoline_jll OpenBLAS_jll Random \
+	Artifacts FileWatching Libdl libblastrampoline_jll OpenBLAS_jll \
 	LinearAlgebra Sockets
 
 INDEPENDENT_STDLIBS := \
 	ArgTools Base64 CRC32c Dates DelimitedFiles Distributed Downloads Future \
 	InteractiveUtils LazyArtifacts LibGit2 LibCURL Logging Markdown Mmap \
-	NetworkOptions Profile Printf Pkg REPL Serialization SharedArrays SparseArrays \
-	Statistics Tar Test TOML Unicode UUIDs \
+	NetworkOptions Profile Printf Pkg Random REPL Serialization SharedArrays SparseArrays \
+	Statistics SHA Tar Test TOML Unicode UUIDs \
 	dSFMT_jll GMP_jll libLLVM_jll LLD_jll LLVMLibUnwind_jll LibUnwind_jll LibUV_jll \
 	LibCURL_jll LibSSH2_jll LibGit2_jll nghttp2_jll  MozillaCACerts_jll MbedTLS_jll \
 	MPFR_jll OpenLibm_jll PCRE2_jll p7zip_jll Zlib_jll


### PR DESCRIPTION
This is a version of https://github.com/JuliaLang/julia/pull/51432 that does not have the method world age hack to make it non-breaking. This is to discover (through PkgEval) what packages rely on Random being in the sysimage and should be updated. Even if #51432 is non-breaking, there is some invalidation cost in using the methods without relying on Random so it is still better to have these packages fixed.

