### PR TITLE
add support for (simple) complex ranges

### DIFF
--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -243,13 +243,15 @@ function twiceprecision(val::T, nb::Integer) where {T<:IEEEFloat}
     TwicePrecision{T}(hi, val - hi)
 end
 
-function twiceprecision(val::TwicePrecision{T}, nb::Integer) where {T<:IEEEFloat}
+function twiceprecision(val::TwicePrecision{T}, nb::Integer) where {T<:Union{IEEEFloat,Complex{<:IEEEFloat}}}
     hi = truncbits(val.hi, nb)
     TwicePrecision{T}(hi, (val.hi - hi) + val.lo)
 end
 
 nbitslen(r::StepRangeLen) = nbitslen(eltype(r), length(r), r.offset)
 nbitslen(::Type{T}, len, offset) where {T<:IEEEFloat} =
+    min(cld(precision(T), 2), nbitslen(len, offset))
+nbitslen(::Type{Complex{T}}, len, offset) where {T<:IEEEFloat} =
     min(cld(precision(T), 2), nbitslen(len, offset))
 # The +1 here is for safety, because the precision of the significand
 # is 1 bit higher than the number that are explicitly stored.

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2727,6 +2727,17 @@ end
     @test Base._log_twice64_unchecked(Inf).lo isa Float64
 end
 
+@testset "Complex ranges" begin
+    r = 0:.1:1
+    for f in (collect, identity)
+        @test collect(r .+ r .* im) ≈ [v + v*im for v in r]
+        @test collect(r.*im .+ r.*im) ≈ [v*im + v*im for v in r]
+        @test collect(r.+0im .+ r.+0im) ≈ [v + v for v in r]
+        @test collect(r.+0im .+ r.*im) ≈ [v + v*im for v in r]
+        @test collect(r.*im .+ r.+0im) ≈ [v*im + v for v in r]
+    end
+end
+
 @testset "OneTo promotion" begin
     struct MyUnitRange{T} <: AbstractUnitRange{T}
         range::UnitRange{T}


### PR DESCRIPTION
Although ranges don't have a linear ordering, it's easy to stumble into creating a complex range through straightforward (likely broadcasted) arithmetic.