### PR TITLE
Fix racecondition in UUIDs tests

### DIFF
--- a/stdlib/UUIDs/src/UUIDs.jl
+++ b/stdlib/UUIDs/src/UUIDs.jl
@@ -36,11 +36,13 @@ const namespace_oid  = UUID(0x6ba7b8129dad11d180b400c04fd430c8) # 6ba7b812-9dad-
 const namespace_x500 = UUID(0x6ba7b8149dad11d180b400c04fd430c8) # 6ba7b814-9dad-11d1-80b4-00c04fd430c8
 
 """
-    uuid1([rng::AbstractRNG]) -> UUID
+    uuid1([rng::AbstractRNG], [timestamp::Float64=time()]) -> UUID
 
 Generates a version 1 (time-based) universally unique identifier (UUID), as specified
-by RFC 4122. Note that the Node ID is randomly generated (does not identify the host)
+by [RFC 4122](https://www.ietf.org/rfc/rfc4122). Note that the Node ID is randomly generated (does not identify the host)
 according to section 4.5 of the RFC.
+
+The optionally passed timestamp is expected to be seconds since the UNIX epoch.
 
 The default rng used by `uuid1` is not `Random.default_rng()` and every invocation of `uuid1()` without
 an argument should be expected to return a unique identifier. Importantly, the outputs of
@@ -50,6 +52,9 @@ detail that may change in the future.
 
 !!! compat "Julia 1.6"
     The output of `uuid1` does not depend on `Random.default_rng()` as of Julia 1.6.
+
+!!! compat "Julia 1.12"
+    Passing a timestamp directly is available as of Julia 1.12.
 
 # Examples
 ```jldoctest; filter = r"[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}"
@@ -61,7 +66,7 @@ julia> uuid1(rng)
 UUID("cfc395e8-590f-11e8-1f13-43a2532b2fa8")
 ```
 """
-function uuid1(rng::AbstractRNG=Random.RandomDevice())
+function uuid1(rng::AbstractRNG=Random.RandomDevice(), t::Float64=time())
     u = rand(rng, UInt128)
 
     # mask off clock sequence and node
@@ -72,7 +77,7 @@ function uuid1(rng::AbstractRNG=Random.RandomDevice())
 
     # 0x01b21dd213814000 is the number of 100 nanosecond intervals
     # between the UUID epoch and Unix epoch
-    timestamp = round(UInt64, time() * 1e7) + 0x01b21dd213814000
+    timestamp = round(UInt64, t * 1e7) + 0x01b21dd213814000
     ts_low = timestamp & typemax(UInt32)
     ts_mid = (timestamp >> 32) & typemax(UInt16)
     ts_hi = (timestamp >> 48) & 0x0fff
@@ -81,14 +86,14 @@ function uuid1(rng::AbstractRNG=Random.RandomDevice())
     u |= UInt128(ts_mid) << 80
     u |= UInt128(ts_hi) << 64
 
-    UUID(u)
+    return UUID(u)
 end
 
 """
     uuid4([rng::AbstractRNG]) -> UUID
 
 Generates a version 4 (random or pseudo-random) universally unique identifier (UUID),
-as specified by RFC 4122.
+as specified by [RFC 4122](https://www.ietf.org/rfc/rfc4122).
 
 The default rng used by `uuid4` is not `Random.default_rng()` and every invocation of `uuid4()` without
 an argument should be expected to return a unique identifier. Importantly, the outputs of
@@ -158,10 +163,12 @@ function uuid5(ns::UUID, name::String)
 end
 
 """
-    uuid7([rng::AbstractRNG]) -> UUID
+    uuid7([rng::AbstractRNG], [timestamp::Float64]) -> UUID
 
 Generates a version 7 (random or pseudo-random) universally unique identifier (UUID),
