### PR TITLE
[WIP] Stack allocate some genericmemory

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -507,10 +507,10 @@ const undef = UndefInitializer()
 
 # type and dimensionality specified
 (self::Type{GenericMemory{kind,T,addrspace}})(::UndefInitializer, m::Int) where {T,addrspace,kind} =
-    if isdefined(self, :instance) && m === 0
-        self.instance
-    else
+    if (kind === :not_atomic && addrspace === CPU) || (!isdefined(self, :instance) || m !== 0)
         ccall(:jl_alloc_genericmemory, Ref{GenericMemory{kind,T,addrspace}}, (Any, Int), self, m)
+    else
+        self.instance
     end
 (self::Type{GenericMemory{kind,T,addrspace}})(::UndefInitializer, d::NTuple{1,Int}) where {T,kind,addrspace} = self(undef, getfield(d,1))
 # empty vector constructor

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -639,6 +639,13 @@ typedef union {
     uint8_t packed;
 } jl_code_info_flags_t;
 
+typedef struct {
+    size_t elsize;
+    uint8_t isunion;
+    uint8_t zeroinit;
+    uint8_t isboxed;
+} jl_genericmemory_info_t;
+
 // -- functions -- //
 
 JL_DLLEXPORT jl_code_info_t *jl_type_infer(jl_method_instance_t *li, size_t world, int force);
@@ -987,6 +994,11 @@ STATIC_INLINE size_t n_linkage_blobs(void) JL_NOTSAFEPOINT
 size_t external_blob_index(jl_value_t *v) JL_NOTSAFEPOINT;
 
 uint8_t jl_object_in_image(jl_value_t* v) JL_NOTSAFEPOINT;
+
+// used by alloc-opt
+JL_DLLEXPORT size_t jl_genericmemory_bytesize(const jl_genericmemory_info_t *info, size_t nel);
+// used by codegen to give info to alloc-opt
+JL_DLLEXPORT jl_genericmemory_info_t jl_get_genericmemory_info(jl_value_t *mtype);
 
 // the first argument to jl_idtable_rehash is used to return a value
 // make sure it is rooted if it is used after the function returns

--- a/src/llvm-alloc-helpers.cpp
+++ b/src/llvm-alloc-helpers.cpp
@@ -185,11 +185,13 @@ JL_USED_FUNC void AllocUseInfo::dump()
 #define REMARK(remark)
 #endif
 
