### PR TITLE
Functional alias to `Base.Cartesian.@nif`

### DIFF
--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -258,8 +258,7 @@ macro nif(N, condition, operation...)
 end
 
 """
-    nif(condition, expression, ::Val{N}) where {N}
-    nif(condition, expression, else_expression, ::Val{N}) where {N}
+    nif(condition, expression, [else_expression,] ::Val{N}) where {N}
 
 Generate a sequence of `if ... elseif ... else ... end` statements.
 
@@ -271,7 +270,7 @@ Generate a sequence of `if ... elseif ... else ... end` statements.
     the condition is true.
 - `else_expression`: (optional) A function that takes `N` as input
     returns an expression to be evaluated if all conditions are false.
-- `N`: The number of conditions to check, passed as a `Val{N}` type.
+- `N`: The number of conditions to check, passed as a `Val{N}` instance.
 
 This function is similar to the `@nif` macro but can be used in cases
 where `N` is not known at parse time.

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -306,7 +306,7 @@ end
         return else_expression(n)
     end
 end
-typeof(function nif end).name.max_methods = UInt8(5)
+typeof(function nif end).name.max_methods = UInt8(2)
 
 ## Utilities
 

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -295,7 +295,7 @@ end
     n = N::Int  # Can improve inference; see #54544
     (n >= 0) || throw(ArgumentError(LazyString("if statement length should be ≥ 0, got ", n)))
     if @generated
-        return :(@nif $N d -> condition(d) d -> expression(d) d -> else_expression(d))
+        :(@nif $N d -> condition(d) d -> expression(d) d -> else_expression(d))
     else
         for d = 1:(n - 1)
             if condition(d)

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -264,7 +264,7 @@ end
 Generate a sequence of `if ... elseif ... else ... end` statements.
 
 # Arguments
-- `condition`: A function that takes an integer between `1` and `N` and
+- `condition`: A function that takes an integer between `1` and `N-1` and
     returns a boolean condition.
 - `expression`: A function that takes an integer between `1` and `N` (or,
     only up to `N-1`, if `else_expression` is provided) and is called if

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -293,19 +293,20 @@ julia> Base.Cartesian.nif(d -> x[d] > 0, d -> d, Val(4))
     nif(condition, expression, expression, Val(N))
 end
 @inline function nif(condition::F, expression::G, else_expression::H, ::Val{N}) where {F,G,H,N}
-    N::Int
-    (N >= 0) || throw(ArgumentError(LazyString("if statement length should be ≥ 0, got ", N)))
+    n = N::Int  # Can improve inference; see #54544
+    (n >= 0) || throw(ArgumentError(LazyString("if statement length should be ≥ 0, got ", n)))
     if @generated
-        return :(@nif $N d -> condition(d) d -> expression(d) d -> else_expression(d))
+        return :(@nif $n d -> condition(d) d -> expression(d) d -> else_expression(d))
     else
-        for d = 1:(N - 1)
+        for d = 1:(n - 1)
             if condition(d)
                 return expression(d)
             end
         end
-        return else_expression(N)
+        return else_expression(n)
     end
 end
+typeof(function nif end).name.max_methods = UInt8(5)
 
 ## Utilities
 

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -257,6 +257,56 @@ macro nif(N, condition, operation...)
     ex
 end
 
+"""
+    nif(condition, expression, ::Val{N}) where {N}
+    nif(condition, expression, else_expression, ::Val{N}) where {N}
+
+Generate a sequence of `if ... elseif ... else ... end` statements.
+
+# Arguments
+- `condition`: A function that takes an integer between `1` and `N` and
+    returns a boolean condition.
+- `expression`: A function that takes an integer between `1` and `N` (or,
+    only up to `N-1`, if `else_expression` is provided) and is called if
+    the condition is true.
+- `else_expression`: (optional) A function that takes `N` as input
+    returns an expression to be evaluated if all conditions are false.
+- `N`: The number of conditions to check, passed as a `Val{N}` type.
+
+This function is similar to the `@nif` macro but can be used in cases
+where `N` is not known at parse time.
+
+# Examples
+
+For example, here we find the first index of a positive element in a
+fixed-size tuple using `nif`:
+
+```jldoctest
+julia> x = (0, -1, 1, 0)
+(0, -1, 1, 0)
+
+julia> nif(d -> x[d] > 0, d -> d, Val(4))
+3
+```
+"""
+@inline function nif(condition, expression, ::Val{N}) where {N}
+    nif(condition, expression, expression, Val(N))
+end
+@inline function nif(condition::F, expression::G, else_expression::H, ::Val{N}) where {F,G,H,N}
+    N::Int
+    (N >= 0) || throw(ArgumentError(LazyString("if statement length should be ≥ 0, got ", N)))
+    if @generated
+        :(@nif $N d -> condition(d) d -> expression(d) d -> else_expression(d))
+    else
+        for d = 1:(N - 1)
+            if condition(d)
+                return expression(d)
+            end
+        end
+        return else_expression(N)
+    end
+end
+
 ## Utilities
 
 # Simplify expressions like :(d->3:size(A,d)-3) given an explicit value for d

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -289,7 +289,7 @@ julia> Base.Cartesian.nif(d -> x[d] > 0, d -> d, Val(4))
 3
 ```
 """
