### PR TITLE
Use the public `wait()` in the `errormonitor()` docstring

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -728,7 +728,7 @@ Print an error log to `stderr` if task `t` fails.
 
 # Examples
 ```julia-repl
-julia> wait(errormonitor(Threads.@spawn error("task failed")))
+julia> wait(errormonitor(Threads.@spawn error("task failed")); throw = false)
 Unhandled Task ERROR: task failed
 Stacktrace:
 [...]

--- a/base/task.jl
+++ b/base/task.jl
@@ -728,7 +728,7 @@ Print an error log to `stderr` if task `t` fails.
 
 # Examples
 ```julia-repl
-julia> Base._wait(errormonitor(Threads.@spawn error("task failed")))
+julia> wait(errormonitor(Threads.@spawn error("task failed")))
 Unhandled Task ERROR: task failed
 Stacktrace:
 [...]


### PR DESCRIPTION
`Base._wait()` is private so it feels a bit odd to use it in a docstring. The difference between the results is that `wait()` will also throw a `TaskFailedException`.