### PR TITLE
prefer jl_gc_new_weakref over jl_gc_new_weakref_th

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -448,8 +448,7 @@ end
 mutable struct WeakRef
     value
     WeakRef() = WeakRef(nothing)
-    WeakRef(@nospecialize(v)) = ccall(:jl_gc_new_weakref_th, Ref{WeakRef},
-                                      (Ptr{Cvoid}, Any), getptls(), v)
+    WeakRef(@nospecialize(v)) = ccall(:jl_gc_new_weakref, Ref{WeakRef}, (Any, ), v)
 end
 
 Tuple{}() = ()

--- a/src/gc.c
+++ b/src/gc.c
@@ -903,16 +903,6 @@ STATIC_INLINE void maybe_collect(jl_ptls_t ptls)
 
 // weak references
 
-JL_DLLEXPORT jl_weakref_t *jl_gc_new_weakref_th(jl_ptls_t ptls,
-                                                jl_value_t *value)
-{
-    jl_weakref_t *wr = (jl_weakref_t*)jl_gc_alloc(ptls, sizeof(void*),
-                                                  jl_weakref_type);
-    wr->value = value;  // NOTE: wb not needed here
-    small_arraylist_push(&ptls->heap.weak_refs, wr);
-    return wr;
-}
-
 static void clear_weak_refs(void)
 {
     assert(gc_n_threads);
@@ -4314,7 +4304,10 @@ JL_DLLEXPORT void jl_finalize(jl_value_t *o)
 JL_DLLEXPORT jl_weakref_t *jl_gc_new_weakref(jl_value_t *value)
 {
     jl_ptls_t ptls = jl_current_task->ptls;
-    return jl_gc_new_weakref_th(ptls, value);
+    jl_weakref_t *wr = (jl_weakref_t*)jl_gc_alloc(ptls, sizeof(void*), jl_weakref_type);
+    wr->value = value;  // NOTE: wb not needed here
+    small_arraylist_push(&ptls->heap.weak_refs, wr);
+    return wr;
 }
 
 JL_DLLEXPORT jl_value_t *jl_gc_allocobj(size_t sz)

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -167,7 +167,6 @@
     XX(jl_gc_mark_queue_objarray) \
     XX(jl_gc_max_internal_obj_size) \
     XX(jl_gc_new_weakref) \
-    XX(jl_gc_new_weakref_th) \
     XX(jl_gc_num) \
     XX(jl_gc_pool_alloc) \
     XX(jl_gc_pool_alloc_instrumented) \


### PR DESCRIPTION
Again, motivation is to clean up the GC interface a bit by removing possibly redundant functions.

@vtjnash, @gbaraldi: I suspect this is not breaking.

Please let me know if that's actually breaking, or whether you folks have any other concerns (e.g. performance? -- but that seems fine) about this change.