### PR TITLE
Refine eltype of `Base.Generator` when its type is concrete

### DIFF
--- a/base/generator.jl
+++ b/base/generator.jl
@@ -146,8 +146,8 @@ IteratorEltype(::Type) = HasEltype()  # HasEltype is the default
 IteratorEltype(::Type{Union{}}, slurp...) = throw(ArgumentError("Union{} does not have elements"))
 IteratorEltype(::Type{Any}) = EltypeUnknown()
 
-function IteratorEltype(T::Type{Generator})
-    T_el = @infer_eltype(T)
+function IteratorEltype(t::Type{Generator{I,T}}) where {I,T}
+    T_el = @infer_eltype(t)
     return isconcretetype(T_el) ? HasEltype() : EltypeUnknown()
 end
 


### PR DESCRIPTION
Tries to address #54157 

Now:

```julia
julia> iter = (x^2 for x in 1:10)
Base.Generator{UnitRange{Int64}, var"#1#2"}(var"#1#2"(), 1:10)

julia> eltype(iter)
Int64
```

Before

```julia
julia> iter = (x^2 for x in 1:10)
Base.Generator{UnitRange{Int64}, var"#1#2"}(var"#1#2"(), 1:10)

julia> eltype(iter)
Any
```

Took inspiration from `Base.@default_eltype` for the `infer_type` macro. The first couldn't be used directly because it accepts an instance, not a type.