### PR TITLE
Allow AnnotatedStrings in log messages

### DIFF
--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -118,8 +118,17 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
     end
 
     # Generate a text representation of the message and all key value pairs,
-    # split into lines.
-    msglines = [(indent=0, msg=l) for l in split(chomp(convert(String, string(message))::String), '\n')]
+    # split into lines.  This is specialised to improve type inference,
+    # and reduce the risk of resulting method invalidations.
+    message = string(message)
+    msglines = if Base._isannotated(message) && !isempty(Base.annotations(message))
+        message = Base.AnnotatedString(String(message), Base.annotations(message))
+        @NamedTuple{indent::Int, msg::Union{SubString{Base.AnnotatedString{String}}, SubString{String}}}[
+            (indent=0, msg=l) for l in split(chomp(message), '\n')]
+    else
+        [(indent=0, msg=l) for l in split(
+             chomp(convert(String, message)::String), '\n')]
+    end
     stream::IO = logger.stream
     if !(isopen(stream)::Bool)
         stream = stderr

--- a/stdlib/Logging/test/runtests.jl
+++ b/stdlib/Logging/test/runtests.jl
@@ -52,6 +52,15 @@ end
     end
     @test String(take!(buf)) == ""
 
+    # Check that the AnnotatedString path works too
+    with_logger(logger) do
+        @info Base.AnnotatedString("test")
+    end
+    @test String(take!(buf)) ==
+    """
+    [ Info: test
+    """
+
     @testset "Default metadata formatting" begin
         @test Logging.default_metafmt(Logging.Debug, Base, :g, :i, expanduser("~/somefile.jl"), 42) ==
             (:log_debug, "Debug:",   "@ Base ~/somefile.jl:42")


### PR DESCRIPTION
Permitting annotated strings allows for styling information to be preserved through to log printing.

![image](https://github.com/JuliaLang/julia/assets/20903656/84327e30-6ae7-4d65-b1c5-9d5fa8c9a569)
