### PR TITLE
improve construction of `<:Tuple` types from constant-length iterators

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -6879,8 +6879,6 @@ let a = Foo17149()
 end
 
 # issue #21004
-const PTuple_21004{N,T} = NTuple{N,VecElement{T}}
-@test_throws ArgumentError("too few elements for tuple type $PTuple_21004") PTuple_21004(1)
 @test_throws UndefVarError(:T, :static_parameter) PTuple_21004_2{N,T} = NTuple{N, VecElement{T}}(1)
 
 #issue #22792


### PR DESCRIPTION
Make tuple construction from known constant-length iterators inferrable and prevent allocation.

Fixes #52993