### PR TITLE
Compatible parent index when displaying dots in SubArrays

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -483,8 +483,8 @@ end
 has_offset_axes(S::SubArray) = has_offset_axes(S.indices...)
 
 function replace_in_print_matrix(S::SubArray{<:Any,2,<:AbstractMatrix}, i::Integer, j::Integer, s::AbstractString)
-    replace_in_print_matrix(S.parent, reindex(S.indices, (i,j))..., s)
+    replace_in_print_matrix(S.parent, to_indices(S.parent, reindex(S.indices, (i,j)))..., s)
 end
 function replace_in_print_matrix(S::SubArray{<:Any,1,<:AbstractVector}, i::Integer, j::Integer, s::AbstractString)
-    replace_in_print_matrix(S.parent, reindex(S.indices, (i,))..., j, s)
+    replace_in_print_matrix(S.parent, to_indices(S.parent, reindex(S.indices, (i,)))..., j, s)
 end

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -799,6 +799,9 @@ end
     end
     V = view(OneElVec(6, 2), 1:5)
     @test sprint(show, "text/plain", V) == "$(summary(V)):\n ⋅\n 1\n ⋅\n ⋅\n ⋅"
+
+    V = view(1:2, [CartesianIndex(2)])
+    @test sprint(show, "text/plain", V) == "$(summary(V)):\n 2"
 end
 
 @testset "Base.first_index for offset indices" begin


### PR DESCRIPTION
Fix #52095 by passing the `reindex`ed indices through `to_indices` to convert them to `Integer`s. This should strip `CartesianIndex`es in particular, which resolves the issue.

Fixes:
```julia
julia> view(1:2, [CartesianIndex(2)])
1-element view(::UnitRange{Int64}, CartesianIndex{1}[CartesianIndex(2,)]) with eltype Int64:
 2
```