### PR TITLE
Add boundscheck in speccache_eq to avoid OOB access due to data race

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -113,7 +113,7 @@ static int8_t jl_cachearg_offset(jl_methtable_t *mt)
 
 static uint_t speccache_hash(size_t idx, jl_value_t *data)
 {
-    jl_method_instance_t *ml = (jl_method_instance_t*)jl_svecref(data, idx);
+    jl_method_instance_t *ml = (jl_method_instance_t*)jl_svecref(data, idx); // This must always happen inside the lock
     jl_value_t *sig = ml->specTypes;
     if (jl_is_unionall(sig))
         sig = jl_unwrap_unionall(sig);
@@ -122,6 +122,8 @@ static uint_t speccache_hash(size_t idx, jl_value_t *data)
 
 static int speccache_eq(size_t idx, const void *ty, jl_value_t *data, uint_t hv)
 {
+    if (idx >= jl_svec_len(data))
+        return 0; // We got a OOB access, probably due to a data race
     jl_method_instance_t *ml = (jl_method_instance_t*)jl_svecref(data, idx);
     jl_value_t *sig = ml->specTypes;
     if (ty == sig)


### PR DESCRIPTION
Like https://github.com/JuliaLang/julia/pull/54671, but for `speccache_eq`.

Saw another segfault with this in the stack trace, hence this fix. I also looked for other uses of `jl_smallintset_lookup` and there's one in `idset.c`. That doesn't appear to be racy but I'm not familiar with the code, so maybe you can take a look at it in case we need to push a fix for that one too @gbaraldi or @vtjnash?