### PR TITLE
Avoid allocations in views of views

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -282,8 +282,9 @@ reindex(::Tuple{}, ::Tuple{}) = ()
 
 _maybeview(A, i1::Integer, inds::Integer...) = (@_propagate_inbounds_meta; A[i1, inds...])
 function _maybeview(A, v...)
+    @_propagate_inbounds_meta
     B = view(A, v...)
-    B isa SubArray{<:Any, 0} ? B[] : B
+    iszero(ndims(B)) ? B[] : B
 end
 
 # Skip dropped scalars, so simply peel them off the parent indices and continue

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -280,7 +280,7 @@ AbstractZeroDimArray{T} = AbstractArray{T, 0}
 
 reindex(::Tuple{}, ::Tuple{}) = ()
 
-_maybeview(A, i1::Integer, inds::Integer...) = A[i1, inds...]
+_maybeview(A, i1::Integer, inds::Integer...) = (@_propagate_inbounds_meta; A[i1, inds...])
 function _maybeview(A, v...)
     B = view(A, v...)
     B isa SubArray{<:Any, 0} ? B[] : B

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -280,13 +280,6 @@ AbstractZeroDimArray{T} = AbstractArray{T, 0}
 
 reindex(::Tuple{}, ::Tuple{}) = ()
 
-_maybeview(A, i1::Integer, inds::Integer...) = (@_propagate_inbounds_meta; A[i1, inds...])
-function _maybeview(A, v...)
-    @_propagate_inbounds_meta
-    B = view(A, v...)
-    iszero(ndims(B)) ? B[] : B
-end
-
 # Skip dropped scalars, so simply peel them off the parent indices and continue
 reindex(idxs::Tuple{ScalarIndex, Vararg{Any}}, subidxs::Tuple{Vararg{Any}}) =
     (@_propagate_inbounds_meta; (idxs[1], reindex(tail(idxs), subidxs)...))
@@ -297,18 +290,18 @@ reindex(idxs::Tuple{Slice, Vararg{Any}}, subidxs::Tuple{Any, Vararg{Any}}) =
 
 # Re-index into parent vectors with one subindex
 reindex(idxs::Tuple{AbstractVector, Vararg{Any}}, subidxs::Tuple{Any, Vararg{Any}}) =
-    (@_propagate_inbounds_meta; (_maybeview(idxs[1], subidxs[1]), reindex(tail(idxs), tail(subidxs))...))
+    (@_propagate_inbounds_meta; (maybeview(idxs[1], subidxs[1]), reindex(tail(idxs), tail(subidxs))...))
 
 # Parent matrices are re-indexed with two sub-indices
 reindex(idxs::Tuple{AbstractMatrix, Vararg{Any}}, subidxs::Tuple{Any, Any, Vararg{Any}}) =
-    (@_propagate_inbounds_meta; (_maybeview(idxs[1], subidxs[1], subidxs[2]), reindex(tail(idxs), tail(tail(subidxs)))...))
+    (@_propagate_inbounds_meta; (maybeview(idxs[1], subidxs[1], subidxs[2]), reindex(tail(idxs), tail(tail(subidxs)))...))
 
 # In general, we index N-dimensional parent arrays with N indices
 @generated function reindex(idxs::Tuple{AbstractArray{T,N}, Vararg{Any}}, subidxs::Tuple{Vararg{Any}}) where {T,N}
     if length(subidxs.parameters) >= N
         subs = [:(subidxs[$d]) for d in 1:N]
         tail = [:(subidxs[$d]) for d in N+1:length(subidxs.parameters)]
-        :(@_propagate_inbounds_meta; (_maybeview(idxs[1], $(subs...)), reindex(tail(idxs), ($(tail...),))...))
+        :(@_propagate_inbounds_meta; (maybeview(idxs[1], $(subs...)), reindex(tail(idxs), ($(tail...),))...))
     else
         :(throw(ArgumentError("cannot re-index SubArray with fewer indices than dimensions\nThis should not occur; please submit a bug report.")))
     end

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -280,6 +280,12 @@ AbstractZeroDimArray{T} = AbstractArray{T, 0}
 
 reindex(::Tuple{}, ::Tuple{}) = ()
 
+_maybeview(A, i1::Integer, inds::Integer...) = A[i1, inds...]
+function _maybeview(A, v...)
+    B = view(A, v...)
+    B isa SubArray{<:Any, 0} ? B[] : B
+end
+
 # Skip dropped scalars, so simply peel them off the parent indices and continue
 reindex(idxs::Tuple{ScalarIndex, Vararg{Any}}, subidxs::Tuple{Vararg{Any}}) =
     (@_propagate_inbounds_meta; (idxs[1], reindex(tail(idxs), subidxs)...))
