### PR TITLE
make `Base.uabs` public

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1149,6 +1149,9 @@ public
     isoperator,
     isunaryoperator,
 
+# scalar math
+    uabs,
+
 # C interface
     cconvert,
     unsafe_convert,

--- a/base/float.jl
+++ b/base/float.jl
@@ -218,7 +218,7 @@ function ieee754_representation(
 end
 
 """
-    uabs(x::Integer)
+    Base.uabs(x::Integer)
 
 Return the absolute value of `x`, possibly returning a different type should the
 operation be susceptible to overflow. This typically arises when `x` is a two's complement

--- a/doc/src/base/math.md
+++ b/doc/src/base/math.md
@@ -142,6 +142,7 @@ Base.minmax
 Base.Math.clamp
 Base.Math.clamp!
 Base.abs
+Base.uabs
 Base.Checked
 Base.Checked.checked_abs
 Base.Checked.checked_neg


### PR DESCRIPTION
`Base.uabs` is helpful when writing code that works with generic integers without worrying about silent overflows or overflow errors when using integers from [SaferIntegers.jl](https://github.com/JeffreySarnoff/SaferIntegers.jl)

`Base.uabs` is already being used by a few packages https://juliahub.com/ui/Search?q=uabs&type=code&w=true and has a docstring.

Ref: https://github.com/JeffreySarnoff/SaferIntegers.jl/pull/41