### PR TITLE
Docs: Change "Packages that wrap external libraries or programs should be named after those libraries or programs" to "Packages that wrap external libraries or programs can be named after those libraries or programs"

### DIFF
--- a/doc/src/tutorials/creating-packages.md
+++ b/doc/src/tutorials/creating-packages.md
@@ -601,7 +601,7 @@ may fit your package better.
        and other packages each implement a unique approach based on a particular design philosophy.
      * In contrast, `SortingAlgorithms` provides a consistent interface to use many well-established
        sorting algorithms.
-6. Packages that wrap external libraries or programs should be named after those libraries or programs.
+6. Packages that wrap external libraries or programs can be named after those libraries or programs.
 
      * `CPLEX.jl` wraps the `CPLEX` library, which can be identified easily in a web search.
      * `MATLAB.jl` provides an interface to call the MATLAB engine from within Julia.


### PR DESCRIPTION
Before this PR:

> Packages that wrap external libraries or programs should be named after those libraries or programs.

I think that "should" is a little too strong.

After this PR:

> Packages that wrap external libraries or programs can be named after those libraries or programs.

## Motivation

This might make it a bit easier to convince package authors that they can use a longer more descriptive name for their package, instead of needing to exactly match the name of the underlying software that they are wrapping.

Suppose for example that someone is making a Julia package to wrap a piece of software named `HW`. Under the "should be named..." guideline, this would lead the package author to register a Julia package named HW.jl. Personally I'd like to encourage longer and more descriptive names. So, under the "can be named..." guideline, the author won't feel like the Julia package needs to be named HW.jl, and thus they might be more amenable to a longer name such as HelloWorld.jl.