### PR TITLE
LinearAlgebra: 2-arg show for adjoint/transpose

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1944,7 +1944,7 @@ julia> vcat(range(1, 2, length=3))  # collects lazy ranges
  2.0
 
 julia> two = ([10, 20, 30]', Float64[4 5 6; 7 8 9])  # row vector and a matrix
-([10 20 30], [4.0 5.0 6.0; 7.0 8.0 9.0])
+(adjoint([10, 20, 30]), [4.0 5.0 6.0; 7.0 8.0 9.0])
 
 julia> vcat(two...)
 3×3 Matrix{Float64}:

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -295,12 +295,22 @@ function Base.showarg(io::IO, v::Adjoint, toplevel)
     toplevel && print(io, " with eltype ", eltype(v))
     return nothing
 end
+function Base.show(io::IO, v::Adjoint)
+    print(io, "adjoint(")
+    show(io, parent(v))
+    print(io, ')')
+end
 function Base.showarg(io::IO, v::Transpose, toplevel)
     print(io, "transpose(")
     Base.showarg(io, parent(v), false)
     print(io, ')')
     toplevel && print(io, " with eltype ", eltype(v))
     return nothing
+end
+function Base.show(io::IO, v::Transpose)
+    print(io, "transpose(")
+    show(io, parent(v))
+    print(io, ')')
 end
 
 # some aliases for internal convenience use

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -295,7 +295,7 @@ function Base.showarg(io::IO, v::Adjoint, toplevel)
     toplevel && print(io, " with eltype ", eltype(v))
     return nothing
 end
-function Base.show(io::IO, v::Adjoint)
+function Base.show(io::IO, v::Adjoint{<:Any, <:AbstractVector})
     print(io, "adjoint(")
     show(io, parent(v))
     print(io, ')')
@@ -307,7 +307,7 @@ function Base.showarg(io::IO, v::Transpose, toplevel)
     toplevel && print(io, " with eltype ", eltype(v))
     return nothing
 end
-function Base.show(io::IO, v::Transpose)
+function Base.show(io::IO, v::Transpose{<:Any, <:AbstractVector})
     print(io, "transpose(")
     show(io, parent(v))
     print(io, ')')

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -506,6 +506,13 @@ end
     @test B == A .* A'
 end
 
+@testset "show" begin
+    for t in ([1,2], [1 2; 3 4])
+        @test repr(transpose(t)) == "transpose($(repr(t)))"
+        @test repr(adjoint(t)) == "adjoint($(repr(t)))"
+    end
+end
+
 @testset "test show methods for $t of Factorizations" for t in (adjoint, transpose)
     A = randn(ComplexF64, 4, 4)
     F = lu(A)

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -507,10 +507,9 @@ end
 end
 
 @testset "show" begin
-    for t in ([1,2], [1 2; 3 4])
-        @test repr(transpose(t)) == "transpose($(repr(t)))"
-        @test repr(adjoint(t)) == "adjoint($(repr(t)))"
-    end
+    t = [1,2]
+    @test repr(transpose(t)) == "transpose($(repr(t)))"
+    @test repr(adjoint(t)) == "adjoint($(repr(t)))"
 end
 
 @testset "test show methods for $t of Factorizations" for t in (adjoint, transpose)


### PR DESCRIPTION
After this,
```julia
julia> t = [1,2]
2-element Vector{Int64}:
 1
 2

julia> show(transpose(t))
transpose([1, 2])
```
and similarly for `Adjoint`. This way, the displayed form is a valid constructor.

Edit: I've restricted this to cases where the parent is an `AbstractVector`, as this is the case where the difference between a dual vector and a matrix matters the most. A lazily transposed matrix is not all that different from the materialized form.