### PR TITLE
Add `@save`

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -658,6 +658,7 @@ export
     @info,
     @warn,
     @error,
+    @save,
 
 # bigfloat & precision
     precision,

--- a/base/logging/ConsoleLogger.jl
+++ b/base/logging/ConsoleLogger.jl
@@ -106,6 +106,10 @@ end
 function handle_message(logger::ConsoleLogger, level::LogLevel, message, _module, group, id,
                         filepath, line; kwargs...)
     @nospecialize
+    if haskey(kwargs, :save)
+        Core.eval(Main, Expr(:(=), kwargs[:save], message))
+        return
+    end
     hasmaxlog = haskey(kwargs, :maxlog) ? 1 : 0
     maxlog = get(kwargs, :maxlog, nothing)
     if maxlog isa Core.BuiltinInts

--- a/base/logging/logging.jl
+++ b/base/logging/logging.jl
@@ -289,7 +289,7 @@ macro error(exs...) logmsg_code((@_sourceinfo)..., :Error, exs...) end
 
 Save `variable` for manual user inspection.
 
-When using the default [`ConsoleLogger`](@ref), Sets `Main.varaible` equal to the result
+When using the default [`ConsoleLogger`](@ref), Sets `Main.variable` equal to the result
 of `expression`, or the value of `variable` if `expression` is not provided.
 
 Behavior may be overridden by a custom logging backend. See [`@logmsg`](@ref) for more info.
@@ -321,7 +321,7 @@ get_key_value(arg::Symbol) = arg, arg
 function get_key_value(arg)
     Base.isexpr(arg, :(=), 2) || throw(ArgumentError("Invalid @save argument: `$arg`. Try `@save x = $arg`."))
     k = arg.args[1]
-    k isa Symbol || throw(ArgumentError("Invalid @save argument: `$arg`. The left hand side of assignment opperator must be a symbol. Try `@save x = $(arg.args[2])`."))
+    k isa Symbol || throw(ArgumentError("Invalid @save argument: `$arg`. The left hand side of assignment operator must be a symbol. Try `@save x = $(arg.args[2])`."))
     NTuple{2, Any}(arg.args)
 end
 function get_save_args(arg)

--- a/base/logging/logging.jl
+++ b/base/logging/logging.jl
@@ -195,16 +195,13 @@ _logmsg_docs = """
     @warn  message  [key=value | value ...]
     @error message  [key=value | value ...]
 
-    @save  value    [key=value | value ...]
-
     @logmsg level message [key=value | value ...]
 
 Create a log record with an informational `message`.  For convenience, four
 logging macros `@debug`, `@info`, `@warn` and `@error` are defined which log
-at the standard severity levels `Debug`, `Info`, `Warn` and `Error`.
-[`@save`](@ref) logs at the `Info` security level and sets the key `save`
-to `:variable`. `@logmsg` allows `level` to be set programmatically to any
-`LogLevel` or custom log level types.
+at the standard severity levels `Debug`, `Info`, `Warn` and `Error`. `@logmsg`
+allows `level` to be set programmatically to any `LogLevel` or custom log level
+types.
 
 `message` is an expression which is evaluated at log time and should evaluate
 to a human readable object. By convention, this object will be converted to a
@@ -288,17 +285,48 @@ macro error(exs...) logmsg_code((@_sourceinfo)..., :Error, exs...) end
 
 """
     @save variable
+    @save (variable | variable=expression)...
 
 Save `variable` for manual user inspection.
 
-When using the default [`ConsoleLogger`](@ref), Sets `Main.varaible` equal to the value of
-`variable` at the callsite.
+When using the default [`ConsoleLogger`](@ref), Sets `Main.varaible` equal to the result
+of `expression`, or the value of `variable` if `expression` is not provided.
 
 Behavior may be overridden by a custom logging backend. See [`@logmsg`](@ref) for more info.