-@inline function nif(condition, expression, ::Val{N}) where {N}
+@inline function nif(condition::F, expression::G, ::Val{N}) where {F,G,N}
     nif(condition, expression, expression, Val(N))
 end
 @inline function nif(condition::F, expression::G, else_expression::H, ::Val{N}) where {F,G,H,N}

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -296,7 +296,7 @@ end
     N::Int
     (N >= 0) || throw(ArgumentError(LazyString("if statement length should be ≥ 0, got ", N)))
     if @generated
-        :(@nif $N d -> condition(d) d -> expression(d) d -> else_expression(d))
+        return :(@nif $N d -> condition(d) d -> expression(d) d -> else_expression(d))
     else
         for d = 1:(N - 1)
             if condition(d)

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -296,7 +296,7 @@ end
     n = N::Int  # Can improve inference; see #54544
     (n >= 0) || throw(ArgumentError(LazyString("if statement length should be ≥ 0, got ", n)))
     if @generated
-        return :(@nif $n d -> condition(d) d -> expression(d) d -> else_expression(d))
+        return :(@nif $N d -> condition(d) d -> expression(d) d -> else_expression(d))
     else
         for d = 1:(n - 1)
             if condition(d)

--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -285,7 +285,7 @@ fixed-size tuple using `nif`:
 julia> x = (0, -1, 1, 0)
 (0, -1, 1, 0)
 
