### PR TITLE
Replace mul! by broadcasting in exp!

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -705,8 +705,8 @@ function exp!(A::StridedMatrix{T}) where T<:BlasFloat
         V = mul!(C[3]*P, true, C[1]*I, true, true) #V = C[1]*I + C[3]*P
         for k in 2:(div(length(C), 2) - 1)
             P *= A2
-            mul!(U, C[2k + 2], P, true, true) # U += C[2k+2]*P
-            mul!(V, C[2k + 1], P, true, true) # V += C[2k+1]*P
+            U .+= C[2k + 2] .* P
+            V .+= C[2k + 1] .* P
         end
 
         U = A * U


### PR DESCRIPTION
This reduces TTFX by a bit, by avoiding the `*ₛ` broadcast and inlining the result instead. This also makes the operation easier to read.
TTFX improvement:
```julia
julia> using LinearAlgebra

julia> A = rand(2,2);

julia> @time LinearAlgebra.exp!(A);
  3.536534 seconds (5.32 M allocations: 278.674 MiB, 8.06% gc time, 100.00% compilation time) # master
  3.132689 seconds (4.88 M allocations: 255.420 MiB, 1.93% gc time, 99.99% compilation time) # This PR
```