### PR TITLE
Chunked copy in copyto_unalised for nD Cartesian destination

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1119,7 +1119,7 @@ function copyto_unaliased!(deststyle::IndexStyle, dest::AbstractArray, srcstyle:
             end
         else
             # Dual-iterator implementation
-            if iterdest isa CartesianIndices && ndims(iterdest) > 1 && srcstyle isa IndexLinear
+            if iterdest isa CartesianIndices && ndims(iterdest) > 1 && itersrc isa AbstractUnitRange
                 iterdesttail = CartesianIndices(tail(iterdest.indices))
                 indsdestslice = first(iterdest.indices)
                 slicelen = length(indsdestslice)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1950,3 +1950,10 @@ end
     @test repeat(f, 2, 3, 4) === FillArrays.Fill(3, (8, 6, 4))
     @test repeat(f, inner=(1,2), outer=(3,1)) === FillArrays.Fill(3, (12, 4))
 end
+
+@testset "copyto! with matched CartesianIndices" begin
+    a = zeros(2, 2)
+    b = rand(size(a)...)
+    copyto!(view(a, axes(a)...), view(b, axes(b)...))
+    @test a == b
+end


### PR DESCRIPTION
The idea is that if the indices of the destination are `CartesianIndices((r1, r2))`, we may treat it as a collection of slices with indices `CartesianIndices((r1,))`, and possibly dispatch to the more efficient linear-indexing branch for the individual slices. The method is called recursively on the slices.

Performance comparisons:
```julia
julia> a = rand(200, 200); b = rand(size(a)...);

julia> @btime $a[axes($a)...] .= @view $b[axes($b)...];
  73.799 μs (0 allocations: 0 bytes) # master
  10.077 μs (0 allocations: 0 bytes) # PR

julia> @btime $a[axes($a)...] .= $b;
  38.515 μs (0 allocations: 0 bytes) # master
  10.155 μs (0 allocations: 0 bytes) # PR

julia> @btime $a[reverse.(axes($a))...] .= @view $b[axes($b)...];
  122.423 μs (0 allocations: 0 bytes) # master
  25.809 μs (0 allocations: 0 bytes) # PR

julia> @btime $a[reverse.(axes($a))...] .= @view $b[reverse.(axes($b))...];
  545.094 μs (0 allocations: 0 bytes) # master
  33.586 μs (0 allocations: 0 bytes) # PR
```
One concern is that constructing the `view`s may allocate in certain cases (see e.g. #53231):
```julia
julia> @btime $a[$(collect.(axes(a)))...] .= @view $b[$(collect(axes(b)))...];
  76.822 μs (7 allocations: 240 bytes) # master
  52.168 μs (407 allocations: 325.23 KiB) # PR
```