### PR TITLE
in `copyto_impl!`, shadow a name as intended to ensure type stability

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -308,7 +308,7 @@ function _copyto_impl!(dest::Union{Array,Memory}, doffs::Integer, src::Union{Arr
     n > 0 || _throw_argerror("Number of elements to copy must be non-negative.")
     @boundscheck checkbounds(dest, doffs:doffs+n-1)
     @boundscheck checkbounds(src, soffs:soffs+n-1)
-    @inbounds let dest = GenericMemoryRef(dest isa Array ? getfield(dest, :ref) : dest, doffs)
+    @inbounds let dest = GenericMemoryRef(dest isa Array ? getfield(dest, :ref) : dest, doffs),
                   src = GenericMemoryRef(src isa Array ? getfield(src, :ref) : src, soffs)
         unsafe_copyto!(dest, src, n)
     end


### PR DESCRIPTION
Not sure how much this matters, if at all, given that the compiler seems to be pretty smart nowadays, but clearly the intent behind the code was to shadow `src` with the `let` block, to prevent the variable from changing type during run time.

NB: union splitting seems to save the day anyway, but "better be safe
    than sorry", I guess