### PR TITLE
REPLCompletions: async cache PATH scan

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -17,6 +17,7 @@ module REPL
 const PRECOMPILE_STATEMENTS = Vector{String}()
 
 function __init__()
+    Base.generating_output() || Threads.@spawn REPLCompletions.cache_path()
     Base.REPL_MODULE_REF[] = REPL
     # We can encounter the situation where the sub-ordinate process used
     # during precompilation of REPL, can load a valid cache-file.

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -17,7 +17,7 @@ module REPL
 const PRECOMPILE_STATEMENTS = Vector{String}()
 
 function __init__()
-    Base.generating_output() || Threads.@spawn REPLCompletions.cache_path()
+    Base.generating_output() || Base.errormonitor(Threads.@spawn REPLCompletions.cache_path())
     Base.REPL_MODULE_REF[] = REPL
     # We can encounter the situation where the sub-ordinate process used
     # during precompilation of REPL, can load a valid cache-file.

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -17,7 +17,6 @@ module REPL
 const PRECOMPILE_STATEMENTS = Vector{String}()
 
 function __init__()
-    Base.generating_output() || Base.errormonitor(Threads.@spawn REPLCompletions.cache_path())
     Base.REPL_MODULE_REF[] = REPL
     # We can encounter the situation where the sub-ordinate process used
     # during precompilation of REPL, can load a valid cache-file.

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -328,6 +328,7 @@ function cache_path()
                     rethrow()
                 end
             end
+            yield() # so startup doesn't block when -t1
         end
     end
     return path_cache

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -276,6 +276,7 @@ function cached_PATH_changed()
     global cached_PATH_string
     @lock(PATH_cache_lock, cached_PATH_string) !== get(ENV, "PATH", nothing)
 end
+const PATH_cache_finished = Base.Condition() # used for sync in tests
 
 # caches all reachable files in PATH dirs
 function cache_PATH()
@@ -335,6 +336,7 @@ function cache_PATH()
             yield() # so startup doesn't block when -t1
         end
     end
+    notify(PATH_cache_finished)
     @debug "caching PATH files took $t seconds" length(pathdirs) length(PATH_cache)
     return PATH_cache
 end

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -285,7 +285,7 @@ function cache_path()
     @debug "caching PATH files" PATH=path
     pathdirs = split(path, @static Sys.iswindows() ? ";" : ":")
 
-    for pathdir in pathdirs
+    t = @elapsed for pathdir in pathdirs
         actualpath = try
             realpath(pathdir)
         catch ex
@@ -331,6 +331,7 @@ function cache_path()
             yield() # so startup doesn't block when -t1
         end
     end
+    @debug "caching PATH files took $t seconds" length(pathdirs) length(path_cache)
     return path_cache
 end
 

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -278,7 +278,7 @@ function cache_path()
     global cached_path_string
     path = @lock path_cache_lock begin
         empty!(path_cache)
-        global cached_path_string = get(ENV, "PATH", nothing)
+        cached_path_string = get(ENV, "PATH", nothing)
     end
     path isa String || return
 
