### PR TITLE
Truecolor terminal capability detection for Windows

### DIFF
--- a/base/terminfo.jl
+++ b/base/terminfo.jl
@@ -332,15 +332,15 @@ Multiple conditions are taken as signifying truecolor support, specifically any 
     unable to resolve the fragmentation in the terminal ecosystem.
 """
 function ttyhastruecolor()
-    @static if Sys.iswindows()
-        is_windows_console = ccall( (:GetConsoleWindow, "kernel32"), stdcall, UInt32, () ) != UInt32(0) # See <https://learn.microsoft.com/en-us/windows/console/getconsolewindow>
-        return Sys.windows_version() ≥ v"10.0.14931" && is_windows_console # See <https://devblogs.microsoft.com/commandline/24-bit-color-in-the-windows-console/>
-    end
     # Lasciate ogne speranza, voi ch'intrate
     get(ENV, "COLORTERM", "") ∈ ("truecolor", "24bit") ||
         get(current_terminfo, :RGB, false) || get(current_terminfo, :Tc, false) ||
         (haskey(current_terminfo, :setrgbf) && haskey(current_terminfo, :setrgbb)) ||
         @static if Sys.isunix() get(current_terminfo, :colors, 0) > 256 else false end ||
+        @static if Sys.iswindows()
+            is_windows_console = ccall((:GetConsoleWindow, "kernel32"), stdcall, UInt32, () ) != UInt32(0) # See <https://learn.microsoft.com/en-us/windows/console/getconsolewindow>
+            Sys.windows_version() ≥ v"10.0.14931" && is_windows_console # See <https://devblogs.microsoft.com/commandline/24-bit-color-in-the-windows-console/>
+        else false end ||
         something(tryparse(Int, get(ENV, "VTE_VERSION", "")), 0) >= 3600 || # Per GNOME bug #685759 <https://bugzilla.gnome.org/show_bug.cgi?id=685759>
         haskey(ENV, "XTERM_VERSION") ||
         get(ENV, "TERMINAL_PROGRAM", "") == "iTerm.app" || # Why does Apple need to be special?

--- a/base/terminfo.jl
+++ b/base/terminfo.jl
@@ -337,10 +337,7 @@ function ttyhastruecolor()
         get(current_terminfo, :RGB, false) || get(current_terminfo, :Tc, false) ||
         (haskey(current_terminfo, :setrgbf) && haskey(current_terminfo, :setrgbb)) ||
         @static if Sys.isunix() get(current_terminfo, :colors, 0) > 256 else false end ||
-        @static if Sys.iswindows()
-            is_windows_console = ccall((:GetConsoleWindow, "kernel32"), stdcall, UInt32, () ) != UInt32(0) # See <https://learn.microsoft.com/en-us/windows/console/getconsolewindow>
-            Sys.windows_version() ≥ v"10.0.14931" && is_windows_console # See <https://devblogs.microsoft.com/commandline/24-bit-color-in-the-windows-console/>
-        else false end ||
+        (Sys.iswindows() && Sys.windows_version() ≥ v"10.0.14931") || # See <https://devblogs.microsoft.com/commandline/24-bit-color-in-the-windows-console/>
         something(tryparse(Int, get(ENV, "VTE_VERSION", "")), 0) >= 3600 || # Per GNOME bug #685759 <https://bugzilla.gnome.org/show_bug.cgi?id=685759>
         haskey(ENV, "XTERM_VERSION") ||
         get(ENV, "TERMINAL_PROGRAM", "") == "iTerm.app" || # Why does Apple need to be special?

--- a/base/terminfo.jl
+++ b/base/terminfo.jl
@@ -332,6 +332,10 @@ Multiple conditions are taken as signifying truecolor support, specifically any 
     unable to resolve the fragmentation in the terminal ecosystem.
 """
 function ttyhastruecolor()
+    @static if Sys.iswindows()
+        is_windows_console = ccall( (:GetConsoleWindow, "kernel32"), stdcall, UInt32, () ) != UInt32(0) # See <https://learn.microsoft.com/en-us/windows/console/getconsolewindow>
+        return Sys.windows_version() ≥ v"10.0.14931" && is_windows_console # See <https://devblogs.microsoft.com/commandline/24-bit-color-in-the-windows-console/>
+    end
     # Lasciate ogne speranza, voi ch'intrate
     get(ENV, "COLORTERM", "") ∈ ("truecolor", "24bit") ||
         get(current_terminfo, :RGB, false) || get(current_terminfo, :Tc, false) ||


### PR DESCRIPTION
```
for i in 0:255
    print("\x1b[38;2;$i;0;0m█")
end
```
shows on Windows Terminal
![image](https://github.com/JuliaLang/julia/assets/7318249/d742b739-9645-4daa-8572-d4c28803013e)
so it does have true-color support.
With this PR, `Base.ttyhastruecolor()` returns `true` on Windows Terminal and Cygwin64 Terminal, those are the ones I tried out.

Notes:

https://devblogs.microsoft.com/commandline/24-bit-color-in-the-windows-console/ says
> in Windows 10 Insiders Build # 14931, we’ve updated the Windows Console to support full, glorious 24-bit RGB true color!

https://learn.microsoft.com/en-us/windows/console/getconsolewindow says
> We do not recommend using this content in new products, but we will continue to support existing usages for the indefinite future.
