### PR TITLE
Docs: cross-reference `username` and `homedir`

### DIFF
--- a/base/path.jl
+++ b/base/path.jl
@@ -77,6 +77,8 @@ Return the current user's home directory.
     `homedir` determines the home directory via `libuv`'s `uv_os_homedir`. For details
     (for example on how to specify the home directory via environment variables), see the
     [`uv_os_homedir` documentation](http://docs.libuv.org/en/v1.x/misc.html#c.uv_os_homedir).
+
+See also [`Sys.username`](@ref).
 """
 function homedir()
     buf = Base.StringVector(AVG_PATH - 1) # space for null-terminator implied by StringVector

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -582,6 +582,8 @@ user = get(Sys.username, ENV, "USER")
 
 !!! compat "Julia 1.11"
     This function requires at least Julia 1.11.
+
+See also [`homedir`](@ref).
 """
 function username()
     pw = Libc.getpw()


### PR DESCRIPTION
To improve discoverability (mainly) of `username`.

[skip ci]