### PR TITLE
stacktrace: Enable method signature printing for inlined frames

### DIFF
--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -99,6 +99,56 @@ function hash(frame::StackFrame, h::UInt)
     return h
 end
 
+function debuginfo_func_name(di::Core.DebugInfo)
+    def = di.def
+    if def isa Core.MethodInstance
+        m = def.def
+        return m isa Method ? m.name : nothing
+    elseif def isa Method
+        return def.name
+    elseif def isa Symbol
+        return def
+    end
+    return nothing
+end
+
+# Find a DebugInfo edge matching the inlined frame at `infos[frame_idx]` by function name.
+# When multiple edges match, uses inner frames (`frame_idx-1`, ..., `1`) and then
+# DWARF source location for disambiguation.
+function find_matching_edge(debuginfo::Core.DebugInfo, infos::Core.SimpleVector, frame_idx::Int)
+    edges = debuginfo.edges::Core.SimpleVector
+    func_name = (infos[frame_idx]::Core.SimpleVector)[1]::Symbol
+    candidates = Core.DebugInfo[]
+    for j in 1:length(edges)
+        edge = edges[j]::Core.DebugInfo
+        debuginfo_func_name(edge) === func_name || continue
+        if frame_idx > 1
+            find_matching_edge(edge, infos, frame_idx - 1) === nothing && continue
+        end
+        push!(candidates, edge)
+    end
+    length(candidates) <= 1 && return isempty(candidates) ? nothing : candidates[1]
+    # Multiple matches: disambiguate using DWARF source location.
+    # Different methods of the same generic function have distinct Method objects
+    # with different source file/line, so we match against the DWARF-reported location.
+    info = infos[frame_idx]::Core.SimpleVector
+    file = info[2]::Symbol
+    line = info[3]::Int
+    best = candidates[1]
+    best_line = 0
+    for edge in candidates
+        def = edge.def
+        def isa Core.MethodInstance || continue
+        m = def.def
+        m isa Method || continue
+        if m.file === file && m.line <= line && m.line > best_line
+            best = edge
+            best_line = m.line
+        end
+    end
+    return best
+end
+
 """
     lookup(pointer::Ptr{Cvoid})::Vector{StackFrame}
 
@@ -110,8 +160,10 @@ Base.@constprop :none function lookup(pointer::Ptr{Cvoid})
     infos = @ccall jl_lookup_code_address(pointer::Ptr{Cvoid}, false::Cint)::Core.SimpleVector
     pointer = convert(UInt64, pointer)
     isempty(infos) && return [StackFrame(empty_sym, empty_sym, -1, nothing, true, false, pointer)] # this is equal to UNKNOWN
-    res = Vector{StackFrame}(undef, length(infos))
-    for i in 1:length(infos)
+    ninfos = length(infos)
+    res = Vector{StackFrame}(undef, ninfos)
+    local debuginfo = false
+    for i = ninfos:-1:1
         info = infos[i]::Core.SimpleVector
         @assert length(info) == 6 "corrupt return from jl_lookup_code_address"
         func = info[1]::Symbol
@@ -119,7 +171,23 @@ Base.@constprop :none function lookup(pointer::Ptr{Cvoid})
         linenum = info[3]::Int
         linfo = info[4]
         if linfo isa Core.CodeInstance
+            if debuginfo === false
+                debuginfo = linfo.debuginfo
+            else
+                debuginfo = true
+            end
             linfo = linfo.def
+        elseif debuginfo isa Core.DebugInfo
+            edge = find_matching_edge(debuginfo, infos, i)
+            if edge !== nothing
+                debuginfo = edge
+                def = edge.def
+                if !(def isa Symbol)
+                    linfo = def
+                end
+            else
+                debuginfo = true
+            end
         end
         res[i] = StackFrame(func, file, linenum, linfo, info[5]::Bool, info[6]::Bool, pointer)
     end

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -47,6 +47,14 @@ Stack information representing execution context, with the following fields:
 
   Representation of the pointer to the execution context as returned by `backtrace`.
 
+- `pc::Int`
+
+  1-based statement index within the frame's `CodeInfo`, recovered from the DWARF
+  column emitted by codegen. `0` when unavailable (e.g. for C frames or frames
+  without enriched debug info). Used internally by `StackTraces.lookup` to resolve
+  the `MethodInstance` for inlined frames; also surfaced in low-level safe
+  backtrace output (e.g. on segfault) but not in Julia's default `show` for
+  `StackFrame`.
 """
 struct StackFrame # this type should be kept platform-agnostic so that profiles can be dumped on one machine and read on another
     "the name of the function containing the execution context"
