### PR TITLE
Try to fix incorrect documentation of `nthreads`

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -45,7 +45,7 @@ maxthreadid() = Int(Core.Intrinsics.atomic_pointerref(cglobal(:jl_n_threads, Cin
     Threads.nthreads(:default | :interactive) -> Int
 
 Get the current number of threads within the specified thread pool. The threads in `:interactive`
-have id numbers `1:nthreads(:interactive)`, and the threads in `:default` have id numbers in 
+have id numbers `1:nthreads(:interactive)`, and the threads in `:default` have id numbers in
 `nthreads(:interactive):nthreads(:default)+nthreads(:interactive)`.
 
 See also `BLAS.get_num_threads` and `BLAS.set_num_threads` in the [`LinearAlgebra`](@ref

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -46,7 +46,7 @@ maxthreadid() = Int(Core.Intrinsics.atomic_pointerref(cglobal(:jl_n_threads, Cin
 
 Get the current number of threads within the specified thread pool. The threads in `:interactive`
 have id numbers `1:nthreads(:interactive)`, and the threads in `:default` have id numbers in
-`nthreads(:interactive):nthreads(:default)+nthreads(:interactive)`.
+`nthreads(:interactive) .+ (1:nthreads(:default))`.
 
 See also `BLAS.get_num_threads` and `BLAS.set_num_threads` in the [`LinearAlgebra`](@ref
 man-linalg) standard library, and `nprocs()` in the [`Distributed`](@ref man-distributed)

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -44,8 +44,9 @@ maxthreadid() = Int(Core.Intrinsics.atomic_pointerref(cglobal(:jl_n_threads, Cin
 """
     Threads.nthreads(:default | :interactive) -> Int
 
-Get the current number of threads within the specified thread pool. The threads in default
-have id numbers `1:nthreads(:default)`.
+Get the current number of threads within the specified thread pool. The threads in `:interactive`
+have id numbers `1:nthreads(:interactive)`, and the threads in `:default` have id numbers in 
+`nthreads(:interactive):nthreads(:default)+nthreads(:interactive)`.
 
 See also `BLAS.get_num_threads` and `BLAS.set_num_threads` in the [`LinearAlgebra`](@ref
 man-linalg) standard library, and `nprocs()` in the [`Distributed`](@ref man-distributed)


### PR DESCRIPTION
Since https://github.com/JuliaLang/julia/pull/49094, the docstring of `nthreads` has been incorrect. It currently states that

> The threads in default have id numbers `1:nthreads(:default)`.

whereas that is no longer true:
```julia
julia> filter(i -> Threads.threadpool(i) == :interactive, 1:Threads.maxthreadid())
3-element Vector{Int64}:
 1
 2
 3

julia> filter(i -> Threads.threadpool(i) == :default, 1:Threads.maxthreadid())
6-element Vector{Int64}:
 4
 5
 6
 7
 8
 9
```