### PR TITLE
set `@max_methods 2` for `error`

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -27,6 +27,15 @@ throw
 
 ## native julia error handling ##
 
+# This is `Experimental.@max_methods 2 function error end`, which is not available at this point in bootstrap.
+# NOTE It is important to always be able to infer the return type of `error` as `Union{}`,
+# but there's a hitch when a package globally sets `@max_methods 1` and it causes inference
+# for `error(::Any)` to fail (JuliaLang/julia#54029).
+# This definition site `@max_methods 2` setting overrides any global `@max_methods 1` settings
+# on package side, guaranteeing that return type inference on `error` is successful always.
+function error end
+typeof(error).name.max_methods = UInt8(2)
+
 """
     error(message::AbstractString)
 

--- a/test/error.jl
+++ b/test/error.jl
@@ -127,3 +127,15 @@ end
     visited = test_exceptions(Base)
     test_exceptions(Core, visited)
 end
+
+# inference quality test for `error`
+@test Base.infer_return_type(error, (Any,)) === Union{}
+@test Base.infer_return_type(xs->error(xs...), (Vector{Any},)) === Union{}
+module Issue54029
+export raise54029
+Base.Experimental.@max_methods 1
+raise54029(x) = error(x)
+end
+using .Issue54029
+@test Base.infer_return_type(raise54029, (Any,)) === Union{}
+@test Base.infer_return_type(xs->raise54029(xs...), (Vector{Any},)) === Union{}


### PR DESCRIPTION
It is important to always be able to infer the return type of `error` as `Union{}`, but there's a hitch when a package globally sets `@max_methods 1` and it causes inference for `error(::Any)` to fail (JuliaLang/julia#54029).

To address this, this commit sets `@max_methods 2 function error end` at the definition of `error`. This overrides any global `@max_methods 1` settings on package side, guaranteeing that return type inference on `error` is successful always.

- closes #54029