### PR TITLE
In reprocess_instruction include the statement in unhandled expression error

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -168,8 +168,7 @@ function reprocess_instruction!(interp::AbstractInterpreter, inst::Instruction, 
         elseif head === :leave
             return false
         else
-            Core.println(stmt)
-            error("reprocess_instruction!: unhandled expression found")
+            error("reprocess_instruction!: unhandled expression found. Expr: $stmt")
         end
     elseif isa(stmt, PhiNode)
         rt = abstract_eval_phi_stmt(interp, stmt, idx, irsv)


### PR DESCRIPTION
Printing the erroring expression to stdout rather than including it in the error message is bad and leads to this being easy to miss when reading tests.
current output is e.g.
```
...
Expr(:code_coverage_effect)
Eras mode: true: Error During Test at /home/runner/work/Diffractor.jl/Diffractor.jl/test/forward_diff_no_inf.jl:111
  Got exception outside of a @test
  reprocess_instruction!: unhandled expression found
  Stacktrace:
    [1] error(s::String)
      @ Core.Compiler ./error.jl:35
 ...
 ```