### PR TITLE
add hascodepoint(c::AbstractChar) and use it

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -78,6 +78,8 @@ Standard library changes
 ------------------------
 
 * `gcdx(0, 0)` now returns `(0, 0, 0)` instead of `(0, 1, 0)` ([#40989]).
+* New `hascodepoint(c::AbstractChar)` function returns
+  whether `codepoint(c)` will succeed ([#54393]).
 
 #### StyledStrings
 

--- a/base/char.jl
+++ b/base/char.jl
@@ -140,7 +140,7 @@ malformed or overlong character encodings.
 
 An [`isvalid`](@ref) character must always have a codepoint,
 but the converse is not necessarily true: for example, `hascodepoint`
-will return `true` for both `'\U110000'` and `'\ud800'`, but
+will return `true` for both `'\\U110000'` and `'\\ud800'`, but
 `isvalid` will return `false` for these characters because they
 cannot be present in any valid Unicode string (being too large
 in the first case, and part of a UTF-16 surrogate pair in the second case).

--- a/base/char.jl
+++ b/base/char.jl
@@ -135,8 +135,8 @@ isoverlong(c::AbstractChar) = false
     hascodepoint(c::AbstractChar) -> Bool
 
 Return `true` if [`codepoint(c)`](@ref) will return a codepoint
-value, or `false` if it will throw an error (e.g.
-for [`ismalformed`](@ref) or [`isoverlong`](@ref) characters).
+value, or `false` if it will throw an error, e.g. for
+[`ismalformed`](@ref) or [`isoverlong`](@ref) characters.
 """
 hascodepoint(c::AbstractChar) = !ismalformed(c) & !isoverlong(c)
 
@@ -288,8 +288,8 @@ end
 """
     show_invalid(io::IO, c::AbstractChar)
 
-Called by `show(io, c)` when [`isoverlong(c)`](@ref) or
-[`ismalformed(c)`](@ref) return `true`.   Subclasses
+Called by `show(io, c)` when [`hascodepoint(c)`](@ref)
+returns `false`.   Subclasses
 of `AbstractChar` should define `Base.show_invalid` methods
 if they support storing invalid character data.
 """
@@ -314,7 +314,7 @@ function show(io::IO, c::AbstractChar)
             return
         end
     end
-    if isoverlong(c) || ismalformed(c)
+    if !hascodepoint(c)
         show_invalid(io, c)
     elseif isprint(c)
         write(io, 0x27)

--- a/base/char.jl
+++ b/base/char.jl
@@ -136,7 +136,7 @@ isoverlong(c::AbstractChar) = false
 
 Return `true` if [`codepoint(c)`](@ref) will return a codepoint
 value, or `false` if it will throw an error, e.g. for
-[`ismalformed`](@ref) or [`isoverlong`](@ref) characters.
+malformed or overlong character encodings.
 
 An [`isvalid`](@ref) character must always have a codepoint,
 but the converse is not necessarily true: for example, `hascodepoint`

--- a/base/char.jl
+++ b/base/char.jl
@@ -137,6 +137,13 @@ isoverlong(c::AbstractChar) = false
 Return `true` if [`codepoint(c)`](@ref) will return a codepoint
 value, or `false` if it will throw an error, e.g. for
 [`ismalformed`](@ref) or [`isoverlong`](@ref) characters.
+
+An [`isvalid`](@ref) character must always have a codepoint,
+but the converse is not necessarily true: for example, `hascodepoint`
+will return `true` for both `'\U110000'` and `'\ud800'`, but
+`isvalid` will return `false` for these characters because they
+cannot be present in any valid Unicode string (being too large
+in the first case, and part of a UTF-16 surrogate pair in the second case).
 """
 hascodepoint(c::AbstractChar) = !ismalformed(c) & !isoverlong(c)
 

--- a/base/char.jl
+++ b/base/char.jl
@@ -131,6 +131,15 @@ See also [`decode_overlong`](@ref) and [`show_invalid`](@ref).
 """
 isoverlong(c::AbstractChar) = false
 
+"""
+    hascodepoint(c::AbstractChar) -> Bool
+
+Return `true` if [`codepoint(c)`](@ref) will return a codepoint
+value, or `false` if it will throw an error (e.g.
+for [`ismalformed`](@ref) or [`isoverlong`](@ref) characters).
+"""
+hascodepoint(c::AbstractChar) = !ismalformed(c) & !isoverlong(c)
+
 @constprop :aggressive function UInt32(c::Char)
     # TODO: use optimized inline LLVM
     u = bitcast(UInt32, c)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -598,6 +598,7 @@ export
     eachsplit,
     eachrsplit,
     escape_string,
+    hascodepoint,
     hex2bytes,
     hex2bytes!,
     isascii,

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -427,7 +427,7 @@ function escape_string(io::IO, s::AbstractString, esc=""; keep = ())
             '\a' <= c <= '\r'  ? print(io, '\\', "abtnvfr"[Int(c)-6]) :
             isprint(c)         ? print(io, c) :
                                  print(io, "\\x", string(UInt32(c), base = 16, pad = 2))
-        elseif !isoverlong(c) && !ismalformed(c)
+        elseif hascodepoint(c)
             isprint(c)         ? print(io, c) :
             c <= '\x7f'        ? print(io, "\\x", string(UInt32(c), base = 16, pad = 2)) :
             c <= '\uffff'      ? print(io, "\\u", string(UInt32(c), base = 16, pad = need_full_hex(peek(a)::Union{AbstractChar,Nothing}) ? 4 : 2)) :

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -4,7 +4,7 @@
 module Unicode
 
 import Base: show, ==, hash, string, Symbol, isless, length, eltype,
-             convert, isvalid, ismalformed, hascodepoint, iterate,
+             convert, isvalid, hascodepoint, iterate,
              AnnotatedString, AnnotatedChar, annotated_chartransform,
              @assume_effects
 
@@ -256,7 +256,7 @@ julia> textwidth('⛵')
 ```
 """
 function textwidth(c::AbstractChar)
-    ismalformed(c) && return 1
+    !hascodepoint(c) && return 1
     Int(ccall(:utf8proc_charwidth, Cint, (UInt32,), c))
 end
 

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -36,6 +36,7 @@ Base.@raw_str
 Base.@b_str
 Base.Docs.@html_str
 Base.Docs.@text_str
+Base.hascodepoint
 Base.isvalid(::Any)
 Base.isvalid(::Any, ::Any)
 Base.isvalid(::AbstractString, ::Integer)

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -223,7 +223,7 @@ end
 # because of the bitfields.
 combining_class(uc::Integer) =
     0x000301 ≤ uc ≤ 0x10ffff ? unsafe_load(ccall(:utf8proc_get_property, Ptr{UInt16}, (UInt32,), uc), 2) : 0x0000
-combining_class(c::AbstractChar) = ismalformed(c) ? 0x0000 : combining_class(UInt32(c))
+combining_class(c::AbstractChar) = !hascodepoint(c) ? 0x0000 : combining_class(UInt32(c))
 
 """
     isequal_normalized(s1::AbstractString, s2::AbstractString; casefold=false, stripmark=false, chartransform=identity)

--- a/test/char.jl
+++ b/test/char.jl
@@ -355,7 +355,7 @@ end
     let c = '\xf0\x8e\x80\x80' # overlong but not malformed
         @test Base.isoverlong(c)
         @test !Base.ismalformed(c)
-        @test hascodepoint(c)
+        @test !hascodepoint(c)
         @test !isuppercase(c) && !islowercase(c) # issue #54343
     end
 

--- a/test/char.jl
+++ b/test/char.jl
@@ -362,7 +362,7 @@ end
     @test !Base.isoverlong('😺')
     @test !Base.ismalformed('😺')
     @test Base.hascodepoint('😺')
-    @test hascodepoint('\U110000') && !isvalid('\U110000')
+    @test hascodepoint(Char(0x110000)) && !isvalid(Char(0x110000))
     @test hascodepoint('\ud800') && !isvalid('\ud800')
 end
 

--- a/test/char.jl
+++ b/test/char.jl
@@ -354,6 +354,7 @@ end
 
     let c = '\xf0\x8e\x80\x80' # overlong but not malformed
         @test Base.isoverlong(c)
+        @test !Base.isvalid(c)
         @test !Base.ismalformed(c)
         @test !hascodepoint(c)
         @test !isuppercase(c) && !islowercase(c) # issue #54343

--- a/test/char.jl
+++ b/test/char.jl
@@ -348,6 +348,7 @@ end
     @test all(Base.is_overlong_enc, overlong_uints)
     @test all(Base.isoverlong, overlong_chars)
     @test all(Base.ismalformed, overlong_chars)
+    @test all(!hascodepoint, overlong_chars)
     @test repr("text/plain", overlong_chars[1]) ==
         "'\\xc0': Malformed UTF-8 (category Ma: Malformed, bad data)"
 end

--- a/test/char.jl
+++ b/test/char.jl
@@ -351,6 +351,19 @@ end
     @test all(!hascodepoint, overlong_chars)
     @test repr("text/plain", overlong_chars[1]) ==
         "'\\xc0': Malformed UTF-8 (category Ma: Malformed, bad data)"
+
+    let c = '\xf0\x8e\x80\x80' # overlong but not malformed
+        @test Base.isoverlong(c)
+        @test !Base.ismalformed(c)
+        @test hascodepoint(c)
+        @test !isuppercase(c) && !islowercase(c) # issue #54343
+    end
+
+    @test !Base.isoverlong('😺')
+    @test !Base.ismalformed('😺')
+    @test Base.hascodepoint('😺')
+    @test hascodepoint('\U110000') && !isvalid('\U110000')
+    @test hascodepoint('\ud800') && !isvalid('\ud800')
 end
 
 @testset "More fallback tests" begin


### PR DESCRIPTION
This PR adds and exports a new function `hascodepoint(c::AbstractChar)` which returns whether or not `codepoint(c)` will succeed.

It then uses this function before several calls to `codepoint(c)` or `UInt32(c)` instead of `!ismalformed(c)`, which was incorrect because it didn't handle the `isoverlong(c)` case.  Fixes  #54343.

(Potentially we could also have an `unsafe_codepoint(c)` function that assumes `hascodepoint(c) == true` in order to optimize conversions in cases where `hascodepoint(c)` has already been checked.)

**Update:** This PR is superseded by #55152.