### PR TITLE
Split generic_matmul for strided matrices into two halves

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -573,6 +573,8 @@ wrapper_char(A::Hermitian) =  WrapperChar('H', A.uplo == 'U')
 wrapper_char(A::Hermitian{<:Real}) = WrapperChar('S', A.uplo == 'U')
 wrapper_char(A::Symmetric) = WrapperChar('S', A.uplo == 'U')
 
+isNTC(A::AbstractArray) = uppercase(wrapper_char(A)) in ('N', 'T', 'C')
+
 Base.@constprop :aggressive function wrap(A::AbstractVecOrMat, tA::AbstractChar)
     # merge the result of this before return, so that we can type-assert the return such
     # that even if the tmerge is inaccurate, inference can still identify that the

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -573,7 +573,9 @@ wrapper_char(A::Hermitian) =  WrapperChar('H', A.uplo == 'U')
 wrapper_char(A::Hermitian{<:Real}) = WrapperChar('S', A.uplo == 'U')
 wrapper_char(A::Symmetric) = WrapperChar('S', A.uplo == 'U')
 
-isNTC(A::AbstractArray) = uppercase(wrapper_char(A)) in ('N', 'T', 'C')
+wrapper_char_NTC(A::AbstractArray) = uppercase(wrapper_char(A)) == 'N'
+wrapper_char_NTC(A::Union{StridedArray, Adjoint, Transpose}) = true
+wrapper_char_NTC(A::Union{Symmetric, Hermitian}) = false
 
 Base.@constprop :aggressive function wrap(A::AbstractVecOrMat, tA::AbstractChar)
     # merge the result of this before return, so that we can type-assert the return such

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -293,14 +293,23 @@ true
 @inline mul!(C::AbstractMatrix, A::AbstractVecOrMat, B::AbstractVecOrMat, α::Number, β::Number) = _mul!(C, A, B, α, β)
 # Add a level of indirection and specialize _mul! to avoid ambiguities in mul!
 @inline _mul!(C::AbstractMatrix, A::AbstractVecOrMat, B::AbstractVecOrMat, α::Number, β::Number) =
-    generic_matmatmul!(
+    generic_matmatmul_wrapper!(
         C,
         wrapper_char(A),
         wrapper_char(B),
         _unwrap(A),
         _unwrap(B),
-        α, β
+        α, β,
+        Val(isNTC(A) & isNTC(B))
     )
+
+# this indirection allows is to specialize on the types of the wrappers of A and B to some extent,
+# even though the wrappers are stripped off in mul!
+# By default, we ignore the wrapper info and forward the arguments to generic_matmatmul!
+Base.@constprop :aggressive function generic_matmatmul_wrapper!(C, tA, tB, A, B, α, β, @nospecialize(val))
+    generic_matmatmul!(C, tA, tB, A, B, α, β)
+end
+
 
 """
     rmul!(A, B)
@@ -368,9 +377,9 @@ julia> lmul!(F.Q, B)
 """
 lmul!(A, B)
 
-# THE one big BLAS dispatch
-Base.@constprop :aggressive function generic_matmatmul!(C::StridedMatrix{T}, tA, tB, A::StridedVecOrMat{T}, B::StridedVecOrMat{T},
-                                    α::Number, β::Number) where {T<:BlasFloat}
+# THE one big BLAS dispatch. This is split into two methods to improve latency
+Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedMatrix{T}, tA, tB, A::StridedVecOrMat{T}, B::StridedVecOrMat{T},
+                                    α::Number, β::Number, ::Val{true}) where {T<:BlasFloat}
     mA, nA = lapack_size(tA, A)
     mB, nB = lapack_size(tB, B)
     if any(iszero, size(A)) || any(iszero, size(B)) || iszero(α)
