### PR TITLE
Fix `MethodError` when warning about a toplevel module

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2022,7 +2022,10 @@ function warn_if_already_loaded_different(uuidkey::PkgId)
                 end
             end
             @warn warnstr
-            push!(already_warned_path_change_pkgs, uuidkey.uuid)
+            # Toplevel modules have a `uuid` of `Nothing`
+            if uuidkey.uuid !== nothing
+                push!(already_warned_path_change_pkgs, uuidkey.uuid)
+            end
         end
     end
 end


### PR DESCRIPTION
Observed on CI here: https://buildkite.com/julialang/julia-master/builds/31909#018cdf0c-6f53-43d5-9f7e-9bc895a7f2e2/776-1066