### PR TITLE
Fix string output of `Base.format_bytes` when `binary=false`

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -140,7 +140,7 @@ function format_bytes(bytes; binary=true) # also used by InteractiveUtils
     factor = binary ? 1024 : 1000
     bytes, mb = prettyprint_getunits(bytes, length(units), Int64(factor))
     if mb == 1
-        return string(Int(bytes), " ", units[mb], bytes==1 ? "" : "s")
+        return string(Int(bytes), " ", _mem_units[mb], bytes==1 ? "" : "s")
     else
         return string(Ryu.writefixed(Float64(bytes), 3), binary ? " $(units[mb])" : "$(units[mb])B")
     end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1394,7 +1394,10 @@ end
     @test (@allocations "a") == 0
     @test (@allocations "a" * "b") == 0 # constant propagation
     @test (@allocations "a" * Base.inferencebarrier("b")) == 1
+end
 
+#TODO: merge with `@testset "Base/timing.jl"` once https://github.com/JuliaLang/julia/issues/52948 is resolved
+@testset "Base/timing.jl2" begin
     # Test the output of `format_bytes()`
     inputs = [(factor * ((1000)^e),binary) for binary in (false,true), factor in (1,2), e in 0:6][:]
     expected_output = ["1 byte", "1 byte", "2 bytes", "2 bytes", "1000 bytes", "1000 bytes", "2.000 kB", "1.953 KiB",

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1399,7 +1399,7 @@ end
 #TODO: merge with `@testset "Base/timing.jl"` once https://github.com/JuliaLang/julia/issues/52948 is resolved
 @testset "Base/timing.jl2" begin
     # Test the output of `format_bytes()`
-    inputs = [(factor * ((1000)^e),binary) for binary in (false,true), factor in (1,2), e in 0:6][:]
+    inputs = [(factor * (Int64(1000)^e),binary) for binary in (false,true), factor in (1,2), e in 0:6][:]
     expected_output = ["1 byte", "1 byte", "2 bytes", "2 bytes", "1000 bytes", "1000 bytes", "2.000 kB", "1.953 KiB",
                         "1000.000 kB", "976.562 KiB", "2.000 MB", "1.907 MiB", "1000.000 MB", "953.674 MiB",
                         "2.000 GB", "1.863 GiB", "1000.000 GB", "931.323 GiB", "2.000 TB", "1.819 TiB",

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1394,6 +1394,18 @@ end
     @test (@allocations "a") == 0
     @test (@allocations "a" * "b") == 0 # constant propagation
     @test (@allocations "a" * Base.inferencebarrier("b")) == 1
+
+    # Test the output of `format_bytes()`
+    inputs = [(factor * ((1000)^e),binary) for binary in (false,true), factor in (1,2), e in 0:6][:]
+    expected_output = ["1 byte", "1 byte", "2 bytes", "2 bytes", "1000 bytes", "1000 bytes", "2.000 kB", "1.953 KiB",
+                        "1000.000 kB", "976.562 KiB", "2.000 MB", "1.907 MiB", "1000.000 MB", "953.674 MiB",
+                        "2.000 GB", "1.863 GiB", "1000.000 GB", "931.323 GiB", "2.000 TB", "1.819 TiB",
+                        "1000.000 TB", "909.495 TiB", "2.000 PB", "1.776 PiB", "1000.000 PB", "888.178 PiB",
+                        "2000.000 PB", "1776.357 PiB"]
+
+    for ((n, binary), expected) in zip(inputs, expected_output)
+        @test Base.format_bytes(n; binary) == expected
+    end
 end
 
 @testset "in_finalizer" begin


### PR DESCRIPTION
Introduced in [50572](https://github.com/JuliaLang/julia/pull/50572)

Before:
```
julia> Base.format_bytes(1, binary=false)
"1 "

julia> Base.format_bytes(11, binary=false)
"11 s"
```

This PR:
```
julia> Base.format_bytes(1, binary=false)
"1 byte"

julia> Base.format_bytes(11, binary=false)
"11 bytes"
```
Also add tests.