### PR TITLE
Ensure non-ASCII decimal digits are also `isdigit`

### DIFF
--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -433,6 +433,8 @@ end
     isdigit(c::AbstractChar) -> Bool
 
 Tests whether a character is a decimal digit (0-9).
+A character is classified as a letter if it belongs to the Unicode general
+category Number, decimal digit, i.e. a character whose category code is `ND`.
 
 See also: [`isletter`](@ref).
 
@@ -448,7 +450,7 @@ julia> isdigit('α')
 false
 ```
 """
-isdigit(c::AbstractChar) = (c >= '0') & (c <= '9')
+isdigit(c::AbstractChar) = category_code(c) == UTF8PROC_CATEGORY_ND
 
 """
     isletter(c::AbstractChar) -> Bool

--- a/test/unicode/utf8.jl
+++ b/test/unicode/utf8.jl
@@ -36,3 +36,7 @@ end
     # Specifically check UTF-8 string whose lead byte is same as a surrogate
     @test String(b"\xed\x9f\xbf") == "\xed\x9f\xbf" == "\ud7ff"
 end
+
+@testset "decimal digits" begin
+    @test isdigit('４')
+end


### PR DESCRIPTION
I noticed that

```julia
julia> '４' |> isdigit
false
```

even though

```julia
julia> '４'
'４': Unicode U+FF14 (category Nd: Number, decimal digit)
```

The docstring doesn't say that this only checks ASCII, and the unicode category (see [here](https://www.unicode.org/reports/tr44/#Numeric_Type)) is an exact match for the definition (ten glyphs making up the numbers zero through nine, in various scripts). So while some things will still slip through (e.g. [`四`](https://jisho.org/word/%E5%9B%9B), which is considered a letter by Unicode), this implementation is a tiny bit more correct.

However, it's not just roses and sunshine; there is a downside, in that this won't vectorize anymore due to the `ccall` behind `category_code`. We could bring the double table lookup into pure Julia, but I'm not sure whether that would restore performance here. Maybe it could? As is, this PR comes with a 100x regression in a microbenchmark.

v1.11-alpha2:

```julia
julia> @benchmark count(isdigit, v) setup=(v=rand(Char, 10_000))
BenchmarkTools.Trial: 10000 samples with 202 evaluations.
 Range (min … max):  392.871 ns … 509.455 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     400.743 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   405.332 ns ±  12.212 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

       ▂▅█▆▇▆▄▂                  ▁▁   ▁▃▂▂▂                     ▂
  ▆▂▅▅██████████▇▆▅▄▄▄▄▂▄▄▄▅▅▅▆▆▇██▇▇▆███████▇▇▇▆▇▆▆▇▆▆▆▇█████▇ █
  393 ns        Histogram: log(frequency) by time        446 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

This PR:

```julia
julia> @benchmark count(isdigit, v) setup=(v=rand(Char, 10_000))
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  40.870 μs … 483.089 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     42.200 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   45.848 μs ±  19.561 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▆▃▃▂                                                        ▁
  ████████▆▆▄▄▆▄▅▅▅▄▅▅▇▄▄▄▄▄▁▁▁▃▁▃▁▁▁▁▁▁▁▁▃▇██▇▅▆▃▆█▄▄▄▃▁▁▁▁▁█ █
  40.9 μs       Histogram: log(frequency) by time       129 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

In a single-invocation benchmark, we "merely" have a 2-3x/10ns regression:

v1.11-alpha2:

```julia
julia> @benchmark isdigit(v) setup=(v=rand(Char)) evals=1
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  10.000 ns … 40.000 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     20.000 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   17.548 ns ±  4.491 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                                            █  
  ▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▂
  10 ns           Histogram: frequency by time          20 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

This PR:

```julia
julia> @benchmark isdigit(v) setup=(v=rand(Char)) evals=1
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  20.000 ns … 520.000 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     30.000 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   32.170 ns ±  31.893 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▇  █  ▂                      ▂   ▂                           ▁
  █▁▁█▁▁█▁▁▇▁▁▁▅▁▁▄▁▁▁▁▁▁▁▁▁▆▁▁█▁▁▁█▁▁█▁▁▅▁▁▁▄▁▁▃▁▁▄▁▁▁▃▁▁▇▁▁▅ █
  20 ns         Histogram: log(frequency) by time       200 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

That being said, we already check `category_code` pretty much everywhere else, and this microbenchmark is extremely unlikely to be representative of an actual workload. 