### PR TITLE
Define parent(::GenericMemoryRef)

### DIFF
--- a/base/genericmemory.jl
+++ b/base/genericmemory.jl
@@ -71,6 +71,8 @@ size(a::GenericMemory) = (length(a),)
 
 IndexStyle(::Type{<:GenericMemory}) = IndexLinear()
 
+parent(ref::GenericMemoryRef) = ref.mem
+
 pointer(mem::GenericMemoryRef) = unsafe_convert(Ptr{Cvoid}, mem) # no bounds check, even for empty array
 
 _unsetindex!(A::Memory, i::Int) =  (@_propagate_inbounds_meta; _unsetindex!(memoryref(A, i)); A)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -3246,3 +3246,9 @@ end
     @test size(mem, 2) == 1
     @test size(mem, 0x2) == 1
 end
+
+@testset "MemoryRef" begin
+    mem = Memory{Float32}(undef, 3)
+    ref = memoryref(mem, 2)
+    @test parent(ref) === mem
+end


### PR DESCRIPTION
It would be nice to have function to extract the `GenericMemory` underlying the `GenericMemoryRef`, without accessing its undocumented field `.mem`. I'm not sure `parent` is the right function for this, but it's the best I could think of.