### PR TITLE
Fix ?(#TAB method search name exploration

### DIFF
--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -142,6 +142,10 @@ let ex = quote
         struct WeirdNames end
         Base.propertynames(::WeirdNames) = (Symbol("oh no!"), Symbol("oh yes!"))
 
+        # https://github.com/JuliaLang/julia/issues/52551#issuecomment-1858543413
+        export exported_symbol
+        exported_symbol(::WeirdNames) = nothing
+
         end # module CompletionFoo
         test_repl_comp_dict = CompletionFoo.test_dict
         test_repl_comp_customdict = CompletionFoo.test_customdict
@@ -741,6 +745,9 @@ end
 @test test_complete("CompletionFoo.?()") == test_complete("CompletionFoo.?(;)")
 
 #TODO: @test_nocompletion("CompletionFoo.?(3; len2=5; ")
+
+# https://github.com/JuliaLang/julia/issues/52551
+@test !isempty(test_complete("?("))
 
 #################################################################
 


### PR DESCRIPTION
Fix #52551.

This PR ensures that a `SomeModule.?(...#TAB` completion can only suggests method `foo` such that `SomeModule.foo` exists (by checking `isdefined(SomeModule, :foo)`). This is equivalent, I believe, to the initial implementation of https://github.com/JuliaLang/julia/pull/38791, less the bug.

Now that we have #51345, we may want to relax the above condition somewhat to include public names present in modules loaded into `SomeModule`, so that, for instance, a direct completion of `?(` would include `@assume_effects`. This could be good for method exploration because even though typing `@assume_effects` with no qualification in `Main` will error, the error now includes the helpful message
```
Hint: a global variable of this name also exists in Base.
```
But that can wait for a later PR anyway, this one is just the bugfix.

The bug mentioned at https://github.com/JuliaLang/julia/issues/52551#issuecomment-1858543413 dates from the initial #38791 so this could be backported as far back as v1.8.