### PR TITLE
Less restrictive copyto! signature for triangular matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -553,7 +553,7 @@ end
 _triangularize!(::UpperOrUnitUpperTriangular) = triu!
 _triangularize!(::LowerOrUnitLowerTriangular) = tril!
 
-@propagate_inboundsfunction copyto!(dest::StridedMatrix, U::UpperOrLowerTriangular)
+@propagate_inbounds function copyto!(dest::StridedMatrix, U::UpperOrLowerTriangular)
     if axes(dest) != axes(U)
         @invoke copyto!(dest::StridedMatrix, U::AbstractArray)
     else

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -246,10 +246,11 @@ Base.isstored(A::UpperTriangular, i::Int, j::Int) =
 @propagate_inbounds getindex(A::UpperTriangular, i::Int, j::Int) =
     i <= j ? A.data[i,j] : _zero(A.data,j,i)
 
+_struct_zero_half_str(::Type{<:UpperTriangular}) = "lower"
+_struct_zero_half_str(::Type{<:LowerTriangular}) = "upper"
+
 @noinline function throw_nonzeroerror(T, @nospecialize(x), i, j)
-    _upper_lower_str(::Type{<:UpperOrUnitUpperTriangular}) = "upper"
-    _upper_lower_str(::Type{<:LowerOrUnitLowerTriangular}) = "lower"
-    Ts = _upper_lower_str(T)
+    Ts = _struct_zero_half_str(T)
     Tn = nameof(T)
     throw(ArgumentError(
         lazy"cannot set index in the $Ts triangular part ($i, $j) of an $Tn matrix to a nonzero value ($x)"))
@@ -301,8 +302,6 @@ end
 end
 
 @noinline function throw_setindex_structuralzero_error(T, @nospecialize(x))
-    _struct_zero_half_str(::Type{<:UpperTriangular}) = "lower"
-    _struct_zero_half_str(::Type{<:LowerTriangular}) = "upper"
     Ts = _struct_zero_half_str(T)
     Tn = nameof(T)
     throw(ArgumentError(

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -246,11 +246,11 @@ Base.isstored(A::UpperTriangular, i::Int, j::Int) =
 @propagate_inbounds getindex(A::UpperTriangular, i::Int, j::Int) =
     i <= j ? A.data[i,j] : _zero(A.data,j,i)
 
-_struct_zero_half_str(::Type{<:UpperTriangular}) = "lower"
-_struct_zero_half_str(::Type{<:LowerTriangular}) = "upper"
+_zero_triangular_half_str(::Type{<:UpperOrUnitUpperTriangular}) = "lower"
+_zero_triangular_half_str(::Type{<:LowerOrUnitLowerTriangular}) = "upper"
 
 @noinline function throw_nonzeroerror(T, @nospecialize(x), i, j)
-    Ts = _struct_zero_half_str(T)
+    Ts = _zero_triangular_half_str(T)
     Tn = nameof(T)
     throw(ArgumentError(
         lazy"cannot set index in the $Ts triangular part ($i, $j) of an $Tn matrix to a nonzero value ($x)"))
@@ -302,7 +302,7 @@ end
 end
 
 @noinline function throw_setindex_structuralzero_error(T, @nospecialize(x))
-    Ts = _struct_zero_half_str(T)
+    Ts = _zero_triangular_half_str(T)
     Tn = nameof(T)
     throw(ArgumentError(
         lazy"cannot set indices in the $Ts triangular part of an $Tn matrix to a nonzero value ($x)"))

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -1083,11 +1083,21 @@ end
 
 @testset "copyto! with aliasing (#39460)" begin
     M = Matrix(reshape(1:36, 6, 6))
-    @testset for T in (UpperTriangular, LowerTriangular)
+    @testset for T in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular)
         A = T(view(M, 1:5, 1:5))
         A2 = copy(A)
         B = T(view(M, 2:6, 2:6))
         @test copyto!(B, A) == A2
+    end
+end
+
+@testset "copyto! with different sizes" begin
+    Ap = zeros(3,3)
+    Bp = rand(2,2)
+    @testset for T in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular)
+        A = T(Ap)
+        B = T(Bp)
+        @test_throws ArgumentError copyto!(A, B)
     end
 end
 

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -1099,6 +1099,15 @@ end
         B = T(Bp)
         @test_throws ArgumentError copyto!(A, B)
     end
+    @testset "error message" begin
+        A = UpperTriangular(Ap)
+        B = UpperTriangular(Bp)
+        @test_throws "cannot set index in the lower triangular part" copyto!(A, B)
+
+        A = LowerTriangular(Ap)
+        B = LowerTriangular(Bp)
+        @test_throws "cannot set index in the upper triangular part" copyto!(A, B)
+    end
 end
 
 @testset "getindex with Integers" begin


### PR DESCRIPTION
On nightly, `copyto!(A::T, B::T) where {T<:UpperTriangular}` checks for the types to be identical. This is overly restrictive, as we only need to check that they are both `UpperTriangular`. This PR relaxes this, which provides a significant performance boost for mismatched types.
  
```julia
julia> using LinearAlgebra

julia> A = UpperTriangular(rand(200,200)); B = UpperTriangular(view(rand(200,200),:,:));

julia> @btime copyto!($A, $B);
  44.878 μs (0 allocations: 0 bytes) # nightly v"1.12.0-DEV.641" 
  5.658 μs (0 allocations: 0 bytes) # this PR
```

This PR also changes the behavior when the source and the destination don't have the same size, in which case, `copyto!` should carry out a linear copy and not a Cartesian one, as per its docstring. The previous behavior may be obtained by calling
```julia
copyto!(A, CartesianIndices(B), B, CartesianIndices(B))
```
This change would mean that certain operations that used to work would error now, e.g.:
```julia
julia> A = UpperTriangular(zeros(3,3)); B = UpperTriangular(rand(2,2));

julia> copyto!(A, B)
ERROR: ArgumentError: cannot set index in the upper triangular part (3, 1) of an UpperTriangular matrix to a nonzero value (0.6898709830945821)
```
whereas this used to carry out a Cartesian copy previously.