### PR TITLE
Rename some JL_HAVE_* constants to `JL_TASK_SWITCH_*` for clarity, and some related cleanup

### DIFF
--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -40,8 +40,8 @@ JL_DLLEXPORT void jl_set_ptls_rng(uint64_t new_seed) JL_NOTSAFEPOINT;
 
 //  Options for task switching algorithm (in order of preference):
 // JL_HAVE_ASM -- mostly setjmp
-// JL_HAVE_ASM && JL_HAVE_UNW_CONTEXT -- libunwind-based
-// JL_HAVE_UNW_CONTEXT -- libunwind-based
+// JL_HAVE_ASM && JL_TASK_SWITCH_LIBUNWIND -- libunwind-based
+// JL_TASK_SWITCH_LIBUNWIND -- libunwind-based
 // JL_TASK_SWITCH_WINDOWS -- implementation for Windows
 
 #ifdef _OS_WINDOWS_
@@ -52,7 +52,7 @@ typedef jl_stack_context_t _jl_ucontext_t;
 #else
 
 #if defined(_OS_OPENBSD_)
-#define JL_HAVE_UNW_CONTEXT
+#define JL_TASK_SWITCH_LIBUNWIND
 #endif
 
 typedef struct {
@@ -60,7 +60,7 @@ typedef struct {
 } jl_stack_context_t;
 
 #if !defined(JL_HAVE_ASM) && \
-    !defined(JL_HAVE_UNW_CONTEXT)
+    !defined(JL_TASK_SWITCH_LIBUNWIND)
 #if (defined(_CPU_X86_64_) || defined(_CPU_X86_) || defined(_CPU_AARCH64_) ||  \
      defined(_CPU_ARM_) || defined(_CPU_PPC64_) || defined(_CPU_RISCV64_))
 #define JL_HAVE_ASM
