### PR TITLE
Delete redundant xcat methods that previously improved performance

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2108,22 +2108,11 @@ julia> a * b
 # `@constprop :aggressive` allows `catdims` to be propagated as constant improving return type inference
 @constprop :aggressive _cat(catdims, A::AbstractArray{T}...) where {T} = _cat_t(catdims, T, A...)
 
-# The specializations for 1 and 2 inputs are important
-# especially when running with --inline=no, see #11158
-vcat(A::AbstractArray) = cat(A; dims=Val(1))
-vcat(A::AbstractArray, B::AbstractArray) = cat(A, B; dims=Val(1))
-vcat(A::AbstractArray...) = cat(A...; dims=Val(1))
 vcat(A::Union{AbstractArray,Number}...) = cat(A...; dims=Val(1))
-hcat(A::AbstractArray) = cat(A; dims=Val(2))
-hcat(A::AbstractArray, B::AbstractArray) = cat(A, B; dims=Val(2))
 hcat(A::AbstractArray...) = cat(A...; dims=Val(2))
 hcat(A::Union{AbstractArray,Number}...) = cat(A...; dims=Val(2))
 
-typed_vcat(T::Type, A::AbstractArray) = _cat_t(Val(1), T, A)
-typed_vcat(T::Type, A::AbstractArray, B::AbstractArray) = _cat_t(Val(1), T, A, B)
 typed_vcat(T::Type, A::AbstractArray...) = _cat_t(Val(1), T, A...)
-typed_hcat(T::Type, A::AbstractArray) = _cat_t(Val(2), T, A)
-typed_hcat(T::Type, A::AbstractArray, B::AbstractArray) = _cat_t(Val(2), T, A, B)
 typed_hcat(T::Type, A::AbstractArray...) = _cat_t(Val(2), T, A...)
 
 # 2d horizontal and vertical concatenation


### PR DESCRIPTION
Deleting these because I ran `./julia --startup-file=no --inline=no -e '@time Base.runtests("ranges")'` before and after this PR and found a 2 second (1%) regression, which is within margin of error of zero and _way_ less than the original performance improvement when these were added in 2015 in #11158 by @timholy 