### PR TITLE
Avoid fallback to scalar indexing in slicing wrapped gpu arrays

### DIFF
--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -332,6 +332,8 @@ IndexStyle(::Type{<:AdjOrTransAbsMat}) = IndexCartesian()
 @propagate_inbounds Base.isassigned(v::AdjOrTransAbsMat, i::Int, j::Int) = isassigned(v.parent, j, i)
 @propagate_inbounds getindex(v::AdjOrTransAbsVec{T}, i::Int) where {T} = wrapperop(v)(v.parent[i-1+first(axes(v.parent)[1])])::T
 @propagate_inbounds getindex(A::AdjOrTransAbsMat{T}, i::Int, j::Int) where {T} = wrapperop(A)(A.parent[j, i])::T
+@propagate_inbounds getindex(A::AdjOrTransAbsMat{T}, ::Colon, j::Int) where {T} = A.parent[j, :] # avoid scalar indexing on gpu
+@propagate_inbounds getindex(A::AdjOrTransAbsMat{T}, i::Int, ::Colon) where {T} = A.parent[:, i] # avoid scalar indexing on gpu
 @propagate_inbounds setindex!(v::AdjOrTransAbsVec, x, i::Int) = (setindex!(v.parent, wrapperop(v)(x), i-1+first(axes(v.parent)[1])); v)
 @propagate_inbounds setindex!(A::AdjOrTransAbsMat, x, i::Int, j::Int) = (setindex!(A.parent, wrapperop(A)(x), j, i); A)
 # AbstractArray interface, additional definitions to retain wrapper over vectors where appropriate

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -332,8 +332,8 @@ IndexStyle(::Type{<:AdjOrTransAbsMat}) = IndexCartesian()
 @propagate_inbounds Base.isassigned(v::AdjOrTransAbsMat, i::Int, j::Int) = isassigned(v.parent, j, i)
 @propagate_inbounds getindex(v::AdjOrTransAbsVec{T}, i::Int) where {T} = wrapperop(v)(v.parent[i-1+first(axes(v.parent)[1])])::T
 @propagate_inbounds getindex(A::AdjOrTransAbsMat{T}, i::Int, j::Int) where {T} = wrapperop(A)(A.parent[j, i])::T
-@propagate_inbounds getindex(A::AdjOrTransAbsMat{T}, ::Colon, j::Int) where {T} = A.parent[j, :] # avoid scalar indexing on gpu
-@propagate_inbounds getindex(A::AdjOrTransAbsMat{T}, i::Int, ::Colon) where {T} = A.parent[:, i] # avoid scalar indexing on gpu
+@propagate_inbounds getindex(A::AdjOrTransAbsMat{T}, ::Colon, j::Int) where {T} = wrapperop(A).(view(A.parent,j, :)) # avoid scalar indexing on gpu
+@propagate_inbounds getindex(A::AdjOrTransAbsMat{T}, i::Int, ::Colon) where {T} = wrapperop(A).(view(A.parent,:, i)) # avoid scalar indexing on gpu
 @propagate_inbounds setindex!(v::AdjOrTransAbsVec, x, i::Int) = (setindex!(v.parent, wrapperop(v)(x), i-1+first(axes(v.parent)[1])); v)
 @propagate_inbounds setindex!(A::AdjOrTransAbsMat, x, i::Int, j::Int) = (setindex!(A.parent, wrapperop(A)(x), j, i); A)
 # AbstractArray interface, additional definitions to retain wrapper over vectors where appropriate

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -128,21 +128,33 @@ end
         @test Adjoint(intmat) == tintmat
         @test Transpose(intvec) == tintvec
         @test Transpose(intmat) == tintmat
+        # test slicing for correctness and type stability, for arrays with concrete real scalar eltype
+        @test @inferred Adjoint(intmat)[:, 1] == tintmat[:,1]
+        @test @inferred Transpose(intmat)[:,1] == tintmat[:,1]
         # implicitly test elementary definitions, for arrays with concrete complex scalar eltype
         @test Adjoint(complexintvec) == acomplexintvec
         @test Adjoint(complexintmat) == acomplexintmat
         @test Transpose(complexintvec) == tcomplexintvec
         @test Transpose(complexintmat) == tcomplexintmat
+        # test slicing for correctness and type stability, for arrays with concrete complex scalar eltype
+        @test @inferred Adjoint(complexintmat)[:,1] == acomplexintmat[:,1]
+        @test @inferred Transpose(complexintmat)[:,1] == tcomplexintmat[:,1]
         # implicitly test elementary definitions, for arrays with concrete real-array eltype
         @test Adjoint(intvecvec) == tintvecvec
         @test Adjoint(intmatmat) == tintmatmat
         @test Transpose(intvecvec) == tintvecvec
         @test Transpose(intmatmat) == tintmatmat
