### PR TITLE
Add functions to manipulate the GC heap counters

### DIFF
--- a/src/gc-interface.h
+++ b/src/gc-interface.h
@@ -147,9 +147,9 @@ JL_DLLEXPORT struct _jl_value_t *jl_gc_small_alloc(struct _jl_tls_states_t *ptls
 // allocation of that type in the allocation profiler.
 JL_DLLEXPORT struct _jl_value_t *jl_gc_big_alloc(struct _jl_tls_states_t *ptls, size_t sz,
                                                  struct _jl_value_t *type);
-// Update the allocation counters as if an allocation occured.
+// Update the allocation counters as if an allocation occurred.
 JL_DLLEXPORT void jl_gc_heap_increment(size_t sz);
-// Update the allocation counters as if a free occured.
+// Update the allocation counters as if a free occurred.
 JL_DLLEXPORT void jl_gc_heap_decrement(size_t sz);
 // Wrapper around Libc malloc that updates Julia allocation counters.
 JL_DLLEXPORT void *jl_gc_counted_malloc(size_t sz);

--- a/src/gc-interface.h
+++ b/src/gc-interface.h
@@ -147,6 +147,10 @@ JL_DLLEXPORT struct _jl_value_t *jl_gc_small_alloc(struct _jl_tls_states_t *ptls
 // allocation of that type in the allocation profiler.
 JL_DLLEXPORT struct _jl_value_t *jl_gc_big_alloc(struct _jl_tls_states_t *ptls, size_t sz,
                                                  struct _jl_value_t *type);
+// Update the allocation counters as if an allocation occured.
+JL_DLLEXPORT void jl_gc_heap_increment(size_t sz);
+// Update the allocation counters as if a free occured.
+JL_DLLEXPORT void jl_gc_heap_decrement(size_t sz);
 // Wrapper around Libc malloc that updates Julia allocation counters.
 JL_DLLEXPORT void *jl_gc_counted_malloc(size_t sz);
 // Wrapper around Libc calloc that updates Julia allocation counters.

--- a/src/gc-stock.c
+++ b/src/gc-stock.c
@@ -3595,6 +3595,28 @@ JL_DLLEXPORT uint64_t jl_gc_get_max_memory(void)
 
 // allocation wrappers that track allocation and let collection run
 
+JL_DLLEXPORT void jl_gc_heap_increment(size_t sz)
+{
+    jl_gcframe_t **pgcstack = jl_get_pgcstack();
+    jl_task_t *ct = jl_current_task;
+    if (pgcstack != NULL && ct->world_age) {
+        jl_ptls_t ptls = ct->ptls;
+        maybe_collect(ptls);
+        jl_atomic_store_relaxed(&ptls->gc_tls.gc_num.allocd,
+            jl_atomic_load_relaxed(&ptls->gc_tls.gc_num.allocd) + sz);
+        jl_batch_accum_heap_size(ptls, sz);
+    }
+}
+
+JL_DLLEXPORT void jl_gc_heap_decrement(size_t sz)
+{
+    jl_gcframe_t **pgcstack = jl_get_pgcstack();
+    jl_task_t *ct = jl_current_task;
+    if (pgcstack != NULL && ct->world_age) {
+        jl_batch_accum_free_size(ct->ptls, sz);
+    }
+}
+
 JL_DLLEXPORT void *jl_gc_counted_malloc(size_t sz)
 {
     jl_gcframe_t **pgcstack = jl_get_pgcstack();

--- a/src/jl_exported_funcs.inc
+++ b/src/jl_exported_funcs.inc
@@ -156,6 +156,8 @@
     XX(jl_gc_find_taggedvalue_pool) \
     XX(jl_gc_get_total_bytes) \
     XX(jl_gc_get_max_memory) \
+    XX(jl_gc_heap_increment) \
+    XX(jl_gc_heap_decrement) \
     XX(jl_gc_internal_obj_base_ptr) \
     XX(jl_gc_is_enabled) \
     XX(jl_gc_is_in_finalizer) \


### PR DESCRIPTION
`jl_malloc` and `jl_free` can be used to inform the GC about memory
pressure caused by external libraries. This PR adds two functions
that only do the accounting and not the memory allocation/freeing.

The intended audience is users of libraries that do their own memory
management, but still have establishes sizes and deallocation points.
An example of this is the unified memory API in CUDA.
