### PR TITLE
minor followups on the linetable changes

### DIFF
--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -327,7 +327,7 @@ Base.show(io::IO, code::Union{IRCode, IncrementalCompact}) = show_ir(io, code)
 lineinfo_disabled(io::IO, linestart::String, idx::Int) = ""
 
 # utility function to extract the file name from a DebugInfo object
-function debuginfo_file1(debuginfo::Union{Core.DebugInfo,DebugInfoStream})
+function debuginfo_file1(debuginfo::Union{DebugInfo,DebugInfoStream})
     def = debuginfo.def
     if def isa MethodInstance
         def = def.def
@@ -342,7 +342,7 @@ function debuginfo_file1(debuginfo::Union{Core.DebugInfo,DebugInfoStream})
 end
 
 # utility function to extract the first line number and file of a block of code
-function debuginfo_firstline(debuginfo::Union{Core.DebugInfo,DebugInfoStream})
+function debuginfo_firstline(debuginfo::Union{DebugInfo,DebugInfoStream})
     linetable = debuginfo.linetable
     while linetable != nothing
         debuginfo = linetable
@@ -375,7 +375,7 @@ function append_scopes!(scopes::Vector{LineInfoNode}, pc::Int, debuginfo, @nospe
             line < 0 && (doupdate = false; line = 0) # broken debug info
             push!(scopes, LineInfoNode(def, debuginfo_file1(debuginfo), Int32(line)))
         else
-            doupdate = append_scopes!(scopes, line, debuginfo.linetable::Core.DebugInfo, def) && doupdate
+            doupdate = append_scopes!(scopes, line, debuginfo.linetable::DebugInfo, def) && doupdate
         end
         inl_to == 0 && return doupdate
         def = :var"macro expansion"

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -328,7 +328,7 @@ function CodeInstance(interp::AbstractInterpreter, result::InferenceResult;
     end
     # n.b. relocatability = (isa(inferred_result, String) && inferred_result[end]) || inferred_result === nothing
     if !@isdefined edges
-        edges = Core.DebugInfo(result.linfo)
+        edges = DebugInfo(result.linfo)
     end
     return CodeInstance(result.linfo, owner,
         widenconst(result_type), widenconst(result.exc_result), rettype_const, inferred_result,
@@ -923,7 +923,7 @@ function codeinfo_for_const(interp::AbstractInterpreter, mi::MethodInstance, @no
     tree.slotnames = ccall(:jl_uncompress_argnames, Vector{Symbol}, (Any,), method.slot_syms)
     tree.slotflags = fill(0x00, nargs)
     tree.ssavaluetypes = 1
-    tree.debuginfo = Core.DebugInfo(mi)
+    tree.debuginfo = DebugInfo(mi)
     tree.ssaflags = UInt32[0]
     set_inlineable!(tree, true)
     tree.parent = mi


### PR DESCRIPTION
- remove unnecessary `Core.` accessors to `DebugInfo` within `Core.Compiler`
- improve the type of `DebugInfoStream`'s `edges` field