### PR TITLE
Add `exec` option to `mmap`

### DIFF
--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -81,7 +81,8 @@ function settings(s::RawFD, shared::Bool, exec::Bool)
        prot |= PROT_EXEC
        @static if Sys.isapple()
           MAP_JIT = Cint(0x0800)
-          flags |= MAP_JIT
+          # Bypassing W^X protections requires the MAP_JIT permission
+          ((prot & PROT_WRITE) > 0) && (flags |= MAP_JIT)
        end
     end
     return prot, flags, (prot & PROT_WRITE) > 0

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -63,7 +63,7 @@ const F_GETFL       = Cint(3)
 gethandle(io::IO) = RawFD(fd(io))
 
 # Determine a stream's read/write mode, and return prot & flags appropriate for mmap
-function settings(s::RawFD, shared::Bool, exec::Bool=false)
+function settings(s::RawFD, shared::Bool, exec::Bool)
     flags = shared ? MAP_SHARED : MAP_PRIVATE
     if s == INVALID_OS_HANDLE
         flags |= MAP_ANONYMOUS

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -77,7 +77,13 @@ function settings(s::RawFD, shared::Bool, exec::Bool=false)
             throw(ArgumentError("mmap requires read permissions on the file (open with \"r+\" mode to override)"))
         end
     end
