### PR TITLE
make threaded exit and cache file loading safer by pausing other threads

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -1107,6 +1107,8 @@ STATIC_INLINE void jl_gc_multi_wb(const void *parent, const jl_value_t *ptr) JL_
 JL_DLLEXPORT void *jl_gc_managed_malloc(size_t sz);
 JL_DLLEXPORT void jl_gc_safepoint(void);
 JL_DLLEXPORT int jl_safepoint_suspend_thread(int tid, int waitstate);
+JL_DLLEXPORT void jl_safepoint_suspend_all_threads(struct _jl_task_t *ct);
+JL_DLLEXPORT void jl_safepoint_resume_all_threads(struct _jl_task_t *ct);
 JL_DLLEXPORT int jl_safepoint_resume_thread(int tid) JL_NOTSAFEPOINT;
 
 void *mtarraylist_get(small_arraylist_t *_a, size_t idx) JL_NOTSAFEPOINT;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -959,6 +959,7 @@ extern JL_DLLEXPORT ssize_t jl_tls_offset;
 extern JL_DLLEXPORT const int jl_tls_elf_support;
 void jl_init_threading(void);
 void jl_start_threads(void);
+extern uv_mutex_t safepoint_lock;
 
 // Whether the GC is running
 extern char *jl_safepoint_pages;

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -45,7 +45,6 @@ static void attach_exception_port(thread_port_t thread, int segv_only);
 
 // low 16 bits are the thread id, the next 8 bits are the original gc_state
 static arraylist_t suspended_threads;
-extern uv_mutex_t safepoint_lock;
 extern uv_cond_t safepoint_cond_begin;
 
 #define GC_STATE_SHIFT 8*sizeof(int16_t)

--- a/src/threading.c
+++ b/src/threading.c
@@ -432,6 +432,30 @@ JL_DLLEXPORT jl_gcframe_t **jl_adopt_thread(void)
     return &ct->gcstack;
 }
 
+
+void jl_safepoint_suspend_all_threads(jl_task_t *ct)
+{
+    // TODO: prevent jl_n_threads changing or jl_safepoint_resume_thread calls on another thread
+    //uv_mutex_lock(&tls_lock);
+    //disallow_resume = ct->tid;
+    //uv_mutex_unlock(&tls_lock);
+    for (int16_t tid = 0; tid < jl_atomic_load_relaxed(&jl_n_threads); tid++) {
+        if (tid != jl_atomic_load_relaxed(&ct->tid))
+            jl_safepoint_suspend_thread(tid, 1);
+    };
+}
+
+void jl_safepoint_resume_all_threads(jl_task_t *ct)
+{
+    //uv_mutex_lock(&tls_lock);
+    //if (disallow_resume != ct->tid) return;
+    //uv_mutex_unlock(&tls_lock);
+    for (int16_t tid = 0; tid < jl_atomic_load_relaxed(&jl_n_threads); tid++) {
+        if (tid != jl_atomic_load_relaxed(&ct->tid))
+            jl_safepoint_resume_thread(tid);
+    };
+}
+
 void jl_task_frame_noreturn(jl_task_t *ct) JL_NOTSAFEPOINT;
 void scheduler_delete_thread(jl_ptls_t ptls) JL_NOTSAFEPOINT;
 

--- a/test/atexit.jl
+++ b/test/atexit.jl
@@ -220,7 +220,7 @@ using Test
                     # Block until the atexit hooks have all finished. We use a manual "spin
                     # lock" because task switch is disallowed inside the finalizer, below.
                     atexit_has_finished[] = 1
-                    while atexit_has_finished[] == 1 end
+                    while atexit_has_finished[] == 1; GC.safepoint(); end
                     try
                         # By the time this runs, all the atexit hooks will be done.
                         # So this will throw.
@@ -232,7 +232,7 @@ using Test
                         exit(22)
                     end
                 end
-                while atexit_has_finished[] == 0 end
+                while atexit_has_finished[] == 0; GC.safepoint(); end
             end
             # Finalizers run after the atexit hooks, so this blocks exit until the spawned
             # task above gets a chance to run.
@@ -241,7 +241,7 @@ using Test
                 # Allow the spawned task to finish
                 atexit_has_finished[] = 2
                 # Then spin forever to prevent exit.
-                while atexit_has_finished[] == 2 end
+                while atexit_has_finished[] == 2; GC.safepoint(); end
             end
             exit(0)
             """ => 22,


### PR DESCRIPTION
Also add a missing lock call in jl_safepoint_suspend_thread.

Instead of only preventing access to LLVM and inference (via the codegen lock), this prevents further access to all internals by disabling the safepoints and waiting for the threads to stop (or to be in unmanaged code that we don't care about).

This then uses that to also make staticdata loading a bit safer, since `jl_lookup_cache_type_` assumes there are no concurrent mutator threads, and we can make that true by pausing all of those.