### PR TITLE
add `@_propagate_inbounds_meta` to `Array` indexing methods so `@inbounds` isn't placebo

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -926,6 +926,7 @@ function getindex end
 
 function getindex(A::Array, i1::Int, i2::Int, I::Int...)
     @inline
+    @_propagate_inbounds_meta
     @boundscheck checkbounds(A, i1, i2, I...) # generally _to_linear_index requires bounds checking
     return @inbounds A[_to_linear_index(A, i1, i2, I...)]
 end
@@ -933,6 +934,7 @@ end
 # Faster contiguous indexing using copyto! for AbstractUnitRange and Colon
 function getindex(A::Array, I::AbstractUnitRange{<:Integer})
     @inline
+    @_propagate_inbounds_meta
     @boundscheck checkbounds(A, I)
     lI = length(I)
     X = similar(A, axes(I))
@@ -983,6 +985,7 @@ function setindex! end
 
 function setindex!(A::Array{T}, x, i::Int) where {T}
     @_noub_if_noinbounds_meta
+    @_propagate_inbounds_meta
     @boundscheck (i - 1)%UInt < length(A)%UInt || throw_boundserror(A, (i,))
     memoryrefset!(memoryref(A.ref, i, false), x isa T ? x : convert(T,x)::T, :not_atomic, false)
     return A
@@ -990,6 +993,7 @@ end
 function setindex!(A::Array{T}, x, i1::Int, i2::Int, I::Int...) where {T}
     @inline
     @_noub_if_noinbounds_meta
+    @_propagate_inbounds_meta
     @boundscheck checkbounds(A, i1, i2, I...) # generally _to_linear_index requires bounds checking
     memoryrefset!(memoryref(A.ref, _to_linear_index(A, i1, i2, I...), false), x isa T ? x : convert(T,x)::T, :not_atomic, false)
     return A

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -888,12 +888,14 @@ end
 # linear indexing
 function getindex(A::Array, i::Int)
     @_noub_if_noinbounds_meta
+    @_propagate_inbounds_meta
     @boundscheck ult_int(bitcast(UInt, sub_int(i, 1)), bitcast(UInt, length(A))) || throw_boundserror(A, (i,))
     memoryrefget(memoryref(getfield(A, :ref), i, false), :not_atomic, false)
 end
 # simple Array{Any} operations needed for bootstrap
 function setindex!(A::Array{Any}, @nospecialize(x), i::Int)
     @_noub_if_noinbounds_meta
+    @_propagate_inbounds_meta
     @boundscheck ult_int(bitcast(UInt, sub_int(i, 1)), bitcast(UInt, length(A))) || throw_boundserror(A, (i,))
     memoryrefset!(memoryref(getfield(A, :ref), i, false), x, :not_atomic, false)
     return A


### PR DESCRIPTION
Found by @chriselrod. Tagging jameson for review since I have a sneaking suspicion he might have intentionally not added them.