### PR TITLE
Handle large integer exponents in matrix powers

### DIFF
--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -596,6 +596,17 @@ end
 
     A8 = 100 * [-1+1im 0 0 1e-8; 0 1 0 0; 0 0 1 0; 0 0 0 1]
     @test exp(log(A8)) ≈ A8
+
+    @testset "large exponents (issue #55300)" begin
+        A = [1 1e-10; 0 1]
+        B = A^(1e20)
+        @test B ≈ [1 1e10; 0 1]
+        B = A^(-1e20)
+        @test B ≈ inv(A)^1e20
+        @test (A^prevfloat(Inf64))[1,2] ≈ A[1,2] * prevfloat(Inf64)
+        @test (A^prevfloat(Inf32))[1,2] ≈ A[1,2] * prevfloat(Inf32)
+        @test (A^prevfloat(Inf16))[1,2] ≈ A[1,2] * prevfloat(Inf16)
+    end
 end
 
 @testset "Matrix trigonometry" begin


### PR DESCRIPTION
The idea here is that `A^p` is evaluated as `A^Int(p)` if `isinteger(p)`, but `Int(p)` may error if `p` is large. In such cases, we may express the exponent as `p = m*q + r`, where `m` and `r` are small enough so that `Int(m)` and `Int(r)` succeed, and the operation becomes `(A^m)^q * A^r`. This is evaluated recursively by repeatedly dividing the exponent. 

After this, the following works:
```julia
julia> [1 1e-10; 0 1] ^ (1e20)
2×2 Matrix{Float64}:
 1.0  1.0e10
 0.0  1.0
```

Fixes https://github.com/JuliaLang/LinearAlgebra.jl/issues/1082, but I have not carried out any error analysis to check the accuracy of results in general. Suggestions are welcome. In particular, I'm unsure how the rounding in `divrem` impacts the results if the exponents are huge.