### PR TITLE
Modify identify_package_env, explicit_project_deps_get for extensions

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -817,7 +817,7 @@ function explicit_project_deps_get(project_file::String, name::String)::Union{No
     end
     # check weakdeps in case extensions need to resolve from parent package
     weakdeps = get(d, "weakdeps", nothing)::Union{Dict{String, Any}, Nothing}
-    if deps !== nothing
+    if weakdeps !== nothing
         uuid = get(weakdeps, name, nothing)::Union{String, Nothing}
         @debug "Explicitly checked project weak deps:" name uuid
         uuid === nothing || return UUID(uuid)


### PR DESCRIPTION
Extensions need additional help to resolve dependencies in implicit
environments where a comprehensive Project.toml and Manifest.toml is
absent. These modifications allow package extensions to search their
parent packages in order to resolve dependencies and weak
dependencies.

Proposed fix for #53264
