### PR TITLE
Avoid concatenating LazyString in setindex! for triangular matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -246,14 +246,20 @@ Base.isstored(A::UpperTriangular, i::Int, j::Int) =
 @propagate_inbounds getindex(A::UpperTriangular, i::Int, j::Int) =
     i <= j ? A.data[i,j] : _zero(A.data,j,i)
 
-Base._reverse(A::UpperOrUnitUpperTriangular, dims::Integer) = reverse!(Matrix(A); dims)
-Base._reverse(A::UpperTriangular, ::Colon) = LowerTriangular(reverse(A.data))
-Base._reverse(A::UnitUpperTriangular, ::Colon) = UnitLowerTriangular(reverse(A.data))
+@noinline function throw_nonzeroerror(T, @nospecialize(x), i, j)
+    _upper_lower_str(::Type{<:UpperOrUnitUpperTriangular}) = "upper"
+    _upper_lower_str(::Type{<:LowerOrUnitLowerTriangular}) = "lower"
+    throw(ArgumentError(LazyString("cannot set index in the ", _upper_lower_str(T), " triangular part",
+            lazy"($i, $j) of an $(nameof(T)) matrix to a nonzero value ($x)")))
+end
+@noinline function throw_nononeerror(T, @nospecialize(x), i, j)
+    throw(ArgumentError(LazyString("cannot set index on the diagonal",
+            lazy"($i, $j) of an $(nameof(T)) matrix to a non-unit value ($x)")))
+end
 
 @propagate_inbounds function setindex!(A::UpperTriangular, x, i::Integer, j::Integer)
     if i > j
-        iszero(x) || throw(ArgumentError("cannot set index in the lower triangular part " *
-            lazy"($i, $j) of an UpperTriangular matrix to a nonzero value ($x)"))
+        iszero(x) || throw_nonzeroerror(typeof(A), x, i, j)
     else
         A.data[i,j] = x
     end
@@ -262,25 +268,18 @@ end
 
 @propagate_inbounds function setindex!(A::UnitUpperTriangular, x, i::Integer, j::Integer)
     if i > j
-        iszero(x) || throw(ArgumentError("cannot set index in the lower triangular part " *
-            lazy"($i, $j) of a UnitUpperTriangular matrix to a nonzero value ($x)"))
+        iszero(x) || throw_nonzeroerror(typeof(A), x, i, j)
     elseif i == j
-        x == oneunit(x) || throw(ArgumentError(lazy"cannot set index on the diagonal ($i, $j) " *
-            lazy"of a UnitUpperTriangular matrix to a non-unit value ($x)"))
+        x == oneunit(x) || throw_nononeerror(typeof(A), x, i, j)
     else
         A.data[i,j] = x
     end
     return A
 end
 
-Base._reverse(A::LowerOrUnitLowerTriangular, dims) = reverse!(Matrix(A); dims)
-Base._reverse(A::LowerTriangular, ::Colon) = UpperTriangular(reverse(A.data))
-Base._reverse(A::UnitLowerTriangular, ::Colon) = UnitUpperTriangular(reverse(A.data))
-
 @propagate_inbounds function setindex!(A::LowerTriangular, x, i::Integer, j::Integer)
     if i < j
-        iszero(x) || throw(ArgumentError("cannot set index in the upper triangular part " *
-            lazy"($i, $j) of a LowerTriangular matrix to a nonzero value ($x)"))
+        iszero(x) || throw_nonzeroerror(typeof(A), x, i, j)
     else
         A.data[i,j] = x
     end
@@ -289,33 +288,44 @@ end
 
 @propagate_inbounds function setindex!(A::UnitLowerTriangular, x, i::Integer, j::Integer)
     if i < j
-        iszero(x) || throw(ArgumentError("cannot set index in the upper triangular part " *
-            lazy"($i, $j) of a UnitLowerTriangular matrix to a nonzero value ($x)"))
+        iszero(x) || throw_nonzeroerror(typeof(A), x, i, j)
     elseif i == j
-        x == oneunit(x) || throw(ArgumentError(lazy"cannot set index on the diagonal ($i, $j) " *
-            lazy"of a UnitLowerTriangular matrix to a non-unit value ($x)"))
+        x == oneunit(x) || throw_nononeerror(typeof(A), x, i, j)
     else
         A.data[i,j] = x
     end
     return A
 end
 
+@noinline function throw_setindex_structuralzero_error(T, @nospecialize(x))
+    _struct_zero_half_str(::Type{<:UpperTriangular}) = "lower"
+    _struct_zero_half_str(::Type{<:LowerTriangular}) = "upper"
+    throw(ArgumentError(LazyString("cannot set indices in the", _struct_zero_half_str(T),
+            " triangular part ",
+            lazy"of an $(nameof(T)) matrix to a nonzero value ($x)")))
+end
+
 @inline function fill!(A::UpperTriangular, x)
-    iszero(x) || throw(ArgumentError("cannot set indices in the lower triangular part " *
-            lazy"of an UpperTriangular matrix to a nonzero value ($x)"))
+    iszero(x) || throw_setindex_structuralzero_error(typeof(A), x)
     for col in axes(A,2), row in firstindex(A,1):col
         @inbounds A.data[row, col] = x
     end
     A
 end
 @inline function fill!(A::LowerTriangular, x)
