### PR TITLE
Add note to `unsafe_trunc` docstring

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -398,6 +398,8 @@ float(::Type{Union{}}, slurp...) = Union{}(0.0)
 Return the nearest integral value of type `T` whose absolute value is
 less than or equal to the absolute value of `x`. If the value is not representable by `T`,
 an arbitrary value will be returned.
+"Arbitrary" here means that it is not only dependent on the CPU architecture or
+the julia version, but also possibly different on every invocation.
 See also [`trunc`](@ref).
 
 # Examples
@@ -405,7 +407,7 @@ See also [`trunc`](@ref).
 julia> unsafe_trunc(Int, -2.2)
 -2
 
-julia> unsafe_trunc(Int, NaN)
+julia> unsafe_trunc(Int, NaN) # possibly different on every invocation
 -9223372036854775808
 ```
 """


### PR DESCRIPTION
cf. #54264

The behavior of `unsafe_trunc` for out-of-range values appears to be equivalent to “unspecified behavior” (not "undefined behavior"), using the C++ Standard terminology.
The trouble with that analogy is that it implicitly reminds me that this works deterministically from a local perspective.
Julia is far more dynamic than languages such as C++, which negates the expectation.

The `NaN` example is also misleading as it implies that it is locally deterministic.
However, "worse" examples such as `unsafe_trunc(UInt8, -2.2)` should not be there because the doctest fails.

I am not a good writer, so I will leave the editing to other reviewers.