### PR TITLE
preserve non-float in `hypot(::Number)`

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -712,6 +712,9 @@ Stacktrace:
 julia> hypot(3, 4im)
 5.0
 
+julia> hypot(-5)
+5
+
 julia> hypot(-5.7)
 5.7
 
@@ -724,7 +727,7 @@ julia> norm([a, a, a, a]) == hypot(a, a, a, a)
 true
 ```
 """
-hypot(x::Number) = abs(float(x))
+hypot(x::Number) = abs(x)
 hypot(x::Number, y::Number) = _hypot(float.(promote(x, y))...)
 hypot(x::Number, y::Number, xs::Number...) = _hypot(float.(promote(x, y, xs...)))
 function _hypot(x, y)

--- a/test/math.jl
+++ b/test/math.jl
@@ -1328,7 +1328,7 @@ end
     @test (@inferred hypot(1e-162)) ≈ 1e-162
     @test (@inferred hypot(2e-162, 1e-162, 1e-162)) ≈ hypot(2, 1, 1)*1e-162
     @test (@inferred hypot(1e162)) ≈ 1e162
-    @test hypot(-2) === 2.0
+    @test hypot(-2) === 2
     @test hypot(-2, 0) === 2.0
     let i = typemax(Int)
         @test (@inferred hypot(i, i)) ≈ i * √2


### PR DESCRIPTION
Don't unnecessarily force to a floating-point number type.