### PR TITLE
Update package naming guidelines to encourage consideration of the global namespace

### DIFF
--- a/doc/src/tutorials/creating-packages.md
+++ b/doc/src/tutorials/creating-packages.md
@@ -609,7 +609,7 @@ may fit your package better.
 7. Avoid naming a package closely to an existing package
      * `Websocket` is too close to `WebSockets` and can be confusing to users. Rather use a new name such as `SimpleWebsockets`.
 
-8. Avoid using a distinctive name that is already in use in another unrelated project.
+8. Avoid using a distinctive name that is already in use in a well known, unrelated project.
      * Don't use the names `Tkinter.jl`, `TkinterGUI.jl`, etc. for a package that is unrelated
        to the popular `tkinter` python package. Users are likely to assume a connection that
        does not exist.

--- a/doc/src/tutorials/creating-packages.md
+++ b/doc/src/tutorials/creating-packages.md
@@ -605,8 +605,19 @@ may fit your package better.
 
      * `CPLEX.jl` wraps the `CPLEX` library, which can be identified easily in a web search.
      * `MATLAB.jl` provides an interface to call the MATLAB engine from within Julia.
+
 7. Avoid naming a package closely to an existing package
      * `Websocket` is too close to `WebSockets` and can be confusing to users. Rather use a new name such as `SimpleWebsockets`.
