### PR TITLE
WIP: improve some cases of loading extensions in the presence of packages in the sysimage.

### DIFF
--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1143,10 +1143,10 @@ end
         # We run this test in a new process so we are not vulnerable to a previous test having loaded LinearAlgebra
         proj_libdlext = joinpath(@__DIR__, "project", "Extensions", "GotLibdlExt")
         sysimg_ext_test_code = """
-            #uuid_key_la = Base.PkgId(Base.UUID("37e2e46d-f89d-539d-b4ee-838fcccc9c8e"), "LinearAlgebra")
-           # Base.in_sysimage(uuid_key_la) || error("LinearAlgebra not in sysimage")
-            #uuid_key_libdl = Base.PkgId(Base.UUID("8f399da3-3557-5675-b5ff-fb832c97cbdb"), "Libdl")
-           # Base.in_sysimage(uuid_key_libdl) || error("Libdl not in sysimage")
+            uuid_key_la = Base.PkgId(Base.UUID("37e2e46d-f89d-539d-b4ee-838fcccc9c8e"), "LinearAlgebra")
+            Base.in_sysimage(uuid_key_la) || error("LinearAlgebra not in sysimage")
+            uuid_key_libdl = Base.PkgId(Base.UUID("8f399da3-3557-5675-b5ff-fb832c97cbdb"), "Libdl")
+            Base.in_sysimage(uuid_key_libdl) || error("Libdl not in sysimage")
             using GotLibdlExt
             using LinearAlgebra
             Base.get_extension(GotLibdlExt, :LibdlExt) isa Module || error("expected extension to load")

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -1125,18 +1125,17 @@ end
         sysimg_ext_test_code = """
             uuid_key = Base.PkgId(Base.UUID("37e2e46d-f89d-539d-b4ee-838fcccc9c8e"), "LinearAlgebra")
             Base.in_sysimage(uuid_key) || error("LinearAlgebra not in sysimage")
-            haskey(Base.explicit_loaded_modules, uuid_key) && error("LinearAlgebra already loaded")
+            in(Base.explicit_loaded_modules, uuid_key) && error("LinearAlgebra already loaded")
             using HasExtensions
             Base.get_extension(HasExtensions, :LinearAlgebraExt) === nothing || error("unexpectedly got an extension")
             using LinearAlgebra
-            haskey(Base.explicit_loaded_modules, uuid_key) || error("LinearAlgebra not loaded")
+            in(Base.explicit_loaded_modules, uuid_key) || error("LinearAlgebra not loaded")
             Base.get_extension(HasExtensions, :LinearAlgebraExt) isa Module || error("expected extension to load")
         """
         cmd =  `$(Base.julia_cmd()) --startup-file=no -e $sysimg_ext_test_code`
         cmd = addenv(cmd, "JULIA_LOAD_PATH" => join([proj, "@stdlib"], sep))
         @test success(cmd)
 
-        # Failure of loading some extensions when trigger is in the sysimage
         # The test below requires that LinearAlgebra is in the sysimage and that it has not been loaded yet
         # and that it depends on Libdl.
         # If it gets moved out, this test will need to be updated.
@@ -1150,6 +1149,18 @@ end
             using GotLibdlExt
             using LinearAlgebra
             Base.get_extension(GotLibdlExt, :LibdlExt) isa Module || error("expected extension to load")
+        """
+        cmd =  `$(Base.julia_cmd()) --startup-file=no -e $sysimg_ext_test_code`
+        cmd = addenv(cmd, "JULIA_LOAD_PATH" => join([proj_libdlext, "@stdlib"], sep))
+        @test success(cmd)
+
+        # Failure of loading some extensions when loading a precompiled package with a trigger in the sysimage
+        sysimg_ext_test_code = """
+        uuid_key_la = Base.PkgId(Base.UUID("37e2e46d-f89d-539d-b4ee-838fcccc9c8e"), "LinearAlgebra")
+        using GotLibdlExt
+        using SparseArrays # loads LinearAlgebra
+        haskey(Base.loaded_modules, uuid_key_la) || error("LinearAlgebra not loaded")
+        Base.get_extension(GotLibdlExt, :LibdlExt) isa Module || error("expected extension to load")
         """
         cmd =  `$(Base.julia_cmd()) --startup-file=no -e $sysimg_ext_test_code`
         cmd = addenv(cmd, "JULIA_LOAD_PATH" => join([proj_libdlext, "@stdlib"], sep))

--- a/test/project/Extensions/GotLibdlExt/Project.toml
+++ b/test/project/Extensions/GotLibdlExt/Project.toml
@@ -1,0 +1,9 @@
+name = "GotLibdlExt"
+uuid = "a549ab1b-9b57-4c18-8a82-af63d7789335"
+version = "0.1.0"
+
+[weakdeps]
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[extensions]
+LibdlExt = "Libdl"

--- a/test/project/Extensions/GotLibdlExt/ext/LibdlExt.jl
+++ b/test/project/Extensions/GotLibdlExt/ext/LibdlExt.jl
@@ -1,0 +1,5 @@
+module LibdlExt
+
+using Libdl, GotLibdlExt
+
+end

--- a/test/project/Extensions/GotLibdlExt/src/GotLibdlExt.jl
+++ b/test/project/Extensions/GotLibdlExt/src/GotLibdlExt.jl
@@ -1,0 +1,5 @@
+module GotLibdlExt
+
+greet() = print("Hello World!")
+
+end # module GotLibdlExt


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/52841 was intended to make the loading of extensions be less coupled to what packages are in the sysimage but it didn't get all the way there since the `require` calls are not "recorded" for packages in the sysimage.

In the following situation:

- B depends on C
- A has extension ACExt
- Loading A, B

will load the ACExt in the normal case, but will not load it if B (and thus C) is in the sysimage.

This PR starts fixing that but it will still fail if the package in the sysimage ends up getting loaded from another precompiled package.