### PR TITLE
Change `init`'s role in reduce-like functions: remove "neutral element" restriction and guarantee its use

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,7 +79,7 @@ Standard library changes
 
 * The `init` keyword for `reduce` and other reduction functions without guaranteed
   associativity (`mapreduce`, `maximum`, `minimum`, `sum`, `prod`, `any`, and `all`)
-  now provides greater gaurantees on how its value is incorporated into the reduction:
+  now provides greater guarantees on how its value is incorporated into the reduction:
   it is used exactly once as the left-most argument for all non-empty collections,
   and it is no longer required to be a "neutral" operand for the reduction.
   Previously, its semantics for non-empty collections was explicitly not specified, allowing

--- a/NEWS.md
+++ b/NEWS.md
@@ -77,6 +77,14 @@ New library features
 Standard library changes
 ------------------------
 
+* The `init` keyword for `reduce` and other reduction functions without guaranteed
+  associativity (`mapreduce`, `maximum`, `minimum`, `sum`, `prod`, `any`, and `all`)
+  now provides greater gaurantees on how its value is incorporated into the reduction:
+  it is used exactly once as the left-most argument for all non-empty collections,
+  and it is no longer required to be a "neutral" operand for the reduction.
+  Previously, its semantics for non-empty collections was explicitly not specified, allowing
+  implementations to use it 0, 1, or more times in the reduction ([#53871]).
+
 #### StyledStrings
 
 #### JuliaSyntaxHighlighting

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -296,7 +296,7 @@ with empty collections without specifying an `init` value, but in unambiguous ca
 identity value may be returned; see [`Base.reduce_empty`](@ref) for more details.
 
 [`mapreduce`](@ref) is functionally equivalent to calling
-`reduce(op, map(f, itrs...)...; init=init)`, but will in general execute faster since no
+`reduce(op, map(f, itrs...); init=init)`, but will in general execute faster since no
 intermediate collection needs to be created. See documentation for [`reduce`](@ref) and
 [`map`](@ref).
 

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -298,15 +298,17 @@ The return value for non-associative `op` functions may vary between
 different methods and between Julia versions. For example, `-` is not
 associative and thus `mapreduce(√, -, [1, 4, 9])` may return either
 `-4.0` or `2.0` depending upon the exact method or version of Julia.
-This is also true of some floating point operations that are typically
-associative, for example `mapreduce(identity, +, [.1, .2, .3])` may return
+Because floating-point roundoff errors typically break associativity,
+even for operations like + that are associative in exact arithmetic,
+this also means that the floating-point errors incurred by mapreduce
+are implementation-defined; for example `mapreduce(identity, +, [.1, .2, .3])` may return
 either `0.6` or `0.6000000000000001`.
 
 While the associativity of the reduction is not defined, `mapreduce` does preserve
-the ordering of the iterator for ordered collections.  For example,
-`mapreduce(uppercase, string, ['j','u','l','i','a'])` is guaranteed to always
+the ordering of the iterator for ordered collections, so that the result does *not* require `op` to be commutative.  For example,
+`mapreduce(uppercase, *, ['j','u','l','i','a'])` is guaranteed to always
 return the properly-spelled `"JULIA"` because `Array`s are ordered collections;
-the returned ordering is not guaranteed with an unordered collection like `Set`.
+in contrast, the operand ordering is not guaranteed with an unordered collection like `Set`.
 
 [`mapreduce`](@ref) is functionally equivalent to calling
 `reduce(op, map(f, itrs...); init=init)`, but will in general execute faster since no
@@ -314,7 +316,7 @@ intermediate collection needs to be created. See documentation for [`reduce`](@r
 [`map`](@ref).
 
 Some commonly-used operators may have special implementations of a mapped reduction, and
-should be used instead: [`maximum`](@ref)`(itr)`, [`minimum`](@ref)`(itr)`, [`sum`](@ref)`(itr)`,
+are recommended instead of `mapreduce`: [`maximum`](@ref)`(itr)`, [`minimum`](@ref)`(itr)`, [`sum`](@ref)`(itr)`,
 [`prod`](@ref)`(itr)`, [`any`](@ref)`(itr)`, [`all`](@ref)`(itr)`.
 
 !!! compat "Julia 1.2"
@@ -328,10 +330,10 @@ julia> mapreduce(√, +, [1, 4, 9])
 julia> mapreduce(identity, +, [.1, .2, .3]) ≈ 0.6
 true
 
-julia> mapreduce(uppercase, string, ['j','u','l','i','a'])
+julia> mapreduce(uppercase, *, ['j','u','l','i','a'])
 "JULIA"
 
-julia> mapreduce(uppercase, string, ['j','u','l','i','a'], init="Hello ")
+julia> mapreduce(uppercase, *, ['j','u','l','i','a'], init="Hello ")
 "Hello JULIA"
 ```
 """


### PR DESCRIPTION
Here's a shot at revamped documentation in light of https://github.com/JuliaLang/julia/issues/49042.  The goal here is ~~threefold~~ fivefold:

* Document that `init` provides the return value if the collections are empty (status quo)
* Document how reductions over empty collections may be errors (status quo)
* Remove the restriction that `init` must be a "neutral element" (**change**)
* Guarantee that `init` is used exactly once (**change** from being completely unspecified)
* Guarantee that `init` is used as the left-most argument in the reduction (**change** from being unspecified)

And in the process, this cleans up the language around associativity a bit.

This is a draft as this language needs to be propagated through to all the "special" reduction functions like `sum` et al.  But it gives us something concrete to consider.