### PR TITLE
Use Memory in some more fast methods

### DIFF
--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -141,7 +141,7 @@ import .Base:
     bytesavailable, position, read, read!, readavailable, seek, seekend, show,
     skip, stat, unsafe_read, unsafe_write, write, transcode, uv_error,
     setup_stdio, rawhandle, OS_HANDLE, INVALID_OS_HANDLE, windowserror, filesize,
-    isexecutable, isreadable, iswritable
+    isexecutable, isreadable, iswritable, MutableByteArray
 
 import .Base.RefValue
 

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -309,7 +309,7 @@ bytesavailable(f::File) = max(0, filesize(f) - position(f)) # position can be > 
 
 eof(f::File) = bytesavailable(f) == 0
 
-function readbytes!(f::File, b::Array{UInt8}, nb=length(b))
+function readbytes!(f::File, b::MutableByteArray, nb=length(b))
     nr = min(nb, bytesavailable(f))
     if length(b) < nr
         resize!(b, nr)

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -141,7 +141,7 @@ import .Base:
     bytesavailable, position, read, read!, readavailable, seek, seekend, show,
     skip, stat, unsafe_read, unsafe_write, write, transcode, uv_error,
     setup_stdio, rawhandle, OS_HANDLE, INVALID_OS_HANDLE, windowserror, filesize,
-    isexecutable, isreadable, iswritable, MutableByteArray
+    isexecutable, isreadable, iswritable, MutableDenseArrayType
 
 import .Base.RefValue
 
@@ -309,7 +309,7 @@ bytesavailable(f::File) = max(0, filesize(f) - position(f)) # position can be > 
 
 eof(f::File) = bytesavailable(f) == 0
 
-function readbytes!(f::File, b::MutableByteArray, nb=length(b))
+function readbytes!(f::File, b::MutableDenseArrayType{UInt8}, nb=length(b))
     nr = min(nb, bytesavailable(f))
     if length(b) < nr
         resize!(b, nr)

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -219,7 +219,7 @@ function read_sub(from::GenericIOBuffer, a::AbstractArray{T}, offs, nel) where T
     if offs+nel-1 > length(a) || offs < 1 || nel < 0
         throw(BoundsError())
     end
-    if isbitstype(T) && isa(a,Array)
+    if isbitstype(T) && isa(a,MutableByteArray)
         nb = UInt(nel * sizeof(T))
         GC.@preserve a unsafe_read(from, pointer(a, offs), nb)
     else

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -548,8 +548,15 @@ end
     return sizeof(UInt8)
 end
 
-readbytes!(io::GenericIOBuffer, b::Array{UInt8}, nb=length(b)) = readbytes!(io, b, Int(nb))
-function readbytes!(io::GenericIOBuffer, b::Array{UInt8}, nb::Int)
+const MutableByteArray = Union{
+    Array{UInt8},
+    Memory{UInt8},
+    FastContiguousSubArray{UInt8,<:Any,<:Array{UInt8}},
+    FastContiguousSubArray{UInt8,<:Any,<:Memory{UInt8}},
+}
+
+readbytes!(io::GenericIOBuffer, b::MutableByteArray, nb=length(b)) = readbytes!(io, b, Int(nb))
+function readbytes!(io::GenericIOBuffer, b::MutableByteArray, nb::Int)
     nr = min(nb, bytesavailable(io))
     if length(b) < nr
         resize!(b, nr)

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -219,7 +219,7 @@ function read_sub(from::GenericIOBuffer, a::AbstractArray{T}, offs, nel) where T
     if offs+nel-1 > length(a) || offs < 1 || nel < 0
         throw(BoundsError())
     end
-    if isbitstype(T) && isa(a,MutableByteArray)
+    if isa(a, MutableDenseArrayType{UInt8})
         nb = UInt(nel * sizeof(T))
         GC.@preserve a unsafe_read(from, pointer(a, offs), nb)
     else
@@ -548,15 +548,8 @@ end
     return sizeof(UInt8)
 end
 
