### PR TITLE
change IOBuffer to use Memory internally

### DIFF
--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -455,26 +455,24 @@ end
 
 function copyuntil(out::IOBuffer, s::IOStream, delim::UInt8; keep::Bool=false)
     ensureroom(out, 1) # make sure we can read at least 1 byte, for iszero(n) check below
-    ptr = (out.append ? out.size+1 : out.ptr)
-    d = out.data
-    len = length(d)
     while true
+        d = out.data
+        len = length(d)
+        ptr = (out.append ? out.size+1 : out.ptr)
         GC.@preserve d @_lock_ios s n=
             Int(ccall(:jl_readuntil_buf, Csize_t, (Ptr{Cvoid}, UInt8, Ptr{UInt8}, Csize_t),
                 s.ios, delim, pointer(d, ptr), (len - ptr + 1) % Csize_t))
         iszero(n) && break
         ptr += n
-        if d[ptr-1] == delim
-            keep || (ptr -= 1)
-            break
-        end
+        found = (d[ptr - 1] == delim)
+        found && !keep && (ptr -= 1)
+        out.size = max(out.size, ptr - 1)
+        out.append || (out.ptr = ptr)
+        found && break
         (eof(s) || len == out.maxsize) && break
         len = min(2len + 64, out.maxsize)
-        resize!(d, len)
-    end
-    out.size = max(out.size, ptr - 1)
-    if !out.append
-        out.ptr = ptr
+        ensureroom(out, len)
+        @assert length(out.data) >= len
     end
     return out
 end

