### PR TITLE
Unicode: assume foldable ccall in category_code

### DIFF
--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -350,7 +350,7 @@ function category_code(c::AbstractChar)
 end
 
 function category_code(x::Integer)
-    x ≤ 0x10ffff ? ccall(:utf8proc_category, Cint, (UInt32,), x) : Cint(30)
+    x ≤ 0x10ffff ? (@assume_effects :foldable @ccall utf8proc_category(UInt32(x)::UInt32)::Cint) : Cint(30)
 end
 
 # more human-readable representations of the category code

--- a/test/char.jl
+++ b/test/char.jl
@@ -361,10 +361,15 @@ end
     @test convert(ASCIIChar, 1) == Char(1)
 end
 
-@testset "foldable isuppercase/islowercase" begin
+@testset "foldable functions" begin
     v = @inferred (() -> Val(isuppercase('C')))()
     @test v isa Val{true}
     v = @inferred (() -> Val(islowercase('C')))()
+    @test v isa Val{false}
+
+    v = @inferred (() -> Val(isletter('C')))()
+    @test v isa Val{true}
+    v = @inferred (() -> Val(isnumeric('C')))()
     @test v isa Val{false}
 
     struct MyChar <: AbstractChar
@@ -376,5 +381,10 @@ end
     v = @inferred (() -> Val(isuppercase(MyChar('C'))))()
     @test v isa Val{true}
     v = @inferred (() -> Val(islowercase(MyChar('C'))))()
+    @test v isa Val{false}
+
+    v = @inferred (() -> Val(isletter(MyChar('C'))))()
+    @test v isa Val{true}
+    v = @inferred (() -> Val(isnumeric(MyChar('C'))))()
     @test v isa Val{false}
 end


### PR DESCRIPTION
Following on from https://github.com/JuliaLang/julia/pull/54346, this marks the `ccall` in `category_code` as foldable. This lets us compute the results of several functions at compile time, such as:
```julia
julia> @code_typed (() -> isletter('C'))()
CodeInfo(
1 ─     return true
) => Bool

julia> @code_typed (() -> isnumeric('C'))()
CodeInfo(
1 ─     return false
) => Bool

julia> @code_typed (() -> ispunct('C'))()
CodeInfo(
1 ─     return false
) => Bool
```