### PR TITLE
Add `@force_compile` to `Profile.@profile` macros

### DIFF
--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -79,6 +79,7 @@ end
 
 function _prof_expr(expr, opts)
     quote
+        Base.Experimental.@force_compile
         $start(; $(esc(opts)))
         try
             $(esc(expr))

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -37,6 +37,7 @@ appended to an internal buffer of backtraces.
 macro profile(ex)
     return quote
         try
+            Base.Experimental.@force_compile
             start_timer()
             $(esc(ex))
         finally


### PR DESCRIPTION
This removes some spurious allocations you might otherwise see in the REPL and better aligns the output to match `@allocated`:

```julia
julia> using Profile

julia> Profile.Allocs.@profile sample_rate=1 sin(1.5)
0.9974949866040544

julia> length(Profile.Allocs.fetch().allocs)
0

julia> @allocated sin(1.5)
0
```

Without this change, `@profile` reports 1 allocation. Resolves #52022