### PR TITLE
Specialize `fill!` for `Lower`/`UpperTriangular`

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -295,16 +295,16 @@ end
 end
 
 @propagate_inbounds function fill!(A::UpperTriangular, x)
-    iszero(x) || throw(ArgumentError("cannot set index in the lower triangular part " *
-            "($i, $j) of an UpperTriangular matrix to a nonzero value ($x)"))
+    iszero(x) || throw(ArgumentError("cannot set indices in the lower triangular part " *
+            "of an UpperTriangular matrix to a nonzero value ($x)"))
     for col in axes(A,2), row in firstindex(A,1):col
         A.data[row, col] = x
     end
     A
 end
 @propagate_inbounds function fill!(A::LowerTriangular, x)
-    iszero(x) || throw(ArgumentError("cannot set index in the upper triangular part " *
-            "($i, $j) of a LowerTriangular matrix to a nonzero value ($x)"))
+    iszero(x) || throw(ArgumentError("cannot set indices in the upper triangular part " *
+            "of a LowerTriangular matrix to a nonzero value ($x)"))
     for col in axes(A,2), row in col:lastindex(A,1)
         A.data[row, col] = x
     end

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -294,19 +294,19 @@ end
     return A
 end
 
-@inline function fill!(A::UpperTriangular, x)
+@propagate_inbounds function fill!(A::UpperTriangular, x)
     iszero(x) || throw(ArgumentError("cannot set index in the lower triangular part " *
             "($i, $j) of an UpperTriangular matrix to a nonzero value ($x)"))
     for col in axes(A,2), row in firstindex(A,1):col
-        @inbounds A.data[row, col] = x
+        A.data[row, col] = x
     end
     A
 end
-@inline function fill!(A::LowerTriangular, x)
+@propagate_inbounds function fill!(A::LowerTriangular, x)
     iszero(x) || throw(ArgumentError("cannot set index in the upper triangular part " *
             "($i, $j) of a LowerTriangular matrix to a nonzero value ($x)"))
     for col in axes(A,2), row in col:lastindex(A,1)
-        @inbounds A.data[row, col] = x
+        A.data[row, col] = x
     end
     A
 end

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -294,19 +294,19 @@ end
     return A
 end
 
-@propagate_inbounds function fill!(A::UpperTriangular, x)
+@inline function fill!(A::UpperTriangular, x)
     iszero(x) || throw(ArgumentError("cannot set indices in the lower triangular part " *
             "of an UpperTriangular matrix to a nonzero value ($x)"))
     for col in axes(A,2), row in firstindex(A,1):col
-        A.data[row, col] = x
+        @inbounds A.data[row, col] = x
     end
     A
 end
-@propagate_inbounds function fill!(A::LowerTriangular, x)
+@inline function fill!(A::LowerTriangular, x)
     iszero(x) || throw(ArgumentError("cannot set indices in the upper triangular part " *
             "of a LowerTriangular matrix to a nonzero value ($x)"))
     for col in axes(A,2), row in col:lastindex(A,1)
-        A.data[row, col] = x
+        @inbounds A.data[row, col] = x
     end
     A
 end

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -294,6 +294,22 @@ end
     return A
 end
 
+@inline function fill!(A::UpperTriangular, x)
+    iszero(x) || throw(ArgumentError("cannot set index in the lower triangular part " *
+            "($i, $j) of an UpperTriangular matrix to a nonzero value ($x)"))
+    for col in axes(A,2), row in firstindex(A,1):col
+        @inbounds A.data[row, col] = x
+    end
+    A
+end
+@inline function fill!(A::LowerTriangular, x)
+    iszero(x) || throw(ArgumentError("cannot set index in the upper triangular part " *
+            "($i, $j) of a LowerTriangular matrix to a nonzero value ($x)"))
+    for col in axes(A,2), row in col:lastindex(A,1)
+        @inbounds A.data[row, col] = x
+    end
+    A
+end
 
 ## structured matrix methods ##
 function Base.replace_in_print_matrix(A::Union{UpperTriangular,UnitUpperTriangular},

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -189,7 +189,7 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
 
         # zero
         if A1 isa UpperTriangular || A1 isa LowerTriangular
-            @test zero(A1) == zero(Matrix(A1))
+            @test zero(A1) == zero(parent(A1))
         end
 
         # Unary operations

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -187,6 +187,11 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
         @test imag(A1) == imag(Matrix(A1))
         @test abs.(A1) == abs.(Matrix(A1))
 
+        # zero
+        if A1 isa UpperTriangular || A1 isa LowerTriangular
+            @test zero(A1) == zero(Matrix(A1))
+        end
+
         # Unary operations
         @test -A1 == -Matrix(A1)
 


### PR DESCRIPTION
Only looping over the triangular part provides a performance boost:
```julia
julia> U = UpperTriangular(rand(3000,3000));

julia> @btime zero($U);
  23.575 ms (3 allocations: 68.66 MiB) # master
  15.739 ms (3 allocations: 68.66 MiB) # PR
```
This is only really applicable when filling a triangular matrix with zeros, but this has several applications (e.g. imaginary part of a real matrix).