### PR TITLE
Fix variable name in scaling an `AbstractTriangular` with zero alpha

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -545,7 +545,7 @@ end
 
 function _triscale!(A::UpperTriangular, B::UpperTriangular, c::Number, _add)
     n = checksize1(A, B)
-    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
+    iszero(_add.alpha) && return _rmul_or_fill!(A, _add.beta)
     for j = 1:n
         for i = 1:j
             @inbounds _modify!(_add, B.data[i,j] * c, A.data, (i,j))
@@ -555,7 +555,7 @@ function _triscale!(A::UpperTriangular, B::UpperTriangular, c::Number, _add)
 end
 function _triscale!(A::UpperTriangular, c::Number, B::UpperTriangular, _add)
     n = checksize1(A, B)
-    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
+    iszero(_add.alpha) && return _rmul_or_fill!(A, _add.beta)
     for j = 1:n
         for i = 1:j
             @inbounds _modify!(_add, c * B.data[i,j], A.data, (i,j))
@@ -565,7 +565,7 @@ function _triscale!(A::UpperTriangular, c::Number, B::UpperTriangular, _add)
 end
 function _triscale!(A::UpperOrUnitUpperTriangular, B::UnitUpperTriangular, c::Number, _add)
     n = checksize1(A, B)
-    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
+    iszero(_add.alpha) && return _rmul_or_fill!(A, _add.beta)
     for j = 1:n
         @inbounds _modify!(_add, c, A, (j,j))
         for i = 1:(j - 1)
@@ -576,7 +576,7 @@ function _triscale!(A::UpperOrUnitUpperTriangular, B::UnitUpperTriangular, c::Nu
 end
 function _triscale!(A::UpperOrUnitUpperTriangular, c::Number, B::UnitUpperTriangular, _add)
     n = checksize1(A, B)
-    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
+    iszero(_add.alpha) && return _rmul_or_fill!(A, _add.beta)
     for j = 1:n
         @inbounds _modify!(_add, c, A, (j,j))
         for i = 1:(j - 1)
@@ -587,7 +587,7 @@ function _triscale!(A::UpperOrUnitUpperTriangular, c::Number, B::UnitUpperTriang
 end
 function _triscale!(A::LowerTriangular, B::LowerTriangular, c::Number, _add)
     n = checksize1(A, B)
-    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
+    iszero(_add.alpha) && return _rmul_or_fill!(A, _add.beta)
     for j = 1:n
         for i = j:n
             @inbounds _modify!(_add, B.data[i,j] * c, A.data, (i,j))
@@ -597,7 +597,7 @@ function _triscale!(A::LowerTriangular, B::LowerTriangular, c::Number, _add)
 end
 function _triscale!(A::LowerTriangular, c::Number, B::LowerTriangular, _add)
     n = checksize1(A, B)
-    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
+    iszero(_add.alpha) && return _rmul_or_fill!(A, _add.beta)
     for j = 1:n
         for i = j:n
             @inbounds _modify!(_add, c * B.data[i,j], A.data, (i,j))
@@ -607,7 +607,7 @@ function _triscale!(A::LowerTriangular, c::Number, B::LowerTriangular, _add)
 end
 function _triscale!(A::LowerOrUnitLowerTriangular, B::UnitLowerTriangular, c::Number, _add)
     n = checksize1(A, B)
-    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
+    iszero(_add.alpha) && return _rmul_or_fill!(A, _add.beta)
     for j = 1:n
         @inbounds _modify!(_add, c, A, (j,j))
         for i = (j + 1):n
@@ -618,7 +618,7 @@ function _triscale!(A::LowerOrUnitLowerTriangular, B::UnitLowerTriangular, c::Nu
 end
 function _triscale!(A::LowerOrUnitLowerTriangular, c::Number, B::UnitLowerTriangular, _add)
     n = checksize1(A, B)
-    iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
+    iszero(_add.alpha) && return _rmul_or_fill!(A, _add.beta)
     for j = 1:n
         @inbounds _modify!(_add, c, A, (j,j))
         for i = (j + 1):n

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -252,6 +252,11 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
                 A2tmp = unitt(A1)
                 mul!(A1tmp, cr, A2tmp)
                 @test A1tmp == cr * A2tmp
+
+                A1tmp .= A1
+                @test mul!(A1tmp, A2tmp, cr, 0, 2) == 2A1
+                A1tmp .= A1
+                @test mul!(A1tmp, cr, A2tmp, 0, 2) == 2A1
             else
                 A1tmp = copy(A1)
                 rmul!(A1tmp, ci)


### PR DESCRIPTION
There is no `C` defined in these methods, so this branch used to error.