### PR TITLE
add being able to pass a `CacheFlags()` to `isprecompiled` to verify against a set of custom flags

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1606,7 +1606,7 @@ function isprecompiled(pkg::PkgId;
             modpaths = find_all_in_cache_path(modkey)
             for modpath_to_try in modpaths::Vector{String}
                 stale_cache_key = (modkey, modbuild_id, modpath, modpath_to_try)::StaleCacheKey
-                if get!(() -> stale_cachefile(stale_cache_key...; ignore_loaded, flags) === true,
+                if get!(() -> stale_cachefile(stale_cache_key...; ignore_loaded, requested_flags=flags) === true,
                         stale_cache, stale_cache_key)
                     continue
                 end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2613,7 +2613,7 @@ function create_expr_cache(pkg::PkgId, input::String, output::String, output_o::
     else
         @debug "Generating cache file for $(repr("text/plain", pkg))"
         cpu_target = nothing
-        opts = `--output-ji $(output) --output-incremental=yes -O0`
+        opts = `-O0 --output-ji $(output) --output-incremental=yes`
     end
 
     deps_eltype = sprint(show, eltype(concrete_deps); context = :module=>nothing)

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -387,6 +387,7 @@
     XX(jl_raise_debugger) \
     XX(jl_readuntil) \
     XX(jl_cache_flags) \
+    XX(jl_match_cache_flags_current) \
     XX(jl_match_cache_flags) \
     XX(jl_read_verify_header) \
     XX(jl_realloc) \

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -3566,7 +3566,7 @@ static jl_value_t *jl_validate_cache_file(ios_t *f, jl_array_t *depmods, uint64_
                 "Precompile file header verification checks failed.");
     }
     uint8_t flags = read_uint8(f);
-    if (pkgimage && !jl_match_cache_flags(flags)) {
+    if (pkgimage && !jl_match_cache_flags_current(flags)) {
         return jl_get_exceptionf(jl_errorexception_type, "Pkgimage flags mismatch");
     }
     if (!pkgimage) {

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -2001,8 +2001,7 @@ precompile_test_harness("Test flags") do load_path
         current_flags.inline,
         3
     )
-
-    ji, ofile = Base.compilecache(Base.PkgId("TestFlags"); flags=modified_flags)
+    ji, ofile = Base.compilecache(Base.PkgId("TestFlags"); flags=`--check-bounds=no -O3`)
     open(ji, "r") do io
         Base.isvalid_cache_header(io)
         _, _, _, _, _, _, _, flags = Base.parse_cache_header(io, ji)


### PR DESCRIPTION
This makes it easier to also update `isprecompiled` to check for staleness with custom flags

This is the second take of https://github.com/JuliaLang/julia/pull/53316.
