### PR TITLE
fix typo in cis docs

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -570,7 +570,7 @@ end
 """
     cis(x)
 
-More efficient method for `exp(im*x)` by using Euler's formula: ``cos(x) + i sin(x) = \\exp(i x)``.
+More efficient method for `exp(im*x)` by using Euler's formula: ``\\cos(x) + i \\sin(x) = \\exp(i x)``.
 
 See also [`cispi`](@ref), [`sincos`](@ref), [`exp`](@ref), [`angle`](@ref).
 


### PR DESCRIPTION
Fixes a typo where "sin" and "cos" were formatted incorrectly in the LaTeX formula.