### PR TITLE
Log pid of parent process that is running the CI tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,6 +126,7 @@ cd(@__DIR__) do
 
     println("""
         Running parallel tests with:
+          getpid() = $(getpid())
           nworkers() = $(nworkers())
           nthreads() = $(Threads.threadpoolsize())
           Sys.CPU_THREADS = $(Sys.CPU_THREADS)


### PR DESCRIPTION
It wasn't clear to me which process is being killed here given the pid (493) doesn't match any workers, so I guess it's the parent. So query that at the start.
```
Test       (Worker) | Time (s) | GC (s) | GC % | Alloc (MB) | RSS (MB)
download        (3) |        started at 2023-12-15T06:53:19.236 on pid 579
Artifacts       (5) |        started at 2023-12-15T06:53:19.515 on pid 621
LibGit2/online  (4) |        started at 2023-12-15T06:53:19.583 on pid 599
Downloads       (6) |        started at 2023-12-15T06:53:19.583 on pid 642
LazyArtifacts   (7) |        started at 2023-12-15T06:53:19.583 on pid 662
Pkg             (2) |        started at 2023-12-15T06:53:19.584 on pid 557
      From worker 2:	┌ Info: Pkg test output is being logged to file
      From worker 2:	└   logfile = "/tmp/jl_xJZVU5/Pkg.log"
LazyArtifacts   (7) |    15.01 |   0.11 |  0.8 |     183.51 |   473.43
Artifacts       (5) |    18.16 |   0.11 |  0.6 |     366.84 |   521.54
LibGit2/online  (4) |    24.16 |   0.12 |  0.5 |     189.73 |   451.09
download        (3) |    32.45 |   0.00 |  0.0 |       9.86 |   405.11
Downloads       (6) |    82.58 |   0.22 |  0.3 |     248.04 |   685.46
Process failed to exit within 2700s, requesting termination (SIGTERM) of PID 493.
Sent SIGTERM to PID 493.
```