### PR TITLE
make sleep work for much shorter time increments

### DIFF
--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -266,8 +266,8 @@ end
 
 Block the current task for at least specified number of seconds.
 The resolution of sleep is around 2 microsecond (2e-6 seconds), but
-as the amount of time decreases, the likelyhood of the sleep exceeding the
-given ammount of time increases (since the OS or julia scheduler might not
+as the amount of time decreases, the likelihood of the sleep exceeding the
+given amount of time increases (since the OS or julia scheduler might not
 wake up the thread/task at exactly the right time).
 
 Note that using sleep for small increments of time usually implies that you are

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -270,8 +270,8 @@ as the amount of time decreases, the likelihood of the sleep exceeding the
 given amount of time increases (since the OS or julia scheduler might not
 wake up the thread/task at exactly the right time).
 
-Note that using sleep for small increments of time usually implies that you are
-doing something weird and should consider using some form of notification system.
+Note that using sleep for small increments of time is usually sub-optimal
+and should consider either using yield, or some form of event notification system.
 """
 function sleep(sec::Real)
     sec ≥ 0 || throw(ArgumentError("cannot sleep for $sec seconds"))


### PR DESCRIPTION
I'm not convinced that this is the best implementation of this, but it is an easy one that will reliably work cross platform.  We should probably introduce higher precision `Timer`s since in the past few years they have gained support in Windows which was the last holdout, but IMO this PR on it's own is worthwhile.

```
julia> @benchmark Base.mysleep(1e-4)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):   99.121 μs … 120.211 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     100.730 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   100.571 μs ± 616.414 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                          ▁▃ ▃▆▂▅█▂▅▄ ▂▂ ▂       
  ▂▁▁▂▂▂▂▃▃▃▄▅▄▅▅▆▆▇▆█▇▅▆▆▅▅▇▄▄▄▄▄▃▄▄▄▅▆█▆███████████▇██▆██▅▆▅▃ ▅
  99.1 μs          Histogram: frequency by time          101 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark Base.mysleep(1e-5)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  10.120 μs …  15.920 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     10.860 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   10.867 μs ± 284.132 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                     ▂▁▂▃▆▁  ▂      ▁▅        ▃▆▃█▁             
  ▂▁▂▂▁▂▂▂▁▂▂▂▂▂▃▃▄▄███████▇██▅▆▃▂▄▅██▆▄▄▄▆▄▇▆██████▇▇▇▄▄▂▂▂▂▂ ▄
  10.1 μs         Histogram: frequency by time         11.4 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark Base.mysleep(2e-6)
BenchmarkTools.Trial: 10000 samples with 9 evaluations.
 Range (min … max):  2.357 μs …   4.843 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.534 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.541 μs ± 107.653 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

       ▁▃ ▁▂▁▄▄▂       ▃▁▇▂▄▂ ▃         ▂▄█▁▂                  
  ▁▁▂▄███████████▆▄▃▃▅▇██████████▆▃▃▃▄▇▇█████▇█▇▅▄▃▂▁▁▁▁▁▁▁▁▁ ▄
  2.36 μs         Histogram: frequency by time        2.78 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark Base.mysleep(1e-6)
BenchmarkTools.Trial: 10000 samples with 10 evaluations.
 Range (min … max):  1.528 μs …   5.098 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.723 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.742 μs ± 106.515 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                 ▃▇▇██▂▁▅▁▁    ▂▅▇▇▄                           
  ▁▂▂▂▂▂▂▂▃▃▂▂▂▂▄██████████▆▅▄▅█████▆▅▆▆▃▃▃▂▂▄▅▄▅▃▂▂▂▁▁▁▁▁▁▁▁ ▄
  1.53 μs         Histogram: frequency by time           2 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```