### PR TITLE
Widen eltype in complex hermitian tridiagonal eigen

### DIFF
--- a/stdlib/LinearAlgebra/src/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/src/symmetriceigen.jl
@@ -312,7 +312,7 @@ function eigen(A::Hermitian{Complex{T}, <:Tridiagonal}; kwargs...) where {T}
         S = Vector{Complex{eigtype(T)}}(undef, N)
         S[1] = 1
         for i ∈ 1:N-1
-            S[i+1] = iszero(Er[i]) ? one(eltype(S)) : S[i] * sign(E[i])
+            S[i+1] = iszero(Er[i]) ? oneunit(eltype(S)) : S[i] * sign(E[i])
         end
         B = SymTridiagonal(real(d), Er)
         Λ, Φ = eigen(B; kwargs...)

--- a/stdlib/LinearAlgebra/src/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/src/symmetriceigen.jl
@@ -309,12 +309,12 @@ function eigen(A::Hermitian{Complex{T}, <:Tridiagonal}; kwargs...) where {T}
             E = dl
             Er = abs.(E)
         end
-        S = Vector{Complex{eigtype(T)}}(undef, N)
+        S = Vector{eigtype(eltype(A))}(undef, N)
         S[1] = 1
         for i ∈ 1:N-1
             S[i+1] = iszero(Er[i]) ? oneunit(eltype(S)) : S[i] * sign(E[i])
         end
-        B = SymTridiagonal(real(d), Er)
+        B = SymTridiagonal(float.(real.(d)), Er)
         Λ, Φ = eigen(B; kwargs...)
         return Eigen(Λ, Diagonal(S) * Φ)
     end
@@ -322,6 +322,6 @@ end
 
 function eigvals(A::Hermitian{Complex{T}, <:Tridiagonal}; kwargs...) where {T}
     (; dl, d, du) = parent(A)
-    E = A.uplo == 'U' ? abs.(du) : abs.(dl)
-    eigvals(SymTridiagonal(real.(d), E); kwargs...)
+    Er = A.uplo == 'U' ? abs.(du) : abs.(dl)
+    eigvals(SymTridiagonal(float.(real.(d)), Er); kwargs...)
 end

--- a/stdlib/LinearAlgebra/src/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/src/symmetriceigen.jl
@@ -309,10 +309,10 @@ function eigen(A::Hermitian{Complex{T}, <:Tridiagonal}; kwargs...) where {T}
             E = dl
             Er = abs.(E)
         end
-        S = Vector{Complex{T}}(undef, N)
+        S = Vector{Complex{eigtype(T)}}(undef, N)
         S[1] = 1
         for i ∈ 1:N-1
-            S[i+1] = iszero(Er[i]) ? one(Complex{T}) : S[i] * sign(E[i])
+            S[i+1] = iszero(Er[i]) ? one(eltype(S)) : S[i] * sign(E[i])
         end
         B = SymTridiagonal(real(d), Er)
         Λ, Φ = eigen(B; kwargs...)

--- a/stdlib/LinearAlgebra/test/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/test/symmetriceigen.jl
@@ -144,4 +144,11 @@ end
     @test e0 ≈ eu
 end
 
+@testset "Hermitian tridiagonal eigen with Complex{Int} elements (#52801)" begin
+    dv, ev = fill(complex(2), 4), fill(3-4im, 3)
+    HT = Hermitian(Tridiagonal(ev, dv, ev))
+    λ, V = eigen(HT)
+    @test HT * V ≈ V * Diagonal(λ)
+end
+
 end # module TestSymmetricEigen


### PR DESCRIPTION
Close JuliaLang/LinearAlgebra.jl#1048 by widening the `eltype` appropriately.