### PR TITLE
Build mbedTLS, libssh2, nghttp2 and curl disregarding `USE_SYSTEM_LIBGIT2=1`

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -119,7 +119,6 @@ ifeq ($(USE_SYSTEM_GMP), 0)
 DEP_LIBS += gmp
 endif
 
-ifeq ($(USE_SYSTEM_LIBGIT2), 0)
 ifeq ($(USE_SYSTEM_MBEDTLS), 0)
 DEP_LIBS += mbedtls
 endif
@@ -136,8 +135,9 @@ ifeq ($(USE_SYSTEM_CURL), 0)
 DEP_LIBS += curl
 endif
 
+ifeq ($(USE_SYSTEM_LIBGIT2), 0)
 DEP_LIBS += libgit2
-endif # USE_SYSTEM_LIBGIT2
+endif
 
 ifeq ($(USE_SYSTEM_MPFR), 0)
 DEP_LIBS += mpfr


### PR DESCRIPTION
A long time ago, these libraries were only used indirectly by libgit2, so https://github.com/JuliaLang/julia/pull/18153/commits/4526b65d7bfaf75e904f77b03e33f554d7ab5d14 made building them conditional on `USE_SYSTEM_LIBGIT2=0`. But nowadays we always generate MbedTLS_jll, LibSSH2_jll, nghttp2_jll and LibCURL_jll, even when not building libgit2, so we always need to have these libraries available.