### PR TITLE
irinterp: add Tarjan SCC algorithm for reachability

### DIFF
--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -200,6 +200,7 @@ include("compiler/validation.jl")
 include("compiler/ssair/basicblock.jl")
 include("compiler/ssair/domtree.jl")
 include("compiler/ssair/ir.jl")
+include("compiler/ssair/tarjan.jl")
 
 include("compiler/abstractlattice.jl")
 include("compiler/inferenceresult.jl")

--- a/base/compiler/ssair/tarjan.jl
+++ b/base/compiler/ssair/tarjan.jl
@@ -1,0 +1,299 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+using Core.Compiler: DomTree, CFG, BasicBlock, StmtRange, dominates
+
+struct SCCStackItem
+    v::Int32
+    # which child of `v` to scan
+    child::Int32
+    # the location of `parent` in the stack
+    parent::Int32
+    # the index in the (pre-order traversal of the) DFS tree
+    preorder::Int32
+    # the minimum node (by pre-order index) reachable from any node in the DFS sub-tree rooted at `v`
+    minpreorder::Int32
+    # whether this node is reachable from BasicBlock #1
+    live::Bool
+end
+
+function SCCStackItem(item::SCCStackItem; child=item.child,
+                      minpreorder=item.minpreorder, live=item.live)
+    return SCCStackItem(
+        item.v,        # v
+        child,         # child
+        item.parent,   # parent
+        item.preorder, # preorder
+        minpreorder,   # minpreorder
+        live,          # live
+    )
+end
+
+struct CFGReachability
+    irreducible::BitVector # BBNumber -> Bool
+    scc::Vector{Int}       # BBNumber -> SCCNumber
+    domtree::DomTree
+
+    _worklist::Vector{Int}       # for node removal
+    _stack::Vector{SCCStackItem} # for Tarjan's SCC algorithm
+end
+
+function CFGReachability(cfg::CFG, domtree::DomTree)
+    n_blocks = length(cfg.blocks)
+    reachability = CFGReachability(
+        BitVector(undef, n_blocks), # irreducible
+        zeros(Int, n_blocks),       # scc
+        domtree,                    # domtree
+        Int[],                      # _worklist
+        SCCStackItem[],             # _stack
+    )
+    tarjan!(reachability, cfg)
+    return reachability
+end
+
+bb_unreachable(reach::CFGReachability, bb::Int) = reach.scc[bb] == 0
+
+bb_in_irreducible_loop(reach::CFGReachability, bb::Int) = reach.irreducible[bb]
+
+# Returns `true` if a node is 'rooted' as reachable, i.e. it is has an incoming
+# edge from a resolved SCC other than its own (or it is BasicBlock #1).
+#
+# `tarjan!` takes the transitive closure of this relation in order to detect
+# which BasicBlocks are unreachable.
+function _bb_externally_reachable(reach::CFGReachability, cfg::CFG, bb::Int)
+    (; scc) = reach
+    bb == 1 && return true
+    for pred in cfg.blocks[bb].preds
+        scc[pred] <= 0 && continue
+        dominates(reach.domtree, bb, pred) && continue
+        @assert scc[pred] != scc[bb]
+        return true
+    end
+    return false
+end
+
+"""
+    tarjan!(reach::CFGReachability, cfg::CFG, root::Int=1)
+
+Tarjan's strongly-connected components algorithm. Traverses the CFG starting at `root`, ignoring
+nodes with resolved SCC's and updating outputs for all un-resolved nodes.
+
+Returns true if any node was discovered to be unreachable, false otherwise.
+
+Outputs:
+  - `reach.scc`: strongly-connected components, ignoring backedges to (natural) loops
+  - `reach.irreducible`: true iff a BasicBlock is part of a (non-trivial) SCC / irreducible loop
+  - `reach._worklist`: if performing an incremental update (`root != 1`), any traversed nodes that
+    are unreachable from BasicBlock #1 are enqueued to this worklist
+"""
+function tarjan!(reach::CFGReachability, cfg::CFG; root::Int=1)
+    (; scc, irreducible, domtree) = reach
+    scc[root] != 0 && return scc
+    live = _bb_externally_reachable(reach, cfg, root)
+
+    # the original algorithm has a separate stack and worklist (unrelated to `reach._worklist`)
+    # here we use a single combined stack for improved memory/cache efficiency
+    stack = reach._stack
+    push!(stack, SCCStackItem(
+        root, # v
+        1,    # child
+        0,    # parent
+        1,    # preorder
+        1,    # minpreorder
+        live, # live
+    ))
+    scc[root] = -1
+    cursor = length(stack)
+
+    # worklist length before any new unreachable nodes are added
+    worklist_len = length(reach._worklist)
+
+    # last (pre-order) DFS label assigned to a node
+    preorder_id = 1
+    while true
+        (; v, child, minpreorder, live) = item = stack[cursor]
+
+        bb = cfg.blocks[v]
+        if child <= length(bb.succs) # queue next child
+            stack[cursor] = item = SCCStackItem(item; child=child+1)
+            succ = bb.succs[child]
+
+            # ignore any back-edges in a (natural) loop (see `kill_edge!`)
+            if dominates(domtree, succ, convert(Int, v))
+                # This check ensures that reducible CFG's will contain no SCC's. The vast majority
+                # of functions have reducible CFG's, so this optimization is very important.
+                continue
+            end
+
+            if scc[succ] < 0
+                # next child is already in DFS tree
+                child_preorder = stack[-scc[succ]].preorder
+
+                # only need to update `minpreorder` for `v`
+                stack[cursor] = item = SCCStackItem(item;
+                                                    minpreorder=min(minpreorder, child_preorder))
+            elseif scc[succ] == 0
+                # next child is a new element in DFS tree
+                preorder_id += 1
+                live = live || _bb_externally_reachable(reach, cfg, succ)
+                push!(stack, SCCStackItem(
+                    succ,        # v
+                    1,           # child
+                    cursor,      # parent (index in stack)
+                    preorder_id, # preorder
+                    preorder_id, # minpreorder
+                    live,        # live
+                ))
+                scc[succ] = -length(stack)
+                cursor = length(stack)
+            else end # next child is a resolved SCC (do nothing)
+        else # v's children are processed, finalize v
+            if item.minpreorder == item.preorder
+                has_one_element = stack[end].v == v
+                while true
+                    item = pop!(stack)
+                    if live
+                        scc[item.v] = v
+                        scan_subgraph!(reach, cfg, convert(Int, item.v),
+                            #= filter =# (pred,x)->(!dominates(domtree, x, pred) && scc[x] > typemax(Int)÷2),
+                            #= action =# (x)->(scc[x] -= typemax(Int)÷2;),
+                        )
+                    else # this offset marks a node as 'maybe-dead'
+                        scc[item.v] = v + typemax(Int)÷2
+                        push!(reach._worklist, item.v)
+                    end
+                    irreducible[item.v] = !has_one_element
+                    (item.v == v) && break
+                end
+                item.parent == 0 && break # all done
+            elseif live
+                stack[item.parent] = SCCStackItem(stack[item.parent]; live=true)
+            end
+
+            # update `minpreorder` for parent
+            parent = stack[item.parent]
+            minpreorder = min(parent.minpreorder, item.minpreorder)
+            stack[item.parent] = SCCStackItem(parent; minpreorder)
+
+            cursor = item.parent
+        end
+    end
+
+    worklist = reach._worklist
+
+    # filter the worklist, leaving any nodes not proven to be reachable from BB #1
+    n_filtered = 0
+    for i = (worklist_len + 1):length(worklist)
+        @assert worklist[i] != 1
+        @assert scc[worklist[i]] > 0
+        if scc[worklist[i]] > typemax(Int)÷2
+            # node is unreachable, enqueue it
+            scc[worklist[i]] = 0
+            worklist[i - n_filtered] = worklist[i]
+        else
+            n_filtered += 1
+        end
+    end
+    resize!(worklist, length(worklist) - n_filtered)
+
+    return length(worklist) > worklist_len # if true, a (newly) unreachable node was enqueued
+end
+
+"""
+Scan the subtree rooted at `root`, excluding `root` itself
+
+Note: This function will not detect cycles for you. The `filter` provided must
+      protect against infinite cycle traversal.
+"""
+function scan_subgraph!(reach::CFGReachability, cfg::CFG, root::Int, filter, action)
+    worklist = reach._worklist
+    start_len = length(worklist)
+
+    push!(worklist, root)
+    while length(worklist) > start_len
+        v = pop!(worklist)
+        for succ in cfg.blocks[v].succs
+            !filter(v, succ) && continue
+            action(succ)
+            push!(worklist, succ)
+        end
+    end
+end
+
+function enqueue_if_unreachable!(reach::CFGReachability, cfg::CFG, bb::Int)
+    (; domtree, scc) = reach
+    @assert scc[bb] != 0
+
+    bb == 1 && return false
+    if bb_in_irreducible_loop(reach, bb)
+        # irreducible CFG
+        # this requires a full scan of the irreducible loop
+
+        scc′ = scc[bb]
+        scc[bb] = 0
+        scan_subgraph!(reach, cfg, bb, # set this SCC to 0
+            #= filter =# (pred,x)->(!dominates(domtree, x, pred) && scc[x] == scc′),
+            #= action =# (x)->(scc[x] = 0;),
+        )
+
+        # re-compute the SCC's for this portion of the CFG, adding any freshly
+        # unreachable nodes to `reach._worklist`
+        return tarjan!(reach, cfg; root=bb)
+    else
+        # target is a reducible CFG node
+        # this node lives iff it still has an incoming forward edge
+        for pred in cfg.blocks[bb].preds
+            !dominates(domtree, bb, pred) && return false # forward-edge
+        end
+        scc[bb] = 0
+        push!(reach._worklist, bb)
+        return true
+    end
+end
+
+"""
+Remove from `cfg` and `reach` the edge (from → to), as well as any blocks/edges
+this causes to become unreachable.
+
+Calls:
+  - `block_callback` for every unreachable block.
+  - `edge_callback` for every unreachable edge into a reachable block (may also
+     be called for blocks which are later discovered to be unreachable).
+"""
+function kill_edge!(reach::CFGReachability, cfg::CFG, from::Int, to::Int,
+                    edge_callback=nothing, block_callback=nothing)
+    (reach.scc[from] == 0) && return # source is already unreachable
+    @assert reach.scc[to] != 0
+
+    # delete (from → to) edge
+    preds, succs = cfg.blocks[to].preds, cfg.blocks[from].succs
+    deleteat!(preds, findfirst(x::Int->x==from, preds)::Int)
+    deleteat!(succs, findfirst(x::Int->x==to, succs)::Int)
+
+    # check for unreachable target
+    enqueued = enqueue_if_unreachable!(reach, cfg, to)
+    if !enqueued && edge_callback !== nothing
+        edge_callback(from, to)
+    end
+    while !isempty(reach._worklist)
+        node = convert(Int, pop!(reach._worklist))
+
+        # already marked unreachable, just need to notify
+        @assert reach.scc[node] == 0 && node != 1
+        if block_callback !== nothing
+            block_callback(node)
+        end
+
+        for succ in cfg.blocks[node].succs
+            # delete (node → succ) edge
+            preds = cfg.blocks[succ].preds
+            deleteat!(preds, findfirst(x::Int->x==node, preds)::Int)
+
+            # check for newly unreachable target
+            reach.scc[succ] == 0 && continue
+            enqueued = enqueue_if_unreachable!(reach, cfg, succ)
+            if !enqueued && edge_callback !== nothing
+                edge_callback(node, succ)
+            end
+        end
+    end
+end

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -156,10 +156,9 @@ function choosetests(choices = [])
     filtertests!(tests, "subarray")
     filtertests!(tests, "compiler", [
         "compiler/datastructures", "compiler/inference", "compiler/effects",
-        "compiler/validation", "compiler/ssair", "compiler/irpasses",
-        "compiler/codegen", "compiler/inline", "compiler/contextual",
-        "compiler/invalidation", "compiler/AbstractInterpreter",
-        "compiler/EscapeAnalysis/EscapeAnalysis"])
+        "compiler/validation", "compiler/ssair", "compiler/irpasses", "compiler/tarjan",
+        "compiler/codegen", "compiler/inline", "compiler/contextual", "compiler/invalidation",
+        "compiler/AbstractInterpreter", "compiler/EscapeAnalysis/EscapeAnalysis"])
     filtertests!(tests, "compiler/EscapeAnalysis", [
         "compiler/EscapeAnalysis/EscapeAnalysis"])
     filtertests!(tests, "stdlib", STDLIBS)

