### PR TITLE
cfg_simplify: Add one more check to avoid merging :leave terminator

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -2140,10 +2140,10 @@ function legalize_bb_drop_pred!(ir::IRCode, bb::BasicBlock, bbidx::Int, bbs::Vec
         end
         ir[last_fallthrough_term_ssa] = nothing
         kill_edge!(bbs, last_fallthrough, terminator.dest)
-    elseif isa(terminator, EnterNode)
-        return false
     elseif isa(terminator, GotoNode)
         return true
+    elseif isterminator(terminator)
+        return false
     end
     # Hack, but effective. If we have a predecessor with a fall-through terminator, change the
     # instruction numbering to merge the blocks now such that below processing will properly

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1594,7 +1594,7 @@ let code = Any[
         # Block 2
         EnterNode(4),
         # Block 3
-        Expr(:leave),
+        Expr(:leave, SSAValue(2)),
         # Block 4
         GotoNode(5),
         # Block 5
@@ -1603,7 +1603,7 @@ let code = Any[
     ir = make_ircode(code)
     ir = Core.Compiler.cfg_simplify!(ir)
     Core.Compiler.verify_ir(ir)
-    @test length(ir.cfg.blocks) == 4
+    @test length(ir.cfg.blocks) <= 5
 end
 
 # Test CFG simplify with single predecessor phi node


### PR DESCRIPTION
In #52608, I made `:leave` a proper terminator (we already considered it as such during CFG construction, we just didn't maintain that property in the optimizer). As part of this, I adjusted one place in cfg_simplify to avoid merging blocks that end with non-trivial terminators (previously only EnterNode was considered). Turns out there's another one, so fix that as well.