### PR TITLE
Reduce matmul latency by splitting small matmul

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -946,11 +946,11 @@ function __matmul_checks(C, A, B, sz)
 end
 
 # separate function with the core of matmul2x2! that doesn't depend on a MulAddMul
-function _matmul2x2_elements!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix)
+function _matmul2x2_elements(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix)
     __matmul_checks(C, A, B, (2,2))
-    __matmul2x2_elements!(tA, tB, A, B)
+    __matmul2x2_elements(tA, tB, A, B)
 end
-function __matmul2x2_elements!(tA, tB, A::AbstractMatrix, B::AbstractMatrix)
+function __matmul2x2_elements(tA, tB, A::AbstractMatrix, B::AbstractMatrix)
     @inbounds begin
     if tA == 'N'
         A11 = A[1,1]; A12 = A[1,2]; A21 = A[2,1]; A22 = A[2,2]
@@ -1005,7 +1005,7 @@ end
 
 function matmul2x2!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix,
                     _add::MulAddMul = MulAddMul())
-    (A11, A12, A21, A22), (B11, B12, B21, B22) = _matmul2x2_elements!(C, tA, tB, A, B)
+    (A11, A12, A21, A22), (B11, B12, B21, B22) = _matmul2x2_elements(C, tA, tB, A, B)
     @inbounds begin
     _modify!(_add, A11*B11 + A12*B21, C, (1,1))
     _modify!(_add, A21*B11 + A22*B21, C, (2,1))
@@ -1021,11 +1021,11 @@ function matmul3x3(tA, tB, A::AbstractMatrix{T}, B::AbstractMatrix{S}) where {T,
 end
 
 # separate function with the core of matmul3x3! that doesn't depend on a MulAddMul
-function _matmul3x3_elements!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix)
+function _matmul3x3_elements(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix)
     __matmul_checks(C, A, B, (3,3))
-    __matmul3x3_elements!(tA, tB, A, B)
+    __matmul3x3_elements(tA, tB, A, B)
 end
-function __matmul3x3_elements!(tA, tB, A::AbstractMatrix, B::AbstractMatrix)
+function __matmul3x3_elements(tA, tB, A::AbstractMatrix, B::AbstractMatrix)
     @inbounds begin
     if tA == 'N'
         A11 = A[1,1]; A12 = A[1,2]; A13 = A[1,3]
@@ -1098,7 +1098,7 @@ function matmul3x3!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMat
                     _add::MulAddMul = MulAddMul())
 
     (A11, A12, A13, A21, A22, A23, A31, A32, A33),
-        (B11, B12, B13, B21, B22, B23, B31, B32, B33) = _matmul3x3_elements!(C, tA, tB, A, B)
+        (B11, B12, B13, B21, B22, B23, B31, B32, B33) = _matmul3x3_elements(C, tA, tB, A, B)
 
     @inbounds begin
     _modify!(_add, A11*B11 + A12*B21 + A13*B31, C, (1,1))

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -930,7 +930,7 @@ end
 
 
 # multiply 2x2 matrices
-function matmul2x2(tA, tB, A::AbstractMatrix{T}, B::AbstractMatrix{S}) where {T,S}
+Base.@constprop :aggressive function matmul2x2(tA, tB, A::AbstractMatrix{T}, B::AbstractMatrix{S}) where {T,S}
     matmul2x2!(similar(B, promote_op(matprod, T, S), 2, 2), tA, tB, A, B)
 end
 
@@ -946,11 +946,11 @@ function __matmul_checks(C, A, B, sz)
 end
 
 # separate function with the core of matmul2x2! that doesn't depend on a MulAddMul
-function _matmul2x2_elements(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix)
+Base.@constprop :aggressive function _matmul2x2_elements(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix)
     __matmul_checks(C, A, B, (2,2))
     __matmul2x2_elements(tA, tB, A, B)
 end
