### PR TITLE
Don't extend non-public methods in the InfiniteArrays test helper

### DIFF
--- a/test/testhelpers/InfiniteArrays.jl
+++ b/test/testhelpers/InfiniteArrays.jl
@@ -46,8 +46,5 @@ Base.size(r::OneToInf) = (Infinity(),)
 Base.first(r::OneToInf{T}) where {T} = oneunit(T)
 Base.length(r::OneToInf) = Infinity()
 Base.last(r::OneToInf) = Infinity()
-Base.unitrange(r::OneToInf) = r
-Base.oneto(::Infinity) = OneToInf()
-Base.unchecked_oneto(::Infinity) = OneToInf()
 
 end


### PR DESCRIPTION
Ideally, this should only extend `public` methods to mirror what packages are expected to do. This would also expose potential regressions instead of masking them. Ideally, there should be full support for infinite arrays without the need to tinker with internals.

Inspired by https://github.com/JuliaLang/julia/issues/52481