### PR TITLE
Clarify the docs of @__DIR__

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3401,9 +3401,33 @@ end
 """
     @__DIR__ -> String
 
-Expand to a string with the absolute path to the directory of the file
-containing the macrocall.
-Return the current working directory if run from a REPL or if evaluated by `julia -e <expr>`.
+Macro to obtain the absolute path of the current directory as a string.
+
+If in a script, returns the directory of the script containing the `@__DIR__` macrocall. If run from a 
+REPL or if evaluated by `julia -e <expr>`, returns the current working directory.
+
+# Example
+
+The example illustrates the difference in the behaviors of `@__DIR__` and `pwd()`, by creating
+a simple script in a different directory than the current working one and executing both commands:
+
+```julia-repl
+julia> cd("/home/JuliaUser") # working directory
+
+julia> # create script at /home/JuliaUser/Projects
+       open("/home/JuliaUser/Projects/test.jl","w") do io
+           print(io, """
+               println("@__DIR__ = ", @__DIR__)
+               println("pwd() = ", pwd())
+           """)
+       end
+
+julia> # outputs script directory and current working directory
+       include("/home/JuliaUser/Projects/test.jl")
+@__DIR__ = /home/JuliaUser/Documents
+pwd() = /home/JuliaUser
+```
+    
 """
 macro __DIR__()
     __source__.file === nothing && return nothing

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3403,7 +3403,7 @@ end
 
 Macro to obtain the absolute path of the current directory as a string.
 
-If in a script, returns the directory of the script containing the `@__DIR__` macrocall. If run from a 
+If in a script, returns the directory of the script containing the `@__DIR__` macrocall. If run from a
 REPL or if evaluated by `julia -e <expr>`, returns the current working directory.
 
 # Example
@@ -3427,7 +3427,6 @@ julia> # outputs script directory and current working directory
 @__DIR__ = /home/JuliaUser/Projects
 pwd() = /home/JuliaUser
 ```
-    
 """
 macro __DIR__()
     __source__.file === nothing && return nothing

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3424,7 +3424,7 @@ julia> # create script at /home/JuliaUser/Projects
 
 julia> # outputs script directory and current working directory
        include("/home/JuliaUser/Projects/test.jl")
-@__DIR__ = /home/JuliaUser/Documents
+@__DIR__ = /home/JuliaUser/Projects
 pwd() = /home/JuliaUser
 ```
     


### PR DESCRIPTION
The original docs start with `Expand`, which is already a concept that might not be clear to the reader. Furthermore, in this version there is an example to illustrate how this macro is different from `pwd()`.