-function __matmul2x2_elements(tA, A::AbstractMatrix)
+Base.@constprop :aggressive function __matmul2x2_elements(tA, A::AbstractMatrix)
     @inbounds begin
     if tA == 'N'
         A11 = A[1,1]; A12 = A[1,2]; A21 = A[2,1]; A22 = A[2,2]
@@ -978,9 +978,9 @@ function __matmul2x2_elements(tA, A::AbstractMatrix)
     end # inbounds
     A11, A12, A21, A22
 end
-__matmul2x2_elements(tA, tB, A, B) = __matmul2x2_elements(tA, A), __matmul2x2_elements(tB, B)
+Base.@constprop :aggressive __matmul2x2_elements(tA, tB, A, B) = __matmul2x2_elements(tA, A), __matmul2x2_elements(tB, B)
 
-function matmul2x2!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix,
+Base.@constprop :aggressive function matmul2x2!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix,
                     _add::MulAddMul = MulAddMul())
     (A11, A12, A21, A22), (B11, B12, B21, B22) = _matmul2x2_elements(C, tA, tB, A, B)
     @inbounds begin
@@ -993,16 +993,16 @@ function matmul2x2!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMat
 end
 
 # Multiply 3x3 matrices
-function matmul3x3(tA, tB, A::AbstractMatrix{T}, B::AbstractMatrix{S}) where {T,S}
+Base.@constprop :aggressive function matmul3x3(tA, tB, A::AbstractMatrix{T}, B::AbstractMatrix{S}) where {T,S}
     matmul3x3!(similar(B, promote_op(matprod, T, S), 3, 3), tA, tB, A, B)
 end
 
 # separate function with the core of matmul3x3! that doesn't depend on a MulAddMul
-function _matmul3x3_elements(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix)
+Base.@constprop :aggressive function _matmul3x3_elements(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix)
     __matmul_checks(C, A, B, (3,3))
     __matmul3x3_elements(tA, tB, A, B)
 end
-function __matmul3x3_elements(tA, A::AbstractMatrix)
+Base.@constprop :aggressive function __matmul3x3_elements(tA, A::AbstractMatrix)
     @inbounds begin
     if tA == 'N'
         A11 = A[1,1]; A12 = A[1,2]; A13 = A[1,3]
@@ -1038,9 +1038,9 @@ function __matmul3x3_elements(tA, A::AbstractMatrix)
     end # inbounds
     A11, A12, A13, A21, A22, A23, A31, A32, A33
 end
-__matmul3x3_elements(tA, tB, A, B) = __matmul3x3_elements(tA, A), __matmul3x3_elements(tB, B)
+Base.@constprop :aggressive __matmul3x3_elements(tA, tB, A, B) = __matmul3x3_elements(tA, A), __matmul3x3_elements(tB, B)
 
