### PR TITLE
comment out an assertion that fires when loading Parquet2

### DIFF
--- a/src/staticdata_utils.c
+++ b/src/staticdata_utils.c
@@ -1255,7 +1255,8 @@ static void jl_insert_backedges(jl_array_t *edges, jl_array_t *ext_targets, jl_a
                 JL_GC_PROMISE_ROOTED(owner);
 
                 assert(jl_atomic_load_relaxed(&codeinst->min_world) == minworld);
-                assert(jl_atomic_load_relaxed(&codeinst->max_world) == WORLD_AGE_REVALIDATION_SENTINEL);
+                // See #53586, #53109
+                // assert(jl_atomic_load_relaxed(&codeinst->max_world) == WORLD_AGE_REVALIDATION_SENTINEL);
                 assert(jl_atomic_load_relaxed(&codeinst->inferred));
                 jl_atomic_store_relaxed(&codeinst->max_world, maxvalid);
 


### PR DESCRIPTION
Removes the milestone from https://github.com/JuliaLang/julia/issues/53109, see https://github.com/JuliaLang/julia/issues/53109#issuecomment-2072747065