### PR TITLE
Allow exact redefinition for types with recursive supertype reference

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -2197,6 +2197,9 @@ static int equiv_type(jl_value_t *ta, jl_value_t *tb)
     JL_GC_PUSH2(&a, &b);
     a = jl_rewrap_unionall((jl_value_t*)dta->super, dta->name->wrapper);
     b = jl_rewrap_unionall((jl_value_t*)dtb->super, dtb->name->wrapper);
+    // if tb recursively refers to itself in its supertype, assume that it refers to ta
+    // before checking whether the supertypes are equal
+    b = jl_substitute_datatype(b, dtb, dta);
     if (!jl_types_equal(a, b))
         goto no;
     JL_TRY {

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -769,6 +769,7 @@ jl_unionall_t *jl_rename_unionall(jl_unionall_t *u);
 JL_DLLEXPORT jl_value_t *jl_unwrap_unionall(jl_value_t *v JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_value_t *jl_rewrap_unionall(jl_value_t *t, jl_value_t *u);
 JL_DLLEXPORT jl_value_t *jl_rewrap_unionall_(jl_value_t *t, jl_value_t *u);
+jl_value_t* jl_substitute_datatype(jl_value_t *t, jl_datatype_t * x, jl_datatype_t * y);
 int jl_count_union_components(jl_value_t *v);
 JL_DLLEXPORT jl_value_t *jl_nth_union_component(jl_value_t *v JL_PROPAGATES_ROOT, int i) JL_NOTSAFEPOINT;
 int jl_find_union_component(jl_value_t *haystack, jl_value_t *needle, unsigned *nth) JL_NOTSAFEPOINT;

--- a/test/core.jl
+++ b/test/core.jl
@@ -5612,19 +5612,19 @@ end
 end
 
 # issue #54757, type redefinitions with recursive reference in supertype
-struct T54757{A>:Int,N} <: AbstractArray{Tuple{X,Union{T54757{Union{X,Integer}},T54757{A,N}},Vararg{T54757,N}} where X, N}
+struct T54757{A>:Int,N} <: AbstractArray{Tuple{X,Tuple{Vararg},Union{T54757{Union{X,Integer}},T54757{A,N}},Vararg{Y,N}} where {X,Y<:T54757}, N}
     x::A
     y::Union{A,T54757{A,N}}
     z::T54757{A}
 end
 
-struct T54757{A>:Int,N} <: AbstractArray{Tuple{X,Union{T54757{Union{X,Integer}},T54757{A,N}},Vararg{T54757,N}} where X, N}
+struct T54757{A>:Int,N} <: AbstractArray{Tuple{X,Tuple{Vararg},Union{T54757{Union{X,Integer}},T54757{A,N}},Vararg{Y,N}} where {X,Y<:T54757}, N}
     x::A
     y::Union{A,T54757{A,N}}
     z::T54757{A}
 end
 
-@test_throws ErrorException struct T54757{A>:Int,N} <: AbstractArray{Tuple{X,Union{T54757{Union{X,Integer}},T54757{A}},Vararg{T54757,N}} where X, N}
+@test_throws ErrorException struct T54757{A>:Int,N} <: AbstractArray{Tuple{X,Tuple{Vararg},Union{T54757{Union{X,Integer}},T54757{A}},Vararg{Y,N}} where {X,Y<:T54757}, N}
     x::A
     y::Union{A,T54757{A,N}}
     z::T54757{A}

--- a/test/core.jl
+++ b/test/core.jl
@@ -5611,6 +5611,26 @@ end
     x::Array{T} where T<:Integer
 end
 
+# issue #54757, type redefinitions with recursive reference in supertype
+struct T54757{A>:Int,N} <: AbstractArray{Tuple{X,Union{T54757{Union{X,Integer}},T54757{A,N}},Vararg{T54757,N}} where X, N}
+    x::A
+    y::Union{A,T54757{A,N}}
+    z::T54757{A}
+end
+
+struct T54757{A>:Int,N} <: AbstractArray{Tuple{X,Union{T54757{Union{X,Integer}},T54757{A,N}},Vararg{T54757,N}} where X, N}
+    x::A
+    y::Union{A,T54757{A,N}}
+    z::T54757{A}
+end
+
+@test_throws ErrorException struct T54757{A>:Int,N} <: AbstractArray{Tuple{X,Union{T54757{Union{X,Integer}},T54757{A}},Vararg{T54757,N}} where X, N}
+    x::A
+    y::Union{A,T54757{A,N}}
+    z::T54757{A}
+end
+
+
 let a = Vector{Core.TypeofBottom}(undef, 2)
     @test a[1] == Union{}
     @test a == [Union{}, Union{}]


### PR DESCRIPTION
This PR allows redefining a type when the new type is exactly identical to the previous one (like #17618, #20592 and #21024), even if the type has a reference to itself in its supertype. That particular case used to error (issue #54757), whereas with this PR:
```julia
julia> struct Rec <: AbstractVector{Rec} end

julia> struct Rec <: AbstractVector{Rec} end # this used to error

julia>
```


Fix #54757 by implementing the solution proposed there. Hence, this should also fix downstream Revise bug https://github.com/timholy/Revise.jl/issues/813.