### PR TITLE
Fix docs link to package tests docs

### DIFF
--- a/doc/src/tutorials/creating-packages.md
+++ b/doc/src/tutorials/creating-packages.md
@@ -246,7 +246,7 @@ in expression starting at /home/kc/HelloWorld/deps/build.jl:1
     A build step should generally not create or modify any files in the package directory. If you need to store some files
     from the build step, use the [Scratch.jl](https://github.com/JuliaPackaging/Scratch.jl) package.
 
-## Adding tests to the package
+## [Adding tests to the package](@id adding-tests-to-packages)
 
 When a package is tested the file `test/runtests.jl` is executed:
 

--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -20,7 +20,7 @@ The `Test` module provides simple *unit testing* functionality. Unit testing is 
 see if your code is correct by checking that the results are what you expect. It can be helpful
 to ensure your code still works after you make changes, and can be used when developing as a way
 of specifying the behaviors your code should have when complete. You may also want to look at the
-documentation for [adding tests to your Julia Package](https://pkgdocs.julialang.org/dev/creating-packages/#Adding-tests-to-the-package).
+documentation for [adding tests to your Julia Package](@ref adding-tests-to-packages).
 
 Simple unit testing can be performed with the `@test` and `@test_throws` macros:
 
@@ -420,7 +420,7 @@ end
 We will need to create those two included files, `math_tests.jl` and `greeting_tests.jl`, and add some tests to them.
 
 > **Note:** Notice how we did not have to specify add `Example` into the `test` environment's `Project.toml`.
-> This is a benefit of Julia's testing system that you could [read about more here](https://pkgdocs.julialang.org/dev/creating-packages/).
+> This is a benefit of Julia's testing system that you could [read about more here](@ref adding-tests-to-packages).
 
 #### Writing Tests for `math_tests.jl`
 


### PR DESCRIPTION
Since https://github.com/JuliaLang/julia/pull/52102 these links to the Pkg.jl docs are dead. This should point them to the new location in the Julia docs.

There is a reference in CONTRIBUTING.md that should change as well, but maybe not until a Julia version with these changes is released: https://github.com/JuliaLang/julia/blob/3e4b38684e38a015446253f5752ee9cf840f50cc/CONTRIBUTING.md?plain=1#L17