### PR TITLE
slightly better type inference for `reverse(::NTuple)`

### DIFF
--- a/base/ntuple.jl
+++ b/base/ntuple.jl
@@ -97,5 +97,5 @@ end
 function reverse(t::NTuple{N}) where N
     ntuple(Val{N}()) do i
         t[end+1-i]
-    end
+    end::NTuple
 end

--- a/base/ntuple.jl
+++ b/base/ntuple.jl
@@ -97,5 +97,5 @@ end
 function reverse(t::NTuple{N}) where N
     ntuple(Val{N}()) do i
         t[end+1-i]
-    end::NTuple
+    end::typeof(t)
 end

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -850,3 +850,5 @@ end
         end
     end
 end
+
+@test NTuple == Core.Compiler.return_type(reverse, Tuple{NTuple})

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -851,4 +851,4 @@ end
     end
 end
 
-@test NTuple == Core.Compiler.return_type(reverse, Tuple{NTuple})
+@test NTuple == Base.infer_return_type(reverse, Tuple{NTuple})

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -852,3 +852,4 @@ end
 end
 
 @test NTuple == Base.infer_return_type(reverse, Tuple{NTuple})
+@test Tuple{Vararg{Int}} == Base.infer_return_type(reverse, Tuple{Tuple{Vararg{Int}}})


### PR DESCRIPTION
Before the return type of `reverse(::NTuple)` inferred as `Tuple`, now it's more precise, inferring as `NTuple`.

This is a partial reland of #55124 and partial revert of #55375.

Fixes #54495