### PR TITLE
[LAPACK] Interface lacpy! and add a Julia version copytrito!

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -153,6 +153,7 @@ export
     triu,
     tril!,
     triu!,
+    lacpy!
 
 # Operators
     \,

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -76,7 +76,7 @@ export
     cond,
     condskeel,
     copyto!,
-    copytotri!,
+    copytrito!,
     copy_transpose!,
     cross,
     adjoint,

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -76,6 +76,7 @@ export
     cond,
     condskeel,
     copyto!,
+    copytotri!,
     copy_transpose!,
     cross,
     adjoint,
@@ -153,7 +154,6 @@ export
     triu,
     tril!,
     triu!,
-    lacpy!,
 
 # Operators
     \,

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -153,7 +153,7 @@ export
     triu,
     tril!,
     triu!,
-    lacpy!
+    lacpy!,
 
 # Operators
     \,

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1899,7 +1899,7 @@ normalize(x) = x / norm(x)
 normalize(x, p::Real) = x / norm(x, p)
 
 """
-    copytotri!(uplo, A, B) -> B
+    copytotri!(B, A, uplo) -> B
 
 Copies a triangular part of a matrix `A` to another matrix `B`.
 `uplo` specifies the part of the matrix `A` to be copied to `B`.
@@ -1915,26 +1915,28 @@ julia> A = [1 2 ; 3 4];
 
 julia> B = [0 0 ; 0 0];
 
-julia> copytotri!('L', A, B)
+julia> copytotri!(B, A, 'L')
 2×2 Matrix{Int64}:
  1  0
  3  4
 ```
 """
-function copytotri!(uplo::AbstractChar, A::AbstractMatrix, B::AbstractMatrix)
+function copytotri!(B::AbstractMatrix, A::AbstractMatrix, uplo::AbstractChar)
     require_one_based_indexing(A, B)
     LinearAlgebra.BLAS.chkuplo(uplo)
-    m, n = size(A)
+    m,n = size(A)
+    m1,n1 = size(B)
+    (m1 < m || n1 < n) && throw(DimensionMismatch("B of size ($m1,$n1) should have at least the same number of rows and columns than A of size ($m,$n)"))
     if uplo == 'U'
-        @inbounds for j=1:n
-            @inbounds for i=1:min(j,m)
-                B[i,j] = A[i,j]
+        for j=1:n
+            for i=1:min(j,m)
+                @inbounds B[i,j] = A[i,j]
             end
         end
     else  # uplo == 'L'
-        @inbounds for j=1:n
-            @inbounds for i=j:m
-                B[i,j] = A[i,j]
+        for j=1:n
+            for i=j:m
+                @inbounds B[i,j] = A[i,j]
             end
         end
     end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1923,7 +1923,7 @@ julia> copytrito!(B, A, 'L')
 """
 function copytrito!(B::AbstractMatrix, A::AbstractMatrix, uplo::AbstractChar)
     require_one_based_indexing(A, B)
-    LinearAlgebra.BLAS.chkuplo(uplo)
+    BLAS.chkuplo(uplo)
     m,n = size(A)
     m1,n1 = size(B)
     (m1 < m || n1 < n) && throw(DimensionMismatch("B of size ($m1,$n1) should have at least the same number of rows and columns than A of size ($m,$n)"))

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1899,7 +1899,7 @@ normalize(x) = x / norm(x)
 normalize(x, p::Real) = x / norm(x, p)
 
 """
-    copytotri!(B, A, uplo) -> B
+    copytrito!(B, A, uplo) -> B
 
 Copies a triangular part of a matrix `A` to another matrix `B`.
 `uplo` specifies the part of the matrix `A` to be copied to `B`.
@@ -1907,7 +1907,7 @@ Set `uplo = 'L'` for the lower triangular part or `uplo = 'U'
 for the upper triangular part.
 
 !!! compat "Julia 1.11"
-    `copytotri!` requires at least Julia 1.11.
+    `copytrito!` requires at least Julia 1.11.
 
 # Examples
 ```jldoctest
@@ -1915,13 +1915,13 @@ julia> A = [1 2 ; 3 4];
 
 julia> B = [0 0 ; 0 0];
 
