### PR TITLE
Mention `@lock` in `lock(f, l)` docstring

### DIFF
--- a/base/lock.jl
+++ b/base/lock.jl
@@ -220,6 +220,8 @@ available.
 When this function returns, the `lock` has been released, so the caller should
 not attempt to `unlock` it.
 
+See also: [`@lock`](@ref).
+
 !!! compat "Julia 1.7"
     Using a [`Channel`](@ref) as the second argument requires Julia 1.7 or later.
 """


### PR DESCRIPTION
Follow up to: https://github.com/JuliaLang/julia/issues/36441. Makes this macro much easier to learn about if you're just viewing the docstrings.