### PR TITLE
Make type hashing `:total`

### DIFF
--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -29,7 +29,10 @@ See also: [`objectid`](@ref), [`Dict`](@ref), [`Set`](@ref).
 """
 hash(x::Any) = hash(x, zero(UInt))
 hash(w::WeakRef, h::UInt) = hash(w.value, h)
-hash(T::Type, h::UInt) = hash_uint(3h - ccall(:jl_type_hash, UInt, (Any,), T))
+
+# Types can't be deleted, so marking as total allows the compiler to look up the hash
+@assume_effects :total _typehash(T::Type) = ccall(:jl_type_hash, UInt, (Any,), T)
+hash(T::Type, h::UInt) = hash_uint(3h - _typehash(T))
 
 ## hashing general objects ##
 

--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -31,8 +31,7 @@ hash(x::Any) = hash(x, zero(UInt))
 hash(w::WeakRef, h::UInt) = hash(w.value, h)
 
 # Types can't be deleted, so marking as total allows the compiler to look up the hash
-@assume_effects :total _typehash(T::Type) = ccall(:jl_type_hash, UInt, (Any,), T)
-hash(T::Type, h::UInt) = hash_uint(3h - _typehash(T))
+hash(T::Type, h::UInt) = hash_uint(3h - @assume_effects :total ccall(:jl_type_hash, UInt, (Any,), T))
 
 ## hashing general objects ##
 

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -303,4 +303,4 @@ struct AUnionParam{T<:Union{Nothing,Float32,Float64}} end
     @test hash(5//3) == hash(big(5)//3)
 end
 
-@test Base.infer_effects(hash, Tuple{Type{Int}, UInt}) == Core.Compiler.EFFECTS_TOTAL
+@test Core.Compiler.is_foldable_nothrow(hash, Tuple{Type{Int}, UInt})

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -303,4 +303,4 @@ struct AUnionParam{T<:Union{Nothing,Float32,Float64}} end
     @test hash(5//3) == hash(big(5)//3)
 end
 
-@test Core.Compiler.is_foldable_nothrow(hash, Tuple{Type{Int}, UInt})
+@test Core.Compiler.is_foldable_nothrow(Base.infer_effects(hash, Tuple{Type{Int}, UInt}))

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -302,3 +302,5 @@ struct AUnionParam{T<:Union{Nothing,Float32,Float64}} end
     # test hashing of rational with odd denominator
     @test hash(5//3) == hash(big(5)//3)
 end
+
+@test Base.infer_effects(hash, Tuple{Type{Int}, UInt}) == Core.Compiler.EFFECTS_TOTAL


### PR DESCRIPTION
Since types can't really be deleted and the hash of a type is already being cached inside of the type object itself, it should be legal to mark the `ccall` retrieving that hash as `:total`, permitting hashing of types to be concretely evaluated.

I'm unsure if the test I've added is good as written, or whether this should be done differently.