### PR TITLE
make custom log macros work

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -370,23 +370,23 @@ function logmsg_code(_module, file, line, level, message, exs...)
         let
             level = $level
             # simplify std_level code emitted, if we know it is one of our global constants
-            std_level = $(level isa Symbol ? :level : :(level isa LogLevel ? level : convert(LogLevel, level)::LogLevel))
-            if std_level >= _min_enabled_level[]
+            std_level = $(level isa Symbol ? :level : :(level isa Base.CoreLogging.LogLevel ? level : convert(Base.CoreLogging.LogLevel, level)::Base.CoreLogging.LogLevel))
+            if std_level >= Base.CoreLogging._min_enabled_level[]
                 group = $(log_data._group)
                 _module = $(log_data._module)
-                logger = current_logger_for_env(std_level, group, _module)
+                logger = Base.CoreLogging.current_logger_for_env(std_level, group, _module)
                 if !(logger === nothing)
                     id = $(log_data._id)
                     # Second chance at an early bail-out (before computing the message),
                     # based on arbitrary logger-specific logic.
-                    if invokelatest(shouldlog, logger, level, _module, group, id)
+                    if invokelatest(Base.CoreLogging.shouldlog, logger, level, _module, group, id)
                         file = $(log_data._file)
                         if file isa String
                             file = Base.fixup_stdlib_path(file)
                         end
                         line = $(log_data._line)
                         local msg, kwargs
-                        $(logrecord) && invokelatest(handle_message,
+                        $(logrecord) && invokelatest(Base.CoreLogging.handle_message,
                             logger, level, msg, _module, group, id, file, line;
                             kwargs...)
                     end

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -159,6 +159,9 @@ Alias for [`LogLevel(2000)`](@ref LogLevel).
 const Error         = LogLevel(    2000)
 const AboveMaxLevel = LogLevel( 1000001)
 
+# Global log limiting mechanism for super fast but inflexible global log limiting.
+const _min_enabled_level = Ref{LogLevel}(Debug)
+
 function show(io::IO, level::LogLevel)
     if     level == BelowMinLevel  print(io, "BelowMinLevel")
     elseif level == Debug          print(io, "Debug")
@@ -319,6 +322,15 @@ function issimplekw(@nospecialize val)
     return false
 end
 
+# helper function to get the current logger, if enabled for the specified message type
+@noinline Base.@constprop :none function current_logger_for_env(std_level::LogLevel, group, _module)
+    logstate = @inline current_logstate()
+    if std_level >= logstate.min_enabled_level || env_override_minlevel(group, _module)
+        return logstate.logger
+    end
+    return nothing
+end
+
 # Generate code for logging macros
 function logmsg_code(_module, file, line, level, message, exs...)
     @nospecialize
@@ -370,23 +382,23 @@ function logmsg_code(_module, file, line, level, message, exs...)
         let
             level = $level
             # simplify std_level code emitted, if we know it is one of our global constants
-            std_level = $(level isa Symbol ? :level : :(level isa Base.CoreLogging.LogLevel ? level : convert(Base.CoreLogging.LogLevel, level)::Base.CoreLogging.LogLevel))
-            if std_level >= Base.CoreLogging._min_enabled_level[]
+            std_level = $(level isa Symbol ? :level : :(level isa $LogLevel ? level : convert($LogLevel, level)::$LogLevel))
+            if std_level >= $(_min_enabled_level)[]
                 group = $(log_data._group)
                 _module = $(log_data._module)
-                logger = Base.CoreLogging.current_logger_for_env(std_level, group, _module)
+                logger = $(current_logger_for_env)(std_level, group, _module)
                 if !(logger === nothing)
                     id = $(log_data._id)
                     # Second chance at an early bail-out (before computing the message),
                     # based on arbitrary logger-specific logic.
-                    if invokelatest(Base.CoreLogging.shouldlog, logger, level, _module, group, id)
+                    if invokelatest($shouldlog, logger, level, _module, group, id)
                         file = $(log_data._file)
                         if file isa String
                             file = Base.fixup_stdlib_path(file)
                         end
                         line = $(log_data._line)
                         local msg, kwargs
-                        $(logrecord) && invokelatest(Base.CoreLogging.handle_message,
+                        $(logrecord) && invokelatest($handle_message,
                             logger, level, msg, _module, group, id, file, line;
                             kwargs...)
                     end
@@ -481,9 +493,6 @@ function logmsg_shim(level, message, _module, group, id, file, line, kwargs)
     nothing
 end
 
-# Global log limiting mechanism for super fast but inflexible global log limiting.
-const _min_enabled_level = Ref{LogLevel}(Debug)
-
 # LogState - a cache of data extracted from the logger, plus the logger itself.
 struct LogState
     min_enabled_level::LogLevel
@@ -497,15 +506,6 @@ const CURRENT_LOGSTATE = ScopedValue{LogState}()
 function current_logstate()
     maybe = @inline Base.ScopedValues.get(CURRENT_LOGSTATE)
     return something(maybe, _global_logstate)::LogState
-end
-
-# helper function to get the current logger, if enabled for the specified message type
-@noinline Base.@constprop :none function current_logger_for_env(std_level::LogLevel, group, _module)
-    logstate = @inline current_logstate()
-    if std_level >= logstate.min_enabled_level || env_override_minlevel(group, _module)
-        return logstate.logger
-    end
-    return nothing
 end
 
 with_logstate(f::Function, logstate) = @with(CURRENT_LOGSTATE => logstate, f())


### PR DESCRIPTION
Taken from https://github.com/JuliaLang/julia/pull/52196 so the fix part can be backported to 1.10

Without this
```
julia> using Logging

julia> CustomLog = LogLevel(-500)
LogLevel(-500)

julia> macro customlog(exs...) Base.CoreLogging.logmsg_code((Base.CoreLogging.@_sourceinfo)..., esc(CustomLog), exs...) end
@customlog (macro with 1 method)

julia> @customlog "hello"
ERROR: UndefVarError: `_min_enabled_level` not defined
Stacktrace:
 [1] top-level scope
   @ logging.jl:373
```