### PR TITLE
Use a distinct interactive system image, isys.so, if Julia is interactive. Fallback to sys.so.

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -57,6 +57,7 @@ struct JLOptions
     strip_ir::Int8
     permalloc_pkgimg::Int8
     heap_size_hint::UInt64
+    argc::Int32
 end
 
 # This runs early in the sysimage != is not defined yet

--- a/src/Makefile
+++ b/src/Makefile
@@ -179,6 +179,7 @@ CODEGEN_DOBJS := $(CODEGEN_SRCS:%=$(BUILDDIR)/%.dbg.obj)
 
 # Add SONAME defines so we can embed proper `dlopen()` calls.
 ADDL_SHIPFLAGS  := "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys.$(SHLIB_EXT)\"" \
+                   "-DJL_ISYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/isys.$(SHLIB_EXT)\"" \
                    "-DJL_LIBJULIA_SONAME=\"$(LIBJULIA_PATH_REL).$(JL_MAJOR_SHLIB_EXT)\""
 ADDL_DEBUGFLAGS := "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys-debug.$(SHLIB_EXT)\"" \
                    "-DJL_LIBJULIA_SONAME=\"$(LIBJULIA_PATH_REL)-debug.$(JL_MAJOR_SHLIB_EXT)\""

--- a/src/init.c
+++ b/src/init.c
@@ -850,8 +850,15 @@ static NOINLINE void _finish_julia_init(JL_IMAGE_SEARCH rel, jl_ptls_t ptls, jl_
     // loads sysimg if available, and conditionally sets jl_options.cpu_target
     if (rel == JL_IMAGE_IN_MEMORY)
         jl_set_sysimg_so(jl_exe_handle);
-    else if (jl_options.image_file)
+    else if (jl_options.image_file) {
         jl_preload_sysimg_so(jl_options.image_file);
+        if (jl_options.isinteractive && !jl_options.image_file_specified && !jl_preload_successful()) {
+            jl_options.image_file = jl_get_default_sysimg_path();
+            //jl_resolve_sysimg_location(JL_IMAGE_JULIA_HOME);
+            jl_resolve_sysimg_location(rel);
+            jl_preload_sysimg_so(jl_options.image_file);
+        }
+    }
     if (jl_options.cpu_target == NULL)
         jl_options.cpu_target = "native";
     jl_init_codegen();

--- a/src/init.c
+++ b/src/init.c
@@ -747,6 +747,9 @@ JL_DLLEXPORT int jl_is_interactive(void)
     if (jl_options.isinteractive)
         return 1;
 
+    if (jl_options.argc > 0)
+        return 0;
+
     //based on the Julia function unsafe_load_commands
     //not interactive if -e or -E is provided as a command
     if (jl_options.cmds) {

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -285,6 +285,7 @@
     XX(jl_is_imported) \
     XX(jl_is_initialized) \
     XX(jl_is_in_pure_context) \
+    XX(jl_is_interactive) \
     XX(jl_is_memdebug) \
     XX(jl_is_not_broken_subtype) \
     XX(jl_is_operator) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -206,6 +206,7 @@
     XX(jl_cpu_has_fma) \
     XX(jl_get_current_task) \
     XX(jl_get_default_sysimg_path) \
+    XX(jl_get_interactive_sysimg_path) \
     XX(jl_get_excstack) \
     XX(jl_get_fenv_consts) \
     XX(jl_get_field) \
@@ -366,6 +367,7 @@
     XX(jl_pointerref) \
     XX(jl_pointerset) \
     XX(jl_pop_handler) \
+    XX(jl_preload_successful) \
     XX(jl_preload_sysimg_so) \
     XX(jl_prepend_cwd) \
     XX(jl_printf) \

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -24,6 +24,12 @@ JL_DLLEXPORT const char *jl_get_default_sysimg_path(void)
     return &system_image_path[1];
 }
 
+static const char interactive_system_image_path[256] = "\0" JL_ISYSTEM_IMAGE_PATH;
+JL_DLLEXPORT const char *jl_get_interactive_sysimg_path(void)
+{
+    return &interactive_system_image_path[1];
+}
+
 static int jl_options_initialized = 0;
 
 JL_DLLEXPORT void jl_init_options(void)
@@ -664,6 +670,9 @@ restart_switch:
             break;
         case 'i': // isinteractive
             jl_options.isinteractive = 1;
+            if (!jl_options.image_file_specified) {
+                jl_options.image_file = jl_get_interactive_sysimg_path();
+            }
             break;
         case opt_check_bounds:
             if (!strcmp(optarg,"yes"))

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -96,6 +96,7 @@ JL_DLLEXPORT void jl_init_options(void)
                         0, // strip-ir
                         0, // permalloc_pkgimg
                         0, // heap-size-hint
+                        0, // argc
     };
     jl_options_initialized = 1;
 }
@@ -872,6 +873,7 @@ restart_switch:
     int proc_args = *argcp < optind ? *argcp : optind;
     *argvp += proc_args;
     *argcp -= proc_args;
+    jl_options.argc = *argcp;
 }
 
 JL_DLLEXPORT ssize_t jl_sizeof_jl_options(void)

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -61,6 +61,7 @@ typedef struct {
     int8_t strip_ir;
     int8_t permalloc_pkgimg;
     uint64_t heap_size_hint;
+    int32_t argc;
 } jl_options_t;
 
 #endif

