### PR TITLE
add ability to specify heap size hint as a percent

### DIFF
--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -227,8 +227,8 @@ fallbacks to the latest compatible BugReporting.jl if not. For more information,
 
 .TP
 --heap-size-hint=<size>
-Forces garbage collection if memory usage is higher than that value. The memory hint might be
-specified in megabytes (500M) or gigabytes (1.5G)
+Forces garbage collection if memory usage is higher than that value. The value can be
+specified in units of K, M, G, T, or % of physical memory.
 
 .TP
 --compile={yes*|no|all|min}

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -189,7 +189,7 @@ static const char opts[]  =
     "                            --bug-report=help.\n\n"
 
     " --heap-size-hint=<size>    Forces garbage collection if memory usage is higher than that value.\n"
-    "                            The memory hint might be specified in megabytes(500M) or gigabytes(1G)\n\n"
+    "                            The value can be specified in units of K, M, G, T, or % of physical memory.\n\n"
 ;
 
 static const char opts_hidden[]  =
@@ -821,14 +821,24 @@ restart_switch:
                         case 'T':
                             multiplier <<= 40;
                             break;
+                        case '%':
+                            if (value > 100)
+                                jl_errorf("julia: invalid percentage specified in --heap-size-hint");
+                            uint64_t mem = uv_get_total_memory();
+                            uint64_t cmem = uv_get_constrained_memory();
+                            if (cmem > 0 && cmem < mem)
+                                mem = cmem;
+                            multiplier = mem/100;
+                            break;
                         default:
+                            jl_errorf("julia: invalid unit specified in --heap-size-hint");
                             break;
                     }
                     jl_options.heap_size_hint = (uint64_t)(value * multiplier);
                 }
             }
             if (jl_options.heap_size_hint == 0)
-                jl_errorf("julia: invalid argument to --heap-size-hint without memory size specified");
+                jl_errorf("julia: invalid memory size specified in --heap-size-hint");
 
             break;
         case opt_gc_threads:


### PR DESCRIPTION
also fix overflowed subtraction with size hints < 250mb --- we should pick some minimum soft heap limit; I chose 1mb here but it could be anything.