### PR TITLE
Docs: change "Package naming guidelines" to "Package naming rules"

### DIFF
--- a/doc/src/tutorials/creating-packages.md
+++ b/doc/src/tutorials/creating-packages.md
@@ -566,7 +566,7 @@ if it finds packages under `[compat]` that is not listed in `[extras]`.
 ## Package naming rules
 
 Package names should be sensible to most Julia users, *even to those who are not domain experts*.
-The following guidelines apply to the `General` registry but may be useful for other package
+The following rules apply to the `General` registry but may be useful for other package
 registries as well.
 
 Since the `General` registry belongs to the entire community, people may have opinions about

--- a/doc/src/tutorials/creating-packages.md
+++ b/doc/src/tutorials/creating-packages.md
@@ -563,7 +563,7 @@ duplicated into `[extras]`. This is an unfortunate duplication, but without
 doing this the project verifier under older Julia versions will throw an error
 if it finds packages under `[compat]` that is not listed in `[extras]`.
 
-## Package naming guidelines
+## Package naming rules
 
 Package names should be sensible to most Julia users, *even to those who are not domain experts*.
 The following guidelines apply to the `General` registry but may be useful for other package


### PR DESCRIPTION
I think that "guidelines" implies that these are just optional suggestions.

But in practice, I think we usually insist that these are followed.

So I think it might be worth changing "guidelines" to "rules", to clarify that we enforce these.