### PR TITLE
inference: Allow any non-nothing source in ci_has_source for extern owner

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -1118,7 +1118,7 @@ const SOURCE_MODE_FORCE_SOURCE = 0x2
 
 function ci_has_source(code::CodeInstance)
     inf = @atomic :monotonic code.inferred
-    return isa(inf, CodeInfo) || isa(inf, String)
+    return code.owner === nothing ? (isa(inf, CodeInfo) || isa(inf, String)) : inf !== nothing
 end
 
 """


### PR DESCRIPTION
In updating DAECompiler to the new engine API, I was running some trouble, because the source it produces is not a `CodeInfo` or a `String` (which is fine because it has a non-nothing `owner`). Adjust the test to consider any non-nothing value in .inferred valid source (at least for non-nothing CI owners).