### PR TITLE
make Base.setindex() public

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -99,6 +99,7 @@ Standard library changes
 ------------------------
 
 * `gcdx(0, 0)` now returns `(0, 0, 0)` instead of `(0, 1, 0)` ([#40989]).
+* `Base.setindex` function is now marked as `public` ([#55129]).
 
 #### StyledStrings
 

--- a/base/public.jl
+++ b/base/public.jl
@@ -44,6 +44,7 @@ public
     rest,
     split_rest,
     tail,
+    setindex,
     checked_length,
     elsize,
 

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -52,7 +52,7 @@ julia> Base.setindex((1, 2, 6), 2, 3) == (1, 2, 2)
 true
 ```
 """
-function setindex(x::Tuple, v, i::Integer)
+public function setindex(x::Tuple, v, i::Integer)
     @boundscheck 1 <= i <= length(x) || throw(BoundsError(x, i))
     @inline
     _setindex(v, i, x...)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -52,7 +52,7 @@ julia> Base.setindex((1, 2, 6), 2, 3) == (1, 2, 2)
 true
 ```
 """
-public function setindex(x::Tuple, v, i::Integer)
+function setindex(x::Tuple, v, i::Integer)
     @boundscheck 1 <= i <= length(x) || throw(BoundsError(x, i))
     @inline
     _setindex(v, i, x...)

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -151,6 +151,7 @@ Base.modifyproperty!
 Base.setpropertyonce!
 Base.propertynames
 Base.hasproperty
+Base.setindex
 Core.getfield
 Core.setfield!
 Core.modifyfield!


### PR DESCRIPTION
setindex() is a widely used well-documented function, it should be marked public, right?

Not sure what's the right way to make a function with multiple methods public, please correct me if I'm wrong here!