-    iszero(x) || throw(ArgumentError("cannot set indices in the upper triangular part " *
-            lazy"of a LowerTriangular matrix to a nonzero value ($x)"))
+    iszero(x) || throw_setindex_structuralzero_error(typeof(A), x)
     for col in axes(A,2), row in col:lastindex(A,1)
         @inbounds A.data[row, col] = x
     end
     A
 end
+
+Base._reverse(A::UpperOrUnitUpperTriangular, dims::Integer) = reverse!(Matrix(A); dims)
+Base._reverse(A::UpperTriangular, ::Colon) = LowerTriangular(reverse(A.data))
+Base._reverse(A::UnitUpperTriangular, ::Colon) = UnitLowerTriangular(reverse(A.data))
+Base._reverse(A::LowerOrUnitLowerTriangular, dims) = reverse!(Matrix(A); dims)
+Base._reverse(A::LowerTriangular, ::Colon) = UpperTriangular(reverse(A.data))
+Base._reverse(A::UnitLowerTriangular, ::Colon) = UnitUpperTriangular(reverse(A.data))
 
 ## structured matrix methods ##
 function Base.replace_in_print_matrix(A::Union{UpperTriangular,UnitUpperTriangular},

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -303,9 +303,10 @@ end
 @noinline function throw_setindex_structuralzero_error(T, @nospecialize(x))
     _struct_zero_half_str(::Type{<:UpperTriangular}) = "lower"
     _struct_zero_half_str(::Type{<:LowerTriangular}) = "upper"
-    throw(ArgumentError(LazyString("cannot set indices in the", _struct_zero_half_str(T),
-            " triangular part ",
-            lazy"of an $(nameof(T)) matrix to a nonzero value ($x)")))
+    Ts = _struct_zero_half_str(T)
+    Tn = nameof(T)
+    throw(ArgumentError(
+        lazy"cannot set indices in the $Ts triangular part of an $Tn matrix to a nonzero value ($x)"))
 end
 
 @inline function fill!(A::UpperTriangular, x)

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -249,12 +249,15 @@ Base.isstored(A::UpperTriangular, i::Int, j::Int) =
 @noinline function throw_nonzeroerror(T, @nospecialize(x), i, j)
     _upper_lower_str(::Type{<:UpperOrUnitUpperTriangular}) = "upper"
     _upper_lower_str(::Type{<:LowerOrUnitLowerTriangular}) = "lower"
-    throw(ArgumentError(LazyString("cannot set index in the ", _upper_lower_str(T), " triangular part",
-            lazy"($i, $j) of an $(nameof(T)) matrix to a nonzero value ($x)")))
+    Ts = _upper_lower_str(T)
+    Tn = nameof(T)
+    throw(ArgumentError(
+        lazy"cannot set index in the $Ts triangular part ($i, $j) of an $Tn matrix to a nonzero value ($x)"))
 end
 @noinline function throw_nononeerror(T, @nospecialize(x), i, j)
-    throw(ArgumentError(LazyString("cannot set index on the diagonal",
-            lazy"($i, $j) of an $(nameof(T)) matrix to a non-unit value ($x)")))
+    Tn = nameof(T)
+    throw(ArgumentError(
+        lazy"cannot set index on the diagonal ($i, $j) of an $Tn matrix to a non-unit value ($x)"))
 end
 
 @propagate_inbounds function setindex!(A::UpperTriangular, x, i::Integer, j::Integer)


### PR DESCRIPTION
This PR changes operations like `a::String * b::LazyString` to `LazyString(a, b)`, which avoids some runtime dispatches and plays better with JET. The changes are in the error paths of `setindex!` for `AbstractTriangular` matrices. This also reduces code duplication.

Specifically, this fixes the warnings in the following:
On v1.11:
```julia
julia> using LinearAlgebra

julia> using JET

julia> @report_opt eigen(Hermitian(rand(2,2)))
[ Info: tracking Base
┌ Warning: skipping var"#_#113"(kw::Base.Pairs{Symbol, V, NTuple{N, Symbol}, NamedTuple{names, T}} where {V, N, names, T<:NTuple{N, Any}}, c::ComposedFunction, x...) @ Base operators.jl:1050 to avoid parsing too much code
└ @ Revise ~/.julia/packages/Revise/bAgL0/src/packagedef.jl:1092
┌ Warning: skipping var"#sprint#594"(context, sizehint::Integer, ::typeof(sprint), f::Function, args...) @ Base strings/io.jl:107 to avoid parsing too much code
└ @ Revise ~/.julia/packages/Revise/bAgL0/src/packagedef.jl:1092
┌ Warning: skipping (::Base.var"#120#121")(io) @ Base strings/lazy.jl:84 to avoid parsing too much code
└ @ Revise ~/.julia/packages/Revise/bAgL0/src/packagedef.jl:1092
═════ 1 possible error found ═════
┌ eigen(A::Hermitian{Float64, Matrix{Float64}}) @ LinearAlgebra /cache/build/builder-amdci4-5/julialang/julia-release-1-dot-11/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/symmetriceigen.jl:11
│┌ eigen(A::Hermitian{Float64, Matrix{Float64}}; sortby::Nothing) @ LinearAlgebra /cache/build/builder-amdci4-5/julialang/julia-release-1-dot-11/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/symmetriceigen.jl:13
││┌ eigencopy_oftype(A::Hermitian{Float64, Matrix{Float64}}, S::Type{Float64}) @ LinearAlgebra /cache/build/builder-amdci4-5/julialang/julia-release-1-dot-11/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/symmetriceigen.jl:4
│││┌ copy_similar(A::Hermitian{Float64, Matrix{Float64}}, ::Type{Float64}) @ LinearAlgebra /cache/build/builder-amdci4-5/julialang/julia-release-1-dot-11/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/LinearAlgebra.jl:475
││││┌ copyto!(dest::Matrix{Float64}, src::Hermitian{Float64, Matrix{Float64}}) @ Base ./abstractarray.jl:1060
│││││┌ unalias(dest::Matrix{Float64}, A::Hermitian{Float64, Matrix{Float64}}) @ Base ./abstractarray.jl:1503
││││││┌ unaliascopy(A::Hermitian{Float64, Matrix{Float64}}) @ Base ./abstractarray.jl:1520
│││││││┌ copy(A::Hermitian{Float64, Matrix{Float64}}) @ LinearAlgebra /cache/build/builder-amdci4-5/julialang/julia-release-1-dot-11/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/symmetric.jl:342
││││││││┌ parentof_applytri(f::typeof(copy), args::Hermitian{Float64, Matrix{Float64}}) @ LinearAlgebra /cache/build/builder-amdci4-5/julialang/julia-release-1-dot-11/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/symmetric.jl:297
│││││││││┌ applytri(f::ComposedFunction{typeof(parent), typeof(copy)}, A::Hermitian{Float64, Matrix{Float64}}) @ LinearAlgebra /cache/build/builder-amdci4-5/julialang/julia-release-1-dot-11/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/symmetric.jl:280
││││││││││┌ (::ComposedFunction{typeof(parent), typeof(copy)})(x::UpperTriangular{Float64, Matrix{Float64}}) @ Base ./operators.jl:1050
│││││││││││┌ (::ComposedFunction{typeof(parent), typeof(copy)})(x::UpperTriangular{Float64, Matrix{Float64}}; kw::@Kwargs{}) @ Base ./operators.jl:1050
││││││││││││┌ call_composed(fs::Tuple{typeof(parent), typeof(copy)}, x::Tuple{UpperTriangular{Float64, Matrix{…}}}, kw::@Kwargs{}) @ Base ./operators.jl:1053
│││││││││││││┌ call_composed(fs::Tuple{typeof(copy)}, x::Tuple{UpperTriangular{Float64, Matrix{Float64}}}, kw::@Kwargs{}) @ Base ./operators.jl:1054
││││││││││││││┌ copy(A::UpperTriangular{Float64, Matrix{Float64}}) @ LinearAlgebra /cache/build/builder-amdci4-5/julialang/julia-release-1-dot-11/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/triangular.jl:183
│││││││││││││││┌ copyto!(A::UpperTriangular{Float64, Matrix{Float64}}, B::UpperTriangular{Float64, Matrix{Float64}}) @ LinearAlgebra /cache/build/builder-amdci4-5/julialang/julia-release-1-dot-11/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/triangular.jl:520
││││││││││││││││┌ setindex!(A::UpperTriangular{Float64, Matrix{Float64}}, x::Float64, i::Int64, j::Int64) @ LinearAlgebra /cache/build/builder-amdci4-5/julialang/julia-release-1-dot-11/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/triangular.jl:274
│││││││││││││││││┌ *(s1::String, ss::LazyString) @ Base ./strings/basic.jl:265
││││││││││││││││││┌ string(::String, ::LazyString) @ Base ./strings/io.jl:189
│││││││││││││││││││┌ print_to_string(::String, ::LazyString) @ Base ./strings/io.jl:148
││││││││││││││││││││┌ print(io::IOBuffer, s::LazyString) @ Base ./strings/io.jl:195
│││││││││││││││││││││┌ iterate(s::LazyString) @ Base ./strings/lazy.jl:94
││││││││││││││││││││││┌ String(l::LazyString) @ Base ./strings/lazy.jl:83
│││││││││││││││││││││││┌ sprint(::Base.var"#120#121"{LazyString}) @ Base ./strings/io.jl:107
││││││││││││││││││││││││┌ sprint(::Base.var"#120#121"{LazyString}; context::Nothing, sizehint::Int64) @ Base ./strings/io.jl:114
│││││││││││││││││││││││││┌ (::Base.var"#120#121"{LazyString})(io::IOBuffer) @ Base ./strings/lazy.jl:85
││││││││││││││││││││││││││ runtime dispatch detected: print(io::IOBuffer, %16::Any)::Any
```
With the changes from this PR
```julia
julia> @report_opt eigen(Hermitian(rand(2,2)))
No errors detected
```