### PR TITLE
Make the memory GEP use the memory type

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -4288,8 +4288,7 @@ static jl_cgval_t emit_memoryref(jl_codectx_t &ctx, const jl_cgval_t &ref, jl_cg
 #endif
         // boffset = ctx.builder.CreateMul(offset, elsz);
         Type *elty = isboxed ? ctx.types().T_prjlvalue : julia_type_to_llvm(ctx, jl_tparam1(ref.typ));
-        newdata = emit_bitcast(ctx, data, getPointerTy(ctx.builder.getContext()));
-        newdata = ctx.builder.CreateInBoundsGEP(elty, newdata, offset);
+        newdata = ctx.builder.CreateInBoundsGEP(elty, data, offset);
         (void)boffset; // LLVM is very bad at handling GEP with types different from the load
         if (bc) {
             BasicBlock *failBB, *endBB;

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -4286,9 +4286,10 @@ static jl_cgval_t emit_memoryref(jl_codectx_t &ctx, const jl_cgval_t &ref, jl_cg
             ovflw = ctx.builder.CreateICmpUGE(ctx.builder.CreateAdd(offset, mlen), ctx.builder.CreateNUWAdd(mlen, mlen));
         }
 #endif
-        //Is this change fine
-        boffset = ctx.builder.CreateMul(offset, elsz);
-        newdata = ctx.builder.CreateGEP(getInt8Ty(ctx.builder.getContext()), data, boffset);
+        // boffset = ctx.builder.CreateMul(offset, elsz);
+        Type *elty = isboxed ? ctx.types().T_prjlvalue : julia_type_to_llvm(ctx, jl_tparam1(ref.typ));
+        newdata = emit_bitcast(ctx, data, getPointerTy(ctx.builder.getContext()));
+        newdata = ctx.builder.CreateInBoundsGEP(elty, newdata, offset);
         (void)boffset; // LLVM is very bad at handling GEP with types different from the load
         if (bc) {
             BasicBlock *failBB, *endBB;


### PR DESCRIPTION
Given the comment `LLVM is very bad at handling GEP with types different from the load` seems like we want this. https://github.com/JuliaLang/julia/pull/54853 said this was changed in preparation for gep changing but it seems easy enough to make this change then.

Fixes https://github.com/JuliaLang/julia/issues/55090, closes #55107.