### PR TITLE
add an actionable suggestion to UndefVarError

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -90,7 +90,7 @@ end
 function _UndefVarError_warnfor(io::IO, m::Module, var::Symbol)
     Base.isbindingresolved(m, var) || return false
     (Base.isexported(m, var) || Base.ispublic(m, var)) || return false
-    print(io, "\nHint: a global variable of this name also exists in $m.")
+    print(io, "\nHint: a global variable of this name also exists in `$m`. Try `$m.$var` to access it.")
     return true
 end
 


### PR DESCRIPTION
From

```julia
julia> tail
ERROR: UndefVarError: `tail` not defined in `Main`
Suggestion: check for spelling errors or missing imports.
Hint: a global variable of this name also exists in Base.
```

to

```julia
julia> tail
ERROR: UndefVarError: `tail` not defined in `Main`
Suggestion: check for spelling errors or missing imports.
Hint: a global variable of this name also exists in `Base`. Try `Base.tail` to access it.
```