### PR TITLE
[NFC] some minor code cleanup of getHostCPUName handling

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -77,11 +77,8 @@ else
 # JULIACODEGEN != LLVM
 endif
 
-RT_LLVM_LIBS := support
-
-ifeq ($(LLVM_VER_MAJ),16)
-RT_LLVM_LIBS += targetparser
-endif
+RT_LLVM_LIBS := support # for APMath and some other useful ADT
+RT_LLVM_LIBS += targetparser # for getHostCPUName on LLVM 16+
 
 ifeq ($(OS),WINNT)
 SRCS += win32_ucontext

--- a/src/Makefile
+++ b/src/Makefile
@@ -78,7 +78,9 @@ else
 endif
 
 RT_LLVM_LIBS := support # for APMath and some other useful ADT
+ifneq ($(LLVM_VER_MAJ),15)
 RT_LLVM_LIBS += targetparser # for getHostCPUName on LLVM 16+
+endif
 
 ifeq ($(OS),WINNT)
 SRCS += win32_ucontext

--- a/src/processor.h
+++ b/src/processor.h
@@ -264,8 +264,6 @@ struct jl_target_spec_t {
  * Return the list of targets to clone
  */
 extern "C" JL_DLLEXPORT llvm::SmallVector<jl_target_spec_t, 0> jl_get_llvm_clone_targets(void) JL_NOTSAFEPOINT;
-std::string jl_get_cpu_name_llvm(void) JL_NOTSAFEPOINT;
-std::string jl_get_cpu_features_llvm(void) JL_NOTSAFEPOINT;
 // NOLINTEND(clang-diagnostic-return-type-c-linkage)
 struct FeatureName {
     const char *name;

--- a/src/processor_arm.cpp
+++ b/src/processor_arm.cpp
@@ -1827,16 +1827,6 @@ JL_DLLEXPORT void jl_dump_host_cpu(void)
                   cpus, ncpu_names);
 }
 
-JL_DLLEXPORT jl_value_t *jl_get_cpu_name(void)
-{
-    return jl_cstr_to_string(host_cpu_name().c_str());
-}
-
-JL_DLLEXPORT jl_value_t *jl_get_cpu_features(void)
-{
-    return jl_cstr_to_string(jl_get_cpu_features_llvm().c_str());
-}
-
 JL_DLLEXPORT jl_value_t *jl_cpu_has_fma(int bits)
 {
 #ifdef _CPU_AARCH64_

--- a/src/processor_fallback.cpp
+++ b/src/processor_fallback.cpp
@@ -162,16 +162,6 @@ llvm::SmallVector<jl_target_spec_t, 0> jl_get_llvm_clone_targets(void)
     return res;
 }
 
-JL_DLLEXPORT jl_value_t *jl_get_cpu_name(void)
-{
-    return jl_cstr_to_string(host_cpu_name().c_str());
-}
-
-JL_DLLEXPORT jl_value_t *jl_get_cpu_features(void)
-{
-    return jl_cstr_to_string(jl_get_cpu_features_llvm().c_str());
-}
-
 JL_DLLEXPORT jl_value_t *jl_cpu_has_fma(int bits)
 {
     return jl_false; // Match behaviour of have_fma in src/llvm-cpufeatures.cpp (assume false)

--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -1063,16 +1063,6 @@ JL_DLLEXPORT jl_value_t* jl_check_pkgimage_clones(char *data)
     return jl_nothing;
 }
 
-JL_DLLEXPORT jl_value_t *jl_get_cpu_name(void)
-{
-    return jl_cstr_to_string(host_cpu_name().c_str());
-}
-
-JL_DLLEXPORT jl_value_t *jl_get_cpu_features(void)
-{
-    return jl_cstr_to_string(jl_get_cpu_features_llvm().c_str());
-}
-
 JL_DLLEXPORT jl_value_t *jl_cpu_has_fma(int bits)
 {
     TargetData<feature_sz> target = jit_targets.front();

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -4,7 +4,6 @@
 #include <map>
 #include <string>
 #include <llvm/ADT/StringMap.h>
-#include <llvm/Support/Host.h>
 #include <llvm/Support/raw_ostream.h>
 
 #include "julia.h"
@@ -84,42 +83,6 @@ void *jl_lazy_load_and_lookup(jl_value_t *lib_val, const char *f_name)
 }
 
 // miscellany
-std::string jl_get_cpu_name_llvm(void)
-{
-    return llvm::sys::getHostCPUName().str();
-}
-
-std::string jl_get_cpu_features_llvm(void)
-{
-    StringMap<bool> HostFeatures;
-    llvm::sys::getHostCPUFeatures(HostFeatures);
-    std::string attr;
-    for (auto &ele: HostFeatures) {
-        if (ele.getValue()) {
-            if (!attr.empty()) {
-                attr.append(",+");
-            }
-            else {
-                attr.append("+");
-            }
-            attr.append(ele.getKey().str());
-        }
-    }
-    // Explicitly disabled features need to be added at the end so that
-    // they are not re-enabled by other features that implies them by default.
-    for (auto &ele: HostFeatures) {
-        if (!ele.getValue()) {
-            if (!attr.empty()) {
-                attr.append(",-");
-            }
-            else {
-                attr.append("-");
-            }
-            attr.append(ele.getKey().str());
-        }
-    }
-    return attr;
-}
 
 extern "C" JL_DLLEXPORT
 jl_value_t *jl_get_JIT(void)


### PR DESCRIPTION
Try to minimize the places the code depends on this library function, since it is useful for generic code as long as LLVM is available, but we would also be happy with returning the text "native" here in most cases.