### PR TITLE
Document that `lt` must return a `Bool`

### DIFF
--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -111,7 +111,7 @@ ReverseOrdering(by::By) = By(by.by, ReverseOrdering(by.order))
 ReverseOrdering(perm::Perm) = Perm(ReverseOrdering(perm.order), perm.data)
 
 """
-    lt(o::Ordering, a, b)
+    lt(o::Ordering, a, b) -> Bool
 
 Test whether `a` is less than `b` according to the ordering `o`.
 """


### PR DESCRIPTION
A tiny change that does not significantly increase verbosity.

We already do `::Bool` checks in sort.jl