### PR TITLE
WIP: create separate object pools for long-lived types

### DIFF
--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -694,6 +694,8 @@ static void rr_detach_teleport(void) {
 }
 #endif
 
+void gc_enable_heap_dump(void);
+
 JL_DLLEXPORT int jl_repl_entrypoint(int argc, char *argv[])
 {
 #ifdef USE_TRACY
@@ -737,6 +739,8 @@ JL_DLLEXPORT int jl_repl_entrypoint(int argc, char *argv[])
     }
     int ret = true_main(argc, (char**)new_argv);
     jl_atexit_hook(ret);
+    gc_enable_heap_dump();
+    jl_gc_collect(JL_GC_FULL);
     return ret;
 }
 

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -162,7 +162,13 @@ typedef struct {
 
     // variables for allocating objects from pools
 #define JL_GC_N_MAX_POOLS 51 // conservative. must be kept in sync with `src/julia_internal.h`
-    jl_gc_pool_t norm_pools[JL_GC_N_MAX_POOLS];
+    // pool layout:
+    // - [0, JL_GC_N_MAX_POOLS): small objects which are not special cased (see below)
+    // - [JL_GC_N_MAX_POOLS, 2 * JL_GC_N_MAX_POOLS): SimpleVector
+    // - 2 * JL_GC_N_MAX_POOLS: CodeInstance
+    // - 2 * JL_GC_N_MAX_POOLS + 1: MethodInstance
+    // - 2 * JL_GC_N_MAX_POOLS + 2: TypeMapEntry
+    jl_gc_pool_t norm_pools[2 * JL_GC_N_MAX_POOLS + 3];
 
 #define JL_N_STACK_POOLS 16
     small_arraylist_t free_stacks[JL_N_STACK_POOLS];


### PR DESCRIPTION
We're seeing high fragmentation in some workloads and we suspect that types such as `CodeInstance `, `MethodInstance`, etc. might be the biggest contributors to that.

In particular, we built some very simple instrumentation to get an idea of object distribution in pages (see `GC_HEAP_DUMP` flag) and noticed that in a few micro-benchmarks, we often run into the scenario where we have a whole GC page allocated with very few objects of these types in it.

We think that allocating them in a separate region could help with reducing fragmentation.