@@ -378,8 +378,8 @@ function complete_path(path::AbstractString;
         # If we cannot get lock because its still caching just pass over this so that initial
         # typing isn't laggy. If the PATH string has changed since last cache re-cache it
         global cached_path_string
-        get(ENV, "PATH", nothing) === @lock(path_cache_lock, cached_path_string) || cache_path()
         if trylock(path_cache_lock)
+            get(ENV, "PATH", nothing) === cached_path_string || cache_path()
             for file in path_cache
                 startswith(file, prefix) && push!(matches, file)
             end

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -269,6 +269,42 @@ function do_string_escape(s)
     return escape_string(s, ('\"','$'))
 end
 
+const path_cache_lock = Base.ReentrantLock()
+const path_cache = Dict{String,Vector{String}}()
+
+function cache_path()
+    pathdirs = split(ENV["PATH"], @static Sys.iswindows() ? ";" : ":")
+
+    for pathdir in pathdirs
+        actualpath = try
+            realpath(pathdir)
+        catch ex
+            ex isa Base.IOError || rethrow()
+            # Bash doesn't expect every folder in PATH to exist, so neither shall we
+            continue
+        end
+
+        if actualpath != pathdir && in(actualpath, pathdirs)
+            # Remove paths which (after resolving links) are in the env path twice.
+            # Many distros eg. point /bin to /usr/bin but have both in the env path.
+            continue
+        end
+
+        try
+            @lock path_cache_lock get!(path_cache, pathdir, readdir(pathdir))
+        catch e
+            # Bash allows dirs in PATH that can't be read, so we should as well.
+            if isa(e, Base.IOError) || isa(e, Base.ArgumentError)
+                continue
+            else
+                # We only handle IOError and ArgumentError here
+                rethrow()
+            end
+        end
+    end
+    return path_cache
+end
+
 function complete_path(path::AbstractString;
                        use_envpath=false,
                        shell_escape=false,
@@ -307,37 +343,11 @@ function complete_path(path::AbstractString;
         end
     end
 
-    if use_envpath && isempty(dir)
-        # Look for files in PATH as well
-        pathdirs = split(ENV["PATH"], @static Sys.iswindows() ? ";" : ":")
-
-        for pathdir in pathdirs
-            actualpath = try
-                realpath(pathdir)
-            catch ex
-                ex isa Base.IOError || rethrow()
-                # Bash doesn't expect every folder in PATH to exist, so neither shall we
-                continue
-            end
-
-            if actualpath != pathdir && in(actualpath, pathdirs)
-                # Remove paths which (after resolving links) are in the env path twice.
-                # Many distros eg. point /bin to /usr/bin but have both in the env path.
-                continue
-            end
-
-            filesinpath = try
-                readdir(pathdir)
-            catch e
-                # Bash allows dirs in PATH that can't be read, so we should as well.
-                if isa(e, Base.IOError) || isa(e, Base.ArgumentError)
-                    continue
-                else
-                    # We only handle IOError and ArgumentError here
-                    rethrow()
-                end
-            end
-
+    if use_envpath && isempty(dir) && trylock(path_cache_lock)
+        # Look for files in PATH as well.
+        # these are cached in `cache_path` in a separate task at first shell mode switch.
+        # If we cannot get lock because its still caching just pass over this.
+        for (pathdir, filesinpath) in path_cache
             for file in filesinpath
                 # In a perfect world, we would filter on whether the file is executable
                 # here, or even on whether the current user can execute the file in question.

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -270,12 +270,14 @@ function do_string_escape(s)
 end
 
 const path_cache_lock = Base.ReentrantLock()
-const path_cache = Dict{String,Vector{String}}()
+const path_cache = Set{String}()
 cached_path_string::Union{String,Nothing} = nothing
 
+# caches all reachable files in PATH dirs
 function cache_path()
     pathdirs = @lock path_cache_lock begin
         global cached_path_string = get(ENV, "PATH", nothing)
+        empty!(path_cache)
         cached_path_string isa String || return
         split(cached_path_string, @static Sys.iswindows() ? ";" : ":")
     end
@@ -295,8 +297,8 @@ function cache_path()
             continue
         end
 
-        try
-            @lock path_cache_lock path_cache[pathdir] = readdir(pathdir)
+        filesinpath = try
+            readdir(pathdir)
         catch e
             # Bash allows dirs in PATH that can't be read, so we should as well.
             if isa(e, Base.IOError) || isa(e, Base.ArgumentError)
@@ -304,6 +306,24 @@ function cache_path()
             else
                 # We only handle IOError and ArgumentError here
                 rethrow()
+            end
+        end
+        for file in filesinpath
+            # In a perfect world, we would filter on whether the file is executable
+            # here, or even on whether the current user can execute the file in question.
+            try
+                if isfile(joinpath(pathdir, file))
+                    @lock path_cache_lock push!(path_cache, file)
+                end
+            catch e
+                # `isfile()` can throw in rare cases such as when probing a
+                # symlink that points to a file within a directory we do not
+                # have read access to.
+                if isa(e, Base.IOError)
+                    continue
+                else
+                    rethrow()
+                end
             end
         end
     end
@@ -355,26 +375,10 @@ function complete_path(path::AbstractString;
         if trylock(path_cache_lock)
             # Look for files in PATH as well.
             # these are cached in `cache_path` in a separate task at first shell mode switch.
-            # If we cannot get lock because its still caching just pass over this.
-            for (pathdir, filesinpath) in path_cache
-                for file in filesinpath
-                    # In a perfect world, we would filter on whether the file is executable
-                    # here, or even on whether the current user can execute the file in question.
-                    try
-                        if startswith(file, prefix) && isfile(joinpath(pathdir, file))
-                            push!(matches, file)
-                        end
-                    catch e
-                        # `isfile()` can throw in rare cases such as when probing a
-                        # symlink that points to a file within a directory we do not
-                        # have read access to.
-                        if isa(e, Base.IOError)
-                            continue
-                        else
-                            rethrow()
-                        end
-                    end
-                end
+            # If we cannot get lock because its still caching just pass over this so that initial
+            # typing isn't laggy
+            for file in path_cache
+                startswith(file, prefix) && push!(matches, file)
             end
         end
     end

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -381,7 +381,6 @@ function complete_path(path::AbstractString;
         # Look for files in PATH as well. These are cached in `cache_PATH` in a separate task in REPL init.
         # If we cannot get lock because its still caching just pass over this so that initial
         # typing isn't laggy. If the PATH string has changed since last cache re-cache it
-        global cached_PATH_string
         cached_PATH_changed() && Base.errormonitor(Threads.@spawn REPLCompletions.cache_PATH())
         if trylock(PATH_cache_lock)
             for file in PATH_cache

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -387,6 +387,7 @@ function complete_path(path::AbstractString;
             for file in PATH_cache
                 startswith(file, prefix) && push!(matches, file)
             end
+            unlock(PATH_cache_lock)
         end
     end
 

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1147,6 +1147,11 @@ let s, c, r
             withenv("PATH" => string(path, ":", unreadable)) do
                 s = "tmp-execu"
                 c,r = test_scomplete(s)
+                # Files reachable by PATH are cached async when PATH is seen to have been changed by `complete_path`
+                # so changes are unlikely to appear in the first complete. For testing purposes we can wait for
+                # caching to finish
+                wait(REPL.REPLCompletions.PATH_cache_finished)
+                c,r = test_scomplete(s)
                 @test "tmp-executable" in c
                 @test r == 1:9
                 @test s[r] == "tmp-execu"
@@ -1174,6 +1179,8 @@ let s, c, r
 
             withenv("PATH" => string(tempdir(), ":", dir)) do
                 s = string("repl-completio")
+                c,r = test_scomplete(s)
+                wait(REPL.REPLCompletions.PATH_cache_finished) # wait for caching to complete
                 c,r = test_scomplete(s)
                 @test ["repl-completion"] == c
                 @test s[r] == "repl-completio"


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/52765

In `shell>` when first typing a word tab completion hinting searches the entire PATH list for completions again and again for every char entry.

On slower systems the hinting can make typing quite slow because of this i.e. https://github.com/JuliaLang/julia/issues/52765

This treats the contents reachable by PATH as static for a given session unless the PATH string changes, by caching it once at startup async and then if PATH changes at tab-completion time.

A modification would be to instead do something like update the cache on an async timer.

```
Base.generating_output() || Timer(t->REPLCompletions.cache_path(), 0; interval=60)
``` 