### PR TITLE
remove `switch_[to|from]_irinterp` mechanism

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -251,8 +251,6 @@ populate_def_use_map!(tpdum::TwoPhaseDefUseMap, ir::IRCode) =
 
 function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IRInterpretationState;
         externally_refined::Union{Nothing,BitSet} = nothing)
-    interp = switch_to_irinterp(interp)
-
     (; ir, tpdum, ssa_refined) = irsv
 
     all_rets = Int[]

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -243,7 +243,6 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState)
 end
 
 function _typeinf(interp::AbstractInterpreter, frame::InferenceState)
-    interp = switch_from_irinterp(interp)
     typeinf_nocycle(interp, frame) || return false # frame is now part of a higher cycle
     # with no active ip's, frame is done
     frames = frame.callers_in_cycle


### PR DESCRIPTION
This seems to cause (probably not very profitable) union-splitting all over the place and complicate code generation. Let's just remove it.

@nanosoldier `runbenchmarks("inference", vs=":master")`