### PR TITLE
Add support for intrinsics for `NTuple{VecElement}`

### DIFF
--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -327,7 +327,7 @@ end
 
 @nospecs function preferred_vector_width_tfunc(𝕃::ConstsLattice, t)
     # Want to return Union(Const(1), Const(2))
-    # hardcode AVX512
+    # hardcode AVX256
     if sizeof(widenconst(t)) === 1
         return Const(32)
     elseif sizeof(widenconst(t)) === 2
@@ -337,7 +337,7 @@ end
     elseif sizeof(widenconst(t)) === 8
         return Const(4)
     elseif sizeof(widenconst(t)) === 16
-        return Const(4)
+        return Const(2)
     end
     return Union{Nothing, Int}
 end

--- a/Compiler/src/tfuncs.jl
+++ b/Compiler/src/tfuncs.jl
@@ -51,7 +51,7 @@ end
 
 const INT_INF = typemax(Int) # integer infinity
 
-const N_IFUNC = reinterpret(Int32, have_fma) + 1
+const N_IFUNC = reinterpret(Int32, preferred_vector_width) + 1
 const T_IFUNC = Vector{Tuple{Int, Int, Any}}(undef, N_IFUNC)
 const T_IFUNC_COST = Vector{Int}(undef, N_IFUNC)
 const T_FFUNC_KEY = Vector{Any}()
@@ -320,6 +320,28 @@ end
 add_tfunc(Core.Intrinsics.cglobal, 1, 2, cglobal_tfunc, 5)
 
 add_tfunc(Core.Intrinsics.have_fma, 1, 1, @nospecs((𝕃::AbstractLattice, x)->Bool), 1)
+
+@nospecs function preferred_vector_width_tfunc(𝕃::AbstractLattice, t)
+    return preferred_vector_width_tfunc(widenlattice(𝕃), t)
+end
+
+@nospecs function preferred_vector_width_tfunc(𝕃::ConstsLattice, t)
+    # Want to return Union(Const(1), Const(2))
+    # hardcode AVX512
+    if sizeof(widenconst(t)) === 1
+        return Const(32)
+    elseif sizeof(widenconst(t)) === 2
+        return Const(16)
+    elseif sizeof(widenconst(t)) === 4
+        return Const(8)
+    elseif sizeof(widenconst(t)) === 8
+        return Const(4)
+    elseif sizeof(widenconst(t)) === 16
+        return Const(4)
+    end
+    return Union{Nothing, Int}
+end
+add_tfunc(Core.Intrinsics.preferred_vector_width, 1, 1, preferred_vector_width_tfunc, 1)
 
 # builtin functions
 # =================

--- a/base/experimental.jl
+++ b/base/experimental.jl
@@ -507,6 +507,9 @@ usage, by eliminating the tracking of those possible invalidation.
 """
 disable_new_worlds() = ccall(:jl_disable_new_worlds, Cvoid, ())
 
+# SIMD utilities
+include("simd.jl")
+
 ### Task metrics
 
 """

--- a/base/simd.jl
+++ b/base/simd.jl
@@ -1,0 +1,70 @@
+module SIMD
+
+import Base: VecElement, Memory, MemoryRef
+import Base: @propagate_inbounds, @_propagate_inbounds_meta, @_boundscheck, @_noub_if_noinbounds_meta
+import Base: memoryrefget, memoryrefnew, memoryrefset!
+
+export Vec
+export vload, vstore!, natural_vecwidth
+
+# TODO: See C# and Co Vec type 
+# TODO: Hardware portable vector types...
+
+struct Vec{N, T}
+    data::NTuple{N, VecElement{T}}
+end
+
+# Constructors
+@inline Vec(v::NTuple{N, T}) where {N, T} = Vec(VecElement.(v))
+@inline Vec(v::Vararg{T, N}) where {N, T} = Vec(v)
+@inline Vec(v::Vec) = v
+
+# Numbers defines this and it is needed in power_by_squaring...
+Base.copy(v::Vec) = v
+
+function Base.show(io::IO, v::Vec{N, T}) where {N, T}
+    io = IOContext(io, :typeinfo => eltype(v))
+    print(io, "<$N x $T>[")
+    join(io, [sprint(show, x.value; context=io) for x in v.data], ", ")
+    print(io, "]")
+end
+
+# Breaks with multi-versioning
+natural_vecwidth(::Type{Float32}) = 8
+natural_vecwidth(::Type{Float64}) = 4
+
+import Base: +, -, *
+
+# Mocked vload/vstore! relying on SLP
+
+@inline function vload(::Type{Vec{N, T}}, A::Array{T}, i::Int) where {N, T}
+    @_noub_if_noinbounds_meta
+    # TODO: Alignment...; may need an intrinsic for vectorized loads.
+    # Writting my own boundscheck loop since `inbounds` doesn't propagate through `ntuple` FFS
+    @boundscheck checkbounds(A, i:(i+ N - 1))
+    mem = A.ref
+    data = ntuple(Val(N)) do j
+        # why does `@inbounds  ref = memoryrefnew(mem, i + j - 1, @_boundscheck)` not work?
+        ref = memoryrefnew(mem, i + j - 1, false)
+        VecElement{T}(memoryrefget(ref, :not_atomic, false))
+    end
+    return Vec(data)
+end
+
+@inline function vstore!(A::Array{T}, v::Vec{N, T}, i::Int) where {N, T}
+    @_noub_if_noinbounds_meta
+    # TODO: Alignment...; may need an intrinsic for vectorized loads.
+    # Writting my own boundscheck loop since `inbounds` doesn't propagate through `ntuple` FFS
+    @boundscheck checkbounds(A, i:(i+ N - 1))
+    mem = A.ref
+    data = v.data
+    ntuple(Val(N)) do j
+        # why does `@inbounds  ref = memoryrefnew(mem, i + j - 1, @_boundscheck)` not work?
+        ref = memoryrefnew(mem, i + j - 1, false)
+        memoryrefset!(ref, data[j].value, :not_atomic, false)
+        return nothing
+    end
+    return nothing
+end
+
+end # module

