### PR TITLE
export `jl_alloc_array_nd`, re-add convenience wrappers

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -167,6 +167,18 @@ JL_DLLEXPORT jl_array_t *jl_alloc_array_1d(jl_value_t *atype, size_t nr)
     return new_array(atype, 1, &nr);
 }
 
+JL_DLLEXPORT jl_array_t *jl_alloc_array_2d(jl_value_t *atype, size_t nr, size_t nc)
+{
+    size_t dims[2] = {nr, nc};
+    return new_array(atype, 2, &dims[0]);
+}
+
+JL_DLLEXPORT jl_array_t *jl_alloc_array_3d(jl_value_t *atype, size_t nr, size_t nc, size_t z)
+{
+    size_t dims[3] = {nr, nc, z};
+    return new_array(atype, 3, &dims[0]);
+}
+
 JL_DLLEXPORT jl_array_t *jl_alloc_array_nd(jl_value_t *atype, size_t *dims, size_t ndims)
 {
     return new_array(atype, ndims, dims);

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -6,6 +6,8 @@
     XX(jl_adopt_thread) \
     XX(jl_alignment) \
     XX(jl_alloc_array_1d) \
+    XX(jl_alloc_array_2d) \
+    XX(jl_alloc_array_3d) \
     XX(jl_alloc_array_nd) \
     XX(jl_alloc_string) \
     XX(jl_alloc_svec) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -6,6 +6,7 @@
     XX(jl_adopt_thread) \
     XX(jl_alignment) \
     XX(jl_alloc_array_1d) \
+    XX(jl_alloc_array_nd) \
     XX(jl_alloc_string) \
     XX(jl_alloc_svec) \
     XX(jl_alloc_svec_uninit) \

--- a/src/julia.h
+++ b/src/julia.h
@@ -1833,6 +1833,19 @@ JL_DLLEXPORT void jl_array_del_end(jl_array_t *a, size_t dec);
 JL_DLLEXPORT void jl_array_ptr_1d_push(jl_array_t *a, jl_value_t *item);
 JL_DLLEXPORT void jl_array_ptr_1d_append(jl_array_t *a, jl_array_t *a2);
 JL_DLLEXPORT jl_value_t *jl_apply_array_type(jl_value_t *type, size_t dim);
+
+STATIC_INLINE jl_array_t *jl_alloc_array_2d(jl_value_t *atype, size_t nr, size_t nc)
+{
+    size_t dims[2] = {nr, nc};
+    return jl_alloc_array_nd(atype, &dims[0], 2);
+}
+
+STATIC_INLINE jl_array_t *jl_alloc_array_3d(jl_value_t *atype, size_t nr, size_t nc, size_t z)
+{
+    size_t dims[3] = {nr, nc, z};
+    return jl_alloc_array_nd(atype, &dims[0], 3);
+}
+
 // property access
 JL_DLLEXPORT void *jl_array_ptr(jl_array_t *a);
 JL_DLLEXPORT void *jl_array_eltype(jl_value_t *a);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1821,6 +1821,8 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
                                          jl_value_t *dims, int own_buffer);
 
 JL_DLLEXPORT jl_array_t *jl_alloc_array_1d(jl_value_t *atype, size_t nr);
+JL_DLLEXPORT jl_array_t *jl_alloc_array_2d(jl_value_t *atype, size_t nr, size_t nc);
+JL_DLLEXPORT jl_array_t *jl_alloc_array_3d(jl_value_t *atype, size_t nr, size_t nc, size_t z);
 JL_DLLEXPORT jl_array_t *jl_alloc_array_nd(jl_value_t *atype, size_t *dims, size_t ndims);
 JL_DLLEXPORT jl_array_t *jl_pchar_to_array(const char *str, size_t len);
 JL_DLLEXPORT jl_value_t *jl_pchar_to_string(const char *str, size_t len);
@@ -1833,19 +1835,6 @@ JL_DLLEXPORT void jl_array_del_end(jl_array_t *a, size_t dec);
 JL_DLLEXPORT void jl_array_ptr_1d_push(jl_array_t *a, jl_value_t *item);
 JL_DLLEXPORT void jl_array_ptr_1d_append(jl_array_t *a, jl_array_t *a2);
 JL_DLLEXPORT jl_value_t *jl_apply_array_type(jl_value_t *type, size_t dim);
-
-STATIC_INLINE jl_array_t *jl_alloc_array_2d(jl_value_t *atype, size_t nr, size_t nc)
-{
-    size_t dims[2] = {nr, nc};
-    return jl_alloc_array_nd(atype, &dims[0], 2);
-}
-
-STATIC_INLINE jl_array_t *jl_alloc_array_3d(jl_value_t *atype, size_t nr, size_t nc, size_t z)
-{
-    size_t dims[3] = {nr, nc, z};
-    return jl_alloc_array_nd(atype, &dims[0], 3);
-}
-
 // property access
 JL_DLLEXPORT void *jl_array_ptr(jl_array_t *a);
 JL_DLLEXPORT void *jl_array_eltype(jl_value_t *a);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1821,6 +1821,7 @@ JL_DLLEXPORT jl_array_t *jl_ptr_to_array(jl_value_t *atype, void *data,
                                          jl_value_t *dims, int own_buffer);
 
 JL_DLLEXPORT jl_array_t *jl_alloc_array_1d(jl_value_t *atype, size_t nr);
+JL_DLLEXPORT jl_array_t *jl_alloc_array_nd(jl_value_t *atype, size_t *dims, size_t ndims);
 JL_DLLEXPORT jl_array_t *jl_pchar_to_array(const char *str, size_t len);
 JL_DLLEXPORT jl_value_t *jl_pchar_to_string(const char *str, size_t len);
 JL_DLLEXPORT jl_value_t *jl_cstr_to_string(const char *str);


### PR DESCRIPTION
This is used in an example here in the docs https://docs.julialang.org/en/v1.11-dev/manual/embedding/#Multidimensional-Arrays and needed to adapt to the removed `jl_alloc_array_2d` (#51319).

I also added inline convenience wrappers for `jl_alloc_array_2d` and `jl_alloc_array_3d` to un-break existing code, both functions were removed in the Memory PR in favor of the `_nd` variant. If this is undesired I can remove them again and only keep the new export.