### PR TITLE
add missing setting of inferred field when setting inference result

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -609,6 +609,7 @@ JL_DLLEXPORT void jl_fill_codeinst(
     codeinst->analysis_results = analysis_results;
     assert(jl_atomic_load_relaxed(&codeinst->min_world) == 1);
     assert(jl_atomic_load_relaxed(&codeinst->max_world) == 0);
+    jl_atomic_store_release(&codeinst->inferred, jl_nothing);
     jl_atomic_store_release(&codeinst->min_world, min_world);
     jl_atomic_store_release(&codeinst->max_world, max_world);
 }


### PR DESCRIPTION
This previously could confuse inference, which expects that the field is set to indicate that the rettype has been computed, and cannot tolerate putting objects in the cache for which that is not true. This was causing Nanosoldier to fail.

Also cleanup `sv.unreachable` after IR modification so that it remains (mostly) consistent, even though unused (except for the unreachable nodes themselves), as this was confusing me in debugging.