### PR TITLE
Implement lock based on uv_mutex for OS aware but not julia scheduler aware synchronization

### DIFF
--- a/base/lock.jl
+++ b/base/lock.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-const ThreadSynchronizer = GenericCondition{Threads.SpinLock}
+const ThreadSynchronizer = GenericCondition{Threads.SystemMutex}
 
 # Advisory reentrant lock
 """

--- a/src/sys.c
+++ b/src/sys.c
@@ -61,6 +61,7 @@
 extern "C" {
 #endif
 
+JL_DLLEXPORT int jl_sizeof_uv_mutex_t(void) { return sizeof(uv_mutex_t); }
 JL_DLLEXPORT int jl_sizeof_off_t(void) { return sizeof(off_t); }
 #ifndef _OS_WINDOWS_
 JL_DLLEXPORT int jl_sizeof_mode_t(void) { return sizeof(mode_t); }

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -159,7 +159,7 @@ let
     @test @lock(lockable2, lockable2[]["foo"]) == "hello"
 end
 
-for l in (Threads.SpinLock(), ReentrantLock())
+for l in (Threads.SpinLock(), Threads.SystemMutex(), ReentrantLock())
     @test get_finalizers_inhibited() == 0
     @test lock(get_finalizers_inhibited, l) == 1
     @test get_finalizers_inhibited() == 0


### PR DESCRIPTION
I called them SystemMutex but maybe SystemLock is a more correct name?

The idea is to replace SpinLock in locks that are expected to be held for more than a couple cycles. 