### PR TITLE
add doxygen for exported functions in jlapi.c

### DIFF
--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -136,11 +136,17 @@ void JL_UV_LOCK(void)
     }
 }
 
+/**
+ * @brief Begin an IO lock.
+ */
 JL_DLLEXPORT void jl_iolock_begin(void)
 {
     JL_UV_LOCK();
 }
 
+/**
+ * @brief End an IO lock.
+ */
 JL_DLLEXPORT void jl_iolock_end(void)
 {
     JL_UV_UNLOCK();
@@ -227,9 +233,16 @@ static void uv_flush_callback(uv_write_t *req, int status)
     free(req);
 }
 
-// Turn a normal write into a blocking write (primarily for use from C and gdb).
-// Warning: This calls uv_run, so it can have unbounded side-effects.
-// Be care where you call it from! - the libuv loop is also not reentrant.
+/**
+ * @brief Flush a UV stream.
+ *
+ * Primarily used from C and gdb to convert a normal write operation on a UV stream
+ * into a blocking write. It calls uv_run, which can have unbounded side-effects.
+ * Caution is advised as the location from where this function is called is critical
+ * due to the non-reentrancy of the libuv loop.
+ *
+ * @param stream A pointer to `uv_stream_t` representing the stream to flush.
+ */
 JL_DLLEXPORT void jl_uv_flush(uv_stream_t *stream)
 {
     if (stream == (void*)STDIN_FILENO ||
@@ -261,21 +274,111 @@ JL_DLLEXPORT void jl_uv_flush(uv_stream_t *stream)
 
 // getters and setters
 // TODO: check if whoever calls these is thread-safe
+/**
+ * @brief Get the process ID of a UV process.
+ *
+ * @param p A pointer to `uv_process_t` representing the UV process.
+ * @return The process ID.
+ */
 JL_DLLEXPORT int jl_uv_process_pid(uv_process_t *p) { return p->pid; }
+
+/**
+ * @brief Get the data associated with a UV process.
+ *
+ * @param p A pointer to `uv_process_t` representing the UV process.
+ * @return A pointer to the process data.
+ */
 JL_DLLEXPORT void *jl_uv_process_data(uv_process_t *p) { return p->data; }
+
+/**
+ * @brief Get the base pointer of a UV buffer.
+ *
+ * @param buf A constant pointer to `uv_buf_t` representing the UV buffer.
+ * @return A pointer to the base of the buffer.
+ */
 JL_DLLEXPORT void *jl_uv_buf_base(const uv_buf_t *buf) { return buf->base; }
+
+/**
+ * @brief Get the length of a UV buffer.
+ *
+ * @param buf A constant pointer to `uv_buf_t` representing the UV buffer.
+ * @return The length of the buffer as `size_t`.
+ */
 JL_DLLEXPORT size_t jl_uv_buf_len(const uv_buf_t *buf) { return buf->len; }
+
+/**
+ * @brief Set the base pointer of a UV buffer.
+ *
+ * @param buf A pointer to `uv_buf_t` representing the UV buffer.
+ * @param b A pointer to `char` representing the new base of the buffer.
+ */
 JL_DLLEXPORT void jl_uv_buf_set_base(uv_buf_t *buf, char *b) { buf->base = b; }
+
+/**
+ * @brief Set the length of a UV buffer.
+ *
+ * @param buf A pointer to `uv_buf_t` representing the UV buffer.
+ * @param n The new length of the buffer as `size_t`.
+ */
 JL_DLLEXPORT void jl_uv_buf_set_len(uv_buf_t *buf, size_t n) { buf->len = n; }
+
+/**
+ * @brief Get the handle associated with a UV connect request.
+ *
+ * @param connect A pointer to `uv_connect_t` representing the connect request.
+ * @return A pointer to the associated handle.
+ */
 JL_DLLEXPORT void *jl_uv_connect_handle(uv_connect_t *connect) { return connect->handle; }
+
+/**
+ * @brief Get the file descriptor from a UV file structure.
+ *
+ * @param f A pointer to `jl_uv_file_t` representing the UV file.
+ * @return The file descriptor as `uv_os_fd_t`.
+ */
 JL_DLLEXPORT uv_os_fd_t jl_uv_file_handle(jl_uv_file_t *f) { return f->file; }
+
+/**
+ * @brief Get the data field from a UV request.
+ *
+ * @param req A pointer to `uv_req_t` representing the request.
+ * @return A pointer to the data associated with the request.
+ */
 JL_DLLEXPORT void *jl_uv_req_data(uv_req_t *req) { return req->data; }
+
+/**
+ * @brief Set the data field of a UV request.
+ *
+ * @param req A pointer to `uv_req_t` representing the request.
+ * @param data A pointer to the data to be associated with the request.
+ */
 JL_DLLEXPORT void jl_uv_req_set_data(uv_req_t *req, void *data) { req->data = data; }
+
+/**
+ * @brief Get the data field from a UV handle.
+ *
+ * @param handle A pointer to `uv_handle_t` representing the handle.
+ * @return A pointer to the data associated with the handle.
+ */
 JL_DLLEXPORT void *jl_uv_handle_data(uv_handle_t *handle) { return handle->data; }
+
+/**
+ * @brief Get the handle associated with a UV write request.
+ *
+ * @param req A pointer to `uv_write_t` representing the write request.
+ * @return A pointer to the handle associated with the write request.
+ */
 JL_DLLEXPORT void *jl_uv_write_handle(uv_write_t *req) { return req->handle; }
 
 extern _Atomic(unsigned) _threadedregion;
 
+/**
+ * @brief Process pending UV events.
+ *
+ * See also `uv_run` in the libuv documentation for status code enumeration.
+ *
+ * @return An integer indicating the status of the event processing.
+ */
 JL_DLLEXPORT int jl_process_events(void)
 {
     jl_task_t *ct = jl_current_task;
@@ -302,6 +405,11 @@ static void jl_proc_exit_cleanup_cb(uv_process_t *process, int64_t exit_status, 
     uv_close((uv_handle_t*)process, (uv_close_cb)&free);
 }
 
+/**
+ * @brief Close a UV handle.
+ *
+ * @param handle A pointer to `uv_handle_t` that needs to be closed.
+ */
 JL_DLLEXPORT void jl_close_uv(uv_handle_t *handle)
 {
     JL_UV_LOCK();
@@ -335,6 +443,11 @@ JL_DLLEXPORT void jl_close_uv(uv_handle_t *handle)
     JL_UV_UNLOCK();
 }
 
+/**
+ * @brief Forcefully close a UV handle.
+ *
+ * @param handle A pointer to `uv_handle_t` to be forcefully closed.
+ */
 JL_DLLEXPORT void jl_forceclose_uv(uv_handle_t *handle)
 {
     if (!uv_is_closing(handle)) { // avoid double-closing the stream
@@ -346,12 +459,23 @@ JL_DLLEXPORT void jl_forceclose_uv(uv_handle_t *handle)
     }
 }
 
+/**
+ * @brief Associate a Julia structure with a UV handle.
+ *
+ * @param handle A pointer to `uv_handle_t` to be associated with a Julia structure.
+ * @param data Additional parameters representing the Julia structure to be associated.
+ */
 JL_DLLEXPORT void jl_uv_associate_julia_struct(uv_handle_t *handle,
                                                jl_value_t *data)
 {
     handle->data = data;
 }
 
+/**
+ * @brief Disassociate a Julia structure from a UV handle.
+ *
+ * @param handle A pointer to `uv_handle_t` from which the Julia structure will be disassociated.
+ */
 JL_DLLEXPORT void jl_uv_disassociate_julia_struct(uv_handle_t *handle)
 {
     handle->data = NULL;
@@ -359,6 +483,29 @@ JL_DLLEXPORT void jl_uv_disassociate_julia_struct(uv_handle_t *handle)
 
 #define UV_HANDLE_CLOSED 0x02
 
+/**
+ * @brief Spawn a new process.
+ *
+ * Spawns a new process to execute external programs or scripts within the context of the Julia application.
+ *
+ * @param name A C string representing the name or path of the executable to spawn.
+ * @param argv An array of C strings representing the arguments for the process. The array should be null-terminated.
+ * @param loop A pointer to `uv_loop_t` representing the event loop where the process is registered.
+ * @param proc A pointer to `uv_process_t` where the details of the spawned process are stored.
+ * @param stdio An array of `uv_stdio_container_t` representing the file descriptors for standard input, output, and error.
+ * @param nstdio An integer representing the number of elements in the stdio array.
+ * @param flags A uint32_t representing process creation flags.
+          See also `enum uv_process_flags` in the libuv documentation.
+ * @param env An array of C strings for setting environment variables. The array should be null-terminated.
+ * @param cwd A C string representing the current working directory for the process.
+ * @param cpumask A C string representing the CPU affinity mask for the process.
+          See also the `cpumask` field of the `uv_process_options_t` structure in the libuv documentation.
+ * @param cpumask_size The size of the cpumask.
+ * @param cb A function pointer to `uv_exit_cb` which is the callback function to be called upon process exit.
+ *
+ * @return An integer indicating the success or failure of the spawn operation. A return value of 0 indicates success,
+ *         while a non-zero value indicates an error.
+ */
 JL_DLLEXPORT int jl_spawn(char *name, char **argv,
                           uv_loop_t *loop, uv_process_t *proc,
                           uv_stdio_container_t *stdio, int nstdio,

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -878,6 +878,7 @@ JL_DLLEXPORT int jl_get_fenv_rounding(void)
  * @brief Set the floating-point rounding mode.
  *
  * @param i An integer representing the desired floating-point rounding mode.
+          See also "floating-point rounding" macros in `<fenv.h>`.
  * @return An integer indicating the success or failure of setting the rounding mode.
  */
 JL_DLLEXPORT int jl_set_fenv_rounding(int i)

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -26,11 +26,28 @@ extern "C" {
 #include <fenv.h>
 #endif
 
+/**
+ * @brief Check if Julia is already initialized.
+ *
+ * Determine if Julia has been previously initialized
+ * via `jl_init` or `jl_init_with_image`.
+ *
+ * @return Returns 1 if Julia is initialized, 0 otherwise.
+ */
 JL_DLLEXPORT int jl_is_initialized(void)
 {
     return jl_main_module != NULL;
 }
 
+/**
+ * @brief Set Julia command line arguments.
+ *
+ * Allows setting the command line arguments for Julia,
+ * similar to arguments passed in the main function of a C program.
+ *
+ * @param argc The number of command line arguments.
+ * @param argv Array of command line arguments.
+ */
 JL_DLLEXPORT void jl_set_ARGS(int argc, char **argv)
 {
     if (jl_core_module != NULL) {
@@ -51,11 +68,20 @@ JL_DLLEXPORT void jl_set_ARGS(int argc, char **argv)
     }
 }
 
-// First argument is the usr/bin directory where the julia binary is, or NULL to guess.
-// Second argument is the path of a system image file (*.so).
-// A non-absolute path is interpreted as relative to the first argument path, or
-// relative to the default julia home dir.
-// The default is something like ../lib/julia/sys.so
+/**
+ * @brief Initialize Julia with a specified system image file.
+ *
+ * Initializes Julia by specifying the usr/bin directory where the Julia binary is
+ * and the path of a system image file (*.so). If the julia_bindir is NULL, the function
+ * attempts to guess the directory. The image_path is interpreted as a path to the system image
+ * file. A non-absolute path for the system image is considered relative to julia_bindir, or
+ * relative to the default Julia home directory. The default system image is typically
+ * something like ../lib/julia/sys.so.
+ *
+ * @param julia_bindir The usr/bin directory where the Julia binary is located, or NULL to guess.
+ * @param image_path The path of a system image file (*.so). Interpreted as relative to julia_bindir
+ *                   or the default Julia home directory if not an absolute path.
+ */
 JL_DLLEXPORT void jl_init_with_image(const char *julia_bindir,
                                      const char *image_path)
 {
@@ -71,6 +97,12 @@ JL_DLLEXPORT void jl_init_with_image(const char *julia_bindir,
     jl_exception_clear();
 }
 
+/**
+ * @brief Initialize the Julia runtime.
+ *
+ * Initializes the Julia runtime without any specific system image.
+ * It must be called before any other Julia API functions.
+ */
 JL_DLLEXPORT void jl_init(void)
 {
     char *libbindir = NULL;
@@ -105,6 +137,13 @@ static void _jl_exception_clear(jl_task_t *ct) JL_NOTSAFEPOINT
     ct->ptls->previous_exception = NULL;
 }
 
+/**
+ * @brief Evaluate a Julia expression from a string.
+ *
+ * @param str A C string containing the Julia expression to be evaluated.
+ * @return A pointer to `jl_value_t` representing the result of the evaluation.
+ *         Returns `NULL` if an error occurs during parsing or evaluation.
+ */
 JL_DLLEXPORT jl_value_t *jl_eval_string(const char *str)
 {
     jl_value_t *r;
@@ -125,23 +164,44 @@ JL_DLLEXPORT jl_value_t *jl_eval_string(const char *str)
     return r;
 }
 
+/**
+ * @brief Get the current exception in the Julia context.
+ *
+ * @return A pointer to `jl_value_t` representing the current exception.
+ *         Returns `NULL` if no exception is currently thrown.
+ */
 JL_DLLEXPORT jl_value_t *jl_current_exception(void) JL_GLOBALLY_ROOTED JL_NOTSAFEPOINT
 {
     jl_excstack_t *s = jl_current_task->excstack;
     return s && s->top != 0 ? jl_excstack_exception(s, s->top) : jl_nothing;
 }
 
+/**
+ * @brief Check if an exception has occurred in the Julia context.
+ *
+ * @return A pointer to `jl_value_t` representing the exception that occurred.
+ *         Returns `NULL` if no exception has occurred.
+ */
 JL_DLLEXPORT jl_value_t *jl_exception_occurred(void)
 {
     return jl_current_task->ptls->previous_exception;
 }
 
+/**
+ * @brief Clear the current exception in the Julia context.
+ *
+ */
 JL_DLLEXPORT void jl_exception_clear(void)
 {
     _jl_exception_clear(jl_current_task);
 }
 
-// get the name of a type as a string
+/**
+ * @brief Get the type name of a Julia value.
+ *
+ * @param v A pointer to `jl_value_t` representing the Julia value.
+ * @return A C string containing the name of the type.
+ */
 JL_DLLEXPORT const char *jl_typename_str(jl_value_t *v)
 {
     if (!jl_is_datatype(v))
@@ -149,22 +209,51 @@ JL_DLLEXPORT const char *jl_typename_str(jl_value_t *v)
     return jl_symbol_name(((jl_datatype_t*)v)->name->name);
 }
 
-// get the name of typeof(v) as a string
+/**
+ * @brief Get the string representation of a Julia value's type.
+ *
+ * @param v A pointer to `jl_value_t` representing the Julia value.
+ * @return A C string describing the type of the value.
+ */
 JL_DLLEXPORT const char *jl_typeof_str(jl_value_t *v)
 {
     return jl_typename_str((jl_value_t*)jl_typeof(v));
 }
 
+/**
+ * @brief Get the element type of a Julia array.
+ *
+ * @param a A pointer to `jl_value_t` representing the Julia array.
+ * @return A pointer to the type of the array elements.
+ */
 JL_DLLEXPORT void *jl_array_eltype(jl_value_t *a)
 {
     return jl_tparam0(jl_typeof(a));
 }
 
+/**
+ * @brief Get the number of dimensions of a Julia array.
+ *
+ * Returns the rank (number of dimensions) of a Julia array.
+ *
+ * @param a A pointer to `jl_value_t` representing the Julia array.
+ * @return An integer representing the number of dimensions of the array.
+ */
 JL_DLLEXPORT int jl_array_rank(jl_value_t *a)
 {
     return jl_array_ndims(a);
 }
 
+/**
+ * @brief Get the size of a specific dimension of a Julia array.
+ *
+ * Returns the size (number of elements) of a specific dimension
+ * of a Julia array.
+ *
+ * @param a A pointer to `jl_array_t` representing the Julia array.
+ * @param d The dimension for which the size is requested.
+ * @return The size of the specified dimension of the array.
+ */
 JL_DLLEXPORT size_t jl_array_size(jl_array_t *a, int d)
 {
     // n.b this functions only use was to violate the vector abstraction, so we have to continue to emulate that
@@ -173,11 +262,25 @@ JL_DLLEXPORT size_t jl_array_size(jl_array_t *a, int d)
     return jl_array_dim(a, d);
 }
 
+/**
+ * @brief Get the C string pointer from a Julia string.
+ *
+ * @param s A pointer to `jl_value_t` representing the Julia string.
+ * @return A C string pointer containing the contents of the Julia string.
+ */
 JL_DLLEXPORT const char *jl_string_ptr(jl_value_t *s)
 {
     return jl_string_data(s);
 }
 
+/**
+ * @brief Call a Julia function with a specified number of arguments.
+ *
+ * @param f A pointer to `jl_function_t` representing the Julia function to call.
+ * @param args An array of pointers to `jl_value_t` representing the arguments.
+ * @param nargs The number of arguments in the array.
+ * @return A pointer to `jl_value_t` representing the result of the function call.
+ */
 JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, uint32_t nargs)
 {
     jl_value_t *v;
@@ -203,6 +306,14 @@ JL_DLLEXPORT jl_value_t *jl_call(jl_function_t *f, jl_value_t **args, uint32_t n
     return v;
 }
 
+/**
+ * @brief Call a Julia function with no arguments.
+ *
+ * A specialized case of `jl_call` for simpler scenarios.
+ *
+ * @param f A pointer to `jl_function_t` representing the Julia function to call.
+ * @return A pointer to `jl_value_t` representing the result of the function call.
+ */
 JL_DLLEXPORT jl_value_t *jl_call0(jl_function_t *f)
 {
     jl_value_t *v;
@@ -223,6 +334,15 @@ JL_DLLEXPORT jl_value_t *jl_call0(jl_function_t *f)
     return v;
 }
 
+/**
+ * @brief Call a Julia function with one argument.
+ *
+ * A specialized case of `jl_call` for simpler scenarios.
+ *
+ * @param f A pointer to `jl_function_t` representing the Julia function to call.
+ * @param a A pointer to `jl_value_t` representing the argument to the function.
+ * @return A pointer to `jl_value_t` representing the result of the function call.
+ */
 JL_DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a)
 {
     jl_value_t *v;
@@ -246,6 +366,16 @@ JL_DLLEXPORT jl_value_t *jl_call1(jl_function_t *f, jl_value_t *a)
     return v;
 }
 
+/**
+ * @brief Call a Julia function with two arguments.
+ *
+ * A specialized case of `jl_call` for simpler scenarios.
+ *
+ * @param f A pointer to `jl_function_t` representing the Julia function to call.
+ * @param a A pointer to `jl_value_t` representing the first argument.
+ * @param b A pointer to `jl_value_t` representing the second argument.
+ * @return A pointer to `jl_value_t` representing the result of the function call.
+ */
 JL_DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b)
 {
     jl_value_t *v;
@@ -270,6 +400,17 @@ JL_DLLEXPORT jl_value_t *jl_call2(jl_function_t *f, jl_value_t *a, jl_value_t *b
     return v;
 }
 
+/**
+ * @brief Call a Julia function with three arguments.
+ *
+ * A specialized case of `jl_call` for simpler scenarios.
+ *
+ * @param f A pointer to `jl_function_t` representing the Julia function to call.
+ * @param a A pointer to `jl_value_t` representing the first argument.
+ * @param b A pointer to `jl_value_t` representing the second argument.
+ * @param c A pointer to `jl_value_t` representing the third argument.
+ * @return A pointer to `jl_value_t` representing the result of the function call.
+ */
 JL_DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a,
                                   jl_value_t *b, jl_value_t *c)
 {
@@ -296,6 +437,11 @@ JL_DLLEXPORT jl_value_t *jl_call3(jl_function_t *f, jl_value_t *a,
     return v;
 }
 
+/**
+ * @brief Yield to the Julia scheduler.
+ *
+ * Yields control to the Julia scheduler, allowing other Julia tasks to run.
+ */
 JL_DLLEXPORT void jl_yield(void)
 {
     static jl_function_t *yieldfunc = NULL;
@@ -305,6 +451,13 @@ JL_DLLEXPORT void jl_yield(void)
         jl_call0(yieldfunc);
 }
 
+/**
+ * @brief Get a field from a Julia object.
+ *
+ * @param o A pointer to `jl_value_t` representing the Julia object.
+ * @param fld A C string representing the name of the field to retrieve.
+ * @return A pointer to `jl_value_t` representing the value of the field.
+ */
 JL_DLLEXPORT jl_value_t *jl_get_field(jl_value_t *o, const char *fld)
 {
     jl_value_t *v;
@@ -321,11 +474,23 @@ JL_DLLEXPORT jl_value_t *jl_get_field(jl_value_t *o, const char *fld)
     return v;
 }
 
+/**
+ * @brief Begin an atomic signal-protected region.
+ *
+ * Marks the start of a region of code that should be protected
+ * from interruption by asynchronous signals.
+ */
 JL_DLLEXPORT void jl_sigatomic_begin(void)
 {
     JL_SIGATOMIC_BEGIN();
 }
 
+/**
+ * @brief End an atomic signal-protected region.
+ *
+ * Marks the end of a region of code protected from asynchronous signals.
+ * It should be used in conjunction with `jl_sigatomic_begin` to define signal-protected regions.
+ */
 JL_DLLEXPORT void jl_sigatomic_end(void)
 {
     jl_task_t *ct = jl_current_task;
@@ -334,6 +499,11 @@ JL_DLLEXPORT void jl_sigatomic_end(void)
     JL_SIGATOMIC_END();
 }
 
+/**
+ * @brief Check if Julia is running in debug build mode.
+ *
+ * @return Returns 1 if Julia is in debug build mode, 0 otherwise.
+ */
 JL_DLLEXPORT int jl_is_debugbuild(void) JL_NOTSAFEPOINT
 {
 #ifdef JL_DEBUG_BUILD
@@ -343,6 +513,11 @@ JL_DLLEXPORT int jl_is_debugbuild(void) JL_NOTSAFEPOINT
 #endif
 }
 
+/**
+ * @brief Check if Julia's memory debugging is enabled.
+ *
+ * @return Returns 1 if memory debugging is enabled, 0 otherwise.
+ */
 JL_DLLEXPORT int8_t jl_is_memdebug(void) JL_NOTSAFEPOINT {
 #ifdef MEMDEBUG
     return 1;
@@ -351,41 +526,81 @@ JL_DLLEXPORT int8_t jl_is_memdebug(void) JL_NOTSAFEPOINT {
 #endif
 }
 
+/**
+ * @brief Get the directory path of the Julia binary.
+ *
+ * @return A pointer to `jl_value_t` representing the directory path as a Julia string.
+ */
 JL_DLLEXPORT jl_value_t *jl_get_julia_bindir(void)
 {
     return jl_cstr_to_string(jl_options.julia_bindir);
 }
 
+/**
+ * @brief Get the path to the Julia binary.
+ *
+ * @return A pointer to `jl_value_t` representing the full path as a Julia string.
+ */
 JL_DLLEXPORT jl_value_t *jl_get_julia_bin(void)
 {
     return jl_cstr_to_string(jl_options.julia_bin);
 }
 
+/**
+ * @brief Get the path to the Julia system image file.
+ *
+ * @return A pointer to `jl_value_t` representing the system image file path as a Julia string.
+ */
 JL_DLLEXPORT jl_value_t *jl_get_image_file(void)
 {
     return jl_cstr_to_string(jl_options.image_file);
 }
 
+/**
+ * @brief Get the major version number of Julia.
+ *
+ * @return The major version number as an integer.
+ */
 JL_DLLEXPORT int jl_ver_major(void)
 {
     return JULIA_VERSION_MAJOR;
 }
 
+/**
+ * @brief Get the minor version number of Julia.
+ *
+ * @return The minor version number as an integer.
+ */
 JL_DLLEXPORT int jl_ver_minor(void)
 {
     return JULIA_VERSION_MINOR;
 }
 
+/**
+ * @brief Get the patch version number of Julia.
+ *
+ * @return The patch version number as an integer.
+ */
 JL_DLLEXPORT int jl_ver_patch(void)
 {
     return JULIA_VERSION_PATCH;
 }
 
+/**
+ * @brief Check if the current Julia version is a release version.
+ *
+ * @return Returns 1 if it is a release version, 0 otherwise.
+ */
 JL_DLLEXPORT int jl_ver_is_release(void)
 {
     return JULIA_VERSION_IS_RELEASE;
 }
 
+/**
+ * @brief Get the Julia version as a string.
+ *
+ * @return A C string containing the version information.
+ */
 JL_DLLEXPORT const char *jl_ver_string(void)
 {
    return JULIA_VERSION_STRING;
@@ -402,6 +617,11 @@ static const char *git_info_string(const char *fld)
     return jl_string_data(f);
 }
 
+/**
+ * @brief Get the name of the Git branch for the Julia build.
+ *
+ * @return A C string containing the name of the Git branch.
+ */
 JL_DLLEXPORT const char *jl_git_branch(void)
 {
     static const char *branch = NULL;
@@ -409,6 +629,11 @@ JL_DLLEXPORT const char *jl_git_branch(void)
     return branch;
 }
 
+/**
+ * @brief Get the Git commit hash for the Julia build.
+ *
+ * @return A C string containing the Git commit hash.
+ */
 JL_DLLEXPORT const char *jl_git_commit(void)
 {
     static const char *commit = NULL;
@@ -416,27 +641,63 @@ JL_DLLEXPORT const char *jl_git_commit(void)
     return commit;
 }
 
-// Create function versions of some useful macros for GDB or FFI use
+/**
+ * @brief Convert a Julia value to a tagged value.
+ *
+ * Converts a Julia value into its corresponding tagged value representation.
+ * Tagged values include additional metadata used internally by the Julia runtime.
+ *
+ * @param v A pointer to `jl_value_t` representing the Julia value.
+ * @return A pointer to `jl_taggedvalue_t` representing the tagged value.
+ */
 JL_DLLEXPORT jl_taggedvalue_t *(jl_astaggedvalue)(jl_value_t *v)
 {
     return jl_astaggedvalue(v);
 }
 
+/**
+ * @brief Convert a tagged value back to a Julia value.
+ *
+ * Converts a tagged value back into its original Julia value.
+ * It's the inverse operation of `jl_astaggedvalue`.
+ *
+ * @param v A pointer to `jl_taggedvalue_t` representing the tagged value.
+ * @return A pointer to `jl_value_t` representing the original Julia value.
+ */
 JL_DLLEXPORT jl_value_t *(jl_valueof)(jl_taggedvalue_t *v)
 {
     return jl_valueof(v);
 }
 
+/**
+ * @brief Get the type of a Julia value.
+ *
+ * @param v A pointer to `jl_value_t` representing the Julia value.
+ * @return A pointer to `jl_value_t` representing the type of the value.
+ */
 JL_DLLEXPORT jl_value_t *(jl_typeof)(jl_value_t *v)
 {
     return jl_typeof(v);
 }
 
+/**
+ * @brief Get the field types of a Julia value.
+ *
+ * @param v A pointer to `jl_value_t` representing the Julia value.
+ * @return A pointer to `jl_value_t` representing the field types.
+ */
 JL_DLLEXPORT jl_value_t *(jl_get_fieldtypes)(jl_value_t *v)
 {
     return (jl_value_t*)jl_get_fieldtypes((jl_datatype_t*)v);
 }
 
+/**
+ * @brief Check equality of two Julia values.
+ *
+ * @param a A pointer to `jl_value_t` representing the first Julia value.
+ * @param b A pointer to `jl_value_t` representing the second Julia value.
+ * @return Returns 1 if the values are equal, 0 otherwise.
+ */
 JL_DLLEXPORT int ijl_egal(jl_value_t *a, jl_value_t *b)
 {
     return jl_egal(a, b);
@@ -444,24 +705,56 @@ JL_DLLEXPORT int ijl_egal(jl_value_t *a, jl_value_t *b)
 
 
 #ifndef __clang_gcanalyzer__
+/**
+ * @brief Enter a state where concurrent garbage collection (GC) is considered unsafe.
+ *
+ * Marks the beginning of a code region where garbage collection operations are unsafe.
+ * Used to make it legal to access GC-managed state (almost anything)
+ *
+ * @return An `int8_t` state value representing the previous GC state.
+ */
 JL_DLLEXPORT int8_t (jl_gc_unsafe_enter)(void)
 {
     jl_task_t *ct = jl_current_task;
     return jl_gc_unsafe_enter(ct->ptls);
 }
 
+/**
+ * @brief Leave the state where garbage collection is considered unsafe.
+ *
+ * Ends a code region where garbage collection was marked as unsafe.
+ * It restores the previous GC state using the state value returned by `jl_gc_unsafe_enter`.
+ *
+ * @param state The state value returned by `jl_gc_unsafe_enter` to restore the previous GC state.
+ */
 JL_DLLEXPORT void (jl_gc_unsafe_leave)(int8_t state)
 {
     jl_task_t *ct = jl_current_task;
     jl_gc_unsafe_leave(ct->ptls, state);
 }
 
+/**
+ * @brief Enter a state where garbage collection (GC) is considered safe.
+ *
+ * Marks the beginning of a code region where garbage collection operations are safe.
+ * Used to enable GC in sections of code where it was previously marked as unsafe.
+ *
+ * @return An `int8_t` state value representing the previous GC state.
+ */
 JL_DLLEXPORT int8_t (jl_gc_safe_enter)(void)
 {
     jl_task_t *ct = jl_current_task;
     return jl_gc_safe_enter(ct->ptls);
 }
 
+/**
+ * @brief Leave the state where garbage collection is considered safe.
+ *
+ * Ends a code region where garbage collection was marked as safe.
+ * It restores the previous GC state using the state value returned by `jl_gc_safe_enter`.
+ *
+ * @param state The state value returned by `jl_gc_safe_enter` to restore the previous GC state.
+ */
 JL_DLLEXPORT void (jl_gc_safe_leave)(int8_t state)
 {
     jl_task_t *ct = jl_current_task;
@@ -469,49 +762,96 @@ JL_DLLEXPORT void (jl_gc_safe_leave)(int8_t state)
 }
 #endif
 
+/**
+ * @brief Trigger a garbage collection safepoint in a GC-unsafe region.
+ *
+ * Triggers a safepoint for garbage collection. Used to
+ * ensure that the garbage collector can run at specific points in the code,
+ * particularly in long-running operations or loops.
+ */
 JL_DLLEXPORT void jl_gc_safepoint(void)
 {
     jl_task_t *ct = jl_current_task;
     jl_gc_safepoint_(ct->ptls);
 }
 
+/**
+ * @brief Pause CPU execution for a brief moment.
+ *
+ * Used to pause the CPU briefly, typically to reduce power consumption
+ * or manage CPU resources more effectively in a tight loop or busy wait scenario.
+ */
 JL_DLLEXPORT void (jl_cpu_pause)(void)
 {
     jl_cpu_pause();
 }
 
+/**
+ * @brief Suspend CPU execution.
+ *
+ * Suspends CPU execution until a specific condition or event occurs.
+ */
 JL_DLLEXPORT void (jl_cpu_suspend)(void)
 {
     jl_cpu_suspend();
 }
 
+/**
+ * @brief Wake the CPU from a suspended state.
+ *
+ * Used to resume CPU execution after it has been suspended using `jl_cpu_suspend`.
+ */
 JL_DLLEXPORT void (jl_cpu_wake)(void)
 {
     jl_cpu_wake();
 }
 
+/**
+ * @brief Enable cumulative compile timing.
+ */
 JL_DLLEXPORT void jl_cumulative_compile_timing_enable(void)
 {
     // Increment the flag to allow reentrant callers to `@time`.
     jl_atomic_fetch_add(&jl_measure_compile_time_enabled, 1);
 }
 
+/**
+ * @brief Disable cumulative compile timing.
+ */
 JL_DLLEXPORT void jl_cumulative_compile_timing_disable(void)
 {
     // Decrement the flag when done measuring, allowing other callers to continue measuring.
     jl_atomic_fetch_add(&jl_measure_compile_time_enabled, -1);
 }
 
+/**
+ * @brief Get the cumulative compilation time in nanoseconds.
+ *
+ * @return The cumulative compilation time in nanoseconds.
+ */
 JL_DLLEXPORT uint64_t jl_cumulative_compile_time_ns(void)
 {
     return jl_atomic_load_relaxed(&jl_cumulative_compile_time);
 }
 
+/**
+ * @brief Get the cumulative recompilation time in nanoseconds.
+ *
+ * @return The cumulative recompilation time in nanoseconds.
+ */
 JL_DLLEXPORT uint64_t jl_cumulative_recompile_time_ns(void)
 {
     return jl_atomic_load_relaxed(&jl_cumulative_recompile_time);
 }
 
+/**
+ * @brief Retrieve floating-point environment constants.
+ *
+ * Populates an array with constants related to the floating-point environment,
+ * such as rounding modes and exception flags.
+ *
+ * @param ret An array of integers to be populated with floating-point environment constants.
+ */
 JL_DLLEXPORT void jl_get_fenv_consts(int *ret)
 {
     ret[0] = FE_INEXACT;
@@ -533,6 +873,13 @@ JL_DLLEXPORT int jl_get_fenv_rounding(void)
 {
     return fegetround();
 }
+
+/**
+ * @brief Set the floating-point rounding mode.
+ *
+ * @param i An integer representing the desired floating-point rounding mode.
+ * @return An integer indicating the success or failure of setting the rounding mode.
+ */
 JL_DLLEXPORT int jl_set_fenv_rounding(int i)
 {
     return fesetround(i);
@@ -694,6 +1041,13 @@ static void rr_detach_teleport(void) {
 }
 #endif
 
+/**
+ * @brief Entry point for the Julia REPL (Read-Eval-Print Loop).
+ *
+ * @param argc The number of command-line arguments.
+ * @param argv Array of command-line arguments.
+ * @return An integer indicating the exit status of the REPL session.
+ */
 JL_DLLEXPORT int jl_repl_entrypoint(int argc, char *argv[])
 {
 #ifdef USE_TRACY


### PR DESCRIPTION
This adds some brief doxygen-formatted docstrings to jlapi.c.
The objective of this PR is to set doxygen docstrings as the
documentation method for Julia's C code, and allow for
further development of reference material for the use
of Julia through the C API.

These docstrings are immediately useful for consumption by
C/C++ development extensions such as tooltips.
In the future these can be useful to generate a cohesive API reference,
though this is a seperate concern involving the build system.
