### PR TITLE
Restrict LinearAlgebra.onedefined to concrete number types

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -528,7 +528,7 @@ _droplast!(A) = deleteat!(A, lastindex(A))
 # but we are actually asking for oneunit(T), that is, however, defined for generic T as
 # `T(one(T))`, so the question is equivalent for whether one(T) is defined
 onedefined(::Type) = false
-onedefined(::Type{<:Number}) = true
+onedefined(::Type{T}) where {T<:Number} = isconcretetype(T)
 
 # initialize return array for op(A, B)
 _init_eltype(::typeof(*), ::Type{TA}, ::Type{TB}) where {TA,TB} =

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -861,4 +861,11 @@ end
     @test axes(B) === (ax, ax)
 end
 
+@testset "abstract eltype" begin
+    A = Bidiagonal{Number}(ones(4), ones(3)*im, :U);
+    B = Bidiagonal{ComplexF64}(ones(4), ones(3)*im, :U);
+    v = ones(4)
+    @test A \ v == B \ v
+end
+
 end # module TestBidiagonal


### PR DESCRIPTION
This makes `onedefined` more conservative, so that now
```julia
julia> LinearAlgebra.onedefined(Number)
false

julia> LinearAlgebra.onedefined(Union{Float64,ComplexF64})
false
```
In general, we cannot guarantee that `oneunit` works with abstract or union types. After this, the following contrived example works correctly instead of throwing an error:
```julia
julia> using Symbolics

julia> @variables x
1-element Vector{Num}:
 x

julia> A = Bidiagonal{Real}([1,2], [x], :U)
2×2 Bidiagonal{Real, Vector{Real}}:
 1  x
 ⋅  2

julia> A \ [1,2]
2-element Vector{Any}:
 1 - x
     1.0
``` 
This change widens certain inferred types. E.g., on master:
```julia
julia> Bidiagonal{Number}(ones(4), ones(3), :U) \ ones(4)
4-element Vector{Float64}:
 0.0
 1.0
 0.0
 1.0
``` 
whereas, in this PR, this returns a `Vector{Any}`. This may be acceptable, though, if one starts with abstract types.