### PR TITLE
Revert "Support sorting iterators (#46104)"

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -5,8 +5,7 @@ module Sort
 using Base.Order
 
 using Base: copymutable, midpoint, require_one_based_indexing, uinttype,
-    sub_with_overflow, add_with_overflow, OneTo, BitSigned, BitIntegerType, top_set_bit,
-    IteratorSize, HasShape, IsInfinite, tail
+    sub_with_overflow, add_with_overflow, OneTo, BitSigned, BitIntegerType, top_set_bit
 
 import Base:
     sort,
@@ -1474,11 +1473,6 @@ end
 
 Variant of [`sort!`](@ref) that returns a sorted copy of `v` leaving `v` itself unmodified.
 
-Uses `Base.copymutable` to support immutable collections and iterables.
-
-!!! compat "Julia 1.10"
-    `sort` of arbitrary iterables requires at least Julia 1.10.
-
 # Examples
 ```jldoctest
 julia> v = [3, 1, 2];
@@ -1496,39 +1490,7 @@ julia> v
  2
 ```
 """
-function sort(v; kws...)
-    size = IteratorSize(v)
-    size == HasShape{0}() && throw(ArgumentError("$v cannot be sorted"))
-    size == IsInfinite() && throw(ArgumentError("infinite iterator $v cannot be sorted"))
-    sort!(copymutable(v); kws...)
-end
-sort(v::AbstractVector; kws...) = sort!(copymutable(v); kws...) # for method disambiguation
-sort(::AbstractString; kws...) =
-    throw(ArgumentError("sort(::AbstractString) is not supported"))
-sort(::Tuple; kws...) =
-    throw(ArgumentError("sort(::Tuple) is only supported for NTuples"))
-
-function sort(x::NTuple{N}; lt::Function=isless, by::Function=identity,
-              rev::Union{Bool,Nothing}=nothing, order::Ordering=Forward) where N
-    o = ord(lt,by,rev,order)
-    if N > 9
-        v = sort!(copymutable(x), DEFAULT_STABLE, o)
-        tuple((v[i] for i in 1:N)...)
-    else
-        _sort(x, o)
-    end
-end
-_sort(x::Union{NTuple{0}, NTuple{1}}, o::Ordering) = x
-function _sort(x::NTuple, o::Ordering)
-    a, b = Base.IteratorsMD.split(x, Val(length(x)>>1))
-    merge(_sort(a, o), _sort(b, o), o)
-end
-merge(x::NTuple, y::NTuple{0}, o::Ordering) = x
-merge(x::NTuple{0}, y::NTuple, o::Ordering) = y
-merge(x::NTuple{0}, y::NTuple{0}, o::Ordering) = x # Method ambiguity
-merge(x::NTuple, y::NTuple, o::Ordering) =
-    (lt(o, y[1], x[1]) ? (y[1], merge(x, tail(y), o)...) : (x[1], merge(tail(x), y, o)...))
-
+sort(v::AbstractVector; kws...) = sort!(copymutable(v); kws...)
 
 ## partialsortperm: the permutation to sort the first k elements of an array ##
 

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1500,7 +1500,7 @@ function sort(v; kws...)
     size = IteratorSize(v)
     size == HasShape{0}() && throw(ArgumentError("$v cannot be sorted"))
     size == IsInfinite() && throw(ArgumentError("infinite iterator $v cannot be sorted"))
-    sort!(collect(v); kws...)
+    sort!(copymutable(v); kws...)
 end
 sort(v::AbstractVector; kws...) = sort!(copymutable(v); kws...) # for method disambiguation
 sort(::AbstractString; kws...) =
@@ -1512,7 +1512,7 @@ function sort(x::NTuple{N}; lt::Function=isless, by::Function=identity,
               rev::Union{Bool,Nothing}=nothing, order::Ordering=Forward) where N
     o = ord(lt,by,rev,order)
     if N > 9
-        v = sort!(collect(x), DEFAULT_STABLE, o)
+        v = sort!(copymutable(x), DEFAULT_STABLE, o)
         tuple((v[i] for i in 1:N)...)
     else
         _sort(x, o)

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1474,8 +1474,7 @@ end
 
 Variant of [`sort!`](@ref) that returns a sorted copy of `v` leaving `v` itself unmodified.
 
-Returns something [`similar`](@ref) to `v` when `v` is an `AbstractArray` and uses
-[`collect`](@ref) to support arbitrary non-`AbstractArray` iterables.
+Uses `Base.copymutable` to support immutable collections and iterables.
 
 !!! compat "Julia 1.10"
     `sort` of arbitrary iterables requires at least Julia 1.10.

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -184,7 +184,7 @@ log_nonpublic_access(expr, ::Module, _) = expr
 
 function insert_internal_warning(md::Markdown.MD, internal_access::Set{Pair{Module,Symbol}})
     if !isempty(internal_access)
-        items = Any[Any[Markdown.Paragraph(Any[Markdown.Code("", s)])] for s in sort("$mod.$sym" for (mod, sym) in internal_access)]
+        items = Any[Any[Markdown.Paragraph(Any[Markdown.Code("", s)])] for s in sort!(["$mod.$sym" for (mod, sym) in internal_access])]
         admonition = Markdown.Admonition("warning", "Warning", Any[
             Markdown.Paragraph(Any["The following bindings may be internal; they may change or be removed in future versions:"]),
             Markdown.List(items, -1, false)])

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -559,11 +559,6 @@ end
 
     @test_throws ArgumentError sort("string")
     @test_throws ArgumentError("1 cannot be sorted") sort(1)
-
-    @test sort(Set((1, 3, 6))) == [1, 3, 6]
-    @test sort(Dict((1=>9, 3=>2, 6=>5))) == [1=>9, 3=>2, 6=>5]
-    @test sort(keys(Dict((1=>2, 3=>5, 6=>9)))) == [1, 3, 6]
-    @test sort(values(Dict((1=>9, 3=>2, 6=>5)))) == [2, 5, 9]
 end
 
 @testset "sort!(::AbstractVector{<:Integer}) with short int range" begin

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -88,20 +88,6 @@ end
         vcat(2000, (x:x+99 for x in 1900:-100:100)..., 1:99)
 end
 
-function tuple_sort_test(x)
-    @test issorted(sort(x))
-    length(x) > 9 && return # length > 9 uses a vector fallback
-    @test 0 == @allocated sort(x)
-end
-@testset "sort(::NTuple)" begin
-    @test sort((9,8,3,3,6,2,0,8)) == (0,2,3,3,6,8,8,9)
-    @test sort((9,8,3,3,6,2,0,8), by=x->x÷3) == (2,0,3,3,8,6,8,9)
-    for i in 1:40
-        tuple_sort_test(tuple(rand(i)...))
-    end
-    @test_throws ArgumentError sort((1,2,3.0))
-end
-
 @testset "partialsort" begin
     @test partialsort([3,6,30,1,9],3) == 6
     @test partialsort([3,6,30,1,9],3:4) == [6,9]
@@ -542,23 +528,6 @@ end
     @test issorted(c)
     @test isequal(c, [5,6,7,NaN])
     @test isequal(a, [8,6,7,NaN,5,3,0,9])
-end
-
-@testset "sort!(iterable)" begin
-    gen = (x % 7 + 0.1x for x in 1:50)
-    @test sort(gen) == sort!(collect(gen))
-    gen = (x % 7 + 0.1y for x in 1:10, y in 1:5)
-    @test sort(gen; dims=1) == sort!(collect(gen); dims=1)
-    @test sort(gen; dims=2) == sort!(collect(gen); dims=2)
-
-    @test_throws ArgumentError("dimension out of range") sort(gen; dims=3)
-
-    @test_throws UndefKeywordError(:dims) sort(gen)
-    @test_throws UndefKeywordError(:dims) sort(collect(gen))
-    @test_throws UndefKeywordError(:dims) sort!(collect(gen))
-
-    @test_throws ArgumentError sort("string")
-    @test_throws ArgumentError("1 cannot be sorted") sort(1)
 end
 
 @testset "sort!(::AbstractVector{<:Integer}) with short int range" begin


### PR DESCRIPTION
This reverts commit 84bf67c8a25d15fd9f05f85918617794bc5c154f.

Fixes https://github.com/JuliaLang/julia/issues/51977