### PR TITLE
TOML: Make `Dates` a type parameter

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -268,7 +268,11 @@ struct TOMLCache{Dates}
     p::TOML.Parser{Dates}
     d::Dict{String, CachedTOMLDict}
 end
-const TOML_CACHE = TOMLCache(TOML.Parser{nothing}(), Dict{String, CachedTOMLDict}())
+TOMLCache(p::TOML.Parser) = TOMLCache(p, Dict{String, CachedTOMLDict}())
+# TODO: Delete this converting constructor once Pkg stops using it
+TOMLCache(p::TOML.Parser, d::Dict{String, Dict{String, Any}}) = TOMLCache(p, convert(Dict{String, CachedTOMLDict}, d))
+
+const TOML_CACHE = TOMLCache(TOML.Parser{nothing}())
 
 parsed_toml(project_file::AbstractString) = parsed_toml(project_file, TOML_CACHE, require_lock)
 function parsed_toml(project_file::AbstractString, toml_cache::TOMLCache, toml_lock::ReentrantLock)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -264,11 +264,11 @@ const LOADING_CACHE = Ref{Union{LoadingCache, Nothing}}(nothing)
 LoadingCache() = LoadingCache(load_path(), Dict(), Dict(), Dict(), Set(), Dict(), Dict(), Dict())
 
 
-struct TOMLCache
-    p::TOML.Parser
+struct TOMLCache{Dates}
+    p::TOML.Parser{Dates}
     d::Dict{String, CachedTOMLDict}
 end
-const TOML_CACHE = TOMLCache(TOML.Parser(), Dict{String, Dict{String, Any}}())
+const TOML_CACHE = TOMLCache(TOML.Parser(), Dict{String, CachedTOMLDict}())
 
 parsed_toml(project_file::AbstractString) = parsed_toml(project_file, TOML_CACHE, require_lock)
 function parsed_toml(project_file::AbstractString, toml_cache::TOMLCache, toml_lock::ReentrantLock)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -268,7 +268,7 @@ struct TOMLCache{Dates}
     p::TOML.Parser{Dates}
     d::Dict{String, CachedTOMLDict}
 end
-const TOML_CACHE = TOMLCache(TOML.Parser(), Dict{String, CachedTOMLDict}())
+const TOML_CACHE = TOMLCache(TOML.Parser{nothing}(), Dict{String, CachedTOMLDict}())
 
 parsed_toml(project_file::AbstractString) = parsed_toml(project_file, TOML_CACHE, require_lock)
 function parsed_toml(project_file::AbstractString, toml_cache::TOMLCache, toml_lock::ReentrantLock)

--- a/stdlib/REPL/src/Pkg_beforeload.jl
+++ b/stdlib/REPL/src/Pkg_beforeload.jl
@@ -71,7 +71,9 @@ end
 function projname(project_file::String)
     if isfile(project_file)
         name = try
-            p = Base.TOML.Parser()
+            # The `nothing` here means that this TOML parser does not return proper Dates.jl
+            # objects - but that's OK since we're just checking the name here.
+            p = Base.TOML.Parser{nothing}()
             Base.TOML.reinit!(p, read(project_file, String); filepath=project_file)
             proj = Base.TOML.parse(p)
             get(proj, "name", nothing)

--- a/stdlib/TOML/src/TOML.jl
+++ b/stdlib/TOML/src/TOML.jl
@@ -44,8 +44,7 @@ const Parser = Internals.Parser
 Constructor for a TOML `Parser` which returns date and time objects from Dates.
 """
 function DTParser(args...; kwargs...)
-    parser = Parser(args...; kwargs...)
-    parser.Dates = Dates
+    parser = Parser{Dates}(args...; kwargs...)
     return parser
 end
 

--- a/stdlib/TOML/src/TOML.jl
+++ b/stdlib/TOML/src/TOML.jl
@@ -38,15 +38,10 @@ performance if a larger number of small files are parsed.
 """
 const Parser = Internals.Parser
 
-"""
-    DTParser()
-
-Constructor for a TOML `Parser` which returns date and time objects from Dates.
-"""
-function DTParser(args...; kwargs...)
-    parser = Parser{Dates}(args...; kwargs...)
-    return parser
-end
+# Dates-enabled constructors
+Parser() = Parser{Dates}()
+Parser(io::IO) = Parser{Dates}(io)
+Parser(str::String; filepath=nothing) = Parser{Dates}(str; filepath)
 
 """
     parsefile(f::AbstractString)
@@ -58,7 +53,7 @@ Parse file `f` and return the resulting table (dictionary). Throw a
 See also [`TOML.tryparsefile`](@ref).
 """
 parsefile(f::AbstractString) =
-    Internals.parse(DTParser(readstring(f); filepath=abspath(f)))
+    Internals.parse(Parser(readstring(f); filepath=abspath(f)))
 parsefile(p::Parser, f::AbstractString) =
     Internals.parse(Internals.reinit!(p, readstring(f); filepath=abspath(f)))
 
@@ -72,7 +67,7 @@ Parse file `f` and return the resulting table (dictionary). Return a
 See also [`TOML.parsefile`](@ref).
 """
 tryparsefile(f::AbstractString) =
-    Internals.tryparse(DTParser(readstring(f); filepath=abspath(f)))
+    Internals.tryparse(Parser(readstring(f); filepath=abspath(f)))
 tryparsefile(p::Parser, f::AbstractString) =
     Internals.tryparse(Internals.reinit!(p, readstring(f); filepath=abspath(f)))
 
@@ -86,7 +81,7 @@ Throw a [`ParserError`](@ref) upon failure.
 See also [`TOML.tryparse`](@ref).
 """
 parse(str::AbstractString) =
-    Internals.parse(DTParser(String(str)))
+    Internals.parse(Parser(String(str)))
 parse(p::Parser, str::AbstractString) =
     Internals.parse(Internals.reinit!(p, String(str)))
 parse(io::IO) = parse(read(io, String))
@@ -102,7 +97,7 @@ Return a [`ParserError`](@ref) upon failure.
 See also [`TOML.parse`](@ref).
 """
 tryparse(str::AbstractString) =
-    Internals.tryparse(DTParser(String(str)))
+    Internals.tryparse(Parser(String(str)))
 tryparse(p::Parser, str::AbstractString) =
     Internals.tryparse(Internals.reinit!(p, String(str)))
 tryparse(io::IO) = tryparse(read(io, String))


### PR DESCRIPTION
This will allow us to resolve the `Dates` at compile-time eventually. It also fixes `TOML.Parser()` to return Dates types again.

The plan is to land:
1. This PR
2. https://github.com/JuliaLang/Pkg.jl/pull/3938
3. https://github.com/JuliaLang/julia/pull/55016

~This is a breaking change for anyone who was using the internal `Dates` support downstream, but then again so was https://github.com/JuliaLang/julia/pull/54755/~