### PR TITLE
Use libuv thread instead of std::thread to avoid musl issues

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1357,6 +1357,11 @@ endif
 JLIBLDFLAGS += -Wl,-z,noexecstack
 endif
 
+#musl has a really small default stack
+ifeq ($(findstring musl,$(BB_TRIPLET)),musl)
+JLDFLAGS += -Wl,-z,stack-size=1024768
+endif
+
 ifeq ($(OS), FreeBSD)
 JLDFLAGS += -Wl,-Bdynamic
 OSLIBS += -lelf -lkvm -lrt -lpthread -latomic

--- a/Make.inc
+++ b/Make.inc
@@ -1357,7 +1357,6 @@ endif
 JLIBLDFLAGS += -Wl,-z,noexecstack
 endif
 
-
 ifeq ($(OS), FreeBSD)
 JLDFLAGS += -Wl,-Bdynamic
 OSLIBS += -lelf -lkvm -lrt -lpthread -latomic

--- a/Make.inc
+++ b/Make.inc
@@ -1357,10 +1357,6 @@ endif
 JLIBLDFLAGS += -Wl,-z,noexecstack
 endif
 
-#musl has a really small default stack
-ifeq ($(findstring musl,$(BB_TRIPLET)),musl)
-JLDFLAGS += -Wl,-z,stack-size=1024768
-endif
 
 ifeq ($(OS), FreeBSD)
 JLDFLAGS += -Wl,-Bdynamic

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -1418,7 +1418,8 @@ static unsigned compute_image_thread_count(const ModuleInfo &info) {
         LLVM_DEBUG(dbgs() << "COFF is restricted to a single thread for large images\n");
         return 1;
     }
-
+    if (info.triple.isMusl())
+        return 1;
     // This is not overridable because empty modules do occasionally appear, but they'll be very small and thus exit early to
     // known easy behavior. Plus they really don't warrant multiple threads
     if (info.weight < 1000) {

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -1263,6 +1263,12 @@ static void construct_vars(Module &M, Partition &partition) {
     gidxs_var->setDSOLocal(true);
 }
 
+extern "C" void lambda_trampoline(void* arg) {
+    std::function<void()>* func = static_cast<std::function<void()>*>(arg);
+    (*func)();
+    delete func;
+}
+
 // Entrypoint to optionally-multithreaded image compilation. This handles global coordination of the threading,
 // as well as partitioning, serialization, and deserialization.
 template<typename ModuleReleasedFunc>
@@ -1351,9 +1357,9 @@ static SmallVector<AOTOutputs, 16> add_output(Module &M, TargetMachine &TM, Stri
     // Start all of the worker threads
     {
         JL_TIMING(NATIVE_AOT, NATIVE_Opt);
-        std::vector<std::thread> workers(threads);
+        std::vector<uv_thread_t> workers(threads);
         for (unsigned i = 0; i < threads; i++) {
-            workers[i] = std::thread([&, i]() {
+            std::function<void()> func = [&, i]() {
                 LLVMContext ctx;
                 // Lazily deserialize the entire module
                 timers[i].deserialize.startTimer();
@@ -1375,12 +1381,14 @@ static SmallVector<AOTOutputs, 16> add_output(Module &M, TargetMachine &TM, Stri
                 timers[i].construct.stopTimer();
 
                 outputs[i] = add_output_impl(*M, TM, timers[i], unopt_out, opt_out, obj_out, asm_out);
-            });
+            };
+            auto arg = new std::function<void()>(func);
+            uv_thread_create(&workers[i], lambda_trampoline, arg); // Use libuv thread to avoid issues with stack sizes
         }
 
         // Wait for all of the worker threads to finish
-        for (auto &w : workers)
-            w.join();
+        for (unsigned i = 0; i < threads; i++)
+            uv_thread_join(&workers[i]);
     }
 
     output_timer.stopTimer();
@@ -1418,8 +1426,6 @@ static unsigned compute_image_thread_count(const ModuleInfo &info) {
         LLVM_DEBUG(dbgs() << "COFF is restricted to a single thread for large images\n");
         return 1;
     }
-    if (info.triple.isMusl())
-        return 1;
     // This is not overridable because empty modules do occasionally appear, but they'll be very small and thus exit early to
     // known easy behavior. Plus they really don't warrant multiple threads
     if (info.weight < 1000) {


### PR DESCRIPTION
See https://ariadne.space/2021/06/25/understanding-thread-stack-sizes-and-how-alpine-is-different/ and https://git.alpinelinux.org/aports/commit/?id=4ab6ef38f167f4983008f8b213e5beace8d453f0