### PR TITLE
Add type annotations to Base._any() and Base._all()

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -1222,7 +1222,7 @@ any(f, itr) = _any(f, itr, :)
 for ItrT = (Tuple,Any)
     # define a generic method and a specialized version for `Tuple`,
     # whose method bodies are identical, while giving better effects to the later
-    @eval function _any(f, itr::$ItrT, ::Colon)
+    @eval function _any(f::Function, itr::$ItrT, ::Colon)
         $(ItrT === Tuple ? :(@_terminates_locally_meta) : :nothing)
         anymissing = false
         for x in itr
@@ -1295,7 +1295,7 @@ all(f, itr) = _all(f, itr, :)
 for ItrT = (Tuple,Any)
     # define a generic method and a specialized version for `Tuple`,
     # whose method bodies are identical, while giving better effects to the later
-    @eval function _all(f, itr::$ItrT, ::Colon)
+    @eval function _all(f::Function, itr::$ItrT, ::Colon)
         $(ItrT === Tuple ? :(@_terminates_locally_meta) : :nothing)
         anymissing = false
         for x in itr


### PR DESCRIPTION
This removes invalidations from other specializations from SparseArrays, discovered when looking into Dagger.jl with SnoopCompile. *Might* also fix https://github.com/JuliaSparse/SparseArrays.jl/issues/506. Disclaimer: I'm not an expert :smiling_face_with_tear: Not entirely sure that I'm doing the right thing here.

I should also mention that I've only tested these changes on Julia 1.10 because Cthulu and JET don't work on 1.11 yet.

Before:
```julia
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬──────────────────┬───────────────┬─────────────────┐
│ <file name>:<line number>                                                                                                         │  Function Name   │ Invalidations │ Invalidations % │
│                                                                                                                                   │                  │               │     (xᵢ/∑x)     │
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────────────┼───────────────┼─────────────────┤
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/SparseArrays/src/sparsematrix.jl:2375 │       _any       │      90       │       29        │
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/SparseArrays/src/sparsematrix.jl:2377 │       _all       │      35       │       11        │
│ /home/james/.julia/packages/DataStructures/jFDPC/src/circular_buffer.jl:157                                                       │      eltype      │      33       │       11        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/SizedArray.jl:88                                                               │     convert      │      25       │        8        │
│ /home/james/.julia/packages/DataStructures/jFDPC/src/container_loops.jl:233                                                       │       keys       │      23       │        7        │
│ /home/james/.julia/packages/FillArrays/oXkMk/src/FillArrays.jl:697                                                                │ print_matrix_row │      18       │        6        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/SArray.jl:71                                                                   │  unsafe_convert  │      16       │        5        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/broadcast.jl:25                                                                │      _axes       │      14       │        5        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/broadcast.jl:78                                                                │      _bcs1       │      11       │        4        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/broadcast.jl:85                                                                │      _bcs1       │      10       │        3        │
│ /cache/build/builder-amdci5-1/julialang/julia-release-1-dot-10/usr/share/julia/stdlib/v1.10/SparseArrays/src/readonly.jl:33       │     resize!      │       7       │        2        │
│ /home/james/.julia/packages/FillArrays/oXkMk/src/fillalgebra.jl:396                                                               │   reduce_first   │       6       │        2        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/SizedArray.jl:82                                                               │     convert      │       4       │        1        │
│ /home/james/.julia/dev/Dagger/src/array/darray.jl:26                                                                              │     getindex     │       3       │        1        │
│ /home/james/.julia/packages/FillArrays/oXkMk/src/fillbroadcast.jl:258                                                             │   broadcasted    │       3       │        1        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/abstractarray.jl:178                                                           │      rdims       │       2       │        1        │
│ /home/james/.julia/packages/ConcurrentUtils/UEN6K/src/read_write_lock.jl:121                                                      │      unlock      │       2       │        1        │
│ /home/james/.julia/packages/ConcurrentUtils/UEN6K/src/read_write_lock.jl:107                                                      │       lock       │       2       │        1        │
│ /home/james/.julia/dev/Dagger/src/scopes.jl:165                                                                                   │      isless      │       1       │        0        │
│ /home/james/.julia/dev/Dagger/src/scopes.jl:153                                                                                   │      isless      │       1       │        0        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/abstractarray.jl:177                                                           │      rdims       │       1       │        0        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/abstractarray.jl:16                                                            │    eachindex     │       1       │        0        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/SOneTo.jl:57                                                                   │   getproperty    │       1       │        0        │
│ /home/james/.julia/packages/DataStructures/jFDPC/src/circular_buffer.jl:166                                                       │     convert      │       1       │        0        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/indexing.jl:413                                                                │     SubArray     │       0       │        0        │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴──────────────────┴───────────────┴─────────────────┘
```

