### PR TITLE
Avoid `unalias()` for matching `Array{T}` when broadcasting

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -945,6 +945,11 @@ end
 broadcast_unalias(dest, src) = dest === src ? src : unalias(dest, src)
 broadcast_unalias(::Nothing, src) = src
 
+# `Base.mightalias` considers two arrays to be aliased iff they have the same
+# base pointer in memory, which is exactly the case where it is safe to not
+# make a defensive copy due to the traversal mentioned above.
+broadcast_unalias(dest::Array{T}, src::Array{T}) where T = src
+
 # Preprocessing a `Broadcasted` does two things:
 # * unaliases any arguments from `dest`
 # * "extrudes" the arguments where it is advantageous to pre-compute the broadcasted indices


### PR DESCRIPTION
It would be good to some review of the reasoning here.

I am assuming that:
  - `Base.mightalias` considers two `Array{T}` to be aliased iff they have the same base pointer in memory
  - `broadcast!(f, A, ..., A, ...)` enforces that the two arrays have the same dimensions
  
This implies that when we do an `unaliascopy()` for arrays of the same type, the arrays were aligned element-for-element in memory anyway, which is exactly the case where it is safe to not make a defensive copy due to the traversal mentioned just above.