### PR TITLE
Fix lowering for `export` and similar

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -5124,7 +5124,7 @@ f(x) = yt(x)
             ((nospecialize-meta? e)
              ;; convert nospecialize vars to slot numbers
              `(meta ,(cadr e) ,@(map renumber-stuff (cddr e))))
-            ((or (atom? e) (quoted? e) (eq? (car e) 'global) (eq? (car e) 'toplevel))
+            ((or (atom? e) (quoted? e) (memq (car e) '(using import export public global toplevel)))
              e)
             ((ssavalue? e)
              (let ((idx (get ssavalue-table (cadr e) #f)))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -3736,3 +3736,14 @@ begin
     Foreign54607.bar = 9
 end
 @test Foreign54607.bar == 9
+
+# Issue #54805 - export mislowering
+module Export54805
+let
+    local b54805=1
+    export b54805
+end
+b54805 = 2
+end
+using .Export54805
+@test b54805 == 2


### PR DESCRIPTION
Keep things as raw symbols - don't try to rename them. Fixes #54805.