### PR TITLE
Support escape expressions in @kwdef

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -60,7 +60,7 @@ function.
 
 include("bindings.jl")
 
-import .Base.Meta: quot, isexpr
+import .Base.Meta: quot, isexpr, unblock, unescape, uncurly
 import .Base: Callable, with_output_color
 using .Base: RefValue, mapany
 import ..CoreDocs: lazy_iterpolate
@@ -284,29 +284,6 @@ catdoc() = nothing
 catdoc(xs...) = vcat(xs...)
 
 const keywords = Dict{Symbol, DocStr}()
-
-function unblock(@nospecialize ex)
-    while isexpr(ex, :var"hygienic-scope")
-        isexpr(ex.args[1], :escape) || break
-        ex = ex.args[1].args[1]
-    end
-    isexpr(ex, :block) || return ex
-    exs = filter(ex -> !(isa(ex, LineNumberNode) || isexpr(ex, :line)), ex.args)
-    length(exs) == 1 || return ex
-    return unblock(exs[1])
-end
-
-# peek through ex to figure out what kind of expression it may eventually act like
-# but ignoring scopes and line numbers
-function unescape(@nospecialize ex)
-    ex = unblock(ex)
-    while isexpr(ex, :escape) || isexpr(ex, :var"hygienic-scope")
-       ex = unblock(ex.args[1])
-    end
-    return ex
-end
-
-uncurly(@nospecialize ex) = isexpr(ex, :curly) ? ex.args[1] : ex
 
 namify(@nospecialize x) = astname(x, isexpr(x, :macro))::Union{Symbol,Expr,GlobalRef}
 

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -496,7 +496,7 @@ function unescape(@nospecialize ex)
 end
 
 """
-    uncurly(expr)
+    Meta.uncurly(expr)
 
 Turn `T{P...}` into just `T`.
 """

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -16,10 +16,7 @@ export quot,
        ispostfixoperator,
        replace_sourceloc!,
        show_sexpr,
-       @dump,
-       unblock,
-       unescape,
-       uncurly
+       @dump
 
 using Base: isidentifier, isoperator, isunaryoperator, isbinaryoperator, ispostfixoperator
 import Base: isexpr

--- a/base/util.jl
+++ b/base/util.jl
@@ -563,23 +563,29 @@ Stacktrace:
 macro kwdef(expr)
     expr = macroexpand(__module__, expr) # to expand @static
     isexpr(expr, :struct) || error("Invalid usage of @kwdef")
-    T = expr.args[2]
+    _, T, fieldsblock = expr.args
     if T isa Expr && T.head === :<:
         T = T.args[1]
     end
 
-    params_ex = Expr(:parameters)
-    call_args = Any[]
+    fieldnames = Any[]
+    defvals = Any[]
+    extract_names_and_defvals_from_kwdef_fieldblock!(fieldsblock, fieldnames, defvals)
+    parameters = map(fieldnames, defvals) do fieldname, defval
+        if isnothing(defval)
+            return fieldname
+        else
+            return Expr(:kw, fieldname, esc(defval))
+        end
+    end
 
-    _kwdef!(expr.args[3], params_ex.args, call_args)
     # Only define a constructor if the type has fields, otherwise we'll get a stack
     # overflow on construction
-    if !isempty(params_ex.args)
+    if !isempty(parameters)
         T_no_esc,_ = strip_esc(T)
         if T_no_esc isa Symbol
-            sig = :(($(esc(T)))($params_ex))
-            call = :(($(esc(T)))($(call_args...)))
-            body = Expr(:block, __source__, call)
+            sig = Expr(:call, esc(T), Expr(:parameters, parameters...))
+            body = Expr(:block, __source__, Expr(:call, esc(T), fieldnames...))
             kwdefs = Expr(:function, sig, body)
         elseif isexpr(T_no_esc, :curly)
             # if T == S{A<:AA,B<:BB}, define two methods
@@ -589,11 +595,11 @@ macro kwdef(expr)
             P = T.args[2:end]
             Q = Any[isexpr(U, :<:) ? U.args[1] : U for U in P]
             SQ = :($S{$(Q...)})
-            body1 = Expr(:block, __source__, :(($(esc(S)))($(call_args...))))
-            sig1 = :(($(esc(S)))($params_ex))
+            body1 = Expr(:block, __source__, Expr(:call, esc(S), fieldnames...))
+            sig1 = Expr(:call, esc(S), Expr(:parameters, parameters...))
             def1 = Expr(:function, sig1, body1)
-            body2 = Expr(:block, __source__, :(($(esc(SQ)))($(call_args...))))
-            sig2 = :(($(esc(SQ)))($params_ex) where {$(esc.(P)...)})
+            body2 = Expr(:block, __source__, Expr(:call, esc(SQ), fieldnames...))
+            sig2 = :($(Expr(:call, esc(SQ), Expr(:parameters, parameters...))) where {$(esc.(P)...)})
             def2 = Expr(:function, sig2, body2)
             kwdefs = Expr(:block, def1, def2)
         else