+        # test slicing for correctness and type stability, for arrays with concrete real-array eltype
+        @test @inferred Adjoint(intmatmat)[:,1] == tintmatmat[:,1]
+        @test @inferred Transpose(intmatmat)[:,1] == tintmatmat[:,1]
         # implicitly test elementary definitions, for arrays with concrete complex-array type
         @test Adjoint(complexintvecvec) == acomplexintvecvec
         @test Adjoint(complexintmatmat) == acomplexintmatmat
         @test Transpose(complexintvecvec) == tcomplexintvecvec
         @test Transpose(complexintmatmat) == tcomplexintmatmat
+        # test slicing for correctness and type stability, for arrays with concrete complex-array eltype
+        @test @inferred Adjoint(complexintmatmat)[:,1] == acomplexintmatmat[:,1]
+        @test @inferred Transpose(complexintmatmat)[:,1] == tcomplexintmatmat[:,1]
     end
     @testset "getindex(::AdjOrTransVec, ::Colon, ::AbstractArray{Int}) methods that preserve wrapper type" begin
         # for arrays with concrete scalar eltype


### PR DESCRIPTION
On GPU, wrapper types such as Transpose and Adjoint are missing handling of `::Colon` on `getindex`, leading to fallback to so called scalar indexing which is much slower on GPU (causes memory copying from device to host).

MWE without this fix:
```julia
julia> using LinearAlgebra, JLArrays
julia> JLArrays.allowscalar(false)
julia> x = rand(Float32, 2,2) |> jl ; y = transpose(x);
julia> y[:,1]
ERROR: Scalar indexing is disallowed.
Invocation of getindex resulted in scalar indexing of a GPU array.
This is typically caused by calling an iterating implementation of a method.
Such implementations *do not* execute on the GPU, but very slowly on the CPU,
and therefore should be avoided.

If you want to allow scalar iteration, use `allowscalar` or `@allowscalar`
to enable scalar iteration globally or for the operations in question.
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] errorscalar(op::String)
    @ GPUArraysCore ~/.julia/packages/GPUArraysCore/GMsgk/src/GPUArraysCore.jl:155
  [3] _assertscalar(op::String, behavior::GPUArraysCore.ScalarIndexing)
    @ GPUArraysCore ~/.julia/packages/GPUArraysCore/GMsgk/src/GPUArraysCore.jl:128
  [4] assertscalar(op::String)
    @ GPUArraysCore ~/.julia/packages/GPUArraysCore/GMsgk/src/GPUArraysCore.jl:116
  [5] getindex
    @ ~/.julia/packages/GPUArrays/EoKy0/src/host/indexing.jl:48 [inlined]
  [6] scalar_getindex
    @ ~/.julia/packages/GPUArrays/EoKy0/src/host/indexing.jl:34 [inlined]
  [7] _getindex
    @ ~/.julia/packages/GPUArrays/EoKy0/src/host/indexing.jl:17 [inlined]
  [8] getindex
    @ ~/.julia/packages/GPUArrays/EoKy0/src/host/indexing.jl:15 [inlined]
  [9] getindex
    @ ~/julia/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/adjtrans.jl:334 [inlined]
 [10] macro expansion
    @ ./multidimensional.jl:921 [inlined]
 [11] macro expansion
    @ ./cartesian.jl:64 [inlined]
 [12] _unsafe_getindex!
    @ ./multidimensional.jl:916 [inlined]
 [13] _unsafe_getindex(::IndexCartesian, ::Transpose{Float32, JLArray{Float32, 2}}, ::Base.Slice{Base.OneTo{Int64}}, ::Int64)
    @ Base ./multidimensional.jl:907
 [14] _getindex
    @ Base ./multidimensional.jl:893 [inlined]
 [15] getindex(::Transpose{Float32, JLArray{Float32, 2}}, ::Function, ::Int64)
    @ Base ./abstractarray.jl:1314
 [16] top-level scope
    @ REPL[10]:1
```

After adding the missing path with `::Colon`:
```julia
julia> using LinearAlgebra, JLArrays
julia> JLArrays.allowscalar(false)
julia> x = rand(Float32, 2,2) |> jl ; y = transpose(x);
julia> display(y[:,1])
2-element JLArray{Float32, 1}:
 0.5699245
 0.44491202
julia> y[:,1] == x[1,:]
true
```

Any thoughts and comments are appreciated, as well as directing me to where the equivalent code should be in the case of `PermutedDimsArray` and any other similar cases of interest.