### PR TITLE
fix sysimage-native-code=no option with pkgimages

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -607,15 +607,8 @@ extern void * JL_WEAK_SYMBOL_OR_ALIAS_DEFAULT(system_image_data_unavailable) jl_
 extern void * JL_WEAK_SYMBOL_OR_ALIAS_DEFAULT(system_image_data_unavailable) jl_system_image_size;
 static void jl_load_sysimg_so(void)
 {
-    int imaging_mode = jl_generating_output() && !jl_options.incremental;
-    // in --build mode only use sysimg data, not precompiled native code
-    if (!imaging_mode && jl_options.use_sysimage_native_code==JL_OPTIONS_USE_SYSIMAGE_NATIVE_CODE_YES) {
-        assert(sysimage.fptrs.ptrs);
-    }
-    else {
-        memset(&sysimage.fptrs, 0, sizeof(sysimage.fptrs));
-    }
     const char *sysimg_data;
+    assert(sysimage.fptrs.ptrs); // jl_init_processor_sysimg should already be run
     if (jl_sysimg_handle == jl_exe_handle &&
             &jl_system_image_data != JL_WEAK_SYMBOL_DEFAULT(system_image_data_unavailable))
         sysimg_data = (const char*)&jl_system_image_data;
@@ -3096,6 +3089,17 @@ static void jl_restore_system_image_from_stream_(ios_t *f, jl_image_t *image, jl
     htable_t new_dt_objs;
     htable_new(&new_dt_objs, 0);
     arraylist_new(&deser_sym, 0);
+
+    // in --build mode only use sysimg data, not precompiled native code
+    int imaging_mode = jl_generating_output() && !jl_options.incremental;
+    if (!imaging_mode && jl_options.use_sysimage_native_code == JL_OPTIONS_USE_SYSIMAGE_NATIVE_CODE_YES) {
+        if (image->gvars_base)
+            assert(image->fptrs.ptrs);
+    }
+    else {
+        memset(&image->fptrs, 0, sizeof(image->fptrs));
+        image->gvars_base = NULL;
+    }
 
     // step 1: read section map
     assert(ios_pos(f) == 0 && f->bm == bm_mem);


### PR DESCRIPTION
Loading pkgimages would try to access the sysimage native code, which will fail. Ensure that no code tries to load if the sysimage native code is not available, as it may try to link against it.

Fixes #53147