### PR TITLE
ir: Add IR_FLAG_UNUSED

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2428,7 +2428,11 @@ struct RTEffects
 end
 
 function abstract_call(interp::AbstractInterpreter, arginfo::ArgInfo, sv::InferenceState)
-    si = StmtInfo(!call_result_unused(sv, sv.currpc))
+    unused = call_result_unused(sv, sv.currpc)
+    if unused
+        add_curr_ssaflag!(sv, IR_FLAG_UNUSED)
+    end
+    si = StmtInfo(!unused)
     call = abstract_call(interp, arginfo, si, sv)
     sv.stmt_info[sv.currpc] = call.info
     return call

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -44,8 +44,10 @@ const IR_FLAG_NOUB        = one(UInt32) << 9
 const IR_FLAG_EFIIMO      = one(UInt32) << 10
 # This statement is :inaccessiblememonly == INACCESSIBLEMEM_OR_ARGMEMONLY
 const IR_FLAG_INACCESSIBLEMEM_OR_ARGMEM = one(UInt32) << 11
+# This statement has no users and may be deleted if flags get refined to IR_FLAGS_REMOVABLE
+const IR_FLAG_UNUSED      = one(UInt32) << 12
 
-const NUM_IR_FLAGS = 12 # sync with julia.h
+const NUM_IR_FLAGS = 13 # sync with julia.h
 
 const IR_FLAGS_EFFECTS =
     IR_FLAG_CONSISTENT | IR_FLAG_EFFECT_FREE | IR_FLAG_NOTHROW | IR_FLAG_TERMINATES | IR_FLAG_NOUB

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1933,7 +1933,10 @@ function maybe_erase_unused!(callback::Function, compact::IncrementalCompact, id
     stmt = inst[:stmt]
     stmt === nothing && return false
     inst[:type] === Bottom && return false
-    has_flag(inst, IR_FLAGS_REMOVABLE) || return false
+    if !has_flag(inst, IR_FLAGS_REMOVABLE)
+        add_flag!(inst, IR_FLAG_UNUSED)
+        return false
+    end
     foreachssa(stmt) do val::SSAValue
         if compact.used_ssas[val.id] == 1
             if val.id < idx || in_worklist

--- a/base/compiler/ssair/irinterp.jl
+++ b/base/compiler/ssair/irinterp.jl
@@ -191,6 +191,13 @@ function reprocess_instruction!(interp::AbstractInterpreter, inst::Instruction, 
         rt = argextype(stmt, irsv.ir)
     end
     if rt !== nothing
+        if has_flag(inst, IR_FLAG_UNUSED)
+            # Don't bother checking the type if we know it's unused
+            if has_flag(inst, IR_FLAGS_REMOVABLE)
+                inst[:stmt] = nothing
+            end
+            return false
+        end
         if isa(rt, Const)
             inst[:type] = rt
             if is_inlineable_constant(rt.val) && has_flag(inst, IR_FLAGS_REMOVABLE)

--- a/src/julia.h
+++ b/src/julia.h
@@ -284,7 +284,7 @@ typedef union __jl_purity_overrides_t {
 } _jl_purity_overrides_t;
 
 #define NUM_EFFECTS_OVERRIDES 9
-#define NUM_IR_FLAGS 12
+#define NUM_IR_FLAGS 13
 
 // This type describes a single function body
 typedef struct _jl_code_info_t {


### PR DESCRIPTION
Set on statements whose result is unused. Allows irinterp to skip some type processing on these and eagerly delete statements that become refined to be dead without requiring a subsequent compaction.