### PR TITLE
Fixed diagonal matrix eigen decomposition to return eigenvectors as diagonal matrix

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -812,10 +812,15 @@ function eigen(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{
     end
     Td = Base.promote_op(/, eltype(D), eltype(D))
     λ = eigvals(D)
-    evecs = Diagonal{eltype(λ)}(ones(length(λ)))
     if !isnothing(sortby)
         p = sortperm(λ; alg=QuickSort, by=sortby)
         λ = λ[p]
+        evecs = zeros(Td, size(D))
+        @inbounds for i in eachindex(p)
+            evecs[p[i],i] = one(Td)
+        end
+    else
+        evecs = Diagonal{eltype(λ)}(ones(length(λ)))
     end
     Eigen(λ, evecs)
 end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -820,7 +820,7 @@ function eigen(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{
             evecs[p[i],i] = one(Td)
         end
     else
-        evecs = Diagonal{eltype(λ)}(ones(length(λ)))
+        evecs = Diagonal(ones(eltype(λ), length(λ)))
     end
     Eigen(λ, evecs)
 end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -820,7 +820,7 @@ function eigen(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{
             evecs[p[i],i] = one(Td)
         end
     else
-        evecs = Diagonal(ones(eltype(λ), length(λ)))
+        evecs = Diagonal(ones(Td, length(λ)))
     end
     Eigen(λ, evecs)
 end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -812,15 +812,10 @@ function eigen(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{
     end
     Td = Base.promote_op(/, eltype(D), eltype(D))
     λ = eigvals(D)
+    evecs = Diagonal{eltype(λ)}(ones(length(λ)))
     if !isnothing(sortby)
         p = sortperm(λ; alg=QuickSort, by=sortby)
         λ = λ[p]
-        evecs = zeros(Td, size(D))
-        @inbounds for i in eachindex(p)
-            evecs[p[i],i] = one(Td)
-        end
-    else
-        evecs = Matrix{Td}(I, size(D))
     end
     Eigen(λ, evecs)
 end

--- a/uv_constants.jl
+++ b/uv_constants.jl
@@ -1,0 +1,5 @@
+-mmacosx-version-min=11.0
+
+-P
+-I/Users/ozgurmertemir/Projects/julia/julia/usr/include
+16

--- a/uv_constants.jl
+++ b/uv_constants.jl
@@ -1,5 +1,0 @@
--mmacosx-version-min=11.0
-
--P
--I/Users/ozgurmertemir/Projects/julia/julia/usr/include
-16


### PR DESCRIPTION
Solution to issue [Eigen decomposition of Diagonal matrix returns Dense eigenvectors JuliaLang/LinearAlgebra.jl#1049](https://github.com/JuliaLang/LinearAlgebra.jl/issues/1049). Modified the eigen function for diagonal matrices to return eigenvectors as diagonal matrices.

Closes JuliaLang/LinearAlgebra.jl#1049.