### PR TITLE
optimize: Delete incoming unreachable edges from PhiNode

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -1104,6 +1104,19 @@ function convert_to_ircode(ci::CodeInfo, sv::OptimizationState)
                         code[i] = nothing
                     end
                 end
+            elseif isa(expr, PhiNode)
+                new_edges = Int32[]
+                new_vals = Any[]
+                for j = 1:length(expr.edges)
+                    (expr.edges[j] in sv.unreachable) && continue
+                    push!(new_edges, expr.edges[j])
+                    if isassigned(expr.values, j)
+                        push!(new_vals, expr.values[j])
+                    else
+                        resize!(new_vals, length(new_edges))
+                    end
+                end
+                code[i] = PhiNode(new_edges, new_vals)
             end
         end
     end

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -1108,8 +1108,9 @@ function convert_to_ircode(ci::CodeInfo, sv::OptimizationState)
                 new_edges = Int32[]
                 new_vals = Any[]
                 for j = 1:length(expr.edges)
-                    (expr.edges[j] in sv.unreachable) && continue
-                    push!(new_edges, expr.edges[j])
+                    edge = expr.edges[j]
+                    (edge in sv.unreachable || ssavaluetypes[edge] === Union{}) && continue
+                    push!(new_edges, edge)
                     if isassigned(expr.values, j)
                         push!(new_vals, expr.values[j])
                     else

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -1109,7 +1109,7 @@ function convert_to_ircode(ci::CodeInfo, sv::OptimizationState)
                 new_vals = Any[]
                 for j = 1:length(expr.edges)
                     edge = expr.edges[j]
-                    (edge in sv.unreachable || ssavaluetypes[edge] === Union{}) && continue
+                    (edge in sv.unreachable || (ssavaluetypes[edge] === Union{} && !isa(code[edge], PhiNode))) && continue
                     push!(new_edges, edge)
                     if isassigned(expr.values, j)
                         push!(new_vals, expr.values[j])

--- a/test/compiler/interpreter_exec.jl
+++ b/test/compiler/interpreter_exec.jl
@@ -110,3 +110,29 @@ let m = Meta.@lower 1 + 1
     @test :b === @eval $m
     @test isempty(current_exceptions())
 end
+
+# Test that things don't break if one branch of the frontend PhiNode becomes unreachable
+let m = Meta.@lower 1 + 1
+    @assert Meta.isexpr(m, :thunk)
+    src = m.args[1]::CodeInfo
+    src.code = Any[
+        # block 1
+        GlobalRef(@__MODULE__, :global_error_switch),
+        GotoIfNot(SSAValue(1), 4),
+        # block 2
+        Expr(:call, error, "This error is expected"),
+        # block 3
+        PhiNode(Int32[2, 3], Any[1, 2]),
+        ReturnNode(SSAValue(4))
+    ]
+    nstmts = length(src.code)
+    src.ssavaluetypes = nstmts
+    src.ssaflags = fill(UInt8(0x00), nstmts)
+    src.debuginfo = Core.DebugInfo(:none)
+    Core.Compiler.verify_ir(Core.Compiler.inflate_ir(src))
+    global global_error_switch = true
+    @test_throws ErrorException @eval $m
+    global global_error_switch = false
+    @test 1 === @eval $m
+    @test isempty(current_exceptions())
+end

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -755,6 +755,7 @@ end
 end
 
 # Test that things don't break if one branch of the frontend PhiNode becomes unreachable
+global global_error_switch::Bool = true
 function gen_unreachable_phinode_edge(world::UInt, source, _)
     ci = make_codeinfo(Any[
         # block 1
@@ -774,7 +775,9 @@ end
     $(Expr(:meta, :generated_only))
     #= no body =#
 end
-global global_error_switch = true
+let ir = first(only(Base.code_ircode(f_unreachable_phinode_edge)))
+    @test !any(@nospecialize(x)->isa(x,PhiNode), ir.stmts.stmt)
+end
 @test_throws ErrorException f_unreachable_phinode_edge()
 global global_error_switch = false
 @test f_unreachable_phinode_edge() == 1

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -9,16 +9,6 @@ include("irutils.jl")
 
 make_bb(preds, succs) = BasicBlock(Compiler.StmtRange(0, 0), preds, succs)
 
-function make_ci(code)
-    ci = (Meta.@lower 1 + 1).args[1]
-    ci.code = code
-    nstmts = length(ci.code)
-    ci.ssavaluetypes = nstmts
-    ci.codelocs = fill(Int32(1), nstmts)
-    ci.ssaflags = fill(Int32(0), nstmts)
-    return ci
-end
-
 # TODO: this test is broken
 #let code = Any[
 #        GotoIfNot(SlotNumber(2), 4),
@@ -763,3 +753,28 @@ end
         end
     end
 end
+
+# Test that things don't break if one branch of the frontend PhiNode becomes unreachable
+function gen_unreachable_phinode_edge(world::UInt, source, _)
+    ci = make_codeinfo(Any[
+        # block 1
+        GlobalRef(@__MODULE__, :global_error_switch),
+        GotoIfNot(SSAValue(1), 4),
+        # block 2
+        Expr(:call, error, "This error is expected"),
+        # block 3
+        PhiNode(Int32[2, 3], Any[1, 2]),
+        ReturnNode(SSAValue(4))
+    ]; slottypes=Any[Any])
+    ci.slotnames = Symbol[:var"#self#"]
+    return ci
+end
+@eval function f_unreachable_phinode_edge()
+    $(Expr(:meta, :generated, gen_unreachable_phinode_edge))
+    $(Expr(:meta, :generated_only))
+    #= no body =#
+end
+global global_error_switch = true
+@test_throws ErrorException f_unreachable_phinode_edge()
+global global_error_switch = false
+@test f_unreachable_phinode_edge() == 1


### PR DESCRIPTION
Incoming IR very rarely contains PhiNodes, but we do allow it to make things easier on downstream packages like Diffractor that want to generate the same code structures in both typed and untyped mode. However, this does of course mean that once inference is finished, any PhiNodes in the original source must be adjusted to maintain IRCode invariants. One particular important invariant here is that the edges list in a PhiNode must match the predecessor list, so in particular if a predecessor becomes unreachable during inference, we must filter that edge before passing it on to the optimizer.