### PR TITLE
Generalize Diagonal * AdjOrTransAbsMat to arbitrary element types

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -320,17 +320,6 @@ end
 rmul!(A::AbstractMatrix, D::Diagonal) = @inline mul!(A, A, D)
 lmul!(D::Diagonal, B::AbstractVecOrMat) = @inline mul!(B, D, B)
 
-function (*)(A::AdjOrTransAbsMat, D::Diagonal)
-    T = promote_op(*, eltype(A), eltype(D.diag))
-    dest = similar(A, T, size(A))
-    mul!(dest, A, D)
-end
-function (*)(D::Diagonal, A::AdjOrTransAbsMat)
-    T = promote_op(*, eltype(D.diag), eltype(A))
-    dest = similar(A, T, size(A))
-    mul!(dest, D, A)
-end
-
 function __muldiag!(out, D::Diagonal, B, _add::MulAddMul{ais1,bis0}) where {ais1,bis0}
     require_one_based_indexing(out, B)
     alpha, beta = _add.alpha, _add.beta

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -321,12 +321,14 @@ rmul!(A::AbstractMatrix, D::Diagonal) = @inline mul!(A, A, D)
 lmul!(D::Diagonal, B::AbstractVecOrMat) = @inline mul!(B, D, B)
 
 function (*)(A::AdjOrTransAbsMat, D::Diagonal)
-    Ac = copy_similar(A, promote_op(*, eltype(A), eltype(D.diag)))
-    rmul!(Ac, D)
+    T = promote_op(*, eltype(A), eltype(D.diag))
+    dest = similar(A, T, size(A))
+    mul!(dest, A, D)
 end
 function (*)(D::Diagonal, A::AdjOrTransAbsMat)
-    Ac = copy_similar(A, promote_op(*, eltype(A), eltype(D.diag)))
-    lmul!(D, Ac)
+    T = promote_op(*, eltype(D.diag), eltype(A))
+    dest = similar(A, T, size(A))
+    mul!(dest, D, A)
 end
 
 function __muldiag!(out, D::Diagonal, B, _add::MulAddMul{ais1,bis0}) where {ais1,bis0}

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -18,6 +18,9 @@ using .Main.InfiniteArrays
 isdefined(Main, :FillArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "FillArrays.jl"))
 using .Main.FillArrays
 
+isdefined(Main, :SizedArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "SizedArrays.jl"))
+using .Main.SizedArrays
+
 const n=12 # Size of matrix problem to test
 Random.seed!(1)
 
@@ -778,6 +781,11 @@ end
         D = Diagonal(fill(M, n))
         @test D == Matrix{eltype(D)}(D)
     end
+
+    S = SizedArray{(2,3)}(reshape([1:6;],2,3))
+    D = Diagonal(fill(S,3))
+    @test D * fill(S,2,3)' == fill(S * S', 3, 2)
+    @test fill(S,3,2)' * D == fill(S' * S, 2, 3)
 end
 
 @testset "Eigensystem for block diagonal (issue #30681)" begin

--- a/test/testhelpers/SizedArrays.jl
+++ b/test/testhelpers/SizedArrays.jl
@@ -9,6 +9,8 @@ module SizedArrays
 
 import Base: +, *, ==
 
+using LinearAlgebra
+
 export SizedArray
 
 struct SizedArray{SZ,T,N,A<:AbstractArray} <: AbstractArray{T,N}
@@ -31,9 +33,16 @@ Base.getindex(A::SizedArray, i...) = getindex(A.data, i...)
 Base.zero(::Type{T}) where T <: SizedArray = SizedArray{size(T)}(zeros(eltype(T), size(T)))
 +(S1::SizedArray{SZ}, S2::SizedArray{SZ}) where {SZ} = SizedArray{SZ}(S1.data + S2.data)
 ==(S1::SizedArray{SZ}, S2::SizedArray{SZ}) where {SZ} = S1.data == S2.data
-function *(S1::SizedArray, S2::SizedArray)
+
+const SizedArrayLike = Union{SizedArray, Transpose{<:Any, <:SizedArray}, Adjoint{<:Any, <:SizedArray}}
+
+_data(S::SizedArray) = S.data
+_data(T::Transpose{<:Any, <:SizedArray}) = transpose(_data(parent(T)))
+_data(T::Adjoint{<:Any, <:SizedArray}) = adjoint(_data(parent(T)))
+
+function *(S1::SizedArrayLike, S2::SizedArrayLike)
     0 < ndims(S1) < 3 && 0 < ndims(S2) < 3 && size(S1, 2) == size(S2, 1) || throw(ArgumentError("size mismatch!"))
-    data = S1.data * S2.data
+    data = _data(S1) * _data(S2)
     SZ = ndims(data) == 1 ? (size(S1, 1), ) : (size(S1, 1), size(S2, 2))
     SizedArray{SZ}(data)
 end


### PR DESCRIPTION
The current implementation assumes that the adjoint matrix may be copied to the destination, but this is not necessary in general. This PR ~changes the implementation to use `mul!` instead of `copy` + `(l/r)mul!`~ removes the specialized methods, so that the multiplication generalizes to arbitrary element types. In particular, the following works after this:
```julia
julia> SM = SMatrix{2,3}(reshape([1:6;],2,3))
2×3 SMatrix{2, 3, Int64, 6} with indices SOneTo(2)×SOneTo(3):
 1  3  5
 2  4  6

julia> D = Diagonal(fill(SM,2))
2×2 Diagonal{SMatrix{2, 3, Int64, 6}, Vector{SMatrix{2, 3, Int64, 6}}}:
 [1 3 5; 2 4 6]        ⋅       
       ⋅         [1 3 5; 2 4 6]

julia> A = fill(SM,2,2)'
2×2 adjoint(::Matrix{SMatrix{2, 3, Int64, 6}}) with eltype SMatrix{3, 2, Int64, 6}:
 [1 2; 3 4; 5 6]  [1 2; 3 4; 5 6]
 [1 2; 3 4; 5 6]  [1 2; 3 4; 5 6]

julia> D * A
2×2 Matrix{SMatrix{2, 2, Int64, 4}}:
 [35 44; 44 56]  [35 44; 44 56]
 [35 44; 44 56]  [35 44; 44 56]

julia> A * D
2×2 Matrix{SMatrix{3, 3, Int64, 9}}:
 [5 11 17; 11 25 39; 17 39 61]  [5 11 17; 11 25 39; 17 39 61]
 [5 11 17; 11 25 39; 17 39 61]  [5 11 17; 11 25 39; 17 39 61]
```