### PR TITLE
[RFC]: Added normalization checks for isidentifier(::Symbol)

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1522,10 +1522,10 @@ recognize a variable, it uses a limited set of characters (greatly extended by
 Unicode). `isidentifier()` makes it possible to query the parser directly
 whether a symbol contains valid characters.
 
-The isidentifier function for symbols has been extended to include
-a normalization check. It ensures that the provided symbol is normalized
-using Unicode normalization with stability and composition enabled. This
-ensures consistent and standardized representation of the symbol.
+!!! compat "Julia 1.11"
+    In Julia 1.11 or later, `isidentifier` for `Symbol` arguments also requires the symbol to be
+    Unicode-normalized so that it is equivalent to the result of parsing a valid identifier string
+    into a `Symbol`.
 
 # Examples
 ```jldoctest

--- a/base/show.jl
+++ b/base/show.jl
@@ -1522,6 +1522,11 @@ recognize a variable, it uses a limited set of characters (greatly extended by
 Unicode). `isidentifier()` makes it possible to query the parser directly
 whether a symbol contains valid characters.
 
+The isidentifier function for symbols has been extended to include
+a normalization check. It ensures that the provided symbol is normalized
+using Unicode normalization with stability and composition enabled. This
+ensures consistent and standardized representation of the symbol.
+
 # Examples
 ```jldoctest
 julia> Meta.isidentifier(:x), Meta.isidentifier("1x")
@@ -1536,7 +1541,11 @@ function isidentifier(s::AbstractString)
     is_id_start_char(c) || return false
     return all(is_id_char, rest)
 end
-isidentifier(s::Symbol) = isidentifier(string(s))
+
+function isidentifier(s::Symbol)
+    str = string(s)
+    return !isidentifier(str) ? false : str == Unicode.normalize(str; stable=true, compose=true)
+end
 
 is_op_suffix_char(c::AbstractChar) = ccall(:jl_op_suffix_char, Cint, (UInt32,), c) != 0
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -2673,3 +2673,6 @@ end
 using .Issue49382
 (::Type{Issue49382.Type49382})() = 1
 @test sprint(show, methods(Issue49382.Type49382)) isa String
+
+#issue #52641
+@test Base.isidentifier(Symbol("e\u0301")) == false

--- a/test/show.jl
+++ b/test/show.jl
@@ -2675,4 +2675,9 @@ using .Issue49382
 @test sprint(show, methods(Issue49382.Type49382)) isa String
 
 #issue #52641
-@test Base.isidentifier(Symbol("e\u0301")) == false
+@testset "isidentifier normalization" begin
+    @test !Base.isidentifier(Symbol("e\u0301")) # not NFC-normalized
+    @test Base.isidentifier(Symbol("\u00E9"))   # NFC-normalized
+    @test !Base.isidentifier(Symbol("\u00B5))   # U+00B5 = µ normalized to U+03BC = μ by parser
+    @test Base.isidentifier(Symbol("\u03BC"))   # U+03BC = μ is the normalized form
+end


### PR DESCRIPTION
**Overview:**
This pull request fixes #52641, `Base.isidentifier` lack Unicode normalization checks, leading to inconsistencies in symbol validation and display

**Changes Made:**
- modified `isidentifier` function for Julia symbols checks both identifier validity and Unicode normalization.
- Added test 

**Testing:**
- Tested the updated code to ensure that updated code is working as expected.
- Verified that other functionalities remain unaffected.
![Screenshot from 2024-01-04 16-19-08](https://github.com/JuliaLang/julia/assets/76656712/87425a3a-1ceb-4e3f-a2a5-8e36f6f2d7e5)



**Dependencies:**
- No dependencies on other pull requests.

**CC:**
- @stevengj 
