### PR TITLE
Document `Threads.threadid(::Task)`

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -28,8 +28,8 @@ julia> Threads.threadid(Threads.@spawn "foo")
 
 !!! note
     The thread that a task runs on may change if the task yields, which is known as [`Task Migration`](@ref man-task-migration).
-    For this reason in most cases it is not safe to use `threadid()` to index into, say, a vector of buffer or stateful objects.
-
+    For this reason in most cases it is not safe to use `threadid([task])` to index into, say, a vector of buffer or stateful
+    objects.
 """
 threadid() = Int(ccall(:jl_threadid, Int16, ())+1)
 

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -28,7 +28,7 @@ julia> Threads.threadid(Threads.@spawn "foo")
 
 !!! note
     The thread that a task runs on may change if the task yields, which is known as [`Task Migration`](@ref man-task-migration).
-    For this reason in most cases it is not safe to use `threadid([task])` to index into, say, a vector of buffer or stateful
+    For this reason in most cases it is not safe to use `threadid([task])` to index into, say, a vector of buffers or stateful
     objects.
 """
 threadid() = Int(ccall(:jl_threadid, Int16, ())+1)

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -4,10 +4,10 @@ export threadid, nthreads, @threads, @spawn,
        threadpool, nthreadpools
 
 """
-    Threads.threadid() -> Int
+    Threads.threadid([t::Task]) -> Int
 
-Get the ID number of the current thread of execution. The master thread has
-ID `1`.
+Get the ID number of the current thread of execution, or the thread of task
+`t`. The master thread has ID `1`.
 
 # Examples
 ```julia-repl
@@ -21,6 +21,9 @@ julia> Threads.@threads for i in 1:4
 2
 5
 4
+
+julia> Threads.threadid(Threads.@spawn "foo")
+2
 ```
 
 !!! note


### PR DESCRIPTION
This is quite handy to figure out which thread a task is running on, and I couldn't find another way to do it from outside the task.