### PR TITLE
Copy for `CartesianIndices`/`LinearIndices` need not materialize

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -565,6 +565,7 @@ function getindex(iter::LinearIndices, i::AbstractRange{<:Integer})
     @boundscheck checkbounds(iter, i)
     @inbounds isa(iter, LinearIndices{1}) ? iter.indices[1][i] : (first(iter):last(iter))[i]
 end
+copy(iter::LinearIndices) = iter
 # More efficient iteration — predominantly for non-vector LinearIndices
 # but one-dimensional LinearIndices must be special-cased to support OffsetArrays
 iterate(iter::LinearIndices{1}, s...) = iterate(axes1(iter.indices[1]), s...)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -4,7 +4,7 @@
 module IteratorsMD
     import .Base: eltype, length, size, first, last, in, getindex, setindex!,
                   min, max, zero, oneunit, isless, eachindex,
-                  convert, show, iterate, promote_rule, to_indices
+                  convert, show, iterate, promote_rule, to_indices, copy
 
     import .Base: +, -, *, (:)
     import .Base: simd_outer_range, simd_inner_length, simd_index, setindex
@@ -475,6 +475,8 @@ module IteratorsMD
 
     @inline in(i::CartesianIndex, r::CartesianIndices) = false
     @inline in(i::CartesianIndex{N}, r::CartesianIndices{N}) where {N} = all(map(in, i.I, r.indices))
+
+    copy(iter::CartesianIndices) = iter
 
     simd_outer_range(iter::CartesianIndices{0}) = iter
     function simd_outer_range(iter::CartesianIndices)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -332,6 +332,13 @@ end
     end
 end
 
+@testset "copy for LinearIndices/CartesianIndices" begin
+    C = CartesianIndices((1:2, 1:4))
+    @test copy(C) === C
+    L = LinearIndices((1:2, 1:4))
+    @test copy(L) === L
+end
+
 # token type on which to dispatch testing methods in order to avoid potential
 # name conflicts elsewhere in the base test suite
 mutable struct TestAbstractArray end


### PR DESCRIPTION
Currently,
```julia
julia> C = CartesianIndices((1:2, 1:2))
CartesianIndices((1:2, 1:2))

julia> copy(C)
2×2 Matrix{CartesianIndex{2}}:
 CartesianIndex(1, 1)  CartesianIndex(1, 2)
 CartesianIndex(2, 1)  CartesianIndex(2, 2)
```
However, seeing that a `CartesianIndices` is equivalent to an n-D range, there doesn't seem to be a need to materialize the result. This PR also ensures that `copy(C)` returns the same type as `C`.

After this PR:
```julia
julia> C = CartesianIndices((1:2, 1:2))
CartesianIndices((1:2, 1:2))

julia> copy(C)
CartesianIndices((1:2, 1:2))
```
Also, a similar change for `LinearIndices` is added.