### PR TITLE
place work-stealing queue indices on different cache lines to avoid false-sharing

### DIFF
--- a/src/work-stealing-queue.h
+++ b/src/work-stealing-queue.h
@@ -36,7 +36,8 @@ static inline ws_array_t *create_ws_array(size_t capacity, int32_t eltsz) JL_NOT
 
 typedef struct {
     _Atomic(int64_t) top;
-    _Atomic(int64_t) bottom;
+    char _padding[128 - sizeof(int64_t)];
+    _Atomic(int64_t) bottom; // put on a separate cache line. conservatively estimate cache line size as 128 bytes
     _Atomic(ws_array_t *) array;
 } ws_queue_t;
 


### PR DESCRIPTION
For some reason this only shows up in the `many_refs.jl` benchmark, since it's the only one that hammers the work-stealing queue (we also didn't test this benchmark on a large number of GC threads in our [previous analysis](https://github.com/JuliaLang/julia/pull/48600#issuecomment-1518944785)).

- master:
```
bench = "many_refs.jl"
(gcthreads, threads) = (1, 1)
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       4268 │    3243 │      3048 │        194 │         1126 │                15 │      868 │         76 │
│  median │       4270 │    3246 │      3051 │        195 │         1128 │                17 │      868 │         76 │
│ maximum │       4278 │    3247 │      3052 │        195 │         1128 │                18 │      868 │         76 │
│   stdev │          5 │       2 │         2 │          0 │            1 │                 1 │        0 │          0 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
(gcthreads, threads) = (2, 1)
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       2728 │    1692 │      1551 │        141 │          598 │                23 │      868 │         62 │
│  median │       2732 │    1709 │      1567 │        141 │          603 │                23 │      868 │         62 │
│ maximum │       2744 │    1712 │      1571 │        143 │          607 │                24 │      868 │         63 │
│   stdev │          6 │       9 │         9 │          1 │            4 │                 0 │        0 │          0 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
(gcthreads, threads) = (4, 1)
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       2105 │    1082 │       987 │         95 │          405 │                23 │      875 │         51 │
│  median │       2115 │    1089 │       994 │         95 │          409 │                23 │      875 │         52 │
│ maximum │       2127 │    1100 │      1003 │         97 │          417 │                25 │      875 │         52 │
│   stdev │          8 │       8 │         7 │          1 │            5 │                 1 │        0 │          0 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
(gcthreads, threads) = (8, 1)
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       3861 │    2755 │      2676 │         79 │         1301 │                22 │      878 │         68 │
│  median │       3864 │    2835 │      2756 │         80 │         1342 │                25 │      879 │         73 │
│ maximum │       4032 │    2877 │      2797 │         80 │         1378 │                26 │      880 │         74 │
│   stdev │         73 │      45 │        45 │          1 │           28 │                 2 │        1 │          2 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
(gcthreads, threads) = (16, 1)
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       7455 │    6425 │      6344 │         80 │         3262 │                24 │      882 │         86 │
│  median │       7703 │    6682 │      6602 │         81 │         3313 │                25 │      884 │         87 │
│ maximum │       7826 │    6806 │      6725 │         81 │         3422 │                27 │      887 │         87 │
│   stdev │        152 │     153 │       153 │          0 │           68 │                 1 │        2 │          0 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
```

- PR:
```
bench = "many_refs.jl"
(gcthreads, threads) = (1, 1)
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       4264 │    3240 │      3048 │        192 │         1127 │                15 │      868 │         76 │
│  median │       4271 │    3244 │      3052 │        192 │         1129 │                17 │      868 │         76 │
│ maximum │       4514 │    3481 │      3289 │        193 │         1247 │                18 │      868 │         77 │
│   stdev │        109 │     106 │       106 │          0 │           53 │                 1 │        0 │          1 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
(gcthreads, threads) = (2, 1)
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       2712 │    1680 │      1541 │        138 │          591 │                22 │      868 │         62 │
│  median │       2713 │    1691 │      1552 │        140 │          594 │                24 │      868 │         62 │
│ maximum │       2732 │    1710 │      1569 │        141 │          606 │                25 │      868 │         63 │
│   stdev │         11 │      12 │        12 │          1 │            6 │                 1 │        0 │          0 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
(gcthreads, threads) = (4, 1)
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       2090 │    1057 │       962 │         95 │          398 │                22 │      874 │         50 │
│  median │       2103 │    1070 │       974 │         95 │          401 │                24 │      874 │         51 │
│ maximum │       2140 │    1074 │       978 │         96 │          402 │                25 │      875 │         51 │
│   stdev │         19 │       6 │         6 │          0 │            1 │                 1 │        1 │          1 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
(gcthreads, threads) = (8, 1)
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       2236 │    1208 │      1129 │         79 │          528 │                23 │      880 │         54 │
│  median │       2238 │    1214 │      1135 │         79 │          533 │                23 │      880 │         54 │
│ maximum │       2246 │    1218 │      1138 │         80 │          534 │                35 │      880 │         54 │
│   stdev │          4 │       4 │         4 │          0 │            3 │                 5 │        0 │          0 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
(gcthreads, threads) = (16, 1)
┌─────────┬────────────┬─────────┬───────────┬────────────┬──────────────┬───────────────────┬──────────┬────────────┐
│         │ total time │ gc time │ mark time │ sweep time │ max GC pause │ time to safepoint │ max heap │ percent gc │
│         │         ms │      ms │        ms │         ms │           ms │                us │       MB │          % │
├─────────┼────────────┼─────────┼───────────┼────────────┼──────────────┼───────────────────┼──────────┼────────────┤
│ minimum │       2326 │    1297 │      1216 │         80 │          595 │                24 │      884 │         56 │
│  median │       2348 │    1325 │      1245 │         80 │          620 │                25 │      885 │         56 │
│ maximum │       2370 │    1341 │      1262 │         81 │          631 │                26 │      887 │         57 │
│   stdev │         17 │      19 │        19 │          0 │           14 │                 1 │        1 │          0 │
└─────────┴────────────┴─────────┴───────────┴────────────┴──────────────┴───────────────────┴──────────┴────────────┘
```