### PR TITLE
add back a function people tend to use in the logging code

### DIFF
--- a/stdlib/Logging/src/Logging.jl
+++ b/stdlib/Logging/src/Logging.jl
@@ -70,6 +70,9 @@ const AboveMaxLevel = Base.CoreLogging.AboveMaxLevel
 using Base.CoreLogging:
     closed_stream, ConsoleLogger, default_metafmt
 
+# Some packages use `Logging.default_logcolor`
+const default_logcolor = Base.CoreLogging.default_logcolor
+
 export
     AbstractLogger,
     LogLevel,


### PR DESCRIPTION
Apparently, people use this function so let's put it back to reduce unnecessary breakage. This was moved in https://github.com/JuliaLang/julia/pull/54428.