### PR TITLE
Preserve Git objects from being garbage collected

### DIFF
--- a/stdlib/LibGit2/src/blame.jl
+++ b/stdlib/LibGit2/src/blame.jl
@@ -13,7 +13,7 @@ function GitBlame(repo::GitRepo, path::AbstractString; options::BlameOptions=Bla
     blame_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_blame_file, libgit2), Cint,
                   (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring, Ptr{BlameOptions}),
-                   blame_ptr_ptr, repo.ptr, path, Ref(options))
+                   blame_ptr_ptr, repo, path, Ref(options))
     return GitBlame(repo, blame_ptr_ptr[])
 end
 
@@ -27,7 +27,7 @@ that function later.
 """
 function counthunks(blame::GitBlame)
     ensure_initialized()
-    return ccall((:git_blame_get_hunk_count, libgit2), Int32, (Ptr{Cvoid},), blame.ptr)
+    return ccall((:git_blame_get_hunk_count, libgit2), Int32, (Ptr{Cvoid},), blame)
 end
 
 function Base.getindex(blame::GitBlame, i::Integer)

--- a/stdlib/LibGit2/src/blob.jl
+++ b/stdlib/LibGit2/src/blob.jl
@@ -2,7 +2,7 @@
 
 function Base.length(blob::GitBlob)
     ensure_initialized()
-    return ccall((:git_blob_rawsize, libgit2), Int64, (Ptr{Cvoid},), blob.ptr)
+    return ccall((:git_blob_rawsize, libgit2), Int64, (Ptr{Cvoid},), blob)
 end
 
 """
@@ -20,7 +20,7 @@ is binary and not valid Unicode.
 """
 function rawcontent(blob::GitBlob)
     ensure_initialized()
-    ptr = ccall((:git_blob_rawcontent, libgit2), Ptr{UInt8}, (Ptr{Cvoid},), blob.ptr)
+    ptr = ccall((:git_blob_rawcontent, libgit2), Ptr{UInt8}, (Ptr{Cvoid},), blob)
     copy(unsafe_wrap(Array, ptr, (length(blob),), own = false))
 end
 
@@ -47,7 +47,7 @@ the first 8000 bytes.
 """
 function isbinary(blob::GitBlob)
     ensure_initialized()
-    bin_flag = ccall((:git_blob_is_binary, libgit2), Cint, (Ptr{Cvoid},), blob.ptr)
+    bin_flag = ccall((:git_blob_is_binary, libgit2), Cint, (Ptr{Cvoid},), blob)
     return bin_flag == 1
 end
 
@@ -69,7 +69,7 @@ function addblob!(repo::GitRepo, path::AbstractString)
     id_ref = Ref{GitHash}()
     @check ccall((:git_blob_create_from_disk, libgit2), Cint,
                  (Ptr{GitHash}, Ptr{Cvoid}, Cstring),
-                 id_ref, repo.ptr, path)
+                 id_ref, repo, path)
     return id_ref[]
 end
 

--- a/stdlib/LibGit2/src/commit.jl
+++ b/stdlib/LibGit2/src/commit.jl
@@ -73,16 +73,16 @@ function commit(repo::GitRepo,
     ensure_initialized()
     commit_id_ptr = Ref(GitHash())
     nparents = length(parents)
-    GC.@preserve repo author committer tree parents begin
+    GC.@preserve parents begin
         parentptrs = Ptr{Cvoid}[c.ptr for c in parents]
         @check ccall((:git_commit_create, libgit2), Cint,
                      (Ptr{GitHash}, Ptr{Cvoid}, Ptr{UInt8},
                       Ptr{SignatureStruct}, Ptr{SignatureStruct},
                       Ptr{UInt8}, Ptr{UInt8}, Ptr{Cvoid},
                       Csize_t, Ptr{Ptr{Cvoid}}),
-                     commit_id_ptr, repo.ptr, isempty(refname) ? C_NULL : refname,
-                     author.ptr, committer.ptr,
-                     C_NULL, msg, tree.ptr,
+                     commit_id_ptr, repo, isempty(refname) ? C_NULL : refname,
+                     author, committer,
+                     C_NULL, msg, tree,
                      nparents, nparents > 0 ? parentptrs : C_NULL)
     end
     return commit_id_ptr[]

--- a/stdlib/LibGit2/src/commit.jl
+++ b/stdlib/LibGit2/src/commit.jl
@@ -73,16 +73,18 @@ function commit(repo::GitRepo,
     ensure_initialized()
     commit_id_ptr = Ref(GitHash())
     nparents = length(parents)
-    parentptrs = Ptr{Cvoid}[c.ptr for c in parents]
-    @check ccall((:git_commit_create, libgit2), Cint,
-                 (Ptr{GitHash}, Ptr{Cvoid}, Ptr{UInt8},
-                  Ptr{SignatureStruct}, Ptr{SignatureStruct},
-                  Ptr{UInt8}, Ptr{UInt8}, Ptr{Cvoid},
-                  Csize_t, Ptr{Ptr{Cvoid}}),
-                 commit_id_ptr, repo.ptr, isempty(refname) ? C_NULL : refname,
-                 author.ptr, committer.ptr,
-                 C_NULL, msg, tree.ptr,
-                 nparents, nparents > 0 ? parentptrs : C_NULL)
+    GC.@preserve repo author committer tree parents begin
+        parentptrs = Ptr{Cvoid}[c.ptr for c in parents]
+        @check ccall((:git_commit_create, libgit2), Cint,
+                     (Ptr{GitHash}, Ptr{Cvoid}, Ptr{UInt8},
+                      Ptr{SignatureStruct}, Ptr{SignatureStruct},
+                      Ptr{UInt8}, Ptr{UInt8}, Ptr{Cvoid},
+                      Csize_t, Ptr{Ptr{Cvoid}}),
+                     commit_id_ptr, repo.ptr, isempty(refname) ? C_NULL : refname,
+                     author.ptr, committer.ptr,
+                     C_NULL, msg, tree.ptr,
+                     nparents, nparents > 0 ? parentptrs : C_NULL)
+    end
     return commit_id_ptr[]
 end
 

--- a/stdlib/LibGit2/src/config.jl
+++ b/stdlib/LibGit2/src/config.jl
@@ -89,18 +89,15 @@ function addfile(cfg::GitConfig, path::AbstractString,
                  repo::Union{GitRepo, Nothing} = nothing,
                  force::Bool=false)
     ensure_initialized()
-    GC.@preserve cfg repo begin
-        # FIXME Check first argument, cfg.ptr, in the ccall's below.
-        @static if LibGit2.VERSION >= v"0.27.0"
-            @check ccall((:git_config_add_file_ondisk, libgit2), Cint,
-                         (Ptr{Ptr{Cvoid}}, Cstring, Cint, Ptr{Cvoid}, Cint),
-                         cfg.ptr, path, Cint(level), isa(repo, GitRepo) ? repo.ptr : C_NULL, Cint(force))
-        else
-            repo === nothing || error("repo argument is not supported in this version of LibGit2")
-            @check ccall((:git_config_add_file_ondisk, libgit2), Cint,
-                         (Ptr{Ptr{Cvoid}}, Cstring, Cint, Cint),
-                         cfg.ptr, path, Cint(level), Cint(force))
-        end
+    @static if LibGit2.VERSION >= v"0.27.0"
+        @check ccall((:git_config_add_file_ondisk, libgit2), Cint,
+                     (Ptr{Cvoid}, Cstring, Cint, Ptr{Cvoid}, Cint),
+                     cfg, path, Cint(level), isa(repo, GitRepo) ? repo : C_NULL, Cint(force))
+    else
+        repo === nothing || error("repo argument is not supported in this version of LibGit2")
+        @check ccall((:git_config_add_file_ondisk, libgit2), Cint,
+                     (Ptr{Cvoid}, Cstring, Cint, Cint),
+                     cfg, path, Cint(level), Cint(force))
     end
 end
 

--- a/stdlib/LibGit2/src/config.jl
+++ b/stdlib/LibGit2/src/config.jl
@@ -35,7 +35,7 @@ function GitConfig(repo::GitRepo)
     ensure_initialized()
     cfg_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_repository_config, libgit2), Cint,
-                  (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}), cfg_ptr_ptr, repo.ptr)
+                  (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}), cfg_ptr_ptr, repo)
     return GitConfig(repo, cfg_ptr_ptr[])
 end
 
@@ -58,7 +58,7 @@ function GitConfig(level::Consts.GIT_CONFIG = Consts.CONFIG_LEVEL_DEFAULT)
         try
             @check ccall((:git_config_open_level, libgit2), Cint,
                          (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cint),
-                          glb_cfg_ptr_ptr, cfg.ptr, Cint(level))
+                          glb_cfg_ptr_ptr, cfg, Cint(level))
             cfg = GitConfig(glb_cfg_ptr_ptr[])
         finally
             close(tmpcfg)
@@ -89,15 +89,18 @@ function addfile(cfg::GitConfig, path::AbstractString,
                  repo::Union{GitRepo, Nothing} = nothing,
                  force::Bool=false)
     ensure_initialized()
