### PR TITLE
Make `jl_*affinity` tests more portable

### DIFF
--- a/test/threads.jl
+++ b/test/threads.jl
@@ -357,12 +357,12 @@ end
 
 @testset "jl_*affinity" begin
     cpumasksize = @ccall uv_cpumask_size()::Cint
-    if !Sys.iswindows() && cpumasksize > 0 # otherwise affinities are not supported on the platform (UV_ENOTSUP)
-        mask = zeros(Cchar, cpumasksize);
+    if cpumasksize > 0 # otherwise affinities are not supported on the platform (UV_ENOTSUP)
         jl_getaffinity = (tid, mask, cpumasksize) -> ccall(:jl_getaffinity, Int32, (Int16, Ptr{Cchar}, Int32), tid, mask, cpumasksize)
         jl_setaffinity = (tid, mask, cpumasksize) -> ccall(:jl_setaffinity, Int32, (Int16, Ptr{Cchar}, Int32), tid, mask, cpumasksize)
-        @test jl_getaffinity(1, mask, cpumasksize) == 0
-        fill!(mask, 1)
-        @test jl_setaffinity(1, mask, cpumasksize) == 0
+        mask = zeros(Cchar, cpumasksize)
+        @test jl_getaffinity(0, mask, cpumasksize) == 0
+        @test !all(iszero, mask)
+        @test jl_setaffinity(0, mask, cpumasksize) == 0
     end
 end


### PR DESCRIPTION
Changes made:
- Use 0 for the thread ID to ensure it's always valid. The function expects `0 <= tid < jl_n_threads` so 1 is incorrect if `jl_n_threads` is 1.
- After retrieving the affinity mask with `jl_getaffinity`, pass that same mask back to `jl_setaffinity`. This ensures that the mask is always valid. Using a mask of all ones results in `EINVAL` on FreeBSD. Based on the discussion in #53402, this change may also fix Windows, so I've tried reenabling it here.
- To check whether `jl_getaffinity` actually did something, we can check that the mask is no longer all zeros after the call.

Fixes #54817