### PR TITLE
LinearAlgebra: move alg to a keyword argument in symmetric eigen

### DIFF
--- a/stdlib/LinearAlgebra/src/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/src/symmetriceigen.jl
@@ -6,10 +6,10 @@ eigencopy_oftype(A::Hermitian, S) = Hermitian(copytrito!(similar(parent(A), S, s
 eigencopy_oftype(A::Symmetric, S) = Symmetric(copytrito!(similar(parent(A), S, size(A)), A.data, A.uplo), sym_uplo(A.uplo))
 eigencopy_oftype(A::Symmetric{<:Complex}, S) = copyto!(similar(parent(A), S), A)
 
-default_eigen_alg(A) = DivideAndConquer()
+default_eigen_alg(@nospecialize(A)) = DivideAndConquer()
 
 # Eigensolvers for symmetric and Hermitian matrices
-function eigen!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}, alg::Algorithm = default_eigen_alg(A); sortby::Union{Function,Nothing}=nothing)
+function eigen!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; sortby::Union{Function,Nothing}=nothing, alg::Algorithm = default_eigen_alg(A))
     if alg === DivideAndConquer()
         Eigen(sorteig!(LAPACK.syevd!('V', A.uplo, A.data)..., sortby)...)
     elseif alg === QRIteration()
@@ -29,7 +29,7 @@ function eigen(A::RealHermSymComplexHerm{Float16}; sortby::Union{Function,Nothin
 end
 
 """
-    eigen(A::Union{Hermitian, Symmetric}, alg::Algorithm = default_eigen_alg(A)) -> Eigen
+    eigen(A::Union{Hermitian, Symmetric}; alg::LinearAlgebra.Algorithm = LinearAlgebra.default_eigen_alg(A)) -> Eigen
 
 Compute the eigenvalue decomposition of `A`, returning an [`Eigen`](@ref) factorization object `F`
 which contains the eigenvalues in `F.values` and the eigenvectors in the columns of the
@@ -52,9 +52,9 @@ The default `alg` used may change in the future.
 
 The following functions are available for `Eigen` objects: [`inv`](@ref), [`det`](@ref), and [`isposdef`](@ref).
 """
-function eigen(A::RealHermSymComplexHerm, alg::Algorithm = default_eigen_alg(A); sortby::Union{Function,Nothing}=nothing)
+function eigen(A::RealHermSymComplexHerm; sortby::Union{Function,Nothing}=nothing, alg::Algorithm = default_eigen_alg(A))
     S = eigtype(eltype(A))
-    eigen!(eigencopy_oftype(A, S), alg; sortby)
+    eigen!(eigencopy_oftype(A, S); sortby, alg)
 end
 
 
@@ -109,7 +109,7 @@ function eigen(A::RealHermSymComplexHerm, vl::Real, vh::Real)
 end
 
 
-function eigvals!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}, alg::Algorithm = default_eigen_alg(A); sortby::Union{Function,Nothing}=nothing)
+function eigvals!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; sortby::Union{Function,Nothing}=nothing, alg::Algorithm = default_eigen_alg(A))
     vals::Vector{real(eltype(A))} = if alg === DivideAndConquer()
         LAPACK.syevd!('N', A.uplo, A.data)
     elseif alg === QRIteration()
@@ -124,7 +124,7 @@ function eigvals!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}, alg::Al
 end
 
 """
-    eigvals(A::Union{Hermitian, Symmetric}, alg::Algorithm = default_eigen_alg(A))) -> values
+    eigvals(A::Union{Hermitian, Symmetric}; alg::LinearAlgebra.Algorithm = LinearAlgebra.default_eigen_alg(A))) -> values
 
 Return the eigenvalues of `A`.
 
@@ -138,9 +138,9 @@ a comparison of the accuracy and performance of different methods.
 
 The default `alg` used may change in the future.
 """
-function eigvals(A::RealHermSymComplexHerm, alg::Algorithm = default_eigen_alg(A); sortby::Union{Function,Nothing}=nothing)
+function eigvals(A::RealHermSymComplexHerm; sortby::Union{Function,Nothing}=nothing, alg::Algorithm = default_eigen_alg(A))
     S = eigtype(eltype(A))
-    eigvals!(eigencopy_oftype(A, S), alg; sortby)
+    eigvals!(eigencopy_oftype(A, S); sortby, alg)
 end
 
 

