### PR TITLE
Fix completion hint for sub/superscripts

### DIFF
--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1711,6 +1711,17 @@ fake_repl() do stdin_write, stdout_read, repl
     end
     @test LineEdit.state(repl.mistate).hint === nothing
 
+    # issue #52376
+    write(stdin_write, "\x15")
+    write(stdin_write, "\\_ailuj")
+    while LineEdit.state(repl.mistate).hint !== nothing
+        sleep(0.1)
+    end
+    @test LineEdit.state(repl.mistate).hint === nothing
+    s5 = readuntil(stdout_read, "\\_ailuj")
+    write(stdin_write, "\t")
+    s6 = readuntil(stdout_read, "ₐᵢₗᵤⱼ")
+
     write(stdin_write, "\x15\x04")
     Base.wait(repltask)
 end


### PR DESCRIPTION
Fix #52376

The completion hint starting offset was not computed considering the case where the input and the completion do not share the same prefix, which happens when completing into a subscript or a superscript. This fixes that by iteratively going through the characters of the hint until reaching that which marks the end of the input.