### PR TITLE
Make PersistentDict behave like an IdDict

### DIFF
--- a/base/hamt.jl
+++ b/base/hamt.jl
@@ -62,36 +62,47 @@ A HashArrayMappedTrie that optionally supports persistence.
 mutable struct HAMT{K, V}
     const data::Vector{Union{Leaf{K, V}, HAMT{K, V}}}
     bitmap::BITMAP
+    HAMT{K,V}(data, bitmap) where {K,V} = new{K,V}(data, bitmap)
+    HAMT{K, V}() where {K, V} = new{K,V}(Vector{Union{Leaf{K, V}, HAMT{K, V}}}(undef, 0), zero(BITMAP))
 end
-HAMT{K, V}() where {K, V} = HAMT(Vector{Union{Leaf{K, V}, HAMT{K, V}}}(undef, 0), zero(BITMAP))
-function HAMT{K,V}(k::K, v) where {K, V}
+function HAMT{K,V}((k,v)::Pair) where {K, V}
+    k = convert(K, k)
     v = convert(V, v)
     # For a single element we can't have a hash-collision
-    trie = HAMT(Vector{Union{Leaf{K, V}, HAMT{K, V}}}(undef, 1), zero(BITMAP))
+    trie = HAMT{K,V}(Vector{Union{Leaf{K, V}, HAMT{K, V}}}(undef, 1), zero(BITMAP))
     trie.data[1] = Leaf{K,V}(k,v)
     bi = BitmapIndex(HashState(k))
     set!(trie, bi)
     return trie
 end
-HAMT(k::K, v::V) where {K, V} = HAMT{K,V}(K, V)
+HAMT(pair::Pair{K,V}) where {K, V} = HAMT{K,V}(pair)
 
+# TODO: Parameterize by hash function
 struct HashState{K}
     key::K
     hash::UInt
     depth::Int
     shift::Int
 end
-HashState(key)= HashState(key, hash(key), 0, 0)
+HashState(key) = HashState(key, objectid(key), 0, 0)
 # Reconstruct
-HashState(key, depth, shift) = HashState(key, hash(key, UInt(depth ÷ BITS_PER_LEVEL)), depth, shift)
+function HashState(other::HashState, key)
+    h = HashState(key)
+    while h.depth !== other.depth
+        h = next(h)
+    end
+    return h
+end
 
 function next(h::HashState)
     depth = h.depth + 1
     shift = h.shift + BITS_PER_LEVEL
+    @assert h.shift <= MAX_SHIFT
     if shift > MAX_SHIFT
         # Note we use `UInt(depth ÷ BITS_PER_LEVEL)` to seed the hash function
         # the hash docs, do we need to hash `UInt(depth ÷ BITS_PER_LEVEL)` first?
-        h_hash = hash(h.key, UInt(depth ÷ BITS_PER_LEVEL))
+        h_hash = hash(objectid(h.key), UInt(depth ÷ BITS_PER_LEVEL))
+        shift = 0
     else
         h_hash = h.hash
     end
@@ -137,8 +148,7 @@ as the current `level`.
 If a copy function is provided `copyf` use the return `top` for the
 new persistent tree.
 """
-@inline function path(trie::HAMT{K,V}, key, _h, copy=false) where {K, V}
-    h = HashState(key, _h, 0, 0)
+@inline function path(trie::HAMT{K,V}, key, h::HashState, copy=false) where {K, V}
     if copy
         trie = top = HAMT{K,V}(Base.copy(trie.data), trie.bitmap)
     else
@@ -151,7 +161,7 @@ new persistent tree.
             next = @inbounds trie.data[i]
             if next isa Leaf{K,V}
                 # Check if key match if not we will need to grow.
-                found = (next.key === h.key || isequal(next.key, h.key))
+                found = next.key === h.key
                 return found, true, trie, i, bi, top, h
             end
             if copy
@@ -184,7 +194,7 @@ or grows the HAMT by inserting a new trie instead.
         @assert present
         # collision -> grow
         leaf = @inbounds trie.data[i]::Leaf{K,V}
-        leaf_h = HashState(leaf.key, h.depth, h.shift)
+        leaf_h = HashState(h, leaf.key)
         if leaf_h.hash == h.hash
             error("Perfect hash collision")
         end

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1103,8 +1103,10 @@ import Base.PersistentDict
         end
         @test hs.depth == recompute_depth
         @test hs.shift == 0
-        hsr = Base.HAMT.HashState(h, 12)
+        hsr = Base.HAMT.HashState(hs, key)
         @test hs.hash == hsr.hash
+        @test hs.depth == hsr.depth
+        @test hs.shift == hsr.shift
     end
     @testset "basics" begin
         dict = PersistentDict{Int, Int}()

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1103,7 +1103,7 @@ import Base.PersistentDict
         end
         @test hs.depth == recompute_depth
         @test hs.shift == 0
-        hsr = Base.HAMT.HashState(key, 12, 0)
+        hsr = Base.HAMT.HashState(h, 12)
         @test hs.hash == hsr.hash
     end
     @testset "basics" begin


### PR DESCRIPTION
As noted by @topolarity in https://github.com/JuliaLang/julia/pull/51993#discussion_r1388108501

```julia
julia> x = Int64[0];

julia> d = Base.PersistentDict(x => false, [1] => true);

julia> x[1] = 1

julia> d[x]
true
```

I was already considering doing `hash(sv::ScopedValue) = objectid(sv)`, but as cody showed this is a general issue,
The current behaviour is consistent with `Dict` but not with `ImmutableDict` (which `PersistentDict` is a close cousin off).


