### PR TITLE
implement mergewith(combine, ::NamedTuple, ...)

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -385,6 +385,24 @@ function merge(a::NamedTuple, itr)
     merge(a, NamedTuple{(names...,)}((vals...,)))
 end
 
+function mergewith(combine, a::NamedTuple{an}, b::NamedTuple{bn}) where {an, bn}
+    if @generated
+        names = merge_names(an, bn)
+        vals = map(names) do n
+            if sym_in(n, an) && sym_in(n, bn)
+                :(combine(a.$n, b.$n))
+            elseif sym_in(n, an)
+                :(a.$n)
+            elseif sym_in(n, bn)
+                :(b.$n)
+            end
+        end
+        :( NamedTuple{$names}(($(vals...),)) )
+    else
+        # todo
+    end
+end
+
 keys(nt::NamedTuple{names}) where {names} = names::Tuple{Vararg{Symbol}}
 values(nt::NamedTuple) = Tuple(nt)
 haskey(nt::NamedTuple, key::Union{Integer, Symbol}) = isdefined(nt, key)

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -161,6 +161,10 @@ end
 @test merge(NamedTuple(), [:a=>1, :b=>2, :c=>3, :a=>4, :c=>5]) == (a=4, b=2, c=5)
 @test merge((c=0, z=1), [:a=>1, :b=>2, :c=>3, :a=>4, :c=>5]) == (c=5, z=1, a=4, b=2)
 
+@test mergewith(+, (b=2,), (a=10,)) == (b=2, a=10)
+@test mergewith(+, (a=1, b=2), (a=10,)) == (a=11, b=2)
+@test mergewith((a,b) -> error(), NamedTuple(), NamedTuple()) == NamedTuple()
+
 @test keys((a=1, b=2, c=3)) == (:a, :b, :c)
 @test keys(NamedTuple()) == ()
 @test keys((a=1,)) == (:a,)


### PR DESCRIPTION
Functionality is useful, but the previous PR https://github.com/JuliaLang/julia/pull/36291 is stale for years. This is intended as an updated modern implementation.
Closes https://github.com/JuliaLang/julia/issues/36048.
Follows how `merge()` is defined.