### PR TITLE
Generalize `broadcast!(f, ::BitVector)` optimization to `BitArray`.

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -979,7 +979,7 @@ end
 @inline function copyto!(dest::BitArray, bc::Broadcasted{Nothing})
     axes(dest) == axes(bc) || throwdm(axes(dest), axes(bc))
     ischunkedbroadcast(dest, bc) && return chunkedcopyto!(dest, bc)
-    ndims(dest) == 0 && return Base.@invoke copyto!(dest::AbstractArray, bc)
+    ndims(dest) == 0 && (dest[] = bc[]; return dest)
     bc′ = preprocess(dest, bc)
     ax = axes(bc′)
     ax1, out = ax[1], CartesianIndices(tail(ax))

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -974,53 +974,43 @@ preprocess(dest, x) = extrude(broadcast_unalias(dest, x))
     return dest
 end
 
-# Performance optimization: for BitVector outputs, we cache the result
-# in a 64-bit register before writing into memory (to bypass LSQ)
-@inline function copyto!(dest::BitVector, bc::Broadcasted{Nothing})
-    axes(dest) == axes(bc) || throwdm(axes(dest), axes(bc))
-    ischunkedbroadcast(dest, bc) && return chunkedcopyto!(dest, bc)
-    destc = dest.chunks
-    bcp = preprocess(dest, bc)
-    length(bcp) <= 0 && return dest
-    len = Base.num_bit_chunks(Int(length(bcp)))
-    @inbounds for i = 0:(len - 2)
-        z = UInt64(0)
-        for j = 0:63
-           z |= UInt64(bcp[i*64 + j + 1]::Bool) << (j & 63)
-        end
-        destc[i + 1] = z
-    end
-    @inbounds let i = len - 1
-        z = UInt64(0)
-        for j = 0:((length(bcp) - 1) & 63)
-             z |= UInt64(bcp[i*64 + j + 1]::Bool) << (j & 63)
-        end
-        destc[i + 1] = z
-    end
-    return dest
-end
-
 # Performance optimization: for BitArray outputs, we cache the result
-# in a "small" Vector{Bool}, and then copy in chunks into the output
+# in a 64-bit register before writing into memory (to bypass LSQ)
 @inline function copyto!(dest::BitArray, bc::Broadcasted{Nothing})
     axes(dest) == axes(bc) || throwdm(axes(dest), axes(bc))
     ischunkedbroadcast(dest, bc) && return chunkedcopyto!(dest, bc)
-    length(dest) < 256 && return invoke(copyto!, Tuple{AbstractArray, Broadcasted{Nothing}}, dest, bc)
-    tmp = Vector{Bool}(undef, bitcache_size)
-    destc = dest.chunks
-    cind = 1
+    ndims(dest) == 0 && return Base.@invoke copyto!(dest::AbstractArray, bc)
     bc′ = preprocess(dest, bc)
-    @inbounds for P in Iterators.partition(eachindex(bc′), bitcache_size)
-        ind = 1
-        @simd for I in P
-            tmp[ind] = bc′[I]
-            ind += 1
+    ax = axes(bc′)
+    ax1, out = ax[1], CartesianIndices(tail(ax))
+    destc, indc = dest.chunks, 0
+    bitst, remain = 0, UInt64(0)
+    @inbounds for I in out
+        i = first(ax1) - 1
+        if ndims(bc) == 1 || bitst >= 64 - length(ax1)
+            if ndims(bc) > 1 && bitst != 0
+                z = remain
+                @simd for j = bitst:63
+                    z |= UInt64(convert(Bool, bc′[i+=1, I])) << (j & 63)
+                end
+                destc[indc+=1] = z
+            end
+            while i <= last(ax1) - 64
+                z = UInt64(0)
+                @simd for j = 0:63
+                    z |= UInt64(convert(Bool, bc′[i+=1, I])) << (j & 63)
+                end
+                destc[indc+=1] = z
+            end
+            bitst, remain = 0, UInt64(0)
         end
