### PR TITLE
Fix GC rooting during rehashing of iddict

### DIFF
--- a/src/iddict.c
+++ b/src/iddict.c
@@ -15,10 +15,11 @@ JL_DLLEXPORT jl_genericmemory_t *jl_idtable_rehash(jl_genericmemory_t *a, size_t
     size_t sz = a->length;
     size_t i;
     jl_value_t **ol = (jl_value_t **) a->ptr;
-    jl_genericmemory_t *newa = jl_alloc_memory_any(newsz);
+    jl_genericmemory_t *newa = NULL;
     // keep the original memory in the original slot since we need `ol`
     // to be valid in the loop below.
     JL_GC_PUSH2(&newa, &a);
+    newa = jl_alloc_memory_any(newsz);
     for (i = 0; i < sz; i += 2) {
         if (ol[i + 1] != NULL) {
             jl_table_assign_bp(&newa, ol[i], ol[i + 1]);

--- a/src/iddict.c
+++ b/src/iddict.c
@@ -23,8 +23,6 @@ JL_DLLEXPORT jl_genericmemory_t *jl_idtable_rehash(jl_genericmemory_t *a, size_t
     for (i = 0; i < sz; i += 2) {
         if (ol[i + 1] != NULL) {
             jl_table_assign_bp(&newa, ol[i], ol[i + 1]);
-            // it is however necessary here because allocation
-            // can (and will) occur in a recursive call inside table_lookup_bp
         }
     }
     JL_GC_POP();


### PR DESCRIPTION
Should fix #52558. `a` should be rooted before the alloc call. I removed the comment as it seemed to refer to a write barrier that was removed long ago.