### PR TITLE
RFC: Add `@test_throws Union{} expr` to test that no exception is thrown

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,8 @@ Standard library changes
 
 #### Test
 
+* `@test_throws Union{} expr` can now be used to test that `expr` does not throw an exception ([#51982]).
+
 #### Dates
 
 #### Statistics

--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -94,6 +94,33 @@ Test Passed
       Thrown: MethodError
 ```
 
+Sometimes the output of an expression is not of interest and you only want to ensure that
+your code doesn't throw an exception of any type. This is accomplished similarly to checking
+for a particular exception type as above, but using `Union{}` as the type (since no object
+can have type `Union{}`):
+
+```jldoctest
+julia> @test_throws Union{} sqrt(-0.0)
+Test Passed
+  No exception thrown
+```
+
+Note that, when possible, it's typically better to test that the result of an expression is
+what you expect it to be rather than only checking that it doesn't error.
+
+Testing other properties of an expected exception, e.g. that it does _not_ have a particular
+type, can be achieved using `@test` rather than `@test_throws`:
+
+```jldoctest
+julia> @test try
+           sqrt("hello")
+           false  # ensure the test fails if the call does not error
+       catch ex
+           !isa(ex, DomainError)
+       end
+Test Passed
+```
+
 ## Working with Test Sets
 
 Typically a large number of tests are used to make sure functions work correctly over a range

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -163,6 +163,7 @@ let fails = @testset NoThrowTestSet begin
         @test_throws r"sqrt\([Cc]omplx" sqrt(-1)
         @test_throws str->occursin("a T", str) error("a test")
         @test_throws ["BoundsError", "aquire", "1-element", "at index [2]"] [1][2]
+        @test_throws Union{} error("I have errored")
     end
     for fail in fails
         @test fail isa Test.Fail
@@ -298,6 +299,10 @@ let fails = @testset NoThrowTestSet begin
         @test occursin(r"Message: \"BoundsError.* 1-element.*at index \[2\]", str)
     end
 
+    let str = sprint(show, fails[27])
+        @test occursin("Expected: No exception thrown", str)
+        @test occursin("Thrown: ErrorException", str)
+    end
 end
 
 struct BadError <: Exception end


### PR DESCRIPTION
This implements (part of) @tpapp's [suggestion](https://github.com/JuliaLang/julia/issues/18780#issuecomment-863978096) in #18780. Much of the discussion in the linked issue centered around the addition of a `@test_nothrow` or similarly named macro. If implemented as [suggested](https://github.com/JuliaLang/julia/issues/18780#issuecomment-276058838) by @cossio, i.e. `@test_nothrow T expr`, that would be strictly more powerful than what's implemented here; I opted for the simpler route that extends existing functionality at the expense of flexibility. I'm happy to close if another solution is preferred.