### PR TITLE
fix effects for Float64^Int on 32 bit

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -1328,9 +1328,7 @@ end
 end
 
 @constprop :aggressive @inline function ^(x::Float64, n::Integer)
-    x^clamp(n, Int64)
-end
-@constprop :aggressive @inline function ^(x::Float64, n::Int64)
+    n = clamp(Int64, n)
     n == 0 && return one(x)
     if use_power_by_squaring(n)
         return pow_body(x, n)

--- a/base/math.jl
+++ b/base/math.jl
@@ -1328,7 +1328,7 @@ end
 end
 
 @constprop :aggressive @inline function ^(x::Float64, n::Integer)
-    n = clamp(Int64, n)
+    n = clamp(n, Int64)
     n == 0 && return one(x)
     if use_power_by_squaring(n)
         return pow_body(x, n)

--- a/test/math.jl
+++ b/test/math.jl
@@ -1602,10 +1602,8 @@ end
                     @test Core.Compiler.is_foldable(effects)
                 end
             end
-            @static if Sys.WORD_SIZE != 32 # COMBAK debug this
-                @testset let effects = Base.infer_effects(^, (T,Int))
-                    @test Core.Compiler.is_foldable(effects)
-                end
+            @testset let effects = Base.infer_effects(^, (T,Int))
+                @test Core.Compiler.is_foldable(effects)
             end
             @testset let effects = Base.infer_effects(^, (T,T))
                 @test Core.Compiler.is_foldable(effects)


### PR DESCRIPTION
fixes https://github.com/JuliaLang/julia/pull/54910 properly.

The recursion heuristic was getting mad at this for some reason...