### PR TITLE
refactor the optimization flags set and utilities

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2722,7 +2722,7 @@ end
 function abstract_eval_statement(interp::AbstractInterpreter, @nospecialize(e), vtypes::VarTable, sv::InferenceState)
     if !isa(e, Expr)
         if isa(e, PhiNode)
-            add_curr_ssaflag!(sv, IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW)
+            add_curr_ssaflag!(sv, IR_FLAGS_REMOVABLE)
             return RTEffects(abstract_eval_phi(interp, e, vtypes, sv), Union{}, EFFECTS_TOTAL)
         end
         (; rt, exct, effects) = abstract_eval_special_value(interp, e, vtypes, sv)

--- a/base/compiler/ssair/EscapeAnalysis/EscapeAnalysis.jl
+++ b/base/compiler/ssair/EscapeAnalysis/EscapeAnalysis.jl
@@ -25,9 +25,9 @@ using ._TOP_MOD:     # Base definitions
     unwrap_unionall, !, !=, !==, &, *, +, -, :, <, <<, =>, >, |, ∈, ∉, ∩, ∪, ≠, ≤, ≥, ⊆
 using Core.Compiler: # Core.Compiler specific definitions
     Bottom, IRCode, IR_FLAG_NOTHROW, InferenceResult, SimpleInferenceLattice,
-    argextype, check_effect_free!, fieldcount_noerror, hasintersect, has_flag,
-    intrinsic_nothrow, is_meta_expr_head, isbitstype, isexpr, println, setfield!_nothrow,
-    singleton_type, try_compute_field, try_compute_fieldidx, widenconst, ⊑, AbstractLattice
+    argextype, fieldcount_noerror, hasintersect, has_flag, intrinsic_nothrow,
+    is_meta_expr_head, isbitstype, isexpr, println, setfield!_nothrow, singleton_type,
+    try_compute_field, try_compute_fieldidx, widenconst, ⊑, AbstractLattice
 
 include(x) = _TOP_MOD.include(@__MODULE__, x)
 if _TOP_MOD === Core.Compiler
@@ -597,12 +597,12 @@ struct LivenessChange <: Change
 end
 const Changes = Vector{Change}
 
-struct AnalysisState{T, L <: AbstractLattice}
+struct AnalysisState{GetEscapeCache, Lattice<:AbstractLattice}
     ir::IRCode
     estate::EscapeState
     changes::Changes
-    𝕃ₒ::L
-    get_escape_cache::T
+    𝕃ₒ::Lattice
+    get_escape_cache::GetEscapeCache
 end
 
 """

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -58,7 +58,7 @@ function kill_block!(ir::IRCode, bb::Int)
         inst = ir[SSAValue(bidx)]
         inst[:stmt] = nothing
         inst[:type] = Bottom
-        inst[:flag] = IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW
+        inst[:flag] = IR_FLAGS_REMOVABLE
     end
     ir[SSAValue(last(stmts))][:stmt] = ReturnNode()
     return
@@ -204,7 +204,7 @@ function reprocess_instruction!(interp::AbstractInterpreter, inst::Instruction, 
     if rt !== nothing
         if isa(rt, Const)
             inst[:type] = rt
-            if is_inlineable_constant(rt.val) && has_flag(inst, (IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW))
+            if is_inlineable_constant(rt.val) && has_flag(inst, IR_FLAGS_REMOVABLE)
                 inst[:stmt] = quoted(rt.val)
             end
             return true

--- a/src/julia.h
+++ b/src/julia.h
@@ -266,7 +266,7 @@ typedef union __jl_purity_overrides_t {
 } _jl_purity_overrides_t;
 
 #define NUM_EFFECTS_OVERRIDES 9
-#define NUM_IR_FLAGS 11
+#define NUM_IR_FLAGS 12
 
 // This type describes a single function body
 typedef struct _jl_code_info_t {
@@ -279,14 +279,15 @@ typedef struct _jl_code_info_t {
         // 1 << 1 = callsite inline region
         // 1 << 2 = callsite noinline region
         // 1 << 3 = throw block
-        // 1 << 4 = :effect_free
-        // 1 << 5 = :nothrow
-        // 1 << 6 = :consistent
-        // 1 << 7 = :refined
-        // 1 << 8 = :noub
-        // 1 << 9 = :effect_free_if_inaccessiblememonly
-        // 1 << 10 = :inaccessiblemem_or_argmemonly
-        // 1 << 11-18 = callsite effects overrides
+        // 1 << 4 = refined statement
+        // 1 << 5 = :consistent
+        // 1 << 6 = :effect_free
+        // 1 << 7 = :nothrow
+        // 1 << 8 = :terminates
+        // 1 << 9 = :noub
+        // 1 << 10 = :effect_free_if_inaccessiblememonly
+        // 1 << 11 = :inaccessiblemem_or_argmemonly
+        // 1 << 12-19 = callsite effects overrides
     // miscellaneous data:
     jl_value_t *method_for_inference_limit_heuristics; // optional method used during inference
     jl_value_t *linetable; // Table of locations [TODO: make this volatile like slotnames]


### PR DESCRIPTION
This commit serves as a preliminary PR for #52991. It involves adding `IR_FLAG_TERMINATES` to the optimization flags and carrying out various renaming refactors. As `IR_FLAG_TERMINATES` isn't utilized in this particular commit, it doesn't bring any changes to the compiler's functionality. The incoming commit will make use of it and fix #52991 along with other accompanying changes.