### PR TITLE
Move error comment line in scoping example

### DIFF
--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -31,8 +31,8 @@ a global variable by the same name is allowed or not.
     ```julia
     # Print the numbers 1 through 5
     i = 0
-    while i < 5  # ERROR: UndefVarError: `i` not defined
-        i += 1
+    while i < 5
+        i += 1     # ERROR: UndefVarError: `i` not defined
         println(i)
     end
     ```
@@ -43,8 +43,8 @@ a global variable by the same name is allowed or not.
     ```julia
     # Print the numbers 1 through 5
     let i = 0
-        while i < 5  # Now `i` is defined in the inner scope of the while loop
-            i += 1
+        while i < 5
+            i += 1     # Now outer `i` is defined in the inner scope of the while loop
             println(i)
         end
     end


### PR DESCRIPTION
Continuation of #54500.
I realized the erroring line is one lower.