### PR TITLE
allow destructive inlining only when the source is volatile

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -884,7 +884,7 @@ function resolve_todo(mi::MethodInstance, result::Union{Nothing,InferenceResult,
     elseif isa(result, VolatileInferenceResult)
         inferred_result = get_local_result(result.inf_result)
         # volatile inference result can be inlined destructively
-        preserve_local_sources = OptimizationParams(state.interp).preserve_local_sources
+        preserve_local_sources = !result.inf_result.is_src_volatile | OptimizationParams(state.interp).preserve_local_sources
     else
         inferred_result = get_cached_result(state, mi)
     end

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -361,7 +361,9 @@ function transform_result_for_cache(interp::AbstractInterpreter,
     linfo::MethodInstance, valid_worlds::WorldRange, result::InferenceResult)
     inferred_result = result.src
     if inferred_result isa CodeInfo
+        uncompressed = inferred_result
         inferred_result = maybe_compress_codeinfo(interp, linfo, inferred_result)
+        result.is_src_volatile |= uncompressed !== inferred_result
     end
     # The global cache can only handle objects that codegen understands
     if !isa(inferred_result, MaybeCompressed)

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -76,12 +76,13 @@ mutable struct InferenceResult
     ipo_effects::Effects     # if inference is finished
     effects::Effects         # if optimization is finished
     argescapes               # ::ArgEscapeCache if optimized, nothing otherwise
+    is_src_volatile::Bool    # `src` has been cached globally as the compressed format already, allowing `src` to be used destructively
     function InferenceResult(linfo::MethodInstance, cache_argtypes::Vector{Any}, overridden_by_const::BitVector)
         # def = linfo.def
         # nargs = def isa Method ? Int(def.nargs) : 0
         # @assert length(cache_argtypes) == nargs
         return new(linfo, cache_argtypes, overridden_by_const, nothing, nothing,
-            WorldRange(), Effects(), Effects(), nothing)
+            WorldRange(), Effects(), Effects(), nothing, false)
     end
 end
 InferenceResult(linfo::MethodInstance, 𝕃::AbstractLattice=fallback_lattice) =


### PR DESCRIPTION
Destructive inlining introduced by JuliaLang/julia#51934 implicitly presupposes that inferred `CodeInfo` source has been compressed to the `String` format when cached, which is not generally true for external `AbstractInterpreter`s that may disable the `may_compress` and/or `may_discard_trees` settings. This commit adds a safeguard to ensure the eligibility of such `CodeInfo` source propagated by `VolatileInferenceResult` for destructive inlining.

@nanosoldier `runbenchmarks("inference", vs=":master")`