### PR TITLE
Restrict vector indexing of views to 1-based ranges

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -338,7 +338,9 @@ function getindex(V::FastContiguousSubArray, i::Int)
 end
 # parents of FastContiguousSubArrays may support fast indexing with AbstractUnitRanges,
 # so we may just forward the indexing to the parent
-function getindex(V::FastContiguousSubArray, i::AbstractUnitRange{Int})
+# This may only be done for non-offset ranges, as the result would otherwise have offset axes
+const OneBasedRanges = Union{OneTo{Int}, UnitRange{Int}, Slice{OneTo{Int}}, IdentityUnitRange{OneTo{Int}}}
+function getindex(V::FastContiguousSubArray, i::OneBasedRanges)
     @inline
     @boundscheck checkbounds(V, i)
     @inbounds r = V.parent[V.offset1 .+ i]

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -864,3 +864,8 @@ end
     # this is fixed in #40038, so the evaluation of its CartesianIndices should work
     @test CartesianIndices(A) == CartesianIndices(B)
 end
+
+@testset "indexing views (#53249)" begin
+    v = view([1,2,3,4], :)
+    @test v[Base.IdentityUnitRange(2:3)] == OffsetArray(2:3, 2:3)
+end

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -489,6 +489,10 @@ end
                 inds2 = 3:2:5
                 d1 = @view a1[inds2]
                 @test d1[axes(d1,1)] == d1[:] == a1[inds2]
+
+                if a1 isa SubArray
+                    @test_throws MethodError a1[Base.IdentityUnitRange(2:3)]
+                end
             end
         end
 

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -489,10 +489,6 @@ end
                 inds2 = 3:2:5
                 d1 = @view a1[inds2]
                 @test d1[axes(d1,1)] == d1[:] == a1[inds2]
-
-                if a1 isa SubArray
-                    @test_throws MethodError a1[Base.IdentityUnitRange(2:3)]
-                end
             end
         end
 


### PR DESCRIPTION
This will be an offset array in general, so we need to restrict the method to 1-based ranges. This restores the behavior on `v"1.10"`.

The method was added in #45371