### PR TITLE
note that REPL doesn't show "nothing" values

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1521,6 +1521,8 @@ Nothing
 The singleton instance of type [`Nothing`](@ref), used by convention when there is no value to return
 (as in a C `void` function) or when a variable or field holds no value.
 
+A return value of `nothing` is not displayed by the REPL and similar interactive environments.
+
 See also: [`isnothing`](@ref), [`something`](@ref), [`missing`](@ref).
 """
 nothing


### PR DESCRIPTION
It seemed worth documenting that display of `nothing` is suppressed by the REPL (and similar environments, e.g. IJulia).