### PR TITLE
Debug Artifacts windows failure

### DIFF
--- a/stdlib/Artifacts/test/runtests.jl
+++ b/stdlib/Artifacts/test/runtests.jl
@@ -5,6 +5,14 @@ using Artifacts, Test, Base.BinaryPlatforms
 using Artifacts: with_artifacts_directory, pack_platform!, unpack_platform, load_overrides
 using TOML
 
+@info "Artifacts tests" Base.DEPOT_PATH artifacts_dirs() Artifacts.ARTIFACTS_DIR_OVERRIDE[]
+for depot in Base.DEPOT_PATH
+    @info "depot $depot" readdir(depot)
+end
+for artifact_dir in artifacts_dirs()
+    @info "artifact_dir $artifact_dir" readdir(artifact_dir)
+end
+
 # prepare for the package tests by ensuring the required artifacts are downloaded now
 artifacts_dir = mktempdir()
 run(addenv(`$(Base.julia_cmd()) --color=no $(joinpath(@__DIR__, "refresh_artifacts.jl")) $(artifacts_dir)`, "TERM"=>"dumb"))

--- a/stdlib/Pkg.version
+++ b/stdlib/Pkg.version
@@ -1,4 +1,4 @@
-PKG_BRANCH = master
+PKG_BRANCH = ib/reset_artifact_test
 PKG_SHA1 = 3c86ba27e904807e13beb8cb0466ed70365b0b2d
 PKG_GIT_URL := https://github.com/JuliaLang/Pkg.jl.git
 PKG_TAR_URL = https://api.github.com/repos/JuliaLang/Pkg.jl/tarball/$1


### PR DESCRIPTION
Debugging the intermittent issue https://github.com/JuliaLang/julia/issues/52679 which happens on windows.

It appears that sometimes these Pkg test files in a temp dir 
https://github.com/JuliaLang/Pkg.jl/blob/800cc68cb7edcc35fd0a2305f8cbcce977a189dc/test/artifacts.jl#L666C9-L666C9

are somehow being picked up by Artifacts CI here 
https://github.com/JuliaLang/julia/blob/c3836e1b4d934ce9dfbd4e4a529840842490b1dd/stdlib/Artifacts/test/runtests.jl#L57

where it should be empty.

On jobs where it happens there are temp dir tidyup failures. But it's not clear to me why temp dirs are being shared between these independent test runs.

I'm guessing this started happening since Pkg tests were moved earlier in https://github.com/JuliaLang/julia/pull/52460

