### PR TITLE
Mark codeinstance.specsigflags as atomic

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3311,7 +3311,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             //"absolute_max",
                             "ipo_purity_bits", "purity_bits",
                             "analysis_results",
-                            "isspecsig", "precompile", "relocatability",
+                            "specsigflags", "precompile", "relocatability",
                             "invoke", "specptr"), // function object decls
                         jl_svec(17,
                             jl_method_instance_type,

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3335,7 +3335,7 @@ void jl_init_types(void) JL_GC_DISABLED
                         0, 1, 1);
     jl_svecset(jl_code_instance_type->types, 2, jl_code_instance_type);
     const static uint32_t code_instance_constfields[1]  = { 0b00000101011100011 }; // Set fields 1, 2, 6-8, 10, 12 as const
-    const static uint32_t code_instance_atomicfields[1] = { 0b11010010100011100 }; // Set fields 3-5, 9, 11, 14, 16-17 as atomic
+    const static uint32_t code_instance_atomicfields[1] = { 0b11011010100011100 }; // Set fields 3-5, 9, 11, 13-14, 16-17 as atomic
     //Fields 4-5 are only operated on by construction and deserialization, so are const at runtime
     //Fields 12 and 16 must be protected by locks, and thus all operations on jl_code_instance_t are threadsafe
     jl_code_instance_type->name->constfields = code_instance_constfields;

--- a/test/core.jl
+++ b/test/core.jl
@@ -32,7 +32,7 @@ end
 # sanity tests that our built-in types are marked correctly for atomic fields
 for (T, c) in (
         (Core.CodeInfo, []),
-        (Core.CodeInstance, [:next, :min_world, :max_world, :inferred, :purity_bits, :invoke, :specptr, :precompile]),
+        (Core.CodeInstance, [:next, :min_world, :max_world, :inferred, :purity_bits, :invoke, :specptr, :specsigflags, :precompile]),
         (Core.Method, [:primary_world, :deleted_world]),
         (Core.MethodInstance, [:uninferred, :cache, :precompiled]),
         (Core.MethodTable, [:defs, :leafcache, :cache, :max_args]),


### PR DESCRIPTION
A correctness fix from #53255

This shouldn't matter much as that field is
only accessed from the runtime, but this
synchronizes the C-header definition, with
the Julia native definition.


