### PR TITLE
speed up `first` and `only` for various types

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -446,7 +446,7 @@ julia> firstindex(rand(3,4,5), 2)
 firstindex(a::AbstractArray) = (@inline; first(eachindex(IndexLinear(), a)))
 firstindex(a, d) = (@inline; first(axes(a, d)))
 
-@propagate_inbounds first(a::AbstractArray) = a[firstindex(a)]
+@propagate_inbounds first(a::AbstractArray) = a[first(eachindex(a))]
 
 """
     first(coll)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -446,7 +446,7 @@ julia> firstindex(rand(3,4,5), 2)
 firstindex(a::AbstractArray) = (@inline; first(eachindex(IndexLinear(), a)))
 firstindex(a, d) = (@inline; first(axes(a, d)))
 
-first(a::AbstractArray) = a[first(eachindex(a))]
+@propagate_inbounds first(a::AbstractArray) = a[firstindex(a)]
 
 """
     first(coll)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -735,10 +735,10 @@ end
 end
 @propagate_inbounds iterate(t::Dict, i) = _iterate(t, skip_deleted(t, i))
 
-@propagate_inbounds Iterators.only(t::Dict) = only(t, Val(:first))
-
 isempty(t::Dict) = (t.count == 0)
 length(t::Dict) = t.count
+
+@propagate_inbounds Iterators.only(t::Dict) = Iterators._only(t, first)
 
 @propagate_inbounds function Base.iterate(v::T, i::Int = v.dict.idxfloor) where T <: Union{KeySet{<:Any, <:Dict}, ValueIterator{<:Dict}}
     i == 0 && return nothing
@@ -1051,3 +1051,5 @@ iterate(dict::PersistentDict, state=nothing) = HAMT.iterate(dict.trie, state)
 length(dict::PersistentDict) = HAMT.length(dict.trie)
 isempty(dict::PersistentDict) = HAMT.isempty(dict.trie)
 empty(::PersistentDict, ::Type{K}, ::Type{V}) where {K, V} = PersistentDict{K, V}()
+
+@propagate_inbounds Iterators.only(dict::PersistentDict) = Iterators._only(dict, first)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -735,6 +735,8 @@ end
 end
 @propagate_inbounds iterate(t::Dict, i) = _iterate(t, skip_deleted(t, i))
 
+@propagate_inbounds Iterators.only(t::Dict) = only(t, Val(:first))
+
 isempty(t::Dict) = (t.count == 0)
 length(t::Dict) = t.count
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -11,7 +11,7 @@ const Base = parentmodule(@__MODULE__)
 using .Base:
     @inline, Pair, Pairs, AbstractDict, IndexLinear, IndexStyle, AbstractVector, Vector,
     SizeUnknown, HasLength, HasShape, IsInfinite, EltypeUnknown, HasEltype, OneTo,
-    @propagate_inbounds, @isdefined, @boundscheck, @inbounds, Generator,
+    @propagate_inbounds, @isdefined, @boundscheck, @inbounds, Generator, IdDict, Val,
     AbstractRange, AbstractUnitRange, UnitRange, LinearIndices, TupleOrBottom,
     (:), |, +, -, *, !==, !, ==, !=, <=, <, >, >=, missing,
     any, _counttuple, eachindex, ntuple, zero, prod, reduce, in, firstindex, lastindex,
