### PR TITLE
Make local scope for `else` blocks in `try`/`catch`/`else`

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1424,7 +1424,7 @@
                 (scope-block ,finalb)))))
           ((length> e 3)
            (and (length> e 6) (error "invalid \"try\" form"))
-           (let ((elseb (if (length= e 6) (cdddddr e) '())))
+           (let ((elseb (if (length= e 6) `((scope-block ,@(cdddddr e))) '())))
              (expand-forms
                `(,(if (null? elseb) 'trycatch 'trycatchelse)
                  (scope-block ,tryb)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -3187,6 +3187,22 @@ end
     end
     @test err == 5 + 6
     @test x == 1
+
+    x = 0
+    try
+    catch
+    else
+        x = 1
+    end
+    @test x == 1
+
+    try
+    catch
+    else
+        tryelse_in_local_scope = true
+    end
+
+    @test !@isdefined(tryelse_in_local_scope)
 end
 
 @test_parseerror """


### PR DESCRIPTION
[Docs](https://docs.julialang.org/en/v1/manual/control-flow/#else-Clauses) state:

> The try, catch, else, and finally clauses each introduce their own
> scope blocks.

But it is currently not the case for `else` blocks

```julia
julia> try
       catch
       else
           z = 1
       end
1

julia> z
1
```

This change actually makes `else` blocks have their own scope block:

```julia
julia> try
       catch
       else
           z = 1
       end
1

julia> z
ERROR: UndefVarError: `z` not defined
```