### PR TITLE
change back an `eachindex` to `1:length` where it made more sense

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -978,7 +978,7 @@ end
 
 Return an array with element type `T` (default `Int`) of the digits of `n` in the given
 base, optionally padded with zeros to a specified size. More significant digits are at
-higher indices, such that `n == sum(digits[k]*base^(k-1) for k in eachindex(digits))`.
+higher indices, such that `n == sum(digits[k]*base^(k-1) for k in 1:length(digits))`.
 
 See also [`ndigits`](@ref), [`digits!`](@ref),
 and for base 2 also [`bitstring`](@ref), [`count_ones`](@ref).


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/55137/files/53345774673eecabc0aa015fb9e228c256bdff73#diff-abc81972c168887f1ef7dcd20d5faa41849209524dab40b8d42f7ead3dc84c46