### PR TITLE
reviving `instancemethods`

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -796,6 +796,7 @@ export
     isinteractive,
     hasmethod,
     methods,
+    instancemethods,
     nameof,
     parentmodule,
     pathof,

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1272,8 +1272,10 @@ function instancemethods(t::Type, @nospecialize(tmatch),
     world = get_world_counter()
     mm = _instancemethods(t, tmatch, -1, world)
     ms = collect_methods(mm, mod)
-    mt = t === Function ? typeof(t).name.mt : typename(t).mt
-    return MethodList(ms, mt)
+    if t in (Any, Function, Core.Builtin)
+        t = DataType
+    end
+    return MethodList(ms, typename(t).mt)
 end
 
 instancemethods(t::Type, @nospecialize(tmatch), mod::Module) =

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1238,7 +1238,7 @@ list for instances of a type without instantiating any object. Another
 difference is that the type `T` need not be concrete.
 
 If `types` is specified, return the methods whose types match.
-If `module` is specified, return the methods defined in that module.
+If `module` is specified, only return the methods defined in that module.
 Multiple modules can also be specified as an array.
 
 # Example

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -36,6 +36,7 @@ Base.include_dependency
 __init__
 Base.which(::Any, ::Any)
 Base.methods
+Base.instancemethods
 Base.@show
 ans
 err

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -960,38 +960,70 @@ end
 end
 
 module TestInstanceMethods
+
 struct A{T}
     x::T
 end
-(a::A)(y) = a.x + y
-(a::A)(x::String) = "$x: $a.x"
-(a::A{Float64})(x::Float64) = a.x + x
+
+(a::A)(y::Int) = a.x + y
+(a::A{Float64})(y::Float64) = a.x + y
+(a::A)(y::String) = "$y: $a.x"
+(a::A)(y::Char) = "$y: $a.x"
+(a::A{String})(y::Char) = "$y: $a.x"
 
 struct B
     x::Int
 end
 
 (b::B)(y) = b.x + y
-(b::B)(x::String) = string(b.x) * x
 (b::B)(y::Float64) = b.x + y
+(b::B)(y::String) = string(b.x) * y
+
 end
 
 @testset "instancemethods" begin
-    using .TestInstanceMethods: A, B
+    using .TestInstanceMethods: TestInstanceMethods, A, B
 
-    @test methods(A(1)) == instancemethods(A{Int})
-    @test methods(B(1)) == instancemethods(B)
+    for x in (1, 1.0, "1")
+        T = typeof(x)
+        @test instancemethods(A{T}) == methods(A(x))
+        @test instancemethods(A{T}, Tuple{String}) == methods(A(x), Tuple{String})
+        @test instancemethods(A{T}, TestInstanceMethods) ==
+            methods(A(x), TestInstanceMethods)
+        @test isempty(instancemethods(A{T}, [Base]))
+        @test instancemethods(A{T}, Tuple{Float64}, [TestInstanceMethods]) ==
+            methods(A(x), Tuple{Float64}, TestInstanceMethods)
+        @test isempty(instancemethods(A{T}, Tuple{String}, Base))
+    end
 
-    @test length(methods(A{<:Any})) == 1
-    @test length(instancemethods(A{<:Any})) == 3
+    @test instancemethods(B) == methods(B(1))
+    @test instancemethods(B, Tuple{Float64}) == methods(B(1), Tuple{Float64})
+    @test instancemethods(B, [TestInstanceMethods]) ==
+        methods(B(1), TestInstanceMethods)
+    @test isempty(instancemethods(B, Base))
+    @test instancemethods(B, Tuple{Float64}, TestInstanceMethods) ==
+        methods(B(1), Tuple{Float64}, TestInstanceMethods)
+    @test isempty(instancemethods(B, Tuple{Float64}, [Base]))
 
-    @test methods(A("s")) == instancemethods(A{String})
+    @test length(instancemethods(A)) == 5
+    @test length(instancemethods(A, Tuple{Char})) == 2
+    @test length(instancemethods(A, TestInstanceMethods)) == 5
+    @test length(instancemethods(A, Tuple{Char}, [TestInstanceMethods])) == 2
+    @test length(instancemethods(A, [Base])) == 0
+    @test length(instancemethods(A, Tuple{Char}, Base)) == 0
 
-    @test length(methods(A{String})) == 1
-    @test length(instancemethods(A{String})) == 2
-
-    @test length(methods(B)) == 2
     @test length(instancemethods(B)) == 3
+    @test length(instancemethods(B, Tuple{Char})) == 1
+    @test length(instancemethods(B, [TestInstanceMethods])) == 3
+    @test length(instancemethods(B, Base)) == 0
+    @test length(instancemethods(B, Tuple{Char}, TestInstanceMethods)) == 1
+    @test length(instancemethods(B, Tuple{Char}, [Base])) == 0
+
+    @test instancemethods(typeof(+)) == methods(+)
+    @test instancemethods(typeof(+), Base) == methods(+, Base)
+    @test instancemethods(typeof(+), Tuple{Number,Number}) == methods(+, Tuple{Number,Number})
+    @test instancemethods(typeof(+), Tuple{Number,Number}, Base) ==
+        methods(+, Tuple{Number,Number}, Base)
 end
 
 module BodyFunctionLookup

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -959,6 +959,41 @@ end
     @test length(methods(g, ())) == 1
 end
 
+module TestInstanceMethods
+struct A{T}
+    x::T
+end
+(a::A)(y) = a.x + y
+(a::A)(x::String) = "$x: $a.x"
+(a::A{Float64})(x::Float64) = a.x + x
+
+struct B
+    x::Int
+end
+
+(b::B)(y) = b.x + y
+(b::B)(x::String) = string(b.x) * x
+(b::B)(y::Float64) = b.x + y
+end
+
+@testset "instancemethods" begin
+    using .TestInstanceMethods: A, B
+
+    @test methods(A(1)) == instancemethods(A{Int})
+    @test methods(B(1)) == instancemethods(B)
+
+    @test length(methods(A{<:Any})) == 1
+    @test length(instancemethods(A{<:Any})) == 3
+
+    @test methods(A("s")) == instancemethods(A{String})
+
+    @test length(methods(A{String})) == 1
+    @test length(instancemethods(A{String})) == 2
+
+    @test length(methods(B)) == 2
+    @test length(instancemethods(B)) == 3
+end
+
 module BodyFunctionLookup
 f1(x, y; a=1) = error("oops")
 f2(f::Function, args...; kwargs...) = f1(args...; kwargs...)


### PR DESCRIPTION
The purpose of this PR is to finally add `instancemethods` to master. This function was created by @algunion in #50898 and #51068 in response to a [question](https://discourse.julialang.org/t/how-to-determine-the-methods-for-a-callable-object-without-instantiating-it/102618) of mine on Discourse. @algunion seems to be busy at the moment and [said](https://github.com/JuliaLang/julia/pull/51068#issuecomment-1771808720) that I could complete the PR.

Recall that the idea of `instancemethods(T::Type)` is to return all methods for instances of `T` without the need to instantiate any object. I believe I have addressed all comments made in #51068. Some remarks about the current version:

* The code for `methods` contains the line

https://github.com/JuliaLang/julia/blob/9ea29d9b8f41509ea2609ce012cea69dfc4285e8/base/reflection.jl#L1187

which is currently not in `instancemethods`. Does it need to be added?

* ~~The following gives an error at present:~~
```
julia> length(instancemethods(Function))   # OK
24726

julia> length(instancemethods(Any))   # EDIT: OUTDATED
ERROR: UndefRefError: access to undefined reference
Stacktrace:
 [1] getproperty
   @ ./Base.jl:49 [inlined]
 [2] instancemethods(t::Type, tmatch::Any, mod::Nothing)
   @ Base ./reflection.jl:1275
 [3] instancemethods
   @ Base ./reflection.jl:1283 [inlined]
 [4] instancemethods(t::Type)
   @ Base ./reflection.jl:1283
 [5] top-level scope
   @ REPL[9]:1
```
EDIT: Besides `Function` (which is already dealt with), also `Any` and `Core.Builtin` have the property that `Base.typename(T)` has no field `mt`.  This is fixed now.

EDIT 2: `instancemethods(Core.Builtin)` gives an empty method list although [builtin functions](https://docs.julialang.org/en/v1.11-dev/devdocs/functions/#Builtins) are instances of this type. Is this a problem?

* If/when the PR gets accepted, we need to add something to NEWS.md. Where would it go there? To "New language features", to "New library features" or elsewhere?