### PR TITLE
Avoid runtime dispatch in `similar` in broadcast

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -226,12 +226,12 @@ end
 ## Allocating the output container
 Base.similar(bc::Broadcasted, ::Type{T}) where {T} = similar(bc, T, axes(bc))
 Base.similar(::Broadcasted{DefaultArrayStyle{N}}, ::Type{ElType}, dims) where {N,ElType} =
-    similar(Array{ElType}, dims)
+    similar(Array{ElType, length(dims)}, dims)
 Base.similar(::Broadcasted{DefaultArrayStyle{N}}, ::Type{Bool}, dims) where N =
     similar(BitArray, dims)
 # In cases of conflict we fall back on Array
 Base.similar(::Broadcasted{ArrayConflict}, ::Type{ElType}, dims) where ElType =
-    similar(Array{ElType}, dims)
+    similar(Array{ElType, length(dims)}, dims)
 Base.similar(::Broadcasted{ArrayConflict}, ::Type{Bool}, dims) =
     similar(BitArray, dims)
 


### PR DESCRIPTION
I noticed a runtime dispatch occurring in a broadcast, because the array element is specified but not the dimensions, even though the dimensions are known. With this PR, that runtime dispatch is eliminated by explicitly passing the dimensions into the type.

`@profview` results:

![image](https://github.com/JuliaLang/julia/assets/1438610/0e044077-8fdd-41a6-9a66-9cca05aac99c)

![image](https://github.com/JuliaLang/julia/assets/1438610/203f8919-9aab-4bca-9ec4-a079c7a8ce9c)

This is from 1.10.2 but the lines haven't changed in 4 years.