### PR TITLE
propagate the terminal's `displaysize` to the `IOContext` used by the REPL

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -208,7 +208,12 @@ function show(
         get(io, :limit, false)::Bool || return show(io, str)
         limit = max(20, displaysize(io)[2])
         # one line in collection, seven otherwise
-        get(io, :typeinfo, nothing) === nothing && (limit *= 7)
+        if get(io, :typeinfo, nothing) === nothing
+            limit *= 7
+        else
+            # strings in collections are typically indented one space
+            limit -= 1
+        end
     end
 
     # early out for short strings

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -510,6 +510,7 @@ function display(d::REPLDisplay, mime::MIME"text/plain", x)
             # this can override the :limit property set initially
             io = foldl(IOContext, d.repl.options.iocontext, init=io)
         end
+        io = IOContext(io, :displaysize => displaysize(outstream(d.repl)))
         show_repl(io, mime, x[])
         println(io)
     end

--- a/test/show.jl
+++ b/test/show.jl
@@ -897,7 +897,7 @@ end
         @test r == repr("x"^271) * " ⋯ 459 bytes ⋯ " * repr("x"^270)
         r = replstr(["x"^1000])
         @test length(r) < 120
-        @test r == "1-element Vector{String}:\n " * repr("x"^31) * " ⋯ 939 bytes ⋯ " * repr("x"^30)
+        @test r == "1-element Vector{String}:\n " * repr("x"^30) * " ⋯ 940 bytes ⋯ " * repr("x"^30)
     end
 end
 


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/49440 (and all other cases where `displaysize` is used in Base with the expectation that this actually gives something related to the terminal).

Needed because of https://github.com/JuliaLang/julia/issues/34721