### PR TITLE
handle `nothing` result for `JULIA_VERBOSE_LINKING`

### DIFF
--- a/base/linking.jl
+++ b/base/linking.jl
@@ -79,7 +79,7 @@ end
 const VERBOSE = Ref{Bool}(false)
 
 function __init__()
-    VERBOSE[] = Base.get_bool_env("JULIA_VERBOSE_LINKING", false)
+    VERBOSE[] = something(Base.get_bool_env("JULIA_VERBOSE_LINKING", false), false)
 
     __init_lld_path()
     __init_dsymutil_path()


### PR DESCRIPTION
As written, this function would error if the environment variable has ambiguous "truthiness".