### PR TITLE
Fixes for bitcast bugs with LLVM 17 / opaque pointers

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -640,7 +640,9 @@ static jl_cgval_t generic_bitcast(jl_codectx_t &ctx, ArrayRef<jl_cgval_t> argv)
                 setName(ctx.emission_context, vx, "bitcast_coercion");
         } else {
             vx = emit_bitcast(ctx, vx, llvmt);
-            setName(ctx.emission_context, vx, "bitcast_coercion");
+            if (isa<Instruction>(vx) && !vx->hasName())
+                // emit_bitcast may undo another bitcast
+                setName(ctx.emission_context, vx, "bitcast_coercion");
         }
     }
 


### PR DESCRIPTION
Fixes an assertion encountered in the wild. I still think we shouldn't be adding checks like that all over the place and just have `setName` bail out, as it's hard to predict when operations will be folded.

Also fixes https://github.com/JuliaLang/julia/issues/54549; we were using `emit_bitcast` which preserves the _source_ address space, while `bitcast(LLVMPtr{T,A}, ptr)` should most definitely respect the _target_ address space.

The added test covers both issues.