### PR TITLE
Export several genericmemory-related functions that used to be exported for arrays.

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -28,7 +28,11 @@
     XX(jl_array_ptr) \
     XX(jl_array_ptr_1d_append) \
     XX(jl_array_ptr_1d_push) \
+    XX(jl_genericmemory_isassigned) \
     XX(jl_genericmemory_owner) \
+    XX(jl_genericmemoryref) \
+    XX(jl_genericmemoryset) \
+    XX(jl_genericmemoryunset) \
     XX(jl_array_rank) \
     XX(jl_array_to_string) \
     XX(jl_atexit_hook) \


### PR DESCRIPTION
The functionality of `jl_array_isassigned`, `jl_arrayref`, `jl_arrayset`, and `jl_arrayunset` has been moved to new functions, but those new functions aren't exported. This PR exports them.

I think it would make sense from an embedding perspective to also restore the original functions, but that's a separate matter.