### PR TITLE
Revert "cleanup `MemoryRef` (#54647)"

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -216,7 +216,7 @@ isbitsunion(u::Type) = u isa Union && allocatedinline(u)
 function _unsetindex!(A::Array, i::Int)
     @inline
     @boundscheck checkbounds(A, i)
-    @inbounds _unsetindex!(memoryref(A.ref, i))
+    @inbounds _unsetindex!(GenericMemoryRef(A.ref, i))
     return A
 end
 
@@ -239,14 +239,14 @@ function isassigned(a::Array, i::Int...)
     @_noub_if_noinbounds_meta
     @boundscheck checkbounds(Bool, a, i...) || return false
     ii = _sub2ind(size(a), i...)
-    return @inbounds isassigned(memoryrefnew(a.ref, ii, false))
+    return @inbounds isassigned(memoryref(a.ref, ii, false))
 end
 
 function isassigned(a::Vector, i::Int) # slight compiler simplification for the most common case
     @inline
     @_noub_if_noinbounds_meta
     @boundscheck checkbounds(Bool, a, i) || return false
-    return @inbounds isassigned(memoryrefnew(a.ref, i, false))
+    return @inbounds isassigned(memoryref(a.ref, i, false))
 end
 
 
@@ -281,7 +281,7 @@ the same manner as C.
 """
 function unsafe_copyto!(dest::Array, doffs, src::Array, soffs, n)
     n == 0 && return dest
-    unsafe_copyto!(memoryref(dest.ref, doffs), memoryref(src.ref, soffs), n)
+    unsafe_copyto!(GenericMemoryRef(dest.ref, doffs), GenericMemoryRef(src.ref, soffs), n)
     return dest
 end
 
@@ -303,8 +303,8 @@ function _copyto_impl!(dest::Union{Array,Memory}, doffs::Integer, src::Union{Arr
     n > 0 || _throw_argerror("Number of elements to copy must be non-negative.")
     @boundscheck checkbounds(dest, doffs:doffs+n-1)
     @boundscheck checkbounds(src, soffs:soffs+n-1)
-    @inbounds let dest = memoryref(dest isa Array ? getfield(dest, :ref) : dest, doffs),
-                  src = memoryref(src isa Array ? getfield(src, :ref) : src, soffs)
+    @inbounds let dest = GenericMemoryRef(dest isa Array ? getfield(dest, :ref) : dest, doffs),
+                  src = GenericMemoryRef(src isa Array ? getfield(src, :ref) : src, soffs)
         unsafe_copyto!(dest, src, n)
     end
     return dest
@@ -348,7 +348,7 @@ copy
     @_nothrow_meta
     ref = a.ref
     newmem = ccall(:jl_genericmemory_copy_slice, Ref{Memory{T}}, (Any, Ptr{Cvoid}, Int), ref.mem, ref.ptr_or_offset, length(a))
-    return $(Expr(:new, :(typeof(a)), :(memoryref(newmem)), :(a.size)))
+    return $(Expr(:new, :(typeof(a)), :(Core.memoryref(newmem)), :(a.size)))
 end
 
 ## Constructors ##
@@ -964,21 +964,21 @@ function setindex! end
 function setindex!(A::Array{T}, x, i::Int) where {T}
     @_noub_if_noinbounds_meta
     @boundscheck (i - 1)%UInt < length(A)%UInt || throw_boundserror(A, (i,))
-    memoryrefset!(memoryrefnew(A.ref, i, false), x isa T ? x : convert(T,x)::T, :not_atomic, false)
+    memoryrefset!(memoryref(A.ref, i, false), x isa T ? x : convert(T,x)::T, :not_atomic, false)
     return A
 end
 function setindex!(A::Array{T}, x, i1::Int, i2::Int, I::Int...) where {T}
     @inline
     @_noub_if_noinbounds_meta
     @boundscheck checkbounds(A, i1, i2, I...) # generally _to_linear_index requires bounds checking
-    memoryrefset!(memoryrefnew(A.ref, _to_linear_index(A, i1, i2, I...), false), x isa T ? x : convert(T,x)::T, :not_atomic, false)
+    memoryrefset!(memoryref(A.ref, _to_linear_index(A, i1, i2, I...), false), x isa T ? x : convert(T,x)::T, :not_atomic, false)
     return A
 end
 
 __safe_setindex!(A::Vector{Any}, @nospecialize(x), i::Int) = (@inline; @_nothrow_noub_meta;
-    memoryrefset!(memoryrefnew(A.ref, i, false), x, :not_atomic, false); return A)
+    memoryrefset!(memoryref(A.ref, i, false), x, :not_atomic, false); return A)
 __safe_setindex!(A::Vector{T}, x::T, i::Int) where {T} = (@inline; @_nothrow_noub_meta;
-    memoryrefset!(memoryrefnew(A.ref, i, false), x, :not_atomic, false); return A)
+    memoryrefset!(memoryref(A.ref, i, false), x, :not_atomic, false); return A)
 __safe_setindex!(A::Vector{T}, x,    i::Int) where {T} = (@inline;
     __safe_setindex!(A, convert(T, x)::T, i))
 
@@ -1050,7 +1050,7 @@ function _growbeg!(a::Vector, delta::Integer)
     setfield!(a, :size, (newlen,))
     # if offset is far enough advanced to fit data in existing memory without copying
     if delta <= offset - 1
-        setfield!(a, :ref, @inbounds memoryref(ref, 1 - delta))
+        setfield!(a, :ref, @inbounds GenericMemoryRef(ref, 1 - delta))
     else
         @noinline (function()
         memlen = length(mem)
@@ -1075,7 +1075,7 @@ function _growbeg!(a::Vector, delta::Integer)
         if ref !== a.ref
             @noinline throw(ConcurrencyViolationError("Vector can not be resized concurrently"))
         end
-        setfield!(a, :ref, @inbounds memoryref(newmem, newoffset))
+        setfield!(a, :ref, @inbounds GenericMemoryRef(newmem, newoffset))
         end)()
     end
     return
@@ -1114,7 +1114,7 @@ function _growend!(a::Vector, delta::Integer)
             newmem = array_new_memory(mem, newmemlen2)
             newoffset = offset
         end
-        newref = @inbounds memoryref(newmem, newoffset)
+        newref = @inbounds GenericMemoryRef(newmem, newoffset)
         unsafe_copyto!(newref, ref, len)
         if ref !== a.ref
             @noinline throw(ConcurrencyViolationError("Vector can not be resized concurrently"))
@@ -1146,7 +1146,7 @@ function _growat!(a::Vector, i::Integer, delta::Integer)
     prefer_start = i <= div(len, 2)
     # if offset is far enough advanced to fit data in beginning of the memory
     if prefer_start && delta <= offset - 1
-        newref = @inbounds memoryref(mem, offset - delta)
+        newref = @inbounds GenericMemoryRef(mem, offset - delta)
         unsafe_copyto!(newref, ref, i)
         setfield!(a, :ref, newref)
         for j in i:i+delta-1
@@ -1163,7 +1163,7 @@ function _growat!(a::Vector, i::Integer, delta::Integer)
         newmemlen = max(overallocation(memlen), len+2*delta+1)
         newoffset = (newmemlen - newlen) ÷ 2 + 1
         newmem = array_new_memory(mem, newmemlen)
-        newref = @inbounds memoryref(newmem, newoffset)
+        newref = @inbounds GenericMemoryRef(newmem, newoffset)
         unsafe_copyto!(newref, ref, i-1)
         unsafe_copyto!(newmem, newoffset + delta + i - 1, mem, offset + i - 1, len - i + 1)
         setfield!(a, :ref, newref)
@@ -1180,7 +1180,7 @@ function _deletebeg!(a::Vector, delta::Integer)
     end
     newlen = len - delta
     if newlen != 0 # if newlen==0 we could accidentally index past the memory
-        newref = @inbounds memoryref(a.ref, delta + 1)
+        newref = @inbounds GenericMemoryRef(a.ref, delta + 1)
         setfield!(a, :ref, newref)
     end
     setfield!(a, :size, (newlen,))
@@ -1497,16 +1497,16 @@ function sizehint!(a::Vector, sz::Integer; first::Bool=false, shrink::Bool=true)
         end
         newmem = array_new_memory(mem, sz)
         if first
-            newref = memoryref(newmem, inc + 1)
+            newref = GenericMemoryRef(newmem, inc + 1)
         else
-            newref = memoryref(newmem)
+            newref = GenericMemoryRef(newmem)
         end
         unsafe_copyto!(newref, ref, len)
         setfield!(a, :ref, newref)
     elseif first
         _growbeg!(a, inc)
         newref = getfield(a, :ref)
-        newref = memoryref(newref, inc + 1)
+        newref = GenericMemoryRef(newref, inc + 1)
         setfield!(a, :size, (len,)) # undo the size change from _growbeg!
         setfield!(a, :ref, newref) # undo the offset change from _growbeg!
     else # last

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -534,12 +534,15 @@ const undef = UndefInitializer()
 # empty vector constructor
 (self::Type{GenericMemory{kind,T,addrspace}})() where {T,kind,addrspace} = self(undef, 0)
 
-memoryref(mem::GenericMemory) = memoryrefnew(mem)
-memoryref(mem::GenericMemory, i::Integer) = memoryrefnew(memoryrefnew(mem), Int(i), @_boundscheck)
-memoryref(ref::GenericMemoryRef, i::Integer) = memoryrefnew(ref, Int(i), @_boundscheck)
 GenericMemoryRef(mem::GenericMemory) = memoryref(mem)
-GenericMemoryRef(mem::GenericMemory, i::Integer) = memoryref(mem, i)
-GenericMemoryRef(mem::GenericMemoryRef, i::Integer) = memoryref(mem, i)
+GenericMemoryRef(ref::GenericMemoryRef, i::Integer) = memoryref(ref, Int(i), @_boundscheck)
+GenericMemoryRef(mem::GenericMemory, i::Integer) = memoryref(memoryref(mem), Int(i), @_boundscheck)
+GenericMemoryRef{kind,<:Any,AS}(mem::GenericMemory{kind,<:Any,AS}) where {kind,AS} = memoryref(mem)
+GenericMemoryRef{kind,<:Any,AS}(ref::GenericMemoryRef{kind,<:Any,AS}, i::Integer) where {kind,AS} = memoryref(ref, Int(i), @_boundscheck)
+GenericMemoryRef{kind,<:Any,AS}(mem::GenericMemory{kind,<:Any,AS}, i::Integer) where {kind,AS}  = memoryref(memoryref(mem), Int(i), @_boundscheck)
+GenericMemoryRef{kind,T,AS}(mem::GenericMemory{kind,T,AS}) where {kind,T,AS}  = memoryref(mem)
+GenericMemoryRef{kind,T,AS}(ref::GenericMemoryRef{kind,T,AS}, i::Integer) where {kind,T,AS} = memoryref(ref, Int(i), @_boundscheck)
+GenericMemoryRef{kind,T,AS}(mem::GenericMemory{kind,T,AS}, i::Integer) where {kind,T,AS} = memoryref(memoryref(mem), Int(i), @_boundscheck)
 
 const Memory{T} = GenericMemory{:not_atomic, T, CPU}
 const MemoryRef{T} = GenericMemoryRef{:not_atomic, T, CPU}
@@ -647,12 +650,12 @@ module IR
 export CodeInfo, MethodInstance, CodeInstance, GotoNode, GotoIfNot, ReturnNode,
     NewvarNode, SSAValue, SlotNumber, Argument,
     PiNode, PhiNode, PhiCNode, UpsilonNode, DebugInfo,
-    Const, PartialStruct, InterConditional, EnterNode, memoryref
+    Const, PartialStruct, InterConditional, EnterNode
 
 using Core: CodeInfo, MethodInstance, CodeInstance, GotoNode, GotoIfNot, ReturnNode,
     NewvarNode, SSAValue, SlotNumber, Argument,
     PiNode, PhiNode, PhiCNode, UpsilonNode, DebugInfo,
-    Const, PartialStruct, InterConditional, EnterNode, memoryref
+    Const, PartialStruct, InterConditional, EnterNode
 
 end # module IR
 

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -666,7 +666,7 @@ function iscall_with_boundscheck(@nospecialize(stmt), sv::PostOptAnalysisState)
     f === nothing && return false
     if f === getfield
         nargs = 4
-    elseif f === memoryrefnew || f === memoryrefget || f === memoryref_isassigned
+    elseif f === memoryref || f === memoryrefget || f === memoryref_isassigned
         nargs = 4
     elseif f === memoryrefset!
         nargs = 5

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -2028,7 +2028,7 @@ end
     hasintersect(widenconst(idx), Int) || return Bottom
     return ref
 end
-add_tfunc(memoryrefnew, 1, 3, memoryref_tfunc, 1)
+add_tfunc(memoryref, 1, 3, memoryref_tfunc, 1)
 
 @nospecs function memoryrefoffset_tfunc(𝕃::AbstractLattice, mem)
     hasintersect(widenconst(mem), GenericMemoryRef) || return Bottom
@@ -2181,7 +2181,7 @@ function _builtin_nothrow(𝕃::AbstractLattice, @nospecialize(f::Builtin), argt
                           @nospecialize(rt))
     ⊑ = partialorder(𝕃)
     na = length(argtypes)
-    if f === memoryrefnew
+    if f === memoryref
         return memoryref_builtin_common_nothrow(argtypes)
     elseif f === memoryrefoffset
         length(argtypes) == 1 || return false
@@ -2297,7 +2297,7 @@ const _EFFECT_FREE_BUILTINS = [
     isa,
     UnionAll,
     getfield,
-    memoryrefnew,
+    memoryref,
     memoryrefoffset,
     memoryrefget,
     memoryref_isassigned,
@@ -2332,7 +2332,7 @@ const _INACCESSIBLEMEM_BUILTINS = Any[
 ]
 
 const _ARGMEM_BUILTINS = Any[
-    memoryrefnew,
+    memoryref,
     memoryrefoffset,
     memoryrefget,
     memoryref_isassigned,
@@ -2503,7 +2503,7 @@ function builtin_effects(𝕃::AbstractLattice, @nospecialize(f::Builtin), argty
     else
         if contains_is(_CONSISTENT_BUILTINS, f)
             consistent = ALWAYS_TRUE
-        elseif f === memoryrefnew || f === memoryrefoffset
+        elseif f === memoryref || f === memoryrefoffset
             consistent = ALWAYS_TRUE
         elseif f === memoryrefget || f === memoryrefset! || f === memoryref_isassigned
             consistent = CONSISTENT_IF_INACCESSIBLEMEMONLY
@@ -2527,7 +2527,7 @@ function builtin_effects(𝕃::AbstractLattice, @nospecialize(f::Builtin), argty
         else
             inaccessiblememonly = ALWAYS_FALSE
         end
-        if f === memoryrefnew || f === memoryrefget || f === memoryrefset! || f === memoryref_isassigned
+        if f === memoryref || f === memoryrefget || f === memoryrefset! || f === memoryref_isassigned
             noub = memoryop_noub(f, argtypes) ? ALWAYS_TRUE : ALWAYS_FALSE
         else
             noub = ALWAYS_TRUE
@@ -2541,7 +2541,7 @@ function memoryop_noub(@nospecialize(f), argtypes::Vector{Any})
     nargs == 0 && return true # must throw and noub
     lastargtype = argtypes[end]
     isva = isvarargtype(lastargtype)
-    if f === memoryrefnew
+    if f === memoryref
         if nargs == 1 && !isva
             return true
         elseif nargs == 2 && !isva

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -105,16 +105,16 @@ function _deepcopy_memory_t(@nospecialize(x::Memory), T, stackdict::IdDict)
     end
     dest = typeof(x)(undef, length(x))
     stackdict[x] = dest
-    xr = memoryref(x)
-    dr = memoryref(dest)
+    xr = Core.memoryref(x)
+    dr = Core.memoryref(dest)
     for i = 1:length(x)
-        xi = Core.memoryrefnew(xr, i, false)
+        xi = Core.memoryref(xr, i, false)
         if Core.memoryref_isassigned(xi, :not_atomic, false)
             xi = Core.memoryrefget(xi, :not_atomic, false)
             if !isbits(xi)
                 xi = deepcopy_internal(xi, stackdict)::typeof(xi)
             end
-            di = Core.memoryrefnew(dr, i, false)
+            di = Core.memoryref(dr, i, false)
             Core.memoryrefset!(di, xi, :not_atomic, false)
         end
     end
@@ -131,9 +131,9 @@ function deepcopy_internal(x::GenericMemoryRef, stackdict::IdDict)
         return stackdict[x]::typeof(x)
     end
     mem = getfield(x, :mem)
-    dest = memoryref(deepcopy_internal(mem, stackdict)::typeof(mem))
+    dest = GenericMemoryRef(deepcopy_internal(mem, stackdict)::typeof(mem))
     i = memoryrefoffset(x)
-    i == 1 || (dest = Core.memoryrefnew(dest, i, true))
+    i == 1 || (dest = Core.memoryref(dest, i, true))
     return dest
 end
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2683,23 +2683,23 @@ julia> Memory{Float64}(undef, 3)
 Memory{T}(::UndefInitializer, n)
 
 """
