### PR TITLE
make `log_quasitriu` always take at least one sqrt

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -1938,7 +1938,7 @@ function _find_params_log_quasitriu!(A)
     d = complex.(@view(A[diagind(A)]))
     dm1 = d .- 1
     s = 0
-    while norm(dm1, Inf) > theta[tmax] && s < maxsqrt
+    while s<1 || norm(dm1, Inf) > theta[tmax] && s < maxsqrt
         d .= sqrt.(d)
         dm1 .= d .- 1
         s = s + 1


### PR DESCRIPTION
seems to fix https://github.com/JuliaLang/LinearAlgebra.jl/issues/1078 (although it's not a fully principled fix, I just think this might have been an edge-case neglected in the original paper, that said, it also possibly is a problem with `m>4` that is independent of the number of sqrts we take).

Before: 
```
julia> qtriu = [0.9950041652780259 -0.09983341664682815 0.07153667745275474; 0.09983341664682804 0.9950041652780259 0.06981527929449967; 0.0 0.0 1.0]
#before
julia> exp(log(qtriu)) - qtriu
3×3 Matrix{Float64}:
 1.11022e-16  1.38778e-17  -0.00269465
 0.0          1.11022e-16   0.00260462
 0.0          0.0           0.0
 #after
 3×3 Matrix{Float64}:
 1.11022e-16  1.38778e-17  3.99319e-13
 0.0          1.11022e-16  3.8973e-13
 0.0          0.0          0.0
```

This still needs tests.
