### PR TITLE
Simplify `dropdims(::Transpose)` and `insertdims(::PermutedDimsArray)` etc.

### DIFF
--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -388,6 +388,25 @@ hcat(avs::Adjoint{T,Vector{T}}...) where {T} = _adjoint_hcat(avs...)
 hcat(tvs::Transpose{T,Vector{T}}...) where {T} = _transpose_hcat(tvs...)
 # TODO unify and allow mixed combinations
 
+### dropdims
+function Base._dropdims(A::Transpose{<:Number}, dims::Tuple{Int})
+    if only(dims) == 1
+        vec(parent(A))
+    elseif only(dims) == 2
+        Base._dropdims(parent(A), (1,))
+    else
+        throw(ArgumentError("dropped dims must be in range 1:ndims(A)"))
+    end
+end
+function Base._dropdims(A::Adjoint{<:Real}, dims::Tuple{Int})
+    if only(dims) == 1
+        vec(parent(A))
+    elseif only(dims) == 2
+        Base._dropdims(parent(A), (1,))
+    else
+        throw(ArgumentError("dropped dims must be in range 1:ndims(A)"))
+    end
+end
 
 ### higher order functions
 # preserve Adjoint/Transpose wrapper around vectors

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -325,6 +325,20 @@ end
     @test hcat(Transpose(vecvec), Transpose(vecvec))::Transpose{Transpose{Complex{Int},Vector{Complex{Int}}},Vector{Vector{Complex{Int}}}} == hcat(tvecvec, tvecvec)
 end
 
+@testset "dropdims on Adjoint/Transpose-wrapped vectors & matrices" begin
+    intvec = [1, 2]
+    @test dropdims(Adjoint(intvec); dims=1) === intvec
+    @test dropdims(Transpose(intvec); dims=1) === intvec
+    cvec = [1.0 + 3im, 3.0 + 4im]
+    @test dropdims(Adjoint(cvec); dims=1) == conj(cvec)
+    @test dropdims(Transpose(cvec); dims=1) === cvec
+    intmat = [1 2 3]
+    @test dropdims(Adjoint(intmat); dims=2) == vec(intmat)
+    @test dropdims(Adjoint(intmat); dims=2) isa Vector
+    @test dropdims(Transpose(intmat); dims=2) == vec(intmat)
+    @test dropdims(Transpose(intmat); dims=2) isa Vector
+end
+
 @testset "map/broadcast over Adjoint/Transpose-wrapped vectors and Numbers" begin
     # map and broadcast over Adjoint/Transpose-wrapped vectors and Numbers
     # should preserve the Adjoint/Transpose-wrapper to preserve semantics downstream

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -378,6 +378,62 @@ end
 
     @test isequal(reshape(reshape(1:27, 3, 3, 3), Val(2))[1,:], [1,  4,  7,  10,  13,  16,  19,  22,  25])
 end
+
+@testset "dropdims/insertdims on PermutedDimsArray" begin
+    # Matrix
+    P1 = PermutedDimsArray(randn(5,1), (2,1))
+    M1 = collect(P1)
+    @test dropdims(P1; dims=1) == dropdims(M1; dims=1)
+    @test insertdims(P1; dims=1) == insertdims(M1; dims=1)
+
+    @test dropdims(P1; dims=1) isa Vector
+    @test insertdims(P1; dims=1) isa PermutedDimsArray
+
+    @test_throws ArgumentError dropdims(P1; dims=0)
+    @test_throws ArgumentError dropdims(P1; dims=2)
+    @test_throws ArgumentError dropdims(P1; dims=3)
+    @test_throws ArgumentError dropdims(P1; dims=(1,1))
+
+    @test_throws ArgumentError insertdims(P1; dims=0)
+    @test_throws ArgumentError insertdims(P1; dims=4)
+    @test_throws ArgumentError insertdims(P1; dims=(1,1))
+
+    # More dims
+    P2 = PermutedDimsArray(randn(3,1,4), (3,2,1))
+    M2 = collect(P2)
+    @test dropdims(P2; dims=2) == dropdims(M2; dims=2)
+    @test insertdims(P2; dims=2) == insertdims(M2; dims=2)
+
+    P13 = PermutedDimsArray(randn(2,1,3,1,4), (4,5,2,1,3))
+    A13 = collect(P13)
+    @test dropdims(P13; dims=3) == dropdims(A13; dims=3)
+    @test dropdims(P13; dims=(1,3)) == dropdims(A13; dims=(1,3))
+    @test dropdims(P13; dims=(3,1)) == dropdims(A13; dims=(3,1))
+
+    @test insertdims(P13; dims=2) == insertdims(A13; dims=2)
+    @test insertdims(P13; dims=(4,6)) == insertdims(A13; dims=(4,6))
+    @test insertdims(P13; dims=(4,1)) == insertdims(A13; dims=(4,1))
+
+    @test dropdims(P13; dims=(1,3)) isa PermutedDimsArray
+    @test insertdims(P13; dims=(4,6)) isa PermutedDimsArray
+
+    @test_throws ArgumentError dropdims(P13; dims=0)
+    @test_throws ArgumentError dropdims(P13; dims=2)
+    @test_throws ArgumentError dropdims(P13; dims=4)
+    @test_throws ArgumentError dropdims(P13; dims=(3,3))
+
+    # Zero-dim cases
+    p1 = PermutedDimsArray(rand(1), (1,))
+    @test dropdims(p1; dims=1) == dropdims(collect(p1); dims=1)
+    p12 = PermutedDimsArray(rand(1,1), (2,1))
+    @test dropdims(p12; dims=2) == dropdims(collect(p12); dims=2)
+    @test dropdims(p12; dims=(1,2)) == dropdims(collect(p12); dims=(1,2))
+    a = fill(rand())
+    p = PermutedDimsArray(a, ())
+    @test insertdims(p, dims=1) == insertdims(a, dims=1)
+    @test insertdims(p, dims=(1,2)) == insertdims(a, dims=(1,2))
+end
+
 @testset "find(in(b), a)" begin
     # unsorted inputs
     a = [3, 5, -7, 6]


