### PR TITLE
Count GC's time waiting for a safepoint as GC time

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -199,7 +199,7 @@ function time_print(io::IO, elapsedtime, bytes=0, gctime=0, allocs=0, lock_confl
                 print(io, ", ")
             end
             print(io, Ryu.writefixed(Float64(100*total_gc_time/elapsedtime), 2), "% gc time")
-            if gcwaittime/total_gc_time > 0.5
+            if gcwaittime/total_gc_time > 0.005
                 print(io, ": ", Ryu.writefixed(Float64(100*gcwaittime/total_gc_time), 0), "% of which was waiting for safepoints")
             end
         end

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -57,7 +57,7 @@ function GC_Diff(new::GC_Num, old::GC_Num)
                    new.poolalloc    - old.poolalloc,
                    new.bigalloc     - old.bigalloc,
                    new.freecall     - old.freecall,
-                   new.total_time   - old.total_time,
+                   (new.total_time  - old.total_time) + (new.total_time_to_safepoint - old.total_time_to_safepoint),
                    new.pause        - old.pause,
                    new.full_sweep   - old.full_sweep)
 end


### PR DESCRIPTION
This is a very simple change that will hopefully help folks identify things like https://discourse.julialang.org/t/inconsistent-cpu-utilisation-in-threads-loops/110512 a little faster.

Before:

```julia
julia> @time @sync begin
           Threads.@spawn @ccall sleep(1::Cuint)::Cuint
           sleep(.5)
           Threads.@spawn GC.gc()
       end
  1.078393 seconds (927 allocations: 65.078 KiB, 5.85% gc time, 1.19% compilation time)
```

After:

```julia
julia> @time @sync begin
           Threads.@spawn @ccall sleep(1::Cuint)::Cuint
           sleep(.5)
           Threads.@spawn GC.gc()
       end
  1.040344 seconds (1.35 k allocations: 65.266 KiB, 50.85% gc time: 94% of which was waiting for safepoints, 1.09% compilation time)
```