### PR TITLE
Fix a regression in the test for #13432

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -3999,6 +3999,14 @@ end
 end
 @test f13432b(true) == true
 @test f13432b(false) == false
+@noinline function f13432c(x)
+    offset = x ? Base.Bottom : 1
+    # Barrier for inference, so the optimizer cannot optimize this,
+    # but codegen can still see this is a constant
+    return ===(offset, Base.inferencebarrier(Base.Bottom))
+end
+@test f13432c(true) == true
+@test f13432c(false) == false
 
 #13433, read!(::IO, a::Vector{UInt8}) should return a
 mutable struct IO13433 <: IO end


### PR DESCRIPTION
The test for #13432 is supposed to test a particular codegen path involving Bottom. It turns out that this code path is regressed on master, but hidden by the fact that in modern julia, the optimizer can fold this code path early. Fix the bug and add a variant of the test that shows the issue on julia master. Note that this is both an assertion failure and incorrect codegen. This PR addresses both.