### PR TITLE
REPLCompletions: allow completions for explicitly `using`-ed names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -108,6 +108,9 @@ Standard library changes
 
 #### REPL
 
+- Using the new `usings=true` feature of the `names()` function, REPL completions can now
+  complete names that have been explicitly `using`-ed. ([#54610])
+
 #### SuiteSparse
 
 #### SparseArrays

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -120,6 +120,7 @@ let ex = quote
         kwtest5(a::Char, b; xyz) = pass
 
         const named = (; len2=3)
+        const fmsoebelkv = (; len2=3)
 
         array = [1, 1]
         varfloat = 0.1
@@ -2129,7 +2130,7 @@ end
 end
 
 # issue #51194
-for (s, compl) in (("2*CompletionFoo.nam", "named"),
+for (s, compl) in (("2*CompletionFoo.fmsoe", "fmsoebelkv"),
                    (":a isa CompletionFoo.test!1", "test!12"),
                    ("-CompletionFoo.Test_y(3).", "yy"),
                    ("99 ⨷⁻ᵨ⁷ CompletionFoo.type_test.", "xx"),
@@ -2138,8 +2139,11 @@ for (s, compl) in (("2*CompletionFoo.nam", "named"),
                    ("CompletionFoo.type_test + CompletionFoo.unicode_αβγ.", "yy"),
                    ("(CompletionFoo.type_test + CompletionFoo.unicode_αβγ).", "xx"),
                    ("foo'CompletionFoo.test!1", "test!12"))
-    c, r = test_complete(s)
-    @test only(c) == compl
+    @testset let s=s, compl=compl
+        c, r = test_complete_noshift(s)
+        @test length(c) == 1
+        @test only(c) == compl
+    end
 end
 
 # allows symbol completion within incomplete :macrocall
@@ -2259,4 +2263,48 @@ let s = "Issue53126()."
     c, r, res = test_complete_context(s)
     @test res
     @test isempty(c)
+end
+
+# complete explicitly `using`ed names
+baremodule TestExplicitUsing
+using Base: @assume_effects
+end # baremodule TestExplicitUsing
+let s = "@assu"
+    c, r, res = test_complete_context(s, TestExplicitUsing)
+    @test res
+    @test "@assume_effects" in c
+end
+let s = "TestExplicitUsing.@assu"
+    c, r, res = test_complete_context(s)
+    @test res
+    @test "@assume_effects" in c
+end
+baremodule TestExplicitUsingNegative end
+let s = "@assu"
+    c, r, res = test_complete_context(s, TestExplicitUsingNegative)
+    @test res
+    @test "@assume_effects" ∉ c
+end
+let s = "TestExplicitUsingNegative.@assu"
+    c, r, res = test_complete_context(s)
+    @test res
+    @test "@assume_effects" ∉ c
+end
+# should complete implicitly `using`ed names
+module TestImplicitUsing end
+let s = "@asse"
+    c, r, res = test_complete_context(s, TestImplicitUsing)
+    @test res
+    @test "@assert" in c
+end
+let s = "TestImplicitUsing.@asse"
+    c, r, res = test_complete_context(s)
+    @test res
+    @test "@assert" in c
+end
+# JuliaLang/julia#53999
+let s = "using Base.Thre"
+    c, r, res = test_complete_context(s)
+    @test res
+    @test "Threads" in c
 end


### PR DESCRIPTION
The new feature `usings=true` added to `names` enhances REPL completions by allowing explicitly `using`-ed names to be found.
```julia
julia> using Base: @assume_effects

julia> @assu| # completes to `@assume_effects`
```

As a result, the implementation of REPL completions has been simplified. Additionally, it allows completion for names that are implicitly or explicitly `using`-ed in code specifying a module explicitly, such as:
```julia
julia> module A end

julia> A.signi| # completes to `A.significand`
```

- fixes #29275
- fixes #40356
- fixes #49109
- fixes #53524
- ~~fixes #53999~~