--- a/base/strings/annotated.jl
+++ b/base/strings/annotated.jl
@@ -200,34 +200,36 @@ julia> annotatedstring(AnnotatedString("annotated", [(1:9, :label => 1)]), ", an
 function annotatedstring(xs...)
     isempty(xs) && return AnnotatedString("")
     size = mapreduce(_str_sizehint, +, xs)
-    s = IOContext(IOBuffer(sizehint=size), :color => true)
+    buf = IOBuffer(sizehint=size)
+    s = IOContext(buf, :color => true)
     annotations = Vector{Tuple{UnitRange{Int}, Pair{Symbol, Any}}}()
     for x in xs
+        size = filesize(s.io)
         if x isa AnnotatedString
             for (region, annot) in x.annotations
-                push!(annotations, (s.io.size .+ (region), annot))
+                push!(annotations, (size .+ (region), annot))
             end
             print(s, x.string)
         elseif x isa SubString{<:AnnotatedString}
             for (region, annot) in x.string.annotations
                 start, stop = first(region), last(region)
                 if start <= x.offset + x.ncodeunits && stop > x.offset
-                    rstart = s.io.size + max(0, start - x.offset - 1) + 1
-                    rstop = s.io.size + min(stop, x.offset + x.ncodeunits) - x.offset
+                    rstart = size + max(0, start - x.offset - 1) + 1
+                    rstop = size + min(stop, x.offset + x.ncodeunits) - x.offset
                     push!(annotations, (rstart:rstop, annot))
                 end
             end
             print(s, SubString(x.string.string, x.offset, x.ncodeunits, Val(:noshift)))
         elseif x isa AnnotatedChar
             for annot in x.annotations
-                push!(annotations, (1+s.io.size:1+s.io.size, annot))
+                push!(annotations, (1+size:1+size, annot))
             end
             print(s, x.char)
         else
             print(s, x)
         end
     end
-    str = String(resize!(s.io.data, s.io.size))
+    str = String(take!(buf))
     AnnotatedString(str, annotations)
 end
 
@@ -404,7 +406,8 @@ AnnotatedIOBuffer() = AnnotatedIOBuffer(IOBuffer())
 
 function show(io::IO, aio::AnnotatedIOBuffer)
     show(io, AnnotatedIOBuffer)
-    print(io, '(', aio.io.size, " byte", ifelse(aio.io.size == 1, "", "s"), ", ",
+    size = filesize(aio.io)
+    print(io, '(', size, " byte", ifelse(size == 1, "", "s"), ", ",
           length(aio.annotations), " annotation", ifelse(length(aio.annotations) == 1, "", "s"), ")")
 end
 

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -543,3 +543,6 @@ end
 function replace_in_print_matrix(S::SubArray{<:Any,1,<:AbstractVector}, i::Integer, j::Integer, s::AbstractString)
     replace_in_print_matrix(S.parent, to_indices(S.parent, reindex(S.indices, (i,)))..., j, s)
 end
+
+# XXX: this is considerably more unsafe than the other similarly named methods
+unsafe_wrap(::Type{Vector{UInt8}}, s::FastContiguousSubArray{UInt8,1,Vector{UInt8}}) = unsafe_wrap(Vector{UInt8}, pointer(s), size(s))

--- a/src/array.c
+++ b/src/array.c
@@ -99,21 +99,6 @@ jl_genericmemory_t *_new_genericmemory_(jl_value_t *mtype, size_t nel, int8_t is
 
 JL_DLLEXPORT jl_genericmemory_t *jl_string_to_genericmemory(jl_value_t *str);
 
-JL_DLLEXPORT jl_array_t *jl_string_to_array(jl_value_t *str)
-{
-    jl_task_t *ct = jl_current_task;
-    jl_genericmemory_t *mem = jl_string_to_genericmemory(str);
-    JL_GC_PUSH1(&mem);
-    int ndimwords = 1;
-    int tsz = sizeof(jl_array_t) + ndimwords*sizeof(size_t);
-    jl_array_t *a = (jl_array_t*)jl_gc_alloc(ct->ptls, tsz, jl_array_uint8_type);
-    a->ref.mem = mem;
-    a->ref.ptr_or_offset = mem->ptr;
-    a->dimsize[0] = mem->length;
-    JL_GC_POP();
-    return a;
-}
-
 JL_DLLEXPORT jl_array_t *jl_ptr_to_array_1d(jl_value_t *atype, void *data,
                                             size_t nel, int own_buffer)
 {

--- a/src/genericmemory.c
+++ b/src/genericmemory.c
@@ -101,6 +101,8 @@ JL_DLLEXPORT jl_genericmemory_t *jl_alloc_genericmemory(jl_value_t *mtype, size_
 
 JL_DLLEXPORT jl_genericmemory_t *jl_string_to_genericmemory(jl_value_t *str)
 {
+    if (jl_string_len(str) == 0)
+        return (jl_genericmemory_t*)((jl_datatype_t*)jl_memory_uint8_type)->instance;
     jl_task_t *ct = jl_current_task;
     int tsz = sizeof(jl_genericmemory_t) + sizeof(void*);
     jl_genericmemory_t *m = (jl_genericmemory_t*)jl_gc_alloc(ct->ptls, tsz, jl_memory_uint8_type);

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -436,7 +436,6 @@
     XX(jl_stdout_stream) \
     XX(jl_stored_inline) \
     XX(jl_string_ptr) \
-    XX(jl_string_to_array) \
     XX(jl_subtype) \
     XX(jl_subtype_env) \
     XX(jl_subtype_env_size) \

--- a/stdlib/REPL/test/precompilation.jl
+++ b/stdlib/REPL/test/precompilation.jl
@@ -27,7 +27,7 @@ if !Sys.iswindows()
         tracecompile_out = read(f, String)
         close(ptm) # close after reading so we don't get precompiles from error shutdown
 
-        expected_precompiles = 0
+        expected_precompiles = 1
 
         n_precompiles = count(r"precompile\(", tracecompile_out)
 

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -120,6 +120,7 @@ end
     Base.compact(io)
     @test position(io) == 0
     @test ioslength(io) == 0
+    Base._resize!(io,0)
     Base.ensureroom(io,50)
     @test position(io) == 0
     @test ioslength(io) == 0

--- a/test/show.jl
+++ b/test/show.jl
@@ -1250,12 +1250,12 @@ end
 @testset "PR 17117: print_array" begin
     s = IOBuffer(Vector{UInt8}(), read=true, write=true)
     Base.print_array(s, [1, 2, 3])
-    @test String(resize!(s.data, s.size)) == " 1\n 2\n 3"
+    @test String(take!(s)) == " 1\n 2\n 3"
     close(s)
     s2 = IOBuffer(Vector{UInt8}(), read=true, write=true)
     z = zeros(0,0,0,0,0,0,0,0)
     Base.print_array(s2, z)
-    @test String(resize!(s2.data, s2.size)) == ""
+    @test String(take!(s2)) == ""
     close(s2)
 end
 


### PR DESCRIPTION
An Array is often still allocated on output, but this gives the compiler a chance to potentially elide that in certain cases.

For measurement, it seems about 10% faster as a string builder:
```
julia> @btime repr("hello\nworld"^10);
  1.096 μs (10 allocations: 640 bytes) # master
  973.000 ns (9 allocations: 608 bytes) # PR
  994.000 ns (8 allocations: 576 bytes) # also PR, after Revise-ing Base.wrap
```