### PR TITLE
Allow sysimage build without the doc system

### DIFF
--- a/base/shell.jl
+++ b/base/shell.jl
@@ -4,7 +4,7 @@
 
 const shell_special = "#{}()[]<>|&*?~;"
 
-@doc raw"""
+(@doc raw"""
     rstrip_shell(s::AbstractString)
 
 Strip trailing whitespace from a shell command string, while respecting a trailing backslash followed by a space ("\\ ").
@@ -16,7 +16,7 @@ julia> Base.rstrip_shell("echo 'Hello World' \\ ")
 julia> Base.rstrip_shell("echo 'Hello World'    ")
 "echo 'Hello World'"
 ```
-""" ->
+"""
 function rstrip_shell(s::AbstractString)
     c_old = nothing
     for (i, c) in Iterators.reverse(pairs(s))
@@ -26,7 +26,7 @@ function rstrip_shell(s::AbstractString)
         c_old = c
     end
     SubString(s, 1, 0)
-end
+end)
 
 function shell_parse(str::AbstractString, interpolate::Bool=true;
                      special::AbstractString="", filename="none")


### PR DESCRIPTION
The earliest bootstrapping code has a definition of `atdoc` that is just supposed to ignore the doc string and pass the defining code through. This function is then replaced by the actual docsystem once that is available. For testing, I wanted to build the whole system image without the doc system using this boostrap definition. However, this turns out not to be possible, because there's a few doc syntax semantics that do not actually just ignore the doc string.

In particular:
```
"""
I am a doc for a particular signature
"""
foo(x::Int, y::Float64)
```

Does not acutally result in a call to `foo`.

And similarly

```
"""
I am a doc for a global binding
"""
MyModule.foo
```

Does not require `MyModule.foo` to actually have a value, since it only documents the binding.

This PR allows both of those cases in the boostrap version of `atdoc` so that we can bootstrap without the doc system if we wanted to.