### PR TITLE
[REPLCompletions] fix #52099 by adjusting effects of `HAMT` methods

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -698,7 +698,7 @@ function scan_non_dataflow_flags!(inst::Instruction, sv::PostOptAnalysisState)
     flag = inst[:flag]
     # If we can prove that the argmem does not escape the current function, we can
     # refine this to :effect_free.
-    needs_ea_validation = (flag & IR_FLAGS_NEEDS_EA) == IR_FLAGS_NEEDS_EA
+    needs_ea_validation = has_flag(flag, IR_FLAGS_NEEDS_EA)
     stmt = inst[:stmt]
     if !needs_ea_validation
         if !isterminator(stmt) && stmt !== nothing
@@ -730,7 +730,7 @@ end
 
 function scan_inconsistency!(inst::Instruction, sv::PostOptAnalysisState)
     flag = inst[:flag]
-    stmt_inconsistent = iszero(flag & IR_FLAG_CONSISTENT)
+    stmt_inconsistent = !has_flag(flag, IR_FLAG_CONSISTENT)
     stmt = inst[:stmt]
     # Special case: For `getfield` and memory operations, we allow inconsistency of the :boundscheck argument
     (; inconsistent, tpdum) = sv

--- a/base/hamt.jl
+++ b/base/hamt.jl
@@ -66,21 +66,21 @@ mutable struct HAMT{K, V}
     HAMT{K, V}() where {K, V} = new{K,V}(Vector{Union{Leaf{K, V}, HAMT{K, V}}}(undef, 0), zero(BITMAP))
 end
 
-@Base.assume_effects :nothrow function init_hamt(K, V, k, v)
-    # For a single element we can't have a hash-collision
+Base.@assume_effects :nothrow :effect_free function init_hamt(K, V, k, v)
+    # For a single element we can't have a 'hash-collision
     trie = HAMT{K,V}(Vector{Union{Leaf{K, V}, HAMT{K, V}}}(undef, 1), zero(BITMAP))
     trie.data[1] = Leaf{K,V}(k,v)
     return trie
 end
 
-function HAMT{K,V}((k,v)::Pair) where {K, V}
-    k = convert(K, k)
-    v = convert(V, v)
+Base.@assume_effects :effect_free function HAMT{K,V}((k,v)::Pair{K,V}) where {K, V}
     trie = init_hamt(K, V, k, v)
     bi = BitmapIndex(HashState(k))
     set!(trie, bi)
     return trie
 end
+HAMT{K,V}(kv::Pair) where {K, V} = HAMT{K,V}(convert(Pair{K,V}, kv))
+
 HAMT(pair::Pair{K,V}) where {K, V} = HAMT{K,V}(pair)
 
 # TODO: Parameterize by hash function

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -2148,3 +2148,11 @@ end
 let t = REPLCompletions.repl_eval_ex(:(unsafe_method(42)), @__MODULE__)
     @test isnothing(t)
 end
+
+# https://github.com/JuliaLang/julia/issues/52099
+const issue52099 = []
+let t = REPLCompletions.repl_eval_ex(:(Base.PersistentDict(issue52099 => 3)), @__MODULE__)
+    if t isa Core.Const
+        @test length(t.val) == 1
+    end
+end

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1107,6 +1107,9 @@ import Base.PersistentDict
         @test hs.hash == hsr.hash
         @test hs.depth == hsr.depth
         @test hs.shift == hsr.shift
+
+        @test Core.Compiler.is_removable_if_unused(Base.infer_effects(Base.HAMT.init_hamt, (Type{Vector{Any}},Type{Int},Vector{Any},Int)))
+        @test Core.Compiler.is_removable_if_unused(Base.infer_effects(Base.HAMT.HAMT{Vector{Any},Int}, (Pair{Vector{Any},Int},)))
     end
     @testset "basics" begin
         dict = PersistentDict{Int, Int}()


### PR DESCRIPTION
After looking into #52099, I discovered that it has the same root cause as #51548. Essentially, when a method that's not `!effect_free` is applied to a `Const` value concretized by the `REPLInterpreter`'s aggressive inference, since the `!effect_free` method will not be concretized, it will eventually lead to the `Const` representing unexpected object being returned.

This commit tries to fix the specific problem reported in #52099 by enhancing the effects of `Base.HAMT` methods, so they're concrete-evaled.

Admittedly, this is more of a quick fix than a complete solution, and not the best one, but it was the simplest. A better solution might involve implementing EA's handling of `Memory`-objects that allows the compiler to automatically prove `:effect_free` in more scenarios. But this would need a bigger overhaul, so I plan to tackle it in another PR.