### PR TITLE
contrib/check-whitespace: Use / for all platform

### DIFF
--- a/contrib/check-whitespace.jl
+++ b/contrib/check-whitespace.jl
@@ -23,10 +23,10 @@ allow_tabs(path) =
     endswith(path, "Makefile") ||
     endswith(path, ".make") ||
     endswith(path, ".mk") ||
-    startswith(path, joinpath("src", "support")) ||
-    startswith(path, joinpath("src", "flisp")) ||
-    endswith(path, joinpath("test", "syntax.jl")) ||
-    endswith(path, joinpath("test", "triplequote.jl"))
+    startswith(path, "src/support") ||
+    startswith(path, "src/flisp") ||
+    endswith(path, "test/syntax.jl") ||
+    endswith(path, "test/triplequote.jl")
 
 const errors = Set{Tuple{String,Int,String}}()
 

--- a/contrib/check-whitespace.jl
+++ b/contrib/check-whitespace.jl
@@ -18,6 +18,8 @@ const patterns = split("""
     *Makefile
 """)
 
+# Note: `git ls-files` gives `/` as a path separator on Windows,
+#   so we just use `/` for all platforms.
 allow_tabs(path) =
     path == "Make.inc" ||
     endswith(path, "Makefile") ||


### PR DESCRIPTION
When built on Windows, the source code build will not pass `check-whitespace`.

_check-whitespace issues (truncated):_
```
$ make check-whitespace
Whitespace check found 1658 issues:
src/flisp/aliases.scm:25 -- tab
src/flisp/aliases.scm:27 -- tab
src/flisp/aliases.scm:28 -- tab
src/flisp/aliases.scm:29 -- tab
src/flisp/aliases.scm:73 -- tab
src/flisp/color.lsp:55 -- tab
....
```

Because `git ls-files` use `/` as a path separator on Windows.
https://github.com/JuliaLang/julia/blob/649982aa0995c45165084baa643ce5c7c5b489cb/contrib/check-whitespace.jl#L33
_"git ls-files" output on win (truncated):_
```
$ git ls-files -- *.jl
base/Base.jl
base/Enums.jl
base/abstractarray.jl
base/abstractarraymath.jl
base/abstractdict.jl
base/abstractset.jl
base/accumulate.jl
...
```


But `joinpath` gives `\\` on win, so it won't match.
https://github.com/JuliaLang/julia/blob/649982aa0995c45165084baa643ce5c7c5b489cb/contrib/check-whitespace.jl#L21-L29


Change: just use `/` for all platforms.

