### PR TITLE
use a separate depot for `--pkgimages` loading test

### DIFF
--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1439,7 +1439,7 @@ end
 end
 
 @testset "command-line flags" begin
-    mktempdir() do dir
+    mktempdir() do depot_path mktempdir() do dir
         # generate a Parent.jl and Child.jl package, with Parent depending on Child
         open(joinpath(dir, "Child.jl"), "w") do io
             println(io, """
@@ -1458,6 +1458,7 @@ end
             code = "using $name"
             cmd = addenv(`$(Base.julia_cmd()) -e $code $args`,
                         "JULIA_LOAD_PATH" => dir,
+                        "JULIA_DEPOT_PATH" => depot_path,
                         "JULIA_DEBUG" => "loading")
 
             out = Pipe()
@@ -1514,7 +1515,7 @@ end
         @test occursin(r"Loading object cache file .+ for Child", log)
         @test occursin(r"Generating object cache file for Parent", log)
         @test occursin(r"Loading object cache file .+ for Parent", log)
-    end
+    end end
 end
 
 @testset "including non-existent file throws proper error #52462" begin


### PR DESCRIPTION
Otherwise this will write compile files to your home directory (and you get confused in the debug output next time you run the tests due to old precompile files being there)