### PR TITLE
Optimize calls to jl_small_typeof by moving it inside the module

### DIFF
--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -1819,7 +1819,7 @@ void addTargetPasses(legacy::PassManagerBase *PM, const Triple &triple, TargetIR
     PM->add(new TargetLibraryInfoWrapperPass(triple));
     PM->add(createTargetTransformInfoWrapperPass(std::move(analysis)));
 }
-
+void jl_optimize_small_typeof(GlobalVariable *GV) JL_NOTSAFEPOINT;
 // --- native code info, and dump function to IR and ASM ---
 // Get pointer to llvm::Function instance, compiling if necessary
 // for use in reflection from Julia.
@@ -1919,6 +1919,9 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t* dump, jl_method_instance_t *mi, siz
                     global.second->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
                     global.second->setVisibility(GlobalValue::DefaultVisibility);
                 }
+            }
+            if (auto GV = (*m.getModuleUnlocked()).getNamedGlobal("jl_small_typeof")) {
+                jl_optimize_small_typeof(GV);
             }
             if (!jl_options.image_codegen) {
                 optimizeDLSyms(*m.getModuleUnlocked());

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -750,7 +750,7 @@ static const auto jldlli_var = new JuliaVariable{
 static const auto jl_small_typeof_var = new JuliaVariable{
     XSTR(jl_small_typeof),
     true,
-    [](Type *T_size) -> Type * { return getInt8Ty(T_size->getContext()); },
+    [](Type *T_size) -> Type * { return ArrayType::get(getInt8Ty(T_size->getContext()), sizeof(jl_small_typeof)); },
 };
 
 static const auto jlstack_chk_guard_var = new JuliaVariable{


### PR DESCRIPTION
I'm not satisfied with this currently, because this seems a bit wasteful. Though I'm not sure if it's possible to constant fold without putting it inside the module.