### PR TITLE
codegen: fix ssa order regression from initializing structs

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -3733,7 +3733,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                 strct = emit_static_alloca(ctx, lt);
                 setName(ctx.emission_context, strct, arg_typename);
                 if (nargs < nf)
-                    ctx.builder.CreateStore(ctx.builder.CreateFreeze(UndefValue::get(lt)), strct);
+                    promotion_point = ctx.builder.CreateStore(ctx.builder.CreateFreeze(UndefValue::get(lt)), strct);
                 if (tracked.count)
                     undef_derived_strct(ctx, strct, sty, ctx.tbaa().tbaa_stack);
             }


### PR DESCRIPTION
Fixes #52276 (confirmed in local testing of the package as I do not have a reduced example of the IR).