@@ -64,10 +72,14 @@ struct StackFrame # this type should be kept platform-agnostic so that profiles 
     inlined::Bool
     "representation of the pointer to the execution context as returned by `backtrace`"
     pointer::UInt64  # Large enough to be read losslessly on 32- and 64-bit machines.
+    "1-based statement index (PC) within the frame's CodeInfo, or 0 if unavailable"
+    pc::Int
 end
 
+StackFrame(func, file, line, linfo, from_c, inlined, pointer) =
+    StackFrame(func, file, line, linfo, from_c, inlined, pointer, 0)
 StackFrame(func, file, line) = StackFrame(Symbol(func), Symbol(file), line,
-                                          nothing, false, false, 0)
+                                          nothing, false, false, 0, 0)
 
 """
     StackTrace
@@ -99,55 +111,13 @@ function hash(frame::StackFrame, h::UInt)
     return h
 end
 
-function debuginfo_func_name(di::Core.DebugInfo)
-    def = di.def
-    if def isa Core.MethodInstance
-        m = def.def
-        return m isa Method ? m.name : nothing
-    elseif def isa Method
-        return def.name
-    elseif def isa Symbol
-        return def
-    end
-    return nothing
-end
-
-# Find a DebugInfo edge matching the inlined frame at `infos[frame_idx]` by function name.
-# When multiple edges match, uses inner frames (`frame_idx-1`, ..., `1`) and then
-# DWARF source location for disambiguation.
-function find_matching_edge(debuginfo::Core.DebugInfo, infos::Core.SimpleVector, frame_idx::Int)
-    edges = debuginfo.edges::Core.SimpleVector
-    func_name = (infos[frame_idx]::Core.SimpleVector)[1]::Symbol
-    candidates = Core.DebugInfo[]
-    for j in 1:length(edges)
-        edge = edges[j]::Core.DebugInfo
-        debuginfo_func_name(edge) === func_name || continue
-        if frame_idx > 1
-            find_matching_edge(edge, infos, frame_idx - 1) === nothing && continue
-        end
-        push!(candidates, edge)
-    end
-    length(candidates) <= 1 && return isempty(candidates) ? nothing : candidates[1]
-    # Multiple matches: disambiguate using DWARF source location.
-    # Different methods of the same generic function have distinct Method objects
-    # with different source file/line, so we match against the DWARF-reported location.
-    info = infos[frame_idx]::Core.SimpleVector
-    file = info[2]::Symbol
-    line = info[3]::Int
-    best = candidates[1]
-    best_line = 0
-    for edge in candidates
-        def = edge.def
-        def isa Core.MethodInstance || continue
-        m = def.def
-        m isa Method || continue
-        if m.file === file && m.line <= line && m.line > best_line
-            best = edge
-            best_line = m.line
-        end
-    end
-    return best
-end
+# Decode a single codeloc entry, advancing one level of inlining. Returns
+# `(line, to, next_pc)` where `to` is the 1-based index into `debuginfo.edges`
+# for the inlined call directly at `pc` (0 if none), and `next_pc` is the PC
+# within `debuginfo.edges[to]`'s CodeInfo. To traverse nested inlinings, the
+# caller must follow the edge and call this again with `(edges[to], next_pc)`.
+debuginfo_codeloc(debuginfo::Core.DebugInfo, pc::Integer) =
+    @ccall jl_uncompress1_codeloc(debuginfo.codelocs::Any, pc::Csize_t)::NTuple{3,Int32}
 
 """
     lookup(pointer::Ptr{Cvoid})::Vector{StackFrame}
@@ -163,13 +133,15 @@ Base.@constprop :none function lookup(pointer::Ptr{Cvoid})
     ninfos = length(infos)
     res = Vector{StackFrame}(undef, ninfos)
     local debuginfo = false
+    local parent_pc = 0
     for i = ninfos:-1:1
         info = infos[i]::Core.SimpleVector
-        @assert length(info) == 6 "corrupt return from jl_lookup_code_address"
+        @assert length(info) == 7 "corrupt return from jl_lookup_code_address"
         func = info[1]::Symbol
         file = info[2]::Symbol
         linenum = info[3]::Int
         linfo = info[4]
