### PR TITLE
refactor mallocarray_t to reflect it should carry jl_genericmemory_t

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -1009,7 +1009,7 @@ void gc_stats_big_obj(void)
             v = v->next;
         }
 
-        mallocarray_t *ma = ptls2->gc_tls.heap.mallocarrays;
+        mallocmemory_t *ma = ptls2->gc_tls.heap.mallocarrays;
         while (ma != NULL) {
             if (gc_marked(jl_astaggedvalue(ma->a)->bits.gc)) {
                 nused++;

--- a/src/gc-tls.h
+++ b/src/gc-tls.h
@@ -28,8 +28,8 @@ typedef struct {
     small_arraylist_t live_tasks;
 
     // variables for tracking malloc'd arrays
-    struct _mallocarray_t *mallocarrays;
-    struct _mallocarray_t *mafreelist;
+    struct _mallocmemory_t *mallocarrays;
+    struct _mallocmemory_t *mafreelist;
 
     // variable for tracking young (i.e. not in `GC_OLD_MARKED`/last generation) large objects
     struct _bigval_t *young_generation_of_bigvals;

--- a/src/gc.c
+++ b/src/gc.c
@@ -1069,15 +1069,15 @@ static void sweep_big(jl_ptls_t ptls) JL_NOTSAFEPOINT
 
 void jl_gc_track_malloced_genericmemory(jl_ptls_t ptls, jl_genericmemory_t *m, int isaligned){
     // This is **NOT** a GC safe point.
-    mallocarray_t *ma;
+    mallocmemory_t *ma;
     if (ptls->gc_tls.heap.mafreelist == NULL) {
-        ma = (mallocarray_t*)malloc_s(sizeof(mallocarray_t));
+        ma = (mallocmemory_t*)malloc_s(sizeof(mallocmemory_t));
     }
     else {
         ma = ptls->gc_tls.heap.mafreelist;
         ptls->gc_tls.heap.mafreelist = ma->next;
     }
-    ma->a = (jl_value_t*)((uintptr_t)m | !!isaligned);
+    ma->a = (jl_genericmemory_t*)((uintptr_t)m | !!isaligned);
     ma->next = ptls->gc_tls.heap.mallocarrays;
     ptls->gc_tls.heap.mallocarrays = ma;
 }
@@ -1193,10 +1193,10 @@ static void sweep_malloced_memory(void) JL_NOTSAFEPOINT
     for (int t_i = 0; t_i < gc_n_threads; t_i++) {
         jl_ptls_t ptls2 = gc_all_tls_states[t_i];
         if (ptls2 != NULL) {
-            mallocarray_t *ma = ptls2->gc_tls.heap.mallocarrays;
-            mallocarray_t **pma = &ptls2->gc_tls.heap.mallocarrays;
+            mallocmemory_t *ma = ptls2->gc_tls.heap.mallocarrays;
+            mallocmemory_t **pma = &ptls2->gc_tls.heap.mallocarrays;
             while (ma != NULL) {
-                mallocarray_t *nxt = ma->next;
+                mallocmemory_t *nxt = ma->next;
                 jl_value_t *a = (jl_value_t*)((uintptr_t)ma->a & ~1);
                 int bits = jl_astaggedvalue(a)->bits.gc;
                 if (gc_marked(bits)) {

--- a/src/gc.h
+++ b/src/gc.h
@@ -145,12 +145,11 @@ JL_EXTENSION typedef struct _bigval_t {
     // must be 64-byte aligned here, in 32 & 64 bit modes
 } bigval_t;
 
-// data structure for tracking malloc'd arrays and genericmemory.
-
-typedef struct _mallocarray_t {
-    jl_value_t *a;
-    struct _mallocarray_t *next;
-} mallocarray_t;
+// data structure for tracking malloc'd genericmemory.
+typedef struct _mallocmemory_t {
+    jl_genericmemory_t *a; // lowest bit is tagged if this is aligned memory
+    struct _mallocmemory_t *next;
+} mallocmemory_t;
 
 // pool page metadata
 typedef struct _jl_gc_pagemeta_t {


### PR DESCRIPTION
Seems like this `mallocarray_t` container is only carrying objects of type  `jl_genericmemory_t` after the memory work. 

Let's:

* Rename the container type to `mallocmemory_t`.
* Make the payload type a bit more strict to ensure a bit more type safety (i.e. change the `a` field from `jl_value_t *` to `jl_genericmemory_t *`).
* Add a comment to indicate the pointer tagging in the lowest bit of the payload.