### PR TITLE
inference: Remove special case for `typename`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -2249,8 +2249,6 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
         end
         argtypes = Any[typeof(<:), argtypes[3], argtypes[2]]
         return abstract_call_known(interp, <:, ArgInfo(fargs, argtypes), si, sv, max_methods)
-    elseif la == 2 && istopfunction(f, :typename)
-        return CallMeta(typename_static(argtypes[2]), Bottom, EFFECTS_TOTAL, MethodResultPure())
     elseif f === Core._hasmethod
         return _hasmethod_tfunc(interp, argtypes, sv)
     end

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -3016,14 +3016,6 @@ function _hasmethod_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, sv
     return CallMeta(rt, Any, EFFECTS_TOTAL, NoCallInfo())
 end
 
-# N.B.: typename maps type equivalence classes to a single value
-function typename_static(@nospecialize(t))
-    t isa Const && return _typename(t.val)
-    t isa Conditional && return Bool.name
-    t = unwrap_unionall(widenconst(t))
-    return isType(t) ? _typename(t.parameters[1]) : Core.TypeName
-end
-
 function global_order_nothrow(@nospecialize(o), loading::Bool, storing::Bool)
     o isa Const || return false
     sym = o.val


### PR DESCRIPTION
This was introduced in [1] to improve constant propagation. These days this is handled via concrete eval and the special case is no longer required.

[1] https://github.com/JuliaLang/julia/commit/0292c42c9ad62ca7ca3f6375f6ef86a145deb8c6