### PR TITLE
Small fix to `randn`/`randexp`

### DIFF
--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -70,8 +70,8 @@ end
 @noinline function randn_unlikely(rng, idx, rabs, x)
     @inbounds if idx == 0
         while true
-            xx = -ziggurat_nor_inv_r*log(rand(rng))
-            yy = -log(rand(rng))
+            xx = -ziggurat_nor_inv_r*log1p(-rand(rng))
+            yy = -log1p(-rand(rng))
             yy+yy > xx*xx &&
                 return (rabs >> 8) % Bool ? -ziggurat_nor_r-xx : ziggurat_nor_r+xx
         end
@@ -138,7 +138,7 @@ end
 
 @noinline function randexp_unlikely(rng, idx, x)
     @inbounds if idx == 0
-        return ziggurat_exp_r - log(rand(rng))
+        return ziggurat_exp_r - log1p(-rand(rng))
     elseif (fe[idx] - fe[idx+1])*rand(rng) + fe[idx+1] < exp(-x)
         return x # return from the triangular area
     else


### PR DESCRIPTION
The pattern `log(rand(rng))` has the consequence of permitting `log(0.0) == -Inf` to be computed, since the domain of `rand` is $[0,1)$. It looks like this mishap wouldn't actually escape `randn` (due to exit conditionals), but it appears that it can escape `randexp`, resulting in a return value of `+Inf`. While this is a literally admissible return value, it is grossly over-represented. On the current version, it occurs with probability roughly $10^{-18}$. For reference, values $>41$ should occur about that often. The correct return frequency for values that exceed `floatmax(Float64)` (i.e., `+Inf`) should be roughly $10^{-10^{308}}$.

Replacing `log(rand(rng))` with `log1p(-rand(rng))` is "statistically identical" (modulo the effects of finite representations) except that it equivalently shifts the support of inputs to `log` from $[0,1)$ to the better-behaved $(0,1]$.

This will change the stream of values produced by `randn`/`randexp`. Additionally, the largest value returned by `randexp` will change from $+\infty$ to roughly $44$. Somewhat larger values will be possible if we extend the dynamic range of `rand` as discussed [on Discourse](https://discourse.julialang.org/t/output-distribution-of-rand-float32-and-rand-float64-thread-2/105184).