### PR TITLE
Cleanups for tagged code instance

### DIFF
--- a/src/precompile_utils.c
+++ b/src/precompile_utils.c
@@ -182,7 +182,10 @@ static int precompile_enq_specialization_(jl_method_instance_t *mi, void *closur
     jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
     while (codeinst) {
         int do_compile = 0;
-        if (jl_atomic_load_relaxed(&codeinst->invoke) != jl_fptr_const_return) {
+        if (codeinst->owner != jl_nothing) {
+            // TODO(vchuravy) native code caching for foreign interpreters
+        }
+        else if (jl_atomic_load_relaxed(&codeinst->invoke) != jl_fptr_const_return) {
             jl_value_t *inferred = jl_atomic_load_relaxed(&codeinst->inferred);
             if (inferred &&
                 inferred != jl_nothing &&


### PR DESCRIPTION
Two small cleanups to #52233
- Don't use foreign code-instances for native code caching decision making
- don't return a non-native codeinst for jl_method_compiled
