### PR TITLE
Remove the WarnMissedTransformations pass from the 1.10 pipeline

### DIFF
--- a/src/pipeline.cpp
+++ b/src/pipeline.cpp
@@ -72,7 +72,6 @@
 #include <llvm/Transforms/Scalar/SROA.h>
 #include <llvm/Transforms/Scalar/SimpleLoopUnswitch.h>
 #include <llvm/Transforms/Scalar/SimplifyCFG.h>
-#include <llvm/Transforms/Scalar/WarnMissedTransforms.h>
 #include <llvm/Transforms/Utils/InjectTLIMappings.h>
 #include <llvm/Transforms/Vectorize/LoopVectorize.h>
 #include <llvm/Transforms/Vectorize/SLPVectorizer.h>
@@ -568,7 +567,6 @@ static void buildPipeline(ModulePassManager &MPM, PassBuilder *PB, OptimizationL
         if (O.getSpeedupLevel() >= 2) {
             buildVectorPipeline(FPM, PB, O, options);
         }
-        FPM.addPass(WarnMissedTransformationsPass());
         MPM.addPass(createModuleToFunctionPassAdaptor(std::move(FPM)));
     }
     buildIntrinsicLoweringPipeline(MPM, PB, O, options);


### PR DESCRIPTION
Backport of https://github.com/JuliaLang/julia/pull/54871 onto 1.10

We don't have the luxury of modifying the C-API. This pass surfaces LLVM missed transformation warnings,
which is surprising to users. It can be very helpful, but it can also add unactionable noise to the output
of Julia programs.

This PR simply removes it from the pipeline.