-const MutableByteArray = Union{
-    Array{UInt8},
-    Memory{UInt8},
-    FastContiguousSubArray{UInt8,<:Any,<:Array{UInt8}},
-    FastContiguousSubArray{UInt8,<:Any,<:Memory{UInt8}},
-}
-
-readbytes!(io::GenericIOBuffer, b::MutableByteArray, nb=length(b)) = readbytes!(io, b, Int(nb))
-function readbytes!(io::GenericIOBuffer, b::MutableByteArray, nb::Int)
+readbytes!(io::GenericIOBuffer, b::MutableDenseArrayType{UInt8}, nb=length(b)) = readbytes!(io, b, Int(nb))
+function readbytes!(io::GenericIOBuffer, b::MutableDenseArrayType{UInt8}, nb::Int)
     nr = min(nb, bytesavailable(io))
     if length(b) < nr
         resize!(b, nr)

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -486,7 +486,7 @@ function copyuntil(out::IOStream, s::IOStream, delim::UInt8; keep::Bool=false)
     return out
 end
 
-function readbytes_all!(s::IOStream, b::MutableByteArray, nb::Integer)
+function readbytes_all!(s::IOStream, b::MutableDenseArrayType{UInt8}, nb::Integer)
     olb = lb = length(b)
     nr = 0
     let l = s._dolock, slock = s.lock
@@ -514,7 +514,7 @@ function readbytes_all!(s::IOStream, b::MutableByteArray, nb::Integer)
     return nr
 end
 
-function readbytes_some!(s::IOStream, b::MutableByteArray, nb::Integer)
+function readbytes_some!(s::IOStream, b::MutableDenseArrayType{UInt8}, nb::Integer)
     olb = length(b)
     if nb > olb
         resize!(b, nb)
@@ -543,7 +543,7 @@ requested bytes, until an error or end-of-file occurs. If `all` is `false`, at m
 `read` call is performed, and the amount of data returned is device-dependent. Note that not
 all stream types support the `all` option.
 """
-function readbytes!(s::IOStream, b::MutableByteArray, nb=length(b); all::Bool=true)
+function readbytes!(s::IOStream, b::MutableDenseArrayType{UInt8}, nb=length(b); all::Bool=true)
     return all ? readbytes_all!(s, b, nb) : readbytes_some!(s, b, nb)
 end
 

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -487,7 +487,12 @@ function copyuntil(out::IOStream, s::IOStream, delim::UInt8; keep::Bool=false)
 end
 
 function readbytes_all!(s::IOStream,
-                        b::Union{Array{UInt8}, FastContiguousSubArray{UInt8,<:Any,<:Array{UInt8}}},
+                        b::Union{
+                            Array{UInt8},
+                            Memory{UInt8},
+                            FastContiguousSubArray{UInt8,<:Any,<:Array{UInt8}},
+                            FastContiguousSubArray{UInt8,<:Any,<:Memory{UInt8}},
+                        },
                         nb::Integer)
     olb = lb = length(b)
     nr = 0
@@ -517,7 +522,12 @@ function readbytes_all!(s::IOStream,
 end
 
 function readbytes_some!(s::IOStream,
-                         b::Union{Array{UInt8}, FastContiguousSubArray{UInt8,<:Any,<:Array{UInt8}}},
+                         b::Union{
+                            Array{UInt8},
+                            Memory{UInt8},
+                            FastContiguousSubArray{UInt8,<:Any,<:Array{UInt8}},
+                            FastContiguousSubArray{UInt8,<:Any,<:Memory{UInt8}},
+                        },
                          nb::Integer)
     olb = length(b)
     if nb > olb
@@ -548,7 +558,12 @@ requested bytes, until an error or end-of-file occurs. If `all` is `false`, at m
 all stream types support the `all` option.
 """
 function readbytes!(s::IOStream,
-                    b::Union{Array{UInt8}, FastContiguousSubArray{UInt8,<:Any,<:Array{UInt8}}},
+                    b::Union{
+                        Array{UInt8},
+                        Memory{UInt8},
+                        FastContiguousSubArray{UInt8,<:Any,<:Array{UInt8}},
+                        FastContiguousSubArray{UInt8,<:Any,<:Memory{UInt8}},
+                    },
                     nb=length(b);
                     all::Bool=true)
     return all ? readbytes_all!(s, b, nb) : readbytes_some!(s, b, nb)

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -489,8 +489,8 @@ end
 const MutableByteArray = Union{
     Array{UInt8},
     Memory{UInt8},
-    FastContiguousSubArray{UInt8,<:Any,<:Array{UInt8}}},
-    FastContiguousSubArray{UInt8,<:Any,<:Memory{UInt8}}}
+    FastContiguousSubArray{UInt8,<:Any,<:Array{UInt8}},
+    FastContiguousSubArray{UInt8,<:Any,<:Memory{UInt8}},
 }
 
 function readbytes_all!(s::IOStream, b::MutableByteArray, nb::Integer)

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -486,9 +486,14 @@ function copyuntil(out::IOStream, s::IOStream, delim::UInt8; keep::Bool=false)
     return out
 end
 
