### PR TITLE
also enable gc_assert_parent_validity on GC_VERIFY

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1862,7 +1862,7 @@ STATIC_INLINE uintptr_t gc_read_stack(void *_addr, uintptr_t offset,
 
 STATIC_INLINE void gc_assert_parent_validity(jl_value_t *parent, jl_value_t *child) JL_NOTSAFEPOINT
 {
-#ifdef GC_ASSERT_PARENT_VALIDITY
+#if defined(GC_VERIFY) || defined(GC_ASSERT_PARENT_VALIDITY)
     jl_taggedvalue_t *child_astagged = jl_astaggedvalue(child);
     jl_taggedvalue_t *child_vtag = (jl_taggedvalue_t *)(child_astagged->header & ~(uintptr_t)0xf);
     uintptr_t child_vt = (uintptr_t)child_vtag;

--- a/src/options.h
+++ b/src/options.h
@@ -64,6 +64,10 @@
 #endif
 #endif
 
+// GC_ASSERT_PARENT_VALIDITY will check whether an object is valid when **pushing**
+// it to the mark queue
+// #define GC_ASSERT_PARENT_VALIDITY
+
 // profiling options
 
 // GC_FINAL_STATS prints total GC stats at exit


### PR DESCRIPTION
Keeping this functionality untested on CI increases the chance of it rotting.