### PR TITLE
Correct `@NamedTuple` printing for non-identitifer keys

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1192,7 +1192,7 @@ function show_at_namedtuple(io::IO, syms::Tuple, types::DataType)
         if !first
             print(io, ", ")
         end
-        print(io, syms[i])
+        show_sym(io, syms[i])
         typ = types.parameters[i]
         if typ !== Any
             print(io, "::")

--- a/test/show.jl
+++ b/test/show.jl
@@ -1381,6 +1381,7 @@ test_repr("(:).a")
 @test repr(@NamedTuple{kw::@NamedTuple{kw2::Int64}}) == "@NamedTuple{kw::@NamedTuple{kw2::Int64}}"
 @test repr(@NamedTuple{kw::NTuple{7, Int64}}) == "@NamedTuple{kw::NTuple{7, Int64}}"
 @test repr(@NamedTuple{a::Float64, b}) == "@NamedTuple{a::Float64, b}"
+@test repr(@NamedTuple{var"#"::Int64}) == "@NamedTuple{var\"#\"::Int64}"
 
 # Test general printing of `Base.Pairs` (it should not use the `@Kwargs` macro syntax)
 @test repr(@Kwargs{init::Int}) == "Base.Pairs{Symbol, $Int, Tuple{Symbol}, @NamedTuple{init::$Int}}"


### PR DESCRIPTION
Before:
```
julia> typeof((;:var"#"=>1))
@NamedTuple{#::Int64}

julia> @NamedTuple{#::Int64}
ERROR: ParseError:
 # Error @ REPL[47]:2:2
 @NamedTuple{#::Int64}

 #└ ── Expected `}`
Stacktrace:
 [1] top-level scope
   @ none:1
```

After:
```
julia> typeof((;:var"#"=>1))
@NamedTuple{var"#"::Int64}

julia> @NamedTuple{var"#"::Int64}
@NamedTuple{var"#"::Int64}
```