### PR TITLE
Fix (?) `_array_for` fallback case

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -660,7 +660,7 @@ _array_for(::Type{T}, ::HasLength, len::Integer) where {T} = Vector{T}(undef, In
 _array_for(::Type{T}, ::HasShape{N}, axs) where {T,N} = similar(Array{T,N}, axs)
 
 # used by syntax lowering for simple typed comprehensions
-_array_for(::Type{T}, itr, isz) where {T} = _array_for(T, isz, _similar_shape(itr, isz))
+_array_for(::Type{T}, isz, itr) where {T} = _array_for(T, isz, _similar_shape(itr, isz))
 
 
 """


### PR DESCRIPTION
While looking through the JET output of one of my packages, I tried to understand parts of the `collect` code of list comprehensions. 
This line made no sense to me, as the arguments seem to be in the wrong order. At all callsites of `_array_for` I could find in the repository, the size is always the second argument. Changing this seems to work locally. Let's have a look at CI.