### PR TITLE
Exception type: Model intrinsics

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2088,8 +2088,13 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
         rt = abstract_call_builtin(interp, f, arginfo, sv)
         ft = popfirst!(argtypes)
         effects = builtin_effects(𝕃ᵢ, f, argtypes, rt)
+        if effects.nothrow
+            exct = Union{}
+        else
+            exct = builtin_exct(𝕃ᵢ, f, argtypes, rt)
+        end
         pushfirst!(argtypes, ft)
-        return CallMeta(rt, effects.nothrow ? Union{} : Any, effects, NoCallInfo())
+        return CallMeta(rt, exct, effects, NoCallInfo())
     elseif isa(f, Core.OpaqueClosure)
         # calling an OpaqueClosure about which we have no information returns no information
         return CallMeta(typeof(f).parameters[2], Any, Effects(), NoCallInfo())

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -2799,10 +2799,7 @@ function intrinsic_exct(𝕃::AbstractLattice, f::IntrinsicFunction, argtypes::V
 
     if f === Intrinsics.have_fma
         ty, isexact, isconcrete = instanceof_tfunc(argtypes[1], true)
-        if !isconcrete
-            return Union{ErrorException, TypeError}
-        end
-        if !isprimitivetype(ty)
+        if !(isconcrete && isprimitivetype(ty))
             return TypeError
         end
         return Union{}

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -850,6 +850,17 @@ function isabstracttype(@nospecialize(t))
     return isa(t, DataType) && (t.name.flags & 0x1) == 0x1
 end
 
+function is_datatype_layoutopaque(dt::DataType)
+    datatype_nfields(dt) == 0 && !datatype_pointerfree(dt)
+end
+
+function is_valid_intrinsic_elptr(@nospecialize(ety))
+    ety === Any && return true
+    isconcretetype(ety) || return false
+    ety <: Array && return false
+    return !is_datatype_layoutopaque(ety)
+end
+
 """
     Base.issingletontype(T)
 

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -1356,3 +1356,7 @@ end
 @test get_a52531() == -1
 @test set_a52531!(1) == 1
 @test get_a52531() == 1
+
+# pointerref nothrow for invalid pointer
+@test !Core.Compiler.intrinsic_nothrow(Core.Intrinsics.pointerref, Any[Type{Ptr{Vector{Int64}}}, Int, Int])
+@test !Core.Compiler.intrinsic_nothrow(Core.Intrinsics.pointerref, Any[Type{Ptr{T}} where T, Int, Int])

--- a/test/core.jl
+++ b/test/core.jl
@@ -8083,3 +8083,6 @@ function test_try_catch_else()
     end
 end
 @test test_try_catch_else() == 1
+
+# #52433
+@test_throws ErrorException Core.Intrinsics.pointerref(Ptr{Vector{Int64}}(C_NULL), 1, 0)


### PR DESCRIPTION
And then use this model for `nothrow` also (eventually we should just refactor everything to make nothrow just the appropriate query on exct). While we're at it, fix the nothrow model for pointerref/pointerset, which was missing a type check.