-    `memoryref(::GenericMemory)`
+    MemoryRef(memory)
 
-Construct a `GenericMemoryRef` from a memory object. This does not fail, but the
-resulting memory will point out-of-bounds if and only if the memory is empty.
+Construct a MemoryRef from a memory object. This does not fail, but the
+resulting memory may point out-of-bounds if the memory is empty.
 """
-memoryref(::Memory)
+MemoryRef(::Memory)
 
 """
-    memoryref(::GenericMemory, index::Integer)
-    memoryref(::GenericMemoryRef, index::Integer)
+    MemoryRef(::Memory, index::Integer)
+    MemoryRef(::MemoryRef, index::Integer)
 
-Construct a `GenericMemoryRef` from a memory object and an offset index (1-based) which
+Construct a MemoryRef from a memory object and an offset index (1-based) which
 can also be negative. This always returns an inbounds object, and will throw an
 error if that is not possible (because the index would result in a shift
 out-of-bounds of the underlying memory).
 """
-memoryref(::Union{GenericMemory,GenericMemoryRef}, ::Integer)
+MemoryRef(::Union{Memory,MemoryRef}, ::Integer)
 
 """
     Vector{T}(undef, n)

--- a/base/docs/intrinsicsdocs.jl
+++ b/base/docs/intrinsicsdocs.jl
@@ -23,20 +23,20 @@ The `Core.Intrinsics` module holds the `Core.IntrinsicFunction` objects.
 Core.Intrinsics
 
 """
-    Core.memoryrefnew(::GenericMemory)
-    Core.memoryrefnew(::GenericMemoryRef, index::Int, [boundscheck::Bool])
+    Core.memoryref(::GenericMemory)
+    Core.memoryref(::GenericMemoryRef, index::Int, [boundscheck::Bool])
 
-Return a `GenericMemoryRef` for a `GenericMemory`. See [`memoryref`](@ref).
+Return a `GenericMemoryRef` for a `GenericMemory`. See [`MemoryRef`](@ref).
 
 !!! compat "Julia 1.11"
     This function requires Julia 1.11 or later.
 """
