### PR TITLE
clarify that :compact prohibition on line breaks is for 2-arg show

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -352,7 +352,7 @@ The following properties are in common use:
 
  - `:compact`: Boolean specifying that values should be printed more compactly, e.g.
    that numbers should be printed with fewer digits. This is set when printing array
-   elements. `:compact` output should not contain line breaks.
+   elements. `:compact` output for 2-argument [`show(io, x)`](@ref) should not contain line breaks.
  - `:limit`: Boolean specifying that containers should be truncated, e.g. showing `…` in
    place of most elements.
  - `:displaysize`: A `Tuple{Int,Int}` giving the size in rows and columns to use for text


### PR DESCRIPTION
The docs say that `:compact=>true` in the `IOContext` means that the output should not contain line breaks.  Clarify that this is for the 2-argument `show(io, x)` output.

(As opposed to 3-arg `show`, whose whole purpose has always been to enable verbose multi-line display, and which is normally only called at the top level by `display`, not for nested objects).

See also [this discourse thread](https://discourse.julialang.org/t/why-does-show-for-arrays-and-dictionaries-ignore-compact/118159).