### PR TITLE
carefully cache freshly-inferred edge for call-site inlining

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -519,10 +519,10 @@ CC.bail_out_toplevel_call(::REPLInterpreter, ::CC.InferenceLoopState, ::CC.Infer
 # `REPLInterpreter` is specifically used by `repl_eval_ex`, where all top-level frames are
 # `repl_frame` always. However, this assumption wouldn't stand if `REPLInterpreter` were to
 # be employed, for instance, by `typeinf_ext_toplevel`.
-is_repl_frame(sv::CC.InferenceState) = sv.linfo.def isa Module && sv.cache_mode === :no
+is_repl_frame(sv::CC.InferenceState) = sv.linfo.def isa Module && sv.cache_mode === CC.CACHE_MODE_NULL
 
 function is_call_graph_uncached(sv::CC.InferenceState)
-    sv.cache_mode === :global && return false
+    sv.cache_mode === CC.CACHE_MODE_GLOBAL && return false
     parent = sv.parent
     parent === nothing && return true
     return is_call_graph_uncached(parent::CC.InferenceState)

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -570,6 +570,18 @@ end
     end
 end
 
+@noinline fresh_edge_noinlined(a::Integer) = unresolvable(a)
+let src = code_typed1((Integer,)) do x
+        @inline fresh_edge_noinlined(x)
+    end
+    @test count(iscall((src, fresh_edge_noinlined)), src.code) == 0
+end
+let src = code_typed1((Integer,)) do x
+        @inline fresh_edge_noinlined(x)
+    end
+    @test count(iscall((src, fresh_edge_noinlined)), src.code) == 0 # should be idempotent
+end
+
 # force constant-prop' for `setproperty!`
 # https://github.com/JuliaLang/julia/pull/41882
 let code = @eval Module() begin


### PR DESCRIPTION
Currently call-site inlining fails on freshly-inferred edge if its source isn't inlineable. This happens because such sources are exclusively cached globally. For successful call-site inlining, it's necessary to cache these locally also, ensuring the inliner can access them later.

To this end, the type of the `cache_mode` field of `InferenceState` has been switched to `UInt8` from `Symbol`. This change allows it to encode multiple caching strategies. A new caching mode can be introduced, e.g. `VOLATILE_CACHE_MODE`, in the future.

@nanosoldier `runbenchmarks("inference", vs=":master")`