### PR TITLE
Fix typo in `Sys.total_memory` docstring.

### DIFF
--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -358,7 +358,7 @@ free_memory() = ccall(:uv_get_available_memory, UInt64, ())
 
 Get the total memory in RAM (including that which is currently used) in bytes.
 This amount may be constrained, e.g., by Linux control groups. For the unconstrained
-amount, see `Sys.physical_memory()`.
+amount, see `Sys.total_physical_memory()`.
 """
 function total_memory()
     constrained = ccall(:uv_get_constrained_memory, UInt64, ())


### PR DESCRIPTION
Fixes #53298.

Can someone with the right permissions add a backport to 1.10 label?