### PR TITLE
minor followups on recent `CodeInstance` refactors

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -803,18 +803,18 @@ mutable struct IRInterpretationState
 end
 
 function IRInterpretationState(interp::AbstractInterpreter,
-    code::CodeInstance, mi::MethodInstance, argtypes::Vector{Any}, world::UInt)
-    @assert code.def === mi
-    src = @atomic :monotonic code.inferred
+    codeinst::CodeInstance, mi::MethodInstance, argtypes::Vector{Any}, world::UInt)
+    @assert codeinst.def === mi "method instance is not synced with code instance"
+    src = @atomic :monotonic codeinst.inferred
     if isa(src, String)
-        src = _uncompressed_ir(code, src)
+        src = _uncompressed_ir(codeinst, src)
     else
         isa(src, CodeInfo) || return nothing
     end
     method_info = MethodInfo(src)
     ir = inflate_ir(src, mi)
     return IRInterpretationState(interp, method_info, ir, mi, argtypes, world,
-                                 code.min_world, code.max_world)
+                                 codeinst.min_world, codeinst.max_world)
 end
 
 # AbsIntState

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -127,29 +127,23 @@ function get_staged(mi::MethodInstance, world::UInt)
     end
 end
 
-function retrieve_code_info(linfo::MethodInstance, world::UInt)
-    def = linfo.def
-    if !isa(def, Method)
-        return linfo.uninferred
-    end
-    c = nothing
-    if isdefined(def, :generator)
-        # user code might throw errors – ignore them
-        c = get_staged(linfo, world)
-    end
+function retrieve_code_info(mi::MethodInstance, world::UInt)
+    def = mi.def
+    isa(def, Method) || return mi.uninferred
+    c = isdefined(def, :generator) ? get_staged(mi, world) : nothing
     if c === nothing && isdefined(def, :source)
         src = def.source
         if src === nothing
             # can happen in images built with --strip-ir
             return nothing
         elseif isa(src, String)
-            c = ccall(:jl_uncompress_ir, Any, (Any, Ptr{Cvoid}, Any), def, C_NULL, src)
+            c = ccall(:jl_uncompress_ir, Ref{CodeInfo}, (Any, Ptr{Cvoid}, Any), def, C_NULL, src)
         else
             c = copy(src::CodeInfo)
         end
     end
     if c isa CodeInfo
-        c.parent = linfo
+        c.parent = mi
         return c
     end
     return nothing

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1322,9 +1322,12 @@ uncompressed_ir(m::Method) = isdefined(m, :source) ? _uncompressed_ir(m) :
                              error("Code for this Method is not available.")
 function _uncompressed_ir(m::Method)
     s = m.source
-    s isa String && (s = ccall(:jl_uncompress_ir, Any, (Any, Ptr{Cvoid}, Any), m, C_NULL, s))
+    if s isa String
+        s = ccall(:jl_uncompress_ir, Ref{CodeInfo}, (Any, Ptr{Cvoid}, Any), m, C_NULL, s)
+    end
     return s::CodeInfo
 end
+
 # for backwards compat
 const uncompressed_ast = uncompressed_ir
 const _uncompressed_ast = _uncompressed_ir


### PR DESCRIPTION
- ~~simplifies the signature of `transform_result_for_cache`~~
- ~~make `jl_uncompress_ir` take `MethodInstance` instead of `CodeInstance`
  and simplifies the inlining algorithm~~
- renames of `codeinst::CodeInstace` objects
- removal of dead code