### PR TITLE
Reduce usage of generic `ErrorException`s that should be `ArgumentError`s

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -30,7 +30,7 @@ macro noinline() Expr(:meta, :noinline) end
 # (and these don't need the extra convert code)
 getproperty(x::Module, f::Symbol) = (@inline; getglobal(x, f))
 getproperty(x::Type, f::Symbol) = (@inline; getfield(x, f))
-setproperty!(x::Type, f::Symbol, v) = error("setfield! fields of Types should not be changed")
+setproperty!(x::Type, f::Symbol, v) = throw(ArgumentError("setfield! fields of Types should not be changed"))
 getproperty(x::Tuple, f::Int) = (@inline; getfield(x, f))
 setproperty!(x::Tuple, f::Int, v) = setfield!(x, f, v) # to get a decent error
 
@@ -51,7 +51,7 @@ function setproperty!(x::Module, f::Symbol, v, order::Symbol=:monotonic)
     return setglobal!(x, f, val, order)
 end
 getproperty(x::Type, f::Symbol, order::Symbol) = (@inline; getfield(x, f, order))
-setproperty!(x::Type, f::Symbol, v, order::Symbol) = error("setfield! fields of Types should not be changed")
+setproperty!(x::Type, f::Symbol, v, order::Symbol) = throw(ArgumentError("setfield! fields of Types should not be changed"))
 getproperty(x::Tuple, f::Int, order::Symbol) = (@inline; getfield(x, f, order))
 setproperty!(x::Tuple, f::Int, v, order::Symbol) = setfield!(x, f, v, order) # to get a decent error
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1330,7 +1330,7 @@ error_if_canonical_getindex(::IndexStyle, ::AbstractArray, ::Any...) = nothing
 
 ## Internal definitions
 _getindex(::IndexStyle, A::AbstractArray, I...) =
-    error("getindex for $(typeof(A)) with types $(typeof(I)) is not supported")
+    throw(ArgumentError("getindex for $(typeof(A)) with types $(typeof(I)) is not supported"))
 
 ## IndexLinear Scalar indexing: canonical method is one Int
 _getindex(::IndexLinear, A::AbstractVector, i::Int) = (@_propagate_inbounds_meta; getindex(A, i))  # ambiguity resolution in case packages specialize this (to be avoided if at all possible, but see Interpolations.jl)
@@ -1424,7 +1424,7 @@ error_if_canonical_setindex(::IndexStyle, ::AbstractArray, ::Any...) = nothing
 
 ## Internal definitions
 _setindex!(::IndexStyle, A::AbstractArray, v, I...) =
-    error("setindex! for $(typeof(A)) with types $(typeof(I)) is not supported")
+throw(ArgumentError("setindex! for $(typeof(A)) with types $(typeof(I)) is not supported"))
 
 ## IndexLinear Scalar indexing
 _setindex!(::IndexLinear, A::AbstractArray, v, i::Int) = (@_propagate_inbounds_meta; setindex!(A, v, i))
