### PR TITLE
Handle zero on arrays of unions of number types and missings

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1218,6 +1218,7 @@ end
 copymutable(itr) = collect(itr)
 
 zero(x::AbstractArray{T}) where {T<:Number} = fill!(similar(x, typeof(zero(T))), zero(T))
+zero(x::AbstractArray{S}) where {T<:Number, S<:Union{Missing, T}} = fill!(similar(x, typeof(zero(S))), zero(S))
 zero(x::AbstractArray) = map(zero, x)
 
 ## iteration support for arrays by iterating over `eachindex` in the array ##

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1218,7 +1218,7 @@ end
 copymutable(itr) = collect(itr)
 
 zero(x::AbstractArray{T}) where {T<:Number} = fill!(similar(x, typeof(zero(T))), zero(T))
-zero(x::AbstractArray{S}) where {T<:Number, S<:Union{Missing, T}} = fill!(similar(x, typeof(zero(S))), zero(S))
+zero(x::AbstractArray{S}) where {S<:Union{Missing, Number}} = fill!(similar(x, typeof(zero(S))), zero(S))
 zero(x::AbstractArray) = map(zero, x)
 
 ## iteration support for arrays by iterating over `eachindex` in the array ##

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1981,6 +1981,7 @@ end
     Base.zero(::Type{CustomNumber}) = CustomNumber(0.0)
     @test zero([CustomNumber(5.0)]) == [CustomNumber(0.0)]
     @test zero(Union{CustomNumber, Missing}[missing]) == [CustomNumber(0.0)]
+    @test zero(Vector{Union{CustomNumber, Missing}}(undef, 1)) == [CustomNumber(0.0)]
 end
 
 @testset "`_prechecked_iterate` optimization" begin

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1972,6 +1972,15 @@ end
 
     @test zero([[2,2], [3,3,3]]) isa Vector{Vector{Int}}
     @test zero([[2,2], [3,3,3]]) == [[0,0], [0, 0, 0]]
+
+
+    @test zero(Union{Float64, Missing}[missing]) == [0.0]
+    struct CustomNumber <: Number
+        val::Float64
+    end
+    Base.zero(::Type{CustomNumber}) = CustomNumber(0.0)
+    @test zero([CustomNumber(5.0)]) == [CustomNumber(0.0)]
+    @test zero(Union{CustomNumber, Missing}[missing]) == [CustomNumber(0.0)]
 end
 
 @testset "`_prechecked_iterate` optimization" begin


### PR DESCRIPTION
I believe this resolves https://github.com/JuliaLang/julia/issues/53582 

The intent of https://github.com/JuliaLang/julia/pull/51458
was to only change cases that were errors into successes.
(or in case of `undef` elements into different errors)
Not to change behavour of any existing non-erroring code.

This particular interaction was the result of the existance of 
```
 [19] zero(::Type{Union{Missing, T}}) where T
     @ missing.jl:105
```
Which only uses the `T` to determine the zero, not the whole type.
Which could not be replicated by iterting over the elements, as those all have concrete types.
This just pushed that check up to also happen at the AbstractArray level.
Which isn't particularly satifying, but does fix the issue, and I suspect all similar cases that actually exist in the wild.
(I will note that we do not require the same for `nothing` as that does not have a similar `zero(Union{Nothing, T})` overload.)

Possibly there are other cases involving `Vector{T}(undef,...)` that also now error, which this PR does not fix.
These would exist if there is a **non-isbits** type that implements `zero{T}`, but which does not implement `zero(::AbstractArray{T})`, of which AFAICT there are none in `Base` from looking at `methods` zero.
In general arrays containing `undef` break for a ton of operations, so I didn't worry about them to much in the original PR.