### PR TITLE
also disable `is_foldable` test on other 32bit platforms

### DIFF
--- a/test/math.jl
+++ b/test/math.jl
@@ -1602,11 +1602,11 @@ end
                     @test Core.Compiler.is_foldable(effects)
                 end
             end
-            @static if !(Sys.iswindows()&&Int==Int32) # COMBAK debug this
-            @testset let effects = Base.infer_effects(^, (T,Int))
-                @test Core.Compiler.is_foldable(effects)
+            @static if Sys.WORD_SIZE != 32 # COMBAK debug this
+                @testset let effects = Base.infer_effects(^, (T,Int))
+                    @test Core.Compiler.is_foldable(effects)
+                end
             end
-            end # @static
             @testset let effects = Base.infer_effects(^, (T,T))
                 @test Core.Compiler.is_foldable(effects)
             end


### PR DESCRIPTION
Follow-on from https://github.com/JuliaLang/julia/pull/54323

@aviatesk I think this should also be disabled on linux? It's been failing there

On `test i686-linux-gnu`
```
math                                              (7) |         failed at 2024-06-23T13:58:26.792
Test Failed at /cache/build/tester-amdci5-8/julialang/julia-buildkite/julia-2d4ef8a238/share/julia/test/math.jl:1607
  Expression: Core.Compiler.is_foldable(effects)
     Context: effects = (+c,+e,+n,!t,+s,+m,+u,+o)
              T = Float64
```