### PR TITLE
Make FDWatcher check for file descriptors equal to -1

### DIFF
--- a/base/libc.jl
+++ b/base/libc.jl
@@ -41,7 +41,7 @@ dup(src::RawFD, target::RawFD) = systemerror("dup", -1 ==
     ccall((@static Sys.iswindows() ? :_dup2 : :dup2), Int32,
                 (RawFD, RawFD), src, target))
 
-show(io::IO, fd::RawFD) = print(io, "RawFD(", bitcast(UInt32, fd), ')')  # avoids invalidation via show_default
+show(io::IO, fd::RawFD) = print(io, "RawFD(", bitcast(Int32, fd), ')')  # avoids invalidation via show_default
 
 # Wrapper for an OS file descriptor (for Windows)
 if Sys.iswindows()

--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -235,6 +235,10 @@ mutable struct _FDWatcher
     @static if Sys.iswindows()
         _FDWatcher(fd::RawFD, mask::FDEvent) = _FDWatcher(fd, mask.readable, mask.writable)
         function _FDWatcher(fd::RawFD, readable::Bool, writable::Bool)
+            if fd == RawFD(-1)
+                throw(ArgumentError("Passed file descriptor is $(fd) == RawFD(-1), this is probably not a valid file descriptor"))
+            end
+
             handle = Libc._get_osfhandle(fd)
             return _FDWatcher(handle, readable, writable)
         end

--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -164,9 +164,12 @@ mutable struct _FDWatcher
         @static if Sys.isunix()
             _FDWatcher(fd::RawFD, mask::FDEvent) = _FDWatcher(fd, mask.readable, mask.writable)
             function _FDWatcher(fd::RawFD, readable::Bool, writable::Bool)
-                if !readable && !writable
+                if fd == RawFD(-1)
+                    throw(ArgumentError("Passed file descriptor is $(fd) == RawFD(-1), this is probably not a valid file descriptor"))
+                elseif !readable && !writable
                     throw(ArgumentError("must specify at least one of readable or writable to create a FDWatcher"))
                 end
+
                 fdnum = Core.Intrinsics.bitcast(Int32, fd) + 1
                 iolock_begin()
                 if fdnum > length(FDWatchers)

--- a/stdlib/FileWatching/test/runtests.jl
+++ b/stdlib/FileWatching/test/runtests.jl
@@ -443,6 +443,9 @@ unwatch_folder(dir)
 rm(file)
 rm(dir)
 
+# Test that creating a FDWatcher with a (probably) negative FD fails
+@test_throws ArgumentError FDWatcher(RawFD(-1), true, true)
+
 @testset "Pidfile" begin
     include("pidfile.jl")
 end


### PR DESCRIPTION
This is almost definitely an invalid file descriptor. And if it's not then that means the process is running out of file descriptors anyway.

I ran into this when my code passed `poll_fd()` a `RawFD(-1)` from a C library, which caused a rather confusing error:
```julia
1-element ExceptionStack:                                                                                                                                                                                                                      
BoundsError: attempt to access 0-element Vector{Any} at index [0]                                                                                                                                                                              
Stacktrace:                                                                                                                                                                                                                                    
 [1] getindex                                                                                                                                                                                                                                  
   @ Base ./essentials.jl:13 [inlined]                                                                                                                                                                                                         
 [2] FileWatching._FDWatcher(fd::RawFD, readable::Bool, writable::Bool)                                                                                                                                                                        
   @ FileWatching /cache/build/builder-amdci4-6/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/FileWatching/src/FileWatching.jl:176                                                                                             
 [3] FileWatching._FDWatcher(fd::RawFD, readable::Bool, writable::Bool)                                                                                                                                                                        
   @ FileWatching /cache/build/builder-amdci4-6/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/FileWatching/src/FileWatching.jl:165 [inlined]                                                                                   
 [4] poll_fd(s::RawFD, timeout_s::Int64; readable::Bool, writable::Bool)                                                                                                                                                                       
   @ FileWatching /cache/build/builder-amdci4-6/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/FileWatching/src/FileWatching.jl:709                                                                                             
 [5] poll_fd (repeats 2 times)                                                                                                                                                                                                                 
   @ /cache/build/builder-amdci4-6/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/FileWatching/src/FileWatching.jl:706 [inlined]
```