### PR TITLE
[NFC] Update comment referring to Yosemite to Mojave

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -482,7 +482,7 @@ endif
 
 FC := $(CROSS_COMPILE)gfortran
 
-# Note: Supporting only macOS Yosemite and above
+# Note: Supporting only macOS Mojave and above
 ifeq ($(OS), Darwin)
 APPLE_ARCH := $(shell uname -m)
 ifneq ($(APPLE_ARCH),arm64)


### PR DESCRIPTION
mac os 10.14 is Mojave.

[no-ci]