### PR TITLE
Use correct module when printing code_llvm for opaque closures

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -1895,7 +1895,7 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t* dump, jl_method_instance_t *mi, siz
                         elty = p->getType()->getNonOpaquePointerElementType();
                     }
                     // For pretty printing, when LLVM inlines the global initializer into its loads
-                    auto alias = GlobalAlias::create(elty, 0, GlobalValue::PrivateLinkage, global.second->getName() + ".jit", p, m.getModuleUnlocked());
+                    auto alias = GlobalAlias::create(elty, 0, GlobalValue::PrivateLinkage, global.second->getName() + ".jit", p, global.second->getParent());
                     global.second->setInitializer(ConstantExpr::getBitCast(alias, global.second->getValueType()));
                     global.second->setConstant(true);
                     global.second->setLinkage(GlobalValue::PrivateLinkage);

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -347,3 +347,5 @@ let ir = Base.code_ircode((Int,Int)) do x, y
     code_llvm(io, oc, (Int,Int))
     @test occursin("j_*_", String(take!(io)))
 end
+                                                        
+code_llvm(()) do; Base.Experimental.@opaque(@noinline x::Int->println(x))(1) end #Shouldn't crash

--- a/test/opaque_closure.jl
+++ b/test/opaque_closure.jl
@@ -347,5 +347,5 @@ let ir = Base.code_ircode((Int,Int)) do x, y
     code_llvm(io, oc, (Int,Int))
     @test occursin("j_*_", String(take!(io)))
 end
-                                                        
+
 code_llvm(()) do; Base.Experimental.@opaque(@noinline x::Int->println(x))(1) end #Shouldn't crash


### PR DESCRIPTION
Another way to fix this is to only look at the globals in `m` instead of globals_target. 

Fixes https://github.com/JuliaLang/julia/issues/51842