@@ -610,58 +616,44 @@ end
 
 # @kwdef helper function
 # mutates arguments inplace
-function _kwdef!(blk, params_args, call_args, esc_count = 0)
-    for i in eachindex(blk.args)
-        ei = blk.args[i]
-        if ei isa Symbol
-            #  var
-            push!(params_args, ei)
-            push!(call_args, ei)
-        elseif ei isa Expr
-            is_atomic = ei.head === :atomic
-            ei = is_atomic ? first(ei.args) : ei # strip "@atomic" and add it back later
-            is_const = ei.head === :const
-            ei = is_const ? first(ei.args) : ei # strip "const" and add it back later
-            # Note: `@atomic const ..` isn't valid, but reconstruct it anyway to serve a nice error
-            if ei isa Symbol
-                # const var
-                push!(params_args, ei)
-                push!(call_args, ei)
-            elseif ei.head === :(=)
-                lhs = ei.args[1]
-                lhs_no_esc, lhs_esc_count = strip_esc(lhs)
-                if lhs_no_esc isa Symbol
-                    #  var = defexpr
-                    var = lhs_no_esc
-                elseif lhs_no_esc isa Expr && lhs_no_esc.head === :(::) && strip_esc(lhs_no_esc.args[1])[1] isa Symbol
-                    #  var::T = defexpr
-                    var = strip_esc(lhs_no_esc.args[1])[1]
-                else
-                    # something else, e.g. inline inner constructor
-                    #   F(...) = ...
-                    continue
+function extract_names_and_defvals_from_kwdef_fieldblock!(block, names, defvals)
+    for (i, item) in pairs(block.args)
+        if isexpr(item, :block)
+            extract_names_and_defvals_from_kwdef_fieldblock!(item, names, defvals)
+        elseif item isa Expr && item.head in (:escape, :var"hygienic-scope")
+            n = length(names)
+            extract_names_and_defvals_from_kwdef_fieldblock!(item, names, defvals)
+            for j in n+1:length(defvals)
+                if !isnothing(defvals[j])
+                    defvals[j] = Expr(item.head, defvals[j])
                 end
-                defexpr = ei.args[2]  # defexpr
-                defexpr = wrap_esc(defexpr, esc_count + lhs_esc_count)
-                push!(params_args, Expr(:kw, var, esc(defexpr)))
-                push!(call_args, var)
-                lhs = is_const ? Expr(:const, lhs) : lhs
-                lhs = is_atomic ? Expr(:atomic, lhs) : lhs
-                blk.args[i] = lhs # overrides arg
-            elseif ei.head === :(::) && strip_esc(ei.args[1])[1] isa Symbol
-                # var::Typ
-                var,_ = strip_esc(ei.args[1])
-                push!(params_args, var)
-                push!(call_args, var)
-            elseif ei.head === :block
-                # can arise with use of @static inside type decl
-                _kwdef!(ei, params_args, call_args)
-            elseif ei.head === :escape
-                _kwdef!(ei, params_args, call_args, esc_count + 1)
             end
+        else
+            def, name, defval = @something(def_name_defval_from_kwdef_fielddef(item), continue)
+            block.args[i] = def
+            push!(names, name)
+            push!(defvals, defval)
         end
     end
-    blk
+end
+
+function def_name_defval_from_kwdef_fielddef(kwdef)
+    if kwdef isa Symbol
+        return kwdef, kwdef, nothing
+    elseif isexpr(kwdef, :(::))
+        name, _ = kwdef.args
+        return kwdef, strip_esc(name)[1], nothing
+    elseif isexpr(kwdef, :(=))
+        lhs, rhs = kwdef.args
+        def, name, _ = @something(def_name_defval_from_kwdef_fielddef(lhs), return nothing)
+        return def, name, rhs
+    elseif kwdef isa Expr && kwdef.head in (:const, :atomic)
+        def, name, defval = @something(def_name_defval_from_kwdef_fielddef(kwdef.args[1]), return nothing)
+        return Expr(kwdef.head, def), name, defval
+    elseif kwdef isa Expr && kwdef.head in (:escape, :var"hygienic-scope")
+        def, name, defval = @something(def_name_defval_from_kwdef_fielddef(kwdef.args[1]), return nothing)
+        return Expr(kwdef.head, def), name, isnothing(defval) ? defval : Expr(kwdef.head, defval)
+    end
 end
 
 function strip_esc(expr)

--- a/base/util.jl
+++ b/base/util.jl
@@ -582,7 +582,7 @@ macro kwdef(expr)
     # Only define a constructor if the type has fields, otherwise we'll get a stack
     # overflow on construction
     if !isempty(parameters)
