### PR TITLE
Abbreviate `show(io, ::Module)`

### DIFF
--- a/base/atomics.jl
+++ b/base/atomics.jl
@@ -60,7 +60,7 @@ Atomic objects can be accessed using the `[]` notation:
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(3)
-Base.Threads.Atomic{Int64}(3)
+Threads.Atomic{Int64}(3)
 
 julia> x[] = 1
 1
@@ -107,17 +107,17 @@ time.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(3)
-Base.Threads.Atomic{Int64}(3)
+Threads.Atomic{Int64}(3)
 
 julia> Threads.atomic_cas!(x, 4, 2);
 
 julia> x
-Base.Threads.Atomic{Int64}(3)
+Threads.Atomic{Int64}(3)
 
 julia> Threads.atomic_cas!(x, 3, 2);
 
 julia> x
-Base.Threads.Atomic{Int64}(2)
+Threads.Atomic{Int64}(2)
 ```
 """
 function atomic_cas! end
@@ -135,7 +135,7 @@ For further details, see LLVM's `atomicrmw xchg` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(3)
-Base.Threads.Atomic{Int64}(3)
+Threads.Atomic{Int64}(3)
 
 julia> Threads.atomic_xchg!(x, 2)
 3
@@ -159,7 +159,7 @@ For further details, see LLVM's `atomicrmw add` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(3)
-Base.Threads.Atomic{Int64}(3)
+Threads.Atomic{Int64}(3)
 
 julia> Threads.atomic_add!(x, 2)
 3
@@ -183,7 +183,7 @@ For further details, see LLVM's `atomicrmw sub` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(3)
-Base.Threads.Atomic{Int64}(3)
+Threads.Atomic{Int64}(3)
 
 julia> Threads.atomic_sub!(x, 2)
 3
@@ -206,7 +206,7 @@ For further details, see LLVM's `atomicrmw and` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(3)
-Base.Threads.Atomic{Int64}(3)
+Threads.Atomic{Int64}(3)
 
 julia> Threads.atomic_and!(x, 2)
 3
@@ -229,7 +229,7 @@ For further details, see LLVM's `atomicrmw nand` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(3)
-Base.Threads.Atomic{Int64}(3)
+Threads.Atomic{Int64}(3)
 
 julia> Threads.atomic_nand!(x, 2)
 3
@@ -252,7 +252,7 @@ For further details, see LLVM's `atomicrmw or` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(5)
-Base.Threads.Atomic{Int64}(5)
+Threads.Atomic{Int64}(5)
 
 julia> Threads.atomic_or!(x, 7)
 5
@@ -275,7 +275,7 @@ For further details, see LLVM's `atomicrmw xor` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(5)
-Base.Threads.Atomic{Int64}(5)
+Threads.Atomic{Int64}(5)
 
 julia> Threads.atomic_xor!(x, 7)
 5
@@ -298,7 +298,7 @@ For further details, see LLVM's `atomicrmw max` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(5)
-Base.Threads.Atomic{Int64}(5)
+Threads.Atomic{Int64}(5)
 
 julia> Threads.atomic_max!(x, 7)
 5
@@ -321,7 +321,7 @@ For further details, see LLVM's `atomicrmw min` instruction.
 # Examples
 ```jldoctest
 julia> x = Threads.Atomic{Int}(7)
