### PR TITLE
Show repeating line in stacktrace in bold red

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -762,7 +762,7 @@ function print_stackframe(io, i, frame::StackFrame, n::Int, ndigits_max, modulec
 
     StackTraces.show_spec_linfo(IOContext(io, :backtrace=>true), frame)
     if n > 1
-        printstyled(io, " (repeats $n times)"; color=:light_black)
+        printstyled(io, " (repeats $n times)"; color = :red, bold = true)
     end
     println(io)
 


### PR DESCRIPTION
Before:

<img width="273" alt="image" src="https://github.com/JuliaLang/julia/assets/54778816/c82bd7a3-3b4d-4a2d-8e40-6e6577ec9a4f">

After:

<img width="791" alt="image" src="https://github.com/JuliaLang/julia/assets/54778816/ceb72e58-1414-46b1-9758-59243550fb9c">

---

This can be useful to identify when traces are longer, as shown in the screenshot taken from the slack thread (`lu` is repeating):

![image](https://github.com/JuliaLang/julia/assets/54778816/b00475dd-c6ae-4072-9a0d-7856d9a8ce08)
