### PR TITLE
avoid intermediate map allocations in multi-arg mapreduce

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -578,7 +578,7 @@ an `Int`.
 """
 Base.@propagate_inbounds newindex(arg, I::CartesianIndex) = to_index(_newindex(axes(arg), I.I))
 Base.@propagate_inbounds newindex(arg, I::Integer) = to_index(_newindex(axes(arg), (I,)))
-Base.@propagate_inbounds _newindex(ax::Tuple, I::Tuple) = (ifelse(length(ax[1]) == 1, ax[1][1], I[1]), _newindex(tail(ax), tail(I))...)
+Base.@propagate_inbounds _newindex(ax::Tuple, I::Tuple) = (ifelse(length(ax[1]) == 1, ax[1][begin], I[1]), _newindex(tail(ax), tail(I))...)
 Base.@propagate_inbounds _newindex(ax::Tuple{}, I::Tuple) = ()
 Base.@propagate_inbounds _newindex(ax::Tuple, I::Tuple{}) = (ax[1][1], _newindex(tail(ax), ())...)
 Base.@propagate_inbounds _newindex(ax::Tuple{}, I::Tuple{}) = ()


### PR DESCRIPTION
Now that the mapreduce infrastructure (mostly) supports broadcasted objects, we can use a lazy Broadcasted on array-likes instead of using an intermediate `map`. This exercises the internals more thoroughly and identifies a few more places where we need to use `::AbstractArrayOrBroadcasted` and requires an offset axis bugfix.

Fixes #38558 

<details><summary>local benchmarks</summary>

```julia-repl
julia> using BenchmarkTools

julia> function f(x, y)
           return @inbounds mapreduce(==,+,x, y)
       end
f (generic function with 1 method)

julia> function f2(x, y)
               total=0
               @inbounds for i in 1:length(x)
                       total += x[i]==y[i]
               end
               return total
       end
f2 (generic function with 1 method)

julia> x = randn(10240); y = similar(x);

julia> @btime f2(x,y)
  1.988 μs (0 allocations: 0 bytes)
0

julia> @btime f(x,y)
  2.023 μs (0 allocations: 0 bytes)
0
```
</details>

Alternative to:  #41001 (cc @mcabbott)

Fixes #53417

<details><summary>more benchmarking from 53417</summary>

```julia-repl
julia> x = randn((512,512));

julia> y = randn((512, 512));

julia> g(x) = x^2
g (generic function with 1 method)

julia> @time mapreduce(g,+,x)
  0.031427 seconds (90.73 k allocations: 4.607 MiB, 24.14% gc time, 99.23% compilation time)
262233.95257231314

julia> @time mapreduce(g,+,x)
  0.000064 seconds (1 allocation: 16 bytes)
262233.95257231314

julia> f(x,y) = x * y
f (generic function with 1 method)

julia> mapreduce(f, +, x, y);

julia> @time mapreduce(f, +, x, y);
  0.000746 seconds (3 allocations: 80 bytes)
```

</details>