### PR TITLE
refactors `interpreter_exec.jl` further

### DIFF
--- a/test/compiler/interpreter_exec.jl
+++ b/test/compiler/interpreter_exec.jl
@@ -23,10 +23,15 @@ let m = Meta.@lower 1 + 1
     src.ssavaluetypes = nstmts
     src.ssaflags = fill(UInt8(0x00), nstmts)
     src.codelocs = fill(Int32(1), nstmts)
-    @assert !src.inferred
+    @test !src.inferred
     Core.Compiler.verify_ir(Core.Compiler.inflate_ir(src))
     global test29262 = true
     @test :a === @eval $m
+    compile_mode = @ccall jl_get_module_compile(@__MODULE__()::Module)::Cint
+    if compile_mode == 3
+        # implies `Base.Experimental.@compiler_options compile=min`
+        @test !src.inferred
+    end
     global test29262 = false
     @test :b === @eval $m
 end
@@ -64,9 +69,15 @@ let m = Meta.@lower 1 + 1
     src.ssavaluetypes = nstmts
     src.ssaflags = fill(UInt8(0x00), nstmts)
     src.codelocs = fill(Int32(1), nstmts)
+    @test !src.inferred
     Core.Compiler.verify_ir(Core.Compiler.inflate_ir(src))
     global test29262 = true
     @test (:b, :a, :c, :c) === @eval $m
+    compile_mode = @ccall jl_get_module_compile(@__MODULE__()::Module)::Cint
+    if compile_mode == 3
+        # implies `Base.Experimental.@compiler_options compile=min`
+        @test !src.inferred
+    end
     src.ssavaluetypes = nstmts
     global test29262 = false
     @test (:b, :a, :c, :b) === @eval $m
@@ -101,23 +112,15 @@ let m = Meta.@lower 1 + 1
     src.ssavaluetypes = nstmts
     src.ssaflags = fill(UInt8(0x00), nstmts)
     src.codelocs = fill(Int32(1), nstmts)
+    @test !src.inferred
     Core.Compiler.verify_ir(Core.Compiler.inflate_ir(src))
     global test29262 = true
     @test :a === @eval $m
+    compile_mode = @ccall jl_get_module_compile(@__MODULE__()::Module)::Cint
+    if compile_mode == 3
+        # implies `Base.Experimental.@compiler_options compile=min`
+        @test !src.inferred
+    end
     global test29262 = false
     @test :b === @eval $m
 end
-
-# https://github.com/JuliaLang/julia/issues/47065
-# `Core.Compiler.sort!` should be able to handle a big list
-let n = 1000
-    ex = :(return 1)
-    for _ in 1:n
-        ex = :(rand() < .1 && $(ex))
-    end
-    @eval global function f_1000_blocks()
-        $ex
-        return 0
-    end
-end
-@test f_1000_blocks() == 0

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1787,3 +1787,17 @@ let code = Any[
     @test !any(iscall((ir, getfield)), ir.stmts.stmt)
     @test length(ir.cfg.blocks[end].stmts) == 1
 end
+
+# https://github.com/JuliaLang/julia/issues/47065
+# `Core.Compiler.sort!` should be able to handle a big list
+let n = 1000
+    ex = :(return 1)
+    for _ in 1:n
+        ex = :(rand() < .1 && $(ex))
+    end
+    @eval global function f_1000_blocks()
+        $ex
+        return 0
+    end
+end
+@test f_1000_blocks() == 0

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -92,11 +92,15 @@ let cfg = CFG(BasicBlock[
     end
 end
 
-for compile in ("min", "yes")
-    cmd = `$(Base.julia_cmd()) --compile=$compile interpreter_exec.jl`
-    if !success(pipeline(Cmd(cmd, dir=@__DIR__); stdout=stdout, stderr=stderr))
-        error("Interpreter test failed, cmd : $cmd")
-    end
+# test code execution with the default compile-mode
+module CompilerExecTest
+include("interpreter_exec.jl")
+end
+
+# test code execution with the interpreter mode (compile=min)
+module InterpreterExecTest
+Base.Experimental.@compiler_options compile=min
+include("interpreter_exec.jl")
 end
 
 # PR #32145


### PR DESCRIPTION
This commit refines `interpreter_exec.jl` further, on top of #53218. In detail, by using `Base.Experimental.@compiler_options compile=min`, it's now possible to mimic the effect of `julia --compile=[min|yes]`. This commit is leveraging it and includes `interpreter_exec.jl` from `test/compiler/ssair.jl`, allowing us to get better stack traces and test summaries.

In addition, I've introduced several tests concerning the `src.inferred` values and have relocated the tests from #47066 within `interpreter_exec.jl` to `test/compiler/irpasses.jl`, since it is related to Julia-level compilation and not to interpreter execution.