### PR TITLE
speculative: physically compact objects through a shm layer

### DIFF
--- a/src/gc-page-profiler.c
+++ b/src/gc-page-profiler.c
@@ -32,7 +32,7 @@ void gc_page_serializer_init(gc_page_profiler_serializer_t *serializer,
 {
     if (__unlikely(page_profile_enabled)) {
         serializer->typestrs.len = 0;
-        serializer->data = (char *)pg->data;
+        serializer->data = (char *)pg->shm_addr_triplet.data;
         serializer->osize = pg->osize;
     }
 }

--- a/src/options.h
+++ b/src/options.h
@@ -80,7 +80,10 @@
 // pool allocator configuration options
 
 // GC_SMALL_PAGE allocates objects in 4k pages
-// #define GC_SMALL_PAGE
+#define GC_SMALL_PAGE
+
+// GC_COPY_THROUGH_SHM copies objects by remapping pages through `shm`
+#define GC_COPY_THROUGH_SHM
 
 
 // method dispatch profiling --------------------------------------------------


### PR DESCRIPTION
Very speculative/experimental for now (and I'm not sure if this would violate some semantics of the memory mapping system calls on Linux).

Basically adds a `shm` layer on top of the pool allocator pages and implements object compaction for disjoint pages.

Consider this scenario: if pages 1 and 2 belong to the same size classes and have capacity for three objects, and page 1 has slots 1 and 2 allocated, while page 2 has slot 3 allocated, then this PR will move the third object of page 2 to page 1, and change the physical mapping so that page 2 is physically mapped to page 1.

In principle, this will lead to more packed/less fragmented pages, though I didn't do a very extensive analysis yet.

If we judge that `gc_evacuate_objects` is too expensive to run on every GC, then we can in principle expose it through a `ccall` to defragment the heap as needed.