### PR TITLE
compiler: use `_uncompressed_ir` instead of direct `ccall`

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -733,7 +733,7 @@ function IRInterpretationState(interp::AbstractInterpreter,
     @assert code.def === mi
     src = @atomic :monotonic code.inferred
     if isa(src, String)
-        src = ccall(:jl_uncompress_ir, Any, (Any, Ptr{Cvoid}, Any), mi.def, C_NULL, src)::CodeInfo
+        src = _uncompressed_ir(mi.def, src)
     else
         isa(src, CodeInfo) || return nothing
     end

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -977,7 +977,7 @@ function analyze_method!(match::MethodMatch, argtypes::Vector{Any},
 end
 
 function retrieve_ir_for_inlining(mi::MethodInstance, src::String)
-    src = ccall(:jl_uncompress_ir, Any, (Any, Ptr{Cvoid}, Any), mi.def, C_NULL, src)::CodeInfo
+    src = _uncompressed_ir(mi.def, src)
     return inflate_ir!(src, mi)
 end
 retrieve_ir_for_inlining(mi::MethodInstance, src::CodeInfo) = inflate_ir(src, mi)

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -140,7 +140,7 @@ function retrieve_code_info(linfo::MethodInstance, world::UInt)
             # can happen in images built with --strip-ir
             return nothing
         elseif isa(src, String)
-            c = ccall(:jl_uncompress_ir, Any, (Any, Ptr{Cvoid}, Any), m, C_NULL, src)
+            c = _uncompressed_ir(m, src)
         else
             c = copy(src::CodeInfo)
         end


### PR DESCRIPTION
Just cosmetic changes.