### PR TITLE
llvmcall: verify that the number of arguments is equal to number of argument types

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -920,16 +920,18 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
     size_t nargt = jl_svec_len(tt);
     SmallVector<llvm::Type*, 0> argtypes;
     SmallVector<Value *, 8> argvals(nargt);
+
+    if (nargs - 3 != nargt) {
+        emit_error(ctx, "Mismatch between number of argument types and number of arguments to llvmcall");
+        JL_GC_POP();
+        return jl_cgval_t();
+    }
+
     for (size_t i = 0; i < nargt; ++i) {
         jl_value_t *tti = jl_svecref(tt,i);
         bool toboxed;
         Type *t = julia_type_to_llvm(ctx, tti, &toboxed);
         argtypes.push_back(t);
-        if (4 + i > nargs) {
-            emit_error(ctx, "Missing arguments to llvmcall!");
-            JL_GC_POP();
-            return jl_cgval_t();
-        }
         jl_value_t *argi = args[4 + i];
         jl_cgval_t arg = emit_expr(ctx, argi);
 

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -218,3 +218,21 @@ s = MyStruct()
 @test eltype(supertype(Core.LLVMPtr{UInt8,1})) <: UInt8
 @test s.kern == 0
 @test reinterpret(Int, s.ptr) == 0
+
+function too_few_args(x::Int32, y::Int32)
+    llvmcall("""%3 = add i32 %1, %0
+                ret i32 %3""",
+        Int32,
+        Tuple{Int32, Int32},
+        x)
+end
+@test_throws ErrorException too_few_args(Int32(1), Int32(1))
+
+function too_many_args(x::Int32, y::Int32)
+    llvmcall("""%3 = add i32 %1, %0
+                ret i32 %3""",
+        Int32,
+        Tuple{Int32, Int32},
+        x,y,x)
+end
+@test_throws ErrorException too_many_args(Int32(1), Int32(1))


### PR DESCRIPTION
Currently, giving too many arguments makes them just be ignored.