### PR TITLE
fix Unicode.julia_chartransform for Julia 1.10

### DIFF
--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -179,6 +179,7 @@ const _julia_charmap = Dict{UInt32,UInt32}(
     0x00B7 => 0x22C5,
     0x0387 => 0x22C5,
     0x2212 => 0x002D,
+    0x210F => 0x0127,
 )
 
 utf8proc_map(s::AbstractString, flags::Integer, chartransform=identity) = utf8proc_map(String(s), flags, chartransform)

--- a/stdlib/Unicode/test/runtests.jl
+++ b/stdlib/Unicode/test/runtests.jl
@@ -27,8 +27,8 @@ using Unicode: normalize, isassigned, julia_chartransform
     @test normalize("\u0072\u0307\u0323", :NFC) == "\u1E5B\u0307" #26917
 
     # julia_chartransform identifier normalization
-    @test normalize("julia\u025B\u00B5\u00B7\u0387\u2212", chartransform=julia_chartransform) ==
-        "julia\u03B5\u03BC\u22C5\u22C5\u002D"
+    @test normalize("julia\u025B\u00B5\u00B7\u0387\u2212\u210F", chartransform=julia_chartransform) ==
+        "julia\u03B5\u03BC\u22C5\u22C5\u002D\u0127"
     @test julia_chartransform('\u00B5') === '\u03BC'
 end
 


### PR DESCRIPTION
#49559 by @JeffBezanson updated `src/flisp/julia_charmap.h` but missed [the comment](https://github.com/JuliaLang/julia/blob/164969f3d06919b073f3aa9ee608e40974ca82d9/src/flisp/julia_charmap.h#L5-L6) noting that `base/strings/unicode.jl` has to be updated accordingly.