### PR TITLE
effects: don't taint `:noub` for `:new` allocations

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1265,7 +1265,7 @@ function check_effect_free!(ir::IRCode, idx::Int, @nospecialize(stmt), @nospecia
     elseif nothrow
         ir.stmts[idx][:flag] |= IR_FLAG_NOTHROW
     end
-    if !isexpr(stmt, :call) && !isexpr(stmt, :invoke)
+    if !(isexpr(stmt, :call) || isexpr(stmt, :invoke))
         # There is a bit of a subtle point here, which is that some non-call
         # statements (e.g. PiNode) can be UB:, however, we consider it
         # illegal to introduce such statements that actually cause UB (for any


### PR DESCRIPTION
After #52169, the UB previously associated with allocations with uninitialized fields has been addressed, so there's no longer a need to taint `:noub` for `:new` allocations during abstract interpretation.

I believe, even without #52169, uninitialized field does not inherently leads to UB, but just causes inconsistency of the program, since what actually causes UB is `getfield` that accesses into whatever object, but not the allocation itself.