--- a/base/simd.jl
+++ b/base/simd.jl
@@ -46,6 +46,14 @@ function Base.show(io::IO, v::Vec{N, T}) where {N, T}
     print(io, "]")
 end
 
+# TODO: llvm.vp expects a mask of i1
+struct Mask{N}
+    data::NTuple{N, VecElement{Bool}}
+end
+
+function mask_all(::Val{N}, val::Bool) where N
+    Mask(ntuple(_->VecElement(val),Val(N)))
+end
 
 # Mocked vload/vstore! relying on SLP
 

--- a/src/array.c
+++ b/src/array.c
@@ -32,6 +32,7 @@ JL_DLLEXPORT int jl_array_validate_dims(size_t *nel, uint32_t ndims, size_t *dim
     return 0;
 }
 
+#ifndef JL_NDEBUG
 static inline int is_ntuple_long(jl_value_t *v)
 {
     if (!jl_is_tuple(v))
@@ -45,6 +46,7 @@ static inline int is_ntuple_long(jl_value_t *v)
     }
     return 1;
 }
+#endif
 
 #define jl_array_elsize(a) (((jl_datatype_t*)jl_typetagof((a)->ref.mem))->layout->size)
 

--- a/src/array.c
+++ b/src/array.c
@@ -32,7 +32,6 @@ JL_DLLEXPORT int jl_array_validate_dims(size_t *nel, uint32_t ndims, size_t *dim
     return 0;
 }
 
-#ifndef JL_NDEBUG
 static inline int is_ntuple_long(jl_value_t *v)
 {
     if (!jl_is_tuple(v))
@@ -46,7 +45,6 @@ static inline int is_ntuple_long(jl_value_t *v)
     }
     return 1;
 }
-#endif
 
 #define jl_array_elsize(a) (((jl_datatype_t*)jl_typetagof((a)->ref.mem))->layout->size)
 

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1307,7 +1307,6 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
         return emit_llvmcall(ctx, args, nargs);
     if (f == cglobal_auto || f == cglobal)
         return emit_cglobal(ctx, args, nargs);
