### PR TITLE
cglobal: Fall back to runtime intrinsic

### DIFF
--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1937,3 +1937,14 @@ end
 
 # issue #52025
 @test Base.unsafe_convert(Ptr{Ptr{Cchar}}, Base.cconvert(Ptr{Ptr{Cchar}}, map(pointer, ["ab"]))) isa Ptr{Ptr{Cchar}}
+
+# Cglobal with non-static symbols doesn't error
+function cglobal_non_static1()
+    sym = (:global_var, libccalltest)
+    cglobal(sym)
+end
+global the_sym = (:global_var, libccalltest)
+cglobal_non_static2() = cglobal(the_sym)
+
+@test isa(cglobal_non_static1(), Ptr)
+@test isa(cglobal_non_static2(), Ptr)


### PR DESCRIPTION
Our codegen for `cglobal` was sharing the `static_eval` code for symbols with ccall. However, we do have full runtime emulation for this intrinsic, so mandating that the symbol can be statically evaluated is not required and causes semantic differences between the interpreter and codegen, which is undesirable. Just fall back to the runtime intrinsic instead.