-function matmul3x3!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix,
+Base.@constprop :aggressive function matmul3x3!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix,
                     _add::MulAddMul = MulAddMul())
 
     (A11, A12, A13, A21, A22, A23, A31, A32, A33),

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -950,7 +950,7 @@ function _matmul2x2_elements(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::Ab
     __matmul_checks(C, A, B, (2,2))
     __matmul2x2_elements(tA, tB, A, B)
 end
-function __matmul2x2_elements(tA, tB, A::AbstractMatrix, B::AbstractMatrix)
+function __matmul2x2_elements(tA, A::AbstractMatrix)
     @inbounds begin
     if tA == 'N'
         A11 = A[1,1]; A12 = A[1,2]; A21 = A[2,1]; A22 = A[2,2]
@@ -975,33 +975,10 @@ function __matmul2x2_elements(tA, tB, A::AbstractMatrix, B::AbstractMatrix)
         A11 = hermitian(A[1,1], :L); A12 = copy(adjoint(A[2,1]))
         A21 = A[2,1]; A22 = hermitian(A[2,2], :L)
     end
-    if tB == 'N'
-        B11 = B[1,1]; B12 = B[1,2];
-        B21 = B[2,1]; B22 = B[2,2]
-    elseif tB == 'T'
-        # TODO making these lazy could improve perf
-        B11 = copy(transpose(B[1,1])); B12 = copy(transpose(B[2,1]))
-        B21 = copy(transpose(B[1,2])); B22 = copy(transpose(B[2,2]))
-    elseif tB == 'C'
-        # TODO making these lazy could improve perf
-        B11 = copy(B[1,1]'); B12 = copy(B[2,1]')
-        B21 = copy(B[1,2]'); B22 = copy(B[2,2]')
-    elseif tB == 'S'
-        B11 = symmetric(B[1,1], :U); B12 = B[1,2]
-        B21 = copy(transpose(B[1,2])); B22 = symmetric(B[2,2], :U)
-    elseif tB == 's'
-        B11 = symmetric(B[1,1], :L); B12 = copy(transpose(B[2,1]))
-        B21 = B[2,1]; B22 = symmetric(B[2,2], :L)
-    elseif tB == 'H'
-        B11 = hermitian(B[1,1], :U); B12 = B[1,2]
-        B21 = copy(adjoint(B[1,2])); B22 = hermitian(B[2,2], :U)
-    else # if tB == 'h'
-        B11 = hermitian(B[1,1], :L); B12 = copy(adjoint(B[2,1]))
-        B21 = B[2,1]; B22 = hermitian(B[2,2], :L)
-    end
     end # inbounds
-    (A11, A12, A21, A22), (B11, B12, B21, B22)
+    A11, A12, A21, A22
 end
+__matmul2x2_elements(tA, tB, A, B) = __matmul2x2_elements(tA, A), __matmul2x2_elements(tB, B)
 
 function matmul2x2!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix,
                     _add::MulAddMul = MulAddMul())
