### PR TITLE
Optimize `sort!` for AbstractArray

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1896,24 +1896,37 @@ function sort!(A::AbstractArray{T};
                by=identity,
                rev::Union{Bool,Nothing}=nothing,
                order::Ordering=Forward, # TODO stop eagerly over-allocating.
-               scratch::Union{Vector{T}, Nothing}=Vector{T}(undef, size(A, dims))) where T
-    __sort!(A, Val(dims), maybe_apply_initial_optimizations(alg), ord(lt, by, rev, order), scratch)
-end
-function __sort!(A::AbstractArray{T}, ::Val{K},
-                alg::Algorithm,
-                order::Ordering,
-                scratch::Union{Vector{T}, Nothing}) where {K,T}
+               scratch::Union{Vector{T}, Nothing}=size(A, dims) < 10 ? nothing : Vector{T}(undef, size(A, dims))) where T
     nd = ndims(A)
+    1 <= dims <= nd || throw(ArgumentError("dimension out of range"))
+    alg2 = maybe_apply_initial_optimizations(alg)
+    order2 = ord(lt, by, rev, order)
+    foreach(ntuple(Val, nd)) do d
+        get_value(d) == dims || return
+        # We assume that an Integer between 1 and nd must be equal to one of the
+        # values 1:nd. If this assumption is false, then what's an integer? and
+        # also sort! will silently do nothing.
 
-    1 <= K <= nd || throw(ArgumentError("dimension out of range"))
-
-    remdims = ntuple(i -> i == K ? 1 : axes(A, i), nd)
-    for idx in CartesianIndices(remdims)
-        Av = view(A, ntuple(i -> i == K ? Colon() : idx[i], nd)...)
-        sort!(Av; alg, order, scratch)
+        idxs = CartesianIndices(ntuple(i -> i == get_value(d) ? 1 : axes(A, i), ndims(A)))
+        get_view(idx) = view(A, ntuple(i -> i == get_value(d) ? Colon() : idx[i], ndims(A))...)
+        if d == Val(1) || size(A, get_value(d)) < 30
+            for idx in idxs
+                sort!(get_view(idx); alg=alg2, order=order2, scratch)
+            end
+        else
+            v = similar(get_view(first(idxs)))
+            for idx in idxs
+                vw = get_view(idx)
+                v .= vw
+                sort!(v; alg=alg2, order=order2, scratch)
+                vw .= v
+            end
+        end
+        A
     end
     A
 end
+get_value(::Val{x}) where x = x
 
 
 ## uint mapping to allow radix sorting primitives other than UInts ##


### PR DESCRIPTION
## Concept
- Use `foreach` to union-split on dim rather than using dynamic dispatch. This is
reasonable because it is unrolling to a finite set with size equal to `ndims` (e.g. 2)
For high dimension arrays, this may still use dynamic dispatch (which is okay!)
- When `dims != 0`, we're sorting slices with non-one step size. These are slow to sort
so for large inputs we should copy to a contiguous array, sort that, and copy back.
- For very short inputs, don't even allocate a scratch space.


## Cherrypicked significant performance improvements
```
julia> @btime sort!(x; dims=1) setup=(x=rand(5, 5)) evals=1;
  250.000 ns (2 allocations: 96 bytes) => 125.000 ns (0 allocations: 0 bytes)
julia> @btime sort!(x; dims=2) setup=(x=rand(1013, 42250)) evals=1;
  1.765 s (3042 allocations: 8.36 MiB) => 674.610 ms (3045 allocations: 8.68 MiB)
```

## JET
Before:
```
julia> JET.@report_opt sort!(rand(3,3), dims=1)
═════ 243 possible errors found ═════
┌ kwcall(::@NamedTuple{dims::Int64}, ::typeof(sort!), A::Matrix{Float64}) @ Base.Sort /Users/x/.julia/dev/julia/base/sort.jl:1892
│┌ sort!(A::Matrix{Float64}; dims::Int64, alg::Base.Sort.SubArrayOptimization{Base.Sort.MissingOptimization{Base.Sort.BoolOptimization{Base.Sort.
...
```

After:
```
julia> JET.@report_opt sort!(rand(3,3), dims=1)
No errors detected
```

## Comprehensive reproducible benchmarks

Paste this into a Julia REPL (tested on [master](abfc2c6b57424e32a93a08f6121a8013c50504ee)):

<details>
<summary>Details</summary>

