### PR TITLE
Access only stored inds in `copy` for strided `AbstractTriangular`

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -181,6 +181,12 @@ end
 Array(A::AbstractTriangular) = Matrix(A)
 parent(A::UpperOrLowerTriangular) = A.data
 
+# For strided matrices, we may only loop over the filled triangle
+copy(A::UpperTriangular{<:Any, <:StridedMaybeAdjOrTransMat}) = UpperTriangular(copytrito!(similar(A.data), A.data, 'U'))
+copy(A::UnitUpperTriangular{<:Any, <:StridedMaybeAdjOrTransMat}) = UnitUpperTriangular(copytrito!(similar(A.data), A.data, 'U'))
+copy(A::LowerTriangular{<:Any, <:StridedMaybeAdjOrTransMat}) = LowerTriangular(copytrito!(similar(A.data), A.data, 'L'))
+copy(A::UnitLowerTriangular{<:Any, <:StridedMaybeAdjOrTransMat}) = UnitLowerTriangular(copytrito!(similar(A.data), A.data, 'L'))
+
 # then handle all methods that requires specific handling of upper/lower and unit diagonal
 
 function Matrix{T}(A::LowerTriangular) where T

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -182,10 +182,7 @@ Array(A::AbstractTriangular) = Matrix(A)
 parent(A::UpperOrLowerTriangular) = A.data
 
 # For strided matrices, we may only loop over the filled triangle
-copy(A::UpperTriangular{<:Any, <:StridedMaybeAdjOrTransMat}) = UpperTriangular(copytrito!(similar(A.data), A.data, 'U'))
-copy(A::UnitUpperTriangular{<:Any, <:StridedMaybeAdjOrTransMat}) = UnitUpperTriangular(copytrito!(similar(A.data), A.data, 'U'))
-copy(A::LowerTriangular{<:Any, <:StridedMaybeAdjOrTransMat}) = LowerTriangular(copytrito!(similar(A.data), A.data, 'L'))
-copy(A::UnitLowerTriangular{<:Any, <:StridedMaybeAdjOrTransMat}) = UnitLowerTriangular(copytrito!(similar(A.data), A.data, 'L'))
+copy(A::UpperOrLowerTriangular{<:Any, <:StridedMaybeAdjOrTransMat}) = copyto!(similar(A), A)
 
 # then handle all methods that requires specific handling of upper/lower and unit diagonal
 

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -1007,6 +1007,7 @@ end
             L = MT(A)
             B .= 0
             copyto!(B, L)
+            @test copy(L) == B
             @test L * 2 == 2 * L == 2B
             @test L/2 == B/2
             @test 2\L == 2\B
@@ -1032,6 +1033,7 @@ end
             U = MT(A)
             B .= 0
             copyto!(B, U)
+            @test copy(U) == B
             @test U * 2 == 2 * U == 2B
             @test U/2 == B/2
             @test 2\U == 2\B


### PR DESCRIPTION
This PR fixes the following:
on master
```julia
julia> M = Matrix{Complex{BigFloat}}(undef, 2, 2);

julia> M[1,1] = M[2,2] = M[1,2] = 2;

julia> U = UpperTriangular(view(M, :, :)) # need a wrapper, as the error doesn't happen for `Array`s
2×2 UpperTriangular{Complex{BigFloat}, SubArray{Complex{BigFloat}, 2, Matrix{Complex{BigFloat}}, Tuple{Base.Slice{Base.OneTo{Int64}}, Base.Slice{Base.OneTo{Int64}}}, true}}:
 2.0+0.0im  2.0+0.0im
     ⋅      2.0+0.0im

julia> copy(U)
ERROR: UndefRefError: access to undefined reference
Stacktrace:
  [1] getindex
    @ ./essentials.jl:817 [inlined]
  [2] getindex
    @ ./array.jl:912 [inlined]
  [3] macro expansion
    @ ./multidimensional.jl:919 [inlined]
  [4] macro expansion
    @ ./cartesian.jl:64 [inlined]
  [5] _unsafe_getindex!
    @ ./multidimensional.jl:914 [inlined]
  [6] _unsafe_getindex(::IndexLinear, ::Matrix{Complex{BigFloat}}, ::Base.Slice{Base.OneTo{Int64}}, ::Base.Slice{Base.OneTo{Int64}})
    @ Base ./multidimensional.jl:905
  [7] _getindex
    @ Base ./multidimensional.jl:891 [inlined]
  [8] getindex
    @ Base ./abstractarray.jl:1307 [inlined]
  [9] copy
    @ Base ./subarray.jl:73 [inlined]
 [10] copy(A::UpperTriangular{Complex{BigFloat}, SubArray{Complex{BigFloat}, 2, Matrix{Complex{…}}, Tuple{Base.Slice{…}, Base.Slice{…}}, true}})
    @ LinearAlgebra ~/packages/julias/julia-latest/share/julia/stdlib/v1.11/LinearAlgebra/src/triangular.jl:47
 [11] top-level scope
    @ REPL[36]:1
Some type information was truncated. Use `show(err)` to see complete types
```
This PR:
```julia
julia> copy(U) # doesn't access the indices corresponding to structural zeros
2×2 UpperTriangular{Complex{BigFloat}, Matrix{Complex{BigFloat}}}:
 2.0+0.0im  2.0+0.0im
     ⋅      2.0+0.0im
```
This also improves performance in `isbits` cases:
```julia
julia> M = Matrix{ComplexF64}(undef, 1000, 1000);

julia> L = LowerTriangular(M);

julia> @btime copy($L);
  1.234 ms (3 allocations: 15.26 MiB) # master
  843.973 μs (3 allocations: 15.26 MiB) # PR
```