### PR TITLE
Fix bootstrap Base precompile in cross compile configuration

### DIFF
--- a/pkgimage.mk
+++ b/pkgimage.mk
@@ -6,8 +6,8 @@ include $(JULIAHOME)/stdlib/stdlib.mk
 
 
 # set some influential environment variables
-export JULIA_DEPOT_PATH := $(build_prefix)/share/julia
-export JULIA_LOAD_PATH := @stdlib:$(JULIAHOME)/stdlib
+export JULIA_DEPOT_PATH := $(shell echo $(call cygpath_w,$(build_prefix)/share/julia))
+export JULIA_LOAD_PATH := @stdlib$(PATHSEP)$(shell echo $(call cygpath_w,$(JULIAHOME)/stdlib))
 unexport JULIA_PROJECT :=
 unexport JULIA_BINDIR :=
 


### PR DESCRIPTION
The environment variables here need to have target semantics, so on Windows the path separator needs to be `;` and the path needs to be converted to windows before being passed through julia. Because variable assignment is not ordinarily shell expanded, we also need an extra `$(shell)` to perform this conversion. Fixes MSYS2 builds of Julia after #53598.