### PR TITLE
Create isclosing and isclosed methods

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -387,9 +387,16 @@ function isclosing(x::Union{LibuvStream, LibuvServer})
     return x.status == StatusClosing
 end
 
+"""
+    isclosed(x)
+
+Determine whether a stream has been closed. Return true if the steram has been
+closed. In general, `isclosed(x) == !isopen(x)`.
+"""
 function isclosed(x::Union{LibuvStream, LibuvServer})
     return x.status == StatusClosed
 end
+isclosed(x) = !isopen(x)
 
 function check_open(x::Union{LibuvStream, LibuvServer})
     if !isopen(x) || isclosing(x)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -383,8 +383,16 @@ function isopen(x::Union{LibuvStream, LibuvServer})
     return x.status != StatusClosed
 end
 
+function isclosing(x::Union{LibuvStream, LibuvServer})
+    return x.status == StatusClosing
+end
+
+function isclosed(x::Union{LibuvStream, LibuvServer})
+    return x.status == StatusClosed
+end
+
 function check_open(x::Union{LibuvStream, LibuvServer})
-    if !isopen(x) || x.status == StatusClosing
+    if !isopen(x) || isclosing(x)
         throw(IOError("stream is closed or unusable", 0))
     end
 end


### PR DESCRIPTION
In #53392, I noticed a missing API call to check if a stream had a state of `Base.StatusClosing`.

A stream acquires a state of `Base.StatusClosing` after one uses `close(stream)`.
A stream acquires the state of `Base.StatusClosed` once libuv calls back into Julia to confirm
the closed state.

To avoid the implementation details of how an IO stream's state from leaking out of base, I
propose we add `Base.isclosing` and `Base.isclosed` methods.
