### PR TITLE
seekend: Add a second argument for the number of bytes relative to the end

### DIFF
--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -334,8 +334,8 @@ function seek(f::File, n::Integer)
     return f
 end
 
-function seekend(f::File)
-    ret = ccall(:jl_lseek, Int64, (OS_HANDLE, Int64, Int32), f.handle, 0, SEEK_END)
+function seekend(f::File, n::Integer=0)
+    ret = ccall(:jl_lseek, Int64, (OS_HANDLE, Int64, Int32), f.handle, n, SEEK_END)
     ret == -1 && (@static Sys.iswindows() ? windowserror : systemerror)("seekend")
     return f
 end

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -335,6 +335,9 @@ function seek(f::File, n::Integer)
 end
 
 function seekend(f::File, n::Integer=0)
+    # jl_lseek (POSIX lseek) validates the absolute offset: an EOF+n that would land
+    # before the start of the file returns -1/EINVAL and is reported via systemerror
+    # below. Past-EOF positioning is allowed by POSIX (sparse-file semantics).
     ret = ccall(:jl_lseek, Int64, (OS_HANDLE, Int64, Int32), f.handle, n, SEEK_END)
     ret == -1 && (@static Sys.iswindows() ? windowserror : systemerror)("seekend")
     return f

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -523,8 +523,8 @@ function seek(io::GenericIOBuffer, n::Int)
     return io
 end
 
-function seekend(io::GenericIOBuffer)
-    io.ptr = io.size+1
+function seekend(io::GenericIOBuffer, n::Integer=0)
+    io.ptr = io.size+1+n
     return io
 end
 

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -524,6 +524,9 @@ function seek(io::GenericIOBuffer, n::Int)
 end
 
 function seekend(io::GenericIOBuffer, n::Integer=0)
+    if !io.seekable && n != 0
+        throw(ArgumentError("seek failed, IOBuffer is not seekable and n != 0"))
+    end
     io.ptr = io.size+1+n
     return io
 end

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -523,12 +523,19 @@ function seek(io::GenericIOBuffer, n::Int)
     return io
 end
 
-function seekend(io::GenericIOBuffer, n::Integer=0)
-    if !io.seekable && n != 0
-        throw(ArgumentError("seek failed, IOBuffer is not seekable and n != 0"))
-    end
-    io.ptr = io.size+1+n
+function seekend(io::GenericIOBuffer)
+    io.ptr = io.size+1
     return io
+end
+
+function seekend(io::GenericIOBuffer, n::Integer)
+    n == 0 && return seekend(io)
+    io.seekable || throw(ArgumentError("seek failed, IOBuffer is not seekable and n != 0"))
+    # Delegate to seek to inherit the [get_offset(io)+1, io.size+1] clamping and the
+    # widen-based overflow handling in translate_seek_position above. The user-visible end
+    # position is io.size - io.offset_or_compacted (correct for both offset > 0 and
+    # compacted < 0 states).
+    return seek(io, widen(io.size) - widen(io.offset_or_compacted) + widen(n))
 end
 
 # Resize the io's data to `new_size`, which must not be > io.maxsize.

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -185,14 +185,17 @@ julia> read(io, Char)
 seekstart(s::IO) = seek(s,0)
 
 """
-    seekend(s)
+    seekend(s, n=0)
 
-Seek a stream to its end.
+Seek a stream to `n` bytes relative to its end.
 """
 function seekend(s::IOStream)
     err = @_lock_ios s ccall(:ios_seek_end, Int64, (Ptr{Cvoid},), s.ios) != 0
     systemerror("seekend", err)
     return s
