### PR TITLE
build: ignore `SparseArrays` when set `USE_GPL_LIBS=0`

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -31,6 +31,7 @@ cd(joinpath(@__DIR__, "src")) do
         else
             sourcefile = joinpath(sourcefile, "index.md")
         end
+        # TODO: skip SuiteSparse
         if isfile(sourcefile)
             targetfile = joinpath("stdlib", dir * ".md")
             push!(STDLIB_DOCS, (stdlib = Symbol(dir), targetfile = targetfile))
@@ -311,12 +312,15 @@ for stdlib in STDLIB_DOCS
 end
 # A few standard libraries need more than just the module itself in the DocTestSetup.
 # This overwrites the existing ones from above though, hence the warn=false.
+if Base.USE_GPL_LIBS
 DocMeta.setdocmeta!(
     SparseArrays,
     :DocTestSetup,
     maybe_revise(:(using SparseArrays, LinearAlgebra));
     recursive=true, warn=false,
 )
+end
+
 DocMeta.setdocmeta!(
     UUIDs,
     :DocTestSetup,

--- a/pkgimage.mk
+++ b/pkgimage.mk
@@ -73,7 +73,9 @@ $(eval $(call stdlib_builder,Sockets,))
 $(eval $(call stdlib_builder,Unicode,))
 $(eval $(call stdlib_builder,Profile,))
 $(eval $(call stdlib_builder,StyledStrings,))
+ifeq ($(USE_GPL_LIBS), 1)
 $(eval $(call stdlib_builder,SuiteSparse_jll,))
+endif # USE_GPL_LIBS
 
 # 1-depth packages
 $(eval $(call stdlib_builder,GMP_jll,Artifacts Libdl))
@@ -131,5 +133,9 @@ $(eval $(call stdlib_builder,Pkg, Artifacts Dates Downloads FileWatching LibGit2
 # 7-depth packages
 $(eval $(call stdlib_builder,LazyArtifacts,Artifacts Pkg))
 
+ifeq ($(USE_GPL_LIBS), 1)
 $(eval $(call stdlib_builder,SparseArrays,Libdl LinearAlgebra Random Serialization SuiteSparse_jll))
 $(eval $(call stdlib_builder,Statistics,LinearAlgebra SparseArrays))
+else # NO GPL
+$(eval $(call stdlib_builder,Statistics,LinearAlgebra))
+endif # USE_GPL_LIBS

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -47,8 +47,11 @@ STDLIBS = Artifacts Base64 CRC32c Dates FileWatching \
           $(JLL_NAMES)
 
 STDLIBS_EXT = Pkg Statistics LazyArtifacts LibCURL DelimitedFiles Downloads ArgTools \
-              Tar NetworkOptions SuiteSparse SparseArrays StyledStrings SHA Distributed \
+              Tar NetworkOptions SuiteSparse StyledStrings SHA Distributed \
               JuliaSyntaxHighlighting
+ifeq ($(USE_GPL_LIBS), 1)
+STDLIBS_EXT += SparseArrays
+endif # USE_GPL_LIBS
 
 $(foreach module, $(STDLIBS_EXT), $(eval $(call stdlib-external,$(module),$(shell echo $(module) | tr a-z A-Z))))
 

--- a/stdlib/stdlib.mk
+++ b/stdlib/stdlib.mk
@@ -6,11 +6,13 @@ INDEPENDENT_STDLIBS := \
 	ArgTools Base64 CRC32c Dates DelimitedFiles Distributed Downloads Future \
 	InteractiveUtils JuliaSyntaxHighlighting LazyArtifacts LibGit2 LibCURL Logging \
     Markdown Mmap NetworkOptions Profile Printf Pkg REPL Serialization SharedArrays \
-    SparseArrays Statistics StyledStrings SuiteSparse_jll Tar Test TOML Unicode UUIDs \
+    Statistics StyledStrings Tar Test TOML Unicode UUIDs \
 	dSFMT_jll GMP_jll libLLVM_jll LLD_jll LLVMLibUnwind_jll LibUnwind_jll LibUV_jll \
 	LibCURL_jll LibSSH2_jll LibGit2_jll nghttp2_jll  MozillaCACerts_jll MbedTLS_jll \
 	MPFR_jll OpenLibm_jll PCRE2_jll p7zip_jll Zlib_jll
-
+ifeq ($(USE_GPL_LIBS), 1)
+INDEPENDENT_STDLIBS += SparseArrays SuiteSparse_jll
+endif # USE_GPL_LIBS
 
 STDLIBS := $(STDLIBS_WITHIN_SYSIMG) $(INDEPENDENT_STDLIBS)
 VERSDIR := v$(shell cut -d. -f1-2 < $(JULIAHOME)/VERSION)


### PR DESCRIPTION
fix #53211

TODO:
- [ ] Skip `SparseArrays` docs
- [ ] Skip `SparseArrays` tests
- [ ] Update `Statistics.jl`
	https://github.com/JuliaStats/Statistics.jl/blob/68869af06e8cdeb7aba1d5259de602da7328057f/src/Statistics.jl#L1096-L1099
