### PR TITLE
Fix sortperm(::OffsetRange)

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -1393,7 +1393,7 @@ sort!(r::AbstractUnitRange) = r
 
 sort(r::AbstractRange) = issorted(r) ? r : reverse(r)
 
-sortperm(r::AbstractUnitRange) = eachindex(x)
+sortperm(r::AbstractUnitRange) = eachindex(r)
 sortperm(r::AbstractRange) = issorted(r) ? (firstindex(r):1:lastindex(r)) : (lastindex(r):-1:firstindex(r))
 
 function sum(r::AbstractRange{<:Real})

--- a/base/range.jl
+++ b/base/range.jl
@@ -1393,8 +1393,8 @@ sort!(r::AbstractUnitRange) = r
 
 sort(r::AbstractRange) = issorted(r) ? r : reverse(r)
 
-sortperm(r::AbstractUnitRange) = 1:length(r)
-sortperm(r::AbstractRange) = issorted(r) ? (1:1:length(r)) : (length(r):-1:1)
+sortperm(r::AbstractUnitRange) = eachindex(x)
+sortperm(r::AbstractRange) = issorted(r) ? (firstindex(r):1:lastindex(r)) : (lastindex(r):-1:firstindex(r))
 
 function sum(r::AbstractRange{<:Real})
     l = length(r)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -3,6 +3,9 @@
 using Base.Checked: checked_length
 using InteractiveUtils: code_llvm
 
+isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
+using .Main.OffsetArrays
+
 @testset "range construction" begin
     @test_throws ArgumentError range(start=1, step=1, stop=2, length=10)
     @test_throws ArgumentError range(start=1, step=1, stop=10, length=11)
@@ -545,6 +548,12 @@ end
         @test sort(1:10, rev=true) == 10:-1:1
         @test sort(-3:3, by=abs) == [0,-1,1,-2,2,-3,3]
         @test partialsort(1:10, 4) == 4
+
+        @testset "offset ranges" begin
+            x = OffsetArrays.IdOffsetRange(values=4:13, indices=4:13)
+            @test sort(x) === x === sort!(x)
+            @test sortperm(x) == eachindex(x)
+        end
     end
     @testset "in" begin
         @test 0 in UInt(0):100:typemax(UInt)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -553,6 +553,7 @@ end
             x = OffsetArrays.IdOffsetRange(values=4:13, indices=4:13)
             @test sort(x) === x === sort!(x)
             @test sortperm(x) == eachindex(x)
+            @test issorted(x[sortperm(x)])
         end
     end
     @testset "in" begin


### PR DESCRIPTION
I thought we required all `AbstractRange`s and `AbstractUnitRange`s to use one-based indexing, but can't find that documented anywhere so I guess these implementations are buggy.

If we do require all abstract ranges to have one-based indexing then the change to source is still appropriate, but the change to test should get some extra comments.