### PR TITLE
Remove specialized view method for `OneTo` arguments

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -214,10 +214,6 @@ function view(A::AbstractArray, I::Vararg{Any,M}) where {M}
 end
 
 # Ranges implement getindex to return recomputed ranges; use that for views, too (when possible)
-function view(r1::OneTo, r2::OneTo)
-    @_propagate_inbounds_meta
-    getindex(r1, r2)
-end
 function view(r1::AbstractUnitRange, r2::AbstractUnitRange{<:Integer})
     @_propagate_inbounds_meta
     getindex(r1, r2)


### PR DESCRIPTION
This seems unnecessary, as the fallback method on line 221 does the same.