@@ -389,19 +398,37 @@ Base.@constprop :aggressive function generic_matmatmul!(C::StridedMatrix{T}, tA,
     # and extract the char corresponding to the wrapper type
     tA_uc, tB_uc = uppercase(tA), uppercase(tB)
     # the map in all ensures constprop by acting on tA and tB individually, instead of looping over them.
-    if all(map(in(('N', 'T', 'C')), (tA_uc, tB_uc)))
-        if tA_uc == 'T' && tB_uc == 'N' && A === B
-            return syrk_wrapper!(C, 'T', A, α, β)
-        elseif tA_uc == 'N' && tB_uc == 'T' && A === B
-            return syrk_wrapper!(C, 'N', A, α, β)
-        elseif tA_uc == 'C' && tB_uc == 'N' && A === B
-            return herk_wrapper!(C, 'C', A, α, β)
-        elseif tA_uc == 'N' && tB_uc == 'C' && A === B
-            return herk_wrapper!(C, 'N', A, α, β)
-        else
-            return gemm_wrapper!(C, tA, tB, A, B, α, β)
-        end
+    if tA_uc == 'T' && tB_uc == 'N' && A === B
+        return syrk_wrapper!(C, 'T', A, α, β)
+    elseif tA_uc == 'N' && tB_uc == 'T' && A === B
+        return syrk_wrapper!(C, 'N', A, α, β)
+    elseif tA_uc == 'C' && tB_uc == 'N' && A === B
+        return herk_wrapper!(C, 'C', A, α, β)
+    elseif tA_uc == 'N' && tB_uc == 'C' && A === B
+        return herk_wrapper!(C, 'N', A, α, β)
+    else
+        return gemm_wrapper!(C, tA, tB, A, B, α, β)
     end
+end
+Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedMatrix{T}, tA, tB, A::StridedVecOrMat{T}, B::StridedVecOrMat{T},
+                                    α::Number, β::Number, ::Val{false}) where {T<:BlasFloat}
+    mA, nA = lapack_size(tA, A)
+    mB, nB = lapack_size(tB, B)
+    if any(iszero, size(A)) || any(iszero, size(B)) || iszero(α)
+        if size(C) != (mA, nB)
+            throw(DimensionMismatch(lazy"C has dimensions $(size(C)), should have ($mA,$nB)"))
+        end
+        return _rmul_or_fill!(C, β)
+    end
+    if size(C) == size(A) == size(B) == (2,2)
+        return matmul2x2!(C, tA, tB, A, B, α, β)
+    end
+    if size(C) == size(A) == size(B) == (3,3)
+        return matmul3x3!(C, tA, tB, A, B, α, β)
+    end
+    # We convert the chars to uppercase to potentially unwrap a WrapperChar,
+    # and extract the char corresponding to the wrapper type
+    tA_uc, tB_uc = uppercase(tA), uppercase(tB)
     alpha, beta = promote(α, β, zero(T))
     if alpha isa Union{Bool,T} && beta isa Union{Bool,T}
         if tA_uc == 'S' && tB_uc == 'N'
@@ -421,18 +448,13 @@ Base.@constprop :aggressive generic_matmatmul!(C::StridedMatrix{T}, tA, tB, A::S
         _add::MulAddMul = MulAddMul()) where {T<:BlasFloat} =
     generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
 
