### PR TITLE
inference: disable constprop for unused arguments

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1366,6 +1366,9 @@ function matching_cache_argtypes(𝕃::AbstractLattice, mi::MethodInstance,
     else
         given_argtypes = va_process_argtypes(𝕃, given_argtypes, mi)
     end
+    # XXX The argtype widening should probably be handled by `WidenedArgtypes`, but it would
+    # be fine to widen it here as well, since unused-ness ensures that the argtype has no
+    # contribution to the results like return type, effects, etc.
     if used !== nothing
         for i = 1:length(given_argtypes)
             if !used[i]

--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -190,7 +190,7 @@ function cache_lookup(𝕃::AbstractLattice, mi::MethodInstance, given_argtypes:
         cache_argtypes = cached_result.argtypes
         @assert length(cache_argtypes) == nargtypes "invalid `cache_argtypes` for `mi`"
         cache_argsinfo = cached_result.argsinfo
-        cache_argsinfo isa ArgtypeOverridden || @goto next_cache # cached locally, but not constant prop'ed
+        cache_argsinfo isa ArgtypeOverrideInfo || @goto next_cache # cached locally, but not constant prop'ed
         cache_overridden_by_const = cache_argsinfo.overridden_by_const
         for i in 1:nargtypes
             if !is_argtype_match(𝕃, given_argtypes[i], cache_argtypes[i], cache_overridden_by_const[i])

--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -189,7 +189,9 @@ function cache_lookup(𝕃::AbstractLattice, mi::MethodInstance, given_argtypes:
         cached_result.linfo === mi || @goto next_cache
         cache_argtypes = cached_result.argtypes
         @assert length(cache_argtypes) == nargtypes "invalid `cache_argtypes` for `mi`"
-        cache_overridden_by_const = cached_result.overridden_by_const::BitVector
+        cache_argsinfo = cached_result.argsinfo
+        cache_argsinfo isa ArgtypeOverridden || @goto next_cache # cached locally, but not constant prop'ed
+        cache_overridden_by_const = cache_argsinfo.overridden_by_const
         for i in 1:nargtypes
             if !is_argtype_match(𝕃, given_argtypes[i], cache_argtypes[i], cache_overridden_by_const[i])
                 @goto next_cache

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -510,13 +510,23 @@ function _should_insert_coverage(info::DebugInfo)
     return false
 end
 
+struct ArgUsed
+    used::BitVector
+end
+
 function InferenceState(result::InferenceResult, cache_mode::UInt8, interp::AbstractInterpreter)
     # prepare an InferenceState object for inferring lambda
     world = get_inference_world(interp)
     src = retrieve_code_info(result.linfo, world)
     src === nothing && return nothing
     maybe_validate_code(result.linfo, src, "lowered")
-    return InferenceState(result, src, cache_mode, interp)
+    sv = InferenceState(result, src, cache_mode, interp)
+    used = falses(length(result.argtypes))
+    for i = 1:length(result.argtypes)
+        used[i] |= !iszero(src.slotflags[i])
+    end
+    stack_analysis_result!(result, ArgUsed(used))
+    return sv
 end
 InferenceState(result::InferenceResult, cache_mode::Symbol, interp::AbstractInterpreter) =
     InferenceState(result, convert_cache_mode(cache_mode), interp)

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -854,7 +854,7 @@ end
 frame_parent(sv::InferenceState) = sv.parent::Union{Nothing,AbsIntState}
 frame_parent(sv::IRInterpretationState) = sv.parent::Union{Nothing,AbsIntState}
 
-is_constproped(sv::InferenceState) = sv.result.argsinfo isa ArgtypeOverridden
+is_constproped(sv::InferenceState) = sv.result.argsinfo isa ArgtypeOverrideInfo
 is_constproped(::IRInterpretationState) = true
 
 is_cached(sv::InferenceState) = !iszero(sv.cache_mode & CACHE_MODE_GLOBAL)

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -13,6 +13,12 @@ struct CallMeta
     exct::Any
     effects::Effects
     info::CallInfo
+    argtypes_profitable::Union{Nothing,BitVector}
+    function CallMeta(rt::Any, exct::Any, effects::Effects, info::CallInfo,
+                      argtypes_profitable::Union{Nothing,BitVector}=nothing)
+        @nospecialize rt exct info
+        return new(rt, exct, effects, info, argtypes_profitable)
+    end
 end
 
 struct NoCallInfo <: CallInfo end

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -23,9 +23,10 @@ abstract type AbstractLattice end
 struct ArgInfo
     fargs::Union{Nothing,Vector{Any}}
     argtypes::Vector{Any}
-    used::Union{Nothing,BitVector}
-    function ArgInfo(fargs::Union{Nothing,Vector{Any}}, argtypes::Vector{Any}, used::Union{Nothing,BitVector}=nothing)
-        return new(fargs, argtypes, used)
+    argtypes_profitable::Union{Nothing,BitVector}
+    function ArgInfo(fargs::Union{Nothing,Vector{Any}}, argtypes::Vector{Any},
+                     argtypes_profitable::Union{Nothing,BitVector}=nothing)
+        return new(fargs, argtypes, argtypes_profitable)
     end
 end
 
@@ -71,10 +72,10 @@ struct AnalysisResults
 end
 const NULL_ANALYSIS_RESULTS = AnalysisResults(nothing)
 
-struct ArgUsed
-    used::BitVector
+struct ArgtypeProfitability
+    profitable::BitVector
 end
-struct ArgtypeOverridden
+struct ArgtypeOverrideInfo
     overridden_by_const::BitVector
 end
 
@@ -85,13 +86,13 @@ A type that represents the result of running type inference on a chunk of code.
 There are two constructor available:
 - `InferenceResult(mi::MethodInstance, [𝕃::AbstractLattice])` for regular inference,
   without extended lattice information included in `result.argtypes`.
-- `InferenceResult(mi::MethodInstance, argtypes::Vector{Any}, argsinfo::ArgtypeOverridden)`
+- `InferenceResult(mi::MethodInstance, argtypes::Vector{Any}, argsinfo::ArgtypeOverrideInfo)`
   for constant inference, with extended lattice information included in `result.argtypes`.
 """
 mutable struct InferenceResult
     const linfo::MethodInstance
     const argtypes::Vector{Any}
-    const argsinfo::Union{ArgUsed,ArgtypeOverridden} # `ArgUsed` for regular inference, `ArgtypeOverridden` for constant inference
+    const argsinfo::Union{ArgtypeProfitability,ArgtypeOverrideInfo} # `ArgtypeProfitability` for regular inference, `ArgtypeOverrideInfo` for constant inference
     result                   # extended lattice element if inferred, nothing otherwise
     exc_result               # like `result`, but for the thrown value
     src                      # ::Union{CodeInfo, IRCode, OptimizationState} if inferred copy is available, nothing otherwise
@@ -101,7 +102,7 @@ mutable struct InferenceResult
     analysis_results::AnalysisResults # AnalysisResults with e.g. result::ArgEscapeCache if optimized, otherwise NULL_ANALYSIS_RESULTS
     is_src_volatile::Bool    # `src` has been cached globally as the compressed format already, allowing `src` to be used destructively
     ci::CodeInstance         # CodeInstance if this result has been added to the cache
-    function InferenceResult(mi::MethodInstance, argtypes::Vector{Any}, argsinfo::Union{ArgUsed,ArgtypeOverridden})
+    function InferenceResult(mi::MethodInstance, argtypes::Vector{Any}, argsinfo::Union{ArgtypeProfitability,ArgtypeOverrideInfo})
         def = mi.def
         nargs = def isa Method ? Int(def.nargs) : 0
         @assert length(argtypes) == nargs "invalid `argtypes` for `mi`"
@@ -111,7 +112,7 @@ mutable struct InferenceResult
 end
 function InferenceResult(mi::MethodInstance, 𝕃::AbstractLattice=fallback_lattice)
     argtypes = matching_cache_argtypes(𝕃, mi)
-    argsinfo = ArgUsed(falses(length(argtypes)))
+    argsinfo = ArgtypeProfitability(falses(length(argtypes)))
     return InferenceResult(mi, argtypes, argsinfo)
 end
 

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -23,6 +23,10 @@ abstract type AbstractLattice end
 struct ArgInfo
     fargs::Union{Nothing,Vector{Any}}
     argtypes::Vector{Any}
+    used::Union{Nothing,BitVector}
+    function ArgInfo(fargs::Union{Nothing,Vector{Any}}, argtypes::Vector{Any}, used::Union{Nothing,BitVector}=nothing)
+        return new(fargs, argtypes, used)
+    end
 end
 
 struct StmtInfo

--- a/test/compiler/AbstractInterpreter.jl
+++ b/test/compiler/AbstractInterpreter.jl
@@ -447,7 +447,7 @@ const CONST_INVOKE_INTERP = ConstInvokeInterp(; world=CONST_INVOKE_INTERP_WORLD)
 function custom_lookup(mi::MethodInstance, min_world::UInt, max_world::UInt)
     for inf_result in CONST_INVOKE_INTERP.inf_cache
         if inf_result.linfo === mi
-            if CC.any(inf_result.overridden_by_const)
+            if inf_result.argsinfo isa CC.ArgtypeOverridden
                 return CodeInstance(CONST_INVOKE_INTERP, inf_result)
             end
         end

--- a/test/compiler/AbstractInterpreter.jl
+++ b/test/compiler/AbstractInterpreter.jl
@@ -447,7 +447,7 @@ const CONST_INVOKE_INTERP = ConstInvokeInterp(; world=CONST_INVOKE_INTERP_WORLD)
 function custom_lookup(mi::MethodInstance, min_world::UInt, max_world::UInt)
     for inf_result in CONST_INVOKE_INTERP.inf_cache
         if inf_result.linfo === mi
-            if inf_result.argsinfo isa CC.ArgtypeOverridden
+            if inf_result.argsinfo isa CC.ArgtypeOverrideInfo
                 return CodeInstance(CONST_INVOKE_INTERP, inf_result)
             end
         end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5767,7 +5767,7 @@ function test_func_unused_constprop2_inter(x)
 end;
 let interp = LocalCacheInterp()
     @test Base.infer_return_type(test_func_unused_constprop2_inter, (Float64,); interp) == Tuple{Base.RefValue{Float64}, Base.RefValue{Float64}}
-    @test_broken count(interp.inf_cache) do result
+    @test count(interp.inf_cache) do result
         result.linfo.def.name === :func_unused_constprop2_inter
     end == 0
 end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5754,7 +5754,7 @@ function test_func_unused_constprop2(x)
 end;
 let interp = LocalCacheInterp()
     @test Base.infer_return_type(test_func_unused_constprop2, (Float64,); interp) == Tuple{Base.RefValue{Float64}, Base.RefValue{Float64}}
-    @test_broken count(interp.inf_cache) do result
+    @test count(interp.inf_cache) do result
         result.linfo.def.name === :func_unused_constprop2
     end == 0
 end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5706,7 +5706,7 @@ end
 
 # inference local cache lookup with extended lattice elements that may be transformed
 # by `matching_cache_argtypes`
-@newinterp CachedConditionalInterp
+@newinterp LocalCacheInterp
 Base.@constprop :aggressive function func_cached_conditional(x, y)
     if x
         @noinline sin(y)
@@ -5719,9 +5719,42 @@ function test_func_cached_conditional(y)
     y₂ = func_cached_conditional(isa(y, Float64), y)
     return y₁, y₂
 end;
-let interp = CachedConditionalInterp();
+let interp = LocalCacheInterp()
     @test Base.infer_return_type(test_func_cached_conditional, (Any,); interp) == Tuple{Float64, Float64}
     @test count(interp.inf_cache) do result
         result.linfo.def.name === :func_cached_conditional
     end == 1
+end
+
+@noinline Base.@constprop :aggressive func_unused_constprop1(x, y) = Ref(sin(x)) # NOTE Ref(...) prevents semi-concrete interpretation
+function test_func_unused_constprop1(x)
+    x₁ = func_unused_constprop1(x, true)
+    x₂ = func_unused_constprop1(x, false)
+    return x₁, x₂
+end;
+let interp = LocalCacheInterp()
+    @test Base.infer_return_type(test_func_unused_constprop1, (Float64,); interp) == Tuple{Base.RefValue{Float64}, Base.RefValue{Float64}}
+    @test count(interp.inf_cache) do result
+        result.linfo.def.name === :func_unused_constprop1
+    end == 0
+end
+let interp = LocalCacheInterp() # exercise globally-cached cases
+    @test Base.infer_return_type(test_func_unused_constprop1, (Float64,); interp) == Tuple{Base.RefValue{Float64}, Base.RefValue{Float64}}
+    @test count(interp.inf_cache) do result
+        result.linfo.def.name === :func_unused_constprop1
+    end == 0
+end
+
+@noinline Base.@constprop :aggressive func_unused_constprop2(x, y) =
+    Ref(isa(x, Float64) ? sin(x) : y) # NOTE Ref(...) prevents semi-concrete interpretation
+function test_func_unused_constprop2(x)
+    x₁ = func_unused_constprop2(x, true)
+    x₂ = func_unused_constprop2(x, false)
+    return x₁, x₂
+end;
+let interp = LocalCacheInterp()
+    @test Base.infer_return_type(test_func_unused_constprop2, (Float64,); interp) == Tuple{Base.RefValue{Float64}, Base.RefValue{Float64}}
+    @test_broken count(interp.inf_cache) do result
+        result.linfo.def.name === :func_unused_constprop2
+    end == 0
 end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5759,6 +5759,19 @@ let interp = LocalCacheInterp()
     end == 0
 end
 
+func_unused_constprop2_inter(x, y) = func_unused_constprop2(x, y)
+function test_func_unused_constprop2_inter(x)
+    x₁ = func_unused_constprop2_inter(x, true)
+    x₂ = func_unused_constprop2_inter(x, false)
+    return x₁, x₂
+end;
+let interp = LocalCacheInterp()
+    @test Base.infer_return_type(test_func_unused_constprop2_inter, (Float64,); interp) == Tuple{Base.RefValue{Float64}, Base.RefValue{Float64}}
+    @test_broken count(interp.inf_cache) do result
+        result.linfo.def.name === :func_unused_constprop2_inter
+    end == 0
+end
+
 @noinline Base.@constprop :aggressive function func_unused_constprop3(x, y)
     z = y
     return Ref(sin(x)) # NOTE Ref(...) prevents semi-concrete interpretation


### PR DESCRIPTION
This commit implements the idea concept suggested in #54036 to stop constant propagation for unused arguments. There are still some tasks to complete, but I've turned it into a PR to facilitate benchmarking. The pending tasks are as follows:
- [x] incorporate used-ness information derived from abstract interpretation (this will address the `@test_broken` that is being added by this commit)
- [ ] apply `WidenedArgtypes` appropriately

@nanosoldier `runbenchmarks("inference", vs=":master")`