### PR TITLE
Make `mv` more atomic by trying rename before deleting `dst`

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -440,10 +440,49 @@ julia> rm("goodbye.txt");
 ```
 """
 function mv(src::AbstractString, dst::AbstractString; force::Bool=false)
-    checkfor_mv_cp_cptree(src, dst, "moving"; force=force)
-    rename(src, dst)
+    if force
+        _mv_replace(src, dst)
+    else
+        _mv_noreplace(src, dst)
+    end
+end
+
+function _mv_replace(src::AbstractString, dst::AbstractString)
+    # First try to do a regular rename, because this might avoid a situation
+    # where dst is deleted or truncated.
+    try
+        rename(src, dst)
+    catch ex
+        ex isa IOError || rethrow()
+        # on rename error try to delete dst if it exists and isn't the same as src
+        checkfor_mv_cp_cptree(src, dst, "moving"; force=true)
+        try
+            rename(src, dst)
+        catch ex
+            ex isa IOError || rethrow()
+            # on second error, default to force cp && rm
+            cp(src, dst; force=true, follow_symlinks=false)
+            rm(src; recursive=true)
+        end
+    end
     dst
 end
+
+function _mv_noreplace(src::AbstractString, dst::AbstractString)
+    # Error if dst exists.
+    # This check currently has TOCTTOU issues.
+    checkfor_mv_cp_cptree(src, dst, "moving"; force=false)
+    try
+        rename(src, dst)
+    catch ex
+        ex isa IOError || rethrow()
+        # on error, default to cp && rm
+        cp(src, dst; force=false, follow_symlinks=false)
+        rm(src; recursive=true)
+    end
+    dst
+end
+
 
 """
     touch(path::AbstractString)
@@ -1126,15 +1165,27 @@ function unlink(p::AbstractString)
     nothing
 end
 
-# For move command
-function rename(src::AbstractString, dst::AbstractString; force::Bool=false)
-    err = ccall(:jl_fs_rename, Int32, (Cstring, Cstring), src, dst)
-    # on error, default to cp && rm
+"""
+    rename(oldpath::AbstractString, newpath::AbstractString)
+
+Change the name of a file from `oldpath` to `newpath`. If `newpath` is an existing file it may be replaced.
+Equivalent to [rename(2)](https://man7.org/linux/man-pages/man2/rename.2.html).
+Throws an `IOError` on failure.
+Return `newpath`.
+
+OS-specific restrictions may apply when `oldpath` and `newpath` are in different directories.
+
+See also: [`mv`](@ref).
+
+!!! compat "Julia 1.12"
+    This method was added in Julia 1.12.
+"""
+function rename(oldpath::AbstractString, newpath::AbstractString)
+    err = ccall(:jl_fs_rename, Int32, (Cstring, Cstring), oldpath, newpath)
     if err < 0
-        cp(src, dst; force=force, follow_symlinks=false)
-        rm(src; recursive=true)
+        uv_error("rename($(repr(oldpath)), $(repr(newpath)))", err)
     end
-    nothing
+    newpath
 end
 
 function sendfile(src::AbstractString, dst::AbstractString)

--- a/base/file.jl
+++ b/base/file.jl
@@ -448,6 +448,7 @@ function mv(src::AbstractString, dst::AbstractString; force::Bool=false)
 end
 
 function _mv_replace(src::AbstractString, dst::AbstractString)
+    # This check is copied from checkfor_mv_cp_cptree
     if ispath(dst) && Base.samefile(src, dst)
         abs_src = islink(src) ? abspath(readlink(src)) : abspath(src)
         abs_dst = islink(dst) ? abspath(readlink(dst)) : abspath(dst)

--- a/base/file.jl
+++ b/base/file.jl
@@ -1176,9 +1176,6 @@ Return `newpath`.
 OS-specific restrictions may apply when `oldpath` and `newpath` are in different directories.
 
 See also: [`mv`](@ref).
-
-!!! compat "Julia 1.12"
-    This method was added in Julia 1.12.
 """
 function rename(oldpath::AbstractString, newpath::AbstractString)
     err = ccall(:jl_fs_rename, Int32, (Cstring, Cstring), oldpath, newpath)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -3047,7 +3047,9 @@ function compilecache(pkg::PkgId, path::String, internal_stderr::IO = stderr, in
                 end
             end
             # this is atomic according to POSIX (not Win32):
-            rename(tmppath, cachefile; force=true)
+            # but force=true means it will fall back to non atomic
+            # move if the initial rename fails.
+            mv(tmppath, cachefile; force=true)
             return cachefile, ocachefile
         end
     finally
@@ -3066,7 +3068,7 @@ end
 
 function rename_unique_ocachefile(tmppath_so::String, ocachefile_orig::String, ocachefile::String = ocachefile_orig, num = 0)
     try
-        rename(tmppath_so, ocachefile; force=true)
+        mv(tmppath_so, ocachefile; force=true)
     catch e
         e isa IOError || rethrow()
         # If `rm` was called on a dir containing a loaded DLL, we moved it to temp for cleanup

--- a/test/file.jl
+++ b/test/file.jl
@@ -1031,7 +1031,7 @@ if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
         @test_throws Base._UVError("open($(repr(nonexisting_src)), $(Base.JL_O_RDONLY), 0)", Base.UV_ENOENT) cp(nonexisting_src, dst; force=true, follow_symlinks=false)
         @test_throws Base._UVError("open($(repr(nonexisting_src)), $(Base.JL_O_RDONLY), 0)", Base.UV_ENOENT) cp(nonexisting_src, dst; force=true, follow_symlinks=true)
         # mv
-        @test_throws Base._UVError("open($(repr(nonexisting_src)), $(Base.JL_O_RDONLY), 0)", Base.UV_ENOENT) mv(nonexisting_src, dst; force=true)
+        @test_throws Base._UVError("rename($(repr(nonexisting_src)), $(repr(dst)))", Base.UV_ENOENT) mv(nonexisting_src, dst; force=true)
     end
 end
 

--- a/test/filesystem.jl
+++ b/test/filesystem.jl
@@ -44,7 +44,7 @@ end
 @testset "Base.Filesystem docstrings" begin
     undoc = Docs.undocumented_names(Base.Filesystem)
     @test_broken isempty(undoc)
-    @test undoc == [:File, :Filesystem, :cptree, :futime, :rename, :sendfile, :unlink]
+    @test undoc == [:File, :Filesystem, :cptree, :futime, :sendfile, :unlink]
 end
 
 @testset "write return type" begin


### PR DESCRIPTION
As noted in https://github.com/JuliaLang/julia/issues/41584 and https://discourse.julialang.org/t/safe-overwriting-of-files/117758/3 `mv` is usually expected to be "best effort atomic".

Currently calling `mv` with `force=true` calls `checkfor_mv_cp_cptree(src, dst, "moving"; force=true)` before renaming. `checkfor_mv_cp_cptree` will delete `dst` if exists and isn't the same as `src`.

If `dst` is an existing file and julia stops after deleting `dst` but before doing the rename, `dst` will be removed but will not be replaced with `src`.

This PR changes `mv` with `force=true` to first try rename, and only delete `dst` if that fails. Assuming file system support and the first rename works, julia stopping will not lead to `dst` being removed without being replaced.

This also replaces a stopgap solution from https://github.com/JuliaLang/julia/pull/36638#discussion_r453820564