### PR TITLE
sroa: Fix small logic bug

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1209,10 +1209,11 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
         end
         if scope_mapping !== nothing && did_just_finish_bb(compact)
             bb = compact.active_result_bb - 1
-            if isexpr(stmt, :leave)
-                update_scope_mapping!(scope_mapping, bb+1, scope_mapping[block_for_inst(compact, scope_mapping[bb])])
+            bbs = scope_mapping[bb]
+            if isexpr(stmt, :leave) && bbs != SSAValue(0)
+                update_scope_mapping!(scope_mapping, bb+1, scope_mapping[block_for_inst(compact, bbs)])
             else
-                update_scope_mapping!(scope_mapping, bb+1, scope_mapping[bb])
+                update_scope_mapping!(scope_mapping, bb+1, bbs)
             end
         end
         # check whether this statement is `getfield` / `setfield!` (or other "interesting" statement)

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1725,3 +1725,18 @@ function f52610()
     return nothing
 end
 @test code_typed(f52610)[1][2] === Nothing
+
+# Issue #52703
+@eval function f52703()
+    try
+        $(Expr(:tryfinally,
+            Expr(:block,
+                Expr(:tryfinally, :(), :(), 2),
+                :(return Base.inferencebarrier(Core.current_scope)()::Int)),
+        :(), 1))
+    catch
+        return 1
+    end
+    return 0
+end
+@test code_typed(f52703)[1][2] === Int


### PR DESCRIPTION
This fixes #52703, which happened when a function had a foldable, try-catch-with-scope inside an ordinary try/catch. The fix is to simply ignore the ordinary try/catch and treat it as a regular fallthrough terminator.