### PR TITLE
Support execution of code from external abstract interpreters

### DIFF
--- a/Compiler/src/stmtinfo.jl
+++ b/Compiler/src/stmtinfo.jl
@@ -497,4 +497,9 @@ function add_edges_impl(edges::Vector{Any}, info::GlobalAccessInfo)
     push!(edges, info.b)
 end
 
+struct WithinCallInfo <: CallInfo
+    compiler::CompilerInstance
+    info::CallInfo
+end
+
 @specialize

--- a/Compiler/test/plugins.jl
+++ b/Compiler/test/plugins.jl
@@ -1,0 +1,67 @@
+original_load_path = copy(Base.LOAD_PATH)
+pushfirst!(Base.LOAD_PATH, joinpath(@__DIR__, "plugins"))
+
+using Test
+using Tracer
+
+# XXX: should these be in `Tracer/test/runtests.jl`?
+
+function fib(x)
+    if x <= 1
+        return x
+    else
+        return fib(x-1) + fib(x-2)
+    end
+end
+
+let tr = trace(fib, 1)
+    @test tr.f == fib
+    @test tr.args == (1,)
+    child = only(tr.children)
+    @test child.f == Base.:<=
+    @test child.args == (1,1)
+end
+
+let tr = trace(fib, 2)
+    @test tr.f == fib
+    @test tr.args == (2,)
+    @test length(tr.children) == 6
+end
+
+
+using MultilineFusion
+
+# XXX: should these be in `MultilineFusion/test/runtests.jl`?
+
+function multiline(A, B)
+    C = A .* B
+    D = C .+ A
+end
+
+let A = ones(3,3)
+    B = ones(3)
+    @test (@inferred multiline_fusion(multiline, A, B))::Matrix{Float64} == multiline(A, B)
+end
+
+let (ir, _) = only(Base.code_ircode(multiline, (Matrix{Float64}, Vector{Float64}), optimize_until="compact 1"))
+    @test length(ir.stmts) == 5
+    @test ir.stmts[2][:stmt].args[1] == GlobalRef(Base, :materialize)
+end
+
+let (ir, _) = only(Base.code_ircode(multiline, (Matrix{Float64}, Vector{Float64}), optimize_until="compact 1", interp=MultilineFusion.MLFInterp()))
+    @test length(ir.stmts) == 4
+end
+
+# XXX: should these be in `CustomMethodTables/test/runtests.jl`?
+using CustomMethodTables
+
+Base.Experimental.@MethodTable(CustomMT)
+Base.Experimental.@overlay CustomMT Base.sin(x::Float64) = Base.cos(x)
+
+# FIXME: Currently doesn't infer and ends in "Skipped call_within since compiler plugin not constant"
+overlay(f, args...) = CustomMethodTables.overlay(CustomMT, f, args...)
+@test_broken overlay(sin, 1.0) == cos(1.0) # Bug in inference, not using the method_table for initial lookup
+@test overlay((x)->sin(x), 1.0) == cos(1.0)
+
+empty!(Base.LOAD_PATH)
+append!(Base.LOAD_PATH, original_load_path)

--- a/Compiler/test/plugins/MultilineFusion/Project.toml
+++ b/Compiler/test/plugins/MultilineFusion/Project.toml
@@ -1,0 +1,3 @@
+name = "MultilineFusion"
+uuid = "bb4966f2-fd13-4cc8-856b-cab8c274a504"
+version = "0.1.0"

--- a/Compiler/test/plugins/MultilineFusion/src/MultilineFusion.jl
+++ b/Compiler/test/plugins/MultilineFusion/src/MultilineFusion.jl
@@ -1,0 +1,204 @@
+module MultilineFusion
+
+export multiline_fusion
+
+function multiline_fusion(f, args...)
+    Base.invoke_within(MLFCompiler(), f, args...)
+end
+
+const CC = Core.Compiler
+import .CC: SSAValue, GlobalRef
+
+const COMPILER_WORLD = Ref{UInt}(0)
+function __init__()
+    COMPILER_WORLD[] = Base.get_world_counter()
+end
+
+struct MLFCompiler <: CC.AbstractCompiler end
+CC.compiler_world(::MLFCompiler) = COMPILER_WORLD[]
+CC.abstract_interpreter(compiler::MLFCompiler, world::UInt) =
+    MLFInterp(compiler; world)
+
+struct MLFInterp <: CC.AbstractInterpreter
+    compiler::MLFCompiler
+    world::UInt
+    inf_params::CC.InferenceParams
+    opt_params::CC.OptimizationParams
+    inf_cache::Vector{CC.InferenceResult}
+    function MLFInterp(compiler::MLFCompiler = MLFCompiler();
+                world::UInt = Base.get_world_counter(),
+                inf_params::CC.InferenceParams = CC.InferenceParams(),
+                opt_params::CC.OptimizationParams = CC.OptimizationParams(),
+                inf_cache::Vector{CC.InferenceResult} = CC.InferenceResult[])
+        return new(compiler, world, inf_params, opt_params, inf_cache)
+    end
+end
+
+CC.InferenceParams(interp::MLFInterp) = interp.inf_params
+CC.OptimizationParams(interp::MLFInterp) = interp.opt_params
+CC.get_inference_world(interp::MLFInterp) = interp.world
+CC.get_inference_cache(interp::MLFInterp) = interp.inf_cache
+CC.cache_owner(interp::MLFInterp) = interp.compiler
+
+import Core.Compiler: retrieve_code_info, maybe_validate_code
+# Replace usage sited of `retrieve_code_info`, OptimizationState is one such, but in all interesting use-cases
+# it is derived from an InferenceState. There is a third one in `typeinf_ext` in case the module forbids inference.
+function CC.InferenceState(result::CC.InferenceResult, cache_mode::UInt8, interp::MLFInterp)
+    world = CC.get_inference_world(interp)
+    src = retrieve_code_info(result.linfo, world)
+    src === nothing && return nothing
+    maybe_validate_code(result.linfo, src, "lowered")
+    src = transform(interp, result.linfo, src)
+    maybe_validate_code(result.linfo, src, "transformed")
+    return CC.InferenceState(result, src, cache_mode, interp)
+end
+
+function transform(interp, mi, src)
+    ci = copy(src)
+    transform!(mi, ci)
+    return ci
+end
+
+import .CC: userefs, UseRefIterator, UseRef
+
+Base.iterate(useref::UseRefIterator, state...) = CC.iterate(useref, state...)
+Base.getindex(useref::UseRef) = CC.getindex(useref)
+Base.setindex!(useref::UseRef, x) = CC.setindex!(useref, x)
+
+"""
+    is_ir_element(x, y, code::Vector)
+
+Return `true` if `x === y` or if `x` is an `SSAValue` such that
+`is_ir_element(code[x.id], y, code)` is `true`.
+See also: [`replace_match!`](@ref), [`insert_statements!`](@ref)
+"""
+function is_ir_element(x, y, code::Vector)
+    result = false
+    while true # break by default
+        if x === y #
+            result = true
+            break
+        elseif isa(x, Core.SSAValue)
+            x = code[x.id]
+        else
+            break
+        end
+    end
+    return result
+end
+
+mutable struct MaterializeAnalysis
+    def::SSAValue
+    forward::Any
+    removable::Bool
+    MaterializeAnalysis(def, forward) = new(def, forward, true)
+end
+
+"""
+    transform!
+
+The goal of this transform is to perform multi-line fusion of broadcast statements.
+This needs to happen before inference since the broadcast machinery depends on inference
+to perform the actual fusion.
+
+```
+C = A .* B
+D = C .+ A
+```
+
+Is lowered to
+
+```
+1 ─ %1 = Base.broadcasted(Main.:*, A, B)
+│        C = Base.materialize(%1)
+│   %3 = C
+│   %4 = Base.broadcasted(Main.:+, %3, A)
+│   %5 = Base.materialize(%4)
+│        D = %5
+└──      return %5
+```
+
+We find all calls to `materialize` and find all their uses.
+If the materialize statment is used inside a `broadcasted`
+statment we forward the argument to the `broadcasted`.
+
+If it is only used for broadcasted statements we delete
+the call to `Base.materialize`.
+
+```
+1 ─ %1 = Base.broadcasted(Main.:*, A, B)
+│        C = nothing
+│   %3 = C
+│   %4 = Base.broadcasted(Main.:+, %1, A)
+│   %5 = Base.materialize(%4)
+│        D = %5
+└──      return %5
+```
+"""
+function transform!(mi, src)
+    materialize = Base.IdDict{Any, MaterializeAnalysis}()
+    for (i, x) in enumerate(src.code)
+        isassign = Base.Meta.isexpr(x, :(=))
+        stmt = isassign ? x.args[2] : x
+        if Base.Meta.isexpr(stmt, :call)
+            if is_ir_element(stmt.args[1], GlobalRef(Base, :materialize), src.code)
+                manalysis = MaterializeAnalysis(SSAValue(i), stmt.args[2])
+                if isassign
+                    materialize[x.args[1]] = manalysis
+                end
+                materialize[SSAValue(i)] = manalysis
+                continue
+            end
+            if is_ir_element(stmt.args[1], GlobalRef(Base, :broadcasted), src.code)
+                for op in userefs(stmt)
+                    use = op[]
+                    manalysis = get(materialize, use, nothing)
+                    if manalysis !== nothing
+                        op[] = manalysis.forward
+                    end
+                end
+            end
+        elseif isassign
+            if haskey(materialize, x.args[2])
+                materialize[x.args[1]] = materialize[x.args[2]]
+            end
+        elseif x isa CC.SlotNumber || x isa CC.SSAValue
+            if haskey(materialize, x)
+                materialize[SSAValue(i)] = materialize[x]
+            end
+        else
+            for op in userefs(stmt)
+                use = op[]
+                manalysis = get(materialize, use, nothing)
+                if manalysis !== nothing
+                    manalysis.removable = false
+                end
+            end
+        end
+    end
+
+    for manalysis in unique(values(materialize))
+        if manalysis.removable
+            x = src.code[manalysis.def.id]
+            if Base.Meta.isexpr(x, :(=))
+                x.args[2] = nothing
+            else
+                src.code[manalysis.def.id] = nothing
+            end
+        end
+    end
+    return nothing
+end
+
+
+# precompilation
+precompile(CC.abstract_interpreter, (MLFCompiler, UInt))
+precompile(CC.typeinf_ext_toplevel, (MLFInterp, CC.MethodInstance))
+
+COMPILER_WORLD[] = Base.get_world_counter()
+# Insert code execution statements here
+
+# end precompile
+COMPILER_WORLD[] = 0
+
+end # module MultilineFusion