-    @static if LibGit2.VERSION >= v"0.27.0"
-        @check ccall((:git_config_add_file_ondisk, libgit2), Cint,
-                     (Ptr{Ptr{Cvoid}}, Cstring, Cint, Ptr{Cvoid}, Cint),
-                     cfg.ptr, path, Cint(level), isa(repo, GitRepo) ? repo.ptr : C_NULL, Cint(force))
-    else
-        repo === nothing || error("repo argument is not supported in this version of LibGit2")
-        @check ccall((:git_config_add_file_ondisk, libgit2), Cint,
-                     (Ptr{Ptr{Cvoid}}, Cstring, Cint, Cint),
-                     cfg.ptr, path, Cint(level), Cint(force))
+    GC.@preserve cfg repo begin
+        # FIXME Check first argument, cfg.ptr, in the ccall's below.
+        @static if LibGit2.VERSION >= v"0.27.0"
+            @check ccall((:git_config_add_file_ondisk, libgit2), Cint,
+                         (Ptr{Ptr{Cvoid}}, Cstring, Cint, Ptr{Cvoid}, Cint),
+                         cfg.ptr, path, Cint(level), isa(repo, GitRepo) ? repo.ptr : C_NULL, Cint(force))
+        else
+            repo === nothing || error("repo argument is not supported in this version of LibGit2")
+            @check ccall((:git_config_add_file_ondisk, libgit2), Cint,
+                         (Ptr{Ptr{Cvoid}}, Cstring, Cint, Cint),
+                         cfg.ptr, path, Cint(level), Cint(force))
+        end
     end
 end
 
@@ -105,7 +108,7 @@ function get(::Type{<:AbstractString}, c::GitConfig, name::AbstractString)
     ensure_initialized()
     buf_ref = Ref(Buffer())
     @check ccall((:git_config_get_string_buf, libgit2), Cint,
-                 (Ptr{Buffer}, Ptr{Cvoid}, Cstring), buf_ref, c.ptr, name)
+                 (Ptr{Buffer}, Ptr{Cvoid}, Cstring), buf_ref, c, name)
     buf = buf_ref[]
     str = unsafe_string(buf.ptr, buf.size)
     free(buf_ref)
@@ -116,7 +119,7 @@ function get(::Type{Bool}, c::GitConfig, name::AbstractString)
     ensure_initialized()
     val_ptr = Ref(Cint(0))
     @check ccall((:git_config_get_bool, libgit2), Cint,
-          (Ptr{Cint}, Ptr{Cvoid}, Cstring), val_ptr, c.ptr, name)
+          (Ptr{Cint}, Ptr{Cvoid}, Cstring), val_ptr, c, name)
     return Bool(val_ptr[])
 end
 
@@ -124,7 +127,7 @@ function get(::Type{Int32}, c::GitConfig, name::AbstractString)
     ensure_initialized()
     val_ptr = Ref(Cint(0))
     @check ccall((:git_config_get_int32, libgit2), Cint,
-          (Ptr{Cint}, Ptr{Cvoid}, Cstring), val_ptr, c.ptr, name)
+          (Ptr{Cint}, Ptr{Cvoid}, Cstring), val_ptr, c, name)
     return val_ptr[]
 end
 
@@ -132,7 +135,7 @@ function get(::Type{Int64}, c::GitConfig, name::AbstractString)
     ensure_initialized()
     val_ptr = Ref(Cintmax_t(0))
     @check ccall((:git_config_get_int64, libgit2), Cint,
-          (Ptr{Cintmax_t}, Ptr{Cvoid}, Cstring), val_ptr, c.ptr, name)
+          (Ptr{Cintmax_t}, Ptr{Cvoid}, Cstring), val_ptr, c, name)
     return val_ptr[]
 end
 
@@ -165,33 +168,33 @@ end
 function set!(c::GitConfig, name::AbstractString, value::AbstractString)
     ensure_initialized()
     @check ccall((:git_config_set_string, libgit2), Cint,
-                  (Ptr{Cvoid}, Cstring, Cstring), c.ptr, name, value)
+                  (Ptr{Cvoid}, Cstring, Cstring), c, name, value)
 end
 
 function set!(c::GitConfig, name::AbstractString, value::Bool)
     ensure_initialized()
     bval = Int32(value)
     @check ccall((:git_config_set_bool, libgit2), Cint,
-                  (Ptr{Cvoid}, Cstring, Cint), c.ptr, name, bval)
+                  (Ptr{Cvoid}, Cstring, Cint), c, name, bval)
 end
 
 function set!(c::GitConfig, name::AbstractString, value::Int32)
     ensure_initialized()
     @check ccall((:git_config_set_int32, libgit2), Cint,
-                  (Ptr{Cvoid}, Cstring, Cint), c.ptr, name, value)
+                  (Ptr{Cvoid}, Cstring, Cint), c, name, value)
 end
 
 function set!(c::GitConfig, name::AbstractString, value::Int64)
     ensure_initialized()
     @check ccall((:git_config_set_int64, libgit2), Cint,
-                  (Ptr{Cvoid}, Cstring, Cintmax_t), c.ptr, name, value)
+                  (Ptr{Cvoid}, Cstring, Cintmax_t), c, name, value)
 end
 
 function GitConfigIter(cfg::GitConfig)
     ensure_initialized()
     ci_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_config_iterator_new, libgit2), Cint,
-                  (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}), ci_ptr, cfg.ptr)
+                  (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}), ci_ptr, cfg)
     return GitConfigIter(ci_ptr[])
 end
 
@@ -200,7 +203,7 @@ function GitConfigIter(cfg::GitConfig, name::AbstractString)
     ci_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_config_multivar_iterator_new, libgit2), Cint,
                   (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring, Cstring),
-                  ci_ptr, cfg.ptr, name, C_NULL)
+                  ci_ptr, cfg, name, C_NULL)
     return GitConfigIter(ci_ptr[])
 end
 
@@ -209,7 +212,7 @@ function GitConfigIter(cfg::GitConfig, name::AbstractString, value::Regex)
     ci_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_config_multivar_iterator_new, libgit2), Cint,
                   (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring, Cstring),
-                  ci_ptr, cfg.ptr, name, value.pattern)
+                  ci_ptr, cfg, name, value.pattern)
     return GitConfigIter(ci_ptr[])
 end
 
@@ -218,7 +221,7 @@ function GitConfigIter(cfg::GitConfig, name::Regex)
     ci_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_config_iterator_glob_new, libgit2), Cint,
                   (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring),
-                  ci_ptr, cfg.ptr, name.pattern)
+                  ci_ptr, cfg, name.pattern)
     return GitConfigIter(ci_ptr[])
 end
 
@@ -226,7 +229,7 @@ function Base.iterate(ci::GitConfigIter, state=nothing)
     ensure_initialized()
     entry_ptr_ptr = Ref{Ptr{ConfigEntry}}(C_NULL)
     err = ccall((:git_config_next, libgit2), Cint,
-                 (Ptr{Ptr{ConfigEntry}}, Ptr{Cvoid}), entry_ptr_ptr, ci.ptr)
+                 (Ptr{Ptr{ConfigEntry}}, Ptr{Cvoid}), entry_ptr_ptr, ci)
     if err == Cint(Error.GIT_OK)
         return (unsafe_load(entry_ptr_ptr[]), nothing)
     elseif err == Cint(Error.ITEROVER)

--- a/stdlib/LibGit2/src/diff.jl
+++ b/stdlib/LibGit2/src/diff.jl
@@ -122,10 +122,10 @@ function Base.getindex(diff::GitDiff, i::Integer)
         throw(BoundsError(diff, (i,)))
     end
     ensure_initialized()
-    GC.@preserve diff begin
+    GC.@preserve diff begin # preserve `diff` object until return of `unsafe_load`
         delta_ptr = ccall((:git_diff_get_delta, libgit2),
                           Ptr{DiffDelta},
-                          (Ptr{Cvoid}, Csize_t), diff.ptr, i-1)
+                          (Ptr{Cvoid}, Csize_t), diff, i-1)
         return unsafe_load(delta_ptr)
     end
 end

--- a/stdlib/LibGit2/src/diff.jl
+++ b/stdlib/LibGit2/src/diff.jl
@@ -29,11 +29,11 @@ function diff_tree(repo::GitRepo, tree::GitTree, pathspecs::AbstractString=""; c
     if cached
         @check ccall((:git_diff_tree_to_index, libgit2), Cint,
                      (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{DiffOptionsStruct}),
-                     diff_ptr_ptr, repo.ptr, tree.ptr, C_NULL, isempty(pathspecs) ? C_NULL : pathspecs)
+                     diff_ptr_ptr, repo, tree, C_NULL, isempty(pathspecs) ? C_NULL : pathspecs)
     else
         @check ccall((:git_diff_tree_to_workdir_with_index, libgit2), Cint,
                      (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{DiffOptionsStruct}),
-                     diff_ptr_ptr, repo.ptr, tree.ptr, isempty(pathspecs) ? C_NULL : pathspecs)
+                     diff_ptr_ptr, repo, tree, isempty(pathspecs) ? C_NULL : pathspecs)
     end
     return GitDiff(repo, diff_ptr_ptr[])
 end
@@ -53,7 +53,7 @@ function diff_tree(repo::GitRepo, oldtree::GitTree, newtree::GitTree)
     diff_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_diff_tree_to_tree, libgit2), Cint,
                   (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{DiffOptionsStruct}),
-                   diff_ptr_ptr, repo.ptr, oldtree.ptr, newtree.ptr, C_NULL)
+                   diff_ptr_ptr, repo, oldtree, newtree, C_NULL)
     return GitDiff(repo, diff_ptr_ptr[])
 end
 
@@ -69,7 +69,7 @@ function GitDiffStats(diff::GitDiff)
     diff_stat_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_diff_get_stats, libgit2), Cint,
                   (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}),
