### PR TITLE
Support `@opaque Tuple{T,U...}->RT (...)->...` syntax for explicit arg/return types

### DIFF
--- a/base/opaque_closure.jl
+++ b/base/opaque_closure.jl
@@ -18,11 +18,23 @@ the argument type may be fixed length even if the function is variadic.
     This interface is experimental and subject to change or removal without notice.
 """
 macro opaque(ex)
-    esc(Expr(:opaque_closure, ex))
+    esc(Expr(:opaque_closure, nothing, nothing, nothing, ex))
 end
 
 macro opaque(ty, ex)
-    esc(Expr(:opaque_closure, ty, ex))
+    if Base.isexpr(ty, :->)
+        (AT, body) = ty.args
+        filter!((n)->!isa(n, Core.LineNumberNode), body.args)
+        if !Base.isexpr(body, :block) || length(body.args) != 1
+            error("Opaque closure type must be specified in the form Tuple{T,U...}->RT")
+        end
+        RT = only(body.args)
+    else
+        error("Opaque closure type must be specified in the form Tuple{T,U...}->RT")
+    end
+    AT = (AT !== :_) ? AT : nothing
+    RT = (RT !== :_) ? RT : nothing
+    return esc(Expr(:opaque_closure, AT, RT, RT, ex))
 end
 
 # OpaqueClosure construction from pre-inferred CodeInfo/IRCode

--- a/base/show.jl
+++ b/base/show.jl
@@ -3335,8 +3335,8 @@ bitstring(B::BitArray) = sprint(bitshow, B)
 function show(io::IO, oc::Core.OpaqueClosure)
     A, R = typeof(oc).parameters
     show_tuple_as_call(io, Symbol(""), A; hasfirst=false)
-    print(io, "::", R)
     print(io, "->◌")
+    print(io, "::", R)
 end
 
 function show(io::IO, ::MIME"text/plain", oc::Core.OpaqueClosure{A, R}) where {A, R}

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -139,7 +139,7 @@ tag = "ANY"
 @test !warntype_hastag(ImportIntrinsics15819.sqrt15819, Tuple{Float32}, tag)
 
 @testset "code_warntype OpaqueClosure" begin
-    g = Base.Experimental.@opaque Tuple{Float64} x -> 0.0
+    g = Base.Experimental.@opaque Tuple{Float64}->_ x -> 0.0
     @test warntype_hastag(g, Tuple{Float64}, "::Float64")
 end
 


### PR DESCRIPTION
This gives users a way to explicitly specify the return type of an OpaqueClosure, and it also removes the old syntax `@opaque AT ...` in preference of `@opaque AT->_ ...`