### PR TITLE
irverify: Force terminators to have `Any` type

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -555,7 +555,7 @@ function ir_inline_unionsplit!(compact::IncrementalCompact, idx::Int, argexprs::
                     cond = insert_node_here!(compact, NewInstruction(and_expr, and_type, line))
                 end
             end
-            insert_node_here!(compact, NewInstruction(GotoIfNot(cond, next_cond_bb), Union{}, line))
+            insert_node_here!(compact, NewInstruction(GotoIfNot(cond, next_cond_bb), Any, line))
         end
         bb = next_cond_bb - 1
         finish_current_bb!(compact, 0)
@@ -588,7 +588,7 @@ function ir_inline_unionsplit!(compact::IncrementalCompact, idx::Int, argexprs::
             push!(pn.edges, bb)
             push!(pn.values, val)
             insert_node_here!(compact,
-                NewInstruction(GotoNode(join_bb), Union{}, line))
+                NewInstruction(GotoNode(join_bb), Any, line))
         else
             insert_node_here!(compact,
                 NewInstruction(ReturnNode(), Union{}, line))
@@ -601,7 +601,7 @@ function ir_inline_unionsplit!(compact::IncrementalCompact, idx::Int, argexprs::
         ssa = insert_node_here!(compact, NewInstruction(stmt, typ, line))
         push!(pn.edges, bb)
         push!(pn.values, ssa)
-        insert_node_here!(compact, NewInstruction(GotoNode(join_bb), Union{}, line))
+        insert_node_here!(compact, NewInstruction(GotoNode(join_bb), Any, line))
         finish_current_bb!(compact, 0)
     end
 

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -129,7 +129,6 @@ function reprocess_instruction!(interp::AbstractInterpreter, inst::Instruction, 
             add_flag!(inst, IR_FLAG_NOTHROW)
             if condval
                 inst[:stmt] = nothing
-                inst[:type] = Any
                 kill_edge!(irsv, bb, stmt.dest)
             else
                 inst[:stmt] = GotoNode(stmt.dest)
@@ -177,6 +176,9 @@ function reprocess_instruction!(interp::AbstractInterpreter, inst::Instruction, 
         rt = argextype(stmt.val, irsv.ir)
     elseif isa(stmt, PhiCNode)
         # Currently not modeled
+        return false
+    elseif isa(stmt, EnterNode)
+        # TODO: Propagate scope type changes
         return false
     elseif isa(stmt, ReturnNode)
         # Handled at the very end

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -325,9 +325,15 @@ function verify_ir(ir::IRCode, print::Bool=true,
                     error("")
                 end
             end
-        elseif isterminator(stmt) && idx != last(ir.cfg.blocks[bb].stmts)
-            @verify_error "Terminator $idx in bb $bb is not the last statement in the block"
-            error("")
+        elseif isterminator(stmt)
+            if idx != last(ir.cfg.blocks[bb].stmts)
+                @verify_error "Terminator $idx in bb $bb is not the last statement in the block"
+                error("")
+            end
+            if !isa(stmt, ReturnNode) && ir[SSAValue(idx)][:type] !== Any
+                @verify_error "Explicit terminators (other than ReturnNode) must have `Any` type"
+                error("")
+            end
         else
             isforeigncall = false
             if isa(stmt, Expr)

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -802,7 +802,7 @@ function each_stmt_a_bb(stmts, preds, succs)
     ir = IRCode()
     empty!(ir.stmts.stmt)
     append!(ir.stmts.stmt, stmts)
-    empty!(ir.stmts.type); append!(ir.stmts.type, [Nothing for _ = 1:length(stmts)])
+    empty!(ir.stmts.type); append!(ir.stmts.type, [Any for _ = 1:length(stmts)])
     empty!(ir.stmts.flag); append!(ir.stmts.flag, [0x0 for _ = 1:length(stmts)])
     empty!(ir.stmts.line); append!(ir.stmts.line, [Int32(0) for _ = 1:3length(stmts)])
     empty!(ir.stmts.info); append!(ir.stmts.info, [NoCallInfo() for _ = 1:length(stmts)])
@@ -1893,7 +1893,7 @@ let code = Any[
         # block 4
         ReturnNode(nothing),
     ]
-    ir = make_ircode(code; ssavaluetypes=Any[Union{}, Union{}, Any, Union{}])
+    ir = make_ircode(code; ssavaluetypes=Any[Any, Union{}, Any, Union{}])
 
     # Unfortunately `compute_basic_blocks` does not notice the `throw()` so it gives us
     # a slightly imprecise CFG. Instead manually construct the CFG we need for this test:
@@ -1930,7 +1930,7 @@ let code = Any[
         # block 8
         ReturnNode(2),
     ]
-    ir = make_ircode(code; ssavaluetypes=Any[Union{}, Union{}, Union{}, Union{}, Nothing, Union{}, Union{}, Union{}])
+    ir = make_ircode(code; ssavaluetypes=Any[Any, Any, Any, Any, Any, Any, Union{}, Union{}])
     @test length(ir.cfg.blocks) == 8
     Core.Compiler.verify_ir(ir)
 


### PR DESCRIPTION
We were mostly consistent about assigning `Any` type to terminators in absint, but some optimization passes preferred `Union{}` instead. Yet elsewhere, we accidentally put `Const(EnterNode(...))` here. None of this really matters, because we're never supposed to look at this, but it's nice to be able to rely on `Union{}` reliably meaning that control terminates after the statement (other than for PhiNode, but that's a separate story) to avoid issues like #54262.