### PR TITLE
cfg_simplify: Correctly handle must-throw blocks

### DIFF
--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1896,7 +1896,7 @@ let code = Any[
     ir = make_ircode(code; ssavaluetypes=Any[Union{}, Union{}, Any, Union{}])
 
     # Unfortunately `compute_basic_blocks` does not notice the `throw()` so it gives us
-    # the wrong CFG. Instead manually construct the intended CFG:
+    # a slightly imprecise CFG. Instead manually construct the CFG we need for this test:
     empty!(ir.cfg.blocks)
     push!(ir.cfg.blocks, BasicBlock(StmtRange(1,1), [], [2,4]))
     push!(ir.cfg.blocks, BasicBlock(StmtRange(2,2), [1], []))

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1881,3 +1881,33 @@ end
 @test !fully_eliminated() do
     all(iszero, Iterators.repeated(0))
 end
+
+## Test that cfg_simplify respects implicit `unreachable` terminators
+let code = Any[
+        # block 1
+        GotoIfNot(Core.Argument(2), 4),
+        # block 2
+        Expr(:call, Base.throw, "error"), # an implicit `unreachable` terminator
+        # block 3
+        Expr(:call, :opaque),
+        # block 4
+        ReturnNode(nothing),
+    ]
+    ir = make_ircode(code; ssavaluetypes=Any[Union{}, Union{}, Any, Union{}])
+
+    # Unfortunately `compute_basic_blocks` does not notice the `throw()` so it gives us
+    # the wrong CFG. Instead manually construct the intended CFG:
+    empty!(ir.cfg.blocks)
+    push!(ir.cfg.blocks, BasicBlock(StmtRange(1,1), [], [2,4]))
+    push!(ir.cfg.blocks, BasicBlock(StmtRange(2,2), [1], []))
+    push!(ir.cfg.blocks, BasicBlock(StmtRange(3,3), [], []))
+    push!(ir.cfg.blocks, BasicBlock(StmtRange(4,4), [1], []))
+    empty!(ir.cfg.index)
+    append!(ir.cfg.index, Int[2,3,4])
+    ir.stmts.stmt[1] = GotoIfNot(Core.Argument(2), 4)
+
+    Core.Compiler.verify_ir(ir)
+    ir = Core.Compiler.cfg_simplify!(ir)
+    Core.Compiler.verify_ir(ir)
+    @test length(ir.cfg.blocks) == 3 # should have removed block 3
+end


### PR DESCRIPTION
We have a special exception in our IR that allows `::Union{}` marked instructions to act as an `unreachable` terminator.

Without this fix, we were advancing into the subsequent block despite it not being a successor.