### PR TITLE
Remove `Pkg` dependency from `SuiteSparse_jll`

### DIFF
--- a/stdlib/SuiteSparse_jll/Project.toml
+++ b/stdlib/SuiteSparse_jll/Project.toml
@@ -4,7 +4,6 @@ version = "7.2.1+1"
 
 [deps]
 libblastrampoline_jll = "8e850b90-86db-534c-a0d3-1478176c7d93"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 


### PR DESCRIPTION
This dependency seems to be superfluous, and `Pkg` brings lots of dependencies into the project (Downloads, LibGit2, etc.) which makes it hard to create leaner binary packages via `PackageCompiler` for projects that depend on `SuiteSparse_jll`.