### PR TITLE
Do not give `StringVector`s to users

### DIFF
--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -319,9 +319,9 @@ function readbytes!(f::File, b::Array{UInt8}, nb=length(b))
     uv_error("read", ret)
     return ret
 end
-read(io::File) = read!(io, Base.StringVector(bytesavailable(io)))
+read(io::File) = read!(io, Vector{UInt8}(undef, bytesavailable(io)))
 readavailable(io::File) = read(io)
-read(io::File, nb::Integer) = read!(io, Base.StringVector(min(nb, bytesavailable(io))))
+read(io::File, nb::Integer) = read!(io, Vector{UInt8}(undef, min(nb, bytesavailable(io))))
 
 const SEEK_SET = Int32(0)
 const SEEK_CUR = Int32(1)

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -447,10 +447,10 @@ function take!(io::GenericIOBuffer)
     ismarked(io) && unmark(io)
     if io.seekable
         nbytes = io.size - io.offset
-        data = copyto!(StringVector(nbytes), 1, io.data, io.offset + 1, nbytes)
+        data = io.data[io.offset+1:io.offset+nbytes]
     else
         nbytes = bytesavailable(io)
-        data = read!(io, StringVector(nbytes))
+        data = read!(io, Vector{UInt8}(undef, nbytes))
     end
     if io.writable
         io.ptr = 1
@@ -464,16 +464,16 @@ function take!(io::IOBuffer)
     if io.seekable
         nbytes = filesize(io)
         if nbytes == 0 || io.reinit
-            data = StringVector(0)
+            data = UInt8[]
         elseif io.writable
             data = view(io.data, io.offset+1:nbytes+io.offset)
         else
-            data = copyto!(StringVector(nbytes), 1, io.data, io.offset + 1, nbytes)
+            data = io.data[io.offset+1:io.offset+nbytes]
         end
     else
         nbytes = bytesavailable(io)
         if nbytes == 0
-            data = StringVector(0)
+            data = UInt8[]
         elseif io.writable
             data = view(io.data, io.ptr:io.ptr+nbytes-1)
         else
@@ -557,9 +557,9 @@ function readbytes!(io::GenericIOBuffer, b::Array{UInt8}, nb::Int)
     read_sub(io, b, 1, nr)
     return nr
 end
-read(io::GenericIOBuffer) = read!(io, StringVector(bytesavailable(io)))
+read(io::GenericIOBuffer) = read!(io, Vector{UInt8}(undef, bytesavailable(io)))
 readavailable(io::GenericIOBuffer) = read(io)
-read(io::GenericIOBuffer, nb::Integer) = read!(io, StringVector(min(nb, bytesavailable(io))))
+read(io::GenericIOBuffer, nb::Integer) = read!(io, Vector{UInt8}(undef, min(nb, bytesavailable(io))))
 
 function occursin(delim::UInt8, buf::IOBuffer)
     p = pointer(buf.data, buf.ptr)

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -562,7 +562,7 @@ function read(s::IOStream)
     @_lock_ios s begin
         nb = ccall(:ios_fillbuf, Cssize_t, (Ptr{Cvoid},), s.ios)
         if nb != -1
-            b = StringVector(nb)
+            b = Vector{UInt8}(undef, nb)
             readbytes_all!(s, b, nb)
         else
             sz = try # filesize is just a hint, so ignore if it fails
@@ -577,7 +577,7 @@ function read(s::IOStream)
                     sz -= pos
                 end
             end
-            b = StringVector(sz < 0 ? 1024 : sz)
+            b = Vector{UInt8}(undef, sz < 0 ? 1024 : sz)
             nr = readbytes_all!(s, b, sz < 0 ? typemax(Int) : sz)
             resize!(b, nr)
         end

--- a/base/strings/cstring.jl
+++ b/base/strings/cstring.jl
@@ -264,7 +264,7 @@ function transcode(::Type{UInt8}, src::AbstractVector{UInt16})
         a = src[i += 1]
     end
 
-    dst = StringVector(m)
+    dst = Vector{UInt8}(undef, m)
     a = src[1]
     i, j = 1, 0
     while true


### PR DESCRIPTION
A `StringVector` v is a `Vector{UInt8}` which wraps memory allocated as a string. This allows `String(v)` to be zero-copy which is good for performance. However, if users are handed a `StringVector` directly, they can use that to unknowingly mutate strings, which is illegal.
For example, suppose a user calls a function `f` which returns a `StringVector` `v`. They can then do the following to mutate a string `s`:

```julia
v = fill!(Base.StringVector(3), 0x00);
v2 = reshape(v, 3, 1)
s = String(v) # all zeros
v2[1] = 0x01
s
```

The solution in this PR is to not ever let `StringVector`s escape out to the user, by instead returning normal `Vector{UInt8}` from the functions that would otherwise do so.

## For reviewers
Potential solution to #54434
Alternative to #54424

Still needs to be rebased on top of #54372 before merging, as these two PRs overlap quite a bit
