### PR TITLE
reflection: use `CC.findall` instead of `_methods_by_ftype`

### DIFF
--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -157,8 +157,10 @@ function code_warntype(io::IO, @nospecialize(f), @nospecialize(tt=Base.default_t
         print_warntype_codeinfo(io, Base.code_typed_opaque_closure(f, tt)[1]..., nargs; lineprinter)
         return nothing
     end
-    matches = Base._methods_by_ftype(Base.signature_type(f, tt), #=lim=#-1, world)::Vector
-    for match in matches
+    tt = Base.signature_type(f, tt)
+    matches = Core.Compiler.findall(tt, Core.Compiler.method_table(interp))
+    matches === nothing && Base.raise_match_failure(:code_warntype, tt)
+    for match in matches.matches
         match = match::Core.MethodMatch
         (src, rettype) = Core.Compiler.typeinf_code(interp, match, optimize)
         mi = Core.Compiler.specialize_method(match)

--- a/test/error.jl
+++ b/test/error.jl
@@ -111,8 +111,8 @@ end
             for name in names(mod, all=true)
                 isdefined(mod, name) || continue
                 value = getfield(mod, name)
-
                 if value isa Module
+                    value === Main && continue
                     test_exceptions(value, visited)
                 elseif value isa Type
                     str = string(value)


### PR DESCRIPTION
Some of reflection functions use `_methods_by_ftype`, which doesn't account for the overlay method table, leading to the issues reported in #54189.
With this commit, these problems are addressed by switching these reflection functions to use `CC.findall`, aligning them with the other ones.

- closes #54189