### PR TITLE
Iterators: use public keyword for public unexported API

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -36,6 +36,7 @@ import .Base:
     popfirst!, isdone, peek, intersect
 
 export enumerate, zip, rest, countfrom, take, drop, takewhile, dropwhile, cycle, repeated, product, flatten, flatmap
+public accumulate, filter, map, peel, reverse, Stateful
 
 if Base !== Core.Compiler
 export partition


### PR DESCRIPTION
I believe that these fields are all the public fields of `Iterators` that are not exported. This PR marks them as `public`.