### PR TITLE
Make REPL.TerminalMenus public

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -110,6 +110,8 @@ export
     LineEditREPL,
     StreamREPL
 
+public TerminalMenus
+
 import Base:
     AbstractDisplay,
     display,

--- a/stdlib/REPL/src/TerminalMenus/TerminalMenus.jl
+++ b/stdlib/REPL/src/TerminalMenus/TerminalMenus.jl
@@ -4,7 +4,7 @@
     REPL.TerminalMenus
 
 A module that contains code for displaying text mode interactive menus.
-Key exported symobls include [`REPL.TerminalMenus.RadioMenu`](@ref) and
+Key exported symbols include [`REPL.TerminalMenus.RadioMenu`](@ref) and
 [`REPL.TerminalMenus.MultiSelectMenu`](@ref).
 """
 module TerminalMenus

--- a/stdlib/REPL/src/TerminalMenus/TerminalMenus.jl
+++ b/stdlib/REPL/src/TerminalMenus/TerminalMenus.jl
@@ -1,5 +1,12 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+"""
+    REPL.TerminalMenus
+
+A module that contains code for displaying text mode interactive menus.
+Key exported symobls include [`REPL.TerminalMenus.RadioMenu`](@ref) and
+[`REPL.TerminalMenus.MultiSelectMenu`](@ref).
+"""
 module TerminalMenus
 
 using ..REPL: REPL

--- a/stdlib/REPL/src/TerminalMenus/TerminalMenus.jl
+++ b/stdlib/REPL/src/TerminalMenus/TerminalMenus.jl
@@ -30,6 +30,8 @@ export
     Pager,
     request
 
+public pick, cancel, writeline, options, numoptions, selected, header, keypress
+
 # TODO: remove in Julia 2.0
 # While not exported, AbstractMenu documented these as an extension interface
 @deprecate printMenu printmenu

--- a/stdlib/REPL/src/TerminalMenus/TerminalMenus.jl
+++ b/stdlib/REPL/src/TerminalMenus/TerminalMenus.jl
@@ -30,6 +30,7 @@ export
     Pager,
     request
 
+public Config, config, MultiSelectConfig
 public pick, cancel, writeline, options, numoptions, selected, header, keypress
 
 # TODO: remove in Julia 2.0

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -29,8 +29,6 @@ export rand!, randn!,
        randcycle, randcycle!,
        AbstractRNG, MersenneTwister, RandomDevice, TaskLocalRNG, Xoshiro
 
-public default_rng, seed!
-
 ## general definitions
 
 """

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -29,6 +29,8 @@ export rand!, randn!,
        randcycle, randcycle!,
        AbstractRNG, MersenneTwister, RandomDevice, TaskLocalRNG, Xoshiro
 
+public default_rng, seed!
+
 ## general definitions
 
 """


### PR DESCRIPTION
This makes the symbols `Random.default_rng` and `Random.seed!` public when using the Random package. These are popular symbols to use and seeing as they are mentioned in the manual, according to #51335 they should normally be public. Please also consider this for backport to the "release-1.11" branch.