### PR TITLE
irinterp: skip `nothing` statement when analyzing `:nothrow` and `:noub`

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1588,7 +1588,7 @@ function finish_current_bb!(compact::IncrementalCompact, active_bb::Int,
             if unreachable
                 node[:stmt], node[:type], node[:line] = ReturnNode(), Union{}, 0
             else
-                node[:stmt], node[:type], node[:line] = nothing, Nothing, 0
+                node[:stmt], node[:type], node[:line], node[:flag] = nothing, Nothing, 0, IR_FLAGS_EFFECTS
             end
             compact.result_idx = old_result_idx + 1
         elseif cfg_transforms_enabled && compact.result_idx - 1 == first(bb.stmts)

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -418,6 +418,11 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
 
     nothrow = noub = true
     for idx = 1:length(ir.stmts)
+        if ir[SSAValue(idx)][:stmt] === nothing
+            # skip `nothing` statement, which might be inserted as a dummy node,
+            # e.g. by `finish_current_bb!` without explicitly marking it as `:nothrow`
+            continue
+        end
         flag = ir[SSAValue(idx)][:flag]
         nothrow &= has_flag(flag, IR_FLAG_NOTHROW)
         noub &= has_flag(flag, IR_FLAG_NOUB)


### PR DESCRIPTION
This commit makes irinterp skip `nothing` statements when looking through `:nothrow` and `:noub` flags of all statements. This is necessary since `nothing` can be inserted as a dummy node, e.g. to prevent CFG change by `finish_current_bb!`, without explicitly marking it as `IR_FLAG_NOTHROW`.

Alternatively, rather than altering irinterp, it might be better to mark `IR_FLAG_NOTHROW` (and maybe even `IR_FLAG_EFFECT_FREE` and other flags too) where those `nothing` statements are inserted. But I wasn't confident that this would address all scenarios or if it's the best way to go, so this commit opts for the previously mentioned symptomatic approach.