### PR TITLE
cfg_simplify: Check for implicit terminators properly

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -2341,8 +2341,9 @@ function cfg_simplify!(ir::IRCode)
                     curr = merged_succ[curr]
                 end
                 terminator = ir[SSAValue(bbs[curr].stmts[end])][:stmt]
-                is_throw = ir[SSAValue(bbs[curr].stmts[end])][:type] === Union{} && !isa(terminator, PhiNode)
-                if isa(terminator, GotoNode) || isa(terminator, ReturnNode) || is_throw
+                is_terminator_or_phi = isterminator(terminator) || isa(terminator, PhiNode)
+                is_implicit_throw = ir[SSAValue(bbs[curr].stmts[end])][:type] === Union{} && !is_terminator_or_phi
+                if isa(terminator, GotoNode) || isa(terminator, ReturnNode) || is_implicit_throw
                     # Only advance to next block if it's a successor
                     # (avoid GotoNode, ReturnNode, throw()/Union{})
                     break

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1911,3 +1911,26 @@ let code = Any[
     Core.Compiler.verify_ir(ir)
     @test length(ir.cfg.blocks) == 3 # should have removed block 3
 end
+
+let code = Any[
+        # block 1
+        GotoIfNot(Core.Argument(2), 3),
+        # block 2
+        GotoNode(4),
+        # block 3
+        ReturnNode(nothing),
+        # block 4
+        GotoIfNot(Core.Argument(2), 7),
+        # block 5
+        Expr(:call, :opaque),
+        GotoNode(7),
+        # block 6
+        ReturnNode(nothing),
+    ]
+    ir = make_ircode(code; ssavaluetypes=Any[Union{} for i = 1:7])
+
+    Core.Compiler.verify_ir(ir)
+    ir = Core.Compiler.cfg_simplify!(ir)
+    Core.Compiler.verify_ir(ir)
+    @test length(ir.cfg.blocks) == 5 # should have merged block 2 into 4
+end


### PR DESCRIPTION
The check I added in #54216 failed to consider that explicit terminators also carry a `Union{}` type, not just ϕ-nodes and non-terminators.

This was causing GotoIfNot nodes to exit scheduling early and fail to assign a contiguous index for their fallthrough successor.