### PR TITLE
New macro @dt_str(x)

### DIFF
--- a/stdlib/Dates/src/Dates.jl
+++ b/stdlib/Dates/src/Dates.jl
@@ -79,6 +79,7 @@ export Period, DatePeriod, TimePeriod,
        firstdayofquarter, lastdayofquarter,
        tonext, toprev, tofirst, tolast,
        # io.jl
-       ISODateTimeFormat, ISODateFormat, ISOTimeFormat, DateFormat, RFC1123Format, @dateformat_str
+       ISODateTimeFormat, ISODateFormat, ISOTimeFormat, DateFormat, RFC1123Format,
+       @dateformat_str, @dt_str
 
 end # module

--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -568,6 +568,22 @@ repeatedly parsing similarly formatted date time strings with a pre-created
 DateTime(dt::AbstractString, df::DateFormat=ISODateTimeFormat) = parse(DateTime, dt, df)
 
 """
+    @dt_str(isodt)
+
+Construct a [`DateTime`](@ref) from the given input string.
+Equivalent to writing `DateTime(isodt)`.
+
+# Example
+
+```julia
+dt"2020-12-31T15:16:17.18"
+```
+"""
+macro dt_str(isodt)
+    DateTime(isodt)
+end
+
+"""
     Date(d::AbstractString, format::AbstractString; locale="english") -> Date
 
 Construct a `Date` by parsing the `d` date string following the pattern given


### PR DESCRIPTION
This is a suggestion to add the functionality to more conveniently specify `DateTime` constants.
I find myself writing a lot of these constants in my code and if this PR is implemented, then I could
write something like

```julia
dt"2022-02-01" < dt"2022-02-01T12:00:00.001"
```
rather than
```julia
DateTime(2022,02,1) < DateTime(2022,2,1,12,0,0.1)
```
or
```julia
DateTime("2022-02-01") < DateTime("2022-02-01T12:00:00.001")
```

This would be considerably shorter and in my opinion easier read.
Regarding the name: There is `@dateformat_str`, but Julia has a tradition for short _str
macro names, e.g. `@r_str`, `@v_str` and `@tz_str`, so `@dt_str` fits in to this tradition.

I am aware that this PR would need more work to be accepted.
My intention with this PR is to get an indication of whether you the maintainers of Julia feel
that this would be a relevant enhancement to be included in Julia if more work was done on it.
If so, then I am open to improvement suggestions and making a merge ready PR.

One of the enhancements that I can think of is to do this for the `Date` and `Time` types also,
although here I would suggest a notation like `date"2022-02-01", time"20:21:22.33"`.
Please also give your opinions on this.

If you find this PR promising, would there be other things than tests that I would need to write?