### PR TITLE
precompilepkgs: simplify custom config printing if only one

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -551,11 +551,14 @@ function precompilepkgs(pkgs::Vector{String}=String[];
     else
         target = "project"
     end
-    nconfig = length(configs)
-    if nconfig > 1
-        target *= " for $nconfig compilation configurations..."
-    else
+    nconfigs = length(configs)
+    if nconfigs == 1
+        if !isempty(only(configs)[1])
+            target *= " for configuration $(join(only(configs)[1], " "))"
+        end
         target *= "..."
+    else
+        target *= " for $nconfigs compilation configurations..."
     end
     @debug "precompile: packages filtered"
 
@@ -677,7 +680,7 @@ function precompilepkgs(pkgs::Vector{String}=String[];
                             loaded = warn_loaded && haskey(Base.loaded_modules, dep)
                             _name = haskey(exts, dep) ? string(exts[dep], " → ", dep.name) : dep.name
                             name = dep in direct_deps ? _name : string(color_string(_name, :light_black))
-                            if !isempty(config[1])
+                            if nconfigs > 1 && !isempty(config[1])
                                 config_str = "$(join(config[1], " "))"
                                 name *= color_string(" $(config_str)", :light_black)
                             end
@@ -769,7 +772,7 @@ function precompilepkgs(pkgs::Vector{String}=String[];
 
                         _name = haskey(exts, pkg) ? string(exts[pkg], " → ", pkg.name) : pkg.name
                         name = is_direct_dep ? _name : string(color_string(_name, :light_black))
-                        if !isempty(flags)
+                        if nconfigs > 1 && !isempty(flags)
                             config_str = "$(join(flags, " "))"
                             name *= color_string(" $(config_str)", :light_black)
                         end


### PR DESCRIPTION
Currently it's a bit excessive in the `Pkg.test` precompile job

![Screenshot 2024-03-20 at 12 04 03 PM](https://github.com/JuliaLang/julia/assets/1694067/7600f0b8-6e4b-43b2-9c42-c8d5d16b8d57)


This PR
```
Precompiling project for configuration --code-coverage=none --color=yes --check-bounds=yes --warn-overwrite=yes --depwarn=yes --inline=yes --startup-file=no --track-allocation=none...
    354.9 ms  ✓ RFFT
  1 dependency successfully precompiled in 1 seconds. 38 already precompiled.
```

Pkg could also just set the non-default flags to minimize the list.