### PR TITLE
sroa: More fixes for KeyValue optimization

### DIFF
--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1575,6 +1575,18 @@ end
 @test_broken fully_eliminated(persistent_dict_elim_multiple_phi)
 @test code_typed(persistent_dict_elim_multiple_phi)[1][1].code[end] == Core.ReturnNode(1)
 
+function persistent_dict_elim_multiple_phi2(c::Bool)
+    z = Base.inferencebarrier(1)::Int
+    if c
+        a = Base.PersistentDict(:a => z)
+    else
+        a = Base.PersistentDict(:a => z)
+    end
+    b = Base.PersistentDict(a, :b => 2)
+    return b[:a]
+end
+@test persistent_dict_elim_multiple_phi2(true) == 1
+
 # Test CFG simplify with try/catch blocks
 let code = Any[
         # Block 1


### PR DESCRIPTION
Fixes some mistakes in #52542 that led to the following issue:
```
function persistent_dict_elim_multiple_phi2(c::Bool)
           z = Base.inferencebarrier(1)::Int
           if c
               a = Base.PersistentDict(:a => z)
           else
               a = Base.PersistentDict(:a => z)
           end
           b = Base.PersistentDict(a, :b => 2)
           return b[:a]
end

julia> persistent_dict_elim_multiple_phi2(true)
ERROR: KeyError: key :a not found
Stacktrace:
 [1] getindex
   @ Base ./dict.jl:1010 [inlined]
 [2] persistent_dict_elim_multiple_phi2(c::Bool)
   @ Main ./REPL[1]:9
 [3] top-level scope
   @ REPL[3]:1
```

i.e. sroa incorrectly thought the value was not found.