### PR TITLE
Try giving some more informative errors for various malformed input

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5251,8 +5251,12 @@ static jl_cgval_t emit_invoke(jl_codectx_t &ctx, const jl_cgval_t &lival, ArrayR
         Value *r = emit_jlcall(ctx, jlinvoke_func, boxed(ctx, lival), argv, nargs, julia_call2);
         result = mark_julia_type(ctx, r, true, rt);
     }
-    if (result.typ == jl_bottom_type)
+    if (result.typ == jl_bottom_type) {
+#ifndef JL_NDEBUG
+        emit_error(ctx, "(Internal Error - IR Validity): Returned from function we expected not to.");
+#endif
         CreateTrap(ctx.builder);
+    }
     return result;
 }
 
@@ -6523,7 +6527,12 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaidx_
 
             SmallVector<jl_value_t *, 0> env_component_ts(nargs-4);
             for (size_t i = 0; i < nargs - 4; ++i) {
-                env_component_ts[i] = argv[4+i].typ;
+                jl_value_t *typ = argv[4+i].typ;
+                if (typ == jl_bottom_type) {
+                    JL_GC_POP();
+                    return jl_cgval_t();
+                }
+                env_component_ts[i] = typ;
             }
 
             env_t = jl_apply_tuple_type_v(env_component_ts.data(), nargs-4);
@@ -9754,9 +9763,6 @@ jl_llvm_functions_t jl_emit_code(
         jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception(jl_current_task));
         jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
         jlbacktrace(); // written to STDERR_FILENO
-#ifndef JL_NDEBUG
-        abort();
-#endif
     }
 
     return decls;

--- a/src/opaque_closure.c
+++ b/src/opaque_closure.c
@@ -50,7 +50,15 @@ static jl_opaque_closure_t *new_opaque_closure(jl_tupletype_t *argt, jl_value_t 
     JL_GC_PUSH2(&sigtype, &selected_rt);
     sigtype = jl_argtype_with_function(captures, (jl_value_t*)argt);
 
-    jl_method_instance_t *mi = jl_specializations_get_linfo(source, sigtype, jl_emptysvec);
+    jl_method_instance_t *mi = NULL;
+    if (source->source) {
+        mi = jl_specializations_get_linfo(source, sigtype, jl_emptysvec);
+    } else {
+        mi = (jl_method_instance_t *)jl_atomic_load_relaxed(&source->specializations);
+        if (!jl_subtype(sigtype, mi->specTypes)) {
+            jl_error("sigtype mismatch in optimized opaque closure");
+        }
+    }
     jl_task_t *ct = jl_current_task;
     size_t world = ct->world_age;
     jl_code_instance_t *ci = NULL;
@@ -147,7 +155,8 @@ JL_DLLEXPORT jl_opaque_closure_t *jl_new_opaque_closure_from_code_info(jl_tuplet
     jl_atomic_store_release(&meth->deleted_world, world);
 
     if (isinferred) {
-        sigtype = jl_argtype_with_function(env, (jl_value_t*)argt);
+        jl_value_t *argslotty = jl_array_ptr_ref(ci->slottypes, 0);
+        sigtype = jl_argtype_with_function_type(argslotty, (jl_value_t*)argt);
         jl_method_instance_t *mi = jl_specializations_get_linfo((jl_method_t*)root, sigtype, jl_emptysvec);
         inst = jl_new_codeinst(mi, jl_nothing, rt_ub, (jl_value_t*)jl_any_type, NULL, (jl_value_t*)ci,
             0, world, world, 0, 0, jl_nothing, 0, ci->debuginfo);

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -743,6 +743,7 @@ end
 @testset "code_llvm on opaque_closure" begin
     let ci = code_typed(+, (Int, Int))[1][1]
         ir = Core.Compiler.inflate_ir(ci)
+        ir.argtypes[1] = Tuple{}
         @test ir.debuginfo.def === nothing
         ir.debuginfo.def = Symbol(@__FILE__)
         oc = Core.OpaqueClosure(ir)

--- a/test/compiler/AbstractInterpreter.jl
+++ b/test/compiler/AbstractInterpreter.jl
@@ -163,24 +163,30 @@ CC.method_table(interp::OverlaySinInterp) = CC.OverlayMethodTable(CC.get_inferen
 overlay_sin1(x) = error("Not supposed to be called.")
 @overlay OverlaySinMT overlay_sin1(x) = cos(x)
 @overlay OverlaySinMT Base.sin(x::Union{Float32,Float64}) = overlay_sin1(x)
-let oc = Base.code_ircode(; interp=OverlaySinInterp()) do
+let ir = Base.code_ircode(; interp=OverlaySinInterp()) do
         sin(0.)
-    end |> only |> first |> Core.OpaqueClosure
+    end |> only |> first
+    ir.argtypes[1] = Tuple{}
+    oc = Core.OpaqueClosure(ir)
     @test oc() == cos(0.)
 end
 @overlay OverlaySinMT Base.sin(x::Union{Float32,Float64}) = @noinline overlay_sin1(x)
-let oc = Base.code_ircode(; interp=OverlaySinInterp()) do
+let ir = Base.code_ircode(; interp=OverlaySinInterp()) do
         sin(0.)
-    end |> only |> first |> Core.OpaqueClosure
+    end |> only |> first
+    ir.argtypes[1] = Tuple{}
+    oc = Core.OpaqueClosure(ir)
     @test oc() == cos(0.)
 end
 _overlay_sin2(x) = error("Not supposed to be called.")
 @overlay OverlaySinMT _overlay_sin2(x) = cos(x)
 overlay_sin2(x) = _overlay_sin2(x)
 @overlay OverlaySinMT Base.sin(x::Union{Float32,Float64}) = @noinline overlay_sin2(x)
-let oc = Base.code_ircode(; interp=OverlaySinInterp()) do
+let ir = Base.code_ircode(; interp=OverlaySinInterp()) do
         sin(0.)
-    end |> only |> first |> Core.OpaqueClosure
+    end |> only |> first
+    ir.argtypes[1] = Tuple{}
+    oc = Core.OpaqueClosure(ir)
     @test oc() == cos(0.)
 end
 

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -2200,6 +2200,7 @@ issue52644(::UnionAll) = :UnionAll
 let ir = Base.code_ircode((Issue52644,); optimize_until="Inlining") do t
         issue52644(t.tuple)
     end |> only |> first
+    ir.argtypes[1] = Tuple{}
     irfunc = Core.OpaqueClosure(ir)
     @test irfunc(Issue52644(Tuple{})) === :DataType
     @test irfunc(Issue52644(Tuple{<:Integer})) === :UnionAll
@@ -2208,6 +2209,7 @@ issue52644_single(x::DataType) = :DataType
 let ir = Base.code_ircode((Issue52644,); optimize_until="Inlining") do t
         issue52644_single(t.tuple)
     end |> only |> first
+    ir.argtypes[1] = Tuple{}
     irfunc = Core.OpaqueClosure(ir)
     @test irfunc(Issue52644(Tuple{})) === :DataType
     @test_throws MethodError irfunc(Issue52644(Tuple{<:Integer}))


### PR DESCRIPTION
I was playing with generating some code for OpaqueClosures. It's pretty easy to generate IR that will pass the verifier, but cause assertion errors in codegen. This tries to make the experience slightly nicer by turning some of them into proper error messages (thus letting the runtime discover, so that e.g. the code can be inspected at the REPL) rather than assertions.