### PR TITLE
Various fixes to byte / bytearray search

### DIFF
--- a/base/char.jl
+++ b/base/char.jl
@@ -223,6 +223,7 @@ hash(x::Char, h::UInt) =
     hash_uint64(((bitcast(UInt32, x) + UInt64(0xd4d64234)) << 32) ⊻ UInt64(h))
 
 first_utf8_byte(c::Char) = (bitcast(UInt32, c) >> 24) % UInt8
+first_utf8_byte(c::AbstractChar) = first_utf8_byte(Char(c)::Char)
 
 # fallbacks:
 isless(x::AbstractChar, y::AbstractChar) = isless(Char(x), Char(y))

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -61,8 +61,6 @@ const DenseBytes = Union{
     CodeUnits{UInt8, <:Union{String, SubString{String}}},
 }
 
-const ByteArray = Union{DenseBytes, DenseArrayType{Int8}}
-
 function findfirst(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:Union{UInt8, Int8}}, a::Union{DenseInt8, DenseUInt8})
     findnext(pred, a, firstindex(a))
 end

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -31,16 +31,6 @@ const DenseUInt8 = Union{
 
 const DenseUInt8OrInt8 = Union{DenseUInt8, DenseInt8}
 
-function last_utf8_byte(c::Char)
-    u = reinterpret(UInt32, c)
-    shift = ((4 - ncodeunits(c)) * 8) & 31
-    (u >> shift) % UInt8
-end
-
-# Whether the given byte is guaranteed to be the only byte in a Char
-# This holds even in the presence of invalid UTF8
-is_standalone_byte(x::UInt8) = (x < 0x80) | (x > 0xf7)
-
 last_byteindex(x::Union{String, SubString{String}}) = ncodeunits(x)
 last_byteindex(x::DenseUInt8OrInt8) = lastindex(x)
 
@@ -144,9 +134,8 @@ function _rsearch(a::Union{String,SubString{String},DenseUInt8OrInt8}, b::Union{
     fst = firstindex(a)
     lst = last_byteindex(a)
     if i < fst
-        return i == 0 ? nothing : throw(BoundsError(a, i))
+        return i == fst - 1 ? nothing : throw(BoundsError(a, i))
     end
-    n_bytes = lst - i + 1
     if i > lst
         return i == lst+1 ? nothing : throw(BoundsError(a, i))
     end

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -33,6 +33,9 @@ const DenseUInt8OrInt8 = Union{DenseUInt8, DenseInt8}
 
 nothing_sentinel(i) = i == 0 ? nothing : i
 
+n_bytes_of(x::Union{String, SubString{String}}) = ncodeunits(x)
+n_bytes_of(x::DenseUInt8OrInt8) = length(x)
+
 function findnext(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:AbstractChar},
                   s::Union{String, SubString{String}}, i::Integer)
     if i < 1 || i > sizeof(s)
@@ -78,11 +81,11 @@ findfirst(::typeof(iszero), a::DenseUInt8OrInt8) = nothing_sentinel(_search(a, z
 findnext(::typeof(iszero), a::DenseUInt8OrInt8, i::Integer) = nothing_sentinel(_search(a, zero(UInt8), i))
 
 function _search(a::Union{String,SubString{String},DenseUInt8OrInt8}, b::Union{Int8,UInt8}, i::Integer = 1)
-    @boundscheck if i < 1
+    if i < 1
         throw(BoundsError(a, i))
     end
-    n = sizeof(a)
-    @boundscheck if i > n
+    n = n_bytes_of(a)
+    if i > n
         return i == n+1 ? 0 : throw(BoundsError(a, i))
     end
     GC.@preserve a begin
@@ -129,11 +132,11 @@ end
 findlast(::typeof(iszero), a::DenseUInt8OrInt8) = nothing_sentinel(_rsearch(a, zero(UInt8)))
 findprev(::typeof(iszero), a::DenseUInt8OrInt8, i::Integer) = nothing_sentinel(_rsearch(a, zero(UInt8), i))
 
-function _rsearch(a::Union{String,SubString{String},DenseUInt8OrInt8}, b::Union{Int8,UInt8}, i::Integer = sizeof(a))
+function _rsearch(a::Union{String,SubString{String},DenseUInt8OrInt8}, b::Union{Int8,UInt8}, i::Integer = n_bytes_of(a))
     if i < 1
         return i == 0 ? 0 : throw(BoundsError(a, i))
     end
-    n = sizeof(a)
+    n = n_bytes_of(a)
     if i > n
         return i == n+1 ? 0 : throw(BoundsError(a, i))
     end

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -146,7 +146,7 @@ function _rsearch(a::Union{String,SubString{String},DenseUInt8OrInt8}, b::Union{
     end
     GC.@preserve a begin
         p = pointer(a)
-        q = ccall(:memrchr, Ptr{UInt8}, (Ptr{UInt8}, Int32, Csize_t), p, b, i-fst)
+        q = ccall(:memrchr, Ptr{UInt8}, (Ptr{UInt8}, Int32, Csize_t), p, b, i-fst+1)
     end
     return q == C_NULL ? 0 : (q-p+fst) % Int
 end

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -388,7 +388,7 @@ julia> findnext('o', "Hello to the world", 6)
 findnext(ch::AbstractChar, string::AbstractString, start::Integer) =
     findnext(==(ch), string, start)
 
-    """
+"""
     findnext(pattern::AbstractVector{<:Union{Int8,UInt8}},
              A::AbstractVector{<:Union{Int8,UInt8}},
              start::Integer)
@@ -430,7 +430,7 @@ julia> findfirst("Julia", "JuliaLang")
 findlast(pattern::AbstractString, string::AbstractString) =
     findprev(pattern, string, lastindex(string))
 
-    """
+"""
     findlast(pattern::AbstractVector{<:Union{Int8,UInt8}},
              A::AbstractVector{<:Union{Int8,UInt8}})
 
@@ -510,10 +510,9 @@ julia> findall(UInt8[1,2], UInt8[1,2,3,1,2])
 !!! compat "Julia 1.3"
      This method requires at least Julia 1.3.
 """
-
-function findall(t::Union{AbstractString, AbstractPattern, AbstractVector{T}},
-                 s::Union{AbstractString, AbstractPattern, AbstractVector{T}},
-                 ; overlap::Bool=false) where T <: Union{Int8, UInt8}
+function findall(t::Union{AbstractString, AbstractPattern, AbstractVector{UInt8}},
+                 s::Union{AbstractString, AbstractPattern, AbstractVector{UInt8}},
+                 ; overlap::Bool=false)
     found = UnitRange{Int}[]
     i, e = firstindex(s), lastindex(s)
     while true
@@ -703,7 +702,7 @@ julia> findprev('o', "Hello to the world", 18)
 findprev(ch::AbstractChar, string::AbstractString, start::Integer) =
     findprev(==(ch), string, start)
 
-    """
+"""
     findprev(pattern::AbstractVector{<:Union{Int8,UInt8}},
              A::AbstractVector{<:Union{Int8,UInt8}},
              start::Integer)
@@ -723,7 +722,6 @@ findprev(pattern::AbstractVector{<:Union{Int8,UInt8}},
          A::AbstractVector{<:Union{Int8,UInt8}},
          start::Integer) =
     _rsearch(A, pattern, start)
-
 """
     occursin(needle::Union{AbstractString,AbstractPattern,AbstractChar}, haystack::AbstractString)
 

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -45,7 +45,7 @@ function findnext(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:AbstractChar}
     while true
         i = _search(s, first_utf8_byte(c), i)
         i == 0 && return nothing
-        pred(s[i]) && return i
+        isvalid(s, i) && pred(s[i]) && return i
         i = nextind(s, i)
     end
 end
@@ -108,7 +108,7 @@ function findprev(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:AbstractChar}
     while true
         i = _rsearch(s, b, i)
         i == 0 && return nothing
-        pred(s[i]) && return i
+        isvalid(s, i) && pred(s[i]) && return i
         i = prevind(s, i)
     end
 end

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -15,18 +15,18 @@ abstract type AbstractPattern end
 # This deserves a better solution - see #53178.
 # If such a better solution comes in place, these unions should be replaced.
 const DenseInt8 = Union{
-    <:DenseArray{Int8},
-    <:FastContiguousSubArray{Int8,N,<:DenseArray} where N
+    DenseArray{Int8},
+    FastContiguousSubArray{Int8,N,<:DenseArray} where N
 }
 
 # Note: This union is different from that above in that it includes CodeUnits.
 # Currently, this is redundant as CodeUnits <: DenseVector, but this subtyping
 # is buggy and may be removed in the future, see #54002
 const DenseUInt8 = Union{
-    <:DenseArray{UInt8},
-    <:FastContiguousSubArray{UInt8,N,<:DenseArray} where N,
+    DenseArray{UInt8},
+    FastContiguousSubArray{UInt8,N,<:DenseArray} where N,
     CodeUnits{UInt8, <:Union{String, SubString{String}}},
-    <:FastContiguousSubArray{UInt8,N,<:CodeUnits{UInt8, <:Union{String, SubString{String}}}} where N,
+    FastContiguousSubArray{UInt8,N,<:CodeUnits{UInt8, <:Union{String, SubString{String}}}} where N,
 }
 
 const DenseUInt8OrInt8 = Union{DenseUInt8, DenseInt8}

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -462,6 +462,7 @@ end
 
 @testset "DenseArray with offsets" begin
     isdefined(Main, :OffsetDenseArrays) || @eval Main include("../testhelpers/OffsetDenseArrays.jl")
+    OffsetDenseArrays = Main.OffsetDenseArrays
 
     A = OffsetDenseArrays.OffsetDenseArray(collect(0x61:0x69), 100)
     @test findfirst(==(0x61), A) == 101

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -461,7 +461,7 @@ end
 end
 
 @testset "DenseArray with offsets" begin
-    isdefined(Main, :OffsetDenseArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "OffsetDenseArrays.jl"))
+    isdefined(Main, :OffsetDenseArrays) || @eval Main include("testhelpers/OffsetDenseArrays.jl")
 
     A = OffsetDenseArrays.OffsetDenseArray(collect(0x61:0x69), 100)
     @test findfirst(==(0x61), A) == 101

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -429,6 +429,9 @@ end
             @test_throws BoundsError findprev(pattern, A, -3)
         end
     end
+
+    @test findall([0x01, 0x02], [0x03, 0x01, 0x02, 0x01, 0x02, 0x06]) == [2:3, 4:5]
+    @test isempty(findall([0x04, 0x05], [0x03, 0x04, 0x06]))
 end
 
 # Issue 54578

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -460,6 +460,25 @@ end
     @test isnothing(findprev(UInt8[0xff, 0xfe], Int8[1, 9, 2, -1, -2, 3], 6))
 end
 
+@testset "DenseArray with offsets" begin
+    isdefined(Main, :OffsetDenseArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "OffsetDenseArrays.jl"))
+
+    A = OffsetDenseArrays.OffsetDenseArray(collect(0x61:0x69), 100)
+    @test findfirst(==(0x61), A) == 101
+    @test findlast(==(0x61), A) == 101
+    @test findfirst(==(0x00), A) === nothing
+
+    @test findfirst([0x62, 0x63, 0x64], A) == 102:104
+    @test findlast([0x63, 0x64], A) == 103:104
+    @test findall([0x62, 0x63], A) == [102:103]
+
+    @test findfirst(iszero, A) === nothing
+    A = OffsetDenseArrays.OffsetDenseArray([0x01, 0x02, 0x00, 0x03], -100)
+    @test findfirst(iszero, A) == -97
+    @test findnext(==(0x02), A, -99) == -98
+    @test findnext(==(0x02), A, -97) === nothing
+end
+
 # issue 32568
 for T = (UInt, BigInt)
     for x = (4, 5)

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -461,7 +461,7 @@ end
 end
 
 @testset "DenseArray with offsets" begin
-    isdefined(Main, :OffsetDenseArrays) || @eval Main include("testhelpers/OffsetDenseArrays.jl")
+    isdefined(Main, :OffsetDenseArrays) || @eval Main include("../testhelpers/OffsetDenseArrays.jl")
 
     A = OffsetDenseArrays.OffsetDenseArray(collect(0x61:0x69), 100)
     @test findfirst(==(0x61), A) == 101

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -155,6 +155,16 @@ for str in [u8str]
     @test findprev(isequal('ε'), str, 4) == nothing
 end
 
+# See the comments in #54579
+@testset "Search for invalid chars" begin
+    @test findfirst(==('\xff'), "abc\xffde") == 4
+    @test findprev(isequal('\xa6'), "abc\xa69", 5) == 4
+    @test isnothing(findfirst(==('\xff'), "abcdeæd"))
+
+    @test isnothing(findnext(==('\xa6'), "æ", 1))
+    @test isnothing(findprev(==('\xa6'), "æa", 2))
+end
+
 # string forward search with a single-char string
 @test findfirst("x", astr) == nothing
 @test findfirst("H", astr) == 1:1

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -429,6 +429,13 @@ end
             @test_throws BoundsError findprev(pattern, A, -3)
         end
     end
+
+    @test_throws InexactError findfirst(==(UInt8(-1)), [0xff])
+    @test_throws InexactError findnext(==(UInt8(-1)), [0xff], 1)
+    @test_throws InexactError findprev(==(UInt8(-1)), [0xff], 1)
+    @test_throws InexactError findfirst([UInt8(-1)], [0xff])
+    @test_throws InexactError findnext([UInt8(-1)], [0xff], 1)
+    @test_throws InexactError findprev([UInt8(-1)], Union{UInt8, Int8}[0xff], 1)
 end
 
 # issue 32568

--- a/test/testhelpers/OffsetDenseArrays.jl
+++ b/test/testhelpers/OffsetDenseArrays.jl
@@ -1,0 +1,31 @@
+"""
+    module OffsetDenseArrays
+
+A minimal implementation of an offset array which is also <: DenseArray.
+"""
+module OffsetDenseArrays
+
+struct OffsetDenseArray{A <: DenseVector, T} <: DenseVector{T}
+    x::A
+    offset::Int
+end
+OffsetDenseArray(x::AbstractVector{T}, i::Integer) where {T} = OffsetDenseArray{typeof(x), T}(x, Int(i))
+
+Base.size(x::OffsetDenseArray) = size(x.x)
+Base.pointer(x::OffsetDenseArray) = pointer(x.x)
+
+function Base.getindex(x::OffsetDenseArray, i::Integer)
+    @boundscheck checkbounds(x.x, i - x.offset)
+    x.x[i - x.offset]
+end
+
+function Base.setindex(x::OffsetDenseArray, v, i::Integer)
+    @boundscheck checkbounds(x.x, i - x.offset)
+    x.x[i - x.offset] = v
+end
+
+IndexStyle(::Type{<:OffsetDenseArray}) = Base.IndexLinear()
+Base.axes(x::OffsetDenseArray) = (x.offset + 1 : x.offset + length(x.x),)
+Base.keys(x::OffsetDenseArray) = only(axes(x))
+
+end # module


### PR DESCRIPTION
This was originally intended as a targeted fix to #54578, but I ran into a bunch of smaller issues with this code that also needed to be solved and it turned out to be difficult to fix them with small, trivial PRs.

I would also like to refactor this whole file, but I want these correctness fixes to be merged first, because a larger refactoring has higher risk of getting stuck without getting reviewed and merged.

## Larger things that needs decisions
* The internal union `Base.ByteArray` has been deleted. Instead, the unions `DenseInt8` and `DenseUInt8` have been added. These more comprehensively cover the types that was meant, e.g. `Memory{UInt8}` was incorrectly not covered by the former. As stated in the TODO, the concept of a "memory backed dense byte array" is needed throughout Julia, so this ideally needs to be implemented as a single type and used throughout Base. The fix here is a decent temporary solution. See #53178 #54581
* The `findall` docstring between two arrays was incorrectly not attached to the method - now it is. **Note that this change _changes_ the documentation** since it includes a docstring that was previously missed. Hence, it's an API addition.
* Added a new minimal `testhelpers/OffsetDenseArrays.jl` which provide a `DenseVector` with offset axes for testing purposes.

## Trivial fixes
* `findfirst(==(Int8(-1)), [0xff])` and similar findlast, findnext and findprev is no longer buggy, see #54578
* `findfirst([0x0ff], Int8[-1])` is similarly no longer buggy, see #54578
* `findnext(==('\xa6'), "æ", 1)` and `findprev(==('\xa6'), "æa", 2)` no longer incorrectly throws an error
* The byte-oriented find* functions now work correctly with offset arrays
* Fixed incorrect use of `GC.@preserve`, where the pointer was taken before the preserve block.
* More of the optimised string methods now also apply to `SubString{String}`


Closes #54578