### PR TITLE
fix sorting for iterables that define copymutable

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1500,7 +1500,7 @@ function sort(v; kws...)
     size = IteratorSize(v)
     size == HasShape{0}() && throw(ArgumentError("$v cannot be sorted"))
     size == IsInfinite() && throw(ArgumentError("infinite iterator $v cannot be sorted"))
-    sort!(copymutable(v); kws...)
+    sort!(collect(v); kws...)
 end
 sort(v::AbstractVector; kws...) = sort!(copymutable(v); kws...) # for method disambiguation
 sort(::AbstractString; kws...) =
@@ -1512,7 +1512,7 @@ function sort(x::NTuple{N}; lt::Function=isless, by::Function=identity,
               rev::Union{Bool,Nothing}=nothing, order::Ordering=Forward) where N
     o = ord(lt,by,rev,order)
     if N > 9
-        v = sort!(copymutable(x), DEFAULT_STABLE, o)
+        v = sort!(collect(x), DEFAULT_STABLE, o)
         tuple((v[i] for i in 1:N)...)
     else
         _sort(x, o)

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -559,6 +559,11 @@ end
 
     @test_throws ArgumentError sort("string")
     @test_throws ArgumentError("1 cannot be sorted") sort(1)
+
+    @test sort(Set((1, 3, 6))) == [1, 3, 6]
+    @test sort(Dict((1=>9, 3=>2, 6=>5))) == [1=>9, 3=>2, 6=>5]
+    @test sort(keys(Dict((1=>2, 3=>5, 6=>9)))) == [1, 3, 6]
+    @test sort(values(Dict((1=>9, 3=>2, 6=>5)))) == [2, 5, 9]
 end
 
 @testset "sort!(::AbstractVector{<:Integer}) with short int range" begin


### PR DESCRIPTION
`copymutable` is only defined to return an array for abstract arrays, but that is only what this method is never called with. For other types, it has a default of `collect` (which means the default behavior appears to give an array), but can be changed by other types (such as AbstractSet) to do something different.

Correction to #46104