### PR TITLE
Fix typo in heuristics of BracketedSort

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1262,7 +1262,7 @@ function _sort!(v::AbstractVector, a::BracketedSort, o::Ordering, kw)
     k = cbrt(ln)
     k2 = round(Int, k^2)
     k2ln = k2/ln
-    offset = .15k2*top_set_bit(k2) # TODO for further optimization: tune this
+    offset = .15k*top_set_bit(k2) # TODO for further optimization: tune this
     lo_signpost_i, hi_signpost_i =
         (floor(Int, (tar - lo) * k2ln + lo + off) for (tar, off) in
             ((minimum(target), -offset), (maximum(target), offset)))

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -721,10 +721,9 @@ end
     for alg in safe_algs
         @test sort(1:n, alg=alg, lt = (i,j) -> v[i]<=v[j]) == perm
     end
-    # This could easily break with minor heuristic adjustments
-    # because partialsort is not even guaranteed to be stable:
-    @test partialsort(1:n, 172, lt = (i,j) -> v[i]<=v[j]) == perm[172]
-    @test partialsort(1:n, 315:415, lt = (i,j) -> v[i]<=v[j]) == perm[315:415]
+    # Broken by the introduction of BracketedSort in #52006 which is unstable
+    @test_broken partialsort(1:n, 172, lt = (i,j) -> v[i]<=v[j]) == perm[172]
+    @test_broken partialsort(1:n, 315:415, lt = (i,j) -> v[i]<=v[j]) == perm[315:415]
 
     # lt can be very poorly behaved and sort will still permute its input in some way.
     for alg in safe_algs


### PR DESCRIPTION
The impact of this typo was a) massively decreased performance that was b) predicted by heuristic dispatch, resulting in this algorithm not being dispatched too. I introduced this typo in https://github.com/JuliaLang/julia/pull/52006/commits/5657e5fb5f0ef6ffe3592c1d8e47bb26456b46d6 (a commit on PR #52006) after performing all the benchmarking.

Even with this typo there were no major performance regressions and there are no correction bugs, which makes it a hard thing to add tests for. I'm open to suggestions for how to test this.