### PR TITLE
remove allocation from PermutedDimsArray constructor

### DIFF
--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -12,7 +12,7 @@ struct PermutedDimsArray{T,N,perm,iperm,AA<:AbstractArray} <: AbstractArray{T,N}
     function PermutedDimsArray{T,N,perm,iperm,AA}(data::AA) where {T,N,perm,iperm,AA<:AbstractArray}
         (isa(perm, NTuple{N,Int}) && isa(iperm, NTuple{N,Int})) || error("perm and iperm must both be NTuple{$N,Int}")
         isperm(perm) || throw(ArgumentError(string(perm, " is not a valid permutation of dimensions 1:", N)))
-        all(ntuple(d->iperm[perm[d]]==d, Val{N}())) || throw(ArgumentError(string(perm, " and ", iperm, " must be inverses")))
+        all(d->iperm[perm[d]]==d, 1:N) || throw(ArgumentError(string(perm, " and ", iperm, " must be inverses")))
         new(data)
     end
 end

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -12,7 +12,7 @@ struct PermutedDimsArray{T,N,perm,iperm,AA<:AbstractArray} <: AbstractArray{T,N}
     function PermutedDimsArray{T,N,perm,iperm,AA}(data::AA) where {T,N,perm,iperm,AA<:AbstractArray}
         (isa(perm, NTuple{N,Int}) && isa(iperm, NTuple{N,Int})) || error("perm and iperm must both be NTuple{$N,Int}")
         isperm(perm) || throw(ArgumentError(string(perm, " is not a valid permutation of dimensions 1:", N)))
-        all(map(d->iperm[perm[d]]==d, 1:N)) || throw(ArgumentError(string(perm, " and ", iperm, " must be inverses")))
+        all(ntuple(d->iperm[perm[d]]==d, Val{N}())) || throw(ArgumentError(string(perm, " and ", iperm, " must be inverses")))
         new(data)
     end
 end


### PR DESCRIPTION
The `PermutedDimsArray` constructor currently allocates a small vector by mapping over a range of `1:N`.

This PR instead uses `all` ~~`ntuple`~~ to do the same thing without the allocation.