### PR TITLE
post-opt analysis: fix conditional successor visitation logic

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -531,17 +531,22 @@ function any_stmt_may_throw(ir::IRCode, bb::Int)
     return false
 end
 
-function conditional_successors_may_throw(lazypostdomtree::LazyPostDomtree, ir::IRCode, bb::Int)
+function visit_conditional_successors(callback, lazypostdomtree::LazyPostDomtree, ir::IRCode, bb::Int)
     visited = BitSet((bb,))
     worklist = Int[bb]
     while !isempty(worklist)
-        thisbb = pop!(worklist)
+        thisbb = popfirst!(worklist)
         for succ in ir.cfg.blocks[thisbb].succs
             succ in visited && continue
             push!(visited, succ)
-            postdominates(get!(lazypostdomtree), succ, thisbb) && continue
-            any_stmt_may_throw(ir, succ) && return true
-            push!(worklist, succ)
+            if postdominates(get!(lazypostdomtree), succ, bb)
+                # this successor is not conditional, so no need to visit it further
+                continue
+            elseif callback(succ)
+                return true
+            else
+                push!(worklist, succ)
+            end
         end
     end
     return false
@@ -833,8 +838,10 @@ function ((; sv)::ScanStmt)(inst::Instruction, lstmt::Int, bb::Int)
             # inconsistent region.
             if !sv.result.ipo_effects.terminates
                 sv.all_retpaths_consistent = false
-            elseif conditional_successors_may_throw(sv.lazypostdomtree, sv.ir, bb)
-                # Check if there are potential throws that require
+            elseif visit_conditional_successors(sv.lazypostdomtree, sv.ir, bb) do succ::Int
+                       return any_stmt_may_throw(sv.ir, succ)
+                   end
+                # check if this `GotoIfNot` leads to conditional throws, which taints consistency
                 sv.all_retpaths_consistent = false
             else
                 (; cfg, domtree) = get!(sv.lazyagdomtree)

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -1382,3 +1382,8 @@ let; Base.Experimental.@force_compile; func52843(); end
 # pointerref nothrow for invalid pointer
 @test !Core.Compiler.intrinsic_nothrow(Core.Intrinsics.pointerref, Any[Type{Ptr{Vector{Int64}}}, Int, Int])
 @test !Core.Compiler.intrinsic_nothrow(Core.Intrinsics.pointerref, Any[Type{Ptr{T}} where T, Int, Int])
+
+# post-opt :consistent-cy analysis correctness
+# https://github.com/JuliaLang/julia/issues/53508
+@test !Core.Compiler.is_consistent(Base.infer_effects(getindex, (UnitRange{Int},Int)))
+@test !Core.Compiler.is_consistent(Base.infer_effects(getindex, (Base.OneTo{Int},Int)))


### PR DESCRIPTION
Previously `conditional_successors_may_throw` performed post-domination analysis not on the initially specified `bb` (which was given as the argument), but on those BBs being analyzed that were popped from the work-queue at the time. As a result, there were cases where not all conditional successors were visited.

fixes #53508