### PR TITLE
Create `jl_clear_coverage_data` to dynamically reset coverage

### DIFF
--- a/src/coverage.cpp
+++ b/src/coverage.cpp
@@ -77,11 +77,10 @@ JL_DLLEXPORT uint64_t *jl_malloc_data_pointer(StringRef filename, int line)
     return allocLine(mallocData[filename], line);
 }
 
-// Resets the malloc counts.
-extern "C" JL_DLLEXPORT void jl_clear_malloc_data(void)
+static void clear_log_data(logdata_t &logData, int resetValue)
 {
-    logdata_t::iterator it = mallocData.begin();
-    for (; it != mallocData.end(); it++) {
+    logdata_t::iterator it = logData.begin();
+    for (; it != logData.end(); it++) {
         SmallVector<logdata_block*, 0> &bytes = (*it).second;
         SmallVector<logdata_block*, 0>::iterator itb;
         for (itb = bytes.begin(); itb != bytes.end(); itb++) {
@@ -89,12 +88,24 @@ extern "C" JL_DLLEXPORT void jl_clear_malloc_data(void)
                 logdata_block &data = **itb;
                 for (int i = 0; i < logdata_blocksize; i++) {
                     if (data[i] > 0)
-                        data[i] = 1;
+                        data[i] = resetValue;
                 }
             }
         }
     }
     jl_gc_sync_total_bytes(0);
+}
+
+// Resets the malloc counts.
+extern "C" JL_DLLEXPORT void jl_clear_malloc_data(void)
+{
+    clear_log_data(mallocData, 1);
+}
+
+// Resets the code coverage
+extern "C" JL_DLLEXPORT void jl_clear_coverage_data(void)
+{
+    clear_log_data(coverageData, 0);
 }
 
 static void write_log_data(logdata_t &logData, const char *extension)


### PR DESCRIPTION
There are some use-cases that would benefit from being able to reset the code coverage information during runtime:

- https://github.com/JuliaLang/julia/issues/50215
- https://discourse.julialang.org/t/workflow-for-faster-testing-of-julia-packages/113836?u=milescranmer

This creates the function `jl_clear_coverage_data` to reset the `coverageData` global. I should be clear that I don't have a deep understanding of the coverage mechanism, so please review this change carefully.

@IanButterworth what do you think? Also, who else would be good to review this?