### PR TITLE
Add `conj!`  for arrays of arrays

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -119,7 +119,7 @@ julia> A
 """
 conj!(A::AbstractArray{<:Number}) = (@inbounds broadcast!(conj, A, A); A)
 conj!(x::AbstractArray{<:Real}) = x
-function conj!(A::AbstractArray{<:AbstractArray})
+function conj!(A::AbstractArray)
     foreach(A) do ai
         conj!(ai)
     end

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -119,12 +119,7 @@ julia> A
 """
 conj!(A::AbstractArray{<:Number}) = (@inbounds broadcast!(conj, A, A); A)
 conj!(x::AbstractArray{<:Real}) = x
-function conj!(A::AbstractArray)
-    foreach(A) do ai
-        conj!(ai)
-    end
-    return A
-end
+conj!(A::AbstractArray) = (foreach(conj!, A); A)
 
 """
     conj(A::AbstractArray)

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -119,6 +119,12 @@ julia> A
 """
 conj!(A::AbstractArray{<:Number}) = (@inbounds broadcast!(conj, A, A); A)
 conj!(x::AbstractArray{<:Real}) = x
+function conj!(A::AbstractArray{<:AbstractArray})
+    foreach(A) do ai
+        conj!(ai)
+    end
+    return A
+end
 
 """
     conj(A::AbstractArray)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2612,7 +2612,7 @@ end
 end
 
 @testset "sign, conj[!], ~" begin
-    local A, B, C
+    local A, B, C, D, E
     A = [-10,0,3]
     B = [-10.0,0.0,3.0]
     C = [1,im,0]
@@ -2629,6 +2629,11 @@ end
     @test typeof(conj(A)) == Vector{Int}
     @test typeof(conj(B)) == Vector{Float64}
     @test typeof(conj(C)) == Vector{Complex{Int}}
+    D = [C copy(C); copy(C) copy(C)]
+    @test conj(D) == conj!(copy(D))
+    E = [D, copy(D)]
+    @test conj(E) == conj!(copy(E))
+    @test (@allocations conj!(E)) == 0
 
     @test .~A == [9,-1,-4]
     @test typeof(.~A) == Vector{Int}


### PR DESCRIPTION
Apparently, `broadcast!(conj!, A, A)` is not allocation-free, so I spelled it out, but perhaps there's a more elegant solution.