### PR TITLE
Faster trace for `StridedMatrix`es

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -370,10 +370,10 @@ julia> diagm([1,2,3])
 diagm(v::AbstractVector) = diagm(0 => v)
 diagm(m::Integer, n::Integer, v::AbstractVector) = diagm(m, n, 0 => v)
 
-function tr(A::Matrix{T}) where T
+function tr(A::StridedMatrix{T}) where T
     checksquare(A)
     isempty(A) && return zero(T)
-    reduce(+, (A[i] for i in diagind(A)))
+    reduce(+, (A[i] for i in diagind(A, IndexStyle(A))))
 end
 
 _kronsize(A::AbstractMatrix, B::AbstractMatrix) = map(*, size(A), size(B))

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -1290,10 +1290,14 @@ end
         S = [1 2; 3 4]
         M = fill(S, 3, 3)
         @test tr(M) == 3S
+        @test tr(view(M, :, :)) == 3S
+        @test tr(view(M, axes(M)...)) == 3S
     end
     @testset "avoid promotion" begin
         A = Int8[1 3; 2 4]
         @test tr(A) === Int8(5)
+        @test tr(view(A, :, :)) === Int8(5)
+        @test tr(view(A, axes(A)...)) === Int8(5)
     end
 end
 


### PR DESCRIPTION
This PR generalizes the `tr(::Matrix)` method to accept `StridedMatrix` types.
As a consequence:
```julia
julia> A = rand(1000,1000);

julia> V = view(A, axes(A)...);

julia> @btime tr($V);
  1.990 μs (3 allocations: 7.88 KiB) # nightly v"1.12.0-DEV.1063"
  999.455 ns (0 allocations: 0 bytes) # this PR
```