### PR TITLE
[release-1.11] fix GC race bug in pool sweep

### DIFF
--- a/src/gc.h
+++ b/src/gc.h
@@ -441,7 +441,6 @@ extern jl_gc_num_t gc_num;
 extern bigval_t *big_objects_marked;
 extern arraylist_t finalizer_list_marked;
 extern arraylist_t to_finalize;
-extern int64_t buffered_pages;
 extern int gc_first_tid;
 extern int gc_n_threads;
 extern jl_ptls_t* gc_all_tls_states;


### PR DESCRIPTION
We have parallel sweeping on 1.11, so we should use atomics here.

This issue has already been fixed on master due to https://github.com/JuliaLang/julia/pull/54961.

We can also backport https://github.com/JuliaLang/julia/pull/54961 to release-1.11, but I have some preference to land this one since it's considerably less disruptive and we're already on RC2.