### PR TITLE
fix cumsum ignoring first element returned in call to promote_op

### DIFF
--- a/base/accumulate.jl
+++ b/base/accumulate.jl
@@ -33,7 +33,7 @@ function accumulate_pairwise!(op::Op, result::AbstractVector, v::AbstractVector)
 end
 
 function accumulate_pairwise(op, v::AbstractVector{T}) where T
-    out = similar(v, promote_op(op, T, T))
+    out = similar(v, promote_op(op, T, T; throw_error=true))
     return accumulate_pairwise!(op, out, v)
 end
 
@@ -111,7 +111,7 @@ julia> cumsum(a, dims=2)
     widening happens and integer overflow results in `Int8[100, -128]`.
 """
 function cumsum(A::AbstractArray{T}; dims::Integer) where T
-    out = similar(A, promote_op(add_sum, T, T))
+    out = similar(A, promote_op(add_sum, T, T; throw_error=true))
     cumsum!(out, A, dims=dims)
 end
 
@@ -282,9 +282,9 @@ function accumulate(op, A; dims::Union{Nothing,Integer}=nothing, kw...)
     end
     nt = values(kw)
     if isempty(kw)
-        out = similar(A, promote_op(op, eltype(A), eltype(A)))
+        out = similar(A, promote_op(op, eltype(A), eltype(A); throw_error=true))
     elseif keys(nt) === (:init,)
-        out = similar(A, promote_op(op, typeof(nt.init), eltype(A)))
+        out = similar(A, promote_op(op, typeof(nt.init), eltype(A); throw_error=true))
     else
         throw(ArgumentError("accumulate does not support the keyword arguments $(setdiff(keys(nt), (:init,)))"))
     end

--- a/base/accumulate.jl
+++ b/base/accumulate.jl
@@ -33,7 +33,7 @@ function accumulate_pairwise!(op::Op, result::AbstractVector, v::AbstractVector)
 end
 
 function accumulate_pairwise(op, v::AbstractVector{T}) where T
-    out = similar(v, promote_op(op, T, T; throw_error=true))
+    out = similar(v, promote_op(op, T, T))
     return accumulate_pairwise!(op, out, v)
 end
 
@@ -111,7 +111,7 @@ julia> cumsum(a, dims=2)
     widening happens and integer overflow results in `Int8[100, -128]`.
 """
 function cumsum(A::AbstractArray{T}; dims::Integer) where T
-    out = similar(A, promote_op(add_sum, T, T; throw_error=true))
+    out = similar(A, promote_op(add_sum, T, T))
     cumsum!(out, A, dims=dims)
 end
 
@@ -282,9 +282,9 @@ function accumulate(op, A; dims::Union{Nothing,Integer}=nothing, kw...)
     end
     nt = values(kw)
     if isempty(kw)
-        out = similar(A, promote_op(op, eltype(A), eltype(A); throw_error=true))
+        out = similar(A, promote_op(op, eltype(A), eltype(A)))
     elseif keys(nt) === (:init,)
-        out = similar(A, promote_op(op, typeof(nt.init), eltype(A); throw_error=true))
+        out = similar(A, promote_op(op, typeof(nt.init), eltype(A)))
     else
         throw(ArgumentError("accumulate does not support the keyword arguments $(setdiff(keys(nt), (:init,)))"))
     end

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -502,12 +502,10 @@ function TupleOrBottom(tt...)
 end
 
 """
-    promote_op(f, argtypes...; throw_error=false)
+    promote_op(f, argtypes...)
 
 Guess what an appropriate container eltype would be for storing results of
 `f(::argtypes...)`. The guess is in part based on type inference, so can change any time.
-If `f(::argtypes...)` does not return (e.g., a method does not exist) then `Union{}` will be returned.
-Passing `throw_error=true` will cause an error rather than returning `Union{}`.
 
 Accordingly, return a type `R` such that `f(args...) isa R` where `args isa T`.
 
@@ -610,13 +608,7 @@ loosen the API guarantee:
 
 However, it is discouraged to define such unconventional API guarantees.
 """
-function promote_op(f, S::Type...; throw_error=false)
-    T = _promote_op(f, S...)
-    T === Union{} && throw_error && throw(ArgumentError(string(f, S, " does not return")))
-    return T
-end
-
-function _promote_op(f, S::Type...)
+function promote_op(f, S::Type...)
     argT = TupleOrBottom(S...)
     argT === Union{} && return Union{}
     return _return_type(f, argT)

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -502,10 +502,12 @@ function TupleOrBottom(tt...)
 end
 
 """
-    promote_op(f, argtypes...)
+    promote_op(f, argtypes...; throw_error=false)
 
 Guess what an appropriate container eltype would be for storing results of
 `f(::argtypes...)`. The guess is in part based on type inference, so can change any time.
+If `f(::argtypes...)` does not return (e.g., a method does not exist) then `Union{}` will be returned.
+Passing `throw_error=true` will cause an error rather than returning `Union{}`.
 
 Accordingly, return a type `R` such that `f(args...) isa R` where `args isa T`.
 
@@ -608,7 +610,13 @@ loosen the API guarantee:
 
 However, it is discouraged to define such unconventional API guarantees.
 """
-function promote_op(f, S::Type...)
+function promote_op(f, S::Type...; throw_error=false)
+    T = _promote_op(f, S...)
+    T === Union{} && throw_error && throw(ArgumentError(string(f, S, " does not return")))
+    return T
+end
+
+function _promote_op(f, S::Type...)
     argT = TupleOrBottom(S...)
     argT === Union{} && return Union{}
     return _return_type(f, argT)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2854,9 +2854,14 @@ end
 
     # #53438
     v = [(1, 2), (3, 4)]
