### PR TITLE
Only run Test.jl precompilation workload when outputting

### DIFF
--- a/stdlib/Test/src/precompile.jl
+++ b/stdlib/Test/src/precompile.jl
@@ -1,9 +1,11 @@
-redirect_stdout(devnull) do
-    @testset "example" begin
-        @test 1 == 1
-        @test_throws ErrorException error()
-        @test_logs (:info, "Doing foo with n=2") @info "Doing foo with n=2"
-        @test_broken 1 == 2
-        @test 1 ≈ 1.0000000000000001
+if Base.generating_output()
+    redirect_stdout(devnull) do
+        @testset "example" begin
+            @test 1 == 1
+            @test_throws ErrorException error()
+            @test_logs (:info, "Doing foo with n=2") @info "Doing foo with n=2"
+            @test_broken 1 == 2
+            @test 1 ≈ 1.0000000000000001
+        end
     end
 end


### PR DESCRIPTION
These types of workloads are usually only run when generating output.