### PR TITLE
use old linker on macos to avoid warnings

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -634,6 +634,12 @@ define IMPLIB_FLAGS
 endef
 endif
 
+# On MacOS use old, slower linker for now to avoid linker warnings such as
+# ld: warning: no platform load command found in '../julia/usr/lib/julia/sys-o.a[2](text#0.o)', assuming: macOS
+ifeq ($(OS),Darwin)
+LDFLAGS += -Wl,-ld_classic
+endif
+
 # On Windows, we want shared library files to end up in $(build_bindir), instead of $(build_libdir)
 # We also don't really have a private bindir on windows right now, due to lack of RPATH.
 ifeq ($(OS),WINNT)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/51562

@gbaraldi do we need to implement the xcode version check from [this](https://projects.blender.org/blender/blender/pulls/110243/files)? I couldn't see an easy way to?