### PR TITLE
Add tests for alignment of `Int128`/`UInt128`

### DIFF
--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -993,8 +993,9 @@ for (T, StructName) in ((Int128, :Issue55558), (UInt128, :UIssue55558))
             b::Int64
             c::$(T)
         end
-        @test fieldoffset($(StructName), 2) == 16
-        @test fieldoffset($(StructName), 3) == 32
-        @test sizeof($(StructName)) == 48
+        local broken_i128 = Base.BinaryPlatforms.arch(Base.BinaryPlatforms.HostPlatform()) == "powerpc64le"
+        @test fieldoffset($(StructName), 2) == 16 broken=broken_i128
+        @test fieldoffset($(StructName), 3) == 32 broken=broken_i128
+        @test sizeof($(StructName)) == 48 broken=broken_i128
     end
 end

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -984,3 +984,17 @@ end
 @test g55208((Union{}, true, true), 0) === typeof(Union{})
 
 @test string((Core.Union{}, true, true, true)) == "(Union{}, true, true, true)"
+
+# Issue #55558
+for (T, StructName) in ((Int128, :Issue55558), (UInt128, :UIssue55558))
+    @eval begin
+        struct $(StructName)
+            a::$(T)
+            b::Int64
+            c::$(T)
+        end
+        @test fieldoffset($(StructName), 2) == 16
+        @test fieldoffset($(StructName), 3) == 32
+        @test sizeof($(StructName)) == 48
+    end
+end

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -994,7 +994,7 @@ for (T, StructName) in ((Int128, :Issue55558), (UInt128, :UIssue55558))
             c::$(T)
         end
         local broken_i128 = Base.BinaryPlatforms.arch(Base.BinaryPlatforms.HostPlatform()) == "powerpc64le"
-        @test fieldoffset($(StructName), 2) == 16 broken=broken_i128
+        @test fieldoffset($(StructName), 2) == 16
         @test fieldoffset($(StructName), 3) == 32 broken=broken_i128
         @test sizeof($(StructName)) == 48 broken=broken_i128
     end


### PR DESCRIPTION
@vchuravy is this enough for test the alignment?  Note: I tested this on aarch64 and x86_64, I'm not sure of the alignment value on powerpc64le, i686 or arm. 

Fix #55558.