### PR TITLE
Add `Base.Broadcast.BroadcastFunction` Documentation

### DIFF
--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -79,6 +79,7 @@ to operate on arrays, you should use `sin.(a)` to vectorize via `broadcast`.
 Base.broadcast
 Base.Broadcast.broadcast!
 Base.@__dot__
+Base.Broadcast.BroadcastFunction
 ```
 
 For specializing broadcast on custom types, see


### PR DESCRIPTION
`Base.Broadcast.BroadcastFunction` not documented and [caused some inconvenience](https://github.com/LuxDL/Lux.jl/issues/687#issuecomment-2170637044)

This PR add `BroadcastFunction` to documentation