### PR TITLE
Allow optimized OC in :new_opaque_closure

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6168,8 +6168,17 @@ static std::pair<Function*, Function*> get_oc_function(jl_codectx_t &ctx, jl_met
     }
     sigtype = jl_apply_tuple_type_v(jl_svec_data(sig_args), nsig);
 
-    jl_method_instance_t *mi = jl_specializations_get_linfo(closure_method, sigtype, jl_emptysvec);
-    jl_code_instance_t *ci = (jl_code_instance_t*)jl_rettype_inferred_addr(mi, ctx.min_world, ctx.max_world);
+    jl_method_instance_t *mi;
+    jl_code_instance_t *ci;
+
+    if (closure_method->source) {
+        mi = jl_specializations_get_linfo(closure_method, sigtype, jl_emptysvec);
+        ci = (jl_code_instance_t*)jl_rettype_inferred_addr(mi, ctx.min_world, ctx.max_world);
+    } else {
+        mi = (jl_method_instance_t*)jl_atomic_load_relaxed(&closure_method->specializations);
+        assert(jl_is_method_instance(mi));
+        ci = jl_atomic_load_relaxed(&mi->cache);
+    }
 
     if (ci == NULL || (jl_value_t*)ci == jl_nothing) {
         JL_GC_POP();


### PR DESCRIPTION
This isn't officially supported, but some packages are currently using the pattern of creating an optimized opaque closure, pulling out its method and then using that in `:new_opaque_closure` to change the environment. This stopped working properly when I changed optimized ocs to not have a ->source field in the method. Let's keep this working for now, but I'd like to provide a more first class mechanism for these kinds of use cases in the near future.