### PR TITLE
Disambiguate some out-of-place matrix multiplications

### DIFF
--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -475,14 +475,14 @@ mul(u::AdjOrTransAbsVec, v::AbstractVector) = _dot_nonrecursive(u, v)
 
 
 # vector * Adjoint/Transpose-vector
-*(u::AbstractVector, v::AdjOrTransAbsVec) = broadcast(*, u, v)
+mul(u::AbstractVector, v::AdjOrTransAbsVec) = broadcast(*, u, v)
 
 # AdjOrTransAbsVec{<:Any,<:AdjOrTransAbsVec} is a lazy conj vectors
 # We need to expand the combinations to avoid ambiguities
-(*)(u::TransposeAbsVec, v::AdjointAbsVec{<:Any,<:TransposeAbsVec}) = _dot_nonrecursive(u, v)
-(*)(u::AdjointAbsVec,   v::AdjointAbsVec{<:Any,<:TransposeAbsVec}) = _dot_nonrecursive(u, v)
-(*)(u::TransposeAbsVec, v::TransposeAbsVec{<:Any,<:AdjointAbsVec}) = _dot_nonrecursive(u, v)
-(*)(u::AdjointAbsVec,   v::TransposeAbsVec{<:Any,<:AdjointAbsVec}) = _dot_nonrecursive(u, v)
+mul(u::TransposeAbsVec, v::AdjointAbsVec{<:Any,<:TransposeAbsVec}) = _dot_nonrecursive(u, v)
+mul(u::AdjointAbsVec,   v::AdjointAbsVec{<:Any,<:TransposeAbsVec}) = _dot_nonrecursive(u, v)
+mul(u::TransposeAbsVec, v::TransposeAbsVec{<:Any,<:AdjointAbsVec}) = _dot_nonrecursive(u, v)
+mul(u::AdjointAbsVec,   v::TransposeAbsVec{<:Any,<:AdjointAbsVec}) = _dot_nonrecursive(u, v)
 
 ## pseudoinversion
 pinv(v::AdjointAbsVec, tol::Real = 0) = pinv(v.parent, tol).parent

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -469,9 +469,9 @@ function _dot_nonrecursive(u, v)
 end
 
 # Adjoint/Transpose-vector * vector
-*(u::AdjointAbsVec{<:Number}, v::AbstractVector{<:Number}) = dot(u.parent, v)
-*(u::TransposeAbsVec{T}, v::AbstractVector{T}) where {T<:Real} = dot(u.parent, v)
-*(u::AdjOrTransAbsVec, v::AbstractVector) = _dot_nonrecursive(u, v)
+mul(u::AdjointAbsVec{<:Number}, v::AbstractVector{<:Number}) = dot(u.parent, v)
+mul(u::TransposeAbsVec{T}, v::AbstractVector{T}) where {T<:Real} = dot(u.parent, v)
+mul(u::AdjOrTransAbsVec, v::AbstractVector) = _dot_nonrecursive(u, v)
 
 
 # vector * Adjoint/Transpose-vector

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -63,7 +63,9 @@ end
 end
 
 # this will throw a DimensionMismatch unless B has 1 row (or 1 col for transposed case):
