### PR TITLE
boot.jl: Remove duplicated definition

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -546,8 +546,6 @@ GenericMemoryRef(mem::GenericMemory) = memoryref(mem)
 GenericMemoryRef(mem::GenericMemory, i::Integer) = memoryref(mem, i)
 GenericMemoryRef(mem::GenericMemoryRef, i::Integer) = memoryref(mem, i)
 
-const Memory{T} = GenericMemory{:not_atomic, T, CPU}
-const MemoryRef{T} = GenericMemoryRef{:not_atomic, T, CPU}
 const AtomicMemory{T} = GenericMemory{:atomic, T, CPU}
 const AtomicMemoryRef{T} = GenericMemoryRef{:atomic, T, CPU}
 


### PR DESCRIPTION
The same definition exists a few lines earlier. Split from #54654 where it would be an error to try to do this before the invalidation mechanism exists, but the change is generally applicable.