### PR TITLE
Clarify what "no program" means in egal docs

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -341,6 +341,16 @@ false
 julia> a === a
 true
 ```
+
+# Extended help
+It might be possible to construct a program that is actually able to distinguish
+two egal values. For example, one could heap-allocate two integers,
+then compare the value of a pointer pointing to their heap address.
+However, all such programs rely on observing behaviour outside Julia's allowed
+semantics, and so happen to work due to implementation details and/or triggering
+undefined behaviour.
+In the example, it is invalid to assume that a value on the heap has a single
+unique pointer referencing it, and that any such pointer references no other value.
 """
 ===
 const ≡ = ===


### PR DESCRIPTION
While the statement in the docstring is correct, it relies on an idiosyncratic definition of "no program", referencing Julia's semantics. Occasionally, a Julia user will point out that they can actually write a program that can distinguish two egal values.
This commit clarifies that while such programs may work, they rely on going outside the language's semantics.