### PR TITLE
Profile.print: color Base/Core & packages. Make paths clickable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -138,6 +138,9 @@ Standard library changes
 * `Profile.take_heap_snapshot` takes a new keyword argument, `redact_data::Bool`,
   that is `true` by default. When set, the contents of Julia objects are not emitted
   in the heap snapshot. This currently only applies to strings. ([#55326])
+* `Profile.print()` now colors Base/Core/Package modules similarly to how they are in stacktraces.
+  Also paths, even if truncated, are now clickable in terminals that support URI links
+  to take you to the specified `JULIA_EDITOR` for the given file & line number. ([#55335])
 
 #### Random
 

--- a/stdlib/Manifest.toml
+++ b/stdlib/Manifest.toml
@@ -68,12 +68,12 @@ version = "1.11.0"
 [[deps.JuliaSyntaxHighlighting]]
 deps = ["StyledStrings"]
 uuid = "dc6e5ff7-fb65-4e79-a425-ec3bc9c03011"
-version = "1.11.0"
+version = "1.12.0"
 
 [[deps.LLD_jll]]
 deps = ["Artifacts", "Libdl", "Zlib_jll", "libLLVM_jll"]
 uuid = "d55e3150-da41-5e91-b323-ecfd1eec6109"
-version = "16.0.6+4"
+version = "18.1.7+2"
 
 [[deps.LLVMLibUnwind_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -113,12 +113,12 @@ version = "1.11.0+1"
 [[deps.LibUV_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "183b4373-6708-53ba-ad28-60e28bb38547"
-version = "2.0.1+16"
+version = "2.0.1+17"
 
 [[deps.LibUnwind_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "745a5e78-f969-53e9-954f-d19f2f74f4e3"
-version = "1.8.1+0"
+version = "1.8.1+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -163,7 +163,7 @@ version = "1.2.0"
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.26+2"
+version = "0.3.28+2"
 
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -223,7 +223,7 @@ version = "1.11.0"
 [[deps.SparseArrays]]
 deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-version = "1.11.0"
+version = "1.12.0"
 
 [[deps.Statistics]]
 deps = ["LinearAlgebra"]
@@ -242,7 +242,7 @@ version = "1.11.0"
 [[deps.SuiteSparse_jll]]
 deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
 uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
-version = "7.7.0+0"
+version = "7.8.0+0"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -281,12 +281,12 @@ version = "2.2.5+0"
 [[deps.libLLVM_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8f36deef-c2a5-5394-99ed-8e07531fb29a"
-version = "16.0.6+4"
+version = "18.1.7+2"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.8.0+1"
+version = "5.11.0+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/stdlib/Manifest.toml
+++ b/stdlib/Manifest.toml
@@ -190,6 +190,7 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 version = "1.11.0"
 
 [[deps.Profile]]
+deps = ["StyledStrings"]
 uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 version = "1.11.0"
 

--- a/stdlib/Profile/Project.toml
+++ b/stdlib/Profile/Project.toml
@@ -2,6 +2,12 @@ name = "Profile"
 uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 version = "1.11.0"
 
+[deps]
+StyledStrings = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+
+[compat]
+StyledStrings = "1.11.0"
+
 [extras]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -321,7 +321,7 @@ end
 function flat(io::IO, data::Vector{Alloc}, cols::Int, fmt::ProfileFormat)
     fmt.combine || error(ArgumentError("combine=false"))
     lilist, n, m, totalbytes = parse_flat(fmt.combine ? StackFrame : UInt64, data, fmt.C)
-    filenamemap = Dict{Symbol,String}()
+    filenamemap = Dict{Symbol,Tuple{String,String}}()
     if isempty(lilist)
         warning_empty()
         return true

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -321,7 +321,7 @@ end
 function flat(io::IO, data::Vector{Alloc}, cols::Int, fmt::ProfileFormat)
     fmt.combine || error(ArgumentError("combine=false"))
     lilist, n, m, totalbytes = parse_flat(fmt.combine ? StackFrame : UInt64, data, fmt.C)
-    filenamemap = FileNameMap()
+    filenamemap = Profile.FileNameMap()
     if isempty(lilist)
         warning_empty()
         return true

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -321,7 +321,7 @@ end
 function flat(io::IO, data::Vector{Alloc}, cols::Int, fmt::ProfileFormat)
     fmt.combine || error(ArgumentError("combine=false"))
     lilist, n, m, totalbytes = parse_flat(fmt.combine ? StackFrame : UInt64, data, fmt.C)
-    filenamemap = Dict{Symbol,Tuple{String,String}}()
+    filenamemap = FileNameMap()
     if isempty(lilist)
         warning_empty()
         return true

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -65,7 +65,7 @@ end
 
 # An internal function called to show the report after an information request (SIGINFO or SIGUSR1).
 function _peek_report()
-    iob = IOBuffer()
+    iob = Base.AnnotatedIOBuffer()
     ioc = IOContext(IOContext(iob, stderr), :displaysize=>displaysize(stderr))
     print(ioc, groupby = [:thread, :task])
     Base.print(stderr, read(seekstart(iob), AnnotatedString))

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -876,7 +876,7 @@ function print_flat(io::IO, lilist::Vector{StackFrame},
             isempty(file) && (file = "[unknown file]")
             pkgcolor = get!(() -> popfirst!(Base.STACKTRACE_MODULECOLORS), PACKAGE_FIXEDCOLORS, pkgname)
             Base.printstyled(io, pkgname, color=pkgcolor)
-            file_trunc = ltruncate(file, wfile)
+            file_trunc = ltruncate(file, max(1, wfile))
             wpad = wfile - textwidth(pkgname)
             if !isempty(pkgname) && !startswith(file_trunc, "/")
                 Base.print(io, "/")
@@ -980,7 +980,7 @@ function tree_format(frames::Vector{<:StackFrameTree}, level::Int, cols::Int, ma
                         fname)
                 end
                 pkgcolor = get!(() -> popfirst!(Base.STACKTRACE_MODULECOLORS), PACKAGE_FIXEDCOLORS, pkgname)
-                remaining_path = ltruncate(filename, widthfile - textwidth(pkgname) - 1)
+                remaining_path = ltruncate(filename, max(1, widthfile - textwidth(pkgname) - 1))
                 linenum = li.line == -1 ? "?" : string(li.line)
                 slash = (!isempty(pkgname) && !startswith(remaining_path, "/")) ? "/" : ""
                 styled_path = styled"{$pkgcolor:$pkgname}$slash$remaining_path:$linenum"

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -813,7 +813,7 @@ function print_flat(io::IO, lilist::Vector{StackFrame},
     for i in eachindex(lilist)
         li = lilist[i]
         maxline = max(maxline, li.line)
-        maxfunc = max(maxfunc, length(funcnames[i]))
+        maxfunc = max(maxfunc, textwidth(funcnames[i]))
         maxfile = max(maxfile, sum(textwidth, pkgnames_filenames[i]) + 1)
     end
     wline = max(5, ndigits(maxline))
@@ -945,7 +945,7 @@ function tree_format(frames::Vector{<:StackFrameTree}, level::Int, cols::Int, ma
                         fname)
                 end
                 pkgcolor = get!(() -> popfirst!(Base.STACKTRACE_MODULECOLORS), PACKAGE_FIXEDCOLORS, pkgname)
-                remaining_path = ltruncate(filename, widthfile - length(pkgname) - 1)
+                remaining_path = ltruncate(filename, widthfile - textwidth(pkgname) - 1)
                 strs[i] = Base.annotatedstring(stroverhead, "╎", base, strcount, " ",
                     styled"{$pkgcolor:$pkgname}",
                     !isempty(pkgname) && !startswith(remaining_path, "/") ? "/" : "",

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -679,7 +679,7 @@ function add_fake_meta(data; threadid = 1, taskid = 0xf0f0f0f0)
     !isempty(data) && has_meta(data) && error("input already has metadata")
     cpu_clock_cycle = UInt64(99)
     data_with_meta = similar(data, 0)
-    for i = 1:length(data)
+    for i in eachindex(data)
         val = data[i]
         if iszero(val)
             # META_OFFSET_THREADID, META_OFFSET_TASKID, META_OFFSET_CPUCYCLECLOCK, META_OFFSET_SLEEPSTATE
@@ -810,7 +810,7 @@ function print_flat(io::IO, lilist::Vector{StackFrame},
     maxline = 1
     maxfile = 6
     maxfunc = 10
-    for i in 1:length(lilist)
+    for i in eachindex(lilist)
         li = lilist[i]
         maxline = max(maxline, li.line)
         maxfunc = max(maxfunc, length(funcnames[i]))
@@ -830,7 +830,7 @@ function print_flat(io::IO, lilist::Vector{StackFrame},
             rpad("File", wfile, " "), " ", lpad("Line", wline, " "), " Function")
     println(io, lpad("=====", wcounts, " "), " ", lpad("========", wself, " "), " ",
             rpad("====", wfile, " "), " ", lpad("====", wline, " "), " ========")
-    for i = 1:length(n)
+    for i in eachindex(n)
         n[i] < fmt.mincount && continue
         li = lilist[i]
         Base.print(io, lpad(string(n[i]), wcounts, " "), " ")
@@ -915,7 +915,7 @@ function tree_format(frames::Vector{<:StackFrameTree}, level::Int, cols::Int, ma
         nindent -= ndigits(nextra) + 2
         showextra = true
     end
-    for i = 1:length(frames)
+    for i in eachindex(frames)
         frame = frames[i]
         li = frame.frame
         stroverhead = lpad(frame.overhead > 0 ? string(frame.overhead) : "", ndigoverhead, " ")

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -846,7 +846,7 @@ function print_flat(io::IO, lilist::Vector{StackFrame},
             isempty(file) && (file = "[unknown file]")
             pkgcolor = get!(() -> popfirst!(Base.STACKTRACE_MODULECOLORS), PACKAGE_FIXEDCOLORS, pkgname)
             Base.printstyled(io, pkgname, color=pkgcolor)
-            file_trunc = rtruncto(file, wfile)
+            file_trunc = ltruncate(file, wfile)
             wpad = wfile - textwidth(pkgname)
             if !isempty(pkgname) && !startswith(file_trunc, "/")
                 Base.print(io, "/")
@@ -859,7 +859,7 @@ function print_flat(io::IO, lilist::Vector{StackFrame},
                 fname = sprint(show_spec_linfo, li)
             end
             isempty(fname) && (fname = "[unknown function]")
-            Base.print(io, ltruncto(fname, wfunc))
+            Base.print(io, rtruncate(fname, wfunc))
         end
         println(io)
     end
@@ -945,7 +945,7 @@ function tree_format(frames::Vector{<:StackFrameTree}, level::Int, cols::Int, ma
                         fname)
                 end
                 pkgcolor = get!(() -> popfirst!(Base.STACKTRACE_MODULECOLORS), PACKAGE_FIXEDCOLORS, pkgname)
-                remaining_path = rtruncto(filename, widthfile - length(pkgname) - 1)
+                remaining_path = ltruncate(filename, widthfile - length(pkgname) - 1)
                 strs[i] = Base.annotatedstring(stroverhead, "╎", base, strcount, " ",
                     styled"{$pkgcolor:$pkgname}",
                     !isempty(pkgname) && !startswith(remaining_path, "/") ? "/" : "",
@@ -958,7 +958,7 @@ function tree_format(frames::Vector{<:StackFrameTree}, level::Int, cols::Int, ma
         else
             strs[i] = string(stroverhead, "╎", base, strcount, " [unknown stackframe]")
         end
-        strs[i] = ltruncto(strs[i], cols)
+        strs[i] = rtruncate(strs[i], cols)
     end
     return strs
 end
@@ -1212,37 +1212,7 @@ function callersf(matchfunc::Function, bt::Vector, lidict::LineInfoFlatDict)
     return [(v[i], k[i]) for i in p]
 end
 
-# Utilities
-function rtruncto(str::AbstractString, w::Int, replace_str::AbstractString = "…")
-    if textwidth(str) <= w
-        return str
-    else
-        i, acclen = firstindex(str), textwidth(replace_str)
-        while acclen + textwidth(str[i]) <= w && i < lastindex(str)
-            acclen += textwidth(str[i])
-            i = nextind(str, i)
-        end
-        return str[firstindex(str):prevind(str, i)] * replace_str
-    end
-end
-
-function ltruncto(str::AbstractString, w::Int, replace_str::AbstractString = "…")
-    if textwidth(str) <= w
-        return str
-    else
-        i, acclen = lastindex(str), textwidth(replace_str)
-        while acclen + textwidth(str[i]) <= w && i > firstindex(str)
-            acclen += textwidth(str[i])
-            i = prevind(str, i)
-        end
-        return replace_str * str[nextind(str, i):lastindex(str)]
-    end
-end
-
-
-
-
-truncto(str::Symbol, w::Int) = truncto(string(str), w)
+## Utilities
 
 # Order alphabetically (file, function) and then by line number
 function liperm(lilist::Vector{StackFrame})

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -990,7 +990,10 @@ function tree_format(frames::Vector{<:StackFrameTree}, level::Int, cols::Int, ma
                     link = editor_link(path, li.line)
                     styled"{link=$link:$styled_path}"
                 end
-                strs[i] = Base.annotatedstring(stroverhead, "╎", base, strcount, " ", rich_file, "; $fname")
+                strs[i] = Base.annotatedstring(stroverhead, "╎", base, strcount, " ", rich_file, "; ", fname)
+                if frame.overhead > 0
+                    strs[i] = styled"{bold:$(strs[i])}"
+                end
             end
         else
             strs[i] = string(stroverhead, "╎", base, strcount, " [unknown stackframe]")

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -268,7 +268,7 @@ function print(io::IO,
         end
         any_nosamples = true
         if format === :tree
-            Base.print(io, "Overhead ╎ [+additional indent] Count File:Line; Function\n")
+            Base.print(io, "Overhead ╎ [+additional indent] Count File:Line  Function\n")
             Base.print(io, "=========================================================\n")
         end
         if groupby == [:task, :thread]
@@ -990,7 +990,7 @@ function tree_format(frames::Vector{<:StackFrameTree}, level::Int, cols::Int, ma
                     link = editor_link(path, li.line)
                     styled"{link=$link:$styled_path}"
                 end
-                strs[i] = Base.annotatedstring(stroverhead, "╎", base, strcount, " ", rich_file, "; ", fname)
+                strs[i] = Base.annotatedstring(stroverhead, "╎", base, strcount, " ", rich_file, "  ", fname)
                 if frame.overhead > 0
                     strs[i] = styled"{bold:$(strs[i])}"
                 end
@@ -1160,7 +1160,7 @@ function print_tree(io::IO, bt::StackFrameTree{T}, cols::Int, fmt::ProfileFormat
     filenamemap = FileNameMap()
     worklist = [(bt, 0, 0, AnnotatedString(""))]
     if !is_subsection
-        Base.print(io, "Overhead ╎ [+additional indent] Count File:Line; Function\n")
+        Base.print(io, "Overhead ╎ [+additional indent] Count File:Line  Function\n")
         Base.print(io, "=========================================================\n")
     end
     while !isempty(worklist)


### PR DESCRIPTION
Updated
## This PR
![Screenshot 2024-09-02 at 1 47 23 PM](https://github.com/user-attachments/assets/1264e623-70b2-462a-a595-1db2985caf64)


## master
![Screenshot 2024-09-02 at 1 49 42 PM](https://github.com/user-attachments/assets/14d62fe1-c317-4df5-86e9-7c555f9ab6f1)



Todo:
- [ ] ~Maybe drop the `@` prefix when coloring it, given it's obviously special when colored~ If someone copy-pasted the profile into an issue this would make it confusing.
- [ ] Figure out why `Profile.print(format=:flat)` is truncating before the terminal width is used up
- [x] Make filepaths terminal links (even if they're truncated)