-    @test_throws "cannot convert a value to Union{}" accumulate(+, v)
-    @test_throws "cannot convert a value to Union{}" cumsum(v)
-    @test_throws "cannot convert a value to Union{}" cumprod(v)
+    @test_throws MethodError accumulate(+, v)
+    @test_throws MethodError cumsum(v)
+    @test_throws MethodError cumprod(v)
+    # Fallback to Iterators.accumulate
+    @test_throws MethodError accumulate(+, v; init=(0, 0))
+    # Fail to fallback if `dims` is set
+    @test_throws "accumulate could not determine an appropriate container eltype" accumulate(+, v; dims=1, init=(0, 0))
+
 end
 
 struct F21666{T <: Base.ArithmeticStyle}

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2854,9 +2854,9 @@ end
 
     # #53438
     v = [(1, 2), (3, 4)]
-    @test_throws "does not return" accumulate(+, v)
-    @test_throws "does not return" cumsum(v)
-    @test_throws "does not return" cumprod(v)
+    @test_throws "cannot convert a value to Union{}" accumulate(+, v)
+    @test_throws "cannot convert a value to Union{}" cumsum(v)
+    @test_throws "cannot convert a value to Union{}" cumprod(v)
 end
 
 struct F21666{T <: Base.ArithmeticStyle}

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2854,9 +2854,9 @@ end
 
     # #53438
     v = [(1, 2), (3, 4)]
-    @test_throws "cannot convert a value to Union{}" accumulate(+, v)
-    @test_throws "cannot convert a value to Union{}" cumsum(v)
-    @test_throws "cannot convert a value to Union{}" cumprod(v)
+    @test_throws "does not return" accumulate(+, v)
+    @test_throws "does not return" cumsum(v)
+    @test_throws "does not return" cumprod(v)
 end
 
 struct F21666{T <: Base.ArithmeticStyle}

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2851,6 +2851,12 @@ end
     @inferred accumulate(*, String[])
     @test accumulate(*, ['a' 'b'; 'c' 'd'], dims=1) == ["a" "b"; "ac" "bd"]
     @test accumulate(*, ['a' 'b'; 'c' 'd'], dims=2) == ["a" "ab"; "c" "cd"]
+
+    # #53438
+    v = [(1, 2), (3, 4)]
+    @test_throws "cannot convert a value to Union{}" accumulate(+, v)
+    @test_throws "cannot convert a value to Union{}" cumsum(v)
+    @test_throws "cannot convert a value to Union{}" cumprod(v)
 end
 
 struct F21666{T <: Base.ArithmeticStyle}

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2871,7 +2871,7 @@ end
         foo(x::ComplexF64, y::Int)::String = string(x, "+", y)
 
         v = collect(1:5)
-        @test Base._accumulate_promote_op(foo, v; init=true) === Base._accumulate_promote_op(foo, v) == Any
+        @test Base._accumulate_promote_op(foo, v; init=true) === Base._accumulate_promote_op(foo, v) == Union{Float64, String, ComplexF64}
         @test Base._accumulate_promote_op(/, v) === Base._accumulate_promote_op(/, v; init=0) == Float64
         @test Base._accumulate_promote_op(+, v) === Base._accumulate_promote_op(+, v; init=0) === Int
         @test Base._accumulate_promote_op(+, v; init=0.0) === Float64

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2589,7 +2589,7 @@ end
     @test accumulate(+, 0x00:0xff)[end] === 0x80         # overflow
     @test_throws InexactError cumsum!(similar(0x00:0xff), 0x00:0xff) # overflow
 
-    @test cumsum([[true], [true], [false]])::Vector{Union{Vector{Bool}, Vector{Int}}} == [[1], [2], [2]]
+    @test cumsum([[true], [true], [false]])::Vector{Vector{Int}} == [[1], [2], [2]]
 end
 #issue #18336
 @test cumsum([-0.0, -0.0])[1] === cumsum([-0.0, -0.0])[2] === -0.0
@@ -2871,11 +2871,12 @@ end
         foo(x::ComplexF64, y::Int)::String = string(x, "+", y)
 
         v = collect(1:5)
-        @test Base._accumulate_promote_op(foo, v; init=true) === Union{Int, Float64, ComplexF64, String}
-        @test Base._accumulate_promote_op(foo, v) === Union{Int, Float64, ComplexF64, String}
-        @test Base._accumulate_promote_op(/, v; init=0) === Float64
-        @test Base._accumulate_promote_op(/, v) === Union{Int, Float64}
+        @test Base._accumulate_promote_op(foo, v; init=true) === Base._accumulate_promote_op(foo, v) == Any
+        @test Base._accumulate_promote_op(/, v) === Base._accumulate_promote_op(/, v; init=0) == Float64
         @test Base._accumulate_promote_op(+, v) === Base._accumulate_promote_op(+, v; init=0) === Int
+        @test Base._accumulate_promote_op(+, v; init=0.0) === Float64
+        @test Base._accumulate_promote_op(+, Union{Int, Missing}[v...]) === Union{Int, Missing}
+        @test Base._accumulate_promote_op(+, Union{Int, Nothing}[v...]) === Union{Int, Nothing}
     end
 end
 


### PR DESCRIPTION
Include an option to have `promote_op` throw an error rather than return `Union{}`. We're not changing the default behaviour, but in some cases returning `Union{}` will result in less clear error messages.

Closes #53438

@LilithHafner may have comments