### PR TITLE
Consistently format Julia in the docstring for Base.DEPOT_PATH

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -75,11 +75,11 @@ Here is an overview of some of the subdirectories that may exist in a depot:
 
 * `artifacts`: Contains content that packages use for which Pkg manages the installation of.
 * `clones`: Contains full clones of package repos. Maintained by `Pkg.jl` and used as a cache.
-* `config`: Contains julia-level configuration such as a `startup.jl`
+* `config`: Contains julia-level configuration such as a `startup.jl`.
 * `compiled`: Contains precompiled `*.ji` files for packages. Maintained by Julia.
 * `dev`: Default directory for `Pkg.develop`. Maintained by `Pkg.jl` and the user.
 * `environments`: Default package environments. For instance the global environment for a specific julia version. Maintained by `Pkg.jl`.
-* `logs`: Contains logs of `Pkg` and `REPL` operations. Maintained by `Pkg.jl` and `Julia`.
+* `logs`: Contains logs of `Pkg` and `REPL` operations. Maintained by `Pkg.jl` and Julia.
 * `packages`: Contains packages, some of which were explicitly installed and some which are implicit dependencies. Maintained by `Pkg.jl`.
 * `registries`: Contains package registries. By default only `General`. Maintained by `Pkg.jl`.
 * `scratchspaces`: Contains content that a package itself installs via the [`Scratch.jl`](https://github.com/JuliaPackaging/Scratch.jl) package. `Pkg.gc()` will delete content that is known to be unused.


### PR DESCRIPTION
It is unclear what `Julia` exactly means in this docstring, but the two occurences of the word have different formatting. The guidelines say
> in docstrings refer to the language as "Julia" and the executable as "`julia`".

Given that we are not talking about the executable here, I removed the backticks.