### PR TITLE
Optimize issorted for rev=true

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -90,9 +90,9 @@ function issorted(itr;
     # Explicit branching because the compiler can't optimize away the
     # type instability of the `ord` call with Bool `rev` parameter.
     if rev === true
-        issorted(itr, ReverseOrdering(ord(lt,by,nothing,order)))
+        issorted(itr, ord(lt, by, true, order))
     else
-        issorted(itr, ord(lt,by,nothing,order))
+        issorted(itr, ord(lt, by, nothing, order))
     end
 end
 

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -85,9 +85,16 @@ julia> issorted([1, 2, -2, 3], by=abs)
 true
 ```
 """
-issorted(itr;
-    lt=isless, by=identity, rev::Union{Bool,Nothing}=nothing, order::Ordering=Forward) =
-    issorted(itr, ord(lt,by,rev,order))
+function issorted(itr;
+        lt=isless, by=identity, rev::Union{Bool,Nothing}=nothing, order::Ordering=Forward)
+    # Explicit branching because the compiler can't optimize away the
+    # type instability of the `ord` call with Bool `rev` parameter.
+    if rev === true
+        issorted(itr, ReverseOrdering(ord(lt,by,nothing,order)))
+    else
+        issorted(itr, ord(lt,by,nothing,order))
+    end
+end
 
 function partialsort!(v::AbstractVector, k::Union{Integer,OrdinalRange}, o::Ordering)
     # TODO move k from `alg` to `kw`


### PR DESCRIPTION
Fixes #54217 by inserting an explicit branch on `rev`.
```julia
julia> using Chairmarks

julia> struct S <: AbstractVector{Float64}
           v::Vector{Float64}
       end

julia> Base.@propagate_inbounds Base.getindex(s::S, i) = s.v[i]

julia> Base.size(s::S) = size(s.v)

julia> v = sort!(rand(10));

julia> rv = sort(v, rev=true);

julia> s = S(v);

julia> rs = S(sort(v, rev=true));

julia> @b issorted($v)
7.973 ns

julia> @b issorted($s)
11.693 ns

julia> @b issorted($v, rev=false)
11.987 ns

julia> @b issorted($s, rev=false)
15.509 ns

julia> @b issorted($rv, rev=true)
18.178 ns

julia> @b issorted($rs, rev=true)
27.119 ns (1 allocs: 16 bytes)

julia> @eval Base.Sort function issorted(itr;
               lt=isless, by=identity, rev::Union{Bool,Nothing}=nothing, order::Ordering=Forward)
           # Explicit branching because the compiler can't optimize away the
           # type instability of the `ord` call with Bool `rev` parameter.
           if rev === true
               issorted(itr, ReverseOrdering(ord(lt,by,nothing,order)))
           else
               issorted(itr, ord(lt,by,nothing,order))
           end
       end
issorted (generic function with 5 methods)

julia> @b issorted($v)
8.213 ns

julia> @b issorted($s)
12.078 ns

julia> @b issorted($v, rev=false)
10.812 ns

julia> @b issorted($s, rev=false)
14.343 ns

julia> @b issorted($rv, rev=true)
10.823 ns

julia> @b issorted($rs, rev=true)
14.408 ns
```