### PR TITLE
#54739-related fixes for loading stdlibs

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1979,7 +1979,7 @@ end
         finally
             for modkey in newdeps
                 insert_extension_triggers(modkey)
-                run_package_callbacks(modkey)
+                stalecheck && run_package_callbacks(modkey)
             end
             empty!(newdeps)
         end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1935,9 +1935,10 @@ end
                 dep = staledeps[i]
                 dep isa Module && continue
                 modpath, modkey, modbuild_id, modcachepath, modstaledeps, modocachepath = dep::Tuple{String, PkgId, UInt128, String, Vector{Any}, Union{Nothing, String}}
-                dep = get(loaded_precompiles, modkey => modbuild_id, nothing)
-                if dep === nothing
+                if stalecheck
                     dep = maybe_root_module(modkey)
+                else
+                    dep = get(loaded_precompiles, modkey => modbuild_id, nothing)
                 end
                 while true
                     if dep isa Module


### PR DESCRIPTION
This fixes a couple unconventional issues people encountered and were able to report as bugs against #54739

Note that due to several bugs in REPLExt itself (https://github.com/JuliaLang/julia/issues/54889, https://github.com/JuliaLang/julia/issues/54888), loading the extension may still crash julia in some circumstances, but that is now a Pkg bug, and no longer the fault of the loading code.