-Core.memoryrefnew
+Core.memoryref
 
 """
     Core..memoryrefoffset(::GenericMemoryRef)
 
-Return the offset index that was used to construct the `MemoryRef`. See [`memoryref`](@ref).
+Return the offset index that was used to construct the `MemoryRef`. See [`Core.memoryref`](@ref).
 
 !!! compat "Julia 1.11"
     This function requires Julia 1.11 or later.

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Core: CodeInfo, SimpleVector, donotdelete, compilerbarrier, memoryrefnew, memoryrefget, memoryrefset!
+using Core: CodeInfo, SimpleVector, donotdelete, compilerbarrier, memoryref, memoryrefget, memoryrefset!
 
 const Callable = Union{Function,Type}
 
@@ -361,7 +361,7 @@ default_access_order(a::GenericMemoryRef{:not_atomic}) = :not_atomic
 default_access_order(a::GenericMemoryRef{:atomic}) = :monotonic
 
 getindex(A::GenericMemory, i::Int) = (@_noub_if_noinbounds_meta;
-    memoryrefget(memoryrefnew(memoryrefnew(A), i, @_boundscheck), default_access_order(A), false))
+    memoryrefget(memoryref(memoryref(A), i, @_boundscheck), default_access_order(A), false))
 getindex(A::GenericMemoryRef) = memoryrefget(A, default_access_order(A), @_boundscheck)
 
 """
