### PR TITLE
REPL: Fix precompilation and add tests

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1033,8 +1033,13 @@ function cache_file_entry(pkg::PkgId)
         uuid === nothing ? pkg.name : package_slug(uuid)
 end
 
+# for use during running the REPL precompilation subprocess script, given we don't
+# want it to pick up caches that already exist for other optimization levels
+const ignore_compiled_cache = PkgId[]
+
 function find_all_in_cache_path(pkg::PkgId)
     paths = String[]
+    pkg in ignore_compiled_cache && return paths
     entrypath, entryfile = cache_file_entry(pkg)
     for path in joinpath.(DEPOT_PATH, entrypath)
         isdir(path) || continue

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -50,6 +50,12 @@ precompile(Tuple{typeof(Base.hashindex), String, Int64})
 precompile(Tuple{typeof(Base.write), Base.GenericIOBuffer{Array{UInt8, 1}}, String})
 precompile(Tuple{typeof(Base.indexed_iterate), Tuple{Nothing, Int64}, Int64})
 precompile(Tuple{typeof(Base.indexed_iterate), Tuple{Nothing, Int64}, Int64, Int64})
+precompile(Tuple{typeof(Base._typeddict), Base.Dict{String, Any}, Base.Dict{String, Any}, Vararg{Base.Dict{String, Any}}})
+precompile(Tuple{typeof(Base.promoteK), Type, Base.Dict{String, Any}, Base.Dict{String, Any}})
+precompile(Tuple{typeof(Base.promoteK), Type, Base.Dict{String, Any}})
+precompile(Tuple{typeof(Base.promoteV), Type, Base.Dict{String, Any}, Base.Dict{String, Any}})
+precompile(Tuple{typeof(Base.eval_user_input), Base.PipeEndpoint, Any, Bool})
+precompile(Tuple{typeof(Base.get), Base.PipeEndpoint, Symbol, Bool})
 
 # used by Revise.jl
 precompile(Tuple{typeof(Base.parse_cache_header), String})

--- a/src/gf.c
+++ b/src/gf.c
@@ -2341,24 +2341,11 @@ jl_code_instance_t *jl_method_compiled(jl_method_instance_t *mi, size_t world)
 }
 
 jl_mutex_t precomp_statement_out_lock;
-ios_t f_precompile;
-JL_STREAM* s_precompile = NULL;
-
-static void init_precompile_output(void)
-{
-    const char *t = jl_options.trace_compile;
-    if (!strncmp(t, "stderr", 6)) {
-        s_precompile = JL_STDERR;
-    }
-    else {
-        if (ios_file(&f_precompile, t, 1, 1, 1, 1) == NULL)
-            jl_errorf("cannot open precompile statement file \"%s\" for writing", t);
-        s_precompile = (JL_STREAM*) &f_precompile;
-    }
-}
 
 static void record_precompile_statement(jl_method_instance_t *mi)
 {
+    static ios_t f_precompile;
+    static JL_STREAM* s_precompile = NULL;
     jl_method_t *def = mi->def.method;
     if (jl_options.trace_compile == NULL)
         return;
@@ -2367,7 +2354,15 @@ static void record_precompile_statement(jl_method_instance_t *mi)
 
     JL_LOCK(&precomp_statement_out_lock);
     if (s_precompile == NULL) {
-        init_precompile_output();
+        const char *t = jl_options.trace_compile;
+        if (!strncmp(t, "stderr", 6)) {
+            s_precompile = JL_STDERR;
+        }
+        else {
+            if (ios_file(&f_precompile, t, 1, 1, 1, 1) == NULL)
+                jl_errorf("cannot open precompile statement file \"%s\" for writing", t);
+            s_precompile = (JL_STREAM*) &f_precompile;
+        }
     }
     if (!jl_has_free_typevars(mi->specTypes)) {
         jl_printf(s_precompile, "precompile(");
@@ -2376,20 +2371,6 @@ static void record_precompile_statement(jl_method_instance_t *mi)
         if (s_precompile != JL_STDERR)
             ios_flush(&f_precompile);
     }
-    JL_UNLOCK(&precomp_statement_out_lock);
-}
-
-JL_DLLEXPORT void jl_write_precompile_statement(char* statement)
-{
-    if (jl_options.trace_compile == NULL)
-        return;
-    JL_LOCK(&precomp_statement_out_lock);
-    if (s_precompile == NULL) {
-        init_precompile_output();
-    }
-    jl_printf(s_precompile, "%s\n", statement);
-    if (s_precompile != JL_STDERR)
-        ios_flush(&f_precompile);
     JL_UNLOCK(&precomp_statement_out_lock);
 }
 

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -355,7 +355,6 @@
     XX(jl_new_typevar) \
     XX(jl_next_from_addrinfo) \
     XX(jl_normalize_to_compilable_sig) \