+end
+function seekend(s::IOStream, n::Integer)
+    return skip(seekend(s), n)
 end
 
 """

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -205,17 +205,26 @@ function seekend(s::IOStream)
 end
 function seekend(s::IOStream, n::Integer)
     n == 0 && return seekend(s)
-    # Save the original position so callers observe either success or a no-op: if the
-    # seek pair fails (e.g. `skip` with `n` more negative than the file size), restore
-    # the stream before rethrowing rather than leaving it at EOF. Not thread-atomic;
-    # concurrent operations on `s` may still interleave between the two ccalls.
-    pos = position(s)
+    # Hold the stream's reentrant lock across position/seekend/skip/restore so a
+    # concurrent task on the same `IOStream` cannot observe the intermediate EOF
+    # state, and so an error in the seek pair restores the original position before
+    # rethrowing. The outer try/finally guarantees the lock is released even on
+    # throw — `@_lock_ios` does not wrap its body in try/finally, so we acquire and
+    # release explicitly here. The inner Julia-level calls each reacquire the same
+    # `ReentrantLock` as no-ops.
+    locked = s._dolock
+    locked && lock(s.lock)
     try
-        seekend(s)
-        skip(s, n)
-    catch
-        seek(s, pos)
-        rethrow()
+        pos = position(s)
+        try
+            seekend(s)
+            skip(s, n)
+        catch
+            seek(s, pos)
+            rethrow()
+        end
+    finally
+        locked && unlock(s.lock)
     end
     return s
 end

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -204,9 +204,20 @@ function seekend(s::IOStream)
     return s
 end
 function seekend(s::IOStream, n::Integer)
-    # Non-atomic: if skip errors (e.g. n more negative than the file size), the stream
-    # is left at EOF rather than its original position.
-    return skip(seekend(s), n)
+    n == 0 && return seekend(s)
+    # Save the original position so callers observe either success or a no-op: if the
+    # seek pair fails (e.g. `skip` with `n` more negative than the file size), restore
+    # the stream before rethrowing rather than leaving it at EOF. Not thread-atomic;
+    # concurrent operations on `s` may still interleave between the two ccalls.
+    pos = position(s)
+    try
+        seekend(s)
+        skip(s, n)
+    catch
+        seek(s, pos)
+        rethrow()
+    end
+    return s
 end
 
 """

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -187,7 +187,16 @@ seekstart(s::IO) = seek(s,0)
 """
     seekend(s, n=0)
 
-Seek a stream to `n` bytes relative to its end.
+Seek a stream to `n` bytes relative to its end. With the default `n == 0`,
+the stream is positioned at its end (equivalent to the legacy
+single-argument form `seekend(s)`).
+
+`n` may be negative to position the stream that many bytes before the end.
+Behavior at the boundaries depends on the underlying stream: file-backed
+streams permit positioning past end-of-file (POSIX `lseek`/`SEEK_END`
+semantics), while in-memory buffers clamp the resulting position to the
+buffer's writable range. A non-seekable in-memory buffer rejects calls
+with `n != 0` by throwing an `ArgumentError`.
 """
 function seekend(s::IOStream)
     err = @_lock_ios s ccall(:ios_seek_end, Int64, (Ptr{Cvoid},), s.ios) != 0
@@ -195,6 +204,8 @@ function seekend(s::IOStream)
     return s
 end
 function seekend(s::IOStream, n::Integer)
+    # Non-atomic: if skip errors (e.g. n more negative than the file size), the stream
+    # is left at EOF rather than its original position.
     return skip(seekend(s), n)
 end
 

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -40,9 +40,11 @@ macro _lock_ios(s, expr)
         l = ($s)._dolock
         temp = ($s).lock
         l && lock(temp)
-        val = $(esc(expr))
-        l && unlock(temp)
-        val
+        try
+            $(esc(expr))
+        finally
+            l && unlock(temp)
+        end
     end
 end
 
@@ -208,13 +210,9 @@ function seekend(s::IOStream, n::Integer)
     # Hold the stream's reentrant lock across position/seekend/skip/restore so a
     # concurrent task on the same `IOStream` cannot observe the intermediate EOF
     # state, and so an error in the seek pair restores the original position before
-    # rethrowing. The outer try/finally guarantees the lock is released even on
-    # throw — `@_lock_ios` does not wrap its body in try/finally, so we acquire and
-    # release explicitly here. The inner Julia-level calls each reacquire the same
-    # `ReentrantLock` as no-ops.
-    locked = s._dolock
-    locked && lock(s.lock)
-    try
+    # rethrowing. The inner Julia-level calls each reacquire the same `ReentrantLock`
+    # as no-ops.
+    @_lock_ios s begin
         pos = position(s)
         try
             seekend(s)
@@ -223,8 +221,6 @@ function seekend(s::IOStream, n::Integer)
             seek(s, pos)
             rethrow()
         end
-    finally
-        locked && unlock(s.lock)
     end
     return s
 end

--- a/base/secretbuffer.jl
+++ b/base/secretbuffer.jl
@@ -170,6 +170,7 @@ end
 
 seek(io::SecretBuffer, n::Integer) = (io.ptr = max(min(n+1, io.size+1), 1); io)
 seekend(io::SecretBuffer) = seek(io, io.size+1)
+seekend(io::SecretBuffer, n::Integer) = skip(seekend(io), n)
 skip(io::SecretBuffer, n::Integer) = seek(io, position(io) + n)
 
 bytesavailable(io::SecretBuffer) = io.size - io.ptr + 1

--- a/base/secretbuffer.jl
+++ b/base/secretbuffer.jl
@@ -170,7 +170,7 @@ end
 
 seek(io::SecretBuffer, n::Integer) = (io.ptr = max(min(n+1, io.size+1), 1); io)
 seekend(io::SecretBuffer) = seek(io, io.size+1)
