### PR TITLE
Add @typeconst

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,7 @@ New library functions
 * `logrange(start, stop; length)` makes a range of constant ratio, instead of constant step ([#39071])
 * The new `isfull(c::Channel)` function can be used to check if `put!(c, some_value)` will block. ([#53159])
 * `waitany(tasks; throw=false)` and `waitall(tasks; failfast=false, throw=false)` which wait multiple tasks at once ([#53341]).
+* `@typeconst x = y` declares the global `x` as being of type `y`, aiming to replace the widespread use of `const` to improve the performance of globals ([#????]).
 
 New library features
 --------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,7 @@ New library functions
 * `logrange(start, stop; length)` makes a range of constant ratio, instead of constant step ([#39071])
 * The new `isfull(c::Channel)` function can be used to check if `put!(c, some_value)` will block. ([#53159])
 * `waitany(tasks; throw=false)` and `waitall(tasks; failfast=false, throw=false)` which wait multiple tasks at once ([#53341]).
-* `@typeconst x = y` declares the global `x` as being of type `y`, aiming to replace the widespread use of `const` to improve the performance of globals ([#????]).
+* `@typeconst x = y` declares the global `x` as being of type `y` ([#54117]).
 
 New library features
 --------------------

--- a/base/util.jl
+++ b/base/util.jl
@@ -662,7 +662,7 @@ function typeconst_ex(ex)
     ex isa Expr || return ex
     if ex.head === :(=)
         quote
-            tmp = $(esc(ex.args[2]))
+            local tmp = $(esc(ex.args[2]))
             $(esc(ex.args[1]))::typeof(tmp) = tmp
         end
     elseif ex.head === :block

--- a/base/util.jl
+++ b/base/util.jl
@@ -657,6 +657,39 @@ function def_name_defval_from_kwdef_fielddef(kwdef)
     end
 end
 
+function typeconst_ex(ex)
+    ex isa Expr || return ex
+    if ex.head === :(=)
+        quote
+            tmp = $(esc(ex.args[2]))
+            $(esc(ex.args[1]))::typeof(tmp) = tmp
+        end
+    elseif ex.head === :block
+        ex = copy(x)
+        for i in eachindex(ex.args)
+            ex.args[i] = typeconst_ex(ex.args[i])
+        end
+        ex
+    else
+        ex
+    end
+end
+"""
+    @typeconst x = y
+
+Declares the global `x` as being of constant type `y`, and performs the assignment `x = y`.
+Equivalent to `tmp = y; x::typeof(tmp) = tmp`.
+Typically used to improve the performance of globals.
+Can also be used as `@typeconst begin x = 2; y = 3; end` to perform this replacement on several assignments.
+"""
+macro typeconst(expr)
+    if !(ex isa Expr && (ex.head in (:block, :(=))))
+        throw(ArgumentError("@typeconst: argument must be assignment or `begin` block"))
+    else
+        typeconst_ex(expr)
+    end
+end
+
 # testing
 
 """

--- a/base/util.jl
+++ b/base/util.jl
@@ -657,6 +657,7 @@ function def_name_defval_from_kwdef_fielddef(kwdef)
     end
 end
 
+
 function typeconst_ex(ex)
     ex isa Expr || return ex
     if ex.head === :(=)
@@ -665,7 +666,7 @@ function typeconst_ex(ex)
             $(esc(ex.args[1]))::typeof(tmp) = tmp
         end
     elseif ex.head === :block
-        ex = copy(x)
+        ex = copy(ex)
         for i in eachindex(ex.args)
             ex.args[i] = typeconst_ex(ex.args[i])
         end
@@ -682,11 +683,11 @@ Equivalent to `tmp = y; x::typeof(tmp) = tmp`.
 Typically used to improve the performance of globals.
 Can also be used as `@typeconst begin x = 2; y = 3; end` to perform this replacement on several assignments.
 """
-macro typeconst(expr)
+macro typeconst(ex)
     if !(ex isa Expr && (ex.head in (:block, :(=))))
         throw(ArgumentError("@typeconst: argument must be assignment or `begin` block"))
     else
-        typeconst_ex(expr)
+        typeconst_ex(ex)
     end
 end
 


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/pull/54114
I'd like it to support `@typeconst x = 3.1; @typeconst x = 3`, as well as `x = 2; @typeconst x=3.2`, but this requires figuring out if x already has a type assertion, and I don't know how to do that...