### PR TITLE
implement `sret_union` ABI for pointer-ful types

### DIFF
--- a/doc/src/devdocs/compiler.md
+++ b/doc/src/devdocs/compiler.md
@@ -36,16 +36,6 @@ determine how to assign or pass it somewhere.
 They are created via one of the helper constructors, usually:
 `mark_julia_type` (for immediate values) and `mark_julia_slot` (for pointers to values).
 
-The function `convert_julia_type` can transform between any two types.
-It returns an R-value with `cgval.typ` set to `typ`.
-It'll cast the object to the requested representation,
-making heap boxes, allocating stack copies, and computing tagged unions as
-needed to change the representation.
-
-By contrast `update_julia_type` will change `cgval.typ` to `typ`,
-only if it can be done at zero-cost (i.e. without emitting any code).
-
-
 ## Union representation
 
 Inferred union types may be stack allocated via a tagged type representation.

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -523,16 +523,33 @@ static const std::string make_errmsg(const char *fname, int n, const char *err)
     return msg.str();
 }
 
+// bitcast whatever Ptr kind x might be (even if it is part of a union) into Ptr{Cvoid}
+// given that the caller already had emit_cpointercheck on this branch, so that
+// the conversion is guaranteed to be valid on this runtiem branch
+static jl_cgval_t voidpointer_update(jl_codectx_t &ctx, const jl_cgval_t &x)
+{
+    if (x.typ == (jl_value_t*)jl_voidpointer_type)
+        return x;
+    if (jl_type_intersection(x.typ, (jl_value_t*)jl_pointer_type) == jl_bottom_type)
+        return jl_cgval_t();
+    if (x.constant)
+        return mark_julia_type(ctx, julia_const_to_llvm(ctx, x.constant), false, jl_voidpointer_type);
+    if (x.V == nullptr)
+        return jl_cgval_t();
+    if (!x.inline_roots.empty() || x.ispointer())
+        return mark_julia_slot(x.V, (jl_value_t*)jl_voidpointer_type, NULL, x.tbaa);
+    return mark_julia_type(ctx, x.V, false, jl_voidpointer_type);
+}
+
 static jl_cgval_t typeassert_input(jl_codectx_t &ctx, const jl_cgval_t &jvinfo, jl_value_t *jlto, jl_unionall_t *jlto_env, int argn)
 {
     if (jlto != (jl_value_t*)jl_any_type && !jl_subtype(jvinfo.typ, jlto)) {
         if (jlto == (jl_value_t*)jl_voidpointer_type) {
             // allow a bit more flexibility for what can be passed to (void*) due to Ref{T} conversion behavior in input
-            if (!jl_is_cpointer_type(jvinfo.typ)) {
+            if (!jl_is_cpointer_type(jvinfo.typ))
                 // emit a typecheck, if not statically known to be correct
                 emit_cpointercheck(ctx, jvinfo, make_errmsg("ccall", argn + 1, ""));
-                return update_julia_type(ctx, jvinfo, (jl_value_t*)jl_pointer_type);
-            }
+            return voidpointer_update(ctx, jvinfo);
         }
         else {
             // emit a typecheck, if not statically known to be correct
@@ -581,7 +598,7 @@ static Value *julia_to_native(
 
     jvinfo = typeassert_input(ctx, jvinfo, jlto, jlto_env, argn);
     if (!byRef)
-        return emit_unbox(ctx, to, jvinfo, jlto);
+        return emit_unbox(ctx, to, jvinfo);
 
     // pass the address of an alloca'd thing, not a box
     // since those are immutable.
@@ -740,8 +757,7 @@ static void interpret_ccall_symbol_arg(jl_codectx_t &ctx, native_sym_arg_t &out,
             const char *errmsg = "ccall: first argument not a pointer or valid constant expression";
             emit_cpointercheck(ctx, arg1, errmsg);
         }
-        arg1 = update_julia_type(ctx, arg1, (jl_value_t*)jl_voidpointer_type);
-        out.jl_ptr = emit_unbox(ctx, ctx.types().T_ptr, arg1, (jl_value_t*)jl_voidpointer_type);
+        out.jl_ptr = emit_unbox(ctx, ctx.types().T_ptr, voidpointer_update(ctx, arg1));
     }
 
     // Handle Julia internal symbol lookup for static function names
@@ -804,8 +820,7 @@ static jl_cgval_t emit_cglobal(jl_codectx_t &ctx, jl_value_t **args, size_t narg
             argv[1] = emit_expr(ctx, args[2]);
         if (!jl_is_cpointer_type(argv[0].typ))
             return emit_runtime_call(ctx, nargs == 1 ? JL_I::cglobal_auto : JL_I::cglobal, argv, nargs);
-        argv[0] = update_julia_type(ctx, argv[0], (jl_value_t*)jl_voidpointer_type);
-        sym.jl_ptr = emit_unbox(ctx, ctx.types().T_ptr, argv[0], (jl_value_t*)jl_voidpointer_type);
+        sym.jl_ptr = emit_unbox(ctx, ctx.types().T_ptr, voidpointer_update(ctx, argv[0]));
         res = sym.jl_ptr;
     }
 
@@ -1668,8 +1683,11 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
             retval = boxed(ctx, argv[0]);
             retval = emit_pointer_from_objref(ctx, retval /*T_prjlvalue*/);
         }
+        else if (tti == (jl_value_t*)jl_voidpointer_type) {
+            retval = emit_unbox(ctx, largty, voidpointer_update(ctx, argv[0]));
+        }
         else {
-            retval = emit_unbox(ctx, largty, argv[0], tti);
+            retval = emit_unbox(ctx, largty, update_julia_type(ctx, argv[0], tti));
         }
         // retval is now an untracked jl_value_t*
         if (retboxed)
@@ -1788,7 +1806,7 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         const int rng_offset = offsetof(jl_tls_states_t, rngseed);
         Value *rng_ptr = ctx.builder.CreateInBoundsGEP(getInt8Ty(ctx.builder.getContext()), ptls_p, ConstantInt::get(ctx.types().T_size, rng_offset / sizeof(int8_t)));
         setName(ctx.emission_context, rng_ptr, "rngseed_ptr");
-        Value *val64 = emit_unbox(ctx, getInt64Ty(ctx.builder.getContext()), argv[0], (jl_value_t*)jl_uint64_type);
+        Value *val64 = emit_unbox(ctx, getInt64Ty(ctx.builder.getContext()), update_julia_type(ctx, argv[0], (jl_value_t*)jl_uint64_type));
         auto store = ctx.builder.CreateAlignedStore(val64, rng_ptr, Align(sizeof(void*)));
         jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe);
         ai.decorateInst(store);
@@ -1962,14 +1980,13 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         const jl_cgval_t &dst = argv[0];
         const jl_cgval_t &src = argv[1];
         const jl_cgval_t &n = argv[2];
-        Value *destp = emit_unbox(ctx, ctx.types().T_ptr, dst, (jl_value_t*)jl_voidpointer_type);
-
+        Value *destp = emit_unbox(ctx, ctx.types().T_ptr, voidpointer_update(ctx, dst));
         ctx.builder.CreateMemCpy(
                 destp,
                 MaybeAlign(1),
-                emit_unbox(ctx, ctx.types().T_ptr, src, (jl_value_t*)jl_voidpointer_type),
+                emit_unbox(ctx, ctx.types().T_ptr, voidpointer_update(ctx, src)),
                 MaybeAlign(1),
-                emit_unbox(ctx, ctx.types().T_size, n, (jl_value_t*)jl_ulong_type),
+                emit_unbox(ctx, ctx.types().T_size, update_julia_type(ctx, n, (jl_value_t*)jl_ulong_type)),
                 false);
         JL_GC_POP();
         return rt == (jl_value_t*)jl_nothing_type ? ghostValue(ctx, jl_nothing_type) :
@@ -1980,13 +1997,13 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         const jl_cgval_t &dst = argv[0];
         const jl_cgval_t &val = argv[1];
         const jl_cgval_t &n = argv[2];
-        Value *destp = emit_unbox(ctx, ctx.types().T_ptr, dst, (jl_value_t*)jl_voidpointer_type);
-        Value *val32 = emit_unbox(ctx, getInt32Ty(ctx.builder.getContext()), val, (jl_value_t*)jl_uint32_type);
+        Value *destp = emit_unbox(ctx, ctx.types().T_ptr, voidpointer_update(ctx, dst));
+        Value *val32 = emit_unbox(ctx, getInt32Ty(ctx.builder.getContext()), update_julia_type(ctx, val, (jl_value_t*)jl_int32_type));
         Value *val8 = ctx.builder.CreateTrunc(val32, getInt8Ty(ctx.builder.getContext()), "memset_val");
         ctx.builder.CreateMemSet(
             destp,
             val8,
-            emit_unbox(ctx, ctx.types().T_size, n, (jl_value_t*)jl_ulong_type),
+            emit_unbox(ctx, ctx.types().T_size, update_julia_type(ctx, n, (jl_value_t*)jl_ulong_type)),
             MaybeAlign(1)
         );
         JL_GC_POP();
@@ -1998,14 +2015,14 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         const jl_cgval_t &dst = argv[0];
         const jl_cgval_t &src = argv[1];
         const jl_cgval_t &n = argv[2];
-        Value *destp = emit_unbox(ctx, ctx.types().T_ptr, dst, (jl_value_t*)jl_voidpointer_type);
+        Value *destp = emit_unbox(ctx, ctx.types().T_ptr, voidpointer_update(ctx, dst));
 
         ctx.builder.CreateMemMove(
                 destp,
                 MaybeAlign(0),
-                emit_unbox(ctx, ctx.types().T_ptr, src, (jl_value_t*)jl_voidpointer_type),
+                emit_unbox(ctx, ctx.types().T_ptr, update_julia_type(ctx, src, (jl_value_t*)jl_voidpointer_type)),
                 MaybeAlign(0),
-                emit_unbox(ctx, ctx.types().T_size, n, (jl_value_t*)jl_ulong_type),
+                emit_unbox(ctx, ctx.types().T_size, update_julia_type(ctx, n, (jl_value_t*)jl_ulong_type)),
                 false);
         JL_GC_POP();
         return rt == (jl_value_t*)jl_nothing_type ? ghostValue(ctx, jl_nothing_type) :
@@ -2099,8 +2116,7 @@ jl_cgval_t function_sig_t::emit_a_ccall(
         if (jl_is_abstract_ref_type(jargty)) {
             if (!jl_is_cpointer_type(arg.typ)) {
                 emit_cpointercheck(ctx, arg, "ccall: argument to Ref{T} is not a pointer");
-                arg.typ = (jl_value_t*)jl_voidpointer_type;
-                arg.isboxed = false;
+                arg = voidpointer_update(ctx, arg);
             }
             jargty_in_env = (jl_value_t*)jl_voidpointer_type;
         }

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -525,7 +525,7 @@ static const std::string make_errmsg(const char *fname, int n, const char *err)
 
 // bitcast whatever Ptr kind x might be (even if it is part of a union) into Ptr{Cvoid}
 // given that the caller already had emit_cpointercheck on this branch, so that
-// the conversion is guaranteed to be valid on this runtiem branch
+// the conversion is guaranteed to be valid on this runtime branch
 static jl_cgval_t voidpointer_update(jl_codectx_t &ctx, const jl_cgval_t &x)
 {
     if (x.typ == (jl_value_t*)jl_voidpointer_type)

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -340,6 +340,20 @@ static void find_perm_offsets(jl_datatype_t *typ, SmallVectorImpl<unsigned> &res
     }
 }
 
+static llvm::SmallVector<Value*,0> extract_gc_roots(jl_codectx_t &ctx, Value *data_pointer, jl_datatype_t *typ, size_t npointers, MDNode *tbaa, bool isVolatile=false)
+{
+    SmallVector<Value*,0> gcroots(npointers);
+    Type *T_prjlvalue = ctx.types().T_prjlvalue;
+    auto roots_ai = jl_aliasinfo_t::fromTBAA(ctx, tbaa);
+    for (size_t i = 0; i < npointers; i++) {
+        Value *field_ptr = emit_ptrgep(ctx, data_pointer, jl_ptr_offset(typ, i) * sizeof(jl_value_t*));
+        Instruction *root = ctx.builder.CreateAlignedLoad(T_prjlvalue, field_ptr, Align(sizeof(void*)), isVolatile);
+        roots_ai.decorateInst(root);
+        gcroots[i] = root;
+    }
+    return gcroots;
+}
+
 // load a pointer to N inlined_roots into registers (as a SmallVector)
 static llvm::SmallVector<Value*,0> load_gc_roots(jl_codectx_t &ctx, Value *inline_roots_ptr, size_t npointers, MDNode *tbaa, bool isVolatile=false)
 {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -300,7 +300,7 @@ static Value *emit_pointer_from_objref(jl_codectx_t &ctx, Value *V)
     return Call;
 }
 
-static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x, jl_value_t *jt);
+static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x);
 static void emit_unbox_store(jl_codectx_t &ctx, const jl_cgval_t &x, Value* dest, MDNode *tbaa_dest, MaybeAlign align_src, Align align_dst, bool isVolatile=false);
 
 static bool type_is_permalloc(jl_value_t *typ)
@@ -378,7 +378,7 @@ static llvm::SmallVector<Value*,0> get_gc_roots_for(jl_codectx_t &ctx, const jl_
     else if (jl_is_concrete_immutable(x.typ) && !jl_is_pointerfree(x.typ)) {
         jl_value_t *jltype = x.typ;
         Type *T = julia_type_to_llvm(ctx, jltype);
-        Value *agg = emit_unbox(ctx, T, x, jltype);
+        Value *agg = emit_unbox(ctx, T, x);
         SmallVector<unsigned,4> perm_offsets;
         find_perm_offsets((jl_datatype_t*)jltype, perm_offsets, 0);
         return ExtractTrackedValues(agg, agg->getType(), false, ctx.builder, perm_offsets);
@@ -2380,7 +2380,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             r = ctx.builder.CreateLoad(realelty, intcast);
         }
         else if (aliasscope || Order != AtomicOrdering::NotAtomic || (tracked_pointers && rhs.inline_roots.empty())) {
-            r = emit_unbox(ctx, realelty, rhs, jltype);
+            r = emit_unbox(ctx, realelty, rhs);
         }
         if (realelty != elty)
             r = ctx.builder.CreateZExt(r, elty);
@@ -2451,7 +2451,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             // if this value can be loaded from memory, do that now so that it is sequenced before the atomicmodify
             // and the IR is less dependent on what was emitted before now to create this rhs.
             // Inlining should do okay to clean this up later if there are parts we don't need.
-            rhs = jl_cgval_t(emit_unbox(ctx, julia_type_to_llvm(ctx, rhs.typ), rhs, rhs.typ), rhs.typ, NULL);
+            rhs = jl_cgval_t(emit_unbox(ctx, julia_type_to_llvm(ctx, rhs.typ), rhs), rhs.typ, NULL);
         }
         bool gcstack_arg = JL_FEAT_TEST(ctx,gcstack_arg);
         Function *op = emit_modifyhelper(ctx, cmpop, *modifyop, jltype, elty, rhs, fname, gcstack_arg);
