### PR TITLE
Fix comparison base for line table compression

### DIFF
--- a/src/ircode.c
+++ b/src/ircode.c
@@ -1234,7 +1234,6 @@ JL_DLLEXPORT jl_string_t *jl_compress_codelocs(int32_t firstline, jl_value_t *co
 #undef SETMIN
 #undef SETMAX
     }
-    min.line = min.to = min.pc = firstline <= 0 ? INT32_MAX : firstline;
     int32_t header[3];
     header[0] = min.line > max.line ? 0 : min.line;
     header[1] = min.line > max.line ? 0 : max.line - min.line;

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -825,3 +825,10 @@ end
 @test_throws ErrorException f_must_throw_phinode_edge()
 global global_error_switch = false
 @test f_must_throw_phinode_edge() == 1
+
+# Test roundtrip of debuginfo compression
+let cl = Int32[32, 1, 1, 1000, 240, 230]
+    str = ccall(:jl_compress_codelocs, Any, (Int32, Any, Int), 378, cl, 2)::String;
+    cl2 = ccall(:jl_uncompress_codelocs, Any, (Any, Int), str, 2)
+    @test cl == cl2
+end


### PR DESCRIPTION
I'm not entirely sure what the original intent of this statement was, but the effect ends up being that some codeloc entries end up negative in the compressed representation, but the code always assumes unsigned integers, so things roundtripped badly, leading to badly corrupted stack traces. I guess this might have been a rebase mistake,
since the same line exists (correctly) a few lines prior. Fixes #54031.