### PR TITLE
Fix #52989: DateTime parser would return an error when parsing a year string

### DIFF
--- a/stdlib/Dates/src/parse.jl
+++ b/stdlib/Dates/src/parse.jl
@@ -207,7 +207,7 @@ function Base.parse(::Type{DateTime}, s::AbstractString, df::typeof(ISODateTimeF
     let val = tryparsenext_base10(s, i, end_pos, 1)
         val === nothing && @goto error
         dy, i = val
-        i > end_pos && @goto error
+        i > end_pos && @goto done
     end
 
     c, i = iterate(s, i)::Tuple{Char, Int}

--- a/stdlib/Dates/test/io.jl
+++ b/stdlib/Dates/test/io.jl
@@ -470,6 +470,9 @@ end
 # Issue #44003
 @test tryparse(Dates.Date, "2017", Dates.DateFormat(".s")) === nothing
 
+# Issue #52989
+@test Dates.DateTime("2000") == Dates.DateTime(2000)
+
 @testset "parse milliseconds, Issue #22100" begin
     @test Dates.DateTime("2017-Mar-17 00:00:00.0000", "y-u-d H:M:S.s") == Dates.DateTime(2017, 3, 17)
     @test Dates.parse_components(".1", Dates.DateFormat(".s")) == [Dates.Millisecond(100)]


### PR DESCRIPTION
Fix #52989.
Originally checked on version 1.10.0 but still relevant in the current version in master

Bug: When executing the method DateTime to create a DateTime value with a string input only containing a year (ex: "2000") the method returns an 'ArgumentError: Invalid DateTime string' when it should, from what I understood, return a DateTime like 2000-01-01T00:00:00 seeing as if you call the same method with a number indicating a year (ex: 2000) the method returns correctly.

Fix: The fix was simple, on the first tryparsenext_base10 block (line 207-211) where a year is parsed from the string the exit condition i > end_pos should jump into 'done' so it returns a correct value instead of 'error'