### PR TITLE
Add error dialog for critical errors on Windows

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -69,6 +69,7 @@ struct JLOptions
     timeout_for_safepoint_straggler_s::Int16
     gc_sweep_always_full::Int8
     compress_sysimage::Int8
+    alert_on_critical_error::Int8
 end
 
 # This runs early in the sysimage != is not defined yet

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -162,6 +162,7 @@ JL_DLLEXPORT void jl_init_options(void)
                         -1, // timeout_for_safepoint_straggler_s
                         0, // gc_sweep_always_full
                         0, // compress_sysimage
+                        0, // alert_on_critical_error
     };
     jl_options_initialized = 1;
 }

--- a/src/jloptions.h
+++ b/src/jloptions.h
@@ -73,6 +73,7 @@ typedef struct {
     int16_t timeout_for_safepoint_straggler_s;
     int8_t gc_sweep_always_full;
     int8_t compress_sysimage;
+    int8_t alert_on_critical_error;
 } jl_options_t;
 
 #endif

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -117,9 +117,11 @@ void __cdecl crt_sig_handler(int sig, int num)
             );
             free(strings[0]);
 
-            MessageBoxW(NULL, /* message */ L"error: libjulia received a fatal signal.\n\n"
-                                            L"See Application log in Event Viewer for more information.",
-                        /* title */ L"fatal error in libjulia", MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);
+            if (jl_options.alert_on_critical_error) {
+                MessageBoxW(NULL, /* message */ L"error: libjulia received a fatal signal.\n\n"
+                                                L"See Application log in Event Viewer for more information.",
+                            /* title */ L"fatal error in libjulia", MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);
+            }
         }
         raise(sig);
     }
@@ -379,11 +381,13 @@ LONG WINAPI jl_exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo)
         );
         free(strings[0]);
 
-        ios_putc('\0', &summary);
-        const wchar_t *message = ios_utf8_to_wchar(summary.buf);
-        MessageBoxW(NULL, message, /* title */ L"fatal error in libjulia",
-                    MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);
-        free(message);
+        if (jl_options.alert_on_critical_error) {
+            ios_putc('\0', &summary);
+            const wchar_t *message = ios_utf8_to_wchar(summary.buf);
+            MessageBoxW(NULL, message, /* title */ L"fatal error in libjulia",
+                        MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);
+            free(message);
+        }
     }
 
     ios_close(&summary);

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -96,9 +96,31 @@ void __cdecl crt_sig_handler(int sig, int num)
         }
         memset(&Context, 0, sizeof(Context));
         RtlCaptureContext(&Context);
+
+        ios_t s;
+        ios_mem(&s, 0);
         if (sig == SIGILL)
-            jl_fprint_sigill(ios_safe_stderr, &Context);
-        jl_fprint_critical_error(ios_safe_stderr, sig, 0, &Context, jl_get_current_task());
+            jl_fprint_sigill(&s, &Context);
+        jl_fprint_critical_error(&s, sig, 0, &Context, jl_get_current_task());
+
+        // First write to stderr
+        ios_write_direct(ios_safe_stderr, &s);
+
+        // Then write to Application log
+        HANDLE event_source = RegisterEventSourceW(NULL, L"julia");
+        if (event_source != INVALID_HANDLE_VALUE) {
+            ios_putc('\0', &s);
+            const wchar_t *strings[] = { ios_utf8_to_wchar(s.buf) };
+            ReportEventW(
+                event_source, EVENTLOG_ERROR_TYPE, /* category */ 0, /* event_id */ (DWORD)0xE0000000L,
+               /* user_sid */ NULL, /* n_strings */ 1, /* data_size */ 0, strings, /* data */ NULL
+            );
+            free(strings[0]);
+
+            MessageBoxW(NULL, /* message */ L"error: libjulia received a fatal signal.\n\n"
+                                            L"See Application log in Event Viewer for more information.",
+                        /* title */ L"fatal error in libjulia", MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);
+        }
         raise(sig);
     }
 }
@@ -283,59 +305,89 @@ LONG WINAPI jl_exception_handler(struct _EXCEPTION_POINTERS *ExceptionInfo)
             break;
         }
     }
+    ios_t full_error, summary;
+    ios_mem(&full_error, 0);
     if (ExceptionInfo->ExceptionRecord->ExceptionCode == EXCEPTION_ILLEGAL_INSTRUCTION) {
-        jl_safe_printf("\n");
-        jl_fprint_sigill(ios_safe_stderr, ExceptionInfo->ContextRecord);
+        jl_safe_fprintf(&full_error, "\n");
+        jl_fprint_sigill(&full_error, ExceptionInfo->ContextRecord);
     }
