### PR TITLE
add notice of excessive scheduling time to time macro etc.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -101,6 +101,8 @@ New library features
   content is fully written, then call `closewrite` manually to avoid
   data-races. Or use the callback form of `open` to have all that handled
   automatically.
+* `@time` now shows if the time spent on scheduling tasks (not including sleeping/waiting) is more
+  than 10% of the total time, as a percentage. ([#55103])
 * `@timed` now additionally returns the elapsed compilation and recompilation time ([#52889])
 * `escape_string` takes additional keyword arguments `ascii=true` (to escape all
   non-ASCII characters) and `fullhex=true` (to require full 4/8-digit hex numbers

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -425,8 +425,8 @@ include("weakkeydict.jl")
 include("scopedvalues.jl")
 
 # used by task.jl
-const task_times_per_thread = ScopedValues.ScopedValue{Vector{UInt}}()
-const sleep_times_per_thread = ScopedValues.ScopedValue{Vector{UInt}}()
+const task_times_per_thread = ScopedValues.ScopedValue{Vector{UInt64}}() # time_ns always returns UInt64
+const sleep_times_per_thread = ScopedValues.ScopedValue{Vector{UInt64}}()
 
 # metaprogramming
 include("meta.jl")

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -425,7 +425,8 @@ include("weakkeydict.jl")
 include("scopedvalues.jl")
 
 # used by task.jl
-const Workqueue_sched_times = ScopedValues.ScopedValue{Vector{UInt}}()
+const task_times_per_thread = ScopedValues.ScopedValue{Vector{UInt}}()
+const sleep_times_per_thread = ScopedValues.ScopedValue{Vector{UInt}}()
 
 # metaprogramming
 include("meta.jl")

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -424,6 +424,9 @@ include("weakkeydict.jl")
 # ScopedValues
 include("scopedvalues.jl")
 
+# used by task.jl
+const Workqueue_sched_times = ScopedValues.ScopedValue{Vector{UInt}}()
+
 # metaprogramming
 include("meta.jl")
 

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -293,7 +293,9 @@ A macro to execute an expression, printing the time it took to execute, the numb
 allocations, and the total number of bytes its execution caused to be allocated, before
 returning the value of the expression. Any time spent garbage collecting (gc), compiling
 new code, or recompiling invalidated code is shown as a percentage. Any lock conflicts
-where a [`ReentrantLock`](@ref) had to wait are shown as a count.
+where a [`ReentrantLock`](@ref) had to wait are shown as a count. If the time spent on
+scheduling tasks (not including sleeping/waiting) is more than 10% of the total time it
+is also shown as a percentage.
 
 Optionally provide a description string to print before the time report.
 
@@ -316,6 +318,9 @@ See also [`@showtime`](@ref), [`@timev`](@ref), [`@timed`](@ref), [`@elapsed`](@
 
 !!! compat "Julia 1.11"
     The reporting of any lock conflicts was added in Julia 1.11.
+
+!!! compat "Julia 1.12"
+    The reporting of excessive scheduling time was added in Julia 1.12.
 
 ```julia-repl
 julia> x = rand(10,10);

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -633,12 +633,12 @@ macro timed(ex)
                 Threads.lock_profiling(false))
             )
             local diff = GC_Diff(gc_num(), stats)
-            local sched_times = Int[]
-            for i in 1:Threads.maxthreadid()
+            local sched_times = Int64[]
+            for i in 1:length(task_times_per_thread[])
                 # filter out zeros in task timers which can only happen if nothing was scheduled
                 if task_times_per_thread[][i] != 0
                     # subtract task and sleep times from global elapsed time to get scheduling time per thread
-                    push!(sched_times, Int(elapsedtime) - Int(task_times_per_thread[][i]) - Int(sleep_times_per_thread[][i]))
+                    push!(sched_times, Int64(elapsedtime) - Int64(task_times_per_thread[][i]) - Int64(sleep_times_per_thread[][i]))
                 end
             end
             local sched_time_avg = isempty(sched_times) ? 0 : sum(sched_times) / length(sched_times)

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -568,8 +568,9 @@ end
 
 A macro to execute an expression, and return the value of the expression, elapsed time in seconds,
 total bytes allocated, garbage collection time, an object with various memory allocation
-counters, compilation time in seconds, and recompilation time in seconds. Any lock conflicts
-where a [`ReentrantLock`](@ref) had to wait are shown as a count.
+counters, compilation time in seconds, with recompilation time in seconds, any lock conflicts
+where a [`ReentrantLock`](@ref) had to wait as a count, and the average time spent on
+scheduling tasks (not including sleeping/waiting) across threads.
 
 In some cases the system will look inside the `@timed` expression and compile some of the
 called code before execution of the top-level expression begins. When that happens, some
@@ -609,6 +610,9 @@ julia> stats.recompile_time
 
 !!! compat "Julia 1.11"
     The `lock_conflicts`, `compile_time`, and `recompile_time` fields were added in Julia 1.11.
+
+!!! compat "Julia 1.12"
+    The `sched_time_avg` field was added in Julia 1.11.
 """
 macro timed(ex)
     quote

--- a/test/scopedvalues.jl
+++ b/test/scopedvalues.jl
@@ -82,11 +82,16 @@ end
 @testset "show" begin
     @test sprint(show, ScopedValue{Int}()) == "Base.ScopedValues.ScopedValue{$Int}(undefined)"
     @test sprint(show, sval) == "Base.ScopedValues.ScopedValue{$Int}(1)"
-    @test sprint(show, Core.current_scope()) == "nothing"
+    if Core.current_scope() === nothing
+        # Base.runtests uses @timed which introduces a scope for scheduler timing
+        @test sprint(show, Core.current_scope()) == "nothing"
+    end
     with(sval => 2.0) do
         @test sprint(show, sval) == "Base.ScopedValues.ScopedValue{$Int}(2)"
         objid = sprint(show, Base.objectid(sval))
-        @test sprint(show, Core.current_scope()) == "Base.ScopedValues.Scope(Base.ScopedValues.ScopedValue{$Int}@$objid => 2)"
+        # Base.runtests uses @timed which introduces a scope for scheduler timing
+        @test startswith(sprint(show, Core.current_scope()), "Base.ScopedValues.Scope(")
+        @test contains(sprint(show, Core.current_scope()), "Base.ScopedValues.ScopedValue{$Int}@$objid => 2")
     end
 end
 


### PR DESCRIPTION
Replaces https://github.com/JuliaLang/julia/pull/55094

Balancing number of tasks vs. task duration is a key optimization aspect, so this aims to bring a warning when it's notably imbalanced to the most common place that a user might try to see why their function is taking so long etc.

If more than 10% of wall time is spent (on average across all worker threads) specifically scheduling tasks then warn in `@time`.

```julia
julia> function foo(n; spawn=true)
          for i in 1:n
              if spawn
                  fetch(Threads.@spawn global j = i)
              else
                  global j = i
              end
           end
       end
foo (generic function with 4 methods)

julia> @time foo(1000)
  0.018877 seconds (10.71 k allocations: 396.266 KiB, 99.81% scheduling time, 11.34% compilation time)

julia> @time foo(1000)
  0.017071 seconds (9.97 k allocations: 358.875 KiB, 99.71% scheduling time)

julia> @time foo(1000; spawn=false)
  0.000004 seconds (489 allocations: 7.641 KiB)

julia> @time foo(1000; spawn=false)
  0.000004 seconds (489 allocations: 7.641 KiB)
```
A real world example that doesn't show the schedule warning.
```julia
julia> @time Pkg.update()
    Updating registry at `~/.julia/registries/General.toml`
   Installed JpegTurbo_jll ── v3.0.4+0
   Installed LZO_jll ──────── v2.10.2+1
   Installed Zstd_jll ─────── v1.5.6+1
   Installed Glib_jll ─────── v2.80.5+0
   Installed GtkObservables ─ v2.1.3
   Installed Revise ───────── v3.6.0
  Installing artifacts  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4/4
    Updating `~/.julia/environments/v1.12/Project.toml`
  [295af30f] ↑ Revise v3.5.18 ⇒ v3.6.0
    Updating `~/.julia/environments/v1.12/Manifest.toml`
  [8710efd8] ↑ GtkObservables v2.1.2 ⇒ v2.1.3
  [295af30f] ↑ Revise v3.5.18 ⇒ v3.6.0
  [7746bdde] ↑ Glib_jll v2.80.2+0 ⇒ v2.80.5+0
  [aacddb02] ↑ JpegTurbo_jll v3.0.3+0 ⇒ v3.0.4+0
  [dd4b983a] ↑ LZO_jll v2.10.2+0 ⇒ v2.10.2+1
  [3161d3a3] ↑ Zstd_jll v1.5.6+0 ⇒ v1.5.6+1
Precompiling packages finished.
  97 dependencies successfully precompiled in 37 seconds. 34 already precompiled.
 44.095062 seconds (18.75 M allocations: 1.120 GiB, 0.56% gc time, 71 lock conflicts, 8.85% compilation time: 18% of which was recompilation)
```