### PR TITLE
Declare `LinearAlgebra.AbstractTriangular` to be public

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -161,6 +161,9 @@ export
 # Constants
     I
 
+# not exported, but public names
+public AbstractTriangular
+
 const BlasFloat = Union{Float64,Float32,ComplexF64,ComplexF32}
 const BlasReal = Union{Float64,Float32}
 const BlasComplex = Union{ComplexF64,ComplexF32}

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -3,6 +3,12 @@
 ## Triangular
 
 # could be renamed to Triangular when that name has been fully deprecated
+"""
+    AbstractTriangular
+
+Supertype of triangular matrix types such as [`LowerTriangular`](@ref), [`UpperTriangular`](@ref),
+[`UnitLowerTriangular`](@ref) and [`UnitUpperTriangular`](@ref).
+"""
 abstract type AbstractTriangular{T} <: AbstractMatrix{T} end
 
 # First loop through all methods that don't need special care for upper/lower and unit diagonal


### PR DESCRIPTION
Since methods such as `mul!`, `(l/r)mul!` and `(l/r)div!` are defined for `AbstractTriangular`, having this be public allows easier disambiguation in packages. [Several packages](https://juliahub.com/ui/Search?q=AbstractTriangular&type=code) are already using it as if it's public, so it makes sense to support this.

This would resolve the specific issue in https://discourse.julialang.org/t/methoderrors-suggest-fixes-that-may-depend-on-internal-bindings/106468