### PR TITLE
LinearAlgebra: Type-stability in broadcasting numbers over Bidiagonal

### DIFF
--- a/stdlib/LinearAlgebra/src/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/src/structuredbroadcast.jl
@@ -172,7 +172,7 @@ isvalidstructbc(dest, bc::Broadcasted{T}) where {T<:StructuredMatrixStyle} =
     (isstructurepreserving(bc) || fzeropreserving(bc))
 
 isvalidstructbc(dest::Bidiagonal, bc::Broadcasted{StructuredMatrixStyle{Bidiagonal}}) =
-    (size(dest, 1) < 2 || first(find_uplo(bc)) == dest.uplo) &&
+    (size(dest, 1) < 2 || find_uplo(bc) == dest.uplo) &&
     (isstructurepreserving(bc) || fzeropreserving(bc))
 
 function copyto!(dest::Diagonal, bc::Broadcasted{<:StructuredMatrixStyle})

--- a/stdlib/LinearAlgebra/test/structuredbroadcast.jl
+++ b/stdlib/LinearAlgebra/test/structuredbroadcast.jl
@@ -96,6 +96,24 @@ using Test, LinearAlgebra
             @test broadcast!(*, Z, X, Y) == broadcast(*, fX, fY)
         end
     end
+
+    @testset "type-stability in Bidiagonal" begin
+        B2 = @inferred (B -> .- B)(B)
+        @test B2 isa Bidiagonal
+        @test B2 == -1 * B
+        B2 = @inferred (B -> B .* 2)(B)
+        @test B2 isa Bidiagonal
+        @test B2 == B + B
+        B2 = @inferred (B -> 2 .* B)(B)
+        @test B2 isa Bidiagonal
+        @test B2 == B + B
+        B2 = @inferred (B -> B ./ 1)(B)
+        @test B2 isa Bidiagonal
+        @test B2 == B
+        B2 = @inferred (B -> 1 .\ B)(B)
+        @test B2 isa Bidiagonal
+        @test B2 == B
+    end
 end
 
 @testset "broadcast! where the destination is a structured matrix" begin


### PR DESCRIPTION
This makes the following type-stable:
```julia
julia> B = Bidiagonal(rand(3), rand(2), :U);

julia> @inferred (B -> B .* 2)(B)
3×3 Bidiagonal{Float64, Vector{Float64}}:
 0.3929  1.93165   ⋅ 
  ⋅      1.61301  1.00202
  ⋅       ⋅       1.96483
```
Similarly, for other operations involving a single `Bidiagonal` and numbers. This is not type-stable on master, as the number of `Bidiagonal` matrices in a broadcast operation is not tracked (even though this is used in promoting the `uplo`). Since the `uplo` can't be constant-propagated, we count this by introducing an additional flag in the promotion mechanism, which is entirely determined by the types of the terms in the broadcast operation.