### PR TITLE
Highlight julia-repl code in Markdown specially

### DIFF
--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -45,6 +45,7 @@ const MARKDOWN_FACES = [
     :markdown_h6 => Face(height=1.05, inherit=:markdown_header),
     :markdown_admonition => Face(weight=:bold),
     :markdown_code => Face(inherit=:code),
+    :markdown_julia_prompt => Face(inherit=:repl_prompt_julia),
     :markdown_footnote => Face(inherit=:bright_yellow),
     :markdown_hrule => Face(inherit=:shadow),
     :markdown_inlinecode => Face(inherit=:markdown_code),


### PR DESCRIPTION
Fixes #54399 by re-introducing the code seperated out from the styled Markdown PR at Jameson's request (https://github.com/JuliaLang/julia/pull/51928#discussion_r1483598716).

The code itself is modelled after [equivalent code in OhMyREPL](https://github.com/KristofferC/OhMyREPL.jl/blob/b0071f5ee785a81ca1e69a561586ff270b4dc2bb/src/MarkdownHighlighter.jl#L15-L31).

### Sample:

![image](https://github.com/JuliaLang/julia/assets/20903656/a5c1584f-922c-4a32-a755-2518a86ea42c)

### Bonus:

The new `markdown_julia_prompt` face allows people to make the "prompt" shown in Markdown code visually distinct, to [avoid confusing it with the REPL prompt at a glance](https://github.com/KristofferC/OhMyREPL.jl/issues/100). By way of example, I make it italic by augmenting my `faces.toml` with

```toml
[markdown]
julia_prompt = { italic = true }
```

![image](https://github.com/JuliaLang/julia/assets/20903656/3230cf01-bcdf-456c-84ac-06487f00c0d9)
