### PR TITLE
Only `notify` one waiting task in `unlock(::ReentrantLock)`

### DIFF
--- a/base/lock.jl
+++ b/base/lock.jl
@@ -180,11 +180,11 @@ internal counter and return immediately.
         if n == 0x0000_00000
             @atomic :monotonic rl.locked_by = nothing
             if (@atomicswap :release rl.havelock = 0x00) == 0x02
-                (@noinline function notifywaiters(rl)
+                (@noinline function notifywaiter(rl)
                     cond_wait = rl.cond_wait
                     lock(cond_wait)
                     try
-                        notify(cond_wait)
+                        notify(cond_wait, all=false)
                     finally
                         unlock(cond_wait)
                     end


### PR DESCRIPTION
There's no need to notify all the waiting tasks.