### PR TITLE
test: fix timeout changed by #52461 accidentally

### DIFF
--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -199,7 +199,7 @@ if Sys.isbsd() || Sys.islinux()
             finally
                 closewrite(iob)
             end
-            t = Timer(10) do t
+            t = Timer(120) do t
                 # should be under 10 seconds, so give it 2 minutes then report failure
                 println("KILLING siginfo/sigusr1 test BY PROFILE TEST WATCHDOG\n")
                 kill(p, Base.SIGTERM)


### PR DESCRIPTION
Accidentally changed this when doing some testing of #52461 and accidentally forgot to change this back, causing some failures in CI due to the aggressively short timeout.