### PR TITLE
Validate more on assertion builds, and abort on errors

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -479,7 +479,7 @@ function InferenceState(result::InferenceResult, cache_mode::UInt8, interp::Abst
     world = get_world_counter(interp)
     src = retrieve_code_info(result.linfo, world)
     src === nothing && return nothing
-    validate_code_in_debug_mode(result.linfo, src, "lowered")
+    maybe_validate_code(result.linfo, src, "lowered")
     return InferenceState(result, src, cache_mode, interp)
 end
 InferenceState(result::InferenceResult, cache_mode::Symbol, interp::AbstractInterpreter) =

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -934,7 +934,7 @@ function run_passes_ipo_safe(
     if made_changes
         @pass "compact 3" ir = compact!(ir, true)
     end
-    if JLOptions().debug_level == 2
+    if ccall(:jl_is_assertsbuild, Cint, ()) == 1
         @timeit "verify 3" (verify_ir(ir, true, false, optimizer_lattice(sv.inlining.interp)); verify_linetable(ir.linetable))
     end
     @label __done__  # used by @pass

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -581,7 +581,7 @@ function finish(me::InferenceState, interp::AbstractInterpreter)
         end
     end
 
-    validate_code_in_debug_mode(me.linfo, me.src, "inferred")
+    maybe_validate_code(me.linfo, me.src, "inferred")
     nothing
 end
 

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -520,6 +520,7 @@ end
 is_root_module(m::Module) = false
 
 inlining_enabled() = (JLOptions().can_inline == 1)
+
 function coverage_enabled(m::Module)
     generating_output() && return false # don't alter caches
     cov = JLOptions().code_coverage
@@ -533,9 +534,12 @@ function coverage_enabled(m::Module)
     end
     return false
 end
+
 function inbounds_option()
     opt_check_bounds = JLOptions().check_bounds
     opt_check_bounds == 0 && return :default
     opt_check_bounds == 1 && return :on
     return :off
 end
+
+is_asserts() = ccall(:jl_is_assertsbuild, Cint, ()) == 1

--- a/base/compiler/validation.jl
+++ b/base/compiler/validation.jl
@@ -62,7 +62,7 @@ end
 InvalidCodeError(kind::AbstractString) = InvalidCodeError(kind, nothing)
 
 function validate_code_in_debug_mode(linfo::MethodInstance, src::CodeInfo, kind::String)
-    if JLOptions().debug_level == 2
+    if ccall(:jl_is_debugbuild, Cint, ()) == 1
         # this is a debug build of julia, so let's validate linfo
         errors = validate_code(linfo, src)
         if !isempty(errors)

--- a/base/compiler/validation.jl
+++ b/base/compiler/validation.jl
@@ -61,9 +61,8 @@ struct InvalidCodeError <: Exception
 end
 InvalidCodeError(kind::AbstractString) = InvalidCodeError(kind, nothing)
 
-function validate_code_in_debug_mode(linfo::MethodInstance, src::CodeInfo, kind::String)
-    if ccall(:jl_is_debugbuild, Cint, ()) == 1
-        # this is a debug build of julia, so let's validate linfo
+function maybe_validate_code(linfo::MethodInstance, src::CodeInfo, kind::String)
+    if is_asserts()
         errors = validate_code(linfo, src)
         if !isempty(errors)
             for e in errors
@@ -75,6 +74,7 @@ function validate_code_in_debug_mode(linfo::MethodInstance, src::CodeInfo, kind:
                             linfo.def, ": ", e)
                 end
             end
+            error("")
         end
     end
 end

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9187,6 +9187,9 @@ jl_llvm_functions_t jl_emit_code(
         jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception());
         jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
         jlbacktrace(); // written to STDERR_FILENO
+#ifndef JL_NDEBUG
+        abort();
+#endif
     }
 
     return decls;

--- a/src/gf.c
+++ b/src/gf.c
@@ -402,6 +402,9 @@ jl_code_info_t *jl_type_infer(jl_method_instance_t *mi, size_t world, int force)
             jlbacktrace(); // written to STDERR_FILENO
         }
         src = NULL;
+#ifndef JL_NDEBUG
+        abort();
+#endif
     }
     ct->world_age = last_age;
     ct->reentrant_timing -= 0b10;

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -284,6 +284,7 @@
     XX(jl_is_binding_deprecated) \
     XX(jl_is_char_signed) \
     XX(jl_is_const) \
+    XX(jl_is_assertsbuild) \
     XX(jl_is_debugbuild) \
     XX(jl_is_foreign_type) \
     XX(jl_is_identifier) \

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -514,6 +514,19 @@ JL_DLLEXPORT int jl_is_debugbuild(void) JL_NOTSAFEPOINT
 }
 
 /**
+ * @brief Check if Julia has been build with assertions enabled.
+ *
+ * @return Returns 1 if assertions are enabled, 0 otherwise.
+ */
+JL_DLLEXPORT int8_t jl_is_assertsbuild(void) JL_NOTSAFEPOINT {
+#ifndef JL_NDEBUG
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+/**
  * @brief Check if Julia's memory debugging is enabled.
  *
  * @return Returns 1 if memory debugging is enabled, 0 otherwise.

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -330,7 +330,9 @@ let _true = Ref(true), f, g, h
 end
 
 # manually generate a broken function, which will break codegen
-# and make sure Julia doesn't crash
+# and make sure Julia doesn't crash (when using a non-asserts build)
+is_asserts() = ccall(:jl_is_assertsbuild, Cint, ()) == 1
+if !is_asserts()
 @eval @noinline Base.@constprop :none f_broken_code() = 0
 let m = which(f_broken_code, ())
    let src = Base.uncompressed_ast(m)
@@ -370,6 +372,7 @@ let err = tempname(),
         end
         rm(err)
     end
+end
 end
 
 # Issue #33163


### PR DESCRIPTION
This PR add a `jl_is_assertsbuild` function (cfr. `jl_is_debugbuild`) for checking if this is an assertions build.
It's used in two places:

1. to enable IR validation, which currently (rather weirdly) depends on `-g2`
2. to make internal compiler errors fatal

Both these changes are intended to help PkgEval in detecting more issues (invalid Julia IR) and make for more robust detection (a fatal signal instead of having to grep logs for `Internal error`, which leads to false positives).

RFC because people actually working on the compiler might have opinions about the process not aborting if invalid IR is encountered.

cc @gbaraldi