### PR TITLE
[TOML] remove Dates hack, replace with explicit usage

### DIFF
--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -492,3 +492,8 @@ end
 
 Base.OrderStyle(::Type{<:AbstractTime}) = Base.Ordered()
 Base.ArithmeticStyle(::Type{<:AbstractTime}) = Base.ArithmeticWraps()
+
+# minimal Base.TOML support
+Date(d::Base.TOML.Date) = Date(d.year, d.month, d.day)
+Time(t::Base.TOML.Time) = Time(t.hour, t.minute, t.second, t.ms)
+DateTime(dt::Base.TOML.DateTime) = DateTime(Date(dt.date), Time(dt.time))

--- a/stdlib/TOML/Project.toml
+++ b/stdlib/TOML/Project.toml
@@ -6,12 +6,13 @@ version = "1.0.3"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [compat]
+Dates = "1.11.0"
 julia = "1.6"
 
 [extras]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 
 [targets]

--- a/stdlib/TOML/src/TOML.jl
+++ b/stdlib/TOML/src/TOML.jl
@@ -7,6 +7,8 @@ and to serialize Julia data structures to TOML format.
 """
 module TOML
 
+using Dates
+
 module Internals
     # The parser is defined in Base
     using Base.TOML: Parser, parse, tryparse, ParserError, isvalid_barekey_char, reinit!
@@ -37,6 +39,17 @@ performance if a larger number of small files are parsed.
 const Parser = Internals.Parser
 
 """
+    DTParser()
+
+Constructor for a TOML `Parser` which returns date and time objects from Dates.
+"""
+function DTParser(args...; kwargs...)
+    parser = Parser(args...; kwargs...)
+    parser.Dates = Dates
+    return parser
+end
+
+"""
     parsefile(f::AbstractString)
     parsefile(p::Parser, f::AbstractString)
 
@@ -46,7 +59,7 @@ Parse file `f` and return the resulting table (dictionary). Throw a
 See also [`TOML.tryparsefile`](@ref).
 """
 parsefile(f::AbstractString) =
-    Internals.parse(Parser(readstring(f); filepath=abspath(f)))
+    Internals.parse(DTParser(readstring(f); filepath=abspath(f)))
 parsefile(p::Parser, f::AbstractString) =
     Internals.parse(Internals.reinit!(p, readstring(f); filepath=abspath(f)))
 
@@ -60,7 +73,7 @@ Parse file `f` and return the resulting table (dictionary). Return a
 See also [`TOML.parsefile`](@ref).
 """
 tryparsefile(f::AbstractString) =
-    Internals.tryparse(Parser(readstring(f); filepath=abspath(f)))
+    Internals.tryparse(DTParser(readstring(f); filepath=abspath(f)))
 tryparsefile(p::Parser, f::AbstractString) =
     Internals.tryparse(Internals.reinit!(p, readstring(f); filepath=abspath(f)))
 
@@ -74,7 +87,7 @@ Throw a [`ParserError`](@ref) upon failure.
 See also [`TOML.tryparse`](@ref).
 """
 parse(str::AbstractString) =
-    Internals.parse(Parser(String(str)))
+    Internals.parse(DTParser(String(str)))
 parse(p::Parser, str::AbstractString) =
     Internals.parse(Internals.reinit!(p, String(str)))
 parse(io::IO) = parse(read(io, String))
@@ -90,7 +103,7 @@ Return a [`ParserError`](@ref) upon failure.
 See also [`TOML.parse`](@ref).
 """
 tryparse(str::AbstractString) =
-    Internals.tryparse(Parser(String(str)))
+    Internals.tryparse(DTParser(String(str)))
 tryparse(p::Parser, str::AbstractString) =
     Internals.tryparse(Internals.reinit!(p, String(str)))
 tryparse(io::IO) = tryparse(read(io, String))

--- a/stdlib/TOML/src/print.jl
+++ b/stdlib/TOML/src/print.jl
@@ -34,7 +34,8 @@ function print_toml_escaped(io::IO, s::AbstractString)
 end
 
 const MbyFunc = Union{Function, Nothing}
-const TOMLValue = Union{AbstractVector, AbstractDict, Dates.DateTime, Dates.Time, Dates.Date, Bool, Integer, AbstractFloat, AbstractString}
+const TOMLValue = Union{AbstractVector, AbstractDict, Bool, Integer, AbstractFloat, AbstractString,
+                        Dates.DateTime, Dates.Time, Dates.Date, Base.TOML.DateTime, Base.TOML.Time, Base.TOML.Date}
 
 
 ########
@@ -89,6 +90,9 @@ function printvalue(f::MbyFunc, io::IO, value::AbstractVector, sorted::Bool)
 end
 
 function printvalue(f::MbyFunc, io::IO, value::TOMLValue, sorted::Bool)
+    value isa Base.TOML.DateTime && (value = Dates.DateTime(value))
+    value isa Base.TOML.Time && (value = Dates.Time(value))
+    value isa Base.TOML.Date && (value = Dates.Date(value))
     value isa Dates.DateTime ? Base.print(io, Dates.format(value, Dates.dateformat"YYYY-mm-dd\THH:MM:SS.sss\Z")) :
     value isa Dates.Time     ? Base.print(io, Dates.format(value, Dates.dateformat"HH:MM:SS.sss")) :
     value isa Dates.Date     ? Base.print(io, Dates.format(value, Dates.dateformat"YYYY-mm-dd")) :


### PR DESCRIPTION
This hack will cease functioning soon (#54739), so it must be removed so that packages can stop relying on it.

As an aid, now provide some basic conversion and printing support for the Base.TOML variants of this as well such that users can round-trip the contents (if they are well-formed as a date/time).