### PR TITLE
More cautious legacy_color conversion in Logging

### DIFF
--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -148,7 +148,10 @@ function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module
     # Format lines as text with appropriate indentation and with a box
     # decoration on the left.
     color, prefix, suffix = logger.meta_formatter(level, _module, group, id, filepath, line)::Tuple{Union{Symbol,Int},String,String}
-    color = StyledStrings.Face(foreground=StyledStrings.Legacy.legacy_color(color))
+    lcolor = StyledStrings.Legacy.legacy_color(color)
+    if !isnothing(lcolor)
+        color = StyledStrings.Face(foreground=lcolor)
+    end
     minsuffixpad = 2
     buf = IOBuffer()
     iob = IOContext(buf, stream)


### PR DESCRIPTION
Can be seen as a follow-on from #51829, also wants
https://github.com/JuliaLang/StyledStrings.jl/pull/37
 to behave as expected.