### PR TITLE
Raise an error when using `include_dependency` with non-existent file or directory

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2059,9 +2059,9 @@ function _include_dependency(mod::Module, _path::AbstractString; track_content=t
     end
     if !_track_dependencies[]
         if !path_maybe_dir && !isfile(path)
-            throw(ArgumentError("including $(repr(path)): No such file"))
+            throw(SystemError("including file $(repr(path))", Libc.ENOENT))
         elseif path_maybe_dir && !ispath(path)
-            throw(ArgumentError("including $(repr(path)): No such file or directory"))
+            throw(SystemError("including file or folder $(repr(path))", Libc.ENOENT))
         end
     else
         @lock require_lock begin

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2050,7 +2050,7 @@ const _concrete_dependencies = Pair{PkgId,UInt128}[] # these dependency versions
 const _require_dependencies = Any[] # a list of (mod, abspath, fsize, hash, mtime) tuples that are the file dependencies of the module currently being precompiled
 const _track_dependencies = Ref(false) # set this to true to track the list of file dependencies
 function _include_dependency(mod::Module, _path::AbstractString; track_content=true,
-                             path_maybe_dir=false)
+                             path_may_be_dir=false)
     prev = source_path(nothing)
     if prev === nothing
         path = abspath(_path)
@@ -2058,9 +2058,9 @@ function _include_dependency(mod::Module, _path::AbstractString; track_content=t
         path = normpath(joinpath(dirname(prev), _path))
     end
     if !_track_dependencies[]
-        if !path_maybe_dir && !isfile(path)
+        if !path_may_be_dir && !isfile(path)
             throw(SystemError("including file $(repr(path))", Libc.ENOENT))
-        elseif path_maybe_dir && !ispath(path)
+        elseif path_may_be_dir && !ispath(path)
             throw(SystemError("including file or folder $(repr(path))", Libc.ENOENT))
         end
     else
@@ -2093,7 +2093,7 @@ no effect outside of compilation.
     Keyword argument `track_content` requires at least Julia 1.11.
 """
 function include_dependency(path::AbstractString; track_content::Bool=false)
-    _include_dependency(Main, path, track_content=track_content, path_maybe_dir=true)
+    _include_dependency(Main, path, track_content=track_content, path_may_be_dir=true)
     return nothing
 end
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2063,7 +2063,7 @@ function _include_dependency(mod::Module, _path::AbstractString; track_content=t
                 # use mtime=-1.0 here so that fsize==0 && mtime==0.0 corresponds to a missing include_dependency
                 push!(_require_dependencies, (mod, path, filesize(path), hash, -1.0))
             else
-                isfile(path) || throw(ArgumentError("$(repr(path)) is not a readable file"))
+                ispath(path) || throw(ArgumentError("$(repr(path)): No such file or directory"))
                 push!(_require_dependencies, (mod, path, UInt64(0), UInt32(0), mtime(path)))
             end
         end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2063,6 +2063,7 @@ function _include_dependency(mod::Module, _path::AbstractString; track_content=t
                 # use mtime=-1.0 here so that fsize==0 && mtime==0.0 corresponds to a missing include_dependency
                 push!(_require_dependencies, (mod, path, filesize(path), hash, -1.0))
             else
+                isfile(path) || throw(ArgumentError("$(repr(path)) is not a readable file"))
                 push!(_require_dependencies, (mod, path, UInt64(0), UInt32(0), mtime(path)))
             end
         end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2059,9 +2059,9 @@ function _include_dependency(mod::Module, _path::AbstractString; track_content=t
     end
     if !_track_dependencies[]
         if !path_may_be_dir && !isfile(path)
-            throw(SystemError("including file $(repr(path))", Libc.ENOENT))
+            throw(SystemError("opening file $(repr(path))", Libc.ENOENT))
         elseif path_may_be_dir && !Filesystem.isreadable(path)
-            throw(SystemError("including file or folder $(repr(path))", Libc.ENOENT))
+            throw(SystemError("opening file or folder $(repr(path))", Libc.ENOENT))
         end
     else
         @lock require_lock begin

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2049,16 +2049,25 @@ const include_callbacks = Any[]
 const _concrete_dependencies = Pair{PkgId,UInt128}[] # these dependency versions are "set in stone", and the process should try to avoid invalidating them
 const _require_dependencies = Any[] # a list of (mod, abspath, fsize, hash, mtime) tuples that are the file dependencies of the module currently being precompiled
 const _track_dependencies = Ref(false) # set this to true to track the list of file dependencies
-function _include_dependency(mod::Module, _path::AbstractString; track_content=true)
+function _include_dependency(mod::Module, _path::AbstractString; track_content=true,
+                             path_maybe_dir=false)
     prev = source_path(nothing)
     if prev === nothing
         path = abspath(_path)
     else
         path = normpath(joinpath(dirname(prev), _path))
     end
-    ispath(path) || throw(ArgumentError("$(repr(path)): No such file or directory"))
-    uperm(path) & 0x04 == 0x04 || throw(ArgumentError("$(repr(path)): Missing read permission"))
-    if _track_dependencies[]
+    if !_track_dependencies[]
+        if !path_maybe_dir && !isfile(path)
+            throw(ArgumentError("including $(repr(path)): No such file"))
+        elseif path_maybe_dir && !ispath(path)
+            throw(ArgumentError("including $(repr(path)): No such file or directory"))
+        end
+        readable = @static Sys.iswindows() ? uperm(path) & 0x04 == 0x04 : Sys.isreadable(path)
+        if !readable
+            throw(ArgumentError("including $(repr(path)): Missing read permission"))
+        end
+    else
         @lock require_lock begin
             if track_content
                 hash = isdir(path) ? _crc32c(join(readdir(path))) : open(_crc32c, path, "r")
@@ -2088,7 +2097,7 @@ no effect outside of compilation.
     Keyword argument `track_content` requires at least Julia 1.11.
 """
 function include_dependency(path::AbstractString; track_content::Bool=false)
-    _include_dependency(Main, path, track_content=track_content)
+    _include_dependency(Main, path, track_content=track_content, path_maybe_dir=true)
     return nothing
 end
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2060,7 +2060,7 @@ function _include_dependency(mod::Module, _path::AbstractString; track_content=t
     if !_track_dependencies[]
         if !path_may_be_dir && !isfile(path)
             throw(SystemError("including file $(repr(path))", Libc.ENOENT))
-        elseif path_may_be_dir && !ispath(path)
+        elseif path_may_be_dir && !Filesystem.isreadable(path)
             throw(SystemError("including file or folder $(repr(path))", Libc.ENOENT))
         end
     else

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2063,10 +2063,6 @@ function _include_dependency(mod::Module, _path::AbstractString; track_content=t
         elseif path_maybe_dir && !ispath(path)
             throw(ArgumentError("including $(repr(path)): No such file or directory"))
         end
-        readable = @static Sys.iswindows() ? uperm(path) & 0x04 == 0x04 : Sys.isreadable(path)
-        if !readable
-            throw(ArgumentError("including $(repr(path)): Missing read permission"))
-        end
     else
         @lock require_lock begin
             if track_content

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2056,6 +2056,8 @@ function _include_dependency(mod::Module, _path::AbstractString; track_content=t
     else
         path = normpath(joinpath(dirname(prev), _path))
     end
+    ispath(path) || throw(ArgumentError("$(repr(path)): No such file or directory"))
+    uperm(path) & 0x04 == 0x04 || throw(ArgumentError("$(repr(path)): Missing read permission"))
     if _track_dependencies[]
         @lock require_lock begin
             if track_content
@@ -2063,7 +2065,6 @@ function _include_dependency(mod::Module, _path::AbstractString; track_content=t
                 # use mtime=-1.0 here so that fsize==0 && mtime==0.0 corresponds to a missing include_dependency
                 push!(_require_dependencies, (mod, path, filesize(path), hash, -1.0))
             else
-                ispath(path) || throw(ArgumentError("$(repr(path)): No such file or directory"))
                 push!(_require_dependencies, (mod, path, UInt64(0), UInt32(0), mtime(path)))
             end
         end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1549,7 +1549,13 @@ end
         end
 
         file = joinpath(depot, "dev", "non-existent.jl")
-        @test_throws SystemError("opening file $(repr(file))") include(file)
+        @test try
+            include(file); false
+        catch e
+            @test e isa SystemError
+            @test e.prefix == "opening file $(repr(file))"
+            true
+        end
         touch(file)
         @test include_dependency(file) === nothing
         chmod(file, 0x000)
@@ -1559,7 +1565,13 @@ end
             @test include_dependency(dir) === nothing
             dir
         end
-        @test_throws SystemError("opening file or folder $(repr(dir))") include_dependency(dir)
+        @test try
+            include_dependency(dir); false
+        catch e
+            @test e isa SystemError
+            @test e.prefix == "opening file or folder $(repr(dir))"
+            true
+        end
     end
 end
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1550,6 +1550,19 @@ end
 
         file = joinpath(depot, "dev", "non-existent.jl")
         @test_throws ArgumentError("$(repr(file)): No such file or directory") include(file)
+        touch(file)
+        @test include_dependency(file) === nothing
+        chmod(file, 0x000)
+        @test_throws ArgumentError("$(repr(file)): Missing read permission") include_dependency(file)
+
+        # same for include_dependency: #52063
+        dir = mktempdir() do dir
+            @test include_dependency(dir) === nothing
+            chmod(dir, 0x000)
+            @test_throws ArgumentError("$(repr(dir)): Missing read permission") include_dependency(dir)
+            dir
+        end
+        @test_throws ArgumentError("$(repr(dir)): No such file or directory") include_dependency(dir)
     end
 end
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1553,13 +1553,10 @@ end
         touch(file)
         @test include_dependency(file) === nothing
         chmod(file, 0x000)
-        @test_throws ArgumentError("including $(repr(file)): Missing read permission") include_dependency(file)
 
         # same for include_dependency: #52063
         dir = mktempdir() do dir
             @test include_dependency(dir) === nothing
-            chmod(dir, 0x000)
-            @test_throws ArgumentError("including $(repr(dir)): Missing read permission") include_dependency(dir)
             dir
         end
         @test_throws ArgumentError("including $(repr(dir)): No such file or directory") include_dependency(dir)

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -650,9 +650,9 @@ end
 # normalization of paths by include (#26424)
 @test begin
     exc = try; include("./notarealfile.jl"); "unexpectedly reached!"; catch exc; exc; end
-    @test exc isa ArgumentError
-    exc.msg
-end == "including $(repr(joinpath(@__DIR__, "notarealfile.jl"))): No such file"
+    @test exc isa SystemError
+    exc.prefix
+end == "including file $(repr(joinpath(@__DIR__, "notarealfile.jl"))): No such file"
 
 old_act_proj = Base.ACTIVE_PROJECT[]
 pushfirst!(LOAD_PATH, "@")
@@ -1549,7 +1549,7 @@ end
         end
 
         file = joinpath(depot, "dev", "non-existent.jl")
-        @test_throws ArgumentError("including $(repr(file)): No such file") include(file)
+        @test_throws SystemError("including file $(repr(file)): No such file") include(file)
         touch(file)
         @test include_dependency(file) === nothing
         chmod(file, 0x000)
@@ -1559,7 +1559,7 @@ end
             @test include_dependency(dir) === nothing
             dir
         end
-        @test_throws ArgumentError("including $(repr(dir)): No such file or directory") include_dependency(dir)
+        @test_throws SystemError("including $(repr(dir)): No such file or directory") include_dependency(dir)
     end
 end
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -652,7 +652,7 @@ end
     exc = try; include("./notarealfile.jl"); "unexpectedly reached!"; catch exc; exc; end
     @test exc isa SystemError
     exc.prefix
-end == "including file $(repr(joinpath(@__DIR__, "notarealfile.jl"))): No such file"
+end == "including file $(repr(joinpath(@__DIR__, "notarealfile.jl")))"
 
 old_act_proj = Base.ACTIVE_PROJECT[]
 pushfirst!(LOAD_PATH, "@")
@@ -1549,7 +1549,7 @@ end
         end
 
         file = joinpath(depot, "dev", "non-existent.jl")
-        @test_throws SystemError("including file $(repr(file)): No such file") include(file)
+        @test_throws SystemError("including file $(repr(file))") include(file)
         touch(file)
         @test include_dependency(file) === nothing
         chmod(file, 0x000)
@@ -1559,7 +1559,7 @@ end
             @test include_dependency(dir) === nothing
             dir
         end
-        @test_throws SystemError("including $(repr(dir)): No such file or directory") include_dependency(dir)
+        @test_throws SystemError("including file or directory $(repr(dir))") include_dependency(dir)
     end
 end
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1559,7 +1559,7 @@ end
             @test include_dependency(dir) === nothing
             dir
         end
-        @test_throws SystemError("including file or directory $(repr(dir))") include_dependency(dir)
+        @test_throws SystemError("including file or folder $(repr(dir))") include_dependency(dir)
     end
 end
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -652,7 +652,7 @@ end
     exc = try; include("./notarealfile.jl"); "unexpectedly reached!"; catch exc; exc; end
     @test exc isa ArgumentError
     exc.msg
-end == "$(repr(joinpath(@__DIR__, "notarealfile.jl"))): No such file or directory"
+end == "including $(repr(joinpath(@__DIR__, "notarealfile.jl"))): No such file"
 
 old_act_proj = Base.ACTIVE_PROJECT[]
 pushfirst!(LOAD_PATH, "@")
@@ -1549,20 +1549,20 @@ end
         end
 
         file = joinpath(depot, "dev", "non-existent.jl")
-        @test_throws ArgumentError("$(repr(file)): No such file or directory") include(file)
+        @test_throws ArgumentError("including $(repr(file)): No such file") include(file)
         touch(file)
         @test include_dependency(file) === nothing
         chmod(file, 0x000)
-        @test_throws ArgumentError("$(repr(file)): Missing read permission") include_dependency(file)
+        @test_throws ArgumentError("including $(repr(file)): Missing read permission") include_dependency(file)
 
         # same for include_dependency: #52063
         dir = mktempdir() do dir
             @test include_dependency(dir) === nothing
             chmod(dir, 0x000)
-            @test_throws ArgumentError("$(repr(dir)): Missing read permission") include_dependency(dir)
+            @test_throws ArgumentError("including $(repr(dir)): Missing read permission") include_dependency(dir)
             dir
         end
-        @test_throws ArgumentError("$(repr(dir)): No such file or directory") include_dependency(dir)
+        @test_throws ArgumentError("including $(repr(dir)): No such file or directory") include_dependency(dir)
     end
 end
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -652,7 +652,7 @@ end
     exc = try; include("./notarealfile.jl"); "unexpectedly reached!"; catch exc; exc; end
     @test exc isa SystemError
     exc.prefix
-end == "including file $(repr(joinpath(@__DIR__, "notarealfile.jl")))"
+end == "opening file $(repr(joinpath(@__DIR__, "notarealfile.jl")))"
 
 old_act_proj = Base.ACTIVE_PROJECT[]
 pushfirst!(LOAD_PATH, "@")
@@ -1549,7 +1549,7 @@ end
         end
 
         file = joinpath(depot, "dev", "non-existent.jl")
-        @test_throws SystemError("including file $(repr(file))") include(file)
+        @test_throws SystemError("opening file $(repr(file))") include(file)
         touch(file)
         @test include_dependency(file) === nothing
         chmod(file, 0x000)
@@ -1559,7 +1559,7 @@ end
             @test include_dependency(dir) === nothing
             dir
         end
-        @test_throws SystemError("including file or folder $(repr(dir))") include_dependency(dir)
+        @test_throws SystemError("opening file or folder $(repr(dir))") include_dependency(dir)
     end
 end
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -650,9 +650,9 @@ end
 # normalization of paths by include (#26424)
 @test begin
     exc = try; include("./notarealfile.jl"); "unexpectedly reached!"; catch exc; exc; end
-    @test exc isa SystemError
-    exc.prefix
-end == "opening file $(repr(joinpath(@__DIR__, "notarealfile.jl")))"
+    @test exc isa ArgumentError
+    exc.msg
+end == "$(repr(joinpath(@__DIR__, "notarealfile.jl"))): No such file or directory"
 
 old_act_proj = Base.ACTIVE_PROJECT[]
 pushfirst!(LOAD_PATH, "@")
@@ -1549,7 +1549,7 @@ end
         end
 
         file = joinpath(depot, "dev", "non-existent.jl")
-        @test_throws SystemError("opening file $(repr(file))") include(file)
+        @test_throws ArgumentError("$(repr(file)): No such file or directory") include(file)
     end
 end
 

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2003,18 +2003,18 @@ end
 
 precompile_test_harness("Issue #52063") do load_path
     fname = joinpath(load_path, "i_do_not_exist.jl")
-    @test_throws ArgumentError("$(repr(fname)): No such file or directory") include_dependency(fname)
+    @test_throws SystemError("opening file or folder $(repr(fname))") include_dependency(fname)
     touch(fname)
     @test include_dependency(fname) === nothing
     chmod(fname, 0x000)
-    @test_throws ArgumentError("$(repr(fname)): Missing read permission") include_dependency(fname)
+    @test_throws SystemError("opening file or folder $(repr(fname))", Libc.ENOENT) include_dependency(fname)
     dir = mktempdir() do dir
         @test include_dependency(dir) === nothing
         chmod(dir, 0x000)
-        @test_throws ArgumentError("$(repr(dir)): Missing read permission") include_dependency(dir)
+        @test_throws SystemError("opening file or folder $(repr(dir))", Libc.ENOENT) include_dependency(dir)
         dir
     end
-    @test_throws ArgumentError("$(repr(dir)): No such file or directory") include_dependency(dir)
+    @test_throws SystemError("opening file or folder $(repr(dir))") include_dependency(dir)
 end
 
 finish_precompile_test!()

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1996,4 +1996,14 @@ precompile_test_harness("Generated Opaque") do load_path
     end
 end
 
+precompile_test_harness("Issue #52063") do load_path
+    write(joinpath(load_path, "I52063.jl"),
+        """
+        module I52063
+        include_dependency("i_do_not_exist.jl")
+        end
+        """)
+    @test_throws ArgumentError Base.compilecache(Base.PkgId("I50538"))
+end
+
 finish_precompile_test!()

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -6,6 +6,8 @@ using REPL # doc lookup function
 include("precompile_utils.jl")
 
 Foo_module = :Foo4b3a94a1a081a8cb
+foo_incl_dep = :foo4b3a94a1a081a8cb
+bar_incl_dep = :bar4b3a94a1a081a8cb
 Foo2_module = :F2oo4b3a94a1a081a8cb
 FooBase_module = :FooBase4b3a94a1a081a8cb
 @eval module ConflictingBindings
@@ -75,6 +77,8 @@ precompile_test_harness(false) do dir
     Foo_file = joinpath(dir, "$Foo_module.jl")
     Foo2_file = joinpath(dir, "$Foo2_module.jl")
     FooBase_file = joinpath(dir, "$FooBase_module.jl")
+    foo_file = joinpath(dir, "$foo_incl_dep.jl")
+    bar_file = joinpath(dir, "$bar_incl_dep.jl")
 
     write(FooBase_file,
           """
@@ -123,11 +127,11 @@ precompile_test_harness(false) do dir
 
               # test that docs get reconnected
               @doc "foo function" foo(x) = x + 1
-              include_dependency("foo.jl")
-              include_dependency("foo.jl")
+              include_dependency("$foo_incl_dep.jl")
+              include_dependency("$foo_incl_dep.jl")
               module Bar
                   public bar
-                  include_dependency("bar.jl")
+                  include_dependency("$bar_incl_dep.jl")
               end
               @doc "Bar module" Bar # this needs to define the META dictionary via eval
               @eval Bar @doc "bar function" bar(x) = x + 2
@@ -270,6 +274,8 @@ precompile_test_harness(false) do dir
               oid_mat_int = objectid(a_mat_int)
           end
           """)
+    # Issue #52063
+    touch(foo_file); touch(bar_file)
     # Issue #12623
     @test __precompile__(false) === nothing
 
@@ -412,8 +418,7 @@ precompile_test_harness(false) do dir
         modules, (deps, _, requires), required_modules, _... = Base.parse_cache_header(cachefile)
         discard_module = mod_fl_mt -> mod_fl_mt.filename
         @test modules == [ Base.PkgId(Foo) => Base.module_build_id(Foo) % UInt64 ]
-        # foo.jl and bar.jl are never written to disk, so they are not relocatable
-        @test map(x -> x.filename, deps) == [ Foo_file, joinpath("@depot", "foo.jl"), joinpath("@depot", "bar.jl") ]
+        @test map(x -> x.filename, deps) == [ Foo_file, joinpath("@depot", foo_file), joinpath("@depot", bar_file) ]
         @test requires == [ Base.PkgId(Foo) => Base.PkgId(string(FooBase_module)),
                             Base.PkgId(Foo) => Base.PkgId(Foo2),
                             Base.PkgId(Foo) => Base.PkgId(Test),
@@ -422,7 +427,7 @@ precompile_test_harness(false) do dir
         @test !isempty(srctxt) && srctxt == read(Foo_file, String)
         @test_throws ErrorException Base.read_dependency_src(cachefile, "/tmp/nonexistent.txt")
         # dependencies declared with `include_dependency` should not be stored
-        @test_throws ErrorException Base.read_dependency_src(cachefile, joinpath(dir, "foo.jl"))
+        @test_throws ErrorException Base.read_dependency_src(cachefile, joinpath(dir, foo_file))
 
         modules, deps1 = Base.cache_dependencies(cachefile)
         modules_ok = merge(


### PR DESCRIPTION
Replaces #52105
Fixes #52063

There is a question about whether the `ispath & uperm` check should be moved inside the `_track_dependencies[]` check (like it was in #52105),
which would make it such that any errors are thrown only during precompilation.