### PR TITLE
TOML: Return `Dates` objects by default, even for explicit `Parser`

### DIFF
--- a/stdlib/TOML/src/TOML.jl
+++ b/stdlib/TOML/src/TOML.jl
@@ -36,15 +36,8 @@ explicitly create a `Parser` but instead one directly use use
 will however reuse some internal data structures which can be beneficial for
 performance if a larger number of small files are parsed.
 """
-const Parser = Internals.Parser
-
-"""
-    DTParser()
-
-Constructor for a TOML `Parser` which returns date and time objects from Dates.
-"""
-function DTParser(args...; kwargs...)
-    parser = Parser(args...; kwargs...)
+function Parser(args...; kwargs...)
+    parser = Internals.Parser(args...; kwargs...)
     parser.Dates = Dates
     return parser
 end
@@ -59,8 +52,8 @@ Parse file `f` and return the resulting table (dictionary). Throw a
 See also [`TOML.tryparsefile`](@ref).
 """
 parsefile(f::AbstractString) =
-    Internals.parse(DTParser(readstring(f); filepath=abspath(f)))
-parsefile(p::Parser, f::AbstractString) =
+    Internals.parse(Parser(readstring(f); filepath=abspath(f)))
+parsefile(p::Internals.Parser, f::AbstractString) =
     Internals.parse(Internals.reinit!(p, readstring(f); filepath=abspath(f)))
 
 """
@@ -73,8 +66,8 @@ Parse file `f` and return the resulting table (dictionary). Return a
 See also [`TOML.parsefile`](@ref).
 """
 tryparsefile(f::AbstractString) =
-    Internals.tryparse(DTParser(readstring(f); filepath=abspath(f)))
-tryparsefile(p::Parser, f::AbstractString) =
+    Internals.tryparse(Parser(readstring(f); filepath=abspath(f)))
+tryparsefile(p::Internals.Parser, f::AbstractString) =
     Internals.tryparse(Internals.reinit!(p, readstring(f); filepath=abspath(f)))
 
 """
@@ -87,11 +80,11 @@ Throw a [`ParserError`](@ref) upon failure.
 See also [`TOML.tryparse`](@ref).
 """
 parse(str::AbstractString) =
-    Internals.parse(DTParser(String(str)))
-parse(p::Parser, str::AbstractString) =
+    Internals.parse(Parser(String(str)))
+parse(p::Internals.Parser, str::AbstractString) =
     Internals.parse(Internals.reinit!(p, String(str)))
 parse(io::IO) = parse(read(io, String))
-parse(p::Parser, io::IO) = parse(p, read(io, String))
+parse(p::Internals.Parser, io::IO) = parse(p, read(io, String))
 
 """
     tryparse(x::Union{AbstractString, IO})
@@ -103,11 +96,11 @@ Return a [`ParserError`](@ref) upon failure.
 See also [`TOML.parse`](@ref).
 """
 tryparse(str::AbstractString) =
-    Internals.tryparse(DTParser(String(str)))
-tryparse(p::Parser, str::AbstractString) =
+    Internals.tryparse(Parser(String(str)))
+tryparse(p::Internals.Parser, str::AbstractString) =
     Internals.tryparse(Internals.reinit!(p, String(str)))
 tryparse(io::IO) = tryparse(read(io, String))
-tryparse(p::Parser, io::IO) = tryparse(p, read(io, String))
+tryparse(p::Internals.Parser, io::IO) = tryparse(p, read(io, String))
 
 """
     ParserError

--- a/stdlib/TOML/test/values.jl
+++ b/stdlib/TOML/test/values.jl
@@ -4,16 +4,29 @@ using Test
 using TOML
 using TOML: Internals
 
+# Construct an explicit Parser to test the "cached" version of parsing
+const test_parser = TOML.Parser()
+
 function testval(s, v)
     f = "foo = $s"
+    # First, test with the standard entrypoint
     parsed = TOML.parse(f)["foo"]
-    return isequal(v, parsed) && typeof(v) == typeof(parsed)
+    (!isequal(v, parsed) || typeof(v) != typeof(parsed)) && return false
+    # Next, test with the "cached" (explicit Parser) entrypoint
+    parsed = TOML.parse(test_parser, f)["foo"]
+    (!isequal(v, parsed) || typeof(v) != typeof(parsed)) && return false
+    return true
 end
 
 function failval(s, v)
     f = "foo = $s"
+    # First, test with the standard entrypoint
     err = TOML.tryparse(f);
-    return err isa TOML.Internals.ParserError && err.type == v
+    (!isa(err, TOML.Internals.ParserError) || err.type != v) && return false
+    # Next, test with the "cached" (explicit Parser) entrypoint
+    err = TOML.tryparse(test_parser, f);
+    (!isa(err, TOML.Internals.ParserError) || err.type != v) && return false
+    return true
 end
 
 @testset "Numbers" begin


### PR DESCRIPTION
The doc-comment here strongly suggests this was intended to be a public interface (although not the most frequently used one), so this tries a bit harder to avoid breaking the Dates-related behavior here.

This removes `DTParser`, which effectively behaved the way the existing `Parser()` behaved before https://github.com/JuliaLang/julia/pull/54755

As a side effect, this hides the `Base.TOML.Parser` type out of the way the public API.