### PR TITLE
Tweak malloc_stack on OpenBSD to match other implementations; explain lack of guard page

### DIFF
--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -56,7 +56,7 @@ static void *malloc_stack(size_t bufsz) JL_NOTSAFEPOINT
     void* stk = mmap(0, bufsz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
     if (stk == MAP_FAILED)
         return MAP_FAILED;
-    jl_atomic_fetch_add(&num_stack_mappings, 1);
+    jl_atomic_fetch_add_relaxed(&num_stack_mappings, 1);
     return stk;
 }
 # else

--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -32,11 +32,14 @@ static void *malloc_stack(size_t bufsz) JL_NOTSAFEPOINT
     void *stk = VirtualAlloc(NULL, bufsz, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
     if (stk == NULL)
         return MAP_FAILED;
+
+    // set up a guard page to detect stack overflow
     DWORD dwOldProtect;
     if (!VirtualProtect(stk, jl_guard_size, PAGE_READWRITE | PAGE_GUARD, &dwOldProtect)) {
         VirtualFree(stk, 0, MEM_RELEASE);
         return MAP_FAILED;
     }
+
     jl_atomic_fetch_add_relaxed(&num_stack_mappings, 1);
     return stk;
 }
@@ -56,6 +59,13 @@ static void *malloc_stack(size_t bufsz) JL_NOTSAFEPOINT
     void* stk = mmap(0, bufsz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
     if (stk == MAP_FAILED)
         return MAP_FAILED;
+
+    // we don't set up a guard page to detect stack overflow: on OpenBSD, any
+    // mmap-ed region has guard page managed by the kernel, so there is no
+    // need for it. Additionally, a memory region used as stack (memory
+    // allocated with MAP_STACK option) has strict permission, and you can't
+    // "create" a guard page on such memory by using `mprotect` on it
+
     jl_atomic_fetch_add_relaxed(&num_stack_mappings, 1);
     return stk;
 }
@@ -65,13 +75,15 @@ static void *malloc_stack(size_t bufsz) JL_NOTSAFEPOINT
     void* stk = mmap(0, bufsz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (stk == MAP_FAILED)
         return MAP_FAILED;
+
 #if !defined(JL_HAVE_UCONTEXT) && !defined(JL_HAVE_SIGALTSTACK)
-    // setup a guard page to detect stack overflow
+    // set up a guard page to detect stack overflow
     if (mprotect(stk, jl_guard_size, PROT_NONE) == -1) {
         munmap(stk, bufsz);
         return MAP_FAILED;
     }
 #endif
+
     jl_atomic_fetch_add_relaxed(&num_stack_mappings, 1);
     return stk;
 }


### PR DESCRIPTION
The other malloc_stack implementations were switched to using jl_atomic_fetch_add_relaxed on 2024-02-23. I suspect that this simply overlapped in time with the creation of the OpenBSD patches, which were submitted in March, but presumably work started before that :-).

CC @semarie please check that I am not messing up something for you.

Also, while at it, I noticed that the OpenBSD `malloc_stack` is missing the `mprotect` for setting up a guard page, which concerns me a bit. Is there a deeper reason for this omission?