### PR TITLE
Use `jl_types_egal` in `equiv_field_types`

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1786,7 +1786,7 @@ static int equiv_field_types(jl_value_t *old, jl_value_t *ft)
         jl_value_t *ta = jl_svecref(old, i);
         jl_value_t *tb = jl_svecref(ft, i);
         if (jl_has_free_typevars(ta)) {
-            if (!jl_has_free_typevars(tb) || !jl_egal(ta, tb))
+            if (!jl_has_free_typevars(tb) || !jl_types_egal(ta, tb))
                 return 0;
         }
         else if (jl_has_free_typevars(tb) || jl_typetagof(ta) != jl_typetagof(tb) ||

--- a/test/core.jl
+++ b/test/core.jl
@@ -111,18 +111,21 @@ let abcd = ABCDconst(1, 2, 3, 4)
         abcd.d = nothing)
     @test (1, 2, "not constant", 4) === (abcd.a, abcd.b, abcd.c, abcd.d)
 end
-@test begin
-    # Issue #52686
-    for i in 1:2
-        @eval begin
-            struct A{T} end
-            struct B{T, S}
-              a::A{<:T}
-            end
+# Issue #52686
+struct A52686{T} end
+struct B52686{T, S}
+    a::A52686{<:T}
+end
+function func52686()
+    @eval begin
+        struct A52686{T} end
+        struct B52686{T, S}
+            a::A52686{<:T}
         end
     end
-    true
+    return true
 end
+@test func52686()
 
 # test `===` handling null pointer in struct #44712
 struct N44712

--- a/test/core.jl
+++ b/test/core.jl
@@ -111,6 +111,21 @@ let abcd = ABCDconst(1, 2, 3, 4)
         abcd.d = nothing)
     @test (1, 2, "not constant", 4) === (abcd.a, abcd.b, abcd.c, abcd.d)
 end
+@test begin
+    # Issue #52686
+    mktemp() do f, io
+        write(io, """
+            struct A{T} end
+            struct B{T, S}
+              a::A{<:T}
+            end
+            """)
+        close(io)
+        include(f)
+        include(f)
+    end
+    true
+end
 
 # test `===` handling null pointer in struct #44712
 struct N44712

--- a/test/core.jl
+++ b/test/core.jl
@@ -113,16 +113,13 @@ let abcd = ABCDconst(1, 2, 3, 4)
 end
 @test begin
     # Issue #52686
-    mktemp() do f, io
-        write(io, """
+    for i in 1:2
+        @eval begin
             struct A{T} end
             struct B{T, S}
               a::A{<:T}
             end
-            """)
-        close(io)
-        include(f)
-        include(f)
+        end
     end
     true
 end


### PR DESCRIPTION
Fixes #52686
Fixes https://github.com/timholy/Revise.jl/issues/770