### PR TITLE
delete unused function `Base.Iterators.tail_if_any`

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -61,9 +61,6 @@ julia> collect(Iterators.map(x -> x^2, 1:3))
 """
 map(f, arg, args...) = Base.Generator(f, arg, args...)
 
-tail_if_any(::Tuple{}) = ()
-tail_if_any(x::Tuple) = tail(x)
-
 _min_length(a, b, ::IsInfinite, ::IsInfinite) = min(length(a),length(b)) # inherit behaviour, error
 _min_length(a, b, A, ::IsInfinite) = length(a)
 _min_length(a, b, ::IsInfinite, B) = length(b)

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -978,13 +978,6 @@ end
     @test accumulate(+, (x^2 for x in 1:3); init=100) == [101, 105, 114]
 end
 
-
-@testset "Iterators.tail_if_any" begin
-    @test Iterators.tail_if_any(()) == ()
-    @test Iterators.tail_if_any((1, 2)) == (2,)
-    @test Iterators.tail_if_any((1,)) == ()
-end
-
 @testset "IteratorSize trait for zip" begin
     @test Base.IteratorSize(zip()) == Base.IsInfinite()                     # for zip of empty tuple
     @test Base.IteratorSize(zip((1,2,3), repeated(0))) == Base.HasLength()  # for zip of ::HasLength and ::IsInfinite


### PR DESCRIPTION
Apart from being unused, it was a duplicate of `Base.safe_tail`.

A JuliaHub search shows the function being completely unused across the ecosystem:

https://juliahub.com/ui/Search?q=tail_if_any&type=symbols