### PR TITLE
clarify keyword arg method error message

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -330,7 +330,7 @@ function showerror(io::IO, ex::MethodError)
         if ex.world == typemax(UInt) || isempty(kwargs)
             print(io, "\nThis error has been manually thrown, explicitly, so the method may exist but be intentionally marked as unimplemented.")
         else
-            print(io, "\nThis method may not support any kwargs.")
+            print(io, "\nThis method may not support any keyword arguments.")
         end
     elseif hasmethod(f, arg_types) && !hasmethod(f, arg_types, world=ex.world)
         curworld = get_world_counter()

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -669,7 +669,7 @@ end
 
     str = sprint(Base.showerror, MethodError(Core.kwcall, ((; a=3.0), +, 1.0, 2.0), Base.get_world_counter()))
     @test startswith(str, "MethodError: no method matching +(::Float64, ::Float64; a::Float64)")
-    @test occursin("This method may not support any kwargs", str)
+    @test occursin("This method may not support any keyword arguments", str)
 
     @test_throws "MethodError: no method matching kwcall()" Core.kwcall()
 end


### PR DESCRIPTION
This is a nice explanatory message, so I think we should make the wording less obscure.