### PR TITLE
Implement the standard logging levels with same logic as custom log levels

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -132,6 +132,9 @@ isless(a::LogLevel, b::LogLevel) = isless(a.level, b.level)
 -(level::LogLevel, inc::Integer) = LogLevel(level.level-inc)
 convert(::Type{LogLevel}, level::Integer) = LogLevel(level)
 
+# stored as LogLevel => (name, color)
+const _log_levels = Dict{LogLevel,Tuple{Symbol,Union{Symbol,Int,Nothing}}}()
+
 const BelowMinLevel = LogLevel(-1000001)
 """
     Debug
@@ -139,41 +142,44 @@ const BelowMinLevel = LogLevel(-1000001)
 Alias for [`LogLevel(-1000)`](@ref LogLevel).
 """
 const Debug         = LogLevel(   -1000)
+_log_levels[Debug] = (:Debug, nothing)
+
 """
     Info
 
 Alias for [`LogLevel(0)`](@ref LogLevel).
 """
 const Info          = LogLevel(       0)
+_log_levels[Info] = (:Info, nothing)
+
 """
     Warn
 
 Alias for [`LogLevel(1000)`](@ref LogLevel).
 """
 const Warn          = LogLevel(    1000)
+_log_levels[Warn] = (:Warn, nothing)
+
 """
     Error
 
 Alias for [`LogLevel(2000)`](@ref LogLevel).
 """
 const Error         = LogLevel(    2000)
+_log_levels[Error] = (:Error, nothing)
+
 const AboveMaxLevel = LogLevel( 1000001)
+_log_levels[AboveMaxLevel] = (:AboveMaxLevel, nothing)
 
 # Global log limiting mechanism for super fast but inflexible global log limiting.
 const _min_enabled_level = Ref{LogLevel}(Debug)
 
-# stored as LogLevel => (name, color)
-const custom_log_levels = Dict{LogLevel,Tuple{Symbol,Union{Symbol,Int}}}()
 
 function show(io::IO, level::LogLevel)
-    if     haskey(custom_log_levels, level) print(io, custom_log_levels[level][1])
-    elseif level == BelowMinLevel           print(io, "BelowMinLevel")
-    elseif level == Debug                   print(io, "Debug")
-    elseif level == Info                    print(io, "Info")
-    elseif level == Warn                    print(io, "Warn")
-    elseif level == Error                   print(io, "Error")
-    elseif level == AboveMaxLevel           print(io, "AboveMaxLevel")
-    else                                    print(io, "LogLevel($(level.level))")
+    if haskey(_log_levels, level)
+        print(io, _log_levels[level][1])
+    else
+        print(io, "LogLevel($(level.level))")
     end
 end
 

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -58,11 +58,16 @@ end
 showvalue(io, ex::Exception) = showerror(io, ex)
 
 function default_logcolor(level::LogLevel)
-    level in keys(custom_log_levels) ? custom_log_levels[level][2] :
-    level < Info  ? Base.debug_color() :
-    level < Warn  ? Base.info_color()  :
-    level < Error ? Base.warn_color()  :
-                    Base.error_color()
+    color = get(_log_levels, level, nothing)
+    if isnothing(color)
+        # default colors: based such that colors for standard log levels (Info etc) are in middle of color range
+        level = level.level
+        color = level < -500 ? Base.debug_color() :
+                level <  500 ? Base.info_color()  :
+                level < 1500 ? Base.warn_color()  :
+                               Base.error_color()
+    end
+    return color
 end
 
 function default_metafmt(level::LogLevel, _module, group, id, file, line)


### PR DESCRIPTION
Follow up to
https://github.com/JuliaLang/julia/pull/52359

Not entirely convinced this is a good idea, but wanted to put it out there for comment.
A big reason why i don't know that it is a good idea is that we can't actually use the custom log level macro as it is in the logging stdlib rather than in `Base.CoreLogging`.
I thus reimplement the code it would generate, though i could instead move it into `Base.CoreLogging` which would probably be cleaner.

I do think it is a good feature to have the color be optional and to default to the ones defined by the nearest of error/warn/debug/info.
Since those are user configurable colors.
Which honestly kinda seem like the right colors anyway.
A user defined `trace` should use same color as `debug`, and a user defined `critical` should use the same color as either `warn` or `error` depending on which it is closer to.
Not some made up color that might not match how user has configured their system.