### PR TITLE
Add `Iterators.findeach`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,7 @@ New library functions
 * Exporting function `fieldindex` to get the index of a struct's field ([#58119]).
 * `Base.donotdelete` is now public. It prevents deadcode elemination of its arguments ([#55774]).
 * `Sys.sysimage_target()` returns the CPU target string used to build the current system image ([#58970]).
+* `Iterators.findeach` is a lazy version of `findall` ([#54124])
 
 New library features
 --------------------

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -32,7 +32,7 @@ import Base:
     getindex, setindex!, get, iterate,
     popfirst!, isdone, peek, intersect
 
-export enumerate, zip, rest, countfrom, take, drop, takewhile, dropwhile, cycle, repeated, product, flatten, flatmap, partition, nth
+export enumerate, zip, rest, countfrom, take, drop, takewhile, dropwhile, cycle, repeated, product, flatten, flatmap, partition, nth, findeach
 public accumulate, filter, map, peel, reverse, Stateful
 
 """
@@ -944,6 +944,34 @@ end
 IteratorSize(::Type{<:DropWhile}) = SizeUnknown()
 eltype(::Type{DropWhile{I,P}}) where {I,P} = eltype(I)
 IteratorEltype(::Type{DropWhile{I,P}}) where {I,P} = IteratorEltype(I)
+
+"""
+    findeach(f, it)
+    findeach(it)
+
+An iterator that generates every key from the key/value pairs of `pairs(it)`,
+where `f(value)` returns `true`.
+
+If `f` is not specified, default to `identity`.
+
+`Iterators.findeach` is the lazy equivalent of `findall`.
+
+!!! compat "Julia 1.13"
+    Lazy `findeach` requires at least Julia 1.13.
+
+# Examples
+```jldoctest
+julia> collect(Iterators.findeach(isodd, Dict(2 => 3, 3 => 2)))
+1-element Vector{Int64}:
+ 2
+
+julia> only(Iterators.findeach(==(1), [3,6,2,1]))
+4
+```
+"""
+findeach(f, it) = map(first, filter(i -> f(last(i)), pairs(it)))
+
+findeach(it) = findeach(identity, it)
 
 
 # Cycle an iterator forever

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -957,7 +957,7 @@ If `f` is not specified, default to `identity`.
 `Iterators.findeach` is the lazy equivalent of `findall`.
 
 !!! compat "Julia 1.13"
-    Lazy `findeach` requires at least Julia 1.13.
+    `findeach` requires at least Julia 1.13.
 
 # Examples
 ```jldoctest

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -969,7 +969,7 @@ julia> only(Iterators.findeach(==(1), [3,6,2,1]))
 4
 ```
 """
-findeach(f, it) = map(first, filter(i -> f(last(i)), pairs(it)))
+findeach(f, it) = (k for (k, v) in pairs(it) if f(v))
 
 findeach(it) = findeach(identity, it)
 

--- a/doc/src/base/iterators.md
+++ b/doc/src/base/iterators.md
@@ -10,6 +10,7 @@ Base.Iterators.take
 Base.Iterators.takewhile
 Base.Iterators.drop
 Base.Iterators.dropwhile
+Base.Iterators.findall
 Base.Iterators.cycle
 Base.Iterators.repeated
 Base.Iterators.product

--- a/doc/src/base/iterators.md
+++ b/doc/src/base/iterators.md
@@ -10,7 +10,7 @@ Base.Iterators.take
 Base.Iterators.takewhile
 Base.Iterators.drop
 Base.Iterators.dropwhile
-Base.Iterators.findall
+Base.Iterators.findeach
 Base.Iterators.cycle
 Base.Iterators.repeated
 Base.Iterators.product

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -251,8 +251,8 @@ end
         @test collect(f) == [4,5,6]
 
         f = findall(isodd, Dict(1 => 2, 2 => 4, 3 => 6))
-        @test_throws ArgumentError only(f)
         @test isempty(f)
+        @test_throws isnothing(iterate(f)) # test isempty works correctly
 
         f = findall(isodd, Dict(1 => 2, 2 => 3, 3 => 4))
         @test only(f) == 2

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -252,7 +252,7 @@ end
 
         f = findall(isodd, Dict(1 => 2, 2 => 4, 3 => 6))
         @test isempty(f)
-        @test_throws isnothing(iterate(f)) # test isempty works correctly
+        @test isnothing(iterate(f)) # test isempty works correctly
 
         f = findall(isodd, Dict(1 => 2, 2 => 3, 3 => 4))
         @test only(f) == 2

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -242,6 +242,23 @@ end
     @test (@inferred Base.IteratorEltype(typeof(dropwhile(<(4),Iterators.map(identity, 1:10))))) isa Base.EltypeUnknown
 end
 
+# findall
+# ----------------
+@testset "Iterators.findall" begin
+    let findall = Iterators.findall
+        f = findall(isnumeric, "abc257wf")
+        @test !(f isa AbstractArray) # it's lazy
+        @test collect(f) == [4,5,6]
+
+        f = findall(isodd, Dict(1 => 2, 2 => 4, 3 => 6))
+        @test_throws ArgumentError only(f)
+        @test isempty(f)
+
+        f = findall(isodd, Dict(1 => 2, 2 => 3, 3 => 4))
+        @test only(f) == 2
+    end
+end
+
 # cycle
 # -----
 let i = 0

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -242,7 +242,7 @@ end
     @test (@inferred Base.IteratorEltype(typeof(dropwhile(<(4),Iterators.map(identity, 1:10))))) isa Base.EltypeUnknown
 end
 
-# findall
+# findeach
 # ----------------
 @testset "Iterators.findeach" begin
     let findeach = Iterators.findeach

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -244,17 +244,17 @@ end
 
 # findall
 # ----------------
-@testset "Iterators.findall" begin
-    let findall = Iterators.findall
-        f = findall(isnumeric, "abc257wf")
+@testset "Iterators.findeach" begin
+    let findeach = Iterators.findeach
+        f = findeach(isnumeric, "abc257wf")
         @test !(f isa AbstractArray) # it's lazy
         @test collect(f) == [4,5,6]
 
-        f = findall(isodd, Dict(1 => 2, 2 => 4, 3 => 6))
+        f = findeach(isodd, Dict(1 => 2, 2 => 4, 3 => 6))
         @test isempty(f)
         @test isnothing(iterate(f)) # test isempty works correctly
 
-        f = findall(isodd, Dict(1 => 2, 2 => 3, 3 => 4))
+        f = findeach(isodd, Dict(1 => 2, 2 => 3, 3 => 4))
         @test only(f) == 2
     end
 end


### PR DESCRIPTION
This is a lazy version of `findall` which avoids allocating an array.

Closes https://github.com/JuliaLang/julia/issues/43737