--- a/test/compiler/tarjan.jl
+++ b/test/compiler/tarjan.jl
@@ -1,0 +1,167 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+using Core.Compiler: CFGReachability, DomTree, CFG, BasicBlock, StmtRange, dominates,
+                     bb_unreachable, kill_edge!
+
+const CC = Core.Compiler
+
+function reachable(g::CFG, a::Int, b::Int; domtree=nothing)
+    visited = BitVector(false for _ = 1:length(g.blocks))
+    worklist = Int[a]
+    while !isempty(worklist)
+        node = pop!(worklist)
+        node == b && return true
+        visited[node] = true
+        for child in g.blocks[node].succs
+            if domtree !== nothing && dominates(domtree, child, node)
+                continue # if provided `domtree`, ignore back-edges
+            end
+
+            !visited[child] && push!(worklist, child)
+        end
+    end
+    return false
+end
+
+function rand_cfg(V, E)
+    bbs = [BasicBlock(StmtRange(0,0), Int[], Int[]) for _ = 1:V]
+
+    reachable = BitVector(false for _ = 1:V)
+    reachable[1] = true
+
+    targets = BitVector(false for _ = 1:V)
+
+    for _ = 1:E
+        # Pick any source (with at least 1 missing edge)
+        source, dest = 0, 0
+        while true
+            source = rand(findall(reachable))
+            for v = 1:V
+                targets[v] = !in(v, bbs[source].succs)
+            end
+            any(targets) && break
+        end
+
+        # Pick any new target for source
+        dest = rand(findall(targets))
+
+        # Add edge to graph
+        push!(bbs[source].succs, dest)
+        push!(bbs[dest].preds, source)
+
+        reachable[dest] = true
+    end
+
+    return CFG(bbs, zeros(Int, V + 1))
+end
+
+function get_random_edge(cfg::CFG, V)
+    source = rand(1:V)
+    while length(cfg.blocks[source].succs) == 0
+        source = rand(1:V)
+    end
+    target = rand(cfg.blocks[source].succs)
+    return source, target
+end
+
+# Generate a random CFG with the requested number of vertices and edges, then simulate
+# `deletions` edge removals and verify that reachability is maintained correctly.
+#
+# If `all_checks` is true, verify internal data structures as well with O(E^2) checks.
+function test_reachability(V, E; deletions = 2E ÷ 3, all_checks=false)
+
+    function check_reachability(reachability, cfg, domtree, all_checks)
+        for i = 1:V
+            # All nodes should be reported as unreachable only if we cannot reach them from BB #1.
+            @test reachable(cfg, 1, i) == !bb_unreachable(reachability, i)
+
+            # All predecessors of a reachable block should be reachable.
+            if !bb_unreachable(reachability, i)
+                for pred in cfg.blocks[i].preds
+                    @test !bb_unreachable(reachability, pred)
+                end
+            end
+        end
+
+        if all_checks # checks for internal data structures - O(E^2)
+
+            # Nodes should be mutually reachable iff they are in the same SCC.
+            scc = reachability.scc
+            reachable_nodes = BitSet(v for v = 1:V if !bb_unreachable(reachability, v))
+            for i ∈ reachable_nodes
+                for j ∈ reachable_nodes
+                    @test (reachable(cfg, i, j; domtree) && reachable(cfg, j, i; domtree)) == (scc[i] == scc[j])
+                end
+            end
+
+            # Nodes in any non-trivial SCC (ignoring backedges) should be marked irreducible.
+            irreducible = reachability.irreducible
+            for i ∈ reachable_nodes
+                in_nontrivial_scc = any(v != i && scc[v] == scc[i] for v = 1:V)
+                @test CC.getindex(irreducible, i) == in_nontrivial_scc
+            end
+        end
+    end
+
+    cfg = rand_cfg(V, E)
+    domtree = Core.Compiler.construct_domtree(cfg.blocks)
+    reachability = CFGReachability(cfg, domtree)
+    check_reachability(reachability, cfg, domtree, all_checks)
+
+    # track the reachable blocks/edges so that we can verify callbacks below
+    blocks = Set{Int}()
+    edges = Set{Tuple{Int,Int}}()
+    for bb in 1:V
+        !bb_unreachable(reachability, bb) && push!(blocks, bb)
+        for succ in cfg.blocks[bb].succs
+            push!(edges, (bb, succ))
+        end
+    end
+
+    killed_edges = Tuple{Int,Int}[]
+    killed_blocks = Int[]
+    for k = 1:deletions
+        from, to = get_random_edge(cfg, V)
+        kill_edge!(reachability, cfg, from, to,
+            (from::Int, to::Int) -> push!(killed_edges, (from, to)),
+            (bb::Int) -> push!(killed_blocks, bb),
+        )
+
+        # If these nodes are still reachable, to and from edges should have been removed.
+        @test !reachable(cfg, 1, from) || !in(to, cfg.blocks[from].succs)
+        @test !reachable(cfg, 1, to)   || !in(from, cfg.blocks[to].preds)
+
+        check_reachability(reachability, cfg, domtree, all_checks)
+
+        for bb in 1:V
+            if bb_unreachable(reachability, bb) && in(bb, blocks)
+                # If the block changed from reachable -> unreachable, we should have gotten a callback.
+                @test bb in killed_blocks
+                delete!(blocks, bb)
+            end
+        end
+        for (from, to) in edges
+            if !in(from, cfg.blocks[to].preds) && !bb_unreachable(reachability, to)
+                # If the edge changed from reachable -> unreachable and feeds into a reachable BasicBlock,
+                # we should have gotten a callback.
+                @test (from, to) in killed_edges
+                delete!(edges, (from, to))
+            end
+        end
+
+        empty!(killed_edges)
+        empty!(killed_blocks)
+    end
+end
+
+@testset "CFGReachability tests" begin
+    test_reachability(1, 0; all_checks=true)
+
+    test_reachability(10, 15; all_checks=true)
+    test_reachability(10, 15; all_checks=true)
+    test_reachability(10, 15; all_checks=true)
+
+    test_reachability(100, 150; all_checks=false)
+    test_reachability(100, 150; all_checks=false)
+    test_reachability(100, 1000; all_checks=false)
+end

