### PR TITLE
Add nested precomp highlight debug

### DIFF
--- a/pkgimage.mk
+++ b/pkgimage.mk
@@ -69,6 +69,9 @@ cache-debug-$1: $$(BUILDDIR)/stdlib/$1.debug.image
 .SECONDARY: $$(BUILDDIR)/stdlib/$1.release.image $$(BUILDDIR)/stdlib/$1.debug.image
 endef
 
+# Note: you can check for the correctness of this tree by running `JULIA_DEBUG=nested_precomp make` and looking
+# out for `Debug: Nested precompilation` logs.
+
 # no dependencies
 $(eval $(call stdlib_builder,MozillaCACerts_jll,))
 $(eval $(call stdlib_builder,ArgTools,))


### PR DESCRIPTION
Fixes the `pkgimage.mk` stdlib dep tree which was slightly wrong and causing some nested precompilation

And adds debugs that identified the above issue, and have been useful for debugging https://github.com/JuliaLang/julia/issues/53081

i.e.
```
% JULIA_DEBUG=nested_precomp ./julia -q

(@v1.11) pkg> precompile
Precompiling project...
  103 dependencies successfully precompiled in 34 seconds. 40 already precompiled.
  2 dependencies had output during precompilation:
┌ FillArrays → FillArraysPDMatsExt
│  ┌ Debug: Nested precompilation: FillArraysPDMatsExt > FillArraysSparseArraysExt
│  └ @ Base loading.jl:2520
└  
┌ Symbolics → SymbolicsPreallocationToolsExt
│  ┌ Debug: Nested precompilation: SymbolicsPreallocationToolsExt > SymbolicsForwardDiffExt
│  └ @ Base loading.jl:2520
│  ┌ Warning: Module SymbolicsPreallocationToolsExt with build ID ffffffff-ffff-ffff-0008-f643010bcdb7 is missing from the cache.
│  │ This may mean SymbolicsPreallocationToolsExt [d479e226-fb54-5ebe-a75e-a7af7f39127f] does not support precompilation but is imported by a module that does.
│  └ @ Base loading.jl:2121
│  ┌ Error: Error during loading of extension SymbolicsPreallocationToolsExt of Symbolics, use `Base.retry_load_extensions()` to retry.
```