### PR TITLE
[REPL] Fix shell completion error on unreadable symlink

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -329,8 +329,19 @@ function complete_path(path::AbstractString, pos::Int;
             for file in filesinpath
                 # In a perfect world, we would filter on whether the file is executable
                 # here, or even on whether the current user can execute the file in question.
-                if startswith(file, prefix) && isfile(joinpath(pathdir, file))
-                    push!(matches, file)
+                try
+                    if startswith(file, prefix) && isfile(joinpath(pathdir, file))
+                        push!(matches, file)
+                    end
+                catch e
+                    # `isfile()` can throw in rare cases such as when probing a
+                    # symlink that points to a file within a directory we do not
+                    # have read access to.
+                    if isa(e, Base.IOError)
+                        continue
+                    else
+                        rethrow()
+                    end
                 end
             end
         end


### PR DESCRIPTION
In macOS there is a file, `/usr/sbin/weakpass_edit` that is a symlink to a directory that is only readable by `root`.  Our REPL shell completion attempts to call `isfile()` when entering the shell mode and pressing `w`, throwing an ugly error into the REPL.

This PR fixes the root cause (skipping files that fail the `isfile()` condition) and adds a test that synthesizes an analogous condition.