### PR TITLE
gc: count bytes allocated for task stacks

### DIFF
--- a/src/gc.h
+++ b/src/gc.h
@@ -476,6 +476,7 @@ void gc_mark_loop_parallel(jl_ptls_t ptls, int master);
 void gc_sweep_pool_parallel(void);
 void gc_free_pages(void);
 void sweep_stack_pools(void);
+size_t total_stack_nbytes(void) JL_NOTSAFEPOINT;
 void jl_gc_debug_init(void);
 
 // GC pages


### PR DESCRIPTION
Should fix https://github.com/JuliaLang/julia/issues/52523.

Still needs some performance assessment to check whether the cost of these `mincore` system calls is prohibitive. We might still be able to do the stack bytes accounting less frequently than in every major collection.