### PR TITLE
WIP: canonicalize callable names through a per-module counter

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -742,6 +742,8 @@ static void init_global_mutexes(void) {
     JL_MUTEX_INIT(&profile_show_peek_cond_lock, "profile_show_peek_cond_lock");
 }
 
+extern htable_t scm_to_jl_sym_map;
+
 JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
 {
     // initialize many things, in no particular order
@@ -824,6 +826,7 @@ JL_DLLEXPORT void julia_init(JL_IMAGE_SEARCH rel)
 
     jl_gc_init();
 
+    htable_new(&scm_to_jl_sym_map, 0);
     arraylist_new(&jl_linkage_blobs, 0);
     arraylist_new(&jl_image_relocs, 0);
     arraylist_new(&eytzinger_image_tree, 0);

--- a/src/julia.h
+++ b/src/julia.h
@@ -661,6 +661,7 @@ typedef struct _jl_module_t {
     int8_t max_methods;
     jl_mutex_t lock;
     intptr_t hash;
+    uint32_t sym_counter;
 } jl_module_t;
 
 struct _jl_globalref_t {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -842,6 +842,12 @@ jl_method_t *jl_make_opaque_closure_method(jl_module_t *module, jl_value_t *name
     int nargs, jl_value_t *functionloc, jl_code_info_t *ci, int isva, int isinferred);
 JL_DLLEXPORT int jl_is_valid_oc_argtype(jl_tupletype_t *argt, jl_method_t *source);
 
+STATIC_INLINE int has_gensym_suffix(char *name) JL_NOTSAFEPOINT
+{
+    char *other = strrchr(name, '#');
+    return other != NULL && '0' < other[1] && other[1] <= '9';
+}
+
 // Each tuple can exist in one of 4 Vararg states:
 //   NONE: no vararg                            Tuple{Int,Float32}
 //   INT: vararg with integer length            Tuple{Int,Vararg{Float32,2}}

--- a/src/module.c
+++ b/src/module.c
@@ -49,6 +49,7 @@ JL_DLLEXPORT jl_module_t *jl_new_module_(jl_sym_t *name, jl_module_t *parent, ui
         jl_module_public(m, name, 1);
         JL_GC_POP();
     }
+    m->sym_counter = 0;
     return m;
 }
 


### PR DESCRIPTION
We've been noticing that `precompile` statements lists from one version of our codebase often don't apply cleanly in a slightly different version because a lot of nested and anonymous function names have a global numeric suffix which is incremented every time a new name is generated, and these numeric suffixes are not very stable across codebase changes.

To solve, this, this PR basically introduces an extra step in the Scheme => Julia symbol conversion in which the numeric suffixes are replaced with a per-module counter.

I.e., something like this:

```julia
julia> function foo(x)
           function bar(y)
               return x + y
           end
           return bar
       end
foo (generic function with 1 method)

julia> f = foo(42)
(::var"#bar#Main<1>"{Int64}) (generic function with 1 method)
```