-                  diff_stat_ptr_ptr, diff.ptr)
+                  diff_stat_ptr_ptr, diff)
     return GitDiffStats(diff.owner, diff_stat_ptr_ptr[])
 end
 
@@ -83,7 +83,7 @@ are to be included or not).
 """
 function files_changed(diff_stat::GitDiffStats)
     ensure_initialized()
-    return ccall((:git_diff_stats_files_changed, libgit2), Csize_t, (Ptr{Cvoid},), diff_stat.ptr)
+    return ccall((:git_diff_stats_files_changed, libgit2), Csize_t, (Ptr{Cvoid},), diff_stat)
 end
 
 """
@@ -96,7 +96,7 @@ are to be included or not).
 """
 function insertions(diff_stat::GitDiffStats)
     ensure_initialized()
-    return ccall((:git_diff_stats_insertions, libgit2), Csize_t, (Ptr{Cvoid},), diff_stat.ptr)
+    return ccall((:git_diff_stats_insertions, libgit2), Csize_t, (Ptr{Cvoid},), diff_stat)
 end
 
 """
@@ -109,12 +109,12 @@ are to be included or not).
 """
 function deletions(diff_stat::GitDiffStats)
     ensure_initialized()
-    return ccall((:git_diff_stats_deletions, libgit2), Csize_t, (Ptr{Cvoid},), diff_stat.ptr)
+    return ccall((:git_diff_stats_deletions, libgit2), Csize_t, (Ptr{Cvoid},), diff_stat)
 end
 
 function count(diff::GitDiff)
     ensure_initialized()
-    return ccall((:git_diff_num_deltas, libgit2), Cint, (Ptr{Cvoid},), diff.ptr)
+    return ccall((:git_diff_num_deltas, libgit2), Cint, (Ptr{Cvoid},), diff)
 end
 
 function Base.getindex(diff::GitDiff, i::Integer)
@@ -122,10 +122,12 @@ function Base.getindex(diff::GitDiff, i::Integer)
         throw(BoundsError(diff, (i,)))
     end
     ensure_initialized()
-    delta_ptr = ccall((:git_diff_get_delta, libgit2),
-                      Ptr{DiffDelta},
-                      (Ptr{Cvoid}, Csize_t), diff.ptr, i-1)
-    return unsafe_load(delta_ptr)
+    GC.@preserve diff begin
+        delta_ptr = ccall((:git_diff_get_delta, libgit2),
+                          Ptr{DiffDelta},
+                          (Ptr{Cvoid}, Csize_t), diff.ptr, i-1)
+        return unsafe_load(delta_ptr)
+    end
 end
 
 function Base.show(io::IO, diff_stat::GitDiffStats)

--- a/stdlib/LibGit2/src/index.jl
+++ b/stdlib/LibGit2/src/index.jl
@@ -9,7 +9,7 @@ function GitIndex(repo::GitRepo)
     ensure_initialized()
     idx_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_repository_index, libgit2), Cint,
-                 (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}), idx_ptr_ptr, repo.ptr)
+                 (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}), idx_ptr_ptr, repo)
     return GitIndex(repo, idx_ptr_ptr[])
 end
 
@@ -25,7 +25,7 @@ has changed since the last time it was loaded into `idx`.
 """
 function read!(idx::GitIndex, force::Bool = false)
     ensure_initialized()
-    @check ccall((:git_index_read, libgit2), Cint, (Ptr{Cvoid}, Cint), idx.ptr, Cint(force))
+    @check ccall((:git_index_read, libgit2), Cint, (Ptr{Cvoid}, Cint), idx, Cint(force))
     return idx
 end
 
@@ -36,7 +36,7 @@ Write the state of index `idx` to disk using a file lock.
 """
 function write!(idx::GitIndex)
     ensure_initialized()
-    @check ccall((:git_index_write, libgit2), Cint, (Ptr{Cvoid},), idx.ptr)
+    @check ccall((:git_index_write, libgit2), Cint, (Ptr{Cvoid},), idx)
     return idx
 end
 
@@ -52,7 +52,7 @@ function write_tree!(idx::GitIndex)
     ensure_initialized()
     oid_ptr = Ref(GitHash())
     @check ccall((:git_index_write_tree, libgit2), Cint,
-                 (Ptr{GitHash}, Ptr{Cvoid}), oid_ptr, idx.ptr)
+                 (Ptr{GitHash}, Ptr{Cvoid}), oid_ptr, idx)
     return oid_ptr[]
 end
 
@@ -74,7 +74,7 @@ Read the tree `tree` (or the tree pointed to by `treehash` in the repository own
 function read_tree!(idx::GitIndex, tree::GitTree)
     ensure_initialized()
     @check ccall((:git_index_read_tree, libgit2), Cint,
-                 (Ptr{Cvoid}, Ptr{Cvoid}), idx.ptr, tree.ptr)
+                 (Ptr{Cvoid}, Ptr{Cvoid}), idx, tree)
 end
 read_tree!(idx::GitIndex, hash::AbstractGitHash) =
     read_tree!(idx, GitTree(repository(idx), hash))
@@ -106,7 +106,7 @@ function add!(idx::GitIndex, files::AbstractString...;
     ensure_initialized()
     @check ccall((:git_index_add_all, libgit2), Cint,
                  (Ptr{Cvoid}, Ptr{StrArrayStruct}, Cuint, Ptr{Cvoid}, Ptr{Cvoid}),
-                 idx.ptr, collect(files), flags, C_NULL, C_NULL)
+                 idx, collect(files), flags, C_NULL, C_NULL)
 end
 
 """
@@ -122,7 +122,7 @@ function update!(idx::GitIndex, files::AbstractString...)
     ensure_initialized()
     @check ccall((:git_index_update_all, libgit2), Cint,
                  (Ptr{Cvoid}, Ptr{StrArrayStruct}, Ptr{Cvoid}, Ptr{Cvoid}),
-                 idx.ptr, collect(files), C_NULL, C_NULL)
+                 idx, collect(files), C_NULL, C_NULL)
 end
 
 """
@@ -136,7 +136,7 @@ function remove!(idx::GitIndex, files::AbstractString...)
     ensure_initialized()
     @check ccall((:git_index_remove_all, libgit2), Cint,
                  (Ptr{Cvoid}, Ptr{StrArrayStruct}, Ptr{Cvoid}, Ptr{Cvoid}),
-                 idx.ptr, collect(files), C_NULL, C_NULL)
+                 idx, collect(files), C_NULL, C_NULL)
 end
 
 function add!(repo::GitRepo, files::AbstractString...;
@@ -173,7 +173,7 @@ end
 
 function count(idx::GitIndex)
     ensure_initialized()
-    return ccall((:git_index_entrycount, libgit2), Csize_t, (Ptr{Cvoid},), idx.ptr)
+    return ccall((:git_index_entrycount, libgit2), Csize_t, (Ptr{Cvoid},), idx)
 end
 
 function Base.getindex(idx::GitIndex, i::Integer)
@@ -192,7 +192,7 @@ function Base.findall(path::String, idx::GitIndex)
     ensure_initialized()
     pos_ref = Ref{Csize_t}(0)
     ret = ccall((:git_index_find, libgit2), Cint,
-                  (Ref{Csize_t}, Ptr{Cvoid}, Cstring), pos_ref, idx.ptr, path)
+                  (Ref{Csize_t}, Ptr{Cvoid}, Cstring), pos_ref, idx, path)
     ret == Cint(Error.ENOTFOUND) && return nothing
     return pos_ref[]+1
 end

--- a/stdlib/LibGit2/src/oid.jl
+++ b/stdlib/LibGit2/src/oid.jl
@@ -133,7 +133,7 @@ function GitHash(repo::GitRepo, ref_name::AbstractString)
     oid_ptr  = Ref(GitHash())
     @check ccall((:git_reference_name_to_id, libgit2), Cint,
                     (Ptr{GitHash}, Ptr{Cvoid}, Cstring),
-                     oid_ptr, repo.ptr, ref_name)
+                     oid_ptr, repo, ref_name)
     return oid_ptr[]
 end
 
@@ -144,7 +144,7 @@ Get the identifier (`GitHash`) of `obj`.
 """
 function GitHash(obj::GitObject)
     ensure_initialized()
-    GitHash(ccall((:git_object_id, libgit2), Ptr{UInt8}, (Ptr{Cvoid},), obj.ptr))
+    GitHash(ccall((:git_object_id, libgit2), Ptr{UInt8}, (Ptr{Cvoid},), obj))
 end
 
 ==(obj1::GitObject, obj2::GitObject) = GitHash(obj1) == GitHash(obj2)
@@ -160,7 +160,7 @@ function GitShortHash(obj::GitObject)
     ensure_initialized()
     buf_ref = Ref(Buffer())
     @check ccall((:git_object_short_id, libgit2), Cint,
-                 (Ptr{Buffer},Ptr{Cvoid}), buf_ref, obj.ptr)
+                 (Ptr{Buffer},Ptr{Cvoid}), buf_ref, obj)
     sid = GitShortHash(buf_ref[])
     free(buf_ref)
     return sid

--- a/stdlib/LibGit2/src/reference.jl
+++ b/stdlib/LibGit2/src/reference.jl
@@ -5,7 +5,7 @@ function GitReference(repo::GitRepo, refname::AbstractString)
     ref_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_reference_lookup, libgit2), Cint,
                   (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring),
-                   ref_ptr_ptr, repo.ptr, refname)
+                   ref_ptr_ptr, repo, refname)
     return GitReference(repo, ref_ptr_ptr[])
 end
 
