### PR TITLE
Add 3-Argument div and rem to documentation

### DIFF
--- a/base/div.jl
+++ b/base/div.jl
@@ -22,6 +22,8 @@ See also [`fld`](@ref) and [`cld`](@ref), which are special cases of this functi
 
 # Examples:
 ```jldoctest
+julia> div(4, 3, RoundToZero) # Matches div(4, 3)
+1
 julia> div(4, 3, RoundDown) # Matches fld(4, 3)
 1
 julia> div(4, 3, RoundUp) # Matches cld(4, 3)

--- a/doc/src/base/math.md
+++ b/doc/src/base/math.md
@@ -14,10 +14,12 @@ Base.fma
 Base.muladd
 Base.inv(::Number)
 Base.div
+Base.div(::Any, ::Any, ::RoundingMode)
 Base.fld
 Base.cld
 Base.mod
 Base.rem
+Base.rem(::Any, ::Any, ::RoundingMode)
 Base.rem2pi
 Base.Math.mod2pi
 Base.divrem


### PR DESCRIPTION
Reference for 3-Argument div and rem added in doc/src/base/math.md

Resolves https://github.com/JuliaLang/julia/issues/52624