-function readbytes_all!(s::IOStream,
-                        b::Union{DenseArray{UInt8}, FastContiguousSubArray{UInt8,<:Any,<:DenseArray{UInt8}}},
-                        nb::Integer)
+const MutableByteArray = Union{
+    Array{UInt8},
+    Memory{UInt8},
+    FastContiguousSubArray{UInt8,<:Any,<:Array{UInt8}}},
+    FastContiguousSubArray{UInt8,<:Any,<:Memory{UInt8}}}
+}
+
+function readbytes_all!(s::IOStream, b::MutableByteArray, nb::Integer)
     olb = lb = length(b)
     nr = 0
     let l = s._dolock, slock = s.lock
@@ -516,9 +521,7 @@ function readbytes_all!(s::IOStream,
     return nr
 end
 
-function readbytes_some!(s::IOStream,
-                         b::Union{DenseArray{UInt8}, FastContiguousSubArray{UInt8,<:Any,<:DenseArray{UInt8}}},
-                         nb::Integer)
+function readbytes_some!(s::IOStream, b::MutableByteArray, nb::Integer)
     olb = length(b)
     if nb > olb
         resize!(b, nb)
@@ -547,10 +550,7 @@ requested bytes, until an error or end-of-file occurs. If `all` is `false`, at m
 `read` call is performed, and the amount of data returned is device-dependent. Note that not
 all stream types support the `all` option.
 """
-function readbytes!(s::IOStream,
-                    b::Union{DenseArray{UInt8}, FastContiguousSubArray{UInt8,<:Any,<:DenseArray{UInt8}}},
-                    nb=length(b);
-                    all::Bool=true)
+function readbytes!(s::IOStream, b::MutableByteArray, nb=length(b); all::Bool=true)
     return all ? readbytes_all!(s, b, nb) : readbytes_some!(s, b, nb)
 end
 

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -486,13 +486,6 @@ function copyuntil(out::IOStream, s::IOStream, delim::UInt8; keep::Bool=false)
     return out
 end
 
-const MutableByteArray = Union{
-    Array{UInt8},
-    Memory{UInt8},
-    FastContiguousSubArray{UInt8,<:Any,<:Array{UInt8}},
-    FastContiguousSubArray{UInt8,<:Any,<:Memory{UInt8}},
-}
-
 function readbytes_all!(s::IOStream, b::MutableByteArray, nb::Integer)
     olb = lb = length(b)
     nr = 0

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -487,12 +487,7 @@ function copyuntil(out::IOStream, s::IOStream, delim::UInt8; keep::Bool=false)
 end
 
 function readbytes_all!(s::IOStream,
-                        b::Union{
-                            Array{UInt8},
-                            Memory{UInt8},
-                            FastContiguousSubArray{UInt8,<:Any,<:Array{UInt8}},
-                            FastContiguousSubArray{UInt8,<:Any,<:Memory{UInt8}},
-                        },
+                        b::Union{DenseArray{UInt8}, FastContiguousSubArray{UInt8,<:Any,<:DenseArray{UInt8}}},
                         nb::Integer)
     olb = lb = length(b)
     nr = 0
@@ -522,12 +517,7 @@ function readbytes_all!(s::IOStream,
 end
 
 function readbytes_some!(s::IOStream,
-                         b::Union{
-                            Array{UInt8},
-                            Memory{UInt8},
-                            FastContiguousSubArray{UInt8,<:Any,<:Array{UInt8}},
-                            FastContiguousSubArray{UInt8,<:Any,<:Memory{UInt8}},
-                        },
+                         b::Union{DenseArray{UInt8}, FastContiguousSubArray{UInt8,<:Any,<:DenseArray{UInt8}}},
                          nb::Integer)
     olb = length(b)
     if nb > olb
@@ -558,12 +548,7 @@ requested bytes, until an error or end-of-file occurs. If `all` is `false`, at m
 all stream types support the `all` option.
 """
 function readbytes!(s::IOStream,
-                    b::Union{
-                        Array{UInt8},
-                        Memory{UInt8},
-                        FastContiguousSubArray{UInt8,<:Any,<:Array{UInt8}},
-                        FastContiguousSubArray{UInt8,<:Any,<:Memory{UInt8}},
-                    },
+                    b::Union{DenseArray{UInt8}, FastContiguousSubArray{UInt8,<:Any,<:DenseArray{UInt8}}},
                     nb=length(b);
                     all::Bool=true)
     return all ? readbytes_all!(s, b, nb) : readbytes_some!(s, b, nb)

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -29,6 +29,14 @@ function findnext(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:AbstractChar}
     end
 end
 
+# Note: Currently, CodeUnits <: DenseVector, which makes this union redundant w.r.t
+# DenseArrayType{UInt8}, but this is a bug, and may be removed in future versions
+# of Julia. See #54002
+const DenseBytes = Union{
+    <:DenseArrayType{UInt8},
+    CodeUnits{UInt8, <:Union{String, SubString{String}}},
+}
+
 const ByteArray = Union{DenseBytes, DenseArrayType{Int8}}
 
 findfirst(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:Union{Int8,UInt8}}, a::ByteArray) =

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -29,6 +29,8 @@ function findnext(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:AbstractChar}
     end
 end
 
