### PR TITLE
inference: avoid adding duplicate edges as invoke targets

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -827,7 +827,7 @@ function compileable_specialization(mi::MethodInstance, effects::Effects,
         end
     end
     add_inlining_backedge!(et, mi) # to the dispatch lookup
-    push!(et.edges, method.sig, mi_invoke) # add_inlining_backedge to the invoke call
+    mi_invoke !== mi && push!(et.edges, method.sig, mi_invoke) # add_inlining_backedge to the invoke call, if that is different
     return InvokeCase(mi_invoke, effects, info)
 end
 


### PR DESCRIPTION
This was inefficient, though not wrong.

Fixes #53020