### PR TITLE
Ensure that annotations are well-ordered in optimisation

### DIFF
--- a/base/strings/annotated.jl
+++ b/base/strings/annotated.jl
@@ -242,9 +242,12 @@ AnnotatedString(s::SubString{<:AnnotatedString}) = annotatedstring(s)
 """
     annotatedstring_optimize!(str::AnnotatedString)
 
-Merge contiguous identical annotations in `str`.
+Ensure that the annotations in `str` are well ordered, then merge contiguous
+identical annotations.
 """
 function annotatedstring_optimize!(s::AnnotatedString)
+    issorted(s.annotations, by=_annot_sortkey) ||
+        sort!(s.annotations, by=_annot_sortkey)
     last_seen = Dict{Pair{Symbol, Any}, Int}()
     i = 1
     while i <= length(s.annotations)


### PR DESCRIPTION
This is a follow-on from #53794 (which needs to be merged before this PR) that largely seems like a "might as well" type thing to me.

See the commit message for more details.

A cosmetic change this has me considering is whether it would be nice to rename this function to `annotatedstring_normalize!`. Thoughts? 