### PR TITLE
Code validation and IR verification improvements

### DIFF
--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -2,7 +2,8 @@
 
 function maybe_show_ir(ir::IRCode)
     if isdefined(Core, :Main)
-        invokelatest(Core.Main.Base.display, ir)
+        # ensure we use I/O that does not yield, as this gets called during compilation
+        invokelatest(Core.Main.Base.show, Core.stdout, "text/plain", ir)
     end
 end
 

--- a/base/compiler/validation.jl
+++ b/base/compiler/validation.jl
@@ -253,7 +253,7 @@ end
 
 function is_valid_rvalue(@nospecialize(x))
     is_valid_argument(x) && return true
-    if isa(x, Expr) && x.head in (:new, :splatnew, :the_exception, :isdefined, :call, :invoke, :invoke_modify, :foreigncall, :cfunction, :gc_preserve_begin, :copyast)
+    if isa(x, Expr) && x.head in (:new, :splatnew, :the_exception, :isdefined, :call, :invoke, :invoke_modify, :foreigncall, :cfunction, :gc_preserve_begin, :copyast, :new_opaque_closure)
         return true
     end
     return false


### PR DESCRIPTION
Fixes this code validation error:

```
❯ julia -g2

julia> function test(a)
           f = Base.Experimental.@opaque(()->nothing)
           return 0
       end
test (generic function with 1 method)

julia> Base.code_ircode(test, (Any,))
WARNING: Encountered invalid lowered code for method test(Any): Core.Compiler.InvalidCodeError(kind="invalid RHS value", meta=Expr(:new_opaque_closure, SSAValue(1), SSAValue(2), Core.Any, Tuple))
```

This is already covered by our tests; we just don't happen to run with `-g2` to enable validation (which is what https://github.com/JuliaLang/julia/pull/52830 is aiming to change).

---

Also fixes this IR verification issue:

```
    julia: /cache/build/builder-amdci4-3/julialang/julia-master/src/task.c:447: ctx_switch: Assertion `ptls->locks.len == 0' failed.
[957] signal 6 (-6): Aborted
in expression starting at /cache/build/tester-amdci4-8/julialang/julia-master/julia-0819ad94c1/share/julia/test/subtype.jl:1100
gsignal at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
abort at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
unknown function (ip: 0x7fd5d2fc240e)
__assert_fail at /lib/x86_64-linux-gnu/libc.so.6 (unknown line)
ctx_switch at /cache/build/builder-amdci4-3/julialang/julia-master/src/task.c:447
ijl_switch at /cache/build/builder-amdci4-3/julialang/julia-master/src/task.c:657
try_yieldto at ./task.jl:934
wait at ./task.jl:1008
uv_write at ./stream.jl:1060
...
display at ./multimedia.jl:254
display at ./multimedia.jl:255 [inlined]
display at ./multimedia.jl:340
jfptr_display_53896.1 at /cache/build/tester-amdci4-8/julialang/julia-master/julia-0819ad94c1/lib/julia/sys.so (unknown line)
_jl_invoke at /cache/build/builder-amdci4-3/julialang/julia-master/src/gf.c:2924 [inlined]
ijl_apply_generic at /cache/build/builder-amdci4-3/julialang/julia-master/src/gf.c:3101
jl_apply at /cache/build/builder-amdci4-3/julialang/julia-master/src/julia.h:2152 [inlined]
jl_f__call_latest at /cache/build/builder-amdci4-3/julialang/julia-master/src/builtins.c:875
#invokelatest#3 at ./essentials.jl:955 [inlined]
invokelatest at ./essentials.jl:952 [inlined]
maybe_show_ir at ./compiler/ssair/verify.jl:5 [inlined]
verify_ir at ./compiler/ssair/verify.jl:18
```

... by using `Core.stdout` as an unbuffered version of our libuv output streams.