### PR TITLE
Fix printing of `InexactError` for `Inf16` arg and similar

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -187,6 +187,8 @@ function showerror(io::IO, ex::InexactError)
     print(io, "InexactError: ", ex.func, '(')
     T = first(ex.args)
     nameof(T) === ex.func || print(io, T, ", ")
+    # `join` calls `string` on its arguments, which shadows the size of e.g. Inf16
+    # as `string(Inf16) == "Inf"` instead of "Inf16". Thus we cannot use `join` here.
     for arg in ex.args[2:end-1]
         show(io, arg)
         print(io, ", ")

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -187,7 +187,11 @@ function showerror(io::IO, ex::InexactError)
     print(io, "InexactError: ", ex.func, '(')
     T = first(ex.args)
     nameof(T) === ex.func || print(io, T, ", ")
-    join(io, ex.args[2:end], ", ")
+    for arg in ex.args[2:end-1]
+        show(io, arg)
+        print(io, ", ")
+    end
+    show(io, ex.args[end])
     print(io, ")")
     Experimental.show_error_hints(io, ex)
 end

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -1090,3 +1090,15 @@ let e = @test_throws MethodError convert(TypeCompareError{Float64,1}, TypeCompar
     @test  occursin("TypeCompareError{Float64,1}", str)
     @test !occursin("TypeCompareError{Float64{},2}", str) # No {...} for types without params
 end
+
+@testset "InexactError for Inf16 should print '16' (#51087)" begin
+    for IntType in [Int8, Int16, Int32, Int64, Int128, UInt8, UInt16, UInt32, UInt64, UInt128]
+        IntStr = string(IntType)
+        for InfVal in [Inf, Inf16, Inf32, Inf64]
+            InfStr = InfVal === Inf ? "Inf" : string(InfVal)
+            e = @test_throws InexactError IntType(InfVal)
+            str = sprint(Base.showerror, e.value)
+            @test occursin("InexactError: $(IntStr)($InfStr)", str)
+        end
+    end
+end

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -1092,13 +1092,15 @@ let e = @test_throws MethodError convert(TypeCompareError{Float64,1}, TypeCompar
 end
 
 @testset "InexactError for Inf16 should print '16' (#51087)" begin
+    @test sprint(showerror, InexactError(:UInt128, UInt128, Inf16)) == "InexactError: UInt128(Inf16)"
+
     for IntType in [Int8, Int16, Int32, Int64, Int128, UInt8, UInt16, UInt32, UInt64, UInt128]
         IntStr = string(IntType)
-        for InfVal in [Inf, Inf16, Inf32, Inf64]
-            InfStr = InfVal === Inf ? "Inf" : string(InfVal)
+        for InfVal in Any[Inf, Inf16, Inf32, Inf64]
+            InfStr = repr(InfVal)
             e = @test_throws InexactError IntType(InfVal)
             str = sprint(Base.showerror, e.value)
-            @test occursin("InexactError: $(IntStr)($InfStr)", str)
+            @test occursin("InexactError: $IntStr($InfStr)", str)
         end
     end
 end


### PR DESCRIPTION
Resolves https://github.com/JuliaLang/julia/issues/51087
Closes https://github.com/JuliaLang/julia/pull/51163

Use `show` as pointed out in https://github.com/JuliaLang/julia/pull/51163#discussion_r1328682832.

Furthermore add some tests to make sure that everything works as expected.