### PR TITLE
Adjust const docs to be clearer

### DIFF
--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -755,28 +755,7 @@ julia> const z = 100
 julia> z = 100
 100
 ```
-The last rule applies to immutable objects even if the variable binding would change, e.g.:
-```julia-repl
-julia> const s1 = "1"
-"1"
-
-julia> s2 = "1"
-"1"
-
-julia> pointer.([s1, s2], 1)
-2-element Array{Ptr{UInt8},1}:
- Ptr{UInt8} @0x00000000132c9638
- Ptr{UInt8} @0x0000000013dd3d18
-
-julia> s1 = s2
-"1"
-
-julia> pointer.([s1, s2], 1)
-2-element Array{Ptr{UInt8},1}:
- Ptr{UInt8} @0x0000000013dd3d18
- Ptr{UInt8} @0x0000000013dd3d18
-```
-However, for mutable objects the warning is printed as expected:
+* if an assignment would change the mutable object to which the variable points (regardless of whether those two objects are deeply equal), a warning is printed:
 ```jldoctest
 julia> const a = [1]
 1-element Vector{Int64}:


### PR DESCRIPTION
I propose this adjustment to the const docs to improve clarity.

The main issue with the docs before is that the immutable objects example was incorrect (the pointers do not change).
However, I don't feel this adds significant value to the docs; users should not care whether the actual pointer value
changed because all the semantics explained prior to that example are still obeyed.
The two globals `s1` and `s2` will still contain equal, immutable values.

My proposal is to remove that example and clarify the wording on how consts of mutable objects work.
I think this is the core of what the original example was trying to explain.

Closes #55140.