### PR TITLE
Remove the GMP.round function

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -320,11 +320,6 @@ function BigInt(x::Float64)
     unsafe_trunc(BigInt,x)
 end
 
-function round(::Type{BigInt}, x::Union{Float16,Float32,Float64}, r::RoundingMode{:ToZero})
-    isfinite(x) || throw(InexactError(:trunc, BigInt, x))
-    unsafe_trunc(BigInt,x)
-end
-
 BigInt(x::Float16) = BigInt(Float64(x))
 BigInt(x::Float32) = BigInt(Float64(x))
 


### PR DESCRIPTION
This looks like it's supposed to be a method of `Base.round`, but it's actually its own function. Should be unnecessary after https://github.com/JuliaLang/julia/pull/50812 (and should also be unnecessary before that?)