### PR TITLE
Refine the type of Phi node statements when they are replaced

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1542,6 +1542,12 @@ function process_node!(compact::IncrementalCompact, result_idx::Int, inst::Instr
             if isa(v, SSAValue)
                 used_ssas[v.id] -= 1
             end
+            # If the type of this Phi node is wider than the type of the value we
+            # are replacing it with, request that this statement get refined in
+            # future optimization passes
+            if inst[:type] !== argextype(v, compact)
+                v = Refined(v)
+            end
             ssa_rename[idx] = v
         else
             result[result_idx][:stmt] = PhiNode(edges, values)


### PR DESCRIPTION
When we replace a Phi node in `acde_pass!()` due to being able to prove that one path is always taken, we should request that downstream optimization passes refine the type of this Phi node in the event that the type of the replacing value is more narrow than the type of the Phi node itself.