### PR TITLE
LinearAlgebra: use band index in structured broadcast

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -499,6 +499,33 @@ See also: `copymutable_oftype`.
 """
 copy_similar(A::AbstractArray, ::Type{T}) where {T} = copyto!(similar(A, T, size(A)), A)
 
+"""
+    BandIndex(band, index)
+
+Represent a Cartesian index as a linear index along a band.
+This type is primarily meant to index into a speficic band without branches,
+so, for best performance, `band` should be a compile-time constant.
+"""
+struct BandIndex
+    band :: Int
+    index :: Int
+end
+function _cartinds(b::BandIndex)
+    (; band, index) = b
+    bandg0 = max(band,0)
+    row = index - band + bandg0
+    col = index + bandg0
+    CartesianIndex(row, col)
+end
+function Base.to_indices(A, inds, t::Tuple{BandIndex, Vararg{Any}})
+    to_indices(A, inds, (_cartinds(first(t)), Base.tail(t)...))
+end
+function Base.checkbounds(::Type{Bool}, A::AbstractMatrix, b::BandIndex)
+    checkbounds(Bool, A, _cartinds(b))
+end
+function Base.checkbounds(A::Broadcasted, b::BandIndex)
+    checkbounds(A, _cartinds(b))
+end
 
 include("adjtrans.jl")
 include("transpose.jl")

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -503,7 +503,7 @@ copy_similar(A::AbstractArray, ::Type{T}) where {T} = copyto!(similar(A, T, size
     BandIndex(band, index)
 
 Represent a Cartesian index as a linear index along a band.
-This type is primarily meant to index into a speficic band without branches,
+This type is primarily meant to index into a specific band without branches,
 so, for best performance, `band` should be a compile-time constant.
 """
 struct BandIndex

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -169,6 +169,19 @@ end
     end
 end
 
+@inline function getindex(A::Bidiagonal{T}, b::BandIndex) where T
+    @boundscheck checkbounds(A, _cartinds(b))
+    if b.band == 0
+        return @inbounds A.dv[b.index]
+    elseif A.uplo == 'U' && b.band == 1
+        return @inbounds A.ev[b.index]
+    elseif A.uplo == 'L' && b.band == -1
+        return @inbounds A.ev[b.index]
+    else
+        return bidiagzero(A, Tuple(_cartinds(b))...)
+    end
+end
+
 @inline function setindex!(A::Bidiagonal, x, i::Integer, j::Integer)
     @boundscheck checkbounds(A, i, j)
     if i == j

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -188,9 +188,15 @@ end
 diagzero(::Diagonal{T}, i, j) where {T} = zero(T)
 diagzero(D::Diagonal{<:AbstractMatrix{T}}, i, j) where {T} = zeros(T, size(D.diag[i], 1), size(D.diag[j], 2))
 
-Base._reverse(A::Diagonal, dims) = reverse!(Matrix(A); dims)
-Base._reverse(A::Diagonal, ::Colon) = Diagonal(reverse(A.diag))
-Base._reverse!(A::Diagonal, ::Colon) = (reverse!(A.diag); A)
+@inline function getindex(D::Diagonal, b::BandIndex)
+    @boundscheck checkbounds(D, b)
+    if b.band == 0
+        @inbounds r = D.diag[b.index]
+    else
+        r = diagzero(D, Tuple(_cartinds(b))...)
+    end
+    r
+end
 
 function setindex!(D::Diagonal, v, i::Int, j::Int)
     @boundscheck checkbounds(D, i, j)
@@ -211,6 +217,10 @@ end
 parent(D::Diagonal) = D.diag
 
 copy(D::Diagonal) = Diagonal(copy(D.diag))
+
+Base._reverse(A::Diagonal, dims) = reverse!(Matrix(A); dims)
+Base._reverse(A::Diagonal, ::Colon) = Diagonal(reverse(A.diag))
+Base._reverse!(A::Diagonal, ::Colon) = (reverse!(A.diag); A)
 
 ishermitian(D::Diagonal{<:Real}) = true
 ishermitian(D::Diagonal{<:Number}) = isreal(D.diag)

--- a/stdlib/LinearAlgebra/test/special.jl
+++ b/stdlib/LinearAlgebra/test/special.jl
@@ -3,7 +3,7 @@
 module TestSpecial
 
 using Test, LinearAlgebra, Random
-using LinearAlgebra: rmul!
+using LinearAlgebra: rmul!, BandIndex
 
 n= 10 #Size of matrix to test
 Random.seed!(1)
@@ -769,6 +769,19 @@ end
                 end
             end
         end
+    end
+end
+
+@testset "BandIndex indexing" begin
+    for D in (Diagonal(1:3), Bidiagonal(1:3, 2:3, :U), Bidiagonal(1:3, 2:3, :L),
+                Tridiagonal(2:3, 1:3, 1:2), SymTridiagonal(1:3, 2:3))
+        M = Matrix(D)
+        for band in -size(D,1)+1:size(D,1)-1
+            for idx in 1:size(D,1)-abs(band)
+                @test D[BandIndex(band, idx)] == M[BandIndex(band, idx)]
+            end
+        end
+        @test_throws BoundsError D[BandIndex(size(D,1),1)]
     end
 end
 


### PR DESCRIPTION
This adds a new `BandIndex` type internal to `LinearAlgebra` that parallels a `CartesianIndex`, and stores a band index and a linear index of an element along that band. If the index of the band is a compile-time constant (which is often the case with `Diagonal`/`Bidiagonal`/`Tridiagonal` matrices), constant-propagation may eliminate branches in indexing into the matrix, and directly forward the indexing to the corresponding diagonal. This is particularly important in broadcasting for these matrices, which acts band-wise.

An example of an improvement in performance with this PR:
```julia
julia> using LinearAlgebra

julia> T = Tridiagonal(rand(893999), rand(894000), rand(893999)); # a large matrix

julia> @btime $T .+ $T;
  5.387 ms (10 allocations: 20.46 MiB) # v"1.12.0-DEV.337"
  2.872 ms (10 allocations: 20.46 MiB) # This PR

julia> @btime $T + $T; # reference
  2.885 ms (10 allocations: 20.46 MiB)
```
This makes the broadcast operation as fast as the sum, where the latter adds the diagonals directly.

I'm not 100% certain why this works as well as it does, as the constant band index may get lost in the `newindex` computation. I suspect branch prediction somehow works around this and preserves the constant.