-julia> copytotri!(B, A, 'L')
+julia> copytrito!(B, A, 'L')
 2×2 Matrix{Int64}:
  1  0
  3  4
 ```
 """
-function copytotri!(B::AbstractMatrix, A::AbstractMatrix, uplo::AbstractChar)
+function copytrito!(B::AbstractMatrix, A::AbstractMatrix, uplo::AbstractChar)
     require_one_based_indexing(A, B)
     LinearAlgebra.BLAS.chkuplo(uplo)
     m,n = size(A)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1918,8 +1918,8 @@ julia> B = [0 0 ; 0 0];
 
 julia> lacpy!('L', A, B)
 2×2 Matrix{Int64}:
- 1  2
- 3  0
+ 1  0
+ 3  4
 ```
 """
 function lacpy!(uplo::AbstractChar, A::AbstractMatrix, B::AbstractMatrix)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1899,16 +1899,15 @@ normalize(x) = x / norm(x)
 normalize(x, p::Real) = x / norm(x, p)
 
 """
-    lacpy!(uplo, A, B) -> B
+    copytotri!(uplo, A, B) -> B
 
-Copies all or part of a matrix A to another matrix B.
-uplo specifies the part of the matrix A to be copied to B.
-Set `uplo = 'L'` for the lower triangular part, `uplo = 'U'`
-for the upper triangular part, any other character for all
-the matrix A.
+Copies a triangular part of a matrix `A` to another matrix `B`.
+`uplo` specifies the part of the matrix `A` to be copied to `B`.
+Set `uplo = 'L'` for the lower triangular part or `uplo = 'U'
+for the upper triangular part.
 
 !!! compat "Julia 1.11"
-    `lacpy!` requires at least Julia 1.11.
+    `copytotri!` requires at least Julia 1.11.
 
 # Examples
 ```jldoctest
@@ -1916,34 +1915,28 @@ julia> A = [1 2 ; 3 4];
 
 julia> B = [0 0 ; 0 0];
 
-julia> lacpy!('L', A, B)
+julia> copytotri!('L', A, B)
 2×2 Matrix{Int64}:
  1  0
  3  4
 ```
 """
-function lacpy!(uplo::AbstractChar, A::AbstractMatrix, B::AbstractMatrix)
+function copytotri!(uplo::AbstractChar, A::AbstractMatrix, B::AbstractMatrix)
+    require_one_based_indexing(A, B)
+    chkuplo(uplo)
     m, n = size(A)
     if uplo == 'U'
-        for j=1:n
-            for i=1:min(j,m)
+        @inbounds for j=1:n
+            @inbounds for i=1:min(j,m)
                 B[i,j] = A[i,j]
             end
         end
-    elseif uplo == 'L'
-        for j=1:n
-            for i=j:m
-                B[i,j] = A[i,j]
-            end
-        end
-    else
-        for j=1:n
-            for i=1:m
+    else  # uplo == 'L'
+        @inbounds for j=1:n
+            @inbounds for i=j:m
                 B[i,j] = A[i,j]
             end
         end
     end
     return B
 end
-
-lacpy!(uplo::AbstractChar, A::StridedMatrix{T}, B::StridedMatrix{T}) where {T<:BlasFloat} = LAPACK.lacpy!(uplo, A, B)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1897,3 +1897,53 @@ end
 
 normalize(x) = x / norm(x)
 normalize(x, p::Real) = x / norm(x, p)
+
+"""
+    lacpy!(uplo, A, B) -> B
+
+Copies all or part of a matrix A to another matrix B.
+uplo specifies the part of the matrix A to be copied to B.
+Set `uplo = 'L'` for the lower triangular part, `uplo = 'U'`
+for the upper triangular part, any other character for all
+the matrix A.
+
+!!! compat "Julia 1.11"
+    `lacpy!` requires at least Julia 1.11.
+
+# Examples
+```jldoctest
+julia> A = [1 2 ; 3 4];
+
+julia> B = [0 0 ; 0 0];
+
+julia> lacpy!('L', A, B)
+2×2 Matrix{Int64}:
+ 1  2
+ 3  0
+```
+"""
+function lacpy!(uplo::AbstractChar, A::AbstractMatrix, B::AbstractMatrix)
+    m, n = size(A)
+    if uplo == 'U'
+        for j=1:n
+            for i=1:min(j,m)
+                B[i,j] = A[i,j]
+            end
+        end
+    elseif uplo == 'L'
+        for j=1:n
+            for i=j:m
+                B[i,j] = A[i,j]
+            end
+        end
+    else
+        for j=1:n
+            for i=1:m
+                B[i,j] = A[i,j]
+            end
+        end
+    end
+    return B
+end
+
+lacpy!(uplo::AbstractChar, A::StridedMatrix{T}, B::StridedMatrix{T}) where {T<:BlasFloat} = LAPACK.lacpy!(uplo, A, B)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1923,7 +1923,7 @@ julia> copytotri!('L', A, B)
 """
 function copytotri!(uplo::AbstractChar, A::AbstractMatrix, B::AbstractMatrix)
     require_one_based_indexing(A, B)
-    chkuplo(uplo)
+    LinearAlgebra.BLAS.chkuplo(uplo)
     m, n = size(A)
     if uplo == 'U'
         @inbounds for j=1:n

--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -7008,6 +7008,7 @@ for (fn, elty) in ((:dlacpy_, :Float64),
         function lacpy!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
             require_one_based_indexing(A, B)
             chkstride1(A, B)
+            chkuplo(uplo)
             m,n = size(A)
             m1,n1 = size(B)
             (m1 < m || n1 < n) && throw(DimensionMismatch("B of size ($m1,$n1) should have at least the same number of rows and columns than A of size ($m,$n)"))

--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -7005,7 +7005,7 @@ for (fn, elty) in ((:dlacpy_, :Float64),
         #     .. Array Arguments ..
         #     DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         #     ..
-        function lacpy!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
+        function lacpy!(B::AbstractMatrix{$elty}, A::AbstractMatrix{$elty}, uplo::AbstractChar)
             require_one_based_indexing(A, B)
             chkstride1(A, B)
             chkuplo(uplo)
@@ -7024,7 +7024,7 @@ for (fn, elty) in ((:dlacpy_, :Float64),
 end
 
 """
-    lacpy!(uplo, A, B) -> B
+    lacpy!(B, A, uplo) -> B
 
 Copies all or part of a matrix `A` to another matrix `B`.
 uplo specifies the part of the matrix `A` to be copied to `B`.
@@ -7038,12 +7038,12 @@ julia> A = [1. 2. ; 3. 4.];
 
 julia> B = [0. 0. ; 0. 0.];
 
-julia> LAPACK.lacpy!('U', A, B)
+julia> LAPACK.lacpy!(B, A, 'U')
 2×2 Matrix{Float64}:
  1.0  2.0
  0.0  4.0
 ```
 """
-lacpy!(uplo::AbstractChar, A::AbstractMatrix, B::AbstractMatrix)
+lacpy!(B::AbstractMatrix, A::AbstractMatrix, uplo::AbstractChar)
 
 end # module

--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -7008,7 +7008,6 @@ for (fn, elty) in ((:dlacpy_, :Float64),
         function lacpy!(B::AbstractMatrix{$elty}, A::AbstractMatrix{$elty}, uplo::AbstractChar)
             require_one_based_indexing(A, B)
             chkstride1(A, B)
-            chkuplo(uplo)
             m,n = size(A)
             m1,n1 = size(B)
             (m1 < m || n1 < n) && throw(DimensionMismatch("B of size ($m1,$n1) should have at least the same number of rows and columns than A of size ($m,$n)"))

--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -6992,4 +6992,57 @@ Returns `X` (overwriting `C`) and `scale`.
 """
 trsyl!(transa::AbstractChar, transb::AbstractChar, A::AbstractMatrix, B::AbstractMatrix, C::AbstractMatrix, isgn::Int=1)
 
