### PR TITLE
optimize remset marking

### DIFF
--- a/src/gc.h
+++ b/src/gc.h
@@ -118,6 +118,8 @@ typedef struct _jl_gc_chunk_t {
 #define GC_PTR_QUEUE_INIT_SIZE (1 << 18)    // initial size of queue of `jl_value_t *`
 #define GC_CHUNK_QUEUE_INIT_SIZE (1 << 14)  // initial size of chunk-queue
 
+#define GC_REMSET_PTR_TAG (0x1)             // lowest bit of `jl_value_t *` is tagged if it's in the remset
+
 // layout for big (>2k) objects
 
 JL_EXTENSION typedef struct _bigval_t {


### PR DESCRIPTION
Tag the lowest bit of a pointer to indicate it's in the remset and enqueue objects in the remset for later processing when GC threads have woken up, instead of sequentially marking them all at once.

In principle, this should allow for more parallelism in the mark phase, though I didn't benchmark it yet.