### PR TITLE
Fix errant lmul! for tridiagonal and triangular

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -953,7 +953,14 @@ isunit_char(::UnitUpperTriangular) = 'U'
 isunit_char(::LowerTriangular) = 'N'
 isunit_char(::UnitLowerTriangular) = 'U'
 
-lmul!(A::Tridiagonal, B::AbstractTriangular) = A*full!(B)
+function lmul!(A::Tridiagonal, B::AbstractTriangular)
+    # this only succeeds if A is actually bidiagonal (or diagonal)
+    if isdiag(A)
+        lmul!(Diagonal(A.d), B)
+    else
+        lmul!(convert(Bidiagonal, A), B)
+    end
+end
 
 # generic fallback for AbstractTriangular matrices outside of the four subtypes provided here
 _trimul!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVector) =

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -953,11 +953,6 @@ isunit_char(::UnitUpperTriangular) = 'U'
 isunit_char(::LowerTriangular) = 'N'
 isunit_char(::UnitLowerTriangular) = 'U'
 
-function lmul!(A::Tridiagonal, B::AbstractTriangular)
-    # this only succeeds if A is actually bidiagonal
-    lmul!(convert(Bidiagonal, A), B)
-end
-
 # generic fallback for AbstractTriangular matrices outside of the four subtypes provided here
 _trimul!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVector) =
     lmul!(A, copyto!(C, B))

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -954,12 +954,8 @@ isunit_char(::LowerTriangular) = 'N'
 isunit_char(::UnitLowerTriangular) = 'U'
 
 function lmul!(A::Tridiagonal, B::AbstractTriangular)
-    # this only succeeds if A is actually bidiagonal (or diagonal)
-    if isdiag(A)
-        lmul!(Diagonal(A.d), B)
-    else
-        lmul!(convert(Bidiagonal, A), B)
-    end
+    # this only succeeds if A is actually bidiagonal
+    lmul!(convert(Bidiagonal, A), B)
 end
 
 # generic fallback for AbstractTriangular matrices outside of the four subtypes provided here

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -436,8 +436,20 @@ debug && println("Test basic type functionality")
 
             debug && println("elty1: $elty1, A1: $t1, B: $eltyB")
 
+            if A1 isa Union{UpperTriangular, UnitUpperTriangular}
+                Tri = Tridiagonal(zeros(eltyB,n-1),rand(eltyB,n),rand(eltyB,n-1))
+            else
+                Tri = Tridiagonal(rand(eltyB,n-1),rand(eltyB,n),zeros(eltyB,n-1))
+            end
+            A1c = copy(A1)
+            lmul!(Tri, A1c)
+            @test A1c ≈ Tri*M1
+            Tri = Tridiagonal(zeros(eltyB,n-1),rand(eltyB,n),zeros(eltyB,n-1))
+            A1c = copy(A1)
+            lmul!(Tri, A1c)
+            @test A1c ≈ Tri*M1
             Tri = Tridiagonal(rand(eltyB,n-1),rand(eltyB,n),rand(eltyB,n-1))
-            @test lmul!(Tri,copy(A1)) ≈ Tri*M1
+            @test_throws "matrix cannot be represented as Bidiagonal" lmul!(Tri, A1c)
             Tri = Tridiagonal(rand(eltyB,n-1),rand(eltyB,n),rand(eltyB,n-1))
             C = Matrix{promote_type(elty1,eltyB)}(undef, n, n)
             mul!(C, Tri, A1)

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -436,24 +436,6 @@ debug && println("Test basic type functionality")
 
             debug && println("elty1: $elty1, A1: $t1, B: $eltyB")
 
