### PR TITLE
Add a "lower" `cat` method for LinearAlgebra types

### DIFF
--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -463,6 +463,9 @@ for (f, _f, dim, name) in ((:hcat, :_hcat, 1, "rows"), (:vcat, :_vcat, 2, "cols"
     end
 end
 
+Base._cat(dims, A::Union{AbstractArray,AbstractQ,Number}...) =
+    Base._cat_t(dims, Base.promote_eltypeof(A...), A...)
+
 hvcat(rows::Tuple{Vararg{Int}}, A::Union{AbstractArray,AbstractQ,UniformScaling}...) = _hvcat(rows, A...)
 hvcat(rows::Tuple{Vararg{Int}}, A::Union{AbstractArray,AbstractQ,UniformScaling,Number}...) = _hvcat(rows, A...)
 function _hvcat(rows::Tuple{Vararg{Int}}, A::Union{AbstractArray,AbstractQ,UniformScaling,Number}...; array_type = promote_to_array_type(A))

--- a/stdlib/LinearAlgebra/test/special.jl
+++ b/stdlib/LinearAlgebra/test/special.jl
@@ -275,8 +275,8 @@ end
     specialmats = (diagmat, bidiagmat, tridiagmat, symtridiagmat, abstractq, zeros(Int,N,N))
     for specialmata in specialmats, specialmatb in specialmats
         MA = collect(specialmata); MB = collect(specialmatb)
-        @test hcat(specialmata, specialmatb) == hcat(MA, MB)
-        @test vcat(specialmata, specialmatb) == vcat(MA, MB)
+        @test hcat(specialmata, specialmatb) == cat(specialmata, specialmatb, dims=2) == hcat(MA, MB)
+        @test vcat(specialmata, specialmatb) == cat(specialmata, specialmatb, dims=1) == vcat(MA, MB)
         @test hvcat((1,1), specialmata, specialmatb) == hvcat((1,1), MA, MB)
         @test cat(specialmata, specialmatb; dims=(1,2)) == cat(MA, MB; dims=(1,2))
     end
@@ -286,12 +286,12 @@ end
     for specialmat in specialmats
         SM = Matrix(specialmat)
         # --> Tests applicable only to pairs of matrices
-        @test vcat(specialmat, densemat) == vcat(SM, densemat)
-        @test vcat(densemat, specialmat) == vcat(densemat, SM)
+        @test vcat(specialmat, densemat) == cat(specialmat, densemat, dims=1) == vcat(SM, densemat)
+        @test vcat(densemat, specialmat) == cat(densemat, specialmat, dims=1) == vcat(densemat, SM)
         # --> Tests applicable also to pairs including vectors
         for specialmat in specialmats, othermatorvec in (densemat, densevec)
             SM = Matrix(specialmat); OM = Array(othermatorvec)
-            @test hcat(specialmat, othermatorvec) == hcat(SM, OM)
+            @test hcat(specialmat, othermatorvec) == cat(specialmat, othermatorvec, dims=2) == hcat(SM, OM)
             @test hcat(othermatorvec, specialmat) == hcat(OM, SM)
             @test hvcat((2,), specialmat, othermatorvec) == hvcat((2,), SM, OM)
             @test hvcat((2,), othermatorvec, specialmat) == hvcat((2,), OM, SM)


### PR DESCRIPTION
This adds a `Base._cat` methods that catches all `LinearAlgebra` types, which have previously been handled by generic call paths. That made it very hard to extend this in packages.