-        @simd for i in ind:bitcache_size
-            tmp[i] = false
+        @simd for j = i+1:last(ax1)
+            remain |= UInt64(convert(Bool, bc′[j, I])) << (bitst & 63)
+            bitst += 1
         end
-        dumpbitcache(destc, cind, tmp)
-        cind += bitcache_chunks
+    end
+    @inbounds if bitst != 0
+        destc[indc+=1] = remain
     end
     return dest
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -592,6 +592,16 @@ end
     end
 end
 
+@testset "convert behavior of logical broadcast" begin
+    a = mod.(1:4, 2)
+    @test !isa(a, BitArray)
+    for T in (Array{Bool}, BitArray)
+        la = T(a)
+        la .= mod.(0:3, 2)
+        @test la == [false; true; false; true]
+    end
+end
+
 # Test that broadcast treats type arguments as scalars, i.e. containertype yields Any,
 # even for subtypes of abstract array. (https://github.com/JuliaStats/DataArrays.jl/issues/229)
 @testset "treat type arguments as scalars, DataArrays issue 229" begin


### PR DESCRIPTION
Follows #32048.
This PR fully avoids the allocation thus make nd logical broadcast better scaled for small inputs.

<details>
  <summary>Some Benchmark</summary>

```julia
import Random, Statistics
using BenchmarkTools
using Base:tail, bitcache_size, bitcache_chunks, dumpbitcache
Random.seed!(0)

@inline function master_copyto!(dest::BitVector, bc)
    axes(dest) == axes(bc) || Base.Broadcast.throwdm(axes(dest), axes(bc))
    Base.Broadcast.ischunkedbroadcast(dest, bc) && return Base.Broadcast.chunkedcopyto!(dest, bc)
    destc = dest.chunks
    bcp = Base.Broadcast.preprocess(dest, bc)
    length(bcp) <= 0 && return dest
    len = Base.num_bit_chunks(Int(length(bcp)))
    @inbounds for i = 0:(len - 2)
        z = UInt64(0)
        for j = 0:63
           z |= UInt64(bcp[i*64 + j + 1]::Bool) << (j & 63)
        end
        destc[i + 1] = z
    end
    @inbounds let i = len - 1
        z = UInt64(0)
        for j = 0:((length(bcp) - 1) & 63)
             z |= UInt64(bcp[i*64 + j + 1]::Bool) << (j & 63)
        end
        destc[i + 1] = z
    end
    return dest
end

# Performance optimization: for BitArray outputs, we cache the result
# in a "small" Vector{Bool}, and then copy in chunks into the output
@inline function master_copyto!(dest::BitArray, bc)
    axes(dest) == axes(bc) || Base.Broadcast.throwdm(axes(dest), axes(bc))
    Base.Broadcast.ischunkedbroadcast(dest, bc) && return Base.Broadcast.chunkedcopyto!(dest, bc)
    length(dest) < 256 && return Base.@invoke copyto!(dest::AbstractArray, bc)
    tmp = Vector{Bool}(undef, bitcache_size)
    destc = dest.chunks
    cind = 1
    bc′ = Base.Broadcast.preprocess(dest, bc)
    @inbounds for P in Iterators.partition(eachindex(bc′), bitcache_size)
        ind = 1
        @simd for I in P
            tmp[ind] = bc′[I]
            ind += 1
        end
        @simd for i in ind:bitcache_size
            tmp[i] = false
        end
        dumpbitcache(destc, cind, tmp)
        cind += bitcache_chunks
    end
    return dest
end

function pr_copyto!(dest::BitArray, bc)
    axes(dest) == axes(bc) || Base.Broadcast.throwdm(axes(dest), axes(bc))
    Base.Broadcast.ischunkedbroadcast(dest, bc) && return Base.Broadcast.chunkedcopyto!(dest, bc)
    ndims(dest) == 0 && return Base.@invoke copyto!(dest::AbstractArray, bc)
    ax = axes(bc)
    ax1, out = ax[1], CartesianIndices(tail(ax))
    destc, indc = dest.chunks, 0
    bitst, remain = 0, UInt64(0)
    bc′ = Base.Broadcast.preprocess(dest, bc)
     @inbounds for I in out
        i = first(ax1) - 1
        if ndims(bc) == 1 || bitst >= 64 - length(ax1)
            if ndims(bc) > 1 && bitst != 0
                z = remain
                @simd for j = bitst:63
                    z |= UInt64(convert(Bool, bc[i+=1, I])) << (j & 63)
                end
                destc[indc+=1] = z
            end
            while i <= last(ax1) - 64
                z = UInt64(0)
                @simd for j = 0:63
                    z |= UInt64(convert(Bool, bc[i+=1, I])) << (j & 63)
                end
                destc[indc+=1] = z
            end
            bitst, remain = 0, UInt64(0)
        end
        @simd for j = i+1:last(ax1)
            remain |= UInt64(convert(Bool, bc[j, I])) << (bitst & 63)
            bitst += 1
        end
    end
    @inbounds if bitst != 0
        destc[indc+=1] = remain
    end
    return dest
end

for n in round.(Int, [3 5 10 63 64 65 100])
    for T in (Int8, Int32, Int64)
        for (desc, dims) in (("1d", (100n,)),
                             ("2d (wide)", (10, 10n)),
                             ("2d (tall)", (10n, 10)),
                             (n > 10 ? (("3d (wide)", (10, 10, n)),
                                        ("3d (tall)", (n, 10, 10)),) : ())...)
            a = rand(T(0):T(4), dims)
            a = view(a, axes(a)...)
            bc = Base.broadcasted(==, a, 0)
            bc = Base.Broadcast.instantiate(bc)
            b = BitArray(undef, size(a))
            bc = convert(Base.Broadcast.Broadcasted{Nothing}, bc)
            master = @benchmark master_copyto!($b, $bc)
            pr = @benchmark pr_copyto!($b, $bc)
            println("$T, $(100n), $(Base.dims2string(dims)), $desc, $(median(pr).time/median(master).time)")
        end
    end
end

```
<table>
    <tr>
        <td>type</td>
        <td>len</td>
        <td>size</td>
        <td>dimension</td>
        <td>ratio</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>300</td>
        <td>300</td>
        <td>1d</td>
        <td>0.8049701082178423</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>300</td>
        <td>10×30</td>
        <td>2d (wide)</td>
        <td>0.14661725552845356</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>300</td>
        <td>30×10</td>
        <td>2d (tall)</td>
        <td>0.21419304402787712</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>300</td>
        <td>300</td>
        <td>1d</td>
        <td>0.8562138296047829</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>300</td>
        <td>10×30</td>
        <td>2d (wide)</td>
        <td>0.36087548666933134</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>300</td>
        <td>30×10</td>
        <td>2d (tall)</td>
        <td>0.23401590810405398</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>300</td>
        <td>300</td>
        <td>1d</td>
        <td>0.7572145199966925</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>300</td>
        <td>10×30</td>
        <td>2d (wide)</td>
        <td>0.3141521846653253</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>300</td>
        <td>30×10</td>
        <td>2d (tall)</td>
        <td>0.19794190115328072</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>500</td>
        <td>500</td>
        <td>1d</td>
        <td>0.772538940009253</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>500</td>
        <td>10×50</td>
        <td>2d (wide)</td>
        <td>0.47195179556897127</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>500</td>
        <td>50×10</td>
        <td>2d (tall)</td>
        <td>0.27832403048421167</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>500</td>
        <td>500</td>
        <td>1d</td>
        <td>0.8102381389012601</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>500</td>
        <td>10×50</td>
        <td>2d (wide)</td>
        <td>0.49712456275567674</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>500</td>
        <td>50×10</td>
        <td>2d (tall)</td>
        <td>0.29639818364298487</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>500</td>
        <td>500</td>
        <td>1d</td>
        <td>0.680161943319838</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>500</td>
        <td>10×50</td>
        <td>2d (wide)</td>
        <td>0.47691933916423707</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>500</td>
        <td>50×10</td>
        <td>2d (tall)</td>
        <td>0.25733235297889534</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>1000</td>
        <td>1000</td>
        <td>1d</td>
        <td>0.7740494843876912</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>1000</td>
        <td>10×100</td>
        <td>2d (wide)</td>
        <td>0.7955315763989763</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>1000</td>
        <td>100×10</td>
        <td>2d (tall)</td>
        <td>0.39482795983723</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>1000</td>
        <td>1000</td>
        <td>1d</td>
        <td>0.7664919113876304</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>1000</td>
        <td>10×100</td>
        <td>2d (wide)</td>
        <td>0.7918898474427308</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>1000</td>
        <td>100×10</td>
        <td>2d (tall)</td>
        <td>0.4206732580037665</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>1000</td>
        <td>1000</td>
        <td>1d</td>
        <td>0.6162508215892311</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>1000</td>
        <td>10×100</td>
        <td>2d (wide)</td>
        <td>0.7419391308280197</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>1000</td>
        <td>100×10</td>
        <td>2d (tall)</td>
        <td>0.28843806921675774</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>6300</td>
        <td>6300</td>
        <td>1d</td>
        <td>0.7508786158421195</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>6300</td>
        <td>10×630</td>
        <td>2d (wide)</td>
        <td>1.1015625</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>6300</td>
        <td>630×10</td>
        <td>2d (tall)</td>
        <td>0.5841503267973855</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>6300</td>
        <td>10×10×63</td>
        <td>3d (wide)</td>
        <td>1.0446096654275092</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>6300</td>
        <td>63×10×10</td>
        <td>3d (tall)</td>
        <td>0.9523809523809523</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>6300</td>
        <td>6300</td>
        <td>1d</td>
        <td>0.7714673386315177</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>6300</td>
        <td>10×630</td>
        <td>2d (wide)</td>
        <td>1.060377358490566</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>6300</td>
        <td>630×10</td>
        <td>2d (tall)</td>
        <td>0.5455993628036638</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>6300</td>
        <td>10×10×63</td>
        <td>3d (wide)</td>
        <td>1.0881226053639848</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>6300</td>
        <td>63×10×10</td>
        <td>3d (tall)</td>
        <td>1.03125</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>6300</td>
        <td>6300</td>
        <td>1d</td>
        <td>0.5650955545919919</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>6300</td>
        <td>10×630</td>
        <td>2d (wide)</td>
        <td>1.1023622047244095</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>6300</td>
        <td>630×10</td>
        <td>2d (tall)</td>
        <td>0.3621870397643593</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>6300</td>
        <td>10×10×63</td>
        <td>3d (wide)</td>
        <td>1.0795454545454546</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>6300</td>
        <td>63×10×10</td>
        <td>3d (tall)</td>
        <td>0.7745098039215687</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>6400</td>
        <td>6400</td>
        <td>1d</td>
        <td>0.7665206279664111</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>6400</td>
        <td>10×640</td>
        <td>2d (wide)</td>
        <td>1.14453125</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>6400</td>
        <td>640×10</td>
        <td>2d (tall)</td>
        <td>0.5405405405405406</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>6400</td>
        <td>10×10×64</td>
        <td>3d (wide)</td>
        <td>1.032490974729242</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>6400</td>
        <td>64×10×10</td>
        <td>3d (tall)</td>
        <td>0.6187290969899666</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>6400</td>
        <td>6400</td>
        <td>1d</td>
        <td>0.763771712158809</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>6400</td>
        <td>10×640</td>
        <td>2d (wide)</td>
        <td>1.055350553505535</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>6400</td>
        <td>640×10</td>
        <td>2d (tall)</td>
        <td>0.5044358507734303</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>6400</td>
        <td>10×10×64</td>
        <td>3d (wide)</td>
        <td>1.1162790697674418</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>6400</td>
        <td>64×10×10</td>
        <td>3d (tall)</td>
        <td>0.5995934959349594</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>6400</td>
        <td>6400</td>
        <td>1d</td>
        <td>0.551921470342523</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>6400</td>
        <td>10×640</td>
        <td>2d (wide)</td>
        <td>1.111969111969112</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>6400</td>
        <td>640×10</td>
        <td>2d (tall)</td>
        <td>0.32497607655502386</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>6400</td>
        <td>10×10×64</td>
        <td>3d (wide)</td>
        <td>1.1254752851711027</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>6400</td>
        <td>64×10×10</td>
        <td>3d (tall)</td>
        <td>0.39924961377179435</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>6500</td>
        <td>6500</td>
        <td>1d</td>
        <td>0.760268456375839</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>6500</td>
        <td>10×650</td>
        <td>2d (wide)</td>
        <td>1.1221374045801527</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>6500</td>
        <td>650×10</td>
        <td>2d (tall)</td>
        <td>0.5633802816901409</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>6500</td>
        <td>10×10×65</td>
        <td>3d (wide)</td>
        <td>1.0469314079422383</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>6500</td>
        <td>65×10×10</td>
        <td>3d (tall)</td>
        <td>1.064102564102564</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>6500</td>
        <td>6500</td>
        <td>1d</td>
        <td>0.7692039916453933</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>6500</td>
        <td>10×650</td>
        <td>2d (wide)</td>
        <td>1.1153846153846154</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>6500</td>
        <td>650×10</td>
        <td>2d (tall)</td>
        <td>0.5496323529411764</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>6500</td>
        <td>10×10×65</td>
        <td>3d (wide)</td>
        <td>1.0541516245487366</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>6500</td>
        <td>65×10×10</td>
        <td>3d (tall)</td>
        <td>1.0121212121212122</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>6500</td>
        <td>6500</td>
        <td>1d</td>
        <td>0.5520719460113399</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>6500</td>
        <td>10×650</td>
        <td>2d (wide)</td>
        <td>1.118320610687023</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>6500</td>
        <td>650×10</td>
        <td>2d (tall)</td>
        <td>0.361455716080402</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>6500</td>
        <td>10×10×65</td>
        <td>3d (wide)</td>
        <td>1.0640569395017794</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>6500</td>
        <td>65×10×10</td>
        <td>3d (tall)</td>
        <td>0.7994923857868022</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>10000</td>
        <td>10000</td>
        <td>1d</td>
        <td>0.7973856209150327</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>10000</td>
        <td>10×1000</td>
        <td>2d (wide)</td>
        <td>1.1263208453410183</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>10000</td>
        <td>1000×10</td>
        <td>2d (tall)</td>
        <td>0.5541871921182265</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>10000</td>
        <td>10×10×100</td>
        <td>3d (wide)</td>
        <td>1.0932475884244375</td>
    </tr>
    <tr>
        <td>Int8</td>
        <td>10000</td>
        <td>100×10×10</td>
        <td>3d (tall)</td>
        <td>0.8782608695652174</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>10000</td>
        <td>10000</td>
        <td>1d</td>
        <td>0.7612903225806451</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>10000</td>
        <td>10×1000</td>
        <td>2d (wide)</td>
        <td>1.1429263565891472</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>10000</td>
        <td>1000×10</td>
        <td>2d (tall)</td>
        <td>0.5195454545454545</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>10000</td>
        <td>10×10×100</td>
        <td>3d (wide)</td>
        <td>1.1467236467236466</td>
    </tr>
    <tr>
        <td>Int32</td>
        <td>10000</td>
        <td>100×10×10</td>
        <td>3d (tall)</td>
        <td>0.8681818181818182</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>10000</td>
        <td>10000</td>
        <td>1d</td>
        <td>0.5546050755631594</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>10000</td>
        <td>10×1000</td>
        <td>2d (wide)</td>
        <td>1.1632850241545893</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>10000</td>
        <td>1000×10</td>
        <td>2d (tall)</td>
        <td>0.349034749034749</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>10000</td>
        <td>10×10×100</td>
        <td>3d (wide)</td>
        <td>1.1310185185185184</td>
    </tr>
    <tr>
        <td>Int64</td>
        <td>10000</td>
        <td>100×10×10</td>
        <td>3d (tall)</td>
        <td>0.6534351145038167</td>
    </tr>
</table>
</details>

So looks like this change is a general win as the iteration in the 1st dimension is better vectorized.