### PR TITLE
Make `pop!(::Set{A}, ::B)` return an A, not B

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -101,8 +101,15 @@ function in!(x, s::Set)
 end
 
 push!(s::Set, x) = (s.dict[x] = nothing; s)
-pop!(s::Set, x) = (pop!(s.dict, x); x)
+
 pop!(s::Set, x, default) = (x in s ? pop!(s, x) : default)
+function pop!(s::Set, x)
+    index = ht_keyindex(s.dict, x)
+    index < 1 && throw(KeyError(x))
+    result = @inbounds s.dict.keys[index]
+    _delete!(s.dict, index)
+    result
+end
 
 function pop!(s::Set)
     isempty(s) && throw(ArgumentError("set must be non-empty"))

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -124,6 +124,14 @@ end
     @test isempty(s)
     @test_throws ArgumentError pop!(s)
     @test length(Set(['x',120])) == 2
+
+    # Test that pop! returns the element in the set, not the query
+    s = Set{Any}(Any[0x01, UInt(2), 3, 4.0])
+    @test pop!(s, 1) === 0x01
+    @test pop!(s, 2) === UInt(2)
+    @test pop!(s, 3) === 3
+    @test pop!(s, 4) === 4.0
+    @test_throws KeyError pop!(s, 5)
 end
 @testset "copy" begin
     data_in = (1,2,9,8,4)


### PR DESCRIPTION
Previously, `pop!(::Set, x)` returned `x`, not the element in the set.This matters if multiple different elements are equal and hash to the same.

I believe this might have been an oversight. It was not tested for, and it makes most sense to me that `pop!` returns the element actually in the set.


Before:
```julia
julia> pop!(Set([1]), 0x01)
0x01
```
Now:
```julia
julia> pop!(Set([1]), 0x01)
1
```