### PR TITLE
print types more verbosely in page profiler

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -317,9 +317,10 @@ $(BUILDDIR)/debuginfo.o $(BUILDDIR)/debuginfo.dbg.obj: $(addprefix $(SRCDIR)/,de
 $(BUILDDIR)/disasm.o $(BUILDDIR)/disasm.dbg.obj: $(SRCDIR)/debuginfo.h $(SRCDIR)/processor.h
 $(BUILDDIR)/gc-debug.o $(BUILDDIR)/gc-debug.dbg.obj: $(SRCDIR)/gc.h
 $(BUILDDIR)/gc-pages.o $(BUILDDIR)/gc-pages.dbg.obj: $(SRCDIR)/gc.h
-$(BUILDDIR)/gc.o $(BUILDDIR)/gc.dbg.obj: $(SRCDIR)/gc.h $(SRCDIR)/gc-heap-snapshot.h $(SRCDIR)/gc-alloc-profiler.h
+$(BUILDDIR)/gc.o $(BUILDDIR)/gc.dbg.obj: $(SRCDIR)/gc.h $(SRCDIR)/gc-heap-snapshot.h $(SRCDIR)/gc-alloc-profiler.h $(SRCDIR)/gc-page-profiler.h
 $(BUILDDIR)/gc-heap-snapshot.o $(BUILDDIR)/gc-heap-snapshot.dbg.obj: $(SRCDIR)/gc.h $(SRCDIR)/gc-heap-snapshot.h
 $(BUILDDIR)/gc-alloc-profiler.o $(BUILDDIR)/gc-alloc-profiler.dbg.obj: $(SRCDIR)/gc.h $(SRCDIR)/gc-alloc-profiler.h
+$(BUILDDIR)/gc-page-profiler.o $(BUILDDIR)/gc-page-profiler.dbg.obj: $(SRCDIR)/gc-page-profiler.h
 $(BUILDDIR)/init.o $(BUILDDIR)/init.dbg.obj: $(SRCDIR)/builtin_proto.h
 $(BUILDDIR)/interpreter.o $(BUILDDIR)/interpreter.dbg.obj: $(SRCDIR)/builtin_proto.h
 $(BUILDDIR)/jitlayers.o $(BUILDDIR)/jitlayers.dbg.obj: $(SRCDIR)/jitlayers.h $(SRCDIR)/llvm-codegen-shared.h

--- a/src/gc-page-profiler.c
+++ b/src/gc-page-profiler.c
@@ -20,6 +20,8 @@ gc_page_profiler_serializer_t gc_page_serializer_create(void) JL_NOTSAFEPOINT
     gc_page_profiler_serializer_t serializer;
     if (__unlikely(page_profile_enabled)) {
         arraylist_new(&serializer.typestrs, GC_PAGE_SZ);
+        serializer.buffers = (char *)malloc_s(GC_PAGE_PROFILER_SERIALIZER_INIT_CAPACITY);
+        serializer.cursor = 0;
     }
     else {
         serializer.typestrs.len = 0;
@@ -34,6 +36,8 @@ void gc_page_serializer_init(gc_page_profiler_serializer_t *serializer,
         serializer->typestrs.len = 0;
         serializer->data = (char *)pg->data;
         serializer->osize = pg->osize;
+        serializer->cursor = 0;
+        serializer->capacity = GC_PAGE_PROFILER_SERIALIZER_INIT_CAPACITY;
     }
 }
 
@@ -41,6 +45,7 @@ void gc_page_serializer_destroy(gc_page_profiler_serializer_t *serializer) JL_NO
 {
     if (__unlikely(page_profile_enabled)) {
         arraylist_free(&serializer->typestrs);
+        free(serializer->buffers);
     }
 }
 
@@ -71,8 +76,9 @@ void gc_page_profile_write_preamble(gc_page_profiler_serializer_t *serializer)
     JL_NOTSAFEPOINT
 {
     if (__unlikely(page_profile_enabled)) {
-        char str[GC_TYPE_STR_MAXLEN];
-        snprintf(str, GC_TYPE_STR_MAXLEN,
+        const size_t large_enough_str_size = 4096;
+        char str[large_enough_str_size];
+        snprintf(str, large_enough_str_size,
                  "{\"address\": \"%p\",\"object_size\": %d,\"objects\": [",
                  serializer->data, serializer->osize);
         ios_write(page_profile_stream, str, strlen(str));
@@ -102,22 +108,27 @@ void gc_page_profile_write_comma(gc_page_profiler_serializer_t *serializer) JL_N
 void gc_page_profile_write_to_file(gc_page_profiler_serializer_t *serializer)
     JL_NOTSAFEPOINT
 {
+    size_t large_enough_str_size = 4096;
     if (__unlikely(page_profile_enabled)) {
         // write to file
         uv_mutex_lock(&page_profile_lock);
         gc_page_profile_write_comma(serializer);
         gc_page_profile_write_preamble(serializer);
-        char str[GC_TYPE_STR_MAXLEN];
+        char *str = (char *)malloc_s(large_enough_str_size);
         for (size_t i = 0; i < serializer->typestrs.len; i++) {
             const char *name = (const char *)serializer->typestrs.items[i];
             if (name == GC_SERIALIZER_EMPTY) {
-                snprintf(str, GC_TYPE_STR_MAXLEN, "\"empty\",");
+                snprintf(str, large_enough_str_size, "\"empty\",");
             }
             else if (name == GC_SERIALIZER_GARBAGE) {
-                snprintf(str, GC_TYPE_STR_MAXLEN, "\"garbage\",");
+                snprintf(str, large_enough_str_size, "\"garbage\",");
             }
             else {
-                snprintf(str, GC_TYPE_STR_MAXLEN, "\"%s\",", name);
+                while ((strlen(name) + 1) > large_enough_str_size) {
+                    large_enough_str_size *= 2;
+                    str = (char *)realloc_s(str, large_enough_str_size);
+                }
+                snprintf(str, large_enough_str_size, "\"%s\",", name);
             }
             // remove trailing comma for last element
             if (i == serializer->typestrs.len - 1) {
@@ -125,6 +136,7 @@ void gc_page_profile_write_to_file(gc_page_profiler_serializer_t *serializer)
             }
             ios_write(page_profile_stream, str, strlen(str));
         }
+        free(str);
         gc_page_profile_write_epilogue(serializer);
         page_profile_pages_written++;
         uv_mutex_unlock(&page_profile_lock);

--- a/src/gc-page-profiler.h
+++ b/src/gc-page-profiler.h
@@ -9,22 +9,29 @@
 extern "C" {
 #endif
 
-#define GC_TYPE_STR_MAXLEN (512)
+#define GC_PAGE_PROFILER_SERIALIZER_INIT_CAPACITY (4096)
 
 typedef struct {
     arraylist_t typestrs;
     char *data;
     int osize;
+    char *buffers;
+    size_t cursor;
+    size_t capacity;
 } gc_page_profiler_serializer_t;
 
 // mutex for page profile
 extern uv_mutex_t page_profile_lock;
+// whether page profiling is enabled
+extern int page_profile_enabled;
 
 // Serializer functions
 gc_page_profiler_serializer_t gc_page_serializer_create(void) JL_NOTSAFEPOINT;
-void gc_page_serializer_init(gc_page_profiler_serializer_t *serializer, jl_gc_pagemeta_t *pg) JL_NOTSAFEPOINT;
+void gc_page_serializer_init(gc_page_profiler_serializer_t *serializer,
+                             jl_gc_pagemeta_t *pg) JL_NOTSAFEPOINT;
 void gc_page_serializer_destroy(gc_page_profiler_serializer_t *serializer) JL_NOTSAFEPOINT;
-void gc_page_serializer_write(gc_page_profiler_serializer_t *serializer, const char *str) JL_NOTSAFEPOINT;
+void gc_page_serializer_write(gc_page_profiler_serializer_t *serializer,
+                              const char *str) JL_NOTSAFEPOINT;
 // Page profile functions
 #define GC_SERIALIZER_EMPTY ((const char *)0x1)
 #define GC_SERIALIZER_GARBAGE ((const char *)0x2)
@@ -42,13 +49,89 @@ STATIC_INLINE void gc_page_profile_write_garbage(gc_page_profiler_serializer_t *
         gc_page_serializer_write(serializer, GC_SERIALIZER_GARBAGE);
     }
 }
+STATIC_INLINE char *gc_page_profile_request_buffer(gc_page_profiler_serializer_t *serializer, size_t size) JL_NOTSAFEPOINT
+{
+    while (serializer->cursor + size >= serializer->capacity) {
+        serializer->capacity *= 2;
+        serializer->buffers = (char *)realloc_s(serializer->buffers, serializer->capacity);
+    }
+    char *p = &serializer->buffers[serializer->cursor];
+    memset(p, 0, size);
+    serializer->cursor += size;
+    return p;
+}
 STATIC_INLINE void gc_page_profile_write_live_obj(gc_page_profiler_serializer_t *serializer,
                                                   jl_taggedvalue_t *v,
                                                   int enabled) JL_NOTSAFEPOINT
 {
     if (__unlikely(enabled)) {
-        const char *name = jl_typeof_str(jl_valueof(v));
-        gc_page_serializer_write(serializer, name);
+        jl_value_t *a = jl_valueof(v);
+        jl_value_t *t = jl_typeof(a);
+        ios_t str_;
+        int ios_need_close = 0;
+        char *type_name = NULL;
+        char *type_name_in_serializer = NULL;
+        if (t == (jl_value_t *)jl_get_buff_tag()) {
+            type_name = "Buffer";
+            type_name_in_serializer =
+                gc_page_profile_request_buffer(serializer, strlen(type_name) + 1);
+            strcpy(type_name_in_serializer, type_name);
+        }
+        else if (jl_is_string(a)) {
+            type_name = "String";
+            type_name_in_serializer =
+                gc_page_profile_request_buffer(serializer, strlen(type_name) + 1);
+            strcpy(type_name_in_serializer, type_name);
+        }
+        else if (jl_is_symbol(a)) {
+            type_name = jl_symbol_name((jl_sym_t *)a);
+            type_name_in_serializer =
+                gc_page_profile_request_buffer(serializer, strlen(type_name) + 1);
+            strcpy(type_name_in_serializer, type_name);
+        }
+        else if (jl_is_simplevector(a)) {
+            type_name = "SimpleVector";
+            type_name_in_serializer =
+                gc_page_profile_request_buffer(serializer, strlen(type_name) + 1);
+            strcpy(type_name_in_serializer, type_name);
+        }
+        else if (jl_is_module(a)) {
+            type_name = jl_symbol_name_(((jl_module_t *)a)->name);
+            type_name_in_serializer =
+                gc_page_profile_request_buffer(serializer, strlen(type_name) + 1);
+            strcpy(type_name_in_serializer, type_name);
+        }
+        else if (jl_is_task(a)) {
+            type_name = "Task";
+            type_name_in_serializer =
+                gc_page_profile_request_buffer(serializer, strlen(type_name) + 1);
+            strcpy(type_name_in_serializer, type_name);
+        }
+        else if (jl_is_datatype(a)) {
+            ios_need_close = 1;
+            ios_mem(&str_, 0);
+            JL_STREAM *str = (JL_STREAM *)&str_;
+            jl_static_show(str, a);
+            type_name = str_.buf;
+            type_name_in_serializer =
+                gc_page_profile_request_buffer(serializer, str_.size + 1);
+            memcpy(type_name_in_serializer, type_name, str_.size);
+        }
+        else {
+            ios_need_close = 1;
+            ios_mem(&str_, 0);
+            JL_STREAM *str = (JL_STREAM *)&str_;
+            jl_static_show(str, t);
+            type_name = str_.buf;
+            type_name_in_serializer =
+                gc_page_profile_request_buffer(serializer, str_.size + 1);
+            memcpy(type_name_in_serializer, type_name, str_.size);
+        }
+        gc_page_serializer_write(serializer, type_name_in_serializer);
+        if (ios_need_close) {
+            ios_close(&str_);
+        }
+        jl_may_leak(type_name_in_serializer);
     }
 }
 void gc_enable_page_profile(void) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -536,7 +536,7 @@ JL_DLLEXPORT jl_value_t *jl_gc_alloc(jl_ptls_t ptls, size_t sz, void *ty);
 // defined as uint64_t[3] so that we can get the right alignment of this and a "type tag" on it
 const extern uint64_t _jl_buff_tag[3];
 #define jl_buff_tag ((uintptr_t)LLT_ALIGN((uintptr_t)&_jl_buff_tag[1],16))
-JL_DLLEXPORT uintptr_t jl_get_buff_tag(void);
+JL_DLLEXPORT uintptr_t jl_get_buff_tag(void) JL_NOTSAFEPOINT;
 
 typedef void jl_gc_tracked_buffer_t; // For the benefit of the static analyzer
 STATIC_INLINE jl_gc_tracked_buffer_t *jl_gc_alloc_buf(jl_ptls_t ptls, size_t sz)


### PR DESCRIPTION
Instead of just printing `Tuple`, print the full type signature such as `Tuple{UnionAll, GenericMemory{:not_atomic, Tuple{Int64, Int64, Array{Pair{Any, Any}, 1}}, Core.AddrSpace{Core}(0x00)}, Int64}`