### PR TITLE
Update functions.md example hypot

### DIFF
--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -174,7 +174,7 @@ julia> function hypot(x, y)
                return x*sqrt(1 + r*r)
            end
            if y == 0
-               return zero(x)
+               return x
            end
            r = x/y
            return y*sqrt(1 + r*r)


### PR DESCRIPTION
In the section explaining the `return` key word, the example of the function computing the hypotenuse length of a right triangle with sides of length x and y should return `abs(x)` if y is zero, and not `zero(x)`.