### PR TITLE
Lowering: Insert QuoteNode for captured boxed value

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3586,7 +3586,7 @@ f(x) = yt(x)
                   (rhs  (convert-for-type-decl rhs1 (cl-convert vt fname lam #f #f #f interp opaq (table) locals) #t lam))
                   (ex (cond (closed `(call (core setfield!)
                                            ,(if interp
-                                                `($ ,var)
+                                                `($ (call (core QuoteNode) ,var))
                                                 (capt-var-access var fname opaq))
                                            (inert contents)
                                            ,rhs))

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -1357,9 +1357,24 @@ end
 @test set_a52531!(1) == 1
 @test get_a52531() == 1
 
+let
+    global is_initialized52531, set_initialized52531
+    _is_initialized = false
+    set_initialized52531(flag::Bool) = (_is_initialized = flag)
+    is_initialized52531()            = _is_initialized
+end
+@test !is_initialized52531()
+@test set_initialized52531(true)
+@test is_initialized52531()
+@test !set_initialized52531(false)
+@test !is_initialized52531()
+foo52531(4)
+@test is_initialized52531()
+
 @test Core.Compiler.is_inaccessiblememonly(Base.infer_effects(identity∘identity, Tuple{Any}))
 @test Core.Compiler.is_inaccessiblememonly(Base.infer_effects(()->Vararg, Tuple{}))
 
 # pointerref nothrow for invalid pointer
 @test !Core.Compiler.intrinsic_nothrow(Core.Intrinsics.pointerref, Any[Type{Ptr{Vector{Int64}}}, Int, Int])
 @test !Core.Compiler.intrinsic_nothrow(Core.Intrinsics.pointerref, Any[Type{Ptr{T}} where T, Int, Int])
+foo52531(x) = (set_initialized52531(true); nothing)

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -1347,9 +1347,9 @@ const a52531 = Core.Ref(1)
 @test !Core.Compiler.is_consistent(Base.infer_effects(getref52531))
 let
     global set_a52531!, get_a52531
-    _a::Int       = -1
+    _a::Int             = -1
     set_a52531!(a::Int) = (_a = a; return get_a52531())
-    get_a52531()       = _a
+    get_a52531()        = _a
 end
 @test !Core.Compiler.is_consistent(Base.infer_effects(set_a52531!, (Int,)))
 @test !Core.Compiler.is_consistent(Base.infer_effects(get_a52531, ()))
@@ -1358,17 +1358,16 @@ end
 @test get_a52531() == 1
 
 let
-    global is_initialized52531, set_initialized52531
-    _is_initialized = false
-    set_initialized52531(flag::Bool) = (_is_initialized = flag)
-    is_initialized52531()            = _is_initialized
+    global is_initialized52531, set_initialized52531!
+    _is_initialized                   = false
+    set_initialized52531!(flag::Bool) = (_is_initialized = flag)
+    is_initialized52531()             = _is_initialized
 end
+top_52531(_) = (set_initialized52531!(true); nothing)
+@test !Core.Compiler.is_consistent(Base.infer_effects(is_initialized52531))
+@test !Core.Compiler.is_removable_if_unused(Base.infer_effects(set_initialized52531!, (Bool,)))
 @test !is_initialized52531()
-@test set_initialized52531(true)
-@test is_initialized52531()
-@test !set_initialized52531(false)
-@test !is_initialized52531()
-foo52531(4)
+top_52531(0)
 @test is_initialized52531()
 
 @test Core.Compiler.is_inaccessiblememonly(Base.infer_effects(identity∘identity, Tuple{Any}))
@@ -1377,4 +1376,3 @@ foo52531(4)
 # pointerref nothrow for invalid pointer
 @test !Core.Compiler.intrinsic_nothrow(Core.Intrinsics.pointerref, Any[Type{Ptr{Vector{Int64}}}, Int, Int])
 @test !Core.Compiler.intrinsic_nothrow(Core.Intrinsics.pointerref, Any[Type{Ptr{T}} where T, Int, Int])
-foo52531(x) = (set_initialized52531(true); nothing)


### PR DESCRIPTION
`Core.Box` is not self-quoting so it should be captured in a QuoteNode.
This has been benign until the improved effect system, we handle `QuoteNode`
of a mutable value as a global access, whereas a direct reference to a value
is treated as inaccessible memory.

Fixes #52531
