### PR TITLE
Color todo admonitions in the REPL

### DIFF
--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -39,6 +39,8 @@ function term(io::IO, md::Admonition, columns)
         Symbol(md.category)
     elseif md.category == "compat"
         :bright_cyan
+    elseif md.category == "todo"
+        :magenta
     else
         :default
     end


### PR DESCRIPTION
This patch adds magenta coloring for `!!! todo` admonitions in addition to the existing styling of `danger`, `warning`, `info`, `note`, `tip`, and `compat` admonitions. This is useful if you want to leave some more colorful todo notes in docstrings, for example.

Accompanying PR for Documenter to render these in HTML and PDF docs: https://github.com/JuliaDocs/Documenter.jl/pull/2526.