+for (fn, elty) in ((:dlacpy_, :Float64),
+                   (:slacpy_, :Float32),
+                   (:zlacpy_, :ComplexF64),
+                   (:clacpy_, :ComplexF32))
+    @eval begin
+        # SUBROUTINE DLACPY( UPLO, M, N, A, LDA, B, LDB )
+        #     .. Scalar Arguments ..
+        #      CHARACTER          UPLO
+        #      INTEGER            LDA, LDB, M, N
+        #     ..
+        #     .. Array Arguments ..
+        #     DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
+        #     ..
+        function lacpy!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
+            require_one_based_indexing(A, B)
+            chkstride1(A, B)
+            m,n = size(A)
+            m1,n1 = size(B)
+            (m1 < m || n1 < n) && throw(DimensionMismatch("B of size ($m1,$n1) should have at least the same number of rows and columns than A of size ($m,$n)"))
+            lda = max(1, stride(A, 2))
+            ldb = max(1, stride(B, 2))
+            ccall((@blasfunc($fn), libblastrampoline), Cvoid,
+                 (Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ptr{$elty},
+                  Ref{BlasInt}, Ptr{$elty}, Ref{BlasInt}, Clong),
+                  uplo, m, n, A, lda, B, ldb, 1)
+            B
+        end
+    end
+end
+
+"""
+    lacpy!(uplo, A, B) -> B
+
+Copies all or part of a matrix A to another matrix B.
+uplo specifies the part of the matrix A to be copied to B.
+Set `uplo = 'L'` for the lower triangular part, `uplo = 'U'`
+for the upper triangular part, any other character for all
+the matrix A.
+
+# Examples
+```jldoctest
+julia> A = [1. 2. ; 3. 4.];
+
+julia> B = [0. 0. ; 0. 0.];
+
+julia> LAPACK.lacpy!('U', A, B)
+2×2 Matrix{Float64}:
+ 1.0  2.0
+ 0.0  4.0
+```
+"""
+lacpy!(uplo::AbstractChar, A::AbstractMatrix, B::AbstractMatrix)
+
 end # module

