### PR TITLE
incorporate upstream fixes to crc32c.c

### DIFF
--- a/src/crc32c.c
+++ b/src/crc32c.c
@@ -106,10 +106,8 @@ static uint32_t crc32c_sse42(uint32_t crc, const char *buf, size_t len)
         len--;
     }
 
-    /* compute the crc on sets of LONG*3 bytes, executing three independent crc
-       instructions, each on LONG bytes -- this is optimized for the Nehalem,
-       Westmere, Sandy Bridge, and Ivy Bridge architectures, which have a
-       throughput of one crc per cycle, but a latency of three cycles */
+    /* compute the crc on sets of LONG*3 bytes,
+       making use of three ALUs in parallel on a single core. */
     while (len >= LONG * 3) {
         uintptr_t crc1 = 0;
         uintptr_t crc2 = 0;

--- a/src/crc32c.c
+++ b/src/crc32c.c
@@ -1,6 +1,6 @@
 /* crc32c.c -- compute CRC-32C using software table or available hardware instructions
  * Copyright (C) 2013, 2021 Mark Adler
- * Version 1.1  1 Aug 2013  Mark Adler, updated 31 May 2021
+ * Version 1.1  1 Aug 2013  Mark Adler, updates from Version 1.2 5 June 2021
  *
  * Code retrieved in August 2016 from August 2013 post by Mark Adler on
  *    http://stackoverflow.com/questions/17645167/implementing-sse-4-2s-crc32c-in-software
@@ -40,7 +40,8 @@
 /* Version history:
    1.0  10 Feb 2013  First version
    1.1   1 Aug 2013  Correct comments on why three crc instructions in parallel
-        31 May 2021  Correct register constraints on assembly instructions
+   1.2   5 Jun 2021  Correct register constraints on assembly instructions
+                     (+ other changes that were superfluous for us)
 */
 
 #include "julia.h"

--- a/src/crc32c.c
+++ b/src/crc32c.c
@@ -141,7 +141,10 @@ static uint32_t crc32c_sse42(uint32_t crc, const char *buf, size_t len)
                     CRC32_PTR "\t" SHORTx1 "(%3), %1\n\t"
                     CRC32_PTR "\t" SHORTx2 "(%3), %2"
                     : "+r"(crc0), "+r"(crc1), "+r"(crc2)
-                    : "r"(buf), "m"(*buf));
+                    : "r"(buf),
+                      "m"(* (const char (*)[sizeof(void*)]) &buf[0]),
+                      "m"(* (const char (*)[sizeof(void*)]) &buf[SHORT]),
+                      "m"(* (const char (*)[sizeof(void*)]) &buf[SHORT*2]));
             buf += sizeof(void*);
         } while (buf < end);
         crc0 = crc32c_shift(crc32c_short, crc0) ^ crc1;

--- a/src/crc32c.c
+++ b/src/crc32c.c
@@ -119,9 +119,9 @@ static uint32_t crc32c_sse42(uint32_t crc, const char *buf, size_t len)
                     CRC32_PTR "\t" LONGx2 "(%3), %2"
                     : "+r"(crc0), "+r"(crc1), "+r"(crc2)
                     : "r"(buf),
-                    "m"(* (const char (*)[sizeof(void*)]) &buf[0]),
-                    "m"(* (const char (*)[sizeof(void*)]) &buf[LONG]),
-                    "m"(* (const char (*)[sizeof(void*)]) &buf[LONG*2]));
+                      "m"(* (const char (*)[sizeof(void*)]) &buf[0]),
+                      "m"(* (const char (*)[sizeof(void*)]) &buf[LONG]),
+                      "m"(* (const char (*)[sizeof(void*)]) &buf[LONG*2]));
             buf += sizeof(void*);
         } while (buf < end);
         crc0 = crc32c_shift(crc32c_long, crc0) ^ crc1;

--- a/src/crc32c.c
+++ b/src/crc32c.c
@@ -1,6 +1,6 @@
 /* crc32c.c -- compute CRC-32C using software table or available hardware instructions
- * Copyright (C) 2013 Mark Adler
- * Version 1.1  1 Aug 2013  Mark Adler
+ * Copyright (C) 2013, 2021 Mark Adler
+ * Version 1.1  1 Aug 2013  Mark Adler, updated 31 May 2021
  *
  * Code retrieved in August 2016 from August 2013 post by Mark Adler on
  *    http://stackoverflow.com/questions/17645167/implementing-sse-4-2s-crc32c-in-software
@@ -10,6 +10,7 @@
  *    - architecture and compiler detection
  *    - precompute crc32c tables and store in a generated .c file
  *    - ARMv8 support
+ * Updated to incorporate upstream 2021 patch by Mark Adler to register constraints.
  */
 
 /*
@@ -39,6 +40,7 @@
 /* Version history:
    1.0  10 Feb 2013  First version
    1.1   1 Aug 2013  Correct comments on why three crc instructions in parallel
+        31 May 2021  Correct register constraints on assembly instructions
 */
 
 #include "julia.h"
