### PR TITLE
Reduce code duplication in `eigen(::AbstractMatrix)` methods

### DIFF
--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -236,22 +236,23 @@ true
 ```
 """
 function eigen(A::AbstractMatrix{T}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) where T
-    isdiag(A) && return eigen(Diagonal{eigtype(T)}(diag(A)); sortby)
-    ishermitian(A) && return eigen!(eigencopy_oftype(Hermitian(A), eigtype(T)); sortby)
-    AA = eigencopy_oftype(A, eigtype(T))
-    return eigen!(AA; permute, scale, sortby)
+    _eigen(A; permute, scale, sortby)
 end
 function eigen(A::AbstractMatrix{T}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) where {T <: Union{Float16,Complex{Float16}}}
-    isdiag(A) && return eigen(Diagonal{eigtype(T)}(diag(A)); sortby)
-    E = if ishermitian(A)
-        eigen!(eigencopy_oftype(Hermitian(A), eigtype(T)); sortby)
-    else
-        eigen!(eigencopy_oftype(A, eigtype(T)); permute, scale, sortby)
-    end
+    E = _eigen(A; permute, scale, sortby)
     values = convert(AbstractVector{isreal(E.values) ? Float16 : Complex{Float16}}, E.values)
     vectors = convert(AbstractMatrix{isreal(E.vectors) ? Float16 : Complex{Float16}}, E.vectors)
     return Eigen(values, vectors)
 end
+function _eigen(A::AbstractMatrix{T}; permute=true, scale=true, sortby=eigsortby) where {T}
+    isdiag(A) && return eigen(Diagonal{eigtype(T)}(diag(A)); sortby)
+    if ishermitian(A)
+        eigen!(eigencopy_oftype(Hermitian(A), eigtype(T)); sortby)
+    else
+        eigen!(eigencopy_oftype(A, eigtype(T)); permute, scale, sortby)
+    end
+end
+
 eigen(x::Number) = Eigen([x], fill(one(x), 1, 1))
 
 """

--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -241,6 +241,21 @@ end
     @test F.vectors isa Matrix{ComplexF16}
     @test F.values ≈ F32.values
     @test F.vectors ≈ F32.vectors
+
+    for T in (Float16, ComplexF16)
+        D = Diagonal(T[1,2,4])
+        A = Array(D)
+        B = eigen(A)
+        @test B isa Eigen{Float16, Float16, Matrix{Float16}, Vector{Float16}}
+        @test B.values isa Vector{Float16}
+        @test B.vectors isa Matrix{Float16}
+    end
+    D = Diagonal(ComplexF16[im,2,4])
+    A = Array(D)
+    B = eigen(A)
+    @test B isa Eigen{Float16, ComplexF16, Matrix{Float16}, Vector{ComplexF16}}
+    @test B.values isa Vector{ComplexF16}
+    @test B.vectors isa Matrix{Float16}
 end
 
 @testset "complex eigen inference (#52289)" begin


### PR DESCRIPTION
This also fixes the following:
```julia
julia> D = Diagonal(Float16[1,2,4])
3×3 Diagonal{Float16, Vector{Float16}}:
 1.0   ⋅    ⋅ 
  ⋅   2.0   ⋅ 
  ⋅    ⋅   4.0

julia> eigen(Array(D)) # returns Float32
Eigen{Float32, Float32, Matrix{Float32}, Vector{Float32}}
values:
3-element Vector{Float32}:
 1.0
 2.0
 4.0
vectors:
3×3 Matrix{Float32}:
 1.0  0.0  0.0
 0.0  1.0  0.0
 0.0  0.0  1.0

julia> eigen(D)  # returns Float16 as expected
Eigen{Float16, Float16, Matrix{Float16}, Vector{Float16}}
values:
3-element Vector{Float16}:
 1.0
 2.0
 4.0
vectors:
3×3 Matrix{Float16}:
 1.0  0.0  0.0
 0.0  1.0  0.0
 0.0  0.0  1.0
```
After this,
```julia
julia> eigen(Array(D))
Eigen{Float16, Float16, Matrix{Float16}, Vector{Float16}}
values:
3-element Vector{Float16}:
 1.0
 2.0
 4.0
vectors:
3×3 Matrix{Float16}:
 1.0  0.0  0.0
 0.0  1.0  0.0
 0.0  0.0  1.0
```