### PR TITLE
make: use `readelf` for LLVM symbol version detection

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -127,7 +127,7 @@ ifeq ($(JULIACODEGEN),LLVM)
 ifneq ($(USE_SYSTEM_LLVM),0)
 # USE_SYSTEM_LLVM != 0
 CG_LLVMLINK += $(LLVM_LDFLAGS) $(shell $(LLVM_CONFIG_HOST) --libs --system-libs)
-LLVM_SHLIB_SYMBOL_VERSION := $(shell nm -D --with-symbol-versions $(shell $(LLVM_CONFIG_HOST) --libfiles --link-shared | awk '{print $1; exit}') | \
+LLVM_SHLIB_SYMBOL_VERSION := $(shell readelf -W --dyn-syms $(shell $(LLVM_CONFIG_HOST) --libfiles --link-shared | awk '{print $1; exit}') | \
                                grep _ZN4llvm3Any6TypeId | head -n 1 | sed -ne 's/.*@//p')
 
 # HACK: llvm-config doesn't correctly point to shared libs on all platforms


### PR DESCRIPTION
Apparently on some distributions `nm --with-symbol-versions` does not report symbol versions, despite the flag.

`readelf` should be a more reliable alternative which is also part of binutils.

See https://github.com/spack/spack/issues/44534#issuecomment-2151796917 for more information