### PR TITLE
LinearAlgebra: aggressive constprop in opnorm

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -808,7 +808,7 @@ julia> opnorm(A, 1)
 5.0
 ```
 """
-function opnorm(A::AbstractMatrix, p::Real=2)
+Base.@constprop :aggressive function opnorm(A::AbstractMatrix, p::Real=2)
     if p == 2
         return opnorm2(A)
     elseif p == 1


### PR DESCRIPTION
Currently, most of the time in compiling `opnorm` is spent on `opnorm2`, so it makes sense to avoid compiling this for other values of `p`.

Latency improvement:
```julia
julia> using LinearAlgebra

julia> @time (A -> LinearAlgebra.opnorm(A,1))(A);
  0.347217 seconds (335.97 k allocations: 17.232 MiB, 96.74% compilation time) # nightly
  0.119258 seconds (332.86 k allocations: 17.146 MiB, 90.39% compilation time) # This PR
```