### PR TITLE
WIP: save registers of tasks that were active right before GC on a ucontext_t for conservative scanning

### DIFF
--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -152,6 +152,12 @@ JL_DLLEXPORT void jl_active_task_stack(jl_task_t *task,
                                        char **active_start, char **active_end,
                                        char **total_start, char **total_end) JL_NOTSAFEPOINT;
 
+// Save the context of a task for conservative scanning.
+// Requires `GC_SAVE_CONTEXT_FOR_CONSERVATIVE_SCANNING` to be defined.
+// If ctx is NULL, the registers of the thread at the moment of the call are saved, else
+// the registers of the context ctx are saved into the `ctx_at_the_time_gc_started` field of Julia's TLS.
+JL_DLLEXPORT void jl_save_context_for_conservative_scanning(jl_ptls_t ptls, void *ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -285,6 +285,10 @@ typedef struct _jl_tls_states_t {
     uv_mutex_t sleep_lock;
     uv_cond_t wake_signal;
 #endif
+
+#ifdef GC_SAVE_CONTEXT_FOR_CONSERVATIVE_SCANNING
+    ucontext_t ctx_at_the_time_gc_started;
+#endif
 } jl_tls_states_t;
 
 #ifndef JL_LIBRARY_EXPORTS

--- a/src/options.h
+++ b/src/options.h
@@ -82,6 +82,13 @@
 // GC_SMALL_PAGE allocates objects in 4k pages
 // #define GC_SMALL_PAGE
 
+// GC_SAVE_CONTEXT_FOR_CONSERVATIVE_SCANNING saves the context of the tasks that
+// were running right before GC started so that they can be used for conservative
+// scanning. Currently only available on x86_64 Linux.
+#define GC_SAVE_CONTEXT_FOR_CONSERVATIVE_SCANNING
+#if !defined(x86_64) || !defined(_OS_LINUX_)
+#undef GC_SAVE_CONTEXT_FOR_CONSERVATIVE_SCANNING
+#endif
 
 // method dispatch profiling --------------------------------------------------
 


### PR DESCRIPTION
Garbage collectors that are fully or partially conservative usually need to look at what was stored in the registers of the tasks right before GC started, and may also benefit from having information about the stack pointer at the time GC started in order to determine the lower/upper bounds of the stack.

Let's expose a call to support register saving for conservative GCs.

The current implementation is WIP because:
- Can be optimized for space by saving the context into the tasks' `jl_ucontext_t` itself, instead of adding a new field to the TLS as I'm doing now.
- It's only `x86_64` Linux for now.

CC: @qinsoon, @kpamnany.