### PR TITLE
fix swallowing internal errors in precompilepkgs

### DIFF
--- a/base/precompilation.jl
+++ b/base/precompilation.jl
@@ -897,6 +897,7 @@ function precompilepkgs(pkgs::Vector{String}=String[];
                     length(tasks) == 1 && notify(interrupted_or_done)
                 end
             end
+            Base.errormonitor(task) # interrupts are handled separately so ok to watch for other errors like this
             push!(tasks, task)
         end
     end


### PR DESCRIPTION
Testing:

- with a package error
```
(SimpleLooper) pkg> precompile
Precompiling all packages...
  ✗ SimpleLooper
  0 dependencies successfully precompiled in 2 seconds

ERROR: The following 1 direct dependency failed to precompile:

SimpleLooper 

Failed to precompile SimpleLooper [ff33fe5b-d8e3-4cbd-8bd9-3d2408ff8cab] to "/Users/ian/.julia/compiled/v1.12/SimpleLooper/jl_PQArnH".
ERROR: LoadError: 
Stacktrace:
  [1] error()
    @ Base ./error.jl:53
```

- with interrupt
```
(SimpleLooper) pkg> precompile
Precompiling all packages...
^C Interrupted: Exiting precompilation...
  ◒ SimpleLooper
  1 dependency had output during precompilation:
┌ SimpleLooper
│  [57879] signal 2: Interrupt: 2
│  in expression starting at /Users/ian/Documents/GitHub/SimpleLooper.jl/src/SimpleLooper.jl:2
└  
```

- an internal error simulated in the same scope that https://github.com/JuliaLang/Pkg.jl/issues/3984 was failing to throw from
 ```
  JULIA stdlib/release.image
Unhandled Task ERROR: 
Stacktrace:
 [1] error()
   @ Base ./error.jl:53
 [2] (::Base.Precompilation.var"#27#65"{Bool, Bool, Vector{Task}, Dict{Tuple{Base.PkgId, Pair{Cmd, Base.CacheFlags}}, String}, Dict{Tuple{Base.PkgId, Pair{Cmd, Base.CacheFlags}}, String}, Base.Event, Base.Event, ReentrantLock, Vector{Tuple{Base.PkgId, Pair{Cmd, Base.CacheFlags}}}, Dict{Tuple{Base.PkgId, Pair{Cmd, Base.CacheFlags}}, String}, Vector{Tuple{Base.PkgId, Pair{Cmd, Base.CacheFlags}}}, Int64, Vector{Base.PkgId}, Dict{Tuple{Base.PkgId, Pair{Cmd, Base.CacheFlags}}, Bool}, Dict{Tuple{Base.PkgId, Pair{Cmd, Base.CacheFlags}}, Base.Event}, Dict{Tuple{Base.PkgId, Pair{Cmd, Base.CacheFlags}}, Bool}, Vector{Base.PkgId}, Dict{Base.PkgId, String}, Dict{Tuple{Base.PkgId, UInt128, String, String}, Bool}, Base.Precompilation.var"#color_string#38"{Bool}, Bool, Base.Semaphore, Bool, String, Vector{String}, Vector{Base.PkgId}, Base.PkgId, Base.CacheFlags, Cmd, Pair{Cmd, Base.CacheFlags}, Tuple{Base.PkgId, Pair{Cmd, Base.CacheFlags}}})()
   @ Base.Precompilation ./precompilation.jl:819
```