### PR TITLE
RNG reproducibility discussion - rm confusing ref to MenneTwister

### DIFF
--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -350,8 +350,8 @@ DocTestSetup = nothing
 
 By using an RNG parameter initialized with a given seed, you can reproduce the same pseudorandom
 number sequence when running your program multiple times. However, a minor release of Julia (e.g.
-1.3 to 1.4) *may change* the sequence of pseudorandom numbers generated from a specific seed, in
-particular if `MersenneTwister` is used. (Even if the sequence produced by a low-level function like
+1.3 to 1.4) *may change* the sequence of pseudorandom numbers generated from a specific seed.
+(Even if the sequence produced by a low-level function like
 [`rand`](@ref) does not change, the output of higher-level functions like [`randsubseq`](@ref) may
 change due to algorithm updates.) Rationale: guaranteeing that pseudorandom streams never change
 prohibits many algorithmic improvements.


### PR DESCRIPTION
There was an odd phrase "in particular if `MersenneTwister` is used" in the reproducibility discussion, which made it seem like the discussion was specific to `MersenneTwister` (which we don't even use by default anymore).   I just deleted this clause.