### PR TITLE
REPL.prompt!: don't use Char peek

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2840,7 +2840,7 @@ function prompt!(term::TextTerminal, prompt::ModalInterface, s::MIState = init_s
         # spawn this because the main repl task is sticky (due to use of @async and _wait2)
         # and we want to not block typing when the repl task thread is busy
         t2 = Threads.@spawn :interactive while true
-            eof(term) || peek(term, Char) # wait before locking but don't consume
+            eof(term) || peek(term) # wait before locking but don't consume
             @lock l begin
                 kmap = keymap(s, prompt)
                 fcn = match_input(kmap, s)


### PR DESCRIPTION
Just use `peek(term)` rather than `peek(term, Char)` because:
1. the latter appears to be broken for non-ascii Chars https://github.com/JuliaLang/julia/pull/54785#issuecomment-2181053084
2. `peek(term)` seems to be the simplest public method that gives what we want (a wait for input).

Fixes 
```
nested task error: ArgumentError: IOBuffer not marked
        Stacktrace:
         [1] reset
           @ ./io.jl:1429 [inlined]
         [2] reset
           @ ./stream.jl:1489 [inlined]
         [3] peek(s::Base.TTY, ::Type{Char})
           @ Base ./stream.jl:1496
         [4] peek(t::REPL.Terminals.TTYTerminal, ::Type{Char})
           @ REPL.Terminals ~/julia/usr/share/julia/stdlib/v1.12/REPL/src/Terminals.jl:161
         [5] (::REPL.LineEdit.var"#282#284"{REPL.Terminals.TTYTerminal, REPL.LineEdit.ModalInterface, REPL.LineEdit.MIState, ReentrantLock, REPL.LineEdit.Prompt})()
           @ REPL.LineEdit ~/julia/usr/share/julia/stdlib/v1.12/REPL/src/LineEdit.jl:2843      
```

which could be reproduced by typing an emoji into the repl.

Replaces https://github.com/JuliaLang/julia/pull/54854
Replaces https://github.com/JuliaLang/julia/pull/54862