### PR TITLE
simplify the active_module implementation and make it a "Base feature"

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -513,11 +513,8 @@ function _show_default(io::IO, @nospecialize(x))
     print(io,')')
 end
 
-function active_module()
-    REPL = REPL_MODULE_REF[]
-    REPL === Base && return Main
-    return invokelatest(REPL.active_module)::Module
-end
+_active_module::Module = Main
+active_module() = _active_module
 
 # Check if a particular symbol is exported from a standard library module
 function is_exported_from_stdlib(name::Symbol, mod::Module)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -151,4 +151,5 @@ Base.TOML.reinit!(Base.TOML_CACHE.p, "")
     BINDIR = ""
     STDLIB = ""
 end
+Base._active_module = Main
 end

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1157,16 +1157,20 @@ fake_repl() do stdin_write, stdout_read, repl
     s = readuntil(stdout_read, "\n\n")
     @test endswith(s, "(123, Base.Fix1)")
 
-    repl.mistate.active_module = Base # simulate activate_module(Base)
-    write(stdin_write, " ( 456 , Base.Fix2 , ) \n")
-    s = readuntil(stdout_read, "\n\n")
-    # ".Base" prefix not shown here
-    @test endswith(s, "(456, Fix2)")
+    try
+        Base._active_module = Base # simulate activate_module(Base)
+        write(stdin_write, " ( 456 , Base.Fix2 , ) \n")
+        s = readuntil(stdout_read, "\n\n")
+        # ".Base" prefix not shown here
+        @test endswith(s, "(456, Fix2)")
 
-    # Close REPL ^D
-    readuntil(stdout_read, "julia> ", keep=true)
-    write(stdin_write, '\x04')
-    Base.wait(repltask)
+        # Close REPL ^D
+        readuntil(stdout_read, "julia> ", keep=true)
+        write(stdin_write, '\x04')
+        Base.wait(repltask)
+    finally
+        Base._active_module = Main
+    end
 end
 
 help_result(line, mod::Module=Base) = Core.eval(mod, REPL._helpmode(IOBuffer(), line, mod))


### PR DESCRIPTION
The current implementation of `active_module` is REPL instance specific but it becomes confusing since `Base` has to try reach out for a REPL to ask it what the active module is. There is also things like a global `previous_active_module` which shows that the REPL instance specific implementation is a best effort at best.

This simplifies things by making the `active_module` a Base feature (just a global value) and then anything (including the REPL) can set that.

Should fix https://github.com/JuliaLang/julia/issues/54888, https://github.com/JuliaLang/julia/issues/54780.