### PR TITLE
ignore mightalias for empty objects

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1507,7 +1507,7 @@ Perform a conservative test to check if arrays `A` and `B` might share the same 
 By default, this simply checks if either of the arrays reference the same memory
 regions, as identified by their [`Base.dataids`](@ref).
 """
-mightalias(A::AbstractArray, B::AbstractArray) = !isbits(A) && !isbits(B) && !_isdisjoint(dataids(A), dataids(B))
+mightalias(A::AbstractArray, B::AbstractArray) = !isbits(A) && !isbits(B) && !isempty(A) && !isempty(B) && !_isdisjoint(dataids(A), dataids(B))
 mightalias(x, y) = false
 
 _isdisjoint(as::Tuple{}, bs::Tuple{}) = true


### PR DESCRIPTION
There is no bytes that overlap, so it is safe to use these without needing to make an explicit copy of nothing.