@@ -15,7 +15,7 @@ function GitReference(repo::GitRepo, obj_oid::GitHash, refname::AbstractString =
     ref_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_reference_create, libgit2), Cint,
                   (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{UInt8}, Ptr{GitHash}, Cint, Cstring),
-                   ref_ptr_ptr, repo.ptr, refname, Ref(obj_oid), Cint(force),
+                   ref_ptr_ptr, repo, refname, Ref(obj_oid), Cint(force),
                    isempty(msg) ? C_NULL : msg)
     return GitReference(repo, ref_ptr_ptr[])
 end
@@ -29,7 +29,7 @@ to this branch will have no parents.
 function isorphan(repo::GitRepo)
     ensure_initialized()
     r = @check ccall((:git_repository_head_unborn, libgit2), Cint,
-                     (Ptr{Cvoid},), repo.ptr)
+                     (Ptr{Cvoid},), repo)
     r != 0
 end
 
@@ -42,7 +42,7 @@ function head(repo::GitRepo)
     ensure_initialized()
     head_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_repository_head, libgit2), Cint,
-                  (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}), head_ptr_ptr, repo.ptr)
+                  (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}), head_ptr_ptr, repo)
     return GitReference(repo, head_ptr_ptr[])
 end
 
@@ -68,7 +68,7 @@ function shortname(ref::GitReference)
     isempty(ref) && return ""
     ensure_initialized()
     GC.@preserve ref begin
-        name_ptr = ccall((:git_reference_shorthand, libgit2), Cstring, (Ptr{Cvoid},), ref.ptr)
+        name_ptr = ccall((:git_reference_shorthand, libgit2), Cstring, (Ptr{Cvoid},), ref)
         name_ptr == C_NULL && return ""
         name = unsafe_string(name_ptr)
     end
@@ -85,7 +85,7 @@ Return a `Cint` corresponding to the type of `ref`:
 """
 function reftype(ref::GitReference)
     ensure_initialized()
-    return ccall((:git_reference_type, libgit2), Cint, (Ptr{Cvoid},), ref.ptr)
+    return ccall((:git_reference_type, libgit2), Cint, (Ptr{Cvoid},), ref)
 end
 
 """
@@ -139,7 +139,7 @@ function ishead(ref::GitReference)
     isempty(ref) && return false
     ensure_initialized()
     err = ccall((:git_branch_is_head, libgit2), Cint,
-                  (Ptr{Cvoid},), ref.ptr)
+                  (Ptr{Cvoid},), ref)
     return err == 1
 end
 
@@ -147,7 +147,7 @@ function isbranch(ref::GitReference)
     isempty(ref) && return false
     ensure_initialized()
     err = ccall((:git_reference_is_branch, libgit2), Cint,
-                  (Ptr{Cvoid},), ref.ptr)
+                  (Ptr{Cvoid},), ref)
     return err == 1
 end
 
@@ -155,7 +155,7 @@ function istag(ref::GitReference)
     isempty(ref) && return false
     ensure_initialized()
     err = ccall((:git_reference_is_tag, libgit2), Cint,
-                  (Ptr{Cvoid},), ref.ptr)
+                  (Ptr{Cvoid},), ref)
     return err == 1
 end
 
@@ -163,7 +163,7 @@ function isremote(ref::GitReference)
     isempty(ref) && return false
     ensure_initialized()
     err = ccall((:git_reference_is_remote, libgit2), Cint,
-                  (Ptr{Cvoid},), ref.ptr)
+                  (Ptr{Cvoid},), ref)
     return err == 1
 end
 
@@ -200,7 +200,7 @@ function peel(::Type{T}, ref::GitReference) where T<:GitObject
     ensure_initialized()
     obj_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_reference_peel, libgit2), Cint,
-                 (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cint), obj_ptr_ptr, ref.ptr, Consts.OBJECT(T))
+                 (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cint), obj_ptr_ptr, ref, Consts.OBJECT(T))
     return T(ref.owner, obj_ptr_ptr[])
 end
 peel(ref::GitReference) = peel(GitObject, ref)
@@ -214,7 +214,7 @@ function ref_list(repo::GitRepo)
     ensure_initialized()
     sa_ref = Ref(StrArrayStruct())
     @check ccall((:git_reference_list, libgit2), Cint,
-                      (Ptr{StrArrayStruct}, Ptr{Cvoid}), sa_ref, repo.ptr)
+                      (Ptr{StrArrayStruct}, Ptr{Cvoid}), sa_ref, repo)
     res = convert(Vector{String}, sa_ref[])
     free(sa_ref)
     res
@@ -237,7 +237,7 @@ function create_branch(repo::GitRepo,
     ref_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_branch_create, libgit2), Cint,
                   (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring, Ptr{Cvoid}, Cint),
-                   ref_ptr_ptr, repo.ptr, bname, commit_obj.ptr, Cint(force))
+                   ref_ptr_ptr, repo, bname, commit_obj, Cint(force))
     return GitReference(repo, ref_ptr_ptr[])
 end
 
@@ -248,7 +248,7 @@ Delete the branch pointed to by `branch`.
 """
 function delete_branch(branch::GitReference)
     ensure_initialized()
-    @check ccall((:git_branch_delete, libgit2), Cint, (Ptr{Cvoid},), branch.ptr)
+    @check ccall((:git_branch_delete, libgit2), Cint, (Ptr{Cvoid},), branch)
 end
 
 """
@@ -260,7 +260,7 @@ function head!(repo::GitRepo, ref::GitReference)
     ensure_initialized()
     ref_name = name(ref)
     @check ccall((:git_repository_set_head, libgit2), Cint,
-                  (Ptr{Cvoid}, Cstring), repo.ptr, ref_name)
+                  (Ptr{Cvoid}, Cstring), repo, ref_name)
     return ref
 end
 
@@ -282,7 +282,7 @@ function lookup_branch(repo::GitRepo,
     branch_type = remote ? Consts.BRANCH_REMOTE : Consts.BRANCH_LOCAL
     err = ccall((:git_branch_lookup, libgit2), Cint,
                  (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{UInt8}, Cint),
-                  ref_ptr_ptr, repo.ptr, branch_name, branch_type)
+                  ref_ptr_ptr, repo, branch_name, branch_type)
     if err != Int(Error.GIT_OK)
         if err == Int(Error.ENOTFOUND)
             return nothing
@@ -308,7 +308,7 @@ function upstream(ref::GitReference)
     ensure_initialized()
     ref_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     err = ccall((:git_branch_upstream, libgit2), Cint,
-                  (Ref{Ptr{Cvoid}}, Ptr{Cvoid},), ref_ptr_ptr, ref.ptr)
+                  (Ref{Ptr{Cvoid}}, Ptr{Cvoid},), ref_ptr_ptr, ref)
     if err != Int(Error.GIT_OK)
         if err == Int(Error.ENOTFOUND)
             return nothing
@@ -328,7 +328,7 @@ function target!(ref::GitReference, new_oid::GitHash; msg::AbstractString="")
     ref_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_reference_set_target, libgit2), Cint,
              (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{GitHash}, Cstring),
-             ref_ptr_ptr, ref.ptr, Ref(new_oid), isempty(msg) ? C_NULL : msg)
+             ref_ptr_ptr, ref, Ref(new_oid), isempty(msg) ? C_NULL : msg)
     return GitReference(ref.owner, ref_ptr_ptr[])
 end
 
@@ -336,7 +336,7 @@ function GitBranchIter(repo::GitRepo, flags::Cint=Cint(Consts.BRANCH_LOCAL))
     ensure_initialized()
     bi_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_branch_iterator_new, libgit2), Cint,
-                  (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cint), bi_ptr, repo.ptr, flags)
+                  (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cint), bi_ptr, repo, flags)
     return GitBranchIter(repo, bi_ptr[])
 end
 
@@ -346,7 +346,7 @@ function Base.iterate(bi::GitBranchIter, state=nothing)
     btype = Ref{Cint}()
     err = ccall((:git_branch_next, libgit2), Cint,
                  (Ptr{Ptr{Cvoid}}, Ptr{Cint}, Ptr{Cvoid}),
-                  ref_ptr_ptr, btype, bi.ptr)
+                  ref_ptr_ptr, btype, bi)
     if err == Cint(Error.GIT_OK)
         return ((GitReference(bi.owner, ref_ptr_ptr[]), btype[]), nothing)
     elseif err == Cint(Error.ITEROVER)

--- a/stdlib/LibGit2/src/remote.jl
+++ b/stdlib/LibGit2/src/remote.jl
@@ -16,7 +16,7 @@ function GitRemote(repo::GitRepo, rmt_name::AbstractString, rmt_url::AbstractStr
     rmt_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_remote_create, libgit2), Cint,
                 (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring, Cstring),
-                rmt_ptr_ptr, repo.ptr, rmt_name, rmt_url)
+                rmt_ptr_ptr, repo, rmt_name, rmt_url)
     return GitRemote(repo, rmt_ptr_ptr[])
 end
 
@@ -39,7 +39,7 @@ function GitRemote(repo::GitRepo, rmt_name::AbstractString, rmt_url::AbstractStr
     rmt_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_remote_create_with_fetchspec, libgit2), Cint,
                 (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring, Cstring, Cstring),
-                rmt_ptr_ptr, repo.ptr, rmt_name, rmt_url, fetch_spec)
+                rmt_ptr_ptr, repo, rmt_name, rmt_url, fetch_spec)
     return GitRemote(repo, rmt_ptr_ptr[])
 end
 
