### PR TITLE
`PropertyError` similar to `FieldError`

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -46,7 +46,15 @@ setproperty!(x::Array, f::Symbol, v) = error("setfield! fields of Array should n
 getproperty(x::Tuple, f::Int) = (@inline; getfield(x, f))
 setproperty!(x::Tuple, f::Int, v) = setfield!(x, f, v) # to get a decent error
 
-getproperty(x, f::Symbol) = (@inline; getfield(x, f))
+getproperty(x, f::Symbol) = begin
+    try
+        getfield(x, f)
+    catch FieldError
+        throw(PropertyError(x, f))
+    end
+end
+
+# (@inline; getfield(x, f))
 function setproperty!(x, f::Symbol, v)
     ty = fieldtype(typeof(x), f)
     val = v isa ty ? v : convert(ty, v)

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -46,15 +46,7 @@ setproperty!(x::Array, f::Symbol, v) = error("setfield! fields of Array should n
 getproperty(x::Tuple, f::Int) = (@inline; getfield(x, f))
 setproperty!(x::Tuple, f::Int, v) = setfield!(x, f, v) # to get a decent error
 
-getproperty(x, f::Symbol) = (@inline; begin
-    try
-        getfield(x, f)
-    catch FieldError
-        throw(PropertyError(x, f))
-    end
-end)
-
-# (@inline; getfield(x, f))
+getproperty(x, f::Symbol) = (@inline; getfield(x, f))
 function setproperty!(x, f::Symbol, v)
     ty = fieldtype(typeof(x), f)
     val = v isa ty ? v : convert(ty, v)

--- a/base/Base.jl
+++ b/base/Base.jl
@@ -46,13 +46,13 @@ setproperty!(x::Array, f::Symbol, v) = error("setfield! fields of Array should n
 getproperty(x::Tuple, f::Int) = (@inline; getfield(x, f))
 setproperty!(x::Tuple, f::Int, v) = setfield!(x, f, v) # to get a decent error
 
-getproperty(x, f::Symbol) = begin
+getproperty(x, f::Symbol) = (@inline; begin
     try
         getfield(x, f)
     catch FieldError
         throw(PropertyError(x, f))
     end
-end
+end)
 
 # (@inline; getfield(x, f))
 function setproperty!(x, f::Symbol, v)

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -411,7 +411,7 @@ struct FieldError <: Exception
 end
 
 struct PropertyError <: Exception
-    obj::Any
+    type::DataType
     property::Symbol
 end
 

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -206,7 +206,7 @@ export
     InterruptException, InexactError, OutOfMemoryError, ReadOnlyMemoryError,
     OverflowError, StackOverflowError, SegmentationFault, UndefRefError, UndefVarError,
     TypeError, ArgumentError, MethodError, AssertionError, LoadError, InitError,
-    UndefKeywordError, ConcurrencyViolationError, FieldError,
+    UndefKeywordError, ConcurrencyViolationError, FieldError, PropertyError,
     # AST representation
     Expr, QuoteNode, LineNumberNode, GlobalRef,
     # object model functions
@@ -408,6 +408,11 @@ AssertionError() = AssertionError("")
 struct FieldError <: Exception
     type::DataType
     field::Symbol
+end
+
+struct PropertyError <: Exception
+    obj::Any
+    property::Symbol
 end
 
 abstract type WrappedException <: Exception end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1699,6 +1699,35 @@ Stacktrace:
 FieldError
 
 """
+    PropertyError(type::DataType, field::Symbol)
+
+An operation tried to access invalid `property` of `type`.
+
+!!! compat "Julia 1.12"
+    Prior to Julia 1.12, invalid field access threw an [`ErrorException`](@ref)
+
+See [`getfield`, `FieldError``](@ref)
+
+# Examples
+```jldoctest
+julia> struct AB
+          a::Float32
+          b::Float64
+       end
+
+julia> ab = AB(1, 3)
+AB(1.0f0, 3.0)
+
+julia> ab.c # field `c` doesn't exist
+ERROR: PropertyError: instance of `AB`` has no property `c`
+Stacktrace:
+[...]
+```
+"""
+PropertyError
+
+
+"""
     WrappedException(msg)
 
 Generic type for `Exception`s wrapping another `Exception`, such as `LoadError` and

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1706,7 +1706,7 @@ An operation tried to access invalid `property` of `type`.
 !!! compat "Julia 1.12"
     Prior to Julia 1.12, invalid field access threw an [`ErrorException`](@ref)
 
-See [`getfield`, `FieldError``](@ref)
+See [`getfield`, `getproperty`](@ref)
 
 # Examples
 ```jldoctest

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1706,7 +1706,7 @@ An operation tried to access invalid `property` of `type`.
 !!! compat "Julia 1.12"
     Prior to Julia 1.12, invalid field access threw an [`ErrorException`](@ref)
 
-See [`getfield`, `getproperty`](@ref)
+See also [`getfield`]@ref, [`getproperty`](@ref)
 
 # Examples
 ```jldoctest

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -375,7 +375,7 @@ end
 
 function showerror(io::IO, exc::PropertyError)
     @nospecialize
-    print(io, "PropertyError: instance of type `$(exc.obj |> typeof)` has no property `$(exc.property)`")
+    print(io, "PropertyError: instance of type `$(exc.type |> nameof)` has no property `$(exc.property)`")
     Base.Experimental.show_error_hints(io, exc)
 end
 
@@ -1116,9 +1116,9 @@ Experimental.register_error_hint(fielderror_hint_handler, FieldError)
 function propertyerror_hint_handler(io, exc)
     @nospecialize
     property = exc.property
-    obj = exc.obj
+    type = exc.type
     # print(io, "\nAn instance of type $(typeof(obj)) doesn't recognize property $property.\n")
-    printstyled(io, "\n$(typeof(obj)) has following properties $(propertynames(obj, true))", color=:cyan)
+    printstyled(io, "\n$(type) has following properties $(fieldnames(type))", color=:cyan)
     println(io)
 end
 

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -373,6 +373,12 @@ function showerror(io::IO, exc::FieldError)
     Base.Experimental.show_error_hints(io, exc)
 end
 
+function showerror(io::IO, exc::PropertyError)
+    @nospecialize
+    print(io, "PropertyError: type object of type `$(exc.obj |> typeof)` has no property $(exc.property)")
+    Base.Experimental.show_error_hints(io, exc)
+end
+
 striptype(::Type{T}) where {T} = T
 striptype(::Any) = nothing
 
@@ -1105,6 +1111,18 @@ function fielderror_hint_handler(io, exc)
 end
 
 Experimental.register_error_hint(fielderror_hint_handler, FieldError)
+
+# Display a hint in case the user tries to access non-member property of container type datastructures
+function propertyerror_hint_handler(io, exc)
+    @nospecialize
+    property = exc.property
+    obj = exc.obj
+    print(io, "\n An instance of type $(typeof(obj)) doesn't recognize property $property.\n")
+    printstyled(io, "$(typeof(obj)) has following properties $(propertynames(obj, true))", color=:cyan)
+    println(io)
+end
+
+Experimental.register_error_hint(propertyerror_hint_handler, PropertyError)
 
 # ExceptionStack implementation
 size(s::ExceptionStack) = size(s.stack)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -375,7 +375,7 @@ end
 
 function showerror(io::IO, exc::PropertyError)
     @nospecialize
-    print(io, "PropertyError: type object of type `$(exc.obj |> typeof)` has no property $(exc.property)")
+    print(io, "PropertyError: instance of type `$(exc.obj |> typeof)` has no property `$(exc.property)`")
     Base.Experimental.show_error_hints(io, exc)
 end
 
@@ -1117,8 +1117,8 @@ function propertyerror_hint_handler(io, exc)
     @nospecialize
     property = exc.property
     obj = exc.obj
-    print(io, "\n An instance of type $(typeof(obj)) doesn't recognize property $property.\n")
-    printstyled(io, "$(typeof(obj)) has following properties $(propertynames(obj, true))", color=:cyan)
+    # print(io, "\nAn instance of type $(typeof(obj)) doesn't recognize property $property.\n")
+    printstyled(io, "\n$(typeof(obj)) has following properties $(propertynames(obj, true))", color=:cyan)
     println(io)
 end
 

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -431,6 +431,7 @@ Base.LoadError
 Base.MethodError
 Base.MissingException
 Core.OutOfMemoryError
+Core.PropertyError
 Core.ReadOnlyMemoryError
 Core.OverflowError
 Base.ProcessFailedException

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -602,6 +602,7 @@ below all interrupt the normal flow of control.
 | [`EOFError`](@ref)            |
 | [`ErrorException`](@ref)      |
 | [`FieldError`](@ref)          |
+| [`PropertyError`](@ref)       |
 | [`InexactError`](@ref)        |
 | [`InitError`](@ref)           |
 | [`InterruptException`](@ref)  |

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4587,7 +4587,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                     assert(jl_svec_len(fn) == 1);
                     Value *typ_sym = literal_pointer_val(ctx, jl_svecref(fn, 0));
                     Value *cond = ctx.builder.CreateICmpEQ(mark_callee_rooted(ctx, typ_sym), mark_callee_rooted(ctx, boxed(ctx, fld)));
-                    emit_hasnoproperty_error_ifnot(ctx, cond, utt, fld);
+                    emit_hasnofield_error_ifnot(ctx, cond, utt, fld);
                     *ret = emit_getfield_knownidx(ctx, obj, 0, utt, order);
                     return true;
                 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -838,6 +838,13 @@ static const auto jlhasnofield_func = new JuliaFunction<>{
              PointerType::get(JuliaType::get_jlvalue_ty(C), AddressSpace::CalleeRooted)}, false); },
     get_attrs_noreturn,
 };
+static const auto jlhasnoproperty_func = new JuliaFunction<>{
+    XSTR(jl_has_no_property_error),
+    [](LLVMContext &C) { return FunctionType::get(getVoidTy(C),
+            {PointerType::get(JuliaType::get_jlvalue_ty(C), AddressSpace::CalleeRooted),
+             PointerType::get(JuliaType::get_jlvalue_ty(C), AddressSpace::CalleeRooted)}, false); },
+    get_attrs_noreturn,
+};
 static const auto jlboundserrorv_func = new JuliaFunction<TypeFnContextAndSizeT>{
     XSTR(jl_bounds_error_ints),
     [](LLVMContext &C, Type *T_size) { return FunctionType::get(getVoidTy(C),
@@ -4075,6 +4082,7 @@ static jl_llvm_functions_t
         jl_codegen_params_t &params);
 
 static void emit_hasnofield_error_ifnot(jl_codectx_t &ctx, Value *ok, jl_datatype_t *type, jl_cgval_t name);
+static void emit_hasnoproperty_error_ifnot(jl_codectx_t &ctx, Value *ok, jl_datatype_t *type, jl_cgval_t name);
 
 static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                               ArrayRef<jl_cgval_t> argv, size_t nargs, jl_value_t *rt,
@@ -4579,7 +4587,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                     assert(jl_svec_len(fn) == 1);
                     Value *typ_sym = literal_pointer_val(ctx, jl_svecref(fn, 0));
                     Value *cond = ctx.builder.CreateICmpEQ(mark_callee_rooted(ctx, typ_sym), mark_callee_rooted(ctx, boxed(ctx, fld)));
-                    emit_hasnofield_error_ifnot(ctx, cond, utt, fld);
+                    emit_hasnoproperty_error_ifnot(ctx, cond, utt, fld);
                     *ret = emit_getfield_knownidx(ctx, obj, 0, utt, order);
                     return true;
                 }
@@ -4587,7 +4595,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                     Value *index = ctx.builder.CreateCall(prepare_call(jlfieldindex_func),
                             {emit_typeof(ctx, obj, false, false), boxed(ctx, fld), ConstantInt::get(getInt32Ty(ctx.builder.getContext()), 0)});
                     Value *cond = ctx.builder.CreateICmpNE(index, ConstantInt::get(getInt32Ty(ctx.builder.getContext()), -1));
-                    emit_hasnofield_error_ifnot(ctx, cond, utt, fld);
+                    emit_hasnoproperty_error_ifnot(ctx, cond, utt, fld);
                     Value *idx2 = ctx.builder.CreateAdd(ctx.builder.CreateIntCast(index, ctx.types().T_size, false), ConstantInt::get(ctx.types().T_size, 1)); // getfield_unknown is 1 based
                     if (emit_getfield_unknownidx(ctx, ret, obj, idx2, utt, jl_false, order))
                         return true;
@@ -5418,6 +5426,22 @@ static void emit_hasnofield_error_ifnot(jl_codectx_t &ctx, Value *ok, jl_datatyp
     ctx.builder.CreateCondBr(ok, ifok, err);
     ctx.builder.SetInsertPoint(err);
     ctx.builder.CreateCall(prepare_call(jlhasnofield_func),
+                          {mark_callee_rooted(ctx, literal_pointer_val(ctx, (jl_value_t*)type)),
+                           mark_callee_rooted(ctx, boxed(ctx, name))});
+    ctx.builder.CreateUnreachable();
+    ifok->insertInto(ctx.f);
+    ctx.builder.SetInsertPoint(ifok);
+}
+
+static void emit_hasnoproperty_error_ifnot(jl_codectx_t &ctx, Value *ok, jl_datatype_t *type, jl_cgval_t name)
+{
+    ++EmittedUndefVarErrors;
+    assert(name.typ == (jl_value_t*)jl_symbol_type);
+    BasicBlock *err = BasicBlock::Create(ctx.builder.getContext(), "err", ctx.f);
+    BasicBlock *ifok = BasicBlock::Create(ctx.builder.getContext(), "ok");
+    ctx.builder.CreateCondBr(ok, ifok, err);
+    ctx.builder.SetInsertPoint(err);
+    ctx.builder.CreateCall(prepare_call(jlhasnoproperty_func),
                           {mark_callee_rooted(ctx, literal_pointer_val(ctx, (jl_value_t*)type)),
                            mark_callee_rooted(ctx, boxed(ctx, name))});
     ctx.builder.CreateUnreachable();
@@ -10035,6 +10059,7 @@ static void init_jit_functions(void)
     add_named_global(jlthrow_func, &jl_throw);
     add_named_global(jlundefvarerror_func, &jl_undefined_var_error);
     add_named_global(jlhasnofield_func, &jl_has_no_field_error);
+    add_named_global(jlhasnoproperty_func, &jl_has_no_property_error);
     add_named_global(jlboundserrorv_func, &jl_bounds_error_ints);
     add_named_global(jlboundserror_func, &jl_bounds_error_int);
     add_named_global(jlvboundserror_func, &jl_bounds_error_tuple_int);

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -1736,8 +1736,10 @@ JL_DLLEXPORT int jl_field_index(jl_datatype_t *t, jl_sym_t *fld, int err)
             }
         }
     }
-    if (err)
+    if (err == 1)
         jl_has_no_field_error(t, fld);
+    if (err == 2)
+        jl_has_no_property_error(t, fld);
     return -1;
 }
 

--- a/src/jl_exported_data.inc
+++ b/src/jl_exported_data.inc
@@ -139,6 +139,7 @@
     XX(jl_undefref_exception) \
     XX(jl_undefvarerror_type) \
     XX(jl_fielderror_type) \
+    XX(jl_propertyerror_type) \
     XX(jl_unionall_type) \
     XX(jl_uniontype_type) \
     XX(jl_upsilonnode_type) \

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -496,6 +496,7 @@
     XX(jl_undefined_var_error) \
     XX(jl_unwrap_unionall) \
     XX(jl_has_no_field_error) \
+    XX(jl_has_no_property_error) \
     XX(jl_value_ptr) \
     XX(jl_ver_is_release) \
     XX(jl_ver_major) \

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -450,7 +450,7 @@ JL_DLLEXPORT jl_value_t *jl_get_field(jl_value_t *o, const char *fld)
     jl_task_t *ct = jl_current_task;
     JL_TRY {
         jl_value_t *s = (jl_value_t*)jl_symbol(fld);
-        int i = jl_field_index((jl_datatype_t*)jl_typeof(o), (jl_sym_t*)s, 1);
+        int i = jl_field_index((jl_datatype_t*)jl_typeof(o), (jl_sym_t*)s, 2);
         v = jl_get_nth_field(o, i);
         jl_exception_clear();
     }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -3779,6 +3779,7 @@ void post_boot_hooks(void)
     jl_undefref_exception  = jl_new_struct_uninit((jl_datatype_t*)core("UndefRefError"));
     jl_undefvarerror_type  = (jl_datatype_t*)core("UndefVarError");
     jl_fielderror_type     = (jl_datatype_t*)core("FieldError");
+    jl_propertyerror_type     = (jl_datatype_t*)core("PropertyError");
     jl_atomicerror_type    = (jl_datatype_t*)core("ConcurrencyViolationError");
     jl_interrupt_exception = jl_new_struct_uninit((jl_datatype_t*)core("InterruptException"));
     jl_boundserror_type    = (jl_datatype_t*)core("BoundsError");

--- a/src/julia.h
+++ b/src/julia.h
@@ -866,6 +866,7 @@ extern JL_DLLIMPORT jl_datatype_t *jl_typeerror_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_methoderror_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_undefvarerror_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_fielderror_type JL_GLOBALLY_ROOTED;
+extern JL_DLLIMPORT jl_datatype_t *jl_propertyerror_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_atomicerror_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_missingcodeerror_type JL_GLOBALLY_ROOTED;
 extern JL_DLLIMPORT jl_datatype_t *jl_lineinfonode_type JL_GLOBALLY_ROOTED;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1999,6 +1999,7 @@ JL_DLLEXPORT void JL_NORETURN jl_type_error_rt(const char *fname,
                                                jl_value_t *got JL_MAYBE_UNROOTED);
 JL_DLLEXPORT void JL_NORETURN jl_undefined_var_error(jl_sym_t *var, jl_value_t *scope JL_MAYBE_UNROOTED);
 JL_DLLEXPORT void JL_NORETURN jl_has_no_field_error(jl_datatype_t *t, jl_sym_t *var);
+JL_DLLEXPORT void JL_NORETURN jl_has_no_property_error(jl_datatype_t *t, jl_sym_t *var);
 JL_DLLEXPORT void JL_NORETURN jl_atomic_error(char *str);
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error(jl_value_t *v JL_MAYBE_UNROOTED,
                                               jl_value_t *t JL_MAYBE_UNROOTED);

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -157,6 +157,11 @@ JL_DLLEXPORT void JL_NORETURN jl_has_no_field_error(jl_datatype_t *t, jl_sym_t *
     jl_throw(jl_new_struct(jl_fielderror_type, t, var));
 }
 
+JL_DLLEXPORT void JL_NORETURN jl_has_no_property_error(jl_datatype_t *v, jl_sym_t *var)
+{
+    jl_throw(jl_new_struct(jl_propertyerror_type, v, var));
+}
+
 JL_DLLEXPORT void JL_NORETURN jl_atomic_error(char *str) // == jl_exceptionf(jl_atomicerror_type, "%s", str)
 {
     jl_value_t *msg = jl_pchar_to_string((char*)str, strlen(str));

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -100,7 +100,7 @@ extern "C" {
 // TODO: put WeakRefs on the weak_refs list during deserialization
 // TODO: handle finalizers
 
-#define NUM_TAGS    191
+#define NUM_TAGS    192
 
 // An array of references that need to be restored from the sysimg
 // This is a manually constructed dual of the gvars array, which would be produced by codegen for Julia code, for C.
@@ -236,6 +236,7 @@ jl_value_t **const*const get_tags(void) {
         INSERT_TAG(jl_initerror_type);
         INSERT_TAG(jl_undefvarerror_type);
         INSERT_TAG(jl_fielderror_type);
+        INSERT_TAG(jl_propertyerror_type);
         INSERT_TAG(jl_stackovf_exception);
         INSERT_TAG(jl_diverror_exception);
         INSERT_TAG(jl_interrupt_exception);

--- a/stdlib/LinearAlgebra/test/bunchkaufman.jl
+++ b/stdlib/LinearAlgebra/test/bunchkaufman.jl
@@ -114,7 +114,7 @@ bimint = rand(1:5, n, 2)
                 bc1 = bunchkaufman(Symmetric(asym, uplo))
                 @test getproperty(bc1, uplo)*bc1.D*transpose(getproperty(bc1, uplo)) ≈ asym[bc1.p, bc1.p]
                 @test getproperty(bc1, uplo)*bc1.D*transpose(getproperty(bc1, uplo)) ≈ bc1.P*asym*transpose(bc1.P)
-                @test_throws FieldError bc1.Z
+                @test_throws PropertyError bc1.Z
                 @test_throws ArgumentError uplo === :L ? bc1.U : bc1.L
             end
             # test Base.iterate

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -22,7 +22,7 @@ function unary_ops_tests(a, ca, tol; n=size(a, 1))
     @test logabsdet_ca[1] ≈ logabsdet_a[1]
     @test logabsdet_ca[2] ≈ logabsdet_a[2]
     @test isposdef(ca)
-    @test_throws FieldError ca.Z
+    @test_throws PropertyError ca.Z
     @test size(ca) == size(a)
     @test Array(copy(ca)) ≈ a
     @test tr(ca) ≈ tr(a) skip=ca isa CholeskyPivoted

--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -80,7 +80,7 @@ aimg  = randn(n,n)/2
             @test eigvecs(asym_sg, ASG2) == f.vectors
             @test eigvals(f) === f.values
             @test eigvecs(f) === f.vectors
-            @test_throws FieldError f.Z
+            @test_throws PropertyError f.Z
 
             d,v = eigen(asym_sg, ASG2)
             @test d == f.values
@@ -141,7 +141,7 @@ aimg  = randn(n,n)/2
             @test f.values ≈ eigvals(a1_nsg, a2_nsg; sortby = sortfunc)
             @test prod(f.values) ≈ prod(eigvals(a1_nsg/a2_nsg, sortby = sortfunc)) atol=50000ε
             @test eigvecs(a1_nsg, a2_nsg; sortby = sortfunc) == f.vectors
-            @test_throws FieldError f.Z
+            @test_throws PropertyError f.Z
 
             g = eigen(a1_nsg, Diagonal(1:n1))
             @test a1_nsg*g.vectors ≈ (Diagonal(1:n1)*g.vectors) * Diagonal(g.values)

--- a/stdlib/LinearAlgebra/test/hessenberg.jl
+++ b/stdlib/LinearAlgebra/test/hessenberg.jl
@@ -148,7 +148,7 @@ let n = 10
         @test size(H.Q, 2) == size(A, 2)
         @test size(H.Q) == size(A)
         @test size(H) == size(A)
-        @test_throws FieldError H.Z
+        @test_throws PropertyError H.Z
         @test convert(Array, H) ≈ A
         @test (H.Q * H.H) * H.Q' ≈ A ≈ (Matrix(H.Q) * Matrix(H.H)) * Matrix(H.Q)'
         @test (H.Q' * A) * H.Q ≈ H.H

--- a/stdlib/LinearAlgebra/test/lq.jl
+++ b/stdlib/LinearAlgebra/test/lq.jl
@@ -50,7 +50,7 @@ rectangularQ(Q::LinearAlgebra.LQPackedQ) = convert(Array, Q)
                     for (ii, lq_obj) in enumerate(lqa)
                         @test ref_obs[ii] == lq_obj
                     end
-                    @test_throws FieldError lqa.Z
+                    @test_throws PropertyError lqa.Z
                     @test Array(copy(adjoint(lqa))) ≈ a'
                     @test q*squareQ(q)' ≈ Matrix(I, n, n)
                     @test l*q ≈ a

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -59,7 +59,7 @@ dimg  = randn(n)/2
     κ  = cond(a,1)
     @testset "(Automatic) Square LU decomposition" begin
         lua   = factorize(a)
-        @test_throws FieldError lua.Z
+        @test_throws PropertyError lua.Z
         l,u,p = lua.L, lua.U, lua.p
         ll,ul,pl = @inferred lu(a)
         @test ll * ul ≈ a[pl,:]
@@ -88,7 +88,7 @@ dimg  = randn(n)/2
         lud = @inferred lu(d)
         @test LinearAlgebra.issuccess(lud)
         @test @inferred(lu(lud)) == lud
-        @test_throws FieldError lud.Z
+        @test_throws PropertyError lud.Z
         @test lud.L*lud.U ≈ lud.P*Array(d)
         @test lud.L*lud.U ≈ Array(d)[lud.p,:]
         @test AbstractArray(lud) ≈ d

--- a/stdlib/LinearAlgebra/test/qr.jl
+++ b/stdlib/LinearAlgebra/test/qr.jl
@@ -50,7 +50,7 @@ rectangularQ(Q::LinearAlgebra.AbstractQ) = Matrix(Q)
             @testset "QR decomposition (without pivoting)" begin
                 qra   = @inferred qr(a)
                 q, r  = qra.Q, qra.R
-                @test_throws FieldError qra.Z
+                @test_throws PropertyError qra.Z
                 @test q'*squareQ(q) ≈ Matrix(I, a_1, a_1)
                 @test q*squareQ(q)' ≈ Matrix(I, a_1, a_1)
                 @test q'*Matrix(1.0I, a_1, a_1)' ≈ squareQ(q)'
@@ -79,7 +79,7 @@ rectangularQ(Q::LinearAlgebra.AbstractQ) = Matrix(Q)
             @testset "Thin QR decomposition (without pivoting)" begin
                 qra   = @inferred qr(a[:, 1:n1], NoPivot())
                 q,r   = qra.Q, qra.R
-                @test_throws FieldError qra.Z
+                @test_throws PropertyError qra.Z
                 @test q'*squareQ(q) ≈ Matrix(I, a_1, a_1)
                 @test q'*rectangularQ(q) ≈ Matrix(I, a_1, n1)
                 @test q*r ≈ a[:, 1:n1]
@@ -106,7 +106,7 @@ rectangularQ(Q::LinearAlgebra.AbstractQ) = Matrix(Q)
 
                 qrpa  = factorize(a[1:n1,:])
                 q,r = qrpa.Q, qrpa.R
-                @test_throws FieldError qrpa.Z
+                @test_throws PropertyError qrpa.Z
                 p = qrpa.p
                 @test q'*squareQ(q) ≈ Matrix(I, n1, n1)
                 @test q*squareQ(q)' ≈ Matrix(I, n1, n1)
@@ -134,7 +134,7 @@ rectangularQ(Q::LinearAlgebra.AbstractQ) = Matrix(Q)
             @testset "(Automatic) Thin (pivoted) QR decomposition" begin
                 qrpa  = factorize(a[:,1:n1])
                 q,r = qrpa.Q, qrpa.R
-                @test_throws FieldError qrpa.Z
+                @test_throws PropertyError qrpa.Z
                 p = qrpa.p
                 @test q'*squareQ(q) ≈ Matrix(I, a_1, a_1)
                 @test q*squareQ(q)' ≈ Matrix(I, a_1, a_1)

--- a/stdlib/LinearAlgebra/test/schur.jl
+++ b/stdlib/LinearAlgebra/test/schur.jl
@@ -33,7 +33,7 @@ aimg  = randn(n,n)/2
         @test sort(imag(f.values)) ≈ sort(imag(d))
         @test istriu(f.Schur) || eltype(a)<:Real
         @test convert(Array, f) ≈ a
-        @test_throws FieldError f.A
+        @test_throws PropertyError f.A
 
         sch, vecs, vals = schur(UpperTriangular(triu(a)))
         @test vecs*sch*vecs' ≈ triu(a)
@@ -68,7 +68,7 @@ aimg  = randn(n,n)/2
             O = ordschur(S, select)
             sum(select) != 0 && @test S.values[findall(select)] ≈ O.values[1:sum(select)]
             @test O.vectors*O.Schur*O.vectors' ≈ ordschura
-            @test_throws FieldError f.A
+            @test_throws PropertyError f.A
             Snew = LinearAlgebra.Schur(S.T, S.Z, S.values)
             SchurNew = ordschur!(copy(Snew), select)
             @test O.vectors ≈ SchurNew.vectors
@@ -88,7 +88,7 @@ aimg  = randn(n,n)/2
             @test f.Q*f.T*f.Z' ≈ a2_sf
             @test istriu(f.S) || eltype(a)<:Real
             @test istriu(f.T) || eltype(a)<:Real
-            @test_throws FieldError f.A
+            @test_throws PropertyError f.A
 
             sstring = sprint((t, s) -> show(t, "text/plain", s), f.S)
             tstring = sprint((t, s) -> show(t, "text/plain", s), f.T)

--- a/stdlib/LinearAlgebra/test/svd.jl
+++ b/stdlib/LinearAlgebra/test/svd.jl
@@ -75,7 +75,7 @@ aimg  = randn(n,n)/2
             @test usv.U * (Diagonal(usv.S) * usv.Vt) ≈ a
             @test convert(Array, usv) ≈ a
             @test usv.Vt' ≈ usv.V
-            @test_throws FieldError usv.Z
+            @test_throws PropertyError usv.Z
             b = rand(eltya,n)
             @test usv\b ≈ a\b
             @test Base.propertynames(usv) == (:U, :S, :V, :Vt)
@@ -94,7 +94,7 @@ aimg  = randn(n,n)/2
                 @test usv.U * (Diagonal(usv.S) * usv.Vt) ≈ transform(a)
                 @test convert(Array, usv) ≈ transform(a)
                 @test usv.Vt' ≈ usv.V
-                @test_throws FieldError usv.Z
+                @test_throws PropertyError usv.Z
                 b = rand(eltya,n)
                 @test usv\b ≈ transform(a)\b
             end
@@ -106,8 +106,8 @@ aimg  = randn(n,n)/2
             @test gsvd.U*gsvd.D1*gsvd.R*gsvd.Q' ≈ a
             @test gsvd.V*gsvd.D2*gsvd.R*gsvd.Q' ≈ a_svd
             @test usv.Vt' ≈ usv.V
-            @test_throws FieldError usv.Z
-            @test_throws FieldError gsvd.Z
+            @test_throws PropertyError usv.Z
+            @test_throws PropertyError gsvd.Z
             @test gsvd.vals ≈ svdvals(a,a_svd)
             α = eltya == Int ? -1 : rand(eltya)
             β = svd(α)
@@ -148,7 +148,7 @@ aimg  = randn(n,n)/2
             @test usv.U * (Diagonal(usv.S) * usv.Vt) ≈ T(asym)
             @test convert(Array, usv) ≈ T(asym)
             @test usv.Vt' ≈ usv.V
-            @test_throws FieldError usv.Z
+            @test_throws PropertyError usv.Z
             b = rand(eltya,n)
             @test usv\b ≈ T(asym)\b
         end

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -1543,7 +1543,7 @@ end
 @testset "FieldError Shim tests and Softdeprecation of @test_throws ErrorException" begin
     feexc = FEexc(nothing, nothing)
     # This is redundant regular test for FieldError
-    @test_throws FieldError feexc.c
+    @test_throws PropertyError feexc.c
     # This should raise ErrorException
     @test_throws ErrorException feexc.a = 1
     # This is test for FieldError shim and deprecation

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -859,7 +859,7 @@ foo50964(1) # Shouldn't assert!
 
 # https://github.com/JuliaLang/julia/issues/51233
 obj51233 = (1,)
-@test_throws FieldError obj51233.x
+@test_throws PropertyError obj51233.x
 
 # Very specific test for multiversioning
 if Sys.ARCH === :x86_64

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -479,7 +479,7 @@ end
 @test f15259(1,2) == (1,2,1,2)
 # check that error cases are still correct
 @eval g15259(x,y) = (a = $(Expr(:new, :A15259, :x, :y)); a.z)
-@test_throws FieldError g15259(1,1)
+@test_throws PropertyError g15259(1,1)
 @eval h15259(x,y) = (a = $(Expr(:new, :A15259, :x, :y)); getfield(a, 3))
 @test_throws BoundsError h15259(1,1)
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -1924,9 +1924,9 @@ end
 
 # issue #4526
 f4526(x) = isa(x.a, Nothing)
-@test_throws FieldError f4526(1)
-@test_throws FieldError f4526(im)
-@test_throws FieldError f4526(1+2im)
+@test_throws PropertyError f4526(1)
+@test_throws PropertyError f4526(im)
+@test_throws PropertyError f4526(1+2im)
 
 # issue #4528
 function f4528(A, B)

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -11,6 +11,7 @@ Base.Experimental.register_error_hint(Base.string_concatenation_hint_handler, Me
 Base.Experimental.register_error_hint(Base.methods_on_iterable, MethodError)
 Base.Experimental.register_error_hint(Base.nonsetable_type_hint_handler, MethodError)
 Base.Experimental.register_error_hint(Base.fielderror_hint_handler, FieldError)
+Base.Experimental.register_error_hint(Base.propertyerror_hint_handler, PropertyError)
 
 @testset "SystemError" begin
     err = try; systemerror("reason", Cint(0)); false; catch ex; ex; end::SystemError
@@ -817,13 +818,13 @@ end
 
     s = FieldFoo(1, 2)
 
-    test = @test_throws FieldError s.c
+    test = @test_throws PropertyError s.c
 
-    ex = test.value::FieldError
+    ex = test.value::PropertyError
 
     # Check error message first
     errorMsg = sprint(Base.showerror, ex)
-    @test occursin("FieldError: type FieldFoo has no field c", errorMsg)
+    @test occursin("PropertyError: instance FieldFoo has no property c", errorMsg)
 
     d = Dict(s => 1)
 
@@ -835,12 +836,12 @@ end
         end
         @test !(ex isa Type) || ex <: FieldError
     end
-    test = @test_throws FieldError d.c
+    test = @test_throws PropertyError d.c
 
-    ex = test.value::FieldError
+    ex = test.value::PropertyError
 
     errorMsg = sprint(Base.showerror, ex)
-    @test occursin("FieldError: type Dict has no field c", errorMsg)
+    @test occursin("PropertyError: instance Dict has no property c", errorMsg)
     # Check hint message
     hintExpected = "Did you mean to access dict values using key: `:c` ? Consider using indexing syntax dict[:c]\n"
     @test occursin(hintExpected, errorMsg)

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -30,13 +30,13 @@ using Base: delete
 @test (x=4, y=5, z=6)[()] == NamedTuple()
 @test (x=4, y=5, z=6)[:] == (x=4, y=5, z=6)
 @test NamedTuple()[()] == NamedTuple()
-@test_throws FieldError (x=4, y=5, z=6).a
+@test_throws PropertyError (x=4, y=5, z=6).a
 @test_throws BoundsError (a=2,)[0]
 @test_throws BoundsError (a=2,)[2]
-@test_throws FieldError (x=4, y=5, z=6)[(:a,)]
-@test_throws FieldError (x=4, y=5, z=6)[(:x, :a)]
-@test_throws FieldError (x=4, y=5, z=6)[[:a]]
-@test_throws FieldError (x=4, y=5, z=6)[[:x, :a]]
+@test_throws PropertyError (x=4, y=5, z=6)[(:a,)]
+@test_throws PropertyError (x=4, y=5, z=6)[(:x, :a)]
+@test_throws PropertyError (x=4, y=5, z=6)[[:a]]
+@test_throws PropertyError (x=4, y=5, z=6)[[:x, :a]]
 @test_throws ErrorException (x=4, y=5, z=6)[(:x, :x)]
 
 @test length(NamedTuple()) == 0
@@ -257,7 +257,7 @@ function abstr_nt_22194_2()
     a = NamedTuple[(a=1,), (b=2,)]
     return a[1].b
 end
-@test_throws FieldError abstr_nt_22194_2()
+@test_throws PropertyError abstr_nt_22194_2()
 @test Base.return_types(abstr_nt_22194_2, ()) == Any[Any]
 
 mutable struct HasAbstractNamedTuples
@@ -449,7 +449,7 @@ end
 for NT in (NamedTuple{(:a, :b), Union{}}, NamedTuple{(:a, :b), T} where T<:Union{})
     @test fieldtype(NT, 1) == Union{}
     @test fieldtype(NT, :b) == Union{}
-    @test_throws FieldError fieldtype(NT, :c)
+    @test_throws PropertyError fieldtype(NT, :c)
     @test_throws BoundsError fieldtype(NT, 0)
     @test_throws BoundsError fieldtype(NT, 3)
     @test Base.return_types((Type{NT},)) do NT; fieldtype(NT, :a); end == Any[Type{Union{}}]

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2831,7 +2831,7 @@ end
     @test a == 5
     @test b == 6
 
-    @test_throws FieldError (; a, b) = (x=1,)
+    @test_throws PropertyError (; a, b) = (x=1,)
 
     @test Meta.isexpr(Meta.@lower(begin (a, b; c) = x end), :error)
     @test Meta.isexpr(Meta.@lower(begin (a, b; c) = x, y end), :error)
@@ -2840,7 +2840,7 @@ end
     f((; a, b)) = a, b
     @test f((b=3, a=4)) == (4, 3)
     @test f((b=3, c=2, a=4)) == (4, 3)
-    @test_throws FieldError f((;))
+    @test_throws PropertyError f((;))
 
     # with type annotation
     let num, den, a, b


### PR DESCRIPTION

> This PR drafts a naive implementation for `PropertyError` similar to `FieldError` addressing #55224.
> 
> This first implementation piggybacks on `FieldError`. 
> 
> ```julia
> 
> julia> struct D
>                a::Float32
>                b::Float64
>        end
> 
> julia> d = D(1, 2)
> D(1.0f0, 2.0)
> 
> julia> d.c
> ERROR: PropertyError: instance of type `D` has no property `c`
> D has following properties (:a, :b)
> 
> Stacktrace:
>  [1] getproperty(x::D, f::Symbol)
>    @ Base ./Base.jl:53
>  [2] top-level scope
>    @ REPL[3]:1
> 
> caused by: FieldError: type D has no field c
> Stacktrace:
>  [1] getproperty(x::D, f::Symbol)
>    @ Base ./Base.jl:51
>  [2] top-level scope
>    @ REPL[3]:1
> ```
> 
> We just overload getproperties in this implementation.
> 
> https://github.com/JuliaLang/julia/pull/55298/files#diff-552535418914ef7bb1ebe851ebb5bdd5c1485570a1b4c24ffa42a8d90aa972deR49-R55
> 
> ![image](https://github.com/user-attachments/assets/24d3b1d7-41d8-44bd-8623-2b137fb5e039)
> 
> 
> 
> Since we are piggybacking on `FieldError` with try catch exceptions, this might add overhead. We can push this implementation into `jl_f_getfield` or `jl_has_no_field_error` or any other function to keep `Base.jl` code unchanged may be.
> 

---

update

`Base.jl` is unchanged now.

And `PropertyError` is duplicate of `FieldError`,nothing special, but code emission is specific to objects instead.

