### PR TITLE
compiler: apply more accurate effects to return_type_tfunc

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -284,7 +284,8 @@ macro _foldable_meta()
         #=:inaccessiblememonly=#true,
         #=:noub=#true,
         #=:noub_if_noinbounds=#false,
-        #=:consistent_overlay=#false))
+        #=:consistent_overlay=#false,
+        #=:no_return_type_call=#true))
 end
 
 macro inline()   Expr(:meta, :inline)   end

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -285,7 +285,7 @@ macro _foldable_meta()
         #=:noub=#true,
         #=:noub_if_noinbounds=#false,
         #=:consistent_overlay=#false,
-        #=:no_return_type_call=#true))
+        #=:nortcall=#true))
 end
 
 macro inline()   Expr(:meta, :inline)   end

--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -482,7 +482,7 @@ function cmd_gen(parsed)
     end
 end
 
-@assume_effects :effect_free :terminates_globally :noub function cmd_gen(
+@assume_effects :foldable !:consistent function cmd_gen(
     parsed::Tuple{Vararg{Tuple{Vararg{Union{String, SubString{String}}}}}}
 )
     return @invoke cmd_gen(parsed::Any)

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -980,7 +980,7 @@ function concrete_eval_eligible(interp::AbstractInterpreter,
         end
     end
     mi = result.edge
-    if mi !== nothing && is_foldable(effects)
+    if mi !== nothing && is_foldable(effects, #=check_return_type_call=#true)
         if f !== nothing && is_all_const_arg(arginfo, #=start=#2)
             if (is_nonoverlayed(interp) || is_nonoverlayed(effects) ||
                 # Even if overlay methods are involved, when `:consistent_overlay` is

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -980,7 +980,7 @@ function concrete_eval_eligible(interp::AbstractInterpreter,
         end
     end
     mi = result.edge
-    if mi !== nothing && is_foldable(effects, #=check_return_type_call=#true)
+    if mi !== nothing && is_foldable(effects, #=check_rtcall=#true)
         if f !== nothing && is_all_const_arg(arginfo, #=start=#2)
             if (is_nonoverlayed(interp) || is_nonoverlayed(effects) ||
                 # Even if overlay methods are involved, when `:consistent_overlay` is
@@ -2910,8 +2910,9 @@ function override_effects(effects::Effects, override::EffectsOverride)
         notaskstate = override.notaskstate ? true : effects.notaskstate,
         inaccessiblememonly = override.inaccessiblememonly ? ALWAYS_TRUE : effects.inaccessiblememonly,
         noub = override.noub ? ALWAYS_TRUE :
-               (override.noub_if_noinbounds && effects.noub !== ALWAYS_TRUE) ? NOUB_IF_NOINBOUNDS :
-               effects.noub)
+            (override.noub_if_noinbounds && effects.noub !== ALWAYS_TRUE) ? NOUB_IF_NOINBOUNDS :
+            effects.noub,
+        nortcall = override.nortcall ? true : effects.nortcall)
 end
 
 isdefined_globalref(g::GlobalRef) = !iszero(ccall(:jl_globalref_boundp, Cint, (Any,), g))

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -49,10 +49,11 @@ struct EffectsOverride
     noub::Bool
     noub_if_noinbounds::Bool
     consistent_overlay::Bool
+    no_return_type_call::Bool
 end
 function EffectsOverride(
     override::EffectsOverride =
-        EffectsOverride(false, false, false, false, false, false, false, false, false, false);
+        EffectsOverride(false, false, false, false, false, false, false, false, false, false, false);
     consistent::Bool = override.consistent,
     effect_free::Bool = override.effect_free,
     nothrow::Bool = override.nothrow,
@@ -62,7 +63,8 @@ function EffectsOverride(
     inaccessiblememonly::Bool = override.inaccessiblememonly,
     noub::Bool = override.noub,
     noub_if_noinbounds::Bool = override.noub_if_noinbounds,
-    consistent_overlay::Bool = override.consistent_overlay)
+    consistent_overlay::Bool = override.consistent_overlay,
+    no_return_type_call::Bool = override.no_return_type_call)
     return EffectsOverride(
         consistent,
         effect_free,
@@ -73,9 +75,10 @@ function EffectsOverride(
         inaccessiblememonly,
         noub,
         noub_if_noinbounds,
-        consistent_overlay)
+        consistent_overlay,
+        no_return_type_call)
 end
-const NUM_EFFECTS_OVERRIDES = 10 # sync with julia.h
+const NUM_EFFECTS_OVERRIDES = 11 # sync with julia.h
 
 # essential files and libraries
 include("essentials.jl")

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -49,7 +49,7 @@ struct EffectsOverride
     noub::Bool
     noub_if_noinbounds::Bool
     consistent_overlay::Bool
-    no_return_type_call::Bool
+    nortcall::Bool
 end
 function EffectsOverride(
     override::EffectsOverride =
@@ -64,7 +64,7 @@ function EffectsOverride(
     noub::Bool = override.noub,
     noub_if_noinbounds::Bool = override.noub_if_noinbounds,
     consistent_overlay::Bool = override.consistent_overlay,
-    no_return_type_call::Bool = override.no_return_type_call)
+    nortcall::Bool = override.nortcall)
     return EffectsOverride(
         consistent,
         effect_free,
@@ -76,7 +76,7 @@ function EffectsOverride(
         noub,
         noub_if_noinbounds,
         consistent_overlay,
-        no_return_type_call)
+        nortcall)
 end
 const NUM_EFFECTS_OVERRIDES = 11 # sync with julia.h
 

--- a/base/compiler/effects.jl
+++ b/base/compiler/effects.jl
@@ -58,6 +58,9 @@ following meanings:
     methods are `:consistent` with their non-overlayed original counterparts
     (see [`Base.@assume_effects`](@ref) for the exact definition of `:consistenct`-cy).
   * `ALWAYS_FALSE`: this method may invoke overlayed methods.
+- `no_return_type_call::Bool`: this method does not call `Core.Compiler.return_type`,
+  and it is guaranteed that any other methods this method might call also do not call
+  `Core.Compiler.return_type`.
 
 Note that the representations above are just internal implementation details and thus likely
 to change in the future. See [`Base.@assume_effects`](@ref) for more detailed explanation
@@ -103,6 +106,9 @@ The output represents the state of different effect properties in the following 
     - `+o` (green): `ALWAYS_TRUE`
     - `-o` (red): `ALWAYS_FALSE`
     - `?o` (yellow): `CONSISTENT_OVERLAY`
+9. `:no_return_type_call` (`r`):
+    - `+r` (green): `true`
+    - `-r` (red): `false`
 """
 struct Effects
     consistent::UInt8
@@ -113,6 +119,7 @@ struct Effects
     inaccessiblememonly::UInt8
     noub::UInt8
     nonoverlayed::UInt8
+    no_return_type_call::Bool
     function Effects(
         consistent::UInt8,
         effect_free::UInt8,
@@ -121,7 +128,8 @@ struct Effects
         notaskstate::Bool,
         inaccessiblememonly::UInt8,
         noub::UInt8,
-        nonoverlayed::UInt8)
+        nonoverlayed::UInt8,
+        no_return_type_call::Bool)
         return new(
             consistent,
             effect_free,
@@ -130,7 +138,8 @@ struct Effects
             notaskstate,
             inaccessiblememonly,
             noub,
-            nonoverlayed)
+            nonoverlayed,
+            no_return_type_call)
     end
 end
 
@@ -160,10 +169,10 @@ const NOUB_IF_NOINBOUNDS = 0x01 << 1
 # :nonoverlayed bits
 const CONSISTENT_OVERLAY = 0x01 << 1
 
-const EFFECTS_TOTAL    = Effects(ALWAYS_TRUE,  ALWAYS_TRUE,  true,  true,  true,  ALWAYS_TRUE,  ALWAYS_TRUE,  ALWAYS_TRUE)
-const EFFECTS_THROWS   = Effects(ALWAYS_TRUE,  ALWAYS_TRUE,  false, true,  true,  ALWAYS_TRUE,  ALWAYS_TRUE,  ALWAYS_TRUE)
-const EFFECTS_UNKNOWN  = Effects(ALWAYS_FALSE, ALWAYS_FALSE, false, false, false, ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_TRUE) # unknown mostly, but it's not overlayed at least (e.g. it's not a call)
-const _EFFECTS_UNKNOWN = Effects(ALWAYS_FALSE, ALWAYS_FALSE, false, false, false, ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_FALSE) # unknown really
+const EFFECTS_TOTAL    = Effects(ALWAYS_TRUE,  ALWAYS_TRUE,  true,  true,  true,  ALWAYS_TRUE,  ALWAYS_TRUE,  ALWAYS_TRUE,  true)
+const EFFECTS_THROWS   = Effects(ALWAYS_TRUE,  ALWAYS_TRUE,  false, true,  true,  ALWAYS_TRUE,  ALWAYS_TRUE,  ALWAYS_TRUE,  true)
+const EFFECTS_UNKNOWN  = Effects(ALWAYS_FALSE, ALWAYS_FALSE, false, false, false, ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_TRUE,  false) # unknown mostly, but it's not overlayed at least (e.g. it's not a call)
+const _EFFECTS_UNKNOWN = Effects(ALWAYS_FALSE, ALWAYS_FALSE, false, false, false, ALWAYS_FALSE, ALWAYS_FALSE, ALWAYS_FALSE, false) # unknown really
 
 function Effects(effects::Effects = _EFFECTS_UNKNOWN;
     consistent::UInt8 = effects.consistent,
@@ -173,7 +182,8 @@ function Effects(effects::Effects = _EFFECTS_UNKNOWN;
     notaskstate::Bool = effects.notaskstate,
     inaccessiblememonly::UInt8 = effects.inaccessiblememonly,
     noub::UInt8 = effects.noub,
-    nonoverlayed::UInt8 = effects.nonoverlayed)
+    nonoverlayed::UInt8 = effects.nonoverlayed,
+    no_return_type_call::Bool = effects.no_return_type_call)
     return Effects(
         consistent,
         effect_free,
@@ -182,7 +192,8 @@ function Effects(effects::Effects = _EFFECTS_UNKNOWN;
         notaskstate,
         inaccessiblememonly,
         noub,
-        nonoverlayed)
+        nonoverlayed,
+        no_return_type_call)
 end
 
 function is_better_effects(new::Effects, old::Effects)
@@ -247,6 +258,11 @@ function is_better_effects(new::Effects, old::Effects)
     elseif new.nonoverlayed != old.nonoverlayed
         return false
     end
+    if new.no_return_type_call
+        any_improved |= !old.no_return_type_call
+    elseif new.no_return_type_call != old.no_return_type_call
+        return false
+    end
     return any_improved
 end
 
@@ -259,7 +275,8 @@ function merge_effects(old::Effects, new::Effects)
         merge_effectbits(old.notaskstate, new.notaskstate),
         merge_effectbits(old.inaccessiblememonly, new.inaccessiblememonly),
         merge_effectbits(old.noub, new.noub),
-        merge_effectbits(old.nonoverlayed, new.nonoverlayed))
+        merge_effectbits(old.nonoverlayed, new.nonoverlayed),
+        merge_effectbits(old.no_return_type_call, new.no_return_type_call))
 end
 
 function merge_effectbits(old::UInt8, new::UInt8)
@@ -279,16 +296,18 @@ is_inaccessiblememonly(effects::Effects) = effects.inaccessiblememonly === ALWAY
 is_noub(effects::Effects)                = effects.noub === ALWAYS_TRUE
 is_noub_if_noinbounds(effects::Effects)  = effects.noub === NOUB_IF_NOINBOUNDS
 is_nonoverlayed(effects::Effects)        = effects.nonoverlayed === ALWAYS_TRUE
+is_no_return_type_call(effects::Effects) = effects.no_return_type_call
 
 # implies `is_notaskstate` & `is_inaccessiblememonly`, but not explicitly checked here
-is_foldable(effects::Effects) =
+is_foldable(effects::Effects, check_return_type_call::Bool=false) =
     is_consistent(effects) &&
     (is_noub(effects) || is_noub_if_noinbounds(effects)) &&
     is_effect_free(effects) &&
-    is_terminates(effects)
+    is_terminates(effects) &&
+    (!check_return_type_call || is_no_return_type_call(effects))
 
-is_foldable_nothrow(effects::Effects) =
-    is_foldable(effects) &&
+is_foldable_nothrow(effects::Effects, check_return_type_call::Bool=false) =
+    is_foldable(effects, check_return_type_call) &&
     is_nothrow(effects)
 
 # TODO add `is_noub` here?
@@ -318,7 +337,8 @@ function encode_effects(e::Effects)
            ((e.notaskstate         % UInt32) << 7)  |
            ((e.inaccessiblememonly % UInt32) << 8)  |
            ((e.noub                % UInt32) << 10) |
-           ((e.nonoverlayed        % UInt32) << 12)
+           ((e.nonoverlayed        % UInt32) << 12) |
+           ((e.no_return_type_call % UInt32) << 14)
 end
 
 function decode_effects(e::UInt32)
@@ -330,7 +350,8 @@ function decode_effects(e::UInt32)
         _Bool((e >> 7) & 0x01),
         UInt8((e >> 8) & 0x03),
         UInt8((e >> 10) & 0x03),
-        UInt8((e >> 12) & 0x03))
+        UInt8((e >> 12) & 0x03),
+        _Bool((e >> 14) & 0x01))
 end
 
 function encode_effects_override(eo::EffectsOverride)
@@ -345,6 +366,7 @@ function encode_effects_override(eo::EffectsOverride)
     eo.noub                && (e |= (0x0001 << 7))
     eo.noub_if_noinbounds  && (e |= (0x0001 << 8))
     eo.consistent_overlay  && (e |= (0x0001 << 9))
+    eo.no_return_type_call && (e |= (0x0001 << 10))
     return e
 end
 
@@ -359,7 +381,8 @@ function decode_effects_override(e::UInt16)
         !iszero(e & (0x0001 << 6)),
         !iszero(e & (0x0001 << 7)),
         !iszero(e & (0x0001 << 8)),
-        !iszero(e & (0x0001 << 9)))
+        !iszero(e & (0x0001 << 9)),
+        !iszero(e & (0x0001 << 10)))
 end
 
 decode_statement_effects_override(ssaflag::UInt32) =

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -1051,7 +1051,7 @@ function Base.show(io::IO, e::Effects)
     print(io, ',')
     printstyled(io, effectbits_letter(e, :nonoverlayed, 'o'); color=effectbits_color(e, :nonoverlayed))
     print(io, ',')
-    printstyled(io, effectbits_letter(e, :no_return_type_call, 'r'); color=effectbits_color(e, :no_return_type_call))
+    printstyled(io, effectbits_letter(e, :nortcall, 'r'); color=effectbits_color(e, :nortcall))
     print(io, ')')
 end
 

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -1050,6 +1050,8 @@ function Base.show(io::IO, e::Effects)
     printstyled(io, effectbits_letter(e, :noub, 'u'); color=effectbits_color(e, :noub))
     print(io, ',')
     printstyled(io, effectbits_letter(e, :nonoverlayed, 'o'); color=effectbits_color(e, :nonoverlayed))
+    print(io, ',')
+    printstyled(io, effectbits_letter(e, :no_return_type_call, 'r'); color=effectbits_color(e, :no_return_type_call))
     print(io, ')')
 end
 

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -2871,7 +2871,7 @@ end
 # since abstract_call_gf_by_type is a very inaccurate model of _method and of typeinf_type,
 # while this assumes that it is an absolutely precise and accurate and exact model of both
 function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, si::StmtInfo, sv::AbsIntState)
-    UNKNOWN = CallMeta(Type, Any, EFFECTS_THROWS, NoCallInfo())
+    UNKNOWN = CallMeta(Type, Any, Effects(EFFECTS_THROWS, terminates=false), NoCallInfo())
     if !(2 <= length(argtypes) <= 3)
         return UNKNOWN
     end
@@ -2916,27 +2916,30 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
     end
     info = verbose_stmt_info(interp) ? MethodResultPure(ReturnTypeCallInfo(call.info)) : MethodResultPure()
     rt = widenslotwrapper(call.rt)
+    # effects are not an issue if we know this statement will get removed, but if it does not get removed,
+    # then this could be recursively re-entering inference (via concrete-eval), which will not terminate
+    effects = EFFECTS_TOTAL
     if isa(rt, Const)
         # output was computed to be constant
-        return CallMeta(Const(typeof(rt.val)), Union{}, EFFECTS_TOTAL, info)
+        return CallMeta(Const(typeof(rt.val)), Union{}, effects, info)
     end
     rt = widenconst(rt)
     if rt === Bottom || (isconcretetype(rt) && !iskindtype(rt))
         # output cannot be improved so it is known for certain
-        return CallMeta(Const(rt), Union{}, EFFECTS_TOTAL, info)
+        return CallMeta(Const(rt), Union{}, effects, info)
     elseif isa(sv, InferenceState) && !isempty(sv.pclimitations)
         # conservatively express uncertainty of this result
         # in two ways: both as being a subtype of this, and
         # because of LimitedAccuracy causes
-        return CallMeta(Type{<:rt}, Union{}, EFFECTS_TOTAL, info)
+        return CallMeta(Type{<:rt}, Union{}, Effects(effects; terminates=false), info)
     elseif isa(tt, Const) || isconstType(tt)
         # input arguments were known for certain
         # XXX: this doesn't imply we know anything about rt
-        return CallMeta(Const(rt), Union{}, EFFECTS_TOTAL, info)
+        return CallMeta(Const(rt), Union{}, effects, info)
     elseif isType(rt)
-        return CallMeta(Type{rt}, Union{}, EFFECTS_TOTAL, info)
+        return CallMeta(Type{rt}, Union{}, Effects(effects; terminates=false), info)
     else
-        return CallMeta(Type{<:rt}, Union{}, EFFECTS_TOTAL, info)
+        return CallMeta(Type{<:rt}, Union{}, Effects(effects; terminates=false), info)
     end
 end
 

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -2871,7 +2871,7 @@ end
 # since abstract_call_gf_by_type is a very inaccurate model of _method and of typeinf_type,
 # while this assumes that it is an absolutely precise and accurate and exact model of both
 function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, si::StmtInfo, sv::AbsIntState)
-    UNKNOWN = CallMeta(Type, Any, Effects(EFFECTS_THROWS, terminates=false), NoCallInfo())
+    UNKNOWN = CallMeta(Type, Any, Effects(EFFECTS_THROWS; no_return_type_call=false), NoCallInfo())
     if !(2 <= length(argtypes) <= 3)
         return UNKNOWN
     end
@@ -2899,8 +2899,12 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
         return UNKNOWN
     end
 
+    # effects are not an issue if we know this statement will get removed, but if it does not get removed,
+    # then this could be recursively re-entering inference (via concrete-eval), which will not terminate
+    RT_CALL_EFFECTS = Effects(EFFECTS_TOTAL; no_return_type_call=false)
+
     if contains_is(argtypes_vec, Union{})
-        return CallMeta(Const(Union{}), Union{}, EFFECTS_TOTAL, NoCallInfo())
+        return CallMeta(Const(Union{}), Union{}, RT_CALL_EFFECTS, NoCallInfo())
     end
 
     # Run the abstract_call without restricting abstract call
@@ -2916,30 +2920,27 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
     end
     info = verbose_stmt_info(interp) ? MethodResultPure(ReturnTypeCallInfo(call.info)) : MethodResultPure()
     rt = widenslotwrapper(call.rt)
-    # effects are not an issue if we know this statement will get removed, but if it does not get removed,
-    # then this could be recursively re-entering inference (via concrete-eval), which will not terminate
-    effects = EFFECTS_TOTAL
     if isa(rt, Const)
         # output was computed to be constant
-        return CallMeta(Const(typeof(rt.val)), Union{}, effects, info)
+        return CallMeta(Const(typeof(rt.val)), Union{}, RT_CALL_EFFECTS, info)
     end
     rt = widenconst(rt)
     if rt === Bottom || (isconcretetype(rt) && !iskindtype(rt))
         # output cannot be improved so it is known for certain
-        return CallMeta(Const(rt), Union{}, effects, info)
+        return CallMeta(Const(rt), Union{}, RT_CALL_EFFECTS, info)
     elseif isa(sv, InferenceState) && !isempty(sv.pclimitations)
         # conservatively express uncertainty of this result
         # in two ways: both as being a subtype of this, and
         # because of LimitedAccuracy causes
-        return CallMeta(Type{<:rt}, Union{}, Effects(effects; terminates=false), info)
+        return CallMeta(Type{<:rt}, Union{}, RT_CALL_EFFECTS, info)
     elseif isa(tt, Const) || isconstType(tt)
         # input arguments were known for certain
         # XXX: this doesn't imply we know anything about rt
-        return CallMeta(Const(rt), Union{}, effects, info)
+        return CallMeta(Const(rt), Union{}, RT_CALL_EFFECTS, info)
     elseif isType(rt)
-        return CallMeta(Type{rt}, Union{}, Effects(effects; terminates=false), info)
+        return CallMeta(Type{rt}, Union{}, RT_CALL_EFFECTS, info)
     else
-        return CallMeta(Type{<:rt}, Union{}, Effects(effects; terminates=false), info)
+        return CallMeta(Type{<:rt}, Union{}, RT_CALL_EFFECTS, info)
     end
 end
 

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -2871,7 +2871,7 @@ end
 # since abstract_call_gf_by_type is a very inaccurate model of _method and of typeinf_type,
 # while this assumes that it is an absolutely precise and accurate and exact model of both
 function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, si::StmtInfo, sv::AbsIntState)
-    UNKNOWN = CallMeta(Type, Any, Effects(EFFECTS_THROWS; no_return_type_call=false), NoCallInfo())
+    UNKNOWN = CallMeta(Type, Any, Effects(EFFECTS_THROWS; nortcall=false), NoCallInfo())
     if !(2 <= length(argtypes) <= 3)
         return UNKNOWN
     end
@@ -2901,7 +2901,7 @@ function return_type_tfunc(interp::AbstractInterpreter, argtypes::Vector{Any}, s
 
     # effects are not an issue if we know this statement will get removed, but if it does not get removed,
     # then this could be recursively re-entering inference (via concrete-eval), which will not terminate
-    RT_CALL_EFFECTS = Effects(EFFECTS_TOTAL; no_return_type_call=false)
+    RT_CALL_EFFECTS = Effects(EFFECTS_TOTAL; nortcall=false)
 
     if contains_is(argtypes_vec, Union{})
         return CallMeta(Const(Union{}), Union{}, RT_CALL_EFFECTS, NoCallInfo())

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -449,6 +449,9 @@ function adjust_effects(ipo_effects::Effects, def::Method)
     if is_effect_overridden(override, :consistent_overlay)
         ipo_effects = Effects(ipo_effects; nonoverlayed=CONSISTENT_OVERLAY)
     end
+    if is_effect_overridden(override, :no_return_type_call)
+        ipo_effects = Effects(ipo_effects; no_return_type_call=true)
+    end
     return ipo_effects
 end
 

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -449,8 +449,8 @@ function adjust_effects(ipo_effects::Effects, def::Method)
     if is_effect_overridden(override, :consistent_overlay)
         ipo_effects = Effects(ipo_effects; nonoverlayed=CONSISTENT_OVERLAY)
     end
-    if is_effect_overridden(override, :no_return_type_call)
-        ipo_effects = Effects(ipo_effects; no_return_type_call=true)
+    if is_effect_overridden(override, :nortcall)
+        ipo_effects = Effects(ipo_effects; nortcall=true)
     end
     return ipo_effects
 end

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -202,7 +202,8 @@ macro _total_meta()
         #=:inaccessiblememonly=#true,
         #=:noub=#true,
         #=:noub_if_noinbounds=#false,
-        #=:consistent_overlay=#false))
+        #=:consistent_overlay=#false,
+        #=:no_return_type_call=#true))
 end
 # can be used in place of `@assume_effects :foldable` (supposed to be used for bootstrapping)
 macro _foldable_meta()
@@ -216,7 +217,8 @@ macro _foldable_meta()
         #=:inaccessiblememonly=#true,
         #=:noub=#true,
         #=:noub_if_noinbounds=#false,
-        #=:consistent_overlay=#false))
+        #=:consistent_overlay=#false,
+        #=:no_return_type_call=#true))
 end
 # can be used in place of `@assume_effects :terminates_locally` (supposed to be used for bootstrapping)
 macro _terminates_locally_meta()
@@ -230,7 +232,8 @@ macro _terminates_locally_meta()
         #=:inaccessiblememonly=#false,
         #=:noub=#false,
         #=:noub_if_noinbounds=#false,
-        #=:consistent_overlay=#false))
+        #=:consistent_overlay=#false,
+        #=:no_return_type_call=#false))
 end
 # can be used in place of `@assume_effects :terminates_globally` (supposed to be used for bootstrapping)
 macro _terminates_globally_meta()
@@ -244,7 +247,8 @@ macro _terminates_globally_meta()
         #=:inaccessiblememonly=#false,
         #=:noub=#false,
         #=:noub_if_noinbounds=#false,
-        #=:consistent_overlay=#false))
+        #=:consistent_overlay=#false,
+        #=:no_return_type_call=#false))
 end
 # can be used in place of `@assume_effects :terminates_globally :notaskstate` (supposed to be used for bootstrapping)
 macro _terminates_globally_notaskstate_meta()
@@ -258,7 +262,8 @@ macro _terminates_globally_notaskstate_meta()
         #=:inaccessiblememonly=#false,
         #=:noub=#false,
         #=:noub_if_noinbounds=#false,
-        #=:consistent_overlay=#false))
+        #=:consistent_overlay=#false,
+        #=:no_return_type_call=#false))
 end
 # can be used in place of `@assume_effects :terminates_globally :noub` (supposed to be used for bootstrapping)
 macro _terminates_globally_noub_meta()
@@ -272,7 +277,8 @@ macro _terminates_globally_noub_meta()
         #=:inaccessiblememonly=#false,
         #=:noub=#true,
         #=:noub_if_noinbounds=#false,
-        #=:consistent_overlay=#false))
+        #=:consistent_overlay=#false,
+        #=:no_return_type_call=#false))
 end
 # can be used in place of `@assume_effects :effect_free :terminates_locally` (supposed to be used for bootstrapping)
 macro _effect_free_terminates_locally_meta()
@@ -286,7 +292,8 @@ macro _effect_free_terminates_locally_meta()
         #=:inaccessiblememonly=#false,
         #=:noub=#false,
         #=:noub_if_noinbounds=#false,
-        #=:consistent_overlay=#false))
+        #=:consistent_overlay=#false,
+        #=:no_return_type_call=#false))
 end
 # can be used in place of `@assume_effects :nothrow :noub` (supposed to be used for bootstrapping)
 macro _nothrow_noub_meta()
@@ -300,7 +307,8 @@ macro _nothrow_noub_meta()
         #=:inaccessiblememonly=#false,
         #=:noub=#true,
         #=:noub_if_noinbounds=#false,
-        #=:consistent_overlay=#false))
+        #=:consistent_overlay=#false,
+        #=:no_return_type_call=#false))
 end
 # can be used in place of `@assume_effects :nothrow` (supposed to be used for bootstrapping)
 macro _nothrow_meta()
@@ -314,7 +322,8 @@ macro _nothrow_meta()
         #=:inaccessiblememonly=#false,
         #=:noub=#false,
         #=:noub_if_noinbounds=#false,
-        #=:consistent_overlay=#false))
+        #=:consistent_overlay=#false,
+        #=:no_return_type_call=#false))
 end
 # can be used in place of `@assume_effects :nothrow` (supposed to be used for bootstrapping)
 macro _noub_meta()
@@ -342,7 +351,8 @@ macro _notaskstate_meta()
         #=:inaccessiblememonly=#false,
         #=:noub=#false,
         #=:noub_if_noinbounds=#false,
-        #=:consistent_overlay=#false))
+        #=:consistent_overlay=#false,
+        #=:no_return_type_call=#false))
 end
 # can be used in place of `@assume_effects :noub_if_noinbounds` (supposed to be used for bootstrapping)
 macro _noub_if_noinbounds_meta()
@@ -356,7 +366,8 @@ macro _noub_if_noinbounds_meta()
         #=:inaccessiblememonly=#false,
         #=:noub=#false,
         #=:noub_if_noinbounds=#true,
-        #=:consistent_overlay=#false))
+        #=:consistent_overlay=#false,
+        #=:no_return_type_call=#false))
 end
 
 # another version of inlining that propagates an inbounds context

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -203,7 +203,7 @@ macro _total_meta()
         #=:noub=#true,
         #=:noub_if_noinbounds=#false,
         #=:consistent_overlay=#false,
-        #=:no_return_type_call=#true))
+        #=:nortcall=#true))
 end
 # can be used in place of `@assume_effects :foldable` (supposed to be used for bootstrapping)
 macro _foldable_meta()
@@ -218,7 +218,7 @@ macro _foldable_meta()
         #=:noub=#true,
         #=:noub_if_noinbounds=#false,
         #=:consistent_overlay=#false,
-        #=:no_return_type_call=#true))
+        #=:nortcall=#true))
 end
 # can be used in place of `@assume_effects :terminates_locally` (supposed to be used for bootstrapping)
 macro _terminates_locally_meta()
@@ -233,7 +233,7 @@ macro _terminates_locally_meta()
         #=:noub=#false,
         #=:noub_if_noinbounds=#false,
         #=:consistent_overlay=#false,
-        #=:no_return_type_call=#false))
+        #=:nortcall=#false))
 end
 # can be used in place of `@assume_effects :terminates_globally` (supposed to be used for bootstrapping)
 macro _terminates_globally_meta()
@@ -248,7 +248,7 @@ macro _terminates_globally_meta()
         #=:noub=#false,
         #=:noub_if_noinbounds=#false,
         #=:consistent_overlay=#false,
-        #=:no_return_type_call=#false))
+        #=:nortcall=#false))
 end
 # can be used in place of `@assume_effects :terminates_globally :notaskstate` (supposed to be used for bootstrapping)
 macro _terminates_globally_notaskstate_meta()
@@ -263,7 +263,7 @@ macro _terminates_globally_notaskstate_meta()
         #=:noub=#false,
         #=:noub_if_noinbounds=#false,
         #=:consistent_overlay=#false,
-        #=:no_return_type_call=#false))
+        #=:nortcall=#false))
 end
 # can be used in place of `@assume_effects :terminates_globally :noub` (supposed to be used for bootstrapping)
 macro _terminates_globally_noub_meta()
@@ -278,7 +278,7 @@ macro _terminates_globally_noub_meta()
         #=:noub=#true,
         #=:noub_if_noinbounds=#false,
         #=:consistent_overlay=#false,
-        #=:no_return_type_call=#false))
+        #=:nortcall=#false))
 end
 # can be used in place of `@assume_effects :effect_free :terminates_locally` (supposed to be used for bootstrapping)
 macro _effect_free_terminates_locally_meta()
@@ -293,7 +293,7 @@ macro _effect_free_terminates_locally_meta()
         #=:noub=#false,
         #=:noub_if_noinbounds=#false,
         #=:consistent_overlay=#false,
-        #=:no_return_type_call=#false))
+        #=:nortcall=#false))
 end
 # can be used in place of `@assume_effects :nothrow :noub` (supposed to be used for bootstrapping)
 macro _nothrow_noub_meta()
@@ -308,7 +308,7 @@ macro _nothrow_noub_meta()
         #=:noub=#true,
         #=:noub_if_noinbounds=#false,
         #=:consistent_overlay=#false,
-        #=:no_return_type_call=#false))
+        #=:nortcall=#false))
 end
 # can be used in place of `@assume_effects :nothrow` (supposed to be used for bootstrapping)
 macro _nothrow_meta()
@@ -323,7 +323,7 @@ macro _nothrow_meta()
         #=:noub=#false,
         #=:noub_if_noinbounds=#false,
         #=:consistent_overlay=#false,
-        #=:no_return_type_call=#false))
+        #=:nortcall=#false))
 end
 # can be used in place of `@assume_effects :nothrow` (supposed to be used for bootstrapping)
 macro _noub_meta()
@@ -352,7 +352,7 @@ macro _notaskstate_meta()
         #=:noub=#false,
         #=:noub_if_noinbounds=#false,
         #=:consistent_overlay=#false,
-        #=:no_return_type_call=#false))
+        #=:nortcall=#false))
 end
 # can be used in place of `@assume_effects :noub_if_noinbounds` (supposed to be used for bootstrapping)
 macro _noub_if_noinbounds_meta()
@@ -367,7 +367,7 @@ macro _noub_if_noinbounds_meta()
         #=:noub=#false,
         #=:noub_if_noinbounds=#true,
         #=:consistent_overlay=#false,
-        #=:no_return_type_call=#false))
+        #=:nortcall=#false))
 end
 
 # another version of inlining that propagates an inbounds context

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -505,6 +505,7 @@ The following `setting`s are supported.
 - `:inaccessiblememonly`
 - `:noub`
 - `:noub_if_noinbounds`
+- `:no_return_type_call`
 - `:foldable`
 - `:removable`
 - `:total`
@@ -674,6 +675,20 @@ any other effect assertions (such as `:consistent` or `:effect_free`) as well, b
 not model this, and they assume the absence of undefined behavior.
 
 ---
+## `:no_return_type_call`
+
+The `:no_return_type_call` setting asserts that the method does not call `Core.Compiler.return_type`,
+and that any other methods this method might call also do not call `Core.Compiler.return_type`.
+
+!!! note
+    To be precise, this assertion can be used when a call to `Core.Compiler.return_type` is
+    not made at runtime; that is, when the result of `Core.Compiler.return_type` is known
+    exactly at compile time and the call is eliminated by the optimizer. However, since
+    whether the result of `Core.Compiler.return_type` is folded at compile time depends
+    heavily on the compiler's implementation, it is generally risky to assert this if
+    the method in question uses `Core.Compiler.return_type` in any form.
+
+---
 ## `:foldable`
 
 This setting is a convenient shortcut for the set of effects that the compiler
@@ -683,6 +698,7 @@ currently equivalent to the following `setting`s:
 - `:effect_free`
 - `:terminates_globally`
 - `:noub`
+- `:no_return_type_call`
 
 !!! note
     This list in particular does not include `:nothrow`. The compiler will still
@@ -716,6 +732,7 @@ the following other `setting`s:
 - `:notaskstate`
 - `:inaccessiblememonly`
 - `:noub`
+- `:no_return_type_call`
 
 !!! warning
     `:total` is a very strong assertion and will likely gain additional semantics
@@ -794,17 +811,17 @@ function compute_assumed_setting(override::EffectsOverride, @nospecialize(settin
     elseif setting === :noub_if_noinbounds
         return EffectsOverride(override; noub_if_noinbounds = val)
     elseif setting === :foldable
-        consistent = effect_free = terminates_globally = noub = val
-        return EffectsOverride(override; consistent, effect_free, terminates_globally, noub)
+        consistent = effect_free = terminates_globally = noub = no_return_type_call = val
+        return EffectsOverride(override; consistent, effect_free, terminates_globally, noub, no_return_type_call)
     elseif setting === :removable
         effect_free = nothrow = terminates_globally = val
         return EffectsOverride(override; effect_free, nothrow, terminates_globally)
     elseif setting === :total
         consistent = effect_free = nothrow = terminates_globally = notaskstate =
-            inaccessiblememonly = noub = val
+            inaccessiblememonly = noub = no_return_type_call = val
         return EffectsOverride(override;
             consistent, effect_free, nothrow, terminates_globally, notaskstate,
-            inaccessiblememonly, noub)
+            inaccessiblememonly, noub, no_return_type_call)
     end
     return nothing
 end

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -505,7 +505,7 @@ The following `setting`s are supported.
 - `:inaccessiblememonly`
 - `:noub`
 - `:noub_if_noinbounds`
-- `:no_return_type_call`
+- `:nortcall`
 - `:foldable`
 - `:removable`
 - `:total`
@@ -675,9 +675,9 @@ any other effect assertions (such as `:consistent` or `:effect_free`) as well, b
 not model this, and they assume the absence of undefined behavior.
 
 ---
-## `:no_return_type_call`
+## `:nortcall`
 
-The `:no_return_type_call` setting asserts that the method does not call `Core.Compiler.return_type`,
+The `:nortcall` setting asserts that the method does not call `Core.Compiler.return_type`,
 and that any other methods this method might call also do not call `Core.Compiler.return_type`.
 
 !!! note
@@ -698,7 +698,7 @@ currently equivalent to the following `setting`s:
 - `:effect_free`
 - `:terminates_globally`
 - `:noub`
-- `:no_return_type_call`
+- `:nortcall`
 
 !!! note
     This list in particular does not include `:nothrow`. The compiler will still
@@ -732,7 +732,7 @@ the following other `setting`s:
 - `:notaskstate`
 - `:inaccessiblememonly`
 - `:noub`
-- `:no_return_type_call`
+- `:nortcall`
 
 !!! warning
     `:total` is a very strong assertion and will likely gain additional semantics
@@ -811,17 +811,17 @@ function compute_assumed_setting(override::EffectsOverride, @nospecialize(settin
     elseif setting === :noub_if_noinbounds
         return EffectsOverride(override; noub_if_noinbounds = val)
     elseif setting === :foldable
-        consistent = effect_free = terminates_globally = noub = no_return_type_call = val
-        return EffectsOverride(override; consistent, effect_free, terminates_globally, noub, no_return_type_call)
+        consistent = effect_free = terminates_globally = noub = nortcall = val
+        return EffectsOverride(override; consistent, effect_free, terminates_globally, noub, nortcall)
     elseif setting === :removable
         effect_free = nothrow = terminates_globally = val
         return EffectsOverride(override; effect_free, nothrow, terminates_globally)
     elseif setting === :total
         consistent = effect_free = nothrow = terminates_globally = notaskstate =
-            inaccessiblememonly = noub = no_return_type_call = val
+            inaccessiblememonly = noub = nortcall = val
         return EffectsOverride(override;
             consistent, effect_free, nothrow, terminates_globally, notaskstate,
-            inaccessiblememonly, noub, no_return_type_call)
+            inaccessiblememonly, noub, nortcall)
     end
     return nothing
 end

--- a/src/julia.h
+++ b/src/julia.h
@@ -271,12 +271,13 @@ typedef union __jl_purity_overrides_t {
         uint16_t ipo_noub                : 1;
         uint16_t ipo_noub_if_noinbounds  : 1;
         uint16_t ipo_consistent_overlay  : 1;
+        uint16_t ipo_no_return_type_call : 1;
     } overrides;
     uint16_t bits;
 } _jl_purity_overrides_t;
 
-#define NUM_EFFECTS_OVERRIDES 10
-#define NUM_IR_FLAGS 12
+#define NUM_EFFECTS_OVERRIDES 11
+#define NUM_IR_FLAGS 13
 
 // This type describes a single function body
 typedef struct _jl_code_info_t {

--- a/src/julia.h
+++ b/src/julia.h
@@ -271,7 +271,7 @@ typedef union __jl_purity_overrides_t {
         uint16_t ipo_noub                : 1;
         uint16_t ipo_noub_if_noinbounds  : 1;
         uint16_t ipo_consistent_overlay  : 1;
-        uint16_t ipo_no_return_type_call : 1;
+        uint16_t ipo_nortcall            : 1;
     } overrides;
     uint16_t bits;
 } _jl_purity_overrides_t;

--- a/src/method.c
+++ b/src/method.c
@@ -491,6 +491,8 @@ jl_code_info_t *jl_new_code_info_from_ir(jl_expr_t *ir)
                         if (noub_if_noinbounds) li->purity.overrides.ipo_noub_if_noinbounds = noub_if_noinbounds;
                         int8_t consistent_overlay = jl_unbox_bool(jl_exprarg(ma, 9));
                         if (consistent_overlay) li->purity.overrides.ipo_consistent_overlay = consistent_overlay;
+                        int8_t no_return_type_call = jl_unbox_bool(jl_exprarg(ma, 10));
+                        if (no_return_type_call) li->purity.overrides.ipo_no_return_type_call = no_return_type_call;
                     }
                 }
                 else

--- a/src/method.c
+++ b/src/method.c
@@ -491,8 +491,8 @@ jl_code_info_t *jl_new_code_info_from_ir(jl_expr_t *ir)
                         if (noub_if_noinbounds) li->purity.overrides.ipo_noub_if_noinbounds = noub_if_noinbounds;
                         int8_t consistent_overlay = jl_unbox_bool(jl_exprarg(ma, 9));
                         if (consistent_overlay) li->purity.overrides.ipo_consistent_overlay = consistent_overlay;
-                        int8_t no_return_type_call = jl_unbox_bool(jl_exprarg(ma, 10));
-                        if (no_return_type_call) li->purity.overrides.ipo_no_return_type_call = no_return_type_call;
+                        int8_t nortcall = jl_unbox_bool(jl_exprarg(ma, 10));
+                        if (nortcall) li->purity.overrides.ipo_nortcall = nortcall;
                     }
                 }
                 else


### PR DESCRIPTION
In extreme cases, the compiler could mark this function for concrete-eval, even though that is illegal unless the compiler has first deleted this instruction. Otherwise the attempt to concrete-eval will re-run the function repeatedly until it hits a StackOverflow.

Workaround to fix #55147

@aviatesk You might know how to solve this even better, using post-optimization effect refinements? Since we should actually only apply the refinement of terminates=false => terminates=true (and thus allowing concrete eval) if the optimization occurs, and not just in inference thinks the optimization would be legal.