### PR TITLE
Invalidate methods when binding is typed/const-defined

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -1038,6 +1038,14 @@ function add_mt_backedge!(irsv::IRInterpretationState, mt::MethodTable, @nospeci
     return push!(irsv.edges, mt, typ)
 end
 
+function add_binding_backedge!(caller::InferenceState, g::GlobalRef, kind::Symbol)
+    isa(caller.linfo.def, Method) || return nothing # don't add backedges to toplevel method instance
+    return push!(get_stmt_edges!(caller), g, kind)
+end
+function add_binding_backedge!(irsv::IRInterpretationState, g::GlobalRef)
+    return push!(irsv.edges, g, kind)
+end
+
 get_curr_ssaflag(sv::InferenceState) = sv.src.ssaflags[sv.currpc]
 get_curr_ssaflag(sv::IRInterpretationState) = sv.ir.stmts[sv.curridx][:flag]
 

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -641,6 +641,8 @@ function store_backedges(caller::MethodInstance, edges::Vector{Any})
         callee = itr.caller
         if isa(callee, MethodInstance)
             ccall(:jl_method_instance_add_backedge, Cvoid, (Any, Any, Any), callee, itr.sig, caller)
+        elseif isa(callee, GlobalRef)
+            ccall(:jl_globalref_add_backedge, Cvoid, (Any, Any, Any), callee, itr.sig, caller)
         else
             typeassert(callee, MethodTable)
             ccall(:jl_method_table_add_backedge, Cvoid, (Any, Any, Any), callee, itr.sig, caller)

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -336,9 +336,9 @@ end
 const empty_backedge_iter = BackedgeIterator(Any[])
 
 struct BackedgePair
-    sig # ::Union{Nothing,Type}
-    caller::Union{MethodInstance,MethodTable}
-    BackedgePair(@nospecialize(sig), caller::Union{MethodInstance,MethodTable}) = new(sig, caller)
+    sig # ::Union{Nothing,Symbol,Type}
+    caller::Union{MethodInstance,MethodTable,GlobalRef}
+    BackedgePair(@nospecialize(sig), caller::Union{MethodInstance,MethodTable,GlobalRef}) = new(sig, caller)
 end
 
 function iterate(iter::BackedgeIterator, i::Int=1)
@@ -346,6 +346,7 @@ function iterate(iter::BackedgeIterator, i::Int=1)
     i > length(backedges) && return nothing
     item = backedges[i]
     isa(item, MethodInstance) && return BackedgePair(nothing, item), i+1      # regular dispatch
+    isa(item, GlobalRef) && return BackedgePair(backedges[i+1], item), i+2    # (untyped) binding
     isa(item, MethodTable) && return BackedgePair(backedges[i+1], item), i+2  # abstract dispatch
     return BackedgePair(item, backedges[i+1]::MethodInstance), i+2            # `invoke` calls
 end

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3201,7 +3201,7 @@ static jl_cgval_t emit_globalref(jl_codectx_t &ctx, jl_module_t *mod, jl_sym_t *
             return mark_julia_const(ctx, v);
         ty = jl_atomic_load_relaxed(&bnd->ty);
     }
-    if (ty == nullptr)
+    if (ty == nullptr || jl_is_binding_edges(ty))
         ty = (jl_value_t*)jl_any_type;
     return update_julia_type(ctx, emit_checked_var(ctx, bp, name, (jl_value_t*)mod, false, ctx.tbaa().tbaa_binding), ty);
 }
