### PR TITLE
reflection: refactor `@assume_effects` implementation

### DIFF
--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -33,9 +33,44 @@ macro _boundscheck() Expr(:boundscheck) end
 convert(::Type{Any}, Core.@nospecialize x) = x
 convert(::Type{T}, x::T) where {T} = x
 
-# mostly used by compiler/methodtable.jl, but also by reflection.jl
+# These types are used by reflection.jl and expr.jl too, so declare them here.
+# Note that `@assume_effects` is available only after loading namedtuple.jl.
 abstract type MethodTableView end
 abstract type AbstractInterpreter end
+struct EffectsOverride
+    consistent::Bool
+    effect_free::Bool
+    nothrow::Bool
+    terminates_globally::Bool
+    terminates_locally::Bool
+    notaskstate::Bool
+    inaccessiblememonly::Bool
+    noub::Bool
+    noub_if_noinbounds::Bool
+end
+function EffectsOverride(
+    override::EffectsOverride =
+        EffectsOverride(false, false, false, false, false, false, false, false, false);
+    consistent::Bool = override.consistent,
+    effect_free::Bool = override.effect_free,
+    nothrow::Bool = override.nothrow,
+    terminates_globally::Bool = override.terminates_globally,
+    terminates_locally::Bool = override.terminates_locally,
+    notaskstate::Bool = override.notaskstate,
+    inaccessiblememonly::Bool = override.inaccessiblememonly,
+    noub::Bool = override.noub,
+    noub_if_noinbounds::Bool = override.noub_if_noinbounds)
+    return EffectsOverride(
+        consistent,
+        effect_free,
+        nothrow,
+        terminates_globally,
+        terminates_locally,
+        notaskstate,
+        inaccessiblememonly,
+        noub,
+        noub_if_noinbounds)
+end
 
 # essential files and libraries
 include("essentials.jl")

--- a/base/compiler/effects.jl
+++ b/base/compiler/effects.jl
@@ -319,18 +319,6 @@ function decode_effects(e::UInt32)
         _Bool((e >> 12) & 0x01))
 end
 
-struct EffectsOverride
-    consistent::Bool
-    effect_free::Bool
-    nothrow::Bool
-    terminates_globally::Bool
-    terminates_locally::Bool
-    notaskstate::Bool
-    inaccessiblememonly::Bool
-    noub::Bool
-    noub_if_noinbounds::Bool
-end
-
 function encode_effects_override(eo::EffectsOverride)
     e = 0x0000
     eo.consistent          && (e |= (0x0001 << 0))

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -271,14 +271,10 @@ getindex(match::Core.MethodMatch, field::Int) =
 # these were internal functions, but some packages seem to be relying on them
 tuple_type_head(T::Type) = fieldtype(T, 1)
 tuple_type_cons(::Type, ::Type{Union{}}) = Union{}
-function tuple_type_cons(::Type{S}, ::Type{T}) where T<:Tuple where S
-    @_foldable_meta
+@assume_effects :foldable tuple_type_cons(::Type{S}, ::Type{T}) where T<:Tuple where S =
     Tuple{S, T.parameters...}
-end
-function parameter_upper_bound(t::UnionAll, idx)
-    @_foldable_meta
-    return rewrap_unionall((unwrap_unionall(t)::DataType).parameters[idx], t)
-end
+@assume_effects :foldable parameter_upper_bound(t::UnionAll, idx) =
+    rewrap_unionall((unwrap_unionall(t)::DataType).parameters[idx], t)
 
 # these were internal functions, but some packages seem to be relying on them
 @deprecate cat_shape(dims, shape::Tuple{}, shapes::Tuple...) cat_shape(dims, shapes) false

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -719,64 +719,71 @@ macro assume_effects(args...)
         ex = nothing
         idx = length(args)
     end
