### PR TITLE
expand the doc string of `Union{}`

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -3186,13 +3186,23 @@ Any
     Union{}
 
 `Union{}`, the empty [`Union`](@ref) of types, is the type that has no values. That is, it has the defining
-property `isa(x, Union{}) == false` for any `x`. `Base.Bottom` is defined as its alias and the type of `Union{}`
-is `Core.TypeofBottom`.
+property `isa(x, Union{}) == false` for any `x`. Thus it is an *empty*/*uninhabited* type.
+
+A property of `Union{}` is that it's the *bottom* type of the type system. That is, for each `T`
+such that `T isa Type`, `Union{} <: T`. Refer to the subtyping operator's documentation: [`<:`](@ref).
+
+`Base.Bottom` is defined as its alias and the type of `Union{}` is `Core.TypeofBottom`.
 
 # Examples
 ```jldoctest
 julia> isa(nothing, Union{})
 false
+
+julia> Union{} <: Union{} <: Int
+true
+
+julia> typeof(Union{}) === Core.TypeofBottom
+true
 ```
 """
 kw"Union{}", Base.Bottom

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -3198,7 +3198,7 @@ A property of `Union{}` is that it's the *bottom* type of the type system. That 
 julia> isa(nothing, Union{})
 false
 
-julia> Union{} <: Union{} <: Int
+julia> Union{} <: Int
 true
 
 julia> typeof(Union{}) === Core.TypeofBottom

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -3185,11 +3185,11 @@ Any
 """
     Union{}
 
-`Union{}`, the empty [`Union`](@ref) of types, is the type that has no values. That is, it has the defining
-property `isa(x, Union{}) == false` for any `x`. Thus it is an *empty*/*uninhabited* type.
+`Union{}`, the empty [`Union`](@ref) of types, is the *bottom* type of the type system. That is, for each
+`T::Type`, `Union{} <: T`. Also see the subtyping operator's documentation: [`<:`](@ref).
 
-A property of `Union{}` is that it's the *bottom* type of the type system. That is, for each `T::Type`,
-`Union{} <: T`. Refer to the subtyping operator's documentation: [`<:`](@ref).
+As such, `Union{}` is also an *empty*/*uninhabited* type, meaning that it has no values. That is, for each `x`,
+`isa(x, Union{}) == false`.
 
 `Base.Bottom` is defined as its alias and the type of `Union{}` is `Core.TypeofBottom`.
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -3203,6 +3203,9 @@ true
 
 julia> typeof(Union{}) === Core.TypeofBottom
 true
+
+julia> isa(Union{}, Union)
+false
 ```
 """
 kw"Union{}", Base.Bottom

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -3188,8 +3188,8 @@ Any
 `Union{}`, the empty [`Union`](@ref) of types, is the type that has no values. That is, it has the defining
 property `isa(x, Union{}) == false` for any `x`. Thus it is an *empty*/*uninhabited* type.
 
-A property of `Union{}` is that it's the *bottom* type of the type system. That is, for each `T`
-such that `T isa Type`, `Union{} <: T`. Refer to the subtyping operator's documentation: [`<:`](@ref).
+A property of `Union{}` is that it's the *bottom* type of the type system. That is, for each `T::Type`,
+`Union{} <: T`. Refer to the subtyping operator's documentation: [`<:`](@ref).
 
 `Base.Bottom` is defined as its alias and the type of `Union{}` is `Core.TypeofBottom`.
 


### PR DESCRIPTION
Give some characterizations/relevant terms from type theory.

Clarify the, previously unexplained, usage of "bottom" in names. Cross-reference the subtyping doc string.

Add an entry to the doctest, clarifying the last sentence.