### PR TITLE
[LinearAlgebra] Improve resilience to unknown libblastrampoline flags

### DIFF
--- a/stdlib/LinearAlgebra/src/lbt.jl
+++ b/stdlib/LinearAlgebra/src/lbt.jl
@@ -13,6 +13,19 @@ struct lbt_library_info_t
     f2c::Int32
     cblas::Int32
 end
+
+macro get_warn(map, key)
+    return quote
+        if !haskey($(esc(map)), $(esc(key)))
+            @warn(string("[LBT] Unknown key into ", $(string(map)), ": ", $(esc(key)), ", defaulting to :unknown"))
+            # All the unknown values share a common value: `-1`
+            $(esc(map))[$(esc(LBT_INTERFACE_UNKNOWN))]
+        else
+            $(esc(map))[$(esc(key))]
+        end
+    end
+end
+
 const LBT_INTERFACE_LP64    = 32
 const LBT_INTERFACE_ILP64   = 64
 const LBT_INTERFACE_UNKNOWN = -1
@@ -35,10 +48,12 @@ const LBT_INV_F2C_MAP = Dict(v => k for (k, v) in LBT_F2C_MAP)
 
 const LBT_COMPLEX_RETSTYLE_NORMAL   =  0
 const LBT_COMPLEX_RETSTYLE_ARGUMENT =  1
+const LBT_COMPLEX_RETSTYLE_FNDA     =  2
 const LBT_COMPLEX_RETSTYLE_UNKNOWN  = -1
 const LBT_COMPLEX_RETSTYLE_MAP = Dict(
     LBT_COMPLEX_RETSTYLE_NORMAL   => :normal,
     LBT_COMPLEX_RETSTYLE_ARGUMENT => :argument,
+    LBT_COMPLEX_RETSTYLE_FNDA     => :float_normal_double_argument,
     LBT_COMPLEX_RETSTYLE_UNKNOWN  => :unknown,
 )
 const LBT_INV_COMPLEX_RETSTYLE_MAP = Dict(v => k for (k, v) in LBT_COMPLEX_RETSTYLE_MAP)
@@ -69,10 +84,10 @@ struct LBTLibraryInfo
             lib_info.handle,
             unsafe_string(lib_info.suffix),
             unsafe_wrap(Vector{UInt8}, lib_info.active_forwards, div(num_exported_symbols,8)+1),
-            LBT_INTERFACE_MAP[lib_info.interface],
-            LBT_COMPLEX_RETSTYLE_MAP[lib_info.complex_retstyle],
-            LBT_F2C_MAP[lib_info.f2c],
-            LBT_CBLAS_MAP[lib_info.cblas],
+            @get_warn(LBT_INTERFACE_MAP, lib_info.interface),
+            @get_warn(LBT_COMPLEX_RETSTYLE_MAP, lib_info.complex_retstyle),
+            @get_warn(LBT_F2C_MAP, lib_info.f2c),
+            @get_warn(LBT_CBLAS_MAP, lib_info.cblas),
         )
     end
 end


### PR DESCRIPTION
When testing a new version of `libblastrampoline` that may have flags and values that we don't know about, raise a nice warning rather than a hard error.