### PR TITLE
remove `mapreduce` methods that don't take an iterator argument

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -297,7 +297,7 @@ implementations may reuse the return value of `f` for elements that appear multi
 guaranteed left or right associativity and invocation of `f` for every value.
 """
 mapreduce(f, op, itr; kw...) = mapfoldl(f, op, itr; kw...)
-mapreduce(f, op, itrs...; kw...) = reduce(op, Generator(f, itrs...); kw...)
+mapreduce(f, op, itr, itrs...; kw...) = reduce(op, Generator(f, itr, itrs...); kw...)
 
 # Note: sum_seq usually uses four or more accumulators after partial
 # unrolling, so each accumulator gets at most 256 numbers

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -326,8 +326,8 @@ julia> mapreduce(isodd, |, a, dims=1)
 """
 mapreduce(f, op, A::AbstractArrayOrBroadcasted; dims=:, init=_InitialValue()) =
     _mapreduce_dim(f, op, init, A, dims)
-mapreduce(f, op, A::AbstractArrayOrBroadcasted...; kw...) =
-    reduce(op, map(f, A...); kw...)
+mapreduce(f, op, A::AbstractArrayOrBroadcasted, B::AbstractArrayOrBroadcasted...; kw...) =
+    reduce(op, map(f, A, B...); kw...)
 
 _mapreduce_dim(f, op, nt, A::AbstractArrayOrBroadcasted, ::Colon) =
     mapfoldl_impl(f, op, nt, A)


### PR DESCRIPTION
PR #52631 made `map` throw `MethodError` when called without an iterator argument. That made `mapreduce` throw `MethodError` when called without an iterator argument, too, something that was *not* noticed back then. This change makes iteratorless `mapreduce` throw before it can be called, instead of when it tries to call `map` (or `Generator`) without passing it an iterator argument.

Now all of these functions should only have methods that take a positive number of iterator arguments, which improves consistency:

1. `map`
2. `Iterators.map`
3. `foreach`
4. `reduce`
5. `foldl`
6. `foldr`
7. `mapreduce`
8. `mapfoldl`
9. `mapfoldr`
10. `Base.Generator`