### PR TITLE
Don't recurse lowering symbol renaming through `Expr(:toplevel)`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -2504,6 +2504,11 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
     elseif head === :meta && nargs == 2 && args[1] === :pop_loc
         print(io, "# meta: pop locations ($(args[2]::Int))")
     # print anything else as "Expr(head, args...)"
+    elseif head === :toplevel
+        # Reset SOURCE_SLOTNAMES. Raw SlotNumbers are not valid in Expr(:toplevel), but
+        # we want to show bad ASTs reasonably to make errors understandable.
+        lambda_io = IOContext(io, :SOURCE_SLOTNAMES => false)
+        show_unquoted_expr_fallback(lambda_io, ex, indent, quote_level)
     else
         unhandled = true
     end

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -5131,7 +5131,7 @@ f(x) = yt(x)
             ((nospecialize-meta? e)
              ;; convert nospecialize vars to slot numbers
              `(meta ,(cadr e) ,@(map renumber-stuff (cddr e))))
-            ((or (atom? e) (quoted? e) (eq? (car e) 'global))
+            ((or (atom? e) (quoted? e) (eq? (car e) 'global) (eq? (car e) 'toplevel))
              e)
             ((ssavalue? e)
              (let ((idx (get ssavalue-table (cadr e) #f)))

--- a/test/show.jl
+++ b/test/show.jl
@@ -2683,3 +2683,14 @@ end
 using .Issue49382
 (::Type{Issue49382.Type49382})() = 1
 @test sprint(show, methods(Issue49382.Type49382)) isa String
+
+# Showing of bad SlotNumber in Expr(:toplevel)
+let lowered = Meta.lower(Main, Expr(:let, Expr(:block), Expr(:block, Expr(:toplevel, :(x = 1)), :(y = 1))))
+    ci = lowered.args[1]
+    @assert isa(ci, Core.CodeInfo)
+    @test !isempty(ci.slotnames)
+    @assert ci.code[1].head === :toplevel
+    ci.code[1].args[1] = :($(Core.SlotNumber(1)) = 1)
+    # Check that this gets printed as `_1 = 1` not `y = 1`
+    @test contains(sprint(show, ci), "_1 = 1")
+end

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -3669,3 +3669,7 @@ let nnames = length(names(MacroHygieneGenerator; all=true))
     @test (MacroHygieneGenerator.@gen3) == Bool[false]
     @test length(names(MacroHygieneGenerator; all=true)) == nnames
 end
+
+# Issue #53729 - Lowering recursion into Expr(:toplevel)
+@test eval(Expr(:let, Expr(:block), Expr(:block, Expr(:toplevel, :(f53729(x) = x)), :(x=1)))) == 1
+@test f53729(2) == 2


### PR DESCRIPTION
Fixes #53729.