### PR TITLE
Allow PrecompileTools to see MI's inferred by foreign abstract interpreters

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -204,9 +204,8 @@ If set to `true`, record per-method-instance timings within type inference in th
 __set_measure_typeinf(onoff::Bool) = __measure_typeinf__[] = onoff
 const __measure_typeinf__ = fill(false)
 
-# Wrapper around `_typeinf` that optionally records the exclusive time for
-# each inference performed by `NativeInterpreter`.
-function typeinf(interp::NativeInterpreter, frame::InferenceState)
+# Wrapper around `_typeinf` that optionally records the exclusive time for each invocation.
+function typeinf(interp::AbstractInterpreter, frame::InferenceState)
     if __measure_typeinf__[]
         Timings.enter_new_timer(frame)
         v = _typeinf(interp, frame)
@@ -216,7 +215,6 @@ function typeinf(interp::NativeInterpreter, frame::InferenceState)
         return _typeinf(interp, frame)
     end
 end
-typeinf(interp::AbstractInterpreter, frame::InferenceState) = _typeinf(interp, frame)
 
 function finish!(interp::AbstractInterpreter, caller::InferenceState)
     result = caller.result


### PR DESCRIPTION
Partially reverts https://github.com/JuliaLang/julia/pull/49391

PrecompileTools uses the timing infrastructure to snoop on the inference process.
The reason for #49391 was that this could lead to accidental pollution of the caches
with foreign results (https://github.com/timholy/SnoopCompile.jl/issues/338)

After #52233 and especially #53336 we now filter results by cache owner and
don't try to cache foreign code using the native pipeline.

Motivated by https://github.com/JuliaGPU/GPUCompiler.jl/pull/567 which demonstrated 
that a foreign code instance would not be cached without PrecompileTools.
