### PR TITLE
Retry downloads in toml tests

### DIFF
--- a/stdlib/TOML/test/utils/utils.jl
+++ b/stdlib/TOML/test/utils/utils.jl
@@ -33,7 +33,7 @@ end
 function get_data()
     tmp = mktempdir()
     path = joinpath(tmp, basename(url))
-    Downloads.download(url, path)
+    retry(Downloads.download, delays=fill(10,5))(url, path)
     Tar.extract(`$(exe7z()) x $path -so`, joinpath(tmp, "testfiles"))
     return joinpath(tmp, "testfiles", "toml-test-julia-$version", "testfiles")
 end


### PR DESCRIPTION
Given https://buildkite.com/julialang/julia-master/builds/34934#018e69c0-1a7a-492d-943f-51603e9a502b/26995-27455
```
LoadError: RequestError: HTTP/1.1 302 Found (Failed to connect to codeload.github.com port 443 after 21347 ms: Couldn't connect to server) while requesting https://github.com/KristofferC/toml-test-julia/archive/refs/tags/v1.2.0.tar.gz
```