### PR TITLE
Remove specialized IndexStyle method for SubArray

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -430,7 +430,6 @@ function _unsetindex!(V::SubArray{T,N}, i::Vararg{Int,N}) where {T,N}
 end
 
 IndexStyle(::Type{<:FastSubArray}) = IndexLinear()
-IndexStyle(::Type{<:SubArray}) = IndexCartesian()
 
 # Strides are the distance in memory between adjacent elements in a given dimension
 # which we determine from the strides of the parent

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -339,6 +339,7 @@ end
     A = copy(reshape(1:120, 3, 5, 8))
     sA = view(A, 2:2, 1:5, :)
     @test @inferred(strides(sA)) == (1, 3, 15)
+    @test IndexStyle(sA) == IndexStyle(typeof(sA)) == IndexCartesian()
     @test parent(sA) == A
     @test parentindices(sA) == (2:2, 1:5, Base.Slice(1:8))
     @test size(sA) == (1, 5, 8)


### PR DESCRIPTION
The fallback method `IndexStyle(::Type{<:AbstractArray})` does the same, so this is unnecessary.