### PR TITLE
constprop: Add facility for widening arguments before constprop

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1243,12 +1243,17 @@ const_prop_result(inf_result::InferenceResult) =
 return_cached_result(::AbstractInterpreter, inf_result::InferenceResult, ::AbsIntState) =
     const_prop_result(inf_result)
 
+function compute_forwarded_argtypes(interp::AbstractInterpreter, arginfo::ArgInfo, sv::AbsIntState)
+    𝕃ᵢ = typeinf_lattice(interp)
+    return has_conditional(𝕃ᵢ, sv) ? ConditionalSimpleArgtypes(arginfo, sv) : SimpleArgtypes(arginfo.argtypes)
+end
+
 function const_prop_call(interp::AbstractInterpreter,
     mi::MethodInstance, result::MethodCallResult, arginfo::ArgInfo, sv::AbsIntState,
     concrete_eval_result::Union{Nothing, ConstCallResults}=nothing)
     inf_cache = get_inference_cache(interp)
     𝕃ᵢ = typeinf_lattice(interp)
-    argtypes = has_conditional(𝕃ᵢ, sv) ? ConditionalArgtypes(arginfo, sv) : SimpleArgtypes(arginfo.argtypes)
+    forwarded_argtypes = compute_forwarded_argtypes(interp, arginfo, sv)
     # use `cache_argtypes` that has been constructed for fresh regular inference if available
     volatile_inf_result = result.volatile_inf_result
     if volatile_inf_result !== nothing
@@ -1256,7 +1261,7 @@ function const_prop_call(interp::AbstractInterpreter,
     else
         cache_argtypes = matching_cache_argtypes(𝕃ᵢ, mi)
     end
-    argtypes = matching_cache_argtypes(𝕃ᵢ, mi, argtypes, cache_argtypes)
+    argtypes = matching_cache_argtypes(𝕃ᵢ, mi, forwarded_argtypes, cache_argtypes)
     inf_result = cache_lookup(𝕃ᵢ, mi, argtypes, inf_cache)
     if inf_result !== nothing
         # found the cache for this constant prop'
@@ -1290,7 +1295,10 @@ function const_prop_call(interp::AbstractInterpreter,
         return nothing
     end
     @assert inf_result.result !== nothing
-    if concrete_eval_result !== nothing
+    # ConditionalSimpleArgtypes is allowed, because the only case in which it modifies
+    # the argtypes is when one of the argtypes is a `Conditional`, which case
+    # concrete_eval_result will not be available.
+    if concrete_eval_result !== nothing && isa(forwarded_argtypes, Union{SimpleArgtypes, ConditionalSimpleArgtypes})
         # override return type and effects with concrete evaluation result if available
         inf_result.result = concrete_eval_result.rt
         inf_result.ipo_effects = concrete_eval_result.effects
@@ -1300,13 +1308,13 @@ end
 
 # TODO implement MustAlias forwarding
 
-struct ConditionalArgtypes
+struct ConditionalSimpleArgtypes
     arginfo::ArgInfo
     sv::InferenceState
 end
 
 function matching_cache_argtypes(𝕃::AbstractLattice, mi::MethodInstance,
-                                 conditional_argtypes::ConditionalArgtypes,
+                                 conditional_argtypes::ConditionalSimpleArgtypes,
                                  cache_argtypes::Vector{Any})
     (; arginfo, sv) = conditional_argtypes
     (; fargs, argtypes) = arginfo

--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -9,8 +9,15 @@ struct SimpleArgtypes
     argtypes::Vector{Any}
 end
 
+# Like `SimpleArgtypes`, but allows the argtypes to be wider than the current call.
+# As a result, it is not legal to refine the cache result with information more
+# precise than was it deducible from the `WidenedSimpleArgtypes`.
+struct WidenedArgtypes
+    argtypes::Vector{Any}
+end
+
 function matching_cache_argtypes(𝕃::AbstractLattice, mi::MethodInstance,
-                                 simple_argtypes::SimpleArgtypes,
+                                 simple_argtypes::Union{SimpleArgtypes, WidenedArgtypes},
                                  cache_argtypes::Vector{Any})
     (; argtypes) = simple_argtypes
     given_argtypes = Vector{Any}(undef, length(argtypes))


### PR DESCRIPTION
There are various situations where we may want to constprop with something other than the most precise concrete arguments in order to make the resulting cache more useful to other call sites. One particular example of this might be a method where non-concrete inference already discovered that one argument is unused:

```
function foo(a, b::DispatchOnly)
    expensive_to_compile(a)
end
```

Right now, we will generally perform constprop for every different value of `b`, even though we already have the information that `b` is unused.

Another example is external absints that may want to treat certain types fully symbolically. They may want to substitute concrete values for an abstract domain.

This adds the facility to do both of these things by
1. Adding an appropriate interp hook in the constprop path
2. Adding a WidendedSimpleArgtypes wrapper that's like SimpleArgtypes but works around an issue where we would override cache information using values from concrete eval, which is not legal if the argtypes were widened.