### PR TITLE
Add sleep to avoid possible data race between julia and the file system

### DIFF
--- a/test/relocatedepot.jl
+++ b/test/relocatedepot.jl
@@ -161,6 +161,7 @@ if !test_relocated_depot
                         pushfirst!(DEPOT_PATH, depot3)
                         pkg = Base.identify_package("Foo")
                         Base.require(pkg)
+                        sleep(1) # Sleep to avoid a filesystem data race
                         cachefile = joinpath(depot3, "compiled",
                                              "v$(VERSION.major).$(VERSION.minor)", "Foo.ji")
                         _, (deps, _, _), _... = Base.parse_cache_header(cachefile)


### PR DESCRIPTION
I'm not sure if this is what's actually happening, but that's my current hypothesis as to why this test sometimes fails.
Fixes https://github.com/JuliaLang/julia/issues/53103 hopefully, I couldn't reproduce the failure locally.