### PR TITLE
Matmul: dispatch on specific blas paths using an enum 

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -512,11 +512,19 @@ function _lrchar_ulchar(tA, tB)
 end
 function _symm_hemm_generic!(C, tA, tB, A, B, alpha, beta, ::Val{BlasFlag.SYMM})
     lrchar, ulchar = _lrchar_ulchar(tA, tB)
-    BLAS.symm!(lrchar, ulchar, alpha, A, B, beta, C)
+    if lrchar == 'L'
+        BLAS.symm!(lrchar, ulchar, alpha, A, B, beta, C)
+    else
+        BLAS.symm!(lrchar, ulchar, alpha, B, A, beta, C)
+    end
 end
 function _symm_hemm_generic!(C, tA, tB, A, B, alpha, beta, ::Val{BlasFlag.HEMM})
     lrchar, ulchar = _lrchar_ulchar(tA, tB)
-    BLAS.hemm!(lrchar, ulchar, alpha, A, B, beta, C)
+    if lrchar == 'L'
+        BLAS.hemm!(lrchar, ulchar, alpha, A, B, beta, C)
+    else
+        BLAS.hemm!(lrchar, ulchar, alpha, B, A, beta, C)
+    end
 end
 Base.@constprop :aggressive function _symm_hemm_generic!(C, tA, tB, A, B, α, β, ::Val{BlasFlag.NONE})
     _generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), MulAddMul(α, β))

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -500,7 +500,7 @@ Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedMatrix
     _symm_hemm_generic!(C, tA, tB, A, B, αβ..., Val(_blasfn))
     return C
 end
-function _lrchar_ulchar(tA, tB)
+Base.@constprop :aggressive function _lrchar_ulchar(tA, tB)
     if uppercase(tA) == 'N'
         lrchar = 'R'
         ulchar = isuppercase(tB) ? 'U' : 'L'
@@ -526,8 +526,8 @@ function _symm_hemm_generic!(C, tA, tB, A, B, alpha, beta, ::Val{BlasFlag.HEMM})
         BLAS.hemm!(lrchar, ulchar, alpha, B, A, beta, C)
     end
 end
-Base.@constprop :aggressive function _symm_hemm_generic!(C, tA, tB, A, B, α, β, ::Val{BlasFlag.NONE})
-    _generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), MulAddMul(α, β))
+Base.@constprop :aggressive function _symm_hemm_generic!(C, tA, tB, A, B, alpha, beta, ::Val{BlasFlag.NONE})
+    @stable_muladdmul _generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), MulAddMul(alpha, beta))
 end
 
 # legacy method

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -303,8 +303,8 @@ true
 # Add a level of indirection and specialize _mul! to avoid ambiguities in mul!
 module BlasFlag
 @enum BlasFunction SYRK HERK GEMM SYMM HEMM NONE
-const ValSyrkHerkGemm = Union{Val{SYRK}, Val{HERK}, Val{GEMM}}
-const ValSymmHemmGeneric = Union{Val{SYMM}, Val{HEMM}, Val{NONE}}
+const SyrkHerkGemm = Union{Val{SYRK}, Val{HERK}, Val{GEMM}}
+const SymmHemmGeneric = Union{Val{SYMM}, Val{HEMM}, Val{NONE}}
 end
 @inline function _mul!(C::AbstractMatrix, A::AbstractVecOrMat, B::AbstractVecOrMat, α::Number, β::Number)
     tA = wrapper_char(A)
@@ -444,7 +444,7 @@ end
 
 # THE one big BLAS dispatch. This is split into two methods to improve latency
 Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedMatrix{T}, tA, tB, A::StridedVecOrMat{T}, B::StridedVecOrMat{T},
-                                    α::Number, β::Number, val::BlasFlag.ValSyrkHerkGemm) where {T<:BlasFloat}
+                                    α::Number, β::Number, val::BlasFlag.SyrkHerkGemm) where {T<:BlasFloat}
     mA, nA = lapack_size(tA, A)
     mB, nB = lapack_size(tB, B)
     if any(iszero, size(A)) || any(iszero, size(B)) || iszero(α)
@@ -478,7 +478,7 @@ Base.@constprop :aggressive function _syrk_herk_gemm_wrapper!(C, tA, tB, A, B, �
 end
 _valtypeparam(v::Val{T}) where {T} = T
 Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedMatrix{T}, tA, tB, A::StridedVecOrMat{T}, B::StridedVecOrMat{T},
-                                    α::Number, β::Number, val::BlasFlag.ValSymmHemmGeneric) where {T<:BlasFloat}
+                                    α::Number, β::Number, val::BlasFlag.SymmHemmGeneric) where {T<:BlasFloat}
     mA, nA = lapack_size(tA, A)
     mB, nB = lapack_size(tB, B)
     if any(iszero, size(A)) || any(iszero, size(B)) || iszero(α)


### PR DESCRIPTION
This expands on the approach taken by https://github.com/JuliaLang/julia/pull/54552.

We pass on more type information to `generic_matmatmul_wrapper!`, which lets us convert the branches to method dispatches. This helps spread the latency around, so that instead of compiling all the branches in the first call, we now compile the branches only when they are actually taken. While this reduces the latency in individual branches, there is no reduction in latency if all the branches are reachable.

```julia
julia> A = rand(2,2);

julia> @time A * A;
  0.479805 seconds (809.66 k allocations: 40.764 MiB, 99.93% compilation time) # 1.12.0-DEV.806
  0.346739 seconds (633.17 k allocations: 31.320 MiB, 99.90% compilation time) # This PR

julia> @time A * A';
  0.030413 seconds (101.98 k allocations: 5.359 MiB, 98.54% compilation time) # v1.12.0-DEV.806
  0.148118 seconds (219.51 k allocations: 11.652 MiB, 99.72% compilation time) # This PR
```
The latency is spread between the two calls here.

In fresh sessions:
```julia
julia> A = rand(2,2);

julia> @time A * A';
  0.473630 seconds (825.65 k allocations: 41.554 MiB, 99.91% compilation time) # v1.12.0-DEV.806
  0.490305 seconds (774.87 k allocations: 38.824 MiB, 99.90% compilation time) # This PR
```
In this case, both the `syrk` and `gemm` branches are reachable, so there is no reduction in latency.

Analogously, there is a reduction in latency in the second set of matrix multiplications where we call `symm!/hemm!` or `_generic_matmatmul`:

```julia
julia> using LinearAlgebra

julia> A = rand(2,2);

julia> @time Symmetric(A) * A;
  0.711178 seconds (2.06 M allocations: 103.878 MiB, 2.20% gc time, 99.98% compilation time) # v1.12.0-DEV.806
  0.540669 seconds (904.12 k allocations: 43.576 MiB, 2.60% gc time, 97.36% compilation time) # This PR
```