### PR TITLE
In the `UndefVarError(::Symbol)` constructor, set `scope` to `nothing`

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -341,7 +341,8 @@ struct UndefRefError       <: Exception end
 struct UndefVarError <: Exception
     var::Symbol
     scope # a Module or Symbol or other object describing the context where this variable was looked for (e.g. Main or :local or :static_parameter)
-    UndefVarError(var::Symbol) = new(var)
+    # If `scope` is not provided in the constructor, set `scope` to `nothing` (instead of making it undefined).
+    UndefVarError(var::Symbol) = new(var, nothing)
     UndefVarError(var::Symbol, @nospecialize scope) = new(var, scope)
 end
 struct ConcurrencyViolationError <: Exception


### PR DESCRIPTION
Fixes #54082
Alternative to #54084

---

This is one possible way to fix #54082.

Before this PR, if the `UndefVarError(::Symbol)` constructor is called, the `scope` field is left undefined.

After this PR, if the `UndefVarError(::Symbol)` constructor is called, the `scope` field is set to `nothing`.