### PR TITLE
Mark ScopedValue, with and @with as public

### DIFF
--- a/base/public.jl
+++ b/base/public.jl
@@ -86,6 +86,7 @@ public
     @constprop,
     @locals,
     @propagate_inbounds,
+    @with,
 
 # External processes
     shell_escape,
@@ -108,6 +109,10 @@ public
     # functions
     reseteof,
     link_pipe!,
+
+# Scoped values
+    ScopedValue,
+    with,
 
 # misc
     notnothing,


### PR DESCRIPTION
This is exported from the ScopedValues module into Base, but not exported from Base, and therefore not marked as public.