### PR TITLE
add `public` statement to `Base.Broadcast`

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -12,6 +12,9 @@ using .Base: Indices, OneTo, tail, to_shape, isoperator, promote_typejoin, promo
              _msk_end, unsafe_bitgetindex, bitcache_chunks, bitcache_size, dumpbitcache, unalias, negate
 import .Base: copy, copyto!, axes
 export broadcast, broadcast!, BroadcastStyle, broadcast_axes, broadcastable, dotview, @__dot__, BroadcastFunction
+public AbstractArrayStyle, ArrayStyle, Broadcasted, DefaultArrayStyle, DefaultMatrixStyle,
+    DefaultVectorStyle, Unknown, Style, combine_axes, combine_styles, flatten, instantiate,
+    materialize, result_style
 
 ## Computing the result's axes: deprecated name
 const broadcast_axes = axes

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -12,8 +12,8 @@ using .Base: Indices, OneTo, tail, to_shape, isoperator, promote_typejoin, promo
              _msk_end, unsafe_bitgetindex, bitcache_chunks, bitcache_size, dumpbitcache, unalias, negate
 import .Base: copy, copyto!, axes
 export broadcast, broadcast!, BroadcastStyle, broadcast_axes, broadcastable, dotview, @__dot__, BroadcastFunction
-public AbstractArrayStyle, ArrayStyle, Broadcasted, DefaultArrayStyle, DefaultMatrixStyle,
-    DefaultVectorStyle, Unknown, Style, combine_axes, combine_styles, flatten, instantiate,
+public AbstractArrayStyle, ArrayStyle, Broadcasted, DefaultArrayStyle,
+    Unknown, Style, combine_axes, combine_styles, flatten, instantiate,
     materialize, result_style
 
 ## Computing the result's axes: deprecated name

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1179,7 +1179,7 @@ f51129(v, x) = (1 .- (v ./ x) .^ 2)
 @testset "Docstrings" begin
     undoc = Docs.undocumented_names(Broadcast)
     @test_broken isempty(undoc)
-    @test undoc == [:dotview]
+    @test undoc == [:Broadcasted, :Unknown, :dotview]
 end
 
 @testset "broadcast for `AbstractArray` without `CartesianIndex` support" begin


### PR DESCRIPTION
This PR makes the following symbols from `Base.Broadcast` public:

- Symbols appearing in the documentation, with docstring
```
AbstractArrayStyle
ArrayStyle
Broadcasted
DefaultArrayStyle
Style
combine_axes
combine_styles
flatten
instantiate
result_style
```

- Symbols appearing in the documentation, **without** docstring
```
Unknown
```

- Symbols **not** appearing in the documentation, with docstring
```
materialize
```
I think it makes sense to make it public given that `Broadcasted` is also public.

- Symbols **not** appearing in the documentation, **without** docstring
```
DefaultMatrixStyle
DefaultVectorStyle
```
I think it makes sense to have them available as shortcuts. Maybe one should even mention them in the documentation instead of using `DefaultArrayStyle{1}`, for example.

EDIT: Making `DefaultVectorStyle` and `DefaultMatrixStyle` public leads to failing doctests because they now appear in the Julia output instead of `DefaultArrayStyle{1}` and `DefaultArrayStyle{2}`. However, they are never used in broadcast.jl. If one doesn't want to have them public, why are they defined at all? Let me know if you want to have them public. Then I adjust the documentation.

- The following functions have been left out although they have docstrings:
```
broadcast_preserving_zero_d
broadcast_shape
make_makeargs
newindex
_broadcast_getindex
```

- The following symbol (with docstring) is currently exported **without** appearing in the documentation:
```
BroadcastFunction
```