+const ByteArray = Union{DenseArrayType{UInt8}, DenseArrayType{Int8}}
+
 findfirst(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:Union{Int8,UInt8}}, a::ByteArray) =
     nothing_sentinel(_search(a, pred.x))
 
@@ -38,7 +40,7 @@ findnext(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:Union{Int8,UInt8}}, a:
 findfirst(::typeof(iszero), a::ByteArray) = nothing_sentinel(_search(a, zero(UInt8)))
 findnext(::typeof(iszero), a::ByteArray, i::Integer) = nothing_sentinel(_search(a, zero(UInt8), i))
 
-function _search(a::Union{String,SubString{String},ByteArray}, b::Union{Int8,UInt8}, i::Integer = 1)
+function _search(a::Union{String,SubString{String},<:ByteArray}, b::Union{Int8,UInt8}, i::Integer = 1)
     if i < 1
         throw(BoundsError(a, i))
     end

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -29,7 +29,7 @@ function findnext(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:AbstractChar}
     end
 end
 
-const ByteArray = Union{DenseArrayType{UInt8}, DenseArrayType{Int8}}
+const ByteArray = Union{DenseBytes, DenseArrayType{Int8}}
 
 findfirst(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:Union{Int8,UInt8}}, a::ByteArray) =
     nothing_sentinel(_search(a, pred.x))

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -27,7 +27,19 @@ function Base.showerror(io::IO, exc::StringIndexError)
     end
 end
 
