### PR TITLE
Don't use `deepcopy_internal(xi, stackdict)` for bits fields

### DIFF
--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -65,7 +65,9 @@ function deepcopy_internal(@nospecialize(x), stackdict::IdDict)
         for i in 1:nf
             if isdefined(x, i)
                 xi = getfield(x, i)
-                !isbits(xi) && (xi = deepcopy_internal(xi, stackdict)::typeof(xi))
+                if !isbits(xi)
+                    xi = deepcopy_internal(xi, stackdict)::typeof(xi)
+                end                
                 ccall(:jl_set_nth_field, Cvoid, (Any, Csize_t, Any), y, i-1, xi)
             end
         end
@@ -76,7 +78,9 @@ function deepcopy_internal(@nospecialize(x), stackdict::IdDict)
         for i in 1:nf
             if isdefined(x, i)
                 xi = getfield(x, i)
-                !isbits(xi) && (xi = deepcopy_internal(xi, stackdict)::typeof(xi))
+                if !isbits(xi)
+                    xi = deepcopy_internal(xi, stackdict)::typeof(xi)
+                end                
                 flds[i] = xi
             else
                 nf = i - 1 # rest of tail must be undefined values

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -65,7 +65,7 @@ function deepcopy_internal(@nospecialize(x), stackdict::IdDict)
         for i in 1:nf
             if isdefined(x, i)
                 xi = getfield(x, i)
-                xi = deepcopy_internal(xi, stackdict)::typeof(xi)
+                !isbits(xi) && (xi = deepcopy_internal(xi, stackdict)::typeof(xi))
                 ccall(:jl_set_nth_field, Cvoid, (Any, Csize_t, Any), y, i-1, xi)
             end
         end
@@ -76,7 +76,7 @@ function deepcopy_internal(@nospecialize(x), stackdict::IdDict)
         for i in 1:nf
             if isdefined(x, i)
                 xi = getfield(x, i)
-                xi = deepcopy_internal(xi, stackdict)::typeof(xi)
+                !isbits(xi) && (xi = deepcopy_internal(xi, stackdict)::typeof(xi))
                 flds[i] = xi
             else
                 nf = i - 1 # rest of tail must be undefined values

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -67,7 +67,7 @@ function deepcopy_internal(@nospecialize(x), stackdict::IdDict)
                 xi = getfield(x, i)
                 if !isbits(xi)
                     xi = deepcopy_internal(xi, stackdict)::typeof(xi)
-                end                
+                end
                 ccall(:jl_set_nth_field, Cvoid, (Any, Csize_t, Any), y, i-1, xi)
             end
         end
@@ -80,7 +80,7 @@ function deepcopy_internal(@nospecialize(x), stackdict::IdDict)
                 xi = getfield(x, i)
                 if !isbits(xi)
                     xi = deepcopy_internal(xi, stackdict)::typeof(xi)
-                end                
+                end
                 flds[i] = xi
             else
                 nf = i - 1 # rest of tail must be undefined values


### PR DESCRIPTION
This gives a good speed-up in some common cases e.g. with my computer on julia 1.10-rc3

```julia
julia> mutable struct A
           x::Int
       end

julia> a = A(1)
A(1)

# before
julia> @benchmark deepcopy($a)
BenchmarkTools.Trial: 10000 samples with 209 evaluations.
 Range (min … max):  370.895 ns …   4.573 μs  ┊ GC (min … max): 0.00% … 83.23%
 Time  (median):     389.206 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   406.474 ns ± 136.334 ns  ┊ GC (mean ± σ):  1.19% ±  3.34%

   ▁▁▆█▆▄▆▅▄▃▂▁                                                 ▂
  ▆█████████████▇▆▆▅▅▅▅▃▃▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▄▆▆▇▇▆▇▆█▇███▇▇▇▇█▇█▇ █
  371 ns        Histogram: log(frequency) by time        596 ns <

 Memory estimate: 352 bytes, allocs estimate: 3.

# this pr
julia> @benchmark deepcopy($a)
BenchmarkTools.Trial: 10000 samples with 964 evaluations.
 Range (min … max):  80.261 ns …  1.642 μs  ┊ GC (min … max): 0.00% … 86.97%
 Time  (median):     87.662 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   96.426 ns ± 77.467 ns  ┊ GC (mean ± σ):  6.20% ±  7.42%

  ▂█▅▆▁                                                        
  █████▄▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▁▁▂▁▁▁▁▁▁▁▁▂▂▂▂▂▂▂▂▂ ▃
  80.3 ns         Histogram: frequency by time         239 ns <

 Memory estimate: 352 bytes, allocs estimate: 3.

julia> mutable struct B
           x::Int
           y::Float64
       end

julia> b = B(1, 1.0)
B(1, 1.0)

# before
julia> @benchmark deepcopy($b)
BenchmarkTools.Trial: 10000 samples with 153 evaluations.
 Range (min … max):  699.569 ns …   9.972 μs  ┊ GC (min … max): 0.00% … 89.92%
 Time  (median):     723.804 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   738.515 ns ± 222.079 ns  ┊ GC (mean ± σ):  0.93% ±  2.94%

      ▂▇█▁                                                       
  ▂▂▂▃████▆▅▄▅▇▆▅▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▁▁▂▁▁▁▁▂▁▂▁▁▁▁▁▁▂▁▁▂▁▂▁▂▂▂▂ ▃
  700 ns           Histogram: frequency by time          914 ns <

 Memory estimate: 384 bytes, allocs estimate: 4.

# this pr
julia> @benchmark deepcopy($b)
BenchmarkTools.Trial: 10000 samples with 956 evaluations.
 Range (min … max):   91.535 ns …  1.660 μs  ┊ GC (min … max): 0.00% … 81.91%
 Time  (median):      99.322 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   108.450 ns ± 88.399 ns  ┊ GC (mean ± σ):  6.97% ±  7.82%

         ▁▃██▅▂                                                 
  ▂▂▂▂▃▄▇███████▇▆▅▄▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▁▁▁▂ ▃
  91.5 ns         Histogram: frequency by time          134 ns <

 Memory estimate: 384 bytes, allocs estimate: 4.
```

---

All copy.jl tests pass on my machine