### PR TITLE
Fix typos CI job for PRs that don't edit any files or do edit binary files

### DIFF
--- a/.github/workflows/Typos.yml
+++ b/.github/workflows/Typos.yml
@@ -26,7 +26,7 @@ jobs:
           # This is necessary because the typos command interprets the
           # empty string as "check all files" rather than "check no files".
           if [ -z "$NEW_FILES" ]; then
-            echo "All eddited files were deleted. Skipping typos check."
+            echo "All edited files were deleted. Skipping typos check."
             exit 0
           fi
 

--- a/.github/workflows/Typos.yml
+++ b/.github/workflows/Typos.yml
@@ -54,12 +54,14 @@ jobs:
           old = set()
           with open(sys.argv[1]) as old_file:
             for line in old_file:
-              old.add(json.loads(line)["typo"])
+              j = json.loads(line)
+              if j["type"] == "typo":
+                old.add(j["typo"])
           clean = True
           with open(sys.argv[2]) as new_file:
             for line in new_file:
               new = json.loads(line)
-              if new["typo"] not in old:
+              if new["type"] == "typo" and new["typo"] not in old:
                 if len(new["typo"]) > 6: # Short typos might be false positives. Long are probably real.
                   clean = False
                 print("::warning file={},line={},col={}::perhaps \"{}\" should be \"{}\".".format(

--- a/.github/workflows/Typos.yml
+++ b/.github/workflows/Typos.yml
@@ -23,6 +23,13 @@ jobs:
           OLD_FILES=$(git diff-index --name-only --diff-filter=ad FETCH_HEAD)
           NEW_FILES=$(git diff-index --name-only --diff-filter=d FETCH_HEAD)
 
+          # This is necessary because the typos command interprets the
+          # empty string as "check all files" rather than "check no files".
+          if [ -z "$NEW_FILES" ]; then
+            echo "All eddited files were deleted. Skipping typos check."
+            exit 0
+          fi
+
           mkdir -p "${{ runner.temp }}/typos"
           RELEASE_ASSET_URL="$(
             gh api /repos/crate-ci/typos/releases/latest \
@@ -35,7 +42,12 @@ jobs:
 
           echo -n $NEW_FILES | xargs "${{ runner.temp }}/typos/typos" --format json >> ${{ runner.temp }}/new_typos.jsonl || true
           git checkout FETCH_HEAD -- $OLD_FILES
-          echo -n $OLD_FILES | xargs "${{ runner.temp }}/typos/typos" --format json >> ${{ runner.temp }}/old_typos.jsonl  || true
+          if [ -z "$OLD_FILES" ]; then
+            touch "${{ runner.temp }}/old_typos.jsonl" # No old files, so no old typos.
+          else
+            echo -n $OLD_FILES | xargs "${{ runner.temp }}/typos/typos" --format json >> ${{ runner.temp }}/old_typos.jsonl || true
+          fi
+
 
           python -c '
           import sys, json


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/52599.

Two issues, each fixed by its own commit
1) mis-handling empty sets of "new" and "old" files (e.g. if a PR exclusively adds files, we considered the whole repo's typos to be false positives rather than assuming no false positives)
2) crashing on binary files

These two combined cause crashing on any PR that exclusively adds or exclusively removes files.

The github history is a hot mess but the git history should be pristine.