### PR TITLE
RFC: Curried getproperty syntax

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -664,7 +664,7 @@ macro __doc__(x)
     return Expr(:escape, Expr(:block, Expr(:meta, :doc), x))
 end
 
-isbasicdoc(@nospecialize x) = (isa(x, Expr) && x.head === :.) || isa(x, Union{QuoteNode, Symbol})
+isbasicdoc(@nospecialize x) = (isa(x, Expr) && x.head === :var".") || isa(x, Union{QuoteNode, Symbol})
 iscallexpr(ex::Expr) = (isa(ex, Expr) && ex.head === :where) ? iscallexpr(ex.args[1]) : (isa(ex, Expr) && ex.head === :call)
 iscallexpr(ex) = false
 function ignoredoc(source, mod, str, expr)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1245,7 +1245,7 @@ __dot__(x) = x
 function __dot__(x::Expr)
     dotargs = Base.mapany(__dot__, x.args)
     if x.head === :call && dottable(x.args[1])
-        Expr(:., dotargs[1], Expr(:tuple, dotargs[2:end]...))
+        Expr(:var".", dotargs[1], Expr(:tuple, dotargs[2:end]...))
     elseif x.head === :comparison
         Expr(:comparison, (iseven(i) && dottable(arg) && arg isa Symbol && isoperator(arg) ?
                                Symbol('.', arg) : arg for (i, arg) in pairs(dotargs))...)

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -289,7 +289,7 @@ namify(@nospecialize x) = astname(x, isexpr(x, :macro))::Union{Symbol,Expr,Globa
 
 function astname(x::Expr, ismacro::Bool)
     head = x.head
-    if head === :.
+    if head === :var"."
         ismacro ? macroname(x) : x
     elseif head === :call && isexpr(x.args[1], :(::))
         return astname((x.args[1]::Expr).args[end], ismacro)
@@ -305,7 +305,7 @@ astname(@nospecialize(other), ismacro::Bool) = other
 macroname(s::Symbol) = Symbol('@', s)
 macroname(x::Expr)   = Expr(x.head, x.args[1], macroname(x.args[end].value))
 
-isfield(@nospecialize x) = isexpr(x, :.) &&
+isfield(@nospecialize x) = isexpr(x, :var".") &&
     (isa(x.args[1], Symbol) || isfield(x.args[1])) &&
     (isa(x.args[2], QuoteNode) || isexpr(x.args[2], :quote))
 
@@ -559,7 +559,7 @@ isquotedmacrocall(@nospecialize x) =
     isa(x.args[1], QuoteNode) &&
     isexpr(x.args[1].value, :macrocall, 2)
 # Simple expressions / atoms the may be documented.
-isbasicdoc(@nospecialize x) = isexpr(x, :.) || isa(x, Union{QuoteNode, Symbol})
+isbasicdoc(@nospecialize x) = isexpr(x, :var".") || isa(x, Union{QuoteNode, Symbol})
 is_signature(@nospecialize x) = isexpr(x, :call) || (isexpr(x, :(::), 2) && isexpr(x.args[1], :call)) || isexpr(x, :where)
 
 function docm(source::LineNumberNode, mod::Module, ex)

--- a/base/docs/bindings.jl
+++ b/base/docs/bindings.jl
@@ -21,7 +21,7 @@ resolve(b::Binding) = getfield(b.mod, b.var)
 
 function splitexpr(x::Expr)
     isexpr(x, :macrocall) ? splitexpr(x.args[1]) :
-    isexpr(x, :.)         ? (x.args[1], x.args[2]) :
+    isexpr(x, :var".")    ? (x.args[1], x.args[2]) :
     error("Invalid @var syntax `$x`.")
 end
 splitexpr(s::Symbol) = Expr(:macrocall, getfield(Base, Symbol("@__MODULE__")), nothing), quot(s)

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -375,4 +375,18 @@ adding them to the global method table.
 """
 :@MethodTable
 
+struct GetPropertyLens
+    syms::Tuple{Vararg{Symbol}}
+end
+Base.getproperty() = GetPropertyLens(())
+Base.getproperty(lens::GetPropertyLens, s::Symbol) =
+    GetPropertyLens(lens, tuple(getfield(lens, :syms)..., s))
+
+function (lens::GetPropertyLens)(strct)
+    syms = getfield(lens, :syms)
+    isempty(syms) && return strct
+    sym = first(syms)
+    return GetPropertyLens(Base.tail(syms))(Base.getproperty(strct, sym))
+end
+
 end

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -380,7 +380,7 @@ struct GetPropertyLens
 end
 Base.getproperty() = GetPropertyLens(())
 Base.getproperty(lens::GetPropertyLens, s::Symbol) =
-    GetPropertyLens(lens, tuple(getfield(lens, :syms)..., s))
+    GetPropertyLens(tuple(getfield(lens, :syms)..., s))
 
 function (lens::GetPropertyLens)(strct)
     syms = getfield(lens, :syms)

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -1175,14 +1175,14 @@ end
 function make_atomic(order, ex)
     @nospecialize
     if ex isa Expr
-        if isexpr(ex, :., 2)
+        if isexpr(ex, :var".", 2)
             l, r = esc(ex.args[1]), esc(ex.args[2])
             return :(getproperty($l, $r, $order))
         elseif isexpr(ex, :call, 3)
             return make_atomic(order, ex.args[2], ex.args[1], ex.args[3])
         elseif ex.head === :(=)
             l, r = ex.args[1], esc(ex.args[2])
-            if is_expr(l, :., 2)
+            if is_expr(l, :var".", 2)
                 ll, lr = esc(l.args[1]), esc(l.args[2])
                 return :(setproperty!($ll, $lr, $r, $order))
             end

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1479,3 +1479,17 @@ julia> [1, 2] .∉ ([2, 3],)
 ```
 """
 ∉, ∌
+
+struct GetPropertyLens
+    syms::Tuple{Vararg{Symbol}}
+end
+getproperty() = GetPropertyLens(())
+getproperty(lens::GetPropertyLens, s::Symbol) =
+    GetPropertyLens(lens, tuple(getfield(lens, :syms)..., s))
+
+function (lens::GetPropertyLens)(strct)
+    syms = getfield(lens, :syms)
+    isempty(syms) && return strct
+    sym = first(syms)
+    return GetPropertyLens(tail(syms))(getproperty(strct, sym))
+end

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1479,17 +1479,3 @@ julia> [1, 2] .∉ ([2, 3],)
 ```
 """
 ∉, ∌
-
-struct GetPropertyLens
-    syms::Tuple{Vararg{Symbol}}
-end
-getproperty() = GetPropertyLens(())
-getproperty(lens::GetPropertyLens, s::Symbol) =
-    GetPropertyLens(lens, tuple(getfield(lens, :syms)..., s))
-
-function (lens::GetPropertyLens)(strct)
-    syms = getfield(lens, :syms)
-    isempty(syms) && return strct
-    sym = first(syms)
-    return GetPropertyLens(tail(syms))(getproperty(strct, sym))
-end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -2761,7 +2761,7 @@ function destructure_callex(topmod::Module, @nospecialize(ex))
                 push!(args, x)
             end
         end
-    elseif isexpr(ex, :.)   # `x.f`
+    elseif isexpr(ex, :var".")   # `x.f`
         f = GlobalRef(topmod, :getproperty)
         args = flatten(ex.args)
     elseif isexpr(ex, :ref) # `x[i]`
@@ -2769,7 +2769,7 @@ function destructure_callex(topmod::Module, @nospecialize(ex))
         args = flatten(ex.args)
     elseif isexpr(ex, :(=)) # `x.f = v` or `x[i] = v`
         lhs, rhs = ex.args
-        if isexpr(lhs, :.)
+        if isexpr(lhs, :var".")
             f = GlobalRef(topmod, :setproperty!)
             args = flatten(Any[lhs.args..., rhs])
         elseif isexpr(lhs, :ref)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1516,7 +1516,7 @@ const expr_infix_wide = Set{Symbol}([
 const expr_infix = Set{Symbol}([:(:), :(->), :(::)])
 const expr_infix_any = union(expr_infix, expr_infix_wide)
 const expr_calls  = Dict(:call => ('(',')'), :calldecl => ('(',')'),
-                         :ref => ('[',']'), :curly => ('{','}'), :(.) => ('(',')'))
+                         :ref => ('[',']'), :curly => ('{','}'), :var"." => ('(',')'))
 const expr_parens = Dict(:tuple=>('(',')'), :vcat=>('[',']'),
                          :hcat =>('[',']'), :row =>('[',']'), :vect=>('[',']'),
                          :ncat =>('[',']'), :nrow =>('[',']'),
@@ -1769,9 +1769,9 @@ end
 # kw: `=` expressions are parsed with head `kw` in this context
 function show_call(io::IO, head, func, func_args, indent, quote_level, kw::Bool)
     op, cl = expr_calls[head]
-    if (isa(func, Symbol) && func !== :(:) && !(head === :. && isoperator(func))) ||
+    if (isa(func, Symbol) && func !== :(:) && !(head === :var"." && isoperator(func))) ||
             (isa(func, Symbol) && !is_valid_identifier(func)) ||
-            (isa(func, Expr) && (func.head === :. || func.head === :curly || func.head === :macroname)) ||
+            (isa(func, Expr) && (func.head === :var"." || func.head === :curly || func.head === :macroname)) ||
             isa(func, GlobalRef)
         show_unquoted(io, func, indent, 0, quote_level)
     else
@@ -1779,7 +1779,7 @@ function show_call(io::IO, head, func, func_args, indent, quote_level, kw::Bool)
         show_unquoted(io, func, indent, 0, quote_level)
         print(io, ')')
     end
-    if head === :(.)
+    if head === :var"."
         print(io, '.')
     end
     if !isempty(func_args) && isa(func_args[1], Expr) && (func_args[1]::Expr).head === :parameters
@@ -1907,7 +1907,7 @@ function valid_import_path(@nospecialize(ex), allow_as = true)
     if allow_as && is_expr(ex, :as) && length((ex::Expr).args) == 2
         ex = (ex::Expr).args[1]
     end
-    return is_expr(ex, :(.)) && length((ex::Expr).args) > 0 && all(a->isa(a,Symbol), (ex::Expr).args)
+    return is_expr(ex, :var".") && length((ex::Expr).args) > 0 && all(a->isa(a,Symbol), (ex::Expr).args)
 end
 
 function show_import_path(io::IO, ex, quote_level)
@@ -1922,10 +1922,10 @@ function show_import_path(io::IO, ex, quote_level)
             end
             show_import_path(io, ex.args[i], quote_level)
         end
-    elseif ex.head === :(.)
+    elseif ex.head === :var"."
         for i = 1:length(ex.args)
             sym = ex.args[i]::Symbol
-            if sym === :(.)
+            if sym === :var"."
                 print(io, '.')
             else
                 if sym === :(..)
@@ -1946,7 +1946,7 @@ end
 function allow_macroname(ex)
     if (ex isa Symbol && first(string(ex)) == '@') ||
        ex isa GlobalRef ||
-       (is_expr(ex, :(.)) && length(ex.args) == 2 &&
+       (is_expr(ex, :var".") && length(ex.args) == 2 &&
         (is_expr(ex.args[2], :quote) || ex.args[2] isa QuoteNode))
        return Expr(:macroname, ex)
     else
@@ -1978,7 +1978,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
     head, args, nargs = ex.head, ex.args, length(ex.args)
     unhandled = false
     # dot (i.e. "x.y"), but not compact broadcast exps
-    if head === :(.) && (nargs != 2 || !is_expr(args[2], :tuple))
+    if head === :var"." && (nargs != 2 || !is_expr(args[2], :tuple))
         # standalone .op
         if nargs == 1 && args[1] isa Symbol && isoperator(args[1]::Symbol)
             print(io, "(.", args[1], ")")
@@ -1986,7 +1986,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
             item = args[1]
             # field
             field = unquoted(args[2])
-            parens = !is_quoted(item) && !(item isa Symbol && isidentifier(item)) && !is_expr(item, :(.))
+            parens = !is_quoted(item) && !(item isa Symbol && isidentifier(item)) && !is_expr(item, :var".")
             parens && print(io, '(')
             show_unquoted(io, item, indent, 0, quote_level)
             parens && print(io, ')')
@@ -2155,7 +2155,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
 
     # other call-like expressions ("A[1,2]", "T{X,Y}", "f.(X,Y)")
     elseif haskey(expr_calls, head) && nargs >= 1  # :ref/:curly/:calldecl/:(.)
-        funcargslike = head === :(.) ? (args[2]::Expr).args : args[2:end]
+        funcargslike = head === :var"." ? (args[2]::Expr).args : args[2:end]
         show_call(head === :ref ? IOContext(io, beginsym=>true) : io, head, args[1], funcargslike, indent, quote_level, head !== :curly)
 
     # comprehensions
@@ -2334,10 +2334,10 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
             show_sym(io, arg1, allow_macroname=true)
         elseif arg1 isa GlobalRef
             show_globalref(io, arg1, allow_macroname=true)
-        elseif is_expr(arg1, :(.)) && length((arg1::Expr).args) == 2
+        elseif is_expr(arg1, :var".") && length((arg1::Expr).args) == 2
             arg1 = arg1::Expr
             m = arg1.args[1]
-            if m isa Symbol || m isa GlobalRef || is_expr(m, :(.), 2)
+            if m isa Symbol || m isa GlobalRef || is_expr(m, :var".", 2)
                 show_unquoted(io, m)
             else
                 print(io, "(")
@@ -2754,7 +2754,7 @@ resolvebinding(@nospecialize(ex)) = ex
 resolvebinding(ex::QuoteNode) = ex.value
 resolvebinding(ex::Symbol) = resolvebinding(GlobalRef(Main, ex))
 function resolvebinding(ex::Expr)
-    if ex.head === :. && isa(ex.args[2], Symbol)
+    if ex.head === :var"." && isa(ex.args[2], Symbol)
         parent = resolvebinding(ex.args[1])
         if isa(parent, Module)
             return resolvebinding(GlobalRef(parent, ex.args[2]))

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -22,10 +22,10 @@
                `(incomplete ,msg)
                (cons 'error (cdr e))))
          (begin
-           ;;(newline)
-           ;;(display "unexpected error: ")
-           ;;(prn e)
-           ;;(print-stack-trace (stacktrace))
+           (newline)
+           (display "unexpected error: ")
+           (prn e)
+           (print-stack-trace (stacktrace))
            '(error "malformed expression"))))
    thk))
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2439,8 +2439,14 @@
    '|.|
    (lambda (e)
      (if (length= e 2)
-         ;; e = (|.| op)
-         `(call (top BroadcastFunction) ,(cadr e))
+         (let ((oplens (cadr e)))
+           (if (symbol? oplens)
+            ;; e = (|.| op)
+            `(call (top BroadcastFunction) ,oplens)
+            ;; e = (|.| lens)
+            (if (eq? (car oplens) '|.|)
+              (expand-fuse-broadcast '() `(|.| (|.| (call (top getproperty)) ,(cadr oplens)) ,(caddr oplens)))
+              (expand-fuse-broadcast '() `(|.| (call (top getproperty)) ,oplens)))))
          ;; e = (|.| f x)
          (expand-fuse-broadcast '() e)))
 
@@ -2624,7 +2630,7 @@
            (cond ((dotop-named? f)
                   (expand-fuse-broadcast '() `(|.| ,(undotop f) (tuple ,@(cddr e)))))
                  ;; "(.op)(...)"
-                 ((and (length= f 2) (eq? (car f) '|.|))
+                 ((and (length= f 2) (eq? (car f) '|.|) (symbol? (cadr f)))
                   (expand-fuse-broadcast '() `(|.| ,(cadr f) (tuple ,@(cddr e)))))
                  ((eq? f 'ccall)
                   (if (not (length> e 4)) (error "too few arguments to ccall"))


### PR DESCRIPTION
This PR adds support for parsing `.a` as `x->x.a`. This kind of thing has come up multiple times in the past, but I'm currently finding myself doing a lot of work on nested structs where this operation is very common.

In general, we've had the position that this kind of thing should be a special case of the short-currying syntax (e.g. #38713), but I actually think that might be a false constraint. In particular, `.a` is a bit of a worst case for the curry syntax. If there is no requirement for `.a` to be excessively short in an eventual underscore curry syntax, I think that could open more options.

That said, any syntax proposal of course needs to stand on its own, so let me motivate the cases where I think this plays:

# Motivation 
## Curried getfield

I think this is probably the most obvious and often requested. The syntax here is very useful for situations where higher order functions operate on collections of records:

1. `map(.a, vec)` and reductions for getting the fields of an object - also includes things like `sum(.price, items)`
2. Predicates like `sort(vecs, by=.x)` or `filter(!(.deleted), entries)`
3. In pipelines `vecs |> .x |> sqrt |> sum`

I think that's mostly what people are thinking of, but the use case for this syntax is more general.

## A syntax for lenses

Packages like Accessors.jl provide lens-like abstractions. Currently these are written as `lens = @optic _.a`. An example use of Accessors.jl is (from their documentation)
```
julia> modify(lowercase, (;a="AA", b="BB"), @optic _.a)
T("aa", "BB")
```

This PR can be thought of as providing lenses first class syntax, as in:
```
julia> modify(lowercase, (;a="AA", b="BB"), .a)
T("aa", "BB")
```

## Symbol index generalization to hierarchical structures

We have a lot of packages in the ecosystem that support named axes of various forms (Canonical examples might be DataFrames and NamedArrays, but there's probably two dozen of these). Generally the way that this syntax works is that people use quoted symbols for indexing:

```
df[5, :col]
```

However, this breaks down when there is hierachical composition involved. For example, for simulation models, you often build parameter sets and solutions out of hierarchies of simpler models.

There's a couple of solutions that people have come up with for this problem:
1. Some packages parse out hierachy from symbol names: `sol[:var"my.nested.hierachy.state"]`
2. Other packages have a global root object: `sol[○.my.nested.hierarchy.state]` 2a. A variant of this is using the object as its own root `sol[sol.my.nested.hierarchy.state]` 2b. Yet another variant is having the root object be context specific `sol[sys.my.nested.hierarchy.state]`
3. Yet other packages put symbolic names into the global namespaces `sol[my.nested.hierarchy.state]`

These solutions are all lacking. 1 requires string manipulation for composition, the various variants of 2 are ok, but there is no agreement among packages what the root object looks like or is spelled, and even so, it's an extra export and 3 pollutes the global namespaces.

By using the same mechanism here, we essentially standardize the solution `2`, but make the root object implicit.`

# Additional considerations

- As mentioned above, this was previously argued to be a special case of underscore currying. Esp if used for the other use cases above (which don't necessarily use this applicatively), I don't think that's necessarily dispositive, but as always it's better to add one syntax rather than two.

- This is of course also related to the long-standing (almost 10 years - oh no) issue of "mutating immutables" (ref #11902). I think this makes sense independent of any proposal there, but it's worth thinking about.

- Every once in a while people request broadcasted getproperty along the lines of `vec..a`. This of course provides that with `(.a).(vec)`. I had briefly explored not requiring the parentheses, along the lines of `.a.(vec)`, but it didn't feel right when I played with it, so this PR explicitly reserves that syntax.

!!! note
This only provides an flisp implementation for people to play around with. As such, this needs `JULIA_USE_FLISP_PARSER=true`. I will provide a JuliaSyntax implementation once there's consensus on semantics.