### PR TITLE
Only initialize libgit2's `atexit` once

### DIFF
--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -1026,7 +1026,10 @@ end
 
     cert_loc = NetworkOptions.ca_roots()
     cert_loc !== nothing && set_ssl_cert_locations(cert_loc)
+    return nothing
+end
 
+function __init__()
     atexit() do
         # refcount zero, no objects to be finalized
         if Threads.atomic_sub!(REFCOUNT, 1) == 1


### PR DESCRIPTION
The current implementation registers multiple `atexit`
handlers because the `git_libgit2_init` `ccall` returns
the number of inits that have happened. So,
every time we run `ensure_initialized` (which is frequent),
we register a new, unnecessary handler.
