### PR TITLE
Forward aliasing check for `ReshapedArray`s to the parent

### DIFF
--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -225,6 +225,11 @@ elsize(::Type{<:ReshapedArray{<:Any,<:Any,P}}) where {P} = elsize(P)
 
 unaliascopy(A::ReshapedArray) = typeof(A)(unaliascopy(A.parent), A.dims, A.mi)
 dataids(A::ReshapedArray) = dataids(A.parent)
+# forward the aliasing check the parent in case there are specializations
+mightalias(A::ReshapedArray, B::ReshapedArray) = mightalias(parent(A), parent(B))
+# special handling for reshaped SubArrays that dispatches to the subarray aliasing check
+mightalias(A::ReshapedArray, B::SubArray) = mightalias(parent(A), B)
+mightalias(A::SubArray, B::ReshapedArray) = mightalias(A, parent(B))
 
 @inline ind2sub_rs(ax, ::Tuple{}, i::Int) = (i,)
 @inline ind2sub_rs(ax, strds, i) = _ind2sub_rs(ax, strds, i - 1)

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -1120,3 +1120,19 @@ end
         end
     end
 end
+
+@testset "aliasing check with reshaped subarrays" begin
+    C = rand(2,1)
+    V1 = @view C[1, :]
+    V2 = @view C[2, :]
+
+    @test !Base.mightalias(V1, V2)
+    @test !Base.mightalias(V1, permutedims(V2))
+    @test !Base.mightalias(permutedims(V1), V2)
+    @test !Base.mightalias(permutedims(V1), permutedims(V2))
+
+    @test Base.mightalias(V1, V1)
+    @test Base.mightalias(V1, permutedims(V1))
+    @test Base.mightalias(permutedims(V1), V1)
+    @test Base.mightalias(permutedims(V1), permutedims(V1))
+end


### PR DESCRIPTION
`SubArray`s have a specialized aliasing check that uses both the parent and the indices to detect potential overlaps. However, wrappers of `SubArrays` use only the `dataids`, which is usually determined only by the parent, ignoring the indices. This PR extends the aliasing check to reshaped subarrays as well, by forwarding the check to the parent subarray. This makes the following not allocate:

On master:
```julia
julia> C = rand(2000,2000);

julia> @btime $C[2:end, :] .= permutedims(@view $C[1, :]);
  2.816 ms (3 allocations: 15.70 KiB)
```
This PR
```julia
julia> @btime $C[2:end, :] .= permutedims(@view $C[1, :]);
  2.882 ms (0 allocations: 0 bytes)
```