### PR TITLE
rename `variable` used in `inbounds` to avoid accidental collisions due to macro hygiene bug

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -861,9 +861,9 @@ end
 macro inbounds(blk)
     return Expr(:block,
         Expr(:inbounds, true),
-        Expr(:local, Expr(:(=), :val, esc(blk))),
+        Expr(:local, Expr(:(=), :val_49f6338b, esc(blk))),
         Expr(:inbounds, :pop),
-        :val)
+        :val_49f6338b)
 end
 
 """

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -2123,3 +2123,17 @@ end
     @test one(Mat([1 2; 3 4])) == Mat([1 0; 0 1])
     @test one(Mat([1 2; 3 4])) isa Mat
 end
+
+
+macro foo_54417(x,i)
+    quote
+        val = $x
+        @inbounds $x[$i]
+        val
+    end
+end
+
+@testset "inbounds hygien confusion" begin
+    z = [1,2,3]
+    @test (@foo_54417 z 1) == z
+end

--- a/test/depot/logs/manifest_usage.toml
+++ b/test/depot/logs/manifest_usage.toml
@@ -1,0 +1,5 @@
+[["/home/kc/julia/test/project/Manifest.toml"]]
+time = 2024-04-03T10:54:36.548Z
+
+[["/home/kc/julia/test/project/ProjectPath/Manifest.toml"]]
+time = 2024-04-03T10:55:25.343Z

--- a/test/depot/logs/manifest_usage.toml
+++ b/test/depot/logs/manifest_usage.toml
@@ -1,5 +1,0 @@
-[["/home/kc/julia/test/project/Manifest.toml"]]
-time = 2024-04-03T10:54:36.548Z
-
-[["/home/kc/julia/test/project/ProjectPath/Manifest.toml"]]
-time = 2024-04-03T10:55:25.343Z


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/54417