### PR TITLE
improve inference of `CPU_THREADS` in `Sys.__init__`

### DIFF
--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -147,7 +147,7 @@ function __init__()
     end
     global CPU_THREADS = if env_threads !== nothing
         env_threads = tryparse(Int, env_threads)
-        if !(env_threads isa Int && env_threads > 0)
+        if env_threads === nothing || env_threads <= 0
             env_threads = Int(ccall(:jl_cpu_threads, Int32, ()))
             Core.print(Core.stderr, "WARNING: couldn't parse `JULIA_CPU_THREADS` environment variable. Defaulting Sys.CPU_THREADS to $env_threads.\n")
         end


### PR DESCRIPTION
Without this change, the compiler fails to notice that `env_threads isa Int` in the fall-through case, leading to a union-split with a branch that is in fact unreachable:

```
43 ┄ %109 = φ (#41 => %105, #42 => %108)::Union{Nothing, Int64}
│    %110 = (%109 isa Int64)::Bool
└───        goto #45 if not %110
...
45 ─ %126 = π (%109, Nothing)
│           Base.convert(Int64, %126)::Union{}
└───        unreachable
```

After this change, the union-split is eliminated.