+
+# Examples
+
+```jldoctest
+julia> function f(x)
+           x -= 1
+           @save x
+           1/x
+       end
+f (generic function with 1 method)
+
+julia> f(1)
+Inf
+
+julia> x
+0
+```
 """
-macro  save(exs...)
+macro save(exs...)
     save_arg = Expr(:(=), :save, QuoteNode(Symbol(first(exs))))
-    logmsg_code((@_sourceinfo)..., :Info,  exs..., save_arg)
+    Base.exprarray(:block, Any[
+            logmsg_code((@_sourceinfo)..., :Info,  get_save_args(ex)...)
+        for ex in exs])
+end
+get_key_value(arg::Symbol) = arg, arg
+function get_key_value(arg)
+    Base.isexpr(arg, :(=), 2) || throw(ArgumentError("Invalid @save argument: `$arg`. Try `@save x = $arg`."))
+    k = arg.args[1]
+    k isa Symbol || throw(ArgumentError("Invalid @save argument: `$arg`. The left hand side of assignment opperator must be a symbol. Try `@save x = $(arg.args[2])`."))
+    NTuple{2, Any}(arg.args)
+end
+function get_save_args(arg)
+    k, v = get_key_value(arg)
+    v, Expr(:(=), :save, QuoteNode(k::Symbol))
 end
 
 _log_record_ids = Set{Symbol}()

--- a/test/corelogging.jl
+++ b/test/corelogging.jl
@@ -471,11 +471,39 @@ end
 # @save
 module AtSaveTestModule
     using Test
-    @test !isdefined(Main, :xc44f6e16f91ba48824afec66744d3faf)
-    xc44f6e16f91ba48824afec66744d3faf = rand(3,3)
-    @test !isdefined(Main, :xc44f6e16f91ba48824afec66744d3faf)
-    @save xc44f6e16f91ba48824afec66744d3faf
-    @test isdefined(Main, :xc44f6e16f91ba48824afec66744d3faf)
-    @test getglobal(Main, :xc44f6e16f91ba48824afec66744d3faf) == xc44f6e16f91ba48824afec66744d3faf
-    @test getglobal(Main, :xc44f6e16f91ba48824afec66744d3faf) === xc44f6e16f91ba48824afec66744d3faf
+    @test !isdefined(Main, :xc44f6e16f91ba48824afec66744d3faf_1)
+    xc44f6e16f91ba48824afec66744d3faf_1 = rand(3,3)
+    @test !isdefined(Main, :xc44f6e16f91ba48824afec66744d3faf_1)
+    @save xc44f6e16f91ba48824afec66744d3faf_1
+    @test isdefined(Main, :xc44f6e16f91ba48824afec66744d3faf_1)
+    @test getglobal(Main, :xc44f6e16f91ba48824afec66744d3faf_1) == xc44f6e16f91ba48824afec66744d3faf_1
+    @test getglobal(Main, :xc44f6e16f91ba48824afec66744d3faf_1) === xc44f6e16f91ba48824afec66744d3faf_1
+
+    xc44f6e16f91ba48824afec66744d3faf_2 = rand(3,2)
+    xc44f6e16f91ba48824afec66744d3faf_3 = rand(3,1)
+    @save xc44f6e16f91ba48824afec66744d3faf_2 xc44f6e16f91ba48824afec66744d3faf_3 xc44f6e16f91ba48824afec66744d3faf_3=6
+    @test getglobal(Main, :xc44f6e16f91ba48824afec66744d3faf_2) == xc44f6e16f91ba48824afec66744d3faf_2
+    @test getglobal(Main, :xc44f6e16f91ba48824afec66744d3faf_3) == 6
+
+    # Malformed arguments throw at lower time
+    for (expr_str, hint) in [
+        ("@save 1+1",     "Invalid @save argument: `1 + 1`. Try `@save x = 1 + 1`."),
+        ("@save a,b,c",   "Invalid @save argument: `(a, b, c)`. Try `@save x = (a, b, c)`."),
+        ("@save a,b=1,2", "Invalid @save argument: `(a, b) = (1, 2)`. The left hand side of assignment opperator must be a symbol. Try `@save x = (1, 2)`."),
+    ]
+        # Using Meta.parse instead of quoted exprs discards line numbers, which are out
+        # of scope for this testset and would make the LoadError equality check fail
+        expr = Meta.parse(expr_str)
+        @test_throws LoadError("none", 1, ArgumentError(hint)) Meta.lower(@__MODULE__, expr)
+    end
+
+    # A malformed argument throws without logging anything
+    @test_throws LoadError eval(:(@save xc44f6e16f91ba48824afec66744d3faf_4=0 1+1))
+    @test !isdefined(Main, :xc44f6e16f91ba48824afec66744d3faf_4)
+
+    # Runtime errors are suppressed
+    redirect_stderr(devnull) do
+        @save xc44f6e16f91ba48824afec66744d3faf_5=error()
+    end
+    @test !isdefined(Main, :xc44f6e16f91ba48824afec66744d3faf_5)
 end

--- a/test/corelogging.jl
+++ b/test/corelogging.jl
@@ -467,3 +467,15 @@ end
 for (k, v) in pairs(original_env)
     ENV[k] = v
 end
+
+# @save
+module AtSaveTestModule
+    using Test
+    @test !isdefined(Main, :xc44f6e16f91ba48824afec66744d3faf)
+    xc44f6e16f91ba48824afec66744d3faf = rand(3,3)
+    @test !isdefined(Main, :xc44f6e16f91ba48824afec66744d3faf)
+    @save xc44f6e16f91ba48824afec66744d3faf
+    @test isdefined(Main, :xc44f6e16f91ba48824afec66744d3faf)
+    @test getglobal(Main, :xc44f6e16f91ba48824afec66744d3faf) == xc44f6e16f91ba48824afec66744d3faf
+    @test getglobal(Main, :xc44f6e16f91ba48824afec66744d3faf) === xc44f6e16f91ba48824afec66744d3faf
+end

--- a/test/corelogging.jl
+++ b/test/corelogging.jl
@@ -489,7 +489,7 @@ module AtSaveTestModule
     for (expr_str, hint) in [
         ("@save 1+1",     "Invalid @save argument: `1 + 1`. Try `@save x = 1 + 1`."),
         ("@save a,b,c",   "Invalid @save argument: `(a, b, c)`. Try `@save x = (a, b, c)`."),
-        ("@save a,b=1,2", "Invalid @save argument: `(a, b) = (1, 2)`. The left hand side of assignment opperator must be a symbol. Try `@save x = (1, 2)`."),
+        ("@save a,b=1,2", "Invalid @save argument: `(a, b) = (1, 2)`. The left hand side of assignment operator must be a symbol. Try `@save x = (1, 2)`."),
     ]
         # Using Meta.parse instead of quoted exprs discards line numbers, which are out
         # of scope for this testset and would make the LoadError equality check fail


### PR DESCRIPTION
Implement `@save` debugging tool similar to `@show`, but instead of printing, saves the captured values to globals in Main.

````
    @save variable
    @save (variable | variable=expression)...

Save `variable` for manual user inspection.

When using the default [`ConsoleLogger`](@ref), Sets `Main.varaible` equal to the result
of `expression`, or the value of `variable` if `expression` is not provided.

Behavior may be overridden by a custom logging backend. See [`@logmsg`](@ref) for more info.

# Examples

```jldoctest
julia> function f(x)
           x -= 1
           @save x
           1/x
       end
f (generic function with 1 method)

julia> f(1)
Inf

julia> x
0
```
````

---

Passes through Logging so that results can be aggregated or redirected by custom logging backends. e.g. you might want to save all the results of an `@save` callsite instead of only the most recent.