### PR TITLE
inference: add basic support for `:globaldecl` expressions

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2705,6 +2705,8 @@ function abstract_eval_statement_expr(interp::AbstractInterpreter, e::Expr, vtyp
     elseif ehead === :gc_preserve_end || ehead === :leave || ehead === :pop_exception ||
            ehead === :global || ehead === :popaliasscope
         return RTEffects(Nothing, Union{}, Effects(EFFECTS_TOTAL; effect_free=EFFECT_FREE_GLOBALLY))
+    elseif ehead === :globaldecl
+        return RTEffects(Nothing, Any, EFFECTS_UNKNOWN)
     elseif ehead === :thunk
         return RTEffects(Any, Any, EFFECTS_UNKNOWN)
     end

--- a/base/compiler/validation.jl
+++ b/base/compiler/validation.jl
@@ -22,6 +22,7 @@ const VALID_EXPR_HEADS = IdDict{Symbol,UnitRange{Int}}(
     :copyast => 1:1,
     :meta => 0:typemax(Int),
     :global => 1:1,
+    :globaldecl => 2:2,
     :foreigncall => 5:typemax(Int), # name, RT, AT, nreq, (cconv, effects), args..., roots...
     :cfunction => 5:5,
     :isdefined => 1:2,

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -2391,3 +2391,8 @@ let (c, r, res) = test_complete_context("const xxx = Base.si", Main)
     @test res
     @test "sin" ∈ c
 end
+
+let (c, r, res) = test_complete_context("global xxx::Number = Base.", Main)
+    @test res
+    @test "pi" ∈ c
+end


### PR DESCRIPTION
Following up #54773.
Required for external abstract interpreters that may run inference on arbitrary top-level thunks.