### PR TITLE
Add accessor for determining if field is stored as a pointer

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -411,6 +411,11 @@ JL_DLLEXPORT int jl_stored_inline(jl_value_t *eltype)
     return jl_islayout_inline(eltype, &fsz, &al);
 }
 
+JL_DLLEXPORT int jl_field_stored_ptr(jl_datatype_t *st, int i)
+{
+    return jl_field_isptr(st, i) != 0;
+}
+
 // whether instances of this type can use pointer comparison for `===`
 int jl_pointer_egal(jl_value_t *t)
 {


### PR DESCRIPTION
This is necessary within Enzyme (and likely other GPUCompiler-family) code for determining how to access data within a struct, in particular whether or not a field is boxed. This information is not available within isallocatedinline since that type itself may be inline, but only boxed as a field of an outer type.

For example, within:
```
@with_kw mutable struct mso_params_ops1{F<:Function}

    T::Int               # Total steps to integrate 
    t::Int = 0           # placeholder for current step
    dt::Float64 = 0.001  # timestep

    x::Vector{Float64} = zeros(6)        # placeholder for state vector 
    u::Matrix{Float64} = zeros(6, T+1)   # random forcing (if any), otherwise just leave zero 
    n::Matrix{Float64} = zeros(6, T+1)   # placeholder for noise to add to the data 

    k::Float64 = 30          # spring constant
    r::Float64 = 0.5         # Rayleigh friction coefficient

    q::F                     # forcing function 

    J::Float64 = 0.0         # cost function evaluation 

    data_steps::Vector{Int64}  # the timesteps where data points exist 
    data::Matrix{Float64}

    states::Matrix{Float64}    # placeholder for computed states 
    energy::Matrix{Float64}    # placeholder for computed energy

    A::Matrix{Float64} = zeros(6,6)                            # Time-step (x(t+1) = A x(t))
    B::Matrix{Float64} = diagm([1., 0., 0., 0., 0., 0.])       # Distributes known forcing  
    Gamma::Matrix{Float64} = zeros(6,6)                        # Distrubutes unknown (random) forcing

    E::Matrix{Float64} = zeros(6,6)           # Acts on data vector, generally the identity (e.g. full info on all positions/velocities)

    Q::Matrix{Float64} = zeros(6,6)           # Covariance matrix for unknown (random) forcing
    Q_inv::Float64
    R::Matrix{Float64} = zeros(6,6)           # Covariance matrix for noise in data
    R_inv::Matrix{Float64}                    # Inverse of operator R

    K::Matrix{Float64} = zeros(6,6)           # Placeholder for Kalman gain matrix 
    Kc::Matrix{Float64} = zeros(6,6)     

end

if q is itself a closure over a float
```

Please backport this so one can avoid having to write a bunch of manual sizeof for eah julia version to get this manually from the datalayout.