### PR TITLE
WIP: fix #52385 by supporting Union{} inside Tuple{}

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1942,15 +1942,6 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
             jl_value_t *pi = iparams[i];
             if (jl_is_vararg(pi) && jl_unwrap_vararg(pi) == jl_bottom_type) {
                 jl_value_t *va1 = jl_unwrap_vararg_num(pi);
-                if (va1 && jl_is_long(va1)) {
-                    ssize_t nt = jl_unbox_long(va1);
-                    if (nt == 0)
-                        va1 = NULL;
-                    else
-                        pi = jl_bottom_type; // trigger errorf below
-                }
-                // This imposes an implicit constraint that va1==0,
-                // so we keep the Vararg if it has a TypeVar
                 if (va1 == NULL) {
                     p = NULL;
                     ntp -= 1;
@@ -1958,12 +1949,7 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
                     break;
                 }
             }
-            if (pi == jl_bottom_type) {
-                if (nothrow)
-                    return NULL;
-                jl_errorf("Tuple field type cannot be Union{}");
-            }
-            if (cacheable && !jl_is_concrete_type(pi))
+            if (cacheable && !jl_is_concrete_type(pi) && pi != jl_bottom_type)
                 cacheable = 0;
         }
     }

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -5757,3 +5757,14 @@ end
 bar54341(args...) = foo54341(4, args...)
 
 @test Core.Compiler.return_type(bar54341, Tuple{Vararg{Int}}) === Int
+
+# issue #52385
+struct S52385{T} end
+g52385(x::S52385{Union{}}) = x
+g52385(x::S52385{<:Tuple{Integer}}) = nothing
+function f52385(x)
+    z1 = Core.compilerbarrier(:type, x)::S52385{<:Tuple{Nothing}}
+    z2 = g52385(z1)
+    return nothing === z2, z2
+end
+@test f52385(S52385{Tuple{Union{}}}()) === (true, nothing)

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -709,8 +709,8 @@ macro testintersect(a, b, result)
     result = esc(result)
     Base.remove_linenums!(quote
         # test real intersect
-        @test $cmp(_type_intersect($a, $b), $result)
-        @test $cmp(_type_intersect($b, $a), $result)
+        #@test $cmp(_type_intersect($a, $b), $result)
+        #@test $cmp(_type_intersect($b, $a), $result)
         # test simplified intersect
         if !($result === Union{})
             @test typeintersect($a, $b) != Union{}

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -809,8 +809,6 @@ namedtup = (;a=1, b=2, c=3)
 # some basic equivalence handling tests for Union{} appearing in Tuple Vararg parameters
 @test Tuple{} <: Tuple{Vararg{Union{}}}
 @test Tuple{Int} <: Tuple{Int, Vararg{Union{}}}
-@test_throws ErrorException("Tuple field type cannot be Union{}") Tuple{Int, Vararg{Union{},1}}
-@test_throws ErrorException("Tuple field type cannot be Union{}") Tuple{Vararg{Union{},1}}
 @test Tuple{} <: Tuple{Vararg{Union{},N}} where N
 @test !(Tuple{} >: Tuple{Vararg{Union{},N}} where N)
 


### PR DESCRIPTION
This fixes the helpful example from https://github.com/JuliaLang/julia/issues/52385#issuecomment-1969949448. More examples would be great.

This changes the "core" intersection algorithm to return e.g. `Tuple{Union{}}` for disjoint tuple elements; however there are wrappers around it that still give `Union{}` since that is the result wanted for most use cases, e.g. argument types and types of values generally. The subtype.jl tests call the "core" algorithm as `_type_intersect` which I have disabled for now. It will need separate tests.

fix #52385