### PR TITLE
fix typo in gc_mark_memory8 when chunking a large array

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -2337,7 +2337,7 @@ STATIC_INLINE void gc_mark_memory8(jl_ptls_t ptls, jl_value_t *ary8_parent, jl_v
             pushed_chunk = 1;
         }
     }
-    for (; ary8_begin < ary8_end; ary8_begin += elsize) {
+    for (; ary8_begin < scan_end; ary8_begin += elsize) {
         for (uint8_t *pindex = elem_begin; pindex < elem_end; pindex++) {
             jl_value_t **slot = &ary8_begin[*pindex];
             new_obj = *slot;


### PR DESCRIPTION
Should fix https://github.com/JuliaLang/julia/issues/54247.

- Before:
```
Julia Version 1.12.0-DEV.410
Commit 0735854ab3* (2024-04-25 14:35 UTC)
Platform Info:
  OS: macOS (arm64-apple-darwin23.4.0)
  CPU: 12 × Apple M2 Max
  WORD_SIZE: 64
  LLVM: libLLVM-16.0.6 (ORCJIT, apple-m2)
Threads: 8 default, 0 interactive, 4 GC (on 8 virtual cores)
***** Vector *****
serial: 0.607365 seconds (3 allocations: 381.470 MiB, 0.22% gc time)
serial: 0.597241 seconds (3 allocations: 381.470 MiB, 1.18% gc time)
serial: 0.589679 seconds (3 allocations: 381.470 MiB, 1.21% gc time)
serial: 0.581607 seconds (3 allocations: 381.470 MiB, 0.97% gc time)
serial: 0.578147 seconds (3 allocations: 381.470 MiB, 0.96% gc time)
serial: 0.577399 seconds (3 allocations: 381.470 MiB, 0.94% gc time)
serial: 0.564742 seconds (3 allocations: 381.470 MiB, 0.93% gc time)
serial: 0.591733 seconds (3 allocations: 381.470 MiB, 0.90% gc time)
serial: 0.565088 seconds (3 allocations: 381.470 MiB, 0.97% gc time)
serial: 0.556800 seconds (3 allocations: 381.470 MiB, 0.94% gc time)
parallel: 0.563600 seconds (3.33 k allocations: 381.640 MiB, 0.10% gc time, 0.94% compilation time)
parallel: 0.564652 seconds (9 allocations: 381.470 MiB, 1.02% gc time)
parallel: 0.581996 seconds (9 allocations: 381.470 MiB, 0.95% gc time)
parallel: 0.576503 seconds (9 allocations: 381.470 MiB, 0.90% gc time)
parallel: 0.565595 seconds (9 allocations: 381.470 MiB, 0.94% gc time)
parallel: 0.575850 seconds (9 allocations: 381.470 MiB, 0.95% gc time)
parallel: 0.604621 seconds (9 allocations: 381.470 MiB, 0.91% gc time)
parallel: 0.578168 seconds (9 allocations: 381.470 MiB, 0.91% gc time)
parallel: 0.600408 seconds (9 allocations: 381.470 MiB, 0.92% gc time)
parallel: 0.576794 seconds (9 allocations: 381.470 MiB, 0.95% gc time)

***** Astruct *****
serial: 0.659020 seconds (3 allocations: 762.940 MiB, 0.18% gc time)
serial: 0.674630 seconds (3 allocations: 762.940 MiB, 1.63% gc time)
serial: 0.670532 seconds (3 allocations: 762.940 MiB, 1.86% gc time)
serial: 0.682483 seconds (3 allocations: 762.940 MiB, 1.57% gc time)
serial: 0.673673 seconds (3 allocations: 762.940 MiB, 1.62% gc time)
serial: 0.652506 seconds (3 allocations: 762.940 MiB, 1.72% gc time)
serial: 0.667336 seconds (3 allocations: 762.940 MiB, 1.69% gc time)
serial: 0.659686 seconds (3 allocations: 762.940 MiB, 1.76% gc time)
serial: 0.673387 seconds (3 allocations: 762.940 MiB, 1.73% gc time)
serial: 0.668930 seconds (3 allocations: 762.940 MiB, 1.67% gc time)
parallel: 0.646382 seconds (3.42 k allocations: 763.114 MiB, 0.09% gc time, 0.77% compilation time)
parallel: 0.665347 seconds (9 allocations: 762.940 MiB, 1.70% gc time)
parallel: 0.676490 seconds (9 allocations: 762.940 MiB, 1.84% gc time)
parallel: 22.732728 seconds (9 allocations: 762.940 MiB, 97.12% gc time)
parallel: 22.668091 seconds (9 allocations: 762.940 MiB, 97.15% gc time)
parallel: 0.629117 seconds (9 allocations: 762.940 MiB)
parallel: 22.948883 seconds (9 allocations: 762.940 MiB, 97.26% gc time)
parallel: 0.629834 seconds (9 allocations: 762.940 MiB)
parallel: 1.108239 seconds (9 allocations: 762.940 MiB, 42.54% gc time)
parallel: 0.648325 seconds (9 allocations: 762.940 MiB)
```

- After:
```
Julia Version 1.12.0-DEV.410
Commit 0735854ab3* (2024-04-25 14:35 UTC)
Platform Info:
  OS: macOS (arm64-apple-darwin23.4.0)
  CPU: 12 × Apple M2 Max
  WORD_SIZE: 64
  LLVM: libLLVM-16.0.6 (ORCJIT, apple-m2)
Threads: 8 default, 0 interactive, 4 GC (on 8 virtual cores)
***** Vector *****
serial: 0.600418 seconds (3 allocations: 381.470 MiB, 0.20% gc time)
serial: 0.613808 seconds (3 allocations: 381.470 MiB, 1.17% gc time)
serial: 0.596335 seconds (3 allocations: 381.470 MiB, 1.21% gc time)
serial: 0.589423 seconds (3 allocations: 381.470 MiB, 0.92% gc time)
serial: 0.621845 seconds (3 allocations: 381.470 MiB, 0.89% gc time)
serial: 0.580239 seconds (3 allocations: 381.470 MiB, 0.94% gc time)
serial: 0.604881 seconds (3 allocations: 381.470 MiB, 0.90% gc time)
serial: 0.581353 seconds (3 allocations: 381.470 MiB, 0.95% gc time)
serial: 0.603317 seconds (3 allocations: 381.470 MiB, 0.89% gc time)
serial: 0.599634 seconds (3 allocations: 381.470 MiB, 0.90% gc time)
parallel: 0.589694 seconds (3.33 k allocations: 381.640 MiB, 0.10% gc time, 1.01% compilation time)
parallel: 0.600812 seconds (9 allocations: 381.470 MiB, 0.98% gc time)
parallel: 0.610956 seconds (9 allocations: 381.470 MiB, 5.13% gc time)
parallel: 0.677189 seconds (9 allocations: 381.470 MiB, 14.26% gc time)
parallel: 0.571583 seconds (9 allocations: 381.470 MiB, 1.80% gc time)
parallel: 0.742617 seconds (9 allocations: 381.470 MiB, 17.81% gc time)
parallel: 0.624541 seconds (9 allocations: 381.470 MiB, 5.02% gc time)
parallel: 0.723963 seconds (9 allocations: 381.470 MiB, 14.03% gc time)
parallel: 0.609618 seconds (9 allocations: 381.470 MiB)
parallel: 0.708227 seconds (9 allocations: 381.470 MiB, 16.29% gc time)

***** Astruct *****
serial: 0.627853 seconds (3 allocations: 762.940 MiB)
serial: 0.647795 seconds (3 allocations: 762.940 MiB, 2.14% gc time)
serial: 0.640387 seconds (3 allocations: 762.940 MiB, 1.91% gc time)
serial: 0.698194 seconds (3 allocations: 762.940 MiB, 1.73% gc time)
serial: 0.673018 seconds (3 allocations: 762.940 MiB, 1.68% gc time)
serial: 0.641571 seconds (3 allocations: 762.940 MiB, 1.79% gc time)
serial: 0.669718 seconds (3 allocations: 762.940 MiB, 1.65% gc time)
serial: 0.661993 seconds (3 allocations: 762.940 MiB, 1.73% gc time)
serial: 0.661846 seconds (3 allocations: 762.940 MiB, 1.85% gc time)
serial: 0.661637 seconds (3 allocations: 762.940 MiB, 1.73% gc time)
parallel: 0.645750 seconds (3.42 k allocations: 763.114 MiB, 0.09% gc time, 0.83% compilation time)
parallel: 0.653331 seconds (9 allocations: 762.940 MiB, 1.92% gc time)
parallel: 0.673813 seconds (9 allocations: 762.940 MiB, 1.80% gc time)
parallel: 0.720503 seconds (9 allocations: 762.940 MiB, 9.40% gc time)
parallel: 0.889651 seconds (9 allocations: 762.940 MiB, 25.33% gc time)
parallel: 0.644618 seconds (9 allocations: 762.940 MiB, 2.26% gc time)
parallel: 0.919954 seconds (9 allocations: 762.940 MiB, 28.99% gc time)
parallel: 0.750246 seconds (9 allocations: 762.940 MiB, 9.03% gc time)
parallel: 0.767282 seconds (9 allocations: 762.940 MiB, 10.55% gc time)
parallel: 0.899596 seconds (9 allocations: 762.940 MiB, 25.69% gc time)
```