### PR TITLE
Assert that `exit` never returns

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -25,7 +25,7 @@ Stop the program with an exit code. The default exit code is zero, indicating th
 program completed successfully. In an interactive session, `exit()` can be called with
 the keyboard shortcut `^D`.
 """
-exit(n) = (ccall(:jl_exit, Cvoid, (Int32,), n); error())
+exit(n) = ccall(:jl_exit, Union{}, (Int32,), n)
 exit() = exit(0)
 
 const roottask = current_task()

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -25,7 +25,7 @@ Stop the program with an exit code. The default exit code is zero, indicating th
 program completed successfully. In an interactive session, `exit()` can be called with
 the keyboard shortcut `^D`.
 """
-exit(n) = ccall(:jl_exit, Cvoid, (Int32,), n)::Union{}
+exit(n) = (ccall(:jl_exit, Cvoid, (Int32,), n); error())
 exit() = exit(0)
 
 const roottask = current_task()

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -25,7 +25,7 @@ Stop the program with an exit code. The default exit code is zero, indicating th
 program completed successfully. In an interactive session, `exit()` can be called with
 the keyboard shortcut `^D`.
 """
-exit(n) = ccall(:jl_exit, Cvoid, (Int32,), n)
+exit(n) = ccall(:jl_exit, Cvoid, (Int32,), n)::Union{}
 exit() = exit(0)
 
 const roottask = current_task()

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5365,9 +5365,9 @@ end
 @test phic_type3() === 2
 
 # Test that `exit` returns `Union{}` (issue #51856)
-function test_error_bottom(s)
+function test_exit_bottom(s)
     n = tryparse(Int, s)
     isnothing(n) && exit()
     n
 end
-@test only(Base.return_types(test_error_bottom, Tuple{String})) == Int
+@test only(Base.return_types(test_exit_bottom, Tuple{String})) == Int

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5363,3 +5363,11 @@ function phic_type3()
 end
 @test Base.return_types(phic_type3) |> only === Union{Int, Float64}
 @test phic_type3() === 2
+
+# Test that `exit` returns `Union{}` (issue #51856)
+function test_error_bottom(s)
+    n = tryparse(Int, s)
+    isnothing(n) && exit()
+    n
+end
+@test only(Base.return_types(test_error_bottom, Tuple{String})) == Int


### PR DESCRIPTION
Typeassert `exit()::Union{}`, such that the compiler knows that `exit` never returns, and thus can refine types based on this information.

Edit: This has been changed to manually calling `error()` instead of typeasserting.

Closes #51856 

Note to reviewers: I don't think the solution `exit()::Union{}` is particularly nice. For example, it shows up in JET as an error because `exit()` is still inferred to `Nothing` before the typeassert. But I don't know how to directly tell the compiler that this function doesn't return.