### PR TITLE
Use out-of-place fill in zeros/ones

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -591,21 +591,9 @@ for (fname, felt) in ((:zeros, :zero), (:ones, :one))
         $fname(::Type{T}, dims::DimOrInd...) where {T} = $fname(T, dims)
         $fname(dims::Tuple{Vararg{DimOrInd}}) = $fname(Float64, dims)
         $fname(::Type{T}, dims::NTuple{N, Union{Integer, OneTo}}) where {T,N} = $fname(T, map(to_dim, dims))
-        function $fname(::Type{T}, dims::NTuple{N, Integer}) where {T,N}
-            a = Array{T,N}(undef, dims)
-            fill!(a, $felt(T))
-            return a
-        end
-        function $fname(::Type{T}, dims::Tuple{}) where {T}
-            a = Array{T}(undef)
-            fill!(a, $felt(T))
-            return a
-        end
-        function $fname(::Type{T}, dims::NTuple{N, DimOrInd}) where {T,N}
-            a = similar(Array{T,N}, dims)
-            fill!(a, $felt(T))
-            return a
-        end
+        $fname(::Type{T}, dims::NTuple{N, Integer}) where {T,N} = fill($felt(T), dims)
+        $fname(::Type{T}, dims::Tuple{}) where {T} = fill($felt(T), dims)
+        $fname(::Type{T}, dims::NTuple{N, DimOrInd}) where {T,N} = fill($felt(T), dims)
     end
 end
 

--- a/test/testhelpers/SizedArrays.jl
+++ b/test/testhelpers/SizedArrays.jl
@@ -70,6 +70,7 @@ function Base.reshape(x::AbstractArray, shape::Tuple{SOneTo, Vararg{SOneTo}})
     sz = map(length, shape)
     SizedArray{length.(sz)}(reshape(x, length.(sz)))
 end
+Base.fill(x, ax::Tuple{SOneTo, Vararg{SOneTo}}) = SizedArray{length.(ax)}(fill(x, length.(ax)))
 
 const SizedMatrixLike = Union{SizedMatrix, Transpose{<:Any, <:SizedMatrix}, Adjoint{<:Any, <:SizedMatrix}}
 


### PR DESCRIPTION
Currently, `zeros` and `ones` allocate an array and call the in-place `fill!` to populate it. This PR changes it to call `fill` instead, so that immutable arrays that extend `fill` and return the same type will also get `zeros` and `ones` to preserve the type of the array.

This also reduces code duplication.