### PR TITLE
Better error message in _check_mutable

### DIFF
--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -38,7 +38,7 @@ WeakRef
 # Used by `Base.finalizer` to validate mutability of an object being finalized.
 function _check_mutable(@nospecialize(o)) @noinline
     if !ismutable(o)
-        error("objects of type ", typeof(o), " cannot be finalized")
+        error("objects of type ", typeof(o), " cannot be finalized because they are not mutable")
     end
 end
 


### PR DESCRIPTION
Improve error message when trying to finalize a non-mutable object.

This would have saved me an hour of debugging... A web search doesn't bring up useful results, pointing mostly to the change of argument order in `finalizer` some time ago.
