### PR TITLE
LLVM: Activate typed pointers through the API instead of a global option.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9310,17 +9310,6 @@ extern "C" void jl_init_llvm(void)
     if (clopt && clopt->getNumOccurrences() == 0)
         cl::ProvidePositionalOption(clopt, "4", 1);
 
-#if JL_LLVM_VERSION >= 150000
-    clopt = llvmopts.lookup("opaque-pointers");
-    if (clopt && clopt->getNumOccurrences() == 0) {
-#ifdef JL_LLVM_OPAQUE_POINTERS
-        cl::ProvidePositionalOption(clopt, "true", 1);
-#else
-        cl::ProvidePositionalOption(clopt, "false", 1);
-#endif
-    }
-#endif
-
     jl_ExecutionEngine = new JuliaOJIT();
 
     bool jl_using_gdb_jitevents = false;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9310,6 +9310,12 @@ extern "C" void jl_init_llvm(void)
     if (clopt && clopt->getNumOccurrences() == 0)
         cl::ProvidePositionalOption(clopt, "4", 1);
 
+    // we want the opaque-pointers to be opt-in, per LLVMContext, for this release
+    // so change the default value back to pre-14.x, without changing the NumOccurrences flag for it
+    clopt = llvmopts.lookup("opaque-pointers");
+    if (clopt && clopt->getNumOccurrences() == 0) {
+        clopt->addOccurrence(1, clopt->ArgStr, "false", true);
+    }
     jl_ExecutionEngine = new JuliaOJIT();
 
     bool jl_using_gdb_jitevents = false;

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1629,6 +1629,10 @@ JuliaOJIT::JuliaOJIT()
     DLSymOpt(std::make_unique<DLSymOptimizer>(false)),
     ContextPool([](){
         auto ctx = std::make_unique<LLVMContext>();
+#ifndef JL_LLVM_OPAQUE_POINTERS
+        if (ctx->supportsTypedPointers())
+            ctx->setOpaquePointers(false);
+#endif
         return orc::ThreadSafeContext(std::move(ctx));
     }),
 #ifdef JL_USE_JITLINK

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1629,9 +1629,11 @@ JuliaOJIT::JuliaOJIT()
     DLSymOpt(std::make_unique<DLSymOptimizer>(false)),
     ContextPool([](){
         auto ctx = std::make_unique<LLVMContext>();
+        if (!ctx->hasSetOpaquePointersValue())
 #ifndef JL_LLVM_OPAQUE_POINTERS
-        if (ctx->supportsTypedPointers())
             ctx->setOpaquePointers(false);
+#else
+            ctx->setOpaquePointers(true);
 #endif
         return orc::ThreadSafeContext(std::move(ctx));
     }),


### PR DESCRIPTION
This allows other users of LLVM to use opaque pointers on their contexts. I'd like to get this in 1.10 (or a minor version) so that we can start updating packages to be compatible with opaque pointers. Currently, that requires overriding the global option, which is unwanted (may break Julia, definitely breaks certain GPUCompiler back-ends, etc).

Picked from https://github.com/JuliaLang/julia/pull/49846.