### PR TITLE
clarify documentation of do-block syntax

### DIFF
--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -923,9 +923,9 @@ map([A, B, C]) do x
 end
 ```
 
-The `do x` syntax creates an anonymous function with argument `x` and passes 
+The `do x` syntax creates an anonymous function with argument `x` and passes
 the anonymous function as the first argument
-to the "outer" function - [`map`](@ref) in this example. 
+to the "outer" function - [`map`](@ref) in this example.
 Similarly, `do a,b` would create a two-argument anonymous function. Note that `do (a,b)` would create a one-argument anonymous function,
 whose argument is a tuple to be deconstructed. A plain `do` would declare that what follows is an anonymous function of the form `() -> ...`.
 

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -925,7 +925,8 @@ end
 
 The `do x` syntax creates an anonymous function with argument `x` and passes 
 the anonymous function as the first argument
-to [`map`](@ref). Similarly, `do a,b` would create a two-argument anonymous function. Note that `do (a,b)` would create a one-argument anonymous function,
+to the "outer" function - [`map`](@ref) in this example. 
+Similarly, `do a,b` would create a two-argument anonymous function. Note that `do (a,b)` would create a one-argument anonymous function,
 whose argument is a tuple to be deconstructed. A plain `do` would declare that what follows is an anonymous function of the form `() -> ...`.
 
 How these arguments are initialized depends on the "outer" function; here, [`map`](@ref) will

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -923,7 +923,8 @@ map([A, B, C]) do x
 end
 ```
 
-The `do x` syntax creates an anonymous function with argument `x` and passes it as the first argument
+The `do x` syntax creates an anonymous function with argument `x` and passes 
+the anonymous function as the first argument
 to [`map`](@ref). Similarly, `do a,b` would create a two-argument anonymous function. Note that `do (a,b)` would create a one-argument anonymous function,
 whose argument is a tuple to be deconstructed. A plain `do` would declare that what follows is an anonymous function of the form `() -> ...`.
 


### PR DESCRIPTION
I tried to clarify the documentation of the `do`-block syntax. The previous version

> The `do x` syntax creates an anonymous function with argument `x` and passes *it* as the first argument

could be misunderstood since one may think that *it* refers to the argument `x`, not the anonymous function.

CC @DanielDoering