### PR TITLE
sroa: Handle looking through chains of KeyValue instances

### DIFF
--- a/base/scopedvalues.jl
+++ b/base/scopedvalues.jl
@@ -70,11 +70,14 @@ function Scope(parent::Union{Nothing, Scope}, key::ScopedValue{T}, value) where 
     return Scope(ScopeStorage(parent.values, key=>val))
 end
 
-function Scope(scope, pairs::Pair{<:ScopedValue}...)
-    for pair in pairs
-        scope = Scope(scope, pair...)
-    end
-    return scope::Scope
+function Scope(scope, pair::Pair{<:ScopedValue})
+    return Scope(scope, pair...)
+end
+
+function Scope(scope, pair1::Pair{<:ScopedValue}, pair2::Pair{<:ScopedValue}, pairs::Pair{<:ScopedValue}...)
+    # Unroll this loop through recursion to make sure that
+    # our compiler optimization support works
+    return Scope(Scope(scope, pair1...), pair2, pairs...)
 end
 Scope(::Nothing) = nothing
 

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1549,10 +1549,19 @@ function persistent_dict_elim()
     a = Base.PersistentDict(:a => 1)
     return a[:a]
 end
+
 # Ideally we would be able to fully eliminate this,
 # but currently this would require an extra round of constprop
 @test_broken fully_eliminated(persistent_dict_elim)
 @test code_typed(persistent_dict_elim)[1][1].code[end] == Core.ReturnNode(1)
+
+function persistent_dict_elim_multiple()
+    a = Base.PersistentDict(:a => 1)
+    b = Base.PersistentDict(a, :b => 2)
+    return b[:a]
+end
+@test_broken fully_eliminated(persistent_dict_elim_multiple)
+@test code_typed(persistent_dict_elim_multiple)[1][1].code[end] == Core.ReturnNode(1)
 
 # Test CFG simplify with try/catch blocks
 let code = Any[


### PR DESCRIPTION
Addresses an outstanding todo from the KeyValue PR and allows (once all the PRs are merged), optimization when multiple ScopedValues are used `with(a=>1, b=>2)`, etc. To facilitate this, in addition to the sroa adjustment, the ScopedValue code is adjusted to unroll the PersistentDict creation so that the optimizer can see the full chain (we do not support loops in the optimizer).