### PR TITLE
Add fast method for copyto!(::Memory, ::Memory)

### DIFF
--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -163,6 +163,7 @@ end
 
 copy(a::T) where {T<:Memory} = ccall(:jl_genericmemory_copy, Ref{T}, (Any,), a)
 
+copyto!(dest::Memory, src::Memory) = copyto!(dest, 1, src, 1, length(src))
 function copyto!(dest::Memory, doffs::Integer, src::Memory, soffs::Integer, n::Integer)
     n < 0 && _throw_argerror("Number of elements to copy must be non-negative.")
     unsafe_copyto!(dest, doffs, src, soffs, n)

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -49,6 +49,15 @@ chnlprod(x) = Channel(c->for i in x; put!(c,i); end)
 
         @test_throws Union{BoundsError, ArgumentError} copyto!(dest, 1, src(), 2, 2)
     end
+
+    v = rand(Float32, 4)
+    a = Memory{Float32}(v)
+    b = similar(a)
+    copyto!(b, a)
+    @test a == b
+
+    c = Memory{Float32}(undef, 3)
+    @test_throws BoundsError copyto!(c, a)
 end
 
 @testset "with CartesianIndices" begin


### PR DESCRIPTION
Previously, this method hit the slow generic AbstractArray fallback.

Closes #55079

This is an ad-hoc bandaid that really ought to be fixed by resolving #54581.