### PR TITLE
inlining: use method match signature for union-spliting

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5627,3 +5627,15 @@ end
 
 # Issue #52613
 @test (code_typed((Any,)) do x; TypeVar(x...); end)[1][2] === TypeVar
+
+# https://github.com/JuliaLang/julia/issues/53590
+func53590(b) = b ? Int : Float64
+function issue53590(b1, b2)
+    T1 = func53590(b1)
+    T2 = func53590(b2)
+    return typejoin(T1, T2)
+end
+@test issue53590(true, true) == Int
+@test issue53590(true, false) == Real
+@test issue53590(false, false) == Float64
+@test issue53590(false, true) == Real


### PR DESCRIPTION
In cases where the results of constant inference, like concrete-eval, are used for union-split inlining, `isa`-blocks are generated using the `result.edge.specTypes` stored within each `result`. However, it's been found that the `edge` returned by abstract interpretation may have been widened by the new `@nospecializeinfer`, which can result in invalid union-splitting. To address this problem, this commit tweaks the inlining algorithm so that it performs union-split inlining using the original signatures that abstract interpretation used for union-split inference, by using `match::MethodMatch`.

- fixes #53590