### PR TITLE
LinearAlgebra: Do not specialize arguments in check_A_mul_B!_sizes

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -541,12 +541,7 @@ function rmul!(B::Bidiagonal, D::Diagonal)
     return B
 end
 
-function check_A_mul_B!_sizes(@nospecialize(C::AbstractMatrix),
-                                @nospecialize(A::AbstractMatrix),
-                                @nospecialize(B::AbstractMatrix))
-    _check_A_mul_B!_sizes(size(C), size(A), size(B))
-end
-@noinline function _check_A_mul_B!_sizes((mC, nC), (mA, nA), (mB, nB))
+@noinline function check_A_mul_B!_sizes((mC, nC)::NTuple{2,Integer}, (mA, nA)::NTuple{2,Integer}, (mB, nB)::NTuple{2,Integer})
     if mA != mC
         throw(DimensionMismatch(lazy"first dimension of A, $mA, and first dimension of output C, $mC, must match"))
     elseif nA != mB
@@ -575,7 +570,7 @@ _mul!(C::AbstractMatrix, A::BiTriSym, B::TriSym, _add::MulAddMul) =
 _mul!(C::AbstractMatrix, A::BiTriSym, B::Bidiagonal, _add::MulAddMul) =
     _bibimul!(C, A, B, _add)
 function _bibimul!(C, A, B, _add)
-    check_A_mul_B!_sizes(C, A, B)
+    check_A_mul_B!_sizes(size(C), size(A), size(B))
     n = size(A,1)
     n <= 3 && return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
     # We use `_rmul_or_fill!` instead of `_modify!` here since using
@@ -633,7 +628,7 @@ end
 
 function _mul!(C::AbstractMatrix, A::BiTriSym, B::Diagonal, _add::MulAddMul)
     require_one_based_indexing(C)
-    check_A_mul_B!_sizes(C, A, B)
+    check_A_mul_B!_sizes(size(C), size(A), size(B))
     n = size(A,1)
     iszero(n) && return C
     n <= 3 && return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
@@ -699,7 +694,7 @@ end
 
 function _mul!(C::AbstractMatrix, A::AbstractMatrix, B::TriSym, _add::MulAddMul)
     require_one_based_indexing(C, A)
-    check_A_mul_B!_sizes(C, A, B)
+    check_A_mul_B!_sizes(size(C), size(A), size(B))
     iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
     n = size(A,1)
     m = size(B,2)
@@ -734,7 +729,7 @@ end
 
 function _mul!(C::AbstractMatrix, A::AbstractMatrix, B::Bidiagonal, _add::MulAddMul)
     require_one_based_indexing(C, A)
-    check_A_mul_B!_sizes(C, A, B)
+    check_A_mul_B!_sizes(size(C), size(A), size(B))
     iszero(_add.alpha) && return _rmul_or_fill!(C, _add.beta)
     if size(A, 1) <= 3 || size(B, 2) <= 1
         return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
@@ -764,7 +759,7 @@ _mul!(C::AbstractMatrix, A::Diagonal, B::TriSym, _add::MulAddMul) =
     _dibimul!(C, A, B, _add)
 function _dibimul!(C, A, B, _add)
     require_one_based_indexing(C)
-    check_A_mul_B!_sizes(C, A, B)
+    check_A_mul_B!_sizes(size(C), size(A), size(B))
     n = size(A,1)
     n <= 3 && return mul!(C, Array(A), Array(B), _add.alpha, _add.beta)
     _rmul_or_fill!(C, _add.beta)  # see the same use above

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -541,10 +541,12 @@ function rmul!(B::Bidiagonal, D::Diagonal)
     return B
 end
 
-function check_A_mul_B!_sizes(C, A, B)
-    mA, nA = size(A)
-    mB, nB = size(B)
-    mC, nC = size(C)
+function check_A_mul_B!_sizes(@nospecialize(C::AbstractMatrix),
+                                @nospecialize(A::AbstractMatrix),
+                                @nospecialize(B::AbstractMatrix))
+    _check_A_mul_B!_sizes(size(C), size(A), size(B))
+end
+@noinline function _check_A_mul_B!_sizes((mC, nC), (mA, nA), (mB, nB))
     if mA != mC
         throw(DimensionMismatch(lazy"first dimension of A, $mA, and first dimension of output C, $mC, must match"))
     elseif nA != mB


### PR DESCRIPTION
Since this is a check that only depends on the sizes of the matrices, we do not need to specialize the method for the types of the matrix arguments. This would reduce TTFX if the method is called for three or more combinations of argument types (the break-even is at two, and this implementation is strictly worse if the method is only called once). However, the TTFX is hardly a factor if it is only called once.

On v"1.12.0-DEV.875"
```julia
julia> using LinearAlgebra

julia> n = 5; B = Bidiagonal(rand(n), rand(n-1), :U); D = Diagonal(rand(size(B,1))); C = similar(B, size(B));

julia> @time LinearAlgebra.check_A_mul_B!_sizes(C, B, D);
  0.010095 seconds (7.68 k allocations: 371.203 KiB, 99.76% compilation time)

julia> @time LinearAlgebra.check_A_mul_B!_sizes(C, D, B);
  0.008804 seconds (5.74 k allocations: 275.203 KiB, 99.79% compilation time)

julia> C = similar(B);

julia> @time LinearAlgebra.check_A_mul_B!_sizes(C, B, D);
  0.007851 seconds (5.83 k allocations: 279.781 KiB, 99.78% compilation time)

julia> @time LinearAlgebra.check_A_mul_B!_sizes(C, D, B);
  0.008116 seconds (5.84 k allocations: 280.031 KiB, 99.77% compilation time)
```
This PR
```julia
julia> @time LinearAlgebra.check_A_mul_B!_sizes(C, B, D);
  0.022551 seconds (11.69 k allocations: 550.625 KiB, 99.58% compilation time)

julia> @time LinearAlgebra.check_A_mul_B!_sizes(C, D, B);
  0.000014 seconds (3 allocations: 96 bytes)

julia> C = similar(B);

julia> @time LinearAlgebra.check_A_mul_B!_sizes(C, B, D);
  0.000013 seconds (3 allocations: 96 bytes)

julia> @time LinearAlgebra.check_A_mul_B!_sizes(C, D, B);
  0.000013 seconds (3 allocations: 96 bytes)
```