### PR TITLE
Add docstring for InteractiveUtils module

### DIFF
--- a/stdlib/InteractiveUtils/docs/src/index.md
+++ b/stdlib/InteractiveUtils/docs/src/index.md
@@ -4,7 +4,9 @@ EditURL = "https://github.com/JuliaLang/julia/blob/master/stdlib/InteractiveUtil
 
 # [Interactive Utilities](@id man-interactive-utils)
 
-This module is intended for interactive work. It is loaded automatically in [interactive mode](@ref command-line-interface).
+The `InteractiveUtils` module provides utilities for interactive use of Julia,
+such as code introspection and clipboard access.
+It is intended for interactive work and is loaded automatically in [interactive mode](@ref command-line-interface).
 
 ```@docs
 InteractiveUtils.apropos

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -1,5 +1,10 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+"""
+The `InteractiveUtils` module provides utilities for interactive use of Julia,
+such as code introspection and clipboard access.
+It is intended for interactive work and is loaded automatically in interactive mode.
+"""
 module InteractiveUtils
 
 Base.Experimental.@optlevel 1

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -726,7 +726,5 @@ end
 @test Base.infer_effects(sin, (Int,)) == InteractiveUtils.@infer_effects sin(42)
 
 @testset "Docstrings" begin
-    undoc = Docs.undocumented_names(InteractiveUtils)
-    @test_broken isempty(undoc)
-    @test undoc == [:InteractiveUtils]
+    @test isempty(Docs.undocumented_names(InteractiveUtils))
 end


### PR DESCRIPTION
Handles the `InteractiveUtils` part of https://github.com/JuliaLang/julia/issues/52725.

cc @stevengj 