### PR TITLE
Make sure `fieldcount` constant-folds for `Tuple{...}`

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1003,12 +1003,15 @@ function datatype_fieldcount(t::DataType)
             return fieldcount(types)
         end
         return nothing
-    elseif isabstracttype(t) || (t.name === Tuple.name && isvatuple(t))
+    elseif isabstracttype(t)
         return nothing
     end
-    if isdefined(t, :types)
+    if t.name === Tuple.name
+        isvatuple(t) && return nothing
         return length(t.types)
     end
+    # Equivalent to length(t.types), but `t.types` is lazy and we do not want
+    # to be forced to compute it.
     return length(t.name.names)
 end
 

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5725,3 +5725,6 @@ let interp = CachedConditionalInterp();
         result.linfo.def.name === :func_cached_conditional
     end == 1
 end
+
+# fieldcount on `Tuple` should constant fold, even though `.fields` not const
+@test fully_eliminated(Base.fieldcount, Tuple{Type{Tuple{Nothing, Int, Int}}})


### PR DESCRIPTION
In PR #53750, we stopped constant folding `isdefined` for non-`const` fields assuming that they may revert to `undef`. Unfortunately, this broke const-prop for `fieldcount` for `Tuple`s, causing significant inference quality degradation. Adjust `fieldcount` to avoid this.