### PR TITLE
Copy parent in copy_similar for Symmetric/Hermitian

### DIFF
--- a/stdlib/LinearAlgebra/src/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/src/symmetriceigen.jl
@@ -1,8 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # preserve HermOrSym wrapper
-# Call `copytrito!` instead of `copy_similar` as we know that the the `uplo` is matched, and we don't need to compile
-# the mismatched-`uplo` branch in `copyto!`
+# Call `copytrito!` instead of `copy_similar` to only copy the matching triangular half
 eigencopy_oftype(A::Hermitian, S) = Hermitian(copytrito!(similar(parent(A), S, size(A)), A.data, A.uplo), sym_uplo(A.uplo))
 eigencopy_oftype(A::Symmetric, S) = Symmetric(copytrito!(similar(parent(A), S, size(A)), A.data, A.uplo), sym_uplo(A.uplo))
 

--- a/stdlib/LinearAlgebra/src/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/src/symmetriceigen.jl
@@ -1,8 +1,10 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # preserve HermOrSym wrapper
-eigencopy_oftype(A::Hermitian, S) = Hermitian(copy_similar(parent(A), S), sym_uplo(A.uplo))
-eigencopy_oftype(A::Symmetric, S) = Symmetric(copy_similar(parent(A), S), sym_uplo(A.uplo))
+# Call `copytrito!` instead of `copy_similar` as we know that the the `uplo` is matched, and we don't need to compile
+# the mismatched-`uplo` branch in `copyto!`
+eigencopy_oftype(A::Hermitian, S) = Hermitian(copytrito!(similar(parent(A), S, size(A)), A.data, A.uplo), sym_uplo(A.uplo))
+eigencopy_oftype(A::Symmetric, S) = Symmetric(copytrito!(similar(parent(A), S, size(A)), A.data, A.uplo), sym_uplo(A.uplo))
 
 # Eigensolvers for symmetric and Hermitian matrices
 eigen!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; sortby::Union{Function,Nothing}=nothing) =

--- a/stdlib/LinearAlgebra/src/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/src/symmetriceigen.jl
@@ -1,8 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # preserve HermOrSym wrapper
-eigencopy_oftype(A::Hermitian, S) = Hermitian(copy_similar(A, S), sym_uplo(A.uplo))
-eigencopy_oftype(A::Symmetric, S) = Symmetric(copy_similar(A, S), sym_uplo(A.uplo))
+eigencopy_oftype(A::Hermitian, S) = Hermitian(copy_similar(parent(A), S), sym_uplo(A.uplo))
+eigencopy_oftype(A::Symmetric, S) = Symmetric(copy_similar(parent(A), S), sym_uplo(A.uplo))
 
 # Eigensolvers for symmetric and Hermitian matrices
 eigen!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; sortby::Union{Function,Nothing}=nothing) =


### PR DESCRIPTION
This should be equivalent to copying the `Symmetric`/`Hermitian` matrix, as only one triangular half is used. However, this reduces latency when the parent is a `Matrix` (and possibly others too, although I've not checked this).

```julia
julia> using LinearAlgebra

julia> A = rand(2,2); H = Hermitian(A);

julia> @time eigen(H);
  0.342207 seconds (440.61 k allocations: 22.926 MiB, 99.95% compilation time) # nightly
  0.260913 seconds (326.62 k allocations: 16.926 MiB, 99.93% compilation time) # This PR
```
Copying the parent is also marginally faster, although this doesn't really matter in `eigen`:
```julia
julia> A = rand(1000,1000); H = Hermitian(A);

julia> @btime LinearAlgebra.copy_similar($H, Float64);
  1.839 ms (3 allocations: 7.63 MiB) # nightly
  1.760 ms (3 allocations: 7.63 MiB) # This PR
```