### PR TITLE
TOML: Improve type-stability of BigInt/UInt support

### DIFF
--- a/base/toml_parser.jl
+++ b/base/toml_parser.jl
@@ -1114,7 +1114,7 @@ function _parse_local_time(l::Parser, skip_hour=false)::Err{NTuple{4, Int64}}
         end
         # DateTime in base only manages 3 significant digits in fractional
         # second
-        fractional_second = parse_int(l, false)
+        fractional_second = parse_int(l, false)::Int64
         # Truncate off the rest eventual digits
         accept_batch(l, isdigit)
     end

--- a/base/toml_parser.jl
+++ b/base/toml_parser.jl
@@ -854,7 +854,7 @@ function parse_number_or_date_start(l::Parser)
     ate, contains_underscore = @try accept_batch_underscore(l, isdigit, readed_zero)
     read_underscore |= contains_underscore
     if (read_digit || ate) && ok_end_value(peek(l))
-        return parse_int(l, contains_underscore)
+        return parse_integer(l, contains_underscore)
     end
     # Done with integers here
 
@@ -904,7 +904,18 @@ function parse_float(l::Parser, contains_underscore)::Err{Float64}
     return v
 end
 
-for (name, T1, T2, n1, n2) in (("int", Int64,  Int128,  17,  33),
+function parse_int(l::Parser, contains_underscore, base=nothing)::Err{Int64}
+    s = take_string_or_substring(l, contains_underscore)
+    v = try
+        Base.parse(Int64, s; base=base)
+    catch e
+        e isa Base.OverflowError && return(ParserError(ErrOverflowError))
+        error("internal parser error: did not correctly discredit $(repr(s)) as an int")
+    end
+    return v
+end
+
+for (name, T1, T2, n1, n2) in (("integer", Int64,  Int128,  17,  33),
                                ("hex", UInt64, UInt128, 18,  34),
                                ("oct", UInt64, UInt128, 24,  45),
                                ("bin", UInt64, UInt128, 66, 130),


### PR DESCRIPTION
From a type-stability perspective, this restores a lot of our behavior before #47903.

As it turns out, 10 of the 11 uses of `parse_int` (now called `parse_integer`) introduced in that PR are unnecessary since the TOML format already requires the parsed value to be within a very limited range.

Note that this change does not actually revert any functionality (in contrast to #49576)