### PR TITLE
effects: improve idempotency of effects derived by post-opt analysis

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1393,8 +1393,7 @@ function compute_inlining_cases(@nospecialize(info::CallInfo), flag::UInt32, sig
     cases = InliningCase[]
     argtypes = sig.argtypes
     local handled_all_cases::Bool = true
-    local revisit_idx = nothing
-    local only_method = nothing
+    local revisit_idx = local only_method = nothing
     local meth::MethodLookupResult
     local all_result_count = 0
     local joint_effects::Effects = EFFECTS_TOTAL
@@ -1410,14 +1409,14 @@ function compute_inlining_cases(@nospecialize(info::CallInfo), flag::UInt32, sig
             handled_all_cases = false
             continue
         else
-            if length(meth) == 1 && only_method !== false
+            if length(meth) == 1 && only_method !== missing
                 if only_method === nothing
                     only_method = meth[1].method
                 elseif only_method !== meth[1].method
-                    only_method = false
+                    only_method = missing
                 end
             else
-                only_method = false
+                only_method = missing
             end
         end
         local split_fully_covered::Bool = false

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -537,7 +537,7 @@ function finish(me::InferenceState, interp::AbstractInterpreter)
     end
     me.result.valid_worlds = me.valid_worlds
     me.result.result = bestguess
-    me.ipo_effects = me.result.ipo_effects = adjust_effects(me)
+    me.result.ipo_effects = me.ipo_effects = adjust_effects(me)
 
     if limited_ret
         # a parent may be cached still, but not this intermediate work:
@@ -856,7 +856,7 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
         update_valid_age!(caller, frame.valid_worlds)
         isinferred = is_inferred(frame)
         edge = isinferred ? mi : nothing
-        effects = isinferred ? frame.ipo_effects : adjust_effects(Effects(), method) # effects are adjusted already within `finish` for ipo_effects
+        effects = isinferred ? frame.result.ipo_effects : adjust_effects(Effects(), method) # effects are adjusted already within `finish` for ipo_effects
         # propagate newly inferred source to the inliner, allowing efficient inlining w/o deserialization:
         # note that this result is cached globally exclusively, we can use this local result destructively
         volatile_inf_result = isinferred && let inferred_src = result.src

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -138,7 +138,7 @@ end
       Core.Compiler.limit_type_size(Type{Any}, Type, Union{}, 0, 0) ==
       Type{Any}
 
-# issue #43296 #43296
+# issue #43296
 struct C43296{t,I} end
 r43296(b) = r43296(typeof(b))
 r43296(::Type) = nothing
@@ -149,7 +149,8 @@ f43296(g, :) = h
 k43296(b, j, :) = l
 k43296(b, j, ::Nothing) = b
 i43296(b, j) = k43296(b, j, r43296(j))
-@test only(Base.return_types(i43296, (Int, C43296{C43296{C43296{Val, Tuple}, Tuple}}))) == Int
+@test only(Base.return_types(i43296, (Int, C43296{C43296{C43296{Val, Tuple}}}))) <: Int
+@test only(Base.return_types(i43296, (Int, C43296{C43296{C43296{Val, <:Tuple}}}))) <: Int
 
 abstract type e43296{a, j} <: AbstractArray{a, j} end
 abstract type b43296{a, j, c, d} <: e43296{a, j} end


### PR DESCRIPTION
Since now effects can be refined by post-opt analysis, `typeinf_edge` should propagate `frame.result.ipo_effects` instead of `frame.ipo_effects`.