### PR TITLE
Export `jl_genericmemory_typetagdata`

### DIFF
--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -30,6 +30,7 @@
     XX(jl_array_ptr_1d_push) \
     XX(jl_genericmemory_isassigned) \
     XX(jl_genericmemory_owner) \
+    XX(jl_genericmemory_typetagdata) \
     XX(jl_genericmemoryref) \
     XX(jl_genericmemoryset) \
     XX(jl_genericmemoryunset) \


### PR DESCRIPTION
`jl_array_typetagdata` is exported, so this one should be too.