### PR TITLE
Map instead of broadcast in Diagonal matrix functions

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -729,7 +729,8 @@ for f in (:exp, :cis, :log, :sqrt,
           :cosh, :sinh, :tanh, :csch, :sech, :coth,
           :acos, :asin, :atan, :acsc, :asec, :acot,
           :acosh, :asinh, :atanh, :acsch, :asech, :acoth)
-    @eval $f(D::Diagonal) = Diagonal($f.(D.diag))
+    # we use map instead of broadcast to avoid recursive broadcasting calls
+    @eval $f(D::Diagonal) = Diagonal(map($f, D.diag))
 end
 
 # Cube root of a real-valued diagonal matrix


### PR DESCRIPTION
When working with a block Diagonal matrix, where the elements are also matrices, broadcasting an operation like `exp.(D.diag)` may lead to recursive calls
```julia
julia> using LinearAlgebra

julia> D = Diagonal(fill(rand(2,2), 2))
2×2 Diagonal{Matrix{Float64}, Vector{Matrix{Float64}}}:
 [0.0296101 0.895408; 0.808117 0.193101]          ⋅         
         ⋅                                [0.0296101 0.895408; 0.808117 0.193101]

julia> @report_opt exp(D)
[lots of output...]
│││││││││┌ exp!(A::Matrix{Float64}) @ LinearAlgebra /cache/build/builder-amdci4-5/julialang/julia-release-1-dot-11/usr/share/julia/stdlib/v1.11/LinearAlgebra/src/dense.jl:677
││││││││││ failed to optimize due to recursion: LinearAlgebra.exp!(::Matrix{Float64})

julia> VERSION
v"1.11.0-beta2"
```
This PR changes the top-level call to a `map` from a broadcast, which doesn't lead to recursion. One caveat here is that `InfiniteArrays` currently defines broadcasting but not `map`, so this will break that package. However, this should be addressed from their end by specializing `map` analogous to broadcasting.