### PR TITLE
Fix precompile reason print when nothing

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3325,7 +3325,7 @@ list_reasons(::Nothing) = ""
 # returns true if it "cachefile.ji" is stale relative to "modpath.jl" and build_id for modkey
 # otherwise returns the list of dependencies to also check
 @constprop :none function stale_cachefile(modpath::String, cachefile::String; ignore_loaded::Bool = false, reasons=nothing)
-    return stale_cachefile(PkgId(""), UInt128(0), modpath, cachefile; ignore_loaded)
+    return stale_cachefile(PkgId(""), UInt128(0), modpath, cachefile; ignore_loaded, reasons)
 end
 @constprop :none function stale_cachefile(modkey::PkgId, build_id::UInt128, modpath::String, cachefile::String;
                                             ignore_loaded::Bool = false, reasons::Union{Dict{String,Int},Nothing}=nothing)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2568,7 +2568,7 @@ This can be used to reduce package load times. Cache files are stored in
 `DEPOT_PATH[1]/compiled`. See [Module initialization and precompilation](@ref)
 for important notes.
 """
-function compilecache(pkg::PkgId, internal_stderr::IO = stderr, internal_stdout::IO = stdout; reasons::Union{Dict{String,Int},Nothing}=nothing)
+function compilecache(pkg::PkgId, internal_stderr::IO = stderr, internal_stdout::IO = stdout; reasons::Union{Dict{String,Int},Nothing}=Dict{String,Int}())
     @nospecialize internal_stderr internal_stdout
     path = locate_package(pkg)
     path === nothing && throw(ArgumentError("$pkg not found during precompilation"))
@@ -2578,7 +2578,7 @@ end
 const MAX_NUM_PRECOMPILE_FILES = Ref(10)
 
 function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, internal_stdout::IO = stdout,
-                      keep_loaded_modules::Bool = true; reasons::Union{Dict{String,Int},Nothing}=nothing)
+                      keep_loaded_modules::Bool = true; reasons::Union{Dict{String,Int},Nothing}=Dict{String,Int}())
 
     @nospecialize internal_stderr internal_stdout
     # decide where to put the resulting cache file

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3320,6 +3320,7 @@ function list_reasons(reasons::Dict{String,Int})
     isempty(reasons) && return ""
     return "(cache misses: $(join(("$k ($v)" for (k,v) in reasons), ", ")))"
 end
+list_reasons(::Nothing) = ""
 
 # returns true if it "cachefile.ji" is stale relative to "modpath.jl" and build_id for modkey
 # otherwise returns the list of dependencies to also check

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -624,7 +624,7 @@ precompile_test_harness(false) do dir
           end
           """)
 
-    cachefile, _ = Base.compilecache(Base.PkgId("FooBar"))
+    @test_logs (:debug, r"Precompiling FooBar") min_level=Logging.Debug (cachefile, _ = Base.compilecache(Base.PkgId("FooBar")))
     empty_prefs_hash = Base.get_preferences_hash(nothing, String[])
     @test cachefile == Base.compilecache_path(Base.PkgId("FooBar"), empty_prefs_hash)
     @test isfile(joinpath(cachedir, "FooBar.ji"))

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -624,7 +624,7 @@ precompile_test_harness(false) do dir
           end
           """)
 
-    @test_logs (:debug, r"Precompiling FooBar") min_level=Logging.Debug match_mode=:any (cachefile, _ = Base.compilecache(Base.PkgId("FooBar")))
+    cachefile, _ = @test_logs (:debug, r"Precompiling FooBar") min_level=Logging.Debug match_mode=:any Base.compilecache(Base.PkgId("FooBar"))
     empty_prefs_hash = Base.get_preferences_hash(nothing, String[])
     @test cachefile == Base.compilecache_path(Base.PkgId("FooBar"), empty_prefs_hash)
     @test isfile(joinpath(cachedir, "FooBar.ji"))

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -579,7 +579,7 @@ precompile_test_harness(false) do dir
           end
           """)
 
-    @test Base.compilecache(Base.PkgId("OverwriteMethodError")) == Base.PrecompilableError() # due to piracy
+    @test (@test_warn "overwritten in module OverwriteMethodError" Base.compilecache(Base.PkgId("OverwriteMethodError"))) == Base.PrecompilableError() # due to piracy
 
     UseBaz_file = joinpath(dir, "UseBaz.jl")
     write(UseBaz_file,

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -3,7 +3,7 @@
 original_depot_path = copy(Base.DEPOT_PATH)
 original_load_path = copy(Base.LOAD_PATH)
 
-using Test, Distributed, Random
+using Test, Distributed, Random, Logging
 using REPL # doc lookup function
 
 Foo_module = :Foo4b3a94a1a081a8cb
@@ -624,7 +624,7 @@ precompile_test_harness(false) do dir
           end
           """)
 
-    @test_logs (:debug, r"Precompiling FooBar") min_level=Logging.Debug (cachefile, _ = Base.compilecache(Base.PkgId("FooBar")))
+    @test_logs (:debug, r"Precompiling FooBar") min_level=Logging.Debug match_mode=:any (cachefile, _ = Base.compilecache(Base.PkgId("FooBar")))
     empty_prefs_hash = Base.get_preferences_hash(nothing, String[])
     @test cachefile == Base.compilecache_path(Base.PkgId("FooBar"), empty_prefs_hash)
     @test isfile(joinpath(cachedir, "FooBar.ji"))


### PR DESCRIPTION
Fixup on https://github.com/JuliaLang/julia/pull/52619

Fixes manual compilecache calls and expands tests to cover this logging path which is only a debug on non-interactive
```
Base.compilecache(Base.identify_package("OrdinaryDiffEq"))
┌ Error: Exception while generating log record in module Base at loading.jl:2598
│   exception =
│    MethodError: no method matching list_reasons(::Nothing)
│
│    Closest candidates are:
│      list_reasons(::Dict{String, Int64})
│       @ Base loading.jl:3319
│
│    Stacktrace:
│      [1] macro expansion
│        @ Base ./logging.jl:376 [inlined]
│      [2] compilecache(pkg::Base.PkgId, path::String, internal_stderr::IO, internal_stdout::IO, keep_loaded_modules::Bool; reasons::Nothing)
...
```