### PR TITLE
Avoid macro-expand recursion into `Expr(:toplevel, ...)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,12 @@ Language changes
    may pave the way for inference to be able to intelligently re-use the old
    results, once the new method is deleted. ([#53415])
 
+ - Macro expansion will no longer eargerly recurse into into `Expr(:toplevel)`
+   expressions returned from macros. Instead, macro expansion of `:toplevel`
+   expressions will be delayed until evaluation time. This allows a later
+   expression within a given `:toplevel` expression to make use of macros
+   defined earlier in the same `:toplevel` expression. ([#53515])
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -446,6 +446,52 @@ more than one expression is marked then the same docstring is applied to each ex
     end
 
 `@__doc__` has no effect when a macro that uses it is not documented.
+
+!!! compat "Julia 1.12"
+
+    This section documents a very subtle corner case that is only relevant to
+    macros which themselves both define other macros and then attempt to use them
+    within the same expansion. Such macros were impossible to write prior to
+    Julia 1.12 and are still quite rare. If you are not writing such a macro,
+    you may ignore this note.
+
+    In versions prior to Julia 1.12, macroexpansion would recursively expand through
+    `Expr(:toplevel)` blocks. This behavior was changed in Julia 1.12 to allow
+    macros to recursively define other macros and use them in the same returned
+    expression. However, to preserve backwards compatibility with existing uses of
+    `@__doc__`, the doc system will still expand through `Expr(:toplevel)` blocks
+    when looking for `@__doc__` markers. As a result, macro-defining-macros will
+    have an observable behavior difference when annotated with a docstring:
+
+    ```julia
+    julia> macro macroception()
+        Expr(:toplevel, :(macro foo() 1 end), :(@foo))
+    end
+
+    julia> @macroception
+    1
+
+    julia> "Docstring" @macroception
+    ERROR: LoadError: UndefVarError: `@foo` not defined in `Main`
+    ```
+
+    The supported workaround is to manually expand the `@__doc__` macro in the
+    defining macro, which the docsystem will recognize and suppress the recursive
+    expansion:
+
+    ```julia
+    julia> macro macroception()
+        Expr(:toplevel,
+            macroexpand(__module__, :(@__doc__ macro foo() 1 end); recursive=false),
+            :(@foo))
+    end
+
+    julia> @macroception
+    1
+
+    julia> "Docstring" @macroception
+    1
+    ```
 """
 :(Core.@__doc__)
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -1154,7 +1154,7 @@ static jl_value_t *jl_expand_macros(jl_value_t *expr, jl_module_t *inmodule, str
     jl_expr_t *e = (jl_expr_t*)expr;
     if (e->head == jl_inert_sym ||
         e->head == jl_module_sym ||
-        //e->head == jl_toplevel_sym || // TODO: enable this once julia-expand-macroscope is fixed / removed
+        e->head == jl_toplevel_sym ||
         e->head == jl_meta_sym) {
         return expr;
     }

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -194,18 +194,18 @@
       (unescape (cadr e))
       e))
 
-(define (unescape-global-lhs e env m parent-scope inarg)
+(define (unescape-global-lhs e env m lno parent-scope inarg)
   (cond ((not (pair? e)) e)
-        ((eq? (car e) 'escape) (unescape-global-lhs (cadr e) env m parent-scope inarg))
+        ((eq? (car e) 'escape) (unescape-global-lhs (cadr e) env m lno parent-scope inarg))
         ((memq (car e) '(parameters tuple))
          (list* (car e) (map (lambda (e)
-                          (unescape-global-lhs e env m parent-scope inarg))
+                          (unescape-global-lhs e env m lno parent-scope inarg))
                         (cdr e))))
         ((and (memq (car e) '(|::| kw)) (length= e 3))
-         (list (car e) (unescape-global-lhs (cadr e) env m parent-scope inarg)
-                       (resolve-expansion-vars-with-new-env (caddr e) env m parent-scope inarg)))
+         (list (car e) (unescape-global-lhs (cadr e) env m lno parent-scope inarg)
+                       (resolve-expansion-vars-with-new-env (caddr e) env m lno parent-scope inarg)))
         (else
-         (resolve-expansion-vars-with-new-env e env m parent-scope inarg))))
+         (resolve-expansion-vars-with-new-env e env m lno parent-scope inarg))))
 
 (define (typedef-expr-name e)
   (cond ((atom? e) e)
@@ -290,18 +290,18 @@
 ;; resolve-expansion-vars-with-new-env, but turn on `inarg` if we get inside
 ;; a formal argument list. `e` in general might be e.g. `(f{T}(x)::T) where T`,
 ;; and we want `inarg` to be true for the `(x)` part.
-(define (resolve-in-lhs e env m parent-scope inarg)
-  (define (recur x) (resolve-in-lhs x env m parent-scope inarg))
-  (define (other x) (resolve-expansion-vars-with-new-env x env m parent-scope inarg))
+(define (resolve-in-lhs e env m lno parent-scope inarg)
+  (define (recur x) (resolve-in-lhs x env m lno parent-scope inarg))
+  (define (other x) (resolve-expansion-vars-with-new-env x env m lno parent-scope inarg))
   (case (and (pair? e) (car e))
     ((where) `(where ,(recur (cadr e)) ,@(map other (cddr e))))
     ((|::|)  `(|::| ,(recur (cadr e)) ,(other (caddr e))))
     ((call)  `(call ,(other (cadr e))
                     ,@(map (lambda (x)
-                             (resolve-expansion-vars-with-new-env x env m parent-scope #t))
+                             (resolve-expansion-vars-with-new-env x env m lno parent-scope #t))
                            (cddr e))))
     ((tuple) `(tuple ,@(map (lambda (x)
-                              (resolve-expansion-vars-with-new-env x env m parent-scope #t))
+                              (resolve-expansion-vars-with-new-env x env m lno parent-scope #t))
                             (cdr e))))
     (else (other e))))
 
@@ -338,7 +338,7 @@
                    (keywords-introduced-by x))
               env)))))))
 
-(define (resolve-expansion-vars-with-new-env x env m parent-scope inarg (outermost #f))
+(define (resolve-expansion-vars-with-new-env x env m lno parent-scope inarg (outermost #f))
   (resolve-expansion-vars-
    x
    (if (and (pair? x) (eq? (car x) 'let))
@@ -346,7 +346,7 @@
        ;; the same expression
        env
        (new-expansion-env-for x env outermost))
-   m parent-scope inarg))
+   m lno parent-scope inarg))
 
 (define (reescape ux x)
   (if (and (pair? x) (eq? (car x) 'escape))
@@ -355,29 +355,29 @@
 
 ;; type has special behavior: identifiers inside are
 ;; field names, not expressions.
-(define (resolve-struct-field-expansion x env m parent-scope inarg)
+(define (resolve-struct-field-expansion x env m lno parent-scope inarg)
   (let ((ux (unescape x)))
     (cond
         ((atom? ux) ux)
         ((and (pair? ux) (eq? (car ux) '|::|))
          `(|::| ,(unescape (cadr ux))
-           ,(resolve-expansion-vars- (reescape (caddr ux) x) env m parent-scope inarg)))
+           ,(resolve-expansion-vars- (reescape (caddr ux) x) env m lno parent-scope inarg)))
         ((and (pair? ux) (memq (car ux) '(const atomic)))
-         `(,(car ux) ,(resolve-struct-field-expansion (reescape (cadr ux) x) env m parent-scope inarg)))
+         `(,(car ux) ,(resolve-struct-field-expansion (reescape (cadr ux) x) env m lno parent-scope inarg)))
         (else
-         (resolve-expansion-vars-with-new-env x env m parent-scope inarg)))))
+         (resolve-expansion-vars-with-new-env x env m lno parent-scope inarg)))))
 
