### PR TITLE
inference: add missing `MustAlias` widening in `_getfield_tfunc`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1098,7 +1098,7 @@ end
 end
 
 @nospecs function _getfield_tfunc(𝕃::AnyMustAliasesLattice, s00, name, setfield::Bool)
-    return _getfield_tfunc(widenlattice(𝕃), widenmustalias(s00), name, setfield)
+    return _getfield_tfunc(widenlattice(𝕃), widenmustalias(s00), widenmustalias(name), setfield)
 end
 
 @nospecs function _getfield_tfunc(𝕃::PartialsLattice, s00, name, setfield::Bool)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2565,6 +2565,14 @@ Base.return_types(intermustalias_edgecase, (Any,); interp=MustAliasInterpreter()
     intermustalias_edgecase(x)
 end |> only === Core.Compiler.InterMustAlias
 
+@test Base.infer_return_type((AliasableField,Integer,); interp=MustAliasInterpreter()) do a, x
+    s = (;x)
+    if getfield(a, :f) isa Symbol
+        return getfield(s, getfield(a, :f))
+    end
+    return 0
+end == Integer
+
 function f25579(g)
     h = g[]
     t = (h === nothing)


### PR DESCRIPTION
Otherwise it may result in missing `⊑` method error in uses cases by external abstract interpreters using `MustAliasesLattice` like JET.