### PR TITLE
add docstring and test for `Base.format_bytes`

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -135,6 +135,30 @@ function padded_nonzero_print(value, str, always_print = true)
     end
 end
 
+"""
+    format_bytes(bytes; binary=true)
+
+Format a given number of bytes into a human-readable string.
+
+# Arguments
+- `bytes`: The number of bytes to format.
+- `binary=true`: If `true`, formats the bytes in binary units (powers of 1024). If `false`, uses decimal units (powers of 1000).
+
+# Returns
+`String`: A human-readable string representation of the bytes, formatted in either binary or decimal units based on the `binary` argument.
+
+# Examples
+```jldoctest
+julia> Base.format_bytes(1024)
+"1024 bytes"
+
+julia> Base.format_bytes(10000)
+"9.766 KiB"
+
+julia> Base.format_bytes(10000, binary=false)
+"10.000 kB"
+```
+"""
 function format_bytes(bytes; binary=true) # also used by InteractiveUtils
     units = binary ? _mem_units : _cnt_units
     factor = binary ? 1024 : 1000


### PR DESCRIPTION
There are many uses of this function throughout the package
ecosystem. In addition, it is common to see it re-implemented.
This adds some docstrings and tests for `Base.format_bytes`
to help aid discovery.
