### PR TITLE
Type-Parameterize Core.Box

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -427,10 +427,12 @@ include(m::Module, fname::String) = ccall(:jl_load_, Any, (Any, Any), m, fname)
 
 eval(m::Module, @nospecialize(e)) = ccall(:jl_toplevel_eval_in, Any, (Any, Any), m, e)
 
-mutable struct Box
-    contents::Any
-    Box(@nospecialize(x)) = new(x)
-    Box() = new()
+mutable struct Box{C}
+    contents::C
+    Box{C}(c) where C = new{C}(c)
+    Box(@nospecialize(c)) = new{Any}(c)
+    Box{C}() where C = new{C}()
+    Box() = new{Any}()
 end
 
 # constructors for built-in types


### PR DESCRIPTION
There are performance optimizations that do not occur when `Box` accesses are `typeassert`ed, which instead require the `Box` to be type-parameterized ([example](https://github.com/JuliaLang/julia/issues/15276#issuecomment-1396889311)). The first step will be to parameterize `Core.Box`, and then other improvements can be made. 

By this edit, type parameterization must be performed explicitly; otherwise behavior is the same as before (e.g. `Box(1)` is a `Box{Any}(1)`; call `Box{Int}(1)` to construct a `Box{Int}`).