### PR TITLE
Remove some duplicates from emitted compilation traces

### DIFF
--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -43,10 +43,11 @@ JL_DLLEXPORT void jl_generate_fptr_for_unspecialized_fallback(jl_code_instance_t
     jl_atomic_store_release(&unspec->invoke, &jl_fptr_interpret_call);
 }
 
-JL_DLLEXPORT void jl_compile_codeinst_fallback(jl_code_instance_t *unspec)
+JL_DLLEXPORT int jl_compile_codeinst_fallback(jl_code_instance_t *unspec)
 {
     // Do nothing. The caller will notice that we failed to provide a an ->invoke and trigger
     // appropriate fallbacks.
+    return 0;
 }
 
 JL_DLLEXPORT uint32_t jl_get_LLVM_VERSION_fallback(void)

--- a/src/gf.c
+++ b/src/gf.c
@@ -2568,12 +2568,12 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
         }
 
         JL_GC_PUSH1(&codeinst);
-        jl_compile_codeinst(codeinst);
+        int did_compile = jl_compile_codeinst(codeinst);
 
         if (jl_atomic_load_relaxed(&codeinst->invoke) == NULL) {
             // Something went wrong. Bail to the fallback path.
             codeinst = NULL;
-        } else {
+        } else if (did_compile) {
             record_precompile_statement(mi);
         }
         JL_GC_POP();

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1727,7 +1727,7 @@ JL_DLLEXPORT uint32_t jl_crc32c(uint32_t crc, const char *buf, size_t len);
 #define IR_FLAG_INBOUNDS 0x01
 
 JL_DLLIMPORT void jl_generate_fptr_for_unspecialized(jl_code_instance_t *unspec);
-JL_DLLIMPORT void jl_compile_codeinst(jl_code_instance_t *unspec);
+JL_DLLIMPORT int jl_compile_codeinst(jl_code_instance_t *unspec);
 JL_DLLIMPORT int jl_compile_extern_c(LLVMOrcThreadSafeModuleRef llvmmod, void *params, void *sysimg, jl_value_t *declrt, jl_value_t *sigt);
 
 typedef struct {


### PR DESCRIPTION
When multiple threads concurrently attempt to compile the same method, `--trace-compile` could emit duplicate `precompile` statements. This small tweak eliminates one source of these duplicates.