### PR TITLE
Artifacts: use a different way of getting the UUID of a module

### DIFF
--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -545,10 +545,10 @@ function jointail(dir, tail)
 end
 
 function _artifact_str(__module__, artifacts_toml, name, path_tail, artifact_dict, hash, platform, @nospecialize(lazyartifacts))
-    moduleroot = Base.moduleroot(__module__)
-    if haskey(Base.module_keys, moduleroot)
+    pkg = Base.PkgId(__module__)
+    if pkg.uuid !== nothing
         # Process overrides for this UUID, if we know what it is
-        process_overrides(artifact_dict, Base.module_keys[moduleroot].uuid)
+        process_overrides(artifact_dict, pkg.uuid)
     end
 
     # If the artifact exists, we're in the happy path and we can immediately

--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -545,7 +545,8 @@ function jointail(dir, tail)
 end
 
 function _artifact_str(__module__, artifacts_toml, name, path_tail, artifact_dict, hash, platform, @nospecialize(lazyartifacts))
-    pkg = Base.PkgId(__module__)
+    moduleroot = Base.moduleroot(__module__)
+    pkg = Base.PkgId(moduleroot)
     if pkg.uuid !== nothing
         # Process overrides for this UUID, if we know what it is
         process_overrides(artifact_dict, pkg.uuid)

--- a/stdlib/Artifacts/src/Artifacts.jl
+++ b/stdlib/Artifacts/src/Artifacts.jl
@@ -545,8 +545,7 @@ function jointail(dir, tail)
 end
 
 function _artifact_str(__module__, artifacts_toml, name, path_tail, artifact_dict, hash, platform, @nospecialize(lazyartifacts))
-    moduleroot = Base.moduleroot(__module__)
-    pkg = Base.PkgId(moduleroot)
+    pkg = Base.PkgId(__module__)
     if pkg.uuid !== nothing
         # Process overrides for this UUID, if we know what it is
         process_overrides(artifact_dict, pkg.uuid)


### PR DESCRIPTION
Hopefully fixes https://github.com/JuliaLang/julia/issues/54930 but I don't know how to reproduce the issue.

cc @barche, @staticfloat, @vtjnash 