### PR TITLE
Add 3-arg `*` to the manual

### DIFF
--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -412,6 +412,7 @@ Other sparse solvers are available as Julia packages.
 
 ```@docs
 Base.:*(::AbstractMatrix, ::AbstractMatrix)
+Base.:*(::AbstractMatrix, ::AbstractMatrix, ::AbstractVector)
 Base.:\(::AbstractMatrix, ::AbstractVecOrMat)
 Base.:/(::AbstractVecOrMat, ::AbstractVecOrMat)
 LinearAlgebra.SingularException


### PR DESCRIPTION
#37898 added methods to `*` for chained matrix multiplication. They have a descriptive docstring but I don't think this is mentioned in the manual.

First commit should include the docstring here: https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#Standard-functions 

Is that the right place? And should this be mentioned in text anywhere else?