### PR TITLE
Add test for upper/lower/titlecase and fix call

### DIFF
--- a/base/strings/annotated.jl
+++ b/base/strings/annotated.jl
@@ -384,7 +384,7 @@ a vector of region–annotation tuples.
 In accordance with the semantics documented in [`AnnotatedString`](@ref), the
 order of annotations returned matches the order in which they were applied.
 
-See also: `annotate!`.
+See also: [`annotate!`](@ref).
 """
 annotations(s::AnnotatedString) = s.annotations
 

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -6,7 +6,7 @@ module Unicode
 import Base: show, ==, hash, string, Symbol, isless, length, eltype,
              convert, isvalid, ismalformed, isoverlong, iterate,
              AnnotatedString, AnnotatedChar, annotated_chartransform,
-             @assume_effects
+             @assume_effects, annotations
 
 # whether codepoints are valid Unicode scalar values, i.e. 0-0xd7ff, 0xe000-0x10ffff
 

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -303,7 +303,7 @@ julia> lowercase('Ö')
 lowercase(c::T) where {T<:AbstractChar} = isascii(c) ? ('A' <= c <= 'Z' ? c + 0x20 : c) :
     T(ccall(:utf8proc_tolower, UInt32, (UInt32,), c))
 
-lowercase(c::AnnotatedChar) = AnnotatedChar(lowercase(c.char), annotations(c))
+lowercase(c::AnnotatedChar) = AnnotatedChar(lowercase(c.char), c.annotations)
 
 """
     uppercase(c::AbstractChar)
@@ -324,7 +324,7 @@ julia> uppercase('ê')
 uppercase(c::T) where {T<:AbstractChar} = isascii(c) ? ('a' <= c <= 'z' ? c - 0x20 : c) :
     T(ccall(:utf8proc_toupper, UInt32, (UInt32,), c))
 
-uppercase(c::AnnotatedChar) = AnnotatedChar(uppercase(c.char), annotations(c))
+uppercase(c::AnnotatedChar) = AnnotatedChar(uppercase(c.char), c.annotations)
 
 """
     titlecase(c::AbstractChar)
@@ -349,7 +349,7 @@ julia> uppercase('ǆ')
 titlecase(c::T) where {T<:AbstractChar} = isascii(c) ? ('a' <= c <= 'z' ? c - 0x20 : c) :
     T(ccall(:utf8proc_totitle, UInt32, (UInt32,), c))
 
-titlecase(c::AnnotatedChar) = AnnotatedChar(titlecase(c.char), annotations(c))
+titlecase(c::AnnotatedChar) = AnnotatedChar(titlecase(c.char), c.annotations)
 
 ############################################################################
 

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -303,7 +303,7 @@ julia> lowercase('Ö')
 lowercase(c::T) where {T<:AbstractChar} = isascii(c) ? ('A' <= c <= 'Z' ? c + 0x20 : c) :
     T(ccall(:utf8proc_tolower, UInt32, (UInt32,), c))
 
-lowercase(c::AnnotatedChar) = AnnotatedChar(lowercase(c.char), c.annotations)
+lowercase(c::AnnotatedChar) = AnnotatedChar(lowercase(c.char), annotations(c))
 
 """
     uppercase(c::AbstractChar)
@@ -324,7 +324,7 @@ julia> uppercase('ê')
 uppercase(c::T) where {T<:AbstractChar} = isascii(c) ? ('a' <= c <= 'z' ? c - 0x20 : c) :
     T(ccall(:utf8proc_toupper, UInt32, (UInt32,), c))
 
-uppercase(c::AnnotatedChar) = AnnotatedChar(uppercase(c.char), c.annotations)
+uppercase(c::AnnotatedChar) = AnnotatedChar(uppercase(c.char), annotations(c))
 
 """
     titlecase(c::AbstractChar)
@@ -349,7 +349,7 @@ julia> uppercase('ǆ')
 titlecase(c::T) where {T<:AbstractChar} = isascii(c) ? ('a' <= c <= 'z' ? c - 0x20 : c) :
     T(ccall(:utf8proc_totitle, UInt32, (UInt32,), c))
 
-titlecase(c::AnnotatedChar) = AnnotatedChar(titlecase(c.char), c.annotations)
+titlecase(c::AnnotatedChar) = AnnotatedChar(titlecase(c.char), annotations(c))
 
 ############################################################################
 

--- a/test/strings/annotated.jl
+++ b/test/strings/annotated.jl
@@ -64,6 +64,9 @@ end
 @testset "AnnotatedChar" begin
     chr = Base.AnnotatedChar('c')
     @test chr == Base.AnnotatedChar(chr.char, Pair{Symbol, Any}[])
+    @test uppercase(chr) == Base.AnnotatedChar('C')
+    @test titlecase(chr) == Base.AnnotatedChar('C')
+    @test lowercase(Base.AnnotatedChar('C')) == chr 
     str = Base.AnnotatedString("hmm", [(1:1, :attr => "h0h0"),
                                (1:2, :attr => "h0m1"),
                                (2:3, :attr => "m1m2")])

--- a/test/strings/annotated.jl
+++ b/test/strings/annotated.jl
@@ -66,7 +66,7 @@ end
     @test chr == Base.AnnotatedChar(chr.char, Pair{Symbol, Any}[])
     @test uppercase(chr) == Base.AnnotatedChar('C')
     @test titlecase(chr) == Base.AnnotatedChar('C')
-    @test lowercase(Base.AnnotatedChar('C')) == chr 
+    @test lowercase(Base.AnnotatedChar('C')) == chr
     str = Base.AnnotatedString("hmm", [(1:1, :attr => "h0h0"),
                                (1:2, :attr => "h0m1"),
                                (2:3, :attr => "m1m2")])


### PR DESCRIPTION
Looks like there's no `annotations` function defined so I added a direct reference to the field. Can always add a getter function if preferred. 