### PR TITLE
Remove some UB from examples in performance tips

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1446,7 +1446,7 @@ the optimizer from trying to be too clever and defeat our benchmark):
 ```julia
 @noinline function inner(x, y)
     s = zero(eltype(x))
-    for i=eachindex(x)
+    for i in eachindex(x, y)
         @inbounds s += x[i]*y[i]
     end
     return s
@@ -1454,7 +1454,7 @@ end
 
 @noinline function innersimd(x, y)
     s = zero(eltype(x))
-    @simd for i = eachindex(x)
+    @simd for i in eachindex(x, y)
         @inbounds s += x[i] * y[i]
     end
     return s


### PR DESCRIPTION
Remove some UB from examples in performance tips

Fixes #54218

I also changed the iteration specification to better align with elsewhere in the document.

A separate PR may want to delete or revise this section if automatic simd has improved. Nevertheless, I think this PR should be unobjectionable as is.