### PR TITLE
Add timing to precompile trace compile

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2858,7 +2858,7 @@ function create_expr_cache(pkg::PkgId, input::String, output::String, output_o::
         opts = `-O0 --output-ji $(output) --output-incremental=yes`
     end
 
-    trace = isassigned(PRECOMPILE_TRACE_COMPILE) ? `--trace-compile=$(PRECOMPILE_TRACE_COMPILE[])` : ``
+    trace = isassigned(PRECOMPILE_TRACE_COMPILE) ? `--trace-compile=$(PRECOMPILE_TRACE_COMPILE[]) --trace-compile-timing` : ``
     io = open(pipeline(addenv(`$(julia_cmd(;cpu_target)::Cmd)
                              $(flags)
                              $(opts)


### PR DESCRIPTION
I think this tool is there mainly to see what's taking so long, so timing information is helpful.