### PR TITLE
Use lacpy! in copytrito! for strided matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -287,15 +287,16 @@ const NonConstRangeIndex = Union{IncreasingRangeIndex, StepRange{<:BitInteger, <
 DenseOrStridedReshapedReinterpreted{T,N} =
     Union{DenseArray{T,N}, Base.StridedReshapedArray{T,N}, Base.StridedReinterpretArray{T,N}}
 # Similar to Base.StridedSubArray, except with a NonConstRangeIndex instead of a RangeIndex
-StridedSubArrayStandard{T,N,A,
+StridedSubArrayStandard{T,N,A<:DenseOrStridedReshapedReinterpreted,
     I<:Tuple{Vararg{Union{NonConstRangeIndex, Base.ReshapedUnitRange, Base.AbstractCartesianIndex}}}} = Base.StridedSubArray{T,N,A,I}
 StridedArrayStdSubArray{T,N} = Union{DenseOrStridedReshapedReinterpreted{T,N},StridedSubArrayStandard{T,N}}
 # Similar to Base.StridedSubArray, except with a IncreasingRangeIndex instead of a RangeIndex
-StridedSubArrayIncr{T,N,A,
+StridedSubArrayIncr{T,N,A<:DenseOrStridedReshapedReinterpreted,
     I<:Tuple{Vararg{Union{IncreasingRangeIndex, Base.ReshapedUnitRange, Base.AbstractCartesianIndex}}}} = Base.StridedSubArray{T,N,A,I}
 StridedArrayStdSubArrayIncr{T,N} = Union{DenseOrStridedReshapedReinterpreted{T,N},StridedSubArrayIncr{T,N}}
 # These subarrays have a stride of 1 along the first dimension
-StridedSubArrayAUR{T,N,A,I<:Tuple{AbstractUnitRange{<:BitInteger}}} = Base.StridedSubArray{T,N,A,I}
+StridedSubArrayAUR{T,N,A<:DenseOrStridedReshapedReinterpreted,
+    I<:Tuple{AbstractUnitRange{<:BitInteger}}} = Base.StridedSubArray{T,N,A,I}
 StridedArrayStride1{T,N} = Union{DenseOrStridedReshapedReinterpreted{T,N},StridedSubArrayIncr{T,N}}
 # StridedMatrixStride1 may typically be forwarded to LAPACK methods
 StridedMatrixStride1{T} = StridedArrayStride1{T,2}

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -279,6 +279,27 @@ stride1(x::DenseArray) = stride(x, 1)::Int
 @noinline _chkstride1(ok::Bool) = ok || error("matrix does not have contiguous columns")
 @inline _chkstride1(ok::Bool, A, B...) = _chkstride1(ok & (stride1(A) == 1), B...)
 
+# Subtypes of StridedArrays that satisfy certain properties on their strides
+# Similar to Base.RangeIndex, but only include range types where the step is statically known to be non-zero
+const IncreasingRangeIndex = Union{BitInteger, AbstractUnitRange{<:BitInteger}}
+const NonConstRangeIndex = Union{IncreasingRangeIndex, StepRange{<:BitInteger, <:BitInteger}}
+# StridedArray subtypes for which _fullstride2(::T) === true is known from the type
+DenseOrStridedReshapedReinterpreted{T,N} =
+    Union{DenseArray{T,N}, Base.StridedReshapedArray{T,N}, Base.StridedReinterpretArray{T,N}}
+# Similar to Base.StridedSubArray, except with a NonConstRangeIndex instead of a RangeIndex
+StridedSubArrayStandard{T,N,A,
+    I<:Tuple{Vararg{Union{NonConstRangeIndex, Base.ReshapedUnitRange, Base.AbstractCartesianIndex}}}} = Base.StridedSubArray{T,N,A,I}
+StridedArrayStdSubArray{T,N} = Union{DenseOrStridedReshapedReinterpreted{T,N},StridedSubArrayStandard{T,N}}
+# Similar to Base.StridedSubArray, except with a IncreasingRangeIndex instead of a RangeIndex
+StridedSubArrayIncr{T,N,A,
+    I<:Tuple{Vararg{Union{IncreasingRangeIndex, Base.ReshapedUnitRange, Base.AbstractCartesianIndex}}}} = Base.StridedSubArray{T,N,A,I}
+StridedArrayStdSubArrayIncr{T,N} = Union{DenseOrStridedReshapedReinterpreted{T,N},StridedSubArrayIncr{T,N}}
+# These subarrays have a stride of 1 along the first dimension
+StridedSubArrayAUR{T,N,A,I<:Tuple{AbstractUnitRange{<:BitInteger}}} = Base.StridedSubArray{T,N,A,I}
+StridedArrayStride1{T,N} = Union{DenseOrStridedReshapedReinterpreted{T,N},StridedSubArrayIncr{T,N}}
+# StridedMatrixStride1 may typically be forwarded to LAPACK methods
+StridedMatrixStride1{T} = StridedArrayStride1{T,2}
+
 """
     LinearAlgebra.checksquare(A)
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -2028,7 +2028,7 @@ function copytrito!(B::AbstractMatrix, A::AbstractMatrix, uplo::AbstractChar)
     end
     return B
 end
-# Forward contiguous strided matrices to LAPACK to avail the faster method
+# Forward LAPACK-compatible strided matrices to lacpy
 function copytrito!(B::StridedMatrixStride1{T}, A::StridedMatrixStride1{T}, uplo::AbstractChar) where {T<:BlasFloat}
     LAPACK.lacpy!(B, A, uplo)
 end

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -2028,3 +2028,7 @@ function copytrito!(B::AbstractMatrix, A::AbstractMatrix, uplo::AbstractChar)
     end
     return B
 end
+# Forward contiguous strided matrices to LAPACK to avail the faster method
+function copytrito!(B::StridedMatrixStride1{T}, A::StridedMatrixStride1{T}, uplo::AbstractChar) where {T<:BlasFloat}
+    LAPACK.lacpy!(B, A, uplo)
+end

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -462,8 +462,6 @@ end
 _fullstride2(A, f=identity) = f(stride(A, 2)) >= size(A, 1)
 # for some standard StridedArrays, the _fullstride2 condition is known to hold at compile-time
 # We specialize the function for certain StridedArray subtypes
-
-
 _fullstride2(A::StridedArrayStdSubArray, ::typeof(abs)) = true
 _fullstride2(A::StridedArrayStdSubArrayIncr, ::typeof(identity)) = true
 

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -463,18 +463,9 @@ _fullstride2(A, f=identity) = f(stride(A, 2)) >= size(A, 1)
 # for some standard StridedArrays, the _fullstride2 condition is known to hold at compile-time
 # We specialize the function for certain StridedArray subtypes
 
-# Similar to Base.RangeIndex, but only include range types where the step is statically known to be non-zero
-const IncreasingRangeIndex = Union{BitInteger, AbstractUnitRange{<:BitInteger}}
-const NonConstRangeIndex = Union{IncreasingRangeIndex, StepRange{<:BitInteger, <:BitInteger}}
-# StridedArray subtypes for which _fullstride2(::T) === true is known from the type
-const DenseOrStridedReshapedReinterpreted = Union{DenseArray, Base.StridedReshapedArray, Base.StridedReinterpretArray}
-# Similar to Base.StridedSubArray, except with a NonConstRangeIndex instead of a RangeIndex
-StridedSubArrayStandard{T,N,A,
-    I<:Tuple{Vararg{Union{NonConstRangeIndex, Base.ReshapedUnitRange, Base.AbstractCartesianIndex}}}} = Base.StridedSubArray{T,N,A,I}
-_fullstride2(A::Union{DenseOrStridedReshapedReinterpreted,StridedSubArrayStandard}, ::typeof(abs)) = true
-StridedSubArrayIncr{T,N,A,
-    I<:Tuple{Vararg{Union{IncreasingRangeIndex, Base.ReshapedUnitRange, Base.AbstractCartesianIndex}}}} = Base.StridedSubArray{T,N,A,I}
-_fullstride2(A::Union{DenseOrStridedReshapedReinterpreted,StridedSubArrayIncr}, ::typeof(identity)) = true
+
+_fullstride2(A::StridedSubArrayStandard, ::typeof(abs)) = true
+_fullstride2(A::StridedArrayStdSubArrayIncr, ::typeof(identity)) = true
 
 Base.@constprop :aggressive function gemv!(y::StridedVector{T}, tA::AbstractChar,
                 A::StridedVecOrMat{T}, x::StridedVector{T},

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -464,7 +464,7 @@ _fullstride2(A, f=identity) = f(stride(A, 2)) >= size(A, 1)
 # We specialize the function for certain StridedArray subtypes
 
 
-_fullstride2(A::StridedSubArrayStandard, ::typeof(abs)) = true
+_fullstride2(A::StridedArrayStdSubArray, ::typeof(abs)) = true
 _fullstride2(A::StridedArrayStdSubArrayIncr, ::typeof(identity)) = true
 
 Base.@constprop :aggressive function gemv!(y::StridedVector{T}, tA::AbstractChar,

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -647,12 +647,14 @@ end
 
 @testset "copytrito!" begin
     n = 10
-    A = rand(n, n)
-    for uplo in ('L', 'U')
-        B = zeros(n, n)
-        copytrito!(B, A, uplo)
-        C = uplo == 'L' ? tril(A) : triu(A)
-        @test B ≈ C
+    for A in (rand(n, n), rand(Int8, n, n)), uplo in ('L', 'U')
+        for AA in (A, view(A, reverse.(axes(A))...))
+            for B in (zeros(n, n), zeros(n+1, n+2))
+                copytrito!(B, AA, uplo)
+                C = uplo == 'L' ? tril(AA) : triu(AA)
+                @test view(B, 1:n, 1:n) == C
+            end
+        end
     end
     @testset "aliasing" begin
         M = Matrix(reshape(1:36, 6, 6))


### PR DESCRIPTION
For strided matrices that have a stride of `1` along the first dimension, and are of a `BlasFloat` `eltype`, we may forward `copytrito!` to `lacpy!`, as the latter is faster in general for large matrices.

The benchmark below is comparing the minimum runtimes for the two for various matrix sizes, using the script:
```julia
using LinearAlgebra
using BenchmarkTools
using PrettyTables

function timecopy(pr)
	copytrito_times = zeros(Float64, length(pr))
	lacpy_times = similar(copytrito_times)
	sizes = (2).^pr
	for (ind, n) in enumerate(sizes)
	   A = rand(n,n)
	   B = zeros(n,n)
	   bc = @benchmark copytrito!($B, $A, 'U')
	   bl = @benchmark LAPACK.lacpy!($B, $A, 'U')
	   copytrito_times[ind] = minimum(bc.times)/1e6
	   lacpy_times[ind] = minimum(bl.times)/1e6
	end
	ct = round.(copytrito_times, sigdigits=2)
	lt = round.(lacpy_times, sigdigits=2)
	ratio = round.(copytrito_times./lacpy_times, sigdigits=2)
	pretty_table(Number[sizes ct lt ratio],
		header=["Size", "copytrito", "lacpy", "Ratio"])
end
```

The runtimes are (in ms):
Using OpenBLAS
```julia
┌──────┬───────────┬────────┬───────┐
│ Size │ copytrito │  lacpy │ Ratio │
├──────┼───────────┼────────┼───────┤
│  128 │    0.0023 │ 0.0027 │  0.86 │
│  256 │    0.0086 │ 0.0094 │  0.91 │
│  512 │     0.071 │  0.077 │  0.92 │
│ 1024 │      0.47 │   0.35 │   1.3 │
│ 2048 │       2.4 │    1.8 │   1.3 │
│ 4096 │       9.8 │    7.2 │   1.4 │
│ 8192 │      39.0 │   28.0 │   1.4 │
└──────┴───────────┴────────┴───────┘
```

Using MKL
```julia
┌──────┬───────────┬────────┬───────┐
│ Size │ copytrito │  lacpy │ Ratio │
├──────┼───────────┼────────┼───────┤
│  128 │    0.0021 │ 0.0018 │   1.2 │
│  256 │    0.0088 │ 0.0057 │   1.5 │
│  512 │     0.071 │  0.026 │   2.7 │
│ 1024 │      0.49 │   0.21 │   2.3 │
│ 2048 │       2.4 │    1.6 │   1.5 │
│ 4096 │       9.7 │    6.3 │   1.5 │
│ 8192 │      39.0 │   26.0 │   1.5 │
└──────┴───────────┴────────┴───────┘
```

Calling `lacpy` also lowers the compilation latency by a bit:
```julia
julia> A = rand(4,4); B = zeros(size(A));

julia> @time copytrito!(B, A, 'U');
  0.059249 seconds (40.74 k allocations: 2.092 MiB, 99.94% compilation time) # nightly
  0.026956 seconds (24.68 k allocations: 1.185 MiB, 99.60% compilation time) # This PR
```

Overall, OpenBLAS is slower at matrix sizes below 1024x1024, although the performance is still comparable. The gains at higher sizes are significant, though.