### PR TITLE
add docstring note about `displaysize` and `IOContext` with `context`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -336,6 +336,11 @@ end
     IOContext(io::IO, context::IOContext)
 
 Create an `IOContext` that wraps an alternate `IO` but inherits the properties of `context`.
+
+!!! note
+    Unless explicitly set in the wrapped `io` the `displaysize` of `io` will not be inherited.
+    This is because by default `displaysize` is not a property of IO objects themselves, but lazily inferred,
+    as the size of the terminal window can change during the lifetime of the IO object.
 """
 IOContext(io::IO, context::IO) = IOContext(io, ioproperties(context))
 


### PR DESCRIPTION
Given https://github.com/JuliaLang/julia/issues/34721 which was closed as not planned.