### PR TITLE
REPLInterpreter: discard sources aggressively

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -566,6 +566,9 @@ CC.cache_owner(::REPLInterpreter) = REPLCacheToken()
 # REPLInterpreter is only used for type analysis, so it should disable optimization entirely
 CC.may_optimize(::REPLInterpreter) = false
 
+# REPLInterpreter doesn't need any sources to be cached, so discard them aggressively
+CC.transform_result_for_cache(::REPLInterpreter, ::Core.MethodInstance, ::CC.WorldRange, ::CC.InferenceResult) = nothing
+
 # REPLInterpreter analyzes a top-level frame, so better to not bail out from it
 CC.bail_out_toplevel_call(::REPLInterpreter, ::CC.InferenceLoopState, ::CC.InferenceState) = false
 


### PR DESCRIPTION
There's no need to hold any inferred sources in the `REPLInterpreter`s cache, so it's more space efficient to aggressively discard the inferred sources.