### PR TITLE
fix Event to use normal Condition variable

### DIFF
--- a/base/lock.jl
+++ b/base/lock.jl
@@ -498,10 +498,10 @@ This provides an acquire & release memory ordering on notify/wait.
     The `autoreset` functionality and memory ordering guarantee requires at least Julia 1.8.
 """
 mutable struct Event
-    const notify::ThreadSynchronizer
+    const notify::Threads.Condition
     const autoreset::Bool
     @atomic set::Bool
-    Event(autoreset::Bool=false) = new(ThreadSynchronizer(), autoreset, false)
+    Event(autoreset::Bool=false) = new(Threads.Condition(), autoreset, false)
 end
 
 function wait(e::Event)


### PR DESCRIPTION
ThreadSynchronizer is only for things that are very trivial, as there are a lot of things they are forbidden from doing (such as waiting for a Task to set it).

Happened to notice while reviewing https://github.com/JuliaLang/julia/pull/55439#pullrequestreview-2231026949 that this was still using the pre-v1.2 style lock, which makes this mostly useless in v1.4+