### PR TITLE
simpler example for randn

### DIFF
--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -24,7 +24,7 @@ See also [`randn!`](@ref) to act in-place.
 
 # Examples
 
-1. Generating a single random number, by default of type `Float64`:
+Generating a single random number, by default of type `Float64`:
 
 ```julia-repl
 julia> using Random
@@ -33,7 +33,7 @@ julia> randn()
 -0.942481877315864
 ```
 
-2. Generating a matrix of normal random numbers, by default of type `Float64`:
+Generating a matrix of normal random numbers, by default of type `Float64`:
 
 ```julia-repl
 julia> using Random
@@ -44,7 +44,7 @@ julia> randn(2,3)
  -0.342792  -0.134299  -1.45005
 ```
 
-3. Setting up of the random number generator with a user-defined seed, and the generation of a random `ComplexF64` number, or a matrix `ComplexF32` normal random numbers:
+Setting up of the random number generator with a user-defined seed, and the generation of a random `ComplexF64` number, or a matrix `ComplexF32` normal random numbers:
 
 ```jldoctest
 julia> using Random

--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -45,7 +45,7 @@ julia> randn(2,3)
 ```
 
 Setting up of the random number generator `rng` with a user-defined seed (for reproducible numbers)
-and using it to generate a random `Float32` number or a matrix `ComplexF32` random numbers:
+and using it to generate a random `Float32` number or a matrix of `ComplexF32` random numbers:
 
 ```jldoctest
 julia> using Random

--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -44,8 +44,7 @@ julia> randn(2,3)
  -0.342792  -0.134299  -1.45005
 ```
 
-3. Setting up of the random number generator with a user-defined seed, and the
-generation of a random `ComplexF64` number, or a matrix `ComplexF32` normal random numbers:
+3. Setting up of the random number generator with a user-defined seed, and the generation of a random `ComplexF64` number, or a matrix `ComplexF32` normal random numbers:
 
 ```jldoctest
 julia> using Random

--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -33,8 +33,19 @@ julia> randn()
 -0.942481877315864
 ```
 
-2. Setting up of the random number generator with a user-defined seed, and the
-generation of a random number with a `ComplexF32` type:
+2. Generating a matrix of normal random numbers, by default of type `Float64`:
+
+```julia-repl
+julia> using Random
+
+julia> randn(2,3)
+2×3 Matrix{Float64}:
+  1.18786   -0.678616   1.49463
+ -0.342792  -0.134299  -1.45005
+```
+
+3. Setting up of the random number generator with a user-defined seed, and the
+generation of a random `ComplexF64` number, or a matrix `ComplexF32` normal random numbers:
 
 ```jldoctest
 julia> using Random

--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -14,50 +14,51 @@
 
 Generate a normally-distributed random number of type `T`
 with mean 0 and standard deviation 1.
-Optionally generate an array of normally-distributed random numbers.
-The `Base` module currently provides an implementation for the types
-[`Float16`](@ref), [`Float32`](@ref), and [`Float64`](@ref) (the default), and their
-[`Complex`](@ref) counterparts. When the type argument is complex, the values are drawn
-from the circularly symmetric complex normal distribution of variance 1 (corresponding to real and imaginary part having independent normal distribution with mean zero and variance `1/2`).
+Given the optional `dims` argument, generate an array of size `dims` of such numbers.
+Julia's standard library supports `randn` for any floating-point type
+that implements [`rand`](@ref), e.g. the `Base` types
+[`Float16`](@ref), [`Float32`](@ref), [`Float64`](@ref) (the default), and [`BigFloat`](@ref),
+along with their [`Complex`](@ref) counterparts.
+
+(When `T` is complex, the values are drawn
+from the circularly symmetric complex normal distribution of variance 1, corresponding to real and imaginary parts
+having independent normal distribution with mean zero and variance `1/2`).
 
 See also [`randn!`](@ref) to act in-place.
 
 # Examples
 
-Generating a single random number, by default of type `Float64`:
+Generating a single random number (with the default `Float64` type):
 
 ```julia-repl
