### PR TITLE
Unary `+` operator for a single `CartesianIndex`

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -115,6 +115,7 @@ module IteratorsMD
     oneunit(::Type{CartesianIndex{N}}) where {N} = CartesianIndex(ntuple(Returns(1), Val(N)))
 
     # arithmetic, min/max
+    @inline (+)(index::CartesianIndex) = index
     @inline (-)(index::CartesianIndex{N}) where {N} =
         CartesianIndex{N}(map(-, index.I))
     @inline (+)(index1::CartesianIndex{N}, index2::CartesianIndex{N}) where {N} =

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2072,6 +2072,7 @@ end
 
     I1 = CartesianIndex((2,3,0))
     I2 = CartesianIndex((-1,5,2))
+    @test +I1 == I1
     @test -I1 == CartesianIndex((-2,-3,0))
     @test I1 + I2 == CartesianIndex((1,8,2))
     @test I2 + I1 == CartesianIndex((1,8,2))


### PR DESCRIPTION
This operation seems like it should exist for a `CartesianIndex`.
```julia
julia> +(CartesianIndex(2,2))
CartesianIndex(2, 2)
```
Noticed in https://github.com/JuliaArrays/FillArrays.jl/pull/363