### PR TITLE
Handle no-postdominator case in finalizer pass

### DIFF
--- a/base/compiler/ssair/domtree.jl
+++ b/base/compiler/ssair/domtree.jl
@@ -657,6 +657,8 @@ end
 Compute the nearest common (post-)dominator of `a` and `b`.
 """
 function nearest_common_dominator(domtree::GenericDomTree, a::BBNumber, b::BBNumber)
+    a == 0 && return a
+    b == 0 && return b
     alevel = domtree.nodes[a].level
     blevel = domtree.nodes[b].level
     # W.l.g. assume blevel <= alevel

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1614,6 +1614,7 @@ function try_resolve_finalizer!(ir::IRCode, idx::Int, finalizer_idx::Int, defuse
     end
     all(check_defuse, defuse.uses) || return nothing
     all(check_defuse, defuse.defs) || return nothing
+    bb_insert_block != 0 || return nothing # verify post-dominator of all uses exists
 
     # Check #3
     dominates(domtree, finalizer_bb, bb_insert_block) || return nothing


### PR DESCRIPTION
This pass was assuming that the post-dominator of all finalizer uses exists as a real BB in the CFG.

Resolves https://github.com/JuliaLang/julia/issues/54596