### PR TITLE
allow up to 5 max methods for `ntuple`

### DIFF
--- a/base/ntuple.jl
+++ b/base/ntuple.jl
@@ -75,6 +75,7 @@ julia> ntuple(i -> 2*i, Val(4))
         Tuple(f(i) for i = 1:N)
     end
 end
+typeof(function ntuple end).name.max_methods = UInt8(5)
 
 @inline function fill_to_length(t::Tuple, val, ::Val{_N}) where {_N}
     M = length(t)

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -654,6 +654,8 @@ end
 
     f() = Base.setindex((1:1, 2:2, 3:3), 9, 1)
     @test @inferred(f()) == (9, 2:2, 3:3)
+
+    @test Base.return_types(Base.setindex, Tuple{Tuple,Nothing,Int}) == [Tuple]
 end
 
 @testset "inferable range indexing with constant values" begin


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/54462