### PR TITLE
Fix field access overlooked by rename

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -797,15 +797,15 @@ function AnnotatedString(chars::AbstractVector{C}) where {C<:AbstractChar}
             end
         end
     end
-    props = Tuple{UnitRange{Int}, Pair{Symbol, Any}}[]
+    annots = Tuple{UnitRange{Int}, Pair{Symbol, Any}}[]
     point = 1
     for c in chars
         if c isa AnnotatedChar
-            for prop in c.properties
-                push!(props, (point:point, prop))
+            for annot in c.annotations
+                push!(annots, (point:point, annot))
             end
         end
         point += ncodeunits(c)
     end
-    AnnotatedString(str, props)
+    AnnotatedString(str, annots)
 end

--- a/test/strings/annotated.jl
+++ b/test/strings/annotated.jl
@@ -30,6 +30,8 @@
     @test str != Base.AnnotatedString("some string", [(1:1, :thing => 0x01), (6:6, :other => 0x02), (11:11, :all => 0x03)])
     @test str != Base.AnnotatedString("some string", [(1:4, :thing => 0x11), (1:11, :all => 0x13), (6:11, :other => 0x12)])
     @test str != Base.AnnotatedString("some thingg", [(1:4, :thing => 0x01), (1:11, :all => 0x03), (6:11, :other => 0x02)])
+    @test Base.AnnotatedString([Base.AnnotatedChar('a', [:a => 1]), Base.AnnotatedChar('b', [:b => 2])]) ==
+        Base.AnnotatedString("ab", [(1:1, :a => 1), (2:2, :b => 2)])
     let allstrings =
         ['a', Base.AnnotatedChar('a'), Base.AnnotatedChar('a', [:aaa => 0x04]),
         "a string", Base.AnnotatedString("a string"),


### PR DESCRIPTION
In e5cd9b6b3888c, the properties field was renamed to annotations, but the code here was not updated.

This was missed because there was no test for the
`AnnotatedString(::AbstractVector{AbstractChar})` method, which is also corrected here.