### PR TITLE
gc: add some guard rails and refinements to MemBalancer

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -979,27 +979,25 @@ void gc_time_summary(int sweep_full, uint64_t start, uint64_t end,
 
 void gc_heuristics_summary(
         uint64_t old_alloc_diff, uint64_t alloc_mem,
-        uint64_t old_nongc_time, uint64_t nongc_time,
         uint64_t old_mut_time, uint64_t alloc_time,
         uint64_t old_freed_diff, uint64_t gc_mem,
         uint64_t old_pause_time, uint64_t gc_time,
-        int thrash_counter,
+        int thrash_counter, const char *reason,
         uint64_t current_heap, uint64_t target_heap)
 {
     jl_safe_printf("Estimates: alloc_diff=%" PRIu64 "kB (%" PRIu64 ")"
-                            "  nongc_time=%" PRIu64 "ns (%" PRIu64 ")"
+                            //"  nongc_time=%" PRIu64 "ns (%" PRIu64 ")"
                             "  mut_time=%" PRIu64 "ns (%" PRIu64 ")"
                             "  freed_diff=%" PRIu64 "kB (%" PRIu64 ")"
                             "  pause_time=%" PRIu64 "ns (%" PRIu64 ")"
-                            "  thrash_counter=%d"
+                            "  thrash_counter=%d%s"
                             "  current_heap=%" PRIu64 " MB"
                             "  target_heap=%" PRIu64 " MB\n",
                    old_alloc_diff/1024, alloc_mem/1024,
-                   old_nongc_time/1000, nongc_time/1000,
                    old_mut_time/1000, alloc_time/1000,
                    old_freed_diff/1024, gc_mem/1024,
                    old_pause_time/1000, gc_time/1000,
-                   thrash_counter,
+                   thrash_counter, reason,
                    current_heap/1024/1024, target_heap/1024/1024);
 }
 #endif

--- a/src/gc.h
+++ b/src/gc.h
@@ -525,6 +525,14 @@ void gc_time_summary(int sweep_full, uint64_t start, uint64_t end,
                      uint64_t freed, uint64_t live, uint64_t interval,
                      uint64_t pause, uint64_t ttsp, uint64_t mark,
                      uint64_t sweep);
+void gc_heuristics_summary(
+        uint64_t old_alloc_diff, uint64_t alloc_mem,
+        uint64_t old_nongc_time, uint64_t nongc_time,
+        uint64_t old_mut_time, uint64_t alloc_time,
+        uint64_t old_freed_diff, uint64_t gc_mem,
+        uint64_t old_pause_time, uint64_t gc_time,
+        int thrash_counter,
+        uint64_t current_heap, uint64_t target_heap);
 #else
 #define gc_time_pool_start()
 STATIC_INLINE void gc_time_count_page(int freedall, int pg_skpd) JL_NOTSAFEPOINT
@@ -552,6 +560,14 @@ STATIC_INLINE void gc_time_count_mallocd_memory(int bits) JL_NOTSAFEPOINT
                             estimate_freed, sweep_full)
 #define  gc_time_summary(sweep_full, start, end, freed, live,           \
                          interval, pause, ttsp, mark, sweep)
+#define gc_heuristics_summary( \
+        old_alloc_diff, alloc_mem, \
+        old_nongc_time, nongc_time, \
+        old_mut_time, alloc_time, \
+        old_freed_diff, gc_mem, \
+        old_pause_time, gc_time, \
+        thrash_counter, \
+        current_heap, target_heap)
 #endif
 
 #ifdef MEMFENCE

--- a/src/gc.h
+++ b/src/gc.h
@@ -527,11 +527,10 @@ void gc_time_summary(int sweep_full, uint64_t start, uint64_t end,
                      uint64_t sweep);
 void gc_heuristics_summary(
         uint64_t old_alloc_diff, uint64_t alloc_mem,
-        uint64_t old_nongc_time, uint64_t nongc_time,
         uint64_t old_mut_time, uint64_t alloc_time,
         uint64_t old_freed_diff, uint64_t gc_mem,
         uint64_t old_pause_time, uint64_t gc_time,
-        int thrash_counter,
+        int thrash_counter, const char *reason,
         uint64_t current_heap, uint64_t target_heap);
 #else
 #define gc_time_pool_start()
@@ -562,11 +561,10 @@ STATIC_INLINE void gc_time_count_mallocd_memory(int bits) JL_NOTSAFEPOINT
                          interval, pause, ttsp, mark, sweep)
 #define gc_heuristics_summary( \
         old_alloc_diff, alloc_mem, \
-        old_nongc_time, nongc_time, \
         old_mut_time, alloc_time, \
         old_freed_diff, gc_mem, \
         old_pause_time, gc_time, \
-        thrash_counter, \
+        thrash_counter, reason, \
         current_heap, target_heap)
 #endif
 


### PR DESCRIPTION
This replaces https://github.com/JuliaLang/julia/pull/50909, though notably does not include the change to use heap size instead of heap memory. Similar to that PR however, it is expected (and observed in running the GC benchmarks scripts) that this may show slightly higher memory utilization at usually similar performance since the tuning parameter is increased.

This adds the smoothing behavior from that prior PR (to better estimate the long-term rates / ignore transient changes), updates the GC_TIME printing to reflect the change to use MemBalancer heuristics, and adds some other guardrails to the decisions so they do not get put off too far into the future. Since, unlike several other languages that use MemBalancer, we do not have a time-based trigger for GC to update these heuristics continuously, so we need to make sure each step is reasonably conservative (both from under and over predicting the rate). Finally, this is stricter about observing limits set by the user, by strictly limiting the exceedence rate to around 10%, while avoiding some prior possible issues with the hard cut-off being disjoint at the cutoff. This should mean we will go over the threshold slowly if the program continues to demand more space. If we OOM eventually by the kerenl, we would have died anyways from OOM now by ourself.