### PR TITLE
Clarify/improve the FieldError docstring

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1673,7 +1673,7 @@ ErrorException
 """
     FieldError(type::DataType, field::Symbol)
 
-An operation tried to access invalid `field` of `type`.
+An operation tried to access invalid field `field` on an object of type `type`.
 
 !!! compat "Julia 1.12"
     Prior to Julia 1.12, invalid field access threw an [`ErrorException`](@ref)

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1673,7 +1673,7 @@ ErrorException
 """
     FieldError(type::DataType, field::Symbol)
 
-An operation tried to access invalid field `field` on an object of type `type`.
+An operation tried to access invalid `field` on an object of `type`.
 
 !!! compat "Julia 1.12"
     Prior to Julia 1.12, invalid field access threw an [`ErrorException`](@ref)


### PR DESCRIPTION
The docstring is very short, a few extra words won't hurt readability as much as they help clarity.