### PR TITLE
define zero-argument function composition

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1057,6 +1057,7 @@ struct Constructor{F} <: Function end
 maybeconstructor(::Type{F}) where {F} = Constructor{F}()
 maybeconstructor(f) = f
 
+∘() = identity
 ∘(f) = f
 ∘(f, g) = ComposedFunction(f, g)
 ∘(f, g, h...) = ∘(f ∘ g, h...)

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -167,6 +167,7 @@ end
     @test ∘(x -> x-2, x -> x-3, x -> x+5)(7) == 7
     fs = [x -> x[1:2], uppercase, lowercase]
     @test ∘(fs...)("ABC") == "AB"
+    @test ∘() === identity
 
     # Like +() and *() we leave ∘() undefined.
     # While `∘() = identity` is a reasonable definition for functions, this


### PR DESCRIPTION
`identity` is the natural neutral element of composition. The zero-arg method makes 
```julia
F1 = ∘(fs...) ∘ ∘(gs...)
F2 = ∘(fs..., gs...)
# now F1 is equivalent to F2
```
to hold always, including empty `fs` or `gs`.