### PR TITLE
REPLCompletions: PATH caching tweaks

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -384,7 +384,7 @@ function complete_path(path::AbstractString;
     end
 
     if use_envpath && isempty(dir)
-        # Look for files in PATH as well. These are cached in `cache_PATH` in a separate task in REPL init.
+        # Look for files in PATH as well. These are cached in `cache_PATH` in an async task to not block typing.
         # If we cannot get lock because its still caching just pass over this so that initial
         # typing isn't laggy. If the PATH string has changed since last cache re-cache it
         if cached_PATH_changed()

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -278,9 +278,9 @@ function maybe_spawn_cache_PATH()
     @lock PATH_cache_lock begin
         PATH_cache_task isa Task && !istaskdone(PATH_cache_task) && return
         time() < next_cache_update && return
+        PATH_cache_task = Threads.@spawn REPLCompletions.cache_PATH()
+        Base.errormonitor(PATH_cache_task)
     end
-    PATH_cache_task = Threads.@spawn REPLCompletions.cache_PATH()
-    Base.errormonitor(PATH_cache_task)
 end
 
 # caches all reachable files in PATH dirs

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -276,7 +276,7 @@ function cached_PATH_changed()
     global cached_PATH_string
     @lock(PATH_cache_lock, cached_PATH_string) !== get(ENV, "PATH", nothing)
 end
-const PATH_cache_finished = Base.Condition() # used for sync in tests
+const PATH_cache_finished = Threads.Condition() # used for sync in tests
 
 # caches all reachable files in PATH dirs
 function cache_PATH()
@@ -336,7 +336,7 @@ function cache_PATH()
             yield() # so startup doesn't block when -t1
         end
     end
-    notify(PATH_cache_finished)
+    @lock(PATH_cache_finished, notify(PATH_cache_finished))
     @debug "caching PATH files took $t seconds" length(pathdirs) length(PATH_cache)
     return PATH_cache
 end

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -290,6 +290,8 @@ function cache_PATH()
     @debug "caching PATH files" PATH=path
     pathdirs = split(path, @static Sys.iswindows() ? ";" : ":")
 
+    next_yield_time = time() + 0.01
+
     t = @elapsed for pathdir in pathdirs
         actualpath = try
             realpath(pathdir)
@@ -333,7 +335,10 @@ function cache_PATH()
                     rethrow()
                 end
             end
-            yield() # so startup doesn't block when -t1
+            if time() >= next_yield_time
+                yield() # to avoid blocking typing when -t1
+                next_yield_time = time() + 0.01
+            end
         end
     end
     @debug "caching PATH files took $t seconds" length(pathdirs) length(PATH_cache)

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1150,7 +1150,7 @@ let s, c, r
                 # Files reachable by PATH are cached async when PATH is seen to have been changed by `complete_path`
                 # so changes are unlikely to appear in the first complete. For testing purposes we can wait for
                 # caching to finish
-                wait(REPL.REPLCompletions.PATH_cache_finished)
+                wait(REPL.REPLCompletions.PATH_cache_task::Task)
                 c,r = test_scomplete(s)
                 @test "tmp-executable" in c
                 @test r == 1:9
@@ -1180,7 +1180,7 @@ let s, c, r
             withenv("PATH" => string(tempdir(), ":", dir)) do
                 s = string("repl-completio")
                 c,r = test_scomplete(s)
-                wait(REPL.REPLCompletions.PATH_cache_finished) # wait for caching to complete
+                wait(REPL.REPLCompletions.PATH_cache_task::Task) # wait for caching to complete
                 c,r = test_scomplete(s)
                 @test ["repl-completion"] == c
                 @test s[r] == "repl-completio"

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -1146,11 +1146,15 @@ let s, c, r
             # PATH can also contain folders which we aren't actually allowed to read.
             withenv("PATH" => string(path, ":", unreadable)) do
                 s = "tmp-execu"
-                c,r = test_scomplete(s)
                 # Files reachable by PATH are cached async when PATH is seen to have been changed by `complete_path`
                 # so changes are unlikely to appear in the first complete. For testing purposes we can wait for
                 # caching to finish
-                wait(REPL.REPLCompletions.PATH_cache_task::Task)
+                @lock REPL.REPLCompletions.PATH_cache_lock begin
+                    # force the next cache update to happen immediately
+                    REPL.REPLCompletions.next_cache_update = 0
+                end
+                c,r = test_scomplete(s)
+                wait(REPL.REPLCompletions.PATH_cache_task::Task) # wait for caching to complete
                 c,r = test_scomplete(s)
                 @test "tmp-executable" in c
                 @test r == 1:9
@@ -1179,6 +1183,10 @@ let s, c, r
 
             withenv("PATH" => string(tempdir(), ":", dir)) do
                 s = string("repl-completio")
+                @lock REPL.REPLCompletions.PATH_cache_lock begin
+                    # force the next cache update to happen immediately
+                    REPL.REPLCompletions.next_cache_update = 0
+                end
                 c,r = test_scomplete(s)
                 wait(REPL.REPLCompletions.PATH_cache_task::Task) # wait for caching to complete
                 c,r = test_scomplete(s)


### PR DESCRIPTION
Followup to https://github.com/JuliaLang/julia/pull/52833

- [x] Switch to waiting on the cache task for tests (Fixes https://github.com/JuliaLang/julia/issues/52890)
- [x] Only yield if at least 0.01s since last yield, to keep performance but not block typing
- [x] If 10s has passed since last cache re-cache, incase the filesystem has changed

Fixes https://github.com/JuliaLang/julia/issues/52890