### PR TITLE
add a `Base.tail` method for nonempty tuples

### DIFF
--- a/base/ntuple.jl
+++ b/base/ntuple.jl
@@ -88,3 +88,10 @@ end
         (t..., fill(val, N-M)...)
     end
 end
+
+function tail(x::Tuple{Any,Vararg{Any,n}}) where {n}
+    f = let x = x
+        i -> x[i + 1]
+    end
+    ntuple(f, Val(n))::NTuple{n,Any}
+end


### PR DESCRIPTION
I have some code that sorts tuples using recursion. When the tuple length gets big (over around 65), suddenly I get lots of allocations in my code, when there should be none. Using `@profview_allocs` shows that the allocations happen in `Base.tail`. This simple implementation fixes that.