### PR TITLE
Added tests for load_overrides() in Artifacts.jl

### DIFF
--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -34,7 +34,6 @@ run(addenv(`$(Base.julia_cmd()) --color=no $(joinpath(@__DIR__, "refresh_artifac
 
         # Get the path to the Overrides.toml file
         overrides_path = joinpath(artifacts_dir, "Overrides.toml")
-        println("runtests.Load Artifacts.create_test_overrides_toml(): overrides_path=$overrides_path")
 
         # Create the Overrides.toml file
         open(overrides_path, "w") do io
@@ -42,13 +41,13 @@ run(addenv(`$(Base.julia_cmd()) --color=no $(joinpath(@__DIR__, "refresh_artifac
         end
     end
 
-    # Specify the expected test result when depot path does not exist
+    # Specify the expected test result when depot path does not exist or no overriding happened
     empty_output = Dict{Symbol, Any}(
         :UUID => Dict{Base.UUID, Dict{String, Union{SHA1, String}}}(),
         :hash => Dict{SHA1, Union{SHA1, String}}()
     )
 
-    # Specify the expected test result
+    # Specify the expected test result when overriding happened
     expected_output = Dict{Symbol, Any}(
         :UUID => Dict{Base.UUID, Dict{String, Union{SHA1, String}}}(Base.UUID("d57dbccd-ca19-4d82-b9b8-9d660942965b") => Dict("c_simple" => "/path/to/c_simple_dir", "libfoo" => SHA1("fb886e813a4aed4147d5979fcdf27457d20aa35d"))),
         :hash => Dict{SHA1, Union{SHA1, String}}(SHA1("78f35e74ff113f02274ce60dab6e92b4546ef806") => "/path/to/replacement", SHA1("c76f8cda85f83a06d17de6c57aabf9e294eb2537") => SHA1("fb886e813a4aed4147d5979fcdf27457d20aa35d"))
@@ -73,7 +72,7 @@ run(addenv(`$(Base.julia_cmd()) --color=no $(joinpath(@__DIR__, "refresh_artifac
             # Test `load_overrides()` works *with* "Overrides.toml" file but non-nothing ARTIFACT_OVERRIDES[]
             @test load_overrides() == empty_output
 
-            # Test `load_overrides()` works *with* "Overrides.toml" file with force parameter
+            # Test `load_overrides()` works *with* "Overrides.toml" file with force parameter, which overrides even when `ARTIFACT_OVERRIDES[] !== nothing``
             @test load_overrides(force=true) == expected_output
         finally # Make sure `DEPOT_PATH` will be restored to the status quo in the event of a bug
             # Restore the old `DEPOT_PATH` to avoid messing with any other code

--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -103,13 +103,13 @@ run(addenv(`$(Base.julia_cmd()) --color=no $(joinpath(@__DIR__, "refresh_artifac
         end
     end
 
-    # -- Overrides.toml in the artifacts directory    
+    # -- Overrides.toml in the artifacts directory
     # Create "Overrides.toml" for the test
     created_artifacts_dir, created_overrides_toml = create_test_overrides_toml()
 
     # Run test
     expected_output = Dict{Symbol, Any}(
-        :UUID => Dict{Base.UUID, Dict{String, Union{SHA1, String}}}(Base.UUID("d57dbccd-ca19-4d82-b9b8-9d660942965b") => Dict("c_simple" => "/path/to/c_simple_dir", "libfoo" => SHA1("fb886e813a4aed4147d5979fcdf27457d20aa35d"))), 
+        :UUID => Dict{Base.UUID, Dict{String, Union{SHA1, String}}}(Base.UUID("d57dbccd-ca19-4d82-b9b8-9d660942965b") => Dict("c_simple" => "/path/to/c_simple_dir", "libfoo" => SHA1("fb886e813a4aed4147d5979fcdf27457d20aa35d"))),
         :hash => Dict{SHA1, Union{SHA1, String}}(SHA1("78f35e74ff113f02274ce60dab6e92b4546ef806") => "/path/to/replacement", SHA1("c76f8cda85f83a06d17de6c57aabf9e294eb2537") => SHA1("fb886e813a4aed4147d5979fcdf27457d20aa35d"))
     )
     @test load_overrides() == expected_output

--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -9,22 +9,13 @@ using TOML
 artifacts_dir = mktempdir()
 run(addenv(`$(Base.julia_cmd()) --color=no $(joinpath(@__DIR__, "refresh_artifacts.jl")) $(artifacts_dir)`, "TERM"=>"dumb"))
 
-@testset "Load Overrides()" begin
-    # -- helper functions to create the test `Overrides.toml` and restore the status quo afterwards
+@testset "Load Overrides" begin
     """
-        create_test_overrides_toml()::Tuple{Bool, Bool}
+        create_test_overrides_toml(temp_dir::String)
 
-    Create "Overrides.toml" in the "~/.julia/artifacts" dir if it is not already there.
-    Otherwise, do nothing.
-
-    Return two parameters:
-    The first parameter returns true if the artifacts directory did not exist and was created.
-    Otherwise return false.
-
-    The second parameter returns true if "Overrides.toml" did not exist and was created.
-    Otherwise return false.
+    Create "Overrides.toml" in the given `temp_dir`.
     """
-    function create_test_overrides_toml()::Tuple{Bool, Bool}
+    function create_test_overrides_toml(temp_dir::String)
         # Define the overrides
         overrides = Dict(
             "78f35e74ff113f02274ce60dab6e92b4546ef806" => "/path/to/replacement",
@@ -35,91 +26,40 @@ run(addenv(`$(Base.julia_cmd()) --color=no $(joinpath(@__DIR__, "refresh_artifac
             )
         )
 
-        # Get the path to the default depot
-        depot_path = DEPOT_PATH[1]
-
-        # Get the artifacts directory
-        artifacts_dir = joinpath(depot_path, "artifacts")
-
-        # Check if the directory already exists
-        created_artifacts_dir = !isdir(artifacts_dir)
-
-        # Ensure the artifacts directory exists
-        isdir(artifacts_dir) || mkdir(artifacts_dir)
-
         # Get the path to the Overrides.toml file
-        overrides_path = joinpath(artifacts_dir, "Overrides.toml")
+        overrides_path = joinpath(temp_dir, "Overrides.toml")
 
-        # Create the Overrides.toml file if it doesn't exist
-        if !isfile(overrides_path)
-            open(overrides_path, "w") do io
-                TOML.print(io, overrides)
-            end
-            return created_artifacts_dir, true
-        else
-            return created_artifacts_dir, false
+        # Create the Overrides.toml file
+        open(overrides_path, "w") do io
+            TOML.print(io, overrides)
         end
     end
 
-    """
-        clear_test_overrides_toml(created_artifacts_dir::Bool, created_overrides_toml::Bool)
-
-    Delete "Overrides.toml" in the "~/.julia/artifacts" dir and the artifacts directory
-    if they were created by `create_test_overrides_toml()`.
-    Otherwise, do nothing.
-    """
-    function clear_test_overrides_toml(created_artifacts_dir::Bool, created_overrides_toml::Bool)
-        # Get the path to the default depot
-        depot_path = DEPOT_PATH[1]
-
-        # Get the artifacts directory
-        artifacts_dir = joinpath(depot_path, "artifacts")
-
-        # Get the path to the Overrides.toml file
-        overrides_path = joinpath(artifacts_dir, "Overrides.toml")
-
-        # Delete the Overrides.toml file if it exists
-        if created_overrides_toml
-            if isfile(overrides_path)
-                # Overrides.toml file deleted.
-                rm(overrides_path)
-            else
-                # Overrides.toml file does not exist.
-            end
-        end
-
-        # Delete the artifacts directory if it exists and is empty
-        if created_artifacts_dir
-            if isdir(artifacts_dir)
-                if isempty(readdir(artifacts_dir))
-                    # Artifacts directory deleted.
-                    rm(artifacts_dir)
-                else
-                    # Artifacts directory is not empty. Not deleting.
-                end
-            else
-                # Artifacts directory does not exist.
-            end
-        end
-    end
-
-    # -- Overrides.toml in the artifacts directory
-    # Create "Overrides.toml" for the test
-    created_artifacts_dir, created_overrides_toml = create_test_overrides_toml()
-
-    # Run test
+    # Specify the expected test result
     expected_output = Dict{Symbol, Any}(
         :UUID => Dict{Base.UUID, Dict{String, Union{SHA1, String}}}(Base.UUID("d57dbccd-ca19-4d82-b9b8-9d660942965b") => Dict("c_simple" => "/path/to/c_simple_dir", "libfoo" => SHA1("fb886e813a4aed4147d5979fcdf27457d20aa35d"))),
         :hash => Dict{SHA1, Union{SHA1, String}}(SHA1("78f35e74ff113f02274ce60dab6e92b4546ef806") => "/path/to/replacement", SHA1("c76f8cda85f83a06d17de6c57aabf9e294eb2537") => SHA1("fb886e813a4aed4147d5979fcdf27457d20aa35d"))
     )
+
+    # Test `load_overrides()` works with *no* "Overrides.toml" file
     @test load_overrides() == expected_output
 
-    # -- Overrides.toml not in the artifacts directory
-    # Delete test "Overrides.toml"
-    clear_test_overrides_toml(created_artifacts_dir, created_overrides_toml)
+    # Create a temporary directory and set DEPOT_PATH to that directory
+    temp_dir = mktempdir()
+    old_depot_path = DEPOT_PATH[1]
+    DEPOT_PATH[1] = temp_dir
 
-    # Run test
+    # Create "Overrides.toml" for the test
+    create_test_overrides_toml(temp_dir)
+
+    # Test `load_overrides()` works *with* "Overrides.toml" file
     @test load_overrides() == expected_output
+
+    # Restore DEPOT_PATH
+    DEPOT_PATH[1] = old_depot_path
+
+    # Temporary directory and test "Overrides.toml" file will be automatically deleted when out of scope
+    # This means after the function exits, the system *should* and will behave like this test never happened.
 end
 
 @testset "Artifact Paths" begin


### PR DESCRIPTION
Fixes #48551
Continued from #51815
The `load_overrides()` method in `Artifacts.jl` has a large untested branch. This PR increases the test coverage for this method.

![image](https://github.com/JuliaLang/julia/assets/141328479/a9744e25-e79f-4664-8522-320dd29c4c50)
https://app.codecov.io/gh/JuliaLang/julia/blob/master/stdlib%2FArtifacts%2Fsrc%2FArtifacts.jl#L121