### PR TITLE
Unalias source from dest in copytrito

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -2012,6 +2012,7 @@ function copytrito!(B::AbstractMatrix, A::AbstractMatrix, uplo::AbstractChar)
     m,n = size(A)
     m1,n1 = size(B)
     (m1 < m || n1 < n) && throw(DimensionMismatch(lazy"B of size ($m1,$n1) should have at least the same number of rows and columns than A of size ($m,$n)"))
+    A = Base.unalias(B, A)
     if uplo == 'U'
         for j=1:n
             for i=1:min(j,m)

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -654,6 +654,14 @@ end
         C = uplo == 'L' ? tril(A) : triu(A)
         @test B ≈ C
     end
+    @testset "aliasing" begin
+        M = Matrix(reshape(1:36, 6, 6))
+        A = view(M, 1:5, 1:5)
+        A2 = Matrix(A)
+        B = view(M, 2:6, 2:6)
+        copytrito!(B, A, 'U')
+        @test UpperTriangular(B) == UpperTriangular(A2)
+    end
 end
 
 @testset "immutable arrays" begin


### PR DESCRIPTION
Currently, `copytrito!` doesn't check for aliasing, and as a consequence, if the source and destination overlap, the source is overwritten during the copy, and the destination doesn't receive the original values contained in the source:
```julia
julia> M = Matrix(reshape(1:3^2, 3, 3))
3×3 Matrix{Int64}:
 1  4  7
 2  5  8
 3  6  9

julia> A = view(M, 1:size(M,1)-1, 1:size(M,2)-1)
2×2 view(::Matrix{Int64}, 1:2, 1:2) with eltype Int64:
 1  4
 2  5

julia> B = view(M, 2:size(M,1), 2:size(M,2))
2×2 view(::Matrix{Int64}, 2:3, 2:3) with eltype Int64:
 5  8
 6  9

julia> A2 = copy(A);

julia> copytrito!(B, A, 'U')
2×2 view(::Matrix{Int64}, 2:3, 2:3) with eltype Int64:
 1  4
 6  1

julia> UpperTriangular(B) == UpperTriangular(A2)
false

julia> UpperTriangular(B) == UpperTriangular(A)
true
```
Ideally, `copytrito!` should behave like `copyto!`, and `unalias` the arguments before the actual copy. After this PR,
```julia
julia> copytrito!(B, A, 'U')
2×2 view(::Matrix{Int64}, 2:3, 2:3) with eltype Int64:
 1  4
 6  5

julia> UpperTriangular(B) == UpperTriangular(A2)
true

julia> UpperTriangular(B) == UpperTriangular(A)
false
```
This way, the destination receives the original values in `A`, irrespective of whether `A` is updated during the copy.