### PR TITLE
Rename at-scriptdir project argument to at-script and search upwards for Project.toml

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -68,6 +68,7 @@ difference between defining a `main` function and executing the code directly at
 * The `--compiled-modules` and `--pkgimages` flags can now be set to `existing`, which will
   cause Julia to consider loading existing cache files, but not to create new ones ([#50586]
   and [#52573]).
+* The `--project` argument now accepts `@script` to give a path to a directory with a Project.toml relative to the passed script file. `--project=@script/foo` for the `foo` subdirectory. If no path is given after (i.e. `--project=@script`) then (like `--project=@.`) the directory and its parents are searched for a Project.toml ([#50864] and [#53352])
 
 Multi-threading changes
 -----------------------

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -278,7 +278,7 @@ function load_path_expand(env::AbstractString)::Union{String, Nothing}
         env == "@" && return active_project(false)
         env == "@." && return current_project()
         env == "@stdlib" && return Sys.STDLIB
-        if startswith(env, "@scriptdir")
+        if startswith(env, "@script")
             if @isdefined(PROGRAM_FILE)
                 dir = dirname(PROGRAM_FILE)
             else
@@ -289,7 +289,12 @@ function load_path_expand(env::AbstractString)::Union{String, Nothing}
                 end
                 dir = dirname(ARGS[1])
             end
-            return abspath(replace(env, "@scriptdir" => dir))
+            if env == "@script"  # complete match, not startswith, so search upwards
+                return current_project(dir)
+            else
+                # starts with, so assume relative path is after
+                return abspath(replace(env, "@script" => dir))
+            end
         end
         env = replace(env, '#' => VERSION.major, count=1)
         env = replace(env, '#' => VERSION.minor, count=1)


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/53352

I also noticed it wasn't mentioned in the NEWs.md
and so I added it .

Reconciling the relative path behavior, with the search upwads behavour requested in #53352 is a thing.
