### PR TITLE
Added explanation for the interpolation of tuple

### DIFF
--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -243,6 +243,19 @@ julia> ex = :(a in $:((1,2,3)) )
 :(a in (1, 2, 3))
 ```
 
+- a in $:((1,2,3)) is a quoted expression created using : It consists of two parts:
+
+* a in ...: This represents a membership test where a is checked for membership in a collection.
+* $:((1,2,3)): This is an interpolated expression within the quoted block. 
+
+- $(1,2,3): Inside the interpolation $(), (1,2,3) represents a tuple containing three elements: 1, 2, and 3.
+
+- The interpolation $:((1,2,3)) substitutes the tuple (1,2,3) into the expression. It results in the expression a in (1, 2, 3).
+
+- a in (1, 2, 3): This checks whether the value of a is present in the tuple (1, 2, 3).
+
+- ex = :(a in $:((1,2,3))): Assigns the quoted expression a in $:((1,2,3)) to the variable ex.
+
 The use of `$` for expression interpolation is intentionally reminiscent of [string interpolation](@ref string-interpolation)
 and [command interpolation](@ref command-interpolation). Expression interpolation allows convenient, readable programmatic
 construction of complex Julia expressions.

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -243,18 +243,18 @@ julia> ex = :(a in $:((1,2,3)) )
 :(a in (1, 2, 3))
 ```
 
-- a in $:((1,2,3)) is a quoted expression created using : It consists of two parts:
+- `a in $:((1,2,3))` is a quoted expression created using `:` It consists of two parts:
 
-* a in ...: This represents a membership test where a is checked for membership in a collection.
-* $:((1,2,3)): This is an interpolated expression within the quoted block. 
+  - `a in ...`: This represents a membership test where `a` is checked for membership in a collection.
+  - `$:((1,2,3))`: This is an interpolated expression within the quoted block. 
 
-- $(1,2,3): Inside the interpolation $(), (1,2,3) represents a tuple containing three elements: 1, 2, and 3.
+- `$(1,2,3)`: Inside the interpolation `$(), (1,2,3)` represents a tuple containing three elements: 1, 2, and 3.
 
-- The interpolation $:((1,2,3)) substitutes the tuple (1,2,3) into the expression. It results in the expression a in (1, 2, 3).
+- The interpolation `$:((1,2,3))` substitutes the tuple `(1,2,3)` into the expression. It results in the expression `a in (1, 2, 3)`.
 
 - a in (1, 2, 3): This checks whether the value of a is present in the tuple (1, 2, 3).
 
-- ex = :(a in $:((1,2,3))): Assigns the quoted expression a in $:((1,2,3)) to the variable ex.
+- ex = `:(a in $:((1,2,3)))`: Assigns the quoted expression `a in $:((1,2,3))` to the variable `ex`.
 
 The use of `$` for expression interpolation is intentionally reminiscent of [string interpolation](@ref string-interpolation)
 and [command interpolation](@ref command-interpolation). Expression interpolation allows convenient, readable programmatic


### PR DESCRIPTION
Fixed #52187 

This pull request adds an explanation for the example code `ex = :(a in $:((1,2,3)))` in Julia. The explanation provides a meaningful description of how the code works and its purpose. This addition enhances the clarity and understanding of the code for beginners.