### PR TITLE
Provide better error hint when `UndefVarError` results from name clashes

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -47,7 +47,10 @@ function UndefVarError_hint(io::IO, ex::UndefVarError)
                     # It could be the binding was exported by two modules, which we can detect
                     # by the `usingfailed` flag in the binding:
                     if isdefined(bnd, :flags) && Bool(bnd.flags >> 4 & 1) # magic location of the `usingfailed` flag
-                        print(io, "\nHint: It looks like this name was exported by two different modules, resulting in ambiguity. Try explicitly importing it, or qualifying the name with the module it should come from.")
+                        print(io, "\nHint: It looks like two or more modules export different ",
+                              "bindings with this name, resulting in ambiguity. Try explicitly ",
+                              "importing it from a particular module, or qualifying the name ",
+                              "with the module it should come from.")
                     else
                         print(io, "\nSuggestion: check for spelling errors or missing imports.")
                     end

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -44,7 +44,13 @@ function UndefVarError_hint(io::IO, ex::UndefVarError)
                 if C_NULL == owner
                     # No global of this name exists in this module.
                     # This is the common case, so do not print that information.
-                    print(io, "\nSuggestion: check for spelling errors or missing imports.")
+                    # It could be the binding was exported by two modules, which we can detect
+                    # by the `usingfailed` flag in the binding:
+                    if isdefined(bnd, :flags) && Bool(bnd.flags >> 4 & 1) # magic location of the `usingfailed` flag
+                        print(io, "\nHint: It looks like this name was exported by two different modules, resulting in ambiguity. Try explicitly importing it, or qualifying the name with the module it should come from.")
+                    else
+                        print(io, "\nSuggestion: check for spelling errors or missing imports.")
+                    end
                     owner = bnd
                 else
                     owner = unsafe_pointer_to_objref(owner)::Core.Binding

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1716,14 +1716,7 @@ try # test the functionality of `UndefVarError_hint` against import clashes
 
     end # X
 
-    str = try
-        X.x
-        @test false # should not reach this
-    catch e
-        sprint(Base.showerror, e)
-    end
-
-    @test contains(str, "Hint: It looks like this name was exported by two different modules, resulting in ambiguity. Try explicitly importing it, or qualifying the name with the module it should come from.")
+    @test_throws "Hint: It looks like this name was exported by two different modules, resulting in ambiguity. Try explicitly importing it, or qualifying the name with the module it should come from." X.x
 finally
     empty!(Base.Experimental._hint_handlers)
 end

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1716,7 +1716,11 @@ try # test the functionality of `UndefVarError_hint` against import clashes
 
     end # X
 
-    @test_throws "Hint: It looks like this name was exported by two different modules, resulting in ambiguity. Try explicitly importing it, or qualifying the name with the module it should come from." X.x
+    expected_message = string("\nHint: It looks like two or more modules export different ",
+                              "bindings with this name, resulting in ambiguity. Try explicitly ",
+                              "importing it from a particular module, or qualifying the name ",
+                              "with the module it should come from.")
+    @test_throws expected_message X.x
 finally
     empty!(Base.Experimental._hint_handlers)
 end

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1700,33 +1700,30 @@ try # test the functionality of `UndefVarError_hint` against import clashes
     @assert isempty(Base.Experimental._hint_handlers)
     Base.Experimental.register_error_hint(REPL.UndefVarError_hint, UndefVarError)
 
-    fake_repl() do stdin_write, stdout_read, repl
-        backend = REPL.REPLBackend()
-        repltask = @async REPL.run_repl(repl; backend)
-        write(stdin_write, """
-        module X
+    @eval module X
 
-        module A
-        export x
-        x = 1
-        end # A
+    module A
+    export x
+    x = 1
+    end # A
 
-        module B
-        export x
-        x = 2
-        end # B
+    module B
+    export x
+    x = 2
+    end # B
 
-        using .A, .B
+    using .A, .B
 
-        end # X
-        """)
-        write(stdin_write,
-              "\nX.x\n\"ZZZZZ\"\n")
-        txt = readuntil(stdout_read, "ZZZZZ")
-        write(stdin_write, '\x04')
-        wait(repltask)
-        @test occursin("Hint: It looks like this name was exported by two different modules, resulting in ambiguity. Try explicitly importing it, or qualifying the name with the module it should come from.", txt)
+    end # X
+
+    str = try
+        X.x
+        @test false # should not reach this
+    catch e
+        sprint(Base.showerror, e)
     end
+
+    @test contains(str, "Hint: It looks like this name was exported by two different modules, resulting in ambiguity. Try explicitly importing it, or qualifying the name with the module it should come from.")
 finally
     empty!(Base.Experimental._hint_handlers)
 end


### PR DESCRIPTION
We can detect this since we set the `usingfailed` bit when the clash occurs (to avoid printing the `WARNING` multiple times). In this case, typos or missing imports (the current message) isn't quite as clear as it could be, because in fact the name is probably spelled totally right, it's just that there is a missing explicit import or the name should be qualified.

This code will stop working if we change the flags in `Core.Binding`, but the test I added should catch that. However if REPL is supposed to be independent of Base and not depend on internals there, there could be an issue. In that case we should probably add an API to Base to inspect this `usingfailed` bit so we can use it in the REPL.