### PR TITLE
Reverse stacktrace display order

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -108,7 +108,6 @@ istrivialerror(stack::ExceptionStack) =
     # frame 1 = top level; assumes already went through scrub_repl_backtrace; MethodError see #50803
 
 function display_error(io::IO, stack::ExceptionStack)
-    printstyled(io, "ERROR: "; bold=true, color=Base.error_color())
     show_exception_stack(IOContext(io, :limit => true), stack)
     println(io)
 end
@@ -116,7 +115,6 @@ display_error(stack::ExceptionStack) = display_error(stderr, stack)
 
 # these forms are depended on by packages outside Julia
 function display_error(io::IO, er, bt)
-    printstyled(io, "ERROR: "; bold=true, color=Base.error_color())
     showerror(IOContext(io, :limit => true), er, bt, backtrace = bt!==nothing)
     println(io)
 end


### PR DESCRIPTION
Triage mentioned this favorably a few meetings ago—here's an implementation.

- [ ] Add option to keep the old order (requested by @NHDaly)
- [ ] Fix tests
- [ ] Maybe run nanosoldier to see how bad this will be?

Here's an example of how this works

```julia
f(f0, x, args...) = x == 0 ? f0(args...) : g(f0, x, args...)
g(f0, x, args...) = f(f0, x-1, args...)
for i in 1:100
    symi = Symbol(:delay_, i)
    symim1 = Symbol(:delay_, i-1)
    @eval $symi(f, args...) = $symim1(f, args...)
end
delay_0(f, args...) = f(args...)
h(f, g, args...) = try f() catch e g(args...) end

delay_4(h, () -> delay_4(Int∘inv, 0), f, sqrt, 100, -1)
```

Master:
```
ERROR: DomainError with -1.0:
sqrt was called with a negative real argument but will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
Stacktrace:
   [1] throw_complex_domainerror(f::Symbol, x::Float64)
     @ Base.Math ./math.jl:33
   [2] sqrt
     @ Base.Math ./math.jl:686 [inlined]
   [3] sqrt(x::Int64)
     @ Base.Math ./math.jl:1579
   [4] f(f0::Function, x::Int64, args::Int64)
     @ Main ./REPL[1]:1
   [5] g(f0::Function, x::Int64, args::Int64)
     @ Main ./REPL[2]:1
--- the above 2 lines are repeated 99 more times ---
 [204] f(f0::Function, x::Int64, args::Int64)
     @ Main ./REPL[1]:1
 [205] h(::var"#10#11", ::Function, ::Function, ::Vararg{Any})
     @ Main ./REPL[5]:1
 [206] delay_0(::Function, ::Function, ::Vararg{Any})
     @ Main ./REPL[4]:1
 [207] delay_1(::Function, ::Function, ::Vararg{Any})
     @ Main ./REPL[3]:4
 [208] delay_2(::Function, ::Function, ::Vararg{Any})
     @ Main ./REPL[3]:4
 [209] delay_3(::Function, ::Function, ::Vararg{Any})
     @ Main ./REPL[3]:4
 [210] delay_4(::Function, ::Function, ::Vararg{Any})
     @ Main ./REPL[3]:4

caused by: InexactError: Int64(Inf)             <- Primary error is here
Stacktrace:
  [1] Int64
    @ Base ./float.jl:963 [inlined]
  [2] Constructor
    @ Base ./operators.jl:1056 [inlined]
  [3] call_composed
    @ Base ./operators.jl:1052 [inlined]
  [4] (::ComposedFunction{Type{Int64}, typeof(inv)})(x::Int64)
    @ Base ./operators.jl:1049
  [5] delay_0(f::Function, args::Int64)
    @ Main ./REPL[4]:1
  [6] delay_1
    @ Main ./REPL[3]:4 [inlined]
  [7] delay_2
    @ Main ./REPL[3]:4 [inlined]
  [8] delay_3
    @ Main ./REPL[3]:4 [inlined]
  [9] delay_4(f::Function, args::Int64)
    @ Main ./REPL[3]:4
 [10] (::var"#10#11")()
    @ Main ./REPL[6]:1
 [11] h(::var"#10#11", ::Function, ::Function, ::Vararg{Any})
    @ Main ./REPL[5]:1
 [12] delay_0(::Function, ::Function, ::Vararg{Any})
    @ Main ./REPL[4]:1
 [13] delay_1(::Function, ::Function, ::Vararg{Any})
    @ Main ./REPL[3]:4
 [14] delay_2(::Function, ::Function, ::Vararg{Any})
    @ Main ./REPL[3]:4
 [15] delay_3(::Function, ::Function, ::Vararg{Any})
    @ Main ./REPL[3]:4
 [16] delay_4(::Function, ::Function, ::Vararg{Any})
    @ Main ./REPL[3]:4
 [17] top-level scope
    @ REPL[6]:1
```

