### PR TITLE
Support broadcasting over structured block matrices

### DIFF
--- a/stdlib/LinearAlgebra/test/special.jl
+++ b/stdlib/LinearAlgebra/test/special.jl
@@ -111,6 +111,7 @@ Random.seed!(1)
         struct TypeWithZero end
         Base.promote_rule(::Type{TypeWithoutZero}, ::Type{TypeWithZero}) = TypeWithZero
         Base.convert(::Type{TypeWithZero}, ::TypeWithoutZero) = TypeWithZero()
+        Base.zero(x::Union{TypeWithoutZero, TypeWithZero}) = zero(typeof(x))
         Base.zero(::Type{<:Union{TypeWithoutZero, TypeWithZero}}) = TypeWithZero()
         LinearAlgebra.symmetric(::TypeWithoutZero, ::Symbol) = TypeWithoutZero()
         LinearAlgebra.symmetric_type(::Type{TypeWithoutZero}) = TypeWithoutZero

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -289,13 +289,20 @@ end
         Dcopy = copy.(D)
         @test Dcopy isa T
         @test Dcopy == D
+        Df = float.(D)
+        @test Df isa T
+        @test Df == D
+        @test eltype(eltype(Df)) <: AbstractFloat
         @test (x -> (x,)).(D) == (x -> (x,)).(M)
+        @test (x -> 1).(D) == ones(Int,size(D))
+        @test_throws MethodError size.(D)
     end
     @testset "Diagonal" begin
         @testset "square" begin
             A = [1 3; 2 4]
             D = Diagonal([A, A])
             standardbroadcastingtests(D, Diagonal)
+            @test sincos.(D) == sincos.(Matrix{eltype(D)}(D))
             M = [x for x in D]
             @test cos.(D) == cos.(M)
         end
@@ -308,6 +315,14 @@ end
         @testset "rectangular blocks" begin
             D = Diagonal([ones(Bool,3,4), ones(Bool,2,3)])
             standardbroadcastingtests(D, Diagonal)
+        end
+
+        @testset "incompatible sizes" begin
+            A = reshape(1:12, 4, 3)
+            B = reshape(1:12, 3, 4)
+            D1 = Diagonal(fill(A, 2))
+            D2 = Diagonal(fill(B, 2))
+            @test_throws DimensionMismatch D1 .+ D2
         end
     end
     @testset "Bidiagonal" begin

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -281,54 +281,44 @@ end
 @test tuple.(Diagonal([1, 2])) == [(1,) (0,); (0,) (2,)]
 
 @testset "broadcast over structured matrices with matrix elements" begin
-    @testset "Diagonal" begin
-        A = [1 3; 2 4]
-        D = Diagonal([A, A])
-        M = [D[i,j] for i in axes(D,1), j in axes(D,2)]
+    function standardbroadcastingtests(D, T)
+        M = [x for x in D]
         Dsum = D .+ D
-        @test Dsum isa Diagonal
-        @test Dsum == Diagonal(fill(2A, 2))
+        @test Dsum isa T
+        @test Dsum == M .+ M
         Dcopy = copy.(D)
-        @test Dcopy isa Diagonal
-        @test Dcopy == D
-        @test cos.(D) == cos.(M)
-
-        D = Diagonal([ones(3,3), fill(3.0,2,2)])
-        M = reshape([ones(3,3), zeros(2,3), zeros(3,2), fill(3.0,2,2)], 2, 2)
-        Dsum = D .+ D
-        @test Dsum isa Diagonal
-        @test Dsum == Diagonal([fill(2.0, 3,3), fill(6.0,2,2)])
-        Dcopy = copy.(D)
-        @test Dcopy isa Diagonal
+        @test Dcopy isa T
         @test Dcopy == D
         @test (x -> (x,)).(D) == (x -> (x,)).(M)
+    end
+    @testset "Diagonal" begin
+        @testset "square" begin
+            A = [1 3; 2 4]
+            D = Diagonal([A, A])
+            standardbroadcastingtests(D, Diagonal)
+            M = [x for x in D]
+            @test cos.(D) == cos.(M)
+        end
+
+        @testset "different-sized square blocks" begin
+            D = Diagonal([ones(3,3), fill(3.0,2,2)])
+            standardbroadcastingtests(D, Diagonal)
+        end
+
+        @testset "rectangular blocks" begin
+            D = Diagonal([ones(Bool,3,4), ones(Bool,2,3)])
+            standardbroadcastingtests(D, Diagonal)
+        end
     end
     @testset "Bidiagonal" begin
         A = [1 3; 2 4]
         B = Bidiagonal(fill(A,3), fill(A,2), :U)
-        M = [B[i,j] for i in axes(B,1), j in axes(B,2)]
-        Bsum = B .+ B
-        @test Bsum isa Bidiagonal
-        @test Bsum == Bidiagonal(fill(2A,3), fill(2A,2), :U)
-        Bcopy = copy.(B)
-        @test Bcopy isa Bidiagonal
-        @test Bcopy == B
-        @test (x -> (x,)).(B) == (x -> (x,)).(M)
+        standardbroadcastingtests(B, Bidiagonal)
     end
     @testset "UpperTriangular" begin
         A = [1 3; 2 4]
         U = UpperTriangular([(i+j)*A for i in 1:3, j in 1:3])
