### PR TITLE
clarify tip about untyped globals: const globals need no annotation

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -26,7 +26,7 @@ performance:
 const DEFAULT_VAL = 0
 ```
 
-If a global is known to always be of the same type, [the type should be annotated](@ref man-typed-globals).
+If a non-constant global is known to always be of the same type, [the type should be annotated](@ref man-typed-globals); `const` globals need not be annotated because their type is inferred from their initialization value.
 
 Uses of untyped globals can be optimized by annotating their types at the point of use:
 


### PR DESCRIPTION
The performance tip from #43671 by @simeonschaub 

> If a global is known to always be of the same type, [the type should be annotated](https://docs.julialang.org/en/v1/manual/variables-and-scoping/#man-typed-globals).

was a bit unclear to me, because it does not apply to `const` globals (whose type requires no annotation).  This PR clarifies that point