### PR TITLE
Remove confusing `::AdjointAbsVec * ::AdjointAbsVec` methods

### DIFF
--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -476,10 +476,6 @@ end
 
 # vector * Adjoint/Transpose-vector
 *(u::AbstractVector, v::AdjOrTransAbsVec) = broadcast(*, u, v)
-# Adjoint/Transpose-vector * Adjoint/Transpose-vector
-# (necessary for disambiguation with fallback methods in linalg/matmul)
-*(u::AdjointAbsVec, v::AdjointAbsVec) = throw(MethodError(*, (u, v)))
-*(u::TransposeAbsVec, v::TransposeAbsVec) = throw(MethodError(*, (u, v)))
 
 # AdjOrTransAbsVec{<:Any,<:AdjOrTransAbsVec} is a lazy conj vectors
 # We need to expand the combinations to avoid ambiguities


### PR DESCRIPTION
These methods presumably exist to throw an error at the top-level, rather than after the arrays have been unwrapped. However, the error message is confusingly incorrect:
```julia
julia> x = [1]';

julia> x isa Adjoint{T, <:AbstractVector} where T
true

julia> x * x
ERROR: MethodError: no method matching *(::LinearAlgebra.Adjoint{Int64, Vector{Int64}}, ::LinearAlgebra.Adjoint{Int64, Vector{Int64}})

Closest candidates are:
  *(::LinearAlgebra.Adjoint{T, <:AbstractVector} where T, ::LinearAlgebra.Adjoint{T, <:AbstractVector} where T)
   @ LinearAlgebra ~/packages/julias/julia-latest/share/julia/stdlib/v1.11/LinearAlgebra/src/adjtrans.jl:481
  *(::LinearAlgebra.Adjoint{T, <:AbstractVector} where T, ::AbstractMatrix)
   @ LinearAlgebra ~/packages/julias/julia-latest/share/julia/stdlib/v1.11/LinearAlgebra/src/matmul.jl:87
  *(::AbstractMatrix, ::AbstractMatrix, ::Number, ::Number)
   @ LinearAlgebra ~/packages/julias/julia-latest/share/julia/stdlib/v1.11/LinearAlgebra/src/matmul.jl:1084
  ...

Stacktrace:
 [1] *(u::LinearAlgebra.Adjoint{Int64, Vector{Int64}}, v::LinearAlgebra.Adjoint{Int64, Vector{Int64}})
   @ LinearAlgebra ~/packages/julias/julia-latest/share/julia/stdlib/v1.11/LinearAlgebra/src/adjtrans.jl:481
 [2] top-level scope
   @ REPL[2]:1
```
Note that the first suggested method is the one that we're hitting, except this is throwing a `MethodError` again, which makes it seem like there is no match. We may potentially change this from a `MethodError` to a different type (perhaps `ArgumentError`), but perhaps this method is not necessary anyway? After this PR, we obtain
```julia
julia> x * x
ERROR: MethodError: no method matching *(::Vector{Int64}, ::Vector{Int64})

Closest candidates are:
  *(::Any, ::Any, ::Any, ::Any...)
   @ Base operators.jl:595
  *(::Dates.Period, ::AbstractArray)
   @ Dates ~/julia/usr/share/julia/stdlib/v1.11/Dates/src/periods.jl:93
  *(::Number, ::AbstractArray)
   @ Base arraymath.jl:21
  ...

Stacktrace:
 [1] *(x::Adjoint{Int64, Vector{Int64}}, A::Adjoint{Int64, Vector{Int64}})
   @ LinearAlgebra ~/julia/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/matmul.jl:87
 [2] top-level scope
   @ REPL[9]:1
```
This makes it clear that the real issue is that we can't multiply two vectors.