### PR TITLE
mark failing double counting test as broken on i686-linux

### DIFF
--- a/test/misc.jl
+++ b/test/misc.jl
@@ -587,7 +587,8 @@ struct Z53061
 end
 let z = Z53061[Z53061(S53061(rand(), (rand(),rand())), 0) for _ in 1:10^4]
     @test allequal(summarysize(z) for i in 1:10)
-    @test abs(summarysize(z) - 640000)/640000 <= 0.01
+    # broken on i868 linux. issue #54895
+    @test abs(summarysize(z) - 640000)/640000 <= 0.01 broken = Sys.WORD_SIZE == 32 && Sys.islinux()
 end
 
 ## test conversion from UTF-8 to UTF-16 (for Windows APIs)


### PR DESCRIPTION
Introduced by https://github.com/JuliaLang/julia/pull/54606
See https://github.com/JuliaLang/julia/pull/54606#issuecomment-2183664446

Issue https://github.com/JuliaLang/julia/issues/54895