### PR TITLE
use iszero in isinteger(::AbstractFloat)

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -42,7 +42,7 @@ it is the minimum of `maxintfloat(T)` and [`typemax(S)`](@ref).
 maxintfloat(::Type{S}, ::Type{T}) where {S<:AbstractFloat, T<:Integer} = min(maxintfloat(S), S(typemax(T)))
 maxintfloat() = maxintfloat(Float64)
 
-isinteger(x::AbstractFloat) = iszero(x - trunc(x)) # note: x == trunc(x) would fail for x=Inf
+isinteger(x::AbstractFloat) = iszero(x - trunc(x)) # note: x == trunc(x) would be incorrect for x=Inf
 
 # See rounding.jl for docstring.
 

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -42,7 +42,7 @@ it is the minimum of `maxintfloat(T)` and [`typemax(S)`](@ref).
 maxintfloat(::Type{S}, ::Type{T}) where {S<:AbstractFloat, T<:Integer} = min(maxintfloat(S), S(typemax(T)))
 maxintfloat() = maxintfloat(Float64)
 
-isinteger(x::AbstractFloat) = (x - trunc(x) == 0)
+isinteger(x::AbstractFloat) = iszero(x - trunc(x)) # note: x == trunc(x) would fail for x=Inf
 
 # See rounding.jl for docstring.
 


### PR DESCRIPTION
This is a very slight tweak to the implementation of `isinteger(::AbstractFloat)` to use `iszero` rather than `== 0`.  It shouldn't make any difference with any of the built-in floating-point types, but `iszero` might conceivably be faster for some user-defined types.

I also added a comment to indicate why it's using `iszero(x - trunc(x))` rather than `x == trunc(x)` (due to non-finite values); this code dates back to #14569 in Julia 0.5.