### PR TITLE
`AbstractInterpreter`: stash inferred `CodeInfo` even when optimization doesn't happen

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -566,6 +566,8 @@ function finish(me::InferenceState, interp::AbstractInterpreter)
         end
         if doopt && may_optimize(interp)
             me.result.src = OptimizationState(me, interp)
+        else
+            me.result.src = me.src # for reflection etc.
         end
     end
     validate_code_in_debug_mode(me.linfo, me.src, "inferred")


### PR DESCRIPTION
After #51888, `(result::InferenceResult).src` is set to `nothing` in two situations:

1. When the inference result is limited due to recursion.
2. When optimization is unnecessary as the result is already precise.

This commit allows external `AbstractInterpreter` to differentiate between these two situations by retaining the inferred source code in `result.src` for the latter case. This is particularly crucial for the functionality of JET's analysis.

@nanosoldier `runbenchmarks("inference", vs=":master")`