### PR TITLE
Make `deepcopy_internal` inferrable for BigInt and BigFloat

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -832,7 +832,7 @@ Base.add_with_overflow(a::BigInt, b::BigInt) = a + b, false
 Base.sub_with_overflow(a::BigInt, b::BigInt) = a - b, false
 Base.mul_with_overflow(a::BigInt, b::BigInt) = a * b, false
 
-Base.deepcopy_internal(x::BigInt, stackdict::IdDict) = get!(() -> MPZ.set(x), stackdict, x)
+Base.deepcopy_internal(x::BigInt, stackdict::IdDict) = get!(() -> MPZ.set(x), stackdict, x)::BigInt
 
 ## streamlined hashing for BigInt, by avoiding allocation from shifts ##
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -1199,7 +1199,7 @@ function Base.deepcopy_internal(x::BigFloat, stackdict::IdDict)
         y = _BigFloat(x.prec, x.sign, x.exp, d′)
         #ccall((:mpfr_custom_move,libmpfr), Cvoid, (Ref{BigFloat}, Ptr{Limb}), y, d) # unnecessary
         return y
-    end
+    end::BigFloat
 end
 
 function decompose(x::BigFloat)::Tuple{BigInt, Int, Int}

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -248,6 +248,11 @@ end
     @test (@inferred Base.deepcopy_internal(zeros(), IdDict())) == zeros()
 end
 
+@testset "deepcopy_internal big" begin
+    @inferred Base.deepcopy_internal(big(1), IdDict())
+    @inferred Base.deepcopy_internal(big(1.0), IdDict())
+end
+
 @testset "`copyto!`'s unaliasing" begin
     a = view([1:3;], :)
     @test copyto!(a, 2, a, 1, 2) == [1;1:2;]


### PR DESCRIPTION
I noticed this is not inferrable/typestable when looking at a `deepcopy_internal` implementation of one of my own types using JET.

```julia
deepcopy_internal(a::ResElem, dict::IdDict) =
   parent(a)(deepcopy_internal(data(a), dict))
```
`data(a)` is here a BigInt (and julia can infer this in 1.10), but the type of `deepcopy_internal(data(a), dict)` gets inferred as `Any`, thus leading to dynamic dispatch in the surrounding code.

This PR fixes this.