### PR TITLE
Do not let `public` unexport names

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -667,7 +667,7 @@ JL_DLLEXPORT void jl_module_public(jl_module_t *from, jl_sym_t *s, int exported)
 {
     jl_binding_t *b = jl_get_module_binding(from, s, 1);
     b->publicp = 1;
-    b->exportp = exported;
+    b->exportp |= exported;
 }
 
 JL_DLLEXPORT int jl_boundp(jl_module_t *m, jl_sym_t *var)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1182,6 +1182,7 @@ let (src, rt) = only(code_typed(sub2ind_gen, (NTuple,Int,Int,); optimize=false))
 end
 
 # marking a symbol as public should not "unexport" it
+# https://github.com/JuliaLang/julia/issues/52812
 module Mod52812
 export a, b
 public a

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -1180,3 +1180,14 @@ let (src, rt) = only(code_typed(sub2ind_gen, (NTuple,Int,Int,); optimize=false))
     @test any(iscall((src,sub2ind_gen_fallback)), src.code)
     @test any(iscall((src,error)), src.code)
 end
+
+# marking a symbol as public should not "unexport" it
+module Mod52812
+export a, b
+public a
+end
+
+@test Base.isexported(Mod52812, :a)
+@test Base.isexported(Mod52812, :b)
+@test Base.ispublic(Mod52812, :a)
+@test Base.ispublic(Mod52812, :b)


### PR DESCRIPTION
Fixes #52812

(shoutout to caching in the build process: rebuilding Julia from source to test this change was very fast)