-void jl_alloc::runEscapeAnalysis(llvm::CallInst *I, EscapeAnalysisRequiredArgs required, EscapeAnalysisOptionalArgs options) {
+void jl_alloc::runEscapeAnalysis(llvm::Instruction *I, EscapeAnalysisRequiredArgs required, EscapeAnalysisOptionalArgs options) {
     required.use_info.reset();
-    Attribute allockind = I->getFnAttr(Attribute::AllocKind);
-    if (allockind.isValid())
-        required.use_info.allockind = allockind.getAllocKind();
+    if (auto CI = dyn_cast<CallInst>(I)) {
+        Attribute allockind = CI->getFnAttr(Attribute::AllocKind);
+        if (allockind.isValid())
+            required.use_info.allockind = allockind.getAllocKind();
+    }
     if (I->use_empty())
         return;
     CheckInst::Frame cur{I, 0, I->use_begin(), I->use_end()};

--- a/src/llvm-alloc-helpers.cpp
+++ b/src/llvm-alloc-helpers.cpp
@@ -249,6 +249,8 @@ void jl_alloc::runEscapeAnalysis(llvm::CallInst *I, EscapeAnalysisRequiredArgs r
             }
             if (required.pass.write_barrier_func == callee)
                 return true;
+            if (required.pass.gc_loaded_func == callee)
+                return true;
             auto opno = use->getOperandNo();
             // Uses in `jl_roots` operand bundle are not counted as escaping, everything else is.
             if (!call->isBundleOperand(opno) ||

--- a/src/llvm-alloc-helpers.h
+++ b/src/llvm-alloc-helpers.h
@@ -119,14 +119,6 @@ namespace jl_alloc {
         bool addMemOp(llvm::Instruction *inst, unsigned opno, uint32_t offset, llvm::Type *elty,
                       bool isstore, const llvm::DataLayout &DL);
         std::pair<const uint32_t,Field> &getField(uint32_t offset, uint32_t size, llvm::Type *elty);
-        std::map<uint32_t,Field>::iterator findLowerField(uint32_t offset)
-        {
-            // Find the last field that starts no higher than `offset`.
-            auto it = memops.upper_bound(offset);
-            if (it != memops.begin())
-                return --it;
-            return memops.end();
-        }
     };
 
     struct EscapeAnalysisRequiredArgs {

--- a/src/llvm-alloc-helpers.h
+++ b/src/llvm-alloc-helpers.h
@@ -147,7 +147,7 @@ namespace jl_alloc {
         }
     };
 
-    void runEscapeAnalysis(llvm::CallInst *I, EscapeAnalysisRequiredArgs required, EscapeAnalysisOptionalArgs options=EscapeAnalysisOptionalArgs());
+    void runEscapeAnalysis(llvm::Instruction *I, EscapeAnalysisRequiredArgs required, EscapeAnalysisOptionalArgs options=EscapeAnalysisOptionalArgs());
 }
 
 

--- a/src/llvm-alloc-helpers.h
+++ b/src/llvm-alloc-helpers.h
@@ -62,6 +62,7 @@ namespace jl_alloc {
     struct AllocUseInfo {
         llvm::SmallSet<llvm::Instruction*,16> uses;
         llvm::SmallSet<llvm::CallInst*,4> preserves;
+        llvm::SmallSet<llvm::BasicBlock*,4> errorbbs;
         std::map<uint32_t,Field> memops;
         // Completely unknown use
         bool escaped:1;
@@ -85,8 +86,6 @@ namespace jl_alloc {
         bool hasunknownmem:1;
         // The object is returned
         bool returned:1;
-        // The object is used in an error function
-        bool haserror:1;
         // For checking attributes of "uninitialized" or "zeroed" or unknown
         llvm::AllocFnKind allockind;
 
@@ -106,12 +105,12 @@ namespace jl_alloc {
             hastypeof = false;
             hasunknownmem = false;
             returned = false;
-            haserror = false;
             allockind = llvm::AllocFnKind::Unknown;
             has_unknown_objref = false;
             has_unknown_objrefaggr = false;
             uses.clear();
             preserves.clear();
+            errorbbs.clear();
             memops.clear();
         }
         void dump(llvm::raw_ostream &OS);

--- a/src/llvm-alloc-opt.cpp
+++ b/src/llvm-alloc-opt.cpp
@@ -346,6 +346,7 @@ bool Optimizer::canDeoptimizeErrorBlocks(CallInst *orig) {
     for (auto &field : use_info.memops) {
         for (auto &acc : field.second.accesses) {
             assert(isa<LoadInst>(acc.inst) && "Should only have loads of array length/data");
+            (void) acc;
         }
         if (field.first == 0) {
             if (field.second.size > pass.DL->getPointerSize()) {
@@ -549,6 +550,7 @@ void Optimizer::sinkArrayDataPointer(CallInst *orig, DenseMap<BasicBlock *, Sunk
                 bool success = gep->collectOffset(*pass.DL, BitWidth, frame.variables, frame.constant);
                 assert(success); // TODO this may not work on ARM with scalable vectors,
                 // but for now let's just start with this
+                (void) success;
                 frame.offset_frame = stack.size();
                 break;
             }
@@ -816,6 +818,13 @@ void Optimizer::optimizeArray(CallInst *orig, jl_genericmemory_info_t info) {
             REMARK([&]() {
                 return OptimizationRemarkMissed(DEBUG_TYPE, "Escaped", orig)
                     << "GC genericmemory allocation size is too large " << ore::NV("GC GenericMemory Allocation", orig);
+            });
+            return;
+        }
+        if (bytes == 0) {
+            REMARK([&]() {
+                return OptimizationRemarkMissed(DEBUG_TYPE, "Escaped", orig)
+                    << "GC genericmemory allocation size was 0 " << ore::NV("GC GenericMemory Allocation", orig);
             });
             return;
         }

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -2458,6 +2458,15 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S, bool *CFGModified) {
 
                 // Update the pointer numbering.
                 UpdatePtrNumbering(CI, newI, S);
+            } else if (alloc_genericmemory_func && callee == alloc_genericmemory_func) {
+                assert(CI->arg_size() == 6);
+                auto gmalloc = F.getParent()->getOrInsertFunction("jl_alloc_genericmemory", T_prjlvalue, T_prjlvalue, T_size);
+                IRBuilder<> builder(CI);
+                builder.SetCurrentDebugLocation(CI->getDebugLoc());
+                auto newI = builder.CreateCall(gmalloc, {CI->getArgOperand(0), CI->getArgOperand(1)});
+                newI->takeName(CI);
+                CI->replaceAllUsesWith(newI);
+                UpdatePtrNumbering(CI, newI, S);
             } else if (typeof_func && callee == typeof_func) {
                 assert(CI->arg_size() == 1);
                 IRBuilder<> builder(CI);

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -53,6 +53,7 @@ void JuliaPassContext::initFunctions(Module &M)
     typeof_func = M.getFunction("julia.typeof");
     write_barrier_func = M.getFunction("julia.write_barrier");
     alloc_obj_func = M.getFunction("julia.gc_alloc_obj");
+    alloc_genericmemory_func = M.getFunction("julia.gc_alloc_genericmemory");
     call_func = M.getFunction("julia.call");
     call2_func = M.getFunction("julia.call2");
     call3_func = M.getFunction("julia.call3");

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -58,6 +58,7 @@ struct JuliaPassContext {
     llvm::Function *pointer_from_objref_func;
     llvm::Function *gc_loaded_func;
     llvm::Function *alloc_obj_func;
+    llvm::Function *alloc_genericmemory_func;
     llvm::Function *typeof_func;
     llvm::Function *write_barrier_func;
     llvm::Function *call_func;

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -480,20 +480,30 @@ static void buildScalarOptimizerPipeline(FunctionPassManager &FPM, PassBuilder *
         FPM.addPass(IRCEPass());
         FPM.addPass(InstCombinePass());
         FPM.addPass(JumpThreadingPass());
-    }
-    if (O.getSpeedupLevel() >= 3) {
+        // TODO we traded gvn later for this gvn and replaced it with earlycse,
+        // is this a good trade? it really helps with eliding array allocations
         FPM.addPass(GVNPass());
-    }
-    if (O.getSpeedupLevel() >= 2) {
         FPM.addPass(DSEPass());
         invokePeepholeEPCallbacks(FPM, PB, O);
         FPM.addPass(SimplifyCFGPass(aggressiveSimplifyCFGOptions()));
+        // TODO is it worth updating memoryssa in alloc-opt? it would mean at O3 we don't have a
+        // guaranteed recompute of mssa for LICM
         JULIA_PASS(FPM.addPass(AllocOptPass()));
         {
+            // last-chance loop optimizations
+            // most array allocations that are elided end up wanting these
             LoopPassManager LPM;
+            // TODO reenable the O3 guard if this is too expensive
+            // if (O.getSpeedupLevel() >= 3) {
+                LPM.addPass(LICMPass(LICMOptions()));
+                LPM.addPass(JuliaLICMPass());
+                LPM.addPass(IndVarSimplifyPass());
+                LPM.addPass(LoopIdiomRecognizePass());
+                // LPM.addPass(LoopFullUnrollPass()); // doesn't support memoryssa preservation in LLVM 15
+            // }
             LPM.addPass(LoopDeletionPass());
             LPM.addPass(LoopInstSimplifyPass());
-            FPM.addPass(createFunctionToLoopPassAdaptor(std::move(LPM)));
+            FPM.addPass(createFunctionToLoopPassAdaptor(std::move(LPM), true));
         }
         FPM.addPass(LoopDistributePass());
     }
@@ -572,7 +582,7 @@ static void buildCleanupPipeline(ModulePassManager &MPM, PassBuilder *PB, Optimi
         FunctionPassManager FPM;
         JULIA_PASS(FPM.addPass(DemoteFloat16Pass()));
         if (O.getSpeedupLevel() >= 2) {
-            FPM.addPass(GVNPass());
+            FPM.addPass(EarlyCSEPass());
         }
         MPM.addPass(createModuleToFunctionPassAdaptor(std::move(FPM)));
     }

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -371,6 +371,8 @@ static void buildEarlyOptimizerPipeline(ModulePassManager &MPM, PassBuilder *PB,
         invokeCGSCCCallbacks(CGPM, PB, O);
         if (O.getSpeedupLevel() >= 2) {
             FunctionPassManager FPM;
+            // get rid of random FCAs that confuse alloc-opt
+            FPM.addPass(InstCombinePass());
             JULIA_PASS(FPM.addPass(AllocOptPass()));
             FPM.addPass(Float2IntPass());
             FPM.addPass(LowerConstantIntrinsicsPass());

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -430,6 +430,11 @@ static void buildLoopOptimizerPipeline(FunctionPassManager &FPM, PassBuilder *PB
     }
     if (O.getSpeedupLevel() >= 2) {
         LoopPassManager LPM;
+        LPM.addPass(LoopFullUnrollPass());
+        FPM.addPass(createFunctionToLoopPassAdaptor(std::move(LPM)));
+    }
+    if (O.getSpeedupLevel() >= 2) {
+        LoopPassManager LPM;
         LPM.addPass(BeforeLICMMarkerPass());
         LPM.addPass(LICMPass(LICMOptions()));
         LPM.addPass(JuliaLICMPass());


### PR DESCRIPTION
Just trying this out.

Examples:
<details>
<summary> Example 1 </summary

```julia
julia> function my_cumsum(arr)
           length(arr) < 1 && return zero(eltype(arr))
           temp = zeros(eltype(arr), length(arr))
           @inbounds temp[1] = arr[1]
           for i in 2:length(temp)
               @inbounds temp[i] = temp[i-1] + arr[i]
           end
           @inbounds temp[length(arr)]
       end
my_cumsum (generic function with 1 method)

julia> @code_llvm my_cumsum([0, 1, 2, 3])
```
Before:
```llvm
; Function Signature: my_cumsum(Array{Int64, 1})
;  @ REPL[1]:1 within `my_cumsum`
define i64 @julia_my_cumsum_724({}* noundef nonnull align 8 dereferenceable(24) %"arr::Array") #0 {
top:
;  @ REPL[1]:2 within `my_cumsum`
; ┌ @ essentials.jl:11 within `length`
   %0 = bitcast {}* %"arr::Array" to i8*
   %1 = getelementptr inbounds i8, i8* %0, i64 16
   %memcpy_refined_src = bitcast i8* %1 to i64*
   %2 = load i64, i64* %memcpy_refined_src, align 8
; └
; ┌ @ int.jl:83 within `<`
   %3 = icmp sgt i64 %2, 0
; └
  br i1 %3, label %L82, label %common.ret

common.ret:                                       ; preds = %L192, %top
  %common.ret.op = phi i64 [ %87, %L192 ], [ 0, %top ]
;  @ REPL[1] within `my_cumsum`
  ret i64 %common.ret.op

L82:                                              ; preds = %top
;  @ REPL[1]:3 within `my_cumsum`
; ┌ @ array.jl:571 within `zeros` @ array.jl:575
; │┌ @ boot.jl:586 within `Array` @ boot.jl:573
; ││┌ @ boot.jl:513 within `GenericMemory`
     %"Memory{Int64}[]" = call {}* @jl_alloc_genericmemory({}* @"+Core.GenericMemory#730.jit", i64 %2)
; ││└
; ││ @ boot.jl:586 within `Array` @ boot.jl:574
    %4 = bitcast {}* %"Memory{Int64}[]" to { i64, {}** }*
    %.data_ptr = getelementptr inbounds { i64, {}** }, { i64, {}** }* %4, i64 0, i32 1
    %5 = load {}**, {}*** %.data_ptr, align 8
; │└
; │ @ array.jl:571 within `zeros` @ array.jl:576
; │┌ @ array.jl:330 within `fill!`
    %6 = bitcast {}** %5 to i8*
    %7 = shl nuw i64 %2, 3
; ││ @ array.jl:329 within `fill!`
; ││┌ @ array.jl:969 within `setindex!`
     call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %6, i8 0, i64 %7, i1 false)
; └└└

...
```

After:
```llvm
; Function Signature: my_cumsum(Array{Int64, 1})
;  @ REPL[1]:1 within `my_cumsum`
define i64 @julia_my_cumsum_724({}* noundef nonnull align 8 dereferenceable(24) %"arr::Array") #0 {
top:
  %"Memory{Int64}[].stack_data206" = alloca [4096 x i8], align 16
;  @ REPL[1]:2 within `my_cumsum`
; ┌ @ essentials.jl:11 within `length`
   %0 = bitcast {}* %"arr::Array" to i8*
   %1 = getelementptr inbounds i8, i8* %0, i64 16
   %memcpy_refined_src = bitcast i8* %1 to i64*
   %2 = load i64, i64* %memcpy_refined_src, align 8
; └
; ┌ @ int.jl:83 within `<`
   %3 = icmp sgt i64 %2, 0
; └
  br i1 %3, label %L82, label %common.ret

common.ret:                                       ; preds = %L192, %top
  %common.ret.op = phi i64 [ %88, %L192 ], [ 0, %top ]
;  @ REPL[1] within `my_cumsum`
  ret i64 %common.ret.op

L82:                                              ; preds = %top
  %"Memory{Int64}[].stack_data206.sub" = getelementptr inbounds [4096 x i8], [4096 x i8]* %"Memory{Int64}[].stack_data206", i64 0, i64 0
;  @ REPL[1]:3 within `my_cumsum`
; ┌ @ array.jl:571 within `zeros` @ array.jl:575
; │┌ @ boot.jl:586 within `Array` @ boot.jl:573
; ││┌ @ boot.jl:513 within `GenericMemory`
     %4 = icmp ugt i64 %2, 4096
     br i1 %4, label %stack_alloc_fallback, label %allocated_array

stack_alloc_fallback:                             ; preds = %L82
     %5 = call {}* @jl_alloc_genericmemory({}* @"+Core.GenericMemory#730.jit", i64 %2)
     %6 = bitcast {}* %5 to i8**
     %"Memory{Int64}[].fallback_data_ptr" = getelementptr i8*, i8** %6, i64 1
     %"Memory{Int64}[].fallback_data" = load i8*, i8** %"Memory{Int64}[].fallback_data_ptr", align 8
     br label %allocated_array

allocated_array:                                  ; preds = %stack_alloc_fallback, %L82
     %"Memory{Int64}[].data" = phi i8* [ %"Memory{Int64}[].stack_data206.sub", %L82 ], [ %"Memory{Int64}[].fallback_data", %stack_alloc_fallback ]
; ││└
; ││ @ boot.jl:586 within `Array` @ boot.jl:574
    %7 = bitcast i8* %"Memory{Int64}[].data" to {}**
; │└
; │ @ array.jl:571 within `zeros` @ array.jl:576
; │┌ @ array.jl:330 within `fill!`
    %8 = shl nuw i64 %2, 3
; ││ @ array.jl:329 within `fill!`
; ││┌ @ array.jl:969 within `setindex!`
     call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %"Memory{Int64}[].data", i8 0, i64 %8, i1 false)
; └└└

...
```

</details>
