### PR TITLE
LinearAlgebra: compile-time stride check in `gemv!` to reduce latency

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -18,7 +18,7 @@ import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, as
     typed_hcat, vec, view, zero
 using Base: IndexLinear, promote_eltype, promote_op, print_matrix,
     @propagate_inbounds, reduce, typed_hvcat, typed_vcat, require_one_based_indexing,
-    splat
+    splat, BitInteger
 using Base.Broadcast: Broadcasted, broadcasted
 using Base.PermutedDimsArrays: CommutativeOps
 using OpenBLAS_jll

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -514,9 +514,9 @@ Base.@constprop :aggressive function gemv!(y::StridedVector{Complex{T}}, tA::Abs
     alpha, beta = promote(α, β, zero(T))
     tA_uc = uppercase(tA) # potentially convert a WrapperChar to a Char
     if alpha isa Union{Bool,T} && beta isa Union{Bool,T} &&
-        stride(A, 1) == 1 && abs(stride(A, 2)) >= size(A, 1) &&
-        stride(y, 1) == 1 && tA_uc == 'N' && # reinterpret-based optimization is valid only for contiguous `y`
-        !iszero(stride(x, 1))
+            stride(A, 1) == 1 && _fullstride2(A) &&
+            stride(y, 1) == 1 && tA_uc == 'N' && # reinterpret-based optimization is valid only for contiguous `y`
+            !iszero(stride(x, 1))
         BLAS.gemv!(tA, alpha, reinterpret(T, A), x, beta, reinterpret(T, y))
         return y
     else
@@ -538,8 +538,8 @@ Base.@constprop :aggressive function gemv!(y::StridedVector{Complex{T}}, tA::Abs
     alpha, beta = promote(α, β, zero(T))
     tA_uc = uppercase(tA) # potentially convert a WrapperChar to a Char
     @views if alpha isa Union{Bool,T} && beta isa Union{Bool,T} &&
-        stride(A, 1) == 1 && abs(stride(A, 2)) >= size(A, 1) &&
-        !iszero(stride(x, 1)) && tA_uc in ('N', 'T', 'C')
+            stride(A, 1) == 1 && _fullstride2(A) &&
+            !iszero(stride(x, 1)) && tA_uc in ('N', 'T', 'C')
         xfl = reinterpret(reshape, T, x) # Use reshape here.
         yfl = reinterpret(reshape, T, y)
         BLAS.gemv!(tA, alpha, A, xfl[1, :], beta, yfl[1, :])

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -208,6 +208,15 @@ end
         C .= C0 = rand(eltype(C), size(C))
         @test mul!(C, vf, transpose(vf), 2, 3) ≈ 2vf * vf' .+ 3C0
     end
+
+    @testset "zero stride" begin
+        for AAv in (view(AA, StepRangeLen(2,0,size(AA,1)), :),
+                    view(AA, StepRangeLen.(2,0,size(AA))...))
+            C = AAv * BB
+            @test allequal(C)
+            @test C ≈ Array(AAv) * BB
+        end
+    end
 end
 
 @testset "generic_matvecmul for vectors of vectors" begin

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -211,10 +211,13 @@ end
 
     @testset "zero stride" begin
         for AAv in (view(AA, StepRangeLen(2,0,size(AA,1)), :),
-                    view(AA, StepRangeLen.(2,0,size(AA))...))
-            C = AAv * BB
-            @test allequal(C)
-            @test C ≈ Array(AAv) * BB
+                    view(AA, StepRangeLen.(2,0,size(AA))...),
+                    view(complex.(AA, AA), StepRangeLen.(2,0,size(AA))...),)
+            for BB2 in (BB, complex.(BB, BB))
+                C = AAv * BB2
+                @test allequal(C)
+                @test C ≈ Array(AAv) * BB2
+            end
         end
     end
 end


### PR DESCRIPTION
Currently, `gemv!` includes a check `abs(stride(A, 2)) >= size(A, 1)` that is usually carried out at run-time, but for several common `StridedArray` types, this should be known at compile time. The check is on line 475:
https://github.com/JuliaLang/julia/blob/50063122b44df1ba80e83fb5abee3f05074f0223/stdlib/LinearAlgebra/src/matmul.jl#L474-L484

E.g. for a `DenseArray`, `stride(A,2)` is known to be equal to `size(A,1)`
https://github.com/JuliaLang/julia/blob/50063122b44df1ba80e83fb5abee3f05074f0223/base/reinterpretarray.jl#L190
https://github.com/JuliaLang/julia/blob/50063122b44df1ba80e83fb5abee3f05074f0223/base/abstractarray.jl#L606-L608

This should typically also hold for common `StridedSubArray`s as well, omitting cases where the indices of the view have zero step. This is because the strides of a `StridedSubArray` are those of the parent multiplied by the step of the indices, so the absolute value of the stride along the second dimension may only increase in magnitude, while the size along the first dimension will not.

If this is evaluated at compile-time, this reduces latency considerably for the BLAS-compatible cases, as the `@stable_muladdmul` branches need not be compiled at all.
```julia
julia> using LinearAlgebra

julia> A = rand(2,2); B = rand(2); C = zeros(2);

julia> @time mul!(C, A, B);
  0.561814 seconds (2.03 M allocations: 104.825 MiB, 34.79% gc time, 99.99% compilation time) # nightly
  0.096350 seconds (159.92 k allocations: 8.093 MiB, 99.94% compilation time) # This PR

julia> A = rand(2,2); B = rand(ComplexF64,2); C = zeros(ComplexF64,2);

julia> @time mul!(C, A, B);
  2.517071 seconds (2.32 M allocations: 117.916 MiB, 7.63% gc time, 100.00% compilation time) # nightly
  0.374085 seconds (2.21 M allocations: 113.495 MiB, 4.84% gc time, 99.99% compilation time) # This PR

julia> A = rand(ComplexF64,2,2); B = rand(2); C = zeros(ComplexF64,2);

julia> @time mul!(C, A, B);
  0.415799 seconds (761.91 k allocations: 39.284 MiB, 41.67% gc time, 99.98% compilation time) # nightly
  0.195291 seconds (484.16 k allocations: 24.472 MiB, 99.97% compilation time) # This PR
```