### PR TITLE
specialize `VersionNumber` constructors less aggressively

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -51,8 +51,7 @@ struct VersionNumber
     build::VerTuple
 
     function VersionNumber(major::VInt, minor::VInt, patch::VInt,
-            pre::VerTuple,
-            bld::VerTuple)
+                           @nospecialize(pre::VerTuple), @nospecialize(bld::VerTuple))
         major >= 0 || throw(ArgumentError("invalid negative major version: $major"))
         minor >= 0 || throw(ArgumentError("invalid negative minor version: $minor"))
         patch >= 0 || throw(ArgumentError("invalid negative patch version: $patch"))


### PR DESCRIPTION
There's no need to specialize this code for every set of Tuple types that it might see, especially when the primary callers don't know their Tuple type any more precisely than this anyway.

Eliminates a dynamic dispatch from `tryparse(VersionNumber, "...")`