### PR TITLE
FieldError shim to avoid breaks in tests

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -806,7 +806,13 @@ function do_test_throws(result::ExecutionResult, orig_expr, extype)
                     isa(exc, extype)
                 end
         elseif isa(extype, Type) && extype == ErrorException
-            success = isa(exc, ErrorException) || isa(exc, FieldError)
+            success =
+                if isa(exc, FieldError)
+                    Base.depwarn(lazy"ErrorException should no longer be used to test field access; FieldError should be used instead!", :do_test_throws)
+                    true
+                else
+                    isa(exc, extype)
+                end
         elseif isa(extype, Exception) || !isa(exc, Exception)
             if extype isa LoadError && !(exc isa LoadError) && typeof(extype.error) == typeof(exc)
                 extype = extype.error # deprecated

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -797,17 +797,12 @@ function do_test_throws(result::ExecutionResult, orig_expr, extype)
             orig_expr isa Expr &&
             orig_expr.head in (:call, :macrocall) &&
             orig_expr.args[1] in MACROEXPAND_LIKE
-        if isa(extype, Type) && extype != ErrorException
+        if isa(extype, Type)
             success =
                 if from_macroexpand && extype == LoadError && exc isa Exception
                     Base.depwarn("macroexpand no longer throws a LoadError so `@test_throws LoadError ...` is deprecated and passed without checking the error type!", :do_test_throws)
                     true
-                else
-                    isa(exc, extype)
-                end
-        elseif isa(extype, Type) && extype == ErrorException
-            success =
-                if isa(exc, FieldError)
+                elseif extype == ErrorException && isa(exc, FieldError)
                     Base.depwarn(lazy"ErrorException should no longer be used to test field access; FieldError should be used instead!", :do_test_throws)
                     true
                 else

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -797,7 +797,7 @@ function do_test_throws(result::ExecutionResult, orig_expr, extype)
             orig_expr isa Expr &&
             orig_expr.head in (:call, :macrocall) &&
             orig_expr.args[1] in MACROEXPAND_LIKE
-        if isa(extype, Type)
+        if isa(extype, Type) && extype != ErrorException
             success =
                 if from_macroexpand && extype == LoadError && exc isa Exception
                     Base.depwarn("macroexpand no longer throws a LoadError so `@test_throws LoadError ...` is deprecated and passed without checking the error type!", :do_test_throws)
@@ -805,6 +805,8 @@ function do_test_throws(result::ExecutionResult, orig_expr, extype)
                 else
                     isa(exc, extype)
                 end
+        elseif isa(extype, Type) && extype == ErrorException
+            success = isa(exc, ErrorException) || isa(exc, FieldError)
         elseif isa(extype, Exception) || !isa(exc, Exception)
             if extype isa LoadError && !(exc isa LoadError) && typeof(extype.error) == typeof(exc)
                 extype = extype.error # deprecated

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -1543,15 +1543,10 @@ end
 @testset "FieldError Shim tests and Softdeprecation of @test_throws ErrorException" begin
     feexc = FEexc(nothing, nothing)
     # This is redundant regular test for FieldError
-    exc_result1 = @test_throws FieldError feexc.c
-    @test  exc_result1.value isa FieldError
-    # This is test for FieldError shim
-    exc_result2 = @test_throws ErrorException feexc.c
-    @test exc_result2.value isa FieldError
+    @test_throws FieldError feexc.c
     # This should raise ErrorException
-    exc_result3 = @test_throws ErrorException feexc.a = 1
-    @test exc_result3.value isa ErrorException
-    # checks for deprecation
+    @test_throws ErrorException feexc.a = 1
+    # This is test for FieldError shim and deprecation
     @test_deprecated @test_throws ErrorException feexc.c
 end
 

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -1534,6 +1534,27 @@ end
     @test_throws LoadError("file", 111, ErrorException("Real error")) @macroexpand @test_macro_throw_2
 end
 
+# Issue 54807
+struct FEexc
+    a::Nothing
+    b::Nothing
+end
+
+@testset "FieldError Shim tests and Softdeprecation of @test_throws ErrorException" begin
+    feexc = FEexc(nothing, nothing)
+    # This is redundant regular test for FieldError
+    exc_result1 = @test_throws FieldError feexc.c
+    @test  exc_result1.value isa FieldError
+    # This is test for FieldError shim
+    exc_result2 = @test_throws ErrorException feexc.c
+    @test exc_result2.value isa FieldError
+    # This should raise ErrorException
+    exc_result3 = @test_throws ErrorException feexc.a = 1
+    @test exc_result3.value isa ErrorException
+    # checks for deprecation
+    @test_deprecated @test_throws ErrorException feexc.c
+end
+
 # Issue 25483
 mutable struct PassInformationTestSet <: Test.AbstractTestSet
     results::Vector


### PR DESCRIPTION
Original commit introducing FieldError exception is 7e5d9a3. Since existing packages were using `ErrorException` to capture `no field` errors, we need to have a shim to avoid test breaks for external packages with such uses until they update to `FieldError`. 

addressing `need shim for FieldError` #54807
