### PR TITLE
irinterp: improve semi-concrete interpretation accuracy

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -903,11 +903,13 @@ end
 is_all_const_arg(arginfo::ArgInfo, start::Int) = is_all_const_arg(arginfo.argtypes, start::Int)
 function is_all_const_arg(argtypes::Vector{Any}, start::Int)
     for i = start:length(argtypes)
-        a = widenslotwrapper(argtypes[i])
-        isa(a, Const) || isconstType(a) || issingletontype(a) || return false
+        argtype = widenslotwrapper(argtypes[i])
+        is_const_argtype(argtype) || return false
     end
     return true
 end
+
+is_const_argtype(@nospecialize argtype) = isa(argtype, Const) || isconstType(argtype) || issingletontype(argtype)
 
 any_conditional(argtypes::Vector{Any}) = any(@nospecialize(x)->isa(x, Conditional), argtypes)
 any_conditional(arginfo::ArgInfo) = any_conditional(arginfo.argtypes)

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -956,7 +956,7 @@ function insert_node_here!(compact::IncrementalCompact, newinst::NewInstruction,
     return inst
 end
 
-function delete_inst_here!(compact)
+function delete_inst_here!(compact::IncrementalCompact)
     # Delete the statement, update refcounts etc
     compact[SSAValue(compact.result_idx-1)] = nothing
     # Pretend that we never compacted this statement in the first place

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -23,6 +23,10 @@ mul_wrappers = [
     @test @inferred(f(A)) === A
     g(A) = LinearAlgebra.wrap(A, 'T')
     @test @inferred(g(A)) === transpose(A)
+    # https://github.com/JuliaLang/julia/issues/52202
+    @test Base.infer_return_type((Vector{Float64},)) do v
+        LinearAlgebra.wrap(v, 'N')
+    end == Vector{Float64}
 end
 
 @testset "matrices with zero dimensions" begin

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5592,6 +5592,13 @@ end |> only === Float64
 @test Base.infer_exception_type(c::Missing -> c ? 1 : 2) == TypeError
 @test Base.infer_exception_type(c::Any -> c ? 1 : 2) == TypeError
 
+# semi-concrete interpretation accuracy
+# https://github.com/JuliaLang/julia/issues/50037
+@inline countvars50037(bitflags::Int, var::Int) = bitflags >> 0
+@test Base.infer_return_type() do var::Int
+    Val(countvars50037(1, var))
+end == Val{1}
+
 # Issue #52168
 f52168(x, t::Type) = x::NTuple{2, Base.inferencebarrier(t)::Type}
 @test f52168((1, 2.), Any) === (1, 2.)


### PR DESCRIPTION
By enforcing re-inference on calls with all constant arguments.

While it's debatable whether this approach is the most efficient, it was the easiest choice given that `used_ssas` based on `IncrementaCompact` wasn't an option for irinterp.

- fixes #52202
- fixes #50037