### PR TITLE
fix rare GC segfault coming from bug in mark-loop (alternative to 53351)

### DIFF
--- a/src/gc.h
+++ b/src/gc.h
@@ -511,6 +511,7 @@ extern uv_cond_t gc_threads_cond;
 extern uv_sem_t gc_sweep_assists_needed;
 extern _Atomic(int) gc_n_threads_marking;
 extern _Atomic(int) gc_n_threads_sweeping;
+extern _Atomic(int) gc_master_tid;
 void gc_mark_queue_all_roots(jl_ptls_t ptls, jl_gc_markqueue_t *mq);
 void gc_mark_finlist_(jl_gc_markqueue_t *mq, jl_value_t *fl_parent, jl_value_t **fl_begin, jl_value_t **fl_end) JL_NOTSAFEPOINT;
 void gc_mark_finlist(jl_gc_markqueue_t *mq, arraylist_t *list, size_t start) JL_NOTSAFEPOINT;

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -114,7 +114,7 @@ void JL_NORETURN jl_finish_task(jl_task_t *t);
 
 static inline int may_mark(void) JL_NOTSAFEPOINT
 {
-    return (jl_atomic_load(&gc_n_threads_marking) > 0);
+    return (jl_atomic_load(&gc_master_tid) != -1);
 }
 
 static inline int may_sweep(jl_ptls_t ptls) JL_NOTSAFEPOINT


### PR DESCRIPTION
Should fix https://github.com/JuliaLang/julia/issues/52757, https://github.com/JuliaLang/julia/issues/53026 and https://github.com/JuliaLang/julia/issues/53350.

Removes some of the awkwardness from https://github.com/JuliaLang/julia/pull/53351 but does require waiting for all threads to join at the end of mark-loop.