### PR TITLE
REPL: Try to fix intermittent hang during precompile

### DIFF
--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -40,7 +40,7 @@ foo(x) = 1
 @time @eval foo(1)
 ; pwd
 $CTRL_C
-$CTRL_R$CTRL_C
+$CTRL_R$CTRL_C#
 ? reinterpret
 using Ra\t$CTRL_C
 \\alpha\t$CTRL_C
@@ -93,6 +93,7 @@ generate_precompile_statements() = try
                 Sys.iswindows() && (sleep(0.1); yield(); yield()) # workaround hang - probably a libuv issue?
                 write(output_copy, l)
             end
+            write(debug_output, "\n#### EOF ####\n")
         catch ex
             if !(ex isa Base.IOError && ex.code == Base.UV_EIO)
                 rethrow() # ignore EIO on ptm after pts dies
@@ -117,7 +118,10 @@ generate_precompile_statements() = try
                 bytesavailable(output_copy) > 0 && readavailable(output_copy)
                 # push our input
                 write(debug_output, "\n#### inputting statement: ####\n$(repr(l))\n####\n")
-                write(ptm, l, "\n")
+                # If the line ends with a CTRL_C, don't write an extra newline, which would
+                # cause a second empty prompt. Our code below expects one new prompt per
+                # input line and can race out of sync with the unexpected second line.
+                endswith(l, CTRL_C) ? write(ptm, l) : write(ptm, l, "\n")
                 readuntil(output_copy, "\n")
                 # wait for the next prompt-like to appear
                 readuntil(output_copy, "\n")
@@ -131,6 +135,7 @@ generate_precompile_statements() = try
                     sleep(0.1)
                 end
             end
+            write(debug_output, "\n#### COMPLETED - Closing REPL ####\n")
             write(ptm, "$CTRL_D")
             wait(tee)
             success(p) || Base.pipeline_error(p)


### PR DESCRIPTION
I was intermittently observing the REPL precompile process not finishing. What I believe was happening is the following:

1. The last line of the precompile script is `cd("complete_path\t\t$CTRL_C`
2. As soon as child julia sees the `CTRL_C`, the prompt is terminated, and a new prompt is echod.
3. The parent julia tries to complete the line by sending `\n`, and immediately returns, because the child has already written a new prompt.
4. The child reads the `\n` and enters raw mode (ignoring things like ^D).
5. The parent tries to write `^D` to complete the process, but because the child is still processing the `\n`, this `^D` is ignored and the process hangs.

Try to fix this by not writing the superfluous `\n` if the precompile line ends in `^C`.