### PR TITLE
LinearAlgebra: improve type-inference in Symmetric/Hermitian matmul

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -519,6 +519,7 @@ export ⋅, ×
 # Separate the char corresponding to the wrapper from that corresponding to the uplo
 # In most cases, the former may be constant-propagated, while the latter usually can't be.
 # This improves type-inference in wrap for Symmetric/Hermitian matrices
+# A WrapperChar is equivalent to `isuppertri ? uppercase(wrapperchar) : lowercase(wrapperchar)`
 struct WrapperChar <: AbstractChar
     wrapperchar :: Char
     isuppertri :: Bool
@@ -533,16 +534,18 @@ function Base.Char(w::WrapperChar)
 end
 Base.codepoint(w::WrapperChar) = codepoint(Char(w))
 WrapperChar(n::UInt32) = WrapperChar(Char(n), true)
+# We extract the wrapperchar so that the result may be constant-propagated
+# This doesn't return a value of the same type on purpose
 Base.uppercase(w::WrapperChar) = uppercase(w.wrapperchar)
 Base.lowercase(w::WrapperChar) = lowercase(w.wrapperchar)
 _isuppertri(w::WrapperChar) = w.isuppertri
 _isuppertri(x::AbstractChar) = isuppercase(x) # compatibility with earlier Char-based implementation
 _getuplo(x) = _isuppertri(x) ? (:U) : (:L)
 
-wrapper_char(::AbstractArray) = WrapperChar('N')
-wrapper_char(::Adjoint) = WrapperChar('C')
-wrapper_char(::Adjoint{<:Real}) = WrapperChar('T')
-wrapper_char(::Transpose) = WrapperChar('T')
+wrapper_char(::AbstractArray) = 'N'
+wrapper_char(::Adjoint) = 'C'
+wrapper_char(::Adjoint{<:Real}) = 'T'
+wrapper_char(::Transpose) = 'T'
 wrapper_char(A::Hermitian) =  WrapperChar('H', A.uplo == 'U')
 wrapper_char(A::Hermitian{<:Real}) = WrapperChar('S', A.uplo == 'U')
 wrapper_char(A::Symmetric) = WrapperChar('S', A.uplo == 'U')

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -533,7 +533,8 @@ function Base.Char(w::WrapperChar)
     end
 end
 Base.codepoint(w::WrapperChar) = codepoint(Char(w))
-WrapperChar(n::UInt32) = WrapperChar(Char(n), true)
+WrapperChar(n::UInt32) = WrapperChar(Char(n))
+WrapperChar(c::Char) = WrapperChar(c, true) # this constructor helps with assuming :nothrow
 # We extract the wrapperchar so that the result may be constant-propagated
 # This doesn't return a value of the same type on purpose
 Base.uppercase(w::WrapperChar) = uppercase(w.wrapperchar)

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -526,7 +526,7 @@ struct WrapperChar <: AbstractChar
 end
 function Base.Char(w::WrapperChar)
     T = w.wrapperchar
-    if T ∉ ('S', 'H')
+    if T ∈ ('N', 'T', 'C') # known cases where isuppertri is true
         T
     else
         _isuppertri(w) ? uppercase(T) : lowercase(T)
@@ -534,14 +534,14 @@ function Base.Char(w::WrapperChar)
 end
 Base.codepoint(w::WrapperChar) = codepoint(Char(w))
 WrapperChar(n::UInt32) = WrapperChar(Char(n))
-WrapperChar(c::Char) = WrapperChar(c, true) # this constructor helps with assuming :nothrow
+WrapperChar(c::Char) = WrapperChar(c, isuppercase(c))
 # We extract the wrapperchar so that the result may be constant-propagated
 # This doesn't return a value of the same type on purpose
 Base.uppercase(w::WrapperChar) = uppercase(w.wrapperchar)
 Base.lowercase(w::WrapperChar) = lowercase(w.wrapperchar)
 _isuppertri(w::WrapperChar) = w.isuppertri
 _isuppertri(x::AbstractChar) = isuppercase(x) # compatibility with earlier Char-based implementation
-_getuplo(x) = _isuppertri(x) ? (:U) : (:L)
+_uplosym(x) = _isuppertri(x) ? (:U) : (:L)
 
 wrapper_char(::AbstractArray) = 'N'
 wrapper_char(::Adjoint) = 'C'
