### PR TITLE
inbounds propagation in the `copyto!` implementation for `Array`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -304,6 +304,7 @@ copyto!(dest::Memory, doffs::Integer, src::Array, soffs::Integer, n::Integer) = 
 copyto!(dest::Array{T}, doffs::Integer, src::Array{T}, soffs::Integer, n::Integer) where {T} = _copyto_impl!(dest, doffs, src, soffs, n)
 
 function _copyto_impl!(dest::Union{Array,Memory}, doffs::Integer, src::Union{Array,Memory}, soffs::Integer, n::Integer)
+    @_propagate_inbounds_meta
     n == 0 && return dest
     n > 0 || _throw_argerror("Number of elements to copy must be non-negative.")
     @boundscheck checkbounds(dest, doffs:doffs+n-1)


### PR DESCRIPTION
I think this is necessary for `@inbounds copyto!(d, s)` to work as intended.