### PR TITLE
RFC: Make `include_dependency(path; track_content=true)` the default

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2090,13 +2090,13 @@ function _include_dependency(mod::Module, _path::AbstractString; track_content=t
 end
 
 """
-    include_dependency(path::AbstractString; track_content::Bool=false)
+    include_dependency(path::AbstractString; track_content::Bool=true)
 
 In a module, declare that the file, directory, or symbolic link specified by `path`
-(relative or absolute) is a dependency for precompilation; that is, the module will need
-to be recompiled if the modification time `mtime` of `path` changes.
-If `track_content=true` recompilation is triggered when the content of `path` changes
+(relative or absolute) is a dependency for precompilation; that is, if `track_content=true`
+the module will need to be recompiled if the content of `path` changes
 (if `path` is a directory the content equals `join(readdir(path))`).
+If `track_content=false` recompilation is triggered when the modification time `mtime` of `path` changes.
 
 This is only needed if your module depends on a path that is not used via [`include`](@ref). It has
 no effect outside of compilation.
@@ -2104,7 +2104,7 @@ no effect outside of compilation.
 !!! compat "Julia 1.11"
     Keyword argument `track_content` requires at least Julia 1.11.
 """
-function include_dependency(path::AbstractString; track_content::Bool=false)
+function include_dependency(path::AbstractString; track_content::Bool=true)
     _include_dependency(Main, path, track_content=track_content, path_may_be_dir=true)
     return nothing
 end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -2103,6 +2103,7 @@ no effect outside of compilation.
 
 !!! compat "Julia 1.11"
     Keyword argument `track_content` requires at least Julia 1.11.
+    An error is now thrown if `path` is not readable.
 """
 function include_dependency(path::AbstractString; track_content::Bool=true)
     _include_dependency(Main, path, track_content=track_content, path_may_be_dir=true)

--- a/test/RelocationTestPkg2/src/RelocationTestPkg2.jl
+++ b/test/RelocationTestPkg2/src/RelocationTestPkg2.jl
@@ -1,7 +1,7 @@
 module RelocationTestPkg2
 
-include_dependency("foo.txt")
-include_dependency("foodir")
+include_dependency("foo.txt", track_content=false)
+include_dependency("foodir", track_content=false)
 greet() = print("Hello World!")
 
 end # module RelocationTestPkg2


### PR DESCRIPTION
By changing the default to `true` we make it easier to build relocatable packages from already existing ones when 1.11 lands.

This keyword was just added during 1.11, so its not yet too late to change its default.