### PR TITLE
Avoid using zero for the eltype in `tr(::Matrix)`

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -373,7 +373,7 @@ diagm(m::Integer, n::Integer, v::AbstractVector) = diagm(m, n, 0 => v)
 function tr(A::Matrix{T}) where T
     checksquare(A)
     isempty(A) && return zero(T)
-    sum(A[i] for i in diagind(A))
+    reduce(+, (A[i] for i in diagind(A)))
 end
 
 _kronsize(A::AbstractMatrix, B::AbstractMatrix) = map(*, size(A), size(B))

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -371,12 +371,9 @@ diagm(v::AbstractVector) = diagm(0 => v)
 diagm(m::Integer, n::Integer, v::AbstractVector) = diagm(m, n, 0 => v)
 
 function tr(A::Matrix{T}) where T
-    n = checksquare(A)
-    t = zero(T)
-    @inbounds @simd for i in 1:n
-        t += A[i,i]
-    end
-    t
+    checksquare(A)
+    isempty(A) && return zero(T)
+    sum(A[i] for i in diagind(A))
 end
 
 _kronsize(A::AbstractMatrix, B::AbstractMatrix) = map(*, size(A), size(B))

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -1285,10 +1285,16 @@ end
     @test eltype(A) == eltype(T)
 end
 
-@testset "tr for block matrices" begin
-    S = [1 2; 3 4]
-    M = fill(S, 3, 3)
-    @test tr(M) == 3S
+@testset "tr" begin
+    @testset "block matrices" begin
+        S = [1 2; 3 4]
+        M = fill(S, 3, 3)
+        @test tr(M) == 3S
+    end
+    @testset "avoid promotion" begin
+        A = Int8[1 3; 2 4]
+        @test tr(A) === Int8(5)
+    end
 end
 
 end # module TestDense

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -1285,4 +1285,10 @@ end
     @test eltype(A) == eltype(T)
 end
 
+@testset "tr for block matrices" begin
+    S = [1 2; 3 4]
+    M = fill(S, 3, 3)
+    @test tr(M) == 3S
+end
+
 end # module TestDense


### PR DESCRIPTION
This lets us compute the `tr` for `Matrix`es where the `eltype` does not have a zero, but we may sum over the diagonal.
E.g. the following works after this:
```julia
julia> M = fill([1 2; 3 4], 2, 2)
2×2 Matrix{Matrix{Int64}}:
 [1 2; 3 4]  [1 2; 3 4]
 [1 2; 3 4]  [1 2; 3 4]

julia> tr(M)
2×2 Matrix{Int64}:
 2  4
 6  8
```

Also, using linear indexing over Cartesian appears to provide a slight speed-up for small to mid-sized matrices:
```julia
julia> A = rand(1000,1000);

julia> @btime tr($A);
  1.796 μs (0 allocations: 0 bytes) # nightly
  1.524 μs (0 allocations: 0 bytes) # This PR
```