-seekend(io::SecretBuffer, n::Integer) = skip(seekend(io), n)
+seekend(io::SecretBuffer, n::Integer) = seek(io, io.size + n)
 skip(io::SecretBuffer, n::Integer) = seek(io, position(io) + n)
 
 bytesavailable(io::SecretBuffer) = io.size - io.ptr + 1

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -332,15 +332,25 @@ end
     @test read(io, String) == "ef"
     seekend(io, -3)
     @test read(io, String) == "def"
-    # Positive n moves the pointer past the end (no bounds check today; pin behavior).
+    # Positive n is clamped to the buffer's end (matches seek's clamping).
     seekend(io, 2)
-    @test position(io) == 8
+    @test position(io) == 6
 
     ub = new_unseekable_buffer()
     write(ub, "xyz")
     @test seekend(ub, 0) === ub
     @test_throws ArgumentError seekend(ub, 1)
     @test_throws ArgumentError seekend(ub, -1)
+
+    # Regression: with hidden offset bytes at the front of the buffer, a large negative n
+    # must not put io.ptr below the visible region and expose those bytes. popfirst! advances
+    # the Vector's memory ref, so the IOBuffer constructor records offset_or_compacted == 2.
+    v = UInt8['x', 'y', 'a', 'b', 'c']
+    popfirst!(v); popfirst!(v)
+    buf = IOBuffer(v; write=true, read=true)
+    @test seekend(buf, -100) === buf
+    @test position(buf) == 0
+    @test read(buf, String) == "abc"
 end
 
 @testset "takestring!" begin

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -321,6 +321,28 @@ end
     @test_throws ArgumentError seek(io, 0)
 end
 
+@testset "seekend with offset" begin
+    # seekend(io, n) seeks `n` bytes relative to the end; non-seekable buffers reject n != 0.
+    io = IOBuffer()
+    write(io, "abcdef")
+    @test seekend(io, 0) === io
+    @test position(io) == 6
+    @test seekend(io, -2) === io
+    @test position(io) == 4
+    @test read(io, String) == "ef"
+    seekend(io, -3)
+    @test read(io, String) == "def"
+    # Positive n moves the pointer past the end (no bounds check today; pin behavior).
+    seekend(io, 2)
+    @test position(io) == 8
+
+    ub = new_unseekable_buffer()
+    write(ub, "xyz")
+    @test seekend(ub, 0) === ub
+    @test_throws ArgumentError seekend(ub, 1)
+    @test_throws ArgumentError seekend(ub, -1)
+end
+
 @testset "takestring!" begin
     buf = IOBuffer()
     write(buf, "abcø")

--- a/test/read.jl
+++ b/test/read.jl
@@ -566,6 +566,11 @@ for fi in (f1, f2)
     @test position(fi) == 1
     @test seekend(fi, 2) == fi
     @test position(fi) == 5
+    # Atomic on error: a failing seekend(fi, n) must leave the position unchanged
+    # rather than at EOF (File: kernel lseek; IOStream: Julia-level save/restore).
+    seek(fi, 1)
+    @test_throws SystemError seekend(fi, -10)
+    @test position(fi) == 1
     @test seekend(fi) == fi
     @test position(fi) == 3
 end

--- a/test/read.jl
+++ b/test/read.jl
@@ -558,6 +558,17 @@ end
 @test seekend(f2) == f2
 @test eof(f1)
 @test eof(f2)
+# seekend(f, n) seeks `n` bytes relative to the end of the file (filesize is 3).
+for fi in (f1, f2)
+    @test seekend(fi, 0) == fi
+    @test position(fi) == 3
+    @test seekend(fi, -2) == fi
+    @test position(fi) == 1
+    @test seekend(fi, 2) == fi
+    @test position(fi) == 5
+    @test seekend(fi) == fi
+    @test position(fi) == 3
+end
 @test skip(f1, -2) == f1
 @test skip(f2, -2) == f2
 @test position(f1) == 1

--- a/test/secretbuffer.jl
+++ b/test/secretbuffer.jl
@@ -110,6 +110,17 @@ using Test, Random
         seekend(sb)
         @test read(sb, String) == ""
         shred!(sb)
+
+        # seekend(sb, n) seeks `n` bytes relative to the end; positive n is clamped to sb.size.
+        sb = SecretBuffer("hello")
+        @test seekend(sb, 0) === sb
+        @test position(sb) == sb.size
+        @test seekend(sb, -2) === sb
+        @test position(sb) == sb.size - 2
+        @test read(sb, String) == "lo"
+        @test seekend(sb, 2) === sb
+        @test position(sb) == sb.size
+        shred!(sb)
     end
     @testset "position" begin
         sb = SecretBuffer("Julia")


### PR DESCRIPTION

The C routines fseek and lseek both take offset arguments allowing the user
to seek relative to the beginning, the current position, or the end. Here we
add a second argument to seekend to make it easier to similarly seek to a byte
relative to the end.
