### PR TITLE
generalize the `Number` identity constructor

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -891,7 +891,9 @@ UInt32(x::BuiltinInts)  = toUInt32(x)::UInt32
 UInt64(x::BuiltinInts)  = toUInt64(x)::UInt64
 UInt128(x::BuiltinInts) = toUInt128(x)::UInt128
 
-(::Type{T})(x::T) where {T<:Number} = x
+# Assert the type to help type inference and satisfy `return_types`
+# tests in the test/numbers.jl test set.
+(s::Type{S})(x::T) where {T<:Number,S>:T} = x::s
 
 Int(x::Ptr)  = bitcast(Int, x)
 UInt(x::Ptr) = bitcast(UInt, x)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -3164,3 +3164,17 @@ end
         end
     end
 end
+
+@testset "union constructor from `Number`, issue #53129" begin
+    types = (
+        Base.BitInteger_types..., BigInt, Bool, Rational{Int}, Rational{BigInt},
+        Float16, Float32, Float64, BigFloat, Complex{Int}, Complex{UInt},
+        ComplexF16, ComplexF32, ComplexF64
+    )
+    @testset "T: $T" for T ∈ types
+        o = one(T)
+        @test o === @inferred Union{String,T}(o)
+        @test o === @inferred Union{String,supertype(T)}(o)
+        @test o === @inferred Union{String,Number}(o)
+    end
+end


### PR DESCRIPTION
Increase the consistency when trying to construct a `Union` type from a `Number` value.

Before:

```julia
Union{Int8,Int}(4)    # returns `4`
Union{String,Int}(4)  # throws
```

After:

```julia
Union{Int8,Int}(4)    # returns `4`
Union{String,Int}(4)  # returns `4`
```

Fixes #53129