### PR TITLE
create phantom task for GC threads

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -129,6 +129,11 @@ void jl_parallel_gc_threadfun(void *arg)
 
     // initialize this thread (set tid and create heap)
     jl_ptls_t ptls = jl_init_threadtls(targ->tid);
+    void *stack_lo, *stack_hi;
+    jl_init_stack_limits(0, &stack_lo, &stack_hi);
+    // warning: this changes `jl_current_task`, so be careful not to call that from this function
+    jl_task_t *ct = jl_init_root_task(ptls, stack_lo, stack_hi);
+    JL_GC_PROMISE_ROOTED(ct);
     (void)jl_atomic_fetch_add_relaxed(&nrunning, -1);
     // wait for all threads
     jl_gc_state_set(ptls, JL_GC_STATE_WAITING, JL_GC_STATE_UNSAFE);
@@ -158,6 +163,11 @@ void jl_concurrent_gc_threadfun(void *arg)
 
     // initialize this thread (set tid and create heap)
     jl_ptls_t ptls = jl_init_threadtls(targ->tid);
+    void *stack_lo, *stack_hi;
+    jl_init_stack_limits(0, &stack_lo, &stack_hi);
+    // warning: this changes `jl_current_task`, so be careful not to call that from this function
+    jl_task_t *ct = jl_init_root_task(ptls, stack_lo, stack_hi);
+    JL_GC_PROMISE_ROOTED(ct);
     (void)jl_atomic_fetch_add_relaxed(&nrunning, -1);
     // wait for all threads
     jl_gc_state_set(ptls, JL_GC_STATE_WAITING, JL_GC_STATE_UNSAFE);

--- a/src/task.c
+++ b/src/task.c
@@ -1649,6 +1649,7 @@ jl_task_t *jl_init_root_task(jl_ptls_t ptls, void *stack_lo, void *stack_hi)
     JL_GC_PROMISE_ROOTED(ct);
     jl_set_pgcstack(&ct->gcstack);
     assert(jl_current_task == ct);
+    assert(jl_current_task->ptls == ptls);
 
 #ifdef _COMPILER_TSAN_ENABLED_
     ct->ctx.tsan_state = __tsan_get_current_fiber();


### PR DESCRIPTION
A common idiom used throughout the codebase is to get a pointer to thread-local-state through `jl_current_task->ptls`.

Create a phantom task for GC threads so that we can make use of this idiom when running in the GC threads as well.

Idea originally suggested by @vchuravy, bugs are mine.