### PR TITLE
post-opt: run full scan within `check_inconsistency!`

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -656,7 +656,6 @@ end
 
 function ((; sv)::ScanStmt)(inst::Instruction, idx::Int, lstmt::Int, bb::Int)
     stmt = inst[:stmt]
-    flag = inst[:flag]
 
     if isexpr(stmt, :enter)
         # try/catch not yet modeled
@@ -707,9 +706,10 @@ function ((; sv)::ScanStmt)(inst::Instruction, idx::Int, lstmt::Int, bb::Int)
 end
 
 function check_inconsistentcy!(sv::PostOptAnalysisState, scanner::BBScanner)
-    scan!(ScanStmt(sv), scanner, true)
+    scan!(ScanStmt(sv), scanner, false)
     complete!(sv.tpdum); push!(scanner.bb_ip, 1)
     populate_def_use_map!(sv.tpdum, scanner)
+
     (; ir, inconsistent, tpdum) = sv
     stmt_ip = BitSetBoundedMinPrioritySet(length(ir.stmts))
     for def in sv.inconsistent

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -1130,3 +1130,15 @@ let effects = Base.infer_effects(x -> `a $x`, (Any,))
     @test !Core.Compiler.is_noub(effects)
     @test !Core.Compiler.is_consistent(effects)
 end
+
+function issue51837(; openquotechar::Char, newlinechar::Char)
+    ncodeunits(openquotechar) == 1 || throw(ArgumentError("`openquotechar` must be a single-byte character"))
+    if !isnothing(newlinechar)
+        ncodeunits(newlinechar) > 1 && throw(ArgumentError("`newlinechar` must be a single-byte character."))
+    end
+    return nothing
+end
+@test Base.infer_effects() do openquotechar::Char, newlinechar::Char
+    issue51837(; openquotechar, newlinechar)
+end |> !Core.Compiler.is_nothrow
+@test_throws ArgumentError issue51837(; openquotechar='α', newlinechar='\n')


### PR DESCRIPTION
Otherwise we fail to scan all statements.

fix #51837