### PR TITLE
Declare hermitian/hermitian_type to be public

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -162,7 +162,11 @@ export
     I
 
 # not exported, but public names
-public AbstractTriangular
+public AbstractTriangular,
+        hermitian,
+        hermitian_type,
+        symmetric,
+        symmetric_type
 
 const BlasFloat = Union{Float64,Float32,ComplexF64,ComplexF32}
 const BlasReal = Union{Float64,Float32}


### PR DESCRIPTION
Similarly, for `symmetric/symmetric_type`. These are meant to be specialized by custom types, so these should not be marked internal to `LinearAlgebra`.