### PR TITLE
replace the `depwarn` special case with the recent compiler annotations

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -517,10 +517,6 @@ const RECURSION_MSG_HARDLIMIT = "Bounded recursion detected under hardlimit. Cal
 function abstract_call_method(interp::AbstractInterpreter,
                               method::Method, @nospecialize(sig), sparams::SimpleVector,
                               hardlimit::Bool, si::StmtInfo, sv::AbsIntState)
-    if method.name === :depwarn && isdefined(Main, :Base) && method.module === Main.Base
-        add_remark!(interp, sv, "Refusing to infer into `depwarn`")
-        return MethodCallResult(Any, Any, false, false, nothing, Effects())
-    end
     sigtuple = unwrap_unionall(sig)
     sigtuple isa DataType ||
         return MethodCallResult(Any, Any, false, false, nothing, Effects())

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -118,7 +118,8 @@ macro deprecate(old, new, export_old=true)
     end
 end
 
-function depwarn(msg, funcsym; force::Bool=false)
+@nospecializeinfer function depwarn(msg, funcsym; force::Bool=false)
+    @nospecialize
     opts = JLOptions()
     if opts.depwarn == 2
         throw(ErrorException(msg))

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -120,6 +120,13 @@ end
 
 @nospecializeinfer function depwarn(msg, funcsym; force::Bool=false)
     @nospecialize
+    # N.B. With this use of `@invokelatest`, we're preventing the addition of backedges from
+    # callees, such as `convert`, to this user-facing method. This approach is designed to
+    # enhance the resilience of packages that utilize `depwarn` against invalidation.
+    return @invokelatest _depwarn(msg, funcsym, force)
+end
+@nospecializeinfer function _depwarn(msg, funcsym, force::Bool)
+    @nospecialize
     opts = JLOptions()
     if opts.depwarn == 2
         throw(ErrorException(msg))


### PR DESCRIPTION
The special handling for `depwarn`, originating from JuliaLang/julia#27918 in 2018, is now set to be replaced by the more recent compiler annotations, esp. `@nospecializeinfer`. Assessing potential regressions from this change might be challenging, but I confirmed this only has a minimal impact on image sizes at least.