### PR TITLE
Add missing type annotation reported by JET

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1278,7 +1278,7 @@ function _insert_extension_triggers(parent::PkgId, extensions::Dict{String, Any}
     for (ext, triggers) in extensions
         triggers = triggers::Union{String, Vector{String}}
         triggers isa String && (triggers = [triggers])
-        id = PkgId(uuid5(parent.uuid, ext), ext)
+        id = PkgId(uuid5(parent.uuid::UUID, ext), ext)
         if id in keys(EXT_PRIMED) || haskey(Base.loaded_modules, id)
             continue  # extension is already primed or loaded, don't add it again
         end


### PR DESCRIPTION
We already know from https://github.com/JuliaLang/julia/blob/d0a3edddda407302930f3b2a742a7c8ebbcafb5b/base/loading.jl#L1212 that the value is not `nothing`. However, type inference does not know that as the check lives in a different function.