### PR TITLE
LinearAlgebra: LazyString in interpolated error messages

### DIFF
--- a/stdlib/LinearAlgebra/src/abstractq.jl
+++ b/stdlib/LinearAlgebra/src/abstractq.jl
@@ -149,13 +149,13 @@ end
 # generically, treat AbstractQ like a matrix with its definite size
 qsize_check(Q::AbstractQ, B::AbstractVecOrMat) =
     size(Q, 2) == size(B, 1) ||
-        throw(DimensionMismatch("second dimension of Q, $(size(Q,2)), must coincide with first dimension of B, $(size(B,1))"))
+        throw(DimensionMismatch(lazy"second dimension of Q, $(size(Q,2)), must coincide with first dimension of B, $(size(B,1))"))
 qsize_check(A::AbstractVecOrMat, Q::AbstractQ) =
     size(A, 2) == size(Q, 1) ||
-        throw(DimensionMismatch("second dimension of A, $(size(A,2)), must coincide with first dimension of Q, $(size(Q,1))"))
+        throw(DimensionMismatch(lazy"second dimension of A, $(size(A,2)), must coincide with first dimension of Q, $(size(Q,1))"))
 qsize_check(Q::AbstractQ, P::AbstractQ) =
     size(Q, 2) == size(P, 1) ||
-        throw(DimensionMismatch("second dimension of A, $(size(Q,2)), must coincide with first dimension of B, $(size(P,1))"))
+        throw(DimensionMismatch(lazy"second dimension of A, $(size(Q,2)), must coincide with first dimension of B, $(size(P,1))"))
 
 # mimic the AbstractArray fallback
 *(Q::AbstractQ{<:Number}) = Q
@@ -317,7 +317,7 @@ function lmul!(A::QRPackedQ, B::AbstractVecOrMat)
     mA, nA = size(A.factors)
     mB, nB = size(B,1), size(B,2)
     if mA != mB
-        throw(DimensionMismatch("matrix A has dimensions ($mA,$nA) but B has dimensions ($mB, $nB)"))
+        throw(DimensionMismatch(lazy"matrix A has dimensions ($mA,$nA) but B has dimensions ($mB, $nB)"))
     end
     Afactors = A.factors
     @inbounds begin
@@ -353,7 +353,7 @@ function lmul!(adjA::AdjointQ{<:Any,<:QRPackedQ}, B::AbstractVecOrMat)
     mA, nA = size(A.factors)
     mB, nB = size(B,1), size(B,2)
     if mA != mB
-        throw(DimensionMismatch("matrix A has dimensions ($mA,$nA) but B has dimensions ($mB, $nB)"))
+        throw(DimensionMismatch(lazy"matrix A has dimensions ($mA,$nA) but B has dimensions ($mB, $nB)"))
     end
     Afactors = A.factors
     @inbounds begin
@@ -384,7 +384,7 @@ function rmul!(A::AbstractVecOrMat, Q::QRPackedQ)
     mQ, nQ = size(Q.factors)
     mA, nA = size(A,1), size(A,2)
     if nA != mQ
-        throw(DimensionMismatch("matrix A has dimensions ($mA,$nA) but matrix Q has dimensions ($mQ, $nQ)"))
+        throw(DimensionMismatch(lazy"matrix A has dimensions ($mA,$nA) but matrix Q has dimensions ($mQ, $nQ)"))
     end
     Qfactors = Q.factors
     @inbounds begin
@@ -420,7 +420,7 @@ function rmul!(A::AbstractVecOrMat, adjQ::AdjointQ{<:Any,<:QRPackedQ})
     mQ, nQ = size(Q.factors)
     mA, nA = size(A,1), size(A,2)
     if nA != mQ
-        throw(DimensionMismatch("matrix A has dimensions ($mA,$nA) but matrix Q has dimensions ($mQ, $nQ)"))
+        throw(DimensionMismatch(lazy"matrix A has dimensions ($mA,$nA) but matrix Q has dimensions ($mQ, $nQ)"))
     end
     Qfactors = Q.factors
     @inbounds begin
@@ -521,10 +521,10 @@ rmul!(X::Adjoint{T,<:StridedVecOrMat{T}}, adjQ::AdjointQ{<:Any,<:HessenbergQ{T}}
 # flexible left-multiplication (and adjoint right-multiplication)
 qsize_check(Q::Union{QRPackedQ,QRCompactWYQ,HessenbergQ}, B::AbstractVecOrMat) =
     size(B, 1) in size(Q.factors) ||
-        throw(DimensionMismatch("first dimension of B, $(size(B,1)), must equal one of the dimensions of Q, $(size(Q.factors))"))
+        throw(DimensionMismatch(lazy"first dimension of B, $(size(B,1)), must equal one of the dimensions of Q, $(size(Q.factors))"))
 qsize_check(A::AbstractVecOrMat, adjQ::AdjointQ{<:Any,<:Union{QRPackedQ,QRCompactWYQ,HessenbergQ}}) =
     (Q = adjQ.Q; size(A, 2) in size(Q.factors) ||
-        throw(DimensionMismatch("second dimension of A, $(size(A,2)), must equal one of the dimensions of Q, $(size(Q.factors))")))
+        throw(DimensionMismatch(lazy"second dimension of A, $(size(A,2)), must equal one of the dimensions of Q, $(size(Q.factors))")))
 
 det(Q::HessenbergQ) = _det_tau(Q.τ)
 
@@ -560,10 +560,10 @@ size(Q::LQPackedQ) = (n = size(Q.factors, 2); return n, n)
 
 qsize_check(adjQ::AdjointQ{<:Any,<:LQPackedQ}, B::AbstractVecOrMat) =
     size(B, 1) in size(adjQ.Q.factors) ||
-        throw(DimensionMismatch("first dimension of B, $(size(B,1)), must equal one of the dimensions of Q, $(size(adjQ.Q.factors))"))
+        throw(DimensionMismatch(lazy"first dimension of B, $(size(B,1)), must equal one of the dimensions of Q, $(size(adjQ.Q.factors))"))
 qsize_check(A::AbstractVecOrMat, Q::LQPackedQ) =
     size(A, 2) in size(Q.factors) ||
-        throw(DimensionMismatch("second dimension of A, $(size(A,2)), must equal one of the dimensions of Q, $(size(Q.factors))"))
+        throw(DimensionMismatch(lazy"second dimension of A, $(size(A,2)), must equal one of the dimensions of Q, $(size(Q.factors))"))
 
 # in-place right-application of LQPackedQs
 # these methods require that the applied-to matrix's (A's) number of columns

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -465,7 +465,7 @@ tr(A::Transpose) = transpose(tr(parent(A)))
 function _dot_nonrecursive(u, v)
     lu = length(u)
     if lu != length(v)
-        throw(DimensionMismatch("first array has length $(lu) which does not match the length of the second, $(length(v))."))
+        throw(DimensionMismatch(lazy"first array has length $(lu) which does not match the length of the second, $(length(v))."))
     end
     if lu == 0
         zero(eltype(u)) * zero(eltype(v))

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -8,7 +8,7 @@ struct Bidiagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
     function Bidiagonal{T,V}(dv, ev, uplo::AbstractChar) where {T,V<:AbstractVector{T}}
         require_one_based_indexing(dv, ev)
         if length(ev) != max(length(dv)-1, 0)
-            throw(DimensionMismatch("length of diagonal vector is $(length(dv)), length of off-diagonal vector is $(length(ev))"))
+            throw(DimensionMismatch(lazy"length of diagonal vector is $(length(dv)), length of off-diagonal vector is $(length(ev))"))
         end
         (uplo != 'U' && uplo != 'L') && throw_uplo()
         new{T,V}(dv, ev, uplo)
@@ -438,11 +438,11 @@ function check_A_mul_B!_sizes(C, A, B)
     mB, nB = size(B)
     mC, nC = size(C)
     if mA != mC
-        throw(DimensionMismatch("first dimension of A, $mA, and first dimension of output C, $mC, must match"))
+        throw(DimensionMismatch(lazy"first dimension of A, $mA, and first dimension of output C, $mC, must match"))
     elseif nA != mB
-        throw(DimensionMismatch("second dimension of A, $nA, and first dimension of B, $mB, must match"))
+        throw(DimensionMismatch(lazy"second dimension of A, $nA, and first dimension of B, $mB, must match"))
     elseif nB != nC
-        throw(DimensionMismatch("second dimension of output C, $nC, and second dimension of B, $nB, must match"))
+        throw(DimensionMismatch(lazy"second dimension of output C, $nC, and second dimension of B, $nB, must match"))
     end
 end
 
