### PR TITLE
remove unnecessary size argument in LinearAlgebra.copy_similar

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -427,7 +427,7 @@ of the output corresponds to that of the three-argument method `similar(A, T, si
 
 See also: `copymutable_oftype`.
 """
-copy_similar(A::AbstractArray, ::Type{T}) where {T} = copyto!(similar(A, T, size(A)), A)
+copy_similar(A::AbstractArray, ::Type{T}) where {T} = copyto!(similar(A, T), A)
 
 
 include("adjtrans.jl")


### PR DESCRIPTION
The third argument passed by `copy_similar` to `similar` is unnecessary and implied anyway.

The problem with this is it breaks dispatch for packages that cant easily make similar arrays of  a new size without additional information, like DimensionalData.jl. If there is no size argument we can create the same wrapper array with the same type. If there is size, we have to assume it means a _different_ size, and fall back to the parent array type.