@@ -98,8 +100,8 @@ static uint32_t crc32c_sse42(uint32_t crc, const char *buf, size_t len)
        to an eight-byte boundary */
     while (len && ((uintptr_t)buf & 7) != 0) {
         __asm__("crc32b\t" "(%1), %0"
-                : "=r"(crc0)
-                : "r"(buf), "0"(crc0));
+                : "+r"(crc0)
+                : "r"(buf), "m"(*buf));
         buf++;
         len--;
     }
@@ -116,8 +118,8 @@ static uint32_t crc32c_sse42(uint32_t crc, const char *buf, size_t len)
             __asm__(CRC32_PTR "\t" "(%3), %0\n\t"
                     CRC32_PTR "\t" LONGx1 "(%3), %1\n\t"
                     CRC32_PTR "\t" LONGx2 "(%3), %2"
-                    : "=r"(crc0), "=r"(crc1), "=r"(crc2)
-                    : "r"(buf), "0"(crc0), "1"(crc1), "2"(crc2));
+                    : "+r"(crc0), "+r"(crc1), "+r"(crc2)
+                    : "r"(buf), "m"(*buf));
             buf += sizeof(void*);
         } while (buf < end);
         crc0 = crc32c_shift(crc32c_long, crc0) ^ crc1;
@@ -136,8 +138,8 @@ static uint32_t crc32c_sse42(uint32_t crc, const char *buf, size_t len)
             __asm__(CRC32_PTR "\t" "(%3), %0\n\t"
                     CRC32_PTR "\t" SHORTx1 "(%3), %1\n\t"
                     CRC32_PTR "\t" SHORTx2 "(%3), %2"
-                    : "=r"(crc0), "=r"(crc1), "=r"(crc2)
-                    : "r"(buf), "0"(crc0), "1"(crc1), "2"(crc2));
+                    : "+r"(crc0), "+r"(crc1), "+r"(crc2)
+                    : "r"(buf), "m"(*buf));
             buf += sizeof(void*);
         } while (buf < end);
         crc0 = crc32c_shift(crc32c_short, crc0) ^ crc1;
@@ -151,8 +153,8 @@ static uint32_t crc32c_sse42(uint32_t crc, const char *buf, size_t len)
     const char *end = buf + (len - (len & 7));
     while (buf < end) {
         __asm__(CRC32_PTR "\t" "(%1), %0"
-                : "=r"(crc0)
-                : "r"(buf), "0"(crc0));
+                : "+r"(crc0)
+                : "r"(buf), "m"(*buf));
         buf += sizeof(void*);
     }
     len &= 7;
@@ -160,8 +162,8 @@ static uint32_t crc32c_sse42(uint32_t crc, const char *buf, size_t len)
     /* compute the crc for up to seven trailing bytes */
     while (len) {
         __asm__("crc32b\t" "(%1), %0"
-                : "=r"(crc0)
-                : "r"(buf), "0"(crc0));
+                : "+r"(crc0)
+                : "r"(buf), "m"(*buf));
         buf++;
         len--;
     }

--- a/src/crc32c.c
+++ b/src/crc32c.c
@@ -118,7 +118,7 @@ static uint32_t crc32c_sse42(uint32_t crc, const char *buf, size_t len)
                     CRC32_PTR "\t" LONGx1 "(%3), %1\n\t"
                     CRC32_PTR "\t" LONGx2 "(%3), %2"
                     : "+r"(crc0), "+r"(crc1), "+r"(crc2)
-                    : "r"(buf), "m"(* (const char (*)[LONG*3]) buf));
+                    : "r"(buf), "m"(*buf));
             buf += sizeof(void*);
         } while (buf < end);
         crc0 = crc32c_shift(crc32c_long, crc0) ^ crc1;

--- a/src/crc32c.c
+++ b/src/crc32c.c
@@ -118,7 +118,10 @@ static uint32_t crc32c_sse42(uint32_t crc, const char *buf, size_t len)
                     CRC32_PTR "\t" LONGx1 "(%3), %1\n\t"
                     CRC32_PTR "\t" LONGx2 "(%3), %2"
                     : "+r"(crc0), "+r"(crc1), "+r"(crc2)
