### PR TITLE
show: improve processed StackTrace check

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -800,7 +800,7 @@ function show_backtrace(io::IO, t::Vector)
     end
 
     # t is a pre-processed backtrace (ref #12856)
-    if t isa Vector{Any}
+    if t isa Vector{Any} && (length(t) == 0 || t[1] isa Tuple{StackFrame,Int})
         filtered = t
     else
         filtered = process_backtrace(t)


### PR DESCRIPTION
This change is necessary for widely-typed vectors of stack traces to work correctly:
```julia
Base.show_backtrace(stdout, convert(Vector{Any}, Base.stacktrace()))
```

which currently outputs a confusing error:
```julia
Stacktrace:
ERROR: MethodError: no method matching iterate(::Base.StackTraces.StackFrame)
...
```