### PR TITLE
RFC: Do not consider inlining cost for precompilation

### DIFF
--- a/src/precompile_utils.c
+++ b/src/precompile_utils.c
@@ -188,8 +188,7 @@ static int precompile_enq_specialization_(jl_method_instance_t *mi, void *closur
         else if (jl_atomic_load_relaxed(&codeinst->invoke) != jl_fptr_const_return) {
             jl_value_t *inferred = jl_atomic_load_relaxed(&codeinst->inferred);
             if (inferred &&
-                inferred != jl_nothing &&
-                (jl_ir_inlining_cost(inferred) == UINT16_MAX)) {
+                inferred != jl_nothing) {
                 do_compile = 1;
             }
             else if (jl_atomic_load_relaxed(&codeinst->invoke) != NULL || jl_atomic_load_relaxed(&codeinst->precompile)) {

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -1212,7 +1212,7 @@ precompile_test_harness("invoke") do dir
     m = only(methods(M.callq))
     @test isempty(Base.specializations(m)) || nvalid(m.specializations::Core.MethodInstance) == 0
     m = only(methods(M.callqnc))
-    @test isempty(Base.specializations(m)) || nvalid(m.specializations::Core.MethodInstance) == 0
+    @test isempty(Base.specializations(m)) || nvalid(m.specializations::Core.MethodInstance) == 1
     m = only(methods(M.callqi))
     @test (m.specializations::Core.MethodInstance).specTypes == Tuple{typeof(M.callqi), Int}
     m = only(methods(M.callqnci))


### PR DESCRIPTION
This helps to minimize the amount of failed precompiles that occur by eliding the inlining cost check. It is likely this will lead to slightly larger sys/pkgimg sizes. However in practice it leads to more extensive and successful precompilation, which can minimize the number of JIT events which occur when using Julia.