### PR TITLE
Set stdlib sources as read-only during installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,6 +385,7 @@ endif
 
 	# Set .jl sources as read-only to match package directories
 	find $(DESTDIR)$(datarootdir)/julia/base -type f -name \*.jl -exec chmod 0444 '{}' \;
+	find $(DESTDIR)$(datarootdir)/julia/stdlib -type f -name \*.jl -exec chmod 0444 '{}' \;
 	find $(DESTDIR)$(datarootdir)/julia/test -type f -name \*.jl -exec chmod 0444 '{}' \;
 
 	# Copy documentation


### PR DESCRIPTION
We previously did this for `base` and `test` in https://github.com/JuliaLang/julia/pull/55524, may as well do it for `stdlib` as well.