### PR TITLE
fix handling of `nothing` in init_load_path

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -245,8 +245,11 @@ function init_load_path()
     if haskey(ENV, "JULIA_LOAD_PATH")
         paths = parse_load_path(ENV["JULIA_LOAD_PATH"])
     else
-        paths = filter!(env -> env !== nothing,
-            String[env == "@." ? current_project() : env for env in DEFAULT_LOAD_PATH])
+        paths = String[
+            env == "@." ? current_project() : env
+            for env in DEFAULT_LOAD_PATH
+            if env !== nothing
+        ]
     end
     append!(empty!(LOAD_PATH), paths)
 end

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -245,11 +245,14 @@ function init_load_path()
     if haskey(ENV, "JULIA_LOAD_PATH")
         paths = parse_load_path(ENV["JULIA_LOAD_PATH"])
     else
-        paths = String[
-            env == "@." ? current_project() : env
-            for env in DEFAULT_LOAD_PATH
-            if env !== nothing
-        ]
+        paths = String[]
+        for env in DEFAULT_LOAD_PATH
+            if env == "@."
+                env = current_project()
+                env === nothing && continue
+            end
+            push!(paths, env)
+        end
     end
     append!(empty!(LOAD_PATH), paths)
 end


### PR DESCRIPTION
As-written, this was checking for `nothing` after the `String` convert, which will obviously throw a MethodError.