### PR TITLE
Profile: use full terminal cols to show function name

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1193,14 +1193,14 @@ end
 
 # Utilities
 function rtruncto(str::String, w::Int)
-    if length(str) <= w
+    if textwidth(str) <= w
         return str
     else
         return string("…", str[prevind(str, end, w-2):end])
     end
 end
 function ltruncto(str::String, w::Int)
-    if length(str) <= w
+    if textwidth(str) <= w
         return str
     else
         return string(str[1:nextind(str, 1, w-2)], "…")

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -891,7 +891,6 @@ function tree_format(frames::Vector{<:StackFrameTree}, level::Int, cols::Int, ma
     ndigline = ndigits(maximum(frame.frame.line for frame in frames)) + 6
     ntext = max(30, cols - ndigoverhead - nindent - ndigcounts - ndigline - 6)
     widthfile = 2*ntext÷5 # min 12
-    widthfunc = 3*ntext÷5 # min 18
     strs = Vector{String}(undef, length(frames))
     showextra = false
     if level > nindent
@@ -933,11 +932,12 @@ function tree_format(frames::Vector{<:StackFrameTree}, level::Int, cols::Int, ma
                     ":",
                     li.line == -1 ? "?" : string(li.line),
                     "; ",
-                    ltruncto(fname, widthfunc))
+                    fname)
             end
         else
             strs[i] = string(stroverhead, "╎", base, strcount, " [unknown stackframe]")
         end
+        strs[i] = ltruncto(strs[i], cols)
     end
     return strs
 end
@@ -1196,14 +1196,14 @@ function rtruncto(str::String, w::Int)
     if length(str) <= w
         return str
     else
-        return string("...", str[prevind(str, end, w-4):end])
+        return string("…", str[prevind(str, end, w-2):end])
     end
 end
 function ltruncto(str::String, w::Int)
     if length(str) <= w
         return str
     else
-        return string(str[1:nextind(str, 1, w-4)], "...")
+        return string(str[1:nextind(str, 1, w-2)], "…")
     end
 end
 


### PR DESCRIPTION
Currently the function printing is truncated shorter than it needs to be, and uses `...` rather than the single char `…`
```
------------------------------------terminal width----------------------------------------------->|
julia> Profile.print()
Overhead ╎ [+additional indent] Count File:Line; Function
=========================================================
    ╎50   @Base/client.jl:535; _start()
    ╎ 50   @Base/client.jl:561; repl_main
    ╎  50   @Base/client.jl:424; run_main_repl(interactive::Bool, quiet::...
    ╎   50   @Base/essentials.jl:1017; invokelatest
    ╎    50   @Base/essentials.jl:1020; #invokelatest#2
    ╎     50   @Base/client.jl:440; (::Base.var"#1096#1098"{Bool, Symbol, B...
    ╎    ╎ 50   @REPL/src/REPL.jl:447; run_repl(repl::REPL.AbstractREPL, cons...
    ╎    ╎  50   @REPL/src/REPL.jl:461; run_repl(repl::REPL.AbstractREPL, con...
    ╎    ╎   50   @REPL/src/REPL.jl:302; kwcall(::NamedTuple, ::typeof(REPL.st...
    ╎    ╎    50   @REPL/src/REPL.jl:305; start_repl_backend(backend::REPL.REP...
    ╎    ╎     50   @REPL/src/REPL.jl:320; repl_backend_loop(backend::REPL.REPL...
    ╎    ╎    ╎ 50   @REPL/src/REPL.jl:224; eval_user_input(ast::Any, backend::...
   1╎    ╎    ╎  50   @Base/boot.jl:428; eval
    ╎    ╎    ╎   49   ...c/InteractiveUtils.jl:333; peakflops()
    ╎    ╎    ╎    49   ...c/InteractiveUtils.jl:333; peakflops
    ╎    ╎    ╎     49   ...c/InteractiveUtils.jl:338; peakflops(n::Int64; eltype::DataT...
```
This PR
```
------------------------------------terminal width----------------------------------------------->|
julia> Profile.print()
Overhead ╎ [+additional indent] Count File:Line; Function
=========================================================
    ╎50   @Base/client.jl:535; _start()
    ╎ 50   @Base/client.jl:561; repl_main
    ╎  50   @Base/client.jl:424; run_main_repl(interactive::Bool, quiet::Bool, banner::Symbol, hi…
    ╎   50   @Base/essentials.jl:1017; invokelatest
    ╎    50   @Base/essentials.jl:1020; #invokelatest#2
    ╎     50   @Base/client.jl:440; (::Base.var"#1096#1098"{Bool, Symbol, Bool})(REPL::Module)
    ╎    ╎ 50   @REPL/src/REPL.jl:447; run_repl(repl::REPL.AbstractREPL, consumer::Any)
    ╎    ╎  50   @REPL/src/REPL.jl:461; run_repl(repl::REPL.AbstractREPL, consumer::Any; backend_…
    ╎    ╎   50   @REPL/src/REPL.jl:302; kwcall(::NamedTuple, ::typeof(REPL.start_repl_backend), …
    ╎    ╎    50   @REPL/src/REPL.jl:305; start_repl_backend(backend::REPL.REPLBackend, consumer:…
    ╎    ╎     50   @REPL/src/REPL.jl:320; repl_backend_loop(backend::REPL.REPLBackend, get_modul…
    ╎    ╎    ╎ 50   @REPL/src/REPL.jl:224; eval_user_input(ast::Any, backend::REPL.REPLBackend, …
   1╎    ╎    ╎  50   @Base/boot.jl:428; eval
    ╎    ╎    ╎   49   …src/InteractiveUtils.jl:333; peakflops()
    ╎    ╎    ╎    49   …src/InteractiveUtils.jl:333; peakflops
    ╎    ╎    ╎     49   …src/InteractiveUtils.jl:338; peakflops(n::Int64; eltype::DataType, ntri…
```