### PR TITLE
improve exception type inference for core math functions

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -130,9 +130,9 @@ to tell the compiler that indexing operations within the applied expression are 
 inbounds and do not need to taint `:consistent` and `:nothrow`.
 """
 macro _safeindex(ex)
-    return esc(_safeindex(__module__, ex))
+    return esc(_safeindex(ex))
 end
-function _safeindex(__module__, ex)
+function _safeindex(ex)
     isa(ex, Expr) || return ex
     if ex.head === :(=)
         lhs = ex.args[1]
@@ -141,16 +141,16 @@ function _safeindex(__module__, ex)
             xs = lhs.args[1]
             args = Vector{Any}(undef, length(lhs.args)-1)
             for i = 2:length(lhs.args)
-                args[i-1] = _safeindex(__module__, lhs.args[i])
+                args[i-1] = _safeindex(lhs.args[i])
             end
-            return Expr(:call, GlobalRef(__module__, :__safe_setindex!), xs, _safeindex(__module__, rhs), args...)
+            return Expr(:call, GlobalRef(@__MODULE__, :__safe_setindex!), xs, _safeindex(rhs), args...)
         end
     elseif ex.head === :ref # xs[i]
-        return Expr(:call, GlobalRef(__module__, :__safe_getindex), ex.args...)
+        return Expr(:call, GlobalRef(@__MODULE__, :__safe_getindex), ex.args...)
     end
     args = Vector{Any}(undef, length(ex.args))
     for i = 1:length(ex.args)
-        args[i] = _safeindex(__module__, ex.args[i])
+        args[i] = _safeindex(ex.args[i])
     end
     return Expr(ex.head, args...)
 end

--- a/base/math.jl
+++ b/base/math.jl
@@ -304,14 +304,19 @@ end
 
 # polynomial evaluation using compensated summation.
 # much more accurate, especially when lo can be combined with other rounding errors
-Base.@assume_effects :terminates_locally @inline function exthorner(x, p::Tuple)
-    hi, lo = p[end], zero(x)
-    for i in length(p)-1:-1:1
-        pi = getfield(p, i) # needed to prove consistency
-        prod, err = two_mul(hi,x)
-        hi = pi+prod
-        lo = fma(lo, x, prod - (hi - pi) + err)
-    end
+@inline function exthorner(x::T, p::Tuple{T,T,T}) where T<:Union{Float32,Float64}
+    hi, lo = p[lastindex(p)], zero(x)
+    hi, lo = _exthorner(2, x, p, hi, lo)
+    hi, lo = _exthorner(1, x, p, hi, lo)
+    return hi, lo
+end
+
+@inline function _exthorner(i::Int, x::T, p::Tuple{T,T,T}, hi::T, lo::T) where T<:Union{Float32,Float64}
+    i == 2 || i == 1 || error("unexpected index")
+    pi = p[i]
+    prod, err = two_mul(hi,x)
+    hi = pi+prod
+    lo = fma(lo, x, prod - (hi - pi) + err)
     return hi, lo
 end
 
@@ -1215,7 +1220,7 @@ end
 end
 
 @inline function pow_body(xu::UInt64, y::Float64)
-    logxhi,logxlo = Base.Math._log_ext(xu)
+    logxhi,logxlo = _log_ext(xu)
     xyhi, xylo = two_mul(logxhi,y)
     xylo = muladd(logxlo, y, xylo)
     hi = xyhi+xylo

--- a/base/special/log.jl
+++ b/base/special/log.jl
@@ -155,14 +155,11 @@ logbU(::Type{Float64},::Val{10}) = 0.4342944819032518
 logbL(::Type{Float64},::Val{10}) = 1.098319650216765e-17
 
 # Procedure 1
-# XXX we want to mark :noub here so that this function can be concrete-folded,
-# because the effect analysis currently can't prove it in the presence of `@inbounds` or
-# `:boundscheck`, but still the access to `t_log_Float64` is really safe here
-Base.@assume_effects :consistent :noub @inline function log_proc1(y::Float64,mf::Float64,F::Float64,f::Float64,base=Val(:ℯ))
+@inline function log_proc1(y::Float64,mf::Float64,F::Float64,f::Float64,base=Val(:ℯ))
     jp = unsafe_trunc(Int,128.0*F)-127
 
     ## Steps 1 and 2
-    @inbounds hi,lo = t_log_Float64[jp]
+    Base.@_safeindex hi,lo = t_log_Float64[jp]
     l_hi = mf* 0.6931471805601177 + hi
     l_lo = mf*-1.7239444525614835e-13 + lo
 
@@ -216,14 +213,11 @@ end
 end
 
 # Procedure 1
-# XXX we want to mark :noub here so that this function can be concrete-folded,
-# because the effect analysis currently can't prove it in the presence of `@inbounds` or
-# `:boundscheck`, but still the access to `t_log_Float32` is really safe here
-Base.@assume_effects :consistent :noub @inline function log_proc1(y::Float32,mf::Float32,F::Float32,f::Float32,base=Val(:ℯ))
+@inline function log_proc1(y::Float32,mf::Float32,F::Float32,f::Float32,base=Val(:ℯ))
     jp = unsafe_trunc(Int,128.0f0*F)-127
 
     ## Steps 1 and 2
-    @inbounds hi = t_log_Float32[jp]
+    Base.@_safeindex hi = t_log_Float32[jp]
     l = mf*0.6931471805599453 + hi
 
     ## Step 3
@@ -267,7 +261,7 @@ end
 @noinline log(x::Float64)   = _log(x, Val(:ℯ), :log)
 @noinline log10(x::Float64) = _log(x, Val(10), :log10)
 
-@inline function _log(x::Float64, base, func)
+@inline function _log(x::Float64, base, func::Symbol)
     if x > 0.0
         x == Inf && return x
 
@@ -294,15 +288,15 @@ end
 
         return log_proc1(y,mf,F,f,base)
     elseif x == 0.0
-        -Inf
+        return -Inf
     elseif isnan(x)
-        NaN
+        return NaN
     else
         throw_complex_domainerror(func, x)
     end
 end
 
-@inline function _log(x::Float32, base, func)
+@inline function _log(x::Float32, base, func::Symbol)
     if x > 0f0
         x == Inf32 && return x
 
@@ -327,11 +321,11 @@ end
         F = (y + 65536.0f0) - 65536.0f0 # 0x1p-7*round(0x1p7*y)
         f = y-F
 
-        log_proc1(y,mf,F,f,base)
+        return log_proc1(y,mf,F,f,base)
     elseif x == 0f0
-        -Inf32
+        return -Inf32
     elseif isnan(x)
-        NaN32
+        return NaN32
     else
         throw_complex_domainerror(func, x)
     end
@@ -562,17 +556,15 @@ end
 # Adapted and modified from https://github.com/ARM-software/optimized-routines/blob/master/math/pow.c
 # Copyright (c) 2018-2020, Arm Limited. (which is also MIT licensed)
 # note that this isn't an exact translation as this version compacts the table to reduce cache pressure.
-function _log_ext(xu)
+function _log_ext(xu::UInt64)
     # x = 2^k z; where z is in range [0x1.69555p-1,0x1.69555p-0) and exact.
     # The range is split into N subintervals.
     # The ith subinterval contains z and c is near the center of the interval.
     tmp = reinterpret(Int64, xu - 0x3fe6955500000000) #0x1.69555p-1
-    i = (tmp >> 45) & 127
     z = reinterpret(Float64, xu - (tmp & 0xfff0000000000000))
     k = Float64(tmp >> 52)
     # log(x) = k*Ln2 + log(c) + log1p(z/c-1).
-    # getfield instead of getindex to satisfy effect analysis not knowing whether this is inbounds
-    t, logctail = getfield(t_log_table_compact, Int(i+1))
+    t, logctail = compute_logctail(tmp)
     invc, logc = log_tab_unpack(t)
     # Note: invc is j/N or j/N/2 where j is an integer in [N,2N) and
     # |z/c - 1| < 1/N, so r = z/c - 1 is exactly representable.
@@ -590,4 +582,11 @@ function _log_ext(xu)
     p = evalpoly(r, (-0x1.555555555556p-1, 0x1.0000000000006p-1, -0x1.999999959554ep-2, 0x1.555555529a47ap-2, -0x1.2495b9b4845e9p-2, 0x1.0002b8b263fc3p-2))
     lo = lo1 + lo2 + lo3 + muladd(r*ar2, p, lo4)
     return hi, lo
+end
+
+# N.B. :nothrow and :noub since `idx` is known to be `1 ≤ idx ≤ length(t_log_table_compact)`
+Base.@assume_effects :nothrow :noub function compute_logctail(tmp::Int64)
+    i = (tmp >> 45) & (length(t_log_table_compact)-1)
+    idx = i + 1
+    return @inbounds t_log_table_compact[idx]
 end

--- a/base/special/rem_pio2.jl
+++ b/base/special/rem_pio2.jl
@@ -126,10 +126,7 @@ function fromfraction(f::Int128)
     return (z1,z2)
 end
 
-# XXX we want to mark :noub here so that this function can be concrete-folded,
-# because the effect analysis currently can't prove it in the presence of `@inbounds` or
-# `:boundscheck`, but still the accesses to `INV_2PI` are really safe here
-Base.@assume_effects :consistent :noub function paynehanek(x::Float64)
+function paynehanek(x::Float64)
     # 1. Convert to form
     #
     #    x = X * 2^k,
@@ -168,15 +165,15 @@ Base.@assume_effects :consistent :noub function paynehanek(x::Float64)
     idx = k >> 6
 
     shift = k - (idx << 6)
-    if shift == 0
-        @inbounds a1 = INV_2PI[idx+1]
-        @inbounds a2 = INV_2PI[idx+2]
-        @inbounds a3 = INV_2PI[idx+3]
+    Base.@_safeindex if shift == 0
+        a1 = INV_2PI[idx+1]
+        a2 = INV_2PI[idx+2]
+        a3 = INV_2PI[idx+3]
     else
         # use shifts to extract the relevant 64 bit window
-        @inbounds a1 = (idx < 0 ? zero(UInt64) : INV_2PI[idx+1] << shift) | (INV_2PI[idx+2] >> (64 - shift))
-        @inbounds a2 = (INV_2PI[idx+2] << shift) | (INV_2PI[idx+3] >> (64 - shift))
-        @inbounds a3 = (INV_2PI[idx+3] << shift) | (INV_2PI[idx+4] >> (64 - shift))
+        a1 = (idx < 0 ? zero(UInt64) : INV_2PI[idx+1] << shift) | (INV_2PI[idx+2] >> (64 - shift))
+        a2 = (INV_2PI[idx+2] << shift) | (INV_2PI[idx+3] >> (64 - shift))
+        a3 = (INV_2PI[idx+3] << shift) | (INV_2PI[idx+4] >> (64 - shift))
     end
 
     # 3. Perform the multiplication:

--- a/base/special/rem_pio2.jl
+++ b/base/special/rem_pio2.jl
@@ -165,7 +165,7 @@ function paynehanek(x::Float64)
     idx = k >> 6
 
     shift = k - (idx << 6)
-    Base.@_safeindex if shift == 0
+    Base.@assume_effects :nothrow :noub @inbounds if shift == 0
         a1 = INV_2PI[idx+1]
         a2 = INV_2PI[idx+2]
         a3 = INV_2PI[idx+3]

--- a/test/math.jl
+++ b/test/math.jl
@@ -1547,6 +1547,7 @@ end
             for f = Any[sin, cos, tan, log, log2, log10, log1p, exponent, sqrt, cbrt, fourthroot,
                         asin, atan, acos, sinh, cosh, tanh, asinh, acosh, atanh, exp, exp2, exp10, expm1]
                 @testset let f = f
+                    @test Base.infer_return_type(f, (T,)) != Union{}
                     @test Core.Compiler.is_foldable(Base.infer_effects(f, (T,)))
                 end
             end
@@ -1581,7 +1582,7 @@ end;
         end
     end
 end;
-@test Base.return_types((Int,)) do x
+@test Base.infer_return_type((Int,)) do x
     local r = nothing
     try
         r = sin(x)
@@ -1591,7 +1592,7 @@ end;
         end
     end
     return r
-end |> only === Float64
+end === Float64
 
 @testset "BigInt Rationals with special funcs" begin
     @test sinpi(big(1//1)) == big(0.0)

--- a/test/math.jl
+++ b/test/math.jl
@@ -1542,23 +1542,12 @@ end
 end
 
 @testset "constant-foldability of core math functions" begin
-    for fn in (:sin, :cos, :tan, :log, :log2, :log10, :log1p, :exponent, :sqrt, :cbrt, :fourthroot,
-            :asin, :atan, :acos, :sinh, :cosh, :tanh, :asinh, :acosh, :atanh,
-            :exp, :exp2, :exp10, :expm1
-            )
-        for T in (Float16, Float32, Float64)
-            @testset let f = getfield(@__MODULE__, fn), T = T
-                @test Core.Compiler.is_foldable(Base.infer_effects(f, (T,)))
-            end
-        end
-    end
-end;
-@testset "removability of core math functions" begin
-    for T in (Float16, Float32, Float64)
+    for T = Any[Float16, Float32, Float64]
         @testset let T = T
-            for f in (exp, exp2, exp10)
+            for f = Any[sin, cos, tan, log, log2, log10, log1p, exponent, sqrt, cbrt, fourthroot,
+                        asin, atan, acos, sinh, cosh, tanh, asinh, acosh, atanh, exp, exp2, exp10, expm1]
                 @testset let f = f
-                    @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (T,)))
+                    @test Core.Compiler.is_foldable(Base.infer_effects(f, (T,)))
                 end
             end
             @test Core.Compiler.is_foldable(Base.infer_effects(^, (T,Int)))
@@ -1566,6 +1555,43 @@ end;
         end
     end
 end;
+@testset "removability of core math functions" begin
+    for T = Any[Float16, Float32, Float64]
+        @testset let T = T
+            for f = Any[exp, exp2, exp10, expm1]
+                @testset let f = f
+                    @test Core.Compiler.is_removable_if_unused(Base.infer_effects(f, (T,)))
+                end
+            end
+        end
+    end
+end;
+@testset "exception type inference of core math functions" begin
+    MathErrorT = Union{DomainError, InexactError}
+    for T = (Float16, Float32, Float64)
+        @testset let T = T
+            for f = Any[sin, cos, tan, log, log2, log10, log1p, exponent, sqrt, cbrt, fourthroot,
+                        asin, atan, acos, sinh, cosh, tanh, asinh, acosh, atanh, exp, exp2, exp10, expm1]
+                @testset let f = f
+                    @test Base.infer_exception_type(f, (T,)) <: MathErrorT
+                end
+            end
+            @test Base.infer_exception_type(^, (T,Int)) <: MathErrorT
+            @test Base.infer_exception_type(^, (T,T)) <: MathErrorT
+        end
+    end
+end;
+@test Base.return_types((Int,)) do x
+    local r = nothing
+    try
+        r = sin(x)
+    catch err
+        if err isa DomainError
+            r = 0.0
+        end
+    end
+    return r
+end |> only === Float64
 
 @testset "BigInt Rationals with special funcs" begin
     @test sinpi(big(1//1)) == big(0.0)


### PR DESCRIPTION
Continued from #52241. 

This PR focuses on improving exception type inference for core math functions. Part of the discussion will be exploring an alternative to `Base.@_safeindex`.