### PR TITLE
Fix GC.gc docstring

### DIFF
--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -119,9 +119,9 @@ const GC_INCREMENTAL = 2
     GC.gc([full=true])
 
 Perform garbage collection. The argument `full` determines the kind of
-collection: A full collection (default) sweeps all objects, which makes the
-next GC scan much slower, while an incremental collection may only sweep
-so-called young objects.
+collection: a full collection (default) traverses all live objects (e.g. full mark)
+and should reclaim memory from all unreachable objects. An incremental collection only
+reclaims memory from young objects which are not reachable.
 
 !!! warning
     Excessive use will likely lead to poor performance.

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -119,7 +119,7 @@ const GC_INCREMENTAL = 2
     GC.gc([full=true])
 
 Perform garbage collection. The argument `full` determines the kind of
-collection: a full collection (default) traverses all live objects (e.g. full mark)
+collection: a full collection (default) traverses all live objects (i.e. full mark)
 and should reclaim memory from all unreachable objects. An incremental collection only
 reclaims memory from young objects which are not reachable.
 

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -123,6 +123,9 @@ collection: a full collection (default) traverses all live objects (i.e. full ma
 and should reclaim memory from all unreachable objects. An incremental collection only
 reclaims memory from young objects which are not reachable.
 
+The GC may decide to perform a full collection even if an incremental collection was
+requested.
+
 !!! warning
     Excessive use will likely lead to poor performance.
 """


### PR DESCRIPTION
GC.gc(true) will perform a full mark (note the use of [recollect in gc.c ](https://github.com/JuliaLang/julia/blob/5eaad532f961d4d1a1630b5c5b60499d2a7b9ae5/src/gc.c#L3338)if the previous sweep was not full).

Fixes https://github.com/JuliaLang/julia/issues/51796.