### PR TITLE
Highlight repeated function calls in stack traces

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -762,7 +762,7 @@ function print_stackframe(io, i, frame::StackFrame, n::Int, ndigits_max, modulec
 
     StackTraces.show_spec_linfo(IOContext(io, :backtrace=>true), frame)
     if n > 1
-        printstyled(io, " (repeats $n times)"; color=:light_black)
+        printstyled(io, " (repeats $n times)"; color=:yellow, bold=true)
     end
     println(io)
 

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -762,7 +762,7 @@ function print_stackframe(io, i, frame::StackFrame, n::Int, ndigits_max, modulec
 
     StackTraces.show_spec_linfo(IOContext(io, :backtrace=>true), frame)
     if n > 1
-        printstyled(io, " (repeats $n times)"; color=:yellow, bold=true)
+        printstyled(io, " (repeats $n times)"; color=Base.warn_color(), bold=true)
     end
     println(io)
 


### PR DESCRIPTION
As pointed out in #52334, stack traces of `StackOverflowError`s currently don't highlight recursions enough. Spotting the light black `(repeats $n times)` note in a colorful stack trace is difficult.

This PR highlights this note in bold yellow color.

## Examples
Before the PR, the recursion in `[4] lu` is hard to spot:
 
<img width="808" alt="Screenshot 2024-06-06 at 15 36 31" src="https://github.com/JuliaLang/julia/assets/20258504/33fdc78c-0928-46f7-98e7-e16bf514dd65">

After this PR, it is emphasized in bold and yellow color:

<img width="808" alt="Screenshot 2024-06-06 at 15 53 08" src="https://github.com/JuliaLang/julia/assets/20258504/dfa7f825-19ba-4f12-9dc9-736b31168db2">
