### PR TITLE
replace jl_gc_wb_binding with jl_gc_wb

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1298,7 +1298,7 @@ JL_CALLABLE(jl_f_set_binding_type)
         jl_errorf("cannot set type for global %s.%s. It already has a value or is already set to a different type.",
                   jl_symbol_name(m->name), jl_symbol_name(s));
     }
-    jl_gc_wb_binding(b, ty);
+    jl_gc_wb(b, ty);
     return jl_nothing;
 }
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -578,11 +578,6 @@ void jl_gc_add_finalizer_(jl_ptls_t ptls, void *v, void *f) JL_NOTSAFEPOINT;
 
 void gc_setmark_buf(jl_ptls_t ptls, void *buf, uint8_t, size_t) JL_NOTSAFEPOINT;
 
-STATIC_INLINE void jl_gc_wb_binding(jl_binding_t *bnd, void *val) JL_NOTSAFEPOINT // val isa jl_value_t*
-{
-    jl_gc_wb(bnd, val);
-}
-
 STATIC_INLINE void jl_gc_wb_buf(void *parent, void *bufptr, size_t minsz) JL_NOTSAFEPOINT // parent isa jl_value_t*
 {
     // if parent is marked and buf is not

--- a/src/module.c
+++ b/src/module.c
@@ -810,7 +810,7 @@ JL_DLLEXPORT void jl_set_const(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var
         if (constp = bp->constp, bp->constp = 1, constp == 0) {
             jl_value_t *old = NULL;
             if (jl_atomic_cmpswap(&bp->value, &old, val)) {
-                jl_gc_wb_binding(bp, val);
+                jl_gc_wb(bp, val);
                 return;
             }
         }
@@ -899,7 +899,7 @@ JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_module_t *mod, jl_sy
     if (b->constp) {
         jl_value_t *old = NULL;
         if (jl_atomic_cmpswap(&b->value, &old, rhs)) {
-            jl_gc_wb_binding(b, rhs);
+            jl_gc_wb(b, rhs);
             return;
         }
         if (jl_egal(rhs, old))
@@ -913,7 +913,7 @@ JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_module_t *mod, jl_sy
                        jl_symbol_name(mod->name), jl_symbol_name(var));
     }
     jl_atomic_store_release(&b->value, rhs);
-    jl_gc_wb_binding(b, rhs);
+    jl_gc_wb(b, rhs);
 }
 
 JL_DLLEXPORT void jl_declare_constant(jl_binding_t *b, jl_module_t *mod, jl_sym_t *var)

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -167,7 +167,7 @@ static jl_value_t *jl_eval_module_expr(jl_module_t *parent_module, jl_expr_t *ex
             jl_printf(JL_STDERR, "WARNING: replacing module %s.\n", jl_symbol_name(name));
             old = jl_atomic_exchange(&b->value, (jl_value_t*)newm);
         }
-        jl_gc_wb_binding(b, newm);
+        jl_gc_wb(b, newm);
         if (old != NULL) {
             // create a hidden gc root for the old module
             JL_LOCK(&jl_modules_mutex);


### PR DESCRIPTION
`jl_gc_wb_binding` has become a thin wrapper around `jl_gc_wb` now that `jl_binding_t` is first class.

Replace it with `jl_gc_wb` to clean-up the write-barrier uses a bit.