### PR TITLE
Allow `include()` and `include_dependency()` files to resolve to different depots

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -43,7 +43,7 @@ relocatedepot:
 	@cp -R $(SRCDIR)/RelocationTestPkg1 $(SRCDIR)/relocatedepot
 	@cp -R $(SRCDIR)/RelocationTestPkg2 $(SRCDIR)/relocatedepot
 	@cd $(SRCDIR) && \
-	$(call PRINT_JULIA, $(call spawn,JULIA_DEBUG=loading RELOCATEDEPOT="" JULIA_DEPOT_PATH=$(SRCDIR)/relocatedepot/julia $(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl $@)
+	$(call PRINT_JULIA, $(call spawn,JULIA_DEBUG=loading RELOCATEDEPOT="" $(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl $@)
 
 revise-relocatedepot: revise-% :
 	@rm -rf $(SRCDIR)/relocatedepot
@@ -54,7 +54,7 @@ revise-relocatedepot: revise-% :
 	@cp -R $(SRCDIR)/RelocationTestPkg1 $(SRCDIR)/relocatedepot
 	@cp -R $(SRCDIR)/RelocationTestPkg2 $(SRCDIR)/relocatedepot
 	@cd $(SRCDIR) && \
-	$(call PRINT_JULIA, $(call spawn,JULIA_DEBUG=loading RELOCATEDEPOT="" JULIA_DEPOT_PATH=$(SRCDIR)/relocatedepot/julia $(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --revise $*)
+	$(call PRINT_JULIA, $(call spawn,JULIA_DEBUG=loading RELOCATEDEPOT="" $(JULIA_EXECUTABLE)) --check-bounds=yes --startup-file=no --depwarn=error ./runtests.jl --revise $*)
 
 embedding:
 	@$(MAKE) -C $(SRCDIR)/$@ check $(EMBEDDING_ARGS)

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -436,7 +436,8 @@ precompile_test_harness(false) do dir
         modules, (deps, _, requires), required_modules, _... = Base.parse_cache_header(cachefile)
         discard_module = mod_fl_mt -> mod_fl_mt.filename
         @test modules == [ Base.PkgId(Foo) => Base.module_build_id(Foo) % UInt64 ]
-        @test map(x -> x.filename, deps) == [ Foo_file, joinpath(dir, "foo.jl"), joinpath(dir, "bar.jl") ]
+        # foo.jl and bar.jl are never written to disk, so they are not relocatable
+        @test map(x -> x.filename, deps) == [ Foo_file, joinpath("@depot", "foo.jl"), joinpath("@depot", "bar.jl") ]
         @test requires == [ Base.PkgId(Foo) => Base.PkgId(string(FooBase_module)),
                             Base.PkgId(Foo) => Base.PkgId(Foo2),
                             Base.PkgId(Foo) => Base.PkgId(Test),

--- a/test/relocatedepot.jl
+++ b/test/relocatedepot.jl
@@ -95,21 +95,6 @@ if !test_relocated_depot
 
 else
 
-    # must come before any of the load tests, because the will recompile and generate new cache files
-    @testset "attempt loading precompiled pkgs when depot is missing" begin
-        test_harness() do
-            empty!(LOAD_PATH)
-            push!(LOAD_PATH, joinpath(@__DIR__, "relocatedepot"))
-            for pkgname in ("RelocationTestPkg1", "RelocationTestPkg2")
-                pkg = Base.identify_package(pkgname)
-                cachefile = only(Base.find_all_in_cache_path(pkg))
-                @test_throws ArgumentError("""
-                  Failed to determine depot from srctext files in cache file $cachefile.
-                  - Make sure you have adjusted DEPOT_PATH in case you relocated depots.""") Base.isprecompiled(pkg)
-            end
-        end
-    end
-
     @testset "load stdlib from test/relocatedepot" begin
         test_harness() do
             push!(LOAD_PATH, joinpath(@__DIR__, "relocatedepot"))

--- a/test/relocatedepot.jl
+++ b/test/relocatedepot.jl
@@ -93,6 +93,58 @@ if !test_relocated_depot
         end
     end
 
+    @testset "#52161" begin
+        # Take the src files from two RelocationTestPkg1 and RelocationTestPkg2,
+        # which are each located in depot1 and depot2, respectively, and
+        # add them as include_dependency()s to a new pkg Foo, which will be precompiled into depot3.
+        # After loading the include_dependency()s of Foo should refer to depot1 depot2 each.
+        test_harness() do
+            mktempdir() do depot1
+                # precompile RelocationTestPkg1 in depot1
+                cp(joinpath(@__DIR__,"RelocationTestPkg1"),joinpath(depot1,"RelocationTestPkg1"))
+                pushfirst!(LOAD_PATH, depot1)
+                pushfirst!(DEPOT_PATH, depot1)
+                pkg = Base.identify_package("RelocationTestPkg1")
+                Base.require(pkg)
+                mktempdir() do depot2
+                    cp(joinpath(@__DIR__,"RelocationTestPkg2"),joinpath(depot2,"RelocationTestPkg2"))
+                    # precompile RelocationTestPkg2 in depot2
+                    pushfirst!(LOAD_PATH, depot2)
+                    pushfirst!(DEPOT_PATH, depot2)
+                    pkg = Base.identify_package("RelocationTestPkg2")
+                    Base.require(pkg)
+                    # precompile Foo into in depot3
+                    mktempdir() do depot3
+                        pushfirst!(LOAD_PATH, depot3)
+                        pushfirst!(DEPOT_PATH, depot3)
+                        foofile = joinpath(depot3, "Foo.jl")
+                        write(foofile, """
+                            module Foo
+                            using RelocationTestPkg1
+                            using RelocationTestPkg2
+                            srcfile1 = joinpath(pkgdir(RelocationTestPkg1), "src", "RelocationTestPkg1.jl")
+                            srcfile2 = joinpath(pkgdir(RelocationTestPkg2), "src", "RelocationTestPkg2.jl")
+                            @show srcfile1
+                            @show srcfile2
+                            include_dependency(srcfile1)
+                            include_dependency(srcfile2)
+                            end
+                        """)
+                        pkg = Base.identify_package("Foo")
+                        Base.require(pkg)
+                        cachefile = joinpath(depot3, "compiled", "v1.11", "Foo.ji")
+                        _, (deps, _, _), _... = Base.parse_cache_header(cachefile)
+                        @test map(x -> x.filename, deps) ==
+                            [ joinpath(depot3, "Foo.jl"),
+                              joinpath(depot1, "RelocationTestPkg1", "src", "RelocationTestPkg1.jl"),
+                              joinpath(depot2, "RelocationTestPkg2", "src", "RelocationTestPkg2.jl") ]
+                    end
+                end
+            end
+        end
+    end
+
+
 else
 
     @testset "load stdlib from test/relocatedepot" begin


### PR DESCRIPTION
Fixes #52161

#52161 is an awkward use of the relocation feature in the sense that it attempts to load the `include()` and `include_dependency` files of a pkg from two separate depots.
The problem there is that the value with which we replace the `@depot` tag for both `include()` and `include_dependency()` files is determined by trying to relocate only the `include()` files. We then end up not finding the `include_dependency()` files.

Solution:
@staticfloat noted that the pkg slugs in depot paths like `@depot/packages/Foo/1a2b3c/src/Foo.jl` are already enough to (weakly) content-address a depot.
This means that we should be able to load any `include()` file of a pkg from any `depot` that contains a precompile cache, provided the hashes match.
The same logic can be extended to `include_dependency()` files, which this PR does.

Note that we continue to use only one file from the `include()` files to determine the depot which we use to relocate all `include()` files. [this behavior is kept from master]
But for `include_dependency()` files we allow each file to resolve to a different depot. This way the MWE given in #52161 should be extendable to two README files being located in two different pkgs that lie in two different depots.

---

Side note: #49866 started with explicitly verifying that all `include()` files come from the same depot. In #52346 this was already relaxed to pick the first depot for which any `include()` file can be resolved to. This works, because if any other file might be missing from that depot then this is caught in `stalecache()`.