### PR TITLE
Avoid allocations in `mapreduce` with multiple arrays

### DIFF
--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -327,7 +327,7 @@ julia> mapreduce(isodd, |, a, dims=1)
 mapreduce(f, op, A::AbstractArrayOrBroadcasted; dims=:, init=_InitialValue()) =
     _mapreduce_dim(f, op, init, A, dims)
 mapreduce(f, op, A::AbstractArrayOrBroadcasted...; kw...) =
-    reduce(op, map(f, A...); kw...)
+    reduce(op, Iterators.map(f, A...); kw...)
 
 _mapreduce_dim(f, op, nt, A::AbstractArrayOrBroadcasted, ::Colon) =
     mapfoldl_impl(f, op, nt, A)


### PR DESCRIPTION
Should fix #53417, seeing if it passes tests.

If there is no way around it, changing the documentation that promises "no intermediate collection needs to be created" is warranted.