-
     SmallVector<jl_cgval_t, 0> argv(nargs);
     for (size_t i = 0; i < nargs; ++i) {
         jl_cgval_t arg = emit_expr(ctx, args[i + 1]);
@@ -1429,9 +1428,17 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
     default: {
         assert(nargs >= 1 && "invalid nargs for intrinsic call");
         const jl_cgval_t &xinfo = argv[0];
-
         // verify argument types
-        if (!jl_is_primitivetype(xinfo.typ))
+        if (jl_is_primitivetype(xinfo.typ)){}
+        else if (is_ntuple_type(xinfo.typ) && jl_nparams(xinfo.typ) > 0)
+        {
+            jl_value_t *et = jl_tparam0(xinfo.typ);
+            if (((jl_datatype_t*)et)->name == jl_vecelement_typename && jl_is_primitivetype(jl_tparam(et, 0)))
+                et = jl_tparam0(et);
+            else
+                return emit_runtime_call(ctx, f, argv, nargs);
+        }
+        else
             return emit_runtime_call(ctx, f, argv, nargs);
         Type *xtyp = bitstype_to_llvm(xinfo.typ, ctx.builder.getContext(), true);
         if (float_func()[f]) {
@@ -1443,6 +1450,8 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
         }
         if (!xtyp)
             return emit_runtime_call(ctx, f, argv, nargs);
+        bool isboxed=true;
+        Type *xtyp = julia_type_to_llvm(ctx, xinfo.typ, &(isboxed));
         ////Bool are required to be in the range [0,1]
         ////so while they are represented as i8,
         ////the operations need to be done in mod 1

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1511,14 +1511,6 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
         }
         if (!xtyp)
             return emit_runtime_call(ctx, f, argv, nargs);
-        bool isboxed=true;
-        Type *xtyp = julia_type_to_llvm(ctx, xinfo.typ, &(isboxed));
-        if (float_func()[f])
-            xtyp = FLOATT(xtyp);
-        else
-            xtyp = INTT(xtyp, DL);
-        if (!xtyp)
-             return emit_runtime_call(ctx, f, argv, nargs);
         ////Bool are required to be in the range [0,1]
         ////so while they are represented as i8,
         ////the operations need to be done in mod 1

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -148,6 +148,13 @@ static Type *FLOATT(Type *t)
 {
     if (t->isFloatingPointTy())
         return t;
+    if (auto *tv = dyn_cast<VectorType>(t))
+    {
+        Type *st = FLOATT(tv->getElementType());
+        if (!st)
+            return NULL;
+        return VectorType::get(st, tv->getElementCount());
+    }
     unsigned nb = (t->isPointerTy() ? sizeof(void*) * 8 : t->getPrimitiveSizeInBits());
     auto &ctxt = t->getContext();
     if (nb == 64)
@@ -169,6 +176,13 @@ static Type *INTT(Type *t, const DataLayout &DL)
         return t;
     if (t->isPointerTy())
         return DL.getIntPtrType(t);
+    if (auto *tv = dyn_cast<VectorType>(t))
+    {
+        Type *st = INTT(tv->getElementType(), DL);
+        if (!st)
+            return NULL;
+        return VectorType::get(st, tv->getElementCount());
+    }
     if (t == getDoubleTy(ctxt))
         return getInt64Ty(ctxt);
     if (t == getFloatTy(ctxt))
@@ -1452,6 +1466,12 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
             return emit_runtime_call(ctx, f, argv, nargs);
         bool isboxed=true;
         Type *xtyp = julia_type_to_llvm(ctx, xinfo.typ, &(isboxed));
+        if (float_func()[f])
+            xtyp = FLOATT(xtyp);
+        else
+            xtyp = INTT(xtyp, DL);
+        if (!xtyp)
+             return emit_runtime_call(ctx, f, argv, nargs);
         ////Bool are required to be in the range [0,1]
         ////so while they are represented as i8,
         ////the operations need to be done in mod 1

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -106,6 +106,7 @@
     ALIAS(llvmcall, llvmcall) \
     /*  cpu feature tests */ \
     ADD_I(have_fma, 1) \
+    ADD_I(preferred_vector_width, 1) \
     /*  hidden intrinsics */ \
     ADD_HIDDEN(cglobal_auto, 1)
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -1734,6 +1734,24 @@ STATIC_INLINE int jl_is_tuple_type(void *t) JL_NOTSAFEPOINT
             ((jl_datatype_t*)(t))->name == jl_tuple_typename);
 }
 