--- a/Compiler/test/plugins/Tracer/Project.toml
+++ b/Compiler/test/plugins/Tracer/Project.toml
@@ -1,0 +1,3 @@
+name = "Tracer"
+uuid = "93438636-d1a8-481a-b8c0-4c0e71b04dee"
+version = "0.1.0"

--- a/Compiler/test/plugins/Tracer/src/Tracer.jl
+++ b/Compiler/test/plugins/Tracer/src/Tracer.jl
@@ -1,0 +1,272 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module Tracer
+
+export trace
+
+struct Call
+    parent
+    f
+    args
+    children
+end
+
+# TODO: Handle task-safety
+const call_tree = ScopedValue{Ref{Call}}()
+
+function prehook(f, args...)
+    parent = call_tree[][]
+    current = Call(parent, f, args, Call[])
+    push!(parent.children, current)
+    call_tree[][] = current
+end
+
+function posthook(_, f, args...)
+    current = call_tree[][]
+    call_tree[][] = current.parent
+end
+
+function trace(f, args...)
+    top = Call(nothing, f, args, Call[])
+    @with call_tree => Ref(top) begin
+        Base.invoke_within(TracerCompiler(), f, args...)
+    end
+    return top
+end
+
+const CC = Core.Compiler
+import .CC: SSAValue, GlobalRef
+
+const COMPILER_WORLD = Ref{UInt}(0)
+function __init__()
+    COMPILER_WORLD[] = Base.get_world_counter()
+end
+
+struct TracerCompiler <: CC.AbstractCompiler end
+CC.compiler_world(::TracerCompiler) = COMPILER_WORLD[]
+CC.abstract_interpreter(compiler::TracerCompiler, world::UInt) =
+    TracerInterp(compiler; world)
+
+struct TracerInterp <: CC.AbstractInterpreter
+    compiler::TracerCompiler
+    world::UInt
+    inf_params::CC.InferenceParams
+    opt_params::CC.OptimizationParams
+    inf_cache::Vector{CC.InferenceResult}
+    function TracerInterp(compiler::TracerCompiler;
+                world::UInt = Base.get_world_counter(),
+                inf_params::CC.InferenceParams = CC.InferenceParams(),
+                opt_params::CC.OptimizationParams = CC.OptimizationParams(),
+                inf_cache::Vector{CC.InferenceResult} = CC.InferenceResult[])
+        return new(compiler, world, inf_params, opt_params, inf_cache)
+    end
+end
+
+CC.InferenceParams(interp::TracerInterp) = interp.inf_params
+CC.OptimizationParams(interp::TracerInterp) = interp.opt_params
+CC.get_inference_world(interp::TracerInterp) = interp.world
+CC.get_inference_cache(interp::TracerInterp) = interp.inf_cache
+CC.cache_owner(interp::TracerInterp) = interp.compiler
+
+import Core.Compiler: retrieve_code_info, maybe_validate_code
+# Replace usage sited of `retrieve_code_info`, OptimizationState is one such, but in all interesting use-cases
+# it is derived from an InferenceState. There is a third one in `typeinf_ext` in case the module forbids inference.
+function CC.InferenceState(result::CC.InferenceResult, cache_mode::UInt8, interp::TracerInterp)
+    world = CC.get_inference_world(interp)
+    src = retrieve_code_info(result.linfo, world)
+    src === nothing && return nothing
+    maybe_validate_code(result.linfo, src, "lowered")
+    src = transform(interp, result.linfo, src)
+    maybe_validate_code(result.linfo, src, "transformed")
+    return CC.InferenceState(result, src, cache_mode, interp)
+end
+
+function transform(src)
+    return src
+end
+
+##
+# Cassette style early transform
+##
+
+# Allows for Cassette Pass transforms
+
+function static_eval(mod, name)
+    if Base.isbindingresolved(mod, name) && Base.isdefined(mod, name)
+        return getfield(mod, name)
+    else
+        return nothing
+    end
+end
+
+function prehook end
+function posthook end
+
+function transform(interp, mi, src)
+    method = mi.def
+    f = static_eval(method.module, method.name)
+    if f === Core._apply
+        return src
+    end
+    if f isa Core.Builtin
+        error("Transforming builtin")
+    end
+    ci = copy(src)
+    transform!(mi, ci)
+    return ci
+end
+
+function ir_element(x, code::Vector)
+    while isa(x, Core.SSAValue)
+        x = code[x.id]
+    end
+    return x
+end
+
+"""
+    is_ir_element(x, y, code::Vector)
+
+Return `true` if `x === y` or if `x` is an `SSAValue` such that
+`is_ir_element(code[x.id], y, code)` is `true`.
+See also: [`replace_match!`](@ref), [`insert_statements!`](@ref)
+"""
+function is_ir_element(x, y, code::Vector)
+    result = false
+    while true # break by default
+        if x === y #
+            result = true
+            break
+        elseif isa(x, Core.SSAValue)
+            x = code[x.id]
+        else
+            break
+        end
+    end
+    return result
+end
+
+"""
+    insert_statements!(code::Vector, codelocs::Vector, stmtcount, newstmts)
+
+
+For every statement `stmt` at position `i` in `code` for which `stmtcount(stmt, i)` returns
+an `Int`, remove `stmt`, and in its place, insert the statements returned by
+`newstmts(stmt, i)`. If `stmtcount(stmt, i)` returns `nothing`, leave `stmt` alone.
+
+For every insertion, all downstream `SSAValue`s, label indices, etc. are incremented
+appropriately according to number of inserted statements.
+
+Proper usage of this function dictates that following properties hold true:
+
+- `code` is expected to be a valid value for the `code` field of a `CodeInfo` object.
+- `codelocs` is expected to be a valid value for the `codelocs` field of a `CodeInfo` object.
+- `newstmts(stmt, i)` should return a `Vector` of valid IR statements.
+- `stmtcount` and `newstmts` must obey `stmtcount(stmt, i) == length(newstmts(stmt, i))` if
+    `isa(stmtcount(stmt, i), Int)`.
+
+To gain a mental model for this function's behavior, consider the following scenario. Let's
+say our `code` object contains several statements:
+code = Any[oldstmt1, oldstmt2, oldstmt3, oldstmt4, oldstmt5, oldstmt6]
+codelocs = Int[1, 2, 3, 4, 5, 6]
+
+Let's also say that for our `stmtcount` returns `2` for `stmtcount(oldstmt2, 2)`, returns `3`
+for `stmtcount(oldstmt5, 5)`, and returns `nothing` for all other inputs. From this setup, we
+can think of `code`/`codelocs` being modified in the following manner:
+newstmts2 = newstmts(oldstmt2, 2)
+newstmts5 = newstmts(oldstmt5, 5)
+code = Any[oldstmt1,
+           newstmts2[1], newstmts2[2],
+           oldstmt3, oldstmt4,
+           newstmts5[1], newstmts5[2], newstmts5[3],
+           oldstmt6]
+codelocs = Int[1, 2, 2, 3, 4, 5, 5, 5, 6]
+
+See also: [`replace_match!`](@ref), [`is_ir_element`](@ref)
+"""
+function insert_statements!(src, stmtcount, newstmts)
+    code = src.code
+    codelocs = src.codelocs
+    ssaflags = src.ssaflags
+    ssachangemap = fill(0, length(code))
+    labelchangemap = fill(0, length(code))
+    worklist = Tuple{Int,Int}[]
+    for i in 1:length(code)
+        stmt = code[i]
+        nstmts = stmtcount(stmt, i)
+        if nstmts !== nothing
+            addedstmts = nstmts - 1
+            push!(worklist, (i, addedstmts))
+            ssachangemap[i] = addedstmts
+            if i < length(code)
+                labelchangemap[i + 1] = addedstmts
+            end
+        end
+    end
+    Core.Compiler.renumber_ir_elements!(code, ssachangemap, labelchangemap)
+    for (i, addedstmts) in worklist
+        i += ssachangemap[i] - addedstmts # correct the index for accumulated offsets
+        stmts = newstmts(code[i], i)
+        @assert length(stmts) == (addedstmts + 1)
+        code[i] = stmts[end]
+        for j in 1:(length(stmts) - 1) # insert in reverse to maintain the provided ordering
+            insert!(code, i, stmts[end - j])
+            insert!(codelocs, i, codelocs[i])
+            insert!(ssaflags, i, CC.IR_FLAG_NULL)
+            src.ssavaluetypes += 1
+        end
+    end
+end
+
+function transform!(mi, src)
+    stmtcount = (x, i) -> begin
+        isassign = Base.Meta.isexpr(x, :(=))
+        stmt = isassign ? x.args[2] : x
+        if Base.Meta.isexpr(stmt, :call)
+            return 4
+        end
+        return nothing
+    end
+    newstmts = (x, i) -> begin
+        callstmt = Base.Meta.isexpr(x, :(=)) ? x.args[2] : x
+        isapplycall = is_ir_element(callstmt.args[1], GlobalRef(Core, :_apply), src.code)
+        isapplyiteratecall = is_ir_element(callstmt.args[1], GlobalRef(Core, :_apply_iterate), src.code)
+        if isapplycall || isapplyiteratecall
+            callf = callstmt.args[2]
+            callargs = callstmt.args[3:end]
+            stmts = Any[
+                Expr(:call,
+                     GlobalRef(Core, :_call_within), nothing,
+                     prehook, callf, callargs...),
+                callstmt,
+                Expr(:call,
+                     GlobalRef(Core, :_call_within), nothing,
+                     posthook, SSAValue(i + 1), callf, callargs...),
+                Base.Meta.isexpr(x, :(=)) ? Expr(:(=), x.args[1], SSAValue(i + 1)) : SSAValue(i + 1)
+            ]
+        else
+            stmts = Any[
+                Expr(:call, GlobalRef(Core, :_call_within), nothing, prehook, callstmt.args...),
+                callstmt,
+                Expr(:call, GlobalRef(Core, :_call_within), nothing, posthook, SSAValue(i + 1), callstmt.args...),
+                Base.Meta.isexpr(x, :(=)) ? Expr(:(=), x.args[1], SSAValue(i + 1)) : SSAValue(i + 1)
+            ]
+        end
+        return stmts
+    end
+    insert_statements!(src, stmtcount, newstmts)
+    return nothing
+end
+
+
+# precompilation
+precompile(CC.abstract_interpreter, (TracerCompiler, UInt))
+precompile(CC.typeinf_ext_toplevel, (TracerInterp, CC.MethodInstance))
+
+COMPILER_WORLD[] = Base.get_world_counter()
+# Insert code execution statements here
+
+# end precompile
+COMPILER_WORLD[] = 0
+
+
+end # module Tracer

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -181,6 +181,7 @@
 #    donenotify::Any
 #    result::Any
 #    scope::Any
