### PR TITLE
cfg_simplify: Handle various corner cases with try/catch blocks

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -2334,6 +2334,12 @@ function cfg_simplify!(ir::IRCode)
                             else
                                 resize!(values, length(values)+1)
                             end
+                        elseif new_edge == -1
+                            @assert length(phi.edges) == 1
+                            if isassigned(phi.values, old_index)
+                                push!(edges, -1)
+                                push!(values, phi.values[old_index])
+                            end
                         elseif new_edge == -3
                             # Multiple predecessors, we need to expand out this phi
                             all_new_preds = Int32[]

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -2011,6 +2011,7 @@ function follow_map(map::Vector{Int}, idx::Int)
 end
 
 function ascend_eliminated_preds(bbs::Vector{BasicBlock}, pred::Int)
+    pred == 0 && return pred
     while pred != 1 && length(bbs[pred].preds) == 1 && length(bbs[pred].succs) == 1
         pred = bbs[pred].preds[1]
     end
@@ -2048,6 +2049,10 @@ function add_preds!(all_new_preds::Vector{Int32}, bbs::Vector{BasicBlock}, bb_re
     preds = copy(bbs[old_edge].preds)
     while !isempty(preds)
         old_edge′ = popfirst!(preds)
+        if old_edge′ == 0
+            push!(all_new_preds, old_edge′)
+            continue
+        end
         new_edge = bb_rename_pred[old_edge′]
         if new_edge > 0 && new_edge ∉ all_new_preds
             push!(all_new_preds, Int32(new_edge))
@@ -2147,9 +2152,9 @@ function cfg_simplify!(ir::IRCode)
                         push!(worklist, terminator.dest)
                     end
                 elseif isa(terminator, EnterNode)
-                    enteridx = terminator.args[1]::Int
-                    if bb_rename_succ[enteridx] == 0
-                        push!(worklist, enteridx)
+                    catchbb = terminator.catch_dest
+                    if bb_rename_succ[catchbb] == 0
+                        push!(worklist, catchbb)
                     end
                 end
                 ncurr = curr + 1


### PR DESCRIPTION
Mostly long-standing bugs related to not handling the virtual predecessor to catch blocks, but also one recent regression from the EnterNode change.