### PR TITLE
add back an alias for `check_top_bit`

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -969,6 +969,7 @@ arrayset(inbounds::Bool, A::Array{T}, x::Any, i::Int...) where {T} = Main.Base.s
 arraysize(a::Array) = a.size
 arraysize(a::Array, i::Int) = sle_int(i, nfields(a.size)) ? getfield(a.size, i) : 1
 export arrayref, arrayset, arraysize, const_arrayref
+const check_top_bit = check_sign_bit
 
 # For convenience
 EnterNode(old::EnterNode, new_dest::Int) = isdefined(old, :scope) ?


### PR DESCRIPTION
Used in some packages (https://github.com/rfourquet/BitIntegers.jl/blob/deb17db47649cc59b49a3dfd29d74efa311590d7/src/BitIntegers.jl#L27-L31)

Renamed in https://github.com/JuliaLang/julia/pull/53166