### PR TITLE
make debug messages for relocatable srcfiles into a separate group

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3046,9 +3046,9 @@ function parse_cache_header(f::IO, cachefile::AbstractString)
     # determine depot for @depot replacement for include() files and include_dependency() files separately
     srcfiles_depot = resolve_depot(first(srcfiles))
     if srcfiles_depot === :no_depot_found
-        @debug("Unable to resolve @depot tag include() files from cache file $cachefile", srcfiles)
+        @debug("Unable to resolve @depot tag include() files from cache file $cachefile", srcfiles, _group=:relocatable)
     elseif srcfiles_depot === :not_relocatable
-        @debug("include() files from $cachefile are not relocatable", srcfiles)
+        @debug("include() files from $cachefile are not relocatable", srcfiles, _group=:relocatable)
     else
         for inc in includes_srcfiles
             inc.filename = restore_depot_path(inc.filename, srcfiles_depot)
@@ -3057,9 +3057,9 @@ function parse_cache_header(f::IO, cachefile::AbstractString)
     for inc in includes_depfiles
         depot = resolve_depot(inc.filename)
         if depot === :no_depot_found
-            @debug("Unable to resolve @depot tag for include_dependency() file $(inc.filename) from cache file $cachefile", srcfiles)
+            @debug("Unable to resolve @depot tag for include_dependency() file $(inc.filename) from cache file $cachefile", srcfiles, _group=:relocatable)
         elseif depot === :not_relocatable
-            @debug("include_dependency() file $(inc.filename) from $cachefile is not relocatable", srcfiles)
+            @debug("include_dependency() file $(inc.filename) from $cachefile is not relocatable", srcfiles, _group=:relocatable)
         else
             inc.filename = restore_depot_path(inc.filename, depot)
         end


### PR DESCRIPTION
These create a lot of noisy output that is typically not interesting. As an example of the output :

```
┌ Debug: include() files from /Users/kristoffercarlsson/.julia/compiled/v1.12/Pkg/tUTdb_NNLzf.ji are not relocatable
│   srcfiles =
│    Set{String} with 27 elements:
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/BinaryPlatforms_compat.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/MiniProgressBars.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Registry/registry_instance.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Registry/Registry.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Resolve/maxsum.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Types.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/REPLMode/command_declarations.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Resolve/versionweights.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Artifacts.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Operations.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/API.jl"
│      ⋮ 
└ @ Base loading.jl:3051
┌ Debug: include() files from /Users/kristoffercarlsson/.julia/compiled/v1.12/Pkg/tUTdb_Qo7WJ.ji are not relocatable
│   srcfiles =
│    Set{String} with 27 elements:
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/BinaryPlatforms_compat.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/MiniProgressBars.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Registry/registry_instance.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Registry/Registry.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Resolve/maxsum.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Types.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/REPLMode/command_declarations.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Resolve/versionweights.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Artifacts.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Operations.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/API.jl"
│      ⋮ 
└ @ Base loading.jl:3051
┌ Debug: include() files from /Users/kristoffercarlsson/.julia/compiled/v1.12/Pkg/tUTdb_bHWms.ji are not relocatable
│   srcfiles =
│    Set{String} with 27 elements:
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/BinaryPlatforms_compat.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/MiniProgressBars.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Registry/registry_instance.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Registry/Registry.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Resolve/maxsum.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Types.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/REPLMode/command_declarations.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Resolve/versionweights.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Artifacts.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Operations.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/API.jl"
│      ⋮ 
└ @ Base loading.jl:3051
┌ Debug: include() files from /Users/kristoffercarlsson/.julia/compiled/v1.12/Pkg/tUTdb_ePY5e.ji are not relocatable
│   srcfiles =
│    Set{String} with 27 elements:
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/BinaryPlatforms_compat.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/MiniProgressBars.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Registry/registry_instance.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Registry/Registry.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Resolve/maxsum.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Types.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/REPLMode/command_declarations.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Resolve/versionweights.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Artifacts.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Operations.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/API.jl"
│      ⋮ 
└ @ Base loading.jl:3051
┌ Debug: include() files from /Users/kristoffercarlsson/.julia/compiled/v1.12/Pkg/tUTdb_s9CWW.ji are not relocatable
│   srcfiles =
│    Set{String} with 27 elements:
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/BinaryPlatforms_compat.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/MiniProgressBars.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Registry/registry_instance.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Registry/Registry.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Resolve/maxsum.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Types.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/REPLMode/command_declarations.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Resolve/versionweights.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Artifacts.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/Operations.jl"
│      "/Users/kristoffercarlsson/JuliaPkgs/Pkg.jl/src/API.jl"
│      ⋮ 
```

