### PR TITLE
Aggressive constprop in the PermutedDimsArray constructor

### DIFF
--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -39,7 +39,7 @@ julia> B[3,1,2] == A[1,2,3]
 true
 ```
 """
-function PermutedDimsArray(data::AbstractArray{T,N}, perm) where {T,N}
+Base.@constprop :aggressive function PermutedDimsArray(data::AbstractArray{T,N}, perm) where {T,N}
     length(perm) == N || throw(ArgumentError(string(perm, " is not a valid permutation of dimensions 1:", N)))
     iperm = invperm(perm)
     PermutedDimsArray{T,N,(perm...,),(iperm...,),typeof(data)}(data)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1281,6 +1281,9 @@ Base.cconvert(::Type{Ptr{T}}, S::Strider{T}) where {T} = memoryref(S.data.ref, S
             end
         end
     end
+    # constant propagation in the PermutedDimsArray constructor
+    X = @inferred (A -> PermutedDimsArray(A, (2,3,1)))(A)
+    @test @inferred((X -> PermutedDimsArray(X, (3,1,2)))(X)) == A
 end
 
 @testset "simple 2d strided views, permutes, transposes" for sz in ((5, 3), (7, 11))


### PR DESCRIPTION
After this, the return type in the `PermutedDimsArray` constructor is concretely inferred for `Array`s if the permutation is known at compile time: 
```julia
julia> @inferred (() -> PermutedDimsArray(collect(reshape(1:8,2,2,2)), (2,3,1)))()
2×2×2 PermutedDimsArray(::Array{Int64, 3}, (2, 3, 1)) with eltype Int64:
[:, :, 1] =
 1  5
 3  7

[:, :, 2] =
 2  6
 4  8
```
This should address the second concern in https://github.com/JuliaLang/julia/issues/54918