### PR TITLE
posix compatibility: avoid using ln -v

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -203,7 +203,7 @@ endif
 $(build_bindir)/7z$(EXE):
 	[ -e "$(7Z_PATH)" ] && \
 	rm -f "$@" && \
-	ln -svf "$(7Z_PATH)" "$@"
+	ln -sf "$(7Z_PATH)" "$@"
 
 symlink_llvm_utils: $(build_depsbindir)/lld$(EXE) $(build_depsbindir)/dsymutil$(EXE)
 
@@ -216,12 +216,12 @@ endif
 $(build_depsbindir)/lld$(EXE):
 	[ -e "$(LLD_PATH)" ] && \
 	rm -f "$@" && \
-	ln -svf "$(LLD_PATH)" "$@"
+	ln -sf "$(LLD_PATH)" "$@"
 
 $(build_depsbindir)/dsymutil$(EXE):
 	[ -e "$(DSYMUTIL_PATH)" ] && \
 	rm -f "$@" && \
-	ln -svf "$(DSYMUTIL_PATH)" "$@"
+	ln -sf "$(DSYMUTIL_PATH)" "$@"
 
 # the following excludes: libuv.a, libutf8proc.a
 


### PR DESCRIPTION
the PR removes `-v` argument from `ln` invocation. it permits to stick to POSIX `ln` version without using extension.

it is part of on-going work to port julia to OpenBSD.