### PR TITLE
Strip trailing slashes in `JULIA_DEPOT_PATH` when embedding `@depot`

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2600,8 +2600,15 @@ end
 
 function replace_depot_path(path::AbstractString)
     for depot in DEPOT_PATH
+        # Skip depots that don't exist
+        if !isdirpath(depot)
+            continue
+        end
+
+        # Strip extraneous pathseps through normalization.
+        depot = dirname(depot)
         if startswith(path, depot)
-            path = replace(path, depot => "@depot")
+            path = replace(path, depot => "@depot"; count=1)
             break
         end
     end
@@ -2619,7 +2626,7 @@ function resolve_depot(includes)
     end
     for depot in DEPOT_PATH
         if all(includes) do inc
-                isfile(replace(inc, r"^@depot" => depot))
+                isfile(replace(inc, r"^@depot" => depot; count=1))
             end
             return depot
         end
@@ -2725,7 +2732,7 @@ function parse_cache_header(f::IO, cachefile::AbstractString)
         @debug "Missing @depot tag for include dependencies in cache file $cachefile."
     else
         for inc in includes
-            inc.filename = replace(inc.filename, r"^@depot" => depot)
+            inc.filename = replace(inc.filename, r"^@depot" => depot; count=1)
         end
     end
     includes_srcfiles_only = includes[keepidx]

--- a/test/relocatedepot.jl
+++ b/test/relocatedepot.jl
@@ -37,7 +37,7 @@ if !test_relocated_depot
         pkgname = "RelocationTestPkg2"
         test_harness() do
             push!(LOAD_PATH, @__DIR__)
-            push!(DEPOT_PATH, @__DIR__)
+            push!(DEPOT_PATH, string(@__DIR__, "/"))
             pkg = Base.identify_package(pkgname)
             cachefiles = Base.find_all_in_cache_path(pkg)
             rm.(cachefiles, force=true)


### PR DESCRIPTION
The new relocatable cache file work uses simple text substitution when stripping out the depot from a cache file's paths, and when substituting it in again over the `@depot` marker.  However, if a user starts julia with `JULIA_DEPOT_PATH=/opt/foo/`, the embedded path for `Foo.jl`'s includes list will look like `@depotpackages/Foo/XYZ/src/Foo.jl`, and if the user then uses `JULIA_DEPOT_PATH=/opt/foo` (which should be equivalent) the cache file will fail to load with the message:

```
Failed to determine depot from srctext files
```

This commit standardizes the serialization format to always contain a trailing `pathsep()`, so that textual substitution is more likely to work regardless of slightly-inconsistent `JULIA_DEPOT_PATH` settings.