### PR TITLE
NFC: Add `fprint` variants of internal print functions

### DIFF
--- a/doc/src/devdocs/debuggingtips.md
+++ b/doc/src/devdocs/debuggingtips.md
@@ -128,7 +128,7 @@ The corresponding LLDB command is (after the process is started):
 (lldb) pro hand -p true -s false -n false SIGSEGV
 ```
 
-If you are debugging a segfault with threaded code, you can set a breakpoint on `jl_critical_error`
+If you are debugging a segfault with threaded code, you can set a breakpoint on `jl_fprint_critical_error`
 (`sigdie_handler` should also work on Linux and BSD) in order to only catch the actual segfault
 rather than the GC synchronization points.
 

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2456,7 +2456,7 @@ JL_CALLABLE(jl_f_intrinsic_call)
         default:
             assert(0 && "unexpected number of arguments to an intrinsic function");
     }
-    jl_gc_debug_critical_error();
+    jl_gc_debug_fprint_critical_error(ios_safe_stderr);
     abort();
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -9869,7 +9869,7 @@ jl_llvm_functions_t jl_emit_code(
         jl_printf((JL_STREAM*)STDERR_FILENO, "Internal error: encountered unexpected error during compilation of %s:\n", mname.c_str());
         jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception(jl_current_task));
         jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
-        jlbacktrace(); // written to STDERR_FILENO
+        jl_fprint_backtrace(ios_safe_stderr);
     }
 
     return decls;

--- a/src/gf.c
+++ b/src/gf.c
@@ -109,7 +109,7 @@ void jl_call_tracer(tracer_cb callback, jl_value_t *tracee)
         jl_printf((JL_STREAM*)STDERR_FILENO, "WARNING: tracer callback function threw an error:\n");
         jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception(ct));
         jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
-        jlbacktrace(); // written to STDERR_FILENO
+        jl_fprint_backtrace(ios_safe_stderr);
     }
 }
 
@@ -475,7 +475,7 @@ jl_code_instance_t *jl_type_infer(jl_method_instance_t *mi, size_t world, uint8_
             jl_printf((JL_STREAM*)STDERR_FILENO, "unexpected error in runtime:\n");
             jl_static_show((JL_STREAM*)STDERR_FILENO, e);
             jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
-            jlbacktrace(); // written to STDERR_FILENO
+            jl_fprint_backtrace(ios_safe_stderr);
         }
         ci = NULL;
 #ifndef JL_NDEBUG

--- a/src/gf.c
+++ b/src/gf.c
@@ -3152,7 +3152,7 @@ static void JL_NORETURN jl_method_error_bare(jl_value_t *f, jl_value_t *args, si
         jl_static_show((JL_STREAM*)STDERR_FILENO,args); jl_printf((JL_STREAM*)STDERR_FILENO,"\n");
         jl_ptls_t ptls = jl_current_task->ptls;
         ptls->bt_size = rec_backtrace(ptls->bt_data, JL_MAX_BT_SIZE, 0);
-        jl_critical_error(0, 0, NULL, jl_current_task);
+        jl_fprint_critical_error(ios_safe_stderr, 0, 0, NULL, jl_current_task);
         abort();
     }
     // not reached

--- a/src/init.c
+++ b/src/init.c
@@ -266,7 +266,7 @@ JL_DLLEXPORT void jl_atexit_hook(int exitcode) JL_NOTSAFEPOINT_ENTER
                 jl_printf((JL_STREAM*)STDERR_FILENO, "\natexit hook threw an error: ");
                 jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception(ct));
                 jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
-                jlbacktrace(); // written to STDERR_FILENO
+                jl_fprint_backtrace(ios_safe_stderr);
             }
             JL_GC_POP();
         }
@@ -315,7 +315,7 @@ JL_DLLEXPORT void jl_atexit_hook(int exitcode) JL_NOTSAFEPOINT_ENTER
                     jl_printf((JL_STREAM*)STDERR_FILENO, "error during exit cleanup: close: ");
                     jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception(ct));
                     jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
-                    jlbacktrace(); // written to STDERR_FILENO
+                    jl_fprint_backtrace(ios_safe_stderr);
                     item = next_shutdown_queue_item(item);
                 }
             }
@@ -371,7 +371,7 @@ JL_DLLEXPORT void jl_postoutput_hook(void)
                 jl_printf((JL_STREAM*)STDERR_FILENO, "\npostoutput hook threw an error: ");
                 jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception(ct));
                 jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
-                jlbacktrace(); // written to STDERR_FILENO
+                jl_fprint_backtrace(ios_safe_stderr);
             }
         }
         ct->world_age = last_age;

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -421,6 +421,7 @@
     XX(jl_specializations_get_linfo) \
     XX(jl_specializations_lookup) \
     XX(jl_static_show) \
+    XX(jl_safe_static_show) \
     XX(jl_static_show_func_sig) \
     XX(jl_stderr_obj) \
     XX(jl_stderr_stream) \

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -926,7 +926,7 @@ static int exec_program(char *program)
         jl_load(jl_main_module, program);
     }
     JL_CATCH {
-        // TODO: It is possible for this output to be mangled due to `jl_print_backtrace`
+        // TODO: It is possible for this output to be mangled due to `jl_fprint_backtrace`
         //       printing directly to STDERR_FILENO.
         int shown_err = 0;
         jl_printf(JL_STDERR, "error during bootstrap:\n");
@@ -945,7 +945,7 @@ static int exec_program(char *program)
             jl_static_show((JL_STREAM*)STDERR_FILENO, exc);
             jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
         }
-        jl_print_backtrace(); // written to STDERR_FILENO
+        jl_fprint_backtrace(ios_safe_stderr);
         jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
         return 1;
     }
@@ -1022,7 +1022,7 @@ static NOINLINE int true_main(int argc, char *argv[])
             jl_printf((JL_STREAM*)STDERR_FILENO, "\nparser error:\n");
             jl_static_show((JL_STREAM*)STDERR_FILENO, jl_current_exception(ct));
             jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
-            jl_print_backtrace(); // written to STDERR_FILENO
+            jl_fprint_backtrace(ios_safe_stderr);
         }
     }
     return 0;

--- a/src/julia.h
+++ b/src/julia.h
@@ -2470,6 +2470,8 @@ JL_DLLEXPORT int jl_vprintf(struct uv_stream_s *s, const char *format, va_list a
     _JL_FORMAT_ATTR(2, 0);
 JL_DLLEXPORT void jl_safe_printf(const char *str, ...) JL_NOTSAFEPOINT
     _JL_FORMAT_ATTR(1, 2);
+JL_DLLEXPORT void jl_safe_fprintf(ios_t *s, const char *str, ...) JL_NOTSAFEPOINT
+    _JL_FORMAT_ATTR(2, 3);
 
 extern JL_DLLEXPORT JL_STREAM *JL_STDIN;
 extern JL_DLLEXPORT JL_STREAM *JL_STDOUT;

--- a/src/julia.h
+++ b/src/julia.h
@@ -2488,6 +2488,7 @@ JL_DLLEXPORT jl_value_t *jl_stderr_obj(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_print_backtrace(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_fprint_backtrace(ios_t *s) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jlbacktrace(void) JL_NOTSAFEPOINT; // deprecated
 // Mainly for debugging, use `void*` so that no type cast is needed in C++.
 JL_DLLEXPORT void jl_(void *jl_value) JL_NOTSAFEPOINT;

--- a/src/julia.h
+++ b/src/julia.h
@@ -2486,6 +2486,7 @@ JL_DLLEXPORT int jl_termios_size(void);
 JL_DLLEXPORT void jl_flush_cstdio(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_stderr_obj(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v) JL_NOTSAFEPOINT;
+JL_DLLEXPORT size_t jl_safe_static_show(JL_STREAM *out, jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_print_backtrace(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_fprint_backtrace(ios_t *s) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -664,8 +664,8 @@ void jl_gc_run_all_finalizers(jl_task_t *ct);
 void jl_release_task_stack(jl_ptls_t ptls, jl_task_t *task);
 void jl_gc_add_finalizer_(jl_ptls_t ptls, void *v, void *f) JL_NOTSAFEPOINT;
 
-void jl_gc_debug_print_status(void) JL_NOTSAFEPOINT;
-JL_DLLEXPORT void jl_gc_debug_critical_error(void) JL_NOTSAFEPOINT;
+void jl_gc_debug_fprint_status(ios_t *s) JL_NOTSAFEPOINT;
+JL_DLLEXPORT void jl_gc_debug_fprint_critical_error(ios_t *s) JL_NOTSAFEPOINT;
 void jl_print_gc_stats(JL_STREAM *s);
 void jl_gc_reset_alloc_count(void);
 uint32_t jl_get_gs_ctr(void);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1524,7 +1524,7 @@ size_t rec_backtrace_ctx_dwarf(jl_bt_element_t *bt_data, size_t maxsize, bt_cont
 #endif
 JL_DLLEXPORT jl_value_t *jl_get_backtrace(void);
 JL_DLLEXPORT jl_value_t *jl_backtrace_from_here(int returnsp, int skip);
-void jl_critical_error(int sig, int si_code, bt_context_t *context, jl_task_t *ct);
+void jl_fprint_critical_error(ios_t *t, int sig, int si_code, bt_context_t *context, jl_task_t *ct);
 JL_DLLEXPORT void jl_raise_debugger(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_gdblookup(void* ip) JL_NOTSAFEPOINT;
 void jl_fprint_native_codeloc(ios_t *s, uintptr_t ip) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1527,8 +1527,8 @@ JL_DLLEXPORT jl_value_t *jl_backtrace_from_here(int returnsp, int skip);
 void jl_critical_error(int sig, int si_code, bt_context_t *context, jl_task_t *ct);
 JL_DLLEXPORT void jl_raise_debugger(void) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_gdblookup(void* ip) JL_NOTSAFEPOINT;
-void jl_print_native_codeloc(uintptr_t ip) JL_NOTSAFEPOINT;
-void jl_print_bt_entry_codeloc(jl_bt_element_t *bt_data) JL_NOTSAFEPOINT;
+void jl_fprint_native_codeloc(ios_t *s, uintptr_t ip) JL_NOTSAFEPOINT;
+void jl_fprint_bt_entry_codeloc(ios_t *s, jl_bt_element_t *bt_data) JL_NOTSAFEPOINT;
 #ifdef _OS_WINDOWS_
 JL_DLLEXPORT void jl_refresh_dbg_module_list(void);
 #endif

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -243,7 +243,7 @@ JL_DLLEXPORT void __stack_chk_fail(void)
 {
     /* put your panic function or similar in here */
     fprintf(stderr, "fatal error: stack corruption detected\n");
-    jl_gc_debug_critical_error();
+    jl_gc_debug_fprint_critical_error(ios_safe_stderr);
     abort(); // end with abort, since the compiler destroyed the stack upon entry to this function, there's no going back now
 }
 #endif

--- a/src/safepoint.c
+++ b/src/safepoint.c
@@ -106,7 +106,7 @@ void jl_safepoint_init(void)
 #endif
     if (addr == NULL) {
         jl_printf(JL_STDERR, "could not allocate GC synchronization page\n");
-        jl_gc_debug_critical_error();
+        jl_gc_debug_fprint_critical_error(ios_safe_stderr);
         abort();
     }
 //    // If we able to skip past the faulting safepoint instruction conditionally,

--- a/src/safepoint.c
+++ b/src/safepoint.c
@@ -172,7 +172,7 @@ void jl_gc_wait_for_the_world(jl_ptls_t* gc_all_tls_states, int gc_n_threads)
                         size_t bt_size = jl_try_record_thread_backtrace(ptls2, ptls->bt_data, JL_MAX_BT_SIZE);
                         // Print the backtrace of the straggler
                         for (size_t i = 0; i < bt_size; i += jl_bt_entry_size(ptls->bt_data + i)) {
-                            jl_print_bt_entry_codeloc(ptls->bt_data + i);
+                            jl_fprint_bt_entry_codeloc(ios_safe_stderr, ptls->bt_data + i);
                         }
                     }
                 }

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -612,7 +612,7 @@ void jl_critical_error(int sig, int si_code, bt_context_t *context, jl_task_t *c
     size_t *bt_size = ct ? &ct->ptls->bt_size : NULL;
     size_t i, n = ct ? *bt_size : 0;
     if (sig) {
-        // kill this task, so that we cannot get back to it accidentally (via an untimely ^C or jlbacktrace in jl_exit)
+        // kill this task, so that we cannot get back to it accidentally (via an untimely ^C or jl_fprint_backtrace in jl_exit)
         // and also resets the state of ct and ptls so that some code can run on this task again
         jl_task_frame_noreturn(ct);
 #ifndef _OS_WINDOWS_
@@ -647,7 +647,7 @@ void jl_critical_error(int sig, int si_code, bt_context_t *context, jl_task_t *c
         *bt_size = n = rec_backtrace_ctx(bt_data, JL_MAX_BT_SIZE, context, NULL);
     }
     for (i = 0; i < n; i += jl_bt_entry_size(bt_data + i)) {
-        jl_print_bt_entry_codeloc(bt_data + i);
+        jl_fprint_bt_entry_codeloc(ios_safe_stderr, bt_data + i);
     }
     jl_gc_debug_print_status();
     jl_gc_debug_critical_error();

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -649,8 +649,8 @@ void jl_critical_error(int sig, int si_code, bt_context_t *context, jl_task_t *c
     for (i = 0; i < n; i += jl_bt_entry_size(bt_data + i)) {
         jl_fprint_bt_entry_codeloc(ios_safe_stderr, bt_data + i);
     }
-    jl_gc_debug_print_status();
-    jl_gc_debug_critical_error();
+    jl_gc_debug_fprint_status(ios_safe_stderr);
+    jl_gc_debug_fprint_critical_error(ios_safe_stderr);
 }
 
 #ifdef __cplusplus

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -579,7 +579,7 @@ static void jl_try_deliver_sigint(void)
 
 static void JL_NORETURN jl_exit_thread0_cb(int signo)
 {
-    jl_critical_error(signo, 0, NULL, jl_current_task);
+    jl_fprint_critical_error(ios_safe_stderr, signo, 0, NULL, jl_current_task);
     jl_atexit_hook(128);
     jl_raise(signo);
 }

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -236,7 +236,7 @@ static void sigdie_handler(int sig, siginfo_t *info, void *context)
     signal(sig, SIG_DFL);
     uv_tty_reset_mode();
     if (sig == SIGILL)
-        jl_show_sigill(context);
+        jl_fprint_sigill(ios_safe_stderr, context);
     jl_task_t *ct = jl_get_current_task();
     jl_critical_error(sig, info->si_code, jl_to_bt_context(context), ct);
     if (ct)

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -1112,7 +1112,7 @@ static void *signal_listener(void *arg)
             jl_safe_printf("\nsignal (%d): %s\n", sig, strsignal(sig));
             size_t i;
             for (i = 0; i < signal_bt_size; i += jl_bt_entry_size(signal_bt_data + i)) {
-                jl_print_bt_entry_codeloc(signal_bt_data + i);
+                jl_fprint_bt_entry_codeloc(ios_safe_stderr, signal_bt_data + i);
             }
             jl_safe_printf("\n");
             // Enable trace compilation to stderr with timing during profile collection

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -238,7 +238,7 @@ static void sigdie_handler(int sig, siginfo_t *info, void *context)
     if (sig == SIGILL)
         jl_fprint_sigill(ios_safe_stderr, context);
     jl_task_t *ct = jl_get_current_task();
-    jl_critical_error(sig, info->si_code, jl_to_bt_context(context), ct);
+    jl_fprint_critical_error(ios_safe_stderr, sig, info->si_code, jl_to_bt_context(context), ct);
     if (ct)
         jl_atomic_store_relaxed(&ct->ptls->safepoint, (size_t*)NULL + 1);
     if (info->si_code == 0 ||
@@ -560,7 +560,7 @@ static void JL_NORETURN jl_exit_thread0_cb(void)
 {
 CFI_NORETURN
     jl_atomic_fetch_add(&jl_gc_disable_counter, -1);
-    jl_critical_error(thread0_exit_signo, 0, NULL, jl_current_task);
+    jl_fprint_critical_error(ios_safe_stderr, thread0_exit_signo, 0, NULL, jl_current_task);
     jl_atexit_hook(128);
     jl_raise(thread0_exit_signo);
 }

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -333,7 +333,7 @@ LONG WINAPI jl_exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo)
         jl_safe_printf("UNKNOWN"); break;
     }
     jl_safe_printf(" at 0x%zx -- ", (size_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
-    jl_print_native_codeloc((uintptr_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
+    jl_fprint_native_codeloc(ios_safe_stderr, (uintptr_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
 
     jl_critical_error(0, 0, ExceptionInfo->ContextRecord, ct);
     static int recursion = 0;

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -98,7 +98,7 @@ void __cdecl crt_sig_handler(int sig, int num)
         RtlCaptureContext(&Context);
         if (sig == SIGILL)
             jl_fprint_sigill(ios_safe_stderr, &Context);
-        jl_critical_error(sig, 0, &Context, jl_get_current_task());
+        jl_fprint_critical_error(ios_safe_stderr, sig, 0, &Context, jl_get_current_task());
         raise(sig);
     }
 }
@@ -335,7 +335,7 @@ LONG WINAPI jl_exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo)
     jl_safe_printf(" at 0x%zx -- ", (size_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
     jl_fprint_native_codeloc(ios_safe_stderr, (uintptr_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
 
-    jl_critical_error(0, 0, ExceptionInfo->ContextRecord, ct);
+    jl_fprint_critical_error(ios_safe_stderr, 0, 0, ExceptionInfo->ContextRecord, ct);
     static int recursion = 0;
     if (recursion++)
         exit(1);

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -97,7 +97,7 @@ void __cdecl crt_sig_handler(int sig, int num)
         memset(&Context, 0, sizeof(Context));
         RtlCaptureContext(&Context);
         if (sig == SIGILL)
-            jl_show_sigill(&Context);
+            jl_fprint_sigill(ios_safe_stderr, &Context);
         jl_critical_error(sig, 0, &Context, jl_get_current_task());
         raise(sig);
     }
@@ -285,7 +285,7 @@ LONG WINAPI jl_exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo)
     }
     if (ExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_ILLEGAL_INSTRUCTION) {
         jl_safe_printf("\n");
-        jl_show_sigill(ExceptionInfo->ContextRecord);
+        jl_fprint_sigill(ios_safe_stderr, ExceptionInfo->ContextRecord);
     }
     jl_safe_printf("\nPlease submit a bug report with steps to reproduce this fault, and any error messages that follow (in their entirety). Thanks.\nException: ");
     switch (ExceptionInfo->ExceptionRecord->ExceptionCode) {

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -1061,6 +1061,7 @@ ios_t *ios_fd(ios_t *s, long fd, int isfile, int own)
 ios_t *ios_stdin = NULL;
 ios_t *ios_stdout = NULL;
 ios_t *ios_stderr = NULL;
+ios_t *ios_safe_stderr = NULL;
 
 void ios_init_stdstreams(void)
 {
@@ -1074,6 +1075,12 @@ void ios_init_stdstreams(void)
     ios_stderr = (ios_t*)malloc_s(sizeof(ios_t));
     ios_fd(ios_stderr, STDERR_FILENO, 0, 0);
     ios_stderr->bm = bm_none;
+
+    // this 'safe' variant must use `bm_none` to avoid memory allocation
+    // in an async-signal context
+    ios_safe_stderr = (ios_t*)malloc_s(sizeof(ios_t));
+    ios_fd(ios_safe_stderr, STDERR_FILENO, 0, 0);
+    ios_safe_stderr->bm = bm_none;
 }
 
 /* higher level interface */

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -125,6 +125,7 @@ JL_DLLEXPORT ios_t *ios_fd(ios_t *s, long fd, int isfile, int own);
 extern JL_DLLEXPORT ios_t *ios_stdin;
 extern JL_DLLEXPORT ios_t *ios_stdout;
 extern JL_DLLEXPORT ios_t *ios_stderr;
+extern JL_DLLEXPORT ios_t *ios_safe_stderr; // safe for async-signal context
 void ios_init_stdstreams(void);
 
 /* high-level functions - output */

--- a/src/task.c
+++ b/src/task.c
@@ -352,7 +352,7 @@ void JL_NORETURN jl_finish_task(jl_task_t *ct)
             jl_no_exc_handler(jl_current_exception(ct), ct);
         }
     }
-    jl_gc_debug_critical_error();
+    jl_gc_debug_fprint_critical_error(ios_safe_stderr);
     abort();
 }
 
@@ -1263,7 +1263,7 @@ skip_pop_exception:;
     ct->result = res;
     jl_gc_wb(ct, ct->result);
     jl_finish_task(ct);
-    jl_gc_debug_critical_error();
+    jl_gc_debug_fprint_critical_error(ios_safe_stderr);
     abort();
 }
 

--- a/src/task.c
+++ b/src/task.c
@@ -735,7 +735,8 @@ JL_DLLEXPORT JL_NORETURN void jl_no_exc_handler(jl_value_t *e, jl_task_t *ct)
     jl_printf((JL_STREAM*)STDERR_FILENO, "fatal: error thrown and no exception handler available.\n");
     jl_static_show((JL_STREAM*)STDERR_FILENO, e);
     jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
-    jlbacktrace(); // written to STDERR_FILENO
+    jl_fprint_backtrace(ios_safe_stderr);
+
     if (ct == NULL)
         jl_raise(6);
     jl_exit(1);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -26,9 +26,9 @@ extern "C" {
 #endif
 
 // current line number in a file
-JL_DLLEXPORT _Atomic(int) jl_lineno = 0; // need to update jl_critical_error if this is TLS
+JL_DLLEXPORT _Atomic(int) jl_lineno = 0; // need to update jl_fprint_critical_error if this is TLS
 // current file name
-JL_DLLEXPORT _Atomic(const char *) jl_filename = "none"; // need to update jl_critical_error if this is TLS
+JL_DLLEXPORT _Atomic(const char *) jl_filename = "none"; // need to update jl_fprint_critical_error if this is TLS
 
 htable_t jl_current_modules;
 jl_mutex_t jl_modules_mutex;
@@ -617,7 +617,7 @@ JL_DLLEXPORT jl_value_t *jl_toplevel_eval_flex(jl_module_t *JL_NONNULL m, jl_val
                 assert(jl_is_symbol(file));
                 *toplevel_filename = jl_symbol_name((jl_sym_t*)file);
             }
-            // Not thread safe. For debugging and last resort error messages (jl_critical_error) only.
+            // Not thread safe. For debugging and last resort error messages (jl_fprint_critical_error) only.
             jl_atomic_store_relaxed(&jl_filename, *toplevel_filename);
             jl_atomic_store_relaxed(&jl_lineno, *toplevel_lineno);
             return jl_nothing;


### PR DESCRIPTION
This adds/changes a number of `fprint_*` variants to internal debug functions:
  - rename + new `ios_t *` argument:
    - `jl_critical_error` -> `jl_fprint_critical_error`
    - `jl_print_native_codeloc` -> `jl_fprint_native_codeloc`
    - `jl_print_bt_entry_codeloc` -> `jl_fprint_bt_entry_codeloc`
    - `jl_gc_debug_print_status` -> `jl_gc_debug_fprint_status`
    - `jl_gc_debug_critical_error` -> `jl_gc_debug_fprint_critical_error`
 - new `fprint_*` variants:
    - `jl_safe_fprintf`
    - `jl_safe_static_show`
    - `jl_fprint_backtrace(t)`

Note that care needs to be taken w.r.t. what `ios_t *` value is passed into these functions from within a signal handler on Unix. Memory allocation is not async-signal-safe, so the ios_t needs to wrap a raw `fd_t` handle.

Immediate motivation is https://github.com/JuliaLang/julia/pull/54836