+        pc = info[7]::Int
         if linfo isa Core.CodeInstance
             if debuginfo === false
                 debuginfo = linfo.debuginfo
@@ -177,11 +149,13 @@ Base.@constprop :none function lookup(pointer::Ptr{Cvoid})
                 debuginfo = true
             end
             linfo = linfo.def
-        elseif debuginfo isa Core.DebugInfo
-            edge = find_matching_edge(debuginfo, infos, i)
-            if edge !== nothing
-                debuginfo = edge
-                def = edge.def
+        elseif debuginfo isa Core.DebugInfo && parent_pc > 0
+            # Use the parent frame's PC to look up which inlining edge of the
+            # current `debuginfo` corresponds to this frame's call site.
+            _, to::Int, _ = debuginfo_codeloc(debuginfo, parent_pc)
+            if to > 0 && to <= length(debuginfo.edges)
+                debuginfo = debuginfo.edges[to]::Core.DebugInfo
+                def = debuginfo.def
                 if !(def isa Symbol)
                     linfo = def
                 end
@@ -189,7 +163,8 @@ Base.@constprop :none function lookup(pointer::Ptr{Cvoid})
                 debuginfo = true
             end
         end
-        res[i] = StackFrame(func, file, linenum, linfo, info[5]::Bool, info[6]::Bool, pointer)
+        parent_pc = pc
+        res[i] = StackFrame(func, file, linenum, linfo, info[5]::Bool, info[6]::Bool, pointer, pc)
     end
     return res
 end

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -107,7 +107,7 @@ up stack frame context information. Returns an array of frame information for al
 inlined at that point, innermost function first.
 """
 Base.@constprop :none function lookup(pointer::Ptr{Cvoid})
-    infos = ccall(:jl_lookup_code_address, Any, (Ptr{Cvoid}, Cint), pointer, false)::Core.SimpleVector
+    infos = @ccall jl_lookup_code_address(pointer::Ptr{Cvoid}, false::Cint)::Core.SimpleVector
     pointer = convert(UInt64, pointer)
     isempty(infos) && return [StackFrame(empty_sym, empty_sym, -1, nothing, true, false, pointer)] # this is equal to UNKNOWN
     res = Vector{StackFrame}(undef, length(infos))
@@ -118,6 +118,9 @@ Base.@constprop :none function lookup(pointer::Ptr{Cvoid})
         file = info[2]::Symbol
         linenum = info[3]::Int
         linfo = info[4]
+        if linfo isa Core.CodeInstance
+            linfo = linfo.def
+        end
         res[i] = StackFrame(func, file, linenum, linfo, info[5]::Bool, info[6]::Bool, pointer)
     end
     return res

--- a/src/codegen-stubs.c
+++ b/src/codegen-stubs.c
@@ -34,7 +34,7 @@ JL_DLLEXPORT int jl_getFunctionInfo_fallback(jl_frame_t **frames, uintptr_t poin
 }
 
 JL_DLLEXPORT void jl_register_fptrs_fallback(uint64_t image_base, const struct _jl_image_fptrs_t *fptrs,
-                       jl_method_instance_t **linfos, size_t n)
+                       jl_code_instance_t **linfos, size_t n)
 {
     (void)image_base; (void)fptrs; (void)linfos; (void)n;
 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9329,8 +9329,12 @@ static jl_llvm_functions_t
                         info.is_user_code = in_user_mod(modu);
                     if (debug_enabled) {
                         StringRef fname = jl_debuginfo_name(func);
+                        // Encode the 1-based statement index into the DWARF column field so that
+                        // stacktraces can recover the exact PC that each inlined frame points at.
+                        // `pc` here is the 1-based statement index within `debuginfo`'s CodeInfo.
+                        unsigned col = (unsigned)pc;
                         if (new_lineinfo.empty() && info.file == ctx.file) { // if everything matches, emit a toplevel line number
-                            info.loc = DILocation::get(ctx.builder.getContext(), info.line, 0, SP, NULL);
+                            info.loc = DILocation::get(ctx.builder.getContext(), info.line, col, SP, NULL);
                         }
                         else { // otherwise, describe this as an inlining frame
                             DebugLoc inl_loc = new_lineinfo.empty() ? DebugLoc(DILocation::get(ctx.builder.getContext(), 0, 0, SP, NULL)) : new_lineinfo.back().loc;
@@ -9351,7 +9355,7 @@ static jl_llvm_functions_t
                                                              ,nullptr          // ThrownTypes
                                                              );
                             }
-                            info.loc = DILocation::get(ctx.builder.getContext(), info.line, 0, inl_SP, inl_loc);
+                            info.loc = DILocation::get(ctx.builder.getContext(), info.line, col, inl_SP, inl_loc);
                         }
                     }
                     new_lineinfo.push_back(info);

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -368,6 +368,11 @@ void JITDebugInfoRegistry::registerJITObject(
         if (it != sym_to_ci.end()) {
             codeinst = it->second;
         }
+        if (codeinst) {
+            JL_GC_PROMISE_ROOTED(codeinst);
+            if (jl_is_method(jl_get_ci_mi(codeinst)->def.method) && jl_get_ci_mi(codeinst)->def.method->is_for_opaque_closure)
+                codeinst = (jl_code_instance_t*)jl_as_global_root((jl_value_t*)codeinst, 1);
+        }
         jl_profile_atomic([&]() JL_NOTSAFEPOINT {
             if (codeinst)
                 cimap[Addr] = std::make_pair(Size, codeinst);

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -523,6 +523,7 @@ static int lookup_pointer(
             frame->fromC = 1;
 
         frame->line = info.Line;
+        frame->pc = info.Column;
         std::string file_name(info.FileName);
 
         if (file_name == "<invalid>")

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -2194,7 +2194,7 @@ JL_DLLIMPORT void jl_get_llvm_external_fns(void *native_code, size_t *num_els,
 JL_DLLIMPORT void jl_get_function_id(void *native_code, jl_code_instance_t *ncode,
         int32_t *func_idx, int32_t *specfunc_idx);
 JL_DLLIMPORT void jl_register_fptrs(uint64_t image_base, const struct _jl_image_fptrs_t *fptrs,
-                                    jl_method_instance_t **linfos, size_t n);
+                                    jl_code_instance_t **linfos, size_t n);
 JL_DLLIMPORT void jl_get_llvm_cis(void *native_code, size_t *num_els,
                                   jl_code_instance_t **CIs);
 JL_DLLIMPORT void jl_init_codegen(void);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1570,6 +1570,9 @@ typedef struct {
     char *func_name;
     char *file_name;
     int line;
+    // PC within the inlined frame's CodeInfo, or 0 if unavailable.
+    // Carried in the DWARF column field by codegen (see `update_lineinfo` in codegen.cpp).
+    int pc;
     jl_code_instance_t *ci;
     int fromC;
     int inlined;

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -794,7 +794,7 @@ JL_DLLEXPORT jl_value_t *jl_lookup_code_address(void *ip, int skipC)
     JL_GC_PUSH1(&rs);
     for (int i = 0; i < n; i++) {
         jl_frame_t frame = frames[i];
-        jl_value_t *r = (jl_value_t*)jl_alloc_svec(6);
+        jl_value_t *r = (jl_value_t*)jl_alloc_svec(7);
         jl_svecset(rs, i, r);
         if (frame.func_name)
             jl_svecset(r, 0, jl_symbol(frame.func_name));
@@ -810,6 +810,7 @@ JL_DLLEXPORT jl_value_t *jl_lookup_code_address(void *ip, int skipC)
         jl_svecset(r, 3, frame.ci != NULL ? (jl_value_t*)frame.ci : jl_nothing);
         jl_svecset(r, 4, jl_box_bool(frame.fromC));
         jl_svecset(r, 5, jl_box_bool(frame.inlined));
+        jl_svecset(r, 6, jl_box_long(frame.pc));
     }
     free(frames);
     JL_GC_POP();
@@ -817,11 +818,14 @@ JL_DLLEXPORT jl_value_t *jl_lookup_code_address(void *ip, int skipC)
 }
 
 static void jl_safe_fprint_codeloc(ios_t *s, const char* func_name, const char* file_name,
-                                   int line, int inlined) JL_NOTSAFEPOINT
+                                   int line, int pc, int inlined) JL_NOTSAFEPOINT
 {
     const char *inlined_str = inlined ? " [inlined]" : "";
     if (line != -1) {
-        jl_safe_fprintf(s, "%s at %s:%d%s\n", func_name, file_name, line, inlined_str);
+        if (pc > 0)
+            jl_safe_fprintf(s, "%s at %s:%d:%d%s\n", func_name, file_name, line, pc, inlined_str);
+        else
+            jl_safe_fprintf(s, "%s at %s:%d%s\n", func_name, file_name, line, inlined_str);
     }
     else {
         jl_safe_fprintf(s, "%s at %s (unknown line)%s\n", func_name, file_name, inlined_str);
@@ -846,7 +850,7 @@ void jl_fprint_native_codeloc(ios_t *s, uintptr_t ip) JL_NOTSAFEPOINT
             jl_safe_fprintf(s, "unknown function (ip: %p) at %s\n", (void*)ip, frame.file_name ? frame.file_name : "(unknown file)");
         }
         else {
-            jl_safe_fprint_codeloc(s, frame.func_name, frame.file_name, frame.line, frame.inlined);
+            jl_safe_fprint_codeloc(s, frame.func_name, frame.file_name, frame.line, frame.pc, frame.inlined);
             free(frame.func_name);
         }
         free(frame.file_name);
@@ -929,7 +933,7 @@ static void jl_fprint_debugloc(ios_t *s, jl_debuginfo_t *debuginfo, jl_value_t *
             ip2 = 0;
         const char *func_name = jl_debuginfo_name(func);
         const char *file = jl_debuginfo_firstline(debuginfo, NULL);
-        jl_safe_fprint_codeloc(s, func_name, file, ip2, inlined);
+        jl_safe_fprint_codeloc(s, func_name, file, ip2, (int)ip, inlined);
     }
 }
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2175,7 +2175,7 @@ static void jl_update_all_fptrs(jl_serializer_state *s, jl_image_t *image)
     uintptr_t base = (uintptr_t)&s->s->buf[0];
     // These will become MethodInstance references, but they start out as a list of
     // offsets into `s` for CodeInstances
-    jl_method_instance_t **linfos = (jl_method_instance_t**)&s->fptr_record->buf[0];
+    jl_code_instance_t **linfos = (jl_code_instance_t**)&s->fptr_record->buf[0];
     uint32_t clone_idx = 0;
     for (i = 0; i < img_fvars_max; i++) {
         reloc_t offset = *(reloc_t*)&linfos[i];
@@ -2190,7 +2190,7 @@ static void jl_update_all_fptrs(jl_serializer_state *s, jl_image_t *image)
             jl_code_instance_t *codeinst = (jl_code_instance_t*)(base + offset);
             assert(jl_is_method(jl_get_ci_mi(codeinst)->def.method) && jl_atomic_load_relaxed(&codeinst->invoke) != jl_fptr_const_return);
             assert(specfunc ? jl_atomic_load_relaxed(&codeinst->invoke) != NULL : jl_atomic_load_relaxed(&codeinst->invoke) == NULL);
-            linfos[i] = jl_get_ci_mi(codeinst);     // now it's a MethodInstance
+            linfos[i] = codeinst;
             void *fptr = fvars.ptrs[i];
             for (; clone_idx < fvars.nclones; clone_idx++) {
                 uint32_t idx = fvars.clone_idxs[clone_idx] & jl_sysimg_val_mask;

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -91,12 +91,9 @@ trace = (try; f(3); catch; stacktrace(catch_backtrace()); end)[1:3]
 can_inline = Bool(Base.JLOptions().can_inline)
 for (frame, func, inlined) in zip(trace, [g,h,f], (can_inline, can_inline, false))
     @test frame.func === typeof(func).name.singletonname
-    # broken until #50082 can be addressed
-    mi = isa(frame.linfo, Core.CodeInstance) ? frame.linfo.def : frame.linfo
-    @test mi.def.module === which(func, (Any,)).module broken=inlined
-    @test mi.def === which(func, (Any,)) broken=inlined
-    @test mi.specTypes === Tuple{typeof(func), Int} broken=inlined
-    # line
+    @test frame.linfo.def.module === which(func, (Any,)).module
+    @test frame.linfo.def === which(func, (Any,))
+    @test frame.linfo.specTypes === Tuple{typeof(func), Int}
     @test frame.file === Symbol(@__FILE__)
     @test !frame.from_c
     @test frame.inlined === inlined
@@ -263,7 +260,6 @@ end
     @test isempty(Docs.undocumented_names(StackTraces))
 end
 
-
 @testset "Dispatch backtraces" begin
     # Check that it's possible to capture a backtrace upon entrance to inference
     # This test ensures that SnoopCompile will continue working
@@ -296,5 +292,63 @@ end
         ci.def.def === mcaller && any(stacktrace(bt)) do sf
             sf.file == fl && sf.line == ln
         end
+    end
+end
+
+global f_parent1_line::Int, f_inner1_line::Int, f_innermost1_line::Int
+function f_parent1(a)
+    x = a
+    return begin
+        @inline f_inner1(x)
+    end
+end; f_parent1_line = (@__LINE__) - 2
+function f_inner1(a)
+    x = a
+    return @inline f_innermost1(x)
+end; f_inner1_line = (@__LINE__) - 1
+f_innermost1(x) = x > 0 ? @noinline(sin(x)) : error("x is negative")
+f_innermost1_line = (@__LINE__) - 1
+let st = try
+        f_parent1(-1)
+    catch err
+        stacktrace(catch_backtrace())
+    end
+    @test any(st) do sf
+        sf.func === :f_parent1 && sf.line == f_parent1_line && sf.linfo isa Core.MethodInstance
+    end
+    @test any(st) do sf
+        sf.func === :f_inner1 && sf.line == f_inner1_line && sf.linfo isa Core.MethodInstance && sf.inlined
+    end
+    @test any(st) do sf
+        sf.func === :f_innermost1 && sf.line == f_innermost1_line && sf.linfo isa Core.MethodInstance && sf.inlined
+    end
+end
+
+global f_parent2_line::Int, f_inner2_line::Int, f_innermost2_line::Int
+function f_parent2(a)
+    x = identity(a)
+    return begin
+        @inline f_inner2(x)
+    end
+end; f_parent2_line = (@__LINE__) - 2
+function f_inner2(a)
+    x = identity(a)
+    return @inline f_innermost2(x)
+end; f_inner2_line = (@__LINE__) - 1
+f_innermost2(x) = x > 0 ? @noinline(sin(x)) : error("x is negative")
+f_innermost2_line = (@__LINE__) - 1
+let st = try
+        f_parent2(-1)
+    catch err
+        stacktrace(catch_backtrace())
+    end
+    @test any(st) do sf
+        sf.func === :f_parent2 && sf.line == f_parent2_line && sf.linfo isa Core.MethodInstance
+    end
+    @test any(st) do sf
+        sf.func === :f_inner2 && sf.line == f_inner2_line && sf.linfo isa Core.MethodInstance && sf.inlined
+    end
+    @test any(st) do sf
+        sf.func === :f_innermost2 && sf.line == f_innermost2_line && sf.linfo isa Core.MethodInstance && sf.inlined
     end
 end


### PR DESCRIPTION
This is an attempt to revive #41099 using the newly added invert linetable format (#52415).
It's a work in progress, but I've opened this PR to spark a discussion on whether I'm moving in the right direction with this approach. Currently, I've tweaked `jl_lookup_code_address` to give back a `CodeInstance` containing `debuginfo` rather than the `MethodInstance` for the outermost frame. This info is then used to find the `MethodInstance` for inlined inner frames from the Julia side.

```julia
julia> function f1(a)
           x = a
           return begin
               @inline f2(x)
           end
       end;

julia> function f2(a)
           x = a
           return @inline sin(x)
       end;

julia> f1(Inf)
ERROR: DomainError with Inf:
sin(x) is only defined for finite x.
Stacktrace:
```
```diff
diff --git a/old b/new
index f913ab20c3..215037aa56 100644
--- a/old
+++ b/new
@@ -1,10 +1,10 @@
  [1] sin_domain_error(x::Float64)
    @ Base.Math ./special/trig.jl:28
- [2] sin
-   @ ./special/trig.jl:39 [inlined]
- [3] f2
-   @ ./REPL[2]:3 [inlined]
+ [2] sin(x::Float64)
+   @ Base.Math ./special/trig.jl:39 [inlined]
+ [3] f2(a::Float64)
+   @ Main ./REPL[2]:3 [inlined]
  [4] f1(a::Float64)
    @ Main ./REPL[1]:4
  [5] top-level scope
    @ REPL[3]:1
```