### PR TITLE
sroa: Better walk for chained KeyValue

### DIFF
--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1563,6 +1563,18 @@ end
 @test_broken fully_eliminated(persistent_dict_elim_multiple)
 @test code_typed(persistent_dict_elim_multiple)[1][1].code[end] == Core.ReturnNode(1)
 
+function persistent_dict_elim_multiple_phi(c::Bool)
+    if c
+        a = Base.PersistentDict(:a => 1)
+    else
+        a = Base.PersistentDict(:a => 1)
+    end
+    b = Base.PersistentDict(a, :b => 2)
+    return b[:a]
+end
+@test_broken fully_eliminated(persistent_dict_elim_multiple_phi)
+@test code_typed(persistent_dict_elim_multiple_phi)[1][1].code[end] == Core.ReturnNode(1)
+
 # Test CFG simplify with try/catch blocks
 let code = Any[
         # Block 1


### PR DESCRIPTION
This redoes #52369, to put the walk through tothe chained KeyValue into a more logical place (the definition walking). This way, we automatically inherit correct handling of PhiNodes and ifelse.