### PR TITLE
Print binary sizes of more libraries in `build-stats` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -672,7 +672,7 @@ endif
 		$(call cygpath_w,$(build_shlibdir)/libjulia.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia-internal.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia-codegen.$(SHLIB_EXT)) \
-		$(call cygpath_w,$(build_shlibdir)/$(LLVM_SHARED_LIB_NAME)) \
+		$(call cygpath_w,$(build_shlibdir)/$(LLVM_SHARED_LIB_NAME).$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_bindir)/julia$(EXE)))
 	@printf $(JULCOLOR)' ==> ./julia launch speedtest\n'$(ENDCOLOR)
 	@time $(call spawn,$(build_bindir)/julia$(EXE) -e '')

--- a/Makefile
+++ b/Makefile
@@ -667,12 +667,17 @@ build-stats:
 ifeq ($(USE_BINARYBUILDER_LLVM),1)
 	@$(MAKE) -C deps install-llvm-tools
 endif
+ifeq ($(OS),Darwin)
+	LIB_LLVM_NAME := libLLVM
+else
+	LIB_LLVM_NAME := $(LLVM_SHARED_LIB_NAME)
+endif
 	@printf $(JULCOLOR)' ==> ./julia binary sizes\n'$(ENDCOLOR)
 	$(call spawn,$(LLVM_SIZE) -A $(call cygpath_w,$(build_private_libdir)/sys.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia-internal.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia-codegen.$(SHLIB_EXT)) \
-		$(call cygpath_w,$(build_shlibdir)/$(LLVM_SHARED_LIB_NAME).$(SHLIB_EXT)) \
+		$(call cygpath_w,$(build_shlibdir)/$(LIB_LLVM_NAME).$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_bindir)/julia$(EXE)))
 	@printf $(JULCOLOR)' ==> ./julia launch speedtest\n'$(ENDCOLOR)
 	@time $(call spawn,$(build_bindir)/julia$(EXE) -e '')

--- a/Makefile
+++ b/Makefile
@@ -667,18 +667,17 @@ build-stats:
 ifeq ($(USE_BINARYBUILDER_LLVM),1)
 	@$(MAKE) -C deps install-llvm-tools
 endif
-ifeq ($(OS),Darwin)
-	LIB_LLVM_NAME := libLLVM
-else
-	LIB_LLVM_NAME := $(LLVM_SHARED_LIB_NAME)
-endif
 	@printf $(JULCOLOR)' ==> ./julia binary sizes\n'$(ENDCOLOR)
 	$(call spawn,$(LLVM_SIZE) -A $(call cygpath_w,$(build_private_libdir)/sys.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia-internal.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia-codegen.$(SHLIB_EXT)) \
-		$(call cygpath_w,$(build_shlibdir)/$(LIB_LLVM_NAME).$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_bindir)/julia$(EXE)))
+ifeq ($(OS),Darwin)
+	$(call spawn,$(LLVM_SIZE) -A $(call cygpath_w,$(build_shlibdir)/libLLVM.$(SHLIB_EXT)))
+else
+	$(call spawn,$(LLVM_SIZE) -A $(call cygpath_w,$(build_shlibdir)/$(LLVM_SHARED_LIB_NAME).$(SHLIB_EXT)))
+endif
 	@printf $(JULCOLOR)' ==> ./julia launch speedtest\n'$(ENDCOLOR)
 	@time $(call spawn,$(build_bindir)/julia$(EXE) -e '')
 	@time $(call spawn,$(build_bindir)/julia$(EXE) -e '')

--- a/Makefile
+++ b/Makefile
@@ -669,8 +669,6 @@ ifeq ($(USE_BINARYBUILDER_LLVM),1)
 endif
 	@printf $(JULCOLOR)' ==> ./julia binary sizes\n'$(ENDCOLOR)
 	$(call spawn,$(LLVM_SIZE) -A $(call cygpath_w,$(build_private_libdir)/sys.$(SHLIB_EXT)) \
-		$(call cygpath_w,$(build_private_libdir)/sys.ji) \
-		$(call cygpath_w,$(build_private_libdir)/corecompiler.ji) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia-internal.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia-codegen.$(SHLIB_EXT)) \

--- a/Makefile
+++ b/Makefile
@@ -669,7 +669,12 @@ ifeq ($(USE_BINARYBUILDER_LLVM),1)
 endif
 	@printf $(JULCOLOR)' ==> ./julia binary sizes\n'$(ENDCOLOR)
 	$(call spawn,$(LLVM_SIZE) -A $(call cygpath_w,$(build_private_libdir)/sys.$(SHLIB_EXT)) \
+		$(call cygpath_w,$(build_private_libdir)/sys.ji) \
+		$(call cygpath_w,$(build_private_libdir)/corecompiler.ji) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia.$(SHLIB_EXT)) \
+		$(call cygpath_w,$(build_shlibdir)/libjulia-internal.$(SHLIB_EXT)) \
+		$(call cygpath_w,$(build_shlibdir)/libjulia-codegen.$(SHLIB_EXT)) \
+		$(call cygpath_w,$(build_shlibdir)/libLLVM.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_bindir)/julia$(EXE)))
 	@printf $(JULCOLOR)' ==> ./julia launch speedtest\n'$(ENDCOLOR)
 	@time $(call spawn,$(build_bindir)/julia$(EXE) -e '')

--- a/Makefile
+++ b/Makefile
@@ -672,7 +672,7 @@ endif
 		$(call cygpath_w,$(build_shlibdir)/libjulia.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia-internal.$(SHLIB_EXT)) \
 		$(call cygpath_w,$(build_shlibdir)/libjulia-codegen.$(SHLIB_EXT)) \
-		$(call cygpath_w,$(build_shlibdir)/libLLVM.$(SHLIB_EXT)) \
+		$(call cygpath_w,$(build_shlibdir)/$(LLVM_SHARED_LIB_NAME)) \
 		$(call cygpath_w,$(build_bindir)/julia$(EXE)))
 	@printf $(JULCOLOR)' ==> ./julia launch speedtest\n'$(ENDCOLOR)
 	@time $(call spawn,$(build_bindir)/julia$(EXE) -e '')


### PR DESCRIPTION
I just picked some big files that seemed related to Julia or LLVM.