-# Complex matrix times (transposed) real matrix. Reinterpret the first matrix to real for efficiency.
-Base.@constprop :aggressive function generic_matmatmul!(C::StridedVecOrMat{Complex{T}}, tA, tB, A::StridedVecOrMat{Complex{T}}, B::StridedVecOrMat{T},
-                    α::Number, β::Number) where {T<:BlasReal}
-    # We convert the chars to uppercase to potentially unwrap a WrapperChar,
-    # and extract the char corresponding to the wrapper type
-    tA_uc, tB_uc = uppercase(tA), uppercase(tB)
-    # the map in all ensures constprop by acting on tA and tB individually, instead of looping over them.
-    if all(map(in(('N', 'T', 'C')), (tA_uc, tB_uc)))
-        gemm_wrapper!(C, tA, tB, A, B, α, β)
-    else
-        _generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), MulAddMul(α, β))
-    end
+Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedVecOrMat{Complex{T}}, tA, tB, A::StridedVecOrMat{Complex{T}}, B::StridedVecOrMat{T},
+                    α::Number, β::Number, ::Val{true}) where {T<:BlasReal}
+    gemm_wrapper!(C, tA, tB, A, B, α, β)
+end
+Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedVecOrMat{Complex{T}}, tA, tB, A::StridedVecOrMat{Complex{T}}, B::StridedVecOrMat{T},
+                    α::Number, β::Number, ::Val{false}) where {T<:BlasReal}
+    _generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), MulAddMul(α, β))
 end
 # legacy method
 Base.@constprop :aggressive generic_matmatmul!(C::StridedVecOrMat{Complex{T}}, tA, tB, A::StridedVecOrMat{Complex{T}}, B::StridedVecOrMat{T},

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -448,7 +448,7 @@ Base.@constprop :aggressive generic_matmatmul!(C::StridedMatrix{T}, tA, tB, A::S
         _add::MulAddMul = MulAddMul()) where {T<:BlasFloat} =
     generic_matmatmul!(C, tA, tB, A, B, _add.alpha, _add.beta)
 
-Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedVecOrMat{Complex{T}}, tA, tB, A::StridedVecOrMat{Complex{T}}, B::StridedVecOrMat{T},
+function generic_matmatmul_wrapper!(C::StridedVecOrMat{Complex{T}}, tA, tB, A::StridedVecOrMat{Complex{T}}, B::StridedVecOrMat{T},
                     α::Number, β::Number, ::Val{true}) where {T<:BlasReal}
     gemm_wrapper!(C, tA, tB, A, B, α, β)
 end

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -300,7 +300,7 @@ true
         _unwrap(A),
         _unwrap(B),
         α, β,
-        Val(isNTC(A) & isNTC(B))
+        Val(wrapper_char_NTC(A) & wrapper_char_NTC(B))
     )
 
 # this indirection allows is to specialize on the types of the wrappers of A and B to some extent,


### PR DESCRIPTION
Splitting the large method into two appears to reduce the TTFX for both the methods, and shifts part of the latency to the other call.

First, the TTFX results (each call in a separate session):
```julia
julia> using LinearAlgebra

julia> A = rand(2,2);

julia> @time A * A;
  0.826312 seconds (2.29 M allocations: 117.527 MiB, 2.01% gc time, 99.96% compilation time) # nightly v"1.12.0-DEV.575"
  0.597563 seconds (1.06 M allocations: 54.232 MiB, 2.67% gc time, 99.94% compilation time) # This PR

julia> @time A * Symmetric(B);
  1.023856 seconds (2.63 M allocations: 133.677 MiB, 1.46% gc time, 99.98% compilation time) # nightly
  0.842010 seconds (2.37 M allocations: 120.082 MiB, 3.26% gc time, 98.59% compilation time) # This PR
```

As expected, the PR shifts some of the latency to the second call if both the paths are taken:
On nightly (this time, running both the calls in the same session):
```julia
julia> using LinearAlgebra

julia> A = rand(2,2);

julia> @time A * A;
  0.826312 seconds (2.29 M allocations: 117.527 MiB, 2.01% gc time, 99.96% compilation time)

julia> B = rand(2,2);

julia> @time A * Symmetric(B);
  0.343180 seconds (634.63 k allocations: 32.043 MiB, 99.96% compilation time)
```
vs this PR
```julia
julia> @time A * A;
  0.597563 seconds (1.06 M allocations: 54.232 MiB, 2.67% gc time, 99.94% compilation time)

julia> @time A * Symmetric(B);
  0.485075 seconds (1.71 M allocations: 87.530 MiB, 3.76% gc time, 99.97% compilation time)
```
The total seems roughly the same, although each individual TTFX is improved.

Now the motivation: I noticed that even though the `_generic_matmatmul!` path on line 417 in `generic_matmatmul!` is unreachable for `A * B`, this was still contributing to the latency. Removing the line speeds up the call, even though it is dead code. I'm not certain why this is the case (perhaps a combination of constant-propagation and type-inference time, before the path is inferred to be unreachable?). I would appreciate some insight into this.

Since matrix multiplication is ubiquitous in `LinearAlgebra`, this will reduce latency elsewhere as well, e.g.:
```julia
julia> @time sin(A);
  3.665069 seconds (7.38 M allocations: 381.982 MiB, 6.74% gc time, 99.80% compilation time) # nightly
  3.012707 seconds (5.02 M allocations: 259.484 MiB, 1.79% gc time, 99.75% compilation time) # this PR
```

That being said, it would be great to understand where the real benefit arises from.

Also, runtimes appear unaffected for reasonably sized matrices, as this would be dominated by the LAPACK calls in any case.