### PR TITLE
Prefer `# Examples` in docstrings

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -416,7 +416,7 @@ end
 Update `d`, removing elements for which `f` is `false`.
 The function `f` is passed `key=>value` pairs.
 
-# Example
+# Examples
 ```jldoctest
 julia> d = Dict(1=>"a", 2=>"b", 3=>"c")
 Dict{Int64, String} with 3 entries:

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -115,7 +115,7 @@ Generate a function call expression with keyword arguments `kw...`. As
 in the case of [`@ncall`](@ref), `sym` represents any number of function arguments, the
 last of which may be an anonymous-function expression and is expanded into `N` arguments.
 
-# Example
+# Examples
 ```jldoctest
 julia> using Base.Cartesian
 

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1097,7 +1097,7 @@ second is used for rounding the imaginary components.
 which rounds to the nearest integer, with ties (fractional values of 0.5)
 being rounded to the nearest even integer.
 
-# Example
+# Examples
 ```jldoctest
 julia> round(3.14 + 4.5im)
 3.0 + 4.0im

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -90,7 +90,7 @@ f(y) = [x for x in y]
     standard ones) on type-inference. Use [`Base.@nospecializeinfer`](@ref) together with
     `@nospecialize` to additionally suppress inference.
 
-# Example
+# Examples
 
 ```julia
 julia> f(A::AbstractArray) = g(A)

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -254,7 +254,7 @@ When issuing a hint, the output should typically start with `\\n`.
 If you define custom exception types, your `showerror` method can
 support hints by calling [`Experimental.show_error_hints`](@ref).
 
-# Example
+# Examples
 
 ```
 julia> module Hinter

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -831,7 +831,7 @@ end
 Tells the compiler to infer `f` using the declared types of `@nospecialize`d arguments.
 This can be used to limit the number of compiler-generated specializations during inference.
 
-# Example
+# Examples
 
 ```julia
 julia> f(A::AbstractArray) = g(A)

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -70,7 +70,6 @@ end
 A finalizer may be registered at object construction. In the following example note that
 we implicitly rely on the finalizer returning the newly created mutable struct `x`.
 
-# Example
 ```julia
 mutable struct MyMutableStruct
     bar

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -464,7 +464,7 @@ julia> extrema(b)
 
 Return a `LinearIndices` array with the specified shape or [`axes`](@ref).
 
-# Example
+# Examples
 
 The main purpose of this constructor is intuitive conversion
 from cartesian to linear indexing:

--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -130,7 +130,7 @@ end
 Wrapper for usage with `do` blocks to automatically close the dynamic library once
 control flow leaves the `do` block scope.
 
-# Example
+# Examples
 ```julia
 vendor = dlopen("libblas") do lib
     if Libdl.dlsym(lib, :openblas_set_num_threads; throw_error=false) !== nothing
@@ -234,7 +234,7 @@ end
 
 Get the full path of the library `libname`.
 
-# Example
+# Examples
 ```julia-repl
 julia> dlpath("libjulia")
 ```

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2335,7 +2335,7 @@ and return the value of the last expression.
 The optional `args` argument can be used to set the input arguments of the script (i.e. the global `ARGS` variable).
 Note that definitions (e.g. methods, globals) are evaluated in the anonymous module and do not affect the current module.
 
-# Example
+# Examples
 
 ```jldoctest
 julia> write("testfile.jl", \"\"\"
@@ -3558,7 +3558,7 @@ Macro to obtain the absolute path of the current directory as a string.
 If in a script, returns the directory of the script containing the `@__DIR__` macrocall. If run from a
 REPL or if evaluated by `julia -e <expr>`, returns the current working directory.
 
-# Example
+# Examples
 
 The example illustrates the difference in the behaviors of `@__DIR__` and `pwd()`, by creating
 a simple script in a different directory than the current working one and executing both commands:

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -608,7 +608,7 @@ end
 
 Execute `function`, directing all log messages to `logger`.
 
-# Example
+# Examples
 
 ```julia
 function test(x)

--- a/base/math.jl
+++ b/base/math.jl
@@ -177,7 +177,7 @@ a Goertzel-like [^DK62] algorithm if `x` is complex.
 !!! compat "Julia 1.4"
     This function requires Julia 1.4 or later.
 
