### PR TITLE
add test case to check live_bytes doesn't grow arbitrarily on String(::Array{UInt8}))

### DIFF
--- a/test/gc.jl
+++ b/test/gc.jl
@@ -28,6 +28,25 @@ function run_pg_size_test()
     @test page_size == (1 << 12) || page_size == (1 << 14)
 end
 
+function issue_54275_alloc_string()
+    String(UInt8['a' for i in 1:10000000])
+end
+
+function issue_54275_test()
+    GC.gc(true)
+    baseline = Base.gc_live_bytes()
+    live_bytes_has_grown_too_much = false
+    for _ in 1:10
+        issue_54275_alloc_string()
+        GC.gc(true)
+        if Base.gc_live_bytes() - baseline > 1_000_000
+            live_bytes_has_grown_too_much = true
+            break
+        end
+    end
+    @test !live_bytes_has_grown_too_much
+end
+
 # !!! note:
 #     Since we run our tests on 32bit OS as well we confine ourselves
 #     to parameters that allocate about 512MB of objects. Max RSS is lower
@@ -42,6 +61,10 @@ end
 @testset "GC page metrics" begin
     run_nonzero_page_utilization_test()
     run_pg_size_test()
+end
+
+@testset "issue-54275" begin
+    issue_54275_test()
 end
 
 @testset "Base.GC docstrings" begin


### PR DESCRIPTION
Follow-up to https://github.com/JuliaLang/julia/pull/54331.