### PR TITLE
Noteworthy differences: `exp.(A)` vs `exp(A)`

### DIFF
--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -56,6 +56,10 @@ may trip up Julia users accustomed to MATLAB:
   * In Julia, if `A` and `B` are arrays, logical comparison operations like `A == B` do not return
     an array of booleans. Instead, use `A .== B`, and similarly for the other boolean operators like
     [`<`](@ref), [`>`](@ref).
+  * In Julia, when you want to apply a scalar-valued function elementwise to an array, use broadcasting
+    syntax: `f.(A)` instead of `f(A)`. In some cases, both operations are defined but mean different things:
+    in MATLAB `exp(A)` applies elementwise and `expm(A)` is the [matrix exponential](https://en.wikipedia.org/wiki/Matrix_exponential),
+    but in Julia `exp.(A)` applies elementwise and `exp(A)` is the matrix exponential.
   * In Julia, the operators [`&`](@ref), [`|`](@ref), and [`⊻`](@ref xor) ([`xor`](@ref)) perform the
     bitwise operations equivalent to `and`, `or`, and `xor` respectively in MATLAB, and have precedence
     similar to Python's bitwise operators (unlike C). They can operate on scalars or element-wise
@@ -245,6 +249,10 @@ For users coming to Julia from R, these are some noteworthy differences:
   * In Julia, the exponentiation operator is `^`, not `**` as in Python.
   * Julia uses `nothing` of type `Nothing` to represent a null value, whereas Python uses `None` of type `NoneType`.
   * In Julia, the standard operators over a matrix type are matrix operations, whereas, in Python, the standard operators are element-wise operations. When both `A` and `B` are matrices, `A * B` in Julia performs matrix multiplication, not element-wise multiplication as in Python. `A * B` in Julia is equivalent with `A @ B` in Python, whereas `A * B` in Python is equivalent with `A .* B` in Julia.
+  * In Julia, when you want to apply a scalar-valued function elementwise to an array, use broadcasting
+    syntax: `f.(A)` instead of `f(A)`. In some cases, both operations are defined but mean different things:
+    `numpy.exp(A)` applies elementwise and `scipy.linalg.expm(A)` is the [matrix exponential](https://en.wikipedia.org/wiki/Matrix_exponential),
+    but in Julia `exp.(A)` applies elementwise and `exp(A)` is the matrix exponential.
   * The adjoint operator `'` in Julia returns an adjoint of a vector (a lazy representation of row vector), whereas the transpose operator `.T` over a vector in Python returns the original vector (non-op).
   * In Julia, a function may contain multiple concrete implementations (called *methods*), which are selected via multiple dispatch based on the types of all arguments to the call, as compared to functions in Python, which have a single implementation and no polymorphism (as opposed to Python method calls which use a different syntax and allows dispatch on the receiver of the method).
   * There are no classes in Julia. Instead there are structures (mutable or immutable), containing data but no methods.


### PR DESCRIPTION
I've seen this error in the wild, and as it can indeed be a gotcha it seems worth having. I can't speak to languages besides MATLAB and Python, so feel free to chime in if similar material should be added elsewhere.