### PR TITLE
Fix invalid let syntax from LHS views

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1653,8 +1653,10 @@
                  (let ((g (make-ssavalue)))
                    (begin (set! a (cons `(= ,g ,x) a))
                           g)))))
-        (cons (cons (car e) (map arg-to-temp (cdr e)))
-              (reverse a)))))
+        (if (eq? (car e) 'let)
+          (cons (arg-to-temp e) (reverse a))
+          (cons (cons (car e) (map arg-to-temp (cdr e)))
+                (reverse a))))))
 
 (define (lower-kw-call f args)
   (let* ((para (if (has-parameters? args) (cdar args) '()))


### PR DESCRIPTION
When the frontend lowers an expression like `lhs .+= rhs`, it needs to prevent evaluating the LHS more than once before re-writing to `lhs .= lhs .+ rhs`.  If the LHS was a `let` block — commonly generated by `@views` and (since #53064) `@view` — the lowering pass had previously been emitting an invalid `let` temporary.  This very directly addresses that case.

Fixes #53107.
Fixes #44356.