### PR TITLE
Set `.jl` sources as read-only during installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,8 +384,8 @@ endif
 	cp -R -L $(build_datarootdir)/julia/* $(DESTDIR)$(datarootdir)/julia
 
 	# Set .jl sources as read-only to match package directories
-	find $(DESTDIR)$(datarootdir)/julia/base -name \*.jl -exec chmod 0444 {}
-	find $(DESTDIR)$(datarootdir)/julia/test -name \*.jl -exec chmod 0444 {}
+	find $(DESTDIR)$(datarootdir)/julia/base -name \*.jl -exec chmod 0444 '{}' \;
+	find $(DESTDIR)$(datarootdir)/julia/test -name \*.jl -exec chmod 0444 '{}' \;
 
 	# Copy documentation
 	cp -R -L $(BUILDROOT)/doc/_build/html $(DESTDIR)$(docdir)/

--- a/Makefile
+++ b/Makefile
@@ -383,9 +383,9 @@ endif
 	cp -R -L $(JULIAHOME)/test/* $(DESTDIR)$(datarootdir)/julia/test
 	cp -R -L $(build_datarootdir)/julia/* $(DESTDIR)$(datarootdir)/julia
 
-        # Set .jl sources as read-only to match package directories
-        find $(DESTDIR)$(datarootdir)/julia/base -name \*.jl -exec chmod 0444 {}
-        find $(DESTDIR)$(datarootdir)/julia/test -name \*.jl -exec chmod 0444 {}
+	# Set .jl sources as read-only to match package directories
+	find $(DESTDIR)$(datarootdir)/julia/base -name \*.jl -exec chmod 0444 {}
+	find $(DESTDIR)$(datarootdir)/julia/test -name \*.jl -exec chmod 0444 {}
 
 	# Copy documentation
 	cp -R -L $(BUILDROOT)/doc/_build/html $(DESTDIR)$(docdir)/

--- a/Makefile
+++ b/Makefile
@@ -384,8 +384,8 @@ endif
 	cp -R -L $(build_datarootdir)/julia/* $(DESTDIR)$(datarootdir)/julia
 
 	# Set .jl sources as read-only to match package directories
-	find $(DESTDIR)$(datarootdir)/julia/base -name \*.jl -exec chmod 0444 '{}' \;
-	find $(DESTDIR)$(datarootdir)/julia/test -name \*.jl -exec chmod 0444 '{}' \;
+	find $(DESTDIR)$(datarootdir)/julia/base -type f -name \*.jl -exec chmod 0444 '{}' \;
+	find $(DESTDIR)$(datarootdir)/julia/test -type f -name \*.jl -exec chmod 0444 '{}' \;
 
 	# Copy documentation
 	cp -R -L $(BUILDROOT)/doc/_build/html $(DESTDIR)$(docdir)/

--- a/Makefile
+++ b/Makefile
@@ -382,6 +382,11 @@ endif
 	cp -R -L $(JULIAHOME)/base/* $(DESTDIR)$(datarootdir)/julia/base
 	cp -R -L $(JULIAHOME)/test/* $(DESTDIR)$(datarootdir)/julia/test
 	cp -R -L $(build_datarootdir)/julia/* $(DESTDIR)$(datarootdir)/julia
+
+        # Set .jl sources as read-only to match package directories
+        find $(DESTDIR)$(datarootdir)/julia/base -name \*.jl -exec chmod 0444 {}
+        find $(DESTDIR)$(datarootdir)/julia/test -name \*.jl -exec chmod 0444 {}
+
 	# Copy documentation
 	cp -R -L $(BUILDROOT)/doc/_build/html $(DESTDIR)$(docdir)/
 	# Remove various files which should not be installed


### PR DESCRIPTION
This sets all `.jl` files in `$(prefix)/base` and `$(prefix)/test` to have `0444` permissions, to better match how `Pkg` installs packages (and sets them to be read-only).

Fixes https://github.com/JuliaLang/juliaup/issues/865