-const ByteArray = Union{CodeUnits{UInt8,String}, Vector{UInt8},Vector{Int8}, FastContiguousSubArray{UInt8,1,CodeUnits{UInt8,String}}, FastContiguousSubArray{UInt8,1,Vector{UInt8}}, FastContiguousSubArray{Int8,1,Vector{Int8}}}
+const ByteArray = Union{
+    CodeUnits{UInt8,String},
+    CodeUnits{UInt8,SubString{String}},
+    Vector{UInt8},
+    Vector{Int8},
+    Memory{UInt8},
+    Memory{Int8},
+    FastContiguousSubArray{UInt8,1,CodeUnits{UInt8,String}},
+    FastContiguousSubArray{UInt8,1,Vector{UInt8}},
+    FastContiguousSubArray{Int8,1,Vector{Int8}},
+    FastContiguousSubArray{UInt8,1,Memory{UInt8}},
+    FastContiguousSubArray{Int8,1,Memory{Int8}},
+}
 
 @inline between(b::T, lo::T, hi::T) where {T<:Integer} = (lo ≤ b) & (b ≤ hi)
 

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -28,17 +28,8 @@ function Base.showerror(io::IO, exc::StringIndexError)
 end
 
 const ByteArray = Union{
-    CodeUnits{UInt8,String},
-    CodeUnits{UInt8,SubString{String}},
-    Vector{UInt8},
-    Vector{Int8},
-    Memory{UInt8},
-    Memory{Int8},
-    FastContiguousSubArray{UInt8,1,CodeUnits{UInt8,String}},
-    FastContiguousSubArray{UInt8,1,Vector{UInt8}},
-    FastContiguousSubArray{Int8,1,Vector{Int8}},
-    FastContiguousSubArray{UInt8,1,Memory{UInt8}},
-    FastContiguousSubArray{Int8,1,Memory{Int8}},
+    DenseVector{<:Union{UInt8, Int8}},
+    FastContiguousSubArray{<:Union{UInt8, Int8},1,<:DenseVector{<:Union{UInt8, Int8}}},
 }
 
 @inline between(b::T, lo::T, hi::T) where {T<:Integer} = (lo ≤ b) & (b ≤ hi)

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -27,11 +27,6 @@ function Base.showerror(io::IO, exc::StringIndexError)
     end
 end
 