-    exec && (prot |= PROT_EXEC)
+    if exec
+       prot |= PROT_EXEC
+       @static if Sys.isapple()
+          MAP_JIT = Cint(0x0800)
+          flags |= MAP_JIT
+       end
+    end
     return prot, flags, (prot & PROT_WRITE) > 0
 end
 

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -137,7 +137,7 @@ end # os-test
 """
     mmap(io::Union{IOStream,AbstractString}[, type::Type{Array{T,N}}, dims, offset]; grow::Bool=true, shared::Bool=true)
     mmap(io::Anonymous[, type::Type{Array{T,N}}, dims, offset]; grow::Bool=true, shared::Bool=true, exec::Bool=false)
-    mmap(type::Type{Array{T,N}}, dims)
+    mmap(type::Type{Array{T,N}}, dims; shared::Bool=true, exec::Bool=false)
 
 Create an `Array` whose values are linked to a file, using memory-mapping. This provides a
 convenient way of working with data too large to fit in the computer's memory.

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -223,9 +223,6 @@ function _mmap(io::IO,
     # check inputs
     isopen(io) || throw(ArgumentError("$io must be open to mmap"))
     isbitstype(T)  || throw(ArgumentError("unable to mmap $T; must satisfy isbitstype(T) == true"))
-    if exec && !iswritable(io)
-        throw(ArgumentError("$io must be writeable to mmap with exec = true"))
-    end
     @static if Sys.isapple()
        # on MacOS exec=true requires the MAP_JIT flag to bypass W^X protections
        # but combining MAP_JIT with MAP_SHARED is disallowed on MacOS, although its undocumented

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -168,6 +168,10 @@ will be visible to other processes mapping the same file.
 
 The `exec` keyword argument specifies whether the underlying mmap data will be executable.
 
+!!! note
+    On MacOS `exec=true` implies `shared=false`, because each thread has its own access permissions to `mmap` regions.
+
+
 For example, the following code
 
 ```julia
@@ -222,11 +226,10 @@ function _mmap(io::IO,
     if exec && !iswritable(io)
         throw(ArgumentError("$io must be writeable to mmap with exec = true"))
     end
-
     @static if Sys.isapple()
-        # on MacOS each thread has its own access permissions, so we can't share when exec=true
-        # https://developer.apple.com/documentation/apple-silicon/porting-just-in-time-compilers-to-apple-silicon#Disable-Write-Protections-Before-You-Generate-Instructions
-        exec && (shared = false)
+       # on MacOS each thread has its own access permissions, so we can't share when exec=true
+       # https://developer.apple.com/documentation/apple-silicon/porting-just-in-time-compilers-to-apple-silicon#Disable-Write-Protections-Before-You-Generate-Instructions
+       exec && (shared = false)
     end
 
     len = Base.aligned_sizeof(T)

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -206,7 +206,7 @@ function mmap(io::Anonymous,
               type::Type{Array{T,N}}=Vector{UInt8},
               dims::NTuple{N,Integer}=(div(filesize(io)-position(io),sizeof(T)),),
               offset::Integer=position(io); grow::Bool=true, shared::Bool=true,
-              exec::Bool=true) where {T,N}
+              exec::Bool=false) where {T,N}
     _mmap(io, type, dims, offset; grow, shared, exec)
 end
 

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -160,7 +160,7 @@ privileges are required to grow the file.
 The `shared` keyword argument specifies whether the resulting `Array` and changes made to it
 will be visible to other processes mapping the same file.
 
-The `exec` keyword argument specifies whether the underlying mmap data will be executale.
+The `exec` keyword argument specifies whether the underlying mmap data will be executable.
 
 For example, the following code
 

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -219,8 +219,8 @@ function _mmap(io::IO,
     # check inputs
     isopen(io) || throw(ArgumentError("$io must be open to mmap"))
     isbitstype(T)  || throw(ArgumentError("unable to mmap $T; must satisfy isbitstype(T) == true"))
-    if exec && !(io isa Anonymous)
-        throw(ArgumentError("unable to mmap a file with exec=true"))
+    if exec && !iswritable(io)
+        throw(ArgumentError("$io must be writeable to mmap with exec = true"))
     end
 
     len = Base.aligned_sizeof(T)

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -167,6 +167,7 @@ The `shared` keyword argument specifies whether the resulting `Array` and change
 will be visible to other processes mapping the same file.
 
 The `exec` keyword argument specifies whether the underlying mmap data will be executable.
+Warning: on most CPUs, you must call a platform-specific function after creating this region and after writing to it, before executing it, or risk unpredictable behavior and corruption.
 
 !!! note
     On MacOS `exec=true` implies `shared=false`.

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -253,7 +253,7 @@ function mmap(io::IO,
         handle = create ? ccall(:CreateFileMappingW, stdcall, Ptr{Cvoid}, (OS_HANDLE, Ptr{Cvoid}, DWORD, DWORD, DWORD, Cwstring),
                                 file_desc, C_NULL, page_flag, szfile >> 32, szfile & typemax(UInt32), name) :
                           ccall(:OpenFileMappingW, stdcall, Ptr{Cvoid}, (DWORD, Cint, Cwstring),
-                                page_flag, true, name)
+                                file_flag, true, name)
         Base.windowserror(:mmap, handle == C_NULL)
         ptr = ccall(:MapViewOfFile, stdcall, Ptr{Cvoid}, (Ptr{Cvoid}, DWORD, DWORD, DWORD, Csize_t),
                     handle, file_flag, offset_page >> 32, offset_page & typemax(UInt32), mmaplen)

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -223,6 +223,12 @@ function _mmap(io::IO,
         throw(ArgumentError("$io must be writeable to mmap with exec = true"))
     end
 
+    @static if Sys.isapple()
+        # on MacOS each thread has its own access permissions, so we can't share when exec=true
+        # https://developer.apple.com/documentation/apple-silicon/porting-just-in-time-compilers-to-apple-silicon#Disable-Write-Protections-Before-You-Generate-Instructions
+        exec && (shared = false)
+    end
+
     len = Base.aligned_sizeof(T)
     for l in dims
         len, overflow = Base.Checked.mul_with_overflow(promote(len, l)...)

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -169,7 +169,7 @@ will be visible to other processes mapping the same file.
 The `exec` keyword argument specifies whether the underlying mmap data will be executable.
 
 !!! note
-    On MacOS `exec=true` implies `shared=false`, because each thread has its own access permissions to `mmap` regions.
+    On MacOS `exec=true` implies `shared=false`.
 
 
 For example, the following code
@@ -227,8 +227,9 @@ function _mmap(io::IO,
         throw(ArgumentError("$io must be writeable to mmap with exec = true"))
     end
     @static if Sys.isapple()
-       # on MacOS each thread has its own access permissions, so we can't share when exec=true
-       # https://developer.apple.com/documentation/apple-silicon/porting-just-in-time-compilers-to-apple-silicon#Disable-Write-Protections-Before-You-Generate-Instructions
+       # on MacOS exec=true requires the MAP_JIT flag to bypass W^X protections
+       # but combining MAP_JIT with MAP_SHARED is disallowed on MacOS, although its undocumented
+       # https://github.com/apple-oss-distributions/xnu/blob/1031c584a5e37aff177559b9f69dbd3c8c3fd30a/bsd/kern/kern_mman.c#L328-L337
        exec && (shared = false)
     end
 

--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -28,12 +28,10 @@ finalize(m); m=nothing; GC.gc()
 @test length(@inferred mmap(file, Matrix{Int8}, (12,1), 0)) == 12
 @test length(@inferred mmap(file, Matrix{Int8}, (12,1), 0; grow=false)) == 12
 @test length(@inferred mmap(file, Matrix{Int8}, (12,1), 0; shared=false)) == 12
-@test length(@inferred mmap(file, Matrix{Int8}, (12,1), 0; exec=true)) == 12
 @test length(@inferred mmap(file, Vector{Int8}, 12)) == 12
 @test length(@inferred mmap(file, Vector{Int8}, 12, 0)) == 12
 @test length(@inferred mmap(file, Vector{Int8}, 12, 0; grow=false)) == 12
 @test length(@inferred mmap(file, Vector{Int8}, 12, 0; shared=false)) == 12
-@test length(@inferred mmap(file, Vector{Int8}, 12, 0; exec=true)) == 12
 s = open(file)
 @test length(@inferred mmap(s)) == 12
 @test length(@inferred mmap(s, Vector{Int8})) == 12
@@ -41,12 +39,10 @@ s = open(file)
 @test length(@inferred mmap(s, Matrix{Int8}, (12,1), 0)) == 12
 @test length(@inferred mmap(s, Matrix{Int8}, (12,1), 0; grow=false)) == 12
 @test length(@inferred mmap(s, Matrix{Int8}, (12,1), 0; shared=false)) == 12
-@test length(@inferred mmap(s, Matrix{Int8}, (12,1), 0; exec=true)) == 12
 @test length(@inferred mmap(s, Vector{Int8}, 12)) == 12
 @test length(@inferred mmap(s, Vector{Int8}, 12, 0)) == 12
 @test length(@inferred mmap(s, Vector{Int8}, 12, 0; grow=false)) == 12
 @test length(@inferred mmap(s, Vector{Int8}, 12, 0; shared=false)) == 12
-@test length(@inferred mmap(s, Vector{Int8}, 12, 0; exec=true)) == 12
 close(s)
 @test_throws ArgumentError mmap(file, Vector{Ref}) # must be bit-type
 GC.gc(); GC.gc()
@@ -297,8 +293,10 @@ m = mmap(Vector{UInt8}, 12)
 m[1] = 0x0a
 Mmap.sync!(m)
 @test m[1] === 0x0a
-m = mmap(Vector{UInt8}, 12; shared=false)
-m = mmap(Vector{UInt8}, 12; exec=true)
+m = mmap(Vector{UInt8}, 12; shared=false, exec=false)
+m = mmap(Vector{UInt8}, 12; shared=true,  exec=false)
+m = mmap(Vector{UInt8}, 12; shared=false, exec=true)
+m = mmap(Vector{UInt8}, 12; shared=true,  exec=true)
 m = mmap(Vector{Int}, 12)
 @test length(m) == 12
 @test all(m .== 0)

--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -28,10 +28,12 @@ finalize(m); m=nothing; GC.gc()
 @test length(@inferred mmap(file, Matrix{Int8}, (12,1), 0)) == 12
 @test length(@inferred mmap(file, Matrix{Int8}, (12,1), 0; grow=false)) == 12
 @test length(@inferred mmap(file, Matrix{Int8}, (12,1), 0; shared=false)) == 12
+@test length(@inferred mmap(file, Matrix{Int8}, (12,1), 0; exec=true)) == 12
 @test length(@inferred mmap(file, Vector{Int8}, 12)) == 12
 @test length(@inferred mmap(file, Vector{Int8}, 12, 0)) == 12
 @test length(@inferred mmap(file, Vector{Int8}, 12, 0; grow=false)) == 12
 @test length(@inferred mmap(file, Vector{Int8}, 12, 0; shared=false)) == 12
+@test length(@inferred mmap(file, Vector{Int8}, 12, 0; exec=true)) == 12
 s = open(file)
 @test length(@inferred mmap(s)) == 12
 @test length(@inferred mmap(s, Vector{Int8})) == 12
@@ -39,10 +41,12 @@ s = open(file)
 @test length(@inferred mmap(s, Matrix{Int8}, (12,1), 0)) == 12
 @test length(@inferred mmap(s, Matrix{Int8}, (12,1), 0; grow=false)) == 12
 @test length(@inferred mmap(s, Matrix{Int8}, (12,1), 0; shared=false)) == 12
+@test length(@inferred mmap(s, Matrix{Int8}, (12,1), 0; exec=true)) == 12
 @test length(@inferred mmap(s, Vector{Int8}, 12)) == 12
 @test length(@inferred mmap(s, Vector{Int8}, 12, 0)) == 12
 @test length(@inferred mmap(s, Vector{Int8}, 12, 0; grow=false)) == 12
 @test length(@inferred mmap(s, Vector{Int8}, 12, 0; shared=false)) == 12
+@test length(@inferred mmap(s, Vector{Int8}, 12, 0; exec=true)) == 12
 close(s)
 @test_throws ArgumentError mmap(file, Vector{Ref}) # must be bit-type
 GC.gc(); GC.gc()
@@ -294,6 +298,7 @@ m[1] = 0x0a
 Mmap.sync!(m)
 @test m[1] === 0x0a
 m = mmap(Vector{UInt8}, 12; shared=false)
+m = mmap(Vector{UInt8}, 12; exec=true)
 m = mmap(Vector{Int}, 12)
 @test length(m) == 12
 @test all(m .== 0)


### PR DESCRIPTION
`mmap(exec=true)` should allow one to generate a buffer that is writeable and (with enough precautions taken) can be executed.

We only implement `exec=true` for non-file-backed `mmap`, in which we request a new file handle from the OS, as otherwise we would have to adjust permissions on whatever file handle we received, which might not be possible in all cases.

---

MWE. Don't try this at home

```julia
# mwe_exec.jl
using Mmap

buf = mmap(Vector{UInt8}, 6, shared=false, exec=true)
function myidentity(x::Int32)
    ux = unsigned(x)
    buf[1] = 0xb8
    buf[2:5] .= reinterpret(UInt8, [ux])
    buf[6] = 0xc3
    return ccall(pointer(buf), Cint, ())
end

for x in rand(Int32, 5)
    @show x == myidentity(x)
end
```
```julia
julia> versioninfo()
Julia Version 1.12.0-DEV.5
Commit 1c13b8b90f (2024-02-17 22:20 UTC)
Platform Info:
  OS: Linux (x86_64-unknown-linux-gnu)
  CPU: 12 × Intel(R) Core(TM) i7-5820K CPU @ 3.30GHz
  WORD_SIZE: 64
  LLVM: libLLVM-16.0.6 (ORCJIT, haswell)
Threads: 1 default, 0 interactive, 1 GC (on 12 virtual cores)

julia> include("mwe_exec.jl")
x == myidentity(x) = true
x == myidentity(x) = true
x == myidentity(x) = true
x == myidentity(x) = true
x == myidentity(x) = true
```

- Anyone knows why this segfaults when either `buf` is marked `const` or `buf` initialization is moved into `myidentity`?