### PR TITLE
Fix `widen_diagonal` bug for nested `UnionAll`

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -4460,19 +4460,18 @@ static jl_value_t *insert_nondiagonal(jl_value_t *type, jl_varbinding_t *troot, 
         jl_value_t *newbody = insert_nondiagonal(body, troot, widen2ub);
         if (v) v->var = var; // And restore it after inner insertation.
         jl_value_t *newvar = NULL;
-        JL_GC_PUSH2(&newbody, &newvar);
+        JL_GC_PUSH3(&newbody, &newvar, &type);
         if (body == newbody || jl_has_typevar(newbody, var)) {
             if (body != newbody)
-                newbody = jl_new_struct(jl_unionall_type, var, newbody);
+                type = jl_new_struct(jl_unionall_type, var, newbody);
             // n.b. we do not widen lb, since that would be the wrong direction
             newvar = insert_nondiagonal(var->ub, troot, widen2ub);
             if (newvar != var->ub) {
                 newvar = (jl_value_t*)jl_new_typevar(var->name, var->lb, newvar);
-                newbody = jl_apply_type1(newbody, newvar);
-                newbody = jl_type_unionall((jl_tvar_t*)newvar, newbody);
+                newbody = jl_apply_type1(type, newvar);
+                type = jl_type_unionall((jl_tvar_t*)newvar, newbody);
             }
         }
-        type = newbody;
         JL_GC_POP();
     }
     else if (jl_is_uniontype(type)) {

--- a/test/core.jl
+++ b/test/core.jl
@@ -8076,14 +8076,14 @@ let src = code_lowered(check_globalref_lowering)[1]
 end
 
 # Test correctness of widen_diagonal
-let widen_diagonal(x::UnionAll) = Base.rewrap_unionall(Base.widen_diagonal(Base.unwrap_unionall(x), x), x),
-    check_widen_diagonal(x, y) = !<:(x, y) && x <: widen_diagonal(y)
+let widen_diagonal(x::UnionAll) = Base.rewrap_unionall(Base.widen_diagonal(Base.unwrap_unionall(x), x), x)
     @test Tuple{Int,Float64} <: widen_diagonal(NTuple)
     @test Tuple{Int,Float64} <: widen_diagonal(Tuple{T,T} where {T})
     @test Tuple{Real,Int,Float64} <: widen_diagonal(Tuple{S,Vararg{T}} where {S, T<:S})
     @test Tuple{Int,Int,Float64,Float64} <: widen_diagonal(Tuple{S,S,Vararg{T}} where {S, T<:S})
     @test Union{Tuple{T}, Tuple{T,Int}} where {T} === widen_diagonal(Union{Tuple{T}, Tuple{T,Int}} where {T})
     @test Tuple === widen_diagonal(Union{Tuple{Vararg{S}}, Tuple{Vararg{T}}} where {S, T})
+    @test Tuple{Vararg{Val{<:Set}}} == widen_diagonal(Tuple{Vararg{T}} where T<:Val{<:Set})
 end
 
 # Test try/catch/else ordering


### PR DESCRIPTION
Fix #52919.

BTW, v1.10 was not affected because #52228 was not backported.
(I guess the commit got lost during local rebasing.)