@@ -1547,7 +1547,9 @@ Stacktrace:
 [...]
 ```
 """
-@propagate_inbounds function only(x)
+@propagate_inbounds only(x) = only(x, Val(:iterate))
+
+@propagate_inbounds function only(x, ::Val{:iterate})
     i = iterate(x)
     @boundscheck if i === nothing
         throw(ArgumentError("Collection is empty, must contain exactly 1 element"))
@@ -1558,6 +1560,15 @@ Stacktrace:
     end
     return ret
 end
+
+@inline function only(x, ::Val{:first})
+    @boundscheck if length(x) != 1
+        throw(ArgumentError("Collection must contain exactly 1 element"))
+    end
+    @inbounds first(x)
+end
+
+@propagate_inbounds only(x::IdDict) = only(x, Val(:first))
 
 # Specific error messages for tuples and named tuples
 only(x::Tuple{Any}) = x[1]

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -11,7 +11,7 @@ const Base = parentmodule(@__MODULE__)
 using .Base:
     @inline, Pair, Pairs, AbstractDict, IndexLinear, IndexStyle, AbstractVector, Vector,
     SizeUnknown, HasLength, HasShape, IsInfinite, EltypeUnknown, HasEltype, OneTo,
-    @propagate_inbounds, @isdefined, @boundscheck, @inbounds, Generator, IdDict, Val,
+    @propagate_inbounds, @isdefined, @boundscheck, @inbounds, Generator, IdDict,
     AbstractRange, AbstractUnitRange, UnitRange, LinearIndices, TupleOrBottom,
     (:), |, +, -, *, !==, !, ==, !=, <=, <, >, >=, missing,
     any, _counttuple, eachindex, ntuple, zero, prod, reduce, in, firstindex, lastindex,
@@ -1547,9 +1547,9 @@ Stacktrace:
 [...]
 ```
 """
-@propagate_inbounds only(x) = only(x, Val(:iterate))
+@propagate_inbounds only(x) = _only(x, iterate)
 
-@propagate_inbounds function only(x, ::Val{:iterate})
+@propagate_inbounds function _only(x, ::typeof(iterate))
     i = iterate(x)
     @boundscheck if i === nothing
         throw(ArgumentError("Collection is empty, must contain exactly 1 element"))
@@ -1561,14 +1561,14 @@ Stacktrace:
     return ret
 end
 
-@inline function only(x, ::Val{:first})
+@inline function _only(x, ::typeof(first))
     @boundscheck if length(x) != 1
         throw(ArgumentError("Collection must contain exactly 1 element"))
     end
     @inbounds first(x)
 end
 
-@propagate_inbounds only(x::IdDict) = only(x, Val(:first))
+@propagate_inbounds only(x::IdDict) = _only(x, first)
 
 # Specific error messages for tuples and named tuples
 only(x::Tuple{Any}) = x[1]

--- a/base/set.jl
+++ b/base/set.jl
@@ -175,6 +175,8 @@ rehash!(s::Set) = (rehash!(s.dict); s)
 
 iterate(s::Set, i...)       = iterate(KeySet(s.dict), i...)
 
+@propagate_inbounds Iterators.only(s::Set) = only(s, Val(:first))
+
 # In case the size(s) is smaller than size(t) its more efficient to iterate through
 # elements of s instead and only delete the ones also contained in t.
 # The threshold for this decision boils down to a tradeoff between

--- a/base/set.jl
+++ b/base/set.jl
@@ -175,7 +175,7 @@ rehash!(s::Set) = (rehash!(s.dict); s)
 
 iterate(s::Set, i...)       = iterate(KeySet(s.dict), i...)
 
-@propagate_inbounds Iterators.only(s::Set) = only(s, Val(:first))
+@propagate_inbounds Iterators.only(s::Set) = Iterators._only(s, first)
 
 # In case the size(s) is smaller than size(t) its more efficient to iterate through
 # elements of s instead and only delete the ones also contained in t.

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -179,6 +179,8 @@ firstindex(s::AbstractString) = 1
 lastindex(s::AbstractString) = thisind(s, ncodeunits(s)::Int)
 isempty(s::AbstractString) = iszero(ncodeunits(s)::Int)
 
+@propagate_inbounds first(s::AbstractString) = s[firstindex(s)]
+
 function getindex(s::AbstractString, i::Integer)
     @boundscheck checkbounds(s, i)
     @inbounds return isvalid(s, i) ? (iterate(s, i)::NTuple{2,Any})[1] : string_index_err(s, i)

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -213,4 +213,6 @@ function iterate(t::WeakKeyDict{K,V}, state...) where {K, V}
     end
 end
 
+@propagate_inbounds Iterators.only(d::WeakKeyDict) = Iterators._only(d, first)
+
 filter!(f, d::WeakKeyDict) = filter_in_one_pass!(f, d)


### PR DESCRIPTION
This PR is the result of [this Discourse thread](https://discourse.julialang.org/t/make-only-use-first-for-dictionaries-or-other-types/106606). It speeds up `first` for `Array` and `String` and `only` for `Dict`, `IdDict` and `Set`. For `only` the speed up comes from using `length` and `first` instead of calling `iterate` twice (once to get the first element, once to check that there are no more). I have also deleted dedicated `only` methods for `Tuple`, `Int` and the like because they are not faster than the standard method.

Here are some benchmarks. They were generated by the function
```
function runtest(v)
    y = only(v[1])
    @show eltype(v)
    @btime count(x -> first(x) == $y, $v)
    @btime count(x -> @inbounds(first(x)) == $y, $v)
    @btime count(x -> only(x) == $y, $v)
    @btime count(x -> @inbounds(only(x)) == $y, $v)
end
```
applied to a `Vector` `v` with `n = 1000` randomly generated containers of the given type having one element each. Below I only show the relevant output.

#### `first`

| type | master | new | `@inbounds` master | `@inbounds` new |
|---|---|---|---|---|
| `String` | 3.145 μs | 1.241 μs | 3.147 μs | 1.368 μs |
| `Vector{Char}` | 985.571 ns | 982.688 ns | 961.227 ns | 748.953 ns |
| `Matrix{Char}` | 1.275 μs | 1.276 μs | 1.277 μs | 866.526 ns |
| `Array{Char, 3}` | 1.273 μs | 1.268 μs | 1.302 μs | 872.368 ns |

#### `only`

| type | master | new | `@inbounds` master | `@inbounds` new |
|---|---|---|---|---|
| `Dict{Char, Int64}` | 16.931 μs | 5.940 μs | 6.167 μs | 5.830 μs |
| `IdDict{Char, Int64}` | 28.419 μs | 18.514 μs | 22.029 μs |15.923 μs |
| `Set{Char}` | 14.810 μs | 3.742 μs | 5.113 μs | 3.561 μs |
| `Tuple{Int64}` | 71.966 ns | 70.243 ns | 71.962 ns | 70.251 ns |
| `Int64` | 71.974 ns | 71.031 ns | 71.961 ns | 71.061 ns |
| `Char` | 102.729 ns | 102.744 ns | 100.216 ns | 100.071 ns |

There are a couple of types where the new method `only(x, Val(:first))` would be faster the current one (now accessible as `only(x, Val(:iterate))`, but only when using `@inbounds`. However, if one adds `@inbounds`, then one can also switch to `first` instead of `only` to get a larger speed-up.

Note that `only` for `IdDict` is defined in iterators.jl since it is included later than iddict.jl into Base.jl. Maybe there is a more elegant way of doing it. 