### PR TITLE
Specialize findlast for integer AbstractUnitRanges and StepRanges

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -2453,19 +2453,26 @@ end
 findfirst(testf::Function, A::Union{AbstractArray, AbstractString}) =
     findnext(testf, A, first(keys(A)))
 
-findfirst(p::Union{Fix2{typeof(isequal),Int},Fix2{typeof(==),Int}}, r::OneTo{Int}) =
-    1 <= p.x <= r.stop ? p.x : nothing
+findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::OneTo) where {T<:Integer} =
+    1 <= p.x <= r.stop ? convert(keytype(r), p.x) : nothing
 
-findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::AbstractUnitRange) where {T<:Integer} =
-    first(r) <= p.x <= last(r) ? firstindex(r) + Int(p.x - first(r)) : nothing
+findfirst(::typeof(iszero), ::OneTo) = nothing
+
+function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::AbstractUnitRange{<:Integer}) where {T<:Integer}
+    first(r) <= p.x <= last(r) || return nothing
+    i1 = first(keys(r))
+    return i1 + oftype(i1, p.x - first(r))
+end
 
 function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::StepRange{T,S}) where {T,S}
     isempty(r) && return nothing
     minimum(r) <= p.x <= maximum(r) || return nothing
-    d = convert(S, p.x - first(r))::S
+    d = p.x - first(r)
     iszero(d % step(r)) || return nothing
-    return d ÷ step(r) + 1
+    return convert(keytype(r), d ÷ step(r) + 1)
 end
+
+findfirst(::typeof(iszero), r::AbstractRange) = findfirst(==(zero(first(r))), r)
 
 """
     findprev(A, i)
@@ -2636,6 +2643,15 @@ end
 # Needed for bootstrap, and allows defining only an optimized findprev method
 findlast(testf::Function, A::Union{AbstractArray, AbstractString}) =
     findprev(testf, A, last(keys(A)))
+
+# for monotonic ranges, there is a unique index corresponding to a value, so findfirst and findlast are identical
+function findlast(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T},typeof(iszero)}, r::AbstractUnitRange{<:Integer}) where {T<:Integer}
+    findfirst(p, r)
+end
+
+function findlast(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}, typeof(iszero)}, r::StepRange{T,S}) where {T,S}
+    findfirst(p, r)
+end
 
 """
     findall(f::Function, A)

--- a/base/array.jl
+++ b/base/array.jl
@@ -2457,6 +2457,7 @@ findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::OneTo) where 
     1 <= p.x <= r.stop ? convert(keytype(r), p.x) : nothing
 
 findfirst(::typeof(iszero), ::OneTo) = nothing
+findfirst(::typeof(isone), r::OneTo) = oneunit(keytype(r))
 
 function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::AbstractUnitRange{<:Integer}) where {T<:Integer}
     first(r) <= p.x <= last(r) || return nothing
@@ -2473,6 +2474,7 @@ function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::Step
 end
 
 findfirst(::typeof(iszero), r::AbstractRange) = findfirst(==(zero(first(r))), r)
