### PR TITLE
Patch curl so that it builds without BinaryBuilder

### DIFF
--- a/deps/curl.mk
+++ b/deps/curl.mk
@@ -37,7 +37,7 @@ checksum-curl: $(SRCCACHE)/curl-$(CURL_VER).tar.bz2
 # Disable....almost everything
 CURL_CONFIGURE_FLAGS := $(CONFIGURE_COMMON) \
 	--without-gnutls --without-libidn2 --without-librtmp \
-	--without-nss --without-libpsl --without-libgsasl --without-fish-functions-dir \
+	--without-libpsl --without-libgsasl --without-fish-functions-dir \
 	--disable-ares --disable-manual --disable-ldap --disable-ldaps --disable-static \
 	--without-gssapi --without-brotli
 # A few things we actually enable
@@ -57,7 +57,15 @@ CURL_TLS_CONFIGURE_FLAGS := --with-mbedtls=$(build_prefix)
 endif
 CURL_CONFIGURE_FLAGS += $(CURL_TLS_CONFIGURE_FLAGS)
 
-$(BUILDDIR)/curl-$(CURL_VER)/build-configured: $(SRCCACHE)/curl-$(CURL_VER)/source-extracted
+$(SRCCACHE)/curl-$(CURL_VER)/curl-8.6.0-build.patch-applied: $(SRCCACHE)/curl-$(CURL_VER)/source-extracted
+	cd $(dir $@) && \
+		patch -p1 -f < $(SRCDIR)/patches/curl-8.6.0-build.patch
+	echo 1 > $@
+
+$(SRCCACHE)/curl-$(CURL_VER)/source-patched: $(SRCCACHE)/curl-$(CURL_VER)/curl-8.6.0-build.patch-applied
+	echo 1 > $@
+
+$(BUILDDIR)/curl-$(CURL_VER)/build-configured: $(SRCCACHE)/curl-$(CURL_VER)/source-patched
 	mkdir -p $(dir $@)
 	cd $(dir $@) && \
 	$(dir $<)/configure $(CURL_CONFIGURE_FLAGS) \

--- a/deps/patches/curl-8.6.0-build.patch
+++ b/deps/patches/curl-8.6.0-build.patch
@@ -1,0 +1,23 @@
+From 5cc2b016c36aaf5a08e2feb7c068fca5bb0a8052 Mon Sep 17 00:00:00 2001
+From: Daniel Stenberg <daniel@haxx.se>
+Date: Mon, 5 Feb 2024 15:22:08 +0100
+Subject: [PATCH] md4: include strdup.h for the memdup proto
+
+Reported-by: Erik Schnetter
+Fixes #12849
+Closes #12863
+---
+ lib/md4.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/md4.c b/lib/md4.c
+index 067c211e420afd..58dd1166cf924f 100644
+--- a/lib/md4.c
++++ b/lib/md4.c
+@@ -28,6 +28,7 @@
+
+ #include <string.h>
+
++#include "strdup.h"
+ #include "curl_md4.h"
+ #include "warnless.h"


### PR DESCRIPTION
Also removes nss flag as NSS seems to have been removed from curl and I think the flag was dropped in https://github.com/curl/curl/pull/11459/files.

Fixes #55286.