### PR TITLE
Revert "Generalize `broadcast!(f, ::BitVector)` optimization to `BitArray`."

### DIFF
--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -592,16 +592,6 @@ end
     end
 end
 
-@testset "convert behavior of logical broadcast" begin
-    a = mod.(1:4, 2)
-    @test !isa(a, BitArray)
-    for T in (Array{Bool}, BitArray)
-        la = T(a)
-        la .= mod.(0:3, 2)
-        @test la == [false; true; false; true]
-    end
-end
-
 # Test that broadcast treats type arguments as scalars, i.e. containertype yields Any,
 # even for subtypes of abstract array. (https://github.com/JuliaStats/DataArrays.jl/issues/229)
 @testset "treat type arguments as scalars, DataArrays issue 229" begin


### PR DESCRIPTION
Reverts JuliaLang/julia#52736; cc @N5N3. This broke many packages on PkgEval.

Error 1: MultiScaleTreeGraph.jl

```
  Got exception outside of a @test
  MethodError: no method matching SubDataFrame(::DataFrame, ::CartesianIndex{1}, ::Colon)
  
  Closest candidates are:
    SubDataFrame(::DataFrame, !Matched::Colon, ::Any)
     @ DataFrames ~/.julia/packages/DataFrames/58MUJ/src/subdataframe/subdataframe.jl:86
    SubDataFrame(::DataFrame, !Matched::AbstractVector{Bool}, ::Any)
     @ DataFrames ~/.julia/packages/DataFrames/58MUJ/src/subdataframe/subdataframe.jl:98
    SubDataFrame(::DataFrame, !Matched::AbstractVector{Int64}, ::Any)
     @ DataFrames ~/.julia/packages/DataFrames/58MUJ/src/subdataframe/subdataframe.jl:80
    ...
  
  Stacktrace:
    [1] copyto!
      @ ./broadcast.jl:0 [inlined]
    [2] copyto!
      @ Base.Broadcast ./broadcast.jl:924 [inlined]
    [3] copy
      @ Base.Broadcast ./broadcast.jl:896 [inlined]
    [4] materialize(bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, DataFrames.var"#103#104"{MultiScaleTreeGraph.var"#130#132"{String}}, Tuple{DataFrames.DataFrameRows{DataFrame}}})
      @ Base.Broadcast ./broadcast.jl:871
    [5] _filter_helper(f::Function, cols::DataFrames.DataFrameRows{DataFrame})
      @ DataFrames ~/.julia/packages/DataFrames/58MUJ/src/abstractdataframe/abstractdataframe.jl:1216
    [6] #filter#92
      @ ~/.julia/packages/DataFrames/58MUJ/src/abstractdataframe/abstractdataframe.jl:1189 [inlined]
    [7] filter
      @ ~/.julia/packages/DataFrames/58MUJ/src/abstractdataframe/abstractdataframe.jl:1188 [inlined]
    [8] paste_node_mtg(mtg::Node{MutableNodeMTG, Dict{Symbol, Any}}, features::DataFrame)
      @ MultiScaleTreeGraph ~/.julia/packages/MultiScaleTreeGraph/gizDZ/src/write_mtg/write_mtg.jl:131
    [9] (::MultiScaleTreeGraph.var"#126#128"{Node{MutableNodeMTG, Dict{Symbol, Any}}, DataFrame, Nothing, DataFrame})(io::IOStream)
      @ MultiScaleTreeGraph ~/.julia/packages/MultiScaleTreeGraph/gizDZ/src/write_mtg/write_mtg.jl:92
   [10] open(::MultiScaleTreeGraph.var"#126#128"{Node{MutableNodeMTG, Dict{Symbol, Any}}, DataFrame, Nothing, DataFrame}, ::String, ::Vararg{String}; kwargs::@Kwargs{})
      @ Base ./io.jl:408
   [11] open
      @ ./io.jl:405 [inlined]
   [12] write_mtg(file::String, mtg::Node{MutableNodeMTG, Dict{Symbol, Any}}, classes::DataFrame, description::Nothing, features::DataFrame)
      @ MultiScaleTreeGraph ~/.julia/packages/MultiScaleTreeGraph/gizDZ/src/write_mtg/write_mtg.jl:49
   [13] #write_mtg#125
      @ MultiScaleTreeGraph ~/.julia/packages/MultiScaleTreeGraph/gizDZ/src/write_mtg/write_mtg.jl:44 [inlined]
   [14] write_mtg(file::String, mtg::Node{MutableNodeMTG, Dict{Symbol, Any}})
      @ MultiScaleTreeGraph ~/.julia/packages/MultiScaleTreeGraph/gizDZ/src/write_mtg/write_mtg.jl:29
   [15] (::var"#55#56")(f::String, io::IOStream)
      @ Main ~/.julia/packages/MultiScaleTreeGraph/gizDZ/test/test-write_mtg.jl:9
   [16] mktemp(fn::var"#55#56", parent::String)
      @ Base.Filesystem ./file.jl:771
   [17] mktemp(fn::Function)
      @ Base.Filesystem ./file.jl:769
   [18] macro expansion
      @ ~/.julia/packages/MultiScaleTreeGraph/gizDZ/test/test-write_mtg.jl:8 [inlined]
   [19] macro expansion
      @ /opt/julia/share/julia/stdlib/v1.11/Test/src/Test.jl:1598 [inlined]
   [20] top-level scope
      @ ~/.julia/packages/MultiScaleTreeGraph/gizDZ/test/test-write_mtg.jl:8
   [21] include(fname::String)
      @ Main ./sysimg.jl:38
   [22] macro expansion
      @ ~/.julia/packages/MultiScaleTreeGraph/gizDZ/test/runtests.jl:38 [inlined]
   [23] macro expansion
      @ /opt/julia/share/julia/stdlib/v1.11/Test/src/Test.jl:1598 [inlined]
   [24] top-level scope
      @ ~/.julia/packages/MultiScaleTreeGraph/gizDZ/test/runtests.jl:38
   [25] include(fname::String)
      @ Main ./sysimg.jl:38
   [26] top-level scope
      @ none:6
   [27] eval
      @ Core ./boot.jl:428 [inlined]
   [28] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:291
   [29] _start()
      @ Base ./client.jl:525
```

