### PR TITLE
inference: refine slot undef info within `then` branch of `@isdefined`

### DIFF
--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -6050,6 +6050,18 @@ end |> Core.Compiler.is_nothrow
     return nothing
 end |> Core.Compiler.is_nothrow
 
+# refine `undef` information from `@isdefined` check
+@test Base.infer_effects((Bool,Int)) do c, x
+    local val
+    if c
+        val = x
+    end
+    if @isdefined val
+        return val
+    end
+    return zero(Int)
+end |> Core.Compiler.is_nothrow
+
 # End to end test case for the partially initialized struct with `PartialStruct`
 @noinline broadcast_noescape1(a) = (broadcast(identity, a); nothing)
 @test fully_eliminated() do


### PR DESCRIPTION
By adding some information to `Conditional`, it is possible to improve the `undef` information of `slot` within the `then` branch of `@isdefined slot`.
As a result, it's now possible to prove the `:nothrow`-ness in cases like:
```julia
@test Base.infer_effects((Bool,Int)) do c, x
    local val
    if c
        val = x
    end
    if @isdefined val
        return val
    end
    return zero(Int)
end |> Core.Compiler.is_nothrow
```

@nanosoldier `runbenchmarks("inference", vs=":master")`