### PR TITLE
Switch to Pkg mode prompt immediately and load Pkg in the background

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1250,7 +1250,9 @@ function setup_interface(
                             transition(s, pkg_mode) do
                                 LineEdit.state(s, pkg_mode).input_buffer = buf
                             end
-                            @invokelatest(LineEdit.check_for_hint(s)) && @invokelatest(LineEdit.refresh_line(s))
+                            if !isempty(s)
+                                @invokelatest(LineEdit.check_for_hint(s)) && @invokelatest(LineEdit.refresh_line(s))
+                            end
                             transition_finished = true
                         end
                     end

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1252,9 +1252,11 @@ function setup_interface(
                 Base.errormonitor(t_replswitch)
                 # while loading just accept all keys, no keymap functionality
                 while !istaskdone(t_replswitch)
-                    c = read(stdin, Char)
-                    istaskdone(t_replswitch) && break
-                    edit_insert(s, c)
+                    # wait but only take if task is still running
+                    peek(stdin, Char)
+                    if !istaskdone(t_replswitch)
+                        edit_insert(s, read(stdin, Char))
+                    end
                 end
             else
                 edit_insert(s, ']')

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1080,9 +1080,6 @@ setup_interface(
     extra_repl_keymap::Any = repl.options.extra_keymap
 ) = setup_interface(repl, hascolor, extra_repl_keymap)
 
-# we have to grab this after Pkg is loaded so cache it
-pkg_mode::Union{Nothing,LineEdit.Prompt} = nothing
-
 # This non keyword method can be precompiled which is important
 function setup_interface(
     repl::LineEditREPL,
@@ -1228,41 +1225,40 @@ function setup_interface(
         end,
         ']' => function (s::MIState,o...)
             if isempty(s) || position(LineEdit.buffer(s)) == 0
-                global pkg_mode
-                if pkg_mode === nothing
-                    LineEdit.clear_line(LineEdit.terminal(s))
-                    # use 6 .'s here because its the same width as the most likely `@v1.xx` env name
-                    print(LineEdit.terminal(s), styled"{blue,bold:({gray:......}) pkg> }")
-                    # spawn Pkg load to avoid blocking typing during loading. Typing will block if only 1 thread
-                    t_replswitch = Threads.@spawn begin
-                        pkgid = Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg")
-                        REPLExt = Base.require_stdlib(pkgid, "REPLExt")
-                        if REPLExt isa Module && isdefined(REPLExt, :PkgCompletionProvider)
-                            for mode in repl.interface.modes
-                                if mode isa LineEdit.Prompt && mode.complete isa REPLExt.PkgCompletionProvider
-                                    pkg_mode = mode
-                                    break
-                                end
-                            end
-                        end
-                        if pkg_mode !== nothing
-                            buf = copy(LineEdit.buffer(s))
-                            transition(s, pkg_mode) do
-                                LineEdit.state(s, pkg_mode).input_buffer = buf
+                # print a dummy pkg prompt while Pkg loads
+                LineEdit.clear_line(LineEdit.terminal(s))
+                # use 6 .'s here because its the same width as the most likely `@v1.xx` env name
+                print(LineEdit.terminal(s), styled"{blue,bold:({gray:......}) pkg> }")
+                pkg_mode = nothing
+                # spawn Pkg load to avoid blocking typing during loading. Typing will block if only 1 thread
+                t_replswitch = Threads.@spawn begin
+                    pkgid = Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg")
+                    REPLExt = Base.require_stdlib(pkgid, "REPLExt")
+                    if REPLExt isa Module && isdefined(REPLExt, :PkgCompletionProvider)
+                        for mode in repl.interface.modes
+                            if mode isa LineEdit.Prompt && mode.complete isa REPLExt.PkgCompletionProvider
+                                pkg_mode = mode
+                                break
                             end
                         end
                     end
-                    Base.errormonitor(t_replswitch)
-                    # while loading just accept all keys, no keymap functionality
-                    while !istaskdone(t_replswitch)
-                        c = read(stdin, Char)
-                        istaskdone(t_replswitch) && break
-                        edit_insert(s, c)
+                    if pkg_mode !== nothing
+                        buf = copy(LineEdit.buffer(s))
+                        transition(s, pkg_mode) do
+                            LineEdit.state(s, pkg_mode).input_buffer = buf
+                        end
                     end
-                    return
                 end
+                Base.errormonitor(t_replswitch)
+                # while loading just accept all keys, no keymap functionality
+                while !istaskdone(t_replswitch)
+                    c = read(stdin, Char)
+                    istaskdone(t_replswitch) && break
+                    edit_insert(s, c)
+                end
+            else
+                edit_insert(s, ']')
             end
-            edit_insert(s, ']')
         end,
 
         # Bracketed Paste Mode

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1247,6 +1247,7 @@ function setup_interface(
                         transition(s, pkg_mode) do
                             LineEdit.state(s, pkg_mode).input_buffer = buf
                         end
+                        @invokelatest(LineEdit.check_for_hint(s)) && @invokelatest(LineEdit.refresh_line(s))
                     end
                 end
                 Base.errormonitor(t_replswitch)

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -220,4 +220,14 @@ end
 generate_precompile_statements()
 
 precompile(Tuple{typeof(getproperty), REPL.REPLBackend, Symbol})
+
+# Helps Pkg repl mode switch
+precompile(Tuple{typeof(REPL.Terminals.clear_line), REPL.Terminals.TTYTerminal})
+precompile(Tuple{typeof(Base.print), REPL.Terminals.TTYTerminal, Base.AnnotatedString{String}})
+precompile(Tuple{typeof(Base.peek), Base.TTY, Type{Char}})
+precompile(Tuple{typeof(Base.similar), Array{String, 1}})
+precompile(Tuple{typeof(Base.Iterators.enumerate), Array{String, 1}})
+precompile(Tuple{typeof(Base.setindex!), Array{String, 1}, String, Int64})
+precompile(Tuple{typeof(Base.convert), Type{Base.Dict{String, Union{Array{String, 1}, String}}}, Base.Dict{String, Any}})
+
 end # Precompile


### PR DESCRIPTION
Because Pkg is now a pkgimage and can load slowly on slower machines, which is a bit frustrating in the repl.

This makes the repl immediately switch to a dummy prompt that looks like Pkg mode to allow the user to keep typing while Pkg loads. During which the keymap is disabled.

It works best if julia has >1 thread, otherwise typing stalls during Pkg load.
Side note, it might make sense if by default julia in interactive mode started with at least `-t1,1`.

If Pkg takes longer to load than the user to type the command and press return, then the UX isn't great as it won't do anything.

Opening as a draft as the threading limitation is a bit awkward, and there may be a better approach to achieve the same UX.



https://github.com/JuliaLang/julia/assets/1694067/1bf17323-441a-4db2-8a3b-4d571eac622f


