### PR TITLE
Fix variable naming confusion in `warn_if_already_loaded_different()`

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2001,7 +2001,7 @@ function warn_if_already_loaded_different(uuidkey::PkgId)
                 v = get_pkgversion_from_path(dirname(dirname(pkgorig.path)))
                 cur_vstr = isnothing(v) ? "" : "v$v "
             else
-                cur_vstr = "v$v "
+                cur_vstr = "v$(pkgorig.version) "
             end
             new_v = get_pkgversion_from_path(dirname(dirname(new_path)))
             new_vstr = isnothing(new_v) ? "" : "v$new_v "


### PR DESCRIPTION
Without this, it is possible to run into an error that looks like:

```
ERROR: LoadError: UndefVarError: `v` not defined in local scope
Suggestion: check for an assignment to a local variable that shadows a
global of the same name.
Stacktrace:
  [1] warn_if_already_loaded_different(uuidkey::Base.PkgId)
    @ Base ./loading.jl:1998
  [2] __require_prelocked(uuidkey::Base.PkgId, env::String)
    @ Base ./loading.jl:1980
  [3] #invoke_in_world#3
    @ Base ./essentials.jl:989 [inlined]
  [4] invoke_in_world
    @ Base ./essentials.jl:986 [inlined]
  [5] _require_prelocked
    @ Base ./loading.jl:1962 [inlined]
  [6] macro expansion
    @ Base ./loading.jl:1900 [inlined]
  [7] macro expansion
    @ Base ./lock.jl:269 [inlined]
  [8] __require(into::Module, mod::Symbol)
    @ Base ./loading.jl:1861
  [9] #invoke_in_world#3
    @ Base ./essentials.jl:989 [inlined]
 [10] invoke_in_world
    @ Base ./essentials.jl:986 [inlined]
 [11] require(into::Module, mod::Symbol)
    @ Base ./loading.jl:1854
```