### PR TITLE
Mark sorting tests as no longer broken

### DIFF
--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -722,8 +722,8 @@ end
         @test sort(1:n, alg=alg, lt = (i,j) -> v[i]<=v[j]) == perm
     end
     # Broken by the introduction of BracketedSort in #52006 which is unstable
-    @test_broken partialsort(1:n, 172, lt = (i,j) -> v[i]<=v[j]) == perm[172]
-    @test_broken partialsort(1:n, 315:415, lt = (i,j) -> v[i]<=v[j]) == perm[315:415]
+    @test partialsort(1:n, 172, lt = (i,j) -> v[i]<=v[j]) == perm[172]
+    @test partialsort(1:n, 315:415, lt = (i,j) -> v[i]<=v[j]) == perm[315:415]
 
     # lt can be very poorly behaved and sort will still permute its input in some way.
     for alg in safe_algs


### PR DESCRIPTION
This seems to be blocking CI for e.g. https://github.com/JuliaLang/julia/pull/49546 (relevant log [here](https://buildkite.com/julialang/julia-master/builds/31485#018c9191-8147-4344-8533-d2c6b38b96c9)). Not sure where the fix was that landed. 
```julia
julia> @testset "invalid lt (#11429)" begin
           # lt must be a total linear order (e.g. < not <=) so this usage is
           # not allowed. Consequently, none of the behavior tested in this
           # testset is guaranteed to work in future minor versions of Julia.
       
           safe_algs = [InsertionSort, MergeSort, Base.Sort.ScratchQuickSort(), Base.DEFAULT_STABLE, Base.DEFAULT_UNSTABLE]
       
           n = 1000
           v = rand(1:5, n);
           s = sort(v);
       
           # Nevertheless, it still works...
           for alg in safe_algs
               @test sort(v, alg=alg, lt = <=) == s
           end
           @test partialsort(v, 172, lt = <=) == s[172]
           @test partialsort(v, 315:415, lt = <=) == s[315:415]
       
           # ...and it is consistently reverse stable. All these algorithms swap v[i] and v[j]
           # where i < j if and only if lt(o, v[j], v[i]). This invariant holds even for
           # this invalid lt order.
           perm = reverse(sortperm(v, rev=true))
           for alg in safe_algs
               @test sort(1:n, alg=alg, lt = (i,j) -> v[i]<=v[j]) == perm
           end
           # Broken by the introduction of BracketedSort in #52006 which is unstable
           @test partialsort(1:n, 172, lt = (i,j) -> v[i]<=v[j]) == perm[172]
           @test partialsort(1:n, 315:415, lt = (i,j) -> v[i]<=v[j]) == perm[315:415]
       end
Test Summary:       | Pass  Total  Time
invalid lt (#11429) |   14     14  0.6s
Test.DefaultTestSet("invalid lt (#11429)", Any[], 14, false, false, true, 1.703254459992415e9, 1.703254460631963e9, false, "REPL[10]")

```