### PR TITLE
Fix `size` on `GenericMemory` with non-`Int` `Integer` argument

### DIFF
--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -23,7 +23,7 @@ size(a::GenericMemory, d::Int) =
     d < 1 ? error("dimension out of range") :
     d == 1 ? length(a) :
     1
-size(a::GenericMemory, d::Integer) =  size(a, convert(d, Int))
+size(a::GenericMemory, d::Integer) =  size(a, convert(Int, d))
 size(a::GenericMemory) = (length(a),)
 
 IndexStyle(::Type{<:GenericMemory}) = IndexLinear()

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -3192,3 +3192,12 @@ end
     @test_throws DimensionMismatch wrap(Array, memref2, 9)
     @test_throws DimensionMismatch wrap(Array, memref2, 10)
 end
+
+@testset "Memory size" begin
+    len = 5
+    mem = Memory{Int}(undef, len)
+    @test size(mem, 1) == len
+    @test size(mem, 0x1) == len
+    @test size(mem, 2) == 1
+    @test size(mem, 0x2) == 1
+end


### PR DESCRIPTION
I found this through fuzzing. The nature of the issue indicates to me that this was untested, but coverage doesn't seem to have run for the past three months so I can't check, which is why I added an explicit test.

I'm not sure `arrayops.jl` is the best place for tests related to  `GenericMemory`, so feel free to suggest a better one.