-                    : "r"(buf), "m"(*buf));
+                    : "r"(buf),
+                    "m"(* (const char (*)[sizeof(void*)]) &buf[0]),
+                    "m"(* (const char (*)[sizeof(void*)]) &buf[LONG]),
+                    "m"(* (const char (*)[sizeof(void*)]) &buf[LONG*2]));
             buf += sizeof(void*);
         } while (buf < end);
         crc0 = crc32c_shift(crc32c_long, crc0) ^ crc1;

--- a/src/crc32c.c
+++ b/src/crc32c.c
@@ -159,7 +159,7 @@ static uint32_t crc32c_sse42(uint32_t crc, const char *buf, size_t len)
     while (buf < end) {
         __asm__(CRC32_PTR "\t" "(%1), %0"
                 : "+r"(crc0)
-                : "r"(buf), "m"(*buf));
+                : "r"(buf), "m"(* (const char (*)[sizeof(void*)]) buf));
         buf += sizeof(void*);
     }
     len &= 7;

--- a/src/crc32c.c
+++ b/src/crc32c.c
@@ -118,7 +118,7 @@ static uint32_t crc32c_sse42(uint32_t crc, const char *buf, size_t len)
                     CRC32_PTR "\t" LONGx1 "(%3), %1\n\t"
                     CRC32_PTR "\t" LONGx2 "(%3), %2"
                     : "+r"(crc0), "+r"(crc1), "+r"(crc2)
-                    : "r"(buf), "m"(*buf));
+                    : "r"(buf), "m"(* (const char (*)[LONG*3]) buf));
             buf += sizeof(void*);
         } while (buf < end);
         crc0 = crc32c_shift(crc32c_long, crc0) ^ crc1;

--- a/stdlib/CRC32c/test/runtests.jl
+++ b/stdlib/CRC32c/test/runtests.jl
@@ -45,6 +45,15 @@ function test_crc32c(crc32c)
             rm(f, force=true)
         end
     end
+
+    # test longer arrays to cover all the code paths in crc32c.c
+    LONG = 8192 # from crc32c.c
+    SHORT = 256 # from crc32c.c
+    n = LONG*3+SHORT*3+SHORT*2+64+7
+    big = vcat(reinterpret(UInt8, hton.(0x74d7f887 .^ (1:n÷4))), UInt8[1:n%4;])
+    for (offset,crc) in [(0, 0x13a5ecd5), (1, 0xecf34b7e), (2, 0xfa71b596), (3, 0xbfd24745), (4, 0xf0cb3370), (5, 0xb0ec88b5), (6, 0x258c20a8), (7, 0xa9bd638d)]
+        @test crc == crc32c(@view big[1+offset:end])
+    end
 end
 unsafe_crc32c_sw(a, n, crc) =
     ccall(:jl_crc32c_sw, UInt32, (UInt32, Ptr{UInt8}, Csize_t), crc, a, n)


### PR DESCRIPTION
Closes #52325.

I have ~~no~~ only a [vague](https://gcc.gnu.org/onlinedocs/gcc/Simple-Constraints.html) [idea](https://stackoverflow.com/questions/40638326/inline-assembly-clarification-of-constraint-modifiers) what these changes to the `__asm__` register arguments actually do; I just copied them from @madler [upstream](https://stackoverflow.com/questions/17645167/implementing-sse-4-2s-crc32c-in-software/17646775#17646775).  It would be good if @yuyichao or @vtjnash or someone else who knows `__asm__` syntax would take a look.   It looks like they are a response to [this comment](https://stackoverflow.com/questions/17645167/implementing-sse-4-2s-crc32c-in-software/17646775#comment88832559_17646775) on StackOverflow:

> Your asm constraints aren't strictly safe. A pointer in a `"r"` constraint does not imply that the pointed-to memory is also an input. You could just use memory operands (or the `_mm_crc32_u64` intrinsic), but if you want to force the addressing mode you can use a dummy memory operand like `asm("crc32 (%1),%0 " : "+r"(crc0) : "r"(next),  "m" (*(const char (*)[24]) pStr) )`;. Inlining or LTO could break this. See [at&t asm inline c++ problem](https://stackoverflow.com/posts/comments/81680441) (which needs an update: pointer-to-array is cleaner than a struct with a flexible array member).

~~There should be test coverage of this PR via https://github.com/JuliaLang/julia/blob/master/stdlib/CRC32c/test/runtests.jl~~ The existing test coverage wasn't enough to fully exercise Adler's code, so I added another test.