### PR TITLE
inference: simplify generated function handling

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -603,9 +603,10 @@ end
 function InferenceState(result::InferenceResult, cache_mode::UInt8, interp::AbstractInterpreter)
     # prepare an InferenceState object for inferring lambda
     world = get_inference_world(interp)
-    src = retrieve_code_info(result.linfo, world)
+    mi = result.linfo
+    src = retrieve_code_info(mi, world)
     src === nothing && return nothing
-    maybe_validate_code(result.linfo, src, "lowered")
+    maybe_validate_code(mi, src, "lowered")
     return InferenceState(result, src, cache_mode, interp)
 end
 InferenceState(result::InferenceResult, cache_mode::Symbol, interp::AbstractInterpreter) =

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -139,10 +139,8 @@ use_const_api(li::CodeInstance) = invoke_api(li) == 2
 function get_staged(mi::MethodInstance, world::UInt)
     may_invoke_generator(mi) || return nothing
     try
-        # user code might throw errors – ignore them
-        ci = ccall(:jl_code_for_staged, Any, (Any, UInt, Ptr{Cvoid}), mi, world, C_NULL)::CodeInfo
-        return ci
-    catch
+        return ccall(:jl_code_for_staged, Ref{CodeInfo}, (Any, UInt, Ptr{Cvoid}), mi, world, C_NULL)
+    catch # user code might throw errors – ignore them
         return nothing
     end
 end
@@ -162,7 +160,7 @@ function retrieve_code_info(mi::MethodInstance, world::UInt)
         # @atomic ci.inferred = C_NULL
         return src
     end
-    c = isdefined(def, :generator) ? get_staged(mi, world) : nothing
+    c = hasgenerator(def) ? get_staged(mi, world) : nothing
     if c === nothing && isdefined(def, :source)
         src = def.source
         if src === nothing

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1188,7 +1188,7 @@ function code_lowered(@nospecialize(f), @nospecialize(t=Tuple); generated::Bool=
     for m in method_instances(f, t, world)
         if generated && hasgenerator(m)
             if may_invoke_generator(m)
-                code = ccall(:jl_code_for_staged, Any, (Any, UInt, Ptr{Cvoid}), m, world, C_NULL)::CodeInfo
+                code = ccall(:jl_code_for_staged, Ref{CodeInfo}, (Any, UInt, Ptr{Cvoid}), m, world, C_NULL)
             else
                 error("Could not expand generator for `@generated` method ", m, ". ",
                       "This can happen if the provided argument types (", t, ") are ",

--- a/src/method.c
+++ b/src/method.c
@@ -727,8 +727,6 @@ JL_DLLEXPORT jl_code_instance_t *jl_cache_uninferred(jl_method_instance_t *mi, j
     return newci;
 }
 
-
-
 // Return a newly allocated CodeInfo for the function signature
 // effectively described by the tuple (specTypes, env, Method) inside linfo
 JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *mi, size_t world, jl_code_instance_t **cache)


### PR DESCRIPTION
Removed some unnecessary type assertions in the handling of generated functions to simplify the code a bit. There are no changes to the basic functionality.