@@ -892,16 +892,16 @@ end
 function getindex(A::Array, i::Int)
     @_noub_if_noinbounds_meta
     @boundscheck ult_int(bitcast(UInt, sub_int(i, 1)), bitcast(UInt, length(A))) || throw_boundserror(A, (i,))
-    memoryrefget(memoryrefnew(getfield(A, :ref), i, false), :not_atomic, false)
+    memoryrefget(memoryref(getfield(A, :ref), i, false), :not_atomic, false)
 end
 # simple Array{Any} operations needed for bootstrap
 function setindex!(A::Array{Any}, @nospecialize(x), i::Int)
     @_noub_if_noinbounds_meta
     @boundscheck ult_int(bitcast(UInt, sub_int(i, 1)), bitcast(UInt, length(A))) || throw_boundserror(A, (i,))
-    memoryrefset!(memoryrefnew(getfield(A, :ref), i, false), x, :not_atomic, false)
+    memoryrefset!(memoryref(getfield(A, :ref), i, false), x, :not_atomic, false)
     return A
 end
-setindex!(A::Memory{Any}, @nospecialize(x), i::Int) = (memoryrefset!(memoryrefnew(memoryrefnew(A), i, @_boundscheck), x, :not_atomic, @_boundscheck); A)
+setindex!(A::Memory{Any}, @nospecialize(x), i::Int) = (memoryrefset!(memoryref(memoryref(A), i, @_boundscheck), x, :not_atomic, @_boundscheck); A)
 setindex!(A::MemoryRef{T}, x) where {T} = (memoryrefset!(A, convert(T, x), :not_atomic, @_boundscheck); A)
 setindex!(A::MemoryRef{Any}, @nospecialize(x)) = (memoryrefset!(A, x, :not_atomic, @_boundscheck); A)
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -549,7 +549,6 @@ export
     mapfoldl,
     mapfoldr,
     mapreduce,
