### PR TITLE
Test and fix non-int-length bug in `view(::Memory, ::Union{UnitRange, Base.OneTo})`

### DIFF
--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -308,7 +308,7 @@ end
         isempty(inds) && return T[] # needed to allow view(Memory{T}(undef, 0), 2:1)
         @boundscheck checkbounds(m, inds)
         ref = MemoryRef(m, first(inds)) # @inbounds would be safe here but does not help performance.
-        dims = (length(inds),)
+        dims = (Int(length(inds)),)
         $(Expr(:new, :(Array{T, 1}), :ref, :dims))
     end
 end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -3205,6 +3205,9 @@ end
     @test @inferred(view(mem, -5:-7))::Vector{Int} == []
     @test @inferred(reshape(mem, 5, 2))::Matrix{Int} == reshape(11:20, 5, 2)
 
+    # 53990
+    @test @inferred(view(mem, unsigned(1):10))::Vector{Int} == 11:20
+
     empty_mem = Memory{Module}(undef, 0)
     @test_throws BoundsError view(empty_mem, 0:1)
     @test_throws BoundsError view(empty_mem, 1:2)

--- a/test/core.jl
+++ b/test/core.jl
@@ -5524,6 +5524,9 @@ let a = Base.StringVector(2^17)
     @test sizeof(c) == 0
 end
 
+# issue #53990 / https://github.com/JuliaLang/julia/pull/53896#discussion_r1555087951
+@test Base.StringVector(UInt64(2)) isa String
+
 @test_throws ArgumentError eltype(Bottom)
 
 # issue #16424, re-evaluating type definitions

--- a/test/core.jl
+++ b/test/core.jl
@@ -5525,7 +5525,7 @@ let a = Base.StringVector(2^17)
 end
 
 # issue #53990 / https://github.com/JuliaLang/julia/pull/53896#discussion_r1555087951
-@test Base.StringVector(UInt64(2)) isa String
+@test Base.StringVector(UInt64(2)) isa Vector{UInt8}
 
 @test_throws ArgumentError eltype(Bottom)
 


### PR DESCRIPTION
We assumed, falsely, that `length(inds) isa Int`. The length must be convertible to an `Int` or we throw, but that conversion may need to be explicitly performed.

Fixes #53990

CC @oscardssmith @vtjnash @odow 