### PR TITLE
Update help info for qr.jl

### DIFF
--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -417,7 +417,7 @@ true
     `qr` returns multiple types because LAPACK uses several representations
     that minimize the memory storage requirements of products of Householder
     elementary reflectors, so that the `Q` and `R` matrices can be stored
-    compactly rather as two separate dense matrices.
+    compactly rather than two separate dense matrices.
 """
 function qr(A::AbstractMatrix{T}, arg...; kwargs...) where T
     require_one_based_indexing(A)


### PR DESCRIPTION
'Rather than' seems to be the correct intent of the help info. This would mean that Julia stores the result of QR in compact form instead of (=rather than) storing in dense form.

'Rather as' would mean that Julia stores Q and R in two separate dense matrices and not in compact form.