### PR TITLE
Force @generated to have min_world == 1 if they are unbounded and have no edges

### DIFF
--- a/src/method.c
+++ b/src/method.c
@@ -794,6 +794,12 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *mi, size_t
             }
         }
 
+        if (func->edges == jl_nothing && func->max_world == ~(size_t)0) {
+            if (func->min_world != 1) {
+                jl_error("Generated function result with `edges == nothing` and `max_world == typemax(UInt)` must have `min_world == 1`");
+            }
+        }
+
         if (cache || needs_cache_for_correctness) {
             uninferred = (jl_code_info_t*)jl_copy_ast((jl_value_t*)func);
             ci = jl_new_codeinst_for_uninferred(mi, uninferred);


### PR DESCRIPTION
Our pkgimage generation code uses `min_world == 1` as a shorthand for "no backedges target this" to skip revalidation on load, which I ran into when I accidentally broke that assumption in #54654. However, I then realized that is was possible for this property to be false, even today in the presence of generated functions. The failure case isn't too terrible (it just fails to use the precompile'd version), but it's still a very subtle silent bug. For now, forbid this configuration in generated functions so that the staticdata assumption is always valid and add a test case that would have failed with #54654 to make sure we notice if this regresses.