### PR TITLE
Tighten signature of `repeat` to match what's documented

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -432,7 +432,7 @@ julia> repeat([1, 2, 3], 2, 3)
  3  3  3
 ```
 """
-function repeat(A::AbstractArray, counts...)
+function repeat(A::AbstractArray, counts::Integer...)
     return repeat(A, outer=counts)
 end
 

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -432,7 +432,7 @@ julia> repeat([1, 2, 3], 2, 3)
  3  3  3
 ```
 """
-function repeat(A::AbstractArray, counts::Integer...)
+function repeat(A::AbstractArray, counts...)
     return repeat(A, outer=counts)
 end
 
@@ -518,6 +518,9 @@ function check(arr, inner, outer)
         # TODO: Currently one based indexing is demanded for inner !== nothing,
         # but not for outer !== nothing. Decide for something consistent.
         Base.require_one_based_indexing(arr)
+        if !all(n -> n isa Integer, inner)
+            throw(ArgumentError("repeat requires integer counts, got inner = $inner"))
+        end
         if any(<(0), inner)
             throw(ArgumentError("no inner repetition count may be negative; got $inner"))
         end
@@ -526,6 +529,9 @@ function check(arr, inner, outer)
         end
     end
     if outer !== nothing
+        if !all(n -> n isa Integer, outer)
+            throw(ArgumentError("repeat requires integer counts, got outer = $outer"))
+        end
         if any(<(0), outer)
             throw(ArgumentError("no outer repetition count may be negative; got $outer"))
         end


### PR DESCRIPTION
Accidentally passing a float here (due to forgetting that `ceil` doesn't return an integer) gives an error that's more confusing than it has to be:
```julia
julia> repeat(1:3, 4.0)
ERROR: MethodError: no method matching similar(::UnitRange{Int64}, ::Float64)
The function `similar` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  similar(::JuliaInterpreter.Compiled, ::Any)
   @ JuliaInterpreter ~/.julia/packages/JuliaInterpreter/tYiNO/src/types.jl:7
  similar(::AbstractArray, ::Type{T}) where T
   @ Base abstractarray.jl:821
  similar(::AbstractArray, ::Type{T}, ::NTuple{N, Int64}) where {T, N}
   @ Base abstractarray.jl:833
  ...

Stacktrace:
 [1] repeat_outer(a::UnitRange{Int64}, ::Tuple{Float64})
   @ Base._RepeatInnerOuter ./abstractarraymath.jl:480
 [2] repeat_inner_outer(arr::UnitRange{Int64}, ::Nothing, outer::Tuple{Float64})
   @ Base._RepeatInnerOuter ./abstractarraymath.jl:460
 [3] repeat(arr::UnitRange{Int64}; inner::Nothing, outer::Tuple{Float64})
   @ Base._RepeatInnerOuter ./abstractarraymath.jl:402
 [4] repeat(A::UnitRange{Int64}; inner::Nothing, outer::Tuple{Float64})
   @ Base ./abstractarraymath.jl:394
 [5] repeat(A::UnitRange{Int64}, counts::Float64)
   @ Base ./abstractarraymath.jl:357
 [6] top-level scope
   @ REPL[48]:1

help?> repeat
search: repeat reset pad_repeat keepat! relpath replace read @deprecate realpath repr RecipeData

  repeat(A::AbstractArray, counts::Integer...)

  Construct an array by repeating array A a given number of times in each dimension, specified by
  counts.

  See also: fill, Iterators.repeated, Iterators.cycle.
```

After:
```julia
julia> repeat(1:3, 4.0)
ERROR: MethodError: no method matching repeat(::UnitRange{Int64}, ::Float64)
The function `repeat` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  repeat(::AbstractArray, ::Integer...)
   @ Base REPL[4]:1
```