### PR TITLE
better type inference for several functions taking `NTuple` args

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -501,7 +501,13 @@ julia> Base.tail(())
 ERROR: ArgumentError: Cannot call tail on an empty tuple.
 ```
 """
-tail(x::Tuple) = argtail(x...)
+function tail(x::Tuple{Any,Vararg})
+    y = argtail(x...)::Tuple
+    if x isa NTuple
+        y = y::NTuple
+    end
+    y
+end
 tail(::Tuple{}) = throw(ArgumentError("Cannot call tail on an empty tuple."))
 
 function unwrap_unionall(@nospecialize(a))

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -503,7 +503,7 @@ ERROR: ArgumentError: Cannot call tail on an empty tuple.
 """
 function tail(x::Tuple{Any,Vararg})
     y = argtail(x...)::Tuple
-    if x isa NTuple
+    if x isa NTuple  # help the type inference
         y = y::NTuple
     end
     y

--- a/base/ntuple.jl
+++ b/base/ntuple.jl
@@ -95,5 +95,5 @@ end
 function reverse(t::NTuple{N}) where N
     ntuple(Val{N}()) do i
         t[end+1-i]
-    end
+    end::NTuple
 end

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -344,7 +344,7 @@ function front(t::Tuple)
         throw(ArgumentError("Cannot call front on an empty tuple."))
     end
     r = _front(t...)::Tuple
-    if t isa NTuple
+    if t isa NTuple  # help the type inference
         r = r::NTuple
     end
     r
@@ -706,7 +706,7 @@ function circshift(x::Tuple{Any,Any,Any,Vararg{Any,N}}, shift::Integer) where {N
     len = N + 3
     j = mod1(shift, len)
     y = ntuple(k -> getindex(x, k-j+ifelse(k>j,0,len)), Val(len))::Tuple
-    if x isa NTuple
+    if x isa NTuple  # help the type inference
         y = y::NTuple
     end
     y

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -340,9 +340,15 @@ ERROR: ArgumentError: Cannot call front on an empty tuple.
 """
 function front(t::Tuple)
     @inline
-    _front(t...)
+    if t === ()
+        throw(ArgumentError("Cannot call front on an empty tuple."))
+    end
+    r = _front(t...)::Tuple
+    if t isa NTuple
+        r = r::NTuple
+    end
+    r
 end
-_front() = throw(ArgumentError("Cannot call front on an empty tuple."))
 _front(v) = ()
 function _front(v, t...)
     @inline
@@ -699,5 +705,9 @@ function circshift(x::Tuple{Any,Any,Any,Vararg{Any,N}}, shift::Integer) where {N
     @inline
     len = N + 3
     j = mod1(shift, len)
-    ntuple(k -> getindex(x, k-j+ifelse(k>j,0,len)), Val(len))::Tuple
+    y = ntuple(k -> getindex(x, k-j+ifelse(k>j,0,len)), Val(len))::Tuple
+    if x isa NTuple
+        y = y::NTuple
+    end
+    y
 end

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -845,3 +845,10 @@ end
         end
     end
 end
+
+@testset "abstract return type inference for homogeneous tuples" begin
+    @test NTuple == Core.Compiler.return_type(Base.tail, Tuple{NTuple})
+    @test NTuple == Core.Compiler.return_type(Base.front, Tuple{NTuple})
+    @test NTuple == Core.Compiler.return_type(reverse, Tuple{NTuple})
+    @test NTuple == Core.Compiler.return_type(circshift, Tuple{NTuple,Int})
+end


### PR DESCRIPTION
Improves the abstract return type inference for these functions, for homogeneous tuple arguments:

* `tail`
* `front`
* `reverse`
* `circshift`

Example:

```julia
f(g, t::Type{<:Tuple}) = println(Core.Compiler.return_type(g, t))
f(Base.tail, Tuple{NTuple})
f(Base.front, Tuple{NTuple})
f(reverse, Tuple{NTuple})
f(circshift, Tuple{NTuple,Int})
```

Results before:

```julia
Tuple
Tuple
Tuple
Tuple
```

Results after:

```julia
NTuple{N, T} where {N, T}
NTuple{N, T} where {N, T}
NTuple{N, T} where {N, T}
NTuple{N, T} where {N, T}
```

Updates #54495