### PR TITLE
Fix docs for Sockets.getaddrinfo()

### DIFF
--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -122,10 +122,20 @@ end
 getalladdrinfo(host::AbstractString) = getalladdrinfo(String(host))
 
 """
-    getaddrinfo(host::AbstractString, IPAddr=IPv4) -> IPAddr
+    getaddrinfo(host::AbstractString, IPAddr) -> IPAddr
 
 Gets the first IP address of the `host` of the specified `IPAddr` type.
-Uses the operating system's underlying getaddrinfo implementation, which may do a DNS lookup.
+Uses the operating system's underlying getaddrinfo implementation, which may do
+a DNS lookup.
+
+# Examples
+```julia-repl
+julia> getaddrinfo("localhost", IPv6)
+ip"::1"
+
+julia> getaddrinfo("localhost", IPv4)
+ip"127.0.0.1"
+```
 """
 function getaddrinfo(host::String, T::Type{<:IPAddr})
     addrs = getalladdrinfo(host)
@@ -137,6 +147,14 @@ function getaddrinfo(host::String, T::Type{<:IPAddr})
     throw(DNSError(host, UV_EAI_NONAME))
 end
 getaddrinfo(host::AbstractString, T::Type{<:IPAddr}) = getaddrinfo(String(host), T)
+
+"""
+    getaddrinfo(host::AbstractString) -> IPAddr
+
+Gets the first available IP address of `host`, which may be either an `IPv4` or
+`IPv6` address. Uses the operating system's underlying getaddrinfo
+implementation, which may do a DNS lookup.
+"""
 function getaddrinfo(host::AbstractString)
     addrs = getalladdrinfo(String(host))
     if !isempty(addrs)


### PR DESCRIPTION
Previously only the two-argument method was documented, which stated that the default type to be returned was IPv4. But that hasn't been true since 2ab654ce5b (#36029), so now both methods are documented and corrected.

I believe this fixes #40306.