### PR TITLE
added cholesky of cholesky

### DIFF
--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -551,7 +551,6 @@ end
 # allow packages like SparseArrays.jl to hook into here and redirect to out-of-place `cholesky`
 _cholesky(A::AbstractMatrix, args...; kwargs...) = cholesky!(A, args...; kwargs...)
 
-
 # allow cholesky of cholesky 
 cholesky(A::M) where {M <: Cholesky} = A
 

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -551,6 +551,10 @@ end
 # allow packages like SparseArrays.jl to hook into here and redirect to out-of-place `cholesky`
 _cholesky(A::AbstractMatrix, args...; kwargs...) = cholesky!(A, args...; kwargs...)
 
+
+# allow cholesky of cholesky 
+cholesky(A::M) where {M <: Cholesky} = A
+
 ## With pivoting
 """
     cholesky(A, RowMaximum(); tol = 0.0, check = true) -> CholeskyPivoted

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -552,7 +552,7 @@ end
 _cholesky(A::AbstractMatrix, args...; kwargs...) = cholesky!(A, args...; kwargs...)
 
 # allow cholesky of cholesky
-cholesky(A::M) where {M <: Cholesky} = A
+cholesky(A::Cholesky) = A
 
 ## With pivoting
 """

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -551,7 +551,7 @@ end
 # allow packages like SparseArrays.jl to hook into here and redirect to out-of-place `cholesky`
 _cholesky(A::AbstractMatrix, args...; kwargs...) = cholesky!(A, args...; kwargs...)
 
-# allow cholesky of cholesky 
+# allow cholesky of cholesky
 cholesky(A::M) where {M <: Cholesky} = A
 
 ## With pivoting

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -630,4 +630,15 @@ end
     end
 end
 
+@testset "diag" begin
+    for T in (Float64, ComplexF64), k in (0, 1, -3), uplo in (:U, :L)
+        A = randn(T, 100, 100)
+        P = Hermitian(A' * A, uplo)
+        C = cholesky(P)
+        CC = cholesky(C)
+        @test C == CC
+    end
+end
+
+
 end # module TestCholesky

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -630,8 +630,8 @@ end
     end
 end
 
-@testset "diag" begin
-    for T in (Float64, ComplexF64), k in (0, 1, -3), uplo in (:U, :L)
+@testset "cholesky_of_cholesky" begin
+    for T in (Float64, ComplexF64), uplo in (:U, :L)
         A = randn(T, 100, 100)
         P = Hermitian(A' * A, uplo)
         C = cholesky(P)
@@ -639,6 +639,5 @@ end
         @test C == CC
     end
 end
-
 
 end # module TestCholesky


### PR DESCRIPTION
Currently, if you have a cholesky matrix, you cannot call `cholesky` on it again:

```
using LinearAlgebra

N = 10
A = randn(N, N)
P = Symmetric(A * A' + I)

C = cholesky(P)

CC = cholesky(C)   # this line throws an error
```

This small PR provides the fix. 