### PR TITLE
fix `pow_fast(x, y)` for large integer `y`

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -281,11 +281,11 @@ exp10_fast(x::Union{Float32,Float64}) = Base.Math.exp10_fast(x)
 
 # builtins
 
-function pow_fast(x::Union{Float32,Float64}, y::Integer)
+function pow_fast(x::Float64, y::Integer)
     z = y % Int32
     z == y ? pow_fast(x, z) : x^y
 end
-pow_fast(x::Float32, y::Int32) = ccall("llvm.powi.f32.i32", llvmcall, Float32, (Float32, Int32), x, y)
+pow_fast(x::Float32, y::Integer) = x^y
 pow_fast(x::Float64, y::Int32) = ccall("llvm.powi.f64.i32", llvmcall, Float64, (Float64, Int32), x, y)
 pow_fast(x::FloatTypes, ::Val{p}) where {p} = pow_fast(x, p) # inlines already via llvm.powi
 @inline pow_fast(x, v::Val) = Base.literal_pow(^, x, v)

--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -281,8 +281,12 @@ exp10_fast(x::Union{Float32,Float64}) = Base.Math.exp10_fast(x)
 
 # builtins
 
-pow_fast(x::Float32, y::Integer) = ccall("llvm.powi.f32.i32", llvmcall, Float32, (Float32, Int32), x, y)
-pow_fast(x::Float64, y::Integer) = ccall("llvm.powi.f64.i32", llvmcall, Float64, (Float64, Int32), x, y)
+function pow_fast(x::Union{Float32,Float64}, y::Integer)
+    z = y % Int32
+    z == y ? pow_fast(x, z) : x^y
+end
+pow_fast(x::Float32, y::Int32) = ccall("llvm.powi.f32.i32", llvmcall, Float32, (Float32, Int32), x, y)
+pow_fast(x::Float64, y::Int32) = ccall("llvm.powi.f64.i32", llvmcall, Float64, (Float64, Int32), x, y)
 pow_fast(x::FloatTypes, ::Val{p}) where {p} = pow_fast(x, p) # inlines already via llvm.powi
 @inline pow_fast(x, v::Val) = Base.literal_pow(^, x, v)
 

--- a/test/fastmath.jl
+++ b/test/fastmath.jl
@@ -273,6 +273,12 @@ end
     end
     @test_throws MethodError @fastmath(^(2))
 end
+# issue #53857
+@testset "fast_pow" begin
+    n = 2^52
+    @test @fastmath (1 + 1 / n) ^ n ≈ ℯ
+    @test @fastmath (1 + 1 / n) ^ 4503599627370496 ≈ ℯ
+end
 
 @testset "sincos fall-backs" begin
     struct FloatWrapper

--- a/test/fastmath.jl
+++ b/test/fastmath.jl
@@ -275,7 +275,7 @@ end
 end
 # issue #53857
 @testset "fast_pow" begin
-    n = 2^52
+    n = Int64(2)^52
     @test @fastmath (1 + 1 / n) ^ n ≈ ℯ
     @test @fastmath (1 + 1 / n) ^ 4503599627370496 ≈ ℯ
 end


### PR DESCRIPTION
Fixes #53857

For `x::Union{Float32,Float64}` and `y::Integer` with `y % Int32 != y` a stack trace appears when calling `@fastmath x^y`.

This fix calls `x^y` in those cases, while leaving the other cases as is.