### PR TITLE
[backport] v1.11: mark Lockable as `public` and update NEWS.md for Lockable not being exported

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -60,7 +60,7 @@ Multi-threading changes
 -----------------------
 
 * `Threads.@threads` now supports the `:greedy` scheduler, intended for non-uniform workloads ([#52096]).
-* A new exported struct `Lockable{T, L<:AbstractLock}` makes it easy to bundle a resource and its lock together ([#52898]).
+* A new unexported struct `Lockable{T, L<:AbstractLock}` makes it easy to bundle a resource and its lock together ([#52898]).
 
 New library functions
 ---------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -60,7 +60,7 @@ Multi-threading changes
 -----------------------
 
 * `Threads.@threads` now supports the `:greedy` scheduler, intended for non-uniform workloads ([#52096]).
-* A new unexported struct `Lockable{T, L<:AbstractLock}` makes it easy to bundle a resource and its lock together ([#52898]).
+* A new public (but unexported) struct `Base.Lockable{T, L<:AbstractLock}` makes it easy to bundle a resource and its lock together ([#52898]).
 
 New library functions
 ---------------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1090,6 +1090,7 @@ public
     Fix2,
     Generator,
     ImmutableDict,
+    Lockable,
     OneTo,
     LogRange,
     AnnotatedString,


### PR DESCRIPTION
In https://github.com/JuliaLang/julia/pull/52898 we originally intended to export Lockable, but noticed it caused some clashes in the ecosystem. We decided to not export it and merge, with the intent to mark it exported later, which left the NEWS.md out-of-date (as noticed by @jakobnissen).

I think it may be too late for v1.11 to make it exported, so this PR updates the NEWS.md and marks it public.

(see https://github.com/JuliaLang/julia/pull/54595 for a companion to PR to master)