### PR TITLE
fix `_checked_mul_dims` in the presence of 0s and overflow.

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -566,17 +566,18 @@ function _checked_mul_dims(m::Int, d::Int...)
     a = m
     i = 1
     ovflw = false
-    zero = a === 0
+    neg = Intrinsics.ule_int(typemax_Int, m)
+    zero = false # if m==0 we won't have overflow since we go left to right
     while Intrinsics.sle_int(i, nfields(d))
         di = getfield(d, i)
         b = Intrinsics.checked_smul_int(a, di)
         zero = Intrinsics.or_int(zero, di === 0)
         ovflw = Intrinsics.or_int(ovflw, getfield(b, 2))
-        ovflw = Intrinsics.or_int(ovflw, Intrinsics.ule_int(typemax_Int, di))
+        neg = Intrinsics.or_int(neg, Intrinsics.ule_int(typemax_Int, di))
         a = getfield(b, 1)
         i = Intrinsics.add_int(i, 1)
    end
-   return a, Intrinsics.and_int(ovflw, Intrinsics.not_int(zero))
+   return a, Intrinsics.or_int(neg, Intrinsics.and_int(ovflw, Intrinsics.not_int(zero)))
 end
 
 # convert a set of dims to a length, with overflow checking

--- a/test/core.jl
+++ b/test/core.jl
@@ -7213,6 +7213,16 @@ end
 @test_throws ArgumentError Array{Int, 2}(undef, -10, 0)
 @test_throws ArgumentError Array{Int, 2}(undef, -1, -1)
 
+# issue #54244
+# test that zero sized array doesn't throw even with large axes
+bignum = Int==Int64 ? 2^32 : 2^16 
+Array{Int}(undef, 0, bignum, bignum)
+Array{Int}(undef, bignum, bignum, 0)
+Array{Int}(undef, bignum, bignum, 0, bignum, bignum)
+# but also test that it does throw if the axes multiply to a multiple of typemax(UInt)
+@test_throws ArgumentError Array{Int, 2}(undef, bignum, bignum)
+@test_throws ArgumentError Array{Int, 2}(undef, 1, bignum, bignum)
+
 # issue #28812
 @test Tuple{Vararg{Array{T} where T,3}} === Tuple{Array,Array,Array}
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -7222,6 +7222,10 @@ Array{Int}(undef, bignum, bignum, 0, bignum, bignum)
 # but also test that it does throw if the axes multiply to a multiple of typemax(UInt)
 @test_throws ArgumentError Array{Int, 2}(undef, bignum, bignum)
 @test_throws ArgumentError Array{Int, 2}(undef, 1, bignum, bignum)
+# also test that we always throw erros for negative dims even if other dims are 0 or the product is positive
+@test_throws ArgumentError Array{Int, 2}(undef, 0, -4, -4)
+@test_throws ArgumentError Array{Int, 2}(undef, -4, 1, 0)
+@test_throws ArgumentError Array{Int, 2}(undef, -4, -4, 1)
 
 # issue #28812
 @test Tuple{Vararg{Array{T} where T,3}} === Tuple{Array,Array,Array}

--- a/test/core.jl
+++ b/test/core.jl
@@ -7215,7 +7215,7 @@ end
 
 # issue #54244
 # test that zero sized array doesn't throw even with large axes
-bignum = Int==Int64 ? 2^32 : 2^16 
+bignum = Int==Int64 ? 2^32 : 2^16
 Array{Int}(undef, 0, bignum, bignum)
 Array{Int}(undef, bignum, bignum, 0)
 Array{Int}(undef, bignum, bignum, 0, bignum, bignum)

--- a/test/core.jl
+++ b/test/core.jl
@@ -7220,12 +7220,12 @@ Array{Int}(undef, 0, bignum, bignum)
 Array{Int}(undef, bignum, bignum, 0)
 Array{Int}(undef, bignum, bignum, 0, bignum, bignum)
 # but also test that it does throw if the axes multiply to a multiple of typemax(UInt)
-@test_throws ArgumentError Array{Int, 2}(undef, bignum, bignum)
-@test_throws ArgumentError Array{Int, 2}(undef, 1, bignum, bignum)
+@test_throws ArgumentError Array{Int}(undef, bignum, bignum)
+@test_throws ArgumentError Array{Int}(undef, 1, bignum, bignum)
 # also test that we always throw erros for negative dims even if other dims are 0 or the product is positive
-@test_throws ArgumentError Array{Int, 2}(undef, 0, -4, -4)
-@test_throws ArgumentError Array{Int, 2}(undef, -4, 1, 0)
-@test_throws ArgumentError Array{Int, 2}(undef, -4, -4, 1)
+@test_throws ArgumentError Array{Int}(undef, 0, -4, -4)
+@test_throws ArgumentError Array{Int}(undef, -4, 1, 0)
+@test_throws ArgumentError Array{Int}(undef, -4, -4, 1)
 
 # issue #28812
 @test Tuple{Vararg{Array{T} where T,3}} === Tuple{Array,Array,Array}


### PR DESCRIPTION
fixes https://github.com/JuliaLang/julia/issues/54244.