### PR TITLE
precompilepkgs: don't confuse single package in project with requesting single package

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -361,6 +361,7 @@ function precompilepkgs(pkgs::Vector{String}=String[];
                         manifest::Bool=false,)
 
     configs = configs isa Config ? [configs] : configs
+    requested_pkgs = copy(pkgs) # for understanding user intent
 
     time_start = time_ns()
 
@@ -748,7 +749,7 @@ function precompilepkgs(pkgs::Vector{String}=String[];
     for (pkg, deps) in depsmap
         cachepaths = Base.find_all_in_cache_path(pkg)
         sourcepath = Base.locate_package(pkg)
-        single_requested_pkg = length(pkgs) == 1 && only(pkgs) == pkg.name
+        single_requested_pkg = length(requested_pkgs) == 1 && only(requested_pkgs) == pkg.name
         for config in configs
             pkg_config = (pkg, config)
             if sourcepath === nothing


### PR DESCRIPTION
Followup to https://github.com/JuliaLang/julia/pull/53653
Separate from #53862 because this one is just broken on master

Without this if you precompile a project with a single dep it thought the user was calling `precompile Dep` or `using Dep` so went into live print mode, which is confusing.