### PR TITLE
update the syntax in the docstring for `@doc` to align with current uses

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -577,8 +577,6 @@ end
 # Drop incorrect line numbers produced by nested macro calls.
 docm(source::LineNumberNode, mod::Module, _, _, x...) = docm(source, mod, x...)
 
-function lookup_doc()
-
 # iscallexpr checks if an expression is a :call expression. The call expression may be
 # also part of a :where expression, so it unwraps the :where layers until it reaches the
 # "actual" expression

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -19,8 +19,9 @@ module Docs
 Functions, methods and types can be documented by placing a string before the definition:
 
     \"\"\"
-    # The Foo Function
-    `foo(x)`: Foo the living hell out of `x`.
+        foo(x)
+
+    Return a fooified version of `x`.
     \"\"\"
     foo(x) = ...
 
@@ -575,6 +576,8 @@ function docm(source::LineNumberNode, mod::Module, ex)
 end
 # Drop incorrect line numbers produced by nested macro calls.
 docm(source::LineNumberNode, mod::Module, _, _, x...) = docm(source, mod, x...)
+
+function lookup_doc()
 
 # iscallexpr checks if an expression is a :call expression. The call expression may be
 # also part of a :where expression, so it unwraps the :where layers until it reaches the


### PR DESCRIPTION
Also, take the opportunity to "soften" the language a bit.