### PR TITLE
Move isassigned within inbounds in copyto_unaliased

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1100,9 +1100,9 @@ function copyto_unaliased!(deststyle::IndexStyle, dest::AbstractArray, srcstyle:
         iterdest, itersrc = eachindex(dest), eachindex(src)
         if iterdest == itersrc
             # Shared-iterator implementation
-            for I in iterdest
+            @inbounds for I in iterdest
                 if isassigned(src, I)
-                    @inbounds dest[I] = src[I]
+                    dest[I] = src[I]
                 else
                     _unsetindex!(dest, I)
                 end

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1979,3 +1979,31 @@ end
     test_prechecked_iterate(LinearIndices(()))
     test_prechecked_iterate(Base.SCartesianIndices2{3}(1:3))
 end
+
+@testset "IndexStyles in copyto!" begin
+    A = rand(3,2)
+    B = zeros(size(A))
+    colons = ntuple(_->:, ndims(B))
+    # Ensure that the AbstractArray methods are hit
+    # by using views instead of Arrays
+    @testset "IndexLinear - IndexLinear" begin
+        B .= 0
+        copyto!(view(B, colons...), A)
+        @test B == A
+    end
+    @testset "IndexLinear - IndexCartesian" begin
+        B .= 0
+        copyto!(view(B, colons...), view(A, axes(A)...))
+        @test B == A
+    end
+    @testset "IndexCartesian - IndexLinear" begin
+        B .= 0
+        copyto!(view(B, axes(B)...), A)
+        @test B == A
+    end
+    @testset "IndexCartesian - IndexCartesian" begin
+        B .= 0
+        copyto!(view(B, axes(B)...), view(A, axes(A)...))
+        @test B == A
+    end
+end


### PR DESCRIPTION
This matches the other branches where the `isassigned` and ` _unsetindex!` are within `@inbounds` blocks, and this might help with performance after https://github.com/JuliaLang/julia/pull/53305