### PR TITLE
make `view(::Memory, ::Colon)` produce a Vector

### DIFF
--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -312,3 +312,4 @@ end
         $(Expr(:new, :(Array{T, 1}), :ref, :dims))
     end
 end
+view(m::GenericMemory, inds::Colon) = view(m, eachindex(m))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -3203,6 +3203,7 @@ end
     @test @inferred(view(mem, 3:8))::Vector{Int} == 13:18
     @test @inferred(view(mem, 20:19))::Vector{Int} == []
     @test @inferred(view(mem, -5:-7))::Vector{Int} == []
+    @test @inferred(view(mem, :))::Vector{Int} == mem
     @test @inferred(reshape(mem, 5, 2))::Matrix{Int} == reshape(11:20, 5, 2)
 
     # 53990
@@ -3217,6 +3218,7 @@ end
 
     @test @inferred(view(empty_mem, 1:0))::Vector{Module} == []
     @test @inferred(view(empty_mem, 10:3))::Vector{Module} == []
+    @test @inferred(view(empty_mem, :))::Vector{Module} == empty_mem
     @test isempty(@inferred(reshape(empty_mem, 0, 7, 1))::Array{Module, 3})
 
     offset_inds = OffsetArrays.IdOffsetRange(values=3:6, indices=53:56)


### PR DESCRIPTION
Followup for https://github.com/JuliaLang/julia/pull/53896. It seems weird and inconsistent for `view(m, eachindex(m))` to produce something more efficient than `view(m, :)`.

cc @oscardssmith 