### PR TITLE
irinterp: Add :leave support

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -177,6 +177,8 @@ function reprocess_instruction!(interp::AbstractInterpreter, inst::Instruction, 
         elseif head === :gc_preserve_begin ||
                head === :gc_preserve_end
             return false
+        elseif head === :leave
+            return false
         else
             error("reprocess_instruction!: unhandled expression found")
         end


### PR DESCRIPTION
We still don't model exceptions, but the :leave expression doesn't participate in type refinement, so adding it here is easy.