### PR TITLE
Add some trivial helper functions for working with IRCode and MethodInstance

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -1410,9 +1410,9 @@ end
 
 function inline_cost(ir::IRCode, params::OptimizationParams, cost_threshold::Int)
     bodycost = 0
-    for i = 1:length(ir.stmts)
-        stmt = ir[SSAValue(i)][:stmt]
-        thiscost = statement_or_branch_cost(stmt, i, ir, ir.sptypes, params)
+    for i in eachindex(ir)
+        stmt = ir[i][:stmt]
+        thiscost = statement_or_branch_cost(stmt, i.id, ir, ir.sptypes, params)
         bodycost = plus_saturate(bodycost, thiscost)
         if bodycost > cost_threshold
             return MAX_INLINE_COST

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -497,6 +497,8 @@ function setindex!(x::IRCode, repl::Union{Instruction, Nothing, AnySSAValue}, s:
     return x
 end
 
+eachindex(ir::IRCode) = (SSAValue(i) for i in 1:length(ir.stmts))
+
 mutable struct UseRefIterator
     stmt::Any
     relevant::Bool

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1230,8 +1230,7 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
                 # by `stmt.args`. Which have :scope set. In practice, the frontend
                 # does emit these in order, so we could simply go to the last one,
                 # but we want to avoid making that semantic assumption.
-                for i = 1:length(stmt.args)
-                    scope = stmt.args[i]
+                for scope in stmt.args
                     scope === nothing && continue
                     enter = compact[scope][:inst]
                     @assert isa(enter, EnterNode)
@@ -1521,16 +1520,16 @@ function try_inline_finalizer!(ir::IRCode, argexprs::Vector{Any}, idx::Int,
 
     # TODO: Use the actual inliner here rather than open coding this special purpose inliner.
     ssa_rename = Vector{Any}(undef, length(src.stmts))
-    for idx′ = 1:length(src.stmts)
-        inst = src[SSAValue(idx′)]
+    for idx′ = eachindex(src)
+        inst = src[idx′]
         stmt′ = inst[:stmt]
         isa(stmt′, ReturnNode) && continue
         stmt′ = ssamap(stmt′) do ssa::SSAValue
             ssa_rename[ssa.id]
         end
         stmt′ = ssa_substitute_op!(InsertBefore(ir, SSAValue(idx)), inst, stmt′, ssa_substitute)
-        ssa_rename[idx′] = insert_node!(ir, idx,
-            NewInstruction(inst; stmt=stmt′, line=(ssa_substitute.inlined_at[1], ssa_substitute.inlined_at[2], Int32(idx′))),
+        ssa_rename[idx′.id] = insert_node!(ir, idx,
+            NewInstruction(inst; stmt=stmt′, line=(ssa_substitute.inlined_at[1], ssa_substitute.inlined_at[2], Int32(idx′.id))),
             attach_after)
     end
 

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1230,7 +1230,8 @@ function sroa_pass!(ir::IRCode, inlining::Union{Nothing,InliningState}=nothing)
                 # by `stmt.args`. Which have :scope set. In practice, the frontend
                 # does emit these in order, so we could simply go to the last one,
                 # but we want to avoid making that semantic assumption.
-                for scope in stmt.args
+                for i in eachindex(stmt.args)
+                    scope = stmt.args[i]
                     scope === nothing && continue
                     enter = compact[scope][:inst]
                     @assert isa(enter, EnterNode)

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -133,6 +133,8 @@ is_nospecializeinfer(method::Method) = method.nospecializeinfer && is_nospeciali
 # MethodInstance/CodeInfo #
 ###########################
 
+MethodInstance() = ccall(:jl_new_method_instance_uninit,Ref{MethodInstance},())
+
 invoke_api(li::CodeInstance) = ccall(:jl_invoke_api, Cint, (Any,), li)
 use_const_api(li::CodeInstance) = invoke_api(li) == 2
 

--- a/base/opaque_closure.jl
+++ b/base/opaque_closure.jl
@@ -43,7 +43,7 @@ using Core: CodeInfo
 
 function compute_ir_rettype(ir::IRCode)
     rt = Union{}
-    for i in eachindex(ir)
+    for i in Core.Compiler.eachindex(ir)
         stmt = ir[i][:stmt]
         if isa(stmt, Core.Compiler.ReturnNode) && isdefined(stmt, :val)
             rt = Core.Compiler.tmerge(Core.Compiler.argextype(stmt.val, ir), rt)

--- a/base/opaque_closure.jl
+++ b/base/opaque_closure.jl
@@ -43,8 +43,8 @@ using Core: CodeInfo
 
 function compute_ir_rettype(ir::IRCode)
     rt = Union{}
-    for i = 1:length(ir.stmts)
-        stmt = ir[SSAValue(i)][:stmt]
+    for i in eachindex(ir)
+        stmt = ir[i][:stmt]
         if isa(stmt, Core.Compiler.ReturnNode) && isdefined(stmt, :val)
             rt = Core.Compiler.tmerge(Core.Compiler.argextype(stmt.val, ir), rt)
         end

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1490,7 +1490,7 @@ let code = Any[
     slottypes = Any[Any, Union{Bool, Nothing}, Bool, Union{Bool, Nothing}]
     src = make_codeinfo(code; slottypes)
 
-    mi = ccall(:jl_new_method_instance_uninit, Ref{Core.MethodInstance}, ());
+    mi = Core.MethodInstance()
     mi.specTypes = Tuple{}
     mi.def = Module()
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -2700,7 +2700,7 @@ end
 @test is_juliarepr(Ptr{Vector{Complex{Float16}}}(UInt(0xdeadbeef)))
 
 # Toplevel MethodInstance with undef :uninferred
-let topmi = ccall(:jl_new_method_instance_uninit, Ref{Core.MethodInstance}, ());
+let topmi = Core.MethodInstance()
     topmi.specTypes = Tuple{}
     topmi.def = Main
     @test contains(repr(topmi), "Toplevel MethodInstance")

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -103,7 +103,7 @@ end
 end
 
 let src = Meta.lower(Main, quote let x = 1 end end).args[1]::Core.CodeInfo
-    li = ccall(:jl_new_method_instance_uninit, Ref{Core.MethodInstance}, ())
+    li = Core.MethodInstance()
     @atomic li.cache = ccall(:jl_new_codeinst_for_uninferred, Ref{Core.CodeInstance}, (Any, Any), li, src)
     li.specTypes = Tuple{}
     li.def = @__MODULE__


### PR DESCRIPTION
- `eachindex(::IRCode)`
- `MethodInstance()` constructor

These should make working with the compiler slightly more accessible by using more conventional syntax for construction and iteration.

I also used these new functions in a few places where they are appropriate.