-(define (resolve-letlike-assign bind env newenv m parent-scope inarg)
+(define (resolve-letlike-assign bind env newenv m lno parent-scope inarg)
   (if (assignment? bind)
     (make-assignment
       ;; expand binds in newenv with dummy RHS
       (cadr (resolve-expansion-vars- (make-assignment (cadr bind) 0)
-                                    newenv m parent-scope inarg))
+                                    newenv m lno parent-scope inarg))
       ;; expand initial values in old env
-      (resolve-expansion-vars- (caddr bind) env m parent-scope inarg))
+      (resolve-expansion-vars- (caddr bind) env m lno parent-scope inarg))
     ;; Just expand everything else that's not an assignment. N.B.: This includes
     ;; assignments inside escapes, which probably need special handling (TODO).
-    (resolve-expansion-vars- bind newenv m parent-scope inarg)))
+    (resolve-expansion-vars- bind newenv m lno parent-scope inarg)))
 
 (define (for-ranges-list ranges)
   (if (eq? (car ranges) 'escape)
@@ -386,7 +386,7 @@
       (cdr ranges)
       (list ranges))))
 
-(define (resolve-expansion-vars- e env m parent-scope inarg)
+(define (resolve-expansion-vars- e env m lno parent-scope inarg)
   (cond ((or (eq? e 'begin) (eq? e 'end) (eq? e 'ccall) (eq? e 'cglobal) (underscore-symbol? e))
          e)
         ((symbol? e)
@@ -405,23 +405,23 @@
                      (env (car scope))
                      (m (cadr scope))
                      (parent-scope (cdr parent-scope)))
-                (resolve-expansion-vars-with-new-env (cadr e) env m parent-scope inarg))))
+                (resolve-expansion-vars-with-new-env (cadr e) env m lno parent-scope inarg))))
            ((global)
             `(global
                ,@(map (lambda (arg)
                        (if (assignment? arg)
-                           `(= ,(unescape-global-lhs (cadr arg) env m parent-scope inarg)
-                               ,(resolve-expansion-vars-with-new-env (caddr arg) env m parent-scope inarg))
-                           (unescape-global-lhs arg env m parent-scope inarg)))
+                           `(= ,(unescape-global-lhs (cadr arg) env m lno parent-scope inarg)
+                               ,(resolve-expansion-vars-with-new-env (caddr arg) env m lno parent-scope inarg))
+                           (unescape-global-lhs arg env m lno parent-scope inarg)))
                       (cdr e))))
            ((using import export meta line inbounds boundscheck loopinfo inline noinline purity) (map unescape e))
            ((macrocall) e) ; invalid syntax anyways, so just act like it's quoted.
            ((symboliclabel) e)
            ((symbolicgoto) e)
            ((struct)
-            `(struct ,(cadr e) ,(resolve-expansion-vars- (caddr e) env m parent-scope inarg)
+            `(struct ,(cadr e) ,(resolve-expansion-vars- (caddr e) env m lno parent-scope inarg)
                      ,(map (lambda (x)
-                            (resolve-struct-field-expansion x env m parent-scope inarg))
+                            (resolve-struct-field-expansion x env m lno parent-scope inarg))
                            (cadddr e))))
 
            ((parameters)
@@ -432,17 +432,17 @@
                                 (x (if (and (not inarg) (symbol? ux))
                                        `(kw ,ux ,x)
                                        x)))
