### PR TITLE
REPL: disable flaky win32 stacktrace tests

### DIFF
--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -244,10 +244,9 @@ fake_repl(options = REPL.Options(confirm_exit=false,hascolor=true)) do stdin_wri
         @test occursin("shell> ", s) # check for the echo of the prompt
         @test occursin("'", s) # check for the echo of the input
         s = readuntil(stdout_read, "\n\n")
-        if !(Sys.iswindows() && Sys.WORD_SIZE == 32)
-            @test startswith(s, "\e[0mERROR: unterminated single quote\nStacktrace:\n  [1] ") ||
-                startswith(s, "\e[0m\e[1m\e[91mERROR: \e[39m\e[22m\e[91munterminated single quote\e[39m\nStacktrace:\n  [1] ")
-        end
+        @test(startswith(s, "\e[0mERROR: unterminated single quote\nStacktrace:\n  [1] ") ||
+            startswith(s, "\e[0m\e[1m\e[91mERROR: \e[39m\e[22m\e[91munterminated single quote\e[39m\nStacktrace:\n  [1] "),
+            skip = Sys.iswindows() && Sys.WORD_SIZE == 32)
         write(stdin_write, "\b")
         wait(t)
     end
@@ -1652,16 +1651,12 @@ fake_repl() do stdin_write, stdout_read, repl
     write(stdin_write, "foobar\n")
     readline(stdout_read)
     @test readline(stdout_read) == "\e[0mERROR: UndefVarError: `foobar` not defined in `Main`"
-    if !(Sys.iswindows() && Sys.WORD_SIZE == 32)
-        @test readline(stdout_read) == ""
-    end
+    @test readline(stdout_read) == "" skip = Sys.iswindows() && Sys.WORD_SIZE == 32
     readuntil(stdout_read, "julia> ", keep=true)
     # check that top-level error did not change `err`
     write(stdin_write, "err\n")
     readline(stdout_read)
-    if !(Sys.iswindows() && Sys.WORD_SIZE == 32)
-        @test readline(stdout_read) == "\e[0m"
-    end
+    @test readline(stdout_read) == "\e[0m" skip = Sys.iswindows() && Sys.WORD_SIZE == 32
     readuntil(stdout_read, "julia> ", keep=true)
     # generate deeper error
     write(stdin_write, "foo() = foobar\n")

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -244,8 +244,10 @@ fake_repl(options = REPL.Options(confirm_exit=false,hascolor=true)) do stdin_wri
         @test occursin("shell> ", s) # check for the echo of the prompt
         @test occursin("'", s) # check for the echo of the input
         s = readuntil(stdout_read, "\n\n")
-        @test startswith(s, "\e[0mERROR: unterminated single quote\nStacktrace:\n  [1] ") ||
-              startswith(s, "\e[0m\e[1m\e[91mERROR: \e[39m\e[22m\e[91munterminated single quote\e[39m\nStacktrace:\n  [1] ")
+        if !(Sys.iswindows() && Sys.WORD_SIZE == 32)
+            @test startswith(s, "\e[0mERROR: unterminated single quote\nStacktrace:\n  [1] ") ||
+                startswith(s, "\e[0m\e[1m\e[91mERROR: \e[39m\e[22m\e[91munterminated single quote\e[39m\nStacktrace:\n  [1] ")
+        end
         write(stdin_write, "\b")
         wait(t)
     end
@@ -1650,12 +1652,16 @@ fake_repl() do stdin_write, stdout_read, repl
     write(stdin_write, "foobar\n")
     readline(stdout_read)
     @test readline(stdout_read) == "\e[0mERROR: UndefVarError: `foobar` not defined in `Main`"
-    @test readline(stdout_read) == ""
+    if !(Sys.iswindows() && Sys.WORD_SIZE == 32)
+        @test readline(stdout_read) == ""
+    end
     readuntil(stdout_read, "julia> ", keep=true)
     # check that top-level error did not change `err`
     write(stdin_write, "err\n")
     readline(stdout_read)
-    @test readline(stdout_read) == "\e[0m"
+    if !(Sys.iswindows() && Sys.WORD_SIZE == 32)
+        @test readline(stdout_read) == "\e[0m"
+    end
     readuntil(stdout_read, "julia> ", keep=true)
     # generate deeper error
     write(stdin_write, "foo() = foobar\n")


### PR DESCRIPTION
Disables these tests on win32 that have been flaky on that platform since February at least https://github.com/JuliaLang/julia/issues/53340
```
  | 2024-08-07 12:02:57 EDT | REPL                                            (11) \|         failed at 2024-08-07T16:03:13.216
  | 2024-08-07 12:03:13 EDT | Test Failed at C:\buildkite-agent\builds\win2k22-amdci6-0\julialang\julia-master\julia-dcab5c9d52\share\julia\stdlib\v1.12\REPL\test\repl.jl:247
  | 2024-08-07 12:03:13 EDT | Expression: startswith(s, "\e[0mERROR: unterminated single quote\nStacktrace:\n  [1] ") \|\| startswith(s, "\e[0m\e[1m\e[91mERROR: \e[39m\e[22m\e[91munterminated single quote\e[39m\nStacktrace:\n  [1] ")
  | 2024-08-07 12:03:13 EDT |  
  | 2024-08-07 12:03:13 EDT | Test Failed at C:\buildkite-agent\builds\win2k22-amdci6-0\julialang\julia-master\julia-dcab5c9d52\share\julia\stdlib\v1.12\REPL\test\repl.jl:1653
  | 2024-08-07 12:03:13 EDT | Expression: readline(stdout_read) == ""
  | 2024-08-07 12:03:13 EDT | Evaluated: "Stacktrace:" == ""
  | 2024-08-07 12:03:13 EDT |  
  | 2024-08-07 12:03:13 EDT | Test Failed at C:\buildkite-agent\builds\win2k22-amdci6-0\julialang\julia-master\julia-dcab5c9d52\share\julia\stdlib\v1.12\REPL\test\repl.jl:1658
  | 2024-08-07 12:03:13 EDT | Expression: readline(stdout_read) == "\e[0m"
  | 2024-08-07 12:03:13 EDT | Evaluated: "\e[0m1-element ExceptionStack:" == "\e[0m"
```