### PR TITLE
InteractiveUtils: add `@repeat`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -150,6 +150,8 @@ Standard library changes
 #### DelimitedFiles
 
 #### InteractiveUtils
+- New `@repeat` macro for repeating a call either a number of times, or indefinitely, or while a given
+  expression returns `true`. i.e. `@time @repeat 1000 foo()`, `@repeat rand() > 0.5 foo()` ([#...])
 
 Deprecated or removed
 ---------------------

--- a/stdlib/InteractiveUtils/docs/src/index.md
+++ b/stdlib/InteractiveUtils/docs/src/index.md
@@ -34,4 +34,5 @@ InteractiveUtils.code_native
 InteractiveUtils.@code_native
 InteractiveUtils.@time_imports
 InteractiveUtils.clipboard
+InteractiveUtils.@repeat
 ```

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -11,7 +11,7 @@ Base.Experimental.@optlevel 1
 
 export apropos, edit, less, code_warntype, code_llvm, code_native, methodswith, varinfo,
     versioninfo, subtypes, supertypes, @which, @edit, @less, @functionloc, @code_warntype,
-    @code_typed, @code_lowered, @code_llvm, @code_native, @time_imports, clipboard
+    @code_typed, @code_lowered, @code_llvm, @code_native, @time_imports, clipboard, @repeat
 
 import Base.Docs.apropos
 

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -777,3 +777,16 @@ end
 @testset "Docstrings" begin
     @test isempty(Docs.undocumented_names(InteractiveUtils))
 end
+
+@testset "@repeat" begin
+    counter = 0
+    @repeat 3 counter += 1
+    @test counter == 3
+
+    counter = 0
+    @repeat counter < 5 counter += 1
+    @test counter == 5
+
+    # cannot test because we cannot interrupt the infinite loop
+    # @repeat counter += 1
+end


### PR DESCRIPTION
Redo of https://github.com/JuliaLang/julia/pull/41455

I've had this in my startup.jl since https://github.com/JuliaLang/julia/pull/41455 and I do think it's specifically useful in the repl. Adding it to Base was evidently an unpopular language design choice, but from experience it has utility in the repl.

I'd re-open that PR but the branch is lost and github no longer provides a way to restore it.

```julia-repl
julia> @repeat 2 println("Hello, world!")
Hello, world!
Hello, world!

julia> @time @repeat 100000000 rand()
  0.095913 seconds

julia> @profile @repeat 10000 foo()

julia> @repeat rand() > 0.5 println("I fancy my chances")

julia> 
```