### PR TITLE
Rewrite sortslices from scratch and add inference tests

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1885,7 +1885,7 @@ julia> sortslices(reshape([5; 4; 3; 2; 1], (1,1,5)), dims=3, by=x->x[1,1])
 function sortslices(A::AbstractArray; dims::Union{Integer, Tuple{Vararg{Integer}}}, kws...)
     if A isa Matrix && dims isa Integer && dims == 1
         # TODO: remove once the generic version becomes as fast or faster
-        perm = sortperm(eachslice(A, dims); kws...)
+        perm = sortperm(eachslice(A; dims); kws...)
         return A[perm, :]
     end
 

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1885,7 +1885,7 @@ julia> sortslices(reshape([5; 4; 3; 2; 1], (1,1,5)), dims=3, by=x->x[1,1])
 function sortslices(A::AbstractArray; dims::Union{Integer, Tuple{Vararg{Integer}}}, kws...)
     if A isa Matrix && dims isa Integer && dims == 1
         # TODO: remove once the generic version becomes as fast or faster
-        perm = sortperm(eachslice(A, 1); kws...)
+        perm = sortperm(eachslice(A, dims); kws...)
         return A[perm, :]
     end
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1446,6 +1446,15 @@ end
     @test sortslices(B, dims=(1,3)) == B
 end
 
+@testset "sortslices inference (#52019)" begin
+    x = rand(3, 2)
+    @inferred sortslices(x, dims=1)
+    @inferred sortslices(x, dims=(2,))
+    x = rand(1, 2, 3)
+    @inferred sortslices(x, dims=(1,2))
+    @inferred sortslices(x, dims=3, by=sum)
+end
+
 @testset "fill" begin
     @test fill!(Float64[1.0], -0.0)[1] === -0.0
     A = fill(1.,3,3)


### PR DESCRIPTION
My emotional response to the implementation and API design...
- `sortslices` On master: Eeeewww!!
- `sortslices` On with PR: Eew.

Observe the notable improvement :)

It still includes dynamic dispatch. It's still not particularly nice to the compiler, it's still significantly less efficient than it theoretically could be, and its handling of sorting multiple dimensions by `vec`ing them is still inconsistent with `sort`. But at least it's shorter, simpler, and faster than it was before and its return type inferrs all the time.

Motivating benchmarks:
```julia
function my_sortslices(A::AbstractArray; dims::Union{Integer, Tuple{Vararg{Integer}}}, kws...)

    if A isa Matrix && dims isa Integer && dims == 1
        # TODO: remove once the generic version becomes as fast or faster
        perm = sortperm(eachslice(A; dims); kws...)
        return A[perm, :]
    end

    B = similar(A)
    _my_sortslices!(B, A, Val{dims}(); kws...)
    B
end

function _my_sortslices!(B, A, ::Val{dims}; kws...) where dims
    ves = vec(eachslice(A; dims))
    perm = sortperm(ves; kws...)
    bes = eachslice(B; dims)

    # TODO for further optimization: traverse in memory order
    for (slice, i) in zip(eachslice(B; dims), perm)
        slice .= ves[i]
    end
end

using BenchmarkTools, Random, Test
for x in [Array(reshape(randperm(25), 5, 5)),
          Array(reshape(randperm(27), 3, 3, 3)),
          Array(reshape(randperm(40000), 200, 200)),
          Array(reshape(randperm(27000), 30, 30, 30)),
    ]
    for dims in ((ndims(x) == 2) ? [1, 2] : [(1,2), (2,1), (1,3), (3,1), (2,3), (3,2)])
        println((size(x), dims))
        sortslices(x; dims) == my_sortslices(x; dims) || error("Bad sort")
        @inferred my_sortslices(x; dims)
        ln = round(Int, cbrt(length(x)))
        @btime sortslices($x; dims=$dims) evals=400÷ln samples=4000÷ln gctrial=false
        @btime my_sortslices($x; dims=$dims) evals=400÷ln samples=4000÷ln gctrial=false
    end
end
```

Results
```
((5, 5), 1)
  399.436 ns (17 allocations: 1.05 KiB)
  209.902 ns (4 allocations: 368 bytes)
((5, 5), 2)
  415.414 ns (17 allocations: 1.05 KiB)
  167.602 ns (4 allocations: 368 bytes)
((3, 3, 3), (1, 2))
  536.030 ns (17 allocations: 1.59 KiB)
  338.030 ns (5 allocations: 448 bytes)
((3, 3, 3), (2, 1))
  544.173 ns (17 allocations: 1.59 KiB)
  336.466 ns (5 allocations: 448 bytes)
((3, 3, 3), (1, 3))
  531.015 ns (17 allocations: 1.59 KiB)
  314.226 ns (5 allocations: 448 bytes)
((3, 3, 3), (3, 1))
  533.211 ns (17 allocations: 1.59 KiB)
  332.707 ns (5 allocations: 448 bytes)
((3, 3, 3), (2, 3))
  565.474 ns (17 allocations: 1.59 KiB)
  342.737 ns (5 allocations: 448 bytes)
((3, 3, 3), (3, 2))
  562.654 ns (17 allocations: 1.59 KiB)
  327.692 ns (5 allocations: 448 bytes)
((200, 200), 1)
  35.928 μs (21 allocations: 327.20 KiB)
  35.830 μs (7 allocations: 315.83 KiB)
((200, 200), 2)
  30.587 μs (21 allocations: 327.20 KiB)
  15.220 μs (7 allocations: 315.83 KiB)
((30, 30, 30), (1, 2))
  66.776 μs (25 allocations: 296.03 KiB)
  72.465 μs (10 allocations: 225.30 KiB)
((30, 30, 30), (2, 1))
  67.170 μs (25 allocations: 296.03 KiB)
  71.353 μs (10 allocations: 225.30 KiB)
((30, 30, 30), (1, 3))
  59.019 μs (25 allocations: 296.03 KiB)
  64.070 μs (10 allocations: 225.30 KiB)
((30, 30, 30), (3, 1))
  70.413 μs (25 allocations: 296.03 KiB)
  70.667 μs (10 allocations: 225.30 KiB)
((30, 30, 30), (2, 3))
  58.744 μs (25 allocations: 296.03 KiB)
  55.760 μs (10 allocations: 225.30 KiB)
((30, 30, 30), (3, 2))
  62.343 μs (25 allocations: 296.03 KiB)
  62.279 μs (10 allocations: 225.30 KiB)
```

There's still a lot of room for possible runtime improvement by traversing the arrays in memory order during the copy step, but that is for another PR (if ever).

Fixes #52019

A net negative LOC PR.