### PR TITLE
Fix: bug displaying Inf16 instead of Inf

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -2011,6 +2011,7 @@ function follow_map(map::Vector{Int}, idx::Int)
 end
 
 function ascend_eliminated_preds(bbs::Vector{BasicBlock}, pred::Int)
+    pred == 0 && return pred
     while pred != 1 && length(bbs[pred].preds) == 1 && length(bbs[pred].succs) == 1
         pred = bbs[pred].preds[1]
     end
@@ -2048,6 +2049,10 @@ function add_preds!(all_new_preds::Vector{Int32}, bbs::Vector{BasicBlock}, bb_re
     preds = copy(bbs[old_edge].preds)
     while !isempty(preds)
         old_edge′ = popfirst!(preds)
+        if old_edge′ == 0
+            push!(all_new_preds, old_edge′)
+            continue
+        end
         new_edge = bb_rename_pred[old_edge′]
         if new_edge > 0 && new_edge ∉ all_new_preds
             push!(all_new_preds, Int32(new_edge))
@@ -2147,9 +2152,9 @@ function cfg_simplify!(ir::IRCode)
                         push!(worklist, terminator.dest)
                     end
                 elseif isa(terminator, EnterNode)
-                    enteridx = terminator.args[1]::Int
-                    if bb_rename_succ[enteridx] == 0
-                        push!(worklist, enteridx)
+                    catchbb = terminator.catch_dest
+                    if bb_rename_succ[catchbb] == 0
+                        push!(worklist, catchbb)
                     end
                 end
                 ncurr = curr + 1
@@ -2328,6 +2333,12 @@ function cfg_simplify!(ir::IRCode)
                                 push!(values, renamed_values[old_index])
                             else
                                 resize!(values, length(values)+1)
+                            end
+                        elseif new_edge == -1
+                            @assert length(phi.edges) == 1
+                            if isassigned(phi.values, old_index)
+                                push!(edges, -1)
+                                push!(values, phi.values[old_index])
                             end
                         elseif new_edge == -3
                             # Multiple predecessors, we need to expand out this phi

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -185,10 +185,8 @@ end
 
 function showerror(io::IO, ex::InexactError)
     print(io, "InexactError: ", ex.func, '(')
-    T = first(ex.args)
-    nameof(T) === ex.func || print(io, T, ", ")
-    join(io, ex.args[2:end], ", ")
-    print(io, ")")
+    print(io, join([repr(arg) for arg in ex.args[2:end]], ", "))
+    println(io, ")")
     Experimental.show_error_hints(io, ex)
 end
 

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -187,8 +187,10 @@ function showerror(io::IO, ex::InexactError)
     print(io, "InexactError: ", ex.func, '(')
     T = first(ex.args)
     nameof(T) === ex.func || print(io, T, ", ")
-    join(io, ex.args[2:end], ", ")
-    print(io, ")")
+    for arg in ex.args[2:end]
+        print(io, repr(arg))
+    end
+    println(io, ")")
     Experimental.show_error_hints(io, ex)
 end
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -627,7 +627,9 @@ true
 !!! compat "Julia 1.5"
     This function requires at least Julia 1.5.
 """
-ismutable(@nospecialize(x)) = (@_total_meta; typeof(x).name.flags & 0x2 == 0x2)
+ismutable(@nospecialize(x)) = (@_total_meta; (typeof(x).name::Core.TypeName).flags & 0x2 == 0x2)
+# The type assertion above is required to fix some invalidations.
+# See also https://github.com/JuliaLang/julia/issues/52134
 
 """
     ismutabletype(T) -> Bool

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1626,3 +1626,56 @@ end
 # but currently this would require an extra round of constprop
 @test_broken fully_eliminated(persistent_dict_elim)
 @test code_typed(persistent_dict_elim)[1][1].code[end] == Core.ReturnNode(1)
+
+# Test CFG simplify with try/catch blocks
+let m = Meta.@lower 1 + 1
+    @assert Meta.isexpr(m, :thunk)
+    src = m.args[1]::CodeInfo
+    src.code = Any[
+        # Block 1
+        GotoIfNot(Argument(1), 5),
+        # Block 2
+        EnterNode(4),
+        # Block 3
+        Expr(:leave),
+        # Block 4
+        GotoNode(5),
+        # Block 5
+        ReturnNode(1)
+    ]
+    nstmts = length(src.code)
+    src.ssavaluetypes = nstmts
+    src.codelocs = fill(Int32(1), nstmts)
+    src.ssaflags = fill(Int32(0), nstmts)
+    ir = Core.Compiler.inflate_ir(src)
+    Core.Compiler.verify_ir(ir)
+    ir = Core.Compiler.cfg_simplify!(ir)
+    Core.Compiler.verify_ir(ir)
+    @test length(ir.cfg.blocks) == 4
+end
+
+# Test CFG simplify with single predecessor phi node
+let m = Meta.@lower 1 + 1
+    @assert Meta.isexpr(m, :thunk)
+    src = m.args[1]::CodeInfo
+    src.code = Any[
+        # Block 1
+        Expr(:call, Base.inferencebarrier, 1),
+        GotoNode(3),
+        # Block 2
+        PhiNode(Int32[1], Any[SSAValue(1)]),
+        ReturnNode(SSAValue(3))
+    ]
+    nstmts = length(src.code)
+    src.ssavaluetypes = nstmts
+    src.codelocs = fill(Int32(1), nstmts)
+    src.ssaflags = fill(Int32(0), nstmts)
+    ir = Core.Compiler.inflate_ir(src)
+    Core.Compiler.verify_ir(ir)
+    ir = Core.Compiler.cfg_simplify!(ir)
+    Core.Compiler.verify_ir(ir)
+    @test length(ir.cfg.blocks) == 1
+    ir = Core.Compiler.compact!(ir)
+    @test length(ir.stmts) == 2
+    @test (ir[SSAValue(2)][:stmt]::ReturnNode).val == SSAValue(1)
+end


### PR DESCRIPTION
fix: #51087 
I have fixed the  bug in the error display functionality, found in the **base/errorshow.jl** file. Now the function **errorshow** correctly take into account the difference between **inf** and **inf16** 


I also executed the tests in test/errorshow with success

![Screenshot 2023-11-27 191039](https://github.com/JuliaLang/julia/assets/51833287/c6e9452d-9211-4f16-ac63-6679c42bf3b5)

