### PR TITLE
Add missing GC_POP() in emit_cfunction

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7379,6 +7379,7 @@ static jl_cgval_t emit_cfunction(jl_codectx_t &ctx, jl_value_t *output_type, con
     if (ctx.emission_context.TargetTriple.isAArch64() || ctx.emission_context.TargetTriple.isARM() || ctx.emission_context.TargetTriple.isPPC64()) {
         if (nest) {
             emit_error(ctx, "cfunction: closures are not supported on this platform");
+            JL_GC_POP();
             return jl_cgval_t();
         }
     }

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -297,6 +297,7 @@ JL_DLLEXPORT void jl_eh_restore_state(jl_task_t *ct, jl_handler_t *eh)
 
 JL_DLLEXPORT void jl_eh_restore_state_noexcept(jl_task_t *ct, jl_handler_t *eh)
 {
+    assert(ct->gcstack == eh->gcstack && "Incorrect GC usage under try catch");
     ct->eh = eh->prev;
     ct->ptls->defer_signal = eh->defer_signal; // optional, but certain try-finally (in stream.jl) may be slightly harder to write without this
 }


### PR DESCRIPTION
~~Apparently somewhere in codegen inside `emit_codeinst`some piece of code is relying on the implicit try catch gcstack restoring. I haven't got the analyzer working on that file yet (it has hundreds of issues and it doesn't like C++ code that much + the file is tens of thousands of lines after includes so it struggles).~~

This fixes the compileall segfault in apple-aarch64 ci.
Fix #53811