+
+8. Avoid using a distinctive name that is already in use in another unrelated project.
+     * Don't use the names `Tkinter.jl`, `TkinterGUI.jl`, etc. for a package that is unrelated
+       to the popular `tkinter` python package. Users are likey to assume an affiliation that
+       does not exist.
+     * It's okay to name a package `HTTP.jl` even though it is unrelated to the popular rust
+       crate `http` becuase "http" is not a distinctive name.
+     * It's okay to name a package `AlphaZero.jl` if it provides an implementation of the
+       DeepMind's AlphaZero algorithm, even without explicit affiliation with the creators of
+       the AlphaZero algorithm (provided there's no copyright or trademark infringement etc.)
 
 ## Registering packages
 

--- a/doc/src/tutorials/creating-packages.md
+++ b/doc/src/tutorials/creating-packages.md
@@ -616,9 +616,9 @@ may fit your package better.
      * It's okay to name a package `HTTP.jl` even though it is unrelated to the popular rust
        crate `http` because in most usages the name "http" refers to the hypertext transfer
        protocol, not to the `http` python package.
-     * It's okay to name a package `AlphaZero.jl` if it provides an implementation of
-       DeepMind's AlphaZero algorithm, even without explicit affiliation with the creators of
-       the AlphaZero algorithm (provided there's no copyright or trademark infringement etc.)
+     * It's okay to name a package `OpenSSL.jl` if it provides an interface to the OpenSSL
+       library, even without explicit affiliation with the creators of the OpenSSL (provided
+       there's no copyright or trademark infringement etc.)
 
 ## Registering packages
 

--- a/doc/src/tutorials/creating-packages.md
+++ b/doc/src/tutorials/creating-packages.md
@@ -611,10 +611,10 @@ may fit your package better.
 
 8. Avoid using a distinctive name that is already in use in another unrelated project.
      * Don't use the names `Tkinter.jl`, `TkinterGUI.jl`, etc. for a package that is unrelated
-       to the popular `tkinter` python package. Users are likey to assume an affiliation that
+       to the popular `tkinter` python package. Users are likely to assume an affiliation that
        does not exist.
      * It's okay to name a package `HTTP.jl` even though it is unrelated to the popular rust
-       crate `http` becuase "http" is not a distinctive name.
+       crate `http` because "http" is not a distinctive name.
      * It's okay to name a package `AlphaZero.jl` if it provides an implementation of
        DeepMind's AlphaZero algorithm, even without explicit affiliation with the creators of
        the AlphaZero algorithm (provided there's no copyright or trademark infringement etc.)

--- a/doc/src/tutorials/creating-packages.md
+++ b/doc/src/tutorials/creating-packages.md
@@ -611,8 +611,9 @@ may fit your package better.
 
 8. Avoid using a distinctive name that is already in use in a well known, unrelated project.
      * Don't use the names `Tkinter.jl`, `TkinterGUI.jl`, etc. for a package that is unrelated
-       to the popular `tkinter` python package. Users are likely to assume a connection that
-       does not exist.
+       to the popular `tkinter` python package, even if it provides bindings to Tcl/Tk.
+       A package name of `Tkinter.jl` would only be appropriate if the package used Python's
+       library to accomplish its work or was spearheaded by the same community of developers.
      * It's okay to name a package `HTTP.jl` even though it is unrelated to the popular rust
        crate `http` because in most usages the name "http" refers to the hypertext transfer
        protocol, not to the `http` rust crate.

--- a/doc/src/tutorials/creating-packages.md
+++ b/doc/src/tutorials/creating-packages.md
@@ -615,7 +615,7 @@ may fit your package better.
        does not exist.
      * It's okay to name a package `HTTP.jl` even though it is unrelated to the popular rust
        crate `http` becuase "http" is not a distinctive name.
-     * It's okay to name a package `AlphaZero.jl` if it provides an implementation of the
+     * It's okay to name a package `AlphaZero.jl` if it provides an implementation of
        DeepMind's AlphaZero algorithm, even without explicit affiliation with the creators of
        the AlphaZero algorithm (provided there's no copyright or trademark infringement etc.)
 

--- a/doc/src/tutorials/creating-packages.md
+++ b/doc/src/tutorials/creating-packages.md
@@ -615,7 +615,7 @@ may fit your package better.
        does not exist.
      * It's okay to name a package `HTTP.jl` even though it is unrelated to the popular rust
        crate `http` because in most usages the name "http" refers to the hypertext transfer
-       protocol, not to the `http` python package.
+       protocol, not to the `http` rust crate.
      * It's okay to name a package `OpenSSL.jl` if it provides an interface to the OpenSSL
        library, even without explicit affiliation with the creators of the OpenSSL (provided
        there's no copyright or trademark infringement etc.)

--- a/doc/src/tutorials/creating-packages.md
+++ b/doc/src/tutorials/creating-packages.md
@@ -611,7 +611,7 @@ may fit your package better.
 
 8. Avoid using a distinctive name that is already in use in another unrelated project.
      * Don't use the names `Tkinter.jl`, `TkinterGUI.jl`, etc. for a package that is unrelated
-       to the popular `tkinter` python package. Users are likely to assume an affiliation that
+       to the popular `tkinter` python package. Users are likely to assume a connection that
        does not exist.
      * It's okay to name a package `HTTP.jl` even though it is unrelated to the popular rust
        crate `http` because in most usages the name "http" refers to the hypertext transfer protocol, not to the `http` python package.

--- a/doc/src/tutorials/creating-packages.md
+++ b/doc/src/tutorials/creating-packages.md
@@ -614,7 +614,7 @@ may fit your package better.
        to the popular `tkinter` python package. Users are likely to assume an affiliation that
        does not exist.
      * It's okay to name a package `HTTP.jl` even though it is unrelated to the popular rust
-       crate `http` because "http" is not a distinctive name.
+       crate `http` because in most usages the name "http" refers to the hypertext transfer protocol, not to the `http` python package.
      * It's okay to name a package `AlphaZero.jl` if it provides an implementation of
        DeepMind's AlphaZero algorithm, even without explicit affiliation with the creators of
        the AlphaZero algorithm (provided there's no copyright or trademark infringement etc.)

--- a/doc/src/tutorials/creating-packages.md
+++ b/doc/src/tutorials/creating-packages.md
@@ -614,7 +614,8 @@ may fit your package better.
        to the popular `tkinter` python package. Users are likely to assume a connection that
        does not exist.
      * It's okay to name a package `HTTP.jl` even though it is unrelated to the popular rust
-       crate `http` because in most usages the name "http" refers to the hypertext transfer protocol, not to the `http` python package.
+       crate `http` because in most usages the name "http" refers to the hypertext transfer
+       protocol, not to the `http` python package.
      * It's okay to name a package `AlphaZero.jl` if it provides an implementation of
        DeepMind's AlphaZero algorithm, even without explicit affiliation with the creators of
        the AlphaZero algorithm (provided there's no copyright or trademark infringement etc.)


### PR DESCRIPTION
Adds a

> Avoid using a distinctive name that is already in use in another unrelated project.

clause.

(Also adds a newline to make the list formatting uniform)