### PR TITLE
clarify isdigit docs - ASCII digits only

### DIFF
--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -432,7 +432,7 @@ end
 """
     isdigit(c::AbstractChar) -> Bool
 
-Tests whether a character is a decimal digit (0-9).
+Tests whether a character is an ASCII decimal digit (`0`-`9`).
 
 See also: [`isletter`](@ref).
 


### PR DESCRIPTION
The `isdigit` function only checks for ASCII digits — this PR clarifies the docs to make that explicit.

See https://github.com/JuliaLang/julia/pull/54447#issuecomment-2108425286. Closes #54447.