### PR TITLE
[deps] Fix SuiteSparse from source build

### DIFF
--- a/deps/libsuitesparse.mk
+++ b/deps/libsuitesparse.mk
@@ -43,7 +43,7 @@ checksum-libsuitesparse: $(SRCCACHE)/SuiteSparse-$(LIBSUITESPARSE_VER).tar.gz
 	$(JLCHECKSUM) $<
 
 # https://github.com/DrTimothyAldenDavis/SuiteSparse/pull/671
-$(SRCCACHE)/SuiteSparse-$(LIBSUITESPARSE_VER)/suitesparse-blas-suffix.patch-applied: $(SRCCACHE)/SuiteSparse-$(LIBSUITESPARSE_VER)/source-extracted
+$(SRCCACHE)/SuiteSparse-$(LIBSUITESPARSE_VER)/suitesparse-blas-suffix.patch-applied: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/source-extracted
 	cd $(dir $@) && \
 		patch -p1 -f < $(SRCDIR)/patches/suitesparse-blas-suffix.patch
 	echo 1 > $@

--- a/deps/libsuitesparse.mk
+++ b/deps/libsuitesparse.mk
@@ -43,17 +43,17 @@ checksum-libsuitesparse: $(SRCCACHE)/SuiteSparse-$(LIBSUITESPARSE_VER).tar.gz
 	$(JLCHECKSUM) $<
 
 # https://github.com/DrTimothyAldenDavis/SuiteSparse/pull/671
-$(SRCCACHE)/SuiteSparse-$(LIBSUITESPARSE_VER)/suitesparse-blas-suffix.patch-applied: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/source-extracted
+$(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/suitesparse-blas-suffix.patch-applied: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/source-extracted
 	cd $(dir $@) && \
 		patch -p1 -f < $(SRCDIR)/patches/suitesparse-blas-suffix.patch
 	echo 1 > $@
 
-$(SRCCACHE)/SuiteSparse-$(LIBSUITESPARSE_VER)/source-patched: $(SRCCACHE)/SuiteSparse-$(LIBSUITESPARSE_VER)/suitesparse-blas-suffix.patch-applied
+$(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/source-patched: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/suitesparse-blas-suffix.patch-applied
 	echo 1 > $@
 
 $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled: | $(build_prefix)/manifest/blastrampoline
 
-$(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled: $(SRCCACHE)/SuiteSparse-$(LIBSUITESPARSE_VER)/source-patched
+$(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/build-compiled: $(BUILDDIR)/SuiteSparse-$(LIBSUITESPARSE_VER)/source-patched
 	cd $(dir $<) && $(CMAKE) .. $(LIBSUITESPARSE_CMAKE_FLAGS)
 	make
 	make install


### PR DESCRIPTION
I haven't tested whether the rest of the build works, but this should fix the error
```
make[1]: *** No rule to make target '/cache/build/builder-amdci5-1/julialang/julia-master-scheduled/deps/srccache/SuiteSparse-7.5.1/source-extracted', needed by '/cache/build/builder-amdci5-1/julialang/julia-master-scheduled/deps/srccache/SuiteSparse-7.5.1/suitesparse-blas-suffix.patch-applied'.  Stop.
```
mentioned at https://github.com/JuliaLang/julia/issues/53122#issue-2108629800.

This will eventually fix #53122.