### PR TITLE
Add Zulip to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ and installing Julia, below.
 - **Documentation:** <https://docs.julialang.org>
 - **Packages:** <https://julialang.org/packages/>
 - **Discussion forum:** <https://discourse.julialang.org>
+- **Zulip:** <https://julialang.zulipchat.com/>
 - **Slack:** <https://julialang.slack.com> (get an invite from <https://julialang.org/slack/>)
 - **YouTube:** <https://www.youtube.com/user/JuliaLanguage>
 - **Code coverage:** <https://coveralls.io/r/JuliaLang/julia>


### PR DESCRIPTION
As [suggested](https://github.com/JuliaLang/www.julialang.org/pull/1982#issuecomment-1839772373) by @jariji

Placing it above Slack because

- Zulip does not eat messages (the slackhole is a drain of community resources, esp. on the #helpdesk channel)
- Zulip is FOSS
- Zulip is a wee bit more feature complete (this is debatable, but I hold it to be true)