### PR TITLE
Assume :nothrow in iterating over tuples

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -68,6 +68,7 @@ end
 
 function iterate(@nospecialize(t::Tuple), i::Int=1)
     @inline
+    @_nothrow_meta
     return (1 <= i <= length(t)) ? (t[i], i + 1) : nothing
 end
 

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -210,8 +210,7 @@ end
     @test eachindex((2,5,"foo")) === Base.OneTo(3)
     @test eachindex((2,5,"foo"), (1,2,5,7)) === Base.OneTo(4)
 
-    x = Base.infer_effects(iterate, (Tuple{Int,Int,Int}, Int))
-    @test x.nothrow
+    @test Core.Compiler.is_nothrow(Base.infer_effects(iterate, (Tuple{Int,Int,Int}, Int)))
 end
 
 

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -209,6 +209,9 @@ end
 
     @test eachindex((2,5,"foo")) === Base.OneTo(3)
     @test eachindex((2,5,"foo"), (1,2,5,7)) === Base.OneTo(4)
+
+    x = Base.infer_effects(iterate, (Tuple{Int,Int,Int}, Int))
+    @test x.nothrow
 end
 
 


### PR DESCRIPTION
On master,
```julia
julia> Base.infer_effects(iterate, (Tuple{Int,Int,Int}, Int))
(+c,+e,!n,+t,+s,+m,+u)
```
Since the indexing is only carried out for valid indices, it should be safe to mark this as `nothrow`.
After this PR,
```julia
julia> Base.infer_effects(iterate, (Tuple{Int,Int,Int}, Int))
(+c,+e,+n,+t,+s,+m,+u)
```
