### PR TITLE
Fix docs builds when not in Git tree

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -103,7 +103,14 @@ documenter_stdlib_remotes = let stdlib_dir = realpath(joinpath(@__DIR__, "..", "
         isdir(package_root_dir) || mkpath(package_root_dir)
         package_root_dir => (remote, package_sha)
     end
-    Dict(remotes_list)
+    Dict(
+        # We also add the root of the repository to `remotes`, because we do not always build the docs in a
+        # checked out JuliaLang/julia repository. In particular, when building Julia from tarballs, there is no
+        # Git information available. And also the way the BuildKite CI is configured to check out the code means
+        # that in some circumstances the Git repository information is incorrect / no available via Git.
+        dirname(@__DIR__) => (Documenter.Remotes.GitHub("JuliaLang", "julia"), Base.GIT_VERSION_INFO.commit),
+        remotes_list...
+    )
 end
 
 # Check if we are building a PDF


### PR DESCRIPTION
The documentation builds can fail if the Julia source code is not properly in a Git repo (tarballs, Buildkite). This should ensure that Documenter knows which remote repository corresponds to the Julia source tree.

Hopefully will fix https://github.com/JuliaCI/julia-buildkite/issues/336