### PR TITLE
1.11: improve type stability of `_unsafe_take!(::IOBuffer)`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -3082,8 +3082,10 @@ function _wrap(ref::MemoryRef{T}, dims::NTuple{N, Int}) where {T, N}
     return ref
 end
 
-@noinline invalid_wrap_err(len, dims, proddims) = throw(DimensionMismatch(
-    "Attempted to wrap a MemoryRef of length $len with an Array of size dims=$dims, which is invalid because prod(dims) = $proddims > $len, so that the array would have more elements than the underlying memory can store."))
+@noinline invalid_wrap_err(len, dims, proddims) = throw(DimensionMismatch(LazyString(
+    "Attempted to wrap a MemoryRef of length ", len, " with an Array of size dims=", dims,
+    " which is invalid because prod(dims) = ", proddims, " > ", len,
+    " so that the array would have more elements than the underlying memory can store.")))
 
 @eval @propagate_inbounds function wrap(::Type{Array}, m::MemoryRef{T}, dims::NTuple{N, Integer}) where {T, N}
     dims = convert(Dims, dims)

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -116,7 +116,7 @@ function sprint(f::Function, args...; context=nothing, sizehint::Integer=0)
     String(_unsafe_take!(s))
 end
 
-function _str_sizehint(x)
+function _str_sizehint(@nospecialize x)
     if x isa Float64
         return 20
     elseif x isa Float32


### PR DESCRIPTION
fixes JuliaLang/julia#54900