### PR TITLE
forward-port the test cases added in #53076

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1396,7 +1396,7 @@ function compute_inlining_cases(@nospecialize(info::CallInfo), flag::UInt32, sig
         fully_covered &= split_fully_covered
     end
 
-    (handled_all_cases && fully_covered) || (joint_effects = Effects(joint_effects; nothrow=false))
+    (handled_all_cases & fully_covered) || (joint_effects = Effects(joint_effects; nothrow=false))
 
     if handled_all_cases && revisit_idx !== nothing
         # we handled everything except one match with unmatched sparams,


### PR DESCRIPTION
The fix for #53062 was included in #50805, but it lacked explicit test cases added. This commit cherry-picks the test cases from #53076 to prevent future regression.