### PR TITLE
Fix typo in docs for `partialsortperm`

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -1732,7 +1732,7 @@ sort(v::AbstractVector; kws...) = sort!(copymutable(v); kws...)
 ## partialsortperm: the permutation to sort the first k elements of an array ##
 
 """
-    partialsortperm(v, k; by=ientity, lt=isless, rev=false)
+    partialsortperm(v, k; by=identity, lt=isless, rev=false)
 
 Return a partial permutation `I` of the vector `v`, so that `v[I]` returns values of a fully
 sorted version of `v` at index `k`. If `k` is a range, a vector of indices is returned; if


### PR DESCRIPTION
Resolves https://github.com/JuliaLang/julia/issues/54132.