+#    compiler::Any
 #    code::Any
 #    @atomic _state::UInt8
 #    sticky::UInt8

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -1095,6 +1095,19 @@ function invoke_in_world(world::UInt, @nospecialize(f), @nospecialize args...; k
 end
 
 """
+    invoke_within(compiler, f, args...; kwargs...)
+
+Call `f(args...; kwargs...)` within the compiler context provided by `compiler`.
+"""
+function invoke_within(compiler::Core.Compiler.CompilerInstance, @nospecialize(f), @nospecialize args...; kwargs...)
+    kwargs = Base.merge(NamedTuple(), kwargs)
+    if isempty(kwargs)
+        return Core._call_within(compiler, f, args...)
+    end
+    return Core._call_within(compiler, Core.kwcall, kwargs, f, args...)
+end
+
+"""
     inferencebarrier(x)
 
 A shorthand for `compilerbarrier(:type, x)` causes the type of this statement to be inferred as `Any`.

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -155,17 +155,27 @@ struct CodegenParams
     """
     trim::Cint
 
+    """
+    An instance of type Core.Compiler.CompilerInstance
+
+    Used to look up the code instance corresponding to a particular method instance,
+    from the particular compiler instance.
+    """
+    compiler::Core.Compiler.CompilerInstance
+
     function CodegenParams(; track_allocations::Bool=true, code_coverage::Bool=true,
                    prefer_specsig::Bool=false,
                    gnu_pubnames::Bool=true, debug_info_kind::Cint = default_debug_info_kind(),
                    debug_info_level::Cint = Cint(JLOptions().debug_level), safepoint_on_entry::Bool=true,
-                   gcstack_arg::Bool=true, use_jlplt::Bool=true, trim::Cint=Cint(0))
+                   gcstack_arg::Bool=true, use_jlplt::Bool=true, trim::Cint=Cint(0),
+                   compiler::Core.Compiler.CompilerInstance=nothing)
         return new(
             Cint(track_allocations), Cint(code_coverage),
             Cint(prefer_specsig),
             Cint(gnu_pubnames), debug_info_kind,
             debug_info_level, Cint(safepoint_on_entry),
-            Cint(gcstack_arg), Cint(use_jlplt), Cint(trim))
+            Cint(gcstack_arg), Cint(use_jlplt), Cint(trim),
+            compiler)
     end
 end
 

--- a/doc/src/devdocs/compilerplugins.md
+++ b/doc/src/devdocs/compilerplugins.md
@@ -1,0 +1,87 @@
+# Compiler plugins
+
+!!! warning
+    Compiler plugins are an unstable feature and depend on compiler internals.
+    Users of compiler plugins are encouraged to actively keep track of Julia upstream,
+    and to contribute necessary enhancements.
+
+Compiler plugins use the `AbstractInterpreter` interface to customize Julia's high-level compiler,
+and the `AbstractCompiler` interface to make the results from a foreign abstract interpreter executable.
+
+Each task has a private field `compiler` that is like a scoped value to set and propagate the compiler plugin
+across a task-graph. It can be accessed through `Core.Compiler.current_compiler()` and set through `Base.invoke_within`.
+
+Instances of `AbstractCompiler` are used a cache lookup tokens and are compared with `jl_egal`.
+
+!!! note
+    The native compiler of Julia uses `nothing` as a compiler instance and cache token. Switching back to the native compiler
+    can thus be done with `Base.invoke_within(nothing, f, args...)`.
+
+## Interface
+
+```@docs
+Core.Compiler.AbstractCompiler
+Core.Compiler.current_compiler
+Core.Compiler.abstract_interpreter
+Core.Compiler.compiler_world
+Base.invoke_within
+```
+
+!!! important
+    While the abstract interpreter interface can be used independently of compiler plugins, if it is used for a compiler plugin.
+    `CC.cache_owner(interp::AbstractInterpreter)` must return as a cache token the `AbstractCompiler` instance that was used
+    to construct the `AbstractInterpreter` with `Core.Compiler.abstract_interpreter`.
+
+## Intermediate representations and compiler pipeline
+
+### Pre-inference IR
+### Post-inference IR
+
+
+## Freezing compiler world-ages
+
+It is often undesirable for compiler code to be invalidated by user code. Julia's `Core.Compiler`
+as executed by `jl_type_infer` is run in a frozen world-age (`jl_typeinf_world`). Compiler plugins
+are not reachable from that world-age and need to be executed in a newer one.
+
+The API [`Core.Compiler.compiler_world`](@ref) can be used to return a frozen world-age.
+
+```julia
+const CC = Core.Compiler
+
+struct MyCompiler <: CC.AbstractCompiler end
+CC.abstract_interpreter(compiler::MyCompiler, world::UInt) = # ...
+
+const COMPILER_WORLD = Ref{UInt}(0)
+
+function __init__()
+    COMPILER_WORLD[] = Base.get_world_counter()
+end
+
+CC.compiler_world(::MyCompiler) = COMPILER_WORLD[]
+```
+
+By default, `compiler_world` returns `get_world_counter()`, thus `invoke_in_world(compiler_world(...), ...)`
+being equivalent to `invokelatest`. This default definition can be useful during development.
+
+## Runtime executed implicit functions
+
+The Julia runtime executes implicit functions like finalizers and `__init__` functions.
+Currently, these are all executed within the native compiler.
+
+!!! warning
+    This is currently not fully implemented and might cause spooky action at a distance.
+
+## Accidental recursive instrumentation
+
+## Future work
+
+- Compiler standard library
+- Cross-compiler inference
+  - Inlining?
+
+## Examples
+
+### Tracing
+
+### Broadcast fusion

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -2351,6 +2351,7 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t *dump, jl_method_instance_t *mi, jl_
     // emit this function into a new llvm module
     dump->F = nullptr;
     dump->TSM = nullptr;
+    jl_value_t *compiler = params.compiler;
     if (src && jl_is_code_info(src)) {
         auto ctx = jl_ExecutionEngine->makeContext();
         orc::ThreadSafeModule m = jl_create_ts_module(name_from_method_instance(mi), ctx);
@@ -2380,7 +2381,7 @@ void jl_get_llvmf_defn_impl(jl_llvmf_dump_t *dump, jl_method_instance_t *mi, jl_
                 jl_method_instance_t *mi = jl_get_specialization1((jl_tupletype_t*)sigt, latestworld, 0);
                 if (mi == nullptr)
                     continue;
-                jl_code_instance_t *codeinst = jl_type_infer(mi, latestworld, SOURCE_MODE_NOT_REQUIRED);
+                jl_code_instance_t *codeinst = jl_type_infer(compiler, mi, latestworld, SOURCE_MODE_NOT_REQUIRED);
                 if (codeinst == nullptr || compiled_functions.count(codeinst))
                     continue;
                 orc::ThreadSafeModule decl_m = jl_create_ts_module("extern", ctx);

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -25,6 +25,7 @@ DECLARE_BUILTIN(_apply_iterate);
 DECLARE_BUILTIN(_apply_pure);
 DECLARE_BUILTIN(_call_in_world);
 DECLARE_BUILTIN(_call_in_world_total);
+DECLARE_BUILTIN(_call_within);
 DECLARE_BUILTIN(_call_latest);
 DECLARE_BUILTIN(_compute_sparams);
 DECLARE_BUILTIN(_expr);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -929,6 +929,25 @@ JL_CALLABLE(jl_f__call_in_world_total)
     return ret;
 }
 
+JL_CALLABLE(jl_f__call_within)
+{
+    JL_NARGSV(_apply_within, 2);
+    jl_task_t *ct = jl_current_task;
+    jl_value_t *last_compiler = ct->compiler;
+    jl_value_t *compiler = args[0];
+    jl_value_t *ret = NULL;
+    JL_TRY {
+        ct->compiler = compiler;
+        ret = jl_apply(&args[1], nargs - 1);
+        ct->compiler = last_compiler;
+    }
+    JL_CATCH {
+        ct->compiler = last_compiler;
+        jl_rethrow();
+    }
+    return ret;
+}
+
 // tuples ---------------------------------------------------------------------
 
 static jl_value_t *arg_tuple(jl_value_t *a1, jl_value_t **args, size_t nargs)
@@ -2536,6 +2555,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin_func("_call_latest", jl_f__call_latest);
     add_builtin_func("_call_in_world", jl_f__call_in_world);
     add_builtin_func("_call_in_world_total", jl_f__call_in_world_total);
+    add_builtin_func("_call_within", jl_f__call_within);
     add_builtin_func("_typevar", jl_f__typevar);
     add_builtin_func("_structtype", jl_f__structtype);
     add_builtin_func("_abstracttype", jl_f__abstracttype);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -4422,7 +4422,8 @@ static int compare_cgparams(const jl_cgparams_t *a, const jl_cgparams_t *b)
            (a->debug_info_kind == b->debug_info_kind) &&
            (a->safepoint_on_entry == b->safepoint_on_entry) &&
            (a->gcstack_arg == b->gcstack_arg) &&
-           (a->use_jlplt == b->use_jlplt);
+           (a->use_jlplt == b->use_jlplt) &&
+           (a->compiler == b->compiler);
 }
 #endif
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1585,6 +1585,7 @@ static const auto &builtin_func_map() {
           { jl_f__call_latest_addr,       new JuliaFunction<>{XSTR(jl_f__call_latest), get_func_sig, get_func_attrs} },
           { jl_f__call_in_world_addr,     new JuliaFunction<>{XSTR(jl_f__call_in_world), get_func_sig, get_func_attrs} },
           { jl_f__call_in_world_total_addr, new JuliaFunction<>{XSTR(jl_f__call_in_world_total), get_func_sig, get_func_attrs} },
+          { jl_f__call_within_addr, new JuliaFunction<>{XSTR(jl_f__call_within), get_func_sig, get_func_attrs} },
           { jl_f_throw_addr,              new JuliaFunction<>{XSTR(jl_f_throw), get_func_sig, get_func_attrs} },
           { jl_f_throw_methoderror_addr,  new JuliaFunction<>{XSTR(jl_f_throw_methoderror), get_func_sig, get_func_attrs} },
           { jl_f_tuple_addr,              jltuple_func },
@@ -1965,6 +1966,7 @@ public:
     bool use_cache = false;
     bool external_linkage = false;
     const jl_cgparams_t *params = NULL;
+    jl_value_t *compiler = NULL;
 
     SmallVector<std::unique_ptr<Module>, 0> llvmcall_modules;
 
@@ -1976,7 +1978,8 @@ public:
         max_world(max_world),
         use_cache(params.cache),
         external_linkage(params.external_linkage),
-        params(params.params) {
+        params(params.params),
+        compiler(params.compiler) {
     }
 
     jl_codectx_t(LLVMContext &llvmctx, jl_codegen_params_t &params, jl_code_instance_t *ci) :
@@ -3201,8 +3204,10 @@ static jl_value_t *static_eval(jl_codectx_t &ctx, jl_value_t *ex)
                         }
                     }
                     size_t last_age = jl_current_task->world_age;
