### PR TITLE
loading: Don't assume a package is loaded by its own name

### DIFF
--- a/test/loading.jl
+++ b/test/loading.jl
@@ -266,6 +266,7 @@ end
         ("Bar",     "2a550a13-6bab-4a91-a4ee-dff34d6b99d0", "project/deps/Bar/src/Bar.jl"        ),
         ("Foo.Baz", "6801f525-dc68-44e8-a4e8-cabd286279e7", "depot/packages/Baz/81oLe/src/Baz.jl"),
         ("Foo.Qux", "b5ec9b9c-e354-47fd-b367-a348bdc8f909", "project/deps/Qux.jl"                ),
+        ("Renamed", "b93c0545-2f14-404a-a207-11bc71528a7e", "project/deps/RenameMe/src/RenameMe.jl")
     ]
         n = map(String, split(names, '.'))
         pkg = recurse_package(n...)

--- a/test/project/Manifest.toml
+++ b/test/project/Manifest.toml
@@ -26,3 +26,8 @@ git-tree-sha1 = "efc7e24c53d6a328011975294a2c75fed2f9800a"
 [[Qux]]
 uuid = "b5ec9b9c-e354-47fd-b367-a348bdc8f909"
 path = "deps/Qux.jl"
+
+[[Renamed]]
+name = "RenameMe"
+uuid = "b93c0545-2f14-404a-a207-11bc71528a7e"
+path = "deps/RenameMe"

--- a/test/project/Project.toml
+++ b/test/project/Project.toml
@@ -4,3 +4,4 @@ uuid = "84c38c17-0c6f-4d12-a694-d20b69c16777"
 [deps]
 Foo = "767738be-2f1f-45a9-b806-0234f3164144"
 Bar = "2a550a13-6bab-4a91-a4ee-dff34d6b99d0"
+Renamed = "b93c0545-2f14-404a-a207-11bc71528a7e"

--- a/test/project/deps/RenameMe/Project.toml
+++ b/test/project/deps/RenameMe/Project.toml
@@ -1,0 +1,2 @@
+name = "RenameMe"
+uuid = "b93c0545-2f14-404a-a207-11bc71528a7e"

--- a/test/project/deps/RenameMe/src/RenameMe.jl
+++ b/test/project/deps/RenameMe/src/RenameMe.jl
@@ -1,0 +1,3 @@
+module RenameMe
+    const this = :RenameMe
+end


### PR DESCRIPTION
Recent discussion on slack has revealed that there is some disagreement about what it means for a package to have a different name in the `deps` section for one of its dependencies than said dependency itself declares in its own Project.toml.

There's basically two views:
1. This situation shouldn't arise, the primary purpose of the deps section is to disambiguate between two packages of the same name (but with different UUIDs).

2. The `Project.toml` file declares a mapping `name` => `uuid` that all loading operations within said package operate on and the actual name of the package is largely irrelevant.

Worse, the current code doesn't really do either. It mostly behaves like the second, except that it doesn't actually work, because it forms the default entrypath using the name from the deps section, not the Project.toml (resp. a copy of it in the Manifest.toml). As a result, the only time you're allowed to use a name other than what the project declares in a `[deps]` section is when the dependency explicitly declares an `entrypath` (which is a relatively new feature).

This PR adjusts loading to fully behave like the second interpretation. For example, having the following in

Project.toml
```
[deps]
GeneralHTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
```

```
[[deps.GeneralHTTP]]
name = "HTTP"
deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
git-tree-sha1 = "d1d712be3164d61d1fb98e7ce9bcbc6cc06b45ed"
uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
version = "1.10.8"
```

would allow `using GeneralHTTP` to load the package otherwise known as `HTTP`.

This is only the loading side of this. While Pkg seems surprisingly ok with this also, it is definitely not tested and likely to cause confusing behavior, so the primary purpose of this PR is to decide which behavior we think is correct and then to gradually bring the implementation into compliance.