### PR TITLE
add `:import`/`:using`/`:export` heads to `VALID_EXPR_HEADS`

### DIFF
--- a/base/compiler/validation.jl
+++ b/base/compiler/validation.jl
@@ -34,7 +34,10 @@ const VALID_EXPR_HEADS = IdDict{Symbol,UnitRange{Int}}(
     :throw_undef_if_not => 2:2,
     :aliasscope => 0:0,
     :popaliasscope => 0:0,
-    :new_opaque_closure => 4:typemax(Int)
+    :new_opaque_closure => 4:typemax(Int),
+    :import => 1:typemax(Int),
+    :using => 1:typemax(Int),
+    :export => 1:typemax(Int),
 )
 
 # @enum isn't defined yet, otherwise I'd use it for this


### PR DESCRIPTION
Typically, top-level thunks that include these exprs aren't compiled. However, in certain `AbstractInterpreter`s such as JET, there's a need to perform inference on arbitrary top-level thunks for analysis purposes. So this commit updates the IR validator so that it does not raise errors on these exprs.