@@ -59,7 +59,7 @@ function GitRemoteAnon(repo::GitRepo, url::AbstractString)
     rmt_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_remote_create_anonymous, libgit2), Cint,
                 (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring),
-                rmt_ptr_ptr, repo.ptr, url)
+                rmt_ptr_ptr, repo, url)
     return GitRemote(repo, rmt_ptr_ptr[])
 end
 
@@ -95,7 +95,7 @@ function lookup_remote(repo::GitRepo, remote_name::AbstractString)
     rmt_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     err = ccall((:git_remote_lookup, libgit2), Cint,
                 (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring),
-                rmt_ptr_ptr, repo.ptr, remote_name)
+                rmt_ptr_ptr, repo, remote_name)
     if err == Int(Error.GIT_OK)
         return GitRemote(repo, rmt_ptr_ptr[])
     elseif err == Int(Error.ENOTFOUND)
@@ -110,7 +110,7 @@ function get(::Type{GitRemote}, repo::GitRepo, rmt_name::AbstractString)
     rmt_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_remote_lookup, libgit2), Cint,
                 (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring),
-                rmt_ptr_ptr, repo.ptr, rmt_name)
+                rmt_ptr_ptr, repo, rmt_name)
     return GitRemote(repo, rmt_ptr_ptr[])
 end
 
@@ -133,9 +133,11 @@ julia> LibGit2.url(remote)
 """
 function url(rmt::GitRemote)
     ensure_initialized()
-    url_ptr = ccall((:git_remote_url, libgit2), Cstring, (Ptr{Cvoid},), rmt.ptr)
-    url_ptr == C_NULL && return ""
-    return unsafe_string(url_ptr)
+    GC.@preserve rmt begin
+        url_ptr = ccall((:git_remote_url, libgit2), Cstring, (Ptr{Cvoid},), rmt.ptr)
+        url_ptr == C_NULL && return ""
+        return unsafe_string(url_ptr)
+    end
 end
 
 """
@@ -157,9 +159,11 @@ julia> LibGit2.push_url(LibGit2.get(LibGit2.GitRemote, repo, "origin"))
 """
 function push_url(rmt::GitRemote)
     ensure_initialized()
-    url_ptr = ccall((:git_remote_pushurl, libgit2), Cstring, (Ptr{Cvoid},), rmt.ptr)
-    url_ptr == C_NULL && return ""
-    return unsafe_string(url_ptr)
+    GC.@preserve rmt begin
+        url_ptr = ccall((:git_remote_pushurl, libgit2), Cstring, (Ptr{Cvoid},), rmt.ptr)
+        url_ptr == C_NULL && return ""
+        return unsafe_string(url_ptr)
+    end
 end
 
 """
@@ -183,9 +187,11 @@ julia> name(remote)
 """
 function name(rmt::GitRemote)
     ensure_initialized()
-    name_ptr = ccall((:git_remote_name, libgit2), Cstring, (Ptr{Cvoid},), rmt.ptr)
-    name_ptr == C_NULL && return ""
-    return unsafe_string(name_ptr)
+    GC.@preserve rmt begin
+        name_ptr = ccall((:git_remote_name, libgit2), Cstring, (Ptr{Cvoid},), rmt.ptr)
+        name_ptr == C_NULL && return ""
+        return unsafe_string(name_ptr)
+    end
 end
 
 """
@@ -208,7 +214,7 @@ function fetch_refspecs(rmt::GitRemote)
     ensure_initialized()
     sa_ref = Ref(StrArrayStruct())
     @check ccall((:git_remote_get_fetch_refspecs, libgit2), Cint,
-                 (Ptr{StrArrayStruct}, Ptr{Cvoid}), sa_ref, rmt.ptr)
+                 (Ptr{StrArrayStruct}, Ptr{Cvoid}), sa_ref, rmt)
     res = convert(Vector{String}, sa_ref[])
     free(sa_ref)
     res
@@ -238,7 +244,7 @@ function push_refspecs(rmt::GitRemote)
     ensure_initialized()
     sa_ref = Ref(StrArrayStruct())
     @check ccall((:git_remote_get_push_refspecs, libgit2), Cint,
-                 (Ptr{StrArrayStruct}, Ptr{Cvoid}), sa_ref, rmt.ptr)
+                 (Ptr{StrArrayStruct}, Ptr{Cvoid}), sa_ref, rmt)
     res = convert(Vector{String}, sa_ref[])
     free(sa_ref)
     res
@@ -261,7 +267,7 @@ String["+refs/heads/*:refs/remotes/upstream/*"]
 function add_fetch!(repo::GitRepo, rmt::GitRemote, fetch_spec::String)
     ensure_initialized()
     @check ccall((:git_remote_add_fetch, libgit2), Cint,
-                 (Ptr{Cvoid}, Cstring, Cstring), repo.ptr,
+                 (Ptr{Cvoid}, Cstring, Cstring), repo,
                  name(rmt), fetch_spec)
 end
 
@@ -290,7 +296,7 @@ String["refs/heads/master"]
 function add_push!(repo::GitRepo, rmt::GitRemote, push_spec::String)
     ensure_initialized()
     @check ccall((:git_remote_add_push, libgit2), Cint,
-                 (Ptr{Cvoid}, Cstring, Cstring), repo.ptr,
+                 (Ptr{Cvoid}, Cstring, Cstring), repo,
                  name(rmt), push_spec)
 end
 
@@ -311,7 +317,7 @@ function fetch(rmt::GitRemote, refspecs::Vector{<:AbstractString};
     msg = "libgit2.fetch: $msg"
     @check ccall((:git_remote_fetch, libgit2), Cint,
                  (Ptr{Cvoid}, Ptr{StrArrayStruct}, Ptr{FetchOptions}, Cstring),
-                 rmt.ptr, isempty(refspecs) ? C_NULL : refspecs, Ref(options), msg)
+                 rmt, isempty(refspecs) ? C_NULL : refspecs, Ref(options), msg)
 end
 
 """
@@ -336,7 +342,7 @@ function push(rmt::GitRemote, refspecs::Vector{<:AbstractString};
     ensure_initialized()
     @check ccall((:git_remote_push, libgit2), Cint,
                  (Ptr{Cvoid}, Ptr{StrArrayStruct}, Ptr{PushOptions}),
-                 rmt.ptr, isempty(refspecs) ? C_NULL : refspecs, Ref(options))
+                 rmt, isempty(refspecs) ? C_NULL : refspecs, Ref(options))
 end
 
 """
@@ -348,7 +354,7 @@ function remote_delete(repo::GitRepo, remote_name::AbstractString)
     ensure_initialized()
     @check ccall((:git_remote_delete, libgit2), Cint,
                  (Ptr{Cvoid}, Cstring),
-                 repo.ptr, remote_name)
+                 repo, remote_name)
 end
 
 Base.show(io::IO, rmt::GitRemote) = print(io, "GitRemote:\nRemote name: ", name(rmt), " url: ", url(rmt))
@@ -367,7 +373,7 @@ function set_remote_fetch_url(repo::GitRepo, remote_name::AbstractString, url::A
     ensure_initialized()
     @check ccall((:git_remote_set_url, libgit2), Cint,
                  (Ptr{Cvoid}, Cstring, Cstring),
-                 repo.ptr, remote_name, url)
+                 repo, remote_name, url)
 end
 
 function set_remote_fetch_url(path::AbstractString, remote_name::AbstractString, url::AbstractString)
@@ -390,7 +396,7 @@ function set_remote_push_url(repo::GitRepo, remote_name::AbstractString, url::Ab
     ensure_initialized()
     @check ccall((:git_remote_set_pushurl, libgit2), Cint,
                  (Ptr{Cvoid}, Cstring, Cstring),
-                 repo.ptr, remote_name, url)
+                 repo, remote_name, url)
 end
 
 function set_remote_push_url(path::AbstractString, remote_name::AbstractString, url::AbstractString)
@@ -432,7 +438,7 @@ function connect(rmt::GitRemote, direction::Consts.GIT_DIRECTION,
                  callbacks::RemoteCallbacks)
     @check ccall((:git_remote_connect, libgit2),
                  Cint, (Ptr{Cvoid}, Cint, Ref{RemoteCallbacks}, Ptr{Cvoid}, Ptr{Cvoid}),
-                 rmt.ptr, direction, callbacks, C_NULL, C_NULL)
+                 rmt, direction, callbacks, C_NULL, C_NULL)
     return rmt
 end
 
@@ -442,7 +448,7 @@ end
 Check whether the remote is connected
 """
 function connected(rmt::GitRemote)
-    return ccall((:git_remote_connected, libgit2), Cint, (Ptr{Cvoid},), rmt.ptr) != 0
+    return ccall((:git_remote_connected, libgit2), Cint, (Ptr{Cvoid},), rmt) != 0
 end
 
 """
