### PR TITLE
ensure package callbacks are invoked when no valid precompile file exists for an "auto loaded" stdlib

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2547,7 +2547,7 @@ function require_stdlib(uuidkey::PkgId, ext::Union{Nothing, String}=nothing)
         run_package_callbacks(uuidkey)
     else
         # if the user deleted their bundled depot, next try to load it completely normally
-        newm = _require(uuidkey)
+        newm = _require_prelocked(uuidkey)
     end
     return newm
     end


### PR DESCRIPTION
The `_require` call skips the logic for running package callbacks (and extension triggers) so if Pkg is loaded in the startup file and then REPL failed to load from `_require_search_from_serialized` (and instead loaded via `_require`) the REPL extension from Pkg would not load.