### PR TITLE
Add Debian terminfo directory default to find_terminfo_file

### DIFF
--- a/base/terminfo.jl
+++ b/base/terminfo.jl
@@ -253,7 +253,7 @@ function find_terminfo_file(term::String)
                 replace(split(ENV["TERMINFO_DIRS"], ':'),
                         "" => "/usr/share/terminfo"))
     Sys.isunix() &&
-        push!(terminfo_dirs, "/etc/terminfo", "/usr/share/terminfo")
+        push!(terminfo_dirs, "/etc/terminfo", "/lib/terminfo", "/usr/share/terminfo")
     for dir in terminfo_dirs
         if isfile(joinpath(dir, chr, term))
             return joinpath(dir, chr, term)


### PR DESCRIPTION
Without this, `Base.current_terminfo` returns `TermInfo(String[]; 0 flags, 0 numbers, 0 strings)` because it cannot find the correct terminfo files. In the regular terminal, there was basic color and formatting functionality because `$TERM`s starting with `xterm` are treated specially, but in a tmux session, where the `$TERM = tmux-256color`, there was no color at all.

This also has the side-effect of enabling strikethrough and italics in the default gnome terminal emulator.

The readme found in `/etc/terminfo/README` (as mentioned in `terminfo(5) "Fetching Compiled Descriptions"`) says the following:

```
/etc/terminfo/README 
This directory is for system-local terminfo descriptions. By default,
ncurses will search ${HOME}/.terminfo first, then /etc/terminfo (this
directory), then /lib/terminfo, and last not least /usr/share/terminfo.
```

I believe the manual might be different depending on the distro.