@@ -562,10 +562,10 @@ function _mul!(C::AbstractVecOrMat, A::BiTriSym, B::AbstractVecOrMat, _add::MulA
     nA = size(A,1)
     nB = size(B,2)
     if !(size(C,1) == size(B,1) == nA)
-        throw(DimensionMismatch("A has first dimension $nA, B has $(size(B,1)), C has $(size(C,1)) but all must match"))
+        throw(DimensionMismatch(lazy"A has first dimension $nA, B has $(size(B,1)), C has $(size(C,1)) but all must match"))
     end
     if size(C,2) != nB
-        throw(DimensionMismatch("A has second dimension $nA, B has $(size(B,2)), C has $(size(C,2)) but all must match"))
+        throw(DimensionMismatch(lazy"A has second dimension $nA, B has $(size(B,2)), C has $(size(C,2)) but all must match"))
     end
     iszero(nA) && return C
     iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
@@ -763,11 +763,11 @@ function ldiv!(c::AbstractVecOrMat, A::Bidiagonal, b::AbstractVecOrMat)
     N = size(A, 2)
     mb, nb = size(b, 1), size(b, 2)
     if N != mb
-        throw(DimensionMismatch("second dimension of A, $N, does not match first dimension of b, $mb"))
+        throw(DimensionMismatch(lazy"second dimension of A, $N, does not match first dimension of b, $mb"))
     end
     mc, nc = size(c, 1), size(c, 2)
     if mc != mb || nc != nb
-        throw(DimensionMismatch("size of result, ($mc, $nc), does not match the size of b, ($mb, $nb)"))
+        throw(DimensionMismatch(lazy"size of result, ($mc, $nc), does not match the size of b, ($mb, $nb)"))
     end
 
     if N == 0
@@ -833,11 +833,11 @@ function _rdiv!(C::AbstractMatrix, A::AbstractMatrix, B::Bidiagonal)
     require_one_based_indexing(C, A, B)
     m, n = size(A)
     if size(B, 1) != n
-        throw(DimensionMismatch("right hand side B needs first dimension of size $n, has size $(size(B,1))"))
+        throw(DimensionMismatch(lazy"right hand side B needs first dimension of size $n, has size $(size(B,1))"))
     end
     mc, nc = size(C)
     if mc != m || nc != n
-        throw(DimensionMismatch("expect output to have size ($m, $n), but got ($mc, $nc)"))
+        throw(DimensionMismatch(lazy"expect output to have size ($m, $n), but got ($mc, $nc)"))
     end
 
     zi = findfirst(iszero, B.dv)

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -336,7 +336,7 @@ function diagm_size(size::Tuple{Int,Int}, kv::Pair{<:Integer,<:AbstractVector}..
     mmax = mapreduce(x -> length(x.second) - min(0,Int(x.first)), max, kv; init=0)
     nmax = mapreduce(x -> length(x.second) + max(0,Int(x.first)), max, kv; init=0)
     m, n = size
-    (m ≥ mmax && n ≥ nmax) || throw(DimensionMismatch("invalid size=$size"))
+    (m ≥ mmax && n ≥ nmax) || throw(DimensionMismatch(lazy"invalid size=$size"))
     return m, n
 end
 function diagm_container(size, kv::Pair{<:Integer,<:AbstractVector}...)
@@ -1645,7 +1645,7 @@ function cond(A::AbstractMatrix, p::Real=2)
             end
         end
     end
-    throw(ArgumentError("p-norm must be 1, 2 or Inf, got $p"))
+    throw(ArgumentError(lazy"p-norm must be 1, 2 or Inf, got $p"))
 end
 
 ## Lyapunov and Sylvester equation

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -191,7 +191,7 @@ function setindex!(D::Diagonal, v, i::Int, j::Int)
     if i == j
         @inbounds D.diag[i] = v
     elseif !iszero(v)
-        throw(ArgumentError("cannot set off-diagonal entry ($i, $j) to a nonzero value ($v)"))
+        throw(ArgumentError(lazy"cannot set off-diagonal entry ($i, $j) to a nonzero value ($v)"))
     end
     return v
 end
@@ -280,13 +280,13 @@ Base.literal_pow(::typeof(^), D::Diagonal, ::Val{-1}) = inv(D) # for disambiguat
 function _muldiag_size_check(A, B)
     nA = size(A, 2)
     mB = size(B, 1)
-    @noinline throw_dimerr(::AbstractMatrix, nA, mB) = throw(DimensionMismatch("second dimension of A, $nA, does not match first dimension of B, $mB"))
-    @noinline throw_dimerr(::AbstractVector, nA, mB) = throw(DimensionMismatch("second dimension of D, $nA, does not match length of V, $mB"))
+    @noinline throw_dimerr(::AbstractMatrix, nA, mB) = throw(DimensionMismatch(lazy"second dimension of A, $nA, does not match first dimension of B, $mB"))
+    @noinline throw_dimerr(::AbstractVector, nA, mB) = throw(DimensionMismatch(lazy"second dimension of D, $nA, does not match length of V, $mB"))
     nA == mB || throw_dimerr(B, nA, mB)
     return nothing
 end
 # the output matrix should have the same size as the non-diagonal input matrix or vector
-@noinline throw_dimerr(szC, szA) = throw(DimensionMismatch("output matrix has size: $szC, but should have size $szA"))
+@noinline throw_dimerr(szC, szA) = throw(DimensionMismatch(lazy"output matrix has size: $szC, but should have size $szA"))
 _size_check_out(C, ::Diagonal, A) = _size_check_out(C, A)
 _size_check_out(C, A, ::Diagonal) = _size_check_out(C, A)
 _size_check_out(C, A::Diagonal, ::Diagonal) = _size_check_out(C, A)
@@ -432,7 +432,7 @@ function _rdiv!(B::AbstractVecOrMat, A::AbstractVecOrMat, D::Diagonal)
     dd = D.diag
     m, n = size(A, 1), size(A, 2)
     if (k = length(dd)) != n
-        throw(DimensionMismatch("left hand side has $n columns but D is $k by $k"))
+        throw(DimensionMismatch(lazy"left hand side has $n columns but D is $k by $k"))
     end
     @inbounds for j in 1:n
         ddj = dd[j]
@@ -458,8 +458,8 @@ function ldiv!(B::AbstractVecOrMat, D::Diagonal, A::AbstractVecOrMat)
     d = length(dd)
     m, n = size(A, 1), size(A, 2)
     m′, n′ = size(B, 1), size(B, 2)
-    m == d || throw(DimensionMismatch("right hand side has $m rows but D is $d by $d"))
-    (m, n) == (m′, n′) || throw(DimensionMismatch("expect output to be $m by $n, but got $m′ by $n′"))
+    m == d || throw(DimensionMismatch(lazy"right hand side has $m rows but D is $d by $d"))
+    (m, n) == (m′, n′) || throw(DimensionMismatch(lazy"expect output to be $m by $n, but got $m′ by $n′"))
     j = findfirst(iszero, D.diag)
     isnothing(j) || throw(SingularException(j))
     @inbounds for j = 1:n, i = 1:m
@@ -470,7 +470,7 @@ end
 
 function _rdiv!(Dc::Diagonal, Db::Diagonal, Da::Diagonal)
     n, k = length(Db.diag), length(Da.diag)
-    n == k || throw(DimensionMismatch("left hand side has $n columns but D is $k by $k"))
+    n == k || throw(DimensionMismatch(lazy"left hand side has $n columns but D is $k by $k"))
     j = findfirst(iszero, Da.diag)
     isnothing(j) || throw(SingularException(j))
     Dc.diag .= Db.diag ./ Da.diag
@@ -498,10 +498,10 @@ function ldiv!(T::Tridiagonal, D::Diagonal, S::Union{SymTridiagonal,Tridiagonal}
     m = size(S, 1)
     dd = D.diag
     if (k = length(dd)) != m
-        throw(DimensionMismatch("diagonal matrix is $k by $k but right hand side has $m rows"))
+        throw(DimensionMismatch(lazy"diagonal matrix is $k by $k but right hand side has $m rows"))
     end
     if length(T.d) != m
-        throw(DimensionMismatch("target matrix size $(size(T)) does not match input matrix size $(size(S))"))
+        throw(DimensionMismatch(lazy"target matrix size $(size(T)) does not match input matrix size $(size(S))"))
     end
     m == 0 && return T
     j = findfirst(iszero, dd)
@@ -535,10 +535,10 @@ function _rdiv!(T::Tridiagonal, S::Union{SymTridiagonal,Tridiagonal}, D::Diagona
     n = size(S, 2)
     dd = D.diag
     if (k = length(dd)) != n
-        throw(DimensionMismatch("left hand side has $n columns but D is $k by $k"))
+        throw(DimensionMismatch(lazy"left hand side has $n columns but D is $k by $k"))
     end
     if length(T.d) != n
-        throw(DimensionMismatch("target matrix size $(size(T)) does not match input matrix size $(size(S))"))
+        throw(DimensionMismatch(lazy"target matrix size $(size(T)) does not match input matrix size $(size(S))"))
     end
     n == 0 && return T
     j = findfirst(iszero, dd)
@@ -608,7 +608,7 @@ end
     valB = B.diag; nB = length(valB)
     nC = checksquare(C)
     @boundscheck nC == nA*nB ||
-        throw(DimensionMismatch("expect C to be a $(nA*nB)x$(nA*nB) matrix, got size $(nC)x$(nC)"))
+        throw(DimensionMismatch(lazy"expect C to be a $(nA*nB)x$(nA*nB) matrix, got size $(nC)x$(nC)"))
     isempty(A) || isempty(B) || fill!(C, zero(A[1,1] * B[1,1]))
     @inbounds for i = 1:nA, j = 1:nB
         idx = (i-1)*nB+j
@@ -639,7 +639,7 @@ end
     (mB, nB) = size(B)
     (mC, nC) = size(C)
     @boundscheck (mC, nC) == (mA * mB, nA * nB) ||
-        throw(DimensionMismatch("expect C to be a $(mA * mB)x$(nA * nB) matrix, got size $(mC)x$(nC)"))
+        throw(DimensionMismatch(lazy"expect C to be a $(mA * mB)x$(nA * nB) matrix, got size $(mC)x$(nC)"))
     isempty(A) || isempty(B) || fill!(C, zero(A[1,1] * B[1,1]))
     m = 1
     @inbounds for j = 1:nA
@@ -662,7 +662,7 @@ end
     (mB, nB) = size(B)
     (mC, nC) = size(C)
     @boundscheck (mC, nC) == (mA * mB, nA * nB) ||
-        throw(DimensionMismatch("expect C to be a $(mA * mB)x$(nA * nB) matrix, got size $(mC)x$(nC)"))
+        throw(DimensionMismatch(lazy"expect C to be a $(mA * mB)x$(nA * nB) matrix, got size $(mC)x$(nC)"))
     isempty(A) || isempty(B) || fill!(C, zero(A[1,1] * B[1,1]))
     m = 1
     @inbounds for j = 1:nA
@@ -875,7 +875,7 @@ dot(x::AbstractVector, D::Diagonal, y::AbstractVector) = _mapreduce_prod(dot, x,
 
 dot(A::Diagonal, B::Diagonal) = dot(A.diag, B.diag)
 function dot(D::Diagonal, B::AbstractMatrix)
-    size(D) == size(B) || throw(DimensionMismatch("Matrix sizes $(size(D)) and $(size(B)) differ"))
+    size(D) == size(B) || throw(DimensionMismatch(lazy"Matrix sizes $(size(D)) and $(size(B)) differ"))
     return dot(D.diag, view(B, diagind(B, IndexStyle(B))))
 end
 
@@ -883,7 +883,7 @@ dot(A::AbstractMatrix, B::Diagonal) = conj(dot(B, A))
 
 function _mapreduce_prod(f, x, D::Diagonal, y)
     if !(length(x) == length(D.diag) == length(y))
-        throw(DimensionMismatch("x has length $(length(x)), D has size $(size(D)), and y has $(length(y))"))
+        throw(DimensionMismatch(lazy"x has length $(length(x)), D has size $(size(D)), and y has $(length(y))"))
     end
     if isempty(x) && isempty(D) && isempty(y)
         return zero(promote_op(f, eltype(x), eltype(D), eltype(y)))

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -110,7 +110,7 @@ end
 
 function generic_mul!(C::AbstractArray, X::AbstractArray, s::Number, _add::MulAddMul)
     if length(C) != length(X)
-        throw(DimensionMismatch("first array has length $(length(C)) which does not match the length of the second, $(length(X))."))
+        throw(DimensionMismatch(lazy"first array has length $(length(C)) which does not match the length of the second, $(length(X))."))
     end
     for (IC, IX) in zip(eachindex(C), eachindex(X))
         @inbounds _modify!(_add, X[IX] * s, C, IC)
@@ -120,7 +120,7 @@ end
 
 function generic_mul!(C::AbstractArray, s::Number, X::AbstractArray, _add::MulAddMul)
     if length(C) != length(X)
-        throw(DimensionMismatch("first array has length $(length(C)) which does not
+        throw(DimensionMismatch(lazy"first array has length $(length(C)) which does not
 match the length of the second, $(length(X))."))
     end
     for (IC, IX) in zip(eachindex(C), eachindex(X))
@@ -748,7 +748,7 @@ function opnorm(A::AbstractMatrix, p::Real=2)
     elseif p == Inf
         return opnormInf(A)
     else
-        throw(ArgumentError("invalid p-norm p=$p. Valid: 1, 2, Inf"))
+        throw(ArgumentError(lazy"invalid p-norm p=$p. Valid: 1, 2, Inf"))
     end
 end
 
@@ -886,7 +886,7 @@ dot(x::Number, y::Number) = conj(x) * y
 function dot(x::AbstractArray, y::AbstractArray)
     lx = length(x)
     if lx != length(y)
-        throw(DimensionMismatch("first array has length $(lx) which does not match the length of the second, $(length(y))."))
+        throw(DimensionMismatch(lazy"first array has length $(lx) which does not match the length of the second, $(length(y))."))
     end
     if lx == 0
         return dot(zero(eltype(x)), zero(eltype(y)))
@@ -1464,7 +1464,7 @@ julia> axpy!(2, x, y)
 function axpy!(α, x::AbstractArray, y::AbstractArray)
     n = length(x)
     if n != length(y)
-        throw(DimensionMismatch("x has length $n, but y has length $(length(y))"))
+        throw(DimensionMismatch(lazy"x has length $n, but y has length $(length(y))"))
     end
     iszero(α) && return y
     for (IY, IX) in zip(eachindex(y), eachindex(x))
@@ -1475,7 +1475,7 @@ end
 
 function axpy!(α, x::AbstractArray, rx::AbstractArray{<:Integer}, y::AbstractArray, ry::AbstractArray{<:Integer})
     if length(rx) != length(ry)
-        throw(DimensionMismatch("rx has length $(length(rx)), but ry has length $(length(ry))"))
+        throw(DimensionMismatch(lazy"rx has length $(length(rx)), but ry has length $(length(ry))"))
     elseif !checkindex(Bool, eachindex(IndexLinear(), x), rx)
         throw(BoundsError(x, rx))
     elseif !checkindex(Bool, eachindex(IndexLinear(), y), ry)
@@ -1509,7 +1509,7 @@ julia> axpby!(2, x, 2, y)
 """
 function axpby!(α, x::AbstractArray, β, y::AbstractArray)
     if length(x) != length(y)
-        throw(DimensionMismatch("x has length $(length(x)), but y has length $(length(y))"))
+        throw(DimensionMismatch(lazy"x has length $(length(x)), but y has length $(length(y))"))
     end
     iszero(α) && isone(β) && return y
     for (IX, IY) in zip(eachindex(x), eachindex(y))
@@ -1549,7 +1549,7 @@ function rotate!(x::AbstractVector, y::AbstractVector, c, s)
     require_one_based_indexing(x, y)
     n = length(x)
     if n != length(y)
-        throw(DimensionMismatch("x has length $(length(x)), but y has length $(length(y))"))
+        throw(DimensionMismatch(lazy"x has length $(length(x)), but y has length $(length(y))"))
     end
     @inbounds for i = 1:n
         xi, yi = x[i], y[i]
@@ -1572,7 +1572,7 @@ function reflect!(x::AbstractVector, y::AbstractVector, c, s)
     require_one_based_indexing(x, y)
     n = length(x)
     if n != length(y)
-        throw(DimensionMismatch("x has length $(length(x)), but y has length $(length(y))"))
+        throw(DimensionMismatch(lazy"x has length $(length(x)), but y has length $(length(y))"))
     end
     @inbounds for i = 1:n
         xi, yi = x[i], y[i]
@@ -1613,7 +1613,7 @@ Multiplies `A` in-place by a Householder reflection on the left. It is equivalen
     require_one_based_indexing(x)
     m, n = size(A, 1), size(A, 2)
     if length(x) != m
-        throw(DimensionMismatch("reflector has length $(length(x)), which must match the first dimension of matrix A, $m"))
+        throw(DimensionMismatch(lazy"reflector has length $(length(x)), which must match the first dimension of matrix A, $m"))
     end
     m == 0 && return A
     @inbounds for j = 1:n
@@ -1943,7 +1943,7 @@ function copytrito!(B::AbstractMatrix, A::AbstractMatrix, uplo::AbstractChar)
     BLAS.chkuplo(uplo)
     m,n = size(A)
     m1,n1 = size(B)
-    (m1 < m || n1 < n) && throw(DimensionMismatch("B of size ($m1,$n1) should have at least the same number of rows and columns than A of size ($m,$n)"))
+    (m1 < m || n1 < n) && throw(DimensionMismatch(lazy"B of size ($m1,$n1) should have at least the same number of rows and columns than A of size ($m,$n)"))
     if uplo == 'U'
         for j=1:n
             for i=1:min(j,m)

--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -90,7 +90,7 @@ Base.@propagate_inbounds getindex(H::UpperHessenberg{T}, i::Integer, j::Integer)
 Base.@propagate_inbounds function setindex!(A::UpperHessenberg, x, i::Integer, j::Integer)
     if i > j+1
         x == 0 || throw(ArgumentError("cannot set index in the lower triangular part " *
-            "($i, $j) of an UpperHessenberg matrix to a nonzero value ($x)"))
+            lazy"($i, $j) of an UpperHessenberg matrix to a nonzero value ($x)"))
     else
         A.data[i,j] = x
     end
@@ -180,7 +180,7 @@ end
 function ldiv!(F::UpperHessenberg, B::AbstractVecOrMat; shift::Number=false)
     checksquare(F)
     m = size(F,1)
-    m != size(B,1) && throw(DimensionMismatch("wrong right-hand-side # rows != $m"))
+    m != size(B,1) && throw(DimensionMismatch(lazy"wrong right-hand-side # rows != $m"))
     require_one_based_indexing(B)
     n = size(B,2)
     H = F.data
@@ -230,7 +230,7 @@ end
 function rdiv!(B::AbstractMatrix, F::UpperHessenberg; shift::Number=false)
     checksquare(F)
     m = size(F,1)
-    m != size(B,2) && throw(DimensionMismatch("wrong right-hand-side # cols != $m"))
+    m != size(B,2) && throw(DimensionMismatch(lazy"wrong right-hand-side # cols != $m"))
     require_one_based_indexing(B)
     n = size(B,1)
     H = F.data

--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -26,7 +26,7 @@ Handle only negative LAPACK error codes
 """
 function chkargsok(ret::BlasInt)
     if ret < 0
-        throw(ArgumentError("invalid argument #$(-ret) to LAPACK call"))
+        throw(ArgumentError(lazy"invalid argument #$(-ret) to LAPACK call"))
     end
 end
 
@@ -35,7 +35,7 @@ function chklapackerror(ret::BlasInt, f...)
     if ret == 0
         return
     elseif ret < 0
-        throw(ArgumentError("invalid argument #$(-ret) to LAPACK call"))
+        throw(ArgumentError(lazy"invalid argument #$(-ret) to LAPACK call"))
     else # ret > 0
         chklapackerror_positive(ret, f...)
     end
@@ -63,7 +63,7 @@ end
 function chkvalidparam(position::Int, var::String, val, validvals)
     if val ∉ validvals
         throw(ArgumentError(
-            "argument #$position: $var must be one of $validvals, but $(repr(val)) was passed"))
+            lazy"argument #$position: $var must be one of $validvals, but $(repr(val)) was passed"))
     end
     return val
 end
@@ -71,7 +71,7 @@ end
 "Check that {c}transpose is correctly specified"
 function chktrans(trans::AbstractChar)
     if !(trans == 'N' || trans == 'C' || trans == 'T')
-        throw(ArgumentError("trans argument must be 'N' (no transpose), 'T' (transpose), or 'C' (conjugate transpose), got '$trans'"))
+        throw(ArgumentError(lazy"trans argument must be 'N' (no transpose), 'T' (transpose), or 'C' (conjugate transpose), got '$trans'"))
     end
     trans
 end
@@ -79,7 +79,7 @@ end
 "Check that left/right hand side multiply is correctly specified"
 function chkside(side::AbstractChar)
     if !(side == 'L' || side == 'R')
-        throw(ArgumentError("side argument must be 'L' (left hand multiply) or 'R' (right hand multiply), got '$side'"))
+        throw(ArgumentError(lazy"side argument must be 'L' (left hand multiply) or 'R' (right hand multiply), got '$side'"))
     end
     side
 end
@@ -87,7 +87,7 @@ end
 "Check that unit diagonal flag is correctly specified"
 function chkdiag(diag::AbstractChar)
     if !(diag == 'U' || diag =='N')
-        throw(ArgumentError("diag argument must be 'U' (unit diagonal) or 'N' (non-unit diagonal), got '$diag'"))
+        throw(ArgumentError(lazy"diag argument must be 'U' (unit diagonal) or 'N' (non-unit diagonal), got '$diag'"))
     end
     diag
 end
@@ -178,7 +178,7 @@ for (gbtrf, gbtrs, elty) in
             info = Ref{BlasInt}()
             n    = size(AB,2)
             if m != n || m != size(B,1)
-                throw(DimensionMismatch("matrix AB has dimensions $(size(AB)), but right hand side matrix B has dimensions $(size(B))"))
+                throw(DimensionMismatch(lazy"matrix AB has dimensions $(size(AB)), but right hand side matrix B has dimensions $(size(B))"))
             end
             ccall((@blasfunc($gbtrs), libblastrampoline), Cvoid,
                   (Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{BlasInt}, Ref{BlasInt},
@@ -355,7 +355,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
             n     = BlasInt(size(A, 2))
             lda   = BlasInt(max(1,stride(A, 2)))
             if length(tau) != min(m,n)
-                throw(DimensionMismatch("tau has length $(length(tau)), but needs length $(min(m,n))"))
+                throw(DimensionMismatch(lazy"tau has length $(length(tau)), but needs length $(min(m,n))"))
             end
             lwork = BlasInt(-1)
             work  = Vector{$elty}(undef, 1)
@@ -386,7 +386,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
             n     = BlasInt(size(A, 2))
             lda   = BlasInt(max(1,stride(A, 2)))
             if length(tau) != min(m,n)
-                throw(DimensionMismatch("tau has length $(length(tau)), but needs length $(min(m,n))"))
+                throw(DimensionMismatch(lazy"tau has length $(length(tau)), but needs length $(min(m,n))"))
             end
             lwork = BlasInt(-1)
             work  = Vector{$elty}(undef, 1)
@@ -416,10 +416,10 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
             chkstride1(A,jpvt,tau)
             m,n = size(A)
             if length(tau) != min(m,n)
-                throw(DimensionMismatch("tau has length $(length(tau)), but needs length $(min(m,n))"))
+                throw(DimensionMismatch(lazy"tau has length $(length(tau)), but needs length $(min(m,n))"))
             end
             if length(jpvt) != n
-                throw(DimensionMismatch("jpvt has length $(length(jpvt)), but needs length $n"))
+                throw(DimensionMismatch(lazy"jpvt has length $(length(jpvt)), but needs length $n"))
             end
             lda = stride(A,2)
             if lda == 0
@@ -466,7 +466,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
             minmn = min(m, n)
             nb = size(T, 1)
             if nb > minmn
-                throw(ArgumentError("block size $nb > $minmn too large"))
+                throw(ArgumentError(lazy"block size $nb > $minmn too large"))
             end
             lda = max(1, stride(A,2))
             work = Vector{$elty}(undef, nb*n)
@@ -491,10 +491,10 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
             m, n = size(A)
             p, q = size(T)
             if m < n
-                throw(DimensionMismatch("input matrix A has dimensions ($m,$n), but should have more rows than columns"))
+                throw(DimensionMismatch(lazy"input matrix A has dimensions ($m,$n), but should have more rows than columns"))
             end
             if p != n || q != n
-                throw(DimensionMismatch("block reflector T has dimensions ($p,$q), but should have dimensions ($n,$n)"))
+                throw(DimensionMismatch(lazy"block reflector T has dimensions ($p,$q), but should have dimensions ($n,$n)"))
             end
             if n > 0    # this implies `m > 0` because of `m >= n`
                 info = Ref{BlasInt}()
@@ -519,7 +519,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
             chkstride1(A,tau)
             m, n  = size(A)
             if length(tau) != min(m,n)
-                throw(DimensionMismatch("tau has length $(length(tau)), but needs length $(min(m,n))"))
+                throw(DimensionMismatch(lazy"tau has length $(length(tau)), but needs length $(min(m,n))"))
             end
             work  = Vector{$elty}(undef, 1)
             lwork = BlasInt(-1)
@@ -548,7 +548,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
             chkstride1(A,tau)
             m, n  = size(A)
             if length(tau) != min(m,n)
-                throw(DimensionMismatch("tau has length $(length(tau)), but needs length $(min(m,n))"))
+                throw(DimensionMismatch(lazy"tau has length $(length(tau)), but needs length $(min(m,n))"))
             end
             lwork = BlasInt(-1)
             work  = Vector{$elty}(undef, 1)
@@ -869,7 +869,7 @@ for (tzrzf, ormrz, elty) in
             chkstride1(A)
             m, n = size(A)
             if n < m
-                throw(DimensionMismatch("input matrix A has dimensions ($m,$n), but cannot have fewer columns than rows"))
+                throw(DimensionMismatch(lazy"input matrix A has dimensions ($m,$n), but cannot have fewer columns than rows"))
             end
             lda = max(1, stride(A,2))
             tau = similar(A, $elty, m)
@@ -974,7 +974,7 @@ for (gels, gesv, getrs, getri, elty) in
             btrn  = trans == 'T'
             m, n  = size(A)
             if size(B,1) != (btrn ? n : m)
-                throw(DimensionMismatch("matrix A has dimensions ($m,$n), transposed: $btrn, but leading dimension of B is $(size(B,1))"))
+                throw(DimensionMismatch(lazy"matrix A has dimensions ($m,$n), transposed: $btrn, but leading dimension of B is $(size(B,1))"))
             end
             info  = Ref{BlasInt}()
             work  = Vector{$elty}(undef, 1)
@@ -1017,7 +1017,7 @@ for (gels, gesv, getrs, getri, elty) in
             chkstride1(A, B)
             n = checksquare(A)
             if size(B,1) != n
-                throw(DimensionMismatch("B has leading dimension $(size(B,1)), but needs $n"))
+                throw(DimensionMismatch(lazy"B has leading dimension $(size(B,1)), but needs $n"))
             end
             ipiv = similar(A, BlasInt, n)
             info = Ref{BlasInt}()
@@ -1042,10 +1042,10 @@ for (gels, gesv, getrs, getri, elty) in
             chkstride1(A, B, ipiv)
             n = checksquare(A)
             if n != size(B, 1)
-                throw(DimensionMismatch("B has leading dimension $(size(B,1)), but needs $n"))
+                throw(DimensionMismatch(lazy"B has leading dimension $(size(B,1)), but needs $n"))
             end
             if n != length(ipiv)
-                throw(DimensionMismatch("ipiv has length $(length(ipiv)), but needs to be $n"))
+                throw(DimensionMismatch(lazy"ipiv has length $(length(ipiv)), but needs to be $n"))
             end
             nrhs = size(B, 2)
             info = Ref{BlasInt}()
@@ -1068,7 +1068,7 @@ for (gels, gesv, getrs, getri, elty) in
             chkstride1(A, ipiv)
             n = checksquare(A)
             if n != length(ipiv)
-                throw(DimensionMismatch("ipiv has length $(length(ipiv)), but needs $n"))
+                throw(DimensionMismatch(lazy"ipiv has length $(length(ipiv)), but needs $n"))
             end
             lda = max(1,stride(A, 2))
             lwork = BlasInt(-1)
@@ -1331,7 +1331,7 @@ for (gelsd, gelsy, elty) in
             chkstride1(A, B)
             m, n  = size(A)
             if size(B, 1) != m
-                throw(DimensionMismatch("B has leading dimension $(size(B,1)) but needs $m"))
+                throw(DimensionMismatch(lazy"B has leading dimension $(size(B,1)) but needs $m"))
             end
             newB = [B; zeros($elty, max(0, n - size(B, 1)), size(B, 2))]
             s     = similar(A, $elty, min(m, n))
@@ -1376,7 +1376,7 @@ for (gelsd, gelsy, elty) in
             n = size(A, 2)
             nrhs = size(B, 2)
             if size(B, 1) != m
-                throw(DimensionMismatch("B has leading dimension $(size(B,1)) but needs $m"))
+                throw(DimensionMismatch(lazy"B has leading dimension $(size(B,1)) but needs $m"))
             end
             newB = [B; zeros($elty, max(0, n - size(B, 1)), size(B, 2))]
             lda = max(1, stride(A,2))
@@ -1426,7 +1426,7 @@ for (gelsd, gelsy, elty, relty) in
             chkstride1(A, B)
             m, n  = size(A)
             if size(B, 1) != m
-                throw(DimensionMismatch("B has leading dimension $(size(B,1)) but needs $m"))
+                throw(DimensionMismatch(lazy"B has leading dimension $(size(B,1)) but needs $m"))
             end
             newB = [B; zeros($elty, max(0, n - size(B, 1)), size(B, 2))]
             s     = similar(A, $relty, min(m, n))
@@ -1473,7 +1473,7 @@ for (gelsd, gelsy, elty, relty) in
             m, n = size(A)
             nrhs = size(B, 2)
             if size(B, 1) != m
-                throw(DimensionMismatch("B has leading dimension $(size(B,1)) but needs $m"))
+                throw(DimensionMismatch(lazy"B has leading dimension $(size(B,1)) but needs $m"))
             end
             newB = [B; zeros($elty, max(0, n - size(B, 1)), size(B, 2))]
             lda = max(1, m)
@@ -1547,13 +1547,13 @@ for (gglse, elty) in ((:dgglse_, :Float64),
             m, n = size(A)
             p = size(B, 1)
             if size(B, 2) != n
-                throw(DimensionMismatch("B has second dimension $(size(B,2)), needs $n"))
+                throw(DimensionMismatch(lazy"B has second dimension $(size(B,2)), needs $n"))
             end
             if length(c) != m
-                throw(DimensionMismatch("c has length $(length(c)), needs $m"))
+                throw(DimensionMismatch(lazy"c has length $(length(c)), needs $m"))
             end
             if length(d) != p
-                throw(DimensionMismatch("d has length $(length(d)), needs $p"))
+                throw(DimensionMismatch(lazy"d has length $(length(d)), needs $p"))
             end
             X = zeros($elty, n)
             info  = Ref{BlasInt}()
@@ -1823,7 +1823,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
             @chkvalidparam 3 jobq ('Q', 'N')
             m, n = size(A)
             if size(B, 2) != n
-                throw(DimensionMismatch("B has second dimension $(size(B,2)) but needs $n"))
+                throw(DimensionMismatch(lazy"B has second dimension $(size(B,2)) but needs $n"))
             end
             p = size(B, 1)
             k = Vector{BlasInt}(undef, 1)
@@ -1953,7 +1953,7 @@ for (f, elty) in ((:dggsvd3_, :Float64),
             @chkvalidparam 3 jobq ('Q', 'N')
             m, n = size(A)
             if size(B, 2) != n
-                throw(DimensionMismatch("B has second dimension $(size(B,2)) but needs $n"))
+                throw(DimensionMismatch(lazy"B has second dimension $(size(B,2)) but needs $n"))
             end
             p = size(B, 1)
             k = Ref{BlasInt}()
@@ -2015,7 +2015,7 @@ for (f, elty, relty) in ((:zggsvd3_, :ComplexF64, :Float64),
             @chkvalidparam 3 jobq ('Q', 'N')
             m, n = size(A)
             if size(B, 2) != n
-                throw(DimensionMismatch("B has second dimension $(size(B,2)) but needs $n"))
+                throw(DimensionMismatch(lazy"B has second dimension $(size(B,2)) but needs $n"))
             end
             p = size(B, 1)
             k = Vector{BlasInt}(undef, 1)
@@ -2103,7 +2103,7 @@ for (geevx, ggev, ggev3, elty) in
             @chkvalidparam 1 balanc ('N', 'P', 'S', 'B')
             @chkvalidparam 4 sense ('N', 'E', 'V', 'B')
             if sense ∈ ('E', 'B') && !(jobvl == jobvr == 'V')
-                throw(ArgumentError("sense = '$sense' requires jobvl = 'V' and jobvr = 'V'"))
+                throw(ArgumentError(lazy"sense = '$sense' requires jobvl = 'V' and jobvr = 'V'"))
             end
             n = checksquare(A)
             ldvl = 0
@@ -2112,7 +2112,7 @@ for (geevx, ggev, ggev3, elty) in
             elseif jobvl == 'N'
                 ldvl = 0
             else
-                throw(ArgumentError("jobvl must be 'V' or 'N', but $jobvl was passed"))
+                throw(ArgumentError(lazy"jobvl must be 'V' or 'N', but $jobvl was passed"))
             end
             ldvr = 0
             if jobvr == 'V'
@@ -2120,7 +2120,7 @@ for (geevx, ggev, ggev3, elty) in
             elseif jobvr == 'N'
                 ldvr = 0
             else
-                throw(ArgumentError("jobvr must be 'V' or 'N', but $jobvr was passed"))
+                throw(ArgumentError(lazy"jobvr must be 'V' or 'N', but $jobvr was passed"))
             end
             chkfinite(A) # balancing routines don't support NaNs and Infs
             lda = max(1,stride(A,2))
@@ -2142,7 +2142,7 @@ for (geevx, ggev, ggev3, elty) in
             elseif sense == 'V' || sense == 'B'
                 iworksize = 2*n - 2
             else
-                throw(ArgumentError("sense must be 'N', 'E', 'V' or 'B', but $sense was passed"))
+                throw(ArgumentError(lazy"sense must be 'N', 'E', 'V' or 'B', but $sense was passed"))
             end
             iwork = Vector{BlasInt}(undef, iworksize)
             info = Ref{BlasInt}()
@@ -2186,7 +2186,7 @@ for (geevx, ggev, ggev3, elty) in
             chkstride1(A,B)
             n, m = checksquare(A,B)
             if n != m
-                throw(DimensionMismatch("A has dimensions $(size(A)), and B has dimensions $(size(B)), but A and B must have the same size"))
+                throw(DimensionMismatch(lazy"A has dimensions $(size(A)), and B has dimensions $(size(B)), but A and B must have the same size"))
             end
             ldvl = 0
             if jobvl == 'V'
@@ -2194,7 +2194,7 @@ for (geevx, ggev, ggev3, elty) in
             elseif jobvl == 'N'
                 ldvl = 1
             else
-                throw(ArgumentError("jobvl must be 'V' or 'N', but $jobvl was passed"))
+                throw(ArgumentError(lazy"jobvl must be 'V' or 'N', but $jobvl was passed"))
             end
             ldvr = 0
             if jobvr == 'V'
@@ -2202,7 +2202,7 @@ for (geevx, ggev, ggev3, elty) in
             elseif jobvr == 'N'
                 ldvr = 1
             else
-                throw(ArgumentError("jobvr must be 'V' or 'N', but $jobvr was passed"))
+                throw(ArgumentError(lazy"jobvr must be 'V' or 'N', but $jobvr was passed"))
             end
             lda = max(1, stride(A, 2))
             ldb = max(1, stride(B, 2))
@@ -2250,7 +2250,7 @@ for (geevx, ggev, ggev3, elty) in
             chkstride1(A,B)
             n, m = checksquare(A,B)
             if n != m
-                throw(DimensionMismatch("A has dimensions $(size(A)), and B has dimensions $(size(B)), but A and B must have the same size"))
+                throw(DimensionMismatch(lazy"A has dimensions $(size(A)), and B has dimensions $(size(B)), but A and B must have the same size"))
             end
             ldvl = 0
             if jobvl == 'V'
@@ -2258,7 +2258,7 @@ for (geevx, ggev, ggev3, elty) in
             elseif jobvl == 'N'
                 ldvl = 1
             else
-                throw(ArgumentError("jobvl must be 'V' or 'N', but $jobvl was passed"))
+                throw(ArgumentError(lazy"jobvl must be 'V' or 'N', but $jobvl was passed"))
             end
             ldvr = 0
             if jobvr == 'V'
@@ -2266,7 +2266,7 @@ for (geevx, ggev, ggev3, elty) in
             elseif jobvr == 'N'
                 ldvr = 1
             else
-                throw(ArgumentError("jobvr must be 'V' or 'N', but $jobvr was passed"))
+                throw(ArgumentError(lazy"jobvr must be 'V' or 'N', but $jobvr was passed"))
             end
             lda = max(1, stride(A, 2))
             ldb = max(1, stride(B, 2))
@@ -2322,13 +2322,13 @@ for (geevx, ggev, ggev3, elty, relty) in
         function geevx!(balanc::AbstractChar, jobvl::AbstractChar, jobvr::AbstractChar, sense::AbstractChar, A::AbstractMatrix{$elty})
             require_one_based_indexing(A)
             if balanc ∉ ('N', 'P', 'S', 'B')
-                throw(ArgumentError("balanc must be 'N', 'P', 'S', or 'B', but $balanc was passed"))
+                throw(ArgumentError(lazy"balanc must be 'N', 'P', 'S', or 'B', but $balanc was passed"))
             end
             if sense ∉ ('N','E','V','B')
-                throw(ArgumentError("sense must be 'N', 'E', 'V' or 'B', but $sense was passed"))
+                throw(ArgumentError(lazy"sense must be 'N', 'E', 'V' or 'B', but $sense was passed"))
             end
             if sense ∈ ('E', 'B') && !(jobvl == jobvr == 'V')
-                throw(ArgumentError("sense = '$sense' requires jobvl = 'V' and jobvr = 'V'"))
+                throw(ArgumentError(lazy"sense = '$sense' requires jobvl = 'V' and jobvr = 'V'"))
             end
             n = checksquare(A)
             ldvl = 0
@@ -2337,7 +2337,7 @@ for (geevx, ggev, ggev3, elty, relty) in
             elseif jobvl == 'N'
                 ldvl = 0
             else
-                throw(ArgumentError("jobvl must be 'V' or 'N', but $jobvl was passed"))
+                throw(ArgumentError(lazy"jobvl must be 'V' or 'N', but $jobvl was passed"))
             end
             ldvr = 0
             if jobvr == 'V'
@@ -2345,7 +2345,7 @@ for (geevx, ggev, ggev3, elty, relty) in
             elseif jobvr == 'N'
                 ldvr = 0
             else
-                throw(ArgumentError("jobvr must be 'V' or 'N', but $jobvr was passed"))
+                throw(ArgumentError(lazy"jobvr must be 'V' or 'N', but $jobvr was passed"))
             end
             chkfinite(A) # balancing routines don't support NaNs and Infs
             lda = max(1,stride(A,2))
@@ -2401,7 +2401,7 @@ for (geevx, ggev, ggev3, elty, relty) in
             chkstride1(A, B)
             n, m = checksquare(A, B)
             if n != m
-                throw(DimensionMismatch("A has dimensions $(size(A)), and B has dimensions $(size(B)), but A and B must have the same size"))
+                throw(DimensionMismatch(lazy"A has dimensions $(size(A)), and B has dimensions $(size(B)), but A and B must have the same size"))
             end
             ldvl = 0
             if jobvl == 'V'
@@ -2409,7 +2409,7 @@ for (geevx, ggev, ggev3, elty, relty) in
             elseif jobvl == 'N'
                 ldvl = 1
             else
-                throw(ArgumentError("jobvl must be 'V' or 'N', but $jobvl was passed"))
+                throw(ArgumentError(lazy"jobvl must be 'V' or 'N', but $jobvl was passed"))
             end
             ldvr = 0
             if jobvr == 'V'
@@ -2417,7 +2417,7 @@ for (geevx, ggev, ggev3, elty, relty) in
             elseif jobvr == 'N'
                 ldvr = 1
             else
-                throw(ArgumentError("jobvr must be 'V' or 'N', but $jobvr was passed"))
+                throw(ArgumentError(lazy"jobvr must be 'V' or 'N', but $jobvr was passed"))
             end
             lda = max(1, stride(A, 2))
             ldb = max(1, stride(B, 2))
@@ -2466,7 +2466,7 @@ for (geevx, ggev, ggev3, elty, relty) in
             chkstride1(A, B)
             n, m = checksquare(A, B)
             if n != m
-                throw(DimensionMismatch("A has dimensions $(size(A)), and B has dimensions $(size(B)), but A and B must have the same size"))
+                throw(DimensionMismatch(lazy"A has dimensions $(size(A)), and B has dimensions $(size(B)), but A and B must have the same size"))
             end
             ldvl = 0
             if jobvl == 'V'
@@ -2474,7 +2474,7 @@ for (geevx, ggev, ggev3, elty, relty) in
             elseif jobvl == 'N'
                 ldvl = 1
             else
-                throw(ArgumentError("jobvl must be 'V' or 'N', but $jobvl was passed"))
+                throw(ArgumentError(lazy"jobvl must be 'V' or 'N', but $jobvl was passed"))
             end
             ldvr = 0
             if jobvr == 'V'
@@ -2482,7 +2482,7 @@ for (geevx, ggev, ggev3, elty, relty) in
             elseif jobvr == 'N'
                 ldvr = 1
             else
-                throw(ArgumentError("jobvr must be 'V' or 'N', but $jobvr was passed"))
+                throw(ArgumentError(lazy"jobvr must be 'V' or 'N', but $jobvr was passed"))
             end
             lda = max(1, stride(A, 2))
             ldb = max(1, stride(B, 2))
@@ -2576,7 +2576,7 @@ for (laic1, elty) in
             @chkvalidparam 1 job (1,2)
             j = length(x)
             if j != length(w)
-                throw(DimensionMismatch("vectors must have same length, but length of x is $j and length of w is $(length(w))"))
+                throw(DimensionMismatch(lazy"vectors must have same length, but length of x is $j and length of w is $(length(w))"))
             end
             sestpr = Ref{$elty}()
             s = Ref{$elty}()
@@ -2611,7 +2611,7 @@ for (laic1, elty, relty) in
             @chkvalidparam 1 job (1,2)
             j = length(x)
             if j != length(w)
-                throw(DimensionMismatch("vectors must have same length, but length of x is $j and length of w is $(length(w))"))
+                throw(DimensionMismatch(lazy"vectors must have same length, but length of x is $j and length of w is $(length(w))"))
             end
             sestpr = Ref{$relty}()
             s = Ref{$elty}()
@@ -2646,13 +2646,13 @@ for (gtsv, gttrf, gttrs, elty) in
             chkstride1(B, dl, d, du)
             n = length(d)
             if !(n >= length(dl) >= n - 1)
-                throw(DimensionMismatch("subdiagonal has length $(length(dl)), but should be $n or $(n - 1)"))
+                throw(DimensionMismatch(lazy"subdiagonal has length $(length(dl)), but should be $n or $(n - 1)"))
             end
             if !(n >= length(du) >= n - 1)
-                throw(DimensionMismatch("superdiagonal has length $(length(du)), but should be $n or $(n - 1)"))
+                throw(DimensionMismatch(lazy"superdiagonal has length $(length(du)), but should be $n or $(n - 1)"))
             end
             if n != size(B,1)
-                throw(DimensionMismatch("B has leading dimension $(size(B,1)), but should have $n"))
+                throw(DimensionMismatch(lazy"B has leading dimension $(size(B,1)), but should have $n"))
             end
             if n == 0
                 return B # Early exit if possible
@@ -2677,10 +2677,10 @@ for (gtsv, gttrf, gttrs, elty) in
             chkstride1(dl,d,du)
             n    = length(d)
             if length(dl) != n - 1
-                throw(DimensionMismatch("subdiagonal has length $(length(dl)), but should be $(n - 1)"))
+                throw(DimensionMismatch(lazy"subdiagonal has length $(length(dl)), but should be $(n - 1)"))
             end
             if length(du) != n - 1
-                throw(DimensionMismatch("superdiagonal has length $(length(du)), but should be $(n - 1)"))
+                throw(DimensionMismatch(lazy"superdiagonal has length $(length(du)), but should be $(n - 1)"))
             end
             du2  = similar(d, $elty, n-2)
             ipiv = similar(d, BlasInt, n)
@@ -2708,13 +2708,13 @@ for (gtsv, gttrf, gttrs, elty) in
             chkstride1(B, ipiv, dl, d, du, du2)
             n = length(d)
             if length(dl) != n - 1
-                throw(DimensionMismatch("subdiagonal has length $(length(dl)), but should be $(n - 1)"))
+                throw(DimensionMismatch(lazy"subdiagonal has length $(length(dl)), but should be $(n - 1)"))
             end
             if length(du) != n - 1
-                throw(DimensionMismatch("superdiagonal has length $(length(du)), but should be $(n - 1)"))
+                throw(DimensionMismatch(lazy"superdiagonal has length $(length(du)), but should be $(n - 1)"))
             end
             if n != size(B,1)
-                throw(DimensionMismatch("B has leading dimension $(size(B,1)), but should have $n"))
+                throw(DimensionMismatch(lazy"B has leading dimension $(size(B,1)), but should have $n"))
             end
             info = Ref{BlasInt}()
             ccall((@blasfunc($gttrs), libblastrampoline), Cvoid,
@@ -2778,7 +2778,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
             n = size(A, 2)
             m = min(n, size(A, 1))
             if k > m
-                throw(DimensionMismatch("invalid number of reflectors: k = $k should be <= m = $m"))
+                throw(DimensionMismatch(lazy"invalid number of reflectors: k = $k should be <= m = $m"))
             end
             work  = Vector{$elty}(undef, 1)
             lwork = BlasInt(-1)
@@ -2812,7 +2812,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
             m = size(A, 1)
             n = min(m, size(A, 2))
             if k > n
-                throw(DimensionMismatch("invalid number of reflectors: k = $k should be <= n = $n"))
+                throw(DimensionMismatch(lazy"invalid number of reflectors: k = $k should be <= n = $n"))
             end
             work  = Vector{$elty}(undef, 1)
             lwork = BlasInt(-1)
@@ -2848,7 +2848,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
             m = size(A, 1)
             n = min(m, size(A, 2))
             if k > n
-                throw(DimensionMismatch("invalid number of reflectors: k = $k should be <= n = $n"))
+                throw(DimensionMismatch(lazy"invalid number of reflectors: k = $k should be <= n = $n"))
             end
             work  = Vector{$elty}(undef, 1)
             lwork = BlasInt(-1)
@@ -2883,10 +2883,10 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
             chkstride1(A,tau)
             m, n = size(A)
             if n < m
-                throw(DimensionMismatch("input matrix A has dimensions ($m,$n), but cannot have fewer columns than rows"))
+                throw(DimensionMismatch(lazy"input matrix A has dimensions ($m,$n), but cannot have fewer columns than rows"))
             end
             if k > n
-                throw(DimensionMismatch("invalid number of reflectors: k = $k should be <= n = $n"))
+                throw(DimensionMismatch(lazy"invalid number of reflectors: k = $k should be <= n = $n"))
             end
             work  = Vector{$elty}(undef, 1)
             lwork = BlasInt(-1)
@@ -2924,16 +2924,16 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
             nA = size(A, 2)
             k   = length(tau)
             if side == 'L' && m != nA
-                throw(DimensionMismatch("for a left-sided multiplication, the first dimension of C, $m, must equal the second dimension of A, $nA"))
+                throw(DimensionMismatch(lazy"for a left-sided multiplication, the first dimension of C, $m, must equal the second dimension of A, $nA"))
             end
             if side == 'R' && n != nA
-                throw(DimensionMismatch("for a right-sided multiplication, the second dimension of C, $n, must equal the second dimension of A, $nA"))
+                throw(DimensionMismatch(lazy"for a right-sided multiplication, the second dimension of C, $n, must equal the second dimension of A, $nA"))
             end
             if side == 'L' && k > m
-                throw(DimensionMismatch("invalid number of reflectors: k = $k should be <= m = $m"))
+                throw(DimensionMismatch(lazy"invalid number of reflectors: k = $k should be <= m = $m"))
             end
             if side == 'R' && k > n
-                throw(DimensionMismatch("invalid number of reflectors: k = $k should be <= n = $n"))
+                throw(DimensionMismatch(lazy"invalid number of reflectors: k = $k should be <= n = $n"))
             end
             work  = Vector{$elty}(undef, 1)
             lwork = BlasInt(-1)
@@ -2971,16 +2971,16 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
             mA  = size(A, 1)
             k   = length(tau)
             if side == 'L' && m != mA
-                throw(DimensionMismatch("for a left-sided multiplication, the first dimension of C, $m, must equal the second dimension of A, $mA"))
+                throw(DimensionMismatch(lazy"for a left-sided multiplication, the first dimension of C, $m, must equal the second dimension of A, $mA"))
             end
             if side == 'R' && n != mA
-                throw(DimensionMismatch("for a right-sided multiplication, the second dimension of C, $m, must equal the second dimension of A, $mA"))
+                throw(DimensionMismatch(lazy"for a right-sided multiplication, the second dimension of C, $m, must equal the second dimension of A, $mA"))
             end
             if side == 'L' && k > m
-                throw(DimensionMismatch("invalid number of reflectors: k = $k should be <= m = $m"))
+                throw(DimensionMismatch(lazy"invalid number of reflectors: k = $k should be <= m = $m"))
             end
             if side == 'R' && k > n
-                throw(DimensionMismatch("invalid number of reflectors: k = $k should be <= n = $n"))
+                throw(DimensionMismatch(lazy"invalid number of reflectors: k = $k should be <= n = $n"))
             end
             work  = Vector{$elty}(undef, 1)
             lwork = BlasInt(-1)
@@ -3021,16 +3021,16 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
             mA  = size(A, 1)
             k   = length(tau)
             if side == 'L' && m != mA
-                throw(DimensionMismatch("for a left-sided multiplication, the first dimension of C, $m, must equal the second dimension of A, $mA"))
+                throw(DimensionMismatch(lazy"for a left-sided multiplication, the first dimension of C, $m, must equal the second dimension of A, $mA"))
             end
             if side == 'R' && n != mA
-                throw(DimensionMismatch("for a right-sided multiplication, the second dimension of C, $m, must equal the second dimension of A, $mA"))
+                throw(DimensionMismatch(lazy"for a right-sided multiplication, the second dimension of C, $m, must equal the second dimension of A, $mA"))
             end
             if side == 'L' && k > m
-                throw(DimensionMismatch("invalid number of reflectors: k = $k should be <= m = $m"))
+                throw(DimensionMismatch(lazy"invalid number of reflectors: k = $k should be <= m = $m"))
             end
             if side == 'R' && k > n
-                throw(DimensionMismatch("invalid number of reflectors: k = $k should be <= n = $n"))
+                throw(DimensionMismatch(lazy"invalid number of reflectors: k = $k should be <= n = $n"))
             end
             work  = Vector{$elty}(undef, 1)
             lwork = BlasInt(-1)
@@ -3071,16 +3071,16 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
             nA  = size(A, 2)
             k   = length(tau)
             if side == 'L' && m != nA
-                throw(DimensionMismatch("for a left-sided multiplication, the first dimension of C, $m, must equal the second dimension of A, $nA"))
+                throw(DimensionMismatch(lazy"for a left-sided multiplication, the first dimension of C, $m, must equal the second dimension of A, $nA"))
             end
             if side == 'R' && n != nA
-                throw(DimensionMismatch("for a right-sided multiplication, the second dimension of C, $m, must equal the second dimension of A, $nA"))
+                throw(DimensionMismatch(lazy"for a right-sided multiplication, the second dimension of C, $m, must equal the second dimension of A, $nA"))
             end
             if side == 'L' && k > m
-                throw(DimensionMismatch("invalid number of reflectors: k = $k should be <= m = $m"))
+                throw(DimensionMismatch(lazy"invalid number of reflectors: k = $k should be <= m = $m"))
             end
             if side == 'R' && k > n
-                throw(DimensionMismatch("invalid number of reflectors: k = $k should be <= n = $n"))
+                throw(DimensionMismatch(lazy"invalid number of reflectors: k = $k should be <= n = $n"))
             end
             work  = Vector{$elty}(undef, 1)
             lwork = BlasInt(-1)
@@ -3113,31 +3113,31 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
             end
             if side == 'L'
                 if !(0 <= k <= m)
-                    throw(DimensionMismatch("wrong value for k = $k: must be between 0 and $m"))
+                    throw(DimensionMismatch(lazy"wrong value for k = $k: must be between 0 and $m"))
                 end
                 if m != size(V,1)
-                    throw(DimensionMismatch("first dimensions of C, $m, and V, $(size(V,1)) must match"))
+                    throw(DimensionMismatch(lazy"first dimensions of C, $m, and V, $(size(V,1)) must match"))
                 end
                 ldv = stride(V,2)
                 if ldv < max(1, m)
-                    throw(DimensionMismatch("Q and C don't fit! The stride of V, $ldv, is too small"))
+                    throw(DimensionMismatch(lazy"Q and C don't fit! The stride of V, $ldv, is too small"))
                 end
                 wss = n*k
             elseif side == 'R'
                 if !(0 <= k <= n)
-                    throw(DimensionMismatch("wrong value for k = $k: must be between 0 and $n"))
+                    throw(DimensionMismatch(lazy"wrong value for k = $k: must be between 0 and $n"))
                 end
                 if n != size(V,1)
-                    throw(DimensionMismatch("second dimension of C, $n, and first dimension of V, $(size(V,1)) must match"))
+                    throw(DimensionMismatch(lazy"second dimension of C, $n, and first dimension of V, $(size(V,1)) must match"))
                 end
                 ldv = stride(V,2)
                 if ldv < max(1, n)
-                    throw(DimensionMismatch("Q and C don't fit! The stride of V, $ldv, is too small"))
+                    throw(DimensionMismatch(lazy"Q and C don't fit! The stride of V, $ldv, is too small"))
                 end
                 wss = m*k
             end
             if !(1 <= nb <= k)
-                throw(DimensionMismatch("wrong value for nb = $nb, which must be between 1 and $k"))
+                throw(DimensionMismatch(lazy"wrong value for nb = $nb, which must be between 1 and $k"))
             end
             ldc = stride(C, 2)
             work = Vector{$elty}(undef, wss)
@@ -3258,7 +3258,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
             n = checksquare(A)
             chkuplo(uplo)
             if size(B,1) != n
-                throw(DimensionMismatch("first dimension of B, $(size(B,1)), and size of A, ($n,$n), must match!"))
+                throw(DimensionMismatch(lazy"first dimension of B, $(size(B,1)), and size of A, ($n,$n), must match!"))
             end
             info = Ref{BlasInt}()
             ccall((@blasfunc($posv), libblastrampoline), Cvoid,
@@ -3328,7 +3328,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
             chkuplo(uplo)
             nrhs = size(B,2)
             if size(B,1) != n
-                throw(DimensionMismatch("first dimension of B, $(size(B,1)), and size of A, ($n,$n), must match!"))
+                throw(DimensionMismatch(lazy"first dimension of B, $(size(B,1)), and size of A, ($n,$n), must match!"))
             end
             lda = max(1,stride(A,2))
             if lda == 0 || nrhs == 0
@@ -3445,10 +3445,10 @@ for (ptsv, pttrf, elty, relty) in
             chkstride1(B, D, E)
             n = length(D)
             if length(E) != n - 1
-                throw(DimensionMismatch("E has length $(length(E)), but needs $(n - 1)"))
+                throw(DimensionMismatch(lazy"E has length $(length(E)), but needs $(n - 1)"))
             end
             if n != size(B,1)
-                throw(DimensionMismatch("B has first dimension $(size(B,1)) but needs $n"))
+                throw(DimensionMismatch(lazy"B has first dimension $(size(B,1)) but needs $n"))
             end
             info = Ref{BlasInt}()
             ccall((@blasfunc($ptsv), libblastrampoline), Cvoid,
@@ -3469,7 +3469,7 @@ for (ptsv, pttrf, elty, relty) in
             chkstride1(D, E)
             n = length(D)
             if length(E) != n - 1
-                throw(DimensionMismatch("E has length $(length(E)), but needs $(n - 1)"))
+                throw(DimensionMismatch(lazy"E has length $(length(E)), but needs $(n - 1)"))
             end
             info = Ref{BlasInt}()
             ccall((@blasfunc($pttrf), libblastrampoline), Cvoid,
@@ -3513,10 +3513,10 @@ for (pttrs, elty, relty) in
             chkstride1(B, D, E)
             n = length(D)
             if length(E) != n - 1
-                throw(DimensionMismatch("E has length $(length(E)), but needs $(n - 1)"))
+                throw(DimensionMismatch(lazy"E has length $(length(E)), but needs $(n - 1)"))
             end
             if n != size(B,1)
-                throw(DimensionMismatch("B has first dimension $(size(B,1)) but needs $n"))
+                throw(DimensionMismatch(lazy"B has first dimension $(size(B,1)) but needs $n"))
             end
             info = Ref{BlasInt}()
             ccall((@blasfunc($pttrs), libblastrampoline), Cvoid,
@@ -3547,10 +3547,10 @@ for (pttrs, elty, relty) in
             chkuplo(uplo)
             n = length(D)
             if length(E) != n - 1
-                throw(DimensionMismatch("E has length $(length(E)), but needs $(n - 1)"))
+                throw(DimensionMismatch(lazy"E has length $(length(E)), but needs $(n - 1)"))
             end
             if n != size(B,1)
-                throw(DimensionMismatch("B has first dimension $(size(B,1)) but needs $n"))
+                throw(DimensionMismatch(lazy"B has first dimension $(size(B,1)) but needs $n"))
             end
             info = Ref{BlasInt}()
             ccall((@blasfunc($pttrs), libblastrampoline), Cvoid,
@@ -3616,7 +3616,7 @@ for (trtri, trtrs, elty) in
             n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
-                throw(DimensionMismatch("B has first dimension $(size(B,1)) but needs $n"))
+                throw(DimensionMismatch(lazy"B has first dimension $(size(B,1)) but needs $n"))
             end
             info = Ref{BlasInt}()
             ccall((@blasfunc($trtrs), libblastrampoline), Cvoid,
@@ -3707,7 +3707,7 @@ for (trcon, trevc, trrfs, elty) in
             require_one_based_indexing(select, T, VL, VR)
             # Extract
             if side ∉ ('L','R','B')
-                throw(ArgumentError("side argument must be 'L' (left eigenvectors), 'R' (right eigenvectors), or 'B' (both), got $side"))
+                throw(ArgumentError(lazy"side argument must be 'L' (left eigenvectors), 'R' (right eigenvectors), or 'B' (both), got $side"))
             end
             @chkvalidparam 2 howmny ('A', 'B', 'S')
             n, mm = checksquare(T), size(VL, 2)
@@ -3773,7 +3773,7 @@ for (trcon, trevc, trrfs, elty) in
             n = size(A,2)
             nrhs = size(B,2)
             if nrhs != size(X,2)
-                throw(DimensionMismatch("second dimensions of B, $nrhs, and X, $(size(X,2)), must match"))
+                throw(DimensionMismatch(lazy"second dimensions of B, $nrhs, and X, $(size(X,2)), must match"))
             end
             work = Vector{$elty}(undef, 3n)
             iwork = Vector{BlasInt}(undef, n)
@@ -3849,7 +3849,7 @@ for (trcon, trevc, trrfs, elty, relty) in
             # Check
             chkstride1(T, select, VL, VR)
             if side ∉ ('L','R','B')
-                throw(ArgumentError("side argument must be 'L' (left eigenvectors), 'R' (right eigenvectors), or 'B' (both), got $side"))
+                throw(ArgumentError(lazy"side argument must be 'L' (left eigenvectors), 'R' (right eigenvectors), or 'B' (both), got $side"))
             end
             @chkvalidparam 2 howmny ('A', 'B', 'S')
 
@@ -3910,7 +3910,7 @@ for (trcon, trevc, trrfs, elty, relty) in
             n = size(A,2)
             nrhs = size(B,2)
             if nrhs != size(X,2)
-                throw(DimensionMismatch("second dimensions of B, $nrhs, and X, $(size(X,2)), must match"))
+                throw(DimensionMismatch(lazy"second dimensions of B, $nrhs, and X, $(size(X,2)), must match"))
             end
             work  = Vector{$elty}(undef, 2n)
             rwork = Vector{$relty}(undef, n)
@@ -3982,7 +3982,7 @@ for (stev, stebz, stegr, stein, elty) in
             chkstride1(dv, ev)
             n = length(dv)
             if length(ev) != n - 1 && length(ev) != n
-                throw(DimensionMismatch("ev has length $(length(ev)) but needs one less than or equal to dv's length, $n)"))
+                throw(DimensionMismatch(lazy"ev has length $(length(ev)) but needs one less than or equal to dv's length, $n)"))
             end
             Zmat = similar(dv, $elty, (n, job != 'N' ? n : 0))
             work = Vector{$elty}(undef, max(1, 2n-2))
@@ -4006,7 +4006,7 @@ for (stev, stebz, stegr, stein, elty) in
             chkstride1(dv, ev)
             n = length(dv)
             if length(ev) != n - 1
-                throw(DimensionMismatch("ev has length $(length(ev)) but needs one less than dv's length, $n)"))
+                throw(DimensionMismatch(lazy"ev has length $(length(ev)) but needs one less than dv's length, $n)"))
             end
             m = Ref{BlasInt}()
             nsplit = Vector{BlasInt}(undef, 1)
@@ -4045,7 +4045,7 @@ for (stev, stebz, stegr, stein, elty) in
                 eev = copy(ev)
                 eev[n] = zero($elty)
             else
-                throw(DimensionMismatch("ev has length $ne but needs one less than or equal to dv's length, $n)"))
+                throw(DimensionMismatch(lazy"ev has length $ne but needs one less than or equal to dv's length, $n)"))
             end
 
             abstol = Vector{$elty}(undef, 1)
@@ -4095,12 +4095,12 @@ for (stev, stebz, stegr, stein, elty) in
                 ev = copy(ev_in)
                 ev[n] = zero($elty)
             else
-                throw(DimensionMismatch("ev_in has length $ne but needs one less than or equal to dv's length, $n)"))
+                throw(DimensionMismatch(lazy"ev_in has length $ne but needs one less than or equal to dv's length, $n)"))
             end
             ldz = n #Leading dimension
             #Number of eigenvalues to find
             if !(1 <= length(w_in) <= n)
-                throw(DimensionMismatch("w_in has length $(length(w_in)), but needs to be between 1 and $n"))
+                throw(DimensionMismatch(lazy"w_in has length $(length(w_in)), but needs to be between 1 and $n"))
             end
             m = length(w_in)
             #If iblock and isplit are invalid input, assume worst-case block partitioning,
@@ -4236,7 +4236,7 @@ for (syconv, sysv, sytrf, sytri, sytrs, elty) in
             n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
-                throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
+                throw(DimensionMismatch(lazy"B has first dimension $(size(B,1)), but needs $n"))
             end
             ipiv  = similar(A, BlasInt, n)
             work  = Vector{$elty}(undef, 1)
@@ -4365,7 +4365,7 @@ for (syconv, sysv, sytrf, sytri, sytrs, elty) in
             n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
-                throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
+                throw(DimensionMismatch(lazy"B has first dimension $(size(B,1)), but needs $n"))
             end
             info = Ref{BlasInt}()
             ccall((@blasfunc($sytrs), libblastrampoline), Cvoid,
@@ -4397,7 +4397,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty) in
             n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
-                throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
+                throw(DimensionMismatch(lazy"B has first dimension $(size(B,1)), but needs $n"))
             end
             ipiv  = similar(A, BlasInt, n)
             work  = Vector{$elty}(undef, 1)
@@ -4490,7 +4490,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty) in
             n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
-                throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
+                throw(DimensionMismatch(lazy"B has first dimension $(size(B,1)), but needs $n"))
             end
             info = Ref{BlasInt}()
             ccall((@blasfunc($sytrs), libblastrampoline), Cvoid,
@@ -4524,10 +4524,10 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty) in
                 throw(ArgumentError("way must be C or R"))
             end
             if length(ipiv) != n
-                throw(ArgumentError("length of pivot vector was $(length(ipiv)) but should have been $n"))
+                throw(ArgumentError(lazy"length of pivot vector was $(length(ipiv)) but should have been $n"))
             end
             if length(e) != n
-                throw(ArgumentError("length of e vector was $(length(e)) but should have been $n"))
+                throw(ArgumentError(lazy"length of e vector was $(length(e)) but should have been $n"))
             end
 
             # allocate
@@ -4591,7 +4591,7 @@ for (syconv, hesv, hetrf, hetri, hetrs, elty, relty) in
             n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
-                throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
+                throw(DimensionMismatch(lazy"B has first dimension $(size(B,1)), but needs $n"))
             end
             ipiv  = similar(A, BlasInt, n)
             work  = Vector{$elty}(undef, 1)
@@ -4718,7 +4718,7 @@ for (syconv, hesv, hetrf, hetri, hetrs, elty, relty) in
             chkstride1(A,B,ipiv)
             n = checksquare(A)
             if n != size(B,1)
-                throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
+                throw(DimensionMismatch(lazy"B has first dimension $(size(B,1)), but needs $n"))
             end
             info = Ref{BlasInt}()
             ccall((@blasfunc($hetrs), libblastrampoline), Cvoid,
@@ -4749,7 +4749,7 @@ for (hesv, hetrf, hetri, hetrs, elty, relty) in
             n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
-                throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
+                throw(DimensionMismatch(lazy"B has first dimension $(size(B,1)), but needs $n"))
             end
             ipiv  = similar(A, BlasInt, n)
             work  = Vector{$elty}(undef, 1)
@@ -4839,7 +4839,7 @@ for (hesv, hetrf, hetri, hetrs, elty, relty) in
             chkuplo(uplo)
             n = checksquare(A)
             if n != size(B,1)
-                throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
+                throw(DimensionMismatch(lazy"B has first dimension $(size(B,1)), but needs $n"))
             end
             info = Ref{BlasInt}()
             ccall((@blasfunc($hetrs), libblastrampoline), Cvoid,
@@ -4871,7 +4871,7 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
             n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
-                throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
+                throw(DimensionMismatch(lazy"B has first dimension $(size(B,1)), but needs $n"))
             end
             ipiv  = similar(A, BlasInt, n)
             work  = Vector{$elty}(undef, 1)
@@ -5001,7 +5001,7 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
             n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
-                throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
+                throw(DimensionMismatch(lazy"B has first dimension $(size(B,1)), but needs $n"))
             end
             info = Ref{BlasInt}()
             ccall((@blasfunc($sytrs), libblastrampoline), Cvoid,
@@ -5033,7 +5033,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty, relty) in
             n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
-                throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
+                throw(DimensionMismatch(lazy"B has first dimension $(size(B,1)), but needs $n"))
             end
             ipiv  = similar(A, BlasInt, n)
             work  = Vector{$elty}(undef, 1)
@@ -5127,7 +5127,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty, relty) in
             n = checksquare(A)
             chkuplo(uplo)
             if n != size(B,1)
-                throw(DimensionMismatch("B has first dimension $(size(B,1)), but needs $n"))
+                throw(DimensionMismatch(lazy"B has first dimension $(size(B,1)), but needs $n"))
             end
             info = Ref{BlasInt}()
             ccall((@blasfunc($sytrs), libblastrampoline), Cvoid,
@@ -5160,13 +5160,13 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty, relty) in
             # check
             chkuplo(uplo)
             if way != 'C' && way != 'R'
-                throw(ArgumentError("way must be 'C' or 'R'"))
+                throw(ArgumentError(lazy"way must be 'C' or 'R'"))
             end
             if length(ipiv) != n
-                throw(ArgumentError("length of pivot vector was $(length(ipiv)) but should have been $n"))
+                throw(ArgumentError(lazy"length of pivot vector was $(length(ipiv)) but should have been $n"))
             end
             if length(e) != n
-                throw(ArgumentError("length of e vector was $(length(e)) but should have been $n"))
+                throw(ArgumentError(lazy"length of e vector was $(length(e)) but should have been $n"))
             end
 
             # allocate
@@ -5368,10 +5368,10 @@ for (syev, syevr, syevd, sygvd, elty) in
             chkstride1(A)
             n = checksquare(A)
             if range == 'I' && !(1 <= il <= iu <= n)
-                throw(ArgumentError("illegal choice of eigenvalue indices (il = $il, iu = $iu), which must be between 1 and n = $n"))
+                throw(ArgumentError(lazy"illegal choice of eigenvalue indices (il = $il, iu = $iu), which must be between 1 and n = $n"))
             end
             if range == 'V' && vl >= vu
-                throw(ArgumentError("lower boundary, $vl, must be less than upper boundary, $vu"))
+                throw(ArgumentError(lazy"lower boundary, $vl, must be less than upper boundary, $vu"))
             end
             chkuplofinite(A, uplo)
             lda = stride(A,2)
@@ -5476,7 +5476,7 @@ for (syev, syevr, syevd, sygvd, elty) in
             chkstride1(A, B)
             n, m = checksquare(A, B)
             if n != m
-                throw(DimensionMismatch("dimensions of A, ($n,$n), and B, ($m,$m), must match"))
+                throw(DimensionMismatch(lazy"dimensions of A, ($n,$n), and B, ($m,$m), must match"))
             end
             lda = max(1, stride(A, 2))
             ldb = max(1, stride(B, 2))
@@ -5571,10 +5571,10 @@ for (syev, syevr, syevd, sygvd, elty, relty) in
             chkuplofinite(A, uplo)
             n = checksquare(A)
             if range == 'I' && !(1 <= il <= iu <= n)
-                throw(ArgumentError("illegal choice of eigenvalue indices (il = $il, iu=$iu), which must be between 1 and n = $n"))
+                throw(ArgumentError(lazy"illegal choice of eigenvalue indices (il = $il, iu=$iu), which must be between 1 and n = $n"))
             end
             if range == 'V' && vl >= vu
-                throw(ArgumentError("lower boundary, $vl, must be less than upper boundary, $vu"))
+                throw(ArgumentError(lazy"lower boundary, $vl, must be less than upper boundary, $vu"))
             end
             lda = max(1,stride(A,2))
             m = Ref{BlasInt}()
@@ -5691,7 +5691,7 @@ for (syev, syevr, syevd, sygvd, elty, relty) in
             chkuplofinite(B, uplo)
             n, m = checksquare(A, B)
             if n != m
-                throw(DimensionMismatch("dimensions of A, ($n,$n), and B, ($m,$m), must match"))
+                throw(DimensionMismatch(lazy"dimensions of A, ($n,$n), and B, ($m,$m), must match"))
             end
             lda = max(1, stride(A, 2))
             ldb = max(1, stride(B, 2))
@@ -5802,19 +5802,19 @@ for (bdsqr, relty, elty) in
             # Do checks
             chkuplo(uplo)
             if length(e_) != n - 1
-                throw(DimensionMismatch("off-diagonal has length $(length(e_)) but should have length $(n - 1)"))
+                throw(DimensionMismatch(lazy"off-diagonal has length $(length(e_)) but should have length $(n - 1)"))
             end
             if ncvt > 0 && ldvt < n
-                throw(DimensionMismatch("leading dimension of Vt, $ldvt, must be at least $n"))
+                throw(DimensionMismatch(lazy"leading dimension of Vt, $ldvt, must be at least $n"))
             end
             if ldu < nru
-                throw(DimensionMismatch("leading dimension of U, $ldu, must be at least $nru"))
+                throw(DimensionMismatch(lazy"leading dimension of U, $ldu, must be at least $nru"))
             end
             if size(U, 2) != n
-                throw(DimensionMismatch("U must have $n columns but has $(size(U, 2))"))
+                throw(DimensionMismatch(lazy"U must have $n columns but has $(size(U, 2))"))
             end
             if ncc > 0 && ldc < n
-                throw(DimensionMismatch("leading dimension of C, $ldc, must be at least $n"))
+                throw(DimensionMismatch(lazy"leading dimension of C, $ldc, must be at least $n"))
             end
             # Allocate
             work = Vector{$relty}(undef, 4n)
@@ -5881,7 +5881,7 @@ for (bdsdc, elty) in
                 ldvt=ldu=max(1, n)
                 lwork=3*n^2 + 4*n
             else
-                throw(ArgumentError("COMPQ argument must be 'N', 'P' or 'I', got $(repr(compq))"))
+                throw(ArgumentError(lazy"COMPQ argument must be 'N', 'P' or 'I', got $(repr(compq))"))
             end
             u  = similar(d, $elty, (ldu,  n))
             vt = similar(d, $elty, (ldvt, n))
@@ -6069,7 +6069,7 @@ for (orghr, elty) in
             chkstride1(A, tau)
             n = checksquare(A)
             if n - length(tau) != 1
-                throw(DimensionMismatch("tau has length $(length(tau)), needs $(n - 1)"))
+                throw(DimensionMismatch(lazy"tau has length $(length(tau)), needs $(n - 1)"))
             end
             work = Vector{$elty}(undef, 1)
             lwork = BlasInt(-1)
@@ -6124,7 +6124,7 @@ for (ormhr, elty) in
             mC, nC = size(C, 1), size(C, 2)
 
             if n - length(tau) != 1
-                throw(DimensionMismatch("tau has length $(length(tau)), needs $(n - 1)"))
+                throw(DimensionMismatch(lazy"tau has length $(length(tau)), needs $(n - 1)"))
             end
             if (side == 'L' && mC != n) || (side == 'R' && nC != n)
                 throw(DimensionMismatch("A and C matrices are not conformable"))
@@ -6326,7 +6326,7 @@ for (orgtr, elty) in
             chkstride1(A, tau)
             n = checksquare(A)
             if n - length(tau) != 1
-                throw(DimensionMismatch("tau has length $(length(tau)), needs $(n - 1)"))
+                throw(DimensionMismatch(lazy"tau has length $(length(tau)), needs $(n - 1)"))
             end
             chkuplo(uplo)
             work = Vector{$elty}(undef, 1)
@@ -6383,10 +6383,10 @@ for (ormtr, elty) in
             mC, nC = size(C, 1), size(C, 2)
 
             if n - length(tau) != 1
-                throw(DimensionMismatch("tau has length $(length(tau)), needs $(n - 1)"))
+                throw(DimensionMismatch(lazy"tau has length $(length(tau)), needs $(n - 1)"))
             end
             if (side == 'L' && mC != n) || (side == 'R' && nC != n)
-                throw(DimensionMismatch("A and C matrices are not conformable"))
+                throw(DimensionMismatch(lazy"A and C matrices are not conformable"))
             end
 
             work = Vector{$elty}(undef, 1)
@@ -6473,7 +6473,7 @@ for (gees, gges, gges3, elty) in
             chkstride1(A, B)
             n, m = checksquare(A, B)
             if n != m
-                throw(DimensionMismatch("dimensions of A, ($n,$n), and B, ($m,$m), must match"))
+                throw(DimensionMismatch(lazy"dimensions of A, ($n,$n), and B, ($m,$m), must match"))
             end
             sdim = BlasInt(0)
             alphar = similar(A, $elty, n)
@@ -6525,7 +6525,7 @@ for (gees, gges, gges3, elty) in
             chkstride1(A, B)
             n, m = checksquare(A, B)
             if n != m
-                throw(DimensionMismatch("dimensions of A, ($n,$n), and B, ($m,$m), must match"))
+                throw(DimensionMismatch(lazy"dimensions of A, ($n,$n), and B, ($m,$m), must match"))
             end
             sdim = BlasInt(0)
             alphar = similar(A, $elty, n)
@@ -6625,7 +6625,7 @@ for (gees, gges, gges3, elty, relty) in
             chkstride1(A, B)
             n, m = checksquare(A, B)
             if n != m
-                throw(DimensionMismatch("dimensions of A, ($n,$n), and B, ($m,$m), must match"))
+                throw(DimensionMismatch(lazy"dimensions of A, ($n,$n), and B, ($m,$m), must match"))
             end
             sdim = BlasInt(0)
             alpha = similar(A, $elty, n)
@@ -6678,7 +6678,7 @@ for (gees, gges, gges3, elty, relty) in
             chkstride1(A, B)
             n, m = checksquare(A, B)
             if n != m
-                throw(DimensionMismatch("dimensions of A, ($n,$n), and B, ($m,$m), must match"))
+                throw(DimensionMismatch(lazy"dimensions of A, ($n,$n), and B, ($m,$m), must match"))
             end
             sdim = BlasInt(0)
             alpha = similar(A, $elty, n)
@@ -6859,13 +6859,13 @@ for (trexc, trsen, tgsen, elty) in
             chkstride1(select, S, T, Q, Z)
             n, nt, nq, nz = checksquare(S, T, Q, Z)
             if n != nt
-                throw(DimensionMismatch("dimensions of S, ($n,$n), and T, ($nt,$nt), must match"))
+                throw(DimensionMismatch(lazy"dimensions of S, ($n,$n), and T, ($nt,$nt), must match"))
             end
             if n != nq
-                throw(DimensionMismatch("dimensions of S, ($n,$n), and Q, ($nq,$nq), must match"))
+                throw(DimensionMismatch(lazy"dimensions of S, ($n,$n), and Q, ($nq,$nq), must match"))
             end
             if n != nz
-                throw(DimensionMismatch("dimensions of S, ($n,$n), and Z, ($nz,$nz), must match"))
+                throw(DimensionMismatch(lazy"dimensions of S, ($n,$n), and Z, ($nz,$nz), must match"))
             end
             lds = max(1, stride(S, 2))
             ldt = max(1, stride(T, 2))
@@ -7010,13 +7010,13 @@ for (trexc, trsen, tgsen, elty, relty) in
             chkstride1(select, S, T, Q, Z)
             n, nt, nq, nz = checksquare(S, T, Q, Z)
             if n != nt
-                throw(DimensionMismatch("dimensions of S, ($n,$n), and T, ($nt,$nt), must match"))
+                throw(DimensionMismatch(lazy"dimensions of S, ($n,$n), and T, ($nt,$nt), must match"))
             end
             if n != nq
-                throw(DimensionMismatch("dimensions of S, ($n,$n), and Q, ($nq,$nq), must match"))
+                throw(DimensionMismatch(lazy"dimensions of S, ($n,$n), and Q, ($nq,$nq), must match"))
             end
             if n != nz
-                throw(DimensionMismatch("dimensions of S, ($n,$n), and Z, ($nz,$nz), must match"))
+                throw(DimensionMismatch(lazy"dimensions of S, ($n,$n), and Z, ($nz,$nz), must match"))
             end
             lds = max(1, stride(S, 2))
             ldt = max(1, stride(T, 2))
@@ -7115,7 +7115,7 @@ for (fn, elty, relty) in ((:dtrsyl_, :Float64, :Float64),
             ldb = max(1, stride(B, 2))
             m1, n1 = size(C)
             if m != m1 || n != n1
-                throw(DimensionMismatch("dimensions of A, ($m,$n), and C, ($m1,$n1), must match"))
+                throw(DimensionMismatch(lazy"dimensions of A, ($m,$n), and C, ($m1,$n1), must match"))
             end
             ldc = max(1, stride(C, 2))
             scale = Ref{$relty}()
@@ -7165,7 +7165,7 @@ for (fn, elty) in ((:dlacpy_, :Float64),
             chkstride1(A, B)
             m,n = size(A)
             m1,n1 = size(B)
-            (m1 < m || n1 < n) && throw(DimensionMismatch("B of size ($m1,$n1) should have at least the same number of rows and columns than A of size ($m,$n)"))
+            (m1 < m || n1 < n) && throw(DimensionMismatch(lazy"B of size ($m1,$n1) should have at least the same number of rows and columns than A of size ($m,$n)"))
             lda = max(1, stride(A, 2))
             ldb = max(1, stride(B, 2))
             ccall((@blasfunc($fn), libblastrampoline), Cvoid,

--- a/stdlib/LinearAlgebra/src/lbt.jl
+++ b/stdlib/LinearAlgebra/src/lbt.jl
@@ -247,11 +247,11 @@ If the given `symbol_name` is not contained within the list of exported symbols,
 function lbt_find_backing_library(symbol_name, interface::Symbol;
                                   config::LBTConfig = lbt_get_config())
     if interface ∉ (:ilp64, :lp64)
-        throw(ArgumentError("Invalid interface specification: '$(interface)'"))
+        throw(ArgumentError(lazy"Invalid interface specification: '$(interface)'"))
     end
     symbol_idx = findfirst(s -> s == symbol_name, config.exported_symbols)
     if symbol_idx === nothing
-        throw(ArgumentError("Invalid exported symbol name '$(symbol_name)'"))
+        throw(ArgumentError(lazy"Invalid exported symbol name '$(symbol_name)'"))
     end
     # Convert to zero-indexed
     symbol_idx -= 1

--- a/stdlib/LinearAlgebra/src/ldlt.jl
+++ b/stdlib/LinearAlgebra/src/ldlt.jl
@@ -175,7 +175,7 @@ function ldiv!(S::LDLt{<:Any,<:SymTridiagonal}, B::AbstractVecOrMat)
     require_one_based_indexing(B)
     n, nrhs = size(B, 1), size(B, 2)
     if size(S,1) != n
-        throw(DimensionMismatch("Matrix has dimensions $(size(S)) but right hand side has first dimension $n"))
+        throw(DimensionMismatch(lazy"Matrix has dimensions $(size(S)) but right hand side has first dimension $n"))
     end
     d = S.data.dv
     l = S.data.ev

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -680,7 +680,7 @@ function ldiv!(A::LU{T,Tridiagonal{T,V}}, B::AbstractVecOrMat) where {T,V}
     require_one_based_indexing(B)
     n = size(A,1)
     if n != size(B,1)
-        throw(DimensionMismatch("matrix has dimensions ($n,$n) but right hand side has $(size(B,1)) rows"))
+        throw(DimensionMismatch(lazy"matrix has dimensions ($n,$n) but right hand side has $(size(B,1)) rows"))
     end
     nrhs = size(B,2)
     dl = A.factors.dl
@@ -713,7 +713,7 @@ function ldiv!(transA::TransposeFactorization{<:Any,<:LU{T,Tridiagonal{T,V}}}, B
     A = transA.parent
     n = size(A,1)
     if n != size(B,1)
-        throw(DimensionMismatch("matrix has dimensions ($n,$n) but right hand side has $(size(B,1)) rows"))
+        throw(DimensionMismatch(lazy"matrix has dimensions ($n,$n) but right hand side has $(size(B,1)) rows"))
     end
     nrhs = size(B,2)
     dl = A.factors.dl
@@ -750,7 +750,7 @@ function ldiv!(adjA::AdjointFactorization{<:Any,<:LU{T,Tridiagonal{T,V}}}, B::Ab
     A = adjA.parent
     n = size(A,1)
     if n != size(B,1)
-        throw(DimensionMismatch("matrix has dimensions ($n,$n) but right hand side has $(size(B,1)) rows"))
+        throw(DimensionMismatch(lazy"matrix has dimensions ($n,$n) but right hand side has $(size(B,1)) rows"))
     end
     nrhs = size(B,2)
     dl = A.factors.dl

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -541,7 +541,7 @@ function ldiv!(A::QRPivoted{T,<:StridedMatrix}, B::AbstractMatrix{T}, rcond::Rea
     m, n = size(A)
 
     if m > size(B, 1) || n > size(B, 1)
-        throw(DimensionMismatch("B has leading dimension $(size(B, 1)) but needs at least $(max(m, n))"))
+        throw(DimensionMismatch(lazy"B has leading dimension $(size(B, 1)) but needs at least $(max(m, n))"))
     end
 
     if length(A.factors) == 0 || length(B) == 0
@@ -734,7 +734,7 @@ _ret_size(A::Factorization, B::AbstractMatrix) = (max(size(A, 2), size(B, 1)), s
 function (\)(A::Union{QR{T},QRCompactWY{T},QRPivoted{T}}, BIn::VecOrMat{Complex{T}}) where T<:BlasReal
     require_one_based_indexing(BIn)
     m, n = size(A)
-    m == size(BIn, 1) || throw(DimensionMismatch("left hand side has $m rows, but right hand side has $(size(BIn,1)) rows"))
+    m == size(BIn, 1) || throw(DimensionMismatch(lazy"left hand side has $m rows, but right hand side has $(size(BIn,1)) rows"))
 
 # |z1|z3|  reinterpret  |x1|x2|x3|x4|  transpose  |x1|y1|  reshape  |x1|y1|x3|y3|
 # |z2|z4|      ->       |y1|y2|y3|y4|     ->      |x2|y2|     ->    |x2|y2|x4|y4|

--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -287,7 +287,7 @@ _small_enough(A::SymTridiagonal) = size(A, 1) <= 2
 function fill!(A::Union{Diagonal,Bidiagonal,Tridiagonal,SymTridiagonal}, x)
     xT = convert(eltype(A), x)
     (iszero(xT) || _small_enough(A)) && return fillstored!(A, xT)
-    throw(ArgumentError("array of type $(typeof(A)) and size $(size(A)) can
+    throw(ArgumentError(lazy"array of type $(typeof(A)) and size $(size(A)) can
     not be filled with $x, since some of its entries are constrained."))
 end
 

--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -209,7 +209,7 @@ function copyto!(dest::SymTridiagonal, bc::Broadcasted{<:StructuredMatrixStyle})
     end
     for i = 1:size(dest, 1)-1
         v = @inbounds Broadcast._broadcast_getindex(bc, CartesianIndex(i, i+1))
-        v == (@inbounds Broadcast._broadcast_getindex(bc, CartesianIndex(i+1, i))) || throw(ArgumentError("broadcasted assignment breaks symmetry between locations ($i, $(i+1)) and ($(i+1), $i)"))
+        v == (@inbounds Broadcast._broadcast_getindex(bc, CartesianIndex(i+1, i))) || throw(ArgumentError(lazy"broadcasted assignment breaks symmetry between locations ($i, $(i+1)) and ($(i+1), $i)"))
         dest.ev[i] = v
     end
     return dest

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -483,7 +483,7 @@ for (T, trans, real) in [(:Symmetric, :transpose, :identity), (:(Hermitian{<:Uni
         function dot(A::$T, B::$T)
             n = size(A, 2)
             if n != size(B, 2)
-                throw(DimensionMismatch("A has dimensions $(size(A)) but B has dimensions $(size(B))"))
+                throw(DimensionMismatch(lazy"A has dimensions $(size(A)) but B has dimensions $(size(B))"))
             end
 
             dotprod = $real(zero(dot(first(A), first(B))))

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -272,7 +272,7 @@ Base.isstored(A::UpperTriangular, i::Int, j::Int) =
 @propagate_inbounds function setindex!(A::UpperTriangular, x, i::Integer, j::Integer)
     if i > j
         iszero(x) || throw(ArgumentError("cannot set index in the lower triangular part " *
-            "($i, $j) of an UpperTriangular matrix to a nonzero value ($x)"))
+            lazy"($i, $j) of an UpperTriangular matrix to a nonzero value ($x)"))
     else
         A.data[i,j] = x
     end
@@ -282,10 +282,10 @@ end
 @propagate_inbounds function setindex!(A::UnitUpperTriangular, x, i::Integer, j::Integer)
     if i > j
         iszero(x) || throw(ArgumentError("cannot set index in the lower triangular part " *
-            "($i, $j) of a UnitUpperTriangular matrix to a nonzero value ($x)"))
+            lazy"($i, $j) of a UnitUpperTriangular matrix to a nonzero value ($x)"))
     elseif i == j
-        x == oneunit(x) || throw(ArgumentError("cannot set index on the diagonal ($i, $j) " *
-            "of a UnitUpperTriangular matrix to a non-unit value ($x)"))
+        x == oneunit(x) || throw(ArgumentError(lazy"cannot set index on the diagonal ($i, $j) " *
+            lazy"of a UnitUpperTriangular matrix to a non-unit value ($x)"))
     else
         A.data[i,j] = x
     end
@@ -295,7 +295,7 @@ end
 @propagate_inbounds function setindex!(A::LowerTriangular, x, i::Integer, j::Integer)
     if i < j
         iszero(x) || throw(ArgumentError("cannot set index in the upper triangular part " *
-            "($i, $j) of a LowerTriangular matrix to a nonzero value ($x)"))
+            lazy"($i, $j) of a LowerTriangular matrix to a nonzero value ($x)"))
     else
         A.data[i,j] = x
     end
@@ -305,10 +305,10 @@ end
 @propagate_inbounds function setindex!(A::UnitLowerTriangular, x, i::Integer, j::Integer)
     if i < j
         iszero(x) || throw(ArgumentError("cannot set index in the upper triangular part " *
-            "($i, $j) of a UnitLowerTriangular matrix to a nonzero value ($x)"))
+            lazy"($i, $j) of a UnitLowerTriangular matrix to a nonzero value ($x)"))
     elseif i == j
-        x == oneunit(x) || throw(ArgumentError("cannot set index on the diagonal ($i, $j) " *
-            "of a UnitLowerTriangular matrix to a non-unit value ($x)"))
+        x == oneunit(x) || throw(ArgumentError(lazy"cannot set index on the diagonal ($i, $j) " *
+            lazy"of a UnitLowerTriangular matrix to a non-unit value ($x)"))
     else
         A.data[i,j] = x
     end
@@ -317,7 +317,7 @@ end
 
 @inline function fill!(A::UpperTriangular, x)
     iszero(x) || throw(ArgumentError("cannot set indices in the lower triangular part " *
-            "of an UpperTriangular matrix to a nonzero value ($x)"))
+            lazy"of an UpperTriangular matrix to a nonzero value ($x)"))
     for col in axes(A,2), row in firstindex(A,1):col
         @inbounds A.data[row, col] = x
     end
@@ -325,7 +325,7 @@ end
 end
 @inline function fill!(A::LowerTriangular, x)
     iszero(x) || throw(ArgumentError("cannot set indices in the upper triangular part " *
-            "of a LowerTriangular matrix to a nonzero value ($x)"))
+            lazy"of a LowerTriangular matrix to a nonzero value ($x)"))
     for col in axes(A,2), row in col:lastindex(A,1)
         @inbounds A.data[row, col] = x
     end
@@ -540,7 +540,7 @@ end
 
 function checksize1(A, B)
     szA, szB = size(A), size(B)
-    szA == szB || throw(DimensionMismatch("size of A, $szA, does not match size of B, $szB"))
+    szA == szB || throw(DimensionMismatch(lazy"size of A, $szA, does not match size of B, $szB"))
     checksquare(B)
 end
 
@@ -1003,11 +1003,11 @@ function generic_trimatmul!(C::AbstractVecOrMat, uploc, isunitc, tfun::Function,
     m, n = size(B, 1), size(B, 2)
     N = size(A, 1)
     if m != N
-        throw(DimensionMismatch("right hand side B needs first dimension of size $(size(A,1)), has size $m"))
+        throw(DimensionMismatch(lazy"right hand side B needs first dimension of size $(size(A,1)), has size $m"))
     end
     mc, nc = size(C, 1), size(C, 2)
     if mc != N || nc != n
-        throw(DimensionMismatch("output has dimensions ($mc,$nc), should have ($N,$n)"))
+        throw(DimensionMismatch(lazy"output has dimensions ($mc,$nc), should have ($N,$n)"))
     end
     oA = oneunit(eltype(A))
     unit = isunitc == 'U'
@@ -1065,11 +1065,11 @@ function generic_trimatmul!(C::AbstractVecOrMat, uploc, isunitc, ::Function, xA:
     m, n = size(B, 1), size(B, 2)
     N = size(A, 1)
     if m != N
-        throw(DimensionMismatch("right hand side B needs first dimension of size $(size(A,1)), has size $m"))
+        throw(DimensionMismatch(lazy"right hand side B needs first dimension of size $(size(A,1)), has size $m"))
     end
     mc, nc = size(C, 1), size(C, 2)
     if mc != N || nc != n
-        throw(DimensionMismatch("output has dimensions ($mc,$nc), should have ($N,$n)"))
+        throw(DimensionMismatch(lazy"output has dimensions ($mc,$nc), should have ($N,$n)"))
     end
     oA = oneunit(eltype(A))
     unit = isunitc == 'U'
@@ -1102,11 +1102,11 @@ function generic_mattrimul!(C::AbstractMatrix, uploc, isunitc, tfun::Function, A
     m, n = size(A, 1), size(A, 2)
     N = size(B, 1)
     if n != N
-        throw(DimensionMismatch("right hand side B needs first dimension of size $n, has size $N"))
+        throw(DimensionMismatch(lazy"right hand side B needs first dimension of size $n, has size $N"))
     end
     mc, nc = size(C, 1), size(C, 2)
     if mc != m || nc != N
-        throw(DimensionMismatch("output has dimensions ($mc,$nc), should have ($m,$N)"))
+        throw(DimensionMismatch(lazy"output has dimensions ($mc,$nc), should have ($m,$N)"))
     end
     oB = oneunit(eltype(B))
     unit = isunitc == 'U'
@@ -1164,11 +1164,11 @@ function generic_mattrimul!(C::AbstractMatrix, uploc, isunitc, ::Function, A::Ab
     m, n = size(A, 1), size(A, 2)
     N = size(B, 1)
     if n != N
-        throw(DimensionMismatch("right hand side B needs first dimension of size $n, has size $N"))
+        throw(DimensionMismatch(lazy"right hand side B needs first dimension of size $n, has size $N"))
     end
     mc, nc = size(C, 1), size(C, 2)
     if mc != m || nc != N
-        throw(DimensionMismatch("output has dimensions ($mc,$nc), should have ($m,$N)"))
+        throw(DimensionMismatch(lazy"output has dimensions ($mc,$nc), should have ($m,$N)"))
     end
     oB = oneunit(eltype(B))
     unit = isunitc == 'U'
@@ -1212,10 +1212,10 @@ function generic_trimatdiv!(C::AbstractVecOrMat, uploc, isunitc, tfun::Function,
     mA, nA = size(A)
     m, n = size(B, 1), size(B,2)
     if nA != m
-        throw(DimensionMismatch("second dimension of left hand side A, $nA, and first dimension of right hand side B, $m, must be equal"))
+        throw(DimensionMismatch(lazy"second dimension of left hand side A, $nA, and first dimension of right hand side B, $m, must be equal"))
     end
     if size(C) != size(B)
-        throw(DimensionMismatch("size of output, $(size(C)), does not match size of right hand side, $(size(B))"))
+        throw(DimensionMismatch(lazy"size of output, $(size(C)), does not match size of right hand side, $(size(B))"))
     end
     oA = oneunit(eltype(A))
     @inbounds if uploc == 'U'
@@ -1348,10 +1348,10 @@ function generic_trimatdiv!(C::AbstractVecOrMat, uploc, isunitc, ::Function, xA:
     mA, nA = size(A)
     m, n = size(B, 1), size(B,2)
     if nA != m
-        throw(DimensionMismatch("second dimension of left hand side A, $nA, and first dimension of right hand side B, $m, must be equal"))
+        throw(DimensionMismatch(lazy"second dimension of left hand side A, $nA, and first dimension of right hand side B, $m, must be equal"))
     end
     if size(C) != size(B)
-        throw(DimensionMismatch("size of output, $(size(C)), does not match size of right hand side, $(size(B))"))
+        throw(DimensionMismatch(lazy"size of output, $(size(C)), does not match size of right hand side, $(size(B))"))
     end
     oA = oneunit(eltype(A))
     @inbounds if uploc == 'U'
@@ -1430,10 +1430,10 @@ function generic_mattridiv!(C::AbstractMatrix, uploc, isunitc, tfun::Function, A
     require_one_based_indexing(C, A, B)
     m, n = size(A)
     if size(B, 1) != n
-        throw(DimensionMismatch("right hand side B needs first dimension of size $n, has size $(size(B,1))"))
+        throw(DimensionMismatch(lazy"right hand side B needs first dimension of size $n, has size $(size(B,1))"))
     end
     if size(C) != size(A)
-        throw(DimensionMismatch("size of output, $(size(C)), does not match size of left hand side, $(size(A))"))
+        throw(DimensionMismatch(lazy"size of output, $(size(C)), does not match size of left hand side, $(size(A))"))
     end
     oB = oneunit(eltype(B))
     unit = isunitc == 'U'
@@ -1493,10 +1493,10 @@ function generic_mattridiv!(C::AbstractMatrix, uploc, isunitc, ::Function, A::Ab
     require_one_based_indexing(C, A, B)
     m, n = size(A)
     if size(B, 1) != n
-        throw(DimensionMismatch("right hand side B needs first dimension of size $n, has size $(size(B,1))"))
+        throw(DimensionMismatch(lazy"right hand side B needs first dimension of size $n, has size $(size(B,1))"))
     end
     if size(C) != size(A)
-        throw(DimensionMismatch("size of output, $(size(C)), does not match size of left hand side, $(size(A))"))
+        throw(DimensionMismatch(lazy"size of output, $(size(C)), does not match size of left hand side, $(size(A))"))
     end
     oB = oneunit(eltype(B))
     unit = isunitc == 'U'
@@ -1618,7 +1618,7 @@ end
 #     34(3), (2013) 1341–1360.
 function powm!(A0::UpperTriangular, p::Real)
     if abs(p) >= 1
-        throw(ArgumentError("p must be a real number in (-1,1), got $p"))
+        throw(ArgumentError(lazy"p must be a real number in (-1,1), got $p"))
     end
 
     normA0 = opnorm(A0, 1)
@@ -2548,7 +2548,7 @@ function eigvecs(A::AbstractTriangular{T}) where T
     if TT <: BlasFloat
         return eigvecs(convert(AbstractMatrix{TT}, A))
     else
-        throw(ArgumentError("eigvecs type $(typeof(A)) not supported. Please submit a pull request."))
+        throw(ArgumentError(lazy"eigvecs type $(typeof(A)) not supported. Please submit a pull request."))
     end
 end
 det(A::UnitUpperTriangular{T}) where {T} = one(T)

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -9,7 +9,7 @@ struct SymTridiagonal{T, V<:AbstractVector{T}} <: AbstractMatrix{T}
     function SymTridiagonal{T, V}(dv, ev) where {T, V<:AbstractVector{T}}
         require_one_based_indexing(dv, ev)
         if !(length(dv) - 1 <= length(ev) <= length(dv))
-            throw(DimensionMismatch("subdiagonal has wrong length. Has length $(length(ev)), but should be either $(length(dv) - 1) or $(length(dv))."))
+            throw(DimensionMismatch(lazy"subdiagonal has wrong length. Has length $(length(ev)), but should be either $(length(dv) - 1) or $(length(dv))."))
         end
         new{T, V}(dv, ev)
     end
@@ -191,8 +191,8 @@ function diag(M::SymTridiagonal{T}, n::Integer=0) where T<:Number
     elseif absn <= size(M,1)
         return fill!(similar(M.dv, size(M,1)-absn), zero(T))
     else
-        throw(ArgumentError(string("requested diagonal, $n, must be at least $(-size(M, 1)) ",
-            "and at most $(size(M, 2)) for an $(size(M, 1))-by-$(size(M, 2)) matrix")))
+        throw(ArgumentError(string(lazy"requested diagonal, $n, must be at least $(-size(M, 1)) ",
+            lazy"and at most $(size(M, 2)) for an $(size(M, 1))-by-$(size(M, 2)) matrix")))
     end
 end
 function diag(M::SymTridiagonal, n::Integer=0)
@@ -207,8 +207,8 @@ function diag(M::SymTridiagonal, n::Integer=0)
     elseif n <= size(M,1)
         throw(ArgumentError("requested diagonal contains undefined zeros of an array type"))
     else
-        throw(ArgumentError(string("requested diagonal, $n, must be at least $(-size(M, 1)) ",
-            "and at most $(size(M, 2)) for an $(size(M, 1))-by-$(size(M, 2)) matrix")))
+        throw(ArgumentError(string(lazy"requested diagonal, $n, must be at least $(-size(M, 1)) ",
+            lazy"and at most $(size(M, 2)) for an $(size(M, 1))-by-$(size(M, 2)) matrix")))
     end
 end
 
@@ -350,8 +350,8 @@ isdiag(M::SymTridiagonal) =  iszero(_evview(M))
 function tril!(M::SymTridiagonal{T}, k::Integer=0) where T
     n = length(M.dv)
     if !(-n - 1 <= k <= n - 1)
-        throw(ArgumentError(string("the requested diagonal, $k, must be at least ",
-            "$(-n - 1) and at most $(n - 1) in an $n-by-$n matrix")))
+        throw(ArgumentError(string(lazy"the requested diagonal, $k, must be at least ",
+            lazy"$(-n - 1) and at most $(n - 1) in an $n-by-$n matrix")))
     elseif k < -1
         fill!(M.ev, zero(T))
         fill!(M.dv, zero(T))
@@ -369,8 +369,8 @@ end
 function triu!(M::SymTridiagonal{T}, k::Integer=0) where T
     n = length(M.dv)
     if !(-n + 1 <= k <= n + 1)
-        throw(ArgumentError(string("the requested diagonal, $k, must be at least ",
-            "$(-n + 1) and at most $(n + 1) in an $n-by-$n matrix")))
+        throw(ArgumentError(string(lazy"the requested diagonal, $k, must be at least ",
+            lazy"$(-n + 1) and at most $(n + 1) in an $n-by-$n matrix")))
     elseif k > 1
         fill!(M.ev, zero(T))
         fill!(M.dv, zero(T))
@@ -463,7 +463,7 @@ end
     if i == j
         @inbounds A.dv[i] = x
     else
-        throw(ArgumentError("cannot set off-diagonal entry ($i, $j)"))
+        throw(ArgumentError(lazy"cannot set off-diagonal entry ($i, $j)"))
     end
     return x
 end
@@ -480,7 +480,7 @@ struct Tridiagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
         if (length(dl) != n-1 || length(du) != n-1) && !(length(d) == 0 && length(dl) == 0 && length(du) == 0)
             throw(ArgumentError(string("cannot construct Tridiagonal from incompatible ",
                 "lengths of subdiagonal, diagonal and superdiagonal: ",
-                "($(length(dl)), $(length(d)), $(length(du)))")))
+                lazy"($(length(dl)), $(length(d)), $(length(du)))")))
         end
         new{T,V}(dl, d, Base.unalias(dl, du))
     end
@@ -645,8 +645,8 @@ function diag(M::Tridiagonal{T}, n::Integer=0) where T
     elseif abs(n) <= size(M,1)
         return fill!(similar(M.d, size(M,1)-abs(n)), zero(T))
     else
-        throw(ArgumentError(string("requested diagonal, $n, must be at least $(-size(M, 1)) ",
-            "and at most $(size(M, 2)) for an $(size(M, 1))-by-$(size(M, 2)) matrix")))
+        throw(ArgumentError(string(lazy"requested diagonal, $n, must be at least $(-size(M, 1)) ",
+            lazy"and at most $(size(M, 2)) for an $(size(M, 1))-by-$(size(M, 2)) matrix")))
     end
 end
 
@@ -698,8 +698,8 @@ end
     elseif j - i == 1
         @inbounds A.du[i] = x
     elseif !iszero(x)
-        throw(ArgumentError(string("cannot set entry ($i, $j) off ",
-            "the tridiagonal band to a nonzero value ($x)")))
+        throw(ArgumentError(string(lazy"cannot set entry ($i, $j) off ",
+            lazy"the tridiagonal band to a nonzero value ($x)")))
     end
     return x
 end
@@ -741,8 +741,8 @@ isdiag(M::Tridiagonal) = iszero(M.dl) && iszero(M.du)
 function tril!(M::Tridiagonal{T}, k::Integer=0) where T
     n = length(M.d)
     if !(-n - 1 <= k <= n - 1)
-        throw(ArgumentError(string("the requested diagonal, $k, must be at least ",
-            "$(-n - 1) and at most $(n - 1) in an $n-by-$n matrix")))
+        throw(ArgumentError(string(lazy"the requested diagonal, $k, must be at least ",
+            lazy"$(-n - 1) and at most $(n - 1) in an $n-by-$n matrix")))
     elseif k < -1
         fill!(M.dl, zero(T))
         fill!(M.d, zero(T))
@@ -759,8 +759,8 @@ end
 function triu!(M::Tridiagonal{T}, k::Integer=0) where T
     n = length(M.d)
     if !(-n + 1 <= k <= n + 1)
-        throw(ArgumentError(string("the requested diagonal, $k, must be at least ",
-            "$(-n + 1) and at most $(n + 1) in an $n-by-$n matrix")))
+        throw(ArgumentError(string(lazy"the requested diagonal, $k, must be at least ",
+            lazy"$(-n + 1) and at most $(n + 1) in an $n-by-$n matrix")))
     elseif k > 1
         fill!(M.dl, zero(T))
         fill!(M.d, zero(T))
@@ -928,7 +928,7 @@ function ldiv!(A::Tridiagonal, B::AbstractVecOrMat)
     LinearAlgebra.require_one_based_indexing(B)
     n = size(A, 1)
     if n != size(B,1)
-        throw(DimensionMismatch("matrix has dimensions ($n,$n) but right hand side has $(size(B,1)) rows"))
+        throw(DimensionMismatch(lazy"matrix has dimensions ($n,$n) but right hand side has $(size(B,1)) rows"))
     end
     nrhs = size(B, 2)
 


### PR DESCRIPTION
Taken along with #53975, this makes JET report no warnings in the following:
```julia
julia> using LinearAlgebra, JET

julia> @noinline Broadcast.throwdm(axdest, axsrc) =
           throw(DimensionMismatch(lazy"destination axes $axdest are not compatible with source axes $axsrc")) #53975

julia> function LinearAlgebra._muldiag_size_check(A, B) # patch from this PR
           nA = size(A, 2)
           mB = size(B, 1)
           @noinline throw_dimerr(::AbstractMatrix, nA, mB) = throw(DimensionMismatch(lazy"second dimension of A, $nA, does not match first dimension of B, $mB"))
           @noinline throw_dimerr(::AbstractVector, nA, mB) = throw(DimensionMismatch(lazy"second dimension of D, $nA, does not match length of V, $mB"))
           nA == mB || throw_dimerr(B, nA, mB)
           return nothing
       end
_muldiag_size_check (generic function with 2 methods)

julia> D = Diagonal(rand(2));

julia> @report_opt D * D
No errors detected
```
Otherwise, on v1.11.0-alpha2, this reports
```julia
julia> @report_opt D * D
═════ 4 possible errors found ═════
┌ *(Da::Diagonal{Float64, Vector{Float64}}, Db::Diagonal{Float64, Vector{Float64}}) @ LinearAlgebra /cache/build/builder-amdci4-1/julialang/julia-release-1-dot-11/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/diagonal.jl:304
│┌ _muldiag_size_check(A::Diagonal{Float64, Vector{Float64}}, B::Diagonal{Float64, Vector{Float64}}) @ LinearAlgebra /cache/build/builder-amdci4-1/julialang/julia-release-1-dot-11/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/diagonal.jl:284
││┌ (::LinearAlgebra.var"#throw_dimerr#251")(::Diagonal{Float64, Vector{Float64}}, nA::Int64, mB::Int64) @ LinearAlgebra /cache/build/builder-amdci4-1/julialang/julia-release-1-dot-11/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/diagonal.jl:282
│││┌ string(::String, ::Int64, ::String, ::Int64) @ Base ./strings/io.jl:189
││││┌ print_to_string(::String, ::Int64, ::String, ::Int64) @ Base ./strings/io.jl:150
│││││┌ _unsafe_take!(io::IOBuffer) @ Base ./iobuffer.jl:494
││││││┌ wrap(::Type{Array}, m::MemoryRef{UInt8}, l::Int64) @ Base ./array.jl:3101
│││││││ failed to optimize due to recursion: wrap(::Type{Array}, ::MemoryRef{UInt8}, ::Int64)
││││││└────────────────────
│││││┌ print_to_string(::String, ::Int64, ::String, ::Vararg{Any}) @ Base ./strings/io.jl:143
││││││ runtime dispatch detected: Base._str_sizehint(%17::Any)::Int64
│││││└────────────────────
│││││┌ print_to_string(::String, ::Int64, ::String, ::Vararg{Any}) @ Base ./strings/io.jl:148
││││││ runtime dispatch detected: print(%59::IOBuffer, %97::Any)::Any
│││││└────────────────────
│││││┌ string(::String, ::Int64, ::String, ::Tuple{Int64}, ::String, ::Int64, ::String, ::Int64, ::String) @ Base ./strings/io.jl:189
││││││ failed to optimize due to recursion: string(::String, ::Int64, ::String, ::Tuple{Int64}, ::String, ::Int64, ::String, ::Int64, ::String)
│││││└────────────────────
```
I've implemented similar changes for all `DimensionMismatch` and `ArgumentError` messages in `LinearAlgebra` where string interpolation is taking place.