### PR TITLE
Use Julian way `≥(0)` in `findall` docs

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -2635,7 +2635,7 @@ Dict{Symbol, Int64} with 3 entries:
   :B => -1
   :C => 0
 
-julia> findall(x -> x >= 0, d)
+julia> findall(≥(0), d)
 2-element Vector{Symbol}:
  :A
  :C


### PR DESCRIPTION
I'm pretty sure the manual advises against `x -> x >= 0` :)