### PR TITLE
Enable full RELRO on linux

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -550,7 +550,17 @@ export MACOSX_DEPLOYMENT_TARGET=$(MACOSX_VERSION_MIN)
 endif
 endif
 
-JLDFLAGS :=
+# Conditional setting of RELRO flag for enhanced security on Linux builds.
+# RELRO (Read-Only Relocations) is a security feature that marks certain sections
+# of the binary as read-only to prevent exploitation techniques like  GOT (Global Offset Table)
+# overwriting.
+ifeq ($(OS),Linux)
+    RELRO_FLAG := -Wl,-z,relro
+else
+    RELRO_FLAG :=
+endif
+
+JLDFLAGS := $(RELRO_FLAG)
 
 ifeq ($(USECCACHE), 1)
 # Expand CC, CXX and FC here already because we want the original definition and not the ccache version.

--- a/Make.inc
+++ b/Make.inc
@@ -552,8 +552,8 @@ endif
 
 # Conditional setting of RELRO flag for enhanced security on Linux builds.
 # RELRO (Read-Only Relocations) is a security feature that marks certain sections
-# of the binary as read-only to prevent exploitation techniques like  GOT (Global Offset Table)
-# overwriting.
+# of the binary as read-only to prevent exploitation techniques like
+# GOT (Global Offset Table) overwriting attacks.
 ifeq ($(OS),Linux)
     RELRO_FLAG := -Wl,-z,relro
 else


### PR DESCRIPTION
This enables full RELRO (Read-Only Relocations) on Linux.
It is helpful for hardening Linux binaries and prevents GOT overwrite attacks.

There is some concern this would slow down startup or package load, but under
the following workloads there is no detectable difference, and infact RELRO
appears slightly faster.

```
time julia -e 'using Pkg; using LinearAlgebra; exit()'
time julia -e 'exit()'
```

Master sys time average: 0.052
This commit sys time average: 0.044

We can validate that "full RELRO" is enabled with checksec:

```
[nix-shell:~/src/julia]$ checksec --file=./julia
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH      Symbols         FORTIFY Fortified       Fortifiable     FILE
Full RELRO      No canary found   NX enabled    No PIE          No RPATH   RUNPATH     39 Symbols         No    0               0               ./julia
```