-Base.Threads.Atomic{Int64}(7)
+Threads.Atomic{Int64}(7)
 
 julia> Threads.atomic_min!(x, 5)
 7

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -417,7 +417,7 @@ Uses [`BroadcastStyle`](@ref) to get the style for each argument, and uses
 
 ```jldoctest
 julia> Broadcast.combine_styles([1], [1 2; 3 4])
-Base.Broadcast.DefaultArrayStyle{2}()
+Broadcast.DefaultArrayStyle{2}()
 ```
 """
 function combine_styles end
@@ -441,10 +441,10 @@ determine a common `BroadcastStyle`.
 
 ```jldoctest
 julia> Broadcast.result_style(Broadcast.DefaultArrayStyle{0}(), Broadcast.DefaultArrayStyle{3}())
-Base.Broadcast.DefaultArrayStyle{3}()
+Broadcast.DefaultArrayStyle{3}()
 
 julia> Broadcast.result_style(Broadcast.Unknown(), Broadcast.DefaultArrayStyle{1}())
-Base.Broadcast.DefaultArrayStyle{1}()
+Broadcast.DefaultArrayStyle{1}()
 ```
 """
 function result_style end

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -526,7 +526,7 @@ See [`Base.filter`](@ref) for an eager implementation of filtering for arrays.
 # Examples
 ```jldoctest
 julia> f = Iterators.filter(isodd, [1, 2, 3, 4, 5])
-Base.Iterators.Filter{typeof(isodd), Vector{Int64}}(isodd, [1, 2, 3, 4, 5])
+Iterators.Filter{typeof(isodd), Vector{Int64}}(isodd, [1, 2, 3, 4, 5])
 
 julia> foreach(println, f)
 1

--- a/base/show.jl
+++ b/base/show.jl
@@ -1303,7 +1303,8 @@ end
 function print_fullname(io::IO, m::Module)
     module_name = nameof(m)
     mp = parentmodule(m)
-    if m === Main || m === Base || m === Core || mp === m || isvisible(module_name, mp, Main)
+    active_mod = get(io, :module, active_module())
+    if m === Main || m === Base || m === Core || mp === m || isvisible(module_name, mp, active_mod)
         show_sym(io, module_name)
     else
         print_fullname(io, mp)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1301,13 +1301,14 @@ end
 # which allocates. The method below provides the same behavior without allocating.
 # See https://github.com/JuliaLang/julia/pull/42773 for perf information.
 function print_fullname(io::IO, m::Module)
+    module_name = nameof(m)
     mp = parentmodule(m)
-    if m === Main || m === Base || m === Core || mp === m
-        show_sym(io, nameof(m))
+    if m === Main || m === Base || m === Core || mp === m || isvisible(module_name, mp, Main)
+        show_sym(io, module_name)
     else
         print_fullname(io, mp)
         print(io, '.')
-        show_sym(io, nameof(m))
+        show_sym(io, module_name)
     end
 end
 

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -505,7 +505,7 @@ julia> a
 1
 
 julia> b
-Base.Iterators.Rest{Base.Generator{UnitRange{Int64}, typeof(abs2)}, Int64}(Base.Generator{UnitRange{Int64}, typeof(abs2)}(abs2, 1:4), 1)
+Iterators.Rest{Base.Generator{UnitRange{Int64}, typeof(abs2)}, Int64}(Base.Generator{UnitRange{Int64}, typeof(abs2)}(abs2, 1:4), 1)
 ```
 
 See [`Base.rest`](@ref) for details on the precise handling and customization for specific iterators.

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -258,7 +258,7 @@ end
 
 const curmod = @__MODULE__
 const curmod_name = fullname(curmod)
-const curmod_str = curmod === Main ? "Main" : join(curmod_name, ".")
+const curmod_str = curmod === Main ? "Main" : join(curmod_name[2:end], ".")
 
 @test_throws ErrorException("\"this_is_not_defined\" is not defined in module $curmod_str") @which this_is_not_defined
 # issue #13264

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1125,7 +1125,7 @@ fake_repl() do stdin_write, stdout_read, repl
     t = @async write(stdin_write, "TestShowTypeREPL.TypeA\n")
     s = readuntil(stdout_read, "\n\n")
     s2 = rsplit(s, "\n", limit=2)[end]
-    @test s2 == "\e[0mMain.TestShowTypeREPL.TypeA"
+    @test s2 == "\e[0mTestShowTypeREPL.TypeA"
     wait(t)
     @eval Main using .TestShowTypeREPL
     readuntil(stdout_read, "julia> ", keep=true)
@@ -1277,16 +1277,16 @@ f_html() = nothing
 end # module BriefExtended
 
 buf = IOBuffer()
-md = Base.eval(REPL._helpmode(buf, "$(@__MODULE__).BriefExtended.f"))
+md = (@__MODULE__).eval(REPL._helpmode(buf, "$curmod_str.BriefExtended.f"))
 @test length(md.content) == 2 && isa(md.content[2], REPL.Message)
 buf = IOBuffer()
-md = Base.eval(REPL._helpmode(buf, "?$(@__MODULE__).BriefExtended.f"))
+md = (@__MODULE__).eval(REPL._helpmode(buf, "?$curmod_str.BriefExtended.f"))
 @test length(md.content) == 1 && length(md.content[1].content[1].content) == 4
 buf = IOBuffer()
-txt = Base.eval(REPL._helpmode(buf, "$(@__MODULE__).BriefExtended.f_plain"))
+txt = (@__MODULE__).eval(REPL._helpmode(buf, "$curmod_str.BriefExtended.f_plain"))
 @test !isempty(sprint(show, txt))
 buf = IOBuffer()
-html = Base.eval(REPL._helpmode(buf, "$(@__MODULE__).BriefExtended.f_html"))
+html = (@__MODULE__).eval(REPL._helpmode(buf, "$curmod_str.BriefExtended.f_html"))
 @test !isempty(sprint(show, html))
 
 # PR #27562

