### PR TITLE
NFC: move memory pressure callback declaration to julia_gcext.h

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -51,7 +51,6 @@ static jl_gc_callback_list_t *gc_cblist_post_gc;
 static jl_gc_callback_list_t *gc_cblist_notify_external_alloc;
 static jl_gc_callback_list_t *gc_cblist_notify_external_free;
 static jl_gc_callback_list_t *gc_cblist_notify_gc_pressure;
-typedef void (*jl_gc_cb_notify_gc_pressure_t)(void);
 
 #define gc_invoke_callbacks(ty, list, args) \
     do { \

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -34,6 +34,10 @@ JL_DLLEXPORT void jl_gc_set_cb_notify_external_alloc(jl_gc_cb_notify_external_al
 JL_DLLEXPORT void jl_gc_set_cb_notify_external_free(jl_gc_cb_notify_external_free_t cb,
         int enable);
 
+// Memory pressure callback
+typedef void (*jl_gc_cb_notify_gc_pressure_t)(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_gc_set_cb_notify_gc_pressure(jl_gc_cb_notify_gc_pressure_t cb, int enable);
+
 // Types for custom mark and sweep functions.
 typedef uintptr_t (*jl_markfunc_t)(jl_ptls_t, jl_value_t *obj);
 typedef void (*jl_sweepfunc_t)(jl_value_t *obj);


### PR DESCRIPTION
It should probably be in `julia_gcext.h` together with the other callbacks for consistency.