### PR TITLE
deps/csl: Use platform-dependent path separator

### DIFF
--- a/deps/csl.mk
+++ b/deps/csl.mk
@@ -1,7 +1,7 @@
 # Interrogate the fortran compiler (which is always GCC based) on where it is keeping its libraries
 STD_LIB_PATH := $(shell LANG=C $(FC) -print-search-dirs 2>/dev/null | grep '^programs: =' | sed -e "s/^programs: =//")
-ifneq (,$(findstring CYGWIN,$(BUILD_OS))) # the cygwin-mingw32 compiler lies about it search directory paths
 STD_LIB_PATH += $(PATHSEP)$(shell LANG=C $(FC) -print-search-dirs 2>/dev/null | grep '^libraries: =' | sed -e "s/^libraries: =//")
+ifeq ($(BUILD_OS),WINNT)  # the mingw compiler lies about it search directory paths
 STD_LIB_PATH := $(shell echo '$(STD_LIB_PATH)' | sed -e "s!/lib/!/bin/!g")
 endif
 

--- a/deps/csl.mk
+++ b/deps/csl.mk
@@ -1,13 +1,13 @@
 # Interrogate the fortran compiler (which is always GCC based) on where it is keeping its libraries
 STD_LIB_PATH := $(shell LANG=C $(FC) -print-search-dirs 2>/dev/null | grep '^programs: =' | sed -e "s/^programs: =//")
-STD_LIB_PATH += :$(shell LANG=C $(FC) -print-search-dirs 2>/dev/null | grep '^libraries: =' | sed -e "s/^libraries: =//")
 ifneq (,$(findstring CYGWIN,$(BUILD_OS))) # the cygwin-mingw32 compiler lies about it search directory paths
+STD_LIB_PATH += $(PATHSEP)$(shell LANG=C $(FC) -print-search-dirs 2>/dev/null | grep '^libraries: =' | sed -e "s/^libraries: =//")
 STD_LIB_PATH := $(shell echo '$(STD_LIB_PATH)' | sed -e "s!/lib/!/bin/!g")
 endif
 
 # Given a colon-separated list of paths in $(2), find the location of the library given in $(1)
 define pathsearch
-$(firstword $(wildcard $(addsuffix /$(1),$(subst :, ,$(2)))))
+$(firstword $(wildcard $(addsuffix /$(1),$(subst $(PATHSEP), ,$(2)))))
 endef
 
 # CSL bundles lots of system compiler libraries, and while it is quite bleeding-edge


### PR DESCRIPTION
When building julia from source in MSYS2, you need to use `;` as a path separator, otherwise you won't be able to find the required DLLs!


## pr changes
- On win, use `;` as path separator
- Always search for DLLs in the `bin/` directory

### test steps
Clean csl first: `make -C deps/ USE_SYSTEM_CSL=1  clean-csl`

Before pr:
```sh
$ make -C deps/ USE_SYSTEM_CSL=1  install-csl
make: Entering directory '/d/jl/julia/deps'
make: [/d/jl/julia/deps/csl.mk:59: /d/jl/julia/usr/bin/libgfortran-3.dll] Error 1 (ignored)
make: [/d/jl/julia/deps/csl.mk:60: /d/jl/julia/usr/bin/libgfortran-4.dll] Error 1 (ignored)
make: [/d/jl/julia/deps/csl.mk:61: /d/jl/julia/usr/bin/libgfortran-5.dll] Error 1 (ignored)
make: [/d/jl/julia/deps/csl.mk:64: /d/jl/julia/usr/bin/libquadmath-0.dll] Error 1 (ignored)
make: [/d/jl/julia/deps/csl.mk:65: /d/jl/julia/usr/bin/libstdc++-6.dll] Error 1 (ignored)
make: [/d/jl/julia/deps/csl.mk:66: /d/jl/julia/usr/bin/libssp-0.dll] Error 1 (ignored)
make: [/d/jl/julia/deps/csl.mk:67: /d/jl/julia/usr/bin/libatomic-1.dll] Error 1 (ignored)
make: [/d/jl/julia/deps/csl.mk:68: /d/jl/julia/usr/bin/libgomp-1.dll] Error 1 (ignored)
make: [/d/jl/julia/deps/csl.mk:75: /d/jl/julia/usr/bin/libgcc_s_seh-1.dll] Error 1 (ignored)
make: [/d/jl/julia/deps/csl.mk:86: /d/jl/julia/usr/bin/libwinpthread-1.dll] Error 1 (ignored)
make: Leaving directory '/d/jl/julia/deps'
```

After pr:
```sh
$ make -C deps/ USE_SYSTEM_CSL=1  install-csl
make: Entering directory '/d/jl/julia/deps'
make: [/d/jl/julia/deps/csl.mk:59: /d/jl/julia/usr/bin/libgfortran-3.dll] Error 1 (ignored)
make: [/d/jl/julia/deps/csl.mk:60: /d/jl/julia/usr/bin/libgfortran-4.dll] Error 1 (ignored)
make: [/d/jl/julia/deps/csl.mk:66: /d/jl/julia/usr/bin/libssp-0.dll] Error 1 (ignored)
make: Leaving directory '/d/jl/julia/deps'
```


## Env

- Win 11
- MSYS2

`STD_LIB_PATH`
```
$ uname -a
MINGW64_NT-10.0-22631 A309-Y9000P 3.4.10.x86_64 2023-11-30 06:09 UTC x86_64 Msys

$ make -C deps/  print-PATHSEP print-STD_LIB_PATH
make: Entering directory '/d/jl/julia/deps'
PATHSEP=;
STD_LIB_PATH=D:/env/msys64/mingw64/bin/../bin/gcc/x86_64-w64-mingw32/13.2.0/;D:/env/msys64/mingw64/bin/../bin/gcc/;D:/env/msys64/mingw64/bin/../bin/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/x86_64-w64-mingw32/13.2.0/;D:/env/msys64/mingw64/bin/../bin/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/ ;D:/env/msys64/mingw64/bin/../bin/gcc/x86_64-w64-mingw32/13.2.0/;D:/env/msys64/mingw64/bin/../bin/gcc/;D:/env/msys64/mingw64/bin/../bin/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/x86_64-w64-mingw32/13.2.0/;D:/env/msys64/mingw64/bin/../bin/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/../bin/;D:/env/msys64/mingw64/bin/../bin/gcc/x86_64-w64-mingw32/13.2.0/../../../x86_64-w64-mingw32/13.2.0/;D:/env/msys64/mingw64/bin/../bin/gcc/x86_64-w64-mingw32/13.2.0/../../../../bin/;D:/a/msys64/mingw64/bin/x86_64-w64-mingw32/13.2.0/;D:/a/msys64/mingw64/bin/../bin/;D:/env/msys64/mingw64/bin/../bin/gcc/x86_64-w64-mingw32/13.2.0/../../../../x86_64-w64-mingw32/bin/;D:/env/msys64/mingw64/bin/../bin/gcc/x86_64-w64-mingw32/13.2.0/../../../;D:/a/msys64/mingw64/bin/
make: Leaving directory '/d/jl/julia/deps'
```


