### PR TITLE
Switch a bunch of 2-space tabs to 4-space tabs [NFC]

### DIFF
--- a/base/stat.jl
+++ b/base/stat.jl
@@ -66,7 +66,7 @@ struct StatStruct
 end
 
 @eval function Base.:(==)(x::StatStruct, y::StatStruct) # do not include `desc` in equality or hash
-  $(let ex = true
+    $(let ex = true
         for fld in fieldnames(StatStruct)[2:end]
             ex = :(getfield(x, $(QuoteNode(fld))) === getfield(y, $(QuoteNode(fld))) && $ex)
         end
@@ -74,7 +74,7 @@ end
     end)
 end
 @eval function Base.hash(obj::StatStruct, h::UInt)
-  $(quote
+    $(quote
         $(Any[:(h = hash(getfield(obj, $(QuoteNode(fld))), h)) for fld in fieldnames(StatStruct)[2:end]]...)
         return h
     end)

--- a/stdlib/Markdown/src/parse/parse.jl
+++ b/stdlib/Markdown/src/parse/parse.jl
@@ -95,7 +95,7 @@ function parse(stream::IO, block::MD, config::Config; breaking = false)
 end
 
 parse(stream::IO, block::MD; breaking = false) =
-  parse(stream, block, config(block), breaking = breaking)
+    parse(stream, block, config(block), breaking = breaking)
 
 function parse(stream::IO; flavor = julia)
     isa(flavor, Symbol) && (flavor = flavors[flavor])

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -808,8 +808,8 @@ let
 end
 
 let
-  bc = Broadcasted(+, (Broadcasted(*, ([1, 2, 3], 4)), 5))
-  @test isbits(Broadcast.flatten(bc).f)
+    bc = Broadcasted(+, (Broadcasted(*, ([1, 2, 3], 4)), 5))
+    @test isbits(Broadcast.flatten(bc).f)
 end
 
 # Issue #26127: multiple splats in a fused dot-expression

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -621,10 +621,10 @@ g40612(a, b) = a[]|a[] === b[]|b[]
 
 # issue #41438
 struct A41438{T}
-  x::Ptr{T}
+    x::Ptr{T}
 end
 struct B41438{T}
-  x::T
+    x::T
 end
 f41438(y) = y[].x
 @test A41438.body.layout != C_NULL
@@ -722,14 +722,14 @@ mutable struct A42645{T}
     end
 end
 mutable struct B42645{T}
-  y::A42645{T}
+    y::A42645{T}
 end
 x42645 = 1
 function f42645()
-  res = B42645(A42645([x42645]))
-  res.y = A42645([x42645])
-  res.y.x = true
-  res
+    res = B42645(A42645([x42645]))
+    res.y = A42645([x42645])
+    res.y.x = true
+    res
 end
 @test ((f42645()::B42645).y::A42645{Int}).x
 

--- a/test/compiler/contextual.jl
+++ b/test/compiler/contextual.jl
@@ -217,8 +217,8 @@ function generator49715(world, source, self, f, tt)
 end
 
 @eval function doit49715(f, tt)
-  $(Expr(:meta, :generated, generator49715))
-  $(Expr(:meta, :generated_only))
+    $(Expr(:meta, :generated, generator49715))
+    $(Expr(:meta, :generated_only))
 end
 
 @test_throws "oh no" doit49715(sin, Tuple{Int})

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1097,7 +1097,7 @@ f21771(::Val{U}) where {U} = Tuple{g21771(U)}
 
 # PR #28284, check that constants propagate through calls to new
 struct t28284
-  x::Int
+    x::Int
 end
 f28284() = Val(t28284(1))
 @inferred f28284()

--- a/test/core.jl
+++ b/test/core.jl
@@ -4298,13 +4298,13 @@ end
 abstract type abstest_14825 end
 
 mutable struct t1_14825{A <: abstest_14825, B}
-  x::A
-  y::B
+    x::A
+    y::B
 end
 
 mutable struct t2_14825{C, B} <: abstest_14825
-  x::C
-  y::t1_14825{t2_14825{C, B}, B}
+    x::C
+    y::t1_14825{t2_14825{C, B}, B}
 end
 
 @test t2_14825{Int,Int}.types[2] <: t1_14825

--- a/test/filesystem.jl
+++ b/test/filesystem.jl
@@ -2,47 +2,47 @@
 
 mktempdir() do dir
 
-  # Create test file
-  filename = joinpath(dir, "file.txt")
-  text = "123456"
-  write(filename, text)
+    # Create test file
+    filename = joinpath(dir, "file.txt")
+    text = "123456"
+    write(filename, text)
 
-  # test filesystem truncate (shorten)
-  file = Base.Filesystem.open(filename, Base.Filesystem.JL_O_RDWR)
-  Base.Filesystem.truncate(file, 2)
-  text = text[1:2]
-  @test length(read(file)) == 2
-  close(file)
+    # test filesystem truncate (shorten)
+    file = Base.Filesystem.open(filename, Base.Filesystem.JL_O_RDWR)
+    Base.Filesystem.truncate(file, 2)
+    text = text[1:2]
+    @test length(read(file)) == 2
+    close(file)
 
-  # test filesystem truncate (lengthen)
-  file = Base.Filesystem.open(filename, Base.Filesystem.JL_O_RDWR)
-  Base.Filesystem.truncate(file, 20)
-  @test length(read(file)) == 20
-  close(file)
+    # test filesystem truncate (lengthen)
+    file = Base.Filesystem.open(filename, Base.Filesystem.JL_O_RDWR)
+    Base.Filesystem.truncate(file, 20)
+    @test length(read(file)) == 20
+    close(file)
 
-  # test filesystem futime
-  file = Base.Filesystem.open(filename, Base.Filesystem.JL_O_RDWR)
-  Base.Filesystem.futime(file, 1.0, 2.0)
-  @test Base.Filesystem.stat(file).mtime == 2.0
-  close(file)
+    # test filesystem futime
+    file = Base.Filesystem.open(filename, Base.Filesystem.JL_O_RDWR)
+    Base.Filesystem.futime(file, 1.0, 2.0)
+    @test Base.Filesystem.stat(file).mtime == 2.0
+    close(file)
 
-  # test filesystem readbytes!
-  file = Base.Filesystem.open(filename, Base.Filesystem.JL_O_RDWR)
-  res = ones(UInt8, 80)
-  Base.Filesystem.readbytes!(file, res)
-  @test res == UInt8[text..., (i > 20 for i in (length(text) + 1):length(res))...]
-  close(file)
+    # test filesystem readbytes!
+    file = Base.Filesystem.open(filename, Base.Filesystem.JL_O_RDWR)
+    res = ones(UInt8, 80)
+    Base.Filesystem.readbytes!(file, res)
+    @test res == UInt8[text..., (i > 20 for i in (length(text) + 1):length(res))...]
+    close(file)
 
 end
 
 import Base.Filesystem: S_IRUSR, S_IRGRP, S_IROTH
 @testset "types of permission mask constants" begin
-  @test S_IRUSR & ~S_IRGRP == S_IRUSR
-  @test typeof(S_IRUSR) == typeof(S_IRGRP) == typeof(S_IROTH)
+    @test S_IRUSR & ~S_IRGRP == S_IRUSR
+    @test typeof(S_IRUSR) == typeof(S_IRGRP) == typeof(S_IROTH)
 end
 
 @testset "Base.Filesystem docstrings" begin
-  undoc = Docs.undocumented_names(Base.Filesystem)
-  @test_broken isempty(undoc)
-  @test undoc == [:File, :Filesystem, :cptree, :futime, :rename, :sendfile, :unlink]
+    undoc = Docs.undocumented_names(Base.Filesystem)
+    @test_broken isempty(undoc)
+    @test undoc == [:File, :Filesystem, :cptree, :futime, :rename, :sendfile, :unlink]
 end

--- a/test/gc/linkedlist.jl
+++ b/test/gc/linkedlist.jl
@@ -1,11 +1,11 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 mutable struct ListNode
-  key::Int64
-  next::ListNode
-  ListNode() = new()
-  ListNode(x)= new(x)
-  ListNode(x,y) = new(x,y);
+    key::Int64
+    next::ListNode
+    ListNode() = new()
+    ListNode(x)= new(x)
+    ListNode(x,y) = new(x,y);
 end
 
 function list(N=16*1024^2)

--- a/test/math.jl
+++ b/test/math.jl
@@ -882,14 +882,14 @@ end
 end
 
 @testset "isapprox" begin
-  # #22742: updated isapprox semantics
-  @test !isapprox(1.0, 1.0+1e-12, atol=1e-14)
-  @test isapprox(1.0, 1.0+0.5*sqrt(eps(1.0)))
-  @test !isapprox(1.0, 1.0+1.5*sqrt(eps(1.0)), atol=sqrt(eps(1.0)))
+    # #22742: updated isapprox semantics
+    @test !isapprox(1.0, 1.0+1e-12, atol=1e-14)
+    @test isapprox(1.0, 1.0+0.5*sqrt(eps(1.0)))
+    @test !isapprox(1.0, 1.0+1.5*sqrt(eps(1.0)), atol=sqrt(eps(1.0)))
 
-  # #13132: Use of `norm` kwarg for scalar arguments
-  @test isapprox(1, 1+1.0e-12, norm=abs)
-  @test !isapprox(1, 1+1.0e-12, norm=x->1)
+    # #13132: Use of `norm` kwarg for scalar arguments
+    @test isapprox(1, 1+1.0e-12, norm=abs)
+    @test !isapprox(1, 1+1.0e-12, norm=x->1)
 end
 
 # test AbstractFloat fallback pr22716

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -262,7 +262,7 @@ end
 
 # GMP allocation overflow should not cause crash
 if Base.GMP.ALLOC_OVERFLOW_FUNCTION[] && sizeof(Int) > 4
-  @test_throws OutOfMemoryError BigInt(2)^(typemax(Culong))
+    @test_throws OutOfMemoryError BigInt(2)^(typemax(Culong))
 end
 
 # exponentiating with a negative base

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2542,19 +2542,19 @@ end
                                                               3 4 5]
 
 @test Meta.parse("for x in 1:10 g(x) end") ==
-  Meta.parse("for#==#x#==#in#==#1:10#==#g(x)#==#end")
+    Meta.parse("for#==#x#==#in#==#1:10#==#g(x)#==#end")
 @test Meta.parse("(f->f(1))() do x x+1 end") ==
-  Meta.parse("(f->f(1))()#==#do#==#x#==#x+1#==#end")
+    Meta.parse("(f->f(1))()#==#do#==#x#==#x+1#==#end")
 @test Meta.parse("while i < 10 i += 1 end") ==
-  Meta.parse("while#==#i#==#<#==#10#==#i#==#+=#==#1#==#end")
+    Meta.parse("while#==#i#==#<#==#10#==#i#==#+=#==#1#==#end")
 @test Meta.parse("begin x=1 end") == Meta.parse("begin#==#x=1#==#end")
 @test Meta.parse("if x<y x+1 elseif y>0 y+1 else z end") ==
-  Meta.parse("if#==#x<y#==#x+1#==#elseif#==#y>0#==#y+1#==#else#==#z#==#end")
+    Meta.parse("if#==#x<y#==#x+1#==#elseif#==#y>0#==#y+1#==#else#==#z#==#end")
 @test Meta.parse("function(x) x end") == Meta.parse("function(x)#==#x#==#end")
 @test Meta.parse("a ? b : c") == Meta.parse("a#==#?#==#b#==#:#==#c")
 @test_parseerror("f#==#(x)=x", "space before \"(\" not allowed in \"f (\" at none:1")
 @test Meta.parse("try f() catch e g() finally h() end") ==
-  Meta.parse("try#==#f()#==#catch#==#e#==#g()#==#finally#==#h()#==#end")
+    Meta.parse("try#==#f()#==#catch#==#e#==#g()#==#finally#==#h()#==#end")
 @test Meta.parse("@m a b") == Meta.parse("@m#==#a#==#b")
 
 # issue #37540


### PR DESCRIPTION
Following https://docs.julialang.org/en/v1/manual/style-guide/#Indentation

I found these with `ag "\n  [^\s*#]" --julia`

---

I noticed this when writing tests for #54197