### PR TITLE
trace-compile: don't generate `precompile` statements for OpaqueClosure methods

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -2522,6 +2522,8 @@ static void record_precompile_statement(jl_method_instance_t *mi, double compila
         return;
     if (!jl_is_method(def))
         return;
+    if (def->is_for_opaque_closure)
+        return; // OpaqueClosure methods cannot be looked up by their types, so are incompatible with `precompile(...)`
 
     JL_LOCK(&precomp_statement_out_lock);
     if (s_precompile == NULL) {
@@ -2701,7 +2703,7 @@ jl_code_instance_t *jl_compile_method_internal(jl_method_instance_t *mi, size_t 
             // Something went wrong. Bail to the fallback path.
             codeinst = NULL;
         }
-        else if (did_compile) {
+        else if (did_compile && codeinst->owner == jl_nothing) {
             record_precompile_statement(mi, compile_time);
         }
         JL_GC_POP();


### PR DESCRIPTION
These Methods cannot be looked up via their type signature, so they are incompatible with the `precompile(...)` mechanism.