### PR TITLE
faster `BigFloat` construction for more types

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -370,7 +370,7 @@ function BigFloat(x::Rational, r::MPFRRoundingMode=ROUNDING_MODE[]; precision::I
     else
         setprecision(BigFloat, precision) do
             setrounding_raw(BigFloat, r) do
-                BigFloat(numerator(x))::BigFloat / BigFloat(denominator(x))::BigFloat
+                BigFloat(numerator(x))::BigFloat / denominator(x)
             end
         end
     end

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -292,7 +292,7 @@ function BigFloat(x::Base.BitInteger64, r::MPFRRoundingMode=ROUNDING_MODE[]; pre
     end
 
     unsigned_x = unsigned(abs(x))
-    exp_x = (sizeof(x) << 3) - leading_zeros(unsigned_x)
+    exp_x = 8 * sizeof(x) - leading_zeros(unsigned_x)
 
     requiredprecision = exp_x - 1
 
@@ -339,7 +339,7 @@ function BigFloat(x::Base.IEEEFloat, r::MPFRRoundingMode=ROUNDING_MODE[]; precis
 
     # BigFloat doesn't have an implicit bit
     val = UInt64(reinterpret(Base.uinttype(typeof(x)), significand(x)))
-    val <<= (sizeof(UInt64) << 3 - sizeof(x) << 3) + Base.exponent_bits(typeof(x))
+    val <<= (8 * (sizeof(UInt64) - sizeof(x))) + Base.exponent_bits(typeof(x))
     val |= typemin(Int64)
 
     store_significand_in_limbs!(z, val)

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -305,7 +305,10 @@ function BigFloat(x::Base.BitInteger64, r::MPFRRoundingMode=ROUNDING_MODE[]; pre
 
         return z
     else
-        return BigFloat_mpfr_fallback(x, r; precision=precision)::BigFloat
+        # If Clong is 32 bit, MPFR does not have a method for (U)Int64 on Windows
+        return sizeof(x) <= sizeof(Clong) ? 
+            BigFloat_mpfr_fallback(x, r; precision)::BigFloat :
+            BigFloat(BigInt(x), r; precision)
     end
 end
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -306,7 +306,7 @@ function BigFloat(x::Base.BitInteger64, r::MPFRRoundingMode=ROUNDING_MODE[]; pre
         return z
     else
         # If Clong is 32 bit, MPFR does not have a method for (U)Int64 on Windows
-        return sizeof(x) <= sizeof(Clong) ? 
+        return sizeof(x) <= sizeof(Clong) ?
             BigFloat_mpfr_fallback(x, r; precision)::BigFloat :
             BigFloat(BigInt(x), r; precision)
     end

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -27,6 +27,7 @@ import Base.MPFR
     @test typeof(BigFloat(typemax(UInt64))) == BigFloat
     @test typeof(BigFloat(typemax(UInt128))) == BigFloat
 
+    @test typeof(BigFloat(floatmax(Float16))) == BigFloat
     @test typeof(BigFloat(floatmax(Float32))) == BigFloat
     @test typeof(BigFloat(floatmax(Float64))) == BigFloat
 


### PR DESCRIPTION
This pull request addresses #50940 and is a follow-up to #47546.

The changes add Julia construction of `BigFloat`s for some inputs:
- When the Base.BitInteger64 or Base.IEEEFloat when precision is enough to perfectly represent the input as a `BigFloat`
- When the denominator of the `Rational` is a power of 2.

```julia
julia> @btime BigFloat(128)
  14.320 ns (2 allocations: 104 bytes)
128.0

julia> @btime Base.MPFR.BigFloat_mpfr_fallback(128)
  25.518 ns (2 allocations: 104 bytes)
128.0

julia> @btime BigFloat(128.0f0)
  17.952 ns (2 allocations: 104 bytes)
128.0

julia> @btime Base.MPFR.BigFloat_mpfr_fallback(128.0f0)
  35.667 ns (2 allocations: 104 bytes)
128.0
```