### PR TITLE
Add missing methods for UniformScaling

### DIFF
--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-import Base: copy, adjoint, getindex, show, transpose, one, zero, inv,
+import Base: copy, adjoint, getindex, show, transpose, one, zero, inv, float,
              hcat, vcat, hvcat, ^
 
 """
@@ -124,6 +124,8 @@ conj(J::UniformScaling) = UniformScaling(conj(J.λ))
 real(J::UniformScaling) = UniformScaling(real(J.λ))
 imag(J::UniformScaling) = UniformScaling(imag(J.λ))
 
+float(J::UniformScaling) = UniformScaling(float(J.λ))
+
 transpose(J::UniformScaling) = J
 adjoint(J::UniformScaling) = UniformScaling(conj(J.λ))
 
@@ -159,7 +161,7 @@ isposdef(J::UniformScaling) = isposdef(J.λ)
 (-)(A::AbstractMatrix, J::UniformScaling)   = A + (-J)
 
 # matrix functions
-for f in ( :exp,   :log,
+for f in ( :exp,   :log, :cis,
            :expm1, :log1p,
            :sqrt,  :cbrt,
            :sin,   :cos,   :tan,
@@ -171,6 +173,9 @@ for f in ( :exp,   :log,
            :csch,  :sech,  :coth,
            :acsch, :asech, :acoth )
     @eval Base.$f(J::UniformScaling) = UniformScaling($f(J.λ))
+end
+for f in (:sincos, :sincosd)
+    @eval Base.$f(J::UniformScaling) = map(UniformScaling, $f(J.λ))
 end
 
 # Unit{Lower/Upper}Triangular matrices become {Lower/Upper}Triangular under

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -24,6 +24,7 @@ Random.seed!(1234543)
     @test -one(UniformScaling(2)) == UniformScaling(-1)
     @test opnorm(UniformScaling(1+im)) ≈ sqrt(2)
     @test convert(UniformScaling{Float64}, 2I) === 2.0I
+    @test float(2I) === 2.0*I
 end
 
 @testset "getindex" begin
@@ -67,7 +68,7 @@ end
 
     # on complex plane
     J = UniformScaling(randn(ComplexF64))
-    for f in ( exp,   log,
+    for f in ( exp,   log, cis,
                sqrt,
                sin,   cos,   tan,
                asin,  acos,  atan,
@@ -78,6 +79,10 @@ end
                csch,  sech,  coth,
                acsch, asech, acoth )
         @test f(J) ≈ f(M(J))
+    end
+
+    for f in (sincos, sincosd)
+        @test all(splat(≈), zip(f(J), f(M(J))))
     end
 
     # on real axis


### PR DESCRIPTION
The methods `float`, `cis`, `sincos` and `sincosd` are defined for matrices, so it makes sense for these to be defined for a `UniformScaling` as well.
E.g.:
```julia
julia> float(2I)
UniformScaling{Float64}
2.0*I

julia> sincos(2I)
(UniformScaling{Float64}(0.9092974268256817), UniformScaling{Float64}(-0.4161468365471424))
```