### PR TITLE
1.10: inlining: fix `joint_effects` calculation

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1408,7 +1408,7 @@ function compute_inlining_cases(@nospecialize(info::CallInfo), flag::UInt8, sig:
         fully_covered &= split_fully_covered
     end
 
-    fully_covered || (joint_effects = Effects(joint_effects; nothrow=false))
+    (handled_all_cases & fully_covered) || (joint_effects = Effects(joint_effects; nothrow=false))
 
     if handled_all_cases && revisit_idx !== nothing
         # we handled everything except one match with unmatched sparams,

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -2096,3 +2096,20 @@ let src = code_typed1() do
     end
     @test count(isinvoke(:iterate), src.code) == 0
 end
+
+# JuliaLang/julia#53062: proper `joint_effects` for call with empty method matches
+let ir = first(only(Base.code_ircode(setproperty!, (Base.RefValue{Int},Symbol,Base.RefValue{Int}))))
+    i = findfirst(iscall((ir, convert)), ir.stmts.inst)::Int
+    @test iszero(ir.stmts.flag[i] & Core.Compiler.IR_FLAG_NOTHROW)
+end
+function issue53062(cond)
+    x = Ref{Int}(0)
+    if cond
+        x[] = x
+    else
+        return -1
+    end
+end
+@test !Core.Compiler.is_nothrow(Base.infer_effects(issue53062, (Bool,)))
+@test issue53062(false) == -1
+@test_throws MethodError issue53062(true)


### PR DESCRIPTION
This particular fix was part of #50805, but it wasn't included in version 1.10, leading to situations where an incorrect `:nothrow` could occur in 1.10 (#53062). This commit implements a minimal correction in 1.10 and also added some test cases.

Fixes #53062.