### PR TITLE
Update `complex` docstring with `Missing`

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -178,7 +178,7 @@ complex(x::Real, y::Real) = Complex(x, y)
     complex(T::Type)
 
 Return an appropriate type which can represent a value of type `T` as a complex number.
-Equivalent to `typeof(complex(zero(T)))`.
+Equivalent to `typeof(complex(zero(T)))` if `T` does not contain `Missing`.
 
 # Examples
 ```jldoctest
@@ -187,6 +187,9 @@ Complex{Int64}
 
 julia> complex(Int)
 Complex{Int64}
+
+julia> complex(Union{Int, Missing})
+Union{Missing, Complex{Int64}}
 ```
 """
 complex(::Type{T}) where {T<:Real} = Complex{T}


### PR DESCRIPTION
The docstring of `complex(T::Type)` is a bit incorrect if `T` contains `Missing`.

```julia
julia> T = Union{Int, Missing}
Union{Missing, Int64}

julia> complex(T)
Union{Missing, Complex{Int64}}

julia> typeof(complex(zero(T)))
Complex{Int64}
```