### PR TITLE
tweak code loading to make Revise happy

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -985,11 +985,7 @@ function explicit_manifest_entry_path(manifest_file::String, pkg::PkgId, entry::
     end
     hash = get(entry, "git-tree-sha1", nothing)::Union{Nothing, String}
     if hash === nothing
-        mbypath = manifest_uuid_path(Sys.STDLIB, pkg)
-        if mbypath isa String
-            return entry_path(mbypath, pkg.name)
-        end
-        return nothing
+        return joinpath(Sys.STDLIB, pkg.name)
     end
     hash = SHA1(hash)
     # Keep the 4 since it used to be the default

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1545,3 +1545,14 @@ end
         @test_throws SystemError("opening file $(repr(file))") include(file)
     end
 end
+
+@testset "Revise internals" begin
+    entry = Dict{String, Any}(
+        "SparseArrays" => [Dict("deps" => ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"],
+                                "uuid" => "2f01184e-e22b-5df5-ae63-d93ebab69eaf",
+                                "version" => "1.10.0")])
+    id = Base.PkgId(Base.UUID("2f01184e-e22b-5df5-ae63-d93ebab69eaf"), "SparseArrays")
+    manifest_file = mktemp()[1]
+    dir = Base.explicit_manifest_entry_path(manifest_file, id, entry)
+    @test isdir(dir)
+end


### PR DESCRIPTION
There is currently a bit of an inconsistency in an internal code loading function where with an stdlib it gives a path to the entry file while with the normal package we get the path to the folder:

```julia
julia> id_stdlib = Base.identify_package("SparseArrays")
SparseArrays [2f01184e-e22b-5df5-ae63-d93ebab69eaf]

julia> id_pkg = Base.identify_package("Example")
Example [7876af07-990d-54b4-ab0e-23690620f79a]

julia> Base.explicit_manifest_uuid_path(Base.active_project(), id_stdlib)
"/Users/kristoffercarlsson/.julia/juliaup/julia-1.10.1+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/SparseArrays/src/SparseArrays.jl"

julia> Base.explicit_manifest_uuid_path(Base.active_project(), id_pkg)
"/Users/kristoffercarlsson/.julia/packages/Example/aqsx3"
```

For Base itself this turns out to not matter but Revise uses some internals from code loading:

https://github.com/timholy/Revise.jl/blob/dbbeb3594a4ea3eebd861e8ceea8fc746efc0f82/src/pkgs.jl#L410

and this causes it to get upset.

I believe https://github.com/timholy/Revise.jl/pull/806 will fix it in Revise but might as well add this here as well.
