### PR TITLE
enhance the effectiveness of the test cases introduced in #53300

### DIFF
--- a/test/precompile_absint1.jl
+++ b/test/precompile_absint1.jl
@@ -1,0 +1,73 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+using Test
+
+include("precompile_utils.jl")
+
+precompile_test_harness() do load_path
+    write(joinpath(load_path, "SimpleModule.jl"), :(module SimpleModule
+        basic_callee(x) = x
+        basic_caller(x) = basic_callee(x)
+    end) |> string)
+
+    newinterp_path = abspath("compiler/newinterp.jl")
+    write(joinpath(load_path, "TestAbsIntPrecompile1.jl"), :(module TestAbsIntPrecompile1
+        import SimpleModule: basic_caller, basic_callee
+
+        module Custom
+            include("$($newinterp_path)")
+            @newinterp PrecompileInterpreter
+        end
+
+        Base.return_types((Float64,)) do x
+            basic_caller(x)
+        end
+        Base.return_types((Float64,); interp=Custom.PrecompileInterpreter()) do x
+            basic_caller(x)
+        end
+        Base.return_types((Vector{Float64},)) do x
+            sum(x)
+        end
+        Base.return_types((Vector{Float64},); interp=Custom.PrecompileInterpreter()) do x
+            sum(x)
+        end
+    end) |> string)
+    Base.compilecache(Base.PkgId("TestAbsIntPrecompile1"))
+
+    @eval let
+        using TestAbsIntPrecompile1
+        cache_owner = Core.Compiler.cache_owner(
+            TestAbsIntPrecompile1.Custom.PrecompileInterpreter())
+        let m = only(methods(TestAbsIntPrecompile1.basic_callee))
+            mi = only(Base.specializations(m))
+            ci = mi.cache
+            @test isdefined(ci, :next)
+            @test ci.owner === nothing
+            @test ci.max_world == typemax(UInt)
+            ci = ci.next
+            @test !isdefined(ci, :next)
+            @test ci.owner === cache_owner
+            @test ci.max_world == typemax(UInt)
+        end
+        let m = only(methods(sum, (Vector{Float64},)))
+            found = false
+            for mi in Base.specializations(m)
+                if mi isa Core.MethodInstance && mi.specTypes == Tuple{typeof(sum),Vector{Float64}}
+                    ci = mi.cache
+                    @test isdefined(ci, :next)
+                    @test ci.owner === cache_owner
+                    @test ci.max_world == typemax(UInt)
+                    ci = ci.next
+                    @test !isdefined(ci, :next)
+                    @test ci.owner === nothing
+                    @test ci.max_world == typemax(UInt)
+                    found = true
+                    break
+                end
+            end
+            @test found
+        end
+    end
+end
+
+finish_precompile_test!()

