### PR TITLE
fix `code_warntype` on `OpaqueClosure`s

### DIFF
--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -153,7 +153,7 @@ function code_warntype(io::IO, @nospecialize(f), @nospecialize(tt=Base.default_t
     lineprinter = Base.IRShow.__debuginfo[debuginfo]
     nargs::Int = 0
     if isa(f, Core.OpaqueClosure)
-        isa(f.source, Method) && (nargs = f.nargs)
+        isa(f.source, Method) && (nargs = f.source.nargs)
         print_warntype_codeinfo(io, Base.code_typed_opaque_closure(f, tt)[1]..., nargs; lineprinter)
         return nothing
     end

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -138,6 +138,11 @@ tag = "ANY"
 @test !warntype_hastag(ImportIntrinsics15819.sqrt15819, Tuple{Float64}, tag)
 @test !warntype_hastag(ImportIntrinsics15819.sqrt15819, Tuple{Float32}, tag)
 
+@testset "code_warntype OpaqueClosure" begin
+    g = Base.Experimental.@opaque Tuple{Float64} x -> 0.0
+    @test warntype_hastag(g, Tuple{Float64}, "::Float64")
+end
+
 end # module WarnType
 
 # Adds test for PR #17636
@@ -769,9 +774,4 @@ end
 
 @testset "Docstrings" begin
     @test isempty(Docs.undocumented_names(InteractiveUtils))
-end
-
-@testset "code_warntype OpaqueClosure" begin
-    g = Base.Experimental.@opaque Tuple{Float64} x -> 0.0
-    @test warntype_hastag(g, Tuple{Float64}, "::Float64")
 end

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -770,3 +770,8 @@ end
 @testset "Docstrings" begin
     @test isempty(Docs.undocumented_names(InteractiveUtils))
 end
+
+@testset "code_warntype OpaqueClosure" begin
+    g = Base.Experimental.@opaque Tuple{Float64} x -> 0.0
+    @test warntype_hastag(g, Tuple{Float64}, "::Float64")
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/54375