### PR TITLE
Make method overwrite error only happen if we are doing an incremental build

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1585,7 +1585,7 @@ static void method_overwrite(jl_typemap_entry_t *newentry, jl_method_t *oldvalue
         jl_printf(s, ".\n");
         jl_uv_flush(s);
     }
-    if (jl_generating_output()) {
+    if (jl_generating_output() && jl_options.incremental) {
         jl_printf(JL_STDERR, "ERROR: Method overwriting is not permitted during Module precompilation. Use `__precompile__(false)` to opt-out of precompilation.\n");
         jl_throw(jl_precompilable_error);
     }


### PR DESCRIPTION
It should be possible to overwrite methods while loading Base, so this re-allows it.