### PR TITLE
[Profile] Replace `SIGTERM` with `SIGQUIT`

### DIFF
--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -172,7 +172,7 @@ let cmd = Base.julia_cmd()
     t = Timer(120) do t
         # should be under 10 seconds, so give it 2 minutes then report failure
         println("KILLING debuginfo registration test BY PROFILE TEST WATCHDOG\n")
-        kill(p, Base.SIGTERM)
+        kill(p, Base.SIGQUIT)
         sleep(10)
         kill(p, Base.SIGKILL)
     end
@@ -202,7 +202,7 @@ if Sys.isbsd() || Sys.islinux()
             t = Timer(120) do t
                 # should be under 10 seconds, so give it 2 minutes then report failure
                 println("KILLING siginfo/sigusr1 test BY PROFILE TEST WATCHDOG\n")
-                kill(p, Base.SIGTERM)
+                kill(p, Base.SIGQUIT)
                 sleep(10)
                 kill(p, Base.SIGKILL)
                 close(notify_exit)

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -173,7 +173,9 @@ let cmd = Base.julia_cmd()
         # should be under 10 seconds, so give it 2 minutes then report failure
         println("KILLING debuginfo registration test BY PROFILE TEST WATCHDOG\n")
         kill(p, Base.SIGQUIT)
-        sleep(10)
+        sleep(30)
+        kill(p, Base.SIGQUIT)
+        sleep(30)
         kill(p, Base.SIGKILL)
     end
     s = read(p, String)
@@ -203,7 +205,9 @@ if Sys.isbsd() || Sys.islinux()
                 # should be under 10 seconds, so give it 2 minutes then report failure
                 println("KILLING siginfo/sigusr1 test BY PROFILE TEST WATCHDOG\n")
                 kill(p, Base.SIGQUIT)
-                sleep(10)
+                sleep(30)
+                kill(p, Base.SIGQUIT)
+                sleep(30)
                 kill(p, Base.SIGKILL)
                 close(notify_exit)
             end


### PR DESCRIPTION
The `SIGQUIT` signal is handled specially in CI and automatically uploads failure information artifacts, which may be helpful to debug failures.