### PR TITLE
set source of OC method when `isinferred=true`

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -218,7 +218,6 @@ function getdebugidx(debuginfo::DebugInfoStream, pc::Int)
     end
 end
 
-
 # SSA values that need renaming
 struct OldSSAValue
     id::Int

--- a/src/method.c
+++ b/src/method.c
@@ -1021,6 +1021,7 @@ jl_method_t *jl_make_opaque_closure_method(jl_module_t *module, jl_value_t *name
     m->file = jl_is_symbol(file) ? (jl_sym_t*)file : jl_empty_sym;
     m->line = jl_linenode_line(functionloc);
     if (isinferred) {
+        m->source = (jl_value_t*)ci;
         m->slot_syms = jl_compress_argnames(ci->slotnames);
         jl_gc_wb(m, m->slot_syms);
     } else {

--- a/test/compiler/contextual.jl
+++ b/test/compiler/contextual.jl
@@ -7,9 +7,8 @@ module MiniCassette
     # A minimal demonstration of the cassette mechanism. Doesn't support all the
     # fancy features, but sufficient to exercise this code path in the compiler.
 
-    using Core.Compiler: retrieve_code_info, CodeInfo,
-        MethodInstance, SSAValue, GotoNode, GotoIfNot, ReturnNode, SlotNumber, quoted,
-        signature_type, anymap
+    using Core.IR
+    using Core.Compiler: retrieve_code_info, quoted, signature_type, anymap
     using Base: _methods_by_ftype
     using Base.Meta: isexpr
     using Test


### PR DESCRIPTION
Otherwise it would cause a segfault when trying to interpret OC without its source set.