### PR TITLE
Bail out of constprop if we already know it's gonna throw an error

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -872,7 +872,7 @@ function bail_out_const_call(interp::AbstractInterpreter, result::MethodCallResu
     elseif result.rt === Bottom
         if is_terminates(result.effects) && is_effect_free(result.effects)
             # In the future, we may want to add `&& isa(result.exct, Const)` to
-            # the list of conditions here, but currently, our effect system is
+            # the list of conditions here, but currently, our effect system isn't
             # precise enough to let us determine :consistency of `exct`, so we
             # would have to force constprop just to determine this, which is too
             # expensive.

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -869,6 +869,15 @@ function bail_out_const_call(interp::AbstractInterpreter, result::MethodCallResu
         if isa(result.rt, Const) || call_result_unused(si)
             return true
         end
+    elseif result.rt === Bottom
+        if is_terminates(result.effects) && is_effect_free(result.effects)
+            # In the future, we may want to add `&& isa(result.exct, Const)` to
+            # the list of conditions here, but currently, our effect system is
+            # precise enough to let us determine :consistency of `exct`, so we
+            # would have to force constprop just to determine this, which is too
+            # expensive.
+            return true
+        end
     end
     return false
 end


### PR DESCRIPTION
While looking at some other things, I noticed that we call concrete evaluation on every `error("foo")`-like call just to find out again that it errors. which is obviously wasteful. In the future we may want to model exception-`:consistent`-cy in which case there could be some additional `exct` refinement here, but we're not there yet.