+findfirst(::typeof(isone), r::AbstractRange) = findfirst(==(one(first(r))), r)
 
 """
     findprev(A, i)
@@ -2645,11 +2647,13 @@ findlast(testf::Function, A::Union{AbstractArray, AbstractString}) =
     findprev(testf, A, last(keys(A)))
 
 # for monotonic ranges, there is a unique index corresponding to a value, so findfirst and findlast are identical
-function findlast(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T},typeof(iszero)}, r::AbstractUnitRange{<:Integer}) where {T<:Integer}
+function findlast(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T},typeof(iszero),typeof(isone)},
+        r::AbstractUnitRange{<:Integer}) where {T<:Integer}
     findfirst(p, r)
 end
 
-function findlast(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}, typeof(iszero)}, r::StepRange{T,S}) where {T,S}
+function findlast(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T},typeof(iszero),typeof(isone)},
+        r::StepRange{T,S}) where {T,S}
     findfirst(p, r)
 end
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -2647,8 +2647,8 @@ findlast(testf::Function, A::Union{AbstractArray, AbstractString}) =
     findprev(testf, A, last(keys(A)))
 
 # for monotonic ranges, there is a unique index corresponding to a value, so findfirst and findlast are identical
-function findlast(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T},typeof(iszero),typeof(isone)},
-        r::AbstractUnitRange{<:Integer}) where {T<:Integer}
+function findlast(p::Union{Fix2{typeof(isequal),<:Integer},Fix2{typeof(==),<:Integer},typeof(iszero),typeof(isone)},
+        r::AbstractUnitRange{<:Integer})
     findfirst(p, r)
 end
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -2457,7 +2457,7 @@ findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::OneTo) where 
     1 <= p.x <= r.stop ? convert(keytype(r), p.x) : nothing
 
 findfirst(::typeof(iszero), ::OneTo) = nothing
-findfirst(::typeof(isone), r::OneTo) = oneunit(keytype(r))
+findfirst(::typeof(isone), r::OneTo) = isempty(r) ? nothing : oneunit(keytype(r))
 
 function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::AbstractUnitRange{<:Integer}) where {T<:Integer}
     first(r) <= p.x <= last(r) || return nothing

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -434,15 +434,46 @@ end
         @test findfirst(isequal(3), Base.OneTo(10)) == 3
         @test findfirst(==(0), Base.OneTo(10)) === nothing
         @test findfirst(==(11), Base.OneTo(10)) === nothing
+        @test isnothing(findfirst(iszero, Base.OneTo(10)))
         @test findfirst(==(4), Int16(3):Int16(7)) === Int(2)
         @test findfirst(==(2), Int16(3):Int16(7)) === nothing
         @test findfirst(isequal(8), 3:7) === nothing
+        @test isnothing(findfirst(==(0), UnitRange(-0.5, 0.5)))
+        @test findfirst(==(2), big(1):big(2)) === 2
         @test findfirst(isequal(7), 1:2:10) == 4
+        @test findfirst(iszero, -5:5) == 6
+        @test isnothing(findfirst(iszero, 2:5))
         @test findfirst(==(7), 1:2:10) == 4
         @test findfirst(==(10), 1:2:10) === nothing
         @test findfirst(==(11), 1:2:10) === nothing
         @test findfirst(==(-7), 1:-1:-10) == 9
         @test findfirst(==(2),1:-1:2) === nothing
+        @test isnothing(findfirst(iszero, 5:-2:-5))
+        @test findfirst(iszero, 6:-2:-6) == 4
+        @test findfirst(==(Int128(2)), Int128(1):Int128(1):Int128(4)) === 2
+    end
+    @testset "findlast" begin
+        @test findlast(==(1), Base.IdentityUnitRange(-1:1)) == 1
+        @test findlast(isequal(3), Base.OneTo(10)) == 3
+        @test findlast(==(0), Base.OneTo(10)) === nothing
+        @test findlast(==(11), Base.OneTo(10)) === nothing
+        @test isnothing(findlast(iszero, Base.OneTo(10)))
+        @test findlast(==(4), Int16(3):Int16(7)) === Int(2)
+        @test findlast(==(2), Int16(3):Int16(7)) === nothing
+        @test findlast(isequal(8), 3:7) === nothing
+        @test isnothing(findlast(==(0), UnitRange(-0.5, 0.5)))
+        @test findlast(==(2), big(1):big(2)) === 2
+        @test findlast(isequal(7), 1:2:10) == 4
+        @test findlast(iszero, -5:5) == 6
+        @test isnothing(findlast(iszero, 2:5))
+        @test findlast(==(7), 1:2:10) == 4
+        @test findlast(==(10), 1:2:10) === nothing
+        @test findlast(==(11), 1:2:10) === nothing
+        @test findlast(==(-7), 1:-1:-10) == 9
+        @test findlast(==(2),1:-1:2) === nothing
+        @test isnothing(findlast(iszero, 5:-2:-5))
+        @test findlast(iszero, 6:-2:-6) == 4
+        @test findlast(==(Int128(2)), Int128(1):Int128(1):Int128(4)) === 2
     end
     @testset "reverse" begin
         @test reverse(reverse(1:10)) == 1:10

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -434,22 +434,27 @@ end
         @test findfirst(isequal(3), Base.OneTo(10)) == 3
         @test findfirst(==(0), Base.OneTo(10)) === nothing
         @test findfirst(==(11), Base.OneTo(10)) === nothing
-        @test @inferred((() -> Val(findfirst(iszero, Base.OneTo(10))))()) == Val(nothing)
-        @test @inferred((() -> Val(findfirst(isone, Base.OneTo(10))))()) == Val(1)
+        @test @inferred((r -> Val(findfirst(iszero, r)))(Base.OneTo(10))) == Val(nothing)
+        @test findfirst(isone, Base.OneTo(10)) === 1
+        @test findfirst(isone, Base.OneTo(0)) === nothing
         @test findfirst(==(4), Int16(3):Int16(7)) === Int(2)
         @test findfirst(==(2), Int16(3):Int16(7)) === nothing
         @test findfirst(isequal(8), 3:7) === nothing
-        @test isnothing(findfirst(==(0), UnitRange(-0.5, 0.5)))
+        @test findfirst(==(0), UnitRange(-0.5, 0.5)) === nothing
         @test findfirst(==(2), big(1):big(2)) === 2
         @test findfirst(isequal(7), 1:2:10) == 4
         @test findfirst(iszero, -5:5) == 6
-        @test isnothing(findfirst(iszero, 2:5))
+        @test findfirst(iszero, 2:5) === nothing
+        @test findfirst(iszero, 6:5) === nothing
+        @test findfirst(isone, -5:5) == 7
+        @test findfirst(isone, 2:5) === nothing
+        @test findfirst(isone, 6:5) === nothing
         @test findfirst(==(7), 1:2:10) == 4
         @test findfirst(==(10), 1:2:10) === nothing
         @test findfirst(==(11), 1:2:10) === nothing
         @test findfirst(==(-7), 1:-1:-10) == 9
         @test findfirst(==(2),1:-1:2) === nothing
-        @test isnothing(findfirst(iszero, 5:-2:-5))
+        @test findfirst(iszero, 5:-2:-5) === nothing
         @test findfirst(iszero, 6:-2:-6) == 4
         @test findfirst(==(Int128(2)), Int128(1):Int128(1):Int128(4)) === 2
     end
@@ -459,21 +464,23 @@ end
         @test findlast(==(0), Base.OneTo(10)) === nothing
         @test findlast(==(11), Base.OneTo(10)) === nothing
         @test @inferred((() -> Val(findlast(iszero, Base.OneTo(10))))()) == Val(nothing)
-        @test @inferred((() -> Val(findlast(isone, Base.OneTo(10))))()) == Val(1)
+        @test findlast(isone, Base.OneTo(10)) == 1
+        @test findlast(isone, Base.OneTo(0)) === nothing
         @test findlast(==(4), Int16(3):Int16(7)) === Int(2)
         @test findlast(==(2), Int16(3):Int16(7)) === nothing
         @test findlast(isequal(8), 3:7) === nothing
-        @test isnothing(findlast(==(0), UnitRange(-0.5, 0.5)))
+        @test findlast(==(0), UnitRange(-0.5, 0.5)) === nothing
         @test findlast(==(2), big(1):big(2)) === 2
         @test findlast(isequal(7), 1:2:10) == 4
         @test findlast(iszero, -5:5) == 6
-        @test isnothing(findlast(iszero, 2:5))
+        @test findlast(iszero, 2:5) === nothing
+        @test findlast(iszero, 6:5) === nothing
         @test findlast(==(7), 1:2:10) == 4
         @test findlast(==(10), 1:2:10) === nothing
         @test findlast(==(11), 1:2:10) === nothing
         @test findlast(==(-7), 1:-1:-10) == 9
         @test findlast(==(2),1:-1:2) === nothing
-        @test isnothing(findlast(iszero, 5:-2:-5))
+        @test findlast(iszero, 5:-2:-5) === nothing
         @test findlast(iszero, 6:-2:-6) == 4
         @test findlast(==(Int128(2)), Int128(1):Int128(1):Int128(4)) === 2
     end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -434,7 +434,8 @@ end
         @test findfirst(isequal(3), Base.OneTo(10)) == 3
         @test findfirst(==(0), Base.OneTo(10)) === nothing
         @test findfirst(==(11), Base.OneTo(10)) === nothing
-        @test isnothing(findfirst(iszero, Base.OneTo(10)))
+        @test @inferred((() -> Val(findfirst(iszero, Base.OneTo(10))))()) == Val(nothing)
+        @test @inferred((() -> Val(findfirst(isone, Base.OneTo(10))))()) == Val(1)
         @test findfirst(==(4), Int16(3):Int16(7)) === Int(2)
         @test findfirst(==(2), Int16(3):Int16(7)) === nothing
         @test findfirst(isequal(8), 3:7) === nothing
@@ -457,7 +458,8 @@ end
         @test findlast(isequal(3), Base.OneTo(10)) == 3
         @test findlast(==(0), Base.OneTo(10)) === nothing
         @test findlast(==(11), Base.OneTo(10)) === nothing
-        @test isnothing(findlast(iszero, Base.OneTo(10)))
+        @test @inferred((() -> Val(findlast(iszero, Base.OneTo(10))))()) == Val(nothing)
+        @test @inferred((() -> Val(findlast(isone, Base.OneTo(10))))()) == Val(1)
         @test findlast(==(4), Int16(3):Int16(7)) === Int(2)
         @test findlast(==(2), Int16(3):Int16(7)) === nothing
         @test findlast(isequal(8), 3:7) === nothing


### PR DESCRIPTION
For monotonic ranges, `findfirst` and `findlast` with `==(val)` as the predicate should be identical, as each value appears only once in the range. Since `findfirst` is specialized for some ranges, we may define `findlast` as well analogously.

On v"1.12.0-DEV.770"
```julia
julia> @btime findlast(==(1), $(Ref(1:1_000))[])
  1.186 μs (0 allocations: 0 bytes)
1
```
This PR
```julia
julia> @btime findlast(==(1), $(Ref(1:1_000))[])
  3.171 ns (0 allocations: 0 bytes)
1
```

I've also specialized `findfirst(iszero, r::AbstractRange)` to make this be equivalent to `findfirst(==(0), ::AbstractRange)` for numerical ranges. Similarly, for `isone`. These now take the fast path as well.

Thirdly, I've added some `convert` calls to address issues like
```julia
julia> r = Int128(1):Int128(1):Int128(4);

julia> findfirst(==(Int128(2)), r) |> typeof
Int128

julia> keytype(r)
Int64
```
This PR ensures that the return type always corresponds to `keytype`, which is what the docstring promises.

This PR also fixes
```julia
julia> findfirst(==(0), UnitRange(-0.5, 0.5))
ERROR: InexactError: Int64(0.5)
Stacktrace:
 [1] Int64
   @ ./float.jl:994 [inlined]
 [2] findfirst(p::Base.Fix2{typeof(==), Int64}, r::UnitRange{Float64})
   @ Base ./array.jl:2397
 [3] top-level scope
   @ REPL[1]:1
```
which now returns `nothing`, as expected.