### PR TITLE
docs: delete misleading `::Function` annotation in the `ntuple` doc

### DIFF
--- a/base/ntuple.jl
+++ b/base/ntuple.jl
@@ -3,7 +3,7 @@
 # `ntuple`, for constructing tuples of a given length
 
 """
-    ntuple(f::Function, n::Integer)
+    ntuple(f, n::Integer)
 
 Create a tuple of length `n`, computing each element as `f(i)`,
 where `i` is the index of the element.


### PR DESCRIPTION
The first argument is not actually restricted to `Function` types.