-    jl_safe_printf("\nPlease submit a bug report with steps to reproduce this fault, and any error messages that follow (in their entirety). Thanks.\nException: ");
+    jl_safe_fprintf(&full_error, "\nPlease submit a bug report with steps to reproduce this fault, and any error messages that follow (in their entirety). Thanks.\n");
+    ios_mem(&summary, 128);
+    jl_safe_fprintf(&summary, "Exception: ");
     switch (ExceptionInfo->ExceptionRecord->ExceptionCode) {
     case EXCEPTION_ACCESS_VIOLATION:
-        jl_safe_printf("EXCEPTION_ACCESS_VIOLATION"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_ACCESS_VIOLATION"); break;
     case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
-        jl_safe_printf("EXCEPTION_ARRAY_BOUNDS_EXCEEDED"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_ARRAY_BOUNDS_EXCEEDED"); break;
     case EXCEPTION_BREAKPOINT:
-        jl_safe_printf("EXCEPTION_BREAKPOINT"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_BREAKPOINT"); break;
     case EXCEPTION_DATATYPE_MISALIGNMENT:
-        jl_safe_printf("EXCEPTION_DATATYPE_MISALIGNMENT"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_DATATYPE_MISALIGNMENT"); break;
     case EXCEPTION_FLT_DENORMAL_OPERAND:
-        jl_safe_printf("EXCEPTION_FLT_DENORMAL_OPERAND"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_FLT_DENORMAL_OPERAND"); break;
     case EXCEPTION_FLT_DIVIDE_BY_ZERO:
-        jl_safe_printf("EXCEPTION_FLT_DIVIDE_BY_ZERO"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_FLT_DIVIDE_BY_ZERO"); break;
     case EXCEPTION_FLT_INEXACT_RESULT:
-        jl_safe_printf("EXCEPTION_FLT_INEXACT_RESULT"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_FLT_INEXACT_RESULT"); break;
     case EXCEPTION_FLT_INVALID_OPERATION:
-        jl_safe_printf("EXCEPTION_FLT_INVALID_OPERATION"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_FLT_INVALID_OPERATION"); break;
     case EXCEPTION_FLT_OVERFLOW:
-        jl_safe_printf("EXCEPTION_FLT_OVERFLOW"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_FLT_OVERFLOW"); break;
     case EXCEPTION_FLT_STACK_CHECK:
-        jl_safe_printf("EXCEPTION_FLT_STACK_CHECK"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_FLT_STACK_CHECK"); break;
     case EXCEPTION_FLT_UNDERFLOW:
-        jl_safe_printf("EXCEPTION_FLT_UNDERFLOW"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_FLT_UNDERFLOW"); break;
     case EXCEPTION_ILLEGAL_INSTRUCTION:
-        jl_safe_printf("EXCEPTION_ILLEGAL_INSTRUCTION"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_ILLEGAL_INSTRUCTION"); break;
     case EXCEPTION_IN_PAGE_ERROR:
-        jl_safe_printf("EXCEPTION_IN_PAGE_ERROR"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_IN_PAGE_ERROR"); break;
     case EXCEPTION_INT_DIVIDE_BY_ZERO:
-        jl_safe_printf("EXCEPTION_INT_DIVIDE_BY_ZERO"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_INT_DIVIDE_BY_ZERO"); break;
     case EXCEPTION_INT_OVERFLOW:
-        jl_safe_printf("EXCEPTION_INT_OVERFLOW"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_INT_OVERFLOW"); break;
     case EXCEPTION_INVALID_DISPOSITION:
-        jl_safe_printf("EXCEPTION_INVALID_DISPOSITION"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_INVALID_DISPOSITION"); break;
     case EXCEPTION_NONCONTINUABLE_EXCEPTION:
-        jl_safe_printf("EXCEPTION_NONCONTINUABLE_EXCEPTION"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_NONCONTINUABLE_EXCEPTION"); break;
     case EXCEPTION_PRIV_INSTRUCTION:
-        jl_safe_printf("EXCEPTION_PRIV_INSTRUCTION"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_PRIV_INSTRUCTION"); break;
     case EXCEPTION_SINGLE_STEP:
-        jl_safe_printf("EXCEPTION_SINGLE_STEP"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_SINGLE_STEP"); break;
     case EXCEPTION_STACK_OVERFLOW:
-        jl_safe_printf("EXCEPTION_STACK_OVERFLOW"); break;
+        jl_safe_fprintf(&summary, "EXCEPTION_STACK_OVERFLOW"); break;
     default:
-        jl_safe_printf("UNKNOWN"); break;
+        jl_safe_fprintf(&summary, "UNKNOWN"); break;
     }
-    jl_safe_printf(" at 0x%zx -- ", (size_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
-    jl_fprint_native_codeloc(ios_safe_stderr, (uintptr_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
+    jl_safe_fprintf(&summary, " at 0x%zx -- ", (size_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
+    jl_fprint_native_codeloc(&summary, (uintptr_t)ExceptionInfo->ExceptionRecord->ExceptionAddress);
+    ios_write(&full_error, summary.buf, ios_pos(&summary));
+    ios_puts("\nSee Application log in Event Viewer for more information.\n", &summary);
 
-    jl_fprint_critical_error(ios_safe_stderr, 0, 0, ExceptionInfo->ContextRecord, ct);
+    jl_fprint_critical_error(&full_error, 0, 0, ExceptionInfo->ContextRecord, ct);
+
+    // First print to STDERR
+    ios_write_direct(ios_safe_stderr, &full_error);
+
+    // Secondly print to Application log
+    HANDLE event_source = RegisterEventSourceW(NULL, L"julia");
+    if (event_source != INVALID_HANDLE_VALUE) {
+        ios_putc('\0', &full_error);
+        const wchar_t *strings[] = { ios_utf8_to_wchar(full_error.buf) };
+        ReportEventW(
+            event_source, EVENTLOG_ERROR_TYPE, /* category */ 0, /* event_id */ (DWORD)0xE0000000L,
+           /* user_sid */ NULL, /* n_strings */ 1, /* data_size */ 0, strings, /* data */ NULL
+        );
+        free(strings[0]);
+
+        ios_putc('\0', &summary);
+        const wchar_t *message = ios_utf8_to_wchar(summary.buf);
+        MessageBoxW(NULL, message, /* title */ L"fatal error in libjulia",
+                    MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);
+        free(message);
+    }
+
+    ios_close(&summary);
+    ios_close(&full_error);
     static int recursion = 0;
     if (recursion++)
         exit(1);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -3458,8 +3458,6 @@ JL_DLLEXPORT void jl_create_system_image(void **_native_data, jl_array_t *workli
     return;
 }
 
-JL_DLLEXPORT size_t ios_write_direct(ios_t *dest, ios_t *src);
-
 // Takes in a path of the form "usr/lib/julia/sys.so"
 JL_DLLEXPORT jl_image_buf_t jl_preload_sysimg(const char *fname)
 {

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -10,6 +10,7 @@
 #include <stdio.h> // for printf
 
 #include "dtypes.h"
+#include "uv.h"
 
 #ifdef _OS_WINDOWS_
 #include <malloc.h>
@@ -987,6 +988,15 @@ ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int tru
     s->fd = -1;
     return NULL;
 }
+
+#ifdef _OS_WINDOWS_
+const wchar_t *ios_utf8_to_wchar(const char *str) {
+    ssize_t wlen = uv_wtf8_length_as_utf16(str);
+    wchar_t *wstr = (wchar_t *)malloc_s(sizeof(wchar_t) * wlen);
+    uv_wtf8_to_utf16(str, wstr, wlen);
+    return wstr;
+}
+#endif // _OS_WINDOWS_
 
 // Portable ios analogue of mkstemp: modifies fname to replace
 // trailing XXXX's with unique ID and returns the file handle s

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -152,6 +152,10 @@ int ios_ungetc(int c, ios_t *s);
 //wint_t ios_ungetwc(ios_t *s, wint_t wc);
 #define ios_puts(str, s) ios_write(s, str, strlen(str))
 
+#ifdef _OS_WINDOWS_
+const wchar_t *ios_utf8_to_wchar(const char *str);
+#endif
+
 /*
   With memory streams, mixed reads and writes are equivalent to performing
   sequences of *p++, as either an lvalue or rvalue. File streams behave

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -86,6 +86,7 @@ extern void (*ios_set_io_wait_func)(int);
 JL_DLLEXPORT size_t ios_read(ios_t *s, char *dest, size_t n) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t ios_readall(ios_t *s, char *dest, size_t n) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t ios_write(ios_t *s, const char *data, size_t n) JL_NOTSAFEPOINT;
+JL_DLLEXPORT size_t ios_write_direct(ios_t *dest, ios_t *src) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int64_t ios_seek(ios_t *s, int64_t pos) JL_NOTSAFEPOINT; // absolute seek
 JL_DLLEXPORT int64_t ios_seek_end(ios_t *s) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int64_t ios_skip(ios_t *s, int64_t offs);  // relative seek

--- a/src/task.c
+++ b/src/task.c
@@ -755,9 +755,11 @@ JL_DLLEXPORT JL_NORETURN void jl_no_exc_handler(jl_value_t *e, jl_task_t *ct)
         );
         free(strings[0]);
 
-        MessageBoxW(NULL, /* message */ L"fatal: error thrown and no exception handler available\n\n"
-                                        L"See Application log in Event Viewer for more information.",
-                    /* title */ L"fatal error in libjulia", MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);
+        if (jl_options.alert_on_critical_error) {
+            MessageBoxW(NULL, /* message */ L"fatal: error thrown and no exception handler available\n\n"
+                                            L"See Application log in Event Viewer for more information.",
+                        /* title */ L"fatal error in libjulia", MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);
+        }
     }
 #endif
 

--- a/src/task.c
+++ b/src/task.c
@@ -732,11 +732,36 @@ JL_DLLEXPORT JL_NORETURN void jl_no_exc_handler(jl_value_t *e, jl_task_t *ct)
     if (!e)
         e = jl_current_exception(ct);
 
-    jl_printf((JL_STREAM*)STDERR_FILENO, "fatal: error thrown and no exception handler available.\n");
-    jl_static_show((JL_STREAM*)STDERR_FILENO, e);
-    jl_printf((JL_STREAM*)STDERR_FILENO, "\n");
-    jl_fprint_backtrace(ios_safe_stderr);
+    // Write error to memory first
+    ios_t s;
+    ios_mem(&s, 1024);
+    jl_safe_fprintf(&s, "fatal: error thrown and no exception handler available.\n");
+    jl_static_show((JL_STREAM*)&s, e);
+    jl_safe_fprintf(&s, "\n");
+    jl_fprint_backtrace(&s);
+    ios_putc('\0', &s);
 
+    // Then to STDERR
+    fputs(s.buf, stderr);
+
+    // Finally write to system log (if supported)
+#ifdef _OS_WINDOWS_
+    HANDLE event_source = RegisterEventSourceW(NULL, L"julia");
+    if (event_source != INVALID_HANDLE_VALUE) {
+        const wchar_t *strings[] = { ios_utf8_to_wchar(s.buf) };
+        ReportEventW(
+            event_source, EVENTLOG_ERROR_TYPE, /* category */ 0, /* event_id */ (DWORD)0xE0000000L,
+           /* user_sid */ NULL, /* n_strings */ 1, /* data_size */ 0, strings, /* data */ NULL
+        );
+        free(strings[0]);
+
+        MessageBoxW(NULL, /* message */ L"fatal: error thrown and no exception handler available\n\n"
+                                        L"See Application log in Event Viewer for more information.",
+                    /* title */ L"fatal error in libjulia", MB_OK | MB_ICONEXCLAMATION | MB_SYSTEMMODAL);
+    }
+#endif
+
+    ios_close(&s);
     if (ct == NULL)
         jl_raise(6);
     jl_exit(1);

--- a/src/task.c
+++ b/src/task.c
@@ -739,15 +739,15 @@ JL_DLLEXPORT JL_NORETURN void jl_no_exc_handler(jl_value_t *e, jl_task_t *ct)
     jl_static_show((JL_STREAM*)&s, e);
     jl_safe_fprintf(&s, "\n");
     jl_fprint_backtrace(&s);
-    ios_putc('\0', &s);
 
     // Then to STDERR
-    fputs(s.buf, stderr);
+    ios_write_direct(ios_stderr, &s);
 
     // Finally write to system log (if supported)
 #ifdef _OS_WINDOWS_
     HANDLE event_source = RegisterEventSourceW(NULL, L"julia");
     if (event_source != INVALID_HANDLE_VALUE) {
+        ios_putc('\0', &s);
         const wchar_t *strings[] = { ios_utf8_to_wchar(s.buf) };
         ReportEventW(
             event_source, EVENTLOG_ERROR_TYPE, /* category */ 0, /* event_id */ (DWORD)0xE0000000L,


### PR DESCRIPTION
This change adds a small dialog for fatal errors on Windows:
<p align="center">
<img src="https://github.com/JuliaLang/julia/assets/84105208/9b414a16-6522-4cc1-ab3f-1cd6553f9df6" width="40%" />
</p>

with a corresponding entry in the `Application` log (in Event Viewer)
<img src="https://github.com/JuliaLang/julia/assets/84105208/19f373d4-c8ce-4596-bb36-a1229460ac71" width="70%" />


This is intended primarily for users of PackageCompiler.jl, who might be using Julia in a GUI application.

If a Julia-compiled library fails in a GUI application, users currently have no good way to know why/how their application crashed if, e.g., an exception was accidentally left unhandled in their Julia code.

Depends on https://github.com/JuliaLang/julia/pull/54835

**TODO:** Should this be a `jl_options` flag to determine whether to show the GUI? Should we log to the event log unconditionally? Is there any way that we can automatically detect whether `stderr` is connected to a terminal and user-visible?

