### PR TITLE
Aggressive constprop in norm

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -666,7 +666,7 @@ julia> norm(hcat(v,v), Inf) == norm(vcat(v,v), Inf) != norm([v,v], Inf)
 true
 ```
 """
-function norm(itr, p::Real=2)
+Base.@constprop :aggressive function norm(itr, p::Real=2)
     isempty(itr) && return float(norm(zero(eltype(itr))))
     if p == 2
         return norm2(itr)


### PR DESCRIPTION
This helps reduce TTFX by not compiling the unused branches.

On nightly,
```julia
julia> using LinearAlgebra

julia> A = rand(2,2);

julia> @time norm(A);
  0.445819 seconds (341.96 k allocations: 17.589 MiB, 38.80% gc time, 99.99% compilation time) # v"1.12.0-DEV.558"
  0.162979 seconds (341.23 k allocations: 17.554 MiB, 99.98% compilation time) # This PR
```