@@ -563,9 +563,9 @@ Base.@constprop :aggressive function wrap(A::AbstractVecOrMat, tA::AbstractChar)
     elseif tA_uc == 'C'
         adjoint(A)
     elseif tA_uc == 'H'
-        Hermitian(A, _getuplo(tA) #= unwrap a WrapperChar =#)
+        Hermitian(A, _uplosym(tA))
     elseif tA_uc == 'S'
-        Symmetric(A, _getuplo(tA) #= unwrap a WrapperChar =#)
+        Symmetric(A, _uplosym(tA))
     end
     return B::AbstractVecOrMat
 end

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -446,19 +446,19 @@ Base.@constprop :aggressive function gemv!(y::StridedVector{T}, tA::AbstractChar
     mA == 0 && return y
     nA == 0 && return _rmul_or_fill!(y, β)
     alpha, beta = promote(α, β, zero(T))
-    tA_ = uppercase(tA) # potentially convert a WrapperChar to a Char
+    tA_uc = uppercase(tA) # potentially convert a WrapperChar to a Char
     if alpha isa Union{Bool,T} && beta isa Union{Bool,T} &&
         stride(A, 1) == 1 && abs(stride(A, 2)) >= size(A, 1) &&
         !iszero(stride(x, 1)) && # We only check input's stride here.
-        if _in(tA_, ('N', 'T', 'C'))
+        if _in(tA_uc, ('N', 'T', 'C'))
             return BLAS.gemv!(tA, alpha, A, x, beta, y)
-        elseif tA_ == 'S'
+        elseif tA_uc == 'S'
             return BLAS.symv!(tA == 'S' ? 'U' : 'L', alpha, A, x, beta, y)
-        elseif tA_ == 'H'
+        elseif tA_uc == 'H'
             return BLAS.hemv!(tA == 'H' ? 'U' : 'L', alpha, A, x, beta, y)
         end
     end
-    if _in(tA_, ('S', 'H'))
+    if _in(tA_uc, ('S', 'H'))
         # re-wrap again and use plain ('N') matvec mul algorithm,
         # because _generic_matvecmul! can't handle the HermOrSym cases specifically
         return _generic_matvecmul!(y, oftype(tA, 'N'), wrap(A, tA), x, MulAddMul(α, β))

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -373,7 +373,7 @@ all_in(chars, (tA, tB)) = _in(tA, chars) && _in(tB, chars)
 Base.@constprop :aggressive function generic_matmatmul!(C::StridedMatrix{T}, tA, tB, A::StridedVecOrMat{T}, B::StridedVecOrMat{T},
                                     _add::MulAddMul=MulAddMul()) where {T<:BlasFloat}
     # if all(in(('N', 'T', 'C')), (tA, tB)), but we unroll the implementation to enable constprop
-    # We convert the chars to uppercase to potentially unwrap a WraperChar,
+    # We convert the chars to uppercase to potentially unwrap a WrapperChar,
     # and extract the char corresponding to the wrapper type
     tA_uc, tB_uc = uppercase(tA), uppercase(tB)
     if all_in(('N', 'T', 'C'), map(uppercase, (tA_uc, tB_uc)))
@@ -408,7 +408,7 @@ end
 Base.@constprop :aggressive function generic_matmatmul!(C::StridedVecOrMat{Complex{T}}, tA, tB, A::StridedVecOrMat{Complex{T}}, B::StridedVecOrMat{T},
                     _add::MulAddMul=MulAddMul()) where {T<:BlasReal}
     # if all(in(('N', 'T', 'C')), (tA, tB)), but we unroll the implementation to enable constprop
-    # We convert the chars to uppercase to potentially unwrap a WraperChar,
+    # We convert the chars to uppercase to potentially unwrap a WrapperChar,
     # and extract the char corresponding to the wrapper type
     if all_in(('N', 'T', 'C'), map(uppercase, (tA, tB)))
         gemm_wrapper!(C, tA, tB, A, B, _add)
@@ -612,7 +612,7 @@ Base.@constprop :aggressive function gemm_wrapper(tA::AbstractChar, tB::Abstract
     mB, nB = lapack_size(tB, B)
     C = similar(B, T, mA, nB)
     # if all(in(('N', 'T', 'C')), (tA, tB)), but we unroll the implementation to enable constprop
-    # We convert the chars to uppercase to potentially unwrap a WraperChar,
+    # We convert the chars to uppercase to potentially unwrap a WrapperChar,
     # and extract the char corresponding to the wrapper type
     if all_in(('N', 'T', 'C'), map(uppercase, (tA, tB)))
         gemm_wrapper!(C, tA, tB, A, B)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -523,6 +523,7 @@ Base.@constprop :aggressive function gemv!(y::StridedVector{Complex{T}}, tA::Abs
 end
 
 # the aggressive constprop pushes tA and tB into gemm_wrapper!, which is needed for wrap calls within it
+# to be concretely inferred
 Base.@constprop :aggressive function syrk_wrapper!(C::StridedMatrix{T}, tA::AbstractChar, A::StridedVecOrMat{T},
         _add = MulAddMul()) where {T<:BlasFloat}
     nC = checksquare(C)
@@ -563,6 +564,7 @@ Base.@constprop :aggressive function syrk_wrapper!(C::StridedMatrix{T}, tA::Abst
 end
 
 # the aggressive constprop pushes tA and tB into gemm_wrapper!, which is needed for wrap calls within it
+# to be concretely inferred
 Base.@constprop :aggressive function herk_wrapper!(C::Union{StridedMatrix{T}, StridedMatrix{Complex{T}}}, tA::AbstractChar, A::Union{StridedVecOrMat{T}, StridedVecOrMat{Complex{T}}},
         _add = MulAddMul()) where {T<:BlasReal}
     nC = checksquare(C)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -385,11 +385,11 @@ Base.@constprop :aggressive function generic_matmatmul!(C::StridedMatrix{T}, tA,
     if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
         if tA_uc == 'S' && tB_uc == 'N'
             return BLAS.symm!('L', tA == 'S' ? 'U' : 'L', alpha, A, B, beta, C)
-        elseif tB_uc == 'S' && tA_uc == 'N'
+        elseif tA_uc == 'N' && tB_uc == 'S'
             return BLAS.symm!('R', tB == 'S' ? 'U' : 'L', alpha, B, A, beta, C)
         elseif tA_uc == 'H' && tB_uc == 'N'
             return BLAS.hemm!('L', tA == 'H' ? 'U' : 'L', alpha, A, B, beta, C)
-        elseif tB_uc == 'H' && tA_uc == 'N'
+        elseif tA_uc == 'N' && tB_uc == 'H'
             return BLAS.hemm!('R', tB == 'H' ? 'U' : 'L', alpha, B, A, beta, C)
         end
     end

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -405,7 +405,6 @@ end
 # Complex matrix times (transposed) real matrix. Reinterpret the first matrix to real for efficiency.
 Base.@constprop :aggressive function generic_matmatmul!(C::StridedVecOrMat{Complex{T}}, tA, tB, A::StridedVecOrMat{Complex{T}}, B::StridedVecOrMat{T},
                     _add::MulAddMul=MulAddMul()) where {T<:BlasReal}
-    special_cases = ('N', 'T', 'C')
     # if all(in(('N', 'T', 'C')), (tA, tB)), but we unroll the implementation to enable constprop
     # The check is only on the wrapper type, so we may extract that from a WrapperChar
     if all_in(('N', 'T', 'C'), map(_getwrapperchar, (tA, tB)))

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -464,7 +464,7 @@ Base.@constprop :aggressive function gemv!(y::StridedVector{T}, tA::AbstractChar
     if _in(tA_uc, ('S', 'H'))
         # re-wrap again and use plain ('N') matvec mul algorithm,
         # because _generic_matvecmul! can't handle the HermOrSym cases specifically
-        return _generic_matvecmul!(y, oftype(tA, 'N'), wrap(A, tA), x, MulAddMul(α, β))
+        return _generic_matvecmul!(y, 'N', wrap(A, tA), x, MulAddMul(α, β))
     else
         return _generic_matvecmul!(y, tA, A, x, MulAddMul(α, β))
     end
@@ -516,7 +516,7 @@ Base.@constprop :aggressive function gemv!(y::StridedVector{Complex{T}}, tA::Abs
     elseif _in(tA_uc, ('S', 'H'))
         # re-wrap again and use plain ('N') matvec mul algorithm,
         # because _generic_matvecmul! can't handle the HermOrSym cases specifically
-        return _generic_matvecmul!(y, oftype(tA, 'N'), wrap(A, tA), x, MulAddMul(α, β))
+        return _generic_matvecmul!(y, 'N', wrap(A, tA), x, MulAddMul(α, β))
     else
         return _generic_matvecmul!(y, tA, A, x, MulAddMul(α, β))
     end
@@ -530,10 +530,10 @@ Base.@constprop :aggressive function syrk_wrapper!(C::StridedMatrix{T}, tA::Abst
     tA_uc = uppercase(tA) # potentially convert a WrapperChar to a Char
     if tA_uc == 'T'
         (nA, mA) = size(A,1), size(A,2)
-        tAt = oftype(tA, 'N')
+        tAt = 'N'
     else
         (mA, nA) = size(A,1), size(A,2)
-        tAt = oftype(tA, 'T')
+        tAt = 'T'
     end
     if nC != mA
         throw(DimensionMismatch(lazy"output matrix has size: $(nC), but should have size $(mA)"))
@@ -571,10 +571,10 @@ Base.@constprop :aggressive function herk_wrapper!(C::Union{StridedMatrix{T}, St
     tA_uc = uppercase(tA) # potentially convert a WrapperChar to a Char
     if tA_uc == 'C'
         (nA, mA) = size(A,1), size(A,2)
-        tAt = oftype(tA, 'N')
+        tAt = 'N'
     else
         (mA, nA) = size(A,1), size(A,2)
-        tAt = oftype(tA, 'C')
+        tAt = 'C'
     end
     if nC != mA
         throw(DimensionMismatch(lazy"output matrix has size: $(nC), but should have size $(mA)"))

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -39,6 +39,21 @@ mul_wrappers = [
     for S in (Symmetric(M), Hermitian(M))
         @test @inferred((A -> LinearAlgebra.wrap(parent(A), LinearAlgebra.wrapper_char(A)))(S)) === S
     end
+
+    @testset "WrapperChar" begin
+        @test LinearAlgebra.WrapperChar('c') == 'c'
+        @test LinearAlgebra.WrapperChar('C') == 'C'
+        @testset "constant propagation in uppercase/lowercase" begin
+            v = @inferred (() -> Val(uppercase(LinearAlgebra.WrapperChar('C'))))()
+            @test v isa Val{'C'}
+            v = @inferred (() -> Val(uppercase(LinearAlgebra.WrapperChar('s'))))()
+            @test v isa Val{'S'}
+            v = @inferred (() -> Val(lowercase(LinearAlgebra.WrapperChar('C'))))()
+            @test v isa Val{'c'}
+            v = @inferred (() -> Val(lowercase(LinearAlgebra.WrapperChar('s'))))()
+            @test v isa Val{'s'}
+        end
+    end
 end
 
 @testset "matrices with zero dimensions" begin

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -30,6 +30,15 @@ mul_wrappers = [
     h(A) = LinearAlgebra.wrap(LinearAlgebra._unwrap(A), LinearAlgebra.wrapper_char(A))
     @test @inferred(h(transpose(A))) === transpose(A)
     @test @inferred(h(adjoint(A))) === transpose(A)
+
+    M = rand(2,2)
+    for S in (Symmetric(M), Hermitian(M))
+        @test @inferred((A -> LinearAlgebra.wrap(parent(A), LinearAlgebra.wrapper_char(A)))(S)) === Symmetric(M)
+    end
+    M = rand(ComplexF64,2,2)
+    for S in (Symmetric(M), Hermitian(M))
+        @test @inferred((A -> LinearAlgebra.wrap(parent(A), LinearAlgebra.wrapper_char(A)))(S)) === S
+    end
 end
 
 @testset "matrices with zero dimensions" begin


### PR DESCRIPTION
Matrix multiplication for wrapper types such as `Hermitian` currently uses the unwrapping mechanism that assigns a character based on the type of the wrapper. However, this isn't always unique, as for `Hermitian`/`Symmetric` types, this also looks as the `uplo` field, which isn't usually known at compile time.
https://github.com/JuliaLang/julia/blob/6023ad6718514c15b3297197757ae3d93b85270b/stdlib/LinearAlgebra/src/LinearAlgebra.jl#L523-L525
An example of a badly inferred function call because of this:
```julia
julia> @descend_code_warntype (A -> LinearAlgebra.wrap(parent(A), LinearAlgebra.wrapper_char(A)))(Symmetric(rand(2,2)))
(::var"#1#2")(A) @ Main REPL[2]:1
┌ Warning: couldn't retrieve source of (::var"#1#2")(A) @ Main REPL[2]:1
└ @ TypedSyntax ~/.julia/packages/TypedSyntax/cH1Nu/src/node.jl:36
Variables
  #self#::Core.Const(var"#1#2"())
  A::Symmetric{Float64, Matrix{Float64}}

Body::Union{Adjoint{Float64, Matrix{Float64}}, Hermitian{Float64, Matrix{Float64}}, Symmetric{Float64, Matrix{Float64}}, Transpose{Float64, Matrix{Float64}}, Matrix{Float64}}
    @ REPL[2]:1 within `#1`
1 ─ %1 = LinearAlgebra.wrap::Core.Const(LinearAlgebra.wrap)
│   %2 = Main.parent::Core.Const(parent)
│   %3 = (%2)(A)::Matrix{Float64}
│   %4 = LinearAlgebra.wrapper_char::Core.Const(LinearAlgebra.wrapper_char)
│   %5 = (%4)(A)::Char
│   %6 = (%1)(%3, %5)::Union{Adjoint{Float64, Matrix{Float64}}, Hermitian{Float64, Matrix{Float64}}, Symmetric{Float64, Matrix{Float64}}, Transpose{Float64, Matrix{Float64}}, Matrix{Float64}}
└──      return %6
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [w]arn, [h]ide type-stable statements, [t]ype annotations, [s]yntax highlight for Source/LLVM/Native, [j]ump to source always.
Show: [S]ource code, [A]ST, [T]yped code, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
 • %3 = parent(::Symmetric{Float64, Matrix{Float64}})::Matrix{Float64}
   %5 = wrapper_char(::Symmetric{Float64, Matrix{Float64}})::Char
   %6 = wrap(::Matrix{Float64},::Char)::…
```
The output type is inferred as a large union, which complicates further type-inference downstream. Often, the impact of the runtime dispatch is minimal due to function barriers. However, we may avoid the runtime dispatch altogether.

This PR separates the `uplo` character from that for the type, storing them both in a newly defined struct. Using this approach, the type information may be constant-propagated even if the `uplo` isn't, and the return type may be concretely inferred. After this,
```julia
julia> @descend_code_warntype (A -> LinearAlgebra.wrap(parent(A), LinearAlgebra.wrapper_char(A)))(Symmetric(rand(2,2)))
(::var"#3#4")(A) @ Main REPL[3]:1
┌ Warning: couldn't retrieve source of (::var"#3#4")(A) @ Main REPL[3]:1
└ @ TypedSyntax ~/.julia/packages/TypedSyntax/cH1Nu/src/node.jl:36
Variables
  #self#::Core.Const(var"#3#4"())
  A::Symmetric{Float64, Matrix{Float64}}

Body::Symmetric{Float64, Matrix{Float64}}
    @ REPL[3]:1 within `unknown scope`
1 ─ %1 = LinearAlgebra.wrap::Core.Const(LinearAlgebra.wrap)
│   %2 = Main.parent::Core.Const(parent)
│   %3 = (%2)(A)::Matrix{Float64}
│   %4 = LinearAlgebra.wrapper_char::Core.Const(LinearAlgebra.wrapper_char)
│   %5 = (%4)(A)::Core.PartialStruct(LinearAlgebra.WrapperChar, Any[Core.Const('S'), Bool])
│   %6 = (%1)(%3, %5)::Symmetric{Float64, Matrix{Float64}}
└──      return %6
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [w]arn, [h]ide type-stable statements, [t]ype annotations, [s]yntax highlight for Source/LLVM/Native, [j]ump to source always.
Show: [S]ource code, [A]ST, [T]yped code, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
 • %3 = parent(::Symmetric{Float64, Matrix{Float64}})::Matrix{Float64}
   %5 = wrapper_char(::Symmetric{Float64, Matrix{Float64}})::Core.PartialStruct(LinearAlgebra.WrapperChar, Any[Core.Const('S'), Bool])
   %6 = < constprop > wrap(::Matrix{Float64},::Core.PartialStruct(LinearAlgebra.WrapperChar, Any[Core.Const('S'), Bool]))::…
   ↩
```

This change should be compatible with existing codes, as the new struct subtypes an `AbstractChar`, and it may be converted and compared to a `Char` like before.

Fixes https://github.com/JuliaLang/julia/issues/53951.