### PR TITLE
Fix self-recursion in generic triangular (l/r)mul!

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -1028,8 +1028,20 @@ _ldiv!(C::AbstractVecOrMat, A::UpperOrLowerTriangular, B::AbstractVecOrMat) =
 _rdiv!(C::AbstractMatrix, A::AbstractMatrix, B::UpperOrLowerTriangular) =
     generic_mattridiv!(C, uplo_char(B), isunit_char(B), wrapperop(parent(B)), A, _unwrap_at(parent(B)))
 
-ldiv!(A::AbstractTriangular, B::AbstractVecOrMat) = @inline _ldiv!(B, A, B)
-rdiv!(A::AbstractMatrix, B::AbstractTriangular)   = @inline _rdiv!(A, A, B)
+function ldiv!(A::AbstractTriangular, B::AbstractVecOrMat)
+    if istriu(A)
+        _ldiv!(B, UpperTriangular(A), B)
+    else
+        _ldiv!(B, LowerTriangular(A), B)
+    end
+end
+function rdiv!(A::AbstractMatrix, B::AbstractTriangular)
+    if istriu(B)
+        _rdiv!(A, A, UpperTriangular(B))
+    else
+        _rdiv!(A, A, LowerTriangular(B))
+    end
+end
 
 # preserve triangular structure in in-place multiplication/division
 for (cty, aty, bty) in ((:UpperTriangular, :UpperTriangular, :UpperTriangular),

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -979,9 +979,20 @@ _trimul!(C::AbstractMatrix, A::UpperOrLowerTriangular, B::AbstractTriangular) =
 _trimul!(C::AbstractMatrix, A::AbstractTriangular, B::UpperOrLowerTriangular) =
     generic_mattrimul!(C, uplo_char(B), isunit_char(B), wrapperop(parent(B)), A, _unwrap_at(parent(B)))
 
-lmul!(A::AbstractTriangular, B::AbstractVecOrMat) = @inline _trimul!(B, A, B)
-rmul!(A::AbstractMatrix, B::AbstractTriangular)   = @inline _trimul!(A, A, B)
-
+function lmul!(A::AbstractTriangular, B::AbstractVecOrMat)
+    if istriu(A)
+        _trimul!(B, UpperTriangular(A), B)
+    else
+        _trimul!(B, LowerTriangular(A), B)
+    end
+end
+function rmul!(A::AbstractMatrix, B::AbstractTriangular)
+    if istriu(B)
+        _trimul!(A, A, UpperTriangular(B))
+    else
+        _trimul!(A, A, LowerTriangular(B))
+    end
+end
 
 for TC in (:AbstractVector, :AbstractMatrix)
     @eval @inline function _mul!(C::$TC, A::AbstractTriangular, B::AbstractVector, alpha::Number, beta::Number)


### PR DESCRIPTION
This fixes a stack-overflow in the following:
```julia
julia> using LinearAlgebra

julia> struct MyTriangularWithoutLRMul{T, A<:LinearAlgebra.AbstractTriangular{T}} <: LinearAlgebra.AbstractTriangular{T}
           data :: A
       end

julia> Base.size(A::MyTriangularWithoutLRMul) = size(A.data)

julia> Base.getindex(A::MyTriangularWithoutLRMul, i::Int, j::Int) = A.data[i,j]

julia> M = MyTriangularWithoutLRMul(UpperTriangular(rand(4,4)));

julia> A = rand(4,4);

julia> lmul!(M, A)
Warning: detected a stack overflow; program state may be corrupted, so further execution might be unreliable.
ERROR: StackOverflowError:
Stacktrace:
     [1] unsafe_copyto!
       @ ./genericmemory.jl:122 [inlined]
     [2] _copyto_impl!
       @ ./array.jl:308 [inlined]
     [3] copyto!
       @ ./array.jl:299 [inlined]
     [4] copyto!
       @ ./array.jl:322 [inlined]
     [5] _trimul!(C::Matrix{Float64}, A::MyTriangularWithoutLRMul{Float64, UpperTriangular{Float64, Matrix{Float64}}}, B::Matrix{Float64})
       @ LinearAlgebra ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.12/LinearAlgebra/src/triangular.jl:961
     [6] lmul!(A::MyTriangularWithoutLRMul{Float64, UpperTriangular{Float64, Matrix{Float64}}}, B::Matrix{Float64})
       @ LinearAlgebra ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.12/LinearAlgebra/src/triangular.jl:982--- the above 2 lines are repeated 39990 more times ---
```
This is done by rerouting the generic `lmul!`/`rmul!` methods to those for `UpperTriangular` or `LowerTriangular`, depending on which triangular half is populated.

A similar issue with `ldiv!`/`rdiv!` is also resolved.