### PR TITLE
IncrementalCompact: Don't corrupt CFG when finishing early

### DIFF
--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -155,7 +155,7 @@ function choosetests(choices = [])
     # do subarray before sparse but after linalg
     filtertests!(tests, "subarray")
     filtertests!(tests, "compiler", [
-        "compiler/datastructures", "compiler/inference", "compiler/effects",
+        "compiler/datastructures", "compiler/inference", "compiler/effects", "compiler/compact",
         "compiler/validation", "compiler/ssair", "compiler/irpasses", "compiler/tarjan",
         "compiler/codegen", "compiler/inline", "compiler/contextual", "compiler/invalidation",
         "compiler/AbstractInterpreter", "compiler/EscapeAnalysis/EscapeAnalysis"])

--- a/test/compiler/compact.jl
+++ b/test/compiler/compact.jl
@@ -1,0 +1,37 @@
+using Core.Compiler: IncrementalCompact, insert_node_here!, finish,
+    NewInstruction, verify_ir, ReturnNode, SSAValue
+
+foo_test_function(i) = i == 1 ? 1 : 2
+
+@testset "IncrementalCompact statefulness" begin
+    ir = only(Base.code_ircode(foo_test_function, (Int,)))[1]
+    compact = IncrementalCompact(ir)
+
+    # set up first iterator
+    x = Core.Compiler.iterate(compact)
+    x = Core.Compiler.iterate(compact, x[2])
+
+    # set up second iterator
+    x = Core.Compiler.iterate(compact)
+
+    # consume remainder
+    while x !== nothing
+        x = Core.Compiler.iterate(compact, x[2])
+    end
+
+    ir = finish(compact)
+    @test Core.Compiler.verify_ir(ir) === nothing
+end
+
+# Test early finish of IncrementalCompact
+@testset "IncrementalCompact early finish" begin
+    ir = only(Base.code_ircode(foo_test_function, (Int,)))[1]
+    compact = IncrementalCompact(ir)
+
+    insert_node_here!(compact, NewInstruction(ReturnNode(1), Union{}, ir[SSAValue(1)][:line]))
+    new_ir = finish(compact)
+    # TODO: Should IncrementalCompact be doing this internally?
+    empty!(new_ir.cfg.blocks[1].succs)
+    verify_ir(new_ir)
+    @test length(new_ir.cfg.blocks) == 1
+end

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -589,27 +589,6 @@ end
     @test show(devnull, ir) === nothing
 end
 
-@testset "IncrementalCompact statefulness" begin
-    foo(i) = i == 1 ? 1 : 2
-    ir = only(Base.code_ircode(foo, (Int,)))[1]
-    compact = Core.Compiler.IncrementalCompact(ir)
-
-    # set up first iterator
-    x = Core.Compiler.iterate(compact)
-    x = Core.Compiler.iterate(compact, x[2])
-
-    # set up second iterator
-    x = Core.Compiler.iterate(compact)
-
-    # consume remainder
-    while x !== nothing
-        x = Core.Compiler.iterate(compact, x[2])
-    end
-
-    ir = Core.Compiler.complete(compact)
-    @test Core.Compiler.verify_ir(ir) === nothing
-end
-
 # insert_node! operations
 # =======================
 


### PR DESCRIPTION
Finishing an IncrementalComapact before iterating the whole underlying IRCode is not something that we really do in base, or at least not in places other than a basic block boundary. However, it can be useful for downstream consumers, so make it work anyway. Also create a separate test file for IncrementalCompact tests (of which we really should have more) and move one existing test.