### PR TITLE
Fix boundscheck in unsetindex for SubArrays

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -412,19 +412,19 @@ end
 
 function _unsetindex!(V::FastSubArray, i::Int)
     @inline
-    @boundscheck checkbounds(Bool, V, i)
+    @boundscheck checkbounds(V, i)
     @inbounds _unsetindex!(V.parent, _reindexlinear(V, i))
     return V
 end
 function _unsetindex!(V::FastSubArray{<:Any,1}, i::Int)
     @inline
-    @boundscheck checkbounds(Bool, V, i)
+    @boundscheck checkbounds(V, i)
     @inbounds _unsetindex!(V.parent, _reindexlinear(V, i))
     return V
 end
 function _unsetindex!(V::SubArray{T,N}, i::Vararg{Int,N}) where {T,N}
     @inline
-    @boundscheck checkbounds(Bool, V, i...)
+    @boundscheck checkbounds(V, i...)
     @inbounds _unsetindex!(V.parent, reindex(V.indices, i)...)
     return V
 end

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -1062,6 +1062,8 @@ end
             for i in eachindex(A)
                 @test !isassigned(A, i)
             end
+            inds = eachindex(A)
+            @test_throws BoundsError Base._unsetindex!(A, last(inds) + oneunit(eltype(inds)))
         end
         @testset "dest IndexLinear, src IndexLinear" begin
             for p in (fill(BigInt(2)), BigInt[1, 2], BigInt[1 2; 3 4])


### PR DESCRIPTION
These had been copy-pasted incorrectly in https://github.com/JuliaLang/julia/pull/53383, and should throw an error if the indices are out of bounds.