### PR TITLE
Add InteractiveUtils in doc refs to define_editor

### DIFF
--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -223,7 +223,7 @@ Edit a file or directory optionally providing a line number to edit the file at.
 Return to the `julia` prompt when you quit the editor. The editor can be changed
 by setting `JULIA_EDITOR`, `VISUAL` or `EDITOR` as an environment variable.
 
-See also [`define_editor`](@ref).
+See also [`InteractiveUtils.define_editor`](@ref).
 """
 function edit(path::AbstractString, line::Integer=0, column::Integer=0)
     path isa String || (path = convert(String, path))
@@ -255,7 +255,7 @@ method to edit. For modules, open the main source file. The module needs to be l
     `edit` on modules requires at least Julia 1.1.
 
 To ensure that the file can be opened at the given line, you may need to call
-`define_editor` first.
+`InteractiveUtils.define_editor` first.
 """
 function edit(@nospecialize f)
     ms = methods(f).ms


### PR DESCRIPTION
Otherwise since `define_editor` is not exported, it's hard for the user to find what it's referring to.

(Another possibility would be to export `define_editor`)