### PR TITLE
Fix formatting & typo in methods.md

### DIFF
--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -745,8 +745,8 @@ often it is best to separate each level of dispatch into distinct functions.
 This may sound similar in approach to single-dispatch, but as we shall see below, it is still more flexible.
 
 For example, trying to dispatch on the element-type of an array will often run into ambiguous situations.
-Instead, commonly code will dispatch first on the container type,
-then recurse down to a more specific method based on eltype.
+Instead, common code will dispatch first on the container type,
+then recurse down to a more specific method based on `eltype`.
 In most cases, the algorithms lend themselves conveniently to this hierarchical approach,
 while in other cases, this rigor must be resolved manually.
 This dispatching branching can be observed, for example, in the logic to sum two matrices:


### PR DESCRIPTION
* Fixed what I suspect is a typo: commonly -> common 
* Added code quotes to eltype: eltype -> `eltype`

Sentence now reads:
Instead, common code will dispatch first on the container type, then recurse down to a more specific method based on `eltype`.