### PR TITLE
add a precompile signature to Artifacts code that is used by JLLs

### DIFF
--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -759,6 +759,6 @@ precompile(NamedTuple{(:pkg_uuid,)}, (Tuple{Base.UUID},))
 precompile(Core.kwfunc(load_artifacts_toml), (NamedTuple{(:pkg_uuid,), Tuple{Base.UUID}}, typeof(load_artifacts_toml), String))
 precompile(parse_mapping, (String, String, String))
 precompile(parse_mapping, (Dict{String, Any}, String, String))
-
+precompile(Tuple{typeof(Artifacts._artifact_str), Module, String, Base.SubString{String}, String, Base.Dict{String, Any}, Base.SHA1, Base.BinaryPlatforms.Platform, Any})
 
 end # module Artifacts


### PR DESCRIPTION
```
# before
julia> @time using GR_jll
  0.202372 seconds (421.29 k allocations: 23.172 MiB, 4.93% gc time, 37.90% compilation time: 2% of which was recompilation)

# after
julia> @time using GR_jll
  0.176863 seconds (151.62 k allocations: 9.064 MiB, 6.16% gc time, 4.11% compilation time: 29% of which was recompilation)''
```