### PR TITLE
LAPACK: Avoid repr call in `chkvalidparam`

### DIFF
--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -60,10 +60,13 @@ end
 macro chkvalidparam(position::Int, param, validvalues)
     :(chkvalidparam($position, $(string(param)), $(esc(param)), $validvalues))
 end
-function chkvalidparam(position::Int, var::String, val::AbstractChar, validvals)
+function chkvalidparam(position::Int, var::String, val, validvals)
+    # mimic repr for chars without explicitly calling it 
+    _repr(c::AbstractChar) = "'$c'"
+    _repr(c) = c
     if val ∉ validvals
         throw(ArgumentError(
-            lazy"argument #$position: $var must be one of $validvals, but '$val' was passed"))
+            lazy"argument #$position: $var must be one of $validvals, but $(_repr(val)) was passed"))
     end
     return val
 end

--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -61,7 +61,8 @@ macro chkvalidparam(position::Int, param, validvalues)
     :(chkvalidparam($position, $(string(param)), $(esc(param)), $validvalues))
 end
 function chkvalidparam(position::Int, var::String, val, validvals)
-    # mimic repr for chars without explicitly calling it 
+    # mimic `repr` for chars without explicitly calling it
+    # This is because `repr` introduces dynamic dispatch
     _repr(c::AbstractChar) = "'$c'"
     _repr(c) = c
     if val ∉ validvals

--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -60,10 +60,10 @@ end
 macro chkvalidparam(position::Int, param, validvalues)
     :(chkvalidparam($position, $(string(param)), $(esc(param)), $validvalues))
 end
-function chkvalidparam(position::Int, var::String, val, validvals)
+function chkvalidparam(position::Int, var::String, val::AbstractChar, validvals)
     if val ∉ validvals
         throw(ArgumentError(
-            lazy"argument #$position: $var must be one of $validvals, but $(repr(val)) was passed"))
+            lazy"argument #$position: $var must be one of $validvals, but '$val' was passed"))
     end
     return val
 end


### PR DESCRIPTION
We were calling `repr` here to interpolate the character with the quotes into the error message. However, this is overkill for this application, and `repr` introduces dynamic dispatch into the call. This PR hard-codes the quotes into the string, which matches the pattern followed in the other error messages following `chkvalidparam`.