### PR TITLE
enable `less`/`edit` for documented variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -120,6 +120,8 @@ Standard library changes
 
 #### InteractiveUtils
 
+* `less`/`@less` and `edit`/`@edit` are now supported for documented variables ([#53539]).
+
 #### Dates
 
 External dependencies

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -277,6 +277,7 @@ function edit(m::Module)
     path === nothing && error("could not find source file for module: $m")
     edit(path)
 end
+edit(m::Module, n::Symbol) = edit(varloc(m, n)...)
 
 # terminal pager
 
@@ -314,6 +315,30 @@ less(file::AbstractString) = less(file, 1)
 Show the definition of a function using the default pager, optionally specifying a tuple of
 types to indicate which method to see.
 """
-less(f)                   = less(functionloc(f)...)
-less(f, @nospecialize t)  = less(functionloc(f,t)...)
-less(file, line::Integer) = error("could not find source file for function")
+less(f)                    = less(functionloc(f)...)
+less(f, @nospecialize t)   = less(functionloc(f,t)...)
+less(file, line::Integer)  = error("could not find source file for function")
+less(m::Module, n::Symbol) = less(varloc(m, n)...)
+
+# find where a (documented) global is defined using the doc system
+function varloc(mod::Module, name::Symbol)
+    m = Base.Docs.meta(mod)
+    if m !== nothing
+        bnd = Base.Docs.Binding(mod, name)
+        if haskey(m, bnd)
+            docstr = m[bnd]
+            if docstr isa Base.Docs.MultiDoc
+                length(docstr.docs) != 1 && @goto err
+                docstr = only(docstr.docs).second
+            end
+            if docstr isa Base.Docs.DocStr
+                mm = docstr.data
+                if haskey(mm, :path) && haskey(mm, :linenumber)
+                    return (mm[:path], mm[:linenumber])
+                end
+            end
+        end
+    end
+    @label err
+    error("could not determine location of variable $mod.$name")
+end

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -391,6 +391,9 @@ function gen_call_with_extracted_types(__module__, fcn, ex0, kws = Expr[]; is_so
     if isa(ex0, Expr) && ex0.head === :(=) && isa(ex0.args[1], Symbol)
         return gen_call_with_extracted_types(__module__, fcn, ex0.args[2], kws; is_source_reflection, supports_binding_reflection, use_signature_tuple)
     end
+    if isa(ex0, Symbol) && (fcn === :which || fcn === :less || fcn === :edit)
+        return Expr(:call, fcn, __module__, QuoteNode(ex0))
+    end
     _where_params = nothing
     if isa(ex0, Expr)
         ex0, _where_params = extract_where_parameters(ex0)
@@ -563,15 +566,10 @@ for fname in [:which, :less, :edit, :functionloc]
         macro ($fname)(ex0)
             gen_call_with_extracted_types(__module__, $(Expr(:quote, fname)), ex0, Expr[];
                                           is_source_reflection = true,
-                                          supports_binding_reflection = $(fname === :which),
+                                          supports_binding_reflection = $(fname in (:which,:less,:edit)),
                                           use_signature_tuple = true)
         end
     end
-end
-
-macro which(ex0::Symbol)
-    ex0 = QuoteNode(ex0)
-    return :(which($__module__, $ex0))
 end
 
 for fname in [:code_warntype, :code_llvm, :code_native,

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -1074,3 +1074,11 @@ let code = """
         @test occursin("done compiling", output)
     end
 end
+
+var_line = @__LINE__()+1
+"""
+    docs for a global variable
+"""
+const _interactiveutils_some_var_ = 0
+
+@test InteractiveUtils.varloc(@__MODULE__, :_interactiveutils_some_var_) == (@__FILE__, var_line)

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -89,8 +89,9 @@ end
 function parsedoc(d::DocStr)
     if d.object === nothing
         md = formatdoc(d)
-        md.meta[:module] = d.data[:module]
-        md.meta[:path]   = d.data[:path]
+        md.meta[:module]     = d.data[:module]
+        md.meta[:path]       = d.data[:path]
+        md.meta[:linenumber] = d.data[:linenumber]
         d.object = md
     end
     d.object


### PR DESCRIPTION
We don't store the locations of definitions of variables, but the doc system does (when they are documented). This PR uses that info to make `less` and `edit` work on variables.

I'm not sure about the change to REPL. We copy metadata from the docsystem's objects to meta dicts in the markdown object, but for some reason we only copy certain fields. It seems to me that should include both the filename and line number. Then maybe the doc viewer could show locations.

Fix #53534.