### PR TITLE
cfg_simplify: Don't accidentally consider `GotoIfNot` a throwing terminator

### DIFF
--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -325,7 +325,7 @@ function _ir_abstract_constant_propagation(interp::AbstractInterpreter, irsv::IR
             delete!(ssa_refined, idx)
         end
         check_ret!(stmt, idx)
-        is_terminator_or_phi = (isa(stmt, PhiNode) || isterminator(stmt))
+        is_terminator_or_phi = (isa(stmt, PhiNode) || stmt === nothing || isterminator(stmt))
         if typ === Bottom && !(idx == lstmt && is_terminator_or_phi)
             return true
         end


### PR DESCRIPTION
This addresses a bug in #54216, where a `GotoIfNot` was accidentally considered a throwing terminator. Just as I was about to PR this, I noticed that #54260 had already been opened for the same issue. However, there's three differences in this PR that made me open it anyway:

1. There's an additional missing case where the terminator is `nothing` which has special case semantics of allowing any type on it, because it serves as a deletion marker.

2. My test also test the `EnterNode` and `:leave` terminators, just to have a complete sampling.

3. I like the code flow in this version slightly better.