This error also seen with CrystalInfoFramework, Extremes, DTables, ...

Error 2: ReadStatTables.jl

```
  MethodError: no method matching LabeledArray(::Int64, ::Dict{Union{Missing, Int64}, String})
  
  Closest candidates are:
    LabeledArray(!Matched::AbstractArray{V, N}, ::Dict{K, String}) where {V, N, K}
     @ ReadStatTables ~/.julia/packages/ReadStatTables/jDyWh/src/LabeledArrays.jl:219
  
  Stacktrace:
    [1] getindex
      @ ReadStatTables ~/.julia/packages/ReadStatTables/jDyWh/src/LabeledArrays.jl:326 [inlined]
    [2] _broadcast_getindex
      @ Base.Broadcast ./broadcast.jl:643 [inlined]
    [3] _getindex
      @ Base.Broadcast ./broadcast.jl:673 [inlined]
    [4] _broadcast_getindex
      @ Base.Broadcast ./broadcast.jl:649 [inlined]
    [5] getindex
      @ Base.Broadcast ./broadcast.jl:604 [inlined]
    [6] getindex
      @ Base.Broadcast ./broadcast.jl:611 [inlined]
    [7] macro expansion
      @ Base.Broadcast ./broadcast.jl:1007 [inlined]
    [8] macro expansion
      @ Base.Broadcast ./simdloop.jl:77 [inlined]
    [9] copyto!
      @ Base.Broadcast ./broadcast.jl:1006 [inlined]
   [10] copyto!
      @ Base.Broadcast ./broadcast.jl:924 [inlined]
   [11] copy
      @ Base.Broadcast ./broadcast.jl:896 [inlined]
   [12] materialize(bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(==), Tuple{LabeledVector{Int64, Vector{Int64}, Union{Missing, Int64}}, Int64}})
      @ Base.Broadcast ./broadcast.jl:871
   [13] macro expansion
      @ ~/.julia/packages/ReadStatTables/jDyWh/test/LabeledArrays.jl:130 [inlined]
   [14] macro expansion
      @ /opt/julia/share/julia/stdlib/v1.11/Test/src/Test.jl:676 [inlined]
   [15] macro expansion
      @ ~/.julia/packages/ReadStatTables/jDyWh/test/LabeledArrays.jl:130 [inlined]
   [16] macro expansion
      @ /opt/julia/share/julia/stdlib/v1.11/Test/src/Test.jl:1598 [inlined]
   [17] top-level scope
      @ ~/.julia/packages/ReadStatTables/jDyWh/test/LabeledArrays.jl:56
```