--- a/stdlib/LinearAlgebra/src/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/src/symmetriceigen.jl
@@ -6,6 +6,12 @@ eigencopy_oftype(A::Hermitian, S) = Hermitian(copytrito!(similar(parent(A), S, s
 eigencopy_oftype(A::Symmetric, S) = Symmetric(copytrito!(similar(parent(A), S, size(A)), A.data, A.uplo), sym_uplo(A.uplo))
 eigencopy_oftype(A::Symmetric{<:Complex}, S) = copyto!(similar(parent(A), S), A)
 
+"""
+    default_eigen_alg(A)
+
+Return the default algorithm used to solve the eigensystem `A v = λ v` for a symmetric matrix `A`.
+Defaults to `LinearAlegbra.DivideAndConquer()`, which corresponds to the LAPACK function `LAPACK.syevd!`. 
+"""
 default_eigen_alg(@nospecialize(A)) = DivideAndConquer()
 
 # Eigensolvers for symmetric and Hermitian matrices

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -720,21 +720,6 @@ end
     end
 end
 
-@testset "eigendecomposition Algorithms" begin
-    using LinearAlgebra: DivideAndConquer, QRIteration, RobustRepresentations
-    for T in (Float64, ComplexF64, Float32, ComplexF32)
-        n = 4
-        A = T <: Real ? Symmetric(randn(T, n, n)) : Hermitian(randn(T, n, n))
-        d, v = eigen(A)
-        for alg in (DivideAndConquer(), QRIteration(), RobustRepresentations())
-            @test (@inferred eigvals(A, alg)) ≈ d
-            d2, v2 = @inferred eigen(A, alg)
-            @test d2 ≈ d
-            @test A * v2 ≈ v2 * Diagonal(d2)
-        end
-    end
-end
-
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
 isdefined(Main, :ImmutableArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "ImmutableArrays.jl"))
 using .Main.ImmutableArrays

--- a/stdlib/LinearAlgebra/test/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/test/symmetriceigen.jl
@@ -3,6 +3,7 @@
 module TestSymmetricEigen
 
 using Test, LinearAlgebra
+using LinearAlgebra: DivideAndConquer, QRIteration, RobustRepresentations
 
 @testset "chol-eigen-eigvals" begin
     ## Cholesky decomposition based
@@ -179,21 +180,18 @@ end
     @test S * v ≈ v * Diagonal(λ)
 end
 
-@testset "eigvals/eigen alg" begin
-    n = 4
-    S = Symmetric(rand(n,n))
-    λ1 = eigvals(S, alg=LinearAlgebra.DivideAndConquer())
-    λ2 = eigvals(S, alg=LinearAlgebra.RobustRepresentations())
-    λ3 = eigvals(S, alg=LinearAlgebra.QRIteration())
-    @test λ1 ≈ λ2 ≈ λ3
-
-    λ1, v1 = eigen(S, alg=LinearAlgebra.DivideAndConquer())
-    λ2, v2 = eigen(S, alg=LinearAlgebra.RobustRepresentations())
-    λ3, v3 = eigen(S, alg=LinearAlgebra.QRIteration())
-    @test λ1 ≈ λ2 ≈ λ3
-    @test S * v1 ≈ v1 * Diagonal(λ1)
-    @test S * v2 ≈ v2 * Diagonal(λ1)
-    @test S * v3 ≈ v3 * Diagonal(λ1)
+@testset "eigendecomposition Algorithms" begin
+    for T in (Float64, ComplexF64, Float32, ComplexF32)
+        n = 4
+        A = T <: Real ? Symmetric(randn(T, n, n)) : Hermitian(randn(T, n, n))
+        d, v = eigen(A)
+        for alg in (DivideAndConquer(), QRIteration(), RobustRepresentations())
+            @test (@inferred eigvals(A; alg)) ≈ d
+            d2, v2 = @inferred eigen(A; alg)
+            @test d2 ≈ d
+            @test A * v2 ≈ v2 * Diagonal(d2)
+        end
+    end
 end
 
 end # module TestSymmetricEigen

--- a/stdlib/LinearAlgebra/test/symmetriceigen.jl
+++ b/stdlib/LinearAlgebra/test/symmetriceigen.jl
@@ -179,4 +179,21 @@ end
     @test S * v ≈ v * Diagonal(λ)
 end
 
+@testset "eigvals/eigen alg" begin
+    n = 4
+    S = Symmetric(rand(n,n))
+    λ1 = eigvals(S, alg=LinearAlgebra.DivideAndConquer())
+    λ2 = eigvals(S, alg=LinearAlgebra.RobustRepresentations())
+    λ3 = eigvals(S, alg=LinearAlgebra.QRIteration())
+    @test λ1 ≈ λ2 ≈ λ3
+
+    λ1, v1 = eigen(S, alg=LinearAlgebra.DivideAndConquer())
+    λ2, v2 = eigen(S, alg=LinearAlgebra.RobustRepresentations())
+    λ3, v3 = eigen(S, alg=LinearAlgebra.QRIteration())
+    @test λ1 ≈ λ2 ≈ λ3
+    @test S * v1 ≈ v1 * Diagonal(λ1)
+    @test S * v2 ≈ v2 * Diagonal(λ1)
+    @test S * v3 ≈ v3 * Diagonal(λ1)
+end
+
 end # module TestSymmetricEigen


### PR DESCRIPTION
Currently, `eigen` for symmetric matrices accepts an `alg` as the second positional argument, but this departs from the pattern of `eigen(A, B)` representing a generalized eigenvalue problem. This PR moves `alg` to a keyword argument instead. This prevents packages from specializing on `alg`, but I'm unsure if there's demand for that.

Incidentally, `alg` as a keyword argument in `eigen` is also consistent with how it is passed to the `sort` family of functions, although there's no direct relation between these.