### PR TITLE
fix require_stdlib in Base.runtests error path

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -695,7 +695,7 @@ function runtests(tests = ["all"]; ncores::Int = ceil(Int, Sys.CPU_THREADS / 2),
     catch
         buf = PipeBuffer()
         original_load_path = copy(Base.LOAD_PATH); empty!(Base.LOAD_PATH); pushfirst!(Base.LOAD_PATH, "@stdlib")
-        let InteractiveUtils = Base.require_stdlib(Base, :InteractiveUtils)
+        let InteractiveUtils = Base.require_stdlib(Base.PkgId(Base.UUID(0xb77e0a4c_d291_57a0_90e8_8db25a27a240), "InteractiveUtils"))
             @invokelatest InteractiveUtils.versioninfo(buf)
         end
         empty!(Base.LOAD_PATH); append!(Base.LOAD_PATH, original_load_path)


### PR DESCRIPTION
```
  | ERROR: LoadError: Test run finished with errors
  | in expression starting at /Users/julia/.julia/scratchspaces/a66863c6-20e8-4ff4-8a62-49f30b1f605e/agent-cache/default-honeycrisp-R17H3W25T9.0/build/default-honeycrisp-R17H3W25T9-0/julialang/julia-master/julia-2efb19cc73/share/julia/test/runtests.jl:100
  | ERROR: MethodError: no method matching require_stdlib(::Module, ::Symbol)
  | The function `require_stdlib` exists, but no method is defined for this combination of argument types.
  |  
  | Closest candidates are:
  | require_stdlib(::Base.PkgId)
  | @ Base loading.jl:2401
  | require_stdlib(::Base.PkgId, ::Union{Nothing, String})
  | @ Base loading.jl:2401
  |  
  | Stacktrace:
  | [1] runtests(tests::String; ncores::Int64, exit_on_error::Bool, revise::Bool, seed::Nothing)
  | @ Base ./util.jl:698
  | [2] top-level scope
  | @ none:1
```