### PR TITLE
Fix :noshift construction of an empty SubString

### DIFF
--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -37,7 +37,7 @@ struct SubString{T<:AbstractString} <: AbstractString
         return new(s, i-1, nextind(s,j)-i)
     end
     function SubString{T}(s::T, i::Int, j::Int, ::Val{:noshift}) where T<:AbstractString
-        @boundscheck begin
+        @boundscheck if !(i == j == 0)
             si, sj = i + 1, prevind(s, j + i + 1)
             @inbounds isvalid(s, si) || string_index_err(s, si)
             @inbounds isvalid(s, sj) || string_index_err(s, sj)

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -203,6 +203,12 @@ end
         @test (@views (x[3], x[1:2], x[[1,4]])) isa Tuple{Char, SubString, String}
         @test (@views (x[3], x[1:2], x[[1,4]])) == ('c', "ab", "ad")
     end
+
+    @testset ":noshift constructor" begin
+        @test SubString("", 0, 0, Val(:noshift)) == ""
+        @test SubString("abcd", 0, 1, Val(:noshift)) == "a"
+        @test SubString("abcd", 0, 4, Val(:noshift)) == "abcd"
+    end
 end
 
 


### PR DESCRIPTION
This fixes an edge case in the recently introduced `:noshift` substring constructor.