### PR TITLE
Fix task suspension in GC for JL_TIMING

### DIFF
--- a/src/safepoint.c
+++ b/src/safepoint.c
@@ -201,7 +201,6 @@ void jl_safepoint_wait_thread_resume(void)
     // will observe the change to the safepoint, even though the other thread
     // might have already observed our gc_state.
     // if (!jl_atomic_load_relaxed(&ct->ptls->suspend_count)) return;
-    JL_TIMING_SUSPEND_TASK(USER, ct);
     int8_t state = jl_atomic_load_relaxed(&ct->ptls->gc_state);
     jl_atomic_store_release(&ct->ptls->gc_state, JL_GC_STATE_WAITING);
     uv_mutex_lock(&ct->ptls->sleep_lock);


### PR DESCRIPTION
The timing system does not currently support nesting task suspensions, so this `JL_TIMING_SUSPEND_TASK` added in #51489 is not permitted since it is called from within the GC suspension.

This was causing Tracy to crash upon recording with "zone ended twice"