+STATIC_INLINE int is_ntuple_type(jl_value_t *tt)
+{
+    if (!jl_is_tuple_type(tt))
+    {
+        return 0;
+    }
+    size_t i, nfields = jl_nparams(tt);
+    if(!nfields)
+        return 1;
+    jl_value_t *t1 = jl_tparam0(tt);
+    for (i = 1; i < nfields; i++) {
+        if (jl_tparam(tt, i) != t1) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 STATIC_INLINE int jl_is_namedtuple_type(void *t) JL_NOTSAFEPOINT
 {
     return (jl_is_datatype(t) &&

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1773,6 +1773,7 @@ JL_DLLEXPORT jl_value_t *jl_copysign_float(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_flipsign_int(jl_value_t *a, jl_value_t *b);
 
 JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *a);
+JL_DLLEXPORT jl_value_t *jl_preferred_vector_width(jl_value_t *a);
 JL_DLLEXPORT int jl_stored_inline(jl_value_t *el_type);
 JL_DLLEXPORT jl_value_t *(jl_array_data_owner)(jl_array_t *a);
 JL_DLLEXPORT jl_array_t *jl_array_copy(jl_array_t *ary);

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1178,13 +1178,36 @@ jl_value_t *jl_iintrinsic_2(jl_value_t *a, jl_value_t *b, const char *name,
 {
     jl_value_t *ty = jl_typeof(a);
     jl_value_t *tyb = jl_typeof(b);
+    jl_value_t *et = NULL;
+    jl_value_t *np = NULL;
+    jl_value_t *etb = NULL;
+    jl_value_t *npb = NULL;
     if (tyb != ty) {
         if (!cvtb)
             jl_errorf("%s: types of a and b must match", name);
-        if (!jl_is_primitivetype(tyb))
+        if (jl_is_primitivetype(tyb)) {}
+        else if (is_ntuple_type(tyb) && jl_nparams(tyb) > 0)
+        {
+            etb = jl_tparam0(tyb);
+            npb = jl_nparams(tyb);
+            if (((jl_datatype_t*)etb)->name == jl_vecelement_typename && jl_is_primitivetype(jl_tparam(etb, 0))){}
+            else 
+                jl_errorf("%s: eltype is not a VecElement of a primitive type", name);
+        }
+        else
             jl_errorf("%s: b is not a primitive type", name);
     }
-    if (!jl_is_primitivetype(ty))
+    if (jl_is_primitivetype(ty)) {}
+    else if (is_ntuple_type(ty) && jl_nparams(ty) > 0)
+    {
+        et = jl_tparam0(ty);
+        np = jl_nparams(ty); \
+        if (((jl_datatype_t*)et)->name == jl_vecelement_typename && jl_is_primitivetype(jl_tparam(et, 0))){}
+        else 
+            jl_errorf("%s: eltype is not a VecElement of a primitive type", name);
+        // TODO cvtb
+    }
+    else
         jl_errorf("%s: a is not a primitive type", name);
     void *pa = jl_data_ptr(a), *pb = jl_data_ptr(b);
     unsigned sz = jl_datatype_size(ty);

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1254,49 +1254,86 @@ static inline jl_value_t *jl_intrinsiclambda_checkeddiv(jl_value_t *ty, void *pa
 
 // floating point
 
-#define bi_fintrinsic(OP, name) \
-    bi_intrinsic_bfloat(OP, name) \
-    bi_intrinsic_half(OP, name) \
-    bi_intrinsic_ctype(OP, name, 32, float) \
-    bi_intrinsic_ctype(OP, name, 64, double) \
-JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
+static int is_ntuple_type(jl_value_t *tt)
+{
+    if (!jl_is_tuple_type(tt))
+    {
+        return 0;
+    }
+    size_t i, nfields = jl_nparams(tt);
+    if(!nfields)
+        return 1;
+    jl_value_t *t1 = jl_tparam0(tt);
+    for (i = 1; i < nfields; i++) {
+        if (jl_tparam(tt, i) != t1) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+#define bi_fintrinsic(OP, op_name) \
+    bi_intrinsic_bfloat(OP, op_name) \
+    bi_intrinsic_half(OP, op_name) \
+    bi_intrinsic_ctype(OP, op_name, 32, float) \
+    bi_intrinsic_ctype(OP, op_name, 64, double) \
+JL_DLLEXPORT jl_value_t *jl_##op_name(jl_value_t *a, jl_value_t *b) \
 { \
     jl_task_t *ct = jl_current_task; \
     jl_value_t *ty = jl_typeof(a); \
     jl_datatype_t *aty = (jl_datatype_t *)ty; \
+    jl_value_t *et = ty; \
+    int np=1; \
     if (jl_typeof(b) != ty) \
-        jl_error(#name ": types of a and b must match"); \
-    if (!jl_is_primitivetype(ty)) \
-        jl_error(#name ": values are not primitive types"); \
-    int sz = jl_datatype_size(ty); \
-    jl_value_t *newv = jl_gc_alloc(ct->ptls, sz, ty); \
+        jl_error(#op_name ": types of a and b must match"); \
+    if (jl_is_primitivetype(ty)){}\
+    else if (is_ntuple_type(ty) && jl_nparams(ty) > 0) \
+    { \
+        et = jl_tparam0(ty); \
+        np = jl_nparams(ty); \
+        if (((jl_datatype_t*)et)->name == jl_vecelement_typename && jl_is_primitivetype(jl_tparam(et, 0))){} \
+        else \
+            jl_error(#op_name ": eltype is not a VecElement of a primitive type"); \
+    }\
+    else \
+        jl_error(#op_name ": values are not primitive types"); \
+    int sz = jl_datatype_size(et); \
+    jl_value_t *newv = jl_gc_alloc(ct->ptls, sz*np, ty); \
     void *pa = jl_data_ptr(a), *pb = jl_data_ptr(b), *pr = jl_data_ptr(newv); \
     if (aty == jl_float16_type) \
-        jl_##name##16(16, pa, pb, pr); \
+        jl_##name##16(16*np, pa, pb, pr); \
     else if (aty == jl_bfloat16_type) \
-        jl_##name##bf16(16, pa, pb, pr); \
+        jl_##name##bf16(16*np, pa, pb, pr); \
     else if (aty == jl_float32_type) \
-        jl_##name##32(32, pa, pb, pr); \
+        jl_##name##32(32*np, pa, pb, pr); \
     else if (aty == jl_float64_type) \
-        jl_##name##64(64, pa, pb, pr); \
+        jl_##name##64(64*np, pa, pb, pr); \
     else \
         jl_error(#name ": runtime floating point intrinsics require both arguments to be Float16, BFloat16, Float32, or Float64"); \
     return newv; \
 }
 
-#define bool_fintrinsic(OP, name) \
-    bool_intrinsic_bfloat(OP, name) \
-    bool_intrinsic_half(OP, name) \
-    bool_intrinsic_ctype(OP, name, 32, float) \
-    bool_intrinsic_ctype(OP, name, 64, double) \
-JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
+#define bool_fintrinsic(OP, op_name) \
+    bool_intrinsic_bfloat(OP, op_name) \
+    bool_intrinsic_half(OP, op_name) \
+    bool_intrinsic_ctype(OP, op_name, 32, float) \
+    bool_intrinsic_ctype(OP, op_name, 64, double) \
+JL_DLLEXPORT jl_value_t *jl_##op_name(jl_value_t *a, jl_value_t *b) \
 { \
     jl_value_t *ty = jl_typeof(a); \
     jl_datatype_t *aty = (jl_datatype_t *)ty; \
     if (jl_typeof(b) != ty) \
-        jl_error(#name ": types of a and b must match"); \
-    if (!jl_is_primitivetype(ty)) \
-        jl_error(#name ": values are not primitive types"); \
+        jl_error(#op_name ": types of a and b must match"); \
+    if (jl_is_primitivetype(ty)) {}\
+    else if (is_ntuple_type(ty) && jl_nparams(ty) > 0) \
+    { \
+        jl_value_t *et = jl_tparam(ty, 0); \
+        if (((jl_datatype_t*)et)->name == jl_vecelement_typename && jl_is_primitivetype(jl_tparam(et, 0))){} \
+        else \
+            jl_error(#op_name ": eltype is not a VecElement of a primitive type"); \
+    }\
+    else \
+        jl_error(#op_name ": values are not primitive types"); \
     void *pa = jl_data_ptr(a), *pb = jl_data_ptr(b); \
     int cmp; \
     if (aty == jl_float16_type) \
@@ -1313,20 +1350,28 @@ JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b) \
     return cmp ? jl_true : jl_false; \
 }
 
-#define ter_fintrinsic(OP, name) \
-    ter_intrinsic_bfloat(OP, name) \
-    ter_intrinsic_half(OP, name) \
-    ter_intrinsic_ctype(OP, name, 32, float) \
-    ter_intrinsic_ctype(OP, name, 64, double) \
-JL_DLLEXPORT jl_value_t *jl_##name(jl_value_t *a, jl_value_t *b, jl_value_t *c) \
+#define ter_fintrinsic(OP, op_name) \
+    ter_intrinsic_bfloat(OP, op_name) \
+    ter_intrinsic_half(OP, op_name) \
+    ter_intrinsic_ctype(OP, op_name, 32, float) \
+    ter_intrinsic_ctype(OP, op_name, 64, double) \
+JL_DLLEXPORT jl_value_t *jl_##op_name(jl_value_t *a, jl_value_t *b, jl_value_t *c) \
 { \
     jl_task_t *ct = jl_current_task; \
     jl_value_t *ty = jl_typeof(a); \
     jl_datatype_t *aty = (jl_datatype_t *)ty; \
     if (jl_typeof(b) != ty || jl_typeof(c) != ty) \
-        jl_error(#name ": types of a, b, and c must match"); \
-    if (!jl_is_primitivetype(ty)) \
-        jl_error(#name ": values are not primitive types"); \
+        jl_error(#op_name ": types of a, b, and c must match"); \
+    if (jl_is_primitivetype(ty)) {}\
+    else if (is_ntuple_type(ty) && jl_nparams(ty) > 0) \
+    { \
+        jl_value_t *et = jl_tparam(ty, 0); \
+        if (((jl_datatype_t*)et)->name == jl_vecelement_typename && jl_is_primitivetype(jl_tparam(et, 0))){} \
+        else \
+            jl_error(#op_name ": eltype is not a VecElement of a primitive type"); \
+    }\
+    else \
+        jl_error(#op_name ": values are not primitive types"); \
     int sz = jl_datatype_size(ty); \
     jl_value_t *newv = jl_gc_alloc(ct->ptls, sz, ty); \
     void *pa = jl_data_ptr(a), *pb = jl_data_ptr(b), *pc = jl_data_ptr(c), *pr = jl_data_ptr(newv); \

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1766,6 +1766,21 @@ JL_DLLEXPORT jl_value_t *jl_have_fma(jl_value_t *typ)
         return jl_false;
 }
 
+JL_DLLEXPORT jl_value_t *jl_preferred_vector_width(jl_value_t *typ)
+{
+    JL_TYPECHK(preferred_vector_width, datatype, typ); // TODO what about float16/bfloat16?
+    jl_datatype_t* dt = (jl_datatype_t*)typ;
+    int sz = jl_datatype_size(dt);
+    int width = 32 / sz;
+    if (width == 0)
+        return jl_nothing;
+#ifdef _P64
+    return jl_box_int64(width);
+#else
+    return jl_box_int32(width);
+#endif
+}
+
 JL_DLLEXPORT jl_value_t *jl_add_ptr(jl_value_t *ptr, jl_value_t *offset)
 {
     JL_TYPECHK(add_ptr, pointer, ptr);

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1179,9 +1179,9 @@ jl_value_t *jl_iintrinsic_2(jl_value_t *a, jl_value_t *b, const char *name,
     jl_value_t *ty = jl_typeof(a);
     jl_value_t *tyb = jl_typeof(b);
     jl_value_t *et = NULL;
-    jl_value_t *np = NULL;
+    int np = 0;
     jl_value_t *etb = NULL;
-    jl_value_t *npb = NULL;
+    int npb = 0;
     if (tyb != ty) {
         if (!cvtb)
             jl_errorf("%s: types of a and b must match", name);
@@ -1306,15 +1306,15 @@ JL_DLLEXPORT jl_value_t *jl_##op_name(jl_value_t *a, jl_value_t *b) \
     jl_value_t *newv = jl_gc_alloc(ct->ptls, sz*np, ty); \
     void *pa = jl_data_ptr(a), *pb = jl_data_ptr(b), *pr = jl_data_ptr(newv); \
     if (aty == jl_float16_type) \
-        jl_##name##16(16*np, pa, pb, pr); \
+        jl_##op_name##16(16*np, pa, pb, pr); \
     else if (aty == jl_bfloat16_type) \
-        jl_##name##bf16(16*np, pa, pb, pr); \
+        jl_##op_name##bf16(16*np, pa, pb, pr); \
     else if (aty == jl_float32_type) \
-        jl_##name##32(32*np, pa, pb, pr); \
+        jl_##op_name##32(32*np, pa, pb, pr); \
     else if (aty == jl_float64_type) \
-        jl_##name##64(64*np, pa, pb, pr); \
+        jl_##op_name##64(64*np, pa, pb, pr); \
     else \
-        jl_error(#name ": runtime floating point intrinsics require both arguments to be Float16, BFloat16, Float32, or Float64"); \
+        jl_error(#op_name ": runtime floating point intrinsics require both arguments to be Float16, BFloat16, Float32, or Float64"); \
     return newv; \
 }
 
@@ -1342,15 +1342,15 @@ JL_DLLEXPORT jl_value_t *jl_##op_name(jl_value_t *a, jl_value_t *b) \
     void *pa = jl_data_ptr(a), *pb = jl_data_ptr(b); \
     int cmp; \
     if (aty == jl_float16_type) \
-        cmp = jl_##name##16(16, pa, pb); \
+        cmp = jl_##op_name##16(16, pa, pb); \
     else if (aty == jl_bfloat16_type) \
-        cmp = jl_##name##bf16(16, pa, pb); \
+        cmp = jl_##op_name##bf16(16, pa, pb); \
     else if (aty == jl_float32_type) \
-        cmp = jl_##name##32(32, pa, pb); \
+        cmp = jl_##op_name##32(32, pa, pb); \
     else if (aty == jl_float64_type) \
-        cmp = jl_##name##64(64, pa, pb); \
+        cmp = jl_##op_name##64(64, pa, pb); \
     else \
-        jl_error(#name ": runtime floating point intrinsics require both arguments to be Float16, BFloat16, Float32, or Float64"); \
+        jl_error(#op_name ": runtime floating point intrinsics require both arguments to be Float16, BFloat16, Float32, or Float64"); \
  \
     return cmp ? jl_true : jl_false; \
 }
@@ -1381,15 +1381,15 @@ JL_DLLEXPORT jl_value_t *jl_##op_name(jl_value_t *a, jl_value_t *b, jl_value_t *
     jl_value_t *newv = jl_gc_alloc(ct->ptls, sz, ty); \
     void *pa = jl_data_ptr(a), *pb = jl_data_ptr(b), *pc = jl_data_ptr(c), *pr = jl_data_ptr(newv); \
     if (aty == jl_float16_type) \
-            jl_##name##16(16, pa, pb, pc, pr); \
+            jl_##op_name##16(16, pa, pb, pc, pr); \
     else if (aty == jl_bfloat16_type) \
-            jl_##name##bf16(16, pa, pb, pc, pr); \
+            jl_##op_name##bf16(16, pa, pb, pc, pr); \
     else if (aty == jl_float32_type) \
-        jl_##name##32(32, pa, pb, pc, pr); \
+        jl_##op_name##32(32, pa, pb, pc, pr); \
     else if (aty == jl_float64_type) \
-        jl_##name##64(64, pa, pb, pc, pr); \
+        jl_##op_name##64(64, pa, pb, pc, pr); \
     else \
-        jl_error(#name ": runtime floating point intrinsics require both arguments to be Float16, BFloat16, Float32, or Float64"); \
+        jl_error(#op_name ": runtime floating point intrinsics require both arguments to be Float16, BFloat16, Float32, or Float64"); \
     return newv; \
 }
 

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -1254,24 +1254,6 @@ static inline jl_value_t *jl_intrinsiclambda_checkeddiv(jl_value_t *ty, void *pa
 
 // floating point
 
-static int is_ntuple_type(jl_value_t *tt)
-{
-    if (!jl_is_tuple_type(tt))
-    {
-        return 0;
-    }
-    size_t i, nfields = jl_nparams(tt);
-    if(!nfields)
-        return 1;
-    jl_value_t *t1 = jl_tparam0(tt);
-    for (i = 1; i < nfields; i++) {
-        if (jl_tparam(tt, i) != t1) {
-            return 0;
-        }
-    }
-    return 1;
-}
-
 #define bi_fintrinsic(OP, op_name) \
     bi_intrinsic_bfloat(OP, op_name) \
     bi_intrinsic_half(OP, op_name) \

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -11,7 +11,7 @@ const TESTNAMES = [
         "char", "strings", "triplequote", "unicode", "intrinsics",
         "dict", "hashing", "iobuffer", "staged", "offsetarray",
         "arrayops", "tuple", "reduce", "reducedim", "abstractarray",
-        "intfuncs", "simdloop", "vecelement", "rational",
+        "intfuncs", "simdloop", "vecelement", "rational", "simd",
         "bitarray", "copy", "math", "fastmath", "functional", "iterators",
         "operators", "ordering", "path", "ccall", "parse", "loading", "gmp",
         "sorting", "spawn", "backtrace", "exceptions",

--- a/test/simd.jl
+++ b/test/simd.jl
@@ -1,0 +1,36 @@
+using Base.Experimental.SIMD
+using Test
+using InteractiveUtils
+
+function vcopyto!(a::Array{T}, b::Array{T}) where T
+    stride = natural_vecwidth(T)
+    VT = Vec{stride, T}
+    @assert length(a) == length(b)
+    @assert length(a) % stride == 0
+    @inbounds for i in 1:stride:length(a)
+        vec = vload(VT, a, i)
+        vstore!(b, vec, i)
+    end
+end
+
+@testset "load/store" begin
+    A = rand(64)
+    B = zeros(64)
+
+    vcopyto!(A, B)
+    @test A == B
+
+    @test_throws BoundsError vload(Vec{4, Float64}, A, 62)
+    vec = vload(Vec{4, Float64}, A, 1)
+    @test_throws BoundsError vstore!(A, vec, 62)
+
+    load(A, i) = @inbounds vload(Vec{4, Float64}, A, i)
+    store(A,v,i) = @inbounds vstore!(A, v, i)
+
+    ir = sprint(io->code_llvm(io, vload, (Type{Vec{4, Float64}}, Vector{Float64}, Int)))
+    @test contains(ir, "call void @j_throw_boundserror")
+
+    ir = sprint(io->code_llvm(io, load, (Vector{Float64}, Int)))
+    @test contains(ir, "load <4 x double>")
+    @test !contains(ir, "call void @j_throw_boundserror")
+end

--- a/test/simd.jl
+++ b/test/simd.jl
@@ -3,14 +3,26 @@ using Test
 using InteractiveUtils
 
 function vcopyto!(a::Array{T}, b::Array{T}) where T
-    stride = natural_vecwidth(T)
-    VT = Vec{stride, T}
+    VT = preferred_vector(T)
+    stride = width(VT)
     @assert length(a) == length(b)
     @assert length(a) % stride == 0
     @inbounds for i in 1:stride:length(a)
         vec = vload(VT, a, i)
         vstore!(b, vec, i)
     end
+end
+
+# todo: noninline/mutable types?
+primitive type I256 256 end
+primitive type I512 512 end
+
+@testset "preferred_vector_width" begin
+    for T in (Int8, Int16, Int32, Int64, Int128, I256)
+        max_width = 32 # avx2
+        @test width(preferred_vector(T)) == max_width ÷ sizeof(T)
+    end
+    @test_throws ErrorException preferred_vector(I526)
 end
 
 @testset "load/store" begin

--- a/test/simd.jl
+++ b/test/simd.jl
@@ -46,3 +46,24 @@ end
     @test contains(ir, "load <4 x double>")
     @test !contains(ir, "call void @j_throw_boundserror")
 end
+
+@testset "basic arithmetic" begin
+    ir = sprint(io->code_llvm(io, +, (Vec{4, Float64}, Vec{4, Float64})))
+    @test contains(ir, "fadd <4 x double>")
+    ir = sprint(io->code_llvm(io, -, (Vec{4, Float64}, Vec{4, Float64})))
+    @test contains(ir, "fsub <4 x double>")
+    ir = sprint(io->code_llvm(io, *, (Vec{4, Float64}, Vec{4, Float64})))
+    @test contains(ir, "fmul <4 x double>")
+    ir = sprint(io->code_llvm(io, /, (Vec{4, Float64}, Vec{4, Float64})))
+    @test contains(ir, "fdiv <4 x double>")
+
+    ir = sprint(io->code_llvm(io, muladd, (Vec{4, Float64}, Vec{4, Float64}, Vec{4, Float64})))
+    @test contains(ir, "fmul contract <4 x double>")
+    @test contains(ir, "fadd contract <4 x double>")
+
+    ir = sprint(io->code_llvm(io, -, (Vec{4, Float64},)))
+    @test contains(ir, "fneg <4 x double>")
+
+    # TODO: Way to test Intrinsics directly?
+    #`-v` -> ERROR: neg_float_withtype: value is not a primitive type
+end

--- a/test/simd.jl
+++ b/test/simd.jl
@@ -47,20 +47,32 @@ end
     @test !contains(ir, "call void @j_throw_boundserror")
 end
 
-@testset "basic arithmetic" begin
+@testset "basic floating-point arithmetic" begin
+    A = rand(64)
+    v = vload(Vec{4, Float64}, A, 1)
+
+    @test v+v isa Vec{4, Float64}
     ir = sprint(io->code_llvm(io, +, (Vec{4, Float64}, Vec{4, Float64})))
     @test contains(ir, "fadd <4 x double>")
+    
+    @test v-v isa Vec{4, Float64}
     ir = sprint(io->code_llvm(io, -, (Vec{4, Float64}, Vec{4, Float64})))
     @test contains(ir, "fsub <4 x double>")
+
+    @test v*v isa Vec{4, Float64}
     ir = sprint(io->code_llvm(io, *, (Vec{4, Float64}, Vec{4, Float64})))
     @test contains(ir, "fmul <4 x double>")
+
+    @test v/v isa Vec{4, Float64}
     ir = sprint(io->code_llvm(io, /, (Vec{4, Float64}, Vec{4, Float64})))
     @test contains(ir, "fdiv <4 x double>")
 
+    @test muladd(v, v, v) isa Vec{4, Float64}
     ir = sprint(io->code_llvm(io, muladd, (Vec{4, Float64}, Vec{4, Float64}, Vec{4, Float64})))
     @test contains(ir, "fmul contract <4 x double>")
     @test contains(ir, "fadd contract <4 x double>")
 
+    @test -v isa Vec{4, Float64}
     ir = sprint(io->code_llvm(io, -, (Vec{4, Float64},)))
     @test contains(ir, "fneg <4 x double>")
 
@@ -72,4 +84,10 @@ end
     ir = sprint(io->code_llvm(io, select, (Vec{4, Bool}, Vec{4, Float64}, Vec{4, Float64})))
     @test contains(ir, "icmp eq <4 x i8>")
     @test contains(ir, "select <4 x i1>")
+end
+
+@test "basic integer arithmetic" begin
+end
+
+@test "basic logical operations" begin
 end

--- a/test/simd.jl
+++ b/test/simd.jl
@@ -67,3 +67,9 @@ end
     # TODO: Way to test Intrinsics directly?
     #`-v` -> ERROR: neg_float_withtype: value is not a primitive type
 end
+
+@testset "select" begin
+    ir = sprint(io->code_llvm(io, select, (Vec{4, Bool}, Vec{4, Float64}, Vec{4, Float64})))
+    @test contains(ir, "icmp eq <4 x i8>")
+    @test contains(ir, "select <4 x i1>")
+end


### PR DESCRIPTION
This is the start towards proper SIMD support in Base. Currently the main things missing are support for masked/predicated instructions, and an intrinsic to load an arbitrarily chosen sized `NTuple{n, VecElement}` from a `Memory`. Many thanks to Alexandre Prieur for pair programming this with me, and @vtjnash, @gbaraldi and @vchuravy for answering the 50 million questions about C++/LLVM/debugging.
```
julia> f(a,b) = Core.Intrinsics.mul_float(a, b)
julia> a = ntuple(i->VecElement(sqrt(i)), 8);

julia> @code_llvm f(a,a)
; Function Signature: f(NTuple{8, VecElement{Float64}}, NTuple{8, VecElement{Float64}})
;  @ REPL[1]:1 within `f`
define <8 x double> @julia_f_949(<8 x double> %"a::Tuple", <8 x double> %"b::Tuple") #0 {
top:
  %0 = fmul <8 x double> %"a::Tuple", %"b::Tuple"
  ret <8 x double> %0
}