### PR TITLE
make: Fix `sed` command for LLVM libraries with no symbol versioning

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -128,7 +128,7 @@ ifneq ($(USE_SYSTEM_LLVM),0)
 # USE_SYSTEM_LLVM != 0
 CG_LLVMLINK += $(LLVM_LDFLAGS) $(shell $(LLVM_CONFIG_HOST) --libs --system-libs)
 LLVM_SHLIB_SYMBOL_VERSION := $(shell nm -D --with-symbol-versions $(shell $(LLVM_CONFIG_HOST) --libfiles --link-shared | awk '{print $1; exit}') | \
-                               grep _ZN4llvm3Any6TypeId | head -n 1 | sed -e 's/.*@//')
+                               grep _ZN4llvm3Any6TypeId | head -n 1 | sed -ne 's/.*@//p')
 
 # HACK: llvm-config doesn't correctly point to shared libs on all platforms
 #       https://github.com/JuliaLang/julia/issues/29981


### PR DESCRIPTION
If the LLVM library was built without symbol versioning, previously this would return the `nm` output in its entirety, instead of correctly reporting "" as the LLVM symbol version.