-    memoryref,
     merge!,
     mergewith!,
     merge,

--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -48,12 +48,12 @@ IndexStyle(::Type{<:GenericMemory}) = IndexLinear()
 
 pointer(mem::GenericMemoryRef) = unsafe_convert(Ptr{Cvoid}, mem) # no bounds check, even for empty array
 
-_unsetindex!(A::Memory, i::Int) =  (@_propagate_inbounds_meta; _unsetindex!(memoryref(A, i)); A)
+_unsetindex!(A::Memory, i::Int) =  (@_propagate_inbounds_meta; _unsetindex!(GenericMemoryRef(A, i)); A)
 function _unsetindex!(A::MemoryRef{T}) where T
     @_terminates_locally_meta
     @_propagate_inbounds_meta
     @inline
-    @boundscheck memoryref(A, 1)
+    @boundscheck GenericMemoryRef(A, 1)
     mem = A.mem
     MemT = typeof(mem)
     arrayelem = datatype_arrayelem(MemT)
@@ -82,7 +82,7 @@ sizeof(a::GenericMemory) = Core.sizeof(a)
 function isassigned(a::GenericMemory, i::Int)
     @inline
     @boundscheck (i - 1)%UInt < length(a)%UInt || return false
-    return @inbounds memoryref_isassigned(memoryref(a, i), default_access_order(a), false)
+    return @inbounds memoryref_isassigned(GenericMemoryRef(a, i), default_access_order(a), false)
 end
 
 isassigned(a::GenericMemoryRef) = memoryref_isassigned(a, default_access_order(a), @_boundscheck)