--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -7025,11 +7025,11 @@ end
 """
     lacpy!(uplo, A, B) -> B
 
-Copies all or part of a matrix A to another matrix B.
-uplo specifies the part of the matrix A to be copied to B.
+Copies all or part of a matrix `A` to another matrix `B`.
+uplo specifies the part of the matrix `A` to be copied to `B`.
 Set `uplo = 'L'` for the lower triangular part, `uplo = 'U'`
 for the upper triangular part, any other character for all
-the matrix A.
+the matrix `A`.
 
 # Examples
 ```jldoctest

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -641,9 +641,9 @@ end
     A = rand(n, n)
     for uplo in ('L', 'U')
         B = zeros(n, n)
-        copytotri!(uplo, A, B)
+        copytotri!(B, A, uplo)
         C = uplo == 'L' ? tril(A) : triu(A)
-        @test A == C
+        @test A ≈ C
     end
 end
 

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -636,4 +636,15 @@ end
     @test condskeel(A) ≈ condskeel(A, [8,8,8])
 end
 
+@testset "copytotri!" begin
+    n = 10
+    A = rand(n, n)
+    for uplo in ('L', 'U')
+        B = zeros(n, n)
+        copytotri!(uplo, A, B)
+        C = uplo == 'L' ? tril(A) : triu(A)
+        @test A == C
+    end
+end
+
 end # module TestGeneric

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -636,12 +636,12 @@ end
     @test condskeel(A) ≈ condskeel(A, [8,8,8])
 end
 
-@testset "copytotri!" begin
+@testset "copytrito!" begin
     n = 10
     A = rand(n, n)
     for uplo in ('L', 'U')
         B = zeros(n, n)
-        copytotri!(B, A, uplo)
+        copytrito!(B, A, uplo)
         C = uplo == 'L' ? tril(A) : triu(A)
         @test B ≈ C
     end

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -643,7 +643,7 @@ end
         B = zeros(n, n)
         copytotri!(B, A, uplo)
         C = uplo == 'L' ? tril(A) : triu(A)
-        @test A ≈ C
+        @test B ≈ C
     end
 end
 

--- a/stdlib/LinearAlgebra/test/lapack.jl
+++ b/stdlib/LinearAlgebra/test/lapack.jl
@@ -693,7 +693,7 @@ end
             B = zeros(elty, n, n)
             LinearAlgebra.LAPACK.lacpy!(B, A, uplo)
             C = uplo == 'L' ? tril(A) : (uplo == 'U' ? triu(A) : A)
-            @test A ≈ C
+            @test B ≈ C
         end
     end
 end

--- a/stdlib/LinearAlgebra/test/lapack.jl
+++ b/stdlib/LinearAlgebra/test/lapack.jl
@@ -685,6 +685,19 @@ end
     end
 end
 
+@testset "lacpy!" begin
+    @testset for elty in (Float32, Float64, ComplexF32, ComplexF64)
+        n = 10
+        A = rand(elty, n, n)
+        for uplo in ('L', 'U', 'N')
+            B = zeros(elty, n, n)
+            LinearAlgebra.LAPACK.lacpy!(uplo, A, B)
+            C = uplo == 'L' ? tril(A) : (uplo == 'U' ? triu(A) : A)
+            @test A == C
+        end
+    end
+end
+
 @testset "Julia vs LAPACK" begin
     # Test our own linear algebra functionality against LAPACK
     @testset for elty in (Float32, Float64, ComplexF32, ComplexF64)

--- a/stdlib/LinearAlgebra/test/lapack.jl
+++ b/stdlib/LinearAlgebra/test/lapack.jl
@@ -691,9 +691,9 @@ end
         A = rand(elty, n, n)
         for uplo in ('L', 'U', 'N')
             B = zeros(elty, n, n)
-            LinearAlgebra.LAPACK.lacpy!(uplo, A, B)
+            LinearAlgebra.LAPACK.lacpy!(B, A, uplo)
             C = uplo == 'L' ? tril(A) : (uplo == 'U' ? triu(A) : A)
-            @test A == C
+            @test A ≈ C
         end
     end
 end


### PR DESCRIPTION
The PR adds a function `lacpy!` to easily copy a triangular part of a square or rectangular dense matrix.