### PR TITLE
Relax an assertion in jl_mt_assoc_by_type.

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1463,7 +1463,6 @@ static jl_method_instance_t *jl_mt_assoc_by_type(jl_methtable_t *mt JL_PROPAGATE
     jl_method_match_t *matc = NULL;
     JL_GC_PUSH2(&tt, &matc);
     JL_LOCK(&mt->writelock);
-    assert(tt->isdispatchtuple || tt->hasfreetypevars);
     jl_method_instance_t *mi = NULL;
     if (tt->isdispatchtuple) {
         jl_genericmemory_t *leafcache = jl_atomic_load_relaxed(&mt->leafcache);
@@ -3139,7 +3138,7 @@ have_entry:
         mfunc = entry->func.linfo;
     }
     else {
-        assert(tt);
+        assert(tt && (tt->isdispatchtuple || tt->hasfreetypevars));
         // cache miss case
         mfunc = jl_mt_assoc_by_type(mt, tt, world);
         if (jl_options.malloc_log)


### PR DESCRIPTION
Now that `jl_method_lookup(_by_tt)` is an exported utility, it can be used for looking up unspecialized method instances, so relax an assertion that prevents it from being used that way.

This was encountered in https://github.com/JuliaGPU/GPUCompiler.jl/pull/545, where GPUCompiler.jl uses the new `jl_method_lookup_by_tt` to look-up `Runtime.unbox_uint64(::Any)` (as part of the runtime library compilation). Currently that's not allowed:

```julia
julia> Base.method_instance(identity, (Int,))
MethodInstance for identity(::Any)

julia> Base.method_instance(identity, (Any,))
julia: /home/tim/Julia/src/julia/src/gf.c:1485: jl_mt_assoc_by_type: Assertion `tt->isdispatchtuple || tt->hasfreetypevars' failed.
[84712] signal 6 (-6): Aborted
```

We previously used `_findup` for that, which always allows such queries:

```julia
julia> Core.Compiler._findsup(Tuple{typeof(identity), Any}, nothing, Base.get_world_counter())
(Core.MethodMatch(Tuple{typeof(identity), Any}, svec(), identity(x) @ Base operators.jl:531, true), Core.Compiler.WorldRange(0x0000000000001d4a, 0xffffffffffffffff))
```