### PR TITLE
Add `ScopedValues` to export list for Base

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -11,6 +11,7 @@ export
     Iterators,
     Broadcast,
     MathConstants,
+    ScopedValues,
 
 # Types
     AbstractChannel,


### PR DESCRIPTION
This will allow users to type `ScopedValues.with` without having to do a `using` or `import`. (As can be done for `Iterators.take` and `Threads.nthreads`, etc.)

This needs to be backported to 1.11, in my opinion.