### PR TITLE
inlining: optimize `and_int(x, true)` and `or_int(x, false)`

### DIFF
--- a/Compiler/src/ssair/inlining.jl
+++ b/Compiler/src/ssair/inlining.jl
@@ -1629,7 +1629,7 @@ function early_inline_special_case(ir::IRCode, stmt::Expr, flag::UInt32,
                                    @nospecialize(type), sig::Signature, state::InliningState)
     OptimizationParams(state.interp).inlining || return nothing
     (; f, ft, argtypes) = sig
-
+    ⊑ = partialorder(optimizer_lattice(state.interp))
     if isa(type, Const) # || isconstType(type)
         val = type.val
         is_inlineable_constant(val) || return nothing
@@ -1666,8 +1666,24 @@ function early_inline_special_case(ir::IRCode, stmt::Expr, flag::UInt32,
             elseif cond.val === false
                 return SomeCase(stmt.args[4])
             end
-        elseif ⊑(optimizer_lattice(state.interp), cond, Bool) && stmt.args[3] === stmt.args[4]
+        elseif cond ⊑ Bool && stmt.args[3] === stmt.args[4]
             return SomeCase(stmt.args[3])
+        end
+    elseif f === and_int && length(argtypes) == 3
+        argtype2, argtype3 = argtypes[2], argtypes[3]
+        if argtype2 isa Const && argtype2.val === true && argtype3 ⊑ Bool
+            return SomeCase(stmt.args[3])
+        end
+        if argtype3 isa Const && argtype3.val === true && argtype2 ⊑ Bool
+            return SomeCase(stmt.args[2])
+        end
+    elseif f === or_int && length(argtypes) == 3
+        argtype2, argtype3 = argtypes[2], argtypes[3]
+        if argtype2 isa Const && argtype2.val === false && argtype3 ⊑ Bool
+            return SomeCase(stmt.args[3])
+        end
+        if argtype3 isa Const && argtype3.val === false && argtype2 ⊑ Bool
+            return SomeCase(stmt.args[2])
         end
     end
     return nothing

--- a/Compiler/test/inline.jl
+++ b/Compiler/test/inline.jl
@@ -2362,4 +2362,10 @@ let src = code_typed1(issue44428, (Any,))
     @test count(x->Meta.isexpr(x,:call), src.code) == 0
 end
 
+# inlining optimization for `and_int` and `or_int`
+@test fully_eliminated(x->x&true, (Bool,); retval=Argument(2))
+@test fully_eliminated(x->true&x, (Bool,); retval=Argument(2))
+@test fully_eliminated(x->x|false, (Bool,); retval=Argument(2))
+@test fully_eliminated(x->false|x, (Bool,); retval=Argument(2))
+
 end # module inline_tests


### PR DESCRIPTION
We need an additional inlining pass to optimize cases like `and_int(x, true)` and `or_int(x, false)` to `x`.