### PR TITLE
Update asyncmap docs to clarify order of outputs

### DIFF
--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -9,6 +9,8 @@ Uses multiple concurrent tasks to map `f` over a collection (or multiple
 equal length collections). For multiple collection arguments, `f` is
 applied elementwise.
 
+The output is guaranteed to be the same order as the elements of the collection(s) `c`.
+
 `ntasks` specifies the number of tasks to run concurrently.
 Depending on the length of the collections, if `ntasks` is unspecified,
 up to 100 tasks will be used for concurrent mapping.


### PR DESCRIPTION
small addition to `asyncmap` docstring to clarify that order of output is same as input:

> The output is guaranteed to be the same order as the elements of the collection(s) `c`.

I added it to clarify the behavior, especially for new users, and, afaik because it is not consistent across programming languages.

Happy to iterate if there should be updates to doc pages too.