### PR TITLE
Tweak annotation ordering during modifications

### DIFF
--- a/test/strings/annotated.jl
+++ b/test/strings/annotated.jl
@@ -22,14 +22,14 @@
     #     :all
     @test str[3:4] == SubString(str, 3, 4)
     @test Base.AnnotatedString(str[3:4]) ==
-        Base.AnnotatedString("me", [(1:2, :thing => 0x01), (1:2, :all => 0x03)])
+        Base.AnnotatedString("me", [(1:2, :all => 0x03), (1:2, :thing => 0x01)])
     @test Base.AnnotatedString(str[3:6]) ==
-        Base.AnnotatedString("me s", [(1:2, :thing => 0x01), (1:4, :all => 0x03), (4:4, :other => 0x02)])
-    @test str == Base.AnnotatedString("some string", [(1:4, :thing => 0x01), (1:11, :all => 0x03), (6:11, :other => 0x02)])
+        Base.AnnotatedString("me s", [(1:4, :all => 0x03), (1:2, :thing => 0x01), (4:4, :other => 0x02)])
+    @test str == Base.AnnotatedString("some string", [(1:11, :all => 0x03), (1:4, :thing => 0x01), (6:11, :other => 0x02)])
     @test str != Base.AnnotatedString("some string")
-    @test str != Base.AnnotatedString("some string", [(1:1, :thing => 0x01), (6:6, :other => 0x02), (11:11, :all => 0x03)])
-    @test str != Base.AnnotatedString("some string", [(1:4, :thing => 0x11), (1:11, :all => 0x13), (6:11, :other => 0x12)])
-    @test str != Base.AnnotatedString("some thingg", [(1:4, :thing => 0x01), (1:11, :all => 0x03), (6:11, :other => 0x02)])
+    @test str != Base.AnnotatedString("some string", [(1:1, :all => 0x03), (1:4, :thing => 0x01), (6:11, :other => 0x02)])
+    @test str != Base.AnnotatedString("some string", [(1:11, :all => 0x43), (1:4, :thing => 0x21), (6:11, :other => 0x32)])
+    @test str != Base.AnnotatedString("some thingg", [(1:11, :all => 0x03), (1:4, :thing => 0x01), (6:11, :other => 0x02)])
     @test Base.AnnotatedString([Base.AnnotatedChar('a', [:a => 1]), Base.AnnotatedChar('b', [:b => 2])]) ==
         Base.AnnotatedString("ab", [(1:1, :a => 1), (2:2, :b => 2)])
     let allstrings =


### PR DESCRIPTION
In my estimation, these changes make the sorting, particularly in combination with StyledStrings, more consistent/intuitive.

See the commit message and `_annot_sortkey` docstring for more details.

### Status quo 

![image](https://github.com/JuliaLang/julia/assets/20903656/08ac6f4f-8af0-4b69-967e-c6b500ccaca8)

### With this PR (and https://github.com/JuliaLang/StyledStrings.jl/commit/c21b43e38736671342071e2887f78977c0080756)

![image](https://github.com/JuliaLang/julia/assets/20903656/89be0ed6-3254-4f3e-b5a8-406c0a61f769)
