### PR TITLE
WIP: World-age partition bindings

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -550,6 +550,9 @@ for m in methods(include)
     delete_method(m)
 end
 
+# Arm binding invalidation mechanism
+const invalidate_code_for_globalref! = Core.Compiler.invalidate_code_for_globalref!
+
 # This method is here only to be overwritten during the test suite to test
 # various sysimg related invalidation scenarios.
 a_method_to_overwrite_in_test() = inferencebarrier(1)

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -541,8 +541,6 @@ GenericMemoryRef(mem::GenericMemory) = memoryref(mem)
 GenericMemoryRef(mem::GenericMemory, i::Integer) = memoryref(mem, i)
 GenericMemoryRef(mem::GenericMemoryRef, i::Integer) = memoryref(mem, i)
 
-const Memory{T} = GenericMemory{:not_atomic, T, CPU}
-const MemoryRef{T} = GenericMemoryRef{:not_atomic, T, CPU}
 const AtomicMemory{T} = GenericMemory{:atomic, T, CPU}
 const AtomicMemoryRef{T} = GenericMemoryRef{:atomic, T, CPU}
 

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -222,5 +222,7 @@ ccall(:jl_set_typeinf_func, Cvoid, (Any,), typeinf_ext_toplevel)
 include("compiler/parsing.jl")
 Core._setparser!(fl_parse)
 
+include("compiler/invalidation.jl")
+
 end # baremodule Compiler
 ))

