### PR TITLE
Fix calling LLVM_SIZE on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -653,7 +653,7 @@ win-extras:
 ifeq ($(USE_SYSTEM_LLVM), 1)
 LLVM_SIZE := llvm-size$(EXE)
 else
-LLVM_SIZE := $(build_depsbindir)/llvm-size$(EXE)
+LLVM_SIZE := PATH=$(build_bindir):$$PATH; $(build_depsbindir)/llvm-size$(EXE)
 endif
 build-stats:
 ifeq ($(USE_BINARYBUILDER_LLVM),1)


### PR DESCRIPTION
Per https://github.com/JuliaCI/julia-buildkite/pull/224#issuecomment-1474914609, the path needs to be updated so that `llvm-size` can find `libLLVM.dll`.