### PR TITLE
Fix type check in poll_fd() exception handler

### DIFF
--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -727,7 +727,7 @@ function poll_fd(s::Union{RawFD, Sys.iswindows() ? WindowsRawSocket : Union{}}, 
                     end
                 end
             catch ex
-                ex isa EOFError() || rethrow()
+                ex isa EOFError || rethrow()
                 return FDEvent()
             end
         else


### PR DESCRIPTION
Previously this was creating an `EOFError` value and passing it to `isa`, instead of just passing the type.

I tried to write a test but couldn't figure out a nice way of doing it. If I read the code correctly this bug will only be triggered if the file descriptor is closed between creating the `_FDWatcher` in `poll_fd()` (which will throw if it's already closed) and calling `_wait()`.