### PR TITLE
Revert "fix issue with loading stdlibs stalecheck inconsistency"

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1935,10 +1935,9 @@ end
                 dep = staledeps[i]
                 dep isa Module && continue
                 modpath, modkey, modbuild_id, modcachepath, modstaledeps, modocachepath = dep::Tuple{String, PkgId, UInt128, String, Vector{Any}, Union{Nothing, String}}
-                if stalecheck
+                dep = get(loaded_precompiles, modkey => modbuild_id, nothing)
+                if dep === nothing
                     dep = maybe_root_module(modkey)
-                else
-                    dep = get(loaded_precompiles, modkey => modbuild_id, nothing)
                 end
                 while true
                     if dep isa Module


### PR DESCRIPTION
This reverts commit 2cf14aa2bd67dbafb22cacb2417bc1e1bccb0e3d (reverts #54891)

Fixes https://github.com/JuliaLang/julia/issues/54940

This commit causes many packages to precompile on every load, take e.g. PhysicalConstants:

```
julia> using PhysicalConstants
┌ Debug: Loading object cache file /Users/kristoffercarlsson/.julia/compiled/v1.12/Calculus/G3wEN_cfgFb.dylib for Calculus [49dc2e85-a5d0-5ad3-a950-438e2897f1b9]
└ @ Base loading.jl:1227
┌ Debug: Loading object cache file /Users/kristoffercarlsson/.julia/juliaup/julia-nightly/share/julia/compiled/v1.12/Printf/3FQLY_MMwFm.dylib for Printf [de0858da-6303-5e67-8744-51eddeeeb8d7]
└ @ Base loading.jl:1227
┌ Debug: Rejecting cache file /Users/kristoffercarlsson/.julia/compiled/v1.12/PhysicalConstants/ykpMf_cfgFb.ji because required dependency Base.PkgId(Base.UUID("de0858da-6303-5e67-8744-51eddeeeb8d7"), "Printf") failed to load from cache file for /Users/kristoffercarlsson/.julia/juliaup/julia-nightly/share/julia/compiled/v1.12/Printf/3FQLY_MMwFm.ji.
│   exception = Error reading package image file.
└ @ Base loading.jl:1962
```