-                           (resolve-expansion-vars- x env m parent-scope #f)))
+                           (resolve-expansion-vars- x env m lno parent-scope #f)))
                        (cdr e))))
 
            ((->)
-            `(-> ,(resolve-in-lhs (tuple-wrap-arrow-sig (cadr e)) env m parent-scope inarg)
-                 ,(resolve-expansion-vars-with-new-env (caddr e) env m parent-scope inarg)))
+            `(-> ,(resolve-in-lhs (tuple-wrap-arrow-sig (cadr e)) env m lno parent-scope inarg)
+                 ,(resolve-expansion-vars-with-new-env (caddr e) env m lno parent-scope inarg)))
 
            ((= function)
-             `(,(car e) ,(resolve-in-lhs (cadr e) env m parent-scope inarg)
+             `(,(car e) ,(resolve-in-lhs (cadr e) env m lno parent-scope inarg)
                         ,@(map (lambda (x)
-                                   (resolve-expansion-vars-with-new-env x env m parent-scope inarg))
+                                   (resolve-expansion-vars-with-new-env x env m lno parent-scope inarg))
                                  (cddr e))))
 
            ((kw)
@@ -456,44 +456,44 @@
                 `(kw (|::|
                       ,@(if argname
                             (list (if inarg
-                                      (resolve-expansion-vars- argname env m parent-scope inarg)
+                                      (resolve-expansion-vars- argname env m lno parent-scope inarg)
                                       ;; in keyword arg A=B, don't transform "A"
                                       (unescape argname)))
                             '())
-                      ,(resolve-expansion-vars- type env m parent-scope inarg))
-                     ,(resolve-expansion-vars-with-new-env (caddr e) env m parent-scope inarg))))
+                      ,(resolve-expansion-vars- type env m lno parent-scope inarg))
+                     ,(resolve-expansion-vars-with-new-env (caddr e) env m lno parent-scope inarg))))
              (else
               `(kw ,(if inarg
-                        (resolve-expansion-vars- (cadr e) env m parent-scope inarg)
+                        (resolve-expansion-vars- (cadr e) env m lno parent-scope inarg)
                         (unescape (cadr e)))
-                   ,(resolve-expansion-vars-with-new-env (caddr e) env m parent-scope inarg)))))
+                   ,(resolve-expansion-vars-with-new-env (caddr e) env m lno parent-scope inarg)))))
 
            ((let)
             (let* ((newenv (new-expansion-env-for e env))
-                   (body   (resolve-expansion-vars- (caddr e) newenv m parent-scope inarg))
+                   (body   (resolve-expansion-vars- (caddr e) newenv m lno parent-scope inarg))
                    (binds  (let-binds e)))
               `(let (block
                      ,@(map
                         (lambda (bind)
-                          (resolve-letlike-assign bind env newenv m parent-scope inarg))
+                          (resolve-letlike-assign bind env newenv m lno parent-scope inarg))
                         binds))
                  ,body)))
            ((for)
             (let* ((newenv (new-expansion-env-for e env))
-                   (body   (resolve-expansion-vars- (caddr e) newenv m parent-scope inarg))
+                   (body   (resolve-expansion-vars- (caddr e) newenv m lno parent-scope inarg))
                    (expanded-ranges (map (lambda (range)
-                      (resolve-letlike-assign range env newenv m parent-scope inarg)) (for-ranges-list (cadr e)))))
+                      (resolve-letlike-assign range env newenv m lno parent-scope inarg)) (for-ranges-list (cadr e)))))
               (if (length= expanded-ranges 1)
                 `(for ,@expanded-ranges ,body))
                 `(for (block ,@expanded-ranges) ,body)))
            ((generator)
             (let* ((newenv (new-expansion-env-for e env))
-                   (body   (resolve-expansion-vars- (cadr e) newenv m parent-scope inarg))
+                   (body   (resolve-expansion-vars- (cadr e) newenv m lno parent-scope inarg))
                    (filt? (eq? (car (caddr e)) 'filter))
                    (range-exprs (if filt? (cddr (caddr e)) (cddr e)))
-                   (filt (if filt? (resolve-expansion-vars- (cadr (caddr e)) newenv m parent-scope inarg)))
+                   (filt (if filt? (resolve-expansion-vars- (cadr (caddr e)) newenv m lno parent-scope inarg)))
                    (expanded-ranges (map (lambda (range)
-                      (resolve-letlike-assign range env newenv m parent-scope inarg)) range-exprs)))
+                      (resolve-letlike-assign range env newenv m lno parent-scope inarg)) range-exprs)))
               (if filt?
                 `(generator ,body (filter ,filt ,@expanded-ranges))
                 `(generator ,body ,@expanded-ranges))))
@@ -502,21 +502,21 @@
                    (body (cadr e))
                    (m (caddr e))
                    (lno  (cdddr e)))
-              (resolve-expansion-vars-with-new-env body env m parent-scope inarg #t)))
+              (resolve-expansion-vars-with-new-env body env m lno parent-scope inarg #t)))
            ((tuple)
             (cons (car e)
                   (map (lambda (x)
                          (if (assignment? x)
                              `(= ,(unescape (cadr x))
-                                 ,(resolve-expansion-vars-with-new-env (caddr x) env m parent-scope inarg))
-                             (resolve-expansion-vars-with-new-env x env m parent-scope inarg)))
+                                 ,(resolve-expansion-vars-with-new-env (caddr x) env m lno parent-scope inarg))
+                             (resolve-expansion-vars-with-new-env x env m lno parent-scope inarg)))
                        (cdr e))))
 
            ;; todo: trycatch
            (else
             (cons (car e)
                   (map (lambda (x)
-                         (resolve-expansion-vars-with-new-env x env m parent-scope inarg))
+                         (resolve-expansion-vars-with-new-env x env m lno parent-scope inarg))
                        (cdr e))))))))
 
 ;; decl-var that also identifies f in f()=...
