### PR TITLE
Overload `Base.literal_pow` for `AbstractQ`

### DIFF
--- a/stdlib/LinearAlgebra/src/abstractq.jl
+++ b/stdlib/LinearAlgebra/src/abstractq.jl
@@ -20,8 +20,8 @@ adjoint(adjQ::AdjointQ) = adjQ.Q
 
 Base.literal_pow(::typeof(^), Q::AbstractQ, ::Val{p}) where {p} =
     Q*Base.literal_pow(^, Q, Val(p-1)) # for speed
-Base.literal_pow(::typeof(^), Q::AbstractQ, ::Val{1}) = Q*I
-Base.literal_pow(::typeof(^), Q::AbstractQ, ::Val{-1}) = Q'*I # for disambiguation
+Base.literal_pow(::typeof(^), Q::AbstractQ, ::Val{1}) = Q
+Base.literal_pow(::typeof(^), Q::AbstractQ, ::Val{-1}) = inv(Q)
 
 # promotion with AbstractMatrix, at least for equal eltypes
 promote_rule(::Type{<:AbstractMatrix{T}}, ::Type{<:AbstractQ{T}}) where {T} =

--- a/stdlib/LinearAlgebra/src/abstractq.jl
+++ b/stdlib/LinearAlgebra/src/abstractq.jl
@@ -18,10 +18,9 @@ transpose(Q::AbstractQ{<:Real}) = AdjointQ(Q)
 transpose(Q::AbstractQ) = error("transpose not implemented for $(typeof(Q)). Consider using adjoint instead of transpose.")
 adjoint(adjQ::AdjointQ) = adjQ.Q
 
-Base.literal_pow(::typeof(^), Q::AbstractQ, ::Val{p}) where {p} =
-    Q*Base.literal_pow(^, Q, Val(p-1)) # for speed
-Base.literal_pow(::typeof(^), Q::AbstractQ, ::Val{1}) = Q
-Base.literal_pow(::typeof(^), Q::AbstractQ, ::Val{-1}) = inv(Q)
+(^)(Q::AbstractQ, p::Integer) = p < 0 ? power_by_squaring(inv(Q), -p) : power_by_squaring(Q, p)
+@inline Base.literal_pow(::typeof(^), Q::AbstractQ, ::Val{1}) = Q
+@inline Base.literal_pow(::typeof(^), Q::AbstractQ, ::Val{-1}) = inv(Q)
 
 # promotion with AbstractMatrix, at least for equal eltypes
 promote_rule(::Type{<:AbstractMatrix{T}}, ::Type{<:AbstractQ{T}}) where {T} =

--- a/stdlib/LinearAlgebra/src/abstractq.jl
+++ b/stdlib/LinearAlgebra/src/abstractq.jl
@@ -18,6 +18,11 @@ transpose(Q::AbstractQ{<:Real}) = AdjointQ(Q)
 transpose(Q::AbstractQ) = error("transpose not implemented for $(typeof(Q)). Consider using adjoint instead of transpose.")
 adjoint(adjQ::AdjointQ) = adjQ.Q
 
+Base.literal_pow(::typeof(^), Q::AbstractQ, ::Val{p}) where {p} =
+    Q*Base.literal_pow(^, Q, Val(p-1)) # for speed
+Base.literal_pow(::typeof(^), Q::AbstractQ, ::Val{1}) = Q*I
+Base.literal_pow(::typeof(^), Q::AbstractQ, ::Val{-1}) = Q'*I # for disambiguation
+
 # promotion with AbstractMatrix, at least for equal eltypes
 promote_rule(::Type{<:AbstractMatrix{T}}, ::Type{<:AbstractQ{T}}) where {T} =
     (@inline; Union{AbstractMatrix{T},AbstractQ{T}})

--- a/stdlib/LinearAlgebra/test/abstractq.jl
+++ b/stdlib/LinearAlgebra/test/abstractq.jl
@@ -41,9 +41,9 @@ n = 5
         @test I*Q' ≈ I*Q.Q' rtol=2eps(real(T))
         @test Q^3 ≈ Q*Q*Q
         @test Q^2 ≈ Q*Q
-        @test Q^1 ≈ Q*I
-        @test Q^(-1) ≈ Q'*I
-        @test (Q')^(-1) ≈ Q*I
+        @test Q^1 == Q
+        @test Q^(-1) == Q'
+        @test (Q')^(-1) == Q
         @test (Q')^2 ≈ Q'*Q'
         @test abs(det(Q)) ≈ 1
         @test logabsdet(Q)[1] ≈ 0 atol=2n*eps(real(T))

--- a/stdlib/LinearAlgebra/test/abstractq.jl
+++ b/stdlib/LinearAlgebra/test/abstractq.jl
@@ -39,6 +39,12 @@ n = 5
         @test Q'*I ≈ Q.Q'*I rtol=2eps(real(T))
         @test I*Q ≈ Q.Q*I rtol=2eps(real(T))
         @test I*Q' ≈ I*Q.Q' rtol=2eps(real(T))
+        @test Q^3 ≈ Q*Q*Q
+        @test Q^2 ≈ Q*Q
+        @test Q^1 ≈ Q*I
+        @test Q^(-1) ≈ Q'*I
+        @test (Q')^(-1) ≈ Q*I
+        @test (Q')^2 ≈ Q'*Q'
         @test abs(det(Q)) ≈ 1
         @test logabsdet(Q)[1] ≈ 0 atol=2n*eps(real(T))
         y = rand(T, n)


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#1060.

There's a decision to be made here. What do we want `Q^-1` to return? `Q'::AbstractQ` or `Q'*I::Matrix`? On Julia v1.9 and older, `Q^p` returned the matrix representation for any `p` except `p=-1`, where it returned `inv(Q)` which was defined to be `Q'`. I have returned to this behavior after finding out.