### PR TITLE
Fix typos in `@static` docstring

### DIFF
--- a/base/osutils.jl
+++ b/base/osutils.jl
@@ -6,7 +6,7 @@
 Partially evaluate an expression at macro expansion time.
 
 This is useful in cases where a construct would be invalid in some cases, such as a `ccall`
-to a os-dependent function, or macros defined in packages that are not imported.
+to an os-dependent function, or macros defined in packages that are not imported.
 
 `@static` requires a conditional. The conditional can be in an `if` statement, a ternary
 operator, or `&&`\`||`. The conditional is evaluated by recursively expanding macros,
@@ -16,9 +16,9 @@ macro-expanded (and lowered or executed).
 
 # Example
 
-Suppose we want to parse an expression `expr` that is valid only on MacOS. We could solve
+Suppose we want to parse an expression `expr` that is valid only on macOS. We could solve
 this problem using `@static` with `@static if Sys.isapple() expr end`. In case we had
-`expr_apple` for MacOS and `expr_others` for the other operating systems, the solution with
+`expr_apple` for macOS and `expr_others` for the other operating systems, the solution with
 `@static` would be `@static Sys.isapple() ? expr_apple : expr_others`.
 """
 macro static(ex)


### PR DESCRIPTION
Followup for premature merge of #54206

Implements @giordano's suggestions

cc @Sbozzolo