### PR TITLE
precompilepkgs: fix error path & adjust messaging

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -463,10 +463,10 @@ function precompilepkgs(pkgs::Vector{String}=String[];
     was_recompiled = Dict{PkgConfig,Bool}()
     for config in configs
         for pkgid in keys(depsmap)
-            dep_config = (pkgid, config)
-            started[dep_config] = false
-            was_processed[dep_config] = Base.Event()
-            was_recompiled[dep_config] = false
+            pkg_config = (pkgid, config)
+            started[pkg_config] = false
+            was_processed[pkg_config] = Base.Event()
+            was_recompiled[pkg_config] = false
         end
     end
     @debug "precompile: signalling initialized"
@@ -501,9 +501,9 @@ function precompilepkgs(pkgs::Vector{String}=String[];
     for pkg in keys(depsmap)
         if scan_pkg!(pkg, depsmap)
             push!(circular_deps, pkg)
-            for dep_config in keys(was_processed)
+            for pkg_config in keys(was_processed)
                 # notify all to allow skipping
-                dep_config[1] == pkg && notify(was_processed[dep_config])
+                pkg_config[1] == pkg && notify(was_processed[pkg_config])
             end
         end
     end
@@ -672,8 +672,8 @@ function precompilepkgs(pkgs::Vector{String}=String[];
                             str = sprint(io -> show_progress(io, bar; termwidth, carriagereturn=false); context=io)
                             print(iostr, Base._truncate_at_width_or_chars(true, str, termwidth), "\n")
                         end
-                        for dep_config in pkg_queue_show
-                            dep, config = dep_config
+                        for pkg_config in pkg_queue_show
+                            dep, config = pkg_config
                             loaded = warn_loaded && haskey(Base.loaded_modules, dep)
                             _name = haskey(exts, dep) ? string(exts[dep], " → ", dep.name) : dep.name
                             name = dep in direct_deps ? _name : string(color_string(_name, :light_black))
@@ -681,26 +681,26 @@ function precompilepkgs(pkgs::Vector{String}=String[];
                                 config_str = "$(join(config[1], " "))"
                                 name *= color_string(" $(config_str)", :light_black)
                             end
-                            line = if dep_config in precomperr_deps
+                            line = if pkg_config in precomperr_deps
                                 string(color_string("  ? ", Base.warn_color()), name)
-                            elseif haskey(failed_deps, dep_config)
+                            elseif haskey(failed_deps, pkg_config)
                                 string(color_string("  ✗ ", Base.error_color()), name)
-                            elseif was_recompiled[dep_config]
+                            elseif was_recompiled[pkg_config]
                                 !loaded && interrupted_or_done.set && continue
                                 loaded || @async begin # keep successful deps visible for short period
                                     sleep(1);
-                                    filter!(!isequal(dep_config), pkg_queue)
+                                    filter!(!isequal(pkg_config), pkg_queue)
                                 end
                                 string(color_string("  ✓ ", loaded ? Base.warn_color() : :green), name)
-                            elseif started[dep_config]
+                            elseif started[pkg_config]
                                 # Offset each spinner animation using the first character in the package name as the seed.
                                 # If not offset, on larger terminal fonts it looks odd that they all sync-up
                                 anim_char = anim_chars[(i + Int(dep.name[1])) % length(anim_chars) + 1]
                                 anim_char_colored = dep in direct_deps ? anim_char : color_string(anim_char, :light_black)
-                                waiting = if haskey(pkgspidlocked, dep_config)
-                                    who_has_lock = pkgspidlocked[dep_config]
+                                waiting = if haskey(pkgspidlocked, pkg_config)
+                                    who_has_lock = pkgspidlocked[pkg_config]
                                     color_string(" Being precompiled by $(who_has_lock)", Base.info_color())
-                                elseif dep_config in taskwaiting
+                                elseif pkg_config in taskwaiting
                                     color_string(" Waiting for background task / IO / timer. Interrupt to inspect", Base.warn_color())
                                 else
                                     ""
@@ -907,8 +907,8 @@ function precompilepkgs(pkgs::Vector{String}=String[];
         quick_exit && return
         err_str = ""
         n_direct_errs = 0
-        for (dep_config, err) in failed_deps
-            dep, config = dep_config
+        for (pkg_config, err) in failed_deps
+            dep, config = pkg_config
             if strict || (dep in direct_deps)
                 config_str = isempty(config[1]) ? "" : "$(join(config[1], " ")) "
                 err_str = string(err_str, "\n$(dep.name) $config_str\n\n$err", (n_direct_errs > 0 ? "\n" : ""))

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -809,7 +809,7 @@ function precompilepkgs(pkgs::Vector{String}=String[];
                             close(std_pipe.in) # close pipe to end the std output monitor
                             wait(t_monitor)
                             if err isa ErrorException || (err isa ArgumentError && startswith(err.msg, "Invalid header in cache file"))
-                                failed_deps[dep_config] = (strict || is_direct_dep) ? string(sprint(showerror, err), "\n", strip(get(std_outputs, pkg, ""))) : ""
+                                failed_deps[pkg_config] = (strict || is_direct_dep) ? string(sprint(showerror, err), "\n", strip(get(std_outputs, pkg, ""))) : ""
                                 delete!(std_outputs, pkg_config) # so it's not shown as warnings, given error report
                                 !fancyprint && lock(print_lock) do
                                     println(io, " "^9, color_string("  ✗ ", Base.error_color()), name)
@@ -907,9 +907,11 @@ function precompilepkgs(pkgs::Vector{String}=String[];
         quick_exit && return
         err_str = ""
         n_direct_errs = 0
-        for (dep, err) in failed_deps
+        for (dep_config, err) in failed_deps
+            dep, config = dep_config
             if strict || (dep in direct_deps)
-                err_str = string(err_str, "\n$dep\n\n$err", (n_direct_errs > 0 ? "\n" : ""))
+                config_str = isempty(config[1]) ? "" : "$(join(config[1], " ")) "
+                err_str = string(err_str, "\n$(dep.name) $config_str\n\n$err", (n_direct_errs > 0 ? "\n" : ""))
                 n_direct_errs += 1
             end
         end

--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -552,8 +552,8 @@ function precompilepkgs(pkgs::Vector{String}=String[];
         target = "project"
     end
     nconfig = length(configs)
-    if nconfig > 1 || !isempty(only(configs)[1]) # if multiple configs or only one is not default
-        target *= " for $nconfig compilation configuration$(nconfig > 1 ? "s" : "")..."
+    if nconfig > 1
+        target *= " for $nconfig compilation configurations..."
     else
         target *= "..."
     end
@@ -677,8 +677,8 @@ function precompilepkgs(pkgs::Vector{String}=String[];
                             loaded = warn_loaded && haskey(Base.loaded_modules, dep)
                             _name = haskey(exts, dep) ? string(exts[dep], " → ", dep.name) : dep.name
                             name = dep in direct_deps ? _name : string(color_string(_name, :light_black))
-                            if length(configs) > 1
-                                config_str = isempty(config[1]) ? "" : "$(join(config[1], " "))"
+                            if !isempty(config[1])
+                                config_str = "$(join(config[1], " "))"
                                 name *= color_string(" $(config_str)", :light_black)
                             end
                             line = if dep_config in precomperr_deps
@@ -769,8 +769,8 @@ function precompilepkgs(pkgs::Vector{String}=String[];
 
                         _name = haskey(exts, pkg) ? string(exts[pkg], " → ", pkg.name) : pkg.name
                         name = is_direct_dep ? _name : string(color_string(_name, :light_black))
-                        if length(configs) > 1
-                            config_str = isempty(config[1]) ? "" : "$(join(config[1], " "))"
+                        if !isempty(flags)
+                            config_str = "$(join(flags, " "))"
                             name *= color_string(" $(config_str)", :light_black)
                         end
                         !fancyprint && lock(print_lock) do


### PR DESCRIPTION
Fixes issues with the handling of errored dependencies