### PR TITLE
Preserve eltype in converting `Symmetric` to `Matrix`

### DIFF
--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -289,21 +289,20 @@ end
 similar(A::Union{Symmetric,Hermitian}, ::Type{T}, dims::Dims{N}) where {T,N} = similar(parent(A), T, dims)
 
 # Conversion
-function Matrix(A::Symmetric)
-    B = copytri!(convert(Matrix, copy(A.data)), A.uplo)
+function Matrix{T}(A::Symmetric) where {T}
+    B = copytri!(convert(Matrix{T}, copy(A.data)), A.uplo)
     for i = 1:size(A, 1)
         B[i,i] = symmetric(A[i,i], sym_uplo(A.uplo))::symmetric_type(eltype(A.data))
     end
     return B
 end
-function Matrix(A::Hermitian)
-    B = copytri!(convert(Matrix, copy(A.data)), A.uplo, true)
+function Matrix{T}(A::Hermitian) where {T}
+    B = copytri!(convert(Matrix{T}, copy(A.data)), A.uplo, true)
     for i = 1:size(A, 1)
         B[i,i] = hermitian(A[i,i], sym_uplo(A.uplo))::hermitian_type(eltype(A.data))
     end
     return B
 end
-Array(A::Union{Symmetric,Hermitian}) = convert(Matrix, A)
 
 parent(A::HermOrSym) = A.data
 Symmetric{T,S}(A::Symmetric{T,S}) where {T,S<:AbstractMatrix{T}} = A

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -919,4 +919,17 @@ end
     end
 end
 
+@testset "Matrix elements" begin
+    M = [UpperTriangular([1 2; 3 4]) for i in 1:2, j in 1:2]
+    for T in (Symmetric, Hermitian)
+        H = T(M)
+        A = Array(H)
+        @test A isa Matrix
+        @test A == H
+        A = Array{Matrix{Int}}(H)
+        @test A isa Matrix{Matrix{Int}}
+        @test A == H
+    end
+end
+
 end # module TestSymmetric


### PR DESCRIPTION
This allows cases where the `eltype` differs from that of the parent:
```julia
julia> M = [UpperTriangular([1 2; 3 4]) for i in 1:2, j in 1:2]
2×2 Matrix{UpperTriangular{Int64, Matrix{Int64}}}:
 [1 2; 0 4]  [1 2; 0 4]
 [1 2; 0 4]  [1 2; 0 4]

julia> H = Hermitian(M)
2×2 Hermitian{AbstractMatrix, Matrix{UpperTriangular{Int64, Matrix{Int64}}}}:
 [1 2; 2 4]  [1 2; 0 4]
 [1 0; 2 4]  [1 2; 2 4]

julia> Array(H)
2×2 Matrix{AbstractMatrix}:
 [1 2; 2 4]  [1 2; 0 4]
 [1 0; 2 4]  [1 2; 2 4]
```
This conversion throws an error at present on master.