### PR TITLE
Limit REPL suggestions to modules from which name is exported/public

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -1429,7 +1429,7 @@ function UndefVarError_hint(io::IO, ex::UndefVarError)
     else
         scope = undef
     end
-    warnfor(m, var) = Base.isbindingresolved(m, var) && isdefined(m, var) && (print(io, "\nHint: a global variable of this name also exists in $m."); true)
+    warnfor(m, var) = Base.isbindingresolved(m, var) && (Base.isexported(m, var) || Base.ispublic(m, var)) && (print(io, "\nHint: a global variable of this name also exists in $m."); true)
     if scope !== Base && !warnfor(Base, var)
         warned = false
         for m in Base.loaded_modules_order


### PR DESCRIPTION
Close #52387 by implementing the suggestion in https://github.com/JuliaLang/julia/issues/52387#issuecomment-1839152721. After this, in a fresh session
```julia
julia> Diagonal
ERROR: UndefVarError: `Diagonal` not defined in `Main`
Suggestion: check for spelling errors or missing imports.
Hint: a global variable of this name also exists in LinearAlgebra.
```