### PR TITLE
`AbstractInterpreter`: define `add_invalidation_callback!` utility

### DIFF
--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -325,13 +325,10 @@ end
     add_invalidation_callback!(callback, mi::MethodInstance)
 
 Register `callback` to be triggered upon the invalidation of `mi`.
-`callback` should a function taking a single argument, `replaced::MethodInstance`,
+`callback` should a function taking two arguments, `callback(replaced::MethodInstance, max_world::UInt32)`,
 and it will be recursively invoked on `MethodInstance`s within the invalidation graph.
 """
-add_invalidation_callback!(@nospecialize(callback), mi::MethodInstance) =
-    _add_invalidation_callback!(mi, InvalidationCallback(callback))
-
-function _add_invalidation_callback!(mi::MethodInstance, @nospecialize(callback))
+function add_invalidation_callback!(@nospecialize(callback), mi::MethodInstance)
     if !isdefined(mi, :callbacks)
         callbacks = mi.callbacks = Any[callback]
     else
@@ -341,22 +338,6 @@ function _add_invalidation_callback!(mi::MethodInstance, @nospecialize(callback)
         end
     end
     return callbacks
-end
-
-struct InvalidationCallback{Callback}
-    callback::Callback
-end
-function (callback::InvalidationCallback)(replaced::MethodInstance, max_world::UInt32,
-                                          seen::IdSet{MethodInstance}=IdSet{MethodInstance}())
-    push!(seen, replaced)
-    callback.callback(replaced)
-    if isdefined(replaced, :backedges)
-        for mi in replaced.backedges::Vector{Any}
-            isa(mi, MethodInstance) || continue # might be `Type` object representing an `invoke` signature
-            mi in seen && continue # otherwise fail into an infinite loop
-            callback(mi, max_world, seen)
-        end
-    end
 end
 
 #########

--- a/test/compiler/EscapeAnalysis/EAUtils.jl
+++ b/test/compiler/EscapeAnalysis/EAUtils.jl
@@ -137,7 +137,7 @@ CC.getindex(wvc::WorldView{EscapeAnalyzerCacheView}, mi::MethodInstance) = getin
 function CC.setindex!(wvc::WorldView{EscapeAnalyzerCacheView}, ci::CodeInstance, mi::MethodInstance)
     wvc.cache.code_cache.cache[mi] = ci
     # register the callback on invalidation
-    CC.add_invalidation_callback!(mi) do replaced::MethodInstance
+    CC.add_invalidation_callback!(mi) do replaced::MethodInstance, max_world::UInt32
         delete!(wvc.cache.code_cache.cache, replaced)
         delete!(wvc.cache.escape_cache.cache, replaced)
     end

--- a/test/compiler/EscapeAnalysis/EAUtils.jl
+++ b/test/compiler/EscapeAnalysis/EAUtils.jl
@@ -136,38 +136,12 @@ CC.get(wvc::WorldView{EscapeAnalyzerCacheView}, mi::MethodInstance, default) = g
 CC.getindex(wvc::WorldView{EscapeAnalyzerCacheView}, mi::MethodInstance) = getindex(wvc.cache.code_cache.cache, mi)
 function CC.setindex!(wvc::WorldView{EscapeAnalyzerCacheView}, ci::CodeInstance, mi::MethodInstance)
     wvc.cache.code_cache.cache[mi] = ci
-    add_invalidation_callback!(wvc.cache.code_cache, wvc.cache.escape_cache, mi) # register the callback on invalidation
-    return nothing
-end
-function add_invalidation_callback!(code_cache::CodeCache, escape_cache::EscapeCache, mi)
-    callback = InvalidationCallback(code_cache, escape_cache)
-    if !isdefined(mi, :callbacks)
-        mi.callbacks = Any[callback]
-    else
-        if !any(@nospecialize(cb)->cb===callback, mi.callbacks)
-            push!(mi.callbacks, callback)
-        end
+    # register the callback on invalidation
+    CC.add_invalidation_callback!(mi) do replaced::MethodInstance
+        delete!(wvc.cache.code_cache.cache, replaced)
+        delete!(wvc.cache.escape_cache.cache, replaced)
     end
-    return nothing
-end
-struct InvalidationCallback
-    code_cache::CodeCache
-    escape_cache::EscapeCache
-end
-function (callback::InvalidationCallback)(replaced::MethodInstance, max_world,
-                                          seen::IdSet{MethodInstance}=IdSet{MethodInstance}())
-    (; code_cache, escape_cache) = callback
-    push!(seen, replaced)
-    delete!(code_cache.cache, replaced)
-    delete!(escape_cache.cache, replaced)
-    if isdefined(replaced, :backedges)
-        for mi in replaced.backedges
-            isa(mi, MethodInstance) || continue # might be `Type` object representing an `invoke` signature
-            mi in seen && continue # otherwise fall into infinite loop
-            callback(mi, max_world, seen)
-        end
-    end
-    return nothing
+    return wvc
 end
 
 function CC.optimize(interp::EscapeAnalyzer, opt::OptimizationState, caller::InferenceResult)

--- a/test/compiler/invalidation.jl
+++ b/test/compiler/invalidation.jl
@@ -46,9 +46,9 @@ CC.get(wvc::WorldView{InvalidationTesterCacheView}, mi::MethodInstance, default)
 CC.getindex(wvc::WorldView{InvalidationTesterCacheView}, mi::MethodInstance) = getindex(wvc.cache.dict, mi)
 CC.haskey(wvc::WorldView{InvalidationTesterCacheView}, mi::MethodInstance) = haskey(wvc.cache.dict, mi)
 function CC.setindex!(wvc::WorldView{InvalidationTesterCacheView}, ci::CodeInstance, mi::MethodInstance)
-    CC.add_invalidation_callback!(mi) do replaced::MethodInstance
+    CC.add_invalidation_callback!(mi) do replaced::MethodInstance, max_world::UInt32
         delete!(wvc.cache.dict, replaced)
-        # Core.println(replaced) # debug
+        # Core.println("[InvalidationTester] ", replaced) # debug
     end
     setindex!(wvc.cache.dict, ci, mi)
 end

--- a/test/compiler/invalidation.jl
+++ b/test/compiler/invalidation.jl
@@ -18,30 +18,22 @@ InvalidationTesterCache() = InvalidationTesterCache(IdDict{MethodInstance,CodeIn
 const INVALIDATION_TESTER_CACHE = InvalidationTesterCache()
 
 struct InvalidationTester <: CC.AbstractInterpreter
-    callback!
     world::UInt
     inf_params::CC.InferenceParams
     opt_params::CC.OptimizationParams
     inf_cache::Vector{CC.InferenceResult}
     code_cache::InvalidationTesterCache
-    function InvalidationTester(callback! = nothing;
+    function InvalidationTester(;
                                 world::UInt = Base.get_world_counter(),
                                 inf_params::CC.InferenceParams = CC.InferenceParams(),
                                 opt_params::CC.OptimizationParams = CC.OptimizationParams(),
                                 inf_cache::Vector{CC.InferenceResult} = CC.InferenceResult[],
                                 code_cache::InvalidationTesterCache = INVALIDATION_TESTER_CACHE)
-        if callback! === nothing
-            callback! = function (replaced::MethodInstance)
-                # Core.println(replaced) # debug
-                delete!(code_cache.dict, replaced)
-            end
-        end
-        return new(callback!, world, inf_params, opt_params, inf_cache, code_cache)
+        return new(world, inf_params, opt_params, inf_cache, code_cache)
     end
 end
 
 struct InvalidationTesterCacheView
-    interp::InvalidationTester
     dict::IdDict{MethodInstance,CodeInstance}
 end
 
@@ -49,42 +41,17 @@ CC.InferenceParams(interp::InvalidationTester) = interp.inf_params
 CC.OptimizationParams(interp::InvalidationTester) = interp.opt_params
 CC.get_world_counter(interp::InvalidationTester) = interp.world
 CC.get_inference_cache(interp::InvalidationTester) = interp.inf_cache
-CC.code_cache(interp::InvalidationTester) = WorldView(InvalidationTesterCacheView(interp, interp.code_cache.dict), WorldRange(interp.world))
+CC.code_cache(interp::InvalidationTester) = WorldView(InvalidationTesterCacheView(interp.code_cache.dict), WorldRange(interp.world))
 CC.get(wvc::WorldView{InvalidationTesterCacheView}, mi::MethodInstance, default) = get(wvc.cache.dict, mi, default)
 CC.getindex(wvc::WorldView{InvalidationTesterCacheView}, mi::MethodInstance) = getindex(wvc.cache.dict, mi)
 CC.haskey(wvc::WorldView{InvalidationTesterCacheView}, mi::MethodInstance) = haskey(wvc.cache.dict, mi)
 function CC.setindex!(wvc::WorldView{InvalidationTesterCacheView}, ci::CodeInstance, mi::MethodInstance)
-    add_callback!(wvc.cache.interp.callback!, mi)
+    CC.add_invalidation_callback!(mi) do replaced::MethodInstance
+        delete!(wvc.cache.dict, replaced)
+        # Core.println(replaced) # debug
+    end
     setindex!(wvc.cache.dict, ci, mi)
 end
-
-function add_callback!(@nospecialize(callback!), mi::MethodInstance)
-    callback = function (replaced::MethodInstance, max_world,
-                         seen::Base.IdSet{MethodInstance} = Base.IdSet{MethodInstance}())
-        push!(seen, replaced)
-        callback!(replaced)
-        if isdefined(replaced, :backedges)
-            for item in replaced.backedges
-                isa(item, MethodInstance) || continue # might be `Type` object representing an `invoke` signature
-                mi = item
-                mi in seen && continue # otherwise fail into an infinite loop
-                var"#self#"(mi, max_world, seen)
-            end
-        end
-        return nothing
-    end
-
-    if !isdefined(mi, :callbacks)
-        mi.callbacks = Any[callback]
-    else
-        callbacks = mi.callbacks::Vector{Any}
-        if !any(@nospecialize(cb)->cb===callback, callbacks)
-            push!(callbacks, callback)
-        end
-    end
-    return nothing
-end
-
 
 # basic functionality test
 # ------------------------

--- a/test/compiler/newinterp.jl
+++ b/test/compiler/newinterp.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+# TODO set up a version who defines new interpreter with persistent cache?
+
 """
     @newinterp NewInterpreter
 


### PR DESCRIPTION
It seems we're reaching a consensus on how the external `AbstractInterpreter` utilizes user invalidation callbacks. Let's establish a utility within `Core.Compiler` for this purpose, which cannibalizes the pattern, so that external packages can easily access and use it.