### PR TITLE
improve return type inference for `string`

### DIFF
--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -334,7 +334,7 @@ struct LazyLibraryPath
     LazyLibraryPath(pieces::Vector) = new(pieces)
 end
 LazyLibraryPath(args...) = LazyLibraryPath(collect(args))
-Base.string(llp::LazyLibraryPath) = joinpath(string.(llp.pieces)...)
+Base.string(llp::LazyLibraryPath) = joinpath(string.(llp.pieces)...)::String
 Base.cconvert(::Type{Cstring}, llp::LazyLibraryPath) = Base.cconvert(Cstring, string(llp))
 # Define `print` so that we can wrap this in a `LazyString`
 Base.print(io::IO, llp::LazyLibraryPath) = print(io, string(llp))

--- a/test/strings/io.jl
+++ b/test/strings/io.jl
@@ -330,3 +330,12 @@ end
     # test empty args
     @test string() == ""
 end
+
+module StringsIOStringReturnTypesTestModule
+    struct S end
+    Base.joinpath(::S) = S()
+end
+
+@testset "`string` return types" begin
+    @test all(T -> T <: AbstractString, Base.return_types(string))
+end


### PR DESCRIPTION
Packages like URIs.jl overload `joinpath` with methods that return non-strings. This prevents good return type inference for `string` when the types of its arguments are unknown. Even if this is a URIs.jl bug, it makes sense to be defensive about this in the Julia implementation. Also note that URIs.jl is widely-used, JuliaHub says it's got in excess of a thousand (indirect) dependents.

So, IMO, this is a Julia bug that we should fix:

```julia-repl
julia> all(T -> T <: AbstractString, Base.return_types(string))
true

julia> import URIs

julia> all(T -> T <: AbstractString, Base.return_types(string))
false
```

Fixed by adding a `::String` type assertion in `base/libdl.jl`.