### PR TITLE
bugfix: load jl_n_threads in jl_gc_pool_live_bytes

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -3181,9 +3181,11 @@ JL_DLLEXPORT int64_t jl_gc_sync_total_bytes(int64_t offset) JL_NOTSAFEPOINT
 
 JL_DLLEXPORT int64_t jl_gc_pool_live_bytes(void)
 {
+    int n_threads = jl_atomic_load_acquire(&jl_n_threads);
+    jl_ptls_t *all_tls_states = jl_atomic_load_relaxed(&jl_all_tls_states);
     int64_t pool_live_bytes = 0;
-    for (int i = 0; i < gc_n_threads; i++) {
-        jl_ptls_t ptls2 = gc_all_tls_states[i];
+    for (int i = 0; i < n_threads; i++) {
+        jl_ptls_t ptls2 = all_tls_states[i];
         if (ptls2 != NULL) {
             pool_live_bytes += jl_atomic_load_relaxed(&ptls2->gc_num.pool_live_bytes);
         }


### PR DESCRIPTION
Otherwise we may just observe `gc_n_threads = 0` (`jl_gc_collect` sets it to 0 in the very end of its body) and this function becomes a no-op.