### PR TITLE
InteractiveUtils: avoid side-effect compilation in first `@time_imports` print

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1212,13 +1212,13 @@ function run_module_init(mod::Module, i::Int=1)
             cumulative_compile_timing(false);
             comp_time, recomp_time = (cumulative_compile_time_ns() .- compile_elapsedtimes) ./ 1e6
 
-            print(round(elapsedtime, digits=1), " ms $mod.__init__() ")
+            print("$(round(elapsedtime, digits=1)) ms $mod.__init__() ")
             if comp_time > 0
                 printstyled(Ryu.writefixed(Float64(100 * comp_time / elapsedtime), 2), "% compilation time", color = Base.info_color())
             end
             if recomp_time > 0
                 perc = Float64(100 * recomp_time / comp_time)
-                printstyled(" (", perc < 1 ? "<1" : Ryu.writefixed(perc, 0), "% recompilation)", color = Base.warn_color())
+                printstyled(" ($(perc < 1 ? "<1" : Ryu.writefixed(perc, 0))% recompilation)", color = Base.warn_color())
             end
             println()
         end


### PR DESCRIPTION
Before, the first dep with an `__init__()` always showed compilation from just compiling the time_imports tooling
```
% ./julia --startup-file=no -q
julia> @time_imports using NetworkOptions
               ┌ 0.0 ms NetworkOptions.__init__() 
     15.6 ms  NetworkOptions 75.43% compilation time
```
This PR
```
% ./julia --startup-file=no -q                                                                
julia> @time_imports using NetworkOptions
               ┌ 0.0 ms NetworkOptions.__init__() 
      4.6 ms  NetworkOptions
```

Baking `@time_imports` into the REPL pkgimage didn't help because something in the package load system was invalidating the multi-arg print methods this avoids (couldn't figure that out).