### PR TITLE
Check `GenericIOBuffer` data is contiguous

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -19,6 +19,7 @@ mutable struct GenericIOBuffer{T<:AbstractVector{UInt8}} <: IO
     function GenericIOBuffer{T}(data::T, readable::Bool, writable::Bool, seekable::Bool, append::Bool,
                                 maxsize::Integer) where T<:AbstractVector{UInt8}
         require_one_based_indexing(data)
+        _checkcontiguous(Bool, data) || throw(ArgumentError("data must be stored contiguously in memory"))
         return new(data, false, readable, writable, seekable, append, length(data), maxsize, 1, 0, -1)
     end
 end

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -388,3 +388,8 @@ end
     b = pushfirst!([0x02], 0x01)
     @test take!(IOBuffer(b)) == [0x01, 0x02]
 end
+
+@testset "#54636 test IOBuffer checks data is contiguous" begin
+    b = @view(collect(0x00:0x03)[begin:2:end])
+    @test_throws ArgumentError IOBuffer(b)
+end


### PR DESCRIPTION
Fix #54636 by throwing an error on construction of the `GenericIOBuffer` if its data isn't stored contiguously in memory.