### PR TITLE
remove outdated handling of `:static_parameter`

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -288,7 +288,7 @@ populate_def_use_map!(tpdum::TwoPhaseDefUseMap, ir::IRCode) =
 function is_all_const_call(@nospecialize(stmt), interp::AbstractInterpreter, irsv::IRInterpretationState)
     isexpr(stmt, :call) || return false
     @inbounds for i = 2:length(stmt.args)
-        argtype = abstract_eval_value(interp, stmt.args[i], nothing, irsv)
+        argtype = abstract_eval_value(interp, stmt.args[i], irsv)
         is_const_argtype(argtype) || return false
     end
     return true

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -288,7 +288,7 @@ populate_def_use_map!(tpdum::TwoPhaseDefUseMap, ir::IRCode) =
 function is_all_const_call(@nospecialize(stmt), interp::AbstractInterpreter, irsv::IRInterpretationState)
     isexpr(stmt, :call) || return false
     @inbounds for i = 2:length(stmt.args)
-        argtype = abstract_eval_value(interp, stmt.args[i], irsv)
+        argtype = abstract_eval_value(interp, stmt.args[i], nothing, irsv)
         is_const_argtype(argtype) || return false
     end
     return true


### PR DESCRIPTION
After #51970, `Expr(:static_parameter, i::Int)` is now consistently outlined during the lowering, so there's no longer a need for `abstract_eval_value_expr` to handle this expression. This update removes the outdated handling, clarifying where we need to handle the expression.