### PR TITLE
add `--trace-compile-timing` arg to add compile timing comments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,8 @@ Command-line option changes
 [`NO_COLOR`](https://no-color.org/) or [`FORCE_COLOR`](https://force-color.org/) environment
 variables. ([#53742]).
 * `--project=@temp` starts Julia with a temporary environment.
+* New `--trace-compile-timing` option to report how long each method reported by `--trace-compile` took
+  to compile, in ms. ([#54662])
 
 Multi-threading changes
 -----------------------

--- a/base/options.jl
+++ b/base/options.jl
@@ -57,6 +57,7 @@ struct JLOptions
     strip_ir::Int8
     permalloc_pkgimg::Int8
     heap_size_hint::UInt64
+    trace_compile_timing::Int8
 end
 
 # This runs early in the sysimage != is not defined yet

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -286,6 +286,10 @@ Generate an incremental output file (rather than complete)
 Print precompile statements for methods compiled during execution or save to a path
 
 .TP
+--trace-compile-timing=
+If --trace-compile is enabled show how long each took to compile in ms
+
+.TP
 -image-codegen
 Force generate code in imaging mode
 

--- a/doc/src/manual/command-line-interface.md
+++ b/doc/src/manual/command-line-interface.md
@@ -215,6 +215,7 @@ The following is a complete list of command-line switches available when launchi
 |`--output-asm <name>`                  |Generate an assembly file (.s)|
 |`--output-incremental={yes\|no*}`      |Generate an incremental output file (rather than complete)|
 |`--trace-compile={stderr\|name}`       |Print precompile statements for methods compiled during execution or save to a path|
+|`--trace-compile-timing`               |If --trace-compile is enabled show how long each took to compile in ms|
 |`--image-codegen`                      |Force generate code in imaging mode|
 |`--permalloc-pkgimg={yes\|no*}`        |Copy the data section of package images into memory|
 

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -100,6 +100,7 @@ JL_DLLEXPORT void jl_init_options(void)
                         0, // strip-ir
                         0, // permalloc_pkgimg
                         0, // heap-size-hint
+                        0, // trace_compile_timing
     };
     jl_options_initialized = 1;
 }
@@ -258,6 +259,8 @@ static const char opts_hidden[]  =
     "                                               complete)\n"
     " --trace-compile={stderr|name}                 Print precompile statements for methods compiled\n"
     "                                               during execution or save to a path\n"
+    " --trace-compile-timing                        If --trace-compile is enabled show how long each took to\n"
+    "                                               compile in ms\n"
     " --image-codegen                               Force generate code in imaging mode\n"
     " --permalloc-pkgimg={yes|no*}                  Copy the data section of package images into memory\n"
 ;
@@ -280,6 +283,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_inline,
            opt_polly,
            opt_trace_compile,
+           opt_trace_compile_timing,
            opt_math_mode,
            opt_worker,
            opt_bind_to,
@@ -356,6 +360,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "inline",          required_argument, 0, opt_inline },
         { "polly",           required_argument, 0, opt_polly },
         { "trace-compile",   required_argument, 0, opt_trace_compile },
+        { "trace-compile-timing",  no_argument, 0, opt_trace_compile_timing },
         { "math-mode",       required_argument, 0, opt_math_mode },
         { "handle-signals",  required_argument, 0, opt_handle_signals },
         // hidden command line options
@@ -794,7 +799,7 @@ restart_switch:
                 jl_errorf("julia: invalid argument to --inline (%s)", optarg);
             }
             break;
-       case opt_polly:
+        case opt_polly:
             if (!strcmp(optarg,"yes"))
                 jl_options.polly = JL_OPTIONS_POLLY_ON;
             else if (!strcmp(optarg,"no"))
@@ -803,10 +808,13 @@ restart_switch:
                 jl_errorf("julia: invalid argument to --polly (%s)", optarg);
             }
             break;
-         case opt_trace_compile:
+        case opt_trace_compile:
             jl_options.trace_compile = strdup(optarg);
             if (!jl_options.trace_compile)
                 jl_errorf("fatal error: failed to allocate memory: %s", strerror(errno));
+            break;
+        case opt_trace_compile_timing:
+            jl_options.trace_compile_timing = 1;
             break;
         case opt_math_mode:
             if (!strcmp(optarg,"ieee"))

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -61,6 +61,7 @@ typedef struct {
     int8_t strip_ir;
     int8_t permalloc_pkgimg;
     uint64_t heap_size_hint;
+    int8_t trace_compile_timing;
 } jl_options_t;
 
 #endif

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -801,7 +801,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
             `$exename --trace-compile=stderr --trace-compile-timing -i`,
             stderr=io)
         _stderr = String(take!(io))
-        @test occursin(" ms =# precompile(Tuple{typeof(Main.foo), Int64})", _stderr)
+        @test occursin(" ms =# precompile(Tuple{typeof(Main.foo), Int", _stderr)
     end
 
     # test passing arguments

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -793,6 +793,17 @@ let exename = `$(Base.julia_cmd()) --startup-file=no --color=no`
     # tested in test/parallel.jl)
     @test errors_not_signals(`$exename --worker=true`)
 
+    # --trace-compile-timing
+    let
+        io = IOBuffer()
+        v = writereadpipeline(
+            "foo(x) = begin Base.Experimental.@force_compile; x; end; foo(1)",
+            `$exename --trace-compile=stderr --trace-compile-timing -i`,
+            stderr=io)
+        _stderr = String(take!(io))
+        @test occursin(" ms =# precompile(Tuple{typeof(Main.foo), Int64})", _stderr)
+    end
+
     # test passing arguments
     mktempdir() do dir
         testfile, io = mktemp(dir)


### PR DESCRIPTION
```
% ./julia --trace-compile=stderr --trace-compile-timing --start=no -e "using ProfileView"
#=   0.0 ms =# precompile(Tuple{typeof(Requires.__init__)})
#=  19.4 ms =# precompile(Tuple{typeof(Requires.isprecompiling)})
#=   0.0 ms =# precompile(Tuple{typeof(Requires.listenpkg), Any, Base.PkgId})
#=   0.0 ms =# precompile(Tuple{typeof(Requires.loaded), Base.PkgId})
#=  13.4 ms =# precompile(Tuple{typeof(Base.haskey), Base.Dict{Base.PkgId, Module}, Base.PkgId})
#=   0.0 ms =# precompile(Tuple{typeof(Requires.callbacks), Base.PkgId})
#=   0.0 ms =# precompile(Tuple{typeof(Libiconv_jll.__init__)})
#=   0.0 ms =# precompile(Tuple{typeof(Libiconv_jll.find_artifact_dir)})
#=  32.0 ms =# precompile(Tuple{typeof(Artifacts._artifact_str), Module, String, Base.SubString{String}, String, Base.Dict{String, Any}, Base.SHA1, Base.BinaryPlatforms.Platform, Any})
#=   1.5 ms =# precompile(Tuple{typeof(Base.invokelatest), Any})
...
```