### PR TITLE
Remove trailing slash in "Official https://julialang.org/ release"

### DIFF
--- a/doc/src/devdocs/probes.md
+++ b/doc/src/devdocs/probes.md
@@ -188,7 +188,7 @@ Julia session and get the PID and REPL's task address:
    _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
   | | | | | | |/ _` |  |
   | | |_| | | | (_| |  |  Version 1.6.2 (2021-07-14)
- _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
+ _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org release
 |__/                   |
 
 1> getpid()
@@ -264,7 +264,7 @@ We can see this problem illustrated with `bpftrace` quite easily. First, in one 
    _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
   | | | | | | |/ _` |  |
   | | |_| | | | (_| |  |  Version 1.6.2 (2021-07-14)
- _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
+ _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org release
 |__/                   |
 
 1> getpid()

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -104,7 +104,7 @@ function versioninfo(io::IO=stdout; verbose::Bool=false)
     if !isempty(Base.GIT_VERSION_INFO.commit_short)
         println(io, "Commit $(Base.GIT_VERSION_INFO.commit_short) ($(Base.GIT_VERSION_INFO.date_string))")
     end
-    official_release = Base.TAGGED_RELEASE_BANNER == "Official https://julialang.org/ release"
+    official_release = Base.TAGGED_RELEASE_BANNER == "Official https://julialang.org release"
     if Base.isdebugbuild() || !isempty(Base.TAGGED_RELEASE_BANNER) || (Base.GIT_VERSION_INFO.tagged_commit && !official_release)
         println(io, "Build Info:")
         if Base.isdebugbuild()


### PR DESCRIPTION
The url in the "official release" note ends in a trailing slash and is a plausible typo for `https://julialang.org/release` (for a moment I thought this was the case). I propose removing the trailing slash to reduce potential confusion there, and to be consistent with the documentation url, and because in a browser, `https://julialang.org/` redirects to `https://julialang.org`.

Current:
```
x@fedora:~/.julia/dev/julia$ julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.11.0-alpha2 (2024-03-18)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> 
x@fedora:~/.julia/dev/julia$ julia --banner=short
  o  | Version 1.11.0-alpha2 (2024-03-18)
 o o | Official https://julialang.org/ release
julia> 
```

Proposed:
```
x@fedora:~/.julia/dev/julia$ julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.11.0-alpha2 (2024-03-18)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org release
|__/                   |

julia> 
x@fedora:~/.julia/dev/julia$ julia --banner=short
  o  | Version 1.11.0-alpha2 (2024-03-18)
 o o | Official https://julialang.org release
julia> 
```