### PR TITLE
build: disable DT_TEXTREL warning for i686

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -20,7 +20,8 @@ ifeq ($(OS),WINNT)
 LOADER_LDFLAGS += -municode -mconsole -nostdlib --disable-auto-import \
                   --disable-runtime-pseudo-reloc -lntdll -lkernel32 -lpsapi
 else ifeq ($(OS),Linux)
-LOADER_LDFLAGS += -Wl,--no-as-needed -ldl -lpthread -rdynamic -lc -Wl,--as-needed
+# textoff and notext are aliases to the same option which suppress the TEXTREL warning for i686
+LOADER_LDFLAGS += -Wl,--no-as-needed -ldl -lpthread -rdynamic -lc -Wl,--as-needed -Wl,-z,notext
 else ifeq ($(OS),FreeBSD)
 LOADER_LDFLAGS += -Wl,--no-as-needed -ldl -lpthread -rdynamic -lc -Wl,--as-needed
 else ifeq ($(OS),Darwin)

--- a/cli/trampolines/trampolines_i686.S
+++ b/cli/trampolines/trampolines_i686.S
@@ -3,13 +3,41 @@
 #include "common.h"
 #include "../../src/jl_exported_funcs.inc"
 
+// set this option to 1 to get very slightly slower trampolines which however do not trigger
+// this linker warning:
+//   ld: ./loader_trampolines.o: warning: relocation against `jl_***_addr' in read-only section `.text'
+//   ld: warning: creating DT_TEXTREL in a shared object
+// If you have a large libjulia.so file or other restrictions on using TEXTREL for some
+// reason, this may be worthwhile.
+// This is not relevant on Windows (though it is valid there), since it always uses
+// DT_TEXTREL anyways, and does not support this notion of PIC.
+#define USE_PC32 0
+
+#if USE_PC32
+.cfi_startproc
+julia__x86.get_pc_thunk.ax:
+    mov    (%esp),%eax
+    ret
+.cfi_endproc
+
+#define CALL(name) \
+    call julia__x86.get_pc_thunk.ax; \
+    jmpl *(CNAMEADDR(name) - .)(%eax); \
+
+#else
+
+#define CALL(name) \
+    jmpl *(CNAMEADDR(name)); \
+
+#endif
+
 #define XX(name) \
 DEBUGINFO(CNAME(name)); \
 .global CNAME(name); \
 .cfi_startproc; \
 CNAME(name)##:; \
     CET_START(); \
-    jmpl *(CNAMEADDR(name)); \
+    CALL(name); \
     ud2; \
 .cfi_endproc; \
 EXPORT(name); \


### PR DESCRIPTION
This warning was distracting and annoying me, so I looked into whether it was a bug. Turns out the warning is harmless (loading the object just will make a copy of the ~2kb text field into memory). So add the code to disable it, either with different assembly or different linker flags. Default to continuing to use the same assembly.