### PR TITLE
Fix llvm highlighting of variables with `:` in name

### DIFF
--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -353,7 +353,7 @@ const llvm_types =
 const llvm_cond = r"^(?:[ou]?eq|[ou]?ne|[uso][gl][te]|ord|uno)$" # true|false
 
 function print_llvm_tokens(io, tokens)
-    m = match(r"^((?:[^\s:]+:)?)(\s*)(.*)", tokens)
+    m = match(r"^((?:[^%\s:]+:|\"[^:]*\":)?)(\s*)(.*)", tokens)
     if m !== nothing
         label, spaces, tokens = m.captures
         printstyled_ll(io, label, :label, spaces)

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -353,7 +353,7 @@ const llvm_types =
 const llvm_cond = r"^(?:[ou]?eq|[ou]?ne|[uso][gl][te]|ord|uno)$" # true|false
 
 function print_llvm_tokens(io, tokens)
-    m = match(r"^((?:[^%\s:]+:|\"[^:]*\":)?)(\s*)(.*)", tokens)
+    m = match(r"^((?:[^\"\s:]+:|\"[^\"]*\":)?)(\s*)(.*)", tokens)
     if m !== nothing
         label, spaces, tokens = m.captures
         printstyled_ll(io, label, :label, spaces)

--- a/stdlib/InteractiveUtils/test/highlighting.jl
+++ b/stdlib/InteractiveUtils/test/highlighting.jl
@@ -131,6 +131,13 @@ const XU = B * "}" * XB
 
         @test highlight_llvm("L7:\t\t; preds = %top") ==
             "$(L)L7:$(XL)\t\t$(C); preds = %top$(XC)\n"
+
+        @test highlight_llvm("  %\"box::GenericMemoryRef13\" = add i64 0, 0") ==
+            "  $(V)%\"box::GenericMemoryRef13\"$(XV) $EQU " *
+            "$(I)add$(XI) $(T)i64$(XT) $(N)0$(XN)$COM $(N)0$(XN)\n"
+
+        @test highlight_llvm("  \"label-as-string\":\t\t; preds = %top") ==
+            "  $(L)\"label-as-string\":$(XL)\t\t$(C); preds = %top$(XC)\n"
     end
     @testset "define" begin
         @test highlight_llvm("define double @julia_func_1234(float) {") ==


### PR DESCRIPTION
This prevents values with `:` in their name to be printed as labels.

### Before

![image](https://github.com/JuliaLang/julia/assets/9824244/2c2eb23f-5f0e-4cb9-aa70-41211c7bc00a)

### After

![image](https://github.com/JuliaLang/julia/assets/9824244/23dd4c5d-13c8-4952-9831-7a028f1f20d7)
