### PR TITLE
build libwhich on all platforms

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -181,9 +181,7 @@ endif
 endif
 
 ifeq ($(USE_SYSTEM_LIBWHICH), 0)
-ifneq ($(OS), WINNT)
 DEP_LIBS += libwhich
-endif
 endif
 
 DEP_LIBS_STAGED := $(DEP_LIBS)


### PR DESCRIPTION
One of the newly supported platforms is Windows, so we can introspection helper tool build everywhere.