@@ -91,21 +91,21 @@ isassigned(a::GenericMemoryRef) = memoryref_isassigned(a, default_access_order(a
 function unsafe_copyto!(dest::MemoryRef{T}, src::MemoryRef{T}, n) where {T}
     @_terminates_globally_notaskstate_meta
     n == 0 && return dest
-    @boundscheck memoryref(dest, n), memoryref(src, n)
+    @boundscheck GenericMemoryRef(dest, n), GenericMemoryRef(src, n)
     ccall(:jl_genericmemory_copyto, Cvoid, (Any, Ptr{Cvoid}, Any, Ptr{Cvoid}, Int), dest.mem, dest.ptr_or_offset, src.mem, src.ptr_or_offset, Int(n))
     return dest
 end
 
 function unsafe_copyto!(dest::GenericMemoryRef, src::GenericMemoryRef, n)
     n == 0 && return dest
-    @boundscheck memoryref(dest, n), memoryref(src, n)
+    @boundscheck GenericMemoryRef(dest, n), GenericMemoryRef(src, n)
     unsafe_copyto!(dest.mem, memoryrefoffset(dest), src.mem, memoryrefoffset(src), n)
     return dest
 end
 
 function unsafe_copyto!(dest::Memory{T}, doffs, src::Memory{T}, soffs, n) where{T}
     n == 0 && return dest
-    unsafe_copyto!(memoryref(dest, doffs), memoryref(src, soffs), n)
+    unsafe_copyto!(GenericMemoryRef(dest, doffs), GenericMemoryRef(src, soffs), n)
     return dest
 end
 
@@ -209,7 +209,7 @@ getindex(A::Memory, c::Colon) = copy(A)
 
 function setindex!(A::Memory{T}, x, i1::Int) where {T}
     val = x isa T ? x : convert(T,x)::T
-    ref = memoryrefnew(memoryref(A), i1, @_boundscheck)
+    ref = memoryref(memoryref(A), i1, @_boundscheck)
     memoryrefset!(ref, val, :not_atomic, @_boundscheck)
     return A
 end
@@ -294,7 +294,7 @@ end
     function reshape(m::GenericMemory{M, T}, dims::Vararg{Int, N}) where {M, T, N}
         len = Core.checked_dims(dims...)
         length(m) == len || throw(DimensionMismatch("parent has $(length(m)) elements, which is incompatible with size $(dims)"))
-        ref = memoryref(m)
+        ref = MemoryRef(m)
         $(Expr(:new, :(Array{T, N}), :ref, :dims))
     end
 
@@ -307,7 +307,7 @@ end
     function view(m::GenericMemory{M, T}, inds::Union{UnitRange, OneTo}) where {M, T}
         isempty(inds) && return T[] # needed to allow view(Memory{T}(undef, 0), 2:1)
         @boundscheck checkbounds(m, inds)
-        ref = memoryref(m, first(inds)) # @inbounds would be safe here but does not help performance.
+        ref = MemoryRef(m, first(inds)) # @inbounds would be safe here but does not help performance.
         dims = (Int(length(inds)),)
         $(Expr(:new, :(Array{T, 1}), :ref, :dims))
     end

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -51,9 +51,9 @@ eltype(::Type{<:ReshapedArrayIterator{I}}) where {I} = @isdefined(I) ? ReshapedI
     ref = a.ref
     if M == 1 && N !== 1
         mem = ref.mem::Memory{T}
-        if !(ref === memoryref(mem) && len === mem.length)
+        if !(ref === GenericMemoryRef(mem) && len === mem.length)
             mem = ccall(:jl_genericmemory_slice, Memory{T}, (Any, Ptr{Cvoid}, Int), mem, ref.ptr_or_offset, len)
-            ref = memoryref(mem)::typeof(ref)
+            ref = GenericMemoryRef(mem)::typeof(ref)
         end
     end
     # or we could use `a = Array{T,N}(undef, ntuple(0, Val(N))); a.ref = ref; a.size = dims; return a` here

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -79,7 +79,7 @@ function String(v::Vector{UInt8})
     end
     # optimized empty!(v); sizehint!(v, 0) calls
     setfield!(v, :size, (0,))
-    setfield!(v, :ref, memoryref(Memory{UInt8}()))
+    setfield!(v, :ref, MemoryRef(Memory{UInt8}()))
     return str
 end
 

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -31,7 +31,7 @@ Base.StridedVector
 Base.StridedMatrix
 Base.StridedVecOrMat
 Base.Memory
-Base.memoryref
+Base.MemoryRef
 Base.Slices
 Base.RowSlices
 Base.ColumnSlices

--- a/doc/src/devdocs/builtins.md
+++ b/doc/src/devdocs/builtins.md
@@ -7,7 +7,7 @@ definitions for what defines the abilities and behaviors of a Julia program. The
 typically accessed through a higher level generic API.
 
 ```@docs
-Core.memoryrefnew
+Core.memoryref
 Core.memoryrefoffset
 Core.memoryrefget
 Core.memoryrefset!

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2423,7 +2423,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     jl_builtin_setglobalonce = add_builtin_func("setglobalonce!", jl_f_setglobalonce);
 
     // memory primitives
-    jl_builtin_memoryref = add_builtin_func("memoryrefnew", jl_f_memoryref);
+    jl_builtin_memoryref = add_builtin_func("memoryref", jl_f_memoryref);
     jl_builtin_memoryrefoffset = add_builtin_func("memoryrefoffset", jl_f_memoryrefoffset);
     jl_builtin_memoryrefget = add_builtin_func("memoryrefget", jl_f_memoryrefget);
     jl_builtin_memoryrefset = add_builtin_func("memoryrefset!", jl_f_memoryrefset);

--- a/test/core.jl
+++ b/test/core.jl
@@ -6789,14 +6789,14 @@ primitive type TypeWith24Bits 24 end
 TypeWith24Bits(x::UInt32) = Core.Intrinsics.trunc_int(TypeWith24Bits, x)
 let x = TypeWith24Bits(0x112233), y = TypeWith24Bits(0x445566), z = TypeWith24Bits(0x778899)
     a = [x, x]
-    Core.memoryrefset!(Core.memoryrefnew(a.ref, 2, true), y, :not_atomic, true)
+    Core.memoryrefset!(Core.memoryref(a.ref, 2, true), y, :not_atomic, true)
     @test a == [x, y]
     a[2] = z
     @test a == [x, z]
     @test pointer(a, 2) - pointer(a, 1) == 4
 
     b = [(x, x), (x, x)]
-    Core.memoryrefset!(Core.memoryrefnew(b.ref, 2, true), (x, y), :not_atomic, true)
+    Core.memoryrefset!(Core.memoryref(b.ref, 2, true), (x, y), :not_atomic, true)
     @test b == [(x, x), (x, y)]
     b[2] = (y, z)
     @test b == [(x, x), (y, z)]


### PR DESCRIPTION
Reverts https://github.com/JuliaLang/julia/pull/54647

This reverts commit fa038d95b99301072d41514084e9d68a4c0776e9. The commit broke CI across all platforms.