--- a/test/compiler/tarjan.jl
+++ b/test/compiler/tarjan.jl
@@ -56,10 +56,8 @@ function rand_cfg(V, E)
 end
 
 function get_random_edge(cfg::CFG, V)
-    source = rand(1:V)
-    while length(cfg.blocks[source].succs) == 0
-        source = rand(1:V)
-    end
+    has_edge = [length(cfg.blocks[bb].succs) != 0 for bb in 1:V]
+    source = rand(findall(has_edge))
     target = rand(cfg.blocks[source].succs)
     return source, target
 end
@@ -121,6 +119,8 @@ function test_reachability(V, E; deletions = 2E ÷ 3, all_checks=false)
     killed_edges = Tuple{Int,Int}[]
     killed_blocks = Int[]
     for k = 1:deletions
+        length(blocks) == 1 && break # no more reachable blocks
+
         from, to = get_random_edge(cfg, V)
         kill_edge!(reachability, cfg, from, to,
             (from::Int, to::Int) -> push!(killed_edges, (from, to)),


### PR DESCRIPTION
This PR optimizes `kill_edge!` for IR interp.

The basic algorithm flow is:
```
   1. Check whether `target` of dead edge is unreachable, which is true iff:
       - Reducible CFG node: there are no live incoming forward edges (predecessors)
       - Irreducible CFG node: Tarjan's SCC algorithm reports no live incoming forward edges to the SCC
   2. If `target` is dead, repeat (1) for all of its outgoing edges
```

This maintains reachability information very efficiently, especially for reducible CFG's which are overwhelmingly common.

As an added bonus, `CFGReachability` can also be consulted to check which BasicBlocks are part of an irreducible loop.