### PR TITLE
Profile: Add continuous profiling support

### DIFF
--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -107,6 +107,7 @@
     XX(jl_pinode_type) \
     XX(jl_pointer_type) \
     XX(jl_pointer_typename) \
+    XX(jl_profile_continuous) \
     XX(jl_quotenode_type) \
     XX(jl_readonlymemory_exception) \
     XX(jl_ref_type) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -380,6 +380,7 @@
     XX(jl_profile_is_running) \
     XX(jl_profile_len_data) \
     XX(jl_profile_maxlen_data) \
+    XX(jl_profile_read) \
     XX(jl_profile_start_timer) \
     XX(jl_profile_stop_timer) \
     XX(jl_ptr_to_array) \

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -29,6 +29,8 @@ static const    uint64_t GIGA = 1000000000ULL;
 JL_DLLEXPORT void jl_profile_stop_timer(void);
 JL_DLLEXPORT int jl_profile_start_timer(void);
 
+extern JL_DLLIMPORT int jl_profile_continuous;
+
 ///////////////////////
 // Utility functions //
 ///////////////////////
@@ -68,11 +70,23 @@ JL_DLLEXPORT uint64_t jl_profile_delay_nsec(void)
 JL_DLLEXPORT void jl_profile_clear_data(void)
 {
     bt_size_cur = 0;
+    if (jl_profile_continuous) {
+        jl_lock_profile();
+        memset((void*)bt_data_prof, 0, bt_size_max * sizeof(jl_bt_element_t));
+        jl_unlock_profile();
+    }
 }
 
 JL_DLLEXPORT int jl_profile_is_running(void)
 {
     return running;
+}
+
+JL_DLLEXPORT void jl_profile_read(uint8_t *data)
+{
+    jl_lock_profile();
+    memcpy(data, (uint8_t*)bt_data_prof, bt_size_max * sizeof(jl_bt_element_t));
+    jl_unlock_profile();
 }
 
 // Any function that acquires this lock must be either a unmanaged thread

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -662,10 +662,16 @@ void *mach_profile_listener(void *arg)
         for (int idx = nthreads; idx-- > 0; ) {
             // Stop the threads in the random or reverse round-robin order.
             int i = randperm[idx];
-            // if there is no space left, break early
             if (jl_profile_is_buffer_full()) {
-                jl_profile_stop_timer();
-                break;
+                if (jl_profile_continuous) {
+                    // Wrap around to the beginning
+                    bt_size_cur = 0;
+                } else {
+                    // Buffer full: Delete the timer
+                    jl_profile_stop_timer();
+                    // if there is no space left, break early
+                    break;
+                }
             }
 
             if (_dyld_dlopen_atfork_prepare != NULL && _dyld_dlopen_atfork_parent != NULL)

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -893,8 +893,13 @@ static void *signal_listener(void *arg)
                 // do backtrace for profiler
                 if (profile && running) {
                     if (jl_profile_is_buffer_full()) {
-                        // Buffer full: Delete the timer
-                        jl_profile_stop_timer();
+                        if (jl_profile_continuous) {
+                            // Wrap around to the beginning
+                            bt_size_cur = 0;
+                        } else {
+                            // Buffer full: Delete the timer
+                            jl_profile_stop_timer();
+                        }
                     }
                     else {
                         // unwinding can fail, so keep track of the current state

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -400,9 +400,15 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
         Sleep(timeout_ms > 0 ? timeout_ms : 1);
         if (running) {
             if (jl_profile_is_buffer_full()) {
-                jl_profile_stop_timer(); // does not change the thread state
-                SuspendThread(GetCurrentThread());
-                continue;
+                if (jl_profile_continuous) {
+                    // Wrap around to the beginning
+                    bt_size_cur = 0;
+                } else {
+                    // Buffer full: Delete the timer
+                    jl_profile_stop_timer(); // does not change the thread state
+                    SuspendThread(GetCurrentThread());
+                    continue;
+                }
             }
             else {
                 // TODO: bring this up to parity with other OS by adding loop over tid here

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -91,15 +91,20 @@ set_peek_duration(t::Float64) = ccall(:jl_set_profile_peek_duration, Cvoid, (Flo
 ####
 
 """
-    init(; n::Integer, delay::Real)
+    init(; n::Integer, delay::Real, continuous::Bool)
 
-Configure the `delay` between backtraces (measured in seconds), and the number `n` of instruction pointers that may be
-stored per thread. Each instruction pointer corresponds to a single line of code; backtraces generally consist of a long
-list of instruction pointers. Note that 6 spaces for instruction pointers per backtrace are used to store metadata and two
-NULL end markers. Current settings can be obtained by calling this function with no arguments, and each can be set independently
+Configure the `delay` between backtraces (measured in seconds), and the number
+`n` of instruction pointers that may be stored per thread. If `continuous` is
+`false`, then profiling will terminate once no more space exists for
+instruction pointers; if `continuous` is `true`, then profiling will continue
+indefinitely until stopped. Each instruction pointer corresponds to a single
+line of code; backtraces generally consist of a long list of instruction
+pointers. Note that 6 spaces for instruction pointers per backtrace are used to
+store metadata and two NULL end markers. Current settings can be obtained by
+calling this function with no arguments, and each can be set independently
 using keywords or in the order `(n, delay)`.
 """
-function init(; n::Union{Nothing,Integer} = nothing, delay::Union{Nothing,Real} = nothing, limitwarn::Bool = true)
+function init(; n::Union{Nothing,Integer} = nothing, delay::Union{Nothing,Real} = nothing, limitwarn::Bool = true, continuous::Union{Bool,Nothing} = nothing)
     n_cur = ccall(:jl_profile_maxlen_data, Csize_t, ())
     if n_cur == 0 && isnothing(n) && isnothing(delay)
         # indicates that the buffer hasn't been initialized at all, so set the default
@@ -107,15 +112,16 @@ function init(; n::Union{Nothing,Integer} = nothing, delay::Union{Nothing,Real} 
         n_cur = ccall(:jl_profile_maxlen_data, Csize_t, ())
     end
     delay_cur = ccall(:jl_profile_delay_nsec, UInt64, ())/10^9
-    if n === nothing && delay === nothing
+    if n === nothing && delay === nothing && continuous === nothing
         return n_cur, delay_cur
     end
     nnew = (n === nothing) ? (n_cur != 0 ? n_cur : DEFAULT_N) : n
     delaynew = (delay === nothing) ? (delay_cur != 0 ? delay_cur : DEFAULT_DELAY) : delay
-    init(nnew, delaynew; limitwarn)
+    continuous = (continuous === nothing) ? is_continuous() : continuous
+    init(nnew, delaynew; limitwarn, continuous)
 end
 
-function init(n::Integer, delay::Real; limitwarn::Bool = true)
+function init(n::Integer, delay::Real; limitwarn::Bool = true, continuous::Bool = false)
     sample_size_bytes = sizeof(Ptr) # == Sys.WORD_SIZE / 8
     buffer_samples = n
     buffer_size_bytes = buffer_samples * sample_size_bytes
@@ -124,6 +130,7 @@ function init(n::Integer, delay::Real; limitwarn::Bool = true)
         buffer_size_bytes = buffer_samples * sample_size_bytes
         limitwarn && @warn "Requested profile buffer limited to 512MB (n = $buffer_samples) given that this system is 32-bit"
     end
+    unsafe_store!(cglobal(:jl_profile_continuous, Bool), continuous)
     status = ccall(:jl_profile_init, Cint, (Csize_t, UInt64), buffer_samples, round(UInt64, 10^9*delay))
     if status == -1
         error("could not allocate space for ", n, " instruction pointers ($(Base.format_bytes(buffer_size_bytes)))")
@@ -154,6 +161,10 @@ function check_init()
         default_init()
     end
 end
+
+# Returns whether the profiler is in continuous profiling mode
+is_continuous() =
+    unsafe_load(cglobal(:jl_profile_continuous, Bool))
 
 """
     clear()
@@ -634,14 +645,36 @@ function fetch(;include_meta = true, limitwarn = true)
     if maxlen == 0
         error("The profiling data buffer is not initialized. A profile has not been requested this session.")
     end
-    len = len_data()
-    if limitwarn && is_buffer_full()
-        @warn """The profile data buffer is full; profiling probably terminated
-                 before your program finished. To profile for longer runs, call
-                 `Profile.init()` with a larger buffer and/or larger delay."""
+    if is_continuous()
+        data = Vector{UInt}(undef, maxlen)
+        ccall(:jl_profile_read, Cvoid, (Ptr{UInt8},), data)
+        if maxlen >= 6
+            # Find the last valid frame and trim the buffer to that point
+            last_frame_end_idx = nothing
+            for idx in maxlen:-1:nmeta
+                if is_block_end(data, idx)
+                    last_frame_end_idx = idx
+                    break
+                end
+            end
+            if last_frame_end_idx === nothing
+                # Empty buffer
+                resize!(data, 0)
+            elseif last_frame_end_idx < maxlen
+                # Shrink out the unused part of the buffer
+                resize!(data, last_frame_end_idx)
+            end
+        end
+    else
+        len = len_data()
+        if limitwarn && is_buffer_full()
+            @warn """The profile data buffer is full; profiling probably terminated
+                     before your program finished. To profile for longer runs, call
+                     `Profile.init()` with a larger buffer and/or larger delay."""
+        end
+        data = Vector{UInt}(undef, len)
+        GC.@preserve data unsafe_copyto!(pointer(data), get_data_pointer(), len)
     end
-    data = Vector{UInt}(undef, len)
-    GC.@preserve data unsafe_copyto!(pointer(data), get_data_pointer(), len)
     if include_meta || isempty(data)
         return data
     end


### PR DESCRIPTION
Users of Profile may be interested in running the profiler continuously and without stopping, such as for a background-executing runtime like Dagger.jl's. It's thus possible that we want the profiler running for longer than it would take to fill up the profile buffer. Previously, the buffer would fill up, profiling would stop, and any new traces would be lost. Additionally, sampling from the profiler with `Profile.fetch` while the profiler is running would often produce partially-written frames, requiring continuously-profiling users to clean up such frames manually.

This PR provides a new `continuous` kwarg for `Profile.init` which causes two changes in behavior when enabled:
- When the buffer becomes full, instead of stopping the Profile timer, the profiler starts recording again at the beginning of the buffer (overwriting any previously-recorded entries)
- When fetching the buffer with `Profile.fetch`, the profile lock is taken, and the entire buffer is copied out

With this feature, a user or library could use `Profile.start_timer` and periodically call `Profile.fetch` to get different samples from the profiler, all without ever stopping the profiler. Some additional support code is needed to parse entries that have been partially overwritten, but otherwise everything should work as-is.

Supersedes https://github.com/JuliaLang/julia/pull/42169

Todo:
- [x] Fix issue with `init` -> `@profile` (but not `@profile` -> `init`) causing profiling to stop working
- [x] Trim end of buffer to remove empty frames
- [x] Add docs
- [x] Add tests