### PR TITLE
inference: remove the `must_be_codeinf` setting

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -227,7 +227,7 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState)
         store_backedges(result, caller.stmt_edges[1])
     end
     opt = result.src
-    if opt isa OptimizationState && result.must_be_codeinf
+    if opt isa OptimizationState
         result.src = opt = ir_to_codeinf!(opt)
     end
     if opt isa CodeInfo
@@ -235,9 +235,9 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState)
         opt.max_world = last(valid_worlds)
         caller.src = opt
     else
-        # In this case caller.src is invalid for clients (such as typeinf_ext) to use
-        # but that is what !must_be_codeinf permits
-        # This is hopefully unreachable when must_be_codeinf is true
+        # In this case `caller.src` is invalid for clients (such as `typeinf_ext`) to use
+        # but that is what's permitted by `caller.cache_mode`.
+        # This is hopefully unreachable from such clients using `NativeInterpreter`.
     end
     return nothing
 end

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -76,13 +76,12 @@ mutable struct InferenceResult
     ipo_effects::Effects     # if inference is finished
     effects::Effects         # if optimization is finished
     argescapes               # ::ArgEscapeCache if optimized, nothing otherwise
-    must_be_codeinf::Bool    # if this must come out as CodeInfo or leaving it as IRCode is ok
     function InferenceResult(linfo::MethodInstance, cache_argtypes::Vector{Any}, overridden_by_const::BitVector)
         # def = linfo.def
         # nargs = def isa Method ? Int(def.nargs) : 0
         # @assert length(cache_argtypes) == nargs
         return new(linfo, cache_argtypes, overridden_by_const, nothing, nothing,
-            WorldRange(), Effects(), Effects(), nothing, true)
+            WorldRange(), Effects(), Effects(), nothing)
     end
 end
 InferenceResult(linfo::MethodInstance, 𝕃::AbstractLattice=fallback_lattice) =


### PR DESCRIPTION
This setting is no longer utilized in either the base or known external compiler pipelines. And what allowed by setting `must_be_codeinf = false` can now be achieved using the `cache_mode::UInt8` field, making the setting redundant.