### PR TITLE
Tweak test LOAD_PATH and fix loading test

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -599,10 +599,13 @@ CPP_STDOUT := $(CPP) -P
 # file extensions
 ifeq ($(OS), WINNT)
   SHLIB_EXT := dll
+  PATHSEP := ;
 else ifeq ($(OS), Darwin)
   SHLIB_EXT := dylib
+  PATHSEP := :
 else
   SHLIB_EXT := so
+  PATHSEP := :
 endif
 
 ifeq ($(OS),WINNT)

--- a/base/util.jl
+++ b/base/util.jl
@@ -691,7 +691,7 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS / 2),
     ENV2["JULIA_CPU_THREADS"] = "$ncores"
     pathsep = Sys.iswindows() ? ";" : ":"
     ENV2["JULIA_DEPOT_PATH"] = string(mktempdir(; cleanup = true), pathsep) # make sure the default depots can be loaded
-    delete!(ENV2, "JULIA_LOAD_PATH")
+    ENV2["JULIA_LOAD_PATH"] = string("@", pathsep, "@stdlib")
     delete!(ENV2, "JULIA_PROJECT")
     try
         run(setenv(`$(julia_cmd()) $(joinpath(Sys.BINDIR,

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,7 +7,7 @@ STDLIBDIR := $(build_datarootdir)/julia/stdlib/$(VERSDIR)
 # TODO: this Makefile ignores BUILDDIR, except for computing JULIA_EXECUTABLE
 
 export JULIA_DEPOT_PATH := $(build_prefix)/share/julia
-export JULIA_LOAD_PATH := @stdlib
+export JULIA_LOAD_PATH := @$(PATHSEP)@stdlib
 unexport JULIA_PROJECT :=
 unexport JULIA_BINDIR :=
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1277,6 +1277,9 @@ end
 
 @testset "relocatable upgrades #51989" begin
     mktempdir() do depot
+        project_path = joinpath(depot, "project")
+        mkpath(project_path)
+
         # Create fake `Foo.jl` package with two files:
         foo_path = joinpath(depot, "dev", "Foo")
         mkpath(joinpath(foo_path, "src"))
@@ -1300,9 +1303,8 @@ end
 
         # In our depot, `dev` and then `precompile` this `Foo` package.
         @test success(addenv(
-            `$(Base.julia_cmd()) --startup-file=no -e 'import Pkg; Pkg.develop("Foo"); Pkg.precompile(); exit(0)'`,
-            "JULIA_DEPOT_PATH" => depot,
-        ))
+            `$(Base.julia_cmd()) --project=$project_path --startup-file=no -e 'import Pkg; Pkg.develop("Foo"); Pkg.precompile(); exit(0)'`,
+            "JULIA_DEPOT_PATH" => depot))
 
         # Get the size of the generated `.ji` file so that we can ensure that it gets altered
         foo_compiled_path = joinpath(depot, "compiled", "v$(VERSION.major).$(VERSION.minor)", "Foo")
@@ -1321,7 +1323,7 @@ end
 
         # Try to load `Foo`; this should trigger recompilation, not an error!
         @test success(addenv(
-            `$(Base.julia_cmd()) --startup-file=no -e 'using Foo; exit(0)'`,
+            `$(Base.julia_cmd()) --project=$project_path --startup-file=no -e 'using Foo; exit(0)'`,
             "JULIA_DEPOT_PATH" => depot,
         ))
 


### PR DESCRIPTION
This does two things:
1. Give the latest addition to the loading test an active project, so that it works, even without a global one.
2. Standardize the JULIA_LOAD_PATH setting to "@:@stdlib" for both `Base.runtests` (which CI uses) and `make test-*`. Before, the former was using the default load path, while the latter was using "@stdlib" only. However, neither is great. With the default load path, test results could in theory depend on the global environment and tests that accidentally modify the global environment go undetected. The latter resolved those issues. However, without the active project on the load path, the behavior is quite weird - even if you activate a project you can't load it and even if you could, and even if you try to load something explicitly, that project can't find its dependencies. I think "@:@stdlib", is a reasonable compromise here. It has the same protections against the global environment interfering with test results, while also making the active project logic work as usual.

Fixes #52148
Fixes #50055 (the remainder thereof at least)