### PR TITLE
relocation: a fix for `@depot` tag inserting and extra tests

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2617,8 +2617,7 @@ end
 
 # Find depot in DEPOT_PATH for which all @depot tags from the `includes`
 # can be replaced so that they point to a file on disk each.
-# Return nothing when no depot matched.
-function resolve_depot(includes)
+function resolve_depot(includes::Union{AbstractVector,AbstractSet})
     if any(includes) do inc
             !startswith(inc, "@depot")
         end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2600,13 +2600,13 @@ end
 
 function replace_depot_path(path::AbstractString)
     for depot in DEPOT_PATH
-        # Skip depots that don't exist
-        if !isdirpath(depot)
-            continue
-        end
+        !isdir(depot) && continue
 
         # Strip extraneous pathseps through normalization.
-        depot = dirname(depot)
+        if isdirpath(depot)
+            depot = dirname(depot)
+        end
+
         if startswith(path, depot)
             path = replace(path, depot => "@depot"; count=1)
             break

--- a/test/relocatedepot.jl
+++ b/test/relocatedepot.jl
@@ -84,7 +84,6 @@ if !test_relocated_depot
             @test Base.isprecompiled(pkg) == false
             touch(joinpath(@__DIR__, pkgname, "src", "foo.txt"))
             Base.require(pkg) # precompile
-            @info "SERS OIDA"
             @test Base.isprecompiled(pkg, ignore_loaded=true) == true
         end
     end

--- a/test/relocatedepot.jl
+++ b/test/relocatedepot.jl
@@ -36,11 +36,12 @@ if !test_relocated_depot
                 if isdirpath(DEPOT_PATH[1])
                     DEPOT_PATH[1] = dirname(DEPOT_PATH[1]) # strip trailing pathsep
                 end
-                @test startswith(Base.replace_depot_path(path), "@depot/")
+                tag = joinpath("@depot", "") # append a pathsep
+                @test startswith(Base.replace_depot_path(path), tag)
                 DEPOT_PATH[1] = joinpath(DEPOT_PATH[1], "") # append a pathsep
-                @test startswith(Base.replace_depot_path(path), "@depot/")
+                @test startswith(Base.replace_depot_path(path), tag)
                 popfirst!(DEPOT_PATH)
-                @test !startswith(Base.replace_depot_path(path), "@depot/")
+                @test !startswith(Base.replace_depot_path(path), tag)
             end
         end
 
@@ -48,14 +49,18 @@ if !test_relocated_depot
 
     @testset "restore path from @depot tag" begin
 
-        path = "@depot/foo/bar"
-        @test Base.restore_depot_path(path, "/tmp") == "/tmp/foo/bar"
+        tmp = tempdir()
 
-        path = "blabla/foo/bar"
-        @test Base.restore_depot_path(path, "/tmp") == "blabla/foo/bar"
+        path = joinpath("@depot", "foo", "bar")
+        tmppath = joinpath(tmp, "foo", "bar")
+        @test Base.restore_depot_path(path, tmp) == tmppath
 
-        path = "@depot/foo/bar\n@depot/mypkg/src/file.jl"
-        @test Base.restore_depot_path(path, "/tmp") == "/tmp/foo/bar\n@depot/mypkg/src/file.jl"
+        path = joinpath("no@depot", "foo", "bar")
+        @test Base.restore_depot_path(path, tmp) == path
+
+        path = joinpath("@depot", "foo", "bar\n", "@depot", "foo")
+        tmppath = joinpath(tmp, "foo", "bar\n", "@depot", "foo")
+        @test Base.restore_depot_path(path, tmp) == tmppath
 
     end
 
@@ -98,7 +103,6 @@ else
             for pkgname in ("RelocationTestPkg1", "RelocationTestPkg2")
                 pkg = Base.identify_package(pkgname)
                 cachefile = only(Base.find_all_in_cache_path(pkg))
-                @info cachefile
                 @test_throws ArgumentError("""
                   Failed to determine depot from srctext files in cache file $cachefile.
                   - Make sure you have adjusted DEPOT_PATH in case you relocated depots.""") Base.isprecompiled(pkg)


### PR DESCRIPTION
#51892 caused depots to be skipped when inserting the `@depot` tags, because it assumed that `isdirpath(path) == false` means that `path` is not a directory.
This is fixed here while preserving the path normalization introduced there.

Furthermore, this adds tests as requested here https://github.com/JuliaLang/julia/pull/51892#issuecomment-1781754004