### PR TITLE
Revert "Don't export Dates.adjust"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -165,8 +165,6 @@ Standard library changes
 
 #### Dates
 
-The undocumented function `adjust` is no longer exported but is now documented
-
 #### Statistics
 
 * Statistics is now an upgradeable standard library ([#46501]).

--- a/stdlib/Dates/src/Dates.jl
+++ b/stdlib/Dates/src/Dates.jl
@@ -77,7 +77,7 @@ export Period, DatePeriod, TimePeriod,
        firstdayofmonth, lastdayofmonth,
        firstdayofyear, lastdayofyear,
        firstdayofquarter, lastdayofquarter,
-       tonext, toprev, tofirst, tolast,
+       adjust, tonext, toprev, tofirst, tolast,
        # io.jl
        ISODateTimeFormat, ISODateFormat, ISOTimeFormat, DateFormat, RFC1123Format, @dateformat_str
 


### PR DESCRIPTION
Reverts JuliaLang/julia#53027

#53027 broke the `doctest` job in CI.