### PR TITLE
Add GlobalOpt passes, this allows us to remove unused functions and globals

### DIFF
--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -40,6 +40,7 @@
 #include <llvm/Transforms/IPO/ConstantMerge.h>
 #include <llvm/Transforms/IPO/ForceFunctionAttrs.h>
 #include <llvm/Transforms/IPO/GlobalDCE.h>
+#include <llvm/Transforms/IPO/GlobalOpt.h>
 #include <llvm/Transforms/InstCombine/InstCombine.h>
 #include <llvm/Transforms/Instrumentation/AddressSanitizer.h>
 #include <llvm/Transforms/Instrumentation/MemorySanitizer.h>
@@ -416,6 +417,7 @@ static void buildEarlyOptimizerPipeline(ModulePassManager &MPM, PassBuilder *PB,
           MPM.addPass(createModuleToFunctionPassAdaptor(std::move(FPM)));
       }
       MPM.addPass(GlobalDCEPass());
+      MPM.addPass(GlobalOptPass());
     }
     MPM.addPass(AfterEarlyOptimizationMarkerPass());
 }
@@ -589,6 +591,7 @@ static void buildCleanupPipeline(ModulePassManager &MPM, PassBuilder *PB, Optimi
             if (O.getSpeedupLevel() >= 2) {
                 FPM.addPass(GVNPass());
             }
+            MPM.addPass(GlobalOptPass());
             MPM.addPass(createModuleToFunctionPassAdaptor(std::move(FPM)));
         }
     }

--- a/test/llvmpasses/image-codegen.jl
+++ b/test/llvmpasses/image-codegen.jl
@@ -14,7 +14,7 @@
 # CHECK-NOT: private global
 # CHECK: jl_global
 # COM: we emit both declarations and definitions, so we may see either style in the IR
-# CHECK-SAME: = {{(external )?}}global
+# CHECK-SAME: = {{(external )?}}local_unnamed_addr global
 # CHECK: julia_f_
 # CHECK-NOT: internal global
 # CHECK-NOT: private global


### PR DESCRIPTION
This specially allows us to remove unused functions marked internal in the LLVM modules