### PR TITLE
fixup to #51743, timetype subtraction

### DIFF
--- a/stdlib/Dates/src/arithmetic.jl
+++ b/stdlib/Dates/src/arithmetic.jl
@@ -6,8 +6,7 @@
 
 # TimeType arithmetic
 (+)(x::TimeType) = x
-(-)(x::Date, y::Date) = x.instant - y.instant
-(-)(x::Time, y::Time) = x.instant - y.instant
+(-)(x::T, y::T) where {T<:TimeType} = x.instant - y.instant
 (-)(x::DateTime, y::DateTime) = x.instant - y.instant
 (-)(x::AbstractDateTime, y::AbstractDateTime) = -(promote(x, y)...)
 

--- a/stdlib/Dates/test/arithmetic.jl
+++ b/stdlib/Dates/test/arithmetic.jl
@@ -11,8 +11,13 @@ using Dates
     @test Dates.CompoundPeriod(a - b) == Dates.Hour(12)
 end
 
+struct MonthlyDate <: TimeType
+    instant::Dates.UTInstant{Month}
+end
 @testset "TimeType arithmetic" begin
     @test_throws MethodError DateTime(2023, 5, 2) - Date(2023, 5, 1)
+    # check that - between two same-type TimeTypes works by default
+    @test MonthlyDate(Dates.UTInstant(Month(10))) - MonthlyDate(Dates.UTInstant(Month(1))) == Month(9)
 end
 
 @testset "Wrapping arithmetic for Months" begin


### PR DESCRIPTION
Restores the method whose removal was probably causing problems.