### PR TITLE
implement a julia specific debug mode with `--debug`

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -121,6 +121,23 @@ function setpropertyonce!(x::Module, f::Symbol, desired, success_order::Symbol=:
     return Core.setglobalonce!(x, f, val, success_order, fail_order)
 end
 
+julia_debug::Bool = true
+
+"""
+    isdebug() -> Bool
+
+Return whether the julia session is running in debug mode.
+In debug mode `@assert`s are enabled and `isdebug()` returns `true`.
+This is a compile time setting so and hence a useful pattern is the following:
+
+```
+@static if isdebug()
+    # code that is only enabled in debug mode
+end
+```
+"""
+isdebug() = julia_debug
+
 
 convert(::Type{Any}, Core.@nospecialize x) = x
 convert(::Type{T}, x::T) where {T} = x
@@ -649,6 +666,7 @@ end
 function __init__()
     # Base library init
     global _atexit_hooks_finished = false
+    init_julia_debug()
     Filesystem.__postinit__()
     reinit_stdio()
     Multimedia.reinit_displays() # since Multimedia.displays uses stdout as fallback

--- a/base/error.jl
+++ b/base/error.jl
@@ -203,11 +203,12 @@ might decide to check anyways, as an aid to debugging if they fail.
 The optional message `text` is displayed upon assertion failure.
 
 !!! warning
-    An assert might be disabled at some optimization levels.
+    Assertions can be enabled/disabled depending on the `--debug` flag passed to Julia.
     Assert should therefore only be used as a debugging tool
     and not used for authentication verification (e.g., verifying passwords or checking array bounds).
     The code must not rely on the side effects of running `cond` for the correct behavior
     of a function.
+
 
 # Examples
 ```jldoctest
@@ -218,6 +219,9 @@ julia> @assert isodd(3) "What even are numbers?"
 ```
 """
 macro assert(ex, msgs...)
+    enable_asserts = !isdefined(Main, :Base) || Main.Base.julia_debug
+    enable_asserts || return nothing
+
     msg = isempty(msgs) ? ex : msgs[1]
     if isa(msg, AbstractString)
         msg = msg # pass-through

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1177,4 +1177,5 @@ public
 # misc
     notnothing,
     runtests,
-    text_colors
+    text_colors,
+    isdebug

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -504,3 +504,11 @@ function disable_library_threading()
     end
     return
 end
+
+function init_julia_debug()
+    opt_julia_debug = Base.JLOptions().julia_debug
+    # `julia_debug` is disabled everywhere or we are in a package and `--debug="script"` is used (default)
+    if opt_julia_debug == 0 || (Base.generating_output() && opt_julia_debug == 1)
+        global julia_debug = false
+    end
+end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1497,31 +1497,36 @@ end
 
 
 struct CacheFlags
-    # OOICCDDP - see jl_cache_flags
+    # OOJICCDDP - see jl_cache_flags
     use_pkgimages::Bool
     debug_level::Int
     check_bounds::Int
     inline::Bool
+    julia_debug::Bool
     opt_level::Int
 end
-function CacheFlags(f::UInt8)
+
+function CacheFlags(f::UInt16)
     use_pkgimages = Bool(f & 1)
     debug_level = Int((f >> 1) & 3)
     check_bounds = Int((f >> 3) & 3)
     inline = Bool((f >> 5) & 1)
-    opt_level = Int((f >> 6) & 3) # define OPT_LEVEL in statiddata_utils
-    CacheFlags(use_pkgimages, debug_level, check_bounds, inline, opt_level)
+    julia_debug = Bool((f >> 6) & 1)
+    opt_level = Int((f >> 7) & 3)
+    CacheFlags(use_pkgimages, debug_level, check_bounds, inline, julia_debug, opt_level)
 end
-CacheFlags(f::Int) = CacheFlags(UInt8(f))
-CacheFlags() = CacheFlags(ccall(:jl_cache_flags, UInt8, ()))
 
-function _cacheflag_to_uint8(cf::CacheFlags)::UInt8
-    f = UInt8(0)
-    f |= cf.use_pkgimages << 0
-    f |= cf.debug_level << 1
-    f |= cf.check_bounds << 3
-    f |= cf.inline << 5
-    f |= cf.opt_level << 6
+CacheFlags(f::Int) = CacheFlags(UInt16(f))
+CacheFlags() = CacheFlags(ccall(:jl_cache_flags, UInt16, ()))
+
+function _cacheflag_to_uint16(cf::CacheFlags)::UInt16
+    f = UInt16(0)
+    f |= UInt16(cf.use_pkgimages) << 0
+    f |= UInt16(cf.debug_level) << 1
+    f |= UInt16(cf.check_bounds) << 3
+    f |= UInt16(cf.inline) << 5
+    f |= UInt16(cf.julia_debug) << 6
+    f |= UInt16(cf.opt_level) << 7
     return f
 end
 
@@ -1530,6 +1535,7 @@ function show(io::IO, cf::CacheFlags)
     print(io, ", debug_level = ", cf.debug_level)
     print(io, ", check_bounds = ", cf.check_bounds)
     print(io, ", inline = ", cf.inline)
+    print(io, ", julia_debug = ", cf.julia_debug)
     print(io, ", opt_level = ", cf.opt_level)
 end
 
@@ -2948,7 +2954,7 @@ end
 
 
 function parse_cache_header(f::IO, cachefile::AbstractString)
-    flags = read(f, UInt8)
+    flags = read(f, UInt16)
     modules = Vector{Pair{PkgId, UInt64}}()
     while true
         n = read(f, Int32)
@@ -3404,10 +3410,10 @@ end
         if isempty(modules)
             return true # ignore empty file
         end
-        if @ccall(jl_match_cache_flags(_cacheflag_to_uint8(requested_flags)::UInt8, actual_flags::UInt8)::UInt8) == 0
+        if @ccall(jl_match_cache_flags(_cacheflag_to_uint16(requested_flags)::UInt16, actual_flags::UInt16)::UInt16) == 0
             @debug """
             Rejecting cache file $cachefile for $modkey since the flags are mismatched
-              requested flags: $(requested_flags) [$(_cacheflag_to_uint8(requested_flags))]
+              requested flags: $(requested_flags) [$(_cacheflag_to_uint16(requested_flags))]
               cache file:      $(CacheFlags(actual_flags)) [$actual_flags]
             """
             record_reason(reasons, "mismatched flags")

--- a/base/options.jl
+++ b/base/options.jl
@@ -27,6 +27,7 @@ struct JLOptions
     tracked_path::Ptr{UInt8}
     opt_level::Int8
     opt_level_min::Int8
+    julia_debug::Int8
     debug_level::Int8
     check_bounds::Int8
     depwarn::Int8

--- a/base/util.jl
+++ b/base/util.jl
@@ -148,8 +148,8 @@ See also [`print`](@ref), [`println`](@ref), [`show`](@ref).
 
 Return a julia command similar to the one of the running process.
 Propagates any of the `--cpu-target`, `--sysimage`, `--compile`, `--sysimage-native-code`,
-`--compiled-modules`, `--pkgimages`, `--inline`, `--check-bounds`, `--optimize`, `--min-optlevel`, `-g`,
-`--code-coverage`, `--track-allocation`, `--color`, `--startup-file`, and `--depwarn`
+`--compiled-modules`, `--pkgimages`, `--inline`, `--check-bounds`, `--optimize`, `--min-optlevel`, `--debug`,
+`-g`, `--code-coverage`, `--track-allocation`, `--color`, `--startup-file`, and `--depwarn`
 command line arguments that are not at their default values.
 
 Among others, `--math-mode`, `--warn-overwrite`, and `--trace-compile` are notably not propagated currently.
@@ -212,6 +212,8 @@ function julia_cmd(julia=joinpath(Sys.BINDIR, julia_exename()); cpu_target::Unio
     opts.use_pkgimages == 2 && push!(addflags, "--pkgimages=existing")
     opts.opt_level == 2 || push!(addflags, "-O$(opts.opt_level)")
     opts.opt_level_min == 0 || push!(addflags, "--min-optlevel=$(opts.opt_level_min)")
+    opts.julia_debug == 0 && push!(addflags, "--debug=no")
+    opts.julia_debug == 2 && push!(addflags, "--debug=yes")
     push!(addflags, "-g$(opts.debug_level)")
     if opts.code_coverage != 0
         # Forward the code-coverage flag only if applicable (if the filename is pid-dependent)

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -183,6 +183,12 @@ Set the optimization level (level 3 if `-O` is used without a level)
 Set a lower bound on the optimization level
 
 .TP
+--debug={no|script*|yes}
+Control if the `@assert` macro and `isdebug` is `true` nowhere, only in scripts (not packages)\n
+or everywhere, respectively
+
+
+.TP
 -g {0,1*,2}
 Set the level of debug info generation (level 2 if `-g` is used without a level)
 

--- a/pkgimage.mk
+++ b/pkgimage.mk
@@ -34,11 +34,11 @@ $$(BUILDDIR)/stdlib/$1.release.image: export JULIA_CPU_TARGET=$(JULIA_CPU_TARGET
 $$(BUILDDIR)/stdlib/$1.debug.image: export JULIA_CPU_TARGET=$(JULIA_CPU_TARGET)
 ifneq ($(filter $(1),$(INDEPENDENT_STDLIBS)),)
 $$(BUILDDIR)/stdlib/$1.release.image: $$($1_SRCS) $$(addsuffix .release.image,$$(addprefix $$(BUILDDIR)/stdlib/,$2)) $(build_private_libdir)/sys.$(SHLIB_EXT)
-	@$$(call PRINT_JULIA, $$(call spawn,$$(JULIA_EXECUTABLE)) --startup-file=no --check-bounds=yes -e 'Base.compilecache(Base.identify_package("$1"))')
+	@$$(call PRINT_JULIA, $$(call spawn,$$(JULIA_EXECUTABLE)) --startup-file=no --check-bounds=yes --debug=yes -e 'Base.compilecache(Base.identify_package("$1"))')
 	@$$(call PRINT_JULIA, $$(call spawn,$$(JULIA_EXECUTABLE)) --startup-file=no -e 'Base.compilecache(Base.identify_package("$1"))')
 	touch $$@
 $$(BUILDDIR)/stdlib/$1.debug.image: $$($1_SRCS) $$(addsuffix .debug.image,$$(addprefix $$(BUILDDIR)/stdlib/,$2)) $(build_private_libdir)/sys-debug.$(SHLIB_EXT)
-	@$$(call PRINT_JULIA, $$(call spawn,$$(JULIA_EXECUTABLE)) --startup-file=no --check-bounds=yes -e 'Base.compilecache(Base.identify_package("$1"))')
+	@$$(call PRINT_JULIA, $$(call spawn,$$(JULIA_EXECUTABLE)) --startup-file=no --check-bounds=yes --debug=yes -e 'Base.compilecache(Base.identify_package("$1"))')
 	@$$(call PRINT_JULIA, $$(call spawn,$$(JULIA_EXECUTABLE)) --startup-file=no -e 'Base.compilecache(Base.identify_package("$1"))')
 	touch $$@
 endif

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -31,6 +31,7 @@ typedef struct {
     const char *tracked_path;
     int8_t opt_level;
     int8_t opt_level_min;
+    int8_t julia_debug;
     int8_t debug_level;
     int8_t check_bounds;
     int8_t depwarn;

--- a/src/julia.h
+++ b/src/julia.h
@@ -2505,6 +2505,10 @@ JL_DLLEXPORT int jl_generating_output(void) JL_NOTSAFEPOINT;
 #define JL_OPTIONS_USE_PKGIMAGES_YES 1
 #define JL_OPTIONS_USE_PKGIMAGES_NO 0
 
+#define JL_OPTIONS_JULIA_DEBUG_YES 2
+#define JL_OPTIONS_JULIA_DEBUG_SCRIPT 1
+#define JL_OPTIONS_JULIA_DEBUG_NO 0
+
 // Version information
 #include <julia_version.h> // Generated file
 

--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -589,25 +589,26 @@ static void write_mod_list(ios_t *s, jl_array_t *a)
 }
 
 // OPT_LEVEL should always be the upper bits
-#define OPT_LEVEL 6
+#define OPT_LEVEL 7
 
-JL_DLLEXPORT uint8_t jl_cache_flags(void)
+JL_DLLEXPORT uint16_t jl_cache_flags(void)
 {
-    // OOICCDDP
-    uint8_t flags = 0;
-    flags |= (jl_options.use_pkgimages & 1); // 0-bit
-    flags |= (jl_options.debug_level & 3) << 1; // 1-2 bit
-    flags |= (jl_options.check_bounds & 3) << 3; // 3-4 bit
-    flags |= (jl_options.can_inline & 1) << 5; // 5-bit
-    flags |= (jl_options.opt_level & 3) << OPT_LEVEL; // 6-7 bit
+    // OOJICCDDP
+    uint16_t flags = 0;
+    flags |= (jl_options.use_pkgimages & 1) << 0; // 0-bit
+    flags |= (jl_options.debug_level   & 3) << 1; // 1-2 bits
+    flags |= (jl_options.check_bounds  & 3) << 3; // 3-4 bits
+    flags |= (jl_options.can_inline    & 1) << 5; // 5-bit
+    flags |= ((jl_options.julia_debug == JL_OPTIONS_JULIA_DEBUG_YES) ? 1 : 0) << 6; // 6-bit
+    flags |= (jl_options.opt_level     & 3) << OPT_LEVEL; // 7-8 bits
     return flags;
 }
 
 
-JL_DLLEXPORT uint8_t jl_match_cache_flags(uint8_t requested_flags, uint8_t actual_flags)
+JL_DLLEXPORT uint16_t jl_match_cache_flags(uint16_t requested_flags, uint16_t actual_flags)
 {
-    uint8_t supports_pkgimage = (requested_flags & 1);
-    uint8_t is_pkgimage = (actual_flags & 1);
+    uint16_t supports_pkgimage = (requested_flags & 1);
+    uint16_t is_pkgimage = (actual_flags & 1);
 
     // For .ji packages ignore other flags
     if (!supports_pkgimage && !is_pkgimage) {
@@ -620,7 +621,7 @@ JL_DLLEXPORT uint8_t jl_match_cache_flags(uint8_t requested_flags, uint8_t actua
     }
 
     // 2. Check all flags, execept opt level must be exact
-    uint8_t mask = (1 << OPT_LEVEL)-1;
+    uint16_t mask = (1 << OPT_LEVEL)-1;
     if ((actual_flags & mask) != (requested_flags & mask))
         return 0;
     // 3. allow for higher optimization flags in cache
@@ -629,7 +630,7 @@ JL_DLLEXPORT uint8_t jl_match_cache_flags(uint8_t requested_flags, uint8_t actua
     return actual_flags >= requested_flags;
 }
 
-JL_DLLEXPORT uint8_t jl_match_cache_flags_current(uint8_t flags)
+JL_DLLEXPORT uint16_t jl_match_cache_flags_current(uint16_t flags)
 {
     return jl_match_cache_flags(jl_cache_flags(), flags);
 }


### PR DESCRIPTION
This PR adds a new flag to control when a "julia specific" debug mode is active. When the debug mode is active the following happens:
- The `@assert` macro is active
- The `isdebug` function returns `true`.

Currently, the `--debug` has three options:
- `"yes"`: debug mode is active in scripts and packages
- `"script"`: debug mode is active in scripts (default)
- `"no"`: debug is not active anywhere

The debug mode is a "compile time option" meaning that it will recompile packages if it changes.

There are still many open questions regarding this:

- Should this instead use `-g` and coexist with the current behavior of `-g` or should it just steal it?
- Are the defaults here reasonable?
- When running `Pkg.test` should assertions be enabled everywhere or only in the tested package etc?
- Will it be expected that people run their tests under both debug and normal mode?
- Should `--debug` has any influence on `--check-bounds`?
- Probably many more

Subsumes https://github.com/JuliaLang/julia/pull/37874

Ref https://github.com/JuliaLang/julia/pull/41342, https://github.com/JuliaLang/julia/pull/53223