-            if A1 isa Union{UpperTriangular, LowerTriangular} # setindex! may not succeed for unit triangular types
-                if eltype(A1) <: Complex{<:AbstractFloat} || (eltype(A1) <: AbstractFloat && eltyB <: Real)
-                    if A1 isa UpperTriangular
-                        Tri = Tridiagonal(zeros(eltyB,n-1),rand(eltyB,n),rand(eltyB,n-1))
-                    else
-                        Tri = Tridiagonal(rand(eltyB,n-1),rand(eltyB,n),zeros(eltyB,n-1))
-                    end
-                    A1c = copy(A1)
-                    lmul!(Tri, A1c)
-                    @test A1c ≈ Tri*M1
-                    Tri = Tridiagonal(zeros(eltyB,n-1),rand(eltyB,n),zeros(eltyB,n-1))
-                    A1c = copy(A1)
-                    lmul!(Tri, A1c)
-                    @test A1c ≈ Tri*M1
-                end
-            end
-            Tri = Tridiagonal(rand(eltyB,n-1),rand(eltyB,n),rand(eltyB,n-1))
-            @test_throws "matrix cannot be represented as Bidiagonal" lmul!(Tri, A1c)
             Tri = Tridiagonal(rand(eltyB,n-1),rand(eltyB,n),rand(eltyB,n-1))
             C = Matrix{promote_type(elty1,eltyB)}(undef, n, n)
             mul!(C, Tri, A1)

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -436,18 +436,22 @@ debug && println("Test basic type functionality")
 
             debug && println("elty1: $elty1, A1: $t1, B: $eltyB")
 
-            if A1 isa Union{UpperTriangular, UnitUpperTriangular}
-                Tri = Tridiagonal(zeros(eltyB,n-1),rand(eltyB,n),rand(eltyB,n-1))
-            else
-                Tri = Tridiagonal(rand(eltyB,n-1),rand(eltyB,n),zeros(eltyB,n-1))
+            if A1 isa Union{UpperTriangular, LowerTriangular} # setindex! may not succeed for unit triangular types
+                if eltype(A1) <: Complex{<:AbstractFloat} || (eltype(A1) <: AbstractFloat && eltyB <: Real)
+                    if A1 isa UpperTriangular
+                        Tri = Tridiagonal(zeros(eltyB,n-1),rand(eltyB,n),rand(eltyB,n-1))
+                    else
+                        Tri = Tridiagonal(rand(eltyB,n-1),rand(eltyB,n),zeros(eltyB,n-1))
+                    end
+                    A1c = copy(A1)
+                    lmul!(Tri, A1c)
+                    @test A1c ≈ Tri*M1
+                    Tri = Tridiagonal(zeros(eltyB,n-1),rand(eltyB,n),zeros(eltyB,n-1))
+                    A1c = copy(A1)
+                    lmul!(Tri, A1c)
+                    @test A1c ≈ Tri*M1
+                end
             end
-            A1c = copy(A1)
-            lmul!(Tri, A1c)
-            @test A1c ≈ Tri*M1
-            Tri = Tridiagonal(zeros(eltyB,n-1),rand(eltyB,n),zeros(eltyB,n-1))
-            A1c = copy(A1)
-            lmul!(Tri, A1c)
-            @test A1c ≈ Tri*M1
             Tri = Tridiagonal(rand(eltyB,n-1),rand(eltyB,n),rand(eltyB,n-1))
             @test_throws "matrix cannot be represented as Bidiagonal" lmul!(Tri, A1c)
             Tri = Tridiagonal(rand(eltyB,n-1),rand(eltyB,n),rand(eltyB,n-1))


### PR DESCRIPTION
This method is incorrect. Firstly, the current implementation doesn't act in-place. Secondly, the result can't be stored in-place into a triangular matrix in general. This PR changes the implementation to convert the tridiagonal matrix to a `Diagonal` or a `Bidiagonal` one before attempting the `lmul!`.
Currently,
```julia
julia> T = Tridiagonal([1,2], [1,2,3], [1,2]); U = UpperTriangular(fill(2, 3, 3));

julia> lmul!(T, U)
3×3 Matrix{Int64}:
 2  4   4
 2  6  10
 0  4  10

julia> U # not updated
3×3 UpperTriangular{Int64, Matrix{Int64}}:
 2  2  2
 ⋅  2  2
 ⋅  ⋅  2

julia> parent(U) # except for the underlying storage
3×3 Matrix{Int64}:
 2  2  2
 0  2  2
 0  0  2
```
After this,
```julia
julia> lmul!(T, U)
ERROR: ArgumentError: matrix cannot be represented as Bidiagonal
```

I'm unsure if we want this method at all, since there isn't a corresponding `rmul!`, but I've left it there to avoid breakages, if any.