### PR TITLE
curl: fix RPATH to find nghttp2 and libssh2

### DIFF
--- a/deps/curl.mk
+++ b/deps/curl.mk
@@ -14,7 +14,7 @@ $(BUILDDIR)/curl-$(CURL_VER)/build-configured: | $(build_prefix)/manifest/nghttp
 endif
 
 ifneq ($(USE_BINARYBUILDER_CURL),1)
-CURL_LDFLAGS := $(RPATH_ESCAPED_ORIGIN)
+CURL_LDFLAGS := $(RPATH_ESCAPED_ORIGIN) -Wl,-rpath,$(build_shlibdir)
 
 # On older Linuces (those that use OpenSSL < 1.1) we include `libpthread` explicitly.
 # It doesn't hurt to include it explicitly elsewhere, so we do so.


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/48820

I think this is the proper fix, and there might be a configure option to curl or nghttp2 to set it, but I haven't been found it. So we'll do it that way.