-(*)(a::AbstractVector, B::AbstractMatrix) = reshape(a, length(a), 1) * B
+(*)(a::AbstractVector, B::AbstractMatrix) = mul(a, B)
+# Add a level of indirection to avoid ambiguities in methods added to (*) by external packages
+mul(a::AbstractVector, B::AbstractMatrix) = reshape(a, length(a), 1) * B
 
 # Add a level of indirection and specialize _mul! to avoid ambiguities in mul!
 @inline mul!(y::AbstractVector, A::AbstractVecOrMat, x::AbstractVector,

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -56,7 +56,7 @@ function (*)(A::StridedMaybeAdjOrTransMat{T}, x::StridedVector{S}) where {T<:Bla
     mul!(similar(x, TS, size(A,1)), A, y)
 end
 (*)(A::AbstractMatrix, x::AbstractVector) = mul(A, x)
-
+# Add a level of indirection to avoid ambiguities in methods added to (*) by external packages
 @inline function mul(A::AbstractMatrix, x::AbstractVector)
     TS = promote_op(matprod, eltype(A), eltype(x))
     mul!(similar(x, TS, axes(A,1)), A, x)
@@ -110,7 +110,7 @@ julia> [1 1; 0 1] * [1 0; 1 1]
 ```
 """
 (*)(A::AbstractMatrix, B::AbstractMatrix) = mul(A, B)
-
+# Add a level of indirection to avoid ambiguities in methods added to (*) by external packages
 @inline function mul(A::AbstractMatrix, B::AbstractMatrix)
     TS = promote_op(matprod, eltype(A), eltype(B))
     mul!(matprod_dest(A, B, TS), A, B)

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -9,6 +9,9 @@ const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
 isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "OffsetArrays.jl"))
 using .Main.OffsetArrays
 
+isdefined(Main, :SizedArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "SizedArrays.jl"))
+using .Main.SizedArrays
+
 @testset "Adjoint and Transpose inner constructor basics" begin
     intvec, intmat = [1, 2], [1 2; 3 4]
     # Adjoint/Transpose eltype must match the type of the Adjoint/Transpose of the input eltype
@@ -701,6 +704,18 @@ end
     B = zero.(At)
     LinearAlgebra.copy_transpose!(B, axes(B, 1), axes(B, 2), A, axes(A, 1), axes(A, 2))
     @test B == At
+end
+
+@testset "matmul ambiguities" begin
+    A = [1,2]
+    S = SizedArrays.SizedArray{(2,)}(A)
+    @test A' * S == A' * A
+    @test transpose(A) * S == A' * A
+
+    B = fill([1 2; 3 4], 2, 2)
+    S2 = SizedArrays.SizedArray{(2,2)}(B)
+    @test A' * B == A' * S2
+    @test transpose(A) * B == transpose(A) * S2
 end
 
 end # module TestAdjointTranspose

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -856,6 +856,8 @@ end
     Xv1 = [X[:, j] for i in 1:1, j in 1:3]
     Xv2 = [transpose(X[i, :]) for i in 1:3]
     Xv3 = [transpose(X[i, :]) for i in 1:3, j in 1:1]
+    Xv4 = [adjoint(X[i, :]) for i in 1:3]
+    Xv5 = [adjoint(X[i, :]) for i in 1:3, j in 1:1]
 
     XX = X * X
     XtX = transpose(X) * X
@@ -887,6 +889,10 @@ end
     @test Xv3 * Xv3' ≈ XXc
     @test transpose(Xv1) * Xv2' ≈ XtXc
     @test transpose(Xv1) * Xv3' ≈ XtXc
+    @test transpose(Xv1) * transpose(Xv4) ≈ XtXc
+    @test transpose(Xv1) * transpose(Xv5) ≈ XtXc
+    @test Xv1' * transpose(Xv4) ≈ XcXc
+    @test Xv1' * transpose(Xv5) ≈ XcXc
     @test Xv1' * Xv2' ≈ XcXc
     @test Xv1' * Xv3' ≈ XcXc
 end

--- a/test/testhelpers/SizedArrays.jl
+++ b/test/testhelpers/SizedArrays.jl
@@ -62,6 +62,7 @@ end
 
 # deliberately wide method definitions to test for method ambiguties in LinearAlgebra
 *(S1::SizedMatrixLike, M::AbstractMatrix) = _data(S1) * M
+*(M::AbstractMatrix, S2::SizedMatrixLike) = M * _data(S2)
 mul!(dest::AbstractMatrix, S1::SizedMatrix, M::AbstractMatrix, α::Number, β::Number) =
     mul!(dest, _data(S1), M, α, β)
 mul!(dest::AbstractMatrix, M::AbstractMatrix, S2::SizedMatrix, α::Number, β::Number) =


### PR DESCRIPTION
This adds a level of indirection to `*(::AbstractMatrix, ::AbstractMatrix)` and similar functions, rerouting them through the newly defined internal function `mul`, which is in turn specialized for various array types. This eliminates certain method ambiguities that were encountered when packages defined `*(::AbstractMatrix, ::MyMatrix)` for their own matrix types and tried to compute `(::AdjointAbsVec) * (::MyMatrix)`, which conflicted with LinearAlgebra's `(*)(::AdjointAbsVec, ::AbstractMatrix)`.