### PR TITLE
Don't tell people to use Pkg to install Pkg

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1892,7 +1892,7 @@ function __require(into::Module, mod::Symbol)
                     ""
                 end
 
-                throw(ArgumentError("Package $mod not found in current path$hint_message.install_message"))
+                throw(ArgumentError("Package $mod not found in current path$hint_message.$install_message"))
             else
                 manifest_warnings = collect_manifest_warnings()
                 throw(ArgumentError("""

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1885,10 +1885,14 @@ function __require(into::Module, mod::Symbol)
                     end
                 end
                 hint_message = hint ? ", maybe you meant `import/using $(dots)$(mod)`" : ""
-                start_sentence = hint ? "Otherwise, run" : "Run"
-                throw(ArgumentError("""
-                    Package $mod not found in current path$hint_message.
-                    - $start_sentence `import Pkg; Pkg.add($(repr(String(mod))))` to install the $mod package."""))
+                install_message = if mod != :Pkg
+                    start_sentence = hint ? "Otherwise, run" : "Run"
+                    "\n- $start_sentence `import Pkg; Pkg.add($(repr(String(mod))))` to install the $mod package."
+                else  # for some reason Pkg itself isn't availability so do not tell them to use Pkg to install it.
+                    ""
+                end
+
+                throw(ArgumentError("Package $mod not found in current path$hint_message.install_message"))
             else
                 manifest_warnings = collect_manifest_warnings()
                 throw(ArgumentError("""


### PR DESCRIPTION
Occasionally one ends up in a situation where Pkg is not available
This results in the rather nonsensical error message:

```
julia> using Pkg
ERROR: ArgumentError: Package Pkg not found in current path.
- Run `import Pkg; Pkg.add("Pkg")` to install the Pkg package.
```
How dare the REPL mock me like that?


We could display a number of useful and/or humours messages here, like checking if `@stdlib` is JULIA_LOAD_PATH
or commentary about being up shit creek without a paddle, etc.
right now for initial PR I just said nothing.

(One way to replicate this error message is to set the environment variable `JULIA_LOAD_PATH="some nonsense value"` before starting julia. Another is to be building julia from source and have Pkg be in a broken state where it can't precompile. I am sure there is another where you prune stdlibs for your use-case)