### PR TITLE
Revert "Don't expose guard pages to malloc_stack API consumers"

### DIFF
--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -23,22 +23,13 @@
 // number of stacks to always keep available per pool
 #define MIN_STACK_MAPPINGS_PER_POOL 5
 
-#if defined(_OS_WINDOWS_) || (!defined(_OS_OPENBSD_) && !defined(JL_HAVE_UCONTEXT) && !defined(JL_HAVE_SIGALTSTACK))
-#define JL_USE_GUARD_PAGE   1
 const size_t jl_guard_size = (4096 * 8);
-#else
-const size_t jl_guard_size = 0;
-#endif
-
 static _Atomic(uint32_t) num_stack_mappings = 0;
 
 #ifdef _OS_WINDOWS_
 #define MAP_FAILED NULL
 static void *malloc_stack(size_t bufsz) JL_NOTSAFEPOINT
 {
-    size_t guard_size = LLT_ALIGN(jl_guard_size, jl_page_size);
-    bufsz += guard_size;
-
     void *stk = VirtualAlloc(NULL, bufsz, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
     if (stk == NULL)
         return MAP_FAILED;
@@ -49,7 +40,6 @@ static void *malloc_stack(size_t bufsz) JL_NOTSAFEPOINT
         VirtualFree(stk, 0, MEM_RELEASE);
         return MAP_FAILED;
     }
-    stk = (char *)stk + guard_size;
 
     jl_atomic_fetch_add_relaxed(&num_stack_mappings, 1);
     return stk;
@@ -58,12 +48,6 @@ static void *malloc_stack(size_t bufsz) JL_NOTSAFEPOINT
 
 static void free_stack(void *stkbuf, size_t bufsz) JL_NOTSAFEPOINT
 {
-#ifdef JL_USE_GUARD_PAGE
-    size_t guard_size = LLT_ALIGN(jl_guard_size, jl_page_size);
-    bufsz += guard_size;
-    stkbuf = (char *)stkbuf - guard_size;
-#endif
-
     VirtualFree(stkbuf, 0, MEM_RELEASE);
     jl_atomic_fetch_add_relaxed(&num_stack_mappings, -1);
 }
@@ -89,22 +73,16 @@ static void *malloc_stack(size_t bufsz) JL_NOTSAFEPOINT
 # else
 static void *malloc_stack(size_t bufsz) JL_NOTSAFEPOINT
 {
-#ifdef JL_USE_GUARD_PAGE
-    size_t guard_size = LLT_ALIGN(jl_guard_size, jl_page_size);
-    bufsz += guard_size;
-#endif
-
     void* stk = mmap(0, bufsz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (stk == MAP_FAILED)
         return MAP_FAILED;
 
-#ifdef JL_USE_GUARD_PAGE
+#if !defined(JL_HAVE_UCONTEXT) && !defined(JL_HAVE_SIGALTSTACK)
     // set up a guard page to detect stack overflow
     if (mprotect(stk, jl_guard_size, PROT_NONE) == -1) {
         munmap(stk, bufsz);
         return MAP_FAILED;
     }
-    stk = (char *)stk + guard_size;
 #endif
 
     jl_atomic_fetch_add_relaxed(&num_stack_mappings, 1);
@@ -114,12 +92,6 @@ static void *malloc_stack(size_t bufsz) JL_NOTSAFEPOINT
 
 static void free_stack(void *stkbuf, size_t bufsz) JL_NOTSAFEPOINT
 {
-#ifdef JL_USE_GUARD_PAGE
-    size_t guard_size = LLT_ALIGN(jl_guard_size, jl_page_size);
-    bufsz += guard_size;
-    stkbuf = (char *)stkbuf - guard_size;
-#endif
-
     munmap(stkbuf, bufsz);
     jl_atomic_fetch_add_relaxed(&num_stack_mappings, -1);
 }

--- a/src/gc-stacks.c
+++ b/src/gc-stacks.c
@@ -65,7 +65,7 @@ static void *malloc_stack(size_t bufsz) JL_NOTSAFEPOINT
     void* stk = mmap(0, bufsz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
     if (stk == MAP_FAILED)
         return MAP_FAILED;
-#endif
+# else
     void* stk = mmap(0, bufsz, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (stk == MAP_FAILED)
         return MAP_FAILED;
@@ -75,7 +75,7 @@ static void *malloc_stack(size_t bufsz) JL_NOTSAFEPOINT
         munmap(stk, bufsz);
         return MAP_FAILED;
     }
-#endif
+# endif
 
     jl_atomic_fetch_add_relaxed(&num_stack_mappings, 1);
     return stk;


### PR DESCRIPTION
Reverts JuliaLang/julia#54591

This cause the runtime to misbehave and crash, since all of the consumers of this information in the runtime assumed that the guard pages are accounted for correctly as part of the reserved allocation. Nothing in the runtime ever promised that it is valid to access the pages beyond the current redzone (indeed, ASAN would forbid it as well).