### PR TITLE
speed up `M^(Int/2)`

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -563,7 +563,7 @@ function (^)(A::AbstractMatrix{T}, p::Real) where T
 
     # For integer powers, use power_by_squaring
     isinteger(p) && return integerpow(A, p)
-
+    isinteger(p*2) && return A^floor(Integer, p)*sqrt(A)
     # If possible, use diagonalization
     if ishermitian(A)
         return (Hermitian(A)^p)


### PR DESCRIPTION
This is a bit faster for normal matrices, but way faster for AbstractMatrix that have a fast sqrt.
```
julia> M2 = rand(2,2);
julia> @btime sqrt(M2);
  1.969 μs (21 allocations: 1.53 KiB)
julia> @btime M2^.5;
  2.235 μs (31 allocations: 2.19 KiB)
julia> M = @SMatrix rand(2,2);

julia> @btime $M^.5;
  2.245 μs (37 allocations: 2.52 KiB)

julia> @btime sqrt($M);
  5.561 ns (0 allocations: 0 bytes)
```