### PR TITLE
Copy parent to dest in general in copyto! for triangular

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -524,7 +524,11 @@ function copyto!(dest::StridedMatrix, U::UpperOrLowerTriangular)
     return dest
 end
 function _copyto!(dest::StridedMatrix, U::UpperOrLowerTriangular)
-    copytrito!(dest, parent(U), U isa UpperOrUnitUpperTriangular ? 'U' : 'L')
+    if haszero(eltype(dest)) # we may use zero for the eltype in triu!/tril!
+        copytrito!(dest, parent(U), U isa UpperOrUnitUpperTriangular ? 'U' : 'L')
+    else # we will need to index into dest to obtain the zero elements, so ensure that it is fully initialized
+        copyto!(dest, parent(U))
+    end
     _triangularize!(U)(dest)
     if U isa Union{UnitUpperTriangular, UnitLowerTriangular}
         dest[diagind(dest)] .= @view U[diagind(U, IndexCartesian())]

--- a/stdlib/LinearAlgebra/test/special.jl
+++ b/stdlib/LinearAlgebra/test/special.jl
@@ -128,6 +128,14 @@ Random.seed!(1)
         for M in (D, Bu, Bl, Tri, Sym)
             @test Matrix(M) == zeros(TypeWithZero, 3, 3)
         end
+
+        mutable struct MTypeWithZero end
+        Base.convert(::Type{MTypeWithZero}, ::TypeWithoutZero) = MTypeWithZero()
+        Base.zero(x::Union{TypeWithoutZero, MTypeWithZero}) = zero(typeof(x))
+        Base.zero(::Type{<:Union{TypeWithoutZero, MTypeWithZero}}) = MTypeWithZero()
+        U = UpperTriangular(Symmetric(fill(TypeWithoutZero(), 2, 2)))
+        M = Matrix{MTypeWithZero}(U)
+        @test all(==(MTypeWithZero()), M)
     end
 end
 

--- a/stdlib/LinearAlgebra/test/special.jl
+++ b/stdlib/LinearAlgebra/test/special.jl
@@ -135,7 +135,7 @@ Random.seed!(1)
         Base.zero(::Type{<:Union{TypeWithoutZero, MTypeWithZero}}) = MTypeWithZero()
         U = UpperTriangular(Symmetric(fill(TypeWithoutZero(), 2, 2)))
         M = Matrix{MTypeWithZero}(U)
-        @test all(==(MTypeWithZero()), M)
+        @test all(x -> x isa MTypeWithZero, M)
     end
 end
 

--- a/stdlib/LinearAlgebra/test/special.jl
+++ b/stdlib/LinearAlgebra/test/special.jl
@@ -131,8 +131,9 @@ Random.seed!(1)
 
         mutable struct MTypeWithZero end
         Base.convert(::Type{MTypeWithZero}, ::TypeWithoutZero) = MTypeWithZero()
-        Base.zero(x::Union{TypeWithoutZero, MTypeWithZero}) = zero(typeof(x))
-        Base.zero(::Type{<:Union{TypeWithoutZero, MTypeWithZero}}) = MTypeWithZero()
+        Base.convert(::Type{MTypeWithZero}, ::TypeWithZero) = MTypeWithZero()
+        Base.zero(x::MTypeWithZero) = zero(typeof(x))
+        Base.zero(::Type{MTypeWithZero}) = MTypeWithZero()
         U = UpperTriangular(Symmetric(fill(TypeWithoutZero(), 2, 2)))
         M = Matrix{MTypeWithZero}(U)
         @test all(x -> x isa MTypeWithZero, M)


### PR DESCRIPTION
This resolves the issue described in https://github.com/JuliaLang/julia/pull/52730#issuecomment-2121460220.

After this, there are two `copytrito!` passes over the two triangular halves of the matrices. This should work in general, as it doesn't make assumptions about the `eltype` of `dest`.

With this,
```julia
julia> using JuMP, LinearAlgebra

julia> model = Model();

julia> @variable(model, x[1:2, 1:2], Symmetric)
2×2 Symmetric{VariableRef, Matrix{VariableRef}}:
 x[1,1]  x[1,2]
 x[1,2]  x[2,2]

julia> Matrix(UpperTriangular(x))
2×2 Matrix{AffExpr}:
 x[1,1]  x[1,2]
 0       x[2,2]
```

cc @odow 