### PR TITLE
Switch LLVM codegen of Ptr{T} to an actual pointer type.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,11 @@ Language changes
 Compiler/Runtime improvements
 -----------------------------
 
+- Generated LLVM IR now uses actual pointer types instead of passing pointers as integers.
+  This affects `llvmcall`: Inline LLVM IR should be updated to use `i8*` or `ptr` instead of
+  `i32` or `i64`, and remove unneeded `ptrtoint`/`inttoptr` conversions. For compatibility,
+  IR with integer pointers is still supported, but generates a deprecation warning. ([#53687])
+
 Command-line option changes
 ---------------------------
 

--- a/base/atomics.jl
+++ b/base/atomics.jl
@@ -364,13 +364,13 @@ for typ in atomictypes
     irt = "$ilt, $ilt*"
     @eval getindex(x::Atomic{$typ}) =
         GC.@preserve x llvmcall($"""
-                 %ptr = inttoptr i$WORD_SIZE %0 to $lt*
+                 %ptr = bitcast i8* %0 to $lt*
                  %rv = load atomic $rt %ptr acquire, align $(gc_alignment(typ))
                  ret $lt %rv
                  """, $typ, Tuple{Ptr{$typ}}, unsafe_convert(Ptr{$typ}, x))
     @eval setindex!(x::Atomic{$typ}, v::$typ) =
         GC.@preserve x llvmcall($"""
-                 %ptr = inttoptr i$WORD_SIZE %0 to $lt*
+                 %ptr = bitcast i8* %0 to $lt*
                  store atomic $lt %1, $lt* %ptr release, align $(gc_alignment(typ))
                  ret void
                  """, Cvoid, Tuple{Ptr{$typ}, $typ}, unsafe_convert(Ptr{$typ}, x), v)
@@ -379,7 +379,7 @@ for typ in atomictypes
     if typ <: Integer
         @eval atomic_cas!(x::Atomic{$typ}, cmp::$typ, new::$typ) =
             GC.@preserve x llvmcall($"""
-                     %ptr = inttoptr i$WORD_SIZE %0 to $lt*
+                     %ptr = bitcast i8* %0 to $lt*
                      %rs = cmpxchg $lt* %ptr, $lt %1, $lt %2 acq_rel acquire
                      %rv = extractvalue { $lt, i1 } %rs, 0
                      ret $lt %rv
@@ -388,7 +388,7 @@ for typ in atomictypes
     else
         @eval atomic_cas!(x::Atomic{$typ}, cmp::$typ, new::$typ) =
             GC.@preserve x llvmcall($"""
-                     %iptr = inttoptr i$WORD_SIZE %0 to $ilt*
+                     %iptr = bitcast i8* %0 to $ilt*
                      %icmp = bitcast $lt %1 to $ilt
                      %inew = bitcast $lt %2 to $ilt
                      %irs = cmpxchg $ilt* %iptr, $ilt %icmp, $ilt %inew acq_rel acquire
@@ -411,7 +411,7 @@ for typ in atomictypes
         if typ <: Integer
             @eval $fn(x::Atomic{$typ}, v::$typ) =
                 GC.@preserve x llvmcall($"""
-                         %ptr = inttoptr i$WORD_SIZE %0 to $lt*
+                         %ptr = bitcast i8* %0 to $lt*
                          %rv = atomicrmw $rmw $lt* %ptr, $lt %1 acq_rel
                          ret $lt %rv
                          """, $typ, Tuple{Ptr{$typ}, $typ}, unsafe_convert(Ptr{$typ}, x), v)
@@ -419,7 +419,7 @@ for typ in atomictypes
             rmwop === :xchg || continue
             @eval $fn(x::Atomic{$typ}, v::$typ) =
                 GC.@preserve x llvmcall($"""
-                         %iptr = inttoptr i$WORD_SIZE %0 to $ilt*
+                         %iptr = bitcast i8* %0 to $ilt*
                          %ival = bitcast $lt %1 to $ilt
                          %irv = atomicrmw $rmw $ilt* %iptr, $ilt %ival acq_rel
                          %rv = bitcast $ilt %irv to $lt

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -184,8 +184,6 @@ add_tfunc(sdiv_int, 2, 2, math_tfunc, 20)
 add_tfunc(udiv_int, 2, 2, math_tfunc, 20)
 add_tfunc(srem_int, 2, 2, math_tfunc, 20)
 add_tfunc(urem_int, 2, 2, math_tfunc, 20)
-add_tfunc(add_ptr, 2, 2, math_tfunc, 1)
-add_tfunc(sub_ptr, 2, 2, math_tfunc, 1)
 add_tfunc(neg_float, 1, 1, math_tfunc, 1)
 add_tfunc(add_float, 2, 2, math_tfunc, 2)
 add_tfunc(sub_float, 2, 2, math_tfunc, 2)
@@ -662,6 +660,9 @@ function pointer_eltype(@nospecialize(ptr))
     return Any
 end
 
+@nospecs function ptrarith_tfunc(𝕃::AbstractLattice, ptr, offset)
+    return ptr
+end
 @nospecs function pointerref_tfunc(𝕃::AbstractLattice, a, i, align)
     return pointer_eltype(a)
 end
@@ -705,6 +706,8 @@ end
     end
     return ccall(:jl_apply_cmpswap_type, Any, (Any,), T) where T
 end
+add_tfunc(add_ptr, 2, 2, ptrarith_tfunc, 1)
+add_tfunc(sub_ptr, 2, 2, ptrarith_tfunc, 1)
 add_tfunc(pointerref, 3, 3, pointerref_tfunc, 4)
 add_tfunc(pointerset, 4, 4, pointerset_tfunc, 5)
 add_tfunc(atomic_fence, 1, 1, atomic_fence_tfunc, 4)

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -660,7 +660,7 @@ function pointer_eltype(@nospecialize(ptr))
     return Any
 end
 
-@nospecs function ptrarith_tfunc(𝕃::AbstractLattice, ptr, offset)
+@nospecs function pointerarith_tfunc(𝕃::AbstractLattice, ptr, offset)
     return ptr
 end
 @nospecs function pointerref_tfunc(𝕃::AbstractLattice, a, i, align)
@@ -706,8 +706,8 @@ end
     end
     return ccall(:jl_apply_cmpswap_type, Any, (Any,), T) where T
 end
-add_tfunc(add_ptr, 2, 2, ptrarith_tfunc, 1)
-add_tfunc(sub_ptr, 2, 2, ptrarith_tfunc, 1)
+add_tfunc(add_ptr, 2, 2, pointerarith_tfunc, 1)
+add_tfunc(sub_ptr, 2, 2, pointerarith_tfunc, 1)
 add_tfunc(pointerref, 3, 3, pointerref_tfunc, 4)
 add_tfunc(pointerset, 4, 4, pointerset_tfunc, 5)
 add_tfunc(atomic_fence, 1, 1, atomic_fence_tfunc, 4)

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -313,8 +313,8 @@ isless(x::Ptr{T}, y::Ptr{T}) where {T} = x < y
 <(x::Ptr,  y::Ptr) = UInt(x) < UInt(y)
 -(x::Ptr,  y::Ptr) = UInt(x) - UInt(y)
 
-+(x::Ptr, y::Integer) = oftype(x, add_ptr(UInt(x), (y % UInt) % UInt))
--(x::Ptr, y::Integer) = oftype(x, sub_ptr(UInt(x), (y % UInt) % UInt))
++(x::Ptr, y::Integer) = add_ptr(x, (y % UInt) % UInt)
+-(x::Ptr, y::Integer) = sub_ptr(x, (y % UInt) % UInt)
 +(x::Integer, y::Ptr) = y + x
 
 unsigned(x::Ptr) = UInt(x)

--- a/base/task.jl
+++ b/base/task.jl
@@ -154,8 +154,7 @@ const _state_index = findfirst(==(:_state), fieldnames(Task))
 @eval function load_state_acquire(t)
     # TODO: Replace this by proper atomic operations when available
     @GC.preserve t llvmcall($("""
-        %ptr = inttoptr i$(Sys.WORD_SIZE) %0 to i8*
-        %rv = load atomic i8, i8* %ptr acquire, align 8
+        %rv = load atomic i8, i8* %0 acquire, align 8
         ret i8 %rv
         """), UInt8, Tuple{Ptr{UInt8}},
         Ptr{UInt8}(pointer_from_objref(t) + fieldoffset(Task, _state_index)))

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1009,7 +1009,7 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
             }
         }
 
-        // wrap the function, performing the necesary pointer conversion
+        // wrap the function, performing the necessary pointer conversion
 
         Function *inner = f;
         inner->setName(ir_name + ".inner");

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -690,6 +690,8 @@ static Type *bitstype_to_llvm(jl_value_t *bt, LLVMContext &ctxt, bool llvmcall =
         return getDoubleTy(ctxt);
     if (bt == (jl_value_t*)jl_bfloat16_type)
         return getBFloatTy(ctxt);
+    if (jl_is_cpointer_type(bt))
+        return PointerType::get(getInt8Ty(ctxt), 0);
     if (jl_is_llvmpointer_type(bt)) {
         jl_value_t *as_param = jl_tparam1(bt);
         int as;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -283,6 +283,7 @@ extern void _chkstk(void);
 
 // types
 struct jl_typecache_t {
+    Type *T_ptr;
     Type *T_size;
     Type *T_jlvalue;
     Type *T_pjlvalue;
@@ -304,7 +305,7 @@ struct jl_typecache_t {
     bool initialized;
 
     jl_typecache_t() :
-        T_jlvalue(nullptr), T_pjlvalue(nullptr), T_prjlvalue(nullptr),
+        T_ptr(nullptr), T_jlvalue(nullptr), T_pjlvalue(nullptr), T_prjlvalue(nullptr),
         T_ppjlvalue(nullptr), T_pprjlvalue(nullptr),
         T_jlgenericmemory(nullptr), T_jlarray(nullptr), T_pjlarray(nullptr),
         T_jlfunc(nullptr), T_jlfuncparams(nullptr), T_sigatomic(nullptr), T_ppint8(nullptr),
@@ -315,6 +316,7 @@ struct jl_typecache_t {
             return;
         }
         initialized = true;
+        T_ptr = getInt8PtrTy(context);
         T_ppint8 = PointerType::get(getInt8PtrTy(context), 0);
         T_sigatomic = Type::getIntNTy(context, sizeof(sig_atomic_t) * 8);
         T_size = DL.getIntPtrType(context);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -17,8 +17,8 @@ STATISTIC(EmittedRuntimeCalls, "Number of runtime intrinsic calls emitted");
 STATISTIC(EmittedIntrinsics, "Number of intrinsic calls emitted");
 STATISTIC(Emitted_pointerref, "Number of pointerref calls emitted");
 STATISTIC(Emitted_pointerset, "Number of pointerset calls emitted");
-STATISTIC(Emitted_add_ptr, "Number of add_ptr calls emitted")
-STATISTIC(Emitted_sub_ptr, "Number of sub_ptr calls emitted")
+STATISTIC(Emitted_add_ptr, "Number of add_ptr calls emitted");
+STATISTIC(Emitted_sub_ptr, "Number of sub_ptr calls emitted");
 STATISTIC(Emitted_atomic_fence, "Number of atomic_fence calls emitted");
 STATISTIC(Emitted_atomic_pointerref, "Number of atomic_pointerref calls emitted");
 STATISTIC(Emitted_atomic_pointerop, "Number of atomic_pointerop calls emitted");

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -625,10 +625,14 @@ static jl_cgval_t generic_bitcast(jl_codectx_t &ctx, ArrayRef<jl_cgval_t> argv)
             vx = ctx.builder.CreateZExt(vx, llvmt);
         } else if (vxt->isPointerTy() && !llvmt->isPointerTy()) {
             vx = ctx.builder.CreatePtrToInt(vx, llvmt);
-            setName(ctx.emission_context, vx, "bitcast_coercion");
+            if (isa<Instruction>(vx) && !vx->hasName())
+                // CreatePtrToInt may undo an IntToPtr
+                setName(ctx.emission_context, vx, "bitcast_coercion");
         } else if (!vxt->isPointerTy() && llvmt->isPointerTy()) {
             vx = emit_inttoptr(ctx, vx, llvmt);
-            setName(ctx.emission_context, vx, "bitcast_coercion");
+            if (isa<Instruction>(vx) && !vx->hasName())
+                // emit_inttoptr may undo an PtrToInt
+                setName(ctx.emission_context, vx, "bitcast_coercion");
         } else {
             vx = emit_bitcast(ctx, vx, llvmt);
             setName(ctx.emission_context, vx, "bitcast_coercion");
@@ -741,7 +745,8 @@ static jl_cgval_t emit_pointerref(jl_codectx_t &ctx, ArrayRef<jl_cgval_t> argv)
 
     if (ety == (jl_value_t*)jl_any_type) {
         Value *thePtr = emit_unbox(ctx, ctx.types().T_pprjlvalue, e, e.typ);
-        setName(ctx.emission_context, thePtr, "unbox_any_ptr");
+        if (isa<Instruction>(thePtr) && !thePtr->hasName())
+            setName(ctx.emission_context, thePtr, "unbox_any_ptr");
         LoadInst *load = ctx.builder.CreateAlignedLoad(ctx.types().T_prjlvalue, ctx.builder.CreateInBoundsGEP(ctx.types().T_prjlvalue, thePtr, im1), Align(align_nb));
         setName(ctx.emission_context, load, "any_unbox");
         jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_data);
@@ -1270,6 +1275,27 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
         ++Emitted_pointerset;
         assert(nargs == 4);
         return emit_pointerset(ctx, argv);
+
+    case add_ptr: {
+        assert(nargs == 2);
+        if (!jl_is_cpointer_type(argv[0].typ) || argv[1].typ != (jl_value_t*)jl_ulong_type)
+            return emit_runtime_call(ctx, f, argv, nargs);
+        Value *ptr = emit_unbox(ctx, ctx.types().T_ptr, argv[0], argv[0].typ);
+        Value *off = emit_unbox(ctx, ctx.types().T_size, argv[1], argv[1].typ);
+        Value *ans = ctx.builder.CreateGEP(getInt8Ty(ctx.builder.getContext()), ptr, off);
+        return mark_julia_type(ctx, ans, false, argv[0].typ);
+    }
+    case sub_ptr: {
+        assert(nargs == 2);
+        if (!jl_is_cpointer_type(argv[0].typ) || argv[1].typ != (jl_value_t*)jl_ulong_type)
+            return emit_runtime_call(ctx, f, argv, nargs);
+        Value *ptr = emit_unbox(ctx, ctx.types().T_ptr, argv[0], argv[0].typ);
+        Value *off = emit_unbox(ctx, ctx.types().T_size, argv[1], argv[1].typ);
+        Value *ans = ctx.builder.CreateGEP(getInt8Ty(ctx.builder.getContext()), ptr,
+                                           ctx.builder.CreateNeg(off));
+        return mark_julia_type(ctx, ans, false, argv[0].typ);
+    }
+
     case atomic_fence:
         ++Emitted_atomic_fence;
         assert(nargs == 1);
@@ -1436,26 +1462,6 @@ static Value *emit_untyped_intrinsic(jl_codectx_t &ctx, intrinsic f, ArrayRef<Va
     case udiv_int: return ctx.builder.CreateUDiv(x, y);
     case srem_int: return ctx.builder.CreateSRem(x, y);
     case urem_int: return ctx.builder.CreateURem(x, y);
-
-    // LLVM will not fold ptrtoint+arithmetic+inttoptr to GEP. The reason for this
-    // has to do with alias analysis. When adding two integers, either one of them
-    // could be the pointer base. With getelementptr, it is clear which of the
-    // operands is the pointer base. We also have this information at the julia
-    // level. Thus, to not lose information, we need to have a separate intrinsic
-    // for pointer arithmetic which lowers to getelementptr.
-    case add_ptr: {
-        return ctx.builder.CreatePtrToInt(
-            ctx.builder.CreateGEP(getInt8Ty(ctx.builder.getContext()),
-                emit_inttoptr(ctx, x, getInt8PtrTy(ctx.builder.getContext())), y), t);
-
-    }
-
-    case sub_ptr: {
-        return ctx.builder.CreatePtrToInt(
-            ctx.builder.CreateGEP(getInt8Ty(ctx.builder.getContext()),
-                emit_inttoptr(ctx, x, getInt8PtrTy(ctx.builder.getContext())), ctx.builder.CreateNeg(y)), t);
-
-    }
 
     case neg_float: return math_builder(ctx)().CreateFNeg(x);
     case neg_float_fast: return math_builder(ctx, true)().CreateFNeg(x);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1278,7 +1278,8 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
 
     case add_ptr: {
         assert(nargs == 2);
-        if (!jl_is_cpointer_type(argv[0].typ) || argv[1].typ != (jl_value_t*)jl_ulong_type)
+        if (!jl_is_cpointer_type(argv[0].typ) || jl_has_free_typevars(argv[0].typ) ||
+            argv[1].typ != (jl_value_t*)jl_ulong_type)
             return emit_runtime_call(ctx, f, argv, nargs);
         Value *ptr = emit_unbox(ctx, ctx.types().T_ptr, argv[0], argv[0].typ);
         Value *off = emit_unbox(ctx, ctx.types().T_size, argv[1], argv[1].typ);
@@ -1287,7 +1288,8 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
     }
     case sub_ptr: {
         assert(nargs == 2);
-        if (!jl_is_cpointer_type(argv[0].typ) || argv[1].typ != (jl_value_t*)jl_ulong_type)
+        if (!jl_is_cpointer_type(argv[0].typ) || jl_has_free_typevars(argv[0].typ) ||
+            argv[1].typ != (jl_value_t*)jl_ulong_type)
             return emit_runtime_call(ctx, f, argv, nargs);
         Value *ptr = emit_unbox(ctx, ctx.types().T_ptr, argv[0], argv[0].typ);
         Value *off = emit_unbox(ctx, ctx.types().T_size, argv[1], argv[1].typ);

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -17,6 +17,8 @@ STATISTIC(EmittedRuntimeCalls, "Number of runtime intrinsic calls emitted");
 STATISTIC(EmittedIntrinsics, "Number of intrinsic calls emitted");
 STATISTIC(Emitted_pointerref, "Number of pointerref calls emitted");
 STATISTIC(Emitted_pointerset, "Number of pointerset calls emitted");
+STATISTIC(Emitted_add_ptr, "Number of add_ptr calls emitted")
+STATISTIC(Emitted_sub_ptr, "Number of sub_ptr calls emitted")
 STATISTIC(Emitted_atomic_fence, "Number of atomic_fence calls emitted");
 STATISTIC(Emitted_atomic_pointerref, "Number of atomic_pointerref calls emitted");
 STATISTIC(Emitted_atomic_pointerop, "Number of atomic_pointerop calls emitted");
@@ -1277,6 +1279,7 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
         return emit_pointerset(ctx, argv);
 
     case add_ptr: {
+        ++Emitted_add_ptr;
         assert(nargs == 2);
         if (!jl_is_cpointer_type(argv[0].typ) || jl_has_free_typevars(argv[0].typ) ||
             argv[1].typ != (jl_value_t*)jl_ulong_type)
@@ -1287,6 +1290,7 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
         return mark_julia_type(ctx, ans, false, argv[0].typ);
     }
     case sub_ptr: {
+        ++Emitted_sub_ptr;
         assert(nargs == 2);
         if (!jl_is_cpointer_type(argv[0].typ) || jl_has_free_typevars(argv[0].typ) ||
             argv[1].typ != (jl_value_t*)jl_ulong_type)

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -12,8 +12,6 @@
     ADD_I(udiv_int, 2) \
     ADD_I(srem_int, 2) \
     ADD_I(urem_int, 2) \
-    ADD_I(add_ptr, 2) \
-    ADD_I(sub_ptr, 2) \
     ADD_I(neg_float, 1) \
     ADD_I(add_float, 2) \
     ADD_I(sub_float, 2) \
@@ -86,6 +84,9 @@
     ADD_I(rint_llvm, 1) \
     ADD_I(sqrt_llvm, 1) \
     ADD_I(sqrt_llvm_fast, 1) \
+    /*  pointer arithmetic */ \
+    ADD_I(add_ptr, 2) \
+    ADD_I(sub_ptr, 2) \
     /*  pointer access */ \
     ADD_I(pointerref, 3) \
     ADD_I(pointerset, 4) \

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1699,7 +1699,7 @@ JL_DLLEXPORT jl_value_t *jl_add_ptr(jl_value_t *ptr, jl_value_t *offset)
 {
     JL_TYPECHK(add_ptr, pointer, ptr);
     JL_TYPECHK(add_ptr, ulong, offset);
-    long ptrval = jl_unbox_long(ptr) + jl_unbox_long(offset);
+    long ptrval = jl_unbox_long(ptr) + jl_unbox_ulong(offset);
     return jl_new_bits(jl_typeof(ptr), &ptrval);
 }
 
@@ -1707,6 +1707,6 @@ JL_DLLEXPORT jl_value_t *jl_sub_ptr(jl_value_t *ptr, jl_value_t *offset)
 {
     JL_TYPECHK(sub_ptr, pointer, ptr);
     JL_TYPECHK(sub_ptr, ulong, offset);
-    long ptrval = jl_unbox_long(ptr) - jl_unbox_long(offset);
+    long ptrval = jl_unbox_long(ptr) - jl_unbox_ulong(offset);
     return jl_new_bits(jl_typeof(ptr), &ptrval);
 }

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1384,10 +1384,8 @@ JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b, jl_value_t *c) 
 un_iintrinsic_fast(LLVMNeg, neg, neg_int, u)
 #define add(a,b) a + b
 bi_iintrinsic_fast(LLVMAdd, add, add_int, u)
-bi_iintrinsic_fast(LLVMAdd, add, add_ptr, u)
 #define sub(a,b) a - b
 bi_iintrinsic_fast(LLVMSub, sub, sub_int, u)
-bi_iintrinsic_fast(LLVMSub, sub, sub_ptr, u)
 #define mul(a,b) a * b
 bi_iintrinsic_fast(LLVMMul, mul, mul_int, u)
 #define div(a,b) a / b
@@ -1695,4 +1693,20 @@ JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *typ)
         return jl_cpu_has_fma(64);
     else
         return jl_false;
+}
+
+JL_DLLEXPORT jl_value_t *jl_add_ptr(jl_value_t *ptr, jl_value_t *offset)
+{
+    JL_TYPECHK(add_ptr, pointer, ptr);
+    JL_TYPECHK(add_ptr, ulong, offset);
+    long ptrval = jl_unbox_long(ptr) + jl_unbox_long(offset);
+    return jl_new_bits(jl_typeof(ptr), &ptrval);
+}
+
+JL_DLLEXPORT jl_value_t *jl_sub_ptr(jl_value_t *ptr, jl_value_t *offset)
+{
+    JL_TYPECHK(sub_ptr, pointer, ptr);
+    JL_TYPECHK(sub_ptr, ulong, offset);
+    long ptrval = jl_unbox_long(ptr) - jl_unbox_long(offset);
+    return jl_new_bits(jl_typeof(ptr), &ptrval);
 }

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1699,7 +1699,7 @@ JL_DLLEXPORT jl_value_t *jl_add_ptr(jl_value_t *ptr, jl_value_t *offset)
 {
     JL_TYPECHK(add_ptr, pointer, ptr);
     JL_TYPECHK(add_ptr, ulong, offset);
-    long ptrval = jl_unbox_long(ptr) + jl_unbox_ulong(offset);
+    char *ptrval = (char*)jl_unbox_long(ptr) + jl_unbox_ulong(offset);
     return jl_new_bits(jl_typeof(ptr), &ptrval);
 }
 
@@ -1707,6 +1707,6 @@ JL_DLLEXPORT jl_value_t *jl_sub_ptr(jl_value_t *ptr, jl_value_t *offset)
 {
     JL_TYPECHK(sub_ptr, pointer, ptr);
     JL_TYPECHK(sub_ptr, ulong, offset);
-    long ptrval = jl_unbox_long(ptr) - jl_unbox_ulong(offset);
+    char *ptrval = (char*)jl_unbox_long(ptr) - jl_unbox_ulong(offset);
     return jl_new_bits(jl_typeof(ptr), &ptrval);
 }


### PR DESCRIPTION
This PR switches our code generation for `Ptr{T}` from `i64` to an actual LLVM pointer type (`ptr` when using opaque pointers, an untyped `i8*` otherwise). The main motivation is to simplify `llvmcall` usage (doing away with the `inttoptr`/`ptrtoint` conversions), and also make it possible to simply use `ccall` to call intrinsics with pointer arguments (where we currently always need `llvmcall` for converting to a pointer).

Changing codegen like this is a breaking change for `llvmcall` users, but we don't promise any stability there. Also, with the switch to LLVM 17 where typed pointers have been removed, all `llvmcall` snippets will have to be updated anyway, so this seems like a good time to make that change.

Before:

```llvm
julia> @code_llvm pointer([])
define i64 @julia_pointer_1542(ptr noundef nonnull align 8 dereferenceable(24) %"x::Array") #0 {
top:
; ┌ @ pointer.jl:65 within `cconvert`
   %0 = load ptr, ptr %"x::Array", align 8
; └
; ┌ @ pointer.jl:90 within `unsafe_convert`
; │┌ @ pointer.jl:30 within `convert`
    %bitcast_coercion = ptrtoint ptr %0 to i64
    ret i64 %bitcast_coercion
; └└
}
```

After:

```llvm
julia> @code_llvm pointer([])
define ptr @julia_pointer_3880(ptr noundef nonnull align 8 dereferenceable(24) %"x::Array") #0 {
top:
; ┌ @ pointer.jl:65 within `cconvert`
   %0 = load ptr, ptr %"x::Array", align 8
; └
; ┌ @ pointer.jl:90 within `unsafe_convert`
; │┌ @ pointer.jl:30 within `convert`
    ret ptr %0
; └└
}
```

This also simplifies "real code", e.g., when `ccall` converts an Array to a pointer. I don't expect that to affect performance though.

There are a couple of other patterns that could be updated, e.g. the `type` argument to the `GCAllocBytes` intrinsic is currently still a `T_size`.