### PR TITLE
improve return type inference of `typed_hvcat(::Type{T}, rows, as::Any...)`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2195,7 +2195,7 @@ function typed_hvcat(::Type{T}, rows::Tuple{Vararg{Int}}, as...) where T
         rs[i] = typed_hcat(T, as[a:a-1+rows[i]]...)
         a += rows[i]
     end
-    T[rs...;]
+    T[rs...;]::Matrix{T}
 end
 
 ## N-dimensional concatenation ##

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1877,3 +1877,6 @@ f45952(x) = [x;;]
     @test_throws "invalid index: true of type Bool" isassigned(A, 1, true)
     @test_throws "invalid index: true of type Bool" isassigned(A, true)
 end
+
+typed_hvcat_rt() = [1 1.0; true "1.0"]
+@inferred typed_hvcat_rt()


### PR DESCRIPTION
By adding type annotation on the returned value.

xref: https://discourse.julialang.org/t/appropriate-warning-for-size-using-code-warntype/105457