@@ -1606,13 +1606,13 @@ replace_in_print_matrix(A::AbstractVector,i::Integer,j::Integer,s::AbstractStrin
 eltypeof(x) = typeof(x)
 eltypeof(x::AbstractArray) = eltype(x)
 
-promote_eltypeof() = error()
+promote_eltypeof() = throw(ArgumentError("missing arguments"))
 promote_eltypeof(v1) = eltypeof(v1)
 promote_eltypeof(v1, vs...) = promote_type(eltypeof(v1), promote_eltypeof(vs...))
 promote_eltypeof(v1::T, vs::T...) where {T} = eltypeof(v1)
 promote_eltypeof(v1::AbstractArray{T}, vs::AbstractArray{T}...) where {T} = T
 
-promote_eltype() = error()
+promote_eltype() = throw(ArgumentError("missing arguments"))
 promote_eltype(v1) = eltype(v1)
 promote_eltype(v1, vs...) = promote_type(eltype(v1), promote_eltype(vs...))
 promote_eltype(v1::T, vs::T...) where {T} = eltype(T)
@@ -3327,8 +3327,8 @@ julia> map(+, [1, 2, 3], [10, 20, 30, 400, 5000])
 """
 map(f, A) = collect(Generator(f,A)) # default to returning an Array for `map` on general iterators
 
-map(f, ::AbstractDict) = error("map is not defined on dictionaries")
-map(f, ::AbstractSet) = error("map is not defined on sets")
+map(f, ::AbstractDict) = throw(ArgumentError("map is not defined on dictionaries"))
+map(f, ::AbstractSet) = throw(ArgumentError("map is not defined on sets"))
 
 ## 2 argument
 function map!(f::F, dest::AbstractArray, A::AbstractArray, B::AbstractArray) where F

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1424,7 +1424,7 @@ error_if_canonical_setindex(::IndexStyle, ::AbstractArray, ::Any...) = nothing
 
 ## Internal definitions
 _setindex!(::IndexStyle, A::AbstractArray, v, I...) =
-throw(ArgumentError("setindex! for $(typeof(A)) with types $(typeof(I)) is not supported"))
+    throw(ArgumentError("setindex! for $(typeof(A)) with types $(typeof(I)) is not supported"))
 
 ## IndexLinear Scalar indexing
 _setindex!(::IndexLinear, A::AbstractArray, v, i::Int) = (@_propagate_inbounds_meta; setindex!(A, v, i))

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -25,9 +25,9 @@ function in(p::Pair, a::AbstractDict, valcmp=(==))
 end
 
 function in(p, a::AbstractDict)
-    error("""AbstractDict collections only contain Pairs;
+    throw(ArgumentError("""AbstractDict collections only contain Pairs;
              Either look for e.g. A=>B instead, or use the `keys` or `values`
-             function if you are looking for a key or value respectively.""")
+             function if you are looking for a key or value respectively."""))
 end
 
 function summary(io::IO, t::AbstractDict)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -172,7 +172,7 @@ struct Broadcasted{Style<:Union{Nothing,BroadcastStyle}, Axes, F, Args<:Tuple} <
     args::Args
     axes::Axes          # the axes of the resulting object (may be bigger than implied by `args` if this is nested inside a larger `Broadcasted`)
 
-    Broadcasted(style::Union{Nothing,BroadcastStyle}, f::Tuple, args::Tuple) = error() # disambiguation: tuple is not callable
+    Broadcasted(style::Union{Nothing,BroadcastStyle}, f::Tuple, args::Tuple) = throw(ArgumentError("invalid types")) # disambiguation: tuple is not callable
     function Broadcasted(style::Union{Nothing,BroadcastStyle}, f::F, args::Tuple, axes=nothing) where {F}
         # using Core.Typeof rather than F preserves inferrability when f is a type
         return new{typeof(style), typeof(axes), Core.Typeof(f), typeof(args)}(style, f, args, axes)
@@ -446,7 +446,7 @@ function result_style end
 
 result_style(s::BroadcastStyle) = s
 function result_style(s1::S, s2::S) where S<:BroadcastStyle
-    s1 ≡ s2 ? s1 : error("inconsistent broadcast styles, custom rule needed")
+    s1 ≡ s2 ? s1 : throw(ArgumentError("inconsistent broadcast styles, custom rule needed"))
 end
 # Test both orders so users typically only have to declare one order
 result_style(s1, s2) = result_join(s1, s2, BroadcastStyle(s1, s2), BroadcastStyle(s2, s1))
@@ -466,11 +466,11 @@ result_join(::AbstractArrayStyle, ::AbstractArrayStyle, ::Unknown, ::Unknown) =
 result_join(::Any, ::Any, s1::S, s2::S) where S<:BroadcastStyle = result_style(s1, s2)
 
 @noinline function result_join(::S, ::T, ::U, ::V) where {S,T,U,V}
-    error("""
+    throw(ArgumentError("""
 conflicting broadcast rules defined
   Broadcast.BroadcastStyle(::$S, ::$T) = $U()
   Broadcast.BroadcastStyle(::$T, ::$S) = $V()
-One of these should be undefined (and thus return Broadcast.Unknown).""")
+One of these should be undefined (and thus return Broadcast.Unknown)."""))
 end
 
 # Indices utilities

--- a/base/c.jl
+++ b/base/c.jl
@@ -526,7 +526,7 @@ function expand_ccallable(rt, def)
             sig = sig.args[1]
         end
         if rt === nothing
-            error("@ccallable requires a return type")
+            throw(ArgumentError("@ccallable requires a return type"))
         end
         if sig.head === :call
             f = sig.args[1]
@@ -548,7 +548,7 @@ function expand_ccallable(rt, def)
             end
         end
     end
-    error("expected method definition in @ccallable")
+    throw(ArgumentError("expected method definition in @ccallable"))
 end
 
 """

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -184,7 +184,7 @@ evaluate to `true`.
 """
 macro nany(N::Int, criterion::Expr)
     if criterion.head !== :->
-        error("Second argument must be an anonymous function expression yielding the criterion")
+        throw(ArgumentError("Second argument must be an anonymous function expression yielding the criterion"))
     end
     conds = Any[ Expr(:escape, inlineanonymous(criterion, i)) for i = 1:N ]
     Expr(:||, conds...)

--- a/base/client.jl
+++ b/base/client.jl
@@ -658,7 +658,7 @@ const main = MyApp.main
 """
 macro main(args...)
     if !isempty(args)
-        error("USAGE: `@main` is expected to be used as `(@main)` without macro arguments.")
+        throw(ArgumentError("USAGE: `@main` is expected to be used as `(@main)` without macro arguments."))
     end
     if isdefined(__module__, :main)
         if Base.binding_module(__module__, :main) !== __module__

--- a/base/compiler/abstractlattice.jl
+++ b/base/compiler/abstractlattice.jl
@@ -9,7 +9,7 @@ function is_valid_lattice_norec end
 A singleton type representing the lattice of Julia types, without any inference extensions.
 """
 struct JLTypeLattice <: AbstractLattice; end
-widenlattice(::JLTypeLattice) = error("Type lattice is the least-precise lattice available")
+widenlattice(::JLTypeLattice) = throw(ArgumentError("Type lattice is the least-precise lattice available"))
 is_valid_lattice_norec(::JLTypeLattice, @nospecialize(elem)) = isa(elem, Type)
 
 """

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -569,7 +569,7 @@ function insert_node!(ir::IRCode, pos::SSAValue, newinst::NewInstruction, attach
             posid = info.pos
             attach_after = info.attach_after
         else
-            error("Cannot attach before a pending node.")
+            throw(ArgumentError("Cannot attach before a pending node."))
         end
     end
     node = add_inst!(ir.new_nodes, posid, attach_after)

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -984,7 +984,7 @@ function effectbits_letter(effects::Effects, name::Symbol, suffix::Char)
     elseif ft === Bool
         prefix = getfield(effects, name) ? '+' : '!'
     else
-        error("unsupported effectbits type given")
+        throw(ArgumentError("unsupported effectbits type given"))
     end
     return string(prefix, suffix)
 end
@@ -997,7 +997,7 @@ function effectbits_color(effects::Effects, name::Symbol)
     elseif ft === Bool
         color = getfield(effects, name) ? :green : :red
     else
-        error("unsupported effectbits type given")
+        throw(ArgumentError("unsupported effectbits type given"))
     end
     return color
 end

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -212,7 +212,7 @@ function typ_for_val(@nospecialize(x), ci::CodeInfo, ir::IRCode, idx::Int, slott
     isa(x, Argument) && return slottypes[x.n]
     isa(x, NewSSAValue) && return types(ir)[new_to_regular(x, length(ir.stmts))]
     isa(x, QuoteNode) && return Const(x.value)
-    isa(x, Union{Symbol, PiNode, PhiNode, SlotNumber}) && error("unexpected val type")
+    isa(x, Union{Symbol, PiNode, PhiNode, SlotNumber}) && throw(ArgumentError("unexpected val type"))
     return Const(x)
 end
 

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -9,7 +9,7 @@ end
 if !isdefined(@__MODULE__, Symbol("@verify_error"))
     macro verify_error(arg)
         arg isa String && return esc(:(print && println(stderr, $arg)))
-        isexpr(arg, :string) || error("verify_error macro expected a string expression")
+        isexpr(arg, :string) || throw(ArgumentError("verify_error macro expected a string expression"))
         pushfirst!(arg.args, GlobalRef(Core, :stderr))
         pushfirst!(arg.args, :println)
         arg.head = :call

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1121,7 +1121,7 @@ complex(A::AbstractArray{<:Complex}) = A
 
 function complex(A::AbstractArray{T}) where T
     if !isconcretetype(T)
-        error("`complex` not defined on abstractly-typed arrays; please convert to a more specific type")
+        throw(ArgumentError("`complex` not defined on abstractly-typed arrays; please convert to a more specific type"))
     end
     convert(AbstractArray{typeof(complex(zero(T)))}, A)
 end

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -33,7 +33,7 @@ deepcopy_internal(x::Union{Symbol,Core.MethodInstance,Method,GlobalRef,DataType,
                   stackdict::IdDict) = x
 deepcopy_internal(x::Tuple, stackdict::IdDict) =
     ntuple(i->deepcopy_internal(x[i], stackdict), length(x))
-deepcopy_internal(x::Module, stackdict::IdDict) = error("deepcopy of Modules not supported")
+deepcopy_internal(x::Module, stackdict::IdDict) = throw(ArgumentError("deepcopy of Modules not supported"))
 
 function deepcopy_internal(x::SimpleVector, stackdict::IdDict)
     if haskey(stackdict, x)

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -410,7 +410,7 @@ function calldoc(__source__, __module__, str, def::Expr)
     end
 end
 callargs(ex::Expr) = isexpr(ex, :where) ? callargs(ex.args[1]) :
-    isexpr(ex, :call) ? ex.args[2:end] : error("Invalid expression to callargs: $ex")
+    isexpr(ex, :call) ? ex.args[2:end] : throw(ArgumentError("Invalid expression to callargs: $ex"))
 validcall(x) = isa(x, Symbol) || isexpr(x, (:(::), :..., :kw, :parameters))
 
 function moduledoc(__source__, __module__, meta, def, def′::Expr)

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2746,7 +2746,7 @@ julia> 4.5/2
 """
     ArgumentError(msg)
 
-The arguments passed to a function are invalid.
+The number, types, or values of arguments passed to a function are invalid.
 `msg` is a descriptive error message.
 """
 ArgumentError

--- a/base/error.jl
+++ b/base/error.jl
@@ -31,6 +31,7 @@ throw
     error(message::AbstractString)
 
 Raise an `ErrorException` with the given message.
+Whenever possible, use a more specific exception type.
 """
 error(s::AbstractString) = throw(ErrorException(s))
 
@@ -38,6 +39,7 @@ error(s::AbstractString) = throw(ErrorException(s))
     error(msg...)
 
 Raise an `ErrorException` with a message constructed by `string(msg...)`.
+Whenever possible, use a more specific exception type.
 """
 function error(s::Vararg{Any,N}) where {N}
     @noinline
@@ -243,7 +245,7 @@ struct ExponentialBackOff
     jitter::Float64
 
     function ExponentialBackOff(n, first_delay, max_delay, factor, jitter)
-        all(x->x>=0, (n, first_delay, max_delay, factor, jitter)) || error("all inputs must be non-negative")
+        all(x->x>=0, (n, first_delay, max_delay, factor, jitter)) || throw(ArgumentError("all inputs must be non-negative"))
         new(n, first_delay, max_delay, factor, jitter)
     end
 end

--- a/base/error.jl
+++ b/base/error.jl
@@ -245,7 +245,7 @@ struct ExponentialBackOff
     jitter::Float64
 
     function ExponentialBackOff(n, first_delay, max_delay, factor, jitter)
-        all(x->x>=0, (n, first_delay, max_delay, factor, jitter)) || throw(ArgumentError("all inputs must be non-negative"))
+        all(x->x>=0, (n, first_delay, max_delay, factor, jitter)) || throw(DomainError((;n, first_delay, max_delay, factor, jitter)[findall(<(0), (n, first_delay, max_delay, factor, jitter))] ,"all inputs must be non-negative"))
         new(n, first_delay, max_delay, factor, jitter)
     end
 end

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -448,12 +448,12 @@ function unconstrain_vararg_length(va::Core.TypeofVararg)
     return Vararg{unwrapva(va)}
 end
 
-typename(a) = error("typename does not apply to this type")
+typename(a) = throw(ArgumentError("typename does not apply to this type"))
 typename(a::DataType) = a.name
 function typename(a::Union)
     ta = typename(a.a)
     tb = typename(a.b)
-    ta === tb || error("typename does not apply to unions whose components have different typenames")
+    ta === tb || throw(ArgumentError("typename does not apply to unions whose components have different typenames"))
     return tb
 end
 typename(union::UnionAll) = typename(union.body)

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -926,10 +926,10 @@ is_function_def(@nospecialize(ex)) =
 function findmeta(ex::Expr)
     if is_function_def(ex)
         body = ex.args[2]::Expr
-        body.head === :block || error(body, " is not a block expression")
+        body.head === :block || throw(ArgumentError("$body is not a block expression"))
         return findmeta_block(ex.args)
     end
-    error(ex, " is not a function expression")
+    throw(ArgumentError("$ex is not a function expression"))
 end
 
 findmeta(ex::Array{Any,1}) = findmeta_block(ex)
@@ -1039,7 +1039,7 @@ macro generated(f)
                                         Expr(:meta, :generated_only),
                                         Expr(:return, nothing))))))
     else
-        error("invalid syntax; @generated must be used with a function definition")
+        throw(ArgumentError("invalid syntax; @generated must be used with a function definition"))
     end
 end
 
@@ -1158,11 +1158,11 @@ function make_atomic(order, ex)
             end
         end
     end
-    error("could not parse @atomic expression $ex")
+    throw(ArgumentError("could not parse @atomic expression $ex"))
 end
 function make_atomic(order, a1, op, a2)
     @nospecialize
-    is_expr(a1, :., 2) || error("@atomic modify expression missing field access")
+    is_expr(a1, :., 2) || throw(ArgumentError("@atomic modify expression missing field access"))
     a1l, a1r, op, a2 = esc(a1.args[1]), esc(a1.args[2]), esc(op), esc(a2)
     return :(modifyproperty!($a1l, $a1r, $op, $a2, $order))
 end
@@ -1204,9 +1204,9 @@ macro atomicswap(ex)
 end
 function make_atomicswap(order, ex)
     @nospecialize
-    is_expr(ex, :(=), 2) || error("@atomicswap expression missing assignment")
+    is_expr(ex, :(=), 2) || throw(ArgumentError("@atomicswap expression missing assignment"))
     l, val = ex.args[1], esc(ex.args[2])
-    is_expr(l, :., 2) || error("@atomicswap expression missing field access")
+    is_expr(l, :., 2) || throw(ArgumentError("@atomicswap expression missing field access"))
     ll, lr = esc(l.args[1]), esc(l.args[2])
     return :(swapproperty!($ll, $lr, $val, $order))
 end
@@ -1267,7 +1267,7 @@ macro atomicreplace(ex, old_new)
 end
 function make_atomicreplace(success_order, fail_order, ex, old_new)
     @nospecialize
-    is_expr(ex, :., 2) || error("@atomicreplace expression missing field access")
+    is_expr(ex, :., 2) || throw(ArgumentError("@atomicreplace expression missing field access"))
     ll, lr = esc(ex.args[1]), esc(ex.args[2])
     if is_expr(old_new, :call, 3) && old_new.args[1] === :(=>)
         exp, rep = esc(old_new.args[2]), esc(old_new.args[3])

--- a/base/float.jl
+++ b/base/float.jl
@@ -1166,7 +1166,7 @@ float(A::AbstractArray{<:AbstractFloat}) = A
 
 function float(A::AbstractArray{T}) where T
     if !isconcretetype(T)
-        error("`float` not defined on abstractly-typed arrays; please convert to a more specific type")
+        throw(ArgumentError("`float` not defined on abstractly-typed arrays; please convert to a more specific type"))
     end
     convert(AbstractArray{typeof(float(zero(T)))}, A)
 end

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -38,7 +38,7 @@ WeakRef
 # Used by `Base.finalizer` to validate mutability of an object being finalized.
 function _check_mutable(@nospecialize(o)) @noinline
     if !ismutable(o)
-        error("objects of type ", typeof(o), " cannot be finalized")
+        throw(ArgumentError("objects of type ", typeof(o), " cannot be finalized"))
     end
 end
 
@@ -230,7 +230,7 @@ julia> let
 macro preserve(args...)
     syms = args[1:end-1]
     for x in syms
-        isa(x, Symbol) || error("Preserved variable must be a symbol")
+        isa(x, Symbol) || throw(ArgumentError("Preserved variable must be a symbol"))
     end
     esc(Expr(:gc_preserve, args[end], syms...))
 end

--- a/base/io.jl
+++ b/base/io.jl
@@ -219,7 +219,7 @@ julia> read(io, String)
 ```
 """
 read(stream, t)
-read(stream, ::Type{Union{}}, slurp...; kwargs...) = error("cannot read a value of type Union{}")
+read(stream, ::Type{Union{}}, slurp...; kwargs...) = throw(ArgumentError("cannot read a value of type Union{}"))
 
 
 """
@@ -791,7 +791,7 @@ write(to::IO, p::Ptr) = write(to, convert(UInt, p))
 
 function write(s::IO, A::AbstractArray)
     if !isbitstype(eltype(A))
-        error("`write` is not supported on non-isbits arrays")
+        throw(ArgumentError("`write` is not supported on non-isbits arrays"))
     end
     nb = 0
     r = Ref{eltype(A)}()
@@ -804,7 +804,7 @@ end
 
 function write(s::IO, A::StridedArray)
     if !isbitstype(eltype(A))
-        error("`write` is not supported on non-isbits arrays")
+        throw(ArgumentError("`write` is not supported on non-isbits arrays"))
     end
     _checkcontiguous(Bool, A) &&
         return GC.@preserve A unsafe_write(s, pointer(A), elsize(A) * length(A))

--- a/base/linked_list.jl
+++ b/base/linked_list.jl
@@ -28,7 +28,7 @@ function length(q::IntrusiveLinkedList)
 end
 
 function list_append!!(q::IntrusiveLinkedList{T}, q2::IntrusiveLinkedList{T}) where T
-    q === q2 && error("can't append list to itself")
+    q === q2 && throw(ArgumentError("can't append list to itself"))
     head2 = q2.head
     if head2 !== nothing
         tail2 = q2.tail::T
@@ -50,7 +50,7 @@ function list_append!!(q::IntrusiveLinkedList{T}, q2::IntrusiveLinkedList{T}) wh
 end
 
 function push!(q::IntrusiveLinkedList{T}, val::T) where T
-    val.queue === nothing || error("val already in a list")
+    val.queue === nothing || throw(ArgumentError("val already in a list"))
     val.queue = q
     tail = q.tail
     if tail === nothing
@@ -63,7 +63,7 @@ function push!(q::IntrusiveLinkedList{T}, val::T) where T
 end
 
 function pushfirst!(q::IntrusiveLinkedList{T}, val::T) where T
-    val.queue === nothing || error("val already in a list")
+    val.queue === nothing || throw(ArgumentError("val already in a list"))
     val.queue = q
     head = q.head
     if head === nothing

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -173,7 +173,7 @@ internal counter and return immediately.
 """
 @inline function unlock(rl::ReentrantLock)
     rl.locked_by === current_task() ||
-        error(rl.reentrancy_cnt == 0x0000_0000 ? "unlock count must match lock count" : "unlock from wrong thread")
+        throw(ArgumentError(rl.reentrancy_cnt == 0x0000_0000 ? "unlock count must match lock count" : "unlock from wrong thread"))
     (@noinline function _unlock(rl::ReentrantLock)
         n = rl.reentrancy_cnt - 0x0000_0001
         rl.reentrancy_cnt = n
@@ -405,7 +405,7 @@ and resume execution.
 function release(s::Semaphore)
     lock(s.cond_wait)
     try
-        s.curr_cnt > 0 || error("release count must match acquire count")
+        s.curr_cnt > 0 || throw(ArgumentError("release count must match acquire count"))
         s.curr_cnt -= 1
         notify(s.cond_wait; all=false)
     finally

--- a/base/locks-mt.jl
+++ b/base/locks-mt.jl
@@ -63,7 +63,7 @@ end
 
 function unlock(l::SpinLock)
     if (@atomicswap :release l.owned = 0) == 0
-        error("unlock count must match lock count")
+        throw(ArgumentError("unlock count must match lock count"))
     end
     GC.enable_finalizers()
     ccall(:jl_cpu_wake, Cvoid, ())

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -101,7 +101,7 @@ struct NullLogger <: AbstractLogger; end
 min_enabled_level(::NullLogger) = AboveMaxLevel
 shouldlog(::NullLogger, args...) = false
 handle_message(::NullLogger, args...; kwargs...) =
-    (@nospecialize; error("Null logger handle_message() should not be called"))
+    (@nospecialize; throw(ArgumentError("Null logger handle_message() should not be called")))
 
 
 #-------------------------------------------------------------------------------

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -164,7 +164,7 @@ module IteratorsMD
     # Iteration over the elements of CartesianIndex cannot be supported until its length can be inferred,
     # see #23719
     Base.iterate(::CartesianIndex) =
-        error("iteration is deliberately unsupported for CartesianIndex. Use `I` rather than `I...`, or use `Tuple(I)...`")
+        throw(ArgumentError("iteration is deliberately unsupported for CartesianIndex. Use `I` rather than `I...`, or use `Tuple(I)...`"))
 
     # Iteration
     const OrdinalRangeInt = OrdinalRange{Int, Int}

--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -132,7 +132,7 @@ _ord(lt::typeof(isless), by, order::ForwardOrdering)                  = _by(by, 
 _ord(lt::typeof(isless), by, order::ReverseOrdering{ForwardOrdering}) = _by(by, order)  # disambiguation
 _ord(lt,                 by, order::ForwardOrdering)                  = _by(by, Lt(lt))
 _ord(lt,                 by, order::ReverseOrdering{ForwardOrdering}) = reverse(_by(by, Lt(lt)))
-_ord(lt,                 by, order::Ordering) = error("Passing both lt= and order= arguments is ambiguous; please pass order=Forward or order=Reverse (or leave default)")
+_ord(lt,                 by, order::Ordering) = throw(ArgumentError("Passing both lt= and order= arguments is ambiguous; please pass order=Forward or order=Reverse (or leave default)"))
 _by(by, order::Ordering) = By(by, order)
 _by(::typeof(identity), order::Ordering) = order
 

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -36,7 +36,7 @@ julia> parse(Complex{Float64}, "3.2e-1 + 4.5im")
 ```
 """
 parse(T::Type, str; base = Int)
-parse(::Type{Union{}}, slurp...; kwargs...) = error("cannot parse a value as Union{}")
+parse(::Type{Union{}}, slurp...; kwargs...) = throw(ArgumentError("cannot parse a value as Union{}"))
 
 function parse(::Type{T}, c::AbstractChar; base::Integer = 10) where T<:Integer
     a::Int = (base <= 36 ? 10 : 36)
@@ -254,7 +254,7 @@ function parse(::Type{T}, s::AbstractString; base::Union{Nothing,Integer} = noth
     convert(T, tryparse_internal(T, s, firstindex(s), lastindex(s),
                                  base===nothing ? 0 : check_valid_base(base), true))
 end
-tryparse(::Type{Union{}}, slurp...; kwargs...) = error("cannot parse a value as Union{}")
+tryparse(::Type{Union{}}, slurp...; kwargs...) = throw(ArgumentError("cannot parse a value as Union{}"))
 
 ## string to float functions ##
 

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -10,7 +10,7 @@ struct PermutedDimsArray{T,N,perm,iperm,AA<:AbstractArray} <: AbstractArray{T,N}
     parent::AA
 
     function PermutedDimsArray{T,N,perm,iperm,AA}(data::AA) where {T,N,perm,iperm,AA<:AbstractArray}
-        (isa(perm, NTuple{N,Int}) && isa(iperm, NTuple{N,Int})) || error("perm and iperm must both be NTuple{$N,Int}")
+        (isa(perm, NTuple{N,Int}) && isa(iperm, NTuple{N,Int})) || throw(ArgumentError("perm and iperm must both be NTuple{$N,Int}"))
         isperm(perm) || throw(ArgumentError(string(perm, " is not a valid permutation of dimensions 1:", N)))
         all(map(d->iperm[perm[d]]==d, 1:N)) || throw(ArgumentError(string(perm, " and ", iperm, " must be inverses")))
         new(data)

--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -144,7 +144,7 @@ if is_primary_base_module
     Ref{T}() where {T} = RefValue{T}() # Ref{T}()
     Ref{T}(x) where {T} = RefValue{T}(x) # Ref{T}(x)
 
-    Ref(x::Ref, i::Integer) = (i != 1 && error("Ref only has one element"); x)
+    Ref(x::Ref, i::Integer) = (i != 1 && throw(ArgumentError("Ref only has one element")); x)
     Ref(x::Ptr{T}, i::Integer) where {T} = x + (i - 1) * Core.sizeof(T)
 
     # convert Arrays to pointer arrays for ccall

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -620,7 +620,7 @@ _pat_replacer(r::Regex) = RegexAndMatchData(r)
 
 _free_pat_replacer(r::RegexAndMatchData) = PCRE.free_match_data(r.match_data)
 
-replace_err(repl) = error("Bad replacement string: $repl")
+replace_err(repl) = throw(ArgumentError("Bad replacement string: $repl"))
 
 function _write_capture(io::IO, group::Int, str, r, re::RegexAndMatchData)
     len = PCRE.substring_length_bynumber(re.match_data, group)

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -291,7 +291,7 @@ setindex!(A::ReshapedRange, val, index::Int) = _rs_setindex!_err()
 setindex!(A::ReshapedRange{T,N}, val, indices::Vararg{Int,N}) where {T,N} = _rs_setindex!_err()
 setindex!(A::ReshapedRange, val, index::ReshapedIndex) = _rs_setindex!_err()
 
-@noinline _rs_setindex!_err() = error("indexed assignment fails for a reshaped range; consider calling collect")
+@noinline _rs_setindex!_err() = throw(ArgumentError("indexed assignment fails for a reshaped range; consider calling collect"))
 
 cconvert(::Type{Ptr{T}}, a::ReshapedArray{T}) where {T} = cconvert(Ptr{T}, parent(a))
 

--- a/base/scopedvalues.jl
+++ b/base/scopedvalues.jl
@@ -180,11 +180,11 @@ macro with(exprs...)
         ex = only(exprs)
         exprs = ()
     else
-        error("@with expects at least one argument")
+        throw(ArgumentError("@with expects at least one argument"))
     end
     for expr in exprs
         if expr.head !== :call || first(expr.args) !== :(=>)
-            error("@with expects arguments of the form `A => 2` got $expr")
+            throw(ArgumentError("@with expects arguments of the form `A => 2` got $expr"))
         end
     end
     exprs = map(esc, exprs)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -779,7 +779,7 @@ show(io::IO, stream::Pipe) = print(io,
 function open_pipe!(p::PipeEndpoint, handle::OS_HANDLE)
     iolock_begin()
     if p.status != StatusInit
-        error("pipe is already in use or has been closed")
+        throw(ArgumentError("pipe is already in use or has been closed"))
     end
     err = ccall(:uv_pipe_open, Int32, (Ptr{Cvoid}, OS_HANDLE), p.handle, handle)
     uv_error("pipe_open", err)
@@ -838,7 +838,7 @@ function start_reading(stream::LibuvStream)
     iolock_begin()
     if stream.status == StatusOpen
         if !isreadable(stream)
-            error("tried to read a stream that is not readable")
+            throw(ArgumentError("tried to read a stream that is not readable"))
         end
         # libuv may call the alloc callback immediately
         # for a TTY on Windows, so ensure the status is set first

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -723,4 +723,4 @@ false
 """
 occursin(haystack) = Base.Fix2(occursin, haystack)
 
-in(::AbstractString, ::AbstractString) = error("use occursin(needle, haystack) for string containment")
+in(::AbstractString, ::AbstractString) = throw(ArgumentError("use occursin(needle, haystack) for string containment"))

--- a/base/task.jl
+++ b/base/task.jl
@@ -348,7 +348,7 @@ function _wait2(t::Task, waiter::Task)
 end
 
 function wait(t::Task)
-    t === current_task() && error("deadlock detected: cannot wait on current task")
+    t === current_task() && throw(ArgumentError("deadlock detected: cannot wait on current task"))
     _wait(t)
     if istaskfailed(t)
         throw(TaskFailedException(t))
@@ -773,7 +773,7 @@ function workqueue_for(tid::Int)
 end
 
 function enq_work(t::Task)
-    (t._state === task_state_runnable && t.queue === nothing) || error("schedule: Task not runnable")
+    (t._state === task_state_runnable && t.queue === nothing) || throw(ArgumentError("schedule: Task not runnable"))
 
     # Sticky tasks go into their thread's work queue.
     if t.sticky
@@ -892,7 +892,7 @@ A fast, unfair-scheduling version of `schedule(t, arg); yield()` which
 immediately yields to `t` before calling the scheduler.
 """
 function yield(t::Task, @nospecialize(x=nothing))
-    (t._state === task_state_runnable && t.queue === nothing) || error("yield: Task not runnable")
+    (t._state === task_state_runnable && t.queue === nothing) || throw(ArgumentError("yield: Task not runnable"))
     t.result = x
     enq_work(current_task())
     set_next_task(t)

--- a/base/threadcall.jl
+++ b/base/threadcall.jl
@@ -20,9 +20,9 @@ Note that the called function should never call back into Julia.
 macro threadcall(f, rettype, argtypes, argvals...)
     # check for usage errors
     isa(argtypes,Expr) && argtypes.head === :tuple ||
-        error("threadcall: argument types must be a tuple")
+        throw(ArgumentError("threadcall: argument types must be a tuple"))
     length(argtypes.args) == length(argvals) ||
-        error("threadcall: wrong number of arguments to C function")
+        throw(ArgumentError("threadcall: wrong number of arguments to C function"))
 
     # hygiene escape arguments
     f = esc(f)

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -113,9 +113,9 @@ function threadpoolsize(pool::Symbol = :default)
     if pool === :default || pool === :interactive
         tpid = _sym_to_tpid(pool)
     elseif pool == :foreign
-        error("Threadpool size of `:foreign` is indeterminant")
+        throw(ArgumentError("Threadpool size of `:foreign` is indeterminant"))
     else
-        error("invalid threadpool specified")
+        throw(ArgumentError("invalid threadpool specified"))
     end
     return _nthreads_in_pool(tpid)
 end
@@ -132,7 +132,7 @@ function threadpooltids(pool::Symbol)
     elseif pool === :default
         return collect(ni+1:ni+_nthreads_in_pool(Int8(1)))
     else
-        error("invalid threadpool specified")
+        throw(ArgumentError("invalid threadpool specified"))
     end
 end
 
@@ -218,7 +218,7 @@ function _threadsfor(iter, lbody, schedule)
         if $(schedule === :dynamic || schedule === :default)
             threading_run(threadsfor_fun, false)
         elseif ccall(:jl_in_threaded_region, Cint, ()) != 0 # :static
-            error("`@threads :static` cannot be used concurrently or nested")
+            throw(ArgumentError("`@threads :static` cannot be used concurrently or nested"))
         else # :static
             threading_run(threadsfor_fun, true)
         end

--- a/base/util.jl
+++ b/base/util.jl
@@ -565,7 +565,7 @@ Stacktrace:
 """
 macro kwdef(expr)
     expr = macroexpand(__module__, expr) # to expand @static
-    isexpr(expr, :struct) || error("Invalid usage of @kwdef")
+    isexpr(expr, :struct) || throw(ArgumentError("Invalid usage of @kwdef"))
     T = expr.args[2]
     if T isa Expr && T.head === :<:
         T = T.args[1]
@@ -599,7 +599,7 @@ macro kwdef(expr)
             def2 = Expr(:function, sig2, body2)
             kwdefs = Expr(:block, def1, def2)
         else
-            error("Invalid usage of @kwdef")
+            throw(ArgumentError("Invalid usage of @kwdef"))
         end
     else
         kwdefs = nothing


### PR DESCRIPTION
Base has lots of instances where `error()` was used for convenience, but really should be `ArgumentError`s as best I could tell. Let's encourage good exception hygiene!