### PR TITLE
inference: Fix handling of :throw_undef_if_not

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2625,7 +2625,7 @@ function abstract_eval_statement_expr(interp::AbstractInterpreter, e::Expr, vtyp
             effects = EFFECTS_UNKNOWN
         end
     elseif ehead === :throw_undef_if_not
-        condt = argextype(stmt.args[2], ir)
+        condt = abstract_eval_value(interp, e.args[2], vtypes, sv)
         condval = maybe_extract_const_bool(condt)
         t = Nothing
         exct = UndefVarError

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -4839,7 +4839,7 @@ f(x) = yt(x)
                          (set! global-const-error current-loc))
                      (emit e))))
             ((atomic) (error "misplaced atomic declaration"))
-            ((isdefined) (if tail (emit-return tail e) e))
+            ((isdefined throw_undef_if_not) (if tail (emit-return tail e) e))
             ((boundscheck) (if tail (emit-return tail e) e))
 
             ((method)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5640,6 +5640,13 @@ end
 @test issue53590(false, false) == Float64
 @test issue53590(false, true) == Real
 
+# Expr(:throw_undef_if_not) handling
+@eval function has_tuin()
+    $(Expr(:throw_undef_if_not, :x, false))
+end
+@test Core.Compiler.return_type(has_tuin, Tuple{}) === Union{}
+@test_throws UndefVarError has_tuin()
+
 # issue #53585
 let t = ntuple(i -> i % 8 == 1 ? Int64 : Float64, 4000)
     @test only(Base.return_types(Base.promote_typeof, t)) == Type{Float64}


### PR DESCRIPTION
This stmt type doesn't usually get introduced until IR conversion, but we do allow it in inference (to allow it to be emitted by packages like Diffractor). However, we didn't have a test for it, so the code path grew a bug. Fix that and also allow this as a frontend form, so it can be tested without resorting to generated functions.