### PR TITLE
inference: invalidate stale slot wrapper types in `ssavaluetypes`

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -734,11 +734,16 @@ end
 
 _topmod(sv::InferenceState) = _topmod(frame_module(sv))
 
-function record_ssa_assign!(𝕃ᵢ::AbstractLattice, ssa_id::Int, @nospecialize(new), frame::InferenceState)
+function record_ssa_assign!(𝕃ᵢ::AbstractLattice, ssa_id::Int, @nospecialize(new),
+                            frame::InferenceState, slotwrapperssas::BitSet)
     ssavaluetypes = frame.ssavaluetypes
     old = ssavaluetypes[ssa_id]
     if old === NOT_FOUND || !is_lattice_equal(𝕃ᵢ, new, old)
         ssavaluetypes[ssa_id] = new
+        wnew = ignorelimited(new)
+        if new isa Conditional || new isa MustAlias
+            push!(slotwrapperssas, ssa_id)
+        end
         W = frame.ip
         for r in frame.ssavalue_uses[ssa_id]
             if was_reached(frame, r)

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -914,6 +914,15 @@ function dominates_ssa(compact::IncrementalCompact, domtree::DomTree, x::AnySSAV
     return dominates(domtree, xb, yb)
 end
 
+function dominates_ssa(cfg::CFG, domtree::DomTree, x::Int, y::Int)
+    xb = block_for_inst(cfg, x)
+    yb = block_for_inst(cfg, y)
+    if xb == yb
+        return x < y
+    end
+    return dominates(domtree, xb, yb)
+end
+
 function _count_added_node!(compact::IncrementalCompact, @nospecialize(val))
     if isa(val, SSAValue)
         compact.used_ssas[val.id] += 1

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -229,7 +229,7 @@ end
 
 function not_tfunc(𝕃::AbstractLattice, @nospecialize(b))
     if isa(b, Conditional)
-        return Conditional(b.slot, b.elsetype, b.thentype)
+        return Conditional(b.slot, b.elsetype, b.thentype, b.from_ssa)
     elseif isa(b, Const)
         return Const(not_int(b.val))
     end
@@ -350,14 +350,14 @@ end
     if isa(x, Conditional)
         y = widenconditional(y)
         if isa(y, Const)
-            y.val === false && return Conditional(x.slot, x.elsetype, x.thentype)
+            y.val === false && return Conditional(x.slot, x.elsetype, x.thentype, x.from_ssa)
             y.val === true && return x
             return Const(false)
         end
     elseif isa(y, Conditional)
         x = widenconditional(x)
         if isa(x, Const)
-            x.val === false && return Conditional(y.slot, y.elsetype, y.thentype)
+            x.val === false && return Conditional(y.slot, y.elsetype, y.thentype, y.from_ssa)
             x.val === true && return y
             return Const(false)
         end

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -743,15 +743,23 @@ end
 @nospecializeinfer @inline schanged(lattice::AbstractLattice, @nospecialize(n), @nospecialize(o)) =
     (n !== o) && (o === NOT_FOUND || (n !== NOT_FOUND && !(n.undef <= o.undef && ⊑(lattice, n.typ, o.typ))))
 
-# remove any lattice elements that wrap the reassigned slot object from the vartable
-function invalidate_slotwrapper(vt::VarState, changeid::Int, ignore_conditional::Bool)
-    newtyp = ignorelimited(vt.typ)
-    if (!ignore_conditional && isa(newtyp, Conditional) && newtyp.slot == changeid) ||
-       (isa(newtyp, MustAlias) && newtyp.slot == changeid)
-        newtyp = @noinline widenwrappedslotwrapper(vt.typ)
-        return VarState(newtyp, vt.undef)
+function should_invalidate(@nospecialize(typ), changeid::Int, ignore_conditional::Bool=false)
+    typ = ignorelimited(typ)
+    return ((!ignore_conditional && typ isa Conditional && typ.slot == changeid) ||
+            (typ isa MustAlias && typ.slot == changeid))
+end
+
+# remove any lattice elements that wrap the reassigned slot object within `state`
+function invalidate_slotwrapper!(state::VarTable, changeid::Int, ignore_conditional::Bool)
+    for idx = 1:length(state)
+        invalidate_slotwrapper!(state, idx, changeid, ignore_conditional)
     end
-    return nothing
+end
+function invalidate_slotwrapper!(state::VarTable, idx::Int, changeid::Int, ignore_conditional::Bool)
+    vt = state[idx]
+    if should_invalidate(vt.typ, changeid, ignore_conditional)
+        state[idx] = VarState(@noinline(widenwrappedslotwrapper(vt.typ)), vt.undef)
+    end
 end
 
 function stupdate!(lattice::AbstractLattice, state::VarTable, changes::VarTable)
@@ -776,13 +784,10 @@ end
 
 function stoverwrite1!(state::VarTable, change::StateUpdate)
     changeid = slot_id(change.var)
-    for i = 1:length(state)
-        invalidated = invalidate_slotwrapper(state[i], changeid, change.conditional)
-        if invalidated !== nothing
-            state[i] = invalidated
-        end
-    end
-    # and update the type of it
+    # widen any slot wrapper types that should be invalidated by this change
+    # (unless if this change is made from `Conditional`)
+    invalidate_slotwrapper!(state, changeid, #=ignore_conditional=#change.conditional)
+    # and update the type of the slot
     newtype = change.vtype
     state[changeid] = newtype
     return state

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -494,16 +494,16 @@ end
     # type-lattice for Conditional wrapper (NOTE never be merged with InterConditional)
     if isa(typea, Conditional) && isa(typeb, Const)
         if typeb.val === true
-            typeb = Conditional(typea.slot, Any, Union{})
+            typeb = Conditional(typea.slot, Any, Union{}, typea.from_ssa)
         elseif typeb.val === false
-            typeb = Conditional(typea.slot, Union{}, Any)
+            typeb = Conditional(typea.slot, Union{}, Any, typea.from_ssa)
         end
     end
     if isa(typeb, Conditional) && isa(typea, Const)
         if typea.val === true
-            typea = Conditional(typeb.slot, Any, Union{})
+            typea = Conditional(typeb.slot, Any, Union{}, typeb.from_ssa)
         elseif typea.val === false
-            typea = Conditional(typeb.slot, Union{}, Any)
+            typea = Conditional(typeb.slot, Union{}, Any, typeb.from_ssa)
         end
     end
     if isa(typea, Conditional) && isa(typeb, Conditional)
@@ -511,7 +511,7 @@ end
             thentype = tmerge(widenlattice(lattice), typea.thentype, typeb.thentype)
             elsetype = tmerge(widenlattice(lattice), typea.elsetype, typeb.elsetype)
             if thentype !== elsetype
-                return Conditional(typea.slot, thentype, elsetype)
+                return Conditional(typea.slot, thentype, elsetype, typea.from_ssa)
             end
         end
         val = maybe_extract_const_bool(typea)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -6060,3 +6060,14 @@ end
 fcondvarargs(a, b, c, d) = isa(d, Int64)
 gcondvarargs(a, x...) = return fcondvarargs(a, x...) ? isa(a, Int64) : !isa(a, Int64)
 @test Core.Compiler.return_type(gcondvarargs, Tuple{Vararg{Any}}) === Bool
+
+# JuliaLang/julia#55548: invalidate stale slot wrapper types in `ssavaluetypes`
+_issue55548_proj1(a, b) = a
+function issue55548(a)
+    a = Base.inferencebarrier(a)::Union{Int64,Float64}
+    if _issue55548_proj1(isa(a, Int64), (a = Base.inferencebarrier(1.0)::Union{Int64,Float64}; true))
+        return a
+    end
+    return 2
+end
+@test Float64 <: Base.infer_return_type(issue55548, (Int,))

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2035,7 +2035,7 @@ function foo25261()
         next = f25261(Core.getfield(next, 2))
     end
 end
-let opt25261 = code_typed(foo25261, Tuple{}, optimize=true)[1].first.code
+let opt25261 = first(only(code_typed(foo25261, Tuple{}, optimize=true))).code
     i = 1
     # Skip to after the branch
     while !isa(opt25261[i], GotoIfNot)


### PR DESCRIPTION
When updating a state of local variables from an assignment, all stale slot wrapper types must be invalidated. However, up until now, only those held in the local variable state were being invalidated. In fact, those held in `ssavaluetypes` also need to be invalidated, and this commit addresses that.

Currently all `ssavaluetypes` are iterated over with each assignment to a local variable, so this could potentially lead to performance issues. If so it might be necessary to perform invalidation more efficiently along with flow control.

- fixes JuliaLang/julia#55548

@nanosoldier `runbenchmarks("inference", vs=":master")`