### PR TITLE
Make code_llvm return an object that overloads show

### DIFF
--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -278,17 +278,29 @@ Keyword argument `debuginfo` may be one of source (default) or none, to specify 
 
 See also: [`@code_llvm`](@ref), [`code_warntype`](@ref), [`code_typed`](@ref), [`code_lowered`](@ref), [`code_native`](@ref).
 """
-function code_llvm(io::IO, @nospecialize(f), @nospecialize(types=Base.default_tt(f));
-                   raw::Bool=false, dump_module::Bool=false, optimize::Bool=true, debuginfo::Symbol=:default,
-                   params::CodegenParams=CodegenParams(debug_info_kind=Cint(0), debug_info_level=Cint(2), safepoint_on_entry=raw, gcstack_arg=raw))
-    d = _dump_function(f, types, false, false, raw, dump_module, :intel, optimize, debuginfo, false, params)
+function code_llvm end
+
+struct LLVMCode
+    str::String
+end
+
+function Base.show(io::IO, code::LLVMCode)
     if highlighting[:llvm] && get(io, :color, false)::Bool
-        print_llvm(io, d)
+        print_llvm(io, code.str)
     else
-        print(io, d)
+        print(io, code.str)
     end
 end
-code_llvm(args...; kwargs...) = (@nospecialize; code_llvm(stdout, args...; kwargs...))
+
+function code_llvm(@nospecialize(f), @nospecialize(types=Base.default_tt(f));
+    raw::Bool=false, dump_module::Bool=false, optimize::Bool=true, debuginfo::Symbol=:default,
+    params::CodegenParams=CodegenParams(debug_info_kind=Cint(0), debug_info_level=Cint(2), safepoint_on_entry=raw, gcstack_arg=raw))
+    d = _dump_function(f, types, false, false, raw, dump_module, :intel, optimize, debuginfo, false, params)
+    return LLVMCode(d)
+end
+
+code_llvm(io::IO, args...; kwargs...) = show(io, code_llvm(args...; kwargs...))
+
 
 """
     code_native([io=stdout,], f, types; syntax=:intel, debuginfo=:default, binary=false, dump_module=true)

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -730,3 +730,7 @@ end
     @test_broken isempty(undoc)
     @test undoc == [:InteractiveUtils]
 end
+
+@testset "code_llvm returns an object" begin
+    @test (@code_llvm sin(0.5)) isa InteractiveUtils.LLVMCode
+end


### PR DESCRIPTION
Motivation is i want `clipboard(@code_llvm foo())` to work. Which it currently doesn't as `@code_llvm foo()` returns `nothing` and just prints directly.

I suspect that the `code_*` functions are older than our current `show` infrastructure.
And they don't follow its conventions, that rather than printing directly, prefer returning objects that overload show.
This fixes it for `@code_llvm`, while leaving in place the methods that take an `IO` as the first argument