### PR TITLE
[release-1.10] Backport fix for `show` on `MethodList` when methods are from another module

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -2033,7 +2033,11 @@ function delete_method(m::Method)
 end
 
 function get_methodtable(m::Method)
-    return ccall(:jl_method_get_table, Any, (Any,), m)::Core.MethodTable
+    mt = ccall(:jl_method_get_table, Any, (Any,), m)
+    if mt === nothing
+        return nothing
+    end
+    return mt::Core.MethodTable
 end
 
 """

--- a/test/show.jl
+++ b/test/show.jl
@@ -2630,3 +2630,10 @@ end
     ir = Core.Compiler.complete(compact)
     verify_display(ir)
 end
+
+module Issue49382
+    abstract type Type49382 end
+end
+using .Issue49382
+(::Type{Issue49382.Type49382})() = 1
+@test sprint(show, methods(Issue49382.Type49382)) isa String


### PR DESCRIPTION
This is a backport of #52354 directly to the `release-1.10` branch.