### PR TITLE
Add type assertion in iterate for logicalindex

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -786,11 +786,11 @@ end
     n = s[1]
     n > length(L) && return nothing
     #unroll once to help inference, cf issue #29418
-    idx, i = iterate(tail(s)...)
+    idx, i = iterate(tail(s)...)::Tuple{Any,Any,Vararg{Any}}
     s = (n+1, s[2], i)
     L.mask[idx] && return (idx, s)
     while true
-        idx, i = iterate(tail(s)...)
+        idx, i = iterate(tail(s)...)::Tuple{Any,Any,Vararg{Any}}
         s = (n+1, s[2], i)
         L.mask[idx] && return (idx, s)
     end

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -786,11 +786,11 @@ end
     n = s[1]
     n > length(L) && return nothing
     #unroll once to help inference, cf issue #29418
-    idx, i = iterate(tail(s)...)::Tuple{Any,Any,Vararg{Any}}
+    idx, i = iterate(tail(s)...)::Tuple{Any,Any}
     s = (n+1, s[2], i)
     L.mask[idx] && return (idx, s)
     while true
-        idx, i = iterate(tail(s)...)::Tuple{Any,Any,Vararg{Any}}
+        idx, i = iterate(tail(s)...)::Tuple{Any,Any}
         s = (n+1, s[2], i)
         L.mask[idx] && return (idx, s)
     end


### PR DESCRIPTION
The type-assertion helps convey the information that `iterate(tail(s)...)` would never return `nothing`, which makes JET happy.
On master
```julia
julia> L = Base.LogicalIndex([true])
1-element Base.LogicalIndex{Int64, Vector{Bool}}:
 1

julia> @report_call iterate(L)
═════ 2 possible errors found ═════
┌ iterate(L::Base.LogicalIndex{Int64, Vector{Bool}}) @ Base ./multidimensional.jl:778
│┌ iterate(L::Base.LogicalIndex{Int64, Vector{Bool}}, s::Tuple{Int64, LinearIndices{1, Tuple{Base.OneTo{Int64}}}}) @ Base ./multidimensional.jl:789
││┌ indexed_iterate(I::Nothing, i::Int64) @ Base ./tuple.jl:94
│││ no matching method found `iterate(::Nothing)`: x = iterate(I::Nothing)
││└────────────────────
││┌ indexed_iterate(I::Nothing, i::Int64, state::Int64) @ Base ./tuple.jl:99
│││ no matching method found `iterate(::Nothing, ::Int64)`: x = iterate(I::Nothing, state::Int64)
```
This PR
```julia
julia> @report_call iterate(L)
No errors detected
```

Close https://github.com/JuliaArrays/StaticArrays.jl/issues/1225