### PR TITLE
sroa: Relax scope assertion

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1147,7 +1147,18 @@ function (this::IntermediaryCollector)(@nospecialize(pi), @nospecialize(ssa))
 end
 
 function update_scope_mapping!(scope_mapping, bb, val)
-    @assert (scope_mapping[bb] in (val, SSAValue(0)))
+    current_mapping = scope_mapping[bb]
+    if current_mapping != SSAValue(0)
+        if val == SSAValue(0)
+            # Unreachable bbs will have SSAValue(0), but can branch into
+            # try/catch regions. We could validate with the domtree, but that's
+            # quite expensive for a debug check, so simply allow this without
+            # making any changes to mapping.
+            return
+        end
+        @assert current_mapping == val
+        return
+    end
     scope_mapping[bb] = val
 end
 


### PR DESCRIPTION
It's possible for this assertion to be violated if there's dead code in the middle of the function. I think the best thing to do here is just to relax the assertion to allow this particular case. Fixes #52819.