--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -288,7 +288,7 @@ let code = """
 
     bt_str = read(`$(Base.julia_cmd()) --startup-file=no --compile=min -e $code`, String)
     @test occursin(r"InterpreterIP in MethodInstance for .*A\.foo", bt_str)
-    @test occursin("InterpreterIP in top-level CodeInfo for Main.A", bt_str)
+    @test occursin("InterpreterIP in top-level CodeInfo for A", bt_str)
 end
 
 """

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1013,7 +1013,7 @@ p0 = copy(p)
 @test identity(.+) == Broadcast.BroadcastFunction(+)
 @test identity.(.*) == Broadcast.BroadcastFunction(*)
 @test map(.+, [[1,2], [3,4]], [5, 6]) == [[6,7], [9,10]]
-@test repr(.!) == "Base.Broadcast.BroadcastFunction(!)"
+@test repr(.!) == "Broadcast.BroadcastFunction(!)"
 @test eval(:(.+)) == Base.BroadcastFunction(+)
 
 @testset "Issue #5187: Broadcasting of short-circuiting ops" begin

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1285,7 +1285,7 @@ let x = Binding(Main, :+)
 end
 
 let x = Binding(Meta, :parse)
-    @test Meta.parse(string(x)) == :(Base.Meta.parse)
+    @test Meta.parse(string(x)) == :(Meta.parse)
 end
 
 let x = Binding(Main, :⊕)

--- a/test/show.jl
+++ b/test/show.jl
@@ -1823,7 +1823,7 @@ end
 
     b = IOBuffer()
     show(IOContext(b, :module => @__MODULE__), TestShowType.TypeA)
-    @test String(take!(b)) == "$(@__MODULE__).TestShowType.TypeA"
+    @test String(take!(b)) == "TestShowType.TypeA"
 
     b = IOBuffer()
     show(IOContext(b, :module => TestShowType), TestShowType.TypeA)

--- a/test/sysinfo.jl
+++ b/test/sysinfo.jl
@@ -66,7 +66,7 @@ end
     Base.Sys.CPUinfo("Apple M1 Pro", 2400, 0x00000000017726c0, 0x0000000000000000, 0x00000000009491de, 0x0000000048134f1e, 0x0000000000000000)]
 
     Sys.SC_CLK_TCK, save_SC_CLK_TCK = 100, Sys.SC_CLK_TCK # use platform-independent tick units
-    @test repr(example_cpus[1]) == "Base.Sys.CPUinfo(\"Apple M1 Pro\", 2400, 0x000000000d913b08, 0x0000000000000000, 0x0000000005f4243c, 0x00000000352a550a, 0x0000000000000000)"
+    @test repr(example_cpus[1]) == "Sys.CPUinfo(\"Apple M1 Pro\", 2400, 0x000000000d913b08, 0x0000000000000000, 0x0000000005f4243c, 0x00000000352a550a, 0x0000000000000000)"
     @test repr("text/plain", example_cpus[1]) == "Apple M1 Pro: \n        speed         user         nice          sys         idle          irq\n     2400 MHz    2276216 s          0 s     998861 s    8919667 s          0 s"
     @test sprint(Sys.cpu_summary, example_cpus) == "Apple M1 Pro: \n       speed         user         nice          sys         idle          irq\n#1  2400 MHz    2276216 s          0 s     998861 s    8919667 s          0 s\n#2  2400 MHz    2275576 s          0 s     978101 s    8962204 s          0 s\n#3  2400 MHz     403386 s          0 s     166224 s   11853624 s          0 s\n#4  2400 MHz     245859 s          0 s      97367 s   12092250 s          0 s\n"
     Sys.SC_CLK_TCK = save_SC_CLK_TCK

--- a/test/testenv.jl
+++ b/test/testenv.jl
@@ -48,8 +48,8 @@ if !@isdefined(testenv_defined)
 
     const curmod = @__MODULE__
     const curmod_name = fullname(curmod)
-    const curmod_str = curmod === Main ? "Main" : join(curmod_name, ".")
-    const curmod_prefix = curmod === Main ? "" : "$(["$m." for m in curmod_name]...)"
+    const curmod_str = curmod === Main ? "Main" : join(curmod_name[2:end], ".")
+    const curmod_prefix = curmod === Main ? "" : "$(["$m." for m in curmod_name[2:end]]...)"
 
     # platforms that support cfunction with closures
     # (requires LLVM back-end support for trampoline intrinsics)


### PR DESCRIPTION
For cases like

```
module A
    module B end
end
```

, `A` is already visible in `Main` once defined. As a consequence, `B` can be accessed through `A.B` without having to go through `Main`. This adjusts the printing of `A.B`, so that this is reflected.

This also makes cases like

```
module A
    export B

    module B
       f() = "foo"
    end
end
```

have `f` printed like `B.f` and not `A.B.f` after `using A`, since `B` is also already accessible in `Main`.