### PR TITLE
Apple silicon has 128 byte alignment so fix our defines to match

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -485,7 +485,11 @@ STATIC_INLINE uint8_t JL_CONST_FUNC jl_gc_szclass_align8(unsigned sz) JL_NOTSAFE
 }
 
 #define JL_SMALL_BYTE_ALIGNMENT 16
+#if defined(_CPU_AARCH64_) && defined(_OS_DARWIN_) // Apple silicon has 128 cache lines
+#define JL_CACHE_BYTE_ALIGNMENT 128
+#else
 #define JL_CACHE_BYTE_ALIGNMENT 64
+#endif
 // JL_HEAP_ALIGNMENT is the maximum alignment that the GC can provide
 #define JL_HEAP_ALIGNMENT JL_SMALL_BYTE_ALIGNMENT
 #define GC_MAX_SZCLASS (2032-sizeof(void*))


### PR DESCRIPTION
https://github.com/JuliaLang/julia/blob/8a69745bdcb06409ab7e4fc84718f34d7d54a7f9/base/lock.jl#L33-L50 this probably also needs a fix, and maybe other places as well