### PR TITLE
Add boundscheck in bindingkey_eq to avoid OOB access due to data race

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -710,13 +710,15 @@ JL_DLLEXPORT int jl_binding_resolved_p(jl_module_t *m, jl_sym_t *var)
 
 static uint_t bindingkey_hash(size_t idx, jl_value_t *data)
 {
-    jl_binding_t *b = (jl_binding_t*)jl_svecref(data, idx);
+    jl_binding_t *b = (jl_binding_t*)jl_svecref(data, idx); // This must always happen inside the lock
     jl_sym_t *var = b->globalref->name;
     return var->hash;
 }
 
 static int bindingkey_eq(size_t idx, const void *var, jl_value_t *data, uint_t hv)
 {
+    if ((idx >= ((jl_svec_t*)data)->length || idx < 0))
+        return 0; // We got a OOB access, probably due to a data race
     jl_binding_t *b = (jl_binding_t*)jl_svecref(data, idx);
     jl_sym_t *name = b->globalref->name;
     return var == name;

--- a/src/module.c
+++ b/src/module.c
@@ -717,7 +717,7 @@ static uint_t bindingkey_hash(size_t idx, jl_value_t *data)
 
 static int bindingkey_eq(size_t idx, const void *var, jl_value_t *data, uint_t hv)
 {
-    if ((idx >= ((jl_svec_t*)data)->length || idx < 0))
+    if (idx >= jl_svec_len(data))
         return 0; // We got a OOB access, probably due to a data race
     jl_binding_t *b = (jl_binding_t*)jl_svecref(data, idx);
     jl_sym_t *name = b->globalref->name;


### PR DESCRIPTION
The race here is that svec might be replaced and a new binding introduced into the keyset while we hold a reference to the old svec, which led to a OOB access on the svec with the index a binding introduced at the same time. This now introduces a bounds check which will force taking the lock if we fail the lookup i.e we had a data race.

Fixes https://github.com/JuliaLang/julia/issues/54285