### PR TITLE
reimplement `afoldl` using recursion

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -581,53 +581,7 @@ const ⊻ = xor
 const ⊼ = nand
 const ⊽ = nor
 
-# foldl for argument lists. expand fully up to a point, then
-# switch to a loop. this allows small cases like `a+b+c+d` to be managed
-# efficiently, without a major slowdown for `+(x...)` when `x` is big.
-# n.b.: keep this method count small, so it can be inferred without hitting the
-# method count limit in inference
-afoldl(op, a) = a
-function afoldl(op, a, bs...)
-    l = length(bs)
-    i =  0; y = a;            l == i && return y
-    #@nexprs 31 i -> (y = op(y, bs[i]); l == i && return y)
-    i =  1; y = op(y, bs[i]); l == i && return y
-    i =  2; y = op(y, bs[i]); l == i && return y
-    i =  3; y = op(y, bs[i]); l == i && return y
-    i =  4; y = op(y, bs[i]); l == i && return y
-    i =  5; y = op(y, bs[i]); l == i && return y
-    i =  6; y = op(y, bs[i]); l == i && return y
-    i =  7; y = op(y, bs[i]); l == i && return y
-    i =  8; y = op(y, bs[i]); l == i && return y
-    i =  9; y = op(y, bs[i]); l == i && return y
-    i = 10; y = op(y, bs[i]); l == i && return y
-    i = 11; y = op(y, bs[i]); l == i && return y
-    i = 12; y = op(y, bs[i]); l == i && return y
-    i = 13; y = op(y, bs[i]); l == i && return y
-    i = 14; y = op(y, bs[i]); l == i && return y
-    i = 15; y = op(y, bs[i]); l == i && return y
-    i = 16; y = op(y, bs[i]); l == i && return y
-    i = 17; y = op(y, bs[i]); l == i && return y
-    i = 18; y = op(y, bs[i]); l == i && return y
-    i = 19; y = op(y, bs[i]); l == i && return y
-    i = 20; y = op(y, bs[i]); l == i && return y
-    i = 21; y = op(y, bs[i]); l == i && return y
-    i = 22; y = op(y, bs[i]); l == i && return y
-    i = 23; y = op(y, bs[i]); l == i && return y
-    i = 24; y = op(y, bs[i]); l == i && return y
-    i = 25; y = op(y, bs[i]); l == i && return y
-    i = 26; y = op(y, bs[i]); l == i && return y
-    i = 27; y = op(y, bs[i]); l == i && return y
-    i = 28; y = op(y, bs[i]); l == i && return y
-    i = 29; y = op(y, bs[i]); l == i && return y
-    i = 30; y = op(y, bs[i]); l == i && return y
-    i = 31; y = op(y, bs[i]); l == i && return y
-    for i in (i + 1):l
-        y = op(y, bs[i])
-    end
-    return y
-end
-setfield!(typeof(afoldl).name.mt, :max_args, 34, :monotonic)
+afoldl(op, a, bs...) = _tuple_foldl(op, (a, bs...))
 
 for op in (:+, :*, :&, :|, :xor, :min, :max, :kron)
     @eval begin

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -582,6 +582,21 @@ const ⊼ = nand
 const ⊽ = nor
 
 afoldl(op, a, bs...) = _tuple_foldl(op, (a, bs...))
+function afoldl(op,
+    a00, a01, a02, a03, a04, a05, a06, a07, a08, a09, a10, a11, a12, a13, a14, a15, a16,
+    a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33,
+    bs...
+)
+    prefix = (
+        a00, a01, a02, a03, a04, a05, a06, a07, a08, a09, a10, a11, a12, a13, a14, a15, a16,
+        a17, a18, a19, a20, a21, a22, a23, a24, a25, a26, a27, a28, a29, a30, a31, a32, a33
+    )
+    y = _tuple_foldl(op, prefix)
+    for i in eachindex(bs)
+        y = op(y, bs[i])
+    end
+    return y
+end
 
 for op in (:+, :*, :&, :|, :xor, :min, :max, :kron)
     @eval begin

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -456,16 +456,9 @@ function map(f, t1::Any32, t2::Any32, ts::Any32...)
     (A...,)
 end
 
-function _tuple_foldl(op::Op, t::Tuple{Any,Vararg}) where {Op}
+function _tuple_foldl(op::Op, @nospecialize t::Tuple{Any,Vararg}) where {Op}
     ass = _FoldAssociativity.Left()
     _tupleview_fold(op, ass, _TupleViewFront(), t, _tupleview_length_representation(t))
-end
-function _tuple_foldl(op::Op, t::Any32) where {Op}
-    y = t[1]
-    for i ∈ 2:length(t)
-        y = op(y, t[i])
-    end
-    y
 end
 
 # type-stable padding

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2784,7 +2784,7 @@ end
 @test only(Base.return_types((r)->similar(Array{typeof(r[])}, 1), (Base.RefValue{Array{Int}},))) == Vector{<:Array{Int}}
 @test only(Base.return_types((r)->similar(Array{typeof(r[])}, 1), (Base.RefValue{Array{<:Real}},))) == Vector{<:Array{<:Real}}
 # test complexity limit on apply_type on a function capturing functions returning functions
-@test only(Base.return_types(Base.afoldl, (typeof((m, n) -> () -> Returns(nothing)(m, n)), Function, Function, Vararg{Function}))) === Function
+@test all((t -> t <: Function), Base.return_types(Base.afoldl, (typeof((m, n) -> () -> Returns(nothing)(m, n)), Function, Function, Vararg{Function})))
 
 let A = Tuple{A,B,C,D,E,F,G,H} where {A,B,C,D,E,F,G,H}
     B = Core.Compiler.rename_unionall(A)


### PR DESCRIPTION
The new implementation is more elegant and flexible, doing away with the code duplication and extreme amounts of constant-hardcoding.

FTR, this PR is part of a series of changes which (re)implement many of the operations on tuples using a new recursive technique. The ultimate goal is to hopefully increase the value of the loop-vs-recurse cutoff (`Any32`, sometimes hardcoded `32`) for tuple operations.

Demanding type inference example:

```julia-repl
julia> isconcretetype(Core.Compiler.return_type(foldl, Tuple{typeof((l,r) -> l => r),Tuple{Vararg{Int,30}}}))
true
```