### PR TITLE
Fix `--compile=all` mode after CodeInstance refactor

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -1139,11 +1139,13 @@ function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance, source_mod
             return code
         end
     end
+
     # Inference result is not cacheable or is was cacheable, but we do not want to
     # store the source in the cache, but the caller wanted it anyway (e.g. for reflection).
     # We construct a new CodeInstance for it that is not part of the cache hierarchy.
     code = CodeInstance(interp, result, can_discard_trees=(
-        source_mode != SOURCE_MODE_FORCE_SOURCE && source_mode != SOURCE_MODE_FORCE_SOURCE_UNCACHED))
+        source_mode != SOURCE_MODE_FORCE_SOURCE && source_mode != SOURCE_MODE_FORCE_SOURCE_UNCACHED &&
+        is_result_constabi_eligible(result)))
 
     # If the caller cares about the code and this is constabi, still use our synthesis function
     # anyway, because we will have not finished inferring the code inside the CodeInstance once
@@ -1151,6 +1153,7 @@ function typeinf_ext(interp::AbstractInterpreter, mi::MethodInstance, source_mod
     if use_const_api(code) && source_mode in (SOURCE_MODE_FORCE_SOURCE, SOURCE_MODE_FORCE_SOURCE_UNCACHED)
         return codeinstance_for_const_with_code(interp, code)
     end
+    @assert ci_meets_requirement(code, source_mode, false)
     return code
 end
 

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -1788,6 +1788,9 @@ void jl_dump_native_impl(void *native_code,
         // reflect the address of the jl_RTLD_DEFAULT_handle variable
         // back to the caller, so that we can check for consistency issues
         GlobalValue *jlRTLD_DEFAULT_var = jl_emit_RTLD_DEFAULT_var(&metadataM);
+        if (TheTriple.isOSBinFormatCOFF()) {
+            jlRTLD_DEFAULT_var->setDLLStorageClass(GlobalValue::DLLImportStorageClass);
+        }
         addComdat(new GlobalVariable(metadataM,
                                     jlRTLD_DEFAULT_var->getType(),
                                     true,

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -303,6 +303,12 @@ jl_code_instance_t *jl_ci_cache_lookup(const jl_cgparams_t &cgparams, jl_method_
         }
         else {
             codeinst = jl_type_infer(mi, world, 0, SOURCE_MODE_ABI);
+            /* Even if this codeinst is ordinarily not cacheable, we need to force
+             * it into the cache here, since it was explicitly requested and is
+             * otherwise not reachable from anywhere in the system image.
+             */
+            if (!jl_mi_cache_has_ci(mi, codeinst))
+                jl_mi_cache_insert(mi, codeinst);
         }
     }
     return codeinst;

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -288,7 +288,7 @@ static void makeSafeName(GlobalObject &G)
         G.setName(StringRef(SafeName.data(), SafeName.size()));
 }
 
-static void jl_ci_cache_lookup(const jl_cgparams_t &cgparams, jl_method_instance_t *mi, size_t world, jl_code_instance_t **ci_out, jl_code_info_t **src_out)
+jl_code_instance_t *jl_ci_cache_lookup(const jl_cgparams_t &cgparams, jl_method_instance_t *mi, size_t world)
 {
     ++CICacheLookups;
     jl_value_t *ci = cgparams.lookup(mi, world, world);
@@ -296,22 +296,16 @@ static void jl_ci_cache_lookup(const jl_cgparams_t &cgparams, jl_method_instance
     jl_code_instance_t *codeinst = NULL;
     if (ci != jl_nothing) {
         codeinst = (jl_code_instance_t*)ci;
-        *src_out = (jl_code_info_t*)jl_atomic_load_relaxed(&codeinst->inferred);
-        jl_method_t *def = codeinst->def->def.method;
-        if ((jl_value_t*)*src_out == jl_nothing)
-            *src_out = NULL;
-        if (*src_out && jl_is_method(def))
-            *src_out = jl_uncompress_ir(def, codeinst, (jl_value_t*)*src_out);
     }
-    if (*src_out == NULL || !jl_is_code_info(*src_out)) {
+    else {
         if (cgparams.lookup != jl_rettype_inferred_addr) {
             jl_error("Refusing to automatically run type inference with custom cache lookup.");
         }
         else {
-            *ci_out = jl_type_infer(mi, world, 0, SOURCE_MODE_ABI);
+            codeinst = jl_type_infer(mi, world, 0, SOURCE_MODE_ABI);
         }
     }
-    *ci_out = codeinst;
+    return codeinst;
 }
 
 // takes the running content that has collected in the shadow module and dump it to disk
@@ -390,16 +384,14 @@ void *jl_create_native_impl(jl_array_t *methods, LLVMOrcThreadSafeModuleRef llvm
             // then we want to compile and emit this
             if (jl_atomic_load_relaxed(&mi->def.method->primary_world) <= this_world && this_world <= jl_atomic_load_relaxed(&mi->def.method->deleted_world)) {
                 // find and prepare the source code to compile
-                jl_code_instance_t *codeinst = NULL;
-                jl_ci_cache_lookup(*cgparams, mi, this_world, &codeinst, &src);
-                if (src && !params.compiled_functions.count(codeinst)) {
+                jl_code_instance_t *codeinst = jl_ci_cache_lookup(*cgparams, mi, this_world);
+                if (codeinst && !params.compiled_functions.count(codeinst)) {
                     // now add it to our compilation results
                     JL_GC_PROMISE_ROOTED(codeinst->rettype);
                     orc::ThreadSafeModule result_m = jl_create_ts_module(name_from_method_instance(codeinst->def),
                             params.tsctx, clone.getModuleUnlocked()->getDataLayout(),
                             Triple(clone.getModuleUnlocked()->getTargetTriple()));
-                    jl_llvm_functions_t decls = jl_emit_code(result_m, mi, src, codeinst->rettype, params, jl_atomic_load_relaxed(&codeinst->min_world),
-                        jl_atomic_load_relaxed(&codeinst->max_world));
+                    jl_llvm_functions_t decls = jl_emit_codeinst(result_m, codeinst, NULL, params);
                     if (result_m)
                         params.compiled_functions[codeinst] = {std::move(result_m), std::move(decls)};
                 }

--- a/src/gf.c
+++ b/src/gf.c
@@ -470,16 +470,17 @@ JL_DLLEXPORT jl_code_instance_t *jl_get_method_inferred(
     return codeinst;
 }
 
-//JL_DLLEXPORT jl_code_instance_t *jl_get_codeinst_for_src(
-//        jl_method_instance_t *mi JL_PROPAGATES_ROOT, jl_code_info_t *src)
-//{
-//    // TODO: copy backedges from src to mi
-//    size_t max_world = src->max_world;
-//    if (max_world >= jl_atomic_load_acquire(&jl_world_counter))
-//        max_world = ~(size_t)0;
-//    // TODO: this should clone all fields from src that it could to avoid poisoning the IPO cache
-//    return jl_get_method_inferred(mi, src->rettype, src->min_world, max_world, src->debuginfo);
-//}
+JL_DLLEXPORT int jl_mi_cache_has_ci(jl_method_instance_t *mi,
+                                     jl_code_instance_t *ci)
+{
+    jl_code_instance_t *codeinst = jl_atomic_load_relaxed(&mi->cache);
+    while (codeinst) {
+        if (codeinst == ci)
+            return 1;
+        codeinst = jl_atomic_load_relaxed(&codeinst->next);
+    }
+    return 0;
+}
 
 JL_DLLEXPORT jl_code_instance_t *jl_new_codeinst(
         jl_method_instance_t *mi, jl_value_t *owner,

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1028,6 +1028,7 @@ JL_DLLEXPORT void jl_method_instance_add_backedge(jl_method_instance_t *callee, 
 JL_DLLEXPORT void jl_method_table_add_backedge(jl_methtable_t *mt, jl_value_t *typ, jl_value_t *caller);
 JL_DLLEXPORT void jl_mi_cache_insert(jl_method_instance_t *mi JL_ROOTING_ARGUMENT,
                                      jl_code_instance_t *ci JL_ROOTED_ARGUMENT JL_MAYBE_UNROOTED);
+JL_DLLEXPORT int jl_mi_cache_has_ci(jl_method_instance_t *mi, jl_code_instance_t *ci) JL_NOTSAFEPOINT;
 JL_DLLEXPORT extern jl_value_t *(*const jl_rettype_inferred_addr)(jl_method_instance_t *mi JL_PROPAGATES_ROOT, size_t min_world, size_t max_world) JL_NOTSAFEPOINT;
 
 uint32_t jl_module_next_counter(jl_module_t *m) JL_NOTSAFEPOINT;

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -29,7 +29,7 @@ const TESTNAMES = [
         "channels", "iostream", "secretbuffer", "specificity",
         "reinterpretarray", "syntax", "corelogging", "missing", "asyncmap",
         "smallarrayshrink", "opaque_closure", "filesystem", "download",
-        "scopedvalues",
+        "scopedvalues", "compileall"
 ]
 
 const INTERNET_REQUIRED_LIST = [

--- a/test/compileall.jl
+++ b/test/compileall.jl
@@ -5,5 +5,7 @@
 mktempdir() do dir
     run(`$(Base.julia_cmd()) --compile=all --strip-ir --output-o $(dir)/sys.o.a -e 'exit()'`)
     Base.Linking.link_image(joinpath(dir, "sys.o.a"), joinpath(dir, "sys.so"))
-    @test success(`$(Base.julia_cmd()) -J $(dir)/sys.so -e 'Base.scrub_repl_backtrace(nothing); exit()'`)
+    # TODO: Broken on Windows due to
+    # https://github.com/llvm/llvm-project/issues/84424
+    @test success(`$(Base.julia_cmd()) -J $(dir)/sys.so -e 'Base.scrub_repl_backtrace(nothing); exit()'`) broken=Sys.iswindows()
 end

--- a/test/compileall.jl
+++ b/test/compileall.jl
@@ -1,0 +1,9 @@
+# This test builds a full system image, so it can take a little while.
+# We make it a separate test target here, so that it can run in parallel
+# with the rest of the tests.
+
+mktempdir() do dir
+    run(`$(Base.julia_cmd()) --compile=all --strip-ir --output-o $(dir)/sys.o.a -e 'exit()'`)
+    Base.Linking.link_image(joinpath(dir, "sys.o.a"), joinpath(dir, "sys.so"))
+    @test success(`$(Base.julia_cmd()) -J $(dir)/sys.so -e 'Base.scrub_repl_backtrace(nothing); exit()'`)
+end

--- a/test/compileall.jl
+++ b/test/compileall.jl
@@ -3,9 +3,11 @@
 # with the rest of the tests.
 
 mktempdir() do dir
-    run(`$(Base.julia_cmd()) --compile=all --strip-ir --output-o $(dir)/sys.o.a -e 'exit()'`)
-    Base.Linking.link_image(joinpath(dir, "sys.o.a"), joinpath(dir, "sys.so"))
-    # TODO: Broken on Windows due to
-    # https://github.com/llvm/llvm-project/issues/84424
-    @test success(`$(Base.julia_cmd()) -J $(dir)/sys.so -e 'Base.scrub_repl_backtrace(nothing); exit()'`) broken=Sys.iswindows()
+    @test success(`$(Base.julia_cmd()) --compile=all --strip-ir --output-o $(dir)/sys.o.a -e 'exit()'`) broken=(Sys.iswindows() && Sys.WORD_SIZE == 32)
+    if isfile(joinpath(dir, "sys.o.a"))
+        Base.Linking.link_image(joinpath(dir, "sys.o.a"), joinpath(dir, "sys.so"))
+        # TODO: Broken on Windows due to
+        # https://github.com/llvm/llvm-project/issues/84424
+        @test success(`$(Base.julia_cmd()) -J $(dir)/sys.so -e 'Base.scrub_repl_backtrace(nothing); exit()'`) broken=Sys.iswindows()
+    end
 end


### PR DESCRIPTION
This codepath does not have tests, so it wasn't quite correct. Hopefully this fixes it.