### PR TITLE
Implement isopen() for Base.Event

### DIFF
--- a/base/lock.jl
+++ b/base/lock.jl
@@ -484,7 +484,8 @@ end
 Create a level-triggered event source. Tasks that call [`wait`](@ref) on an
 `Event` are suspended and queued until [`notify`](@ref) is called on the `Event`.
 After `notify` is called, the `Event` remains in a signaled state and
-tasks will no longer block when waiting for it, until `reset` is called.
+tasks will no longer block when waiting for it, until `reset` is called. Use
+[`isopen`](@ref) to check whether it is currently un-signaled.
 
 If `autoreset` is true, at most one task will be released from `wait` for
 each call to `notify`.
@@ -496,6 +497,9 @@ This provides an acquire & release memory ordering on notify/wait.
 
 !!! compat "Julia 1.8"
     The `autoreset` functionality and memory ordering guarantee requires at least Julia 1.8.
+
+!!! compat "Julia 1.12"
+    `isopen(::Event)` requires at least Julia 1.12.
 """
 mutable struct Event
     const notify::ThreadSynchronizer
@@ -551,6 +555,8 @@ function reset(e::Event)
     @atomic e.set = false # full barrier
     nothing
 end
+
+isopen(e::Event) = !e.set
 
 @eval Threads begin
     import .Base: Event

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -484,8 +484,9 @@ end
 Create a level-triggered event source. Tasks that call [`wait`](@ref) on an
 `Event` are suspended and queued until [`notify`](@ref) is called on the `Event`.
 After `notify` is called, the `Event` remains in a signaled state and
-tasks will no longer block when waiting for it, until `reset` is called. Use
-[`isopen`](@ref) to check whether it is currently un-signaled.
+tasks will no longer block when waiting for it, until [`reset(::Event)`](@ref)
+is called. Use [`isopen`](@ref) to check if it can still be signaled without
+having to call [`reset(::Event)`](@ref).
 
 If `autoreset` is true, at most one task will be released from `wait` for
 each call to `notify`.
@@ -556,7 +557,7 @@ function reset(e::Event)
     nothing
 end
 
-isopen(e::Event) = !e.set
+isopen(e::Event) = e.autoreset || !e.set
 
 @eval Threads begin
     import .Base: Event

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -27,6 +27,13 @@ let lk = ReentrantLock()
     @test fetch(t1)
 end
 
+# Sanity test for events
+let e = Event()
+    @test isopen(e)
+    notify(e)
+    @test !isopen(e)
+end
+
 let e = Event(), started1 = Event(false), started2 = Event(false)
     for i = 1:3
         done1 = false


### PR DESCRIPTION
~~This is useful to know if the event is signaled or not without checking the `set` field~~, and it matches the API of `AsyncCondition` and `Timer`.