### PR TITLE
[LibCURL_jll] Upgrade to v8.9.0

### DIFF
--- a/deps/curl.mk
+++ b/deps/curl.mk
@@ -37,7 +37,7 @@ checksum-curl: $(SRCCACHE)/curl-$(CURL_VER).tar.bz2
 # Disable....almost everything
 CURL_CONFIGURE_FLAGS := $(CONFIGURE_COMMON) \
 	--without-gnutls --without-libidn2 --without-librtmp \
-	--without-nss --without-libpsl --without-libgsasl --without-fish-functions-dir \
+	--without-libpsl --without-libgsasl --without-fish-functions-dir \
 	--disable-ares --disable-manual --disable-ldap --disable-ldaps --disable-static \
 	--without-gssapi --without-brotli
 # A few things we actually enable

--- a/deps/curl.version
+++ b/deps/curl.version
@@ -3,4 +3,4 @@
 CURL_JLL_NAME := LibCURL
 
 ## source build
-CURL_VER := 8.6.0
+CURL_VER := 8.9.0


### PR DESCRIPTION
Fixes #55286 

I verified with
```
make -C deps distclean-curl configure-curl USE_BINARYBUILDER_CURL=0
```
that the from-source build can be at least configured correctly.