### PR TITLE
Be more conservative on memory effects when args are mutable

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -2429,7 +2429,7 @@ function getfield_effects(𝕃::AbstractLattice, argtypes::Vector{Any}, @nospeci
     elseif is_mutation_free_argtype(obj)
         inaccessiblememonly = ALWAYS_TRUE
     else
-        inaccessiblememonly = INACCESSIBLEMEM_OR_ARGMEMONLY
+        inaccessiblememonly = ALWAYS_FALSE
     end
     return Effects(EFFECTS_TOTAL; consistent, nothrow, inaccessiblememonly, noub)
 end

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -484,7 +484,6 @@ function adjust_effects(sv::InferenceState)
         if is_inaccessiblememonly(ipo_effects)
             consistent = ipo_effects.consistent & ~CONSISTENT_IF_INACCESSIBLEMEMONLY
             ipo_effects = Effects(ipo_effects; consistent)
-        elseif is_inaccessiblemem_or_argmemonly(ipo_effects)
         else # `:inaccessiblememonly` is already tainted, there will be no chance to refine this
             ipo_effects = Effects(ipo_effects; consistent=ALWAYS_FALSE)
         end
@@ -493,7 +492,6 @@ function adjust_effects(sv::InferenceState)
         if is_inaccessiblememonly(ipo_effects)
             effect_free = ipo_effects.effect_free & ~EFFECT_FREE_IF_INACCESSIBLEMEMONLY
             ipo_effects = Effects(ipo_effects; effect_free)
-        elseif is_inaccessiblemem_or_argmemonly(ipo_effects)
         else # `:inaccessiblememonly` is already tainted, there will be no chance to refine this
             ipo_effects = Effects(ipo_effects; effect_free=ALWAYS_FALSE)
         end

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -1340,3 +1340,20 @@ end
     end
     return res
 end |> Core.Compiler.is_terminates
+
+const a52531 = Core.Ref(1)
+
+@eval getref52531() = $(QuoteNode(a52531)).x
+
+@test !Core.Compiler.is_consistent(Base.infer_effects(getref52531, ()))
+
+let
+    global set_a52531!, get_a52531
+    _a::Int       = -1
+    set_a52531!(a::Int) = (_a = a; return get_a52531())
+    get_a52531()       = _a
+end
+
+@test get_a52531() == -1
+@test set_a52531!(1) == 1
+@test get_a52531() == 1


### PR DESCRIPTION
So this is a start, but I'm still not satisfied about this, also the same treatment should probably be passed to setfield!. Though I'm not sure if it's also ever going to be valid. `setfield!` requires a mutable argument, so it's never going to be `m`.
The only way I can see this ever being refined if the types are already known is using escape analysis + getfield/setfield. Which I couldn't find if we do.

Fixes https://github.com/JuliaLang/julia/issues/52531