### PR TITLE
Switch `already_warned_path_change_pkgs` to `Set{PkgId}()`

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1996,6 +1996,7 @@ function warn_if_already_loaded_different(uuidkey::PkgId)
     pkgorig = get(pkgorigins, uuidkey, nothing)
     if pkgorig !== nothing && pkgorig.path !== nothing
         # `locate_package()` can throw an error; if that happens just skip
+        local new_path
         try
             new_path = locate_package(uuidkey)
         catch

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1989,13 +1989,18 @@ function __require_prelocked(uuidkey::PkgId, env=nothing)
     return newm
 end
 
-const already_warned_path_change_pkgs = Set{UUID}()
+const already_warned_path_change_pkgs = Set{PkgId}()
 # warns if the loaded version of a module is different to the one that locate_package wants to load
 function warn_if_already_loaded_different(uuidkey::PkgId)
-    uuidkey.uuid ∈ already_warned_path_change_pkgs && return
+    uuidkey ∈ already_warned_path_change_pkgs && return
     pkgorig = get(pkgorigins, uuidkey, nothing)
     if pkgorig !== nothing && pkgorig.path !== nothing
-        new_path = locate_package(uuidkey)
+        # `locate_package()` can throw an error; if that happens just skip
+        try
+            new_path = locate_package(uuidkey)
+        catch
+            return
+        end
 
         # new_path can be `nothing` if `uuidkey` is not loadable in this environment
         if new_path === nothing
@@ -2027,10 +2032,7 @@ function warn_if_already_loaded_different(uuidkey::PkgId)
                 end
             end
             @warn warnstr
-            # Toplevel modules have a `uuid` of `Nothing`
-            if uuidkey.uuid !== nothing
-                push!(already_warned_path_change_pkgs, uuidkey.uuid)
-            end
+            push!(already_warned_path_change_pkgs, uuidkey)
         end
     end
 end


### PR DESCRIPTION
Also, catch one more area where this can cause problems; `locate_package()` can throw, so we ignore anything that throws in there.

This change suggested by @vtjnash in https://github.com/JuliaLang/julia/pull/52782#issuecomment-1879817224