### PR TITLE
fix fd_in_limits test on Windows

### DIFF
--- a/stdlib/FileWatching/test/runtests.jl
+++ b/stdlib/FileWatching/test/runtests.jl
@@ -24,10 +24,11 @@ for i in 1:n
         uv_error("pipe", ccall(:uv_pipe, Cint, (Ptr{NTuple{2, Base.OS_HANDLE}}, Cint, Cint), Ref(pipe_fds, i), 0, 0))
     end
     Ctype = Sys.iswindows() ? Ptr{Cvoid} : Cint
+    Itype = Sys.iswindows() ? UInt : Int
     FDmax = Sys.iswindows() ? 0xfffffffe : (n + 60 + (isdefined(Main, :Revise) * 30)) # expectations on reasonable values
     fd_in_limits =
-        0 <= Int(Base.cconvert(Ctype, pipe_fds[i][1])) <= FDmax &&
-        0 <= Int(Base.cconvert(Ctype, pipe_fds[i][2])) <= FDmax
+        0 <= Itype(Base.cconvert(Ctype, pipe_fds[i][1])) <= FDmax &&
+        0 <= Itype(Base.cconvert(Ctype, pipe_fds[i][2])) <= FDmax
     # Dump out what file descriptors are open for easier debugging of failure modes
     if !fd_in_limits && Sys.islinux()
         run(`ls -la /proc/$(getpid())/fd`)

--- a/stdlib/FileWatching/test/runtests.jl
+++ b/stdlib/FileWatching/test/runtests.jl
@@ -24,11 +24,10 @@ for i in 1:n
         uv_error("pipe", ccall(:uv_pipe, Cint, (Ptr{NTuple{2, Base.OS_HANDLE}}, Cint, Cint), Ref(pipe_fds, i), 0, 0))
     end
     Ctype = Sys.iswindows() ? Ptr{Cvoid} : Cint
-    Itype = Sys.iswindows() ? UInt : Int
-    FDmax = Sys.iswindows() ? 0xfffffffe : (n + 60 + (isdefined(Main, :Revise) * 30)) # expectations on reasonable values
+    FDmax = Sys.iswindows() ? typemax(Int32) : (n + 60 + (isdefined(Main, :Revise) * 30)) # expectations on reasonable values
     fd_in_limits =
-        0 <= Itype(Base.cconvert(Ctype, pipe_fds[i][1])) <= FDmax &&
-        0 <= Itype(Base.cconvert(Ctype, pipe_fds[i][2])) <= FDmax
+        0 <= Int(Base.cconvert(Ctype, pipe_fds[i][1])) <= FDmax &&
+        0 <= Int(Base.cconvert(Ctype, pipe_fds[i][2])) <= FDmax
     # Dump out what file descriptors are open for easier debugging of failure modes
     if !fd_in_limits && Sys.islinux()
         run(`ls -la /proc/$(getpid())/fd`)

--- a/stdlib/FileWatching/test/runtests.jl
+++ b/stdlib/FileWatching/test/runtests.jl
@@ -24,7 +24,7 @@ for i in 1:n
         uv_error("pipe", ccall(:uv_pipe, Cint, (Ptr{NTuple{2, Base.OS_HANDLE}}, Cint, Cint), Ref(pipe_fds, i), 0, 0))
     end
     Ctype = Sys.iswindows() ? Ptr{Cvoid} : Cint
-    FDmax = Sys.iswindows() ? 0x7fff : (n + 60 + (isdefined(Main, :Revise) * 30)) # expectations on reasonable values
+    FDmax = Sys.iswindows() ? 0xfffffffe : (n + 60 + (isdefined(Main, :Revise) * 30)) # expectations on reasonable values
     fd_in_limits =
         0 <= Int(Base.cconvert(Ctype, pipe_fds[i][1])) <= FDmax &&
         0 <= Int(Base.cconvert(Ctype, pipe_fds[i][2])) <= FDmax


### PR DESCRIPTION
Closes #52506.

`OS_HANDLE` on Windows is an alias for `WindowsRawSocket`, so I looked at the [win32 socket documentation](https://learn.microsoft.com/en-us/windows/win32/winsock/socket-data-type-2), which says that a socket handle "may take any value in the range `0` to `INVALID_SOCKET–1`."   The `INVALID_SOCKET` is [defined as `~0`](https://stackoverflow.com/questions/10817252/why-is-invalid-socket-defined-as-0-in-winsock2-h-c), i.e. `0xffffffff`.

But I'm not 100% sure the socket docs apply here?  @vtjnash's comment said it should be "in `typemax(DWORD)`" (`== typemax(UInt32)`), which would correspond to `0xffffffff` and not `0xffffffff - 1`.     But I can't find clear docs on the value of a `HANDLE` — if it is really just a pointer, couldn't it be just about anything? (The old code corresponds to `typemax(Int16) == 0x7fff`,  which suggests changing it to `typemax(Int32) == 0x7fffffff`, but I'm not sure where that is coming from either.)   Is there a relevant section of the Win32 docs I should be looking at?

Note that this test dates back to #26341 by @vtjnash.  