### PR TITLE
Stylistically disambiguate julia> in docstrings

### DIFF
--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -47,7 +47,7 @@ const MARKDOWN_FACES = [
     :markdown_h6 => Face(height=1.05, inherit=:markdown_header),
     :markdown_admonition => Face(weight=:bold),
     :markdown_code => Face(inherit=:code),
-    :markdown_julia_prompt => Face(inherit=:repl_prompt_julia),
+    :markdown_julia_prompt => Face(slant=:italic, foreground=:bright_green, inherit=:repl_prompt_julia),
     :markdown_footnote => Face(inherit=:bright_yellow),
     :markdown_hrule => Face(inherit=:shadow),
     :markdown_inlinecode => Face(inherit=:markdown_code),


### PR DESCRIPTION
If the styling is exactly the same, occasionally this can produce a bit of confusion or a double take when people mix it up with the REPL Julia prompt.

This has come up in OhMyREPL, and was brought up by @BioTurboNick after #54423 was merged.

There are a few ways we can try varying the style, here I've picked one of them so we've actually got a starting point for discussion: italic + different shade of green.

![image](https://github.com/user-attachments/assets/05f3a8c4-9e16-4751-a662-8a02d95cc664)
