### PR TITLE
Support types other than `Int` in `randstring`, but convert to `Int` prior to entering the "main" method

### DIFF
--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -71,13 +71,14 @@ let b = UInt8['0':'9';'A':'Z';'a':'z']
     global randstring
 
     function randstring(r::AbstractRNG, chars=b, n::Integer=8)
+        _n = convert(Int, n)
         T = eltype(chars)
         if T === UInt8
-            str = Base._string_n(n)
-            GC.@preserve str rand!(r, UnsafeView(pointer(str), n), chars)
+            str = Base._string_n(_n)
+            GC.@preserve str rand!(r, UnsafeView(pointer(str), _n), chars)
             return str
         else
-            v = Vector{T}(undef, n)
+            v = Vector{T}(undef, _n)
             rand!(r, v, chars)
             return String(v)
         end

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -88,7 +88,7 @@ let b = UInt8['0':'9';'A':'Z';'a':'z']
     # One-arg methods:
     randstring(r::AbstractRNG) = randstring(r, b, 8)
     randstring(chars) = randstring(default_rng(), chars, 8)
-    randstring(n::Integer) = randstring(default_rng(), chars, convert(Int, n))
+    randstring(n::Integer) = randstring(default_rng(), b, convert(Int, n))
     # Two-arg methods:
     randstring(r::AbstractRNG, chars) = randstring(r, chars, 8)
     randstring(r::AbstractRNG, n::Integer) = randstring(r, b, 8)

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -92,7 +92,7 @@ let b = UInt8['0':'9';'A':'Z';'a':'z']
     # Two-arg methods:
     randstring(r::AbstractRNG, chars) = randstring(r, chars, 8)
     randstring(r::AbstractRNG, n::Integer) = randstring(r, b, convert(Int, n))
-    randstring(chars, n::Integer) = randstring(default_rng(), chars, n)
+    randstring(chars, n::Integer) = randstring(default_rng(), chars, convert(Int, n))
     # Three-arg methods:
     randstring(r::AbstractRNG, chars, n::Integer) = randstring(r, chars, convert(Int, n))
 end

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -70,23 +70,25 @@ function randstring end
 let b = UInt8['0':'9';'A':'Z';'a':'z']
     global randstring
 
-    function randstring(r::AbstractRNG, chars=b, n::Integer=8)
-        _n = convert(Int, n)
+    function randstring(r::AbstractRNG, chars, n::Int)
         T = eltype(chars)
         if T === UInt8
-            str = Base._string_n(_n)
-            GC.@preserve str rand!(r, UnsafeView(pointer(str), _n), chars)
+            str = Base._string_n(n)
+            GC.@preserve str rand!(r, UnsafeView(pointer(str), n), chars)
             return str
         else
-            v = Vector{T}(undef, _n)
+            v = Vector{T}(undef, n)
             rand!(r, v, chars)
             return String(v)
         end
     end
 
-    randstring(r::AbstractRNG, n::Integer) = randstring(r, b, n)
-    randstring(chars=b, n::Integer=8) = randstring(default_rng(), chars, n)
-    randstring(n::Integer) = randstring(default_rng(), b, n)
+    randstring(r::AbstractRNG) = randstring(r::AbstractRNG, b, 8)
+    randstring(r::AbstractRNG, chars) = randstring(r::AbstractRNG, chars, 8)
+    randstring(r::AbstractRNG, chars, n::Integer) = randstring(r::AbstractRNG, chars, convert(Int, n))
+    randstring(r::AbstractRNG, n::Integer) = randstring(r, b, convert(Int, n))
+    randstring(chars=b, n::Integer=8) = randstring(default_rng(), chars, convert(Int, n))
+    randstring(n::Integer) = randstring(default_rng(), b, convert(Int, n))
 end
 
 

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -91,7 +91,7 @@ let b = UInt8['0':'9';'A':'Z';'a':'z']
     randstring(n::Integer) = randstring(default_rng(), b, convert(Int, n))
     # Two-arg methods:
     randstring(r::AbstractRNG, chars) = randstring(r, chars, 8)
-    randstring(r::AbstractRNG, n::Integer) = randstring(r, b, 8)
+    randstring(r::AbstractRNG, n::Integer) = randstring(r, b, convert(Int, n))
     randstring(chars, n::Integer) = randstring(default_rng(), chars, n)
     # Three-arg methods:
     randstring(r::AbstractRNG, chars, n::Integer) = randstring(r, chars, convert(Int, n))

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -83,12 +83,18 @@ let b = UInt8['0':'9';'A':'Z';'a':'z']
         end
     end
 
-    randstring(r::AbstractRNG) = randstring(r::AbstractRNG, b, 8)
-    randstring(r::AbstractRNG, chars) = randstring(r::AbstractRNG, chars, 8)
-    randstring(r::AbstractRNG, chars, n::Integer) = randstring(r::AbstractRNG, chars, convert(Int, n))
-    randstring(r::AbstractRNG, n::Integer) = randstring(r, b, convert(Int, n))
-    randstring(chars=b, n::Integer=8) = randstring(default_rng(), chars, convert(Int, n))
-    randstring(n::Integer) = randstring(default_rng(), b, convert(Int, n))
+    # Zero-arg methods:
+    randstring() = randstring(default_rng(), b, 8)
+    # One-arg methods:
+    randstring(r::AbstractRNG) = randstring(r, b, 8)
+    randstring(chars) = randstring(default_rng(), chars, 8)
+    randstring(n::Integer) = randstring(default_rng(), chars, convert(Int, n))
+    # Two-arg methods:
+    randstring(r::AbstractRNG, chars) = randstring(r, chars, 8)
+    randstring(r::AbstractRNG, n::Integer) = randstring(r, b, 8)
+    randstring(chars, n::Integer) = randstring(default_rng(), chars, n)
+    # Three-arg methods:
+    randstring(r::AbstractRNG, chars, n::Integer) = randstring(r, chars, convert(Int, n))
 end
 
 

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -694,6 +694,12 @@ let b = ['0':'9';'A':'Z';'a':'z']
     @test randstring(MersenneTwister(0)) == randstring(MersenneTwister(0), b)
 end
 
+@testset "`randstring` with $T" for T in (UInt8, UInt16, UInt32, Int8, Int16, Int32, UInt, Int)
+    # clamp it to a small value so that we don't allocate too much unnecessarily
+    n = clamp(rand(T), Int8) % T
+    @test randstring(n) isa String
+end
+
 # this shouldn't crash (#22403)
 @test_throws MethodError rand!(Union{UInt,Int}[1, 2, 3])
 


### PR DESCRIPTION
Fixes #54397

What remains is that the effectively allowed input still needs to be convertible to `Int` and non-negative. So things like `typemax(Int128)` won't work.