### PR TITLE
fix finding bundled stdlibs even if they are e.g. devved in an environment higher in the load path

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -955,7 +955,13 @@ function explicit_manifest_entry_path(manifest_file::String, pkg::PkgId, entry::
         return path
     end
     hash = get(entry, "git-tree-sha1", nothing)::Union{Nothing, String}
-    hash === nothing && return nothing
+    if hash === nothing
+        mbypath = manifest_uuid_path(Sys.STDLIB, pkg)
+        if mbypath isa String
+            return entry_path(mbypath, pkg.name)
+        end
+        return nothing
+    end
     hash = SHA1(hash)
     # Keep the 4 since it used to be the default
     uuid = pkg.uuid::UUID # checked within `explicit_manifest_uuid_path`


### PR DESCRIPTION
I noticed this when seeing some weird precompile issues when I had SparseArrays devved in my main environment but it was with the standard stdlib format in the current environment:

```
(NearestNeighbors) pkg> st -m
Project NearestNeighbors v0.4.15
Status `~/JuliaPkgs/NearestNeighbors.jl/Manifest.toml`
...
  [2f01184e] SparseArrays v1.10.0 
...
```

But even so, `locate_package` claims that the path to SparseArrays is the one in the main environment:

```
julia> pkg = Base.PkgId(Base.UUID("2f01184e-e22b-5df5-ae63-d93ebab69eaf"), "SparseArrays")
SparseArrays [2f01184e-e22b-5df5-ae63-d93ebab69eaf]

julia> Base.locate_package(pkg)
"/home/kc/JuliaPkgs/SparseArrays.jl/src/SparseArrays.jl"
```

This correctly fixes it so that packages without a `git-tree-sha1` (and without a `path`) are resolved to the stdlib path.