### PR TITLE
Improve type-inference in complex eigen

### DIFF
--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -173,7 +173,8 @@ function eigen!(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true, sortb
     n = size(A, 2)
     n == 0 && return Eigen(zeros(T, 0), zeros(T, 0, 0))
     ishermitian(A) && return eigen!(Hermitian(A), sortby=sortby)
-    eval, evec = LAPACK.geevx!(permute ? (scale ? 'B' : 'P') : (scale ? 'S' : 'N'), 'N', 'V', 'N', A)[[2,4]]
+    E = LAPACK.geevx!(permute ? (scale ? 'B' : 'P') : (scale ? 'S' : 'N'), 'N', 'V', 'N', A)
+    eval, evec = E[2], E[4]
     return Eigen(sorteig!(eval, evec, sortby)...)
 end
 

--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -243,7 +243,7 @@ end
     @test F.vectors ≈ F32.vectors
 end
 
-@testset "complex eigen inference" begin
+@testset "complex eigen inference (#52289)" begin
     A = ComplexF64[1.0 0.0; 0.0 8.0]
     TC = Eigen{ComplexF64, ComplexF64, Matrix{ComplexF64}, Vector{ComplexF64}}
     TR = Eigen{ComplexF64, Float64, Matrix{ComplexF64}, Vector{Float64}}

--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -243,4 +243,12 @@ end
     @test F.vectors ≈ F32.vectors
 end
 
+@testset "complex eigen inference" begin
+    A = ComplexF64[1.0 0.0; 0.0 8.0]
+    TC = Eigen{ComplexF64, ComplexF64, Matrix{ComplexF64}, Vector{ComplexF64}}
+    TR = Eigen{ComplexF64, Float64, Matrix{ComplexF64}, Vector{Float64}}
+    λ, v = @inferred Union{TR,TC} eigen(A)
+    @test λ == [1.0, 8.0]
+end
+
 end # module TestEigen


### PR DESCRIPTION
Indexing using integers instead of a `Vector` uses constant-propagation to improve the inferred return types. After this, the return type of `eigen(::Matrix{ComplexF64})` is inferred as a small union.
```julia
julia> @code_typed eigen(rand(ComplexF64,2,2))
CodeInfo(
1 ─ %1 = invoke LinearAlgebra.:(var"#eigen#94")(true::Bool, true::Bool, LinearAlgebra.eigsortby::typeof(LinearAlgebra.eigsortby), #self#::typeof(eigen), A::Matrix{ComplexF64})::Union{Eigen{ComplexF64, ComplexF64, Matrix{ComplexF64}, Vector{ComplexF64}}, Eigen{ComplexF64, Float64, Matrix{ComplexF64}, Vector{Float64}}}
└──      return %1
) => Union{Eigen{ComplexF64, ComplexF64, Matrix{ComplexF64}, Vector{ComplexF64}}, Eigen{ComplexF64, Float64, Matrix{ComplexF64}, Vector{Float64}}}
```
Close JuliaLang/LinearAlgebra.jl#1039 