### PR TITLE
Mark task.code as constant

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3610,8 +3610,7 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_value_t *listt = jl_new_struct(jl_uniontype_type, jl_task_type, jl_nothing_type);
     jl_svecset(jl_task_type->types, 0, listt);
 
-    // TODO: Shouldn't some of these fields be atomic?
-    const static uint32_t task_constfields[1] = {0x00000080}; // Set fields 7 as constant
+    const static uint32_t task_constfields[1] = {0x00000040}; // Set fields 7 as constant
     jl_task_type->name->constfields = task_constfields;
 
     tv = jl_svec2(tvar("A"), tvar("R"));

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3610,6 +3610,10 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_value_t *listt = jl_new_struct(jl_uniontype_type, jl_task_type, jl_nothing_type);
     jl_svecset(jl_task_type->types, 0, listt);
 
+    // TODO: Shouldn't some of these fields be atomic?
+    const static uint32_t task_constfields[1] = {0x00000080}; // Set fields 7 as constant
+    jl_task_type->name->constfields = task_constfields;
+
     tv = jl_svec2(tvar("A"), tvar("R"));
     jl_opaque_closure_type = (jl_unionall_t*)jl_new_datatype(jl_symbol("OpaqueClosure"), core, jl_function_type, tv,
         // N.B.: OpaqueClosure call code relies on specptr being field 5.

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1564,9 +1564,9 @@ function deserialize(s::AbstractSerializer, ::Type{UnionAll})
 end
 
 function deserialize(s::AbstractSerializer, ::Type{Task})
-    t = Task(()->nothing)
+    code = deserialize(s)
+    t = Task(code)
     deserialize_cycle(s, t)
-    t.code = deserialize(s)
     t.storage = deserialize(s)
     state = deserialize(s)
     if state === :runnable

--- a/test/core.jl
+++ b/test/core.jl
@@ -25,6 +25,7 @@ for (T, c) in (
         (TypeVar, [:name, :ub, :lb]),
         (Core.Memory, [:length, :ptr]),
         (Core.GenericMemoryRef, [:mem, :ptr_or_offset]),
+        (Core.Task, [:code]),
     )
     @test Set((fieldname(T, i) for i in 1:fieldcount(T) if isconst(T, i))) == Set(c)
 end


### PR DESCRIPTION
@gbaraldi and I chatted about this during JuliaCon.

Changing the code field of a task after it has been scheduled is wrong.
One could technically change it before it has ever been scheduled,
but I see no good reason to allow that (one can just create the Task to point to the right closure in the first place).

