### PR TITLE
clarify @views docstring

### DIFF
--- a/base/views.jl
+++ b/base/views.jl
@@ -223,17 +223,13 @@ Similarly, `@views` converts string slices into [`SubString`](@ref) views.
     that appear explicitly in the given `expression`, not array slicing that
     occurs in functions called by that code.
 
-!!! compat "Julia 1.5"
-    Using `begin` in an indexing expression to refer to the first index requires at least
-    Julia 1.5.
-
 # Examples
 ```jldoctest
 julia> A = zeros(3, 3);
 
 julia> @views for row in 1:3
-           b = A[row, :]
-           b[:] .= row
+           b = A[row, :] # b is a view, not a copy
+           b .= row      # assign every element to the row index
        end
 
 julia> A

--- a/base/views.jl
+++ b/base/views.jl
@@ -223,6 +223,10 @@ Similarly, `@views` converts string slices into [`SubString`](@ref) views.
     that appear explicitly in the given `expression`, not array slicing that
     occurs in functions called by that code.
 
+!!! compat "Julia 1.5"
+    Using `begin` in an indexing expression to refer to the first index requires at least
+    was implemented in Julia 1.4, but was only supported by `@views` starting in Julia 1.5.
+
 # Examples
 ```jldoctest
 julia> A = zeros(3, 3);

--- a/base/views.jl
+++ b/base/views.jl
@@ -224,8 +224,8 @@ Similarly, `@views` converts string slices into [`SubString`](@ref) views.
     occurs in functions called by that code.
 
 !!! compat "Julia 1.5"
-    Using `begin` in an indexing expression to refer to the first index requires at least
-    was implemented in Julia 1.4, but was only supported by `@views` starting in Julia 1.5.
+    Using `begin` in an indexing expression to refer to the first index was implemented
+    in Julia 1.4, but was only supported by `@views` starting in Julia 1.5.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
This PR is a slight clarification to the `@views` docstring that:

1. Clarifies the compat notice about `begin` indexing — this was implemented in Julia 1.4, but was only supported by `@views` in Julia 1.5.
2. Changes `b[:] .= row` to `b .= row` in the example — the `[:]` is superfluous and confusing.
3. Adds comments to the code