-const ByteArray = Union{
-    DenseVector{<:Union{UInt8, Int8}},
-    FastContiguousSubArray{<:Union{UInt8, Int8},1,<:DenseVector{<:Union{UInt8, Int8}}},
-}
-
 @inline between(b::T, lo::T, hi::T) where {T<:Integer} = (lo ≤ b) & (b ≤ hi)
 
 """

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -348,6 +348,24 @@ FastContiguousSubArray{T,N,P,I<:Union{Tuple{Union{Slice, AbstractUnitRange}, Var
 @inline _reindexlinear(V::FastContiguousSubArray, i::Int) = V.offset1 + i
 @inline _reindexlinear(V::FastContiguousSubArray, i::AbstractUnitRange{Int}) = V.offset1 .+ i
 
+"""
+An internal type representing arrays stored contiguously in memory.
+"""
+const DenseArrayType{T,N} = Union{
+    DenseArray{T,N},
+    <:FastContiguousSubArray{T,N,<:DenseArray},
+}
+
+"""
+An internal type representing mutable arrays stored contiguously in memory.
+"""
+const MutableDenseArrayType{T,N} = Union{
+    Array{T, N},
+    Memory{T},
+    FastContiguousSubArray{T,N,<:Array},
+    FastContiguousSubArray{T,N,<:Memory}
+}
+
 # parents of FastContiguousSubArrays may support fast indexing with AbstractUnitRanges,
 # so we may just forward the indexing to the parent
 # This may only be done for non-offset ranges, as the result would otherwise have offset axes

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -366,14 +366,6 @@ const MutableDenseArrayType{T,N} = Union{
     FastContiguousSubArray{T,N,<:Memory}
 }
 
-# Note: Currently, CodeUnits <: DenseVector, which makes this union redundant w.r.t
-# DenseArrayType{UInt8}, but this is a bug, and may be removed in future versions
-# of Julia. See #54002
-const DenseBytes = Union{
-    <:DenseArrayType{UInt8},
-    CodeUnits{UInt8, <:Union{String, SubString{String}}},
-}
-
 # parents of FastContiguousSubArrays may support fast indexing with AbstractUnitRanges,
 # so we may just forward the indexing to the parent
 # This may only be done for non-offset ranges, as the result would otherwise have offset axes

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -366,6 +366,14 @@ const MutableDenseArrayType{T,N} = Union{
     FastContiguousSubArray{T,N,<:Memory}
 }
 
+# Note: Currently, CodeUnits <: DenseVector, which makes this union redundant w.r.t
+# DenseArrayType{UInt8}, but this is a bug, and may be removed in future versions
+# of Julia. See #54002
+const DenseBytes = Union{
+    <:DenseArrayType{UInt8},
+    CodeUnits{UInt8, <:Union{String, SubString{String}}},
+}
+
 # parents of FastContiguousSubArrays may support fast indexing with AbstractUnitRanges,
 # so we may just forward the indexing to the parent
 # This may only be done for non-offset ranges, as the result would otherwise have offset axes

--- a/base/util.jl
+++ b/base/util.jl
@@ -491,8 +491,17 @@ unsafe_crc32c(a, n, crc) = ccall(:jl_crc32c, UInt32, (UInt32, Ptr{UInt8}, Csize_
 
 _crc32c(a::NTuple{<:Any, UInt8}, crc::UInt32=0x00000000) =
     unsafe_crc32c(Ref(a), length(a) % Csize_t, crc)
-_crc32c(a::Union{Array{UInt8},FastContiguousSubArray{UInt8,N,<:Array{UInt8}} where N}, crc::UInt32=0x00000000) =
+
+function _crc32c(a::Union{
+        Array{UInt8},
+        Memory{UInt8},
+        FastContiguousSubArray{UInt8,N,<:Array{UInt8}} where N,
+        FastContiguousSubArray{UInt8,N,<:Memory{UInt8}} where N,
+    },
+    crc::UInt32=0x00000000
+)
     unsafe_crc32c(a, length(a) % Csize_t, crc)
+end
 
 function _crc32c(s::Union{String, SubString{String}}, crc::UInt32=0x00000000)
     unsafe_crc32c(s, sizeof(s) % Csize_t, crc)

--- a/base/util.jl
+++ b/base/util.jl
@@ -492,10 +492,7 @@ unsafe_crc32c(a, n, crc) = ccall(:jl_crc32c, UInt32, (UInt32, Ptr{UInt8}, Csize_
 _crc32c(a::NTuple{<:Any, UInt8}, crc::UInt32=0x00000000) =
     unsafe_crc32c(Ref(a), length(a) % Csize_t, crc)
 
-function _crc32c(
-    a::Union{DenseArray{UInt8}, FastContiguousSubArray{UInt8,N,<:DenseArray{UInt8}} where N},
-    crc::UInt32=0x00000000
-)
+function _crc32c(a::DenseArrayType{UInt8}, crc::UInt32=0x00000000)
     unsafe_crc32c(a, length(a) % Csize_t, crc)
 end
 

--- a/base/util.jl
+++ b/base/util.jl
@@ -492,7 +492,7 @@ unsafe_crc32c(a, n, crc) = ccall(:jl_crc32c, UInt32, (UInt32, Ptr{UInt8}, Csize_
 _crc32c(a::NTuple{<:Any, UInt8}, crc::UInt32=0x00000000) =
     unsafe_crc32c(Ref(a), length(a) % Csize_t, crc)
 
-function _crc32c(a::DenseArrayType{UInt8}, crc::UInt32=0x00000000)
+function _crc32c(a::DenseBytes, crc::UInt32=0x00000000)
     unsafe_crc32c(a, length(a) % Csize_t, crc)
 end
 

--- a/base/util.jl
+++ b/base/util.jl
@@ -492,12 +492,8 @@ unsafe_crc32c(a, n, crc) = ccall(:jl_crc32c, UInt32, (UInt32, Ptr{UInt8}, Csize_
 _crc32c(a::NTuple{<:Any, UInt8}, crc::UInt32=0x00000000) =
     unsafe_crc32c(Ref(a), length(a) % Csize_t, crc)
 
-function _crc32c(a::Union{
-        Array{UInt8},
-        Memory{UInt8},
-        FastContiguousSubArray{UInt8,N,<:Array{UInt8}} where N,
-        FastContiguousSubArray{UInt8,N,<:Memory{UInt8}} where N,
-    },
+function _crc32c(
+    a::Union{DenseArray{UInt8}, FastContiguousSubArray{UInt8,N,<:DenseArray{UInt8}} where N},
     crc::UInt32=0x00000000
 )
     unsafe_crc32c(a, length(a) % Csize_t, crc)

--- a/stdlib/CRC32c/src/CRC32c.jl
+++ b/stdlib/CRC32c/src/CRC32c.jl
@@ -35,12 +35,8 @@ but note that the result may be endian-dependent.
 function crc32c end
 
 
-function crc32c(a::Union{
-        Array{UInt8},
-        Memory{UInt8},
-        FastContiguousSubArray{UInt8,N,<:Array{UInt8}} where N,
-        FastContiguousSubArray{UInt8,N,<:Memory{UInt8}} where N,
-    },
+function crc32c(
+    a::Union{DenseArray{UInt8}, FastContiguousSubArray{UInt8,N,<:DenseArray{UInt8}} where N},
     crc::UInt32=0x00000000
 )
     Base._crc32c(a, crc)

--- a/stdlib/CRC32c/src/CRC32c.jl
+++ b/stdlib/CRC32c/src/CRC32c.jl
@@ -35,7 +35,17 @@ but note that the result may be endian-dependent.
 function crc32c end
 
 
-crc32c(a::Union{Array{UInt8},FastContiguousSubArray{UInt8,N,<:Array{UInt8}} where N}, crc::UInt32=0x00000000) = Base._crc32c(a, crc)
+function crc32c(a::Union{
+        Array{UInt8},
+        Memory{UInt8},
+        FastContiguousSubArray{UInt8,N,<:Array{UInt8}} where N,
+        FastContiguousSubArray{UInt8,N,<:Memory{UInt8}} where N,
+    },
+    crc::UInt32=0x00000000
+)
+    Base._crc32c(a, crc)
+end
+
 crc32c(s::Union{String, SubString{String}}, crc::UInt32=0x00000000) = Base._crc32c(s, crc)
 
 """

