### PR TITLE
atexit: move hook before precompile output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,10 @@ New language features
 
 Language changes
 ----------------
+* During precompilation, the `atexit` hooks now run before saving the output file. This
+  allows users to safely tear down background state (such as closing Timers and sending
+  disconnect notifications to heartbeat tasks) and cleanup other resources when the program
+  wants to begin exiting.
 
 Compiler/Runtime improvements
 -----------------------------

--- a/base/file.jl
+++ b/base/file.jl
@@ -521,37 +521,67 @@ const TEMP_CLEANUP = Dict{String,Bool}()
 const TEMP_CLEANUP_LOCK = ReentrantLock()
 
 function temp_cleanup_later(path::AbstractString; asap::Bool=false)
-    lock(TEMP_CLEANUP_LOCK)
+    @lock TEMP_CLEANUP_LOCK begin
     # each path should only be inserted here once, but if there
     # is a collision, let !asap win over asap: if any user might
     # still be using the path, don't delete it until process exit
     TEMP_CLEANUP[path] = get(TEMP_CLEANUP, path, true) & asap
     if length(TEMP_CLEANUP) > TEMP_CLEANUP_MAX[]
-        temp_cleanup_purge()
+        temp_cleanup_purge_prelocked(false)
         TEMP_CLEANUP_MAX[] = max(TEMP_CLEANUP_MIN[], 2*length(TEMP_CLEANUP))
     end
-    unlock(TEMP_CLEANUP_LOCK)
-    return nothing
+    end
+    nothing
 end
 
-function temp_cleanup_purge(; force::Bool=false)
-    need_gc = Sys.iswindows()
-    for (path, asap) in TEMP_CLEANUP
+function temp_cleanup_forget(path::AbstractString)
+    @lock TEMP_CLEANUP_LOCK delete!(TEMP_CLEANUP, path)
+    nothing
+end
+
+function temp_cleanup_purge_prelocked(force::Bool)
+    filter!(TEMP_CLEANUP) do (path, asap)
         try
-            if (force || asap) && ispath(path)
-                need_gc && GC.gc(true)
-                need_gc = false
+            ispath(path) || return false
+            if force || asap
                 prepare_for_deletion(path)
                 rm(path, recursive=true, force=true)
             end
-            !ispath(path) && delete!(TEMP_CLEANUP, path)
+            return ispath(path)
         catch ex
             @warn """
                 Failed to clean up temporary path $(repr(path))
                 $ex
                 """ _group=:file
+            ex isa InterruptException && rethrow()
+            return true
         end
     end
+    nothing
+end
+
+function temp_cleanup_purge_all()
+    may_need_gc = false
+    @lock TEMP_CLEANUP_LOCK filter!(TEMP_CLEANUP) do (path, asap)
+        try
+            ispath(path) || return false
+            may_need_gc = true
+            return true
+        catch ex
+            ex isa InterruptException && rethrow()
+            return true
+        end
+    end
+    if may_need_gc
+        # this is only usually required on Sys.iswindows(), but may as well do it everywhere
+        GC.gc(true)
+    end
+    @lock TEMP_CLEANUP_LOCK temp_cleanup_purge_prelocked(true)
+    nothing
+end
+
+function __postinit__()
+    Base.atexit(temp_cleanup_purge_all)
 end
 
 const temp_prefix = "jl_"
@@ -733,10 +763,11 @@ temporary file upon completion.
 See also: [`mktempdir`](@ref).
 """
 function mktemp(fn::Function, parent::AbstractString=tempdir())
-    (tmp_path, tmp_io) = mktemp(parent, cleanup=false)
+    (tmp_path, tmp_io) = mktemp(parent)
     try
         fn(tmp_path, tmp_io)
     finally
+        temp_cleanup_forget(tmp_path)
         try
             close(tmp_io)
             ispath(tmp_path) && rm(tmp_path)
@@ -761,10 +792,11 @@ See also: [`mktemp`](@ref), [`mkdir`](@ref).
 """
 function mktempdir(fn::Function, parent::AbstractString=tempdir();
     prefix::AbstractString=temp_prefix)
