### PR TITLE
validate `:const` expr properly

### DIFF
--- a/base/compiler/validation.jl
+++ b/base/compiler/validation.jl
@@ -9,7 +9,7 @@ const VALID_EXPR_HEADS = IdDict{Symbol,UnitRange{Int}}(
     :(&) => 1:1,
     :(=) => 2:2,
     :method => 1:4,
-    :const => 1:1,
+    :const => 1:2,
     :new => 1:typemax(Int),
     :splatnew => 2:2,
     :the_exception => 0:0,

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -2386,3 +2386,8 @@ let (c, r, res) = test_complete_context("si", Main; shift=false)
     @test res
     @test "sin" ∈ c
 end
+
+let (c, r, res) = test_complete_context("const xxx = Base.si", Main)
+    @test res
+    @test "sin" ∈ c
+end


### PR DESCRIPTION
Following up JuliaLang/julia#54773.
Since top-level thunks including `:const` expressions are generally not optimized, they are not validated either, which can cause problems for interpreters like `REPLInterpreter` that perform inference on arbitrary top-level chunks.