### PR TITLE
[backport] v1.11: mark Lockable as `public` and update NEWS.md for Lockable not being exported (again)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -60,7 +60,7 @@ Multi-threading changes
 -----------------------
 
 * `Threads.@threads` now supports the `:greedy` scheduler, intended for non-uniform workloads ([#52096]).
-* A new exported struct `Lockable{T, L<:AbstractLock}` makes it easy to bundle a resource and its lock together ([#52898]).
+* A new unexported struct `Lockable{T, L<:AbstractLock}` makes it easy to bundle a resource and its lock together ([#52898]).
 
 New library functions
 ---------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -60,7 +60,7 @@ Multi-threading changes
 -----------------------
 
 * `Threads.@threads` now supports the `:greedy` scheduler, intended for non-uniform workloads ([#52096]).
-* A new unexported struct `Lockable{T, L<:AbstractLock}` makes it easy to bundle a resource and its lock together ([#52898]).
+* A new public (but unexported) struct `Base.Lockable{T, L<:AbstractLock}` makes it easy to bundle a resource and its lock together ([#52898]).
 
 New library functions
 ---------------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1090,6 +1090,7 @@ public
     Fix2,
     Generator,
     ImmutableDict,
+    Lockable,
     OneTo,
     LogRange,
     AnnotatedString,


### PR DESCRIPTION
revival of #54590