@@ -1025,7 +1002,7 @@ function _matmul3x3_elements(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::Ab
     __matmul_checks(C, A, B, (3,3))
     __matmul3x3_elements(tA, tB, A, B)
 end
-function __matmul3x3_elements(tA, tB, A::AbstractMatrix, B::AbstractMatrix)
+function __matmul3x3_elements(tA, A::AbstractMatrix)
     @inbounds begin
     if tA == 'N'
         A11 = A[1,1]; A12 = A[1,2]; A13 = A[1,3]
@@ -1058,41 +1035,10 @@ function __matmul3x3_elements(tA, tB, A::AbstractMatrix, B::AbstractMatrix)
         A21 = A[2,1]; A22 = hermitian(A[2,2], :L); A23 = copy(adjoint(A[3,2]))
         A31 = A[3,1]; A32 = A[3,2]; A33 = hermitian(A[3,3], :L)
     end
-
-    if tB == 'N'
-        B11 = B[1,1]; B12 = B[1,2]; B13 = B[1,3]
-        B21 = B[2,1]; B22 = B[2,2]; B23 = B[2,3]
-        B31 = B[3,1]; B32 = B[3,2]; B33 = B[3,3]
-    elseif tB == 'T'
-        # TODO making these lazy could improve perf
-        B11 = copy(transpose(B[1,1])); B12 = copy(transpose(B[2,1])); B13 = copy(transpose(B[3,1]))
-        B21 = copy(transpose(B[1,2])); B22 = copy(transpose(B[2,2])); B23 = copy(transpose(B[3,2]))
-        B31 = copy(transpose(B[1,3])); B32 = copy(transpose(B[2,3])); B33 = copy(transpose(B[3,3]))
-    elseif tB == 'C'
-        # TODO making these lazy could improve perf
-        B11 = copy(B[1,1]'); B12 = copy(B[2,1]'); B13 = copy(B[3,1]')
-        B21 = copy(B[1,2]'); B22 = copy(B[2,2]'); B23 = copy(B[3,2]')
-        B31 = copy(B[1,3]'); B32 = copy(B[2,3]'); B33 = copy(B[3,3]')
-    elseif tB == 'S'
-        B11 = symmetric(B[1,1], :U); B12 = B[1,2]; B13 = B[1,3]
-        B21 = copy(transpose(B[1,2])); B22 = symmetric(B[2,2], :U); B23 = B[2,3]
-        B31 = copy(transpose(B[1,3])); B32 = copy(transpose(B[2,3])); B33 = symmetric(B[3,3], :U)
-    elseif tB == 's'
-        B11 = symmetric(B[1,1], :L); B12 = copy(transpose(B[2,1])); B13 = copy(transpose(B[3,1]))
-        B21 = B[2,1]; B22 = symmetric(B[2,2], :L); B23 = copy(transpose(B[3,2]))
-        B31 = B[3,1]; B32 = B[3,2]; B33 = symmetric(B[3,3], :L)
-    elseif tB == 'H'
-        B11 = hermitian(B[1,1], :U); B12 = B[1,2]; B13 = B[1,3]
-        B21 = copy(adjoint(B[1,2])); B22 = hermitian(B[2,2], :U); B23 = B[2,3]
-        B31 = copy(adjoint(B[1,3])); B32 = copy(adjoint(B[2,3])); B33 = hermitian(B[3,3], :U)
-    else # if tB == 'h'
-        B11 = hermitian(B[1,1], :L); B12 = copy(adjoint(B[2,1])); B13 = copy(adjoint(B[3,1]))
-        B21 = B[2,1]; B22 = hermitian(B[2,2], :L); B23 = copy(adjoint(B[3,2]))
-        B31 = B[3,1]; B32 = B[3,2]; B33 = hermitian(B[3,3], :L)
-    end
     end # inbounds
-    (A11, A12, A13, A21, A22, A23, A31, A32, A33), (B11, B12, B13, B21, B22, B23, B31, B32, B33)
+    A11, A12, A13, A21, A22, A23, A31, A32, A33
 end
+__matmul3x3_elements(tA, tB, A, B) = __matmul3x3_elements(tA, A), __matmul3x3_elements(tB, B)
 
 function matmul3x3!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix,
                     _add::MulAddMul = MulAddMul())


### PR DESCRIPTION
This splits the `matmul2x2` and `matmul3x3` into components that depend on `MulAddMul` and those that don't depend on it. This improves compilation time, as the `MulAddMul`-independent methods won't need to be recompiled in the `@stable_muladdmul` branches.

TTFX (each call timed in a separate session):
```julia
julia> using LinearAlgebra

julia> A = rand(2,2); B = Symmetric(rand(2,2)); C = zeros(2,2);

julia> @time mul!(C, A, B);
  1.927468 seconds (5.67 M allocations: 282.523 MiB, 12.09% gc time, 100.00% compilation time) # nightly v"1.12.0-DEV.492"
  1.282717 seconds (4.46 M allocations: 228.816 MiB, 4.58% gc time, 100.00% compilation time) # This PR

julia> A = rand(2,2); B = rand(2,2); C = zeros(2,2);

julia> @time mul!(C, A, B);
  1.653368 seconds (5.75 M allocations: 291.586 MiB, 13.94% gc time, 100.00% compilation time) # nightly
  1.148330 seconds (4.46 M allocations: 230.714 MiB, 4.47% gc time, 100.00% compilation time) # This PR
```

Edit: Not inlining the function seems to incur a runtime perfomance cost.
```julia
julia> using LinearAlgebra

julia> A = rand(3,3); B = rand(size(A)...); C = zeros(size(A));

julia> @btime mul!($C, $A, $B);
  23.923 ns (0 allocations: 0 bytes) # nightly
  31.732 ns (0 allocations: 0 bytes) # This PR
```
Adding `@inline` annotations resolves this difference, but this reintroduces the compilation latency. The tradeoff is perhaps ok, as users may use `StaticArrays` for performance-critical matrix multiplications.