### PR TITLE
Add assertion to `_sqrt_quasitriu_diag_block`

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2267,7 +2267,6 @@ function _sqrt_quasitriu_diag_block!(R, A)
         else
             # this branch is never reached when A is complex triangular
             @assert eltype(A) <: Real
-            @assert eltype(R) <: Real
             @views _sqrt_real_2x2!(R[i:(i + 1), i:(i + 1)], A[i:(i + 1), i:(i + 1)])
             i += 2
         end

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2266,6 +2266,8 @@ function _sqrt_quasitriu_diag_block!(R, A)
             i += 1
         else
             # this branch is never reached when A is complex triangular
+            @assert eltype(A) <: Real
+            @assert eltype(R) <: Real
             @views _sqrt_real_2x2!(R[i:(i + 1), i:(i + 1)], A[i:(i + 1), i:(i + 1)])
             i += 2
         end

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2265,7 +2265,7 @@ function _sqrt_quasitriu_diag_block!(R, A)
             R[i, i] = sqrt(ta(A[i, i]))
             i += 1
         else
-            # this branch is never reached when A is complex triangular
+            # This branch is never reached when A is complex triangular
             @assert eltype(A) <: Real
             @views _sqrt_real_2x2!(R[i:(i + 1), i:(i + 1)], A[i:(i + 1), i:(i + 1)])
             i += 2


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/52255

Before this change:
```julia
julia> using JET

julia> report_call(√, Tuple{Matrix{Complex{Float64}}})
═════ 1 possible error found ═════
┌ sqrt(A::Matrix{ComplexF64}) @ LinearAlgebra /home/mason/julia-dev/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/dense.jl:884
│┌ sqrt(A::UpperTriangular{ComplexF64, Matrix{ComplexF64}}) @ LinearAlgebra /home/mason/julia-dev/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/triangular.jl:2159
││┌ sqrt_quasitriu(A0::UpperTriangular{ComplexF64, Matrix{ComplexF64}}) @ LinearAlgebra /home/mason/julia-dev/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/triangular.jl:2184
│││┌ sqrt_quasitriu(A0::UpperTriangular{ComplexF64, Matrix{ComplexF64}}; blockwidth::Int64) @ LinearAlgebra /home/mason/julia-dev/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/triangular.jl:2211
││││┌ kwcall(::@NamedTuple{blockwidth::Int64, n::Int64}, ::typeof(LinearAlgebra._sqrt_quasitriu!), R::Matrix{ComplexF64}, A::UpperTriangular{ComplexF64, Matrix{ComplexF64}}) @ LinearAlgebra /home/mason/julia-dev/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/triangular.jl:2226
│││││┌ _sqrt_quasitriu!(R::Matrix{ComplexF64}, A::UpperTriangular{ComplexF64, Matrix{ComplexF64}}; blockwidth::Int64, n::Int64) @ LinearAlgebra /home/mason/julia-dev/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/triangular.jl:2228
││││││┌ _sqrt_quasitriu_block!(R::Matrix{ComplexF64}, A::UpperTriangular{ComplexF64, Matrix{ComplexF64}}) @ LinearAlgebra /home/mason/julia-dev/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/triangular.jl:2248
│││││││┌ _sqrt_quasitriu_diag_block!(R::Matrix{ComplexF64}, A::UpperTriangular{ComplexF64, Matrix{ComplexF64}}) @ LinearAlgebra /home/mason/julia-dev/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/triangular.jl:2263
││││││││┌ _sqrt_real_2x2!(R::SubArray{ComplexF64, 2, Matrix{ComplexF64}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}, A::SubArray{ComplexF64, 2, UpperTriangular{ComplexF64, Matrix{ComplexF64}}, Tuple{UnitRange{Int64}, UnitRange{Int64}}, false}) @ LinearAlgebra /home/mason/julia-dev/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/triangular.jl:2311
│││││││││┌ _real_sqrt(θ::ComplexF64, μ::Float64) @ LinearAlgebra /home/mason/julia-dev/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/triangular.jl:2323
││││││││││┌ >=(x::ComplexF64, y::Int64) @ Base ./operators.jl:425
│││││││││││┌ <=(x::Int64, y::ComplexF64) @ Base ./operators.jl:401
││││││││││││┌ <(x::Int64, y::ComplexF64) @ Base ./operators.jl:352
│││││││││││││ no matching method found `isless(::Int64, ::ComplexF64)`: isless(x::Int64, y::ComplexF64)
││││││││││││└────────────────────
```

after this change
```julia
julia> report_call(√, Tuple{Matrix{Complex{Float64}}})
No errors detected
```

There was a pre-existing comment in the function claiming "this branch is never reached when A is complex triangular". I don't fully understand why that would be the case, but if we believe it to be true, it would be good to share that information with the compiler. 

I used `@assert` here because it's believed by whoever wrote the algorithm that this branch is unreachable, so I think that's the correct way to use `@assert`, but if people have suggestions for a better way to communicate this info to the compiler, I'd gladly change things around.