@@ -2522,7 +2522,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
                     Compare = ctx.builder.CreateLoad(realelty, intcast);
                 }
                 else {
-                    Compare = emit_unbox(ctx, realelty, cmpop, jltype);
+                    Compare = emit_unbox(ctx, realelty, cmpop);
                 }
                 if (realelty != elty)
                     Compare = ctx.builder.CreateZExt(Compare, elty);
@@ -2595,7 +2595,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
                     ctx.builder.CreateStore(realCompare, intcast);
             }
             else if (Order != AtomicOrdering::NotAtomic || (tracked_pointers && rhs.inline_roots.empty())) {
-                r = emit_unbox(ctx, realelty, rhs, jltype);
+                r = emit_unbox(ctx, realelty, rhs);
             }
             if (realelty != elty)
                 r = ctx.builder.CreateZExt(r, elty);
@@ -2726,7 +2726,7 @@ static jl_cgval_t typed_store(jl_codectx_t &ctx,
             else if (!isboxed && intcast_eltyp) {
                 assert(issetfield);
                 // issetfield doesn't use intcast, so need to reload rhs with the correct type
-                r = emit_unbox(ctx, intcast_eltyp, rhs, jltype);
+                r = emit_unbox(ctx, intcast_eltyp, rhs);
             }
             if (!isboxed)
                 emit_write_multibarrier(ctx, parent, r, rhs.typ);
@@ -3532,7 +3532,7 @@ static Value *call_with_attrs(jl_codectx_t &ctx, JuliaFunction<TypeFn_t> *intr, 
 static Value *as_value(jl_codectx_t &ctx, Type *to, const jl_cgval_t &v)
 {
     assert(!v.isboxed);
-    return emit_unbox(ctx, to, v, v.typ);
+    return emit_unbox(ctx, to, v);
 }
 
 static Value *load_i8box(jl_codectx_t &ctx, Value *v, jl_datatype_t *ty)
@@ -4385,7 +4385,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                         cast<Instruction>(fval_info.V)->eraseFromParent();
                     }
                     else if (init_as_value) {
-                        fval = emit_unbox(ctx, fty, fval_info, jtype);
+                        fval = emit_unbox(ctx, fty, fval_info);
                     }
                     else {
                         split_value_into(ctx, fval_info, align_src, dest, align_dst, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack), false, roots);
@@ -4635,7 +4635,7 @@ static jl_cgval_t emit_memorynew(jl_codectx_t &ctx, jl_datatype_t *typ, jl_cgval
     emptymemBB = BasicBlock::Create(ctx.builder.getContext(), "emptymem");
     nonemptymemBB = BasicBlock::Create(ctx.builder.getContext(), "nonemptymem");
     retvalBB = BasicBlock::Create(ctx.builder.getContext(), "retval");
-    auto nel_unboxed = emit_unbox(ctx, ctx.types().T_size, nel, (jl_value_t*)jl_long_type);
+    auto nel_unboxed = emit_unbox(ctx, ctx.types().T_size, nel);
     Value *memorynew_empty = ctx.builder.CreateICmpEQ(nel_unboxed, ConstantInt::get(T_size, 0));
     setName(ctx.emission_context, memorynew_empty, "memorynew_empty");
     ctx.builder.CreateCondBr(memorynew_empty, emptymemBB, nonemptymemBB);
@@ -4722,7 +4722,11 @@ static jl_cgval_t emit_memoryref_direct(jl_codectx_t &ctx, const jl_cgval_t &mem
     bool isunion = layout->flags.arrayelem_isunion;
     bool isghost = layout->size == 0;
     Value *boxmem = boxed(ctx, mem);
-    Value *i = emit_unbox(ctx, ctx.types().T_size, idx, (jl_value_t*)jl_long_type);
+    emit_typecheck(ctx, idx, (jl_value_t*)jl_long_type, "memoryrefnew");
+    idx = update_julia_type(ctx, idx, (jl_value_t*)jl_long_type);
+    if (idx.typ == jl_bottom_type)
+        return jl_cgval_t();
+    Value *i = emit_unbox(ctx, ctx.types().T_size, idx);
     Value *idx0 = ctx.builder.CreateSub(i, ConstantInt::get(ctx.types().T_size, 1));
     bool bc = bounds_check_enabled(ctx, inbounds);
     if (bc) {
@@ -4796,7 +4800,7 @@ static jl_cgval_t emit_memoryref(jl_codectx_t &ctx, const jl_cgval_t &ref, jl_cg
     maybeSetName(ctx.emission_context, data, "memoryref_data");
     Value *mem = CreateSimplifiedExtractValue(ctx, V, 1);
     maybeSetName(ctx.emission_context, mem, "memoryref_mem");
-    Value *i = emit_unbox(ctx, ctx.types().T_size, idx, (jl_value_t*)jl_long_type);
+    Value *i = emit_unbox(ctx, ctx.types().T_size, idx);
     Value *offset = ctx.builder.CreateSub(i, ConstantInt::get(ctx.types().T_size, 1));
     setName(ctx.emission_context, offset, "memoryref_offset");
     Value *elsz = emit_genericmemoryelsize(ctx, mem, ref.typ, false);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -934,7 +934,7 @@ static bool for_each_uniontype_small(
     else if (ty == (jl_value_t*)jl_typeofbottom_type->super) {
         f(++counter, jl_typeofbottom_type); // treat Tuple{union{}} as identical to typeof(Union{})
     }
-    else if (jl_is_pointerfree(ty)) {
+    else if (!deserves_unionbox(ty)) {
         f(++counter, (jl_datatype_t*)ty);
         return true;
     }
@@ -1281,6 +1281,22 @@ static void recombine_value(jl_codectx_t &ctx, const jl_cgval_t &x, Value *dst, 
             src_off = dst_off;
         }
     }
+}
+
+static void emit_sret_roots(jl_codectx_t &ctx, bool isptr, Value *Src, Type *T, Value *Shadow, Type *ShadowT, unsigned count)
+{
+    assert(T != NULL);
+    unsigned emitted = TrackWithShadow(Src, T, isptr, Shadow, ShadowT, ctx.builder); //This comes from Late-GC-Lowering??
+    if (emitted < count) {
+        Value *ToZero = ctx.builder.CreateConstInBoundsGEP1_32(
+            ctx.types().T_prjlvalue, Shadow, emitted);
+        ctx.builder.CreateMemSet(ToZero,
+            /* Val */ ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0),
+            /* Size */ ConstantInt::get(ctx.types().T_size, (count - emitted) * sizeof(jl_value_t *)),
+            /* Align */ Align(sizeof(jl_value_t *)));
+        emitted += count - emitted;
+    }
+    assert(emitted <= count); (void)emitted; (void)count;
 }
 
 static Value *emit_tagfrom(jl_codectx_t &ctx, jl_datatype_t *dt)
@@ -3644,11 +3660,12 @@ static Value *compute_tindex_unboxed(jl_codectx_t &ctx, const jl_cgval_t &val, j
 
 
 static void union_alloca_type(jl_uniontype_t *ut,
-        bool &allunbox, size_t &nbytes, size_t &align, size_t &min_align)
+        bool &allunbox, size_t &nbytes, size_t &align, size_t &min_align, size_t &return_roots)
 {
     nbytes = 0;
     align = 0;
     min_align = MAX_ALIGN;
+    return_roots = 0;
     // compute the size of the union alloca that could hold this type
     unsigned counter = 0;
     allunbox = for_each_uniontype_small(
@@ -3656,12 +3673,15 @@ static void union_alloca_type(jl_uniontype_t *ut,
                 if (!jl_is_datatype_singleton(jt)) {
                     size_t nb1 = jl_datatype_size(jt);
                     size_t align1 = julia_alignment((jl_value_t*)jt);
+                    size_t n_roots = jl_datatype_layout(jt)->npointers;
                     if (nb1 > nbytes)
                         nbytes = nb1;
                     if (align1 > align)
                         align = align1;
                     if (align1 < min_align)
                         min_align = align1;
+                    if (n_roots > return_roots)
+                        return_roots = n_roots;
                 }
             },
             (jl_value_t*)ut,
@@ -3670,17 +3690,24 @@ static void union_alloca_type(jl_uniontype_t *ut,
         align = JL_HEAP_ALIGNMENT;
 }
 
-static AllocaInst *try_emit_union_alloca(jl_codectx_t &ctx, jl_uniontype_t *ut, bool &allunbox, size_t &min_align, size_t &nbytes)
+static AllocaInst *try_emit_union_alloca(jl_codectx_t &ctx, jl_uniontype_t *ut, bool &allunbox, size_t &min_align, size_t &nbytes, /* TODO: remove */bool require_pointerfree, const char *name)
 {
-    size_t align;
-    union_alloca_type(ut, allunbox, nbytes, align, min_align);
-    if (nbytes > 0) {
+    size_t align, return_roots;
+    union_alloca_type(ut, allunbox, nbytes, align, min_align, return_roots);
+    if (nbytes > 0 && !(require_pointerfree && return_roots != 0)) {
         // at least some of the values can live on the stack
         assert(align % min_align == 0);
         AllocaInst *lv = emit_static_alloca(ctx, nbytes, Align(align));
-        setName(ctx.emission_context, lv, "unionalloca");
+        setName(ctx.emission_context, lv, name);
+        if (return_roots > 0) {
+            StoreInst *SI = new StoreInst(Constant::getNullValue(AT), lv, false, Align(sizeof(void*)));
+            SI->insertAfter(ctx.topalloca);
+        }
         return lv;
     }
+    allunbox = false;
+    nbytes = 0;
+    min_align = 0;
     return NULL;
 }
 
@@ -3893,7 +3920,8 @@ static Value *boxed(jl_codectx_t &ctx, const jl_cgval_t &vinfo, bool is_promotab
 }
 
 // copy src to dest, if src is justbits. if skip is true, the value of dest is undefined
-static void emit_unionmove(jl_codectx_t &ctx, Value *dest, MDNode *tbaa_dst, const jl_cgval_t &src, Value *skip, bool isVolatile=false)
+static void emit_unionmove(jl_codectx_t &ctx, Value *dest, jl_cgval_shadow_t *shadow,
+        MDNode *tbaa_dst, const jl_cgval_t &src, Value *skip, bool isVolatile=false)
 {
     if (AllocaInst *ai = dyn_cast<AllocaInst>(dest))
         // TODO: make this a lifetime_end & dereferenceable annotation?
@@ -3947,6 +3975,11 @@ static void emit_unionmove(jl_codectx_t &ctx, Value *dest, MDNode *tbaa_dst, con
                             ctx.builder.CreateUnreachable();
                             return;
                         } else {
+                            // Maybe assert here (TBD)
+                            if (shadow != nullptr && !jl_is_pointerfree((jl_value_t *)jt)) {
+                                Type *store_ty = julia_type_to_llvm(ctx, (jl_value_t *)jt);
+                                emit_sret_roots(ctx, /* isptr */ true, src_ptr, store_ty, shadow->value, shadow->typ, shadow->n_roots);
+                            }
                             emit_memcpy(ctx, dest, jl_aliasinfo_t::fromTBAA(ctx, tbaa_dst), src_ptr,
                                         jl_aliasinfo_t::fromTBAA(ctx, src.tbaa), nb, Align(alignment), Align(alignment), isVolatile);
                         }
@@ -3975,10 +4008,18 @@ static void emit_unionmove(jl_codectx_t &ctx, Value *dest, MDNode *tbaa_dst, con
     else {
         assert(src.isboxed && "expected boxed value for sizeof/alignment computation");
         emit_guarded_test(ctx, skip, nullptr, [&] {
-            Value *datatype = emit_typeof(ctx, src, false, false);
-            Value *copy_bytes = emit_datatype_size(ctx, datatype);
-            emit_memcpy(ctx, dest, jl_aliasinfo_t::fromTBAA(ctx, tbaa_dst), data_pointer(ctx, src),
-                        jl_aliasinfo_t::fromTBAA(ctx, src.tbaa), copy_bytes, Align(1), Align(1), isVolatile);
+            if (shadow == nullptr) {
+                Value *datatype = emit_typeof(ctx, src, false, false);
+                Value *copy_bytes = emit_datatype_size(ctx, datatype);
+                emit_memcpy(ctx, dest, jl_aliasinfo_t::fromTBAA(ctx, tbaa_dst), data_pointer(ctx, src),
+                            jl_aliasinfo_t::fromTBAA(ctx, src.tbaa), copy_bytes, Align(1), Align(1), isVolatile);
+            } else {
+                Function *trap_func = Intrinsic::getDeclaration(
+                        ctx.f->getParent(),
+                        Intrinsic::trap);
+                ctx.builder.CreateCall(trap_func);
+                ctx.builder.CreateUnreachable();
+            }
             return nullptr;
         });
     }
@@ -4139,7 +4180,7 @@ static jl_cgval_t union_store(jl_codectx_t &ctx,
     ai.decorateInst(ctx.builder.CreateAlignedStore(tindex, ptindex, Align(1)));
     // copy data
     if (!rhs.isghost) {
-        emit_unionmove(ctx, ptr, tbaa, rhs, nullptr);
+        emit_unionmove(ctx, ptr, /*shadow*/nullptr, tbaa, rhs, /*skip*/nullptr);
     }
     if (isreplacefield || ismodifyfield) {
         ctx.builder.CreateBr(DoneBB);
@@ -4343,7 +4384,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                             assert(lt->getStructElementType(llvm_idx) == ET);
                             AllocaInst *lv = emit_static_alloca(ctx, fsz1, Align(al));
                             setName(ctx.emission_context, lv, "unioninit");
-                            emit_unionmove(ctx, lv, ctx.tbaa().tbaa_stack, fval_info, nullptr);
+                            emit_unionmove(ctx, lv, /* shadow */ nullptr, ctx.tbaa().tbaa_stack, fval_info, /* skip */ nullptr);
                             // emit all of the align-sized words
                             unsigned i = 0;
                             for (; i < fsz1 / al; i++) {
@@ -4373,7 +4414,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                         jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_unionselbyte);
                         ai.decorateInst(ctx.builder.CreateAlignedStore(tindex, ptindex, Align(1)));
                         if (!rhs_union.isghost)
-                            emit_unionmove(ctx, dest, ctx.tbaa().tbaa_stack, fval_info, nullptr);
+                            emit_unionmove(ctx, dest, /*shadow*/nullptr, ctx.tbaa().tbaa_stack, fval_info, /*skip*/nullptr);
                     }
                 }
                 else {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1013,20 +1013,6 @@ static void emit_memcpy_llvm(jl_codectx_t &ctx, Value *dst, jl_aliasinfo_t const
                              merged_ai.tbaa, merged_ai.tbaa_struct, merged_ai.scope, merged_ai.noalias);
 }
 
-static void emit_memcpy_llvm(jl_codectx_t &ctx, Value *dst, jl_aliasinfo_t const &dst_ai, Value *src,
-                             jl_aliasinfo_t const &src_ai, Value *sz, Align align_dst, Align align_src, bool is_volatile)
-{
-    if (auto const_sz = dyn_cast<ConstantInt>(sz)) {
-        emit_memcpy_llvm(ctx, dst, dst_ai, src, src_ai, const_sz->getZExtValue(), align_dst, align_src, is_volatile);
-        return;
-    }
-    ++EmittedMemcpys;
-
-    auto merged_ai = dst_ai.merge(src_ai);
-    ctx.builder.CreateMemCpy(dst, align_dst, src, align_src, sz, is_volatile,
-                             merged_ai.tbaa, merged_ai.tbaa_struct, merged_ai.scope, merged_ai.noalias);
-}
-
 template<typename T1>
 static void emit_memcpy(jl_codectx_t &ctx, Value *dst, jl_aliasinfo_t const &dst_ai, Value *src,
                         jl_aliasinfo_t const &src_ai, T1 &&sz, Align align_dst, Align align_src, bool is_volatile=false)
@@ -1042,11 +1028,6 @@ static void emit_memcpy(jl_codectx_t &ctx, Value *dst, jl_aliasinfo_t const &dst
     emit_memcpy_llvm(ctx, dst, dst_ai, data_pointer(ctx, src), src_ai, sz, align_dst, align_src, is_volatile);
 }
 
-static bool allpointers(jl_datatype_t *typ)
-{
-    return jl_datatype_size(typ) == typ->layout->npointers * sizeof(void*);
-}
-
 // compute the space required by split_value_into, by simulating it
 // returns (sizeof(split_value), n_pointers)
 static std::pair<size_t,size_t> split_value_size(jl_datatype_t *typ)
@@ -1056,14 +1037,15 @@ static std::pair<size_t,size_t> split_value_size(jl_datatype_t *typ)
     bool hasptr = typ->layout->first_ptr >= 0;
     size_t npointers = hasptr ? typ->layout->npointers : 0;
     // drop the data pointer if the entire structure is just pointers
-    // TODO: eventually we could drop the slots for the pointers from inside the
+    // n.b.: eventually we could sometimes drop the slots for the pointers from inside the
     //       types to pack it together, but this can change the alignment of the bits
     //       in the fields inside, even if those bits have no pointers themselves. So
     //       we would actually need to compute, for each pointer, whether any
     //       subsequent field needed the extra alignment (for example, we can
-    //       drop space for any runs of two/four pointer).  Some of these
-    //       functions are already written in a way to support that, but not
-    //       fully implemented yet.
+    //       drop space for any runs of two/four pointer). But it would also
+    //       require always copying the type, and not just extracting the
+    //       inline_roots, which can be challenging and inefficient for the type
+    //       to have multiple representations (even though more compact).
     bool nodata = allpointers(typ);
     if (nodata)
         dst_off = 0;
@@ -1072,27 +1054,36 @@ static std::pair<size_t,size_t> split_value_size(jl_datatype_t *typ)
     return std::make_pair(dst_off, npointers);
 }
 
+static void store_all_roots(jl_codectx_t &ctx, ArrayRef<Value*> inline_roots, Value *inline_roots_ptr, jl_aliasinfo_t const &roots_ai, bool isVolatileStore)
+{
+    for (size_t i = 0; i < inline_roots.size(); i++) {
+        Value *unbox = inline_roots[i];
+        roots_ai.decorateInst(ctx.builder.CreateAlignedStore(unbox, emit_ptrgep(ctx, inline_roots_ptr, i * sizeof(void*)), Align(sizeof(void*)), isVolatileStore));
+    }
+}
+
 // take a value `x` and split its bits into dst and the roots into inline_roots
 static void split_value_into(jl_codectx_t &ctx, const jl_cgval_t &x, Align align_src, Value *dst, Align align_dst, jl_aliasinfo_t const &dst_ai, Value *inline_roots_ptr, jl_aliasinfo_t const &roots_ai, bool isVolatileStore=false)
 {
+    if (x.isghost)
+        return;
     jl_datatype_t *typ = (jl_datatype_t*)x.typ;
     assert(jl_is_concrete_type(x.typ));
     auto src_ai = jl_aliasinfo_t::fromTBAA(ctx, x.tbaa);
     Type *T_prjlvalue = ctx.types().T_prjlvalue;
-    if (!x.inline_roots.empty()) {
-        auto sizes = split_value_size(typ);
-        if (sizes.first > 0)
-            emit_memcpy(ctx, dst, dst_ai, x.V, src_ai, sizes.first, align_dst, align_src, isVolatileStore);
-        for (size_t i = 0; i < sizes.second; i++) {
-            Value *unbox = x.inline_roots[i];
-            roots_ai.decorateInst(ctx.builder.CreateAlignedStore(unbox, emit_ptrgep(ctx, inline_roots_ptr, i * sizeof(void*)), Align(sizeof(void*)), isVolatileStore));
-        }
-        return;
-    }
     if (inline_roots_ptr == nullptr) {
         emit_unbox_store(ctx, x, dst, ctx.tbaa().tbaa_stack, align_src, align_dst, isVolatileStore);
         return;
     }
+    if (!x.inline_roots.empty()) {
+        auto sizes = split_value_size(typ);
+        if (sizes.first > 0)
+            emit_memcpy(ctx, dst, dst_ai, x.V, src_ai, sizes.first, align_dst, align_src, isVolatileStore);
+        store_all_roots(ctx, ArrayRef(x.inline_roots).slice(0, sizes.second), inline_roots_ptr, roots_ai, isVolatileStore);
+        return;
+    }
+    if (x.V == nullptr && x.constant == nullptr)
+        return;
     Value *src = data_pointer(ctx, value_to_pointer(ctx, x));
     bool isstack = isa<AllocaInst>(src->stripInBoundsOffsets()) || src_ai.tbaa == ctx.tbaa().tbaa_stack;
     size_t dst_off = 0;
@@ -1137,24 +1128,29 @@ static void split_value_into(jl_codectx_t &ctx, const jl_cgval_t &x, Align align
     }
 }
 
-static void split_value_into(jl_codectx_t &ctx, const jl_cgval_t &x, Align align_src, Value *dst, Align align_dst, jl_aliasinfo_t const &dst_ai, MutableArrayRef<Value*> inline_roots)
+static void split_value_into(jl_codectx_t &ctx, const jl_cgval_t &x, Align align_src, Value *dst, Align align_dst, jl_aliasinfo_t const &dst_ai,
+        bool isVolatileStore, MutableArrayRef<Value*> inline_roots)
 {
+    if (x.isghost)
+        return;
     jl_datatype_t *typ = (jl_datatype_t*)x.typ;
     assert(jl_is_concrete_type(x.typ));
     auto src_ai = jl_aliasinfo_t::fromTBAA(ctx, x.tbaa);
     Type *T_prjlvalue = ctx.types().T_prjlvalue;
+    if (inline_roots.empty()) {
+        emit_unbox_store(ctx, x, dst, ctx.tbaa().tbaa_stack, align_src, align_dst, isVolatileStore);
+        return;
+    }
     if (!x.inline_roots.empty()) {
         auto sizes = split_value_size(typ);
         if (sizes.first > 0)
-            emit_memcpy(ctx, dst, dst_ai, x.V, src_ai, sizes.first, align_dst, align_src);
+            emit_memcpy(ctx, dst, dst_ai, x.V, src_ai, sizes.first, align_dst, align_src, isVolatileStore);
         for (size_t i = 0; i < sizes.second; i++)
             inline_roots[i] = x.inline_roots[i];
         return;
     }
-    if (inline_roots.empty()) {
-        emit_unbox_store(ctx, x, dst, ctx.tbaa().tbaa_stack, align_src, align_dst, false);
+    if (x.V == nullptr && x.constant == nullptr)
         return;
-    }
     Value *src = data_pointer(ctx, value_to_pointer(ctx, x));
     bool isstack = isa<AllocaInst>(src->stripInBoundsOffsets()) || src_ai.tbaa == ctx.tbaa().tbaa_stack;
     size_t dst_off = 0;
@@ -1173,7 +1169,8 @@ static void split_value_into(jl_codectx_t &ctx, const jl_cgval_t &x, Align align
                 src_ai,
                 ptr - src_off,
                 align_dst,
-                align_src);
+                align_src,
+                isVolatileStore);
             dst_off += ptr - src_off;
         }
         if (last)
@@ -1190,7 +1187,8 @@ static void split_value_into(jl_codectx_t &ctx, const jl_cgval_t &x, Align align
             dst_ai.decorateInst(ctx.builder.CreateAlignedStore(
                 ctx.builder.getIntN(sizeof(void*) * 8, (uint64_t)-1),
                 emit_ptrgep(ctx, dst, dst_off),
-                align_src));
+                align_src,
+                isVolatileStore));
             dst_off += sizeof(void*);
             assert(dst_off == src_off);
         }
@@ -1205,7 +1203,7 @@ static std::pair<AllocaInst*, SmallVector<Value*,0>> split_value(jl_codectx_t &c
     AllocaInst *bits = sizes.first > 0 ? emit_static_alloca(ctx, sizes.first, align_dst) : nullptr;
     SmallVector<Value*,0> roots(sizes.second);
     auto stack_ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack);
-    split_value_into(ctx, x, x_alignment, bits, align_dst, stack_ai, MutableArrayRef(roots));
+    split_value_into(ctx, x, x_alignment, bits, align_dst, stack_ai, false, MutableArrayRef(roots));
     return std::make_pair(bits, roots);
 }
 
@@ -1241,7 +1239,7 @@ static std::pair<ssize_t,ssize_t> split_value_field(jl_datatype_t *typ, unsigned
 static void recombine_value(jl_codectx_t &ctx, const jl_cgval_t &x, Value *dst, jl_aliasinfo_t const &dst_ai, Align alignment, bool isVolatileStore)
 {
     jl_datatype_t *typ = (jl_datatype_t*)x.typ;
-    assert(jl_is_concrete_type(x.typ));
+    assert(jl_is_concrete_type(x.typ) && !x.isghost);
     assert(typ->layout->first_ptr >= 0 && !x.inline_roots.empty());
     Align align_dst = alignment;
     Align align_src(julia_alignment(x.typ));
@@ -1281,22 +1279,6 @@ static void recombine_value(jl_codectx_t &ctx, const jl_cgval_t &x, Value *dst, 
             src_off = dst_off;
         }
     }
-}
-
-static void emit_sret_roots(jl_codectx_t &ctx, bool isptr, Value *Src, Type *T, Value *Shadow, Type *ShadowT, unsigned count)
-{
-    assert(T != NULL);
-    unsigned emitted = TrackWithShadow(Src, T, isptr, Shadow, ShadowT, ctx.builder); //This comes from Late-GC-Lowering??
-    if (emitted < count) {
-        Value *ToZero = ctx.builder.CreateConstInBoundsGEP1_32(
-            ctx.types().T_prjlvalue, Shadow, emitted);
-        ctx.builder.CreateMemSet(ToZero,
-            /* Val */ ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0),
-            /* Size */ ConstantInt::get(ctx.types().T_size, (count - emitted) * sizeof(jl_value_t *)),
-            /* Align */ Align(sizeof(jl_value_t *)));
-        emitted += count - emitted;
-    }
-    assert(emitted <= count); (void)emitted; (void)count;
 }
 
 static Value *emit_tagfrom(jl_codectx_t &ctx, jl_datatype_t *dt)
@@ -1666,6 +1648,8 @@ static void null_load_check(jl_codectx_t &ctx, Value *v, jl_module_t *scope, jl_
         raise_exception_unless(ctx, notnull, literal_pointer_val(ctx, jl_undefref_exception));
 }
 
+// ifnot == nullptr && return func()
+// return (ifnot ? func() : defval)
 template<typename Func>
 static void emit_guarded_test(jl_codectx_t &ctx, Value *ifnot, MutableArrayRef<Value*> defval, Func &&func)
 {
@@ -3660,28 +3644,30 @@ static Value *compute_tindex_unboxed(jl_codectx_t &ctx, const jl_cgval_t &val, j
 
 
 static void union_alloca_type(jl_uniontype_t *ut,
-        bool &allunbox, size_t &nbytes, size_t &align, size_t &min_align, size_t &return_roots)
+        bool &allunbox, size_t &nbytes, size_t &align, size_t &min_align, size_t &inline_roots)
 {
     nbytes = 0;
     align = 0;
     min_align = MAX_ALIGN;
-    return_roots = 0;
+    inline_roots = 0;
     // compute the size of the union alloca that could hold this type
     unsigned counter = 0;
     allunbox = for_each_uniontype_small(
             [&](unsigned idx, jl_datatype_t *jt) {
                 if (!jl_is_datatype_singleton(jt)) {
+                    //size_t nb1, n_roots;
+                    //std::tie(nb1, n_roots) = split_value_size(jt); // TODO: deal with using this later
                     size_t nb1 = jl_datatype_size(jt);
-                    size_t align1 = julia_alignment((jl_value_t*)jt);
                     size_t n_roots = jl_datatype_layout(jt)->npointers;
+                    size_t align1 = julia_alignment((jl_value_t*)jt);
                     if (nb1 > nbytes)
                         nbytes = nb1;
                     if (align1 > align)
                         align = align1;
                     if (align1 < min_align)
                         min_align = align1;
-                    if (n_roots > return_roots)
-                        return_roots = n_roots;
+                    if (n_roots > inline_roots)
+                        inline_roots = n_roots;
                 }
             },
             (jl_value_t*)ut,
@@ -3690,24 +3676,17 @@ static void union_alloca_type(jl_uniontype_t *ut,
         align = JL_HEAP_ALIGNMENT;
 }
 
-static AllocaInst *try_emit_union_alloca(jl_codectx_t &ctx, jl_uniontype_t *ut, bool &allunbox, size_t &min_align, size_t &nbytes, /* TODO: remove */bool require_pointerfree, const char *name)
+static AllocaInst *try_emit_union_alloca(jl_codectx_t &ctx, jl_uniontype_t *ut, bool &allunbox, size_t &min_align, size_t &nbytes, size_t &inline_roots)
 {
-    size_t align, return_roots;
-    union_alloca_type(ut, allunbox, nbytes, align, min_align, return_roots);
-    if (nbytes > 0 && !(require_pointerfree && return_roots != 0)) {
+    size_t align;
+    union_alloca_type(ut, allunbox, nbytes, align, min_align, inline_roots);
+    if (nbytes > 0) {
         // at least some of the values can live on the stack
         assert(align % min_align == 0);
         AllocaInst *lv = emit_static_alloca(ctx, nbytes, Align(align));
-        setName(ctx.emission_context, lv, name);
-        if (return_roots > 0) {
-            StoreInst *SI = new StoreInst(Constant::getNullValue(AT), lv, false, Align(sizeof(void*)));
-            SI->insertAfter(ctx.topalloca);
-        }
+        setName(ctx.emission_context, lv, "unionalloca");
         return lv;
     }
-    allunbox = false;
-    nbytes = 0;
-    min_align = 0;
     return NULL;
 }
 
@@ -3756,7 +3735,9 @@ static Value *box_union(jl_codectx_t &ctx, const jl_cgval_t &vinfo, const SmallB
                     box = track_pjlvalue(ctx, literal_pointer_val(ctx, jt->instance));
                 }
                 else {
-                    jl_cgval_t vinfo_r = jl_cgval_t(vinfo, (jl_value_t*)jt, NULL);
+                    jl_cgval_t vinfo_r = update_julia_type(ctx, vinfo, (jl_value_t*)jt);
+                    if (vinfo_r.typ == jl_bottom_type)
+                        return;
                     box = _boxed_special(ctx, vinfo_r, t);
                     if (!box) {
                         box = emit_allocobj(ctx, jt, true);
@@ -3920,41 +3901,46 @@ static Value *boxed(jl_codectx_t &ctx, const jl_cgval_t &vinfo, bool is_promotab
 }
 
 // copy src to dest, if src is justbits. if skip is true, the value of dest is undefined
-static void emit_unionmove(jl_codectx_t &ctx, Value *dest, jl_cgval_shadow_t *shadow,
+// TODO: rename this to just `emit_typed_move`
+static void emit_unionmove(jl_codectx_t &ctx, Value *dest, jl_value_t *desttype, MutableArrayRef<Value*> roots,
         MDNode *tbaa_dst, const jl_cgval_t &src, Value *skip, bool isVolatile=false)
 {
     if (AllocaInst *ai = dyn_cast<AllocaInst>(dest))
         // TODO: make this a lifetime_end & dereferenceable annotation?
         ctx.builder.CreateAlignedStore(UndefValue::get(ai->getAllocatedType()), ai, ai->getAlign());
+    auto dest_ai = jl_aliasinfo_t::fromTBAA(ctx, tbaa_dst);
     if (src.constant) {
         jl_value_t *typ = jl_typeof(src.constant);
-        assert(skip || jl_is_pointerfree(typ));
-        if (jl_is_pointerfree(typ)) {
-            emit_guarded_test(ctx, skip, nullptr, [&] {
+        assert(skip || deserves_stack(typ));
+        if (jl_is_concrete_immutable(typ)) {
+            emit_guarded_test(ctx, skip ? ctx.builder.CreateNot(skip) : nullptr, nullptr, [&] {
                 unsigned alignment = julia_alignment(typ);
-                emit_unbox_store(ctx, mark_julia_const(ctx, src.constant), dest, tbaa_dst, Align(alignment), Align(alignment), isVolatile);
+                split_value_into(ctx, mark_julia_const(ctx, src.constant), Align(alignment), dest, Align(alignment), dest_ai, isVolatile, roots);
                 return nullptr;
             });
         }
     }
     else if (jl_is_concrete_type(src.typ)) {
-        assert(skip || jl_is_pointerfree(src.typ));
-        if (jl_is_pointerfree(src.typ)) {
-            emit_guarded_test(ctx, skip, nullptr, [&] {
+        assert(skip || deserves_stack(src.typ));
+        if (jl_is_concrete_immutable(src.typ)) {
+            emit_guarded_test(ctx, skip ? ctx.builder.CreateNot(skip) : nullptr, nullptr, [&] {
                 unsigned alignment = julia_alignment(src.typ);
-                emit_unbox_store(ctx, src, dest, tbaa_dst, Align(alignment), Align(alignment), isVolatile);
+                split_value_into(ctx, src, Align(alignment), dest, Align(alignment), dest_ai, isVolatile, roots);
                 return nullptr;
             });
         }
     }
-    else if (src.TIndex) {
-        Value *tindex = ctx.builder.CreateAnd(src.TIndex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0x7f));
+    else {
+        Value *tindex = compute_tindex_unboxed(ctx, src, desttype, skip != nullptr);
         if (skip)
             tindex = ctx.builder.CreateSelect(skip, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0), tindex);
-        Value *src_ptr = data_pointer(ctx, src);
         BasicBlock *defaultBB = BasicBlock::Create(ctx.builder.getContext(), "union_move_skip", ctx.f);
         SwitchInst *switchInst = ctx.builder.CreateSwitch(tindex, defaultBB);
         BasicBlock *postBB = BasicBlock::Create(ctx.builder.getContext(), "post_union_move", ctx.f);
+        ctx.builder.SetInsertPoint(postBB);
+        Value *Vnull = Constant::getNullValue(ctx.types().T_prjlvalue);
+        for (size_t i = 0; i < roots.size(); i++)
+            roots[i] = ctx.builder.CreatePHI(Vnull->getType(), 0);
         unsigned counter = 0;
         bool allunboxed = for_each_uniontype_small(
                 [&](unsigned idx, jl_datatype_t *jt) {
@@ -3963,27 +3949,16 @@ static void emit_unionmove(jl_codectx_t &ctx, Value *dest, jl_cgval_shadow_t *sh
                     BasicBlock *tempBB = BasicBlock::Create(ctx.builder.getContext(), "union_move", ctx.f);
                     ctx.builder.SetInsertPoint(tempBB);
                     switchInst->addCase(ConstantInt::get(getInt8Ty(ctx.builder.getContext()), idx), tempBB);
+                    SmallVector<Value*,0> lroots(roots.size(), Vnull);
                     if (nb > 0) {
-                        if (!src_ptr) {
-                            Function *trap_func =
-#if JL_LLVM_VERSION >= 200000
-                                Intrinsic::getOrInsertDeclaration(ctx.f->getParent(), Intrinsic::trap);
-#else
-                                Intrinsic::getDeclaration(ctx.f->getParent(), Intrinsic::trap);
-#endif
-                            ctx.builder.CreateCall(trap_func);
-                            ctx.builder.CreateUnreachable();
-                            return;
-                        } else {
-                            // Maybe assert here (TBD)
-                            if (shadow != nullptr && !jl_is_pointerfree((jl_value_t *)jt)) {
-                                Type *store_ty = julia_type_to_llvm(ctx, (jl_value_t *)jt);
-                                emit_sret_roots(ctx, /* isptr */ true, src_ptr, store_ty, shadow->value, shadow->typ, shadow->n_roots);
-                            }
-                            emit_memcpy(ctx, dest, jl_aliasinfo_t::fromTBAA(ctx, tbaa_dst), src_ptr,
-                                        jl_aliasinfo_t::fromTBAA(ctx, src.tbaa), nb, Align(alignment), Align(alignment), isVolatile);
+                        jl_cgval_t src_pi = update_julia_type(ctx, src, (jl_value_t*)jt);
+                        if (src_pi.typ != jl_bottom_type) {
+                            split_value_into(ctx, src_pi, Align(alignment), dest, Align(alignment), dest_ai, isVolatile, MutableArrayRef(lroots));
                         }
                     }
+                    tempBB = ctx.builder.GetInsertBlock();
+                    for (size_t i = 0; i < roots.size(); i++)
+                        cast<PHINode>(roots[i])->addIncoming(lroots[i], tempBB);
                     ctx.builder.CreateBr(postBB);
                 },
                 src.typ,
@@ -4001,27 +3976,12 @@ static void emit_unionmove(jl_codectx_t &ctx, Value *dest, jl_cgval_shadow_t *sh
             ctx.builder.CreateUnreachable();
         }
         else {
+            Value *Vnull = Constant::getNullValue(ctx.types().T_prjlvalue);
+            for (size_t i = 0; i < roots.size(); i++)
+                cast<PHINode>(roots[i])->addIncoming(Vnull, defaultBB);
             ctx.builder.CreateBr(postBB);
         }
         ctx.builder.SetInsertPoint(postBB);
-    }
-    else {
-        assert(src.isboxed && "expected boxed value for sizeof/alignment computation");
-        emit_guarded_test(ctx, skip, nullptr, [&] {
-            if (shadow == nullptr) {
-                Value *datatype = emit_typeof(ctx, src, false, false);
-                Value *copy_bytes = emit_datatype_size(ctx, datatype);
-                emit_memcpy(ctx, dest, jl_aliasinfo_t::fromTBAA(ctx, tbaa_dst), data_pointer(ctx, src),
-                            jl_aliasinfo_t::fromTBAA(ctx, src.tbaa), copy_bytes, Align(1), Align(1), isVolatile);
-            } else {
-                Function *trap_func = Intrinsic::getDeclaration(
-                        ctx.f->getParent(),
-                        Intrinsic::trap);
-                ctx.builder.CreateCall(trap_func);
-                ctx.builder.CreateUnreachable();
-            }
-            return nullptr;
-        });
     }
 }
 
@@ -4180,7 +4140,7 @@ static jl_cgval_t union_store(jl_codectx_t &ctx,
     ai.decorateInst(ctx.builder.CreateAlignedStore(tindex, ptindex, Align(1)));
     // copy data
     if (!rhs.isghost) {
-        emit_unionmove(ctx, ptr, /*shadow*/nullptr, tbaa, rhs, /*skip*/nullptr);
+        emit_unionmove(ctx, ptr, jltype, /*inline_roots*/MutableArrayRef<Value*>(), tbaa, rhs, /*skip*/nullptr);
     }
     if (isreplacefield || ismodifyfield) {
         ctx.builder.CreateBr(DoneBB);
@@ -4384,7 +4344,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                             assert(lt->getStructElementType(llvm_idx) == ET);
                             AllocaInst *lv = emit_static_alloca(ctx, fsz1, Align(al));
                             setName(ctx.emission_context, lv, "unioninit");
-                            emit_unionmove(ctx, lv, /* shadow */ nullptr, ctx.tbaa().tbaa_stack, fval_info, /* skip */ nullptr);
+                            emit_unionmove(ctx, lv, jtype, /*inline_roots*/MutableArrayRef<Value*>(), ctx.tbaa().tbaa_stack, fval_info, /* skip */ nullptr);
                             // emit all of the align-sized words
                             unsigned i = 0;
                             for (; i < fsz1 / al; i++) {
@@ -4414,7 +4374,7 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                         jl_aliasinfo_t ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_unionselbyte);
                         ai.decorateInst(ctx.builder.CreateAlignedStore(tindex, ptindex, Align(1)));
                         if (!rhs_union.isghost)
-                            emit_unionmove(ctx, dest, /*shadow*/nullptr, ctx.tbaa().tbaa_stack, fval_info, /*skip*/nullptr);
+                            emit_unionmove(ctx, dest, jtype, /*inline_roots*/MutableArrayRef<Value*>(), ctx.tbaa().tbaa_stack, fval_info, /*skip*/nullptr);
                     }
                 }
                 else {
@@ -4427,11 +4387,8 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
                     else if (init_as_value) {
                         fval = emit_unbox(ctx, fty, fval_info, jtype);
                     }
-                    else if (!roots.empty()) {
-                        split_value_into(ctx, fval_info, align_src, dest, align_dst, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack), roots);
-                    }
                     else {
-                        emit_unbox_store(ctx, fval_info, dest, ctx.tbaa().tbaa_stack, align_src, align_dst);
+                        split_value_into(ctx, fval_info, align_src, dest, align_dst, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack), false, roots);
                     }
                 }
                 if (init_as_value) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2759,6 +2759,8 @@ static jl_cgval_t convert_julia_type_to_union(jl_codectx_t &ctx, const jl_cgval_
                     unsigned old_idx = v.TIndex ? get_box_tindex(jt, v.typ) : 0;
                     if (old_idx == 0) {
                         if (jl_datatype_layout(jt)->npointers) {
+                            if (!jl_subtype((jl_value_t*)jt, v.typ))
+                                return;
                             add_roots_count += 1;
                             add_roots_inline = std::max(add_roots_inline, jl_datatype_layout(jt)->npointers);
                         }
@@ -2812,6 +2814,8 @@ static jl_cgval_t convert_julia_type_to_union(jl_codectx_t &ctx, const jl_cgval_
                         if (old_idx == 0) {
                             auto npointers = jl_datatype_layout(jt)->npointers;
                             if (npointers) {
+                                if (!jl_subtype((jl_value_t*)jt, v.typ))
+                                    return;
                                 BasicBlock *splitunboxBB = BasicBlock::Create(ctx.builder.getContext(), "split_unbox_union", ctx.f);
                                 SW->addCase(ConstantInt::get(getInt8Ty(ctx.builder.getContext()), UNION_BOX_MARKER | idx), splitunboxBB);
                                 ctx.builder.SetInsertPoint(splitunboxBB);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3357,7 +3357,7 @@ static Value *emit_box_compare(jl_codectx_t &ctx, const jl_cgval_t &arg1, const 
     });
 }
 
-static Value *emit_bits_compare(jl_codectx_t &ctx, jl_cgval_t arg1, jl_cgval_t arg2);
+static Value *emit_bits_compare(jl_codectx_t &ctx, const jl_cgval_t &arg1, const jl_cgval_t &arg2);
 
 static Value *emit_bitsunion_compare(jl_codectx_t &ctx, const jl_cgval_t &arg1, const jl_cgval_t &arg2)
 {
@@ -3408,7 +3408,7 @@ static Value *emit_bitsunion_compare(jl_codectx_t &ctx, const jl_cgval_t &arg1, 
     return phi;
 }
 
-static Value *emit_bits_compare(jl_codectx_t &ctx, jl_cgval_t arg1, jl_cgval_t arg2)
+static Value *emit_bits_compare(jl_codectx_t &ctx, const jl_cgval_t &arg1, const jl_cgval_t &arg2)
 {
     ++EmittedBitsCompares;
     jl_value_t *argty = (arg1.constant ? jl_typeof(arg1.constant) : arg1.typ);
@@ -3421,16 +3421,16 @@ static Value *emit_bits_compare(jl_codectx_t &ctx, jl_cgval_t arg1, jl_cgval_t a
 
     if (at->isIntegerTy() || at->isPointerTy() || at->isFloatingPointTy()) {
         Type *at_int = INTT(at, ctx.emission_context.DL);
-        Value *varg1 = emit_unbox(ctx, at_int, arg1, argty);
-        Value *varg2 = emit_unbox(ctx, at_int, arg2, argty);
+        Value *varg1 = emit_unbox(ctx, at_int, arg1);
+        Value *varg2 = emit_unbox(ctx, at_int, arg2);
         return ctx.builder.CreateICmpEQ(varg1, varg2);
     }
 
     if (at->isVectorTy()) {
         jl_svec_t *types = ((jl_datatype_t*)argty)->types;
         Value *answer = ConstantInt::get(getInt1Ty(ctx.builder.getContext()), 1);
-        Value *varg1 = emit_unbox(ctx, at, arg1, argty);
-        Value *varg2 = emit_unbox(ctx, at, arg2, argty);
+        Value *varg1 = emit_unbox(ctx, at, arg1);
+        Value *varg2 = emit_unbox(ctx, at, arg2);
         for (size_t i = 0, l = jl_svec_len(types); i < l; i++) {
             jl_value_t *fldty = jl_svecref(types, i);
             Value *subAns, *fld1, *fld2;
@@ -4511,7 +4511,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                         jl_cgval_t va_ary( // fake instantiation of a cgval, in order to call emit_bounds_check (it only checks the `.V` field)
                                 emit_ptrgep(ctx, ctx.argArray, ctx.nReqArgs * sizeof(jl_value_t*)),
                                 NULL, NULL);
-                        Value *idx = emit_unbox(ctx, ctx.types().T_size, fld, (jl_value_t*)jl_long_type);
+                        Value *idx = emit_unbox(ctx, ctx.types().T_size, fld);
                         idx = emit_bounds_check(ctx, va_ary, NULL, idx, valen, boundscheck);
                         idx = ctx.builder.CreateAdd(idx, ConstantInt::get(ctx.types().T_size, ctx.nReqArgs));
                         Instruction *v = ctx.builder.CreateAlignedLoad(ctx.types().T_prjlvalue, ctx.builder.CreateInBoundsGEP(ctx.types().T_prjlvalue, ctx.argArray, idx), Align(sizeof(void*)));
@@ -4539,13 +4539,13 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                     }
                     else {
                         // unknown index
-                        Value *vidx = emit_unbox(ctx, ctx.types().T_size, fld, (jl_value_t*)jl_long_type);
+                        Value *vidx = emit_unbox(ctx, ctx.types().T_size, fld);
                         if (emit_getfield_unknownidx(ctx, ret, obj, vidx, utt, boundscheck, order)) {
                             return true;
                         }
                     }
                 }
-                Value *vidx = emit_unbox(ctx, ctx.types().T_size, fld, (jl_value_t*)jl_long_type);
+                Value *vidx = emit_unbox(ctx, ctx.types().T_size, fld);
                 if (jl_is_tuple_type(utt) && is_tupletype_homogeneous(utt->parameters, true)) {
                     // For tuples, we can emit code even if we don't know the exact
                     // type (e.g. because we don't know the length). This is possible
@@ -4715,7 +4715,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                 Value *tyv = boxed(ctx, typ);
                 Value *types_svec = emit_datatype_types(ctx, tyv);
                 Value *types_len = emit_datatype_nfields(ctx, tyv);
-                Value *idx = emit_unbox(ctx, ctx.types().T_size, fld, (jl_value_t*)jl_long_type);
+                Value *idx = emit_unbox(ctx, ctx.types().T_size, fld);
                 jl_value_t *boundscheck = (nargs == 3 ? argv[3].constant : jl_true);
                 if (nargs == 3)
                     emit_typecheck(ctx, argv[3], (jl_value_t*)jl_bool_type, "fieldtype");
@@ -4856,7 +4856,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
 isdefined_unknown_idx:
             if (nargs == 3 || fld.typ != (jl_value_t*)jl_long_type)
                 return false;
-            Value *vidx = emit_unbox(ctx, ctx.types().T_size, fld, (jl_value_t*)jl_long_type);
+            Value *vidx = emit_unbox(ctx, ctx.types().T_size, fld);
             vidx = ctx.builder.CreateSub(vidx, ConstantInt::get(ctx.types().T_size, 1));
             Value *isd = ctx.builder.CreateCall(prepare_call(jlfieldisdefinedchecked_func), { boxed(ctx, obj), vidx });
             isd = ctx.builder.CreateTrunc(isd, getInt8Ty(ctx.builder.getContext()));
@@ -5106,7 +5106,7 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_clos
                 }
             }
             else {
-                Value *val = emit_unbox(ctx, et, arg, jt);
+                Value *val = emit_unbox(ctx, et, arg);
                 if (!val) {
                     // There was a type mismatch of some sort - exit early
                     emit_error(ctx, "(INTERNAL ERROR - IR Validity): Argument type mismatch in Expr(:invoke)");
@@ -5463,7 +5463,7 @@ static jl_cgval_t emit_specsig_oc_call(jl_codectx_t &ctx, jl_value_t *oc_type, j
     // Load specptr
     jl_cgval_t &theArg = argv[0];
     jl_cgval_t closure_specptr = emit_getfield_knownidx(ctx, theArg, 4, (jl_datatype_t*)oc_type, jl_memory_order_notatomic);
-    Value *specptr = emit_unbox(ctx, ctx.types().T_size, closure_specptr, (jl_value_t*)jl_long_type);
+    Value *specptr = emit_unbox(ctx, ctx.types().T_size, update_julia_type(ctx, closure_specptr, (jl_value_t*)jl_voidpointer_type));
     specptr = emit_inttoptr(ctx, specptr, ctx.types().T_ptr);
     JL_GC_PUSH1(&sigtype);
     jl_cgval_t r = emit_call_specfun_other(ctx, true, sigtype, oc_rett, specptr, "", NULL, argv, nargs,
@@ -6113,7 +6113,7 @@ static Value *emit_condition(jl_codectx_t &ctx, const jl_cgval_t &condV, const T
         emit_typecheck(ctx, condV, (jl_value_t*)jl_bool_type, msg);
     }
     if (isbool) {
-        Value *cond = emit_unbox(ctx, getInt1Ty(ctx.builder.getContext()), condV, (jl_value_t*)jl_bool_type);
+        Value *cond = emit_unbox(ctx, getInt1Ty(ctx.builder.getContext()), update_julia_type(ctx, condV, (jl_value_t*)jl_bool_type));
         return ctx.builder.CreateNot(cond);
     }
     if (condV.isboxed) {
@@ -6404,7 +6404,7 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaidx_
     else if (head == jl_throw_undef_if_not_sym) {
         assert(nargs == 2);
         jl_sym_t *var = (jl_sym_t*)args[0];
-        Value *cond = ctx.builder.CreateTrunc(emit_unbox(ctx, getInt8Ty(ctx.builder.getContext()), emit_expr(ctx, args[1]), (jl_value_t*)jl_bool_type), getInt1Ty(ctx.builder.getContext()));
+        Value *cond = emit_unbox(ctx, getInt1Ty(ctx.builder.getContext()), update_julia_type(ctx, emit_expr(ctx, args[1]), (jl_value_t*)jl_bool_type));
         if (var == jl_getfield_undefref_sym) {
             raise_exception_unless(ctx, cond,
                 literal_pointer_val(ctx, jl_undefref_exception));
@@ -6863,7 +6863,7 @@ static Function *emit_modifyhelper(jl_codectx_t &ctx2, const jl_cgval_t &op, con
     jl_cgval_t ret = emit_invoke(ctx, modifyop, argv, 3, (jl_value_t*)jl_any_type, true);
     emit_typecheck(ctx, ret, jltype, fname);
     ret = update_julia_type(ctx, ret, jltype);
-    ctx.builder.CreateRet(emit_unbox(ctx, elty, ret, jltype));
+    ctx.builder.CreateRet(emit_unbox(ctx, elty, ret));
     if (ctx.topalloca->use_empty()) {
       ctx.topalloca->eraseFromParent();
       ctx.topalloca = nullptr;
@@ -7026,7 +7026,7 @@ static void emit_specsig_to_specsig(
             ctx.builder.CreateRetVoid();
         }
         else {
-            ctx.builder.CreateRet(emit_unbox(ctx, gfrt, gf_retval, rettype));
+            ctx.builder.CreateRet(emit_unbox(ctx, gfrt, gf_retval));
         }
         break;
     }
@@ -7573,7 +7573,7 @@ static Function *gen_cfun_wrapper(
     else if (!type_is_ghost(sig.lrt)) {
         Type *prt = sig.prt;
         bool issigned = jl_signed_type && jl_subtype(declrt, (jl_value_t*)jl_signed_type);
-        Value *v = emit_unbox(ctx, sig.lrt, retval, retval.typ);
+        Value *v = emit_unbox(ctx, sig.lrt, retval);
         r = llvm_type_rewrite(ctx, v, prt, issigned);
         if (sig.sret) {
             ctx.builder.CreateStore(r, sretPtr);
@@ -9303,7 +9303,7 @@ static jl_llvm_functions_t
                 if (type_is_ghost(retty))
                     retval = NULL;
                 else
-                    retval = emit_unbox(ctx, retty, retvalinfo, jlrettype);
+                    retval = emit_unbox(ctx, retty, retvalinfo);
                 break;
             case jl_returninfo_t::SRet:
                 retval = NULL;
@@ -9595,7 +9595,7 @@ static jl_llvm_functions_t
                         // load of val) if the runtime type of val isn't phiType
                         Value *isvalid = emit_isa_and_defined(ctx, val, phiType);
                         V = emit_guarded_test(ctx, isvalid, undef_value_for_type(VN->getType()), [&] {
-                            return emit_unbox(ctx, VN->getType(), val, phiType);
+                            return emit_unbox(ctx, VN->getType(), update_julia_type(ctx, val, phiType));
                         });
                     }
                     VN->addIncoming(V, ctx.builder.GetInsertBlock());

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1598,6 +1598,11 @@ static bool jl_is_pointerfree(jl_value_t* t)
     return layout && layout->npointers == 0;
 }
 
+static bool allpointers(jl_datatype_t *typ)
+{
+    return jl_datatype_size(typ) == typ->layout->npointers * sizeof(void*);
+}
+
 // these queries are usually related, but we split them out here
 // for convenience and clarity (and because it changes the calling convention)
 // n.b. this must include jl_is_datatype_singleton (ghostType) and primitive types
@@ -1805,6 +1810,28 @@ struct jl_cgval_t {
         else {
             assert(isboxed || v.typ == typ || tindex);
         }
+        // discard roots that do not apply anymore
+        // or drop this whole value if there are not enough roots to populate it
+        if (!inline_roots.empty() && tindex == nullptr) {
+            size_t inline_roots_count;
+            if (!deserves_stack(typ)) {
+                inline_roots_count = 0;
+            }
+            else {
+                const jl_datatype_layout_t *layout = ((jl_datatype_t*)typ)->layout;
+                inline_roots_count = layout ? layout->npointers : 0;
+            }
+            assert(v.TIndex || inline_roots.size() == inline_roots_count);
+            if (v.V == nullptr && v.constant == nullptr && !isghost && (inline_roots_count == 0 || !allpointers((jl_datatype_t*)typ)))
+                *this = jl_cgval_t(); // no data to populate this value
+            else if (inline_roots_count < inline_roots.size())
+                inline_roots.truncate(inline_roots_count);
+            else if (inline_roots_count > inline_roots.size())
+                *this = jl_cgval_t(); // not enough roots to populate this value
+            // drop data if all of the content is in the roots
+            if (inline_roots_count > 0 && allpointers((jl_datatype_t*)typ))
+                V = nullptr;
+        }
     }
     explicit jl_cgval_t() : // undef / unreachable constructor
         V(nullptr),
@@ -1822,20 +1849,13 @@ struct jl_cgval_t {
     }
 };
 
-// GC "shadow" of a Julia value, i.e. take only the GC-tracked pointers out of the object and
-// stack them contiguously in an array
-struct jl_cgval_shadow_t {
-    size_t n_roots;
-    Value *value;
-    Type *typ;      // always [n_roots x {}*]
-};
-
 // per-local-variable information
 struct jl_varinfo_t {
     Instruction *boxroot; // an address, if the var might be in a jl_value_t** stack slot (marked ctx.tbaa().tbaa_const, if appropriate)
     jl_cgval_t value; // a stack slot or constant value
     Value *pTIndex; // i8* stack slot for the value.TIndex tag describing `value.V`
     AllocaInst *inline_roots; // stack roots for the inline_roots array, if needed
+    size_t inline_roots_count;
     DILocalVariable *dinfo;
     // if the variable might be used undefined and is not boxed
     // this i1 flag is true when it is defined
@@ -1850,6 +1870,7 @@ struct jl_varinfo_t {
                      value(jl_cgval_t()),
                      pTIndex(nullptr),
                      inline_roots(nullptr),
+                     inline_roots_count(0),
                      dinfo(nullptr),
                      defFlag(nullptr),
                      isSA(false),
@@ -2354,7 +2375,7 @@ static inline jl_cgval_t update_julia_type(jl_codectx_t &ctx, const jl_cgval_t &
             if (alwaysboxed) {
                 // discovered that this union-split type must actually be isboxed
                 if (v.Vboxed) {
-                    return jl_cgval_t(v.Vboxed, true, typ, NULL, best_tbaa(ctx.tbaa(), typ), v.inline_roots);
+                    return jl_cgval_t(v.Vboxed, true, typ, NULL, best_tbaa(ctx.tbaa(), typ), None);
                 }
                 else {
                     // type mismatch (there weren't any boxed values in the union)
@@ -2369,7 +2390,7 @@ static inline jl_cgval_t update_julia_type(jl_codectx_t &ctx, const jl_cgval_t &
     Type *T = julia_type_to_llvm(ctx, typ);
     if (type_is_ghost(T))
         return ghostValue(ctx, typ);
-    else if (v.TIndex && v.V == NULL) {
+    else if (v.TIndex && v.V == NULL && v.inline_roots.empty()) {
         // type mismatch (there weren't any non-ghost values in the union)
         CreateTrap(ctx.builder);
         return jl_cgval_t();
@@ -2577,23 +2598,28 @@ static jl_cgval_t convert_julia_type_union(jl_codectx_t &ctx, const jl_cgval_t &
             }
             Value *slotv;
             MDNode *tbaa;
-            if (v.V == NULL) {
-                // v.V might be NULL if it was all ghost objects before
-                slotv = NULL;
+            if (v.V == nullptr) {
+                // v.V might be NULL if it was all constants before
+                slotv = nullptr;
                 tbaa = ctx.tbaa().tbaa_const;
             }
-            else {
+            else if (!v.inline_roots.empty() || v.ispointer()) {
                 Value *isboxv = ctx.builder.CreateIsNotNull(boxv);
-                jl_cgval_t oldv = value_to_pointer(ctx, v);
-                slotv = oldv.V;
-                tbaa = oldv.tbaa;
+                slotv = v.V;
+                tbaa = v.tbaa;
                 slotv = ctx.builder.CreateSelect(isboxv,
                             decay_derived(ctx, boxv),
                             decay_derived(ctx, slotv));
             }
+            else {
+                jl_cgval_t oldv = value_to_pointer(ctx, v.V, v.typ, v.TIndex);
+                slotv = oldv.V;
+                tbaa = oldv.tbaa;
+            }
             jl_cgval_t newv = jl_cgval_t(slotv, false, typ, new_tindex, tbaa, v.inline_roots);
             assert(boxv->getType() == ctx.types().T_prjlvalue);
             newv.Vboxed = boxv;
+            newv.constant = v.constant;
             return newv;
         }
     }
@@ -2626,10 +2652,9 @@ static jl_cgval_t convert_julia_type(jl_codectx_t &ctx, const jl_cgval_t &v, jl_
         }
         bool mustbox_union = v.TIndex && deserves_unionbox(typ);
         if (v.Vboxed && (v.isboxed || mustbox_union)) {
-            if (skip) {
+            if (skip)
                 *skip = ctx.builder.CreateNot(emit_exactly_isa(ctx, v, (jl_datatype_t*)typ, true));
-            }
-            return jl_cgval_t(v.Vboxed, true, typ, NULL, best_tbaa(ctx.tbaa(), typ), v.inline_roots);
+            return jl_cgval_t(v.Vboxed, true, typ, NULL, best_tbaa(ctx.tbaa(), typ), None);
         }
         if (mustbox_union) {
             // type mismatch: there weren't any boxed values in the union
@@ -5013,7 +5038,6 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_clos
 
     AllocaInst *return_roots = nullptr;
     if (returninfo.return_roots) {
-        assert(returninfo.cc == jl_returninfo_t::SRet);
         return_roots = emit_static_roots(ctx, returninfo.return_roots);
         setName(ctx.emission_context, return_roots, "return_roots");
         argvals[idx] = return_roots;
@@ -5109,7 +5133,11 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_clos
             break;
         case jl_returninfo_t::SRet:
             assert(result);
-            retval = mark_julia_slot(result, jlretty, NULL, ctx.tbaa().tbaa_gcframe, load_gc_roots(ctx, return_roots, returninfo.return_roots, ctx.tbaa().tbaa_gcframe));
+            retval = mark_julia_slot(result,
+                                     jlretty,
+                                     NULL,
+                                     ctx.tbaa().tbaa_gcframe,
+                                     load_gc_roots(ctx, return_roots, returninfo.return_roots, ctx.tbaa().tbaa_gcframe));
             break;
         case jl_returninfo_t::Union: {
             Value *box = ctx.builder.CreateExtractValue(call, 0);
@@ -5124,7 +5152,8 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, bool is_opaque_clos
             retval = mark_julia_slot(derived,
                                      jlretty,
                                      tindex,
-                                     ctx.tbaa().tbaa_stack);
+                                     ctx.tbaa().tbaa_stack,
+                                     load_gc_roots(ctx, return_roots, returninfo.return_roots, ctx.tbaa().tbaa_gcframe));
             retval.Vboxed = box;
             break;
         }
@@ -5651,7 +5680,7 @@ static jl_cgval_t emit_varinfo(jl_codectx_t &ctx, jl_varinfo_t &vi, jl_sym_t *va
         }
         if (vi.inline_roots) {
             AllocaInst *varslot = vi.inline_roots;
-            size_t nroots = cast<ConstantInt>(varslot->getArraySize())->getZExtValue();
+            size_t nroots = vi.inline_roots_count;
             auto T_prjlvalue = varslot->getAllocatedType();
             if (auto AT = dyn_cast<ArrayType>(T_prjlvalue)) {
                 nroots *= AT->getNumElements();
@@ -5731,14 +5760,16 @@ static void emit_vi_assignment_unboxed(jl_codectx_t &ctx, jl_varinfo_t &vi, Valu
         // This check should probably mostly catch the relevant situations.
         if (vi.value.V != nullptr ? vi.value.V != rval_info.V : vi.inline_roots != nullptr) {
             MDNode *tbaa = ctx.tbaa().tbaa_stack; // Use vi.value.tbaa ?
-            if (rval_info.TIndex)
-                emit_unionmove(ctx, vi.value.V, tbaa, rval_info, /*skip*/isboxed, vi.isVolatile);
+            auto roots_ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe);
+            if (rval_info.TIndex) {
+                Value *Vnull = Constant::getNullValue(ctx.types().T_prjlvalue);
+                SmallVector<Value*,0> inline_roots(vi.inline_roots_count, Vnull);
+                emit_unionmove(ctx, vi.value.V, vi.value.typ, MutableArrayRef(inline_roots), tbaa, rval_info, /*skip*/isboxed, vi.isVolatile);
+                store_all_roots(ctx, inline_roots, vi.inline_roots, roots_ai, vi.isVolatile);
+            }
             else {
                 Align align(julia_alignment(rval_info.typ));
-                if (vi.inline_roots)
-                    split_value_into(ctx, rval_info, align, vi.value.V, /*shadow*/nullptr, align, jl_aliasinfo_t::fromTBAA(ctx, tbaa), vi.inline_roots, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe), vi.isVolatile);
-                else
-                    emit_unbox_store(ctx, rval_info, vi.value.V, tbaa, align, align, vi.isVolatile);
+                split_value_into(ctx, rval_info, align, vi.value.V, align, jl_aliasinfo_t::fromTBAA(ctx, tbaa), vi.inline_roots, roots_ai, vi.isVolatile);
             }
         }
     }
@@ -5772,14 +5803,17 @@ static void emit_phinode_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r)
     // used. Hopefully LLVM will be able to fold this back where legal.
     if (jl_is_uniontype(phiType)) {
         bool allunbox;
-        size_t min_align, nbytes;
-        // (BIG) TODO: This `require_pointerfree` could be relaxed so that we keep on the stack any union values
-        // that are pointer-free (and therefore analyzable by the GC passes), but it requires more plumbing so
-        // that we don't ruin the `typ === typ` fast-path for `convert_julia_type`
-        //
-        // The alternative fix is to try to copy around the GC shadow sufficiently that we support all of the
-        // pointer-ful union types in the first place.
-        dest = try_emit_union_alloca(ctx, ((jl_uniontype_t*)phiType), allunbox, min_align, nbytes, /* require_pointerfree */ true, "unionalloc_phi");
+        size_t min_align, nbytes, inline_roots;
+        dest = try_emit_union_alloca(ctx, ((jl_uniontype_t*)phiType), allunbox, min_align, nbytes, inline_roots);
+        if (inline_roots) {
+            assert(dest || allunbox);
+            roots.resize(inline_roots);
+            for (size_t nr = 0; nr < inline_roots; nr++) {
+                auto root_phi = PHINode::Create(ctx.types().T_prjlvalue, jl_array_nrows(edges), "root_phi");
+                root_phi->insertInto(BB, InsertPt);
+                roots[nr] = root_phi;
+            }
+        }
         if (dest) {
             AllocaInst *phi = cast<AllocaInst>(dest->clone());
             phi->insertAfter(dest);
@@ -5795,7 +5829,8 @@ static void emit_phinode_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r)
             Value *ptr = ctx.builder.CreateSelect(isboxed,
                 decay_derived(ctx, ptr_phi),
                 decay_derived(ctx, phi));
-            jl_cgval_t val = mark_julia_slot(ptr, phiType, Tindex_phi, best_tbaa(ctx.tbaa(), phiType));
+            jl_cgval_t val = mark_julia_slot(ptr, phiType, Tindex_phi, best_tbaa(ctx.tbaa(), phiType),
+                roots.empty() ? ArrayRef<Value*>() : ArrayRef((Value *const *)&roots.front(), roots.size()));
             val.Vboxed = ptr_phi;
             ctx.PhiNodes.push_back(std::make_tuple(val, BB, dest, ptr_phi, roots, r));
             ctx.SAvalues[idx] = val;
@@ -5805,7 +5840,8 @@ static void emit_phinode_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r)
         else if (allunbox) {
             PHINode *Tindex_phi = PHINode::Create(getInt8Ty(ctx.builder.getContext()), jl_array_nrows(edges), "tindex_phi");
             Tindex_phi->insertInto(BB, InsertPt);
-            jl_cgval_t val = mark_julia_slot(NULL, phiType, Tindex_phi, ctx.tbaa().tbaa_stack);
+            jl_cgval_t val = mark_julia_slot(NULL, phiType, Tindex_phi, ctx.tbaa().tbaa_stack,
+                roots.empty() ? ArrayRef<Value*>() : ArrayRef((Value *const *)&roots.front(), roots.size()));
             ctx.PhiNodes.push_back(std::make_tuple(val, BB, dest, (PHINode*)nullptr, roots, r));
             ctx.SAvalues[idx] = val;
             ctx.ssavalue_assigned[idx] = true;
@@ -6045,7 +6081,7 @@ static void emit_upsilonnode(jl_codectx_t &ctx, ssize_t phic, jl_value_t *val)
             if (vi.inline_roots) {
                 // memory optimization: make gc pointers re-initialized to NULL
                 AllocaInst *ssaroots = vi.inline_roots;
-                size_t nroots = cast<ConstantInt>(ssaroots->getArraySize())->getZExtValue();
+                size_t nroots = vi.inline_roots_count;
                 auto T_prjlvalue = ssaroots->getAllocatedType();
                 if (auto AT = dyn_cast<ArrayType>(T_prjlvalue)) {
                     nroots *= AT->getNumElements();
@@ -6997,29 +7033,26 @@ static void emit_specsig_to_specsig(
     case jl_returninfo_t::SRet: {
         Value *sret = &*gf_thunk->arg_begin();
         Align align(julia_alignment(rettype));
-        if (return_roots) {
-            Value *roots = gf_thunk->arg_begin() + 1; // root1 has type [n x {}*]*
-            split_value_into(ctx, gf_retval, align, sret, align, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack), roots, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe));
-        }
-        else {
-            emit_unbox_store(ctx, gf_retval, sret, ctx.tbaa().tbaa_stack, align, align);
-        }
+        Value *roots = return_roots ? gf_thunk->arg_begin() + 1 : nullptr; // root1 has type [n x {}*]*
+        split_value_into(ctx, gf_retval, align, sret, align, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack), roots, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe));
         ctx.builder.CreateRetVoid();
         break;
     }
     case jl_returninfo_t::Union: {
+        Type *retty = gf_thunk->getReturnType();
+        Value *tindex = compute_box_tindex(ctx, emit_typeof(ctx, gf_retval, false, true), (jl_value_t*)jl_any_type, rettype);
         Value *gf_ret = boxed(ctx, gf_retval); // TODO: this is not the most optimal way to emit this
         if (return_roots) {
-            Value *root1 = gf_thunk->arg_begin() + 1; // root1 has type [n x {}*]*
-            #if JL_LLVM_VERSION < 170000
-            assert(cast<PointerType>(root1->getType())->isOpaqueOrPointeeTypeMatches(get_returnroots_type(ctx, return_roots)));
-            #endif
-            root1 = ctx.builder.CreateConstInBoundsGEP2_32(get_returnroots_type(ctx, return_roots), root1, 0, 0);
-            ctx.builder.CreateStore(gf_ret, root1);
+            Value *skip = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0x00));
+            Argument *sret = gf_thunk->arg_begin();
+            Argument *roots = gf_thunk->arg_begin() + 1; // root1 has type [n x {}*]*
+            auto roots_ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe);
+            Value *Vnull = Constant::getNullValue(ctx.types().T_prjlvalue);
+            SmallVector<Value*,0> inline_roots(return_roots, Vnull);
+            emit_unionmove(ctx, sret, rettype, MutableArrayRef(inline_roots), ctx.tbaa().tbaa_stack, gf_retval, /*skip*/skip);
+            store_all_roots(ctx, inline_roots, roots, roots_ai, false);
         }
-        Type *retty = gf_thunk->getReturnType();
-        Value *retval = UndefValue::get(retty);
-        Value *tindex = compute_box_tindex(ctx, emit_typeof(ctx, gf_retval, false, true), (jl_value_t*)jl_any_type, rettype);
+        Value *retval = Constant::getNullValue(retty);
         tindex = ctx.builder.CreateOr(tindex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), UNION_BOX_MARKER));
         retval = ctx.builder.CreateInsertValue(retval, gf_ret, 0);
         retval = ctx.builder.CreateInsertValue(retval, tindex, 1);
@@ -7920,7 +7953,7 @@ static jl_returninfo_t get_specsig_function(jl_codegen_params_t &params, Module 
         union_alloca_type((jl_uniontype_t*)jlrettype, allunbox, props.union_bytes, props.union_align,
                 props.union_minalign, return_roots);
         props.return_roots = (int) return_roots;
-        if (props.union_bytes) {
+        if (props.union_bytes || props.return_roots) {
             props.cc = jl_returninfo_t::Union;
             fsig.push_back(PointerType::getUnqual(M->getContext()));
             argnames.push_back("union_bytes_return");
@@ -7984,7 +8017,6 @@ static jl_returninfo_t get_specsig_function(jl_codegen_params_t &params, Module 
     }
     if (props.cc == jl_returninfo_t::Union) {
         AttrBuilder param(M->getContext());
-        param.addAttribute("julia.sret");
         param.addAttribute(Attribute::NoAlias);
         param.addAttribute(Attribute::NoCapture);
         param.addAttribute(Attribute::NoUndef);
@@ -8638,8 +8670,8 @@ static jl_llvm_functions_t
         }
         else if (jl_is_uniontype(jt)) {
             bool allunbox;
-            size_t align, nbytes;
-            Value *lv = try_emit_union_alloca(ctx, (jl_uniontype_t*)jt, allunbox, align, nbytes, /* require_pointerfree */ false, "unionalloc_local");
+            size_t align, nbytes, inline_roots;
+            Value *lv = try_emit_union_alloca(ctx, (jl_uniontype_t*)jt, allunbox, align, nbytes, inline_roots);
             if (lv) {
                 lv->setName(jl_symbol_name(s));
                 varinfo.value = mark_julia_slot(lv, jt, NULL, ctx.tbaa().tbaa_stack);
@@ -8658,6 +8690,11 @@ static jl_llvm_functions_t
             }
             if (lv || allunbox)
                 alloc_def_flag(ctx, varinfo);
+            if (inline_roots) {
+                AllocaInst *roots = emit_static_roots(ctx, inline_roots);
+                varinfo.inline_roots = roots;
+                varinfo.inline_roots_count = inline_roots;
+            }
             if (allunbox)
                 return;
         }
@@ -8669,6 +8706,7 @@ static jl_llvm_functions_t
             if (roots) roots->setName(StringRef(".roots.") + jl_symbol_name(s));
             varinfo.value = mark_julia_slot(bits, jt, NULL, ctx.tbaa().tbaa_stack, None);
             varinfo.inline_roots = roots;
+            varinfo.inline_roots_count = sizes.second;
             alloc_def_flag(ctx, varinfo);
             if (debug_enabled && varinfo.dinfo) {
                 assert((Metadata*)varinfo.dinfo->getType() != debugcache.jl_pvalue_dillvmt);
@@ -9271,33 +9309,42 @@ static jl_llvm_functions_t
                 retval = NULL;
                 break;
             case jl_returninfo_t::Union: {
-                Value *data, *tindex;
+                Value *tindex;
+                Value *data = nullptr;
                 if (retvalinfo.TIndex) {
                     tindex = retvalinfo.TIndex;
-                    data = Constant::getNullValue(ctx.types().T_prjlvalue);
-                    if (retvalinfo.V == NULL) {
-                        // treat this as a simple Ghosts
-                        sret = NULL;
+                    if (!returninfo.return_roots) {
+                        if (retvalinfo.V == NULL) {
+                            // treat this as a simple Ghosts
+                            sret = NULL;
+                        }
+                        else if (retvalinfo.Vboxed) {
+                            // also need to account for the possibility the return object is boxed
+                            // and avoid / skip attempting to copy it to the stack
+                            isboxed_union = ctx.builder.CreateICmpNE(
+                                ctx.builder.CreateAnd(tindex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), UNION_BOX_MARKER)),
+                                ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0));
+                        }
                     }
-                    else if (retvalinfo.Vboxed) {
-                        // also need to account for the possibility the return object is boxed
-                        // and avoid / skip copying it to the stack
-                        isboxed_union = ctx.builder.CreateICmpNE(
-                            ctx.builder.CreateAnd(tindex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), UNION_BOX_MARKER)),
-                            ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0));
-                        data = ctx.builder.CreateSelect(isboxed_union, retvalinfo.Vboxed, data);
+                    else {
+                        isboxed_union = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), UNION_BOX_MARKER));
                     }
+                    data = retvalinfo.Vboxed;
                 }
                 else {
                     // treat this as a simple boxed returninfo
                     //assert(retvalinfo.isboxed);
                     tindex = compute_tindex_unboxed(ctx, retvalinfo, jlrettype);
+                    if (!returninfo.return_roots)
+                        sret = NULL; // skip all
+                    else
+                        isboxed_union = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0));
                     tindex = ctx.builder.CreateOr(tindex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), UNION_BOX_MARKER));
                     data = boxed(ctx, retvalinfo);
-                    sret = NULL;
                 }
-                retval = UndefValue::get(retty);
-                retval = ctx.builder.CreateInsertValue(retval, data, 0);
+                retval = Constant::getNullValue(retty);
+                if (data)
+                    retval = ctx.builder.CreateInsertValue(retval, data, 0);
                 retval = ctx.builder.CreateInsertValue(retval, tindex, 1);
                 break;
             }
@@ -9305,39 +9352,31 @@ static jl_llvm_functions_t
                 retval = compute_tindex_unboxed(ctx, retvalinfo, jlrettype);
                 break;
             }
+            auto roots_ai = jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe);
             if (sret) {
-                Align align(returninfo.union_align);
-                if (!returninfo.return_roots && !retvalinfo.inline_roots.empty()) {
-                    assert(retvalinfo.V == nullptr);
-                    assert(returninfo.cc == jl_returninfo_t::SRet);
-                    split_value_into(ctx, retvalinfo, align, nullptr, align,
-                            jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack), sret, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe));
-                }
-                else if (returninfo.return_roots) {
-                    assert(returninfo.cc == jl_returninfo_t::SRet);
+                if (returninfo.return_roots) {
                     Value *return_roots = f->arg_begin() + 1;
-                    split_value_into(ctx, retvalinfo, align, sret, align,
-                            jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack), return_roots, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_gcframe));
+                    Value *Vnull = Constant::getNullValue(ctx.types().T_prjlvalue);
+                    SmallVector<Value*,0> inline_roots(returninfo.return_roots, Vnull);
+                    emit_unionmove(ctx, sret, jlrettype, MutableArrayRef(inline_roots), ctx.tbaa().tbaa_stack, retvalinfo, /*skip*/isboxed_union);
+                    store_all_roots(ctx, inline_roots, return_roots, roots_ai, false);
+                }
+                else if (retvalinfo.V == nullptr && !retvalinfo.inline_roots.empty()) {
+                    // not returning into roots and don't have a value: might just have roots (might also be all ghost)
+                    store_all_roots(ctx, ArrayRef(retvalinfo.inline_roots).slice(0, std::min(retvalinfo.inline_roots.size(), (size_t)returninfo.union_bytes / sizeof(void*))),
+                            sret, roots_ai, false);
                 }
                 else if (retvalinfo.ispointer()) {
-                    if (returninfo.cc == jl_returninfo_t::SRet) {
-                        assert(jl_is_concrete_type(jlrettype));
-                        emit_memcpy(ctx, sret, jl_aliasinfo_t::fromTBAA(ctx, nullptr), retvalinfo,
-                                    jl_datatype_size(jlrettype), align, align);
-                    }
-                    else { // must be jl_returninfo_t::Union
-                        jl_cgval_shadow_t shadow = {
-                            /* n_roots */ returninfo.return_roots,
-                            /* value */ f->arg_begin() + 1,
-                            /* typ */ get_returnroots_type(ctx, returninfo.return_roots),
-                        };
-                        emit_unionmove(ctx, sret, &shadow, /*tbaa_dst*/nullptr, retvalinfo, /*skip*/isboxed_union);
-                    }
+                    emit_unionmove(ctx, sret, jlrettype, /*inline_roots*/MutableArrayRef<Value*>(), /*tbaa_dst*/nullptr, retvalinfo, /*skip*/isboxed_union);
                 }
                 else {
+                    Align align(returninfo.union_align);
                     ctx.builder.CreateAlignedStore(retvalinfo.V, sret, align);
                     assert(retvalinfo.TIndex == NULL && "unreachable"); // unimplemented representation
                 }
+            }
+            else {
+                assert(!returninfo.return_roots);
             }
 
             mallocVisitStmt(sync_bytes, have_dbg_update);
@@ -9576,10 +9615,7 @@ static jl_llvm_functions_t
                         SmallVector<Value*,0> mayberoots(tracked, Constant::getNullValue(ctx.types().T_prjlvalue));
                         if (typedval.typ != jl_bottom_type) {
                             Align align(julia_alignment(phiType));
-                            if (tracked)
-                                split_value_into(ctx, typedval, align, dest, align, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack), mayberoots);
-                            else
-                                emit_unbox_store(ctx, typedval, dest, ctx.tbaa().tbaa_stack, align, align);
+                            split_value_into(ctx, typedval, align, dest, align, jl_aliasinfo_t::fromTBAA(ctx, ctx.tbaa().tbaa_stack), false, mayberoots);
                         }
                         return mayberoots;
                     });
@@ -9587,9 +9623,9 @@ static jl_llvm_functions_t
                         roots[nr]->addIncoming(incomingroots[nr], ctx.builder.GetInsertBlock());
                 }
                 else if (!roots.empty()) {
-                    Value *V = Constant::getNullValue(ctx.types().T_prjlvalue);
+                    Value *Vnull = Constant::getNullValue(ctx.types().T_prjlvalue);
                     for (size_t nr = 0; nr < roots.size(); nr++)
-                        roots[nr]->addIncoming(V, ctx.builder.GetInsertBlock());
+                        roots[nr]->addIncoming(Vnull, ctx.builder.GetInsertBlock());
                 }
             }
             else {
@@ -9598,7 +9634,8 @@ static jl_llvm_functions_t
                 // `V` is always initialized when it is used.
                 // Ref https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96629
                 Value *V = nullptr;
-                assert(roots.empty());
+                Value *Vnull = Constant::getNullValue(ctx.types().T_prjlvalue);
+                SmallVector<Value*,0> lroots(roots.size(), Vnull);
                 if (val.typ == (jl_value_t*)jl_bottom_type) {
                     if (VN)
                         V = undef_value_for_type(VN->getType());
@@ -9614,10 +9651,10 @@ static jl_llvm_functions_t
                     else {
                         if (VN)
                             V = Constant::getNullValue(ctx.types().T_prjlvalue);
-                        if (dest) {
-                            Align align(julia_alignment(val.typ));
-                            emit_unbox_store(ctx, val, dest, ctx.tbaa().tbaa_stack, align, align);
-                        }
+                        if (dest)
+                            emit_unionmove(ctx, dest, phiType, MutableArrayRef(lroots), ctx.tbaa().tbaa_stack, val, nullptr);
+                        else
+                            assert(VN == nullptr); // allunbox
                         RTindex = ConstantInt::get(getInt8Ty(ctx.builder.getContext()), tindex);
                     }
                 }
@@ -9641,14 +9678,23 @@ static jl_llvm_functions_t
                         V = new_union.Vboxed ? new_union.Vboxed : Constant::getNullValue(ctx.types().T_prjlvalue);
                     if (dest) { // basically, if !ghost union
                         if (new_union.Vboxed != nullptr) {
-                            Value *isboxed = ctx.builder.CreateICmpNE( // if UNION_BOX_MARKER is set, we won't select this slot anyways
+                            Value *isboxed;
+                            if (roots.size())
+                                isboxed = ctx.builder.CreateICmpEQ(RTindex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), UNION_BOX_MARKER));
+                            else
+                                isboxed = ctx.builder.CreateICmpNE( // if UNION_BOX_MARKER is set, we won't select this slot anyways
                                     ctx.builder.CreateAnd(RTindex, ConstantInt::get(getInt8Ty(ctx.builder.getContext()), UNION_BOX_MARKER)),
                                     ConstantInt::get(getInt8Ty(ctx.builder.getContext()), 0));
                             skip = skip ? ctx.builder.CreateOr(isboxed, skip) : isboxed;
                         }
-                        emit_unionmove(ctx, dest, /*shadow*/nullptr, ctx.tbaa().tbaa_arraybuf, new_union, skip);
+                        emit_unionmove(ctx, dest, phiType, MutableArrayRef(lroots), ctx.tbaa().tbaa_arraybuf, new_union, skip);
+                    }
+                    else {
+                        assert(VN == nullptr); // allunbox
                     }
                 }
+                for (size_t nr = 0; nr < roots.size(); nr++)
+                    roots[nr]->addIncoming(lroots[nr], ctx.builder.GetInsertBlock());
                 if (VN)
                     VN->addIncoming(V, ctx.builder.GetInsertBlock());
                 if (TindexN)

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1166,8 +1166,8 @@ static jl_cgval_t emit_ifelse(jl_codectx_t &ctx, jl_cgval_t c, jl_cgval_t x, jl_
         if (t2 == jl_bottom_type)
             return x;
         if (t1 != t2 && jl_is_uniontype(rt_hint)) { // TODO(jwn): && supports TIndex
-            x = convert_julia_type_to_union(ctx, x, rt_hint, nullptr);
-            y = convert_julia_type_to_union(ctx, y, rt_hint, nullptr);
+            x = convert_julia_type_to_union(ctx, x, rt_hint, false);
+            y = convert_julia_type_to_union(ctx, y, rt_hint, false);
             t1 = x.typ;
             t2 = y.typ;
         }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1165,7 +1165,7 @@ static jl_cgval_t emit_ifelse(jl_codectx_t &ctx, jl_cgval_t c, jl_cgval_t x, jl_
             return y;
         if (t2 == jl_bottom_type)
             return x;
-        if (t1 != t2 && jl_is_uniontype(rt_hint)) { // TODO(jwn): && supports TIndex
+        if (t1 != t2 && jl_is_uniontype(rt_hint) && is_uniontype_anyunboxed(rt_hint)) {
             x = convert_julia_type_to_union(ctx, x, rt_hint, false);
             y = convert_julia_type_to_union(ctx, y, rt_hint, false);
             t1 = x.typ;

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1165,9 +1165,11 @@ static jl_cgval_t emit_ifelse(jl_codectx_t &ctx, jl_cgval_t c, jl_cgval_t x, jl_
             return y;
         if (t2 == jl_bottom_type)
             return x;
-        if (t1 != t2 && jl_is_uniontype(rt_hint)) { // TODO: && worthwhile
+        if (t1 != t2 && jl_is_uniontype(rt_hint)) { // TODO(jwn): && supports TIndex
             x = convert_julia_type_to_union(ctx, x, rt_hint, nullptr);
             y = convert_julia_type_to_union(ctx, y, rt_hint, nullptr);
+            t1 = x.typ;
+            t2 = y.typ;
         }
     }
     if (t1 == jl_bottom_type)

--- a/src/llvm-codegen-shared.h
+++ b/src/llvm-codegen-shared.h
@@ -103,7 +103,7 @@ struct CountTrackedPointers {
     CountTrackedPointers(llvm::Type *T, bool ignore_loaded=false);
 };
 
-llvm::SmallVector<llvm::Value*, 0> ExtractTrackedValues(llvm::Value *Src, llvm::Type *STy, bool isptr, llvm::IRBuilder<> &irbuilder, llvm::ArrayRef<unsigned> perm_offsets={});
+llvm::SmallVector<llvm::SmallVector<unsigned, 0>, 0> TrackCompositeType(llvm::Type *T);
 
 static inline void llvm_dump(llvm::Value *v)
 {

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1149,43 +1149,49 @@ void LateLowerGCFrame::FixUpRefinements(ArrayRef<int> PHINumbers, State &S)
 }
 
 // Look through instructions to find all possible allocas that might become the sret argument
-static std::optional<SmallSetVector<AllocaInst *, 8>> FindSretAllocas(Value* SRetArg) {
-    SmallSetVector<AllocaInst *, 8> allocas;
+static SmallSetVector<AllocaInst *, 1> FindSretAllocas(Value* SRetArg) {
+    SmallSetVector<AllocaInst *, 1> allocas;
     if (AllocaInst *OneSRet = dyn_cast<AllocaInst>(SRetArg)) {
         allocas.insert(OneSRet); // Found it directly
-    } else {
+    }
+    else {
         SmallSetVector<Value *, 8> worklist;
         worklist.insert(SRetArg);
         while (!worklist.empty()) {
             Value *V = worklist.pop_back_val();
             if (AllocaInst *Alloca = dyn_cast<AllocaInst>(V->stripInBoundsOffsets())) {
                 allocas.insert(Alloca); // Found a candidate
-            } else if (PHINode *Phi = dyn_cast<PHINode>(V)) {
+            }
+            else if (PHINode *Phi = dyn_cast<PHINode>(V)) {
                 for (Value *Incoming : Phi->incoming_values()) {
                     worklist.insert(Incoming);
                 }
-            } else if (SelectInst *SI = dyn_cast<SelectInst>(V)) {
+            }
+            else if (SelectInst *SI = dyn_cast<SelectInst>(V)) {
                 auto TrueBranch = SI->getTrueValue();
                 auto FalseBranch = SI->getFalseValue();
                 if (TrueBranch && FalseBranch) {
                     worklist.insert(TrueBranch);
                     worklist.insert(FalseBranch);
-                } else {
+                }
+                else {
                     llvm_dump(SI);
                     dbgs() << "Malformed Select\n";
-                    return {};
+                    allocas.clear();
+                    return allocas;
                 }
-            } else {
+            }
+            else {
                 llvm_dump(V);
                 dbgs() << "Unexpected SRet argument\n";
-                return {};
+                allocas.clear();
+                return allocas;
             }
         }
     }
-    assert(allocas.size() > 0);
     assert(std::all_of(allocas.begin(), allocas.end(), [&] (AllocaInst* SRetAlloca) JL_NOTSAFEPOINT {
             return (SRetAlloca->getArraySize() == allocas[0]->getArraySize() &&
-            SRetAlloca->getAllocatedType() == allocas[0]->getAllocatedType());
+                SRetAlloca->getAllocatedType() == allocas[0]->getAllocatedType());
         }
     ));
     return allocas;
@@ -1245,48 +1251,27 @@ State LateLowerGCFrame::LocalScan(Function &F) {
                         BBS.FirstSafepointAfterFirstDef = BBS.FirstSafepoint;
                 }
                 bool HasDefBefore = false;
-                if (CI->hasStructRetAttr()) {
-                    Type *ElT = getAttributeAtIndex(CI->getAttributes(), 1, Attribute::StructRet).getValueAsType();
-                    auto tracked = CountTrackedPointers(ElT, true);
-                    if (tracked.count) {
-                        HasDefBefore = true;
-                        auto allocas_opt = FindSretAllocas((CI->arg_begin()[0])->stripInBoundsOffsets());
+                // Loop over all arguments to find those with "julia.return_roots" attribute
+                AttributeList Attrs = CI->getAttributes();
+                for (unsigned i = 0; i < CI->arg_size(); ++i) {
+                    Attribute RetRootsAttr = Attrs.getParamAttr(i, "julia.return_roots");
+                    if (RetRootsAttr.isValid()) {
+                        size_t return_roots = atol(RetRootsAttr.getValueAsString().data());
+                        assert(return_roots);
+                        auto gc_allocas = FindSretAllocas(CI->getArgOperand(i)->stripInBoundsOffsets());
                         // We know that with the right optimizations we can forward a sret directly from an argument
                         // This hasn't been seen without adding IPO effects to julia functions but it's possible we need to handle that too
-                        // If they are tracked.all we can just pass through but if they have a roots bundle it's possible we need to emit some copies ¯\_(ツ)_/¯
-                        if (!allocas_opt.has_value()) {
+                        if (gc_allocas.size() == 0) {
                             llvm_dump(&F);
                             abort();
                         }
-                        auto allocas = allocas_opt.value();
-                        for (AllocaInst *SRet : allocas) {
-                            if (!(SRet->isStaticAlloca() && isa<PointerType>(ElT) && ElT->getPointerAddressSpace() == AddressSpace::Tracked)) {
-                                assert(!tracked.derived);
-                                if (tracked.all) {
-                                    S.ArrayAllocas[SRet] = tracked.count * cast<ConstantInt>(SRet->getArraySize())->getZExtValue();
-                                }
-                                else {
-                                    Value *arg1 = (CI->arg_begin()[1])->stripInBoundsOffsets();
-                                    auto gc_allocas_opt = FindSretAllocas(arg1);
-                                    if (!gc_allocas_opt.has_value()) {
-                                        llvm_dump(&F);
-                                        abort();
-                                    }
-                                    auto gc_allocas = gc_allocas_opt.value();
-                                    if (gc_allocas.size() == 0) {
-                                        llvm_dump(CI);
-                                        errs() << "Expected one Alloca at least\n";
-                                        abort();
-                                    }
-                                    else {
-                                        for (AllocaInst* SRet_gc : gc_allocas) {
-                                            Type *ElT = SRet_gc->getAllocatedType();
-                                            if (!(SRet_gc->isStaticAlloca() && isa<PointerType>(ElT) && ElT->getPointerAddressSpace() == AddressSpace::Tracked)) {
-                                                S.ArrayAllocas[SRet_gc] = tracked.count * cast<ConstantInt>(SRet_gc->getArraySize())->getZExtValue();
-                                            }
-                                        }
-                                    }
-                                }
+                        for (AllocaInst *SRet_gc : gc_allocas) {
+                            Type *ElT = SRet_gc->getAllocatedType();
+                            if (!(SRet_gc->isStaticAlloca() && isa<PointerType>(ElT) && ElT->getPointerAddressSpace() == AddressSpace::Tracked)) {
+                                // this is a umax operation since we sometimes see the calls cloned, although we don't see these reused for different sizes
+                                auto &live_roots = S.ArrayAllocas[SRet_gc];
+                                if (live_roots < return_roots)
+                                    live_roots = return_roots;
                             }
                         }
                     }

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1258,6 +1258,7 @@ State LateLowerGCFrame::LocalScan(Function &F) {
                     if (RetRootsAttr.isValid()) {
                         size_t return_roots = atol(RetRootsAttr.getValueAsString().data());
                         assert(return_roots);
+                        HasDefBefore = true;
                         auto gc_allocas = FindSretAllocas(CI->getArgOperand(i)->stripInBoundsOffsets());
                         // We know that with the right optimizations we can forward a sret directly from an argument
                         // This hasn't been seen without adding IPO effects to julia functions but it's possible we need to handle that too

--- a/test/llvmpasses/late-lower-gc-sret.ll
+++ b/test/llvmpasses/late-lower-gc-sret.ll
@@ -4,7 +4,7 @@
 
 declare ptr @julia.get_pgcstack()
 
-declare swiftcc void @sret_call(ptr noalias nocapture noundef nonnull sret([3 x ptr addrspace(10)]), ptr nonnull swiftself, ptr addrspace(10) nonnull)
+declare swiftcc void @sret_call(ptr noalias nocapture noundef nonnull "julia.return_roots"="3" sret([3 x ptr addrspace(10)]), ptr nonnull swiftself, ptr addrspace(10) nonnull)
 
 define hidden swiftcc nonnull ptr addrspace(10) @sret_select(ptr nonnull swiftself "gcstack" %0, ptr addrspace(10) noundef nonnull align 8 dereferenceable(88) %1, i1 %unpredictable) {
   ; CHECK-LABEL: @sret_select
@@ -17,7 +17,7 @@ define hidden swiftcc nonnull ptr addrspace(10) @sret_select(ptr nonnull swiftse
   %3 = alloca [3 x i64], align 8
   %4 = alloca [3 x i64], align 8
   %5 = select i1 %unpredictable, ptr %3, ptr %4
-  call swiftcc void @sret_call(ptr noalias nocapture noundef nonnull sret([3 x ptr addrspace(10)]) %5, ptr nonnull swiftself "gcstack" %0, ptr addrspace(10) nonnull %1)
+  call swiftcc void @sret_call(ptr noalias nocapture noundef nonnull "julia.return_roots"="3" sret([3 x ptr addrspace(10)]) %5, ptr nonnull swiftself "gcstack" %0, ptr addrspace(10) nonnull %1)
   ; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
   ret ptr addrspace(10) %1
 }
@@ -43,12 +43,12 @@ false:                                            ; preds = %top
 
 ret:                                              ; preds = %false, %true
   %4 = phi ptr [ %2, %true ], [ %3, %false ]
-  call swiftcc void @sret_call(ptr noalias nocapture noundef nonnull sret([3 x ptr addrspace(10)]) %4, ptr nonnull swiftself "gcstack" %0, ptr addrspace(10) nonnull %1)
+  call swiftcc void @sret_call(ptr noalias nocapture noundef nonnull "julia.return_roots"="3" sret([3 x ptr addrspace(10)]) %4, ptr nonnull swiftself "gcstack" %0, ptr addrspace(10) nonnull %1)
   ; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
   ret ptr addrspace(10) %1
 }
 
-declare swiftcc void @sret_call_gc(ptr noalias nocapture noundef sret({ ptr addrspace(10), i64, i64 }), ptr noalias nocapture noundef, ptr nonnull swiftself)
+declare swiftcc void @sret_call_gc(ptr noalias nocapture noundef sret({ ptr addrspace(10), i64, i64 }), ptr noalias nocapture noundef "julia.return_roots"="1", ptr nonnull swiftself)
 
 define hidden swiftcc void @sret_gc_root_phi(ptr nonnull swiftself "gcstack" %0, i1 %unpredictable) {
 top:
@@ -75,7 +75,7 @@ false:                                            ; preds = %top
 
 ret:                                              ; preds = %false, %true
   %4 = phi ptr [ %2, %true ], [ %3, %false ]
-  call swiftcc void @sret_call_gc(ptr noalias nocapture noundef sret({ ptr addrspace(10), i64, i64 }) %1, ptr noalias nocapture noundef %4, ptr nonnull swiftself "gcstack" %0)
+  call swiftcc void @sret_call_gc(ptr noalias nocapture noundef sret({ ptr addrspace(10), i64, i64 }) %1, ptr noalias nocapture noundef "julia.return_roots"="1" %4, ptr nonnull swiftself "gcstack" %0)
    ; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
   ret void
 }
@@ -110,7 +110,7 @@ false:                                            ; preds = %top
 ret:                                              ; preds = %false, %true
   %5 = phi ptr [ %2, %true ], [ %3, %false ]
   %6 = select i1 %unpredictable2, ptr %4, ptr %5
-  call swiftcc void @sret_call_gc(ptr noalias nocapture noundef sret({ ptr addrspace(10), i64, i64 }) %1, ptr noalias nocapture noundef %6, ptr nonnull swiftself "gcstack" %0)
+  call swiftcc void @sret_call_gc(ptr noalias nocapture noundef sret({ ptr addrspace(10), i64, i64 }) %1, ptr noalias nocapture noundef "julia.return_roots"="1" %6, ptr nonnull swiftself "gcstack" %0)
    ; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
   ret void
 }
@@ -145,7 +145,7 @@ false:                                            ; preds = %top
 ret:                                              ; preds = %false, %true
   %6 = phi ptr [ %2, %true ], [ %5, %false ]
 
-  call swiftcc void @sret_call_gc(ptr noalias nocapture noundef sret({ ptr addrspace(10), i64, i64 }) %1, ptr noalias nocapture noundef %6, ptr nonnull swiftself "gcstack" %0)
+  call swiftcc void @sret_call_gc(ptr noalias nocapture noundef sret({ ptr addrspace(10), i64, i64 }) %1, ptr noalias nocapture noundef "julia.return_roots"="1" %6, ptr nonnull swiftself "gcstack" %0)
    ; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)
   ret void
 }

--- a/test/llvmpasses/late-lower-gc.ll
+++ b/test/llvmpasses/late-lower-gc.ll
@@ -205,7 +205,7 @@ define swiftcc ptr addrspace(10) @insert_element(ptr swiftself "gcstack" %0) {
 ; CHECK: %gcframe = call ptr @julia.new_gc_frame(i32 10)
 ; CHECK: [[gc_slot_addr_:%.*]] = call ptr @julia.get_gc_frame_slot(ptr %gcframe, i32 0)
 ; CHECK: call void @julia.push_gc_frame(ptr %gcframe, i32 10)
-  call void null(ptr sret([2 x [5 x ptr addrspace(10)]]) %2, ptr null, ptr addrspace(11) null, ptr null)
+  call void null(ptr sret([2 x [5 x ptr addrspace(10)]]) "julia.return_roots"="10" %2, ptr null, ptr addrspace(11) null, ptr null)
   %4 = insertelement <4 x ptr> zeroinitializer, ptr %2, i32 0
 ; CHECK: [[gc_slot_addr_:%.*]] = insertelement <4 x ptr> zeroinitializer, ptr [[gc_slot_addr_:%.*]], i32 0
 ; CHECK: call void @julia.pop_gc_frame(ptr %gcframe)


### PR DESCRIPTION
This effectively expands our existing `union` ABI to cover both of these existing cases:
 - `sret`  ABI (which can stack-allocate a _single pointer-ful_ type)
 - `union` ABI (which can stack-allocate _many pointer-free_ types)

This provides some nice speed-ups for temporary "wrappers":
```julia
const v = Any[]
@noinline maybe_wrapped(i) = (i % 32 != 0) ? Some(v) : nothing
function foo()
    count = 0
    for i = 1:1_000_000
        count += (maybe_wrapped(i) !== nothing) ? 1 : 0
    end
    return count
end
```

On this PR this gives:
```julia
julia> @btime foo()
  1.675 ms (0 allocations: 0 bytes)
968750
```

compared to current master:
```julia
julia> @btime foo()
  6.877 ms (968750 allocations: 14.78 MiB)
968750
```

TODO:
 - [x] Figure out what to do about PHI nodes
 - [x] Figure out why https://github.com/JuliaLang/julia/issues/53584 is not fixed, if not the ϕ-node issue

The most outstanding TODO here is what to do about ϕ-nodes. Right now, if the incoming `Union{...}` type has a pointer-containing type then this change forces the incoming object to be boxed, even if the object at run-time is actually pointer-free.

But that's just a band-aid so the code works - it introduces new boxes where we didn't have them before, which is a regression that almost certainly needs to be fixed before landing this.