--- a/stdlib/CRC32c/src/CRC32c.jl
+++ b/stdlib/CRC32c/src/CRC32c.jl
@@ -8,6 +8,7 @@ See [`CRC32c.crc32c`](@ref) for more information.
 module CRC32c
 
 import Base.FastContiguousSubArray
+import Base: DenseArrayType
 
 export crc32c
 
@@ -35,10 +36,7 @@ but note that the result may be endian-dependent.
 function crc32c end
 
 
-function crc32c(
-    a::Union{DenseArray{UInt8}, FastContiguousSubArray{UInt8,N,<:DenseArray{UInt8}} where N},
-    crc::UInt32=0x00000000
-)
+function crc32c(a::DenseArrayType{UInt8}, crc::UInt32=0x00000000)
     Base._crc32c(a, crc)
 end
 

--- a/stdlib/CRC32c/src/CRC32c.jl
+++ b/stdlib/CRC32c/src/CRC32c.jl
@@ -36,7 +36,7 @@ but note that the result may be endian-dependent.
 function crc32c end
 
 
-function crc32c(a::DenseArrayType{UInt8}, crc::UInt32=0x00000000)
+function crc32c(a::DenseBytes, crc::UInt32=0x00000000)
     Base._crc32c(a, crc)
 end
 

--- a/stdlib/CRC32c/src/CRC32c.jl
+++ b/stdlib/CRC32c/src/CRC32c.jl
@@ -8,7 +8,7 @@ See [`CRC32c.crc32c`](@ref) for more information.
 module CRC32c
 
 import Base.FastContiguousSubArray
-import Base: DenseArrayType
+import Base: DenseBytes
 
 export crc32c
 


### PR DESCRIPTION
This commit changes the signature of a bunch of methods that operate on byte buffers, and which previously didn't take `Memory`. For example, a method which previously took
```julia
Union{
    Array{UInt8},
    CodeUnits{UInt8, String},
    FastContiguousSubArray{UInt8,N,<:Array{UInt8}} where N,
}
```
Now also takes `Memory{UInt8}`, and the `Memory`-backed `FastContiguousSubArray`.

## Notes for reviewers
1. I don't think this is a particularly nice design - these large unions are a sign we miss an abstraction. In particular, whether something is a contiguous, memory backed Array (read or read/write). I think we should have a trait for this, which requires an implementation of e.g. `pointer` and `sizeof`. However, that's a larger PR for another time.

3. The functions `readbytes_some!` and `readbytes_all!` may resize its arguments. This will not work for `Memory`. It already didn't work for `SubArray`. Maybe we should have a different method for the arrays that can't be resized, which doesn't attempt to.