### PR TITLE
Transpose elements in `copy_transpose!`

### DIFF
--- a/stdlib/LinearAlgebra/src/transpose.jl
+++ b/stdlib/LinearAlgebra/src/transpose.jl
@@ -194,7 +194,7 @@ function copy_transpose!(B::AbstractVecOrMat, ir_dest::AbstractRange{Int}, jr_de
     for jsrc in jr_src
         jdest = first(jr_dest)
         for isrc in ir_src
-            B[idest,jdest] = A[isrc,jsrc]
+            B[idest,jdest] = transpose(A[isrc,jsrc])
             jdest += step(jr_dest)
         end
         idest += step(ir_dest)

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -681,4 +681,19 @@ end
     @test sprint(Base.print_matrix, Adjoint(o)) == sprint(Base.print_matrix, OneHotVecOrMat((1,2), (1,4)))
 end
 
+@testset "copy_transpose!" begin
+    # scalar case
+    A = [randn() for _ in 1:2, _ in 1:3]
+    At = copy(transpose(A))
+    B = zero.(At)
+    LinearAlgebra.copy_transpose!(B, axes(B, 1), axes(B, 2), A, axes(A, 1), axes(A, 2))
+    @test B == At
+    # matrix of matrices
+    A = [randn(2,3) for _ in 1:2, _ in 1:3]
+    At = copy(transpose(A))
+    B = zero.(At)
+    LinearAlgebra.copy_transpose!(B, axes(B, 1), axes(B, 2), A, axes(A, 1), axes(A, 2))
+    @test B == At
+end
+
 end # module TestAdjointTranspose


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#1033

## Notes

- ~~I had a hard time coming up with a self-contained test to cover this bug, as it only happens for elements which are both `bitstype` and for which `transpose(x) != x`. Not sure how to go about it.~~ If we test `copy_transpose!` directly (and through the matrix multiplication), testing is straightforward. 
- With JuliaLang/julia#52038 this is even more of a corner case since `copy_transpose!` is no longer used in the generic matrix multiplication. Still, I thought maybe it would still be worth fixing.
