### PR TITLE
fix return type of `exec_options`

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -248,7 +248,7 @@ function exec_options(opts)
             let InteractiveUtils = load_InteractiveUtils()
                 invokelatest(InteractiveUtils.report_bug, arg)
             end
-            return nothing
+            return false
         else
             @warn "Unexpected command -$cmd'$arg'"
         end


### PR DESCRIPTION
Should fix the failures observed in JuliaLang/BugReporting.jl#141. Test
for this is in #51776 which depends on afromentioned PR which depends on
this fix.
