### PR TITLE
inference: propagate partially initialized mutable structs more

### DIFF
--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -18,7 +18,7 @@ function hasuniquerep(@nospecialize t)
     iskindtype(typeof(t)) || return true # non-types are always compared by egal in the type system
     isconcretetype(t) && return true # these are also interned and pointer comparable
     if isa(t, DataType) && t.name !== Tuple.name && !isvarargtype(t) # invariant DataTypes
-        return _all(hasuniquerep, t.parameters)
+        return all(hasuniquerep, t.parameters)
     end
     return false
 end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -6033,6 +6033,22 @@ end |> Core.Compiler.is_nothrow
         return x.b
     end
 end |> !Core.Compiler.is_nothrow
+@test Base.infer_effects((PartiallyInitialized2,); optimize=false) do x
+    if isdefined(x, :b)
+        if isdefined(x, :c)
+            return x.c
+        end
+        return x.b
+    end
+    return nothing
+end |> Core.Compiler.is_nothrow
+@test Base.infer_effects((Bool,Int,); optimize=false) do c, b
+    x = c ? PartiallyInitialized1(true) : PartiallyInitialized1(true, b)
+    if isdefined(x, :b)
+        return Val(x.a), x.b
+    end
+    return nothing
+end |> Core.Compiler.is_nothrow
 
 # End to end test case for the partially initialized struct with `PartialStruct`
 @noinline broadcast_noescape1(a) = (broadcast(identity, a); nothing)


### PR DESCRIPTION
Following up JuliaLang/julia#55297.
A mutable struct can have undefined fields in a non-contiguous manner, but `PartialStruct` cannot model such a state. So in JuliaLang/julia#55297 `PartialStruct` was used to represent only the mutable objects where the field following the minimum initialized fields is also defined.

As a follow-up for the PR, this commit implements a minor improvement that, in cases when the mutable object is already represented as a `PartialStruct`, allows inference to add one more `isdefined`-field information on top of those implied by its `fields`.

```julia
mutable struct PartiallyInitialized2
    a; b; c
    PartiallyInitialized2(a) = (@nospecialize; new(a))
    PartiallyInitialized2(a, b) = (@nospecialize; new(a, b))
    PartiallyInitialized2(a, b, c) = (@nospecialize; new(a, b, c))
end

@test Base.infer_effects((PartiallyInitialized2,); optimize=false) do x
    if isdefined(x, :b)
        if isdefined(x, :c)
            return x.c
        end
        return x.b
    end
    return nothing
end |> Core.Compiler.is_nothrow
```

@nanosoldier `runtests()`