### PR TITLE
Additional Phi node semantics details for ssair docs

### DIFF
--- a/doc/src/devdocs/ssair.md
+++ b/doc/src/devdocs/ssair.md
@@ -83,6 +83,14 @@ may assume that any use of a Phi node will have an assigned value in the corresp
 for the mapping to be incomplete, i.e. for a Phi node to have missing incoming edges. In that case, it must
 be dynamically guaranteed that the corresponding value will not be used.
 
+If multiple Phi nodes appear at the start of a basic block, they are run simultaneously.
+This means that in the following IR snippet, if we came from block `23`, `%46` will take the value associated to
+`%45` _before_ we entered this block.
+```julia
+%45 = φ (#18 => %23, #23 => %50)
+%46 = φ (#18 => 1.0, #23 => %45)
+```
+
 PiNodes encode statically proven information that may be implicitly assumed in basic blocks dominated by a given
 pi node. They are conceptually equivalent to the technique introduced in the paper
 [ABCD: Eliminating Array Bounds Checks on Demand](https://dl.acm.org/citation.cfm?id=358438.349342) or the predicate info nodes in LLVM. To see how they work, consider,

--- a/doc/src/devdocs/ssair.md
+++ b/doc/src/devdocs/ssair.md
@@ -83,7 +83,8 @@ may assume that any use of a Phi node will have an assigned value in the corresp
 for the mapping to be incomplete, i.e. for a Phi node to have missing incoming edges. In that case, it must
 be dynamically guaranteed that the corresponding value will not be used.
 
-If multiple Phi nodes appear at the start of a basic block, they are run simultaneously.
+Note that SSA uses semantically occur after the terminator of the corresponding predecessor ("on the edge").
+Consequently, if multiple Phi nodes appear at the start of a basic block, they are run simultaneously.
 This means that in the following IR snippet, if we came from block `23`, `%46` will take the value associated to
 `%45` _before_ we entered this block.
 ```julia


### PR DESCRIPTION
Following a discussion on slack, I thought I would propose to add this to the docs. I'm very open to changing the form of the explanation, I just wanted to get the point across that "all phi nodes at the start of a basic block run simultaneously".