### PR TITLE
Ignore non-uplo half in `LAPACK.hetrd!` in `isfinite` check

### DIFF
--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -6274,7 +6274,6 @@ for (hetrd, elty) in
             require_one_based_indexing(A)
             chkstride1(A)
             n = checksquare(A)
-            chkuplo(uplo)
             chkuplofinite(A, uplo) # balancing routines don't support NaNs and Infs
             tau = similar(A, $elty, max(0,n - 1))
             d = Vector{$relty}(undef, n)

--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -6275,7 +6275,7 @@ for (hetrd, elty) in
             chkstride1(A)
             n = checksquare(A)
             chkuplo(uplo)
-            chkfinite(A) # balancing routines don't support NaNs and Infs
+            chkuplofinite(A, uplo) # balancing routines don't support NaNs and Infs
             tau = similar(A, $elty, max(0,n - 1))
             d = Vector{$relty}(undef, n)
             e = Vector{$relty}(undef, max(0,n - 1))

--- a/stdlib/LinearAlgebra/test/lapack.jl
+++ b/stdlib/LinearAlgebra/test/lapack.jl
@@ -861,4 +861,14 @@ a = zeros(2,0), zeros(0)
     @test_throws DimensionMismatch LinearAlgebra.LAPACK.getrs!('N', A, ipiv, b)
 end
 
+@testset "hetrd ignore non-filled half" begin
+    A = rand(3,3)
+    B = copy(A)
+    B[2,1] = NaN
+    B[3,1] = Inf
+    LAPACK.hetrd!('U', A)
+    LAPACK.hetrd!('U', B)
+    @test UpperTriangular(A) == UpperTriangular(B)
+end
+
 end # module TestLAPACK


### PR DESCRIPTION
The non-`uplo` triangular half is not accessed in the LAPACK call, so the values in that half shouldn't matter, even if these are not finite.

A happy coincidence is that this also makes the check 2x faster.