### PR TITLE
Mark the indexing as `@inbounds` in `triu!`

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -136,7 +136,7 @@ function triu!(M::AbstractMatrix, k::Integer)
     m, n = size(M)
     for j in 1:min(n, m + k)
         for i in max(1, j - k + 1):m
-            M[i,j] = zero(M[i,j])
+            @inbounds M[i,j] = zero(M[i,j])
         end
     end
     M


### PR DESCRIPTION
The corresponding line in `tril!` is also marked `@inbounds`, so I think this makes sense.

Performance difference:
```julia
julia> @btime triu!($(rand(100,100)), 0);
  1.382 μs (0 allocations: 0 bytes) # master
  629.723 ns (0 allocations: 0 bytes) # PR
```