### PR TITLE
Update `unique` and `unique!` docstrings to mention `hash` function

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -165,7 +165,7 @@ end
     unique(itr)
 
 Return an array containing only the unique elements of collection `itr`,
-as determined by [`isequal`](@ref), in the order that the first of each
+as determined by [`isequal`](@ref) and [`hash`](@ref), in the order that the first of each
 set of equivalent elements originally appears. The element type of the
 input is preserved.
 
@@ -400,7 +400,7 @@ end
 """
     unique!(A::AbstractVector)
 
-Remove duplicate items as determined by [`isequal`](@ref), then return the modified `A`.
+Remove duplicate items as determined by [`isequal`](@ref) and [`hash`](@ref), then return the modified `A`.
 `unique!` will return the elements of `A` in the order that they occur. If you do not care
 about the order of the returned data, then calling `(sort!(A); unique!(A))` will be much
 more efficient as long as the elements of `A` can be sorted.


### PR DESCRIPTION
I was confused by the following result, and `help?> unique` does not help.

```julia
julia> struct Foo
           vec::Vector{Int}
       end

julia> function Base.:(==)(a::Foo, b::Foo)
           a.vec == b.vec
       end

julia> a = Foo([1, 2])
Foo([1, 2])

julia> b = Foo([1, 2])
Foo([1, 2])

julia> isequal(a, b)
true

julia> unique([a, b])  # I thought this should be `[Foo([1, 2])]`
2-element Vector{Foo}:
 Foo([1, 2])
 Foo([1, 2])
```

This PR updates docstrings of `unique` and `unique!` to mention the `hash` function.