### PR TITLE
libjulia: add jl_unwrap_unionall to exported_funcs

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -497,6 +497,7 @@
     XX(jl_uncompress_argname_n) \
     XX(jl_uncompress_ir) \
     XX(jl_undefined_var_error) \
+    XX(jl_unwrap_unionall) \
     XX(jl_has_no_field_error) \
     XX(jl_value_ptr) \
     XX(jl_ver_is_release) \


### PR DESCRIPTION
This was recently refactored in #51319 and while trying to adapt `libcxxwrap-julia` to the new changes I got:
```
ld: CMakeFiles/test_module.dir/test_module.cpp.o: in function `jl_datatype_layout':
test_module.cpp:(.text+0x2c2): undefined reference to `jl_unwrap_unionall'
```

The function `jl_datatype_layout` is `STATIC_INLINE` in `julia.h`:
https://github.com/JuliaLang/julia/blob/98542d748540e2390d6222282749c7dd534544da/src/julia.h#L1304-L1312
`jl_unwrap_unionall` is marked `JL_DLLEXPORT` here but it doesn't appear in the exports of `libjulia`.