### PR TITLE
Cut short extension load cycles during precompilation

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1438,7 +1438,7 @@ function run_extension_callbacks(pkgid::PkgId)
     extids = pop!(EXT_DORMITORY, pkgid, nothing)
     extids === nothing && return
     for extid in extids
-        if in(extid.id, precompilation_stack) && !isprecompiled(extid.id)
+        if in(extid.id, precompilation_stack)
             @debug """
             Dependency cycle detected in extension precompilation: $(precompilation_stack_list()) > $(extid.id.name)
             $(extid.id.name) will not be loaded here.

--- a/test/extensions/circular/A/Project.toml
+++ b/test/extensions/circular/A/Project.toml
@@ -1,0 +1,14 @@
+name = "A"
+uuid = "c8938445-7efa-411c-ba8f-721576f9f47a"
+version = "0.1.0"
+
+[deps]
+B = "ef00b25e-dd85-47e0-9cd9-ed3c1ff51032"
+
+[weakdeps]
+C = "d95b043b-fbe6-48a2-93d2-75fba1b51518"
+D = "64e66ba5-e914-4adb-a5f6-036ef0c801f3"
+
+[extensions]
+CExt = "C"
+DExt = "D"

--- a/test/extensions/circular/A/ext/CExt.jl
+++ b/test/extensions/circular/A/ext/CExt.jl
@@ -1,0 +1,3 @@
+module CExt
+
+end # module

--- a/test/extensions/circular/A/ext/DExt.jl
+++ b/test/extensions/circular/A/ext/DExt.jl
@@ -1,0 +1,3 @@
+module DExt
+
+end # module

--- a/test/extensions/circular/A/src/A.jl
+++ b/test/extensions/circular/A/src/A.jl
@@ -1,0 +1,3 @@
+module A
+
+end # module

--- a/test/extensions/circular/B/Project.toml
+++ b/test/extensions/circular/B/Project.toml
@@ -1,0 +1,7 @@
+name = "B"
+uuid = "ef00b25e-dd85-47e0-9cd9-ed3c1ff51032"
+version = "0.1.0"
+
+[deps]
+C = "d95b043b-fbe6-48a2-93d2-75fba1b51518"
+D = "64e66ba5-e914-4adb-a5f6-036ef0c801f3"

--- a/test/extensions/circular/B/src/B.jl
+++ b/test/extensions/circular/B/src/B.jl
@@ -1,0 +1,3 @@
+module B
+
+end # module

--- a/test/extensions/circular/C/Project.toml
+++ b/test/extensions/circular/C/Project.toml
@@ -1,0 +1,3 @@
+name = "C"
+uuid = "d95b043b-fbe6-48a2-93d2-75fba1b51518"
+version = "0.1.0"

--- a/test/extensions/circular/C/src/C.jl
+++ b/test/extensions/circular/C/src/C.jl
@@ -1,0 +1,3 @@
+module C
+
+end # module

--- a/test/extensions/circular/D/Project.toml
+++ b/test/extensions/circular/D/Project.toml
@@ -1,0 +1,3 @@
+name = "D"
+uuid = "64e66ba5-e914-4adb-a5f6-036ef0c801f3"
+version = "0.1.0"

--- a/test/extensions/circular/D/src/D.jl
+++ b/test/extensions/circular/D/src/D.jl
@@ -1,0 +1,3 @@
+module D
+
+end # module

--- a/test/extensions/circular/Manifest.toml
+++ b/test/extensions/circular/Manifest.toml
@@ -1,0 +1,32 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.11.0-DEV"
+manifest_format = "2.0"
+project_hash = "6c189c4d9e1e9194c4a4d7627740c379ecff4942"
+
+[[deps.A]]
+deps = ["B"]
+path = "./A"
+uuid = "c8938445-7efa-411c-ba8f-721576f9f47a"
+version = "0.1.0"
+weakdeps = ["C", "D"]
+
+    [deps.A.extensions]
+    CExt = "C"
+    DExt = "D"
+
+[[deps.B]]
+deps = ["C", "D"]
+path = "./B"
+uuid = "ef00b25e-dd85-47e0-9cd9-ed3c1ff51032"
+version = "0.1.0"
+
+[[deps.C]]
+path = "./C"
+uuid = "d95b043b-fbe6-48a2-93d2-75fba1b51518"
+version = "0.1.0"
+
+[[deps.D]]
+path = "./D"
+uuid = "64e66ba5-e914-4adb-a5f6-036ef0c801f3"
+version = "0.1.0"

--- a/test/extensions/circular/Project.toml
+++ b/test/extensions/circular/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+A = "c8938445-7efa-411c-ba8f-721576f9f47a"
+B = "ef00b25e-dd85-47e0-9cd9-ed3c1ff51032"
+C = "d95b043b-fbe6-48a2-93d2-75fba1b51518"
+D = "64e66ba5-e914-4adb-a5f6-036ef0c801f3"

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1143,6 +1143,13 @@ end
         finally
             copy!(LOAD_PATH, old_load_path)
         end
+
+        # issue 53081
+        @testset "avoid circular precompilation deadlock through extensions" begin
+            testenv = joinpath(@__DIR__, "extensions", "circular")
+            s = read(`$(Base.julia_cmd()) --startup-file=no --project=$testenv -e 'using A'`, String)
+            @test !occursin("Error during loading of extension", s)
+        end
     finally
         try
             rm(depot_path, force=true, recursive=true)


### PR DESCRIPTION
Depends on
- [x] https://github.com/JuliaLang/julia/pull/52795
- [x] https://github.com/JuliaLang/julia/pull/53111

Builds on https://github.com/JuliaLang/julia/pull/53111
Fixes https://github.com/JuliaLang/julia/issues/53081

Cuts the cycle short and highlights when two or more extensions are each triggered during the precompilation of eachother, which causes a dependency cycle in nested precompilation that was seen in #53081.

Note if this is considered safe, the `@warn`s could just be `@debug`s and the user doesn't need to be notified.

i.e. on master this confusing error occurs, and it's actually coming from a double nested precompile worker precompiling `SymbolicsForwardDiffExt` but trying to load `SymbolicsPreallocationToolsExt` which the parent worker is in the process of precompiling
```
(@v1.11) pkg> precompile
Precompiling project...
  103 dependencies successfully precompiled in 34 seconds. 40 already precompiled.
  1 dependency had output during precompilation:
┌ Symbolics → SymbolicsPreallocationToolsExt
│  ┌ Warning: Module SymbolicsPreallocationToolsExt with build ID ffffffff-ffff-ffff-0008-f643010bcdb7 is missing from the cache.
│  │ This may mean SymbolicsPreallocationToolsExt [d479e226-fb54-5ebe-a75e-a7af7f39127f] does not support precompilation but is imported by a module that does.
│  └ @ Base loading.jl:2121
│  ┌ Error: Error during loading of extension SymbolicsPreallocationToolsExt of Symbolics, use `Base.retry_load_extensions()` to retry.
 ```

With this PR
```
(@v1.11) pkg> precompile
Precompiling project...
  103 dependencies successfully precompiled in 36 seconds. 40 already precompiled.
  2 dependencies had output during precompilation:
┌ FillArrays → FillArraysPDMatsExt
│  ┌ Warning: Dependency cycle detected in extension precompilation: FillArraysPDMatsExt > FillArraysSparseArraysExt > FillArraysPDMatsExt
│  └ @ Base loading.jl:1396
└  
┌ Symbolics → SymbolicsPreallocationToolsExt
│  ┌ Warning: Dependency cycle detected in extension precompilation: SymbolicsPreallocationToolsExt > SymbolicsForwardDiffExt > SymbolicsPreallocationToolsExt
│  └ @ Base loading.jl:1396
└ 
```

The cycle issue being this strong dependency branch
```
Symbolics > SymbolicUtils > LabelledArrays > PreallocationTools > ForwardDiff
```
triggers both of these Symbolics extensions without the need for any further packages present.
```
[extensions]
SymbolicsForwardDiffExt = "ForwardDiff"
SymbolicsPreallocationToolsExt = ["ForwardDiff", "PreallocationTools"]
```
So they both get triggered during the precompilation job of the other one.

Note that `FillArraysPDMatsExt` doesn't error on master like `SymbolicsPreallocationToolsExt` does. Not sure why not.

cc. @ChrisRackauckas 