### PR TITLE
Specialize copy for Diagonal

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -203,6 +203,8 @@ end
 
 parent(D::Diagonal) = D.diag
 
+copy(D::Diagonal) = Diagonal(copy(D.diag))
+
 ishermitian(D::Diagonal{<:Real}) = true
 ishermitian(D::Diagonal{<:Number}) = isreal(D.diag)
 ishermitian(D::Diagonal) = all(ishermitian, D.diag)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -1235,4 +1235,8 @@ end
     end
 end
 
+@testset "copy" begin
+    @test copy(Diagonal(1:5)) === Diagonal(1:5)
+end
+
 end # module TestDiagonal


### PR DESCRIPTION
On master
```julia
julia> copy(Diagonal(1:4)) |> typeof
Diagonal{Int64, Vector{Int64}}
```
This PR
```julia
julia> copy(Diagonal(1:4)) |> typeof
Diagonal{Int64, UnitRange{Int64}}
```
Similar methods already exist for `Bidiagonal` and `Tridiagonal`, but this was missing for `Diagonal`.