### PR TITLE
Don't require that `@inbounds` depends only on local information

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -851,7 +851,7 @@ end
 
     Using `@inbounds` may return incorrect results/crashes/corruption
     for out-of-bounds indices. The user is responsible for checking it manually.
-    Only use `@inbounds` when you are certain that all accesses are in bounds (as 
+    Only use `@inbounds` when you are certain that all accesses are in bounds (as
     undefined behavior, e.g. crashes, might occur if this assertion is violated). For
     example, using `1:length(A)` instead of `eachindex(A)` in a function like
     the one above is _not_ safely inbounds because the first index of `A` may not

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -851,11 +851,10 @@ end
 
     Using `@inbounds` may return incorrect results/crashes/corruption
     for out-of-bounds indices. The user is responsible for checking it manually.
-    Only use `@inbounds` when it is certain from the information locally available
-    that all accesses are in bounds. In particular, using `1:length(A)` instead of
-    `eachindex(A)` in a function like the one above is _not_ safely inbounds because
-    the first index of `A` may not be `1` for all user defined types that subtype
-    `AbstractArray`.
+    Only use `@inbounds` when it is certain that all accesses are in bounds. In
+    particular, using `1:length(A)` instead of `eachindex(A)` in a function like
+    the one above is _not_ safely inbounds because the first index of `A` may not
+    be `1` for all user defined types that subtype `AbstractArray`.
 """
 macro inbounds(blk)
     return Expr(:block,

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -851,7 +851,7 @@ end
 
     Using `@inbounds` may return incorrect results/crashes/corruption
     for out-of-bounds indices. The user is responsible for checking it manually.
-    Only use `@inbounds` when it is certain that all accesses are in bounds. In
+    Only use `@inbounds` when you are certain that all accesses are in bounds (as undefined behavior, e.g. crashes, might occur if this assertion is violated). In
     particular, using `1:length(A)` instead of `eachindex(A)` in a function like
     the one above is _not_ safely inbounds because the first index of `A` may not
     be `1` for all user defined types that subtype `AbstractArray`.

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -852,8 +852,8 @@ end
     Using `@inbounds` may return incorrect results/crashes/corruption
     for out-of-bounds indices. The user is responsible for checking it manually.
     Only use `@inbounds` when you are certain that all accesses are in bounds (as 
-    undefined behavior, e.g. crashes, might occur if this assertion is violated). In
-    particular, using `1:length(A)` instead of `eachindex(A)` in a function like
+    undefined behavior, e.g. crashes, might occur if this assertion is violated). For
+    example, using `1:length(A)` instead of `eachindex(A)` in a function like
     the one above is _not_ safely inbounds because the first index of `A` may not
     be `1` for all user defined types that subtype `AbstractArray`.
 """

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -851,7 +851,8 @@ end
 
     Using `@inbounds` may return incorrect results/crashes/corruption
     for out-of-bounds indices. The user is responsible for checking it manually.
-    Only use `@inbounds` when you are certain that all accesses are in bounds (as undefined behavior, e.g. crashes, might occur if this assertion is violated). In
+    Only use `@inbounds` when you are certain that all accesses are in bounds (as 
+    undefined behavior, e.g. crashes, might occur if this assertion is violated). In
     particular, using `1:length(A)` instead of `eachindex(A)` in a function like
     the one above is _not_ safely inbounds because the first index of `A` may not
     be `1` for all user defined types that subtype `AbstractArray`.


### PR DESCRIPTION
Delete "from the information locally available" from "Only use `@inbounds` when it is certain that all accesses are in bounds."

This reflects the fact that the compiler models the possibility of undefined behavior and therefore does not constant propagate functions with `@inbounds` (unless it can prove they are safe).

If one semantically executes and out of bounds `@inbounds`, that's UB. If it's not semantically executed, it's not UB.

Related: #54099. cc @Keno 
Documents that @stevengj is right [here](https://github.com/JuliaLang/julia/pull/54231#discussion_r1579971371)