### PR TITLE
Hoist boundscheck in vector setindex for arrays

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -991,13 +991,13 @@ __safe_setindex!(A::Vector{T}, x,    i::Int) where {T} = (@inline;
 function setindex!(A::Array, X::AbstractArray, I::AbstractVector{Int})
     @_propagate_inbounds_meta
     @boundscheck setindex_shape_check(X, length(I))
+    @boundscheck checkbounds(A, I)
     require_one_based_indexing(X)
     X′ = unalias(A, X)
     I′ = unalias(A, I)
     count = 1
     for i in I′
-        @inbounds x = X′[count]
-        A[i] = x
+        @inbounds A[i] = X′[count]
         count += 1
     end
     return A


### PR DESCRIPTION
As noted by @N5N3 in https://github.com/JuliaLang/julia/issues/40962#issuecomment-1921469633, the bounds-check on the elementwise `setindex!` prevents vectorization. Explicitly performing the bounds-check and marking the `setindex!` as `@inbounds` speeds up the operation.
```julia
julia> A = zeros(1000); B = rand(1000);

julia> @btime $A[1:end] = @view $B[1:end];
  689.940 ns (0 allocations: 0 bytes) # master
  97.629 ns (0 allocations: 0 bytes) # PR
```