### PR TITLE
use correct size when creating output data from an IOBuffer

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -468,7 +468,7 @@ function take!(io::IOBuffer)
         elseif io.writable
             data = view(io.data, io.offset+1:nbytes+io.offset)
         else
-            data = copyto!(StringVector(io.size), 1, io.data, io.offset + 1, nbytes)
+            data = copyto!(StringVector(nbytes), 1, io.data, io.offset + 1, nbytes)
         end
     else
         nbytes = bytesavailable(io)

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -383,3 +383,8 @@ end
     seek(io,0)
     @test Base.read_sub(io,v,1,1) == [1,0]
 end
+
+@testset "with offset" begin
+    b = pushfirst!([0x02], 0x01)
+    @test take!(IOBuffer(b)) == [0x01, 0x02]
+end


### PR DESCRIPTION
PR from https://github.com/JuliaLang/julia/issues/54097. 

Fixes #54097

Co-authored-by: Nathan Zimmerberg