### PR TITLE
Check for non-zero denominator in `iszero` for Rational

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -541,7 +541,7 @@ function ^(z::Complex{<:Rational}, n::Integer)
     n >= 0 ? power_by_squaring(z,n) : power_by_squaring(inv(z),-n)
 end
 
-iszero(x::Rational) = iszero(numerator(x)) && !iszero(denominator(x))
+iszero(x::Rational) = iszero(numerator(x)) && isone(denominator(x))
 isone(x::Rational) = isone(numerator(x)) & isone(denominator(x))
 
 function lerpi(j::Integer, d::Integer, a::Rational, b::Rational)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -541,7 +541,7 @@ function ^(z::Complex{<:Rational}, n::Integer)
     n >= 0 ? power_by_squaring(z,n) : power_by_squaring(inv(z),-n)
 end
 
-iszero(x::Rational) = iszero(numerator(x))
+iszero(x::Rational) = iszero(numerator(x)) && !iszero(denominator(x))
 isone(x::Rational) = isone(numerator(x)) & isone(denominator(x))
 
 function lerpi(j::Integer, d::Integer, a::Rational, b::Rational)

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -801,3 +801,8 @@ end
     @test rationalize(Int64, nextfloat(0.1) * im; tol=0) == precise_next * im
     @test rationalize(0.1im; tol=eps(0.1)) == rationalize(0.1im)
 end
+
+@testset "iszero for 0//0" begin
+    C = reinterpret(reshape, Rational{Int}, zeros(Int, 2, 2, 2))
+    @test !any(iszero, C)
+end


### PR DESCRIPTION
Typically, one can't construct `0//0`, and it's not a valid `Rational`, so this issue doesn't show up in standard use cases. However, `0//0` pops up occasionally in arrays constructed with `similar`, and having this treated as `0` messes with structured matrix detection logic. I am not convinced that this should be `iszero`, since this isn't a valid number in the first place.

Currently,
```julia
julia> C = reinterpret(reshape, Rational{Int}, zeros(Int, 2, 2, 2))
2×2 reinterpret(reshape, Rational{Int64}, ::Array{Int64, 3}) with eltype Rational{Int64}:
 0//0  0//0
 0//0  0//0

julia> all(iszero, C)
true
```
This PR would change this to
```julia
julia> any(iszero, C)
false
```