-as specified by RFC 9652.
+as specified by [RFC 9652](https://www.rfc-editor.org/rfc/rfc9562).
+
+The optionally passed timestamp is expected to be seconds since the UNIX epoch.
 
 The default rng used by `uuid7` is not `Random.default_rng()` and every invocation of `uuid7()` without
 an argument should be expected to return a unique identifier. Importantly, the outputs of
@@ -182,7 +189,7 @@ julia> uuid7(rng)
 UUID("019026ca-e086-772a-9638-f7b8557cd282")
 ```
 """
-function uuid7(rng::AbstractRNG=Random.RandomDevice())
+function uuid7(rng::AbstractRNG=Random.RandomDevice(), t::Float64=time())
     bytes = rand(rng, UInt128)
     # make space for the timestamp
     bytes &= 0x0000000000000fff3fffffffffffffff
@@ -190,7 +197,7 @@ function uuid7(rng::AbstractRNG=Random.RandomDevice())
     bytes |= 0x00000000000070008000000000000000
 
     # current time in ms, rounded to an Integer
-    timestamp = round(UInt128, time() * 1e3)
+    timestamp = round(UInt128, t * 1e3)
     bytes |= timestamp << UInt128(80)
 
     return UUID(bytes)

--- a/stdlib/UUIDs/test/runtests.jl
+++ b/stdlib/UUIDs/test/runtests.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Test, UUIDs, Random
+using UUIDs: _build_uuid1, _build_uuid7
 
 # results similar to Python builtin uuid
 # To reproduce the sequence
@@ -55,7 +56,7 @@ end
     @test u7 == UUID(UInt128(u7))
 end
 
-@testset "no-timestamp API compatibility" begin
+@testset "Passing an RNG" begin
     rng = Xoshiro(0)
     @test uuid1(rng) isa UUID
     @test uuid4(rng) isa UUID
@@ -63,10 +64,14 @@ end
 end
 
 @testset "uuid1, uuid4 & uuid7 RNG stability" begin
-    timestamp = time()
-    @test uuid1(Xoshiro(0), timestamp) == uuid1(Xoshiro(0), timestamp)
-    @test uuid4(Xoshiro(0))            == uuid4(Xoshiro(0))
-    @test uuid7(Xoshiro(0), timestamp) == uuid7(Xoshiro(0), timestamp)
+    @test uuid4(Xoshiro(0)) == uuid4(Xoshiro(0))
+
+    time_uuid1 = rand(UInt64)
+    time_uuid7 = rand(UInt128)
+
+    # we need to go through the internal function to test RNG stability
+    @test _build_uuid1(Xoshiro(0), time_uuid1) == _build_uuid1(Xoshiro(0), time_uuid1)
+    @test _build_uuid7(Xoshiro(0), time_uuid7) == _build_uuid7(Xoshiro(0), time_uuid7)
 end
 
 @testset "Rejection of invalid UUID strings" begin

--- a/stdlib/UUIDs/test/runtests.jl
+++ b/stdlib/UUIDs/test/runtests.jl
@@ -2,7 +2,6 @@
 
 using Test, UUIDs, Random
 
-
 # results similar to Python builtin uuid
 # To reproduce the sequence
 #=
@@ -56,9 +55,18 @@ end
     @test u7 == UUID(UInt128(u7))
 end
 
-@testset "uuid4 & uuid7 RNG stability" begin
-    @test uuid4(Xoshiro(0)) == uuid4(Xoshiro(0))
-    @test uuid7(Xoshiro(0)) == uuid7(Xoshiro(0))
+@testset "no-timestamp API compatibility" begin
+    rng = Xoshiro(0)
+    @test uuid1(rng) isa UUID
+    @test uuid4(rng) isa UUID
+    @test uuid7(rng) isa UUID
+end
+
+@testset "uuid1, uuid4 & uuid7 RNG stability" begin
+    timestamp = time()
+    @test uuid1(Xoshiro(0), timestamp) == uuid1(Xoshiro(0), timestamp)
+    @test uuid4(Xoshiro(0))            == uuid4(Xoshiro(0))
+    @test uuid7(Xoshiro(0), timestamp) == uuid7(Xoshiro(0), timestamp)
 end
 
 @testset "Rejection of invalid UUID strings" begin


### PR DESCRIPTION
By removing the direct reliance on `time()` for individual calls to these two, we can remove a race condition in the testsuite.

There are some other things I noticed while looking at this, but I'll separate those out into their own PRs so that the race condition in CI can be fixed quickly. In particular, this will include using the test vectors provided in the new RFC 9652, which will necessitate a small internal change to the interface (taking a `UInt128` as a timestamp internally). Since that new RFC supersedes the old RFC4122, I'd also like to make a general review of the stdlib to see if we're otherwise still ok. 

cc @jishnub, Fixes #55190 