### PR TITLE
[CI] Run whitespace check on GitHub Actions and annotate source code

### DIFF
--- a/.github/workflows/Whitespace.yml
+++ b/.github/workflows/Whitespace.yml
@@ -1,0 +1,23 @@
+name: Whitespace
+
+permissions: {}
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  typos-check:
+    name: Check whitespace
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout the JuliaLang/julia repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Check whitespace
+        run: |
+          contrib/check-whitespace.jl

--- a/.github/workflows/Whitespace.yml
+++ b/.github/workflows/Whitespace.yml
@@ -9,13 +9,13 @@ on:
   pull_request:
 
 jobs:
-  typos-check:
+  whitespace:
     name: Check whitespace
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
       - name: Checkout the JuliaLang/julia repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           persist-credentials: false
       - name: Check whitespace

--- a/contrib/check-whitespace.jl
+++ b/contrib/check-whitespace.jl
@@ -18,6 +18,8 @@ const patterns = split("""
     *Makefile
 """)
 
+const is_gha = something(tryparse(Bool, get(ENV, "GITHUB_ACTIONS", "false")), false)
+
 # Note: `git ls-files` gives `/` as a path separator on Windows,
 #   so we just use `/` for all platforms.
 allow_tabs(path) =
@@ -63,8 +65,14 @@ function check_whitespace()
         for (path, lineno, msg) in sort!(collect(errors))
             if lineno == 0
                 println(stderr, "$path -- $msg")
+                if is_gha
+                    println(stdout, "::warning title=Whitespace check,file=", path, "::", msg)
+                end
             else
                 println(stderr, "$path:$lineno -- $msg")
+                if is_gha
+                    println(stdout, "::warning title=Whitespace check,file=", path, ",line=", lineno, "::", msg)
+                end
             end
         end
         exit(1)


### PR DESCRIPTION
There some advantages in running this on GitHub Actions (GHA) rather than Buildkite (BK):

* on GHA this task takes ~10 seconds, on BK it takes ~1 minute (job setup on BK takes way too long)
* since for this task we can use GitHub-hosted runners (which come with Julia preinstalled), we can spare BK runners from running this job.  Admittedly it's very marginal saving, but better than nothing when the queue gets long
* using GHA allows us to easily add source code annotations in PR overviews, which make it easier to quickly spot the line to fix from the GitHub web interface.  This would be doable also on BK, but slightly more annoying.  As [an example](https://github.com/giordano/julia/commit/a7725e47e245fcefd60ed02a2e492ed5a0af13e9):
  ![image](https://github.com/user-attachments/assets/8a459a61-8953-4590-980e-ff156a62701f)

If this PR is accepted, I'll remove the corresponding job from BK.