### PR TITLE
Implement more missing BFloat16 intrinsics

### DIFF
--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -310,11 +310,15 @@ void LLVMByteSwap(unsigned numbits, integerPart *pa, integerPart *pr) {
 
 extern "C" float julia_half_to_float(uint16_t ival) JL_NOTSAFEPOINT;
 extern "C" uint16_t julia_float_to_half(float param) JL_NOTSAFEPOINT;
+extern "C" float julia_bfloat_to_float(uint16_t ival) JL_NOTSAFEPOINT;
+extern "C" uint16_t julia_float_to_bfloat(float param) JL_NOTSAFEPOINT;
 
 void LLVMFPtoInt(jl_datatype_t *ty, void *pa, jl_datatype_t *oty, integerPart *pr, bool isSigned, bool *isExact) {
     double Val;
     if (ty == jl_float16_type)
         Val = julia_half_to_float(*(uint16_t*)pa);
+    else if (ty == jl_bfloat16_type)
+        Val = julia_bfloat_to_float(*(uint16_t*)pa);
     else if (ty == jl_float32_type)
         Val = *(float*)pa;
     else if (jl_float64_type)
@@ -393,6 +397,8 @@ void LLVMSItoFP(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerP
     }
     if (oty == jl_float16_type)
         *(uint16_t*)pr = julia_float_to_half(val);
+    else if (oty == jl_bfloat16_type)
+        *(uint16_t*)pr = julia_float_to_bfloat(val);
     else if (oty == jl_float32_type)
         *(float*)pr = val;
     else if (oty == jl_float64_type)
@@ -412,6 +418,8 @@ void LLVMUItoFP(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerP
     }
     if (oty == jl_float16_type)
         *(uint16_t*)pr = julia_float_to_half(val);
+    else if (oty == jl_bfloat16_type)
+        *(uint16_t*)pr = julia_float_to_bfloat(val);
     else if (oty == jl_float32_type)
         *(float*)pr = val;
     else if (oty == jl_float64_type)

--- a/src/APInt-C.cpp
+++ b/src/APInt-C.cpp
@@ -7,15 +7,10 @@
 #include <llvm/Support/MathExtras.h>
 
 #include "APInt-C.h"
-#include "julia.h"
 #include "julia_assert.h"
 #include "julia_internal.h"
 
 using namespace llvm;
-
-inline uint64_t RoundUpToAlignment(uint64_t Value, uint64_t Align, uint64_t Skew = 0) {
-    return alignTo(Value, Align, Skew);
-}
 
 const unsigned int integerPartWidth = llvm::APInt::APINT_BITS_PER_WORD;
 const unsigned int host_char_bit = 8;
@@ -25,11 +20,11 @@ const unsigned int host_char_bit = 8;
     APInt s; \
     if ((numbits % integerPartWidth) != 0) { \
         /* use LLT_ALIGN to round the memory area up to the nearest integerPart-sized chunk */ \
-        unsigned nbytes = RoundUpToAlignment(numbits, integerPartWidth) / host_char_bit; \
+        unsigned nbytes = alignTo(numbits, integerPartWidth) / host_char_bit; \
         integerPart *data_a64 = (integerPart*)alloca(nbytes); \
         /* TODO: this memcpy assumes little-endian,
          * for big-endian, need to align the copy to the other end */ \
-        memcpy(data_a64, p##s, RoundUpToAlignment(numbits, host_char_bit) / host_char_bit); \
+        memcpy(data_a64, p##s, alignTo(numbits, host_char_bit) / host_char_bit); \
         s = APInt(numbits, ArrayRef<uint64_t>(data_a64, nbytes / sizeof(integerPart))); \
     } \
     else { \
@@ -47,7 +42,7 @@ const unsigned int host_char_bit = 8;
     else if (numbits <= 64) \
         *(uint64_t*)p##r = a.getZExtValue(); \
     else \
-        memcpy(p##r, a.getRawData(), RoundUpToAlignment(numbits, host_char_bit) / host_char_bit); \
+        memcpy(p##r, a.getRawData(), alignTo(numbits, host_char_bit) / host_char_bit); \
 
 extern "C" JL_DLLEXPORT
 void LLVMNeg(unsigned numbits, integerPart *pa, integerPart *pr) {
@@ -316,17 +311,18 @@ void LLVMByteSwap(unsigned numbits, integerPart *pa, integerPart *pr) {
 extern "C" float julia_half_to_float(uint16_t ival) JL_NOTSAFEPOINT;
 extern "C" uint16_t julia_float_to_half(float param) JL_NOTSAFEPOINT;
 
-void LLVMFPtoInt(unsigned numbits, void *pa, unsigned onumbits, integerPart *pr, bool isSigned, bool *isExact) {
+void LLVMFPtoInt(jl_datatype_t *ty, void *pa, jl_datatype_t *oty, integerPart *pr, bool isSigned, bool *isExact) {
     double Val;
-    if (numbits == 16)
+    if (ty == jl_float16_type)
         Val = julia_half_to_float(*(uint16_t*)pa);
-    else if (numbits == 32)
+    else if (ty == jl_float32_type)
         Val = *(float*)pa;
-    else if (numbits == 64)
+    else if (jl_float64_type)
         Val = *(double*)pa;
     else
         jl_error("FPtoSI: runtime floating point intrinsics are not implemented for bit sizes other than 16, 32 and 64");
-    unsigned onumbytes = RoundUpToAlignment(onumbits, host_char_bit) / host_char_bit;
+    unsigned onumbytes = jl_datatype_size(oty);
+    unsigned onumbits = onumbytes * host_char_bit;
     if (onumbits <= 64) { // fast-path, if possible
         if (isSigned) {
             int64_t ia = Val;
@@ -353,7 +349,7 @@ void LLVMFPtoInt(unsigned numbits, void *pa, unsigned onumbits, integerPart *pr,
         APFloat a(Val);
         bool isVeryExact;
         APFloat::roundingMode rounding_mode = APFloat::rmNearestTiesToEven;
-        unsigned nbytes = RoundUpToAlignment(onumbits, integerPartWidth) / host_char_bit;
+        unsigned nbytes = alignTo(onumbits, integerPartWidth) / host_char_bit;
         integerPart *parts = (integerPart*)alloca(nbytes);
         APFloat::opStatus status = a.convertToInteger(MutableArrayRef<integerPart>(parts, nbytes), onumbits, isSigned, rounding_mode, &isVeryExact);
         memcpy(pr, parts, onumbytes);
@@ -363,69 +359,74 @@ void LLVMFPtoInt(unsigned numbits, void *pa, unsigned onumbits, integerPart *pr,
 }
 
 extern "C" JL_DLLEXPORT
-void LLVMFPtoSI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
-    LLVMFPtoInt(numbits, pa, onumbits, pr, true, NULL);
+void LLVMFPtoSI(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr) {
+    LLVMFPtoInt(ty, pa, oty, pr, true, NULL);
 }
 
 extern "C" JL_DLLEXPORT
-void LLVMFPtoUI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
-    LLVMFPtoInt(numbits, pa, onumbits, pr, false, NULL);
+void LLVMFPtoUI(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr) {
+    LLVMFPtoInt(ty, pa, oty, pr, false, NULL);
 }
 
 extern "C" JL_DLLEXPORT
-int LLVMFPtoSI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
+int LLVMFPtoSI_exact(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr) {
     bool isExact;
-    LLVMFPtoInt(numbits, pa, onumbits, pr, true, &isExact);
+    LLVMFPtoInt(ty, pa, oty, pr, true, &isExact);
     return isExact;
 }
 
 extern "C" JL_DLLEXPORT
-int LLVMFPtoUI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
+int LLVMFPtoUI_exact(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr) {
     bool isExact;
-    LLVMFPtoInt(numbits, pa, onumbits, pr, false, &isExact);
+    LLVMFPtoInt(ty, pa, oty, pr, false, &isExact);
     return isExact;
 }
 
 extern "C" JL_DLLEXPORT
-void LLVMSItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
+void LLVMSItoFP(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr) {
     double val;
     { // end scope before jl_error call
+        unsigned numbytes = jl_datatype_size(ty);
+        unsigned numbits = numbytes * host_char_bit;
         CREATE(a)
         val = a.roundToDouble(true);
     }
-    if (onumbits == 16)
+    if (oty == jl_float16_type)
         *(uint16_t*)pr = julia_float_to_half(val);
-    else if (onumbits == 32)
+    else if (oty == jl_float32_type)
         *(float*)pr = val;
-    else if (onumbits == 64)
+    else if (oty == jl_float64_type)
         *(double*)pr = val;
     else
         jl_error("SItoFP: runtime floating point intrinsics are not implemented for bit sizes other than 16, 32 and 64");
 }
 
 extern "C" JL_DLLEXPORT
-void LLVMUItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
+void LLVMUItoFP(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr) {
     double val;
     { // end scope before jl_error call
+        unsigned numbytes = jl_datatype_size(ty);
+        unsigned numbits = numbytes * host_char_bit;
         CREATE(a)
         val = a.roundToDouble(false);
     }
-    if (onumbits == 16)
+    if (oty == jl_float16_type)
         *(uint16_t*)pr = julia_float_to_half(val);
-    else if (onumbits == 32)
+    else if (oty == jl_float32_type)
         *(float*)pr = val;
-    else if (onumbits == 64)
+    else if (oty == jl_float64_type)
         *(double*)pr = val;
     else
         jl_error("UItoFP: runtime floating point intrinsics are not implemented for bit sizes other than 32 and 64");
 }
 
 extern "C" JL_DLLEXPORT
-void LLVMSExt(unsigned inumbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
-    if (!(onumbits > inumbits))
+void LLVMSExt(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *otys, integerPart *pr) {
+    unsigned inumbytes = jl_datatype_size(ty);
+    unsigned onumbytes = jl_datatype_size(otys);
+    if (!(onumbytes > inumbytes))
         jl_error("SExt: output bitsize must be > input bitsize");
-    unsigned inumbytes = RoundUpToAlignment(inumbits, host_char_bit) / host_char_bit;
-    unsigned onumbytes = RoundUpToAlignment(onumbits, host_char_bit) / host_char_bit;
+    unsigned inumbits = inumbytes * host_char_bit;
     int bits = (0 - inumbits) % host_char_bit;
     int signbit = (inumbits - 1) % host_char_bit;
     int sign = ((unsigned char*)pa)[inumbytes - 1] & (1 << signbit) ? -1 : 0;
@@ -440,11 +441,12 @@ void LLVMSExt(unsigned inumbits, integerPart *pa, unsigned onumbits, integerPart
 }
 
 extern "C" JL_DLLEXPORT
-void LLVMZExt(unsigned inumbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
-    if (!(onumbits > inumbits))
+void LLVMZExt(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *otys, integerPart *pr) {
+    unsigned inumbytes = jl_datatype_size(ty);
+    unsigned onumbytes = jl_datatype_size(otys);
+    if (!(onumbytes > inumbytes))
         jl_error("ZExt: output bitsize must be > input bitsize");
-    unsigned inumbytes = RoundUpToAlignment(inumbits, host_char_bit) / host_char_bit;
-    unsigned onumbytes = RoundUpToAlignment(onumbits, host_char_bit) / host_char_bit;
+    unsigned inumbits = inumbytes * host_char_bit;
     int bits = (0 - inumbits) % host_char_bit;
     // copy over the input bytes
     memcpy(pr, pa, inumbytes);
@@ -457,10 +459,11 @@ void LLVMZExt(unsigned inumbits, integerPart *pa, unsigned onumbits, integerPart
 }
 
 extern "C" JL_DLLEXPORT
-void LLVMTrunc(unsigned inumbits, integerPart *pa, unsigned onumbits, integerPart *pr) {
-    if (!(onumbits < inumbits))
+void LLVMTrunc(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *otys, integerPart *pr) {
+    unsigned inumbytes = jl_datatype_size(ty);
+    unsigned onumbytes = jl_datatype_size(otys);
+    if (!(onumbytes < inumbytes))
         jl_error("Trunc: output bitsize must be < input bitsize");
-    unsigned onumbytes = RoundUpToAlignment(onumbits, host_char_bit) / host_char_bit;
     memcpy(pr, pa, onumbytes);
 }
 

--- a/src/APInt-C.h
+++ b/src/APInt-C.h
@@ -3,10 +3,12 @@
 #ifndef JL_APINT_C_H
 #define JL_APINT_C_H
 
+#include "julia.h"
+#include "dtypes.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include "dtypes.h"
 
 #ifdef LLVM_VERSION_MAJOR
 using integerPart = llvm::APInt::WordType;
@@ -57,16 +59,16 @@ JL_DLLEXPORT unsigned LLVMCountTrailingZeros(unsigned numbits, integerPart *pa);
 JL_DLLEXPORT unsigned LLVMCountLeadingOnes(unsigned numbits, integerPart *pa);
 JL_DLLEXPORT unsigned LLVMCountLeadingZeros(unsigned numbits, integerPart *pa);
 
-JL_DLLEXPORT void LLVMFPtoSI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-JL_DLLEXPORT void LLVMFPtoUI(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-JL_DLLEXPORT void LLVMSItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-JL_DLLEXPORT void LLVMUItoFP(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-JL_DLLEXPORT void LLVMSExt(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-JL_DLLEXPORT void LLVMZExt(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-JL_DLLEXPORT void LLVMTrunc(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+JL_DLLEXPORT void LLVMFPtoSI(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr);
+JL_DLLEXPORT void LLVMFPtoUI(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr);
+JL_DLLEXPORT void LLVMSItoFP(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr);
+JL_DLLEXPORT void LLVMUItoFP(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr);
+JL_DLLEXPORT void LLVMSExt(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr);
+JL_DLLEXPORT void LLVMZExt(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr);
+JL_DLLEXPORT void LLVMTrunc(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr);
 
-JL_DLLEXPORT int LLVMFPtoSI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
-JL_DLLEXPORT int LLVMFPtoUI_exact(unsigned numbits, integerPart *pa, unsigned onumbits, integerPart *pr);
+JL_DLLEXPORT int LLVMFPtoSI_exact(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr);
+JL_DLLEXPORT int LLVMFPtoUI_exact(jl_datatype_t *ty, integerPart *pa, jl_datatype_t *oty, integerPart *pr);
 
 JL_DLLEXPORT void jl_LLVMSMod(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);
 JL_DLLEXPORT void jl_LLVMFlipSign(unsigned numbits, integerPart *pa, integerPart *pb, integerPart *pr);

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -338,6 +338,14 @@ static inline float bfloat_to_float(uint16_t param) JL_NOTSAFEPOINT
 
 // bfloat16 conversion API
 
+// for use in APInt (without the ABI shenanigans from below)
+uint16_t julia_float_to_bfloat(float param) {
+    return float_to_bfloat(param);
+}
+float julia_bfloat_to_float(uint16_t param) {
+    return bfloat_to_float(param);
+}
+
 // starting with GCC 13 and Clang 17, we have __bf16 on most platforms
 // (but not on Windows; this may be a bug in the MSYS2 GCC compilers)
 #if ((defined(__GNUC__) && __GNUC__ > 12) || \

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1012,7 +1012,7 @@ static inline jl_value_t *jl_intrinsiclambda_u1(jl_value_t *ty, void *pa, unsign
 
 // conversion operator
 
-typedef void (*intrinsic_cvt_t)(unsigned, void*, unsigned, void*);
+typedef void (*intrinsic_cvt_t)(jl_datatype_t*, void*, jl_datatype_t*, void*);
 typedef unsigned (*intrinsic_cvt_check_t)(unsigned, unsigned, void*);
 #define cvt_iintrinsic(LLVMOP, name) \
 JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *ty, jl_value_t *a) \
@@ -1029,12 +1029,9 @@ static inline jl_value_t *jl_intrinsic_cvt(jl_value_t *ty, jl_value_t *a, const 
     if (!jl_is_primitivetype(aty))
         jl_errorf("%s: value is not a primitive type", name);
     void *pa = jl_data_ptr(a);
-    unsigned isize = jl_datatype_size(aty);
     unsigned osize = jl_datatype_size(ty);
     void *pr = alloca(osize);
-    unsigned isize_bits = isize * host_char_bit;
-    unsigned osize_bits = osize * host_char_bit;
-    op(isize_bits, pa, osize_bits, pr);
+    op((jl_datatype_t*)aty, pa, (jl_datatype_t*)ty, pr);
     return jl_new_bits(ty, pr);
 }
 


### PR DESCRIPTION
Extends https://github.com/JuliaLang/julia/pull/51790; I forgot the conversion intrinsics defined in `APInt-C`. To differentiate between Float16/BFloat16, I converted a couple of intrinsics to take a `jl_datatype_t` argument instead an unsigned number of bits. Once again, this could be generalized to other intrinsics, but didn't seem worth the churn.