### PR TITLE
llvmunwind: use LLVM_PATH instead of LLVM_CONFIG_PATH variable

### DIFF
--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -73,7 +73,10 @@ check-unwind: $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-checked
 
 ## LLVM libunwind ##
 
-LLVMUNWIND_OPTS := $(CMAKE_COMMON) -DCMAKE_BUILD_TYPE=MinSizeRel -DLIBUNWIND_ENABLE_PEDANTIC=OFF -DLLVM_CONFIG_PATH=$(build_depsbindir)/llvm-config
+LLVMUNWIND_OPTS := $(CMAKE_COMMON) \
+	-DCMAKE_BUILD_TYPE=MinSizeRel \
+	-DLIBUNWIND_ENABLE_PEDANTIC=OFF \
+	-DLLVM_PATH=$(SRCCACHE)/$(LLVM_SRC_DIR)/llvm
 
 $(SRCCACHE)/llvmunwind-$(LLVMUNWIND_VER).tar.xz: | $(SRCCACHE)
 	$(JLDOWNLOAD) $@ https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LLVMUNWIND_VER)/libunwind-$(LLVMUNWIND_VER).src.tar.xz


### PR DESCRIPTION
with llvm-16, the `--src-root` argument of llvm-config has been removed. see https://github.com/llvm/llvm-project/commit/c061892fcdbdfe46884c54a7a7bfe6df54d1df12

but `llvmunwind` was using it for configuration.
so prefer to use `LLVM_PATH` and explicitly pass the llvm source directory.