### PR TITLE
Document copy! for vector types (#54142)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -896,12 +896,17 @@ emptymutable(itr, ::Type{U}) where {U} = Vector{U}()
 In-place [`copy`](@ref) of `src` into `dst`, discarding any pre-existing
 elements in `dst`.
 If `dst` and `src` are of the same type, `dst == src` should hold after
-the call. If `dst` and `src` are multidimensional arrays, they must have
+the call. If `dst` and `src` are vector types, they must have equal
+offset. If `dst` and `src` are multidimensional arrays, they must have
 equal [`axes`](@ref).
 
 $(_DOCS_ALIASING_WARNING)
 
 See also [`copyto!`](@ref).
+
+!!! note
+    When operating on vector types, if `dst` and `src` are not of the
+    same length, `dst` is resized to `length(src)` prior to the `copy`.
 
 !!! compat "Julia 1.1"
     This method requires at least Julia 1.1. In Julia 1.0 this method


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/54142. Also documents the `firstindex(dst) == firstindex(src)` check, since the `axes(dst) == axes(src)` is already documented.