### PR TITLE
fix var name in `reseteof(s::BufferStream)`

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -1605,7 +1605,7 @@ end
 
 skip(s::BufferStream, n) = skip(s.buffer, n)
 
-function reseteof(x::BufferStream)
+function reseteof(s::BufferStream)
     lock(s.cond) do
         s.status = StatusOpen
         nothing

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -277,6 +277,7 @@ end
     c = zeros(UInt8,8)
     @test bytesavailable(bstream) == 8
     @test !eof(bstream)
+    @test Base.reseteof(bstream) === nothing # TODO: Actually test intended effect
     read!(bstream,c)
     @test c == a[3:10]
     @test closewrite(bstream) === nothing


### PR DESCRIPTION
Evidently not covered by tests etc. (yet)