### PR TITLE
Semver: specify VersionNumber's follow v2-rc2 specifically

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -9,12 +9,12 @@ const VInt = UInt32
     VersionNumber
 
 Version number type which follows the specifications of
-[semantic versioning (semver)](https://semver.org/), composed of major, minor
+[semantic versioning (semver)](https://semver.org/spec/v2.0.0-rc.2.html), composed of major, minor
 and patch numeric values, followed by pre-release and build
 alphanumeric annotations.
 
 `VersionNumber` objects can be compared with all of the standard comparison
-operators (`==`, `<`, `<=`, etc.), with the result following semver rules.
+operators (`==`, `<`, `<=`, etc.), with the result following semver v2.0.0-rc.2 rules.
 
 `VersionNumber` has the following public fields:
 - `v.major::Integer`

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -1142,7 +1142,7 @@ some confusion regarding the matter.
 
 Version numbers can easily be expressed with non-standard string literals of the form [`v"..."`](@ref @v_str).
 Version number literals create [`VersionNumber`](@ref) objects which follow the
-specifications of [semantic versioning](https://semver.org/),
+specifications of [semantic versioning](https://semver.org/spec/v2.0.0-rc.2.html),
 and therefore are composed of major, minor and patch numeric values, followed by pre-release and
 build alphanumeric annotations. For example, `v"0.2.1-rc1+win64"` is broken into major version
 `0`, minor version `2`, patch version `1`, pre-release `rc1` and build `win64`. When entering

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -1142,7 +1142,7 @@ some confusion regarding the matter.
 
 Version numbers can easily be expressed with non-standard string literals of the form [`v"..."`](@ref @v_str).
 Version number literals create [`VersionNumber`](@ref) objects which follow the
-specifications of [semantic versioning](https://semver.org/spec/v2.0.0-rc.2.html),
+specifications of [semantic versioning 2.0.0-rc2](https://semver.org/spec/v2.0.0-rc.2.html),
 and therefore are composed of major, minor and patch numeric values, followed by pre-release and
 build alphanumeric annotations. For example, `v"0.2.1-rc1+win64"` is broken into major version
 `0`, minor version `2`, patch version `1`, pre-release `rc1` and build `win64`. When entering


### PR DESCRIPTION
Since v2 has changed from v2-rc2 by saying build numbers MUST not be taken into account in precedence.

I don't think changing VersionNumber's ordering in a minor release of Julia is acceptable, but since the semver landing page is now v2 rather than v2-rc2, we should update the link.

closes https://github.com/JuliaLang/julia/issues/53502