### PR TITLE
Make AnnotateChar equality consider annotations

### DIFF
--- a/base/strings/annotated.jl
+++ b/base/strings/annotated.jl
@@ -197,11 +197,19 @@ cmp(a::AbstractString, b::AnnotatedString) = cmp(a, b.string)
 # To avoid method ambiguity
 cmp(a::AnnotatedString, b::AnnotatedString) = cmp(a.string, b.string)
 
+# Annotated strings are equal if their strings and annotations are equal
 ==(a::AnnotatedString, b::AnnotatedString) =
     a.string == b.string && a.annotations == b.annotations
 
 ==(a::AnnotatedString, b::AbstractString) = isempty(a.annotations) && a.string == b
 ==(a::AbstractString, b::AnnotatedString) = isempty(b.annotations) && a == b.string
+
+# Annotated chars are equal if their chars and annotations are equal
+==(a::AnnotatedChar, b::AnnotatedChar) =
+    a.char == b.char && a.annotations == b.annotations
+
+==(a::AnnotatedChar, b::AbstractChar) = isempty(a.annotations) && a.char == b
+==(a::AbstractChar, b::AnnotatedChar) = isempty(b.annotations) && a == b.char
 
 # To prevent substring equality from hitting the generic fallback
 

--- a/test/strings/annotated.jl
+++ b/test/strings/annotated.jl
@@ -65,9 +65,9 @@ end
     chr = Base.AnnotatedChar('c')
     @test chr == Base.AnnotatedChar(chr.char, Pair{Symbol, Any}[])
     str = Base.AnnotatedString("hmm", [(1:1, :attr => "h0h0"),
-                               (1:2, :attr => "h0m1"),
-                               (2:3, :attr => "m1m2")])
-    @test str[1] == Base.AnnotatedChar('h', Pair{Symbol, Any}[:attr => "h0h0"])
+                                       (1:2, :attr => "h0m1"),
+                                       (2:3, :attr => "m1m2")])
+    @test str[1] == Base.AnnotatedChar('h', Pair{Symbol, Any}[:attr => "h0h0", :attr => "h0m1"])
     @test str[2] == Base.AnnotatedChar('m', Pair{Symbol, Any}[:attr => "h0m1", :attr => "m1m2"])
     @test str[3] == Base.AnnotatedChar('m', Pair{Symbol, Any}[:attr => "m1m2"])
 end


### PR DESCRIPTION
This is needed for consistency with the view of equality we've adopted for AnnotatedStrings. By making AnnotateChar require annotations to be equal, we preserve the quality that two strings are equal if all their characters are equal.

This oversight was raised by @aplavin in https://github.com/JuliaLang/julia/issues/55244#issuecomment-2272671275.

The alternative is to have equality on `AnnotatedString` and `AnnotatedChar` ignore annotations, but it seems a bit weird if `styled"{red:hey}" == styled"{blue:hey}"`.