-julia> nif(d -> x[d] > 0, d -> d, Val(4))
+julia> Base.Cartesian.nif(d -> x[d] > 0, d -> d, Val(4))
 3
 ```
 """

--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -614,7 +614,7 @@ end
         # not been able to infer that the return type never includes
         # the first element. But since we used an `nif`, the compiler
         # knows all possible branches and can infer the correct type.
-        @test @inferred extract_from_tuple(t, 3) == 3
+        @test @inferred(extract_from_tuple(t, 3)) == 3
 
     end
 end

--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -565,3 +565,56 @@ end
     end
     @test t3 == (1, 2, 0)
 end
+
+@testset "nif" begin
+    let nif = Base.Cartesian.nif
+
+        x = (0, -1, 1, 0)
+        @test nif(d -> x[d] > 0, d -> d, Val(4)) == 3
+
+        @test nif(d -> d > 1, d -> "A", d -> "B", Val(1)) == "B"
+        @test nif(d -> d > 3, d -> "A", d -> "B", Val(3)) == "B"
+
+        # Test with N = 0
+        @test nif(d -> d > 0, d -> "", d -> "A", Val(0)) == "A"
+
+        # Specific branch true
+        @test nif(d -> d == 2, d -> d, d -> "else", Val(3)) == 2
+
+        # Test with condition only true for last branch
+        @test nif(d -> d == 5, d -> "A", d -> "B", Val(5)) == "B"
+
+        # Test with bad input:
+        @test_throws ArgumentError("if statement length should be ≥ 0, got -1") nif(identity, identity, Val(-1))
+
+        # Non-Int64 also throws
+        @test_throws TypeError nif(identity, identity, Val(1.5))
+
+        # Make sure all conditions are actually evaluated
+        result = let c = Ref(0)
+            nif(
+                d -> (c[] += 1; false),
+                d -> 1,
+                Val(4)
+            )
+            c[]
+        end
+        @test result == 3
+
+        # Test inference is good
+        t = ("i am not an int", ntuple(d -> d, Val(10))...)
+        function extract_from_tuple(t::Tuple, i)
+            nif(
+                d -> d == i,
+                d -> t[d + 1],  # We skip the non-integer element
+                Val(length(t) - 1)
+            )
+        end
+        # Normally, had we used getindex here, inference would have
+        # not been able to infer that the return type never includes
+        # the first element. But since we used an `nif`, the compiler
+        # knows all possible branches and can infer the correct type.
+        @test @inferred extract_from_tuple(t, 3) == 3
+
+    end
+end


### PR DESCRIPTION
You can use `ntuple(f, Val(n))` as an alias of `@ntuple(n, f)`. The reason this is preferable is because `@ntuple` requires `n` to be known at **_parse time_**, while `ntuple(f, Val(n))` only requires this information at compile time. Therefore you can have `n` depend on types of arguments when using the functional alias, avoiding the need for `@generated` functions in package code.

However, there is no analog of `Base.Cartesian.@nif`, so you need to use `@generated` whenever you wish to have a type-dependent if statement.

This PR adds this alias as well as a test suite. Fixes #55087. 

## Use-cases

Some of my code in DynamicExpressions.jl needs to use `@generated` functions which roughly look like this:

```julia
@generated function foo(idx, operators::Tuple, data)
    N = length(operators)
    quote
        Base.Cartesian.@nif(
            $N,
            i -> i == idx,
            i -> eval_with(operators[i], data)
        )
    end
end
```

There's no way to do this without a `@generated` function, because `N` needs to be known to the macro at parse time. The code otherwise does not need to use `@generated`, and so likely incurs greater compilation effort than is actually needed.

The reason I need this if statement is so that the compiler is aware of exactly which operator is used at each branch – required for things for Enzyme to work. (If I just used `getindex(t::Tuple, i::Int)`, the compiler would not be able to do constant propagation far enough).

So, rather than require users and package developers to use a `@generated` whenever they want to create a type-dependent `@nif`, this PR creates `Base.Cartesian.nif` which does the code generation internally, in an [analogous way to how `ntuple` works](https://github.com/JuliaLang/julia/blob/24535f67932f1af34a89c3a8b689b6726cfcb218/base/ntuple.jl#L69-L77). This is also nice because it has the non-`@generated` branch for improved inference in cases where the types are not fully known.

For a simple example, consider the following test (included in the test suite):

```julia
t = ("i am not an int", ntuple(d -> d, Val(10))...)

function extract_from_tuple(t::Tuple, i)
    Base.Cartesian.nif(
        d -> d == i,
        d -> t[d + 1],  # We skip the non-integer element
        Val(length(t) - 1)
    )
end
```

Normally, had we used getindex here, inference would have not been able to infer that the return type never includes the first element. But since we used an `nif`, the compiler knows all possible branches, and can inline `d + 1`, and therefore infer the correct type of every branch:

```julia
@test @inferred(extract_from_tuple(t, 3)) == 3
```

To solve this problem with `Base.Cartesian.@nif`, you would have to wrap the function body with `@generated`.

## Tests

`Base.Cartesian.@nif` does not have any tests aside from the `jldoctest`. This PR also adds many tests of `nif` which therefore also test `@nif`.