@@ -3217,7 +3217,7 @@ static jl_cgval_t emit_globalop(jl_codectx_t &ctx, jl_module_t *mod, jl_sym_t *s
         return jl_cgval_t();
     if (bnd && !bnd->constp) {
         jl_value_t *ty = jl_atomic_load_relaxed(&bnd->ty);
-        if (ty != nullptr) {
+        if (ty != nullptr && !jl_is_binding_edges(ty)) {
             const std::string fname = issetglobal ? "setglobal!" : isreplaceglobal ? "replaceglobal!" : isswapglobal ? "swapglobal!" : ismodifyglobal ? "modifyglobal!" : "setglobalonce!";
             if (!ismodifyglobal) {
                 // TODO: use typeassert in jl_check_binding_wr too

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -51,6 +51,7 @@
     XX(jl_floatingpoint_type) \
     XX(jl_function_type) \
     XX(jl_binding_type) \
+    XX(jl_binding_edges_type) \
     XX(jl_globalref_type) \
     XX(jl_gotoifnot_type) \
     XX(jl_enternode_type) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -43,6 +43,7 @@
     XX(jl_backtrace_from_here) \
     XX(jl_base_relative_to) \
     XX(jl_binding_resolved_p) \
+    XX(jl_binding_invalidate) \
     XX(jl_bitcast) \
     XX(jl_boundp) \
     XX(jl_bounds_error) \
@@ -237,6 +238,7 @@
     XX(jl_get_world_counter) \
     XX(jl_get_zero_subnormals) \
     XX(jl_gf_invoke_lookup) \
+    XX(jl_globalref_add_backedge) \
     XX(jl_method_lookup_by_tt) \
     XX(jl_method_lookup) \
     XX(jl_gf_invoke_lookup_worlds) \

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3108,6 +3108,11 @@ void jl_init_types(void) JL_GC_DISABLED
     const static uint32_t binding_constfields[] = { 0x0002 }; // Set fields 2 as constant
     jl_binding_type->name->constfields = binding_constfields;
 
+    jl_binding_edges_type =
+        jl_new_datatype(jl_symbol("BindingBackedges"), core, jl_any_type, jl_emptysvec,
+                        jl_perm_symsvec(1, "edges"), jl_svec(1, jl_any_type),
+                        jl_emptysvec, 0, 0, 1);
+
     jl_globalref_type =
         jl_new_datatype(jl_symbol("GlobalRef"), core, jl_any_type, jl_emptysvec,
                         jl_perm_symsvec(3, "mod", "name", "binding"),

--- a/src/julia.h
+++ b/src/julia.h
@@ -642,6 +642,11 @@ typedef struct _jl_binding_t {
     uint8_t padding:1;
 } jl_binding_t;
 
+typedef struct _jl_binding_edges_t {
+    JL_DATA_TYPE
+    jl_array_t *edges;
+} jl_binding_edges_t;
+
 typedef struct {
     uint64_t hi;
     uint64_t lo;
@@ -930,6 +935,7 @@ extern JL_DLLIMPORT jl_value_t *jl_memoryref_uint8_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_value_t *jl_memoryref_any_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_expr_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_binding_type JL_GLOBALLY_ROOTED;
+extern JL_DLLIMPORT jl_datatype_t *jl_binding_edges_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_globalref_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_linenumbernode_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_gotonode_type JL_GLOBALLY_ROOTED;
@@ -1503,6 +1509,7 @@ static inline int jl_field_isconst(jl_datatype_t *st, int i) JL_NOTSAFEPOINT
 #define jl_is_slotnumber(v)  jl_typetagis(v,jl_slotnumber_type)
 #define jl_is_expr(v)        jl_typetagis(v,jl_expr_type)
 #define jl_is_binding(v)     jl_typetagis(v,jl_binding_type)
+#define jl_is_binding_edges(v)  jl_typetagis(v,jl_binding_edges_type)
 #define jl_is_globalref(v)   jl_typetagis(v,jl_globalref_type)
 #define jl_is_gotonode(v)    jl_typetagis(v,jl_gotonode_type)
 #define jl_is_gotoifnot(v)   jl_typetagis(v,jl_gotoifnot_type)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -835,6 +835,7 @@ JL_DLLEXPORT jl_value_t *jl_nth_slot_type(jl_value_t *sig JL_PROPAGATES_ROOT, si
 void jl_compute_field_offsets(jl_datatype_t *st);
 void jl_module_run_initializer(jl_module_t *m);
 JL_DLLEXPORT jl_binding_t *jl_get_module_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var, int alloc);
+JL_DLLEXPORT void jl_binding_invalidate(jl_value_t *ty, int is_const, jl_binding_edges_t *be);
 JL_DLLEXPORT void jl_binding_deprecation_warning(jl_module_t *m, jl_sym_t *sym, jl_binding_t *b);
 extern jl_array_t *jl_module_init_order JL_GLOBALLY_ROOTED;
 extern htable_t jl_current_modules JL_GLOBALLY_ROOTED;
@@ -1041,6 +1042,7 @@ JL_DLLEXPORT jl_value_t *jl_methtable_lookup(jl_methtable_t *mt JL_PROPAGATES_RO
 JL_DLLEXPORT jl_method_instance_t *jl_specializations_get_linfo(
     jl_method_t *m JL_PROPAGATES_ROOT, jl_value_t *type, jl_svec_t *sparams);
 jl_method_instance_t *jl_specializations_get_or_insert(jl_method_instance_t *mi_ins);
+JL_DLLEXPORT void jl_globalref_add_backedge(jl_globalref_t *callee, jl_sym_t *kind, jl_method_instance_t *caller);
 JL_DLLEXPORT void jl_method_instance_add_backedge(jl_method_instance_t *callee, jl_value_t *invokesig, jl_method_instance_t *caller);
 JL_DLLEXPORT void jl_method_table_add_backedge(jl_methtable_t *mt, jl_value_t *typ, jl_value_t *caller);
 JL_DLLEXPORT void jl_mi_cache_insert(jl_method_instance_t *mi JL_ROOTING_ARGUMENT,

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -329,7 +329,10 @@ void jl_eval_global_expr(jl_module_t *m, jl_expr_t *ex, int set_type) {
             if (set_type) {
                 jl_value_t *old_ty = NULL;
                 // maybe set the type too, perhaps
-                jl_atomic_cmpswap_relaxed(&b->ty, &old_ty, (jl_value_t*)jl_any_type);
+                while (!jl_atomic_cmpswap_relaxed(&b->ty, &old_ty, (jl_value_t*)jl_any_type)) {
+                    if (old_ty && jl_is_binding_edges(old_ty))
+                        break;
+                }
             }
         }
     }

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5757,3 +5757,12 @@ end
 bar54341(args...) = foo54341(4, args...)
 
 @test Core.Compiler.return_type(bar54341, Tuple{Vararg{Int}}) === Int
+
+should_be_invalidated_by_binding_edge() = unknown_foo()
+# Trigger an inference result before all definitions are available
+@test Any === Core.Compiler.return_type(should_be_invalidated_by_binding_edge, Tuple{})
+
+# Binding backedges should guarantee that when `unknown_foo` is const-defined, this is invalidated
+unknown_foo() = rand(Int)
+# Inference in the new world should give a good result
+@test Int === Core.Compiler.return_type(should_be_invalidated_by_binding_edge, Tuple{})


### PR DESCRIPTION
This allows for patterns like:
```julia
julia> function foo(N)
    x = nothing
    for i = 1:N
        x = bar(i)
    end
    return x
end

julia> foo(1_000_000_000)
ERROR: UndefVarError: `bar` not defined
```

not to suffer a tremendous performance regression because of the fact that `foo` was inferred with `bar` still undefined.

This invalidation is not required for correctness, but for performance reasons once the global is defined we'd like to invalidate the code anyway to get an improved inference result:
```julia
julia> bar(x) = 3x
bar (generic function with 1 method)

julia> foo(1_000_000_000) # w/o PR: > 30 seconds, w/ PR: < 1μs
```

**Note:** This is essentially an optimized implementation of the _non-semantic_ portion of https://github.com/JuliaLang/julia/pull/54654 for the special case of untyped/undefined globals, and this should mostly be compatible with that PR. Compared to that change, this adds explicit edges so that invalidation can be significantly faster and bit more fine-grained.

TODO:
 - [ ] Add lock to `jl_binding_edges_t` to prevent corruption from concurrent access
 - [ ] Add additional tests for global vs. const invalidations and x-module bindings
 - [ ] Fix up `binding->ty` not to be reset on serialization (use the closed/open rules on type set instead)