### PR TITLE
zero(::ArrayWrapper) forwards to parent

### DIFF
--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -291,6 +291,13 @@ function fill!(A::Union{Diagonal,Bidiagonal,Tridiagonal,SymTridiagonal}, x)
     not be filled with $x, since some of its entries are constrained."))
 end
 
+# Zero(::ArrayWrapper) forwards to parent
+for func in [:zero]
+    for Wrapper in [:Symmetric, :Hermitian, :Adjoint, :LowerTriangular, :Transpose, :UpperHessenberg, :UpperTriangular]
+        @eval Base.$func(M::$Wrapper) = $Wrapper($func(parent(M)))
+    end
+end
+
 one(D::Diagonal) = Diagonal(one.(D.diag))
 one(A::Bidiagonal{T}) where T = Bidiagonal(fill!(similar(A.dv, typeof(one(T))), one(T)), fill!(similar(A.ev, typeof(one(T))), zero(one(T))), A.uplo)
 one(A::Tridiagonal{T}) where T = Tridiagonal(fill!(similar(A.du, typeof(one(T))), zero(one(T))), fill!(similar(A.d, typeof(one(T))), one(T)), fill!(similar(A.dl, typeof(one(T))), zero(one(T))))

--- a/stdlib/LinearAlgebra/test/special.jl
+++ b/stdlib/LinearAlgebra/test/special.jl
@@ -2,7 +2,7 @@
 
 module TestSpecial
 
-using Test, LinearAlgebra, Random
+using Test, LinearAlgebra, Random, StaticArrays
 using LinearAlgebra: rmul!
 
 n= 10 #Size of matrix to test
@@ -175,6 +175,23 @@ end
                 @test (op)(A, B) ≈ (op)(Matrix(A), Matrix(B)) ≈ Matrix((op)(A, B))
             end
         end
+    end
+end
+
+@testset "zero(::ArrayWrapper) should forward to the parent" begin
+    # Github Issue #53014
+    Stat_mat = SA[1 2; 2 3]
+    S_z = Symmetric(Stat_mat)
+    H_z = Hermitian(Stat_mat)
+    A_z = Adjoint(Stat_mat)
+    L_t_z = LowerTriangular(Stat_mat)
+    T_z = Transpose(Stat_mat)
+    U_h_z = UpperHessenberg(Stat_mat)
+    U_t_z = UpperTriangular(Stat_mat)
+
+    mats = Any[S_z, H_z, A_z, L_t_z, T_z, U_h_z, U_t_z]
+    for A in mats
+        @test typeof(zero(A)) == typeof(A)
     end
 end
 


### PR DESCRIPTION
Issue: JuliaLang/LinearAlgebra.jl#1050 or [Refer](https://github.com/JuliaLang/LinearAlgebra.jl/issues/1050)

Earlier, upon calling the zero method for different Array Wrappers like `Symmetric`, `Hermitian`, `Adjoint`, etc.; fell back to the `AbstractArray` definition which works in terms of `similar`, (`MMatrix` in the example below).

``` julia
julia> using StaticArrays

julia> zero(Symmetric(SA[1 2; 3 4]))
2×2 Symmetric{Int64, MMatrix{2, 2, Int64, 4}} with indices SOneTo(2)×SOneTo(2):
 0  0
 0  0
```

Now, upon calling zero method for the following Array Wrappers:

- `Symmetric`
- `Hermitian`
- `Adjoint`
- `LowerTriangular`
- `Transpose`
- `UpperHessenberg`
- `UpperTriangular`

``` julia
julia> zero(Symmetric(SA[1 2; 3 3]))
2×2 Symmetric{Int64, SMatrix{2, 2, Int64, 4}} with indices SOneTo(2)×SOneTo(2):
 0  0
 0  0
```