@@ -451,7 +457,7 @@ end
 Close the connection to the remote.
 """
 function disconnect(rmt::GitRemote)
-    @check ccall((:git_remote_disconnect, libgit2), Cint, (Ptr{Cvoid},), rmt.ptr)
+    @check ccall((:git_remote_disconnect, libgit2), Cint, (Ptr{Cvoid},), rmt)
     return
 end
 
@@ -465,7 +471,7 @@ This function must only be called after connecting (See [`connect`](@ref)).
 function default_branch(rmt::GitRemote)
     buf_ref = Ref(Buffer())
     @check ccall((:git_remote_default_branch, libgit2), Cint,
-                 (Ptr{Buffer}, Ptr{Cvoid}), buf_ref, rmt.ptr)
+                 (Ptr{Buffer}, Ptr{Cvoid}), buf_ref, rmt)
     buf = buf_ref[]
     str = unsafe_string(buf.ptr, buf.size)
     free(buf_ref)
@@ -484,7 +490,7 @@ function ls(rmt::GitRemote)
     head_refs = Ref{Ptr{Ptr{_GitRemoteHead}}}()
     @check ccall((:git_remote_ls, libgit2), Cint,
                  (Ptr{Ptr{Ptr{_GitRemoteHead}}}, Ptr{Csize_t}, Ptr{Cvoid}),
-                 head_refs, nheads, rmt.ptr)
+                 head_refs, nheads, rmt)
     head_ptr = head_refs[]
     return [GitRemoteHead(unsafe_load(unsafe_load(head_ptr, i)))
             for i in 1:nheads[]]

--- a/stdlib/LibGit2/src/remote.jl
+++ b/stdlib/LibGit2/src/remote.jl
@@ -133,8 +133,8 @@ julia> LibGit2.url(remote)
 """
 function url(rmt::GitRemote)
     ensure_initialized()
-    GC.@preserve rmt begin
-        url_ptr = ccall((:git_remote_url, libgit2), Cstring, (Ptr{Cvoid},), rmt.ptr)
+    GC.@preserve rmt begin # preserve `rmt` object until return of `unsafe_string`
+        url_ptr = ccall((:git_remote_url, libgit2), Cstring, (Ptr{Cvoid},), rmt)
         url_ptr == C_NULL && return ""
         return unsafe_string(url_ptr)
     end
@@ -159,8 +159,8 @@ julia> LibGit2.push_url(LibGit2.get(LibGit2.GitRemote, repo, "origin"))
 """
 function push_url(rmt::GitRemote)
     ensure_initialized()
-    GC.@preserve rmt begin
-        url_ptr = ccall((:git_remote_pushurl, libgit2), Cstring, (Ptr{Cvoid},), rmt.ptr)
+    GC.@preserve rmt begin # preserve `rmt` object until return of `unsafe_string`
+        url_ptr = ccall((:git_remote_pushurl, libgit2), Cstring, (Ptr{Cvoid},), rmt)
         url_ptr == C_NULL && return ""
         return unsafe_string(url_ptr)
     end
@@ -187,8 +187,8 @@ julia> name(remote)
 """
 function name(rmt::GitRemote)
     ensure_initialized()
-    GC.@preserve rmt begin
-        name_ptr = ccall((:git_remote_name, libgit2), Cstring, (Ptr{Cvoid},), rmt.ptr)
+    GC.@preserve rmt begin # preserve `rmt` object until return of `unsafe_string`
+        name_ptr = ccall((:git_remote_name, libgit2), Cstring, (Ptr{Cvoid},), rmt)
         name_ptr == C_NULL && return ""
         return unsafe_string(name_ptr)
     end

--- a/stdlib/LibGit2/src/repository.jl
+++ b/stdlib/LibGit2/src/repository.jl
@@ -142,7 +142,7 @@ function (::Type{T})(repo::GitRepo, spec::AbstractString) where T<:GitObject
     @check ccall((:git_revparse_single, libgit2), Cint,
                  (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring), obj_ptr_ptr, repo, spec)
     # check object is of correct type
-    if T != GitObject && T != GitUnknownObject
+    if T != GitObject && T != GitUnknownObject # FIXME free result on error?
         t = Consts.OBJECT(obj_ptr_ptr[])
         t == Consts.OBJECT(T) || throw(GitError(Error.Object, Error.ERROR, "Expected object of type $T, received object of type $(objtype(t))"))
     end

--- a/stdlib/LibGit2/src/repository.jl
+++ b/stdlib/LibGit2/src/repository.jl
@@ -148,17 +148,7 @@ function (::Type{T})(repo::GitRepo, spec::AbstractString) where T<:GitObject
         if t != Consts.OBJECT(T)
             if obj_ptr != C_NULL
                 # free result
-                if t ==  Consts.OBJ_COMMIT
-                    ccall((:git_commit_free, libgit2), Cvoid, (Ptr{Cvoid},), obj_ptr)
-                elseif t == Consts.OBJ_TREE
-                    ccall((:git_tree_free, libgit2), Cvoid, (Ptr{Cvoid},), obj_ptr)
-                elseif t == Consts.OBJ_BLOB
-                    ccall((:git_blob_free, libgit2), Cvoid, (Ptr{Cvoid},), obj_ptr)
-                elseif t == Consts.OBJ_TAG
-                    ccall((:git_tag_free, libgit2), Cvoid, (Ptr{Cvoid},), obj_ptr)
-                else
-                    @error "Don't know how to free unknown Git object"
-                end
+                ccall((:git_object_free, libgit2), Cvoid, (Ptr{Cvoid},), obj_ptr)
             end
             throw(GitError(Error.Object, Error.ERROR, "Expected object of type $T, received object of type $(objtype(t))"))
         end

--- a/stdlib/LibGit2/src/repository.jl
+++ b/stdlib/LibGit2/src/repository.jl
@@ -32,7 +32,7 @@ end
 function cleanup(r::GitRepo)
     if r.ptr != C_NULL
         ensure_initialized()
-        @check ccall((:git_repository__cleanup, libgit2), Cint, (Ptr{Cvoid},), r.ptr)
+        @check ccall((:git_repository__cleanup, libgit2), Cint, (Ptr{Cvoid},), r)
     end
 end
 
@@ -97,7 +97,7 @@ tree, and no tracking information for remote branches or configurations is prese
 function isbare(repo::GitRepo)
     ensure_initialized()
     @assert repo.ptr != C_NULL
-    return ccall((:git_repository_is_bare, libgit2), Cint, (Ptr{Cvoid},), repo.ptr) == 1
+    return ccall((:git_repository_is_bare, libgit2), Cint, (Ptr{Cvoid},), repo) == 1
 end
 
 """
@@ -109,7 +109,7 @@ Determine if `repo` is detached - that is, whether its HEAD points to a commit
 function isattached(repo::GitRepo)
     ensure_initialized()
     @assert repo.ptr != C_NULL
-    ccall((:git_repository_head_detached, libgit2), Cint, (Ptr{Cvoid},), repo.ptr) != 1
+    ccall((:git_repository_head_detached, libgit2), Cint, (Ptr{Cvoid},), repo) != 1
 end
 
 @doc """
@@ -140,7 +140,7 @@ function (::Type{T})(repo::GitRepo, spec::AbstractString) where T<:GitObject
     obj_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @assert repo.ptr != C_NULL
     @check ccall((:git_revparse_single, libgit2), Cint,
-                 (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring), obj_ptr_ptr, repo.ptr, spec)
+                 (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring), obj_ptr_ptr, repo, spec)
     # check object is of correct type
     if T != GitObject && T != GitUnknownObject
         t = Consts.OBJECT(obj_ptr_ptr[])
@@ -157,7 +157,7 @@ function (::Type{T})(repo::GitRepo, oid::GitHash) where T<:GitObject
     @assert repo.ptr != C_NULL
     @check ccall((:git_object_lookup, libgit2), Cint,
                  (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{GitHash}, Consts.OBJECT),
-                 obj_ptr_ptr, repo.ptr, oid_ptr, Consts.OBJECT(T))
+                 obj_ptr_ptr, repo, oid_ptr, Consts.OBJECT(T))
 
     return T(repo, obj_ptr_ptr[])
 end
@@ -169,7 +169,7 @@ function (::Type{T})(repo::GitRepo, oid::GitShortHash) where T<:GitObject
     @assert repo.ptr != C_NULL
     @check ccall((:git_object_lookup_prefix, libgit2), Cint,
                  (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{GitHash}, Csize_t, Consts.OBJECT),
-                 obj_ptr_ptr, repo.ptr, oid_ptr, oid.len, Consts.OBJECT(T))
+                 obj_ptr_ptr, repo, oid_ptr, oid.len, Consts.OBJECT(T))
 
     return T(repo, obj_ptr_ptr[])
 end
@@ -190,8 +190,10 @@ See also [`workdir`](@ref), [`path`](@ref).
 function gitdir(repo::GitRepo)
     ensure_initialized()
     @assert repo.ptr != C_NULL
-    return unsafe_string(ccall((:git_repository_path, libgit2), Cstring,
-                        (Ptr{Cvoid},), repo.ptr))
+    GC.@preserve repo begin
+        return unsafe_string(ccall((:git_repository_path, libgit2), Cstring,
+                                   (Ptr{Cvoid},), repo))
+    end
 end
 
 """
@@ -211,10 +213,12 @@ See also [`gitdir`](@ref), [`path`](@ref).
 function workdir(repo::GitRepo)
     ensure_initialized()
     @assert repo.ptr != C_NULL
-    sptr = ccall((:git_repository_workdir, libgit2), Cstring,
-                (Ptr{Cvoid},), repo.ptr)
-    sptr == C_NULL && throw(GitError(Error.Object, Error.ERROR, "No working directory found."))
-    return unsafe_string(sptr)
+    GC.@preserve repo begin
+        sptr = ccall((:git_repository_workdir, libgit2), Cstring,
+                     (Ptr{Cvoid},), repo)
+        sptr == C_NULL && throw(GitError(Error.Object, Error.ERROR, "No working directory found."))
+        return unsafe_string(sptr)
+    end
 end
 
 """
