### PR TITLE
make recommendation clearer on manifest version mismatch

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2233,15 +2233,16 @@ function collect_manifest_warnings()
     if !isempty(unsuitable_manifests)
         msg *= """
         - Note that the following manifests in the load path were resolved with a different
-          julia version, which may be the cause of the error:
+          julia version, which may be the cause of the error. Try to re-resolve them in the
+          current version, or consider deleting them if that fails:
             $(join(unsuitable_manifests, "\n    "))
         """
     end
     if !isempty(dev_manifests)
         msg *= """
         - Note that the following manifests in the load path were resolved a potentially
-          different DEV version of the current version, which may be the cause
-          of the error:
+          different DEV version of the current version, which may be the cause of the error.
+          Try to re-resolve them in the current version, or consider deleting them if that fails:
             $(join(dev_manifests, "\n    "))
         """
     end


### PR DESCRIPTION
It seems common for people to not infer the recommended action here, so make it clearer. 