### PR TITLE
Use new `PivotingStrategy` in pivoted Cholesky

### DIFF
--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -431,6 +431,7 @@ LinearAlgebra.NoPivot
 LinearAlgebra.RowNonZero
 LinearAlgebra.RowMaximum
 LinearAlgebra.ColumnNorm
+LinearAlgebra.DiagonalPivoting
 ```
 
 ## Standard functions

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -431,7 +431,7 @@ LinearAlgebra.NoPivot
 LinearAlgebra.RowNonZero
 LinearAlgebra.RowMaximum
 LinearAlgebra.ColumnNorm
-LinearAlgebra.DiagonalPivoting
+LinearAlgebra.DiagonalMaximum
 ```
 
 ## Standard functions

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -38,6 +38,7 @@ export
     CholeskyPivoted,
     ColumnNorm,
     Diagonal,
+    DiagonalPivoting,
     Eigen,
     Factorization,
     GeneralizedEigen,
@@ -241,6 +242,17 @@ Note that the [element type](@ref eltype) of the matrix must admit [`norm`](@ref
 [`abs`](@ref) methods, whose respective result types must admit a [`<`](@ref) method.
 """
 struct ColumnNorm <: PivotingStrategy end
+
+"""
+    DiagonalPivoting
+
+The maximal element along the remaining diagonal elements is chosen as the pivot element.
+This pivoting strategy is used in the pivoted Cholesky decomposition, and yields a
+complete pivoting.
+
+Note that the [element type](@ref eltype) of the matrix must admit a [`<`](@ref) method.
+"""
+struct DiagonalPivoting <: PivotingStrategy end
 
 using Base: DimOrInd
 

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -38,7 +38,7 @@ export
     CholeskyPivoted,
     ColumnNorm,
     Diagonal,
-    DiagonalPivoting,
+    DiagonalMaximum,
     Eigen,
     Factorization,
     GeneralizedEigen,
@@ -244,7 +244,7 @@ Note that the [element type](@ref eltype) of the matrix must admit [`norm`](@ref
 struct ColumnNorm <: PivotingStrategy end
 
 """
-    DiagonalPivoting
+    DiagonalMaximum
 
 The maximal element along the remaining diagonal elements is chosen as the pivot element.
 This pivoting strategy is used in the pivoted Cholesky decomposition, and yields a
@@ -252,7 +252,7 @@ complete pivoting.
 
 Note that the [element type](@ref eltype) of the matrix must admit a [`<`](@ref) method.
 """
-struct DiagonalPivoting <: PivotingStrategy end
+struct DiagonalMaximum <: PivotingStrategy end
 
 using Base: DimOrInd
 

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -10,11 +10,9 @@
 # In the methods below, LAPACK is called when possible, i.e. StridedMatrices with Float32,
 # Float64, ComplexF32, and ComplexF64 element types. For other element or
 # matrix types, the unblocked Julia implementation in _chol! is used. For cholesky
-# and cholesky! pivoting is supported through a RowMaximum() argument. A type argument is
+# and cholesky! pivoting is supported through a DiagonalPivoting() argument. A type argument is
 # necessary for type stability since the output of cholesky and cholesky! is either
-# Cholesky or CholeskyPivoted. The latter is only
-# supported for the four LAPACK element types. For other types, e.g. BigFloats RowMaximum() will
-# give an error. It is required that the input is Hermitian (including real symmetric) either
+# Cholesky or CholeskyPivoted. It is required that the input is Hermitian (including real symmetric) either
 # through the Hermitian and Symmetric views or exact symmetric or Hermitian elements which
 # is checked for and an error is thrown if the check fails.
 
@@ -106,7 +104,7 @@ Base.iterate(C::Cholesky, ::Val{:done}) = nothing
     CholeskyPivoted
 
 Matrix factorization type of the pivoted Cholesky factorization of a dense symmetric/Hermitian
-positive semi-definite matrix `A`. This is the return type of [`cholesky(_, ::RowMaximum)`](@ref),
+positive semi-definite matrix `A`. This is the return type of [`cholesky(_, ::DiagonalPivoting)`](@ref),
 the corresponding matrix factorization function.
 
 The triangular Cholesky factor can be obtained from the factorization `F::CholeskyPivoted`
@@ -126,7 +124,7 @@ julia> X = [1.0, 2.0, 3.0, 4.0];
 
 julia> A = X * X';
 
-julia> C = cholesky(A, RowMaximum(), check = false)
+julia> C = cholesky(A, DiagonalPivoting(), check = false)
 CholeskyPivoted{Float64, Matrix{Float64}, Vector{Int64}}
 U factor with rank 1:
 4×4 UpperTriangular{Float64, Matrix{Float64}}:
@@ -455,23 +453,23 @@ end
 
 ## With pivoting
 ### Non BLAS/LAPACK element types (generic).
-function cholesky!(A::SelfAdjoint, ::RowMaximum; tol = 0.0, check::Bool = true)
+function cholesky!(A::SelfAdjoint, ::DiagonalPivoting; tol = 0.0, check::Bool = true)
     AA, piv, rank, info = _cholpivoted!(A.data, A.uplo == 'U' ? UpperTriangular : LowerTriangular, tol, check)
     C = CholeskyPivoted(AA, A.uplo, piv, rank, tol, info)
     check && chkfullrank(C)
     return C
 end
-@deprecate cholesky!(A::RealHermSymComplexHerm{<:Real}, ::Val{true}; kwargs...) cholesky!(A, RowMaximum(); kwargs...) false
+@deprecate cholesky!(A::RealHermSymComplexHerm{<:Real}, ::Val{true}; kwargs...) cholesky!(A, DiagonalPivoting(); kwargs...) false
 
 """
-    cholesky!(A::AbstractMatrix, RowMaximum(); tol = 0.0, check = true) -> CholeskyPivoted
+    cholesky!(A::AbstractMatrix, DiagonalPivoting(); tol = 0.0, check = true) -> CholeskyPivoted
 
 The same as [`cholesky`](@ref), but saves space by overwriting the input `A`,
 instead of creating a copy. An [`InexactError`](@ref) exception is thrown if the
 factorization produces a number not representable by the element type of `A`,
 e.g. for integer types.
 """
-function cholesky!(A::AbstractMatrix, ::RowMaximum; tol = 0.0, check::Bool = true)
+function cholesky!(A::AbstractMatrix, ::DiagonalPivoting; tol = 0.0, check::Bool = true)
     checksquare(A)
     if !ishermitian(A)
         C = CholeskyPivoted(A, 'U', Vector{BlasInt}(), convert(BlasInt, 1),
@@ -479,10 +477,11 @@ function cholesky!(A::AbstractMatrix, ::RowMaximum; tol = 0.0, check::Bool = tru
         check && checkpositivedefinite(convert(BlasInt, -1))
         return C
     else
-        return cholesky!(Hermitian(A), RowMaximum(); tol, check)
+        return cholesky!(Hermitian(A), DiagonalPivoting(); tol, check)
     end
 end
-@deprecate cholesky!(A::StridedMatrix, ::Val{true}; kwargs...) cholesky!(A, RowMaximum(); kwargs...) false
+@deprecate cholesky!(A::StridedMatrix, ::Val{true}; kwargs...) cholesky!(A, DiagonalPivoting(); kwargs...) false
+@deprecate cholesky!(A::AbstractMatrix, ::RowMaximum; kwargs...) cholesky!(A, DiagonalPivoting(); kwargs...)
 
 # cholesky. Non-destructive methods for computing Cholesky factorization of real symmetric
 # or Hermitian matrix
@@ -553,7 +552,7 @@ _cholesky(A::AbstractMatrix, args...; kwargs...) = cholesky!(A, args...; kwargs.
 
 ## With pivoting
 """
-    cholesky(A, RowMaximum(); tol = 0.0, check = true) -> CholeskyPivoted
+    cholesky(A, DiagonalPivoting(); tol = 0.0, check = true) -> CholeskyPivoted
 
 Compute the pivoted Cholesky factorization of a dense symmetric positive semi-definite matrix `A`
 and return a [`CholeskyPivoted`](@ref) factorization. The matrix `A` can either be a [`Symmetric`](@ref)
@@ -583,7 +582,7 @@ julia> X = [1.0, 2.0, 3.0, 4.0];
 
 julia> A = X * X';
 
-julia> C = cholesky(A, RowMaximum(), check = false)
+julia> C = cholesky(A, DiagonalPivoting(), check = false)
 CholeskyPivoted{Float64, Matrix{Float64}, Vector{Int64}}
 U factor with rank 1:
 4×4 UpperTriangular{Float64, Matrix{Float64}}:
@@ -607,12 +606,13 @@ julia> l == C.L && u == C.U
 true
 ```
 """
-cholesky(A::AbstractMatrix, ::RowMaximum; tol = 0.0, check::Bool = true) =
-    _cholesky(cholcopy(A), RowMaximum(); tol, check)
-@deprecate cholesky(A::Union{StridedMatrix,RealHermSymComplexHerm{<:Real,<:StridedMatrix}}, ::Val{true}; tol = 0.0, check::Bool = true) cholesky(A, RowMaximum(); tol, check) false
+cholesky(A::AbstractMatrix, ::DiagonalPivoting; tol = 0.0, check::Bool = true) =
+    _cholesky(cholcopy(A), DiagonalPivoting(); tol, check)
+@deprecate cholesky(A::Union{StridedMatrix,RealHermSymComplexHerm{<:Real,<:StridedMatrix}}, ::Val{true}; tol = 0.0, check::Bool = true) cholesky(A, DiagonalPivoting(); tol, check) false
+@deprecate cholesky(A::AbstractMatrix, ::RowMaximum; kwargs...) cholesky(A, DiagonalPivoting(); kwargs...)
 
-function cholesky(A::AbstractMatrix{Float16}, ::RowMaximum; tol = 0.0, check::Bool = true)
-    X = _cholesky(cholcopy(A), RowMaximum(); tol, check)
+function cholesky(A::AbstractMatrix{Float16}, ::DiagonalPivoting; tol = 0.0, check::Bool = true)
+    X = _cholesky(cholcopy(A), DiagonalPivoting(); tol, check)
     return CholeskyPivoted{Float16}(X)
 end
 

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -925,7 +925,7 @@ end
 @deprecate cholesky!(A::Diagonal, ::Val{false}; check::Bool = true) cholesky!(A::Diagonal, NoPivot(); check) false
 @deprecate cholesky(A::Diagonal, ::Val{false}; check::Bool = true) cholesky(A::Diagonal, NoPivot(); check) false
 
-function cholesky!(A::Diagonal, ::RowMaximum; tol=0.0, check=true)
+function cholesky!(A::Diagonal, ::DiagonalPivoting; tol=0.0, check=true)
     if !ishermitian(A)
         C = CholeskyPivoted(A, 'U', Vector{BlasInt}(), convert(BlasInt, 1),
                             tol, convert(BlasInt, -1))
@@ -954,6 +954,8 @@ function cholesky!(A::Diagonal, ::RowMaximum; tol=0.0, check=true)
     end
     return C
 end
+
+@deprecate cholesky!(A::Diagonal, ::RowMaximum; kwargs...) cholesky!(A, DiagonalPivoting(); kwargs...)
 
 inv(C::Cholesky{<:Any,<:Diagonal}) = Diagonal(map(inv∘abs2, C.factors.diag))
 

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -925,7 +925,7 @@ end
 @deprecate cholesky!(A::Diagonal, ::Val{false}; check::Bool = true) cholesky!(A::Diagonal, NoPivot(); check) false
 @deprecate cholesky(A::Diagonal, ::Val{false}; check::Bool = true) cholesky(A::Diagonal, NoPivot(); check) false
 
-function cholesky!(A::Diagonal, ::DiagonalPivoting; tol=0.0, check=true)
+function cholesky!(A::Diagonal, ::DiagonalMaximum; tol=0.0, check=true)
     if !ishermitian(A)
         C = CholeskyPivoted(A, 'U', Vector{BlasInt}(), convert(BlasInt, 1),
                             tol, convert(BlasInt, -1))
@@ -955,7 +955,7 @@ function cholesky!(A::Diagonal, ::DiagonalPivoting; tol=0.0, check=true)
     return C
 end
 
-@deprecate cholesky!(A::Diagonal, ::RowMaximum; kwargs...) cholesky!(A, DiagonalPivoting(); kwargs...)
+@deprecate cholesky!(A::Diagonal, ::RowMaximum; kwargs...) cholesky!(A, DiagonalMaximum(); kwargs...)
 
 inv(C::Cholesky{<:Any,<:Diagonal}) = Diagonal(map(inv∘abs2, C.factors.diag))
 

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -155,7 +155,7 @@ end
 
         #pivoted upper Cholesky
         for tol in (0.0, -1.0), APD in (apdh, apdhL)
-            cpapd = cholesky(APD, RowMaximum(), tol=tol)
+            cpapd = cholesky(APD, DiagonalPivoting(), tol=tol)
             unary_ops_tests(APD, cpapd, ε*κ*n)
             @test rank(cpapd) == n
             @test all(diff(real(diag(cpapd.factors))).<=0.) # diagonal should be non-increasing
@@ -190,11 +190,11 @@ end
                 @test norm(apd * (lapd\b) - b)/norm(b) <= ε*κ*n
                 @test norm(apd * (lapd\b[1:n]) - b[1:n])/norm(b[1:n]) <= ε*κ*n
 
-                cpapd = cholesky(apdh, RowMaximum())
+                cpapd = cholesky(apdh, DiagonalPivoting())
                 @test norm(apd * (cpapd\b) - b)/norm(b) <= ε*κ*n # Ad hoc, revisit
                 @test norm(apd * (cpapd\b[1:n]) - b[1:n])/norm(b[1:n]) <= ε*κ*n
 
-                lpapd = cholesky(apdhL, RowMaximum())
+                lpapd = cholesky(apdhL, DiagonalPivoting())
                 @test norm(apd * (lpapd\b) - b)/norm(b) <= ε*κ*n # Ad hoc, revisit
                 @test norm(apd * (lpapd\b[1:n]) - b[1:n])/norm(b[1:n]) <= ε*κ*n
             end
@@ -221,7 +221,7 @@ end
                 ldiv!(capd, BB)
                 @test norm(apd \ B - BB, 1) / norm(BB, 1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
                 @test norm(apd * BB - B, 1) / norm(B, 1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
-                cpapd = cholesky(apdh, RowMaximum())
+                cpapd = cholesky(apdh, DiagonalPivoting())
                 BB = copy(B)
                 ldiv!(cpapd, BB)
                 @test norm(apd \ B - BB, 1) / norm(BB, 1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
@@ -256,12 +256,12 @@ end
                 rdiv!(BB, cpapd)
                 @test norm(B / apd - BB, 1) / norm(BB, 1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
                 @test norm(BB * apd - B, 1) / norm(B, 1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
-                cpapd = cholesky(eltya <: Real ? apds : apdh, RowMaximum())
+                cpapd = cholesky(eltya <: Real ? apds : apdh, DiagonalPivoting())
                 BB = copy(B)
                 rdiv!(BB, cpapd)
                 @test norm(B / apd - BB, 1) / norm(BB, 1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
                 @test norm(BB * apd - B, 1) / norm(B, 1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
-                cpapd = cholesky(eltya <: Real ? apdsL : apdhL, RowMaximum())
+                cpapd = cholesky(eltya <: Real ? apdsL : apdhL, DiagonalPivoting())
                 BB = copy(B)
                 rdiv!(BB, cpapd)
                 @test norm(B / apd - BB, 1) / norm(BB, 1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
@@ -297,27 +297,27 @@ end
         @test !issuccess(cholesky!(copy(M); check = false))
     end
     for M in (A, Hermitian(A)) # hermitian, but not semi-positive definite
-        @test_throws RankDeficientException cholesky(M, RowMaximum())
-        @test_throws RankDeficientException cholesky!(copy(M), RowMaximum())
-        @test_throws RankDeficientException cholesky(M, RowMaximum(); check = true)
-        @test_throws RankDeficientException cholesky!(copy(M), RowMaximum(); check = true)
-        @test !issuccess(cholesky(M, RowMaximum(); check = false))
-        @test !issuccess(cholesky!(copy(M), RowMaximum(); check = false))
-        C = cholesky(M, RowMaximum(); check = false)
+        @test_throws RankDeficientException cholesky(M, DiagonalPivoting())
+        @test_throws RankDeficientException cholesky!(copy(M), DiagonalPivoting())
+        @test_throws RankDeficientException cholesky(M, DiagonalPivoting(); check = true)
+        @test_throws RankDeficientException cholesky!(copy(M), DiagonalPivoting(); check = true)
+        @test !issuccess(cholesky(M, DiagonalPivoting(); check = false))
+        @test !issuccess(cholesky!(copy(M), DiagonalPivoting(); check = false))
+        C = cholesky(M, DiagonalPivoting(); check = false)
         @test_throws RankDeficientException chkfullrank(C)
-        C = cholesky!(copy(M), RowMaximum(); check = false)
+        C = cholesky!(copy(M), DiagonalPivoting(); check = false)
         @test_throws RankDeficientException chkfullrank(C)
     end
     for M in (B,) # not hermitian
-        @test_throws PosDefException(-1) cholesky(M, RowMaximum())
-        @test_throws PosDefException(-1) cholesky!(copy(M), RowMaximum())
-        @test_throws PosDefException(-1) cholesky(M, RowMaximum(); check = true)
-        @test_throws PosDefException(-1) cholesky!(copy(M), RowMaximum(); check = true)
-        @test !issuccess(cholesky(M, RowMaximum(); check = false))
-        @test !issuccess(cholesky!(copy(M), RowMaximum(); check = false))
-        C = cholesky(M, RowMaximum(); check = false)
+        @test_throws PosDefException(-1) cholesky(M, DiagonalPivoting())
+        @test_throws PosDefException(-1) cholesky!(copy(M), DiagonalPivoting())
+        @test_throws PosDefException(-1) cholesky(M, DiagonalPivoting(); check = true)
+        @test_throws PosDefException(-1) cholesky!(copy(M), DiagonalPivoting(); check = true)
+        @test !issuccess(cholesky(M, DiagonalPivoting(); check = false))
+        @test !issuccess(cholesky!(copy(M), DiagonalPivoting(); check = false))
+        C = cholesky(M, DiagonalPivoting(); check = false)
         @test_throws RankDeficientException chkfullrank(C)
-        C = cholesky!(copy(M), RowMaximum(); check = false)
+        C = cholesky!(copy(M), DiagonalPivoting(); check = false)
         @test_throws RankDeficientException chkfullrank(C)
     end
     @test !isposdef(A)
@@ -390,7 +390,7 @@ end
         0.25336108035924787 + 0.975317836492159im 0.0628393808469436 - 0.1253397353973715im
         0.11192755545114 - 0.1603741874112385im 0.8439562576196216 + 1.0850814110398734im
         -1.0568488936791578 - 0.06025820467086475im 0.12696236014017806 - 0.09853584666755086im]
-    cholesky(Hermitian(apd, :L), RowMaximum()) \ b
+    cholesky(Hermitian(apd, :L), DiagonalPivoting()) \ b
     r = cholesky(apd).U
     E = abs.(apd - r'*r)
     ε = eps(abs(float(one(ComplexF32))))
@@ -410,8 +410,8 @@ end
     @test CD.U ≈ Diagonal(.√d) ≈ CM.U
     @test D ≈ CD.L * CD.U
     @test CD.info == 0
-    CD = cholesky(D, RowMaximum())
-    CM = cholesky(Matrix(D), RowMaximum())
+    CD = cholesky(D, DiagonalPivoting())
+    CM = cholesky(Matrix(D), DiagonalPivoting())
     @test CD isa CholeskyPivoted{Float64}
     @test CD.U ≈ Diagonal(.√sort(d, rev=true)) ≈ CM.U
     @test D ≈ Matrix(CD)
@@ -420,16 +420,16 @@ end
     F = cholesky(Hermitian(I(3)))
     @test F isa Cholesky{Float64,<:Diagonal}
     @test Matrix(F) ≈ I(3)
-    F = cholesky(I(3), RowMaximum())
+    F = cholesky(I(3), DiagonalPivoting())
     @test F isa CholeskyPivoted{Float64,<:Diagonal}
     @test Matrix(F) ≈ I(3)
 
     # real, failing
     @test_throws PosDefException cholesky(Diagonal([1.0, -2.0]))
-    @test_throws RankDeficientException cholesky(Diagonal([1.0, -2.0]), RowMaximum())
+    @test_throws RankDeficientException cholesky(Diagonal([1.0, -2.0]), DiagonalPivoting())
     Dnpd = cholesky(Diagonal([1.0, -2.0]); check = false)
     @test Dnpd.info == 2
-    Dnpd = cholesky(Diagonal([1.0, -2.0]), RowMaximum(); check = false)
+    Dnpd = cholesky(Diagonal([1.0, -2.0]), DiagonalPivoting(); check = false)
     @test Dnpd.info == 1
     @test Dnpd.rank == 1
 
@@ -441,8 +441,8 @@ end
     @test CD.U ≈ Diagonal(.√d) ≈ CM.U
     @test D ≈ CD.L * CD.U
     @test CD.info == 0
-    CD = cholesky(D, RowMaximum())
-    CM = cholesky(Matrix(D), RowMaximum())
+    CD = cholesky(D, DiagonalPivoting())
+    CM = cholesky(Matrix(D), DiagonalPivoting())
     @test CD isa CholeskyPivoted{ComplexF64,<:Diagonal}
     @test CD.U ≈ Diagonal(.√sort(d, by=real, rev=true)) ≈ CM.U
     @test D ≈ Matrix(CD)
@@ -451,10 +451,10 @@ end
     # complex, failing
     D[2, 2] = 0.0 + 0im
     @test_throws PosDefException cholesky(D)
-    @test_throws RankDeficientException cholesky(D, RowMaximum())
+    @test_throws RankDeficientException cholesky(D, DiagonalPivoting())
     Dnpd = cholesky(D; check = false)
     @test Dnpd.info == 2
-    Dnpd = cholesky(D, RowMaximum(); check = false)
+    Dnpd = cholesky(D, DiagonalPivoting(); check = false)
     @test Dnpd.info == 1
     @test Dnpd.rank == 2
 
@@ -463,11 +463,11 @@ end
 
     # tolerance
     D = Diagonal([0.5, 1])
-    @test_throws RankDeficientException cholesky(D, RowMaximum(), tol=nextfloat(0.5))
-    CD = cholesky(D, RowMaximum(), tol=nextfloat(0.5), check=false)
+    @test_throws RankDeficientException cholesky(D, DiagonalPivoting(), tol=nextfloat(0.5))
+    CD = cholesky(D, DiagonalPivoting(), tol=nextfloat(0.5), check=false)
     @test rank(CD) == 1
     @test !issuccess(CD)
-    @test Matrix(cholesky(D, RowMaximum(), tol=prevfloat(0.5))) ≈ D
+    @test Matrix(cholesky(D, DiagonalPivoting(), tol=prevfloat(0.5))) ≈ D
 end
 
 @testset "Cholesky for AbstractMatrix" begin
@@ -486,7 +486,7 @@ end
     @test Cholesky(factors, uplo, Int32(info)) == chol
     @test Cholesky(factors, uplo, Int64(info)) == chol
 
-    cholp = cholesky(x'x, RowMaximum())
+    cholp = cholesky(x'x, DiagonalPivoting())
 
     factors, uplo, piv, rank, tol, info =
         cholp.factors, cholp.uplo, cholp.piv, cholp.rank, cholp.tol, cholp.info
@@ -502,25 +502,25 @@ end
 @testset "issue #33704, casting low-rank CholeskyPivoted to Matrix" begin
     A = randn(1,8)
     B = A'A
-    C = cholesky(B, RowMaximum(), check=false)
+    C = cholesky(B, DiagonalPivoting(), check=false)
     @test B ≈ Matrix(C)
 end
 
 @testset "CholeskyPivoted and Factorization" begin
     A = randn(8,8)
     B = A'A
-    C = cholesky(B, RowMaximum(), check=false)
+    C = cholesky(B, DiagonalPivoting(), check=false)
     @test CholeskyPivoted{eltype(C)}(C) === C
     @test Factorization{eltype(C)}(C) === C
-    @test Array(CholeskyPivoted{complex(eltype(C))}(C)) ≈ Array(cholesky(complex(B), RowMaximum(), check=false))
-    @test Array(Factorization{complex(eltype(C))}(C)) ≈ Array(cholesky(complex(B), RowMaximum(), check=false))
+    @test Array(CholeskyPivoted{complex(eltype(C))}(C)) ≈ Array(cholesky(complex(B), DiagonalPivoting(), check=false))
+    @test Array(Factorization{complex(eltype(C))}(C)) ≈ Array(cholesky(complex(B), DiagonalPivoting(), check=false))
     @test eltype(Factorization{complex(eltype(C))}(C)) == complex(eltype(C))
 end
 
 @testset "REPL printing of CholeskyPivoted" begin
     A = randn(8,8)
     B = A'A
-    C = cholesky(B, RowMaximum(), check=false)
+    C = cholesky(B, DiagonalPivoting(), check=false)
     cholstring = sprint((t, s) -> show(t, "text/plain", s), C)
     rankstring = "$(C.uplo) factor with rank $(rank(C)):"
     factorstring = sprint((t, s) -> show(t, "text/plain", s), C.uplo == 'U' ? C.U : C.L)
@@ -529,7 +529,7 @@ end
 end
 
 @testset "destructuring for Cholesky[Pivoted]" begin
-    for val in (NoPivot(), RowMaximum())
+    for val in (NoPivot(), DiagonalPivoting())
         A = rand(8, 8)
         B = A'A
         C = cholesky(B, val, check=false)
@@ -584,8 +584,8 @@ end
     @test B.L ≈ B32.L
     @test B.UL ≈ B32.UL
     @test Matrix(B) ≈ A
-    B = cholesky(A, RowMaximum())
-    B32 = cholesky(Float32.(A), RowMaximum())
+    B = cholesky(A, DiagonalPivoting())
+    B32 = cholesky(Float32.(A), DiagonalPivoting())
     @test B isa CholeskyPivoted{Float16,Matrix{Float16}}
     @test B.U isa UpperTriangular{Float16, Matrix{Float16}}
     @test B.L isa LowerTriangular{Float16, Matrix{Float16}}
@@ -601,7 +601,7 @@ end
          2048 1920 2940 1008 2240 2740;
          4470 4200 6410 2240 4875 6015;
          5490 5140 7903 2740 6015 7370]
-    B = cholesky(A, RowMaximum(), check=false)
+    B = cholesky(A, DiagonalPivoting(), check=false)
     @test det(B)  ==  0.0
     @test det(B)  ≈  det(A) atol=eps()
     @test logdet(B)  ==  -Inf

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -155,7 +155,7 @@ end
 
         #pivoted upper Cholesky
         for tol in (0.0, -1.0), APD in (apdh, apdhL)
-            cpapd = cholesky(APD, DiagonalPivoting(), tol=tol)
+            cpapd = cholesky(APD, DiagonalMaximum(), tol=tol)
             unary_ops_tests(APD, cpapd, ε*κ*n)
             @test rank(cpapd) == n
             @test all(diff(real(diag(cpapd.factors))).<=0.) # diagonal should be non-increasing
@@ -190,11 +190,11 @@ end
                 @test norm(apd * (lapd\b) - b)/norm(b) <= ε*κ*n
                 @test norm(apd * (lapd\b[1:n]) - b[1:n])/norm(b[1:n]) <= ε*κ*n
 
-                cpapd = cholesky(apdh, DiagonalPivoting())
+                cpapd = cholesky(apdh, DiagonalMaximum())
                 @test norm(apd * (cpapd\b) - b)/norm(b) <= ε*κ*n # Ad hoc, revisit
                 @test norm(apd * (cpapd\b[1:n]) - b[1:n])/norm(b[1:n]) <= ε*κ*n
 
-                lpapd = cholesky(apdhL, DiagonalPivoting())
+                lpapd = cholesky(apdhL, DiagonalMaximum())
                 @test norm(apd * (lpapd\b) - b)/norm(b) <= ε*κ*n # Ad hoc, revisit
                 @test norm(apd * (lpapd\b[1:n]) - b[1:n])/norm(b[1:n]) <= ε*κ*n
             end
@@ -221,7 +221,7 @@ end
                 ldiv!(capd, BB)
                 @test norm(apd \ B - BB, 1) / norm(BB, 1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
                 @test norm(apd * BB - B, 1) / norm(B, 1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
-                cpapd = cholesky(apdh, DiagonalPivoting())
+                cpapd = cholesky(apdh, DiagonalMaximum())
                 BB = copy(B)
                 ldiv!(cpapd, BB)
                 @test norm(apd \ B - BB, 1) / norm(BB, 1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
@@ -256,12 +256,12 @@ end
                 rdiv!(BB, cpapd)
                 @test norm(B / apd - BB, 1) / norm(BB, 1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
                 @test norm(BB * apd - B, 1) / norm(B, 1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
-                cpapd = cholesky(eltya <: Real ? apds : apdh, DiagonalPivoting())
+                cpapd = cholesky(eltya <: Real ? apds : apdh, DiagonalMaximum())
                 BB = copy(B)
                 rdiv!(BB, cpapd)
                 @test norm(B / apd - BB, 1) / norm(BB, 1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
                 @test norm(BB * apd - B, 1) / norm(B, 1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
-                cpapd = cholesky(eltya <: Real ? apdsL : apdhL, DiagonalPivoting())
+                cpapd = cholesky(eltya <: Real ? apdsL : apdhL, DiagonalMaximum())
                 BB = copy(B)
                 rdiv!(BB, cpapd)
                 @test norm(B / apd - BB, 1) / norm(BB, 1) <= (3n^2 + n + n^3*ε)*ε/(1-(n+1)*ε)*κ
@@ -297,27 +297,27 @@ end
         @test !issuccess(cholesky!(copy(M); check = false))
     end
     for M in (A, Hermitian(A)) # hermitian, but not semi-positive definite
-        @test_throws RankDeficientException cholesky(M, DiagonalPivoting())
-        @test_throws RankDeficientException cholesky!(copy(M), DiagonalPivoting())
-        @test_throws RankDeficientException cholesky(M, DiagonalPivoting(); check = true)
-        @test_throws RankDeficientException cholesky!(copy(M), DiagonalPivoting(); check = true)
-        @test !issuccess(cholesky(M, DiagonalPivoting(); check = false))
-        @test !issuccess(cholesky!(copy(M), DiagonalPivoting(); check = false))
-        C = cholesky(M, DiagonalPivoting(); check = false)
+        @test_throws RankDeficientException cholesky(M, DiagonalMaximum())
+        @test_throws RankDeficientException cholesky!(copy(M), DiagonalMaximum())
+        @test_throws RankDeficientException cholesky(M, DiagonalMaximum(); check = true)
+        @test_throws RankDeficientException cholesky!(copy(M), DiagonalMaximum(); check = true)
+        @test !issuccess(cholesky(M, DiagonalMaximum(); check = false))
+        @test !issuccess(cholesky!(copy(M), DiagonalMaximum(); check = false))
+        C = cholesky(M, DiagonalMaximum(); check = false)
         @test_throws RankDeficientException chkfullrank(C)
-        C = cholesky!(copy(M), DiagonalPivoting(); check = false)
+        C = cholesky!(copy(M), DiagonalMaximum(); check = false)
         @test_throws RankDeficientException chkfullrank(C)
     end
     for M in (B,) # not hermitian
-        @test_throws PosDefException(-1) cholesky(M, DiagonalPivoting())
-        @test_throws PosDefException(-1) cholesky!(copy(M), DiagonalPivoting())
-        @test_throws PosDefException(-1) cholesky(M, DiagonalPivoting(); check = true)
-        @test_throws PosDefException(-1) cholesky!(copy(M), DiagonalPivoting(); check = true)
-        @test !issuccess(cholesky(M, DiagonalPivoting(); check = false))
-        @test !issuccess(cholesky!(copy(M), DiagonalPivoting(); check = false))
-        C = cholesky(M, DiagonalPivoting(); check = false)
+        @test_throws PosDefException(-1) cholesky(M, DiagonalMaximum())
+        @test_throws PosDefException(-1) cholesky!(copy(M), DiagonalMaximum())
+        @test_throws PosDefException(-1) cholesky(M, DiagonalMaximum(); check = true)
+        @test_throws PosDefException(-1) cholesky!(copy(M), DiagonalMaximum(); check = true)
+        @test !issuccess(cholesky(M, DiagonalMaximum(); check = false))
+        @test !issuccess(cholesky!(copy(M), DiagonalMaximum(); check = false))
+        C = cholesky(M, DiagonalMaximum(); check = false)
         @test_throws RankDeficientException chkfullrank(C)
-        C = cholesky!(copy(M), DiagonalPivoting(); check = false)
+        C = cholesky!(copy(M), DiagonalMaximum(); check = false)
         @test_throws RankDeficientException chkfullrank(C)
     end
     @test !isposdef(A)
@@ -390,7 +390,7 @@ end
         0.25336108035924787 + 0.975317836492159im 0.0628393808469436 - 0.1253397353973715im
         0.11192755545114 - 0.1603741874112385im 0.8439562576196216 + 1.0850814110398734im
         -1.0568488936791578 - 0.06025820467086475im 0.12696236014017806 - 0.09853584666755086im]
-    cholesky(Hermitian(apd, :L), DiagonalPivoting()) \ b
+    cholesky(Hermitian(apd, :L), DiagonalMaximum()) \ b
     r = cholesky(apd).U
     E = abs.(apd - r'*r)
     ε = eps(abs(float(one(ComplexF32))))
@@ -410,8 +410,8 @@ end
     @test CD.U ≈ Diagonal(.√d) ≈ CM.U
     @test D ≈ CD.L * CD.U
     @test CD.info == 0
-    CD = cholesky(D, DiagonalPivoting())
-    CM = cholesky(Matrix(D), DiagonalPivoting())
+    CD = cholesky(D, DiagonalMaximum())
+    CM = cholesky(Matrix(D), DiagonalMaximum())
     @test CD isa CholeskyPivoted{Float64}
     @test CD.U ≈ Diagonal(.√sort(d, rev=true)) ≈ CM.U
     @test D ≈ Matrix(CD)
@@ -420,16 +420,16 @@ end
     F = cholesky(Hermitian(I(3)))
     @test F isa Cholesky{Float64,<:Diagonal}
     @test Matrix(F) ≈ I(3)
-    F = cholesky(I(3), DiagonalPivoting())
+    F = cholesky(I(3), DiagonalMaximum())
     @test F isa CholeskyPivoted{Float64,<:Diagonal}
     @test Matrix(F) ≈ I(3)
 
     # real, failing
     @test_throws PosDefException cholesky(Diagonal([1.0, -2.0]))
-    @test_throws RankDeficientException cholesky(Diagonal([1.0, -2.0]), DiagonalPivoting())
+    @test_throws RankDeficientException cholesky(Diagonal([1.0, -2.0]), DiagonalMaximum())
     Dnpd = cholesky(Diagonal([1.0, -2.0]); check = false)
     @test Dnpd.info == 2
-    Dnpd = cholesky(Diagonal([1.0, -2.0]), DiagonalPivoting(); check = false)
+    Dnpd = cholesky(Diagonal([1.0, -2.0]), DiagonalMaximum(); check = false)
     @test Dnpd.info == 1
     @test Dnpd.rank == 1
 
@@ -441,8 +441,8 @@ end
     @test CD.U ≈ Diagonal(.√d) ≈ CM.U
     @test D ≈ CD.L * CD.U
     @test CD.info == 0
-    CD = cholesky(D, DiagonalPivoting())
-    CM = cholesky(Matrix(D), DiagonalPivoting())
+    CD = cholesky(D, DiagonalMaximum())
+    CM = cholesky(Matrix(D), DiagonalMaximum())
     @test CD isa CholeskyPivoted{ComplexF64,<:Diagonal}
     @test CD.U ≈ Diagonal(.√sort(d, by=real, rev=true)) ≈ CM.U
     @test D ≈ Matrix(CD)
@@ -451,10 +451,10 @@ end
     # complex, failing
     D[2, 2] = 0.0 + 0im
     @test_throws PosDefException cholesky(D)
-    @test_throws RankDeficientException cholesky(D, DiagonalPivoting())
+    @test_throws RankDeficientException cholesky(D, DiagonalMaximum())
     Dnpd = cholesky(D; check = false)
     @test Dnpd.info == 2
-    Dnpd = cholesky(D, DiagonalPivoting(); check = false)
+    Dnpd = cholesky(D, DiagonalMaximum(); check = false)
     @test Dnpd.info == 1
     @test Dnpd.rank == 2
 
@@ -463,11 +463,11 @@ end
 
     # tolerance
     D = Diagonal([0.5, 1])
-    @test_throws RankDeficientException cholesky(D, DiagonalPivoting(), tol=nextfloat(0.5))
-    CD = cholesky(D, DiagonalPivoting(), tol=nextfloat(0.5), check=false)
+    @test_throws RankDeficientException cholesky(D, DiagonalMaximum(), tol=nextfloat(0.5))
+    CD = cholesky(D, DiagonalMaximum(), tol=nextfloat(0.5), check=false)
     @test rank(CD) == 1
     @test !issuccess(CD)
-    @test Matrix(cholesky(D, DiagonalPivoting(), tol=prevfloat(0.5))) ≈ D
+    @test Matrix(cholesky(D, DiagonalMaximum(), tol=prevfloat(0.5))) ≈ D
 end
 
 @testset "Cholesky for AbstractMatrix" begin
@@ -486,7 +486,7 @@ end
     @test Cholesky(factors, uplo, Int32(info)) == chol
     @test Cholesky(factors, uplo, Int64(info)) == chol
 
-    cholp = cholesky(x'x, DiagonalPivoting())
+    cholp = cholesky(x'x, DiagonalMaximum())
 
     factors, uplo, piv, rank, tol, info =
         cholp.factors, cholp.uplo, cholp.piv, cholp.rank, cholp.tol, cholp.info
@@ -502,25 +502,25 @@ end
 @testset "issue #33704, casting low-rank CholeskyPivoted to Matrix" begin
     A = randn(1,8)
     B = A'A
-    C = cholesky(B, DiagonalPivoting(), check=false)
+    C = cholesky(B, DiagonalMaximum(), check=false)
     @test B ≈ Matrix(C)
 end
 
 @testset "CholeskyPivoted and Factorization" begin
     A = randn(8,8)
     B = A'A
-    C = cholesky(B, DiagonalPivoting(), check=false)
+    C = cholesky(B, DiagonalMaximum(), check=false)
     @test CholeskyPivoted{eltype(C)}(C) === C
     @test Factorization{eltype(C)}(C) === C
-    @test Array(CholeskyPivoted{complex(eltype(C))}(C)) ≈ Array(cholesky(complex(B), DiagonalPivoting(), check=false))
-    @test Array(Factorization{complex(eltype(C))}(C)) ≈ Array(cholesky(complex(B), DiagonalPivoting(), check=false))
+    @test Array(CholeskyPivoted{complex(eltype(C))}(C)) ≈ Array(cholesky(complex(B), DiagonalMaximum(), check=false))
+    @test Array(Factorization{complex(eltype(C))}(C)) ≈ Array(cholesky(complex(B), DiagonalMaximum(), check=false))
     @test eltype(Factorization{complex(eltype(C))}(C)) == complex(eltype(C))
 end
 
 @testset "REPL printing of CholeskyPivoted" begin
     A = randn(8,8)
     B = A'A
-    C = cholesky(B, DiagonalPivoting(), check=false)
+    C = cholesky(B, DiagonalMaximum(), check=false)
     cholstring = sprint((t, s) -> show(t, "text/plain", s), C)
     rankstring = "$(C.uplo) factor with rank $(rank(C)):"
     factorstring = sprint((t, s) -> show(t, "text/plain", s), C.uplo == 'U' ? C.U : C.L)
@@ -529,7 +529,7 @@ end
 end
 
 @testset "destructuring for Cholesky[Pivoted]" begin
-    for val in (NoPivot(), DiagonalPivoting())
+    for val in (NoPivot(), DiagonalMaximum())
         A = rand(8, 8)
         B = A'A
         C = cholesky(B, val, check=false)
@@ -584,8 +584,8 @@ end
     @test B.L ≈ B32.L
     @test B.UL ≈ B32.UL
     @test Matrix(B) ≈ A
-    B = cholesky(A, DiagonalPivoting())
-    B32 = cholesky(Float32.(A), DiagonalPivoting())
+    B = cholesky(A, DiagonalMaximum())
+    B32 = cholesky(Float32.(A), DiagonalMaximum())
     @test B isa CholeskyPivoted{Float16,Matrix{Float16}}
     @test B.U isa UpperTriangular{Float16, Matrix{Float16}}
     @test B.L isa LowerTriangular{Float16, Matrix{Float16}}
@@ -601,7 +601,7 @@ end
          2048 1920 2940 1008 2240 2740;
          4470 4200 6410 2240 4875 6015;
          5490 5140 7903 2740 6015 7370]
-    B = cholesky(A, DiagonalPivoting(), check=false)
+    B = cholesky(A, DiagonalMaximum(), check=false)
     @test det(B)  ==  0.0
     @test det(B)  ≈  det(A) atol=eps()
     @test logdet(B)  ==  -Inf

--- a/stdlib/LinearAlgebra/test/factorization.jl
+++ b/stdlib/LinearAlgebra/test/factorization.jl
@@ -6,7 +6,7 @@ using Test, LinearAlgebra
 @testset "equality for factorizations - $f" for f in Any[
     bunchkaufman,
     cholesky,
-    x -> cholesky(x, DiagonalPivoting()),
+    x -> cholesky(x, DiagonalMaximum()),
     eigen,
     hessenberg,
     lq,
@@ -45,7 +45,7 @@ end
 @testset "size for factorizations - $f" for f in Any[
     bunchkaufman,
     cholesky,
-    x -> cholesky(x, DiagonalPivoting()),
+    x -> cholesky(x, DiagonalMaximum()),
     hessenberg,
     lq,
     lu,
@@ -63,7 +63,7 @@ end
 @testset "size for transpose factorizations - $f" for f in Any[
     bunchkaufman,
     cholesky,
-    x -> cholesky(x, DiagonalPivoting()),
+    x -> cholesky(x, DiagonalMaximum()),
     hessenberg,
     lq,
     lu,

--- a/stdlib/LinearAlgebra/test/factorization.jl
+++ b/stdlib/LinearAlgebra/test/factorization.jl
@@ -6,7 +6,7 @@ using Test, LinearAlgebra
 @testset "equality for factorizations - $f" for f in Any[
     bunchkaufman,
     cholesky,
-    x -> cholesky(x, RowMaximum()),
+    x -> cholesky(x, DiagonalPivoting()),
     eigen,
     hessenberg,
     lq,
@@ -45,7 +45,7 @@ end
 @testset "size for factorizations - $f" for f in Any[
     bunchkaufman,
     cholesky,
-    x -> cholesky(x, RowMaximum()),
+    x -> cholesky(x, DiagonalPivoting()),
     hessenberg,
     lq,
     lu,
@@ -63,7 +63,7 @@ end
 @testset "size for transpose factorizations - $f" for f in Any[
     bunchkaufman,
     cholesky,
-    x -> cholesky(x, RowMaximum()),
+    x -> cholesky(x, DiagonalPivoting()),
     hessenberg,
     lq,
     lu,


### PR DESCRIPTION
`RowMaximum` is just nonsense in the Cholesky case, so I propose to change it. The question is whether we want to deprecate, or simply redirect without additional hassle.