### PR TITLE
fix `pointer` for `Memory` by deleting incorrect method

### DIFF
--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -26,7 +26,6 @@ size(a::GenericMemory, d::Int) =
 size(a::GenericMemory, d::Integer) =  size(a, convert(d, Int))
 size(a::GenericMemory) = (length(a),)
 
-pointer(mem::GenericMemory, i::Int) = (@_propagate_inbounds_meta; unsafe_convert(Ptr{Cvoid}, GenericMemoryRef(mem, i))) # boundschecked, even for i==1
 pointer(mem::GenericMemoryRef) = unsafe_convert(Ptr{Cvoid}, mem) # no bounds check, even for empty array
 
 _unsetindex!(A::Memory, i::Int) =  (@_propagate_inbounds_meta; _unsetindex!(GenericMemoryRef(A, i)); A)

--- a/test/core.jl
+++ b/test/core.jl
@@ -1445,6 +1445,9 @@ let
     @test unsafe_load(p2) == 101
     unsafe_store!(p2, 909, 3)
     @test a2 == [101,102,909]
+    # test for issue 51954
+    @test pointer(a.ref.mem)===pointer(a)
+    @test pointer(a.ref.mem,2)===pointer(a,2)
 end
 
 @test unsafe_pointer_to_objref(ccall(:jl_call1, Ptr{Cvoid}, (Any,Any),


### PR DESCRIPTION
The fallback method for `AbstractArray` was correct and the custom one for `Memory` wasn't.