### PR TITLE
add docs and jldoctests for `Base.shell_split` and `Base.rstrip_shell`

### DIFF
--- a/base/shell.jl
+++ b/base/shell.jl
@@ -4,7 +4,7 @@
 
 const shell_special = "#{}()[]<>|&*?~;"
 
-"""
+@doc raw"""
     rstrip_shell(s::AbstractString)
 
 Strip trailing whitespace from a shell command string, while respecting a trailing backslash followed by a space ("\\ ").
@@ -16,7 +16,7 @@ julia> Base.rstrip_shell("echo 'Hello World' \\ ")
 julia> Base.rstrip_shell("echo 'Hello World'    ")
 "echo 'Hello World'"
 ```
-"""
+""" ->
 function rstrip_shell(s::AbstractString)
     c_old = nothing
     for (i, c) in Iterators.reverse(pairs(s))

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -4,7 +4,19 @@
 
 const shell_special = "#{}()[]<>|&*?~;"
 
-# strips the end but respects the space when the string ends with "\\ "
+"""
+    rstrip_shell(s::AbstractString)
+
+Strip trailing whitespace from a shell command string, while respecting a trailing backslash followed by a space ("\\ ").
+
+```jldoctest
+julia> Base.rstrip_shell("echo 'Hello World' \\ ")
+"echo 'Hello World' \\ "
+
+julia> Base.rstrip_shell("echo 'Hello World'    ")
+"echo 'Hello World'"
+```
+"""
 function rstrip_shell(s::AbstractString)
     c_old = nothing
     for (i, c) in Iterators.reverse(pairs(s))
@@ -140,6 +152,21 @@ function shell_parse(str::AbstractString, interpolate::Bool=true;
     return ex, last_arg
 end
 
+"""
+    shell_split(command::AbstractString)
+
+Split a shell command string into its individual components.
+
+# Examples
+```jldoctest
+julia> Base.shell_split("git commit -m 'Initial commit'")
+4-element Vector{String}:
+ "git"
+ "commit"
+ "-m"
+ "Initial commit"
+```
+"""
 function shell_split(s::AbstractString)
     parsed = shell_parse(s, false)[1]
     args = String[]


### PR DESCRIPTION
These were undocumented and I have seen `Base.shell_split` used in
the package ecosystem. This adds some docs for clarity although neither of
these functions are part of Base's exports.