```julia
@eval Base.Sort begin
    function my_sort!(A::AbstractArray{T};
                dims::Integer,
                alg::Algorithm=defalg(A),
                lt=isless,
                by=identity,
                rev::Union{Bool,Nothing}=nothing,
                order::Ordering=Forward, # TODO stop eagerly over-allocating.
                scratch::Union{Vector{T}, Nothing}=size(A, dims) < 10 ? nothing : Vector{T}(undef, size(A, dims))) where T
        nd = ndims(A)
        1 <= dims <= nd || throw(ArgumentError("dimension out of range"))
        alg2 = maybe_apply_initial_optimizations(alg)
        order2 = ord(lt, by, rev, order)
        foreach(ntuple(Val, nd)) do d
            get_value(d) == dims || return
            # We assume that an Integer between 1 and nd must be equal to one of the
            # values 1:nd. If this assumption is false, then what's an integer? and
            # also sort! will silently do nothing.

            idxs = CartesianIndices(ntuple(i -> i == get_value(d) ? 1 : axes(A, i), ndims(A)))
            get_view(idx) = view(A, ntuple(i -> i == get_value(d) ? Colon() : idx[i], ndims(A))...)
            if d == Val(1) || size(A, get_value(d)) < 30
                for idx in idxs
                    sort!(get_view(idx); alg=alg2, order=order2, scratch)
                end
            else
                v = similar(get_view(first(idxs)))
                for idx in idxs
                    vw = get_view(idx)
                    v .= vw
                    sort!(v; alg=alg2, order=order2, scratch)
                    vw .= v
                end
            end
            A
        end
        A
    end
    get_value(::Val{x}) where x = x
end



using StatsBase, Random, Chairmarks
function f()
    Random.seed!(1727)
    axis_sizes = [round(Int, exp(rand()^2*15)) for _ in 1:10]
    for dim in 2:8
        g(Val(dim), axis_sizes)
    end
end
function g(::Val{dim}, axis_sizes) where dim
    sizes = [ntuple(_->rand(axis_sizes), Val(dim)) for _ in 1:50]
    filter!(x->prod(big.(x)) < 1e8, sizes)
    println("dim: $dim, sizes: $(length(sizes))")
    for size in sizes[1:min(10, end)]
        display(size)
        for d in 1:dim
            before = @b rand(size...) rand! sort!(copy(_), dims=d) _ seconds=.5
            after = @b rand(size...) rand! Base.Sort.my_sort!(copy(_), dims=d) _ seconds=.5
            print("$(d): ")
            show(stdout, MIME"text/plain"(), before)
            # print(lpad(round(before.time / prod(size), digits=2), 5))
            print(" => ")
            show(stdout, MIME"text/plain"(), after)
            # print(round(after.time / prod(size), digits=2))
            println()
        end
    end
end
f()

#=
dim: 2, sizes: 48
(3, 4)
1: 127.143 ns (4 allocs: 256 bytes) => 38.807 ns (2 allocs: 176 bytes)
2: 123.053 ns (4 allocs: 272 bytes) => 42.129 ns (2 allocs: 176 bytes)
(3, 99)
1: 912.037 ns (5 allocs: 2.531 KiB) => 848.778 ns (3 allocs: 2.453 KiB)
2: 4.653 μs (5 allocs: 3.281 KiB) => 4.688 μs (7 allocs: 4.109 KiB)
(4, 5)
1: 143.456 ns (4 allocs: 336 bytes) => 61.298 ns (2 allocs: 240 bytes)
2: 145.134 ns (4 allocs: 336 bytes) => 67.490 ns (2 allocs: 240 bytes)
(1, 5)
1: 116.363 ns (4 allocs: 176 bytes) => 28.862 ns (2 allocs: 112 bytes)
2: 113.317 ns (4 allocs: 208 bytes) => 28.679 ns (2 allocs: 112 bytes)
(8929, 3)
1: 278.625 μs (18 allocs: 303.734 KiB) => 255.875 μs (18 allocs: 303.734 KiB)
2: 201.708 μs (5 allocs: 209.469 KiB) => 200.834 μs (3 allocs: 209.391 KiB)
(8929, 4)
1: 376.000 μs (22 allocs: 381.641 KiB) => 375.333 μs (22 allocs: 381.641 KiB)
2: 302.334 μs (5 allocs: 279.234 KiB) => 267.750 μs (3 allocs: 279.141 KiB)
(4, 1013)
1: 28.250 μs (5 allocs: 31.859 KiB) => 28.709 μs (3 allocs: 31.766 KiB)
2: 48.250 μs (18 allocs: 48.266 KiB) => 43.625 μs (21 allocs: 56.266 KiB)
(1013, 42250)
1: 644.391 ms (169006 allocs: 416.763 MiB) => 621.138 ms (169006 allocs: 416.802 MiB, 4.86% gc time)
2: 1.773 s (3045 allocs: 334.893 MiB, 0.03% gc time, without a warmup) => 708.578 ms (3048 allocs: 335.215 MiB, 0.58% gc time)
(8929, 8929)
1: 1.064 s (35722 allocs: 679.458 MiB, 6.23% gc time, without a warmup) => 980.343 ms (35722 allocs: 679.458 MiB, 2.43% gc time)
2: 3.066 s (26793 allocs: 679.185 MiB, 0.02% gc time, without a warmup) => 1.375 s (26796 allocs: 679.253 MiB, 0.04% gc time, without a warmup)
(42250, 5)
1: 2.373 ms (26 allocs: 1.974 MiB) => 2.385 ms (26 allocs: 1.974 MiB)
2: 2.098 ms (5 allocs: 1.612 MiB) => 2.072 ms (3 allocs: 1.612 MiB)
dim: 3, sizes: 34
(3, 1, 1013)
1: 18.708 μs (5 allocs: 23.906 KiB) => 19.000 μs (3 allocs: 23.828 KiB)
2: 6.111 μs (5 allocs: 23.891 KiB) => 6.028 μs (3 allocs: 23.828 KiB)
3: 36.417 μs (15 allocs: 38.203 KiB) => 33.000 μs (18 allocs: 46.203 KiB)
(1324, 5, 1013)
1: 87.178 ms (20266 allocs: 62.013 MiB) => 87.355 ms (20266 allocs: 62.017 MiB)
2: 71.437 ms (5 allocs: 51.163 MiB) => 71.570 ms (3 allocs: 51.163 MiB)
3: 124.363 ms (19866 allocs: 65.083 MiB) => 100.438 ms (19869 allocs: 65.073 MiB)
(5, 1013, 3)
1: 133.208 μs (5 allocs: 118.922 KiB) => 130.167 μs (3 allocs: 118.828 KiB)
2: 218.500 μs (51 allocs: 158.703 KiB) => 192.916 μs (54 allocs: 166.703 KiB)
3: 115.208 μs (5 allocs: 118.906 KiB) => 115.792 μs (3 allocs: 118.828 KiB)
(4, 5, 4)
1: 317.568 ns (4 allocs: 816 bytes) => 227.941 ns (2 allocs: 720 bytes)
2: 325.397 ns (4 allocs: 816 bytes) => 266.562 ns (2 allocs: 720 bytes)
3: 299.887 ns (4 allocs: 816 bytes) => 222.826 ns (2 allocs: 720 bytes)
(5, 1013, 1324)
1: 66.252 ms (5 allocs: 51.163 MiB) => 67.065 ms (3 allocs: 51.163 MiB)
2: 104.007 ms (19866 allocs: 65.079 MiB) => 96.158 ms (19869 allocs: 65.110 MiB)
3: 125.701 ms (15201 allocs: 61.882 MiB) => 102.165 ms (15204 allocs: 61.870 MiB)
(5, 1, 4)
1: 161.607 ns (4 allocs: 336 bytes) => 70.513 ns (2 allocs: 240 bytes)
2: 134.448 ns (4 allocs: 304 bytes) => 68.921 ns (2 allocs: 240 bytes)
3: 141.889 ns (4 allocs: 336 bytes) => 65.497 ns (2 allocs: 240 bytes)
(4, 42250, 4)
1: 6.158 ms (5 allocs: 5.158 MiB) => 6.385 ms (3 allocs: 5.158 MiB)
2: 9.298 ms (54 allocs: 5.607 MiB) => 7.481 ms (57 allocs: 5.929 MiB)
3: 6.890 ms (5 allocs: 5.158 MiB) => 6.847 ms (3 allocs: 5.158 MiB)
(5, 3, 4)
1: 277.439 ns (4 allocs: 688 bytes) => 184.145 ns (2 allocs: 592 bytes)
2: 230.731 ns (4 allocs: 672 bytes) => 157.369 ns (2 allocs: 592 bytes)
3: 249.534 ns (4 allocs: 688 bytes) => 171.875 ns (2 allocs: 592 bytes)
(99, 4, 4)
1: 41.833 μs (5 allocs: 13.281 KiB) => 43.500 μs (5 allocs: 13.281 KiB)
2: 8.417 μs (5 allocs: 12.547 KiB) => 7.967 μs (3 allocs: 12.453 KiB)
3: 8.806 μs (5 allocs: 12.547 KiB) => 7.800 μs (3 allocs: 12.453 KiB)
(3, 342, 4)
1: 25.208 μs (5 allocs: 32.219 KiB) => 25.791 μs (3 allocs: 32.141 KiB)
2: 60.791 μs (30 allocs: 48.016 KiB) => 54.750 μs (33 allocs: 50.766 KiB)
3: 31.584 μs (5 allocs: 32.234 KiB) => 31.625 μs (3 allocs: 32.141 KiB)
dim: 4, sizes: 31
(5, 4, 1, 8929)
1: 1.550 ms (5 allocs: 1.363 MiB) => 1.769 ms (3 allocs: 1.363 MiB)
2: 1.831 ms (5 allocs: 1.363 MiB) => 1.522 ms (3 allocs: 1.363 MiB)
3: 547.333 μs (5 allocs: 1.363 MiB) => 531.166 μs (3 allocs: 1.363 MiB)
4: 3.389 ms (66 allocs: 1.590 MiB) => 2.317 ms (69 allocs: 1.658 MiB)
(8929, 4, 1, 5)
1: 1.919 ms (86 allocs: 1.590 MiB) => 1.938 ms (86 allocs: 1.590 MiB)
2: 1.748 ms (5 allocs: 1.363 MiB) => 1.770 ms (3 allocs: 1.363 MiB)
3: 439.875 μs (5 allocs: 1.363 MiB) => 462.666 μs (3 allocs: 1.363 MiB)
4: 1.869 ms (5 allocs: 1.363 MiB) => 1.882 ms (3 allocs: 1.363 MiB)
(42250, 5, 4, 3)
1: 28.267 ms (246 allocs: 20.141 MiB) => 28.289 ms (246 allocs: 20.141 MiB)
2: 28.098 ms (5 allocs: 19.341 MiB) => 27.544 ms (3 allocs: 19.341 MiB)
3: 26.877 ms (5 allocs: 19.341 MiB) => 27.277 ms (3 allocs: 19.341 MiB)
4: 22.180 ms (5 allocs: 19.341 MiB) => 25.248 ms (3 allocs: 19.341 MiB)
(3, 3, 8929, 5)
1: 3.449 ms (5 allocs: 3.066 MiB) => 3.387 ms (3 allocs: 3.066 MiB)
2: 3.552 ms (5 allocs: 3.066 MiB) => 3.941 ms (3 allocs: 3.066 MiB)
3: 7.076 ms (141 allocs: 3.491 MiB) => 5.352 ms (144 allocs: 3.559 MiB)
4: 3.876 ms (5 allocs: 3.066 MiB) => 4.577 ms (3 allocs: 3.066 MiB)
(99, 4, 1, 8929)
1: 134.327 ms (5 allocs: 26.978 MiB) => 133.530 ms (5 allocs: 26.978 MiB)
2: 37.262 ms (5 allocs: 26.977 MiB) => 36.863 ms (3 allocs: 26.977 MiB)
3: 10.043 ms (5 allocs: 26.977 MiB) => 10.941 ms (3 allocs: 26.977 MiB)
4: 63.411 ms (1194 allocs: 30.187 MiB) => 48.480 ms (1197 allocs: 30.255 MiB)
(4, 5, 342, 99)
1: 5.993 ms (5 allocs: 5.167 MiB) => 5.806 ms (3 allocs: 5.166 MiB)
2: 6.448 ms (5 allocs: 5.167 MiB) => 7.625 ms (3 allocs: 5.166 MiB)
3: 12.422 ms (3971 allocs: 7.289 MiB) => 11.608 ms (3974 allocs: 7.292 MiB)
4: 22.451 ms (5 allocs: 5.167 MiB) => 20.817 ms (7 allocs: 5.168 MiB)
(1324, 5, 1, 8929)
1: 1.016 s (178586 allocs: 546.610 MiB, 0.06% gc time, without a warmup) => 1.010 s (178586 allocs: 546.761 MiB, 3.50% gc time)
2: 906.308 ms (5 allocs: 450.974 MiB) => 675.710 ms (3 allocs: 450.973 MiB, 0.83% gc time)
3: 234.439 ms (5 allocs: 450.974 MiB) => 567.812 ms (3 allocs: 450.973 MiB, 57.18% gc time)
4: 2.798 s (19866 allocs: 503.569 MiB, without a warmup) => 1.014 s (19869 allocs: 503.637 MiB, without a warmup)
(1324, 1324, 4, 5)
1: 535.029 ms (105926 allocs: 324.202 MiB, 1.74% gc time) => 485.721 ms (105926 allocs: 324.295 MiB)
2: 639.796 ms (79446 allocs: 323.442 MiB, 1.41% gc time) => 542.390 ms (79449 allocs: 323.521 MiB, 2.57% gc time)
3: 534.137 ms (5 allocs: 267.483 MiB) => 386.851 ms (3 allocs: 267.483 MiB, 0.83% gc time)
4: 452.627 ms (5 allocs: 267.483 MiB) => 397.876 ms (3 allocs: 267.483 MiB, 0.84% gc time)
(3, 3, 3, 1324)
1: 250.291 μs (5 allocs: 279.484 KiB) => 251.208 μs (3 allocs: 279.406 KiB)
2: 279.250 μs (5 allocs: 279.484 KiB) => 277.917 μs (3 allocs: 279.406 KiB)
3: 298.000 μs (5 allocs: 279.484 KiB) => 280.750 μs (3 allocs: 279.406 KiB)
4: 463.791 μs (87 allocs: 347.219 KiB) => 407.458 μs (90 allocs: 357.656 KiB)
(4, 1324, 1, 4)
1: 158.334 μs (5 allocs: 165.688 KiB) => 159.042 μs (3 allocs: 165.594 KiB)
2: 258.000 μs (54 allocs: 210.031 KiB) => 234.250 μs (57 allocs: 220.469 KiB)
3: 54.458 μs (5 allocs: 165.656 KiB) => 54.916 μs (3 allocs: 165.594 KiB)
4: 192.708 μs (5 allocs: 165.688 KiB) => 189.834 μs (3 allocs: 165.594 KiB)
dim: 5, sizes: 13
(5, 4, 3, 1324, 99)
1: 91.978 ms (5 allocs: 60.002 MiB) => 88.790 ms (5 allocs: 60.002 MiB)
2: 86.060 ms (5 allocs: 60.002 MiB) => 83.487 ms (5 allocs: 60.002 MiB)
3: 78.708 ms (5 allocs: 60.002 MiB) => 83.514 ms (5 allocs: 60.002 MiB)
4: 124.398 ms (17826 allocs: 72.544 MiB) => 112.153 ms (17831 allocs: 72.558 MiB)
5: 312.555 ms (5 allocs: 60.003 MiB) => 282.497 ms (9 allocs: 60.004 MiB, 7.21% gc time)
(3, 3, 1324, 3, 1324)
1: 453.972 ms (5 allocs: 361.102 MiB, 1.84% gc time) => 651.084 ms (5 allocs: 361.102 MiB)
2: 509.070 ms (5 allocs: 361.102 MiB, 0.98% gc time) => 502.113 ms (5 allocs: 361.102 MiB, 1.02% gc time)
3: 1.045 s (107250 allocs: 436.710 MiB) => 709.660 ms (107255 allocs: 436.685 MiB, 1.42% gc time)
4: 542.152 ms (5 allocs: 361.102 MiB, 0.93% gc time) => 801.461 ms (5 allocs: 361.102 MiB)
5: 1.766 s (107250 allocs: 436.751 MiB, without a warmup) => 841.281 ms (107255 allocs: 436.779 MiB, 1.40% gc time)
(1013, 1, 1, 4, 8929)
1: 656.655 ms (142870 allocs: 352.302 MiB, 3.87% gc time) => 874.643 ms (142872 allocs: 352.261 MiB, 17.99% gc time)
2: 155.489 ms (5 allocs: 276.034 MiB) => 160.155 ms (5 allocs: 276.034 MiB)
3: 195.101 ms (5 allocs: 276.034 MiB) => 176.696 ms (5 allocs: 276.034 MiB, 3.44% gc time)
4: 789.449 ms (5 allocs: 276.034 MiB) => 531.671 ms (5 allocs: 276.034 MiB, 1.18% gc time)
5: 2.427 s (12162 allocs: 308.253 MiB, 0.02% gc time, without a warmup) => 820.659 ms (12167 allocs: 308.321 MiB, 1.06% gc time)
(1, 4, 3, 1013, 99)
1: 4.857 ms (5 allocs: 9.182 MiB) => 5.066 ms (5 allocs: 9.182 MiB)
2: 13.602 ms (5 allocs: 9.182 MiB) => 14.592 ms (5 allocs: 9.182 MiB)
3: 13.035 ms (5 allocs: 9.182 MiB) => 12.697 ms (5 allocs: 9.182 MiB)
4: 21.262 ms (3570 allocs: 11.678 MiB) => 17.584 ms (3575 allocs: 11.686 MiB)
5: 51.728 ms (5 allocs: 9.182 MiB) => 45.888 ms (9 allocs: 9.183 MiB)
(342, 3, 5, 1, 8929)
1: 1.359 s (402540 allocs: 497.353 MiB, 0.08% gc time, without a warmup) => 1.263 s (402484 allocs: 497.294 MiB, 0.06% gc time, without a warmup)
2: 534.070 ms (5 allocs: 349.471 MiB, 0.96% gc time) => 738.856 ms (5 allocs: 349.470 MiB)
3: 613.556 ms (5 allocs: 349.471 MiB, 0.91% gc time) => 604.130 ms (5 allocs: 349.470 MiB, 1.00% gc time)
4: 489.424 ms (5 allocs: 349.470 MiB) => 222.259 ms (5 allocs: 349.470 MiB, 2.55% gc time)
5: 2.951 s (15396 allocs: 390.243 MiB, 3.52% gc time, without a warmup) => 1.312 s (15401 allocs: 390.311 MiB, without a warmup)
(5, 1324, 1, 4, 4)
1: 1.077 ms (5 allocs: 827.688 KiB) => 1.040 ms (5 allocs: 827.656 KiB)
2: 1.462 ms (246 allocs: 1008.031 KiB) => 1.310 ms (251 allocs: 1018.531 KiB)
3: 297.000 μs (5 allocs: 827.656 KiB) => 309.083 μs (5 allocs: 827.656 KiB)
4: 1.116 ms (5 allocs: 827.688 KiB) => 1.112 ms (5 allocs: 827.656 KiB)
5: 1.092 ms (5 allocs: 827.688 KiB) => 1.108 ms (5 allocs: 827.656 KiB)
(3, 3, 5, 1, 8929)
1: 3.608 ms (5 allocs: 3.066 MiB) => 3.599 ms (5 allocs: 3.066 MiB)
2: 4.157 ms (5 allocs: 3.066 MiB) => 4.109 ms (5 allocs: 3.066 MiB)
3: 4.582 ms (5 allocs: 3.066 MiB) => 4.764 ms (5 allocs: 3.066 MiB)
4: 1.437 ms (5 allocs: 3.066 MiB) => 1.525 ms (5 allocs: 3.066 MiB)
5: 7.926 ms (141 allocs: 3.491 MiB) => 5.558 ms (146 allocs: 3.559 MiB)
(5, 342, 5, 1324, 4)
1: 872.959 ms (5 allocs: 345.465 MiB) => 646.833 ms (5 allocs: 345.465 MiB, 0.95% gc time)
2: 1.388 s (265506 allocs: 487.591 MiB, 11.16% gc time, without a warmup) => 1.137 s (265511 allocs: 487.594 MiB, 7.26% gc time, without a warmup)
3: 691.208 ms (5 allocs: 345.465 MiB, 4.60% gc time) => 905.029 ms (5 allocs: 345.465 MiB)
4: 1.141 s (102606 allocs: 417.767 MiB, without a warmup) => 1.109 s (102611 allocs: 417.756 MiB, 1.18% gc time)
5: 979.889 ms (5 allocs: 345.465 MiB) => 678.187 ms (5 allocs: 345.465 MiB, 0.86% gc time)
(5, 5, 99, 3, 1324)
1: 129.351 ms (5 allocs: 75.003 MiB) => 146.010 ms (5 allocs: 75.002 MiB)
2: 203.801 ms (5 allocs: 75.003 MiB) => 144.761 ms (5 allocs: 75.002 MiB)
3: 1.108 s (5 allocs: 75.003 MiB, without a warmup) => 978.406 ms (9 allocs: 75.004 MiB)
4: 153.973 ms (5 allocs: 75.002 MiB) => 189.611 ms (5 allocs: 75.002 MiB)
5: 499.948 ms (22281 allocs: 90.706 MiB, 20.41% gc time) => 240.902 ms (22286 allocs: 90.710 MiB)
(8929, 342, 1, 3, 5)
1: 1.306 s (20526 allocs: 390.400 MiB, 0.05% gc time, without a warmup) => 1.350 s (20528 allocs: 390.400 MiB, 0.07% gc time, without a warmup)
2: 2.167 s (268562 allocs: 493.222 MiB, 0.05% gc time, without a warmup) => 1.477 s (268557 allocs: 493.215 MiB, 0.07% gc time, without a warmup)
3: 156.110 ms (5 allocs: 349.470 MiB, 2.64% gc time) => 283.390 ms (5 allocs: 349.470 MiB)
4: 604.345 ms (5 allocs: 349.471 MiB) => 542.328 ms (5 allocs: 349.470 MiB, 0.85% gc time)
5: 595.105 ms (5 allocs: 349.471 MiB) => 598.209 ms (5 allocs: 349.470 MiB, 0.95% gc time)
dim: 6, sizes: 6
(5, 8929, 3, 99, 1, 3)
1: 467.147 ms (5 allocs: 303.488 MiB, 2.07% gc time) => 510.636 ms (3 allocs: 303.487 MiB, 8.13% gc time)
2: 678.903 ms (13371 allocs: 338.904 MiB, 1.30% gc time) => 576.285 ms (13374 allocs: 338.972 MiB, 1.01% gc time)
3: 633.674 ms (5 allocs: 303.488 MiB) => 498.466 ms (3 allocs: 303.487 MiB, 1.23% gc time)
4: 1.661 s (202559 allocs: 315.978 MiB, 0.04% gc time, 2.31% compile time, without a warmup) => 1.515 s (7 allocs: 303.489 MiB, 0.14% gc time, without a warmup)
5: 195.160 ms (5 allocs: 303.488 MiB, 5.08% gc time) => 233.657 ms (3 allocs: 303.487 MiB)
6: 741.991 ms (5 allocs: 303.488 MiB) => 511.727 ms (3 allocs: 303.487 MiB, 1.23% gc time)
(3, 1324, 1, 3, 5, 3)
1: 1.644 ms (5 allocs: 1.364 MiB) => 1.642 ms (3 allocs: 1.364 MiB)
2: 2.882 ms (411 allocs: 1.654 MiB) => 2.513 ms (414 allocs: 1.664 MiB)
3: 643.084 μs (5 allocs: 1.364 MiB) => 640.750 μs (3 allocs: 1.364 MiB)
4: 1.998 ms (5 allocs: 1.364 MiB) => 2.044 ms (3 allocs: 1.364 MiB)
5: 2.247 ms (5 allocs: 1.364 MiB) => 2.309 ms (3 allocs: 1.364 MiB)
6: 2.098 ms (5 allocs: 1.364 MiB) => 2.071 ms (3 allocs: 1.364 MiB)
(1324, 1, 5, 1, 3, 5)
1: 1.394 ms (306 allocs: 948.078 KiB) => 1.340 ms (306 allocs: 948.078 KiB)
2: 312.875 μs (5 allocs: 775.984 KiB) => 317.958 μs (3 allocs: 775.922 KiB)
3: 1.216 ms (5 allocs: 776.016 KiB) => 1.175 ms (3 allocs: 775.922 KiB)
4: 312.042 μs (5 allocs: 775.984 KiB) => 357.250 μs (3 allocs: 775.922 KiB)
5: 1.164 ms (5 allocs: 776.000 KiB) => 1.144 ms (3 allocs: 775.922 KiB)
6: 1.250 ms (5 allocs: 776.016 KiB) => 1.218 ms (3 allocs: 775.922 KiB)
(42250, 4, 99, 1, 5, 1)
1: 1.841 s (7926 allocs: 654.330 MiB, 3.61% gc time, without a warmup) => 1.648 s (7926 allocs: 654.330 MiB, 9.06% gc time, without a warmup)
2: 1.138 s (5 allocs: 638.237 MiB, 0.07% gc time, without a warmup) => 1.149 s (3 allocs: 638.237 MiB, 0.07% gc time, without a warmup)
3: 3.806 s (5 allocs: 638.238 MiB, 0.02% gc time, without a warmup) => 3.969 s (7 allocs: 638.239 MiB, 0.02% gc time, without a warmup)
4: 432.397 ms (5 allocs: 638.237 MiB, 2.35% gc time) => 689.780 ms (3 allocs: 638.237 MiB)
5: 1.203 s (5 allocs: 638.237 MiB, without a warmup) => 1.191 s (3 allocs: 638.237 MiB, 0.06% gc time, without a warmup)
6: 382.427 ms (5 allocs: 638.237 MiB, 1.91% gc time) => 327.421 ms (3 allocs: 638.237 MiB, 1.94% gc time)
(99, 99, 4, 3, 4, 4)
1: 67.652 ms (5 allocs: 14.358 MiB) => 72.922 ms (5 allocs: 14.358 MiB)
2: 75.716 ms (5 allocs: 14.358 MiB) => 68.922 ms (7 allocs: 14.359 MiB)
3: 24.260 ms (5 allocs: 14.357 MiB) => 23.592 ms (3 allocs: 14.357 MiB)
4: 20.471 ms (5 allocs: 14.357 MiB) => 21.712 ms (3 allocs: 14.357 MiB)
5: 23.372 ms (5 allocs: 14.357 MiB) => 23.970 ms (3 allocs: 14.357 MiB)
6: 23.868 ms (5 allocs: 14.357 MiB) => 23.387 ms (3 allocs: 14.357 MiB)
(3, 3, 3, 342, 1, 1013)
1: 98.058 ms (5 allocs: 71.366 MiB) => 97.565 ms (3 allocs: 71.366 MiB)
2: 115.064 ms (5 allocs: 71.366 MiB) => 115.090 ms (3 allocs: 71.366 MiB)
3: 115.297 ms (5 allocs: 71.366 MiB) => 115.667 ms (3 allocs: 71.366 MiB)
4: 200.658 ms (54837 allocs: 100.712 MiB) => 179.335 ms (54835 allocs: 100.710 MiB)
5: 41.974 ms (5 allocs: 71.366 MiB) => 43.589 ms (3 allocs: 71.366 MiB)
6: 255.173 ms (27708 allocs: 90.784 MiB) => 186.030 ms (27711 allocs: 90.776 MiB)
dim: 7, sizes: 1
(3, 3, 99, 4, 4, 1013, 4)
1: 733.529 ms (5 allocs: 440.715 MiB) => 533.793 ms (3 allocs: 440.714 MiB, 0.92% gc time)
2: 652.837 ms (5 allocs: 440.715 MiB) => 690.435 ms (3 allocs: 440.714 MiB, 1.05% gc time)
3: 2.060 s (211223 allocs: 453.731 MiB, 0.04% gc time, 1.37% compile time, without a warmup) => 1.875 s (7 allocs: 440.716 MiB, 0.11% gc time, without a warmup)
4: 705.417 ms (5 allocs: 440.715 MiB, 1.18% gc time) => 678.945 ms (3 allocs: 440.714 MiB, 0.77% gc time)
5: 783.959 ms (5 allocs: 440.715 MiB, 10.65% gc time) => 694.904 ms (3 allocs: 440.714 MiB, 0.99% gc time)
6: 1.247 s (384022 allocs: 573.813 MiB, 6.79% gc time, 2.36% compile time, without a warmup) => 977.739 ms (171081 allocs: 560.771 MiB, 2.71% gc time)
7: 693.616 ms (5 allocs: 440.715 MiB, 1.05% gc time) => 795.938 ms (3 allocs: 440.714 MiB, 11.49% gc time)
dim: 8, sizes: 1
(4, 3, 1, 5, 5, 1, 1013, 1)
1: 3.050 ms (5 allocs: 2.319 MiB) => 2.986 ms (3 allocs: 2.319 MiB)
2: 3.210 ms (5 allocs: 2.319 MiB) => 3.200 ms (3 allocs: 2.319 MiB)
3: 1.163 ms (5 allocs: 2.319 MiB) => 1.282 ms (3 allocs: 2.319 MiB)
4: 3.501 ms (5 allocs: 2.319 MiB) => 3.542 ms (3 allocs: 2.319 MiB)
5: 3.455 ms (5 allocs: 2.319 MiB) => 3.483 ms (3 allocs: 2.319 MiB)
6: 1.243 ms (5 allocs: 2.319 MiB) => 1.340 ms (3 allocs: 2.319 MiB)
7: 4.268 ms (906 allocs: 2.951 MiB) => 3.835 ms (909 allocs: 2.957 MiB)
8: 1.214 ms (5 allocs: 2.319 MiB) => 1.282 ms (3 allocs: 2.319 MiB)
=#
```

</details>

After this PR, `sort!` may (TBD by with more benchmarks) be fast enough that we can get rid of the special case for `sort`.