### PR TITLE
Assume `:foldable` in `isuppercase`/`islowercase` for `Char`

### DIFF
--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -411,14 +411,8 @@ julia> isuppercase('❤')
 false
 ```
 """
-function isuppercase(c::AbstractChar)
-    if ismalformed(c)
-        false
-    else
-        ui = UInt32(c)::UInt32 # type-assertion to ensure that we may assume :foldable
-        @assume_effects :foldable Bool(ccall(:utf8proc_isupper, Cint, (UInt32,), ui))
-    end
-end
+isuppercase(c::AbstractChar) = ismalformed(c) ? false :
+    Bool(@assume_effects :foldable @ccall utf8proc_isupper(UInt32(c)::UInt32)::Cint)
 
 """
     iscased(c::AbstractChar) -> Bool

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -5,7 +5,8 @@ module Unicode
 
 import Base: show, ==, hash, string, Symbol, isless, length, eltype,
              convert, isvalid, ismalformed, isoverlong, iterate,
-             AnnotatedString, AnnotatedChar, annotated_chartransform
+             AnnotatedString, AnnotatedChar, annotated_chartransform,
+             @assume_effects
 
 # whether codepoints are valid Unicode scalar values, i.e. 0-0xd7ff, 0xe000-0x10ffff
 
@@ -385,7 +386,10 @@ julia> islowercase('❤')
 false
 ```
 """
-islowercase(c::AbstractChar) = ismalformed(c) ? false : Bool(ccall(:utf8proc_islower, Cint, (UInt32,), UInt32(c)))
+islowercase(c::AbstractChar) = _islowercase(c)
+# identical method body, but with better effects for a Char argument
+@assume_effects :foldable islowercase(c::Char) = _islowercase(c)
+@inline _islowercase(c) = ismalformed(c) ? false : Bool(ccall(:utf8proc_islower, Cint, (UInt32,), UInt32(c)))
 
 # true for Unicode upper and mixed case
 
@@ -409,7 +413,10 @@ julia> isuppercase('❤')
 false
 ```
 """
-isuppercase(c::AbstractChar) = ismalformed(c) ? false : Bool(ccall(:utf8proc_isupper, Cint, (UInt32,), UInt32(c)))
+isuppercase(c::AbstractChar) = _isuppercase(c)
+# identical method body, but with better effects for a Char argument
+@assume_effects :foldable isuppercase(c::Char) = _isuppercase(c)
+@inline _isuppercase(c) = ismalformed(c) ? false : Bool(ccall(:utf8proc_isupper, Cint, (UInt32,), UInt32(c)))
 
 """
     iscased(c::AbstractChar) -> Bool

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -386,14 +386,8 @@ julia> islowercase('❤')
 false
 ```
 """
-function islowercase(c::AbstractChar)
-    if ismalformed(c)
-        false
-    else
-        ui = UInt32(c)::UInt32 # type-assertion to ensure that we may assume :foldable
-        @assume_effects :foldable Bool(ccall(:utf8proc_islower, Cint, (UInt32,), ui))
-    end
-end
+islowercase(c::AbstractChar) = ismalformed(c) ? false :
+    Bool(@assume_effects :foldable @ccall utf8proc_islower(UInt32(c)::UInt32)::Cint)
 
 # true for Unicode upper and mixed case
 

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -386,10 +386,14 @@ julia> islowercase('❤')
 false
 ```
 """
-islowercase(c::AbstractChar) = _islowercase(c)
-# identical method body, but with better effects for a Char argument
-@assume_effects :foldable islowercase(c::Char) = _islowercase(c)
-@inline _islowercase(c) = ismalformed(c) ? false : Bool(ccall(:utf8proc_islower, Cint, (UInt32,), UInt32(c)))
+function islowercase(c::AbstractChar)
+    if ismalformed(c)
+        false
+    else
+        ui = UInt32(c)::UInt32 # type-assertion to ensure that we may assume :foldable
+        @assume_effects :foldable Bool(ccall(:utf8proc_islower, Cint, (UInt32,), ui))
+    end
+end
 
 # true for Unicode upper and mixed case
 
@@ -413,10 +417,14 @@ julia> isuppercase('❤')
 false
 ```
 """
-isuppercase(c::AbstractChar) = _isuppercase(c)
-# identical method body, but with better effects for a Char argument
-@assume_effects :foldable isuppercase(c::Char) = _isuppercase(c)
-@inline _isuppercase(c) = ismalformed(c) ? false : Bool(ccall(:utf8proc_isupper, Cint, (UInt32,), UInt32(c)))
+function isuppercase(c::AbstractChar)
+    if ismalformed(c)
+        false
+    else
+        ui = UInt32(c)::UInt32 # type-assertion to ensure that we may assume :foldable
+        @assume_effects :foldable Bool(ccall(:utf8proc_isupper, Cint, (UInt32,), ui))
+    end
+end
 
 """
     iscased(c::AbstractChar) -> Bool

--- a/test/char.jl
+++ b/test/char.jl
@@ -360,3 +360,21 @@ end
     @test Base.IteratorSize(Char) == Base.HasShape{0}()
     @test convert(ASCIIChar, 1) == Char(1)
 end
+
+@testset "foldable isuppercase/islowercase" begin
+    v = @inferred (() -> Val(isuppercase('C')))()
+    @test v isa Val{true}
+    v = @inferred (() -> Val(islowercase('C')))()
+    @test v isa Val{false}
+
+    struct MyChar <: AbstractChar
+        x :: Char
+    end
+    Base.codepoint(m::MyChar) = codepoint(m.x)
+    MyChar(x::UInt32) = MyChar(Char(x))
+
+    v = @inferred (() -> Val(isuppercase(MyChar('C'))))()
+    @test v isa Val{true}
+    v = @inferred (() -> Val(islowercase(MyChar('C'))))()
+    @test v isa Val{false}
+end


### PR DESCRIPTION
With this, `isuppercase`/`islowercase` are evaluated at compile-time for `Char` arguments:
```julia
julia> @code_typed (() -> isuppercase('A'))()
CodeInfo(
1 ─     return true
) => Bool

julia> @code_typed (() -> islowercase('A'))()
CodeInfo(
1 ─     return false
) => Bool
```
This would be useful in https://github.com/JuliaLang/julia/pull/54303, where the case of the character indicates which triangular half of a matrix is filled, and may be constant-propagated downstream.