### PR TITLE
`mkpath` always returns the original path 

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -235,10 +235,10 @@ julia> mkpath("my/test/dir/") # returns the original `path`
 ```
 """
 function mkpath(path::AbstractString; mode::Integer = 0o777)
-    dir = dirname(path)
+    parent = dirname(path)
     # stop recursion for `""`, `"/"`, or existing dir
-    (path == dir || isdir(path)) && return path
-    mkpath(dir, mode = checkmode(mode))
+    (path == parent || isdir(path)) && return path
+    mkpath(parent, mode = checkmode(mode))
     try
         # The `isdir` check could be omitted, then `mkdir` will throw an error in cases like `x/`.
         # Although the error will not be rethrown, we avoid it in advance for performance reasons.

--- a/base/file.jl
+++ b/base/file.jl
@@ -230,6 +230,8 @@ julia> mkpath("intermediate_dir/actually_a_directory.txt") # creates two directo
 julia> isdir("intermediate_dir/actually_a_directory.txt")
 true
 
+julia> mkpath("my/test/dir/") # returns the original `path`
+"my/test/dir/"
 ```
 """
 function mkpath(path::AbstractString; mode::Integer = 0o777)

--- a/base/file.jl
+++ b/base/file.jl
@@ -236,12 +236,12 @@ julia> mkpath("my/test/dir/") # returns the original `path`
 """
 function mkpath(path::AbstractString; mode::Integer = 0o777)
     dir = dirname(path)
-    # stop recursion for `""`, `"/"`, or existed dir
+    # stop recursion for `""`, `"/"`, or existing dir
     (path == dir || isdir(path)) && return path
     mkpath(dir, mode = checkmode(mode))
     try
-        # cases like `mkpath("x/")` will cause an error if `isdir(path)` is skipped
-        # the error will not be rethrowed, but it may be slower, and thus we avoid it in advance
+        # The `isdir` check could be omitted, then `mkdir` will throw an error in cases like `x/`.
+        # Although the error will not be rethrown, we avoid it in advance for performance reasons.
         isdir(path) || mkdir(path, mode = mode)
     catch err
         # If there is a problem with making the directory, but the directory

--- a/test/file.jl
+++ b/test/file.jl
@@ -1500,6 +1500,7 @@ mktempdir() do dir
     @test isdir(namepath)
     @test mkpath(namepath) == namepath
     @test isdir(namepath)
+    # issue 54826
     namepath_dirpath = joinpath(dir, "x", "y", "z", "")
     @test mkpath(namepath_dirpath) == namepath_dirpath
 end

--- a/test/file.jl
+++ b/test/file.jl
@@ -1491,7 +1491,7 @@ mktempdir() do dir
     @test isfile(name1)
     @test isfile(name2)
     namedir = joinpath(dir, "chalk")
-    namepath = joinpath(dir, "chalk","cheese","fresh")
+    namepath = joinpath(dir, "chalk", "cheese", "fresh")
     @test !ispath(namedir)
     @test mkdir(namedir) == namedir
     @test isdir(namedir)
@@ -1500,7 +1500,11 @@ mktempdir() do dir
     @test isdir(namepath)
     @test mkpath(namepath) == namepath
     @test isdir(namepath)
+    namepath_dirpath = joinpath(dir, "x", "y", "z", "")
+    @test mkpath(namepath_dirpath) == namepath_dirpath
 end
+@test mkpath("") == ""
+@test mkpath("/") == "/"
 
 # issue #30588
 @test realpath(".") == realpath(pwd())


### PR DESCRIPTION
fix #54826

related performance test code:
```julia
using BenchmarkTools
using Base: IOError

function checkmode(mode::Integer)
    if !(0 <= mode <= 511)
        throw(ArgumentError("Mode must be between 0 and 511 = 0o777"))
    end
    mode
end

function mkpath(path::AbstractString; mode::Integer = 0o777)
    dir = dirname(path)
    # stop recursion for `""`, `"/"`, or existed dir
    (path == dir || isdir(path)) && return path
    mkpath(dir, mode = checkmode(mode))
    try
        # cases like `mkpath("x/")` will cause an error if `isdir(path)` is skipped
        # the error will not be rethrowed, but it may be slower, and thus we avoid it in advance
        isdir(path) || mkdir(path, mode = mode)
    catch err
        # If there is a problem with making the directory, but the directory
        # does in fact exist, then ignore the error. Else re-throw it.
        if !isa(err, IOError) || !isdir(path)
            rethrow()
        end
    end
    return path
end

function mkpath_2(path::AbstractString; mode::Integer = 0o777)
    dir = dirname(path)
    # stop recursion for `""` and `"/"` or existed dir
    (path == dir || isdir(path)) && return path
    mkpath_2(dir, mode = checkmode(mode))
    try
        mkdir(path, mode = mode)
    catch err
        # If there is a problem with making the directory, but the directory
        # does in fact exist, then ignore the error. Else re-throw it.
        if !isa(err, IOError) || !isdir(path)
            rethrow()
        end
    end
    return path
end

versioninfo()
display(@benchmark begin rm("A", recursive=true, force=true); mkpath("A/B/C/D/") end)
display(@benchmark begin rm("A", recursive=true, force=true); mkpath_2("A/B/C/D/") end)
```
output:
```
Julia Version 1.10.4
Commit 48d4fd48430 (2024-06-04 10:41 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: macOS (x86_64-apple-darwin22.4.0)
  CPU: 16 × Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-15.0.7 (ORCJIT, skylake)
Threads: 1 default, 0 interactive, 1 GC (on 16 virtual cores)
Environment:
  JULIA_EDITOR = code
  JULIA_NUM_THREADS = 
BenchmarkTools.Trial: 8683 samples with 1 evaluation.
 Range (min … max):  473.972 μs …  18.867 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     519.704 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   571.261 μs ± 378.851 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▂█▇▄▁                                                         
  ▃███████▇▅▄▄▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  474 μs           Histogram: frequency by time          961 μs <

 Memory estimate: 5.98 KiB, allocs estimate: 65.
BenchmarkTools.Trial: 6531 samples with 1 evaluation.
 Range (min … max):  588.122 μs …  17.449 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     660.071 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   760.333 μs ± 615.759 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ██▆▄▃▁▁                                                       ▁
  ██████████▆▇█▇▆▆▅▅▅▄▁▄▁▄▄▃▄▃▁▃▃▁▃▁▁▁▄▁▁▁▁▁▁▁▃▃▁▁▁▃▁▁▃▁▁▁▁▅▅▄▇ █
  588 μs        Histogram: log(frequency) by time        4.2 ms <

 Memory estimate: 5.63 KiB, allocs estimate: 72.
```