After, and with https://github.com/JuliaData/MemPool.jl/pull/83:
```julia
┌──────────────────────────────────────────────────────────────────────────────────────────┬──────────────────┬───────────────┬─────────────────┐
│ <file name>:<line number>                                                                │  Function Name   │ Invalidations │ Invalidations % │
│                                                                                          │                  │               │     (xᵢ/∑x)     │
├──────────────────────────────────────────────────────────────────────────────────────────┼──────────────────┼───────────────┼─────────────────┤
│ /home/james/.julia/packages/DataStructures/jFDPC/src/circular_buffer.jl:157              │      eltype      │      33       │       17        │
│ /home/james/.julia/packages/DataStructures/jFDPC/src/container_loops.jl:233              │       keys       │      23       │       12        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/SizedArray.jl:88                      │     convert      │      22       │       11        │
│ /home/james/.julia/packages/FillArrays/oXkMk/src/FillArrays.jl:697                       │ print_matrix_row │      18       │        9        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/SArray.jl:71                          │  unsafe_convert  │      16       │        8        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/broadcast.jl:25                       │      _axes       │      14       │        7        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/broadcast.jl:78                       │      _bcs1       │      11       │        6        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/broadcast.jl:85                       │      _bcs1       │      10       │        5        │
│ /home/james/git/julia/usr/share/julia/stdlib/v1.10/SparseArrays/src/readonly.jl:33       │     resize!      │       7       │        4        │
│ /home/james/.julia/packages/FillArrays/oXkMk/src/fillalgebra.jl:396                      │   reduce_first   │       6       │        3        │
│ /home/james/git/julia/usr/share/julia/stdlib/v1.10/SparseArrays/src/sparsevector.jl:1594 │       _all       │       5       │        3        │
│ /home/james/git/julia/usr/share/julia/stdlib/v1.10/SparseArrays/src/sparsevector.jl:1592 │       _any       │       5       │        3        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/SizedArray.jl:82                      │     convert      │       4       │        2        │
│ /home/james/.julia/dev/Dagger/src/array/darray.jl:26                                     │     getindex     │       3       │        2        │
│ /home/james/.julia/packages/FillArrays/oXkMk/src/fillbroadcast.jl:258                    │   broadcasted    │       3       │        2        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/abstractarray.jl:178                  │      rdims       │       2       │        1        │
│ /home/james/.julia/packages/ConcurrentUtils/UEN6K/src/read_write_lock.jl:121             │      unlock      │       2       │        1        │
│ /home/james/.julia/packages/ConcurrentUtils/UEN6K/src/read_write_lock.jl:107             │       lock       │       2       │        1        │
│ /home/james/.julia/dev/Dagger/src/scopes.jl:165                                          │      isless      │       1       │        1        │
│ /home/james/.julia/dev/Dagger/src/scopes.jl:164                                          │      isless      │       1       │        1        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/abstractarray.jl:177                  │      rdims       │       1       │        1        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/abstractarray.jl:16                   │    eachindex     │       1       │        1        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/SOneTo.jl:57                          │   getproperty    │       1       │        1        │
│ /home/james/.julia/packages/DataStructures/jFDPC/src/circular_buffer.jl:166              │     convert      │       1       │        1        │
│ /home/james/.julia/packages/StaticArrays/EHHaF/src/indexing.jl:413                       │     SubArray     │       0       │        0        │
└──────────────────────────────────────────────────────────────────────────────────────────┴──────────────────┴───────────────┴─────────────────┘
```

CC @jpsamaroo 