### PR TITLE
Fix annotated join with non-concrete eltype iters

### DIFF
--- a/test/strings/annotated.jl
+++ b/test/strings/annotated.jl
@@ -101,6 +101,8 @@ end
                      [(1:4, :label => 5),
                       (5:5, :label => 2),
                       (6:9, :label => 5)])
+    @test join((String(str1), str1), ' ') ==
+        Base.AnnotatedString("test test", [(6:9, :label => 5)])
     @test repeat(str1, 2) == Base.AnnotatedString("testtest", [(1:8, :label => 5)])
     @test repeat(str2, 2) == Base.AnnotatedString("casecase", [(2:3, :label => "oomph"),
                                                        (6:7, :label => "oomph")])


### PR DESCRIPTION
As raised in <https://github.com/JuliaLang/StyledStrings.jl/issues/57#issuecomment-2097457142>, when the eltype of an iterator is non-concrete, `_isannotated` will return false. To properly check such cases, we need to see if any of the elements of the iterator are annotated.

This is a bit of an interesting case, since:
- Most of the time it shouldn't be hit, we can reasonably expect most iterables to infer as producing concrete types
- The eltype of the iterator is (generally) known at compile-time, and so in any case other than the ambiguous non-concrete one, this check remains able to be done at compile-time.

With this change, join always preserves annotations. The compromise made is that iterators with non-concrete eltypes can result in join inferring a union return type (i.e. type instability with non-concrete iterators), but that doesn't seem too bad to me (I don't see how we could be completely type stable without concrete types here).

#### Before

![image](https://github.com/JuliaLang/julia/assets/20903656/a7b109ca-a9f1-4361-a9f7-618aa8ceba88)

#### After

![image](https://github.com/JuliaLang/julia/assets/20903656/f70b62a1-37a8-4df8-85b8-cea26ad81757)

I'd be keen to hear people's thoughts here.