### PR TITLE
Fix #35199: type-stable `Base.reduced_indices`

### DIFF
--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -28,11 +28,11 @@ function reduced_indices0(inds::Indices{N}, region_) where N
 end
 
 function _get_valid_region(region)
-    map(region) do i
+    for i in region
         isa(i, Integer) || throw(ArgumentError("reduced dimension(s) must be integers"))
-        (d = Int(i)) < 1 && throw(ArgumentError("region dimension(s) must be ≥ 1, got $d"))
-        return d
+        Int(i) < 1 && throw(ArgumentError("region dimension(s) must be ≥ 1, got $i"))
     end
+    Iterators.map(Int, region)
 end
 
 ###### Generic reduction functions #####

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -17,20 +17,20 @@ reduced_indices(a::AbstractArrayOrBroadcasted, region) = reduced_indices(axes(a)
 # for reductions that keep 0 dims as 0
 reduced_indices0(a::AbstractArray, region) = reduced_indices0(axes(a), region)
 
-function reduced_indices(inds::Indices{N}, region) where N
+function reduced_indices(axs::Indices{N}, region) where N
     _check_valid_region(region)
-    ntuple(i -> i in region ? reduced_index(inds[i]) : inds[i], Val(N))
+    ntuple(d -> d in region ? reduced_index(axs[d]) : axs[d], Val(N))
 end
 
-function reduced_indices0(inds::Indices{N}, region) where N
+function reduced_indices0(axs::Indices{N}, region) where N
     _check_valid_region(region)
-    ntuple(i -> i in region && !isempty(inds[i]) ? reduced_index(inds[i]) : inds[i], Val(N))
+    ntuple(d -> d in region && !isempty(axs[d]) ? reduced_index(axs[d]) : axs[d], Val(N))
 end
 
 function _check_valid_region(region)
-    for i in region
-        isa(i, Integer) || throw(ArgumentError("reduced dimension(s) must be integers"))
-        Int(i) < 1 && throw(ArgumentError("region dimension(s) must be ≥ 1, got $i"))
+    for d in region
+        isa(d, Integer) || throw(ArgumentError("reduced dimension(s) must be integers"))
+        Int(d) < 1 && throw(ArgumentError("region dimension(s) must be ≥ 1, got $d"))
     end
 end
 

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -17,22 +17,21 @@ reduced_indices(a::AbstractArrayOrBroadcasted, region) = reduced_indices(axes(a)
 # for reductions that keep 0 dims as 0
 reduced_indices0(a::AbstractArray, region) = reduced_indices0(axes(a), region)
 
-function reduced_indices(inds::Indices{N}, region_) where N
-    region = _get_valid_region(region_)
+function reduced_indices(inds::Indices{N}, region) where N
+    _check_valid_region(region)
     ntuple(i -> i in region ? reduced_index(inds[i]) : inds[i], Val(N))
 end
 
-function reduced_indices0(inds::Indices{N}, region_) where N
-    region = _get_valid_region(region_)
+function reduced_indices0(inds::Indices{N}, region) where N
+    _check_valid_region(region)
     ntuple(i -> i in region && !isempty(inds[i]) ? reduced_index(inds[i]) : inds[i], Val(N))
 end
 
-function _get_valid_region(region)
+function _check_valid_region(region)
     for i in region
         isa(i, Integer) || throw(ArgumentError("reduced dimension(s) must be integers"))
         Int(i) < 1 && throw(ArgumentError("region dimension(s) must be ≥ 1, got $i"))
     end
-    Iterators.map(Int, region)
 end
 
 ###### Generic reduction functions #####

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -25,9 +25,8 @@ function reduced_indices(inds::Indices{N}, region) where N
         if d < 1
             throw(ArgumentError("region dimension(s) must be ≥ 1, got $d"))
         elseif d <= N
-            rinds = let rinds_=rinds
-                ntuple(j -> j == d ? reduced_index(rinds_[d]) : rinds_[j], Val(N))
-            end
+            tmp = rinds # reassignment prevents boxing
+            rinds = ntuple(j -> j == d ? reduced_index(tmp[d]) : tmp[j], Val(N))
         end
     end
     rinds
@@ -42,9 +41,9 @@ function reduced_indices0(inds::Indices{N}, region) where N
             throw(ArgumentError("region dimension(s) must be ≥ 1, got $d"))
         elseif d <= N
             rind = rinds[d]
-            rinds = let rinds_=rinds, rind=(isempty(rind) ? rind : reduced_index(rind))
-                ntuple(j -> j == d ? rind : rinds_[j], Val(N))
-            end
+            tmpd = isempty(rind) ? rind : reduced_index(rind)
+            tmp = rinds # reassignment prevents boxing
+            rinds = ntuple(j -> j == d ? tmpd : tmp[j], Val(N))
         end
     end
     rinds

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -129,8 +129,7 @@ function issue35199_test(sizes, dims)
     M = rand(Float64, sizes)
     ax = axes(M)
     n1 = @allocations Base.reduced_indices(ax, dims)
-    n2 = @allocations sum(M; dims)
-    return @test (n1, n2) == (0, 1)
+    return @test n1 == 0
 end
 for dims in (1, 2, (1,), (2,), (1,2))
     sizes = (64, 3)

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -124,6 +124,19 @@ fill!(r, -6.3)
 fill!(r, -1.1)
 @test sum!(abs2, r, Breduc, init=false) ≈ safe_sumabs2(Breduc, 1) .- 1.1
 
+# issue #35199
+function issue35199_test(sizes, dims)
+    M = rand(Float64, sizes)
+    ax = axes(M)
+    n1 = @allocations Base.reduced_indices(ax, dims)
+    n2 = @allocations sum(M; dims)
+    return @test (n1, n2) == (0, 1)
+end
+for dims in (1, 2, (1,), (2,), (1,2))
+    sizes = (64, 3)
+    issue35199_test(sizes, dims)
+end
+
 # Small arrays with init=false
 let A = reshape(1:15, 3, 5)
     R = fill(1, 3)


### PR DESCRIPTION
Hi,
This is my first pr to Julia and I would appreciate feedback from the reviewers. It fixes #35199 by rewriting `Base.reduced_indices` to be type stable (and grounded). I was also able to remove a method since that case is covered by the general case.

The changes are illustrated by the following quick benchmarks

```julia
julia> VERSION
v"1.10.0"

julia> using BenchmarkTools

julia> M = [1 2; 3 4]
2×2 Matrix{Int64}:
 1  2
 3  4

julia> @btime sum($M, dims=$(2))
  194.816 ns (5 allocations: 160 bytes)
2×1 Matrix{Int64}:
 3
 7

julia> @btime sum($M, dims=$((2,)))
  209.385 ns (5 allocations: 224 bytes)
2×1 Matrix{Int64}:
 3
 7

julia> function my_reduced_indices(inds::Base.Indices{N}, region) where N
           rinds = inds
           for i in region
               isa(i, Integer) || throw(ArgumentError("reduced dimension(s) must be integers"))
               d = Int(i)
               if d < 1
                   throw(ArgumentError("region dimension(s) must be ≥ 1, got $d"))
               elseif d <= N
                   rinds = let rinds_=rinds
                       ntuple(j -> j == d ? Base.reduced_index(rinds_[d]) : rinds_[j], Val(N))
                   end
               end
           end
           rinds
       end
my_reduced_indices (generic function with 1 method)

julia> Base.reduced_indices(inds::Base.Indices{N}, region::Int) where N = my_reduced_indices(inds, region)

julia> Base.reduced_indices(inds::Base.Indices{N}, region) where N = my_reduced_indices(inds, region)

julia> @btime sum($M, dims=$(2))
  43.582 ns (1 allocation: 80 bytes)
2×1 Matrix{Int64}:
 3
 7

julia> @btime sum($M, dims=$((2,)))
  43.882 ns (1 allocation: 80 bytes)
2×1 Matrix{Int64}:
 3
 7
```

I also rewrote `Base.reduced_indices0` in the same fashion. I wasn't sure how to add tests for this since the improvements are to type-groundedness. Since these changes affect all reductions I hope this solution is robust.