### PR TITLE
`rm`: move open DLLs to temp dir to allow dir to be deleted

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -273,13 +273,6 @@ Stacktrace:
 function rm(path::AbstractString; force::Bool=false, recursive::Bool=false)
     if islink(path) || !isdir(path)
         try
-            @static if Sys.iswindows()
-                # is writable on windows actually means "is deletable"
-                st = lstat(path)
-                if ispath(st) && (filemode(st) & 0o222) == 0
-                    chmod(path, 0o777)
-                end
-            end
             unlink(path)
         catch err
             if force && isa(err, IOError) && err.code==Base.UV_ENOENT

--- a/base/file.jl
+++ b/base/file.jl
@@ -282,13 +282,13 @@ function rm(path::AbstractString; force::Bool=false, recursive::Bool=false)
         end
     else
         if recursive
-            try
-                for p in readdir(path)
+            for p in readdir(path)
+                try
                     rm(joinpath(path, p), force=force, recursive=true)
-                end
-            catch err
-                if !(isa(err, IOError) && err.code==Base.UV_EACCES)
-                    rethrow(err)
+                catch err
+                    if !(isa(err, IOError) && err.code==Base.UV_EACCES)
+                        rethrow(err)
+                    end
                 end
             end
         end

--- a/base/file.jl
+++ b/base/file.jl
@@ -281,8 +281,11 @@ function rm(path::AbstractString; force::Bool=false, recursive::Bool=false)
                     if err.code==Base.UV_EACCES && endswith(path, ".dll")
                         # Loaded DLLs cannot be deleted on Windows, even with posix delete mode
                         # but they can be moved. So move out to allow the dir to be deleted
-                        # and DLL deleted via the temp dir cleanup on next reboot
-                        mv(path, tempname() * "_" * basename(path))
+                        # TODO: Add a mechanism to delete these moved files after dlclose or process exit
+                        dir = mkpath(joinpath(tempdir(), "julia_delayed_deletes"))
+                        temp_path = tempname(dir, cleanup = false) * "_" * basename(path)
+                        @debug "Could not delete DLL most likely because it is loaded, moving to tempdir" path temp_path
+                        mv(path, temp_path)
                     end
                 end
             end

--- a/base/file.jl
+++ b/base/file.jl
@@ -288,7 +288,7 @@ function rm(path::AbstractString; force::Bool=false, recursive::Bool=false, allo
                         # but they can be moved. So move out to allow the dir to be deleted
                         # TODO: Add a mechanism to delete these moved files after dlclose or process exit
                         dir = mkpath(delayed_delete_dir())
-                        temp_path = tempname(dir, cleanup = false) * "_" * basename(path)
+                        temp_path = tempname(dir, cleanup = false, suffix = string("_", basename(path)))
                         @debug "Could not delete DLL most likely because it is loaded, moving to tempdir" path temp_path
                         mv(path, temp_path)
                         return

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2902,7 +2902,11 @@ function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, in
             end
 
             if cache_objects
-                ocachefile = rename_unique_ocachefile(tmppath_so, ocachefile)
+                ocachefile_new = rename_unique_ocachefile(tmppath_so, ocachefile)
+                if ocachefile_new != ocachefile
+                    cachefile = cachefile_from_ocachefile(ocachefile_new)
+                    ocachefile = ocachefile_new
+                end
                 @static if Sys.isapple()
                     run(`$(Linking.dsymutil()) $ocachefile`, Base.DevNull(), Base.DevNull(), Base.DevNull())
                 end
@@ -2925,7 +2929,7 @@ function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, in
     end
 end
 
-function rename_unique_ocachefile(tmppath_so::String, ocachefile_orig::String, ocachefile::String = ocachefile_orig, num = 1)
+function rename_unique_ocachefile(tmppath_so::String, ocachefile_orig::String, ocachefile::String = ocachefile_orig, num = 0)
     try
         rename(tmppath_so, ocachefile; force=true)
     catch e


### PR DESCRIPTION
Based on findings in https://github.com/JuliaLang/julia/pull/53394, loaded (memory mapped) DLLs cannot be deleted on Windows, even with posix delete mode, but they can be moved without breaking the loaded library. So move out to the temp dir to allow the dir to be deleted ~and the DLL will be deleted via the temp dir cleanup on next reboot.~ Turns out Windows doesn't tidy up the temp dir automatically.. So this saves them to a fixed temp dir that Pkg.gc will tidy up https://github.com/JuliaLang/Pkg.jl/pull/3812