### PR TITLE
Speed up `copyto!(::HermOrSym, ::HermOrSym)`

### DIFF
--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -347,7 +347,7 @@ copy(A::Hermitian) = (Hermitian(parentof_applytri(copy, A), sym_uplo(A.uplo)))
 
 function copyto!(dest::Symmetric, src::Symmetric)
     if src.uplo == dest.uplo
-        copyto!(dest.data, src.data)
+        copytrito!(dest.data, src.data, src.uplo)
     else
         transpose!(dest.data, Base.unalias(dest.data, src.data))
     end
@@ -356,7 +356,7 @@ end
 
 function copyto!(dest::Hermitian, src::Hermitian)
     if src.uplo == dest.uplo
-        copyto!(dest.data, src.data)
+        copytrito!(dest.data, src.data, src.uplo)
     else
         adjoint!(dest.data, Base.unalias(dest.data, src.data))
     end


### PR DESCRIPTION
This seems to be an easy optimization.