### PR TITLE
Implement Base.fd() for TCPSocket, UDPSocket, and TCPServer

### DIFF
--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -47,10 +47,9 @@ macro _lock_ios(s, expr)
 end
 
 """
-    fd(stream) -> RawFD
+    fd(x) -> RawFD
 
-Return the file descriptor backing the stream or file. Note that this function only applies
-to synchronous `File`'s and `IOStream`'s not to any of the asynchronous streams.
+Return the file descriptor backing the stream, file, or socket.
 
 `RawFD` objects can be passed directly to other languages via the `ccall` interface.
 
@@ -59,10 +58,10 @@ to synchronous `File`'s and `IOStream`'s not to any of the asynchronous streams.
     `RawFD(fd(x))` to produce a `RawFD` in all Julia versions.
 
 !!! warning
-    Use `Libc.dup(x_fd)` on the returned file descriptor before passing it to
-    another system that will take ownership of it (e.g. a C library). Otherwise
-    both the Julia object `x` and the other system may try to close the file
-    descriptor, which will cause errors.
+    Duplicate the returned file descriptor with [`Libc.dup()`](@ref) before
+    passing it to another system that will take ownership of it (e.g. a C
+    library). Otherwise both the Julia object `x` and the other system may try
+    to close the file descriptor, which will cause errors.
 """
 fd(s::IOStream) = RawFD(ccall(:jl_ios_fd, Clong, (Ptr{Cvoid},), s.ios))
 

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -65,6 +65,11 @@ Return the file descriptor backing the stream, file, or socket.
     passing it to another system that will take ownership of it (e.g. a C
     library). Otherwise both the Julia object `x` and the other system may try
     to close the file descriptor, which will cause errors.
+
+!!! warning
+    The file descriptors for sockets are asynchronous (i.e. `O_NONBLOCK` on
+    POSIX and `OVERLAPPED` on Windows), they may behave differently than regular
+    file descriptors.
 """
 fd(s::IOStream) = RawFD(ccall(:jl_ios_fd, Clong, (Ptr{Cvoid},), s.ios))
 

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -57,6 +57,9 @@ Return the file descriptor backing the stream, file, or socket.
     Prior to 1.12, this function returned an `Int` instead of a `RawFD`. You may use
     `RawFD(fd(x))` to produce a `RawFD` in all Julia versions.
 
+!!! compat "Julia 1.12"
+    Getting the file descriptor of sockets are supported as of Julia 1.12.
+
 !!! warning
     Duplicate the returned file descriptor with [`Libc.dup()`](@ref) before
     passing it to another system that will take ownership of it (e.g. a C

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -57,6 +57,12 @@ to synchronous `File`'s and `IOStream`'s not to any of the asynchronous streams.
 !!! compat "Julia 1.12"
     Prior to 1.12, this function returned an `Int` instead of a `RawFD`. You may use
     `RawFD(fd(x))` to produce a `RawFD` in all Julia versions.
+
+!!! warning
+    Use `Libc.dup(x_fd)` on the returned file descriptor before passing it to
+    another system that will take ownership of it (e.g. a C library). Otherwise
+    both the Julia object `x` and the other system may try to close the file
+    descriptor, which will cause errors.
 """
 fd(s::IOStream) = RawFD(ccall(:jl_ios_fd, Clong, (Ptr{Cvoid},), s.ios))
 

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -36,6 +36,13 @@ RawFD(fd::Integer) = bitcast(RawFD, Cint(fd))
 RawFD(fd::RawFD) = fd
 Base.cconvert(::Type{Cint}, fd::RawFD) = bitcast(Cint, fd)
 
+"""
+    dup(src::RawFD[, target::RawFD])::RawFD
+
+Duplicate the file descriptor `src` so that the duplicate refers to the same OS
+resource (e.g. a file or socket). A `target` file descriptor may be optionally
+be passed to use for the new duplicate.
+"""
 dup(x::RawFD) = ccall((@static Sys.iswindows() ? :_dup : :dup), RawFD, (RawFD,), x)
 dup(src::RawFD, target::RawFD) = systemerror("dup", -1 ==
     ccall((@static Sys.iswindows() ? :_dup2 : :dup2), Int32,

--- a/base/public.jl
+++ b/base/public.jl
@@ -102,6 +102,7 @@ public
     # functions
     reseteof,
     link_pipe!,
+    dup,
 
 # filesystem operations
     rename,

--- a/doc/src/base/libc.md
+++ b/doc/src/base/libc.md
@@ -18,6 +18,7 @@ Base.Libc.strftime
 Base.Libc.strptime
 Base.Libc.TmStruct
 Base.Libc.FILE
+Base.Libc.dup
 Base.Libc.flush_cstdio
 Base.Libc.systemsleep
 Base.Libc.mkfifo

--- a/stdlib/Sockets/src/Sockets.jl
+++ b/stdlib/Sockets/src/Sockets.jl
@@ -107,6 +107,8 @@ if OS_HANDLE != RawFD
     TCPSocket(fd::RawFD) = TCPSocket(Libc._get_osfhandle(fd))
 end
 
+Base.fd(sock::TCPSocket) = Base._fd(sock)
+
 
 mutable struct TCPServer <: LibuvServer
     handle::Ptr{Cvoid}
@@ -138,6 +140,8 @@ function TCPServer(; delay=true)
     iolock_end()
     return tcp
 end
+
+Base.fd(server::TCPServer) = Base._fd(server)
 
 """
     accept(server[, client])
@@ -198,6 +202,8 @@ function UDPSocket()
 end
 
 show(io::IO, stream::UDPSocket) = print(io, typeof(stream), "(", uv_status_string(stream), ")")
+
+Base.fd(sock::UDPSocket) = Base._fd(sock)
 
 function _uv_hook_close(sock::UDPSocket)
     lock(sock.cond)

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -605,6 +605,31 @@ end
     end
 end
 
+@testset "fd() methods" begin
+    function valid_fd(x)
+        if Sys.iswindows()
+            return x isa Base.OS_HANDLE
+        elseif !Sys.iswindows()
+            value = Base.cconvert(Cint, x)
+
+            # 2048 is a bit arbitrary, it depends on the process not having too many
+            # file descriptors open. But select() has a limit of 1024 and people
+            # don't seem to hit it too often so let's hope twice that is safe.
+            return value > 0 && value < 2048
+        end
+    end
+
+    sock = TCPSocket(; delay=false)
+    @test valid_fd(fd(sock))
+
+    sock = UDPSocket()
+    bind(sock, Sockets.localhost, 0)
+    @test valid_fd(fd(sock))
+
+    server = listen(Sockets.localhost, 0)
+    @test valid_fd(fd(server))
+end
+
 @testset "TCPServer constructor" begin
     s = Sockets.TCPServer(; delay=false)
     if ccall(:jl_has_so_reuseport, Int32, ()) == 1


### PR DESCRIPTION
This is quite handy if you want to pass off the file descriptor to a C library. I also added a warning to the `fd()` docstring to warn folks about duplicating the file descriptor first.

BTW, am I correct in thinking that sockets are not asynchronous streams? From looking at the code I'm guessing that only `Pipe` is asynchronous.