### PR TITLE
compact: Don't attempt to amend basic block 0

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1018,7 +1018,8 @@ function did_just_finish_bb(compact)
     result_idx = compact.result_idx
     result_bbs = compact.cfg_transform.result_bbs
     (compact.active_result_bb == length(result_bbs) + 1) ||
-    result_idx == first(result_bbs[compact.active_result_bb].stmts)
+    (result_idx == first(result_bbs[compact.active_result_bb].stmts) &&
+     compact.active_result_bb != 1)
 end
 
 function maybe_reopen_bb!(compact)

--- a/test/compiler/compact.jl
+++ b/test/compiler/compact.jl
@@ -35,3 +35,17 @@ end
     verify_ir(new_ir)
     @test length(new_ir.cfg.blocks) == 1
 end
+
+# Test reverse affinity insert at start of compact
+@testset "IncrementalCompact reverse affinity insert" begin
+    ir = only(Base.code_ircode(foo_test_function, (Int,)))[1]
+    compact = IncrementalCompact(ir)
+    @test !Core.Compiler.did_just_finish_bb(compact)
+
+    insert_node_here!(compact, NewInstruction(ReturnNode(1), Union{}, ir[SSAValue(1)][:line]), true)
+    new_ir = finish(compact)
+    # TODO: Should IncrementalCompact be doing this internally?
+    empty!(new_ir.cfg.blocks[1].succs)
+    verify_ir(new_ir)
+    @test length(new_ir.cfg.blocks) == 1
+end


### PR DESCRIPTION
This allows insert_node_here! with reverse affinity at the start of the first basic block, which is a bit of a corner case, but no reason for it to be disallowed.