-        M = [U[i,j] for i in axes(U,1), j in axes(U,2)]
-        Usum = U .+ U
-        @test Usum isa UpperTriangular
-        @test Usum == 2M
-        Usum = U .+ 2 .* U
-        @test Usum isa UpperTriangular
-        @test Usum == 3M
-        Ucopy = copy.(U)
-        @test Ucopy isa UpperTriangular
-        @test Ucopy == copy.(M)
-        @test (x -> (x,)).(U) == (x -> (x,)).(M)
+        standardbroadcastingtests(U, UpperTriangular)
     end
 end
 

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -280,4 +280,56 @@ end
 # structured broadcast with function returning non-number type
 @test tuple.(Diagonal([1, 2])) == [(1,) (0,); (0,) (2,)]
 
+@testset "broadcast over structured matrices with matrix elements" begin
+    @testset "Diagonal" begin
+        A = [1 3; 2 4]
+        D = Diagonal([A, A])
+        M = [D[i,j] for i in axes(D,1), j in axes(D,2)]
+        Dsum = D .+ D
+        @test Dsum isa Diagonal
+        @test Dsum == Diagonal(fill(2A, 2))
+        Dcopy = copy.(D)
+        @test Dcopy isa Diagonal
+        @test Dcopy == D
+        @test cos.(D) == cos.(M)
+
+        D = Diagonal([ones(3,3), fill(3.0,2,2)])
+        M = reshape([ones(3,3), zeros(2,3), zeros(3,2), fill(3.0,2,2)], 2, 2)
+        Dsum = D .+ D
+        @test Dsum isa Diagonal
+        @test Dsum == Diagonal([fill(2.0, 3,3), fill(6.0,2,2)])
+        Dcopy = copy.(D)
+        @test Dcopy isa Diagonal
+        @test Dcopy == D
+        @test (x -> (x,)).(D) == (x -> (x,)).(M)
+    end
+    @testset "Bidiagonal" begin
+        A = [1 3; 2 4]
+        B = Bidiagonal(fill(A,3), fill(A,2), :U)
+        M = [B[i,j] for i in axes(B,1), j in axes(B,2)]
+        Bsum = B .+ B
+        @test Bsum isa Bidiagonal
+        @test Bsum == Bidiagonal(fill(2A,3), fill(2A,2), :U)
+        Bcopy = copy.(B)
+        @test Bcopy isa Bidiagonal
+        @test Bcopy == B
+        @test (x -> (x,)).(B) == (x -> (x,)).(M)
+    end
+    @testset "UpperTriangular" begin
+        A = [1 3; 2 4]
+        U = UpperTriangular([(i+j)*A for i in 1:3, j in 1:3])
+        M = [U[i,j] for i in axes(U,1), j in axes(U,2)]
+        Usum = U .+ U
+        @test Usum isa UpperTriangular
+        @test Usum == 2M
+        Usum = U .+ 2 .* U
+        @test Usum isa UpperTriangular
+        @test Usum == 3M
+        Ucopy = copy.(U)
+        @test Ucopy isa UpperTriangular
+        @test Ucopy == copy.(M)
+        @test (x -> (x,)).(U) == (x -> (x,)).(M)
+    end
+end
+
 end

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -295,6 +295,7 @@ end
         @test eltype(eltype(Df)) <: AbstractFloat
         @test (x -> (x,)).(D) == (x -> (x,)).(M)
         @test (x -> 1).(D) == ones(Int,size(D))
+        @test all(==(2), ndims.(D))
         @test_throws MethodError size.(D)
     end
     @testset "Diagonal" begin


### PR DESCRIPTION
Fix https://github.com/JuliaLang/LinearAlgebra.jl/issues/985

After this, broadcasting over structured block matrices with matrix-valued elements works:
```julia
julia> D = Diagonal([[1 2; 3 4], [5 6; 7 8]])
2×2 Diagonal{Matrix{Int64}, Vector{Matrix{Int64}}}:
 [1 2; 3 4]      ⋅     
     ⋅       [5 6; 7 8]

julia> D .+ D
2×2 Diagonal{Matrix{Int64}, Vector{Matrix{Int64}}}:
 [2 4; 6 8]      ⋅     
     ⋅       [10 12; 14 16]

julia> cos.(D)
2×2 Matrix{Matrix{Float64}}:
 [0.855423 -0.110876; -0.166315 0.689109]  [1.0 0.0; 0.0 1.0]
 [1.0 0.0; 0.0 1.0]                        [0.928384 -0.069963; -0.0816235 0.893403]
```
Such operations show up when using `BlockArrays`.

The implementation is a bit hacky as it uses `0I` as the zero element in `fzero`, which isn't really the correct zero if the blocks are rectangular. Nonetheless, this works, as `fzero` is only used to determine if the structure is preserved.