### PR TITLE
Fix escaping of docstring in `@__DIR__`

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3548,10 +3548,10 @@ julia> cd("/home/JuliaUser") # working directory
 
 julia> # create script at /home/JuliaUser/Projects
        open("/home/JuliaUser/Projects/test.jl","w") do io
-           print(io, """
+           print(io, \"\"\"
                println("@__DIR__ = ", @__DIR__)
                println("pwd() = ", pwd())
-           """)
+           \"\"\")
        end
 
 julia> # outputs script directory and current working directory


### PR DESCRIPTION
This issue was introduced in #52442.
The markdown parser had issues with the triple-quotes.
Usually you can use quadruple-quotes to fix this, but
this does not appear to be supported, so we escape
each with backslash.

Here is the corrected docstring rendered:

```julia-repl
help?> @__DIR__
  @__DIR__ -> String

  Macro to obtain the absolute path of the current directory as a string.

  If in a script, returns the directory of the script containing the @__DIR__ macrocall. If run from a REPL or if
  evaluated by julia -e <expr>, returns the current working directory.

  Example
  ≡≡≡≡≡≡≡

  The example illustrates the difference in the behaviors of @__DIR__ and pwd(), by creating a simple script in a
  different directory than the current working one and executing both commands:

  julia> cd("/home/JuliaUser") # working directory

  julia> # create script at /home/JuliaUser/Projects
         open("/home/JuliaUser/Projects/test.jl","w") do io
             print(io, """
                 println("@__DIR__ = ", @__DIR__)
                 println("pwd() = ", pwd())
             """)
         end

  julia> # outputs script directory and current working directory
         include("/home/JuliaUser/Projects/test.jl")
  @__DIR__ = /home/JuliaUser/Projects
  pwd() = /home/JuliaUser
```
