### PR TITLE
make sigaltstack failure nonfatal and clean up on thread return

### DIFF
--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -208,7 +208,10 @@ void sweep_stack_pools(void)
         for (int p = 0; p < JL_N_STACK_POOLS; p++) {
             small_arraylist_t *al = &ptls2->heap.free_stacks[p];
             size_t n_to_free;
-            if (al->len > MIN_STACK_MAPPINGS_PER_POOL) {
+            if (ptls2->current_task == NULL) {
+                n_to_free = al->len; // not alive yet or dead, so it does not need these anymore
+            }
+            else if (al->len > MIN_STACK_MAPPINGS_PER_POOL) {
                 n_to_free = al->len / 2;
                 if (n_to_free > (al->len - MIN_STACK_MAPPINGS_PER_POOL))
                     n_to_free = al->len - MIN_STACK_MAPPINGS_PER_POOL;

--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -208,7 +208,7 @@ void sweep_stack_pools(void)
         for (int p = 0; p < JL_N_STACK_POOLS; p++) {
             small_arraylist_t *al = &ptls2->heap.free_stacks[p];
             size_t n_to_free;
-            if (ptls2->current_task == NULL) {
+            if (jl_atomic_load_relaxed(&ptls2->current_task) == NULL) {
                 n_to_free = al->len; // not alive yet or dead, so it does not need these anymore
             }
             else if (al->len > MIN_STACK_MAPPINGS_PER_POOL) {

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -263,6 +263,7 @@ typedef struct _jl_tls_states_t {
     int needs_resetstkoflw;
 #else
     void *signal_stack;
+    size_t signal_stack_size;
 #endif
     jl_thread_t system_id;
     _Atomic(int16_t) suspend_count;

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -463,9 +463,9 @@ void jl_critical_error(int sig, int si_code, bt_context_t *context, jl_task_t *c
         pthread_sigmask(SIG_UNBLOCK, &sset, NULL);
 #endif
         if (si_code)
-            jl_safe_printf("\n[%d] signal (%d.%d): %s\n", getpid(), sig, si_code, strsignal(sig));
+            jl_safe_printf("\n[%d] signal %d (%d): %s\n", getpid(), sig, si_code, strsignal(sig));
         else
-            jl_safe_printf("\n[%d] signal (%d): %s\n", getpid(), sig, strsignal(sig));
+            jl_safe_printf("\n[%d] signal %d: %s\n", getpid(), sig, strsignal(sig));
     }
     jl_safe_printf("in expression starting at %s:%d\n", jl_filename, jl_lineno);
     if (context && ct) {

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -213,13 +213,14 @@ static void jl_call_in_state(jl_ptls_t ptls2, host_thread_state_t *state,
 #else
 #error "julia: throw-in-context not supported on this platform"
 #endif
-    if (ptls2 == NULL || ptls2->signal_stack == NULL || is_addr_on_sigstack(ptls2, (void*)rsp)) {
+    if (ptls2 == NULL || is_addr_on_sigstack(ptls2, (void*)rsp)) {
         rsp = (rsp - 256) & ~(uintptr_t)15; // redzone and re-alignment
     }
     else {
-        rsp = (uintptr_t)ptls2->signal_stack + sig_stack_size;
+        rsp = (uintptr_t)ptls2->signal_stack + (ptls2->signal_stack_size ? ptls2->signal_stack_size : sig_stack_size);
     }
     assert(rsp % 16 == 0);
+    rsp -= 16;
 
 #ifdef _CPU_X86_64_
     rsp -= sizeof(void*);

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -657,9 +657,9 @@ void jl_install_thread_signal_handler(jl_ptls_t ptls)
         signal_stack = malloc(ssize);
         ssize = 0;
         if (signal_stack == NULL)
-            jl_safe_printf("warning: julia signal alt stack could not be allocated (StackOverflowError will be fatal on this thread)");
+            jl_safe_printf("\nwarning: julia signal alt stack could not be allocated (StackOverflowError will be fatal on this thread).\n");
         else
-            jl_safe_printf("warning: julia signal stack allocated without guard page (launch foreign threads earlier to avoid this warning)");
+            jl_safe_printf("\nwarning: julia signal stack allocated without guard page (launch foreign threads earlier to avoid this warning).\n");
     }
     if (signal_stack != NULL) {
         ss.ss_sp = signal_stack;

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -35,10 +35,8 @@
 #include <sys/event.h>
 #endif
 
-// 8M signal stack, same as default stack size and enough
-// for reasonable finalizers.
-// Should also be enough for parallel GC when we have it =)
-#define sig_stack_size (8 * 1024 * 1024)
+// 8M signal stack, same as default stack size (though we barely use this)
+static const size_t sig_stack_size = 8 * 1024 * 1024;
 
 #include "julia_assert.h"
 
@@ -94,8 +92,9 @@ static inline __attribute__((unused)) uintptr_t jl_get_rsp_from_ctx(const void *
 static int is_addr_on_sigstack(jl_ptls_t ptls, void *ptr)
 {
     // One guard page for signal_stack.
-    return !((char*)ptr < (char*)ptls->signal_stack - jl_page_size ||
-             (char*)ptr > (char*)ptls->signal_stack + sig_stack_size);
+    return ptls->signal_stack == NULL ||
+           ((char*)ptr >= (char*)ptls->signal_stack - jl_page_size &&
+            (char*)ptr <= (char*)ptls->signal_stack + (ptls->signal_stack_size ? ptls->signal_stack_size : sig_stack_size));
 }
 
 // Modify signal context `_ctx` so that `fptr` will execute when the signal
@@ -111,7 +110,7 @@ JL_NO_ASAN static void jl_call_in_ctx(jl_ptls_t ptls, void (*fptr)(void), int si
     // checks that the syscall is made in the signal handler and that
     // the ucontext address is valid. Hopefully the value of the ucontext
     // will not be part of the validation...
-    if (!ptls || !ptls->signal_stack) {
+    if (!ptls) {
         sigset_t sset;
         sigemptyset(&sset);
         sigaddset(&sset, sig);
@@ -120,13 +119,12 @@ JL_NO_ASAN static void jl_call_in_ctx(jl_ptls_t ptls, void (*fptr)(void), int si
         return;
     }
     uintptr_t rsp = jl_get_rsp_from_ctx(_ctx);
-    if (is_addr_on_sigstack(ptls, (void*)rsp)) {
+    if (is_addr_on_sigstack(ptls, (void*)rsp))
         rsp = (rsp - 256) & ~(uintptr_t)15; // redzone and re-alignment
-    }
-    else {
-        rsp = (uintptr_t)ptls->signal_stack + sig_stack_size;
-    }
+    else
+        rsp = (uintptr_t)ptls->signal_stack + (ptls->signal_stack_size ? ptls->signal_stack_size : sig_stack_size);
     assert(rsp % 16 == 0);
+    rsp -= 16;
 #if defined(_OS_LINUX_) && defined(_CPU_X86_64_)
     ucontext_t *ctx = (ucontext_t*)_ctx;
     rsp -= sizeof(void*);
@@ -229,7 +227,10 @@ static void sigdie_handler(int sig, siginfo_t *info, void *context)
     uv_tty_reset_mode();
     if (sig == SIGILL)
         jl_show_sigill(context);
-    jl_critical_error(sig, info->si_code, jl_to_bt_context(context), jl_get_current_task());
+    jl_task_t *ct = jl_get_current_task();
+    jl_critical_error(sig, info->si_code, jl_to_bt_context(context), ct);
+    if (ct)
+        jl_atomic_store_relaxed(&ct->ptls->safepoint, (size_t*)NULL + 1);
     if (info->si_code == 0 ||
         info->si_code == SI_USER ||
 #ifdef SI_KERNEL
@@ -252,7 +253,8 @@ static void sigdie_handler(int sig, siginfo_t *info, void *context)
              sig != SIGFPE &&
              sig != SIGTRAP)
         raise(sig);
-    // fall-through return to re-execute faulting statement (but without the error handler)
+    // fall-through return to re-execute faulting statement (but without the
+    // error handler and the pgcstack having been destroyed)
 }
 
 #if defined(_CPU_X86_64_) || defined(_CPU_X86_)
@@ -343,7 +345,8 @@ int is_write_fault(void *context) {
 
 static int jl_is_on_sigstack(jl_ptls_t ptls, void *ptr, void *context)
 {
-    return (is_addr_on_sigstack(ptls, ptr) &&
+    return (ptls->signal_stack != NULL &&
+            is_addr_on_sigstack(ptls, ptr) &&
             is_addr_on_sigstack(ptls, (void*)jl_get_rsp_from_ctx(context)));
 }
 
@@ -635,30 +638,36 @@ static void allocate_segv_handler(void)
     }
 }
 
-static void *alloc_sigstack(size_t *ssize)
-{
-    void *stk = jl_malloc_stack(ssize, NULL);
-    if (stk == NULL)
-        jl_errorf("fatal error allocating signal stack: mmap: %s", strerror(errno));
-    return stk;
-}
-
 void jl_install_thread_signal_handler(jl_ptls_t ptls)
 {
-    size_t ssize = sig_stack_size;
-    void *signal_stack = alloc_sigstack(&ssize);
-    ptls->signal_stack = signal_stack;
-    stack_t ss;
-    ss.ss_flags = 0;
-    ss.ss_size = ssize - 16;
-    ss.ss_sp = signal_stack;
-    if (sigaltstack(&ss, NULL) < 0) {
-        jl_errorf("fatal error: sigaltstack: %s", strerror(errno));
-    }
-
 #ifdef HAVE_MACH
     attach_exception_port(pthread_mach_thread_np(ptls->system_id), 0);
 #endif
+    stack_t ss;
+    if (sigaltstack(NULL, &ss) < 0)
+        jl_errorf("fatal error: sigaltstack: %s", strerror(errno));
+    if ((ss.ss_flags & SS_DISABLE) != SS_DISABLE)
+        return; // someone else appears to have already set this up, so just use that
+    size_t ssize = sig_stack_size;
+    void *signal_stack = jl_malloc_stack(&ssize, NULL);
+    ss.ss_flags = 0;
+    ss.ss_size = ssize;
+    assert(ssize != 0);
+    if (signal_stack == NULL) {
+        signal_stack = malloc(ssize);
+        ssize = 0;
+        if (signal_stack == NULL)
+            jl_safe_printf("warning: julia signal alt stack could not be allocated (StackOverflowError will be fatal on this thread)");
+        else
+            jl_safe_printf("warning: julia signal stack allocated without guard page (launch foreign threads earlier to avoid this warning)");
+    }
+    if (signal_stack != NULL) {
+        ss.ss_sp = signal_stack;
+        if (sigaltstack(&ss, NULL) < 0)
+            jl_errorf("fatal error: sigaltstack: %s", strerror(errno));
+        ptls->signal_stack = signal_stack;
+        ptls->signal_stack_size = ssize;
+    }
 }
 
 const static int sigwait_sigs[] = {
@@ -1029,7 +1038,7 @@ void jl_install_default_signal_handlers(void)
     memset(&actf, 0, sizeof(struct sigaction));
     sigemptyset(&actf.sa_mask);
     actf.sa_sigaction = fpe_handler;
-    actf.sa_flags = SA_ONSTACK | SA_SIGINFO;
+    actf.sa_flags = SA_SIGINFO;
     if (sigaction(SIGFPE, &actf, NULL) < 0) {
         jl_errorf("fatal error: sigaction: %s", strerror(errno));
     }
@@ -1038,7 +1047,7 @@ void jl_install_default_signal_handlers(void)
     memset(&acttrap, 0, sizeof(struct sigaction));
     sigemptyset(&acttrap.sa_mask);
     acttrap.sa_sigaction = sigtrap_handler;
-    acttrap.sa_flags = SA_ONSTACK | SA_SIGINFO;
+    acttrap.sa_flags = SA_SIGINFO;
     if (sigaction(SIGTRAP, &acttrap, NULL) < 0) {
         jl_errorf("fatal error: sigaction: %s", strerror(errno));
     }

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -4,7 +4,7 @@
 // Note that this file is `#include`d by "signal-handling.c"
 #include <mmsystem.h> // hidden by LEAN_AND_MEAN
 
-#define sig_stack_size 131072 // 128k reserved for SEGV handling
+static const size_t sig_stack_size = 131072; // 128k reserved for backtrace_fiber for stack overflow handling
 
 // Copied from MINGW_FLOAT_H which may not be found due to a collision with the builtin gcc float.h
 // eventually we can probably integrate this into OpenLibm.

--- a/src/threading.c
+++ b/src/threading.c
@@ -447,6 +447,30 @@ static void jl_delete_thread(void *value) JL_NOTSAFEPOINT_ENTER
     jl_atomic_store_relaxed(&ptls->sleep_check_state, 2); // dead, interpreted as sleeping and unwakeable
     jl_fence();
     jl_wakeup_thread(0); // force thread 0 to see that we do not have the IO lock (and am dead)
+    // try to free some state we do not need anymore
+#ifndef _OS_WINDOWS_
+    void *signal_stack = ptls->signal_stack;
+    size_t signal_stack_size = ptls->signal_stack_size;
+    if (signal_stack != NULL) {
+        stack_t ss;
+        if (sigaltstack(NULL, &ss))
+            jl_errorf("fatal error: sigaltstack: %s", strerror(errno));
+        if (ss.ss_sp == signal_stack) {
+            ss.ss_flags = SS_DISABLE;
+            if (sigaltstack(&ss, NULL) != 0) {
+                jl_errorf("warning: sigaltstack: %s (will leak this memory)", strerror(errno));
+                signal_stack = NULL;
+            }
+        }
+        if (signal_stack != NULL) {
+            if (signal_stack_size)
+                jl_free_stack(signal_stack, signal_stack_size);
+            else
+                free(signal_stack);
+        }
+        ptls->signal_stack = NULL;
+    }
+#endif
     // Acquire the profile write lock, to ensure we are not racing with the `kill`
     // call in the profile code which will also try to look at this thread.
     // We have no control over when the user calls pthread_join, so we must do


### PR DESCRIPTION
Since we already could handle recursion onto the altstack, we can also handle recursion onto the main stack as well (at the cost of losing the ability to handle stackoverflow when this allocation fails). In the future, on mach, we could consider just using a single stack for handling stackoverflow and use a `_resetstkoflw`-like and/or `collect_backtrace_fiber`-like mechanism (like Windows) to pass it from one thread to the next that sequentially needs to use it.


Closes #50786