-    tmpdir = mktempdir(parent; prefix=prefix, cleanup=false)
+    tmpdir = mktempdir(parent; prefix=prefix)
     try
         fn(tmpdir)
     finally
+        temp_cleanup_forget(tmpdir)
         try
             if ispath(tmpdir)
                 prepare_for_deletion(tmpdir)

--- a/base/file.jl
+++ b/base/file.jl
@@ -580,6 +580,9 @@ function temp_cleanup_purge_all()
     nothing
 end
 
+# deprecated internal function used by some packages
+temp_cleanup_purge(; force=false) = force ? temp_cleanup_purge_all() : @lock TEMP_CLEANUP_LOCK temp_cleanup_purge_prelocked(false)
+
 function __postinit__()
     Base.atexit(temp_cleanup_purge_all)
 end

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -367,9 +367,7 @@ end
 
 ## atexit: register exit hooks ##
 
-const atexit_hooks = Callable[
-    () -> Filesystem.temp_cleanup_purge(force=true)
-]
+const atexit_hooks = Callable[]
 const _atexit_hooks_lock = ReentrantLock()
 global _atexit_hooks_finished::Bool = false
 
@@ -413,7 +411,7 @@ function _atexit(exitcode::Cint)
     # will immediately run here.
     while true
         local f
-        Base.@lock _atexit_hooks_lock begin
+        @lock _atexit_hooks_lock begin
             # If this is the last iteration, atomically disable atexit hooks to prevent
             # someone from registering a hook that will never be run.
             # (We do this inside the loop, so that it is atomic: no one can have registered
@@ -434,7 +432,7 @@ function _atexit(exitcode::Cint)
             end
         catch ex
             showerror(stderr, ex)
-            Base.show_backtrace(stderr, catch_backtrace())
+            show_backtrace(stderr, catch_backtrace())
             println(stderr)
         end
     end
@@ -454,7 +452,7 @@ function _postoutput()
             f()
         catch ex
             showerror(stderr, ex)
-            Base.show_backtrace(stderr, catch_backtrace())
+            show_backtrace(stderr, catch_backtrace())
             println(stderr)
         end
     end

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -334,10 +334,6 @@ end
 
 generate_precompile_statements()
 
-# As a last step in system image generation,
-# remove some references to build time environment for a more reproducible build.
-Base.Filesystem.temp_cleanup_purge(force=true)
-
 let stdout = Ref{IO}(stdout)
     Base.PROGRAM_FILE = ""
     Sys.BINDIR = ""

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -86,12 +86,10 @@ void jl_wait_empty_begin(void)
     }
     JL_UV_UNLOCK();
 }
-
 void jl_wait_empty_end(void)
 {
-    JL_UV_LOCK();
+    // n.b. caller must be holding jl_uv_mutex
     uv_close((uv_handle_t*)&wait_empty_worker, NULL);
-    JL_UV_UNLOCK();
 }
 
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -194,7 +194,6 @@ int jl_running_under_rr(int recheck) JL_NOTSAFEPOINT;
 // Returns time in nanosec
 JL_DLLEXPORT uint64_t jl_hrtime(void) JL_NOTSAFEPOINT;
 
-JL_DLLEXPORT void jl_set_peek_cond(uintptr_t);
 JL_DLLEXPORT double jl_get_profile_peek_duration(void);
 JL_DLLEXPORT void jl_set_profile_peek_duration(double);
 

--- a/src/partr.c
+++ b/src/partr.c
@@ -357,9 +357,14 @@ void jl_task_wait_empty(void)
         ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
         if (f)
             jl_apply_generic(f, NULL, 0);
+        // we are back from jl_task_get_next now
         ct->world_age = lastage;
         wait_empty = NULL;
+        // TODO: move this lock acquire-release pair to the caller, so that we ensure new work
+        // (from uv_unref objects) didn't unexpectedly get scheduled and start running behind our back
+        JL_UV_LOCK();
         jl_wait_empty_end();
