### PR TITLE
show UUID as Base.UUID(...) when not imported

### DIFF
--- a/base/uuid.jl
+++ b/base/uuid.jl
@@ -101,7 +101,7 @@ let groupings = [36:-1:25; 23:-1:20; 18:-1:15; 13:-1:10; 8:-1:1]
 end
 
 print(io::IO, u::UUID) = print(io, string(u))
-show(io::IO, u::UUID) = print(io, "UUID(\"", u, "\")")
+show(io::IO, u::UUID) = print(io, UUID, "(\"", u, "\")")
 
 isless(a::UUID, b::UUID) = isless(a.value, b.value)
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1300,6 +1300,11 @@ end
     @test sort([a, b]) == [b, a]
 end
 
+@testset "UUID display" begin
+    a = Base.UUID("dbd321ed-e87e-4f33-9511-65b7d01cdd55")
+    @test repr(a) == "$(Base.UUID)(\"dbd321ed-e87e-4f33-9511-65b7d01cdd55\")"
+end
+
 @testset "Libc.rand" begin
     low, high = extrema(Libc.rand(Float64) for i=1:10^4)
     # these fail with probability 2^(-10^4) ≈ 5e-3011


### PR DESCRIPTION
Fixes the problem identified in https://github.com/JuliaLang/julia/pull/52795#issuecomment-1884000786 thanks to @IanButterworth — currently, a `UUID` displays as:
```jl
julia> Base.UUID("30b93cbd-6b28-44ea-8d3f-42a2b647d023")
UUID("30b93cbd-6b28-44ea-8d3f-42a2b647d023")
```
even if the `UUID` symbol has not been imported.  It should display as a qualified name `Base.UUID` unless `UUID` is imported (e.g. by doing `using UUIDs`).  That is, after this PR you will get
```jl
julia> Base.UUID("30b93cbd-6b28-44ea-8d3f-42a2b647d023")
Base.UUID("30b93cbd-6b28-44ea-8d3f-42a2b647d023")
```

This is a tiny patch that just uses the standard type-printing machinery to decide how to display the `UUID` type name.