@@ -256,7 +260,7 @@ function peel(::Type{T}, obj::GitObject) where T<:GitObject
     new_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
 
     @check ccall((:git_object_peel, libgit2), Cint,
-                (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cint), new_ptr_ptr, obj.ptr, Consts.OBJECT(T))
+                (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cint), new_ptr_ptr, obj, Consts.OBJECT(T))
 
     return T(obj.owner, new_ptr_ptr[])
 end
@@ -287,7 +291,7 @@ function GitDescribeResult(committish::GitObject;
     result_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_describe_commit, libgit2), Cint,
                  (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{DescribeOptions}),
-                 result_ptr_ptr, committish.ptr, Ref(options))
+                 result_ptr_ptr, committish, Ref(options))
     return GitDescribeResult(committish.owner, result_ptr_ptr[])
 end
 
@@ -314,7 +318,7 @@ function GitDescribeResult(repo::GitRepo; options::DescribeOptions=DescribeOptio
     @assert repo.ptr != C_NULL
     @check ccall((:git_describe_workdir, libgit2), Cint,
                  (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{DescribeOptions}),
-                 result_ptr_ptr, repo.ptr, Ref(options))
+                 result_ptr_ptr, repo, Ref(options))
     return GitDescribeResult(repo, result_ptr_ptr[])
 end
 
@@ -331,7 +335,7 @@ function format(result::GitDescribeResult; options::DescribeFormatOptions=Descri
     buf_ref = Ref(Buffer())
     @check ccall((:git_describe_format, libgit2), Cint,
                  (Ptr{Buffer}, Ptr{Cvoid}, Ptr{DescribeFormatOptions}),
-                 buf_ref, result.ptr, Ref(options))
+                 buf_ref, result, Ref(options))
     buf = buf_ref[]
     str = unsafe_string(buf.ptr, buf.size)
     free(buf_ref)
@@ -357,7 +361,7 @@ function checkout_tree(repo::GitRepo, obj::GitObject;
     @assert repo.ptr != C_NULL
     @check ccall((:git_checkout_tree, libgit2), Cint,
                  (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{CheckoutOptions}),
-                 repo.ptr, obj.ptr, Ref(options))
+                 repo, obj, Ref(options))
 end
 
 """
@@ -373,8 +377,8 @@ function checkout_index(repo::GitRepo, idx::Union{GitIndex, Nothing} = nothing;
     @assert repo.ptr != C_NULL
     @check ccall((:git_checkout_index, libgit2), Cint,
                  (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{CheckoutOptions}),
-                 repo.ptr,
-                 idx === nothing ? C_NULL : idx.ptr,
+                 repo,
+                 idx === nothing ? C_NULL : idx,
                  Ref(options))
 end
 
@@ -393,7 +397,7 @@ function checkout_head(repo::GitRepo; options::CheckoutOptions = CheckoutOptions
     @assert repo.ptr != C_NULL
     @check ccall((:git_checkout_head, libgit2), Cint,
                  (Ptr{Cvoid}, Ptr{CheckoutOptions}),
-                 repo.ptr, Ref(options))
+                 repo, Ref(options))
 end
 
 """
@@ -412,7 +416,7 @@ function cherrypick(repo::GitRepo, commit::GitCommit; options::CherrypickOptions
     @assert repo.ptr != C_NULL
     @check ccall((:git_cherrypick, libgit2), Cint,
                  (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{CherrypickOptions}),
-                 repo.ptr, commit.ptr, Ref(options))
+                 repo, commit, Ref(options))
 end
 
 """Updates some entries, determined by the `pathspecs`, in the index from the target commit tree."""
@@ -421,8 +425,8 @@ function reset!(repo::GitRepo, obj::Union{GitObject, Nothing}, pathspecs::Abstra
     @assert repo.ptr != C_NULL
     @check ccall((:git_reset_default, libgit2), Cint,
                  (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{StrArrayStruct}),
-                 repo.ptr,
-                 obj === nothing ? C_NULL : obj.ptr,
+                 repo,
+                 obj === nothing ? C_NULL : obj,
                  collect(pathspecs))
     return head_oid(repo)
 end
@@ -434,7 +438,7 @@ function reset!(repo::GitRepo, obj::GitObject, mode::Cint;
     @assert repo.ptr != C_NULL
     @check ccall((:git_reset, libgit2), Cint,
                  (Ptr{Cvoid}, Ptr{Cvoid}, Cint, Ptr{CheckoutOptions}),
-                  repo.ptr, obj.ptr, mode, Ref(checkout_opts))
+                  repo, obj, mode, Ref(checkout_opts))
     return head_oid(repo)
 end
 
@@ -492,7 +496,7 @@ function fetchheads(repo::GitRepo)
     @assert repo.ptr != C_NULL
     @check ccall((:git_repository_fetchhead_foreach, libgit2), Cint,
                  (Ptr{Cvoid}, Ptr{Cvoid}, Any),
-                 repo.ptr, ffcb, fh)
+                 repo, ffcb, fh)
     return fh
 end
 
@@ -506,7 +510,7 @@ function remotes(repo::GitRepo)
     sa_ref = Ref(StrArrayStruct())
     @assert repo.ptr != C_NULL
     @check ccall((:git_remote_list, libgit2), Cint,
-                  (Ptr{StrArrayStruct}, Ptr{Cvoid}), sa_ref, repo.ptr)
+                  (Ptr{StrArrayStruct}, Ptr{Cvoid}), sa_ref, repo)
     res = convert(Vector{String}, sa_ref[])
     free(sa_ref)
     return res

--- a/stdlib/LibGit2/src/signature.jl
+++ b/stdlib/LibGit2/src/signature.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 function Signature(ptr::Ptr{SignatureStruct})
+    @assert ptr != C_NULL
     sig   = unsafe_load(ptr)::SignatureStruct
     name  = unsafe_string(sig.name)
     email = unsafe_string(sig.email)
@@ -67,6 +68,6 @@ function default_signature(repo::GitRepo)
     ensure_initialized()
     sig_ptr_ptr = Ref{Ptr{SignatureStruct}}(C_NULL)
     @check ccall((:git_signature_default, libgit2), Cint,
-                 (Ptr{Ptr{SignatureStruct}}, Ptr{Cvoid}), sig_ptr_ptr, repo.ptr)
+                 (Ptr{Ptr{SignatureStruct}}, Ptr{Cvoid}), sig_ptr_ptr, repo)
     return GitSignature(sig_ptr_ptr[])
 end

--- a/stdlib/LibGit2/src/status.jl
+++ b/stdlib/LibGit2/src/status.jl
@@ -14,14 +14,17 @@ function GitStatus(repo::GitRepo; status_opts=StatusOptions())
     stat_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_status_list_new, libgit2), Cint,
                   (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{StatusOptions}),
-                  stat_ptr_ptr, repo.ptr, Ref(status_opts))
+                  stat_ptr_ptr, repo, Ref(status_opts))
     return GitStatus(repo, stat_ptr_ptr[])
 end
 
 function Base.length(status::GitStatus)
     ensure_initialized()
-    return Int(ccall((:git_status_list_entrycount, libgit2), Csize_t,
-                      (Ptr{Ptr{Cvoid}},), status.ptr))
+    GC.@preserve status begin
+        # FIXME Argument is `git_status_list*` in  Ptr{} in `git2/status.h`.
+        return Int(ccall((:git_status_list_entrycount, libgit2), Csize_t,
+                         (Ptr{Ptr{Cvoid}},), status.ptr))
+    end
 end
 
 function Base.getindex(status::GitStatus, i::Integer)
@@ -51,7 +54,7 @@ function status(repo::GitRepo, path::String)
     status_ptr = Ref{Cuint}(0)
     ret =  ccall((:git_status_file, libgit2), Cint,
                   (Ref{Cuint}, Ptr{Cvoid}, Cstring),
-                  status_ptr, repo.ptr, path)
+                  status_ptr, repo, path)
     (ret == Cint(Error.ENOTFOUND) || ret == Cint(Error.EAMBIGUOUS)) && return nothing
     return status_ptr[]
 end

--- a/stdlib/LibGit2/src/status.jl
+++ b/stdlib/LibGit2/src/status.jl
@@ -20,11 +20,8 @@ end
 
 function Base.length(status::GitStatus)
     ensure_initialized()
-    GC.@preserve status begin
-        # FIXME Argument is `git_status_list*` in  Ptr{} in `git2/status.h`.
-        return Int(ccall((:git_status_list_entrycount, libgit2), Csize_t,
-                         (Ptr{Ptr{Cvoid}},), status.ptr))
-    end
+    return Int(ccall((:git_status_list_entrycount, libgit2), Csize_t,
+                         (Ptr{Cvoid},), status))
 end
 
 function Base.getindex(status::GitStatus, i::Integer)

--- a/stdlib/LibGit2/src/tag.jl
+++ b/stdlib/LibGit2/src/tag.jl
@@ -9,7 +9,7 @@ function tag_list(repo::GitRepo)
     ensure_initialized()
     sa_ref = Ref(StrArrayStruct())
     @check ccall((:git_tag_list, libgit2), Cint,
-                 (Ptr{StrArrayStruct}, Ptr{Cvoid}), sa_ref, repo.ptr)
+                 (Ptr{StrArrayStruct}, Ptr{Cvoid}), sa_ref, repo)
     res = convert(Vector{String}, sa_ref[])
     free(sa_ref)
     res
