### PR TITLE
improve `givensAlgorithm(::AbstractFloat)`

### DIFF
--- a/stdlib/LinearAlgebra/src/givens.jl
+++ b/stdlib/LinearAlgebra/src/givens.jl
@@ -78,19 +78,13 @@ function fasthypot(x::T,y::T) where T<:AbstractFloat
         ax, ay = ay, ax
     end
 
-    # Widely varying operands
-    if ay <= ax*sqrt(eps(typeof(ax))/2)  #Note: This also gets ay == 0
-        return ax*oneunit(x)
-    end
-
-    # Operands do not vary widely
     scale = eps(typeof(ax))*sqrt(floatmin(ax))  #Rescaling constant
     invscale = inv(scale)
     if ax > sqrt(floatmax(ax)/2)
         ax = ax*scale
         ay = ay*scale
         scale = invscale
-    elseif ay < sqrt(floatmin(ax))
+    elseif ax < sqrt(floatmin(ax))
         ax = ax*invscale
         ay = ay*invscale
     else

--- a/stdlib/LinearAlgebra/src/givens.jl
+++ b/stdlib/LinearAlgebra/src/givens.jl
@@ -90,7 +90,7 @@ function fasthypot(x::T,y::T) where T<:AbstractFloat
     else
         scale = oneunit(scale)
     end
-    h = sqrt(fma(ax, ax, ay*ay))
+    h = sqrt(muladd(ax, ax, ay*ay))
     return h*scale*oneunit(x)
 end
 fasthypot(x::Union{Float16, Float32}, y::Union{Float16,Float32}) = hypot(x,y)


### PR DESCRIPTION
This is simpler, and more accurate when both arguments are very small. I believe a similar improvement could be made to the Complex case, but that will be harder.
```
# old
julia> @benchmark LinearAlgebra.givensAlgorithm(x,y) setup=x,y=randn(2)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  5.980 ns … 14.240 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     6.131 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   6.251 ns ±  0.352 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

       █▃ ▁▂                                                  
  ▂▂▂▃▂█████▆▄▆▃▅▄▄▃▄▃▂▂▂▂▂▂▂▂▂▃▆▃▃▄▄▃▄▃▆▃▁▂▁▁▁▂▁▂▂▁▂▂▂▂▂▂▂▂ ▃
  5.98 ns        Histogram: frequency by time        6.88 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark givensAlgorithm(x,y) setup=x,y=randn(2)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  6.100 ns … 33.390 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     6.330 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   6.433 ns ±  1.044 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

    ▅█                                                        
  ▄▄██▇▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▁▂▂▁▁▁▁▂▂▁▁▁▂▂▂▂▂▂▂▂▂▁▁▂▂▁▂▂▂▂▂ ▂
  6.1 ns         Histogram: frequency by time        10.5 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

  ▆   █ ▁                                                     
  █▁▇▂█▂█▄▂▃▂▁▄▂▃▂▂▁▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▁▂▁▁▂▂▁▂▁▂▂▂▁▂▂▁▁▂▁▂▂▂▁▂ ▂
  5.12 ns        Histogram: frequency by time        5.98 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

# old
julia> @benchmark LinearAlgebra.givensAlgorithm(x,y) setup=x,y=randn(Float32, 2)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  5.140 ns … 13.170 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.320 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.358 ns ±  0.314 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

    ▁▂▂▅▇█▇▇▅▃▂  ▁▂                                          ▂
  ▆▅███████████▅▆██▆▅▃▄▅▅▅▄▁▃▃▄▃▁▃▃▁▄▃▃▃▄▃▄▁▃▁▃▁▁▁▄▁▁▅▃▄▅▁▃▄ █
  5.14 ns      Histogram: log(frequency) by time     6.48 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

# new Range (min … max):  5.530 ns … 31.580 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.620 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.794 ns ±  1.063 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   █                                                          
  ▇█▅▅▂▇▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▁▂▂▂▂▂▁▂▂▂▂▂▂▁▁▂▁▁▂▂▂▂▂▂▂ ▂
  5.53 ns        Histogram: frequency by time        9.35 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
also fasthypot has been tested on 2^32 random Float32 x,y and it never has errors of over 1 ULP.