### PR TITLE
Aggressive constprop in mapslices

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -3287,7 +3287,7 @@ one *without* a colon in the slice. This is `view(A,:,i,:)`, whereas
 `mapslices(f, A; dims=(1,3))` uses `A[:,i,:]`. The function `f` may mutate
 values in the slice without affecting `A`.
 """
-function mapslices(f, A::AbstractArray; dims)
+@constprop :aggressive function mapslices(f, A::AbstractArray; dims)
     isempty(dims) && return map(f, A)
 
     for d in dims

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1263,6 +1263,10 @@ end
     @test @inferred(mapslices(hcat, [1 2; 3 4], dims=1)) == [1 2; 3 4] # previously an error, now allowed
     @test mapslices(identity, [1 2; 3 4], dims=(2,2)) == [1 2; 3 4] # previously an error
     @test_broken @inferred(mapslices(identity, [1 2; 3 4], dims=(2,2))) == [1 2; 3 4]
+
+    # type inference in mapslices
+    a_ = @inferred (a -> mapslices(identity, reshape(a, size(a)..., 1, 1), dims=(3,4)))(a)
+    @test a_ == reshape(a, size(a)..., 1, 1)
 end
 
 @testset "single multidimensional index" begin


### PR DESCRIPTION
This helps improve type-inference, e.g. the return type in the following call is concretely inferred after this:
```julia
julia> @inferred (() -> mapslices(sum, reshape(collect(1:16), 2, 2, 2, 2), dims=(3,4)))()
2×2×1×1 Array{Int64, 4}:
[:, :, 1, 1] =
 28  36
 32  40
```
This should address the first concern in https://github.com/JuliaLang/julia/issues/54918