### PR TITLE
Rename `Docs.hasdoc` to `Docs.hasdocstring`, to reduce ambiguity

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -83,7 +83,7 @@ New library features
 * `replace(string, pattern...)` now supports an optional `IO` argument to
   write the output to a stream rather than returning a string ([#48625]).
 * `sizehint!(s, n)` now supports an optional `shrink` argument to disable shrinking ([#51929]).
-* New function `Docs.hasdoc(module, symbol)` tells whether a name has a docstring ([#52139]).
+* New function `Docs.hasdocstring(module, symbol)` tells whether a name has a docstring ([#52139], [#52724]).
 * New function `Docs.undocumented_names(module; all)` returns a module's undocumented names ([#52413]).
 * Passing an `IOBuffer` as a stdout argument for `Process` spawn now works as
   expected, synchronized with `wait` or `success`, so a `Base.BufferStream` is

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -657,12 +657,12 @@ function doc end
 
 
 """
-    Docs.hasdoc(mod::Module, sym::Symbol)::Bool
+    Docs.hasdocstring(mod::Module, sym::Symbol)::Bool
 
 Return `true` if `sym` in `mod` has a docstring and `false` otherwise.
 """
-hasdoc(mod::Module, sym::Symbol) = hasdoc(Docs.Binding(mod, sym))
-function hasdoc(binding::Docs.Binding, sig::Type = Union{})
+hasdocstring(mod::Module, sym::Symbol) = hasdocstring(Docs.Binding(mod, sym))
+function hasdocstring(binding::Docs.Binding, sig::Type = Union{})
     # this function is based on the Base.Docs.doc method implemented
     # in REPL/src/docview.jl.  TODO: refactor and unify these methods.
     defined(binding) && !isnothing(getdoc(resolve(binding), sig)) && return true
@@ -671,7 +671,7 @@ function hasdoc(binding::Docs.Binding, sig::Type = Union{})
         !isnothing(dict) && haskey(dict, binding) && return true
     end
     alias = aliasof(binding)
-    return alias == binding ? false : hasdoc(alias, sig)
+    return alias == binding ? false : hasdocstring(alias, sig)
 end
 
 
@@ -683,11 +683,11 @@ Return an array of undocumented symbols in `module` (that is, lacking docstrings
 non-exported symbols, following the behavior of [`names`](@ref). Only valid identifiers
 are included. Names are returned in sorted order.
 
-See also: [`names`](@ref), [`Docs.hasdoc`](@ref), [`Base.isidentifier`](@ref).
+See also: [`names`](@ref), [`Docs.hasdocstring`](@ref), [`Base.isidentifier`](@ref).
 """
 function undocumented_names(mod::Module; all::Bool=false)
     filter!(names(mod; all)) do sym
-        !hasdoc(mod, sym) && Base.isidentifier(sym)
+        !hasdocstring(mod, sym) && Base.isidentifier(sym)
     end
 end
 

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -468,7 +468,7 @@ Base.@locals
 Base.@doc
 Docs.HTML
 Docs.Text
-Docs.hasdoc
+Docs.hasdocstring
 Docs.undocumented_names
 ```
 

--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -20,7 +20,7 @@ environments provide a way to access documentation directly:
   under the cursor.
 
 
-`Docs.hasdoc(module, name)::Bool` tells whether a name has a docstring. `Docs.undocumented_names(module; all)`
+`Docs.hasdocstring(module, name)::Bool` tells whether a name has a docstring. `Docs.undocumented_names(module; all)`
 returns the undocumented names in a module.
 
 ## Writing Documentation

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -70,11 +70,11 @@ $$latex literal$$
 function break_me_docs end
 
 
-# `hasdoc` returns `true` on a name with a docstring.
-@test Docs.hasdoc(Base, :map)
-# `hasdoc` returns `false` on a name without a docstring.
-@test !isdefined(Base, :_this_name_doesnt_exist_) && !Docs.hasdoc(Base, :_this_name_doesnt_exist_)
-@test isdefined(Base, :_typed_vcat) && !Docs.hasdoc(Base, :_typed_vcat)
+# `hasdocstring` returns `true` on a name with a docstring.
+@test Docs.hasdocstring(Base, :map)
+# `hasdocstring` returns `false` on a name without a docstring.
+@test !isdefined(Base, :_this_name_doesnt_exist_) && !Docs.hasdocstring(Base, :_this_name_doesnt_exist_)
+@test isdefined(Base, :_typed_vcat) && !Docs.hasdocstring(Base, :_typed_vcat)
 
 "This module has names without documentation."
 module _ModuleWithUndocumentedNames


### PR DESCRIPTION
`Docs.hasdoc` was introduced in https://github.com/JuliaLang/julia/pull/52139 (https://github.com/JuliaLang/julia/commit/42094740f8f48213c07d9a807d85f5d24cf6c27f), which hasn't made it into a release branch yet.

The term "documented" can have multiple meanings:
1. "X is documented" can mean "X is listed in the manual".
2. "X is documented" can mean "X has a docstring".

Therefore, I think the name `Docs.hasdoc` is a little confusing/ambiguous. I think it would be better to rename the function to `Docs.hasdocstring` (or `Docs.has_docstring`), to make it more clear what this function is doing.

Some more discussion in https://github.com/JuliaLang/julia/pull/52139#issuecomment-1874748877 and https://github.com/JuliaLang/julia/pull/52139#issuecomment-1875614344.