### PR TITLE
Use triple quotes in TOML.print when string contains newline

### DIFF
--- a/stdlib/TOML/src/print.jl
+++ b/stdlib/TOML/src/print.jl
@@ -101,9 +101,10 @@ function printvalue(f::MbyFunc, io::IO, value::TOMLValue, sorted::Bool)
     value isa AbstractFloat  ? Base.print(io, isnan(value) ? "nan" :
                                               isinf(value) ? string(value > 0 ? "+" : "-", "inf") :
                                               Float64(value)) :  # TOML specifies IEEE 754 binary64 for float
-    value isa AbstractString ? (Base.print(io, "\"");
+    value isa AbstractString ? (qmark = Base.contains(value, "\n") ? "\"\"\"" : "\""; 
+                                Base.print(io, qmark);
                                 print_toml_escaped(io, value);
-                                Base.print(io, "\"")) :
+                                Base.print(io, qmark)) :
     value isa AbstractDict ? print_inline_table(f, io, value, sorted) :
     error("internal error in TOML printing, unhandled value")
 end

--- a/stdlib/TOML/src/print.jl
+++ b/stdlib/TOML/src/print.jl
@@ -101,7 +101,7 @@ function printvalue(f::MbyFunc, io::IO, value::TOMLValue, sorted::Bool)
     value isa AbstractFloat  ? Base.print(io, isnan(value) ? "nan" :
                                               isinf(value) ? string(value > 0 ? "+" : "-", "inf") :
                                               Float64(value)) :  # TOML specifies IEEE 754 binary64 for float
-    value isa AbstractString ? (qmark = Base.contains(value, "\n") ? "\"\"\"" : "\""; 
+    value isa AbstractString ? (qmark = Base.contains(value, "\n") ? "\"\"\"" : "\"";
                                 Base.print(io, qmark);
                                 print_toml_escaped(io, value);
                                 Base.print(io, qmark)) :

--- a/stdlib/TOML/test/print.jl
+++ b/stdlib/TOML/test/print.jl
@@ -195,3 +195,13 @@ LocalPkg = {path = "LocalPkg"}
 """
 @test toml_str(d; sorted=true, inline_tables) == s
 @test roundtrip(s)
+
+# multline strings (#55083)
+s = """
+a = \"\"\"lorem ipsum
+
+
+
+alpha\"\"\"
+"""
+@test roundtrip(s)

--- a/stdlib/TOML/test/print.jl
+++ b/stdlib/TOML/test/print.jl
@@ -196,7 +196,7 @@ LocalPkg = {path = "LocalPkg"}
 @test toml_str(d; sorted=true, inline_tables) == s
 @test roundtrip(s)
 
-# multline strings (#55083)
+# multiline strings (#55083)
 s = """
 a = \"\"\"lorem ipsum
 


### PR DESCRIPTION
closes #55083 

Shouldu this also check for `\r`? 