+                    jl_value_t* last_compiler = jl_current_task->compiler;
                     // here we know we're calling specific builtin functions that work in world 1.
                     jl_current_task->world_age = 1;
+                    jl_current_task->compiler = jl_nothing;
                     jl_value_t *result;
                     JL_TRY {
                         result = jl_apply(v, n+1);
@@ -3211,6 +3216,7 @@ static jl_value_t *static_eval(jl_codectx_t &ctx, jl_value_t *ex)
                         result = NULL;
                     }
                     jl_current_task->world_age = last_age;
+                    jl_current_task->compiler = last_compiler;
                     JL_GC_POP();
                     return result;
                 }
@@ -6631,7 +6637,8 @@ static std::pair<Function*, Function*> get_oc_function(jl_codectx_t &ctx, jl_met
 
     if (closure_method->source) {
         mi = jl_specializations_get_linfo(closure_method, sigtype, jl_emptysvec);
-        ci = (jl_code_instance_t*)jl_rettype_inferred_addr(mi, ctx.min_world, ctx.max_world);
+        // TODO(VC)
+        ci = (jl_code_instance_t*)jl_rettype_inferred(jl_nothing, mi, ctx.min_world, ctx.max_world);
     }
     else {
         mi = (jl_method_instance_t*)jl_atomic_load_relaxed(&closure_method->specializations);
@@ -10422,6 +10429,9 @@ int jl_is_timing_passes = 0;
 
 extern "C" void jl_init_llvm(void)
 {
+    if (jl_nothing == NULL) // make a placeholder
+        jl_nothing = jl_gc_permobj(0, jl_nothing_type, 0);
+    jl_default_cgparams.compiler = jl_nothing;
     jl_page_size = jl_getpagesize();
     jl_default_debug_info_kind = jl_default_cgparams.debug_info_kind = (int) DICompileUnit::DebugEmissionKind::FullDebug;
     jl_default_cgparams.debug_info_level = (int) jl_options.debug_level;

--- a/src/gc-common.c
+++ b/src/gc-common.c
@@ -174,13 +174,20 @@ void run_finalizer(jl_task_t *ct, void *o, void *ff)
         ((void (*)(void*))ff)((void*)o);
         return;
     }
+
+    size_t last_age = ct->world_age;
+    jl_value_t *last_compiler = ct->compiler;
     JL_TRY {
-        size_t last_age = ct->world_age;
+        // TODO: Should we capture the compiler for the thunk?
         ct->world_age = jl_atomic_load_acquire(&jl_world_counter);
+        ct->compiler = jl_nothing;
         jl_apply_generic((jl_value_t*)ff, (jl_value_t**)&o, 1);
         ct->world_age = last_age;
+        ct->compiler = last_compiler;
     }
     JL_CATCH {
+        ct->world_age = last_age;
+        ct->compiler = last_compiler;
         jl_printf((JL_STREAM*)STDERR_FILENO, "error in running finalizer: ");
         jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception(ct));
         jl_printf((JL_STREAM*)STDERR_FILENO, "\n");

--- a/src/gf.c
+++ b/src/gf.c
@@ -3290,7 +3290,7 @@ static void _generate_from_hint(jl_method_instance_t *mi, size_t world)
     jl_value_t *codeinst = jl_rettype_inferred(compiler, mi, world, world);
     if (codeinst == jl_nothing) {
         (void)jl_type_infer(compiler, mi, world, SOURCE_MODE_NOT_REQUIRED);
-        codeinst = jl_rettype_inferred_native(compiler, mi, world, world);
+        codeinst = jl_rettype_inferred(compiler, mi, world, world);
     }
     if (codeinst != jl_nothing) {
         if (jl_atomic_load_relaxed(&((jl_code_instance_t*)codeinst)->invoke) == jl_fptr_const_return)

--- a/src/gf.c
+++ b/src/gf.c
@@ -322,7 +322,8 @@ jl_datatype_t *jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_a
     jl_atomic_store_relaxed(&m->unspecialized, mi);
     jl_gc_wb(m, mi);
 
-    jl_code_instance_t *codeinst = jl_new_codeinst(mi, jl_nothing,
+    jl_value_t *compiler = jl_nothing; // Native
+    jl_code_instance_t *codeinst = jl_new_codeinst(mi, compiler,
         (jl_value_t*)jl_any_type, (jl_value_t*)jl_any_type, jl_nothing, jl_nothing,
         0, 1, ~(size_t)0, 0, jl_nothing, NULL, NULL);
     jl_mi_cache_insert(mi, codeinst);
@@ -395,7 +396,7 @@ static jl_code_instance_t *jl_method_inferred_with_abi(jl_method_instance_t *mi 
 // returns the inferred source, and may cache the result in mi
 // if successful, also updates the mi argument to describe the validity of this src
 // if inference doesn't occur (or can't finish), returns NULL instead
-jl_code_instance_t *jl_type_infer(jl_method_instance_t *mi, size_t world, uint8_t source_mode)
+jl_code_instance_t *jl_type_infer(jl_value_t *compiler, jl_method_instance_t *mi, size_t world, uint8_t source_mode)
 {
     if (jl_typeinf_func == NULL) {
         if (source_mode == SOURCE_MODE_ABI)
@@ -419,11 +420,12 @@ jl_code_instance_t *jl_type_infer(jl_method_instance_t *mi, size_t world, uint8_
         return NULL;
     JL_TIMING(INFERENCE, INFERENCE);
     jl_value_t **fargs;
-    JL_GC_PUSHARGS(fargs, 4);
+    JL_GC_PUSHARGS(fargs, 5);
     fargs[0] = (jl_value_t*)jl_typeinf_func;
-    fargs[1] = (jl_value_t*)mi;
-    fargs[2] = jl_box_ulong(world);
-    fargs[3] = jl_box_uint8(source_mode);
+    fargs[1] = compiler;
+    fargs[2] = (jl_value_t*)mi;
+    fargs[3] = jl_box_ulong(world);
+    fargs[4] = jl_box_uint8(source_mode);
     int last_errno = errno;
 #ifdef _OS_WINDOWS_
     DWORD last_error = GetLastError();
@@ -449,8 +451,10 @@ jl_code_instance_t *jl_type_infer(jl_method_instance_t *mi, size_t world, uint8_
     // increase that limit, we'll need to
     // allocate another bit for the counter.
     ct->reentrant_timing += 0b10;
+    jl_value_t *last_compiler = ct->compiler;
     JL_TRY {
-        ci = (jl_code_instance_t*)jl_apply(fargs, 4);
+        ct->compiler = jl_nothing; // switch to native
+        ci = (jl_code_instance_t*)jl_apply(fargs, 5);
     }
     JL_CATCH {
         jl_value_t *e = jl_current_exception(ct);
@@ -472,6 +476,7 @@ jl_code_instance_t *jl_type_infer(jl_method_instance_t *mi, size_t world, uint8_
         abort();
 #endif
     }
+    ct->compiler = last_compiler;
     ct->world_age = last_age;
     ct->reentrant_timing -= 0b10;
     ct->ptls->in_pure_callback = last_pure;
@@ -538,15 +543,15 @@ JL_DLLEXPORT jl_value_t *jl_call_in_typeinf_world(jl_value_t **args, int nargs)
 }
 
 JL_DLLEXPORT jl_code_instance_t *jl_get_method_inferred(
+        jl_value_t* compiler,
         jl_method_instance_t *mi JL_PROPAGATES_ROOT, jl_value_t *rettype,
         size_t min_world, size_t max_world, jl_debuginfo_t *di, jl_svec_t *edges)
 {
-    jl_value_t *owner = jl_nothing; // TODO: owner should be arg
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
     while (codeinst) {
         if (jl_atomic_load_relaxed(&codeinst->min_world) == min_world &&
             jl_atomic_load_relaxed(&codeinst->max_world) == max_world &&
-            jl_egal(codeinst->owner, owner) &&
+            jl_egal(codeinst->owner, compiler) &&
             jl_egal(codeinst->rettype, rettype)) {
             if (di == NULL)
                 return codeinst;
@@ -564,7 +569,7 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_method_inferred(
         codeinst = jl_atomic_load_relaxed(&codeinst->next);
     }
     codeinst = jl_new_codeinst(
-        mi, owner, rettype, (jl_value_t*)jl_any_type, NULL, NULL,
+        mi, compiler, rettype, (jl_value_t*)jl_any_type, NULL, NULL,
         0, min_world, max_world, 0, jl_nothing, di, edges);
     jl_mi_cache_insert(mi, codeinst);
     return codeinst;
@@ -761,6 +766,7 @@ JL_DLLEXPORT int jl_mi_try_insert(jl_method_instance_t *mi JL_ROOTING_ARGUMENT,
 
 static int get_method_unspec_list(jl_typemap_entry_t *def, void *closure)
 {
+    jl_value_t *compiler = jl_nothing; // Native
     size_t world = jl_atomic_load_acquire(&jl_world_counter);
     jl_value_t *specializations = jl_atomic_load_relaxed(&def->func.method->specializations);
     if (specializations == (jl_value_t*)jl_emptysvec)
@@ -768,7 +774,7 @@ static int get_method_unspec_list(jl_typemap_entry_t *def, void *closure)
     if (!jl_is_svec(specializations)) {
         jl_method_instance_t *mi = (jl_method_instance_t*)specializations;
         assert(jl_is_method_instance(mi));
-        if (jl_rettype_inferred_native(mi, world, world) == jl_nothing)
+        if (jl_rettype_inferred(compiler, mi, world, world) == jl_nothing)
             jl_array_ptr_1d_push((jl_array_t*)closure, (jl_value_t*)mi);
         return 1;
     }
@@ -778,7 +784,7 @@ static int get_method_unspec_list(jl_typemap_entry_t *def, void *closure)
         jl_method_instance_t *mi = (jl_method_instance_t*)jl_svecref(specializations, i);
         if ((jl_value_t*)mi != jl_nothing) {
             assert(jl_is_method_instance(mi));
-            if (jl_rettype_inferred_native(mi, world, world) == jl_nothing)
+            if (jl_rettype_inferred(compiler, mi, world, world) == jl_nothing)
                 jl_array_ptr_1d_push((jl_array_t*)closure, (jl_value_t*)mi);
         }
     }
@@ -867,8 +873,6 @@ int jl_foreach_reachable_mtable(int (*visit)(jl_methtable_t *mt, void *env), voi
 
 static int reset_mt_caches(jl_methtable_t *mt, void *env)
 {
-    // removes all method caches
-    // this might not be entirely safe (GC or MT), thus we only do it very early in bootstrapping
     if (!mt->frozen) { // make sure not to reset builtin functions
         jl_atomic_store_release(&mt->leafcache, (jl_genericmemory_t*)jl_an_empty_memory_any);
         jl_atomic_store_release(&mt->cache, jl_nothing);
@@ -888,6 +892,7 @@ JL_DLLEXPORT void jl_set_typeinf_func(jl_value_t *f)
     jl_typeinf_world = jl_get_tls_world_age();
     int world = jl_atomic_fetch_add(&jl_world_counter, 1) + 1; // make type-inference the only thing in this world
     if (newfunc) {
+        jl_value_t *compiler = jl_nothing; // Native
         // give type inference a chance to see all of these
         // TODO: also reinfer if max_world != ~(size_t)0
         jl_array_t *unspec = jl_alloc_vec_any(0);
@@ -896,8 +901,8 @@ JL_DLLEXPORT void jl_set_typeinf_func(jl_value_t *f)
         size_t i, l;
         for (i = 0, l = jl_array_nrows(unspec); i < l; i++) {
             jl_method_instance_t *mi = (jl_method_instance_t*)jl_array_ptr_ref(unspec, i);
-            if (jl_rettype_inferred_native(mi, world, world) == jl_nothing)
-                jl_type_infer(mi, world, SOURCE_MODE_NOT_REQUIRED);
+            if (jl_rettype_inferred(compiler, mi, world, world) == jl_nothing)
+                jl_type_infer(compiler, mi, world, SOURCE_MODE_NOT_REQUIRED);
         }
         JL_GC_POP();
     }
@@ -2611,7 +2616,7 @@ JL_DLLEXPORT jl_method_instance_t *jl_get_unspecialized(jl_method_t *def JL_PROP
     return unspec;
 }
 
-STATIC_INLINE jl_value_t *_jl_rettype_inferred(jl_value_t *owner, jl_method_instance_t *mi, size_t min_world, size_t max_world) JL_NOTSAFEPOINT
+jl_value_t *jl_rettype_inferred(jl_value_t *owner, jl_method_instance_t *mi, size_t min_world, size_t max_world) JL_NOTSAFEPOINT
 {
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
     while (codeinst) {
@@ -2628,25 +2633,14 @@ STATIC_INLINE jl_value_t *_jl_rettype_inferred(jl_value_t *owner, jl_method_inst
     return (jl_value_t*)jl_nothing;
 }
 
-JL_DLLEXPORT jl_value_t *jl_rettype_inferred(jl_value_t *owner, jl_method_instance_t *mi, size_t min_world, size_t max_world) JL_NOTSAFEPOINT
-{
-    return (jl_value_t*)_jl_rettype_inferred(owner, mi, min_world, max_world);
-}
-
-JL_DLLEXPORT jl_value_t *jl_rettype_inferred_native(jl_method_instance_t *mi, size_t min_world, size_t max_world) JL_NOTSAFEPOINT
-{
-    return (jl_value_t*)_jl_rettype_inferred(jl_nothing, mi, min_world, max_world);
-}
-
-JL_DLLEXPORT jl_value_t *(*const jl_rettype_inferred_addr)(jl_method_instance_t *mi, size_t min_world, size_t max_world) JL_NOTSAFEPOINT = jl_rettype_inferred_native;
-
-jl_code_instance_t *jl_method_compiled(jl_method_instance_t *mi, size_t world)
+jl_code_instance_t *jl_method_compiled(jl_value_t *compiler, jl_method_instance_t *mi, size_t world)
 {
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
     for (; codeinst; codeinst = jl_atomic_load_relaxed(&codeinst->next)) {
-        if (codeinst->owner != jl_nothing)
-            continue;
-        if (jl_atomic_load_relaxed(&codeinst->min_world) <= world && world <= jl_atomic_load_relaxed(&codeinst->max_world)) {
+        if (jl_atomic_load_relaxed(&codeinst->min_world) <= world &&
+            world <= jl_atomic_load_relaxed(&codeinst->max_world) &&
+            jl_egal(codeinst->owner, compiler)) {
+
             if (jl_atomic_load_relaxed(&codeinst->invoke) != NULL)
                 return codeinst;
         }
@@ -2834,10 +2828,10 @@ JL_DLLEXPORT void jl_add_codeinst_to_jit(jl_code_instance_t *codeinst, jl_code_i
     }
 }
 
-jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t world)
+jl_code_instance_t *jl_compile_method_internal(jl_value_t *compiler, jl_method_instance_t *mi, size_t world)
 {
     // quick check if we already have a compiled result
-    jl_code_instance_t *codeinst = jl_method_compiled(mi, world);
+    jl_code_instance_t *codeinst = jl_method_compiled(compiler, mi, world);
     if (codeinst)
         return codeinst;
 
@@ -2845,8 +2839,9 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
     // instead and just copy it here for caching
     jl_method_instance_t *mi2 = jl_normalize_to_compilable_mi(mi);
     if (mi2 != mi) {
-        jl_code_instance_t *codeinst2 = jl_compile_method_internal(mi2, world);
+        jl_code_instance_t *codeinst2 = jl_compile_method_internal(compiler, mi2, world);
         jl_code_instance_t *codeinst = jl_get_method_inferred(
+                compiler,
                 mi, codeinst2->rettype,
                 jl_atomic_load_relaxed(&codeinst2->min_world),
                 jl_atomic_load_relaxed(&codeinst2->max_world),
@@ -2909,7 +2904,7 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
                     jl_callptr_t invoke;
                     void *fptr;
                     jl_read_codeinst_invoke(unspec, &specsigflags, &invoke, &fptr, 1);
-                    jl_code_instance_t *codeinst = jl_new_codeinst(mi, jl_nothing,
+                    jl_code_instance_t *codeinst = jl_new_codeinst(mi, compiler,
                         (jl_value_t*)jl_any_type, (jl_value_t*)jl_any_type, NULL, NULL,
                         0, 1, ~(size_t)0, 0, jl_nothing, NULL, NULL);
                     codeinst->rettype_const = unspec->rettype_const;
@@ -2930,7 +2925,7 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
         compile_option == JL_OPTIONS_COMPILE_MIN) {
         jl_code_info_t *src = jl_code_for_interpreter(mi, world);
         if (!jl_code_requires_compiler(src, 0)) {
-            jl_code_instance_t *codeinst = jl_new_codeinst(mi, jl_nothing,
+            jl_code_instance_t *codeinst = jl_new_codeinst(mi, compiler,
                 (jl_value_t*)jl_any_type, (jl_value_t*)jl_any_type, NULL, NULL,
                 0, 1, ~(size_t)0, 0, jl_nothing, NULL, NULL);
             jl_atomic_store_release(&codeinst->invoke, jl_fptr_interpret_call);
@@ -2969,7 +2964,7 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
         int should_skip_inference = !jl_is_method(mi->def.method) || jl_symbol_name(mi->def.method->name)[0] == '@';
 
         if (!should_skip_inference) {
-            codeinst = jl_type_infer(mi, world, SOURCE_MODE_ABI);
+            codeinst = jl_type_infer(compiler, mi, world, SOURCE_MODE_ABI);
         }
     }
 
@@ -2998,7 +2993,7 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
         jl_method_instance_t *unspec = jl_get_unspecialized(def);
         if (unspec == NULL)
             unspec = mi;
-        jl_code_instance_t *ucache = jl_get_method_inferred(unspec, (jl_value_t*)jl_any_type, 1, ~(size_t)0, NULL, NULL);
+        jl_code_instance_t *ucache = jl_get_method_inferred(compiler, unspec, (jl_value_t*)jl_any_type, 1, ~(size_t)0, NULL, NULL);
         // ask codegen to make the fptr for unspec
         jl_callptr_t ucache_invoke = jl_atomic_load_acquire(&ucache->invoke);
         if (ucache_invoke == NULL) {
@@ -3020,7 +3015,7 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
         jl_callptr_t invoke;
         void *fptr;
         jl_read_codeinst_invoke(ucache, &specsigflags, &invoke, &fptr, 1);
-        codeinst = jl_new_codeinst(mi, jl_nothing,
+        codeinst = jl_new_codeinst(mi, compiler,
             (jl_value_t*)jl_any_type, (jl_value_t*)jl_any_type, NULL, NULL,
             0, 1, ~(size_t)0, 0, jl_nothing, NULL, NULL);
         codeinst->rettype_const = ucache->rettype_const;
@@ -3291,10 +3286,11 @@ static jl_method_instance_t *jl_get_compile_hint_specialization(jl_tupletype_t *
 
 static void _generate_from_hint(jl_method_instance_t *mi, size_t world)
 {
-    jl_value_t *codeinst = jl_rettype_inferred_native(mi, world, world);
+    jl_value_t *compiler = jl_nothing; // Native
+    jl_value_t *codeinst = jl_rettype_inferred(compiler, mi, world, world);
     if (codeinst == jl_nothing) {
-        (void)jl_type_infer(mi, world, SOURCE_MODE_NOT_REQUIRED);
-        codeinst = jl_rettype_inferred_native(mi, world, world);
+        (void)jl_type_infer(compiler, mi, world, SOURCE_MODE_NOT_REQUIRED);
+        codeinst = jl_rettype_inferred_native(compiler, mi, world, world);
     }
     if (codeinst != jl_nothing) {
         if (jl_atomic_load_relaxed(&((jl_code_instance_t*)codeinst)->invoke) == jl_fptr_const_return)
@@ -3317,6 +3313,7 @@ static void jl_compile_now(jl_method_instance_t *mi)
 JL_DLLEXPORT void jl_compile_method_instance(jl_method_instance_t *mi, jl_tupletype_t *types, size_t world)
 {
     size_t tworld = jl_typeinf_world;
+    jl_value_t *compiler = jl_nothing;
     uint8_t miflags = jl_atomic_load_relaxed(&mi->flags) | JL_MI_FLAGS_MASK_PRECOMPILED;
     jl_atomic_store_relaxed(&mi->flags, miflags);
     if (jl_generating_output()) {
@@ -3335,18 +3332,18 @@ JL_DLLEXPORT void jl_compile_method_instance(jl_method_instance_t *mi, jl_tuplet
             JL_GC_POP();
             miflags = jl_atomic_load_relaxed(&mi2->flags) | JL_MI_FLAGS_MASK_PRECOMPILED;
             jl_atomic_store_relaxed(&mi2->flags, miflags);
-            if (jl_rettype_inferred_native(mi2, world, world) == jl_nothing)
-                (void)jl_type_infer(mi2, world, SOURCE_MODE_NOT_REQUIRED);
+            if (jl_rettype_inferred(compiler, mi2, world, world) == jl_nothing)
+                (void)jl_type_infer(compiler, mi2, world, SOURCE_MODE_NOT_REQUIRED);
             if (jl_typeinf_func && jl_atomic_load_relaxed(&mi->def.method->primary_world) <= tworld) {
-                if (jl_rettype_inferred_native(mi2, tworld, tworld) == jl_nothing)
-                    (void)jl_type_infer(mi2, tworld, SOURCE_MODE_NOT_REQUIRED);
+                if (jl_rettype_inferred(compiler, mi2, tworld, tworld) == jl_nothing)
+                    (void)jl_type_infer(compiler, mi2, tworld, SOURCE_MODE_NOT_REQUIRED);
             }
         }
     }
     else {
         // Otherwise (this branch), assuming we are at runtime (normal JIT) and
         // we should generate the native code immediately in preparation for use.
-        (void)jl_compile_method_internal(mi, world);
+        (void)jl_compile_method_internal(compiler, mi, world);
     }
 }
 
@@ -3448,9 +3445,12 @@ STATIC_INLINE jl_value_t *verify_type(jl_value_t *v) JL_NOTSAFEPOINT
 STATIC_INLINE jl_value_t *_jl_invoke(jl_value_t *F, jl_value_t **args, uint32_t nargs, jl_method_instance_t *mfunc, size_t world)
 {
     // manually inlined copy of jl_method_compiled
+    jl_value_t *compiler = jl_current_task->compiler;
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mfunc->cache);
     while (codeinst) {
-        if (jl_atomic_load_relaxed(&codeinst->min_world) <= world && world <= jl_atomic_load_relaxed(&codeinst->max_world)) {
+        if (jl_atomic_load_relaxed(&codeinst->min_world) <= world &&
+            world <= jl_atomic_load_relaxed(&codeinst->max_world) &&
+            jl_egal(codeinst->owner, compiler) ) {
             jl_callptr_t invoke = jl_atomic_load_acquire(&codeinst->invoke);
             if (invoke != NULL) {
                 jl_value_t *res = invoke(F, args, nargs, codeinst);
@@ -3464,7 +3464,7 @@ STATIC_INLINE jl_value_t *_jl_invoke(jl_value_t *F, jl_value_t **args, uint32_t 
 #ifdef _OS_WINDOWS_
     DWORD last_error = GetLastError();
 #endif
-    codeinst = jl_compile_method_internal(mfunc, world);
+    codeinst = jl_compile_method_internal(compiler, mfunc, world);
 #ifdef _OS_WINDOWS_
     SetLastError(last_error);
 #endif

--- a/src/init.c
+++ b/src/init.c
@@ -740,7 +740,9 @@ JL_DLLEXPORT jl_cgparams_t jl_default_cgparams = {
         /* safepoint_on_entry */ 1,
         /* gcstack_arg */ 1,
         /* use_jlplt*/ 1,
-        /* trim */ 0 };
+        /* trim */ 0 
+        /* compiler */ NULL }; // defaults to jl_nothing, initialized after runtime.
+};
 
 static void init_global_mutexes(void) {
     JL_MUTEX_INIT(&jl_modules_mutex, "jl_modules_mutex");

--- a/src/init.c
+++ b/src/init.c
@@ -740,8 +740,8 @@ JL_DLLEXPORT jl_cgparams_t jl_default_cgparams = {
         /* safepoint_on_entry */ 1,
         /* gcstack_arg */ 1,
         /* use_jlplt*/ 1,
-        /* trim */ 0 
-        /* compiler */ NULL }; // defaults to jl_nothing, initialized after runtime.
+        /* trim */ 0,
+        /* compiler */ NULL // defaults to jl_nothing, initialized after runtime.
 };
 
 static void init_global_mutexes(void) {

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -819,6 +819,7 @@ int jl_compile_extern_c_impl(LLVMOrcThreadSafeModuleRef llvmmod, void *p, void *
     jl_codegen_params_t *pparams = (jl_codegen_params_t*)p;
     DataLayout DL = pparams ? pparams->DL : jl_ExecutionEngine->getDataLayout();
     Triple TargetTriple = pparams ? pparams->TargetTriple : jl_ExecutionEngine->getTargetTriple();
+    jl_value_t* compiler = pparams ? pparams->compiler : jl_nothing;
     orc::ThreadSafeContext ctx;
     auto into = unwrap(llvmmod);
     orc::ThreadSafeModule backing;
@@ -855,7 +856,7 @@ int jl_compile_extern_c_impl(LLVMOrcThreadSafeModuleRef llvmmod, void *p, void *
                 for (auto &it : params.workqueue) { // really just zero or one, and just the ABI not the rest of the metadata
                     jl_code_instance_t *codeinst = it.first;
                     JL_GC_PROMISE_ROOTED(codeinst);
-                    jl_code_instance_t *newest_ci = jl_type_infer(jl_get_ci_mi(codeinst), newest_world, SOURCE_MODE_ABI);
+                    jl_code_instance_t *newest_ci = jl_type_infer(compiler, jl_get_ci_mi(codeinst), newest_world, SOURCE_MODE_ABI);
                     if (newest_ci) {
                         if (jl_egal(codeinst->rettype, newest_ci->rettype))
                             it.first = codeinst;

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1018,7 +1018,8 @@ jl_value_t *jl_dump_method_asm_impl(jl_method_instance_t *mi, size_t world,
         char emit_mc, char getwrapper, const char* asm_variant, const char *debuginfo, char binary)
 {
     // printing via disassembly
-    jl_code_instance_t *codeinst = jl_compile_method_internal(mi, world);
+    jl_value_t *compiler = jl_nothing; // FIXME
+    jl_code_instance_t *codeinst = jl_compile_method_internal(compiler, mi, world);
     if (codeinst) {
         uintptr_t fptr = (uintptr_t)jl_atomic_load_acquire(&codeinst->invoke);
         uintptr_t specfptr = (uintptr_t)jl_atomic_load_relaxed(&codeinst->specptr.fptr);

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -270,6 +270,7 @@ struct jl_codegen_params_t {
     bool external_linkage = false;
     bool imaging_mode;
     bool use_swiftcc = true;
+    jl_value_t *compiler = nullptr;
     jl_codegen_params_t(orc::ThreadSafeContext ctx, DataLayout DL, Triple triple) JL_NOTSAFEPOINT  JL_NOTSAFEPOINT_ENTER
       : tsctx(std::move(ctx)),
         tsctx_lock(tsctx.getLock()),

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -137,6 +137,7 @@
     XX(jl_gc_add_finalizer_th) \
     XX(jl_gc_add_ptr_finalizer) \
     XX(jl_gc_add_quiescent) \
+    XX(jl_gc_permobj) \
     XX(jl_gc_allocobj) \
     XX(jl_gc_alloc_typed) \
     XX(jl_gc_big_alloc) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3746,13 +3746,14 @@ void jl_init_types(void) JL_GC_DISABLED
                         NULL,
                         jl_any_type,
                         jl_emptysvec,
-                        jl_perm_symsvec(27,
+                        jl_perm_symsvec(28,
                                         "next",
                                         "queue",
                                         "storage",
                                         "donenotify",
                                         "result",
                                         "scope",
+                                        "compiler",
                                         "code",
                                         "_state",
                                         "sticky",
@@ -3774,7 +3775,8 @@ void jl_init_types(void) JL_GC_DISABLED
                                         "last_started_running_at",
                                         "running_time_ns",
                                         "finished_at"),
-                        jl_svec(27,
+                        jl_svec(28,
+                                jl_any_type,
                                 jl_any_type,
                                 jl_any_type,
                                 jl_any_type,
@@ -3803,7 +3805,7 @@ void jl_init_types(void) JL_GC_DISABLED
                                 jl_uint64_type,
                                 jl_uint64_type),
                         jl_emptysvec,
-                        0, 1, 6);
+                        0, 1, 7);
     XX(task);
     jl_value_t *listt = jl_new_struct(jl_uniontype_type, jl_task_type, jl_nothing_type);
     jl_svecset(jl_task_type->types, 0, listt);

--- a/src/julia.h
+++ b/src/julia.h
@@ -2674,6 +2674,8 @@ typedef struct {
 
     int use_jlplt; // Whether to use the Julia PLT mechanism or emit symbols directly
     int trim; // can we emit dynamic dispatches?
+    // Cache access. Default: NativeCompiler()
+    jl_value_t *compiler;
 } jl_cgparams_t;
 extern JL_DLLEXPORT int jl_default_debug_info_kind;
 extern JL_DLLEXPORT jl_cgparams_t jl_default_cgparams;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -674,10 +674,11 @@ JL_DLLEXPORT void jl_engine_fulfill(jl_code_instance_t *ci, jl_code_info_t *src)
 void jl_engine_sweep(jl_ptls_t *gc_all_tls_states) JL_NOTSAFEPOINT;
 int jl_engine_hasreserved(jl_method_instance_t *m, jl_value_t *owner) JL_NOTSAFEPOINT;
 
-JL_DLLEXPORT jl_code_instance_t *jl_type_infer(jl_method_instance_t *li JL_PROPAGATES_ROOT, size_t world, uint8_t source_mode);
+JL_DLLEXPORT jl_code_instance_t *jl_type_infer(jl_value_t* compiler, jl_method_instance_t *li JL_PROPAGATES_ROOT, size_t world, uint8_t source_mode);
 JL_DLLEXPORT jl_code_info_t *jl_gdbcodetyped1(jl_method_instance_t *mi, size_t world);
-JL_DLLEXPORT jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *meth JL_PROPAGATES_ROOT, size_t world);
+JL_DLLEXPORT jl_code_instance_t *jl_compile_method_internal(jl_value_t* compiler, jl_method_instance_t *meth JL_PROPAGATES_ROOT, size_t world);
 JL_DLLEXPORT jl_code_instance_t *jl_get_method_inferred(
+        jl_value_t *compiler,
         jl_method_instance_t *mi JL_PROPAGATES_ROOT, jl_value_t *rettype,
         size_t min_world, size_t max_world, jl_debuginfo_t *di, jl_svec_t *edges);
 JL_DLLEXPORT jl_method_instance_t *jl_get_unspecialized(jl_method_t *def JL_PROPAGATES_ROOT);
@@ -1241,8 +1242,7 @@ JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *mo
 JL_DLLEXPORT jl_method_instance_t *jl_get_specialization1(jl_tupletype_t *types JL_PROPAGATES_ROOT, size_t world, int mt_cache);
 jl_method_instance_t *jl_get_specialized(jl_method_t *m, jl_value_t *types, jl_svec_t *sp) JL_PROPAGATES_ROOT;
 JL_DLLEXPORT jl_value_t *jl_rettype_inferred(jl_value_t *owner, jl_method_instance_t *li JL_PROPAGATES_ROOT, size_t min_world, size_t max_world);
-JL_DLLEXPORT jl_value_t *jl_rettype_inferred_native(jl_method_instance_t *mi, size_t min_world, size_t max_world) JL_NOTSAFEPOINT;
-JL_DLLEXPORT jl_code_instance_t *jl_method_compiled(jl_method_instance_t *mi JL_PROPAGATES_ROOT, size_t world) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_code_instance_t *jl_method_compiled(jl_value_t *compiler, jl_method_instance_t *mi JL_PROPAGATES_ROOT, size_t world) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_methtable_lookup(jl_methtable_t *mt JL_PROPAGATES_ROOT, jl_value_t *type, size_t world);
 JL_DLLEXPORT jl_method_instance_t *jl_specializations_get_linfo(
     jl_method_t *m JL_PROPAGATES_ROOT, jl_value_t *type, jl_svec_t *sparams);
@@ -1257,7 +1257,6 @@ JL_DLLEXPORT int jl_mi_try_insert(jl_method_instance_t *mi JL_ROOTING_ARGUMENT,
 JL_DLLEXPORT jl_code_instance_t *jl_cached_uninferred(jl_code_instance_t *codeinst, size_t world);
 JL_DLLEXPORT jl_code_instance_t *jl_cache_uninferred(jl_method_instance_t *mi, jl_code_instance_t *checked, size_t world, jl_code_instance_t *newci JL_MAYBE_UNROOTED);
 JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst_for_uninferred(jl_method_instance_t *mi, jl_code_info_t *src);
-JL_DLLEXPORT extern jl_value_t *(*const jl_rettype_inferred_addr)(jl_method_instance_t *mi JL_PROPAGATES_ROOT, size_t min_world, size_t max_world) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT void jl_force_trace_compile_timing_enable(void);
 JL_DLLEXPORT void jl_force_trace_compile_timing_disable(void);

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -237,6 +237,7 @@ typedef struct _jl_task_t {
     jl_value_t *donenotify;
     jl_value_t *result;
     jl_value_t *scope;
+    jl_value_t *compiler;
     jl_function_t *start;
     _Atomic(uint8_t) _state;
     uint8_t sticky; // record whether this Task can be migrated to a new thread

--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -61,10 +61,11 @@ static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t 
         }
     }
     jl_task_t *ct = jl_current_task;
+    jl_value_t *compiler = ct->compiler;
     size_t world = ct->world_age;
     jl_code_instance_t *ci = NULL;
     if (do_compile) {
-        ci = jl_compile_method_internal(mi, world);
+        ci = jl_compile_method_internal(compiler, mi, world);
     }
 
     jl_fptr_args_t callptr = (jl_fptr_args_t)jl_interpret_opaque_closure;
@@ -117,7 +118,7 @@ static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t 
         jl_method_instance_t *mi_generic = jl_specializations_get_linfo(jl_opaque_closure_method, sigtype, jl_emptysvec);
 
         // OC wrapper methods are not world dependent and have no edges or other info
-        ci = jl_get_method_inferred(mi_generic, selected_rt, 1, ~(size_t)0, NULL, NULL);
+        ci = jl_get_method_inferred(compiler, mi_generic, selected_rt, 1, ~(size_t)0, NULL, NULL);
         if (!jl_atomic_load_acquire(&ci->invoke)) {
             jl_emit_codeinst_to_jit(ci, NULL); // confusing this actually calls jl_emit_oc_wrapper and never actually compiles ci (which would be impossible since it cannot have source)
             jl_compile_codeinst(ci);

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -369,6 +369,7 @@ void *jl_get_abi_converter(jl_task_t *ct, _Atomic(void*) *fptr, _Atomic(size_t) 
     size_t nargs = jl_nparams(sigt);
     jl_method_instance_t *mi;
     jl_code_instance_t *codeinst;
+    jl_value_t *compiler = jl_nothing; // native
     size_t world;
     // check first, while behind this lock, of the validity of the current contents of this cfunc thunk
     JL_LOCK(&cfun_lock);
@@ -401,7 +402,7 @@ void *jl_get_abi_converter(jl_task_t *ct, _Atomic(void*) *fptr, _Atomic(size_t) 
         }
         JL_UNLOCK(&cfun_lock);
         // next, try to figure out what the target should look like (outside of the lock since this is very slow)
-        codeinst = mi ? jl_type_infer(mi, world, SOURCE_MODE_ABI) : nullptr;
+        codeinst = mi ? jl_type_infer(compiler, mi, world, SOURCE_MODE_ABI) : nullptr;
         // relock for the remainder of the function
         JL_LOCK(&cfun_lock);
     } while (jl_atomic_load_acquire(&jl_world_counter) != world); // restart entirely, since jl_world_counter changed thus jl_get_specialization1 might have changed

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -507,7 +507,8 @@ static htable_t bits_replace;
 static const jl_fptr_args_t id_to_fptrs[] = {
     &jl_f_throw, &jl_f_throw_methoderror, &jl_f_is, &jl_f_typeof, &jl_f_issubtype, &jl_f_isa,
     &jl_f_typeassert, &jl_f__apply_iterate, &jl_f__apply_pure,
-    &jl_f__call_latest, &jl_f__call_in_world, &jl_f__call_in_world_total, &jl_f_isdefined, &jl_f_isdefinedglobal,
+    &jl_f__call_latest, &jl_f__call_in_world, &jl_f__call_in_world_total, &jl_f__call_within, 
+    &jl_f_isdefined, &jl_f_isdefinedglobal,
     &jl_f_tuple, &jl_f_svec, &jl_f_intrinsic_call,
     &jl_f_getfield, &jl_f_setfield, &jl_f_swapfield, &jl_f_modifyfield, &jl_f_setfieldonce,
     &jl_f_replacefield, &jl_f_fieldtype, &jl_f_nfields, &jl_f_apply_type, &jl_f_memorynew,

--- a/src/task.c
+++ b/src/task.c
@@ -1108,6 +1108,7 @@ JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, jl_value_t *completion
     jl_atomic_store_relaxed(&t->_isexception, 0);
     // Inherit scope from parent task
     t->scope = ct->scope;
+    t->compiler = ct->compiler;
     // Fork task-local random state from parent
     jl_rng_split(t->rngState, ct->rngState);
     // there is no active exception handler available on this stack yet
@@ -1573,6 +1574,7 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     ct->donenotify = jl_nothing;
     jl_atomic_store_relaxed(&ct->_isexception, 0);
     ct->scope = jl_nothing;
+    ct->compiler = jl_nothing;
     ct->eh = NULL;
     ct->gcstack = NULL;
     ct->excstack = NULL;

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -1116,8 +1116,9 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval_flex(jl_module_t *JL_NONNULL m, jl_val
         // Don't infer blocks containing e.g. method definitions, since it's probably not worthwhile.
         size_t world = jl_atomic_load_acquire(&jl_world_counter);
         ct->world_age = world;
+        jl_value_t *compiler = ct->compiler;
         if (!has_defs && jl_get_module_infer(m) != 0) {
-            (void)jl_type_infer(mfunc, world, SOURCE_MODE_ABI);
+            (void)jl_type_infer(compiler, mfunc, world, SOURCE_MODE_ABI);
         }
         result = jl_invoke(/*func*/NULL, /*args*/NULL, /*nargs*/0, mfunc);
         ct->world_age = last_age;

--- a/test/compiler/plugins/CustomMethodTables/Project.toml
+++ b/test/compiler/plugins/CustomMethodTables/Project.toml
@@ -1,0 +1,3 @@
+name = "CustomMethodTables"
+uuid = "c7760be9-f452-4d49-98f3-ac2c5719893a"
+version = "0.1.0"

--- a/test/compiler/plugins/CustomMethodTables/src/CustomMethodTables.jl
+++ b/test/compiler/plugins/CustomMethodTables/src/CustomMethodTables.jl
@@ -1,0 +1,58 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module CustomMethodTables
+
+const CC = Core.Compiler
+
+function overlay(mt::CC.MethodTable, f, args...)
+    return Base.invoke_within(CMTCompiler(mt), f, args...)
+end
+
+const COMPILER_WORLD = Ref{UInt}(0)
+function __init__()
+    COMPILER_WORLD[] = Base.get_world_counter()
+end
+
+struct CMTCompiler <: CC.AbstractCompiler
+    mt::CC.MethodTable
+end
+CC.compiler_world(::CMTCompiler) = COMPILER_WORLD[]
+CC.abstract_interpreter(compiler::CMTCompiler, world::UInt) =
+    CMTInterp(compiler; world)
+
+method_table(C::CMTCompiler) = C.mt
+
+struct CMTInterp <: CC.AbstractInterpreter
+    compiler::CMTCompiler
+    world::UInt
+    inf_params::CC.InferenceParams
+    opt_params::CC.OptimizationParams
+    inf_cache::Vector{CC.InferenceResult}
+    function CMTInterp(compiler::CMTCompiler;
+                world::UInt = Base.get_world_counter(),
+                inf_params::CC.InferenceParams = CC.InferenceParams(),
+                opt_params::CC.OptimizationParams = CC.OptimizationParams(),
+                inf_cache::Vector{CC.InferenceResult} = CC.InferenceResult[])
+        return new(compiler, world, inf_params, opt_params, inf_cache)
+    end
+end
+
+CC.InferenceParams(interp::CMTInterp) = interp.inf_params
+CC.OptimizationParams(interp::CMTInterp) = interp.opt_params
+CC.get_inference_world(interp::CMTInterp) = interp.world
+CC.get_inference_cache(interp::CMTInterp) = interp.inf_cache
+CC.cache_owner(interp::CMTInterp) = interp.compiler
+CC.method_table(interp::CMTInterp) = Core.Compiler.OverlayMethodTable(CC.get_inference_world(interp), method_table(interp.compiler))
+
+# precompilation
+precompile(CC.abstract_interpreter, (CMTCompiler, UInt))
+precompile(CC.typeinf_ext_toplevel, (CMTInterp, CC.MethodInstance))
+
+COMPILER_WORLD[] = Base.get_world_counter()
+# Insert code execution statements here
+
+# end precompile
+COMPILER_WORLD[] = 0
+
+
+end # module CustomMethodTables


### PR DESCRIPTION
Currently external abstract interpreters are succesfully used to power analysis,
compilation for external targets like GPU, but there currently doesn't exist a
mechanism within Julia to execute the output of these abstract interpreters and
the community has developed various work-arounds.

- Enzyme.jl uses GPUCompiler.jl + LLVM.jl to spin up it's own external JIT and
  uses ccall to call from Julia native to Enzyme controlled land. It furthermore
  needs to detect dynamic callsites and replaces them to functions controlled by Enzyme.
- CassetteOverlay.jl uses the "cassette" transform to replace all calls `f(args...)`
  to calls to `overdub(ctx, f, args...)`. While this has worked in Cassette.jl for a
  long time, it also leads to hard to read backtraces and overly relies on generated functions.

This PR is a combination of two ideas:
  - The currently active compiler is a dynamically scoped value (implemented as a dedicated task-local for performance)
  - #52233 unifies the cache infrastructure for native and external compilers, thus allows for easy querying inside the runtime and compiler

Concretly this PR introduces `abstract type CompilerInstance end` that allows for the creation of temporary `AbstractInterpreter` instances,
it then uses a new built-in `call_within` to switch between compiler instances, furthermore the compiler instance is also the owner of
the corresponding `CodeInstances`.

After that it is mostly and exercise of threading the compiler instance through in the right places.

## TODO
- [ ] Go through all uses of explicit `jl_nothing` as a owner token and use the correct one.
- [ ] Expose the compiler instance to reflection methods
- [ ] Add abstract interpreter support for `call_within`
- [ ] Concrete evaluation will need to use `call_within`
- [ ] Interpreter support? JuliaInterpreter.jl support? Cthulhu support?
- [ ] Finalizers?

## Example: Cassette style tracer

This PR doesn't do anything about how to work with the IR and write compiler plugins,
it also doesn't provide any hooks for compiler instances to modify the LLVM pipeline,
but a below is a prototype of a Cassette type tracer. Where we have a `prehook`
and a `posthook` function to execute over the callgraph.

<details>

```julia
const CC = Core.Compiler

import .CC: SSAValue, GlobalRef

struct Tracer <: CC.AbstractCompiler end
CC.abstract_interpreter(::Tracer, world::UInt) =
    TracerInterp(; world)

struct TracerInterp <: CC.AbstractInterpreter
    world::UInt
    inf_params::CC.InferenceParams
    opt_params::CC.OptimizationParams
    inf_cache::Vector{CC.InferenceResult}
    code_cache::CC.InternalCodeCache
    compiler::Tracer
    function TracerInterp(;
                world::UInt = Base.get_world_counter(),
                compiler::Tracer = Tracer(),
                inf_params::CC.InferenceParams = CC.InferenceParams(),
                opt_params::CC.OptimizationParams = CC.OptimizationParams(),
                inf_cache::Vector{CC.InferenceResult} = CC.InferenceResult[],
                code_cache::CC.InternalCodeCache = CC.InternalCodeCache(compiler))
        return new(world, inf_params, opt_params, inf_cache, code_cache, compiler)
    end
end

CC.InferenceParams(interp::TracerInterp) = interp.inf_params
CC.OptimizationParams(interp::TracerInterp) = interp.opt_params
CC.get_world_counter(interp::TracerInterp) = interp.world
CC.get_inference_cache(interp::TracerInterp) = interp.inf_cache
CC.code_cache(interp::TracerInterp) = CC.WorldView(interp.code_cache, CC.WorldRange(interp.world))
CC.cache_owner(interp::TracerInterp) = interp.compiler

import Core.Compiler: retrieve_code_info, maybe_validate_code
# Replace usage sited of `retrieve_code_info`, OptimizationState is one such, but in all interesting use-cases
# it is derived from an InferenceState. There is a third one in `typeinf_ext` in case the module forbids inference.
function CC.InferenceState(result::CC.InferenceResult, cache_mode::UInt8, interp::TracerInterp)
    world = CC.get_world_counter(interp)
    src = retrieve_code_info(result.linfo, world)
    src === nothing && return nothing
    maybe_validate_code(result.linfo, src, "lowered")
    src = transform(interp, result.linfo, src)
    maybe_validate_code(result.linfo, src, "transformed")
    return CC.InferenceState(result, src, cache_mode, interp)
end

##
# Cassette style early transform
##

# Allows for Cassette Pass transforms

function static_eval(mod, name)
    if Base.isbindingresolved(mod, name) && Base.isdefined(mod, name)
        return getfield(mod, name)
    else
        return nothing
    end
end

function prehook end
function posthook end

function transform(interp, mi, src)
    method = mi.def
    f = static_eval(method.module, method.name)
    ccall(:jl_, Cvoid, (Any,), mi)
    if f === Core._apply
        return src
    end
    if f isa Core.Builtin
        error("Transforming builtin")
    end
    # if f === prehook || f === posthook
    #     return src
    # end
    ci = copy(src)
    transform!(mi, ci)
    ci.ssavaluetypes = length(ci.code)
    # XXX we need to copy flags
    ci.ssaflags = [0x00 for _ in 1:length(ci.code)]
    # ccall(:jl_, Cvoid, (Any,), ci)
    return ci
end

function ir_element(x, code::Vector)
    while isa(x, Core.SSAValue)
        x = code[x.id]
    end
    return x
end

"""
    is_ir_element(x, y, code::Vector)

Return `true` if `x === y` or if `x` is an `SSAValue` such that
`is_ir_element(code[x.id], y, code)` is `true`.
See also: [`replace_match!`](@ref), [`insert_statements!`](@ref)
"""
function is_ir_element(x, y, code::Vector)
    result = false
    while true # break by default
        if x === y #
            result = true
            break
        elseif isa(x, Core.SSAValue)
            x = code[x.id]
        else
            break
        end
    end
    return result
end

"""
    insert_statements!(code::Vector, codelocs::Vector, stmtcount, newstmts)


For every statement `stmt` at position `i` in `code` for which `stmtcount(stmt, i)` returns
an `Int`, remove `stmt`, and in its place, insert the statements returned by
`newstmts(stmt, i)`. If `stmtcount(stmt, i)` returns `nothing`, leave `stmt` alone.

For every insertion, all downstream `SSAValue`s, label indices, etc. are incremented
appropriately according to number of inserted statements.

Proper usage of this function dictates that following properties hold true:

- `code` is expected to be a valid value for the `code` field of a `CodeInfo` object.
- `codelocs` is expected to be a valid value for the `codelocs` field of a `CodeInfo` object.
- `newstmts(stmt, i)` should return a `Vector` of valid IR statements.
- `stmtcount` and `newstmts` must obey `stmtcount(stmt, i) == length(newstmts(stmt, i))` if
    `isa(stmtcount(stmt, i), Int)`.

To gain a mental model for this function's behavior, consider the following scenario. Let's
say our `code` object contains several statements:
code = Any[oldstmt1, oldstmt2, oldstmt3, oldstmt4, oldstmt5, oldstmt6]
codelocs = Int[1, 2, 3, 4, 5, 6]

Let's also say that for our `stmtcount` returns `2` for `stmtcount(oldstmt2, 2)`, returns `3`
for `stmtcount(oldstmt5, 5)`, and returns `nothing` for all other inputs. From this setup, we
can think of `code`/`codelocs` being modified in the following manner:
newstmts2 = newstmts(oldstmt2, 2)
newstmts5 = newstmts(oldstmt5, 5)
code = Any[oldstmt1,
           newstmts2[1], newstmts2[2],
           oldstmt3, oldstmt4,
           newstmts5[1], newstmts5[2], newstmts5[3],
           oldstmt6]
codelocs = Int[1, 2, 2, 3, 4, 5, 5, 5, 6]

See also: [`replace_match!`](@ref), [`is_ir_element`](@ref)
"""
function insert_statements!(code, codelocs, stmtcount, newstmts)
    ssachangemap = fill(0, length(code))
    labelchangemap = fill(0, length(code))
    worklist = Tuple{Int,Int}[]
    for i in 1:length(code)
        stmt = code[i]
        nstmts = stmtcount(stmt, i)
        if nstmts !== nothing
            addedstmts = nstmts - 1
            push!(worklist, (i, addedstmts))
            ssachangemap[i] = addedstmts
            if i < length(code)
                labelchangemap[i + 1] = addedstmts
            end
        end
    end
    Core.Compiler.renumber_ir_elements!(code, ssachangemap, labelchangemap)
    for (i, addedstmts) in worklist
        i += ssachangemap[i] - addedstmts # correct the index for accumulated offsets
        stmts = newstmts(code[i], i)
        @assert length(stmts) == (addedstmts + 1)
        code[i] = stmts[end]
        for j in 1:(length(stmts) - 1) # insert in reverse to maintain the provided ordering
            insert!(code, i, stmts[end - j])
            insert!(codelocs, i, codelocs[i])
        end
    end
end

function transform!(mi, src)
    stmtcount = (x, i) -> begin
        isassign = Base.Meta.isexpr(x, :(=))
        stmt = isassign ? x.args[2] : x
        if Base.Meta.isexpr(stmt, :call)
            return 4
        end
        return nothing
    end
    newstmts = (x, i) -> begin
        callstmt = Base.Meta.isexpr(x, :(=)) ? x.args[2] : x
        isapplycall = is_ir_element(callstmt.args[1], GlobalRef(Core, :_apply), src.code)
        isapplyiteratecall = is_ir_element(callstmt.args[1], GlobalRef(Core, :_apply_iterate), src.code)
        if isapplycall || isapplyiteratecall
            callf = callstmt.args[2]
            callargs = callstmt.args[3:end]
            stmts = Any[
                Expr(:call,
                     GlobalRef(Core, :_call_within), nothing,
                     prehook, callf, callargs...),
                callstmt,
                Expr(:call,
                     GlobalRef(Core, :_call_within), nothing,
                     posthook, SSAValue(i + 1), callf, callargs...),
                Base.Meta.isexpr(x, :(=)) ? Expr(:(=), x.args[1], SSAValue(i + 1)) : SSAValue(i + 1)
            ]
        else
            stmts = Any[
                Expr(:call, GlobalRef(Core, :_call_within), nothing, prehook, callstmt.args...),
                callstmt,
                Expr(:call, GlobalRef(Core, :_call_within), nothing, posthook, SSAValue(i + 1), callstmt.args...),
                Base.Meta.isexpr(x, :(=)) ? Expr(:(=), x.args[1], SSAValue(i + 1)) : SSAValue(i + 1)
            ]
        end
        return stmts
    end
    insert_statements!(src.code, src.codelocs, stmtcount, newstmts)
    return nothing
end

# TODO:
# - anything called from prehook is still instrumented
#   - either we can stop instrumentation / or switch to native (high overhead)
# - Similar problem with invokelatest, we somehow got recursion
# - invokelatest trace sees prehook call -- do we double transform?
```
</details>

```julia
struct Call
    parent
    f
    args
    children
end

# TODO: Handle task-safety
const call_tree = ScopedValue{Ref{Call}}()

function prehook(f, args...)
    parent = call_tree[][]
    current = Call(parent, f, args, Call[])
    push!(parent.children, current)
    call_tree[][] = current
end

function posthook(_, f, args...)
    current = call_tree[][]
    call_tree[][] = current.parent
end

function f()
end

function trace(f, args...)
    top = Call(nothing, f, args, Call[])
    @with call_tree => Ref(top) begin
        Base.invoke_within(Tracer(), f, args...)
    end
    return top
end

trace(f)
```

