### PR TITLE
document exact BigInt determinants

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1642,6 +1642,15 @@ julia> M = [1 0; 2 2]
 julia> det(M)
 2.0
 ```
+Note that, in general, `det` computes a floating-point approximation of the
+determinant, even for integer matrices, typically via Gaussian elimination.
+Julia includes an exact algorithm for integer determinants (the Bareiss algorithm),
+but only uses it by default for `BigInt` matrices (since determinants quickly
+overflow any fixed integer precision):
+```jldoctest
+julia> det(BigInt[1 0; 2 2]) # exact integer determinant
+2
+```
 """
 function det(A::AbstractMatrix{T}) where {T}
     if istriu(A) || istril(A)


### PR DESCRIPTION
New users are commonly surprised that determinants of integer matrices give an approximate floating-point answer (#40128), and are unaware that an exact algorithm is implemented for `BigInt` matrices (#40868).    This PR comments on both of these facts in the `det` documentation.

(At some point, we may want to mark `LinearAlgebra.det_bareiss` as `public`, and document it, but that can be done in a future PR.)