### PR TITLE
revert "Add @create_log_macro for making custom styled logging macros (#52196)"

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -148,9 +148,6 @@ Standard library changes
 * `lu` and `issuccess(::LU)` now accept an `allowsingular` keyword argument. When set to `true`, a valid factorization with rank-deficient U factor will be treated as success instead of throwing an error. Such factorizations are now shown by printing the factors together with a "rank-deficient" note rather than printing a "Failed Factorization" message ([#52957]).
 
 #### Logging
-* New `@create_log_macro` macro for creating new log macros like `@info`, `@warn` etc. For instance
-  `@create_log_macro MyLog 1500 :magenta` will create `@mylog` to be used like `@mylog "hello"` which
-  will show as `┌ MyLog: hello` etc. ([#52196])
 
 #### Printf
 

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -172,18 +172,14 @@ const AboveMaxLevel = LogLevel( 1000001)
 # Global log limiting mechanism for super fast but inflexible global log limiting.
 const _min_enabled_level = Ref{LogLevel}(Debug)
 
-# stored as LogLevel => (name, color)
-const custom_log_levels = Dict{LogLevel,Tuple{Symbol,Union{Symbol,Int}}}()
-
 function show(io::IO, level::LogLevel)
-    if     haskey(custom_log_levels, level) print(io, custom_log_levels[level][1])
-    elseif level == BelowMinLevel           print(io, "BelowMinLevel")
-    elseif level == Debug                   print(io, "Debug")
-    elseif level == Info                    print(io, "Info")
-    elseif level == Warn                    print(io, "Warn")
-    elseif level == Error                   print(io, "Error")
-    elseif level == AboveMaxLevel           print(io, "AboveMaxLevel")
-    else                                    print(io, "LogLevel($(level.level))")
+    if     level == BelowMinLevel  print(io, "BelowMinLevel")
+    elseif level == Debug          print(io, "Debug")
+    elseif level == Info           print(io, "Info")
+    elseif level == Warn           print(io, "Warn")
+    elseif level == Error          print(io, "Error")
+    elseif level == AboveMaxLevel  print(io, "AboveMaxLevel")
+    else                           print(io, "LogLevel($(level.level))")
     end
 end
 

--- a/stdlib/Logging/docs/src/index.md
+++ b/stdlib/Logging/docs/src/index.md
@@ -62,7 +62,7 @@ automatically extracted. Let's examine the user-defined data first:
 * The *log level* is a broad category for the message that is used for early
   filtering. There are several standard levels of type [`LogLevel`](@ref);
   user-defined levels are also possible.
-  Each built-in log level is distinct in purpose:
+  Each is distinct in purpose:
   - [`Logging.Debug`](@ref) (log level -1000) is information intended for the developer of
     the program. These events are disabled by default.
   - [`Logging.Info`](@ref) (log level 0) is for general information to the user.
@@ -73,17 +73,6 @@ automatically extracted. Let's examine the user-defined data first:
     be recovered, at least by this part of the code.
     Often this log-level is unneeded as throwing an exception can convey
     all the required information.
-
-    You can create logging macros for custom log levels. For instance:
-    ```julia-repl
-    julia> using Logging
-
-    julia> @create_log_macro MyLog 200 :magenta
-    @mylog (macro with 1 method)
-
-    julia> @mylog "hello"
-    [ MyLog: hello
-    ```
 
 * The *message*  is an object describing the event. By convention
   `AbstractString`s passed as messages are assumed to be in markdown format.
@@ -315,7 +304,6 @@ Logging.Warn
 Logging.Error
 Logging.BelowMinLevel
 Logging.AboveMaxLevel
-Logging.@create_log_macro
 ```
 
 ### [Processing events with AbstractLogger](@id AbstractLogger-interface)

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -58,7 +58,6 @@ end
 showvalue(io, ex::Exception) = showerror(io, ex)
 
 function default_logcolor(level::LogLevel)
-    level in keys(custom_log_levels) ? custom_log_levels[level][2] :
     level < Info  ? :log_debug :
     level < Warn  ? :log_info  :
     level < Error ? :log_warn  :

--- a/stdlib/Logging/src/Logging.jl
+++ b/stdlib/Logging/src/Logging.jl
@@ -23,46 +23,12 @@ for sym in [
     Symbol("@warn"),
     Symbol("@error"),
     Symbol("@logmsg"),
-    :custom_log_levels,
     :with_logger,
     :current_logger,
     :global_logger,
     :disable_logging,
     :SimpleLogger]
     @eval const $sym = Base.CoreLogging.$sym
-end
-
-"""
-    @create_log_macro(name::Symbol, level::Int, face::Union{Symbol, StyledStrings.Face})
-
-Creates a custom log macro like `@info`, `@warn` etc. with a given `name`,
-`level` to be displayed with `face`. The macro created is named with the
-lowercase form of `name` but the given form is used for the printing.
-
-```julia-repl
-julia> @create_log_macro(:MyLog, 200, :magenta)
-@mylog (macro with 1 method)
-
-julia> @mylog "hello"
-[ MyLog: hello
-```
-"""
-macro create_log_macro(name, level, color)
-    macro_name = Symbol(lowercase(string(name)))
-    macro_string = QuoteNode(name)
-    loglevel = LogLevel(level)
-    if loglevel in (BelowMinLevel, Debug, Info, Warn, Error, AboveMaxLevel)
-        throw(ArgumentError("Cannot use the same log level as a built in log macro"))
-    end
-    if haskey(custom_log_levels, loglevel)
-        throw(ArgumentError("Custom log macro already exists for given log level"))
-    end
-    quote
-        $(custom_log_levels)[$(esc(loglevel))] = ($(macro_string), $(esc(color)))
-        macro $(esc(macro_name))(exs...)
-            $(Base.CoreLogging.logmsg_code)(($(Base.CoreLogging.@_sourceinfo))..., $(esc(loglevel)), exs...)
-        end
-    end
 end
 
 # LogLevel aliases (re-)documented here (JuliaLang/julia#40978)
@@ -115,7 +81,6 @@ export
     @warn,
     @error,
     @logmsg,
-    @create_log_macro,
     with_logger,
     current_logger,
     global_logger,

--- a/stdlib/Logging/test/runtests.jl
+++ b/stdlib/Logging/test/runtests.jl
@@ -7,8 +7,8 @@ import Logging: min_enabled_level, shouldlog, handle_message
 @noinline func1() = backtrace()
 
 # see "custom log macro" testset
-@create_log_macro CustomLog1 -500 :magenta
-@create_log_macro CustomLog2 1500 1
+CustomLog = LogLevel(-500)
+macro customlog(exs...) Base.CoreLogging.logmsg_code((Base.CoreLogging.@_sourceinfo)..., esc(CustomLog), exs...) end
 
 @testset "Logging" begin
 
@@ -289,24 +289,16 @@ end
 end
 
 @testset "custom log macro" begin
-    llevel = LogLevel(-500)
-
-    @test_logs (llevel, "foo") min_level=llevel @customlog1 "foo"
+    @test_logs (CustomLog, "a") min_level=CustomLog @customlog "a"
 
     buf = IOBuffer()
     io = IOContext(buf, :displaysize=>(30,80), :color=>false)
-    logger = ConsoleLogger(io, llevel)
+    logger = ConsoleLogger(io, CustomLog)
 
     with_logger(logger) do
-        @customlog1 "foo"
+        @customlog "a"
     end
-    @test occursin("CustomLog1: foo", String(take!(buf)))
-
-
-    with_logger(logger) do
-        @customlog2 "hello"
-    end
-    @test occursin("CustomLog2: hello", String(take!(buf)))
+    @test occursin("LogLevel(-500): a", String(take!(buf)))
 end
 
 @testset "Docstrings" begin


### PR DESCRIPTION
reverts #52196 7baa57718e44228925f61b7f27cfd1d05c94b414

See post merge discussion, concluded here https://github.com/JuliaLang/julia/pull/52196#issuecomment-1910104243

On the release-1.11 branch the news entry needs deleting from NEWS.md not HISTORY.md