### PR TITLE
effects: fix #52843, account for mutable values directly embedded to IR

### DIFF
--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -1370,6 +1370,12 @@ top_52531(_) = (set_initialized52531!(true); nothing)
 top_52531(0)
 @test is_initialized52531()
 
+const ref52843 = Ref{Int}()
+@eval func52843() = ($ref52843[] = 1; nothing)
+@test !Core.Compiler.is_foldable(Base.infer_effects(func52843))
+let; Base.Experimental.@force_compile; func52843(); end
+@test ref52843[] == 1
+
 @test Core.Compiler.is_inaccessiblememonly(Base.infer_effects(identity∘identity, Tuple{Any}))
 @test Core.Compiler.is_inaccessiblememonly(Base.infer_effects(()->Vararg, Tuple{}))
 


### PR DESCRIPTION
Fixes another variant of #52531.