### PR TITLE
small changes to make Base more statically compileable

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -769,7 +769,7 @@ function is_top_bit_set(x::Union{Int8,UInt8})
 end
 
 # n.b. This function exists for CUDA to overload to configure error behavior (see #48097)
-throw_inexacterror(args...) = throw(InexactError(args...))
+throw_inexacterror(func::Symbol, to, val) = throw(InexactError(func, to, val))
 
 function check_sign_bit(::Type{To}, x) where {To}
     @inline

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -504,8 +504,6 @@ end
 # options #
 ###########
 
-is_root_module(m::Module) = false
-
 inlining_enabled() = (JLOptions().can_inline == 1)
 
 function coverage_enabled(m::Module)

--- a/base/error.jl
+++ b/base/error.jl
@@ -228,14 +228,14 @@ macro assert(ex, msgs...)
         msg = Main.Base.string(msg)
     else
         # string() might not be defined during bootstrap
-        msg = quote
-            msg = $(Expr(:quote,msg))
-            isdefined(Main, :Base) ? Main.Base.string(msg) :
-                (Core.println(msg); "Error during bootstrap. See stdout.")
-        end
+        msg = :(_assert_tostring($(Expr(:quote,msg))))
     end
     return :($(esc(ex)) ? $(nothing) : throw(AssertionError($msg)))
 end
+
+# this may be overridden in contexts where `string(::Expr)` doesn't work
+_assert_tostring(msg) = isdefined(Main, :Base) ? Main.Base.string(msg) :
+    (Core.println(msg); "Error during bootstrap. See stdout.")
 
 struct ExponentialBackOff
     n::Int

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -400,7 +400,7 @@ end
 
 #Show an error by directly calling jl_printf.
 #Useful in Base submodule __init__ functions where stderr isn't defined yet.
-function showerror_nostdio(err, msg::AbstractString)
+function showerror_nostdio(@nospecialize(err), msg::AbstractString)
     stderr_stream = ccall(:jl_stderr_stream, Ptr{Cvoid}, ())
     ccall(:jl_printf, Cint, (Ptr{Cvoid},Cstring), stderr_stream, msg)
     ccall(:jl_printf, Cint, (Ptr{Cvoid},Cstring), stderr_stream, ":\n")

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -9,7 +9,7 @@ A string containing the script name passed to Julia from the command line. Note 
 script name remains unchanged from within included files. Alternatively see
 [`@__FILE__`](@ref).
 """
-global PROGRAM_FILE = ""
+global PROGRAM_FILE::String = ""
 
 """
     ARGS
@@ -480,7 +480,7 @@ end
 
 ## hook for disabling threaded libraries ##
 
