### PR TITLE
Convert message in timing macros before printing

### DIFF
--- a/base/timing.jl
+++ b/base/timing.jl
@@ -314,8 +314,9 @@ end
 macro time(msg, ex)
     quote
         local ret = @timed $(esc(ex))
-        local _msg = string($(esc(msg)))
-        time_print(stdout, ret.time*1e9, ret.gcstats.allocd, ret.gcstats.total_time, gc_alloc_count(ret.gcstats), ret.lock_conflicts, ret.compile_time*1e9, ret.recompile_time*1e9, true; msg=_msg)
+        local _msg = $(esc(msg))
+        local _msg_str = _msg isa Nothing ? _msg : string(_msg)
+        time_print(stdout, ret.time*1e9, ret.gcstats.allocd, ret.gcstats.total_time, gc_alloc_count(ret.gcstats), ret.lock_conflicts, ret.compile_time*1e9, ret.recompile_time*1e9, true; msg=_msg_str)
         ret.value
     end
 end
@@ -386,8 +387,9 @@ end
 macro timev(msg, ex)
     quote
         local ret = @timed $(esc(ex))
-        local _msg = string($(esc(msg)))
-        timev_print(ret.time*1e9, ret.gcstats, ret.lock_conflicts, (ret.compile_time*1e9, ret.recompile_time*1e9); msg=_msg)
+        local _msg = $(esc(msg))
+        local _msg_str = _msg isa Nothing ? _msg : string(_msg)
+        timev_print(ret.time*1e9, ret.gcstats, ret.lock_conflicts, (ret.compile_time*1e9, ret.recompile_time*1e9); msg=_msg_str)
         ret.value
     end
 end

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -314,7 +314,7 @@ end
 macro time(msg, ex)
     quote
         local ret = @timed $(esc(ex))
-        local _msg = $(esc(msg))
+        local _msg = string($(esc(msg)))
         time_print(stdout, ret.time*1e9, ret.gcstats.allocd, ret.gcstats.total_time, gc_alloc_count(ret.gcstats), ret.lock_conflicts, ret.compile_time*1e9, ret.recompile_time*1e9, true; msg=_msg)
         ret.value
     end
@@ -386,7 +386,7 @@ end
 macro timev(msg, ex)
     quote
         local ret = @timed $(esc(ex))
-        local _msg = $(esc(msg))
+        local _msg = string($(esc(msg)))
         timev_print(ret.time*1e9, ret.gcstats, ret.lock_conflicts, (ret.compile_time*1e9, ret.recompile_time*1e9); msg=_msg)
         ret.value
     end

--- a/base/timing.jl
+++ b/base/timing.jl
@@ -315,7 +315,7 @@ macro time(msg, ex)
     quote
         local ret = @timed $(esc(ex))
         local _msg = $(esc(msg))
-        local _msg_str = _msg isa Nothing ? _msg : string(_msg)
+        local _msg_str = _msg === nothing ? _msg : string(_msg)
         time_print(stdout, ret.time*1e9, ret.gcstats.allocd, ret.gcstats.total_time, gc_alloc_count(ret.gcstats), ret.lock_conflicts, ret.compile_time*1e9, ret.recompile_time*1e9, true; msg=_msg_str)
         ret.value
     end
@@ -388,7 +388,7 @@ macro timev(msg, ex)
     quote
         local ret = @timed $(esc(ex))
         local _msg = $(esc(msg))
-        local _msg_str = _msg isa Nothing ? _msg : string(_msg)
+        local _msg_str = _msg === nothing ? _msg : string(_msg)
         timev_print(ret.time*1e9, ret.gcstats, ret.lock_conflicts, (ret.compile_time*1e9, ret.recompile_time*1e9); msg=_msg_str)
         ret.value
     end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -321,23 +321,32 @@ v11801, t11801 = @timed sin(1)
 @test names(@__MODULE__, all = true) == names_before_timing
 
 redirect_stdout(devnull) do # suppress time prints
+
 # Accepted @time argument formats
 @test @time true
 @test @time "message" true
+@test @time 1 true
 let msg = "message"
     @test @time msg true
 end
 let foo() = "message"
     @test @time foo() true
 end
+let foo() = 1
+    @test @time foo() true
+end
 
 # Accepted @timev argument formats
 @test @timev true
 @test @timev "message" true
+@test @timev 1 true
 let msg = "message"
     @test @timev msg true
 end
 let foo() = "message"
+    @test @timev foo() true
+end
+let foo() = 1
     @test @timev foo() true
 end
 


### PR DESCRIPTION
One of the example in docs of `@time` didn't work before this:

```julia
julia> for loop in 1:3
                   @time loop sleep(1)
               end
ERROR: MethodError: Cannot `convert` an object of type Int64 to an object of type String

Closest candidates are:
  convert(::Type{String}, ::Base.JuliaSyntax.Kind)
   @ Base /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/base/JuliaSyntax/src/kinds.jl:975
  convert(::Type{String}, ::String)
   @ Base essentials.jl:321
  convert(::Type{T}, ::T) where T<:AbstractString
   @ Base strings/basic.jl:231
```