--- a/base/compiler/invalidation.jl
+++ b/base/compiler/invalidation.jl
@@ -1,0 +1,161 @@
+# GlobalRef/binding reflection
+# TODO: This should potentially go in reflection.jl, but `@atomic` is not available
+# there.
+struct GlobalRefIterator
+    mod::Module
+end
+globalrefs(mod::Module) = GlobalRefIterator(mod)
+
+function iterate(gri::GlobalRefIterator, i = 1)
+    m = gri.mod
+    table = ccall(:jl_module_get_bindings, Ref{SimpleVector}, (Any,), m)
+    i == length(table) && return nothing
+    b = table[i]
+    b === nothing && return iterate(gri, i+1)
+    return ((b::Core.Binding).globalref, i+1)
+end
+
+const TYPE_TYPE_MT = Type.body.name.mt
+const NONFUNCTION_MT = MethodTable.name.mt
+function foreach_module_mtable(visit, m::Module)
+    for gb in globalrefs(m)
+        binding = gb.binding
+        if isconst(binding)
+            isdefined(binding, :value) || continue
+            v = @atomic binding.value
+            uw = unwrap_unionall(v)
+            name = gb.name
+            if isa(uw, DataType)
+                tn = uw.name
+                if tn.module === m && tn.name === name && tn.wrapper === v && isdefined(tn, :mt)
+                    # this is the original/primary binding for the type (name/wrapper)
+                    mt = tn.mt
+                    if mt !== nothing && mt !== TYPE_TYPE_MT && mt !== NONFUNCTION_MT
+                        @assert mt.module === m
+                        visit(mt) || return false
+                    end
+                end
+            elseif isa(v, Module) && v !== m && parentmodule(v) === m && _nameof(v) === name
+                # this is the original/primary binding for the submodule
+                foreach_module_mtable(visit, v) || return false
+            elseif isa(v, MethodTable) && v.module === m && v.name === name
+                # this is probably an external method table here, so let's
+                # assume so as there is no way to precisely distinguish them
+                visit(v) || return false
+            end
+        end
+    end
+    return true
+end
+
+function foreach_reachable_mtable(visit)
+    visit(TYPE_TYPE_MT) || return
+    visit(NONFUNCTION_MT) || return
+    if isdefined(Core.Main, :Base)
+        for mod in Core.Main.Base.loaded_modules_array()
+            foreach_module_mtable(visit, mod)
+        end
+    else
+        foreach_module_mtable(visit, Core)
+        foreach_module_mtable(visit, Core.Main)
+    end
+end
+
+function invalidate_code_for_globalref!(gr::GlobalRef, src::CodeInfo)
+    found_any = false
+    labelchangemap = nothing
+    stmts = src.code
+    function get_labelchangemap()
+        if labelchangemap === nothing
+            labelchangemap = fill(0, length(stmts))
+        end
+        labelchangemap
+    end
+    isgr(g::GlobalRef) = gr.mod == g.mod && gr.name === g.name
+    isgr(g) = false
+    for i = 1:length(stmts)
+        stmt = stmts[i]
+        if isgr(stmt)
+            found_any = true
+            continue
+        end
+        found_arg = false
+        ngrs = 0
+        for ur in userefs(stmt)
+            arg = ur[]
+            # If any of the GlobalRefs in this stmt match the one that
+            # we are about, we need to move out all GlobalRefs to preseve
+            # effect order, in case we later invalidate a different GR
+            if isa(arg, GlobalRef)
+                ngrs += 1
+                if isgr(arg)
+                    @assert !isa(stmt, PhiNode)
+                    found_arg = found_any = true
+                    break
+                end
+            end
+        end
+        if found_arg
+            get_labelchangemap()[i] += ngrs
+        end
+    end
+    next_empty_idx = 1
+    if labelchangemap !== nothing
+        cumsum_ssamap!(labelchangemap)
+        new_stmts = Vector(undef, length(stmts)+labelchangemap[end])
+        new_ssaflags = Vector{UInt32}(undef, length(new_stmts))
+        new_debuginfo = DebugInfoStream(nothing, src.debuginfo, length(new_stmts))
+        new_debuginfo.def = src.debuginfo.def
+        for i = 1:length(stmts)
+            stmt = stmts[i]
+            urs = userefs(stmt)
+            new_stmt_idx = i+labelchangemap[i]
+            for ur in urs
+                arg = ur[]
+                if isa(arg, SSAValue)
+                    ur[] = SSAValue(arg.id + labelchangemap[arg.id])
+                elseif next_empty_idx != new_stmt_idx && isa(arg, GlobalRef)
+                    new_debuginfo.codelocs[3next_empty_idx - 2] = i
+                    new_stmts[next_empty_idx] = arg
+                    new_ssaflags[next_empty_idx] = UInt32(0)
+                    ur[] = SSAValue(next_empty_idx)
+                    next_empty_idx += 1
+                end
+            end
+            @assert new_stmt_idx == next_empty_idx
+            new_stmts[new_stmt_idx] = urs[]
+            new_debuginfo.codelocs[3new_stmt_idx - 2] = i
+            new_ssaflags[new_stmt_idx] = src.ssaflags[i]
+            next_empty_idx = new_stmt_idx+1
+        end
+        src.code = new_stmts
+        src.ssavaluetypes = length(new_stmts)
+        src.ssaflags = new_ssaflags
+        src.debuginfo = Core.DebugInfo(new_debuginfo, length(new_stmts))
+    end
+    return found_any
+end
+
+function invalidate_code_for_globalref!(gr::GlobalRef, new_max_world::UInt)
+    valid_in_valuepos = false
+    foreach_reachable_mtable() do mt::MethodTable
+        for method in MethodList(mt)
+            if isdefined(method, :source)
+                src = _uncompressed_ir(method)
+                old_stmts = src.code
+                if invalidate_code_for_globalref!(gr, src)
+                    if src.code !== old_stmts
+                        method.debuginfo = src.debuginfo
+                        method.source = src
+                        method.source = ccall(:jl_compress_ir, Ref{String}, (Any, Ptr{Cvoid}), method, C_NULL)
+                    end
+
+                    for mi in specializations(method)
+                        ccall(:jl_invalidate_method_instance, Cvoid, (Any, UInt), mi, new_max_world)
+                    end
+                end
+            end
+        end
+        return true
+    end
+end

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -1069,6 +1069,50 @@ function invoke_in_world(world::UInt, @nospecialize(f), @nospecialize args...; k
     return Core._call_in_world(world, Core.kwcall, kwargs, f, args...)
 end
 
+"""
+    @world(sym, world)
+
+Resolve the binding `sym` in world `world`. See [`invoke_in_world`](@ref) for running
+arbitrary code in fixed worlds. `world` may be `UnitRange`, in which case the macro
+will error unless the binding is valid and has the same value across the entire world
+range.
+
+The `@world` macro is primarily used in the priniting of bindings that are no longer available
+in the current world.
+
+## Example
+```
+julia> struct Foo; a::Int; end
+Foo
+
+julia> fold = Foo(1)
+
+julia> Int(Base.get_world_counter())
+26866
+
+julia> struct Foo; a::Int; b::Int end
+Foo
+
+julia> fold
+@world(Foo, 26866)(1)
+```
+
+!!! compat "Julia 1.12"
+    This functionality requires at least Julia 1.12.
+"""
+macro world(sym, world)
+    if isa(sym, Symbol)
+        return :($(_resolve_in_world)($world, $(QuoteNode(GlobalRef(__module__, sym)))))
+    elseif isa(sym, GlobalRef)
+        return :($(_resolve_in_world)($world, $(QuoteNode(sym))))
+    else
+        error("`@world` requires a symbol or GlobalRef")
+    end
+end
+
+_resolve_in_world(world::Integer, gr::GlobalRef) =
+    invoke_in_world(UInt(world), Core.getglobal, gr.mod, gr.name)
+
 inferencebarrier(@nospecialize(x)) = compilerbarrier(:type, x)
 
 """

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -810,6 +810,7 @@ export
     @invoke,
     invokelatest,
     @invokelatest,
+    @world,
 
 # loading source files
     __precompile__,

--- a/base/range.jl
+++ b/base/range.jl
@@ -1680,3 +1680,16 @@ function show(io::IO, r::LogRange{T}) where {T}
     show(io, length(r))
     print(io, ')')
 end
+
+# Implementation detail of @world
+# The rest of this is defined in essentials.jl, but UnitRange is not available
+function _resolve_in_world(world::UnitRange, gr::GlobalRef)
+    # Validate that this binding's reference covers the entire world range
+    bnd = ccall(:jl_lookup_module_binding, Any, (Any, Any, UInt), gr.mod, gr.name, first(world))::Union{Core.Binding, Nothing}
+    if bnd !== nothing
+        if bnd.max_world < last(world)
+            error("Binding does not cover the full world range")
+        end
+    end
+    _resolve_in_world(last(world), gr)
+end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -344,6 +344,9 @@ function isconst(g::GlobalRef)
     return ccall(:jl_globalref_is_const, Cint, (Any,), g) != 0
 end
 
+isconst(b::Core.Binding) =
+    ccall(:jl_binding_is_const, Cint, (Any,), b) != 0
+
 """
     isconst(t::DataType, s::Union{Int,Symbol}) -> Bool
 
@@ -2593,6 +2596,18 @@ Make method `m` uncallable and force recompilation of any methods that use(d) it
 """
 function delete_method(m::Method)
     ccall(:jl_method_table_disable, Cvoid, (Any, Any), get_methodtable(m), m)
+end
+
+"""
+    delete_binding(mod::Module, sym::Symbol)
+
+Force the binding `mod.sym` to be undefined again, allowing it be redefined.
+Note that this operation is very expensive, requirinig a full scan of all code in the system,
+as well as potential recompilation of any methods that (may) have used binding
+information.
+"""
+function delete_binding(mod::Module, sym::Symbol)
+    ccall(:jl_disable_binding, Cvoid, (Any,), GlobalRef(mod, sym))
 end
 
 function get_methodtable(m::Method)

--- a/src/ast.c
+++ b/src/ast.c
@@ -173,7 +173,8 @@ static value_t fl_defined_julia_global(fl_context_t *fl_ctx, value_t *args, uint
     (void)tosymbol(fl_ctx, args[0], "defined-julia-global");
     jl_ast_context_t *ctx = jl_ast_ctx(fl_ctx);
     jl_sym_t *var = scmsym_to_julia(fl_ctx, args[0]);
-    jl_binding_t *b = jl_get_module_binding(ctx->module, var, 0);
+    // TODO - this lookup isn't really valid anymore
+    jl_binding_t *b = jl_get_module_binding(ctx->module, var, 0, jl_atomic_load_acquire(&jl_world_counter));
     return (b != NULL && jl_atomic_load_relaxed(&b->owner) == b) ? fl_ctx->T : fl_ctx->F;
 }
 
@@ -203,7 +204,8 @@ static value_t fl_nothrow_julia_global(fl_context_t *fl_ctx, value_t *args, uint
         (void)tosymbol(fl_ctx, args[1], "nothrow-julia-global");
         var = scmsym_to_julia(fl_ctx, args[1]);
     }
-    jl_binding_t *b = jl_get_module_binding(mod, var, 0);
+    // TODO - this lookup isn't really valid anymore
+    jl_binding_t *b = jl_get_module_binding(mod, var, 0, jl_atomic_load_acquire(&jl_world_counter));
     b = b ? jl_atomic_load_relaxed(&b->owner) : NULL;
     return b != NULL && jl_atomic_load_relaxed(&b->value) != NULL ? fl_ctx->T : fl_ctx->F;
 }

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1371,7 +1371,7 @@ JL_CALLABLE(jl_f_get_binding_type)
     JL_TYPECHK(get_binding_type, symbol, (jl_value_t*)var);
     jl_value_t *ty = jl_get_binding_type(mod, var);
     if (ty == (jl_value_t*)jl_nothing) {
-        jl_binding_t *b = jl_get_module_binding(mod, var, 0);
+        jl_binding_t *b = jl_get_module_binding(mod, var, 0, jl_current_task->world_age);
         if (b == NULL)
             return (jl_value_t*)jl_any_type;
         jl_binding_t *b2 = jl_atomic_load_relaxed(&b->owner);

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -308,7 +308,7 @@ JL_DLLEXPORT void *jl_load_dynamic_library(const char *modname, unsigned flags, 
       such as Windows, so we emulate them here.
     */
     if (!abspath && !is_atpath && jl_base_module != NULL) {
-        jl_binding_t *b = jl_get_module_binding(jl_base_module, jl_symbol("DL_LOAD_PATH"), 0);
+        jl_binding_t *b = jl_get_module_binding(jl_base_module, jl_symbol("DL_LOAD_PATH"), 0, jl_atomic_load_acquire(&jl_world_counter));
         jl_array_t *DL_LOAD_PATH = (jl_array_t*)(b ? jl_atomic_load_relaxed(&b->value) : NULL);
         if (DL_LOAD_PATH != NULL) {
             size_t j;

--- a/src/gf.c
+++ b/src/gf.c
@@ -1716,6 +1716,11 @@ static void invalidate_method_instance(jl_method_instance_t *replaced, size_t ma
     JL_UNLOCK(&replaced->def.method->writelock);
 }
 
+JL_DLLEXPORT void jl_invalidate_method_instance(jl_method_instance_t *replaced, size_t max_world)
+{
+    invalidate_method_instance(replaced, max_world, 1);
+}
+
 static void _invalidate_backedges(jl_method_instance_t *replaced_mi, size_t max_world, int depth) {
     jl_array_t *backedges = replaced_mi->backedges;
     if (backedges) {

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -585,8 +585,12 @@ static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, size_t ip,
                         sym = (jl_sym_t*)lhs;
                     }
                     JL_GC_PUSH1(&rhs);
-                    jl_binding_t *b = jl_get_binding_wr(modu, sym, alloc);
-                    jl_checked_assignment(b, modu, sym, rhs);
+                    if (toplevel) {
+                        jl_toplevel_checked_assignment(modu, sym, rhs, alloc);
+                    } else {
+                        jl_binding_t *b = jl_get_binding_wr(modu, sym, 0);
+                        jl_checked_assignment(b, modu, sym, rhs);
+                    }
                     JL_GC_POP();
                 }
             }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3100,12 +3100,12 @@ void jl_init_types(void) JL_GC_DISABLED
 
     jl_binding_type =
         jl_new_datatype(jl_symbol("Binding"), core, jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(5, "value", "globalref", "owner", "ty", "flags"),
-                        jl_svec(5, jl_any_type, jl_any_type/*jl_globalref_type*/, jl_any_type/*jl_binding_type*/, jl_type_type, jl_uint8_type),
+                        jl_perm_symsvec(8, "value", "globalref", "owner", "ty", "min_world", "max_world", "next", "flags"),
+                        jl_svec(8, jl_any_type, jl_any_type/*jl_globalref_type*/, jl_any_type/*jl_binding_type*/, jl_type_type, jl_ulong_type, jl_ulong_type, jl_any_type/*jl_binding_type*/, jl_uint8_type),
                         jl_emptysvec, 0, 1, 0);
-    const static uint32_t binding_atomicfields[] = { 0x0015 }; // Set fields 1, 3, 4 as atomic
+    const static uint32_t binding_atomicfields[] = { 0x006d }; // Set fields 1, 3, 4, 6, 7 as atomic
     jl_binding_type->name->atomicfields = binding_atomicfields;
-    const static uint32_t binding_constfields[] = { 0x0002 }; // Set fields 2 as constant
+    const static uint32_t binding_constfields[] = { 0x0022 }; // Set fields 2, 5 as constant
     jl_binding_type->name->constfields = binding_constfields;
 
     jl_globalref_type =
@@ -3655,6 +3655,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_code_instance_type->types, 17, jl_voidpointer_type);
     jl_svecset(jl_binding_type->types, 1, jl_globalref_type);
     jl_svecset(jl_binding_type->types, 2, jl_binding_type);
+    jl_svecset(jl_binding_type->types, 6, jl_binding_type);
 
     jl_compute_field_offsets(jl_datatype_type);
     jl_compute_field_offsets(jl_typename_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -633,6 +633,9 @@ typedef struct _jl_binding_t {
     jl_globalref_t *globalref;  // cached GlobalRef for this binding
     _Atomic(struct _jl_binding_t*) owner;  // for individual imported bindings (NULL until 'resolved')
     _Atomic(jl_value_t*) ty;  // binding type
+    size_t min_world;
+    _Atomic(size_t) max_world;
+    _Atomic(struct _jl_binding_t*) next;
     uint8_t constp:1;
     uint8_t exportp:1; // `public foo` sets `publicp`, `export foo` sets both `publicp` and `exportp`
     uint8_t publicp:1; // exportp without publicp is not allowed.
@@ -1960,6 +1963,7 @@ JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym
 JL_DLLEXPORT void jl_set_global(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT);
 JL_DLLEXPORT void jl_set_const(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT);
 JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_module_t *mod, jl_sym_t *var, jl_value_t *rhs JL_MAYBE_UNROOTED);
+JL_DLLEXPORT void jl_toplevel_checked_assignment(jl_module_t *mod, jl_sym_t *var, jl_value_t *rhs JL_MAYBE_UNROOTED, int alloc);
 JL_DLLEXPORT jl_value_t *jl_checked_swap(jl_binding_t *b, jl_module_t *mod, jl_sym_t *var, jl_value_t *rhs JL_MAYBE_UNROOTED);
 JL_DLLEXPORT jl_value_t *jl_checked_replace(jl_binding_t *b, jl_module_t *mod, jl_sym_t *var, jl_value_t *expected, jl_value_t *rhs);
 JL_DLLEXPORT jl_value_t *jl_checked_modify(jl_binding_t *b, jl_module_t *mod, jl_sym_t *var, jl_value_t *op, jl_value_t *rhs);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -340,6 +340,7 @@ extern arraylist_t eytzinger_idxs;
 
 extern JL_DLLEXPORT size_t jl_page_size;
 extern jl_function_t *jl_typeinf_func JL_GLOBALLY_ROOTED;
+extern jl_function_t *jl_invalidation_scanner JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT size_t jl_typeinf_world;
 extern _Atomic(jl_typemap_entry_t*) call_cache[N_CALL_CACHE] JL_GLOBALLY_ROOTED;
 
@@ -834,7 +835,7 @@ JL_DLLEXPORT int jl_pointer_egal(jl_value_t *t);
 JL_DLLEXPORT jl_value_t *jl_nth_slot_type(jl_value_t *sig JL_PROPAGATES_ROOT, size_t i) JL_NOTSAFEPOINT;
 void jl_compute_field_offsets(jl_datatype_t *st);
 void jl_module_run_initializer(jl_module_t *m);
-JL_DLLEXPORT jl_binding_t *jl_get_module_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var, int alloc);
+JL_DLLEXPORT jl_binding_t *jl_get_module_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var, int alloc, size_t world);
 JL_DLLEXPORT void jl_binding_deprecation_warning(jl_module_t *m, jl_sym_t *sym, jl_binding_t *b);
 extern jl_array_t *jl_module_init_order JL_GLOBALLY_ROOTED;
 extern htable_t jl_current_modules JL_GLOBALLY_ROOTED;

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -552,7 +552,7 @@ JL_DLLEXPORT jl_value_t *jl_stderr_obj(void) JL_NOTSAFEPOINT
 {
     if (jl_base_module == NULL)
         return NULL;
-    jl_binding_t *stderr_obj = jl_get_module_binding(jl_base_module, jl_symbol("stderr"), 0);
+    jl_binding_t *stderr_obj = jl_get_module_binding(jl_base_module, jl_symbol("stderr"), 0, jl_atomic_load_acquire(&jl_world_counter));
     return stderr_obj ? jl_atomic_load_relaxed(&stderr_obj->value) : NULL;
 }
 
@@ -647,7 +647,7 @@ static int is_globname_binding(jl_value_t *v, jl_datatype_t *dv) JL_NOTSAFEPOINT
 {
     jl_sym_t *globname = dv->name->mt != NULL ? dv->name->mt->name : NULL;
     if (globname && dv->name->module) {
-        jl_binding_t *b = jl_get_module_binding(dv->name->module, globname, 0);
+        jl_binding_t *b = jl_get_module_binding(dv->name->module, globname, 0, jl_atomic_load_acquire(&jl_world_counter));
         if (b && jl_atomic_load_relaxed(&b->owner) && b->constp) {
             jl_value_t *bv = jl_atomic_load_relaxed(&b->value);
             // The `||` makes this function work for both function instances and function types.

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -160,7 +160,7 @@ static jl_value_t *jl_eval_module_expr(jl_module_t *parent_module, jl_expr_t *ex
         jl_value_t *old = NULL;
         if (!jl_atomic_cmpswap(&b->value, &old, (jl_value_t*)newm)) {
             if (!jl_is_module(old)) {
-                jl_errorf("invalid redefinition of constant %s", jl_symbol_name(name));
+                jl_errorf("E: invalid redefinition of constant %s", jl_symbol_name(name));
             }
             if (jl_generating_output())
                 jl_errorf("cannot replace module %s during compilation", jl_symbol_name(name));
@@ -628,7 +628,7 @@ static void import_module(jl_module_t *JL_NONNULL m, jl_module_t *import, jl_sym
     assert(m);
     jl_sym_t *name = asname ? asname : import->name;
     // TODO: this is a bit race-y with what error message we might print
-    jl_binding_t *b = jl_get_module_binding(m, name, 0);
+    jl_binding_t *b = jl_get_module_binding(m, name, 0, jl_atomic_load_acquire(&jl_world_counter));
     jl_binding_t *b2;
     if (b != NULL && (b2 = jl_atomic_load_relaxed(&b->owner)) != NULL) {
         if (b2->constp && jl_atomic_load_relaxed(&b2->value) == (jl_value_t*)import)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -33,7 +33,7 @@ function UndefVarError_hint(io::IO, ex::UndefVarError)
     if isdefined(ex, :scope)
         scope = ex.scope
         if scope isa Module
-            bnd = ccall(:jl_get_module_binding, Any, (Any, Any, Cint), scope, var, true)::Core.Binding
+            bnd = ccall(:jl_get_module_binding, Any, (Any, Any, Cint, UInt), scope, var, true, Base.get_world_counter())::Core.Binding
             if isdefined(bnd, :owner)
                 owner = bnd.owner
                 if owner === bnd

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -29,7 +29,7 @@ const TESTNAMES = [
         "channels", "iostream", "secretbuffer", "specificity",
         "reinterpretarray", "syntax", "corelogging", "missing", "asyncmap",
         "smallarrayshrink", "opaque_closure", "filesystem", "download",
-        "scopedvalues", "compileall"
+        "scopedvalues", "compileall", "rebinding"
 ]
 
 const INTERNET_REQUIRED_LIST = [

--- a/test/rebinding.jl
+++ b/test/rebinding.jl
@@ -1,0 +1,21 @@
+struct ToRedefine1
+	a::Int
+end
+
+previously_defined_method() = ToRedefine1(1)
+const old_reference = previously_defined_method()
+const old_world_age = Base.get_world_counter()
+
+struct ToRedefine1
+	a::Int
+	b::Int
+end
+@test_throws previously_defined_method()
+
+# Test that the binding rename worked
+@test !isa(old_reference, ToRedefine1)
+@test isa(old_reference, @world(ToRedefine1, old_world_age))
+
+# Test that the lowering of the inner constructor references the type by identity,
+# not binding
+@test isa(@world(ToRedefine1, old_world_age)(1), @world(ToRedefine1, old_world_age))


### PR DESCRIPTION
This implements world-age partitioning of bindings as proposed in #40399. In effect, much like methods, the global view of bindings now depends on your currently executing world. This means that `const` bindings can now have different values in different worlds. In principle it also means that regular global variables could have different values in different worlds, but there is currently no case where the system does this.

# Motivation
The reasons for this change are manifold:

1. The primary motivation is to permit Revise to redefine structs. This has been a feature request since the very begining of Revise (https://github.com/timholy/Revise.jl/issues/18) and there have been numerous attempts over the past 7 years to address this, as well as countless duplicate feature request. A past attempt to implement the necessary julia support in #22721 failed because the consequences and semantics of re-defining bindings were not sufficiently worked out. One way to think of this implementation (at least with respect to types) is that it provides a well-grounded implementation of #22721.

2. A secondary motivation is to make `const`-redefinition no longer UB (although `const` redefinition will still have a significant performance penalty, so it is not recommended). See e.g. the full discussion in #54099 and #38584.

3. Not currently implemented, but this mechanism can be used to re-compile code where bindings are introduced after the first compile, which is a common performance trap for new users (#53958).

4. Not currently implemented, but this mechanism can be used to clarify the semantics of bindings import and resolution to address issues like #14055.

# Implementation

In this PR:
 - `Binding` gets `min_world`/`max_world` fields like `CodeInstance`
 - Various lookup functions walk this linked list using the current task world_age as a key
 - Inference accumulates world bounds as it would for methods
 - Upon binding replacement, we walk all methods in the system, invalidating those whose uninferred IR references the replaced GlobalRef
 - One primary complication is that our IR definition permits `const` globals in value position, but if binding replacement is permitted, the validity of this may change after the fact. To address this, there is a helper in `Core.Compiler` that gets invoked in the type inference world and will rewrite the method source to be legal in all worlds.
 - A new `@world` macro can be used to access bindings from old world ages. This is used in printing for old objects.
 - The `const`-override behavior was changed to only be permitted at toplevel. The warnings about it being UB was removed.

Of particular note, this PR does not include any mechanism for invalidating methods whose signatures were created using an old Binding (or types whose fields were the result of a binding evaluation). There was some discussion among the compiler team of whether such a mechanism should exist in base, but the consensus was that it should not. In particular, although uncommon, a pattern like:
```
f() = Any
g(::f()) = 1
f() = Int
```
Does not redefine `g`. Thus to fully address the Revise issue, additional code will be required in Revise to track the dependency of various signatures and struct definitions on bindings.

# Demo
```
julia> struct Foo
               a::Int
       end

julia> g() = Foo(1)
g (generic function with 1 method)

julia> g()
Foo(1)

julia> f(::Foo) = 1
f (generic function with 1 method)

julia> fold = Foo(1)
Foo(1)

julia> struct Foo
               a::Int
               b::Int
       end

julia> g()
ERROR: MethodError: no method matching Foo(::Int64)
The type `Foo` exists, but no method is defined for this combination of argument types when trying to construct it.

Closest candidates are:
  Foo(::Int64, ::Int64)
   @ Main REPL[6]:2
  Foo(::Any, ::Any)
   @ Main REPL[6]:2

Stacktrace:
 [1] g()
   @ Main ./REPL[2]:1
 [2] top-level scope
   @ REPL[7]:1

julia> f(::Foo) = 2
f (generic function with 2 methods)

julia> methods(f)
# 2 methods for generic function "f" from Main:
 [1] f(::Foo)
     @ REPL[8]:1
 [2] f(::@world(Foo, 0:26898))
     @ REPL[4]:1

julia> fold
@world(Foo, 0:26898)(1)
```

# Performance consideration
On my machine, the validation required upon binding replacement for the full system image takes about 200ms. With CedarSim loaded (I tried OmniPackage, but it's not working on master), this increases about 5x. That's a fair bit of compute, but not the end of the world. Still, Revise may have to batch its validation. There may also be opportunities for performance improvement by operating on the compressed representation directly.

# Semantic TODO

- [x] Do we want to change the resolution time of bindings to (semantically) resolve them immediately?
- [x] Do we want to introduce guard bindings when inference assumes the absence of a binding?
- [x] When (if ever) do globals get declared implicitly?

# Implementation TODO
- [x] Precompile re-validation
- [x] Various cleanups in the accessors
- [x] Implement new typed global semantics
- [x] Invert the order of the binding linked list to make the most recent one always the head of the list
- [x] CodeInstances need forward edges for GlobalRefs not part of the uninferred code
- [x] Generated function support [#57230]
- [x] Partition `using` by world age as well
- [x] `const`/`global` lowering changes [#54773]
- [x] Implement new `BindingPartition` type [#54788]
- [x] Implicit introduction of globals by `global a`
- [ ] Implement using reverse edges