### PR TITLE
make dependencies of extensions be found in implicit environments

### DIFF
--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1131,6 +1131,18 @@ end
         cmd =  `$(Base.julia_cmd()) --startup-file=no -e $sysimg_ext_test_code`
         cmd = addenv(cmd, "JULIA_LOAD_PATH" => join([proj, "@stdlib"], sep))
         run(cmd)
+
+
+        # Extensions in implicit environments
+        old_load_path = copy(LOAD_PATH)
+        try
+            empty!(LOAD_PATH)
+            push!(LOAD_PATH, joinpath(@__DIR__, "project", "Extensions", "ImplicitEnv"))
+            pkgid_B = Base.PkgId(Base.uuid5(Base.identify_package("A").uuid, "BExt"), "BExt")
+            @test Base.identify_package(pkgid_B, "B") isa Base.PkgId
+        finally
+            copy!(LOAD_PATH, old_load_path)
+        end
     finally
         try
             rm(depot_path, force=true, recursive=true)

--- a/test/project/Extensions/ImplicitEnv/A/Project.toml
+++ b/test/project/Extensions/ImplicitEnv/A/Project.toml
@@ -1,0 +1,9 @@
+name = "A"
+uuid = "299a509a-2181-4868-8714-15151945d902"
+version = "0.1.0"
+
+[weakdeps]
+B = "c2c18cb0-3543-497c-ac2a-523c527589e5"
+
+[extensions]
+BExt = "B"

--- a/test/project/Extensions/ImplicitEnv/A/ext/BExt.jl
+++ b/test/project/Extensions/ImplicitEnv/A/ext/BExt.jl
@@ -1,0 +1,3 @@
+module BExt
+
+end

--- a/test/project/Extensions/ImplicitEnv/A/src/A.jl
+++ b/test/project/Extensions/ImplicitEnv/A/src/A.jl
@@ -1,0 +1,5 @@
+module A
+
+greet() = print("Hello World!")
+
+end # module A

--- a/test/project/Extensions/ImplicitEnv/B/Project.toml
+++ b/test/project/Extensions/ImplicitEnv/B/Project.toml
@@ -1,0 +1,3 @@
+name = "B"
+uuid = "c2c18cb0-3543-497c-ac2a-523c527589e5"
+version = "0.1.0"

--- a/test/project/Extensions/ImplicitEnv/B/src/B.jl
+++ b/test/project/Extensions/ImplicitEnv/B/src/B.jl
@@ -1,0 +1,5 @@
+module B
+
+greet() = print("Hello World!")
+
+end # module B


### PR DESCRIPTION
Alternative to https://github.com/JuliaLang/julia/pull/53293

This does kind of the same thing but it does not rely on `EXT_PRIMED` to identify extensions which I think is a better idea since we don't really want code lookup to depend on the state of Julia itself imo.

Fixes https://github.com/JuliaLang/julia/issues/53264

cc @mkitti 

-----------------------

Co-authored by: Mark Kittisopikul <`markkitti@fosstodon.org`>
