### PR TITLE
Remove Matrix constructor for AbstractTriangular

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -29,8 +29,6 @@ for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular, :UnitUpperTr
         $t{T}(A::AbstractMatrix) where {T} = $t(convert(AbstractMatrix{T}, A))
         $t{T}(A::$t) where {T} = $t(convert(AbstractMatrix{T}, A.data))
 
-        Matrix(A::$t{T}) where {T} = Matrix{T}(A)
-
         AbstractMatrix{T}(A::$t) where {T} = $t{T}(A)
         AbstractMatrix{T}(A::$t{T}) where {T} = copy(A)
 


### PR DESCRIPTION
This seems redundant, as the fallback constructor does the same.
```julia
julia> using LinearAlgebra

julia> Revise.track(LinearAlgebra)

julia> U = UpperTriangular(rand(4,4))
4×4 UpperTriangular{Float64, Matrix{Float64}}:
 0.798171  0.484117  0.988126  0.986837
  ⋅        0.186955  0.827882  0.600041
  ⋅         ⋅        0.344573  0.344545
  ⋅         ⋅         ⋅        0.29875

julia> Matrix(U)
4×4 Matrix{Float64}:
 0.798171  0.484117  0.988126  0.986837
 0.0       0.186955  0.827882  0.600041
 0.0       0.0       0.344573  0.344545
 0.0       0.0       0.0       0.29875

julia> @which Matrix(U)
(Array{T, N} where T)(x::AbstractArray{S, N}) where {S, N}
     @ Core boot.jl:599
```