### PR TITLE
Add `Base.wrap` to docs

### DIFF
--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -139,6 +139,7 @@ Base.reshape
 Base.dropdims
 Base.vec
 Base.SubArray
+Base.wrap
 ```
 
 ## Concatenation and permutation


### PR DESCRIPTION
I thought that's reasonable in the light that `view` was not implemented: https://github.com/JuliaLang/julia/pull/52049#issuecomment-1848711619