-        T_no_esc,_ = strip_esc(T)
+        T_no_esc = Meta.unescape(T)
         if T_no_esc isa Symbol
             sig = Expr(:call, esc(T), Expr(:parameters, parameters...))
             body = Expr(:block, __source__, Expr(:call, esc(T), fieldnames...))
@@ -642,7 +642,7 @@ function def_name_defval_from_kwdef_fielddef(kwdef)
         return kwdef, kwdef, nothing
     elseif isexpr(kwdef, :(::))
         name, _ = kwdef.args
-        return kwdef, strip_esc(name)[1], nothing
+        return kwdef, Meta.unescape(name), nothing
     elseif isexpr(kwdef, :(=))
         lhs, rhs = kwdef.args
         def, name, _ = @something(def_name_defval_from_kwdef_fielddef(lhs), return nothing)
@@ -654,22 +654,6 @@ function def_name_defval_from_kwdef_fielddef(kwdef)
         def, name, defval = @something(def_name_defval_from_kwdef_fielddef(kwdef.args[1]), return nothing)
         return Expr(kwdef.head, def), name, isnothing(defval) ? defval : Expr(kwdef.head, defval)
     end
-end
-
-function strip_esc(expr)
-    count = 0
-    while isexpr(expr, :escape)
-        expr = expr.args[1]
-        count += 1
-    end
-    return (expr, count)
-end
-
-function wrap_esc(expr, count)
-    for _ = 1:count
-        expr = esc(expr)
-    end
-    return expr
 end
 
 # testing

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1287,6 +1287,51 @@ end
     end
 end
 
+module KwdefWithEsc
+    const Int1 = Int
+    const val1 = 42
+    macro define_struct()
+        quote
+            @kwdef struct $(esc(:Struct))
+                a
+                b = val1
+                c::Int1
+                d::Int1 = val1
+
+                $(esc(quote
+                    e
+                    f = val2
+                    g::Int2
+                    h::Int2 = val2
+                end))
+
+                $(esc(:(i = val2)))
+                $(esc(:(j::Int2)))
+                $(esc(:(k::Int2 = val2)))
+
+                l::$(esc(:Int2))
+                m::$(esc(:Int2)) = val1
+
+                n = $(esc(:val2))
+                o::Int1 = $(esc(:val2))
+
+                $(esc(:p))
+                $(esc(:q)) = val1
+                $(esc(:s))::Int1
+                $(esc(:t))::Int1 = val1
+            end
+        end
+    end
+end
+
+module KwdefWithEsc_TestModule
+    using ..KwdefWithEsc
+    const Int2 = Int
+    const val2 = 42
+    KwdefWithEsc.@define_struct()
+end
+@test isdefined(KwdefWithEsc_TestModule, :Struct)
+
 @testset "exports of modules" begin
     for (_, mod) in Base.loaded_modules
         mod === Main && continue # Main exports everything


### PR DESCRIPTION
`@kwdef` currently does not handle escaped type names and default values correctly. This makes it impossible to write a (correctly escaped) macro that internally uses `@kwdef`:

```julia
julia> module M
       macro define_struct(name)
           quote
               @kwdef struct $(esc(name)) field::Int end
           end
       end
       end;

julia> @macroexpand M.@define_struct(Foo)
ERROR: Invalid usage of @kwdef
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] var"@kwdef"(__source__::LineNumberNode, __module__::Module, expr::Any)
   @ Base ./util.jl:603
 [3] #macroexpand#66
   @ Base ./expr.jl:122 [inlined]
 [4] top-level scope
   @ REPL[5]:1
```

This PR patches `@kwdef` so various types of escaping are handled correctly. Specifically, all of the following now works (see new test case [here](https://github.com/ettersi/julia/blob/adf7e20378ae7d0c3cf24a2cc3c815e560913b78/test/misc.jl#L1290-L1332)):

```julia
module KwdefWithEsc
    const Int1 = Int
    const val1 = 42
    macro define_struct()
        quote
            @kwdef struct $(esc(:Struct))
                a
                b = val1
                c::Int1
                d::Int1 = val1


                $(esc(quote
                    e
                    f = val2
                    g::Int2
                    h::Int2 = val2
                end))


                $(esc(:(i = val2)))
                $(esc(:(j::Int2)))
                $(esc(:(k::Int2 = val2)))


                l::$(esc(:Int2))
                m::$(esc(:Int2)) = val1


                n = $(esc(:val2))
                o::Int1 = $(esc(:val2))


                $(esc(:p))
                $(esc(:q)) = val1
                $(esc(:s))::Int1
                $(esc(:t))::Int1 = val1
            end
        end
    end
end


module KwdefWithEsc_TestModule
    using ..KwdefWithEsc
    const Int2 = Int
    const val2 = 42
    KwdefWithEsc.@define_struct()
end
```