### PR TITLE
Expand `@static` docstring

### DIFF
--- a/base/osutils.jl
+++ b/base/osutils.jl
@@ -3,13 +3,23 @@
 """
     @static
 
-Partially evaluate an expression at parse time.
+Partially evaluate an expression at macro expansion time.
 
-For example, `@static Sys.iswindows() ? foo : bar` will evaluate `Sys.iswindows()` and insert
-either `foo` or `bar` into the expression.
-This is useful in cases where a construct would be invalid on other platforms,
-such as a `ccall` to a non-existent function.
-`@static if Sys.isapple() foo end` and `@static foo <&&,||> bar` are also valid syntax.
+This is useful in cases where a construct would be invalid in some cases, such as a `ccall`
+to a os-dependent function, or macros defined in packages that are not imported.
+
+`@static` requires a conditional. The conditional can be in an `if` statement, a ternary
+operator, or `&&`\`||`. The conditional is evaluated by recursively expanding macros,
+lowering and executing the resulting expressions. Then, the matching branch (if any) is
+returned. All the other branches of the conditional are deleted before they are
+macro-expanded (and lowered or executed).
+
+# Example
+
+Suppose we want to parse an expression `expr` that is valid only on MacOS. We could solve
+this problem using `@static` with `@static if Sys.isapple() expr end`. In case we had
+`expr_apple` for MacOS and `expr_others` for the other operating systems, the solution with
+`@static` would be `@static Sys.isapple() ? expr_apple : expr_others`.
 """
 macro static(ex)
     if isa(ex, Expr)


### PR DESCRIPTION
When I first learned about `@static`, I found its docstring not very clear or helpful. For example, I didn't understand that I had to use a conditional (yes, once you understand what `@static` does, it is obvious, but the reason I was reading the docstring is precisely because I didn't know how to use it). I also found the meaning of `@static foo <&&,||> bar` rather unclear. 

I rephrased the docstring to something that I think is clearer and more helpful.