### PR TITLE
propagate_inbounds to inline in indexing CartesianIndices{0}

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -365,7 +365,7 @@ module IteratorsMD
     end
 
     # getindex for a 0D CartesianIndices is necessary for disambiguation
-    @propagate_inbounds function Base.getindex(iter::CartesianIndices{0,R}) where {R}
+    @inline function Base.getindex(iter::CartesianIndices{0,R}) where {R}
         CartesianIndex()
     end
     @inline function Base.getindex(iter::CartesianIndices{N,R}, I::Vararg{Int, N}) where {N,R}


### PR DESCRIPTION
There's no indexing call in this method which an `@inbounds` may be propagated to.