### PR TITLE
Add optimised findall(isequal(::Char), ::String)

### DIFF
--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -12,6 +12,12 @@ abstract type AbstractPattern end
 
 nothing_sentinel(i) = i == 0 ? nothing : i
 
+function last_utf8_byte(c::Char)
+    u = reinterpret(UInt32, c)
+    shift = ((4 - ncodeunits(c)) * 8) & 31
+    (u >> shift) % UInt8
+end
+
 function findnext(pred::Fix2{<:Union{typeof(isequal),typeof(==)},<:AbstractChar},
                   s::Union{String, SubString{String}}, i::Integer)
     if i < 1 || i > sizeof(s)
@@ -107,22 +113,27 @@ function findall(
     s::Union{String, SubString{String}}
 )
     c = Char(pred.x)::Char
-    byte = first_utf8_byte(c)
+    byte = last_utf8_byte(c)
+    ncu = ncodeunits(c)
 
-    # ASCII chars can never be part of another Char, even in the presence of
-    # invalid UTF8 strings, so we can forward to a simpler, more efficient
-    # byte search
-    isascii(c) && return findall(==(byte), codeunits(s))
+    # If only one byte: Forward to memchr
+    ncu == 1 && return findall(==(byte), codeunits(s))
     result = Int[]
     i = firstindex(s)
     while true
         i = _search(s, byte, i)
         iszero(i) && return result
+        i += 1
+        index = i - ncu
         # If the char is invalid, it's possible that its first byte is
         # inside another char. If so, indexing into the string will throw an
-        # error, so we need to check for valid indices
-        isvalid(s, i) && pred(s[i]) && push!(result, i)
-        i += 1
+        # error, so we need to check for valid indices.
+        isvalid(s, index) || continue
+        # We use iterate here instead of indexing, because indexing wastefully
+        # checks for valid index. It would be better if there was something like
+        # try_getindex(::String, ::Int) we could use.
+        char = first(something(iterate(s, index)))
+        pred(char) && push!(result, index) 
     end
 end
 

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -133,7 +133,7 @@ function findall(
         # checks for valid index. It would be better if there was something like
         # try_getindex(::String, ::Int) we could use.
         char = first(something(iterate(s, index)))
-        pred(char) && push!(result, index) 
+        pred(char) && push!(result, index)
     end
 end
 

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -404,8 +404,8 @@ end
     @test isempty(findall(isequal('K'), ""))
     @test isempty(findall(isequal('α'), ""))
 
-    # Finds an invalid char ONLY if it's at a char boundrary in the string,
-    # i.e. iterating the string would emit char character.
+    # Finds an invalid char ONLY if it's at a char boundary in the string,
+    # i.e. iterating the string would emit the given char.
     findall(==('\xfe'), "abκæøc\xfeα\xfeβå!") == [10, 13]
     findall(==('\xaf'), "abκæ读α\xe8\xaf\xfeβå!") == Int[]
 end

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -395,6 +395,21 @@ s_18109 = "fooα🐨βcd3"
     @test findall("aa", "aaaaaa", overlap=true) == [1:2, 2:3, 3:4, 4:5, 5:6]
 end
 
+@testset "Findall char in string" begin
+    @test findall(==('w'), "wabcwewwawk") == [1, 5, 7, 8, 10]
+    @test isempty(findall(isequal("w"), "abcde!,"))
+    @test findall(==('读'), "联国读大会一九四二月十读日第号决通过并颁布读") == [7, 34, 64]
+
+    # Empty string
+    @test isempty(findall(isequal('K'), ""))
+    @test isempty(findall(isequal('α'), ""))
+
+    # Finds an invalid char ONLY if it's at a char boundrary in the string,
+    # i.e. iterating the string would emit char character.
+    findall(==('\xfe'), "abκæøc\xfeα\xfeβå!") == [10, 13]
+    findall(==('\xaf'), "abκæ读α\xe8\xaf\xfeβå!") == Int[]
+end
+
 # issue 37280
 @testset "UInt8, Int8 vector" begin
     for T in [Int8, UInt8], VT in [Int8, UInt8]

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -406,8 +406,9 @@ end
 
     # Finds an invalid char ONLY if it's at a char boundary in the string,
     # i.e. iterating the string would emit the given char.
-    findall(==('\xfe'), "abκæøc\xfeα\xfeβå!") == [10, 13]
-    findall(==('\xaf'), "abκæ读α\xe8\xaf\xfeβå!") == Int[]
+    @test findall(==('\xfe'), "abκæøc\xfeα\xfeβå!") == [10, 13]
+    @test isempty(findall(==('\xaf'), "abκæ读α\xe8\xaf\xfeβå!"))
+    @test isempty(findall(==('\xc3'), ";æ"))
 end
 
 # issue 37280


### PR DESCRIPTION
This uses the same approach as the existing findnext and findprev functions in the same file.

The following benchmark:
```julia
using BenchmarkTools
s = join(rand('A':'z', 10000));
@btime findall(==('c'), s);
```
Gives these results:
* This PR: 3.489 μs
* 1.11-beta1: 31.970 μs