### PR TITLE
compileall: Print error on failure

### DIFF
--- a/test/compileall.jl
+++ b/test/compileall.jl
@@ -3,7 +3,7 @@
 # with the rest of the tests.
 
 mktempdir() do dir
-    @test success(`$(Base.julia_cmd()) --compile=all --strip-ir --output-o $(dir)/sys.o.a -e 'exit()'`) broken=(Sys.iswindows() && Sys.WORD_SIZE == 32)
+    @test success(pipeline(`$(Base.julia_cmd()) --compile=all --strip-ir --output-o $(dir)/sys.o.a -e 'exit()'`, stderr=stderr)) broken=(Sys.iswindows() && Sys.WORD_SIZE == 32)
     if isfile(joinpath(dir, "sys.o.a"))
         Base.Linking.link_image(joinpath(dir, "sys.o.a"), joinpath(dir, "sys.so"))
         # TODO: Broken on Windows due to


### PR DESCRIPTION
This test appears to be failing intermittently on aarch64 darwin, so stop suppressing any errors that might be happening.