### PR TITLE
Remove timer upper bound

### DIFF
--- a/test/channels.jl
+++ b/test/channels.jl
@@ -559,7 +559,7 @@ end
     e = @elapsed for i = 1:5
         wait(t)
     end
-    @test 1.5 > e >= 0.4
+    @test e >= 0.4
     @test a[] == 0
     nothing
 end


### PR DESCRIPTION
Fixes #52258

From the `?Timer` docstring,

"Waiting tasks are woken after an initial delay of at least delay seconds, and then repeating after at least interval seconds again elapse."

There is no guaranteed upper bound.