### PR TITLE
Replace Unitful aware givensAlgorithm with a generic version.

### DIFF
--- a/stdlib/LinearAlgebra/src/givens.jl
+++ b/stdlib/LinearAlgebra/src/givens.jl
@@ -13,14 +13,14 @@ transpose(R::AbstractRotation) = error("transpose not implemented for $(typeof(R
 (*)(R::AbstractRotation, A::AbstractMatrix) = _rot_mul_vecormat(R, A)
 function _rot_mul_vecormat(R::AbstractRotation{T}, A::AbstractVecOrMat{S}) where {T,S}
     TS = typeof(zero(T)*zero(S) + zero(T)*zero(S))
-    lmul!(convert(AbstractRotation{TS}, R), copy_similar(A, TS))
+    lmul!(R, copy_similar(A, TS))
 end
 
 (*)(A::AbstractVector, R::AbstractRotation) = _vecormat_mul_rot(A, R)
 (*)(A::AbstractMatrix, R::AbstractRotation) = _vecormat_mul_rot(A, R)
 function _vecormat_mul_rot(A::AbstractVecOrMat{T}, R::AbstractRotation{S}) where {T,S}
     TS = typeof(zero(T)*zero(S) + zero(T)*zero(S))
-    rmul!(copy_similar(A, TS), convert(AbstractRotation{TS}, R))
+    rmul!(copy_similar(A, TS), R)
 end
 
 """

--- a/test/testhelpers/Quaternions.jl
+++ b/test/testhelpers/Quaternions.jl
@@ -16,6 +16,7 @@ end
 Quaternion(s::Real, v1::Real, v2::Real, v3::Real) = Quaternion(promote(s, v1, v2, v3)...)
 Base.convert(::Type{Quaternion{T}}, s::Real) where {T <: Real} =
     Quaternion{T}(convert(T, s), zero(T), zero(T), zero(T))
+Base.promote_rule(::Type{Quaternion{T}}, ::Type{S}) where {T,S} = Quaternion{promote_type(T,S)}
 Base.abs2(q::Quaternion) = q.s*q.s + q.v1*q.v1 + q.v2*q.v2 + q.v3*q.v3
 Base.float(z::Quaternion{T}) where T = Quaternion(float(z.s), float(z.v1), float(z.v2), float(z.v3))
 Base.abs(q::Quaternion) = sqrt(abs2(q))
@@ -25,6 +26,7 @@ Base.conj(q::Quaternion) = Quaternion(q.s, -q.v1, -q.v2, -q.v3)
 Base.isfinite(q::Quaternion) = isfinite(q.s) & isfinite(q.v1) & isfinite(q.v2) & isfinite(q.v3)
 Base.zero(::Type{Quaternion{T}}) where T = Quaternion{T}(zero(T), zero(T), zero(T), zero(T))
 
+Base.:(-)(q::Quaternion) = Quaternion(-q.s, -q.v1, -q.v2, -q.v3)
 Base.:(+)(ql::Quaternion, qr::Quaternion) =
  Quaternion(ql.s + qr.s, ql.v1 + qr.v1, ql.v2 + qr.v2, ql.v3 + qr.v3)
 Base.:(-)(ql::Quaternion, qr::Quaternion) =


### PR DESCRIPTION
The implementation is based on

Janovská, D., & Opfer, G. (2003) "Givens’ Transformation Applied to Quaternion Valued Vectors."

Fixes https://github.com/JuliaLang/LinearAlgebra.jl/issues/861