@@ -23,7 +23,7 @@ Remove the git tag `tag` from the repository `repo`.
 function tag_delete(repo::GitRepo, tag::AbstractString)
     ensure_initialized()
     @check ccall((:git_tag_delete, libgit2), Cint,
-                  (Ptr{Cvoid}, Cstring), repo.ptr, tag)
+                  (Ptr{Cvoid}, Cstring), repo, tag)
 end
 
 """
@@ -48,7 +48,7 @@ function tag_create(repo::GitRepo, tag::AbstractString, commit::Union{AbstractSt
             ensure_initialized()
             @check ccall((:git_tag_create, libgit2), Cint,
                  (Ptr{GitHash}, Ptr{Cvoid}, Cstring, Ptr{Cvoid}, Ptr{SignatureStruct}, Cstring, Cint),
-                  oid_ptr, repo.ptr, tag, commit_obj.ptr, git_sig.ptr, msg, Cint(force))
+                  oid_ptr, repo, tag, commit_obj, git_sig, msg, Cint(force))
         end
     end
     return oid_ptr[]

--- a/stdlib/LibGit2/src/tree.jl
+++ b/stdlib/LibGit2/src/tree.jl
@@ -37,7 +37,7 @@ function treewalk(f, tree::GitTree, post::Bool = false)
         end, Cint, (Cstring, Ptr{Cvoid}, Ref{Vector{Any}}))
     err = ccall((:git_tree_walk, libgit2), Cint,
                 (Ptr{Cvoid}, Cint, Ptr{Cvoid}, Any),
-                tree.ptr, post, cbf, payload)
+                tree, post, cbf, payload)
     if err < 0
         err_class, _ = Error.last_error()
         if err_class != Error.Callback
@@ -58,8 +58,10 @@ Return the filename of the object on disk to which `te` refers.
 """
 function filename(te::GitTreeEntry)
     ensure_initialized()
-    str = ccall((:git_tree_entry_name, libgit2), Cstring, (Ptr{Cvoid},), te.ptr)
-    str != C_NULL && return unsafe_string(str)
+    GC.@preserve te begin
+        str = ccall((:git_tree_entry_name, libgit2), Cstring, (Ptr{Cvoid},), te.ptr)
+        str != C_NULL && return unsafe_string(str)
+    end
     return nothing
 end
 
@@ -70,7 +72,7 @@ Return the UNIX filemode of the object on disk to which `te` refers as an intege
 """
 function filemode(te::GitTreeEntry)
     ensure_initialized()
-    return ccall((:git_tree_entry_filemode, libgit2), Cint, (Ptr{Cvoid},), te.ptr)
+    return ccall((:git_tree_entry_filemode, libgit2), Cint, (Ptr{Cvoid},), te)
 end
 
 """
@@ -81,7 +83,7 @@ one of the types which [`objtype`](@ref) returns, e.g. a `GitTree` or `GitBlob`.
 """
 function entrytype(te::GitTreeEntry)
     ensure_initialized()
-    otype = ccall((:git_tree_entry_type, libgit2), Cint, (Ptr{Cvoid},), te.ptr)
+    otype = ccall((:git_tree_entry_type, libgit2), Cint, (Ptr{Cvoid},), te)
     return objtype(Consts.OBJECT(otype))
 end
 
@@ -101,7 +103,7 @@ end
 
 function count(tree::GitTree)
     ensure_initialized()
-    return ccall((:git_tree_entrycount, libgit2), Csize_t, (Ptr{Cvoid},), tree.ptr)
+    return ccall((:git_tree_entrycount, libgit2), Csize_t, (Ptr{Cvoid},), tree)
 end
 
 function Base.getindex(tree::GitTree, i::Integer)
@@ -111,7 +113,7 @@ function Base.getindex(tree::GitTree, i::Integer)
     ensure_initialized()
     te_ptr = ccall((:git_tree_entry_byindex, libgit2),
                    Ptr{Cvoid},
-                   (Ptr{Cvoid}, Csize_t), tree.ptr, i-1)
+                   (Ptr{Cvoid}, Csize_t), tree, i-1)
     return GitTreeEntry(tree, te_ptr, false)
 end
 

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -1057,7 +1057,6 @@ for (typ, owntyp, sup, cname) in Tuple{Symbol,Any,Symbol,Symbol}[
                 return obj
             end
         end
-        @eval Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::$typ) = x.ptr
     else
         @eval mutable struct $typ <: $sup
             owner::$owntyp
@@ -1072,13 +1071,13 @@ for (typ, owntyp, sup, cname) in Tuple{Symbol,Any,Symbol,Symbol}[
                 return obj
             end
         end
-        @eval Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::$typ) = x.ptr
         if isa(owntyp, Expr) && owntyp.args[1] === :Union && owntyp.args[3] === :Nothing
             @eval begin
                 $typ(ptr::Ptr{Cvoid}, fin::Bool=true) = $typ(nothing, ptr, fin)
             end
         end
     end
+    @eval Base.unsafe_convert(::Type{Ptr{Cvoid}}, obj::$typ) = obj.ptr
     @eval function Base.close(obj::$typ)
         if obj.ptr != C_NULL
             ensure_initialized()

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -1115,10 +1115,11 @@ end
 function Base.close(obj::GitSignature)
     if obj.ptr != C_NULL
         ensure_initialized()
-        ccall((:git_signature_free, libgit2), Cvoid, (Ptr{SignatureStruct},), obj.ptr)
+        ccall((:git_signature_free, libgit2), Cvoid, (Ptr{SignatureStruct},), obj)
         obj.ptr = C_NULL
     end
 end
+Base.unsafe_convert(::Type{Ptr{SignatureStruct}}, obj::GitSignature) = obj.ptr
 
 # Structure has the same layout as SignatureStruct
 mutable struct Signature

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -1082,7 +1082,7 @@ for (typ, owntyp, sup, cname) in Tuple{Symbol,Any,Symbol,Symbol}[
     @eval function Base.close(obj::$typ)
         if obj.ptr != C_NULL
             ensure_initialized()
-            ccall(($(string(cname, :_free)), libgit2), Cvoid, (Ptr{Cvoid},), obj.ptr)
+            ccall(($(string(cname, :_free)), libgit2), Cvoid, (Ptr{Cvoid},), obj)
             obj.ptr = C_NULL
             if Threads.atomic_sub!(REFCOUNT, 1) == 1
                 # will the last finalizer please turn out the lights?

--- a/stdlib/LibGit2/src/walker.jl
+++ b/stdlib/LibGit2/src/walker.jl
@@ -22,7 +22,7 @@ function GitRevWalker(repo::GitRepo)
     ensure_initialized()
     w_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_revwalk_new, libgit2), Cint,
-                  (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}), w_ptr, repo.ptr)
+                  (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}), w_ptr, repo)
     return GitRevWalker(repo, w_ptr[])
 end
 
@@ -30,7 +30,7 @@ function Base.iterate(w::GitRevWalker, state=nothing)
     ensure_initialized()
     id_ptr = Ref(GitHash())
     err = ccall((:git_revwalk_next, libgit2), Cint,
-                (Ptr{GitHash}, Ptr{Cvoid}), id_ptr, w.ptr)
+                (Ptr{GitHash}, Ptr{Cvoid}), id_ptr, w)
     if err == Cint(Error.GIT_OK)
         return (id_ptr[], nothing)
     elseif err == Cint(Error.ITEROVER)
@@ -51,7 +51,7 @@ during the walk.
 """
 function push_head!(w::GitRevWalker)
     ensure_initialized()
-    @check ccall((:git_revwalk_push_head, libgit2), Cint, (Ptr{Cvoid},), w.ptr)
+    @check ccall((:git_revwalk_push_head, libgit2), Cint, (Ptr{Cvoid},), w)
     return w
 end
 
@@ -64,20 +64,20 @@ of that year as `cid` and then passing the resulting `w` to [`LibGit2.map`](@ref
 """
 function push!(w::GitRevWalker, cid::GitHash)
     ensure_initialized()
-    @check ccall((:git_revwalk_push, libgit2), Cint, (Ptr{Cvoid}, Ptr{GitHash}), w.ptr, Ref(cid))
+    @check ccall((:git_revwalk_push, libgit2), Cint, (Ptr{Cvoid}, Ptr{GitHash}), w, Ref(cid))
     return w
 end
 
 function push!(w::GitRevWalker, range::AbstractString)
     ensure_initialized()
-    @check ccall((:git_revwalk_push_range, libgit2), Cint, (Ptr{Cvoid}, Ptr{UInt8}), w.ptr, range)
+    @check ccall((:git_revwalk_push_range, libgit2), Cint, (Ptr{Cvoid}, Ptr{UInt8}), w, range)
     return w
 end
 
 function Base.sort!(w::GitRevWalker; by::Cint = Consts.SORT_NONE, rev::Bool=false)
     ensure_initialized()
     rev && (by |= Consts.SORT_REVERSE)
-    @check ccall((:git_revwalk_sorting, libgit2), Cint, (Ptr{Cvoid}, Cint), w.ptr, by)
+    @check ccall((:git_revwalk_sorting, libgit2), Cint, (Ptr{Cvoid}, Cint), w, by)
     return w
 end
 


### PR DESCRIPTION
This issue has been discussed [here](https://discourse.julialang.org/t/preserve-against-garbage-collection-in-libgit2/117095).

In most cases, thanks to the specialization of `Base.unsafe_convert`, it is sufficient to replace `obj.ptr` by `obj` in `ccalls` to fix the issue.

In other cases, for example when a pointer to an internal string is returned, the code has to be wrapped in `GC.https://github.com/preserve obj begin ... end` block.

All `LibGit2` tests run successfully. I have left a few `FIXME` comments where I have doubts about the code, notably with `Ptr{Ptr{Cvoid}}` arguments. 