### PR TITLE
Don't mention __precompile__(false) in skipping message

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2145,7 +2145,7 @@ function _require(pkg::PkgId, env=nothing)
                 elseif isa(cachefile, Exception)
                     if precompilableerror(cachefile)
                         verbosity = isinteractive() ? CoreLogging.Info : CoreLogging.Debug
-                        @logmsg verbosity "Skipping precompilation since __precompile__(false). Importing $pkg."
+                        @logmsg verbosity "Skipping precompilation due to precompilable error. Importing $pkg." exception=m
                     else
                         @warn "The call to compilecache failed to create a usable precompiled cache file for $pkg" exception=m
                     end


### PR DESCRIPTION
I am fairly sure nothing in my dep tree uses `__precompile__(false)`  so this message is misleading.
I know we changed another of them a while ago