### PR TITLE
fix potential double-free in flisp table implementation

### DIFF
--- a/src/flisp/table.c
+++ b/src/flisp/table.c
@@ -102,7 +102,7 @@ value_t fl_table(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
         else
             k = arg;
     }
-    if (h->table != &h->_space[0]) {
+    if (cnt <= HT_N_INLINE && h->table != &h->_space[0]) {
         // We expected to use the inline table, but we ended up outgrowing it.
         // Make sure to register the finalizer.
         add_finalizer(fl_ctx, (cvalue_t*)ptr(nt));

--- a/src/flisp/unittest.lsp
+++ b/src/flisp/unittest.lsp
@@ -267,4 +267,23 @@
 (assert (equal? `(a `(b c)) '(a (quasiquote (b c)))))
 (assert (equal? ````x '```x))
 
+;; make many initialized tables large enough not to be stored in-line
+(for 1 100
+     (lambda (i)
+       (table eq?      2      eqv?     2
+              equal?   2      atom?    1
+              not      1      null?    1
+              boolean? 1      symbol?  1
+              number?  1      bound?   1
+              pair?    1      builtin? 1
+              vector?  1      fixnum?  1
+              cons     2      car      1
+              cdr      1      set-car! 2
+              set-cdr! 2      =        2
+              <        2      compare  2
+              aref     2      aset!    3
+              div0     2)))
+;; now allocate enough to trigger GC
+(for 1 8000000 (lambda (i) (cons 1 2)))
+
 #t


### PR DESCRIPTION
In this case we would add two finalizers, leading to a double free. Introduced by 5fc4ba91931526a08fc1bf8d3937aac731ee2cc6. However, I believe we never hit this in the julia front end, since it requires making a large pre-initialized table (i.e. with many arguments to `table`) which is later freed. That tends not to happen since initialized tables tend to be global constants.