### PR TITLE
prepend signal number and thread ID on backtraces

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1213,8 +1213,8 @@ JL_DLLEXPORT jl_value_t *jl_get_backtrace(void);
 void jl_critical_error(int sig, int si_code, bt_context_t *context, jl_task_t *ct);
 JL_DLLEXPORT void jl_raise_debugger(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_gdblookup(void* ip) JL_NOTSAFEPOINT;
-void jl_print_native_codeloc(uintptr_t ip) JL_NOTSAFEPOINT;
-void jl_print_bt_entry_codeloc(jl_bt_element_t *bt_data) JL_NOTSAFEPOINT;
+void jl_print_native_codeloc(char *pre_str, uintptr_t ip) JL_NOTSAFEPOINT;
+void jl_print_bt_entry_codeloc(int sig, jl_bt_element_t *bt_data) JL_NOTSAFEPOINT;
 #ifdef _OS_WINDOWS_
 JL_DLLEXPORT void jl_refresh_dbg_module_list(void);
 #endif

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -16,7 +16,7 @@ extern "C" {
 #endif
 
 
-JL_DLLEXPORT int16_t jl_threadid(void);
+JL_DLLEXPORT int16_t jl_threadid(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int8_t jl_threadpoolid(int16_t tid) JL_NOTSAFEPOINT;
 
 // JULIA_ENABLE_THREADING may be controlled by altering JULIA_THREADS in Make.user

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -487,7 +487,7 @@ void jl_critical_error(int sig, int si_code, bt_context_t *context, jl_task_t *c
         *bt_size = n = rec_backtrace_ctx(bt_data, JL_MAX_BT_SIZE, context, NULL);
     }
     for (i = 0; i < n; i += jl_bt_entry_size(bt_data + i)) {
-        jl_print_bt_entry_codeloc(bt_data + i);
+        jl_print_bt_entry_codeloc(sig, bt_data + i);
     }
     jl_gc_debug_print_status();
     jl_gc_debug_critical_error();

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -1006,7 +1006,7 @@ static void *signal_listener(void *arg)
             jl_safe_printf("\nsignal (%d): %s\n", sig, strsignal(sig));
             size_t i;
             for (i = 0; i < bt_size; i += jl_bt_entry_size(bt_data + i)) {
-                jl_print_bt_entry_codeloc(bt_data + i);
+                jl_print_bt_entry_codeloc(sig, bt_data + i);
             }
         }
     }

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -327,7 +327,7 @@ LONG WINAPI jl_exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo)
         jl_safe_printf("UNKNOWN"); break;
     }
     jl_safe_printf(" at 0x%Ix -- ", (size_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
-    jl_print_native_codeloc((uintptr_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
+    jl_print_native_codeloc("", (uintptr_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
 
     jl_critical_error(0, 0, ExceptionInfo->ContextRecord, ct);
     static int recursion = 0;

--- a/src/threading.c
+++ b/src/threading.c
@@ -319,7 +319,7 @@ static uv_cond_t cond;
 void jl_init_thread_scheduler(jl_ptls_t ptls) JL_NOTSAFEPOINT;
 
 // return calling thread's ID
-JL_DLLEXPORT int16_t jl_threadid(void)
+JL_DLLEXPORT int16_t jl_threadid(void) JL_NOTSAFEPOINT
 {
     return jl_atomic_load_relaxed(&jl_current_task->tid);
 }


### PR DESCRIPTION
These extra information on the backtraces proved useful for us when filtering which servers failed due to a segmentation fault, for instance, and when diagnosing crashes in production more in general.