### PR TITLE
inference: don't infer const ABI for OpaqueClosure methods

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -225,7 +225,8 @@ function finish!(interp::AbstractInterpreter, caller::InferenceState;
         ci = result.ci
         inferred_result = nothing
         relocatability = 0x1
-        const_flag = is_result_constabi_eligible(result)
+        for_opaque_closure = isa(result.linfo.def, Method) && result.linfo.def.is_for_opaque_closure
+        const_flag = is_result_constabi_eligible(result) && !for_opaque_closure
         if !can_discard_trees || (is_cached(caller) && !const_flag)
             inferred_result = transform_result_for_cache(interp, result.linfo, result.valid_worlds, result, can_discard_trees)
             relocatability = 0x0
@@ -347,7 +348,7 @@ function maybe_compress_codeinfo(interp::AbstractInterpreter, mi::MethodInstance
     isa(def, Method) || return ci # don't compress toplevel code
     cache_the_tree = true
     if can_discard_trees
-        cache_the_tree = is_inlineable(ci) || isa_compileable_sig(mi.specTypes, mi.sparam_vals, def)
+        cache_the_tree = is_inlineable(ci) || isa_compileable_sig(mi.specTypes, mi.sparam_vals, def) || def.is_for_opaque_closure
     end
     if cache_the_tree
         if may_compress(interp)


### PR DESCRIPTION
This IR is always destined for compilation, so the const ABI for these methods is not really useful.

This resolves part of https://github.com/JuliaLang/julia/issues/54377

Specifically, this is fast now:
```julia
foo() = Base.Experimental.@opaque Tuple{Float64}->_ x -> 0.0
bar() = Base.Experimental.@opaque Tuple{Float64}->_ x -> x

const oc1 = foo()
const oc2 = bar()

using BenchmarkTools
@btime sum(oc1, 1.0:100.0) # PR: 197.571 ns (0 allocations: 0 bytes)
                           # (compare to master: 2.932 μs (200 allocations: 6.25 KiB))
@btime sum(oc2, 1.0:100.0) # PR / master: 208.488 ns (0 allocations: 0 bytes)
```

The original MWE with the `@opaque` at toplevel is unfortunately still slow, because it does not get generated at compile-time and `jl_new_opaque_closure` currently does a poor job of enforcing its desired ABI.