### PR TITLE
optimizer: handle `GlobalRef` based on `assume_bindings_static`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2836,7 +2836,7 @@ function abstract_eval_globalref(interp::AbstractInterpreter, g::GlobalRef, sv::
     rt = abstract_eval_globalref_type(g)
     consistent = inaccessiblememonly = ALWAYS_FALSE
     nothrow = false
-    if isa(rt, Const)
+    if isa(rt, Const) # implies `isdefinedconst_globalref(g) === true`
         consistent = ALWAYS_TRUE
         nothrow = true
         if is_mutation_free_argtype(rt)
@@ -2849,8 +2849,6 @@ function abstract_eval_globalref(interp::AbstractInterpreter, g::GlobalRef, sv::
         else
             rt = Union{}
         end
-    elseif isdefinedconst_globalref(g)
-        nothrow = true
     end
     return RTEffects(rt, nothrow ? Union{} : UndefVarError, Effects(EFFECTS_TOTAL; consistent, nothrow, inaccessiblememonly))
 end

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -288,9 +288,6 @@ function new_expr_effect_flags(𝕃ₒ::AbstractLattice, args::Vector{Any}, src:
     return (false, true, true)
 end
 
-assume_bindings_static(ir::IRCode) = ir.assume_bindings_static
-assume_bindings_static(compact::IncrementalCompact) = assume_bindings_static(compact.ir)
-
 # Returns a tuple of `(:consistent, :removable, :nothrow)` flags for a given statement.
 function stmt_effect_flags(𝕃ₒ::AbstractLattice, @nospecialize(stmt), @nospecialize(rt), src::Union{IRCode,IncrementalCompact})
     # TODO: We're duplicating analysis from inference here.
@@ -1236,7 +1233,7 @@ function convert_to_ircode(ci::CodeInfo, sv::OptimizationState)
         renumber_cfg_stmts!(sv.cfg, blockchangemap)
     end
 
-    meta = process_meta!(code)
+    meta = process_meta!(code, InferenceParams(sv.inlining.interp).assume_bindings_static)
     strip_trailing_junk!(code, ssavaluetypes, ssaflags, di, sv.cfg, stmtinfo)
     types = Any[]
     stmts = InstructionStream(code, types, stmtinfo, codelocs, ssaflags)
@@ -1244,11 +1241,10 @@ function convert_to_ircode(ci::CodeInfo, sv::OptimizationState)
     # types of call arguments only once `slot2reg` converts this `IRCode` to the SSA form
     # and eliminates slots (see below)
     argtypes = sv.slottypes
-    return IRCode(stmts, sv.cfg, di, argtypes, meta, sv.sptypes,
-                  InferenceParams(sv.inlining.interp).assume_bindings_static)
+    return IRCode(stmts, sv.cfg, di, argtypes, meta, sv.sptypes)
 end
 
-function process_meta!(code::Vector{Any})
+function process_meta!(code::Vector{Any}, assume_bindings_static::Bool)
     meta = Expr[]
     for i = 1:length(code)
         stmt = code[i]
@@ -1257,8 +1253,23 @@ function process_meta!(code::Vector{Any})
             code[i] = nothing
         end
     end
+    # Temporarily put the configurations of `AbstractInterpreter` that created this `IRCode`
+    # into `meta::Vector{Any}`, making it accessible for various optimization passes.
+    # The `replace_code_newstyle!` needs to filter out these temporary nodes inserted here.
+    pushfirst!(meta, Expr(:assume_bindings_static, assume_bindings_static))
     return meta
 end
+
+function assume_bindings_static(ir::IRCode)
+    for node = ir.meta
+        node.head === :meta && break
+        if node.head === :assume_bindings_static
+            return node.args[1]::Bool
+        end
+    end
+    return false
+end
+assume_bindings_static(compact::IncrementalCompact) = assume_bindings_static(compact.ir)
 
 function slot2reg(ir::IRCode, ci::CodeInfo, sv::OptimizationState)
     # need `ci` for the slot metadata, IR for the code

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -428,14 +428,17 @@ struct IRCode
     cfg::CFG
     new_nodes::NewNodeStream
     meta::Vector{Expr}
+    assume_bindings_static::Bool # XXX propagate `interp::AbstractInterpreter` here?
 
-    function IRCode(stmts::InstructionStream, cfg::CFG, debuginfo::DebugInfoStream, argtypes::Vector{Any}, meta::Vector{Expr}, sptypes::Vector{VarState})
-        return new(stmts, argtypes, sptypes, debuginfo, cfg, NewNodeStream(), meta)
+    function IRCode(stmts::InstructionStream, cfg::CFG, debuginfo::DebugInfoStream,
+                    argtypes::Vector{Any}, meta::Vector{Expr}, sptypes::Vector{VarState},
+                    assume_bindings_static::Bool=false)
+        return new(stmts, argtypes, sptypes, debuginfo, cfg, NewNodeStream(), meta, assume_bindings_static)
     end
     function IRCode(ir::IRCode, stmts::InstructionStream, cfg::CFG, new_nodes::NewNodeStream)
         di = ir.debuginfo
         @assert di.codelocs === stmts.line
-        return new(stmts, ir.argtypes, ir.sptypes, di, cfg, new_nodes, ir.meta)
+        return new(stmts, ir.argtypes, ir.sptypes, di, cfg, new_nodes, ir.meta, ir.assume_bindings_static)
     end
     global function copy(ir::IRCode)
         di = ir.debuginfo
@@ -443,7 +446,8 @@ struct IRCode
         di = copy(di)
         di.edges = copy(di.edges)
         di.codelocs = stmts.line
-        return new(stmts, copy(ir.argtypes), copy(ir.sptypes), di, copy(ir.cfg), copy(ir.new_nodes), copy(ir.meta))
+        return new(stmts, copy(ir.argtypes), copy(ir.sptypes), di, copy(ir.cfg),
+                   copy(ir.new_nodes), copy(ir.meta), ir.assume_bindings_static)
     end
 end
 

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -428,17 +428,15 @@ struct IRCode
     cfg::CFG
     new_nodes::NewNodeStream
     meta::Vector{Expr}
-    assume_bindings_static::Bool # XXX propagate `interp::AbstractInterpreter` here?
 
     function IRCode(stmts::InstructionStream, cfg::CFG, debuginfo::DebugInfoStream,
-                    argtypes::Vector{Any}, meta::Vector{Expr}, sptypes::Vector{VarState},
-                    assume_bindings_static::Bool=false)
-        return new(stmts, argtypes, sptypes, debuginfo, cfg, NewNodeStream(), meta, assume_bindings_static)
+                    argtypes::Vector{Any}, meta::Vector{Expr}, sptypes::Vector{VarState})
+        return new(stmts, argtypes, sptypes, debuginfo, cfg, NewNodeStream(), meta)
     end
     function IRCode(ir::IRCode, stmts::InstructionStream, cfg::CFG, new_nodes::NewNodeStream)
         di = ir.debuginfo
         @assert di.codelocs === stmts.line
-        return new(stmts, ir.argtypes, ir.sptypes, di, cfg, new_nodes, ir.meta, ir.assume_bindings_static)
+        return new(stmts, ir.argtypes, ir.sptypes, di, cfg, new_nodes, ir.meta)
     end
     global function copy(ir::IRCode)
         di = ir.debuginfo
@@ -447,7 +445,7 @@ struct IRCode
         di.edges = copy(di.edges)
         di.codelocs = stmts.line
         return new(stmts, copy(ir.argtypes), copy(ir.sptypes), di, copy(ir.cfg),
-                   copy(ir.new_nodes), copy(ir.meta), ir.assume_bindings_static)
+                   copy(ir.new_nodes), copy(ir.meta))
     end
 end
 

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -82,6 +82,7 @@ function replace_code_newstyle!(ci::CodeInfo, ir::IRCode)
     ssaflags = ci.ssaflags = stmts.flag
     debuginfo = ir.debuginfo
     for metanode in ir.meta
+        metanode.head === :meta || continue
         push!(code, metanode)
         push!(codelocs, 1, 0, 0)
         push!(ssavaluetypes, Any)

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -56,7 +56,7 @@ function check_op(ir::IRCode, domtree::DomTree, @nospecialize(op), use_bb::Int, 
             error("")
         end
     elseif isa(op, GlobalRef)
-        if !isdefined(op.mod, op.name) || !isconst(op.mod, op.name)
+        if !(assume_bindings_static(ir) ? isdefined_globalref(op) : isdefinedconst_globalref(op))
             @verify_error "Unbound GlobalRef not allowed in value position"
             error("")
         end


### PR DESCRIPTION
Following up #53750.
External abstract interpreters with `assume_bindings_static` enabled assume nothrow-ness of defined `GlobalRef`s no matter if they are constant during abstract interpretation. However, post-#53750, the optimizer’s verification switched to stricter checks, causing errors in such interpreters. This commit makes `IRCode` hold `assume_bindings_static::Bool` info to ensure that inlining and verification behaviors are synced with abstract interpretation.