### PR TITLE
inference: incorporate stackoverflow possibility into exc type modeling

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -883,6 +883,9 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
     update_valid_age!(caller, frame.valid_worlds)
     effects = adjust_effects(Effects(), method)
     exc_bestguess = refine_exception_type(frame.exc_bestguess, effects)
+    # this call can fail into an infinite cycle, so incorporate this fact into
+    # `exc_bestguess` by merging `StackOverflowError` into it
+    exc_bestguess = tmerge(typeinf_lattice(interp), Core.StackOverflowError, exc_bestguess)
     return EdgeCallResult(frame.bestguess, exc_bestguess, nothing, effects)
 end
 

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -423,12 +423,13 @@ A14009(a::T) where {T} = A14009{T}()
 f14009(a) = rand(Bool) ? f14009(A14009(a)) : a
 code_typed(f14009, (Int,))
 code_llvm(devnull, f14009, (Int,))
+@test Base.infer_exception_type(f14009, (Int,)) != Union{}
 
 mutable struct B14009{T}; end
 g14009(a) = g14009(B14009{a})
 code_typed(g14009, (Type{Int},))
-code_llvm(devnull, f14009, (Int,))
-
+code_llvm(devnull, g14009, (Type{Int},))
+@test Base.infer_exception_type(g14009, (Type{Int},)) == StackOverflowError
 
 # issue #9232
 arithtype9232(::Type{T},::Type{T}) where {T<:Real} = arithtype9232(T)


### PR DESCRIPTION
Currently `exc_bestguess` does not take into account the possibility of stackoverflow error, causing the inconsistency between exception type modeling and `:nothrow` modeling. This commit fixes it up.