### PR TITLE
Fix errors in `sort` docstring

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1474,7 +1474,7 @@ end
 
 Variant of [`sort!`](@ref) that returns a sorted copy of `v` leaving `v` itself unmodified.
 
-Returns something [`similar`](@ref) to `v` when `v` is an `AbstractArray` and uses 
+Returns something [`similar`](@ref) to `v` when `v` is an `AbstractArray` and uses
 [`collect`](@ref) to support arbitrary non-`AbstractArray` iterables.
 
 !!! compat "Julia 1.10"

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1474,7 +1474,8 @@ end
 
 Variant of [`sort!`](@ref) that returns a sorted copy of `v` leaving `v` itself unmodified.
 
-Uses `Base.copymutable` to support immutable collections and iterables.
+Returns something [`similar`](@ref) to `v` when `v` is an `AbstractArray` and uses 
+[`collect`](@ref) to support arbitrary non-`AbstractArray` iterables.
 
 !!! compat "Julia 1.10"
     `sort` of arbitrary iterables requires at least Julia 1.10.


### PR DESCRIPTION
Two chagnes wrapped into one `Base.copymutable` => `Base.copymutable` & `collect` and `Base.copymutable` => `similar` & words.

Followup for #52086 and #46104; also fixes #51932 (though we still may want to make `copymutable` public at some point)