### PR TITLE
fix spurious overflow for Float16(::Rational)

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -145,8 +145,12 @@ function (::Type{T})(x::Rational{S}) where T<:AbstractFloat where S
     P = promote_type(T,S)
     convert(T, convert(P,x.num)/convert(P,x.den))::T
 end
-Float16(x::Rational{<:Union{Int16,Int32,Int64,Int128,UInt16,UInt32,UInt64,UInt128}}) =
-    Float16(Float32(x)) # avoid spurious overflow (#52394)
+ # avoid spurious overflow (#52394).  (Needed for UInt16 or larger;
+ # we also include Int16 for consistency of accuracy.)
+Float16(x::Rational{<:Union{Int16,Int32,Int64,UInt16,UInt32,UInt64}}) =
+    Float16(Float32(x))
+Float16(x::Rational{<:Union{Int128,UInt128}}) =
+    Float16(Float64(x)) # UInt128 overflows Float32, include Int128 for consistency
 
 function Rational{T}(x::AbstractFloat) where T<:Integer
     r = rationalize(T, x, tol=0)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -151,6 +151,8 @@ Float16(x::Rational{<:Union{Int16,Int32,Int64,UInt16,UInt32,UInt64}}) =
     Float16(Float32(x))
 Float16(x::Rational{<:Union{Int128,UInt128}}) =
     Float16(Float64(x)) # UInt128 overflows Float32, include Int128 for consistency
+Float32(x::Rational{<:Union{Int128,UInt128}}) =
+    Float32(Float64(x)) # UInt128 overflows Float32, include Int128 for consistency
 
 function Rational{T}(x::AbstractFloat) where T<:Integer
     r = rationalize(T, x, tol=0)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -145,6 +145,8 @@ function (::Type{T})(x::Rational{S}) where T<:AbstractFloat where S
     P = promote_type(T,S)
     convert(T, convert(P,x.num)/convert(P,x.den))::T
 end
+Float16(x::Rational{<:Union{Int16,Int32,Int64,Int128,UInt16,UInt32,UInt64,UInt128}})
+    = Float16(Float32(x)) # avoid spurious overflow (#52394)
 
 function Rational{T}(x::AbstractFloat) where T<:Integer
     r = rationalize(T, x, tol=0)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -145,8 +145,8 @@ function (::Type{T})(x::Rational{S}) where T<:AbstractFloat where S
     P = promote_type(T,S)
     convert(T, convert(P,x.num)/convert(P,x.den))::T
 end
-Float16(x::Rational{<:Union{Int16,Int32,Int64,Int128,UInt16,UInt32,UInt64,UInt128}})
-    = Float16(Float32(x)) # avoid spurious overflow (#52394)
+Float16(x::Rational{<:Union{Int16,Int32,Int64,Int128,UInt16,UInt32,UInt64,UInt128}}) =
+    Float16(Float32(x)) # avoid spurious overflow (#52394)
 
 function Rational{T}(x::AbstractFloat) where T<:Integer
     r = rationalize(T, x, tol=0)

--- a/test/float16.jl
+++ b/test/float16.jl
@@ -203,6 +203,9 @@ const minsubf16_32 = Float32(minsubf16)
 # issues #33076
 @test Float16(1f5) == Inf16
 
+# issue #52394
+@test Float16(10^8 // (10^9 + 1)) == convert(Float16, 10^8 // (10^9 + 1)) == Float16(0.1)
+
 @testset "conversion to Float16 from" begin
     for T in (Float32, Float64, BigFloat)
         @testset "conversion from $T" begin

--- a/test/float16.jl
+++ b/test/float16.jl
@@ -205,6 +205,7 @@ const minsubf16_32 = Float32(minsubf16)
 
 # issue #52394
 @test Float16(10^8 // (10^9 + 1)) == convert(Float16, 10^8 // (10^9 + 1)) == Float16(0.1)
+@test Float16((typemax(UInt128)-0x01) // typemax(UInt128)) == Float16(1.0)
 
 @testset "conversion to Float16 from" begin
     for T in (Float32, Float64, BigFloat)

--- a/test/float16.jl
+++ b/test/float16.jl
@@ -206,6 +206,7 @@ const minsubf16_32 = Float32(minsubf16)
 # issue #52394
 @test Float16(10^8 // (10^9 + 1)) == convert(Float16, 10^8 // (10^9 + 1)) == Float16(0.1)
 @test Float16((typemax(UInt128)-0x01) // typemax(UInt128)) == Float16(1.0)
+@test Float32((typemax(UInt128)-0x01) // typemax(UInt128)) == Float32(1.0)
 
 @testset "conversion to Float16 from" begin
     for T in (Float32, Float64, BigFloat)


### PR DESCRIPTION
Fixes #52394.

*Update*: also fixes `Float32` for `UInt128`, since currently `Float32((typemax(UInt128)-0x01) // typemax(UInt128))` gives `Nan32`.