### PR TITLE
Linalg: matprod_dest for Diagonal and adjvec

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -581,6 +581,8 @@ matprod_dest(A::Diagonal, B::StructuredMatrix, TS) = similar(B, TS)
 matprod_dest(A::Diagonal, B::Diagonal, TS) = similar(B, TS)
 matprod_dest(A::HermOrSym, B::Diagonal, TS) = similar(A, TS, size(A))
 matprod_dest(A::Diagonal, B::HermOrSym, TS) = similar(B, TS, size(B))
+# Special handling for adj/trans vec
+matprod_dest(A::Diagonal, B::AdjOrTransAbsVec, TS) = similar(B, TS)
 
 # TODO: remove once not used anymore in SparseArrays.jl
 # some trait like this would be cool

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -1277,4 +1277,15 @@ end
     @test c == Diagonal([2,2,2,2])
 end
 
+@testset "mul/div with an adjoint vector" begin
+    A = [1.0;;]
+    x = [1.0]
+    yadj = Diagonal(A) \ x'
+    @test typeof(yadj) == typeof(x')
+    @test yadj == x'
+    yadj = Diagonal(A) * x'
+    @test typeof(yadj) == typeof(x')
+    @test yadj == x'
+end
+
 end # module TestDiagonal


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/LinearAlgebra.jl/issues/1057

This restores the v1.10 behavior:
```julia
julia> Diagonal([1.0]) \ [1.0]'
1×1 adjoint(::Vector{Float64}) with eltype Float64:
 1.0
```
This interprets the `Diagonal` as the matrix representation of a linear operator in the adjoint vector space.

Something similar may also be done for other structured matrix types for consistency, but that may be a different PR as this one may need to be backported.