### PR TITLE
Simplify pivot selection in ScratchQuickSort

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1036,7 +1036,7 @@ function partition!(t::AbstractVector, lo::Integer, hi::Integer, offset::Integer
         v::AbstractVector, rev::Bool, pivot_dest::AbstractVector, pivot_index_offset::Integer)
     # Ideally we would use `pivot_index = rand(lo:hi)`, but that requires Random.jl
     # and would mutate the global RNG in sorting.
-    pivot_index = typeof(hi-lo)(hash(lo) % (hi-lo+1)) + lo
+    pivot_index = mod(hash(lo), lo:hi)
     @inbounds begin
         pivot = v[pivot_index]
         while lo < pivot_index


### PR DESCRIPTION
This is motivated by the following
```
julia> old(lo, hi) =  typeof(hi-lo)(hash(lo) % (hi-lo+1)) + lo
old (generic function with 1 method)

julia> new(lo, hi) =  mod(hash(lo), lo:hi)
new (generic function with 1 method)

julia> @btime old(x, y) setup=(x=rand(1:10); y=rand(100:1000))
  2.916 ns (0 allocations: 0 bytes)
485

julia> @btime new(x, y) setup=(x=rand(1:10); y=rand(100:1000))
  2.250 ns (0 allocations: 0 bytes)
33
```
I haven't bothered to check performance in larger benchmarks because I'm sure it will be negligible.