### PR TITLE
REPL: spawn prompt! to avoid blocking typing, fix pkg repl transition sequencing

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2823,22 +2823,23 @@ keymap_data(ms::MIState, m::ModalInterface) = keymap_data(state(ms), mode(ms))
 
 function prompt!(term::TextTerminal, prompt::ModalInterface, s::MIState = init_state(term, prompt))
     Base.reseteof(term)
+    l = Base.ReentrantLock()
+    t1 = Threads.@spawn :interactive while true
+        wait(s.async_channel)
+        status = @lock l begin
+            fcn = take!(s.async_channel)
+            fcn(s)
+        end
+        status ∈ (:ok, :ignore) || break
+    end
     raw!(term, true)
     enable_bracketed_paste(term)
     try
         activate(prompt, s, term, term)
         old_state = mode(s)
-        l = Base.ReentrantLock()
-        t = @async while true
-            wait(s.async_channel)
-            status = @lock l begin
-                fcn = take!(s.async_channel)
-                fcn(s)
-            end
-            status ∈ (:ok, :ignore) || break
-        end
-        Base.errormonitor(t)
-        while true
+        # spawn this because the main repl task is sticky (due to use of @async and _wait2)
+        # and we want to not block typing when the repl task thread is busy
+        t2 = Threads.@spawn :interactive while true
             eof(term) || peek(term, Char) # wait before locking but don't consume
             @lock l begin
                 kmap = keymap(s, prompt)
@@ -2873,7 +2874,10 @@ function prompt!(term::TextTerminal, prompt::ModalInterface, s::MIState = init_s
                 end
             end
         end
+        return fetch(t2)
     finally
+        put!(s.async_channel, Returns(:done))
+        wait(t1)
         raw!(term, false) && disable_bracketed_paste(term)
     end
     # unreachable


### PR DESCRIPTION
Based on https://github.com/JuliaLang/julia/pull/54760#discussion_r1635765035 by @Keno 

This changes the `prompt!` design to not consume on the two tasks until inside the lock.

~However, with this design I find that there's a 50% chance that interactive startup with `-t2` will block typing while Pkg loads.~

~As an attempt to avoid typing blocking in this design, suggested by @vchuravy I've made `repl_main` run on a non-sticky task and changing any repl `@async` calls to `@spawn` to avoid thread-pinning the repl task.~

~But the 50% chance of blocking typing while Pkg loads remains.~

~It seems the repl task is still not freely switching threads.~

Spawning `prompt!` specifically avoids typing blocking, because the general repl task is made sticky by use of `_wait2` as well as the `@async`s.