### PR TITLE
Deprecate conflicting @testset arguments

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1838,9 +1838,19 @@ function parse_testset_args(args)
         # a standalone symbol is assumed to be the test set we should use
         # the same is true for a symbol that's not exported from a module
         if isa(arg, Symbol) || Base.isexpr(arg, :.)
+            if testsettype !== nothing
+                msg = """Multiple testset types provided to @testset. \
+                    This may be disallowed in the future."""
+                Base.depwarn(msg, :testset_multiple_testset_types; force=true)
+            end
             testsettype = esc(arg)
         # a string is the description
         elseif isa(arg, AbstractString) || (isa(arg, Expr) && arg.head === :string)
+            if desc !== nothing
+                msg = """Multiple descriptions provided to @testset. \
+                    This may be disallowed in the future."""
+                Base.depwarn(msg, :testset_multiple_descriptions; force=true)
+            end
             desc = esc(arg)
         # an assignment is an option
         elseif isa(arg, Expr) && arg.head === :(=)

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1840,7 +1840,7 @@ function parse_testset_args(args)
         if isa(arg, Symbol) || Base.isexpr(arg, :.)
             if testsettype !== nothing
                 msg = """Multiple testset types provided to @testset. \
-                    This may be disallowed in the future."""
+                    This is deprecated and may error in the future."""
                 Base.depwarn(msg, :testset_multiple_testset_types; force=true)
             end
             testsettype = esc(arg)
@@ -1848,7 +1848,7 @@ function parse_testset_args(args)
         elseif isa(arg, AbstractString) || (isa(arg, Expr) && arg.head === :string)
             if desc !== nothing
                 msg = """Multiple descriptions provided to @testset. \
-                    This may be disallowed in the future."""
+                    This is deprecated and may error in the future."""
                 Base.depwarn(msg, :testset_multiple_descriptions; force=true)
             end
             desc = esc(arg)

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -1725,4 +1725,14 @@ end
         result = read(pipeline(ignorestatus(cmd), stderr=devnull), String)
         @test occursin(expected, result)
     end
+
+end
+
+@testset "Deprecated multiple arguments" begin
+    msg1 = """Multiple descriptions provided to @testset. \
+        This may be disallowed in the future."""
+    @test_logs (:warn, msg1) @macroexpand @testset "name1" "name2" begin end
+    msg2 = """Multiple testset types provided to @testset. \
+        This may be disallowed in the future."""
+    @test_logs (:warn, msg2) @macroexpand @testset DefaultTestSet DefaultTestSet begin end
 end

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -1730,9 +1730,9 @@ end
 
 @testset "Deprecated multiple arguments" begin
     msg1 = """Multiple descriptions provided to @testset. \
-        This may be disallowed in the future."""
-    @test_logs (:warn, msg1) @macroexpand @testset "name1" "name2" begin end
+        This is deprecated and may error in the future."""
+    @test_deprecated msg1 @macroexpand @testset "name1" "name2" begin end
     msg2 = """Multiple testset types provided to @testset. \
-        This may be disallowed in the future."""
-    @test_logs (:warn, msg2) @macroexpand @testset DefaultTestSet DefaultTestSet begin end
+        This is deprecated and may error in the future."""
+    @test_deprecated msg2 @macroexpand @testset DefaultTestSet DefaultTestSet begin end
 end


### PR DESCRIPTION
Currently `@testset` allows specifying multiple descriptions and testset types, and only the last one will take effect. The others will be silently ignored.

This PR starts printing deprecation warnings whenever such conflicting arguments are provided.

Ideally I would also propose fixing the order in which the arguments must be provided (currently order doesn't matter), but I've left that out at least for now since that's a more breaking change. Can put it in though if others are for it.