### PR TITLE
bugfix: don't set pool_live_bytes to zero at the end of GC

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1189,8 +1189,14 @@ static void reset_thread_gc_counts(void) JL_NOTSAFEPOINT
     for (int i = 0; i < gc_n_threads; i++) {
         jl_ptls_t ptls = gc_all_tls_states[i];
         if (ptls != NULL) {
-            memset(&ptls->gc_num, 0, sizeof(ptls->gc_num));
+            // don't reset `pool_live_bytes` here
             jl_atomic_store_relaxed(&ptls->gc_num.allocd, -(int64_t)gc_num.interval);
+            jl_atomic_store_relaxed(&ptls->gc_num.malloc, 0);
+            jl_atomic_store_relaxed(&ptls->gc_num.realloc, 0);
+            jl_atomic_store_relaxed(&ptls->gc_num.poolalloc, 0);
+            jl_atomic_store_relaxed(&ptls->gc_num.bigalloc, 0);
+            jl_atomic_store_relaxed(&ptls->gc_num.alloc_acc, 0);
+            jl_atomic_store_relaxed(&ptls->gc_num.free_acc, 0);
         }
     }
 }


### PR DESCRIPTION
Sanity-checked this on a micro-benchmark (as I should have done two PRs ago) and seems to work now:

```Julia
using Printf

mutable struct ListNode
  key::Int64
  next::ListNode
  ListNode() = new()
  ListNode(x)= new(x)
  ListNode(x,y) = new(x,y);
end

function list(n=128)
    start::ListNode = ListNode(1)
    current::ListNode = start
    for i = 2:(n*1024^2)
        current = ListNode(i,current)
    end
    @printf "%d\n" @ccall jl_gc_pool_live_bytes()::Int64
    return current.key
end

@time list()
```

```
4329322656
  3.560094 seconds (134.31 M allocations: 4.005 GiB, 81.34% gc time, 0.88% compilation time)
```