### PR TITLE
Fix integer overflow in `skip(s::IOBuffer, typemax(Int64))`

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -281,6 +281,10 @@ function seek(io::GenericIOBuffer, n::Int)
         ismarked(io) || throw(ArgumentError("seek failed, IOBuffer is not seekable and is not marked"))
         n == io.mark || throw(ArgumentError("seek failed, IOBuffer is not seekable and n != mark"))
     end
+    # TODO: REPL.jl relies on the fact that this does not throw (by seeking past the beginning or end
+    #       of an GenericIOBuffer), so that would need to be fixed in order to throw an error here
+    #(n < 0 || n > io.size - io.offset) && throw(ArgumentError("Attempted to seek outside IOBuffer boundaries."))
+    #io.ptr = n + io.offset + 1
     io.ptr = clamp(n, 0, io.size - io.offset) + io.offset + 1
     return io
 end

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -267,7 +267,6 @@ function skip(io::GenericIOBuffer, n::Int)
         seekto = clamp(widen(position(io)) + widen(n), Int)
         seek(io, seekto) # Does error checking
     else
-        @assert io.ptr ≤ io.size + 1
         n_max = io.size + 1 - io.ptr
         io.ptr += min(n, n_max)
         io

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -280,7 +280,7 @@ function seek(io::GenericIOBuffer, n::Int)
         ismarked(io) || throw(ArgumentError("seek failed, IOBuffer is not seekable and is not marked"))
         n == io.mark || throw(ArgumentError("seek failed, IOBuffer is not seekable and n != mark"))
     end
-    io.ptr = min(clamp(widen(max(0, n)) + widen(io.offset), Int), io.size)+1
+    io.ptr = clamp(n, 0, io.size - io.offset) + io.offset + 1
     return io
 end
 

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -264,10 +264,12 @@ function skip(io::GenericIOBuffer, n::Integer)
 end
 function skip(io::GenericIOBuffer, n::Int)
     if signbit(n)
-        # Does error checking
-        seek(io, clamp(widen(position(io)) + widen(n), Int))
+        @assert !signbit(position(io))
+        seek(io, position(io) + n) # Does error checking
     else
-        io.ptr = min(clamp(widen(io.ptr) + widen(n), Int), io.size+1)
+        @assert io.ptr ≤ io.size + 1
+        n_max = io.size + 1 - io.ptr
+        io.ptr += min(n, n_max)
         io
     end
 end

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -264,8 +264,8 @@ function skip(io::GenericIOBuffer, n::Integer)
 end
 function skip(io::GenericIOBuffer, n::Int)
     if signbit(n)
-        @assert !signbit(position(io))
-        seek(io, position(io) + n) # Does error checking
+        seekto = clamp(widen(position(io)) + widen(n), Int)
+        seek(io, seekto) # Does error checking
     else
         @assert io.ptr ≤ io.size + 1
         n_max = io.size + 1 - io.ptr

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -196,6 +196,31 @@ end
     @test position(skip(io, -3)) == 0
 end
 
+@testset "issue #53908" begin
+    @testset "offset $first" for first in (false, true)
+        b = collect(0x01:0x05)
+        sizehint!(b, 100; first) # make offset non zero
+        io = IOBuffer(b)
+        @test position(skip(io, 4)) == 4
+        @test position(skip(io, typemax(Int))) == 5
+        @test position(skip(io, typemax(Int128))) == 5
+        @test position(skip(io, typemax(Int32))) == 5
+        @test position(skip(io, typemin(Int))) == 0
+        @test position(skip(io, typemin(Int128))) == 0
+        @test position(skip(io, typemin(Int32))) == 0
+        @test position(skip(io, 4)) == 4
+        @test position(skip(io, -2)) == 2
+        @test position(skip(io, -2)) == 0
+        @test position(seek(io, -2)) == 0
+        @test position(seek(io, typemax(Int))) == 5
+        @test position(seek(io, typemax(Int128))) == 5
+        @test position(seek(io, typemax(Int32))) == 5
+        @test position(seek(io, typemin(Int))) == 0
+        @test position(seek(io, typemin(Int128))) == 0
+        @test position(seek(io, typemin(Int32))) == 0
+    end
+end
+
 @testset "pr #11554" begin
     io  = IOBuffer(SubString("***αhelloworldω***", 4, 16))
     io2 = IOBuffer(Vector{UInt8}(b"goodnightmoon"), read=true, write=true)


### PR DESCRIPTION
Fixes #53908  by clamping before doing addition.

This also fixes an issue with negative skips if `io.offset` isn't zero.

I am assuming that `io.size+1` cannot overflow.