### PR TITLE
Ensure bidiagonal setindex! does not read indices in error message

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -192,7 +192,7 @@ end
         @inbounds A.ev[j] = x
     elseif !iszero(x)
         throw(ArgumentError(LazyString(lazy"cannot set entry ($i, $j) off the ",
-            istriu(A) ? "upper" : "lower", " bidiagonal band to a nonzero value ", x)))
+            A.uplo == 'U' ? "upper" : "lower", " bidiagonal band to a nonzero value ", x)))
     end
     return x
 end

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -984,4 +984,9 @@ end
     @test Tridiagonal{Float64}(B) === Tridiagonal(evf, dvf, zf)
 end
 
+@testset "off-band indexing error" begin
+    B = Bidiagonal(Vector{BigInt}(undef, 4), Vector{BigInt}(undef,3), :L)
+    @test_throws "cannot set entry" B[1,2] = 4
+end
+
 end # module TestBidiagonal


### PR DESCRIPTION
This fixes the error message if the matrix is uninitialized. This is because a `Bidiagonal` with `uplo == 'L'` may still be `istriu` if the subdiaognal is zero. We only care about the band index in the error message, and not the values. 