### PR TITLE
Guarantee `@assert` will not be removed

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -202,12 +202,7 @@ writing assertions, which are conditions that are assumed to be true, but that t
 might decide to check anyways, as an aid to debugging if they fail.
 The optional message `text` is displayed upon assertion failure.
 
-!!! warning
-    An assert might be disabled at some optimization levels.
-    Assert should therefore only be used as a debugging tool
-    and not used for authentication verification (e.g., verifying passwords or checking array bounds).
-    The code must not rely on the side effects of running `cond` for the correct behavior
-    of a function.
+The assertion will not be removed at any debug level and can be used for safety checks.
 
 # Examples
 ```jldoctest

--- a/base/error.jl
+++ b/base/error.jl
@@ -202,7 +202,7 @@ writing assertions, which are conditions that are assumed to be true, but that t
 might decide to check anyways, as an aid to debugging if they fail.
 The optional message `text` is displayed upon assertion failure.
 
-The assertion will not be removed at any debug level and can be used for safety checks.
+The assertion will not be removed at any optimization level and can be used for safety checks.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Several people have suggested that `@assert` should never be removed because too many people rely on it for correctness. This PR changes the docstring to guarantee that it will not be removed.


This PR is an alternative to `@check` from https://github.com/JuliaLang/julia/pull/41342.