### PR TITLE
Make the memory GEP an inbounds GEP since the bounds check has happened somewhere else

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -4263,7 +4263,7 @@ static jl_cgval_t emit_memoryref(jl_codectx_t &ctx, const jl_cgval_t &ref, jl_cg
         }
 #endif
         boffset = ctx.builder.CreateMul(offset, elsz);
-        newdata = ctx.builder.CreateInboundsGEP(getInt8Ty(ctx.builder.getContext()), data, boffset);
+        newdata = ctx.builder.CreateInBoundsGEP(getInt8Ty(ctx.builder.getContext()), data, boffset);
         (void)boffset; // LLVM is very bad at handling GEP with types different from the load
         if (bc) {
             BasicBlock *failBB, *endBB;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -4262,9 +4262,8 @@ static jl_cgval_t emit_memoryref(jl_codectx_t &ctx, const jl_cgval_t &ref, jl_cg
             ovflw = ctx.builder.CreateICmpUGE(ctx.builder.CreateAdd(offset, mlen), ctx.builder.CreateNUWAdd(mlen, mlen));
         }
 #endif
-        //Is this change fine
         boffset = ctx.builder.CreateMul(offset, elsz);
-        newdata = ctx.builder.CreateGEP(getInt8Ty(ctx.builder.getContext()), data, boffset);
+        newdata = ctx.builder.CreateInboundsGEP(getInt8Ty(ctx.builder.getContext()), data, boffset);
         (void)boffset; // LLVM is very bad at handling GEP with types different from the load
         if (bc) {
             BasicBlock *failBB, *endBB;


### PR DESCRIPTION
This makes the code in https://github.com/JuliaLang/julia/issues/55090 look almost the same as it did before the change. Locally I wasn't able to reproduce the regression, but given it's vectorized code I suspect it is backend sensitive.
@Zentrik 

Fixes https://github.com/JuliaLang/julia/issues/55090