### PR TITLE
Rename `Docs.undocumented_names` to `Docs.names_without_docstring`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -84,7 +84,7 @@ New library features
   write the output to a stream rather than returning a string ([#48625]).
 * `sizehint!(s, n)` now supports an optional `shrink` argument to disable shrinking ([#51929]).
 * New function `Docs.hasdoc(module, symbol)` tells whether a name has a docstring ([#52139]).
-* New function `Docs.undocumented_names(module; all)` returns a module's undocumented names ([#52413]).
+* New function `Docs.names_without_docstring(module; all)` returns the names in `module` that do not have docstrings ([#52413], [#TODO]).
 * Passing an `IOBuffer` as a stdout argument for `Process` spawn now works as
   expected, synchronized with `wait` or `success`, so a `Base.BufferStream` is
   no longer required there for correctness to avoid data races ([#52461]).

--- a/NEWS.md
+++ b/NEWS.md
@@ -84,7 +84,7 @@ New library features
   write the output to a stream rather than returning a string ([#48625]).
 * `sizehint!(s, n)` now supports an optional `shrink` argument to disable shrinking ([#51929]).
 * New function `Docs.hasdoc(module, symbol)` tells whether a name has a docstring ([#52139]).
-* New function `Docs.names_without_docstring(module; all)` returns the names in `module` that do not have docstrings ([#52413], [#TODO]).
+* New function `Docs.names_without_docstring(module; all)` returns the names in `module` that do not have docstrings ([#52413], [#52726]).
 * Passing an `IOBuffer` as a stdout argument for `Process` spawn now works as
   expected, synchronized with `wait` or `success`, so a `Base.BufferStream` is
   no longer required there for correctness to avoid data races ([#52461]).

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -676,16 +676,16 @@ end
 
 
 """
-    undocumented_names(mod::Module; all=false)
+    names_without_docstring(mod::Module; all=false)
 
-Return an array of undocumented symbols in `module` (that is, lacking docstrings).
+Return an array of all symbols in `module` that lack docstrings.
 `all=false` returns only exported symbols; whereas `all=true` also includes
 non-exported symbols, following the behavior of [`names`](@ref). Only valid identifiers
 are included. Names are returned in sorted order.
 
 See also: [`names`](@ref), [`Docs.hasdoc`](@ref), [`Base.isidentifier`](@ref).
 """
-function undocumented_names(mod::Module; all::Bool=false)
+function names_without_docstring(mod::Module; all::Bool=false)
     filter!(names(mod; all)) do sym
         !hasdoc(mod, sym) && Base.isidentifier(sym)
     end

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -469,7 +469,7 @@ Base.@doc
 Docs.HTML
 Docs.Text
 Docs.hasdoc
-Docs.undocumented_names
+Docs.names_without_docstring
 ```
 
 ## Code loading

--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -20,8 +20,8 @@ environments provide a way to access documentation directly:
   under the cursor.
 
 
-`Docs.hasdoc(module, name)::Bool` tells whether a name has a docstring. `Docs.undocumented_names(module; all)`
-returns the undocumented names in a module.
+`Docs.hasdoc(module, name)::Bool` tells whether a name has a docstring. `Docs.names_without_docstring(module; all)`
+returns the names in `module` that do not have docstrings.
 
 ## Writing Documentation
 

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -76,23 +76,23 @@ function break_me_docs end
 @test !isdefined(Base, :_this_name_doesnt_exist_) && !Docs.hasdoc(Base, :_this_name_doesnt_exist_)
 @test isdefined(Base, :_typed_vcat) && !Docs.hasdoc(Base, :_typed_vcat)
 
-"This module has names without documentation."
-module _ModuleWithUndocumentedNames
+"This module has names without docstrings."
+module _ModuleWithNamesWithoutDocstring
 export f
 f() = 1
 end
 
-"This module has some documentation."
-module _ModuleWithSomeDocumentedNames
+"This module has some docstrings."
+module _ModuleWithSomeDocstrings
 export f
 "f() is 1."
 f() = 1
 g() = 2
 end
 
-@test Docs.undocumented_names(_ModuleWithUndocumentedNames) == [:f]
-@test isempty(Docs.undocumented_names(_ModuleWithSomeDocumentedNames))
-@test Docs.undocumented_names(_ModuleWithSomeDocumentedNames; all=true) == [:eval, :g, :include]
+@test Docs.names_without_docstring(_ModuleWithNamesWithoutDocstring) == [:f]
+@test isempty(Docs.names_without_docstring(_ModuleWithSomeDocstrings))
+@test Docs.names_without_docstring(_ModuleWithSomeDocstrings; all=true) == [:eval, :g, :include]
 
 
 # issue #11548


### PR DESCRIPTION
This PR renames `Docs.undocumented_names` to `Docs.names_without_docstring`. The rationale behind this PR is the same as that of #52724.

I made this PR and #52724 as two separate PRs, but if desired I can combine them into a single PR.

---

Note: `Docs.undocumented_names` was introduced in https://github.com/JuliaLang/julia/pull/52413 (https://github.com/JuliaLang/julia/commit/1b183b93f4b78f567241b1e7511138798cea6a0d), which hasn't made it into a release branch yet.