### PR TITLE
fix minor typo in mktempdir docs

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -821,7 +821,7 @@ end
     mktempdir(f::Function, parent=tempdir(); prefix=$(repr(temp_prefix)))
 
 Apply the function `f` to the result of [`mktempdir(parent; prefix)`](@ref) and remove the
-temporary directory all of its contents upon completion.
+temporary directory and all of its contents upon completion.
 
 See also: [`mktemp`](@ref), [`mkdir`](@ref).
 


### PR DESCRIPTION
This is a minor change, just adding a missing word to a docstring for `Base.Filesystem.mktempdir`