### PR TITLE
Do not hide libssp.dll.a (Windows import library) in private library dir

### DIFF
--- a/deps/csl.mk
+++ b/deps/csl.mk
@@ -110,7 +110,7 @@ install-csl:
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/13/libgcc_s.a $(build_private_libdir)/
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/13/libgcc.a $(build_private_libdir)/
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/13/libmsvcrt.a $(build_private_libdir)/
-	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/13/libssp.dll.a $(build_private_libdir)/
+	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/13/libssp.dll.a $(build_libdir)/
 endif
 endif
 ifeq ($(OS),WINNT)
@@ -119,5 +119,5 @@ uninstall-gcc-libraries:
 	-rm -f $(build_private_libdir)/libgcc_s.a
 	-rm -f $(build_private_libdir)/libgcc.a
 	-rm -f $(build_private_libdir)/libmsvcrt.a
-	-rm -f $(build_private_libdir)/libssp.dll.a
+	-rm -f $(build_libdir)/libssp.dll.a
 endif

--- a/deps/csl.mk
+++ b/deps/csl.mk
@@ -110,7 +110,8 @@ install-csl:
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/13/libgcc_s.a $(build_private_libdir)/
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/13/libgcc.a $(build_private_libdir)/
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/13/libmsvcrt.a $(build_private_libdir)/
-	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/13/libssp.dll.a $(build_shlibdir)/
+	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/13/libssp.dll.a $(build_private_libdir)/
+	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/13/libssp.dll.a $(build_libdir)/
 endif
 endif
 ifeq ($(OS),WINNT)
@@ -119,5 +120,6 @@ uninstall-gcc-libraries:
 	-rm -f $(build_private_libdir)/libgcc_s.a
 	-rm -f $(build_private_libdir)/libgcc.a
 	-rm -f $(build_private_libdir)/libmsvcrt.a
-	-rm -f $(build_shlibdir)/libssp.dll.a
+	-rm -f $(build_private_libdir)/libssp.dll.a
+	-rm -f $(build_libdir)/libssp.dll.a
 endif

--- a/deps/csl.mk
+++ b/deps/csl.mk
@@ -110,7 +110,7 @@ install-csl:
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/13/libgcc_s.a $(build_private_libdir)/
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/13/libgcc.a $(build_private_libdir)/
 	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/13/libmsvcrt.a $(build_private_libdir)/
-	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/13/libssp.dll.a $(build_libdir)/
+	cp -a $(build_libdir)/gcc/$(BB_TRIPLET)/13/libssp.dll.a $(build_shlibdir)/
 endif
 endif
 ifeq ($(OS),WINNT)
@@ -119,5 +119,5 @@ uninstall-gcc-libraries:
 	-rm -f $(build_private_libdir)/libgcc_s.a
 	-rm -f $(build_private_libdir)/libgcc.a
 	-rm -f $(build_private_libdir)/libmsvcrt.a
-	-rm -f $(build_libdir)/libssp.dll.a
+	-rm -f $(build_shlibdir)/libssp.dll.a
 endif


### PR DESCRIPTION
Fix #51740 

The libssp.dll.a is a [Windows import library](https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-creation#creating-an-import-library) 

> An import library (.lib) file contains information the linker needs to resolve external references to exported DLL functions, so the system can locate the specified DLL and exported DLL functions at run time. You can create an import library for your DLL when you build your DLL.

That contains the necessary information to _dynamically link_ a DLL on Windows.

Since we are providing libssp.dll on Windows and we want to dynamically link to it, exposing libssp.dll.a is necessary.

`build_libdir` is the location of other *.dll.a import libraries:

```
kittisopikulm@KITTISOPIKULM-2 MINGW64 ~/julia/usr/lib
$ ls *.dll.a
libLLVM-15jl.dll.a         libjulia-codegen.dll.a   libpcre2-16.dll.a
libamd.dll.a               libjulia-internal.dll.a  libpcre2-32.dll.a
libblastrampoline-5.dll.a  libjulia.dll.a           libpcre2-8.dll.a
libbtf.dll.a               libklu.dll.a             libpcre2-posix.dll.a
libcamd.dll.a              libklu_cholmod.dll.a     librbio.dll.a
libccolamd.dll.a           libldl.dll.a             libspqr.dll.a
libcholmod.dll.a           libmbedcrypto.dll.a      libssh2.dll.a
libcolamd.dll.a            libmbedtls.dll.a         libssp.dll.a
libcurl.dll.a              libmbedx509.dll.a        libsuitesparseconfig.dll.a
libgit2.dll.a              libmpfr.dll.a            libumfpack.dll.a
libgmp.dll.a               libnghttp2.dll.a         libuv.dll.a
libgmpxx.dll.a             libopenblas64_.dll.a     libz.dll.a
```

Edit: There seems to be some inconsistencies. I changed it to move to `build_shlibdir` which will be the bin directory where libssp-0.dll lives.

The inconsistency is that libjulia-codegen.so looks in `build_libdir` and `build_private_libdir` while standard library precompilation looks in `build_shlibdir` and `build_private_dir`.