### PR TITLE
Trim hash map size when pruning type caches

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1154,6 +1154,7 @@ static void cache_insert_type_set(jl_datatype_t *val, uint_t hv)
 
 jl_svec_t *cache_rehash_set(jl_svec_t *a, size_t newsz)
 {
+    newsz = newsz ? next_power_of_two(newsz) : 0;
     jl_value_t **ol = jl_svec_data(a);
     size_t sz = jl_svec_len(a);
     while (1) {


### PR DESCRIPTION
This doesn't make much of a difference for the smaller type caches (many of which have exactly 1 element actually), but it does offer up to ~75% savings (8192 -> 2048, 4096 -> 512) for some of the larger type caches in our sysimage.