### PR DESCRIPTION
Before, these wrap the wrapper in a ReshapedArray:
```julia
julia> dropdims([1,2,3]'; dims=1)
3-element reshape(adjoint(::Vector{Int64}), 3) with eltype Int64:
 1
 2
 3

julia> insertdims(PermutedDimsArray([1 2; 3 4], (2,1)); dims=2)
2×1×2 reshape(PermutedDimsArray(::Matrix{Int64}, (2, 1)), 2, 1, 2) with eltype Int64:
[:, :, 1] =
 1
 2

[:, :, 2] =
 3
 4
```

After:
```julia
julia> dropdims([1,2,3]'; dims=1)
3-element Vector{Int64}:
 1
 2
 3

julia> insertdims(PermutedDimsArray([1 2; 3 4], (2,1)); dims=2)
2×1×2 PermutedDimsArray(::Array{Int64, 3}, (2, 3, 1)) with eltype Int64:
[:, :, 1] =
 1
 2

[:, :, 2] =
 3
 4
```
This is not always faster, alone, but the hope is that the simpler return type will usually be faster downstream. (Especially with e.g. `CuArray`s, where wrapping twice causes them to miss specialised methods.)
```julia
julia> P13 = PermutedDimsArray(randn(2,1,3,1,4), (4,5,2,1,3));

julia> @btime dropdims($P13; dims=(1,3));
  189.628 ns (10 allocations: 192 bytes)  # before, ReshapedArray(PermutedDimsArray(Array{Float64, 5}))
  272.895 ns (10 allocations: 256 bytes)  # after, PermutedDimsArray(Array{Float64, 3})

julia> A13 = collect(P13);

julia> @btime dropdims($A13; dims=(1,3));
  172.333 ns (11 allocations: 240 bytes)
```
It appears that the compiler can predict the type when `dims` is constant. More stringent tests (or ways to do better) would be welcome:
```julia
julia> drop1(x) = dropdims(x; dims=(1,));

julia> @code_warntype drop1(P13)  # before
MethodInstance for drop1(::PermutedDimsArray{Float64, 5, (4, 5, 2, 1, 3), (4, 3, 5, 1, 2), Array{Float64, 5}})
  from drop1(x) @ Main REPL[12]:1
Arguments
  #self#::Core.Const(drop1)
  x::PermutedDimsArray{Float64, 5, (4, 5, 2, 1, 3), (4, 3, 5, 1, 2), Array{Float64, 5}}
Body::Base.ReshapedArray{Float64, 4, PermutedDimsArray{Float64, 5, (4, 5, 2, 1, 3), (4, 3, 5, 1, 2), Array{Float64, 5}}, NTuple{4, Base.MultiplicativeInverses.SignedMultiplicativeInverse{Int64}}}
1 ─ %1 = (:dims,)::Core.Const((:dims,))
...

julia> @code_warntype drop1(P13)  # after
MethodInstance for drop1(::PermutedDimsArray{Float64, 5, (4, 5, 2, 1, 3), (4, 3, 5, 1, 2), Array{Float64, 5}})
  from drop1(x) @ Main REPL[240]:1
Arguments
  #self#::Core.Const(drop1)
  x::PermutedDimsArray{Float64, 5, (4, 5, 2, 1, 3), (4, 3, 5, 1, 2), Array{Float64, 5}}
Body::PermutedDimsArray{Float64, 4, (4, 2, 1, 3), (3, 2, 4, 1), Array{Float64, 4}}
1 ─ %1 = (:dims,)::Core.Const((:dims,))
...
```