### PR TITLE
don't throw EOFError from sleep

### DIFF
--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -262,7 +262,7 @@ millisecond or input of `0.001`.
 """
 function sleep(sec::Real)
     sec ≥ 0 || throw(ArgumentError("cannot sleep for $sec seconds"))
-    wait(Timer(sec))
+    _trywait(Timer(sec)) # don't error if timer already closed
     nothing
 end
 


### PR DESCRIPTION
This prevents `sleep` from throwing an `EOFError` under rare conditions (with very short timer durations) where the `Timer` object is already closed before it can be signaled, which seems like a bug.

See [the discourse discussion](https://discourse.julialang.org/t/how-can-sleep-0-001-error/113394).