### PR TITLE
use `_readdirx` for `walkdir`

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -1089,18 +1089,16 @@ function walkdir(root; topdown=true, follow_symlinks=false, onerror=throw)
                 end
                 return
             end
-        content = tryf(readdir, root)
-        content === nothing && return
-        dirs = Vector{eltype(content)}()
-        files = Vector{eltype(content)}()
-        for name in content
-            path = joinpath(root, name)
-
+        entries = tryf(_readdirx, root)
+        entries === nothing && return
+        dirs = Vector{String}()
+        files = Vector{String}()
+        for entry in entries
             # If we're not following symlinks, then treat all symlinks as files
-            if (!follow_symlinks && something(tryf(islink, path), true)) || !something(tryf(isdir, path), false)
-                push!(files, name)
+            if (!follow_symlinks && something(tryf(islink, entry), true)) || !something(tryf(isdir, entry), false)
+                push!(files, entry.name)
             else
-                push!(dirs, name)
+                push!(dirs, entry.name)
             end
         end
 


### PR DESCRIPTION
On a M2 Mac there is some benefit, but assumed to be much greater on slower filesystems.
```
# master
julia> @btime collect(walkdir(expanduser("~/Downloads")));
  380.086 ms (310696 allocations: 25.29 MiB)

# This PR
julia> @btime collect(walkdir(expanduser("~/Downloads")));
  289.747 ms (103300 allocations: 7.50 MiB)
```

The implementations appear to produce the same result
```
julia> collect(walkdir(expanduser("~/Downloads"))) == collect(walkdirx(expanduser("~/Downloads")))
true
```