### PR TITLE
Minor improvement to inference of `ntuple`

### DIFF
--- a/base/ntuple.jl
+++ b/base/ntuple.jl
@@ -72,7 +72,7 @@ julia> ntuple(i -> 2*i, Val(4))
     if @generated
         :(@ntuple $N i -> f(i))
     else
-        Tuple(f(i) for i = 1:N)
+        Tuple(f(i) for i = 1:(N::Int))
     end
 end
 typeof(function ntuple end).name.max_methods = UInt8(5)

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -532,6 +532,8 @@ end
     for n = 0:15
         @test ntuple(identity, Val(n)) == ntuple(identity, n)
     end
+
+    @test Core.Compiler.return_type(ntuple, Tuple{typeof(identity), Val}) == Tuple{Vararg{Int}}
 end
 
 struct A_15703{N}


### PR DESCRIPTION
In the non-`@generated` branch, where `N` may be unknown, assert its type as `Int` so that the type of the created range can be inferred.

```julia
julia> Core.Compiler.return_type(ntuple, Tuple{typeof(identity), Val})
Tuple                # master
Tuple{Vararg{Int64}} # PR
```

Unfortunately, if the function argument could not be inferred concretely, inference is still sub-optimal:
```julia
julia> code_typed(Tuple{Any, Int}) do x, n
           ntuple(i -> (x; i), Val(n))
       end
1-element Vector{Any}:
 CodeInfo(
1 ── %1  = Core.typeof(x)::DataType
│    %2  = Core.apply_type(Main.:(var"#26#28"), %1)::Type{var"#26#28"{_A}} where _A
│    %3  = %new(%2, x)::var"#26#28"
│    %4  = Core.apply_type(Base.Val, n)::Type{Val{_A}} where _A
│    %5  = %new(%4)::Val
│    %6  = (isa)(%5, Val{3})::Bool
└───       goto #3 if not %6
2 ──       goto #10
3 ── %9  = (isa)(%5, Val{2})::Bool
└───       goto #5 if not %9
4 ──       goto #10
5 ── %12 = (isa)(%5, Val{1})::Bool
└───       goto #7 if not %12
6 ──       goto #10
7 ── %15 = (isa)(%5, Val{0})::Bool
└───       goto #9 if not %15
8 ──       goto #10
9 ── %18 = Main.ntuple(%3, %5)::Tuple
└───       goto #10
10 ┄ %20 = φ (#2 => (1, 2, 3), #4 => (1, 2), #6 => (1,), #8 => (), #9 => %18)::Tuple
└───       return %20
) => Tuple
```
Here, the inferred type of the closure is abstract as the type of the captured variable is unknown, but its return type can still be inferred, as witnessed for the small-`N` special cases. But for the general-`N` case, the return type is lost for some reason.

A further improvement to inference precision would be to replace `Tuple(f(i) for i = 1:(N::Int))` with `((f(i) for i = 1:(N::Int))...,)`, but for statically unknown `N`, that has worse run-time performance characteristics AFAICT. I therefore stayed with the safer, minimally-invasive change here.