### PR TITLE
use a Dict instead of an IdDict for caching of the `cwstring` for Windows env variables

### DIFF
--- a/base/env.jl
+++ b/base/env.jl
@@ -16,8 +16,8 @@ if Sys.iswindows()
             if isnothing(var)
                 var = env_dict[str] = cwstring(str)
             end
+            return var
         end
-        var
     end
 
     _getenvlen(var::Vector{UInt16}) = ccall(:GetEnvironmentVariableW,stdcall,UInt32,(Ptr{UInt16},Ptr{UInt16},UInt32),var,C_NULL,0)

--- a/base/env.jl
+++ b/base/env.jl
@@ -14,7 +14,8 @@ if Sys.iswindows()
         @lock env_lock begin
             var = get(env_dict, str, nothing)
             if isnothing(var)
-                var = env_dict[str] = cwstring(str)
+                var = cwstring(str)
+                env_dict[str] = var
             end
             return var
         end

--- a/base/env.jl
+++ b/base/env.jl
@@ -11,10 +11,10 @@ if Sys.iswindows()
         # incurred allocations because we had to convert a String to a Vector{Cwchar_t} each time
         # an environment variable was looked up. This function memoizes that lookup process, storing
         # the String => Vector{Cwchar_t} pairs in env_dict
-        var = get(env_dict, str, nothing)
-        if isnothing(var)
-            var = @lock env_lock begin
-                env_dict[str] = cwstring(str)
+        @lock env_lock begin
+            var = get(env_dict, str, nothing)
+            if isnothing(var)
+                var = env_dict[str] = cwstring(str)
             end
         end
         var

--- a/base/env.jl
+++ b/base/env.jl
@@ -3,7 +3,7 @@
 if Sys.iswindows()
     const ERROR_ENVVAR_NOT_FOUND = UInt32(203)
 
-    const env_dict = IdDict{String, Vector{Cwchar_t}}()
+    const env_dict = Dict{String, Vector{Cwchar_t}}()
     const env_lock = ReentrantLock()
 
     function memoized_env_lookup(str::AbstractString)


### PR DESCRIPTION
Should fix https://github.com/JuliaLang/julia/issues/52711.

My analysis of the invalidation is as follows:

We added code to cache the conversion to `cwstring` in env handling on Windows (https://github.com/JuliaLang/julia/pull/51371):

```julia
const env_dict = IdDict{String, Vector{UInt16}}()

function memoized_env_lookup(str::AbstractString)
    ...
    env_dict[str] = cwstring(str)
    ...
end

function access_env(onError::Function, str::AbstractString)
    var = memoized_env_lookup(str)
    ...
end
```

Since `IdDict` has `@nospecialize` on `setindex!` we compile this method:

```julia
setindex!(::IdDict{String, Vector{UInt16}}, ::Any, ::Any)
```

which has an edge to:

```julia
convert(Type{Vector{Int64}}, Any})
```

But then StaticArrays comes along and adds a method

```julia
convert(::Type{Array{T, N}}, ::StaticArray)
```

which invalidates the `setindex!` (due to the edge to `convert`) which invalidates the whole env handling on Windows which causes 4k other methods downstream to be invalidated, in particular the artifact string macro which causes a significant delay in the next jll package you load after loading StaticArrays.

There should be no performance penalty to this since strings already does a hash for their `objectid`.

cc @jaakkor2, could you try this PR out?

cc @MasonProtter 