### PR TITLE
Disambiguate `cconvert(::Ptr, ::MyType)`

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -589,9 +589,11 @@ Neither `convert` nor `cconvert` should take a Julia object and turn it into a `
 """
 function cconvert end
 
-cconvert(T::Type, x) = x isa T ? x : convert(T, x) # do the conversion eagerly in most cases
-cconvert(::Type{Union{}}, x...) = convert(Union{}, x...)
-cconvert(::Type{<:Ptr}, x) = x # but defer the conversion to Ptr to unsafe_convert
+cconvert(T::Type, x) = _cconvert(T, x)
+# Specialize on the types in _cconvert to avoid ambiguities if packages define cconvert(T::Type, ::MyType)
+_cconvert(T::Type, x) = x isa T ? x : convert(T, x) # do the conversion eagerly in most cases
+_cconvert(::Type{Union{}}, x...) = convert(Union{}, x...)
+_cconvert(::Type{<:Ptr}, x) = x # but defer the conversion to Ptr to unsafe_convert
 unsafe_convert(::Type{T}, x::T) where {T} = x # unsafe_convert (like convert) defaults to assuming the convert occurred
 unsafe_convert(::Type{T}, x::T) where {T<:Ptr} = x  # to resolve ambiguity with the next method
 unsafe_convert(::Type{P}, x::Ptr) where {P<:Ptr} = convert(P, x)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1910,5 +1910,5 @@ end
     Base.cconvert(T::Type, M::MyArray) = Base.cconvert(T, M.x)
     a = Float64[1,2]
     ma = MyArray(a)
-    @test pointer(ma) === pointer(a)
+    @test Base.cconvert(Ptr{Float64}, ma) === Base.cconvert(Ptr{Float64}, a)
 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1900,3 +1900,15 @@ f45952(x) = [x;;]
     @test_throws "invalid index: true of type Bool" isassigned(A, 1, true)
     @test_throws "invalid index: true of type Bool" isassigned(A, true)
 end
+
+@testset "cconvert(::Ptr, ::MyArray) ambiguity" begin
+    struct MyArray <: AbstractVector{Float64}
+       x :: Vector{Float64}
+    end
+    Base.size(M::MyArray) = size(M.x)
+    Base.getindex(M::MyArray, i::Int) = getindex(M.x, i::Int)
+    Base.cconvert(T::Type, M::MyArray) = Base.cconvert(T, M.x)
+    a = Float64[1,2]
+    ma = MyArray(a)
+    @test pointer(ma) === pointer(a)
+end


### PR DESCRIPTION
The following currently leads to a method ambiguity:
```julia
julia> struct MyArray <: AbstractVector{Float64}
           x :: Vector{Float64}
       end

julia> Base.size(M::MyArray) = size(M.x)

julia> Base.getindex(M::MyArray, i::Int) = M.x[i]

julia> Base.cconvert(T::Type, M::MyArray) = Base.cconvert(T, M.x)

julia> pointer(MyArray([1.0]))
ERROR: MethodError: cconvert(::Type{Ptr{Float64}}, ::MyArray) is ambiguous.

Candidates:
  cconvert(::Type{<:Ptr}, x)
    @ Base essentials.jl:594
  cconvert(T::Type, M::MyArray)
    @ Main REPL[4]:1

Possible fix, define
  cconvert(::Type{<:Ptr}, ::MyArray)

Stacktrace:
 [1] pointer(x::MyArray)
   @ Base ./abstractarray.jl:1255
 [2] top-level scope
   @ REPL[5]:1
```
Requiring packages to define `cconvert(::Type{<:Ptr}, ::MyArray)` seems unwise, as the docstring for `cconvert` states that "Neither `convert` nor `cconvert` should take a Julia object and turn it into a `Ptr`.". This PR fixes the ambiguity, so that we now obtain
```julia
julia> pointer(MyArray([1.0]))
Ptr{Float64} @0x00007f98ea5dd800
```