### PR TITLE
Targeted `stable_muladdmul` branches in small matmul

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -380,10 +380,10 @@ Base.@constprop :aggressive function generic_matmatmul!(C::StridedMatrix{T}, tA,
         return _rmul_or_fill!(C, β)
     end
     if size(C) == size(A) == size(B) == (2,2)
-        return @stable_muladdmul matmul2x2!(C, tA, tB, A, B, MulAddMul(α, β))
+        return matmul2x2!(C, tA, tB, A, B, α, β)
     end
     if size(C) == size(A) == size(B) == (3,3)
-        return @stable_muladdmul matmul3x3!(C, tA, tB, A, B, MulAddMul(α, β))
+        return matmul3x3!(C, tA, tB, A, B, α, β)
     end
     # We convert the chars to uppercase to potentially unwrap a WrapperChar,
     # and extract the char corresponding to the wrapper type
@@ -996,15 +996,20 @@ Base.@constprop :aggressive function __matmul2x2_elements(tA, A::AbstractMatrix)
 end
 Base.@constprop :aggressive __matmul2x2_elements(tA, tB, A, B) = __matmul2x2_elements(tA, A), __matmul2x2_elements(tB, B)
 
-Base.@constprop :aggressive function matmul2x2!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix,
-                    _add::MulAddMul = MulAddMul())
-    (A11, A12, A21, A22), (B11, B12, B21, B22) = _matmul2x2_elements(C, tA, tB, A, B)
+function _modify2x2!(Aelements, Belements, C, _add)
+    (A11, A12, A21, A22), (B11, B12, B21, B22) = Aelements, Belements
     @inbounds begin
     _modify!(_add, A11*B11 + A12*B21, C, (1,1))
     _modify!(_add, A21*B11 + A22*B21, C, (2,1))
     _modify!(_add, A11*B12 + A12*B22, C, (1,2))
     _modify!(_add, A21*B12 + A22*B22, C, (2,2))
     end # inbounds
+    C
+end
+Base.@constprop :aggressive function matmul2x2!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix,
+                    α = true, β = false)
+    Aelements, Belements = _matmul2x2_elements(C, tA, tB, A, B)
+    @stable_muladdmul _modify2x2!(Aelements, Belements, C, MulAddMul(α, β))
     C
 end
 
@@ -1061,12 +1066,9 @@ Base.@constprop :aggressive function __matmul3x3_elements(tA, A::AbstractMatrix)
 end
 Base.@constprop :aggressive __matmul3x3_elements(tA, tB, A, B) = __matmul3x3_elements(tA, A), __matmul3x3_elements(tB, B)
 
-Base.@constprop :aggressive function matmul3x3!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix,
-                    _add::MulAddMul = MulAddMul())
-
+function _modify3x3!(Aelements, Belements, C, _add)
     (A11, A12, A13, A21, A22, A23, A31, A32, A33),
-        (B11, B12, B13, B21, B22, B23, B31, B32, B33) = _matmul3x3_elements(C, tA, tB, A, B)
-
+        (B11, B12, B13, B21, B22, B23, B31, B32, B33) = Aelements, Belements
     @inbounds begin
     _modify!(_add, A11*B11 + A12*B21 + A13*B31, C, (1,1))
     _modify!(_add, A21*B11 + A22*B21 + A23*B31, C, (2,1))
@@ -1080,6 +1082,13 @@ Base.@constprop :aggressive function matmul3x3!(C::AbstractMatrix, tA, tB, A::Ab
     _modify!(_add, A21*B13 + A22*B23 + A23*B33, C, (2,3))
     _modify!(_add, A31*B13 + A32*B23 + A33*B33, C, (3,3))
     end # inbounds
+    C
+end
+Base.@constprop :aggressive function matmul3x3!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix,
+                    α = true, β = false)
+
+    Aelements, Belements = _matmul3x3_elements(C, tA, tB, A, B)
+    @stable_muladdmul _modify3x3!(Aelements, Belements, C, MulAddMul(α, β))
     C
 end
 


### PR DESCRIPTION
This PR changes the signature of `matmul2x2!` and `matmul3x3!` so that they now accept the alpha and beta parameters instead of the `MulAddMul`. Consequently, the `@stable_muladdmul` macro may be applied to smaller blocks of code within the functions instead of applying it to the entire call. This reduces the matrix multiplication latency by a bit.

```julia
julia> using LinearAlgebra

julia> A = rand(2,2); B = rand(size(A)...); C = zeros(size(A));

julia> @time mul!(C, A, B);
  0.903632 seconds (2.54 M allocations: 130.322 MiB, 5.52% gc time, 100.00% compilation time) # master
  0.813335 seconds (2.28 M allocations: 117.025 MiB, 2.07% gc time, 100.00% compilation time) # This PR
```