### PR TITLE
Add `public` statement to `Base.GC`

### DIFF
--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -109,6 +109,8 @@ Module with garbage collection utilities.
 """
 module GC
 
+public gc, enable, enable_finalizers, in_finalizer, @preserve, safepoint, enable_logging, logging_enabled
+
 # mirrored from julia.h
 const GC_AUTO = 0
 const GC_FULL = 1

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -109,7 +109,7 @@ Module with garbage collection utilities.
 """
 module GC
 
-public gc, enable, enable_finalizers, in_finalizer, @preserve, safepoint, enable_logging, logging_enabled
+public gc, enable, @preserve, safepoint, enable_logging, logging_enabled
 
 # mirrored from julia.h
 const GC_AUTO = 0


### PR DESCRIPTION
https://github.com/JuliaLang/julia/issues/51335 for the `Base.GC` submodule (cc @LilithHafner)

This PR marks the following symbols as public:
```julia
gc
enable
enable_finalizers
in_finalizer
@preserve
safepoint
enable_logging
logging_enabled
```

All of these have a docstring and seem to be useful for external code.

This PR should be backported to 1.11.