### PR TITLE
Type-stable codegen for specialized `in(v, ::Tuple)`

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1348,13 +1348,12 @@ end
 # Specialized variant of in for Tuple, which can generate typed comparisons for each element
 # of the tuple, skipping values that are statically known to be != at compile time.
 function in(x, itr::Tuple)
-    @_terminates_locally_meta
+    @_terminates_globally
     _in_tuple(x, itr, false)
 end
 # This recursive function will be unrolled at compiletime, and will not generate separate
 # llvm-compiled specializations for each step of the recursion.
 @inline function _in_tuple(x, @nospecialize(itr::Tuple), anymissing::Bool)
-    @_terminates_locally_meta
     # Base case
     if isempty(itr)
         return anymissing ? missing : false

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -328,9 +328,21 @@ end
     @test lt5(4) && !lt5(5)
 end
 
+@testset "in tuples" begin
+    @test ∈(5, (1,5,10,11))
+    @test ∉(0, (1,5,10,11))
+    @test ∈(5, (1,"hi","hey",5.0))
+    @test ∉(0, (1,"hi","hey",5.0))
+    @test ∈(5, (5,))
+    @test ∉(0, (5,))
+    @test ∉(5, ())
+end
+
 @testset "ni" begin
     @test ∋([1,5,10,11], 5)
     @test !∋([1,10,11], 5)
+    @test ∋((1,5,10,11), 5)
+    @test ∌((1,10,11), 5)
     @test ∋(5)([5,1])
     @test !∋(42)([0,1,100])
     @test ∌(0)(1:10)


### PR DESCRIPTION
Since we were already specializing in for Tuples anyway, we should be generating code that can take advantage of the tuple type, rather than doing a generic, type-unstable traversal.

Before:
```julia
julia> @btime Base.in($(5), (1, 2.0, 3, "hey", 5.2))
  53.541 ns (6 allocations: 224 bytes)
false
```

After:
```julia
julia> @btime Base.in($(5), (1, 2.0, 3, "hey", 5.2))
  1.666 ns (0 allocations: 0 bytes)
false
```

The new code statically unrolls the tuple comparisons, and thus also compiles away any of the comparisons that are statically known to be not equal, such as the `==(::Int, ::String)` comparison for element 4 in the example above.