### PR TITLE
extend `divrem(x, y)` for `BigInt` to `divrem(x, y, rm)`

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -606,8 +606,8 @@ function top_set_bit(x::BigInt)
     x.size * sizeof(Limb) << 3 - leading_zeros(GC.@preserve x unsafe_load(x.d, x.size))
 end
 
-divrem(x::BigInt, y::BigInt) = MPZ.tdiv_qr(x, y)
-divrem(x::BigInt, y::Integer) = MPZ.tdiv_qr(x, big(y))
+divrem(x::BigInt, y::BigInt,  ::typeof(RoundToZero) = RoundToZero) = MPZ.tdiv_qr(x, y)
+divrem(x::BigInt, y::Integer, ::typeof(RoundToZero) = RoundToZero) = MPZ.tdiv_qr(x, BigInt(y))
 
 cmp(x::BigInt, y::BigInt) = sign(MPZ.cmp(x, y))
 cmp(x::BigInt, y::ClongMax) = sign(MPZ.cmp_si(x, y))


### PR DESCRIPTION
Previously `divrem(x, y, rm)` was dispatched to a more generic code path that called `div`, causing unnecessary allocation. Xref #45159.

Also replaced the `big` call with `BigInt`, which seems more correct to me. The issue is that a user may define some `<:Integer` type for which `big` doesn't convert to `BigInt`, which seems like it would lead to infinite recursion in this case.