### PR TITLE
builtin: allow equal types in set_global_type without error

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2359,6 +2359,22 @@ julia> M.a
 setglobal!
 
 """
+    Core.get_binding_type(module::Module, name::Symbol)
+
+Retrieve the declared type of the binding `name` from the module `module`.
+"""
+Core.get_binding_type
+
+"""
+    Core.set_binding_type!(module::Module, name::Symbol, [type::Type])
+
+Set the declared type of the binding `name` in the module `module` to `type`. Error if the
+binding already has a type that is not equivalent to `type`. If the `type` argument is
+absent, set the binding type to `Any` if unset, but do not error.
+"""
+Core.set_binding_type!
+
+"""
     typeof(x)
 
 Get the concrete type of `x`.

--- a/doc/src/devdocs/builtins.md
+++ b/doc/src/devdocs/builtins.md
@@ -12,6 +12,8 @@ Core.memoryrefoffset
 Core.memoryrefget
 Core.memoryrefset!
 Core.memoryref_isassigned
+Core.get_binding_type
+Core.set_binding_type!
 Core.IntrinsicFunction
 Core.Intrinsics
 Core.IR

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1355,13 +1355,13 @@ JL_CALLABLE(jl_f_set_binding_type)
     JL_TYPECHK(set_binding_type!, type, ty);
     jl_binding_t *b = jl_get_binding_wr(m, s);
     jl_value_t *old_ty = NULL;
-    if (!jl_atomic_cmpswap_relaxed(&b->ty, &old_ty, ty) && ty != old_ty) {
-        if (nargs == 2)
-            return jl_nothing;
+    if (jl_atomic_cmpswap_relaxed(&b->ty, &old_ty, ty)) {
+        jl_gc_wb(b, ty);
+    }
+    else if (nargs != 2 && !jl_types_equal(ty, old_ty)) {
         jl_errorf("cannot set type for global %s.%s. It already has a value or is already set to a different type.",
                   jl_symbol_name(m->name), jl_symbol_name(s));
     }
-    jl_gc_wb(b, ty);
     return jl_nothing;
 }
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -8112,3 +8112,14 @@ end
 @test Int isa Union{Union, Type{Union{Int,T1}}} where {T1}
 @test_broken Int isa Union{UnionAll, Type{Union{Int,T2} where {T2<:T1}} where {T1}}
 @test_broken Int isa Union{Union, Type{Union{Int,T1}} where {T1}}
+
+let M = @__MODULE__
+    @test Core.set_binding_type!(M, :a_typed_global, Tuple{Union{Integer,Nothing}}) === nothing
+    @test Core.get_binding_type(M, :a_typed_global) === Tuple{Union{Integer,Nothing}}
+    @test Core.set_binding_type!(M, :a_typed_global, Tuple{Union{Integer,Nothing}}) === nothing
+    @test Core.set_binding_type!(M, :a_typed_global, Union{Tuple{Integer},Tuple{Nothing}}) === nothing
+    @test_throws(ErrorException("cannot set type for global $(nameof(M)).a_typed_global. It already has a value or is already set to a different type."),
+                 Core.set_binding_type!(M, :a_typed_global, Union{Nothing,Tuple{Union{Integer,Nothing}}}))
+    @test Core.set_binding_type!(M, :a_typed_global) === nothing
+    @test Core.get_binding_type(M, :a_typed_global) === Tuple{Union{Integer,Nothing}}
+end


### PR DESCRIPTION
Use the julia notion of equality (type-equal) instead of the strictly C notion (pointer-equal). Also add tests and docs for this function.