### PR TITLE
Fix pointer calculation for `SubArray` with none-dense parent.

### DIFF
--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -800,3 +800,9 @@ end
     V = view(OneElVec(6, 2), 1:5)
     @test sprint(show, "text/plain", V) == "$(summary(V)):\n ⋅\n 1\n ⋅\n ⋅\n ⋅"
 end
+
+@testset "Base.first_index for offset indices" begin
+    a = Vector(1:10)
+    b = view(a, Base.IdentityUnitRange(4:7))
+    @test first(b) == a[Base.first_index(b)]
+end


### PR DESCRIPTION
And code clean for `first_index` and `compute_linindex`:
1. call `compute_linindex` directly in `first_index(::SlowSubArray)`. (There's no need to calculate stride/offset.)
2. remove the uneeded `compute_linindex` dispatch (`first(x::ScalarIndex) == x`)