### PR TITLE
Do not resolve binding `Module` in Main during sysimg generation

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -90,7 +90,7 @@ let
     tot_time_stdlib = 0.0
     # use a temp module to avoid leaving the type of this closure in Main
     push!(empty!(LOAD_PATH), "@stdlib")
-    m = Module()
+    m = Core.Module()
     GC.@preserve m begin
         print_time = @eval m (mod, t) -> (print(rpad(string(mod) * "  ", $maxlen + 3, "─"));
                                           Base.time_print(stdout, t * 10^9); println())

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Prevent this from putting anything into the Main namespace
-@eval Module() begin
+@eval Core.Module() begin
 
 if Threads.maxthreadid() != 1
     @warn "Running this file with multiple Julia threads may lead to a build error" Threads.maxthreadid()

--- a/test/core.jl
+++ b/test/core.jl
@@ -1180,6 +1180,10 @@ let A = [1]
     @test x == 1
 end
 
+# Make sure that `Module` is not resolved to `Core.Module` during sysimg generation
+# so that users can define their own binding named `Module` in Main.
+@test !Base.isbindingresolved(Main, :Module)
+
 # Module() constructor
 @test names(Module(:anonymous), all = true, imported = true) == [:anonymous]
 @test names(Module(:anonymous, false), all = true, imported = true) == [:anonymous]


### PR DESCRIPTION
Currently, the use of `Module` in the precompilation scripts makes the Module binding automatically resolved in Main because it is embedded in the sysimage. This prevents users from using the name Module for their own variables in Main.