### PR TITLE
Wrap `contrib/check-whitespace.jl` in a function

### DIFF
--- a/contrib/check-whitespace.jl
+++ b/contrib/check-whitespace.jl
@@ -32,39 +32,43 @@ allow_tabs(path) =
 
 const errors = Set{Tuple{String,Int,String}}()
 
-for path in eachline(`git ls-files -- $patterns`)
-    lineno = 0
-    non_blank = 0
+function check_whitespace()
+    for path in eachline(`git ls-files -- $patterns`)
+        lineno = 0
+        non_blank = 0
 
-    file_err(msg) = push!(errors, (path, 0, msg))
-    line_err(msg) = push!(errors, (path, lineno, msg))
+        file_err(msg) = push!(errors, (path, 0, msg))
+        line_err(msg) = push!(errors, (path, lineno, msg))
 
-    isfile(path) || continue
-    for line in eachline(path, keep=true)
-        lineno += 1
-        contains(line, '\r')   && file_err("non-UNIX line endings")
-        contains(line, '\ua0') && line_err("non-breaking space")
-        allow_tabs(path) ||
-        contains(line, '\t')   && line_err("tab")
-        endswith(line, '\n')   || line_err("no trailing newline")
-        line = chomp(line)
-        endswith(line, r"\s")  && line_err("trailing whitespace")
-        contains(line, r"\S")  && (non_blank = lineno)
-    end
-    non_blank < lineno         && line_err("trailing blank lines")
-end
-
-if isempty(errors)
-    println(stderr, "Whitespace check found no issues.")
-    exit(0)
-else
-    println(stderr, "Whitespace check found $(length(errors)) issues:")
-    for (path, lineno, msg) in sort!(collect(errors))
-        if lineno == 0
-            println(stderr, "$path -- $msg")
-        else
-            println(stderr, "$path:$lineno -- $msg")
+        isfile(path) || continue
+        for line in eachline(path, keep=true)
+            lineno += 1
+            contains(line, '\r')   && file_err("non-UNIX line endings")
+            contains(line, '\ua0') && line_err("non-breaking space")
+            allow_tabs(path) ||
+                contains(line, '\t')   && line_err("tab")
+            endswith(line, '\n')   || line_err("no trailing newline")
+            line = chomp(line)
+            endswith(line, r"\s")  && line_err("trailing whitespace")
+            contains(line, r"\S")  && (non_blank = lineno)
         end
+        non_blank < lineno         && line_err("trailing blank lines")
     end
-    exit(1)
+
+    if isempty(errors)
+        println(stderr, "Whitespace check found no issues.")
+        exit(0)
+    else
+        println(stderr, "Whitespace check found $(length(errors)) issues:")
+        for (path, lineno, msg) in sort!(collect(errors))
+            if lineno == 0
+                println(stderr, "$path -- $msg")
+            else
+                println(stderr, "$path:$lineno -- $msg")
+            end
+        end
+        exit(1)
+    end
 end
+
+check_whitespace()


### PR DESCRIPTION
This doesn't affect much CI time as the job is vastly dominated by setup rather than performing the actual check, but locally you can enjoy a sensible speedup: 
```console
% hyperfine --warmup=1 'julia contrib/check-whitespace.jl' 'julia contrib/check-whitespace-new.jl'
Benchmark 1: julia contrib/check-whitespace.jl
  Time (mean ± σ):      2.143 s ±  0.015 s    [User: 2.880 s, System: 0.056 s]
  Range (min … max):    2.129 s …  2.170 s    10 runs

Benchmark 2: julia contrib/check-whitespace-new.jl
  Time (mean ± σ):      1.080 s ±  0.004 s    [User: 1.830 s, System: 0.050 s]
  Range (min … max):    1.075 s …  1.087 s    10 runs

Summary
  'julia contrib/check-whitespace-new.jl' ran
    1.98 ± 0.02 times faster than 'julia contrib/check-whitespace.jl'
```

Somewhat ironically, PR better reviewed by [ignoring whitespaces](https://github.com/JuliaLang/julia/pull/53468/files?w=1).