+        JL_UV_UNLOCK();
     }
 }
 

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -717,22 +717,24 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
     size_t i, l = udeps ? jl_array_nrows(udeps) : 0;
     for (i = 0; i < l; i++) {
         jl_value_t *deptuple = jl_array_ptr_ref(udeps, i);
-        jl_value_t *abspath = jl_fieldref(deptuple, 1);
+        jl_value_t *deppath = jl_fieldref(deptuple, 1);
 
-        jl_value_t **replace_depot_args;
-        JL_GC_PUSHARGS(replace_depot_args, 2);
-        replace_depot_args[0] = replace_depot_func;
-        replace_depot_args[1] = abspath;
-        ct = jl_current_task;
-        size_t last_age = ct->world_age;
-        ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
-        jl_value_t *depalias = (jl_value_t*)jl_apply(replace_depot_args, 2);
-        ct->world_age = last_age;
-        JL_GC_POP();
+        if (replace_depot_func) {
+            jl_value_t **replace_depot_args;
+            JL_GC_PUSHARGS(replace_depot_args, 2);
+            replace_depot_args[0] = replace_depot_func;
+            replace_depot_args[1] = deppath;
+            ct = jl_current_task;
+            size_t last_age = ct->world_age;
+            ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
+            deppath = (jl_value_t*)jl_apply(replace_depot_args, 2);
+            ct->world_age = last_age;
+            JL_GC_POP();
+        }
 
-        size_t slen = jl_string_len(depalias);
+        size_t slen = jl_string_len(deppath);
         write_int32(s, slen);
-        ios_write(s, jl_string_data(depalias), slen);
+        ios_write(s, jl_string_data(deppath), slen);
         write_uint64(s, jl_unbox_uint64(jl_fieldref(deptuple, 2)));    // fsize
         write_uint32(s, jl_unbox_uint32(jl_fieldref(deptuple, 3)));    // hash
         write_float64(s, jl_unbox_float64(jl_fieldref(deptuple, 4)));  // mtime

--- a/stdlib/Profile/Project.toml
+++ b/stdlib/Profile/Project.toml
@@ -2,9 +2,6 @@ name = "Profile"
 uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 version = "1.11.0"
 
-[deps]
-Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-
 [extras]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -205,9 +205,5 @@ end
 
 generate_precompile_statements()
 
-# As a last step in system image generation,
-# remove some references to build time environment for a more reproducible build.
-Base.Filesystem.temp_cleanup_purge(force=true)
-
 precompile(Tuple{typeof(getproperty), REPL.REPLBackend, Symbol})
 end # Precompile

--- a/test/atexit.jl
+++ b/test/atexit.jl
@@ -214,12 +214,13 @@ using Test
             # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
             # 3. attempting to register a hook after all hooks have finished (disallowed)
             """
-            const atexit_has_finished = Threads.Atomic{Bool}(false)
+            const atexit_has_finished = Threads.Atomic{Int}(0)
             atexit() do
                 Threads.@spawn begin
                     # Block until the atexit hooks have all finished. We use a manual "spin
                     # lock" because task switch is disallowed inside the finalizer, below.
-                    while !atexit_has_finished[] end
+                    atexit_has_finished[] = 1
+                    while atexit_has_finished[] == 1 end
                     try
                         # By the time this runs, all the atexit hooks will be done.
                         # So this will throw.
@@ -231,15 +232,16 @@ using Test
                         exit(22)
                     end
                 end
+                while atexit_has_finished[] == 0 end
             end
             # Finalizers run after the atexit hooks, so this blocks exit until the spawned
             # task above gets a chance to run.
             x = []
             finalizer(x) do x
                 # Allow the spawned task to finish
-                atexit_has_finished[] = true
+                atexit_has_finished[] = 2
                 # Then spin forever to prevent exit.
-                while atexit_has_finished[] end
+                while atexit_has_finished[] == 2 end
             end
             exit(0)
             """ => 22,


### PR DESCRIPTION
To show how this is used, this updates the profile_printing_listener background job to use this mechanism.