### PR TITLE
Remove `ArgumentError()` in `parse_cache_header()` when `@depot` cannot be resolved

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2718,11 +2718,9 @@ function parse_cache_header(f::IO, cachefile::AbstractString)
         chi.filename ∈ srcfiles && push!(keepidx, i)
     end
     if depot === :no_depot_found
-        throw(ArgumentError("""
-              Failed to determine depot from srctext files in cache file $cachefile.
-              - Make sure you have adjusted DEPOT_PATH in case you relocated depots."""))
+        @debug("Unable to resolve @depot tag in cache file $cachefile", srcfiles)
     elseif depot === :missing_depot_tag
-        @debug "Missing @depot tag for include dependencies in cache file $cachefile."
+        @debug("Missing @depot tag for include dependencies in cache file $cachefile.", srcfiles)
     else
         for inc in includes
             inc.filename = replace(inc.filename, r"^@depot" => depot)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3273,6 +3273,10 @@ end
             end
             for chi in includes
                 f, fsize_req, hash_req, ftime_req = chi.filename, chi.fsize, chi.hash, chi.mtime
+                if startswith(f, "@depot/")
+                    @debug("Rejecting stale cache file $cachefile because its depot could not be resolved")
+                    return true
+                end
                 if !ispath(f)
                     _f = fixup_stdlib_path(f)
                     if isfile(_f) && startswith(_f, Sys.STDLIB)

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1274,3 +1274,60 @@ end
         @test_throws ErrorException Base.check_src_module_wrap(p, fpath)
     end
 end
+
+@testset "relocatable upgrades #51989" begin
+    mktempdir() do depot
+        # Create fake `Foo.jl` package with two files:
+        foo_path = joinpath(depot, "dev", "Foo")
+        mkpath(joinpath(foo_path, "src"))
+        open(joinpath(foo_path, "src", "Foo.jl"); write=true) do io
+            println(io, """
+            module Foo
+            include("internal.jl")
+            end
+            """)
+        end
+        open(joinpath(foo_path, "src", "internal.jl"); write=true) do io
+            println(io, "const a = \"asd\"")
+        end
+        open(joinpath(foo_path, "Project.toml"); write=true) do io
+            println(io, """
+            name = "Foo"
+            uuid = "00000000-0000-0000-0000-000000000001"
+            version = "1.0.0"
+            """)
+        end
+
+        # In our depot, `dev` and then `precompile` this `Foo` package.
+        @test success(addenv(
+            `$(Base.julia_cmd()) --startup-file=no -e 'import Pkg; Pkg.develop("Foo"); Pkg.precompile(); exit(0)'`,
+            "JULIA_DEPOT_PATH" => depot,
+        ))
+
+        # Get the size of the generated `.ji` file so that we can ensure that it gets altered
+        foo_compiled_path = joinpath(depot, "compiled", "v$(VERSION.major).$(VERSION.minor)", "Foo")
+        cache_path = joinpath(foo_compiled_path, only(filter(endswith(".ji"), readdir(foo_compiled_path))))
+        cache_size = filesize(cache_path)
+
+        # Next, remove the dependence on `internal.jl` and delete it:
+        rm(joinpath(foo_path, "src", "internal.jl"))
+        open(joinpath(foo_path, "src", "Foo.jl"); write=true) do io
+            truncate(io, 0)
+            println(io, """
+            module Foo
+            end
+            """)
+        end
+
+        # Try to load `Foo`; this should trigger recompilation, not an error!
+        @test success(addenv(
+            `$(Base.julia_cmd()) --startup-file=no -e 'using Foo; exit(0)'`,
+            "JULIA_DEPOT_PATH" => depot,
+        ))
+
+        # Ensure that there is still only one `.ji` file (it got replaced
+        # and the file size changed).
+        @test length(filter(endswith(".ji"), readdir(foo_compiled_path))) == 1
+        @test filesize(cache_path) != cache_size
+    end
+end


### PR DESCRIPTION
In the original implementation of relocatable package cache files, `parse_cache_header()` was made responsible for resolving `@depot/`-relative paths, and it threw an `ArgumentError()` if it could not find one.  However, this could happen for a few reasons:

1. The `JULIA_DEPOT_PATH` could be set incorrectly, so the appropriate source text files could not be found in an appropriate `packages/` directory.

2. The package could have been upgraded, leaving a cache file for an older version on-disk, but no matching source files.

For a concrete example of (2), see the following `bash` script:

    #!/bin/bash
    set -euo pipefail

    TEMP_PATH=$(mktemp -d)
    JULIA=${JULIA:-julia}
    echo JULIA: ${JULIA}
    export JULIA_DEPOT_PATH="${TEMP_PATH}"
    trap 'rm -rf ${TEMP_PATH}' EXIT

    # Create a `Foo.jl` that has an `internal.jl` within it
    FOO_DIR=${JULIA_DEPOT_PATH}/dev/Foo
    mkdir -p ${FOO_DIR}/src
    cat >${FOO_DIR}/Project.toml <<EOF
    name = "Foo"
    uuid = "00000000-0000-0000-0000-000000000001"
    version = "1.0.0"
    EOF
    cat >${FOO_DIR}/src/Foo.jl <<EOF
    module Foo

    include("internal.jl")
    end
    EOF

    cat >${FOO_DIR}/src/internal.jl <<EOF
    # Nothing to see here, folks
    EOF

    ${JULIA} -e "import Pkg; Pkg.develop(\"Foo\"); Pkg.precompile()"

    # Change `Foo` to no longer depend on `internal.jl`; this should invalidate its cache files
    cat >${FOO_DIR}/src/Foo.jl <<EOF
    module Foo
    end
    EOF
    rm -f ${FOO_DIR}/src/internal.jl

    # This should print `SUCCESS!`, not `FAILURE!`
    ${JULIA} -e 'using Foo; println("SUCCESS!")' || echo "FAILURE!"

This pull request removes the `ArgumentError()`, as it seems reasonable to require `parse_cache_header()` to not throw errors in cases like these.  We instead rely upon a higher level validation to reject a cachefile whose depot cannot be found, which should happen when `stale_cachefile()` later checks to ensure that all includes are found on-disk, (which will be false, as these paths start with `@depot/`, an unlikely path prefix to exist).