### PR TITLE
put a try catch around calls to `propertynames` in tab completion.

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -190,11 +190,14 @@ function complete_symbol(@nospecialize(ex), name::String, @nospecialize(ffunc), 
             append!(suggestions, filtered_mod_names(p, mod, name, true, false))
         end
     elseif val !== nothing # looking for a property of an instance
-        for property in propertynames(val, false)
-            # TODO: support integer arguments (#36872)
-            if property isa Symbol && startswith(string(property), name)
-                push!(suggestions, PropertyCompletion(val, property))
+        try
+            for property in propertynames(val, false)
+                # TODO: support integer arguments (#36872)
+                if property isa Symbol && startswith(string(property), name)
+                    push!(suggestions, PropertyCompletion(val, property))
+                end
             end
+        catch
         end
     elseif field_completion_eligible(t)
         # Looking for a member of a type

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -2247,3 +2247,8 @@ let s = "using ...Issue52922.Inn"
     @test res
     @test "Inner2" in c
 end
+
+struct Issue53126
+end
+Base.propertynames(::Type{A}) = error()
+@test isempty(test_complete_foo(A))


### PR DESCRIPTION
fixes https://github.com/JuliaLang/julia/issues/53126