### PR TITLE
inference: followups for #51754

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2136,7 +2136,7 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
         argtypes = Any[typeof(<:), argtypes[3], argtypes[2]]
         return abstract_call_known(interp, <:, ArgInfo(fargs, argtypes), si, sv, max_methods)
     elseif la == 2 && istopfunction(f, :typename)
-        return CallMeta(typename_static(argtypes[2]), Any, EFFECTS_TOTAL, MethodResultPure())
+        return CallMeta(typename_static(argtypes[2]), Bottom, EFFECTS_TOTAL, MethodResultPure())
     elseif f === Core._hasmethod
         return _hasmethod_tfunc(interp, argtypes, sv)
     end

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1196,13 +1196,14 @@ function semi_concrete_eval_call(interp::AbstractInterpreter,
                 # state = InliningState(interp)
                 # ir = ssa_inlining_pass!(irsv.ir, state, propagate_inbounds(irsv))
                 effects = result.effects
-                if !is_nothrow(effects)
-                    effects = Effects(effects; nothrow)
+                if nothrow
+                    effects = Effects(effects; nothrow=true)
                 end
                 if noub
-                    effects = Effects(effects; noub = ALWAYS_TRUE)
+                    effects = Effects(effects; noub=ALWAYS_TRUE)
                 end
-                return ConstCallResults(rt, result.exct, SemiConcreteResult(mi, ir, effects), effects, mi)
+                exct = refine_exception_type(result.exct, effects)
+                return ConstCallResults(rt, exct, SemiConcreteResult(mi, ir, effects), effects, mi)
             end
         end
     end

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -51,7 +51,7 @@ function abstract_call(interp::AbstractInterpreter, arginfo::ArgInfo, irsv::IRIn
     return RTEffects(rt, exct, effects)
 end
 
-function kill_block!(ir, bb)
+function kill_block!(ir::IRCode, bb::Int)
     # Kill the entire block
     stmts = ir.cfg.blocks[bb].stmts
     for bidx = stmts
@@ -63,7 +63,6 @@ function kill_block!(ir, bb)
     ir[SSAValue(last(stmts))][:stmt] = ReturnNode()
     return
 end
-
 
 function update_phi!(irsv::IRInterpretationState, from::Int, to::Int)
     ir = irsv.ir


### PR DESCRIPTION
Composed of:

- typeinf_local: factor into `update_cycle_worklists!` utility (78f7b4ecf11b364e543bdfd46aa5fc49b7bdbf42)
- inference: fix exception type of `typename` call (fac36d839cb545a1a12991596aafd5584f95bf3b)
- add missing type annotations (7ce140ea782c847c2c2253a65301d295b10aa183)
- inference: refine exct information if `:nothrow` is proven (76143d37b6563d2da4203747051ef8517453db0d)
- ~~improve exception type inference for core math functions (525bd6c2538cbfebc9432df53b0005c9956079be)~~ Separated into TODO