### PR TITLE
Avoid `StackOverflowError` in generic recursive `dot`

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -864,8 +864,8 @@ function dot(x, y) # arbitrary iterables
     end
     (vx, xs) = ix
     (vy, ys) = iy
-    vx == x && vy == y && throw(ArgumentError(
-            "cannot evaluate dot recursively if an element is identical to the container"))
+    typeof(vx) == typeof(x) && typeof(vy) == typeof(y) && throw(ArgumentError(
+            "cannot evaluate dot recursively if the type of an element is identical to that of the container"))
     s = dot(vx, vy)
     while true
         ix = iterate(x, xs)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -864,6 +864,8 @@ function dot(x, y) # arbitrary iterables
     end
     (vx, xs) = ix
     (vy, ys) = iy
+    (vx == x || vy == y) && throw(ArgumentError(
+            "cannot evaluate dot recursively if an element is identical to the container"))
     s = dot(vx, vy)
     while true
         ix = iterate(x, xs)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -864,7 +864,7 @@ function dot(x, y) # arbitrary iterables
     end
     (vx, xs) = ix
     (vy, ys) = iy
-    (vx == x || vy == y) && throw(ArgumentError(
+    vx == x && vy == y && throw(ArgumentError(
             "cannot evaluate dot recursively if an element is identical to the container"))
     s = dot(vx, vy)
     while true

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -608,6 +608,8 @@ end
 
 @testset "avoid stackoverflow in dot" begin
     @test_throws "cannot evaluate dot recursively" dot('a', 'c')
+    @test_throws "cannot evaluate dot recursively" dot('a', 'b':'c')
+    @test_throws "x and y are of different lengths" dot(1, 1:2)
 end
 
 @testset "generalized dot #32739" begin

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -606,6 +606,10 @@ end
     end
 end
 
+@testset "avoid stackoverflow in dot" begin
+    @test_throws "cannot evaluate dot recursively" dot('a', 'c')
+end
+
 @testset "generalized dot #32739" begin
     for elty in (Int, Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFloat})
         n = 10


### PR DESCRIPTION
A quick check to throw an error early if `first(x) == x && first(y) == y`, in which case the recursive `dot` will lead to a stack overflow.

Close https://github.com/JuliaLang/LinearAlgebra.jl/issues/722