### PR TITLE
inference: refine branched `Conditional` types

### DIFF
--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -159,7 +159,6 @@ end
 struct StateUpdate
     var::SlotNumber
     vtype::VarState
-    state::VarTable
     conditional::Bool
 end
 
@@ -722,28 +721,6 @@ function invalidate_slotwrapper(vt::VarState, changeid::Int, ignore_conditional:
         return VarState(newtyp, vt.undef)
     end
     return nothing
-end
-
-function stupdate!(lattice::AbstractLattice, state::VarTable, changes::StateUpdate)
-    changed = false
-    changeid = slot_id(changes.var)
-    for i = 1:length(state)
-        if i == changeid
-            newtype = changes.vtype
-        else
-            newtype = changes.state[i]
-        end
-        invalidated = invalidate_slotwrapper(newtype, changeid, changes.conditional)
-        if invalidated !== nothing
-            newtype = invalidated
-        end
-        oldtype = state[i]
-        if schanged(lattice, newtype, oldtype)
-            state[i] = smerge(lattice, oldtype, newtype)
-            changed = true
-        end
-    end
-    return changed
 end
 
 function stupdate!(lattice::AbstractLattice, state::VarTable, changes::VarTable)


### PR DESCRIPTION
Separated from JuliaLang/julia#40880.
This subtle adjustment allows for more accurate type inference in the following kind of cases:
```julia
function condition_object_update2(x)
    cond = x isa Int
    if cond # `cond` is known to be `Const(true)` within this branch
        return !cond ? nothing : x # ::Int
    else
        return  cond ? nothing : 1 # ::Int
    end
end
@test Base.infer_return_type(condition_object_update2, (Any,)) == Int
```

Also cleans up typelattice.jl a bit.