-    consistent = effect_free = nothrow = terminates_globally = terminates_locally =
-        notaskstate = inaccessiblememonly = noub = noub_if_noinbounds = false
-    for i in 1:idx
-        org_setting = args[i]
-        (setting, val) = compute_assumed_setting(org_setting)
-        if setting === :consistent
-            consistent = val
-        elseif setting === :effect_free
-            effect_free = val
-        elseif setting === :nothrow
-            nothrow = val
-        elseif setting === :terminates_globally
-            terminates_globally = val
-        elseif setting === :terminates_locally
-            terminates_locally = val
-        elseif setting === :notaskstate
-            notaskstate = val
-        elseif setting === :inaccessiblememonly
-            inaccessiblememonly = val
-        elseif setting === :noub
-            noub = val
-        elseif setting === :noub_if_noinbounds
-            noub_if_noinbounds = val
-        elseif setting === :foldable
-            consistent = effect_free = terminates_globally = noub = val
-        elseif setting === :removable
-            effect_free = nothrow = terminates_globally = val
-        elseif setting === :total
-            consistent = effect_free = nothrow = terminates_globally = notaskstate = inaccessiblememonly = noub = val
-        else
-            throw(ArgumentError("@assume_effects $org_setting not supported"))
-        end
+    override = EffectsOverride()
+    for i = 1:idx
+        setting = args[i]
+        override = compute_assumed_setting(override, setting)
+        override === nothing &&
+            throw(ArgumentError("@assume_effects $setting not supported"))
     end
     if is_function_def(inner)
-        return esc(pushmeta!(ex, :purity,
-            consistent, effect_free, nothrow, terminates_globally, terminates_locally,
-            notaskstate, inaccessiblememonly, noub, noub_if_noinbounds))
+        return esc(pushmeta!(ex, form_purity_expr(override)))
     elseif isexpr(ex, :macrocall) && ex.args[1] === Symbol("@ccall")
         ex.args[1] = GlobalRef(Base, Symbol("@ccall_effects"))
-        insert!(ex.args, 3, Core.Compiler.encode_effects_override(Core.Compiler.EffectsOverride(
-            consistent, effect_free, nothrow, terminates_globally, terminates_locally,
-            notaskstate, inaccessiblememonly, noub, noub_if_noinbounds)))
+        insert!(ex.args, 3, Core.Compiler.encode_effects_override(override))
         return esc(ex)
     else # anonymous function case
-        return Expr(:meta, Expr(:purity,
-            consistent, effect_free, nothrow, terminates_globally, terminates_locally,
-            notaskstate, inaccessiblememonly, noub, noub_if_noinbounds))
+        return Expr(:meta, form_purity_expr(override))
     end
 end
 
-function compute_assumed_setting(@nospecialize(setting), val::Bool=true)
+using Core.Compiler: EffectsOverride
+
+function compute_assumed_setting(override::EffectsOverride, @nospecialize(setting), val::Bool=true)
     if isexpr(setting, :call) && setting.args[1] === :(!)
-        return compute_assumed_setting(setting.args[2], !val)
+        return compute_assumed_setting(override, setting.args[2], !val)
     elseif isa(setting, QuoteNode)
-        return compute_assumed_setting(setting.value, val)
-    else
-        return (setting, val)
+        return compute_assumed_setting(override, setting.value, val)
     end
