### PR TITLE
Improve `walkdir` docstring

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -1102,7 +1102,6 @@ The directory tree can be traversed top-down or bottom-up.
 If `walkdir` or `stat` encounters a `IOError` it will rethrow the error by default.
 A custom error handling function can be provided through `onerror` keyword argument.
 `onerror` is called with a `IOError` as argument.
-The returned iterator is implemented as a [`Channel`](@ref).
 
 See also: [`readdir`](@ref).
 
@@ -1123,8 +1122,7 @@ end
 ```julia-repl
 julia> mkpath("my/test/dir");
 
-julia> itr = walkdir("my")
-Channel{Tuple{String, Vector{String}, Vector{String}}}(0) (1 item available)
+julia> itr = walkdir("my");
 
 julia> (path, dirs, files) = first(itr)
 ("my", ["test"], String[])

--- a/base/file.jl
+++ b/base/file.jl
@@ -1094,10 +1094,10 @@ end
 
 Return an iterator that walks the directory tree of a directory.
 
-The iterator returns a tuple containing `(root, dirs, files)`.
-Each iteration `root` will change to the next directory in the tree;
+The iterator returns a tuple containing `(path, dirs, files)`.
+Each iteration `path` will change to the next directory in the tree;
 then `dirs` and `files` will be vectors containing the directories and files
-in the current `root` directory.
+in the current `path` directory.
 The directory tree can be traversed top-down or bottom-up.
 If `walkdir` or `stat` encounters a `IOError` it will rethrow the error by default.
 A custom error handling function can be provided through `onerror` keyword argument.
@@ -1108,14 +1108,14 @@ See also: [`readdir`](@ref).
 
 # Examples
 ```julia
-for (root, dirs, files) in walkdir(".")
-    println("Directories in \$root")
+for (path, dirs, files) in walkdir(".")
+    println("Directories in \$path")
     for dir in dirs
-        println(joinpath(root, dir)) # path to directories
+        println(joinpath(path, dir)) # path to directories
     end
-    println("Files in \$root")
+    println("Files in \$path")
     for file in files
-        println(joinpath(root, file)) # path to files
+        println(joinpath(path, file)) # path to files
     end
 end
 ```
@@ -1126,18 +1126,18 @@ julia> mkpath("my/test/dir");
 julia> itr = walkdir("my")
 Channel{Tuple{String, Vector{String}, Vector{String}}}(0) (1 item available)
 
-julia> (root, dirs, files) = first(itr)
+julia> (path, dirs, files) = first(itr)
 ("my", ["test"], String[])
 
-julia> (root, dirs, files) = first(itr)
+julia> (path, dirs, files) = first(itr)
 ("my/test", ["dir"], String[])
 
-julia> (root, dirs, files) = first(itr)
+julia> (path, dirs, files) = first(itr)
 ("my/test/dir", String[], String[])
 ```
 """
-function walkdir(root; topdown=true, follow_symlinks=false, onerror=throw)
-    function _walkdir(chnl, root)
+function walkdir(path; topdown=true, follow_symlinks=false, onerror=throw)
+    function _walkdir(chnl, path)
         tryf(f, p) = try
                 f(p)
             catch err
@@ -1149,7 +1149,7 @@ function walkdir(root; topdown=true, follow_symlinks=false, onerror=throw)
                 end
                 return
             end
-        entries = tryf(_readdirx, root)
+        entries = tryf(_readdirx, path)
         entries === nothing && return
         dirs = Vector{String}()
         files = Vector{String}()
@@ -1163,17 +1163,17 @@ function walkdir(root; topdown=true, follow_symlinks=false, onerror=throw)
         end
 
         if topdown
-            push!(chnl, (root, dirs, files))
+            push!(chnl, (path, dirs, files))
         end
         for dir in dirs
-            _walkdir(chnl, joinpath(root, dir))
+            _walkdir(chnl, joinpath(path, dir))
         end
         if !topdown
-            push!(chnl, (root, dirs, files))
+            push!(chnl, (path, dirs, files))
         end
         nothing
     end
-    return Channel{Tuple{String,Vector{String},Vector{String}}}(chnl -> _walkdir(chnl, root))
+    return Channel{Tuple{String,Vector{String},Vector{String}}}(chnl -> _walkdir(chnl, path))
 end
 
 function unlink(p::AbstractString)

--- a/base/file.jl
+++ b/base/file.jl
@@ -1093,11 +1093,16 @@ end
     walkdir(dir; topdown=true, follow_symlinks=false, onerror=throw)
 
 Return an iterator that walks the directory tree of a directory.
-The iterator returns a tuple containing `(rootpath, dirs, files)`.
+
+The iterator returns a tuple containing `(root, dirs, files)`.
+Each iteration `root` will change to the next directory in the tree;
+then `dirs` and `files` will be vectors containing the directories and files
+in the current `root` directory.
 The directory tree can be traversed top-down or bottom-up.
 If `walkdir` or `stat` encounters a `IOError` it will rethrow the error by default.
 A custom error handling function can be provided through `onerror` keyword argument.
 `onerror` is called with a `IOError` as argument.
+The returned iterator is implemented as a [`Channel`](@ref).
 
 See also: [`readdir`](@ref).
 
@@ -1118,7 +1123,8 @@ end
 ```julia-repl
 julia> mkpath("my/test/dir");
 
-julia> itr = walkdir("my");
+julia> itr = walkdir("my")
+Channel{Tuple{String, Vector{String}, Vector{String}}}(0) (1 item available)
 
 julia> (root, dirs, files) = first(itr)
 ("my", ["test"], String[])


### PR DESCRIPTION
I was not able to understand how to use `walkdir` with the current docstring. It was not clear to me that `root` changes each iteration. I thought `root` would stay fixed to the input and `dirs` would iterate.

I also think the second example could use more explanation since I still do not understand it as I explain in this discourse post:
https://discourse.julialang.org/t/find-all-files-named-findthis-csv-in-nested-subfolders-of-rootfolder/118096. Hopefully a reviewer can help with that.