-julia> using Random
-
 julia> randn()
 -0.942481877315864
 ```
 
-Generating a matrix of normal random numbers, by default of type `Float64`:
+Generating a matrix of normal random numbers (with the default `Float64` type):
 
 ```julia-repl
-julia> using Random
-
 julia> randn(2,3)
 2×3 Matrix{Float64}:
   1.18786   -0.678616   1.49463
  -0.342792  -0.134299  -1.45005
 ```
 
-Setting up of the random number generator with a user-defined seed, and the generation of a random `ComplexF64` number, or a matrix `ComplexF32` normal random numbers:
+Setting up of the random number generator `rng` with a user-defined seed (for reproducible numbers)
+and using it to generate a random `Float32` number or a matrix `ComplexF32` random numbers:
 
 ```jldoctest
 julia> using Random
 
 julia> rng = Xoshiro(123);
 
-julia> randn(rng, ComplexF64)
+julia> randn(rng, Float32)
 -0.45660053706486897 - 1.0346749725929225im
 
 julia> randn(rng, ComplexF32, (2, 3))
 2×3 Matrix{ComplexF32}:
- -1.14806-0.153912im   0.056538+1.0954im      0.419454-0.543347im
-  0.34807+0.693657im  -0.948661+0.291442im  -0.0538589-0.463085im
+  -1.03467-1.14806im  0.693657+0.056538im   0.291442+0.419454im
+ -0.153912+0.34807im    1.0954-0.948661im  -0.543347-0.0538589im
 ```
 """
 @inline function randn(rng::AbstractRNG=default_rng())

--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -53,7 +53,7 @@ julia> using Random
 julia> rng = Xoshiro(123);
 
 julia> randn(rng, Float32)
--0.45660053706486897 - 1.0346749725929225im
+-0.6457307f0
 
 julia> randn(rng, ComplexF32, (2, 3))
 2×3 Matrix{ComplexF32}:

--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -14,7 +14,7 @@
 
 Generate a normally-distributed random number of type `T`
 with mean 0 and standard deviation 1.
-Given the optional `dims` argument, generate an array of size `dims` of such numbers.
+Given the optional `dims` argument(s), generate an array of size `dims` of such numbers.
 Julia's standard library supports `randn` for any floating-point type
 that implements [`rand`](@ref), e.g. the `Base` types
 [`Float16`](@ref), [`Float32`](@ref), [`Float64`](@ref) (the default), and [`BigFloat`](@ref),

--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -23,8 +23,23 @@ from the circularly symmetric complex normal distribution of variance 1 (corresp
 See also [`randn!`](@ref) to act in-place.
 
 # Examples
+
+1. Generating a single random number, by default of type `Float64`:
+
+```julia-repl
+julia> using Random
+
+julia> julia> randn()
+-0.942481877315864
+```
+
+2. Setting up of the random number generator with a user-defined seed, and the
+generation of a random number with a `ComplexF32` type: 
+
 ```jldoctest
-julia> using Random; rng = Xoshiro(123);
+julia> using Random 
+
+julia> rng = Xoshiro(123);
 
 julia> randn(rng, ComplexF64)
 -0.45660053706486897 - 1.0346749725929225im

--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -29,7 +29,7 @@ See also [`randn!`](@ref) to act in-place.
 ```julia-repl
 julia> using Random
 
-julia> julia> randn()
+julia> randn()
 -0.942481877315864
 ```
 

--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -34,10 +34,10 @@ julia> randn()
 ```
 
 2. Setting up of the random number generator with a user-defined seed, and the
-generation of a random number with a `ComplexF32` type: 
+generation of a random number with a `ComplexF32` type:
 
 ```jldoctest
-julia> using Random 
+julia> using Random
 
 julia> rng = Xoshiro(123);
 


### PR DESCRIPTION
As noted here: https://discourse.julialang.org/t/how-do-we-julians-win-big-when-the-situation-is-so-unfair/106433/63?u=lmiq

The randn example is overly complicated and does not indicate the simplest usage, which is probably the most typical one.
