### PR TITLE
LinearAlgebra: fix copyto! with aliased arrays

### DIFF
--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -66,6 +66,9 @@ similar(H::UpperHessenberg, ::Type{T}, dims::Dims{N}) where {T,N} = similar(H.da
 AbstractMatrix{T}(H::UpperHessenberg) where {T} = UpperHessenberg{T}(H)
 AbstractMatrix{T}(H::UpperHessenberg{T}) where {T} = copy(H)
 
+Base.dataids(A::UpperHessenberg) = Base.dataids(parent(A))
+Base.unaliascopy(A::UpperHessenberg) = UpperHessenberg(Base.unaliascopy(parent(A)))
+
 copy(H::UpperHessenberg) = UpperHessenberg(copy(H.data))
 real(H::UpperHessenberg{<:Real}) = H
 real(H::UpperHessenberg{<:Complex}) = UpperHessenberg(triu!(real(H.data),-1))

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -269,6 +269,10 @@ end
     end
 end
 
+Base.dataids(A::HermOrSym) = Base.dataids(parent(A))
+Base.unaliascopy(A::Hermitian) = Hermitian(Base.unaliascopy(parent(A)), sym_uplo(A.uplo))
+Base.unaliascopy(A::Symmetric) = Symmetric(Base.unaliascopy(parent(A)), sym_uplo(A.uplo))
+
 _conjugation(::Symmetric) = transpose
 _conjugation(::Hermitian) = adjoint
 
@@ -345,7 +349,7 @@ function copyto!(dest::Symmetric, src::Symmetric)
     if src.uplo == dest.uplo
         copyto!(dest.data, src.data)
     else
-        transpose!(dest.data, src.data)
+        transpose!(dest.data, Base.unalias(dest.data, src.data))
     end
     return dest
 end
@@ -354,7 +358,7 @@ function copyto!(dest::Hermitian, src::Hermitian)
     if src.uplo == dest.uplo
         copyto!(dest.data, src.data)
     else
-        adjoint!(dest.data, src.data)
+        adjoint!(dest.data, Base.unalias(dest.data, src.data))
     end
     return dest
 end

--- a/stdlib/LinearAlgebra/test/hessenberg.jl
+++ b/stdlib/LinearAlgebra/test/hessenberg.jl
@@ -250,4 +250,13 @@ end
     @test axes(S) === (r,r)
 end
 
+@testset "copyto! with aliasing (#39460)" begin
+    M = Matrix(reshape(1:36, 6, 6))
+    A = UpperHessenberg(view(M, 1:5, 1:5))
+    A2 = copy(A)
+    B = UpperHessenberg(view(M, 2:6, 2:6))
+    @test copyto!(B, A) == A2
+end
+
+
 end # module TestHessenberg

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -975,4 +975,19 @@ end
     @test conj(H) == conj(Array(H))
 end
 
+@testset "copyto! with aliasing (#39460)" begin
+    M = Matrix(reshape(1:36, 6, 6))
+    @testset for T in (Symmetric, Hermitian), uploA in (:U, :L), uploB in (:U, :L)
+        A = T(view(M, 1:5, 1:5), uploA)
+        A2 = copy(A)
+        B = T(view(M, 2:6, 2:6), uploB)
+        @test copyto!(B, A) == A2
+
+        A = view(M, 2:4, 2:4)
+        B = T(view(M, 1:3, 1:3), uploB)
+        B2 = copy(B)
+        @test copyto!(A, B) == B2
+    end
+end
+
 end # module TestSymmetric

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -1041,4 +1041,14 @@ end
     end
 end
 
+@testset "copyto! with aliasing (#39460)" begin
+    M = Matrix(reshape(1:36, 6, 6))
+    @testset for T in (UpperTriangular, LowerTriangular)
+        A = T(view(M, 1:5, 1:5))
+        A2 = copy(A)
+        B = T(view(M, 2:6, 2:6))
+        @test copyto!(B, A) == A2
+    end
+end
+
 end # module TestTriangular


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/39460 by ensuring that the matrices are `unalias`ed before copying. Also added `dataids` and `unaliascopy` for some of the wrapper types, which makes more such `copyto!` operations with aliased matrices return correct results.