### PR TITLE
Throw `ConcurrencyViolationError` on `yield` with `current_task`

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -1095,8 +1095,6 @@ end
 
 # yield to a task, throwing an exception in it
 function throwto(t::Task, @nospecialize exc)
-    current = current_task()
-    t === current && throw(ConcurrencyViolationError("Cannot throw an exception to the currently running task!"))
     t.result = exc
     t._isexception = true
     set_next_task(t)

--- a/base/task.jl
+++ b/base/task.jl
@@ -1040,11 +1040,15 @@ end
 
 A fast, unfair-scheduling version of `schedule(t, arg); yield()` which
 immediately yields to `t` before calling the scheduler.
+
+Throws a `ConcurrencyViolationError` if `t` is the currently running task.
 """
 function yield(t::Task, @nospecialize(x=nothing))
-    (t._state === task_state_runnable && t.queue === nothing) || error("yield: Task not runnable")
+    current = current_task()
+    t === current && throw(ConcurrencyViolationError("Cannot yield to currently running task!"))
+    (t._state === task_state_runnable && t.queue === nothing) || throw(ConcurrencyViolationError("yield: Task not runnable"))
     t.result = x
-    enq_work(current_task())
+    enq_work(current)
     set_next_task(t)
     return try_yieldto(ensure_rescheduled)
 end
@@ -1091,6 +1095,8 @@ end
 
 # yield to a task, throwing an exception in it
 function throwto(t::Task, @nospecialize exc)
+    current = current_task()
+    t === current && throw(ConcurrencyViolationError("Cannot throw an exception to the currently running task!"))
     t.result = exc
     t._isexception = true
     set_next_task(t)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -254,12 +254,12 @@ end
 @test_throws ErrorException("deadlock detected: cannot wait on current task") wait(current_task())
 
 @test_throws ConcurrencyViolationError("Cannot yield to currently running task!") yield(current_task())
-@test_throws ConcurrencyViolationError("Cannot throw an exception to the currently running task!") throwto(current_task(), ArgumentError())
+@test_throws ConcurrencyViolationError("Cannot throw an exception to the currently running task!") Base.throwto(current_task(), ArgumentError())
 
 # issue #41347
 let t = @async 1
     wait(t)
-    @test_throws ErrorException yield(t)
+    @test_throws ConcurrencyViolationError yield(t)
 end
 
 let t = @async error(42)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -253,6 +253,9 @@ end
 
 @test_throws ErrorException("deadlock detected: cannot wait on current task") wait(current_task())
 
+@test_throws ConcurrencyViolationError("Cannot yield to currently running task!") yield(current_task())
+@test_throws ConcurrencyViolationError("Cannot throw an exception to the currently running task!") throwto(current_task(), ArgumentError())
+
 # issue #41347
 let t = @async 1
     wait(t)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -254,7 +254,6 @@ end
 @test_throws ErrorException("deadlock detected: cannot wait on current task") wait(current_task())
 
 @test_throws ConcurrencyViolationError("Cannot yield to currently running task!") yield(current_task())
-@test_throws ConcurrencyViolationError("Cannot throw an exception to the currently running task!") Base.throwto(current_task(), ArgumentError())
 
 # issue #41347
 let t = @async 1


### PR DESCRIPTION
Previously, this errored with a nasty type assert *somewhere* in the runtime. Throwing a proper `ConcurrencyViolationError` allows this to be debugged, and makes the error condition known.