### PR TITLE
REPL.prompt!: use lower level than `peek` to wait on input

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1605,7 +1605,7 @@ end
 
 skip(s::BufferStream, n) = skip(s.buffer, n)
 
-function reseteof(x::BufferStream)
+function reseteof(s::BufferStream)
     lock(s.cond) do
         s.status = StatusOpen
         nothing

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2840,7 +2840,7 @@ function prompt!(term::TextTerminal, prompt::ModalInterface, s::MIState = init_s
         # spawn this because the main repl task is sticky (due to use of @async and _wait2)
         # and we want to not block typing when the repl task thread is busy
         t2 = Threads.@spawn :interactive while true
-            eof(term) || Base.wait_readnb(Base.pipe_reader(term), 1) # wait before locking but don't consume
+            Base.wait_readnb(Base.pipe_reader(term), 1) # wait before locking but don't consume
             @lock l begin
                 kmap = keymap(s, prompt)
                 fcn = match_input(kmap, s)

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2840,7 +2840,7 @@ function prompt!(term::TextTerminal, prompt::ModalInterface, s::MIState = init_s
         # spawn this because the main repl task is sticky (due to use of @async and _wait2)
         # and we want to not block typing when the repl task thread is busy
         t2 = Threads.@spawn :interactive while true
-            eof(term) || peek(term, Char) # wait before locking but don't consume
+            eof(term) || Base.wait_readnb(Base.pipe_reader(term), 1) # wait before locking but don't consume
             @lock l begin
                 kmap = keymap(s, prompt)
                 fcn = match_input(kmap, s)


### PR DESCRIPTION
Response to https://github.com/JuliaLang/julia/pull/54785#issuecomment-2179600716

I've not been able to reproduce the `IOBuffer not marked` issue so I'm at the mercy of others testing this.

Requires
- [ ] https://github.com/JuliaLang/Pkg.jl/pull/3931
- [ ] https://github.com/JuliaLang/julia/pull/54859

