### PR TITLE
REPLCompletions: allow completions for `[import|using] AAA: xxx`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -113,6 +113,8 @@ Standard library changes
 
 - Using the new `usings=true` feature of the `names()` function, REPL completions can now
   complete names that have been explicitly `using`-ed. ([#54610])
+- REPL completions can now complete input lines like `[import|using] Mod: xxx|` e.g.
+  complete `using Base.Experimental: @op` to `using Base.Experimental: @opaque`. ([#54719])
 
 #### SuiteSparse
 

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -1437,10 +1437,11 @@ function completions(string::String, pos::Int, context_module::Module=Main, shif
         complete_modules_only = false
     end
 
-    startpos == 0 && (pos = -1)
-    dotpos < startpos && (dotpos = startpos - 1)
-    return complete_identifiers!(suggestions, context_module, string, name, pos,
-                                 dotpos, startpos;
+    if dotpos < startpos
+        dotpos = startpos - 1
+    end
+    return complete_identifiers!(suggestions, context_module, string, name,
+                                 pos, dotpos, startpos;
                                  comp_keywords, complete_modules_only)
 end
 

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -2312,8 +2312,14 @@ end
 # JuliaLang/julia#23374: completion for `import Mod.name`
 module Issue23374
 global v23374 = nothing
+global w23374 = missing
 end
 let s = "import .Issue23374.v"
+    c, r, res = test_complete_context(s)
+    @test res
+    @test "v23374" in c
+end
+let s = "import Base.sin, .Issue23374.v"
     c, r, res = test_complete_context(s)
     @test res
     @test "v23374" in c
@@ -2322,4 +2328,26 @@ let s = "using .Issue23374.v"
     c, r, res = test_complete_context(s)
     @test res
     @test isempty(c)
+end
+# JuliaLang/julia#23374: completion for `using Mod: name`
+let s = "using Base: @ass"
+    c, r, res = test_complete_context(s)
+    @test res
+    @test "@assume_effects" in c
+end
+let s = "using .Issue23374: v"
+    c, r, res = test_complete_context(s)
+    @test res
+    @test "v23374" in c
+end
+let s = "using .Issue23374: v23374, w"
+    c, r, res = test_complete_context(s)
+    @test res
+    @test "w23374" in c
+end
+# completes `using ` to `using [list of available modules]`
+let s = "using "
+    c, r, res = test_complete_context(s)
+    @test res
+    @test !isempty(c)
 end


### PR DESCRIPTION
When an input line like `[import|using] AAA: xxx` is entered, if `AAA`
is already loaded in the REPL session, it will now autocomplete to the
names available in `AAA` that start with `xxx`.
For example, it will autocomplete `using Base.Experimental: @ov|` to
`using Base.Experimental: @overlay`.

- fixes #23374