### PR TITLE
irinterp: don't add backedges to top-level thunks

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -586,12 +586,9 @@ function finish(me::InferenceState, interp::AbstractInterpreter)
 end
 
 # record the backedges
-function store_backedges(caller::InferenceResult, edges::Vector{Any})
-    isa(caller.linfo.def, Method) || return nothing # don't add backedges to toplevel method instance
-    return store_backedges(caller.linfo, edges)
-end
-
+store_backedges(caller::InferenceResult, edges::Vector{Any}) = store_backedges(caller.linfo, edges)
 function store_backedges(caller::MethodInstance, edges::Vector{Any})
+    isa(caller.def, Method) || return nothing # don't add backedges to toplevel method instance
     for itr in BackedgeIterator(edges)
         callee = itr.caller
         if isa(callee, MethodInstance)


### PR DESCRIPTION
irinterp utilizes `store_backedges(::MethodInstance, edges)`, but it doesn't check to prevent adding backedges to top-level thunks. This is no issue in native compilation, however, it can become problematic when an external `AbstractInterpreter` that does irinterp on top-level thunks tries precompilation (this could, for instance, trigger [this assert](https://github.com/JuliaLang/julia/blob/b058146cafec8405aa07f9647642fd485ea3b5d7/src/staticdata_utils.c#L450)). This commit tries to resolve this issue by performing the top-level thunk check within `store_backedges(::MethodInstance, edges)` instead of `store_backedges(::InferenceResult, edges)`