### PR TITLE
Add `DirEntry`-based `readdir` methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -84,6 +84,9 @@ New library features
   `c` to cleanly cancel immediately, `d` to detach, `i` for a profile peek,
   `v` to toggle verbose mode showing elapsed time, CPU%, and memory usage, and `?` for help. ([#60943]).
 * Instances of an `Enum` can now be given their own docstrings within the `@enum` definition ([#61955]).
+* New methods `readdir(DirEntry, path::String)` and `readdir(e::DirEntry)` will now return directory contents
+  along with the type of the entries in a vector of new `DirEntry` objects to provide more efficient `isfile`
+  etc. checks ([#55358]).
 
 Standard library changes
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -84,12 +84,14 @@ New library features
   `c` to cleanly cancel immediately, `d` to detach, `i` for a profile peek,
   `v` to toggle verbose mode showing elapsed time, CPU%, and memory usage, and `?` for help. ([#60943]).
 * Instances of an `Enum` can now be given their own docstrings within the `@enum` definition ([#61955]).
-* New methods `readdir(DirEntry, path::String)` and `readdir(e::DirEntry)` will now return directory contents
+* New methods `readdir(DirEntry, path)` and `readdir(DirEntry, ::DirEntry)` return directory contents
   along with the type of the entries in a vector of new `DirEntry` objects to provide more efficient `isfile`
-  etc. checks ([#55358]).
-* New function `scandir(dir)` returns a stateful, single-pass iterator yielding `DirEntry` objects without
-  first materializing the full listing. Useful for very large directories or when iteration may be
-  short-circuited. A do-block form `scandir(f, dir)` ensures deterministic resource cleanup ([#55358]).
+  etc. checks. `readdir(::DirEntry)` accepts a `DirEntry` as input and, like `readdir(::AbstractString)`,
+  returns a `Vector{String}` of names ([#55358]).
+* New function `scandir(dir)` returns a stateful, single-pass iterator yielding filename `String`s
+  without first materializing the full listing. `scandir(DirEntry, dir)` yields `DirEntry` objects
+  instead. Useful for very large directories or when iteration may be short-circuited. A do-block form
+  `scandir(f, [DirEntry,] dir)` ensures deterministic resource cleanup ([#55358]).
 
 Standard library changes
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -87,7 +87,7 @@ New library features
 * New methods `readdir(DirEntry, path)` and `readdir(DirEntry, ::DirEntry)` return directory contents
   along with the type of the entries in a vector of new `DirEntry` objects to provide more efficient `isfile`
   etc. checks. `readdir(::DirEntry)` accepts a `DirEntry` as input and, like `readdir(::AbstractString)`,
-  returns a `Vector{String}` of names ([#55358]).
+  returns a `Vector{String}` of names. `DirEntry` is exported from `Base` ([#55358]).
 * New function `scandir(dir)` returns a stateful, single-pass iterator yielding filename `String`s
   without first materializing the full listing. `scandir(DirEntry, dir)` yields `DirEntry` objects
   instead. Useful for very large directories or when iteration may be short-circuited. A do-block form

--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,9 @@ New library features
 * New methods `readdir(DirEntry, path::String)` and `readdir(e::DirEntry)` will now return directory contents
   along with the type of the entries in a vector of new `DirEntry` objects to provide more efficient `isfile`
   etc. checks ([#55358]).
+* New function `scandir(dir)` returns a stateful, single-pass iterator yielding `DirEntry` objects without
+  first materializing the full listing. Useful for very large directories or when iteration may be
+  short-circuited. A do-block form `scandir(f, dir)` ensures deterministic resource cleanup ([#55358]).
 
 Standard library changes
 ------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -84,14 +84,10 @@ New library features
   `c` to cleanly cancel immediately, `d` to detach, `i` for a profile peek,
   `v` to toggle verbose mode showing elapsed time, CPU%, and memory usage, and `?` for help. ([#60943]).
 * Instances of an `Enum` can now be given their own docstrings within the `@enum` definition ([#61955]).
-* New methods `readdir(DirEntry, path)` and `readdir(DirEntry, ::DirEntry)` return directory contents
+* New methods `readdir(path, DirEntry)` and `readdir(::DirEntry, DirEntry)` return directory contents
   along with the type of the entries in a vector of new `DirEntry` objects to provide more efficient `isfile`
   etc. checks. `readdir(::DirEntry)` accepts a `DirEntry` as input and, like `readdir(::AbstractString)`,
   returns a `Vector{String}` of names. `DirEntry` is exported from `Base` ([#55358]).
-* New function `scandir(dir)` returns a stateful, single-pass iterator yielding filename `String`s
-  without first materializing the full listing. `scandir(DirEntry, dir)` yields `DirEntry` objects
-  instead. Useful for very large directories or when iteration may be short-circuited. A do-block form
-  `scandir(f, [DirEntry,] dir)` ensures deterministic resource cleanup ([#55358]).
 
 Standard library changes
 ------------------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -889,6 +889,7 @@ export
     close,
     closewrite,
     countlines,
+    DirEntry,
     eachline,
     readeach,
     eof,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1013,7 +1013,6 @@ export
     readlink,
     rm,
     samefile,
-    scandir,
     stat,
     symlink,
     tempdir,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1013,6 +1013,7 @@ export
     readlink,
     rm,
     samefile,
+    scandir,
     stat,
     symlink,
     tempdir,

--- a/base/file.jl
+++ b/base/file.jl
@@ -8,6 +8,7 @@ export
     chown,
     cp,
     cptree,
+    DirEntry,
     diskstat,
     hardlink,
     mkdir,
@@ -1055,9 +1056,16 @@ const UV_DIRENT_BLOCK = Cint(7)
     DirEntry
 
 A type representing a filesystem entry that contains the name of the entry, the directory, and
-the raw type of the entry. The full path of the entry can be obtained lazily by accessing the
-`path` field. The type of the entry can be checked for by calling [`isfile`](@ref), [`isdir`](@ref),
+the raw type of the entry. The full path of the entry can be obtained lazily via [`path`](@ref Base.Filesystem.path)
+or [`joinpath`](@ref).
+
+Public fields:
+- `dir::String`: The directory containing the entry.
+- `name::String`: The name of the entry.
+
+The type of the entry can be checked for by calling [`isfile`](@ref), [`isdir`](@ref),
 [`islink`](@ref), [`isfifo`](@ref), [`issocket`](@ref), [`ischardev`](@ref), and [`isblockdev`](@ref)
+on the entry object.
 """
 struct DirEntry
     dir::String
@@ -1080,13 +1088,14 @@ isblockdev(obj::DirEntry) = (isunknown(obj) || islink(obj)) ? isblockdev(path(ob
 realpath(obj::DirEntry) = realpath(path(obj))
 
 """
-    _readdirx(dir::AbstractString=pwd(); sort::Bool = true)::Vector{DirEntry}
+    readdir(::Type{DirEntry}, dir::Union{AbstractString,DirEntry}=pwd(); sort::Bool = true) -> Vector{DirEntry}
+    readdir(entry::DirEntry; sort::Bool=true) -> Vector{DirEntry}
 
 Return a vector of [`DirEntry`](@ref) objects representing the contents of the directory `dir`,
 or the current working directory if not given. If `sort` is true, the returned vector is
 sorted by name.
 
-Unlike [`readdir`](@ref), `_readdirx` returns [`DirEntry`](@ref) objects, which contain the name of the
+The [`DirEntry`](@ref) objects that are returned contain the name of the
 file, the directory it is in, and the type of the file which is determined during the
 directory scan. This means that calls to [`isfile`](@ref), [`isdir`](@ref), [`islink`](@ref), [`isfifo`](@ref),
 [`issocket`](@ref), [`ischardev`](@ref), and [`isblockdev`](@ref) can be made on the
@@ -1094,13 +1103,23 @@ returned objects without further stat calls. However, for some filesystems, the 
 cannot be determined without a stat call. In these cases the `rawtype` field of the [`DirEntry`](@ref))
 object will be 0 (`UV_DIRENT_UNKNOWN`) and [`isfile`](@ref) etc. will fall back to a `stat` call.
 
+# Examples
 ```julia
-for obj in _readdirx()
-    isfile(obj) && println("\$(obj.name) is a file with path \$(path(obj))")
+for entry in readdir(DirEntry, ".")
+    if isfile(entry)
+        println("\$(entry.name) is a file with path \$(path(entry))")
+        continue
+    end
+    isdir(entry) || continue
+    for entry2 in readdir(entry)
+        ...
+    end
 end
 ```
 """
-_readdirx(dir::AbstractString=pwd(); sort::Bool=true) = _readdir(dir; return_objects=true, sort)::Vector{DirEntry}
+readdir(::Type{DirEntry}, dir::AbstractString=pwd(); sort::Bool=true) = _readdir(dir; return_objects=true, sort)::Vector{DirEntry}
+readdir(::Type{DirEntry}, entry::DirEntry; sort::Bool=true) = readdir(entry; sort)::Vector{DirEntry}
+readdir(entry::DirEntry; sort::Bool=true) = readdir(DirEntry, path(entry); sort)::Vector{DirEntry}
 
 function _readdir(dir::AbstractString; return_objects::Bool=false, join::Bool=false, sort::Bool=true)
     # Allocate space for uv_fs_t struct
@@ -1202,7 +1221,7 @@ function _walkdir(chnl, path, topdown, follow_symlinks, onerror)
             end
             return
         end
-    entries = tryf(_readdirx, path)
+    entries = tryf(p -> readdir(DirEntry, p), path)
     entries === nothing && return
     dirs = Vector{String}()
     files = Vector{String}()

--- a/base/file.jl
+++ b/base/file.jl
@@ -1059,9 +1059,8 @@ const UV_DIRENT_BLOCK = Cint(7)
 A type representing a filesystem entry that contains the name of the entry, the directory, and
 the raw type of the entry. The full path of the entry can be obtained lazily via [`joinpath(entry)`](@ref).
 
-Public fields:
-- `dir::String`: The directory containing the entry.
-- `name::String`: The name of the entry.
+The directory and name components are accessed via [`dirname`](@ref) and [`basename`](@ref),
+respectively, mirroring the behavior of the corresponding string-returning functions.
 
 The type of the entry can be checked for by calling [`isfile`](@ref), [`isdir`](@ref),
 [`islink`](@ref), [`isfifo`](@ref), [`issocket`](@ref), [`ischardev`](@ref), and [`isblockdev`](@ref)
@@ -1081,20 +1080,21 @@ struct DirEntry
     name::String
     rawtype::Cint
 end
-path(obj::DirEntry) = joinpath(getfield(obj, :dir), getfield(obj, :name))
-Base.isless(a::DirEntry, b::DirEntry) = a.dir == b.dir ? isless(a.name, b.name) : isless(a.dir, b.dir)
-Base.hash(o::DirEntry, h::UInt) = hash(o.dir, hash(o.name, hash(o.rawtype, h)))
-Base.:(==)(a::DirEntry, b::DirEntry) = a.name == b.name && a.dir == b.dir && a.rawtype == b.rawtype
-joinpath(obj::DirEntry, args...) = joinpath(path(obj), args...)
+basename(obj::DirEntry) = getfield(obj, :name)
+dirname(obj::DirEntry) = getfield(obj, :dir)
+joinpath(obj::DirEntry, args...) = joinpath(dirname(obj), basename(obj), args...)
+Base.isless(a::DirEntry, b::DirEntry) = dirname(a) == dirname(b) ? isless(basename(a), basename(b)) : isless(dirname(a), dirname(b))
+Base.hash(o::DirEntry, h::UInt) = hash(dirname(o), hash(basename(o), hash(o.rawtype, h)))
+Base.:(==)(a::DirEntry, b::DirEntry) = basename(a) == basename(b) && dirname(a) == dirname(b) && a.rawtype == b.rawtype
 isunknown(obj::DirEntry) =  obj.rawtype == UV_DIRENT_UNKNOWN
-islink(obj::DirEntry) =     isunknown(obj) ? islink(path(obj)) : obj.rawtype == UV_DIRENT_LINK
-isfile(obj::DirEntry) =     (isunknown(obj) || islink(obj)) ? isfile(path(obj))      : obj.rawtype == UV_DIRENT_FILE
-isdir(obj::DirEntry) =      (isunknown(obj) || islink(obj)) ? isdir(path(obj))       : obj.rawtype == UV_DIRENT_DIR
-isfifo(obj::DirEntry) =     (isunknown(obj) || islink(obj)) ? isfifo(path(obj))      : obj.rawtype == UV_DIRENT_FIFO
-issocket(obj::DirEntry) =   (isunknown(obj) || islink(obj)) ? issocket(path(obj))    : obj.rawtype == UV_DIRENT_SOCKET
-ischardev(obj::DirEntry) =  (isunknown(obj) || islink(obj)) ? ischardev(path(obj))   : obj.rawtype == UV_DIRENT_CHAR
-isblockdev(obj::DirEntry) = (isunknown(obj) || islink(obj)) ? isblockdev(path(obj))  : obj.rawtype == UV_DIRENT_BLOCK
-realpath(obj::DirEntry) = realpath(path(obj))
+islink(obj::DirEntry) =     isunknown(obj) ? islink(joinpath(obj)) : obj.rawtype == UV_DIRENT_LINK
+isfile(obj::DirEntry) =     (isunknown(obj) || islink(obj)) ? isfile(joinpath(obj))      : obj.rawtype == UV_DIRENT_FILE
+isdir(obj::DirEntry) =      (isunknown(obj) || islink(obj)) ? isdir(joinpath(obj))       : obj.rawtype == UV_DIRENT_DIR
+isfifo(obj::DirEntry) =     (isunknown(obj) || islink(obj)) ? isfifo(joinpath(obj))      : obj.rawtype == UV_DIRENT_FIFO
+issocket(obj::DirEntry) =   (isunknown(obj) || islink(obj)) ? issocket(joinpath(obj))    : obj.rawtype == UV_DIRENT_SOCKET
+ischardev(obj::DirEntry) =  (isunknown(obj) || islink(obj)) ? ischardev(joinpath(obj))   : obj.rawtype == UV_DIRENT_CHAR
+isblockdev(obj::DirEntry) = (isunknown(obj) || islink(obj)) ? isblockdev(joinpath(obj))  : obj.rawtype == UV_DIRENT_BLOCK
+realpath(obj::DirEntry) = realpath(joinpath(obj))
 
 """
     readdir(::Type{DirEntry}, dir::AbstractString=pwd(); sort::Bool = true) -> Vector{DirEntry}
@@ -1118,7 +1118,7 @@ a `stat` call.
 ```julia
 for entry in readdir(DirEntry, ".")
     if isfile(entry)
-        println("\$(entry.name) is a file with path \$(path(entry))")
+        println("\$(basename(entry)) is a file with path \$(joinpath(entry))")
         continue
     end
     isdir(entry) || continue
@@ -1129,8 +1129,8 @@ end
 ```
 """
 readdir(::Type{DirEntry}, dir::AbstractString=pwd(); sort::Bool=true) = _readdir(dir; return_objects=true, sort)::Vector{DirEntry}
-readdir(::Type{DirEntry}, entry::DirEntry; sort::Bool=true) = readdir(DirEntry, path(entry); sort)::Vector{DirEntry}
-readdir(entry::DirEntry; kwargs...) = readdir(path(entry); kwargs...)::Vector{String}
+readdir(::Type{DirEntry}, entry::DirEntry; sort::Bool=true) = readdir(DirEntry, joinpath(entry); sort)::Vector{DirEntry}
+readdir(entry::DirEntry; kwargs...) = readdir(joinpath(entry); kwargs...)::Vector{String}
 
 function _readdir(dir::AbstractString; return_objects::Bool=false, join::Bool=false, sort::Bool=true)
     # Allocate space for uv_fs_t struct
@@ -1273,9 +1273,9 @@ end
 ```
 """
 scandir(dir::AbstractString=pwd()) = DirEntryIterator{String}(dir)
-scandir(entry::DirEntry) = DirEntryIterator{String}(path(entry))
+scandir(entry::DirEntry) = DirEntryIterator{String}(joinpath(entry))
 scandir(::Type{DirEntry}, dir::AbstractString=pwd()) = DirEntryIterator{DirEntry}(dir)
-scandir(::Type{DirEntry}, entry::DirEntry) = DirEntryIterator{DirEntry}(path(entry))
+scandir(::Type{DirEntry}, entry::DirEntry) = DirEntryIterator{DirEntry}(joinpath(entry))
 function scandir(f, dir)
     it = scandir(dir)
     try

--- a/base/file.jl
+++ b/base/file.jl
@@ -1090,6 +1090,7 @@ realpath(obj::DirEntry) = realpath(path(obj))
 """
     readdir(::Type{DirEntry}, dir::Union{AbstractString,DirEntry}=pwd(); sort::Bool = true) -> Vector{DirEntry}
     readdir(entry::DirEntry; sort::Bool=true) -> Vector{DirEntry}
+    readdir(::Type{String}, entry::DirEntry; join::Bool=false, sort::Bool=true) -> Vector{String}
 
 Return a vector of [`DirEntry`](@ref) objects representing the contents of the directory `dir`,
 or the current working directory if not given. If `sort` is true, the returned vector is
@@ -1120,6 +1121,7 @@ end
 readdir(::Type{DirEntry}, dir::AbstractString=pwd(); sort::Bool=true) = _readdir(dir; return_objects=true, sort)::Vector{DirEntry}
 readdir(::Type{DirEntry}, entry::DirEntry; sort::Bool=true) = readdir(entry; sort)::Vector{DirEntry}
 readdir(entry::DirEntry; sort::Bool=true) = readdir(DirEntry, path(entry); sort)::Vector{DirEntry}
+readdir(::Type{String}, entry::DirEntry; kwargs...) = readdir(path(entry); kwargs...)::Vector{String}
 
 function _readdir(dir::AbstractString; return_objects::Bool=false, join::Bool=false, sort::Bool=true)
     # Allocate space for uv_fs_t struct

--- a/base/file.jl
+++ b/base/file.jl
@@ -1065,7 +1065,16 @@ Public fields:
 
 The type of the entry can be checked for by calling [`isfile`](@ref), [`isdir`](@ref),
 [`islink`](@ref), [`isfifo`](@ref), [`issocket`](@ref), [`ischardev`](@ref), and [`isblockdev`](@ref)
-on the entry object.
+on the entry object. These predicates use the raw type cached at scan time when available; on
+filesystems that report `UV_DIRENT_UNKNOWN` (some network/FUSE mounts) and for symlinks they fall
+through to a `stat` syscall on each call. Callers in tight loops that need multiple predicates for
+the same entry should call [`stat`](@ref) once and reuse the result.
+
+!!! warning "Staleness"
+    A `DirEntry` is a snapshot from when the directory was scanned. The underlying filesystem may
+    have changed in the meantime: the entry may no longer exist, may have been replaced by a
+    different type, or the cached `rawtype` may be wrong. Treat `DirEntry` values as advisory
+    and re-`stat` if up-to-date information is required.
 """
 struct DirEntry
     dir::String

--- a/base/file.jl
+++ b/base/file.jl
@@ -1261,7 +1261,7 @@ See also [`readdir`](@ref), [`DirEntry`](@ref), [`walkdir`](@ref).
 ```julia
 # short-circuit a huge directory
 for entry in scandir(DirEntry, "/very/large/dir")
-    isfile(entry) && entry.name == "needle.txt" && break
+    isfile(entry) && basename(entry) == "needle.txt" && break
 end
 
 # deterministic cleanup
@@ -1367,9 +1367,9 @@ function _walkdir(chnl, path, topdown, follow_symlinks, onerror)
     for entry in entries
         # If we're not following symlinks, then treat all symlinks as files
         if (!follow_symlinks && something(tryf(islink, entry), true)) || !something(tryf(isdir, entry), false)
-            push!(files, entry.name)
+            push!(files, basename(entry))
         else
-            push!(dirs, entry.name)
+            push!(dirs, basename(entry))
         end
     end
 

--- a/base/file.jl
+++ b/base/file.jl
@@ -1097,21 +1097,22 @@ isblockdev(obj::DirEntry) = (isunknown(obj) || islink(obj)) ? isblockdev(path(ob
 realpath(obj::DirEntry) = realpath(path(obj))
 
 """
-    readdir(::Type{DirEntry}, dir::Union{AbstractString,DirEntry}=pwd(); sort::Bool = true) -> Vector{DirEntry}
-    readdir(entry::DirEntry; sort::Bool=true) -> Vector{DirEntry}
-    readdir(::Type{String}, entry::DirEntry; join::Bool=false, sort::Bool=true) -> Vector{String}
+    readdir(::Type{DirEntry}, dir::AbstractString=pwd(); sort::Bool = true) -> Vector{DirEntry}
+    readdir(::Type{DirEntry}, entry::DirEntry; sort::Bool=true) -> Vector{DirEntry}
+    readdir(entry::DirEntry; join::Bool=false, sort::Bool=true) -> Vector{String}
 
 Return a vector of [`DirEntry`](@ref) objects representing the contents of the directory `dir`,
 or the current working directory if not given. If `sort` is true, the returned vector is
 sorted by name.
 
-The [`DirEntry`](@ref) objects that are returned contain the name of the
-file, the directory it is in, and the type of the file which is determined during the
-directory scan. This means that calls to [`isfile`](@ref), [`isdir`](@ref), [`islink`](@ref), [`isfifo`](@ref),
-[`issocket`](@ref), [`ischardev`](@ref), and [`isblockdev`](@ref) can be made on the
-returned objects without further stat calls. However, for some filesystems, the type of the file
-cannot be determined without a stat call. In these cases the `rawtype` field of the [`DirEntry`](@ref))
-object will be 0 (`UV_DIRENT_UNKNOWN`) and [`isfile`](@ref) etc. will fall back to a `stat` call.
+The element type is selected by the leading type argument: pass `DirEntry` to get
+[`DirEntry`](@ref) objects (which carry the type of each entry as determined during the
+directory scan, so [`isfile`](@ref), [`isdir`](@ref), etc. can be called without further
+`stat` calls), or omit it to get a `Vector{String}` of names — independent of whether the
+directory was specified as an `AbstractString` or a `DirEntry`. For some filesystems the
+type of the entry cannot be determined without a `stat` call; in those cases the `rawtype`
+field of the [`DirEntry`](@ref) is 0 (`UV_DIRENT_UNKNOWN`) and the predicates fall back to
+a `stat` call.
 
 # Examples
 ```julia
@@ -1121,16 +1122,15 @@ for entry in readdir(DirEntry, ".")
         continue
     end
     isdir(entry) || continue
-    for entry2 in readdir(entry)
+    for entry2 in readdir(DirEntry, entry)
         ...
     end
 end
 ```
 """
 readdir(::Type{DirEntry}, dir::AbstractString=pwd(); sort::Bool=true) = _readdir(dir; return_objects=true, sort)::Vector{DirEntry}
-readdir(::Type{DirEntry}, entry::DirEntry; sort::Bool=true) = readdir(entry; sort)::Vector{DirEntry}
-readdir(entry::DirEntry; sort::Bool=true) = readdir(DirEntry, path(entry); sort)::Vector{DirEntry}
-readdir(::Type{String}, entry::DirEntry; kwargs...) = readdir(path(entry); kwargs...)::Vector{String}
+readdir(::Type{DirEntry}, entry::DirEntry; sort::Bool=true) = readdir(DirEntry, path(entry); sort)::Vector{DirEntry}
+readdir(entry::DirEntry; kwargs...) = readdir(path(entry); kwargs...)::Vector{String}
 
 function _readdir(dir::AbstractString; return_objects::Bool=false, join::Bool=false, sort::Bool=true)
     # Allocate space for uv_fs_t struct
@@ -1166,21 +1166,25 @@ function _readdir(dir::AbstractString; return_objects::Bool=false, join::Bool=fa
 end
 
 """
-    DirEntryIterator
+    DirEntryIterator{T}
 
 A stateful, single-pass iterator over the entries of a directory, yielding
-[`DirEntry`](@ref) objects. Created by [`scandir`](@ref).
+either filename `String`s or [`DirEntry`](@ref) objects depending on the
+element type `T`. Created by [`scandir`](@ref).
 
 The underlying `uv_fs_t` request is opened lazily on the first call to
 `iterate` and is released when iteration reaches end-of-directory, when
 [`close`](@ref) is called, or by a finalizer. For deterministic cleanup
 on very large directories, prefer the do-block form of `scandir`.
 """
-mutable struct DirEntryIterator
+mutable struct DirEntryIterator{T}
     const dir::String
     req::Ptr{Cvoid}     # uv_fs_t, C_NULL until opened, C_NULL again after close
     closed::Bool
-    DirEntryIterator(dir::AbstractString) = finalizer(close, new(String(dir), C_NULL, false))
+    function DirEntryIterator{T}(dir::AbstractString) where {T}
+        T === String || T === DirEntry || throw(ArgumentError("element type must be String or DirEntry"))
+        finalizer(close, new{T}(String(dir), C_NULL, false))
+    end
 end
 
 function _scandir_open!(it::DirEntryIterator)
@@ -1209,11 +1213,11 @@ function Base.close(it::DirEntryIterator)
     return
 end
 
-Base.IteratorSize(::Type{DirEntryIterator}) = Base.SizeUnknown()
-Base.eltype(::Type{DirEntryIterator}) = DirEntry
+Base.IteratorSize(::Type{<:DirEntryIterator}) = Base.SizeUnknown()
+Base.eltype(::Type{DirEntryIterator{T}}) where {T} = T
 Base.isdone(it::DirEntryIterator, _=nothing) = it.closed
 
-function Base.iterate(it::DirEntryIterator, _=nothing)
+function Base.iterate(it::DirEntryIterator{T}, _=nothing) where {T}
     _scandir_open!(it)
     ent = Ref{uv_dirent_t}()
     rc = ccall(:uv_fs_scandir_next, Cint, (Ptr{Cvoid}, Ptr{uv_dirent_t}), it.req, ent)
@@ -1221,19 +1225,27 @@ function Base.iterate(it::DirEntryIterator, _=nothing)
         close(it)
         return nothing
     end
-    return DirEntry(it.dir, unsafe_string(ent[].name), ent[].typ), nothing
+    name = unsafe_string(ent[].name)
+    value = T === DirEntry ? DirEntry(it.dir, name, ent[].typ) : name
+    return value, nothing
 end
 
 """
-    scandir(dir::AbstractString=pwd()) -> DirEntryIterator
-    scandir(entry::DirEntry)           -> DirEntryIterator
-    scandir(f, dir)                    -> f(::DirEntryIterator)
+    scandir(dir::AbstractString=pwd())                     -> DirEntryIterator{String}
+    scandir(entry::DirEntry)                               -> DirEntryIterator{String}
+    scandir(::Type{DirEntry}, dir::AbstractString=pwd())   -> DirEntryIterator{DirEntry}
+    scandir(::Type{DirEntry}, entry::DirEntry)             -> DirEntryIterator{DirEntry}
+    scandir(f, [::Type{DirEntry},] dir)                    -> f(::DirEntryIterator)
 
-Return a stateful, single-pass iterator yielding [`DirEntry`](@ref) objects for
-the contents of the directory `dir` (or the current working directory if not
-given), without first materializing the full listing. Useful for very large
-directories or when iteration may be short-circuited (e.g. with `break` or
-[`Iterators.take`](@ref)).
+Return a stateful, single-pass iterator over the contents of the directory `dir`
+(or the current working directory if not given), without first materializing the
+full listing. Useful for very large directories or when iteration may be
+short-circuited (e.g. with `break` or [`Iterators.take`](@ref)).
+
+By default the iterator yields filename `String`s, matching [`readdir`](@ref).
+Pass `DirEntry` as the leading type argument to yield [`DirEntry`](@ref)
+objects, which carry the entry type as cached at scan time so [`isfile`](@ref),
+[`isdir`](@ref), etc. can be checked without further `stat` calls.
 
 Unlike [`readdir`](@ref), the entries are returned in filesystem order (not
 sorted) and the iterator can only be traversed once. The do-block form ensures
@@ -1248,22 +1260,32 @@ See also [`readdir`](@ref), [`DirEntry`](@ref), [`walkdir`](@ref).
 # Examples
 ```julia
 # short-circuit a huge directory
-for entry in scandir("/very/large/dir")
+for entry in scandir(DirEntry, "/very/large/dir")
     isfile(entry) && entry.name == "needle.txt" && break
 end
 
 # deterministic cleanup
-scandir("/very/large/dir") do entries
-    for entry in entries
+scandir("/very/large/dir") do names
+    for name in names
         ...
     end
 end
 ```
 """
-scandir(dir::AbstractString=pwd()) = DirEntryIterator(dir)
-scandir(entry::DirEntry) = DirEntryIterator(path(entry))
+scandir(dir::AbstractString=pwd()) = DirEntryIterator{String}(dir)
+scandir(entry::DirEntry) = DirEntryIterator{String}(path(entry))
+scandir(::Type{DirEntry}, dir::AbstractString=pwd()) = DirEntryIterator{DirEntry}(dir)
+scandir(::Type{DirEntry}, entry::DirEntry) = DirEntryIterator{DirEntry}(path(entry))
 function scandir(f, dir)
     it = scandir(dir)
+    try
+        return f(it)
+    finally
+        close(it)
+    end
+end
+function scandir(f, ::Type{DirEntry}, dir)
+    it = scandir(DirEntry, dir)
     try
         return f(it)
     finally

--- a/base/file.jl
+++ b/base/file.jl
@@ -22,6 +22,7 @@ export
     readdir,
     rm,
     samefile,
+    scandir,
     sendfile,
     symlink,
     tempdir,
@@ -1153,6 +1154,112 @@ function _readdir(dir::AbstractString; return_objects::Bool=false, join::Bool=fa
         return entries
     finally
         Libc.free(req)
+    end
+end
+
+"""
+    DirEntryIterator
+
+A stateful, single-pass iterator over the entries of a directory, yielding
+[`DirEntry`](@ref) objects. Created by [`scandir`](@ref).
+
+The underlying `uv_fs_t` request is opened lazily on the first call to
+`iterate` and is released when iteration reaches end-of-directory, when
+[`close`](@ref) is called, or by a finalizer. For deterministic cleanup
+on very large directories, prefer the do-block form of `scandir`.
+"""
+mutable struct DirEntryIterator
+    const dir::String
+    req::Ptr{Cvoid}     # uv_fs_t, C_NULL until opened, C_NULL again after close
+    closed::Bool
+    DirEntryIterator(dir::AbstractString) = finalizer(close, new(String(dir), C_NULL, false))
+end
+
+function _scandir_open!(it::DirEntryIterator)
+    it.req == C_NULL || return
+    it.closed && throw(ArgumentError("DirEntryIterator has already been consumed"))
+    req = Libc.malloc(_sizeof_uv_fs)
+    err = ccall(:uv_fs_scandir, Int32, (Ptr{Cvoid}, Ptr{Cvoid}, Cstring, Cint, Ptr{Cvoid}),
+                C_NULL, req, it.dir, 0, C_NULL)
+    if err < 0
+        Libc.free(req)
+        it.closed = true
+        uv_error("scandir($(repr(it.dir)))", err)
+    end
+    it.req = req
+    return
+end
+
+function Base.close(it::DirEntryIterator)
+    req = it.req
+    if req != C_NULL
+        it.req = C_NULL
+        uv_fs_req_cleanup(req)
+        Libc.free(req)
+    end
+    it.closed = true
+    return
+end
+
+Base.IteratorSize(::Type{DirEntryIterator}) = Base.SizeUnknown()
+Base.eltype(::Type{DirEntryIterator}) = DirEntry
+Base.isdone(it::DirEntryIterator, _=nothing) = it.closed
+
+function Base.iterate(it::DirEntryIterator, _=nothing)
+    _scandir_open!(it)
+    ent = Ref{uv_dirent_t}()
+    rc = ccall(:uv_fs_scandir_next, Cint, (Ptr{Cvoid}, Ptr{uv_dirent_t}), it.req, ent)
+    if rc == Base.UV_EOF
+        close(it)
+        return nothing
+    end
+    return DirEntry(it.dir, unsafe_string(ent[].name), ent[].typ), nothing
+end
+
+"""
+    scandir(dir::AbstractString=pwd()) -> DirEntryIterator
+    scandir(entry::DirEntry)           -> DirEntryIterator
+    scandir(f, dir)                    -> f(::DirEntryIterator)
+
+Return a stateful, single-pass iterator yielding [`DirEntry`](@ref) objects for
+the contents of the directory `dir` (or the current working directory if not
+given), without first materializing the full listing. Useful for very large
+directories or when iteration may be short-circuited (e.g. with `break` or
+[`Iterators.take`](@ref)).
+
+Unlike [`readdir`](@ref), the entries are returned in filesystem order (not
+sorted) and the iterator can only be traversed once. The do-block form ensures
+the underlying `uv_fs_t` resource is released as soon as `f` returns; otherwise
+cleanup happens at end-of-iteration, on [`close`](@ref), or via a finalizer.
+
+See also [`readdir`](@ref), [`DirEntry`](@ref), [`walkdir`](@ref).
+
+!!! compat "Julia 1.13"
+    `scandir` requires Julia 1.13 or later.
+
+# Examples
+```julia
+# short-circuit a huge directory
+for entry in scandir("/very/large/dir")
+    isfile(entry) && entry.name == "needle.txt" && break
+end
+
+# deterministic cleanup
+scandir("/very/large/dir") do entries
+    for entry in entries
+        ...
+    end
+end
+```
+"""
+scandir(dir::AbstractString=pwd()) = DirEntryIterator(dir)
+scandir(entry::DirEntry) = DirEntryIterator(path(entry))
+function scandir(f, dir)
+    it = scandir(dir)
+    try
+        return f(it)
+    finally
+        close(it)
     end
 end
 

--- a/base/file.jl
+++ b/base/file.jl
@@ -1172,42 +1172,55 @@ A stateful, single-pass iterator over the entries of a directory, yielding
 either filename `String`s or [`DirEntry`](@ref) objects depending on the
 element type `T`. Created by [`scandir`](@ref).
 
-The underlying `uv_fs_t` request is opened lazily on the first call to
-`iterate` and is released when iteration reaches end-of-directory, when
-[`close`](@ref) is called, or by a finalizer. For deterministic cleanup
-on very large directories, prefer the do-block form of `scandir`.
+The underlying directory handle is opened lazily on the first call to
+`iterate` (via `uv_fs_opendir`) and is released when iteration reaches
+end-of-directory, when [`close`](@ref) is called, or by a finalizer.
+Entries are streamed one at a time from the operating system; the full
+listing is never materialized in memory. For deterministic cleanup on
+very large directories, prefer the do-block form of `scandir`.
+
+A `DirEntryIterator` is single-consumer: do not iterate or close it from
+multiple tasks concurrently. Calling `close` from a finalizer while the
+owning task has finished iterating is safe.
 """
 mutable struct DirEntryIterator{T}
     const dir::String
-    @atomic req::Ptr{Cvoid}     # uv_fs_t, C_NULL until opened, C_NULL again after close
+    # Opaque uv_dir_t* returned by jl_uv_fs_opendir; C_NULL until opened and
+    # C_NULL again after close. Acts as the ownership gate: the thread that
+    # atomically swaps it to C_NULL is the sole owner of the resources below
+    # and is responsible for cleanup.
+    @atomic uvdir::Ptr{Cvoid}
+    # Single-entry uv_dirent_t buffer that libuv writes into via uv_fs_readdir.
+    # Must outlive `uvdir`; held here so its address remains valid for the
+    # lifetime of the iterator.
+    ent::Base.RefValue{uv_dirent_t}
     closed::Bool
     function DirEntryIterator{T}(dir::AbstractString) where {T}
         T === String || T === DirEntry || throw(ArgumentError("element type must be String or DirEntry"))
-        finalizer(close, new{T}(String(dir), C_NULL, false))
+        finalizer(close, new{T}(String(dir), C_NULL, Ref{uv_dirent_t}(), false))
     end
 end
 
 function _scandir_open!(it::DirEntryIterator)
-    it.req == C_NULL || return
+    it.uvdir == C_NULL || return
     it.closed && throw(ArgumentError("DirEntryIterator has already been consumed"))
-    req = Libc.malloc(_sizeof_uv_fs)
-    err = ccall(:uv_fs_scandir, Int32, (Ptr{Cvoid}, Ptr{Cvoid}, Cstring, Cint, Ptr{Cvoid}),
-                C_NULL, req, it.dir, 0, C_NULL)
+    dir_out = Ref{Ptr{Cvoid}}(C_NULL)
+    err = ccall(:jl_uv_fs_opendir, Cint,
+                (Cstring, Ptr{Ptr{Cvoid}}, Ptr{uv_dirent_t}),
+                it.dir, dir_out, it.ent)
     if err < 0
-        Libc.free(req)
         it.closed = true
         uv_error("scandir($(repr(it.dir)))", err)
     end
-    @atomic it.req = req
+    @atomic it.uvdir = dir_out[]
     return
 end
 
 function Base.close(it::DirEntryIterator)
-    # Atomically claim the request pointer so a concurrent finalizer cannot double-free.
-    req = @atomicswap it.req = C_NULL
-    if req != C_NULL
-        uv_fs_req_cleanup(req)
-        Libc.free(req)
+    # Atomically claim the dir pointer so a concurrent finalizer cannot double-free.
+    uvdir = @atomicswap it.uvdir = C_NULL
+    if uvdir != C_NULL
+        ccall(:jl_uv_fs_closedir, Cint, (Ptr{Cvoid},), uvdir)
     end
     it.closed = true
     return
@@ -1219,14 +1232,25 @@ Base.isdone(it::DirEntryIterator, _=nothing) = it.closed
 
 function Base.iterate(it::DirEntryIterator{T}, _=nothing) where {T}
     _scandir_open!(it)
-    ent = Ref{uv_dirent_t}()
-    rc = ccall(:uv_fs_scandir_next, Cint, (Ptr{Cvoid}, Ptr{uv_dirent_t}), it.req, ent)
-    if rc == Base.UV_EOF
+    name_out = Ref{Ptr{UInt8}}(C_NULL)
+    type_out = Ref{Cint}(0)
+    rc = ccall(:jl_uv_fs_readdir, Cssize_t,
+               (Ptr{Cvoid}, Ptr{Ptr{UInt8}}, Ptr{Cint}),
+               it.uvdir, name_out, type_out)
+    if rc <= 0
+        if rc < 0
+            err = rc
+            close(it)
+            uv_error("scandir($(repr(it.dir)))", err)
+        end
         close(it)
         return nothing
     end
-    name = unsafe_string(ent[].name)
-    value = T === DirEntry ? DirEntry(it.dir, name, ent[].typ) : name
+    name_ptr = name_out[]
+    name = unsafe_string(name_ptr)
+    Libc.free(name_ptr)
+    rawtype = type_out[]
+    value = T === DirEntry ? DirEntry(it.dir, name, rawtype) : name
     return value, nothing
 end
 
@@ -1249,7 +1273,7 @@ objects, which carry the entry type as cached at scan time so [`isfile`](@ref),
 
 Unlike [`readdir`](@ref), the entries are returned in filesystem order (not
 sorted) and the iterator can only be traversed once. The do-block form ensures
-the underlying `uv_fs_t` resource is released as soon as `f` returns; otherwise
+the underlying directory handle is released as soon as `f` returns; otherwise
 cleanup happens at end-of-iteration, on [`close`](@ref), or via a finalizer.
 
 See also [`readdir`](@ref), [`DirEntry`](@ref), [`walkdir`](@ref).

--- a/base/file.jl
+++ b/base/file.jl
@@ -1185,6 +1185,8 @@ owning task has finished iterating is safe.
 """
 mutable struct DirEntryIterator{T}
     const dir::String
+    # Yield joinpath(dir, name) instead of the bare name (String eltype only)
+    const join::Bool
     # Opaque uv_dir_t* returned by jl_uv_fs_opendir; C_NULL until opened and
     # C_NULL again after close. Acts as the ownership gate: the thread that
     # atomically swaps it to C_NULL is the sole owner of the resources below
@@ -1195,9 +1197,9 @@ mutable struct DirEntryIterator{T}
     # valid for the lifetime of the iterator.
     ent::Base.RefValue{uv_dirent_t}
     closed::Bool
-    function DirEntryIterator{T}(dir::AbstractString) where {T}
+    function DirEntryIterator{T}(dir::AbstractString, join::Bool=false) where {T}
         T === String || T === DirEntry || throw(ArgumentError("element type must be String or DirEntry"))
-        finalizer(close, new{T}(String(dir), C_NULL, Ref{uv_dirent_t}(), false))
+        finalizer(close, new{T}(String(dir), join, C_NULL, Ref{uv_dirent_t}(), false))
     end
 end
 
@@ -1247,26 +1249,30 @@ function Base.iterate(it::DirEntryIterator{T}, _=nothing) where {T}
     ent = it.ent[]
     name = unsafe_string(ent.name)
     Libc.free(ent.name)
-    value = T === DirEntry ? DirEntry(it.dir, name, ent.typ) : name
+    value = T === DirEntry ? DirEntry(it.dir, name, ent.typ) :
+            it.join ? joinpath(it.dir, name) : name
     return value, nothing
 end
 
 """
-    scandir(dir::AbstractString=pwd())                     -> DirEntryIterator{String}
-    scandir(entry::DirEntry)                               -> DirEntryIterator{String}
+    scandir(dir::AbstractString=pwd(); join::Bool=false)   -> DirEntryIterator{String}
+    scandir(entry::DirEntry; join::Bool=false)             -> DirEntryIterator{String}
     scandir(::Type{DirEntry}, dir::AbstractString=pwd())   -> DirEntryIterator{DirEntry}
     scandir(::Type{DirEntry}, entry::DirEntry)             -> DirEntryIterator{DirEntry}
-    scandir(f, [::Type{DirEntry},] dir)                    -> f(::DirEntryIterator)
+    scandir(f, [::Type{DirEntry},] dir; kwargs...)         -> f(::DirEntryIterator)
 
 Return a stateful, single-pass iterator over the contents of the directory `dir`
 (or the current working directory if not given), without first materializing the
 full listing. Useful for very large directories or when iteration may be
 short-circuited (e.g. with `break` or [`Iterators.take`](@ref)).
 
-By default the iterator yields filename `String`s, matching [`readdir`](@ref).
+By default the iterator yields filename `String`s, matching [`readdir`](@ref);
+if `join` is true it yields `joinpath(dir, name)` for each name instead.
 Pass `DirEntry` as the leading type argument to yield [`DirEntry`](@ref)
 objects, which carry the entry type as cached at scan time so [`isfile`](@ref),
-[`isdir`](@ref), etc. can be checked without further `stat` calls.
+[`isdir`](@ref), etc. can be checked without further `stat` calls (the full
+path of a `DirEntry` is available via `joinpath(entry)`, so there is no `join`
+keyword for that form, as with `readdir(DirEntry, dir)`).
 
 Unlike [`readdir`](@ref), the entries are returned in filesystem order (not
 sorted) and the iterator can only be traversed once. The do-block form ensures
@@ -1293,12 +1299,12 @@ scandir("/very/large/dir") do names
 end
 ```
 """
-scandir(dir::AbstractString=pwd()) = DirEntryIterator{String}(dir)
-scandir(entry::DirEntry) = DirEntryIterator{String}(joinpath(entry))
+scandir(dir::AbstractString=pwd(); join::Bool=false) = DirEntryIterator{String}(dir, join)
+scandir(entry::DirEntry; join::Bool=false) = DirEntryIterator{String}(joinpath(entry), join)
 scandir(::Type{DirEntry}, dir::AbstractString=pwd()) = DirEntryIterator{DirEntry}(dir)
 scandir(::Type{DirEntry}, entry::DirEntry) = DirEntryIterator{DirEntry}(joinpath(entry))
-function scandir(f, dir)
-    it = scandir(dir)
+function scandir(f, dir; join::Bool=false)
+    it = scandir(dir; join)
     try
         return f(it)
     finally

--- a/base/file.jl
+++ b/base/file.jl
@@ -22,7 +22,6 @@ export
     readdir,
     rm,
     samefile,
-    scandir,
     sendfile,
     symlink,
     tempdir,
@@ -1097,39 +1096,41 @@ isblockdev(obj::DirEntry) = (isunknown(obj) || islink(obj)) ? isblockdev(joinpat
 realpath(obj::DirEntry) = realpath(joinpath(obj))
 
 """
-    readdir(::Type{DirEntry}, dir::AbstractString=pwd(); sort::Bool = true) -> Vector{DirEntry}
-    readdir(::Type{DirEntry}, entry::DirEntry; sort::Bool=true) -> Vector{DirEntry}
-    readdir(entry::DirEntry; join::Bool=false, sort::Bool=true) -> Vector{String}
+    readdir(dir::AbstractString, ::Type{DirEntry}; sort::Bool=true)::Vector{DirEntry}
+    readdir(::Type{DirEntry}; sort::Bool=true)::Vector{DirEntry}
+    readdir(entry::DirEntry, ::Type{DirEntry}; sort::Bool=true)::Vector{DirEntry}
+    readdir(entry::DirEntry; join::Bool=false, sort::Bool=true)::Vector{String}
 
 Return a vector of [`DirEntry`](@ref) objects representing the contents of the directory `dir`,
 or the current working directory if not given. If `sort` is true, the returned vector is
 sorted by name.
 
-The element type is selected by the leading type argument: pass `DirEntry` to get
-[`DirEntry`](@ref) objects (which carry the type of each entry as determined during the
-directory scan, so [`isfile`](@ref), [`isdir`](@ref), etc. can be called without further
-`stat` calls), or omit it to get a `Vector{String}` of names — independent of whether the
-directory was specified as an `AbstractString` or a `DirEntry`. For some filesystems the
-type of the entry cannot be determined without a `stat` call; in those cases the `rawtype`
-field of the [`DirEntry`](@ref) is 0 (`UV_DIRENT_UNKNOWN`) and the predicates fall back to
-a `stat` call.
+The element type is selected by the trailing `DirEntry` type argument (mirroring
+[`read(io, String)`](@ref)): include it to get [`DirEntry`](@ref) objects (which carry the
+type of each entry as determined during the directory scan, so [`isfile`](@ref),
+[`isdir`](@ref), etc. can be called without further `stat` calls), or omit it to get a
+`Vector{String}` of names — independent of whether the directory was specified as an
+`AbstractString` or a `DirEntry`. For some filesystems the type of the entry cannot be
+determined without a `stat` call; in those cases the `rawtype` field of the
+[`DirEntry`](@ref) is 0 (`UV_DIRENT_UNKNOWN`) and the predicates fall back to a `stat` call.
 
 # Examples
 ```julia
-for entry in readdir(DirEntry, ".")
+for entry in readdir(".", DirEntry)
     if isfile(entry)
         println("\$(basename(entry)) is a file with path \$(joinpath(entry))")
         continue
     end
     isdir(entry) || continue
-    for entry2 in readdir(DirEntry, entry)
+    for entry2 in readdir(entry, DirEntry)
         ...
     end
 end
 ```
 """
-readdir(::Type{DirEntry}, dir::AbstractString=pwd(); sort::Bool=true) = _readdir(dir; return_objects=true, sort)::Vector{DirEntry}
-readdir(::Type{DirEntry}, entry::DirEntry; sort::Bool=true) = readdir(DirEntry, joinpath(entry); sort)::Vector{DirEntry}
+readdir(dir::AbstractString, ::Type{DirEntry}; sort::Bool=true) = _readdir(dir; return_objects=true, sort)::Vector{DirEntry}
+readdir(::Type{DirEntry}; sort::Bool=true) = readdir(pwd(), DirEntry; sort)::Vector{DirEntry}
+readdir(entry::DirEntry, ::Type{DirEntry}; sort::Bool=true) = readdir(joinpath(entry), DirEntry; sort)::Vector{DirEntry}
 readdir(entry::DirEntry; kwargs...) = readdir(joinpath(entry); kwargs...)::Vector{String}
 
 function _readdir(dir::AbstractString; return_objects::Bool=false, join::Bool=false, sort::Bool=true)
@@ -1162,161 +1163,6 @@ function _readdir(dir::AbstractString; return_objects::Bool=false, join::Bool=fa
         return entries
     finally
         Libc.free(req)
-    end
-end
-
-"""
-    DirEntryIterator{T}
-
-A stateful, single-pass iterator over the entries of a directory, yielding
-either filename `String`s or [`DirEntry`](@ref) objects depending on the
-element type `T`. Created by [`scandir`](@ref).
-
-The underlying directory handle is opened lazily on the first call to
-`iterate` (via `uv_fs_opendir`) and is released when iteration reaches
-end-of-directory, when [`close`](@ref) is called, or by a finalizer.
-Entries are streamed one at a time from the operating system; the full
-listing is never materialized in memory. For deterministic cleanup on
-very large directories, prefer the do-block form of `scandir`.
-
-A `DirEntryIterator` is single-consumer: do not iterate or close it from
-multiple tasks concurrently. Calling `close` from a finalizer while the
-owning task has finished iterating is safe.
-"""
-mutable struct DirEntryIterator{T}
-    const dir::String
-    # Yield joinpath(dir, name) instead of the bare name (String eltype only)
-    const join::Bool
-    # Opaque uv_dir_t* returned by jl_uv_fs_opendir; C_NULL until opened and
-    # C_NULL again after close. Acts as the ownership gate: the thread that
-    # atomically swaps it to C_NULL is the sole owner of the resources below
-    # and is responsible for cleanup.
-    @atomic uvdir::Ptr{Cvoid}
-    # Single-entry uv_dirent_t buffer passed to jl_uv_fs_readdir; libuv writes
-    # the name pointer and type into it. Held here so its address remains
-    # valid for the lifetime of the iterator.
-    ent::Base.RefValue{uv_dirent_t}
-    closed::Bool
-    function DirEntryIterator{T}(dir::AbstractString, join::Bool=false) where {T}
-        T === String || T === DirEntry || throw(ArgumentError("element type must be String or DirEntry"))
-        finalizer(close, new{T}(String(dir), join, C_NULL, Ref{uv_dirent_t}(), false))
-    end
-end
-
-function _scandir_open!(it::DirEntryIterator)
-    it.uvdir == C_NULL || return
-    it.closed && throw(ArgumentError("DirEntryIterator has already been consumed"))
-    dir_out = Ref{Ptr{Cvoid}}(C_NULL)
-    err = ccall(:jl_uv_fs_opendir, Cint,
-                (Cstring, Ptr{Ptr{Cvoid}}),
-                it.dir, dir_out)
-    if err < 0
-        it.closed = true
-        uv_error("scandir($(repr(it.dir)))", err)
-    end
-    @atomic it.uvdir = dir_out[]
-    return
-end
-
-function Base.close(it::DirEntryIterator)
-    # Atomically claim the dir pointer so a concurrent finalizer cannot double-free.
-    uvdir = @atomicswap it.uvdir = C_NULL
-    if uvdir != C_NULL
-        ccall(:jl_uv_fs_closedir, Cint, (Ptr{Cvoid},), uvdir)
-    end
-    it.closed = true
-    return
-end
-
-Base.IteratorSize(::Type{<:DirEntryIterator}) = Base.SizeUnknown()
-Base.eltype(::Type{DirEntryIterator{T}}) where {T} = T
-Base.isdone(it::DirEntryIterator, _=nothing) = it.closed
-
-function Base.iterate(it::DirEntryIterator{T}, _=nothing) where {T}
-    _scandir_open!(it)
-    rc = ccall(:jl_uv_fs_readdir, Cssize_t,
-               (Ptr{Cvoid}, Ptr{uv_dirent_t}, Csize_t),
-               it.uvdir, it.ent, 1)
-    if rc <= 0
-        if rc < 0
-            err = rc
-            close(it)
-            uv_error("scandir($(repr(it.dir)))", err)
-        end
-        close(it)
-        return nothing
-    end
-    ent = it.ent[]
-    name = unsafe_string(ent.name)
-    Libc.free(ent.name)
-    value = T === DirEntry ? DirEntry(it.dir, name, ent.typ) :
-            it.join ? joinpath(it.dir, name) : name
-    return value, nothing
-end
-
-"""
-    scandir(dir::AbstractString=pwd(); join::Bool=false)   -> DirEntryIterator{String}
-    scandir(entry::DirEntry; join::Bool=false)             -> DirEntryIterator{String}
-    scandir(::Type{DirEntry}, dir::AbstractString=pwd())   -> DirEntryIterator{DirEntry}
-    scandir(::Type{DirEntry}, entry::DirEntry)             -> DirEntryIterator{DirEntry}
-    scandir(f, [::Type{DirEntry},] dir; kwargs...)         -> f(::DirEntryIterator)
-
-Return a stateful, single-pass iterator over the contents of the directory `dir`
-(or the current working directory if not given), without first materializing the
-full listing. Useful for very large directories or when iteration may be
-short-circuited (e.g. with `break` or [`Iterators.take`](@ref)).
-
-By default the iterator yields filename `String`s, matching [`readdir`](@ref);
-if `join` is true it yields `joinpath(dir, name)` for each name instead.
-Pass `DirEntry` as the leading type argument to yield [`DirEntry`](@ref)
-objects, which carry the entry type as cached at scan time so [`isfile`](@ref),
-[`isdir`](@ref), etc. can be checked without further `stat` calls (the full
-path of a `DirEntry` is available via `joinpath(entry)`, so there is no `join`
-keyword for that form, as with `readdir(DirEntry, dir)`).
-
-Unlike [`readdir`](@ref), the entries are returned in filesystem order (not
-sorted) and the iterator can only be traversed once. The do-block form ensures
-the underlying directory handle is released as soon as `f` returns; otherwise
-cleanup happens at end-of-iteration, on [`close`](@ref), or via a finalizer.
-
-See also [`readdir`](@ref), [`DirEntry`](@ref), [`walkdir`](@ref).
-
-!!! compat "Julia 1.14"
-    `scandir` requires Julia 1.14 or later.
-
-# Examples
-```julia
-# short-circuit a huge directory
-for entry in scandir(DirEntry, "/very/large/dir")
-    isfile(entry) && basename(entry) == "needle.txt" && break
-end
-
-# deterministic cleanup
-scandir("/very/large/dir") do names
-    for name in names
-        ...
-    end
-end
-```
-"""
-scandir(dir::AbstractString=pwd(); join::Bool=false) = DirEntryIterator{String}(dir, join)
-scandir(entry::DirEntry; join::Bool=false) = DirEntryIterator{String}(joinpath(entry), join)
-scandir(::Type{DirEntry}, dir::AbstractString=pwd()) = DirEntryIterator{DirEntry}(dir)
-scandir(::Type{DirEntry}, entry::DirEntry) = DirEntryIterator{DirEntry}(joinpath(entry))
-function scandir(f, dir; join::Bool=false)
-    it = scandir(dir; join)
-    try
-        return f(it)
-    finally
-        close(it)
-    end
-end
-function scandir(f, ::Type{DirEntry}, dir)
-    it = scandir(DirEntry, dir)
-    try
-        return f(it)
-    finally
-        close(it)
     end
 end
 
@@ -1387,7 +1233,7 @@ function _walkdir(chnl, path, topdown, follow_symlinks, onerror)
             end
             return
         end
-    entries = tryf(p -> readdir(DirEntry, p), path)
+    entries = tryf(p -> readdir(p, DirEntry), path)
     entries === nothing && return
     dirs = Vector{String}()
     files = Vector{String}()

--- a/base/file.jl
+++ b/base/file.jl
@@ -1057,8 +1057,7 @@ const UV_DIRENT_BLOCK = Cint(7)
     DirEntry
 
 A type representing a filesystem entry that contains the name of the entry, the directory, and
-the raw type of the entry. The full path of the entry can be obtained lazily via [`path`](@ref Base.Filesystem.path)
-or [`joinpath`](@ref).
+the raw type of the entry. The full path of the entry can be obtained lazily via [`joinpath(entry)`](@ref).
 
 Public fields:
 - `dir::String`: The directory containing the entry.

--- a/base/file.jl
+++ b/base/file.jl
@@ -1254,8 +1254,8 @@ cleanup happens at end-of-iteration, on [`close`](@ref), or via a finalizer.
 
 See also [`readdir`](@ref), [`DirEntry`](@ref), [`walkdir`](@ref).
 
-!!! compat "Julia 1.13"
-    `scandir` requires Julia 1.13 or later.
+!!! compat "Julia 1.14"
+    `scandir` requires Julia 1.14 or later.
 
 # Examples
 ```julia

--- a/base/file.jl
+++ b/base/file.jl
@@ -1179,7 +1179,7 @@ on very large directories, prefer the do-block form of `scandir`.
 """
 mutable struct DirEntryIterator{T}
     const dir::String
-    req::Ptr{Cvoid}     # uv_fs_t, C_NULL until opened, C_NULL again after close
+    @atomic req::Ptr{Cvoid}     # uv_fs_t, C_NULL until opened, C_NULL again after close
     closed::Bool
     function DirEntryIterator{T}(dir::AbstractString) where {T}
         T === String || T === DirEntry || throw(ArgumentError("element type must be String or DirEntry"))
@@ -1198,14 +1198,14 @@ function _scandir_open!(it::DirEntryIterator)
         it.closed = true
         uv_error("scandir($(repr(it.dir)))", err)
     end
-    it.req = req
+    @atomic it.req = req
     return
 end
 
 function Base.close(it::DirEntryIterator)
-    req = it.req
+    # Atomically claim the request pointer so a concurrent finalizer cannot double-free.
+    req = @atomicswap it.req = C_NULL
     if req != C_NULL
-        it.req = C_NULL
         uv_fs_req_cleanup(req)
         Libc.free(req)
     end

--- a/base/file.jl
+++ b/base/file.jl
@@ -1190,9 +1190,9 @@ mutable struct DirEntryIterator{T}
     # atomically swaps it to C_NULL is the sole owner of the resources below
     # and is responsible for cleanup.
     @atomic uvdir::Ptr{Cvoid}
-    # Single-entry uv_dirent_t buffer that libuv writes into via uv_fs_readdir.
-    # Must outlive `uvdir`; held here so its address remains valid for the
-    # lifetime of the iterator.
+    # Single-entry uv_dirent_t buffer passed to jl_uv_fs_readdir; libuv writes
+    # the name pointer and type into it. Held here so its address remains
+    # valid for the lifetime of the iterator.
     ent::Base.RefValue{uv_dirent_t}
     closed::Bool
     function DirEntryIterator{T}(dir::AbstractString) where {T}
@@ -1206,8 +1206,8 @@ function _scandir_open!(it::DirEntryIterator)
     it.closed && throw(ArgumentError("DirEntryIterator has already been consumed"))
     dir_out = Ref{Ptr{Cvoid}}(C_NULL)
     err = ccall(:jl_uv_fs_opendir, Cint,
-                (Cstring, Ptr{Ptr{Cvoid}}, Ptr{uv_dirent_t}),
-                it.dir, dir_out, it.ent)
+                (Cstring, Ptr{Ptr{Cvoid}}),
+                it.dir, dir_out)
     if err < 0
         it.closed = true
         uv_error("scandir($(repr(it.dir)))", err)
@@ -1232,11 +1232,9 @@ Base.isdone(it::DirEntryIterator, _=nothing) = it.closed
 
 function Base.iterate(it::DirEntryIterator{T}, _=nothing) where {T}
     _scandir_open!(it)
-    name_out = Ref{Ptr{UInt8}}(C_NULL)
-    type_out = Ref{Cint}(0)
     rc = ccall(:jl_uv_fs_readdir, Cssize_t,
-               (Ptr{Cvoid}, Ptr{Ptr{UInt8}}, Ptr{Cint}),
-               it.uvdir, name_out, type_out)
+               (Ptr{Cvoid}, Ptr{uv_dirent_t}, Csize_t),
+               it.uvdir, it.ent, 1)
     if rc <= 0
         if rc < 0
             err = rc
@@ -1246,11 +1244,10 @@ function Base.iterate(it::DirEntryIterator{T}, _=nothing) where {T}
         close(it)
         return nothing
     end
-    name_ptr = name_out[]
-    name = unsafe_string(name_ptr)
-    Libc.free(name_ptr)
-    rawtype = type_out[]
-    value = T === DirEntry ? DirEntry(it.dir, name, rawtype) : name
+    ent = it.ent[]
+    name = unsafe_string(ent.name)
+    Libc.free(ent.name)
+    value = T === DirEntry ? DirEntry(it.dir, name, ent.typ) : name
     return value, nothing
 end
 

--- a/doc/src/base/file.md
+++ b/doc/src/base/file.md
@@ -7,6 +7,7 @@ Base.Filesystem.pwd
 Base.Filesystem.cd(::AbstractString)
 Base.Filesystem.cd(::Function)
 Base.Filesystem.readdir
+Base.Filesystem.DirEntry
 Base.Filesystem.walkdir
 Base.Filesystem.mkdir
 Base.Filesystem.mkpath

--- a/doc/src/base/file.md
+++ b/doc/src/base/file.md
@@ -8,7 +8,6 @@ Base.Filesystem.cd(::AbstractString)
 Base.Filesystem.cd(::Function)
 Base.Filesystem.readdir
 Base.Filesystem.DirEntry
-Base.Filesystem.scandir
 Base.Filesystem.walkdir
 Base.Filesystem.mkdir
 Base.Filesystem.mkpath

--- a/doc/src/base/file.md
+++ b/doc/src/base/file.md
@@ -8,6 +8,7 @@ Base.Filesystem.cd(::AbstractString)
 Base.Filesystem.cd(::Function)
 Base.Filesystem.readdir
 Base.Filesystem.DirEntry
+Base.Filesystem.scandir
 Base.Filesystem.walkdir
 Base.Filesystem.mkdir
 Base.Filesystem.mkpath

--- a/src/sys.c
+++ b/src/sys.c
@@ -113,7 +113,7 @@ JL_DLLEXPORT char *jl_uv_fs_t_path(uv_fs_t *req) { return (char*)req->path; }
 // and cleans it up before returning, so callers only need to keep the opaque
 // uv_dir_t* alive between calls.
 
-JL_DLLEXPORT int jl_uv_fs_opendir(const char *path, uv_dir_t **dir_out, uv_dirent_t *ent_buf)
+JL_DLLEXPORT int jl_uv_fs_opendir(const char *path, uv_dir_t **dir_out)
 {
     uv_fs_t req;
     int ret = uv_fs_opendir(unused_uv_loop_arg, &req, path, NULL);
@@ -123,34 +123,35 @@ JL_DLLEXPORT int jl_uv_fs_opendir(const char *path, uv_dir_t **dir_out, uv_diren
         return ret;
     }
     uv_dir_t *dir = (uv_dir_t*)req.ptr;
-    // Configure libuv to read one entry per uv_fs_readdir call into the
-    // caller-provided buffer.
-    dir->dirents = ent_buf;
-    dir->nentries = 1;
+    // The dirents buffer is configured per-call in jl_uv_fs_readdir.
+    dir->dirents = NULL;
+    dir->nentries = 0;
     *dir_out = dir;
     uv_fs_req_cleanup(&req);
     return 0;
 }
 
-// Reads the next directory entry. Returns 1 on success, 0 on end-of-directory,
-// or a negative libuv error code. On success, *name_out receives the strdup'd
-// entry name (caller takes ownership and must free() it) and *type_out receives
-// the entry type (a uv_dirent_type_t).
-JL_DLLEXPORT ssize_t jl_uv_fs_readdir(uv_dir_t *dir, char **name_out, int *type_out)
+// Reads up to `nentries` directory entries into the caller-provided `entries`
+// buffer. Returns the number of entries read on success, 0 on end-of-directory,
+// or a negative libuv error code. On success, each filled `entries[i].name` is
+// a strdup'd entry name owned by the caller, which must free() it. The caller
+// also owns the `entries` buffer itself.
+JL_DLLEXPORT ssize_t jl_uv_fs_readdir(uv_dir_t *dir, uv_dirent_t *entries, size_t nentries)
 {
     uv_fs_t req;
+    // Clear caller's slots so a partial/failed read leaves no stale name
+    // pointers, and so we can safely skip them when detaching ownership below.
+    for (size_t i = 0; i < nentries; ++i) {
+        entries[i].name = NULL;
+        entries[i].type = UV_DIRENT_UNKNOWN;
+    }
+    dir->dirents = entries;
+    dir->nentries = nentries;
     ssize_t r = uv_fs_readdir(unused_uv_loop_arg, &req, dir, NULL);
-    if (r > 0) {
-        uv_dirent_t *ent = &dir->dirents[0];
-        // Transfer ownership of the strdup'd name to the caller and detach it
-        // from libuv's bookkeeping so uv_fs_req_cleanup doesn't free it.
-        *name_out = (char*)ent->name;
-        ent->name = NULL;
-        *type_out = (int)ent->type;
-    }
-    else {
-        *name_out = NULL;
-    }
+    // Detach the entries from libuv's bookkeeping so uv_fs_req_cleanup
+    // doesn't free the strdup'd names; ownership now belongs to the caller.
+    dir->dirents = NULL;
+    dir->nentries = 0;
     uv_fs_req_cleanup(&req);
     return r;
 }

--- a/src/sys.c
+++ b/src/sys.c
@@ -106,64 +106,6 @@ JL_DLLEXPORT int32_t jl_nb_available(ios_t *s)
 JL_DLLEXPORT char *jl_uv_fs_t_ptr(uv_fs_t *req) { return (char*)req->ptr; }
 JL_DLLEXPORT char *jl_uv_fs_t_path(uv_fs_t *req) { return (char*)req->path; }
 
-// --- streaming directory iteration ---
-//
-// These helpers wrap uv_fs_opendir / uv_fs_readdir / uv_fs_closedir and hide
-// the uv_dir_t struct layout from Julia. Each runs one synchronous fs request
-// and cleans it up before returning, so callers only need to keep the opaque
-// uv_dir_t* alive between calls.
-
-JL_DLLEXPORT int jl_uv_fs_opendir(const char *path, uv_dir_t **dir_out)
-{
-    uv_fs_t req;
-    int ret = uv_fs_opendir(unused_uv_loop_arg, &req, path, NULL);
-    if (ret < 0) {
-        uv_fs_req_cleanup(&req);
-        *dir_out = NULL;
-        return ret;
-    }
-    uv_dir_t *dir = (uv_dir_t*)req.ptr;
-    // The dirents buffer is configured per-call in jl_uv_fs_readdir.
-    dir->dirents = NULL;
-    dir->nentries = 0;
-    *dir_out = dir;
-    uv_fs_req_cleanup(&req);
-    return 0;
-}
-
-// Reads up to `nentries` directory entries into the caller-provided `entries`
-// buffer. Returns the number of entries read on success, 0 on end-of-directory,
-// or a negative libuv error code. On success, each filled `entries[i].name` is
-// a strdup'd entry name owned by the caller, which must free() it. The caller
-// also owns the `entries` buffer itself.
-JL_DLLEXPORT ssize_t jl_uv_fs_readdir(uv_dir_t *dir, uv_dirent_t *entries, size_t nentries)
-{
-    uv_fs_t req;
-    // Clear caller's slots so a partial/failed read leaves no stale name
-    // pointers, and so we can safely skip them when detaching ownership below.
-    for (size_t i = 0; i < nentries; ++i) {
-        entries[i].name = NULL;
-        entries[i].type = UV_DIRENT_UNKNOWN;
-    }
-    dir->dirents = entries;
-    dir->nentries = nentries;
-    ssize_t r = uv_fs_readdir(unused_uv_loop_arg, &req, dir, NULL);
-    // Detach the entries from libuv's bookkeeping so uv_fs_req_cleanup
-    // doesn't free the strdup'd names; ownership now belongs to the caller.
-    dir->dirents = NULL;
-    dir->nentries = 0;
-    uv_fs_req_cleanup(&req);
-    return r;
-}
-
-JL_DLLEXPORT int jl_uv_fs_closedir(uv_dir_t *dir)
-{
-    uv_fs_t req;
-    int ret = uv_fs_closedir(unused_uv_loop_arg, &req, dir, NULL);
-    uv_fs_req_cleanup(&req);
-    return ret;
-}
-
 // --- stat ---
 JL_DLLEXPORT int jl_sizeof_stat(void) { return sizeof(uv_stat_t); }
 

--- a/src/sys.c
+++ b/src/sys.c
@@ -106,6 +106,63 @@ JL_DLLEXPORT int32_t jl_nb_available(ios_t *s)
 JL_DLLEXPORT char *jl_uv_fs_t_ptr(uv_fs_t *req) { return (char*)req->ptr; }
 JL_DLLEXPORT char *jl_uv_fs_t_path(uv_fs_t *req) { return (char*)req->path; }
 
+// --- streaming directory iteration ---
+//
+// These helpers wrap uv_fs_opendir / uv_fs_readdir / uv_fs_closedir and hide
+// the uv_dir_t struct layout from Julia. Each runs one synchronous fs request
+// and cleans it up before returning, so callers only need to keep the opaque
+// uv_dir_t* alive between calls.
+
+JL_DLLEXPORT int jl_uv_fs_opendir(const char *path, uv_dir_t **dir_out, uv_dirent_t *ent_buf)
+{
+    uv_fs_t req;
+    int ret = uv_fs_opendir(unused_uv_loop_arg, &req, path, NULL);
+    if (ret < 0) {
+        uv_fs_req_cleanup(&req);
+        *dir_out = NULL;
+        return ret;
+    }
+    uv_dir_t *dir = (uv_dir_t*)req.ptr;
+    // Configure libuv to read one entry per uv_fs_readdir call into the
+    // caller-provided buffer.
+    dir->dirents = ent_buf;
+    dir->nentries = 1;
+    *dir_out = dir;
+    uv_fs_req_cleanup(&req);
+    return 0;
+}
+
+// Reads the next directory entry. Returns 1 on success, 0 on end-of-directory,
+// or a negative libuv error code. On success, *name_out receives the strdup'd
+// entry name (caller takes ownership and must free() it) and *type_out receives
+// the entry type (a uv_dirent_type_t).
+JL_DLLEXPORT ssize_t jl_uv_fs_readdir(uv_dir_t *dir, char **name_out, int *type_out)
+{
+    uv_fs_t req;
+    ssize_t r = uv_fs_readdir(unused_uv_loop_arg, &req, dir, NULL);
+    if (r > 0) {
+        uv_dirent_t *ent = &dir->dirents[0];
+        // Transfer ownership of the strdup'd name to the caller and detach it
+        // from libuv's bookkeeping so uv_fs_req_cleanup doesn't free it.
+        *name_out = (char*)ent->name;
+        ent->name = NULL;
+        *type_out = (int)ent->type;
+    }
+    else {
+        *name_out = NULL;
+    }
+    uv_fs_req_cleanup(&req);
+    return r;
+}
+
+JL_DLLEXPORT int jl_uv_fs_closedir(uv_dir_t *dir)
+{
+    uv_fs_t req;
+    int ret = uv_fs_closedir(unused_uv_loop_arg, &req, dir, NULL);
+    uv_fs_req_cleanup(&req);
+    return ret;
+}
+
 // --- stat ---
 JL_DLLEXPORT int jl_sizeof_stat(void) { return sizeof(uv_stat_t); }
 

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -493,8 +493,9 @@ function cache_PATH()
             # here, or even on whether the current user can execute the file in question.
             try
                 if isfile(entry)
-                    @lock PATH_cache_lock push!(PATH_cache, entry.name)
-                    push!(this_PATH_cache, entry.name)
+                    name = basename(entry)
+                    @lock PATH_cache_lock push!(PATH_cache, name)
+                    push!(this_PATH_cache, name)
                 end
             catch e
                 # `isfile()` can throw in rare cases such as when probing a
@@ -553,9 +554,10 @@ function complete_path(path::AbstractString;
 
     matches = Set{String}()
     for entry in entries
-        if startswith(entry.name, prefix)
+        name = basename(entry)
+        if startswith(name, prefix)
             is_dir = try isdir(entry) catch ex; ex isa Base.IOError ? false : rethrow() end
-            push!(matches, is_dir ? joinpath_withsep(entry.name, ""; dirsep) : entry.name)
+            push!(matches, is_dir ? joinpath_withsep(name, ""; dirsep) : name)
         end
     end
 
@@ -1089,7 +1091,7 @@ function complete_loading_candidates!(suggestions::Vector{Completion}, s::String
         end
         isdir(dir) || continue
         for entry in readdir(DirEntry, dir)
-            pname = entry.name
+            pname = basename(entry)
             if pname[1] != '.' && pname != "METADATA" &&
                 pname != "REQUIRE" && startswith(pname, s)
                 # Valid file paths are

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -478,7 +478,7 @@ function cache_PATH()
         end
 
         path_entries = try
-            readdir(DirEntry, pathdir)
+            readdir(pathdir, DirEntry)
         catch e
             # Bash allows dirs in PATH that can't be read, so we should as well.
             if isa(e, Base.IOError) || isa(e, Base.ArgumentError)
@@ -543,7 +543,7 @@ function complete_path(path::AbstractString;
         if isempty(dir)
             readdir(DirEntry)
         elseif isdir(dir)
-            readdir(DirEntry, dir)
+            readdir(dir, DirEntry)
         else
             return Completion[], dir, false
         end
@@ -1090,7 +1090,7 @@ function complete_loading_candidates!(suggestions::Vector{Completion}, s::String
             end
         end
         isdir(dir) || continue
-        for entry in readdir(DirEntry, dir)
+        for entry in readdir(dir, DirEntry)
             pname = basename(entry)
             if pname[1] != '.' && pname != "METADATA" &&
                 pname != "REQUIRE" && startswith(pname, s)

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -11,7 +11,6 @@ using Core: Const
 const CC = Base.Compiler
 using Base.Meta
 using Base: propertynames, something, IdSet
-using Base.Filesystem: _readdirx
 using Base.JuliaSyntax: @K_str, @KSet_str, parseall, byte_range, children, is_prefix_call, is_trivia, kind
 
 using ..REPL.LineEdit: NamedCompletion
@@ -479,7 +478,7 @@ function cache_PATH()
         end
 
         path_entries = try
-            _readdirx(pathdir)
+            readdir(DirEntry, pathdir)
         catch e
             # Bash allows dirs in PATH that can't be read, so we should as well.
             if isa(e, Base.IOError) || isa(e, Base.ArgumentError)
@@ -541,9 +540,9 @@ function complete_path(path::AbstractString;
     end
     entries = try
         if isempty(dir)
-            _readdirx()
+            readdir(DirEntry)
         elseif isdir(dir)
-            _readdirx(dir)
+            readdir(DirEntry, dir)
         else
             return Completion[], dir, false
         end
@@ -1089,7 +1088,7 @@ function complete_loading_candidates!(suggestions::Vector{Completion}, s::String
             end
         end
         isdir(dir) || continue
-        for entry in _readdirx(dir)
+        for entry in readdir(DirEntry, dir)
             pname = entry.name
             if pname[1] != '.' && pname != "METADATA" &&
                 pname != "REQUIRE" && startswith(pname, s)

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -394,7 +394,7 @@ function find_readme(m::Module)::Union{String, Nothing}
     path = dirname(mpath)
     top_path = pkgdir(m)
     while true
-        for entry in readdir(DirEntry, path; sort=true)
+        for entry in readdir(path, DirEntry; sort=true)
             isfile(entry) && (lowercase(basename(entry)) in ["readme.md", "readme"]) || continue
             return joinpath(entry)
         end

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -395,7 +395,7 @@ function find_readme(m::Module)::Union{String, Nothing}
     top_path = pkgdir(m)
     while true
         for entry in readdir(DirEntry, path; sort=true)
-            isfile(entry) && (lowercase(entry.name) in ["readme.md", "readme"]) || continue
+            isfile(entry) && (lowercase(basename(entry)) in ["readme.md", "readme"]) || continue
             return joinpath(entry)
         end
         path == top_path && break # go no further than pkgdir

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -11,8 +11,6 @@ import Base.Docs: doc, formatdoc, parsedoc, apropos
 
 using Base: with_output_color, mapany, isdeprecated, isexported
 
-using Base.Filesystem: _readdirx
-
 using InteractiveUtils: subtypes
 
 using Unicode: normalize
@@ -396,7 +394,7 @@ function find_readme(m::Module)::Union{String, Nothing}
     path = dirname(mpath)
     top_path = pkgdir(m)
     while true
-        for entry in _readdirx(path; sort=true)
+        for entry in readdir(DirEntry, path; sort=true)
             isfile(entry) && (lowercase(entry.name) in ["readme.md", "readme"]) || continue
             return joinpath(entry)
         end

--- a/test/file.jl
+++ b/test/file.jl
@@ -72,6 +72,12 @@ end
         @test sort!(collect(scandir(dir))) == sort!(readdir(dir))
         # DirEntry form yields DirEntry objects matching readdir(DirEntry, ...)
         @test sort!(basename.(collect(scandir(DirEntry, dir)))) == sort!(readdir(dir))
+        # join=true yields full paths matching readdir(dir; join=true)
+        @test sort!(collect(scandir(dir; join=true))) == sort!(readdir(dir; join=true))
+        joined = scandir(dir; join=true) do paths
+            collect(paths)
+        end
+        @test sort!(joined) == sort!(readdir(dir; join=true))
 
         # Iterator type and traits
         it = scandir(dir)
@@ -112,6 +118,7 @@ end
         sub = only(e for e in readdir(DirEntry, dir) if isdir(e))
         @test sort!(collect(scandir(sub))) == ["bfile.txt"]
         @test sort!(basename.(collect(scandir(DirEntry, sub)))) == ["bfile.txt"]
+        @test sort!(collect(scandir(sub; join=true))) == [joinpath(dir, "adir", "bfile.txt")]
     end
 end
 

--- a/test/file.jl
+++ b/test/file.jl
@@ -27,8 +27,8 @@ let err = nothing
 end
 
 @testset "readdir" begin
-    @test ispath("does/not/exist") == false
-    @test isdir("does/not/exist") == false
+    @test !ispath("does/not/exist")
+    @test !isdir("does/not/exist")
     @test_throws Base.IOError readdir("does/not/exist")
     @test_throws Base.IOError readdir(DirEntry, "does/not/exist")
 
@@ -37,7 +37,7 @@ end
         mkdir(joinpath(dir, "adir"))
         touch(joinpath(dir, "adir", "bfile.txt"))
         @test length(readdir(dir)) == 2
-        @test readdir(dir) == map(e->e.name, readdir(DirEntry, dir))
+        @test readdir(dir) == basename.(readdir(DirEntry, dir))
         for p in readdir(dir, join=true)
             if isdir(p)
                 @test only(readdir(p)) == "bfile.txt"

--- a/test/file.jl
+++ b/test/file.jl
@@ -48,9 +48,8 @@ end
         end
         for e in readdir(DirEntry, dir)
             if isdir(e)
-                @test only(readdir(e)).name == "bfile.txt"
+                @test only(readdir(e)) == "bfile.txt"
                 @test only(readdir(DirEntry, e)).name == "bfile.txt"
-                @test only(readdir(String, e)) == "bfile.txt"
             else
                 @test isfile(e)
                 @test e.name == "afile.txt"
@@ -59,23 +58,27 @@ end
     end
 end
 
-# scandir: lazy single-pass iteration of DirEntry objects
+# scandir: lazy single-pass iteration; default String, opt into DirEntry
 @testset "scandir" begin
     @test_throws Base.IOError iterate(scandir("does/not/exist"))
+    @test_throws Base.IOError iterate(scandir(DirEntry, "does/not/exist"))
 
     mktempdir() do dir
         touch(joinpath(dir, "afile.txt"))
         mkdir(joinpath(dir, "adir"))
         touch(joinpath(dir, "adir", "bfile.txt"))
 
-        # Same contents as readdir(DirEntry, …) modulo order
-        names = sort!(map(e -> e.name, collect(scandir(dir))))
-        @test names == sort!(readdir(dir))
+        # Default yields String names matching readdir
+        @test sort!(collect(scandir(dir))) == sort!(readdir(dir))
+        # DirEntry form yields DirEntry objects matching readdir(DirEntry, ...)
+        @test sort!(map(e -> e.name, collect(scandir(DirEntry, dir)))) == sort!(readdir(dir))
 
         # Iterator type and traits
         it = scandir(dir)
-        @test eltype(it) === Base.Filesystem.DirEntry
+        @test eltype(it) === String
         @test Base.IteratorSize(it) === Base.SizeUnknown()
+        itD = scandir(DirEntry, dir)
+        @test eltype(itD) === Base.Filesystem.DirEntry
 
         # Single-pass: once consumed, cannot iterate again
         for _ in it; end
@@ -85,6 +88,9 @@ end
         for e in scandir(dir)
             break
         end
+        for e in scandir(DirEntry, dir)
+            break
+        end
 
         # Explicit close is idempotent and disallows further iteration
         it2 = scandir(dir)
@@ -92,15 +98,20 @@ end
         close(it2)
         @test_throws ArgumentError iterate(it2)
 
-        # do-block form runs and cleans up
-        seen = scandir(dir) do entries
-            collect(e.name for e in entries)
+        # do-block forms run and clean up
+        seen = scandir(dir) do names
+            collect(names)
         end
         @test sort!(seen) == sort!(readdir(dir))
+        seenD = scandir(DirEntry, dir) do entries
+            collect(e.name for e in entries)
+        end
+        @test sort!(seenD) == sort!(readdir(dir))
 
         # Accepts a DirEntry as input
         sub = only(e for e in readdir(DirEntry, dir) if isdir(e))
-        @test sort!(map(e -> e.name, collect(scandir(sub)))) == ["bfile.txt"]
+        @test sort!(collect(scandir(sub))) == ["bfile.txt"]
+        @test sort!(map(e -> e.name, collect(scandir(DirEntry, sub)))) == ["bfile.txt"]
     end
 end
 

--- a/test/file.jl
+++ b/test/file.jl
@@ -59,6 +59,51 @@ end
     end
 end
 
+# scandir: lazy single-pass iteration of DirEntry objects
+@testset "scandir" begin
+    @test_throws Base.IOError iterate(scandir("does/not/exist"))
+
+    mktempdir() do dir
+        touch(joinpath(dir, "afile.txt"))
+        mkdir(joinpath(dir, "adir"))
+        touch(joinpath(dir, "adir", "bfile.txt"))
+
+        # Same contents as readdir(DirEntry, …) modulo order
+        names = sort!(map(e -> e.name, collect(scandir(dir))))
+        @test names == sort!(readdir(dir))
+
+        # Iterator type and traits
+        it = scandir(dir)
+        @test eltype(it) === Base.Filesystem.DirEntry
+        @test Base.IteratorSize(it) === Base.SizeUnknown()
+
+        # Single-pass: once consumed, cannot iterate again
+        for _ in it; end
+        @test_throws ArgumentError iterate(it)
+
+        # Short-circuit via break does not error and frees resources via finalizer/close
+        for e in scandir(dir)
+            break
+        end
+
+        # Explicit close is idempotent and disallows further iteration
+        it2 = scandir(dir)
+        close(it2)
+        close(it2)
+        @test_throws ArgumentError iterate(it2)
+
+        # do-block form runs and cleans up
+        seen = scandir(dir) do entries
+            collect(e.name for e in entries)
+        end
+        @test sort!(seen) == sort!(readdir(dir))
+
+        # Accepts a DirEntry as input
+        sub = only(e for e in readdir(DirEntry, dir) if isdir(e))
+        @test sort!(map(e -> e.name, collect(scandir(sub)))) == ["bfile.txt"]
+    end
+end
+
 if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     dirlink = joinpath(dir, "dirlink")
     symlink(subdir, dirlink)

--- a/test/file.jl
+++ b/test/file.jl
@@ -30,14 +30,14 @@ end
     @test !ispath("does/not/exist")
     @test !isdir("does/not/exist")
     @test_throws Base.IOError readdir("does/not/exist")
-    @test_throws Base.IOError readdir(DirEntry, "does/not/exist")
+    @test_throws Base.IOError readdir("does/not/exist", DirEntry)
 
     mktempdir() do dir
         touch(joinpath(dir, "afile.txt"))
         mkdir(joinpath(dir, "adir"))
         touch(joinpath(dir, "adir", "bfile.txt"))
         @test length(readdir(dir)) == 2
-        @test readdir(dir) == basename.(readdir(DirEntry, dir))
+        @test readdir(dir) == basename.(readdir(dir, DirEntry))
         for p in readdir(dir, join=true)
             if isdir(p)
                 @test only(readdir(p)) == "bfile.txt"
@@ -46,10 +46,10 @@ end
                 @test p == joinpath(dir, "afile.txt")
             end
         end
-        for e in readdir(DirEntry, dir)
+        for e in readdir(dir, DirEntry)
             if isdir(e)
                 @test only(readdir(e)) == "bfile.txt"
-                @test basename(only(readdir(DirEntry, e))) == "bfile.txt"
+                @test basename(only(readdir(e, DirEntry))) == "bfile.txt"
             else
                 @test isfile(e)
                 @test basename(e) == "afile.txt"
@@ -58,77 +58,13 @@ end
     end
 end
 
-# scandir: lazy single-pass iteration; default String, opt into DirEntry
-@testset "scandir" begin
-    @test_throws Base.IOError iterate(scandir("does/not/exist"))
-    @test_throws Base.IOError iterate(scandir(DirEntry, "does/not/exist"))
-
-    mktempdir() do dir
-        touch(joinpath(dir, "afile.txt"))
-        mkdir(joinpath(dir, "adir"))
-        touch(joinpath(dir, "adir", "bfile.txt"))
-
-        # Default yields String names matching readdir
-        @test sort!(collect(scandir(dir))) == sort!(readdir(dir))
-        # DirEntry form yields DirEntry objects matching readdir(DirEntry, ...)
-        @test sort!(basename.(collect(scandir(DirEntry, dir)))) == sort!(readdir(dir))
-        # join=true yields full paths matching readdir(dir; join=true)
-        @test sort!(collect(scandir(dir; join=true))) == sort!(readdir(dir; join=true))
-        joined = scandir(dir; join=true) do paths
-            collect(paths)
-        end
-        @test sort!(joined) == sort!(readdir(dir; join=true))
-
-        # Iterator type and traits
-        it = scandir(dir)
-        @test eltype(it) === String
-        @test Base.IteratorSize(it) === Base.SizeUnknown()
-        itD = scandir(DirEntry, dir)
-        @test eltype(itD) === Base.Filesystem.DirEntry
-
-        # Single-pass: once consumed, cannot iterate again
-        for _ in it; end
-        @test_throws ArgumentError iterate(it)
-
-        # Short-circuit via break does not error and frees resources via finalizer/close
-        for e in scandir(dir)
-            break
-        end
-        for e in scandir(DirEntry, dir)
-            break
-        end
-
-        # Explicit close is idempotent and disallows further iteration
-        it2 = scandir(dir)
-        close(it2)
-        close(it2)
-        @test_throws ArgumentError iterate(it2)
-
-        # do-block forms run and clean up
-        seen = scandir(dir) do names
-            collect(names)
-        end
-        @test sort!(seen) == sort!(readdir(dir))
-        seenD = scandir(DirEntry, dir) do entries
-            collect(basename(e) for e in entries)
-        end
-        @test sort!(seenD) == sort!(readdir(dir))
-
-        # Accepts a DirEntry as input
-        sub = only(e for e in readdir(DirEntry, dir) if isdir(e))
-        @test sort!(collect(scandir(sub))) == ["bfile.txt"]
-        @test sort!(basename.(collect(scandir(DirEntry, sub)))) == ["bfile.txt"]
-        @test sort!(collect(scandir(sub; join=true))) == [joinpath(dir, "adir", "bfile.txt")]
-    end
-end
-
 if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     dirlink = joinpath(dir, "dirlink")
     symlink(subdir, dirlink)
     @test stat(dirlink) == stat(subdir)
     @test readdir(dirlink) == readdir(subdir)
-    @test basename.(readdir(DirEntry, dirlink)) == basename.(readdir(DirEntry, subdir))
-    @test realpath.(readdir(DirEntry, dirlink)) == realpath.(readdir(DirEntry, subdir))
+    @test basename.(readdir(dirlink, DirEntry)) == basename.(readdir(subdir, DirEntry))
+    @test realpath.(readdir(dirlink, DirEntry)) == realpath.(readdir(subdir, DirEntry))
 
     # relative link
     relsubdirlink = joinpath(subdir, "rel_subdirlink")
@@ -136,8 +72,8 @@ if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     symlink(reldir, relsubdirlink)
     @test stat(relsubdirlink) == stat(subdir2)
     @test readdir(relsubdirlink) == readdir(subdir2)
-    @test basename.(readdir(DirEntry, relsubdirlink)) == basename.(readdir(DirEntry, subdir2))
-    @test realpath.(readdir(DirEntry, relsubdirlink)) == realpath.(readdir(DirEntry, subdir2))
+    @test basename.(readdir(relsubdirlink, DirEntry)) == basename.(readdir(subdir2, DirEntry))
+    @test realpath.(readdir(relsubdirlink, DirEntry)) == realpath.(readdir(subdir2, DirEntry))
 
     # creation of symlink to directory that does not yet exist
     new_dir = joinpath(subdir, "new_dir")
@@ -156,7 +92,7 @@ if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     mkdir(new_dir)
     touch(foo_file)
     @test readdir(new_dir) == readdir(nedlink)
-    @test realpath.(readdir(DirEntry, new_dir)) == realpath.(readdir(DirEntry, nedlink))
+    @test realpath.(readdir(new_dir, DirEntry)) == realpath.(readdir(nedlink, DirEntry))
 
     rm(foo_file)
     rm(new_dir)

--- a/test/file.jl
+++ b/test/file.jl
@@ -49,10 +49,10 @@ end
         for e in readdir(DirEntry, dir)
             if isdir(e)
                 @test only(readdir(e)) == "bfile.txt"
-                @test only(readdir(DirEntry, e)).name == "bfile.txt"
+                @test basename(only(readdir(DirEntry, e))) == "bfile.txt"
             else
                 @test isfile(e)
-                @test e.name == "afile.txt"
+                @test basename(e) == "afile.txt"
             end
         end
     end
@@ -71,7 +71,7 @@ end
         # Default yields String names matching readdir
         @test sort!(collect(scandir(dir))) == sort!(readdir(dir))
         # DirEntry form yields DirEntry objects matching readdir(DirEntry, ...)
-        @test sort!(map(e -> e.name, collect(scandir(DirEntry, dir)))) == sort!(readdir(dir))
+        @test sort!(basename.(collect(scandir(DirEntry, dir)))) == sort!(readdir(dir))
 
         # Iterator type and traits
         it = scandir(dir)

--- a/test/file.jl
+++ b/test/file.jl
@@ -47,9 +47,10 @@ end
             end
         end
         for e in readdir(DirEntry, dir)
-            if isdir(e) || continue
+            if isdir(e)
                 @test only(readdir(e)).name == "bfile.txt"
                 @test only(readdir(DirEntry, e)).name == "bfile.txt"
+                @test only(readdir(String, e)) == "bfile.txt"
             else
                 @test isfile(e)
                 @test e.name == "afile.txt"
@@ -63,8 +64,8 @@ if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     symlink(subdir, dirlink)
     @test stat(dirlink) == stat(subdir)
     @test readdir(dirlink) == readdir(subdir)
-    @test isempty(readdir(DirEntry, dirlink))
-    @test isempty(readdir(DirEntry, subdir))
+    @test map(e->e.name, readdir(DirEntry, dirlink)) == map(e->e.name, readdir(DirEntry, subdir))
+    @test realpath.(readdir(DirEntry, dirlink)) == realpath.(readdir(DirEntry, subdir))
 
     # relative link
     relsubdirlink = joinpath(subdir, "rel_subdirlink")
@@ -72,8 +73,8 @@ if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     symlink(reldir, relsubdirlink)
     @test stat(relsubdirlink) == stat(subdir2)
     @test readdir(relsubdirlink) == readdir(subdir2)
-    @test isempty(readdir(DirEntry, relsubdirlink))
-    @test isempty(readdir(DirEntry, subdir2))
+    @test map(e->e.name, readdir(DirEntry, relsubdirlink)) == map(e->e.name, readdir(DirEntry, subdir2))
+    @test realpath.(readdir(DirEntry, relsubdirlink)) == realpath.(readdir(DirEntry, subdir2))
 
     # creation of symlink to directory that does not yet exist
     new_dir = joinpath(subdir, "new_dir")

--- a/test/file.jl
+++ b/test/file.jl
@@ -26,13 +26,45 @@ let err = nothing
     end
 end
 
+@testset "readdir" begin
+    @test ispath("does/not/exist") == false
+    @test isdir("does/not/exist") == false
+    @test_throws Base.IOError readdir("does/not/exist")
+    @test_throws Base.IOError readdir(DirEntry, "does/not/exist")
+
+    mktempdir() do dir
+        touch(joinpath(dir, "afile.txt"))
+        mkdir(joinpath(dir, "adir"))
+        touch(joinpath(dir, "adir", "bfile.txt"))
+        @test length(readdir(dir)) == 2
+        @test readdir(dir) == map(e->e.name, readdir(DirEntry, dir))
+        for p in readdir(dir, join=true)
+            if isdir(p)
+                @test only(readdir(p)) == "bfile.txt"
+            else
+                @test isfile(p)
+                @test p == joinpath(dir, "afile.txt")
+            end
+        end
+        for e in readdir(DirEntry, dir)
+            if isdir(e) || continue
+                @test only(readdir(e)).name == "bfile.txt"
+                @test only(readdir(DirEntry, e)).name == "bfile.txt"
+            else
+                @test isfile(e)
+                @test e.name == "afile.txt"
+            end
+        end
+    end
+end
+
 if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     dirlink = joinpath(dir, "dirlink")
     symlink(subdir, dirlink)
     @test stat(dirlink) == stat(subdir)
     @test readdir(dirlink) == readdir(subdir)
-    @test map(o->o.names, Base.Filesystem._readdirx(dirlink)) == map(o->o.names, Base.Filesystem._readdirx(subdir))
-    @test realpath.(Base.Filesystem._readdirx(dirlink)) == realpath.(Base.Filesystem._readdirx(subdir))
+    @test isempty(readdir(DirEntry, dirlink))
+    @test isempty(readdir(DirEntry, subdir))
 
     # relative link
     relsubdirlink = joinpath(subdir, "rel_subdirlink")
@@ -40,7 +72,8 @@ if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     symlink(reldir, relsubdirlink)
     @test stat(relsubdirlink) == stat(subdir2)
     @test readdir(relsubdirlink) == readdir(subdir2)
-    @test Base.Filesystem._readdirx(relsubdirlink) == Base.Filesystem._readdirx(subdir2)
+    @test isempty(readdir(DirEntry, relsubdirlink))
+    @test isempty(readdir(DirEntry, subdir2))
 
     # creation of symlink to directory that does not yet exist
     new_dir = joinpath(subdir, "new_dir")
@@ -59,7 +92,7 @@ if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     mkdir(new_dir)
     touch(foo_file)
     @test readdir(new_dir) == readdir(nedlink)
-    @test realpath.(Base.Filesystem._readdirx(new_dir)) == realpath.(Base.Filesystem._readdirx(nedlink))
+    @test realpath.(readdir(DirEntry, new_dir)) == realpath.(readdir(DirEntry, nedlink))
 
     rm(foo_file)
     rm(new_dir)
@@ -1773,10 +1806,10 @@ rm(dirwalk, recursive=true)
                 touch(randstring())
             end
             @test issorted(readdir())
-            @test issorted(Base.Filesystem._readdirx())
-            @test map(o->o.name, Base.Filesystem._readdirx()) == readdir()
-            @test map(joinpath, Base.Filesystem._readdirx()) == readdir(join=true)
-            @test count(isfile, readdir(join=true)) == count(isfile, Base.Filesystem._readdirx())
+            @test issorted(readdir(DirEntry))
+            @test map(o->o.name, readdir(DirEntry)) == readdir()
+            @test map(Base.Filesystem.path, readdir(DirEntry)) == readdir(join=true)
+            @test count(isfile, readdir(join=true)) == count(isfile, readdir(DirEntry))
         end
     end
 end

--- a/test/file.jl
+++ b/test/file.jl
@@ -104,14 +104,14 @@ end
         end
         @test sort!(seen) == sort!(readdir(dir))
         seenD = scandir(DirEntry, dir) do entries
-            collect(e.name for e in entries)
+            collect(basename(e) for e in entries)
         end
         @test sort!(seenD) == sort!(readdir(dir))
 
         # Accepts a DirEntry as input
         sub = only(e for e in readdir(DirEntry, dir) if isdir(e))
         @test sort!(collect(scandir(sub))) == ["bfile.txt"]
-        @test sort!(map(e -> e.name, collect(scandir(DirEntry, sub)))) == ["bfile.txt"]
+        @test sort!(basename.(collect(scandir(DirEntry, sub)))) == ["bfile.txt"]
     end
 end
 
@@ -120,7 +120,7 @@ if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     symlink(subdir, dirlink)
     @test stat(dirlink) == stat(subdir)
     @test readdir(dirlink) == readdir(subdir)
-    @test map(e->e.name, readdir(DirEntry, dirlink)) == map(e->e.name, readdir(DirEntry, subdir))
+    @test basename.(readdir(DirEntry, dirlink)) == basename.(readdir(DirEntry, subdir))
     @test realpath.(readdir(DirEntry, dirlink)) == realpath.(readdir(DirEntry, subdir))
 
     # relative link
@@ -129,7 +129,7 @@ if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     symlink(reldir, relsubdirlink)
     @test stat(relsubdirlink) == stat(subdir2)
     @test readdir(relsubdirlink) == readdir(subdir2)
-    @test map(e->e.name, readdir(DirEntry, relsubdirlink)) == map(e->e.name, readdir(DirEntry, subdir2))
+    @test basename.(readdir(DirEntry, relsubdirlink)) == basename.(readdir(DirEntry, subdir2))
     @test realpath.(readdir(DirEntry, relsubdirlink)) == realpath.(readdir(DirEntry, subdir2))
 
     # creation of symlink to directory that does not yet exist
@@ -1864,8 +1864,8 @@ rm(dirwalk, recursive=true)
             end
             @test issorted(readdir())
             @test issorted(readdir(DirEntry))
-            @test map(o->o.name, readdir(DirEntry)) == readdir()
-            @test map(Base.Filesystem.path, readdir(DirEntry)) == readdir(join=true)
+            @test basename.(readdir(DirEntry)) == readdir()
+            @test joinpath.(readdir(DirEntry)) == readdir(join=true)
             @test count(isfile, readdir(join=true)) == count(isfile, readdir(DirEntry))
         end
     end


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/55333

- Renames and publicizes `Base.Filesystem._readdirx` as `readdir(path, DirEntry)`.
- ~Adds a new `scandir` lazy version~ Now on https://github.com/JuliaLang/julia/pull/62164

Some help from Claude on latter changes.