### PR TITLE
Remove unused `JL_HAVE_SIGALTSTACK` code

### DIFF
--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -31,7 +31,6 @@ JL_DLLEXPORT int8_t jl_threadpoolid(int16_t tid) JL_NOTSAFEPOINT;
 // JL_HAVE_ASM && JL_HAVE_UNW_CONTEXT -- libunwind-based
 // JL_HAVE_UNW_CONTEXT -- libunwind-based
 // JL_HAVE_UCONTEXT -- posix standard API, requires syscall for resume
-// JL_HAVE_SIGALTSTACK -- requires several syscall for start, setjmp for resume
 
 #ifdef _OS_WINDOWS_
 #define JL_HAVE_UCONTEXT
@@ -53,8 +52,7 @@ typedef struct {
 } jl_stack_context_t;
 #if !defined(JL_HAVE_UCONTEXT) && \
     !defined(JL_HAVE_ASM) && \
-    !defined(JL_HAVE_UNW_CONTEXT) && \
-    !defined(JL_HAVE_SIGALTSTACK)
+    !defined(JL_HAVE_UNW_CONTEXT)
 #if (defined(_CPU_X86_64_) || defined(_CPU_X86_) || defined(_CPU_AARCH64_) ||  \
      defined(_CPU_ARM_) || defined(_CPU_PPC64_))
 #define JL_HAVE_ASM
@@ -70,7 +68,7 @@ typedef struct {
 #endif
 #endif
 
-#if (!defined(JL_HAVE_UNW_CONTEXT) && defined(JL_HAVE_ASM)) || defined(JL_HAVE_SIGALTSTACK)
+#if !defined(JL_HAVE_UNW_CONTEXT) && defined(JL_HAVE_ASM)
 typedef jl_stack_context_t _jl_ucontext_t;
 #endif
 #pragma GCC visibility push(default)

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -1151,8 +1151,6 @@ static void jl_rec_backtrace(jl_task_t *t) JL_NOTSAFEPOINT
       #pragma message("jl_rec_backtrace not defined for ASM/SETJMP on unknown system")
       (void)c;
      #endif
-#elif defined(JL_HAVE_SIGALTSTACK)
-     #pragma message("jl_rec_backtrace not defined for SIGALTSTACK")
 #else
      #pragma message("jl_rec_backtrace not defined for unknown task system")
 #endif


### PR DESCRIPTION
Nothing is ever activating this, and it probably hasn't been tested in a while.

As far as I can tell, this code path was added by @vtjnash in 082d7d2544e8e080d5f260c94d093480ee72e360

I have no particular beef with this code other than "it complicates the thread / task logic, so dealing with this requires understanding one more moving part, removing it makes it simpler". If it is decided that this code should rather be kept, "just in case" (which, though), that's equally fine by me. Thought perhaps a comment could be added explaining the motivation for keeping it even thought it is currently always disabled?