@@ -617,11 +617,11 @@
         (cdr v)
         '())))
 
-(define (resolve-expansion-vars e m)
+(define (resolve-expansion-vars e m lno)
   ;; expand binding form patterns
   ;; keep track of environment, rename locals to gensyms
   ;; and wrap globals in (globalref module var) for macro's home module
-  (resolve-expansion-vars-with-new-env e '() m '() #f #t))
+  (resolve-expansion-vars-with-new-env e '() m lno '() #f #t))
 
 (define (julia-expand-quotes e)
   (cond ((not (pair? e)) e)
@@ -641,7 +641,7 @@
          (let ((form (cadr e)) ;; form is the expression returned from expand-macros
                (modu (caddr e)) ;; m is the macro's def module
                (lno  (cdddr e))) ;; lno is (optionally) the line number node
-           (resolve-expansion-vars form modu)))
+           (resolve-expansion-vars form modu lno)))
         (else
          (map julia-expand-macroscopes- e))))
 

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -414,6 +414,14 @@
                                ,(resolve-expansion-vars-with-new-env (caddr arg) env m lno parent-scope inarg))
                            (unescape-global-lhs arg env m lno parent-scope inarg)))
                       (cdr e))))
+           ((toplevel) ; re-wrap Expr(:toplevel) in the current hygienic-scope(s)
+            `(toplevel
+               ,@(map (lambda (arg)
+                       (let loop ((parent-scope parent-scope) (m m) (lno lno) (arg arg))
+                        (let ((wrapped `(hygienic-scope ,arg ,m ,@lno)))
+                          (if (null? parent-scope) wrapped
+                            (loop (cdr parent-scope) (cadar parent-scope) (caddar parent-scope) wrapped)))))
+                      (cdr e))))
            ((using import export meta line inbounds boundscheck loopinfo inline noinline purity) (map unescape e))
            ((macrocall) e) ; invalid syntax anyways, so just act like it's quoted.
            ((symboliclabel) e)
