### PR TITLE
Switch to inline ASM to silence warning on newer mingw compilers on ptls code

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -163,14 +163,16 @@ BOOLEAN WINAPI DllMain(IN HINSTANCE hDllHandle, IN DWORD nReason,
 
 #if defined(_CPU_X86_64_)
 #define SAVE_ERRNO \
-    DWORD *plast_error = (DWORD*)(__readgsqword(0x30) + 0x68); \
-    DWORD last_error = *plast_error
+    DWORD *plast_error; \
+    __asm__ ("movq %%gs:0x30,%0" : "=r" (plast_error)); \
+    DWORD last_error = *(plast_error + 0x68)
 #define LOAD_ERRNO \
     *plast_error = last_error
 #elif defined(_CPU_X86_)
 #define SAVE_ERRNO \
-    DWORD *plast_error = (DWORD*)(__readfsdword(0x18) + 0x34); \
-    DWORD last_error = *plast_error
+    DWORD *plast_error; \
+    __asm__ ("movq %%gs:0x18,%0" : "=r" (plast_error)); \
+    DWORD last_error = *(plast_error + 0x34)
 #define LOAD_ERRNO \
     *plast_error = last_error
 #else


### PR DESCRIPTION
We are throwing warnings like
> C:/msys64/mingw64/include/psdk_inc/intrin-impl.h:838:1: warning: array subscript 0 is outside array bounds of 'long long unsigned int[0]' [-Warray-bounds=]
  838 | __buildreadseg(__readgsqword, unsigned __int64, "gs", "q")
      | ^~~~~~~~~~~~~~
In function 'ijl_threadid':
cc1.exe: note: source object is likely at address zero



This follows this recommendation
https://sourceforge.net/p/mingw-w64/mailman/mingw-w64-public/thread/bb25034d-dd29-d1cd-5519-8ec98d287f43@126.com/ 