--- a/src/julia.h
+++ b/src/julia.h
@@ -2031,6 +2031,7 @@ JL_DLLEXPORT void jl_init_with_image(const char *julia_bindir,
 JL_DLLEXPORT const char *jl_get_default_sysimg_path(void);
 JL_DLLEXPORT const char *jl_get_interactive_sysimg_path(void);
 JL_DLLEXPORT int jl_is_initialized(void);
+JL_DLLEXPORT int jl_is_interactive(void);
 JL_DLLEXPORT void jl_atexit_hook(int status);
 JL_DLLEXPORT void jl_task_wait_empty(void);
 JL_DLLEXPORT void jl_postoutput_hook(void);

--- a/src/julia.h
+++ b/src/julia.h
@@ -2029,6 +2029,7 @@ JL_DLLEXPORT void jl_init(void);
 JL_DLLEXPORT void jl_init_with_image(const char *julia_bindir,
                                      const char *image_path);
 JL_DLLEXPORT const char *jl_get_default_sysimg_path(void);
+JL_DLLEXPORT const char *jl_get_interactive_sysimg_path(void);
 JL_DLLEXPORT int jl_is_initialized(void);
 JL_DLLEXPORT void jl_atexit_hook(int status);
 JL_DLLEXPORT void jl_task_wait_empty(void);
@@ -2039,6 +2040,7 @@ JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle);
 JL_DLLEXPORT jl_gcframe_t **jl_adopt_thread(void);
 
 JL_DLLEXPORT int jl_deserialize_verify_header(ios_t *s);
+JL_DLLEXPORT int jl_preload_successful(void);
 JL_DLLEXPORT void jl_preload_sysimg_so(const char *fname);
 JL_DLLEXPORT void jl_set_sysimg_so(void *handle);
 JL_DLLEXPORT void jl_create_system_image(void **, jl_array_t *worklist, bool_t emit_split, ios_t **s, ios_t **z, jl_array_t **udeps, int64_t *srctextpos);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2975,8 +2975,10 @@ JL_DLLEXPORT void jl_preload_sysimg_so(const char *fname)
     // Get handle to sys.so
     if (!is_ji) { // .ji extension => load .ji file only
         // if the interactive sysimg fails to load, fail to preload. See jl_preload_successful and _finish_julia_init.
-        int fallback_to_default_sysimg = jl_options.isinteractive && !jl_options.image_file_specified;
-        void *handle = jl_load_dynamic_library(fname, JL_RTLD_LOCAL | JL_RTLD_NOW, !fallback_to_default_sysimg);
+        int fallback_to_default_sysimg = jl_is_interactive() &&
+            !jl_options.image_file_specified;
+        void *handle = jl_load_dynamic_library(fname, JL_RTLD_LOCAL | JL_RTLD_NOW,
+                !fallback_to_default_sysimg);
         if (!handle)
             return; // failed to set jl_sysimg_handle
         jl_set_sysimg_so(handle);


### PR DESCRIPTION
If Julia is running interactively, attempt to load `isys.so` rather than `sys.so` as the system image. If `isys.so` is not found, fallback to using `sys.so`. This allows the user or perhaps a package to install a distinct system image for interactive use.

This pull request arose as a proof of concept from a [Discourse discussion](https://discourse.julialang.org/t/should-we-distribute-multiple-official-system-images-for-julia-1-11/107353).

The idea is that the user may want a system image that includes REPL.jl, Pkg.jl, and other interactive packages (e.g. OhMyREPL.jl) when using Julia interactively due to faster load times. However, having these in the system image is not necessary for non-interactive use. The REPL.jl and Pkg.jl packages were removed from the standard system image in Julia 1.11.

The following new C API functions are added.
* `jl_is_interactive`
* `jl_get_interactive_sysimg_path`
* `jl_preload_successful`

# Demonstration

Here's a demonstration of how this currently works.

Initially, `isys.so` does not exist, so Julia will load `sys.so`.

```
~/src/julia$ ./julia --banner=no
julia> sysimg = Base.JLOptions().image_file |> unsafe_string
"/home/mkitti/src/julia/usr/lib/julia/sys.so"

julia> cp(sysimg, replace(sysimg, "sys.so" => "isys.so"))
"/home/mkitti/src/julia/usr/lib/julia/isys.so"

julia> exit()
```

We copied sys.so to isys.so. Now `isys.so` exists, so we shoud load it in interactive mode.

```
~/src/julia$ ./julia --banner=no
julia> sysimg = Base.JLOptions().image_file |> unsafe_string
"/home/mkitti/src/julia/usr/lib/julia/isys.so"
```

If we are not running in interactive mode, then the regular `sys.so` is loaded despite `isys.so` existing.
```
~/src/julia$ ./julia -e "Base.JLOptions().image_file |> unsafe_string |> println"
/home/mkitti/src/julia/usr/lib/julia/sys.so
```

With these changes, the user can create an isys.so that is optimized for interactive use while keeping a separate sys.so for non-interactive use.

# Questions

1. Where should the interactive system image be located? If this is meant to be controlled by the user, perhaps `~/.julia/sysimgs/` would be a good alternative place.
2. Should we use `jl_is_interactive` to set the global variable `Base.is_interactive` or implement `Base.isinteractive()`?