### PR TITLE
[release-1.10] switch cache tracking from mtime to fsize & hash

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -89,8 +89,9 @@ let
             print_time(stdlib, tt)
         end
         for dep in Base._require_dependencies
-            dep[3] == 0.0 && continue
-            push!(Base._included_files, dep[1:2])
+            mod, path, fsize = dep[1], dep[2], dep[3]
+            fsize == 0 && continue
+            push!(Base._included_files, (mod, path))
         end
         empty!(Base._require_dependencies)
         Base._track_dependencies[] = false

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2679,7 +2679,7 @@ static void jl_write_header_for_incremental(ios_t *f, jl_array_t *worklist, jl_a
     write_uint8(f, jl_cache_flags());
     // write description of contents (name, uuid, buildid)
     write_worklist_for_header(f, worklist);
-    // Determine unique (module, abspath, mtime) dependencies for the files defining modules in the worklist
+    // Determine unique (module, abspath, hash, fsize) dependencies for the files defining modules in the worklist
     // (see Base._require_dependencies). These get stored in `udeps` and written to the ji-file header.
     // Also write Preferences.
     // last word of the dependency list is the end of the data / start of the srctextpos

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -1,11 +1,6 @@
 // inverse of backedges graph (caller=>callees hash)
 jl_array_t *edges_map JL_GLOBALLY_ROOTED = NULL; // rooted for the duration of our uses of this
 
-static void write_float64(ios_t *s, double x) JL_NOTSAFEPOINT
-{
-    write_uint64(s, *((uint64_t*)&x));
-}
-
 // Decide if `t` must be new, because it points to something new.
 // If it is new, the object (in particular, the super field) might not be entirely
 // valid for the cache, so we want to finish transforming it before attempting
@@ -717,7 +712,8 @@ static int64_t write_dependency_list(ios_t *s, jl_array_t* worklist, jl_array_t 
         size_t slen = jl_string_len(dep);
         write_int32(s, slen);
         ios_write(s, jl_string_data(dep), slen);
-        write_float64(s, jl_unbox_float64(jl_fieldref(deptuple, 2)));  // mtime
+        write_uint64(s, jl_unbox_uint64(jl_fieldref(deptuple, 2)));  // fsize
+        write_uint32(s, jl_unbox_uint32(jl_fieldref(deptuple, 3)));  // hash
         jl_module_t *depmod = (jl_module_t*)jl_fieldref(deptuple, 0);  // evaluating module
         jl_module_t *depmod_top = depmod;
         while (depmod_top->parent != jl_main_module && depmod_top->parent != depmod_top)

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -374,7 +374,7 @@ precompile_test_harness(false) do dir
         @test string(Base.Docs.doc(Foo.Bar)) == "Bar module\n"
 
         modules, (deps, requires), required_modules, _... = Base.parse_cache_header(cachefile)
-        discard_module = mod_fl_mt -> (mod_fl_mt.filename, mod_fl_mt.mtime)
+        discard_module = mod_fl_mt -> mod_fl_mt.filename
         @test modules == [ Base.PkgId(Foo) => Base.module_build_id(Foo) % UInt64 ]
         @test map(x -> x.filename, deps) == [ Foo_file, joinpath(dir, "foo.jl"), joinpath(dir, "bar.jl") ]
         @test requires == [ Base.PkgId(Foo) => Base.PkgId(string(FooBase_module)),
@@ -552,12 +552,12 @@ precompile_test_harness(false) do dir
     fb_uuid = Base.module_build_id(FooBar)
     sleep(2); touch(FooBar_file)
     insert!(DEPOT_PATH, 1, dir2)
-    @test Base.stale_cachefile(FooBar_file, joinpath(cachedir, "FooBar.ji")) === true
+    @test Base.stale_cachefile(FooBar_file, joinpath(cachedir, "FooBar.ji")) isa Tsc
     @eval using FooBar1
     @test !isfile(joinpath(cachedir2, "FooBar.ji"))
     @test !isfile(joinpath(cachedir, "FooBar1.ji"))
     @test isfile(joinpath(cachedir2, "FooBar1.ji"))
-    @test Base.stale_cachefile(FooBar_file, joinpath(cachedir, "FooBar.ji")) === true
+    @test Base.stale_cachefile(FooBar_file, joinpath(cachedir, "FooBar.ji")) isa Tsc
     @test Base.stale_cachefile(FooBar1_file, joinpath(cachedir2, "FooBar1.ji")) isa Tsc
     @test fb_uuid == Base.module_build_id(FooBar)
     fb_uuid1 = Base.module_build_id(FooBar1)


### PR DESCRIPTION
Fixup version of @fatteneder's patch here https://github.com/JuliaLang/julia/issues/50918#issuecomment-1691125054

Caching `/compiled` in CI works great in 1.11 because of https://github.com/JuliaLang/julia/pull/49866 which moved away from mtime tracking to fsize and file hash tracking.

1.10 is in the awkward position of having more stdlibs out of the sysimage and still using mtime, so it's actually a noticeable regression in CI cache effectiveness https://github.com/julia-actions/cache/issues/85

Note that this also removes the current special casing check skip for stdlibs. i.e. `Skipping mtime check for file $f used by $cachefile, since it is a stdlib`


For this to be a viable patch backport it needs to be very safe.


Related https://github.com/JuliaLang/julia/issues/50667