### PR TITLE
Fixup IdSet docstring

### DIFF
--- a/base/idset.jl
+++ b/base/idset.jl
@@ -11,7 +11,7 @@ In the example below, the values are all `isequal` so they get overwritten in th
 The `IdSet` compares by `===` and so preserves the 3 different values.
 
 # Examples
-```jldoctest; filter = r"^\\s*([1\\.0]+|true)"
+```jldoctest; filter = r"^\\s*(1|1\\.0|true)"
 julia> Set(Any[true, 1, 1.0])
 Set{Any} with 1 element:
   1.0

--- a/base/idset.jl
+++ b/base/idset.jl
@@ -11,7 +11,7 @@ In the example below, the values are all `isequal` so they get overwritten in th
 The `IdSet` compares by `===` and so preserves the 3 different values.
 
 # Examples
-```jldoctest; filter = r"^\\s*(1|1\\.0|true)"
+```jldoctest; filter = r"\\n\\s*(1|1\\.0|true)"
 julia> Set(Any[true, 1, 1.0])
 Set{Any} with 1 element:
   1.0

--- a/base/idset.jl
+++ b/base/idset.jl
@@ -5,14 +5,13 @@
     IdSet()
 
 IdSet{T}() constructs a set (see [`Set`](@ref)) using
-`===` as equality with values of type `V`.
+`===` as equality with values of type `T`.
 
-In the example below, the values are all `isequal` so they get overwritten.
-The `IdSet` compares by `===` so preserves the 3 different keys.
+In the example below, the values are all `isequal` so they get overwritten in the ordinary `Set`.
+The `IdSet` compares by `===` and so preserves the 3 different values.
 
-Examples
-≡≡≡≡≡≡≡≡
-
+# Examples
+```jldoctest; filter = r"^\\s*([1\\.0]+|true)"
 julia> Set(Any[true, 1, 1.0])
 Set{Any} with 1 element:
   1.0
@@ -22,6 +21,7 @@ IdSet{Any} with 3 elements:
   1.0
   1
   true
+```
 """
 mutable struct IdSet{K} <: AbstractSet{K}
     list::Memory{Any}


### PR DESCRIPTION
* `IdSet{T}` has values of type `T`, not `V`
* Test the example
* Properly format the example