### PR TITLE
PersistentDict: Use special marker struct for missing entries

### DIFF
--- a/test/scopedvalues.jl
+++ b/test/scopedvalues.jl
@@ -150,3 +150,19 @@ end
 let code = code_typed(with_macro_slot_cross)[1][1].code
     @test !any(x->isa(x, Core.PhiCNode), code)
 end
+
+const sval_53584 = ScopedValue([0])
+@noinline function issue_53584()
+    dvec = sval_53584[]
+    dvec[1] += 1
+    return nothing
+end
+
+@testset "get() allocations" begin
+    @with sval_53584=>[0] begin
+        bytes = @allocated for _ in 1:1000_000
+            issue_53584()
+        end
+        @test bytes == 0
+    end
+end


### PR DESCRIPTION
This avoids allocating a `Tuple{T}` on each `get(dict::PersistentDict{K,V}, ...)` call

The other alternative here would be to force `KeyValue.get` to be inlined at these call-sites, so that SROA can get rid of the temporary but I assume @keno had good reason for trying to avoid that inlining.

Resolves #53584:

```julia
julia> const dynvec = ScopedValue([0])
julia> @noinline function dynfun()
           dvec = dynvec[]
           dvec[1] += 1
           return nothing
       end
julia> foo() = @with dynvec=>[0] for _ in 1:1000_000; dynfun(); end

julia> @allocated foo()
208
```