@@ -68,15 +68,15 @@ typedef struct {
 #if 0
 // very slow, but more debugging
 //#elif defined(_OS_DARWIN_)
-//#define JL_HAVE_UNW_CONTEXT
+//#define JL_TASK_SWITCH_LIBUNWIND
 //#elif defined(_OS_LINUX_)
-//#define JL_HAVE_UNW_CONTEXT
+//#define JL_TASK_SWITCH_LIBUNWIND
 #elif !defined(JL_HAVE_ASM)
-#define JL_HAVE_UNW_CONTEXT // optimistically?
+#define JL_TASK_SWITCH_LIBUNWIND // optimistically?
 #endif
 #endif
 
-#if defined(JL_HAVE_UNW_CONTEXT)
+#if defined(JL_TASK_SWITCH_LIBUNWIND)
 #pragma GCC visibility push(default)
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -49,19 +49,16 @@ JL_DLLEXPORT void jl_set_ptls_rng(uint64_t new_seed) JL_NOTSAFEPOINT;
 typedef win32_ucontext_t jl_stack_context_t;
 typedef jl_stack_context_t _jl_ucontext_t;
 
-#elif defined(_OS_OPENBSD_)
+#else
+
+#if defined(_OS_OPENBSD_)
 #define JL_HAVE_UNW_CONTEXT
-#define UNW_LOCAL_ONLY
-#include <libunwind.h>
-typedef unw_context_t _jl_ucontext_t;
+#endif
+
 typedef struct {
     jl_jmp_buf uc_mcontext;
 } jl_stack_context_t;
 
-#else
-typedef struct {
-    jl_jmp_buf uc_mcontext;
-} jl_stack_context_t;
 #if !defined(JL_HAVE_ASM) && \
     !defined(JL_HAVE_UNW_CONTEXT)
 #if (defined(_CPU_X86_64_) || defined(_CPU_X86_) || defined(_CPU_AARCH64_) ||  \
@@ -79,16 +76,16 @@ typedef struct {
 #endif
 #endif
 
-#if !defined(JL_HAVE_UNW_CONTEXT) && defined(JL_HAVE_ASM)
-typedef jl_stack_context_t _jl_ucontext_t;
-#endif
-#pragma GCC visibility push(default)
 #if defined(JL_HAVE_UNW_CONTEXT)
+#pragma GCC visibility push(default)
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
 typedef unw_context_t _jl_ucontext_t;
-#endif
 #pragma GCC visibility pop
+#elif defined(JL_HAVE_ASM)
+typedef jl_stack_context_t _jl_ucontext_t;
+#endif
+
 #endif
 
 typedef struct {

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -42,10 +42,10 @@ JL_DLLEXPORT void jl_set_ptls_rng(uint64_t new_seed) JL_NOTSAFEPOINT;
 // JL_HAVE_ASM -- mostly setjmp
 // JL_HAVE_ASM && JL_HAVE_UNW_CONTEXT -- libunwind-based
 // JL_HAVE_UNW_CONTEXT -- libunwind-based
-// JL_HAVE_UCONTEXT -- posix standard API, requires syscall for resume
+// JL_TASK_SWITCH_WINDOWS -- implementation for Windows
 
 #ifdef _OS_WINDOWS_
-#define JL_HAVE_UCONTEXT
+#define JL_TASK_SWITCH_WINDOWS
 typedef win32_ucontext_t jl_stack_context_t;
 typedef jl_stack_context_t _jl_ucontext_t;
 
@@ -62,8 +62,7 @@ typedef struct {
 typedef struct {
     jl_jmp_buf uc_mcontext;
 } jl_stack_context_t;
-#if !defined(JL_HAVE_UCONTEXT) && \
-    !defined(JL_HAVE_ASM) && \
+#if !defined(JL_HAVE_ASM) && \
     !defined(JL_HAVE_UNW_CONTEXT)
 #if (defined(_CPU_X86_64_) || defined(_CPU_X86_) || defined(_CPU_AARCH64_) ||  \
      defined(_CPU_ARM_) || defined(_CPU_PPC64_) || defined(_CPU_RISCV64_))
@@ -88,10 +87,6 @@ typedef jl_stack_context_t _jl_ucontext_t;
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
 typedef unw_context_t _jl_ucontext_t;
-#endif
-#if defined(JL_HAVE_UCONTEXT)
-#include <ucontext.h>
-typedef ucontext_t _jl_ucontext_t;
 #endif
 #pragma GCC visibility pop
 #endif

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -39,8 +39,8 @@ JL_DLLEXPORT void jl_set_ptls_rng(uint64_t new_seed) JL_NOTSAFEPOINT;
 #define JULIA_DEBUG_SLEEPWAKE(x)
 
 //  Options for task switching algorithm (in order of preference):
-// JL_HAVE_ASM -- mostly setjmp
-// JL_HAVE_ASM && JL_TASK_SWITCH_LIBUNWIND -- libunwind-based
+// JL_TASK_SWITCH_ASM -- mostly setjmp
+// JL_TASK_SWITCH_ASM && JL_TASK_SWITCH_LIBUNWIND -- libunwind-based
 // JL_TASK_SWITCH_LIBUNWIND -- libunwind-based
 // JL_TASK_SWITCH_WINDOWS -- implementation for Windows
 
@@ -59,11 +59,11 @@ typedef struct {
     jl_jmp_buf uc_mcontext;
 } jl_stack_context_t;
 
-#if !defined(JL_HAVE_ASM) && \
+#if !defined(JL_TASK_SWITCH_ASM) && \
     !defined(JL_TASK_SWITCH_LIBUNWIND)
 #if (defined(_CPU_X86_64_) || defined(_CPU_X86_) || defined(_CPU_AARCH64_) ||  \
      defined(_CPU_ARM_) || defined(_CPU_PPC64_) || defined(_CPU_RISCV64_))
-#define JL_HAVE_ASM
+#define JL_TASK_SWITCH_ASM
 #endif
 #if 0
 // very slow, but more debugging
@@ -71,7 +71,7 @@ typedef struct {
 //#define JL_TASK_SWITCH_LIBUNWIND
 //#elif defined(_OS_LINUX_)
 //#define JL_TASK_SWITCH_LIBUNWIND
-#elif !defined(JL_HAVE_ASM)
+#elif !defined(JL_TASK_SWITCH_ASM)
 #define JL_TASK_SWITCH_LIBUNWIND // optimistically?
 #endif
 #endif
@@ -82,7 +82,7 @@ typedef struct {
 #include <libunwind.h>
 typedef unw_context_t _jl_ucontext_t;
 #pragma GCC visibility pop
-#elif defined(JL_HAVE_ASM)
+#elif defined(JL_TASK_SWITCH_ASM)
 typedef jl_stack_context_t _jl_ucontext_t;
 #endif
 

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -1423,7 +1423,7 @@ JL_DLLEXPORT jl_record_backtrace_result_t jl_record_backtrace(jl_task_t *t, jl_b
             context = &c;
 #elif defined(JL_TASK_SWITCH_LIBUNWIND)
         context = t->ctx.ctx;
-#elif defined(JL_HAVE_ASM)
+#elif defined(JL_TASK_SWITCH_ASM)
         memset(&c, 0, sizeof(c));
         if (jl_simulate_longjmp(*mctx, &c))
             context = &c;

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -1417,14 +1417,12 @@ JL_DLLEXPORT jl_record_backtrace_result_t jl_record_backtrace(jl_task_t *t, jl_b
     if (context == NULL && (!t->ctx.copy_stack && t->ctx.started && t->ctx.ctx != NULL)) {
         // need to read the context from the task stored state
         jl_jmp_buf *mctx = &t->ctx.ctx->uc_mcontext;
-#if defined(_OS_WINDOWS_)
+#if defined(JL_TASK_SWITCH_WINDOWS)
         memset(&c, 0, sizeof(c));
         if (jl_simulate_longjmp(*mctx, &c))
             context = &c;
 #elif defined(JL_HAVE_UNW_CONTEXT)
         context = t->ctx.ctx;
-#elif defined(JL_HAVE_UCONTEXT)
-        context = jl_to_bt_context(t->ctx.ctx);
 #elif defined(JL_HAVE_ASM)
         memset(&c, 0, sizeof(c));
         if (jl_simulate_longjmp(*mctx, &c))

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -1421,7 +1421,7 @@ JL_DLLEXPORT jl_record_backtrace_result_t jl_record_backtrace(jl_task_t *t, jl_b
         memset(&c, 0, sizeof(c));
         if (jl_simulate_longjmp(*mctx, &c))
             context = &c;
-#elif defined(JL_HAVE_UNW_CONTEXT)
+#elif defined(JL_TASK_SWITCH_LIBUNWIND)
         context = t->ctx.ctx;
 #elif defined(JL_HAVE_ASM)
         memset(&c, 0, sizeof(c));

--- a/src/task.c
+++ b/src/task.c
@@ -254,7 +254,7 @@ JL_NO_ASAN static void restore_stack2(jl_ucontext_t *t, jl_ptls_t ptls, jl_ucont
     tsan_switch_to_ctx(t);
     jl_swapcontext(lastt->ctx, t->copy_ctx);
 #else
-#if defined(JL_HAVE_UNW_CONTEXT)
+#if defined(JL_TASK_SWITCH_LIBUNWIND)
     volatile int returns = 0;
     int r = unw_getcontext(lastt->ctx);
     if (++returns == 2) // r is garbage after the first return
@@ -1319,7 +1319,7 @@ static void jl_set_fiber(jl_ucontext_t *t)
 }
 #endif
 
-#if defined(JL_HAVE_UNW_CONTEXT)
+#if defined(JL_TASK_SWITCH_LIBUNWIND)
 #ifdef _OS_WINDOWS_
 #error unw_context_t not defined in Windows
 #endif
@@ -1363,7 +1363,7 @@ static void jl_set_fiber(jl_ucontext_t *t)
 }
 #endif
 
-#if defined(JL_HAVE_UNW_CONTEXT) && !defined(JL_HAVE_ASM)
+#if defined(JL_TASK_SWITCH_LIBUNWIND) && !defined(JL_HAVE_ASM)
 #if defined(_CPU_X86_) || defined(_CPU_X86_64_)
 #define PUSH_RET(ctx, stk) \
     do { \
@@ -1434,7 +1434,7 @@ static void jl_start_fiber_swap(jl_ucontext_t *lastt, jl_ucontext_t *t)
 JL_NO_ASAN static void jl_start_fiber_swap(jl_ucontext_t *lastt, jl_ucontext_t *t)
 {
     assert(lastt);
-#ifdef JL_HAVE_UNW_CONTEXT
+#ifdef JL_TASK_SWITCH_LIBUNWIND
     volatile int returns = 0;
     int r = unw_getcontext(lastt->ctx);
     if (++returns == 2) // r is garbage after the first return

--- a/src/task.c
+++ b/src/task.c
@@ -261,7 +261,7 @@ JL_NO_ASAN static void restore_stack2(jl_ucontext_t *t, jl_ptls_t ptls, jl_ucont
         return;
     if (r != 0 || returns != 1)
         abort();
-#elif defined(JL_HAVE_ASM)
+#elif defined(JL_TASK_SWITCH_ASM)
     if (jl_setjmp(lastt->ctx->uc_mcontext, 0))
         return;
 #else
@@ -274,7 +274,7 @@ JL_NO_ASAN static void restore_stack2(jl_ucontext_t *t, jl_ptls_t ptls, jl_ucont
 
 JL_NO_ASAN static void NOINLINE restore_stack3(jl_ucontext_t *t, jl_ptls_t ptls, char *p)
 {
-#if !defined(JL_HAVE_ASM)
+#if !defined(JL_TASK_SWITCH_ASM)
     char *_x = (char*)ptls->stackbase;
     if (!p) {
         // switch to a stackframe that's well beyond the bounds of the next switch
@@ -1349,7 +1349,7 @@ static void jl_set_fiber(jl_ucontext_t *t)
         abort();
     unw_resume(&c);
 }
-#elif defined(JL_HAVE_ASM)
+#elif defined(JL_TASK_SWITCH_ASM)
 static void jl_swap_fiber(jl_ucontext_t *lastt, jl_ucontext_t *t)
 {
     if (jl_setjmp(lastt->ctx->uc_mcontext, 0))
@@ -1363,7 +1363,7 @@ static void jl_set_fiber(jl_ucontext_t *t)
 }
 #endif
 
-#if defined(JL_TASK_SWITCH_LIBUNWIND) && !defined(JL_HAVE_ASM)
+#if defined(JL_TASK_SWITCH_LIBUNWIND) && !defined(JL_TASK_SWITCH_ASM)
 #if defined(_CPU_X86_) || defined(_CPU_X86_64_)
 #define PUSH_RET(ctx, stk) \
     do { \
@@ -1427,9 +1427,9 @@ static void jl_start_fiber_swap(jl_ucontext_t *lastt, jl_ucontext_t *t)
 }
 #endif
 
-#if defined(JL_HAVE_ASM)
+#if defined(JL_TASK_SWITCH_ASM)
 #ifdef _OS_WINDOWS_
-#error JL_HAVE_ASM not defined in Windows
+#error JL_TASK_SWITCH_ASM not defined in Windows
 #endif
 JL_NO_ASAN static void jl_start_fiber_swap(jl_ucontext_t *lastt, jl_ucontext_t *t)
 {
@@ -1523,7 +1523,7 @@ CFI_NORETURN
         " trap; \n"
         : : "r"(stk), "r"(fn) : "memory");
 #else
-#error JL_HAVE_ASM defined but not implemented for this CPU type
+#error JL_TASK_SWITCH_ASM defined but not implemented for this CPU type
 #endif
     __builtin_unreachable();
 }


### PR DESCRIPTION
- **Replace JL_HAVE_UCONTEXT by JL_TASK_SWITCH_WINDOWS**
- **Untangle OpenBSD checks in julia_threads.h**
- **Rename JL_HAVE_UNW_CONTEXT -> JL_TASK_SWITCH_LIBUNWIND**
- **Rename JL_HAVE_ASM -> JL_TASK_SWITCH_ASM**

Whenever I try to understand the task switch code, I have to figure out
again when which of the various `JL_HAVE_*` constants are set, how they
interact, etc. -- and indeed recall that `JL_HAVE_*` controls the task
switching code in the first place.

So it seems sensible to me to rename these to indicate they control task
switching. This is in particular true for `JL_HAVE_UCONTEXT` which
was/is exclusively used on on Windows, despite the reference to
`ucontext`, a POSIX feature (albeit one removed from the standard in
POSIX.1-2008).

Of course it is still conceivable that in the future someone wants to
port Julia to a new platform and for some reason libunwind switching is
not workable, but the `ucontext` one is -- in that case it wouldn't be
too hard to add back a `JL_TASK_SWITCH_UCONTEXT`. But IMHO such a
hypothetical future is a good reason to confuse people trying to
understand the code today.

