### PR TITLE
Avoid StackOverflowError of generic `norm` on `AbstractChar`

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -602,7 +602,7 @@ function norm(itr, p::Real=2)
     isempty(itr) && return float(norm(zero(eltype(itr))))
     v, s = iterate(itr)
     !isnothing(s) && !ismissing(v) && v == itr && throw(ArgumentError(
-        "cannot evaluate norm recursively if the initial element is identical to that of the container"))
+        "cannot evaluate norm recursively if the type of the initial element is identical to that of the container"))
     if p == 2
         return norm2(itr)
     elseif p == 1

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -600,6 +600,9 @@ true
 """
 function norm(itr, p::Real=2)
     isempty(itr) && return float(norm(zero(eltype(itr))))
+    v, s = iterate(itr)
+    !isnothing(s) && !ismissing(v) && v == itr && throw(ArgumentError(
+        "cannot evaluate norm recursively if the initial element is identical to that of the container"))
     if p == 2
         return norm2(itr)
     elseif p == 1
@@ -656,9 +659,6 @@ julia> norm(-2, Inf)
     end
 end
 norm(::Missing, p::Real=2) = missing
-
-norm(c::AbstractChar, p::Real=2) =
-    throw(ArgumentError(lazy"Cannot compute norm for object of type $(typeof(c))"))
 
 # special cases of opnorm
 function opnorm1(A::AbstractMatrix{T}) where T

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -657,6 +657,9 @@ julia> norm(-2, Inf)
 end
 norm(::Missing, p::Real=2) = missing
 
+norm(c::AbstractChar, p::Real=2) =
+    throw(ArgumentError(lazy"Cannot compute norm for object of type $(typeof(c))"))
+
 # special cases of opnorm
 function opnorm1(A::AbstractMatrix{T}) where T
     require_one_based_indexing(A)

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -571,6 +571,13 @@ end
     @test_broken ismissing(norm(x, 0))
 end
 
+@testset "avoid stackoverflow of norm on AbstractChar" begin
+    @test_throws ArgumentError norm('a')
+    @test_throws ArgumentError norm(['a', 'b'])
+    @test_throws ArgumentError norm("s")
+    @test_throws ArgumentError norm(["s", "t"])
+end
+
 @testset "peakflops" begin
     @test LinearAlgebra.peakflops(1024, eltype=Float32, ntrials=2) > 0
 end


### PR DESCRIPTION
Addresses JuliaLang/LinearAlgebra.jl#1040 (_StackOverflowError when using LinearAlgebra norm on "wrong" datatypes_) in the specific sense of intercepting `AbstractChar` when generically calling `norm` before the recursive loop starts.