@@ -290,18 +296,18 @@ reindex(idxs::Tuple{Slice, Vararg{Any}}, subidxs::Tuple{Any, Vararg{Any}}) =
 
 # Re-index into parent vectors with one subindex
 reindex(idxs::Tuple{AbstractVector, Vararg{Any}}, subidxs::Tuple{Any, Vararg{Any}}) =
-    (@_propagate_inbounds_meta; (idxs[1][subidxs[1]], reindex(tail(idxs), tail(subidxs))...))
+    (@_propagate_inbounds_meta; (_maybeview(idxs[1], subidxs[1]), reindex(tail(idxs), tail(subidxs))...))
 
 # Parent matrices are re-indexed with two sub-indices
 reindex(idxs::Tuple{AbstractMatrix, Vararg{Any}}, subidxs::Tuple{Any, Any, Vararg{Any}}) =
-    (@_propagate_inbounds_meta; (idxs[1][subidxs[1], subidxs[2]], reindex(tail(idxs), tail(tail(subidxs)))...))
+    (@_propagate_inbounds_meta; (_maybeview(idxs[1], subidxs[1], subidxs[2]), reindex(tail(idxs), tail(tail(subidxs)))...))
 
 # In general, we index N-dimensional parent arrays with N indices
 @generated function reindex(idxs::Tuple{AbstractArray{T,N}, Vararg{Any}}, subidxs::Tuple{Vararg{Any}}) where {T,N}
     if length(subidxs.parameters) >= N
         subs = [:(subidxs[$d]) for d in 1:N]
         tail = [:(subidxs[$d]) for d in N+1:length(subidxs.parameters)]
-        :(@_propagate_inbounds_meta; (idxs[1][$(subs...)], reindex(tail(idxs), ($(tail...),))...))
+        :(@_propagate_inbounds_meta; (_maybeview(idxs[1], $(subs...)), reindex(tail(idxs), ($(tail...),))...))
     else
         :(throw(ArgumentError("cannot re-index SubArray with fewer indices than dimensions\nThis should not occur; please submit a bug report.")))
     end

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -1009,4 +1009,18 @@ end
     @test parentindices(av2) === (2,3)
     av2 = view(av, 2:2, 2:2)
     @test parentindices(av2) === (view(inds[1], 2:2), view(inds[2], 2:2))
+
+    inds = (reshape([eachindex(a);], size(a)),)
+    av = view(a, inds...)
+    av2 = view(av, 1, 1)
+    @test parentindices(av2) === (1,)
+    av2 = view(av, 2:2, 2:2)
+    @test parentindices(av2) === (view(inds[1], 2:2, 2:2),)
+
+    inds = (reshape([eachindex(a);], size(a)..., 1),)
+    av = view(a, inds...)
+    av2 = view(av, 1, 1, 1)
+    @test parentindices(av2) === (1,)
+    av2 = view(av, 2:2, 2:2, 1:1)
+    @test parentindices(av2) === (view(inds[1], 2:2, 2:2, 1:1),)
 end

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -999,3 +999,14 @@ end
 catch err
     err isa ErrorException && startswith(err.msg, "syntax:")
 end
+
+
+@testset "avoid allocating in reindex" begin
+    a = reshape(1:16, 4, 4)
+    inds = ([2,3], [3,4])
+    av = view(a, inds...)
+    av2 = view(av, 1, 1)
+    @test parentindices(av2) === (2,3)
+    av2 = view(av, 2:2, 2:2)
+    @test parentindices(av2) === (view(inds[1], 2:2), view(inds[2], 2:2))
+end


### PR DESCRIPTION
Currently, views-of-views construct their re-indexed indices by slicing into the parent indices. This PR changes this to use views of the parent indices instead. This makes the operation faster and non-allocating if the `parentindices` for the original view are `Vector`s.

```julia
julia> a = rand(200, 200);

julia> av = view(a, collect.(axes(a))...);

julia> @btime view($av, axes($av)...);
  312.393 ns (4 allocations: 3.25 KiB) # master
  7.354 ns (0 allocations: 0 bytes) # PR
```
Indexing into the resulting view seems equally fast in simple cases:
```julia
julia> av2 = view(av, axes(av)...);

julia> @btime sum($av2);
  66.883 μs (0 allocations: 0 bytes) # master
  66.888 μs (0 allocations: 0 bytes) # PR

julia> av2 = view(av, collect.(axes(av))...);

julia> @btime sum($av2);
  66.886 μs (0 allocations: 0 bytes) # master
  66.891 μs (0 allocations: 0 bytes) # PR
```