### PR TITLE
Fix some dependency build issues with `USE_BINARYBUILDER=0`

### DIFF
--- a/deps/unwind.mk
+++ b/deps/unwind.mk
@@ -48,12 +48,12 @@ $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured: $(SRCCACHE)/libunwind-$(UN
 	echo 1 > $@
 
 $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-compiled: $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-configured
-	$(CMAKE) --build $(dir $<)
+	$(MAKE) -C $(dir $<)
 	echo 1 > $@
 
 $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-checked: $(BUILDDIR)/libunwind-$(UNWIND_VER)/build-compiled
 ifeq ($(OS),$(BUILD_OS))
-	$(CMAKE) --build $(dir $@) check
+	$(MAKE) -C $(dir $@) check
 endif
 	echo 1 > $@
 

--- a/deps/zlib.mk
+++ b/deps/zlib.mk
@@ -14,7 +14,7 @@ $(BUILDDIR)/$(ZLIB_SRC_DIR)/build-configured: $(SRCCACHE)/$(ZLIB_SRC_DIR)/source
 	echo 1 > $@
 
 $(BUILDDIR)/$(ZLIB_SRC_DIR)/build-compiled: $(BUILDDIR)/$(ZLIB_SRC_DIR)/build-configured
-	$(CMAKE) --build $(dir $<) $(MAKE_COMMON)
+	$(CMAKE) --build $(dir $<)
 	echo 1 > $@
 
 $(eval $(call staged-install, \


### PR DESCRIPTION
A couple of the changes made in #54538 were incorrect. In particular:
- libunwind (non-LLVM) does not use CMake, so the `$(CMAKE) --build` is simply reverted here back to `$(MAKE) -C`.
- zlib does use CMake but regular Make flags were being passed to its `$(CMAKE) --build`. Those can just be dropped since it's already getting the proper CMake flags.