### PR TITLE
remove redundant `print` method for `Splat`

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1339,8 +1339,7 @@ struct Splat{F} <: Function
     Splat(f) = new{Core.Typeof(f)}(f)
 end
 (s::Splat)(args) = s.f(args...)
-print(io::IO, s::Splat) = print(io, "splat(", s.f, ')')
-show(io::IO, s::Splat) = print(io, s)
+show(io::IO, s::Splat) = print(io, "splat(", s.f, ')')
 
 ## in and related operators
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -1339,7 +1339,7 @@ struct Splat{F} <: Function
     Splat(f) = new{Core.Typeof(f)}(f)
 end
 (s::Splat)(args) = s.f(args...)
-show(io::IO, s::Splat) = print(io, "splat(", s.f, ')')
+show(io::IO, s::Splat) = (print(io, "splat("); show(io, s.f); print(io, ")"))
 
 ## in and related operators
 


### PR DESCRIPTION
I think that `print` is redundant here. The docstring for `print` says:

> `print` falls back to calling `show`, so most types should just define `show`.