### PR TITLE
Add enable_logging function

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -543,6 +543,21 @@ function disable_logging(level::LogLevel)
     _min_enabled_level[] = level + 1
 end
 
+"""
+    enable_logging(level)
+
+Enable all log messages at log levels equal to or greater than `level`.
+This is a *global* setting.
+
+# Examples
+```julia
+Logging.enable_logging(Logging.Debug) # Enable debug and info
+```
+"""
+function enable_logging(level::LogLevel)
+    _min_enabled_level[] = level
+end 
+
 let _debug_groups_include::Vector{Symbol} = Symbol[],
     _debug_groups_exclude::Vector{Symbol} = Symbol[],
     _debug_str::String = ""


### PR DESCRIPTION
It is very easy to simply disable logging but very hard to enable it back again. Would this be an acceptable way to do so?

If so, I'll update the PR to 
- [ ] add testing 
- [ ] and import the new function like [this](https://github.com/JuliaLang/julia/blob/3db7323d55cd282f57748ec0ae15459aa37304ad/stdlib/Logging/src/Logging.jl#L13C76-L33C18)