### PR TITLE
Use standard `binomial` for Integer arguments

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -1205,6 +1205,7 @@ Base.@assume_effects :terminates_locally function binomial(n::T, k::T) where T<:
     end
     copysign(x, sgn)
 end
+binomial(n::Integer, k::Integer) = binomial(promote(n, k)...)
 
 """
     binomial(x::Number, k::Integer)

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -593,6 +593,10 @@ end
             x>=0 && @test binomial(x,x-T(2)) == div(x*(x-1), 2)
         end
         @test @inferred(binomial(one(T),one(T))) isa T
+
+        # Arguments of different Integer types do not lead to computation of
+        # generalized binomial coefficient (issue #54296)
+        @test @inferred(binomial(Int64(5), T(2))) === Int64(10)
     end
     for x in ((false,false), (false,true), (true,false), (true,true))
         @test binomial(x...) == (x != (false,true))


### PR DESCRIPTION
Before this commit, `binomial(Int64(10), Int32(5))` meant the generalized binomial coefficient due to the arguments being of different types, which was in contradiction with the documentation.

Fixes #54296