### PR TITLE
Profile: Fix stdlib paths

### DIFF
--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -738,16 +738,16 @@ void *mach_profile_listener(void *arg)
 #endif
                 jl_ptls_t ptls = jl_atomic_load_relaxed(&jl_all_tls_states)[i];
 
-                // store threadid but add 1 as 0 is preserved to indicate end of block
+                // META_OFFSET_THREADID store threadid but add 1 as 0 is preserved to indicate end of block
                 bt_data_prof[bt_size_cur++].uintptr = ptls->tid + 1;
 
-                // store task id (never null)
+                // META_OFFSET_TASKID store task id (never null)
                 bt_data_prof[bt_size_cur++].jlvalue = (jl_value_t*)jl_atomic_load_relaxed(&ptls->current_task);
 
-                // store cpu cycle clock
+                // META_OFFSET_CPUCYCLECLOCK store cpu cycle clock
                 bt_data_prof[bt_size_cur++].uintptr = cycleclock();
 
-                // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
+                // META_OFFSET_SLEEPSTATE store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
                 bt_data_prof[bt_size_cur++].uintptr = jl_atomic_load_relaxed(&ptls->sleep_check_state) + 1;
 
                 // Mark the end of this block with two 0's

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -965,16 +965,16 @@ static void *signal_listener(void *arg)
 
                         jl_ptls_t ptls2 = jl_atomic_load_relaxed(&jl_all_tls_states)[i];
 
-                        // store threadid but add 1 as 0 is preserved to indicate end of block
+                        // META_OFFSET_THREADID store threadid but add 1 as 0 is preserved to indicate end of block
                         bt_data_prof[bt_size_cur++].uintptr = ptls2->tid + 1;
 
-                        // store task id (never null)
+                        // META_OFFSET_TASKID store task id (never null)
                         bt_data_prof[bt_size_cur++].jlvalue = (jl_value_t*)jl_atomic_load_relaxed(&ptls2->current_task);
 
-                        // store cpu cycle clock
+                        // META_OFFSET_CPUCYCLECLOCK store cpu cycle clock
                         bt_data_prof[bt_size_cur++].uintptr = cycleclock();
 
-                        // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
+                        // META_OFFSET_SLEEPSTATE store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
                         bt_data_prof[bt_size_cur++].uintptr = jl_atomic_load_relaxed(&ptls2->sleep_check_state) + 1;
 
                         // Mark the end of this block with two 0's

--- a/src/signals-win.c
+++ b/src/signals-win.c
@@ -421,16 +421,16 @@ static DWORD WINAPI profile_bt( LPVOID lparam )
 
                 jl_ptls_t ptls = jl_atomic_load_relaxed(&jl_all_tls_states)[0]; // given only profiling hMainThread
 
-                // store threadid but add 1 as 0 is preserved to indicate end of block
+                // META_OFFSET_THREADID store threadid but add 1 as 0 is preserved to indicate end of block
                 bt_data_prof[bt_size_cur++].uintptr = ptls->tid + 1;
 
-                // store task id (never null)
+                // META_OFFSET_TASKID store task id (never null)
                 bt_data_prof[bt_size_cur++].jlvalue = (jl_value_t*)jl_atomic_load_relaxed(&ptls->current_task);
 
-                // store cpu cycle clock
+                // META_OFFSET_CPUCYCLECLOCK store cpu cycle clock
                 bt_data_prof[bt_size_cur++].uintptr = cycleclock();
 
-                // store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
+                // META_OFFSET_SLEEPSTATE store whether thread is sleeping but add 1 as 0 is preserved to indicate end of block
                 bt_data_prof[bt_size_cur++].uintptr = jl_atomic_load_relaxed(&ptls->sleep_check_state) + 1;
 
                 // Mark the end of this block with two 0's

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -505,7 +505,7 @@ end
 # based on the package ecosystem
 function short_path(spath::Symbol, filenamecache::Dict{Symbol, String})
     return get!(filenamecache, spath) do
-        path = string(spath)
+        path = Base.fixup_stdlib_path(string(spath))
         if isabspath(path)
             if ispath(path)
                 # try to replace the file-system prefix with a short "@Module" one,

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -681,7 +681,7 @@ function add_fake_meta(data; threadid = 1, taskid = 0xf0f0f0f0)
     for i = 1:length(data)
         val = data[i]
         if iszero(val)
-            # (threadid, taskid, cpu_cycle_clock, thread_sleeping)
+            # META_OFFSET_THREADID, META_OFFSET_TASKID, META_OFFSET_CPUCYCLECLOCK, META_OFFSET_SLEEPSTATE
             push!(data_with_meta, threadid, taskid, cpu_clock_cycle+=1, false+1, 0, 0)
         else
             push!(data_with_meta, val)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/55324

[`6870410` (#55327)](https://github.com/JuliaLang/julia/pull/55327/commits/68704100415ee4b296c21e694f6387e243ed5776) is the actual fix, the other is just comments I keep meaning to add.

Confirmed by redefining this function into the juliaup built nightly
```
julia> Profile.print()
Overhead ╎ [+additional indent] Count File:Line; Function
=========================================================
     ╎34    @Base/client.jl:561; _start()
     ╎ 34    @Base/client.jl:586; repl_main
     ╎  34    @Base/client.jl:504; run_main_repl(interactive::Bool, quiet::Bool, banner::Symbol, history_file::Bool)
     ╎   34    @Base/essentials.jl:1042; invokelatest
     ╎    34    @Base/essentials.jl:1045; #invokelatest#2
     ╎     34    @Base/client.jl:483; run_std_repl(REPL::Module, quiet::Bool, banner::Symbol, history_file::Bool)
     ╎    ╎ 34    @REPL/src/REPL.jl:620; run_repl(repl::REPL.AbstractREPL, consumer::Any)
     ╎    ╎  34    @REPL/src/REPL.jl:634; run_repl(repl::REPL.AbstractREPL, consumer::Any; backend_on_current_task::Bool, backend::Any)
     ╎    ╎   34    @REPL/src/REPL.jl:468; start_repl_backend
     ╎    ╎    34    @REPL/src/REPL.jl:471; start_repl_backend(backend::REPL.REPLBackend, consumer::Any; get_module::Function)
     ╎    ╎     34    @REPL/src/REPL.jl:486; repl_backend_loop(backend::REPL.REPLBackend, get_module::Function)
     ╎    ╎    ╎ 34    @REPL/src/REPL.jl:374; eval_user_input(ast::Any, backend::REPL.REPLBackend, mod::Module)
     ╎    ╎    ╎  34    @REPL/src/REPL.jl:349; toplevel_eval_with_hooks
     ╎    ╎    ╎   34    @REPL/src/REPL.jl:356; toplevel_eval_with_hooks(mod::Module, ast::Any, toplevel_file::Any, toplevel_line::Any)
     ╎    ╎    ╎    34    @REPL/src/REPL.jl:352; toplevel_eval_with_hooks(mod::Module, ast::Any, toplevel_file::Any, toplevel_line::Any)
     ╎    ╎    ╎     34    @REPL/src/REPL.jl:345; __repl_entry_eval_expanded_with_loc(mod::Module, ast::Any, toplevel_file::Ref{Ptr{UInt8}}, toplevel_line::Ref{Int32})
...
```