### PR TITLE
THIRDPARTY: Consider `base/` and `stdlib/` as standard libraries

### DIFF
--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -48,8 +48,8 @@ Julia's `stdlib` uses the following external libraries, which have their own lic
 
 Julia's build process uses the following external tools:
 
-- [PATCHELF](https://nixos.org/patchelf.html)
-- [OBJCONV](https://www.agner.org/optimize/#objconv)
+- [PATCHELF](https://github.com/NixOS/patchelf/blob/master/COPYING) [GPL3]
+- [OBJCONV](https://www.agner.org/optimize/#objconv) [GPL3]
 - [LIBWHICH](https://github.com/vtjnash/libwhich/blob/master/LICENSE) [MIT]
 
 Julia bundles the following external programs and libraries:

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -1,5 +1,5 @@
 The Julia language is licensed under the MIT License (see [LICENSE.md](./LICENSE.md) ). The "language" consists
-of the compiler (the contents of src/), most of the standard library (base/),
+of the compiler (the contents of `src/`), most of the standard library (`base/` and `stdlib/`),
 and some utilities (most of the rest of the files in this repository). See below
 for exceptions.
 

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -27,7 +27,7 @@ own licenses:
 and optionally:
 
 - [LibTracyClient](https://github.com/wolfpld/tracy/blob/master/LICENSE) [BSD-3]
-- [ITTAPI](https://github.com/intel/ittapi/blob/master/LICENSES/BSD-3-Clause.txt) [BSD-3]
+- [ITTAPI](https://github.com/intel/ittapi/tree/master/LICENSES) [BSD-3 AND GPL2]
 
 Julia's `stdlib` uses the following external libraries, which have their own licenses:
 

--- a/THIRDPARTY.md
+++ b/THIRDPARTY.md
@@ -26,6 +26,7 @@ own licenses:
 
 and optionally:
 
+- [LibTracyClient](https://github.com/wolfpld/tracy/blob/master/LICENSE) [BSD-3]
 - [ITTAPI](https://github.com/intel/ittapi/blob/master/LICENSES/BSD-3-Clause.txt) [BSD-3]
 
 Julia's `stdlib` uses the following external libraries, which have their own licenses:

--- a/julia.spdx.json
+++ b/julia.spdx.json
@@ -371,6 +371,32 @@
             "summary": "utf8proc is a small, clean C library that provides Unicode normalization, case-folding, and other operations for data in the UTF-8 encoding."
         },
         {
+            "name": "LibTracyClient",
+            "SPDXID": "SPDXRef-LibTracyClient",
+            "downloadLocation": "git+https://github.com/wolfpld/tracy.git",
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/wolfpld/tracy",
+            "sourceInfo": "The git hash of the version in use can be found in the file deps/libtracyclient.version",
+            "licenseConcluded": "BSD-3-Clause",
+            "licenseDeclared": "BSD-3-Clause",
+            "copyrightText": "Copyright (c) 2017-2024, Bartosz Taudul <wolf@nereid.pl>",
+            "summary": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
+            "comment": "LibTracyClient is an optional dependency that is not built by default"
+        },
+        {
+            "name": "ittapi",
+            "SPDXID": "SPDXRef-ittapi",
+            "downloadLocation": "git+https://github.com/intel/ittapi.git",
+            "filesAnalyzed": false,
+            "homepage": "https://github.com/intel/ittapi",
+            "sourceInfo": "The git hash of the version in use can be found in the file deps/ittapi.version",
+            "licenseConcluded": "BSD-3-Clause AND GPL-2.0-only",
+            "licenseDeclared": "BSD-3-Clause AND GPL-2.0-only",
+            "copyrightText": "Copyright (c) 2019 Intel Corporation",
+            "summary": "The Instrumentation and Tracing Technology (ITT) API enables your application to generate and control the collection of trace data during its execution across different Intel tools.",
+            "comment": "ITTAPI is an optional dependency that is not built by default"
+        },
+        {
             "name": "7-Zip",
             "SPDXID": "SPDXRef-7zip",
             "downloadLocation": "https://sourceforge.net/projects/p7zip/files/p7zip",
@@ -579,6 +605,16 @@
         {
             "spdxElementId": "SPDXRef-utf8proc",
             "relationshipType": "BUILD_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JuliaMain"
+        },
+        {
+            "spdxElementId": "SPDXRef-LibTracyClient",
+            "relationshipType": "OPTIONAL_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JuliaMain"
+        },
+        {
+            "spdxElementId": "SPDXRef-ittapi",
+            "relationshipType": "OPTIONAL_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-JuliaMain"
         },
         {


### PR DESCRIPTION
Changes:
- Consider `base/` and `stdlib/` as standard libraries
- Add optional dep: `LibTracyClient`
- Add license for tools, and update link
- Update spdx.json
