### PR TITLE
Check only for Hermitian and not Symmetric in matrix exponentiation

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -565,9 +565,6 @@ function (^)(A::AbstractMatrix{T}, p::Real) where T
     isinteger(p) && return integerpow(A, p)
 
     # If possible, use diagonalization
-    if issymmetric(A)
-        return (Symmetric(A)^p)
-    end
     if ishermitian(A)
         return (Hermitian(A)^p)
     end


### PR DESCRIPTION
For real matrices, a `Hermitian` eigenvalue problem would be equivalent to a `Symmetric` one, and for complex matrices, there is no special complex symmetric eigensolver (it errors at present, and complex symmetric matrices might not be diagonalizable). I think the `ishermitian` branch should suffice here. Removing the symmetric branch makes the return type simpler to infer.