### PR TITLE
Quickfix: prevent despecialisation of annotations list

### DIFF
--- a/base/strings/annotated.jl
+++ b/base/strings/annotated.jl
@@ -486,7 +486,7 @@ function read(io::AnnotatedIOBuffer, ::Type{AnnotatedString{T}}) where {T <: Abs
     if (start = position(io)) == 0
         AnnotatedString(read(io.io, T), copy(io.annotations))
     else
-        annots = [(max(1, first(region) - start):last(region)-start, val)
+        annots = [(UnitRange{Int}(max(1, first(region) - start), last(region)-start), val)
                   for (region, val) in io.annotations if last(region) > start]
         AnnotatedString(read(io.io, T), annots)
     end

--- a/test/strings/annotated.jl
+++ b/test/strings/annotated.jl
@@ -122,6 +122,7 @@ end
     @test read(seek(aio, 1), Base.AnnotatedString) == Base.AnnotatedString("ello world", [(1:4, :tag => 1), (6:10, :tag => 2)])
     @test read(seek(aio, 4), Base.AnnotatedString) == Base.AnnotatedString("o world", [(1:1, :tag => 1), (3:7, :tag => 2)])
     @test read(seek(aio, 5), Base.AnnotatedString) == Base.AnnotatedString(" world", [(2:6, :tag => 2)])
+    @test read(aio, Base.AnnotatedString) == Base.AnnotatedString("")
     @test read(seekstart(truncate(deepcopy(aio), 5)), Base.AnnotatedString) == Base.AnnotatedString("hello", [(1:5, :tag => 1)])
     @test read(seekstart(truncate(deepcopy(aio), 6)), Base.AnnotatedString) == Base.AnnotatedString("hello ", [(1:5, :tag => 1)])
     @test read(seekstart(truncate(deepcopy(aio), 7)), Base.AnnotatedString) == Base.AnnotatedString("hello w", [(1:5, :tag => 1), (7:7, :tag => 2)])


### PR DESCRIPTION
In f117a500ca93 code modifying annotations via list comprehensions was
introduced. However, when (1) there are annotations present and (2) all
annotations are filtered out, this comprehension is inferred to a wider
type incompatible with the AnnotatedString constructor. This can be
fixed by changing the first element of the tuple to directly use the
UnitRange{Int} constructor, which stops it being inferred as an Any.