### PR TITLE
Sys.SC_CLK_TCK value on windows

### DIFF
--- a/src/sys.c
+++ b/src/sys.c
@@ -631,7 +631,7 @@ JL_DLLEXPORT long jl_SC_CLK_TCK(void)
 #ifndef _OS_WINDOWS_
     return sysconf(_SC_CLK_TCK);
 #else
-    return 0;
+    return 1000; # uv_cpu_info returns times in ms
 #endif
 }
 

--- a/src/sys.c
+++ b/src/sys.c
@@ -631,7 +631,7 @@ JL_DLLEXPORT long jl_SC_CLK_TCK(void)
 #ifndef _OS_WINDOWS_
     return sysconf(_SC_CLK_TCK);
 #else
-    return 1000; # uv_cpu_info returns times in ms
+    return 1000; /* uv_cpu_info returns times in ms on Windows */
 #endif
 }
 


### PR DESCRIPTION
I noticed in #52777 that `Sys.SC_CLK_TCK` is set to `0` on Windows, which is treated as an unknown clock-tick unit.

This undocumented global variable is *only* used by `Sys` to display CPU load times from the `CPUInfo` data structure, which until #52777 was completely undocumented and only seems to be used by `versioninfo(verbose=true)`.    On POSIX systems it is set to a `> 0` value, and is used to convert the CPU times into seconds.   On Windows, it is set to `0`, which is treated as an unknown unit, so the CPU times are displayed without units.

Since it is only used for CPU times, we can look at the [`uv_cpu_info` implementation](https://github.com/libuv/libuv/blob/3b6a1a14caeeeaf5510f2939a8e28ed9ba0ad968/src/win/util.c#L531-L653) to see how libuv computes these values on Windows.  This function calls `pNtQuerySystemInformation`, which returns times in ["100ns intervals"](https://learn.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-ntquerysysteminformation#system_processor_performance_information), i.e. in units of 10⁻⁷ seconds.  However, `uv_cpu_info` then divides these values by `10000`, which converts them to units of milliseconds.

So, I believe that the correct value of `Sys.SC_CLK_TCK` on Windows is `1000`.

Basically this just means that `versioninfo(verbose=true)` output on Windows will get units of seconds when printing CPU loads.  As far as I can tell, no external package is using these (undocumented until now) timing values — the few packages that call `Sys.cpu_info()` only do so to get the `model` (string) field.

cc @inkydragon 