### PR TITLE
check for erroneous prompt entry at start of user input

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -3,6 +3,11 @@
 ## client.jl - frontend handling command line options, environment setup,
 ##             and REPL
 
+const JULIA_PROMPT = "julia>"
+const PKG_PROMPT = "pkg>"
+const SHELL_PROMPT = "shell>"
+const HELP_PROMPT = "help?>"
+
 have_color = nothing
 have_truecolor = nothing
 const default_color_warn = :yellow
@@ -122,7 +127,7 @@ function display_error(io::IO, er, bt)
 end
 display_error(er, bt=nothing) = display_error(stderr, er, bt)
 
-function eval_user_input(errio, @nospecialize(ast), show_value::Bool)
+function eval_user_input(errio, @nospecialize(ast), show_value::Bool, input_str::String)
     errcount = 0
     lasterr = nothing
     have_color = get(stdout, :color, false)::Bool
@@ -134,6 +139,7 @@ function eval_user_input(errio, @nospecialize(ast), show_value::Bool)
             if lasterr !== nothing
                 lasterr = scrub_repl_backtrace(lasterr)
                 istrivialerror(lasterr) || setglobal!(Base.MainInclude, :err, lasterr)
+                lasterr isa ParseError && check_for_prompt_start(input_str)
                 invokelatest(display_error, errio, lasterr)
                 errcount = 0
                 lasterr = nothing
@@ -455,16 +461,17 @@ function run_main_repl(interactive::Bool, quiet::Bool, banner::Symbol, history_f
         let input = stdin
             if isa(input, File) || isa(input, IOStream)
                 # for files, we can slurp in the whole thing at once
-                ex = parse_input_line(read(input, String))
+                input_str = read(input, String)
+                ex = parse_input_line(input_str)
                 if Meta.isexpr(ex, :toplevel)
                     # if we get back a list of statements, eval them sequentially
                     # as if we had parsed them sequentially
                     for stmt in ex.args
-                        eval_user_input(stderr, stmt, true)
+                        eval_user_input(stderr, stmt, true, input_str)
                     end
                     body = ex.args
                 else
-                    eval_user_input(stderr, ex, true)
+                    eval_user_input(stderr, ex, true, input_str)
                 end
             else
                 while !eof(input)
@@ -472,8 +479,8 @@ function run_main_repl(interactive::Bool, quiet::Bool, banner::Symbol, history_f
                         print("julia> ")
                         flush(stdout)
                     end
+                    line = ""
                     try
-                        line = ""
                         ex = nothing
                         while !eof(input)
                             line *= readline(input, keep=true)
@@ -482,7 +489,7 @@ function run_main_repl(interactive::Bool, quiet::Bool, banner::Symbol, history_f
                                 break
                             end
                         end
-                        eval_user_input(stderr, ex, true)
+                        eval_user_input(stderr, ex, true, line)
                     catch err
                         isa(err, InterruptException) ? print("\n\n") : rethrow()
                     end
@@ -491,6 +498,22 @@ function run_main_repl(interactive::Bool, quiet::Bool, banner::Symbol, history_f
         end
     end
     nothing
+end
+
+function check_for_prompt_start(line::String)
+    if startswith(line, JULIA_PROMPT)
+        printstyled("Tip:"; color=info_color())
+        println(" No need to type `$JULIA_PROMPT`; enter your commands directly.")
+    elseif startswith(line, PKG_PROMPT)
+        printstyled("Tip:"; color=info_color())
+        println(" To switch to the `$PKG_PROMPT` prompt, press `]` rather than typing `$PKG_PROMPT`.")
+    elseif startswith(line, SHELL_PROMPT)
+        printstyled("Tip:"; color=info_color())
+        println(" To switch to the `$SHELL_PROMPT` prompt, press `;` rather than typing `$SHELL_PROMPT`.")
+    elseif startswith(line, HELP_PROMPT)
+        printstyled("Tip:"; color=info_color())
+        println(" To switch to the `$HELP_PROMPT` prompt, press `?` rather than typing `$HELP_PROMPT`.")
+    end
 end
 
 # MainInclude exists to weakly add certain identifiers to Main

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -65,7 +65,7 @@ precompile(Tuple{typeof(Base._typeddict), Base.Dict{String, Any}, Base.Dict{Stri
 precompile(Tuple{typeof(Base.promoteK), Type, Base.Dict{String, Any}, Base.Dict{String, Any}})
 precompile(Tuple{typeof(Base.promoteK), Type, Base.Dict{String, Any}})
 precompile(Tuple{typeof(Base.promoteV), Type, Base.Dict{String, Any}, Base.Dict{String, Any}})
-precompile(Tuple{typeof(Base.eval_user_input), Base.PipeEndpoint, Any, Bool})
+precompile(Tuple{typeof(Base.eval_user_input), Base.PipeEndpoint, Any, Bool, String})
 precompile(Tuple{typeof(Base.get), Base.PipeEndpoint, Symbol, Bool})
 
 # used by Revise.jl


### PR DESCRIPTION
WIP. This currently doesn't appear to work. 

I just see
```
julia> pkg> add Foo
ERROR: ParseError:
# Error @ REPL[3]:1:9
pkg> add Foo
#       └──┘ ── extra tokens after end of expression
Stacktrace:
 [1] top-level scope
   @ REPL:1
```

I thought we should only do this on ParseErrors, otherwise it's a bit expensive to do for every user input?