### PR TITLE
cleanups on `src_inlining_policy`

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -115,14 +115,10 @@ function src_inlining_policy(interp::AbstractInterpreter,
         return src_inlineable
     elseif isa(src, IRCode)
         return true
-    elseif isa(src, SemiConcreteResult)
-        return true
     end
     @assert !isa(src, CodeInstance) # handled by caller
     return false
 end
-
-function inlining_policy end # deprecated legacy name used by Cthulhu
 
 struct InliningState{Interp<:AbstractInterpreter}
     edges::Vector{Any}

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -873,7 +873,8 @@ function typeinf_edge(interp::AbstractInterpreter, method::Method, @nospecialize
         exc_bestguess = refine_exception_type(frame.exc_bestguess, effects)
         # propagate newly inferred source to the inliner, allowing efficient inlining w/o deserialization:
         # note that this result is cached globally exclusively, we can use this local result destructively
-        volatile_inf_result = isinferred && (force_inline || src_inlining_policy(interp, result.src, NoCallInfo(), IR_FLAG_NULL) !== nothing) ?
+        volatile_inf_result = (isinferred && (force_inline ||
+            src_inlining_policy(interp, result.src, NoCallInfo(), IR_FLAG_NULL))) ?
             VolatileInferenceResult(result) : nothing
         return EdgeCallResult(frame.bestguess, exc_bestguess, edge, effects, volatile_inf_result)
     elseif frame === true


### PR DESCRIPTION
- fixed the check with `src_inlining_policy` in typeinfer.jl
- removed the `SemiConcreteResult` handling, which is no longer needed