### PR TITLE
Add `zero` for `Base.TwicePrecision`

### DIFF
--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -278,6 +278,7 @@ big(x::TwicePrecision) = big(x.hi) + big(x.lo)
 
 -(x::TwicePrecision) = TwicePrecision(-x.hi, -x.lo)
 
+zero(x::TwicePrecision) = zero(typeof(x))
 function zero(::Type{TwicePrecision{T}}) where {T}
     z = zero(T)
     TwicePrecision{T}(z, z)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -314,6 +314,13 @@ end
             twiceprecision_is_normalized(Base.TwicePrecision{Float64}(rand_twiceprecision(Float32)))
         end
     end
+
+    @testset "displaying a complex range (#52713)" begin
+        r = 1.0*(1:5) .+ im
+        @test startswith(repr(r), repr(first(r)))
+        @test endswith(repr(r), repr(last(r)))
+        @test occursin(repr(step(r)), repr(r))
+    end
 end
 @testset "ranges" begin
     @test size(10:1:0) == (0,)


### PR DESCRIPTION
Since `zero` exists for a `TwicePrecision` type, it makes sense for a method to exist for an instance as well.
Fixes #52713, which was a regression from v1.9.1. After this, the following may be displayed without errors:
```julia
julia> r = 1.0*(1:5) .+ im
1.0 + 1.0im:Base.TwicePrecision{Float64}(1.0, 0.0):5.0 + 1.0im
```
However, in this case, the step is a `Base.TwicePrecision`, which seems to be an implementation detail that's leaking out, although addressing this may be a separate PR.