### PR TITLE
Add single-term multiplication for `AbstractQ` on v1.10 and above

### DIFF
--- a/stdlib/LinearAlgebra/src/abstractq.jl
+++ b/stdlib/LinearAlgebra/src/abstractq.jl
@@ -157,6 +157,9 @@ qsize_check(Q::AbstractQ, P::AbstractQ) =
     size(Q, 2) == size(P, 1) ||
         throw(DimensionMismatch("second dimension of A, $(size(Q,2)), must coincide with first dimension of B, $(size(P,1))"))
 
+# mimic the AbstractArray fallback
+*(Q::AbstractQ) = Q
+
 (*)(Q::AbstractQ, J::UniformScaling) = Q*J.λ
 function (*)(Q::AbstractQ, b::Number)
     T = promote_type(eltype(Q), typeof(b))

--- a/stdlib/LinearAlgebra/src/abstractq.jl
+++ b/stdlib/LinearAlgebra/src/abstractq.jl
@@ -158,7 +158,7 @@ qsize_check(Q::AbstractQ, P::AbstractQ) =
         throw(DimensionMismatch("second dimension of A, $(size(Q,2)), must coincide with first dimension of B, $(size(P,1))"))
 
 # mimic the AbstractArray fallback
-*(Q::AbstractQ) = Q
+*(Q::AbstractQ{<:Number}) = Q
 
 (*)(Q::AbstractQ, J::UniformScaling) = Q*J.λ
 function (*)(Q::AbstractQ, b::Number)

--- a/stdlib/LinearAlgebra/test/abstractq.jl
+++ b/stdlib/LinearAlgebra/test/abstractq.jl
@@ -34,6 +34,7 @@ n = 5
         T <: Complex && @test_throws ErrorException transpose(Q)
         @test convert(AbstractQ{complex(T)}, Q) isa MyQ{complex(T)}
         @test convert(AbstractQ{complex(T)}, Q') isa AdjointQ{<:complex(T),<:MyQ{complex(T)}}
+        @test *(Q) == Q
         @test Q*I ≈ Q.Q*I rtol=2eps(real(T))
         @test Q'*I ≈ Q.Q'*I rtol=2eps(real(T))
         @test I*Q ≈ Q.Q*I rtol=2eps(real(T))


### PR DESCRIPTION
The following works on Julia v1.9 but not on 1.10 and above, as `Q` is not an `AbstractMatrix` anymore, and doesn't have access to the fallback method:
```julia
julia> Q = qr(rand(4,4)).Q;

julia> *(Q)
4×4 LinearAlgebra.QRCompactWYQ{Float64, Matrix{Float64}, Matrix{Float64}}:
 -0.80458    -0.0760911   0.57709   -0.117597
 -0.0134158  -0.952934   -0.192074  -0.23419
 -0.492601    0.251727   -0.733911  -0.394147
 -0.331385   -0.150867   -0.302406   0.880894
```
This PR adds a trivial method to reinstate this behavior. A similar method exists for `Givens`, so something like this may be conceptualized for linear operators. Moreover, this may be pragmatic to avoid breakages. Currently, the tests for `LazyArrays` are broken on v1.10 as this method is missing.