### PR TITLE
fix eltype for partition iterators of substrings

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -571,6 +571,8 @@ end
 
 # Specialization for partition(s,n) to return a SubString
 eltype(::Type{PartitionIterator{T}}) where {T<:AbstractString} = SubString{T}
+# SubStrings do not nest
+eltype(::Type{PartitionIterator{T}}) where {T<:SubString} = T
 
 function iterate(itr::PartitionIterator{<:AbstractString}, state = firstindex(itr.c))
     state > ncodeunits(itr.c) && return nothing

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -1001,3 +1001,7 @@ end
     end
     @test v == ()
 end
+
+@testset "collect partition substring" begin
+    @test collect(Iterators.partition(lstrip("01111", '0'), 2)) == ["11", "11"]
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/51771

The convert method that asserts in #51771 is arguably still faulty though.