### PR TITLE
reimplement `_setindex` using recursion

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -250,7 +250,7 @@ julia> selectdim(A, 2, 3:4)
  7  8
 ```
 """
-@inline selectdim(A::AbstractArray, d::Integer, i) = _selectdim(A, d, i, _setindex(i, d, map(Slice, axes(A))...))
+@inline selectdim(A::AbstractArray, d::Integer, i) = _selectdim(A, d, i, _setindex(i, d, map(Slice, axes(A))))
 @noinline function _selectdim(A, d, i, idxs)
     d >= 1 || throw(ArgumentError("dimension must be ≥ 1, got $d"))
     nd = ndims(A)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -71,7 +71,7 @@ function _tupleview_setindex_to_tuple(
         let lenm1 = _tupleview_length_representation_decremented(length),
             b = nfields(length) == target_length
             e = b ? new_value : _tupleview_single_from(o, parent, length)
-            rest = _tupleview_setindex_to_tuple(o, parent, lenm1, new_value, target_length)
+            rest = _tupleview_setindex_to_tuple(o, parent, lenm1, new_value, target_length)::Tuple
             _tupleview_tuple_concatenation_helper(o, e, rest)
         end
     end


### PR DESCRIPTION
FTR, this PR is part of a series of changes which (re)implement many of the operations on tuples using a new recursive technique. The ultimate goal is to hopefully increase the value of the loop-vs-recurse cutoff (`Any32`, sometimes hardcoded `32`) for tuple operations.

Updates #54462

Closes #54463

Example type inference improvement:

```julia-repl
julia> Core.Compiler.return_type(Base.setindex, Tuple{Tuple{Vararg{Int}},Int,Int})
Tuple{Vararg{Int64}}
```