### PR TITLE
Improve API for jl_method_lookup_by_tt

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1315,6 +1315,15 @@ function method_instances(@nospecialize(f), @nospecialize(t), world::UInt)
     return results
 end
 
+function method_instance(@nospecialize(f), @nospecialize(t);
+                         world=Base.get_world_counter(), method_table=nothing)
+    tt = signature_type(f, t)
+    mi = ccall(:jl_method_lookup_by_tt, Any,
+                (Any, Csize_t, Any),
+                tt, world, method_table)
+    return mi::Union{Nothing, MethodInstance}
+end
+
 default_debug_info_kind() = unsafe_load(cglobal(:jl_default_debug_info_kind, Cint))
 
 # this type mirrors jl_cgparams_t (documented in julia.h)

--- a/src/gf.c
+++ b/src/gf.c
@@ -2244,7 +2244,7 @@ static jl_tupletype_t *lookup_arg_type_tuple(jl_value_t *arg1 JL_PROPAGATES_ROOT
     return jl_lookup_arg_tuple_type(arg1, args, nargs, 1);
 }
 
-JL_DLLEXPORT jl_method_instance_t *jl_method_lookup_by_tt(jl_tupletype_t *tt, size_t world, jl_value_t *_mt)
+JL_DLLEXPORT jl_value_t *jl_method_lookup_by_tt(jl_tupletype_t *tt, size_t world, jl_value_t *_mt)
 {
     jl_methtable_t *mt = NULL;
     if (_mt == jl_nothing)
@@ -2253,7 +2253,10 @@ JL_DLLEXPORT jl_method_instance_t *jl_method_lookup_by_tt(jl_tupletype_t *tt, si
         assert(jl_isa(_mt, (jl_value_t*)jl_methtable_type));
         mt = (jl_methtable_t*) _mt;
     }
-    return jl_mt_assoc_by_type(mt, tt, world);
+    jl_method_instance_t* mi = jl_mt_assoc_by_type(mt, tt, world);
+    if (!mi)
+        return jl_nothing;
+    return (jl_value_t*) mi;
 }
 
 JL_DLLEXPORT jl_method_instance_t *jl_method_lookup(jl_value_t **args, size_t nargs, size_t world)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -777,7 +777,7 @@ JL_DLLEXPORT int jl_is_toplevel_only_expr(jl_value_t *e) JL_NOTSAFEPOINT;
 jl_value_t *jl_call_scm_on_ast_and_loc(const char *funcname, jl_value_t *expr,
                                        jl_module_t *inmodule, const char *file, int line);
 
-JL_DLLEXPORT jl_method_instance_t *jl_method_lookup_by_tt(jl_tupletype_t *tt, size_t world, jl_value_t *_mt);
+JL_DLLEXPORT jl_value_t *jl_method_lookup_by_tt(jl_tupletype_t *tt, size_t world, jl_value_t *_mt);
 JL_DLLEXPORT jl_method_instance_t *jl_method_lookup(jl_value_t **args, size_t nargs, size_t world);
 
 jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value_t **args, size_t nargs);

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1006,8 +1006,9 @@ end
 
 @testset "lookup mi" begin
     @test 1+1 == 2
-    mi1 = @ccall jl_method_lookup_by_tt(Tuple{typeof(+), Int, Int}::Any, Base.get_world_counter()::Csize_t, nothing::Any)::Ref{Core.MethodInstance}
+    mi1 = Base.method_instance(+, (Int, Int))
     @test mi1.def.name == :+
+    # Note `jl_method_lookup` doesn't returns CNull if not found
     mi2 = @ccall jl_method_lookup(Any[+, 1, 1]::Ptr{Any}, 3::Csize_t, Base.get_world_counter()::Csize_t)::Ref{Core.MethodInstance}
     @test mi1 == mi2
 end


### PR DESCRIPTION
@vtjnash what is the right Julia side query to provide an error for:

```
julia> Base.method_instance(basic_callee, (Any,))
julia: /home/vchuravy/src/julia/src/gf.c:1472: jl_mt_assoc_by_type: Assertion `tt->isdispatchtuple || tt->hasfreetypevars' failed.

[81960] signal 6 (-6): Aborted
in expression starting at REPL[3]:1
unknown function (ip: 0x7f3affa1683c)
raise at /usr/lib/libc.so.6 (unknown line)
abort at /usr/lib/libc.so.6 (unknown line)
unknown function (ip: 0x7f3aff9ae3db)
__assert_fail at /usr/lib/libc.so.6 (unknown line)
jl_mt_assoc_by_type at /home/vchuravy/src/julia/src/gf.c:1472
ijl_method_lookup_by_tt at /home/vchuravy/src/julia/src/gf.c:2232
#method_instance#23 at ./reflection.jl:1321 [inlined]
method_instance at ./reflection.jl:1318
```
