### PR TITLE
Warn users about Base.IntrusiveLinkedListSynchronized{T} being non public and document Base.IntrusiveLinkedList{T} better

### DIFF
--- a/base/linked_list.jl
+++ b/base/linked_list.jl
@@ -5,7 +5,7 @@
     Base.IntrusiveLinkedList{T}
 
 Is used like this Base.IntrusiveLinkedList{Base.LinkedListItem{T}} as LinkedList{T}.
-Holds the first (head) and the last (tail) `Base.LinkedListItem{T}` in the list. 
+Holds the first (head) and the last (tail) `Base.LinkedListItem{T}` in the list.
 Ensuring O(1) access to the those elements.
 """
 mutable struct IntrusiveLinkedList{T}
@@ -133,9 +133,9 @@ end
 mutable struct LinkedListItem{T}
     # Adapter class to use any `T` in a LinkedList
     next::Union{LinkedListItem{T}, Nothing}
-    # queue is a reference to linked list making use of this LinkedListItem. 
+    # queue is a reference to linked list making use of this LinkedListItem.
     # Might seem redundant but is used by scheduling which uses IntrusiveLinkedList{Task}
-    queue::Union{IntrusiveLinkedList{LinkedListItem{T}}, Nothing} 
+    queue::Union{IntrusiveLinkedList{LinkedListItem{T}}, Nothing}
     value::T
     LinkedListItem{T}(value::T) where {T} = new{T}(nothing, nothing, value)
 end

--- a/base/linked_list.jl
+++ b/base/linked_list.jl
@@ -1,7 +1,15 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+
+"""
+    Base.IntrusiveLinkedList{T}
+
+Is used like this Base.IntrusiveLinkedList{Base.LinkedListItem{T}} as LinkedList{T}.
+Holds the first (head) and the last (tail) `Base.LinkedListItem{T}` in the list. 
+Ensuring O(1) access to the those elements.
+"""
 mutable struct IntrusiveLinkedList{T}
-    # Invasive list requires that T have a field `.next >: U{T, Nothing}` and `.queue >: U{ILL{T}, Nothing}`
+    # Intrusive list requires that T have a field `.next >: U{T, Nothing}` and `.queue >: U{ILL{T}, Nothing}`
     head::Union{T, Nothing}
     tail::Union{T, Nothing}
     IntrusiveLinkedList{T}() where {T} = new{T}(nothing, nothing)
@@ -77,7 +85,7 @@ end
 
 function pop!(q::IntrusiveLinkedList{T}) where {T}
     val = q.tail::T
-    list_deletefirst!(q, val) # expensive!
+    list_deletefirst!(q, val) # expensive as entire list is traversed!
     return val
 end
 
@@ -125,7 +133,9 @@ end
 mutable struct LinkedListItem{T}
     # Adapter class to use any `T` in a LinkedList
     next::Union{LinkedListItem{T}, Nothing}
-    queue::Union{IntrusiveLinkedList{LinkedListItem{T}}, Nothing}
+    # queue is a reference to linked list making use of this LinkedListItem. 
+    # Might seem redundant but is used by scheduling which uses IntrusiveLinkedList{Task}
+    queue::Union{IntrusiveLinkedList{LinkedListItem{T}}, Nothing} 
     value::T
     LinkedListItem{T}(value::T) where {T} = new{T}(nothing, nothing, value)
 end

--- a/doc/src/manual/multi-threading.md
+++ b/doc/src/manual/multi-threading.md
@@ -525,13 +525,15 @@ There are a few approaches to dealing with this problem:
 
 3. A related third strategy is to use a yield-free queue. We don't currently
    have a lock-free queue implemented in Base, but
-   `Base.IntrusiveLinkedListSynchronized{T}` is suitable. This can frequently be a
-   good strategy to use for code with event loops. For example, this strategy is
-   employed by `Gtk.jl` to manage lifetime ref-counting. In this approach, we
-   don't do any explicit work inside the `finalizer`, and instead add it to a queue
-   to run at a safer time. In fact, Julia's task scheduler already uses this, so
-   defining the finalizer as `x -> @spawn do_cleanup(x)` is one example of this
-   approach. Note however that this doesn't control which thread `do_cleanup`
-   runs on, so `do_cleanup` would still need to acquire a lock. That
-   doesn't need to be true if you implement your own queue, as you can explicitly
-   only drain that queue from your thread.
+   `Base.IntrusiveLinkedListSynchronized{T}` is suitable. This is a non public
+   implementation and might change between Julia versions. Using a yield-free
+   queue can frequently be a good strategy to use for code with event loops.
+   For example, this strategy is employed by `Gtk.jl` to manage lifetime
+   ref-counting. In this approach, we don't do any explicit work inside the
+   `finalizer`, and instead add it to a queue to run at a safer time. In fact,
+   Julia's task scheduler already uses this, so defining the finalizer as
+   `x -> @spawn do_cleanup(x)` is one example of this approach. Note however
+   that this doesn't control which thread `do_cleanup` runs on, so `do_cleanup`
+   would still need to acquire a lock. That doesn't need to be true if you
+   implement your own queue, as you can explicitly only drain that queue from
+   your thread.


### PR DESCRIPTION
Just documentation changes.