### PR TITLE
Make `deepcopy_internal` infer for locks and conditions

### DIFF
--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -157,7 +157,7 @@ end
 
 function deepcopy_internal(x::AbstractLock, stackdict::IdDict)
     if haskey(stackdict, x)
-        return stackdict[x]
+        return stackdict[x]::typeof(x)
     end
     y = typeof(x)()
     stackdict[x] = y
@@ -166,7 +166,7 @@ end
 
 function deepcopy_internal(x::GenericCondition, stackdict::IdDict)
     if haskey(stackdict, x)
-        return stackdict[x]
+        return stackdict[x]::typeof(x)
     end
     y = typeof(x)(deepcopy_internal(x.lock, stackdict))
     stackdict[x] = y

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -269,4 +269,6 @@ end
     @test a.lock !== b.lock
     @test islocked(a.lock)
     @test !islocked(b.lock)
+    @inferred deepcopy(a)
+    @inferred deepcopy(a.lock)
 end


### PR DESCRIPTION
Parallels #54496, cc @lgoettgens