-library_threading_enabled = true
+library_threading_enabled::Bool = true
 const disable_library_threading_hooks = []
 
 function at_disable_library_threading(f)

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -292,12 +292,15 @@ function open(fname::String; lock = true,
     if !lock
         s._dolock = false
     end
-    systemerror("opening file $(repr(fname))",
-                ccall(:ios_file, Ptr{Cvoid},
-                      (Ptr{UInt8}, Cstring, Cint, Cint, Cint, Cint),
-                      s.ios, fname, flags.read, flags.write, flags.create, flags.truncate) == C_NULL)
+    if ccall(:ios_file, Ptr{Cvoid},
+             (Ptr{UInt8}, Cstring, Cint, Cint, Cint, Cint),
+             s.ios, fname, flags.read, flags.write, flags.create, flags.truncate) == C_NULL
+        systemerror("opening file \"$fname\"")
+    end
     if flags.append
-        systemerror("seeking to end of file $fname", ccall(:ios_seek_end, Int64, (Ptr{Cvoid},), s.ios) != 0)
+        if ccall(:ios_seek_end, Int64, (Ptr{Cvoid},), s.ios) != 0
+            systemerror("seeking to end of file \"$fname\"")
+        end
     end
     return s
 end

--- a/base/libuv.jl
+++ b/base/libuv.jl
@@ -134,9 +134,9 @@ function uv_asynccb end
 function uv_timercb end
 
 function reinit_stdio()
-    global stdin = init_stdio(ccall(:jl_stdin_stream, Ptr{Cvoid}, ()))
-    global stdout = init_stdio(ccall(:jl_stdout_stream, Ptr{Cvoid}, ()))
-    global stderr = init_stdio(ccall(:jl_stderr_stream, Ptr{Cvoid}, ()))
+    global stdin = init_stdio(ccall(:jl_stdin_stream, Ptr{Cvoid}, ()))::IO
+    global stdout = init_stdio(ccall(:jl_stdout_stream, Ptr{Cvoid}, ()))::IO
+    global stderr = init_stdio(ccall(:jl_stderr_stream, Ptr{Cvoid}, ()))::IO
     opts = JLOptions()
     if opts.color != 0
         have_color = (opts.color == 1)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2205,7 +2205,6 @@ const explicit_loaded_modules = Dict{PkgId,Module}()
 const loaded_modules_order = Vector{Module}()
 const module_keys = IdDict{Module,PkgId}() # the reverse
 
-is_root_module(m::Module) = @lock require_lock haskey(module_keys, m)
 root_module_key(m::Module) = @lock require_lock module_keys[m]
 
 @constprop :none function register_root_module(m::Module)
@@ -3416,9 +3415,9 @@ function check_clone_targets(clone_targets)
 end
 
 # Set by FileWatching.__init__()
-global mkpidlock_hook
-global trymkpidlock_hook
-global parse_pidfile_hook
+global mkpidlock_hook::Any
+global trymkpidlock_hook::Any
+global parse_pidfile_hook::Any
 
 # The preferences hash is only known after precompilation so just assume no preferences.
 # Also ignore the active project, which means that if all other conditions are equal,

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -20,6 +20,8 @@ Base
 """
 parentmodule(m::Module) = ccall(:jl_module_parent, Ref{Module}, (Any,), m)
 
+is_root_module(m::Module) = parentmodule(m) === m || (isdefined(Main, :Base) && m === Main.Base)
+
 """
     moduleroot(m::Module) -> Module
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1056,7 +1056,7 @@ function show_type_name(io::IO, tn::Core.TypeName)
         # IOContext If :module is not set, default to Main (or current active module).
         # nothing can be used to force printing prefix
         from = get(io, :module, active_module())
-        if isdefined(tn, :module) && (from === nothing || !isvisible(sym, tn.module, from))
+        if isdefined(tn, :module) && (from === nothing || !isvisible(sym, tn.module, from::Module))
             show(io, tn.module)
             print(io, ".")
             if globfunc && !is_id_start_char(first(string(sym)))

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -79,7 +79,7 @@ function _sym_to_tpid(tp::Symbol)
     elseif tp == :foreign
         return Int8(-1)
     else
-        throw(ArgumentError("Unrecognized threadpool name `$(repr(tp))`"))
+        throw(ArgumentError("Unrecognized threadpool name `$tp`"))
     end
 end
 

--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -468,6 +468,11 @@ function uv_fspollcb(handle::Ptr{Cvoid}, status::Int32, prev::Ptr, curr::Ptr)
     nothing
 end
 
+global uv_jl_pollcb::Ptr{Cvoid}
+global uv_jl_fspollcb::Ptr{Cvoid}
+global uv_jl_fseventscb_file::Ptr{Cvoid}
+global uv_jl_fseventscb_folder::Ptr{Cvoid}
+
 function __init__()
     global uv_jl_pollcb = @cfunction(uv_pollcb, Cvoid, (Ptr{Cvoid}, Cint, Cint))
     global uv_jl_fspollcb = @cfunction(uv_fspollcb, Cvoid, (Ptr{Cvoid}, Cint, Ptr{Cvoid}, Ptr{Cvoid}))

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -159,9 +159,8 @@ function check()
     interface = USE_BLAS64 ? :ilp64 : :lp64
     if !any(lib.interface == interface for lib in config.loaded_libs)
         interfacestr = uppercase(string(interface))
-        @error("No loaded BLAS libraries were built with $(interfacestr) support")
-        println("Quitting.")
-        exit()
+        @error("No loaded BLAS libraries were built with $interfacestr support.")
+        exit(1)
     end
 end
 


### PR DESCRIPTION
We (@gbaraldi @topolarity @vtjnash and I) have been seeing how far we can push static typing from applications (or library entry points) through Base, in order to do whole-program compilation where you don't need the JIT or IR or any unused code (similar to StaticCompiler.jl but with the full runtime available). Fortunately many of the barriers to this are just small changes to Base where we are doing silly things. This PR collects several of them.

The only thing here that's even slightly interesting is the changed definition of `is_root_module`. The problem here was that some fairly low-level printing and reflection functions call it, but it's not defined until loading.jl. When we try to infer it before then, the global is not defined so we infer it as Any. The new definition is much simpler. Maybe I'm missing something, but AFAICT it always gives the same answer.

These changes are from gb/small-image2.