### PR TITLE
disable irinterp for interpreters with `may_optimize(...)=false`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -897,7 +897,12 @@ function concrete_eval_eligible(interp::AbstractInterpreter,
             add_remark!(interp, sv, "[constprop] Concrete eval disabled for overlayed methods")
         end
         if !any_conditional(arginfo)
-            return :semi_concrete_eval
+            if may_optimize(interp)
+                return :semi_concrete_eval
+            else
+                # disable irinterp if optimization is disabled, since it requires optimized IR
+                add_remark!(interp, sv, "[constprop] Semi-concrete interpretation disabled for non-optimizing interpreter")
+            end
         end
     end
     return :none

--- a/test/compiler/AbstractInterpreter.jl
+++ b/test/compiler/AbstractInterpreter.jl
@@ -6,6 +6,17 @@ const CC = Core.Compiler
 include("irutils.jl")
 include("newinterp.jl")
 
+# interpreter that performs abstract interpretation only
+# (semi-concrete interpretation should be disabled automatically)
+@newinterp AbsIntOnlyInterp1
+CC.may_optimize(::AbsIntOnlyInterp1) = false
+@test Base.infer_return_type(Base.init_stdio, (Ptr{Cvoid},); interp=AbsIntOnlyInterp1()) >: IO
+
+# it should work even if the interpreter discards inferred source entirely
+@newinterp AbsIntOnlyInterp2
+CC.may_optimize(::AbsIntOnlyInterp2) = false
+CC.transform_result_for_cache(::AbsIntOnlyInterp2, ::Core.MethodInstance, ::CC.WorldRange, ::CC.InferenceResult) = nothing
+@test Base.infer_return_type(Base.init_stdio, (Ptr{Cvoid},); interp=AbsIntOnlyInterp2()) >: IO
 
 # OverlayMethodTable
 # ==================


### PR DESCRIPTION
As discussed at <https://github.com/JuliaLang/julia/commit/b8a0a3978ccf163ce8fc371a4882547dc1271d53#commitcomment-139076159>, currently external abstract interpreter that configures `may_optimize` to return `false` may end up with the internal error from irinterp since it fundamentally required optimized IR but it currently assumes that all sources from cached `CodeInstance`s are optimized.

This commit addresses the issue by incorporating a `may_optimize` check in `concrete_eval_eligible`, which in turn automatically disables irinterp for such interpreters. Although there were earlier discussions suggesting the revival of `codeinfo.inferred::Bool`, this commit does not need it, and I think this approach maintains the current state more cleanly.

This should fix the error of `"inference"` benchmarks from BaseBenchmarks.jl.

@nanosoldier `runbenchmarks("inference", vs="@c0a93f8c3ef20fe9f892e1a728409c60599657cc")`