### PR TITLE
inference: don't taint `:consistent` on access of undefined `isbitstype`-fields

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2456,13 +2456,7 @@ function abstract_eval_new(interp::AbstractInterpreter, e::Expr, vtypes::Union{V
         ismutable = ismutabletype(ut)
         fcount = datatype_fieldcount(ut)
         nargs = length(e.args) - 1
-        has_any_uninitialized = (fcount === nothing || (fcount > nargs && (let t = rt
-                any(i::Int -> !is_undefref_fieldtype(fieldtype(t, i)), (nargs+1):fcount)
-            end)))
-        if has_any_uninitialized
-            # allocation with undefined field is inconsistent always
-            consistent = ALWAYS_FALSE
-        elseif ismutable
+        if ismutable
             # mutable allocation isn't `:consistent`, but we still have a chance that
             # return type information later refines the `:consistent`-cy of the method
             consistent = CONSISTENT_IF_NOTRETURNED

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2456,7 +2456,13 @@ function abstract_eval_new(interp::AbstractInterpreter, e::Expr, vtypes::Union{V
         ismutable = ismutabletype(ut)
         fcount = datatype_fieldcount(ut)
         nargs = length(e.args) - 1
-        if ismutable
+        has_any_uninitialized = (fcount === nothing || (fcount > nargs && (let t = rt
+                any(i::Int -> !is_undefref_fieldtype(fieldtype(t, i)), (nargs+1):fcount)
+            end)))
+        if has_any_uninitialized
+            # allocation with undefined field is inconsistent always
+            consistent = ALWAYS_FALSE
+        elseif ismutable
             # mutable allocation isn't `:consistent`, but we still have a chance that
             # return type information later refines the `:consistent`-cy of the method
             consistent = CONSISTENT_IF_NOTRETURNED

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1240,18 +1240,6 @@ end
     return rewrap_unionall(R, s00)
 end
 
-# checks if a field of this type is guaranteed to be defined to a value
-# and that access to an uninitialized field will cause an `UndefRefError` or return zero
-# - is_undefref_fieldtype(String) === true
-# - is_undefref_fieldtype(Integer) === true
-# - is_undefref_fieldtype(Any) === true
-# - is_undefref_fieldtype(Int) === false
-# - is_undefref_fieldtype(Union{Int32,Int64}) === false
-# - is_undefref_fieldtype(T) === false
-function is_undefref_fieldtype(@nospecialize ftyp)
-    return !has_free_typevars(ftyp) && !allocatedinline(ftyp)
-end
-
 @nospecs function setfield!_tfunc(𝕃::AbstractLattice, o, f, v, order)
     if !isvarargtype(order)
         hasintersect(widenconst(order), Symbol) || return Bottom

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1240,6 +1240,18 @@ end
     return rewrap_unionall(R, s00)
 end
 
+# checks if a field of this type is guaranteed to be defined to a value
+# and that access to an uninitialized field will cause an `UndefRefError` or return zero
+# - is_undefref_fieldtype(String) === true
+# - is_undefref_fieldtype(Integer) === true
+# - is_undefref_fieldtype(Any) === true
+# - is_undefref_fieldtype(Int) === false
+# - is_undefref_fieldtype(Union{Int32,Int64}) === false
+# - is_undefref_fieldtype(T) === false
+function is_undefref_fieldtype(@nospecialize ftyp)
+    return !has_free_typevars(ftyp) && !allocatedinline(ftyp)
+end
+
 @nospecs function setfield!_tfunc(𝕃::AbstractLattice, o, f, v, order)
     if !isvarargtype(order)
         hasintersect(widenconst(order), Symbol) || return Bottom

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -249,11 +249,11 @@ struct SyntacticallyDefined{T}
 end
 @test Base.infer_effects() do
     Maybe{Int}()
-end |> !Core.Compiler.is_consistent
+end |> Core.Compiler.is_consistent
 @test Base.infer_effects() do
     Maybe{Int}()[]
-end |> !Core.Compiler.is_consistent
-@test !fully_eliminated() do
+end |> Core.Compiler.is_consistent
+@test fully_eliminated() do
     Maybe{Int}()[]
 end
 @test Base.infer_effects() do
@@ -272,7 +272,7 @@ end
 end |> !Core.Compiler.is_consistent
 @test Base.infer_effects() do
     Ref{Int}()[]
-end |> !Core.Compiler.is_consistent
+end |> Core.Compiler.is_consistent
 @test !fully_eliminated() do
     Ref{Int}()[]
 end

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -1054,7 +1054,7 @@ function f3_optrefine(x)
     @fastmath sqrt(x)
     return x
 end
-@test !Core.Compiler.is_consistent(Base.infer_effects(f2_optrefine; optimize=false))
+@test !Core.Compiler.is_consistent(Base.infer_effects(f3_optrefine; optimize=false))
 @test Core.Compiler.is_consistent(Base.infer_effects(f3_optrefine, (Float64,)))
 
 # Check that :consistent is properly modeled for throwing statements

--- a/test/compiler/effects.jl
+++ b/test/compiler/effects.jl
@@ -249,11 +249,11 @@ struct SyntacticallyDefined{T}
 end
 @test Base.infer_effects() do
     Maybe{Int}()
-end |> Core.Compiler.is_consistent
+end |> !Core.Compiler.is_consistent
 @test Base.infer_effects() do
     Maybe{Int}()[]
-end |> Core.Compiler.is_consistent
-@test fully_eliminated() do
+end |> !Core.Compiler.is_consistent
+@test !fully_eliminated() do
     Maybe{Int}()[]
 end
 @test Base.infer_effects() do
@@ -272,7 +272,7 @@ end
 end |> !Core.Compiler.is_consistent
 @test Base.infer_effects() do
     Ref{Int}()[]
-end |> Core.Compiler.is_consistent
+end |> !Core.Compiler.is_consistent
 @test !fully_eliminated() do
     Ref{Int}()[]
 end


### PR DESCRIPTION
After #52169, there is no need to taint `:consistent`-cy on accessing undefined `isbitstype` field since the value of the fields is consistent always.