This error also seen with ReadStatTables, ...

Error 3: DrillHoles.jl

```
  ArgumentError: invalid row index: 1 of type Int64
  Stacktrace:
    [1] SubDataFrame
      @ DataFrames ~/.julia/packages/DataFrames/58MUJ/src/subdataframe/subdataframe.jl:88 [inlined]
    [2] SubDataFrame
      @ DataFrames ~/.julia/packages/DataFrames/58MUJ/src/subdataframe/subdataframe.jl:124 [inlined]
    [3] view
      @ DataFrames ~/.julia/packages/DataFrames/58MUJ/src/subdataframe/subdataframe.jl:146 [inlined]
    [4] getindex
      @ DataFrames ~/.julia/packages/DataFrames/58MUJ/src/abstractdataframe/iteration.jl:84 [inlined]
    [5] _broadcast_getindex
      @ Base.Broadcast ./broadcast.jl:643 [inlined]
    [6] _getindex
      @ Base.Broadcast ./broadcast.jl:674 [inlined]
    [7] _broadcast_getindex
      @ Base.Broadcast ./broadcast.jl:649 [inlined]
    [8] getindex
      @ Base.Broadcast ./broadcast.jl:604 [inlined]
    [9] getindex
      @ Base.Broadcast ./broadcast.jl:611 [inlined]
   [10] macro expansion
      @ Base.Broadcast ./broadcast.jl:1007 [inlined]
   [11] macro expansion
      @ Base.Broadcast ./simdloop.jl:77 [inlined]
   [12] copyto!
      @ Base.Broadcast ./broadcast.jl:1006 [inlined]
   [13] copyto!
      @ Base.Broadcast ./broadcast.jl:924 [inlined]
   [14] copy(bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Tuple{Base.OneTo{Int64}}, DataFrames.var"#103#104"{DrillHoles.var"#7#8"{Float64, Float64}}, Tuple{DataFrames.DataFrameRows{SubDataFrame{DataFrame, DataFrames.Index, Vector{Int64}}}}})
      @ Base.Broadcast ./broadcast.jl:896
   [15] materialize
      @ ./broadcast.jl:871 [inlined]
   [16] _filter_helper(f::Function, cols::DataFrames.DataFrameRows{SubDataFrame{DataFrame, DataFrames.Index, Vector{Int64}}})
      @ DataFrames ~/.julia/packages/DataFrames/58MUJ/src/abstractdataframe/abstractdataframe.jl:1216
   [17] #filter#92
      @ ~/.julia/packages/DataFrames/58MUJ/src/abstractdataframe/abstractdataframe.jl:1189 [inlined]
   [18] filter
      @ ~/.julia/packages/DataFrames/58MUJ/src/abstractdataframe/abstractdataframe.jl:1188 [inlined]
   [19] interleave(itables::Vector{DataFrame})
      @ DrillHoles ~/.julia/packages/DrillHoles/cxUUI/src/desurvey.jl:193
   [20] desurvey(collar::Collar{DataFrame}, survey::Survey{DataFrame}, intervals::Vector{Interval{DataFrame}}; step::Symbol, indip::Symbol, outdip::Symbol, len::Nothing, geom::Symbol, radius::Float64)
      @ DrillHoles ~/.julia/packages/DrillHoles/cxUUI/src/desurvey.jl:57
   [21] macro expansion
      @ ~/.julia/packages/DrillHoles/cxUUI/test/runtests.jl:13 [inlined]
   [22] macro expansion
      @ /opt/julia/share/julia/stdlib/v1.11/Test/src/Test.jl:1598 [inlined]
   [23] top-level scope
      @ ~/.julia/packages/DrillHoles/cxUUI/test/runtests.jl:8
   [24] include(fname::String)
      @ Main ./sysimg.jl:38
   [25] top-level scope
      @ none:6
   [26] eval
      @ Core ./boot.jl:428 [inlined]
   [27] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:291
   [28] _start()
      @ Base ./client.jl:525
```