### PR TITLE
Make `write` return `Int` instead of `UInt` in an obscure code-path.

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -800,11 +800,11 @@ end
 
 @noinline unsafe_write(s::IO, p::Ref{T}, n::Integer) where {T} =
     unsafe_write(s, unsafe_convert(Ref{T}, p)::Ptr, n) # mark noinline to ensure ref is gc-rooted somewhere (by the caller)
-unsafe_write(s::IO, p::Ptr, n::Integer) = Int(unsafe_write(s, convert(Ptr{UInt8}, p), convert(UInt, n)))
+unsafe_write(s::IO, p::Ptr, n::Integer) = unsafe_write(s, convert(Ptr{UInt8}, p), convert(UInt, n))
 function write(s::IO, x::Ref{T}) where {T}
     x isa Ptr && error("write cannot copy from a Ptr")
     if isbitstype(T)
-        unsafe_write(s, x, Core.sizeof(T))
+        Int(unsafe_write(s, x, Core.sizeof(T)))
     else
         write(s, x[])
     end

--- a/base/io.jl
+++ b/base/io.jl
@@ -800,7 +800,7 @@ end
 
 @noinline unsafe_write(s::IO, p::Ref{T}, n::Integer) where {T} =
     unsafe_write(s, unsafe_convert(Ref{T}, p)::Ptr, n) # mark noinline to ensure ref is gc-rooted somewhere (by the caller)
-unsafe_write(s::IO, p::Ptr, n::Integer) = unsafe_write(s, convert(Ptr{UInt8}, p), convert(UInt, n))
+unsafe_write(s::IO, p::Ptr, n::Integer) = Int(unsafe_write(s, convert(Ptr{UInt8}, p), convert(UInt, n)))
 function write(s::IO, x::Ref{T}) where {T}
     x isa Ptr && error("write cannot copy from a Ptr")
     if isbitstype(T)

--- a/test/filesystem.jl
+++ b/test/filesystem.jl
@@ -46,3 +46,7 @@ end
   @test_broken isempty(undoc)
   @test undoc == [:File, :Filesystem, :cptree, :futime, :rename, :sendfile, :unlink]
 end
+
+@testet "write return type" begin
+    @test Base.return_types(write, (Base.Filesystem.File, UInt8)) == [Int]
+end


### PR DESCRIPTION
```julia
julia> Base.return_types(write, (Base.Filesystem.File, UInt8))
1-element Vector{Any}:
 UInt64

julia> write(Base.Filesystem.File(Base.Filesystem.RawFD(1)), UInt8(5))
0x0000000000000001

julia> write(IOBuffer(), UInt8(5))
1

julia> @eval Base unsafe_write(s::IO, p::Ptr, n::Integer) = Int(unsafe_write(s, convert(Ptr{UInt8}, p), convert(UInt, n)))
unsafe_write (generic function with 13 methods)

julia> write(Base.Filesystem.File(Base.Filesystem.RawFD(1)), UInt8(5))
1

julia> write(IOBuffer(), UInt8(5))
1

julia> Base.return_types(write, (Base.Filesystem.File, UInt8))
1-element Vector{Any}:
 Int64
```

I used `return_types` at a test instead of actually running it because I don't know how to construct a `Base.Filesystem.File` that is safe to write to.

The conventional return type for this is `Int`, not `UInt`

```julia
julia> Base.return_types(write)
42-element Vector{Any}:
 Int64
 Int64
 Int64
 Int64
 Int64
 Int64
 Int64
 Int64
 ⋮
 Union{Nothing, Bool}
 Any
 Any
 Any
 Any
 Union{}
 Int64
```

---

I found this by auditing `return_types(write)`