### PR TITLE
Transpose triangular wrapper in Cholesky getproperty

### DIFF
--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -519,9 +519,17 @@ function getproperty(C::Cholesky, d::Symbol)
     Cfactors = getfield(C, :factors)
     Cuplo    = getfield(C, :uplo)
     if d === :U
-        return UpperTriangular(Cuplo === char_uplo(d) ? Cfactors : copy(Cfactors'))
+        if Cuplo === 'U'
+            return UpperTriangular(Cfactors)
+        else
+            return copy(LowerTriangular(Cfactors)')
+        end
     elseif d === :L
-        return LowerTriangular(Cuplo === char_uplo(d) ? Cfactors : copy(Cfactors'))
+        if Cuplo === 'L'
+            return LowerTriangular(Cfactors)
+        else
+            return copy(UpperTriangular(Cfactors)')
+        end
     elseif d === :UL
         return (Cuplo === 'U' ? UpperTriangular(Cfactors) : LowerTriangular(Cfactors))
     else

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -546,6 +546,15 @@ end
     @test det(B)  ≈  det(A) atol=eps()
     @test logdet(B)  ==  -Inf
     @test logabsdet(B)[1] == -Inf
- end
+end
+
+@testset "partly initialized factors" begin
+    @testset for uplo in ('U', 'L')
+        M = Matrix{BigFloat}(undef, 2, 2)
+        M[1,1] = M[2,2] = M[1+(uplo=='L'), 1+(uplo=='U')] = 3
+        C = Cholesky(M, uplo, 0)
+        @test C.L == C.U'
+    end
+end
 
 end # module TestCholesky


### PR DESCRIPTION
By swapping the sequence of operations from `UpperTriangular ∘ copy ∘ adjoint` to `copy ∘ adjoint ∘ LowerTriangular`, we ensure that only the structural indices corresponding to the lower triangular half are accessed. This should resolve the failure in https://github.com/JuliaLang/julia/pull/54473.

This also makes the operation faster, as only half the indices need to be copied:
```julia
julia> S = Symmetric(Matrix(Diagonal(rand(100))));

julia> C = cholesky(S);

julia> @btime $C.L;
  22.396 μs (3 allocations: 78.20 KiB) # nightly
  6.519 μs (3 allocations: 78.20 KiB) # This PR
```