### PR TITLE
REPLCompletions: allow module completions for `using` with multiple args

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -1109,8 +1109,8 @@ function complete_identifiers!(suggestions::Vector{Completion}, @nospecialize(ff
             end
             isexpr(ex, :incomplete) && (ex = nothing)
         elseif isexpr(ex, (:using, :import))
-            arg1 = ex.args[1]
-            if isexpr(arg1, :.)
+            arglast = ex.args[end] # focus on completion to the last argument
+            if isexpr(arglast, :.)
                 # We come here for cases like:
                 # - `string`: "using Mod1.Mod2.M"
                 # - `ex`: :(using Mod1.Mod2)
@@ -1120,7 +1120,7 @@ function complete_identifiers!(suggestions::Vector{Completion}, @nospecialize(ff
                 # Note that `ffunc` is set to `module_filter` within `completions`
                 ex = nothing
                 firstdot = true
-                for arg = arg1.args
+                for arg = arglast.args
                     if arg === :.
                         # override `context_module` if multiple `.` accessors are used
                         if firstdot

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -2219,6 +2219,12 @@ let s = "using Base."
     @test res
     @test "BinaryPlatforms" in c
 end
+# JuliaLang/julia#53999
+let s = "using Base.Sort, Base.Th"
+    c, r, res = test_complete_context(s)
+    @test res
+    @test "Threads" in c
+end
 # test cases with the `.` accessor
 module Issue52922
 module Inner1
@@ -2301,10 +2307,4 @@ let s = "TestImplicitUsing.@asse"
     c, r, res = test_complete_context(s)
     @test res
     @test "@assert" in c
-end
-# JuliaLang/julia#53999
-let s = "using Base.Thre"
-    c, r, res = test_complete_context(s)
-    @test res
-    @test "Threads" in c
 end


### PR DESCRIPTION
E.g. completes `using Base.Sort, Base.Th|` to
`using Base.Sort, Base.Threads`.

Fixes #53999