-# Example
+# Examples
 ```jldoctest
 julia> evalpoly(2, (1, 2, 3))
 17

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1242,7 +1242,7 @@ it into the original function. This is useful as an adaptor to pass a
 multi-argument function in a context that expects a single argument, but passes
 a tuple as that single argument.
 
-# Example usage:
+# Examples
 ```jldoctest
 julia> map(splat(+), zip(1:3,4:6))
 3-element Vector{Int64}:

--- a/base/path.jl
+++ b/base/path.jl
@@ -435,11 +435,11 @@ normpath(a::AbstractString, b::AbstractString...) = normpath(joinpath(a,b...))
 Convert a path to an absolute path by adding the current directory if necessary.
 Also normalizes the path as in [`normpath`](@ref).
 
-# Example
+# Examples
 
 If you are in a directory called `JuliaExample` and the data you are using is two levels up relative to the `JuliaExample` directory, you could write:
 
-abspath("../../data")
+    abspath("../../data")
 
 Which gives a path like `"/home/JuliaUser/data/"`.
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1061,7 +1061,7 @@ fieldtypes(T::Type) = (@_foldable_meta; ntupleany(i -> fieldtype(T, i), fieldcou
 Return a collection of all instances of the given type, if applicable. Mostly used for
 enumerated types (see `@enum`).
 
-# Example
+# Examples
 ```jldoctest
 julia> @enum Color red blue green
 
@@ -1555,7 +1555,7 @@ internals.
 - `interp::Core.Compiler.AbstractInterpreter = Core.Compiler.NativeInterpreter(world)`:
   optional, controls the abstract interpreter to use, use the native interpreter if not specified.
 
-# Example
+# Examples
 
 One can put the argument types in a tuple to get the corresponding `code_typed`.
 
@@ -1663,7 +1663,7 @@ internals.
   If it is an integer, it specifies the number of passes to run.
   If it is `nothing` (default), all passes are run.
 
-# Example
+# Examples
 
 One can put the argument types in a tuple to get the corresponding `code_ircode`.
 
@@ -1761,7 +1761,7 @@ candidates for `f` and `types` (see also [`methods(f, types)`](@ref methods).
   methods matching with the given `f` and `types`. The list's order matches the order
   returned by `methods(f, types)`.
 
-# Example
+# Examples
 
 ```julia
 julia> Base.return_types(sum, Tuple{Vector{Int}})
@@ -1830,7 +1830,7 @@ Returns an inferred return type of the function call specified by `f` and `types
     It returns a single return type, taking into account all potential outcomes of
     any function call entailed by the given signature type.
 
-# Example
+# Examples
 
 ```julia
 julia> checksym(::Symbol) = :symbol;
@@ -1901,7 +1901,7 @@ It works like [`Base.return_types`](@ref), but it infers the exception types ins
   methods matching with the given `f` and `types`. The list's order matches the order
   returned by `methods(f, types)`.
 
-# Example
+# Examples
 
 ```julia
 julia> throw_if_number(::Number) = error("number is given");
@@ -1984,7 +1984,7 @@ Returns the type of exception potentially thrown by the function call specified 
     It returns a single exception type, taking into account all potential outcomes of
     any function call entailed by the given signature type.
 
-# Example
+# Examples
 
 ```julia
 julia> f1(x) = x * 2;
@@ -2068,7 +2068,7 @@ Returns the possible computation effects of the function call specified by `f` a
     It returns a single effect, taking into account all potential outcomes of any function
     call entailed by the given signature type.
 
-# Example
+# Examples
 
 ```julia
 julia> f1(x) = x * 2;

--- a/base/secretbuffer.jl
+++ b/base/secretbuffer.jl
@@ -200,7 +200,7 @@ resetting its pointer and size.
 This function is used to securely erase the sensitive data held in the buffer,
 reducing the potential for information leaks.
 
-# Example
+# Examples
 ```julia
 s = SecretBuffer()
 write(s, 's', 'e', 'c', 'r', 'e', 't')

--- a/base/shell.jl
+++ b/base/shell.jl
@@ -416,7 +416,7 @@ rather than returned as a string.
 
 See also [`escape_microsoft_c_args`](@ref), [`shell_escape_posixly`](@ref).
 
-# Example
+# Examples
 ```jldoctest
 julia> Base.shell_escape_wincmd("a^\\"^o\\"^u\\"")
 "a^^\\"^o\\"^^u^\\""

--- a/base/show.jl
+++ b/base/show.jl
@@ -3174,7 +3174,7 @@ representing argument `x` in terms of its type. (The double-colon is
 omitted if `toplevel=true`.) However, you can
 specialize this function for specific types to customize printing.
 
-# Example
+# Examples
 
 A SubArray created as `view(a, :, 3, 2:5)`, where `a` is a
 3-dimensional Float64 array, has type

--- a/base/slicearray.jl
+++ b/base/slicearray.jl
@@ -96,7 +96,7 @@ See also [`eachrow`](@ref), [`eachcol`](@ref), [`mapslices`](@ref) and [`selectd
 !!! compat "Julia 1.9"
      Prior to Julia 1.9, this returned an iterator, and only a single dimension `dims` was supported.
 
-# Example
+# Examples
 
 ```jldoctest
 julia> m = [1 2 3; 4 5 6; 7 8 9]
@@ -144,7 +144,7 @@ See also [`eachcol`](@ref), [`eachslice`](@ref) and [`mapslices`](@ref).
 !!! compat "Julia 1.9"
      Prior to Julia 1.9, this returned an iterator.
 
-# Example
+# Examples
 
 ```jldoctest
 julia> a = [1 2; 3 4]
@@ -182,7 +182,7 @@ See also [`eachrow`](@ref), [`eachslice`](@ref) and [`mapslices`](@ref).
 !!! compat "Julia 1.9"
      Prior to Julia 1.9, this returned an iterator.
 
-# Example
+# Examples
 
 ```jldoctest
 julia> a = [1 2; 3 4]

--- a/base/strings/annotated.jl
+++ b/base/strings/annotated.jl
@@ -45,7 +45,7 @@ AnnotatedString(s::S<:AbstractString, annotations::Vector{Tuple{UnitRange{Int}, 
 A AnnotatedString can also be created with [`annotatedstring`](@ref), which acts much
 like [`string`](@ref) but preserves any annotations present in the arguments.
 
-# Example
+# Examples
 
 ```julia-repl
 julia> AnnotatedString("this is an example annotated string",

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -345,7 +345,7 @@ thread other than 1.
     In newly written library functions, `:static` scheduling is discouraged because the
     functions using this option cannot be called from arbitrary worker threads.
 
-## Example
+## Examples
 
 To illustrate of the different scheduling strategies, consider the following function
 `busywait` containing a non-yielding timed loop that runs for a given number of seconds.

--- a/base/util.jl
+++ b/base/util.jl
@@ -375,7 +375,7 @@ then the user can enter just a newline character to select the `default`.
 
 See also `Base.winprompt` (for Windows) and `Base.getpass` for secure entry of passwords.
 
-# Example
+# Examples
 
 ```julia-repl
 julia> your_name = Base.prompt("Enter your name");

--- a/stdlib/Dates/src/conversions.jl
+++ b/stdlib/Dates/src/conversions.jl
@@ -84,7 +84,7 @@ today() = Date(now())
 Return a `DateTime` corresponding to the user's system time as UTC/GMT.
 For other time zones, see the TimeZones.jl package.
 
-# Example
+# Examples
 ```julia
 julia> now(UTC)
 2023-01-04T10:52:24.864

--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -472,7 +472,7 @@ end
 Describes the ISO8601 formatting for a date and time. This is the default value for `Dates.format`
 of a `DateTime`.
 
-# Example
+# Examples
 ```jldoctest
 julia> Dates.format(DateTime(2018, 8, 8, 12, 0, 43, 1), ISODateTimeFormat)
 "2018-08-08T12:00:43.001"
@@ -486,7 +486,7 @@ default_format(::Type{DateTime}) = ISODateTimeFormat
 
 Describes the ISO8601 formatting for a date. This is the default value for `Dates.format` of a `Date`.
 
-# Example
+# Examples
 ```jldoctest
 julia> Dates.format(Date(2018, 8, 8), ISODateFormat)
 "2018-08-08"
@@ -500,7 +500,7 @@ default_format(::Type{Date}) = ISODateFormat
 
 Describes the ISO8601 formatting for a time. This is the default value for `Dates.format` of a `Time`.
 
-# Example
+# Examples
 ```jldoctest
 julia> Dates.format(Time(12, 0, 43, 1), ISOTimeFormat)
 "12:00:43.001"
@@ -514,7 +514,7 @@ default_format(::Type{Time}) = ISOTimeFormat
 
 Describes the RFC1123 formatting for a date and time.
 
-# Example
+# Examples
 ```jldoctest
 julia> Dates.format(DateTime(2018, 8, 8, 12, 0, 43, 1), RFC1123Format)
 "Wed, 08 Aug 2018 12:00:43"
@@ -538,7 +538,7 @@ pattern given in the `format` string (see [`DateFormat`](@ref)  for syntax).
     that you create a [`DateFormat`](@ref) object instead and use that as the second
     argument to avoid performance loss when using the same format repeatedly.
 
-# Example
+# Examples
 ```jldoctest
 julia> DateTime("2020-01-01", "yyyy-mm-dd")
 2020-01-01T00:00:00
@@ -578,7 +578,7 @@ in the `format` string (see [`DateFormat`](@ref) for syntax).
     that you create a [`DateFormat`](@ref) object instead and use that as the second
     argument to avoid performance loss when using the same format repeatedly.
 
-# Example
+# Examples
 ```jldoctest
 julia> Date("2020-01-01", "yyyy-mm-dd")
 2020-01-01
@@ -618,7 +618,7 @@ in the `format` string (see [`DateFormat`](@ref) for syntax).
     that you create a [`DateFormat`](@ref) object instead and use that as the second
     argument to avoid performance loss when using the same format repeatedly.
 
-# Example
+# Examples
 ```jldoctest
 julia> Time("12:34pm", "HH:MMp")
 12:34:00

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -77,7 +77,7 @@ already work:
 - pycharm
 - bbedit
 
-# Example:
+# Examples
 
 The following defines the usage of terminal-based `emacs`:
 

--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -346,7 +346,7 @@ eigvals(A::AbstractMatrix{T}; kws...) where T =
 """
 For a scalar input, `eigvals` will return a scalar.
 
-# Example
+# Examples
 ```jldoctest
 julia> eigvals(-2)
 -2

--- a/stdlib/Markdown/src/render/html.jl
+++ b/stdlib/Markdown/src/render/html.jl
@@ -191,7 +191,7 @@ writing to an (optional) `io` stream or returning a string.
 One can alternatively use `show(io, "text/html", md)` or `repr("text/html", md)`, which
 differ in that they wrap the output in a `<div class="markdown"> ... </div>` element.
 
-# Example
+# Examples
 ```jldoctest
 julia> html(md"hello _world_")
 "<p>hello <em>world</em></p>\\n"

--- a/stdlib/Markdown/src/render/latex.jl
+++ b/stdlib/Markdown/src/render/latex.jl
@@ -175,7 +175,7 @@ writing to an (optional) `io` stream or returning a string.
 
 One can alternatively use `show(io, "text/latex", md)` or `repr("text/latex", md)`.
 
-# Example
+# Examples
 ```jldoctest
 julia> latex(md"hello _world_")
 "hello \\\\emph{world}\\n\\n"

--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -55,7 +55,7 @@ end
 Gets all of the IP addresses of the `host`.
 Uses the operating system's underlying `getaddrinfo` implementation, which may do a DNS lookup.
 
-# Example
+# Examples
 ```julia-repl
 julia> getalladdrinfo("google.com")
 2-element Array{IPAddr,1}:
@@ -362,7 +362,7 @@ are not guaranteed to be unique beyond their network segment,
 therefore routers do not forward them. Link-local addresses are from
 the address blocks `169.254.0.0/16` or `fe80::/10`.
 
-# Example
+# Examples
 ```julia
 filter(!islinklocaladdr, getipaddrs())
 ```

--- a/stdlib/Test/src/logging.jl
+++ b/stdlib/Test/src/logging.jl
@@ -55,7 +55,7 @@ most `n` times.
 
 See also: [`LogRecord`](@ref).
 
-## Example
+## Examples
 
 ```jldoctest
 julia> using Test, Logging


### PR DESCRIPTION
... as suggested by the Julia manual and by `CONTRIBUTING.md`

In one case `# Example` was dropped (instead of appending an `s`)
because it was redundant.
