### PR TITLE
Make error message more accurate when adding a method to another module's function

### DIFF
--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -178,7 +178,7 @@ julia> using .NiceStuff: nice
 julia> struct Cat end
 
 julia> nice(::Cat) = "nice 😸"
-ERROR: invalid method definition in Main: function NiceStuff.nice must be explicitly imported to be extended
+ERROR: invalid method definition in Main: function NiceStuff.nice must be explicitly imported or prefixed with a module path to be extended
 Stacktrace:
  [1] top-level scope
    @ none:0

--- a/src/module.c
+++ b/src/module.c
@@ -270,7 +270,7 @@ JL_DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m, jl_sym_
             // TODO: we might want to require explicitly importing types to add constructors
             //       or we might want to drop this error entirely
             if (!b->imported && !(b2->constp && jl_is_type(f) && strcmp(jl_symbol_name(var), "=>") != 0)) {
-                jl_errorf("invalid method definition in %s: function %s.%s must be explicitly imported to be extended",
+                jl_errorf("invalid method definition in %s: function %s.%s must be explicitly imported or prefixed with a module path to be extended",
                           jl_symbol_name(m->name), jl_symbol_name(from->name), jl_symbol_name(var));
             }
             return b2;

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2614,7 +2614,7 @@ using ..Mod
 end
 @test Mod3.f(10) == 21
 @test !isdefined(Mod3, :func)
-@test_throws ErrorException("invalid method definition in Mod3: function Mod3.f must be explicitly imported to be extended") Core.eval(Mod3, :(f(x::Int) = x))
+@test_throws ErrorException("invalid method definition in Mod3: function Mod3.f must be explicitly imported or prefixed with a module path to be extended") Core.eval(Mod3, :(f(x::Int) = x))
 @test !isdefined(Mod3, :always_undef) # resolve this binding now in Mod3
 @test_throws ErrorException("invalid method definition in Mod3: exported function Mod.always_undef does not exist") Core.eval(Mod3, :(always_undef(x::Int) = x))
 @test_throws ErrorException("cannot assign a value to imported variable Mod.always_undef from module Mod3") Core.eval(Mod3, :(const always_undef = 3))
@@ -3525,7 +3525,7 @@ macro z49984(s); :(let a; $(esc(s)); end); end
 # issues #37783, #39929, #42552, #43379, and #48332
 let x = 1 => 2
     @test_throws ErrorException @eval a => b = 2
-    @test_throws "function Base.=> must be explicitly imported to be extended" @eval a => b = 2
+    @test_throws "function Base.=> must be explicitly imported or prefixed with a module path to be extended" @eval a => b = 2
 end
 
 # Splatting in non-final default value (Ref #50518)


### PR DESCRIPTION
I noticed the error message for adding a method to another module's function seems inaccurate.

Currently:
```julia
julia> module Mod
       f() = 1
       end
Main.Mod

julia> using .Mod: f

julia> f(x) = 2
ERROR: invalid method definition in Main: function Mod.f must be explicitly imported to be extended
Stacktrace:
 [1] top-level scope
   @ none:0
 [2] top-level scope
   @ REPL[3]:1
```

But I don't *have* to explicitly import `Mod.f`; I can extend it by prefixing `f` with a module path:
```julia
julia> using .Mod

julia> Mod.f(x) = 2
```

Therefore, this PR adds the clause `or prefixed with a module path` to the error message.