### PR TITLE
Add indirection to inplace matrix scaling

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -129,7 +129,10 @@ match the length of the second, $(length(X))."))
     C
 end
 
-@inline function mul!(C::AbstractArray, s::Number, X::AbstractArray, alpha::Number, beta::Number)
+@inline mul!(C::AbstractArray, s::Number, X::AbstractArray, alpha::Number, beta::Number) =
+    _lscale_add!(C, s, X, alpha, beta)
+
+@inline function _lscale_add!(C::AbstractArray, s::Number, X::AbstractArray, alpha::Number, beta::Number)
     if axes(C) == axes(X)
         C .= (s .* X) .*ₛ alpha .+ C .*ₛ beta
     else
@@ -137,7 +140,10 @@ end
     end
     return C
 end
-@inline function mul!(C::AbstractArray, X::AbstractArray, s::Number, alpha::Number, beta::Number)
+@inline mul!(C::AbstractArray, X::AbstractArray, s::Number, alpha::Number, beta::Number) =
+    _rscale_add!(C, X, s, alpha, beta)
+
+@inline function _rscale_add!(C::AbstractArray, X::AbstractArray, s::Number, alpha::Number, beta::Number)
     if axes(C) == axes(X)
         C .= (X .* s) .*ₛ alpha .+ C .*ₛ beta
     else

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -532,11 +532,9 @@ function copyto!(A::T, B::T) where {T<:Union{LowerTriangular,UnitLowerTriangular
     return A
 end
 
-# Define `mul!` for (Unit){Upper,Lower}Triangular matrices times a number.
-# be permissive here and require compatibility later in _triscale!
-@inline mul!(A::AbstractTriangular, B::AbstractTriangular, C::Number, alpha::Number, beta::Number) =
+@inline _rscale_add!(A::AbstractTriangular, B::AbstractTriangular, C::Number, alpha::Number, beta::Number) =
     _triscale!(A, B, C, MulAddMul(alpha, beta))
-@inline mul!(A::AbstractTriangular, B::Number, C::AbstractTriangular, alpha::Number, beta::Number) =
+@inline _lscale_add!(A::AbstractTriangular, B::Number, C::AbstractTriangular, alpha::Number, beta::Number) =
     _triscale!(A, B, C, MulAddMul(alpha, beta))
 
 function checksize1(A, B)


### PR DESCRIPTION
This is not a big deal, but this adds an indirection layer to right/left scale-and-add of ` AbstractMatrix`. Unfortunately, the broadcast in the generic method performs twice worse than the specialized method, but further improvement of  broadcasting over triangular matrices may render the specialized methods obsolete altogether. Together with  #52837, we have

```julia
julia> using LinearAlgebra

julia> methods(mul!)
# 11 methods for generic function "mul!" from LinearAlgebra:
  [1] mul!(out::AbstractMatrix, A::UniformScaling, b::Number, α::Number, β::Number)
     @ ~/bin/julia/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/uniformscaling.jl:303
  [2] mul!(C::AbstractVecOrMat, J::UniformScaling, B::AbstractVecOrMat, alpha::Number, beta::Number)
     @ ~/bin/julia/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/uniformscaling.jl:285
  [3] mul!(C::AbstractVecOrMat{T}, A::AbstractVecOrMat, Q::LinearAlgebra.AbstractQ{T}) where T
     @ ~/bin/julia/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/abstractq.jl:215
  [4] mul!(C::AbstractMatrix, A::AbstractVecOrMat, B::AbstractVecOrMat, α::Number, β::Number)
     @ ~/bin/julia/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/matmul.jl:285
  [5] mul!(y::AbstractVector, A::AbstractVecOrMat, x::AbstractVector, alpha::Number, beta::Number)
     @ ~/bin/julia/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/matmul.jl:70
  [6] mul!(C::AbstractArray, X::AbstractArray, s::Number, alpha::Number, beta::Number)
     @ ~/bin/julia/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/generic.jl:140
  [7] mul!(C::AbstractMatrix, A::AbstractMatrix, J::UniformScaling, alpha::Number, beta::Number)
     @ ~/bin/julia/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/uniformscaling.jl:283
  [8] mul!(C::AbstractVecOrMat{T}, Q::LinearAlgebra.AbstractQ{T}, B::Union{LinearAlgebra.AbstractQ, AbstractVecOrMat}) where T
     @ ~/bin/julia/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/abstractq.jl:200
 [9] mul!(C::AbstractArray, s::Number, X::AbstractArray, alpha::Number, beta::Number)
     @ ~/bin/julia/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/generic.jl:132
 [10] mul!(out::AbstractMatrix{T}, a::Number, B::UniformScaling, α::Number, β::Number) where T
     @ ~/bin/julia/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/uniformscaling.jl:288
 [11] mul!(C, A, B)
     @ ~/bin/julia/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/matmul.jl:253
```

which seems to contain only "orthogonal" methods, no ones for disambiguation.