### PR TITLE
Enable support for `NO_COLOR` and `FORCE_COLOR` environment variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,7 +37,7 @@ Command-line option changes
 * The `-m/--module` flag can be passed to run the `main` function inside a package with a set of arguments.
   This `main` function should be declared using `@main` to indicate that it is an entry point.
 * Enabling or disabling color text in Julia can now be controlled with the
-[`NO_COLOR`](https://no-color.org/) or [`FORCE_COLOR`](https://force-color.org/) environmental
+[`NO_COLOR`](https://no-color.org/) or [`FORCE_COLOR`](https://force-color.org/) environment
 variables. ([#53742]).
 
 Multi-threading changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,9 @@ Command-line option changes
 
 * The `-m/--module` flag can be passed to run the `main` function inside a package with a set of arguments.
   This `main` function should be declared using `@main` to indicate that it is an entry point.
-* Enabling or disabling color text in Julia can now be controlled with the [`NO_COLOR`](https://no-color.org/) or [`FORCE_COLOR`](https://force-color.org/) environmental variables. ([#53742]).
+* Enabling or disabling color text in Julia can now be controlled with the
+[`NO_COLOR`](https://no-color.org/) or [`FORCE_COLOR`](https://force-color.org/) environmental
+variables. ([#53742]).
 
 Multi-threading changes
 -----------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@ Command-line option changes
 
 * The `-m/--module` flag can be passed to run the `main` function inside a package with a set of arguments.
   This `main` function should be declared using `@main` to indicate that it is an entry point.
+* Enabling or disabling color text in Julia can now be controlled with the [`NO_COLOR`](https://no-color.org/) or [`FORCE_COLOR`](https://force-color.org/) environmental variables. ([#53742]).
 
 Multi-threading changes
 -----------------------

--- a/base/client.jl
+++ b/base/client.jl
@@ -419,7 +419,7 @@ end
 global active_repl
 
 # run the requested sort of evaluation loop on stdio
-function run_main_repl(interactive::Bool, quiet::Bool, banner::Symbol, history_file::Bool, color_set::Bool)
+function run_main_repl(interactive::Bool, quiet::Bool, banner::Symbol, history_file::Bool)
     fallback_repl = parse(Bool, get(ENV, "JULIA_FALLBACK_REPL", "false"))
     if !fallback_repl && interactive
         load_InteractiveUtils()
@@ -565,8 +565,7 @@ function repl_main(_)
 
     quiet                 = (opts.quiet != 0)
     history_file          = (opts.historyfile != 0)
-    color_set             = (opts.color != 0) # --color!=auto
-    return run_main_repl(interactiveinput, quiet, banner, history_file, color_set)
+    return run_main_repl(interactiveinput, quiet, banner, history_file)
 end
 
 """

--- a/base/client.jl
+++ b/base/client.jl
@@ -229,7 +229,7 @@ incomplete_tag(exc::Meta.ParseError) = incomplete_tag(exc.detail)
 cmd_suppresses_program(cmd) = cmd in ('e', 'E')
 function exec_options(opts)
     startup               = (opts.startupfile != 2)
-    global have_color     = (opts.color != 0) ? (opts.color == 1) : nothing # --color=on
+    global have_color     = colored_text(opts)
     global is_interactive = (opts.isinteractive != 0)
 
     # pre-process command line argument list

--- a/base/libuv.jl
+++ b/base/libuv.jl
@@ -138,13 +138,13 @@ function reinit_stdio()
     global stdout = init_stdio(ccall(:jl_stdout_stream, Ptr{Cvoid}, ()))::IO
     global stderr = init_stdio(ccall(:jl_stderr_stream, Ptr{Cvoid}, ()))::IO
     opts = JLOptions()
-    if opts.color != 0
-        have_color = (opts.color == 1)
+    color = colored_text(opts)
+    if !isnothing(color)
         if !isa(stdout, TTY)
-            global stdout = IOContext(stdout, :color => have_color)
+            global stdout = IOContext(stdout, :color => color::Bool)
         end
         if !isa(stderr, TTY)
-            global stderr = IOContext(stderr, :color => have_color)
+            global stderr = IOContext(stderr, :color => color::Bool)
         end
     end
     nothing

--- a/base/options.jl
+++ b/base/options.jl
@@ -100,3 +100,14 @@ end
 function is_file_tracked(file::Symbol)
     return ccall(:jl_is_file_tracked, Cint, (Any,), file) == 1
 end
+
+function colored_text(opts::JLOptions)
+    if !isempty(get(ENV, "FORCE_COLOR", ""))
+        color = true
+    elseif !isempty(get(ENV, "NO_COLOR", "")) && opts.color == 0  # `--color=auto`
+        color = false
+    else
+        color = (opts.color != 0) ? (opts.color == 1) : nothing
+    end
+    return color
+end

--- a/base/options.jl
+++ b/base/options.jl
@@ -67,6 +67,18 @@ end
 
 JLOptions() = unsafe_load(cglobal(:jl_options, JLOptions))
 
+function colored_text(opts::JLOptions)
+    return if opts.color != 0
+        opts.color == 1
+    elseif !isempty(get(ENV, "FORCE_COLOR", ""))
+        true
+    elseif !isempty(get(ENV, "NO_COLOR", ""))
+        false
+    else
+        nothing
+    end
+end
+
 function show(io::IO, opt::JLOptions)
     print(io, "JLOptions(")
     fields = fieldnames(JLOptions)
@@ -99,16 +111,4 @@ end
 
 function is_file_tracked(file::Symbol)
     return ccall(:jl_is_file_tracked, Cint, (Any,), file) == 1
-end
-
-function colored_text(opts::JLOptions)
-    color = nothing
-    if opts.color != 0
-        color = (opts.color == 1)
-    elseif haskey(ENV, "NO_COLOR")
-        color = false
-    elseif haskey(ENV, "FORCE_COLOR")
-        color = true
-    end
-    return color
 end

--- a/base/options.jl
+++ b/base/options.jl
@@ -102,12 +102,13 @@ function is_file_tracked(file::Symbol)
 end
 
 function colored_text(opts::JLOptions)
-    if !isempty(get(ENV, "FORCE_COLOR", ""))
-        color = true
-    elseif !isempty(get(ENV, "NO_COLOR", "")) && opts.color == 0  # `--color=auto`
+    color = nothing
+    if opts.color != 0
+        color = (opts.color == 1)
+    elseif haskey(ENV, "NO_COLOR")
         color = false
-    else
-        color = (opts.color != 0) ? (opts.color == 1) : nothing
+    elseif haskey(ENV, "FORCE_COLOR")
+        color = true
     end
     return color
 end

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -376,7 +376,7 @@ affinitized. Otherwise, Julia lets the operating system handle thread policy.
 ## REPL formatting
 
 Environment variables that determine how REPL output should be formatted at the
-terminal. Generally, these variables should be set to [ANSI terminal escape
+terminal. The `JULIA_*_COLOR` variables should be set to [ANSI terminal escape
 sequences](https://en.wikipedia.org/wiki/ANSI_escape_code). Julia provides
 a high-level interface with much of the same functionality; see the section on
 [The Julia REPL](@ref).
@@ -405,6 +405,14 @@ should have at the terminal.
 
 The formatting `Base.answer_color()` (default: normal, `"\033[0m"`) that output
 should have at the terminal.
+
+### `NO_COLOR`
+
+If set to anything besides `""`, then colored text will be disabled on the REPL. Can be overridden with the `--color=yes` flag. This environmental variable is [commonly recognized by command-line applications](https://no-color.org/).
+
+### `FORCE_COLOR`
+
+If set to anything besides `""`, then colored text will be forced on the REPL. Can *not* be overridden with the `--color` flag. This environmental variable is [commonly recognized by command-line applications](https://force-color.org/).
 
 ## System and Package Image Building
 

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -406,17 +406,18 @@ should have at the terminal.
 The formatting `Base.answer_color()` (default: normal, `"\033[0m"`) that output
 should have at the terminal.
 
-### `NO_COLOR`
+### [`NO_COLOR`](@id NO_COLOR)
 
-If set to anything besides `""`, then colored text will be disabled on the REPL. Can be
-overridden with the `--color=yes` flag. This environmental variable is [commonly recognized
-by command-line applications](https://no-color.org/).
+When this variable is present and not an empty string (regardless of its value) then colored
+text will be disabled on the REPL. Can be overridden with the flag `--color=yes` or with the
+environmental variable [`FORCE_COLOR`](@ref FORCE_COLOR). This environmental variable is
+[commonly recognized by command-line applications](https://no-color.org/).
 
-### `FORCE_COLOR`
+### [`FORCE_COLOR`](@id FORCE_COLOR)
 
-If set to anything besides `""`, then colored text will be forced on the REPL. Can *not* be
-overridden with the `--color` flag. This environmental variable is [commonly recognized by
-command-line applications](https://force-color.org/).
+When this variable is present and not an empty string (regardless of its value) then
+colored text will be enabled on the REPL. Can be overridden with the flag `--color=no`. This
+environmental variable is [commonly recognized by command-line applications](https://force-color.org/).
 
 ## System and Package Image Building
 

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -408,11 +408,15 @@ should have at the terminal.
 
 ### `NO_COLOR`
 
-If set to anything besides `""`, then colored text will be disabled on the REPL. Can be overridden with the `--color=yes` flag. This environmental variable is [commonly recognized by command-line applications](https://no-color.org/).
+If set to anything besides `""`, then colored text will be disabled on the REPL. Can be
+overridden with the `--color=yes` flag. This environmental variable is [commonly recognized
+by command-line applications](https://no-color.org/).
 
 ### `FORCE_COLOR`
 
-If set to anything besides `""`, then colored text will be forced on the REPL. Can *not* be overridden with the `--color` flag. This environmental variable is [commonly recognized by command-line applications](https://force-color.org/).
+If set to anything besides `""`, then colored text will be forced on the REPL. Can *not* be
+overridden with the `--color` flag. This environmental variable is [commonly recognized by
+command-line applications](https://force-color.org/).
 
 ## System and Package Image Building
 

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -410,14 +410,14 @@ should have at the terminal.
 
 When this variable is present and not an empty string (regardless of its value) then colored
 text will be disabled on the REPL. Can be overridden with the flag `--color=yes` or with the
-environmental variable [`FORCE_COLOR`](@ref FORCE_COLOR). This environmental variable is
+environment variable [`FORCE_COLOR`](@ref FORCE_COLOR). This environment variable is
 [commonly recognized by command-line applications](https://no-color.org/).
 
 ### [`FORCE_COLOR`](@id FORCE_COLOR)
 
 When this variable is present and not an empty string (regardless of its value) then
 colored text will be enabled on the REPL. Can be overridden with the flag `--color=no`. This
-environmental variable is [commonly recognized by command-line applications](https://force-color.org/).
+environment variable is [commonly recognized by command-line applications](https://force-color.org/).
 
 ## System and Package Image Building
 

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -2,7 +2,6 @@
 
 #include <limits.h>
 #include <errno.h>
-#include <stdlib.h>
 
 #include "julia.h"
 #include "julia_internal.h"
@@ -930,18 +929,6 @@ restart_switch:
         }
     }
     parsing_args_done:
-
-    if (jl_options.color == JL_OPTIONS_COLOR_AUTO) {
-        char *no_color = getenv("NO_COLOR");
-        if (no_color != NULL && no_color[0] != '\0')
-            jl_options.color = JL_OPTIONS_COLOR_OFF;
-    }
-    else if (jl_options.color != JL_OPTIONS_COLOR_ON) {
-        char *force_color = getenv("FORCE_COLOR");
-        if (force_color != NULL && force_color[0] != '\0')
-            jl_options.color = JL_OPTIONS_COLOR_ON;
-    }
-
     jl_options.code_coverage = codecov;
     jl_options.malloc_log = malloclog;
     int proc_args = *argcp < optind ? *argcp : optind;

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -2,6 +2,7 @@
 
 #include <limits.h>
 #include <errno.h>
+#include <stdlib.h>
 
 #include "julia.h"
 #include "julia_internal.h"
@@ -929,6 +930,18 @@ restart_switch:
         }
     }
     parsing_args_done:
+
+    if (jl_options.color == JL_OPTIONS_COLOR_AUTO) {
+        char *no_color = getenv("NO_COLOR");
+        if (no_color != NULL && no_color[0] != '\0')
+            jl_options.color = JL_OPTIONS_COLOR_OFF;
+    }
+    else if (jl_options.color != JL_OPTIONS_COLOR_ON) {
+        char *force_color = getenv("FORCE_COLOR");
+        if (force_color != NULL && force_color[0] != '\0')
+            jl_options.color = JL_OPTIONS_COLOR_ON;
+    }
+
     jl_options.code_coverage = codecov;
     jl_options.malloc_log = malloclog;
     int proc_args = *argcp < optind ? *argcp : optind;

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -429,9 +429,28 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     @test readchomp(`$exename -E "isinteractive()" -i`) == "true"
 
     # --color
-    @test readchomp(`$exename --color=yes -E "Base.have_color"`) == "true"
-    @test readchomp(`$exename --color=no -E "Base.have_color"`) == "false"
-    @test errors_not_signals(`$exename --color=false`)
+    function color_cmd(; flag="auto", no_color=nothing, force_color=nothing)
+        cmd = `$exename --color=$flag -E "Base.have_color"`
+        return addenv(cmd, "NO_COLOR" => no_color, "FORCE_COLOR" => force_color)
+    end
+    @test readchomp(color_cmd(flag="auto")) == "nothing"
+    @test readchomp(color_cmd(flag="no")) == "false"
+    @test readchomp(color_cmd(flag="yes")) == "true"
+    @test errors_not_signals(color_cmd(flag="false"))
+
+    @test readchomp(color_cmd(flag="auto", no_color="")) == "nothing"
+    @test readchomp(color_cmd(flag="auto", no_color="1")) == "false"
+    @test readchomp(color_cmd(flag="no", no_color="1")) == "false"
+    @test readchomp(color_cmd(flag="yes", no_color="1")) == "true"
+
+    @test readchomp(color_cmd(flag="auto", force_color="")) == "nothing"
+    @test readchomp(color_cmd(flag="auto", force_color="1")) == "true"
+    @test readchomp(color_cmd(flag="no", force_color="1")) == "true"
+    @test readchomp(color_cmd(flag="yes", force_color="1")) == "true"
+
+    @test readchomp(color_cmd(flag="auto", no_color="1", force_color="1")) == "true"
+    @test readchomp(color_cmd(flag="no", no_color="1", force_color="1")) == "true"
+    @test readchomp(color_cmd(flag="yes", no_color="1", force_color="1")) == "true"
 
     # --history-file
     @test readchomp(`$exename -E "Bool(Base.JLOptions().historyfile)"

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -429,14 +429,16 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     @test readchomp(`$exename -E "isinteractive()" -i`) == "true"
 
     # --color
-    function color_cmd(; flag="auto", no_color=nothing, force_color=nothing)
+    function color_cmd(; flag, no_color=nothing, force_color=nothing)
         cmd = `$exename --color=$flag -E "Base.have_color"`
         return addenv(cmd, "NO_COLOR" => no_color, "FORCE_COLOR" => force_color)
     end
+
     @test readchomp(color_cmd(flag="auto")) == "nothing"
     @test readchomp(color_cmd(flag="no")) == "false"
     @test readchomp(color_cmd(flag="yes")) == "true"
     @test errors_not_signals(color_cmd(flag="false"))
+    @test errors_not_signals(color_cmd(flag="true"))
 
     @test readchomp(color_cmd(flag="auto", no_color="")) == "nothing"
     @test readchomp(color_cmd(flag="auto", no_color="1")) == "false"
@@ -445,11 +447,11 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
 
     @test readchomp(color_cmd(flag="auto", force_color="")) == "nothing"
     @test readchomp(color_cmd(flag="auto", force_color="1")) == "true"
-    @test readchomp(color_cmd(flag="no", force_color="1")) == "true"
+    @test readchomp(color_cmd(flag="no", force_color="1")) == "false"
     @test readchomp(color_cmd(flag="yes", force_color="1")) == "true"
 
     @test readchomp(color_cmd(flag="auto", no_color="1", force_color="1")) == "true"
-    @test readchomp(color_cmd(flag="no", no_color="1", force_color="1")) == "true"
+    @test readchomp(color_cmd(flag="no", no_color="1", force_color="1")) == "false"
     @test readchomp(color_cmd(flag="yes", no_color="1", force_color="1")) == "true"
 
     # --history-file


### PR DESCRIPTION
Enables support for these two color related environmental variables as outlined in: https://no-color.org/ and https://force-color.org/. One deviation from the [example implementation shown for `FORCE_COLOR`](https://force-color.org/) is that we are treating `--color=yes` or `--color=no` as having a higher precedence than the environment variables ([discussion](https://github.com/JuliaLang/julia/pull/53742#discussion_r1614107866)).

