### PR TITLE
Implement empty! for Channel

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -219,6 +219,21 @@ end
 isopen(c::Channel) = ((@atomic :acquire c.state) === :open)
 
 """
+    empty!(c)
+
+Empty a Channel `c`. Returns the number of elements removed.
+Elements added while emptying the channel are also removed.
+"""
+function Base.empty!(c::Channel)
+    counter = 0
+    while isready(c)
+        take!(c)
+        counter += 1
+    end
+    return counter
+end
+
+"""
     bind(chnl::Channel, task::Task)
 
 Associate the lifetime of `chnl` with a task.

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -219,10 +219,10 @@ end
 isopen(c::Channel) = ((@atomic :acquire c.state) === :open)
 
 """
-    empty!(c)
+    empty!(c::Channel)
 
 Empty a Channel `c` by calling `empty!` on the internal buffer.
-Returns the empty channel.
+Return the empty channel.
 """
 function Base.empty!(c::Channel)
     @lock c begin

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -221,16 +221,12 @@ isopen(c::Channel) = ((@atomic :acquire c.state) === :open)
 """
     empty!(c)
 
-Empty a Channel `c`. Returns the number of elements removed.
-Elements added while emptying the channel are also removed.
+Empty a Channel `c` by calling `empty!` on the internal buffer. 
+Returns the empty channel.
 """
 function Base.empty!(c::Channel)
-    counter = 0
-    while isready(c)
-        take!(c)
-        counter += 1
-    end
-    return counter
+    empty!(c.data)
+    return c
 end
 
 """


### PR DESCRIPTION
What is says on the box. ~Returning the number of elements removed is analogous to `write`, and can provide useful information.~ I ended up changing the implementation to call `empty!` on `c.data`, instead of call `take!` until the channel was empty. I expect this to be significantly more efficient than removing the elements one-by-one.

I have not changed any changelog. I am also not certain if I should have used any `@atomic` annotations, which I saw a lot of in this file. But I would not know how.