### PR TITLE
Make warn missed transformations pass optional

### DIFF
--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -90,6 +90,7 @@ struct OptimizationOptions {
     bool enable_vector_pipeline;
     bool remove_ni;
     bool cleanup;
+    bool warn_missed_transformations;
 
     static constexpr OptimizationOptions defaults(
         bool lower_intrinsics=true,
@@ -103,12 +104,13 @@ struct OptimizationOptions {
         bool enable_loop_optimizations=true,
         bool enable_vector_pipeline=true,
         bool remove_ni=true,
-        bool cleanup=true) {
+        bool cleanup=true,
+        bool warn_missed_transformations=false) {
         return {lower_intrinsics, dump_native, external_use, llvm_only,
                 always_inline, enable_early_simplifications,
                 enable_early_optimizations, enable_scalar_optimizations,
                 enable_loop_optimizations, enable_vector_pipeline,
-                remove_ni, cleanup};
+                remove_ni, cleanup, warn_missed_transformations};
     }
 };
 

--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -609,7 +609,8 @@ static void buildPipeline(ModulePassManager &MPM, PassBuilder *PB, OptimizationL
         if (O.getSpeedupLevel() >= 2) {
             buildVectorPipeline(FPM, PB, O, options);
         }
-        FPM.addPass(WarnMissedTransformationsPass());
+        if (options.warn_missed_transformations)
+            FPM.addPass(WarnMissedTransformationsPass());
         MPM.addPass(createModuleToFunctionPassAdaptor(std::move(FPM)));
     }
     buildIntrinsicLoweringPipeline(MPM, PB, O, options);
@@ -632,6 +633,7 @@ struct PipelineConfig {
     int enable_vector_pipeline;
     int remove_ni;
     int cleanup;
+    int warn_missed_transformations;
 };
 
 extern "C" JL_DLLEXPORT_CODEGEN void jl_build_newpm_pipeline_impl(void *MPM, void *PB, PipelineConfig* config) JL_NOTSAFEPOINT
@@ -672,7 +674,8 @@ extern "C" JL_DLLEXPORT_CODEGEN void jl_build_newpm_pipeline_impl(void *MPM, voi
                                         !!config->enable_loop_optimizations,
                                         !!config->enable_vector_pipeline,
                                         !!config->remove_ni,
-                                        !!config->cleanup});
+                                        !!config->cleanup,
+                                        !!config->warn_missed_transformations});
 }
 
 #undef JULIA_PASS
@@ -870,7 +873,8 @@ static Optional<std::pair<OptimizationLevel, OptimizationOptions>> parseJuliaPip
             OPTION(lower_intrinsics),
             OPTION(dump_native),
             OPTION(external_use),
-            OPTION(llvm_only)
+            OPTION(llvm_only),
+            OPTION(warn_missed_transformations)
 #undef OPTION
         };
         while (!name.empty()) {

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1547,3 +1547,23 @@ end
 @testset "Base.Libc docstrings" begin
     @test isempty(Docs.undocumented_names(Libc))
 end
+
+@testset "Silenced missed transformations" begin
+    # Ensure the WarnMissedTransformationsPass is not on by default
+    src = """
+        @noinline iteration(i) = (@show(i); return nothing)
+        @eval function loop_unroll_full_fail(N)
+            for i in 1:N
+              iteration(i)
+              \$(Expr(:loopinfo, (Symbol("llvm.loop.unroll.full"), 1)))
+          end
+       end
+       loop_unroll_full_fail(3)
+    """
+    out_err = mktemp() do _, f
+        run(`$(Base.julia_cmd()) -e "$src"`, devnull, devnull, f)
+        seekstart(f)
+        read(f, String)
+    end
+    @test !occursin("loop not unrolled", out_err)
+end


### PR DESCRIPTION
This makes the `WarnMissedTransformationsPass` compiler pass optional and off by default.