### PR TITLE
Reduce branches in 2x2 and 3x3 stable_muladdmul for standard cases

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -79,8 +79,6 @@ macro stable_muladdmul(expr)
     for (i, e) in enumerate(expr.args)
         e isa Expr || continue
         if e.head == :call && e.args[1] == :MulAddMul && length(e.args) == 3
-            e.args[2] isa Symbol || continue
-            e.args[3] isa Symbol || continue
             local asym = e.args[2]
             local bsym = e.args[3]
 

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -377,6 +377,33 @@ julia> lmul!(F.Q, B)
 """
 lmul!(A, B)
 
+# We may inline the matmul2x2! and matmul3x3! calls for `α == true`
+# to simplify the @stable_muladdmul branches
+function matmul2x2or3x3_nonzeroalpha!(C, tA, tB, A, B, α, β)
+    if size(C) == size(A) == size(B) == (2,2)
+        matmul2x2!(C, tA, tB, A, B, α, β)
+        return true
+    end
+    if size(C) == size(A) == size(B) == (3,3)
+        matmul3x3!(C, tA, tB, A, B, α, β)
+        return true
+    end
+    return false
+end
+function matmul2x2or3x3_nonzeroalpha!(C, tA, tB, A, B, α::Bool, β)
+    if size(C) == size(A) == size(B) == (2,2)
+        Aelements, Belements = _matmul2x2_elements(C, tA, tB, A, B)
+        @stable_muladdmul _modify2x2!(Aelements, Belements, C, MulAddMul(true, β))
+        return true
+    end
+    if size(C) == size(A) == size(B) == (3,3)
+        Aelements, Belements = _matmul3x3_elements(C, tA, tB, A, B)
+        @stable_muladdmul _modify3x3!(Aelements, Belements, C, MulAddMul(true, β))
+        return true
+    end
+    return false
+end
+
 # THE one big BLAS dispatch. This is split into two methods to improve latency
 Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedMatrix{T}, tA, tB, A::StridedVecOrMat{T}, B::StridedVecOrMat{T},
                                     α::Number, β::Number, ::Val{true}) where {T<:BlasFloat}
@@ -388,12 +415,7 @@ Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedMatrix
         end
         return _rmul_or_fill!(C, β)
     end
-    if size(C) == size(A) == size(B) == (2,2)
-        return matmul2x2!(C, tA, tB, A, B, α, β)
-    end
-    if size(C) == size(A) == size(B) == (3,3)
-        return matmul3x3!(C, tA, tB, A, B, α, β)
-    end
+    matmul2x2or3x3_nonzeroalpha!(C, tA, tB, A, B, α, β) && return C
     # We convert the chars to uppercase to potentially unwrap a WrapperChar,
     # and extract the char corresponding to the wrapper type
     tA_uc, tB_uc = uppercase(tA), uppercase(tB)
@@ -420,12 +442,7 @@ Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedMatrix
         end
         return _rmul_or_fill!(C, β)
     end
-    if size(C) == size(A) == size(B) == (2,2)
-        return matmul2x2!(C, tA, tB, A, B, α, β)
-    end
-    if size(C) == size(A) == size(B) == (3,3)
-        return matmul3x3!(C, tA, tB, A, B, α, β)
-    end
+    matmul2x2or3x3_nonzeroalpha!(C, tA, tB, A, B, α, β) && return C
     # We convert the chars to uppercase to potentially unwrap a WrapperChar,
     # and extract the char corresponding to the wrapper type
     tA_uc, tB_uc = uppercase(tA), uppercase(tB)


### PR DESCRIPTION
We may use the knowledge that `alpha != 0` at the call site to hard-code `alpha = true` in the `MulAddMul` constructor if `alpha isa Bool`. This eliminates the `!isone(alpha)` branches in `@stable_muladdmul`, and reduces latency in matrix multiplication.

```julia
julia> using LinearAlgebra

julia> A = rand(2,2);

julia> @time A * A;
  0.596825 seconds (1.05 M allocations: 53.458 MiB, 5.94% gc time, 99.95% compilation time) # nightly v"1.12.0-DEV.789"
  0.473140 seconds (793.52 k allocations: 39.946 MiB, 3.28% gc time, 99.93% compilation time) # this PR
``` 
In a separate session,
```julia
julia> @time A * Symmetric(A);
  0.829252 seconds (2.37 M allocations: 120.051 MiB, 1.98% gc time, 99.98% compilation time) # nightly v"1.12.0-DEV.789"
  0.712953 seconds (2.06 M allocations: 103.951 MiB, 2.17% gc time, 99.98% compilation time) # This PR
```