### PR TITLE
Don't print "No global of this name exists in this module." on UndefValError

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2347,7 +2347,7 @@ julia> module M end;
 
 julia> M.a  # same as `getglobal(M, :a)`
 ERROR: UndefVarError: `a` not defined in `M`
-Suggestion: check for spelling errors or missing imports. No global of this name exists in this module.
+Suggestion: check for spelling errors or missing imports.
 
 julia> setglobal!(M, :a, 1)
 1

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -863,7 +863,7 @@ end
                foo
            end
     ERROR: UndefVarError: `foo` not defined in `Main`
-    Suggestion: check for spelling errors or missing imports. No global of this name exists in this module.
+    Suggestion: check for spelling errors or missing imports.
     ```
     Use the [`local` keyword](@ref local-scope) outside the `try` block to make the variable
     accessible from anywhere within the outer scope.

--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -91,7 +91,7 @@ julia> module D
            b = a # errors as D's global scope is separate from A's
        end;
 ERROR: UndefVarError: `a` not defined in `D`
-Suggestion: check for spelling errors or missing imports. No global of this name exists in this module.
+Suggestion: check for spelling errors or missing imports.
 ```
 
 If a top-level expression contains a variable declaration with keyword `local`,

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -1409,7 +1409,9 @@ function UndefVarError_hint(io::IO, ex::UndefVarError)
             else
                 owner = ccall(:jl_binding_owner, Ptr{Cvoid}, (Any, Any), scope, var)
                 if C_NULL == owner
-                    print(io, "\nSuggestion: check for spelling errors or missing imports. No global of this name exists in this module.")
+                    # No global of this name exists in this module.
+                    # This is the common case, so do not print that information.
+                    print(io, "\nSuggestion: check for spelling errors or missing imports.")
                     owner = bnd
                 else
                     owner = unsafe_pointer_to_objref(owner)::Core.Binding


### PR DESCRIPTION
When we get an `UndefValError`, we know `!isdefined(Main, :a)`. This is highly correlated with "No global of this name exists in this module." Consequently, the second sentence in the suggestion

```
julia> a
ERROR: UndefVarError: `a` not defined in `Main`
Suggestion: check for spelling errors or missing imports. No global of this name exists in this module.
```

Carries less than one bit of information. I don't like showing users hints that carry less than one bit per sentence. In the cases where a global does exist, that sentence carries much more information and is worth keeping. In any event, a super power user can infer from the lack of that sentence that no global exists.

Master
```
julia> function f()
           global a = 2
       end
f (generic function with 1 method)

julia> a
ERROR: UndefVarError: `a` not defined in `Main`
Suggestion: add an appropriate import or assignment. This global was declared but not assigned.

julia> b
ERROR: UndefVarError: `b` not defined in `Main`
Suggestion: check for spelling errors or missing imports. No global of this name exists in this module.
```

PR
```
julia> function f()
           global a = 2
       end
f (generic function with 1 method)

julia> a
ERROR: UndefVarError: `a` not defined in `Main`
Suggestion: add an appropriate import or assignment. This global was declared but not assigned.

julia> b
ERROR: UndefVarError: `b` not defined in `Main`
Suggestion: check for spelling errors or missing imports.
```

Fixes #52273 (cc @vtjnash @jishnub)