### PR TITLE
Rename Memory wrapper from `view` to `unsafe_vector`

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -986,6 +986,7 @@ export
     pointer,
     pointer_from_objref,
     unsafe_wrap,
+    unsafe_vector,
     unsafe_string,
     reenable_sigint,
     unsafe_copyto!,

--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -299,17 +299,17 @@ end
     end
 
     """
-        view(m::GenericMemory{M, T}, inds::Union{UnitRange, OneTo})
+        unsafe_vector(m::GenericMemory{M, T}, inds::Union{UnitRange, OneTo, Colon})
 
     Create a vector `v::Vector{T}` backed by the specified indices of `m`. It is only safe to
     resize `v` if `m` is subseqently not used.
     """
-    function view(m::GenericMemory{M, T}, inds::Union{UnitRange, OneTo}) where {M, T}
-        isempty(inds) && return T[] # needed to allow view(Memory{T}(undef, 0), 2:1)
+    function unsafe_vector(m::GenericMemory{M, T}, inds::Union{UnitRange, OneTo}) where {M, T}
+        isempty(inds) && return T[] # needed to allow unsafe_vector(Memory{T}(undef, 0), 2:1)
         @boundscheck checkbounds(m, inds)
         ref = MemoryRef(m, first(inds)) # @inbounds would be safe here but does not help performance.
         dims = (Int(length(inds)),)
         $(Expr(:new, :(Array{T, 1}), :ref, :dims))
     end
 end
-view(m::GenericMemory, inds::Colon) = view(m, eachindex(m))
+unsafe_vector(m::GenericMemory, inds::Colon) = unsafe_vector(m, eachindex(m))

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -119,7 +119,7 @@ String(s::AbstractString) = print_to_string(s)
 unsafe_wrap(::Type{Memory{UInt8}}, s::String) = ccall(:jl_string_to_genericmemory, Ref{Memory{UInt8}}, (Any,), s)
 function unsafe_wrap(::Type{Vector{UInt8}}, s::String)
     mem = unsafe_wrap(Memory{UInt8}, s)
-    view(mem, eachindex(mem))
+    unsafe_vector(mem, :)
 end
 
 Vector{UInt8}(s::CodeUnits{UInt8,String}) = copyto!(Vector{UInt8}(undef, length(s)), s)

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -139,6 +139,7 @@ Base.reshape
 Base.dropdims
 Base.vec
 Base.SubArray
+Base.unsafe_vector
 ```
 
 ## Concatenation and permutation

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -3219,7 +3219,7 @@ end
 
     @test_throws DimensionMismatch reshape(mem, 10, 10)
     @test_throws DimensionMismatch reshape(mem, 5)
-    @test_throws BoundsError unsafe_vector(mem, 1:10, 1:10)
+    @test_throws BoundsError view(mem, 1:10, 1:10)
     @test_throws BoundsError unsafe_vector(mem, 1:11)
     @test_throws BoundsError unsafe_vector(mem, 3:11)
     @test_throws BoundsError unsafe_vector(mem, 0:4)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -3214,38 +3214,38 @@ end
     end
 end
 
-@testset "Wrapping Memory into Arrays with view and reshape" begin
+@testset "Wrapping Memory into Arrays with unsafe_vector and reshape" begin
     mem::Memory{Int} = Memory{Int}(undef, 10) .= 11:20
 
     @test_throws DimensionMismatch reshape(mem, 10, 10)
     @test_throws DimensionMismatch reshape(mem, 5)
-    @test_throws BoundsError view(mem, 1:10, 1:10)
-    @test_throws BoundsError view(mem, 1:11)
-    @test_throws BoundsError view(mem, 3:11)
-    @test_throws BoundsError view(mem, 0:4)
+    @test_throws BoundsError unsafe_vector(mem, 1:10, 1:10)
+    @test_throws BoundsError unsafe_vector(mem, 1:11)
+    @test_throws BoundsError unsafe_vector(mem, 3:11)
+    @test_throws BoundsError unsafe_vector(mem, 0:4)
 
-    @test @inferred(view(mem, 1:5))::Vector{Int} == 11:15
-    @test @inferred(view(mem, 1:2))::Vector{Int} == 11:12
-    @test @inferred(view(mem, 1:10))::Vector{Int} == 11:20
-    @test @inferred(view(mem, 3:8))::Vector{Int} == 13:18
-    @test @inferred(view(mem, 20:19))::Vector{Int} == []
-    @test @inferred(view(mem, -5:-7))::Vector{Int} == []
-    @test @inferred(view(mem, :))::Vector{Int} == mem
+    @test @inferred(unsafe_vector(mem, 1:5))::Vector{Int} == 11:15
+    @test @inferred(unsafe_vector(mem, 1:2))::Vector{Int} == 11:12
+    @test @inferred(unsafe_vector(mem, 1:10))::Vector{Int} == 11:20
+    @test @inferred(unsafe_vector(mem, 3:8))::Vector{Int} == 13:18
+    @test @inferred(unsafe_vector(mem, 20:19))::Vector{Int} == []
+    @test @inferred(unsafe_vector(mem, -5:-7))::Vector{Int} == []
+    @test @inferred(unsafe_vector(mem, :))::Vector{Int} == mem
     @test @inferred(reshape(mem, 5, 2))::Matrix{Int} == reshape(11:20, 5, 2)
 
     # 53990
-    @test @inferred(view(mem, unsigned(1):10))::Vector{Int} == 11:20
+    @test @inferred(unsafe_vector(mem, unsigned(1):10))::Vector{Int} == 11:20
 
     empty_mem = Memory{Module}(undef, 0)
-    @test_throws BoundsError view(empty_mem, 0:1)
-    @test_throws BoundsError view(empty_mem, 1:2)
+    @test_throws BoundsError unsafe_vector(empty_mem, 0:1)
+    @test_throws BoundsError unsafe_vector(empty_mem, 1:2)
     @test_throws DimensionMismatch reshape(empty_mem, 1)
     @test_throws DimensionMismatch reshape(empty_mem, 1, 2, 3)
     @test_throws ArgumentError reshape(empty_mem, 2^16, 2^16, 2^16, 2^16)
 
-    @test @inferred(view(empty_mem, 1:0))::Vector{Module} == []
-    @test @inferred(view(empty_mem, 10:3))::Vector{Module} == []
-    @test @inferred(view(empty_mem, :))::Vector{Module} == empty_mem
+    @test @inferred(unsafe_vector(empty_mem, 1:0))::Vector{Module} == []
+    @test @inferred(unsafe_vector(empty_mem, 10:3))::Vector{Module} == []
+    @test @inferred(unsafe_vector(empty_mem, :))::Vector{Module} == empty_mem
     @test isempty(@inferred(reshape(empty_mem, 0, 7, 1))::Array{Module, 3})
 
     offset_inds = OffsetArrays.IdOffsetRange(values=3:6, indices=53:56)


### PR DESCRIPTION
Fixes #54156 
Changes part of #53896

The main difference between `view` and `unsafe_vector` is that the result of `view` has a fixed size, and creates a copy when passed to `String`.

The `String(view(` pattern is fairly common: https://juliahub.com/ui/Search?q=String(view&type=code and as more packages start using `Memory` it may be hard to tell if `view` is being used safely or not.

I'm not sure about the name `unsafe_vector`, but the docstring says 

> It is only safe to
    resize `v` if `m` is subseqently not used.

So I added an `unsafe_` prefix.

Ref https://github.com/JuliaLang/julia/issues/53552#issuecomment-2024288283 for a discussion on why `view` on a `Memory` should produce an `Array`.