### PR TITLE
move out LinearAlgebra from sysimage to see what packages it breaks

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -28,17 +28,10 @@ let
     stdlibs = [
         # No dependencies
         :FileWatching, # used by loading.jl -- implicit assumption that init runs
-        :Libdl, # Transitive through LinAlg
-        :Artifacts, # Transitive through LinAlg
         :SHA, # transitive through Random
         :Sockets, # used by stream.jl
 
-        # Transitive through LingAlg
-        # OpenBLAS_jll
-        # libblastrampoline_jll
-
         # 1-depth packages
-        :LinearAlgebra, # Commits type-piracy and GEMM
         :Random, # Can't be removed due to rand being exported by Base
     ]
     # PackageCompiler can filter out stdlibs so it can be empty

--- a/stdlib/stdlib.mk
+++ b/stdlib/stdlib.mk
@@ -1,15 +1,14 @@
 STDLIBS_WITHIN_SYSIMG := \
-	Artifacts FileWatching Libdl SHA libblastrampoline_jll OpenBLAS_jll Random \
-	LinearAlgebra Sockets
+	FileWatching SHA Random Sockets
 
 INDEPENDENT_STDLIBS := \
-	ArgTools Base64 CRC32c Dates DelimitedFiles Distributed Downloads Future \
-	InteractiveUtils LazyArtifacts LibGit2 LibCURL Logging Markdown Mmap \
+	ArgTools Artifacts Base64 CRC32c Dates DelimitedFiles Distributed Downloads Future \
+	InteractiveUtils LazyArtifacts Libdl LibGit2 LibCURL LinearAlgebra Logging Markdown Mmap \
 	NetworkOptions Profile Printf Pkg REPL Serialization SharedArrays SparseArrays \
 	Statistics Tar Test TOML Unicode UUIDs \
 	dSFMT_jll GMP_jll libLLVM_jll LLD_jll LLVMLibUnwind_jll LibUnwind_jll LibUV_jll \
-	LibCURL_jll LibSSH2_jll LibGit2_jll nghttp2_jll  MozillaCACerts_jll MbedTLS_jll \
-	MPFR_jll OpenLibm_jll PCRE2_jll p7zip_jll Zlib_jll
+	LibCURL_jll LibSSH2_jll LibGit2_jll libblastrampoline_jll nghttp2_jll MozillaCACerts_jll MbedTLS_jll \
+	MPFR_jll OpenBLAS_jll OpenLibm_jll PCRE2_jll p7zip_jll Zlib_jll
 
 
 STDLIBS := $(STDLIBS_WITHIN_SYSIMG) $(INDEPENDENT_STDLIBS)


### PR DESCRIPTION
Same as #51759. 

 This is to discover (through PkgEval) what packages rely on LinearAlgebra being in the sysimage and should be updated.
