### PR TITLE
correction to compat notice for a[begin]

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1389,8 +1389,8 @@ implicitly begin blocks of code. See also [`;`](@ref).
 collection or the first index of a dimension of an array. For example,
 `a[begin]` is the first element of an array `a`.
 
-!!! compat "Julia 1.6"
-    Use of `begin` as an index requires Julia 1.6 or later.
+!!! compat "Julia 1.4"
+    Use of `begin` as an index requires Julia 1.4 or later.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Correction to #55197: `a[begin]` indexing was added in Julia 1.4 (#33946), not in Julia 1.6 (which just changed the implementation in #35779).  My bad.