### PR TITLE
remove Method.roots with --strip-ir

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3167,7 +3167,7 @@ static jl_value_t *jl_ensure_rooted(jl_codectx_t &ctx, jl_value_t *val)
     if (jl_is_globally_rooted(val))
         return val;
     jl_method_t *m = ctx.linfo->def.method;
-    if (jl_is_method(m)) {
+    if (!jl_options.strip_ir && jl_is_method(m)) {
         // the method might have a root for this already; use it if so
         JL_LOCK(&m->writelock);
         if (m->roots) {

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -2437,6 +2437,7 @@ static int strip_all_codeinfos__(jl_typemap_entry_t *def, void *_env)
             }
             if (should_strip_ir) {
                 record_field_change(&m->source, jl_nothing);
+                record_field_change((jl_value_t**)&m->roots, NULL);
                 stripped_ir = 1;
             }
         }


### PR DESCRIPTION
This "roots" list is now only used for references to values in IR, and so is really part of the IR representation and can be removed by --strip-ir (and is also a bit mis-named).