### PR TITLE
Allow CodeInstance in Expr(:invoke)

### DIFF
--- a/base/compiler/ssair/EscapeAnalysis/EscapeAnalysis.jl
+++ b/base/compiler/ssair/EscapeAnalysis/EscapeAnalysis.jl
@@ -1060,7 +1060,8 @@ end
 
 # escape statically-resolved call, i.e. `Expr(:invoke, ::MethodInstance, ...)`
 function escape_invoke!(astate::AnalysisState, pc::Int, args::Vector{Any})
-    mi = first(args)::MethodInstance
+    arg1 = first(args)
+    mi = isa(arg1, Core.CodeInstance) ? arg1.def : arg1::MethodInstance
     first_idx, last_idx = 2, length(args)
     # TODO inspect `astate.ir.stmts[pc][:info]` and use const-prop'ed `InferenceResult` if available
     cache = astate.get_escape_cache(mi)

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -141,7 +141,9 @@ function reprocess_instruction!(interp::AbstractInterpreter, inst::Instruction, 
             (; rt, effects) = abstract_eval_statement_expr(interp, stmt, nothing, irsv)
             add_flag!(inst, flags_for_effects(effects))
         elseif head === :invoke
-            rt, (nothrow, noub) = concrete_eval_invoke(interp, stmt, stmt.args[1]::MethodInstance, irsv)
+            arg1 = stmt.args[1]
+            mi = isa(arg1, CodeInstance) ? arg1.def : arg1::MethodInstance
+            rt, (nothrow, noub) = concrete_eval_invoke(interp, stmt, mi, irsv)
             if nothrow
                 add_flag!(inst, IR_FLAG_NOTHROW)
             end

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -52,7 +52,8 @@ function print_stmt(io::IO, idx::Int, @nospecialize(stmt), used::BitSet, maxleng
         stmt = stmt::Expr
         # TODO: why is this here, and not in Base.show_unquoted
         print(io, "invoke ")
-        linfo = stmt.args[1]::Core.MethodInstance
+        arg1 = stmt.args[1]
+        linfo = isa(arg1, Core.CodeInstance) ? arg1.def : arg1::Core.MethodInstance
         show_unquoted(io, stmt.args[2], indent)
         print(io, "(")
         # XXX: this is wrong if `sig` is not a concretetype method

--- a/test/compiler/irutils.jl
+++ b/test/compiler/irutils.jl
@@ -35,8 +35,8 @@ end
 
 # check if `x` is a statically-resolved call of a function whose name is `sym`
 isinvoke(y) = @nospecialize(x) -> isinvoke(y, x)
-isinvoke(sym::Symbol, @nospecialize(x)) = isinvoke(mi->mi.def.name===sym, x)
-isinvoke(pred::Function, @nospecialize(x)) = isexpr(x, :invoke) && pred(x.args[1]::MethodInstance)
+isinvoke(sym::Symbol, @nospecialize(x)) = isinvoke(mi->(isa(mi, CodeInstance) ? mi.def.def : mi.def).name===sym, x)
+isinvoke(pred::Function, @nospecialize(x)) = isexpr(x, :invoke) && pred(x.args[1]::Union{MethodInstance, CodeInstance})
 
 fully_eliminated(@nospecialize args...; retval=(@__FILE__), kwargs...) =
     fully_eliminated(code_typed1(args...; kwargs...); retval)


### PR DESCRIPTION
This is a quick experiment to see what it would look like to switch Expr(:invoke) to use CodeInstance rather than MethodInstance. There is some unresolved semantic questions here about whether this is a good idea or if there's some other representation that's better, but discussion might be easier with an implementation.

The larger context here is the question of whether and how to do more general method specialization. I had written some thoughts in [1], but as mentioned there remains ongoing discussion of whether this is the correct direction or not.

[1] https://hackmd.io/@Og2_pcUySm6R_RPqbZ06JA/S1bqP1D_6