### PR TITLE
Let `diagzero` propagate information not stored in type where relevant

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -184,7 +184,7 @@ end
     end
     r
 end
-diagzero(::Diagonal{T}, i, j) where {T} = zero(T)
+diagzero(D::Diagonal{T}, i, j) where {T} = haszero(T) ? zero(T) : zero(first(D.diag))
 diagzero(D::Diagonal{<:AbstractMatrix{T}}, i, j) where {T} = zeros(T, size(D.diag[i], 1), size(D.diag[j], 2))
 
 function setindex!(D::Diagonal, v, i::Int, j::Int)


### PR DESCRIPTION
Changes: `diagzero`: `zero(T)` -> `haszero(T) ? zero(T) : zero(first(D))` to capture any relevant information in the elements. 

(DynamicQuantities.jl (https://github.com/SymbolicML/DynamicQuantities.jl/pull/75) currently overloads method this but I think it might be more robust for the ecosystem to just fix it at the source)