### PR TITLE
remove stale collect/interval field from GC_Num

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -12,7 +12,6 @@ struct GC_Num
     freecall        ::Int64
     total_time      ::Int64
     total_allocd    ::Int64 # GC internal
-    collect         ::Csize_t # GC internal
     pause           ::Cint
     full_sweep      ::Cint
     max_pause       ::Int64

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -841,25 +841,25 @@ void gc_time_sweep_pause(uint64_t gc_end_t, int64_t actual_allocd,
 }
 
 void gc_time_summary(int sweep_full, uint64_t start, uint64_t end,
-                     uint64_t freed, uint64_t live, uint64_t interval,
+                     uint64_t freed, uint64_t live,
                      uint64_t pause, uint64_t ttsp, uint64_t mark,
                      uint64_t sweep)
 {
     if (sweep_full > 0)
         jl_safe_printf("TS: %" PRIu64 " Major collection: estimate freed = %" PRIu64
-                       " live = %" PRIu64 "m new interval = %" PRIu64
+                       " live = %" PRIu64
                        "m time = %" PRIu64 "ms ttsp = %" PRIu64 "us mark time = %"
                        PRIu64 "ms sweep time = %" PRIu64 "ms \n",
                        end, freed, live/1024/1024,
-                       interval/1024/1024, pause/1000000, ttsp,
+                       pause/1000000, ttsp,
                        mark/1000000,sweep/1000000);
     else
         jl_safe_printf("TS: %" PRIu64 " Minor collection: estimate freed = %" PRIu64
-                       " live = %" PRIu64 "m new interval = %" PRIu64 "m pause time = %"
+                       " live = %" PRIu64 "m pause time = %"
                        PRIu64 "ms ttsp = %" PRIu64 "us mark time = %" PRIu64
                        "ms sweep time = %" PRIu64 "ms\n",
                        end, freed, live/1024/1024,
-                       interval/1024/1024, pause/1000000, ttsp,
+                       pause/1000000, ttsp,
                        mark/1000000,sweep/1000000);
 }
 

--- a/src/gc.h
+++ b/src/gc.h
@@ -74,7 +74,6 @@ typedef struct {
     uint64_t    freecall;
     uint64_t    total_time;
     uint64_t    total_allocd;
-    size_t      interval;
     int         pause;
     int         full_sweep;
     uint64_t    max_pause;
@@ -616,7 +615,7 @@ void gc_time_sweep_pause(uint64_t gc_end_t, int64_t actual_allocd,
                          int64_t live_bytes, int64_t estimate_freed,
                          int sweep_full);
 void gc_time_summary(int sweep_full, uint64_t start, uint64_t end,
-                     uint64_t freed, uint64_t live, uint64_t interval,
+                     uint64_t freed, uint64_t live,
                      uint64_t pause, uint64_t ttsp, uint64_t mark,
                      uint64_t sweep);
 void gc_heuristics_summary(
@@ -652,7 +651,7 @@ STATIC_INLINE void gc_time_count_mallocd_memory(int bits) JL_NOTSAFEPOINT
 #define gc_time_sweep_pause(gc_end_t, actual_allocd, live_bytes,        \
                             estimate_freed, sweep_full)
 #define  gc_time_summary(sweep_full, start, end, freed, live,           \
-                         interval, pause, ttsp, mark, sweep)
+                         pause, ttsp, mark, sweep)
 #define gc_heuristics_summary( \
         old_alloc_diff, alloc_mem, \
         old_mut_time, alloc_time, \


### PR DESCRIPTION
This is no longer used after we switched to page-based heuristics.

JuliaHub shows no use in packages: https://juliahub.com/ui/Search?type=symbols&q=gc_num.collect.