PR:
```
Stacktrace:
 [210] top-level scope
     @ REPL[7]:1
 [209] delay_4(::Function, ::Function, ::Vararg{Any})
     @ Main ./REPL[4]:4
 [208] delay_3(::Function, ::Function, ::Vararg{Any})
     @ Main ./REPL[4]:4
 [207] delay_2(::Function, ::Function, ::Vararg{Any})
     @ Main ./REPL[4]:4
 [206] delay_1(::Function, ::Function, ::Vararg{Any})
     @ Main ./REPL[4]:4
 [205] delay_0(::Function, ::Function, ::Vararg{Any})
     @ Main ./REPL[5]:1
 [204] h(::var"#10#11", ::Function, ::Function, ::Vararg{Any})
     @ Main ./REPL[6]:1
 [203] f(f0::Function, x::Int64, args::Int64)
     @ Main ./REPL[2]:1
 [202] g(f0::Function, x::Int64, args::Int64)
     @ Main ./REPL[3]:1
--- the above 2 lines are repeated 99 more times ---
   [3] f(f0::Function, x::Int64, args::Int64)
     @ Main ./REPL[2]:1
   [2] sqrt(x::Int64)
     @ Base.Math ./math.jl:1579
   [1] sqrt
     @ Base.Math ./math.jl:686 [inlined]
ERROR: DomainError with -1.0:
sqrt was called with a negative real argument but will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).

caused by: Stacktrace:
 [17] top-level scope
    @ REPL[7]:1
 [16] delay_4(::Function, ::Function, ::Vararg{Any})
    @ Main ./REPL[4]:4
 [15] delay_3(::Function, ::Function, ::Vararg{Any})
    @ Main ./REPL[4]:4
 [14] delay_2(::Function, ::Function, ::Vararg{Any})
    @ Main ./REPL[4]:4
 [13] delay_1(::Function, ::Function, ::Vararg{Any})
    @ Main ./REPL[4]:4
 [12] delay_0(::Function, ::Function, ::Vararg{Any})
    @ Main ./REPL[5]:1
 [11] h(::var"#10#11", ::Function, ::Function, ::Vararg{Any})
    @ Main ./REPL[6]:1
 [10] (::var"#10#11")()
    @ Main ./REPL[7]:1
  [9] delay_4(f::Function, args::Int64)
    @ Main ./REPL[4]:4
  [8] delay_3
    @ Main ./REPL[4]:4 [inlined]
  [7] delay_2
    @ Main ./REPL[4]:4 [inlined]
  [6] delay_1
    @ Main ./REPL[4]:4 [inlined]
  [5] delay_0(f::Function, args::Int64)
    @ Main ./REPL[5]:1
  [4] (::ComposedFunction{Type{Int64}, typeof(inv)})(x::Int64)
    @ Base ./operators.jl:1049
  [3] call_composed
    @ Base ./operators.jl:1052 [inlined]
  [2] Constructor
    @ Base ./operators.jl:1056 [inlined]
  [1] Int64
    @ Base ./float.jl:963 [inlined]
ERROR: InexactError: Int64(Inf)             <- Primary error is here
```