--- a/test/precompile_absint2.jl
+++ b/test/precompile_absint2.jl
@@ -1,0 +1,96 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+using Test
+
+include("precompile_utils.jl")
+
+precompile_test_harness() do load_path
+    write(joinpath(load_path, "SimpleModule.jl"), :(module SimpleModule
+        basic_callee(x) = x
+        basic_caller(x) = basic_callee(x)
+    end) |> string)
+
+    newinterp_path = abspath("compiler/newinterp.jl")
+    write(joinpath(load_path, "TestAbsIntPrecompile2.jl"), :(module TestAbsIntPrecompile2
+        import SimpleModule: basic_caller, basic_callee
+
+        module Custom
+            const CC = Core.Compiler
+            include("$($newinterp_path)")
+            @newinterp PrecompileInterpreter
+            struct CustomData
+                inferred
+                CustomData(@nospecialize inferred) = new(inferred)
+            end
+            function CC.transform_result_for_cache(interp::PrecompileInterpreter,
+                    mi::Core.MethodInstance, valid_worlds::CC.WorldRange, result::CC.InferenceResult)
+                inferred_result = @invoke CC.transform_result_for_cache(interp::CC.AbstractInterpreter,
+                    mi::Core.MethodInstance, valid_worlds::CC.WorldRange, result::CC.InferenceResult)
+                return CustomData(inferred_result)
+            end
+            function CC.src_inlining_policy(interp::PrecompileInterpreter, @nospecialize(src),
+                                            @nospecialize(info::CC.CallInfo), stmt_flag::UInt32)
+                if src isa CustomData
+                    src = src.inferred
+                end
+                return @invoke CC.src_inlining_policy(interp::CC.AbstractInterpreter, src::Any,
+                                                      info::CC.CallInfo, stmt_flag::UInt32)
+            end
+            CC.retrieve_ir_for_inlining(cached_result::Core.CodeInstance, src::CustomData) =
+                CC.retrieve_ir_for_inlining(cached_result, src.inferred)
+            CC.retrieve_ir_for_inlining(mi::Core.MethodInstance, src::CustomData, preserve_local_sources::Bool) =
+                CC.retrieve_ir_for_inlining(mi, src.inferred, preserve_local_sources)
+        end
+
+        Base.return_types((Float64,)) do x
+            basic_caller(x)
+        end
+        Base.return_types((Float64,); interp=Custom.PrecompileInterpreter()) do x
+            basic_caller(x)
+        end
+        Base.return_types((Vector{Float64},)) do x
+            sum(x)
+        end
+        Base.return_types((Vector{Float64},); interp=Custom.PrecompileInterpreter()) do x
+            sum(x)
+        end
+    end) |> string)
+    Base.compilecache(Base.PkgId("TestAbsIntPrecompile2"))
+
+    @eval let
+        using TestAbsIntPrecompile2
+        cache_owner = Core.Compiler.cache_owner(
+            TestAbsIntPrecompile2.Custom.PrecompileInterpreter())
+        let m = only(methods(TestAbsIntPrecompile2.basic_callee))
+            mi = only(Base.specializations(m))
+            ci = mi.cache
+            @test isdefined(ci, :next)
+            @test ci.owner === nothing
+            @test ci.max_world == typemax(UInt)
+            ci = ci.next
+            @test !isdefined(ci, :next)
+            @test ci.owner === cache_owner
+            @test ci.max_world == typemax(UInt)
+        end
+        let m = only(methods(sum, (Vector{Float64},)))
+            found = false
+            for mi = Base.specializations(m)
+                if mi isa Core.MethodInstance && mi.specTypes == Tuple{typeof(sum),Vector{Float64}}
+                    ci = mi.cache
+                    @test isdefined(ci, :next)
+                    @test ci.owner === cache_owner
+                    @test ci.max_world == typemax(UInt)
+                    ci = ci.next
+                    @test !isdefined(ci, :next)
+                    @test ci.owner === nothing
+                    @test ci.max_world == typemax(UInt)
+                    found = true
+                    break
+                end
+            end
+            @test found
+        end
+    end
+end
+
+finish_precompile_test!()

--- a/test/precompile_utils.jl
+++ b/test/precompile_utils.jl
@@ -1,0 +1,41 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+function precompile_test_harness(@nospecialize(f), testset::String)
+    @testset "$testset" precompile_test_harness(f, true)
+end
+function precompile_test_harness(@nospecialize(f), separate::Bool=true)
+    load_path = mktempdir()
+    load_cache_path = separate ? mktempdir() : load_path
+    try
+        pushfirst!(LOAD_PATH, load_path)
+        pushfirst!(DEPOT_PATH, load_cache_path)
+        f(load_path)
+    finally
+        try
+            rm(load_path, force=true, recursive=true)
+        catch err
+            @show err
+        end
+        if separate
+            try
+                rm(load_cache_path, force=true, recursive=true)
+            catch err
+                @show err
+            end
+        end
+        filter!((≠)(load_path), LOAD_PATH)
+        separate && filter!((≠)(load_cache_path), DEPOT_PATH)
+    end
+    return nothing
+end
+
+let original_depot_path = copy(Base.DEPOT_PATH)
+    original_load_path = copy(Base.LOAD_PATH)
+
+    global function finish_precompile_test!()
+        empty!(Base.DEPOT_PATH)
+        append!(Base.DEPOT_PATH, original_depot_path)
+        empty!(Base.LOAD_PATH)
+        append!(Base.LOAD_PATH, original_load_path)
+    end
+end


### PR DESCRIPTION
While experimenting with precompilation for external absints on builds just after #53300 was merged, I found that the test case for `CustomAbstractInterpreterCaching2.jl` fails if the test case for `CustomAbstractInterpreterCaching1.jl` isn't run in the same session beforehand. That is probably because of the previous lack of support for proper `CodeInstance` caching. To address this, I've changed the tests to run in separate processes in this commit. Note that it appears that a recent refactor concerning `CodeInstance` might have resolved this issue, so the new test cases runs successfully on master. However, I suspect the fix hasn't been applied to v1.11 yet, we would need more research.