### PR TITLE
Set LLVM issue tracker URL to Julia's issue tracker

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -210,6 +210,9 @@ LLVM_CMAKE += -DCMAKE_EXE_LINKER_FLAGS="$(LLVM_LDFLAGS)" \
 LLVM_CMAKE += -DLLVM_VERSION_SUFFIX:STRING="jl"
 LLVM_CMAKE += -DLLVM_SHLIB_SYMBOL_VERSION:STRING="JL_LLVM_$(LLVM_VER_SHORT)"
 
+# Change the default bug report URL to Julia's issue tracker
+LLVM_CMAKE += -DBUG_REPORT_URL="https://github.com/julialang/julia"
+
 # Apply version-specific LLVM patches sequentially
 LLVM_PATCH_PREV :=
 define LLVM_PATCH


### PR DESCRIPTION
This patch sets the default issue tracker URL for LLVM to Julia's issue tracker. LLVM issues coming from Julia should probably go through Julia's issue tracker first and then can be reported upstream if there is an issue with something in upstream LLVM. Having this set to the default is moderately confusing for users as it refers to the LLVM issue tracker, which probably isn't wanted.