### PR TITLE
Fixes for allowing `:throw_undef_if_not` on the frontend

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2637,7 +2637,7 @@ function abstract_eval_statement_expr(interp::AbstractInterpreter, e::Expr, vtyp
             else
                 t = Union{}
             end
-        elseif !hasintersect(windenconst(condt), Bool)
+        elseif !hasintersect(widenconst(condt), Bool)
             t = Union{}
         end
     elseif ehead === :boundscheck

--- a/src/method.c
+++ b/src/method.c
@@ -212,7 +212,7 @@ static jl_value_t *resolve_globals(jl_value_t *expr, jl_module_t *module, jl_sve
                 jl_exprargset(e, 0, resolve_globals(jl_exprarg(e, 0), module, sparam_vals, binding_effects, 1));
                 i++;
             }
-            if (e->head == jl_method_sym || e->head == jl_module_sym) {
+            if (e->head == jl_method_sym || e->head == jl_module_sym || e->head == jl_throw_undef_if_not_sym) {
                 i++;
             }
             for (; i < nargs; i++) {

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5647,6 +5647,22 @@ end
 @test Core.Compiler.return_type(has_tuin, Tuple{}) === Union{}
 @test_throws UndefVarError has_tuin()
 
+function gen_tuin_from_arg(world::UInt, source, _, _)
+    ci = make_codeinfo(Any[
+        Expr(:throw_undef_if_not, :x, Core.Argument(2)),
+        ReturnNode(true),
+    ]; slottypes=Any[Any, Bool])
+    ci.slotnames = Symbol[:var"#self#", :def]
+    ci
+end
+
+@eval function has_tuin2(def)
+    $(Expr(:meta, :generated, gen_tuin_from_arg))
+    $(Expr(:meta, :generated_only))
+end
+@test_throws UndefVarError has_tuin2(false)
+@test has_tuin2(true)
+
 # issue #53585
 let t = ntuple(i -> i % 8 == 1 ? Int64 : Float64, 4000)
     @test only(Base.return_types(Base.promote_typeof, t)) == Type{Float64}


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/53875 allowed `:throw_undef_if_not` as a frontend form.

However, the `UndefVarError` being tested is thrown because the first argument is resolved to a global ref:

```julia
julia> @eval function has_tuin()
           $(Expr(:throw_undef_if_not, :x, false))
       end
has_tuin (generic function with 1 method)

julia> @code_lowered has_tuin() # master
CodeInfo(
1 ─ %1 = $(Expr(:throw_undef_if_not, :(Main.x), false))
└──      return %1
)

julia> @code_lowered has_tuin() # this pr
CodeInfo(
1 ─ %1 = $(Expr(:throw_undef_if_not, :x, false))
└──      return %1
)
```

This change skips this global ref resolution for the first argument and fixes a typo which would throw an error in case of non-const second argument.