### PR TITLE
fix `circshift(::Tuple{}, ::Int)`

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -704,6 +704,7 @@ function circshift(t::Tuple{Any,Any}, shift::Integer)
 end
 function circshift(x::Tuple{Any,Any,Any,Vararg{Any}}, shift::Integer)
     @inline
-    j = mod1(shift, length(x))
-    ntuple(k -> getindex(x, k-j+ifelse(k>j,0,length(x))), Val(length(x)))
+    len = length(x)
+    j = mod1(shift, len)
+    ntuple(k -> getindex(x, k-j+ifelse(k>j,0,length(x))), Val(len))
 end

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -695,7 +695,14 @@ foreach(f, itr::Tuple, itrs::Tuple...) = foldl((_, xs) -> (f(xs...); nothing), z
 
 circshift(::Tuple{}, ::Integer) = ()
 circshift(t::Tuple{Any}, ::Integer) = t
-function circshift(x::Tuple{Any,Any,Vararg{Any}}, shift::Integer)
+function circshift(t::Tuple{L,R}, shift::Integer) where {L,R}
+    if iseven(shift)
+        t
+    else
+        reverse(t)::Tuple{R,L}
+    end::Tuple{Any,Any}
+end
+function circshift(x::Tuple{Any,Any,Any,Vararg{Any}}, shift::Integer)
     @inline
     j = mod1(shift, length(x))
     ntuple(k -> getindex(x, k-j+ifelse(k>j,0,length(x))), Val(length(x)))

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -706,5 +706,5 @@ function circshift(x::Tuple{Any,Any,Any,Vararg{Any}}, shift::Integer)
     @inline
     len = length(x)
     j = mod1(shift, len)
-    ntuple(k -> getindex(x, k-j+ifelse(k>j,0,length(x))), Val(len))
+    ntuple(k -> getindex(x, k-j+ifelse(k>j,0,length(x))), len)::Tuple
 end

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -693,13 +693,13 @@ empty(@nospecialize x::Tuple) = ()
 foreach(f, itr::Tuple) = foldl((_, x) -> (f(x); nothing), itr, init=nothing)
 foreach(f, itr::Tuple, itrs::Tuple...) = foldl((_, xs) -> (f(xs...); nothing), zip(itr, itrs...), init=nothing)
 
-circshift(::Tuple{}, ::Integer) = ()
-circshift(t::Tuple{Any}, ::Integer) = t
-function circshift(t::Tuple{L,R}, shift::Integer) where {L,R}
+circshift(::Tuple{}, @nospecialize _::Integer) = ()
+circshift((@nospecialize t::Tuple{Any}), @nospecialize _::Integer) = t
+function circshift(t::Tuple{Any,Any}, shift::Integer)
     if iseven(shift)
         t
     else
-        reverse(t)::Tuple{R,L}
+        reverse(t)
     end::Tuple{Any,Any}
 end
 function circshift(x::Tuple{Any,Any,Any,Vararg{Any}}, shift::Integer)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -694,13 +694,7 @@ foreach(f, itr::Tuple) = foldl((_, x) -> (f(x); nothing), itr, init=nothing)
 foreach(f, itr::Tuple, itrs::Tuple...) = foldl((_, xs) -> (f(xs...); nothing), zip(itr, itrs...), init=nothing)
 
 circshift((@nospecialize t::Union{Tuple{},Tuple{Any}}), @nospecialize _::Integer) = t
-function circshift(t::Tuple{Any,Any}, shift::Integer)
-    if iseven(shift)
-        t
-    else
-        reverse(t)
-    end::Tuple{Any,Any}
-end
+circshift(t::Tuple{Any,Any}, shift::Integer) = iseven(shift) ? t : reverse(t)
 function circshift(x::Tuple{Any,Any,Any,Vararg{Any,N}}, shift::Integer) where {N}
     @inline
     len = N + 3

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -693,6 +693,7 @@ empty(@nospecialize x::Tuple) = ()
 foreach(f, itr::Tuple) = foldl((_, x) -> (f(x); nothing), itr, init=nothing)
 foreach(f, itr::Tuple, itrs::Tuple...) = foldl((_, xs) -> (f(xs...); nothing), zip(itr, itrs...), init=nothing)
 
+circshift(::Tuple{}, ::Integer) = ()
 function circshift(x::Tuple, shift::Integer)
     @inline
     j = mod1(shift, length(x))

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -702,9 +702,9 @@ function circshift(t::Tuple{Any,Any}, shift::Integer)
         reverse(t)
     end::Tuple{Any,Any}
 end
-function circshift(x::Tuple{Any,Any,Any,Vararg{Any}}, shift::Integer)
+function circshift(x::Tuple{Any,Any,Any,Vararg{Any,N}}, shift::Integer) where {N}
     @inline
-    len = length(x)
+    len = N + 3
     j = mod1(shift, len)
-    ntuple(k -> getindex(x, k-j+ifelse(k>j,0,length(x))), len)::Tuple
+    ntuple(k -> getindex(x, k-j+ifelse(k>j,0,len)), Val(len))::Tuple
 end

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -694,7 +694,8 @@ foreach(f, itr::Tuple) = foldl((_, x) -> (f(x); nothing), itr, init=nothing)
 foreach(f, itr::Tuple, itrs::Tuple...) = foldl((_, xs) -> (f(xs...); nothing), zip(itr, itrs...), init=nothing)
 
 circshift(::Tuple{}, ::Integer) = ()
-function circshift(x::Tuple, shift::Integer)
+circshift(t::Tuple{Any}, ::Integer) = t
+function circshift(x::Tuple{Any,Any,Vararg{Any}}, shift::Integer)
     @inline
     j = mod1(shift, length(x))
     ntuple(k -> getindex(x, k-j+ifelse(k>j,0,length(x))), Val(length(x)))

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -693,8 +693,7 @@ empty(@nospecialize x::Tuple) = ()
 foreach(f, itr::Tuple) = foldl((_, x) -> (f(x); nothing), itr, init=nothing)
 foreach(f, itr::Tuple, itrs::Tuple...) = foldl((_, xs) -> (f(xs...); nothing), zip(itr, itrs...), init=nothing)
 
-circshift(::Tuple{}, @nospecialize _::Integer) = ()
-circshift((@nospecialize t::Tuple{Any}), @nospecialize _::Integer) = t
+circshift((@nospecialize t::Union{Tuple{},Tuple{Any}}), @nospecialize _::Integer) = t
 function circshift(t::Tuple{Any,Any}, shift::Integer)
     if iseven(shift)
         t

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -832,6 +832,8 @@ end
     @test @inferred(Base.circshift(t3, -1)) == ('b', 'c', 'd', 'a')
     @test_throws MethodError circshift(t1, 'a')
     for i ∈ -2:2
-        @test () === @inferred circshift((), i)
+        for t ∈ ((), (7,))
+            @test t === @inferred circshift(t, i)
+        end
     end
 end

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -836,4 +836,13 @@ end
             @test t === @inferred circshift(t, i)
         end
     end
+    @testset "length-two" begin
+        t = (10, 20)
+        for i ∈ -4:2:4
+            @test t === @inferred circshift(t, i)
+        end
+        for i ∈ -5:2:5
+            @test reverse(t) === @inferred circshift(t, i)
+        end
+    end
 end

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -831,18 +831,13 @@ end
     @test @inferred(Base.circshift(t3, 7)) == ('b', 'c', 'd', 'a')
     @test @inferred(Base.circshift(t3, -1)) == ('b', 'c', 'd', 'a')
     @test_throws MethodError circshift(t1, 'a')
-    for i ∈ -2:2
-        for t ∈ ((), (7,))
-            @test t === @inferred circshift(t, i)
-        end
-    end
-    @testset "length-two" begin
-        t = (10, 20)
-        for i ∈ -4:2:4
-            @test t === @inferred circshift(t, i)
-        end
-        for i ∈ -5:2:5
-            @test reverse(t) === @inferred circshift(t, i)
+    @test Core.Compiler.return_type(circshift, Tuple{Tuple,Integer}) <: Tuple
+    @test Core.Compiler.return_type(circshift, Tuple{Tuple{Vararg{Any,10}},Integer}) <: Tuple{Vararg{Any,10}}
+    for len ∈ 0:5
+        v = 1:len
+        t = Tuple(v)
+        for shift ∈ -6:6
+            @test circshift(v, shift) == collect(circshift(t, shift))
         end
     end
 end

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -831,4 +831,7 @@ end
     @test @inferred(Base.circshift(t3, 7)) == ('b', 'c', 'd', 'a')
     @test @inferred(Base.circshift(t3, -1)) == ('b', 'c', 'd', 'a')
     @test_throws MethodError circshift(t1, 'a')
+    for i ∈ -2:2
+        @test () === @inferred circshift((), i)
+    end
 end


### PR DESCRIPTION
Fixes `circshift` for empty tuples.

Fixes #54294