### PR TITLE
irinterp: Move irinterp va processing

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -802,7 +802,6 @@ mutable struct IRInterpretationState
             given_argtypes[i] = widenslotwrapper(argtypes[i])
         end
         if isa(mi.def, Method)
-            given_argtypes = va_process_argtypes(optimizer_lattice(interp), given_argtypes, mi)
             argtypes_refined = Bool[!⊑(optimizer_lattice(interp), ir.argtypes[i], given_argtypes[i])
                 for i = 1:length(given_argtypes)]
         else
@@ -832,6 +831,7 @@ function IRInterpretationState(interp::AbstractInterpreter,
     end
     method_info = MethodInfo(src)
     ir = inflate_ir(src, mi)
+    argtypes = va_process_argtypes(optimizer_lattice(interp), argtypes, mi)
     return IRInterpretationState(interp, method_info, ir, mi, argtypes, world,
                                  codeinst.min_world, codeinst.max_world)
 end


### PR DESCRIPTION
Currently we perform the va transform inside the innermost construct of IRInterpretationState. However, I think it makes more sense to lift this processing one level, so that the `argtypes` for the constructor that takes `ir` matches `ir.argtypes`, while the one for the constructor that takes `mi` is the full expanded out argtypes. NFC for base, but the `ir` constructor is used in downstream external absints. However, I think this way around is better for them also, since it's not always clear what format the argtypes they have are in and the va direction is easy and well supported, so it's better to have the option.