### PR TITLE
Use ismissing or !ismissing rather than `=== missing` or `!== missing`

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -1017,7 +1017,7 @@ false
 """
 function isempty(itr)
     d = isdone(itr)
-    d !== missing && return d
+    !ismissing(d) && return d
     iterate(itr) === nothing
 end
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -422,7 +422,7 @@ function locate_package_env(pkg::PkgId, stopenv::Union{String, Nothing}=nothing)
             env′ = env
             path = manifest_uuid_path(env, pkg)
             # missing is used as a sentinel to stop looking further down in envs
-            if path === missing
+            if ismissing(path)
                 path = nothing
                 @goto done
             end
@@ -712,7 +712,7 @@ function project_file_manifest_path(project_file::String)::Union{Nothing,String}
     cache = LOADING_CACHE[]
     if cache !== nothing
         manifest_path = get(cache.project_file_manifest_path, project_file, missing)
-        manifest_path === missing || return manifest_path
+        ismissing(manifest_path) || return manifest_path
     end
     dir = abspath(dirname(project_file))
     d = parsed_toml(project_file)

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -241,7 +241,7 @@ function iterate(itr::SkipMissing, state...)
     y = iterate(itr.x, state...)
     y === nothing && return nothing
     item, state = y
-    while item === missing
+    while ismissing(item)
         y = iterate(itr.x, state)
         y === nothing && return nothing
         item, state = y
@@ -251,12 +251,12 @@ end
 
 IndexStyle(::Type{<:SkipMissing{T}}) where {T} = IndexStyle(T)
 eachindex(itr::SkipMissing) =
-    Iterators.filter(i -> @inbounds(itr.x[i]) !== missing, eachindex(itr.x))
+    Iterators.filter(i -> !ismissing(@inbounds(itr.x[i])), eachindex(itr.x))
 keys(itr::SkipMissing) =
-    Iterators.filter(i -> @inbounds(itr.x[i]) !== missing, keys(itr.x))
+    Iterators.filter(i -> !ismissing(@inbounds(itr.x[i])), keys(itr.x))
 @propagate_inbounds function getindex(itr::SkipMissing, I...)
     v = itr.x[I...]
-    v === missing && throw(MissingException(LazyString("the value at index ", I, " is missing")))
+    ismissing(v) && throw(MissingException(LazyString("the value at index ", I, " is missing")))
     v
 end
 
@@ -280,18 +280,18 @@ function _mapreduce(f, op, ::IndexLinear, itr::SkipMissing{<:AbstractArray})
     ilast = last(inds)
     for outer i in i:ilast
         @inbounds ai = A[i]
-        ai !== missing && break
+        !ismissing(ai) && break
     end
-    ai === missing && return mapreduce_empty(f, op, eltype(itr))
+    ismissing(ai) && return mapreduce_empty(f, op, eltype(itr))
     a1::eltype(itr) = ai
     i == typemax(typeof(i)) && return mapreduce_first(f, op, a1)
     i += 1
     ai = missing
     for outer i in i:ilast
         @inbounds ai = A[i]
-        ai !== missing && break
+        !ismissing(ai) && break
     end
-    ai === missing && return mapreduce_first(f, op, a1)
+    ismissing(ai) && return mapreduce_first(f, op, a1)
     # We know A contains at least two non-missing entries: the result cannot be nothing
     something(mapreduce_impl(f, op, itr, first(inds), last(inds)))
 end
@@ -309,7 +309,7 @@ mapreduce_impl(f, op, A::SkipMissing, ifirst::Integer, ilast::Integer) =
         return nothing
     elseif ifirst == ilast
         @inbounds a1 = A[ifirst]
-        if a1 === missing
+        if ismissing(a1)
             return nothing
         else
             return Some(mapreduce_first(f, op, a1))
@@ -320,25 +320,25 @@ mapreduce_impl(f, op, A::SkipMissing, ifirst::Integer, ilast::Integer) =
         i = ifirst
         for outer i in i:ilast
             @inbounds ai = A[i]
-            ai !== missing && break
+            !ismissing(ai) && break
         end
-        ai === missing && return nothing
+        ismissing(ai) && return nothing
         a1 = ai::eltype(itr)
         i == typemax(typeof(i)) && return Some(mapreduce_first(f, op, a1))
         i += 1
         ai = missing
         for outer i in i:ilast
             @inbounds ai = A[i]
-            ai !== missing && break
+            !ismissing(ai) && break
         end
-        ai === missing && return Some(mapreduce_first(f, op, a1))
+        ismissing(ai) && return Some(mapreduce_first(f, op, a1))
         a2 = ai::eltype(itr)
         i == typemax(typeof(i)) && return Some(op(f(a1), f(a2)))
         i += 1
         v = op(f(a1), f(a2))
         @simd for i = i:ilast
             @inbounds ai = A[i]
-            if ai !== missing
+            if !ismissing(ai)
                 v = op(v, f(ai))
             end
         end
@@ -384,7 +384,7 @@ julia> filter(isodd, skipmissing(x))
 function filter(f, itr::SkipMissing{<:AbstractArray})
     y = similar(itr.x, eltype(itr), 0)
     for xi in itr.x
-        if xi !== missing && f(xi)
+        if !ismissing(xi) && f(xi)
             push!(y, xi)
         end
     end
@@ -450,7 +450,7 @@ ERROR: `b` is still missing
 macro coalesce(args...)
     expr = :(missing)
     for arg in reverse(args)
-        expr = :((val = $arg) !== missing ? val : $expr)
+        expr = :((val = $arg) |> !ismissing ? val : $expr)
     end
     return esc(:(let val; $expr; end))
 end

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -478,7 +478,7 @@ for (sym, exp, type) in [
     @eval function $usym(v, o, kw)
         # using missing instead of nothing because scratch could === nothing.
         res = get(kw, $(Expr(:quote, sym)), missing)
-        res !== missing && return kw, res::$type
+        !ismissing(res) && return kw, res::$type
         $sym = $exp
         (;kw..., $sym), $sym::$type
     end

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -478,7 +478,7 @@ for (sym, exp, type) in [
     @eval function $usym(v, o, kw)
         # using missing instead of nothing because scratch could === nothing.
         res = get(kw, $(Expr(:quote, sym)), missing)
-        !ismissing(res) && return kw, res::$type
+        res !== missing && return kw, res::$type
         $sym = $exp
         (;kw..., $sym), $sym::$type
     end

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -651,3 +651,12 @@ for func in (round, ceil, floor, trunc)
         @test Core.Compiler.is_foldable(Base.infer_effects(func, (Type{Int},Union{Int,Missing})))
     end
 end
+
+@testset "New Missing" begin
+    _replace_missing(itr, replacement) = Iterators.map(x->ismissing(x) ? replacement : x, itr)
+    struct NewMissing end
+    newmissing = NewMissing()
+    Base.ismissing(::NewMissing) = true
+    arr = [missing 1 2 3 missing 10 11 12 missing]
+    @test all(skipmissing(arr) .== skipmissing(_replace_missing(arr, newmissing)))
+end


### PR DESCRIPTION
Changes most of Base to use
* `ismissing` instead of `=== missing`
* `!ismissing` instead of `!== missing`

I made sure not to touch `Core.compiler`.

This allows new `Missing`-like types to utilize infrastructure such as `skipmissing` by defining `ismissing(::MyMissing)`.
