### PR TITLE
macroexpand: handle const/atomic struct fields correctly

### DIFF
--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -340,8 +340,8 @@
 
 (define (reescape ux x)
   (if (and (pair? x) (eq? (car x) 'escape))
-    (reescape '(escape ,ux) (cadr x)))
-    ux)
+    (reescape `(escape ,ux) (cadr x))
+    ux))
 
 ;; type has special behavior: identifiers inside are
 ;; field names, not expressions.
@@ -353,7 +353,7 @@
          `(|::| ,(unescape (cadr ux))
            ,(resolve-expansion-vars- (reescape (caddr ux) x) env m parent-scope inarg)))
         ((and (pair? ux) (memq (car ux) '(const atomic)))
-         `(,(car ux) ,(resolve-struct-field-expansion (cadr ux) env m parent-scope inarg)))
+         `(,(car ux) ,(resolve-struct-field-expansion (reescape (cadr ux) x) env m parent-scope inarg)))
         (else
          (resolve-expansion-vars-with-new-env x env m parent-scope inarg)))))
 

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1789,6 +1789,7 @@ macro struct_macro_51899()
         mutable struct Struct51899
             const const_field
             const const_field_with_type::Int
+            $(esc(Expr(:const, :(escaped_const_field::MyType))))
             @atomic atomic_field
             @atomic atomic_field_with_type::Int
         end
@@ -1796,7 +1797,7 @@ macro struct_macro_51899()
 end
 
 let ex = @macroexpand @struct_macro_51899()
-    const_field, const_field_with_type,
+    const_field, const_field_with_type, escaped_const_field,
     atomic_field, atomic_field_with_type = filter(x -> isa(x, Expr), ex.args[end].args[end].args)
     @test Meta.isexpr(const_field, :const)
     @test const_field.args[1] === :const_field
@@ -1805,6 +1806,11 @@ let ex = @macroexpand @struct_macro_51899()
     @test Meta.isexpr(const_field_with_type.args[1], :(::))
     @test const_field_with_type.args[1].args[1] === :const_field_with_type
     @test const_field_with_type.args[1].args[2] == GlobalRef(@__MODULE__, :Int)
+
+    @test Meta.isexpr(escaped_const_field, :const)
+    @test Meta.isexpr(const_field_with_type.args[1], :(::))
+    @test escaped_const_field.args[1].args[1] === :escaped_const_field
+    @test escaped_const_field.args[1].args[2] === :MyType
 
     @test Meta.isexpr(atomic_field, :atomic)
     @test atomic_field.args[1] === :atomic_field


### PR DESCRIPTION
Fixes #51899.