### PR TITLE
Add in place version of `findall` function

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -2699,6 +2699,48 @@ findall(x::Bool) = x ? [1] : Vector{Int}()
 findall(testf::Function, x::Number) = testf(x) ? [1] : Vector{Int}()
 findall(p::Fix2{typeof(in)}, x::Number) = x in p.x ? [1] : Vector{Int}()
 
+"""
+    findall!(A)
+
+In-place version of [`findall`](@ref). It supports only `AbstractArray` different from `Bool`, because it will update the array in place, putting the integer indices inside the array.
+
+It returns a view of the array.
+
+# Examples
+```jldoctest
+julia> A = [1, 0, 0, 1]
+4-element Vector{Int64}:
+ 1
+ 0
+ 0
+ 1
+
+julia> findall!(A)
+2-element view(::Vector{Int64}, 1:2) with eltype Int64:
+ 1
+ 4
+
+julia> A
+4-element Vector{Int64}:
+ 1
+ 4
+ 0
+ 1
+```
+"""
+function findall!(A::AbstractArray{T}) where {T<:Union{Integer, Real, Complex}}
+    n = count(!iszero, A)
+    I = @view(A[1:n])
+    cnt = 1
+    @inbounds for (i, a) in enumerate(A)
+        if !iszero(a)
+            I[cnt] = i
+            cnt += 1
+        end
+    end
+    return I
+end
+
 # similar to Matlab's ismember
 """
     indexin(a, b)

--- a/base/array.jl
+++ b/base/array.jl
@@ -2700,11 +2700,14 @@ findall(testf::Function, x::Number) = testf(x) ? [1] : Vector{Int}()
 findall(p::Fix2{typeof(in)}, x::Number) = x in p.x ? [1] : Vector{Int}()
 
 """
-    findall!(A)
+    findall!(f::Function, A::AbstractArray)
 
 In-place version of [`findall`](@ref). It supports only `AbstractArray` different from `Bool`, because it will update the array in place, putting the integer indices inside the array.
 
 It returns a view of the array.
+
+!!! compat "Julia 1.11"
+    This method was added in Julia 1.11.
 
 # Examples
 ```jldoctest
@@ -2715,7 +2718,7 @@ julia> A = [1, 0, 0, 1]
  0
  1
 
-julia> findall!(A)
+julia> findall!(!iszero, A)
 2-element view(::Vector{Int64}, 1:2) with eltype Int64:
  1
  4
@@ -2728,12 +2731,12 @@ julia> A
  1
 ```
 """
-function findall!(A::AbstractArray{T}) where {T<:Union{Integer, Real, Complex}}
-    n = count(!iszero, A)
+function findall!(f::Function, A::AbstractArray{T}) where {T<:Union{Integer, Real, Complex}}
+    n = count(f, A)
     I = @view(A[1:n])
     cnt = 1
     @inbounds for (i, a) in enumerate(A)
-        if !iszero(a)
+        if f(a)
             I[cnt] = i
             cnt += 1
         end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -394,6 +394,14 @@ end
 
     @test findall(isodd, 1) == [1]
     @test findall(isodd, 2) == Int[]
+
+    # in-place findall!
+    A = rand(0:3, 30)
+    B = copy(A)
+    idxsA = findall!(==(2), A)
+    idxsB = findall(==(2), B)
+    @test idxsA == idxsB
+    @test A[1:length(idxsA)] == idxsA
 end
 @testset "setindex! return type" begin
     rt = Base.return_types(setindex!, Tuple{Array{Int32, 3}, Vector{UInt8}, Vector{Int}, Int16, UnitRange{Int}})


### PR DESCRIPTION
Hello,

I added the in place version of the `findall` function. This is very useful when it is iteratively called inside a function, maybe with some preallocated cache, avoiding to allocate a lot of memory.