### PR TITLE
free more thread state in jl_delete_thread and GC

### DIFF
--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -223,6 +223,9 @@ void sweep_stack_pools(void)
                 void *stk = small_arraylist_pop(al);
                 free_stack(stk, pool_sizes[p]);
             }
+            if (jl_atomic_load_relaxed(&ptls2->current_task) == NULL) {
+                small_arraylist_free(al);
+            }
         }
 
         small_arraylist_t *live_tasks = &ptls2->heap.live_tasks;

--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -203,6 +203,8 @@ void sweep_stack_pools(void)
     assert(gc_n_threads);
     for (int i = 0; i < gc_n_threads; i++) {
         jl_ptls_t ptls2 = gc_all_tls_states[i];
+        if (ptls2 == NULL)
+            continue;
 
         // free half of stacks that remain unused since last sweep
         for (int p = 0; p < JL_N_STACK_POOLS; p++) {
@@ -226,6 +228,9 @@ void sweep_stack_pools(void)
             if (jl_atomic_load_relaxed(&ptls2->current_task) == NULL) {
                 small_arraylist_free(al);
             }
+        }
+        if (jl_atomic_load_relaxed(&ptls2->current_task) == NULL) {
+            small_arraylist_free(ptls2->heap.free_stacks);
         }
 
         small_arraylist_t *live_tasks = &ptls2->heap.live_tasks;

--- a/src/threading.c
+++ b/src/threading.c
@@ -508,6 +508,11 @@ static void jl_delete_thread(void *value) JL_NOTSAFEPOINT_ENTER
 #else
     pthread_mutex_unlock(&in_signal_lock);
 #endif
+    free(ptls->bt_data);
+    // allow the page root_task is on to be freed
+    ptls->root_task = NULL;
+    void jl_free_thread_gc_state(jl_ptls_t ptls);
+    jl_free_thread_gc_state(ptls);
     // then park in safe-region
     (void)jl_gc_safe_enter(ptls);
 }

--- a/src/threading.c
+++ b/src/threading.c
@@ -435,6 +435,8 @@ JL_DLLEXPORT jl_gcframe_t **jl_adopt_thread(void)
 void jl_task_frame_noreturn(jl_task_t *ct) JL_NOTSAFEPOINT;
 void scheduler_delete_thread(jl_ptls_t ptls) JL_NOTSAFEPOINT;
 
+void jl_free_thread_gc_state(jl_ptls_t ptls);
+
 static void jl_delete_thread(void *value) JL_NOTSAFEPOINT_ENTER
 {
 #ifndef _OS_WINDOWS_
@@ -509,9 +511,10 @@ static void jl_delete_thread(void *value) JL_NOTSAFEPOINT_ENTER
     pthread_mutex_unlock(&in_signal_lock);
 #endif
     free(ptls->bt_data);
+    small_arraylist_free(&ptls->locks);
+    ptls->previous_exception = NULL;
     // allow the page root_task is on to be freed
     ptls->root_task = NULL;
-    void jl_free_thread_gc_state(jl_ptls_t ptls);
     jl_free_thread_gc_state(ptls);
     // then park in safe-region
     (void)jl_gc_safe_enter(ptls);

--- a/src/work-stealing-queue.h
+++ b/src/work-stealing-queue.h
@@ -34,6 +34,12 @@ static inline ws_array_t *create_ws_array(size_t capacity, int32_t eltsz) JL_NOT
     return a;
 }
 
+static inline void free_ws_array(ws_array_t *a)
+{
+    free(a->buffer);
+    free(a);
+}
+
 typedef struct {
     _Atomic(int64_t) top;
     char _padding[JL_CACHE_BYTE_ALIGNMENT - sizeof(_Atomic(int64_t))];


### PR DESCRIPTION
This prevents most memory growth in workloads that start many foreign threads. In the future, we could do even better by moving pages in the heap of an exited thread (and also maybe pooled stacks) elsewhere so they can be reused, and then also free the TLS object itself.