+    if setting === :consistent
+        return EffectsOverride(override; consistent = val)
+    elseif setting === :effect_free
+        return EffectsOverride(override; effect_free = val)
+    elseif setting === :nothrow
+        return EffectsOverride(override; nothrow = val)
+    elseif setting === :terminates_globally
+        return EffectsOverride(override; terminates_globally = val)
+    elseif setting === :terminates_locally
+        return EffectsOverride(override; terminates_locally = val)
+    elseif setting === :notaskstate
+        return EffectsOverride(override; notaskstate = val)
+    elseif setting === :inaccessiblememonly
+        return EffectsOverride(override; inaccessiblememonly = val)
+    elseif setting === :noub
+        return EffectsOverride(override; noub = val)
+    elseif setting === :noub_if_noinbounds
+        return EffectsOverride(override; noub_if_noinbounds = val)
+    elseif setting === :foldable
+        consistent = effect_free = terminates_globally = noub = val
+        return EffectsOverride(override; consistent, effect_free, terminates_globally, noub)
+    elseif setting === :removable
+        effect_free = nothrow = terminates_globally = val
+        return EffectsOverride(override; effect_free, nothrow, terminates_globally)
+    elseif setting === :total
+        consistent = effect_free = nothrow = terminates_globally = notaskstate =
+            inaccessiblememonly = noub = val
+        return EffectsOverride(override;
+            consistent, effect_free, nothrow, terminates_globally, notaskstate,
+            inaccessiblememonly, noub)
+    end
+    return nothing
+end
+
+function form_purity_expr(override::EffectsOverride)
+    return Expr(:purity,
+        override.consistent, override.effect_free, override.nothrow,
+        override.terminates_globally, override.terminates_locally, override.notaskstate,
+        override.inaccessiblememonly, override.noub, override.noub_if_noinbounds)
 end
 
 """
@@ -850,23 +857,17 @@ function unwrap_macrocalls(ex::Expr)
     return inner
 end
 
-function pushmeta!(ex::Expr, sym::Symbol, args::Any...)
-    if isempty(args)
-        tag = sym
-    else
-        tag = Expr(sym, args...)::Expr
-    end
-
+function pushmeta!(ex::Expr, tag::Union{Symbol,Expr})
     inner = unwrap_macrocalls(ex)
-
     idx, exargs = findmeta(inner)
     if idx != 0
-        push!(exargs[idx].args, tag)
+        metastmt = exargs[idx]::Expr
+        push!(metastmt.args, tag)
     else
         body = inner.args[2]::Expr
         pushfirst!(body.args, Expr(:meta, tag))
     end
-    ex
+    return ex
 end
 
 popmeta!(body, sym) = _getmeta(body, sym, true)

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -268,8 +268,9 @@ function map(f, nt::NamedTuple{names}, nts::NamedTuple...) where names
     NamedTuple{names}(map(f, map(Tuple, (nt, nts...))...))
 end
 
-@assume_effects :total function merge_names(an::Tuple{Vararg{Symbol}}, bn::Tuple{Vararg{Symbol}})
-    @nospecialize an bn
+function merge_names(an::Tuple{Vararg{Symbol}}, bn::Tuple{Vararg{Symbol}})
+    @nospecialize
+    @_total_meta
     names = Symbol[an...]
     for n in bn
         if !sym_in(n, an)
@@ -279,15 +280,17 @@ end
     (names...,)
 end
 
-@assume_effects :total function merge_types(names::Tuple{Vararg{Symbol}}, a::Type{<:NamedTuple}, b::Type{<:NamedTuple})
-    @nospecialize names a b
+function merge_types(names::Tuple{Vararg{Symbol}}, a::Type{<:NamedTuple}, b::Type{<:NamedTuple})
+    @nospecialize
+    @_total_meta
     bn = _nt_names(b)
     return Tuple{Any[ fieldtype(sym_in(names[n], bn) ? b : a, names[n]) for n in 1:length(names) ]...}
 end
 
-@assume_effects :foldable function merge_fallback(a::NamedTuple, b::NamedTuple,
-                                                  an::Tuple{Vararg{Symbol}}, bn::Tuple{Vararg{Symbol}})
+function merge_fallback(a::NamedTuple, b::NamedTuple,
+                        an::Tuple{Vararg{Symbol}}, bn::Tuple{Vararg{Symbol}})
     @nospecialize
+    @_foldable_meta
     names = merge_names(an, bn)
     types = merge_types(names, typeof(a), typeof(b))
     n = length(names)
@@ -388,8 +391,9 @@ tail(t::NamedTuple{names}) where names = NamedTuple{tail(names::Tuple)}(t)
 front(t::NamedTuple{names}) where names = NamedTuple{front(names::Tuple)}(t)
 reverse(nt::NamedTuple) = NamedTuple{reverse(keys(nt))}(reverse(values(nt)))
 
-@assume_effects :total function diff_names(an::Tuple{Vararg{Symbol}}, bn::Tuple{Vararg{Symbol}})
-    @nospecialize an bn
+function diff_names(an::Tuple{Vararg{Symbol}}, bn::Tuple{Vararg{Symbol}})
+    @nospecialize
+    @_total_meta
     names = Symbol[]
     for n in an
         if !sym_in(n, bn)
@@ -399,11 +403,15 @@ reverse(nt::NamedTuple) = NamedTuple{reverse(keys(nt))}(reverse(values(nt)))
     (names...,)
 end
 
-@assume_effects :foldable function diff_types(@nospecialize(a::NamedTuple), @nospecialize(names::Tuple{Vararg{Symbol}}))
+function diff_types(a::NamedTuple, names::Tuple{Vararg{Symbol}})
+    @nospecialize
+    @_foldable_meta
     return Tuple{Any[ fieldtype(typeof(a), names[n]) for n in 1:length(names) ]...}
 end
 
-@assume_effects :foldable function diff_fallback(@nospecialize(a::NamedTuple), @nospecialize(an::Tuple{Vararg{Symbol}}), @nospecialize(bn::Tuple{Vararg{Symbol}}))
+function diff_fallback(a::NamedTuple, an::Tuple{Vararg{Symbol}}, bn::Tuple{Vararg{Symbol}})
+    @nospecialize
+    @_foldable_meta
     names = diff_names(an, bn)
     isempty(names) && return (;)
     types = diff_types(a, names)

--- a/doc/src/devdocs/meta.md
+++ b/doc/src/devdocs/meta.md
@@ -34,9 +34,8 @@ quote
 end
 ```
 
-`Base.pushmeta!(ex, :symbol, args...)` appends `:symbol` to the end of the `:meta` expression,
-creating a new `:meta` expression if necessary. If `args` is specified, a nested expression containing
-`:symbol` and these arguments is appended instead, which can be used to specify additional information.
+`Base.pushmeta!(ex, tag::Union{Symbol,Expr})` appends `:tag` to the end of the `:meta` expression,
+creating a new `:meta` expression if necessary.
 
 To use the metadata, you have to parse these `:meta` expressions. If your implementation can be
 performed within Julia, `Base.popmeta!` is very handy: `Base.popmeta!(body, :symbol)` will scan

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -43,77 +43,70 @@ end
 @test foundfunc(h_inlined(), :g_inlined)
 @test foundfunc(h_noinlined(), :g_noinlined)
 
-using Base: pushmeta!, popmeta!
+using Base: popmeta!
 
-macro attach(val, ex)
-    esc(_attach(val, ex))
+macro attach_meta(val, ex)
+    esc(_attach_meta(val, ex))
 end
+_attach_meta(val, ex) = Base.pushmeta!(ex, Expr(:test, val))
 
-_attach(val, ex) = pushmeta!(ex, :test, val)
-
-@attach 42 function dummy()
+@attach_meta 42 function dummy()
     false
 end
-
-asts = code_lowered(dummy, Tuple{})
-@test length(asts) == 1
-ast = asts[1]
-
-body = Expr(:block)
-body.args = ast.code
-
-@test popmeta!(body, :test) == (true, [42])
-@test popmeta!(body, :nonexistent) == (false, [])
+let ast = only(code_lowered(dummy, Tuple{}))
+    body = Expr(:block)
+    body.args = ast.code
+    @test popmeta!(body, :test) == (true, [42])
+    @test popmeta!(body, :nonexistent) == (false, [])
+end
 
 # Simple popmeta!() tests
-ex1 = quote
-    $(Expr(:meta, :foo))
-    x*x+1
+let ex1 = quote
+        $(Expr(:meta, :foo))
+        x*x+1
+    end
+    @test popmeta!(ex1, :foo)[1]
+    @test !popmeta!(ex1, :foo)[1]
+    @test !popmeta!(ex1, :bar)[1]
+    @test !(popmeta!(:(x*x+1), :foo)[1])
 end
-@test popmeta!(ex1, :foo)[1]
-@test !popmeta!(ex1, :foo)[1]
-@test !popmeta!(ex1, :bar)[1]
-@test !(popmeta!(:(x*x+1), :foo)[1])
 
 # Find and pop meta information from general ast locations
-multi_meta = quote
-    $(Expr(:meta, :foo1))
-    y = x
-    $(Expr(:meta, :foo2, :foo3))
-    begin
-        $(Expr(:meta, :foo4, Expr(:foo5, 1, 2)))
+let multi_meta = quote
+        $(Expr(:meta, :foo1))
+        y = x
+        $(Expr(:meta, :foo2, :foo3))
+        begin
+            $(Expr(:meta, :foo4, Expr(:foo5, 1, 2)))
+        end
+        x*x+1
     end
-    x*x+1
-end
-@test popmeta!(deepcopy(multi_meta), :foo1) == (true, [])
-@test popmeta!(deepcopy(multi_meta), :foo2) == (true, [])
-@test popmeta!(deepcopy(multi_meta), :foo3) == (true, [])
-@test popmeta!(deepcopy(multi_meta), :foo4) == (true, [])
-@test popmeta!(deepcopy(multi_meta), :foo5) == (true, [1,2])
-@test popmeta!(deepcopy(multi_meta), :bar)  == (false, [])
+    @test popmeta!(deepcopy(multi_meta), :foo1) == (true, [])
+    @test popmeta!(deepcopy(multi_meta), :foo2) == (true, [])
+    @test popmeta!(deepcopy(multi_meta), :foo3) == (true, [])
+    @test popmeta!(deepcopy(multi_meta), :foo4) == (true, [])
+    @test popmeta!(deepcopy(multi_meta), :foo5) == (true, [1,2])
+    @test popmeta!(deepcopy(multi_meta), :bar)  == (false, [])
 
-# Test that popmeta!() removes meta blocks entirely when they become empty.
-for m in [:foo1, :foo2, :foo3, :foo4, :foo5]
-    @test popmeta!(multi_meta, m)[1]
+    # Test that popmeta!() removes meta blocks entirely when they become empty.
+    ast = :(dummy() = $multi_meta)
+    for m in [:foo1, :foo2, :foo3, :foo4, :foo5]
+        @test popmeta!(multi_meta, m)[1]
+    end
+    @test Base.findmeta(ast)[1] == 0
 end
-@test Base.findmeta(multi_meta.args)[1] == 0
 
 # Test that pushmeta! can push across other macros,
 # in the case multiple pushmeta!-based macros are combined
-
-@attach 40 @attach 41 @attach 42 dummy_multi() = return nothing
-
-asts = code_lowered(dummy_multi, Tuple{})
-@test length(asts) == 1
-ast = asts[1]
-
-body = Expr(:block)
-body.args = ast.code
-
-@test popmeta!(body, :test) == (true, [40])
-@test popmeta!(body, :test) == (true, [41])
-@test popmeta!(body, :test) == (true, [42])
-@test popmeta!(body, :nonexistent) == (false, [])
+@attach_meta 40 @attach_meta 41 @attach_meta 42 dummy_multi() = return nothing
+let ast = only(code_lowered(dummy_multi, Tuple{}))
+    body = Expr(:block)
+    body.args = ast.code
+    @test popmeta!(body, :test) == (true, [40])
+    @test popmeta!(body, :test) == (true, [41])
+    @test popmeta!(body, :test) == (true, [42])
+    @test popmeta!(body, :nonexistent) == (false, [])
+end
 
 # tests to fully cover functions in base/meta.jl
 using Base.Meta


### PR DESCRIPTION
I am working on implementing a support for callsite `@assume_effects` annotation, and this update is part of the preparation for that goal. Along this, I've modified the API from `pushmeta!(::Expr, ::Symbol, args...)` to `pushmeta!(::Expr, ::Union{Symbol,Expr})`. This change isn't breaking as long as the `args` are empty, which is the case for most use cases (actually there is only one usage of `pushmeta!` with non-empty `args` within Julia base). I've verified on JuliaHub, and there don't appear to be any packages using `pushmeta!` with non-empty `args`, so there shouldn't be any (big) issues.