### PR TITLE
Print type signature for what was inferring whenever an error is thrown

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -388,14 +388,15 @@ jl_code_info_t *jl_type_infer(jl_method_instance_t *mi, size_t world, int force)
     }
     JL_CATCH {
         jl_value_t *e = jl_current_exception();
+        jl_printf((JL_STREAM*)STDERR_FILENO, "Internal error during type inference of\n");
+        jl_static_show_func_sig((JL_STREAM*)STDERR_FILENO, (jl_value_t*)mi->specTypes);
+        jl_printf((JL_STREAM*)STDERR_FILENO, "\nEncountered ");
         if (e == jl_stackovf_exception) {
-            jl_printf((JL_STREAM*)STDERR_FILENO, "Internal error: stack overflow in type inference of ");
-            jl_static_show_func_sig((JL_STREAM*)STDERR_FILENO, (jl_value_t*)mi->specTypes);
-            jl_printf((JL_STREAM*)STDERR_FILENO, ".\n");
+            jl_printf((JL_STREAM*)STDERR_FILENO, "stack overflow.\n");
             jl_printf((JL_STREAM*)STDERR_FILENO, "This might be caused by recursion over very long tuples or argument lists.\n");
         }
         else {
-            jl_printf((JL_STREAM*)STDERR_FILENO, "Internal error: encountered unexpected error in runtime:\n");
+            jl_printf((JL_STREAM*)STDERR_FILENO, "unexpected error in runtime:\n");
             jl_static_show((JL_STREAM*)STDERR_FILENO, e);
             jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
             jlbacktrace(); // written to STDERR_FILENO

--- a/src/gf.c
+++ b/src/gf.c
@@ -388,7 +388,7 @@ jl_code_info_t *jl_type_infer(jl_method_instance_t *mi, size_t world, int force)
     }
     JL_CATCH {
         jl_value_t *e = jl_current_exception();
-        jl_printf((JL_STREAM*)STDERR_FILENO, "Internal error during type inference of\n");
+        jl_printf((JL_STREAM*)STDERR_FILENO, "Internal error: during type inference of\n");
         jl_static_show_func_sig((JL_STREAM*)STDERR_FILENO, (jl_value_t*)mi->specTypes);
         jl_printf((JL_STREAM*)STDERR_FILENO, "\nEncountered ");
         if (e == jl_stackovf_exception) {


### PR DESCRIPTION
From discussion on slack with Keno.
When something is going wrong with inference it is always good to know what we were trying to infer.


Example of new output for nonstack-overflow case (what I am dealing with in the wild)
```julia
Internal error: during type inference of
(::Diffractor.∂☆recurse{1})(Diffractor.TangentBundle{1, Diffractor.∂☆{1}, Diffractor.UniformTangent{ChainRulesCore.NoTangent}}, Diffractor.TangentBundle{1, Diffractor.TangentBundle{1, typeof(Core.apply_type), Diffractor.UniformTangent{ChainRulesCore.NoTangent}}, Diffractor.TaylorTangent{Tuple{ChainRulesCore.Tangent{Diffractor.TangentBundle{1, typeof(Core.apply_type), Diffractor.UniformTangent{ChainRulesCore.NoTangent}}, NamedTuple{(:primal, :tangent), Tuple{ChainRulesCore.NoTangent, ChainRulesCore.Tangent{Diffractor.UniformTangent{ChainRulesCore.NoTangent}, NamedTuple{(:val,), Tuple{ChainRulesCore.NoTangent}}}}}}}}}, Diffractor.TangentBundle{1, Diffractor.TangentBundle{1, Type{Base.Val{x} where x}, Diffractor.UniformTangent{ChainRulesCore.NoTangent}}, Diffractor.TaylorTangent{Tuple{ChainRulesCore.Tangent{Diffractor.TangentBundle{1, Type{Base.Val{x} where x}, Diffractor.UniformTangent{ChainRulesCore.NoTangent}}, NamedTuple{(:primal, :tangent), Tuple{ChainRulesCore.NoTangent, ChainRulesCore.Tangent{Diffractor.UniformTangent{ChainRulesCore.NoTangent}, NamedTuple{(:val,), Tuple{ChainRulesCore.NoTangent}}}}}}}}}, Diffractor.TangentBundle{1, Diffractor.TangentBundle{1, Int64, Diffractor.TaylorTangent{Tuple{Int64}}}, Diffractor.TaylorTangent{Tuple{ChainRulesCore.Tangent{Diffractor.TangentBundle{1, Int64, Diffractor.TaylorTangent{Tuple{Int64}}}, NamedTuple{(:primal, :tangent), Tuple{Int64, ChainRulesCore.Tangent{Diffractor.TaylorTangent{Tuple{Int64}}, NamedTuple{(:coeffs,), Tuple{ChainRulesCore.Tangent{Tuple{Int64}, Tuple{Int64}}}}}}}}}}})
Encountered unexpected error in runtime:
MethodError(f=Core.Compiler.:(⊑), args=(Core.Compiler.JLTypeLattice(), Vararg{Any}, Symbol), world=0x00000000000016ae)
jl_method_error_bare at /usr/local/src/julia-crimes/src/gf.c:2216
jl_method_error at /usr/local/src/julia-crimes/src/gf.c:2234
jl_lookup_generic_ at /usr/local/src/julia-crimes/src/gf.c:3079 [inlined]
ijl_apply_generic at /usr/local/src/julia-crimes/src/gf.c:3094
⊑ at ./compiler/typelattice.jl:530
⊑ at ./compiler/typelattice.jl:508
⊑ at ./compiler/typelattice.jl:432 [inlined]
⊑ at ./compiler/typelattice.jl:397
#366 at ./compiler/abstractlattice.jl:288 [inlined]
typevar_nothrow at ./compiler/tfuncs.jl:613 [inlined]
_builtin_nothrow at ./compiler/tfuncs.jl:2180
builtin_nothrow at ./compiler/tfuncs.jl:2605 [inlined]
builtin_effects at ./compiler/tfuncs.jl:2523
abstract_call_known at ./compiler/abstractinterpretation.jl:2122
abstract_call at ./compiler/abstractinterpretation.jl:2250
abstract_apply at ./compiler/abstractinterpretation.jl:1664
abstract_call_known at ./compiler/abstractinterpretation.jl:2076
abstract_call at ./compiler/abstractinterpretation.jl:2250
abstract_call at ./compiler/abstractinterpretation.jl:2243
abstract_call at ./compiler/abstractinterpretation.jl:2401
abstract_eval_call at ./compiler/abstractinterpretation.jl:2416
...
```