@@ -498,7 +506,7 @@
                 `(generator ,body (filter ,filt ,@expanded-ranges))
                 `(generator ,body ,@expanded-ranges))))
            ((hygienic-scope) ; TODO: move this lowering to resolve-scopes, instead of reimplementing it here badly
-             (let ((parent-scope (cons (list env m) parent-scope))
+             (let ((parent-scope (cons (list env m lno) parent-scope))
                    (body (cadr e))
                    (m (caddr e))
                    (lno  (cdddr e)))

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -645,6 +645,7 @@
   (cond ((not (pair? e)) e)
         ((eq? (car e) 'inert) e)
         ((eq? (car e) 'module) e)
+        ((eq? (car e) 'toplevel) e)
         ((eq? (car e) 'hygienic-scope)
          (let ((form (cadr e)) ;; form is the expression returned from expand-macros
                (modu (caddr e)) ;; m is the macro's def module

--- a/test/core.jl
+++ b/test/core.jl
@@ -8125,3 +8125,10 @@ let M = @__MODULE__
 end
 
 @test Base.unsafe_convert(Ptr{Int}, [1]) !== C_NULL
+
+# Test that new macros are allowed to be defined inside Expr(:toplevel) returned by macros
+macro macroception()
+    Expr(:toplevel, :(macro foo() 1 end), :(@foo))
+end
+
+@test (@macroception()) === 1

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1562,3 +1562,15 @@ Base.@ccallable c51586_long()::Int = 3
     @test_broken isempty(undoc)
     @test undoc == [Symbol("@var")]
 end
+
+# Docing the macroception macro
+macro docmacroception()
+    Expr(:toplevel, macroexpand(__module__, :(@Base.__doc__ macro docmacrofoo() 1 end); recursive=false), :(@docmacrofoo))
+end
+
+"""
+This docmacroception has a docstring
+"""
+@docmacroception()
+
+@test Docs.hasdoc(@__MODULE__, :var"@docmacrofoo")


### PR DESCRIPTION
Here's an example output from macroexpand:
```
Expr
  head: Symbol thunk
  args: Array{Any}((1,))
    1: Core.CodeInfo
      code: Array{Any}((2,))
        1: Expr
          head: Symbol toplevel
          args: Array{Any}((17,))
            1: Expr
              head: Symbol hygienic-scope
              args: Array{Any}((3,))
                1: LineNumberNode
                2: Module Base.Enums
                3: LineNumberNode
            2: Expr
              head: Symbol hygienic-scope
              args: Array{Any}((3,))
                1: Expr
                2: Module Base.Enums
                3: LineNumberNode
            3: Expr
              head: Symbol hygienic-scope
              args: Array{Any}((3,))
                1: LineNumberNode
                2: Module Base.Enums
                3: LineNumberNode
            4: Expr
              head: Symbol hygienic-scope
              args: Array{Any}((3,))
                1: Expr
                2: Module Base.Enums
                3: LineNumberNode
 ...
```

Currently fails during bootstrap with:
```
LoadError("sysimg.jl", 3, LoadError("Base.jl", 542, ErrorException("cannot document the following expression:\n\n#= mpfr.jl:65 =# @enum MPFRRoundingMode begin\n        #= mpfr.jl:66 =#\n        MPFRRoundNearest\n        #= mpfr.jl:67 =#\n        MPFRRoundToZero\n        #= mpfr.jl:68 =#\n        MPFRRoundUp\n        #= mpfr.jl:69 =#\n        MPFRRoundDown\n        #= mpfr.jl:70 =#\n        MPFRRoundFromZero\n        #= mpfr.jl:71 =#\n        MPFRRoundFaithful\n    end\n\n'@enum' not documentable. See 'Base.@__doc__' docs for details.\n")))
```


Perhaps we can do better than wrapping each `Expr(:toplevel, ...)` arg individually, or I should be filtering out the LineNumberNodes?