### PR TITLE
define `clamp(x, ::Type{BigInt})`

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -10,7 +10,8 @@ import .Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), xor, 
              trailing_zeros, trailing_ones, count_ones, count_zeros, tryparse_internal,
              bin, oct, dec, hex, isequal, invmod, _prevpow2, _nextpow2, ndigits0zpb,
              widen, signed, unsafe_trunc, trunc, iszero, isone, big, flipsign, signbit,
-             sign, hastypemax, isodd, iseven, digits!, hash, hash_integer, top_set_bit
+             sign, hastypemax, isodd, iseven, digits!, hash, hash_integer, top_set_bit,
+             clamp
 
 if Clong == Int32
     const ClongMax = Union{Int8, Int16, Int32}
@@ -357,6 +358,8 @@ function rem(x::BigInt, ::Type{T}) where T<:Union{Base.BitUnsigned,Base.BitSigne
 end
 
 rem(x::Integer, ::Type{BigInt}) = BigInt(x)
+
+clamp(x, Type{BigInt}) = convert(BigInt, x)
 
 isodd(x::BigInt) = MPZ.tstbit(x, 0)
 iseven(x::BigInt) = !isodd(x)

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -359,7 +359,7 @@ end
 
 rem(x::Integer, ::Type{BigInt}) = BigInt(x)
 
-clamp(x, Type{BigInt}) = convert(BigInt, x)
+clamp(x, ::Type{BigInt}) = convert(BigInt, x)
 
 isodd(x::BigInt) = MPZ.tstbit(x, 0)
 iseven(x::BigInt) = !isodd(x)

--- a/test/math.jl
+++ b/test/math.jl
@@ -58,6 +58,9 @@ has_fma = Dict(
     x = big(2) ^ 100
     @test (@allocated clamp(x, Int16)) == 0
 
+    x = clamp(2.0, BigInt)
+    @test x isa BigInt
+    @test x == big(2)
 end
 
 @testset "constants" begin


### PR DESCRIPTION
While `clamp(x, T)` is defined for all `T<:Integer`, it fails for `T<:BigInt`.
The reason is, that `typemax(BigInt)` is not defined but called.
This PR will allow generic code with `clamp(x, Integer)` to behave without error also if applied to `BigInt`.