### PR TITLE
Move accumulate example to accumulate docstring

### DIFF
--- a/base/accumulate.jl
+++ b/base/accumulate.jl
@@ -257,6 +257,9 @@ julia> accumulate(min, (1, -2, 3, -4, 5), init=0)
 julia> accumulate(/, (2, 4, Inf), init=100)
 (50.0, 12.5, 0.0)
 
+julia> accumulate(=>, (1,2,3,4))
+(1, 1 => 2, (1 => 2) => 3, ((1 => 2) => 3) => 4)
+
 julia> accumulate(=>, i^2 for i in 1:3)
 3-element Vector{Any}:
           1

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -190,9 +190,6 @@ julia> foldl(=>, 1:4)
 
 julia> foldl(=>, 1:4; init=0)
 (((0 => 1) => 2) => 3) => 4
-
-julia> accumulate(=>, (1,2,3,4))
-(1, 1 => 2, (1 => 2) => 3, ((1 => 2) => 3) => 4)
 ```
 """
 foldl(op, itr; kw...) = mapfoldl(identity, op, itr; kw...)


### PR DESCRIPTION
An `accumulate` example was in the `foldl` docstring. This PR moves it to the `accumulate` docstring. 


Originally added in https://github.com/JuliaLang/julia/pull/42019/ by @mcabbott.