### PR TITLE
Add waitany and waitall functions to wait multiple tasks at once

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@ New library functions
 
 * `logrange(start, stop; length)` makes a range of constant ratio, instead of constant step ([#39071])
 * The new `isfull(c::Channel)` function can be used to check if `put!(c, some_value)` will block. ([#53159])
+* `waitany(tasks; throw=false)` and `waitall(tasks; failfast=false, throw=false)` which wait multiple tasks at once ([#53341]).
 
 New library features
 --------------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -706,6 +706,8 @@ export
     yield,
     yieldto,
     wait,
+    waitany,
+    waitall,
     timedwait,
     asyncmap,
     asyncmap!,

--- a/base/task.jl
+++ b/base/task.jl
@@ -368,7 +368,7 @@ end
 # Wait multiple tasks
 
 """
-    waitany(tasks; throw=false) -> (done_tasks, remaining_tasks)
+    waitany(tasks; throw=true) -> (done_tasks, remaining_tasks)
 
 Wait until at least one of the given tasks have been completed.
 
@@ -378,10 +378,10 @@ completed tasks completes with an exception.
 The return value consists of two task vectors. The first one consists of
 completed tasks, and the other consists of uncompleted tasks.
 """
-waitany(tasks; throw=false) = _wait_multiple(tasks, throw)
+waitany(tasks; throw=true) = _wait_multiple(tasks, throw)
 
 """
-    waitall(tasks; failfast=false, throw=false) -> (done_tasks, remaining_tasks)
+    waitall(tasks; failfast=true, throw=true) -> (done_tasks, remaining_tasks)
 
 Wait until all the given tasks have been completed.
 
@@ -395,7 +395,7 @@ given tasks is finished by exception. If `throw` is `true`, throw
 The return value consists of two task vectors. The first one consists of
 completed tasks, and the other consists of uncompleted tasks.
 """
-waitall(tasks; failfast=false, throw=false) = _wait_multiple(tasks, throw, true, failfast)
+waitall(tasks; failfast=true, throw=true) = _wait_multiple(tasks, throw, true, failfast)
 
 function _wait_multiple(waiting_tasks, throwexc=false, all=false, failfast=false)
     tasks = Task[]

--- a/base/task.jl
+++ b/base/task.jl
@@ -410,8 +410,14 @@ function _wait_multiple(waiting_tasks; all=false, failfast=false)
     waiter_tasks = fill(sentinel, length(tasks))
 
     for (i, done) in enumerate(done_mask)
-        if !done
-            t = tasks[i]
+        done && continue
+        t = tasks[i]
+        if istaskdone(t)
+            done_mask[i] = true
+            exception |= istaskfailed(t)
+            nremaining -= 1
+            exception && failfast && break
+        else
             waiter = @task put!(chan, i)
             waiter.sticky = false
             _wait2(t, waiter)

--- a/base/task.jl
+++ b/base/task.jl
@@ -371,19 +371,22 @@ waitall(tasks; failfast=false) = _wait_multiple(tasks; all=true, failfast=failfa
 
 function _wait_multiple(waiting_tasks; all=false, failfast=false)
     tasks = Task[]
-    done_mask = Bool[]
-    exception = false
-    nremaining::Int = 0
 
     for (i, t) in enumerate(waiting_tasks)
         t isa Task || error("Expected an iterator of `Task` object")
         push!(tasks, t)
+    end
+
+    exception = false
+    nremaining::Int = length(tasks)
+    done_mask = falses(nremaining)
+    for (i, t) in enumerate(tasks)
         if istaskdone(t)
-            push!(done_mask, true)
+            done_mask[i] = true
             exception |= istaskfailed(t)
+            nremaining -= 1
         else
-            push!(done_mask, false)
-            nremaining += 1
+            done_mask[i] = false
         end
     end
 

--- a/base/task.jl
+++ b/base/task.jl
@@ -377,6 +377,15 @@ function _wait_multiple(waiting_tasks; all=false, failfast=false)
         push!(tasks, t)
     end
 
+    if all && !failfast
+        # Force everything to finish synchronously for the case of waitall
+        # with failfast=false
+        for t in tasks
+            _wait(t)
+        end
+        return tasks, Task[]
+    end
+
     exception = false
     nremaining::Int = length(tasks)
     done_mask = falses(nremaining)

--- a/base/task.jl
+++ b/base/task.jl
@@ -405,7 +405,7 @@ function _wait_multiple(waiting_tasks, throwexc=false, all=false, failfast=false
         push!(tasks, t)
     end
 
-    if all && !failfast
+    if (all && !failfast) || length(tasks) <= 1
         exception = false
         # Force everything to finish synchronously for the case of waitall
         # with failfast=false

--- a/base/task.jl
+++ b/base/task.jl
@@ -372,7 +372,7 @@ end
 
 Wait until at least one of the given tasks have been completed.
 
-If `throw` is `true`, the `CompositeException` will be thrown when one of the
+If `throw` is `true`, throw `CompositeException` when one of the
 completed tasks completes with an exception.
 
 The return value consists of two task vectors. The first one consists of
@@ -386,8 +386,8 @@ waitany(tasks; throw=false) = _wait_multiple(tasks, throw)
 Wait until all the given tasks have been completed.
 
 If `failfast` is `true`, the function will return when at least one of the
-given tasks is finished by exception. If `throw` is `true`, the
-`CompositeException` will be thrown when one of the completed tasks has failed.
+given tasks is finished by exception. If `throw` is `true`, throw
+`CompositeException` when one of the completed tasks has failed.
 
 `failfast` and `throw` keyword arguments work independently; when only
 `throw=true` is specified, this function waits for all the tasks to complete.

--- a/base/task.jl
+++ b/base/task.jl
@@ -414,7 +414,7 @@ function _wait_multiple(waiting_tasks, throwexc=false, all=false, failfast=false
             exception |= istaskfailed(t)
         end
         if exception && throwexc
-            exceptions = [t.exception for t in tasks if istaskfailed(t)]
+            exceptions = [TaskFailedException(t) for t in tasks if istaskfailed(t)]
             throw(CompositeException(exceptions))
         else
             return tasks, Task[]
@@ -438,7 +438,7 @@ function _wait_multiple(waiting_tasks, throwexc=false, all=false, failfast=false
         return tasks, Task[]
     elseif any(done_mask) && (!all || (failfast && exception))
         if throwexc && (!all || failfast) && exception
-            exceptions = [t.exception for t in tasks[done_mask] if istaskfailed(t)]
+            exceptions = [TaskFailedException(t) for t in tasks[done_mask] if istaskfailed(t)]
             throw(CompositeException(exceptions))
         else
             return tasks[done_mask], tasks[.~done_mask]
@@ -493,7 +493,7 @@ function _wait_multiple(waiting_tasks, throwexc=false, all=false, failfast=false
         end
         done_tasks = tasks[done_mask]
         if throwexc && exception
-            exceptions = [t.exception for t in done_tasks if istaskfailed(t)]
+            exceptions = [TaskFailedException(t) for t in done_tasks if istaskfailed(t)]
             throw(CompositeException(exceptions))
         else
             return done_tasks, tasks[remaining_mask]

--- a/base/task.jl
+++ b/base/task.jl
@@ -369,7 +369,7 @@ end
 waitany(tasks) = _wait_multiple(tasks)
 waitall(tasks; failfast=false) = _wait_multiple(tasks; all=true, failfast=failfast)
 
-function _wait_multiple(waiting_tasks::Union{AbstractVector{Task},AbstractSet{Task},Tuple{Task}}; all=false, failfast=false)::NTuple{2,Vector{Task}}
+function _wait_multiple(waiting_tasks::Union{AbstractVector{Task},AbstractSet{Task},Tuple{Task}}; all=false, failfast=false)
     chan = Channel{Tuple{Int,Task}}(Inf)
     tasks = Task[]
     done_mask = Bool[]

--- a/base/task.jl
+++ b/base/task.jl
@@ -367,9 +367,9 @@ end
 
 # Wait multiple tasks
 waitany(tasks) = _wait_multiple(tasks)
-waitall(tasks; failfast=false) = _wait_multiple(tasks; all=true, failfast=failfast)
+waitall(tasks; failfast=false) = _wait_multiple(tasks, true, failfast)
 
-function _wait_multiple(waiting_tasks; all=false, failfast=false)
+function _wait_multiple(waiting_tasks, all=false, failfast=false)
     tasks = Task[]
 
     for t in waiting_tasks

--- a/base/task.jl
+++ b/base/task.jl
@@ -377,6 +377,12 @@ completed tasks completes with an exception.
 
 The return value consists of two task vectors. The first one consists of
 completed tasks, and the other consists of uncompleted tasks.
+
+!!! warning
+    This may scale poorly compared to writing code that uses multiple individual tasks that
+    each runs serially, since this needs to scan the list of `tasks` each time and
+    synchronize with each one every time this is called. Or consider using
+    [`waitall(tasks; failfast=true)`](@ref waitall) instead.
 """
 waitany(tasks; throw=true) = _wait_multiple(tasks, throw)
 

--- a/base/task.jl
+++ b/base/task.jl
@@ -369,7 +369,13 @@ end
 waitany(tasks) = _wait_multiple(tasks)
 waitall(tasks; failfast=false) = _wait_multiple(tasks; all=true, failfast=failfast)
 
-function _wait_multiple(waiting_tasks::Union{AbstractVector{Task},AbstractSet{Task},Tuple{Task}}; all=false, failfast=false)
+function _wait_multiple(waiting_tasks; all=false, failfast=false)
+    foreach(waiting_tasks) do @nospecialize t
+        if !(t isa Task)
+            error("Expected an iterator of `Task` object")
+        end
+    end
+
     chan = Channel{Tuple{Int,Task}}(Inf)
     tasks = Task[]
     done_mask = Bool[]

--- a/base/task.jl
+++ b/base/task.jl
@@ -372,7 +372,7 @@ waitall(tasks; failfast=false) = _wait_multiple(tasks; all=true, failfast=failfa
 function _wait_multiple(waiting_tasks; all=false, failfast=false)
     tasks = Task[]
 
-    for (i, t) in enumerate(waiting_tasks)
+    for t in waiting_tasks
         t isa Task || error("Expected an iterator of `Task` object")
         push!(tasks, t)
     end

--- a/base/task.jl
+++ b/base/task.jl
@@ -419,7 +419,7 @@ function _wait_multiple(waiting_tasks; all=false, failfast=false)
         end
     end
 
-    while true
+    while nremaining > 0
         i = take!(chan)
         t = tasks[i]
         waiter_tasks[i] = sentinel
@@ -427,7 +427,9 @@ function _wait_multiple(waiting_tasks; all=false, failfast=false)
         exception |= istaskfailed(t)
         nremaining -= 1
 
-        if nremaining == 0 || (!all || failfast && exception)
+        # stop early if requested, unless there is something immediately
+        # ready to consume from the channel (using a race-y check)
+        if (!all || (failfast && exception)) && !isready(chan)
             break
         end
     end

--- a/base/task.jl
+++ b/base/task.jl
@@ -366,7 +366,35 @@ function wait(t::Task)
 end
 
 # Wait multiple tasks
+
+"""
+    waitany(tasks; throw=false) -> (done_tasks, remaining_tasks)
+
+Wait until at least one of the given tasks have been completed.
+
+If `throw` is `true`, the `CompositeException` will be thrown when one of the
+completed tasks completes with an exception.
+
+The return value consists of two task vectors. The first one consists of
+completed tasks, and the other consists of uncompleted tasks.
+"""
 waitany(tasks; throw=false) = _wait_multiple(tasks, throw)
+
+"""
+    waitall(tasks; failfast=false, throw=false) -> (done_tasks, remaining_tasks)
+
+Wait until all the given tasks have been completed.
+
+If `failfast` is `true`, the function will return when at least one of the
+given tasks is finished by exception. If `throw` is `true`, the
+`CompositeException` will be thrown when one of the completed tasks has failed.
+
+`failfast` and `throw` keyword arguments work independently; when only
+`throw=true` is specified, this function waits for all the tasks to complete.
+
+The return value consists of two task vectors. The first one consists of
+completed tasks, and the other consists of uncompleted tasks.
+"""
 waitall(tasks; failfast=false, throw=false) = _wait_multiple(tasks, throw, true, failfast)
 
 function _wait_multiple(waiting_tasks, throwexc=false, all=false, failfast=false)

--- a/base/task.jl
+++ b/base/task.jl
@@ -366,10 +366,10 @@ function wait(t::Task)
 end
 
 # Wait multiple tasks
-waitany(tasks) = _wait_multiple(tasks)
-waitall(tasks; failfast=false, throw=false) = _wait_multiple(tasks, true, failfast, throw)
+waitany(tasks; throw=false) = _wait_multiple(tasks, throw)
+waitall(tasks; failfast=false, throw=false) = _wait_multiple(tasks, throw, true, failfast)
 
-function _wait_multiple(waiting_tasks, all=false, failfast=false, throwexc=false)
+function _wait_multiple(waiting_tasks, throwexc=false, all=false, failfast=false)
     tasks = Task[]
 
     for t in waiting_tasks
@@ -409,7 +409,7 @@ function _wait_multiple(waiting_tasks, all=false, failfast=false, throwexc=false
     if nremaining == 0
         return tasks, Task[]
     elseif any(done_mask) && (!all || (failfast && exception))
-        if throwexc && failfast && exception
+        if throwexc && (!all || failfast) && exception
             exceptions = [t.exception for t in tasks[done_mask] if istaskfailed(t)]
             throw(CompositeException(exceptions))
         else

--- a/base/task.jl
+++ b/base/task.jl
@@ -426,7 +426,8 @@ function _wait_multiple(waiting_tasks; all=false, failfast=false)
         remaining_tasks = tasks[.~done_mask]
         for t in remaining_tasks
             waiter = pop!(waiter_tasks, t)
-            @lock t.donenotify Base.list_deletefirst!((t.donenotify::ThreadSynchronizer).waitq, waiter)
+            donenotify = t.donenotify::ThreadSynchronizer
+            @lock donenotify Base.list_deletefirst!(donenotify.waitq, waiter)
         end
         return tasks[done_mask], remaining_tasks
     end

--- a/base/task.jl
+++ b/base/task.jl
@@ -383,6 +383,7 @@ function _wait_multiple(waiting_tasks; all=false, failfast=false)
     nremaining::Int = 0
 
     for (i, t) in enumerate(waiting_tasks)
+        t = t::Task
         push!(tasks, t)
         if istaskdone(t)
             push!(done_mask, true)

--- a/doc/src/base/parallel.md
+++ b/doc/src/base/parallel.md
@@ -30,6 +30,8 @@ Base.schedule
 Base.errormonitor
 Base.@sync
 Base.wait
+Base.waitany
+Base.waitall
 Base.fetch(t::Task)
 Base.fetch(x::Any)
 Base.timedwait

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1218,15 +1218,28 @@ end
 
     for tasks_type in (Vector{Task}, Set{Task}, Tuple{Task})
         @testset "waitany" begin
-            tasks, event = create_tasks()
-            sleep(0.1)
-            done,  pending = waitany(convert_tasks(tasks_type, tasks))
-            @test length(done) == 2
-            @test tasks[1] ∈ done
-            @test tasks[2] ∈ done
-            @test length(pending) == 1
-            @test tasks[3] ∈ pending
-            teardown(tasks, event)
+            @testset "no options" begin
+                tasks, event = create_tasks()
+                sleep(0.1)
+                done,  pending = waitany(convert_tasks(tasks_type, tasks))
+                @test length(done) == 2
+                @test tasks[1] ∈ done
+                @test tasks[2] ∈ done
+                @test length(pending) == 1
+                @test tasks[3] ∈ pending
+                teardown(tasks, event)
+            end
+
+            @testset "throw=true" begin
+                tasks, event = create_tasks()
+                push!(tasks, Threads.@spawn error("Error"))
+
+                @test_throws CompositeException begin
+                    waitany(convert_tasks(tasks_type, tasks); throw=true)
+                end
+
+                teardown(tasks, event)
+            end
         end
 
         @testset "waitall" begin

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1212,7 +1212,7 @@ end
 
     function teardown(tasks, event)
         notify(event)
-        wait(tasks[3])
+        waitall(resize!(tasks, 3), throw=true)
     end
 
     for tasks_type in (Vector{Task}, Set{Task}, Tuple{Task})

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1212,7 +1212,6 @@ end
 
     function teardown(tasks, event)
         notify(event)
-        yield()
         wait(tasks[3])
     end
 

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -1220,7 +1220,8 @@ end
         @testset "waitany" begin
             @testset "no options" begin
                 tasks, event = create_tasks()
-                sleep(0.1)
+                wait(tasks[1])
+                wait(tasks[2])
                 done,  pending = waitany(convert_tasks(tasks_type, tasks))
                 @test length(done) == 2
                 @test tasks[1] ∈ done
@@ -1246,7 +1247,8 @@ end
             @testset "All tasks succeed" begin
                 tasks, event = create_tasks()
 
-                sleep(0.1)
+                wait(tasks[1])
+                wait(tasks[2])
                 waiter = Threads.@spawn waitall(convert_tasks(tasks_type, tasks))
                 @test !istaskdone(waiter)
 
@@ -1263,7 +1265,8 @@ end
                 tasks, event = create_tasks()
                 push!(tasks, Threads.@spawn error("Error"))
 
-                sleep(0.1)
+                wait(tasks[1])
+                wait(tasks[2])
                 waiter = Threads.@spawn waitall(convert_tasks(tasks_type, tasks); failfast=true)
 
                 done, pending = fetch(waiter)
@@ -1281,7 +1284,6 @@ end
                 tasks, event = create_tasks()
                 push!(tasks, Threads.@spawn error("Error"))
 
-                sleep(0.1)
                 notify(event)
 
                 @test_throws CompositeException begin


### PR DESCRIPTION
I would like to propose adding two functions, `waitany` and `waitall`, discussed in the issue #53226. These functions wait for multiple tasks at once. The `waitany` function blocks until one task finishes. The `waitall` function blocks until all tasks finish. There is an optional keyword argument, `failfast`, for the `waitall` function. The default of `failfast` is `false`. The `waitall` function will immediately stop if any task ends with an exception when the `failfast` is `true`.

This is my own implementation, but I have regrets about the type of the first argument. I wanted to represent a container type from which `Task` objects can be taken out using the `iterate` function, but it seems impossible in current Julia, so I used a union type of `AbstractVector`, `Tuple`, and `Set`. I would like to know if there is a better way to write this part.