-    XX(jl_write_precompile_statement) \
     XX(jl_no_exc_handler) \
     XX(jl_object_id) \
     XX(jl_object_id_) \

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -14,21 +14,8 @@ REPL.run_repl(repl)
 """
 module REPL
 
-const PRECOMPILE_STATEMENTS = Vector{String}()
-
 function __init__()
     Base.REPL_MODULE_REF[] = REPL
-    # We can encounter the situation where the sub-ordinate process used
-    # during precompilation of REPL, can load a valid cache-file.
-    # We need to replay the statements such that the parent process
-    # can also include those. See JuliaLang/julia#51532
-    if Base.JLOptions().trace_compile !== C_NULL && !isempty(PRECOMPILE_STATEMENTS)
-        for statement in PRECOMPILE_STATEMENTS
-            ccall(:jl_write_precompile_statement, Cvoid, (Cstring,), statement)
-        end
-    else
-        empty!(PRECOMPILE_STATEMENTS)
-    end
 end
 
 Base.Experimental.@optlevel 1

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -78,11 +78,18 @@ generate_precompile_statements() = try
         # Collect statements from running a REPL process and replaying our REPL script
         touch(precompile_file)
         pts, ptm = open_fake_pty()
-        cmdargs = `-e 'import REPL; REPL.Terminals.is_precompiling[] = true'`
-        p = run(addenv(addenv(```$(julia_exepath()) -O0 --trace-compile=$precompile_file
-                --cpu-target=native --startup-file=no --compiled-modules=existing --color=yes -i $cmdargs```, procenv),
-                "JULIA_PKG_PRECOMPILE_AUTO" => "0"),
-            pts, pts, pts; wait=false)
+        # we don't want existing REPL caches to be used so ignore them
+        setup_cmd = """
+        push!(Base.ignore_compiled_cache, Base.PkgId(Base.UUID("3fa0cd96-eef1-5676-8a61-b3b8758bbffb"), "REPL"))
+        import REPL
+        REPL.Terminals.is_precompiling[] = true
+        """
+        p = run(
+                addenv(```$(julia_exepath()) -O0 --trace-compile=$precompile_file
+                    --cpu-target=native --startup-file=no --compiled-modules=existing
+                    --color=yes -i -e "$setup_cmd"```, procenv),
+                pts, pts, pts; wait=false
+            )
         Base.close_stdio(pts)
         # Prepare a background process to copy output from process until `pts` is closed
         output_copy = Base.BufferStream()
@@ -181,9 +188,9 @@ generate_precompile_statements() = try
             if !isexpr(ps, :call)
                 # these are typically comments
                 @debug "skipping statement because it does not parse as an expression" statement
+                delete!(statements, statement)
                 continue
             end
-            push!(REPL.PRECOMPILE_STATEMENTS, statement)
             popfirst!(ps.args) # precompile(...)
             ps.head = :tuple
             # println(ps)

--- a/stdlib/REPL/test/precompilation.jl
+++ b/stdlib/REPL/test/precompilation.jl
@@ -1,0 +1,49 @@
+
+## Tests that compilation in the interactive session startup are as expected
+
+using Test
+Base.include(@__MODULE__, joinpath(Sys.BINDIR, "..", "share", "julia", "test", "testhelpers", "FakePTYs.jl"))
+import .FakePTYs: open_fake_pty
+
+if !Sys.iswindows()
+    # TODO: reenable this on Windows. Without it we're not checking that Windows startup has no compilation.
+    # On Windows CI runners using `open_fake_pty` is causing:
+    # ----
+    # `stty: 'standard input': Inappropriate ioctl for device
+    # Unhandled Task ERROR: failed process: Process(`stty raw -echo onlcr -ocrnl opost`, ProcessExited(1)) [1]
+    # ----
+    @testset "No interactive startup compilation" begin
+        f, _ = mktemp()
+
+        # start an interactive session
+        cmd = `$(Base.julia_cmd()[1]) --trace-compile=$f -q --startup-file=no -i`
+        pts, ptm = open_fake_pty()
+        p = run(cmd, pts, pts, pts; wait=false)
+        Base.close_stdio(pts)
+        std = readuntil(ptm, "julia>")
+        # check for newlines instead of equality with "julia>" because color may be on
+        occursin("\n", std) && @info "There was output before the julia prompt:\n$std"
+        sleep(1) # sometimes precompiles output just after prompt appears
+        tracecompile_out = read(f, String)
+        close(ptm) # close after reading so we don't get precompiles from error shutdown
+
+        expected_precompiles = 0
+
+        n_precompiles = count(r"precompile\(", tracecompile_out)
+
+        @test n_precompiles <= expected_precompiles
+
+        if n_precompiles == 0
+            @debug "REPL: trace compile output: (none)"
+        elseif n_precompiles > expected_precompiles
+            @info "REPL: trace compile output:\n$tracecompile_out"
+        else
+            @debug "REPL: trace compile output:\n$tracecompile_out"
+        end
+        # inform if lowered
+        if expected_precompiles > 0 && (n_precompiles < expected_precompiles)
+            @info "REPL: Actual number of precompiles has dropped below expected." n_precompiles expected_precompiles
+        end
+
+    end
+end

--- a/stdlib/REPL/test/runtests.jl
+++ b/stdlib/REPL/test/runtests.jl
@@ -3,6 +3,10 @@
 # Make a copy of the original environment
 original_env = copy(ENV)
 
+module PrecompilationTests
+    include("precompilation.jl")
+end
+
 module REPLTests
     include("repl.jl")
 end


### PR DESCRIPTION
Approaches fixing https://github.com/JuliaLang/julia/issues/51532 in a different way to https://github.com/JuliaLang/julia/pull/51565

Means precompiles aren't dumped out whether or not they're compiled i.e. https://github.com/JuliaLang/julia/issues/52769

With this PR there's no precompiles left out
```
% ./julia --trace-compile=stderr -q --startup-file=no 
julia> 
```
nor `-O3` (after a precompilation run)
```
% ./julia --trace-compile=stderr -q --startup-file=no -O3
julia> 
```
And it sets up tests to keep it 0 (disabled on Windows because of a `open_fake_pty` issue I couldn't figure out)

Fixes https://github.com/JuliaLang/julia/pull/52783