### PR TITLE
Fix off-by-100 error in time_ns() docstring

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -152,7 +152,7 @@ end
 """
     time_ns() -> UInt64
 
-Get the time in nanoseconds. The time corresponding to 0 is undefined, and wraps every 5.8 years.
+Get the time in nanoseconds. The time corresponding to 0 is undefined, and wraps every 585 years.
 """
 time_ns() = ccall(:jl_hrtime, UInt64, ())
 


### PR DESCRIPTION
How long does it take for an unsigned 64-bit integer counting nanoseconds to wrap?

2.0^64 nanoseconds
2.0^64/1e9 seconds
2.0^64/1e9/60 minutes
2.0^64/1e9/60^2 hours
2.0^64/1e9/60^2/24 days
2.0^64/1e9/60^2/24/365.25 years

584.5420460906265 years.

Round to 585.

Not sure where 5.8 came from.

To double check,

From [wikipedia](https://en.wikipedia.org/wiki/Unix_time#Range_of_representable_times)

> Date range cutoffs are not an issue with 64-bit representations of Unix time, as the effective range of dates representable with Unix time stored in a signed 64-bit integer is over 584 billion years, or 292 billion years in either direction of the 1970 epoch.

presumably referring to counting seconds. Switching to nanoseconds shaves off a billion.